### PR TITLE
feat(FunctionField): the Riemann–Roch theorem

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.FunctionField.Differential.Dimension
+public import TauCeti.FieldTheory.FunctionField.RiemannRoch.Uniqueness
+
+/-!
+# The divisor of a Weil differential, and the Riemann–Roch theorem
+
+`TauCeti.Divisor.IsRiemannRochDivisor` records what it means for a divisor `W` to satisfy the
+Riemann–Roch identity `ℓ(D) = deg D + 1 - g₀ + ℓ(W - D)`, and everything about such a `W` —
+that `g₀` is the genus, that `deg W = 2g - 2` and `ℓ(W) = g`, that any two are linearly
+equivalent — is proved there.  What is missing, and is supplied here, is that **one exists**.
+That is the Riemann–Roch theorem.
+
+The witness is the divisor of a nonzero Weil differential.  Enlarging a divisor shrinks the space
+`Ω_F(D)` of Weil differentials it bounds, so the divisors bounding a fixed `ω` form a downward
+closed family; the two facts that make it have a *greatest* element are that the family is stable
+under suprema — because `A_F(D ⊔ E) = A_F(D) + A_F(E)`, which is
+`TauCeti.adeleFiltration_sup` — and that its degrees are bounded above, because past the
+threshold of Riemann's theorem the index of specialty vanishes and with it `Ω_F(D)`.
+A divisor of maximal degree in the family is then the greatest, since places have positive degree.
+
+Writing `W` for that greatest divisor, multiplication by a function is an injective `k`-linear map
+`F → Ω_F` carrying `L(W - D)` onto `Ω_F(D)`: a nonzero `x` has `x · ω ∈ Ω_F(D)` exactly when
+`ω ∈ Ω_F(D - div x)`, which by maximality says `D - div x ≤ W`, that is `x ∈ L(W - D)`; and it is
+onto because every Weil differential is a multiple of `ω` (Proposition 1.5.9, already available as
+`TauCeti.exists_repartitionDualMul_eq`).  So `ℓ(W - D) = dim_k Ω_F(D) = i(D)`, which rearranges to
+the Riemann–Roch identity.
+
+This completes Section I.5 of Stichtenoth.  It also supplies the divisor whose absence is noted in
+`TauCeti/FieldTheory/FunctionField/Differential/LocalComponent.lean`, where the remaining
+statements of Section I.7 are held back for want of it.
+
+## Main results
+
+* `TauCeti.mem_weilDifferentialFiltration_sup`: a Weil differential bounded by `D` and by `E` is
+  bounded by `D ⊔ E`.
+* `TauCeti.exists_forall_degree_lt_of_mem_weilDifferentialFiltration`: the divisors bounding a
+  fixed nonzero Weil differential have bounded degree.
+* `TauCeti.exists_isGreatest_mem_weilDifferentialFiltration`: **the divisor of a nonzero Weil
+  differential** — among the divisors bounding it there is a greatest (Stichtenoth,
+  Proposition 1.5.11).
+* `TauCeti.mem_weilDifferentialFiltration_iff_le_of_isGreatest`: `ω ∈ Ω_F(D) ↔ D ≤ (ω)`, the
+  characteristic property of that divisor.
+* `TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace`: the
+  duality `x · ω ∈ Ω_F(D) ↔ x ∈ L(W - D)` that carries the theorem.
+* `TauCeti.isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration`: that divisor is a
+  Riemann–Roch divisor for the genus (Stichtenoth, Theorem 1.5.15).
+* `TauCeti.exists_isRiemannRochDivisor`: **the Riemann–Roch theorem** — a Riemann–Roch divisor
+  exists.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Section I.5, in particular Proposition 1.5.11 and Theorem 1.5.15.
+* [The algebraic curves roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/AlgebraicCurves/README.md),
+  Layer 4.
+-/
+
+public section
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+open scoped WithZero
+
+variable {k F : Type*} [Field k] [Field F] [Algebra k F]
+
+/-! ### Weil differentials bounded by a supremum -/
+
+/-- A Weil differential bounded by each of two divisors is bounded by their supremum: by
+`TauCeti.adeleFiltration_sup` a repartition bounded by `D ⊔ E` is a sum of two on which the
+differential already vanishes. -/
+theorem mem_weilDifferentialFiltration_sup {D E : Divisor k F}
+    {ω : Module.Dual k ↥(repartitionSpace k F)} (hD : ω ∈ weilDifferentialFiltration D)
+    (hE : ω ∈ weilDifferentialFiltration E) :
+    ω ∈ weilDifferentialFiltration (D ⊔ E) := by
+  refine mem_weilDifferentialFiltration_of_apply_eq_zero (fun a ha ↦ ?_) (fun a ha ↦
+    weilDifferentialFiltration_apply_eq_zero_of_mem_diagonalRepartitions hD a ha)
+  obtain ⟨x, hx, y, hy, hxy⟩ := Submodule.mem_sup.mp ((adeleFiltration_sup D E).le ha)
+  have hxA : x ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace D hx
+  have hyA : y ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace E hy
+  have hsplit : a = ⟨x, hxA⟩ + ⟨y, hyA⟩ := Subtype.ext hxy.symm
+  rw [hsplit, map_add,
+    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hD ⟨x, hxA⟩ hx,
+    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hE ⟨y, hyA⟩ hy, add_zero]
+
+/-! ### The divisor of a nonzero Weil differential -/
+
+/-- The divisors bounding a fixed nonzero Weil differential have bounded degree: past the
+constant supplied by Riemann's theorem the index of specialty vanishes, and with it `Ω_F(D)`. -/
+theorem exists_forall_degree_lt_of_mem_weilDifferentialFiltration (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) :
+    ∃ c : ℤ, ∀ D : Divisor k F, ω ∈ weilDifferentialFiltration D → Divisor.degree D < c := by
+  obtain ⟨c, hc⟩ := exists_forall_dim_eq_degree_add_one_sub_genus hF hex
+  refine ⟨c, fun D hD ↦ ?_⟩
+  by_contra hcon
+  push Not at hcon
+  have hi : Divisor.indexOfSpecialty D = 0 := by
+    rw [Divisor.indexOfSpecialty_def, hc D hcon]; ring
+  have hfd := finiteDimensional_weilDifferentialFiltration hF hex D
+  have hrank : Module.finrank k ↥(weilDifferentialFiltration D) = 0 := by
+    have h := finrank_weilDifferentialFiltration hF hex D
+    rw [hi] at h
+    exact_mod_cast h
+  have hbot : weilDifferentialFiltration D = ⊥ := Submodule.finrank_eq_zero.mp hrank
+  exact hω (by simpa [hbot] using hD)
+
+/-- **The divisor of a nonzero Weil differential** (Stichtenoth, Proposition 1.5.11): the
+divisors bounding `ω` have a greatest element.
+
+Degrees are bounded above, so a divisor `W` of maximal degree among them exists; for any other
+`D` bounding `ω`, the supremum `D ⊔ W` also bounds `ω` and has degree at least that of `W` by
+monotonicity and at most by maximality, hence equals `W` because places have positive degree. -/
+theorem exists_isGreatest_mem_weilDifferentialFiltration (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
+    ∃ W : Divisor k F, IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W := by
+  classical
+  obtain ⟨c, hc⟩ := exists_forall_degree_lt_of_mem_weilDifferentialFiltration hF hex hω
+  obtain ⟨D₀, hD₀⟩ := mem_weilDifferentialSpace_iff.mp hmem
+  obtain ⟨m, ⟨W, hWmem, hWdeg⟩, hmax⟩ :=
+    Int.exists_greatest_of_bdd
+      (P := fun n : ℤ => ∃ D : Divisor k F, ω ∈ weilDifferentialFiltration D ∧
+        Divisor.degree D = n)
+      ⟨c, fun n ⟨D, hD, hDn⟩ => hDn ▸ (hc D hD).le⟩
+      ⟨Divisor.degree D₀, D₀, hD₀, rfl⟩
+  refine ⟨W, hWmem, fun D hD ↦ ?_⟩
+  have hsup : ω ∈ weilDifferentialFiltration (D ⊔ W) := mem_weilDifferentialFiltration_sup hD hWmem
+  have hle : Divisor.degree (D ⊔ W) ≤ Divisor.degree W := hWdeg ▸ hmax _ ⟨D ⊔ W, hsup, rfl⟩
+  have hge : Divisor.degree W ≤ Divisor.degree (D ⊔ W) := Divisor.degree_le_of_le le_sup_right
+  have hWeq : W = D ⊔ W := Divisor.eq_of_le_of_degree_eq hF le_sup_right (le_antisymm hge hle)
+  exact hWeq ▸ le_sup_left
+
+/-- The characteristic property of the divisor of `ω`, in the form consumers use: `ω` is bounded
+by `D` exactly when `D` is at most the divisor of `ω`.  The forward direction is maximality; the
+reverse is antitonicity of the filtration. -/
+theorem mem_weilDifferentialFiltration_iff_le_of_isGreatest
+    {ω : Module.Dual k ↥(repartitionSpace k F)} {W : Divisor k F}
+    (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
+    ω ∈ weilDifferentialFiltration D ↔ D ≤ W :=
+  ⟨fun h => hW.2 h, fun h => weilDifferentialFiltration_antitone h hW.1⟩
+
+/-! ### The Riemann–Roch theorem -/
+
+/-- **Duality between `L(W - D)` and `Ω_F(D)`**, for `W` the divisor of `ω`: a function `x`
+multiplies `ω` into `Ω_F(D)` exactly when it lies in `L(W - D)`.
+
+For nonzero `x`, multiplication translates the filtration by the principal divisor of `x`
+(`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`), so `x · ω ∈ Ω_F(D)` says
+`ω ∈ Ω_F(D - div x)`, which by maximality of `W` says `D - div x ≤ W`. -/
+theorem repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace
+    (hF : IsFunctionField k F) {ω : Module.Dual k ↥(repartitionSpace k F)} {W : Divisor k F}
+    (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W)
+    (D : Divisor k F) (x : F) :
+    repartitionDualMul hF x ω ∈ weilDifferentialFiltration D ↔ x ∈ riemannRochSpace (W - D) := by
+  rcases eq_or_ne x 0 with rfl | hx
+  · simp
+  obtain ⟨z, rfl⟩ : ∃ z : Fˣ, (z : F) = x := ⟨Units.mk0 x hx, rfl⟩
+  have habel : W - (D - Divisor.principal hF z) = Divisor.principal hF z + (W - D) := by abel
+  have hrw : D - Divisor.principal hF z + Divisor.principal hF z = D := by abel
+  have hiff : (D - Divisor.principal hF z ≤ W) ↔ 0 ≤ Divisor.principal hF z + (W - D) := by
+    rw [← habel]; exact sub_nonneg.symm
+  rw [mem_riemannRochSpace_units_iff hF, ← hiff]
+  constructor
+  · intro h
+    refine hW.2 ((repartitionDualMul_mem_weilDifferentialFiltration_iff hF z).mp ?_)
+    rwa [hrw]
+  · intro h
+    have hmem := (repartitionDualMul_mem_weilDifferentialFiltration_iff hF z).mpr
+      (weilDifferentialFiltration_antitone h hW.1)
+    rwa [hrw] at hmem
+
+/-- **The Riemann–Roch theorem** (Stichtenoth, Theorem 1.5.15): the divisor of a nonzero Weil
+differential is a Riemann–Roch divisor for the genus.
+
+Multiplication by a function is an injective `k`-linear map `F → Ω_F` carrying `L(W - D)` onto
+`Ω_F(D)`: membership transfers by
+`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace`, and
+surjectivity is Proposition 1.5.9, every Weil differential being a multiple of `ω`.  Hence
+`ℓ(W - D) = dim_k Ω_F(D) = i(D)`, which rearranges to the Riemann–Roch identity. -/
+theorem isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration
+    (hF : IsFunctionField k F) (hex : IsIntegrallyClosedIn k F)
+    {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) {W : Divisor k F}
+    (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) :
+    W.IsRiemannRochDivisor (genus k F) := by
+  set φ : F →ₗ[k] Module.Dual k ↥(repartitionSpace k F) :=
+    { toFun := fun x => repartitionDualMul hF x ω
+      map_add' := fun x y => by rw [map_add]; rfl
+      map_smul' := fun c x => by rw [map_smul]; rfl } with hφ
+  have hφ_apply : ∀ x : F, φ x = repartitionDualMul hF x ω := fun _ => rfl
+  have hinj : Function.Injective φ := by
+    rw [injective_iff_map_eq_zero]
+    intro x hx
+    by_contra hx0
+    obtain ⟨z, rfl⟩ : ∃ z : Fˣ, (z : F) = x := ⟨Units.mk0 x hx0, rfl⟩
+    refine hω ?_
+    have hinv : repartitionDualMul hF ((z⁻¹ : Fˣ) : F) (repartitionDualMul hF (z : F) ω) = ω := by
+      rw [repartitionDualMul_repartitionDualMul, ← Units.val_mul, inv_mul_cancel, Units.val_one,
+        map_one, Module.End.one_apply]
+    rw [← hinv, ← hφ_apply, hx, map_zero]
+  rw [Divisor.isRiemannRochDivisor_iff]
+  intro D
+  have key : ∀ x : F, φ x ∈ weilDifferentialFiltration D ↔ x ∈ riemannRochSpace (W - D) :=
+    fun x => by
+      rw [hφ_apply]
+      exact repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace hF hW D x
+  have himg : Submodule.map φ (riemannRochSpace (W - D)) = weilDifferentialFiltration D := by
+    refine le_antisymm ?_ ?_
+    · rintro _ ⟨x, hx, rfl⟩
+      exact (key x).mpr hx
+    · intro η hη
+      obtain ⟨c, hc⟩ := exists_repartitionDualMul_eq hF hex
+        (weilDifferentialFiltration_le_weilDifferentialSpace W hW.1) hω
+        (weilDifferentialFiltration_le_weilDifferentialSpace D hη)
+      exact ⟨c, (key c).mp (by rw [hφ_apply, hc]; exact hη), hc⟩
+  have hdim : Divisor.dim (W - D) = Module.finrank k ↥(weilDifferentialFiltration D) := by
+    rw [Divisor.dim_def, ← himg]
+    exact (Submodule.equivMapOfInjective φ hinj (riemannRochSpace (W - D))).finrank_eq
+  have hi := finrank_weilDifferentialFiltration hF hex D
+  rw [← hdim, Divisor.indexOfSpecialty_def] at hi
+  omega
+
+/-- **The Riemann–Roch theorem, existence form** (Stichtenoth, Theorem 1.5.15 with
+Corollary 1.5.16): every algebraic function field with exact constant field has a Riemann–Roch
+divisor, namely the divisor of any nonzero Weil differential.  With
+`TauCeti.Divisor.IsRiemannRochDivisor.dim_eq` and
+`TauCeti.Divisor.IsRiemannRochDivisor.degree_eq` this gives `ℓ(W) = g` and `deg W = 2g - 2`, and
+with `TauCeti.Divisor.IsRiemannRochDivisor.linearlyEquivalent` the class of `W` — the canonical
+class — is well defined. -/
+theorem exists_isRiemannRochDivisor (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) :
+    ∃ W : Divisor k F, W.IsRiemannRochDivisor (genus k F) := by
+  obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
+  obtain ⟨W, hW⟩ := exists_isGreatest_mem_weilDifferentialFiltration hF hex hωmem hω0
+  exact ⟨W, isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration hF hex hω0 hW⟩
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -87,29 +87,24 @@ theorem mem_weilDifferentialFiltration_sup {D E : Divisor k F}
   have hxA : x ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace D hx
   have hyA : y ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace E hy
   have hsplit : a = ⟨x, hxA⟩ + ⟨y, hyA⟩ := Subtype.ext hxy.symm
-  rw [hsplit, map_add,
-    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hD ⟨x, hxA⟩ hx,
-    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hE ⟨y, hyA⟩ hy, add_zero]
+  rw [hsplit, map_add]
+  simp [weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hD ⟨x, hxA⟩ hx,
+    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hE ⟨y, hyA⟩ hy]
 
 /-! ### The divisor of a nonzero Weil differential -/
 
 /-- The divisors bounding a fixed nonzero Weil differential have bounded degree: past the
-constant supplied by Riemann's theorem the index of specialty vanishes, and with it `Ω_F(D)`. -/
+threshold of `TauCeti.exists_forall_indexOfSpecialty_eq_zero` the divisor is nonspecial, and a
+nonspecial divisor bounds no nonzero Weil differential. -/
 theorem exists_forall_degree_lt_of_mem_weilDifferentialFiltration (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) :
     ∃ c : ℤ, ∀ D : Divisor k F, ω ∈ weilDifferentialFiltration D → Divisor.degree D < c := by
-  obtain ⟨c, hc⟩ := exists_forall_dim_eq_degree_add_one_sub_genus hF hex
+  obtain ⟨c, hc⟩ := exists_forall_indexOfSpecialty_eq_zero hF hex
   refine ⟨c, fun D hD ↦ ?_⟩
   by_contra hcon
   push Not at hcon
-  have hi : Divisor.indexOfSpecialty D = 0 := by
-    rw [Divisor.indexOfSpecialty_def, hc D hcon]; ring
-  have hfd := finiteDimensional_weilDifferentialFiltration hF hex D
-  have hrank : Module.finrank k ↥(weilDifferentialFiltration D) = 0 := by
-    have h := finrank_weilDifferentialFiltration hF hex D
-    rw [hi] at h
-    exact_mod_cast h
-  have hbot : weilDifferentialFiltration D = ⊥ := Submodule.finrank_eq_zero.mp hrank
+  have hbot : weilDifferentialFiltration D = ⊥ :=
+    (weilDifferentialFiltration_eq_bot_iff_indexOfSpecialty_eq_zero hF hex D).2 (hc D hcon)
   exact hω (by simpa [hbot] using hD)
 
 /-- **The divisor of a nonzero Weil differential** (Stichtenoth, Proposition 1.5.11): the
@@ -201,10 +196,7 @@ theorem isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration
     by_contra hx0
     obtain ⟨z, rfl⟩ : ∃ z : Fˣ, (z : F) = x := ⟨Units.mk0 x hx0, rfl⟩
     refine hω ?_
-    have hinv : repartitionDualMul hF ((z⁻¹ : Fˣ) : F) (repartitionDualMul hF (z : F) ω) = ω := by
-      rw [repartitionDualMul_repartitionDualMul, ← Units.val_mul, inv_mul_cancel, Units.val_one,
-        map_one, Module.End.one_apply]
-    rw [← hinv, ← hφ_apply, hx, map_zero]
+    rw [← repartitionDualMul_inv_repartitionDualMul hF z ω, ← hφ_apply, hx, map_zero]
   rw [Divisor.isRiemannRochDivisor_iff]
   intro D
   have key : ∀ x : F, φ x ∈ weilDifferentialFiltration D ↔ x ∈ riemannRochSpace (W - D) :=

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -30,6 +30,8 @@ specialty, and are proved in `TauCeti/FieldTheory/FunctionField/Differential/Dim
 * `TauCeti.weilDifferentialFiltration`: the space `Ω_F(D)` of Weil differentials bounded by a
   divisor (Definition 1.5.6), as a `k`-subspace of the dual of `A_F`.
 * `TauCeti.weilDifferentialSpace`: the space `Ω_F` of all Weil differentials.
+* `TauCeti.repartitionDualMul_inv_repartitionDualMul`: multiplying by a unit and then its
+  inverse restores the form.
 * `TauCeti.repartitionDualMul`: the action of `F` on the `k`-linear forms on `A_F`, induced by
   multiplication of repartitions by a function (Definition 1.5.8).
 * `TauCeti.weilDifferentialSpaceMul` and `TauCeti.weilDifferentialSpaceModule`: its restriction
@@ -211,6 +213,15 @@ theorem repartitionDualMul_repartitionDualMul (hF : IsFunctionField k F) (f g : 
     repartitionDualMul hF f (repartitionDualMul hF g ω) = repartitionDualMul hF (f * g) ω := by
   rw [← Module.End.mul_apply, ← map_mul]
 
+/-- **Multiplying by a unit and then by its inverse restores the linear form.** The cancellation
+that makes multiplication by a nonzero function invertible on `Ω_F`. -/
+@[simp]
+theorem repartitionDualMul_inv_repartitionDualMul (hF : IsFunctionField k F) (z : Fˣ)
+    (ω : Module.Dual k ↥(repartitionSpace k F)) :
+    repartitionDualMul hF ((z⁻¹ : Fˣ) : F) (repartitionDualMul hF (z : F) ω) = ω := by
+  rw [← Module.End.mul_apply, ← map_mul, ← Units.val_mul, inv_mul_cancel, Units.val_one,
+    map_one, Module.End.one_apply]
+
 /-- **Multiplication translates the filtration by a principal divisor**: for a nonzero function
 `z`, a linear form is bounded by `D` exactly when `z · ω` is bounded by `D + div z`, exactly as
 multiplication by `z` carries `A_F(D + div z)` into `A_F(D)`. -/
@@ -233,9 +244,7 @@ theorem repartitionDualMul_mem_weilDifferentialFiltration_iff (hF : IsFunctionFi
       rw [coe_repartitionMul_apply]
       exact smul_mem_diagonalRepartitions (y : F) ha
   refine ⟨fun h ↦ ?_, key z D ω⟩
-  have hzz : repartitionDualMul hF ((z⁻¹ : Fˣ) : F) (repartitionDualMul hF (z : F) ω) = ω := by
-    rw [← Module.End.mul_apply, ← map_mul, ← Units.val_mul, inv_mul_cancel, Units.val_one,
-      map_one, Module.End.one_apply]
+  have hzz := repartitionDualMul_inv_repartitionDualMul hF z ω
   have hD : D + Divisor.principal hF z + Divisor.principal hF z⁻¹ = D := by
     rw [Divisor.principal_inv, add_neg_cancel_right]
   have h' := key z⁻¹ _ _ h

--- a/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
@@ -216,6 +216,7 @@ theorem adeleFiltration_mono {D E : Divisor k F} (h : D ≤ E) :
 /-- **The filtration turns suprema of divisors into sums of subspaces.** The inclusion that has
 content is `≤`: a repartition bounded by `D ⊔ E` respects, at each place separately, one of the
 two bounds, so assigning each entry to a side splits it as a sum. -/
+@[simp]
 theorem adeleFiltration_sup (D E : Divisor k F) :
     adeleFiltration (D ⊔ E) = adeleFiltration D ⊔ adeleFiltration E := by
   refine le_antisymm (fun a ha ↦ ?_)

--- a/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
@@ -54,6 +54,7 @@ differentials are the work that consumes this file.
 * `TauCeti.adeleFiltration_le_repartitionSpace`, `TauCeti.adeleFiltration_mono` and
   `TauCeti.directed_adeleFiltration`: the filtration lands in `A_F`, and is monotone and
   directed.
+* `TauCeti.adeleFiltration_sup`: `A_F(D ⊔ E) = A_F(D) + A_F(E)`, the place-by-place splitting.
 * `TauCeti.repartitionSpace_eq_iSup` and `TauCeti.coe_repartitionSpace_eq_iUnion`:
   `A_F = ⋃_D A_F(D)`, the exhaustion.
 * `TauCeti.diagonalRepartitions_le_repartitionSpace`: the diagonal `F ↪ A_F`, which is where
@@ -211,6 +212,36 @@ theorem mem_adeleFiltration_zero_iff {a : Place k F → F} :
 theorem adeleFiltration_mono {D E : Divisor k F} (h : D ≤ E) :
     adeleFiltration D ≤ adeleFiltration E := fun _ ha P ↦
   (ha P).trans (WithZero.exp_le_exp.mpr (WeilDivisor.coeff_le_coeff h P))
+
+/-- **The filtration turns suprema of divisors into sums of subspaces.** The inclusion that has
+content is `≤`: a repartition bounded by `D ⊔ E` respects, at each place separately, one of the
+two bounds, so assigning each entry to a side splits it as a sum. -/
+theorem adeleFiltration_sup (D E : Divisor k F) :
+    adeleFiltration (D ⊔ E) = adeleFiltration D ⊔ adeleFiltration E := by
+  refine le_antisymm (fun a ha ↦ ?_)
+    (sup_le (adeleFiltration_mono le_sup_left) (adeleFiltration_mono le_sup_right))
+  classical
+  set a₁ : Place k F → F :=
+    fun P => if P.valuation (a P) ≤ WithZero.exp (D.coeff P) then a P else 0 with ha₁
+  have h₁ : a₁ ∈ adeleFiltration D := by
+    refine mem_adeleFiltration_iff.mpr fun P ↦ ?_
+    by_cases h : P.valuation (a P) ≤ WithZero.exp (D.coeff P) <;> simp [ha₁, h]
+  have h₂ : a - a₁ ∈ adeleFiltration E := by
+    refine mem_adeleFiltration_iff.mpr fun P ↦ ?_
+    by_cases h : P.valuation (a P) ≤ WithZero.exp (D.coeff P)
+    · simp [ha₁, h]
+    · have hmax := mem_adeleFiltration_iff.mp ha P
+      rw [WeilDivisor.coeff_sup] at hmax
+      have hexp : WithZero.exp ((D.coeff P) ⊔ (E.coeff P)) =
+          WithZero.exp (D.coeff P) ⊔ WithZero.exp (E.coeff P) := by
+        rcases le_total (D.coeff P) (E.coeff P) with hle | hle
+        · rw [sup_eq_right.mpr hle, sup_eq_right.mpr (WithZero.exp_le_exp.mpr hle)]
+        · rw [sup_eq_left.mpr hle, sup_eq_left.mpr (WithZero.exp_le_exp.mpr hle)]
+      rw [hexp] at hmax
+      have : P.valuation (a P) ≤ WithZero.exp (E.coeff P) :=
+        (le_sup_iff.mp hmax).resolve_left h
+      simpa [ha₁, h] using this
+  exact Submodule.mem_sup.mpr ⟨a₁, h₁, a - a₁, h₂, by ring⟩
 
 /-- The filtration is directed: any two of its members are contained in a third, namely the one
 attached to the pointwise maximum of the two divisors. -/


### PR DESCRIPTION
Prepared by Claude Opus 5, reviewed by @mrdouglasny.

`Divisor.IsRiemannRochDivisor` already records the Riemann–Roch identity and everything that follows from it — that `g₀` is the genus, that `deg W = 2g - 2` and `ℓ(W) = g`, that any two such divisors are linearly equivalent. Its own docstring names what is missing: *"the Riemann–Roch theorem itself is the assertion that one exists, and exhibits the divisor of a nonzero Weil differential as such a `W`."* This supplies that, completing Stichtenoth Section I.5.

## The argument

The divisors bounding a fixed nonzero `ω` are stable under suprema, because `A_F(D ⊔ E) = A_F(D) + A_F(E)` — a repartition is assignable place by place to whichever bound it already respects — and their degrees are bounded above, because past the threshold of Riemann's theorem the index of specialty vanishes and with it `Ω_F(D)`. A divisor of maximal degree in that family is therefore its greatest element, places having positive degree.

Multiplication by a function is then an injective `k`-linear map carrying `L(W - D)` onto `Ω_F(D)`: a nonzero `x` has `x · ω ∈ Ω_F(D)` exactly when `ω ∈ Ω_F(D - div x)`, which by maximality says `x ∈ L(W - D)`; surjectivity is Proposition 1.5.9, already available as `exists_repartitionDualMul_eq`. Hence `ℓ(W - D) = dim_k Ω_F(D) = i(D)`, which rearranges to the Riemann–Roch identity.

Essentially all of the work was already on `main` — the local-to-global quotient engine, Riemann's theorem, `dim_k Ω_F(D) = i(D)` (1.5.7), `dim_F Ω_F = 1` (1.5.9), and all of `RiemannRoch/Uniqueness.lean`. What this adds is the last structural step.

## The route does not pass through local components

Stichtenoth builds the divisor of `ω` place by place from its local components, and `Differential/LocalComponent.lean` accordingly records the remaining statements of Section I.7 as blocked for want of that divisor:

> The remaining statements of Section I.7 — that no local component of a nonzero Weil differential vanishes, that `v_P (ω)` is the largest bound its local component respects, and the explicit generator of `Ω_{k(x)}` — need the divisor of a Weil differential, and are not proved here.

Getting the greatest element from sup-stability and bounded degree instead means `LocalComponent` is **not** in this module's import cone. So I.7 is unblocked by this rather than prerequisite to it — the dependency the module structure anticipated runs the other way.

This is the part most worth a reviewer's attention: if the intended design really was local-components-first, that intent is worth stating somewhere, and I would rather be told now than have it discovered later.

## Verification

- `lake build` green; 0 sorries.
- `#print axioms` on `exists_isRiemannRochDivisor`, `isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration`, `exists_isGreatest_mem_weilDifferentialFiltration`: `[propext, Classical.choice, Quot.sound]` only.
- `lake exe lint-style` clean on both files.
- The roadmap's Layer 4 target compiles verbatim against it:

```lean
obtain ⟨W, hW⟩ := exists_isRiemannRochDivisor hF hex
exact ⟨W, hW.degree_eq hF hex, hW.dim_eq hF hex, hW⟩
```

## Placement note

`adeleFiltration_sup` is in `Repartition/Basic.lean`, beside `adeleFiltration_mono` and `directed_adeleFiltration`, rather than here: it mentions no Weil differential and elaborates the definition it sits next to. It is stated as an equality; only `≤` is used downstream, but the reverse is two lines of `adeleFiltration_mono` and the equality is the honest statement.

## Roadmap

Advances [`AlgebraicCurves`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/AlgebraicCurves/README.md), **Layer 4: repartitions, Weil differentials, and Riemann–Roch** — specifically the Riemann–Roch target stated at `TauCetiRoadmap/AlgebraicCurves/Suggested.lean:397`, discharged verbatim above. Layer 5's `deg ≥ 2g − 1` target (Stichtenoth 1.5.17) becomes a short derivation from this but is not included; one topic per PR.

Reference: H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer 2009, Section I.5 — Proposition 1.5.11 and Theorem 1.5.15.

Roadmap: AlgebraicCurves
