### PR TITLE
feat: decompose Lie isotypic components

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Multiplicity.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Multiplicity.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.Lie.DirectSum
 public import TauCeti.Algebra.Lie.Multiplicity
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Isotypic
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Module
@@ -33,6 +34,11 @@ have the same finrank.
 * `LieModule.isotypicMultiplicity_eq_natCard_of_linearEquiv_pi`: for a finite decomposition of `M`
   into simple `U(L)`-modules, the multiplicity is the ring-level count of
   `TauCeti.finrank_linearMap_eq_natCard_of_linearEquiv_pi`.
+* `LieModule.nonempty_lieModuleEquiv_isotypicComponent`: **an isotypic component is a finite
+  power of its irreducible type, with exponent its multiplicity**;
+  `LieModule.nonempty_lieModuleEquiv_of_isotypicComponent_eq_top` and
+  `LieModule.nonempty_lieModuleEquiv_of_isIsotypicOfType` give the corresponding decomposition
+  of the whole module.
 * `LieModule.finrank_isotypicComponent`: **the dimension of an isotypic component is the
   multiplicity times the dimension of its type**;
   `LieModule.finrank_of_isotypicComponent_eq_top`: for a module its own isotypic component, that
@@ -40,32 +46,34 @@ have the same finrank.
   `LieModule.finrank_of_isIsotypicOfType`: the same for a completely reducible module which is
   itself isotypic.
 
-## The dimension of an isotypic component
+## The structure of an isotypic component
 
-`LieModule.finrank_isotypicComponent` is a statement of Lie module theory alone — no enveloping
-algebra occurs in it — but its proof runs through the dictionary, which is why it lives here
-rather than in `TauCeti/Algebra/Lie/Multiplicity.lean`: the isotypic component is carried to
-Mathlib's `isotypicComponent` over `U(L)` by
+The structural equivalence and its numerical consequence are statements of Lie module theory
+alone — no enveloping algebra occurs in them — but their proofs run through the dictionary, which
+is why they live here rather than in `TauCeti/Algebra/Lie/Multiplicity.lean`: the isotypic
+component is carried to Mathlib's `isotypicComponent` over `U(L)` by
 `LieModule.lieSubmoduleOrderIso_isotypicComponent`, where
-`TauCeti.finrank_isotypicComponent` computes its dimension. The two hypotheses are the ones that
-statement needs, finite-dimensionality of `M` and of the irreducible `S`; complete reducibility of
-`M` is not among them, an isotypic component being a sum of copies of `S` in any case. It is not
-needed either for `LieModule.finrank_of_isotypicComponent_eq_top`, which reads off the dimension of
-a module its own `S`-isotypic component; it is needed only to reach that hypothesis from isotypy,
-which is what `LieModule.finrank_of_isIsotypicOfType` does.
+`TauCeti.nonempty_linearEquiv_isotypicComponent` identifies it with the appropriate power of its
+type and `TauCeti.finrank_isotypicComponent` computes its dimension. The two hypotheses are the
+ones those statements need, finite-dimensionality of `M` and of the irreducible `S`; complete
+reducibility of `M` is not among them, an isotypic component being a sum of copies of `S` in any
+case. It is needed only to deduce that an isotypic module is exhausted by this component.
 
 ## Roadmap
 
 This is the enveloping-algebra bridge for the `isotypicMultiplicity` target of the decomposition
 toolkit in Layer 6 of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`, in the same
 role that `TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean` plays for the isotypic component.
-`LieModule.finrank_isotypicComponent` is that milestone's `finrank_isotypicComponent` target,
-"the finrank identity `dim (isotypic component) = m_λ · dim L(λ)`".
+`LieModule.nonempty_lieModuleEquiv_isotypicComponent` supplies the structural `L(λ)^{⊕m_λ}`
+factor needed by that milestone's packaged decomposition, while
+`LieModule.finrank_isotypicComponent` is its `finrank_isotypicComponent` target, "the finrank
+identity `dim (isotypic component) = m_λ · dim L(λ)`".
 -/
 
 public section
 
 open UniversalEnvelopingAlgebra
+open scoped DirectSum
 
 universe u v w w₁
 
@@ -127,7 +135,7 @@ theorem isotypicMultiplicity_eq_natCard_of_linearEquiv_pi
 
 end Count
 
-/-! ### The dimension of an isotypic component -/
+/-! ### The structure of an isotypic component -/
 
 section IsotypicComponent
 
@@ -137,6 +145,75 @@ variable [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
 variable [FiniteDimensional K M]
 
 open Module (finrank)
+
+local notation "U" => _root_.UniversalEnvelopingAlgebra K L
+
+/-- **An isotypic component is the power of its irreducible type counted by its multiplicity.**
+For a finite-dimensional Lie module `M` over an algebraically closed field and a
+finite-dimensional irreducible `S`, its `S`-isotypic component is Lie-equivalent to
+the direct sum of `isotypicMultiplicity K L M S` copies of `S`.
+
+The equivalence is obtained from the corresponding ring-level result for `U(L)`: the submodule
+dictionary identifies the two isotypic components, the homomorphism dictionary identifies their
+multiplicities, and the equivalence dictionary transports the resulting `U(L)`-linear
+equivalence back to Lie modules. Complete reducibility of `M` is not required. -/
+theorem nonempty_lieModuleEquiv_isotypicComponent
+    (S : Type w₁) [AddCommGroup S] [Module K S] [LieRingModule L S]
+    [LieModule K L S] [FiniteDimensional K S] [IsIrreducible K L S] :
+    Nonempty (isotypicComponent K L M S ≃ₗ⁅K,L⁆
+      (⨁ (_ : Fin (isotypicMultiplicity K L M S)), S)) := by
+  let := asModule K L M
+  let := isScalarTower_asModule K L M
+  let := asModule K L S
+  let := isScalarTower_asModule K L S
+  have hM := asModule_ι_smul K L M
+  have hS := asModule_ι_smul K L S
+  let : IsSimpleModule U S := (isIrreducible_iff_isSimpleModule hS).mp inferInstance
+  let := asModule K L (isotypicComponent K L M S)
+  let := isScalarTower_asModule K L (isotypicComponent K L M S)
+  obtain ⟨e⟩ := TauCeti.nonempty_linearEquiv_isotypicComponent
+    (k := K) (A := U) (M := M) (S := S)
+  rw [← lieSubmoduleOrderIso_isotypicComponent hM S hS,
+    ← isotypicMultiplicity_eq_finrank_linearMap_of_ι_smul hM S hS] at e
+  have hsum : ∀ (x : L) (s : ⨁ (_ : Fin (isotypicMultiplicity K L M S)), S),
+      ι K x • s = ⁅x, s⁆ := by
+    intro x s
+    ext i
+    simp only [DirectSum.lie_module_bracket_apply]
+    exact hS x (s i)
+  exact ⟨(lieModuleEquivEquivLinearEquiv
+    (asModule_ι_smul K L (isotypicComponent K L M S))
+    hsum).symm
+      ((lieSubmoduleLinearEquiv hM (isotypicComponent K L M S)).trans e |>.trans
+        (DFinsupp.linearEquivFunOnFintype (R := U)).symm)⟩
+
+/-- **A module exhausted by an isotypic component is the corresponding power of its type.**
+If the `S`-isotypic component is all of `M`, then `M` is Lie-equivalent to the direct sum of
+`isotypicMultiplicity K L M S` copies of `S`. No complete reducibility hypothesis is needed. -/
+theorem nonempty_lieModuleEquiv_of_isotypicComponent_eq_top
+    (S : Type w₁) [AddCommGroup S] [Module K S] [LieRingModule L S]
+    [LieModule K L S] [FiniteDimensional K S] [IsIrreducible K L S]
+    (h : isotypicComponent K L M S = ⊤) :
+    Nonempty (M ≃ₗ⁅K,L⁆ (⨁ (_ : Fin (isotypicMultiplicity K L M S)), S)) := by
+  obtain ⟨e⟩ := nonempty_lieModuleEquiv_isotypicComponent (K := K) (L := L) (M := M) S
+  rw [h] at e
+  exact ⟨(LieModuleEquiv.ofTop K L M).symm.trans e⟩
+
+/-- **A completely reducible isotypic module is the power of its irreducible type counted by its
+multiplicity.** If every irreducible Lie submodule of `M` is equivalent to `S`, then `M` is
+Lie-equivalent to the direct sum of `isotypicMultiplicity K L M S` copies of `S`. -/
+theorem nonempty_lieModuleEquiv_of_isIsotypicOfType
+    (S : Type w₁) [AddCommGroup S] [Module K S] [LieRingModule L S]
+    [LieModule K L S] [FiniteDimensional K S] [IsIrreducible K L S]
+    [ComplementedLattice (LieSubmodule K L M)] (h : IsIsotypicOfType K L M S) :
+    Nonempty (M ≃ₗ⁅K,L⁆ (⨁ (_ : Fin (isotypicMultiplicity K L M S)), S)) := by
+  let := asModule K L M
+  let := isScalarTower_asModule K L M
+  let := asModule K L S
+  let := isScalarTower_asModule K L S
+  exact nonempty_lieModuleEquiv_of_isotypicComponent_eq_top (K := K) (L := L) S
+    ((isotypicComponent_eq_top_iff_of_ι_smul (asModule_ι_smul K L M) S
+      (asModule_ι_smul K L S)).mpr h)
 
 /-- **The dimension of an isotypic component is the multiplicity times the dimension of its
 type.** For a finite-dimensional Lie module `M` over an algebraically closed field and a
@@ -150,23 +227,9 @@ of `S` whether or not `M` itself is completely reducible. -/
 theorem finrank_isotypicComponent (S : Type w₁) [AddCommGroup S] [Module K S] [LieRingModule L S]
     [LieModule K L S] [FiniteDimensional K S] [IsIrreducible K L S] :
     finrank K (isotypicComponent K L M S) = isotypicMultiplicity K L M S * finrank K S := by
-  let := asModule K L M
-  let := isScalarTower_asModule K L M
-  let := asModule K L S
-  let := isScalarTower_asModule K L S
-  have hM := asModule_ι_smul K L M
-  have hS := asModule_ι_smul K L S
-  have : IsSimpleModule (_root_.UniversalEnvelopingAlgebra K L) S :=
-    (isIrreducible_iff_isSimpleModule hS).mp inferInstance
-  have hrank : finrank K (isotypicComponent K L M S) =
-      finrank K ↥(_root_.isotypicComponent (_root_.UniversalEnvelopingAlgebra K L) M S) := by
-    let := asModule K L (isotypicComponent K L M S)
-    let := isScalarTower_asModule K L (isotypicComponent K L M S)
-    have h :=
-      ((lieSubmoduleLinearEquiv hM (isotypicComponent K L M S)).restrictScalars K).finrank_eq
-    rwa [lieSubmoduleOrderIso_isotypicComponent hM S hS] at h
-  rw [hrank, isotypicMultiplicity_eq_finrank_linearMap_of_ι_smul hM S hS,
-    TauCeti.finrank_isotypicComponent (k := K)]
+  obtain ⟨e⟩ := nonempty_lieModuleEquiv_isotypicComponent (K := K) (L := L) (M := M) S
+  rw [e.toLinearEquiv.finrank_eq, Module.finrank_directSum]
+  simp
 
 /-- **A module exhausted by an isotypic component has dimension the multiplicity times the
 dimension of its type.** This is the numerical content of `M ≅ S^{⊕ m}`, and it needs nothing of


### PR DESCRIPTION
This PR packages the next structural step in the RepresentationTheory `LieHighestWeight` Layer 6 decomposition toolkit: identify each Lie isotypic component with the direct sum of exactly `isotypicMultiplicity K L M S` copies of its irreducible type, and expose the corresponding whole-module forms when the component is top or the module is completely reducible and isotypic.

It advances the milestone's exact target, the packaged decomposition `M ≅ ⊕_λ L(λ)^{⊕ m_λ}`, by supplying its counted `L(λ)^{⊕ m_λ}` factors through the named universal-enveloping-algebra dictionary. After this PR, the milestone still needs the global finite indexing and assembly of those factors into the single decomposition of `M` over all irreducible highest weights.

The proof reuses `TauCeti.nonempty_linearEquiv_isotypicComponent`, transports the component and multiplicity through the existing `U(L)` dictionary, and converts the finite power to Mathlib's external direct sum. The existing finrank identity is simplified to a consequence of the new structural equivalence. No supplementary snapshot material is migrated and no Mathlib infrastructure is vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"nonempty-liemoduleequiv-isotypiccomponent"}-->

🤖 Prepared with Codex
