### PR TITLE
feat: make the solvable radical invariant under isomorphism

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -34,6 +34,8 @@ the finite-type coordinate-Hopf-algebra category.
 * `TauCeti.FiniteTypeCommHopfAlgCat.quotient`: the quotient object in
   `FiniteTypeCommHopfAlgCat`.
 * `TauCeti.FiniteTypeCommHopfAlgCat.mkQuotient`: the quotient morphism.
+* `TauCeti.FiniteTypeCommHopfAlgCat.mkQuotient_hom_ext`: morphisms out of a quotient are
+  determined after precomposition with the quotient morphism.
 * `TauCeti.FiniteTypeCommHopfAlgCat.mkQuotient_ker`: its kernel characterization.
 * `TauCeti.FiniteTypeCommHopfAlgCat.liftQuotient`: the induced morphism out of a quotient.
 * `TauCeti.CommHopfAlgCat.toIdeal_le_ker_of_mkQuotient_comp`: a morphism factoring through
@@ -577,6 +579,17 @@ noncomputable def quotientBotIso (H : FiniteTypeCommHopfAlgCat.{u, v} R) :
 noncomputable abbrev mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
     (I : HopfIdeal R H) : H ⟶ quotient H I :=
   ObjectProperty.homMk (CommHopfAlgCat.mkQuotient H.obj I)
+
+/-- Morphisms out of a finite-type Hopf-algebra quotient are determined by their composites
+with the quotient morphism. -/
+theorem mkQuotient_hom_ext {H X : FiniteTypeCommHopfAlgCat.{u, v} R}
+    {I : HopfIdeal R H} {f g : quotient H I ⟶ X}
+    (h : mkQuotient H I ≫ f = mkQuotient H I ≫ g) : f = g := by
+  have hsurjective : Function.Surjective (toBialgHom (mkQuotient H I)) :=
+    CommHopfAlgCat.mkQuotient_surjective H.obj I
+  let _ : Epi (mkQuotient H I) :=
+    ConcreteCategory.epi_of_surjective _ hsurjective
+  exact (cancel_epi (mkQuotient H I)).mp h
 
 /-- The inverse map of the finite-type quotient-by-zero isomorphism is the quotient morphism. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -31,6 +31,8 @@ the finite-type coordinate-Hopf-algebra category.
 
 * `TauCeti.CommHopfAlgCat.quotient`: the quotient object in `CommHopfAlgCat`.
 * `TauCeti.CommHopfAlgCat.mkQuotient_surjective`: the quotient morphism is surjective.
+* `TauCeti.CommHopfAlgCat.mkQuotient_hom_ext`: morphisms out of a quotient are determined
+  after precomposition with the quotient morphism.
 * `TauCeti.FiniteTypeCommHopfAlgCat.quotient`: the quotient object in
   `FiniteTypeCommHopfAlgCat`.
 * `TauCeti.FiniteTypeCommHopfAlgCat.mkQuotient`: the quotient morphism.
@@ -148,6 +150,16 @@ lemma mkQuotient_surjective (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H
   obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
   exact ⟨h, mkQuotient_apply H I h⟩
 
+/-- Morphisms out of a Hopf-algebra quotient are determined by their composites with the
+quotient morphism. -/
+@[ext]
+theorem mkQuotient_hom_ext {H X : _root_.CommHopfAlgCat.{v} R}
+    {I : HopfIdeal R H} {f g : quotient H I ⟶ X}
+    (h : mkQuotient H I ≫ f = mkQuotient H I ≫ g) : f = g := by
+  let _ : Epi (mkQuotient H I) :=
+    ConcreteCategory.epi_of_surjective _ (mkQuotient_surjective H I)
+  exact (cancel_epi (mkQuotient H I)).mp h
+
 variable {H K : _root_.CommHopfAlgCat.{v} R}
 
 /-- A morphism of commutative Hopf algebras out of `H` which kills a Hopf ideal factors
@@ -183,15 +195,8 @@ quotient morphism. -/
 lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
     (hf : I.toIdeal ≤ RingHom.ker f.hom.toAlgHom.toRingHom) (g : quotient H I ⟶ K)
     (hg : mkQuotient H I ≫ g = f) : g = liftQuotient I f hf := by
-  ext q
-  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
-  calc
-    g.hom (Ideal.Quotient.mkₐ R I.toIdeal h) =
-        (mkQuotient H I ≫ g).hom h := by
-      rw [_root_.CommHopfAlgCat.comp_apply, mkQuotient_apply]
-    _ = f.hom h := by rw [hg]
-    _ = (liftQuotient I f hf).hom (Ideal.Quotient.mkₐ R I.toIdeal h) :=
-      (liftQuotient_mk I f hf h).symm
+  apply mkQuotient_hom_ext
+  rw [hg, mkQuotient_comp_liftQuotient]
 
 /-- A surjective morphism remains surjective after factoring through a Hopf-ideal quotient. -/
 theorem liftQuotient_surjective_of_surjective (I : HopfIdeal R H) (f : H ⟶ K)
@@ -393,6 +398,7 @@ noncomputable def quotientBotIso (H : _root_.CommHopfAlgCat.{v} R) :
   hom := liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) bot_le
   inv := mkQuotient H (⊥ : HopfIdeal R H)
   hom_inv_id := by
+    apply _root_.CommHopfAlgCat.hom_ext
     ext q
     obtain ⟨h, rfl⟩ :=
       Ideal.Quotient.mkₐ_surjective R (⊥ : HopfIdeal R H).toIdeal q
@@ -539,10 +545,8 @@ lemma mkQuotient_comp_quotientMapOfLe (H : _root_.CommHopfAlgCat.{v} R)
 @[simp]
 lemma quotientMapOfLe_refl (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
     quotientMapOfLe H (le_refl I) = 𝟙 (quotient H I) := by
-  ext q
-  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
-  rw [quotientMapOfLe_mk]
-  rfl
+  apply mkQuotient_hom_ext
+  simp only [mkQuotient_comp_quotientMapOfLe, Category.comp_id]
 
 /-- Quotient-to-quotient morphisms compose along inclusions of Hopf ideals. -/
 @[simp]
@@ -550,10 +554,9 @@ lemma quotientMapOfLe_comp (H : _root_.CommHopfAlgCat.{v} R)
     {I J K : HopfIdeal R H} (hIJ : I ≤ J) (hJK : J ≤ K) :
     quotientMapOfLe H hIJ ≫ quotientMapOfLe H hJK =
       quotientMapOfLe H (hIJ.trans hJK) := by
-  ext q
-  obtain ⟨h, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
-  rw [_root_.CommHopfAlgCat.comp_apply, quotientMapOfLe_mk, quotientMapOfLe_mk,
-    quotientMapOfLe_mk]
+  apply mkQuotient_hom_ext
+  rw [← Category.assoc, mkQuotient_comp_quotientMapOfLe,
+    mkQuotient_comp_quotientMapOfLe, mkQuotient_comp_quotientMapOfLe]
 
 end CommHopfAlgCat
 
@@ -580,16 +583,23 @@ noncomputable abbrev mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
     (I : HopfIdeal R H) : H ⟶ quotient H I :=
   ObjectProperty.homMk (CommHopfAlgCat.mkQuotient H.obj I)
 
+/-- The finite-type quotient morphism forgets to the `CommHopfAlgCat` quotient morphism. -/
+lemma forget₂_commHopfAlgCat_map_mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    (I : HopfIdeal R H) :
+    (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R) (_root_.CommHopfAlgCat.{v} R)).map
+      (mkQuotient H I) = CommHopfAlgCat.mkQuotient H.obj I :=
+  rfl
+
 /-- Morphisms out of a finite-type Hopf-algebra quotient are determined by their composites
 with the quotient morphism. -/
+@[ext]
 theorem mkQuotient_hom_ext {H X : FiniteTypeCommHopfAlgCat.{u, v} R}
     {I : HopfIdeal R H} {f g : quotient H I ⟶ X}
     (h : mkQuotient H I ≫ f = mkQuotient H I ≫ g) : f = g := by
-  have hsurjective : Function.Surjective (toBialgHom (mkQuotient H I)) :=
-    CommHopfAlgCat.mkQuotient_surjective H.obj I
-  let _ : Epi (mkQuotient H I) :=
-    ConcreteCategory.epi_of_surjective _ hsurjective
-  exact (cancel_epi (mkQuotient H I)).mp h
+  apply ObjectProperty.hom_ext
+  apply CommHopfAlgCat.mkQuotient_hom_ext
+  rw [← forget₂_commHopfAlgCat_map_mkQuotient]
+  exact congrArg (fun q ↦ q.hom) h
 
 /-- The inverse map of the finite-type quotient-by-zero isomorphism is the quotient morphism. -/
 @[simp]
@@ -599,13 +609,6 @@ lemma quotientBotIso_inv (H : FiniteTypeCommHopfAlgCat.{u, v} R) :
     rw [quotientBotIso]
     apply ObjectProperty.hom_ext
     exact CommHopfAlgCat.quotientBotIso_inv H.obj
-
-/-- The finite-type quotient morphism forgets to the `CommHopfAlgCat` quotient morphism. -/
-lemma forget₂_commHopfAlgCat_map_mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
-    (I : HopfIdeal R H) :
-    (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R) (_root_.CommHopfAlgCat.{v} R)).map
-      (mkQuotient H I) = CommHopfAlgCat.mkQuotient H.obj I :=
-  rfl
 
 /-- The kernel of the finite-type quotient morphism is the Hopf ideal being quotiented by. -/
 lemma mkQuotient_ker (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Construction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Construction.lean
@@ -157,12 +157,8 @@ theorem solvableRadical_hom_ext {H X : FiniteTypeCommHopfAlgCat.{u, u} k}
     {f g : solvableRadical H ⟶ X}
     (h : solvableRadicalCoordinateMap H ≫ f = solvableRadicalCoordinateMap H ≫ g) :
     f = g := by
-  have hsurjective : Function.Surjective (toBialgHom (solvableRadicalCoordinateMap H)) := by
-    rw [solvableRadicalCoordinateMap_def]
-    exact CommHopfAlgCat.mkQuotient_surjective H.obj (solvableRadicalDefiningIdeal H)
-  let _ : Epi (solvableRadicalCoordinateMap H) :=
-    ConcreteCategory.epi_of_surjective _ hsurjective
-  exact (cancel_epi (solvableRadicalCoordinateMap H)).mp h
+  rw [solvableRadicalCoordinateMap_def] at h
+  exact mkQuotient_hom_ext h
 
 /-- The kernel of the solvable-radical coordinate morphism is its defining ideal. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Construction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Construction.lean
@@ -150,6 +150,20 @@ lemma solvableRadicalCoordinateMap_def
     solvableRadicalCoordinateMap H = mkQuotient H (solvableRadicalDefiningIdeal H) :=
   (rfl)
 
+/-- A morphism out of a solvable radical is determined by its composite with the coordinate
+quotient map. -/
+@[ext]
+theorem solvableRadical_hom_ext {H X : FiniteTypeCommHopfAlgCat.{u, u} k}
+    {f g : solvableRadical H ⟶ X}
+    (h : solvableRadicalCoordinateMap H ≫ f = solvableRadicalCoordinateMap H ≫ g) :
+    f = g := by
+  have hsurjective : Function.Surjective (toBialgHom (solvableRadicalCoordinateMap H)) := by
+    rw [solvableRadicalCoordinateMap_def]
+    exact CommHopfAlgCat.mkQuotient_surjective H.obj (solvableRadicalDefiningIdeal H)
+  let _ : Epi (solvableRadicalCoordinateMap H) :=
+    ConcreteCategory.epi_of_surjective _ hsurjective
+  exact (cancel_epi (solvableRadicalCoordinateMap H)).mp h
+
 /-- The kernel of the solvable-radical coordinate morphism is its defining ideal. -/
 @[simp]
 theorem solvableRadicalCoordinateMap_ker

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Construction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Construction.lean
@@ -144,6 +144,12 @@ noncomputable def solvableRadicalCoordinateMap
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) : H ⟶ solvableRadical H :=
   mkQuotient H (solvableRadicalDefiningIdeal H)
 
+/-- The solvable-radical coordinate morphism is the canonical quotient morphism. -/
+lemma solvableRadicalCoordinateMap_def
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    solvableRadicalCoordinateMap H = mkQuotient H (solvableRadicalDefiningIdeal H) :=
+  (rfl)
+
 /-- The kernel of the solvable-radical coordinate morphism is its defining ideal. -/
 @[simp]
 theorem solvableRadicalCoordinateMap_ker

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Isomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Isomorphism.lean
@@ -165,7 +165,7 @@ theorem solvableRadicalIsoOfIso_refl :
   apply Iso.ext
   apply solvableRadical_hom_ext
   rw [solvableRadicalCoordinateMap_comp_solvableRadicalIsoOfIso_hom]
-  rfl
+  simp only [Iso.refl_hom, Category.id_comp, Category.comp_id]
 
 /-- Isomorphisms induced on solvable radicals respect composition. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Isomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Isomorphism.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Construction
+
+/-!
+# Isomorphism invariance of the solvable radical
+
+An isomorphism of finite-type commutative Hopf algebras carries connected normal smooth
+solvable closed subgroups to such subgroups. Consequently it carries the greatest one to the
+greatest one: the defining Hopf ideal of the solvable radical pulls back to the defining ideal
+of the source radical.
+
+This file packages that equality as an isomorphism between the coordinate Hopf algebras of the
+two solvable radicals. The isomorphism commutes with their coordinate quotient maps, which
+characterizes it uniquely and gives its identity, composition, and inverse laws.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.IsSolvableRadicalCandidate.comapOfIso`: transport a radical candidate
+  across an ambient isomorphism.
+* `TauCeti.FiniteTypeCommHopfAlgCat.comapOfSurjective_solvableRadicalDefiningIdeal`: the defining
+  ideal of the solvable radical is invariant under isomorphism.
+* `TauCeti.FiniteTypeCommHopfAlgCat.solvableRadicalIsoOfIso`: the induced isomorphism of
+  solvable radicals.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 6.45--6.46.
+* A. Borel, *Linear Algebraic Groups*, Section 11.21.
+
+The formal organization follows
+`TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Isomorphism`.
+
+This supplies the isomorphism-invariance interface for the solvable radical required by Layer 6,
+"Reductive and semisimple groups", of the ReductiveGroups roadmap. It lets the subsequent
+structure theory use the radical independently of a chosen coordinate presentation.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal.IsSolvableRadicalCandidate
+
+variable {k : Type u} [Field k]
+variable {H K : FiniteTypeCommHopfAlgCat.{u, u} k}
+variable {I : HopfIdeal k K}
+
+/-- Pulling a solvable-radical candidate back across an ambient isomorphism gives a
+solvable-radical candidate in the source. -/
+theorem comapOfIso (hI : IsSolvableRadicalCandidate K I) (e : H ≅ K) :
+    IsSolvableRadicalCandidate H
+      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2) := by
+  let qIso := FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I
+  refine .mk
+    (hI.isNormal.comapOfSurjective_of_bijective
+      (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+      (ConcreteCategory.bijective_of_isIso e.hom).1
+      (ConcreteCategory.bijective_of_isIso e.hom).2) ?_ ?_ ?_
+  · exact (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso
+      ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+        (_root_.CommHopfAlgCat.{u} k)).mapIso qIso.symm) hI.geometricallyConnected
+  · exact (smoothCommHopfAlgProperty_iff _).mp <|
+      (smoothCommHopfAlgProperty k).prop_of_iso
+        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+          (_root_.CommHopfAlgCat.{u} k)).mapIso qIso.symm)
+        ((smoothCommHopfAlgProperty_iff _).mpr hI.smooth)
+  · exact (geometricallySolvablePointsCommHopfAlgProperty k).prop_of_iso
+      ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+        (_root_.CommHopfAlgCat.{u} k)).mapIso qIso.symm) hI.geometricallySolvable
+
+end HopfIdeal.IsSolvableRadicalCandidate
+
+namespace FiniteTypeCommHopfAlgCat
+
+variable {k : Type u} [Field k]
+variable {H K L : FiniteTypeCommHopfAlgCat.{u, u} k}
+
+/-- An ambient isomorphism pulls the defining ideal of the target's solvable radical back to
+the defining ideal of the source's solvable radical. -/
+@[simp]
+theorem comapOfSurjective_solvableRadicalDefiningIdeal (e : H ≅ K) :
+    (solvableRadicalDefiningIdeal K).comapOfSurjective (toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2 =
+      solvableRadicalDefiningIdeal H := by
+  let pulled := (solvableRadicalDefiningIdeal K).comapOfSurjective (toBialgHom e.hom)
+    (ConcreteCategory.bijective_of_isIso e.hom).2
+  have hpulled : HopfIdeal.IsSolvableRadicalCandidate H pulled :=
+    (isSolvableRadicalCandidate_solvableRadicalDefiningIdeal K).comapOfIso e
+  apply le_antisymm
+  · let sourcePulled := (solvableRadicalDefiningIdeal H).comapOfSurjective
+      (toBialgHom e.inv) (ConcreteCategory.bijective_of_isIso e.inv).2
+    have hsourcePulled : HopfIdeal.IsSolvableRadicalCandidate K sourcePulled :=
+      (isSolvableRadicalCandidate_solvableRadicalDefiningIdeal H).comapOfIso e.symm
+    have hle : solvableRadicalDefiningIdeal K ≤ sourcePulled :=
+      solvableRadicalDefiningIdeal_le K sourcePulled hsourcePulled
+    intro x hx
+    have hx' := hle (HopfIdeal.mem_comapOfSurjective.mp hx)
+    have hx'' := HopfIdeal.mem_comapOfSurjective.mp hx'
+    have hcancel : (toBialgHom e.inv) ((toBialgHom e.hom) x) = x := by
+      have h := congrArg (fun f : H ⟶ H => toBialgHom f x) e.hom_inv_id
+      simpa only [toBialgHom_comp, BialgHom.comp_apply, toBialgHom_id,
+        BialgHom.coe_id, id_eq] using h
+    rw [hcancel] at hx''
+    exact hx''
+  · exact solvableRadicalDefiningIdeal_le H pulled hpulled
+
+/-- An isomorphism of finite-type commutative Hopf algebras induces an isomorphism of their
+solvable radicals. -/
+noncomputable def solvableRadicalIsoOfIso (e : H ≅ K) :
+    solvableRadical H ≅ solvableRadical K :=
+  eqToIso (congrArg (quotient H)
+    (comapOfSurjective_solvableRadicalDefiningIdeal e).symm) ≪≫
+    quotientIsoOfIso e (solvableRadicalDefiningIdeal K)
+
+/-- The isomorphism of solvable radicals commutes with the coordinate quotient maps. -/
+@[simp]
+theorem solvableRadicalCoordinateMap_comp_solvableRadicalIsoOfIso_hom (e : H ≅ K) :
+    solvableRadicalCoordinateMap H ≫ (solvableRadicalIsoOfIso e).hom =
+      e.hom ≫ solvableRadicalCoordinateMap K := by
+  rw [solvableRadicalIsoOfIso, Iso.trans_hom, eqToIso.hom, ← Category.assoc,
+    solvableRadicalCoordinateMap_def H, solvableRadicalCoordinateMap_def K,
+    mkQuotient_comp_eqToHom, mkQuotient_comp_quotientIsoOfIso_hom]
+  exact comapOfSurjective_solvableRadicalDefiningIdeal e
+
+/-- The inverse isomorphism of solvable radicals commutes with the coordinate quotient maps. -/
+@[simp]
+theorem solvableRadicalCoordinateMap_comp_solvableRadicalIsoOfIso_inv (e : H ≅ K) :
+    solvableRadicalCoordinateMap K ≫ (solvableRadicalIsoOfIso e).inv =
+      e.inv ≫ solvableRadicalCoordinateMap H := by
+  rw [← cancel_mono (solvableRadicalIsoOfIso e).hom]
+  simp
+
+/-- A morphism out of a solvable radical is determined by its composite with the coordinate
+quotient map. -/
+@[ext]
+theorem solvableRadical_hom_ext {X : FiniteTypeCommHopfAlgCat.{u, u} k}
+    {f g : solvableRadical H ⟶ X}
+    (h : solvableRadicalCoordinateMap H ≫ f = solvableRadicalCoordinateMap H ≫ g) :
+    f = g := by
+  have hsurjective : Function.Surjective (toBialgHom (solvableRadicalCoordinateMap H)) := by
+    rw [solvableRadicalCoordinateMap_def]
+    exact CommHopfAlgCat.mkQuotient_surjective H.obj (solvableRadicalDefiningIdeal H)
+  let _ : Epi (solvableRadicalCoordinateMap H) :=
+    ConcreteCategory.epi_of_surjective _ hsurjective
+  exact (cancel_epi (solvableRadicalCoordinateMap H)).mp h
+
+/-- The isomorphism induced by the identity isomorphism is the identity on the solvable
+radical. -/
+@[simp]
+theorem solvableRadicalIsoOfIso_refl :
+    solvableRadicalIsoOfIso (Iso.refl H) = Iso.refl (solvableRadical H) := by
+  apply Iso.ext
+  apply solvableRadical_hom_ext
+  rw [solvableRadicalCoordinateMap_comp_solvableRadicalIsoOfIso_hom]
+  rfl
+
+/-- Isomorphisms induced on solvable radicals respect composition. -/
+@[simp]
+theorem solvableRadicalIsoOfIso_trans (e : H ≅ K) (f : K ≅ L) :
+    solvableRadicalIsoOfIso (e ≪≫ f) =
+      solvableRadicalIsoOfIso e ≪≫ solvableRadicalIsoOfIso f := by
+  apply Iso.ext
+  apply solvableRadical_hom_ext
+  rw [solvableRadicalCoordinateMap_comp_solvableRadicalIsoOfIso_hom]
+  simp only [Iso.trans_hom]
+  conv_rhs =>
+    rw [← Category.assoc,
+      solvableRadicalCoordinateMap_comp_solvableRadicalIsoOfIso_hom,
+      Category.assoc,
+      solvableRadicalCoordinateMap_comp_solvableRadicalIsoOfIso_hom]
+  simp
+
+/-- The inverse of the isomorphism induced on solvable radicals is the isomorphism induced by
+the inverse ambient isomorphism. -/
+@[simp]
+theorem solvableRadicalIsoOfIso_symm (e : H ≅ K) :
+    (solvableRadicalIsoOfIso e).symm = solvableRadicalIsoOfIso e.symm := by
+  apply Iso.ext
+  apply solvableRadical_hom_ext
+  rw [Iso.symm_hom,
+    solvableRadicalCoordinateMap_comp_solvableRadicalIsoOfIso_inv,
+    solvableRadicalCoordinateMap_comp_solvableRadicalIsoOfIso_hom]
+  rfl
+
+end FiniteTypeCommHopfAlgCat
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Isomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Isomorphism.lean
@@ -64,22 +64,21 @@ theorem comapOfIso (hI : IsSolvableRadicalCandidate K I) (e : H ≅ K) :
       (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
         (ConcreteCategory.bijective_of_isIso e.hom).2) := by
   let qIso := FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I
+  let qIso' := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+    (_root_.CommHopfAlgCat.{u} k)).mapIso qIso.symm
   refine .mk
     (hI.isNormal.comapOfSurjective_of_bijective
       (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
       (ConcreteCategory.bijective_of_isIso e.hom).1
       (ConcreteCategory.bijective_of_isIso e.hom).2) ?_ ?_ ?_
   · exact (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso
-      ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-        (_root_.CommHopfAlgCat.{u} k)).mapIso qIso.symm) hI.geometricallyConnected
+      qIso' hI.geometricallyConnected
   · exact (smoothCommHopfAlgProperty_iff _).mp <|
       (smoothCommHopfAlgProperty k).prop_of_iso
-        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-          (_root_.CommHopfAlgCat.{u} k)).mapIso qIso.symm)
+        qIso'
         ((smoothCommHopfAlgProperty_iff _).mpr hI.smooth)
   · exact (geometricallySolvablePointsCommHopfAlgProperty k).prop_of_iso
-      ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-        (_root_.CommHopfAlgCat.{u} k)).mapIso qIso.symm) hI.geometricallySolvable
+      qIso' hI.geometricallySolvable
 
 end HopfIdeal.IsSolvableRadicalCandidate
 
@@ -113,8 +112,7 @@ theorem comapOfSurjective_solvableRadicalDefiningIdeal (e : H ≅ K) :
       have h := congrArg (fun f : H ⟶ H => toBialgHom f x) e.hom_inv_id
       simpa only [toBialgHom_comp, BialgHom.comp_apply, toBialgHom_id,
         BialgHom.coe_id, id_eq] using h
-    rw [hcancel] at hx''
-    exact hx''
+    rwa [hcancel] at hx''
   · exact solvableRadicalDefiningIdeal_le H pulled hpulled
 
 /-- An isomorphism of finite-type commutative Hopf algebras induces an isomorphism of their
@@ -142,20 +140,6 @@ theorem solvableRadicalCoordinateMap_comp_solvableRadicalIsoOfIso_inv (e : H ≅
       e.inv ≫ solvableRadicalCoordinateMap H := by
   rw [← cancel_mono (solvableRadicalIsoOfIso e).hom]
   simp
-
-/-- A morphism out of a solvable radical is determined by its composite with the coordinate
-quotient map. -/
-@[ext]
-theorem solvableRadical_hom_ext {X : FiniteTypeCommHopfAlgCat.{u, u} k}
-    {f g : solvableRadical H ⟶ X}
-    (h : solvableRadicalCoordinateMap H ≫ f = solvableRadicalCoordinateMap H ≫ g) :
-    f = g := by
-  have hsurjective : Function.Surjective (toBialgHom (solvableRadicalCoordinateMap H)) := by
-    rw [solvableRadicalCoordinateMap_def]
-    exact CommHopfAlgCat.mkQuotient_surjective H.obj (solvableRadicalDefiningIdeal H)
-  let _ : Epi (solvableRadicalCoordinateMap H) :=
-    ConcreteCategory.epi_of_surjective _ hsurjective
-  exact (cancel_epi (solvableRadicalCoordinateMap H)).mp h
 
 /-- The isomorphism induced by the identity isomorphism is the identity on the solvable
 radical. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Isomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Isomorphism.lean
@@ -145,12 +145,8 @@ theorem unipotentRadical_hom_ext {X : FiniteTypeCommHopfAlgCat.{u, u} k}
     {f g : unipotentRadical H ⟶ X}
     (h : unipotentRadicalCoordinateMap H ≫ f = unipotentRadicalCoordinateMap H ≫ g) :
     f = g := by
-  have hsurjective : Function.Surjective (toBialgHom (unipotentRadicalCoordinateMap H)) := by
-    rw [unipotentRadicalCoordinateMap_def]
-    exact CommHopfAlgCat.mkQuotient_surjective H.obj (unipotentRadicalDefiningIdeal H)
-  let _ : Epi (unipotentRadicalCoordinateMap H) :=
-    ConcreteCategory.epi_of_surjective _ hsurjective
-  exact (cancel_epi (unipotentRadicalCoordinateMap H)).mp h
+  rw [unipotentRadicalCoordinateMap_def] at h
+  exact mkQuotient_hom_ext h
 
 /-- The isomorphism induced by the identity isomorphism is the identity on the unipotent
 radical. -/


### PR DESCRIPTION
This PR makes the solvable radical invariant under isomorphism of finite-type commutative Hopf algebras. It transports solvable-radical candidates through quotient isomorphisms, proves that an ambient isomorphism pulls back the target defining ideal to the source defining ideal, and packages the induced radical isomorphism with its quotient-map characterization, uniqueness principle, and identity, composition, and inverse laws.

The exact roadmap target is ReductiveGroups Layer 6, “Develop the radical, the centre, and the derived subgroup scheme, and study their interactions.” The milestone served is the Layer 6 construction and structural use of the solvable radical: the construction landed first, and this PR supplies the presentation-independent interface needed before the radical can participate cleanly in centre/derived-group and central-isogeny arguments. After this PR, the milestone still requires the centre and derived subgroup interactions, central isogenies, simply connected and adjoint forms, and the characteristic-zero equivalence between reductivity and linear reductivity.

The formal organization follows the existing Tau Ceti unipotent-radical isomorphism API. Mathematical references are J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 6.45–6.46, and A. Borel, *Linear Algebraic Groups*, Section 11.21. No Mathlib infrastructure is vendored.

The change adds the 202-line `Solvable.Radical.Isomorphism` module and a six-line canonical quotient-map lemma to `Solvable.Radical.Construction`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"solvable-radical-isomorphism-invariance"}-->

🤖 Prepared with Codex
