### PR TITLE
feat: add GL2 linear character rows

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/NonSplitTorus.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/NonSplitTorus.lean
@@ -62,6 +62,8 @@ choice, following the convention of
 * `TauCeti.GL2NonSplitTorus`: its range, the non-split torus.
 * `TauCeti.GL2NonSplitTorus.unitsEquiv`: the resulting multiplicative equivalence `Eˣ ≃*` the
   torus.
+* `TauCeti.GL2NonSplitTorus.normUnitsHom`: the field norm on units, used to state determinant
+  character values without choosing a nonvanishing proof.
 
 ## Main results
 
@@ -163,6 +165,26 @@ theorem trace_gl2NonSplitTorusHom (x : Eˣ) :
     Matrix.trace (GL2NonSplitTorusHom F E hE x : Matrix (Fin 2) (Fin 2) F) =
       Algebra.trace F E (x : E) :=
   trace_unitsLeftMulMatrix _ x
+
+/-- **The field norm on units of a quadratic extension.** The explicit degree hypothesis supplies
+the finite-dimensional instance needed by `Algebra.norm`; packaging the result as a homomorphism
+to `Fˣ` avoids exposing a choice of proof that each norm is nonzero. -/
+noncomputable def normUnitsHom : Eˣ →* Fˣ :=
+  have := Module.finite_of_finrank_eq_succ (n := 1) hE
+  Units.map (Algebra.norm F : E →* F)
+
+/-- The value underlying the norm of a unit is the ordinary field norm. -/
+@[simp]
+theorem coe_normUnitsHom (x : Eˣ) :
+    (normUnitsHom hE x : F) = Algebra.norm F (x : E) := by
+  simp [normUnitsHom]
+
+/-- **The determinant of a non-split-torus element is its field norm, as an equality of units.** -/
+theorem det_gl2NonSplitTorusHom (x : Eˣ) :
+    Matrix.GeneralLinearGroup.det (GL2NonSplitTorusHom F E hE x) = normUnitsHom hE x := by
+  apply Units.ext
+  rw [coe_normUnitsHom]
+  exact val_det_gl2NonSplitTorusHom hE x
 
 /-- A unit of `F` is sent to the corresponding scalar matrix. -/
 @[simp, grind =]

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/NonSplitTorus.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/NonSplitTorus.lean
@@ -12,6 +12,8 @@ public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.LeftMulMatrix
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Borel
 -- `Module.finBasisOfFinrankEq` is the body of `TauCeti.nonSplitTorusBasis`.
 public import Mathlib.LinearAlgebra.Dimension.Free
+-- `TauCeti.Algebra.normUnits` states the determinant of a torus element below.
+public import TauCeti.RingTheory.Norm.Units
 -- Non-public: `Algebra.IsQuadraticExtension.exists_notMem_range_algebraMap`,
 -- `Algebra.norm_ne_zero_iff`, `Module.natCard_eq_pow_finrank` and `Nat.card_units` are used only
 -- inside proofs, so downstream importers do not pay for them.
@@ -62,8 +64,6 @@ choice, following the convention of
 * `TauCeti.GL2NonSplitTorus`: its range, the non-split torus.
 * `TauCeti.GL2NonSplitTorus.unitsEquiv`: the resulting multiplicative equivalence `Eˣ ≃*` the
   torus.
-* `TauCeti.GL2NonSplitTorus.normUnitsHom`: the field norm on units, used to state determinant
-  character values without choosing a nonvanishing proof.
 
 ## Main results
 
@@ -166,24 +166,12 @@ theorem trace_gl2NonSplitTorusHom (x : Eˣ) :
       Algebra.trace F E (x : E) :=
   trace_unitsLeftMulMatrix _ x
 
-/-- **The field norm on units of a quadratic extension.** The explicit degree hypothesis supplies
-the finite-dimensional instance needed by `Algebra.norm`; packaging the result as a homomorphism
-to `Fˣ` avoids exposing a choice of proof that each norm is nonzero. -/
-noncomputable def normUnitsHom : Eˣ →* Fˣ :=
-  have := Module.finite_of_finrank_eq_succ (n := 1) hE
-  Units.map (Algebra.norm F : E →* F)
-
-/-- The value underlying the norm of a unit is the ordinary field norm. -/
-@[simp]
-theorem coe_normUnitsHom (x : Eˣ) :
-    (normUnitsHom hE x : F) = Algebra.norm F (x : E) := by
-  simp [normUnitsHom]
-
 /-- **The determinant of a non-split-torus element is its field norm, as an equality of units.** -/
+@[simp]
 theorem det_gl2NonSplitTorusHom (x : Eˣ) :
-    Matrix.GeneralLinearGroup.det (GL2NonSplitTorusHom F E hE x) = normUnitsHom hE x := by
+    Matrix.GeneralLinearGroup.det (GL2NonSplitTorusHom F E hE x) = Algebra.normUnits F x := by
   apply Units.ext
-  rw [coe_normUnitsHom]
+  rw [Algebra.coe_normUnits]
   exact val_det_gl2NonSplitTorusHom hE x
 
 /-- A unit of `F` is sent to the corresponding scalar matrix. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -108,7 +108,10 @@ theorem finrank_GL2Linear (α : Fˣ →* ℂˣ) :
 @[simp]
 theorem character_GL2Linear (α : Fˣ →* ℂˣ) (g : GL (Fin 2) F) :
     (GL2Linear F α).character g = (α (Matrix.GeneralLinearGroup.det g) : ℂ) := by
-  exact Representation.char_ofLinearCharacter (GL2LinearChar α) g
+  rw [GL2Linear_def, GL2LinearRep_def]
+  -- the carrier of `FDRep.of ρ` is the module that `ρ` acts on, here `ℂ` itself
+  simpa only [FDRep.character, FDRep.of_ρ', Representation.character, GL2LinearChar_apply] using
+    Representation.char_ofLinearCharacter (GL2LinearChar α) g
 
 /-- **Determinant characters of `GL₂` remember their parameter.** Surjectivity of the determinant
 shows that precomposition with it is injective. -/
@@ -193,8 +196,9 @@ section FiniteField
 
 variable [Fintype F]
 
-/-- **The Steinberg representation twisted by `α ∘ det`.** These are the degree-`q` boundary
-constituents of the principal series. -/
+/-- **The Steinberg representation twisted by `α ∘ det`.** These are the expected degree-`q`
+boundary constituents of the principal series; that constituent relation is not proved here, only
+the dimension and the character values below. -/
 noncomputable def GL2SteinbergTwist (F : Type u) [Field F] [Fintype F] (α : Fˣ →* ℂˣ) :
     FDRep ℂ (GL (Fin 2) F) :=
   GL2Linear F α ⊗ GL2Steinberg F

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -132,6 +132,7 @@ theorem GL2Linear_character_injective :
   simpa using this
 
 /-- **The determinant character restricts to the boundary Borel character `α ⊗ α`.** -/
+@[simp]
 theorem GL2LinearChar_comp_gl2BorelSubtype (α : Fˣ →* ℂˣ) :
     (GL2LinearChar α).comp (GL2Borel F).subtype = GL2Borel.linearChar α α := by
   apply MonoidHom.ext
@@ -140,6 +141,7 @@ theorem GL2LinearChar_comp_gl2BorelSubtype (α : Fˣ →* ℂˣ) :
 
 /-- **The linear representation restricts to the one-dimensional Borel representation at the
 boundary pair `(α, α)`.** -/
+@[simp]
 theorem GL2LinearRep_comp_gl2BorelSubtype (α : Fˣ →* ℂˣ) :
     (GL2LinearRep α).comp (GL2Borel F).subtype = GL2Borel.linearRep α α := by
   rw [GL2LinearRep_def, Representation.ofLinearCharacter_comp,

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -8,10 +8,6 @@ module
 -- The untwisted Steinberg values and the four class representatives occur in the statements below.
 public import TauCeti.RepresentationTheory.CharacterTable.GL2.CharacterValues
 public import TauCeti.RepresentationTheory.LinearCharacter
--- Non-public: the tensor notation and dimension/character API are used only in definitions and
--- proofs; their resulting `FDRep` objects are exposed through the public imports above.
-import Mathlib.CategoryTheory.Monoidal.Category
-import TauCeti.RepresentationTheory.FDRep
 
 /-!
 # Linear characters and Steinberg twists of `GL₂(𝔽_q)`
@@ -164,8 +160,9 @@ theorem character_GL2Linear_diagGL (α : Fˣ →* ℂˣ) (a b : Fˣ) :
   rw [character_GL2Linear, det_diagGL]
   simp [Fin.prod_univ_two]
 
-/-- The linear character at a non-semisimple representative is `α(a²)`. The value is independent
-of the nonzero upper-right entry, so the formula is stated without a hypothesis on it. -/
+/-- The linear character at a Jordan-form matrix `jordanGL a b` is `α(a²)`. The value does not
+depend on the upper-right entry `b`, so no hypothesis on it is needed; the matrix represents the
+non-semisimple family exactly when `b ≠ 0`. -/
 theorem character_GL2Linear_jordanGL (α : Fˣ →* ℂˣ) (a : Fˣ) (b : F) :
     (GL2Linear F α).character (jordanGL a b) = (α (a ^ 2) : ℂ) := by
   rw [character_GL2Linear, det_jordanGL]
@@ -206,15 +203,15 @@ theorem GL2SteinbergTwist_def (α : Fˣ →* ℂˣ) :
     GL2SteinbergTwist F α = GL2Linear F α ⊗ GL2Steinberg F :=
   (rfl)
 
-/-- The Steinberg twist has dimension `q`. -/
+/-- The Steinberg twist has dimension `q`, being the tensor product of a line with the Steinberg
+representation. -/
 @[simp]
 theorem finrank_GL2SteinbergTwist (α : Fˣ →* ℂˣ) :
     Module.finrank ℂ (GL2SteinbergTwist F α) = Fintype.card F := by
-  apply Nat.cast_injective (R := ℂ)
-  rw [← FDRep.char_one (GL2SteinbergTwist F α), GL2SteinbergTwist_def,
-    congrFun (FDRep.char_tensor (GL2Linear F α) (GL2Steinberg F)) 1, Pi.mul_apply,
-    character_GL2Linear, FDRep.char_one, finrank_GL2Steinberg]
-  simp
+  -- The carrier of a tensor product in `FDRep` is the tensor product of the carriers.
+  have hcarrier : Module.finrank ℂ (GL2SteinbergTwist F α) =
+      Module.finrank ℂ (TensorProduct ℂ (GL2Linear F α) (GL2Steinberg F)) := rfl
+  rw [hcarrier, Module.finrank_tensorProduct, finrank_GL2Linear, finrank_GL2Steinberg, one_mul]
 
 /-- **The character of a Steinberg twist is the determinant character times the Steinberg
 character.** -/

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -1,0 +1,287 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- The untwisted Steinberg values and the four class representatives occur in the statements below.
+public import TauCeti.RepresentationTheory.CharacterTable.GL2.CharacterValues
+public import TauCeti.RepresentationTheory.LinearCharacter
+-- Non-public: the tensor notation and dimension/character API are used only in definitions and
+-- proofs; their resulting `FDRep` objects are exposed through the public imports above.
+import Mathlib.CategoryTheory.Monoidal.Category
+import TauCeti.RepresentationTheory.FDRep
+
+/-!
+# Linear characters and Steinberg twists of `GL₂(𝔽_q)`
+
+Every multiplicative character `α : Fˣ →* ℂˣ` gives a one-dimensional representation of
+`GL₂(F)` by precomposition with the determinant. This file packages that representation as
+`TauCeti.GL2Linear F α`, proves that distinct `α` give distinct character rows, and computes its
+character on the four families of conjugacy classes.
+
+Tensoring with `TauCeti.GL2Steinberg F` gives the corresponding Steinberg twist
+`TauCeti.GL2SteinbergTwist F α`. Its character is the pointwise product of the determinant
+character and the untwisted Steinberg character, so the four values are
+
+`q α(a²)`, `α(ab)`, `0`, and `-α(N_{E/F}(x))`
+
+on scalar, split semisimple, non-semisimple, and elliptic representatives. These are the two
+expected boundary rows of the principal series `Ind_B^{GL₂}(α ⊗ α)`; this file does not prove the
+representation-level splitting of that principal series.
+
+## Main definitions
+
+* `TauCeti.GL2LinearChar`: the character `α ∘ det` as a homomorphism to `ℂˣ`.
+* `TauCeti.GL2LinearRep`: the corresponding representation on the line `ℂ`.
+* `TauCeti.GL2Linear`: its one-dimensional representation.
+* `TauCeti.GL2SteinbergTwist`: the determinant-character twist of the Steinberg representation.
+
+## Main results
+
+* `TauCeti.character_GL2Linear` and `TauCeti.character_GL2SteinbergTwist`: the character formulas
+  at an arbitrary group element.
+* `TauCeti.GL2LinearChar_comp_gl2BorelSubtype`: restriction to the Borel subgroup is the boundary
+  character `α ⊗ α`.
+* `TauCeti.GL2Linear_character_injective`: distinct multiplicative characters give distinct rows.
+* The `_scalar`, `_diagGL`, `_jordanGL`, and `_gl2NonSplitTorusHom` theorems compute both families
+  on the four class representatives.
+
+## References
+
+* [Character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+  Layer 9, "The boundary: linear and Steinberg constituents" and "Character-value formulas".
+* W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), §5.2.
+* C. Bonnafé, *Representations of `SL₂(𝔽_q)`* (2011), Chapter 5.
+-/
+
+public section
+
+open Matrix
+open CategoryTheory.MonoidalCategory
+
+namespace TauCeti
+
+universe u
+
+section CommRing
+
+variable {F : Type u} [CommRing F]
+
+/-! ### The linear representations -/
+
+/-- **The determinant character attached to `α`.** This is the multiplicative character of
+`GL₂(F)` sending `g` to `α(det g)`. -/
+def GL2LinearChar (α : Fˣ →* ℂˣ) : GL (Fin 2) F →* ℂˣ :=
+  α.comp Matrix.GeneralLinearGroup.det
+
+@[simp]
+theorem GL2LinearChar_apply (α : Fˣ →* ℂˣ) (g : GL (Fin 2) F) :
+    GL2LinearChar α g = α (Matrix.GeneralLinearGroup.det g) :=
+  (rfl)
+
+/-- **The one-dimensional representation `α ∘ det` of `GL₂(F)`.** -/
+def GL2LinearRep (α : Fˣ →* ℂˣ) : Representation ℂ (GL (Fin 2) F) ℂ :=
+  Representation.ofLinearCharacter (GL2LinearChar α)
+
+/-- `TauCeti.GL2LinearRep` is the generic one-dimensional representation associated to
+`TauCeti.GL2LinearChar`. -/
+theorem GL2LinearRep_def (α : Fˣ →* ℂˣ) :
+    GL2LinearRep α = Representation.ofLinearCharacter (GL2LinearChar α) :=
+  (rfl)
+
+/-- **The one-dimensional representation `α ∘ det` of `GL₂(F)`, bundled in `FDRep`.** -/
+noncomputable def GL2Linear (F : Type u) [CommRing F] (α : Fˣ →* ℂˣ) :
+    FDRep ℂ (GL (Fin 2) F) :=
+  FDRep.of (GL2LinearRep α)
+
+/-- `TauCeti.GL2Linear` is the one-dimensional representation associated to
+`TauCeti.GL2LinearChar`. -/
+theorem GL2Linear_def (α : Fˣ →* ℂˣ) :
+    GL2Linear F α = FDRep.of (GL2LinearRep α) :=
+  (rfl)
+
+/-- The linear representation has dimension one. -/
+@[simp]
+theorem finrank_GL2Linear (α : Fˣ →* ℂˣ) :
+    Module.finrank ℂ (GL2Linear F α) = 1 :=
+  Module.finrank_self ℂ
+
+/-- **The character of `TauCeti.GL2Linear F α` is `α ∘ det`.** -/
+@[simp]
+theorem character_GL2Linear (α : Fˣ →* ℂˣ) (g : GL (Fin 2) F) :
+    (GL2Linear F α).character g = (α (Matrix.GeneralLinearGroup.det g) : ℂ) := by
+  exact Representation.char_ofLinearCharacter (GL2LinearChar α) g
+
+/-- **Determinant characters of `GL₂` remember their parameter.** Surjectivity of the determinant
+shows that precomposition with it is injective. -/
+theorem GL2LinearChar_injective : Function.Injective (GL2LinearChar (F := F)) := by
+  intro α β h
+  apply MonoidHom.ext
+  intro a
+  obtain ⟨g, hg⟩ := Matrix.GeneralLinearGroup.det_surjective (n := Fin 2) a
+  have := congrArg (fun χ : GL (Fin 2) F →* ℂˣ => χ g) h
+  simpa [GL2LinearChar_apply, hg] using this
+
+/-- **Distinct parameters give distinct linear character rows of `GL₂`.** -/
+theorem GL2Linear_character_injective :
+    Function.Injective fun α : Fˣ →* ℂˣ => (GL2Linear F α).character := by
+  intro α β h
+  apply GL2LinearChar_injective
+  apply MonoidHom.ext
+  intro g
+  apply Units.ext
+  have := congrFun h g
+  simpa using this
+
+/-- **The determinant character restricts to the boundary Borel character `α ⊗ α`.** -/
+theorem GL2LinearChar_comp_gl2BorelSubtype (α : Fˣ →* ℂˣ) :
+    (GL2LinearChar α).comp (GL2Borel F).subtype = GL2Borel.linearChar α α := by
+  apply MonoidHom.ext
+  intro g
+  exact (GL2Borel.linearChar_self α g).symm
+
+/-- **The linear representation restricts to the one-dimensional Borel representation at the
+boundary pair `(α, α)`.** -/
+theorem GL2Linear_comp_gl2BorelSubtype (α : Fˣ →* ℂˣ) :
+    (GL2LinearRep α).comp (GL2Borel F).subtype = GL2Borel.linearRep α α := by
+  rw [GL2LinearRep_def, Representation.ofLinearCharacter_comp,
+    GL2LinearChar_comp_gl2BorelSubtype, GL2Borel.linearRep_def]
+
+/-! ### The linear character row -/
+
+/-- The linear character at a scalar matrix is `α(a²)`. -/
+theorem character_GL2Linear_scalar (α : Fˣ →* ℂˣ) (a : Fˣ) :
+    (GL2Linear F α).character (Matrix.GeneralLinearGroup.scalar (Fin 2) a) = (α (a ^ 2) : ℂ) := by
+  rw [character_GL2Linear, Matrix.GeneralLinearGroup.det_scalar]
+  norm_num
+
+/-- The linear character at a split semisimple representative is `α(ab)`. The formula does not
+need the usual `a ≠ b` hypothesis because it is an identity for every diagonal matrix. -/
+theorem character_GL2Linear_diagGL (α : Fˣ →* ℂˣ) (a b : Fˣ) :
+    (GL2Linear F α).character (diagGL ![a, b]) = (α (a * b) : ℂ) := by
+  rw [character_GL2Linear, det_diagGL]
+  simp [Fin.prod_univ_two]
+
+/-- The linear character at a non-semisimple representative is `α(a²)`. The value is independent
+of the nonzero upper-right entry, so the formula is stated without a hypothesis on it. -/
+theorem character_GL2Linear_jordanGL (α : Fˣ →* ℂˣ) (a : Fˣ) (b : F) :
+    (GL2Linear F α).character (jordanGL a b) = (α (a ^ 2) : ℂ) := by
+  rw [character_GL2Linear, det_jordanGL]
+
+end CommRing
+
+section Field
+
+variable {F : Type u} [Field F]
+
+section Elliptic
+
+variable {E : Type*} [Field E] [Algebra F E] (hE : Module.finrank F E = 2)
+
+/-- The linear character at a non-split-torus element is the character applied to its field norm. -/
+theorem character_GL2Linear_gl2NonSplitTorusHom (α : Fˣ →* ℂˣ) (x : Eˣ) :
+    (GL2Linear F α).character (GL2NonSplitTorusHom F E hE x) =
+      (α (GL2NonSplitTorus.normUnitsHom hE x) : ℂ) := by
+  rw [character_GL2Linear, GL2NonSplitTorus.det_gl2NonSplitTorusHom]
+
+end Elliptic
+
+/-! ### The Steinberg twists -/
+
+section FiniteField
+
+variable [Fintype F]
+
+/-- **The Steinberg representation twisted by `α ∘ det`.** These are the degree-`q` boundary
+constituents of the principal series. -/
+noncomputable def GL2SteinbergTwist (F : Type u) [Field F] [Fintype F] (α : Fˣ →* ℂˣ) :
+    FDRep ℂ (GL (Fin 2) F) :=
+  GL2Linear F α ⊗ GL2Steinberg F
+
+/-- A Steinberg twist is the tensor product of the determinant character with the untwisted
+Steinberg representation. -/
+theorem GL2SteinbergTwist_def (α : Fˣ →* ℂˣ) :
+    GL2SteinbergTwist F α = GL2Linear F α ⊗ GL2Steinberg F :=
+  (rfl)
+
+/-- The Steinberg twist has dimension `q`. -/
+@[simp]
+theorem finrank_GL2SteinbergTwist (α : Fˣ →* ℂˣ) :
+    Module.finrank ℂ (GL2SteinbergTwist F α) = Fintype.card F := by
+  apply Nat.cast_injective (R := ℂ)
+  rw [← FDRep.char_one (GL2SteinbergTwist F α), GL2SteinbergTwist_def,
+    congrFun (FDRep.char_tensor (GL2Linear F α) (GL2Steinberg F)) 1, Pi.mul_apply,
+    character_GL2Linear, FDRep.char_one, finrank_GL2Steinberg]
+  simp
+
+/-- **The character of a Steinberg twist is the determinant character times the Steinberg
+character.** -/
+theorem character_GL2SteinbergTwist (α : Fˣ →* ℂˣ) (g : GL (Fin 2) F) :
+    (GL2SteinbergTwist F α).character g =
+      (α (Matrix.GeneralLinearGroup.det g) : ℂ) * (GL2Steinberg F).character g := by
+  rw [GL2SteinbergTwist_def, congrFun (FDRep.char_tensor (GL2Linear F α) (GL2Steinberg F)) g,
+    Pi.mul_apply, character_GL2Linear]
+
+/-- The Steinberg twist at a scalar matrix is `q α(a²)`. -/
+theorem character_GL2SteinbergTwist_scalar (α : Fˣ →* ℂˣ) (a : Fˣ) :
+    (GL2SteinbergTwist F α).character (Matrix.GeneralLinearGroup.scalar (Fin 2) a) =
+      (Fintype.card F : ℂ) * α (a ^ 2) := by
+  rw [character_GL2SteinbergTwist, Matrix.GeneralLinearGroup.det_scalar,
+    character_GL2Steinberg_scalar]
+  norm_num
+  ring
+
+/-- The Steinberg twist at a split semisimple representative is `α(ab)`. -/
+theorem character_GL2SteinbergTwist_diagGL (α : Fˣ →* ℂˣ) {a b : Fˣ} (hab : a ≠ b) :
+    (GL2SteinbergTwist F α).character (diagGL ![a, b]) = (α (a * b) : ℂ) := by
+  rw [character_GL2SteinbergTwist, det_diagGL, character_GL2Steinberg_diagGL hab]
+  simp [Fin.prod_univ_two]
+
+/-- **Distinct parameters give distinct Steinberg-twist character rows.** At `diag(a, 1)` the
+Steinberg character is `1` whenever `a ≠ 1`, so the row recovers `α(a)`; every character has value
+`1` at the remaining element. -/
+theorem GL2SteinbergTwist_character_injective :
+    Function.Injective fun α : Fˣ →* ℂˣ => (GL2SteinbergTwist F α).character := by
+  intro α β h
+  apply MonoidHom.ext
+  intro a
+  apply Units.ext
+  by_cases ha : a = 1
+  · subst a
+    simp
+  · have hrow := congrFun h (diagGL ![a, 1])
+    have hrow' : (GL2SteinbergTwist F α).character (diagGL ![a, 1]) =
+        (GL2SteinbergTwist F β).character (diagGL ![a, 1]) := hrow
+    rw [character_GL2SteinbergTwist_diagGL α ha,
+      character_GL2SteinbergTwist_diagGL β ha] at hrow'
+    simpa using hrow'
+
+/-- The Steinberg twist vanishes at a non-semisimple representative. -/
+theorem character_GL2SteinbergTwist_jordanGL (α : Fˣ →* ℂˣ) (a : Fˣ) {b : F}
+    (hb : b ≠ 0) :
+    (GL2SteinbergTwist F α).character (jordanGL a b) = 0 := by
+  rw [character_GL2SteinbergTwist, character_GL2Steinberg_jordanGL a hb, mul_zero]
+
+section Elliptic
+
+variable {E : Type*} [Field E] [Algebra F E] (hE : Module.finrank F E = 2)
+
+/-- The Steinberg twist at an elliptic element is the negative of `α` at its field norm. -/
+theorem character_GL2SteinbergTwist_gl2NonSplitTorusHom (α : Fˣ →* ℂˣ) {x : Eˣ}
+    (hx : (x : E) ∉ Set.range (algebraMap F E)) :
+    (GL2SteinbergTwist F α).character (GL2NonSplitTorusHom F E hE x) =
+      -(α (GL2NonSplitTorus.normUnitsHom hE x) : ℂ) := by
+  rw [character_GL2SteinbergTwist,
+    GL2NonSplitTorus.det_gl2NonSplitTorusHom hE x,
+    character_GL2Steinberg_gl2NonSplitTorusHom hE hx]
+  ring
+
+end Elliptic
+
+end FiniteField
+
+end Field
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -5,9 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
--- The untwisted Steinberg values and the four class representatives occur in the statements below.
+-- The untwisted Steinberg values and the four class representatives occur in the statements below,
+-- and this module re-exports `Representation.ofLinearCharacter`, which the definitions below use.
 public import TauCeti.RepresentationTheory.CharacterTable.GL2.CharacterValues
-public import TauCeti.RepresentationTheory.LinearCharacter
 
 /-!
 # Linear characters and Steinberg twists of `GL₂(𝔽_q)`

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -144,7 +144,7 @@ theorem GL2LinearChar_comp_gl2BorelSubtype (α : Fˣ →* ℂˣ) :
 
 /-- **The linear representation restricts to the one-dimensional Borel representation at the
 boundary pair `(α, α)`.** -/
-theorem GL2Linear_comp_gl2BorelSubtype (α : Fˣ →* ℂˣ) :
+theorem GL2LinearRep_comp_gl2BorelSubtype (α : Fˣ →* ℂˣ) :
     (GL2LinearRep α).comp (GL2Borel F).subtype = GL2Borel.linearRep α α := by
   rw [GL2LinearRep_def, Representation.ofLinearCharacter_comp,
     GL2LinearChar_comp_gl2BorelSubtype, GL2Borel.linearRep_def]
@@ -183,7 +183,7 @@ variable {E : Type*} [Field E] [Algebra F E] (hE : Module.finrank F E = 2)
 /-- The linear character at a non-split-torus element is the character applied to its field norm. -/
 theorem character_GL2Linear_gl2NonSplitTorusHom (α : Fˣ →* ℂˣ) (x : Eˣ) :
     (GL2Linear F α).character (GL2NonSplitTorusHom F E hE x) =
-      (α (GL2NonSplitTorus.normUnitsHom hE x) : ℂ) := by
+      (α (Algebra.normUnits F x) : ℂ) := by
   rw [character_GL2Linear, GL2NonSplitTorus.det_gl2NonSplitTorusHom]
 
 end Elliptic
@@ -218,6 +218,7 @@ theorem finrank_GL2SteinbergTwist (α : Fˣ →* ℂˣ) :
 
 /-- **The character of a Steinberg twist is the determinant character times the Steinberg
 character.** -/
+@[simp]
 theorem character_GL2SteinbergTwist (α : Fˣ →* ℂˣ) (g : GL (Fin 2) F) :
     (GL2SteinbergTwist F α).character g =
       (α (Matrix.GeneralLinearGroup.det g) : ℂ) * (GL2Steinberg F).character g := by
@@ -272,7 +273,7 @@ variable {E : Type*} [Field E] [Algebra F E] (hE : Module.finrank F E = 2)
 theorem character_GL2SteinbergTwist_gl2NonSplitTorusHom (α : Fˣ →* ℂˣ) {x : Eˣ}
     (hx : (x : E) ∉ Set.range (algebraMap F E)) :
     (GL2SteinbergTwist F α).character (GL2NonSplitTorusHom F E hE x) =
-      -(α (GL2NonSplitTorus.normUnitsHom hE x) : ℂ) := by
+      -(α (Algebra.normUnits F x) : ℂ) := by
   rw [character_GL2SteinbergTwist,
     GL2NonSplitTorus.det_gl2NonSplitTorusHom hE x,
     character_GL2Steinberg_gl2NonSplitTorusHom hE hx]

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Data.Complex.Basic
 public import Mathlib.RepresentationTheory.Character
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Borel
+public import TauCeti.RepresentationTheory.LinearCharacter
 public import TauCeti.RepresentationTheory.Induction.FiniteDimensional
 
 /-!
@@ -47,6 +48,8 @@ representation is not proved here.
   `α`; this is the boundary case whose principal series is reducible.
 * `TauCeti.GL2Borel.character_linearRep`: the character of a one-dimensional representation is the
   scalar it acts by.
+* `TauCeti.GL2Borel.linearRep_def`: the representation is the generic one-dimensional
+  representation associated to `TauCeti.GL2Borel.linearChar`.
 * `TauCeti.GL2BorelRep_def`: the bundled Borel representation is `TauCeti.GL2Borel.linearRep`, the
   form to reason from when the action itself, and not only its character, is needed.
 * `TauCeti.finrank_GL2PrincipalSeries` and `TauCeti.character_one_GL2PrincipalSeries`: the
@@ -150,20 +153,19 @@ variable {R : Type*} [CommRing R] {k : Type*} [CommSemiring k]
 /-- **The one-dimensional representation of the Borel subgroup** on which `b` acts by the scalar
 `TauCeti.GL2Borel.linearChar α β b`. This is the representation `α ⊗ β` that parabolic induction
 consumes. -/
-def linearRep (α β : Rˣ →* kˣ) : Representation k (GL2Borel R) k where
-  toFun g := LinearMap.lsmul k k (linearChar α β g : k)
-  map_one' := by
-    refine LinearMap.ext fun x => ?_
-    simp
-  map_mul' g h := by
-    refine LinearMap.ext fun x => ?_
-    simp only [map_mul, Units.val_mul, LinearMap.lsmul_apply, smul_eq_mul, Module.End.mul_apply]
-    ring
+def linearRep (α β : Rˣ →* kˣ) : Representation k (GL2Borel R) k :=
+  Representation.ofLinearCharacter (linearChar α β)
+
+/-- **The Borel representation is the one-dimensional representation associated to
+`TauCeti.GL2Borel.linearChar`.** -/
+theorem linearRep_def (α β : Rˣ →* kˣ) :
+    linearRep α β = Representation.ofLinearCharacter (linearChar α β) :=
+  (rfl)
 
 @[simp]
 theorem linearRep_apply (α β : Rˣ →* kˣ) (g : GL2Borel R) (x : k) :
     linearRep α β g x = (linearChar α β g : k) * x :=
-  (rfl)
+  Representation.ofLinearCharacter_apply (linearChar α β) g x
 
 end CommSemiring
 
@@ -176,12 +178,7 @@ multiplication by `c` on the line `k` is `c`. -/
 @[simp]
 theorem character_linearRep (α β : Rˣ →* kˣ) (g : GL2Borel R) :
     (linearRep (R := R) α β).character g = (linearChar α β g : k) := by
-  rw [Representation.character]
-  have h : (linearRep (R := R) (k := k) α β) g =
-      LinearMap.id.smulRight (linearChar α β g : k) := by
-    refine LinearMap.ext fun x => ?_
-    simp [mul_comm]
-  rw [h, LinearMap.trace_smulRight, LinearMap.id_apply]
+  exact Representation.char_ofLinearCharacter (linearChar α β) g
 
 end Field
 

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/Basic.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Data.Complex.Basic
-public import Mathlib.RepresentationTheory.Character
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Borel
 public import TauCeti.RepresentationTheory.LinearCharacter
 public import TauCeti.RepresentationTheory.Induction.FiniteDimensional

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
-public import Mathlib.RepresentationTheory.Character
+public import TauCeti.RepresentationTheory.LinearCharacter
 
 /-!
 # Determinant-power representations of the general linear group
@@ -40,16 +40,8 @@ section CommRing
 variable [CommRing k]
 
 /-- The one-dimensional representation of `GL n k` on which `g` acts by `det(g)^m`. -/
-def detPowerRep (m : ℤ) : Representation k (GL (Fin n) k) k where
-  toFun g := LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k)
-  map_one' := by
-    apply LinearMap.ext
-    intro x
-    simp
-  map_mul' g h := by
-    apply LinearMap.ext
-    intro x
-    simp [mul_zpow, mul_assoc]
+def detPowerRep (m : ℤ) : Representation k (GL (Fin n) k) k :=
+  Representation.ofLinearCharacter ((Matrix.GeneralLinearGroup.det : GL (Fin n) k →* kˣ) ^ m)
 
 /-- The determinant representation of `GL n k`. -/
 abbrev detRep : Representation k (GL (Fin n) k) k := detPowerRep k n 1
@@ -58,7 +50,7 @@ abbrev detRep : Representation k (GL (Fin n) k) k := detPowerRep k n 1
 @[simp]
 theorem detPowerRep_apply (m : ℤ) (g : GL (Fin n) k) (x : k) :
     detPowerRep k n m g x = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) * x := by
-  simp [detPowerRep, smul_eq_mul]
+  simp [detPowerRep]
 
 /-- The zero determinant power is the trivial representation. -/
 @[simp]
@@ -111,20 +103,7 @@ theorem detPowerRep_neg_apply (m : ℤ) (g : GL (Fin n) k) (x : k) :
 @[simp]
 theorem char_detPowerRep (m : ℤ) (g : GL (Fin n) k) :
     (detPowerRep k n m).character g = (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) := by
-  rw [Representation.character]
-  have haction : detPowerRep k n m g =
-      LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) := by
-    apply LinearMap.ext
-    intro x
-    simp only [detPowerRep_apply, LinearMap.lsmul_apply, smul_eq_mul]
-  rw [haction]
-  have hlsmul : LinearMap.lsmul k k (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) =
-      LinearMap.id.smulRight (↑((Matrix.GeneralLinearGroup.det g) ^ m) : k) := by
-    apply LinearMap.ext
-    intro x
-    simp [LinearMap.lsmul_apply, mul_comm]
-  rw [hlsmul]
-  simp only [LinearMap.trace_smulRight, LinearMap.id_apply]
+  exact Representation.char_ofLinearCharacter _ g
 
 /-- The bundled determinant-power character is the corresponding determinant power. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/LinearCharacter.lean
+++ b/TauCeti/RepresentationTheory/LinearCharacter.lean
@@ -63,6 +63,7 @@ theorem ofLinearCharacter_apply [CommSemiring k] [Monoid G] (χ : G →* kˣ) (g
   (rfl)
 
 /-- **Restricting a one-dimensional representation is precomposition of its character.** -/
+@[simp]
 theorem ofLinearCharacter_comp [CommSemiring k] [Monoid G] {H : Type*} [Monoid H]
     (χ : G →* kˣ) (f : H →* G) :
     (ofLinearCharacter χ).comp f = ofLinearCharacter (χ.comp f) := by

--- a/TauCeti/RepresentationTheory/LinearCharacter.lean
+++ b/TauCeti/RepresentationTheory/LinearCharacter.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RepresentationTheory.Character
+
+/-!
+# One-dimensional representations from linear characters
+
+A multiplicative character `χ : G →* kˣ` acts on the one-dimensional `k`-module `k` by scalar
+multiplication. This file packages that action as `Representation.ofLinearCharacter χ` and records
+the character, functoriality, and injectivity statements that let later constructions reason from
+`χ` rather than unfold the representation.
+
+The construction is the common core of the linear characters of the Borel subgroup and of
+`GL₂`; keeping it here avoids separate scalar-action implementations for each group.
+
+## Main definitions
+
+* `Representation.ofLinearCharacter`: the one-dimensional representation associated to a
+  unit-valued multiplicative character.
+
+## Main results
+
+* `Representation.ofLinearCharacter_apply`: the action is multiplication by the character value.
+* `Representation.ofLinearCharacter_comp`: restriction of the representation is precomposition of
+  the character.
+* `Representation.ofLinearCharacter_injective`: the representation remembers its character.
+* `Representation.char_ofLinearCharacter`: the trace character is the original character, coerced
+  into the coefficient field.
+-/
+
+public section
+
+universe u v
+
+namespace Representation
+
+variable {k : Type u} {G : Type v}
+
+/-- **The one-dimensional representation associated to a multiplicative character.** An element
+`g : G` acts on the line `k` by multiplication by the unit `χ g`. -/
+def ofLinearCharacter [CommSemiring k] [Monoid G] (χ : G →* kˣ) : Representation k G k where
+  toFun g := LinearMap.lsmul k k (χ g : k)
+  map_one' := by
+    apply LinearMap.ext
+    intro x
+    simp
+  map_mul' g h := by
+    apply LinearMap.ext
+    intro x
+    simp only [map_mul, Units.val_mul, LinearMap.lsmul_apply, smul_eq_mul,
+      Module.End.mul_apply]
+    rw [mul_assoc]
+
+/-- The representation associated to `χ` acts by multiplication by `χ`. -/
+@[simp]
+theorem ofLinearCharacter_apply [CommSemiring k] [Monoid G] (χ : G →* kˣ) (g : G) (x : k) :
+    ofLinearCharacter χ g x = (χ g : k) * x :=
+  (rfl)
+
+/-- **Restricting a one-dimensional representation is precomposition of its character.** -/
+theorem ofLinearCharacter_comp [CommSemiring k] [Monoid G] {H : Type*} [Monoid H]
+    (χ : G →* kˣ) (f : H →* G) :
+    (ofLinearCharacter χ).comp f = ofLinearCharacter (χ.comp f) := by
+  apply MonoidHom.ext
+  intro h
+  apply LinearMap.ext
+  intro x
+  rfl
+
+/-- **The one-dimensional representation remembers its multiplicative character.** -/
+theorem ofLinearCharacter_injective [CommSemiring k] [Monoid G] :
+    Function.Injective (ofLinearCharacter : (G →* kˣ) → Representation k G k) := by
+  intro χ ψ h
+  apply MonoidHom.ext
+  intro g
+  apply Units.ext
+  have := congrArg (fun ρ : Representation k G k => ρ g 1) h
+  simpa using this
+
+/-- **The trace character of a one-dimensional representation is its multiplicative character.** -/
+@[simp]
+theorem char_ofLinearCharacter [Field k] [Monoid G] (χ : G →* kˣ) (g : G) :
+    (ofLinearCharacter χ).character g = (χ g : k) := by
+  rw [character]
+  have h : ofLinearCharacter χ g = LinearMap.id.smulRight (χ g : k) := by
+    apply LinearMap.ext
+    intro x
+    simp [mul_comm]
+  rw [h, LinearMap.trace_smulRight, LinearMap.id_apply]
+
+end Representation

--- a/TauCeti/RingTheory/Norm/Units.lean
+++ b/TauCeti/RingTheory/Norm/Units.lean
@@ -16,7 +16,7 @@ statement about the norm of an invertible element wants: the value is a unit by 
 no choice of proof that it is nonzero has to be carried alongside it.
 
 No finiteness hypothesis is needed here, because `Algebra.norm` itself has none: it is the
-determinant of multiplication, which is `1` when `S` is not a finite free `R`-module
+determinant of multiplication, which is `1` when `S` is not module-finite over `R`
 (`Algebra.norm_eq_one_of_not_module_finite`). A consumer that cares about the value — for instance
 the non-split torus of `GL₂` in
 `TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/NonSplitTorus.lean` — supplies its own

--- a/TauCeti/RingTheory/Norm/Units.lean
+++ b/TauCeti/RingTheory/Norm/Units.lean
@@ -24,7 +24,7 @@ finiteness where the value is computed.
 
 ## Main definitions
 
-* `TauCeti.Algebra.normUnits`: the field norm read as a homomorphism `Sˣ →* Rˣ`.
+* `TauCeti.Algebra.normUnits`: the algebra norm read as a homomorphism `Sˣ →* Rˣ`.
 -/
 
 public section

--- a/TauCeti/RingTheory/Norm/Units.lean
+++ b/TauCeti/RingTheory/Norm/Units.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Norm.Defs
+
+/-!
+# The norm on unit groups
+
+The norm `Algebra.norm R : S →* R` of an `R`-algebra is multiplicative, so it sends units to
+units. `TauCeti.Algebra.normUnits` packages that as a homomorphism `Sˣ →* Rˣ`. This is the form a
+statement about the norm of an invertible element wants: the value is a unit by construction, so
+no choice of proof that it is nonzero has to be carried alongside it.
+
+No finiteness hypothesis is needed here, because `Algebra.norm` itself has none: it is the
+determinant of multiplication, which is `1` when `S` is not a finite free `R`-module
+(`Algebra.norm_eq_one_of_not_module_finite`). A consumer that cares about the value — for instance
+the non-split torus of `GL₂` in
+`TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/NonSplitTorus.lean` — supplies its own
+finiteness where the value is computed.
+
+## Main definitions
+
+* `TauCeti.Algebra.normUnits`: the field norm read as a homomorphism `Sˣ →* Rˣ`.
+-/
+
+public section
+
+namespace TauCeti
+
+variable (R : Type*) [CommRing R] {S : Type*} [Ring S] [Algebra R S]
+
+/-- **The norm as a homomorphism of unit groups.** The norm of a unit is a unit, because the norm
+is multiplicative; this is `Algebra.norm R` read as a map `Sˣ →* Rˣ`. -/
+noncomputable def Algebra.normUnits : Sˣ →* Rˣ :=
+  Units.map (Algebra.norm R : S →* R)
+
+/-- The value underlying `TauCeti.Algebra.normUnits` is the ordinary norm. -/
+@[simp]
+theorem Algebra.coe_normUnits (x : Sˣ) : (Algebra.normUnits R x : R) = Algebra.norm R (x : S) := by
+  simp [Algebra.normUnits]
+
+end TauCeti


### PR DESCRIPTION
This PR adds the linear characters `α ∘ det` of `GL₂(F)` and their Steinberg twists, proves that their parameters give distinct character rows, and computes both families on the central, split, unipotent, and elliptic class representatives.

It advances `RepresentationTheory/CharacterTheory`, Layer 9, at the milestone “The boundary: linear and Steinberg constituents” and its “Character-value formulas (build targets)” bullet. This is the most direct next step because the class representatives, untwisted Steinberg row, and principal-series values are already on `main`; the new rows use all three and close the value-formula part of the boundary families. After this PR, Layer 9 still needs the representation-level splitting of `Ind_B(α α)`, the boundary-family count statements, the cuspidal representations and values, and final table assembly.

The supporting API factors unit-valued group characters into one-dimensional representations, reuses it for the existing Borel and determinant-power scalar actions, and adds the unit-valued norm bridge required to state the elliptic values without coercion noise. The mathematics follows the roadmap's cited standard descriptions in Fulton–Harris, §5.2, and Bonnafé, Chapter 5; no code or proof was migrated from the disposable source snapshot, and no Mathlib implementation was vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"gl2-linear-characters"}-->

🤖 Prepared with Codex
