### PR TITLE
feat: the trace of a pair of opposite root vectors on a weight space

### DIFF
--- a/TauCeti/Algebra/Lie/Submodule/Finrank.lean
+++ b/TauCeti/Algebra/Lie/Submodule/Finrank.lean
@@ -22,7 +22,8 @@ submodules pass through: the linear-algebra lemmas about dimensions of direct su
 * `TauCeti.finrank_toSubmodule`: a Lie submodule has the dimension of its carrier submodule.
 * `TauCeti.finrank_toLieSubmodule`: a Lie subalgebra has the dimension of the Lie submodule it
   determines over itself.
-* `TauCeti.finrank_eq_zero_of_eq_bot`: a trivial Lie submodule has dimension zero.
+* `LieSubmodule.finrank_bot`: the trivial Lie submodule has dimension zero.
+* `LieSubmodule.finrank_eq_zero_of_eq_bot`: the hypothesis form of the same fact.
 -/
 
 public section
@@ -41,13 +42,6 @@ theorem finrank_toSubmodule (N : LieSubmodule R L M) :
     finrank R N.toSubmodule = finrank R N :=
   rfl
 
-/-- **A trivial Lie submodule has dimension zero.**  Unlike `Submodule.finrank_eq_zero`, which is
-an equivalence, this needs no finiteness or rank condition; it is the one-directional form in which
-a vanishing weight space contributes nothing to a dimension count. -/
-theorem finrank_eq_zero_of_eq_bot [Nontrivial R] {N : LieSubmodule R L M} (h : N = ⊥) :
-    finrank R N = 0 := by
-  rw [← finrank_toSubmodule, h, LieSubmodule.bot_toSubmodule, finrank_bot]
-
 variable [LieAlgebra R L]
 
 /-- The type underlying a Lie subalgebra is the type underlying the Lie submodule it determines
@@ -58,3 +52,25 @@ theorem finrank_toLieSubmodule (K : LieSubalgebra R L) :
   rfl
 
 end TauCeti
+
+namespace LieSubmodule
+
+open Module
+
+variable {R L M : Type*} [CommRing R] [Nontrivial R] [LieRing L]
+variable [AddCommGroup M] [Module R M] [LieRingModule L M]
+
+/-- **The trivial Lie submodule has dimension zero.**  `TauCeti.finrank_toSubmodule` is oriented
+away from `Submodule`, so `simp` cannot reach `finrank_bot` for submodules from here; this is the
+`LieSubmodule` normal form. -/
+@[simp]
+theorem finrank_bot : finrank R (⊥ : LieSubmodule R L M) = 0 := by
+  rw [← TauCeti.finrank_toSubmodule, bot_toSubmodule, _root_.finrank_bot]
+
+/-- **A trivial Lie submodule has dimension zero.**  Unlike `Submodule.finrank_eq_zero`, which is
+an equivalence, this needs no finiteness or rank condition; it is the one-directional form in which
+a vanishing weight space contributes nothing to a dimension count. -/
+theorem finrank_eq_zero_of_eq_bot {N : LieSubmodule R L M} (h : N = ⊥) : finrank R N = 0 := by
+  rw [h, finrank_bot]
+
+end LieSubmodule

--- a/TauCeti/Algebra/Lie/Submodule/Finrank.lean
+++ b/TauCeti/Algebra/Lie/Submodule/Finrank.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Lie.Submodule
-public import Mathlib.LinearAlgebra.Dimension.Finrank
+public import Mathlib.LinearAlgebra.Dimension.Finite
 
 /-!
 # The dimension of a Lie submodule
@@ -22,6 +22,7 @@ submodules pass through: the linear-algebra lemmas about dimensions of direct su
 * `TauCeti.finrank_toSubmodule`: a Lie submodule has the dimension of its carrier submodule.
 * `TauCeti.finrank_toLieSubmodule`: a Lie subalgebra has the dimension of the Lie submodule it
   determines over itself.
+* `TauCeti.finrank_eq_zero_of_eq_bot`: a trivial Lie submodule has dimension zero.
 -/
 
 public section
@@ -39,6 +40,13 @@ have the same dimension. -/
 theorem finrank_toSubmodule (N : LieSubmodule R L M) :
     finrank R N.toSubmodule = finrank R N :=
   rfl
+
+/-- **A trivial Lie submodule has dimension zero.**  Unlike `Submodule.finrank_eq_zero`, which is
+an equivalence, this needs no finiteness or rank condition; it is the one-directional form in which
+a vanishing weight space contributes nothing to a dimension count. -/
+theorem finrank_eq_zero_of_eq_bot [Nontrivial R] {N : LieSubmodule R L M} (h : N = ⊥) :
+    finrank R N = 0 := by
+  rw [← finrank_toSubmodule, h, LieSubmodule.bot_toSubmodule, finrank_bot]
 
 variable [LieAlgebra R L]
 

--- a/TauCeti/Algebra/Lie/Weights/Trace.lean
+++ b/TauCeti/Algebra/Lie/Weights/Trace.lean
@@ -17,7 +17,7 @@ Let `H` be a nilpotent Lie subalgebra of `L` acting on a module `M` that is fini
 principal ideal domain `K`, let `α : H → K` be a linear form, and let `x` and `y` be root vectors of
 weights `α` and `-α` whose bracket `⁅x, y⁆` lies in `H`, say `⁅x, y⁆ = z`.  Acting first by `x` and
 then by `y` carries the `χ`-weight space of `M` back to itself; write `TauCeti.raiseLowerEnd` for
-the resulting endomorphism.  Given a bound beyond which the spaces `M_{χ + jα}` vanish, this file
+the resulting endomorphism.  Given a rung `N` at which the space `M_{χ + Nα}` vanishes, this file
 computes its trace:
 
 ```text
@@ -35,9 +35,11 @@ because `z` acts on a generalized weight space with the single generalized eigen
 tr_{Mχ}(y ∘ x) = tr_{M_{α+χ}}(y ∘ x) + dim M_{α+χ} · (α+χ)(z),
 ```
 
-which telescopes up the `α`-string.  The initial-segment formulation assumes such an
-eventual-vanishing bound explicitly.  When `K` is a field of characteristic zero and `α` is a
-nonzero linear form, the string leaves the weights of `M` after finitely many steps;
+which telescopes down from a rung where the weight space is trivial: there `raiseLowerEnd` is
+itself `0`, so the ladder terminates and the rungs beyond it never enter the telescope.  The
+initial-segment formulation assumes such a vanishing rung explicitly.  When `K` is a field of
+characteristic zero and `α` is a nonzero linear form, the string leaves the weights of `M`
+after finitely many steps;
 `TauCeti/Algebra/Lie/Weights/String.lean` packages that finite index set as `TauCeti.weightString`.
 
 The identity is the computational input to **Freudenthal's multiplicity formula**: taking `x` and
@@ -56,11 +58,11 @@ recursion, by the normalization `⟨λ, α^∨⟩⟨α, α⟩ = 2⟨λ, α⟩` o
 
 * `TauCeti.trace_raiseLowerEnd_eq_trace_add_nsmul`: the ladder step, expressing the trace at `χ` in
   terms of the trace at `α + χ`.
-* `TauCeti.trace_raiseLowerEnd_eq_sum_Ico`: the closed form, as a sum over an initial segment of
-  `ℕ` reaching past the end of the `α`-string.
-* `TauCeti.trace_raiseLowerEnd_eq_sum_weightString`: the same closed form, summed over the
-  `α`-string above `χ` with its bottom index removed, which is the index set of the inner sum of
-  Freudenthal's formula.
+* `TauCeti.trace_raiseLowerEnd_eq_sum_Ico`: the closed form, as a sum over `Finset.Ico 1 N` for a
+  rung `N` at which the `α`-string above `χ` has a trivial weight space.
+* `TauCeti.trace_raiseLowerEnd_eq_sum_weightString_erase_zero`: the same closed form, summed over
+  the `α`-string above `χ` with its bottom index removed, which is the index set of the inner sum
+  of Freudenthal's formula.
 
 ## References
 
@@ -87,17 +89,24 @@ variable {K : Type u} {L : Type v} {M : Type w} [CommRing K] [LieRing L] [LieAlg
 
 variable (M) in
 /-- The action of a root vector `x` of weight `α`, as a map from the `χ`-weight space of `M` to the
-`ψ`-weight space, for `ψ = α + χ`.  The target weight is an argument rather than the literal sum,
-so that the composites below stay in normal form. -/
+`ψ`-weight space, for `ψ = α + χ`.  This is Mathlib's `LieAlgebra.rootSpaceWeightSpaceProductAux`
+evaluated at `x`, packaged so that the root vector enters as a membership hypothesis rather than as
+an element of `rootSpace H α`. -/
 def rootVectorMap {α χ ψ : H → K} {x : L} (hx : x ∈ rootSpace H α) (hψ : α + χ = ψ) :
     genWeightSpace M χ →ₗ[K] genWeightSpace M ψ :=
-  (toEnd K L M x).restrict fun _ hm =>
-    hψ ▸ mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace K L H M α χ hx hm
+  rootSpaceWeightSpaceProductAux K L H M hψ ⟨x, hx⟩
 
 @[simp]
 theorem coe_rootVectorMap_apply {α χ ψ : H → K} {x : L} (hx : x ∈ rootSpace H α)
     (hψ : α + χ = ψ) (m : genWeightSpace M χ) :
     (rootVectorMap M hx hψ m : M) = ⁅x, (m : M)⁆ :=
+  (rfl)
+
+/-- The action of a root vector on weight spaces is the restriction of its action on all of `M`. -/
+theorem rootVectorMap_eq_restrict {α χ ψ : H → K} {x : L} (hx : x ∈ rootSpace H α)
+    (hψ : α + χ = ψ) :
+    rootVectorMap M hx hψ = (toEnd K L M x).restrict fun _ hm =>
+      hψ ▸ mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace K L H M α χ hx hm :=
   (rfl)
 
 variable (M) in
@@ -107,6 +116,13 @@ def raiseLowerEnd {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
     (hy : y ∈ rootSpace H (-α)) (χ : H → K) : Module.End K (genWeightSpace M χ) :=
   rootVectorMap M hy (neg_add_cancel_left α χ) ∘ₗ rootVectorMap M hx rfl
 
+/-- `raiseLowerEnd` is the composite of the two root-vector actions, in that order. -/
+theorem raiseLowerEnd_def {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
+    (hy : y ∈ rootSpace H (-α)) (χ : H → K) :
+    raiseLowerEnd M hx hy χ
+      = rootVectorMap M hy (neg_add_cancel_left α χ) ∘ₗ rootVectorMap M hx rfl :=
+  (rfl)
+
 @[simp]
 theorem coe_raiseLowerEnd_apply {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
     (hy : y ∈ rootSpace H (-α)) (χ : H → K) (m : genWeightSpace M χ) :
@@ -115,7 +131,8 @@ theorem coe_raiseLowerEnd_apply {α : H → K} {x y : L} (hx : x ∈ rootSpace H
 
 /-- **The Leibniz identity, read on a weight space.**  Lowering and then raising differs from
 raising and then lowering by the action of `⁅x, y⁆`. -/
-theorem rootVectorMap_comp_rootVectorMap_sub_raiseLowerEnd {α : H → K} {x y : L} {z : H}
+theorem rootVectorMap_comp_rootVectorMap_sub_raiseLowerEnd_eq_toEnd
+    {α : H → K} {x y : L} {z : H}
     (hx : x ∈ rootSpace H α) (hy : y ∈ rootSpace H (-α)) (hz : ⁅x, y⁆ = (z : L)) (χ : H → K) :
     rootVectorMap M hx (rfl : α + χ = α + χ) ∘ₗ rootVectorMap M hy (neg_add_cancel_left α χ)
         - raiseLowerEnd M hx hy (α + χ)
@@ -157,24 +174,21 @@ theorem trace_raiseLowerEnd_eq_trace_add_nsmul (hx : x ∈ rootSpace H α)
   have hswap := LinearMap.trace_comp_comm' (R := K) (rootVectorMap M hx (rfl : α + χ = α + χ))
     (rootVectorMap M hy (neg_add_cancel_left α χ))
   have hcomm := congrArg (trace K (genWeightSpace M (α + χ)))
-    (rootVectorMap_comp_rootVectorMap_sub_raiseLowerEnd (M := M) hx hy hz χ)
+    (rootVectorMap_comp_rootVectorMap_sub_raiseLowerEnd_eq_toEnd (M := M) hx hy hz χ)
   rw [map_sub, trace_toEnd_genWeightSpace, sub_eq_iff_eq_add'] at hcomm
-  -- Unfolding `raiseLowerEnd` exposes the two factors that `hswap` exchanges.
-  rw [raiseLowerEnd, hswap, hcomm]
+  -- `raiseLowerEnd_def` exposes the two factors that `hswap` exchanges.
+  rw [raiseLowerEnd_def, hswap, hcomm]
 
-/-- **The closed form of the trace**, as a sum over an initial segment of `ℕ` reaching past the end
-of the `α`-string above `χ`. -/
+/-- **The closed form of the trace**, as a sum over `Finset.Ico 1 N`, for any rung `N` at which the
+`α`-string above `χ` has a trivial weight space.  The ladder terminates there, so nothing beyond
+that rung is assumed. -/
 theorem trace_raiseLowerEnd_eq_sum_Ico (hx : x ∈ rootSpace H α) (hy : y ∈ rootSpace H (-α))
-    (hz : ⁅x, y⁆ = (z : L)) (χ : H → K) {N : ℕ}
-    (hN : ∀ j : ℕ, N ≤ j → genWeightSpace M (χ + j • α) = ⊥) :
+    (hz : ⁅x, y⁆ = (z : L)) (χ : H → K) {N : ℕ} (hN : genWeightSpace M (χ + N • α) = ⊥) :
     trace K _ (raiseLowerEnd M hx hy χ)
       = ∑ j ∈ Finset.Ico 1 N, finrank K (genWeightSpace M (χ + j • α)) • (χ + j • α) z := by
-  have hterm : ∀ k : ℕ, N ≤ k →
-      finrank K (genWeightSpace M (χ + k • α)) • (χ + k • α) z = 0 := fun k hk => by
-    rw [hN k hk, ← finrank_toSubmodule, LieSubmodule.bot_toSubmodule, finrank_bot, zero_smul]
-  -- The statement at the rung `χ + i • α`, proved by induction on the number of rungs `d` still
-  -- available before the string is known to have ended.
-  suffices h : ∀ d i : ℕ, N ≤ i + d →
+  -- The statement at the rung `χ + i • α`, proved by induction on the number `d` of rungs between
+  -- `i` and the terminal rung `N`.
+  suffices h : ∀ d i : ℕ, i + d = N →
       trace K _ (raiseLowerEnd M hx hy (χ + i • α))
         = ∑ j ∈ Finset.Ico (i + 1) N,
             finrank K (genWeightSpace M (χ + j • α)) • (χ + j • α) z by
@@ -184,20 +198,19 @@ theorem trace_raiseLowerEnd_eq_sum_Ico (hx : x ∈ rootSpace H α) (hy : y ∈ r
   induction d with
   | zero =>
     intro i hi
-    rw [raiseLowerEnd_eq_zero hx hy (hN i (by omega)), map_zero,
-      Finset.Ico_eq_empty (by omega), Finset.sum_empty]
+    obtain rfl : i = N := by omega
+    rw [raiseLowerEnd_eq_zero hx hy hN, map_zero, Finset.Ico_eq_empty (by omega),
+      Finset.sum_empty]
   | succ d ih =>
     intro i hi
-    rcases le_or_gt N i with hiN | hiN
-    · rw [raiseLowerEnd_eq_zero hx hy (hN i hiN), map_zero,
-        Finset.Ico_eq_empty (by omega), Finset.sum_empty]
     have hshift : α + (χ + i • α) = χ + (i + 1) • α := by rw [succ_nsmul]; abel
     rw [trace_raiseLowerEnd_eq_trace_add_nsmul hx hy hz, hshift, ih (i + 1) (by omega)]
     rcases lt_or_ge (i + 1) N with hlt | hge
     · rw [Finset.sum_eq_sum_Ico_succ_bot hlt]
       abel
-    · rw [Finset.Ico_eq_empty (by omega), Finset.Ico_eq_empty (by omega), Finset.sum_empty,
-        hterm (i + 1) hge, add_zero]
+    · obtain rfl : i + 1 = N := by omega
+      rw [Finset.Ico_eq_empty (by omega), Finset.Ico_eq_empty (by omega), Finset.sum_empty,
+        finrank_eq_zero_of_eq_bot hN, zero_smul, add_zero]
 
 end Trace
 
@@ -210,34 +223,39 @@ variable {K : Type u} {L : Type v} {M : Type w} [Field K] [CharZero K] [LieRing 
 
 /-- **The closed form of the trace**, summed over the `α`-string above `χ` with its bottom index
 removed.  This is the index set of the inner sum of Freudenthal's multiplicity formula. -/
-theorem trace_raiseLowerEnd_eq_sum_weightString (hα : α ≠ 0)
+theorem trace_raiseLowerEnd_eq_sum_weightString_erase_zero (hα : α ≠ 0)
     (hx : x ∈ rootSpace H (α : H → K)) (hy : y ∈ rootSpace H (-(α : H → K)))
     (hz : ⁅x, y⁆ = (z : L)) :
     trace K _ (raiseLowerEnd M hx hy (χ : H → K))
       = ∑ j ∈ (weightString M hα χ).erase 0,
-          finrank K (genWeightSpace M ((χ : H → K) + j • (α : H → K)))
-            • ((χ : H → K) + j • (α : H → K)) z := by
+          finrank K (genWeightSpace M ((χ + j • α : Dual K H) : H → K))
+            • ((χ + j • α : Dual K H) : H → K) z := by
   classical
-  -- The string API speaks of `↑(χ + j • α)` while the trace results speak of `↑χ + j • ↑α`;
-  -- forgetting linearity commutes with these operations definitionally, so `hN` and
-  -- `mem_weightString_iff` transfer without a rewrite.
+  -- The string API spells the shifted weight `↑(χ + j • α)`, the trace results `↑χ + j • ↑α`;
+  -- `LinearMap.coe_add` and `LinearMap.coe_smul` pass between the two spellings.
+  have hcoe : ∀ j : ℕ, ((χ + j • α : Dual K H) : H → K) = (χ : H → K) + j • (α : H → K) :=
+    fun _ => by simp only [LinearMap.coe_add, LinearMap.coe_smul]
   obtain ⟨N, hN⟩ := exists_genWeightSpace_add_nsmul_eq_bot_of_le (M := M) hα χ
+  have hN' : ∀ j : ℕ, N ≤ j → genWeightSpace M ((χ : H → K) + j • (α : H → K)) = ⊥ :=
+    fun j hj => by rw [← hcoe]; exact hN j hj
   have hmem : ∀ j : ℕ, j ∈ weightString M hα χ ↔
-      genWeightSpace M ((χ : H → K) + j • (α : H → K)) ≠ ⊥ := fun _ => mem_weightString_iff hα χ
-  rw [trace_raiseLowerEnd_eq_sum_Ico hx hy hz _ hN]
+      genWeightSpace M ((χ : H → K) + j • (α : H → K)) ≠ ⊥ :=
+    fun j => by rw [mem_weightString_iff, hcoe]
+  simp only [hcoe]
+  rw [trace_raiseLowerEnd_eq_sum_Ico hx hy hz _ (hN' N le_rfl)]
   refine (Finset.sum_subset (fun j hj => ?_) (fun j hj hj' => ?_)).symm
   · have hjw := (hmem j).mp (Finset.mem_of_mem_erase hj)
     have hj0 : j ≠ 0 := Finset.ne_of_mem_erase hj
     refine Finset.mem_Ico.mpr ⟨by omega, ?_⟩
     by_contra hjN
-    exact hjw (hN j (by omega))
+    exact hjw (hN' j (by omega))
   · have hj0 : j ≠ 0 := by have := (Finset.mem_Ico.mp hj).1; omega
     have hjnot : j ∉ weightString M hα χ := fun hj'' =>
       hj' (Finset.mem_erase.mpr ⟨hj0, hj''⟩)
     have hjw : genWeightSpace M ((χ : H → K) + j • (α : H → K)) = ⊥ := by
       by_contra hne
       exact hjnot ((hmem j).mpr hne)
-    rw [hjw, ← finrank_toSubmodule, LieSubmodule.bot_toSubmodule, finrank_bot, zero_smul]
+    rw [finrank_eq_zero_of_eq_bot hjw, zero_smul]
 
 end WeightString
 

--- a/TauCeti/Algebra/Lie/Weights/Trace.lean
+++ b/TauCeti/Algebra/Lie/Weights/Trace.lean
@@ -21,8 +21,12 @@ the resulting endomorphism.  Given a rung `N` at which the space `M_{χ + Nα}` 
 computes its trace:
 
 ```text
-tr_{Mχ}(y ∘ x) = Σ_{j ≥ 1} dim M_{χ + jα} · (χ + jα)(z).
+tr_{Mχ}(y ∘ x) = Σ_{1 ≤ j < N} dim M_{χ + jα} · (χ + jα)(z).
 ```
+
+Over a field of characteristic zero and for a nonzero `α`, the `α`-string above `χ` is finite, and
+the same computation takes the unbounded shape `Σ_{j ≥ 1}` that Freudenthal's formula uses, indexed
+by that string with its bottom rung removed.
 
 The argument is a ladder, with no `sl₂` representation theory and no complete reducibility.  Acting
 by `x` and by `y` gives maps `Mχ → M_{α+χ}` and `M_{α+χ} → Mχ`, and swapping the two factors of a
@@ -85,6 +89,17 @@ variable {K : Type u} {L : Type v} {M : Type w} [CommRing K] [LieRing L] [LieAlg
   {H : LieSubalgebra K L} [LieRing.IsNilpotent H]
   [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
 
+/-- Acting by a root vector on a weight vector is the bracket.  Mathlib states this elementwise
+description only for the bundled `rootSpaceWeightSpaceProduct`, in
+`coe_rootSpaceWeightSpaceProduct_tmul`, so the auxiliary bilinear map that this file uses is
+unfolded once, here. -/
+@[simp]
+theorem coe_rootSpaceWeightSpaceProductAux_apply {χ₁ χ₂ χ₃ : H → K} (hχ : χ₁ + χ₂ = χ₃)
+    (x : rootSpace H χ₁) (m : genWeightSpace M χ₂) :
+    ((rootSpaceWeightSpaceProductAux K L H M hχ x m : genWeightSpace M χ₃) : M)
+      = ⁅(x : L), (m : M)⁆ :=
+  rfl
+
 variable (M) in
 /-- Acting by a root vector `x` of weight `α` and then by a root vector `y` of weight `-α`, as an
 endomorphism of the `χ`-weight space of `M`. -/
@@ -104,12 +119,26 @@ theorem raiseLowerEnd_def {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
 @[simp]
 theorem coe_raiseLowerEnd_apply {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
     (hy : y ∈ rootSpace H (-α)) (χ : H → K) (m : genWeightSpace M χ) :
-    (raiseLowerEnd M hx hy χ m : M) = ⁅y, ⁅x, (m : M)⁆⁆ :=
-  (rfl)
+    (raiseLowerEnd M hx hy χ m : M) = ⁅y, ⁅x, (m : M)⁆⁆ := by
+  rw [raiseLowerEnd_def]
+  simp only [LinearMap.coe_comp, Function.comp_apply, coe_rootSpaceWeightSpaceProductAux_apply]
+
+/-- `raiseLowerEnd` is the restriction to the `χ`-weight space of the composite of the two actions
+on `M`, which is the shape in which a trace computation over a basis of `L` produces it. -/
+theorem raiseLowerEnd_eq_restrict {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
+    (hy : y ∈ rootSpace H (-α)) (χ : H → K)
+    (h : ∀ m ∈ (genWeightSpace M χ).toSubmodule,
+      (toEnd K L M y ∘ₗ toEnd K L M x) m ∈ (genWeightSpace M χ).toSubmodule) :
+    raiseLowerEnd M hx hy χ = (toEnd K L M y ∘ₗ toEnd K L M x).restrict h := by
+  ext m
+  -- `simp` cannot close this: the goal spells the coercion of `m` through the Lie submodule,
+  -- while `LinearMap.coe_restrict_apply` spells it through the carrier submodule.
+  rw [coe_raiseLowerEnd_apply]
+  exact (LinearMap.coe_restrict_apply h m).symm
 
 /-- **The Leibniz identity, read on a weight space.**  Lowering and then raising differs from
 raising and then lowering by the action of `⁅x, y⁆`. -/
-theorem rootSpaceWeightSpaceProductAux_comp_sub_raiseLowerEnd_eq_toEnd
+private theorem rootSpaceWeightSpaceProductAux_comp_sub_raiseLowerEnd_eq_toEnd
     {α : H → K} {x y : L} {z : H}
     (hx : x ∈ rootSpace H α) (hy : y ∈ rootSpace H (-α)) (hz : ⁅x, y⁆ = (z : L)) (χ : H → K) :
     rootSpaceWeightSpaceProductAux K L H M (rfl : α + χ = α + χ) ⟨x, hx⟩ ∘ₗ
@@ -118,15 +147,10 @@ theorem rootSpaceWeightSpaceProductAux_comp_sub_raiseLowerEnd_eq_toEnd
       = toEnd K H (genWeightSpace M (α + χ)) z := by
   ext m
   have h := leibniz_lie x y (m : M)
-  have hxy :
-      ((rootSpaceWeightSpaceProductAux K L H M (rfl : α + χ = α + χ) ⟨x, hx⟩
-          (rootSpaceWeightSpaceProductAux K L H M (neg_add_cancel_left α χ) ⟨y, hy⟩ m) :
-          genWeightSpace M (α + χ)) : M) = ⁅x, ⁅y, (m : M)⁆⁆ :=
-    rfl
   simp only [LinearMap.sub_apply, LinearMap.coe_comp, Function.comp_apply,
-    AddSubgroupClass.coe_sub, coe_raiseLowerEnd_apply, toEnd_apply_apply,
-    LieSubmodule.coe_bracket, LieSubalgebra.coe_bracket_of_module, ← hz]
-  rw [hxy, h]
+    AddSubgroupClass.coe_sub, coe_rootSpaceWeightSpaceProductAux_apply, coe_raiseLowerEnd_apply,
+    toEnd_apply_apply, LieSubmodule.coe_bracket, LieSubalgebra.coe_bracket_of_module, ← hz]
+  rw [h]
   abel
 
 /-- On a trivial weight space the raise-lower endomorphism vanishes. -/
@@ -195,7 +219,7 @@ theorem trace_raiseLowerEnd_eq_sum_Ico (hx : x ∈ rootSpace H α) (hy : y ∈ r
       abel
     · obtain rfl : i + 1 = N := by omega
       rw [Finset.Ico_eq_empty (by omega), Finset.Ico_eq_empty (by omega), Finset.sum_empty,
-        finrank_eq_zero_of_eq_bot hN, zero_smul, add_zero]
+        LieSubmodule.finrank_eq_zero_of_eq_bot hN, zero_smul, add_zero]
 
 end Trace
 
@@ -240,7 +264,7 @@ theorem trace_raiseLowerEnd_eq_sum_weightString_erase_zero (hα : α ≠ 0)
     have hjw : genWeightSpace M ((χ : H → K) + j • (α : H → K)) = ⊥ := by
       by_contra hne
       exact hjnot ((hmem j).mpr hne)
-    rw [finrank_eq_zero_of_eq_bot hjw, zero_smul]
+    rw [LieSubmodule.finrank_eq_zero_of_eq_bot hjw, zero_smul]
 
 end WeightString
 

--- a/TauCeti/Algebra/Lie/Weights/Trace.lean
+++ b/TauCeti/Algebra/Lie/Weights/Trace.lean
@@ -17,7 +17,8 @@ Let `H` be a nilpotent Lie subalgebra of `L` acting on a finite-dimensional modu
 `α : H → K` be a linear form, and let `x` and `y` be root vectors of weights `α` and `-α` whose
 bracket `⁅x, y⁆` lies in `H`, say `⁅x, y⁆ = z`.  Acting first by `x` and then by `y` carries the
 `χ`-weight space of `M` back to itself; write `TauCeti.raiseLowerEnd` for the resulting
-endomorphism.  This file computes its trace:
+endomorphism.  Given a bound beyond which the spaces `M_{χ + jα}` vanish, this file computes its
+trace:
 
 ```text
 tr_{Mχ}(y ∘ x) = Σ_{j ≥ 1} dim M_{χ + jα} · (χ + jα)(z).
@@ -34,9 +35,10 @@ because `z` acts on a generalized weight space with the single generalized eigen
 tr_{Mχ}(y ∘ x) = tr_{M_{α+χ}}(y ∘ x) + dim M_{α+χ} · (α+χ)(z),
 ```
 
-which telescopes up the `α`-string.  The string leaves the weights of `M` after finitely many
-steps, so the sum is finite; `TauCeti/Algebra/Lie/Weights/String.lean` packages that index set as
-`TauCeti.weightString`.
+which telescopes up the `α`-string.  The initial-segment formulation assumes such an
+eventual-vanishing bound explicitly.  When `K` has characteristic zero and `α` is a nonzero linear
+form, the string leaves the weights of `M` after finitely many steps;
+`TauCeti/Algebra/Lie/Weights/String.lean` packages that finite index set as `TauCeti.weightString`.
 
 The identity is the computational input to **Freudenthal's multiplicity formula**: taking `x` and
 `y` to be the root vectors of an `sl₂` triple attached to a positive root `α`, so that `z = α^∨`,

--- a/TauCeti/Algebra/Lie/Weights/Trace.lean
+++ b/TauCeti/Algebra/Lie/Weights/Trace.lean
@@ -208,15 +208,6 @@ variable {K : Type u} {L : Type v} {M : Type w} [Field K] [CharZero K] [LieRing 
   [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M] [FiniteDimensional K M]
   {α χ : Module.Dual K H} {x y : L} {z : H}
 
-omit [CharZero K] [LieRing.IsNilpotent H] [LieRingModule L M] [LieModule K L M]
-  [FiniteDimensional K M] in
-/-- Translating a linear weight by a multiple of another is the same operation before and after
-forgetting linearity. -/
-private theorem coe_add_nsmul (j : ℕ) :
-    ((χ + j • α : Module.Dual K H) : H → K) = (χ : H → K) + j • (α : H → K) := by
-  ext v
-  simp
-
 /-- **The closed form of the trace**, summed over the `α`-string above `χ` with its bottom index
 removed.  This is the index set of the inner sum of Freudenthal's multiplicity formula. -/
 theorem trace_raiseLowerEnd_eq_sum_weightString (hα : α ≠ 0)
@@ -227,11 +218,12 @@ theorem trace_raiseLowerEnd_eq_sum_weightString (hα : α ≠ 0)
           finrank K (genWeightSpace M ((χ : H → K) + j • (α : H → K)))
             • ((χ : H → K) + j • (α : H → K)) z := by
   classical
+  -- The string API speaks of `↑(χ + j • α)` while the trace results speak of `↑χ + j • ↑α`;
+  -- forgetting linearity commutes with these operations definitionally, so `hN` and
+  -- `mem_weightString_iff` transfer without a rewrite.
   obtain ⟨N, hN⟩ := exists_genWeightSpace_add_nsmul_eq_bot_of_le (M := M) hα χ
-  simp only [coe_add_nsmul] at hN
   have hmem : ∀ j : ℕ, j ∈ weightString M hα χ ↔
-      genWeightSpace M ((χ : H → K) + j • (α : H → K)) ≠ ⊥ := fun j => by
-    rw [mem_weightString_iff, coe_add_nsmul]
+      genWeightSpace M ((χ : H → K) + j • (α : H → K)) ≠ ⊥ := fun _ => mem_weightString_iff hα χ
   rw [trace_raiseLowerEnd_eq_sum_Ico hx hy hz _ hN]
   refine (Finset.sum_subset (fun j hj => ?_) (fun j hj hj' => ?_)).symm
   · have hjw := (hmem j).mp (Finset.mem_of_mem_erase hj)

--- a/TauCeti/Algebra/Lie/Weights/Trace.lean
+++ b/TauCeti/Algebra/Lie/Weights/Trace.lean
@@ -49,8 +49,6 @@ recursion, by the normalization `⟨λ, α^∨⟩⟨α, α⟩ = 2⟨λ, α⟩` o
 
 ## Main definitions
 
-* `TauCeti.rootVectorMap`: the action of a root vector of weight `α`, as a linear map from the
-  `χ`-weight space to the `(α + χ)`-weight space.
 * `TauCeti.raiseLowerEnd`: acting by a root vector of weight `α` and then by one of weight `-α`, as
   an endomorphism of the `χ`-weight space.
 
@@ -88,39 +86,19 @@ variable {K : Type u} {L : Type v} {M : Type w} [CommRing K] [LieRing L] [LieAlg
   [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
 
 variable (M) in
-/-- The action of a root vector `x` of weight `α`, as a map from the `χ`-weight space of `M` to the
-`ψ`-weight space, for `ψ = α + χ`.  This is Mathlib's `LieAlgebra.rootSpaceWeightSpaceProductAux`
-evaluated at `x`, packaged so that the root vector enters as a membership hypothesis rather than as
-an element of `rootSpace H α`. -/
-def rootVectorMap {α χ ψ : H → K} {x : L} (hx : x ∈ rootSpace H α) (hψ : α + χ = ψ) :
-    genWeightSpace M χ →ₗ[K] genWeightSpace M ψ :=
-  rootSpaceWeightSpaceProductAux K L H M hψ ⟨x, hx⟩
-
-@[simp]
-theorem coe_rootVectorMap_apply {α χ ψ : H → K} {x : L} (hx : x ∈ rootSpace H α)
-    (hψ : α + χ = ψ) (m : genWeightSpace M χ) :
-    (rootVectorMap M hx hψ m : M) = ⁅x, (m : M)⁆ :=
-  (rfl)
-
-/-- The action of a root vector on weight spaces is the restriction of its action on all of `M`. -/
-theorem rootVectorMap_eq_restrict {α χ ψ : H → K} {x : L} (hx : x ∈ rootSpace H α)
-    (hψ : α + χ = ψ) :
-    rootVectorMap M hx hψ = (toEnd K L M x).restrict fun _ hm =>
-      hψ ▸ mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace K L H M α χ hx hm :=
-  (rfl)
-
-variable (M) in
 /-- Acting by a root vector `x` of weight `α` and then by a root vector `y` of weight `-α`, as an
 endomorphism of the `χ`-weight space of `M`. -/
 def raiseLowerEnd {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
     (hy : y ∈ rootSpace H (-α)) (χ : H → K) : Module.End K (genWeightSpace M χ) :=
-  rootVectorMap M hy (neg_add_cancel_left α χ) ∘ₗ rootVectorMap M hx rfl
+  rootSpaceWeightSpaceProductAux K L H M (neg_add_cancel_left α χ) ⟨y, hy⟩ ∘ₗ
+    rootSpaceWeightSpaceProductAux K L H M rfl ⟨x, hx⟩
 
 /-- `raiseLowerEnd` is the composite of the two root-vector actions, in that order. -/
 theorem raiseLowerEnd_def {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
     (hy : y ∈ rootSpace H (-α)) (χ : H → K) :
     raiseLowerEnd M hx hy χ
-      = rootVectorMap M hy (neg_add_cancel_left α χ) ∘ₗ rootVectorMap M hx rfl :=
+      = rootSpaceWeightSpaceProductAux K L H M (neg_add_cancel_left α χ) ⟨y, hy⟩ ∘ₗ
+        rootSpaceWeightSpaceProductAux K L H M rfl ⟨x, hx⟩ :=
   (rfl)
 
 @[simp]
@@ -131,18 +109,24 @@ theorem coe_raiseLowerEnd_apply {α : H → K} {x y : L} (hx : x ∈ rootSpace H
 
 /-- **The Leibniz identity, read on a weight space.**  Lowering and then raising differs from
 raising and then lowering by the action of `⁅x, y⁆`. -/
-theorem rootVectorMap_comp_rootVectorMap_sub_raiseLowerEnd_eq_toEnd
+theorem rootSpaceWeightSpaceProductAux_comp_sub_raiseLowerEnd_eq_toEnd
     {α : H → K} {x y : L} {z : H}
     (hx : x ∈ rootSpace H α) (hy : y ∈ rootSpace H (-α)) (hz : ⁅x, y⁆ = (z : L)) (χ : H → K) :
-    rootVectorMap M hx (rfl : α + χ = α + χ) ∘ₗ rootVectorMap M hy (neg_add_cancel_left α χ)
+    rootSpaceWeightSpaceProductAux K L H M (rfl : α + χ = α + χ) ⟨x, hx⟩ ∘ₗ
+        rootSpaceWeightSpaceProductAux K L H M (neg_add_cancel_left α χ) ⟨y, hy⟩
         - raiseLowerEnd M hx hy (α + χ)
       = toEnd K H (genWeightSpace M (α + χ)) z := by
   ext m
   have h := leibniz_lie x y (m : M)
+  have hxy :
+      ((rootSpaceWeightSpaceProductAux K L H M (rfl : α + χ = α + χ) ⟨x, hx⟩
+          (rootSpaceWeightSpaceProductAux K L H M (neg_add_cancel_left α χ) ⟨y, hy⟩ m) :
+          genWeightSpace M (α + χ)) : M) = ⁅x, ⁅y, (m : M)⁆⁆ :=
+    rfl
   simp only [LinearMap.sub_apply, LinearMap.coe_comp, Function.comp_apply,
-    AddSubgroupClass.coe_sub, coe_rootVectorMap_apply, coe_raiseLowerEnd_apply,
-    toEnd_apply_apply, LieSubmodule.coe_bracket, LieSubalgebra.coe_bracket_of_module, ← hz]
-  rw [h]
+    AddSubgroupClass.coe_sub, coe_raiseLowerEnd_apply, toEnd_apply_apply,
+    LieSubmodule.coe_bracket, LieSubalgebra.coe_bracket_of_module, ← hz]
+  rw [hxy, h]
   abel
 
 /-- On a trivial weight space the raise-lower endomorphism vanishes. -/
@@ -171,10 +155,11 @@ theorem trace_raiseLowerEnd_eq_trace_add_nsmul (hx : x ∈ rootSpace H α)
     trace K _ (raiseLowerEnd M hx hy χ)
       = trace K _ (raiseLowerEnd M hx hy (α + χ))
         + finrank K (genWeightSpace M (α + χ)) • (α + χ) z := by
-  have hswap := LinearMap.trace_comp_comm' (R := K) (rootVectorMap M hx (rfl : α + χ = α + χ))
-    (rootVectorMap M hy (neg_add_cancel_left α χ))
+  have hswap := LinearMap.trace_comp_comm' (R := K)
+    (rootSpaceWeightSpaceProductAux K L H M (rfl : α + χ = α + χ) ⟨x, hx⟩)
+    (rootSpaceWeightSpaceProductAux K L H M (neg_add_cancel_left α χ) ⟨y, hy⟩)
   have hcomm := congrArg (trace K (genWeightSpace M (α + χ)))
-    (rootVectorMap_comp_rootVectorMap_sub_raiseLowerEnd_eq_toEnd (M := M) hx hy hz χ)
+    (rootSpaceWeightSpaceProductAux_comp_sub_raiseLowerEnd_eq_toEnd (M := M) hx hy hz χ)
   rw [map_sub, trace_toEnd_genWeightSpace, sub_eq_iff_eq_add'] at hcomm
   -- `raiseLowerEnd_def` exposes the two factors that `hswap` exchanges.
   rw [raiseLowerEnd_def, hswap, hcomm]

--- a/TauCeti/Algebra/Lie/Weights/Trace.lean
+++ b/TauCeti/Algebra/Lie/Weights/Trace.lean
@@ -13,12 +13,12 @@ public section
 /-!
 # The trace of a pair of opposite root vectors on a weight space
 
-Let `H` be a nilpotent Lie subalgebra of `L` acting on a finite-dimensional module `M`, let
-`α : H → K` be a linear form, and let `x` and `y` be root vectors of weights `α` and `-α` whose
-bracket `⁅x, y⁆` lies in `H`, say `⁅x, y⁆ = z`.  Acting first by `x` and then by `y` carries the
-`χ`-weight space of `M` back to itself; write `TauCeti.raiseLowerEnd` for the resulting
-endomorphism.  Given a bound beyond which the spaces `M_{χ + jα}` vanish, this file computes its
-trace:
+Let `H` be a nilpotent Lie subalgebra of `L` acting on a module `M` that is finite and free over a
+principal ideal domain `K`, let `α : H → K` be a linear form, and let `x` and `y` be root vectors of
+weights `α` and `-α` whose bracket `⁅x, y⁆` lies in `H`, say `⁅x, y⁆ = z`.  Acting first by `x` and
+then by `y` carries the `χ`-weight space of `M` back to itself; write `TauCeti.raiseLowerEnd` for
+the resulting endomorphism.  Given a bound beyond which the spaces `M_{χ + jα}` vanish, this file
+computes its trace:
 
 ```text
 tr_{Mχ}(y ∘ x) = Σ_{j ≥ 1} dim M_{χ + jα} · (χ + jα)(z).
@@ -36,8 +36,8 @@ tr_{Mχ}(y ∘ x) = tr_{M_{α+χ}}(y ∘ x) + dim M_{α+χ} · (α+χ)(z),
 ```
 
 which telescopes up the `α`-string.  The initial-segment formulation assumes such an
-eventual-vanishing bound explicitly.  When `K` has characteristic zero and `α` is a nonzero linear
-form, the string leaves the weights of `M` after finitely many steps;
+eventual-vanishing bound explicitly.  When `K` is a field of characteristic zero and `α` is a
+nonzero linear form, the string leaves the weights of `M` after finitely many steps;
 `TauCeti/Algebra/Lie/Weights/String.lean` packages that finite index set as `TauCeti.weightString`.
 
 The identity is the computational input to **Freudenthal's multiplicity formula**: taking `x` and
@@ -128,28 +128,24 @@ theorem rootVectorMap_comp_rootVectorMap_sub_raiseLowerEnd {α : H → K} {x y :
   rw [h]
   abel
 
+/-- On a trivial weight space the raise-lower endomorphism vanishes. -/
+@[simp]
+theorem raiseLowerEnd_eq_zero {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
+    (hy : y ∈ rootSpace H (-α)) {χ : H → K} (hχ : genWeightSpace M χ = ⊥) :
+    raiseLowerEnd M hx hy χ = 0 := by
+  ext m
+  have hm : (m : M) = 0 := by simpa [hχ] using m.2
+  simp [hm]
+
 end Defs
 
 section Trace
 
-variable {K : Type u} {L : Type v} {M : Type w} [Field K] [LieRing L] [LieAlgebra K L]
+variable {K : Type u} {L : Type v} {M : Type w} [CommRing K] [IsDomain K]
+  [IsPrincipalIdealRing K] [LieRing L] [LieAlgebra K L]
   {H : LieSubalgebra K L} [LieRing.IsNilpotent H]
-  [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M] [FiniteDimensional K M]
-  {α : H → K} {x y : L} {z : H}
-
-omit [FiniteDimensional K M] in
-/-- A trivial weight space has dimension zero, so it contributes nothing to a multiplicity sum. -/
-private theorem finrank_genWeightSpace_eq_zero {χ : H → K} (hχ : genWeightSpace M χ = ⊥) :
-    finrank K (genWeightSpace M χ) = 0 := by
-  rw [hχ, ← finrank_toSubmodule, LieSubmodule.bot_toSubmodule, finrank_bot]
-
-omit [FiniteDimensional K M] in
-/-- On a trivial weight space the raise-lower endomorphism vanishes. -/
-theorem raiseLowerEnd_eq_zero (hx : x ∈ rootSpace H α) (hy : y ∈ rootSpace H (-α)) {χ : H → K}
-    (hχ : genWeightSpace M χ = ⊥) : raiseLowerEnd M hx hy χ = 0 := by
-  ext m
-  have hm : (m : M) = 0 := by simpa [hχ] using m.2
-  simp [hm]
+  [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+  [Module.Free K M] [Module.Finite K M] {α : H → K} {x y : L} {z : H}
 
 /-- **The ladder step.**  The trace of `y ∘ x` on the `χ`-weight space exceeds its trace on the
 `(α + χ)`-weight space by `dim M_{α+χ} · (α+χ)(z)`, where `z = ⁅x, y⁆`. -/
@@ -175,7 +171,7 @@ theorem trace_raiseLowerEnd_eq_sum_Ico (hx : x ∈ rootSpace H α) (hy : y ∈ r
       = ∑ j ∈ Finset.Ico 1 N, finrank K (genWeightSpace M (χ + j • α)) • (χ + j • α) z := by
   have hterm : ∀ k : ℕ, N ≤ k →
       finrank K (genWeightSpace M (χ + k • α)) • (χ + k • α) z = 0 := fun k hk => by
-    rw [finrank_genWeightSpace_eq_zero (hN k hk), zero_smul]
+    rw [hN k hk, ← finrank_toSubmodule, LieSubmodule.bot_toSubmodule, finrank_bot, zero_smul]
   -- The statement at the rung `χ + i • α`, proved by induction on the number of rungs `d` still
   -- available before the string is known to have ended.
   suffices h : ∀ d i : ℕ, N ≤ i + d →
@@ -249,7 +245,7 @@ theorem trace_raiseLowerEnd_eq_sum_weightString (hα : α ≠ 0)
     have hjw : genWeightSpace M ((χ : H → K) + j • (α : H → K)) = ⊥ := by
       by_contra hne
       exact hjnot ((hmem j).mpr hne)
-    rw [finrank_genWeightSpace_eq_zero hjw, zero_smul]
+    rw [hjw, ← finrank_toSubmodule, LieSubmodule.bot_toSubmodule, finrank_bot, zero_smul]
 
 end WeightString
 

--- a/TauCeti/Algebra/Lie/Weights/Trace.lean
+++ b/TauCeti/Algebra/Lie/Weights/Trace.lean
@@ -1,0 +1,254 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.Submodule.Finrank
+public import TauCeti.Algebra.Lie.Weights.String
+
+public section
+
+/-!
+# The trace of a pair of opposite root vectors on a weight space
+
+Let `H` be a nilpotent Lie subalgebra of `L` acting on a finite-dimensional module `M`, let
+`α : H → K` be a linear form, and let `x` and `y` be root vectors of weights `α` and `-α` whose
+bracket `⁅x, y⁆` lies in `H`, say `⁅x, y⁆ = z`.  Acting first by `x` and then by `y` carries the
+`χ`-weight space of `M` back to itself; write `TauCeti.raiseLowerEnd` for the resulting
+endomorphism.  This file computes its trace:
+
+```text
+tr_{Mχ}(y ∘ x) = Σ_{j ≥ 1} dim M_{χ + jα} · (χ + jα)(z).
+```
+
+The argument is a ladder, with no `sl₂` representation theory and no complete reducibility.  Acting
+by `x` and by `y` gives maps `Mχ → M_{α+χ}` and `M_{α+χ} → Mχ`, and swapping the two factors of a
+composite does not change its trace, so `tr_{Mχ}(y ∘ x) = tr_{M_{α+χ}}(x ∘ y)`.  On `M_{α+χ}` the
+Leibniz identity gives `x ∘ y - y ∘ x = z`, and the trace of `z` there is `dim M_{α+χ} · (α+χ)(z)`,
+because `z` acts on a generalized weight space with the single generalized eigenvalue `(α+χ)(z)`
+(`LieModule.trace_toEnd_genWeightSpace`).  Together these give the step
+
+```text
+tr_{Mχ}(y ∘ x) = tr_{M_{α+χ}}(y ∘ x) + dim M_{α+χ} · (α+χ)(z),
+```
+
+which telescopes up the `α`-string.  The string leaves the weights of `M` after finitely many
+steps, so the sum is finite; `TauCeti/Algebra/Lie/Weights/String.lean` packages that index set as
+`TauCeti.weightString`.
+
+The identity is the computational input to **Freudenthal's multiplicity formula**: taking `x` and
+`y` to be the root vectors of an `sl₂` triple attached to a positive root `α`, so that `z = α^∨`,
+the right-hand side is `2 / ⟨α, α⟩` times the inner sum `Σ_{j ≥ 1} m_{μ + jα} ⟨μ + jα, α⟩` of that
+recursion, by the normalization `⟨λ, α^∨⟩⟨α, α⟩ = 2⟨λ, α⟩` of the invariant form.
+
+## Main definitions
+
+* `TauCeti.rootVectorMap`: the action of a root vector of weight `α`, as a linear map from the
+  `χ`-weight space to the `(α + χ)`-weight space.
+* `TauCeti.raiseLowerEnd`: acting by a root vector of weight `α` and then by one of weight `-α`, as
+  an endomorphism of the `χ`-weight space.
+
+## Main results
+
+* `TauCeti.trace_raiseLowerEnd_eq_trace_add_nsmul`: the ladder step, expressing the trace at `χ` in
+  terms of the trace at `α + χ`.
+* `TauCeti.trace_raiseLowerEnd_eq_sum_Ico`: the closed form, as a sum over an initial segment of
+  `ℕ` reaching past the end of the `α`-string.
+* `TauCeti.trace_raiseLowerEnd_eq_sum_weightString`: the same closed form, summed over the
+  `α`-string above `χ` with its bottom index removed, which is the index set of the inner sum of
+  Freudenthal's formula.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §22.3, where
+  this trace computation is the lemma behind Freudenthal's formula.
+* [Highest-weight roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md),
+  Layer 7, "Freudenthal's multiplicity formula", to be proved "from the Casimir eigenvalue and the
+  `sl₂`-string action of each `⟨eₐ, hₐ, fₐ⟩` on the weight spaces".  The string action is what is
+  computed here.
+-/
+
+namespace TauCeti
+
+open LieAlgebra LieModule Module
+open LinearMap (trace)
+
+universe u v w
+
+section Defs
+
+variable {K : Type u} {L : Type v} {M : Type w} [CommRing K] [LieRing L] [LieAlgebra K L]
+  {H : LieSubalgebra K L} [LieRing.IsNilpotent H]
+  [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+
+variable (M) in
+/-- The action of a root vector `x` of weight `α`, as a map from the `χ`-weight space of `M` to the
+`ψ`-weight space, for `ψ = α + χ`.  The target weight is an argument rather than the literal sum,
+so that the composites below stay in normal form. -/
+def rootVectorMap {α χ ψ : H → K} {x : L} (hx : x ∈ rootSpace H α) (hψ : α + χ = ψ) :
+    genWeightSpace M χ →ₗ[K] genWeightSpace M ψ :=
+  (toEnd K L M x).restrict fun _ hm =>
+    hψ ▸ mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace K L H M α χ hx hm
+
+@[simp]
+theorem coe_rootVectorMap_apply {α χ ψ : H → K} {x : L} (hx : x ∈ rootSpace H α)
+    (hψ : α + χ = ψ) (m : genWeightSpace M χ) :
+    (rootVectorMap M hx hψ m : M) = ⁅x, (m : M)⁆ :=
+  (rfl)
+
+variable (M) in
+/-- Acting by a root vector `x` of weight `α` and then by a root vector `y` of weight `-α`, as an
+endomorphism of the `χ`-weight space of `M`. -/
+def raiseLowerEnd {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
+    (hy : y ∈ rootSpace H (-α)) (χ : H → K) : Module.End K (genWeightSpace M χ) :=
+  rootVectorMap M hy (neg_add_cancel_left α χ) ∘ₗ rootVectorMap M hx rfl
+
+@[simp]
+theorem coe_raiseLowerEnd_apply {α : H → K} {x y : L} (hx : x ∈ rootSpace H α)
+    (hy : y ∈ rootSpace H (-α)) (χ : H → K) (m : genWeightSpace M χ) :
+    (raiseLowerEnd M hx hy χ m : M) = ⁅y, ⁅x, (m : M)⁆⁆ :=
+  (rfl)
+
+/-- **The Leibniz identity, read on a weight space.**  Lowering and then raising differs from
+raising and then lowering by the action of `⁅x, y⁆`. -/
+theorem rootVectorMap_comp_rootVectorMap_sub_raiseLowerEnd {α : H → K} {x y : L} {z : H}
+    (hx : x ∈ rootSpace H α) (hy : y ∈ rootSpace H (-α)) (hz : ⁅x, y⁆ = (z : L)) (χ : H → K) :
+    rootVectorMap M hx (rfl : α + χ = α + χ) ∘ₗ rootVectorMap M hy (neg_add_cancel_left α χ)
+        - raiseLowerEnd M hx hy (α + χ)
+      = toEnd K H (genWeightSpace M (α + χ)) z := by
+  ext m
+  have h := leibniz_lie x y (m : M)
+  simp only [LinearMap.sub_apply, LinearMap.coe_comp, Function.comp_apply,
+    AddSubgroupClass.coe_sub, coe_rootVectorMap_apply, coe_raiseLowerEnd_apply,
+    toEnd_apply_apply, LieSubmodule.coe_bracket, LieSubalgebra.coe_bracket_of_module, ← hz]
+  rw [h]
+  abel
+
+end Defs
+
+section Trace
+
+variable {K : Type u} {L : Type v} {M : Type w} [Field K] [LieRing L] [LieAlgebra K L]
+  {H : LieSubalgebra K L} [LieRing.IsNilpotent H]
+  [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M] [FiniteDimensional K M]
+  {α : H → K} {x y : L} {z : H}
+
+omit [FiniteDimensional K M] in
+/-- A trivial weight space has dimension zero, so it contributes nothing to a multiplicity sum. -/
+private theorem finrank_genWeightSpace_eq_zero {χ : H → K} (hχ : genWeightSpace M χ = ⊥) :
+    finrank K (genWeightSpace M χ) = 0 := by
+  rw [hχ, ← finrank_toSubmodule, LieSubmodule.bot_toSubmodule, finrank_bot]
+
+omit [FiniteDimensional K M] in
+/-- On a trivial weight space the raise-lower endomorphism vanishes. -/
+theorem raiseLowerEnd_eq_zero (hx : x ∈ rootSpace H α) (hy : y ∈ rootSpace H (-α)) {χ : H → K}
+    (hχ : genWeightSpace M χ = ⊥) : raiseLowerEnd M hx hy χ = 0 := by
+  ext m
+  have hm : (m : M) = 0 := by simpa [hχ] using m.2
+  simp [hm]
+
+/-- **The ladder step.**  The trace of `y ∘ x` on the `χ`-weight space exceeds its trace on the
+`(α + χ)`-weight space by `dim M_{α+χ} · (α+χ)(z)`, where `z = ⁅x, y⁆`. -/
+theorem trace_raiseLowerEnd_eq_trace_add_nsmul (hx : x ∈ rootSpace H α)
+    (hy : y ∈ rootSpace H (-α)) (hz : ⁅x, y⁆ = (z : L)) (χ : H → K) :
+    trace K _ (raiseLowerEnd M hx hy χ)
+      = trace K _ (raiseLowerEnd M hx hy (α + χ))
+        + finrank K (genWeightSpace M (α + χ)) • (α + χ) z := by
+  have hswap := LinearMap.trace_comp_comm' (R := K) (rootVectorMap M hx (rfl : α + χ = α + χ))
+    (rootVectorMap M hy (neg_add_cancel_left α χ))
+  have hcomm := congrArg (trace K (genWeightSpace M (α + χ)))
+    (rootVectorMap_comp_rootVectorMap_sub_raiseLowerEnd (M := M) hx hy hz χ)
+  rw [map_sub, trace_toEnd_genWeightSpace, sub_eq_iff_eq_add'] at hcomm
+  -- Unfolding `raiseLowerEnd` exposes the two factors that `hswap` exchanges.
+  rw [raiseLowerEnd, hswap, hcomm]
+
+/-- **The closed form of the trace**, as a sum over an initial segment of `ℕ` reaching past the end
+of the `α`-string above `χ`. -/
+theorem trace_raiseLowerEnd_eq_sum_Ico (hx : x ∈ rootSpace H α) (hy : y ∈ rootSpace H (-α))
+    (hz : ⁅x, y⁆ = (z : L)) (χ : H → K) {N : ℕ}
+    (hN : ∀ j : ℕ, N ≤ j → genWeightSpace M (χ + j • α) = ⊥) :
+    trace K _ (raiseLowerEnd M hx hy χ)
+      = ∑ j ∈ Finset.Ico 1 N, finrank K (genWeightSpace M (χ + j • α)) • (χ + j • α) z := by
+  have hterm : ∀ k : ℕ, N ≤ k →
+      finrank K (genWeightSpace M (χ + k • α)) • (χ + k • α) z = 0 := fun k hk => by
+    rw [finrank_genWeightSpace_eq_zero (hN k hk), zero_smul]
+  -- The statement at the rung `χ + i • α`, proved by induction on the number of rungs `d` still
+  -- available before the string is known to have ended.
+  suffices h : ∀ d i : ℕ, N ≤ i + d →
+      trace K _ (raiseLowerEnd M hx hy (χ + i • α))
+        = ∑ j ∈ Finset.Ico (i + 1) N,
+            finrank K (genWeightSpace M (χ + j • α)) • (χ + j • α) z by
+    have key := h N 0 (by omega)
+    rwa [zero_nsmul, add_zero] at key
+  intro d
+  induction d with
+  | zero =>
+    intro i hi
+    rw [raiseLowerEnd_eq_zero hx hy (hN i (by omega)), map_zero,
+      Finset.Ico_eq_empty (by omega), Finset.sum_empty]
+  | succ d ih =>
+    intro i hi
+    rcases le_or_gt N i with hiN | hiN
+    · rw [raiseLowerEnd_eq_zero hx hy (hN i hiN), map_zero,
+        Finset.Ico_eq_empty (by omega), Finset.sum_empty]
+    have hshift : α + (χ + i • α) = χ + (i + 1) • α := by rw [succ_nsmul]; abel
+    rw [trace_raiseLowerEnd_eq_trace_add_nsmul hx hy hz, hshift, ih (i + 1) (by omega)]
+    rcases lt_or_ge (i + 1) N with hlt | hge
+    · rw [Finset.sum_eq_sum_Ico_succ_bot hlt]
+      abel
+    · rw [Finset.Ico_eq_empty (by omega), Finset.Ico_eq_empty (by omega), Finset.sum_empty,
+        hterm (i + 1) hge, add_zero]
+
+end Trace
+
+section WeightString
+
+variable {K : Type u} {L : Type v} {M : Type w} [Field K] [CharZero K] [LieRing L]
+  [LieAlgebra K L] {H : LieSubalgebra K L} [LieRing.IsNilpotent H]
+  [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M] [FiniteDimensional K M]
+  {α χ : Module.Dual K H} {x y : L} {z : H}
+
+omit [CharZero K] [LieRing.IsNilpotent H] [LieRingModule L M] [LieModule K L M]
+  [FiniteDimensional K M] in
+/-- Translating a linear weight by a multiple of another is the same operation before and after
+forgetting linearity. -/
+private theorem coe_add_nsmul (j : ℕ) :
+    ((χ + j • α : Module.Dual K H) : H → K) = (χ : H → K) + j • (α : H → K) := by
+  ext v
+  simp
+
+/-- **The closed form of the trace**, summed over the `α`-string above `χ` with its bottom index
+removed.  This is the index set of the inner sum of Freudenthal's multiplicity formula. -/
+theorem trace_raiseLowerEnd_eq_sum_weightString (hα : α ≠ 0)
+    (hx : x ∈ rootSpace H (α : H → K)) (hy : y ∈ rootSpace H (-(α : H → K)))
+    (hz : ⁅x, y⁆ = (z : L)) :
+    trace K _ (raiseLowerEnd M hx hy (χ : H → K))
+      = ∑ j ∈ (weightString M hα χ).erase 0,
+          finrank K (genWeightSpace M ((χ : H → K) + j • (α : H → K)))
+            • ((χ : H → K) + j • (α : H → K)) z := by
+  classical
+  obtain ⟨N, hN⟩ := exists_genWeightSpace_add_nsmul_eq_bot_of_le (M := M) hα χ
+  simp only [coe_add_nsmul] at hN
+  have hmem : ∀ j : ℕ, j ∈ weightString M hα χ ↔
+      genWeightSpace M ((χ : H → K) + j • (α : H → K)) ≠ ⊥ := fun j => by
+    rw [mem_weightString_iff, coe_add_nsmul]
+  rw [trace_raiseLowerEnd_eq_sum_Ico hx hy hz _ hN]
+  refine (Finset.sum_subset (fun j hj => ?_) (fun j hj hj' => ?_)).symm
+  · have hjw := (hmem j).mp (Finset.mem_of_mem_erase hj)
+    have hj0 : j ≠ 0 := Finset.ne_of_mem_erase hj
+    refine Finset.mem_Ico.mpr ⟨by omega, ?_⟩
+    by_contra hjN
+    exact hjw (hN j (by omega))
+  · have hj0 : j ≠ 0 := by have := (Finset.mem_Ico.mp hj).1; omega
+    have hjnot : j ∉ weightString M hα χ := fun hj'' =>
+      hj' (Finset.mem_erase.mpr ⟨hj0, hj''⟩)
+    have hjw : genWeightSpace M ((χ : H → K) + j • (α : H → K)) = ⊥ := by
+      by_contra hne
+      exact hjnot ((hmem j).mpr hne)
+    rw [finrank_genWeightSpace_eq_zero hjw, zero_smul]
+
+end WeightString
+
+end TauCeti


### PR DESCRIPTION
This PR computes the trace of a pair of opposite root vectors on a generalized weight space. Let `H` be a nilpotent Lie subalgebra of `L` acting on a finite-dimensional module `M`, let `x` and `y` be root vectors of weights `α` and `-α` whose bracket `⁅x, y⁆` lies in `H`, say `⁅x, y⁆ = z`. Acting by `x` and then by `y` is an endomorphism `TauCeti.raiseLowerEnd` of the `χ`-weight space, and its trace is `Σ_{j ≥ 1} dim M_{χ + jα} · (χ + jα)(z)`, summed over the `α`-string above `χ`.

The proof is a ladder with no `sl₂` representation theory and no complete reducibility. Acting by `x` and by `y` gives maps `Mχ → M_{α+χ}` and `M_{α+χ} → Mχ` (Mathlib's `LieAlgebra.rootSpaceWeightSpaceProductAux`, evaluated at the root vector), and swapping the two factors of a composite leaves its trace unchanged, so the trace at `χ` of `y ∘ x` equals the trace at `α + χ` of `x ∘ y`. On `M_{α+χ}` the Leibniz identity gives `x ∘ y - y ∘ x = z`, whose trace is `dim M_{α+χ} · (α+χ)(z)` by `LieModule.trace_toEnd_genWeightSpace`. The resulting one-step relation telescopes up the string, which leaves the weights of `M` after finitely many steps.

This is the "string action" half of **Freudenthal's multiplicity formula** (`freudenthal_multiplicity_formula`), the unmet Layer 7 milestone of `RepresentationTheory/LieHighestWeight/README.md`, whose README says to prove it "from the Casimir eigenvalue and the `sl₂`-string action of each `⟨eₐ, hₐ, fₐ⟩` on the weight spaces of `L(λ)`". Taking `x`, `y` to be the root vectors of the `sl₂` triple of a positive root, so that `z = α^∨`, the closed form here is `2/⟨α, α⟩` times the inner sum `Σ_{j ≥ 1} m_{μ + jα} ⟨μ + jα, α⟩` of that recursion. The two stated prerequisites are already on `main`: the Casimir eigenvalue on a highest weight module (`TauCeti/Algebra/Lie/HighestWeight/Casimir.lean`) and the Layer 2 weight theory, together with `TauCeti/Algebra/Lie/Weights/String.lean`, whose `TauCeti.weightString` is the finite index set consumed here and was landed as the companion prerequisite. What remains after this PR, on the path to the milestone, is the Casimir side: computing the trace of `casimirElement` on a weight space against a basis of `L` adapted to the root-space decomposition, and summing the identity proved here over the positive roots.

The results are stated for an arbitrary finite-dimensional module over a nilpotent Lie subalgebra, with the bracket `⁅x, y⁆ = z` an argument rather than a Killing-form consequence, so nothing in the file presumes semisimplicity; the definitions themselves need only a commutative base ring. The closed form comes in two shapes: `TauCeti.trace_raiseLowerEnd_eq_sum_Ico` sums over `Finset.Ico 1 N` for a rung `N` at which the string has a trivial weight space, and needs no characteristic assumption, and `TauCeti.trace_raiseLowerEnd_eq_sum_weightString_erase_zero` sums over `(weightString M hα χ).erase 0`, the index set Freudenthal's inner sum runs over.

New module: `TauCeti/Algebra/Lie/Weights/Trace.lean`. `TauCeti/Algebra/Lie/Submodule/Finrank.lean` gains the dimension of a trivial Lie submodule, `LieSubmodule.finrank_bot` and its hypothesis form `LieSubmodule.finrank_eq_zero_of_eq_bot`, which the telescope consumes at the terminal rung. Nothing is vendored or adapted from an external source; the mathematics follows J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §22.3, where this trace computation is the lemma behind Freudenthal's formula.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"root-vector-trace-weight-space"}-->

🤖 Prepared with Claude Code


