### PR TITLE
feat: the root-datum Steinberg map of any valid Lie-type index

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Assembly.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Assembly.lean
@@ -58,6 +58,8 @@ points, or a finite group.
 
 ## Main results
 
+* `TauCeti.ValidLieTypeIndex.datumSteinberg_def`: the dispatcher itself, for a consumer reasoning
+  about both branches at once.
 * `TauCeti.ValidLieTypeIndex.datumSteinberg_of_usesHalfFrobenius` and
   `TauCeti.ValidLieTypeIndex.datumSteinberg_of_not_usesHalfFrobenius`: the two branch equations,
   exhaustive because the selecting predicate is decidable.
@@ -105,17 +107,29 @@ def datumSteinberg :
   if h : d.1.UsesHalfFrobenius then SuzukiReeIndex.datumSteinberg ⟨d, h⟩
   else GraphTwistedIndex.datumSteinberg ⟨d, h⟩
 
+/-- **The defining equation of the root-datum Steinberg map**, exhibiting it as the `dite` on
+`TauCeti.LieTypeIndex.UsesHalfFrobenius`. This is what a consumer rewrites with to reason about both
+branches at once; when the predicate is already decided one way,
+`TauCeti.ValidLieTypeIndex.datumSteinberg_of_usesHalfFrobenius` and
+`TauCeti.ValidLieTypeIndex.datumSteinberg_of_not_usesHalfFrobenius` are the eliminators to use
+instead. -/
+theorem datumSteinberg_def :
+    d.datumSteinberg =
+      if h : d.1.UsesHalfFrobenius then SuzukiReeIndex.datumSteinberg ⟨d, h⟩
+      else GraphTwistedIndex.datumSteinberg ⟨d, h⟩ := by
+  rw [datumSteinberg]
+
 /-- **The half-Frobenius branch of the Steinberg map.** On the Suzuki, Ree `G₂`, Ree `F₄` and Tits
 indices it is the odd power `τ ^ (2 * m + 1)` of the selected special isogeny. -/
 theorem datumSteinberg_of_usesHalfFrobenius (h : d.1.UsesHalfFrobenius) :
     d.datumSteinberg = SuzukiReeIndex.datumSteinberg ⟨d, h⟩ := by
-  rw [datumSteinberg, dite_eq_left h]
+  rw [datumSteinberg_def, dite_eq_left h]
 
 /-- **The ordinary branch of the Steinberg map.** On the nine untwisted families and on `²Aₙ(q)`,
 `²Dₙ(q)`, `²E₆(q)` and `³D₄(q)` it is the graph automorphism after the `q`-power Frobenius. -/
 theorem datumSteinberg_of_not_usesHalfFrobenius (h : ¬ d.1.UsesHalfFrobenius) :
     d.datumSteinberg = GraphTwistedIndex.datumSteinberg ⟨d, h⟩ := by
-  rw [datumSteinberg, dite_eq_right h]
+  rw [datumSteinberg_def, dite_eq_right h]
 
 /-- **The Steinberg map of a graph-twisted index degenerates to the Frobenius exactly on the
 untwisted families**, where the diagram permutation is trivial. This is

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Assembly.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Assembly.lean
@@ -25,8 +25,8 @@ the domains of the two constructions, so the dispatcher is a `dite` on that deci
 invents nothing on either side. The two branch equations
 `TauCeti.ValidLieTypeIndex.datumSteinberg_of_usesHalfFrobenius` and
 `TauCeti.ValidLieTypeIndex.datumSteinberg_of_not_usesHalfFrobenius` are what a consumer reasons
-with; the body is not exposed, and since the predicate is decidable on a concrete constructor they
-are exhaustive, as the worked branches at the end of the file illustrate.
+with, and since the predicate is decidable on a concrete constructor they are exhaustive, as the
+worked branches at the end of the file illustrate.
 
 ## What the two halves share
 
@@ -35,13 +35,13 @@ exception, where the diagram permutation is trivial and the Steinberg map is `Fr
 `TauCeti.ValidLieTypeIndex.datumSteinberg_eq_datumFrobenius_iff_of_not_usesHalfFrobenius`. What
 holds in general is only an order relation on each side: a graph-twisted map raised to its twist
 order is `Frob_(q ^ e)`, by
-`TauCeti.GraphTwistedIndex.datumSteinberg_pow_twistOrder`, and a half-Frobenius power squares to
-`Frob_q`, by `TauCeti.SuzukiReeIndex.datumSteinberg_mul_self`. What is uniform is that *some*
-positive power is a scaling, which is
+`TauCeti.GraphTwistedIndex.datumSteinberg_pow_twistOrder_eq_smulId`, and a half-Frobenius power
+squares to `Frob_q`, by `TauCeti.SuzukiReeIndex.datumSteinberg_mul_self`. What is uniform is that
+*some* positive power is a scaling by a positive power of the characteristic, which is
 `TauCeti.ValidLieTypeIndex.exists_pow_datumSteinberg_eq_smulId`. That is the defining property of a
 Steinberg endomorphism in Steinberg's sense, and on the group layer it is the reason the fixed
-groups of milestone L3 are finite at all; the two exponents are genuinely different, which is why
-the uniform statement is an existential rather than one formula.
+groups of milestone L3 are finite at all; the two exponents and the two scalars are genuinely
+different, which is why the uniform statement is an existential rather than one formula.
 
 Note that the scaling factors do not follow one rule either. The graph-twisted power is the
 Frobenius of the *larger* field `𝔽_(q ^ e)`, since each of the `e` factors contributes its own `q`;
@@ -62,8 +62,8 @@ points, or a finite group.
   `TauCeti.ValidLieTypeIndex.datumSteinberg_of_not_usesHalfFrobenius`: the two branch equations,
   exhaustive because the selecting predicate is decidable.
 * `TauCeti.ValidLieTypeIndex.exists_pow_datumSteinberg_eq_smulId`: some positive power of the
-  Steinberg map is a scaling, which is the root-datum form of "some power of a Steinberg
-  endomorphism is a Frobenius".
+  Steinberg map is the scaling at a positive power of the characteristic, which is the root-datum
+  form of "some power of a Steinberg endomorphism is a Frobenius".
 * `TauCeti.ValidLieTypeIndex.datumSteinberg_eq_datumFrobenius_iff_of_not_usesHalfFrobenius`: on the
   thirteen ordinary constructors it degenerates to the Frobenius exactly on the nine untwisted
   families.
@@ -71,11 +71,13 @@ points, or a finite group.
 ## Roadmap
 
 This assembles the root-datum layer of milestones L1, "ordinary and graph Steinberg maps", and L2,
-"Suzuki--Ree Steinberg maps", of `TauCetiRoadmap/CFSGStatement/README.md` into the single map that
-L2's completion condition, "`steinberg` unfolds on every branch", asks for. What is still missing
-from L1 and L2 is the group layer: `TauCeti.ValidLieTypeIndex.steinberg`, an endomorphism of the
-points of a pinned Chevalley--Demazure group, together with its action on root subgroups. That waits
-on the carriers of milestone L0, and this file is the shadow those maps will cast on the root datum.
+"Suzuki--Ree Steinberg maps", of `TauCetiRoadmap/CFSGStatement/README.md` into a single map on every
+valid index. It is the root-datum shadow of the map named in L2's completion condition, "`steinberg`
+unfolds on every branch", and does not meet that condition: the condition is about the group-layer
+`TauCeti.ValidLieTypeIndex.steinberg`, an endomorphism of the points of a pinned
+Chevalley--Demazure group, together with its action on root subgroups, and both remain open. That
+group layer waits on the carriers of milestone L0, and the map assembled here is what it will
+dispatch to on each branch.
 
 The conventions follow R. Steinberg, *Endomorphisms of linear algebraic groups*, Memoirs AMS 80
 (1968), §11, and R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex
@@ -127,38 +129,52 @@ theorem datumSteinberg_eq_datumFrobenius_iff_of_not_usesHalfFrobenius
 
 /-- **The twist-order power of an ordinary Steinberg map is a Frobenius**: `(γ ∘ Frob_q) ^ e` is
 `Frob_(q ^ e)`, the Frobenius of the degree-`e` extension of the field the index names. -/
-theorem datumSteinberg_pow_twistOrder_of_not_usesHalfFrobenius (h : ¬ d.1.UsesHalfFrobenius) :
+theorem datumSteinberg_pow_twistOrder_eq_smulId_of_not_usesHalfFrobenius
+    (h : ¬ d.1.UsesHalfFrobenius) :
     d.datumSteinberg ^ GraphTwistedIndex.twistOrder ⟨d, h⟩ =
       RootPairingIsogeny.smulId _
         (d.1.fieldOrderPNat ^ GraphTwistedIndex.twistOrder ⟨d, h⟩) := by
   rw [datumSteinberg_of_not_usesHalfFrobenius d h]
-  exact GraphTwistedIndex.datumSteinberg_pow_twistOrder ⟨d, h⟩
+  exact GraphTwistedIndex.datumSteinberg_pow_twistOrder_eq_smulId ⟨d, h⟩
 
-/-- **The square of a half-Frobenius Steinberg map is a Frobenius**: `(τ ^ (2 * m + 1)) ^ 2` is
-`Frob_(p ^ (2 * m + 1))`, the Frobenius of the field the index itself names. -/
-theorem datumSteinberg_pow_two_of_usesHalfFrobenius (h : d.1.UsesHalfFrobenius) :
-    d.datumSteinberg ^ 2 =
-      RootPairingIsogeny.smulId _ ⟨d.fieldOrder, d.fieldOrder_pos⟩ := by
-  rw [datumSteinberg_of_usesHalfFrobenius d h, pow_two]
+/-- **The square of a half-Frobenius Steinberg map is the Frobenius of the index**:
+`(τ ^ (2 * m + 1)) ^ 2` is `Frob_(p ^ (2 * m + 1))`, the Frobenius of the field the index itself
+names. -/
+theorem datumSteinberg_pow_two_eq_datumFrobenius_of_usesHalfFrobenius
+    (h : d.1.UsesHalfFrobenius) :
+    d.datumSteinberg ^ 2 = d.datumFrobenius := by
+  rw [datumSteinberg_of_usesHalfFrobenius d h, pow_two, datumFrobenius_def]
   exact SuzukiReeIndex.datumSteinberg_mul_self ⟨d, h⟩
 
-/-- **Some positive power of the Steinberg map is a scaling.** This is the root-datum form of the
-property that defines a Steinberg endomorphism: some power of it is a Frobenius. The witnessing
-exponent is the twist order on the thirteen ordinary constructors and `2` on the four
-half-Frobenius ones, so it is stated existentially; the two explicit forms are
-`TauCeti.ValidLieTypeIndex.datumSteinberg_pow_twistOrder_of_not_usesHalfFrobenius` and
-`TauCeti.ValidLieTypeIndex.datumSteinberg_pow_two_of_usesHalfFrobenius`. -/
+/-- **Some positive power of the Steinberg map is the scaling at a positive power of the
+characteristic.** Since the scaling at a prime power is the root-datum shadow of the Frobenius of
+the field of that order, this is the root-datum form of the property that defines a Steinberg
+endomorphism: some power of it is a Frobenius. The witnessing exponent is the twist order on the
+thirteen ordinary constructors and `2` on the four half-Frobenius ones, and the scalar is `q ^ e`
+there and `q` here, so both are recorded existentially; the two explicit forms are
+`TauCeti.ValidLieTypeIndex.datumSteinberg_pow_twistOrder_eq_smulId_of_not_usesHalfFrobenius` and
+`TauCeti.ValidLieTypeIndex.datumSteinberg_pow_two_eq_datumFrobenius_of_usesHalfFrobenius`. -/
 theorem exists_pow_datumSteinberg_eq_smulId :
-    ∃ (n : ℕ) (c : ℕ+), 0 < n ∧ d.datumSteinberg ^ n =
-      RootPairingIsogeny.smulId
-        (d.dynkinType.simplyConnectedRootDatum d.dynkinType_valid) c := by
+    ∃ (n : ℕ) (c : ℕ+) (k : ℕ), 0 < n ∧ 0 < k ∧ (c : ℕ) = d.characteristic ^ k ∧
+      d.datumSteinberg ^ n =
+        RootPairingIsogeny.smulId
+          (d.dynkinType.simplyConnectedRootDatum d.dynkinType_valid) c := by
   by_cases h : d.1.UsesHalfFrobenius
-  · exact ⟨2, ⟨d.fieldOrder, d.fieldOrder_pos⟩, two_pos,
-      d.datumSteinberg_pow_two_of_usesHalfFrobenius h⟩
-  · exact ⟨GraphTwistedIndex.twistOrder ⟨d, h⟩,
+  · -- The square is the Frobenius of the field the index names, a `fieldExponent`-th power of `p`.
+    refine ⟨2, d.1.fieldOrderPNat, d.fieldExponent, two_pos, d.fieldExponent_pos, ?_, ?_⟩
+    · rw [LieTypeIndex.coe_fieldOrderPNat]
+      exact d.fieldOrder_eq_characteristic_pow
+    · rw [d.datumSteinberg_pow_two_eq_datumFrobenius_of_usesHalfFrobenius h, datumFrobenius_def]
+  · -- The twist-order power is the Frobenius of the degree-`e` extension, so the exponent of `p`
+    -- is multiplied by `e`.
+    refine ⟨GraphTwistedIndex.twistOrder ⟨d, h⟩,
       d.1.fieldOrderPNat ^ GraphTwistedIndex.twistOrder ⟨d, h⟩,
+      d.fieldExponent * GraphTwistedIndex.twistOrder ⟨d, h⟩,
       GraphTwistedIndex.twistOrder_pos ⟨d, h⟩,
-      d.datumSteinberg_pow_twistOrder_of_not_usesHalfFrobenius h⟩
+      Nat.mul_pos d.fieldExponent_pos (GraphTwistedIndex.twistOrder_pos ⟨d, h⟩), ?_,
+      d.datumSteinberg_pow_twistOrder_eq_smulId_of_not_usesHalfFrobenius h⟩
+    rw [PNat.pow_coe, LieTypeIndex.coe_fieldOrderPNat, d.1.fieldOrder_eq_characteristic_pow,
+      pow_mul]
 
 end
 
@@ -187,7 +203,7 @@ the Frobenius of the quadratic extension `𝔽_(q ^ 2)`. -/
 example (hv : (LieTypeIndex.twistedA n q).Valid) :
     ValidLieTypeIndex.datumSteinberg ⟨_, hv⟩ ^ 2 =
       RootPairingIsogeny.smulId _ ((LieTypeIndex.twistedA n q).fieldOrderPNat ^ 2) := by
-  have h := ValidLieTypeIndex.datumSteinberg_pow_twistOrder_of_not_usesHalfFrobenius
+  have h := ValidLieTypeIndex.datumSteinberg_pow_twistOrder_eq_smulId_of_not_usesHalfFrobenius
     (⟨_, hv⟩ : ValidLieTypeIndex) (by simp)
   rwa [GraphTwistedIndex.twistOrder_twistedA hv] at h
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Assembly.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Assembly.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Datum.Steinberg
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.HalfFrobenius
+
+/-!
+# The root-datum Steinberg map of an arbitrary valid Lie-type index
+
+The classification list splits its Lie-type families in two according to the shape of their
+Steinberg endomorphism. Thirteen of the seventeen constructors take `γ ∘ Frob_q`, the field
+Frobenius composed with a pinned diagram automorphism, and the remaining four -- the Suzuki, Ree
+`G₂`, Ree `F₄` and Tits indices -- take an odd power of a half-Frobenius. Each half already has its
+root-datum map: `TauCeti.GraphTwistedIndex.datumSteinberg` and
+`TauCeti.SuzukiReeIndex.datumSteinberg`. This file joins them into the single map
+`TauCeti.ValidLieTypeIndex.datumSteinberg` defined on every valid index, and records what the two
+halves have in common.
+
+The split is `TauCeti.LieTypeIndex.UsesHalfFrobenius`, and the two subtypes it cuts out are exactly
+the domains of the two constructions, so the dispatcher is a `dite` on that decidable predicate and
+invents nothing on either side. The two branch equations
+`TauCeti.ValidLieTypeIndex.datumSteinberg_of_usesHalfFrobenius` and
+`TauCeti.ValidLieTypeIndex.datumSteinberg_of_not_usesHalfFrobenius` are what a consumer reasons
+with; the body is not exposed, and since the predicate is decidable on a concrete constructor they
+are exhaustive, as the worked branches at the end of the file illustrate.
+
+## What the two halves share
+
+Neither half is a Frobenius. A graph-twisted map raised to its twist order is `Frob_(q ^ e)`, by
+`TauCeti.GraphTwistedIndex.datumSteinberg_pow_twistOrder`, and a half-Frobenius power squares to
+`Frob_q`, by `TauCeti.SuzukiReeIndex.datumSteinberg_mul_self`. What is uniform is that *some*
+positive power is a scaling, which is
+`TauCeti.ValidLieTypeIndex.exists_pow_datumSteinberg_eq_smulId`. That is the defining property of a
+Steinberg endomorphism in Steinberg's sense, and on the group layer it is the reason the fixed
+groups of milestone L3 are finite at all; the two exponents are genuinely different, which is why
+the uniform statement is an existential rather than one formula.
+
+Note that the scaling factors do not follow one rule either. The graph-twisted power is the
+Frobenius of the *larger* field `𝔽_(q ^ e)`, since each of the `e` factors contributes its own `q`;
+the Suzuki--Ree square is the Frobenius of the field `𝔽_q` the index itself names, since there the
+recorded `q = p ^ (2 * m + 1)` is already the square of what one factor contributes.
+
+This is the root-datum layer and not the group layer: nothing here mentions a group scheme, its
+points, or a finite group.
+
+## Main definitions
+
+* `TauCeti.ValidLieTypeIndex.datumSteinberg`: the root-datum Steinberg map of any valid Lie-type
+  index.
+
+## Main results
+
+* `TauCeti.ValidLieTypeIndex.datumSteinberg_of_usesHalfFrobenius` and
+  `TauCeti.ValidLieTypeIndex.datumSteinberg_of_not_usesHalfFrobenius`: the two branch equations,
+  exhaustive because the selecting predicate is decidable.
+* `TauCeti.ValidLieTypeIndex.exists_pow_datumSteinberg_eq_smulId`: some positive power of the
+  Steinberg map is a scaling, which is the root-datum form of "some power of a Steinberg
+  endomorphism is a Frobenius".
+* `TauCeti.ValidLieTypeIndex.datumSteinberg_eq_datumFrobenius_iff_of_not_usesHalfFrobenius`: on the
+  thirteen ordinary constructors it degenerates to the Frobenius exactly on the nine untwisted
+  families.
+
+## Roadmap
+
+This assembles the root-datum layer of milestones L1, "ordinary and graph Steinberg maps", and L2,
+"Suzuki--Ree Steinberg maps", of `TauCetiRoadmap/CFSGStatement/README.md` into the single map that
+L2's completion condition, "`steinberg` unfolds on every branch", asks for. What is still missing
+from L1 and L2 is the group layer: `TauCeti.ValidLieTypeIndex.steinberg`, an endomorphism of the
+points of a pinned Chevalley--Demazure group, together with its action on root subgroups. That waits
+on the carriers of milestone L0, and this file is the shadow those maps will cast on the root datum.
+
+The conventions follow R. Steinberg, *Endomorphisms of linear algebraic groups*, Memoirs AMS 80
+(1968), §11, and R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex
+Characters*, §1.17.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace ValidLieTypeIndex
+
+variable (d : ValidLieTypeIndex)
+
+noncomputable section
+
+/-- **The root-datum Steinberg map of a valid Lie-type index.** It is the odd half-Frobenius power
+`TauCeti.SuzukiReeIndex.datumSteinberg` on the Suzuki, Ree and Tits indices, and the composite
+`γ ∘ Frob_q` of `TauCeti.GraphTwistedIndex.datumSteinberg` on the other thirteen constructors. The
+selecting predicate `TauCeti.LieTypeIndex.UsesHalfFrobenius` is exactly the one whose two subtypes
+are the domains of those constructions, so no map is invented on either branch. -/
+def datumSteinberg :
+    RootPairingIsogeny (d.dynkinType.simplyConnectedRootDatum d.dynkinType_valid)
+      (d.dynkinType.simplyConnectedRootDatum d.dynkinType_valid) :=
+  if h : d.1.UsesHalfFrobenius then SuzukiReeIndex.datumSteinberg ⟨d, h⟩
+  else GraphTwistedIndex.datumSteinberg ⟨d, h⟩
+
+/-- **The half-Frobenius branch of the Steinberg map.** On the Suzuki, Ree `G₂`, Ree `F₄` and Tits
+indices it is the odd power `τ ^ (2 * m + 1)` of the selected special isogeny. -/
+theorem datumSteinberg_of_usesHalfFrobenius (h : d.1.UsesHalfFrobenius) :
+    d.datumSteinberg = SuzukiReeIndex.datumSteinberg ⟨d, h⟩ := by
+  rw [datumSteinberg, dite_eq_left h]
+
+/-- **The ordinary branch of the Steinberg map.** On the nine untwisted families and on `²Aₙ(q)`,
+`²Dₙ(q)`, `²E₆(q)` and `³D₄(q)` it is the graph automorphism after the `q`-power Frobenius. -/
+theorem datumSteinberg_of_not_usesHalfFrobenius (h : ¬ d.1.UsesHalfFrobenius) :
+    d.datumSteinberg = GraphTwistedIndex.datumSteinberg ⟨d, h⟩ := by
+  rw [datumSteinberg, dite_eq_right h]
+
+/-- **The Steinberg map of a graph-twisted index degenerates to the Frobenius exactly on the
+untwisted families**, where the diagram permutation is trivial. This is
+`TauCeti.GraphTwistedIndex.datumSteinberg_eq_datumFrobenius_iff` transported through the
+dispatcher. -/
+theorem datumSteinberg_eq_datumFrobenius_iff_of_not_usesHalfFrobenius
+    (h : ¬ d.1.UsesHalfFrobenius) :
+    d.datumSteinberg = d.datumFrobenius ↔ GraphTwistedIndex.diagramPerm ⟨d, h⟩ = 1 := by
+  rw [datumSteinberg_of_not_usesHalfFrobenius d h]
+  exact GraphTwistedIndex.datumSteinberg_eq_datumFrobenius_iff ⟨d, h⟩
+
+/-- **The twist-order power of an ordinary Steinberg map is a Frobenius**: `(γ ∘ Frob_q) ^ e` is
+`Frob_(q ^ e)`, the Frobenius of the degree-`e` extension of the field the index names. -/
+theorem datumSteinberg_pow_twistOrder_of_not_usesHalfFrobenius (h : ¬ d.1.UsesHalfFrobenius) :
+    d.datumSteinberg ^ GraphTwistedIndex.twistOrder ⟨d, h⟩ =
+      RootPairingIsogeny.smulId _
+        (d.1.fieldOrderPNat ^ GraphTwistedIndex.twistOrder ⟨d, h⟩) := by
+  rw [datumSteinberg_of_not_usesHalfFrobenius d h]
+  exact GraphTwistedIndex.datumSteinberg_pow_twistOrder ⟨d, h⟩
+
+/-- **The square of a half-Frobenius Steinberg map is a Frobenius**: `(τ ^ (2 * m + 1)) ^ 2` is
+`Frob_(p ^ (2 * m + 1))`, the Frobenius of the field the index itself names. -/
+theorem datumSteinberg_pow_two_of_usesHalfFrobenius (h : d.1.UsesHalfFrobenius) :
+    d.datumSteinberg ^ 2 =
+      RootPairingIsogeny.smulId _ ⟨d.fieldOrder, d.fieldOrder_pos⟩ := by
+  rw [datumSteinberg_of_usesHalfFrobenius d h, pow_two]
+  exact SuzukiReeIndex.datumSteinberg_mul_self ⟨d, h⟩
+
+/-- **Some positive power of the Steinberg map is a scaling.** This is the root-datum form of the
+property that defines a Steinberg endomorphism: some power of it is a Frobenius. The witnessing
+exponent is the twist order on the thirteen ordinary constructors and `2` on the four
+half-Frobenius ones, so it is stated existentially; the two explicit forms are
+`TauCeti.ValidLieTypeIndex.datumSteinberg_pow_twistOrder_of_not_usesHalfFrobenius` and
+`TauCeti.ValidLieTypeIndex.datumSteinberg_pow_two_of_usesHalfFrobenius`. -/
+theorem exists_pow_datumSteinberg_eq_smulId :
+    ∃ (n : ℕ) (c : ℕ+), 0 < n ∧ d.datumSteinberg ^ n =
+      RootPairingIsogeny.smulId
+        (d.dynkinType.simplyConnectedRootDatum d.dynkinType_valid) c := by
+  by_cases h : d.1.UsesHalfFrobenius
+  · exact ⟨2, ⟨d.fieldOrder, d.fieldOrder_pos⟩, two_pos,
+      d.datumSteinberg_pow_two_of_usesHalfFrobenius h⟩
+  · exact ⟨GraphTwistedIndex.twistOrder ⟨d, h⟩,
+      d.1.fieldOrderPNat ^ GraphTwistedIndex.twistOrder ⟨d, h⟩,
+      GraphTwistedIndex.twistOrder_pos ⟨d, h⟩,
+      d.datumSteinberg_pow_twistOrder_of_not_usesHalfFrobenius h⟩
+
+end
+
+end ValidLieTypeIndex
+
+/-! ## Worked branches
+
+The two branch equations are exhaustive because `TauCeti.LieTypeIndex.UsesHalfFrobenius` is
+decidable, so on a concrete constructor the side condition is discharged by `simp`. The following
+representatives cover an untwisted family, a graph-twisted one, a Suzuki--Ree one and the Tits
+index. -/
+
+section Branches
+
+variable {n : ℕ} {q : PrimePower}
+
+/-- On the untwisted family `Aₙ(q)` the Steinberg map is the Frobenius `Frob_q` itself, the diagram
+permutation being trivial there. -/
+example (hv : (LieTypeIndex.A n q).Valid) :
+    ValidLieTypeIndex.datumSteinberg ⟨_, hv⟩ = ValidLieTypeIndex.datumFrobenius ⟨_, hv⟩ :=
+  (ValidLieTypeIndex.datumSteinberg_eq_datumFrobenius_iff_of_not_usesHalfFrobenius ⟨_, hv⟩
+    (by simp)).mpr (GraphTwistedIndex.diagramPerm_A hv)
+
+/-- On the unitary family `²Aₙ(q)` the Steinberg map is genuinely twisted, and squaring it returns
+the Frobenius of the quadratic extension `𝔽_(q ^ 2)`. -/
+example (hv : (LieTypeIndex.twistedA n q).Valid) :
+    ValidLieTypeIndex.datumSteinberg ⟨_, hv⟩ ^ 2 =
+      RootPairingIsogeny.smulId _ ((LieTypeIndex.twistedA n q).fieldOrderPNat ^ 2) := by
+  have h := ValidLieTypeIndex.datumSteinberg_pow_twistOrder_of_not_usesHalfFrobenius
+    (⟨_, hv⟩ : ValidLieTypeIndex) (by simp)
+  rwa [GraphTwistedIndex.twistOrder_twistedA hv] at h
+
+/-- On the Suzuki family `²B₂(2 ^ (2 * m + 1))` the Steinberg map is the odd power of the `B₂`
+special isogeny. -/
+example {m : ℕ} (hv : (LieTypeIndex.suzuki m).Valid) :
+    ValidLieTypeIndex.datumSteinberg ⟨_, hv⟩ =
+      SuzukiReeIndex.datumSteinberg ⟨⟨_, hv⟩, by simp⟩ :=
+  ValidLieTypeIndex.datumSteinberg_of_usesHalfFrobenius ⟨_, hv⟩ (by simp)
+
+/-- On the Tits index the Steinberg map is the `F₄` special isogeny itself, the `m = 0` member of
+the half-Frobenius family. -/
+example (hv : LieTypeIndex.tits.Valid) :
+    ValidLieTypeIndex.datumSteinberg ⟨_, hv⟩ =
+      SuzukiReeIndex.datumSpecialIsogeny ⟨⟨_, hv⟩, by simp⟩ :=
+  (ValidLieTypeIndex.datumSteinberg_of_usesHalfFrobenius ⟨_, hv⟩ (by simp)).trans
+    SuzukiReeIndex.datumSteinberg_tits
+
+end Branches
+
+end TauCeti

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Assembly.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Assembly.lean
@@ -30,7 +30,11 @@ are exhaustive, as the worked branches at the end of the file illustrate.
 
 ## What the two halves share
 
-Neither half is a Frobenius. A graph-twisted map raised to its twist order is `Frob_(q ^ e)`, by
+Neither half is uniformly a Frobenius; on the ordinary branch the nine untwisted families are the
+exception, where the diagram permutation is trivial and the Steinberg map is `Frob_q` itself, by
+`TauCeti.ValidLieTypeIndex.datumSteinberg_eq_datumFrobenius_iff_of_not_usesHalfFrobenius`. What
+holds in general is only an order relation on each side: a graph-twisted map raised to its twist
+order is `Frob_(q ^ e)`, by
 `TauCeti.GraphTwistedIndex.datumSteinberg_pow_twistOrder`, and a half-Frobenius power squares to
 `Frob_q`, by `TauCeti.SuzukiReeIndex.datumSteinberg_mul_self`. What is uniform is that *some*
 positive power is a scaling, which is

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Assembly.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Assembly.lean
@@ -78,8 +78,21 @@ valid index. It is the root-datum shadow of the map named in L2's completion con
 unfolds on every branch", and does not meet that condition: the condition is about the group-layer
 `TauCeti.ValidLieTypeIndex.steinberg`, an endomorphism of the points of a pinned
 Chevalley--Demazure group, together with its action on root subgroups, and both remain open. That
-group layer waits on the carriers of milestone L0, and the map assembled here is what it will
-dispatch to on each branch.
+group layer waits on the carriers of milestone L0.
+
+What this file contributes to it is not the group-level composite. On the ordinary branch that
+composite already exists in another form: `TauCeti.DynkinType.geckTwistedFrobenius` realizes
+`γ ∘ Frob_q` on the points of the pinned Geck carrier, for a diagram symmetry and a field order
+handed to it, and satisfies L1's simple-root-subgroup equation there. What is contributed is the
+branch split and the exponents. The split `TauCeti.LieTypeIndex.UsesHalfFrobenius` is decided here
+once and for every valid index, against the two subtypes that carry the two constructions, so a
+consumer of a total Steinberg map has one place to reason about which shape an index takes; and the
+order relations below fix the exponent and the scalar on each side, the twist order and `q ^ e` on
+the ordinary branch and `2` and `q` on the half-Frobenius one. Those are the root-datum readings of
+the "order relations" half of L1's completion evidence and of L2's
+`steinberg(m) ^ 2 = Frob_(p ^ (2 * m + 1))`. The half-Frobenius branch has no group-level
+counterpart at all yet, since the special isogeny of pinned group schemes it would compose is an
+upstream Layer 9 target.
 
 The conventions follow R. Steinberg, *Endomorphisms of linear algebraic groups*, Memoirs AMS 80
 (1968), §11, and R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Steinberg.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Steinberg.lean
@@ -79,8 +79,8 @@ degenerates to its Frobenius exactly on the nine untwisted families, so `²Aₙ(
 * `TauCeti.GraphTwistedIndex.datumSteinberg_eq_datumFrobenius_iff` and
   `TauCeti.GraphTwistedIndex.datumSteinberg_eq_datumFrobenius_iff_twistOrder`: it is the plain
   Frobenius exactly on the untwisted families, equivalently exactly when the twist order is one.
-* `TauCeti.GraphTwistedIndex.datumSteinberg_pow_twistOrder`: its twist-order power is the Frobenius
-  `Frob_(q ^ e)`, which is the order relation of milestone L1 read on the Steinberg map.
+* `TauCeti.GraphTwistedIndex.datumSteinberg_pow_twistOrder_eq_smulId`: its twist-order power is the
+  Frobenius `Frob_(q ^ e)`, which is the order relation of milestone L1 read on the Steinberg map.
 
 ## Roadmap
 
@@ -228,7 +228,7 @@ theorem datumSteinberg_eq_datumFrobenius_iff_twistOrder :
 order returns the Frobenius of the field of that degree, `Frob_(q ^ e)`. It is milestone L1's
 `γ ^ 2 = 1` and `γ ^ 3 = 1` read on the Steinberg map itself rather than on its graph factor. On an
 untwisted family the twist order is `1` and this is the definition of the Frobenius. -/
-theorem datumSteinberg_pow_twistOrder :
+theorem datumSteinberg_pow_twistOrder_eq_smulId :
     d.datumSteinberg ^ d.twistOrder =
       RootPairingIsogeny.smulId _ (d.1.1.fieldOrderPNat ^ d.twistOrder) := by
   -- the power splits over the two factors because a scaling is central,
@@ -239,7 +239,7 @@ theorem datumSteinberg_pow_twistOrder :
   -- and the graph factor is annihilated by the twist order.
   have hgraph : RootPairingIsogeny.ofEquiv d.datumGraphAut⁻¹ ^ d.twistOrder = 1 := by
     rw [← RootPairingIsogeny.ofEquiv_pow, inv_pow, datumGraphAut_pow_twistOrder, inv_one,
-      RootPairingIsogeny.ofEquiv_one]
+      RootPairingIsogeny.ofEquiv_one, ← RootPairingIsogeny.one_def]
   calc d.datumSteinberg ^ d.twistOrder
       = RootPairingIsogeny.ofEquiv d.datumGraphAut⁻¹ ^ d.twistOrder *
           RootPairingIsogeny.smulId _ d.1.1.fieldOrderPNat ^ d.twistOrder := by

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Steinberg.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Steinberg.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.GroupTheory.SpecificGroups.CFSG.Datum.Frobenius
 public import TauCeti.GroupTheory.SpecificGroups.CFSG.RootDatumAutomorphism
-public import TauCeti.LinearAlgebra.RootSystem.Isogeny.Basic
+public import TauCeti.LinearAlgebra.RootSystem.Isogeny.Power
 
 /-!
 # The root-datum Steinberg map of a graph-twisted index
@@ -79,6 +79,8 @@ degenerates to its Frobenius exactly on the nine untwisted families, so `²Aₙ(
 * `TauCeti.GraphTwistedIndex.datumSteinberg_eq_datumFrobenius_iff` and
   `TauCeti.GraphTwistedIndex.datumSteinberg_eq_datumFrobenius_iff_twistOrder`: it is the plain
   Frobenius exactly on the untwisted families, equivalently exactly when the twist order is one.
+* `TauCeti.GraphTwistedIndex.datumSteinberg_pow_twistOrder`: its twist-order power is the Frobenius
+  `Frob_(q ^ e)`, which is the order relation of milestone L1 read on the Steinberg map.
 
 ## Roadmap
 
@@ -221,6 +223,24 @@ permutation. -/
 theorem datumSteinberg_eq_datumFrobenius_iff_twistOrder :
     d.datumSteinberg = d.1.datumFrobenius ↔ d.twistOrder = 1 := by
   rw [datumSteinberg_eq_datumFrobenius_iff, ← orderOf_diagramPerm d, orderOf_eq_one_iff]
+
+/-- **The order relation of the graph-twisted Steinberg map**: raising `γ ∘ Frob_q` to the twist
+order returns the Frobenius of the field of that degree, `Frob_(q ^ e)`. It is milestone L1's
+`γ ^ 2 = 1` and `γ ^ 3 = 1` read on the Steinberg map itself rather than on its graph factor: the
+factor `γ` is annihilated by `TauCeti.GraphTwistedIndex.datumGraphAut_pow_twistOrder`, and it can be
+collected on one side because a scaling is central,
+`TauCeti.RootPairingIsogeny.commute_smulId`. On an untwisted family the twist order is `1` and this
+is the definition of the Frobenius. -/
+theorem datumSteinberg_pow_twistOrder :
+    d.datumSteinberg ^ d.twistOrder =
+      RootPairingIsogeny.smulId _ (d.1.1.fieldOrderPNat ^ d.twistOrder) := by
+  have hcomm : Commute (RootPairingIsogeny.ofEquiv d.datumGraphAut⁻¹)
+      (RootPairingIsogeny.smulId
+        (d.1.dynkinType.simplyConnectedRootDatum d.1.dynkinType_valid) d.1.1.fieldOrderPNat) :=
+    (RootPairingIsogeny.commute_smulId _ _ _).symm
+  rw [datumSteinberg_def, ValidLieTypeIndex.datumFrobenius_def, ← RootPairingIsogeny.mul_def,
+    hcomm.mul_pow, ← RootPairingIsogeny.ofEquiv_pow, inv_pow, datumGraphAut_pow_twistOrder,
+    inv_one, RootPairingIsogeny.ofEquiv_one, one_mul, RootPairingIsogeny.smulId_pow]
 
 end
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Steinberg.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Steinberg.lean
@@ -226,21 +226,27 @@ theorem datumSteinberg_eq_datumFrobenius_iff_twistOrder :
 
 /-- **The order relation of the graph-twisted Steinberg map**: raising `γ ∘ Frob_q` to the twist
 order returns the Frobenius of the field of that degree, `Frob_(q ^ e)`. It is milestone L1's
-`γ ^ 2 = 1` and `γ ^ 3 = 1` read on the Steinberg map itself rather than on its graph factor: the
-factor `γ` is annihilated by `TauCeti.GraphTwistedIndex.datumGraphAut_pow_twistOrder`, and it can be
-collected on one side because a scaling is central,
-`TauCeti.RootPairingIsogeny.commute_smulId`. On an untwisted family the twist order is `1` and this
-is the definition of the Frobenius. -/
+`γ ^ 2 = 1` and `γ ^ 3 = 1` read on the Steinberg map itself rather than on its graph factor. On an
+untwisted family the twist order is `1` and this is the definition of the Frobenius. -/
 theorem datumSteinberg_pow_twistOrder :
     d.datumSteinberg ^ d.twistOrder =
       RootPairingIsogeny.smulId _ (d.1.1.fieldOrderPNat ^ d.twistOrder) := by
+  -- the power splits over the two factors because a scaling is central,
   have hcomm : Commute (RootPairingIsogeny.ofEquiv d.datumGraphAut⁻¹)
       (RootPairingIsogeny.smulId
         (d.1.dynkinType.simplyConnectedRootDatum d.1.dynkinType_valid) d.1.1.fieldOrderPNat) :=
     (RootPairingIsogeny.commute_smulId _ _ _).symm
-  rw [datumSteinberg_def, ValidLieTypeIndex.datumFrobenius_def, ← RootPairingIsogeny.mul_def,
-    hcomm.mul_pow, ← RootPairingIsogeny.ofEquiv_pow, inv_pow, datumGraphAut_pow_twistOrder,
-    inv_one, RootPairingIsogeny.ofEquiv_one, one_mul, RootPairingIsogeny.smulId_pow]
+  -- and the graph factor is annihilated by the twist order.
+  have hgraph : RootPairingIsogeny.ofEquiv d.datumGraphAut⁻¹ ^ d.twistOrder = 1 := by
+    rw [← RootPairingIsogeny.ofEquiv_pow, inv_pow, datumGraphAut_pow_twistOrder, inv_one,
+      RootPairingIsogeny.ofEquiv_one]
+  calc d.datumSteinberg ^ d.twistOrder
+      = RootPairingIsogeny.ofEquiv d.datumGraphAut⁻¹ ^ d.twistOrder *
+          RootPairingIsogeny.smulId _ d.1.1.fieldOrderPNat ^ d.twistOrder := by
+        rw [datumSteinberg_def, ValidLieTypeIndex.datumFrobenius_def, ← RootPairingIsogeny.mul_def,
+          hcomm.mul_pow]
+    _ = RootPairingIsogeny.smulId _ (d.1.1.fieldOrderPNat ^ d.twistOrder) := by
+        rw [hgraph, one_mul, RootPairingIsogeny.smulId_pow]
 
 end
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean
@@ -43,9 +43,10 @@ pinned group; and its order is the superscript in the printed family name, recor
 
 * `TauCeti.GraphTwistedIndex.cartanMatrix_diagramPerm`: the permutation attached to an index is an
   automorphism of the Cartan matrix of its underlying Dynkin diagram.
-* `TauCeti.GraphTwistedIndex.diagramPerm_pow_twistOrder` and
-  `TauCeti.GraphTwistedIndex.orderOf_diagramPerm`: the twist order annihilates the permutation, and
-  is exactly its order.
+* `TauCeti.GraphTwistedIndex.diagramPerm_pow_twistOrder`,
+  `TauCeti.GraphTwistedIndex.orderOf_diagramPerm` and
+  `TauCeti.GraphTwistedIndex.twistOrder_pos`: the twist order annihilates the permutation, is
+  exactly its order, and is positive.
 
 ## Roadmap
 
@@ -314,6 +315,12 @@ map of the form `γ ∘ Frob_q`. -/
     d.diagramPerm ^ d.twistOrder = 1 := by
   rw [← orderOf_diagramPerm d]
   exact pow_orderOf_eq_one d.diagramPerm
+
+/-- The twist order of an index is positive, being the order of a permutation of a finite set. It is
+`1`, `2` or `3`, and never `0`. -/
+theorem twistOrder_pos (d : GraphTwistedIndex) : 0 < d.twistOrder := by
+  rw [← orderOf_diagramPerm d]
+  exact orderOf_pos d.diagramPerm
 
 end GraphTwistedIndex
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/HalfFrobenius.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/HalfFrobenius.lean
@@ -209,12 +209,14 @@ half-Frobenius returns the Frobenius of the field the index names, `2 ^ (2 * m +
 and Ree `F₄` families, `3 ^ (2 * m + 1)` for Ree `G₂`, and `2` for the Tits index. -/
 @[simp] theorem datumSteinberg_mul_self (e : SuzukiReeIndex) :
     e.datumSteinberg * e.datumSteinberg =
-      RootPairingIsogeny.smulId _ ⟨e.1.fieldOrder, e.1.fieldOrder_pos⟩ := by
+      RootPairingIsogeny.smulId _ e.1.1.fieldOrderPNat := by
   rw [datumSteinberg, RootPairingIsogeny.pow_mul_self_eq_smulId _ e.datumSpecialIsogeny_mul_self]
   -- The two scalings differ only in how their common value `p ^ (2 * m + 1)` is written, so all
   -- that is left is the numeric identity between the field order and that power.
   congr 1
-  exact PNat.coe_injective e.1.fieldOrder_eq_characteristic_pow.symm
+  refine PNat.coe_injective ?_
+  rw [LieTypeIndex.coe_fieldOrderPNat]
+  exact e.1.fieldOrder_eq_characteristic_pow.symm
 
 /-! ### The four pieces of data -/
 

--- a/TauCeti/LinearAlgebra/RootSystem/Isogeny/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Isogeny/Basic.lean
@@ -477,6 +477,10 @@ def id (P : RootPairing ι R M N) : RootPairingIsogeny P P :=
     (id P).exponent i = 1 := by
   rw [id, ofEquiv]
 
+/-- **The identity automorphism becomes the identity isogeny.** -/
+@[simp] theorem ofEquiv_one : ofEquiv (1 : RootPairing.Equiv P P) = id P := by
+  ext <;> simp
+
 /-- Composing an isogeny on the left with the identity isogeny does not change it. -/
 @[simp] theorem comp_id (f : RootPairingIsogeny P Q) : comp (id Q) f = f := by
   ext <;> simp [comp, id, ofEquiv]
@@ -528,8 +532,7 @@ theorem comp_ofEquiv_smulId_eq_iff [Module.Free ℤ M] [Module.Finite ℤ M]
     apply LinearEquiv.toLinearMap_injective
     exact LinearMap.ext fun x => by simpa using hx x
   · rintro rfl
-    have hone : ofEquiv (1 : RootPairing.Equiv P P) = id P := by ext <;> simp
-    rw [hone, comp_id]
+    rw [ofEquiv_one, comp_id]
 
 end RootPairingIsogeny
 

--- a/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
@@ -36,6 +36,12 @@ that component. This is the same shape as `RootPairing.Hom.weightHom`,
 `RootPairing.Hom.coweightHom` and `RootPairing.Hom.indexHom` for the endomorphism monoid of a root
 pairing, and the powers of all three components are `map_pow`.
 
+Two further maps into the monoid are recorded because the Steinberg endomorphisms of the twisted
+families are built from them: the automorphisms of the root pairing land in it multiplicatively,
+`TauCeti.RootPairingIsogeny.ofEquivHom`, and the scalings are central in it,
+`TauCeti.RootPairingIsogeny.commute_smulId`. Together they let a power of an automorphism times a
+scaling be separated into a power of each.
+
 The same hypothesis also splits the powers themselves: an even power is a scaling, and an odd power
 is a scaling times `f`, so an odd power permutes the roots exactly as `f` does while multiplying
 its exponents and its weight and coweight maps by `c ^ m`. The three special isogenies of `B₂`,
@@ -51,9 +57,14 @@ come from.
   `TauCeti.RootPairingIsogeny.indexHom`: the weight map, the coweight map and the index bijection
   as monoid homomorphisms, the coweight map into the opposite endomorphism monoid.
 * `TauCeti.RootPairingIsogeny.smulIdHom`: the scalings, as a monoid homomorphism out of `ℕ+`.
+* `TauCeti.RootPairingIsogeny.ofEquivHom`: the automorphisms of the root pairing, as a monoid
+  homomorphism into the isogeny monoid.
 
 ## Main results
 
+* `TauCeti.RootPairingIsogeny.ofEquiv_pow`: an automorphism and the isogeny it becomes have the
+  same powers.
+* `TauCeti.RootPairingIsogeny.commute_smulId`: a scaling commutes with every endo-isogeny.
 * `TauCeti.RootPairingIsogeny.pow_mul_self_eq_smulId`: a power of an isogeny whose square is a
   scaling squares to the corresponding power of that scaling.
 * `TauCeti.RootPairingIsogeny.pow_two_mul_eq_smulId` and
@@ -125,6 +136,23 @@ theorem one_def : (1 : RootPairingIsogeny P P) = id P := (rfl)
 
 @[simp] theorem exponent_one (i : ι) : (1 : RootPairingIsogeny P P).exponent i = 1 :=
   id_exponent P i
+
+/-- **The automorphisms of a root pairing sit inside its monoid of endo-isogenies**, as a monoid
+homomorphism: an automorphism is an isogeny with every exponent `1`, and composition agrees on the
+two sides. -/
+def ofEquivHom (P : RootPairing ι R M N) : RootPairing.Aut P →* RootPairingIsogeny P P where
+  toFun := ofEquiv
+  map_one' := by rw [one_def]; ext <;> simp
+  map_mul' _ _ := by ext <;> simp
+
+@[simp] theorem ofEquivHom_apply (f : RootPairing.Aut P) : ofEquivHom P f = ofEquiv f := (rfl)
+
+@[simp] theorem ofEquiv_one : ofEquiv (1 : RootPairing.Aut P) = 1 :=
+  map_one (ofEquivHom P)
+
+@[simp] theorem ofEquiv_pow (f : RootPairing.Aut P) (n : ℕ) :
+    ofEquiv (f ^ n) = ofEquiv f ^ n :=
+  map_pow (ofEquivHom P) f n
 
 /-! ## The multiplicative components -/
 
@@ -209,6 +237,14 @@ def smulIdHom : ℕ+ →* RootPairingIsogeny P P where
 /-- A power of a scaling is the scaling by the corresponding power. -/
 @[simp] theorem smulId_pow (c : ℕ+) (n : ℕ) : smulId P c ^ n = smulId P (c ^ n) :=
   (map_pow (smulIdHom P) c n).symm
+
+/-- **A scaling is central in the monoid of endo-isogenies**, the monoid form of
+`TauCeti.RootPairingIsogeny.comp_smulId`. Since a scaling at a prime power `q` is the root-datum
+shadow of the `q`-power Frobenius, this is the root-datum form of the fact that a Frobenius
+commutes with every endomorphism of the datum. -/
+theorem commute_smulId (f : RootPairingIsogeny P P) (c : ℕ+) : Commute (smulId P c) f :=
+  show smulId P c * f = f * smulId P c from
+    (mul_def _ _).trans ((comp_smulId f c).symm.trans (mul_def _ _).symm)
 
 variable {f : RootPairingIsogeny P P} {c : ℕ+}
 

--- a/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
@@ -142,13 +142,10 @@ homomorphism: an automorphism is an isogeny with every exponent `1`, and composi
 two sides. -/
 def ofEquivHom (P : RootPairing ι R M N) : RootPairing.Aut P →* RootPairingIsogeny P P where
   toFun := ofEquiv
-  map_one' := by rw [one_def]; ext <;> simp
+  map_one' := by rw [one_def]; exact ofEquiv_one
   map_mul' _ _ := by ext <;> simp
 
 @[simp] theorem ofEquivHom_apply (f : RootPairing.Aut P) : ofEquivHom P f = ofEquiv f := (rfl)
-
-@[simp] theorem ofEquiv_one : ofEquiv (1 : RootPairing.Aut P) = 1 :=
-  map_one (ofEquivHom P)
 
 /-- **An automorphism and the isogeny it becomes have the same powers**, since
 `TauCeti.RootPairingIsogeny.ofEquiv` is multiplicative. -/

--- a/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
@@ -150,6 +150,8 @@ def ofEquivHom (P : RootPairing ι R M N) : RootPairing.Aut P →* RootPairingIs
 @[simp] theorem ofEquiv_one : ofEquiv (1 : RootPairing.Aut P) = 1 :=
   map_one (ofEquivHom P)
 
+/-- **An automorphism and the isogeny it becomes have the same powers**, since
+`TauCeti.RootPairingIsogeny.ofEquiv` is multiplicative. -/
 @[simp] theorem ofEquiv_pow (f : RootPairing.Aut P) (n : ℕ) :
     ofEquiv (f ^ n) = ofEquiv f ^ n :=
   map_pow (ofEquivHom P) f n
@@ -243,8 +245,7 @@ def smulIdHom : ℕ+ →* RootPairingIsogeny P P where
 shadow of the `q`-power Frobenius, this is the root-datum form of the fact that a Frobenius
 commutes with every endomorphism of the datum. -/
 theorem commute_smulId (f : RootPairingIsogeny P P) (c : ℕ+) : Commute (smulId P c) f :=
-  show smulId P c * f = f * smulId P c from
-    (mul_def _ _).trans ((comp_smulId f c).symm.trans (mul_def _ _).symm)
+  (commute_iff_eq _ _).2 <| by rw [mul_def, mul_def, comp_smulId]
 
 variable {f : RootPairingIsogeny P P} {c : ℕ+}
 


### PR DESCRIPTION
This PR joins the two halves of the root-datum layer of the Lie-type Steinberg maps into one map defined on every valid index. `TauCeti.GraphTwistedIndex.datumSteinberg` covers the thirteen constructors whose Steinberg map is `γ ∘ Frob_q` and `TauCeti.SuzukiReeIndex.datumSteinberg` covers the four whose map is an odd power of a half-Frobenius; `TauCeti.ValidLieTypeIndex.datumSteinberg` dispatches between them on the decidable predicate `LieTypeIndex.UsesHalfFrobenius`, whose two subtypes are exactly the domains of the two constructions, so no map is invented on either branch. The two branch equations `datumSteinberg_of_usesHalfFrobenius` and `datumSteinberg_of_not_usesHalfFrobenius` are what a consumer reasons with; four worked branches at the end of the file exercise them on an untwisted family, on `²Aₙ(q)`, on `²B₂(2^(2m+1))` and on the Tits index.

The new mathematical content is what the two halves share. Neither is uniformly a Frobenius, the nine untwisted families aside, and their order relations differ: `GraphTwistedIndex.datumSteinberg_pow_twistOrder_eq_smulId` proves that raising `γ ∘ Frob_q` to the twist order gives `Frob_(q^e)`, the Frobenius of the *larger* field, while `SuzukiReeIndex.datumSteinberg_mul_self` already gave `Frob_q`, the field the index itself names, for the square of a half-Frobenius power. What is uniform is `ValidLieTypeIndex.exists_pow_datumSteinberg_eq_smulId`: some positive power of the Steinberg map is the scaling at a positive power of the characteristic, which is the root-datum form of "some power of a Steinberg endomorphism is a Frobenius". It is stated existentially precisely because the two exponents and the two scalars follow different rules.

This serves milestone L2 of `TauCetiRoadmap/CFSGStatement/README.md`, whose completion evidence asks that "`steinberg` unfolds on every branch", together with the "order relations" half of the completion evidence for L1, both read at the root-datum layer that PRs https://github.com/TauCetiProject/TauCeti/pull/5145 "feat: the special isogeny selected by a Suzuki-Ree index", https://github.com/TauCetiProject/TauCeti/pull/5159 "feat: the odd half-Frobenius power of a Suzuki-Ree index" and https://github.com/TauCetiProject/TauCeti/pull/5148 "feat: the root-datum Steinberg map of a graph-twisted index" have been building. With this PR that layer is complete: every valid index has a Steinberg map on its pinned simply connected root datum, on both sides of the half-Frobenius split. Neither L1's nor L2's completion condition is met by this PR: both are about the group layer, `ValidLieTypeIndex.steinberg` as an endomorphism of the points of a pinned Chevalley--Demazure group together with the root-subgroup equations `γ(x_α(t)) = x_{γα}(t)` and `Frob_q(x_α(t)) = x_α(t^q)`, which waits on the carriers of milestone L0 and will dispatch to the map assembled here.

Three supporting declarations land in the canonical homes of what they elaborate rather than in the new file. `RootPairingIsogeny.ofEquivHom` and `RootPairingIsogeny.commute_smulId` go to `TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean`: an automorphism of a root pairing lands in the isogeny monoid multiplicatively, and a scaling is central there, which is what lets a power of `ofEquiv γ⁻¹ * smulId q` be split into a power of each factor. `GraphTwistedIndex.twistOrder_pos` goes to `TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean` beside `orderOf_diagramPerm`, which it is read off. `GraphTwistedIndex.datumSteinberg_pow_twistOrder_eq_smulId` goes to `TauCeti/GroupTheory/SpecificGroups/CFSG/Datum/Steinberg.lean` beside the map it is about, whose import of `Isogeny.Basic` widens to `Isogeny.Power` for the monoid structure. `RootPairingIsogeny.ofEquiv_one` goes to `Isogeny/Basic.lean` beside the identity isogeny it names, replacing the fact proved inline there.

The construction reuses `GraphTwistedIndex.datumSteinberg`, `GraphTwistedIndex.datumGraphAut_pow_twistOrder`, `GraphTwistedIndex.datumSteinberg_eq_datumFrobenius_iff`, `SuzukiReeIndex.datumSteinberg`, `SuzukiReeIndex.datumSteinberg_mul_self`, `SuzukiReeIndex.datumSteinberg_tits`, `ValidLieTypeIndex.datumFrobenius`, `LieTypeIndex.fieldOrderPNat` and `RootPairingIsogeny.smulId` with its monoid API; no Mathlib or Tau Ceti material is vendored or restated. Nothing here asserts that any candidate group is finite or simple, and nothing here mentions a group scheme, its points, or a finite group. The conventions follow R. Steinberg, *Endomorphisms of linear algebraic groups*, Memoirs AMS 80 (1968), §11, and R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"validlietypeindex-datumsteinberg"}-->

🤖 Prepared with Claude Code
