### PR TITLE
feat: specialize Schur and character orthogonality to a finite group

### DIFF
--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -23,10 +23,12 @@ algebraic counterpart of that operator is `Representation.averageMap`; this file
 to it, only to the explicit sum.)
 
 Everything the compact theory phrases as an `L²(G)` inner product then becomes a finite Hermitian
-sum. Normalized Haar measure has full support on a discrete space, so a class in `L²(G)` *is* a
-function on `G` and the inner product is `|G|⁻¹ ∑ x, conj (f x) · g x`. Rewriting the compact
-statements along that identity turns the two Schur orthogonality relations and the two character
-orthogonality relations into their classical finite-group forms, and turns the intertwiner count
+sum. Normalized Haar measure has full support on a discrete space and every function on a discrete
+space is continuous, so a class in `L²(G)` *is* a function on `G` — the coercion is a linear
+equivalence `L²(G) ≃ₗ[𝕜] (G → 𝕜)` — and the inner product is `|G|⁻¹ ∑ x, conj (f x) · g x`.
+Rewriting the compact statements along that identity turns the two Schur orthogonality relations
+and the two character orthogonality relations into their classical finite-group forms, and turns
+the intertwiner count
 `⟪χ_π, χ_ρ⟫ = dim Hom_G(V, W)` into `|G|⁻¹ ∑ g, χ_π(g⁻¹) · χ_ρ(g) = dim Hom_G(V, W)`, which is the
 shape Mathlib proves algebraically as `Representation.card_inv_mul_sum_char_mul_char_eq_finrank`.
 Each such specialization carries the name of the compact statement it specializes, with the suffix
@@ -59,9 +61,11 @@ measure computation has just identified.
 * `TauCeti.eq_of_ae_eq_haarProb`: **normalized Haar measure on a finite discrete group has full
   support**, so two functions agreeing almost everywhere agree everywhere. This is what makes an
   `L²` class on a finite group a genuine function.
+* `TauCeti.lpEquivFun`: **`L²(G)` is `G → 𝕜`**, by the linear equivalence taking an `L²` class to
+  its values; the previous item is its injectivity and finiteness is its surjectivity.
 * `TauCeti.inner_Lp_eq_inv_mul_sum`: **the `L²(G)` inner product is the normalized Hermitian
-  pairing** `|G|⁻¹ ∑ x, conj (f x) · g x`, with `TauCeti.inner_toLp_eq_inv_mul_sum` the form for
-  two continuous functions.
+  pairing** `|G|⁻¹ ∑ x, conj (f x) · g x` of those values, with
+  `TauCeti.inner_toLp_eq_inv_mul_sum` the form for two continuous functions.
 * `ContRepresentation.schur_orthogonality_self_sum` and
   `ContRepresentation.schur_orthogonality_sum`: **the two Schur orthogonality relations as finite
   averages** of matrix coefficients.
@@ -77,8 +81,10 @@ statement outright, so only the route through the compact theory is new. The int
 as `Representation.card_inv_mul_sum_char_mul_char_eq_finrank`, for the algebraic intertwiner space
 `Representation.IntertwiningMap`, which in finite dimensions is the continuous one because every
 linear map out of a finite-dimensional normed space is continuous. Both routes are exhibited by
-anonymous `example`s, as is the agreement of `character_orthonormal_self_sum` with the diagonal
-half of Mathlib's `Representation.char_orthonormal`.
+anonymous `example`s, as are both branches of Mathlib's `Representation.char_orthonormal`: the
+diagonal one is `character_orthonormal_self_sum`, and the off-diagonal one is
+`character_orthonormal_distinct_sum` with its intertwiner hypothesis discharged, for a pair of
+inequivalent irreducibles, by the vanishing half of Schur's lemma.
 
 ## Implementation notes
 
@@ -106,12 +112,13 @@ recover the character theory" of the
 `dim V^G = |G|⁻¹ ∑ g, χ_π g` is the finite shadow of
 `ContRepresentation.integral_character_eq_finrank_invariants`, matching Mathlib's
 `FDRep.average_char_eq_finrank_invariants` for the purely algebraic theory. It is also the `L²`,
-Schur and character-orthonormality part of that item: `⟪·, ·⟫_{L²(G)}` becomes the finite Hermitian
-pairing, `schur_orthogonality_self` and `schur_orthogonality` become the classical orthogonality
-relations for matrix coefficients, and `character_orthonormal_self` and
-`character_orthonormal_distinct` become Mathlib's `Representation.char_orthonormal`, exhibited by
-the second anonymous `example` closing the file. The two specializations the roadmap item asks for
-that are still missing are Maschke (the finite shadow of complete reducibility) and Peter-Weyl
+Schur and character-orthonormality part of that item: `L²(G)` is `G → 𝕜` by `TauCeti.lpEquivFun`
+and `⟪·, ·⟫_{L²(G)}` becomes the finite Hermitian pairing on it, `schur_orthogonality_self` and
+`schur_orthogonality` become the classical orthogonality relations for matrix coefficients, and
+`character_orthonormal_self` and `character_orthonormal_distinct` become the two branches of
+Mathlib's `Representation.char_orthonormal`, exhibited by the two anonymous `example`s closing the
+file. The two specializations the roadmap item asks for that are still missing are Maschke (the
+finite shadow of complete reducibility) and Peter-Weyl
 (that `peterWeylBasis` is the matrix-coefficient basis of `k[G]`); neither is proved here.
 -/
 
@@ -251,13 +258,46 @@ section InnerProduct
 variable (G : Type*) [Group G] [Fintype G] [TopologicalSpace G] [DiscreteTopology G]
   [MeasurableSpace G] [BorelSpace G] {𝕜 : Type*} [RCLike 𝕜]
 
+variable (𝕜) in
+/-- **`L²` of a finite discrete group is the space of all functions on it**: taking underlying
+functions is a `𝕜`-linear equivalence `Lp 𝕜 2 (haarProb G) ≃ₗ[𝕜] (G → 𝕜)`.
+
+It is injective because normalized Haar measure has full support (`TauCeti.eq_of_ae_eq_haarProb`),
+so an `L²` class is pinned down by its values, and surjective because `G` is finite and discrete:
+*every* function on `G` is continuous, hence square-integrable against a probability measure, and
+`ContinuousMap.toLp` produces its class. Together with `TauCeti.inner_Lp_eq_inv_mul_sum`, which
+computes the inner product from exactly the values this equivalence reads off, it is the
+identification of `L²(G)` with `G → 𝕜` carrying the normalized Hermitian pairing. -/
+noncomputable def lpEquivFun : Lp 𝕜 2 (haarProb G) ≃ₗ[𝕜] (G → 𝕜) where
+  toFun f := f
+  map_add' f g := eq_of_ae_eq_haarProb G (Lp.coeFn_add f g)
+  map_smul' c f := eq_of_ae_eq_haarProb G (Lp.coeFn_smul c f)
+  invFun f := ContinuousMap.toLp 2 (haarProb G) 𝕜 ⟨f, continuous_of_discreteTopology⟩
+  left_inv f := Lp.ext (ContinuousMap.coeFn_toLp (𝕜 := 𝕜) (p := 2) (haarProb G)
+    ⟨⇑f, continuous_of_discreteTopology⟩)
+  right_inv f := eq_of_ae_eq_haarProb G (ContinuousMap.coeFn_toLp (𝕜 := 𝕜) (p := 2) (haarProb G)
+    ⟨f, continuous_of_discreteTopology⟩)
+
+/-- The equivalence `TauCeti.lpEquivFun` reads off the values of an `L²` class. -/
+@[simp]
+theorem lpEquivFun_apply (f : Lp 𝕜 2 (haarProb G)) (x : G) : lpEquivFun G 𝕜 f x = f x :=
+  (rfl)
+
+/-- The inverse of `TauCeti.lpEquivFun` is `ContinuousMap.toLp`, every function on a discrete space
+being continuous. -/
+theorem lpEquivFun_symm_apply (f : G → 𝕜) :
+    (lpEquivFun G 𝕜).symm f =
+      ContinuousMap.toLp 2 (haarProb G) 𝕜 ⟨f, continuous_of_discreteTopology⟩ :=
+  (rfl)
+
 /-- **The `L²` inner product of a finite discrete group is the normalized Hermitian pairing**
 `|G|⁻¹ ∑ x, conj (f x) * g x`.
 
-This is the identification `L²(G) = (G → 𝕜)` that the roadmap's finite-group acceptance criterion
-asks for: the Haar integral defining the `L²` inner product is the group average, by
-`TauCeti.integral_haarProb_eq_inv_mul_sum`. The conjugation sits on the *first* argument, matching
-Mathlib's convention that the inner product is conjugate-linear there. -/
+This is the pairing carried by the identification `L²(G) = (G → 𝕜)` of `TauCeti.lpEquivFun`, whose
+underlying map is the coercion appearing on the right: the Haar integral defining the `L²` inner
+product is the group average, by `TauCeti.integral_haarProb_eq_inv_mul_sum`. The conjugation sits
+on the *first* argument, matching Mathlib's convention that the inner product is conjugate-linear
+there. -/
 theorem inner_Lp_eq_inv_mul_sum (f g : Lp 𝕜 2 (haarProb G)) :
     ⟪f, g⟫_𝕜 = (Nat.card G : 𝕜)⁻¹ * ∑ x, (starRingEnd 𝕜) (f x) * g x := by
   rw [L2.inner_def,
@@ -481,6 +521,30 @@ example [IsAlgClosed 𝕜] (hunitary : IsUnitary π)
   rw [← character_orthonormal_self_sum π hπ hunitary hirr]
   exact congrArg _ (Finset.sum_congr rfl fun g _ ↦ by
     rw [character_apply_inv π hπ hunitary, mul_comm])
+
+/- **The off-diagonal half of Mathlib's `Representation.char_orthonormal`**, in the same spelling:
+the characters of two inequivalent irreducibles have vanishing group average. This is
+`character_orthonormal_distinct_sum` at the transposed pair `(ρ, π)`, whose intertwiner hypothesis
+is discharged by the vanishing half of Schur's lemma,
+`TauCeti.ContRepresentation.eq_zero_of_isEmpty_equiv`, exactly as `orthonormal_characterLp`
+discharges it in the compact theory. So the substantive vanishing statement is reached, not
+assumed: `character_orthonormal_distinct_sum` keeps the hypothesis of the compact theorem
+`character_orthonormal_distinct` it specializes, as the roadmap's "without new hypotheses"
+criterion asks, and irreducibility enters here.
+
+No name is claimed, for the same reason as above and in the two counting identities: with both
+representations irreducible and inequivalent this is Mathlib's `Representation.char_orthonormal`
+(its `IsEmpty (Equiv ρ π)` branch) at `π.toRepresentation` and `ρ.toRepresentation`. What the
+compact theory contributes is the derivation. -/
+example (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (hunitary : IsUnitary ρ)
+    (hirrπ : Representation.IsIrreducible π.toRepresentation)
+    (hirrρ : Representation.IsIrreducible ρ.toRepresentation)
+    (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) :
+    (Nat.card G : 𝕜)⁻¹ * ∑ g, character π hπ g * character ρ hρ g⁻¹ = 0 := by
+  rw [← character_orthonormal_distinct_sum ρ hρ π hπ hunitary
+    fun f ↦ by simp [eq_zero_of_isEmpty_equiv hirrπ hirrρ hne f]]
+  exact congrArg _ (Finset.sum_congr rfl fun g _ ↦ by
+    rw [character_apply_inv ρ hρ hunitary, mul_comm])
 
 end CharacterOrthogonality
 

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -5,13 +5,14 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.RepresentationTheory.Compact.Intertwiner.Dimension
 public import TauCeti.RepresentationTheory.Compact.Invariants
 public import Mathlib.MeasureTheory.Measure.Count
 public import Mathlib.Probability.UniformOn
 import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
 
 /-!
-# Finite groups: normalized Haar measure is the uniform measure
+# Finite groups: normalized Haar, the `L²` pairing, and orthogonality
 
 A finite group carrying the discrete topology is a compact topological group, so the whole
 compact-group development applies to it. This file identifies the objects it produces with the
@@ -20,6 +21,16 @@ is the group average `|G|⁻¹ ∑ g, F g`, and the Haar average of the action o
 representation is the finite group average `|G|⁻¹ ∑ g, π g`, the Reynolds operator. (Mathlib's
 algebraic counterpart of that operator is `Representation.averageMap`; this file does not connect
 to it, only to the explicit sum.)
+
+Everything the compact theory phrases as an `L²(G)` inner product then becomes a finite Hermitian
+sum. Normalized Haar measure has full support on a discrete space, so a class in `L²(G)` *is* a
+function on `G` and the inner product is `|G|⁻¹ ∑ x, conj (f x) · g x`. Rewriting the compact
+statements along that identity turns the two Schur orthogonality relations and the two character
+orthogonality relations into their classical finite-group forms, and turns the intertwiner count
+`⟪χ_π, χ_ρ⟫ = dim Hom_G(V, W)` into `|G|⁻¹ ∑ g, χ_π(g⁻¹) · χ_ρ(g) = dim Hom_G(V, W)`, which is the
+shape Mathlib proves algebraically as `Representation.card_inv_mul_sum_char_mul_char_eq_finrank`.
+Each such specialization carries the name of the compact statement it specializes, with the suffix
+`_sum` recording that the Haar integral has become a group average.
 
 The measure statement is proved without appealing to the Haar property of the counting measure, and
 in fact without any topology: left invariance alone forces all singletons of a finite group to have
@@ -45,12 +56,27 @@ measure computation has just identified.
   says the same for the bundled averaging operator.
 * `ContRepresentation.haarAverageMap_eq_smul_sum`: the Haar average of the action operators is the
   finite average `|G|⁻¹ • ∑ g, π g v`.
+* `TauCeti.eq_of_ae_eq_haarProb`: **normalized Haar measure on a finite discrete group has full
+  support**, so two functions agreeing almost everywhere agree everywhere. This is what makes an
+  `L²` class on a finite group a genuine function.
+* `TauCeti.inner_Lp_eq_inv_mul_sum`: **the `L²(G)` inner product is the normalized Hermitian
+  pairing** `|G|⁻¹ ∑ x, conj (f x) · g x`, with `TauCeti.inner_toLp_eq_inv_mul_sum` the form for
+  two continuous functions.
+* `ContRepresentation.schur_orthogonality_self_sum` and
+  `ContRepresentation.schur_orthogonality_sum`: **the two Schur orthogonality relations as finite
+  averages** of matrix coefficients.
+* `ContRepresentation.card_inv_mul_sum_character_mul_eq_finrank_contIntertwiningMap`: **the finite
+  character sum counts the intertwiners**, in Mathlib's `χ_π(g⁻¹) · χ_ρ(g)` shape.
+* `ContRepresentation.character_orthonormal_self_sum` and
+  `ContRepresentation.character_orthonormal_distinct_sum`: **the two character orthogonality
+  relations as finite averages**.
 
 The counting identity `|G|⁻¹ ∑ g, χ_π g = dim V^G` that the compact-group character integral
 generalizes then costs one rewrite. It is not given a name: Mathlib already proves it, as
 `Representation.card_inv_mul_sum_char_eq_finrank`, and that lemma closes the `ContRepresentation`
 statement outright, so only the route through the compact theory is new. The route is exhibited by
-the anonymous `example` closing the file.
+an anonymous `example`, as is the agreement of `character_orthonormal_self_sum` with the diagonal
+half of Mathlib's `Representation.char_orthonormal`.
 
 ## Implementation notes
 
@@ -77,15 +103,20 @@ recover the character theory" of the
 `haarProb G` is the normalized counting measure `|G|⁻¹ • count`, and the counting identity
 `dim V^G = |G|⁻¹ ∑ g, χ_π g` is the finite shadow of
 `ContRepresentation.integral_character_eq_finrank_invariants`, matching Mathlib's
-`FDRep.average_char_eq_finrank_invariants` for the purely algebraic theory. The remaining
-specializations the roadmap item asks for — the `L²` theory, Maschke, Schur and character
-orthonormality, and Peter-Weyl — are not treated here.
+`FDRep.average_char_eq_finrank_invariants` for the purely algebraic theory. It is also the `L²`,
+Schur and character-orthonormality part of that item: `⟪·, ·⟫_{L²(G)}` becomes the finite Hermitian
+pairing, `schur_orthogonality_self` and `schur_orthogonality` become the classical orthogonality
+relations for matrix coefficients, and `character_orthonormal_self` and
+`character_orthonormal_distinct` become Mathlib's `Representation.char_orthonormal`, exhibited by
+the second anonymous `example` closing the file. The two specializations the roadmap item asks for
+that are still missing are Maschke (the finite shadow of complete reducibility) and Peter-Weyl
+(that `peterWeylBasis` is the matrix-coefficient basis of `k[G]`); neither is proved here.
 -/
 
 public section
 
 open MeasureTheory Set
-open scoped ENNReal
+open scoped ENNReal InnerProductSpace
 
 namespace TauCeti
 
@@ -193,6 +224,56 @@ theorem haarAverage_eq_smul_sum {𝕜 : Type*} [NontriviallyNormedField 𝕜] [N
 
 end FintypeGroup
 
+/-! ### The `L²` space of a finite group -/
+
+section FullSupport
+
+variable (G : Type*) [Group G] [Finite G] [TopologicalSpace G] [DiscreteTopology G]
+  [MeasurableSpace G] [BorelSpace G]
+
+/-- **Normalized Haar measure on a finite discrete group has full support**, so functions agreeing
+almost everywhere agree everywhere.
+
+Haar measure is positive on nonempty open sets, and on a discrete space every function is
+continuous, so `Continuous.ae_eq_iff_eq` applies with no measurability side condition. In
+particular an element of `Lp 𝕜 2 (haarProb G)`, which is only an almost-everywhere class, is
+pinned down by its values: this is the sense in which `L²(G)` "is" `G → 𝕜`. -/
+theorem eq_of_ae_eq_haarProb {α : Type*} [TopologicalSpace α] [T2Space α] {f g : G → α}
+    (h : f =ᵐ[haarProb G] g) : f = g :=
+  (continuous_of_discreteTopology.ae_eq_iff_eq (haarProb G) continuous_of_discreteTopology).mp h
+
+end FullSupport
+
+section InnerProduct
+
+variable (G : Type*) [Group G] [Fintype G] [TopologicalSpace G] [DiscreteTopology G]
+  [MeasurableSpace G] [BorelSpace G] {𝕜 : Type*} [RCLike 𝕜]
+
+/-- **The `L²` inner product of a finite discrete group is the normalized Hermitian pairing**
+`|G|⁻¹ ∑ x, conj (f x) * g x`.
+
+This is the identification `L²(G) = (G → 𝕜)` that the roadmap's finite-group acceptance criterion
+asks for: the Haar integral defining the `L²` inner product is the group average, by
+`TauCeti.integral_haarProb_eq_inv_mul_sum`. The conjugation sits on the *first* argument, matching
+Mathlib's convention that the inner product is conjugate-linear there. -/
+theorem inner_Lp_eq_inv_mul_sum (f g : Lp 𝕜 2 (haarProb G)) :
+    ⟪f, g⟫_𝕜 = (Nat.card G : 𝕜)⁻¹ * ∑ x, (starRingEnd 𝕜) (f x) * g x := by
+  rw [L2.inner_def,
+    ← integral_haarProb_eq_inv_mul_sum (𝕜 := 𝕜) G fun x ↦ (starRingEnd 𝕜) (f x) * g x]
+  exact integral_congr_ae (Filter.Eventually.of_forall fun x ↦ by
+    simp only [RCLike.inner_apply, mul_comm])
+
+/-- The `L²` inner product of two *continuous* functions on a finite discrete group, the form in
+which the matrix coefficients and the characters present themselves. -/
+theorem inner_toLp_eq_inv_mul_sum (f g : C(G, 𝕜)) :
+    ⟪ContinuousMap.toLp 2 (haarProb G) 𝕜 f, ContinuousMap.toLp 2 (haarProb G) 𝕜 g⟫_𝕜 =
+      (Nat.card G : 𝕜)⁻¹ * ∑ x, (starRingEnd 𝕜) (f x) * g x := by
+  rw [inner_Lp_eq_inv_mul_sum,
+    eq_of_ae_eq_haarProb G (ContinuousMap.coeFn_toLp (𝕜 := 𝕜) (p := 2) (haarProb G) f),
+    eq_of_ae_eq_haarProb G (ContinuousMap.coeFn_toLp (𝕜 := 𝕜) (p := 2) (haarProb G) g)]
+
+end InnerProduct
+
 end TauCeti
 
 open MeasureTheory TauCeti TauCeti.ContRepresentation
@@ -243,5 +324,158 @@ example (π : ContRepresentation 𝕜 G V) (hπ : Continuous π) :
   rw [← integral_character_eq_finrank_invariants π hπ, integral_haarProb_eq_inv_mul_sum]
 
 end Trace
+
+/-! ### Matrix coefficients and the Schur orthogonality relations -/
+
+section MatrixCoefficient
+
+variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSpace G]
+  [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+  [NormedAddCommGroup W] [InnerProductSpace 𝕜 W]
+
+/-- **The `L²` pairing of two matrix coefficients of a finite group is a group average.** This is
+the identity along which the Schur orthogonality relations become finite sums. -/
+theorem inner_matrixCoeffLp_eq_inv_mul_sum (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+    (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (v w : V) (v' w' : W) :
+    ⟪matrixCoeffLp π hπ v w, matrixCoeffLp ρ hρ v' w'⟫_𝕜 =
+      (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v, w⟫_𝕜 * ⟪ρ g v', w'⟫_𝕜 := by
+  rw [matrixCoeffLp_def, matrixCoeffLp_def, inner_toLp_eq_inv_mul_sum]
+  simp only [matrixCoeff_apply]
+
+end MatrixCoefficient
+
+section SchurSelf
+
+variable {𝕜 G V : Type*} [RCLike 𝕜] [IsAlgClosed 𝕜] [Group G] [Fintype G] [TopologicalSpace G]
+  [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+
+/-- **The first Schur orthogonality relation for a finite group.** For a unitary irreducible
+representation of dimension `d`,
+`|G|⁻¹ ∑ g, conj ⟪π g v₁, w₁⟫ * ⟪π g v₂, w₂⟫ = d⁻¹ * (conj ⟪v₁, v₂⟫ * ⟪w₁, w₂⟫)`.
+
+This is `TauCeti.ContRepresentation.schur_orthogonality_self` with the Haar integral of the
+compact theory replaced by the group average; the normalization `|G|⁻¹` is exactly the one that
+makes normalized Haar measure a probability measure. -/
+theorem schur_orthogonality_self_sum (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+    (hunitary : IsUnitary π) (hirr : Representation.IsIrreducible π.toRepresentation)
+    (v₁ w₁ v₂ w₂ : V) :
+    (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v₁, w₁⟫_𝕜 * ⟪π g v₂, w₂⟫_𝕜 =
+      (Module.finrank 𝕜 V : 𝕜)⁻¹ * ((starRingEnd 𝕜) ⟪v₁, v₂⟫_𝕜 * ⟪w₁, w₂⟫_𝕜) := by
+  rw [← inner_matrixCoeffLp_eq_inv_mul_sum π hπ π hπ,
+    schur_orthogonality_self π hπ hunitary hirr]
+
+end SchurSelf
+
+section SchurDistinct
+
+variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSpace G]
+  [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [FiniteDimensional 𝕜 V]
+  [NormedAddCommGroup W] [InnerProductSpace 𝕜 W] [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W]
+  [FiniteDimensional 𝕜 W]
+
+local instance instCompleteSpaceSchurDistinct : CompleteSpace W :=
+  FiniteDimensional.complete 𝕜 W
+
+/-- **The second Schur orthogonality relation for a finite group.** Matrix coefficients of
+inequivalent irreducible representations have vanishing group average, this being
+`TauCeti.ContRepresentation.schur_orthogonality` read through the finite Hermitian pairing. -/
+theorem schur_orthogonality_sum (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+    (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (hunitary : IsUnitary ρ)
+    (hirrπ : Representation.IsIrreducible π.toRepresentation)
+    (hirrρ : Representation.IsIrreducible ρ.toRepresentation)
+    (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) (v w : V) (v' w' : W) :
+    (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v, w⟫_𝕜 * ⟪ρ g v', w'⟫_𝕜 = 0 := by
+  rw [← inner_matrixCoeffLp_eq_inv_mul_sum π hπ ρ hρ,
+    schur_orthogonality π hπ ρ hρ hunitary hirrπ hirrρ hne]
+
+end SchurDistinct
+
+/-! ### Characters -/
+
+section Character
+
+variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSpace G]
+  [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+  [NormedAddCommGroup W] [NormedSpace 𝕜 W] [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W]
+  [FiniteDimensional 𝕜 W]
+  (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+  (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ)
+
+include hπ hρ
+
+omit [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V] [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W] in
+/-- **The `L²` pairing of two characters of a finite group is a group average.** -/
+theorem inner_characterLp_eq_inv_mul_sum :
+    ⟪characterLp π hπ, characterLp ρ hρ⟫_𝕜 =
+      (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) (character π hπ g) * character ρ hρ g := by
+  rw [characterLp_def, characterLp_def, inner_toLp_eq_inv_mul_sum]
+
+omit [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V] in
+/-- **The finite character sum counts the intertwiners**:
+`|G|⁻¹ ∑ g, χ_π(g⁻¹) · χ_ρ(g) = dim Hom_G(V, W)`.
+
+This is `ContRepresentation.integral_character_mul_eq_finrank_contIntertwiningMap` specialized to a
+finite discrete group, and it is exactly the shape of Mathlib's
+`Representation.card_inv_mul_sum_char_mul_char_eq_finrank`. No unitarity is needed: the inverse in
+the first factor is what the compact statement carries, and only for a unitary representation does
+it become a complex conjugate. -/
+theorem card_inv_mul_sum_character_mul_eq_finrank_contIntertwiningMap :
+    (Nat.card G : 𝕜)⁻¹ * ∑ g, character π hπ g⁻¹ * character ρ hρ g
+      = (Module.finrank 𝕜 (ContIntertwiningMap π ρ) : 𝕜) := by
+  rw [← integral_character_mul_eq_finrank_contIntertwiningMap π ρ hπ hρ,
+    integral_haarProb_eq_inv_mul_sum]
+
+end Character
+
+section CharacterOrthogonality
+
+variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSpace G]
+  [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+  [NormedAddCommGroup W] [InnerProductSpace 𝕜 W] [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W]
+  [FiniteDimensional 𝕜 W]
+  (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+
+include hπ
+
+/-- **First character orthogonality for a finite group**:
+`|G|⁻¹ ∑ g, conj (χ_π g) · χ_π g = 1` for an irreducible unitary representation. -/
+theorem character_orthonormal_self_sum [IsAlgClosed 𝕜] (hunitary : IsUnitary π)
+    (hirr : Representation.IsIrreducible π.toRepresentation) :
+    (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) (character π hπ g) * character π hπ g = 1 := by
+  rw [← inner_characterLp_eq_inv_mul_sum π hπ π hπ,
+    character_orthonormal_self π hπ hunitary hirr]
+
+omit [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W] in
+/-- **Second character orthogonality for a finite group**: the group average of `conj χ_π · χ_ρ`
+vanishes when no nonzero continuous intertwiner `ρ → π` exists, which for a pair of irreducibles is
+Schur's lemma. -/
+theorem character_orthonormal_distinct_sum (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ)
+    (hunitary : IsUnitary π)
+    (hdistinct : ∀ f : ContIntertwiningMap ρ π, f.toContinuousLinearMap = 0) :
+    (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) (character π hπ g) * character ρ hρ g = 0 := by
+  rw [← inner_characterLp_eq_inv_mul_sum π hπ ρ hρ,
+    character_orthonormal_distinct π hπ ρ hρ hunitary hdistinct]
+
+/- **The diagonal half of Mathlib's `Representation.char_orthonormal`**, in its `χ_π(g) · χ_π(g⁻¹)`
+spelling, obtained through the compact theory: unitarity turns the inverse into a conjugate by
+`ContRepresentation.character_apply_inv`, and `character_orthonormal_self_sum` is then the
+statement. No name is claimed, since Mathlib's lemma is the general form; what is exhibited is that
+the compact-group normalization agrees with the finite-group one. -/
+example [IsAlgClosed 𝕜] (hunitary : IsUnitary π)
+    (hirr : Representation.IsIrreducible π.toRepresentation) :
+    (Nat.card G : 𝕜)⁻¹ * ∑ g, character π hπ g * character π hπ g⁻¹ = 1 := by
+  rw [← character_orthonormal_self_sum π hπ hunitary hirr]
+  exact congrArg _ (Finset.sum_congr rfl fun g _ ↦ by
+    rw [character_apply_inv π hπ hunitary, mul_comm])
+
+end CharacterOrthogonality
 
 end ContRepresentation

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -24,15 +24,17 @@ to it, only to the explicit sum.)
 
 Everything the compact theory phrases as an `L²(G)` inner product then becomes a finite Hermitian
 sum. Normalized Haar measure has full support on a discrete space and every function on a discrete
-space is continuous, so a class in `L²(G)` *is* a function on `G` — the coercion is a linear
-equivalence `L²(G) ≃ₗ[𝕜] (G → 𝕜)` — and the inner product is `|G|⁻¹ ∑ x, conj (f x) · g x`.
-Rewriting the compact statements along that identity turns the two Schur orthogonality relations
-and the two character orthogonality relations into their classical finite-group forms, and turns
-the intertwiner count
-`⟪χ_π, χ_ρ⟫ = dim Hom_G(V, W)` into `|G|⁻¹ ∑ g, χ_π(g⁻¹) · χ_ρ(g) = dim Hom_G(V, W)`, which is the
-shape Mathlib proves algebraically as `Representation.card_inv_mul_sum_char_mul_char_eq_finrank`.
-Each such specialization carries the name of the compact statement it specializes, with the suffix
-`_sum` recording that the Haar integral has become a group average.
+space is continuous, so a class in `Lp 𝕜 p (haarProb G)` *is* a function on `G` — the coercion is a
+linear equivalence `Lp 𝕜 p (haarProb G) ≃ₗ[𝕜] (G → 𝕜)`, for any exponent — and at `p = 2` the inner
+product is `|G|⁻¹ ∑ x, conj (f x) · g x`. Rewriting the compact statements along that identity turns
+the two Schur orthogonality relations and the two character orthogonality relations into their
+classical finite-group forms, and turns the intertwiner count
+`∫ g, χ_π(g⁻¹) · χ_ρ(g) ∂haarProb G = dim Hom_G(V, W)` into
+`|G|⁻¹ ∑ g, χ_π(g⁻¹) · χ_ρ(g) = dim Hom_G(V, W)`, which is the shape Mathlib proves algebraically as
+`Representation.card_inv_mul_sum_char_mul_char_eq_finrank`. (For a unitary `π` that Haar integral is
+the `L²` inner product `⟪χ_π, χ_ρ⟫`, but no unitarity is needed for the count.) Each such
+specialization carries the name of the compact statement it specializes, with the suffix `_sum`
+recording that the Haar integral has become a group average.
 
 The measure statement is proved without appealing to the Haar property of the counting measure, and
 in fact without any topology: left invariance alone forces all singletons of a finite group to have
@@ -58,20 +60,24 @@ measure computation has just identified.
   says the same for the bundled averaging operator.
 * `ContRepresentation.haarAverageMap_eq_smul_sum`: the Haar average of the action operators is the
   finite average `|G|⁻¹ • ∑ g, π g v`.
-* `TauCeti.eq_of_ae_eq_haarProb`: **normalized Haar measure on a finite discrete group has full
-  support**, so two functions agreeing almost everywhere agree everywhere. This is what makes an
-  `L²` class on a finite group a genuine function.
-* `TauCeti.lpEquivFun`: **`L²(G)` is `G → 𝕜`**, by the linear equivalence taking an `L²` class to
-  its values; the previous item is its injectivity and finiteness is its surjectivity.
-* `TauCeti.inner_Lp_eq_inv_mul_sum`: **the `L²(G)` inner product is the normalized Hermitian
-  pairing** `|G|⁻¹ ∑ x, conj (f x) · g x` of those values, with
-  `TauCeti.inner_toLp_eq_inv_mul_sum` the form for two continuous functions.
-* `ContRepresentation.schur_orthogonality_self_sum` and
+* `TauCeti.ae_haarProb_eq_top`: **normalized Haar measure on a finite discrete group has full
+  support**, so its almost-everywhere filter is `⊤` and, by `TauCeti.eq_of_ae_eq_haarProb`, two
+  functions agreeing almost everywhere agree everywhere. This is what makes an `L²` class on a
+  finite group a genuine function; `TauCeti.coeFn_toLp_haarProb` is the case of it used throughout,
+  that the class of a continuous function is that function.
+* `TauCeti.lpHaarProbEquivFun`: **`L²(G)` is `G → 𝕜`**, by the linear equivalence taking an `Lp`
+  class to its values; the previous item is its injectivity and finiteness is its surjectivity.
+  Nothing in it depends on the exponent, so it is stated for every `p`.
+* `TauCeti.inner_Lp_haarProb_eq_inv_mul_sum`: **the `L²(G)` inner product is the normalized
+  Hermitian pairing** `|G|⁻¹ ∑ x, conj (f x) · g x` of those values, with
+  `TauCeti.inner_toLp_haarProb_eq_inv_mul_sum` the form for two continuous functions.
+* `ContRepresentation.schur_orthogonality_self_sum`,
+  `ContRepresentation.schur_orthogonality_distinct_sum` and
   `ContRepresentation.schur_orthogonality_sum`: **the two Schur orthogonality relations as finite
-  averages** of matrix coefficients.
-* `ContRepresentation.character_orthonormal_self_sum` and
-  `ContRepresentation.character_orthonormal_distinct_sum`: **the two character orthogonality
-  relations as finite averages**.
+  averages** of matrix coefficients, the middle one at the vanishing-intertwiner hypothesis of the
+  compact theory and the last at a pair of inequivalent irreducibles.
+* `ContRepresentation.character_orthonormal_distinct_sum`: **the second character orthogonality
+  relation as a finite average**.
 
 The counting identity `|G|⁻¹ ∑ g, χ_π g = dim V^G` that the compact-group character integral
 generalizes then costs one rewrite. It is not given a name: Mathlib already proves it, as
@@ -82,17 +88,20 @@ as `Representation.card_inv_mul_sum_char_mul_char_eq_finrank`, for the algebraic
 `Representation.IntertwiningMap`, which in finite dimensions is the continuous one because every
 linear map out of a finite-dimensional normed space is continuous. Both routes are exhibited by
 anonymous `example`s, as are both branches of Mathlib's `Representation.char_orthonormal`: the
-diagonal one is `character_orthonormal_self_sum`, and the off-diagonal one is
+diagonal one is `TauCeti.ContRepresentation.character_orthonormal_self` read through the finite
+pairing — Mathlib and `TauCeti.ClassFunction.characterPairing_ofCharacter_self` both already prove
+that identity, so no name is claimed for it either — and the off-diagonal one is
 `character_orthonormal_distinct_sum` with its intertwiner hypothesis discharged, for a pair of
 inequivalent irreducibles, by the vanishing half of Schur's lemma.
 
 ## Implementation notes
 
 Finiteness is spelled `[Finite G]` wherever that suffices — the measure-theoretic statements and the
-equivalence `TauCeti.lpEquivFun` — and `[Fintype G]` only where a sum over `Finset.univ` appears in
-the statement itself, since a `Fintype` instance recovered from `Finite` inside a proof would not be
-the one indexing that sum. The scalars are weakened the same way: `TauCeti.lpEquivFun` needs only
-`[NontriviallyNormedField 𝕜]`, and `[RCLike 𝕜]` appears from the inner-product statements on.
+equivalence `TauCeti.lpHaarProbEquivFun` — and `[Fintype G]` only where a sum over `Finset.univ`
+appears in the statement itself, since a `Fintype` instance recovered from `Finite` inside a proof
+would not be the one indexing that sum. The scalars and the exponent are weakened the same way:
+`TauCeti.lpHaarProbEquivFun` needs only `[NontriviallyNormedField 𝕜]` and an arbitrary `p` with
+`[Fact (1 ≤ p)]`, and `[RCLike 𝕜]` and `p = 2` appear from the inner-product statements on.
 Cardinalities are written `Nat.card G` throughout, matching the rest of the roadmap;
 `Nat.card_eq_fintype_card` converts.
 
@@ -114,8 +123,9 @@ recover the character theory" of the
 `dim V^G = |G|⁻¹ ∑ g, χ_π g` is the finite shadow of
 `ContRepresentation.integral_character_eq_finrank_invariants`, matching Mathlib's
 `FDRep.average_char_eq_finrank_invariants` for the purely algebraic theory. It is also the `L²`,
-Schur and character-orthonormality part of that item: `L²(G)` is `G → 𝕜` by `TauCeti.lpEquivFun`
-and `⟪·, ·⟫_{L²(G)}` becomes the finite Hermitian pairing on it, `schur_orthogonality_self` and
+Schur and character-orthonormality part of that item: `L²(G)` is `G → 𝕜` by
+`TauCeti.lpHaarProbEquivFun` and `⟪·, ·⟫_{L²(G)}` becomes the finite Hermitian pairing on it,
+`schur_orthogonality_self`, `schur_orthogonality_distinct` and
 `schur_orthogonality` become the classical orthogonality relations for matrix coefficients, and
 `character_orthonormal_self` and `character_orthonormal_distinct` become the two branches of
 Mathlib's `Representation.char_orthonormal`, exhibited by the two anonymous `example`s closing the
@@ -242,55 +252,80 @@ section FullSupport
 variable (G : Type*) [Group G] [Finite G] [TopologicalSpace G] [DiscreteTopology G]
   [MeasurableSpace G] [BorelSpace G]
 
-/-- **Normalized Haar measure on a finite discrete group has full support**, so functions agreeing
-almost everywhere agree everywhere.
+/-- **Normalized Haar measure on a finite discrete group has full support**, in the sharp form that
+its almost-everywhere filter is the whole filter: every singleton has mass `|G|⁻¹ ≠ 0`, so the empty
+set is the only null set. -/
+theorem ae_haarProb_eq_top : ae (haarProb G) = ⊤ :=
+  ae_eq_top.2 fun a ↦ by
+    rw [haarProb_singleton]
+    simp
 
-Haar measure is positive on nonempty open sets, and on a discrete space every function is
-continuous, so `Continuous.ae_eq_iff_eq` applies with no measurability side condition. In
-particular an element of `Lp 𝕜 2 (haarProb G)`, which is only an almost-everywhere class, is
+/-- **Functions on a finite discrete group agreeing almost everywhere for normalized Haar measure
+agree everywhere.** This is `TauCeti.ae_haarProb_eq_top` read as a statement about functions;
+nothing is asked of the codomain, the fact being one about the measure alone.
+
+In particular an element of `Lp 𝕜 p (haarProb G)`, which is only an almost-everywhere class, is
 pinned down by its values: this is the sense in which `L²(G)` "is" `G → 𝕜`. -/
-theorem eq_of_ae_eq_haarProb {α : Type*} [TopologicalSpace α] [T2Space α] {f g : G → α}
-    (h : f =ᵐ[haarProb G] g) : f = g :=
-  (continuous_of_discreteTopology.ae_eq_iff_eq (haarProb G) continuous_of_discreteTopology).mp h
+theorem eq_of_ae_eq_haarProb {α : Type*} {f g : G → α} (h : f =ᵐ[haarProb G] g) : f = g := by
+  rw [ae_haarProb_eq_top] at h
+  exact funext (Filter.eventually_top.mp h)
 
 end FullSupport
 
 section LpEquiv
 
 variable (G : Type*) [Group G] [Finite G] [TopologicalSpace G] [DiscreteTopology G]
-  [MeasurableSpace G] [BorelSpace G] {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  [MeasurableSpace G] [BorelSpace G] {𝕜 : Type*} [NontriviallyNormedField 𝕜] {p : ℝ≥0∞}
+  [Fact (1 ≤ p)]
 
-variable (𝕜) in
-/-- **`L²` of a finite discrete group is the space of all functions on it**: taking underlying
-functions is a `𝕜`-linear equivalence `Lp 𝕜 2 (haarProb G) ≃ₗ[𝕜] (G → 𝕜)`.
+/-- **The `Lp` class of a continuous function on a finite discrete group is that function**, on the
+nose and not merely almost everywhere, because normalized Haar measure has full support
+(`TauCeti.eq_of_ae_eq_haarProb`).
+
+This is not a `simp` lemma: `ContinuousMap.coe_toLp` already rewrites the left-hand side to
+`⇑(f.toAEEqFun (haarProb G))`, so tagging it is a `simpNF` error. The value-level `simp` form of
+the round trip through the equivalence below is `TauCeti.coeFn_lpHaarProbEquivFun_symm`. -/
+theorem coeFn_toLp_haarProb (f : C(G, 𝕜)) : ⇑(ContinuousMap.toLp p (haarProb G) 𝕜 f) = f :=
+  eq_of_ae_eq_haarProb G (ContinuousMap.coeFn_toLp (𝕜 := 𝕜) (p := p) (haarProb G) f)
+
+variable (𝕜 p) in
+/-- **`Lp` of a finite discrete group is the space of all functions on it**: taking underlying
+functions is a `𝕜`-linear equivalence `Lp 𝕜 p (haarProb G) ≃ₗ[𝕜] (G → 𝕜)`.
 
 It is injective because normalized Haar measure has full support (`TauCeti.eq_of_ae_eq_haarProb`),
-so an `L²` class is pinned down by its values, and surjective because `G` is finite and discrete:
-*every* function on `G` is continuous, hence square-integrable against a probability measure, and
-`ContinuousMap.toLp` produces its class. Together with `TauCeti.inner_Lp_eq_inv_mul_sum`, which
-computes the inner product from exactly the values this equivalence reads off, it is the
-identification of `L²(G)` with `G → 𝕜` carrying the normalized Hermitian pairing. -/
-noncomputable def lpEquivFun : Lp 𝕜 2 (haarProb G) ≃ₗ[𝕜] (G → 𝕜) where
+so an `Lp` class is pinned down by its values, and surjective because `G` is finite and discrete:
+*every* function on `G` is continuous, hence `p`-integrable against a probability measure, and
+`ContinuousMap.toLp` produces its class. Nothing depends on the exponent; at `p = 2`, together
+with `TauCeti.inner_Lp_haarProb_eq_inv_mul_sum`, which computes the inner product from exactly the
+values this equivalence reads off, it is the identification of `L²(G)` with `G → 𝕜` carrying the
+normalized Hermitian pairing. -/
+noncomputable def lpHaarProbEquivFun : Lp 𝕜 p (haarProb G) ≃ₗ[𝕜] (G → 𝕜) where
   toFun f := f
   map_add' f g := eq_of_ae_eq_haarProb G (Lp.coeFn_add f g)
   map_smul' c f := eq_of_ae_eq_haarProb G (Lp.coeFn_smul c f)
-  invFun f := ContinuousMap.toLp 2 (haarProb G) 𝕜 ⟨f, continuous_of_discreteTopology⟩
-  left_inv f := Lp.ext (ContinuousMap.coeFn_toLp (𝕜 := 𝕜) (p := 2) (haarProb G)
-    ⟨⇑f, continuous_of_discreteTopology⟩)
-  right_inv f := eq_of_ae_eq_haarProb G (ContinuousMap.coeFn_toLp (𝕜 := 𝕜) (p := 2) (haarProb G)
-    ⟨f, continuous_of_discreteTopology⟩)
+  invFun f := ContinuousMap.toLp p (haarProb G) 𝕜 ⟨f, continuous_of_discreteTopology⟩
+  left_inv f := Lp.ext (.of_eq (coeFn_toLp_haarProb G ⟨⇑f, continuous_of_discreteTopology⟩))
+  right_inv f := coeFn_toLp_haarProb G ⟨f, continuous_of_discreteTopology⟩
 
-/-- The equivalence `TauCeti.lpEquivFun` reads off the values of an `L²` class. -/
+/-- The equivalence `TauCeti.lpHaarProbEquivFun` reads off the values of an `Lp` class. -/
 @[simp]
-theorem lpEquivFun_apply (f : Lp 𝕜 2 (haarProb G)) (x : G) : lpEquivFun G 𝕜 f x = f x :=
+theorem lpHaarProbEquivFun_apply (f : Lp 𝕜 p (haarProb G)) (x : G) :
+    lpHaarProbEquivFun G 𝕜 p f x = f x :=
   (rfl)
 
-/-- The inverse of `TauCeti.lpEquivFun` is `ContinuousMap.toLp`, every function on a discrete space
-being continuous. -/
+/-- **The inverse of `TauCeti.lpHaarProbEquivFun` has the values it was handed.** This is the
+simp-normal form of the inverse: it is what makes the round trip through the equivalence reduce. -/
 @[simp]
-theorem lpEquivFun_symm_apply (f : G → 𝕜) :
-    (lpEquivFun G 𝕜).symm f =
-      ContinuousMap.toLp 2 (haarProb G) 𝕜 ⟨f, continuous_of_discreteTopology⟩ :=
+theorem coeFn_lpHaarProbEquivFun_symm (f : G → 𝕜) : ⇑((lpHaarProbEquivFun G 𝕜 p).symm f) = f :=
+  coeFn_toLp_haarProb G ⟨f, continuous_of_discreteTopology⟩
+
+/-- The inverse of `TauCeti.lpHaarProbEquivFun` is `ContinuousMap.toLp`, every function on a
+discrete space being continuous. This is not a simp lemma:
+`TauCeti.coeFn_lpHaarProbEquivFun_symm` is the value-level form, and rewriting the inner term first
+would keep a round trip from reducing by `LinearEquiv.apply_symm_apply`. -/
+theorem lpHaarProbEquivFun_symm_apply (f : G → 𝕜) :
+    (lpHaarProbEquivFun G 𝕜 p).symm f =
+      ContinuousMap.toLp p (haarProb G) 𝕜 ⟨f, continuous_of_discreteTopology⟩ :=
   (rfl)
 
 end LpEquiv
@@ -303,12 +338,12 @@ variable (G : Type*) [Group G] [Fintype G] [TopologicalSpace G] [DiscreteTopolog
 /-- **The `L²` inner product of a finite discrete group is the normalized Hermitian pairing**
 `|G|⁻¹ ∑ x, conj (f x) * g x`.
 
-This is the pairing carried by the identification `L²(G) = (G → 𝕜)` of `TauCeti.lpEquivFun`, whose
-underlying map is the coercion appearing on the right: the Haar integral defining the `L²` inner
-product is the group average, by `TauCeti.integral_haarProb_eq_inv_mul_sum`. The conjugation sits
-on the *first* argument, matching Mathlib's convention that the inner product is conjugate-linear
-there. -/
-theorem inner_Lp_eq_inv_mul_sum (f g : Lp 𝕜 2 (haarProb G)) :
+This is the pairing carried by the identification `L²(G) = (G → 𝕜)` of
+`TauCeti.lpHaarProbEquivFun`, whose underlying map is the coercion appearing on the right: the Haar
+integral defining the `L²` inner product is the group average, by
+`TauCeti.integral_haarProb_eq_inv_mul_sum`. The conjugation sits on the *first* argument, matching
+Mathlib's convention that the inner product is conjugate-linear there. -/
+theorem inner_Lp_haarProb_eq_inv_mul_sum (f g : Lp 𝕜 2 (haarProb G)) :
     ⟪f, g⟫_𝕜 = (Nat.card G : 𝕜)⁻¹ * ∑ x, (starRingEnd 𝕜) (f x) * g x := by
   rw [L2.inner_def,
     ← integral_haarProb_eq_inv_mul_sum (𝕜 := 𝕜) G fun x ↦ (starRingEnd 𝕜) (f x) * g x]
@@ -317,12 +352,11 @@ theorem inner_Lp_eq_inv_mul_sum (f g : Lp 𝕜 2 (haarProb G)) :
 
 /-- The `L²` inner product of two *continuous* functions on a finite discrete group, the form in
 which the matrix coefficients and the characters present themselves. -/
-theorem inner_toLp_eq_inv_mul_sum (f g : C(G, 𝕜)) :
+theorem inner_toLp_haarProb_eq_inv_mul_sum (f g : C(G, 𝕜)) :
     ⟪ContinuousMap.toLp 2 (haarProb G) 𝕜 f, ContinuousMap.toLp 2 (haarProb G) 𝕜 g⟫_𝕜 =
       (Nat.card G : 𝕜)⁻¹ * ∑ x, (starRingEnd 𝕜) (f x) * g x := by
-  rw [inner_Lp_eq_inv_mul_sum,
-    eq_of_ae_eq_haarProb G (ContinuousMap.coeFn_toLp (𝕜 := 𝕜) (p := 2) (haarProb G) f),
-    eq_of_ae_eq_haarProb G (ContinuousMap.coeFn_toLp (𝕜 := 𝕜) (p := 2) (haarProb G) g)]
+  rw [inner_Lp_haarProb_eq_inv_mul_sum]
+  simp only [coeFn_toLp_haarProb]
 
 end InnerProduct
 
@@ -392,7 +426,7 @@ theorem inner_matrixCoeffLp_eq_inv_mul_sum (π : ContRepresentation 𝕜 G V) (h
     (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (v w : V) (v' w' : W) :
     ⟪matrixCoeffLp π hπ v w, matrixCoeffLp ρ hρ v' w'⟫_𝕜 =
       (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v, w⟫_𝕜 * ⟪ρ g v', w'⟫_𝕜 := by
-  rw [matrixCoeffLp_def, matrixCoeffLp_def, inner_toLp_eq_inv_mul_sum]
+  rw [matrixCoeffLp_def, matrixCoeffLp_def, inner_toLp_haarProb_eq_inv_mul_sum]
   simp only [matrixCoeff_apply]
 
 end MatrixCoefficient
@@ -427,14 +461,27 @@ variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSp
   [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
   [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [FiniteDimensional 𝕜 V]
   [NormedAddCommGroup W] [InnerProductSpace 𝕜 W] [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W]
-  [FiniteDimensional 𝕜 W]
+  [CompleteSpace W]
 
-local instance instCompleteSpaceSchurDistinct : CompleteSpace W :=
-  FiniteDimensional.complete 𝕜 W
+omit [FiniteDimensional 𝕜 V] in
+/-- **Schur orthogonality for a finite group and a vanishing intertwiner space.** If the only
+continuous intertwiner `π → ρ` is zero and `ρ` is unitary, then every matrix coefficient of `π` has
+vanishing group average against every matrix coefficient of `ρ`. This is
+`TauCeti.ContRepresentation.schur_orthogonality_distinct` read through the finite Hermitian
+pairing; Schur's lemma is what supplies the hypothesis for a pair of inequivalent irreducibles, as
+in `ContRepresentation.schur_orthogonality_sum` below. -/
+theorem schur_orthogonality_distinct_sum (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+    (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (hunitary : IsUnitary ρ)
+    (hdistinct : ∀ f : ContIntertwiningMap π ρ, f.toContinuousLinearMap = 0)
+    (v w : V) (v' w' : W) :
+    (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v, w⟫_𝕜 * ⟪ρ g v', w'⟫_𝕜 = 0 := by
+  rw [← inner_matrixCoeffLp_eq_inv_mul_sum π hπ ρ hρ,
+    schur_orthogonality_distinct π hπ ρ hρ hunitary hdistinct]
 
 /-- **The second Schur orthogonality relation for a finite group.** Matrix coefficients of
-inequivalent irreducible representations have vanishing group average, this being
-`TauCeti.ContRepresentation.schur_orthogonality` read through the finite Hermitian pairing. -/
+inequivalent irreducible representations, the second of them unitary, have vanishing group average,
+this being `TauCeti.ContRepresentation.schur_orthogonality` read through the finite Hermitian
+pairing. -/
 theorem schur_orthogonality_sum (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
     (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (hunitary : IsUnitary ρ)
     (hirrπ : Representation.IsIrreducible π.toRepresentation)
@@ -466,7 +513,7 @@ omit [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V] [NormedSpace ℝ W] [SMulCom
 theorem inner_characterLp_eq_inv_mul_sum :
     ⟪characterLp π hπ, characterLp ρ hρ⟫_𝕜 =
       (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) (character π hπ g) * character ρ hρ g := by
-  rw [characterLp_def, characterLp_def, inner_toLp_eq_inv_mul_sum]
+  rw [characterLp_def, characterLp_def, inner_toLp_haarProb_eq_inv_mul_sum]
 
 omit [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V] in
 /- **The finite character sum counts the intertwiners**:
@@ -501,18 +548,11 @@ variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSp
 
 include hπ
 
-/-- **First character orthogonality for a finite group**:
-`|G|⁻¹ ∑ g, conj (χ_π g) · χ_π g = 1` for an irreducible unitary representation. -/
-theorem character_orthonormal_self_sum [IsAlgClosed 𝕜] (hunitary : IsUnitary π)
-    (hirr : Representation.IsIrreducible π.toRepresentation) :
-    (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) (character π hπ g) * character π hπ g = 1 := by
-  rw [← inner_characterLp_eq_inv_mul_sum π hπ π hπ,
-    character_orthonormal_self π hπ hunitary hirr]
-
 omit [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W] in
-/-- **Second character orthogonality for a finite group**: the group average of `conj χ_π · χ_ρ`
-vanishes when no nonzero continuous intertwiner `ρ → π` exists, which for a pair of irreducibles is
-Schur's lemma. -/
+/-- **Second character orthogonality for a finite group**: for a *unitary* `π`, the group average of
+`conj χ_π · χ_ρ` vanishes when no nonzero continuous intertwiner `ρ → π` exists, which for a pair of
+irreducibles is Schur's lemma. Unitarity is asked of `π` alone, as in the compact source
+`TauCeti.ContRepresentation.character_orthonormal_distinct`. -/
 theorem character_orthonormal_distinct_sum (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ)
     (hunitary : IsUnitary π)
     (hdistinct : ∀ f : ContIntertwiningMap ρ π, f.toContinuousLinearMap = 0) :
@@ -520,15 +560,22 @@ theorem character_orthonormal_distinct_sum (ρ : ContRepresentation 𝕜 G W) (h
   rw [← inner_characterLp_eq_inv_mul_sum π hπ ρ hρ,
     character_orthonormal_distinct π hπ ρ hρ hunitary hdistinct]
 
-/- **The diagonal half of Mathlib's `Representation.char_orthonormal`**, in its `χ_π(g) · χ_π(g⁻¹)`
-spelling, obtained through the compact theory: unitarity turns the inverse into a conjugate by
-`ContRepresentation.character_apply_inv`, and `character_orthonormal_self_sum` is then the
-statement. No name is claimed, since Mathlib's lemma is the general form; what is exhibited is that
-the compact-group normalization agrees with the finite-group one. -/
+/- **First character orthogonality for a finite group**, which is the diagonal half of Mathlib's
+`Representation.char_orthonormal`, in its `χ_π(g) · χ_π(g⁻¹)` spelling, obtained through the compact
+theory: `TauCeti.ContRepresentation.character_orthonormal_self` says the character of an irreducible
+unitary representation is an `L²` unit vector, `inner_characterLp_eq_inv_mul_sum` turns that pairing
+into a group average, and unitarity turns the inverse into a conjugate by
+`TauCeti.ContRepresentation.character_apply_inv`.
+
+No name is claimed, for the same reason as in the two counting identities above: the identity is
+already Mathlib's `Representation.char_orthonormal` (its diagonal branch) at `π.toRepresentation`,
+and `TauCeti.ClassFunction.characterPairing_ofCharacter_self` proves it again for the character
+pairing — both without unitarity, which is needed only to pass between the two spellings. What is
+exhibited is that the compact-group normalization agrees with the finite-group one. -/
 example [IsAlgClosed 𝕜] (hunitary : IsUnitary π)
     (hirr : Representation.IsIrreducible π.toRepresentation) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, character π hπ g * character π hπ g⁻¹ = 1 := by
-  rw [← character_orthonormal_self_sum π hπ hunitary hirr]
+  rw [← character_orthonormal_self π hπ hunitary hirr, inner_characterLp_eq_inv_mul_sum π hπ π hπ]
   exact congrArg _ (Finset.sum_congr rfl fun g _ ↦ by
     rw [character_apply_inv π hπ hunitary, mul_comm])
 

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RepresentationTheory.Compact.Intertwiner.Dimension
-public import TauCeti.RepresentationTheory.Compact.Invariants
 public import Mathlib.MeasureTheory.Measure.Count
 public import Mathlib.Probability.UniformOn
 import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
@@ -107,7 +106,11 @@ Cardinalities are written `Nat.card G` throughout, matching the rest of the road
 
 `IsTopologicalGroup G`, `CompactSpace G`, `T2Space G` and `MeasurableSingletonClass G` are all
 found by instance search from `[DiscreteTopology G]`, `[Finite G]` and `[BorelSpace G]`, so no
-extra hypotheses are carried.
+extra hypotheses are carried. Continuity of a representation is likewise automatic, by
+`continuous_of_discreteTopology`, and is asked of the caller only where the *statement* needs it:
+`matrixCoeffLp π hπ`, `characterLp π hπ` and `character π hπ` take the continuity proof as an
+argument, so a caller of the pairing lemmas has one in hand already, whereas the orthogonality
+relations are stated as bare sums `∑ g, ⟪π g v, w⟫ · …` and take no continuity argument at all.
 
 The scalar in the averaged sums is real, not `𝕜`: the Bochner integral being specialized is an
 `ℝ`-integral, and `V` is not assumed to be an `ℝ`-`𝕜`-scalar tower. The conversion is confined to
@@ -255,6 +258,7 @@ variable (G : Type*) [Group G] [Finite G] [TopologicalSpace G] [DiscreteTopology
 /-- **Normalized Haar measure on a finite discrete group has full support**, in the sharp form that
 its almost-everywhere filter is the whole filter: every singleton has mass `|G|⁻¹ ≠ 0`, so the empty
 set is the only null set. -/
+@[simp]
 theorem ae_haarProb_eq_top : ae (haarProb G) = ⊤ :=
   ae_eq_top.2 fun a ↦ by
     rw [haarProb_singleton]
@@ -444,14 +448,16 @@ representation of dimension `d`,
 
 This is `TauCeti.ContRepresentation.schur_orthogonality_self` with the Haar integral of the
 compact theory replaced by the group average; the normalization `|G|⁻¹` is exactly the one that
-makes normalized Haar measure a probability measure. -/
-theorem schur_orthogonality_self_sum (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+makes normalized Haar measure a probability measure. No continuity of `π` is asked: the statement
+does not mention it, and on a discrete group `continuous_of_discreteTopology` supplies it. -/
+theorem schur_orthogonality_self_sum (π : ContRepresentation 𝕜 G V)
     (hunitary : IsUnitary π) (hirr : Representation.IsIrreducible π.toRepresentation)
     (v₁ w₁ v₂ w₂ : V) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v₁, w₁⟫_𝕜 * ⟪π g v₂, w₂⟫_𝕜 =
       (Module.finrank 𝕜 V : 𝕜)⁻¹ * ((starRingEnd 𝕜) ⟪v₁, v₂⟫_𝕜 * ⟪w₁, w₂⟫_𝕜) := by
-  rw [← inner_matrixCoeffLp_eq_inv_mul_sum π hπ π hπ,
-    schur_orthogonality_self π hπ hunitary hirr]
+  rw [← inner_matrixCoeffLp_eq_inv_mul_sum π continuous_of_discreteTopology π
+      continuous_of_discreteTopology,
+    schur_orthogonality_self π continuous_of_discreteTopology hunitary hirr]
 
 end SchurSelf
 
@@ -469,27 +475,33 @@ continuous intertwiner `π → ρ` is zero and `ρ` is unitary, then every matri
 vanishing group average against every matrix coefficient of `ρ`. This is
 `TauCeti.ContRepresentation.schur_orthogonality_distinct` read through the finite Hermitian
 pairing; Schur's lemma is what supplies the hypothesis for a pair of inequivalent irreducibles, as
-in `ContRepresentation.schur_orthogonality_sum` below. -/
-theorem schur_orthogonality_distinct_sum (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
-    (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (hunitary : IsUnitary ρ)
+in `ContRepresentation.schur_orthogonality_sum` below. No continuity is asked of either
+representation, for the reason given at `ContRepresentation.schur_orthogonality_self_sum`. -/
+theorem schur_orthogonality_distinct_sum (π : ContRepresentation 𝕜 G V)
+    (ρ : ContRepresentation 𝕜 G W) (hunitary : IsUnitary ρ)
     (hdistinct : ∀ f : ContIntertwiningMap π ρ, f.toContinuousLinearMap = 0)
     (v w : V) (v' w' : W) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v, w⟫_𝕜 * ⟪ρ g v', w'⟫_𝕜 = 0 := by
-  rw [← inner_matrixCoeffLp_eq_inv_mul_sum π hπ ρ hρ,
-    schur_orthogonality_distinct π hπ ρ hρ hunitary hdistinct]
+  rw [← inner_matrixCoeffLp_eq_inv_mul_sum π continuous_of_discreteTopology ρ
+      continuous_of_discreteTopology,
+    schur_orthogonality_distinct π continuous_of_discreteTopology ρ
+      continuous_of_discreteTopology hunitary hdistinct]
 
 /-- **The second Schur orthogonality relation for a finite group.** Matrix coefficients of
 inequivalent irreducible representations, the second of them unitary, have vanishing group average,
 this being `TauCeti.ContRepresentation.schur_orthogonality` read through the finite Hermitian
-pairing. -/
-theorem schur_orthogonality_sum (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
-    (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (hunitary : IsUnitary ρ)
+pairing. No continuity is asked of either representation, for the reason given at
+`ContRepresentation.schur_orthogonality_self_sum`. -/
+theorem schur_orthogonality_sum (π : ContRepresentation 𝕜 G V)
+    (ρ : ContRepresentation 𝕜 G W) (hunitary : IsUnitary ρ)
     (hirrπ : Representation.IsIrreducible π.toRepresentation)
     (hirrρ : Representation.IsIrreducible ρ.toRepresentation)
     (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) (v w : V) (v' w' : W) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v, w⟫_𝕜 * ⟪ρ g v', w'⟫_𝕜 = 0 := by
-  rw [← inner_matrixCoeffLp_eq_inv_mul_sum π hπ ρ hρ,
-    schur_orthogonality π hπ ρ hρ hunitary hirrπ hirrρ hne]
+  rw [← inner_matrixCoeffLp_eq_inv_mul_sum π continuous_of_discreteTopology ρ
+      continuous_of_discreteTopology,
+    schur_orthogonality π continuous_of_discreteTopology ρ continuous_of_discreteTopology
+      hunitary hirrπ hirrρ hne]
 
 end SchurDistinct
 

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -26,8 +26,9 @@ sum. Normalized Haar measure has full support on a discrete space and every func
 space is continuous, so a class in `Lp 𝕜 p (haarProb G)` *is* a function on `G` — the coercion is a
 linear equivalence `Lp 𝕜 p (haarProb G) ≃ₗ[𝕜] (G → 𝕜)`, for any exponent — and at `p = 2` the inner
 product is `|G|⁻¹ ∑ x, conj (f x) · g x`. Rewriting the compact statements along that identity turns
-the two Schur orthogonality relations and the two character orthogonality relations into their
-classical finite-group forms, and turns the intertwiner count
+the two Schur orthogonality relations, and both branches — diagonal and off-diagonal — of the first
+(row) character orthogonality relation, into their classical finite-group forms, and turns the
+intertwiner count
 `∫ g, χ_π(g⁻¹) · χ_ρ(g) ∂haarProb G = dim Hom_G(V, W)` into
 `|G|⁻¹ ∑ g, χ_π(g⁻¹) · χ_ρ(g) = dim Hom_G(V, W)`, which is the shape Mathlib proves algebraically as
 `Representation.card_inv_mul_sum_char_mul_char_eq_finrank`. (For a unitary `π` that Haar integral is
@@ -74,9 +75,12 @@ measure computation has just identified.
   `ContRepresentation.schur_orthogonality_distinct_sum` and
   `ContRepresentation.schur_orthogonality_sum`: **the two Schur orthogonality relations as finite
   averages** of matrix coefficients, the middle one at the vanishing-intertwiner hypothesis of the
-  compact theory and the last at a pair of inequivalent irreducibles.
-* `ContRepresentation.character_orthonormal_distinct_sum`: **the second character orthogonality
-  relation as a finite average**.
+  compact theory and the last at a pair of inequivalent irreducibles, with
+  `ContRepresentation.schur_orthogonality_basis_sum` the Kronecker-delta form of the first in an
+  orthonormal basis.
+* `ContRepresentation.character_orthonormal_distinct_sum`: **the off-diagonal branch of the first
+  (row) character orthogonality relation as a finite average**. (The column sum over the irreducible
+  characters, the second orthogonality relation, is not treated here.)
 
 The counting identity `|G|⁻¹ ∑ g, χ_π g = dim V^G` that the compact-group character integral
 generalizes then costs one rewrite. It is not given a name: Mathlib already proves it, as
@@ -99,8 +103,11 @@ Finiteness is spelled `[Finite G]` wherever that suffices — the measure-theore
 equivalence `TauCeti.lpHaarProbEquivFun` — and `[Fintype G]` only where a sum over `Finset.univ`
 appears in the statement itself, since a `Fintype` instance recovered from `Finite` inside a proof
 would not be the one indexing that sum. The scalars and the exponent are weakened the same way:
-`TauCeti.lpHaarProbEquivFun` needs only `[NontriviallyNormedField 𝕜]` and an arbitrary `p` with
-`[Fact (1 ≤ p)]`, and `[RCLike 𝕜]` and `p = 2` appear from the inner-product statements on.
+`TauCeti.lpHaarProbEquivFun` needs only `[NontriviallyNormedField 𝕜]` and an arbitrary exponent —
+not even `[Fact (1 ≤ p)]`, since `MeasureTheory.MemLp.of_discrete` produces the class of a function
+at every exponent, whereas `ContinuousMap.toLp`, being a continuous linear map, needs a norm on
+`Lp` and hence that hypothesis — and `[RCLike 𝕜]` and `p = 2` appear from the inner-product
+statements on.
 Cardinalities are written `Nat.card G` throughout, matching the rest of the roadmap;
 `Nat.card_eq_fintype_card` converts.
 
@@ -108,9 +115,11 @@ Cardinalities are written `Nat.card G` throughout, matching the rest of the road
 found by instance search from `[DiscreteTopology G]`, `[Finite G]` and `[BorelSpace G]`, so no
 extra hypotheses are carried. Continuity of a representation is likewise automatic, by
 `continuous_of_discreteTopology`, and is asked of the caller only where the *statement* needs it:
-`matrixCoeffLp π hπ`, `characterLp π hπ` and `character π hπ` take the continuity proof as an
-argument, so a caller of the pairing lemmas has one in hand already, whereas the orthogonality
-relations are stated as bare sums `∑ g, ⟪π g v, w⟫ · …` and take no continuity argument at all.
+the two pairing lemmas are about the `L²` classes `matrixCoeffLp π hπ` and `characterLp π hπ`, which
+take the continuity proof as an argument, so a caller of them holds one already. The orthogonality
+relations ask for none: the Schur ones are stated as bare sums `∑ g, ⟪π g v, w⟫ · …`, and the
+character one uses Mathlib's `Representation.character`, which is by
+`TauCeti.ContRepresentation.coe_character` the function underlying `character π hπ`.
 
 The scalar in the averaged sums is real, not `𝕜`: the Bochner integral being specialized is an
 `ℝ`-integral, and `V` is not assumed to be an `ℝ`-`𝕜`-scalar tower. The conversion is confined to
@@ -280,7 +289,6 @@ section LpEquiv
 
 variable (G : Type*) [Group G] [Finite G] [TopologicalSpace G] [DiscreteTopology G]
   [MeasurableSpace G] [BorelSpace G] {𝕜 : Type*} [NontriviallyNormedField 𝕜] {p : ℝ≥0∞}
-  [Fact (1 ≤ p)]
 
 /-- **The `Lp` class of a continuous function on a finite discrete group is that function**, on the
 nose and not merely almost everywhere, because normalized Haar measure has full support
@@ -289,7 +297,8 @@ nose and not merely almost everywhere, because normalized Haar measure has full 
 This is not a `simp` lemma: `ContinuousMap.coe_toLp` already rewrites the left-hand side to
 `⇑(f.toAEEqFun (haarProb G))`, so tagging it is a `simpNF` error. The value-level `simp` form of
 the round trip through the equivalence below is `TauCeti.coeFn_lpHaarProbEquivFun_symm`. -/
-theorem coeFn_toLp_haarProb (f : C(G, 𝕜)) : ⇑(ContinuousMap.toLp p (haarProb G) 𝕜 f) = f :=
+theorem coeFn_toLp_haarProb [Fact (1 ≤ p)] (f : C(G, 𝕜)) :
+    ⇑(ContinuousMap.toLp p (haarProb G) 𝕜 f) = f :=
   eq_of_ae_eq_haarProb G (ContinuousMap.coeFn_toLp (𝕜 := 𝕜) (p := p) (haarProb G) f)
 
 variable (𝕜 p) in
@@ -297,19 +306,19 @@ variable (𝕜 p) in
 functions is a `𝕜`-linear equivalence `Lp 𝕜 p (haarProb G) ≃ₗ[𝕜] (G → 𝕜)`.
 
 It is injective because normalized Haar measure has full support (`TauCeti.eq_of_ae_eq_haarProb`),
-so an `Lp` class is pinned down by its values, and surjective because `G` is finite and discrete:
-*every* function on `G` is continuous, hence `p`-integrable against a probability measure, and
-`ContinuousMap.toLp` produces its class. Nothing depends on the exponent; at `p = 2`, together
-with `TauCeti.inner_Lp_haarProb_eq_inv_mul_sum`, which computes the inner product from exactly the
-values this equivalence reads off, it is the identification of `L²(G)` with `G → 𝕜` carrying the
-normalized Hermitian pairing. -/
+so an `Lp` class is pinned down by its values, and surjective because `G` is finite and the measure
+is finite: *every* function on `G` is then `p`-integrable, by `MeasureTheory.MemLp.of_discrete`, and
+`MeasureTheory.MemLp.toLp` produces its class. Nothing depends on the exponent, not even `1 ≤ p`; at
+`p = 2`, together with `TauCeti.inner_Lp_haarProb_eq_inv_mul_sum`, which computes the inner product
+from exactly the values this equivalence reads off, it is the identification of `L²(G)` with `G → 𝕜`
+carrying the normalized Hermitian pairing. -/
 noncomputable def lpHaarProbEquivFun : Lp 𝕜 p (haarProb G) ≃ₗ[𝕜] (G → 𝕜) where
   toFun f := f
   map_add' f g := eq_of_ae_eq_haarProb G (Lp.coeFn_add f g)
   map_smul' c f := eq_of_ae_eq_haarProb G (Lp.coeFn_smul c f)
-  invFun f := ContinuousMap.toLp p (haarProb G) 𝕜 ⟨f, continuous_of_discreteTopology⟩
-  left_inv f := Lp.ext (.of_eq (coeFn_toLp_haarProb G ⟨⇑f, continuous_of_discreteTopology⟩))
-  right_inv f := coeFn_toLp_haarProb G ⟨f, continuous_of_discreteTopology⟩
+  invFun f := MemLp.toLp f MemLp.of_discrete
+  left_inv _ := Lp.ext (MemLp.coeFn_toLp _)
+  right_inv f := eq_of_ae_eq_haarProb G (MemLp.coeFn_toLp (f := f) MemLp.of_discrete)
 
 /-- The equivalence `TauCeti.lpHaarProbEquivFun` reads off the values of an `Lp` class. -/
 @[simp]
@@ -321,16 +330,19 @@ theorem lpHaarProbEquivFun_apply (f : Lp 𝕜 p (haarProb G)) (x : G) :
 simp-normal form of the inverse: it is what makes the round trip through the equivalence reduce. -/
 @[simp]
 theorem coeFn_lpHaarProbEquivFun_symm (f : G → 𝕜) : ⇑((lpHaarProbEquivFun G 𝕜 p).symm f) = f :=
-  coeFn_toLp_haarProb G ⟨f, continuous_of_discreteTopology⟩
+  eq_of_ae_eq_haarProb G (MemLp.coeFn_toLp (f := f) MemLp.of_discrete)
 
 /-- The inverse of `TauCeti.lpHaarProbEquivFun` is `ContinuousMap.toLp`, every function on a
-discrete space being continuous. This is not a simp lemma:
-`TauCeti.coeFn_lpHaarProbEquivFun_symm` is the value-level form, and rewriting the inner term first
-would keep a round trip from reducing by `LinearEquiv.apply_symm_apply`. -/
-theorem lpHaarProbEquivFun_symm_apply (f : G → 𝕜) :
+discrete space being continuous; this is the identification for the exponents at which that map
+exists. It is not a simp lemma: `TauCeti.coeFn_lpHaarProbEquivFun_symm` is the value-level form, and
+rewriting the inner term first would keep a round trip from reducing by
+`LinearEquiv.apply_symm_apply`. -/
+theorem lpHaarProbEquivFun_symm_apply [Fact (1 ≤ p)] (f : G → 𝕜) :
     (lpHaarProbEquivFun G 𝕜 p).symm f =
       ContinuousMap.toLp p (haarProb G) 𝕜 ⟨f, continuous_of_discreteTopology⟩ :=
-  (rfl)
+  Lp.ext (.of_eq
+    ((coeFn_lpHaarProbEquivFun_symm G f).trans
+      (coeFn_toLp_haarProb G ⟨f, continuous_of_discreteTopology⟩).symm))
 
 end LpEquiv
 
@@ -459,6 +471,22 @@ theorem schur_orthogonality_self_sum (π : ContRepresentation 𝕜 G V)
       continuous_of_discreteTopology,
     schur_orthogonality_self π continuous_of_discreteTopology hunitary hirr]
 
+/-- **The first Schur orthogonality relation for a finite group, in an orthonormal basis.** If
+`πᵢⱼ(g) = ⟪π g eⱼ, eᵢ⟫`, then `|G|⁻¹ ∑ g, conj (πᵢⱼ g) * πₖₗ g = d⁻¹ δⱼₗ δᵢₖ`.
+
+This is `TauCeti.ContRepresentation.schur_orthogonality_basis` with the Haar integral replaced by
+the group average, and it is the form the matrix coefficients of a finite group present themselves
+in: the index order and the placement of the conjugation are the ones fixed there, Kronecker deltas
+being real. -/
+theorem schur_orthogonality_basis_sum (π : ContRepresentation 𝕜 G V)
+    (hunitary : IsUnitary π) (hirr : Representation.IsIrreducible π.toRepresentation)
+    {d : ℕ} (e : OrthonormalBasis (Fin d) 𝕜 V) (i j k l : Fin d) :
+    (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g (e j), e i⟫_𝕜 * ⟪π g (e l), e k⟫_𝕜 =
+      (d : 𝕜)⁻¹ * ((if j = l then (1 : 𝕜) else 0) * (if i = k then (1 : 𝕜) else 0)) := by
+  rw [← inner_matrixCoeffLp_eq_inv_mul_sum π continuous_of_discreteTopology π
+      continuous_of_discreteTopology,
+    schur_orthogonality_basis π continuous_of_discreteTopology hunitary hirr]
+
 end SchurSelf
 
 section SchurDistinct
@@ -556,25 +584,40 @@ variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSp
   [FiniteDimensional 𝕜 V]
   [NormedAddCommGroup W] [InnerProductSpace 𝕜 W] [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W]
   [FiniteDimensional 𝕜 W]
-  (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+  (π : ContRepresentation 𝕜 G V)
+
+omit [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W] in
+/-- **The off-diagonal branch of first (row) character orthogonality for a finite group**: for a
+*unitary* `π`, the group average of `conj χ_π · χ_ρ` vanishes when no nonzero continuous intertwiner
+`ρ → π` exists, which for a pair of irreducibles is Schur's lemma. Unitarity is asked of `π` alone,
+as in the compact source `TauCeti.ContRepresentation.character_orthonormal_distinct`. (The second
+orthogonality relation, the column sum over the irreducible characters, is a different statement and
+is not proved here.)
+
+The characters are written as Mathlib's `Representation.character` of the underlying
+representations, which is by `TauCeti.ContRepresentation.coe_character` the function underlying
+`character π hπ`; so no continuity proof is asked of the caller, the statement not mentioning
+one. -/
+theorem character_orthonormal_distinct_sum (ρ : ContRepresentation 𝕜 G W)
+    (hunitary : IsUnitary π)
+    (hdistinct : ∀ f : ContIntertwiningMap ρ π, f.toContinuousLinearMap = 0) :
+    (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) (π.toRepresentation.character g) *
+        ρ.toRepresentation.character g = 0 := by
+  rw [← coe_character π continuous_of_discreteTopology,
+    ← coe_character ρ continuous_of_discreteTopology,
+    ← inner_characterLp_eq_inv_mul_sum π continuous_of_discreteTopology ρ
+      continuous_of_discreteTopology,
+    character_orthonormal_distinct π continuous_of_discreteTopology ρ
+      continuous_of_discreteTopology hunitary hdistinct]
+
+variable (hπ : Continuous π)
 
 include hπ
 
-omit [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W] in
-/-- **Second character orthogonality for a finite group**: for a *unitary* `π`, the group average of
-`conj χ_π · χ_ρ` vanishes when no nonzero continuous intertwiner `ρ → π` exists, which for a pair of
-irreducibles is Schur's lemma. Unitarity is asked of `π` alone, as in the compact source
-`TauCeti.ContRepresentation.character_orthonormal_distinct`. -/
-theorem character_orthonormal_distinct_sum (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ)
-    (hunitary : IsUnitary π)
-    (hdistinct : ∀ f : ContIntertwiningMap ρ π, f.toContinuousLinearMap = 0) :
-    (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) (character π hπ g) * character ρ hρ g = 0 := by
-  rw [← inner_characterLp_eq_inv_mul_sum π hπ ρ hρ,
-    character_orthonormal_distinct π hπ ρ hρ hunitary hdistinct]
-
-/- **First character orthogonality for a finite group**, which is the diagonal half of Mathlib's
-`Representation.char_orthonormal`, in its `χ_π(g) · χ_π(g⁻¹)` spelling, obtained through the compact
-theory: `TauCeti.ContRepresentation.character_orthonormal_self` says the character of an irreducible
+/- **The diagonal branch of first (row) character orthogonality for a finite group**, which is the
+diagonal half of Mathlib's `Representation.char_orthonormal`, in its `χ_π(g) · χ_π(g⁻¹)` spelling,
+obtained through the compact theory:
+`TauCeti.ContRepresentation.character_orthonormal_self` says the character of an irreducible
 unitary representation is an `L²` unit vector, `inner_characterLp_eq_inv_mul_sum` turns that pairing
 into a group average, and unitarity turns the inverse into a conjugate by
 `TauCeti.ContRepresentation.character_apply_inv`.
@@ -610,8 +653,9 @@ example (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (hunitary : IsU
     (hirrρ : Representation.IsIrreducible ρ.toRepresentation)
     (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, character π hπ g * character ρ hρ g⁻¹ = 0 := by
-  rw [← character_orthonormal_distinct_sum ρ hρ π hπ hunitary
-    fun f ↦ by simp [eq_zero_of_isEmpty_equiv hirrπ hirrρ hne f]]
+  rw [← character_orthonormal_distinct_sum ρ π hunitary
+      fun f ↦ by simp [eq_zero_of_isEmpty_equiv hirrπ hirrρ hne f],
+    ← coe_character ρ hρ, ← coe_character π hπ]
   exact congrArg _ (Finset.sum_congr rfl fun g _ ↦ by
     rw [character_apply_inv ρ hρ hunitary, mul_comm])
 

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -88,9 +88,11 @@ inequivalent irreducibles, by the vanishing half of Schur's lemma.
 
 ## Implementation notes
 
-Finiteness is spelled `[Finite G]` for the measure-theoretic statements and `[Fintype G]` only from
-`TauCeti.integral_haarProb` on, where a sum over `Finset.univ` appears in the statement itself and a
-`Fintype` instance recovered from `Finite` inside a proof would not be the one indexing that sum.
+Finiteness is spelled `[Finite G]` wherever that suffices — the measure-theoretic statements and the
+equivalence `TauCeti.lpEquivFun` — and `[Fintype G]` only where a sum over `Finset.univ` appears in
+the statement itself, since a `Fintype` instance recovered from `Finite` inside a proof would not be
+the one indexing that sum. The scalars are weakened the same way: `TauCeti.lpEquivFun` needs only
+`[NontriviallyNormedField 𝕜]`, and `[RCLike 𝕜]` appears from the inner-product statements on.
 Cardinalities are written `Nat.card G` throughout, matching the rest of the roadmap;
 `Nat.card_eq_fintype_card` converts.
 
@@ -253,10 +255,10 @@ theorem eq_of_ae_eq_haarProb {α : Type*} [TopologicalSpace α] [T2Space α] {f 
 
 end FullSupport
 
-section InnerProduct
+section LpEquiv
 
-variable (G : Type*) [Group G] [Fintype G] [TopologicalSpace G] [DiscreteTopology G]
-  [MeasurableSpace G] [BorelSpace G] {𝕜 : Type*} [RCLike 𝕜]
+variable (G : Type*) [Group G] [Finite G] [TopologicalSpace G] [DiscreteTopology G]
+  [MeasurableSpace G] [BorelSpace G] {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 
 variable (𝕜) in
 /-- **`L²` of a finite discrete group is the space of all functions on it**: taking underlying
@@ -285,10 +287,18 @@ theorem lpEquivFun_apply (f : Lp 𝕜 2 (haarProb G)) (x : G) : lpEquivFun G �
 
 /-- The inverse of `TauCeti.lpEquivFun` is `ContinuousMap.toLp`, every function on a discrete space
 being continuous. -/
+@[simp]
 theorem lpEquivFun_symm_apply (f : G → 𝕜) :
     (lpEquivFun G 𝕜).symm f =
       ContinuousMap.toLp 2 (haarProb G) 𝕜 ⟨f, continuous_of_discreteTopology⟩ :=
   (rfl)
+
+end LpEquiv
+
+section InnerProduct
+
+variable (G : Type*) [Group G] [Fintype G] [TopologicalSpace G] [DiscreteTopology G]
+  [MeasurableSpace G] [BorelSpace G] {𝕜 : Type*} [RCLike 𝕜]
 
 /-- **The `L²` inner product of a finite discrete group is the normalized Hermitian pairing**
 `|G|⁻¹ ∑ x, conj (f x) * g x`.

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -119,7 +119,9 @@ the two pairing lemmas are about the `L²` classes `matrixCoeffLp π hπ` and `c
 take the continuity proof as an argument, so a caller of them holds one already. The orthogonality
 relations ask for none: the Schur ones are stated as bare sums `∑ g, ⟪π g v, w⟫ · …`, and the
 character one uses Mathlib's `Representation.character`, which is by
-`TauCeti.ContRepresentation.coe_character` the function underlying `character π hπ`.
+`TauCeti.ContRepresentation.coe_character` the function underlying `character π hπ`. Those
+statements mention no measure either, so they ask for no measurable structure on `G`: their proofs
+install `borel G` themselves, and the caller is left with a bare finite discrete group.
 
 The scalar in the averaged sums is real, not `𝕜`: the Bochner integral being specialized is an
 `ℝ`-integral, and `V` is not assumed to be an `ℝ`-`𝕜`-scalar tower. The conversion is confined to
@@ -450,7 +452,7 @@ end MatrixCoefficient
 section SchurSelf
 
 variable {𝕜 G V : Type*} [RCLike 𝕜] [IsAlgClosed 𝕜] [Group G] [Fintype G] [TopologicalSpace G]
-  [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
+  [DiscreteTopology G]
   [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
   [FiniteDimensional 𝕜 V]
 
@@ -460,13 +462,17 @@ representation of dimension `d`,
 
 This is `TauCeti.ContRepresentation.schur_orthogonality_self` with the Haar integral of the
 compact theory replaced by the group average; the normalization `|G|⁻¹` is exactly the one that
-makes normalized Haar measure a probability measure. No continuity of `π` is asked: the statement
-does not mention it, and on a discrete group `continuous_of_discreteTopology` supplies it. -/
+makes normalized Haar measure a probability measure. Neither continuity of `π` nor a measurable
+structure on `G` is asked: the statement mentions no measure and no continuity proof, and the proof
+installs the Borel structure it integrates against, `continuous_of_discreteTopology` supplying the
+continuity. -/
 theorem schur_orthogonality_self_sum (π : ContRepresentation 𝕜 G V)
     (hunitary : IsUnitary π) (hirr : Representation.IsIrreducible π.toRepresentation)
     (v₁ w₁ v₂ w₂ : V) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v₁, w₁⟫_𝕜 * ⟪π g v₂, w₂⟫_𝕜 =
       (Module.finrank 𝕜 V : 𝕜)⁻¹ * ((starRingEnd 𝕜) ⟪v₁, v₂⟫_𝕜 * ⟪w₁, w₂⟫_𝕜) := by
+  let _ : MeasurableSpace G := borel G
+  have _ : BorelSpace G := ⟨rfl⟩
   rw [← inner_matrixCoeffLp_eq_inv_mul_sum π continuous_of_discreteTopology π
       continuous_of_discreteTopology,
     schur_orthogonality_self π continuous_of_discreteTopology hunitary hirr]
@@ -483,6 +489,8 @@ theorem schur_orthogonality_basis_sum (π : ContRepresentation 𝕜 G V)
     {d : ℕ} (e : OrthonormalBasis (Fin d) 𝕜 V) (i j k l : Fin d) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g (e j), e i⟫_𝕜 * ⟪π g (e l), e k⟫_𝕜 =
       (d : 𝕜)⁻¹ * ((if j = l then (1 : 𝕜) else 0) * (if i = k then (1 : 𝕜) else 0)) := by
+  let _ : MeasurableSpace G := borel G
+  have _ : BorelSpace G := ⟨rfl⟩
   rw [← inner_matrixCoeffLp_eq_inv_mul_sum π continuous_of_discreteTopology π
       continuous_of_discreteTopology,
     schur_orthogonality_basis π continuous_of_discreteTopology hunitary hirr]
@@ -492,7 +500,7 @@ end SchurSelf
 section SchurDistinct
 
 variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSpace G]
-  [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
+  [DiscreteTopology G]
   [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [FiniteDimensional 𝕜 V]
   [NormedAddCommGroup W] [InnerProductSpace 𝕜 W] [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W]
   [CompleteSpace W]
@@ -510,6 +518,8 @@ theorem schur_orthogonality_distinct_sum (π : ContRepresentation 𝕜 G V)
     (hdistinct : ∀ f : ContIntertwiningMap π ρ, f.toContinuousLinearMap = 0)
     (v w : V) (v' w' : W) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v, w⟫_𝕜 * ⟪ρ g v', w'⟫_𝕜 = 0 := by
+  let _ : MeasurableSpace G := borel G
+  have _ : BorelSpace G := ⟨rfl⟩
   rw [← inner_matrixCoeffLp_eq_inv_mul_sum π continuous_of_discreteTopology ρ
       continuous_of_discreteTopology,
     schur_orthogonality_distinct π continuous_of_discreteTopology ρ
@@ -526,6 +536,8 @@ theorem schur_orthogonality_sum (π : ContRepresentation 𝕜 G V)
     (hirrρ : Representation.IsIrreducible ρ.toRepresentation)
     (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) (v w : V) (v' w' : W) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) ⟪π g v, w⟫_𝕜 * ⟪ρ g v', w'⟫_𝕜 = 0 := by
+  let _ : MeasurableSpace G := borel G
+  have _ : BorelSpace G := ⟨rfl⟩
   rw [← inner_matrixCoeffLp_eq_inv_mul_sum π continuous_of_discreteTopology ρ
       continuous_of_discreteTopology,
     schur_orthogonality π continuous_of_discreteTopology ρ continuous_of_discreteTopology
@@ -579,7 +591,7 @@ end Character
 section CharacterOrthogonality
 
 variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSpace G]
-  [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
+  [DiscreteTopology G]
   [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
   [FiniteDimensional 𝕜 V]
   [NormedAddCommGroup W] [InnerProductSpace 𝕜 W] [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W]
@@ -596,13 +608,15 @@ is not proved here.)
 
 The characters are written as Mathlib's `Representation.character` of the underlying
 representations, which is by `TauCeti.ContRepresentation.coe_character` the function underlying
-`character π hπ`; so no continuity proof is asked of the caller, the statement not mentioning
-one. -/
+`character π hπ`; so no continuity proof is asked of the caller, and no measurable structure on `G`
+either, the statement mentioning neither. -/
 theorem character_orthonormal_distinct_sum (ρ : ContRepresentation 𝕜 G W)
     (hunitary : IsUnitary π)
     (hdistinct : ∀ f : ContIntertwiningMap ρ π, f.toContinuousLinearMap = 0) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, (starRingEnd 𝕜) (π.toRepresentation.character g) *
         ρ.toRepresentation.character g = 0 := by
+  let _ : MeasurableSpace G := borel G
+  have _ : BorelSpace G := ⟨rfl⟩
   rw [← coe_character π continuous_of_discreteTopology,
     ← coe_character ρ continuous_of_discreteTopology,
     ← inner_characterLp_eq_inv_mul_sum π continuous_of_discreteTopology ρ
@@ -630,6 +644,8 @@ exhibited is that the compact-group normalization agrees with the finite-group o
 example [IsAlgClosed 𝕜] (hunitary : IsUnitary π)
     (hirr : Representation.IsIrreducible π.toRepresentation) :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, character π hπ g * character π hπ g⁻¹ = 1 := by
+  let _ : MeasurableSpace G := borel G
+  have _ : BorelSpace G := ⟨rfl⟩
   rw [← character_orthonormal_self π hπ hunitary hirr, inner_characterLp_eq_inv_mul_sum π hπ π hπ]
   exact congrArg _ (Finset.sum_congr rfl fun g _ ↦ by
     rw [character_apply_inv π hπ hunitary, mul_comm])

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -65,8 +65,6 @@ measure computation has just identified.
 * `ContRepresentation.schur_orthogonality_self_sum` and
   `ContRepresentation.schur_orthogonality_sum`: **the two Schur orthogonality relations as finite
   averages** of matrix coefficients.
-* `ContRepresentation.card_inv_mul_sum_character_mul_eq_finrank_contIntertwiningMap`: **the finite
-  character sum counts the intertwiners**, in Mathlib's `χ_π(g⁻¹) · χ_ρ(g)` shape.
 * `ContRepresentation.character_orthonormal_self_sum` and
   `ContRepresentation.character_orthonormal_distinct_sum`: **the two character orthogonality
   relations as finite averages**.
@@ -74,8 +72,12 @@ measure computation has just identified.
 The counting identity `|G|⁻¹ ∑ g, χ_π g = dim V^G` that the compact-group character integral
 generalizes then costs one rewrite. It is not given a name: Mathlib already proves it, as
 `Representation.card_inv_mul_sum_char_eq_finrank`, and that lemma closes the `ContRepresentation`
-statement outright, so only the route through the compact theory is new. The route is exhibited by
-an anonymous `example`, as is the agreement of `character_orthonormal_self_sum` with the diagonal
+statement outright, so only the route through the compact theory is new. The intertwiner count
+`|G|⁻¹ ∑ g, χ_π(g⁻¹) · χ_ρ(g) = dim Hom_G(V, W)` is unnamed for the same reason: Mathlib proves it
+as `Representation.card_inv_mul_sum_char_mul_char_eq_finrank`, for the algebraic intertwiner space
+`Representation.IntertwiningMap`, which in finite dimensions is the continuous one because every
+linear map out of a finite-dimensional normed space is continuous. Both routes are exhibited by
+anonymous `example`s, as is the agreement of `character_orthonormal_self_sum` with the diagonal
 half of Mathlib's `Representation.char_orthonormal`.
 
 ## Implementation notes
@@ -417,15 +419,19 @@ theorem inner_characterLp_eq_inv_mul_sum :
   rw [characterLp_def, characterLp_def, inner_toLp_eq_inv_mul_sum]
 
 omit [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V] in
-/-- **The finite character sum counts the intertwiners**:
-`|G|⁻¹ ∑ g, χ_π(g⁻¹) · χ_ρ(g) = dim Hom_G(V, W)`.
+/- **The finite character sum counts the intertwiners**:
+`|G|⁻¹ ∑ g, χ_π(g⁻¹) · χ_ρ(g) = dim Hom_G(V, W)`, the specialization of
+`ContRepresentation.integral_character_mul_eq_finrank_contIntertwiningMap` to a finite discrete
+group. No unitarity is needed: the inverse in the first factor is what the compact statement
+carries, and only for a unitary representation does it become a complex conjugate.
 
-This is `ContRepresentation.integral_character_mul_eq_finrank_contIntertwiningMap` specialized to a
-finite discrete group, and it is exactly the shape of Mathlib's
-`Representation.card_inv_mul_sum_char_mul_char_eq_finrank`. No unitarity is needed: the inverse in
-the first factor is what the compact statement carries, and only for a unitary representation does
-it become a complex conjugate. -/
-theorem card_inv_mul_sum_character_mul_eq_finrank_contIntertwiningMap :
+No name is claimed, for the same reason as in the counting identity above: Mathlib proves this
+identity as `Representation.card_inv_mul_sum_char_mul_char_eq_finrank`, stated for the algebraic
+intertwiner space `Representation.IntertwiningMap π.toRepresentation ρ.toRepresentation`, which in
+finite dimensions is the continuous one. What the compact theory contributes is the derivation
+below, in which the count is the Haar integral read off by
+`TauCeti.integral_haarProb_eq_inv_mul_sum`. -/
+example :
     (Nat.card G : 𝕜)⁻¹ * ∑ g, character π hπ g⁻¹ * character ρ hρ g
       = (Module.finrank 𝕜 (ContIntertwiningMap π ρ) : 𝕜) := by
   rw [← integral_character_mul_eq_finrank_contIntertwiningMap π ρ hπ hρ,


### PR DESCRIPTION
This PR carries the compact-group `L²` theory down to a finite group, delivering the part of the "Finite groups recover [../CharacterTheory]" worked example that `TauCeti/RepresentationTheory/Compact/Finite.lean` explicitly left open. That file's own docstring recorded the gap — "The remaining specializations the roadmap item asks for — the `L²` theory, Maschke, Schur and character orthonormality, and Peter-Weyl — are not treated here" — and the roadmap item is the first bullet of "Worked examples (acceptance criteria)" in `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`: "`L²(G)` is `G → ℂ` with the Hermitian pairing, ... `schur_orthogonality_self` **specializes to** `char_orthonormal`, `character_orthonormal_self` to the first orthogonality relation", with the acceptance criterion that each general theorem reduces to the finite-group statement without new hypotheses. Everything lands in the existing `Compact/Finite.lean`, whose gap sentence had to be rewritten anyway; the two specializations that remain — Maschke and Peter-Weyl — are named in the new version of that sentence.

The spine is that normalized Haar measure has full support on a discrete space. `TauCeti.ae_haarProb_eq_top` says its almost-everywhere filter is `⊤`, every singleton having mass `|G|⁻¹ ≠ 0`, and `TauCeti.eq_of_ae_eq_haarProb` reads that as: two functions on a finite discrete group agreeing almost everywhere agree everywhere, with nothing asked of the codomain. This is the precise sense in which a class in `L²(G)` *is* a function on `G`. `TauCeti.lpHaarProbEquivFun` packages it as a linear equivalence `Lp 𝕜 p (haarProb G) ≃ₗ[𝕜] (G → 𝕜)` — the identification the roadmap's acceptance criterion asks for, stated for every exponent since nothing in it uses one; its injectivity is that full support, and its surjectivity is finiteness, since every function on a finite discrete group is continuous and `ContinuousMap.toLp` then supplies its class. `TauCeti.coeFn_toLp_haarProb` names the everywhere-equality of that class with the function it came from, and `TauCeti.coeFn_lpHaarProbEquivFun_symm` is the `@[simp]` value-level form of the inverse. At `p = 2`, `TauCeti.inner_Lp_haarProb_eq_inv_mul_sum` computes the `L²` inner product as `|G|⁻¹ ∑ x, conj (f x) * g x` — the file's existing `TauCeti.integral_haarProb_eq_inv_mul_sum` supplies the group average — and `TauCeti.inner_toLp_haarProb_eq_inv_mul_sum` is the form for two continuous functions, which is how matrix coefficients and characters present themselves.

Rewriting the compact statements along that identity is then mechanical, and gives the classical relations. `ContRepresentation.inner_matrixCoeffLp_eq_inv_mul_sum` turns the `L²` pairing of two matrix coefficients into a group average; `ContRepresentation.schur_orthogonality_self_sum` and `ContRepresentation.schur_orthogonality_distinct_sum` are the two Schur orthogonality relations in that form, the second at the vanishing-intertwiner hypothesis of the compact `schur_orthogonality_distinct`, with `ContRepresentation.schur_orthogonality_sum` its irreducible-pair case; `ContRepresentation.inner_characterLp_eq_inv_mul_sum` does the same for characters, and `ContRepresentation.character_orthonormal_distinct_sum` is the second character orthogonality relation. The naming convention is stated in the module docstring: each specialization keeps the name of the compact statement it specializes and adds the suffix `_sum`, recording that the Haar integral has become a group average.

Nothing here duplicates Mathlib, and no name is claimed where Mathlib already has one: that the compact normalization agrees with the finite-group one is exhibited by two anonymous `example`s covering both branches of Mathlib's `Representation.char_orthonormal`. The diagonal one derives `|G|⁻¹ ∑ g, χ_π(g) · χ_π(g⁻¹) = 1` from the compact `character_orthonormal_self` through `inner_characterLp_eq_inv_mul_sum` and `ContRepresentation.character_apply_inv`; it is left unnamed because Mathlib's `Representation.char_orthonormal` and TauCeti's `ClassFunction.characterPairing_ofCharacter_self` already prove that identity, in the inverse spelling and without unitarity (round 1 of review blocked on `reuse` for the named version; this is the fix). The off-diagonal one comes from `character_orthonormal_distinct_sum`, whose intertwiner hypothesis is discharged for a pair of inequivalent irreducibles by the vanishing half of Schur's lemma (`ContRepresentation.eq_zero_of_isEmpty_equiv`), just as `orthonormal_characterLp` discharges it in the compact theory. The intertwiner count `|G|⁻¹ ∑ g, χ_π(g⁻¹) · χ_ρ(g) = dim Hom_G(V, W)` is exhibited the same way, as a third anonymous `example`: Mathlib names that identity, as `Representation.card_inv_mul_sum_char_mul_char_eq_finrank` for the algebraic intertwiner space `Representation.IntertwiningMap`, which in finite dimensions is the continuous one, so only the route through the compact theory is new. This matches the file's existing convention for the invariants count. The declarations live in the root `ContRepresentation` namespace, as the rest of this file already does, rather than in `TauCeti.ContRepresentation`, so that no new `lint-dot-notation` findings are introduced. No Mathlib infrastructure was vendored; `MeasureTheory.ae_eq_top`, `MeasureTheory.L2.inner_def` and `ContinuousMap.coeFn_toLp` are consumed as they stand. `lake build`, `lake exe axioms`, `scripts/lint-env.sh`, `scripts/lint-style.sh` and `scripts/lint-dot-notation.py` all pass locally.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"finite-groups-recover-character-theory"}-->

🤖 Prepared with Claude Code
