### PR TITLE
feat: add E7 minuscule admissible lattice

### DIFF
--- a/TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean
@@ -1,0 +1,289 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E7.Minuscule.Basic
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.CoordinateLattice
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.Serre
+
+/-!
+# The admissible lattice in the type-E7 minuscule representation
+
+This file extends the integral `56`-dimensional minuscule representation of the type-`E₇`
+Serre presentation to the rational Serre algebra and proves that its coordinate `ℤ`-lattice is
+preserved by the Serre Kostant form. The raising and lowering matrices have integral entries, are
+square-zero, and preserve the coordinate lattice. The Cartan matrices act diagonally through the
+weights `TauCeti.DynkinType.e7MinusculeWeight`.
+
+Thus the minuscule coordinate lattice is an admissible lattice for the explicit Serre-generator
+Kostant form. Its weights span the full type-`E₇` character lattice by
+`TauCeti.DynkinType.span_range_e7MinusculeWeight_eq_top`. These are the lattice inputs needed for
+the full-weight type-`E₇` Chevalley--Demazure carrier in Layer 9 of the ReductiveGroups roadmap.
+
+## Main declarations
+
+* `TauCeti.E7Minuscule.rationalSerreRepresentation`: the rational minuscule representation.
+* `TauCeti.E7Minuscule.rep`: its extension to the universal enveloping algebra.
+* `TauCeti.E7Minuscule.lattice`: the coordinate `ℤ`-lattice in the rational module.
+* `TauCeti.E7Minuscule.rep_serreKostantForm_mem_lattice`: the Serre Kostant form preserves the
+  lattice.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate VI.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§13 and 26--27.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1--2.
+
+The formal organization follows the parallel type-`E₆` admissible-lattice development in
+TauCetiProject/TauCeti#5204, specialized here to the already constructed `E₇` minuscule Serre
+system.
+-/
+
+public section
+
+open scoped Matrix
+
+namespace TauCeti.E7Minuscule
+
+open TauCeti.DynkinType
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+/-! ## Extension from the integral representation -/
+
+/-- Entrywise coercion from integral to rational matrices, as a homomorphism of Lie rings. -/
+private noncomputable def castMatrixLieHom :
+    Matrix (Fin 56) (Fin 56) ℤ →ₗ⁅ℤ⁆ Matrix (Fin 56) (Fin 56) ℚ where
+  toLinearMap := (Int.castRingHom ℚ).mapMatrix.toAddMonoidHom.toIntLinearMap
+  map_lie' := by
+    intro x y
+    -- Expose the matrix commutator so the ring-homomorphism laws can rewrite each product.
+    change (Int.castRingHom ℚ).mapMatrix (x * y - y * x) =
+      (Int.castRingHom ℚ).mapMatrix x * (Int.castRingHom ℚ).mapMatrix y -
+        (Int.castRingHom ℚ).mapMatrix y * (Int.castRingHom ℚ).mapMatrix x
+    rw [map_sub, map_mul, map_mul]
+
+@[simp]
+private theorem castMatrixLieHom_apply (M : Matrix (Fin 56) (Fin 56) ℤ) (a b : Fin 56) :
+    castMatrixLieHom M a b = (M a b : ℚ) := by
+  rfl
+
+/-- The rational raising matrix obtained from the integral minuscule representation. -/
+noncomputable def raisingMatrixQ (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℚ :=
+  castMatrixLieHom (raisingMatrix i)
+
+/-- The rational lowering matrix obtained from the integral minuscule representation. -/
+noncomputable def loweringMatrixQ (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℚ :=
+  castMatrixLieHom (loweringMatrix i)
+
+/-- The rational Cartan matrix obtained from the integral minuscule representation. -/
+noncomputable def cartanMatrixQ (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℚ :=
+  castMatrixLieHom (cartanMatrix i)
+
+@[simp]
+theorem raisingMatrixQ_apply (i : Fin 7) (a b : Fin 56) :
+    raisingMatrixQ i a b =
+      if e7MinusculeWeight b i = -1 ∧ a = e7MinusculeReflection i b then 1 else 0 := by
+  rw [raisingMatrixQ, castMatrixLieHom_apply, raisingMatrix_apply]
+  split_ifs <;> norm_num
+
+@[simp]
+theorem loweringMatrixQ_apply (i : Fin 7) (a b : Fin 56) :
+    loweringMatrixQ i a b =
+      if e7MinusculeWeight b i = 1 ∧ a = e7MinusculeReflection i b then 1 else 0 := by
+  rw [loweringMatrixQ, castMatrixLieHom_apply, loweringMatrix_apply]
+  split_ifs <;> norm_num
+
+@[simp]
+theorem cartanMatrixQ_apply (i : Fin 7) (a b : Fin 56) :
+    cartanMatrixQ i a b = if a = b then (e7MinusculeWeight a i : ℚ) else 0 := by
+  rw [cartanMatrixQ, castMatrixLieHom_apply, cartanMatrix_apply]
+  split_ifs <;> norm_num
+
+private theorem ad_pow_int_eq_rat (x y : Matrix (Fin 56) (Fin 56) ℚ) (n : ℕ) :
+    (LieAlgebra.ad ℤ _ x ^ n) y = (LieAlgebra.ad ℚ _ x ^ n) y := by
+  induction n generalizing y with
+  | zero => simp
+  | succ n ih =>
+      simp only [pow_succ, Module.End.mul_apply, LieAlgebra.ad_apply]
+      exact ih ⁅x, y⁆
+
+/-- The rational minuscule matrices satisfy the type-`E₇` Serre relations. -/
+theorem isSerreSystemQ :
+    TauCeti.IsSerreSystem ℚ (CartanMatrix.E 7) cartanMatrixQ raisingMatrixQ loweringMatrixQ where
+  lie_H_H i j := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_H i j)
+    simpa [cartanMatrixQ] using h
+  lie_E_F_self i := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.lie_E_F_self i)
+    simpa [raisingMatrixQ, loweringMatrixQ, cartanMatrixQ] using h
+  lie_E_F_of_ne i j hij := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.lie_E_F_of_ne i j hij)
+    simpa [raisingMatrixQ, loweringMatrixQ] using h
+  lie_H_E i j := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_E i j)
+    rw [LieHom.map_lie, map_zsmul] at h
+    simpa only [cartanMatrixQ, raisingMatrixQ, Int.cast_smul_eq_zsmul] using h
+  lie_H_F i j := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_F i j)
+    rw [LieHom.map_lie, map_neg, map_zsmul] at h
+    simpa only [cartanMatrixQ, loweringMatrixQ, Int.cast_smul_eq_zsmul] using h
+  ad_pow_lie_E_E i j := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.ad_pow_lie_E_E i j)
+    rw [TauCeti.LieHom.map_ad_pow, map_zero] at h
+    rw [← ad_pow_int_eq_rat]
+    simpa [raisingMatrixQ] using h
+  ad_pow_lie_F_F i j := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.ad_pow_lie_F_F i j)
+    rw [TauCeti.LieHom.map_ad_pow, map_zero] at h
+    rw [← ad_pow_int_eq_rat]
+    simpa [loweringMatrixQ] using h
+
+/-- The rational `56`-dimensional minuscule representation of the type-`E₇` Serre
+presentation. -/
+noncomputable def rationalSerreRepresentation :
+    Matrix.ToLieAlgebra ℚ (CartanMatrix.E 7) →ₗ⁅ℚ⁆ Matrix (Fin 56) (Fin 56) ℚ :=
+  TauCeti.serreLift isSerreSystemQ
+
+@[simp]
+theorem rationalSerreRepresentation_serreH (i : Fin 7) :
+    rationalSerreRepresentation (TauCeti.serreH ℚ (CartanMatrix.E 7) i) = cartanMatrixQ i :=
+  TauCeti.serreLift_serreH isSerreSystemQ i
+
+@[simp]
+theorem rationalSerreRepresentation_serreE (i : Fin 7) :
+    rationalSerreRepresentation (TauCeti.serreE ℚ (CartanMatrix.E 7) i) = raisingMatrixQ i :=
+  TauCeti.serreLift_serreE isSerreSystemQ i
+
+@[simp]
+theorem rationalSerreRepresentation_serreF (i : Fin 7) :
+    rationalSerreRepresentation (TauCeti.serreF ℚ (CartanMatrix.E 7) i) = loweringMatrixQ i :=
+  TauCeti.serreLift_serreF isSerreSystemQ i
+
+/-! ## The enveloping-algebra representation -/
+
+/-- The rational minuscule representation extended to the universal enveloping algebra. -/
+noncomputable def rep :
+    _root_.UniversalEnvelopingAlgebra ℚ (Matrix.ToLieAlgebra ℚ (CartanMatrix.E 7)) →ₐ[ℚ]
+      Module.End ℚ (Fin 56 → ℚ) :=
+  _root_.UniversalEnvelopingAlgebra.lift ℚ
+    ((Matrix.toLinAlgEquiv (Pi.basisFun ℚ (Fin 56))).toAlgHom.toLieHom.comp
+      rationalSerreRepresentation)
+
+theorem rep_ι_apply (x : Matrix.ToLieAlgebra ℚ (CartanMatrix.E 7)) (v : Fin 56 → ℚ) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ x) v = rationalSerreRepresentation x *ᵥ v := by
+  rw [rep, _root_.UniversalEnvelopingAlgebra.lift_ι_apply, LieHom.comp_apply,
+    AlgHom.toLieHom_apply, AlgEquiv.toAlgHom_apply, Matrix.toLinAlgEquiv_apply]
+  exact (Pi.basisFun ℚ (Fin 56)).sum_repr (rationalSerreRepresentation x *ᵥ v)
+
+private theorem e7MinusculeWeight_reflection_apply_self (i : Fin 7) (a : Fin 56) :
+    e7MinusculeWeight (e7MinusculeReflection i a) i = -e7MinusculeWeight a i := by
+  have h := congrFun (e7MinusculeWeight_reflection i a) i
+  rw [root_e7SimpleIndex] at h
+  simp [CartanMatrix.E_diag] at h
+  omega
+
+theorem raisingMatrixQ_sq (i : Fin 7) : raisingMatrixQ i ^ 2 = 0 := by
+  ext a b
+  simp only [pow_two, Matrix.mul_apply, raisingMatrixQ_apply, Matrix.zero_apply]
+  by_cases hb : e7MinusculeWeight b i = -1
+  · simp [hb, e7MinusculeWeight_reflection_apply_self]
+  · simp [hb]
+
+theorem loweringMatrixQ_sq (i : Fin 7) : loweringMatrixQ i ^ 2 = 0 := by
+  ext a b
+  simp only [pow_two, Matrix.mul_apply, loweringMatrixQ_apply, Matrix.zero_apply]
+  by_cases hb : e7MinusculeWeight b i = 1
+  · simp [hb, e7MinusculeWeight_reflection_apply_self]
+  · simp [hb]
+
+theorem pow_two_rep_serreRootGenerator_eq_zero (k : Fin 7 ⊕ Fin 7) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+      (TauCeti.serreRootGenerator (CartanMatrix.E 7) k)) ^ 2 = 0 := by
+  apply LinearMap.ext
+  intro v
+  cases k with
+  | inl i =>
+      rw [pow_two, Module.End.mul_apply, rep_ι_apply, rep_ι_apply,
+        TauCeti.serreRootGenerator_inl, rationalSerreRepresentation_serreE,
+        Matrix.mulVec_mulVec, ← pow_two, raisingMatrixQ_sq, Matrix.zero_mulVec,
+        LinearMap.zero_apply]
+  | inr i =>
+      rw [pow_two, Module.End.mul_apply, rep_ι_apply, rep_ι_apply,
+        TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF,
+        Matrix.mulVec_mulVec, ← pow_two, loweringMatrixQ_sq, Matrix.zero_mulVec,
+        LinearMap.zero_apply]
+
+/-! ## The admissible coordinate lattice -/
+
+/-- The coordinate `ℤ`-lattice in the rational minuscule module. -/
+def lattice : Submodule ℤ (Fin 56 → ℚ) :=
+  TauCeti.coordinateLattice (Fin 56)
+
+/-- A minuscule-module vector belongs to the lattice exactly when every coordinate is integral. -/
+@[simp]
+theorem mem_lattice_iff {v : Fin 56 → ℚ} :
+    v ∈ lattice ↔ ∀ a, ∃ z : ℤ, (z : ℚ) = v a :=
+  TauCeti.mem_coordinateLattice_iff (Fin 56)
+
+/-- The coordinate basis of the minuscule lattice. -/
+noncomputable def latticeBasis : Module.Basis (Fin 56) ℤ lattice :=
+  TauCeti.coordinateLatticeBasis (Fin 56)
+
+@[simp]
+theorem coe_latticeBasis (a : Fin 56) :
+    ((latticeBasis a : lattice) : Fin 56 → ℚ) = Pi.single a 1 := by
+  rw [← Pi.basisFun_apply, latticeBasis]
+  exact TauCeti.coe_coordinateLatticeBasis (Fin 56) a
+
+private theorem castMatrix_mulVec_mem_lattice (M : Matrix (Fin 56) (Fin 56) ℤ)
+    {v : Fin 56 → ℚ} (hv : v ∈ lattice) : castMatrixLieHom M *ᵥ v ∈ lattice := by
+  rw [mem_lattice_iff] at hv ⊢
+  choose z hz using hv
+  intro a
+  refine ⟨∑ b, M a b * z b, ?_⟩
+  simp only [Int.cast_sum, Int.cast_mul, hz, Matrix.mulVec, dotProduct,
+    castMatrixLieHom_apply]
+
+theorem rep_serreRootGenerator_mem_lattice (k : Fin 7 ⊕ Fin 7) {v : Fin 56 → ℚ}
+    (hv : v ∈ lattice) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+      (TauCeti.serreRootGenerator (CartanMatrix.E 7) k)) v ∈ lattice := by
+  rw [rep_ι_apply]
+  cases k with
+  | inl i =>
+      rw [TauCeti.serreRootGenerator_inl, rationalSerreRepresentation_serreE, raisingMatrixQ]
+      exact castMatrix_mulVec_mem_lattice (raisingMatrix i) hv
+  | inr i =>
+      rw [TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF, loweringMatrixQ]
+      exact castMatrix_mulVec_mem_lattice (loweringMatrix i) hv
+
+theorem isCartanWeightVector_single (a : Fin 56) :
+    TauCeti.UniversalEnvelopingAlgebra.IsCartanWeightVector
+      (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep (e7MinusculeWeight a) (Pi.single a 1) := by
+  refine (TauCeti.UniversalEnvelopingAlgebra.isCartanWeightVector_iff
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep).mpr fun i ↦ ?_
+  rw [rep_ι_apply, rationalSerreRepresentation_serreH]
+  ext b
+  by_cases h : b = a
+  · subst b
+    simp [Matrix.mulVec, dotProduct, cartanMatrixQ_apply, Pi.single_apply]
+  · simp [Matrix.mulVec, dotProduct, cartanMatrixQ_apply, Pi.single_apply, h]
+
+/-- **The minuscule coordinate lattice is admissible for the type-`E₇` Serre Kostant form.** -/
+theorem rep_serreKostantForm_mem_lattice
+    {u : _root_.UniversalEnvelopingAlgebra ℚ
+      (Matrix.ToLieAlgebra ℚ (CartanMatrix.E 7))}
+    (hu : u ∈ TauCeti.serreKostantForm (CartanMatrix.E 7)) {v : Fin 56 → ℚ}
+    (hv : v ∈ lattice) : rep u v ∈ lattice := by
+  rw [TauCeti.serreKostantForm_def] at hu
+  exact TauCeti.UniversalEnvelopingAlgebra.kostantForm_apply_mem_coordinateLattice
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep
+    (wt := e7MinusculeWeight) pow_two_rep_serreRootGenerator_eq_zero
+    (fun k _ hw ↦ rep_serreRootGenerator_mem_lattice k hw) isCartanWeightVector_single hu hv
+
+end TauCeti.E7Minuscule

--- a/TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean
@@ -27,6 +27,8 @@ the full-weight type-`E₇` Chevalley--Demazure carrier in Layer 9 of the Reduct
 
 * `TauCeti.E7Minuscule.rationalSerreRepresentation`: the rational minuscule representation.
 * `TauCeti.E7Minuscule.rep`: its extension to the universal enveloping algebra.
+* `TauCeti.E7Minuscule.isNilpotent_rep_serreRootGenerator`: the simple-root generators act
+  nilpotently.
 * `TauCeti.E7Minuscule.lattice`: the coordinate `ℤ`-lattice in the rational module.
 * `TauCeti.E7Minuscule.rep_serreKostantForm_mem_lattice`: the Serre Kostant form preserves the
   lattice.
@@ -69,38 +71,42 @@ private noncomputable def castMatrixLieHom :
 @[simp]
 private theorem castMatrixLieHom_apply (M : Matrix (Fin 56) (Fin 56) ℤ) (a b : Fin 56) :
     castMatrixLieHom M a b = (M a b : ℚ) := by
-  rfl
+  change (Int.castRingHom ℚ).mapMatrix M a b = (M a b : ℚ)
+  rw [RingHom.mapMatrix_apply, Matrix.map_apply, Int.coe_castRingHom]
 
 /-- The rational raising matrix obtained from the integral minuscule representation. -/
-noncomputable def raisingMatrixQ (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℚ :=
+noncomputable def raisingMatrixRat (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℚ :=
   castMatrixLieHom (raisingMatrix i)
 
 /-- The rational lowering matrix obtained from the integral minuscule representation. -/
-noncomputable def loweringMatrixQ (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℚ :=
+noncomputable def loweringMatrixRat (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℚ :=
   castMatrixLieHom (loweringMatrix i)
 
 /-- The rational Cartan matrix obtained from the integral minuscule representation. -/
-noncomputable def cartanMatrixQ (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℚ :=
+noncomputable def cartanMatrixRat (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℚ :=
   castMatrixLieHom (cartanMatrix i)
 
+/-- The entries of the rational raising matrix are the integral minuscule raising coefficients. -/
 @[simp]
-theorem raisingMatrixQ_apply (i : Fin 7) (a b : Fin 56) :
-    raisingMatrixQ i a b =
+theorem raisingMatrixRat_apply (i : Fin 7) (a b : Fin 56) :
+    raisingMatrixRat i a b =
       if e7MinusculeWeight b i = -1 ∧ a = e7MinusculeReflection i b then 1 else 0 := by
-  rw [raisingMatrixQ, castMatrixLieHom_apply, raisingMatrix_apply]
+  rw [raisingMatrixRat, castMatrixLieHom_apply, raisingMatrix_apply]
   split_ifs <;> norm_num
 
+/-- The entries of the rational lowering matrix are the integral minuscule lowering coefficients. -/
 @[simp]
-theorem loweringMatrixQ_apply (i : Fin 7) (a b : Fin 56) :
-    loweringMatrixQ i a b =
+theorem loweringMatrixRat_apply (i : Fin 7) (a b : Fin 56) :
+    loweringMatrixRat i a b =
       if e7MinusculeWeight b i = 1 ∧ a = e7MinusculeReflection i b then 1 else 0 := by
-  rw [loweringMatrixQ, castMatrixLieHom_apply, loweringMatrix_apply]
+  rw [loweringMatrixRat, castMatrixLieHom_apply, loweringMatrix_apply]
   split_ifs <;> norm_num
 
+/-- The rational Cartan matrix is diagonal with the minuscule weights on its diagonal. -/
 @[simp]
-theorem cartanMatrixQ_apply (i : Fin 7) (a b : Fin 56) :
-    cartanMatrixQ i a b = if a = b then (e7MinusculeWeight a i : ℚ) else 0 := by
-  rw [cartanMatrixQ, castMatrixLieHom_apply, cartanMatrix_apply]
+theorem cartanMatrixRat_apply (i : Fin 7) (a b : Fin 56) :
+    cartanMatrixRat i a b = if a = b then (e7MinusculeWeight a i : ℚ) else 0 := by
+  rw [cartanMatrixRat, castMatrixLieHom_apply, cartanMatrix_apply]
   split_ifs <;> norm_num
 
 private theorem ad_pow_int_eq_rat (x y : Matrix (Fin 56) (Fin 56) ℚ) (n : ℕ) :
@@ -112,56 +118,63 @@ private theorem ad_pow_int_eq_rat (x y : Matrix (Fin 56) (Fin 56) ℚ) (n : ℕ)
       exact ih ⁅x, y⁆
 
 /-- The rational minuscule matrices satisfy the type-`E₇` Serre relations. -/
-theorem isSerreSystemQ :
-    TauCeti.IsSerreSystem ℚ (CartanMatrix.E 7) cartanMatrixQ raisingMatrixQ loweringMatrixQ where
+theorem isSerreSystemRat :
+    TauCeti.IsSerreSystem ℚ (CartanMatrix.E 7)
+      cartanMatrixRat raisingMatrixRat loweringMatrixRat where
   lie_H_H i j := by
     have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_H i j)
-    simpa [cartanMatrixQ] using h
+    rw [LieHom.map_lie, map_zero] at h
+    simpa only [cartanMatrixRat] using h
   lie_E_F_self i := by
     have h := congrArg castMatrixLieHom (isSerreSystem.lie_E_F_self i)
-    simpa [raisingMatrixQ, loweringMatrixQ, cartanMatrixQ] using h
+    rw [LieHom.map_lie] at h
+    simpa only [raisingMatrixRat, loweringMatrixRat, cartanMatrixRat] using h
   lie_E_F_of_ne i j hij := by
     have h := congrArg castMatrixLieHom (isSerreSystem.lie_E_F_of_ne i j hij)
-    simpa [raisingMatrixQ, loweringMatrixQ] using h
+    rw [LieHom.map_lie, map_zero] at h
+    simpa only [raisingMatrixRat, loweringMatrixRat] using h
   lie_H_E i j := by
     have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_E i j)
     rw [LieHom.map_lie, map_zsmul] at h
-    simpa only [cartanMatrixQ, raisingMatrixQ, Int.cast_smul_eq_zsmul] using h
+    simpa only [cartanMatrixRat, raisingMatrixRat, Int.cast_smul_eq_zsmul] using h
   lie_H_F i j := by
     have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_F i j)
     rw [LieHom.map_lie, map_neg, map_zsmul] at h
-    simpa only [cartanMatrixQ, loweringMatrixQ, Int.cast_smul_eq_zsmul] using h
+    simpa only [cartanMatrixRat, loweringMatrixRat, Int.cast_smul_eq_zsmul] using h
   ad_pow_lie_E_E i j := by
     have h := congrArg castMatrixLieHom (isSerreSystem.ad_pow_lie_E_E i j)
-    rw [TauCeti.LieHom.map_ad_pow, map_zero] at h
+    rw [TauCeti.LieHom.map_ad_pow, LieHom.map_lie, map_zero] at h
     rw [← ad_pow_int_eq_rat]
-    simpa [raisingMatrixQ] using h
+    simpa only [raisingMatrixRat] using h
   ad_pow_lie_F_F i j := by
     have h := congrArg castMatrixLieHom (isSerreSystem.ad_pow_lie_F_F i j)
-    rw [TauCeti.LieHom.map_ad_pow, map_zero] at h
+    rw [TauCeti.LieHom.map_ad_pow, LieHom.map_lie, map_zero] at h
     rw [← ad_pow_int_eq_rat]
-    simpa [loweringMatrixQ] using h
+    simpa only [loweringMatrixRat] using h
 
 /-- The rational `56`-dimensional minuscule representation of the type-`E₇` Serre
 presentation. -/
 noncomputable def rationalSerreRepresentation :
     Matrix.ToLieAlgebra ℚ (CartanMatrix.E 7) →ₗ⁅ℚ⁆ Matrix (Fin 56) (Fin 56) ℚ :=
-  TauCeti.serreLift isSerreSystemQ
+  TauCeti.serreLift isSerreSystemRat
 
+/-- The rational Serre representation sends `H_i` to the rational Cartan matrix. -/
 @[simp]
 theorem rationalSerreRepresentation_serreH (i : Fin 7) :
-    rationalSerreRepresentation (TauCeti.serreH ℚ (CartanMatrix.E 7) i) = cartanMatrixQ i :=
-  TauCeti.serreLift_serreH isSerreSystemQ i
+    rationalSerreRepresentation (TauCeti.serreH ℚ (CartanMatrix.E 7) i) = cartanMatrixRat i :=
+  TauCeti.serreLift_serreH isSerreSystemRat i
 
+/-- The rational Serre representation sends `E_i` to the rational raising matrix. -/
 @[simp]
 theorem rationalSerreRepresentation_serreE (i : Fin 7) :
-    rationalSerreRepresentation (TauCeti.serreE ℚ (CartanMatrix.E 7) i) = raisingMatrixQ i :=
-  TauCeti.serreLift_serreE isSerreSystemQ i
+    rationalSerreRepresentation (TauCeti.serreE ℚ (CartanMatrix.E 7) i) = raisingMatrixRat i :=
+  TauCeti.serreLift_serreE isSerreSystemRat i
 
+/-- The rational Serre representation sends `F_i` to the rational lowering matrix. -/
 @[simp]
 theorem rationalSerreRepresentation_serreF (i : Fin 7) :
-    rationalSerreRepresentation (TauCeti.serreF ℚ (CartanMatrix.E 7) i) = loweringMatrixQ i :=
-  TauCeti.serreLift_serreF isSerreSystemQ i
+    rationalSerreRepresentation (TauCeti.serreF ℚ (CartanMatrix.E 7) i) = loweringMatrixRat i :=
+  TauCeti.serreLift_serreF isSerreSystemRat i
 
 /-! ## The enveloping-algebra representation -/
 
@@ -173,34 +186,22 @@ noncomputable def rep :
     ((Matrix.toLinAlgEquiv (Pi.basisFun ℚ (Fin 56))).toAlgHom.toLieHom.comp
       rationalSerreRepresentation)
 
+/-- The enveloping-algebra inclusion acts by multiplying with the represented matrix. -/
 theorem rep_ι_apply (x : Matrix.ToLieAlgebra ℚ (CartanMatrix.E 7)) (v : Fin 56 → ℚ) :
     rep (_root_.UniversalEnvelopingAlgebra.ι ℚ x) v = rationalSerreRepresentation x *ᵥ v := by
   rw [rep, _root_.UniversalEnvelopingAlgebra.lift_ι_apply, LieHom.comp_apply,
     AlgHom.toLieHom_apply, AlgEquiv.toAlgHom_apply, Matrix.toLinAlgEquiv_apply]
   exact (Pi.basisFun ℚ (Fin 56)).sum_repr (rationalSerreRepresentation x *ᵥ v)
 
-private theorem e7MinusculeWeight_reflection_apply_self (i : Fin 7) (a : Fin 56) :
-    e7MinusculeWeight (e7MinusculeReflection i a) i = -e7MinusculeWeight a i := by
-  have h := congrFun (e7MinusculeWeight_reflection i a) i
-  rw [root_e7SimpleIndex] at h
-  simp [CartanMatrix.E_diag] at h
-  omega
-
 /-- Every rational minuscule raising matrix squares to zero. -/
-theorem raisingMatrixQ_sq (i : Fin 7) : raisingMatrixQ i ^ 2 = 0 := by
-  ext a b
-  simp only [pow_two, Matrix.mul_apply, raisingMatrixQ_apply, Matrix.zero_apply]
-  by_cases hb : e7MinusculeWeight b i = -1
-  · simp [hb, e7MinusculeWeight_reflection_apply_self]
-  · simp [hb]
+theorem raisingMatrixRat_pow_two (i : Fin 7) : raisingMatrixRat i ^ 2 = 0 := by
+  change (Int.castRingHom ℚ).mapMatrix (raisingMatrix i) ^ 2 = 0
+  rw [pow_two, ← map_mul, raisingMatrix_mul_self, map_zero]
 
 /-- Every rational minuscule lowering matrix squares to zero. -/
-theorem loweringMatrixQ_sq (i : Fin 7) : loweringMatrixQ i ^ 2 = 0 := by
-  ext a b
-  simp only [pow_two, Matrix.mul_apply, loweringMatrixQ_apply, Matrix.zero_apply]
-  by_cases hb : e7MinusculeWeight b i = 1
-  · simp [hb, e7MinusculeWeight_reflection_apply_self]
-  · simp [hb]
+theorem loweringMatrixRat_pow_two (i : Fin 7) : loweringMatrixRat i ^ 2 = 0 := by
+  change (Int.castRingHom ℚ).mapMatrix (loweringMatrix i) ^ 2 = 0
+  rw [pow_two, ← map_mul, loweringMatrix_mul_self, map_zero]
 
 /-- Every simple-root generator acts with square zero in the rational minuscule
 representation. -/
@@ -213,13 +214,19 @@ theorem pow_two_rep_serreRootGenerator_eq_zero (k : Fin 7 ⊕ Fin 7) :
   | inl i =>
       rw [pow_two, Module.End.mul_apply, rep_ι_apply, rep_ι_apply,
         TauCeti.serreRootGenerator_inl, rationalSerreRepresentation_serreE,
-        Matrix.mulVec_mulVec, ← pow_two, raisingMatrixQ_sq, Matrix.zero_mulVec,
+        Matrix.mulVec_mulVec, ← pow_two, raisingMatrixRat_pow_two, Matrix.zero_mulVec,
         LinearMap.zero_apply]
   | inr i =>
       rw [pow_two, Module.End.mul_apply, rep_ι_apply, rep_ι_apply,
         TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF,
-        Matrix.mulVec_mulVec, ← pow_two, loweringMatrixQ_sq, Matrix.zero_mulVec,
+        Matrix.mulVec_mulVec, ← pow_two, loweringMatrixRat_pow_two, Matrix.zero_mulVec,
         LinearMap.zero_apply]
+
+/-- Every represented simple-root generator is nilpotent, with nilpotence index at most two. -/
+theorem isNilpotent_rep_serreRootGenerator (k : Fin 7 ⊕ Fin 7) :
+    IsNilpotent (rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+      (TauCeti.serreRootGenerator (CartanMatrix.E 7) k))) :=
+  ⟨2, pow_two_rep_serreRootGenerator_eq_zero k⟩
 
 /-! ## The admissible coordinate lattice -/
 
@@ -237,6 +244,8 @@ theorem mem_lattice_iff {v : Fin 56 → ℚ} :
 noncomputable def latticeBasis : Module.Basis (Fin 56) ℤ lattice :=
   TauCeti.coordinateLatticeBasis (Fin 56)
 
+/-- Coercing a lattice basis vector to the rational module gives the corresponding coordinate
+vector. -/
 @[simp]
 theorem coe_latticeBasis (a : Fin 56) :
     ((latticeBasis a : lattice) : Fin 56 → ℚ) = Pi.single a 1 := by
@@ -260,10 +269,10 @@ theorem rep_serreRootGenerator_mem_lattice (k : Fin 7 ⊕ Fin 7) {v : Fin 56 →
   rw [rep_ι_apply]
   cases k with
   | inl i =>
-      rw [TauCeti.serreRootGenerator_inl, rationalSerreRepresentation_serreE, raisingMatrixQ]
+      rw [TauCeti.serreRootGenerator_inl, rationalSerreRepresentation_serreE, raisingMatrixRat]
       exact castMatrix_mulVec_mem_lattice (raisingMatrix i) hv
   | inr i =>
-      rw [TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF, loweringMatrixQ]
+      rw [TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF, loweringMatrixRat]
       exact castMatrix_mulVec_mem_lattice (loweringMatrix i) hv
 
 /-- Each coordinate basis vector has the corresponding minuscule weight for the Cartan
@@ -277,8 +286,8 @@ theorem isCartanWeightVector_single (a : Fin 56) :
   ext b
   by_cases h : b = a
   · subst b
-    simp [Matrix.mulVec, dotProduct, cartanMatrixQ_apply, Pi.single_apply]
-  · simp [Matrix.mulVec, dotProduct, cartanMatrixQ_apply, Pi.single_apply, h]
+    simp [Matrix.mulVec, dotProduct, cartanMatrixRat_apply, Pi.single_apply]
+  · simp [Matrix.mulVec, dotProduct, cartanMatrixRat_apply, Pi.single_apply, h]
 
 /-- **The minuscule coordinate lattice is admissible for the type-`E₇` Serre Kostant form.** -/
 theorem rep_serreKostantForm_mem_lattice

--- a/TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean
@@ -30,8 +30,8 @@ the full-weight type-`E₇` Chevalley--Demazure carrier in Layer 9 of the Reduct
 * `TauCeti.E7Minuscule.isNilpotent_rep_serreRootGenerator`: the simple-root generators act
   nilpotently.
 * `TauCeti.E7Minuscule.lattice`: the coordinate `ℤ`-lattice in the rational module.
-* `TauCeti.E7Minuscule.rep_serreKostantForm_mem_lattice`: the Serre Kostant form preserves the
-  lattice.
+* `TauCeti.E7Minuscule.rep_serreKostantForm_apply_mem_lattice`: the Serre Kostant form preserves
+  the lattice.
 
 ## References
 
@@ -206,16 +206,25 @@ noncomputable def rep :
 /-- The enveloping-algebra inclusion acts by multiplying with the represented matrix. -/
 theorem rep_ι_apply (x : Matrix.ToLieAlgebra ℚ (CartanMatrix.E 7)) (v : Fin 56 → ℚ) :
     rep (_root_.UniversalEnvelopingAlgebra.ι ℚ x) v = rationalSerreRepresentation x *ᵥ v := by
-  rw [rep, _root_.UniversalEnvelopingAlgebra.lift_ι_apply, LieHom.comp_apply,
-    AlgHom.toLieHom_apply, AlgEquiv.toAlgHom_apply, Matrix.toLinAlgEquiv'_apply]
+  simp [rep]
+
+private theorem castMatrixLieHom_pow_two_eq_zero (M : Matrix (Fin 56) (Fin 56) ℤ)
+    (hM : M * M = 0) : castMatrixLieHom M ^ 2 = 0 := by
+  rw [pow_two, ← castMatrixLieHom_mul, hM, map_zero]
 
 /-- Every rational minuscule raising matrix squares to zero. -/
+@[simp]
 theorem raisingMatrixRat_pow_two (i : Fin 7) : raisingMatrixRat i ^ 2 = 0 := by
-  rw [pow_two, raisingMatrixRat, ← castMatrixLieHom_mul, raisingMatrix_mul_self, map_zero]
+  exact castMatrixLieHom_pow_two_eq_zero (raisingMatrix i) (raisingMatrix_mul_self i)
 
 /-- Every rational minuscule lowering matrix squares to zero. -/
+@[simp]
 theorem loweringMatrixRat_pow_two (i : Fin 7) : loweringMatrixRat i ^ 2 = 0 := by
-  rw [pow_two, loweringMatrixRat, ← castMatrixLieHom_mul, loweringMatrix_mul_self, map_zero]
+  exact castMatrixLieHom_pow_two_eq_zero (loweringMatrix i) (loweringMatrix_mul_self i)
+
+private theorem mulVec_pow_two_eq_zero (M : Matrix (Fin 56) (Fin 56) ℚ) (hM : M ^ 2 = 0)
+    (v : Fin 56 → ℚ) : M *ᵥ M *ᵥ v = 0 := by
+  rw [Matrix.mulVec_mulVec, ← pow_two, hM, Matrix.zero_mulVec]
 
 /-- Every simple-root generator acts with square zero in the rational minuscule
 representation. -/
@@ -224,17 +233,16 @@ theorem pow_two_rep_serreRootGenerator_eq_zero (k : Fin 7 ⊕ Fin 7) :
       (TauCeti.serreRootGenerator (CartanMatrix.E 7) k)) ^ 2 = 0 := by
   apply LinearMap.ext
   intro v
+  rw [pow_two, Module.End.mul_apply]
   cases k with
   | inl i =>
-      rw [pow_two, Module.End.mul_apply, rep_ι_apply, rep_ι_apply,
-        TauCeti.serreRootGenerator_inl, rationalSerreRepresentation_serreE,
-        Matrix.mulVec_mulVec, ← pow_two, raisingMatrixRat_pow_two, Matrix.zero_mulVec,
-        LinearMap.zero_apply]
+      simpa only [TauCeti.serreRootGenerator_inl, rep_ι_apply,
+        rationalSerreRepresentation_serreE, LinearMap.zero_apply] using
+        mulVec_pow_two_eq_zero (raisingMatrixRat i) (raisingMatrixRat_pow_two i) v
   | inr i =>
-      rw [pow_two, Module.End.mul_apply, rep_ι_apply, rep_ι_apply,
-        TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF,
-        Matrix.mulVec_mulVec, ← pow_two, loweringMatrixRat_pow_two, Matrix.zero_mulVec,
-        LinearMap.zero_apply]
+      simpa only [TauCeti.serreRootGenerator_inr, rep_ι_apply,
+        rationalSerreRepresentation_serreF, LinearMap.zero_apply] using
+        mulVec_pow_two_eq_zero (loweringMatrixRat i) (loweringMatrixRat_pow_two i) v
 
 /-- Every represented simple-root generator is nilpotent, with nilpotence index at most two. -/
 theorem isNilpotent_rep_serreRootGenerator (k : Fin 7 ⊕ Fin 7) :
@@ -276,7 +284,7 @@ private theorem castMatrix_mulVec_mem_lattice (M : Matrix (Fin 56) (Fin 56) ℤ)
     castMatrixLieHom_apply]
 
 /-- Every simple-root generator preserves the minuscule coordinate lattice. -/
-theorem rep_serreRootGenerator_mem_lattice (k : Fin 7 ⊕ Fin 7) {v : Fin 56 → ℚ}
+theorem rep_serreRootGenerator_apply_mem_lattice (k : Fin 7 ⊕ Fin 7) {v : Fin 56 → ℚ}
     (hv : v ∈ lattice) :
     rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
       (TauCeti.serreRootGenerator (CartanMatrix.E 7) k)) v ∈ lattice := by
@@ -304,7 +312,7 @@ theorem isCartanWeightVector_single (a : Fin 56) :
   · simp [Matrix.mulVec, dotProduct, cartanMatrixRat_apply, Pi.single_apply, h]
 
 /-- **The minuscule coordinate lattice is admissible for the type-`E₇` Serre Kostant form.** -/
-theorem rep_serreKostantForm_mem_lattice
+theorem rep_serreKostantForm_apply_mem_lattice
     {u : _root_.UniversalEnvelopingAlgebra ℚ
       (Matrix.ToLieAlgebra ℚ (CartanMatrix.E 7))}
     (hu : u ∈ TauCeti.serreKostantForm (CartanMatrix.E 7)) {v : Fin 56 → ℚ}
@@ -314,6 +322,6 @@ theorem rep_serreKostantForm_mem_lattice
     (TauCeti.serreRootGenerator (CartanMatrix.E 7))
     (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep
     (wt := e7MinusculeWeight) pow_two_rep_serreRootGenerator_eq_zero
-    (fun k _ hw ↦ rep_serreRootGenerator_mem_lattice k hw) isCartanWeightVector_single hu hv
+    (fun k _ hw ↦ rep_serreRootGenerator_apply_mem_lattice k hw) isCartanWeightVector_single hu hv
 
 end TauCeti.E7Minuscule

--- a/TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean
@@ -186,6 +186,7 @@ private theorem e7MinusculeWeight_reflection_apply_self (i : Fin 7) (a : Fin 56)
   simp [CartanMatrix.E_diag] at h
   omega
 
+/-- Every rational minuscule raising matrix squares to zero. -/
 theorem raisingMatrixQ_sq (i : Fin 7) : raisingMatrixQ i ^ 2 = 0 := by
   ext a b
   simp only [pow_two, Matrix.mul_apply, raisingMatrixQ_apply, Matrix.zero_apply]
@@ -193,6 +194,7 @@ theorem raisingMatrixQ_sq (i : Fin 7) : raisingMatrixQ i ^ 2 = 0 := by
   · simp [hb, e7MinusculeWeight_reflection_apply_self]
   · simp [hb]
 
+/-- Every rational minuscule lowering matrix squares to zero. -/
 theorem loweringMatrixQ_sq (i : Fin 7) : loweringMatrixQ i ^ 2 = 0 := by
   ext a b
   simp only [pow_two, Matrix.mul_apply, loweringMatrixQ_apply, Matrix.zero_apply]
@@ -200,6 +202,8 @@ theorem loweringMatrixQ_sq (i : Fin 7) : loweringMatrixQ i ^ 2 = 0 := by
   · simp [hb, e7MinusculeWeight_reflection_apply_self]
   · simp [hb]
 
+/-- Every simple-root generator acts with square zero in the rational minuscule
+representation. -/
 theorem pow_two_rep_serreRootGenerator_eq_zero (k : Fin 7 ⊕ Fin 7) :
     rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
       (TauCeti.serreRootGenerator (CartanMatrix.E 7) k)) ^ 2 = 0 := by
@@ -248,6 +252,7 @@ private theorem castMatrix_mulVec_mem_lattice (M : Matrix (Fin 56) (Fin 56) ℤ)
   simp only [Int.cast_sum, Int.cast_mul, hz, Matrix.mulVec, dotProduct,
     castMatrixLieHom_apply]
 
+/-- Every simple-root generator preserves the minuscule coordinate lattice. -/
 theorem rep_serreRootGenerator_mem_lattice (k : Fin 7 ⊕ Fin 7) {v : Fin 56 → ℚ}
     (hv : v ∈ lattice) :
     rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
@@ -261,6 +266,8 @@ theorem rep_serreRootGenerator_mem_lattice (k : Fin 7 ⊕ Fin 7) {v : Fin 56 →
       rw [TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF, loweringMatrixQ]
       exact castMatrix_mulVec_mem_lattice (loweringMatrix i) hv
 
+/-- Each coordinate basis vector has the corresponding minuscule weight for the Cartan
+generators. -/
 theorem isCartanWeightVector_single (a : Fin 56) :
     TauCeti.UniversalEnvelopingAlgebra.IsCartanWeightVector
       (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep (e7MinusculeWeight a) (Pi.single a 1) := by

--- a/TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean
@@ -58,21 +58,19 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 
 /-- Entrywise coercion from integral to rational matrices, as a homomorphism of Lie rings. -/
 private noncomputable def castMatrixLieHom :
-    Matrix (Fin 56) (Fin 56) ℤ →ₗ⁅ℤ⁆ Matrix (Fin 56) (Fin 56) ℚ where
-  toLinearMap := (Int.castRingHom ℚ).mapMatrix.toAddMonoidHom.toIntLinearMap
-  map_lie' := by
-    intro x y
-    -- Expose the matrix commutator so the ring-homomorphism laws can rewrite each product.
-    change (Int.castRingHom ℚ).mapMatrix (x * y - y * x) =
-      (Int.castRingHom ℚ).mapMatrix x * (Int.castRingHom ℚ).mapMatrix y -
-        (Int.castRingHom ℚ).mapMatrix y * (Int.castRingHom ℚ).mapMatrix x
-    rw [map_sub, map_mul, map_mul]
+    Matrix (Fin 56) (Fin 56) ℤ →ₗ⁅ℤ⁆ Matrix (Fin 56) (Fin 56) ℚ :=
+  ((Int.castRingHom ℚ).mapMatrix.toIntAlgHom).toLieHom
 
 @[simp]
 private theorem castMatrixLieHom_apply (M : Matrix (Fin 56) (Fin 56) ℤ) (a b : Fin 56) :
     castMatrixLieHom M a b = (M a b : ℚ) := by
-  change (Int.castRingHom ℚ).mapMatrix M a b = (M a b : ℚ)
-  rw [RingHom.mapMatrix_apply, Matrix.map_apply, Int.coe_castRingHom]
+  simp only [castMatrixLieHom, AlgHom.toLieHom_apply, RingHom.toIntAlgHom_apply,
+    RingHom.mapMatrix_apply, Matrix.map_apply, Int.coe_castRingHom]
+
+@[simp]
+private theorem castMatrixLieHom_mul (M N : Matrix (Fin 56) (Fin 56) ℤ) :
+    castMatrixLieHom (M * N) = castMatrixLieHom M * castMatrixLieHom N := by
+  exact map_mul ((Int.castRingHom ℚ).mapMatrix.toIntAlgHom) M N
 
 /-- The rational raising matrix obtained from the integral minuscule representation. -/
 noncomputable def raisingMatrixRat (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℚ :=
@@ -117,40 +115,59 @@ private theorem ad_pow_int_eq_rat (x y : Matrix (Fin 56) (Fin 56) ℚ) (n : ℕ)
       simp only [pow_succ, Module.End.mul_apply, LieAlgebra.ad_apply]
       exact ih ⁅x, y⁆
 
+private theorem cast_lie_eq_zero {x y : Matrix (Fin 56) (Fin 56) ℤ}
+    (h : ⁅x, y⁆ = 0) : ⁅castMatrixLieHom x, castMatrixLieHom y⁆ = 0 := by
+  rw [← LieHom.map_lie, h, map_zero]
+
+private theorem cast_lie_eq {x y z : Matrix (Fin 56) (Fin 56) ℤ}
+    (h : ⁅x, y⁆ = z) : ⁅castMatrixLieHom x, castMatrixLieHom y⁆ = castMatrixLieHom z := by
+  rw [← LieHom.map_lie, h]
+
+private theorem cast_lie_eq_smul {x y z : Matrix (Fin 56) (Fin 56) ℤ} (c : ℤ)
+    (h : ⁅x, y⁆ = c • z) :
+    ⁅castMatrixLieHom x, castMatrixLieHom y⁆ = c • castMatrixLieHom z := by
+  rw [← LieHom.map_lie, h, map_zsmul]
+
+private theorem cast_lie_eq_neg_smul {x y z : Matrix (Fin 56) (Fin 56) ℤ} (c : ℤ)
+    (h : ⁅x, y⁆ = -(c • z)) :
+    ⁅castMatrixLieHom x, castMatrixLieHom y⁆ = -(c • castMatrixLieHom z) := by
+  rw [← LieHom.map_lie, h, map_neg, map_zsmul]
+
+private theorem cast_ad_pow_lie_eq_zero {x y : Matrix (Fin 56) (Fin 56) ℤ} (n : ℕ)
+    (h : (LieAlgebra.ad ℤ _ x ^ n) ⁅x, y⁆ = 0) :
+    (LieAlgebra.ad ℚ _ (castMatrixLieHom x) ^ n)
+      ⁅castMatrixLieHom x, castMatrixLieHom y⁆ = 0 := by
+  have h' := congrArg castMatrixLieHom h
+  rw [TauCeti.LieHom.map_ad_pow, LieHom.map_lie, map_zero] at h'
+  rw [← ad_pow_int_eq_rat]
+  exact h'
+
 /-- The rational minuscule matrices satisfy the type-`E₇` Serre relations. -/
 theorem isSerreSystemRat :
     TauCeti.IsSerreSystem ℚ (CartanMatrix.E 7)
       cartanMatrixRat raisingMatrixRat loweringMatrixRat where
   lie_H_H i j := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_H i j)
-    rw [LieHom.map_lie, map_zero] at h
-    simpa only [cartanMatrixRat] using h
+    simpa only [cartanMatrixRat] using cast_lie_eq_zero (isSerreSystem.lie_H_H i j)
   lie_E_F_self i := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.lie_E_F_self i)
-    rw [LieHom.map_lie] at h
-    simpa only [raisingMatrixRat, loweringMatrixRat, cartanMatrixRat] using h
+    simpa only [raisingMatrixRat, loweringMatrixRat, cartanMatrixRat] using
+      cast_lie_eq (isSerreSystem.lie_E_F_self i)
   lie_E_F_of_ne i j hij := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.lie_E_F_of_ne i j hij)
-    rw [LieHom.map_lie, map_zero] at h
-    simpa only [raisingMatrixRat, loweringMatrixRat] using h
+    simpa only [raisingMatrixRat, loweringMatrixRat] using
+      cast_lie_eq_zero (isSerreSystem.lie_E_F_of_ne i j hij)
   lie_H_E i j := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_E i j)
-    rw [LieHom.map_lie, map_zsmul] at h
-    simpa only [cartanMatrixRat, raisingMatrixRat, Int.cast_smul_eq_zsmul] using h
+    simpa only [cartanMatrixRat, raisingMatrixRat] using
+      cast_lie_eq_smul (CartanMatrix.E 7 i j) (isSerreSystem.lie_H_E i j)
   lie_H_F i j := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_F i j)
-    rw [LieHom.map_lie, map_neg, map_zsmul] at h
-    simpa only [cartanMatrixRat, loweringMatrixRat, Int.cast_smul_eq_zsmul] using h
+    simpa only [cartanMatrixRat, loweringMatrixRat] using
+      cast_lie_eq_neg_smul (CartanMatrix.E 7 i j) (isSerreSystem.lie_H_F i j)
   ad_pow_lie_E_E i j := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.ad_pow_lie_E_E i j)
-    rw [TauCeti.LieHom.map_ad_pow, LieHom.map_lie, map_zero] at h
-    rw [← ad_pow_int_eq_rat]
-    simpa only [raisingMatrixRat] using h
+    simpa only [raisingMatrixRat] using
+      cast_ad_pow_lie_eq_zero (-(CartanMatrix.E 7) i j).toNat
+        (isSerreSystem.ad_pow_lie_E_E i j)
   ad_pow_lie_F_F i j := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.ad_pow_lie_F_F i j)
-    rw [TauCeti.LieHom.map_ad_pow, LieHom.map_lie, map_zero] at h
-    rw [← ad_pow_int_eq_rat]
-    simpa only [loweringMatrixRat] using h
+    simpa only [loweringMatrixRat] using
+      cast_ad_pow_lie_eq_zero (-(CartanMatrix.E 7) i j).toNat
+        (isSerreSystem.ad_pow_lie_F_F i j)
 
 /-- The rational `56`-dimensional minuscule representation of the type-`E₇` Serre
 presentation. -/
@@ -183,25 +200,22 @@ noncomputable def rep :
     _root_.UniversalEnvelopingAlgebra ℚ (Matrix.ToLieAlgebra ℚ (CartanMatrix.E 7)) →ₐ[ℚ]
       Module.End ℚ (Fin 56 → ℚ) :=
   _root_.UniversalEnvelopingAlgebra.lift ℚ
-    ((Matrix.toLinAlgEquiv (Pi.basisFun ℚ (Fin 56))).toAlgHom.toLieHom.comp
+    (Matrix.toLinAlgEquiv'.toAlgHom.toLieHom.comp
       rationalSerreRepresentation)
 
 /-- The enveloping-algebra inclusion acts by multiplying with the represented matrix. -/
 theorem rep_ι_apply (x : Matrix.ToLieAlgebra ℚ (CartanMatrix.E 7)) (v : Fin 56 → ℚ) :
     rep (_root_.UniversalEnvelopingAlgebra.ι ℚ x) v = rationalSerreRepresentation x *ᵥ v := by
   rw [rep, _root_.UniversalEnvelopingAlgebra.lift_ι_apply, LieHom.comp_apply,
-    AlgHom.toLieHom_apply, AlgEquiv.toAlgHom_apply, Matrix.toLinAlgEquiv_apply]
-  exact (Pi.basisFun ℚ (Fin 56)).sum_repr (rationalSerreRepresentation x *ᵥ v)
+    AlgHom.toLieHom_apply, AlgEquiv.toAlgHom_apply, Matrix.toLinAlgEquiv'_apply]
 
 /-- Every rational minuscule raising matrix squares to zero. -/
 theorem raisingMatrixRat_pow_two (i : Fin 7) : raisingMatrixRat i ^ 2 = 0 := by
-  change (Int.castRingHom ℚ).mapMatrix (raisingMatrix i) ^ 2 = 0
-  rw [pow_two, ← map_mul, raisingMatrix_mul_self, map_zero]
+  rw [pow_two, raisingMatrixRat, ← castMatrixLieHom_mul, raisingMatrix_mul_self, map_zero]
 
 /-- Every rational minuscule lowering matrix squares to zero. -/
 theorem loweringMatrixRat_pow_two (i : Fin 7) : loweringMatrixRat i ^ 2 = 0 := by
-  change (Int.castRingHom ℚ).mapMatrix (loweringMatrix i) ^ 2 = 0
-  rw [pow_two, ← map_mul, loweringMatrix_mul_self, map_zero]
+  rw [pow_two, loweringMatrixRat, ← castMatrixLieHom_mul, loweringMatrix_mul_self, map_zero]
 
 /-- Every simple-root generator acts with square zero in the rational minuscule
 representation. -/

--- a/TauCeti/Algebra/Lie/E7/Minuscule/Basic.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/Basic.lean
@@ -64,6 +64,8 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 def cartanMatrix (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℤ :=
   Matrix.diagonal fun a => e7MinusculeWeight a i
 
+/-- The matrix carrying a weight vector across the `i`th simple-reflection edge when its
+`i`th coordinate is `c`. -/
 private def stepMatrix (i : Fin 7) (c : ℤ) : Matrix (Fin 56) (Fin 56) ℤ :=
   fun a b => if e7MinusculeWeight b i = c ∧ a = e7MinusculeReflection i b then 1 else 0
 

--- a/TauCeti/Algebra/Lie/E7/Minuscule/Basic.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/Basic.lean
@@ -81,18 +81,21 @@ def raisingMatrix (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℤ :=
 def loweringMatrix (i : Fin 7) : Matrix (Fin 56) (Fin 56) ℤ :=
   stepMatrix i 1
 
+/-- The entrywise formula for the diagonal Cartan generator matrix. -/
 @[simp]
 theorem cartanMatrix_apply (i : Fin 7) (a b : Fin 56) :
     cartanMatrix i a b = if a = b then e7MinusculeWeight a i else 0 := by
   classical
   rw [cartanMatrix, Matrix.diagonal_apply]
 
+/-- The entrywise formula for the raising generator matrix. -/
 @[simp]
 theorem raisingMatrix_apply (i : Fin 7) (a b : Fin 56) :
     raisingMatrix i a b =
       if e7MinusculeWeight b i = -1 ∧ a = e7MinusculeReflection i b then 1 else 0 :=
   by rw [raisingMatrix, stepMatrix]
 
+/-- The entrywise formula for the lowering generator matrix. -/
 @[simp]
 theorem loweringMatrix_apply (i : Fin 7) (a b : Fin 56) :
     loweringMatrix i a b =
@@ -270,16 +273,19 @@ noncomputable def serreRepresentation :
     Matrix.ToLieAlgebra ℤ (CartanMatrix.E 7) →ₗ⁅ℤ⁆ Matrix (Fin 56) (Fin 56) ℤ :=
   serreLift isSerreSystem
 
+/-- The integral Serre representation sends `H_i` to the Cartan generator matrix. -/
 @[simp]
 theorem serreRepresentation_serreH (i : Fin 7) :
     serreRepresentation (serreH ℤ (CartanMatrix.E 7) i) = cartanMatrix i :=
   serreLift_serreH isSerreSystem i
 
+/-- The integral Serre representation sends `E_i` to the raising generator matrix. -/
 @[simp]
 theorem serreRepresentation_serreE (i : Fin 7) :
     serreRepresentation (serreE ℤ (CartanMatrix.E 7) i) = raisingMatrix i :=
   serreLift_serreE isSerreSystem i
 
+/-- The integral Serre representation sends `F_i` to the lowering generator matrix. -/
 @[simp]
 theorem serreRepresentation_serreF (i : Fin 7) :
     serreRepresentation (serreF ℤ (CartanMatrix.E 7) i) = loweringMatrix i :=

--- a/TauCeti/Algebra/Lie/E7/Minuscule/Basic.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/Basic.lean
@@ -20,9 +20,9 @@ generator `F_i` makes the reverse move when `lambda_i = 1`.
 
 The resulting integer matrices satisfy the Chevalley--Serre relations for the Bourbaki Cartan
 matrix. The universal property of the Serre presentation gives the explicit integral
-fifty-six-dimensional minuscule representation; extending scalars gives its rational form.
-Each raising and lowering matrix squares to zero, which is the divided-power input for the
-integral coordinate lattice.
+fifty-six-dimensional minuscule representation. Each raising and lowering matrix squares to
+zero. See `TauCeti.Algebra.Lie.E7.Minuscule.AdmissibleLattice` for the rational extension and
+the admissibility of its coordinate lattice.
 
 No identification with the abstract irreducible highest-weight module is asserted here. The
 construction is explicit: every matrix entry is read from the already audited weight and


### PR DESCRIPTION
This PR extends the audited integral 56-dimensional type-`E₇` minuscule Serre representation to `ℚ`, extends it to the universal enveloping algebra, and proves that the full Serre Kostant `ℤ`-form preserves its coordinate lattice. It advances the exact ReductiveGroups Layer 9 target “The Chevalley--Demazure construction,” within the milestone “pinned Chevalley--Demazure group schemes over `ℤ`,” by supplying the admissible full-weight lattice needed for the explicit simply connected type-`E₇` carrier.

The consumer is CFSGStatement milestone L0, “pinned ambient groups”: its type-`E₇` branch consumes the ReductiveGroups Layer 9 pinned simply connected carrier, whose Kostant toral closure needs both the full-character-lattice weight span already proved by `DynkinType.span_range_e7MinusculeWeight_eq_top` and the new stability theorem `E7Minuscule.rep_serreKostantForm_mem_lattice`.

After this PR, Layer 9 still needs to form the type-`E₇` toral-closure carrier and group scheme from this lattice, identify its root datum and reductivity, and supply its pinning, base change, points, and root-subgroup API before CFSGStatement L0 can consume it.

The proof reuses `UniversalEnvelopingAlgebra.kostantForm_apply_mem_coordinateLattice`: the integral Serre relations cast to the rational presentation, the root operators square to zero, and the coordinate basis consists of Cartan weight vectors. Its formal organization follows the parallel type-`E₆` admissible-lattice work in TauCetiProject/TauCeti#5204, specialized to the existing type-`E₇` Serre system; the mathematical conventions follow Bourbaki, Plate VI, Humphreys §§13 and 26--27, and Jantzen II.1--2, as credited in the module documentation. No Mathlib infrastructure is vendored.

The repository’s prefix-placement rule requires this module move:

| Old module | New module |
| --- | --- |
| `TauCeti.Algebra.Lie.E7.Minuscule` | `TauCeti.Algebra.Lie.E7.Minuscule.Basic` |

Add `TauCeti/Algebra/Lie/E7/Minuscule/AdmissibleLattice.lean` (289 lines) and move the existing 304-line basic module, adding only the private-helper docstring required when the moved module is re-linted.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e7-minuscule-admissible-lattice"}-->

🤖 Prepared with Codex
