### PR TITLE
feat: add exact cyclotomic character-table checker

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Cyclotomic/Checker.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Cyclotomic/Checker.lean
@@ -77,7 +77,7 @@ conjugacy classes and its columns by the conjugacy classes themselves. -/
 noncomputable def complexTableOfCyclotomic
     (table : Matrix (Fin d.numClasses) (Fin d.numClasses) (Cyclotomic e)) :
     Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ :=
-  d.complexTableOfMap Cyclotomic.complexEmbedding table
+  d.reindexTableOfMap Cyclotomic.complexEmbedding table
 
 /-- The embedded and reindexed cyclotomic table evaluated at arbitrary row and column indices. -/
 @[simp]
@@ -88,7 +88,7 @@ theorem complexTableOfCyclotomic_apply
       Cyclotomic.complexEmbedding
         (table ((finCongr d.numClasses_eq_card_conjClasses).symm i)
           (d.equivConjClasses.symm C)) :=
-  d.complexTableOfMap_apply Cyclotomic.complexEmbedding table i C
+  d.reindexTableOfMap_apply Cyclotomic.complexEmbedding table i C
 
 /-- The embedded and reindexed cyclotomic table evaluated at a numbered row and numbered class. -/
 theorem complexTableOfCyclotomic_apply_classOf
@@ -97,7 +97,7 @@ theorem complexTableOfCyclotomic_apply_classOf
     d.complexTableOfCyclotomic e table
         (finCongr d.numClasses_eq_card_conjClasses i) (d.classOf j) =
       Cyclotomic.complexEmbedding (table i j) :=
-  d.complexTableOfMap_apply_classOf Cyclotomic.complexEmbedding table i j
+  d.reindexTableOfMap_apply_classOf Cyclotomic.complexEmbedding table i j
 
 namespace IsCyclotomicCharacterTableSpec
 
@@ -119,7 +119,7 @@ theorem centralCharacterRow_complexTableOfCyclotomic
     centralCharacterRow (d.complexTableOfCyclotomic e table) i =
       d.reindexModularRow (fun j => Cyclotomic.complexEmbedding
         (omega ((finCongr d.numClasses_eq_card_conjClasses).symm i) j)) :=
-  IsExactCharacterTableSpec.centralCharacterRow_complexTableOfMap h
+  IsExactCharacterTableSpec.centralCharacterRow_reindexTableOfMap h
     Cyclotomic.complexEmbedding i
 
 /-- **A certified exact cyclotomic table satisfies the complex character-table specification.** -/

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Cyclotomic/Checker.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Cyclotomic/Checker.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ExactChecker
+public import TauCeti.RingTheory.Cyclotomic.Conjugation
+
+/-!
+# An exact checker for cyclotomic character tables
+
+The general stage of the Burnside--Dixon--Schneider algorithm returns central-character and
+ordinary character tables in the computable coefficient-vector ring `TauCeti.Cyclotomic e`.
+This file specializes the generic exact character-table certificate to that ring.  All certificate
+conditions, including Hermitian row orthogonality, are decidable computations on integer
+coefficient vectors.
+
+Only after the exact certificate has been checked is the table sent to `ℂ` through the
+distinguished cyclotomic embedding.  Exact conjugation commutes with that embedding, so the generic
+soundness bridge proves that the embedded table satisfies `TauCeti.IsCharacterTableSpec`.
+
+## Main definitions
+
+* `TauCeti.ClassData.IsCyclotomicCharacterTableSpec`: the exact numbered cyclotomic certificate.
+* `TauCeti.ClassData.cyclotomicCharacterTableChecker`: its executable Boolean checker.
+* `TauCeti.ClassData.complexTableOfCyclotomic`: embed and reindex an exact cyclotomic table.
+
+## Main result
+
+* `TauCeti.ClassData.IsCyclotomicCharacterTableSpec.isCharacterTableSpec`: a successful exact
+  cyclotomic certificate identifies the embedded output as the character table up to row order.
+
+This is the exact-checker step in Layer 6, “The assembled solver”, of the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md).
+-/
+
+public section
+
+namespace TauCeti
+
+namespace ClassData
+
+universe u
+
+variable {G : Type u} [Group G] [Fintype G] [DecidableEq G]
+variable (d : ClassData G)
+variable (e : ℕ) [NeZero e]
+
+/-- An exact character-table certificate specialized to `e`-th cyclotomic integer entries. -/
+abbrev IsCyclotomicCharacterTableSpec
+    (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) (Cyclotomic e))
+    (degree : Fin d.numClasses → ℕ) : Prop :=
+  d.IsExactCharacterTableSpec star omega table degree
+
+/-- The executable Boolean checker for an exact cyclotomic central-character table, ordinary
+table, and their character degrees. -/
+def cyclotomicCharacterTableChecker
+    (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) (Cyclotomic e))
+    (degree : Fin d.numClasses → ℕ) : Bool :=
+  d.exactCharacterTableChecker star omega table degree
+
+omit [NeZero e] in
+/-- The Boolean cyclotomic checker succeeds precisely when the exact cyclotomic certificate
+holds. -/
+@[simp]
+theorem cyclotomicCharacterTableChecker_eq_true_iff
+    (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) (Cyclotomic e))
+    (degree : Fin d.numClasses → ℕ) :
+    d.cyclotomicCharacterTableChecker e omega table degree = true ↔
+      d.IsCyclotomicCharacterTableSpec e omega table degree :=
+  d.exactCharacterTableChecker_eq_true_iff star omega table degree
+
+/-- Embed a numbered exact cyclotomic table into `ℂ`, reindexing its rows by the number of
+conjugacy classes and its columns by the conjugacy classes themselves. -/
+noncomputable def complexTableOfCyclotomic
+    (table : Matrix (Fin d.numClasses) (Fin d.numClasses) (Cyclotomic e)) :
+    Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ :=
+  d.complexTableOfMap Cyclotomic.complexEmbedding table
+
+/-- The embedded and reindexed cyclotomic table evaluated at arbitrary row and column indices. -/
+@[simp]
+theorem complexTableOfCyclotomic_apply
+    (table : Matrix (Fin d.numClasses) (Fin d.numClasses) (Cyclotomic e))
+    (i : Fin (Nat.card (ConjClasses G))) (C : ConjClasses G) :
+    d.complexTableOfCyclotomic e table i C =
+      Cyclotomic.complexEmbedding
+        (table ((finCongr d.numClasses_eq_card_conjClasses).symm i)
+          (d.equivConjClasses.symm C)) :=
+  d.complexTableOfMap_apply Cyclotomic.complexEmbedding table i C
+
+/-- The embedded and reindexed cyclotomic table evaluated at a numbered row and numbered class. -/
+theorem complexTableOfCyclotomic_apply_classOf
+    (table : Matrix (Fin d.numClasses) (Fin d.numClasses) (Cyclotomic e))
+    (i j : Fin d.numClasses) :
+    d.complexTableOfCyclotomic e table
+        (finCongr d.numClasses_eq_card_conjClasses i) (d.classOf j) =
+      Cyclotomic.complexEmbedding (table i j) :=
+  d.complexTableOfMap_apply_classOf Cyclotomic.complexEmbedding table i j
+
+namespace IsCyclotomicCharacterTableSpec
+
+variable {d : ClassData G} {e : ℕ} [NeZero e]
+variable {omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) (Cyclotomic e)}
+variable {degree : Fin d.numClasses → ℕ}
+variable (h : d.IsCyclotomicCharacterTableSpec e omega table degree)
+include h
+
+omit [NeZero e] in
+/-- The identity column of a certified cyclotomic table is its supplied degree vector. -/
+theorem table_index_one (i : Fin d.numClasses) : table i (d.index 1) = degree i :=
+  IsExactCharacterTableSpec.table_index_one h i
+
+/-- The normalized row of the embedded ordinary table is the corresponding embedded
+central-character row. -/
+theorem centralCharacterRow_complexTableOfCyclotomic
+    (i : Fin (Nat.card (ConjClasses G))) :
+    centralCharacterRow (d.complexTableOfCyclotomic e table) i =
+      d.reindexModularRow (fun j => Cyclotomic.complexEmbedding
+        (omega ((finCongr d.numClasses_eq_card_conjClasses).symm i) j)) :=
+  IsExactCharacterTableSpec.centralCharacterRow_complexTableOfMap h
+    Cyclotomic.complexEmbedding i
+
+/-- **A certified exact cyclotomic table satisfies the complex character-table specification.** -/
+theorem isCharacterTableSpec :
+    IsCharacterTableSpec G (d.complexTableOfCyclotomic e table) :=
+  IsExactCharacterTableSpec.isCharacterTableSpec h Cyclotomic.complexEmbedding
+    Cyclotomic.complexEmbedding_star
+
+end IsCyclotomicCharacterTableSpec
+
+end ClassData
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Cyclotomic/CyclicThree.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Cyclotomic/CyclicThree.lean
@@ -7,8 +7,8 @@ module
 
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.Cyclic
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.CentralCharacterCount
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Cyclotomic.Checker
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Lift
-public import TauCeti.RepresentationTheory.CharacterTable.Specification
 
 /-!
 # The cyclotomic Dixon computation for the cyclic group of order three
@@ -126,16 +126,6 @@ theorem cyclicGroupThreeDixonPrimeData_root : cyclicGroupThreeDixonPrimeData.roo
 /-- The numbered conjugacy classes of the cyclic group of order three. -/
 abbrev CyclicGroupThreeClassIndex := Fin (cyclicClassData 3).numClasses
 
-private def cyclicGroupThreeClassIndexEquiv : CyclicGroupThreeClassIndex ≃ Fin 3 :=
-  finCongr (numClasses_cyclicClassData 3)
-
-@[simp]
-private theorem cyclicGroupThreeClassIndexEquiv_symm_apply (i : Fin 3) :
-    cyclicGroupThreeClassIndexEquiv.symm i =
-      ⟨i, by simpa only [numClasses_cyclicClassData] using i.isLt⟩ := by
-  apply Fin.ext
-  rfl
-
 /-- **The exact central and ordinary character table of the cyclic group of order three.**
 Columns are the singleton classes of `0`, `1`, and `2` in that order. Row `i` is the linear
 character sending `Multiplicative.ofAdd j` to `ζ ^ (i * j)`, so rows index the irreducible
@@ -155,14 +145,6 @@ theorem cyclicGroupThreeExactCharacterTable_apply (i j : CyclicGroupThreeClassIn
     cyclicGroupThreeExactCharacterTable i j = Cyclotomic.zeta 3 ^ ((i : ℕ) * (j : ℕ)) := by
   fin_cases i <;> fin_cases j <;> decide
 
-private theorem cyclicGroupThreeExactCharacterTable_apply_reindex (i j : Fin 3) :
-    cyclicGroupThreeExactCharacterTable
-        (cyclicGroupThreeClassIndexEquiv.symm i)
-        (cyclicGroupThreeClassIndexEquiv.symm j) =
-      Cyclotomic.zeta 3 ^ ((i : ℕ) * (j : ℕ)) := by
-  rw [cyclicGroupThreeExactCharacterTable_apply]
-  rfl
-
 /-- Every exact row is normalized at the identity class. -/
 theorem cyclicGroupThreeExactCharacterTable_index_one (i : CyclicGroupThreeClassIndex) :
     cyclicGroupThreeExactCharacterTable i ((cyclicClassData 3).index 1) = 1 := by
@@ -174,6 +156,20 @@ theorem isModularEigenrow_cyclicGroupThreeExactCharacterTable
     (cyclicClassData 3).IsModularEigenrow (cyclicGroupThreeExactCharacterTable i) := by
   rw [(cyclicClassData 3).isModularEigenrow_iff]
   fin_cases i <;> decide
+
+/-- **The exact `C₃` table passes the cyclotomic character-table certificate.**  Its central and
+ordinary tables coincide and all three character degrees are one. -/
+theorem isCyclotomicCharacterTableSpec_cyclicGroupThree :
+    (cyclicClassData 3).IsCyclotomicCharacterTableSpec 3
+      cyclicGroupThreeExactCharacterTable cyclicGroupThreeExactCharacterTable (fun _ => 1) := by
+  decide
+
+/-- The executable exact cyclotomic checker accepts the displayed `C₃` table. -/
+theorem cyclotomicCharacterTableChecker_cyclicGroupThree :
+  (cyclicClassData 3).cyclotomicCharacterTableChecker 3
+      cyclicGroupThreeExactCharacterTable cyclicGroupThreeExactCharacterTable (fun _ => 1) = true :=
+  (cyclicClassData 3).cyclotomicCharacterTableChecker_eq_true_iff 3 _ _ _ |>.2
+    isCyclotomicCharacterTableSpec_cyclicGroupThree
 
 /-- The displayed exact rows reduced at the chosen primitive cube root modulo `7`. -/
 def cyclicGroupThreeModularCentralRows :
@@ -261,8 +257,7 @@ theorem cyclicGroupThreeExactCharacterTable_lift_conjugateResidues
 noncomputable def cyclicGroupThreeComplexCharacterTable :
     Matrix (Fin (Nat.card (ConjClasses (Multiplicative (ZMod 3)))))
       (ConjClasses (Multiplicative (ZMod 3))) ℂ :=
-  (cyclicClassData 3).reindexTableOfMap Cyclotomic.complexEmbedding
-    cyclicGroupThreeExactCharacterTable
+  (cyclicClassData 3).complexTableOfCyclotomic 3 cyclicGroupThreeExactCharacterTable
 
 /-- The embedded table evaluated at arbitrary row and conjugacy-class indices. -/
 @[simp]
@@ -274,7 +269,7 @@ theorem cyclicGroupThreeComplexCharacterTable_apply
         (cyclicGroupThreeExactCharacterTable
           ((finCongr (cyclicClassData 3).numClasses_eq_card_conjClasses).symm i)
           ((cyclicClassData 3).equivConjClasses.symm C)) := by
-  exact (cyclicClassData 3).reindexTableOfMap_apply _ _ _ _
+  exact (cyclicClassData 3).complexTableOfCyclotomic_apply 3 _ _ _
 
 /-- The embedded table evaluated at a numbered row and numbered conjugacy class. -/
 theorem cyclicGroupThreeComplexCharacterTable_apply_classOf
@@ -283,94 +278,13 @@ theorem cyclicGroupThreeComplexCharacterTable_apply_classOf
         (finCongr (cyclicClassData 3).numClasses_eq_card_conjClasses i)
         ((cyclicClassData 3).classOf j) =
       Cyclotomic.complexEmbedding (cyclicGroupThreeExactCharacterTable i j) := by
-  rw [cyclicGroupThreeComplexCharacterTable,
-    (cyclicClassData 3).reindexTableOfMap_apply_classOf]
-
-private theorem cyclicGroupThreeComplexCharacterTable_row_orthonormal
-    (i j : Fin (Nat.card (ConjClasses (Multiplicative (ZMod 3))))) :
-    ∑ C, Nat.card C.carrier * cyclicGroupThreeComplexCharacterTable i C *
-        star (cyclicGroupThreeComplexCharacterTable j C) =
-      if i = j then Nat.card (Multiplicative (ZMod 3)) else 0 := by
-  obtain ⟨i, rfl⟩ :=
-    (finCongr (cyclicClassData 3).numClasses_eq_card_conjClasses).surjective i
-  obtain ⟨j, rfl⟩ :=
-    (finCongr (cyclicClassData 3).numClasses_eq_card_conjClasses).surjective j
-  obtain ⟨i, rfl⟩ := cyclicGroupThreeClassIndexEquiv.symm.surjective i
-  obtain ⟨j, rfl⟩ := cyclicGroupThreeClassIndexEquiv.symm.surjective j
-  have hcard (k : CyclicGroupThreeClassIndex) :
-      Nat.card ((cyclicClassData 3).classOf k).carrier = 1 := by
-    rw [← (cyclicClassData 3).card_classFinset,
-      card_classFinset_cyclicClassData]
-  rw [← (cyclicClassData 3).equivConjClasses.sum_comp]
-  simp only [(cyclicClassData 3).equivConjClasses_apply,
-    cyclicGroupThreeComplexCharacterTable_apply_classOf, hcard, Nat.cast_one, one_mul,
-    Nat.card_eq_fintype_card, Fintype.card_multiplicative, ZMod.card]
-  simp only [Equiv.apply_eq_iff_eq]
-  rw [← cyclicGroupThreeClassIndexEquiv.symm.sum_comp, Fin.sum_univ_three]
-  simp only [cyclicGroupThreeExactCharacterTable_apply_reindex]
-  have hgeom : 1 + Cyclotomic.complexRoot 3 + Cyclotomic.complexRoot 3 ^ 2 = 0 := by
-    simpa [Finset.sum_range_succ] using
-      (Cyclotomic.isPrimitiveRoot_complexRoot (e := 3)).geom_sum_eq_zero (by norm_num)
-  have hred (n : ℕ) : Cyclotomic.complexRoot 3 ^ (n + 3) = Cyclotomic.complexRoot 3 ^ n := by
-    rw [pow_add, Cyclotomic.isPrimitiveRoot_complexRoot.pow_eq_one, mul_one]
-  -- Push the embedding onto `ζ` and rewrite each conjugated entry as a power of `ζ`, so that each
-  -- summand becomes a single power.  Reducing those exponents below `3` with `hred` leaves, in
-  -- each of the nine cases, either `1 + 1 + 1 = 3` or the vanishing geometric sum `hgeom`.
-  simp only [map_pow, Cyclotomic.complexEmbedding_zeta, RCLike.star_def, star_pow,
-    Cyclotomic.conj_complexRoot_eq_pow_sub_one, ← pow_mul, ← pow_add]
-  fin_cases i <;> fin_cases j <;> norm_num [hred] <;> linear_combination hgeom
+  exact (cyclicClassData 3).complexTableOfCyclotomic_apply_classOf 3 _ _ _
 
 /-- The embedded exact `C₃` table satisfies the character-table specification and therefore is
 the complex character table up to a permutation of rows. -/
 theorem isCharacterTableSpec_cyclicGroupThree :
     IsCharacterTableSpec (Multiplicative (ZMod 3))
-      cyclicGroupThreeComplexCharacterTable where
-  exists_degree i := by
-    refine ⟨1, by simp, ?_, by simp⟩
-    obtain ⟨i, rfl⟩ :=
-      (finCongr (cyclicClassData 3).numClasses_eq_card_conjClasses).surjective i
-    rw [← (cyclicClassData 3).classOf_index (1 : Multiplicative (ZMod 3)),
-      cyclicGroupThreeComplexCharacterTable_apply_classOf]
-    rw [cyclicGroupThreeExactCharacterTable_index_one, map_one]
-    norm_num
-  sum_degree_sq := by
-    rw [← (finCongr (cyclicClassData 3).numClasses_eq_card_conjClasses).sum_comp]
-    simp only [← (cyclicClassData 3).classOf_index (1 : Multiplicative (ZMod 3)),
-      cyclicGroupThreeComplexCharacterTable_apply_classOf]
-    simp_rw [cyclicGroupThreeExactCharacterTable_index_one, map_one]
-    norm_num [Nat.card_eq_fintype_card, numClasses_cyclicClassData]
-  row_orthonormal i j := by
-    calc
-      (Nat.card (Multiplicative (ZMod 3)) : ℂ)⁻¹ *
-          ∑ C, Nat.card C.carrier * cyclicGroupThreeComplexCharacterTable i C *
-            star (cyclicGroupThreeComplexCharacterTable j C) =
-          (Nat.card (Multiplicative (ZMod 3)) : ℂ)⁻¹ *
-            (if i = j then Nat.card (Multiplicative (ZMod 3)) else 0) := by
-        rw [cyclicGroupThreeComplexCharacterTable_row_orthonormal]
-      _ = if i = j then 1 else 0 := by
-        split_ifs <;> norm_num [natCard_cyclicGroup_three]
-  row_eigen i := by
-    obtain ⟨i, rfl⟩ :=
-      (finCongr (cyclicClassData 3).numClasses_eq_card_conjClasses).surjective i
-    have heig : IsClassEigenrow ((cyclicClassData 3).reindexModularRow fun j =>
-        Cyclotomic.complexEmbedding (cyclicGroupThreeExactCharacterTable i j)) :=
-      ((cyclicClassData 3).isModularEigenrow_iff_isClassEigenrow _).mp <|
-      (isModularEigenrow_cyclicGroupThreeExactCharacterTable i).map
-        (Cyclotomic.complexEmbedding : Cyclotomic 3 →+* ℂ)
-    suffices centralCharacterRow cyclicGroupThreeComplexCharacterTable
-        (finCongr (cyclicClassData 3).numClasses_eq_card_conjClasses i) =
-          (cyclicClassData 3).reindexModularRow fun j =>
-            Cyclotomic.complexEmbedding (cyclicGroupThreeExactCharacterTable i j) by
-      rwa [this]
-    funext C
-    obtain ⟨j, rfl⟩ := (cyclicClassData 3).equivConjClasses.surjective C
-    rw [centralCharacterRow_apply, (cyclicClassData 3).equivConjClasses_apply,
-      (cyclicClassData 3).reindexModularRow_classOf,
-      cyclicGroupThreeComplexCharacterTable_apply_classOf,
-      ← (cyclicClassData 3).classOf_index (1 : Multiplicative (ZMod 3)),
-      cyclicGroupThreeComplexCharacterTable_apply_classOf,
-      ← (cyclicClassData 3).card_classFinset,
-      card_classFinset_cyclicClassData, Nat.cast_one, one_mul,
-      cyclicGroupThreeExactCharacterTable_index_one, map_one, div_one]
+      cyclicGroupThreeComplexCharacterTable :=
+  isCyclotomicCharacterTableSpec_cyclicGroupThree.isCharacterTableSpec
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/ExactChecker.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/ExactChecker.lean
@@ -26,9 +26,6 @@ same proof serves both the integer-valued stage and the exact cyclotomic stage.
 * `TauCeti.ClassData.IsExactCharacterTableSpec`: an exact numbered certificate over a
   commutative star ring.
 * `TauCeti.ClassData.exactCharacterTableChecker`: its executable Boolean checker.
-* `TauCeti.ClassData.complexTableOfMap`: map an exact table to `ℂ` and reindex its columns by
-  conjugacy classes.
-
 ## Main result
 
 * `TauCeti.ClassData.IsExactCharacterTableSpec.isCharacterTableSpec`: a certified exact table
@@ -126,30 +123,6 @@ theorem exactCharacterTableChecker_eq_true_iff [DecidableEq R]
       d.IsExactCharacterTableSpec conj omega table degree := by
   simp [exactCharacterTableChecker]
 
-/-- Map a numbered exact table to `ℂ`, reindexing its rows by the number of conjugacy classes and
-its columns by the conjugacy classes themselves. -/
-noncomputable def complexTableOfMap (f : R →+* ℂ)
-    (table : Matrix (Fin d.numClasses) (Fin d.numClasses) R) :
-    Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ :=
-  d.reindexTableOfMap f table
-
-/-- The mapped and reindexed exact table evaluated at arbitrary row and column indices. -/
-@[simp]
-theorem complexTableOfMap_apply (f : R →+* ℂ)
-    (table : Matrix (Fin d.numClasses) (Fin d.numClasses) R)
-    (i : Fin (Nat.card (ConjClasses G))) (C : ConjClasses G) :
-    d.complexTableOfMap f table i C =
-      f (table ((finCongr d.numClasses_eq_card_conjClasses).symm i)
-        (d.equivConjClasses.symm C)) :=
-  d.reindexTableOfMap_apply f table i C
-
-/-- The mapped and reindexed exact table evaluated at a numbered row and numbered class. -/
-theorem complexTableOfMap_apply_classOf (f : R →+* ℂ)
-    (table : Matrix (Fin d.numClasses) (Fin d.numClasses) R) (i j : Fin d.numClasses) :
-    d.complexTableOfMap f table
-        (finCongr d.numClasses_eq_card_conjClasses i) (d.classOf j) = f (table i j) :=
-  d.reindexTableOfMap_apply_classOf f table i j
-
 namespace IsExactCharacterTableSpec
 
 variable {d : ClassData G}
@@ -173,9 +146,9 @@ private theorem central_eigen_map (f : R →+* ℂ) (i : Fin d.numClasses) :
 
 /-- The normalized row of the mapped ordinary table is the corresponding mapped central row,
 with both transported from the numbering of `d` to conjugacy classes. -/
-theorem centralCharacterRow_complexTableOfMap (f : R →+* ℂ)
+theorem centralCharacterRow_reindexTableOfMap (f : R →+* ℂ)
     (i : Fin (Nat.card (ConjClasses G))) :
-    centralCharacterRow (d.complexTableOfMap f table) i =
+    centralCharacterRow (d.reindexTableOfMap f table) i =
       d.reindexModularRow
         (fun j => f (omega ((finCongr d.numClasses_eq_card_conjClasses).symm i) j)) := by
   let i' := (finCongr d.numClasses_eq_card_conjClasses).symm i
@@ -185,9 +158,9 @@ theorem centralCharacterRow_complexTableOfMap (f : R →+* ℂ)
   have hdeg : (degree i' : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (h.degree_pos i').ne'
   have hconvert := congrArg f (h.degree_mul_central i' j)
   have htable (k : Fin d.numClasses) :
-      d.complexTableOfMap f table i (d.classOf k) = f (table i' k) := by
+      d.reindexTableOfMap f table i (d.classOf k) = f (table i' k) := by
     rw [← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply i,
-      d.complexTableOfMap_apply_classOf]
+      d.reindexTableOfMap_apply_classOf]
   rw [centralCharacterRow_apply, htable j, ← d.classOf_index (1 : G),
     htable (d.index 1), h.table_index_one, map_natCast, d.reindexModularRow_classOf,
     ← d.card_classFinset]
@@ -196,24 +169,24 @@ theorem centralCharacterRow_complexTableOfMap (f : R →+* ℂ)
 
 /-- The mapped rows of a certified exact table are orthonormal for the complex Hermitian
 character pairing. -/
-private theorem row_orthonormal_complexTableOfMap (f : R →+* ℂ)
+private theorem row_orthonormal_reindexTableOfMap (f : R →+* ℂ)
     (hf : ∀ x, f (conj x) = star (f x))
     (i j : Fin (Nat.card (ConjClasses G))) :
     (Nat.card G : ℂ)⁻¹ * ∑ C : ConjClasses G,
-        (Nat.card C.carrier : ℂ) * d.complexTableOfMap f table i C *
-          (starRingEnd ℂ) (d.complexTableOfMap f table j C) = if i = j then 1 else 0 := by
+        (Nat.card C.carrier : ℂ) * d.reindexTableOfMap f table i C *
+          (starRingEnd ℂ) (d.reindexTableOfMap f table j C) = if i = j then 1 else 0 := by
   let i' := (finCongr d.numClasses_eq_card_conjClasses).symm i
   let j' := (finCongr d.numClasses_eq_card_conjClasses).symm j
   have hsum := congrArg f (h.row_orthogonal i' j')
   have hG : (Fintype.card G : ℂ) ≠ 0 := by exact_mod_cast Fintype.card_pos.ne'
   have htable_i (k : Fin d.numClasses) :
-      d.complexTableOfMap f table i (d.classOf k) = f (table i' k) := by
+      d.reindexTableOfMap f table i (d.classOf k) = f (table i' k) := by
     rw [← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply i,
-      d.complexTableOfMap_apply_classOf]
+      d.reindexTableOfMap_apply_classOf]
   have htable_j (k : Fin d.numClasses) :
-      d.complexTableOfMap f table j (d.classOf k) = f (table j' k) := by
+      d.reindexTableOfMap f table j (d.classOf k) = f (table j' k) := by
     rw [← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply j,
-      d.complexTableOfMap_apply_classOf]
+      d.reindexTableOfMap_apply_classOf]
   simp only [Nat.card_eq_fintype_card]
   rw [← d.equivConjClasses.sum_comp]
   simp only [d.equivConjClasses_apply, htable_i, htable_j, starRingEnd_apply]
@@ -239,23 +212,23 @@ private theorem row_orthonormal_complexTableOfMap (f : R →+* ℂ)
 /-- **A certified exact table satisfies the complex character-table specification after mapping
 through a star-preserving ring homomorphism.** -/
 theorem isCharacterTableSpec (f : R →+* ℂ) (hf : ∀ x, f (conj x) = star (f x)) :
-    IsCharacterTableSpec G (d.complexTableOfMap f table) where
+    IsCharacterTableSpec G (d.reindexTableOfMap f table) where
   exists_degree i := by
     let i' := (finCongr d.numClasses_eq_card_conjClasses).symm i
     refine ⟨degree i', h.degree_pos i', ?_, ?_⟩
     · rw [← d.classOf_index (1 : G),
         ← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply i,
-        d.complexTableOfMap_apply_classOf, h.table_index_one, map_natCast]
+        d.reindexTableOfMap_apply_classOf, h.table_index_one, map_natCast]
     · simpa only [Nat.card_eq_fintype_card] using h.degree_dvd i'
   sum_degree_sq := by
     rw [@Nat.card_eq_fintype_card G, ← h.sum_degree_sq,
       ← (finCongr d.numClasses_eq_card_conjClasses).sum_comp]
-    simp only [← d.classOf_index (1 : G), d.complexTableOfMap_apply_classOf,
+    simp only [← d.classOf_index (1 : G), d.reindexTableOfMap_apply_classOf,
       h.table_index_one, map_natCast]
     exact_mod_cast rfl
-  row_orthonormal := h.row_orthonormal_complexTableOfMap f hf
+  row_orthonormal := h.row_orthonormal_reindexTableOfMap f hf
   row_eigen i := by
-    rw [h.centralCharacterRow_complexTableOfMap f i]
+    rw [h.centralCharacterRow_reindexTableOfMap f i]
     exact (d.isModularEigenrow_iff_isClassEigenrow _).mp
       (h.central_eigen_map f ((finCongr d.numClasses_eq_card_conjClasses).symm i))
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/ExactChecker.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/ExactChecker.lean
@@ -1,0 +1,266 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.EigenvectorSearch
+public import TauCeti.RepresentationTheory.CharacterTable.Specification
+
+/-!
+# Exact certificates for character tables
+
+This file gives a coefficient-independent certificate for the exact stage of the
+Burnside--Dixon--Schneider character-table algorithm.  A numbered central-character table and
+ordinary table over a commutative ring with a chosen conjugation are certified by division-free
+identities: normalized common eigenrows, positive degrees of the right total size,
+central-to-ordinary conversion, and Hermitian row orthogonality.
+
+The certificate is executable whenever equality in the coefficient ring is decidable.  Its
+soundness theorem is stated for a ring homomorphism to `ℂ` that preserves `star`; consequently the
+same proof serves both the integer-valued stage and the exact cyclotomic stage.
+
+## Main definitions
+
+* `TauCeti.ClassData.IsExactCharacterTableSpec`: an exact numbered certificate over a
+  commutative star ring.
+* `TauCeti.ClassData.exactCharacterTableChecker`: its executable Boolean checker.
+* `TauCeti.ClassData.complexTableOfMap`: map an exact table to `ℂ` and reindex its columns by
+  conjugacy classes.
+
+## Main result
+
+* `TauCeti.ClassData.IsExactCharacterTableSpec.isCharacterTableSpec`: a certified exact table
+  maps to the complex character-table specification under any star-preserving ring homomorphism.
+
+This is the checker bridge required by Layer 6, “The assembled solver”, of the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md).
+
+The certificate follows J. D. Dixon, *High speed computation of group characters*, Numer. Math.
+10 (1967), 446--450, and G. Schneider, *Dixon's character table algorithm revisited*, J. Symbolic
+Comput. 9 (1990), 601--606.
+-/
+
+public section
+
+namespace TauCeti
+
+open Matrix
+
+namespace ClassData
+
+universe u v
+
+variable {G : Type u} [Group G] [Fintype G] [DecidableEq G]
+variable (d : ClassData G)
+variable {R : Type v} [CommRing R]
+
+/-- **An exact certificate for a numbered character table over a commutative ring.**
+
+`omega` is the central-character table, `table` is the ordinary table, and `degree` gives their
+common row indexing of the character degrees.  The `conj` argument is the exact operation that
+maps to complex conjugation: it specializes to the identity over `ℤ` and to exact cyclotomic
+conjugation over a cyclotomic coefficient ring. -/
+structure IsExactCharacterTableSpec
+    (conj : R → R)
+    (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) R)
+    (degree : Fin d.numClasses → ℕ) : Prop where
+  /-- Every central-character row is normalized at the identity class. -/
+  central_one : ∀ i, omega i (d.index 1) = 1
+  /-- Every central-character row is a common left eigenrow of the class-multiplication matrices. -/
+  central_eigen : ∀ i, d.IsModularEigenrow (omega i)
+  /-- Character degrees are positive. -/
+  degree_pos : ∀ i, 0 < degree i
+  /-- Character degrees divide the group order. -/
+  degree_dvd : ∀ i, degree i ∣ Fintype.card G
+  /-- The squares of the character degrees sum to the group order. -/
+  sum_degree_sq : ∑ i, degree i ^ 2 = Fintype.card G
+  /-- Division-free conversion from the central table to the ordinary table. -/
+  degree_mul_central : ∀ i j,
+    (degree i : R) * omega i j = (d.classFinset j).card * table i j
+  /-- Class-size weighted Hermitian row orthogonality for the ordinary table. -/
+  row_orthogonal : ∀ i j,
+    ∑ k, (d.classFinset k).card * table i k * conj (table j k) =
+      if i = j then (Fintype.card G : R) else 0
+
+/-- The exact certificate is decidable when equality in the coefficient ring is decidable. -/
+instance instDecidableIsExactCharacterTableSpec [DecidableEq R]
+    (conj : R → R)
+    (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) R)
+    (degree : Fin d.numClasses → ℕ) :
+    Decidable (d.IsExactCharacterTableSpec conj omega table degree) :=
+  decidable_of_iff
+    ((∀ i, omega i (d.index 1) = 1) ∧
+      (∀ i a b, ∑ k, (d.structureConstant a b k : R) * omega i k =
+        omega i a * omega i b) ∧
+      (∀ i, 0 < degree i) ∧
+      (∀ i, degree i ∣ Fintype.card G) ∧
+      (∑ i, degree i ^ 2 = Fintype.card G) ∧
+      (∀ i j, (degree i : R) * omega i j = (d.classFinset j).card * table i j) ∧
+      (∀ i j, ∑ k, (d.classFinset k).card * table i k * conj (table j k) =
+        if i = j then (Fintype.card G : R) else 0))
+    ⟨fun h =>
+      ⟨h.1, fun i => (d.isModularEigenrow_iff (omega i)).mpr (h.2.1 i), h.2.2.1,
+        h.2.2.2.1, h.2.2.2.2.1, h.2.2.2.2.2.1, h.2.2.2.2.2.2⟩,
+      fun h =>
+        ⟨h.central_one, fun i => (d.isModularEigenrow_iff (omega i)).mp (h.central_eigen i),
+          h.degree_pos, h.degree_dvd, h.sum_degree_sq, h.degree_mul_central,
+          h.row_orthogonal⟩⟩
+
+/-- The executable Boolean checker for an exact central-character table, ordinary table, and
+their character degrees. -/
+def exactCharacterTableChecker [DecidableEq R]
+    (conj : R → R)
+    (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) R)
+    (degree : Fin d.numClasses → ℕ) : Bool :=
+  decide (d.IsExactCharacterTableSpec conj omega table degree)
+
+/-- The Boolean exact checker succeeds precisely when the exact certificate holds. -/
+@[simp]
+theorem exactCharacterTableChecker_eq_true_iff [DecidableEq R]
+    (conj : R → R)
+    (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) R)
+    (degree : Fin d.numClasses → ℕ) :
+    d.exactCharacterTableChecker conj omega table degree = true ↔
+      d.IsExactCharacterTableSpec conj omega table degree := by
+  simp [exactCharacterTableChecker]
+
+/-- Map a numbered exact table to `ℂ`, reindexing its rows by the number of conjugacy classes and
+its columns by the conjugacy classes themselves. -/
+noncomputable def complexTableOfMap (f : R →+* ℂ)
+    (table : Matrix (Fin d.numClasses) (Fin d.numClasses) R) :
+    Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ :=
+  d.reindexTableOfMap f table
+
+/-- The mapped and reindexed exact table evaluated at arbitrary row and column indices. -/
+@[simp]
+theorem complexTableOfMap_apply (f : R →+* ℂ)
+    (table : Matrix (Fin d.numClasses) (Fin d.numClasses) R)
+    (i : Fin (Nat.card (ConjClasses G))) (C : ConjClasses G) :
+    d.complexTableOfMap f table i C =
+      f (table ((finCongr d.numClasses_eq_card_conjClasses).symm i)
+        (d.equivConjClasses.symm C)) :=
+  d.reindexTableOfMap_apply f table i C
+
+/-- The mapped and reindexed exact table evaluated at a numbered row and numbered class. -/
+theorem complexTableOfMap_apply_classOf (f : R →+* ℂ)
+    (table : Matrix (Fin d.numClasses) (Fin d.numClasses) R) (i j : Fin d.numClasses) :
+    d.complexTableOfMap f table
+        (finCongr d.numClasses_eq_card_conjClasses i) (d.classOf j) = f (table i j) :=
+  d.reindexTableOfMap_apply_classOf f table i j
+
+namespace IsExactCharacterTableSpec
+
+variable {d : ClassData G}
+variable {conj : R → R}
+variable {omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) R}
+variable {degree : Fin d.numClasses → ℕ}
+variable (h : d.IsExactCharacterTableSpec conj omega table degree)
+include h
+
+/-- The identity column of a certified ordinary table is its supplied degree vector. -/
+theorem table_index_one (i : Fin d.numClasses) : table i (d.index 1) = (degree i : R) := by
+  have hcard : (d.classFinset (d.index 1)).card = 1 := by
+    rw [d.card_classFinset, d.classOf_index, ConjClasses.card_carrier_mk_one]
+  have hconvert := h.degree_mul_central i (d.index 1)
+  simpa only [h.central_one, mul_one, hcard, Nat.cast_one, one_mul] using hconvert.symm
+
+/-- Mapping a certified central row preserves the common-eigenrow condition. -/
+private theorem central_eigen_map (f : R →+* ℂ) (i : Fin d.numClasses) :
+    d.IsModularEigenrow (fun j => f (omega i j)) :=
+  (h.central_eigen i).map f
+
+/-- The normalized row of the mapped ordinary table is the corresponding mapped central row,
+with both transported from the numbering of `d` to conjugacy classes. -/
+theorem centralCharacterRow_complexTableOfMap (f : R →+* ℂ)
+    (i : Fin (Nat.card (ConjClasses G))) :
+    centralCharacterRow (d.complexTableOfMap f table) i =
+      d.reindexModularRow
+        (fun j => f (omega ((finCongr d.numClasses_eq_card_conjClasses).symm i) j)) := by
+  let i' := (finCongr d.numClasses_eq_card_conjClasses).symm i
+  funext C
+  obtain ⟨j, rfl⟩ := d.equivConjClasses.surjective C
+  rw [d.equivConjClasses_apply]
+  have hdeg : (degree i' : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (h.degree_pos i').ne'
+  have hconvert := congrArg f (h.degree_mul_central i' j)
+  have htable (k : Fin d.numClasses) :
+      d.complexTableOfMap f table i (d.classOf k) = f (table i' k) := by
+    rw [← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply i,
+      d.complexTableOfMap_apply_classOf]
+  rw [centralCharacterRow_apply, htable j, ← d.classOf_index (1 : G),
+    htable (d.index 1), h.table_index_one, map_natCast, d.reindexModularRow_classOf,
+    ← d.card_classFinset]
+  apply (div_eq_iff hdeg).2
+  simpa only [map_mul, map_natCast, mul_comm] using hconvert.symm
+
+/-- The mapped rows of a certified exact table are orthonormal for the complex Hermitian
+character pairing. -/
+private theorem row_orthonormal_complexTableOfMap (f : R →+* ℂ)
+    (hf : ∀ x, f (conj x) = star (f x))
+    (i j : Fin (Nat.card (ConjClasses G))) :
+    (Nat.card G : ℂ)⁻¹ * ∑ C : ConjClasses G,
+        (Nat.card C.carrier : ℂ) * d.complexTableOfMap f table i C *
+          (starRingEnd ℂ) (d.complexTableOfMap f table j C) = if i = j then 1 else 0 := by
+  let i' := (finCongr d.numClasses_eq_card_conjClasses).symm i
+  let j' := (finCongr d.numClasses_eq_card_conjClasses).symm j
+  have hsum := congrArg f (h.row_orthogonal i' j')
+  have hG : (Fintype.card G : ℂ) ≠ 0 := by exact_mod_cast Fintype.card_pos.ne'
+  have htable_i (k : Fin d.numClasses) :
+      d.complexTableOfMap f table i (d.classOf k) = f (table i' k) := by
+    rw [← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply i,
+      d.complexTableOfMap_apply_classOf]
+  have htable_j (k : Fin d.numClasses) :
+      d.complexTableOfMap f table j (d.classOf k) = f (table j' k) := by
+    rw [← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply j,
+      d.complexTableOfMap_apply_classOf]
+  simp only [Nat.card_eq_fintype_card]
+  rw [← d.equivConjClasses.sum_comp]
+  simp only [d.equivConjClasses_apply, htable_i, htable_j, starRingEnd_apply]
+  have hsum' :
+      (∑ k, (Fintype.card (d.classOf k).carrier : ℂ) * f (table i' k) *
+          star (f (table j' k))) =
+        if i' = j' then (Fintype.card G : ℂ) else 0 := by
+    have hcard (k : Fin d.numClasses) :
+        Fintype.card (d.classOf k).carrier = (d.classFinset k).card := by
+      rw [← Nat.card_eq_fintype_card, ← d.card_classFinset]
+    simp only [hcard]
+    by_cases hij' : i' = j'
+    · rw [ite_eq_left hij'] at hsum ⊢
+      simpa only [map_sum, map_mul, map_natCast, hf] using hsum
+    · rw [ite_eq_right hij'] at hsum ⊢
+      simpa only [map_sum, map_mul, map_natCast, map_zero, hf] using hsum
+  rw [hsum']
+  have hij : i' = j' ↔ i = j :=
+    (finCongr d.numClasses_eq_card_conjClasses).symm.injective.eq_iff
+  rw [if_congr hij rfl rfl]
+  split_ifs <;> simp [hG]
+
+/-- **A certified exact table satisfies the complex character-table specification after mapping
+through a star-preserving ring homomorphism.** -/
+theorem isCharacterTableSpec (f : R →+* ℂ) (hf : ∀ x, f (conj x) = star (f x)) :
+    IsCharacterTableSpec G (d.complexTableOfMap f table) where
+  exists_degree i := by
+    let i' := (finCongr d.numClasses_eq_card_conjClasses).symm i
+    refine ⟨degree i', h.degree_pos i', ?_, ?_⟩
+    · rw [← d.classOf_index (1 : G),
+        ← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply i,
+        d.complexTableOfMap_apply_classOf, h.table_index_one, map_natCast]
+    · simpa only [Nat.card_eq_fintype_card] using h.degree_dvd i'
+  sum_degree_sq := by
+    rw [@Nat.card_eq_fintype_card G, ← h.sum_degree_sq,
+      ← (finCongr d.numClasses_eq_card_conjClasses).sum_comp]
+    simp only [← d.classOf_index (1 : G), d.complexTableOfMap_apply_classOf,
+      h.table_index_one, map_natCast]
+    exact_mod_cast rfl
+  row_orthonormal := h.row_orthonormal_complexTableOfMap f hf
+  row_eigen i := by
+    rw [h.centralCharacterRow_complexTableOfMap f i]
+    exact (d.isModularEigenrow_iff_isClassEigenrow _).mp
+      (h.central_eigen_map f ((finCongr d.numClasses_eq_card_conjClasses).symm i))
+
+end IsExactCharacterTableSpec
+
+end ClassData
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/ExactChecker.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/ExactChecker.lean
@@ -24,8 +24,9 @@ same proof serves both the integer-valued stage and the exact cyclotomic stage.
 ## Main definitions
 
 * `TauCeti.ClassData.IsExactCharacterTableSpec`: an exact numbered certificate over a
-  commutative star ring.
+  commutative ring with a chosen conjugation operation.
 * `TauCeti.ClassData.exactCharacterTableChecker`: its executable Boolean checker.
+
 ## Main result
 
 * `TauCeti.ClassData.IsExactCharacterTableSpec.isCharacterTableSpec`: a certified exact table

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/IntegerChecker.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/IntegerChecker.lean
@@ -66,7 +66,7 @@ classes and its columns by the conjugacy classes themselves. -/
 noncomputable def complexTableOfInteger
     (table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ) :
     Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ :=
-  d.complexTableOfMap (Int.castRingHom ℂ) table
+  d.reindexTableOfMap (Int.castRingHom ℂ) table
 
 /-- The cast-and-reindexed integer table evaluated at arbitrary row and column indices. -/
 @[simp]
@@ -76,14 +76,14 @@ theorem complexTableOfInteger_apply
     d.complexTableOfInteger table i C =
       (table ((finCongr d.numClasses_eq_card_conjClasses).symm i)
         (d.equivConjClasses.symm C) : ℂ) :=
-  d.complexTableOfMap_apply (Int.castRingHom ℂ) table i C
+  d.reindexTableOfMap_apply (Int.castRingHom ℂ) table i C
 
 /-- The cast-and-reindexed integer table evaluated at a numbered row and numbered class. -/
 theorem complexTableOfInteger_apply_classOf
     (table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ) (i j : Fin d.numClasses) :
     d.complexTableOfInteger table
         (finCongr d.numClasses_eq_card_conjClasses i) (d.classOf j) = (table i j : ℂ) :=
-  d.complexTableOfMap_apply_classOf (Int.castRingHom ℂ) table i j
+  d.reindexTableOfMap_apply_classOf (Int.castRingHom ℂ) table i j
 
 namespace IsIntegerCharacterTableSpec
 
@@ -104,7 +104,7 @@ theorem centralCharacterRow_complexTableOfInteger
     centralCharacterRow (d.complexTableOfInteger table) i =
       d.reindexModularRow
         (fun j => (omega ((finCongr d.numClasses_eq_card_conjClasses).symm i) j : ℂ)) :=
-  IsExactCharacterTableSpec.centralCharacterRow_complexTableOfMap h (Int.castRingHom ℂ) i
+  IsExactCharacterTableSpec.centralCharacterRow_reindexTableOfMap h (Int.castRingHom ℂ) i
 
 /-- **A certified integer table satisfies the complex character-table specification.** -/
 theorem isCharacterTableSpec :

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/IntegerChecker.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/IntegerChecker.lean
@@ -5,49 +5,32 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.EigenvectorSearch
-public import TauCeti.RepresentationTheory.CharacterTable.Specification
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ExactChecker
 
 /-!
 # An exact checker for integer-valued character tables
 
-The rational stage of the Dixon--Schneider algorithm produces two integer matrices: the normalized
-central-character table `Ω` and the ordinary character table `X`. This file gives those numbered
-matrices an executable certificate and proves that a certified `X`, after casting to `ℂ` and
-reindexing its columns by conjugacy classes, satisfies `TauCeti.IsCharacterTableSpec`.
-
-The certificate checks exactly the division-free identities available to an exact computation:
-the central rows are normalized common eigenrows, positive integral degrees divide the group order
-and have the right square sum, `dᵢ Ωᵢⱼ = |Cⱼ| Xᵢⱼ`, and the rows of `X` satisfy class-size weighted
-orthogonality. No equality of complex numbers is evaluated by the checker.
+The rational stage of the Dixon--Schneider algorithm produces integer central-character and
+ordinary character tables.  This file specializes the coefficient-independent exact certificate
+from `TauCeti.RepresentationTheory.CharacterTable.Dixon.ExactChecker` to `ℤ`, where `star` is the
+identity, and preserves the integer-stage API used by the rational solver.
 
 ## Main definitions
 
-* `TauCeti.ClassData.IsIntegerCharacterTableSpec`: the exact numbered certificate.
+* `TauCeti.ClassData.IsIntegerCharacterTableSpec`: the exact numbered certificate over `ℤ`.
 * `TauCeti.ClassData.integerCharacterTableChecker`: its executable Boolean checker.
-* `TauCeti.ClassData.complexTableOfInteger`: the integer ordinary table, cast and reindexed into
-  the type expected by `TauCeti.IsCharacterTableSpec`.
+* `TauCeti.ClassData.complexTableOfInteger`: cast and reindex an integer table into the type
+  expected by `TauCeti.IsCharacterTableSpec`.
 
 ## Main result
 
-* `TauCeti.ClassData.IsIntegerCharacterTableSpec.isCharacterTableSpec`: a successful exact
-  certificate yields the complex character-table specification and therefore identifies the
-  result with the character table up to row permutation.
-
-## References
-
-This is the exact checker bridge required by Layer 6, “The assembled solver”, of the
-[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md).
-See J. D. Dixon, *High speed computation of group characters*, Numer. Math. 10 (1967), 446--450,
-and G. Schneider, *Dixon's character table algorithm revisited*, J. Symbolic Comput. 9 (1990),
-601--606.
+* `TauCeti.ClassData.IsIntegerCharacterTableSpec.isCharacterTableSpec`: a successful integer
+  certificate yields the complex character-table specification.
 -/
 
 public section
 
 namespace TauCeti
-
-open Matrix
 
 namespace ClassData
 
@@ -56,81 +39,36 @@ universe u
 variable {G : Type u} [Group G] [Fintype G] [DecidableEq G]
 variable (d : ClassData G)
 
-/-- **An exact certificate for an integer-valued character table.**
-
-The matrices use the numbering supplied by `d`. The matrix `omega` is the central-character table,
-`table` is the ordinary table, and `degree` is their common row indexing of the character degrees.
-All fields are decidable finite statements over `ℕ` and `ℤ`, so the certificate can be checked by
-kernel evaluation. -/
-structure IsIntegerCharacterTableSpec
+/-- An exact character-table certificate specialized to integer entries. -/
+abbrev IsIntegerCharacterTableSpec
     (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ)
-    (degree : Fin d.numClasses → ℕ) : Prop where
-  /-- Every central-character row is normalized at the identity class. -/
-  central_one : ∀ i, omega i (d.index 1) = 1
-  /-- Every central-character row is a common left eigenrow of the class-multiplication matrices. -/
-  central_eigen : ∀ i, d.IsModularEigenrow (omega i)
-  /-- Character degrees are positive. -/
-  degree_pos : ∀ i, 0 < degree i
-  /-- Character degrees divide the group order. -/
-  degree_dvd : ∀ i, degree i ∣ Fintype.card G
-  /-- The squares of the character degrees sum to the group order. -/
-  sum_degree_sq : ∑ i, degree i ^ 2 = Fintype.card G
-  /-- Division-free conversion from the central table to the ordinary table. -/
-  degree_mul_central : ∀ i j,
-    (degree i : ℤ) * omega i j = (d.classFinset j).card * table i j
-  /-- Class-size weighted row orthogonality for the ordinary table. -/
-  row_orthogonal : ∀ i j,
-    ∑ k, (d.classFinset k).card * table i k * table j k =
-      if i = j then (Fintype.card G : ℤ) else 0
-
-/-- The exact integer certificate is decidable, since every condition is a finite statement over
-`ℕ` or `ℤ`. -/
-instance instDecidableIsIntegerCharacterTableSpec
-    (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ)
-    (degree : Fin d.numClasses → ℕ) :
-    Decidable (d.IsIntegerCharacterTableSpec omega table degree) :=
-  decidable_of_iff
-    ((∀ i, omega i (d.index 1) = 1) ∧
-      (∀ i a b, ∑ k, (d.structureConstant a b k : ℤ) * omega i k =
-        omega i a * omega i b) ∧
-      (∀ i, 0 < degree i) ∧
-      (∀ i, degree i ∣ Fintype.card G) ∧
-      (∑ i, degree i ^ 2 = Fintype.card G) ∧
-      (∀ i j, (degree i : ℤ) * omega i j = (d.classFinset j).card * table i j) ∧
-      (∀ i j, ∑ k, (d.classFinset k).card * table i k * table j k =
-        if i = j then (Fintype.card G : ℤ) else 0))
-    ⟨fun h =>
-      ⟨h.1, fun i => (d.isModularEigenrow_iff (omega i)).mpr (h.2.1 i), h.2.2.1,
-        h.2.2.2.1, h.2.2.2.2.1, h.2.2.2.2.2.1, h.2.2.2.2.2.2⟩,
-      fun h =>
-        ⟨h.central_one, fun i => (d.isModularEigenrow_iff (omega i)).mp (h.central_eigen i),
-          h.degree_pos, h.degree_dvd, h.sum_degree_sq, h.degree_mul_central,
-          h.row_orthogonal⟩⟩
+    (degree : Fin d.numClasses → ℕ) : Prop :=
+  d.IsExactCharacterTableSpec (fun x => x) omega table degree
 
 /-- The executable Boolean checker for an integer central-character table, ordinary table, and
 their character degrees. -/
 def integerCharacterTableChecker
     (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ)
     (degree : Fin d.numClasses → ℕ) : Bool :=
-  decide (d.IsIntegerCharacterTableSpec omega table degree)
+  d.exactCharacterTableChecker (fun x => x) omega table degree
 
-/-- The Boolean exact checker succeeds precisely when the integer certificate holds. -/
+/-- The Boolean integer checker succeeds precisely when the integer certificate holds. -/
 @[simp]
 theorem integerCharacterTableChecker_eq_true_iff
     (omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ)
     (degree : Fin d.numClasses → ℕ) :
     d.integerCharacterTableChecker omega table degree = true ↔
-      d.IsIntegerCharacterTableSpec omega table degree := by
-  simp [integerCharacterTableChecker]
+      d.IsIntegerCharacterTableSpec omega table degree :=
+  d.exactCharacterTableChecker_eq_true_iff (fun x => x) omega table degree
 
 /-- Cast a numbered integer table to `ℂ`, reindexing its rows by the cardinality of the conjugacy
 classes and its columns by the conjugacy classes themselves. -/
 noncomputable def complexTableOfInteger
     (table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ) :
     Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ :=
-  d.reindexTableOfMap (Int.cast : ℤ → ℂ) table
+  d.complexTableOfMap (Int.castRingHom ℂ) table
 
-/-- The cast-and-reindexed integer table, evaluated at arbitrary row and column indices. -/
+/-- The cast-and-reindexed integer table evaluated at arbitrary row and column indices. -/
 @[simp]
 theorem complexTableOfInteger_apply
     (table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ)
@@ -138,14 +76,14 @@ theorem complexTableOfInteger_apply
     d.complexTableOfInteger table i C =
       (table ((finCongr d.numClasses_eq_card_conjClasses).symm i)
         (d.equivConjClasses.symm C) : ℂ) :=
-  d.reindexTableOfMap_apply _ table i C
+  d.complexTableOfMap_apply (Int.castRingHom ℂ) table i C
 
 /-- The cast-and-reindexed integer table evaluated at a numbered row and numbered class. -/
 theorem complexTableOfInteger_apply_classOf
     (table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ) (i j : Fin d.numClasses) :
-    d.complexTableOfInteger table (finCongr d.numClasses_eq_card_conjClasses i) (d.classOf j) =
-      (table i j : ℂ) :=
-  d.reindexTableOfMap_apply_classOf _ table i j
+    d.complexTableOfInteger table
+        (finCongr d.numClasses_eq_card_conjClasses i) (d.classOf j) = (table i j : ℂ) :=
+  d.complexTableOfMap_apply_classOf (Int.castRingHom ℂ) table i j
 
 namespace IsIntegerCharacterTableSpec
 
@@ -155,22 +93,9 @@ variable {degree : Fin d.numClasses → ℕ}
 variable (h : d.IsIntegerCharacterTableSpec omega table degree)
 include h
 
-/-- The identity column of a certified ordinary table is its supplied degree vector. This follows
-from the central-to-ordinary conversion at the identity class. -/
+/-- The identity column of a certified integer table is its supplied degree vector. -/
 theorem table_index_one (i : Fin d.numClasses) : table i (d.index 1) = degree i := by
-  have hcard : (d.classFinset (d.index 1)).card = 1 := by
-    rw [d.card_classFinset, d.classOf_index, ConjClasses.card_carrier_mk_one]
-  have hconvert := h.degree_mul_central i (d.index 1)
-  rw [h.central_one i, mul_one, hcard, Nat.cast_one, one_mul] at hconvert
-  exact_mod_cast hconvert.symm
-
-/-- Casting a certified integral central row to `ℂ` preserves the common-eigenrow condition. -/
-private theorem central_eigen_complex (i : Fin d.numClasses) :
-    d.IsModularEigenrow (fun j => (omega i j : ℂ)) := by
-  have hi := h.central_eigen i
-  rw [d.isModularEigenrow_iff] at hi ⊢
-  intro a b
-  exact_mod_cast hi a b
+  exact_mod_cast IsExactCharacterTableSpec.table_index_one h i
 
 /-- The normalized row of the cast ordinary table is the corresponding cast central-character
 row, with both transported from the numbering of `d` to conjugacy classes. -/
@@ -178,81 +103,13 @@ theorem centralCharacterRow_complexTableOfInteger
     (i : Fin (Nat.card (ConjClasses G))) :
     centralCharacterRow (d.complexTableOfInteger table) i =
       d.reindexModularRow
-        (fun j => (omega ((finCongr d.numClasses_eq_card_conjClasses).symm i) j : ℂ)) := by
-  let i' := (finCongr d.numClasses_eq_card_conjClasses).symm i
-  funext C
-  obtain ⟨j, rfl⟩ := d.equivConjClasses.surjective C
-  rw [d.equivConjClasses_apply]
-  have hdeg : (degree i' : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (h.degree_pos i').ne'
-  have hconvert := h.degree_mul_central i' j
-  have htable (k : Fin d.numClasses) :
-      d.complexTableOfInteger table i (d.classOf k) = (table i' k : ℂ) := by
-    rw [← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply i,
-      d.complexTableOfInteger_apply_classOf]
-  rw [centralCharacterRow_apply, htable j, ← d.classOf_index (1 : G),
-    htable (d.index 1), h.table_index_one, d.reindexModularRow_classOf,
-    ← d.card_classFinset]
-  apply (div_eq_iff hdeg).2
-  have hconvert' :
-      ((d.classFinset j).card : ℂ) * table i' j =
-        (degree i' : ℂ) * omega i' j := by
-    exact_mod_cast hconvert.symm
-  simpa only [mul_comm] using hconvert'
+        (fun j => (omega ((finCongr d.numClasses_eq_card_conjClasses).symm i) j : ℂ)) :=
+  IsExactCharacterTableSpec.centralCharacterRow_complexTableOfMap h (Int.castRingHom ℂ) i
 
-/-- **A certified integer table satisfies the complex character-table specification.** This is the
-soundness theorem for the exact checker: the only passage to `ℂ` occurs after every condition has
-been checked over decidable exact arithmetic. -/
+/-- **A certified integer table satisfies the complex character-table specification.** -/
 theorem isCharacterTableSpec :
-    IsCharacterTableSpec G (d.complexTableOfInteger table) where
-  exists_degree i := by
-    let i' := (finCongr d.numClasses_eq_card_conjClasses).symm i
-    refine ⟨degree i', h.degree_pos i', ?_, ?_⟩
-    · rw [← d.classOf_index (1 : G)]
-      rw [← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply i,
-        d.complexTableOfInteger_apply_classOf]
-      exact_mod_cast h.table_index_one i'
-    · simpa only [Nat.card_eq_fintype_card] using h.degree_dvd i'
-  sum_degree_sq := by
-    rw [@Nat.card_eq_fintype_card G]
-    rw [← h.sum_degree_sq]
-    rw [← (finCongr d.numClasses_eq_card_conjClasses).sum_comp]
-    simp only [← d.classOf_index (1 : G), d.complexTableOfInteger_apply_classOf,
-      h.table_index_one]
-    exact_mod_cast rfl
-  row_orthonormal i j := by
-    let i' := (finCongr d.numClasses_eq_card_conjClasses).symm i
-    let j' := (finCongr d.numClasses_eq_card_conjClasses).symm j
-    have hsum := h.row_orthogonal i' j'
-    have hG : (Fintype.card G : ℂ) ≠ 0 := by exact_mod_cast Fintype.card_pos.ne'
-    have htable_i (k : Fin d.numClasses) :
-        d.complexTableOfInteger table i (d.classOf k) = (table i' k : ℂ) := by
-      rw [← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply i,
-        d.complexTableOfInteger_apply_classOf]
-    have htable_j (k : Fin d.numClasses) :
-        d.complexTableOfInteger table j (d.classOf k) = (table j' k : ℂ) := by
-      rw [← (finCongr d.numClasses_eq_card_conjClasses).apply_symm_apply j,
-        d.complexTableOfInteger_apply_classOf]
-    simp only [Nat.card_eq_fintype_card]
-    rw [← d.equivConjClasses.sum_comp]
-    simp only [d.equivConjClasses_apply, htable_i, htable_j, map_intCast]
-    have hsum' :
-        (∑ k, (Fintype.card (d.classOf k).carrier : ℂ) * (table i' k : ℂ) *
-            (table j' k : ℂ)) =
-          if i' = j' then (Fintype.card G : ℂ) else 0 := by
-      have hcard (k : Fin d.numClasses) :
-          Fintype.card (d.classOf k).carrier = (d.classFinset k).card := by
-        rw [← Nat.card_eq_fintype_card, ← d.card_classFinset]
-      simp only [hcard]
-      exact_mod_cast hsum
-    rw [hsum']
-    have hij : i' = j' ↔ i = j :=
-      (finCongr d.numClasses_eq_card_conjClasses).symm.injective.eq_iff
-    rw [if_congr hij rfl rfl]
-    split_ifs <;> simp [hG]
-  row_eigen i := by
-    rw [h.centralCharacterRow_complexTableOfInteger i]
-    exact (d.isModularEigenrow_iff_isClassEigenrow _).mp
-      (h.central_eigen_complex ((finCongr d.numClasses_eq_card_conjClasses).symm i))
+    IsCharacterTableSpec G (d.complexTableOfInteger table) :=
+  IsExactCharacterTableSpec.isCharacterTableSpec h (Int.castRingHom ℂ) fun x => by simp
 
 end IsIntegerCharacterTableSpec
 


### PR DESCRIPTION
This PR adds an executable exact cyclotomic character-table certificate and proves that every certified table, after the distinguished embedding into `ℂ`, satisfies `IsCharacterTableSpec`. It advances `RepresentationTheory/CharacterTheory/README.md`, Layer 6, “The assembled solver”: that target requires `characterTableDixon` to return an exact cyclotomic table together with a checker certificate, including Hermitian row orthogonality before any passage to noncomputable complex numbers.

The implementation factors the coefficient-independent certificate and soundness bridge out of the existing integer checker as `ClassData.IsExactCharacterTableSpec`, with an explicit exact conjugation operation. The integer stage specializes it with the identity and retains its existing API; `ClassData.IsCyclotomicCharacterTableSpec` specializes it with the computable cyclotomic `star`. `cyclotomicCharacterTableChecker` is a genuine Boolean computation on coefficient vectors, while `IsCyclotomicCharacterTableSpec.isCharacterTableSpec` uses `Cyclotomic.complexEmbedding_star` only after the exact conditions have been checked.

The existing exact `C₃` table is a nontrivial witness: `isCyclotomicCharacterTableSpec_cyclicGroupThree` proves the certificate by kernel computation, `cyclotomicCharacterTableChecker_cyclicGroupThree` records that the Boolean checker returns `true`, and the former bespoke complex orthogonality/eigenrow proof is replaced by the general soundness bridge.

This is the most effective current critical-path step because good Dixon primes, modular common-eigenrow search, center splitting, structured conjugate-residue lifting, the rational solver, and the first exact `C₃` table are already on `main`, while exact cyclotomic conjugation landed specifically to make this certificate expressible. After this PR, Layer 6 still needs to assemble the modular search, structured cyclotomic lift, central-to-ordinary conversion, and degree recovery into the general `characterTableDixon` solver and prove `characterTable_eq`.

The certificate follows J. D. Dixon, *High speed computation of group characters*, Numer. Math. 10 (1967), 446–450, and G. Schneider, *Dixon's character table algorithm revisited*, J. Symbolic Comput. 9 (1990), 601–606. The refactor reuses the existing Tau Ceti integer checker and exact `C₃` computation; no Mathlib infrastructure or supplementary-source material is vendored.

The new files are `TauCeti/RepresentationTheory/CharacterTable/Dixon/ExactChecker.lean` (266 lines) and `TauCeti/RepresentationTheory/CharacterTable/Dixon/Cyclotomic/Checker.lean` (135 lines); the integer checker and `C₃` module are simplified around the shared API.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"cyclotomic-character-table-checker"}-->

🤖 Prepared with Codex
