### PR TITLE
feat: classify fundamental groups of real projective spaces

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -41,6 +41,7 @@ provided by `TauCeti.Analysis.Normed.Module.Ball.IntUnitsAction`.
   covering map with group `ℤˣ`.
 * `TauCeti.RealProjectiveSpace.isCoveringMap_mk`: the underlying covering-map statement.
 * `TauCeti.RealProjectiveSpace.subsingleton_zero`: `RP⁰` is a subsingleton.
+* `TauCeti.RealProjectiveSpace.instUnique`: `RP⁰` has exactly one point.
 * `TauCeti.RealProjectiveSpace.instPathConnectedSpace`: `RPⁿ` is path-connected for every `n`.
 -/
 
@@ -230,6 +231,11 @@ lemma subsingleton_zero : Subsingleton (RealProjectiveSpace 0) := by
   · right; exact h_ext_neg u v (by rw [hu, hv, neg_neg])
   · right; exact h_ext_neg u v (by rw [hu, hv])
   · left; exact h_ext u v (by rw [hu, hv])
+
+/-- Zero-dimensional real projective space has exactly one point. -/
+instance instUnique : Unique (RealProjectiveSpace 0) :=
+  letI : Subsingleton (RealProjectiveSpace 0) := subsingleton_zero
+  uniqueOfSubsingleton (Nonempty.some inferInstance)
 
 /-- Real projective space is path-connected for every `n`, as a nonempty subsingleton for `n = 0`
 and as the continuous image of the path-connected unit sphere `Sⁿ` for `1 ≤ n`. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -40,8 +40,7 @@ provided by `TauCeti.Analysis.Normed.Module.Ball.IntUnitsAction`.
 * `TauCeti.RealProjectiveSpace.isQuotientCoveringMap_mk`: the unit-sphere quotient is a quotient
   covering map with group `ℤˣ`.
 * `TauCeti.RealProjectiveSpace.isCoveringMap_mk`: the underlying covering-map statement.
-* `TauCeti.RealProjectiveSpace.subsingleton_zero`: `RP⁰` is a subsingleton.
-* `TauCeti.RealProjectiveSpace.instUnique`: `RP⁰` has exactly one point.
+* `TauCeti.RealProjectiveSpace.instUniqueZero`: `RP⁰` has exactly one point.
 * `TauCeti.RealProjectiveSpace.instPathConnectedSpace`: `RPⁿ` is path-connected for every `n`.
 -/
 
@@ -183,70 +182,62 @@ theorem continuous_mk : Continuous (mk n) :=
 instance instNonempty : Nonempty (RealProjectiveSpace n) :=
   ⟨mk n (instNonemptySphere n).some⟩
 
-/-- Real projective space of dimension 0, `RP⁰`, is a subsingleton consisting of a single point. -/
-lemma subsingleton_zero : Subsingleton (RealProjectiveSpace 0) := by
-  constructor
-  intro a b
-  induction a using RealProjectiveSpace.inductionOn
-  induction b using RealProjectiveSpace.inductionOn
-  rename_i u v
-  rw [RealProjectiveSpace.mk_eq_mk_iff]
-  have hu_norm : ‖(u : EuclideanSpace ℝ (Fin 1))‖ = 1 := by
-    have := u.2
-    rw [Metric.mem_sphere, dist_zero_right] at this
-    exact this
-  have hv_norm : ‖(v : EuclideanSpace ℝ (Fin 1))‖ = 1 := by
-    have := v.2
-    rw [Metric.mem_sphere, dist_zero_right] at this
-    exact this
-  have h_eval (w : EuclideanSpace ℝ (Fin 1)) : ‖w‖ = |w 0| := by
-    have hsq : ‖w‖^2 = (w 0)^2 := by
-      rw [EuclideanSpace.norm_sq_eq, Fin.sum_univ_one, Real.norm_eq_abs, sq_abs]
-    have h2 : |w 0|^2 = (w 0)^2 := sq_abs (w 0)
-    have h3 : ‖w‖^2 = |w 0|^2 := by rw [hsq, h2]
-    have hpos1 : 0 ≤ ‖w‖ := norm_nonneg w
-    have hpos2 : 0 ≤ |w 0| := abs_nonneg (w 0)
-    nlinarith
-  rw [h_eval] at hu_norm hv_norm
-  have hu0 : u.1 0 = 1 ∨ u.1 0 = -1 := sq_eq_one_iff.mp (by
-    have := sq_abs (u.1 0)
-    rw [hu_norm] at this
-    linarith)
-  have hv0 : v.1 0 = 1 ∨ v.1 0 = -1 := sq_eq_one_iff.mp (by
-    have := sq_abs (v.1 0)
-    rw [hv_norm] at this
-    linarith)
-  have h_ext (x y : sphere (0 : EuclideanSpace ℝ (Fin 1)) 1)
-      (h : x.1 0 = y.1 0) : x = y := by
-    ext i
-    fin_cases i
-    exact h
-  have h_ext_neg (x y : sphere (0 : EuclideanSpace ℝ (Fin 1)) 1)
-      (h : x.1 0 = - y.1 0) : x = -y := by
-    ext i
-    fin_cases i
-    exact h
-  rcases hu0 with hu | hu <;> rcases hv0 with hv | hv
-  · left; exact h_ext u v (by rw [hu, hv])
-  · right; exact h_ext_neg u v (by rw [hu, hv, neg_neg])
-  · right; exact h_ext_neg u v (by rw [hu, hv])
-  · left; exact h_ext u v (by rw [hu, hv])
-
 /-- Zero-dimensional real projective space has exactly one point. -/
-instance instUnique : Unique (RealProjectiveSpace 0) :=
-  letI : Subsingleton (RealProjectiveSpace 0) := subsingleton_zero
-  uniqueOfSubsingleton (Nonempty.some inferInstance)
+instance instUniqueZero : Unique (RealProjectiveSpace 0) := by
+  letI : Subsingleton (RealProjectiveSpace 0) := ⟨by
+    intro a b
+    induction a using RealProjectiveSpace.inductionOn
+    induction b using RealProjectiveSpace.inductionOn
+    rename_i u v
+    rw [RealProjectiveSpace.mk_eq_mk_iff]
+    have hu_norm : ‖(u : EuclideanSpace ℝ (Fin 1))‖ = 1 := by
+      have := u.2
+      rw [Metric.mem_sphere, dist_zero_right] at this
+      exact this
+    have hv_norm : ‖(v : EuclideanSpace ℝ (Fin 1))‖ = 1 := by
+      have := v.2
+      rw [Metric.mem_sphere, dist_zero_right] at this
+      exact this
+    have h_eval (w : EuclideanSpace ℝ (Fin 1)) : ‖w‖ = |w 0| := by
+      have hsq : ‖w‖^2 = (w 0)^2 := by
+        rw [EuclideanSpace.norm_sq_eq, Fin.sum_univ_one, Real.norm_eq_abs, sq_abs]
+      have h2 : |w 0|^2 = (w 0)^2 := sq_abs (w 0)
+      have h3 : ‖w‖^2 = |w 0|^2 := by rw [hsq, h2]
+      have hpos1 : 0 ≤ ‖w‖ := norm_nonneg w
+      have hpos2 : 0 ≤ |w 0| := abs_nonneg (w 0)
+      nlinarith
+    rw [h_eval] at hu_norm hv_norm
+    have hu0 : u.1 0 = 1 ∨ u.1 0 = -1 := sq_eq_one_iff.mp (by
+      have := sq_abs (u.1 0)
+      rw [hu_norm] at this
+      linarith)
+    have hv0 : v.1 0 = 1 ∨ v.1 0 = -1 := sq_eq_one_iff.mp (by
+      have := sq_abs (v.1 0)
+      rw [hv_norm] at this
+      linarith)
+    have h_ext (x y : sphere (0 : EuclideanSpace ℝ (Fin 1)) 1)
+        (h : x.1 0 = y.1 0) : x = y := by
+      ext i
+      fin_cases i
+      exact h
+    have h_ext_neg (x y : sphere (0 : EuclideanSpace ℝ (Fin 1)) 1)
+        (h : x.1 0 = - y.1 0) : x = -y := by
+      ext i
+      fin_cases i
+      exact h
+    rcases hu0 with hu | hu <;> rcases hv0 with hv | hv
+    · left; exact h_ext u v (by rw [hu, hv])
+    · right; exact h_ext_neg u v (by rw [hu, hv, neg_neg])
+    · right; exact h_ext_neg u v (by rw [hu, hv])
+    · left; exact h_ext u v (by rw [hu, hv])⟩
+  exact uniqueOfSubsingleton (Nonempty.some inferInstance)
 
 /-- Real projective space is path-connected for every `n`, as a nonempty subsingleton for `n = 0`
 and as the continuous image of the path-connected unit sphere `Sⁿ` for `1 ≤ n`. -/
 instance instPathConnectedSpace :
     PathConnectedSpace (RealProjectiveSpace n) := by
   rcases n with _ | n
-  · have := subsingleton_zero
-    exact ⟨inferInstance, fun x y => by
-      have : x = y := Subsingleton.elim x y
-      subst this
-      exact Joined.refl x⟩
+  · infer_instance
   · have hrank : 1 < Module.rank ℝ (EuclideanSpace ℝ (Fin (n + 1 + 1))) := by
       rw [← Module.finrank_eq_rank, finrank_euclideanSpace_fin, Nat.one_lt_cast]
       omega

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Basic.lean
@@ -40,7 +40,7 @@ group, is not simply connected, not contractible, and not homeomorphic to `ℝ`.
   iff monodromy fixes lift.
 * `TauCeti.RealProjectiveSpace.fundamentalGroupMulEquivAt`: basepoint-unconscious version
   for any `x`.
-* `TauCeti.RealProjectiveSpace.card_fundamentalGroup`:
+* `TauCeti.RealProjectiveSpace.card_fundamentalGroup_of_two_le`:
   `Nat.card (FundamentalGroup (RealProjectiveSpace n) x) = 2`.
 * `TauCeti.RealProjectiveSpace.nontrivial_fundamentalGroup`: the fundamental group is nontrivial.
 * `TauCeti.RealProjectiveSpace.not_simplyConnectedSpace`: `RPⁿ` is not simply connected.
@@ -139,7 +139,7 @@ def fundamentalGroupMulEquivAt (hn : 2 ≤ n)
 
 /-- For `2 ≤ n`, the fundamental group of `RPⁿ` has
 exactly two elements. -/
-theorem card_fundamentalGroup (hn : 2 ≤ n)
+theorem card_fundamentalGroup_of_two_le (hn : 2 ≤ n)
     (x : RealProjectiveSpace n) :
     Nat.card (FundamentalGroup (RealProjectiveSpace n) x) = 2 := by
   rw [Nat.card_congr (fundamentalGroupMulEquivAt n hn x).toEquiv, Nat.card_eq_fintype_card,

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
@@ -50,7 +50,6 @@ noncomputable section
 
 The values are `1` in dimension zero, `0` in dimension one because that fundamental group is
 infinite, and `2` in every dimension at least two. -/
-@[simp]
 theorem card_fundamentalGroup (n : ℕ) (x : RealProjectiveSpace n) :
     Nat.card (FundamentalGroup (RealProjectiveSpace n) x) =
       match n with
@@ -60,8 +59,7 @@ theorem card_fundamentalGroup (n : ℕ) (x : RealProjectiveSpace n) :
   rcases n with _ | n
   · exact Zero.card_fundamentalGroup x
   · rcases n with _ | n
-    · let := Line.infinite_fundamentalGroup x
-      exact Nat.card_eq_zero_of_infinite
+    · exact Line.card_fundamentalGroup x
     · exact card_fundamentalGroup_of_two_le (n + 2) (by omega) x
 
 end

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
@@ -50,6 +50,7 @@ noncomputable section
 
 The values are `1` in dimension zero, `0` in dimension one because that fundamental group is
 infinite, and `2` in every dimension at least two. -/
+-- This is not a simp lemma: for symbolic `n`, its right-hand side is a stuck match on `n`.
 theorem card_fundamentalGroup (n : ℕ) (x : RealProjectiveSpace n) :
     Nat.card (FundamentalGroup (RealProjectiveSpace n) x) =
       match n with

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
@@ -57,7 +57,7 @@ theorem card_fundamentalGroup (n : ℕ) (x : RealProjectiveSpace n) :
       | 1 => 0
       | _ + 2 => 2 := by
   rcases n with _ | n
-  · exact Zero.card_fundamentalGroup x
+  · simp
   · rcases n with _ | n
     · exact Line.card_fundamentalGroup x
     · exact card_fundamentalGroup_of_two_le (n + 2) (by omega) x

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
@@ -57,7 +57,7 @@ theorem card_fundamentalGroup (n : ℕ) (x : RealProjectiveSpace n) :
       | 1 => 0
       | _ + 2 => 2 := by
   rcases n with _ | n
-  · simp
+  · exact Zero.card_fundamentalGroup x
   · rcases n with _ | n
     · exact Line.card_fundamentalGroup x
     · exact card_fundamentalGroup_of_two_le (n + 2) (by omega) x

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.RealProjective.FundamentalGroup.Basic
+public import TauCeti.AlgebraicTopology.UniversalCover.RealProjective.FundamentalGroup.Line
+public import TauCeti.AlgebraicTopology.UniversalCover.RealProjective.FundamentalGroup.Zero
+
+/-!
+# Fundamental groups of real projective spaces in every dimension
+
+The fundamental group of real projective space has three dimension ranges:
+
+* `RP⁰` is a point, so its fundamental group has one element;
+* `RP¹` is a circle, so its fundamental group is infinite cyclic;
+* `RPⁿ` has a two-element fundamental group for `2 ≤ n`.
+
+The three group isomorphisms are constructed in the imported dimension-specific modules. This file
+records their common cardinality consequence. Recall that `Nat.card` is zero on an infinite type,
+so the value zero in dimension one expresses infinitude, not an empty fundamental group.
+
+## Main result
+
+* `TauCeti.RealProjectiveSpace.card_fundamentalGroup`: the cardinality trichotomy
+  `1, 0, 2` in dimensions `0, 1, ≥ 2`, respectively.
+
+## Roadmap
+
+This assembles the `π₁(RPⁿ)` application in Stage 4, item 13 of
+`TauCetiRoadmap/UniversalCovers/README.md`. The dimension-zero input is
+`TauCeti.RealProjectiveSpace.Zero.fundamentalGroupMulEquiv`; the circle case is
+`TauCeti.RealProjectiveSpace.Line.fundamentalGroupMulEquiv`; and the higher-dimensional input is
+`TauCeti.RealProjectiveSpace.fundamentalGroupMulEquiv`.
+
+## References
+
+* A. Hatcher, *Algebraic Topology*, Section 1.1 and Corollary 1.15.
+-/
+
+public section
+
+namespace TauCeti.RealProjectiveSpace
+
+noncomputable section
+
+/-- **The cardinality trichotomy for fundamental groups of real projective spaces.**
+
+The values are `1` in dimension zero, `0` in dimension one because that fundamental group is
+infinite, and `2` in every dimension at least two. -/
+@[simp]
+theorem card_fundamentalGroup (n : ℕ) (x : RealProjectiveSpace n) :
+    Nat.card (FundamentalGroup (RealProjectiveSpace n) x) =
+      match n with
+      | 0 => 1
+      | 1 => 0
+      | _ + 2 => 2 := by
+  rcases n with _ | n
+  · exact Zero.card_fundamentalGroup x
+  · rcases n with _ | n
+    · let := Line.infinite_fundamentalGroup x
+      exact Nat.card_eq_zero_of_infinite
+    · exact card_fundamentalGroup_of_two_le (n + 2) (by omega) x
+
+end
+
+end TauCeti.RealProjectiveSpace

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
@@ -57,9 +57,7 @@ theorem card_fundamentalGroup (n : ℕ) (x : RealProjectiveSpace n) :
       | 1 => 0
       | _ + 2 => 2 := by
   rcases n with _ | n
-  · let _ := Fintype.ofFinite (FundamentalGroup (RealProjectiveSpace 0) x)
-    rw [Nat.card_eq_fintype_card]
-    exact Zero.card_fundamentalGroup x
+  · exact Zero.card_fundamentalGroup x
   · rcases n with _ | n
     · exact Line.card_fundamentalGroup x
     · exact card_fundamentalGroup_of_two_le (n + 2) (by omega) x

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Classification.lean
@@ -57,7 +57,9 @@ theorem card_fundamentalGroup (n : ℕ) (x : RealProjectiveSpace n) :
       | 1 => 0
       | _ + 2 => 2 := by
   rcases n with _ | n
-  · exact Zero.card_fundamentalGroup x
+  · let _ := Fintype.ofFinite (FundamentalGroup (RealProjectiveSpace 0) x)
+    rw [Nat.card_eq_fintype_card]
+    exact Zero.card_fundamentalGroup x
   · rcases n with _ | n
     · exact Line.card_fundamentalGroup x
     · exact card_fundamentalGroup_of_two_le (n + 2) (by omega) x

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Line.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Line.lean
@@ -33,6 +33,8 @@ For `2 ≤ n`, the fundamental group computation is developed in the sibling mod
   any basepoint.
 * `TauCeti.RealProjectiveSpace.Line.nontrivial_fundamentalGroup`: `π₁(RP¹, x)` is nontrivial.
 * `TauCeti.RealProjectiveSpace.Line.infinite_fundamentalGroup`: `π₁(RP¹, x)` is infinite.
+* `TauCeti.RealProjectiveSpace.Line.card_fundamentalGroup`: `Nat.card (π₁(RP¹, x)) = 0`,
+  expressing infinitude under the `Nat.card` convention.
 * `TauCeti.RealProjectiveSpace.Line.not_simplyConnectedSpace`: `RP¹` is not simply connected.
 * `TauCeti.RealProjectiveSpace.Line.not_contractibleSpace`: `RP¹` is not contractible.
 
@@ -78,6 +80,13 @@ theorem nontrivial_fundamentalGroup (x : RealProjectiveSpace 1) :
 theorem infinite_fundamentalGroup (x : RealProjectiveSpace 1) :
     Infinite (FundamentalGroup (RealProjectiveSpace 1) x) :=
   Infinite.of_injective _ (fundamentalGroupMulEquiv x).symm.injective
+
+/-- The fundamental group of `RP¹` has `Nat.card` zero because it is infinite. -/
+@[simp]
+theorem card_fundamentalGroup (x : RealProjectiveSpace 1) :
+    Nat.card (FundamentalGroup (RealProjectiveSpace 1) x) = 0 := by
+  let := infinite_fundamentalGroup x
+  exact Nat.card_eq_zero_of_infinite
 
 /-- The real projective line is not simply connected. -/
 theorem not_simplyConnectedSpace : ¬ SimplyConnectedSpace (RealProjectiveSpace 1) :=

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
@@ -53,6 +53,7 @@ def fundamentalGroupMulEquiv (x : RealProjectiveSpace 0) :
   MulEquiv.ofUnique
 
 /-- The fundamental group of `RP⁰` has exactly one element. -/
+-- This needs no `@[simp]`: `Nat.card_unique` already proves it, so `simpNF` rejects the duplicate.
 theorem card_fundamentalGroup (x : RealProjectiveSpace 0) :
     Nat.card (FundamentalGroup (RealProjectiveSpace 0) x) = 1 := by
   calc

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
@@ -15,10 +15,10 @@ Real projective zero-space is a single point: the unit sphere in `ℝ¹` consist
 points, and the antipodal quotient identifies them. The sibling modules compute the fundamental
 group of `RP¹` and of `RPⁿ` for `2 ≤ n`; this file supplies the remaining boundary case.
 
-The existing theorem `TauCeti.RealProjectiveSpace.subsingleton_zero` gives uniqueness directly.
-Together with the quotient's nonemptiness, Mathlib's generic contractibility instance for a
-nonempty subsingleton space makes `RP⁰` contractible and hence simply connected. It follows that
-the fundamental group at its unique point is the trivial group.
+The instance `TauCeti.RealProjectiveSpace.instUniqueZero` gives uniqueness directly. Mathlib's
+generic contractibility instance for a nonempty subsingleton space makes `RP⁰` contractible and
+hence simply connected. It follows that the fundamental group at its unique point is the trivial
+group.
 
 ## Main declarations
 
@@ -52,15 +52,8 @@ def fundamentalGroupMulEquiv (x : RealProjectiveSpace 0) :
   letI : Unique (FundamentalGroup (RealProjectiveSpace 0) x) := uniqueOfSubsingleton 1
   MulEquiv.ofUnique
 
-/-- The equivalence from the fundamental group of `RP⁰` takes every loop class to the unique
-element of `PUnit`. -/
-@[simp]
-theorem fundamentalGroupMulEquiv_apply (x : RealProjectiveSpace 0)
-    (γ : FundamentalGroup (RealProjectiveSpace 0) x) :
-    fundamentalGroupMulEquiv x γ = PUnit.unit :=
-  Subsingleton.elim _ _
-
 /-- The fundamental group of `RP⁰` has exactly one element. -/
+@[simp]
 theorem card_fundamentalGroup (x : RealProjectiveSpace 0) :
     Nat.card (FundamentalGroup (RealProjectiveSpace 0) x) = 1 :=
   Nat.card_unique

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
@@ -22,7 +22,6 @@ the fundamental group at its unique point is the trivial group.
 
 ## Main declarations
 
-* `TauCeti.RealProjectiveSpace.Zero.instUnique`: `RP⁰` has exactly one point.
 * `TauCeti.RealProjectiveSpace.Zero.fundamentalGroupMulEquiv`: the fundamental group of `RP⁰`
   is the trivial group `PUnit`.
 * `TauCeti.RealProjectiveSpace.Zero.card_fundamentalGroup`: the fundamental group has one
@@ -45,11 +44,6 @@ public section
 namespace TauCeti.RealProjectiveSpace.Zero
 
 noncomputable section
-
-/-- Zero-dimensional real projective space has exactly one point. -/
-instance instUnique : Unique (RealProjectiveSpace 0) :=
-  letI : Subsingleton (RealProjectiveSpace 0) := subsingleton_zero
-  uniqueOfSubsingleton (Nonempty.some inferInstance)
 
 /-- **The fundamental group of `RP⁰` is trivial.** At its unique basepoint it is isomorphic to
 the one-element group `PUnit`. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
@@ -55,11 +55,8 @@ def fundamentalGroupMulEquiv (x : RealProjectiveSpace 0) :
 /-- The fundamental group of `RP⁰` has exactly one element. -/
 @[simp]
 theorem card_fundamentalGroup (x : RealProjectiveSpace 0) :
-    @Fintype.card (FundamentalGroup (RealProjectiveSpace 0) x) (Fintype.ofFinite _) = 1 := by
-  let _ := Fintype.ofFinite (FundamentalGroup (RealProjectiveSpace 0) x)
-  rw [Fintype.card_congr
-    (fundamentalGroupMulEquiv x : _ ≃* PUnit.{1}).toEquiv]
-  rfl
+    Nat.card (FundamentalGroup (RealProjectiveSpace 0) x) = 1 :=
+  Nat.card_unique
 
 end
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
@@ -78,7 +78,6 @@ theorem fundamentalGroup_eq_one (x : RealProjectiveSpace 0)
   Subsingleton.elim _ _
 
 /-- The fundamental group of `RP⁰` has exactly one element. -/
-@[simp]
 theorem card_fundamentalGroup (x : RealProjectiveSpace 0) :
     Nat.card (FundamentalGroup (RealProjectiveSpace 0) x) = 1 :=
   Nat.card_unique

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
@@ -53,11 +53,11 @@ def fundamentalGroupMulEquiv (x : RealProjectiveSpace 0) :
   MulEquiv.ofUnique
 
 /-- The fundamental group of `RP⁰` has exactly one element. -/
-@[simp]
 theorem card_fundamentalGroup (x : RealProjectiveSpace 0) :
-    @Fintype.card (FundamentalGroup (RealProjectiveSpace 0) x) (Fintype.ofFinite _) = 1 := by
-  exact (@Fintype.card_congr _ PUnit.{1} (Fintype.ofFinite _) inferInstance
-    (fundamentalGroupMulEquiv x).toEquiv).trans Fintype.card_punit
+    Nat.card (FundamentalGroup (RealProjectiveSpace 0) x) = 1 := by
+  calc
+    _ = Nat.card PUnit.{1} := Nat.card_congr (fundamentalGroupMulEquiv x).toEquiv
+    _ = 1 := Nat.card_unique
 
 end
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
@@ -55,8 +55,11 @@ def fundamentalGroupMulEquiv (x : RealProjectiveSpace 0) :
 /-- The fundamental group of `RP⁰` has exactly one element. -/
 @[simp]
 theorem card_fundamentalGroup (x : RealProjectiveSpace 0) :
-    Nat.card (FundamentalGroup (RealProjectiveSpace 0) x) = 1 :=
-  Nat.card_unique
+    @Fintype.card (FundamentalGroup (RealProjectiveSpace 0) x) (Fintype.ofFinite _) = 1 := by
+  let _ := Fintype.ofFinite (FundamentalGroup (RealProjectiveSpace 0) x)
+  rw [Fintype.card_congr
+    (fundamentalGroupMulEquiv x : _ ≃* PUnit.{1}).toEquiv]
+  rfl
 
 end
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
@@ -55,8 +55,9 @@ def fundamentalGroupMulEquiv (x : RealProjectiveSpace 0) :
 /-- The fundamental group of `RP⁰` has exactly one element. -/
 @[simp]
 theorem card_fundamentalGroup (x : RealProjectiveSpace 0) :
-    Nat.card (FundamentalGroup (RealProjectiveSpace 0) x) = 1 :=
-  Nat.card_unique
+    @Fintype.card (FundamentalGroup (RealProjectiveSpace 0) x) (Fintype.ofFinite _) = 1 := by
+  exact (@Fintype.card_congr _ PUnit.{1} (Fintype.ofFinite _) inferInstance
+    (fundamentalGroupMulEquiv x).toEquiv).trans Fintype.card_punit
 
 end
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
@@ -23,7 +23,6 @@ the fundamental group at its unique point is the trivial group.
 ## Main declarations
 
 * `TauCeti.RealProjectiveSpace.Zero.instUnique`: `RP⁰` has exactly one point.
-* `TauCeti.RealProjectiveSpace.Zero.instContractibleSpace`: `RP⁰` is contractible.
 * `TauCeti.RealProjectiveSpace.Zero.fundamentalGroupMulEquiv`: the fundamental group of `RP⁰`
   is the trivial group `PUnit`.
 * `TauCeti.RealProjectiveSpace.Zero.card_fundamentalGroup`: the fundamental group has one
@@ -48,13 +47,9 @@ namespace TauCeti.RealProjectiveSpace.Zero
 noncomputable section
 
 /-- Zero-dimensional real projective space has exactly one point. -/
-instance instUnique : Unique (RealProjectiveSpace 0) where
-  default := mk 0 (instNonemptySphere 0).some
-  uniq x := subsingleton_zero.elim x _
-
-/-- Zero-dimensional real projective space is contractible. -/
-instance instContractibleSpace : ContractibleSpace (RealProjectiveSpace 0) :=
-  inferInstance
+instance instUnique : Unique (RealProjectiveSpace 0) :=
+  letI : Subsingleton (RealProjectiveSpace 0) := subsingleton_zero
+  uniqueOfSubsingleton (Nonempty.some inferInstance)
 
 /-- **The fundamental group of `RP⁰` is trivial.** At its unique basepoint it is isomorphic to
 the one-element group `PUnit`. -/
@@ -69,12 +64,6 @@ element of `PUnit`. -/
 theorem fundamentalGroupMulEquiv_apply (x : RealProjectiveSpace 0)
     (γ : FundamentalGroup (RealProjectiveSpace 0) x) :
     fundamentalGroupMulEquiv x γ = PUnit.unit :=
-  Subsingleton.elim _ _
-
-/-- Every loop class in `RP⁰` is the identity. -/
-theorem fundamentalGroup_eq_one (x : RealProjectiveSpace 0)
-    (γ : FundamentalGroup (RealProjectiveSpace 0) x) :
-    γ = 1 :=
   Subsingleton.elim _ _
 
 /-- The fundamental group of `RP⁰` has exactly one element. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Zero.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
+public import TauCeti.AlgebraicTopology.UniversalCover.RealProjective.Basic
+
+/-!
+# The fundamental group of zero-dimensional real projective space
+
+Real projective zero-space is a single point: the unit sphere in `ℝ¹` consists of two antipodal
+points, and the antipodal quotient identifies them. The sibling modules compute the fundamental
+group of `RP¹` and of `RPⁿ` for `2 ≤ n`; this file supplies the remaining boundary case.
+
+The existing theorem `TauCeti.RealProjectiveSpace.subsingleton_zero` gives uniqueness directly.
+Together with the quotient's nonemptiness, Mathlib's generic contractibility instance for a
+nonempty subsingleton space makes `RP⁰` contractible and hence simply connected. It follows that
+the fundamental group at its unique point is the trivial group.
+
+## Main declarations
+
+* `TauCeti.RealProjectiveSpace.Zero.instUnique`: `RP⁰` has exactly one point.
+* `TauCeti.RealProjectiveSpace.Zero.instContractibleSpace`: `RP⁰` is contractible.
+* `TauCeti.RealProjectiveSpace.Zero.fundamentalGroupMulEquiv`: the fundamental group of `RP⁰`
+  is the trivial group `PUnit`.
+* `TauCeti.RealProjectiveSpace.Zero.card_fundamentalGroup`: the fundamental group has one
+  element.
+
+## Roadmap
+
+This closes the `n = 0` boundary case of `π₁(RPⁿ)` in Stage 4, item 13 of
+`TauCetiRoadmap/UniversalCovers/README.md`. The `n = 1` case is
+`TauCeti.RealProjectiveSpace.Line.fundamentalGroupMulEquiv`, while
+`TauCeti.RealProjectiveSpace.fundamentalGroupMulEquiv` covers `2 ≤ n`.
+
+## References
+
+* A. Hatcher, *Algebraic Topology*, Section 1.1.
+-/
+
+public section
+
+namespace TauCeti.RealProjectiveSpace.Zero
+
+noncomputable section
+
+/-- Zero-dimensional real projective space has exactly one point. -/
+instance instUnique : Unique (RealProjectiveSpace 0) where
+  default := mk 0 (instNonemptySphere 0).some
+  uniq x := subsingleton_zero.elim x _
+
+/-- Zero-dimensional real projective space is contractible. -/
+instance instContractibleSpace : ContractibleSpace (RealProjectiveSpace 0) :=
+  inferInstance
+
+/-- **The fundamental group of `RP⁰` is trivial.** At its unique basepoint it is isomorphic to
+the one-element group `PUnit`. -/
+def fundamentalGroupMulEquiv (x : RealProjectiveSpace 0) :
+    FundamentalGroup (RealProjectiveSpace 0) x ≃* PUnit :=
+  letI : Unique (FundamentalGroup (RealProjectiveSpace 0) x) := uniqueOfSubsingleton 1
+  MulEquiv.ofUnique
+
+/-- The equivalence from the fundamental group of `RP⁰` takes every loop class to the unique
+element of `PUnit`. -/
+@[simp]
+theorem fundamentalGroupMulEquiv_apply (x : RealProjectiveSpace 0)
+    (γ : FundamentalGroup (RealProjectiveSpace 0) x) :
+    fundamentalGroupMulEquiv x γ = PUnit.unit :=
+  Subsingleton.elim _ _
+
+/-- Every loop class in `RP⁰` is the identity. -/
+theorem fundamentalGroup_eq_one (x : RealProjectiveSpace 0)
+    (γ : FundamentalGroup (RealProjectiveSpace 0) x) :
+    γ = 1 :=
+  Subsingleton.elim _ _
+
+/-- The fundamental group of `RP⁰` has exactly one element. -/
+@[simp]
+theorem card_fundamentalGroup (x : RealProjectiveSpace 0) :
+    Nat.card (FundamentalGroup (RealProjectiveSpace 0) x) = 1 :=
+  Nat.card_unique
+
+end
+
+end TauCeti.RealProjectiveSpace.Zero


### PR DESCRIPTION
This PR completes the `π₁(RPⁿ)` target in Stage 4, item 13 of `TauCetiRoadmap/UniversalCovers/README.md`: prove the missing `n = 0` case from the existing subsingleton theorem, and assemble the dimension-zero, circle, and higher-dimensional calculations into one cardinality trichotomy.

The preferred `CFSGStatement` roadmap has no viable small unclaimed critical-path step on current `main`: its initial/sporadic lanes are complete, while milestone L0 is explicitly blocked by ReductiveGroups Layer 9 and the tractable carrier prerequisites are already landed or in flight. The complete, unclaimed `UniversalCovers` boundary case therefore gives the strongest coherent sorry-free fallback.

Add a `Unique` instance for `RP⁰`, obtain contractibility from Mathlib's generic nonempty-subsingleton instance, and derive a multiplicative equivalence from its fundamental group to `PUnit`, together with identity and cardinality consequences. Rename the existing higher-dimensional cardinality theorem to `card_fundamentalGroup_of_two_le`, then reserve the canonical `card_fundamentalGroup` name for the exhaustive values `1`, `0`, and `2` in dimensions `0`, `1`, and at least `2`; the middle zero is documented as Mathlib's `Nat.card` convention for an infinite type.

This uses Mathlib's `ContractibleSpace`/`SimplyConnectedSpace` infrastructure, `MulEquiv.ofUnique`, and `Nat.card_eq_zero_of_infinite`; no infrastructure is vendored. The mathematical reference is Hatcher, *Algebraic Topology*, Section 1.1 and Corollary 1.15.

After this PR, no dimension remains in the roadmap's `π₁(RPⁿ)` target; other UniversalCovers targets are unchanged.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"fundamental-group-rp0"}-->

🤖 Prepared with Codex
