### PR TITLE
feat: the Garnir relations

### DIFF
--- a/TauCeti/Algebra/GroupAction/FixingSubgroup.lean
+++ b/TauCeti/Algebra/GroupAction/FixingSubgroup.lean
@@ -32,17 +32,11 @@ theorem fixingSubgroup_univ {G α : Type*} [Group G] [MulAction G α] [FaithfulS
   exact FaithfulSMul.eq_of_smul_eq_smul fun x =>
     (hg x (Set.mem_univ x)).trans (one_smul G x).symm
 
-/-- A permutation fixes the complement of a finite set `X` pointwise exactly when it moves no
-point outside `X`. -/
-theorem mem_fixingSubgroup_compl_coe_iff {α : Type*} {X : Finset α} {σ : Equiv.Perm α} :
-    σ ∈ _root_.fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ) ↔ ∀ k ∉ X, σ k = k := by
-  simp [_root_.mem_fixingSubgroup_iff]
-
 /-- The transposition of two points of `X` fixes the complement of `X` pointwise. -/
 theorem swap_mem_fixingSubgroup_compl_coe {α : Type*} [DecidableEq α] {X : Finset α} {x y : α}
     (hx : x ∈ X) (hy : y ∈ X) :
     Equiv.swap x y ∈ _root_.fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ) :=
-  mem_fixingSubgroup_compl_coe_iff.mpr fun _ hk =>
+  (_root_.mem_fixingSubgroup_iff _).mpr fun _ hk =>
     Equiv.swap_apply_of_ne_of_ne (fun h => hk (h ▸ hx)) fun h => hk (h ▸ hy)
 
 end TauCeti

--- a/TauCeti/Algebra/GroupAction/FixingSubgroup.lean
+++ b/TauCeti/Algebra/GroupAction/FixingSubgroup.lean
@@ -5,12 +5,17 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.Group.Action.End
+public import Mathlib.Data.Finset.Basic
 public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
+public import Mathlib.Logic.Equiv.Basic
 
 /-!
 # Pointwise fixing subgroups
 
-This file records small generic additions to Mathlib's `fixingSubgroup` API.
+This file records small generic additions to Mathlib's `fixingSubgroup` API, including the
+permutations of a type that fix everything outside a finite set: the subgroup they form is the
+one the signed sums of the Garnir relations range over.
 -/
 
 public section
@@ -26,5 +31,18 @@ theorem fixingSubgroup_univ {G α : Type*} [Group G] [MulAction G α] [FaithfulS
   refine ⟨fun hg => ?_, fun hg x _ => by rw [hg, one_smul]⟩
   exact FaithfulSMul.eq_of_smul_eq_smul fun x =>
     (hg x (Set.mem_univ x)).trans (one_smul G x).symm
+
+/-- A permutation fixes the complement of a finite set `X` pointwise exactly when it moves no
+point outside `X`. -/
+theorem mem_fixingSubgroup_compl_coe_iff {α : Type*} {X : Finset α} {σ : Equiv.Perm α} :
+    σ ∈ _root_.fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ) ↔ ∀ k ∉ X, σ k = k := by
+  simp [_root_.mem_fixingSubgroup_iff]
+
+/-- The transposition of two points of `X` fixes the complement of `X` pointwise. -/
+theorem swap_mem_fixingSubgroup_compl_coe {α : Type*} [DecidableEq α] {X : Finset α} {x y : α}
+    (hx : x ∈ X) (hy : y ∈ X) :
+    Equiv.swap x y ∈ _root_.fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ) :=
+  mem_fixingSubgroup_compl_coe_iff.mpr fun _ hk =>
+    Equiv.swap_apply_of_ne_of_ne (fun h => hk (h ▸ hx)) fun h => hk (h ▸ hy)
 
 end TauCeti

--- a/TauCeti/Algebra/GroupAction/FixingSubgroup.lean
+++ b/TauCeti/Algebra/GroupAction/FixingSubgroup.lean
@@ -5,17 +5,12 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Group.Action.End
-public import Mathlib.Data.Finset.Basic
 public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
-public import Mathlib.Logic.Equiv.Basic
 
 /-!
 # Pointwise fixing subgroups
 
-This file records small generic additions to Mathlib's `fixingSubgroup` API, including the
-permutations of a type that fix everything outside a finite set: the subgroup they form is the
-one the signed sums of the Garnir relations range over.
+This file records small generic additions to Mathlib's `fixingSubgroup` API.
 -/
 
 public section
@@ -31,12 +26,5 @@ theorem fixingSubgroup_univ {G α : Type*} [Group G] [MulAction G α] [FaithfulS
   refine ⟨fun hg => ?_, fun hg x _ => by rw [hg, one_smul]⟩
   exact FaithfulSMul.eq_of_smul_eq_smul fun x =>
     (hg x (Set.mem_univ x)).trans (one_smul G x).symm
-
-/-- The transposition of two points of `X` fixes the complement of `X` pointwise. -/
-theorem swap_mem_fixingSubgroup_compl_coe {α : Type*} [DecidableEq α] {X : Finset α} {x y : α}
-    (hx : x ∈ X) (hy : y ∈ X) :
-    Equiv.swap x y ∈ _root_.fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ) :=
-  (_root_.mem_fixingSubgroup_iff _).mpr fun _ hk =>
-    Equiv.swap_apply_of_ne_of_ne (fun h => hk (h ▸ hx)) fun h => hk (h ▸ hy)
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/SubgroupCharSum.lean
+++ b/TauCeti/RepresentationTheory/SubgroupCharSum.lean
@@ -20,14 +20,14 @@ Expanding it is immediate from the definition: it acts as the `χ`-weighted sum 
 mechanism behind every antisymmetrizer argument: if some `p ∈ H` has `χ(p⁻¹) = -1`, the sum
 absorbs `p` at the cost of a sign, so its value on a vector `p` fixes is its own negative, and
 doubling being injective forces that value to be zero
-(`TauCeti.asAlgebraHom_subgroupCharSum_eq_zero`).  Injective doubling is the hypothesis of
+(`TauCeti.asAlgebraHom_subgroupCharSum_apply_eq_zero`).  Injective doubling is the hypothesis of
 `Representation.asAlgebraHom_eq_zero_of_mul_single_eq_neg`, taken as an assumption rather than
 read off the scalars, so no invertibility of `2` in `k` is needed.
 
 ## Main results
 
 * `TauCeti.asAlgebraHom_subgroupCharSum_apply`: the character sum acts as `∑_{h ∈ H} χ(h) ρ(h)`;
-* `TauCeti.asAlgebraHom_subgroupCharSum_eq_zero`: the character sum annihilates every vector
+* `TauCeti.asAlgebraHom_subgroupCharSum_apply_eq_zero`: the character sum annihilates every vector
   fixed by an element of `H` whose inverse has character `-1`.
 -/
 
@@ -59,7 +59,7 @@ variable {k G V : Type*} [CommRing k] [Group G] [AddCommGroup V] [Module k V]
 /-- **A character sum annihilates whatever an element of character `-1` fixes.**  Right
 multiplication by `p ∈ H` rescales the sum by `χ(p⁻¹) = -1`, so the value of the sum on a vector
 fixed by `p` is its own negative; with doubling injective it vanishes. -/
-theorem asAlgebraHom_subgroupCharSum_eq_zero
+theorem asAlgebraHom_subgroupCharSum_apply_eq_zero
     (h2inj : Function.Injective fun w : V => (2 : ℕ) • w) (ρ : Representation k G V) {p : G}
     (hp : p ∈ H) (hχ : χ p⁻¹ = -1) {v : V} (hfix : ρ p v = v) :
     ρ.asAlgebraHom (subgroupCharSum χ H) v = 0 :=

--- a/TauCeti/RepresentationTheory/SubgroupCharSum.lean
+++ b/TauCeti/RepresentationTheory/SubgroupCharSum.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.MonoidAlgebra.SubgroupCharSum
+public import TauCeti.RepresentationTheory.AsAlgebraHom
+
+/-!
+# Character sums over a subgroup as operators
+
+The character sum `∑_{h ∈ H} χ(h) h` of `TauCeti.subgroupCharSum` lives in the group algebra
+`k[G]`, so it acts on any representation of `G` through `Representation.asAlgebraHom`.  This file
+records the two facts every computation with that operator starts from.
+
+Expanding it is immediate from the definition: it acts as the `χ`-weighted sum of the operators
+`ρ h` over `h ∈ H` (`TauCeti.asAlgebraHom_subgroupCharSum_apply`).  Its vanishing is the
+mechanism behind every antisymmetrizer argument: if some `p ∈ H` has `χ(p⁻¹) = -1`, the sum
+absorbs `p` at the cost of a sign, so its value on a vector `p` fixes is its own negative, and
+doubling being injective forces that value to be zero
+(`TauCeti.asAlgebraHom_subgroupCharSum_eq_zero`).  Injective doubling is the hypothesis of
+`Representation.asAlgebraHom_eq_zero_of_mul_single_eq_neg`, taken as an assumption rather than
+read off the scalars, so no invertibility of `2` in `k` is needed.
+
+## Main results
+
+* `TauCeti.asAlgebraHom_subgroupCharSum_apply`: the character sum acts as `∑_{h ∈ H} χ(h) ρ(h)`;
+* `TauCeti.asAlgebraHom_subgroupCharSum_eq_zero`: the character sum annihilates every vector
+  fixed by an element of `H` whose inverse has character `-1`.
+-/
+
+public section
+
+namespace TauCeti
+
+section Semiring
+
+variable {k G V : Type*} [CommSemiring k] [Group G] [AddCommMonoid V] [Module k V]
+  (χ : G →* k) (H : Subgroup G) [Fintype H]
+
+/-- The character sum of `χ` over `H`, acting on a representation, is the `χ`-weighted sum of the
+actions of the elements of `H`. -/
+theorem asAlgebraHom_subgroupCharSum_apply (ρ : Representation k G V) (v : V) :
+    ρ.asAlgebraHom (subgroupCharSum χ H) v = ∑ h : H, χ (h : G) • ρ (h : G) v := by
+  rw [subgroupCharSum_def, map_sum, LinearMap.sum_apply]
+  exact Finset.sum_congr rfl fun h _ => by
+    rw [map_smul, LinearMap.smul_apply, MonoidAlgebra.of_apply,
+      Representation.asAlgebraHom_single_one]
+
+end Semiring
+
+section Ring
+
+variable {k G V : Type*} [CommRing k] [Group G] [AddCommGroup V] [Module k V]
+  (χ : G →* k) (H : Subgroup G) [Fintype H]
+
+/-- **A character sum annihilates whatever an element of character `-1` fixes.**  Right
+multiplication by `p ∈ H` rescales the sum by `χ(p⁻¹) = -1`, so the value of the sum on a vector
+fixed by `p` is its own negative; with doubling injective it vanishes. -/
+theorem asAlgebraHom_subgroupCharSum_eq_zero
+    (h2inj : Function.Injective fun w : V => (2 : ℕ) • w) (ρ : Representation k G V) {p : G}
+    (hp : p ∈ H) (hχ : χ p⁻¹ = -1) {v : V} (hfix : ρ p v = v) :
+    ρ.asAlgebraHom (subgroupCharSum χ H) v = 0 :=
+  Representation.asAlgebraHom_eq_zero_of_mul_single_eq_neg h2inj ρ hfix
+    (by rw [subgroupCharSum_mul_single χ H ⟨p, hp⟩, hχ, neg_one_smul])
+
+end Ring
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -107,6 +107,12 @@ theorem dominates_of_forall_swap_smul_ne {lam : YoungDiagram} (t : YoungTableau 
 
 /-! ## The column antisymmetrizer acting on a tabloid -/
 
+/-- Classical decidability of membership in the column group, used to form its finite sum, as in
+`TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean`. -/
+noncomputable local instance {lam : YoungDiagram} (t : YoungTableau lam) :
+    DecidablePred (· ∈ colSubgroup t) :=
+  Classical.decPred _
+
 /-- **The column antisymmetrizer kills a tabloid fixed by an odd column permutation.**  The
 antisymmetrizer absorbs such a permutation up to its sign, which is `-1`, while the tabloid is
 left alone, so the value is its own negative. -/
@@ -119,14 +125,11 @@ theorem asAlgebraHom_columnAntisymmetrizer_single_eq_zero {lam : YoungDiagram}
   have hfix' : (permutationModule μ).ρ p (MonoidAlgebra.single q (1 : ℚ)) =
       MonoidAlgebra.single q 1 := by
     rw [Representation.ofMulAction_single, hfix]
-  have hneg : columnAntisymmetrizer t * MonoidAlgebra.single p (1 : ℚ) =
-      -columnAntisymmetrizer t := by
-    rw [mul_columnAntisymmetrizer_right t ⟨p, hp⟩, hsign]
-    simp
   -- the permutation module is a `ℚ`-vector space, so doubling is injective on it
   have : IsAddTorsionFree (permutationModule μ) := .of_module_rat _
-  exact Representation.asAlgebraHom_eq_zero_of_mul_single_eq_neg
-    (nsmul_right_injective two_ne_zero) _ hfix' hneg
+  rw [columnAntisymmetrizer_eq_subgroupCharSum]
+  exact asAlgebraHom_subgroupCharSum_eq_zero _ _ (nsmul_right_injective two_ne_zero) _ hp
+    (by simp [hsign]) hfix'
 
 /-- **James's dominance lemma.**  If the column antisymmetrizer of a `lam`-tableau `t` does not
 annihilate the `μ`-tabloid `q`, then the shape of `t` dominates `μ`.

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -128,7 +128,7 @@ theorem asAlgebraHom_columnAntisymmetrizer_single_eq_zero {lam : YoungDiagram}
   -- the permutation module is a `ℚ`-vector space, so doubling is injective on it
   have : IsAddTorsionFree (permutationModule μ) := .of_module_rat _
   rw [columnAntisymmetrizer_eq_subgroupCharSum]
-  exact asAlgebraHom_subgroupCharSum_eq_zero _ _ (nsmul_right_injective two_ne_zero) _ hp
+  exact asAlgebraHom_subgroupCharSum_apply_eq_zero _ _ (nsmul_right_injective two_ne_zero) _ hp
     (by simp [hsign]) hfix'
 
 /-- **James's dominance lemma.**  If the column antisymmetrizer of a `lam`-tableau `t` does not

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
@@ -216,10 +216,13 @@ rows, and `(i, j + 1) ∈ μ` says the column reaches that far. -/
 private theorem card_filter_cells_col_succ {i j : ℕ} (h : (i, j + 1) ∈ μ) :
     {c ∈ μ.cells | c.2 = j + 1 ∧ c.1 ≤ i}.card = i + 1 := by
   have hlt : i < μ.colLen (j + 1) := YoungDiagram.mem_iff_lt_colLen.mp h
+  -- the counting lemma filters the first `i + 1` rows before the column, so its nested filter
+  -- has to be flattened into the single filter of the statement
+  have hflat : {c ∈ {c ∈ μ.cells | c.1 < i + 1} | c.2 = j + 1} =
+      {c ∈ μ.cells | c.2 = j + 1 ∧ c.1 ≤ i} := by
+    simp [Finset.filter_filter, and_comm]
   have hcard := YoungDiagram.card_filter_fst_lt_filter_snd_eq μ (i + 1) (j + 1)
-  rw [show {c ∈ {c ∈ μ.cells | c.1 < i + 1} | c.2 = j + 1} =
-      {c ∈ μ.cells | c.2 = j + 1 ∧ c.1 ≤ i} from by
-    simp [Finset.filter_filter, and_comm]] at hcard
+  rw [hflat] at hcard
   omega
 
 /-- **A Garnir set is one bigger than the column it straddles.**  Column `j` contributes its cells

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
@@ -90,7 +90,7 @@ open scoped BigOperators
 
 /-- Classical decidability of membership in the subgroup of permutations fixing everything outside
 a finite set, used to form its finite sum. -/
-noncomputable local instance {α : Type*} (X : Finset α) :
+noncomputable local instance decidablePredMemFixingSubgroupCompl {α : Type*} (X : Finset α) :
     DecidablePred (· ∈ fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ)) :=
   Classical.decPred _
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
@@ -5,8 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.GroupAction.FixingSubgroup
-public import TauCeti.RepresentationTheory.AsAlgebraHom
+public import TauCeti.Combinatorics.Young.Diagram
 public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
 
 /-!
@@ -18,7 +17,8 @@ straightening algorithm rewrites an arbitrary polytabloid with are the **Garnir 
 this file proves them.
 
 Write `A_X` for the signed sum `∑ sgn(σ) σ` over the permutations `σ` fixing every label outside a
-finite set `X` (`TauCeti.antisymmetrizerOn`).  The Garnir relation is
+finite set `X` (`TauCeti.antisymmetrizerOn`, defined with the other signed sums in
+`TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean`).  The Garnir relation is
 
 `A_X · e_t = 0`
 
@@ -26,14 +26,13 @@ whenever `X` is too large to be spread over the rows available to it: all the la
 columns of `μ` of length at most `r`, and `X` has more than `r` elements
 (`TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero`).  Applied to the
 polytabloid it reads as the vanishing of a signed sum of the polytabloids `e_{σt}`
-(`TauCeti.YoungTableau.sum_signChar_smul_polytabloid_relabel_eq_zero`).
+(`TauCeti.YoungTableau.sum_sign_smul_polytabloid_relabel_eq_zero`).
 
 Two facts drive the proof.
 
-* **A signed sum kills whatever an odd permutation in it fixes.**  If `σ ↦ sgn(σ) σ` is summed over
-  a subgroup containing a transposition `τ`, then reindexing by `τ` on the right turns the sum into
-  its own negative, so it annihilates every vector fixed by `τ`
-  (`TauCeti.asAlgebraHom_antisymmetrizerOn_apply_eq_zero`).
+* **A signed sum kills whatever an odd permutation in it fixes.**  Absorbing an odd permutation
+  supported in `X` turns `A_X` into its own negative, so `A_X` annihilates every vector that
+  permutation fixes (`TauCeti.asAlgebraHom_antisymmetrizerOn_apply_eq_zero`).
 * **Pigeonhole in the columns.**  A column permutation `q` of `t` moves a label only within its own
   column, so in the tabloid `q · {t}` the labels of `X` still lie in columns of length at most `r`,
   that is, in `r` rows.  As `X` has more than `r` elements, two of them share a row of `q · {t}`,
@@ -60,19 +59,15 @@ relation is proved, and stated, for the whole of `A_X`.
 
 ## Main definitions
 
-* `TauCeti.antisymmetrizerOn`: the signed sum `∑ sgn(σ) σ` over the permutations supported in a
-  finite set.
 * `TauCeti.YoungTableau.garnirSet`: the Garnir set of a tableau at a row and a column.
 
 ## Main results
 
-* `TauCeti.asAlgebraHom_antisymmetrizerOn_apply_eq_zero`: the signed sum annihilates a vector fixed
-  by a transposition of two of its points.
 * `TauCeti.YoungTableau.exists_ne_rowIndex_relabel_eq`: the pigeonhole step, two labels of an
   oversized set share a row after any column permutation.
 * `TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero`: **the Garnir
   relation**.
-* `TauCeti.YoungTableau.sum_signChar_smul_polytabloid_relabel_eq_zero`: the relation as the
+* `TauCeti.YoungTableau.sum_sign_smul_polytabloid_relabel_eq_zero`: the relation as the
   vanishing of a signed sum of polytabloids.
 * `TauCeti.YoungTableau.card_garnirSet`: a Garnir set has one more element than the column it
   straddles has cells.
@@ -92,91 +87,6 @@ public section
 namespace TauCeti
 
 open scoped BigOperators
-
-/-- Classical decidability of membership in the subgroup of permutations fixing everything outside
-a finite set, used to form its finite sum. -/
-noncomputable local instance decidablePredMemFixingSubgroupCompl {α : Type*} (X : Finset α) :
-    DecidablePred (· ∈ fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ)) :=
-  Classical.decPred _
-
-/-! ## The signed sum over the permutations supported in a set -/
-
-section Antisymmetrizer
-
-variable {α : Type*} [DecidableEq α] [Fintype α]
-
-/-- The **antisymmetrizer** of a finite set `X` of points: the signed sum `∑ sgn(σ) σ`, in the
-rational group algebra of `Equiv.Perm α`, over the permutations `σ` fixing every point outside `X`.
-
-For `X` the labels lying in one column of a Young tableau this is the factor of that tableau's
-column antisymmetrizer belonging to that column; the relations it satisfies on the polytabloids of
-a tableau are the Garnir relations. -/
-noncomputable def antisymmetrizerOn (X : Finset α) : MonoidAlgebra ℚ (Equiv.Perm α) :=
-  subgroupCharSum YoungTableau.signChar
-    (fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ))
-
-theorem antisymmetrizerOn_def (X : Finset α) :
-    antisymmetrizerOn X =
-      subgroupCharSum YoungTableau.signChar
-        (fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ)) :=
-  (rfl)
-
-/-- The coefficient of a permutation in `TauCeti.antisymmetrizerOn X` is its sign if it is
-supported in `X`, and zero otherwise. -/
-@[simp]
-theorem antisymmetrizerOn_coeff (X : Finset α) (σ : Equiv.Perm α) :
-    (antisymmetrizerOn X).coeff σ =
-      if ∀ k ∉ X, σ k = k then ((Equiv.Perm.sign σ : ℤ) : ℚ) else 0 := by
-  classical
-  rw [antisymmetrizerOn_def, subgroupCharSum_coeff]
-  simp [mem_fixingSubgroup_iff]
-
-/-- The permutations summed over by `TauCeti.antisymmetrizerOn X`, as a `Finset`. -/
-private theorem mem_filter_forall_notMem_iff (X : Finset α)
-    [DecidablePred fun σ : Equiv.Perm α => ∀ k ∉ X, σ k = k] (σ : Equiv.Perm α) :
-    σ ∈ ({σ : Equiv.Perm α | ∀ k ∉ X, σ k = k} : Finset (Equiv.Perm α)) ↔
-      σ ∈ fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ) := by
-  simp [mem_fixingSubgroup_iff]
-
-/-- The antisymmetrizer of a set, acting on a representation of the symmetric group, is the signed
-sum of the actions of the permutations fixing everything outside that set.
-
-The decidability of the summation range is an instance argument rather than a synthesized one, so
-that the equation rewrites a sum however its own filter was built. -/
-theorem asAlgebraHom_antisymmetrizerOn_apply {M : Type*} [AddCommGroup M] [Module ℚ M]
-    (V : Representation ℚ (Equiv.Perm α) M) (X : Finset α)
-    [DecidablePred fun σ : Equiv.Perm α => ∀ k ∉ X, σ k = k] (v : M) :
-    V.asAlgebraHom (antisymmetrizerOn X) v =
-      ∑ σ ∈ {σ : Equiv.Perm α | ∀ k ∉ X, σ k = k}, YoungTableau.signChar σ • V σ v := by
-  rw [Finset.sum_subtype _ (mem_filter_forall_notMem_iff X)
-      (fun σ => YoungTableau.signChar σ • V σ v),
-    antisymmetrizerOn_def, subgroupCharSum_def, map_sum, LinearMap.sum_apply]
-  exact Finset.sum_congr rfl fun σ _ => by
-    rw [map_smul, LinearMap.smul_apply, MonoidAlgebra.of_apply,
-      Representation.asAlgebraHom_single_one]
-
-/-- Right multiplication by the transposition of two points of `X` negates the antisymmetrizer of
-`X`, since the antisymmetrizer absorbs it up to its sign. -/
-theorem antisymmetrizerOn_mul_single_swap {X : Finset α} {x y : α} (hx : x ∈ X) (hy : y ∈ X)
-    (hxy : x ≠ y) :
-    antisymmetrizerOn X * MonoidAlgebra.single (Equiv.swap x y) (1 : ℚ) = -antisymmetrizerOn X := by
-  rw [antisymmetrizerOn_def,
-    subgroupCharSum_mul_single _ _ ⟨Equiv.swap x y, swap_mem_fixingSubgroup_compl_coe hx hy⟩,
-    Equiv.swap_inv, YoungTableau.signChar_apply, Equiv.Perm.sign_swap hxy]
-  simp
-
-/-- **A signed sum annihilates whatever an odd permutation in it fixes.**  If two distinct points
-of `X` are swapped by a transposition fixing `v`, then the antisymmetrizer of `X` kills `v`:
-absorbing that transposition negates the sum while leaving `v` alone. -/
-theorem asAlgebraHom_antisymmetrizerOn_apply_eq_zero {M : Type*} [AddCommGroup M] [Module ℚ M]
-    (V : Representation ℚ (Equiv.Perm α) M) {X : Finset α} {x y : α} (hx : x ∈ X) (hy : y ∈ X)
-    (hxy : x ≠ y) {v : M} (hv : V (Equiv.swap x y) v = v) :
-    V.asAlgebraHom (antisymmetrizerOn X) v = 0 :=
-  have : IsAddTorsionFree M := .of_module_rat _
-  Representation.asAlgebraHom_eq_zero_of_mul_single_eq_neg
-    (nsmul_right_injective two_ne_zero) _ hv (antisymmetrizerOn_mul_single_swap hx hy hxy)
-
-end Antisymmetrizer
 
 namespace YoungTableau
 
@@ -212,7 +122,9 @@ private theorem asAlgebraHom_antisymmetrizerOn_single_smul_tabloid_eq_zero (t : 
     (permutationModule (shapePartition μ)).ρ.asAlgebraHom (antisymmetrizerOn X)
         (MonoidAlgebra.single (q • tabloid t) (1 : ℚ)) = 0 := by
   obtain ⟨x, hx, y, hy, hxy, hrow⟩ := exists_ne_rowIndex_relabel_eq t hX hcard hq
-  refine asAlgebraHom_antisymmetrizerOn_apply_eq_zero _ hx hy hxy ?_
+  refine asAlgebraHom_antisymmetrizerOn_apply_eq_zero _
+    (fun k hk => Equiv.swap_apply_of_ne_of_ne (fun h => hk (h ▸ hx)) fun h => hk (h ▸ hy))
+    (Equiv.Perm.sign_swap hxy) ?_
   rw [Representation.ofMulAction_single, ← tabloid_relabel]
   exact congrArg (MonoidAlgebra.single · (1 : ℚ))
     (smul_tabloid_eq_self_iff.mpr (swap_mem_rowSubgroup hrow))
@@ -236,11 +148,12 @@ theorem asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero (t : YoungTableau μ)
 /-- **The Garnir relation, as a signed sum of polytabloids.**  Under the hypotheses of
 `TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero`, the signed sum of the
 polytabloids of the relabelings `σt`, over the permutations `σ` supported in `X`, vanishes. -/
-theorem sum_signChar_smul_polytabloid_relabel_eq_zero (t : YoungTableau μ)
+theorem sum_sign_smul_polytabloid_relabel_eq_zero (t : YoungTableau μ)
     {X : Finset (Fin μ.card)} {r : ℕ} (hX : ∀ k ∈ X, μ.colLen (colIndex t k) ≤ r)
-    (hcard : r < X.card) :
+    (hcard : r < X.card)
+    [DecidablePred fun σ : Equiv.Perm (Fin μ.card) => ∀ k ∉ X, σ k = k] :
     ∑ σ ∈ {σ : Equiv.Perm (Fin μ.card) | ∀ k ∉ X, σ k = k},
-        signChar σ • polytabloid (relabel σ t) = 0 := by
+        ((Equiv.Perm.sign σ : ℤ) : ℚ) • polytabloid (relabel σ t) = 0 := by
   rw [← asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero t hX hcard,
     asAlgebraHom_antisymmetrizerOn_apply]
   simp only [polytabloid_relabel]
@@ -265,8 +178,8 @@ theorem mem_garnirSet {t : YoungTableau μ} {i j : ℕ} {k : Fin μ.card} :
 
 /-- Every label of a Garnir set at column `j` lies in a column with at most as many cells as column
 `j` has, since columns of a Young diagram shorten to the right. -/
-theorem colLen_colIndex_le_of_mem_garnirSet {t : YoungTableau μ} {i j : ℕ} {k : Fin μ.card}
-    (hk : k ∈ garnirSet t i j) : μ.colLen (colIndex t k) ≤ μ.colLen j := by
+theorem colLen_colIndex_le_colLen_of_mem_garnirSet {t : YoungTableau μ} {i j : ℕ}
+    {k : Fin μ.card} (hk : k ∈ garnirSet t i j) : μ.colLen (colIndex t k) ≤ μ.colLen j := by
   rcases mem_garnirSet.mp hk with ⟨hcol, -⟩ | ⟨hcol, -⟩
   · rw [hcol]
   · rw [hcol]
@@ -285,31 +198,29 @@ private theorem image_rowIndex_colIndex_garnirSet (t : YoungTableau μ) (i j : �
   · rintro ⟨hmem, hc⟩
     refine ⟨t ⟨c, hmem⟩, ?_, ?_⟩ <;> simp [hc]
 
-/-- The cells of column `j` from row `i` down. -/
-private theorem filter_cells_col (i j : ℕ) :
-    {c ∈ μ.cells | c.2 = j ∧ i ≤ c.1} = (Finset.Ico i (μ.colLen j)).image (fun a => (a, j)) := by
-  ext ⟨a, b⟩
-  simp only [Finset.mem_filter, Finset.mem_image, Finset.mem_Ico, Prod.mk.injEq,
-    YoungDiagram.mem_cells]
-  constructor
-  · rintro ⟨hmem, rfl, hi⟩
-    exact ⟨a, ⟨hi, YoungDiagram.mem_iff_lt_colLen.mp hmem⟩, rfl, rfl⟩
-  · rintro ⟨a', ⟨hi, ha⟩, rfl, rfl⟩
-    exact ⟨YoungDiagram.mem_iff_lt_colLen.mpr ha, rfl, hi⟩
+/-- The cells of column `j` from row `i` down are those of the whole column that the first `i`
+rows leave over. -/
+private theorem card_filter_cells_col (i j : ℕ) :
+    {c ∈ μ.cells | c.2 = j ∧ i ≤ c.1}.card = μ.colLen j - i := by
+  have htop : {c ∈ μ.col j | c.1 < i} = {c ∈ {c ∈ μ.cells | c.1 < i} | c.2 = j} := by
+    simp [YoungDiagram.col, Finset.filter_filter, and_comm]
+  have hbot : {c ∈ μ.col j | ¬ c.1 < i} = {c ∈ μ.cells | c.2 = j ∧ i ≤ c.1} := by
+    simp [YoungDiagram.col, Finset.filter_filter]
+  have hsplit := Finset.card_filter_add_card_filter_not (s := μ.col j)
+    (p := fun c : ℕ × ℕ => c.1 < i)
+  rw [htop, hbot, YoungDiagram.card_filter_fst_lt_filter_snd_eq, ← μ.colLen_eq_card] at hsplit
+  omega
 
-/-- The cells of column `j + 1` from row `i` up, when `(i, j + 1)` is a cell. -/
-private theorem filter_cells_col_succ {i j : ℕ} (h : (i, j + 1) ∈ μ) :
-    {c ∈ μ.cells | c.2 = j + 1 ∧ c.1 ≤ i} =
-      (Finset.range (i + 1)).image (fun a => (a, j + 1)) := by
+/-- The cells of column `j + 1` from row `i` up are those of that column in the first `i + 1`
+rows, and `(i, j + 1) ∈ μ` says the column reaches that far. -/
+private theorem card_filter_cells_col_succ {i j : ℕ} (h : (i, j + 1) ∈ μ) :
+    {c ∈ μ.cells | c.2 = j + 1 ∧ c.1 ≤ i}.card = i + 1 := by
   have hlt : i < μ.colLen (j + 1) := YoungDiagram.mem_iff_lt_colLen.mp h
-  ext ⟨a, b⟩
-  simp only [Finset.mem_filter, Finset.mem_image, Finset.mem_range, Prod.mk.injEq,
-    YoungDiagram.mem_cells]
-  constructor
-  · rintro ⟨-, rfl, hi⟩
-    exact ⟨a, by omega, rfl, rfl⟩
-  · rintro ⟨a', ha, rfl, rfl⟩
-    exact ⟨YoungDiagram.mem_iff_lt_colLen.mpr (by omega), rfl, by omega⟩
+  have hcard := YoungDiagram.card_filter_fst_lt_filter_snd_eq μ (i + 1) (j + 1)
+  rw [show {c ∈ {c ∈ μ.cells | c.1 < i + 1} | c.2 = j + 1} =
+      {c ∈ μ.cells | c.2 = j + 1 ∧ c.1 ≤ i} from by
+    simp [Finset.filter_filter, and_comm]] at hcard
+  omega
 
 /-- **A Garnir set is one bigger than the column it straddles.**  Column `j` contributes its cells
 from row `i` down and column `j + 1` its cells from row `i` up, and `(i, j + 1) ∈ μ` makes both
@@ -329,10 +240,8 @@ theorem card_garnirSet (t : YoungTableau μ) {i j : ℕ} (h : (i, j + 1) ∈ μ)
     rintro c h₁ h₂
     simp only [Finset.mem_filter] at h₁ h₂
     omega
-  rw [← hcard, Finset.filter_or, Finset.card_union_of_disjoint hdisj, filter_cells_col,
-    filter_cells_col_succ h, Finset.card_image_of_injective _ (Prod.mk_left_injective j),
-    Finset.card_image_of_injective _ (Prod.mk_left_injective (j + 1)), Nat.card_Ico,
-    Finset.card_range]
+  rw [← hcard, Finset.filter_or, Finset.card_union_of_disjoint hdisj, card_filter_cells_col,
+    card_filter_cells_col_succ h]
   omega
 
 /-- **The Garnir relation at a Garnir set.**  If `(i, j + 1)` is a cell of `μ`, the antisymmetrizer
@@ -342,7 +251,7 @@ theorem asAlgebraHom_antisymmetrizerOn_garnirSet_eq_zero (t : YoungTableau μ) {
     (permutationModule (shapePartition μ)).ρ.asAlgebraHom (antisymmetrizerOn (garnirSet t i j))
         (polytabloid t) = 0 :=
   asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero t
-    (fun _ hk => colLen_colIndex_le_of_mem_garnirSet hk)
+    (fun _ hk => colLen_colIndex_le_colLen_of_mem_garnirSet hk)
     (by rw [card_garnirSet t h]; exact Nat.lt_succ_self _)
 
 end YoungTableau

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Combinatorics.Young.Diagram
 public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
 
 /-!
@@ -43,7 +42,8 @@ The sets `X` the relation is applied to are the **Garnir sets** `TauCeti.YoungTa
 j`: the labels of `t` in column `j` from row `i` downwards together with those in column `j + 1`
 from row `i` upwards.  As soon as `(i, j + 1)` is a cell of `μ` there are `μ.colLen j + 1` of them
 (`TauCeti.YoungTableau.card_garnirSet`) while they occupy only the `μ.colLen j` rows of column `j`,
-so the relation applies (`TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_garnirSet_eq_zero`).
+so the relation applies
+(`TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_garnirSet_polytabloid_eq_zero`).
 Those are the sets the straightening algorithm uses at a cell `(i, j)` where the rows of the
 tableau fail to increase.
 
@@ -71,8 +71,8 @@ relation is proved, and stated, for the whole of `A_X`.
   vanishing of a signed sum of polytabloids.
 * `TauCeti.YoungTableau.card_garnirSet`: a Garnir set has one more element than the column it
   straddles has cells.
-* `TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_garnirSet_eq_zero`: the Garnir relation at a
-  Garnir set.
+* `TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_garnirSet_polytabloid_eq_zero`: the Garnir
+  relation at a Garnir set.
 
 ## References
 
@@ -249,7 +249,7 @@ theorem card_garnirSet (t : YoungTableau μ) {i j : ℕ} (h : (i, j + 1) ∈ μ)
 
 /-- **The Garnir relation at a Garnir set.**  If `(i, j + 1)` is a cell of `μ`, the antisymmetrizer
 of the Garnir set of `t` at `(i, j)` annihilates the polytabloid of `t`. -/
-theorem asAlgebraHom_antisymmetrizerOn_garnirSet_eq_zero (t : YoungTableau μ) {i j : ℕ}
+theorem asAlgebraHom_antisymmetrizerOn_garnirSet_polytabloid_eq_zero (t : YoungTableau μ) {i j : ℕ}
     (h : (i, j + 1) ∈ μ) :
     (permutationModule (shapePartition μ)).ρ.asAlgebraHom (antisymmetrizerOn (garnirSet t i j))
         (polytabloid t) = 0 :=

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
@@ -13,9 +13,9 @@ public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
 # The Garnir relations
 
 The polytabloids `e_t` of the `μ`-tableaux span the Specht module `S^μ`, and the standard basis
-theorem says that the polytabloids of the *standard* tableaux already do.  The relations that
-rewrite an arbitrary polytabloid in terms of ones closer to standard are the **Garnir relations**,
-and this file proves them.
+theorem says that the polytabloids of the *standard* tableaux already do.  The relations that the
+straightening algorithm rewrites an arbitrary polytabloid with are the **Garnir relations**, and
+this file proves them.
 
 Write `A_X` for the signed sum `∑ sgn(σ) σ` over the permutations `σ` fixing every label outside a
 finite set `X` (`TauCeti.antisymmetrizerOn`).  The Garnir relation is
@@ -24,10 +24,9 @@ finite set `X` (`TauCeti.antisymmetrizerOn`).  The Garnir relation is
 
 whenever `X` is too large to be spread over the rows available to it: all the labels of `X` lie in
 columns of `μ` of length at most `r`, and `X` has more than `r` elements
-(`TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero`).  Since the identity
-contributes the term `e_t`, this expresses `e_t` as a combination of the polytabloids of the
-relabelings `σt`, `σ ≠ 1`
-(`TauCeti.YoungTableau.polytabloid_eq_neg_sum_signChar_smul_polytabloid_relabel`).
+(`TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero`).  Applied to the
+polytabloid it reads as the vanishing of a signed sum of the polytabloids `e_{σt}`
+(`TauCeti.YoungTableau.sum_signChar_smul_polytabloid_relabel_eq_zero`).
 
 Two facts drive the proof.
 
@@ -46,12 +45,18 @@ j`: the labels of `t` in column `j` from row `i` downwards together with those i
 from row `i` upwards.  As soon as `(i, j + 1)` is a cell of `μ` there are `μ.colLen j + 1` of them
 (`TauCeti.YoungTableau.card_garnirSet`) while they occupy only the `μ.colLen j` rows of column `j`,
 so the relation applies (`TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_garnirSet_eq_zero`).
-Those are the sets that straighten a tableau whose rows fail to increase across the cell `(i, j)`.
+Those are the sets the straightening algorithm uses at a cell `(i, j)` where the rows of the
+tableau fail to increase.
 
-The classical Garnir *element* of a Garnir set is a shorter signed sum, over a transversal of the
-permutations internal to the two halves of the set; multiplying it by the signed sum over those
-internal permutations recovers `A_X`.  That repackaging is not carried out here: the relation is
-proved, and stated, for the whole of `A_X`.
+The straightening step itself is *not* proved here, and the relation as stated does not supply it.
+The permutations `σ` supported in `X` that lie in the column group of `t` satisfy
+`e_{σt} = sgn(σ) e_t`, so their terms in the signed sum are further copies of `e_t` rather than of
+anything nearer to standard; simply isolating the identity term of the sum therefore rewrites `e_t`
+in terms of itself.  The classical Garnir *element* avoids this by summing only over a transversal
+of the permutations internal to the two halves of the set, so that `A_X` factors as the signed sum
+over those internal permutations times the Garnir element, and the identity coset contributes `e_t`
+alone.  That repackaging is left to the file that performs the straightening induction; here the
+relation is proved, and stated, for the whole of `A_X`.
 
 ## Main definitions
 
@@ -67,8 +72,8 @@ proved, and stated, for the whole of `A_X`.
   oversized set share a row after any column permutation.
 * `TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero`: **the Garnir
   relation**.
-* `TauCeti.YoungTableau.polytabloid_eq_neg_sum_signChar_smul_polytabloid_relabel`: the relation with
-  the identity term isolated, which is the form that straightens a polytabloid.
+* `TauCeti.YoungTableau.sum_signChar_smul_polytabloid_relabel_eq_zero`: the relation as the
+  vanishing of a signed sum of polytabloids.
 * `TauCeti.YoungTableau.card_garnirSet`: a Garnir set has one more element than the column it
   straddles has cells.
 * `TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_garnirSet_eq_zero`: the Garnir relation at a
@@ -239,25 +244,6 @@ theorem sum_signChar_smul_polytabloid_relabel_eq_zero (t : YoungTableau μ)
   rw [← asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero t hX hcard,
     asAlgebraHom_antisymmetrizerOn_apply]
   simp only [polytabloid_relabel]
-
-/-- **The Garnir relation, straightening a polytabloid.**  Isolating the identity term of
-`TauCeti.YoungTableau.sum_signChar_smul_polytabloid_relabel_eq_zero` writes `e_t` as a rational
-combination of the polytabloids of the relabelings `σt` by the nontrivial permutations `σ`
-supported in `X`. -/
-theorem polytabloid_eq_neg_sum_signChar_smul_polytabloid_relabel (t : YoungTableau μ)
-    {X : Finset (Fin μ.card)} {r : ℕ} (hX : ∀ k ∈ X, μ.colLen (colIndex t k) ≤ r)
-    (hcard : r < X.card) :
-    polytabloid t =
-      -∑ σ ∈ ({σ : Equiv.Perm (Fin μ.card) | ∀ k ∉ X, σ k = k} :
-          Finset (Equiv.Perm (Fin μ.card))).erase 1,
-        signChar σ • polytabloid (relabel σ t) := by
-  have hone : (1 : Equiv.Perm (Fin μ.card)) ∈
-      ({σ : Equiv.Perm (Fin μ.card) | ∀ k ∉ X, σ k = k} : Finset (Equiv.Perm (Fin μ.card))) := by
-    simp
-  have hsum := sum_signChar_smul_polytabloid_relabel_eq_zero t hX hcard
-  rw [← Finset.add_sum_erase _ _ hone] at hsum
-  rw [eq_neg_iff_add_eq_zero, ← hsum]
-  simp
 
 /-! ## Garnir sets -/
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
@@ -129,14 +129,14 @@ theorem antisymmetrizerOn_coeff (X : Finset α) (σ : Equiv.Perm α) :
       if ∀ k ∉ X, σ k = k then ((Equiv.Perm.sign σ : ℤ) : ℚ) else 0 := by
   classical
   rw [antisymmetrizerOn_def, subgroupCharSum_coeff]
-  simp [mem_fixingSubgroup_compl_coe_iff]
+  simp [mem_fixingSubgroup_iff]
 
 /-- The permutations summed over by `TauCeti.antisymmetrizerOn X`, as a `Finset`. -/
 private theorem mem_filter_forall_notMem_iff (X : Finset α)
     [DecidablePred fun σ : Equiv.Perm α => ∀ k ∉ X, σ k = k] (σ : Equiv.Perm α) :
     σ ∈ ({σ : Equiv.Perm α | ∀ k ∉ X, σ k = k} : Finset (Equiv.Perm α)) ↔
       σ ∈ fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ) := by
-  simp [mem_fixingSubgroup_compl_coe_iff]
+  simp [mem_fixingSubgroup_iff]
 
 /-- The antisymmetrizer of a set, acting on a representation of the symmetric group, is the signed
 sum of the actions of the permutations fixing everything outside that set.

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean
@@ -1,0 +1,364 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.GroupAction.FixingSubgroup
+public import TauCeti.RepresentationTheory.AsAlgebraHom
+public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
+
+/-!
+# The Garnir relations
+
+The polytabloids `e_t` of the `μ`-tableaux span the Specht module `S^μ`, and the standard basis
+theorem says that the polytabloids of the *standard* tableaux already do.  The relations that
+rewrite an arbitrary polytabloid in terms of ones closer to standard are the **Garnir relations**,
+and this file proves them.
+
+Write `A_X` for the signed sum `∑ sgn(σ) σ` over the permutations `σ` fixing every label outside a
+finite set `X` (`TauCeti.antisymmetrizerOn`).  The Garnir relation is
+
+`A_X · e_t = 0`
+
+whenever `X` is too large to be spread over the rows available to it: all the labels of `X` lie in
+columns of `μ` of length at most `r`, and `X` has more than `r` elements
+(`TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero`).  Since the identity
+contributes the term `e_t`, this expresses `e_t` as a combination of the polytabloids of the
+relabelings `σt`, `σ ≠ 1`
+(`TauCeti.YoungTableau.polytabloid_eq_neg_sum_signChar_smul_polytabloid_relabel`).
+
+Two facts drive the proof.
+
+* **A signed sum kills whatever an odd permutation in it fixes.**  If `σ ↦ sgn(σ) σ` is summed over
+  a subgroup containing a transposition `τ`, then reindexing by `τ` on the right turns the sum into
+  its own negative, so it annihilates every vector fixed by `τ`
+  (`TauCeti.asAlgebraHom_antisymmetrizerOn_apply_eq_zero`).
+* **Pigeonhole in the columns.**  A column permutation `q` of `t` moves a label only within its own
+  column, so in the tabloid `q · {t}` the labels of `X` still lie in columns of length at most `r`,
+  that is, in `r` rows.  As `X` has more than `r` elements, two of them share a row of `q · {t}`,
+  and the transposition swapping those two fixes that tabloid.  Every tabloid occurring in `e_t` is
+  of this form, so `A_X` kills them all.
+
+The sets `X` the relation is applied to are the **Garnir sets** `TauCeti.YoungTableau.garnirSet t i
+j`: the labels of `t` in column `j` from row `i` downwards together with those in column `j + 1`
+from row `i` upwards.  As soon as `(i, j + 1)` is a cell of `μ` there are `μ.colLen j + 1` of them
+(`TauCeti.YoungTableau.card_garnirSet`) while they occupy only the `μ.colLen j` rows of column `j`,
+so the relation applies (`TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_garnirSet_eq_zero`).
+Those are the sets that straighten a tableau whose rows fail to increase across the cell `(i, j)`.
+
+The classical Garnir *element* of a Garnir set is a shorter signed sum, over a transversal of the
+permutations internal to the two halves of the set; multiplying it by the signed sum over those
+internal permutations recovers `A_X`.  That repackaging is not carried out here: the relation is
+proved, and stated, for the whole of `A_X`.
+
+## Main definitions
+
+* `TauCeti.antisymmetrizerOn`: the signed sum `∑ sgn(σ) σ` over the permutations supported in a
+  finite set.
+* `TauCeti.YoungTableau.garnirSet`: the Garnir set of a tableau at a row and a column.
+
+## Main results
+
+* `TauCeti.asAlgebraHom_antisymmetrizerOn_apply_eq_zero`: the signed sum annihilates a vector fixed
+  by a transposition of two of its points.
+* `TauCeti.YoungTableau.exists_ne_rowIndex_relabel_eq`: the pigeonhole step, two labels of an
+  oversized set share a row after any column permutation.
+* `TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero`: **the Garnir
+  relation**.
+* `TauCeti.YoungTableau.polytabloid_eq_neg_sum_signChar_smul_polytabloid_relabel`: the relation with
+  the identity term isolated, which is the form that straightens a polytabloid.
+* `TauCeti.YoungTableau.card_garnirSet`: a Garnir set has one more element than the column it
+  straddles has cells.
+* `TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_garnirSet_eq_zero`: the Garnir relation at a
+  Garnir set.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Section 7.
+* [B. E. Sagan, *The Symmetric Group*][sagan2001], Section 2.6.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 5, whose standard basis of the Specht module these relations straighten towards.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+/-- Classical decidability of membership in the subgroup of permutations fixing everything outside
+a finite set, used to form its finite sum. -/
+noncomputable local instance {α : Type*} (X : Finset α) :
+    DecidablePred (· ∈ fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ)) :=
+  Classical.decPred _
+
+/-! ## The signed sum over the permutations supported in a set -/
+
+section Antisymmetrizer
+
+variable {α : Type*} [DecidableEq α] [Fintype α]
+
+/-- The **antisymmetrizer** of a finite set `X` of points: the signed sum `∑ sgn(σ) σ`, in the
+rational group algebra of `Equiv.Perm α`, over the permutations `σ` fixing every point outside `X`.
+
+For `X` the labels lying in one column of a Young tableau this is the factor of that tableau's
+column antisymmetrizer belonging to that column; the relations it satisfies on the polytabloids of
+a tableau are the Garnir relations. -/
+noncomputable def antisymmetrizerOn (X : Finset α) : MonoidAlgebra ℚ (Equiv.Perm α) :=
+  subgroupCharSum YoungTableau.signChar
+    (fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ))
+
+theorem antisymmetrizerOn_def (X : Finset α) :
+    antisymmetrizerOn X =
+      subgroupCharSum YoungTableau.signChar
+        (fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ)) :=
+  (rfl)
+
+/-- The coefficient of a permutation in `TauCeti.antisymmetrizerOn X` is its sign if it is
+supported in `X`, and zero otherwise. -/
+@[simp]
+theorem antisymmetrizerOn_coeff (X : Finset α) (σ : Equiv.Perm α) :
+    (antisymmetrizerOn X).coeff σ =
+      if ∀ k ∉ X, σ k = k then ((Equiv.Perm.sign σ : ℤ) : ℚ) else 0 := by
+  classical
+  rw [antisymmetrizerOn_def, subgroupCharSum_coeff]
+  simp [mem_fixingSubgroup_compl_coe_iff]
+
+/-- The permutations summed over by `TauCeti.antisymmetrizerOn X`, as a `Finset`. -/
+private theorem mem_filter_forall_notMem_iff (X : Finset α)
+    [DecidablePred fun σ : Equiv.Perm α => ∀ k ∉ X, σ k = k] (σ : Equiv.Perm α) :
+    σ ∈ ({σ : Equiv.Perm α | ∀ k ∉ X, σ k = k} : Finset (Equiv.Perm α)) ↔
+      σ ∈ fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ) := by
+  simp [mem_fixingSubgroup_compl_coe_iff]
+
+/-- The antisymmetrizer of a set, acting on a representation of the symmetric group, is the signed
+sum of the actions of the permutations fixing everything outside that set.
+
+The decidability of the summation range is an instance argument rather than a synthesized one, so
+that the equation rewrites a sum however its own filter was built. -/
+theorem asAlgebraHom_antisymmetrizerOn_apply {M : Type*} [AddCommGroup M] [Module ℚ M]
+    (V : Representation ℚ (Equiv.Perm α) M) (X : Finset α)
+    [DecidablePred fun σ : Equiv.Perm α => ∀ k ∉ X, σ k = k] (v : M) :
+    V.asAlgebraHom (antisymmetrizerOn X) v =
+      ∑ σ ∈ {σ : Equiv.Perm α | ∀ k ∉ X, σ k = k}, YoungTableau.signChar σ • V σ v := by
+  rw [Finset.sum_subtype _ (mem_filter_forall_notMem_iff X)
+      (fun σ => YoungTableau.signChar σ • V σ v),
+    antisymmetrizerOn_def, subgroupCharSum_def, map_sum, LinearMap.sum_apply]
+  exact Finset.sum_congr rfl fun σ _ => by
+    rw [map_smul, LinearMap.smul_apply, MonoidAlgebra.of_apply,
+      Representation.asAlgebraHom_single_one]
+
+/-- Right multiplication by the transposition of two points of `X` negates the antisymmetrizer of
+`X`, since the antisymmetrizer absorbs it up to its sign. -/
+theorem antisymmetrizerOn_mul_single_swap {X : Finset α} {x y : α} (hx : x ∈ X) (hy : y ∈ X)
+    (hxy : x ≠ y) :
+    antisymmetrizerOn X * MonoidAlgebra.single (Equiv.swap x y) (1 : ℚ) = -antisymmetrizerOn X := by
+  rw [antisymmetrizerOn_def,
+    subgroupCharSum_mul_single _ _ ⟨Equiv.swap x y, swap_mem_fixingSubgroup_compl_coe hx hy⟩,
+    Equiv.swap_inv, YoungTableau.signChar_apply, Equiv.Perm.sign_swap hxy]
+  simp
+
+/-- **A signed sum annihilates whatever an odd permutation in it fixes.**  If two distinct points
+of `X` are swapped by a transposition fixing `v`, then the antisymmetrizer of `X` kills `v`:
+absorbing that transposition negates the sum while leaving `v` alone. -/
+theorem asAlgebraHom_antisymmetrizerOn_apply_eq_zero {M : Type*} [AddCommGroup M] [Module ℚ M]
+    (V : Representation ℚ (Equiv.Perm α) M) {X : Finset α} {x y : α} (hx : x ∈ X) (hy : y ∈ X)
+    (hxy : x ≠ y) {v : M} (hv : V (Equiv.swap x y) v = v) :
+    V.asAlgebraHom (antisymmetrizerOn X) v = 0 :=
+  have : IsAddTorsionFree M := .of_module_rat _
+  Representation.asAlgebraHom_eq_zero_of_mul_single_eq_neg
+    (nsmul_right_injective two_ne_zero) _ hv (antisymmetrizerOn_mul_single_swap hx hy hxy)
+
+end Antisymmetrizer
+
+namespace YoungTableau
+
+variable {μ : YoungDiagram}
+
+/-! ## The Garnir relation -/
+
+/-- **Pigeonhole in the columns.**  Suppose every label of `X` lies in a column of `μ` with at most
+`r` cells, and `X` has more than `r` elements.  Then a column permutation `q` of `t` leaves two
+distinct labels of `X` in a common row of `qt`: it moves each of them only inside its own column,
+so all of them still lie in the top `r` rows. -/
+theorem exists_ne_rowIndex_relabel_eq (t : YoungTableau μ) {X : Finset (Fin μ.card)} {r : ℕ}
+    (hX : ∀ k ∈ X, μ.colLen (colIndex t k) ≤ r) (hcard : r < X.card)
+    {q : Equiv.Perm (Fin μ.card)} (hq : q ∈ colSubgroup t) :
+    ∃ x ∈ X, ∃ y ∈ X, x ≠ y ∧ rowIndex (relabel q t) x = rowIndex (relabel q t) y := by
+  have hmaps : ∀ k ∈ X, rowIndex (relabel q t) k ∈ Finset.range r := by
+    intro k hk
+    have hcol : colIndex t (q⁻¹ k) = colIndex t k := mem_colSubgroup.mp (inv_mem hq) k
+    have hmem : (rowIndex t (q⁻¹ k), colIndex t (q⁻¹ k)) ∈ μ := rowIndex_colIndex_mem t (q⁻¹ k)
+    have hlt : rowIndex t (q⁻¹ k) < μ.colLen (colIndex t (q⁻¹ k)) :=
+      YoungDiagram.mem_iff_lt_colLen.mp hmem
+    rw [Finset.mem_range, rowIndex_relabel]
+    calc rowIndex t (q⁻¹ k) < μ.colLen (colIndex t (q⁻¹ k)) := hlt
+      _ = μ.colLen (colIndex t k) := by rw [hcol]
+      _ ≤ r := hX k hk
+  exact Finset.exists_ne_map_eq_of_card_lt_of_maps_to (by simpa using hcard) hmaps
+
+/-- The antisymmetrizer of `X` annihilates every tabloid reachable from `{t}` by a column
+permutation of `t`, because two labels of `X` share a row of that tabloid. -/
+private theorem asAlgebraHom_antisymmetrizerOn_single_smul_tabloid_eq_zero (t : YoungTableau μ)
+    {X : Finset (Fin μ.card)} {r : ℕ} (hX : ∀ k ∈ X, μ.colLen (colIndex t k) ≤ r)
+    (hcard : r < X.card) {q : Equiv.Perm (Fin μ.card)} (hq : q ∈ colSubgroup t) :
+    (permutationModule (shapePartition μ)).ρ.asAlgebraHom (antisymmetrizerOn X)
+        (MonoidAlgebra.single (q • tabloid t) (1 : ℚ)) = 0 := by
+  obtain ⟨x, hx, y, hy, hxy, hrow⟩ := exists_ne_rowIndex_relabel_eq t hX hcard hq
+  refine asAlgebraHom_antisymmetrizerOn_apply_eq_zero _ hx hy hxy ?_
+  rw [Representation.ofMulAction_single, ← tabloid_relabel]
+  exact congrArg (MonoidAlgebra.single · (1 : ℚ))
+    (smul_tabloid_eq_self_iff.mpr (swap_mem_rowSubgroup hrow))
+
+/-- **The Garnir relation.**  If every label of the finite set `X` lies in a column of `μ` with at
+most `r` cells and `X` has more than `r` elements, then the antisymmetrizer of `X` annihilates the
+polytabloid of `t`.
+
+The labels of `X` cannot be spread over the rows of those columns, so every tabloid occurring in
+`e_t` has two of them in a common row and is killed by the signed sum. -/
+theorem asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero (t : YoungTableau μ)
+    {X : Finset (Fin μ.card)} {r : ℕ} (hX : ∀ k ∈ X, μ.colLen (colIndex t k) ≤ r)
+    (hcard : r < X.card) :
+    (permutationModule (shapePartition μ)).ρ.asAlgebraHom (antisymmetrizerOn X)
+        (polytabloid t) = 0 := by
+  rw [polytabloid_eq_sum, map_sum]
+  refine Finset.sum_eq_zero fun q _ => ?_
+  rw [map_smul, asAlgebraHom_antisymmetrizerOn_single_smul_tabloid_eq_zero t hX hcard q.2,
+    smul_zero]
+
+/-- **The Garnir relation, as a signed sum of polytabloids.**  Under the hypotheses of
+`TauCeti.YoungTableau.asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero`, the signed sum of the
+polytabloids of the relabelings `σt`, over the permutations `σ` supported in `X`, vanishes. -/
+theorem sum_signChar_smul_polytabloid_relabel_eq_zero (t : YoungTableau μ)
+    {X : Finset (Fin μ.card)} {r : ℕ} (hX : ∀ k ∈ X, μ.colLen (colIndex t k) ≤ r)
+    (hcard : r < X.card) :
+    ∑ σ ∈ {σ : Equiv.Perm (Fin μ.card) | ∀ k ∉ X, σ k = k},
+        signChar σ • polytabloid (relabel σ t) = 0 := by
+  rw [← asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero t hX hcard,
+    asAlgebraHom_antisymmetrizerOn_apply]
+  simp only [polytabloid_relabel]
+
+/-- **The Garnir relation, straightening a polytabloid.**  Isolating the identity term of
+`TauCeti.YoungTableau.sum_signChar_smul_polytabloid_relabel_eq_zero` writes `e_t` as a rational
+combination of the polytabloids of the relabelings `σt` by the nontrivial permutations `σ`
+supported in `X`. -/
+theorem polytabloid_eq_neg_sum_signChar_smul_polytabloid_relabel (t : YoungTableau μ)
+    {X : Finset (Fin μ.card)} {r : ℕ} (hX : ∀ k ∈ X, μ.colLen (colIndex t k) ≤ r)
+    (hcard : r < X.card) :
+    polytabloid t =
+      -∑ σ ∈ ({σ : Equiv.Perm (Fin μ.card) | ∀ k ∉ X, σ k = k} :
+          Finset (Equiv.Perm (Fin μ.card))).erase 1,
+        signChar σ • polytabloid (relabel σ t) := by
+  have hone : (1 : Equiv.Perm (Fin μ.card)) ∈
+      ({σ : Equiv.Perm (Fin μ.card) | ∀ k ∉ X, σ k = k} : Finset (Equiv.Perm (Fin μ.card))) := by
+    simp
+  have hsum := sum_signChar_smul_polytabloid_relabel_eq_zero t hX hcard
+  rw [← Finset.add_sum_erase _ _ hone] at hsum
+  rw [eq_neg_iff_add_eq_zero, ← hsum]
+  simp
+
+/-! ## Garnir sets -/
+
+/-- The **Garnir set** of a tableau `t` at row `i` and column `j`: the labels of `t` lying in
+column `j` from row `i` downwards, together with those lying in column `j + 1` from row `i`
+upwards.
+
+When `(i, j + 1)` is a cell of `μ` this set has one element more than column `j` has cells, while
+its labels stay in column `j` or `j + 1` under a column permutation of `t`; that is what makes the
+Garnir relation apply to it. -/
+def garnirSet (t : YoungTableau μ) (i j : ℕ) : Finset (Fin μ.card) :=
+  {k | (colIndex t k = j ∧ i ≤ rowIndex t k) ∨ (colIndex t k = j + 1 ∧ rowIndex t k ≤ i)}
+
+@[simp]
+theorem mem_garnirSet {t : YoungTableau μ} {i j : ℕ} {k : Fin μ.card} :
+    k ∈ garnirSet t i j ↔
+      (colIndex t k = j ∧ i ≤ rowIndex t k) ∨ (colIndex t k = j + 1 ∧ rowIndex t k ≤ i) := by
+  simp [garnirSet]
+
+/-- Every label of a Garnir set at column `j` lies in a column with at most as many cells as column
+`j` has, since columns of a Young diagram shorten to the right. -/
+theorem colLen_colIndex_le_of_mem_garnirSet {t : YoungTableau μ} {i j : ℕ} {k : Fin μ.card}
+    (hk : k ∈ garnirSet t i j) : μ.colLen (colIndex t k) ≤ μ.colLen j := by
+  rcases mem_garnirSet.mp hk with ⟨hcol, -⟩ | ⟨hcol, -⟩
+  · rw [hcol]
+  · rw [hcol]
+    exact μ.colLen_anti j (j + 1) (Nat.le_succ j)
+
+/-- The cells occupied by a Garnir set: those of column `j` from row `i` down, and those of column
+`j + 1` from row `i` up. -/
+private theorem image_rowIndex_colIndex_garnirSet (t : YoungTableau μ) (i j : ℕ) :
+    (garnirSet t i j).image (fun k => (rowIndex t k, colIndex t k)) =
+      {c ∈ μ.cells | (c.2 = j ∧ i ≤ c.1) ∨ (c.2 = j + 1 ∧ c.1 ≤ i)} := by
+  ext c
+  simp only [Finset.mem_image, mem_garnirSet, Finset.mem_filter]
+  constructor
+  · rintro ⟨k, hk, rfl⟩
+    exact ⟨rowIndex_colIndex_mem t k, hk⟩
+  · rintro ⟨hmem, hc⟩
+    refine ⟨t ⟨c, hmem⟩, ?_, ?_⟩ <;> simp [hc]
+
+/-- The cells of column `j` from row `i` down. -/
+private theorem filter_cells_col (i j : ℕ) :
+    {c ∈ μ.cells | c.2 = j ∧ i ≤ c.1} = (Finset.Ico i (μ.colLen j)).image (fun a => (a, j)) := by
+  ext ⟨a, b⟩
+  simp only [Finset.mem_filter, Finset.mem_image, Finset.mem_Ico, Prod.mk.injEq,
+    YoungDiagram.mem_cells]
+  constructor
+  · rintro ⟨hmem, rfl, hi⟩
+    exact ⟨a, ⟨hi, YoungDiagram.mem_iff_lt_colLen.mp hmem⟩, rfl, rfl⟩
+  · rintro ⟨a', ⟨hi, ha⟩, rfl, rfl⟩
+    exact ⟨YoungDiagram.mem_iff_lt_colLen.mpr ha, rfl, hi⟩
+
+/-- The cells of column `j + 1` from row `i` up, when `(i, j + 1)` is a cell. -/
+private theorem filter_cells_col_succ {i j : ℕ} (h : (i, j + 1) ∈ μ) :
+    {c ∈ μ.cells | c.2 = j + 1 ∧ c.1 ≤ i} =
+      (Finset.range (i + 1)).image (fun a => (a, j + 1)) := by
+  have hlt : i < μ.colLen (j + 1) := YoungDiagram.mem_iff_lt_colLen.mp h
+  ext ⟨a, b⟩
+  simp only [Finset.mem_filter, Finset.mem_image, Finset.mem_range, Prod.mk.injEq,
+    YoungDiagram.mem_cells]
+  constructor
+  · rintro ⟨-, rfl, hi⟩
+    exact ⟨a, by omega, rfl, rfl⟩
+  · rintro ⟨a', ha, rfl, rfl⟩
+    exact ⟨YoungDiagram.mem_iff_lt_colLen.mpr (by omega), rfl, by omega⟩
+
+/-- **A Garnir set is one bigger than the column it straddles.**  Column `j` contributes its cells
+from row `i` down and column `j + 1` its cells from row `i` up, and `(i, j + 1) ∈ μ` makes both
+counts available. -/
+theorem card_garnirSet (t : YoungTableau μ) {i j : ℕ} (h : (i, j + 1) ∈ μ) :
+    (garnirSet t i j).card = μ.colLen j + 1 := by
+  classical
+  have hij : (i, j) ∈ μ := μ.up_left_mem (le_refl i) (Nat.le_succ j) h
+  have hi : i < μ.colLen j := YoungDiagram.mem_iff_lt_colLen.mp hij
+  have hinj : Function.Injective fun k : Fin μ.card => (rowIndex t k, colIndex t k) :=
+    rowIndex_colIndex_injective t
+  have hcard := Finset.card_image_of_injective (garnirSet t i j) hinj
+  rw [image_rowIndex_colIndex_garnirSet] at hcard
+  have hdisj :
+      Disjoint {c ∈ μ.cells | c.2 = j ∧ i ≤ c.1} {c ∈ μ.cells | c.2 = j + 1 ∧ c.1 ≤ i} := by
+    rw [Finset.disjoint_left]
+    rintro c h₁ h₂
+    simp only [Finset.mem_filter] at h₁ h₂
+    omega
+  rw [← hcard, Finset.filter_or, Finset.card_union_of_disjoint hdisj, filter_cells_col,
+    filter_cells_col_succ h, Finset.card_image_of_injective _ (Prod.mk_left_injective j),
+    Finset.card_image_of_injective _ (Prod.mk_left_injective (j + 1)), Nat.card_Ico,
+    Finset.card_range]
+  omega
+
+/-- **The Garnir relation at a Garnir set.**  If `(i, j + 1)` is a cell of `μ`, the antisymmetrizer
+of the Garnir set of `t` at `(i, j)` annihilates the polytabloid of `t`. -/
+theorem asAlgebraHom_antisymmetrizerOn_garnirSet_eq_zero (t : YoungTableau μ) {i j : ℕ}
+    (h : (i, j + 1) ∈ μ) :
+    (permutationModule (shapePartition μ)).ρ.asAlgebraHom (antisymmetrizerOn (garnirSet t i j))
+        (polytabloid t) = 0 :=
+  asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero t
+    (fun _ hk => colLen_colIndex_le_of_mem_garnirSet hk)
+    (by rw [card_garnirSet t h]; exact Nat.lt_succ_self _)
+
+end YoungTableau
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -10,7 +10,6 @@ public import Mathlib.Algebra.Group.Subgroup.Finite
 public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
 public import Mathlib.GroupTheory.Perm.Sign
 public import Mathlib.RepresentationTheory.Basic
-public import TauCeti.Algebra.MonoidAlgebra.SubgroupCharSum
 public import TauCeti.RepresentationTheory.SubgroupCharSum
 public import TauCeti.RepresentationTheory.Symmetric.RowColumnSubgroup
 

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -7,9 +7,11 @@ module
 
 public import Mathlib.Algebra.MonoidAlgebra.Basic
 public import Mathlib.Algebra.Group.Subgroup.Finite
+public import Mathlib.GroupTheory.GroupAction.FixingSubgroup
 public import Mathlib.GroupTheory.Perm.Sign
 public import Mathlib.RepresentationTheory.Basic
 public import TauCeti.Algebra.MonoidAlgebra.SubgroupCharSum
+public import TauCeti.RepresentationTheory.SubgroupCharSum
 public import TauCeti.RepresentationTheory.Symmetric.RowColumnSubgroup
 
 /-!
@@ -36,6 +38,14 @@ same two degeneracies evaluate the transported symmetrizer `youngSymmetrizerOver
 full symmetrization `∑_σ σ` and the full antisymmetrization `∑_σ sgn(σ) σ` of the group algebra.
 Finally, `b_t` acting on an arbitrary representation is unfolded into the signed sum over the
 column group, which is how every downstream computation with the operator `b_t` begins.
+
+The file closes with a third signed sum at the sign character, `TauCeti.antisymmetrizerOn X`: the
+sum `∑ sgn(σ) σ` over the permutations of an arbitrary type fixing everything outside a finite set
+`X`.  It is `b_t` with the column group replaced by the pointwise fixing subgroup of the
+complement of `X`, so it shares the coefficient formula, the translation law and the vanishing
+criterion with `b_t`, and it is the element the Garnir relations of
+`TauCeti/RepresentationTheory/Symmetric/Specht/Garnir.lean` are stated for.  Nothing about it
+refers to a tableau, only to the sign character defined here.
 
 The symmetrizers are built over `ℚ`, which is what the essential-idempotence theorem and the
 Specht-module constructions downstream of this file work over.  The coefficients of `c_t` are in
@@ -315,10 +325,8 @@ theorem asAlgebraHom_columnAntisymmetrizer_apply {V : Type*} [AddCommGroup V] [M
     ρ.asAlgebraHom (columnAntisymmetrizer t) v =
       ∑ q : colSubgroup t,
         ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) • ρ q v := by
-  rw [columnAntisymmetrizer_def, map_sum, LinearMap.sum_apply]
-  refine Finset.sum_congr rfl fun q _ => ?_
-  rw [map_smul, MonoidAlgebra.of_apply, Representation.asAlgebraHom_single_one,
-    LinearMap.smul_apply]
+  rw [columnAntisymmetrizer_eq_subgroupCharSum, asAlgebraHom_subgroupCharSum_apply]
+  simp only [signChar_apply]
 
 section Transport
 
@@ -400,5 +408,112 @@ end TransportRing
 end
 
 end YoungTableau
+
+/-! ## The antisymmetrizer of a set of points
+
+The signed sum over the permutations supported in a finite set is the character sum of the sign
+character over the pointwise fixing subgroup of the complement.  Nothing below refers to a
+tableau, only to `TauCeti.YoungTableau.signChar`. -/
+
+section AntisymmetrizerOn
+
+variable {α : Type*} [DecidableEq α] [Fintype α]
+
+/-- Classical decidability of membership in the subgroup of permutations fixing everything outside
+a finite set, used to form its finite sum. -/
+noncomputable local instance decidablePredMemFixingSubgroupCompl (X : Finset α) :
+    DecidablePred (· ∈ fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ)) :=
+  Classical.decPred _
+
+/-- The **antisymmetrizer** of a finite set `X` of points: the signed sum `∑ sgn(σ) σ`, in the
+rational group algebra of `Equiv.Perm α`, over the permutations `σ` fixing every point outside `X`.
+
+For `X` the labels lying in one column of a Young tableau this is the factor of that tableau's
+column antisymmetrizer belonging to that column; the relations it satisfies on the polytabloids of
+a tableau are the Garnir relations. -/
+noncomputable def antisymmetrizerOn (X : Finset α) : MonoidAlgebra ℚ (Equiv.Perm α) :=
+  subgroupCharSum YoungTableau.signChar
+    (fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ))
+
+theorem antisymmetrizerOn_def (X : Finset α) :
+    antisymmetrizerOn X =
+      subgroupCharSum YoungTableau.signChar
+        (fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ)) :=
+  (rfl)
+
+omit [DecidableEq α] [Fintype α] in
+/-- A permutation fixing every point outside `X` belongs to the subgroup the antisymmetrizer of
+`X` is summed over. -/
+private theorem mem_fixingSubgroup_compl_of_forall_notMem {X : Finset α} {σ : Equiv.Perm α}
+    (hσ : ∀ k ∉ X, σ k = k) : σ ∈ fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ) :=
+  (mem_fixingSubgroup_iff _).mpr fun k hk => hσ k (by simpa using hk)
+
+/-- The coefficient of a permutation in `TauCeti.antisymmetrizerOn X` is its sign if it is
+supported in `X`, and zero otherwise. -/
+@[simp]
+theorem antisymmetrizerOn_coeff (X : Finset α) (σ : Equiv.Perm α) :
+    (antisymmetrizerOn X).coeff σ =
+      if ∀ k ∉ X, σ k = k then ((Equiv.Perm.sign σ : ℤ) : ℚ) else 0 := by
+  classical
+  rw [antisymmetrizerOn_def, subgroupCharSum_coeff]
+  simp [mem_fixingSubgroup_iff]
+
+/-- The permutations summed over by `TauCeti.antisymmetrizerOn X`, as a `Finset`. -/
+private theorem mem_filter_forall_notMem_iff (X : Finset α)
+    [DecidablePred fun σ : Equiv.Perm α => ∀ k ∉ X, σ k = k] (σ : Equiv.Perm α) :
+    σ ∈ ({σ : Equiv.Perm α | ∀ k ∉ X, σ k = k} : Finset (Equiv.Perm α)) ↔
+      σ ∈ fixingSubgroup (Equiv.Perm α) ((X : Set α)ᶜ) := by
+  simp [mem_fixingSubgroup_iff]
+
+/-- The antisymmetrizer of a set, acting on a representation of the symmetric group, is the signed
+sum of the actions of the permutations fixing everything outside that set.
+
+The decidability of the summation range is an instance argument rather than a synthesized one, so
+that the equation rewrites a sum however its own filter was built. -/
+theorem asAlgebraHom_antisymmetrizerOn_apply {M : Type*} [AddCommGroup M] [Module ℚ M]
+    (V : Representation ℚ (Equiv.Perm α) M) (X : Finset α)
+    [DecidablePred fun σ : Equiv.Perm α => ∀ k ∉ X, σ k = k] (v : M) :
+    V.asAlgebraHom (antisymmetrizerOn X) v =
+      ∑ σ ∈ {σ : Equiv.Perm α | ∀ k ∉ X, σ k = k},
+        ((Equiv.Perm.sign σ : ℤ) : ℚ) • V σ v := by
+  rw [antisymmetrizerOn_def, asAlgebraHom_subgroupCharSum_apply,
+    ← Finset.sum_subtype _ (mem_filter_forall_notMem_iff X)
+      (fun σ => YoungTableau.signChar σ • V σ v)]
+  simp only [YoungTableau.signChar_apply]
+
+/-- **Right multiplication by a permutation supported in `X` scales the antisymmetrizer of `X` by
+its sign**, since the antisymmetrizer absorbs it up to that sign. -/
+@[simp]
+theorem antisymmetrizerOn_mul_single {X : Finset α} {p : Equiv.Perm α} (hp : ∀ k ∉ X, p k = k) :
+    antisymmetrizerOn X * MonoidAlgebra.single p (1 : ℚ) =
+      ((Equiv.Perm.sign p : ℤ) : ℚ) • antisymmetrizerOn X := by
+  rw [antisymmetrizerOn_def,
+    subgroupCharSum_mul_single _ _ ⟨p, mem_fixingSubgroup_compl_of_forall_notMem hp⟩]
+  simp
+
+/-- Right multiplication by the transposition of two distinct points of `X` negates the
+antisymmetrizer of `X`, that transposition being odd. -/
+theorem antisymmetrizerOn_mul_single_swap_eq_neg {X : Finset α} {x y : α} (hx : x ∈ X)
+    (hy : y ∈ X) (hxy : x ≠ y) :
+    antisymmetrizerOn X * MonoidAlgebra.single (Equiv.swap x y) (1 : ℚ) = -antisymmetrizerOn X := by
+  rw [antisymmetrizerOn_mul_single fun k hk =>
+      Equiv.swap_apply_of_ne_of_ne (fun h => hk (h ▸ hx)) fun h => hk (h ▸ hy),
+    Equiv.Perm.sign_swap hxy]
+  simp
+
+/-- **A signed sum annihilates whatever an odd permutation in it fixes.**  If an odd permutation
+supported in `X` fixes `v`, then the antisymmetrizer of `X` kills `v`: absorbing that permutation
+negates the sum while leaving `v` alone. -/
+theorem asAlgebraHom_antisymmetrizerOn_apply_eq_zero {M : Type*} [AddCommGroup M] [Module ℚ M]
+    (V : Representation ℚ (Equiv.Perm α) M) {X : Finset α} {p : Equiv.Perm α}
+    (hp : ∀ k ∉ X, p k = k) (hsign : Equiv.Perm.sign p = -1) {v : M} (hv : V p v = v) :
+    V.asAlgebraHom (antisymmetrizerOn X) v = 0 := by
+  have : IsAddTorsionFree M := .of_module_rat _
+  rw [antisymmetrizerOn_def]
+  refine asAlgebraHom_subgroupCharSum_eq_zero _ _ (nsmul_right_injective two_ne_zero) V
+    (mem_fixingSubgroup_compl_of_forall_notMem hp) ?_ hv
+  simp [hsign]
+
+end AntisymmetrizerOn
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -491,16 +491,6 @@ theorem antisymmetrizerOn_mul_single {X : Finset α} {p : Equiv.Perm α} (hp : �
     subgroupCharSum_mul_single _ _ ⟨p, mem_fixingSubgroup_compl_of_forall_notMem hp⟩]
   simp
 
-/-- Right multiplication by the transposition of two distinct points of `X` negates the
-antisymmetrizer of `X`, that transposition being odd. -/
-theorem antisymmetrizerOn_mul_single_swap_eq_neg {X : Finset α} {x y : α} (hx : x ∈ X)
-    (hy : y ∈ X) (hxy : x ≠ y) :
-    antisymmetrizerOn X * MonoidAlgebra.single (Equiv.swap x y) (1 : ℚ) = -antisymmetrizerOn X := by
-  rw [antisymmetrizerOn_mul_single fun k hk =>
-      Equiv.swap_apply_of_ne_of_ne (fun h => hk (h ▸ hx)) fun h => hk (h ▸ hy),
-    Equiv.Perm.sign_swap hxy]
-  simp
-
 /-- **A signed sum annihilates whatever an odd permutation in it fixes.**  If an odd permutation
 supported in `X` fixes `v`, then the antisymmetrizer of `X` kills `v`: absorbing that permutation
 negates the sum while leaving `v` alone. -/
@@ -510,7 +500,7 @@ theorem asAlgebraHom_antisymmetrizerOn_apply_eq_zero {M : Type*} [AddCommGroup M
     V.asAlgebraHom (antisymmetrizerOn X) v = 0 := by
   have : IsAddTorsionFree M := .of_module_rat _
   rw [antisymmetrizerOn_def]
-  refine asAlgebraHom_subgroupCharSum_eq_zero _ _ (nsmul_right_injective two_ne_zero) V
+  refine asAlgebraHom_subgroupCharSum_apply_eq_zero _ _ (nsmul_right_injective two_ne_zero) V
     (mem_fixingSubgroup_compl_of_forall_notMem hp) ?_ hv
   simp [hsign]
 


### PR DESCRIPTION
This PR proves the **Garnir relations** for the polytabloids of a Young tableau. Writing `A_X` for
the signed sum `∑ sgn(σ) σ` over the permutations fixing every label outside a finite set `X`, the
relation is `A_X · e_t = 0` whenever the labels of `X` all lie in columns of the shape with at most
`r` cells while `X` has more than `r` elements: a column permutation `q` of `t` moves each label
only inside its own column, so the labels of `X` occupy at most `r` rows of the tabloid `q · {t}`,
two of them share a row of it, and the transposition of those two fixes that tabloid while negating
the signed sum. The PR adds `TauCeti.antisymmetrizerOn` for that signed sum together with its
coefficients, its expansion as an operator on a representation, and the annihilation criterion
`asAlgebraHom_antisymmetrizerOn_apply_eq_zero`; the pigeonhole step
`exists_ne_rowIndex_relabel_eq`; the relation
`asAlgebraHom_antisymmetrizerOn_polytabloid_eq_zero` with its restatement as the vanishing of a
signed sum of the polytabloids `e_{σt}`;
and the **Garnir sets** `garnirSet t i j` — the labels of `t` in column `j` from row `i` downwards
together with those in column `j + 1` from row `i` upwards — with the count
`card_garnirSet : (garnirSet t i j).card = μ.colLen j + 1` that makes the relation apply to them
whenever `(i, j + 1)` is a cell.

The milestone served is the standard basis of the Specht module, Layer 5 of the Schur-Weyl
roadmap: `Basis (StandardYoungTableau μ) ℚ (spechtModule μ)` and hence
`finrank ℚ (spechtModule μ) = standardCount μ`. That layer names the straightening algorithm,
"Garnir relations expressing an arbitrary polytabloid in the standard ones", as a target in its own
right, and it is what the milestone is still missing:
`TauCeti/RepresentationTheory/Symmetric/Specht/StandardBasis.lean` proves only
`standardCount_le_finrank_spechtModule`, and records that the reverse inequality "needs the
straightening algorithm and is not proved here". What remains after this PR is the straightening
induction itself — ordering the tableaux, passing from the antisymmetrizer to the classical Garnir
element over a transversal of the permutations internal to the two halves of a Garnir set, and
applying the resulting relation at a tableau whose rows fail to increase across a cell, to rewrite
its polytabloid as a combination of larger ones — which supplies the spanning half and so the
basis.  Isolating the identity term of the antisymmetrizer sum on its own does not straighten,
since the permutations in it that lie in the column group of `t` contribute further copies of
`e_t`; the module docstring records this.

The two generic lemmas about permutations fixing everything outside a finite set are added to the
existing `TauCeti/Algebra/GroupAction/FixingSubgroup.lean` rather than to the new file, since they
say nothing about tableaux. The transposition argument reuses
`Representation.asAlgebraHom_eq_zero_of_mul_single_eq_neg` from
`TauCeti/RepresentationTheory/AsAlgebraHom.lean`, and the signed sum is the existing
`TauCeti.subgroupCharSum` at the sign character, as the column antisymmetrizer already is. The
mathematics follows James, *The Representation Theory of the Symmetric Groups*, Section 7, and
Sagan, *The Symmetric Group*, Section 2.6; both are cited in the module docstring.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"garnir-relations"}-->

🤖 Prepared with Claude Code

