### PR TITLE
feat: add the Auslander-Reiten transpose

### DIFF
--- a/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
@@ -54,8 +54,11 @@ namespace TauCeti
 universe u v w v' w'
 
 variable {A : Type u} [Ring A]
-variable {P₀ : Type v} {P₁ : Type w} [AddCommGroup P₀] [Module A P₀]
-  [AddCommGroup P₁] [Module A P₁]
+
+section Transpose
+
+variable {P₀ : Type v} {P₁ : Type w} [AddCommMonoid P₀] [Module A P₀]
+  [AddCommMonoid P₁] [Module A P₁]
 
 /-- The **Auslander--Reiten transpose** attached to a projective presentation whose first map is
 `p₁ : P₁ → P₀`.  It is the cokernel of the opposite-linear precomposition map
@@ -148,6 +151,7 @@ theorem lift_comp_mk (f : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] N)
   LinearMap.ext fun φ => lift_mk p₁ f hf φ
 
 /-- Opposite-linear maps out of the transpose are determined by their values on representatives. -/
+@[ext]
 theorem hom_ext {f g : AuslanderReitenTranspose p₁ →ₗ[Aᵐᵒᵖ] N}
     (h : ∀ φ : Module.Dual A P₁, f (mk p₁ φ) = g (mk p₁ φ)) : f = g :=
   LinearMap.ext fun x => induction_on p₁ x h
@@ -166,8 +170,8 @@ variable {p₁}
 
 section Equivalence
 
-variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommGroup Q₀] [Module A Q₀]
-  [AddCommGroup Q₁] [Module A Q₁]
+variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommMonoid Q₀] [Module A Q₀]
+  [AddCommMonoid Q₁] [Module A Q₁]
 
 private theorem map_range_lcomp_eq {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
     (e₁ : P₁ ≃ₗ[A] Q₁)
@@ -205,16 +209,20 @@ theorem linearEquiv_mk {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
     (φ : Module.Dual A P₁) :
     linearEquiv e₀ e₁ hsquare (mk p₁ φ) =
       mk q₁ (e₁.symm.toLinearMap.lcomp Aᵐᵒᵖ A φ) := by
+  have hrep : (e₁.congrLeft A Aᵐᵒᵖ : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] Module.Dual A Q₁) φ =
+      e₁.symm.toLinearMap.lcomp Aᵐᵒᵖ A φ := by
+    ext x
+    simp [LinearMap.lcomp_apply]
   -- `linearEquiv`, `mk` and `AuslanderReitenTranspose` itself are not exposed, so neither the
   -- statement nor Mathlib's quotient lemmas reduce here on their own: an exported theorem may only
   -- unfold exposed definitions.  `with_unfolding_all` lets this proof see through them, and the
   -- `change` then presents the goal in the `Submodule.Quotient` form in which
-  -- `Submodule.Quotient.equiv_apply` and `Submodule.mapQ_apply` apply.
+  -- `Submodule.Quotient.equiv_apply` and `Submodule.mapQ_apply` apply; `hrep` then identifies the
+  -- representative maps through public application lemmas rather than by definitional unfolding.
   with_unfolding_all
     change Submodule.Quotient.equiv _ _ _ _ (Submodule.Quotient.mk φ) =
       Submodule.Quotient.mk _
-    rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
-    rfl
+    rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply, hrep]
 
 /-- Transport along the identity presentation equivalences is the identity. -/
 @[simp]
@@ -234,7 +242,7 @@ theorem linearEquiv_refl :
 /-- Transport along a composite of presentation equivalences is the composite transport. -/
 @[simp]
 theorem linearEquiv_trans {q₁ : Q₁ →ₗ[A] Q₀}
-    {R₀ R₁ : Type*} [AddCommGroup R₀] [Module A R₀] [AddCommGroup R₁] [Module A R₁]
+    {R₀ R₁ : Type*} [AddCommMonoid R₀] [Module A R₀] [AddCommMonoid R₁] [Module A R₁]
     {r₁ : R₁ →ₗ[A] R₀} (e₀ : P₀ ≃ₗ[A] Q₀) (e₁ : P₁ ≃ₗ[A] Q₁)
     (f₀ : Q₀ ≃ₗ[A] R₀) (f₁ : Q₁ ≃ₗ[A] R₁)
     (he : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap)
@@ -285,9 +293,13 @@ end Equivalence
 
 end AuslanderReitenTranspose
 
+end Transpose
+
 namespace IsMinimalProjectivePresentation
 
 variable {M : Type*} [AddCommGroup M] [Module A M]
+variable {P₀ : Type v} {P₁ : Type w} [AddCommGroup P₀] [Module A P₀]
+  [AddCommGroup P₁] [Module A P₁]
 variable {p₁ : P₁ →ₗ[A] P₀} {p₀ : P₀ →ₗ[A] M}
 variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommGroup Q₀] [Module A Q₀]
   [AddCommGroup Q₁] [Module A Q₁]

--- a/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
@@ -34,6 +34,8 @@ duality `D = Hom_k(-, k)` to construct the Auslander--Reiten translate `τ = D T
 
 * `AuslanderReitenTranspose`: the cokernel of the dual of the first map in a projective
   presentation.
+* `AuslanderReitenTranspose.lift`: the universal property of that cokernel, descending an
+  opposite-linear map that kills the functionals factoring through `p₁`.
 * `AuslanderReitenTranspose.linearEquiv`: the equivalence induced by an isomorphism of presentation
   diagrams.
 
@@ -90,6 +92,59 @@ theorem mk_lcomp (φ : Module.Dual A P₀) :
     mk p₁ (p₁.lcomp Aᵐᵒᵖ A φ) = 0 := by
   rw [mk_eq_zero_iff]
   exact LinearMap.mem_range_self _ φ
+
+/-- Every element of the transpose is represented by a functional on `P₁`. -/
+theorem mk_surjective : Function.Surjective (mk p₁) :=
+  Submodule.mkQ_surjective _
+
+/-- Two functionals represent the same element of the transpose exactly when their difference
+factors through the first map of the presentation. -/
+theorem mk_eq_mk_iff (φ ψ : Module.Dual A P₁) :
+    mk p₁ φ = mk p₁ ψ ↔ φ - ψ ∈ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A) :=
+  Submodule.Quotient.eq _
+
+/-- To prove a property of every element of the transpose it suffices to prove it of the classes
+of functionals on `P₁`. -/
+@[elab_as_elim]
+theorem induction_on {motive : AuslanderReitenTranspose p₁ → Prop}
+    (x : AuslanderReitenTranspose p₁) (h : ∀ φ : Module.Dual A P₁, motive (mk p₁ φ)) :
+    motive x :=
+  Submodule.Quotient.induction_on _ x h
+
+section Lift
+
+variable {N : Type*} [AddCommGroup N] [Module Aᵐᵒᵖ N]
+
+/-- The universal property of the transpose: an opposite-linear map out of `Hom_A(P₁, A)` that
+kills every functional factoring through `p₁` descends to the cokernel. -/
+@[expose] def lift (f : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] N)
+    (hf : ∀ φ : Module.Dual A P₀, f (p₁.lcomp Aᵐᵒᵖ A φ) = 0) :
+    AuslanderReitenTranspose p₁ →ₗ[Aᵐᵒᵖ] N :=
+  Submodule.liftQ _ f <| by
+    rintro _ ⟨φ, rfl⟩
+    exact hf φ
+
+@[simp]
+theorem lift_mk (f : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] N)
+    (hf : ∀ φ : Module.Dual A P₀, f (p₁.lcomp Aᵐᵒᵖ A φ) = 0) (φ : Module.Dual A P₁) :
+    lift p₁ f hf (mk p₁ φ) = f φ := by
+  rw [mk_apply]
+  exact Submodule.liftQ_apply _ f φ
+
+/-- Opposite-linear maps out of the transpose are determined by their values on representatives. -/
+theorem hom_ext {f g : AuslanderReitenTranspose p₁ →ₗ[Aᵐᵒᵖ] N}
+    (h : ∀ φ : Module.Dual A P₁, f (mk p₁ φ) = g (mk p₁ φ)) : f = g :=
+  LinearMap.ext fun x => induction_on p₁ x h
+
+/-- `AuslanderReitenTranspose.lift` is the unique descent of `f` to the transpose. -/
+theorem eq_lift (f : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] N)
+    (hf : ∀ φ : Module.Dual A P₀, f (p₁.lcomp Aᵐᵒᵖ A φ) = 0)
+    (g : AuslanderReitenTranspose p₁ →ₗ[Aᵐᵒᵖ] N)
+    (hg : ∀ φ : Module.Dual A P₁, g (mk p₁ φ) = f φ) :
+    g = lift p₁ f hf :=
+  hom_ext p₁ fun φ => by rw [hg, lift_mk]
+
+end Lift
 
 variable {p₁}
 

--- a/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
@@ -218,10 +218,8 @@ theorem linearEquiv_mk {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
 
 /-- Transport along the identity presentation equivalences is the identity. -/
 @[simp]
-theorem linearEquiv_refl
-    (hsquare : (LinearEquiv.refl A P₀).toLinearMap ∘ₗ p₁ =
-      p₁ ∘ₗ (LinearEquiv.refl A P₁).toLinearMap) :
-    linearEquiv (LinearEquiv.refl A P₀) (LinearEquiv.refl A P₁) hsquare =
+theorem linearEquiv_refl :
+    linearEquiv (LinearEquiv.refl A P₀) (LinearEquiv.refl A P₁) (by simp) =
       LinearEquiv.refl Aᵐᵒᵖ (AuslanderReitenTranspose p₁) := by
   apply LinearEquiv.ext
   intro x
@@ -239,11 +237,15 @@ theorem linearEquiv_trans {q₁ : Q₁ →ₗ[A] Q₀}
     {r₁ : R₁ →ₗ[A] R₀} (e₀ : P₀ ≃ₗ[A] Q₀) (e₁ : P₁ ≃ₗ[A] Q₁)
     (f₀ : Q₀ ≃ₗ[A] R₀) (f₁ : Q₁ ≃ₗ[A] R₁)
     (he : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap)
-    (hf : f₀.toLinearMap ∘ₗ q₁ = r₁ ∘ₗ f₁.toLinearMap)
-    (htrans : (e₀.trans f₀).toLinearMap ∘ₗ p₁ =
-      r₁ ∘ₗ (e₁.trans f₁).toLinearMap) :
+    (hf : f₀.toLinearMap ∘ₗ q₁ = r₁ ∘ₗ f₁.toLinearMap) :
     (linearEquiv e₀ e₁ he).trans (linearEquiv f₀ f₁ hf) =
-      linearEquiv (e₀.trans f₀) (e₁.trans f₁) htrans := by
+      linearEquiv (e₀.trans f₀) (e₁.trans f₁)
+        (by
+          ext x
+          have h₀ := LinearMap.congr_fun he x
+          have h₁ := LinearMap.congr_fun hf (e₁ x)
+          simp only [LinearMap.comp_apply, LinearEquiv.coe_coe] at h₀ h₁ ⊢
+          rw [LinearEquiv.trans_apply, LinearEquiv.trans_apply, h₀, h₁]) := by
   apply LinearEquiv.ext
   intro x
   induction x using induction_on p₁ with
@@ -257,9 +259,15 @@ theorem linearEquiv_trans {q₁ : Q₁ →ₗ[A] Q₀}
 /-- The inverse of transport is transport along the inverse presentation equivalences. -/
 theorem linearEquiv_symm {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
     (e₁ : P₁ ≃ₗ[A] Q₁)
-    (hsquare : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap)
-    (hsymm : e₀.symm.toLinearMap ∘ₗ q₁ = p₁ ∘ₗ e₁.symm.toLinearMap) :
-    (linearEquiv e₀ e₁ hsquare).symm = linearEquiv e₀.symm e₁.symm hsymm := by
+    (hsquare : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap) :
+    (linearEquiv e₀ e₁ hsquare).symm =
+      linearEquiv e₀.symm e₁.symm
+        (by
+          ext x
+          have h := LinearMap.congr_fun hsquare (e₁.symm x)
+          simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
+            LinearEquiv.apply_symm_apply] at h ⊢
+          rw [← h, LinearEquiv.symm_apply_apply]) := by
   apply LinearEquiv.ext
   intro x
   induction x using induction_on q₁ with

--- a/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
@@ -117,7 +117,7 @@ variable {N : Type*} [AddCommGroup N] [Module Aᵐᵒᵖ N]
 
 /-- The universal property of the transpose: an opposite-linear map out of `Hom_A(P₁, A)` that
 kills every functional factoring through `p₁` descends to the cokernel. -/
-@[expose] def lift (f : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] N)
+def lift (f : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] N)
     (hf : ∀ φ : Module.Dual A P₀, f (p₁.lcomp Aᵐᵒᵖ A φ) = 0) :
     AuslanderReitenTranspose p₁ →ₗ[Aᵐᵒᵖ] N :=
   Submodule.liftQ _ f <| by
@@ -153,47 +153,21 @@ section Equivalence
 variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommGroup Q₀] [Module A Q₀]
   [AddCommGroup Q₁] [Module A Q₁]
 
-/-- Dualizing a linear equivalence of left modules gives a linear equivalence of their
-opposite-ring duals.  This file-local construction is used to transport the cokernel below. -/
-private def opDualMap (e : P₁ ≃ₗ[A] Q₁) :
-    Module.Dual A P₁ ≃ₗ[Aᵐᵒᵖ] Module.Dual A Q₁ where
-  __ := e.symm.toLinearMap.lcomp Aᵐᵒᵖ A
-  invFun := e.toLinearMap.lcomp Aᵐᵒᵖ A
-  left_inv φ := by
-    ext x
-    exact congrArg φ (e.symm_apply_apply x)
-  right_inv φ := by
-    ext x
-    exact congrArg φ (e.apply_symm_apply x)
-
 private theorem map_range_lcomp_eq {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
     (e₁ : P₁ ≃ₗ[A] Q₁)
     (hsquare : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap) :
-    Submodule.map (opDualMap e₁ : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] Module.Dual A Q₁)
+    Submodule.map (e₁.congrLeft A Aᵐᵒᵖ : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] Module.Dual A Q₁)
         (LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)) =
       LinearMap.range (q₁.lcomp Aᵐᵒᵖ A) := by
-  apply le_antisymm
-  · rintro _ ⟨φ, ⟨ψ, rfl⟩, rfl⟩
-    refine ⟨e₀.symm.toLinearMap.lcomp Aᵐᵒᵖ A ψ, ?_⟩
-    ext x
-    have h := LinearMap.congr_fun hsquare (e₁.symm x)
-    have h' : e₀ (p₁ (e₁.symm x)) = q₁ x := by
-      simpa using h
-    have h'' : p₁ (e₁.symm x) = e₀.symm (q₁ x) := by
-      simpa using congrArg e₀.symm h'
-    -- Expose the nested precomposition applications hidden by the linear-map coercions.
-    change ψ (e₀.symm (q₁ x)) = ψ (p₁ (e₁.symm x))
-    exact congrArg ψ h''.symm
-  · rintro _ ⟨ψ, rfl⟩
-    refine ⟨p₁.lcomp Aᵐᵒᵖ A (e₀.toLinearMap.lcomp Aᵐᵒᵖ A ψ), ?_, ?_⟩
-    · exact LinearMap.mem_range_self _ _
-    · ext x
-      have h := LinearMap.congr_fun hsquare (e₁.symm x)
-      have h' : e₀ (p₁ (e₁.symm x)) = q₁ x := by
-        simpa using h
-      -- Expose the nested precomposition applications hidden by the linear-map coercions.
-      change ψ (e₀ (p₁ (e₁.symm x))) = ψ (q₁ x)
-      exact congrArg ψ h'
+  rw [← LinearMap.range_comp]
+  have hcomp :
+      (e₁.congrLeft A Aᵐᵒᵖ).toLinearMap.comp (p₁.lcomp Aᵐᵒᵖ A) =
+        (q₁.lcomp Aᵐᵒᵖ A).comp (e₀.congrLeft A Aᵐᵒᵖ).toLinearMap := by
+    ext φ x
+    simp only [LinearMap.comp_apply, LinearMap.lcomp_apply]
+    apply congrArg φ
+    simpa using congrArg e₀.symm (LinearMap.congr_fun hsquare (e₁.symm x))
+  rw [hcomp, LinearEquiv.range_comp]
 
 /-- An isomorphism of the first square of two projective presentations induces an equivalence of
 their Auslander--Reiten transposes.  On representatives it sends `φ : Hom_A(P₁, A)` to
@@ -205,7 +179,7 @@ def linearEquiv {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
     (e₁ : P₁ ≃ₗ[A] Q₁)
     (hsquare : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap) :
     AuslanderReitenTranspose p₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose q₁ :=
-  Submodule.Quotient.equiv _ _ (opDualMap e₁) (map_range_lcomp_eq e₀ e₁ hsquare)
+  Submodule.Quotient.equiv _ _ (e₁.congrLeft A Aᵐᵒᵖ) (map_range_lcomp_eq e₀ e₁ hsquare)
 
 /-- The presentation equivalence on transposes, evaluated on a functional representative. -/
 @[simp]

--- a/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
@@ -101,6 +101,7 @@ theorem mk_surjective : Function.Surjective (mk p₁) :=
 
 /-- Two functionals represent the same element of the transpose exactly when their difference
 factors through the first map of the presentation. -/
+@[simp]
 theorem mk_eq_mk_iff (φ ψ : Module.Dual A P₁) :
     mk p₁ φ = mk p₁ ψ ↔ φ - ψ ∈ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A) :=
   Submodule.Quotient.eq _

--- a/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
@@ -298,12 +298,12 @@ end Transpose
 namespace IsMinimalProjectivePresentation
 
 variable {M : Type*} [AddCommGroup M] [Module A M]
-variable {P₀ : Type v} {P₁ : Type w} [AddCommGroup P₀] [Module A P₀]
-  [AddCommGroup P₁] [Module A P₁]
+variable {P₀ : Type v} [AddCommGroup P₀] [Module A P₀]
+
+section Projective
+
+variable {P₁ : Type w} [AddCommMonoid P₁] [Module A P₁]
 variable {p₁ : P₁ →ₗ[A] P₀} {p₀ : P₀ →ₗ[A] M}
-variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommGroup Q₀] [Module A Q₀]
-  [AddCommGroup Q₁] [Module A Q₁]
-variable {q₁ : Q₁ →ₗ[A] Q₀} {q₀ : Q₀ →ₗ[A] M}
 
 /-- The Auslander--Reiten transpose of a projective module is zero, represented here by the
 stronger typeclass-friendly statement that its underlying quotient is a subsingleton. -/
@@ -318,6 +318,16 @@ theorem subsingleton_auslanderReitenTranspose_of_projective
     induction y using AuslanderReitenTranspose.induction_on p₁ with
     | _ ψ => exact congrArg (AuslanderReitenTranspose.mk p₁) (Subsingleton.elim φ ψ)
 
+end Projective
+
+section Comparison
+
+variable {P₁ : Type w} [AddCommGroup P₁] [Module A P₁]
+variable {p₁ : P₁ →ₗ[A] P₀} {p₀ : P₀ →ₗ[A] M}
+variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommGroup Q₀] [Module A Q₀]
+  [AddCommGroup Q₁] [Module A Q₁]
+variable {q₁ : Q₁ →ₗ[A] Q₀} {q₀ : Q₀ →ₗ[A] M}
+
 /-- The Auslander--Reiten transpose is independent, up to opposite-linear equivalence, of the
 chosen minimal projective presentation of a module. -/
 theorem nonempty_linearEquiv_auslanderReitenTranspose
@@ -326,6 +336,8 @@ theorem nonempty_linearEquiv_auslanderReitenTranspose
     Nonempty (AuslanderReitenTranspose p₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose q₁) := by
   obtain ⟨e₀, e₁, -, hsquare⟩ := h.exists_linearEquiv h'
   exact ⟨AuslanderReitenTranspose.linearEquiv e₀ e₁ hsquare⟩
+
+end Comparison
 
 end IsMinimalProjectivePresentation
 

--- a/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
@@ -1,0 +1,197 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Module.MinimalProjectivePresentation
+
+/-!
+# The Auslander--Reiten transpose
+
+Given a projective presentation `P₁ → P₀ → M`, applying `Hom_A(-, A)` reverses the first map.
+The cokernel
+
+`Hom_A(P₁, A) / range(Hom_A(P₀, A) → Hom_A(P₁, A))`
+
+is the **Auslander--Reiten transpose** of the presentation.  It is naturally a left module over the
+opposite ring `Aᵐᵒᵖ`: an element `op a` acts on a functional by multiplication by `a` on the right.
+Mathlib already supplies this opposite-ring module structure on `Module.Dual A P` and the
+precomposition map as `p.lcomp Aᵐᵒᵖ A`; this file forms its cokernel rather than rebuilding either.
+
+The transpose is independent, up to linear equivalence, of the chosen minimal projective
+presentation.  More precisely, an isomorphism of presentation diagrams induces an equivalence of
+the two cokernels (`AuslanderReitenTranspose.linearEquiv`), characterized on representatives, and
+the uniqueness theorem for minimal presentations then gives
+`IsMinimalProjectivePresentation.nonempty_linearEquiv_auslanderReitenTranspose`.
+
+This supplies the transpose construction in sublayer 6C of the quiver-representations roadmap.
+The remaining part of 6C develops its stable equivalence; sublayer 6D then applies finite-field
+duality `D = Hom_k(-, k)` to construct the Auslander--Reiten translate `τ = D Tr`.
+
+## Main definitions
+
+* `AuslanderReitenTranspose`: the cokernel of the dual of the first map in a projective
+  presentation.
+* `AuslanderReitenTranspose.linearEquiv`: the equivalence induced by an isomorphism of presentation
+  diagrams.
+
+## References
+
+* M. Auslander, I. Reiten, S. O. Smalø, *Representation Theory of Artin Algebras*, Cambridge
+  University Press (1995), Section IV.1.
+* I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
+  Algebras, Vol. 1*, Cambridge University Press (2006), Section IV.2.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w v' w'
+
+variable {A : Type u} [Ring A]
+variable {P₀ : Type v} {P₁ : Type w} [AddCommGroup P₀] [Module A P₀]
+  [AddCommGroup P₁] [Module A P₁]
+
+/-- The **Auslander--Reiten transpose** attached to a projective presentation whose first map is
+`p₁ : P₁ → P₀`.  It is the cokernel of the opposite-linear precomposition map
+`Hom_A(P₀, A) → Hom_A(P₁, A)`.
+
+Minimality is not needed to form the cokernel.  It is used by
+`IsMinimalProjectivePresentation.nonempty_linearEquiv_auslanderReitenTranspose` to show that the
+result is independent, up to equivalence, of the chosen presentation of a module. -/
+abbrev AuslanderReitenTranspose (p₁ : P₁ →ₗ[A] P₀) : Type _ :=
+  Module.Dual A P₁ ⧸ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)
+
+namespace AuslanderReitenTranspose
+
+variable (p₁ : P₁ →ₗ[A] P₀)
+
+/-- The quotient map from the dual of the first projective onto its Auslander--Reiten transpose. -/
+def mk : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁ :=
+  (LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)).mkQ
+
+theorem mk_apply (φ : Module.Dual A P₁) :
+    mk p₁ φ = Submodule.Quotient.mk φ :=
+  (rfl)
+
+/-- A functional represents zero in the transpose exactly when it factors through the first map of
+the presentation. -/
+@[simp]
+theorem mk_eq_zero_iff (φ : Module.Dual A P₁) :
+    mk p₁ φ = 0 ↔ φ ∈ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A) := by
+  rw [mk_apply, Submodule.Quotient.mk_eq_zero]
+
+/-- A functional precomposed with the first map of the presentation vanishes in its cokernel. -/
+@[simp]
+theorem mk_lcomp (φ : Module.Dual A P₀) :
+    mk p₁ (p₁.lcomp Aᵐᵒᵖ A φ) = 0 := by
+  rw [mk_eq_zero_iff]
+  exact LinearMap.mem_range_self _ φ
+
+variable {p₁}
+
+section Equivalence
+
+variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommGroup Q₀] [Module A Q₀]
+  [AddCommGroup Q₁] [Module A Q₁]
+
+/-- Dualizing a linear equivalence of left modules gives a linear equivalence of their
+opposite-ring duals.  This file-local construction is used to transport the cokernel below. -/
+private def opDualMap (e : P₁ ≃ₗ[A] Q₁) :
+    Module.Dual A P₁ ≃ₗ[Aᵐᵒᵖ] Module.Dual A Q₁ where
+  __ := e.symm.toLinearMap.lcomp Aᵐᵒᵖ A
+  invFun := e.toLinearMap.lcomp Aᵐᵒᵖ A
+  left_inv φ := by
+    ext x
+    exact congrArg φ (e.symm_apply_apply x)
+  right_inv φ := by
+    ext x
+    exact congrArg φ (e.apply_symm_apply x)
+
+private theorem map_range_lcomp_eq {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
+    (e₁ : P₁ ≃ₗ[A] Q₁)
+    (hsquare : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap) :
+    Submodule.map (opDualMap e₁ : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] Module.Dual A Q₁)
+        (LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)) =
+      LinearMap.range (q₁.lcomp Aᵐᵒᵖ A) := by
+  apply le_antisymm
+  · rintro _ ⟨φ, ⟨ψ, rfl⟩, rfl⟩
+    refine ⟨e₀.symm.toLinearMap.lcomp Aᵐᵒᵖ A ψ, ?_⟩
+    ext x
+    have h := LinearMap.congr_fun hsquare (e₁.symm x)
+    have h' : e₀ (p₁ (e₁.symm x)) = q₁ x := by
+      simpa using h
+    have h'' : p₁ (e₁.symm x) = e₀.symm (q₁ x) := by
+      simpa using congrArg e₀.symm h'
+    -- Expose the nested precomposition applications hidden by the linear-map coercions.
+    change ψ (e₀.symm (q₁ x)) = ψ (p₁ (e₁.symm x))
+    exact congrArg ψ h''.symm
+  · rintro _ ⟨ψ, rfl⟩
+    refine ⟨p₁.lcomp Aᵐᵒᵖ A (e₀.toLinearMap.lcomp Aᵐᵒᵖ A ψ), ?_, ?_⟩
+    · exact LinearMap.mem_range_self _ _
+    · ext x
+      have h := LinearMap.congr_fun hsquare (e₁.symm x)
+      have h' : e₀ (p₁ (e₁.symm x)) = q₁ x := by
+        simpa using h
+      -- Expose the nested precomposition applications hidden by the linear-map coercions.
+      change ψ (e₀ (p₁ (e₁.symm x))) = ψ (q₁ x)
+      exact congrArg ψ h'
+
+/-- An isomorphism of the first square of two projective presentations induces an equivalence of
+their Auslander--Reiten transposes.  On representatives it sends `φ : Hom_A(P₁, A)` to
+`φ ∘ e₁⁻¹ : Hom_A(Q₁, A)`.
+
+The equivalence depends only on the two presentation isomorphisms and their commutative square; the
+maps from `P₀` and `Q₀` to the presented module do not enter the cokernel. -/
+def linearEquiv {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
+    (e₁ : P₁ ≃ₗ[A] Q₁)
+    (hsquare : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap) :
+    AuslanderReitenTranspose p₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose q₁ :=
+  Submodule.Quotient.equiv _ _ (opDualMap e₁) (map_range_lcomp_eq e₀ e₁ hsquare)
+
+/-- The presentation equivalence on transposes, evaluated on a functional representative. -/
+@[simp]
+theorem linearEquiv_mk {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
+    (e₁ : P₁ ≃ₗ[A] Q₁)
+    (hsquare : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap)
+    (φ : Module.Dual A P₁) :
+    linearEquiv e₀ e₁ hsquare (mk p₁ φ) =
+      mk q₁ (e₁.symm.toLinearMap.lcomp Aᵐᵒᵖ A φ) := by
+  rw [mk_apply, linearEquiv, Submodule.Quotient.equiv_apply, Submodule.mapQ_apply, mk_apply]
+  rfl
+
+end Equivalence
+
+end AuslanderReitenTranspose
+
+namespace IsMinimalProjectivePresentation
+
+variable {M : Type*} [AddCommGroup M] [Module A M]
+variable {p₁ : P₁ →ₗ[A] P₀} {p₀ : P₀ →ₗ[A] M}
+variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommGroup Q₀] [Module A Q₀]
+  [AddCommGroup Q₁] [Module A Q₁]
+variable {q₁ : Q₁ →ₗ[A] Q₀} {q₀ : Q₀ →ₗ[A] M}
+
+/-- The Auslander--Reiten transpose of a projective module is zero, represented here by the
+stronger typeclass-friendly statement that its underlying quotient is a subsingleton. -/
+theorem subsingleton_auslanderReitenTranspose_of_projective
+    [Module.Projective A M] (h : IsMinimalProjectivePresentation p₁ p₀) :
+    Subsingleton (AuslanderReitenTranspose p₁) := by
+  let _ : Subsingleton P₁ := h.subsingleton_of_projective
+  infer_instance
+
+/-- The Auslander--Reiten transpose is independent, up to opposite-linear equivalence, of the
+chosen minimal projective presentation of a module. -/
+theorem nonempty_linearEquiv_auslanderReitenTranspose
+    (h : IsMinimalProjectivePresentation p₁ p₀)
+    (h' : IsMinimalProjectivePresentation q₁ q₀) :
+    Nonempty (AuslanderReitenTranspose p₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose q₁) := by
+  obtain ⟨e₀, e₁, -, hsquare⟩ := h.exists_linearEquiv h'
+  exact ⟨AuslanderReitenTranspose.linearEquiv e₀ e₁ hsquare⟩
+
+end IsMinimalProjectivePresentation
+
+end TauCeti

--- a/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
@@ -64,27 +64,29 @@ variable {P₀ : Type v} {P₁ : Type w} [AddCommGroup P₀] [Module A P₀]
 Minimality is not needed to form the cokernel.  It is used by
 `IsMinimalProjectivePresentation.nonempty_linearEquiv_auslanderReitenTranspose` to show that the
 result is independent, up to equivalence, of the chosen presentation of a module. -/
-abbrev AuslanderReitenTranspose (p₁ : P₁ →ₗ[A] P₀) : Type _ :=
+def AuslanderReitenTranspose (p₁ : P₁ →ₗ[A] P₀) : Type _ :=
   Module.Dual A P₁ ⧸ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)
 
 namespace AuslanderReitenTranspose
 
 variable (p₁ : P₁ →ₗ[A] P₀)
 
+instance : AddCommGroup (AuslanderReitenTranspose p₁) :=
+  inferInstanceAs (AddCommGroup (Module.Dual A P₁ ⧸ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)))
+
+instance : Module Aᵐᵒᵖ (AuslanderReitenTranspose p₁) :=
+  inferInstanceAs (Module Aᵐᵒᵖ (Module.Dual A P₁ ⧸ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)))
+
 /-- The quotient map from the dual of the first projective onto its Auslander--Reiten transpose. -/
 def mk : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁ :=
   (LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)).mkQ
-
-theorem mk_apply (φ : Module.Dual A P₁) :
-    mk p₁ φ = Submodule.Quotient.mk φ :=
-  (rfl)
 
 /-- A functional represents zero in the transpose exactly when it factors through the first map of
 the presentation. -/
 @[simp]
 theorem mk_eq_zero_iff (φ : Module.Dual A P₁) :
-    mk p₁ φ = 0 ↔ φ ∈ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A) := by
-  rw [mk_apply, Submodule.Quotient.mk_eq_zero]
+    mk p₁ φ = 0 ↔ φ ∈ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A) :=
+  Submodule.Quotient.mk_eq_zero _
 
 /-- A functional precomposed with the first map of the presentation vanishes in its cokernel. -/
 @[simp]
@@ -127,9 +129,8 @@ def lift (f : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] N)
 @[simp]
 theorem lift_mk (f : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] N)
     (hf : ∀ φ : Module.Dual A P₀, f (p₁.lcomp Aᵐᵒᵖ A φ) = 0) (φ : Module.Dual A P₁) :
-    lift p₁ f hf (mk p₁ φ) = f φ := by
-  rw [mk_apply]
-  exact Submodule.liftQ_apply _ f φ
+    lift p₁ f hf (mk p₁ φ) = f φ :=
+  Submodule.liftQ_apply _ f φ
 
 /-- Opposite-linear maps out of the transpose are determined by their values on representatives. -/
 theorem hom_ext {f g : AuslanderReitenTranspose p₁ →ₗ[Aᵐᵒᵖ] N}
@@ -189,8 +190,66 @@ theorem linearEquiv_mk {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
     (φ : Module.Dual A P₁) :
     linearEquiv e₀ e₁ hsquare (mk p₁ φ) =
       mk q₁ (e₁.symm.toLinearMap.lcomp Aᵐᵒᵖ A φ) := by
-  rw [mk_apply, linearEquiv, Submodule.Quotient.equiv_apply, Submodule.mapQ_apply, mk_apply]
-  rfl
+  with_unfolding_all
+    change Submodule.Quotient.equiv _ _ _ _ (Submodule.Quotient.mk φ) =
+      Submodule.Quotient.mk _
+    rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+    rfl
+
+/-- Transport along the identity presentation equivalences is the identity. -/
+@[simp]
+theorem linearEquiv_refl
+    (hsquare : (LinearEquiv.refl A P₀).toLinearMap ∘ₗ p₁ =
+      p₁ ∘ₗ (LinearEquiv.refl A P₁).toLinearMap) :
+    linearEquiv (LinearEquiv.refl A P₀) (LinearEquiv.refl A P₁) hsquare =
+      LinearEquiv.refl Aᵐᵒᵖ (AuslanderReitenTranspose p₁) := by
+  apply LinearEquiv.ext
+  intro x
+  induction x using induction_on p₁ with
+  | _ φ =>
+    rw [linearEquiv_mk]
+    apply congrArg (mk p₁)
+    ext y
+    simp only [LinearMap.lcomp_apply, LinearEquiv.refl_symm, LinearEquiv.refl_toLinearMap,
+      LinearMap.id_apply]
+
+/-- Transport along a composite of presentation equivalences is the composite transport. -/
+theorem linearEquiv_trans {q₁ : Q₁ →ₗ[A] Q₀}
+    {R₀ R₁ : Type*} [AddCommGroup R₀] [Module A R₀] [AddCommGroup R₁] [Module A R₁]
+    {r₁ : R₁ →ₗ[A] R₀} (e₀ : P₀ ≃ₗ[A] Q₀) (e₁ : P₁ ≃ₗ[A] Q₁)
+    (f₀ : Q₀ ≃ₗ[A] R₀) (f₁ : Q₁ ≃ₗ[A] R₁)
+    (he : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap)
+    (hf : f₀.toLinearMap ∘ₗ q₁ = r₁ ∘ₗ f₁.toLinearMap)
+    (htrans : (e₀.trans f₀).toLinearMap ∘ₗ p₁ =
+      r₁ ∘ₗ (e₁.trans f₁).toLinearMap) :
+    (linearEquiv e₀ e₁ he).trans (linearEquiv f₀ f₁ hf) =
+      linearEquiv (e₀.trans f₀) (e₁.trans f₁) htrans := by
+  apply LinearEquiv.ext
+  intro x
+  induction x using induction_on p₁ with
+  | _ φ =>
+    rw [LinearEquiv.trans_apply, linearEquiv_mk, linearEquiv_mk, linearEquiv_mk]
+    apply congrArg (mk r₁)
+    ext y
+    simp only [LinearMap.lcomp_apply, LinearEquiv.trans_symm, LinearEquiv.coe_trans,
+      LinearMap.comp_apply]
+
+/-- The inverse of transport is transport along the inverse presentation equivalences. -/
+theorem linearEquiv_symm {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
+    (e₁ : P₁ ≃ₗ[A] Q₁)
+    (hsquare : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap)
+    (hsymm : e₀.symm.toLinearMap ∘ₗ q₁ = p₁ ∘ₗ e₁.symm.toLinearMap) :
+    (linearEquiv e₀ e₁ hsquare).symm = linearEquiv e₀.symm e₁.symm hsymm := by
+  apply LinearEquiv.ext
+  intro x
+  induction x using induction_on q₁ with
+  | _ φ =>
+    apply (linearEquiv e₀ e₁ hsquare).injective
+    rw [LinearEquiv.apply_symm_apply, linearEquiv_mk, linearEquiv_mk]
+    apply congrArg (mk q₁)
+    ext y
+    simp only [LinearMap.lcomp_apply, LinearEquiv.symm_symm]
+    exact congrArg φ (e₁.apply_symm_apply y).symm
 
 end Equivalence
 
@@ -210,7 +269,12 @@ theorem subsingleton_auslanderReitenTranspose_of_projective
     [Module.Projective A M] (h : IsMinimalProjectivePresentation p₁ p₀) :
     Subsingleton (AuslanderReitenTranspose p₁) := by
   let _ : Subsingleton P₁ := h.subsingleton_of_projective
-  infer_instance
+  constructor
+  intro x y
+  induction x using AuslanderReitenTranspose.induction_on p₁ with
+  | _ φ =>
+    induction y using AuslanderReitenTranspose.induction_on p₁ with
+    | _ ψ => exact congrArg (AuslanderReitenTranspose.mk p₁) (Subsingleton.elim φ ψ)
 
 /-- The Auslander--Reiten transpose is independent, up to opposite-linear equivalence, of the
 chosen minimal projective presentation of a module. -/

--- a/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
@@ -88,6 +88,13 @@ theorem mk_eq_zero_iff (φ : Module.Dual A P₁) :
     mk p₁ φ = 0 ↔ φ ∈ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A) :=
   Submodule.Quotient.mk_eq_zero _
 
+/-- The quotient map onto the transpose kills exactly the functionals factoring through the first
+map of the presentation. -/
+@[simp]
+theorem ker_mk : LinearMap.ker (mk p₁) = LinearMap.range (p₁.lcomp Aᵐᵒᵖ A) := by
+  ext φ
+  simp [LinearMap.mem_ker]
+
 /-- A functional precomposed with the first map of the presentation vanishes in its cokernel. -/
 @[simp]
 theorem mk_lcomp (φ : Module.Dual A P₀) :
@@ -132,6 +139,13 @@ theorem lift_mk (f : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] N)
     (hf : ∀ φ : Module.Dual A P₀, f (p₁.lcomp Aᵐᵒᵖ A φ) = 0) (φ : Module.Dual A P₁) :
     lift p₁ f hf (mk p₁ φ) = f φ :=
   Submodule.liftQ_apply _ f φ
+
+/-- `AuslanderReitenTranspose.lift` factors the given map through the quotient map. -/
+@[simp]
+theorem lift_comp_mk (f : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] N)
+    (hf : ∀ φ : Module.Dual A P₀, f (p₁.lcomp Aᵐᵒᵖ A φ) = 0) :
+    (lift p₁ f hf).comp (mk p₁) = f :=
+  LinearMap.ext fun φ => lift_mk p₁ f hf φ
 
 /-- Opposite-linear maps out of the transpose are determined by their values on representatives. -/
 theorem hom_ext {f g : AuslanderReitenTranspose p₁ →ₗ[Aᵐᵒᵖ] N}
@@ -191,6 +205,11 @@ theorem linearEquiv_mk {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
     (φ : Module.Dual A P₁) :
     linearEquiv e₀ e₁ hsquare (mk p₁ φ) =
       mk q₁ (e₁.symm.toLinearMap.lcomp Aᵐᵒᵖ A φ) := by
+  -- `linearEquiv`, `mk` and `AuslanderReitenTranspose` itself are not exposed, so neither the
+  -- statement nor Mathlib's quotient lemmas reduce here on their own: an exported theorem may only
+  -- unfold exposed definitions.  `with_unfolding_all` lets this proof see through them, and the
+  -- `change` then presents the goal in the `Submodule.Quotient` form in which
+  -- `Submodule.Quotient.equiv_apply` and `Submodule.mapQ_apply` apply.
   with_unfolding_all
     change Submodule.Quotient.equiv _ _ _ _ (Submodule.Quotient.mk φ) =
       Submodule.Quotient.mk _

--- a/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReitenTranspose.lean
@@ -232,6 +232,7 @@ theorem linearEquiv_refl :
       LinearMap.id_apply]
 
 /-- Transport along a composite of presentation equivalences is the composite transport. -/
+@[simp]
 theorem linearEquiv_trans {q₁ : Q₁ →ₗ[A] Q₀}
     {R₀ R₁ : Type*} [AddCommGroup R₀] [Module A R₀] [AddCommGroup R₁] [Module A R₁]
     {r₁ : R₁ →ₗ[A] R₀} (e₀ : P₀ ≃ₗ[A] Q₀) (e₁ : P₁ ≃ₗ[A] Q₁)
@@ -257,6 +258,7 @@ theorem linearEquiv_trans {q₁ : Q₁ →ₗ[A] Q₀}
       LinearMap.comp_apply]
 
 /-- The inverse of transport is transport along the inverse presentation equivalences. -/
+@[simp]
 theorem linearEquiv_symm {q₁ : Q₁ →ₗ[A] Q₀} (e₀ : P₀ ≃ₗ[A] Q₀)
     (e₁ : P₁ ≃ₗ[A] Q₁)
     (hsquare : e₀.toLinearMap ∘ₗ p₁ = q₁ ∘ₗ e₁.toLinearMap) :


### PR DESCRIPTION
This PR defines the Auslander--Reiten transpose of a projective presentation as the cokernel of the opposite-linear dual map, supplies the quotient API on representatives, and proves that isomorphic presentation squares induce linearly equivalent transposes. It then combines that transport with uniqueness of minimal projective presentations to make the construction independent of the chosen minimal presentation, and records that the transpose of a projective module is zero.

This advances `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, Layer 6, sublayer 6C, “the transpose `Tr` and stable equivalence,” specifically its `Tr` construction from a minimal projective presentation. With minimal projective presentations already available, this is the next dependency required before finite-field duality can form `τ = D Tr`.

After this PR, sublayer 6C still needs the stable-category equivalence induced by `Tr`; sublayer 6D then needs finite-field duality, the object-level `arTranslate`, and AR duality.

The implementation reuses Mathlib's `Module.Dual`, opposite-ring module structure, `LinearMap.lcomp`, and `Submodule.Quotient.equiv`; none of that infrastructure is vendored. The mathematical definition and presentation-independence argument follow Auslander--Reiten--Smalø, *Representation Theory of Artin Algebras*, IV.1, and Assem--Simson--Skowroński, *Elements of the Representation Theory of Associative Algebras*, IV.2, as cited in the module documentation.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"auslander-reiten-transpose"}-->

🤖 Prepared with Codex
