### PR TITLE
feat: factor the type-A Steinberg map through its graph automorphism

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean
@@ -50,8 +50,9 @@ and the two factorizations
 ```text
 F = γ ∘ Frob_q = Frob_q ∘ γ
 ```
-carry the relations that milestone L1 asks of a graph-twisted Steinberg map: `γ` has the order of
-the diagram permutation it realizes, and it commutes with the Frobenius.
+carry the relations that milestone L1 asks of a graph-twisted Steinberg map: the twist order of the
+diagram permutation `γ` realizes annihilates `γ`, that is `γ = 1` on `A_r(q)` and `γ ^ 2 = 1` on
+`²A_r(q)`, and `γ` commutes with the Frobenius. Its exact order is not proved here.
 
 The branch equations `steinberg_ofA` and `steinberg_ofTwistedA` name the Steinberg map of each
 family as `TauCeti.SlStd.frobenius` and `TauCeti.SlStd.twistedFrobenius` outright, so the upstream

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean
@@ -41,6 +41,18 @@ on `²A_r(q)` the reversal `i ↦ i.rev` of the zero-based Bourbaki numbering. F
 `TauCeti.TypeALieIndex.Group d` applies the roadmap's fixed-points, derived-subgroup, and
 central-quotient recipe to this endomorphism.
 
+The Steinberg map is also split back into its two factors. `TauCeti.TypeALieIndex.frobenius` is the
+`q`-power Frobenius, which is the same map on both families, and
+`TauCeti.TypeALieIndex.graphAut` is the pinned graph automorphism realizing the index's diagram
+permutation: the identity on `A_r(q)` and signed reverse inverse transpose on `²A_r(q)`. Their
+pinned equations are `Frob_q (x_i(u)) = x_i(u ^ q)` and the sign-free `γ (x_i(u)) = x_{γ i}(u)`,
+and the two factorizations
+```text
+F = γ ∘ Frob_q = Frob_q ∘ γ
+```
+carry the relations that milestone L1 asks of a graph-twisted Steinberg map: `γ` has the order of
+the diagram permutation it realizes, and it commutes with the Frobenius.
+
 The branch equations `steinberg_ofA` and `steinberg_ofTwistedA` name the Steinberg map of each
 family as `TauCeti.SlStd.frobenius` and `TauCeti.SlStd.twistedFrobenius` outright, so the upstream
 results about those maps apply to `d.steinberg` directly and are not restated here. The upstream
@@ -52,12 +64,11 @@ for the composite Steinberg map. The fixed-point identification
 `TauCeti.SlStd.map_subtype_fixedSubgroup_twistedFrobenius_le` are available in the same way. The
 lemma `simpleRootSubgroup_def` plays this role for the root subgroups.
 
-This closes the type-A branch of milestones L0 and L3 and advances milestone L1 of
-`TauCetiRoadmap/CFSGStatement/README.md`. L1 still needs an index-level `graphAut` on the type-A
-branch of `GraphTwistedIndex`, together with its pinned simple-root equation
-`γ (x_i(u)) = x_{γ i}(u)`. This file does not define the uniform
-`ValidLieTypeIndex.AmbientGroup`: the other Dynkin types still need their full-weight carriers.
-Nothing here asserts that a constructed group is finite or simple.
+This closes the type-A branch of milestones L0, L1 and L3 of
+`TauCetiRoadmap/CFSGStatement/README.md`. This file does not define the uniform
+`ValidLieTypeIndex.AmbientGroup`, `ValidLieTypeIndex.frobenius` or `GraphTwistedIndex.graphAut`:
+the other Dynkin types still need their full-weight carriers. Nothing here asserts that a
+constructed group is finite or simple.
 
 ## Main declarations
 
@@ -70,6 +81,18 @@ Nothing here asserts that a constructed group is finite or simple.
   `TauCeti.TypeALieIndex.steinberg_ofTwistedA`: Frobenius on `A_r(q)` and graph-twisted Frobenius
   on `²A_r(q)`.
 * `TauCeti.TypeALieIndex.steinberg_simpleRootSubgroup`: the pinned simple-root-subgroup equation.
+* `TauCeti.TypeALieIndex.frobenius` and `TauCeti.TypeALieIndex.frobenius_simpleRootSubgroup`: the
+  `q`-power Frobenius factor and its pinned equation.
+* `TauCeti.TypeALieIndex.graphAut`, with `TauCeti.TypeALieIndex.graphAut_ofA` and
+  `TauCeti.TypeALieIndex.graphAut_ofTwistedA`: the pinned graph automorphism factor.
+* `TauCeti.TypeALieIndex.graphAut_simpleRootSubgroup`: its pinned simple-root-subgroup equation
+  `γ (x_i(u)) = x_{γ i}(u)`, with no field power and no sign.
+* `TauCeti.TypeALieIndex.graphAut_pow_twistOrder` and
+  `TauCeti.TypeALieIndex.graphAut_comp_frobenius`: the order relation on the graph factor, and its
+  commutation with the Frobenius.
+* `TauCeti.TypeALieIndex.steinberg_eq_graphAut_comp_frobenius` and
+  `TauCeti.TypeALieIndex.steinberg_eq_frobenius_comp_graphAut`: the Steinberg map is the composite
+  of the two factors, in either order.
 * `TauCeti.TypeALieIndex.FixedPoints` and `TauCeti.TypeALieIndex.Group`: the fixed group and its
   derived central quotient.
 
@@ -171,6 +194,149 @@ theorem steinberg_simpleRootSubgroup (d : TypeALieIndex) (i : Fin d.1.rank)
     change SlStd.rootSubgroupPoints rank (SlStd.graphRootPerm rank (.inl i)) _ _ =
       SlStd.rootSubgroupPoints rank (.inl (graphPermA rank i)) _ _
     rw [SlStd.graphRootPerm_inl, graphPermA_apply]
+
+/-! ## The two factors of the Steinberg map -/
+
+/-- **The `q`-power Frobenius endomorphism of a type-A ambient group**, for `q` the Frobenius
+parameter recorded by the index. It is the same map on both type-A families: what distinguishes
+`²A_r(q)` from `A_r(q)` is the graph automorphism `TauCeti.TypeALieIndex.graphAut` its Steinberg
+map composes with this one. -/
+noncomputable def frobenius (d : TypeALieIndex) : d.AmbientGroup →* d.AmbientGroup :=
+  SlStd.frobenius d.1.rank d.1.characteristic d.1.fieldExponent d.1.Closure
+
+/-- The Frobenius of a type-A index is the standard carrier's Frobenius at the characteristic and
+field exponent recorded by the index. -/
+theorem frobenius_def (d : TypeALieIndex) :
+    d.frobenius = SlStd.frobenius d.1.rank d.1.characteristic d.1.fieldExponent d.1.Closure :=
+  (rfl)
+
+/-- **The Frobenius fixes the Bourbaki numbering of a positive simple-root subgroup and raises its
+parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. -/
+@[simp]
+theorem frobenius_simpleRootSubgroup (d : TypeALieIndex) (i : Fin d.1.rank)
+    (u : Multiplicative d.1.Closure) :
+    d.frobenius (d.simpleRootSubgroup i u) =
+      d.simpleRootSubgroup i (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.fieldOrder)) := by
+  rw [frobenius_def, simpleRootSubgroup_def, SlStd.frobenius_rootSubgroupPoints,
+    ValidLieTypeIndex.fieldOrder_eq_characteristic_pow]
+
+/-- **The pinned graph automorphism of a validated type-A index.** It realizes on the ambient group
+the diagram permutation `TauCeti.GraphTwistedIndex.diagramPerm` already attached to the index: it is
+the identity on `A_r(q)`, whose diagram permutation is trivial, and signed reverse inverse transpose
+on `²A_r(q)`, which reverses the Bourbaki numbering.
+
+The two branch equations `graphAut_ofA` and `graphAut_ofTwistedA` name the selected map on each
+family, so no consumer needs this body. -/
+noncomputable def graphAut (d : TypeALieIndex) : MulAut d.AmbientGroup :=
+  -- As in `steinberg`, matching on `d.1.1` rather than destructuring `d` keeps the validated index
+  -- `d.1` a variable, which is what lets `d.1.rank` and `d.1.Closure` be found uniformly in every
+  -- branch.
+  match h : d.1.1 with
+  | .A _ _ => 1
+  | .twistedA _ _ => SlStd.graphAutomorphismPoints d.1.rank d.1.Closure
+  | .B _ _ | .C _ _ | .D _ _ | .twistedD _ _ | .E6 _ | .E7 _ | .E8 _ | .F4 _ | .G2 _
+  | .twistedE6 _ | .trialityD4 _ | .suzuki _ | .reeG2 _ | .reeF4 _ | .tits =>
+      absurd d.2 (by rw [LieTypeIndex.isTypeA_iff, h]; exact not_false)
+
+/-- On `A_r(q)` the graph automorphism is trivial: the `A_r` diagram symmetry is not used by the
+untwisted family. -/
+theorem graphAut_ofA (rank : ℕ) (q : PrimePower) (hvalid : (LieTypeIndex.A rank q).Valid) :
+    (ofA rank q hvalid).graphAut = 1 := by
+  simp only [graphAut]
+
+/-- On `²A_r(q)` the graph automorphism is the standard carrier's pinned graph automorphism, signed
+reverse inverse transpose. -/
+theorem graphAut_ofTwistedA (rank : ℕ) (q : PrimePower)
+    (hvalid : (LieTypeIndex.twistedA rank q).Valid) :
+    (ofTwistedA rank q hvalid).graphAut =
+      SlStd.graphAutomorphismPoints (ofTwistedA rank q hvalid).1.rank
+        (ofTwistedA rank q hvalid).1.Closure := by
+  simp only [graphAut]
+
+/-- **The graph automorphism has the pinned action on every positive simple-root subgroup**: it
+sends `x_i(u)` to `x_{γ i}(u)`, where `γ` is the diagram permutation of the index. The parameter is
+carried across unchanged, with neither a field power nor a sign; on a general root the equation
+would acquire a sign forced by the Chevalley structure constants. -/
+@[simp]
+theorem graphAut_simpleRootSubgroup (d : TypeALieIndex) (i : Fin d.1.rank)
+    (u : Multiplicative d.1.Closure) :
+    d.graphAut (d.simpleRootSubgroup i u) =
+      d.simpleRootSubgroup (d.toGraphTwistedIndex.diagramPerm i) u := by
+  rcases d.exists_eq_ofA_or_exists_eq_ofTwistedA with
+    ⟨rank, q, hvalid, rfl⟩ | ⟨rank, q, hvalid, rfl⟩
+  · rw [graphAut_ofA, MulAut.one_apply, GraphTwistedIndex.diagramPerm_A, Equiv.Perm.one_apply]
+  · rw [graphAut_ofTwistedA, simpleRootSubgroup_def, simpleRootSubgroup_def,
+      SlStd.graphAutomorphismPoints_rootSubgroupPoints, GraphTwistedIndex.diagramPerm_twistedA]
+    -- As in `steinberg_simpleRootSubgroup`, the remaining two equations `SlStd.graphRootPerm_inl`
+    -- and `graphPermA_apply` are stated for a node of `Fin rank`, whereas the goal types its node
+    -- by the unreduced `Fin (LieTypeIndex.twistedA rank q).dynkinType.rank`. The two agree by the
+    -- exposed `LieTypeIndex.dynkinType` and `DynkinType.rank`. Present the goal in the reduced form
+    -- once, rather than at each rewrite.
+    change Fin rank at i
+    change SlStd.rootSubgroupPoints rank (SlStd.graphRootPerm rank (.inl i)) _ _ =
+      SlStd.rootSubgroupPoints rank (.inl (graphPermA rank i)) _ _
+    rw [SlStd.graphRootPerm_inl, graphPermA_apply]
+
+/-- **The graph automorphism of a type-A index is an involution.** -/
+@[simp]
+theorem graphAut_graphAut (d : TypeALieIndex) (g : d.AmbientGroup) :
+    d.graphAut (d.graphAut g) = g := by
+  rcases d.exists_eq_ofA_or_exists_eq_ofTwistedA with
+    ⟨rank, q, hvalid, rfl⟩ | ⟨rank, q, hvalid, rfl⟩
+  · rw [graphAut_ofA, MulAut.one_apply, MulAut.one_apply]
+  · rw [graphAut_ofTwistedA, SlStd.graphAutomorphismPoints_graphAutomorphismPoints]
+
+/-- The graph automorphism of a type-A index squares to the identity in the automorphism group. -/
+theorem graphAut_mul_self (d : TypeALieIndex) : d.graphAut * d.graphAut = 1 :=
+  MulEquiv.ext fun g => by rw [MulAut.mul_apply, graphAut_graphAut, MulAut.one_apply]
+
+/-- **The twist order of a type-A index annihilates its graph automorphism**, so `γ = 1` on
+`A_r(q)` and `γ ^ 2 = 1` on `²A_r(q)`. This is the order relation milestone L1 asks of the graph
+factor of a Steinberg map, and it matches `TauCeti.GraphTwistedIndex.diagramPerm_pow_twistOrder` on
+the diagram permutation that `γ` realizes. -/
+@[simp]
+theorem graphAut_pow_twistOrder (d : TypeALieIndex) :
+    d.graphAut ^ d.toGraphTwistedIndex.twistOrder = 1 := by
+  rcases d.exists_eq_ofA_or_exists_eq_ofTwistedA with
+    ⟨rank, q, hvalid, rfl⟩ | ⟨rank, q, hvalid, rfl⟩
+  · rw [graphAut_ofA, one_pow]
+  · rw [GraphTwistedIndex.twistOrder_twistedA, pow_two, graphAut_mul_self]
+
+/-- **The graph automorphism commutes with the Frobenius.** -/
+theorem graphAut_frobenius (d : TypeALieIndex) (g : d.AmbientGroup) :
+    d.graphAut (d.frobenius g) = d.frobenius (d.graphAut g) := by
+  rcases d.exists_eq_ofA_or_exists_eq_ofTwistedA with
+    ⟨rank, q, hvalid, rfl⟩ | ⟨rank, q, hvalid, rfl⟩
+  · rw [graphAut_ofA, MulAut.one_apply, MulAut.one_apply]
+  · rw [graphAut_ofTwistedA, frobenius_def, SlStd.graphAutomorphismPoints_frobenius]
+
+/-- The graph automorphism commutes with the Frobenius, as an identity of endomorphisms. This is
+the relation `γ ∘ Frob_q = Frob_q ∘ γ` required of the graph-twisted families by milestone L1. -/
+theorem graphAut_comp_frobenius (d : TypeALieIndex) :
+    d.graphAut.toMonoidHom.comp d.frobenius = d.frobenius.comp d.graphAut.toMonoidHom :=
+  MonoidHom.ext fun g => by
+    simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom]
+    exact d.graphAut_frobenius g
+
+/-- **The Steinberg map of a type-A index is its graph automorphism composed with its Frobenius**,
+uniformly on both families. On `A_r(q)` the graph factor is trivial, so the composite is the
+Frobenius itself. -/
+theorem steinberg_eq_graphAut_comp_frobenius (d : TypeALieIndex) :
+    d.steinberg = d.graphAut.toMonoidHom.comp d.frobenius := by
+  refine MonoidHom.ext fun g => ?_
+  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom]
+  rcases d.exists_eq_ofA_or_exists_eq_ofTwistedA with
+    ⟨rank, q, hvalid, rfl⟩ | ⟨rank, q, hvalid, rfl⟩
+  · rw [steinberg_ofA, graphAut_ofA, frobenius_def, MulAut.one_apply]
+  · rw [steinberg_ofTwistedA, graphAut_ofTwistedA, frobenius_def, SlStd.twistedFrobenius_apply]
+
+/-- The Steinberg map may equally be read with its Frobenius factor last, the two factors
+commuting. -/
+theorem steinberg_eq_frobenius_comp_graphAut (d : TypeALieIndex) :
+    d.steinberg = d.frobenius.comp d.graphAut.toMonoidHom := by
+  rw [steinberg_eq_graphAut_comp_frobenius, graphAut_comp_frobenius]
+
+/-! ## The finite-group candidate -/
 
 /-- The fixed subgroup of the Steinberg endomorphism attached to a type-A index. -/
 abbrev FixedPoints (d : TypeALieIndex) : Type :=

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean
@@ -205,12 +205,6 @@ map composes with this one. -/
 noncomputable def frobenius (d : TypeALieIndex) : d.AmbientGroup →* d.AmbientGroup :=
   SlStd.frobenius d.1.rank d.1.characteristic d.1.fieldExponent d.1.Closure
 
-/-- The Frobenius of a type-A index is the standard carrier's Frobenius at the characteristic and
-field exponent recorded by the index. -/
-theorem frobenius_def (d : TypeALieIndex) :
-    d.frobenius = SlStd.frobenius d.1.rank d.1.characteristic d.1.fieldExponent d.1.Closure :=
-  (rfl)
-
 /-- **The Frobenius fixes the Bourbaki numbering of a positive simple-root subgroup and raises its
 parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. -/
 @[simp]
@@ -218,7 +212,7 @@ theorem frobenius_simpleRootSubgroup (d : TypeALieIndex) (i : Fin d.1.rank)
     (u : Multiplicative d.1.Closure) :
     d.frobenius (d.simpleRootSubgroup i u) =
       d.simpleRootSubgroup i (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.fieldOrder)) := by
-  rw [frobenius_def, simpleRootSubgroup_def, SlStd.frobenius_rootSubgroupPoints,
+  rw [TypeALieIndex.frobenius, simpleRootSubgroup_def, SlStd.frobenius_rootSubgroupPoints,
     ValidLieTypeIndex.fieldOrder_eq_characteristic_pow]
 
 /-- **The pinned graph automorphism of a validated type-A index.** It realizes on the ambient group
@@ -309,7 +303,7 @@ theorem graphAut_frobenius (d : TypeALieIndex) (g : d.AmbientGroup) :
   rcases d.exists_eq_ofA_or_exists_eq_ofTwistedA with
     ⟨rank, q, hvalid, rfl⟩ | ⟨rank, q, hvalid, rfl⟩
   · rw [graphAut_ofA, MulAut.one_apply, MulAut.one_apply]
-  · rw [graphAut_ofTwistedA, frobenius_def, SlStd.graphAutomorphismPoints_frobenius]
+  · rw [graphAut_ofTwistedA, TypeALieIndex.frobenius, SlStd.graphAutomorphismPoints_frobenius]
 
 /-- The graph automorphism commutes with the Frobenius, as an identity of endomorphisms. This is
 the relation `γ ∘ Frob_q = Frob_q ∘ γ` required of the graph-twisted families by milestone L1. -/
@@ -328,8 +322,9 @@ theorem steinberg_eq_graphAut_comp_frobenius (d : TypeALieIndex) :
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom]
   rcases d.exists_eq_ofA_or_exists_eq_ofTwistedA with
     ⟨rank, q, hvalid, rfl⟩ | ⟨rank, q, hvalid, rfl⟩
-  · rw [steinberg_ofA, graphAut_ofA, frobenius_def, MulAut.one_apply]
-  · rw [steinberg_ofTwistedA, graphAut_ofTwistedA, frobenius_def, SlStd.twistedFrobenius_apply]
+  · rw [steinberg_ofA, graphAut_ofA, TypeALieIndex.frobenius, MulAut.one_apply]
+  · rw [steinberg_ofTwistedA, graphAut_ofTwistedA, TypeALieIndex.frobenius,
+      SlStd.twistedFrobenius_apply]
 
 /-- The Steinberg map may equally be read with its Frobenius factor last, the two factors
 commuting. -/


### PR DESCRIPTION
This PR factors the Steinberg map of a validated type-A index into the two maps the classification list builds it from, and proves the relations the roadmap requires of them. `TauCeti.TypeALieIndex.frobenius` is the `q`-power Frobenius of the ambient group, the same map on `A_r(q)` and `²A_r(q)`, and `TauCeti.TypeALieIndex.graphAut` is the pinned graph automorphism realizing the index's own `TauCeti.GraphTwistedIndex.diagramPerm`: trivial on `A_r(q)`, and the standard carrier's signed reverse inverse transpose on `²A_r(q)`. The two pinned equations are `Frob_q (x_i(u)) = x_i(u ^ q)` and the sign-free, power-free `γ (x_i(u)) = x_{γ i}(u)` on every Bourbaki-numbered positive simple-root subgroup, the second restricted to simple roots exactly as the roadmap insists, since on a general root it acquires a sign forced by the Chevalley structure constants.

The relations are the ones milestone L1 asks of a graph-twisted Steinberg map. `graphAut_pow_twistOrder` is the order relation, `γ ^ 1 = 1` on the untwisted family and `γ ^ 2 = 1` on the twisted one, stated against the same `TauCeti.GraphTwistedIndex.twistOrder` that `TauCeti.GraphTwistedIndex.diagramPerm_pow_twistOrder` uses on the permutation `γ` realizes, so the group-level and diagram-level order relations are not two independent conventions. `graphAut_comp_frobenius` is the commutation `γ ∘ Frob_q = Frob_q ∘ γ`. Together they give `steinberg_eq_graphAut_comp_frobenius` and `steinberg_eq_frobenius_comp_graphAut`: the branch-defined `TauCeti.TypeALieIndex.steinberg` is the uniform composite `γ ∘ Frob_q` of the roadmap's L1 table, in either order, on both type-A families at once. `graphAut` is valued in `MulAut` rather than in monoid endomorphisms so that the order relation is an equation in a group; `.toMonoidHom` recovers the roadmap's signature where a consumer wants it.

This advances milestone L1, "ordinary and graph-twisted Steinberg maps", of `TauCetiRoadmap/CFSGStatement/README.md`, whose table sets the Steinberg map of `²A` to `γ₂ ∘ Frob_q` with required relations `γ₂ ^ 2 = 1` and "`γ₂` commutes with `Frob_q`", and whose target signatures in `CFSGStatement/Suggested.lean` are `ValidLieTypeIndex.frobenius`, `ValidLieTypeIndex.frobenius_simpleRootSubgroup`, `GraphTwistedIndex.graphAut` and `GraphTwistedIndex.graphAut_simpleRootSubgroup`. It is the step the merged `CFSG/TypeA.lean` named as the remaining L1 work on this branch. What remains of L1 after this PR is the other twelve constructors of `GraphTwistedIndex`: `graphAut` and its pinned equation can be stated for a family only once L0 has given that family a pinned ambient group, and outside type A no such carrier exists yet, so the uniform `ValidLieTypeIndex.frobenius` and `GraphTwistedIndex.graphAut` still wait on the remaining full-weight carriers.

The declarations go into the existing `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean` beside `steinberg`, which they factor and whose branch equations they are proved from, rather than into a new module; the file grows by 172 lines to 353, and its module docstring is updated to describe the factorization and to drop the note that named this work as outstanding. Everything is built from the already-landed carrier API: `TauCeti.SlStd.frobenius`, `TauCeti.SlStd.graphAutomorphismPoints` with its involution, root-subgroup and Frobenius-commutation lemmas, and `TauCeti.SlStd.twistedFrobenius_apply`. No Mathlib infrastructure is vendored, and nothing here asserts that a constructed group is finite, perfect or simple.

Conventions follow R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17, and R. Steinberg, *Endomorphisms of linear algebraic groups*, §11, as already cited by the file.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"typealieindex-graphaut"}-->

🤖 Prepared with Claude Code
