### PR TITLE
feat: add E6 minuscule toral carrier

### DIFF
--- a/TauCeti/Algebra/Lie/E6/Minuscule/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/GroupScheme.lean
@@ -42,6 +42,10 @@ is asserted here. Those are subsequent steps in the pinned Chevalley--Demazure c
 * N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate V.
 * J. E. Humphreys, *Linear Algebraic Groups*, §26.
 * J. C. Jantzen, *Representations of Algebraic Groups*, II.1--2.
+* The carrier API follows the formal templates in
+  `TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.Basic` and
+  `TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Scheme`, specialized here using the
+  type-`E₆` minuscule representation, lattice, weights, and root characters.
 -/
 
 public section
@@ -107,19 +111,6 @@ theorem lie_serreH_rootGenerator (k : Fin 6 ⊕ Fin 6) (j : Fin 6) :
       simp only [Matrix.transpose_apply, rootGeneratorWeight_inr, Int.cast_neg,
         neg_smul, Int.cast_smul_eq_zsmul]
 
-/-- The admissible-lattice theorem in the exact generic `kostantForm` presentation used by the
-toral-closure construction. -/
-theorem rep_kostantForm_mem_lattice
-    {u : _root_.UniversalEnvelopingAlgebra ℚ
-      (Matrix.ToLieAlgebra ℚ (CartanMatrix.E 6)ᵀ)}
-    (hu : u ∈ TauCeti.UniversalEnvelopingAlgebra.kostantForm
-      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ))
-    {v : Fin 27 → ℚ} (hv : v ∈ lattice) : rep u v ∈ lattice := by
-  apply rep_serreKostantForm_mem_lattice _ hv
-  rw [TauCeti.serreKostantForm_def]
-  exact hu
-
 /-! ## The pinned carrier -/
 
 /-- The Hopf ideal cutting out the type-`E₆` minuscule carrier inside `GL₂₇`. -/
@@ -128,7 +119,9 @@ noncomputable def definingIdeal :
   TauCeti.UniversalEnvelopingAlgebra.kostantToralDefiningIdeal
     (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
     (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
     isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight
 
 /-- The defining ideal is the ideal supplied by the generic Kostant toral-closure construction. -/
@@ -137,7 +130,9 @@ theorem definingIdeal_def :
       TauCeti.UniversalEnvelopingAlgebra.kostantToralDefiningIdeal
         (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
         (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+          rw [TauCeti.serreKostantForm_def]
+          exact hu) hv)
         isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight := by
   rw [definingIdeal]
 
@@ -147,7 +142,9 @@ noncomputable abbrev groupScheme : Grp (Over (Spec (CommRingCat.of ℤ))) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupScheme
     (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
     (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
     isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight
 
 /-- The quotient-spectrum presentation of the type-`E₆` minuscule carrier. -/
@@ -161,7 +158,9 @@ noncomputable def carrierι : groupScheme ⟶ TauCeti.GeneralLinear.groupScheme 
   TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupSchemeι
     (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
     (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
     isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight
 
 /-- The carrier inclusion is the generic Kostant toral-closure inclusion. -/
@@ -169,7 +168,9 @@ theorem carrierι_def :
     carrierι = TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupSchemeι
       (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
       (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
       isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight := by
   rw [carrierι]
 
@@ -185,8 +186,22 @@ noncomputable def rootSubgroup (k : Fin 6 ⊕ Fin 6) :
   TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral
     (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
     (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
     isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight k
+
+/-- The root subgroup is the one supplied by the generic Kostant toral-closure construction. -/
+theorem rootSubgroup_def (k : Fin 6 ⊕ Fin 6) :
+    rootSubgroup k =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+          rw [TauCeti.serreKostantForm_def]
+          exact hu) hv)
+        isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight k := by
+  rw [rootSubgroup]
 
 /-- Including a numbered root subgroup into `GL₂₇` recovers its represented divided-power
 exponential subgroup. -/
@@ -196,7 +211,9 @@ theorem rootSubgroup_comp_carrierι (k : Fin 6 ⊕ Fin 6) :
       TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroup
         (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
         (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv) k
+        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+          rw [TauCeti.serreKostantForm_def]
+          exact hu) hv) k
         (isNilpotent_rep_serreRootGenerator k) latticeBasis := by
   rw [rootSubgroup, carrierι]
   exact TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral_comp_ι
@@ -207,8 +224,22 @@ noncomputable def weightTorus : SplitTorus.groupScheme ℤ (Fin 6) ⟶ groupSche
   TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral
     (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
     (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
     isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight
+
+/-- The weight torus is the one supplied by the generic Kostant toral-closure construction. -/
+theorem weightTorus_def :
+    weightTorus =
+      TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+          rw [TauCeti.serreKostantForm_def]
+          exact hu) hv)
+        isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight := by
+  rw [weightTorus]
 
 /-- Including the weight torus into `GL₂₇` recovers the diagonal torus of the minuscule
 weights. -/
@@ -245,7 +276,9 @@ noncomputable def points (A : Type v) [CommRing A] :
   TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup
     (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
     (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
     isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight A
 
 /-- The carrier points are exactly the invertible matrices cut out by the defining Hopf ideal. -/
@@ -254,6 +287,18 @@ theorem points_def (A : Type v) [CommRing A] :
   rw [points, definingIdeal]
   exact TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup_def
     _ _ _ _ _ _ _ _ A
+
+/-- A matrix is a carrier point exactly when its associated convolution point kills the
+defining Hopf ideal. -/
+@[simp]
+theorem mem_points_iff (A : Type v) [CommRing A]
+    (g : _root_.Matrix.GeneralLinearGroup (Fin 27) A) :
+    g ∈ points A ↔
+      ∀ x ∈ definingIdeal,
+        ((TauCeti.GeneralLinear.pointsMulEquiv (R := ℤ) 27).symm g).ofConv x = 0 := by
+  rw [points, definingIdeal]
+  exact TauCeti.UniversalEnvelopingAlgebra.mem_kostantToralPointsSubgroup_iff
+    _ _ _ _ _ _ _ _ A g
 
 /-- The split weight torus on matrix-valued points of the type-`E₆` carrier. -/
 noncomputable def weightTorusPoints (A : Type v) [CommRing A] :

--- a/TauCeti/Algebra/Lie/E6/Minuscule/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/GroupScheme.lean
@@ -35,6 +35,7 @@ is asserted here. Those are subsequent steps in the pinned Chevalley--Demazure c
 * `TauCeti.E6Minuscule.rootSubgroup`: its twelve numbered simple-root subgroup morphisms.
 * `TauCeti.E6Minuscule.weightTorus`: its closed rank-six split torus.
 * `TauCeti.E6Minuscule.points`: its matrix-valued points over a commutative ring.
+* `TauCeti.E6Minuscule.rootSubgroupPoints`: its numbered root subgroups on matrix-valued points.
 * `TauCeti.E6Minuscule.weightTorus_conj_rootSubgroup`: the scheme-level pinning equation.
 
 ## References
@@ -85,13 +86,13 @@ theorem rootGeneratorWeight_inr (i j : Fin 6) :
 
 /-- The character of a raising generator is the corresponding simple root of the pinned
 simply connected type-`E₆` root datum. -/
-theorem rootGeneratorWeight_inl_eq_root_simpleIndex (i : Fin 6) :
+theorem rootGeneratorWeight_inl_eq_e6Root_e6SimpleIndex (i : Fin 6) :
     rootGeneratorWeight (.inl i) = e6Root (e6SimpleIndex i) := by
   ext j
   rw [rootGeneratorWeight_inl, root_e6SimpleIndex]
 
 /-- The character of a lowering generator is the negative of the corresponding simple root. -/
-theorem rootGeneratorWeight_inr_eq_neg_root_simpleIndex (i : Fin 6) :
+theorem rootGeneratorWeight_inr_eq_neg_e6Root_e6SimpleIndex (i : Fin 6) :
     rootGeneratorWeight (.inr i) = -e6Root (e6SimpleIndex i) := by
   ext j
   rw [rootGeneratorWeight_inr, Pi.neg_apply, root_e6SimpleIndex]
@@ -299,6 +300,39 @@ theorem mem_points_iff (A : Type v) [CommRing A]
   rw [points, definingIdeal]
   exact TauCeti.UniversalEnvelopingAlgebra.mem_kostantToralPointsSubgroup_iff
     _ _ _ _ _ _ _ _ A g
+
+/-- The parametrized numbered root subgroup inside the type-`E₆` minuscule carrier points. -/
+noncomputable def rootSubgroupPoints (k : Fin 6 ⊕ Fin 6) (A : Type v) [CommRing A] :
+    Multiplicative A →* points A :=
+  MonoidHom.codRestrict
+    ((TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv) k (isNilpotent_rep_serreRootGenerator k) latticeBasis).comp
+        (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm.toMonoidHom)
+    (points A) fun u ↦ by
+      rw [points]
+      exact TauCeti.UniversalEnvelopingAlgebra.kostantGeneratedPointsSubgroup_le_toralPoints
+        _ _ _ _ _ _ _ _ A
+        (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_mem_generatedPoints
+          _ _ _ _ _ _ _ A k _)
+
+/-- A numbered root-subgroup point is its represented divided-power exponential matrix. -/
+@[simp]
+theorem coe_rootSubgroupPoints (k : Fin 6 ⊕ Fin 6) (A : Type v) [CommRing A]
+    (u : Multiplicative A) :
+    (rootSubgroupPoints k A u : _root_.Matrix.GeneralLinearGroup (Fin 27) A) =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+          rw [TauCeti.serreKostantForm_def]
+          exact hu) hv) k (isNilpotent_rep_serreRootGenerator k) latticeBasis
+        ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm u) := by
+  rw [rootSubgroupPoints]
+  rfl
 
 /-- The split weight torus on matrix-valued points of the type-`E₆` carrier. -/
 noncomputable def weightTorusPoints (A : Type v) [CommRing A] :

--- a/TauCeti/Algebra/Lie/E6/Minuscule/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/GroupScheme.lean
@@ -1,0 +1,302 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E6.Minuscule.AdmissibleLattice
+public import
+  TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Points
+import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Relations
+import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Rigidity
+import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Torus
+
+/-!
+# The full-weight type-E6 minuscule carrier
+
+This file feeds the explicit `27`-dimensional type-`E₆` minuscule representation, its admissible
+coordinate lattice, and its full set of weights into the Kostant toral-closure construction. The
+result is an explicit affine group scheme over `ℤ`, cut out inside `GL₂₇` by the largest Hopf
+ideal killed by the twelve numbered simple-root subgroups and the represented rank-six split
+torus.
+
+The root-subgroup characters are identified with the positive and negative simple roots of
+`TauCeti.DynkinType.e6SimplyConnectedRootDatum`. Since the minuscule weights span the entire
+character lattice, the represented split torus is a closed immersion. The scheme-level pinning
+equation records its conjugation action on every numbered root subgroup.
+
+No reductivity, smoothness, maximality of the torus, or identification of the carrier's root datum
+is asserted here. Those are subsequent steps in the pinned Chevalley--Demazure construction.
+
+## Main declarations
+
+* `TauCeti.E6Minuscule.groupScheme`: the minuscule Kostant toral-closure carrier over `ℤ`.
+* `TauCeti.E6Minuscule.rootSubgroup`: its twelve numbered simple-root subgroup morphisms.
+* `TauCeti.E6Minuscule.weightTorus`: its closed rank-six split torus.
+* `TauCeti.E6Minuscule.points`: its matrix-valued points over a commutative ring.
+* `TauCeti.E6Minuscule.weightTorus_conj_rootSubgroup`: the scheme-level pinning equation.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate V.
+* J. E. Humphreys, *Linear Algebraic Groups*, §26.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1--2.
+-/
+
+public section
+
+open scoped Matrix
+
+universe v
+
+namespace TauCeti.E6Minuscule
+
+open AlgebraicGeometry CategoryTheory
+open TauCeti.DynkinType
+open TauCeti.UniversalEnvelopingAlgebra
+open scoped CategoryTheory.MonObj TensorProduct
+
+attribute [local instance] TauCeti.moduleNNRat
+attribute [local instance 100] LieRing.ofAssociativeRing
+attribute [local instance high] Algebra.toModule
+
+/-! ## Root characters -/
+
+/-- The character through which the Cartan torus acts on a positive or negative numbered
+type-`E₆` root generator. -/
+def rootGeneratorWeight : Fin 6 ⊕ Fin 6 → Fin 6 → ℤ
+  | .inl i => fun j ↦ CartanMatrix.E 6 i j
+  | .inr i => fun j ↦ -CartanMatrix.E 6 i j
+
+@[simp]
+theorem rootGeneratorWeight_inl (i j : Fin 6) :
+    rootGeneratorWeight (.inl i) j = CartanMatrix.E 6 i j := by
+  rw [rootGeneratorWeight]
+
+@[simp]
+theorem rootGeneratorWeight_inr (i j : Fin 6) :
+    rootGeneratorWeight (.inr i) j = -CartanMatrix.E 6 i j := by
+  rw [rootGeneratorWeight]
+
+/-- The character of a raising generator is the corresponding simple root of the pinned
+simply connected type-`E₆` root datum. -/
+theorem rootGeneratorWeight_inl_eq_root_simpleIndex (i : Fin 6) :
+    rootGeneratorWeight (.inl i) = e6Root (e6SimpleIndex i) := by
+  ext j
+  rw [rootGeneratorWeight_inl, root_e6SimpleIndex]
+
+/-- The character of a lowering generator is the negative of the corresponding simple root. -/
+theorem rootGeneratorWeight_inr_eq_neg_root_simpleIndex (i : Fin 6) :
+    rootGeneratorWeight (.inr i) = -e6Root (e6SimpleIndex i) := by
+  ext j
+  rw [rootGeneratorWeight_inr, Pi.neg_apply, root_e6SimpleIndex]
+
+/-- The numbered Serre root generators are weight vectors for the Cartan generators. -/
+theorem lie_serreH_rootGenerator (k : Fin 6 ⊕ Fin 6) (j : Fin 6) :
+    ⁅TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ j,
+        TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ k⁆ =
+      ((rootGeneratorWeight k j : ℤ) : ℚ) •
+        TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ k := by
+  cases k with
+  | inl i =>
+      rw [TauCeti.serreRootGenerator_inl, TauCeti.lie_serreH_serreE]
+      simp only [Matrix.transpose_apply, rootGeneratorWeight_inl, Int.cast_smul_eq_zsmul]
+  | inr i =>
+      rw [TauCeti.serreRootGenerator_inr, TauCeti.lie_serreH_serreF]
+      simp only [Matrix.transpose_apply, rootGeneratorWeight_inr, Int.cast_neg,
+        neg_smul, Int.cast_smul_eq_zsmul]
+
+/-- The admissible-lattice theorem in the exact generic `kostantForm` presentation used by the
+toral-closure construction. -/
+theorem rep_kostantForm_mem_lattice
+    {u : _root_.UniversalEnvelopingAlgebra ℚ
+      (Matrix.ToLieAlgebra ℚ (CartanMatrix.E 6)ᵀ)}
+    (hu : u ∈ TauCeti.UniversalEnvelopingAlgebra.kostantForm
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ))
+    {v : Fin 27 → ℚ} (hv : v ∈ lattice) : rep u v ∈ lattice := by
+  apply rep_serreKostantForm_mem_lattice _ hv
+  rw [TauCeti.serreKostantForm_def]
+  exact hu
+
+/-! ## The pinned carrier -/
+
+/-- The Hopf ideal cutting out the type-`E₆` minuscule carrier inside `GL₂₇`. -/
+noncomputable def definingIdeal :
+    HopfIdeal ℤ (TauCeti.GeneralLinear.coordinateHopfAlgebra ℤ 27) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantToralDefiningIdeal
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight
+
+/-- The defining ideal is the ideal supplied by the generic Kostant toral-closure construction. -/
+theorem definingIdeal_def :
+    definingIdeal =
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralDefiningIdeal
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+        isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight := by
+  rw [definingIdeal]
+
+/-- The full-weight type-`E₆` minuscule carrier over `ℤ`, obtained as the smallest closed
+subgroup scheme of `GL₂₇` containing the represented numbered root subgroups and weight torus. -/
+noncomputable abbrev groupScheme : Grp (Over (Spec (CommRingCat.of ℤ))) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupScheme
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight
+
+/-- The quotient-spectrum presentation of the type-`E₆` minuscule carrier. -/
+theorem groupScheme_def :
+    groupScheme = CommHopfAlgCat.quotientSpec
+      (TauCeti.GeneralLinear.coordinateHopfAlgebra ℤ 27) definingIdeal := by
+  rw [groupScheme, definingIdeal]
+
+/-- The canonical inclusion of the type-`E₆` minuscule carrier into `GL₂₇`. -/
+noncomputable def carrierι : groupScheme ⟶ TauCeti.GeneralLinear.groupScheme ℤ 27 :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupSchemeι
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight
+
+/-- The carrier inclusion is the generic Kostant toral-closure inclusion. -/
+theorem carrierι_def :
+    carrierι = TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupSchemeι
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight := by
+  rw [carrierι]
+
+/-- The type-`E₆` minuscule carrier is a closed subgroup scheme of `GL₂₇`. -/
+instance isClosedImmersion_carrierι : IsClosedImmersion carrierι.hom.hom.left := by
+  rw [carrierι]
+  exact TauCeti.UniversalEnvelopingAlgebra.isClosedImmersion_kostantToralGroupSchemeι
+    _ _ _ _ _ _ _ _
+
+/-- A positive or negative numbered simple-root subgroup of the type-`E₆` carrier. -/
+noncomputable def rootSubgroup (k : Fin 6 ⊕ Fin 6) :
+    AdditiveGroup.groupScheme ℤ ⟶ groupScheme :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight k
+
+/-- Including a numbered root subgroup into `GL₂₇` recovers its represented divided-power
+exponential subgroup. -/
+@[simp]
+theorem rootSubgroup_comp_carrierι (k : Fin 6 ⊕ Fin 6) :
+    rootSubgroup k ≫ carrierι =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroup
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv) k
+        (isNilpotent_rep_serreRootGenerator k) latticeBasis := by
+  rw [rootSubgroup, carrierι]
+  exact TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral_comp_ι
+    _ _ _ _ _ _ _ _ k
+
+/-- The represented rank-six split weight torus in the type-`E₆` carrier. -/
+noncomputable def weightTorus : SplitTorus.groupScheme ℤ (Fin 6) ⟶ groupScheme :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight
+
+/-- Including the weight torus into `GL₂₇` recovers the diagonal torus of the minuscule
+weights. -/
+@[simp]
+theorem weightTorus_comp_carrierι :
+    weightTorus ≫ carrierι =
+      TauCeti.GeneralLinear.weightTorus (R := ℤ) e6MinusculeWeight := by
+  rw [weightTorus, carrierι]
+  exact TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral_comp_ι
+    _ _ _ _ _ _ _ _
+
+/-- The minuscule weights make the represented split torus a closed subgroup scheme of the
+carrier. -/
+instance isClosedImmersion_weightTorus : IsClosedImmersion weightTorus.hom.hom.left :=
+  TauCeti.UniversalEnvelopingAlgebra.isClosedImmersion_kostantWeightTorusToToral
+    _ _ _ _ _ _ _ _ span_range_e6MinusculeWeight_eq_top
+
+/-- Two morphisms out of the type-`E₆` carrier agree when they agree on its numbered root
+subgroups and represented split torus. -/
+@[ext]
+theorem groupScheme_hom_ext {Y : _root_.CommHopfAlgCat.{0} ℤ}
+    (f g : groupScheme ⟶
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).obj (Opposite.op Y))
+    (hroot : ∀ k, rootSubgroup k ≫ f = rootSubgroup k ≫ g)
+    (htorus : weightTorus ≫ f = weightTorus ≫ g) : f = g := by
+  exact TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupScheme_hom_ext
+    _ _ _ _ _ _ _ _ f g hroot htorus
+
+/-! ## Matrix-valued points -/
+
+/-- The matrix-valued points of the type-`E₆` minuscule carrier. -/
+noncomputable def points (A : Type v) [CommRing A] :
+    Subgroup (_root_.Matrix.GeneralLinearGroup (Fin 27) A) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice hu hv)
+    isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight A
+
+/-- The carrier points are exactly the invertible matrices cut out by the defining Hopf ideal. -/
+theorem points_def (A : Type v) [CommRing A] :
+    points A = TauCeti.GeneralLinear.hopfIdealPointsSubgroup 27 definingIdeal A := by
+  rw [points, definingIdeal]
+  exact TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup_def
+    _ _ _ _ _ _ _ _ A
+
+/-- The split weight torus on matrix-valued points of the type-`E₆` carrier. -/
+noncomputable def weightTorusPoints (A : Type v) [CommRing A] :
+    (Fin 6 → Aˣ) →* points A :=
+  MonoidHom.codRestrict
+    (TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix
+      lattice.toAddSubgroup latticeBasis e6MinusculeWeight)
+    (points A) fun s ↦ by
+      rw [points]
+      exact TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_mem_toralPoints
+        _ _ _ _ _ _ _ _ A s
+
+/-- A minuscule weight-torus point is the diagonal matrix obtained by evaluating each weight. -/
+@[simp]
+theorem coe_weightTorusPoints (A : Type v) [CommRing A] (s : Fin 6 → Aˣ) :
+    (weightTorusPoints A s : _root_.Matrix.GeneralLinearGroup (Fin 27) A) =
+      TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix
+        lattice.toAddSubgroup latticeBasis e6MinusculeWeight s := by
+  rw [weightTorusPoints]
+  rfl
+
+/-! ## The pinning equation -/
+
+/-- **Conjugation by the minuscule weight torus acts on each numbered root subgroup through its
+positive or negative pinned simple-root character.** -/
+@[simp]
+theorem weightTorus_conj_rootSubgroup (k : Fin 6 ⊕ Fin 6) (A : Type) [CommRing A]
+    (s : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (SplitTorus.groupScheme ℤ (Fin 6)).X)
+    (u : A) :
+    (s ≫ weightTorus.hom.hom) *
+        ((AdditiveGroup.groupSchemePointMulEquiv A)
+            ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+              (Multiplicative.ofAdd u)) ≫ (rootSubgroup k).hom.hom) *
+        (s ≫ weightTorus.hom.hom)⁻¹ =
+      (AdditiveGroup.schemePointsMulEquiv A).symm
+          (Multiplicative.ofAdd
+            ((TauCeti.torusCharacter
+              (SplitTorus.schemePointsMulEquiv (R := ℤ) (A := A) s)
+              (rootGeneratorWeight k) : A) * u)) ≫
+        (rootSubgroup k).hom.hom :=
+  kostantWeightTorusToToral_conj_kostantRootSubgroupToToralParam
+      _ _ _ _ _ _ _ isCartanWeightVector_latticeBasis
+      isNilpotent_rep_serreRootGenerator A (lie_serreH_rootGenerator k) s u
+
+end TauCeti.E6Minuscule


### PR DESCRIPTION
This PR constructs the explicit full-weight type-`E₆` minuscule carrier over `ℤ`: feed the landed 27-dimensional admissible lattice into the Kostant toral-closure construction, expose its Hopf-ideal quotient inside `GL₂₇`, its twelve numbered simple-root subgroup morphisms, its rank-six split weight torus, and its matrix-valued points.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, “The Chevalley–Demazure construction,” specifically the explicitly constructed split reductive group scheme over `ℤ` via a Chevalley basis and Kostant form, together with the “Pinnings” and “Root subgroup maps” targets. This advances the explicit pinned type-`E₆` carrier milestone by turning the already-landed minuscule admissible lattice into the actual affine group-scheme carrier: the root characters are identified with the positive and negative Bourbaki-numbered simple roots, the full-weight spanning theorem makes the represented torus a closed immersion, and the scheme-level conjugation equation records the pinning action.

This is the most effective current step because `E6Minuscule.rep_serreKostantForm_mem_lattice` and `DynkinType.span_range_e6MinusculeWeight_eq_top` are on `main`, while no open pull request packages them into the carrier they were built to supply. The dependency edge is CFSGStatement milestone L0, “explicit pinned Chevalley–Demazure groups,” whose type-`E₆` branches consume this carrier, its points, and its numbered simple-root subgroups when defining `ValidLieTypeIndex.AmbientGroup` and `ValidLieTypeIndex.simpleRootSubgroup`.

After this PR, the type-`E₆` path still needs base-change packaging, the Borel and all-root subgroup data, and proofs of smoothness, reductivity, maximality of the torus, and identification with `DynkinType.e6SimplyConnectedRootDatum` before Layer 9 and CFSGStatement L0 close.

Add `TauCeti/Algebra/Lie/E6/Minuscule/GroupScheme.lean` (302 lines). The construction reuses Tau Ceti’s generic `kostantToralGroupScheme`, root-subgroup, torus, points, rigidity, and pinning infrastructure. No Mathlib infrastructure or external formalization is vendored; the conventions follow Bourbaki Plate V, Humphreys §26, and Jantzen II.1–2 as recorded in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e6-minuscule-toral-carrier"}-->

🤖 Prepared with Codex
