### PR TITLE
feat: the Coxeter transformation drives a dimension vector out of the positive cone

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/PosDef.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/PosDef.lean
@@ -90,7 +90,7 @@ theorem finite_setOf_apply_le {q : QuadraticForm ℤ M} (hq : q.PosDef) (n : ℤ
   set T : M →ₗ[ℤ] (Module.Free.ChooseBasisIndex ℤ M → ℤ) :=
     LinearMap.pi fun i ↦ B.flip (b i)
   have hTapply : ∀ (x : M) (i : Module.Free.ChooseBasisIndex ℤ M), T x i = B x (b i) :=
-    fun x i ↦ rfl
+    fun x i ↦ by simp only [T, LinearMap.pi_apply, LinearMap.BilinForm.flip_apply]
   have hTinj : Function.Injective T := by
     refine (injective_iff_map_eq_zero T).mpr fun x hx ↦ ?_
     have hzero : B x = 0 := b.ext fun i ↦ by

--- a/TauCeti/LinearAlgebra/QuadraticForm/PosDef.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/PosDef.lean
@@ -21,10 +21,13 @@ the one that turns an orbit lying in a level set into a periodic orbit.
 
 ## Main results
 
-* `TauCeti.QuadraticMap.PosDef.finite_setOf_apply_le`: a positive definite quadratic form on a
+* `QuadraticMap.PosDef.finite_setOf_apply_le`: a positive definite quadratic form on a
   finitely generated free `ℤ`-module has only finitely many vectors of value at most `n`.
-* `TauCeti.QuadraticMap.PosDef.finite_setOf_apply_eq`: consequently only finitely many vectors of
+* `QuadraticMap.PosDef.finite_setOf_apply_eq`: consequently only finitely many vectors of
   value exactly `n`.
+
+Both live in the root `QuadraticMap.PosDef` namespace so that they are available by dot notation
+on a `QuadraticForm.PosDef` hypothesis.
 
 ## Implementation notes
 
@@ -46,10 +49,6 @@ public section
 
 namespace TauCeti
 
-namespace QuadraticMap
-
-variable {M : Type*} [AddCommGroup M] [Module.Free ℤ M] [Module.Finite ℤ M]
-
 /-- Over `ℤ` a bound on the square is a bound on the absolute value: a nonzero integer is at most
 its own square in absolute value. -/
 private theorem abs_le_of_sq_le {y c : ℤ} (h : y ^ 2 ≤ c) : |y| ≤ c := by
@@ -63,10 +62,16 @@ private theorem abs_le_of_sq_le {y c : ℤ} (h : y ^ 2 ≤ c) : |y| ≤ c := by
       _ = y ^ 2 := by rw [← sq, sq_abs]
       _ ≤ c := h
 
+end TauCeti
+
+namespace QuadraticMap.PosDef
+
+variable {M : Type*} [AddCommGroup M] [Module.Free ℤ M] [Module.Finite ℤ M]
+
 /-- **A positive definite integral quadratic form has finitely many vectors of bounded value.**
 For a positive definite quadratic form `q` on a finitely generated free `ℤ`-module and any integer
 `n`, only finitely many vectors satisfy `q x ≤ n`. -/
-theorem PosDef.finite_setOf_apply_le {q : QuadraticForm ℤ M} (hq : q.PosDef) (n : ℤ) :
+theorem finite_setOf_apply_le {q : QuadraticForm ℤ M} (hq : q.PosDef) (n : ℤ) :
     {x : M | q x ≤ n}.Finite := by
   classical
   set b := Module.Free.chooseBasis ℤ M
@@ -112,16 +117,14 @@ theorem PosDef.finite_setOf_apply_le {q : QuadraticForm ℤ M} (hq : q.PosDef) (
       _ ≤ 2 * n * (2 * q (b i)) := by
           exact mul_le_mul_of_nonneg_right (by omega) h2
       _ = C i := rfl
-  exact abs_le.mp (abs_le_of_sq_le (hcs.trans hle))
+  exact abs_le.mp (TauCeti.abs_le_of_sq_le (hcs.trans hle))
 
 /-- **A positive definite integral quadratic form takes each value finitely often.** For a
 positive definite quadratic form `q` on a finitely generated free `ℤ`-module, only finitely many
 vectors satisfy `q x = n`; for a positive definite lattice this is the finiteness of the set of
 vectors of a given norm. -/
-theorem PosDef.finite_setOf_apply_eq {q : QuadraticForm ℤ M} (hq : q.PosDef) (n : ℤ) :
+theorem finite_setOf_apply_eq {q : QuadraticForm ℤ M} (hq : q.PosDef) (n : ℤ) :
     {x : M | q x = n}.Finite :=
-  (PosDef.finite_setOf_apply_le hq n).subset fun _ hx ↦ le_of_eq hx
+  (finite_setOf_apply_le hq n).subset fun _ hx ↦ le_of_eq hx
 
-end QuadraticMap
-
-end TauCeti
+end QuadraticMap.PosDef

--- a/TauCeti/LinearAlgebra/QuadraticForm/PosDef.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/PosDef.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.Fintype.Pi
+public import Mathlib.LinearAlgebra.BilinearForm.Properties
+public import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
+public import Mathlib.LinearAlgebra.QuadraticForm.Basic
+public import Mathlib.Data.Int.Interval
+
+/-!
+# Vectors of bounded value for a positive definite integral quadratic form
+
+A positive definite quadratic form on a finitely generated free `ℤ`-module takes each of its values
+only finitely often: the sets `{x | q x ≤ n}` and `{x | q x = n}` are finite. This is the
+finiteness that makes "the vectors of norm `n`" of a positive definite lattice a finite list, and
+the one that turns an orbit lying in a level set into a periodic orbit.
+
+## Main results
+
+* `TauCeti.QuadraticMap.PosDef.finite_setOf_apply_le`: a positive definite quadratic form on a
+  finitely generated free `ℤ`-module has only finitely many vectors of value at most `n`.
+* `TauCeti.QuadraticMap.PosDef.finite_setOf_apply_eq`: consequently only finitely many vectors of
+  value exactly `n`.
+
+## Implementation notes
+
+The argument stays inside `ℤ`; no rational or real coefficients, no compactness, and no
+diagonalization enter. Write `B` for the polar form, which is symmetric with `B x x = 2 * q x`,
+hence nonnegative, and let `b` be a basis. The coordinates of `x` in the dual-like map
+`T x = fun i ↦ B x (b i)` are bounded by Cauchy-Schwarz for a positive semidefinite symmetric form
+(`LinearMap.BilinForm.apply_sq_le_of_symm`), since `(B x (b i)) ^ 2 ≤ B x x * B (b i) (b i)` and
+the right-hand side is bounded once `q x` is. The map `T` is injective: a vector it kills is
+orthogonal to a basis, hence to itself, hence isotropic, hence zero. So the set in question is the
+preimage under an injective map of a box of integer vectors.
+
+Note that `T` is *not* claimed to be surjective, and need not be: the polar form of a positive
+definite integral quadratic form is generally not unimodular. Injectivity is all the argument
+uses.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace QuadraticMap
+
+variable {M : Type*} [AddCommGroup M] [Module.Free ℤ M] [Module.Finite ℤ M]
+
+/-- Over `ℤ` a bound on the square is a bound on the absolute value: a nonzero integer is at most
+its own square in absolute value. -/
+private theorem abs_le_of_sq_le {y c : ℤ} (h : y ^ 2 ≤ c) : |y| ≤ c := by
+  rcases eq_or_ne y 0 with rfl | hy
+  · simpa using h
+  · have h1 : 1 ≤ |y| := by
+      rcases hy.lt_or_gt with h' | h'
+      · rw [abs_of_neg h']; omega
+      · rw [abs_of_pos h']; omega
+    calc |y| ≤ |y| * |y| := le_mul_of_one_le_left (abs_nonneg y) h1
+      _ = y ^ 2 := by rw [← sq, sq_abs]
+      _ ≤ c := h
+
+/-- **A positive definite integral quadratic form has finitely many vectors of bounded value.**
+For a positive definite quadratic form `q` on a finitely generated free `ℤ`-module and any integer
+`n`, only finitely many vectors satisfy `q x ≤ n`. -/
+theorem PosDef.finite_setOf_apply_le {q : QuadraticForm ℤ M} (hq : q.PosDef) (n : ℤ) :
+    {x : M | q x ≤ n}.Finite := by
+  classical
+  set b := Module.Free.chooseBasis ℤ M
+  set B : LinearMap.BilinForm ℤ M := q.polarBilin with hBdef
+  have hBself : ∀ x : M, B x x = 2 * q x := fun x ↦ by
+    rw [hBdef, QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_self, two_nsmul]
+    ring
+  have hBnonneg : ∀ x : M, 0 ≤ B x x := fun x ↦ by
+    rw [hBself]
+    exact mul_nonneg (by norm_num) (hq.nonneg x)
+  have hsymm : LinearMap.IsSymm B :=
+    LinearMap.BilinForm.isSymm_iff.mp <| LinearMap.BilinForm.isSymm_def.mpr fun x y ↦ by
+      rw [hBdef, QuadraticMap.polarBilin_apply_apply, QuadraticMap.polarBilin_apply_apply,
+        QuadraticMap.polar_comm]
+  -- Pairing against the basis is injective, because the polar form detects isotropy.
+  set T : M →ₗ[ℤ] (Module.Free.ChooseBasisIndex ℤ M → ℤ) :=
+    LinearMap.pi fun i ↦ B.flip (b i)
+  have hTapply : ∀ (x : M) (i : Module.Free.ChooseBasisIndex ℤ M), T x i = B x (b i) :=
+    fun x i ↦ rfl
+  have hTinj : Function.Injective T := by
+    refine (injective_iff_map_eq_zero T).mpr fun x hx ↦ ?_
+    have hzero : B x = 0 := b.ext fun i ↦ by
+      simpa [hTapply] using congrFun hx i
+    refine hq.anisotropic x ?_
+    have : B x x = 0 := by rw [hzero, LinearMap.zero_apply]
+    rw [hBself] at this
+    omega
+  -- Cauchy-Schwarz bounds each coordinate of `T x` in terms of `n` alone.
+  set C : Module.Free.ChooseBasisIndex ℤ M → ℤ := fun i ↦ 2 * n * (2 * q (b i))
+  refine Set.Finite.subset
+    (Set.Finite.preimage hTinj.injOn (Set.Finite.pi' fun i ↦ Set.finite_Icc (-(C i)) (C i)))
+    fun x hx ↦ ?_
+  simp only [Set.mem_ofPred_eq] at hx
+  simp only [Set.mem_preimage, Set.mem_ofPred_eq, Set.mem_Icc]
+  intro i
+  have hcs : (T x i) ^ 2 ≤ B x x * B (b i) (b i) := by
+    rw [hTapply]
+    exact B.apply_sq_le_of_symm hBnonneg hsymm x (b i)
+  have hle : B x x * B (b i) (b i) ≤ C i := by
+    have h2 : (0 : ℤ) ≤ 2 * q (b i) := by
+      have := hq.nonneg (b i); omega
+    calc B x x * B (b i) (b i) = 2 * q x * (2 * q (b i)) := by rw [hBself, hBself]
+      _ ≤ 2 * n * (2 * q (b i)) := by
+          exact mul_le_mul_of_nonneg_right (by omega) h2
+      _ = C i := rfl
+  exact abs_le.mp (abs_le_of_sq_le (hcs.trans hle))
+
+/-- **A positive definite integral quadratic form takes each value finitely often.** For a
+positive definite quadratic form `q` on a finitely generated free `ℤ`-module, only finitely many
+vectors satisfy `q x = n`; for a positive definite lattice this is the finiteness of the set of
+vectors of a given norm. -/
+theorem PosDef.finite_setOf_apply_eq {q : QuadraticForm ℤ M} (hq : q.PosDef) (n : ℤ) :
+    {x : M | q x = n}.Finite :=
+  (PosDef.finite_setOf_apply_le hq n).subset fun _ hx ↦ le_of_eq hx
+
+end QuadraticMap
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/EulerForm.lean
@@ -231,6 +231,18 @@ public theorem titsForm_single (i : Q) :
   rw [titsForm_def, eulerForm_single_single]
   simp
 
+omit [DecidableEq Q] in
+/-- **A positive definite Tits form has no loops.** The simple dimension vector `αᵢ` has
+`q(αᵢ) = 1 - #(i ⟶ i)`, which a loop at `i` makes non-positive. -/
+public theorem isEmpty_hom_self_of_titsForm_posDef (hpd : (titsForm Q).PosDef) (i : Q) :
+    IsEmpty (i ⟶ i) := by
+  classical
+  have hne : (Pi.single i 1 : Q → ℤ) ≠ 0 := fun h ↦ by simpa using congrFun h i
+  have hpos := hpd _ hne
+  rw [titsForm_single] at hpos
+  rw [← Fintype.card_eq_zero_iff]
+  omega
+
 /-- A loopless vertex has a simple dimension vector of Tits norm one, that is, `αᵢ` is a root. -/
 public theorem titsForm_single_of_isEmpty {i : Q} (h : IsEmpty (i ⟶ i)) :
     titsForm Q (Pi.single i 1) = 1 := by

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
@@ -359,8 +359,9 @@ unchanged by a simple reflection at a loopless vertex, hence by the whole Coxete
 (`TauCeti.titsForm_vertexPreReflectionList`), and no vertex of a repetition-free sink-admissible
 list carries a loop (`TauCeti.Quiver.IsSinkAdmissible.isEmpty_hom_self`). So on an indecomposable
 representation the Coxeter functor either annihilates it or leaves the Tits form of its dimension
-vector alone. This preserved invariant is used by the Layer 5 reflection induction, whose descent
-measure is root height. -/
+vector alone. This preserved invariant feeds the finite-orbit descent theorem
+`TauCeti.exists_vertexPreReflectionList_pow_apply_neg`, which forces a nonzero dimension vector out
+of the nonnegative cone after finitely many Coxeter passes. -/
 theorem titsForm_dimVector_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
     (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
     (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Coxeter.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Coxeter.lean
@@ -34,8 +34,9 @@ every vertex without repetition and the polarized Tits form has trivial radical,
 whenever the Tits form is anisotropic, and so for a quiver of ADE type, where the Tits form is
 positive definite and `QuadraticMap.PosDef.anisotropic` applies. This is the engine of the
 Bernstein-Gelfand-Ponomarev proof of Gabriel's theorem that forbids a nonzero dimension vector from
-being carried to itself after a full pass of the Coxeter functor. The separate positive-root height
-argument supplies the descent to a vertex simple.
+being carried to itself after a full pass of the Coxeter functor. The finite-orbit argument in
+`TauCeti.exists_vertexPreReflectionList_pow_apply_neg` supplies the descent to a vertex simple
+without first passing through root-system combinatorics.
 
 ## Main definitions and results
 
@@ -318,9 +319,10 @@ only the zero vector**, as soon as the word of vertices it is taken along is rep
 exhausts the vertices.
 
 This fixed-point obstruction is one input to the reflection induction behind Gabriel's theorem: no
-nonzero dimension vector survives a full pass of the Coxeter functor unchanged. The descent itself
-requires a separate positive-root height argument. An anisotropic Tits form has trivial radical,
-which is the form the hypothesis takes in
+nonzero dimension vector survives a full pass of the Coxeter functor unchanged. For a positive
+definite Tits form, `TauCeti.exists_vertexPreReflectionList_pow_apply_neg` combines this obstruction
+with a finite-orbit argument to supply the descent without a separate root-height argument. An
+anisotropic Tits form has trivial radical, which is the form the hypothesis takes in
 `TauCeti.vertexPreReflectionList_eq_self_iff_of_anisotropic`. -/
 theorem vertexPreReflectionList_eq_self_iff
     (hsep : LinearMap.SeparatingRight (titsPolarForm Q)) {l : List Q} (hnd : l.Nodup)

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Descent.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Descent.lean
@@ -73,7 +73,7 @@ private theorem exists_pos_pow_apply_eq (v : M) {s : Set M} (hs : s.Finite)
   have key : ∀ m n : ℕ, m < n → (f ^ m) v = (f ^ n) v →
       ∃ N p : ℕ, 0 < p ∧ (f ^ p) ((f ^ N) v) = (f ^ N) v := fun m n hmn hv ↦
     ⟨m, n - m, by omega, by
-      rw [← Module.End.mul_apply, ← pow_add, show n - m + m = n by omega]
+      rw [← Module.End.mul_apply, ← pow_add, Nat.sub_add_cancel (Nat.le_of_lt hmn)]
       exact hv.symm⟩
   obtain ⟨a, b, hab, heq⟩ :=
     Finite.exists_ne_map_eq_of_infinite fun N : ℕ ↦ (⟨(f ^ N) v, hmem N⟩ : s)
@@ -97,17 +97,6 @@ end Orbit
 
 variable (Q : Type u) [Quiver.{v} Q] [Fintype Q] [∀ a b : Q, Fintype (a ⟶ b)]
 
-/-- **A positive definite Tits form has no loops.** The simple dimension vector `αᵢ` has
-`q(αᵢ) = 1 - #(i ⟶ i)`, which a loop at `i` makes non-positive. -/
-theorem isEmpty_hom_self_of_titsForm_posDef (hpd : (titsForm Q).PosDef) (i : Q) :
-    IsEmpty (i ⟶ i) := by
-  classical
-  have hne : (Pi.single i 1 : Q → ℤ) ≠ 0 := fun h ↦ by simpa using congrFun h i
-  have hpos := hpd _ hne
-  rw [titsForm_single] at hpos
-  rw [← Fintype.card_eq_zero_iff]
-  omega
-
 variable [DecidableEq Q]
 
 /-- **The Coxeter transformation drives every nonzero dimension vector out of the positive cone.**
@@ -129,12 +118,15 @@ theorem exists_vertexPreReflectionList_pow_apply_neg (hpd : (titsForm Q).PosDef)
   set c := vertexPreReflectionList Q l with hc
   have hnn : ∀ N : ℕ, 0 ≤ (c ^ N) d := fun N ↦ Pi.le_def.mpr fun i ↦ hcon N i
   -- Every iterate has the same Tits value, so the orbit lies in a level set.
+  have hc_preserves (y : Q → ℤ) : titsForm Q (c y) = titsForm Q y := by
+    rw [hc]
+    exact titsForm_vertexPreReflectionList Q hloop y
   have hlevel : ∀ N : ℕ, titsForm Q ((c ^ N) d) = titsForm Q d := by
     intro N
     induction N with
     | zero => simp
     | succ N ih =>
-      rw [pow_succ', Module.End.mul_apply, hc, titsForm_vertexPreReflectionList Q hloop, ← hc, ih]
+      rw [pow_succ', Module.End.mul_apply, hc_preserves, ih]
   -- The level set is finite, so the orbit returns to one of its own points.
   have hfin : {x : Q → ℤ | titsForm Q x = titsForm Q d}.Finite :=
     QuadraticMap.PosDef.finite_setOf_apply_eq hpd _
@@ -145,9 +137,8 @@ theorem exists_vertexPreReflectionList_pow_apply_neg (hpd : (titsForm Q).PosDef)
     rw [hx, ← Module.End.mul_apply, ← pow_add]
     exact hnn (j + N)
   have hx0 : x ≠ 0 := by
-    have hcoe : ⇑(c ^ N) = (⇑c)^[N] := funext fun z ↦ Module.End.pow_apply c N z
     have hinj : Function.Injective ⇑(c ^ N) := by
-      rw [hcoe]
+      rw [Module.End.coe_pow]
       exact ((vertexPreReflectionList_bijective Q hloop).1).iterate N
     rw [hx]
     intro h

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Descent.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Descent.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.QuadraticForm.PosDef
+public import TauCeti.RepresentationTheory.Quiver.Reflection.Coxeter
+
+/-!
+# The Coxeter transformation drives a dimension vector out of the positive cone
+
+Let `Q` be a finite quiver whose Tits form is positive definite, the numerical side of the ADE
+condition in Gabriel's theorem. This file proves that the Coxeter transformation `c`, the
+composite of the simple reflections along a repetition-free word running over every vertex, moves
+every nonzero dimension vector out of the positive cone: for every `d ≠ 0` some iterate `cᴺ d` has
+a negative coordinate (`TauCeti.exists_vertexPreReflectionList_pow_apply_neg`).
+
+This is the descent that the Bernstein-Gelfand-Ponomarev proof of Gabriel's theorem runs on the
+representation side. A finite-dimensional representation has a nonnegative dimension vector, and
+`TauCeti.indecomposable_and_dimVector_coxeterFunctor_or_isZero` says that a pass of the Coxeter
+functor over an indecomposable either applies `c` to its dimension vector or annihilates it. Since
+`c` cannot keep a nonzero dimension vector nonnegative forever, some pass must annihilate the
+representation, that is, must meet the vertex simple at the sink it is reflecting; iterating that
+observation is the induction that carries an indecomposable down to a vertex simple, and its
+dimension vector down to a simple root.
+
+## Main results
+
+* `TauCeti.isEmpty_hom_self_of_titsForm_posDef`: a positive definite Tits form forces every vertex
+  to be loopless, so the reflection identities are available without a separate hypothesis.
+* `TauCeti.exists_vertexPreReflectionList_pow_apply_neg`: **the descent.** No nonzero dimension
+  vector stays nonnegative under all iterates of the Coxeter transformation.
+
+## Implementation notes
+
+The proof is the finite-orbit argument, and it needs no root-system combinatorics. The iterates
+`cᴺ d` all have the same Tits value, and a positive definite integral quadratic form takes each
+value only finitely often
+(`TauCeti.QuadraticMap.PosDef.finite_setOf_apply_eq`), so the orbit repeats: `cᵖ x = x` for some
+`x = cᴺ d` and some `p > 0`. Were every iterate nonnegative, the sum `x + c x + ⋯ + cᵖ⁻¹ x` over one
+period would be a nonzero vector fixed by `c`, which
+`TauCeti.vertexPreReflectionList_eq_self_iff_of_anisotropic` forbids.
+
+The word is an explicit argument rather than a chosen sink-admissible ordering, matching
+`TauCeti.vertexPreReflectionList` and `TauCeti.coxeterFunctor`: the transformation depends on the
+ordering, so a consumer that names one must be able to pass it.
+
+## References
+
+This is the "descent by height" milestone of the reflection induction in Layer 5, Gabriel's
+theorem, of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`. See
+Bernstein--Gelfand--Ponomarev, *Coxeter functors and Gabriel's theorem*, and Assem--Simson--
+Skowroński, *Elements of the Representation Theory of Associative Algebras* I, VII.5.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v
+
+section Orbit
+
+variable {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M] (f : Module.End R M)
+
+/-- An orbit contained in a finite set returns to one of its own points. -/
+private theorem exists_pos_pow_apply_eq (v : M) {s : Set M} (hs : s.Finite)
+    (hmem : ∀ N : ℕ, (f ^ N) v ∈ s) :
+    ∃ N p : ℕ, 0 < p ∧ (f ^ p) ((f ^ N) v) = (f ^ N) v := by
+  have := hs.to_subtype
+  have key : ∀ m n : ℕ, m < n → (f ^ m) v = (f ^ n) v →
+      ∃ N p : ℕ, 0 < p ∧ (f ^ p) ((f ^ N) v) = (f ^ N) v := fun m n hmn hv ↦
+    ⟨m, n - m, by omega, by
+      rw [← Module.End.mul_apply, ← pow_add, show n - m + m = n by omega]
+      exact hv.symm⟩
+  obtain ⟨a, b, hab, heq⟩ :=
+    Finite.exists_ne_map_eq_of_infinite fun N : ℕ ↦ (⟨(f ^ N) v, hmem N⟩ : s)
+  have heq' : (f ^ a) v = (f ^ b) v := congrArg Subtype.val heq
+  rcases hab.lt_or_gt with h | h
+  · exact key a b h heq'
+  · exact key b a h heq'.symm
+
+/-- The sum of an orbit over one period is fixed. -/
+private theorem apply_sum_range_pow {x : M} {p : ℕ} (hfix : (f ^ p) x = x) :
+    f (∑ j ∈ Finset.range p, (f ^ j) x) = ∑ j ∈ Finset.range p, (f ^ j) x := by
+  rw [map_sum, Finset.sum_congr rfl fun j _ ↦ (by rw [pow_succ', Module.End.mul_apply] :
+    f ((f ^ j) x) = (f ^ (j + 1)) x)]
+  have h1 := Finset.sum_range_succ' (fun j ↦ (f ^ j) x) p
+  have h2 := Finset.sum_range_succ (fun j ↦ (f ^ j) x) p
+  simp only [pow_zero, Module.End.one_apply] at h1
+  rw [hfix] at h2
+  exact add_right_cancel (h1.symm.trans h2)
+
+end Orbit
+
+variable (Q : Type u) [Quiver.{v} Q] [Fintype Q] [∀ a b : Q, Fintype (a ⟶ b)]
+
+/-- **A positive definite Tits form has no loops.** The simple dimension vector `αᵢ` has
+`q(αᵢ) = 1 - #(i ⟶ i)`, which a loop at `i` makes non-positive. -/
+theorem isEmpty_hom_self_of_titsForm_posDef (hpd : (titsForm Q).PosDef) (i : Q) :
+    IsEmpty (i ⟶ i) := by
+  classical
+  have hne : (Pi.single i 1 : Q → ℤ) ≠ 0 := fun h ↦ by simpa using congrFun h i
+  have hpos := hpd _ hne
+  rw [titsForm_single] at hpos
+  rw [← Fintype.card_eq_zero_iff]
+  omega
+
+variable [DecidableEq Q]
+
+/-- **The Coxeter transformation drives every nonzero dimension vector out of the positive cone.**
+For a quiver with positive definite Tits form and a repetition-free word `l` running over all the
+vertices, no nonzero `d` has all of its iterates under the reflection product along `l`
+nonnegative. Nonnegativity of `d` itself is not assumed: at `N = 0` the conclusion is just that `d`
+has a negative coordinate.
+
+On the representation side this is the descent of the Bernstein-Gelfand-Ponomarev induction: a
+dimension vector is nonnegative, so an indecomposable representation cannot survive arbitrarily
+many passes of the Coxeter functor, and the pass that kills it meets a vertex simple. -/
+theorem exists_vertexPreReflectionList_pow_apply_neg (hpd : (titsForm Q).PosDef) {l : List Q}
+    (hnd : l.Nodup) (hmem : ∀ i : Q, i ∈ l) {d : Q → ℤ} (hd0 : d ≠ 0) :
+    ∃ (N : ℕ) (i : Q), (vertexPreReflectionList Q l ^ N) d i < 0 := by
+  classical
+  by_contra hcon
+  push Not at hcon
+  have hloop : ∀ i ∈ l, IsEmpty (i ⟶ i) := fun i _ ↦ isEmpty_hom_self_of_titsForm_posDef Q hpd i
+  set c := vertexPreReflectionList Q l with hc
+  have hnn : ∀ N : ℕ, 0 ≤ (c ^ N) d := fun N ↦ Pi.le_def.mpr fun i ↦ hcon N i
+  -- Every iterate has the same Tits value, so the orbit lies in a level set.
+  have hlevel : ∀ N : ℕ, titsForm Q ((c ^ N) d) = titsForm Q d := by
+    intro N
+    induction N with
+    | zero => simp
+    | succ N ih =>
+      rw [pow_succ', Module.End.mul_apply, hc, titsForm_vertexPreReflectionList Q hloop, ← hc, ih]
+  -- The level set is finite, so the orbit returns to one of its own points.
+  have hfin : {x : Q → ℤ | titsForm Q x = titsForm Q d}.Finite :=
+    QuadraticMap.PosDef.finite_setOf_apply_eq hpd _
+  obtain ⟨N, p, hp, hfix⟩ := exists_pos_pow_apply_eq c d hfin hlevel
+  set x := (c ^ N) d with hx
+  have hxnn : ∀ j : ℕ, 0 ≤ (c ^ j) x := by
+    intro j
+    rw [hx, ← Module.End.mul_apply, ← pow_add]
+    exact hnn (j + N)
+  have hx0 : x ≠ 0 := by
+    have hcoe : ⇑(c ^ N) = (⇑c)^[N] := funext fun z ↦ Module.End.pow_apply c N z
+    have hinj : Function.Injective ⇑(c ^ N) := by
+      rw [hcoe]
+      exact ((vertexPreReflectionList_bijective Q hloop).1).iterate N
+    rw [hx]
+    intro h
+    exact hd0 (hinj (by rw [h, map_zero]))
+  -- The sum over one period is a vector fixed by the Coxeter transformation, hence zero.
+  have hy0 : (∑ j ∈ Finset.range p, (c ^ j) x) = 0 :=
+    (vertexPreReflectionList_eq_self_iff_of_anisotropic Q hpd.anisotropic hnd hmem _).mp
+      (apply_sum_range_pow c hfix)
+  obtain ⟨i, hi⟩ := Function.ne_iff.mp hx0
+  have hxi : 0 < x i := lt_of_le_of_ne (by simpa using Pi.le_def.mp (hnn N) i) (Ne.symm hi)
+  have hsum : ∑ j ∈ Finset.range p, ((c ^ j) x) i = 0 := by
+    simpa using congrFun hy0 i
+  have hpos : 0 < ∑ j ∈ Finset.range p, ((c ^ j) x) i :=
+    Finset.sum_pos' (fun j _ ↦ by simpa using Pi.le_def.mp (hxnn j) i)
+      ⟨0, Finset.mem_range.mpr hp, by simpa using hxi⟩
+  exact hpos.ne' hsum
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Descent.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Descent.lean
@@ -38,7 +38,7 @@ dimension vector down to a simple root.
 The proof is the finite-orbit argument, and it needs no root-system combinatorics. The iterates
 `cᴺ d` all have the same Tits value, and a positive definite integral quadratic form takes each
 value only finitely often
-(`TauCeti.QuadraticMap.PosDef.finite_setOf_apply_eq`), so the orbit repeats: `cᵖ x = x` for some
+(`QuadraticMap.PosDef.finite_setOf_apply_eq`), so the orbit repeats: `cᵖ x = x` for some
 `x = cᴺ d` and some `p > 0`. Were every iterate nonnegative, the sum `x + c x + ⋯ + cᵖ⁻¹ x` over one
 period would be a nonzero vector fixed by `c`, which
 `TauCeti.vertexPreReflectionList_eq_self_iff_of_anisotropic` forbids.


### PR DESCRIPTION
This PR proves the descent step of the Bernstein-Gelfand-Ponomarev reflection induction: for a finite quiver whose Tits form is positive definite, no nonzero dimension vector stays nonnegative under all iterates of the Coxeter transformation. `TauCeti.exists_vertexPreReflectionList_pow_apply_neg` produces, for every `d ≠ 0`, an iterate `cᴺ d` with a negative coordinate, where `c = TauCeti.vertexPreReflectionList Q l` is the reflection product along a repetition-free word `l` running over every vertex. Positive definiteness also forces every vertex to be loopless (`TauCeti.isEmpty_hom_self_of_titsForm_posDef`), so the reflection identities are available without a separate hypothesis.

The milestone is "Descent by height", item 3 of "The reflection induction (the combinatorial core)" in Layer 5, Gabriel's theorem, of `RepresentationTheory/QuiverRepresentations/README.md`. It is the input the module docstring of `TauCeti/RepresentationTheory/Quiver/Reflection/Coxeter.lean` names as still missing ("The separate positive-root height argument supplies the descent to a vertex simple"), and it is the second half of the pair whose first half is already on `main`, the fixed-point obstruction `TauCeti.vertexPreReflectionList_eq_self_iff_of_anisotropic`. The Layer 4 machinery this consumes is on `main` as well: the reflection functor at a sink and its action on the dimension vector of an indecomposable, the composite along a sink-admissible list, and the Coxeter functor with `TauCeti.indecomposable_and_dimVector_coxeterFunctor_or_isZero`, which is what turns the statement proved here into a representation-side descent. A dimension vector is nonnegative, so an indecomposable cannot survive arbitrarily many passes of the Coxeter functor, and the pass that annihilates it is one meeting the vertex simple at its sink.

The proof is a finite-orbit argument rather than a root-height one, which avoids translating `titsForm` into root-system data before that translation exists. All iterates of `d` have the same Tits value, and a positive definite integral quadratic form takes each value only finitely often, so the orbit returns to one of its own points: `cᵖ x = x` with `x = cᴺ d` and `p > 0`. If every iterate were nonnegative then the sum `x + c x + ⋯ + cᵖ⁻¹ x` over one period would be a nonzero vector fixed by `c`, which the fixed-point obstruction forbids.

The finiteness that drives it is proved in general, since it depends on nothing later: `TauCeti.QuadraticMap.PosDef.finite_setOf_apply_le` and `TauCeti.QuadraticMap.PosDef.finite_setOf_apply_eq` say that a positive definite quadratic form on a finitely generated free `ℤ`-module has finitely many vectors of value at most, respectively exactly, any given integer. The argument stays inside `ℤ`, with no rational or real coefficients, no compactness and no diagonalization: Cauchy-Schwarz for the polar form bounds the pairings of a vector against a basis, and pairing against a basis is injective because the polar form detects isotropy, so the level set is the preimage of a box under an injective map. That use of `LinearMap.BilinForm.apply_sq_le_of_symm` in place of eigenvalue theory follows `TauCeti.finite_setOf_forall_sum_mul_le` in `TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean`, which runs the same idea over `ℚ` for a linear inequality system.

What Layer 5 still needs after this PR: running the induction on the representation side to carry an indecomposable down to a vertex simple, identifying positive definiteness of `titsForm` with the simply-laced Dynkin condition through the root-system Cartan data, and assembling the two into the bijection `gabriel_indecomposable_equiv_posRoot` between indecomposables and positive roots.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"gabriel-descent-by-height"}-->

🤖 Prepared with Claude Code
