### PR TITLE
fix: a release main has not reached yet is not unreachable

### DIFF
--- a/docs/toolchain-tags.md
+++ b/docs/toolchain-tags.md
@@ -23,8 +23,10 @@ the recorded CI result and the published cache; neither needs a rebuild.
 
 ## What it does not cover
 
-The tool tags only commits on `main`, and reports a release `main` never ran on as
-`unreachable`. Two things cause that, and they differ in what can be done about them: the
+The tool tags only commits on `main`. A release mathlib has tagged but `main` has not
+reached yet is reported `ahead`: nothing is wrong, the bump has not got there, and it will
+be tagged like any other release when it does. A release `main` went past without stopping
+is reported `unreachable`. Two things cause that, and they differ in what can be done about them: the
 daily bump stepped over the release's window on Mathlib master, which a later bump could
 avoid, or Mathlib cut the release on its `stable` branch, which `check-bump.sh` will not let
 this repository pin at all.

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -302,6 +302,43 @@ class Digest(unittest.TestCase):
         self.assertEqual(tt.state_digest(self.ROWS), tt.state_digest(worded))
 
 
+class AheadOfMain(unittest.TestCase):
+    """A release mathlib has tagged but main has not reached is not `unreachable`.
+
+    `unreachable` reads as permanent and the report files it under "no tag is possible".
+    For a release ahead of main that is the opposite of the truth, and it is the normal
+    state for days or weeks after mathlib cuts one, so it was the commonest thing the
+    report said and it was wrong."""
+
+    def test_a_release_ahead_of_main_is_ahead_not_unreachable(self):
+        row = tt._unreachable_row("v4.34.0-rc2", {}, newest_era="v4.34.0-rc1")
+        self.assertEqual(row["status"], "ahead")
+        self.assertIn("still on v4.34.0-rc1", row["reason"])
+
+    def test_a_release_main_stepped_over_is_still_unreachable(self):
+        # v4.33.1 is BEHIND v4.34.0-rc1, so main went past without stopping.
+        row = tt._unreachable_row("v4.33.1", {}, newest_era="v4.34.0-rc1")
+        self.assertEqual(row["status"], "unreachable")
+
+    def test_every_kind_of_later_release_counts_as_ahead(self):
+        for release in ("v4.34.0-rc2", "v4.34.0", "v4.35.0-rc1"):
+            with self.subTest(release=release):
+                row = tt._unreachable_row(release, {}, newest_era="v4.34.0-rc1")
+                self.assertEqual(row["status"], "ahead")
+
+    def test_the_report_separates_it_from_no_tag_is_possible(self):
+        rows = [tt._unreachable_row("v4.34.0-rc2", {}, newest_era="v4.34.0-rc1")]
+        text = tt.render(rows, include_policy=False)
+        self.assertIn("Ahead of main", text)
+        self.assertNotIn("No tag is possible", text)
+
+    def test_ahead_alone_is_not_worth_posting(self):
+        # Otherwise every mathlib release cut would post, whether or not main can act on it.
+        base = [{"release": "v4.34.0-rc1", "status": "tagged"}]
+        plus = base + [{"release": "v4.34.0-rc2", "status": "ahead"}]
+        self.assertEqual(tt.state_digest(base), tt.state_digest(plus))
+
+
 class DigestCause(unittest.TestCase):
     """A blocked release whose CAUSE changes must repost, or the visible reason stays wrong."""
 

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -290,7 +290,8 @@ older entries.
 If a tag does not match the rule, the tool reports it and changes nothing.
 """ % EARLIEST_RELEASE
 
-STATUSES = ("tagged", "ready", "pending", "blocked", "unreachable", "out-of-scope")
+STATUSES = ("tagged", "ready", "pending", "ahead", "blocked", "unreachable",
+            "out-of-scope")
 
 
 def audit(ref=None):
@@ -303,6 +304,7 @@ def audit(ref=None):
     if not by_release:
         raise RuntimeError("main has never run on a Lean release toolchain")
     oldest = min(by_release, key=release_key)
+    newest_era = max(by_release, key=release_key)   # the toolchain main is on now
     rows = []
 
     for release in sorted(set(mathlib_releases()) | set(by_release), key=release_key):
@@ -310,7 +312,7 @@ def audit(ref=None):
             continue          # predates this repository entirely; not our business
         era = by_release.get(release)
         if era is None:
-            rows.append(_unreachable_row(release, tags))
+            rows.append(_unreachable_row(release, tags, newest_era))
             continue
         sha = era["commit"]
         row = dict(era, status=None, reason=None, mathlib_rev=mathlib_pin(sha),
@@ -353,7 +355,7 @@ def audit(ref=None):
     return rows
 
 
-def _unreachable_row(release, tags):
+def _unreachable_row(release, tags, newest_era=None):
     """A release main never ran on. There is no commit to tag and nothing will construct
     one, so the only useful thing the report can do is say so and why."""
     row = {"release": release, "toolchain": toolchain_for(release), "commit": None,
@@ -384,6 +386,16 @@ def _unreachable_row(release, tags):
     if release_key(release) < release_key(EARLIEST_RELEASE):
         row["status"] = "out-of-scope"
         row["reason"] = f"predates {EARLIEST_RELEASE}, before the Lake cache existed"
+        return row
+    if newest_era and release_key(release) > release_key(newest_era):
+        # Ahead of main, not stepped over. `unreachable` reads as permanent and the report
+        # files it under "no tag is possible", which is the opposite of the truth: the bump
+        # has not arrived yet, and this will be tagged like any other release when it does.
+        # Mathlib tags a release as soon as Lean cuts it, so this is the normal state for
+        # days or weeks rather than an exception.
+        row["status"] = "ahead"
+        row["reason"] = (f"mathlib has tagged it, but main is still on {newest_era}; "
+                         "nothing to do until the bump gets there")
     return row
 
 
@@ -397,10 +409,12 @@ def state_digest(rows):
     Over (release, status) only, so rewording a reason or the policy text does not read as
     a change. `pending` releases are left out entirely: a release whose CI has not finished
     is not news, and including it would post a message on every bump saying "wait", then
-    another when the waiting ended. `out-of-scope` is left out because it never changes."""
+    another when the waiting ended. `ahead` likewise: mathlib tags a release the moment Lean
+    cuts one and main reaches it days or weeks later, so posting then would announce
+    something nobody here can act on. `out-of-scope` is left out because it never changes."""
     interesting = sorted((r["release"], r["status"], r.get("commit"), r.get("ci"))
                          for r in rows
-                         if r["status"] not in ("pending", "out-of-scope"))
+                         if r["status"] not in ("pending", "ahead", "out-of-scope"))
     return hashlib.sha256(repr(interesting).encode()).hexdigest()[:16]
 
 
@@ -438,6 +452,10 @@ def render(rows, include_policy=True, collapse_old=False):
     if blocked:
         lines += ["", "Needing a human:", ""]
         lines += [f"    {r['release']}: {r['reason']}" for r in blocked]
+    ahead = [r for r in rows if r["status"] == "ahead"]
+    if ahead:
+        lines += ["", "Ahead of main, and will be tagged when the bump arrives:", ""]
+        lines += [f"    {r['release']}: {r['reason']}" for r in ahead]
     unreachable = [r for r in rows if r["status"] == "unreachable"]
     if unreachable:
         lines += ["", "No tag is possible for these, and none will be constructed:", ""]


### PR DESCRIPTION
The report called `v4.34.0-rc2` `unreachable` and filed it under "No tag is possible for these, and none will be constructed". That is the opposite of the truth: mathlib tagged it on 21 August, `main` is still on `v4.34.0-rc1` and grinding toward it, and it will be tagged like any other release once the bump arrives.

`unreachable` was written for a release `main` went past without stopping, which is permanent and needs a hand-built commit. A release *ahead* of `main` is the normal state for days or weeks after mathlib cuts one, so it was the commonest thing the report said and it was wrong. Releases later than `main`'s current toolchain now report as `ahead`, in their own section.

Both cases appeared in the same post, which is what made it confusing to read: `v4.33.1` is genuinely stepped over and needs a decision, `v4.34.0-rc2` needs nothing at all, and they were presented identically.

`ahead` is left out of the digest, so a mathlib release cut on its own no longer posts. A release becoming `unreachable` still does, because being stepped over is news.

The other half of that Zulip thread, the untagged code fence rendering as Lean, was already fixed on main by #4749.

Roadmap: none

🤖 Prepared with Claude Code