### PR TITLE
feat: pin the Geck carrier to its root datum

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean
@@ -8,35 +8,36 @@ module
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.GroupScheme
 
 /-!
-# The Geck carrier is pinned by its named root datum
+# The conjugation equations of the Geck carrier, against its named root datum
 
 For a valid Dynkin type `t`, `TauCeti.DynkinType.geckGroupScheme t` is the explicit Kostant
-toral-closure carrier built from Geck's integral coordinate lattice. Its numbered raising and
-lowering subgroups and its split weight torus were constructed using the Bourbaki rows of
-`t.cartanMatrix`. This file identifies those rows with the simple roots of
-`TauCeti.DynkinType.simplyConnectedRootDatum t` and restates the carrier's conjugation equations
-against that named datum.
+toral-closure carrier built from Geck's integral coordinate lattice. Its split weight torus
+conjugates the parameter of the numbered raising subgroup at node `i` through the character
+`t.rootGeneratorWeight ht (.inl i)`, which was constructed as a Bourbaki row of `t.cartanMatrix`.
+This file restates those conjugation equations with that character read instead as a simple root
+of `TauCeti.DynkinType.simplyConnectedRootDatum t`.
 
 The distinction is important to the downstream finite-group construction. Its ambient carrier is
 indexed by a Dynkin type and must use the root datum supplied by the root-systems roadmap; equality
 with a Cartan-matrix row is not by itself an interface connecting the two constructions. The
-results here say that the raising subgroup at node `i` sits at the named simple root `α_i`, the
-lowering subgroup sits at `-α_i`, and the torus acts on their parameters through those characters.
+substitution itself is `TauCeti.DynkinType.rootGeneratorWeight_inl_eq_root_simpleIndex` and its
+lowering counterpart, proved with the Kostant form in
+`TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/KostantForm.lean`; the results below are
+the carrier's conjugation equations that consume it.
 
 The existing Geck lattice has full character lattice exactly in types `E₈`, `F₄`, and `G₂`.
-Thus the results below complete this root-datum part of the pinning interface for those three
-carriers. They are stated uniformly because the root identifications and conjugation equations are
-valid for every Dynkin type, including the other types whose full-weight admissible lattices remain
-to be constructed. Nothing here asserts reductivity, maximality of the torus, or an identification
-of the carrier's root datum; those are separate Layer 9 targets.
+Thus the equations below supply this named-root form of the pinning interface for those three
+carriers. They are stated uniformly because the conjugation equations are valid for every Dynkin
+type, including the other types whose full-weight admissible lattices remain to be constructed.
+Each equation says only how the torus rescales a subgroup parameter: nothing here asserts
+reductivity, maximality of the torus, or that these numbered subgroups exhaust the root subgroups
+of a root datum carried by the group scheme; those are separate Layer 9 targets.
 
 ## Main results
 
-* `TauCeti.DynkinType.rootGeneratorWeight_inl_eq_root_simpleIndex` and
-  `TauCeti.DynkinType.rootGeneratorWeight_inr_eq_neg_root_simpleIndex`: the numbered raising and
-  lowering subgroups sit at the pinned simple roots and their negatives.
 * `TauCeti.DynkinType.geckTorusPoints_conj_geckRootSubgroupParam_root_simpleIndex` and its
-  negative-root counterpart: the pointwise pinning equations against the named datum.
+  negative-root counterpart: the pointwise conjugation equations, with the conjugating character
+  read as a named simple root.
 * `TauCeti.DynkinType.geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex` and its
   negative-root counterpart: the corresponding equations on scheme-valued points.
 
@@ -65,32 +66,9 @@ noncomputable section
 
 variable (t : DynkinType) (ht : t.Valid)
 
-/-! ## The numbered root subgroups sit at the pinned simple roots
+/-! ## The pointwise conjugation equations -/
 
-These identifications are deliberately not `simp` lemmas. Both sides already have canonical simp
-forms: `rootGeneratorWeight_inl` and `root_simpleIndex` reduce them to the same Cartan-matrix row,
-while their negative-root counterparts reduce them to its negative. -/
-
-/-- **The `i`-th numbered raising subgroup of the Geck carrier sits at the `i`-th pinned simple
-root.** The character through which the split torus rescales its parameter is the simple root of
-`t.simplyConnectedRootDatum ht` with the same Bourbaki node number. -/
-theorem rootGeneratorWeight_inl_eq_root_simpleIndex (i : Fin t.rank) :
-    t.rootGeneratorWeight ht (.inl i) =
-      (t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i) := by
-  funext j
-  rw [rootGeneratorWeight_inl, root_simpleIndex]
-
-/-- **The `i`-th numbered lowering subgroup of the Geck carrier sits at the negative of the
-`i`-th pinned simple root.** -/
-theorem rootGeneratorWeight_inr_eq_neg_root_simpleIndex (i : Fin t.rank) :
-    t.rootGeneratorWeight ht (.inr i) =
-      -(t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i) := by
-  funext j
-  rw [rootGeneratorWeight_inr, Pi.neg_apply, root_simpleIndex]
-
-/-! ## The pointwise pinning equations -/
-
-/-- **The pointwise pinning equation of the Geck carrier at a named simple root.** A split-torus
+/-- **The pointwise conjugation equation of the Geck carrier at a named simple root.** A split-torus
 point `s` conjugates the raising-subgroup element of parameter `u` at node `i` into the one of
 parameter `α_i(s)u`, where `α_i` is the corresponding simple root of the pinned simply connected
 datum. -/
@@ -106,7 +84,7 @@ theorem geckTorusPoints_conj_geckRootSubgroupParam_root_simpleIndex (i : Fin t.r
   rw [← t.rootGeneratorWeight_inl_eq_root_simpleIndex ht i]
   exact t.geckTorusPoints_conj_geckRootSubgroupParam ht (.inl i) A s u
 
-/-- **The pointwise pinning equation of the Geck carrier at the negative of a named simple
+/-- **The pointwise conjugation equation of the Geck carrier at the negative of a named simple
 root.** -/
 theorem geckTorusPoints_conj_geckRootSubgroupParam_neg_root_simpleIndex (i : Fin t.rank)
     (A : CommAlgCat.{v} ℤ) (s : Fin t.rank → Aˣ) (u : Multiplicative A) :
@@ -120,9 +98,9 @@ theorem geckTorusPoints_conj_geckRootSubgroupParam_neg_root_simpleIndex (i : Fin
   rw [← t.rootGeneratorWeight_inr_eq_neg_root_simpleIndex ht i]
   exact t.geckTorusPoints_conj_geckRootSubgroupParam ht (.inr i) A s u
 
-/-! ## The scheme-level pinning equations -/
+/-! ## The scheme-level conjugation equations -/
 
-/-- **The scheme-level pinning equation of the Geck carrier at a named simple root.** -/
+/-- **The scheme-level conjugation equation of the Geck carrier at a named simple root.** -/
 theorem geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex (i : Fin t.rank)
     (A : Type) [CommRing A]
     (s : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
@@ -143,7 +121,7 @@ theorem geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex (i : Fin t.rank)
   rw [← t.rootGeneratorWeight_inl_eq_root_simpleIndex ht i]
   exact t.geckWeightTorus_conj_geckRootSubgroup ht (.inl i) A s u
 
-/-- **The scheme-level pinning equation of the Geck carrier at the negative of a named simple
+/-- **The scheme-level conjugation equation of the Geck carrier at the negative of a named simple
 root.** -/
 theorem geckWeightTorus_conj_geckRootSubgroup_neg_root_simpleIndex (i : Fin t.rank)
     (A : Type) [CommRing A]

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.GroupScheme
+
+/-!
+# The Geck carrier is pinned by its named root datum
+
+For a valid Dynkin type `t`, `TauCeti.DynkinType.geckGroupScheme t` is the explicit Kostant
+toral-closure carrier built from Geck's integral coordinate lattice. Its numbered raising and
+lowering subgroups and its split weight torus were constructed using the Bourbaki rows of
+`t.cartanMatrix`. This file identifies those rows with the simple roots of
+`TauCeti.DynkinType.simplyConnectedRootDatum t` and restates the carrier's conjugation equations
+against that named datum.
+
+The distinction is important to the downstream finite-group construction. Its ambient carrier is
+indexed by a Dynkin type and must use the root datum supplied by the root-systems roadmap; equality
+with a Cartan-matrix row is not by itself an interface connecting the two constructions. The
+results here say that the raising subgroup at node `i` sits at the named simple root `α_i`, the
+lowering subgroup sits at `-α_i`, and the torus acts on their parameters through those characters.
+
+The existing Geck lattice has full character lattice exactly in types `E₈`, `F₄`, and `G₂`.
+Thus the results below complete this root-datum part of the pinning interface for those three
+carriers. They are stated uniformly because the root identifications and conjugation equations are
+valid for every Dynkin type, including the other types whose full-weight admissible lattices remain
+to be constructed. Nothing here asserts reductivity, maximality of the torus, or an identification
+of the carrier's root datum; those are separate Layer 9 targets.
+
+## Main results
+
+* `TauCeti.DynkinType.rootGeneratorWeight_inl_eq_root_simpleIndex` and
+  `TauCeti.DynkinType.rootGeneratorWeight_inr_eq_neg_root_simpleIndex`: the numbered raising and
+  lowering subgroups sit at the pinned simple roots and their negatives.
+* `TauCeti.DynkinType.geckTorusPoints_conj_geckRootSubgroupParam_root_simpleIndex` and its
+  negative-root counterpart: the pointwise pinning equations against the named datum.
+* `TauCeti.DynkinType.geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex` and its
+  negative-root counterpart: the corresponding equations on scheme-valued points.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 7.1.
+* J. E. Humphreys, *Linear Algebraic Groups*, §§26--27.
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plates I--IX.
+
+This advances the "Pinnings" and "Root subgroup maps" targets of Layer 9 of
+`TauCetiRoadmap/ReductiveGroups/README.md`. Its consumer is milestone `L0` of
+`TauCetiRoadmap/CFSGStatement/README.md`, which requires each Lie-type carrier to be traceable to
+`DynkinType.simplyConnectedRootDatum` through `ValidLieTypeIndex.dynkinType`.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.DynkinType
+
+universe v
+
+noncomputable section
+
+variable (t : DynkinType) (ht : t.Valid)
+
+/-! ## The numbered root subgroups sit at the pinned simple roots
+
+These identifications are deliberately not `simp` lemmas. Both sides already have canonical simp
+forms: `rootGeneratorWeight_inl` and `root_simpleIndex` reduce them to the same Cartan-matrix row,
+while their negative-root counterparts reduce them to its negative. -/
+
+/-- **The `i`-th numbered raising subgroup of the Geck carrier sits at the `i`-th pinned simple
+root.** The character through which the split torus rescales its parameter is the simple root of
+`t.simplyConnectedRootDatum ht` with the same Bourbaki node number. -/
+theorem rootGeneratorWeight_inl_eq_root_simpleIndex (i : Fin t.rank) :
+    t.rootGeneratorWeight ht (.inl i) =
+      (t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i) := by
+  funext j
+  rw [rootGeneratorWeight_inl, root_simpleIndex]
+
+/-- **The `i`-th numbered lowering subgroup of the Geck carrier sits at the negative of the
+`i`-th pinned simple root.** -/
+theorem rootGeneratorWeight_inr_eq_neg_root_simpleIndex (i : Fin t.rank) :
+    t.rootGeneratorWeight ht (.inr i) =
+      -(t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i) := by
+  funext j
+  rw [rootGeneratorWeight_inr, Pi.neg_apply, root_simpleIndex]
+
+/-! ## The pointwise pinning equations -/
+
+/-- **The pointwise pinning equation of the Geck carrier at a named simple root.** A split-torus
+point `s` conjugates the raising-subgroup element of parameter `u` at node `i` into the one of
+parameter `α_i(s)u`, where `α_i` is the corresponding simple root of the pinned simply connected
+datum. -/
+theorem geckTorusPoints_conj_geckRootSubgroupParam_root_simpleIndex (i : Fin t.rank)
+    (A : CommAlgCat.{v} ℤ) (s : Fin t.rank → Aˣ) (u : Multiplicative A) :
+    t.geckTorusPoints ht A s * t.geckRootSubgroupParam ht (.inl i) A u *
+        (t.geckTorusPoints ht A s)⁻¹ =
+      t.geckRootSubgroupParam ht (.inl i) A
+        (Multiplicative.ofAdd
+          ((TauCeti.torusCharacter s
+              ((t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i)) : A) *
+            Multiplicative.toAdd u)) := by
+  rw [← t.rootGeneratorWeight_inl_eq_root_simpleIndex ht i]
+  exact t.geckTorusPoints_conj_geckRootSubgroupParam ht (.inl i) A s u
+
+/-- **The pointwise pinning equation of the Geck carrier at the negative of a named simple
+root.** -/
+theorem geckTorusPoints_conj_geckRootSubgroupParam_neg_root_simpleIndex (i : Fin t.rank)
+    (A : CommAlgCat.{v} ℤ) (s : Fin t.rank → Aˣ) (u : Multiplicative A) :
+    t.geckTorusPoints ht A s * t.geckRootSubgroupParam ht (.inr i) A u *
+        (t.geckTorusPoints ht A s)⁻¹ =
+      t.geckRootSubgroupParam ht (.inr i) A
+        (Multiplicative.ofAdd
+          ((TauCeti.torusCharacter s
+              (-(t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i)) : A) *
+            Multiplicative.toAdd u)) := by
+  rw [← t.rootGeneratorWeight_inr_eq_neg_root_simpleIndex ht i]
+  exact t.geckTorusPoints_conj_geckRootSubgroupParam ht (.inr i) A s u
+
+/-! ## The scheme-level pinning equations -/
+
+/-- **The scheme-level pinning equation of the Geck carrier at a named simple root.** -/
+theorem geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex (i : Fin t.rank)
+    (A : Type) [CommRing A]
+    (s : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (SplitTorus.groupScheme ℤ (Fin t.rank)).X)
+    (u : A) :
+    (s ≫ (t.geckWeightTorus ht).hom.hom) *
+        ((AdditiveGroup.groupSchemePointMulEquiv A)
+            ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+              (Multiplicative.ofAdd u)) ≫
+          (t.geckRootSubgroup ht (.inl i)).hom.hom) *
+        (s ≫ (t.geckWeightTorus ht).hom.hom)⁻¹ =
+      (AdditiveGroup.schemePointsMulEquiv A).symm
+          (Multiplicative.ofAdd
+            ((TauCeti.torusCharacter
+                (SplitTorus.schemePointsMulEquiv (R := ℤ) (A := A) s)
+                ((t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i)) : A) * u)) ≫
+        (t.geckRootSubgroup ht (.inl i)).hom.hom := by
+  rw [← t.rootGeneratorWeight_inl_eq_root_simpleIndex ht i]
+  exact t.geckWeightTorus_conj_geckRootSubgroup ht (.inl i) A s u
+
+/-- **The scheme-level pinning equation of the Geck carrier at the negative of a named simple
+root.** -/
+theorem geckWeightTorus_conj_geckRootSubgroup_neg_root_simpleIndex (i : Fin t.rank)
+    (A : Type) [CommRing A]
+    (s : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (SplitTorus.groupScheme ℤ (Fin t.rank)).X)
+    (u : A) :
+    (s ≫ (t.geckWeightTorus ht).hom.hom) *
+        ((AdditiveGroup.groupSchemePointMulEquiv A)
+            ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+              (Multiplicative.ofAdd u)) ≫
+          (t.geckRootSubgroup ht (.inr i)).hom.hom) *
+        (s ≫ (t.geckWeightTorus ht).hom.hom)⁻¹ =
+      (AdditiveGroup.schemePointsMulEquiv A).symm
+          (Multiplicative.ofAdd
+            ((TauCeti.torusCharacter
+                (SplitTorus.schemePointsMulEquiv (R := ℤ) (A := A) s)
+                (-(t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i)) : A) * u)) ≫
+        (t.geckRootSubgroup ht (.inr i)).hom.hom := by
+  rw [← t.rootGeneratorWeight_inr_eq_neg_root_simpleIndex ht i]
+  exact t.geckWeightTorus_conj_geckRootSubgroup ht (.inr i) A s u
+
+end
+
+end TauCeti.DynkinType

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/KostantForm.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/KostantForm.lean
@@ -79,6 +79,10 @@ not claimed. This file is the numbered input those later steps consume.
   vectors are Cartan weight vectors with integer weights.
 * `TauCeti.DynkinType.lie_lieBasis_h_rootGenerator`: the Cartan action on each numbered root
   generator is given by its integral root.
+* `TauCeti.DynkinType.rootGeneratorWeight_inl_eq_root_simpleIndex` and
+  `TauCeti.DynkinType.rootGeneratorWeight_inr_eq_neg_root_simpleIndex`: that integral root is the
+  simple root of `TauCeti.DynkinType.simplyConnectedRootDatum` with the same Bourbaki node number,
+  respectively its negative.
 * `TauCeti.DynkinType.geckRepresentation_mem_geckOrbit` and
   `TauCeti.DynkinType.span_geckOrbit_eq_top`: the integral orbit is stable under the Kostant form
   and spans the Geck module over `ℚ`.
@@ -187,6 +191,28 @@ def rootGeneratorWeight : Fin t.rank ⊕ Fin t.rank → Fin t.rank → ℤ :=
 @[simp] theorem rootGeneratorWeight_inr (i j : Fin t.rank) :
     t.rootGeneratorWeight ht (.inr i) j = -t.cartanMatrix i j := by
   rw [rootGeneratorWeight, LieAlgebra.Basis.rootGeneratorWeight_inr, lieBasis_A_eq]
+
+/-! The two identifications below read those Cartan-matrix rows as the simple roots of
+`TauCeti.DynkinType.simplyConnectedRootDatum`. They are deliberately not `simp` lemmas: both sides
+are already `simp`-normal, since `rootGeneratorWeight_inl` and `root_simpleIndex` rewrite them to
+the same row, and orienting the identification either way would undo one of them. -/
+
+/-- **The root of the `i`-th numbered raising generator is the `i`-th pinned simple root.** The
+integral character of the pinned Cartan generators through which they act on that generator is the
+simple root of `t.simplyConnectedRootDatum ht` with the same Bourbaki node number. -/
+theorem rootGeneratorWeight_inl_eq_root_simpleIndex (i : Fin t.rank) :
+    t.rootGeneratorWeight ht (.inl i) =
+      (t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i) := by
+  funext j
+  rw [rootGeneratorWeight_inl, root_simpleIndex]
+
+/-- **The root of the `i`-th numbered lowering generator is the negative of the `i`-th pinned
+simple root.** -/
+theorem rootGeneratorWeight_inr_eq_neg_root_simpleIndex (i : Fin t.rank) :
+    t.rootGeneratorWeight ht (.inr i) =
+      -(t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i) := by
+  funext j
+  rw [rootGeneratorWeight_inr, Pi.neg_apply, root_simpleIndex]
 
 /-- **The pinned Cartan generators act on a numbered root generator through its root.** -/
 theorem lie_lieBasis_h_rootGenerator (i : Fin t.rank ⊕ Fin t.rank) (j : Fin t.rank) :


### PR DESCRIPTION
This PR connects the pinned Geck carrier's numbered raising and lowering subgroups to `DynkinType.simplyConnectedRootDatum`: the subgroup at node `i` sits at the named simple root `α_i`, its lowering counterpart sits at `-α_i`, and both the pointwise and scheme-level torus-conjugation equations are stated against those roots.

The exact target is ReductiveGroups Layer 9, “Pinnings” and “Root subgroup maps,” which requires the equations pinning `x_α` against the pinning and makes those equations part of the downstream interface. The designated consumer milestone is CFSGStatement L0, “explicit pinned Chevalley--Demazure groups.” After this PR, the full-weight Geck carriers in types `E₈`, `F₄`, and `G₂` still need reductivity, a maximal/Borel torus package, and identification of the carrier's root datum; the other Dynkin families additionally need their full-weight carrier work before uniform `ValidLieTypeIndex.AmbientGroup` assembly.

This is the most effective current step because CFSGStatement I0 and S1 are complete while L0 explicitly depends on ReductiveGroups Layer 9. The Geck carrier, its numbered root subgroups, its torus-conjugation equations, the uniform simply connected root datum, and full-weight results for `E₈`, `F₄`, and `G₂` are already on `main`, but no declaration identifies the carrier's root characters with the named simple roots consumed by L0. The open type-`A` and type-`C` bridges concern separate standard carriers, while the open Geck points and Frobenius work does not supply this root-datum identification.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

Dependency edge: CFSGStatement L0 consumes `ValidLieTypeIndex.AmbientGroup` and `ValidLieTypeIndex.simpleRootSubgroup` traced through `ValidLieTypeIndex.dynkinType`; the `E₈(q)`, `F₄(q)`, and `G₂(q)` branches require ReductiveGroups Layer 9's full-weight Geck carriers to have their numbered root subgroups pinned to `DynkinType.simplyConnectedRootDatum`, which this PR supplies.

The new module `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean` has 170 lines and six public theorems: positive and negative root identifications, pointwise pinning equations, and scheme-level pinning equations. It reuses `DynkinType.root_simpleIndex`, `DynkinType.rootGeneratorWeight_inl`, `DynkinType.rootGeneratorWeight_inr`, `DynkinType.geckTorusPoints_conj_geckRootSubgroupParam`, and `DynkinType.geckWeightTorus_conj_geckRootSubgroup`; no Mathlib infrastructure or external formalization is vendored.

The conventions follow Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plates I--IX; Carter, *Simple Groups of Lie Type*, §§4.4 and 7.1; and Humphreys, *Linear Algebraic Groups*, §§26--27, as recorded in the module documentation. The API shape follows the separate type-`A` and type-`C` carrier bridges in TauCetiProject/TauCeti#5198 and TauCetiProject/TauCeti#5201; no code is copied from either change.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geck-carrier-pinned-root-datum-realization"}-->

🤖 Prepared with Codex
