### PR TITLE
feat: the E6 diagram automorphism on the minuscule weights

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/DiagramPermutations.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/DiagramPermutations.lean
@@ -155,6 +155,9 @@ theorem graphPermD_ne_one (n : ℕ) (hn : 2 ≤ n) : graphPermD n hn ≠ 1 := by
 /-- Applying the `E₆` graph permutation twice is the identity. -/
 @[simp] theorem graphPermE6_sq : graphPermE6 ^ 2 = 1 := by decide
 
+/-- The `E₆` graph permutation is its own inverse. -/
+@[simp] lemma graphPermE6_symm : graphPermE6.symm = graphPermE6 := by decide
+
 /-- The `E₆` graph permutation has order exactly two. -/
 @[simp] theorem orderOf_graphPermE6 : orderOf graphPermE6 = 2 :=
   orderOf_eq_prime graphPermE6_sq (by decide)

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/DiagramAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/DiagramAutomorphism.lean
@@ -288,13 +288,6 @@ fundamental weights, the standard basis of the character lattice, by `σ`. -/
     (diagramAut ht hσ).toHom.weightMap = (LinearEquiv.funCongrLeft ℤ ℤ σ.symm).toLinearMap :=
   (rfl)
 
-/-- The diagram automorphism reads a character at the node moved by `σ⁻¹`. This is the pointwise
-form of `TauCeti.DynkinType.diagramAut_weightMap`, which a consumer with a named weight family in
-hand uses instead of unfolding the coordinate equivalence. -/
-theorem diagramAut_weightMap_apply (hσ : σ ∈ t.diagramSymmetry) (x : Fin t.rank → ℤ)
-    (i : Fin t.rank) : (diagramAut ht hσ).toHom.weightMap x i = x (σ.symm i) :=
-  (rfl)
-
 /-- The coweight map of the diagram automorphism is precomposition with `σ`, the transpose of the
 weight map, so it permutes the simple coroots by `σ⁻¹`. -/
 @[simp] theorem diagramAut_coweightMap (hσ : σ ∈ t.diagramSymmetry) :

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/DiagramAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/DiagramAutomorphism.lean
@@ -288,6 +288,13 @@ fundamental weights, the standard basis of the character lattice, by `σ`. -/
     (diagramAut ht hσ).toHom.weightMap = (LinearEquiv.funCongrLeft ℤ ℤ σ.symm).toLinearMap :=
   (rfl)
 
+/-- The diagram automorphism reads a character at the node moved by `σ⁻¹`. This is the pointwise
+form of `TauCeti.DynkinType.diagramAut_weightMap`, which a consumer with a named weight family in
+hand uses instead of unfolding the coordinate equivalence. -/
+theorem diagramAut_weightMap_apply (hσ : σ ∈ t.diagramSymmetry) (x : Fin t.rank → ℤ)
+    (i : Fin t.rank) : (diagramAut ht hσ).toHom.weightMap x i = x (σ.symm i) :=
+  (rfl)
+
 /-- The coweight map of the diagram automorphism is precomposition with `σ`, the transpose of the
 weight map, so it permutes the simple coroots by `σ⁻¹`. -/
 @[simp] theorem diagramAut_coweightMap (hσ : σ ∈ t.diagramSymmetry) :

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -6,20 +6,32 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.DiagramAutomorphism
-public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.MinusculeWeight
 
 /-!
-# Nontriviality of the type `E₆` diagram automorphism
+# The type `E₆` diagram automorphism on the pinned root datum
 
-This file records the type-`E₆` nontriviality consequence of applying the general
+This file records the type-`E₆` consequences of applying the general
 `TauCeti.DynkinType.diagramAut` construction to the order-two symmetry
-`TauCeti.graphPermE6` of the Bourbaki-numbered diagram. The automorphism itself and its order-two
-relation remain expressed through the generic API, without introducing type-specific aliases.
+`TauCeti.graphPermE6` of the Bourbaki-numbered diagram: that it is nontrivial, and how it moves
+the minuscule weights. The automorphism itself and its order-two relation remain expressed through
+the generic API, without introducing type-specific aliases.
+
+Its weight map is the pullback of a character along the diagram symmetry, so it acts on the
+weight tables of `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/MinusculeWeight.lean`
+by permuting coordinates. It does not preserve the twenty-seven minuscule weights, and does
+permute the fifty-four weights of `V(ϖ₁) ⊕ V(ϖ₆)`.
 
 ## Main declarations
 
 * `TauCeti.DynkinType.diagramAut_graphPermE6_ne_one`: the diagram automorphism induced by
   `TauCeti.graphPermE6` is nontrivial.
+* `TauCeti.DynkinType.diagramAut_weightMap_graphPermE6`: its weight map is precomposition with
+  `TauCeti.graphPermE6`.
+* `TauCeti.DynkinType.diagramAut_weightMap_e6DoubledMinusculeWeight`: it permutes the doubled
+  minuscule weight family, along `TauCeti.DynkinType.e6DoubledMinusculeGraphPerm`.
+* `TauCeti.DynkinType.diagramAut_weightMap_e6MinusculeWeight_zero_notMem_range`: it does not
+  preserve the minuscule weight family alone.
 
 ## References
 
@@ -48,6 +60,38 @@ theorem diagramAut_graphPermE6_ne_one :
     (diagramAut_eq_one_iff valid_E6
       (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)).mp h
   simpa [hσ_one] using orderOf_graphPermE6
+
+/-- The weight map of the type-`E₆` diagram automorphism is precomposition with the diagram
+symmetry, which is an involution. -/
+theorem diagramAut_weightMap_graphPermE6 (x : Fin 6 → ℤ) :
+    (diagramAut valid_E6
+        (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)).toHom.weightMap x =
+      x ∘ graphPermE6 := by
+  have h : (diagramAut valid_E6
+      (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)).toHom.weightMap x =
+      x ∘ graphPermE6.symm :=
+    funext fun i => diagramAut_weightMap_apply valid_E6 _ x i
+  rw [h, graphPermE6_symm]
+
+/-- **The type-`E₆` diagram automorphism permutes the doubled minuscule weight family.** This is
+`TauCeti.DynkinType.e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm` read on the character
+lattice of the pinned root datum. -/
+theorem diagramAut_weightMap_e6DoubledMinusculeWeight (x : Fin 27 ⊕ Fin 27) :
+    (diagramAut valid_E6
+        (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)).toHom.weightMap
+        (e6DoubledMinusculeWeight x) =
+      e6DoubledMinusculeWeight (e6DoubledMinusculeGraphPerm x) := by
+  rw [diagramAut_weightMap_graphPermE6]
+  exact funext fun i => (e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm x i).symm
+
+/-- **The type-`E₆` diagram automorphism does not preserve the minuscule weight family.** It sends
+the highest weight `ϖ₁` to `ϖ₆`, which is not a weight of `V(ϖ₁)`. -/
+theorem diagramAut_weightMap_e6MinusculeWeight_zero_notMem_range :
+    (diagramAut valid_E6
+        (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)).toHom.weightMap
+        (e6MinusculeWeight 0) ∉ Set.range e6MinusculeWeight := by
+  rw [diagramAut_weightMap_graphPermE6]
+  exact e6MinusculeWeight_zero_comp_graphPermE6_notMem_range
 
 end
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -70,7 +70,11 @@ theorem diagramAut_weightMap_graphPermE6 (x : Fin 6 → ℤ) :
   have h : (diagramAut valid_E6
       (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)).toHom.weightMap x =
       x ∘ graphPermE6.symm :=
-    funext fun i => diagramAut_weightMap_apply valid_E6 _ x i
+    (LinearMap.congr_fun (diagramAut_weightMap valid_E6
+      (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)) x).trans
+      (funext fun i =>
+        (congrFun (LinearEquiv.funCongrLeft_apply ℤ ℤ graphPermE6.symm x) i).trans
+          (LinearMap.funLeft_apply ℤ ℤ graphPermE6.symm x i))
   rw [h, graphPermE6_symm]
 
 /-- **The type-`E₆` diagram automorphism permutes the doubled minuscule weight family.** This is

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -30,7 +30,7 @@ permute the fifty-four weights of `V(ϖ₁) ⊕ V(ϖ₆)`.
   `TauCeti.graphPermE6`.
 * `TauCeti.DynkinType.diagramAut_weightMap_e6DoubledMinusculeWeight`: it permutes the doubled
   minuscule weight family, along `TauCeti.DynkinType.e6DoubledMinusculeGraphPerm`.
-* `TauCeti.DynkinType.diagramAut_weightMap_e6MinusculeWeight_zero_notMem_range`: it does not
+* `TauCeti.DynkinType.diagramAut_weightMap_e6MinusculeWeight_notMem_range`: it does not
   preserve the minuscule weight family alone.
 
 ## References
@@ -84,14 +84,14 @@ theorem diagramAut_weightMap_e6DoubledMinusculeWeight (x : Fin 27 ⊕ Fin 27) :
   rw [diagramAut_weightMap_graphPermE6]
   exact funext fun i => (e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm x i).symm
 
-/-- **The type-`E₆` diagram automorphism does not preserve the minuscule weight family.** It sends
-the highest weight `ϖ₁` to `ϖ₆`, which is not a weight of `V(ϖ₁)`. -/
-theorem diagramAut_weightMap_e6MinusculeWeight_zero_notMem_range :
+/-- **The type-`E₆` diagram automorphism moves every minuscule weight off the family.** At the
+highest weight it sends `ϖ₁` to `ϖ₆`, which is not a weight of `V(ϖ₁)`. -/
+theorem diagramAut_weightMap_e6MinusculeWeight_notMem_range (a : Fin 27) :
     (diagramAut valid_E6
         (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)).toHom.weightMap
-        (e6MinusculeWeight 0) ∉ Set.range e6MinusculeWeight := by
+        (e6MinusculeWeight a) ∉ Set.range e6MinusculeWeight := by
   rw [diagramAut_weightMap_graphPermE6]
-  exact e6MinusculeWeight_zero_comp_graphPermE6_notMem_range
+  exact e6MinusculeWeight_comp_graphPermE6_notMem_range a
 
 end
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/MinusculeWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/MinusculeWeight.lean
@@ -50,7 +50,7 @@ the doubled family being what its graph-twisted family `²E₆(q)` needs where `
 * `TauCeti.DynkinType.e6MinusculeGraphDualPerm`: the involution of the index set induced by the
   diagram symmetry followed by duality, and
   `TauCeti.DynkinType.e6MinusculeWeight_e6MinusculeGraphDualPerm` its defining equation.
-* `TauCeti.DynkinType.e6MinusculeWeight_zero_comp_graphPermE6_notMem_range`: the twenty-seven
+* `TauCeti.DynkinType.e6MinusculeWeight_comp_graphPermE6_notMem_range`: the twenty-seven
   weights are not stable under the diagram symmetry.
 * `TauCeti.DynkinType.e6DoubledMinusculeWeight`: the fifty-four weights of `V(ϖ₁) ⊕ V(ϖ₆)`, with
   `TauCeti.DynkinType.e6DoubledMinusculeWeight_injective`,
@@ -391,21 +391,17 @@ private theorem exists_e6MinusculeWeight_apply_ne_neg (a b : Fin 27) :
     ∃ i, e6MinusculeWeight a i ≠ -e6MinusculeWeight b i := by
   decide +kernel +revert
 
-private theorem e6MinusculeGraphDualPerm_zero : e6MinusculeGraphDualPerm 0 = 26 := by
-  decide +kernel
-
-/-- **The twenty-seven minuscule weights are not stable under the diagram symmetry.** The image of
-the highest weight `ϖ₁` is `ϖ₆`, which is not a weight of `V(ϖ₁)`. So a carrier built from this
-weight family alone does not inherit the diagram automorphism. -/
-theorem e6MinusculeWeight_zero_comp_graphPermE6_notMem_range :
-    e6MinusculeWeight 0 ∘ graphPermE6 ∉ range e6MinusculeWeight := by
-  rintro ⟨a, ha⟩
-  obtain ⟨i, hi⟩ := exists_e6MinusculeWeight_apply_ne_neg a 26
-  have h26 : e6MinusculeWeight 26 i = -e6MinusculeWeight 0 (graphPermE6 i) := by
-    rw [← e6MinusculeGraphDualPerm_zero, e6MinusculeWeight_e6MinusculeGraphDualPerm_apply]
-  -- The assumed witness reads `e6MinusculeWeight a i` as the image of `ϖ₁`, which `h26` reads
-  -- back as the negative of the `26`-th weight, contradicting the choice of `i`.
-  exact hi (by simp [congrFun ha i, h26])
+/-- **The diagram symmetry moves every minuscule weight off the table.** Its image is the negative
+of a minuscule weight, and no minuscule weight is the negative of another; at the highest weight
+`ϖ₁` this is the image `ϖ₆`, not a weight of `V(ϖ₁)`. So a carrier built from this weight family
+alone does not inherit the diagram automorphism. -/
+theorem e6MinusculeWeight_comp_graphPermE6_notMem_range (a : Fin 27) :
+    e6MinusculeWeight a ∘ graphPermE6 ∉ range e6MinusculeWeight := by
+  rintro ⟨b, hb⟩
+  obtain ⟨i, hi⟩ := exists_e6MinusculeWeight_apply_ne_neg b (e6MinusculeGraphDualPerm a)
+  -- The assumed witness reads `e6MinusculeWeight b i` as the image of the `a`-th weight, which the
+  -- defining equation reads back as the negative of the `e6MinusculeGraphDualPerm a`-th one.
+  exact hi (by simp [congrFun hb i, e6MinusculeWeight_e6MinusculeGraphDualPerm_apply a i])
 
 /-! ## The doubled weight family -/
 
@@ -490,7 +486,7 @@ theorem e6DoubledMinusculeGraphPerm_symm :
 /-- **The doubled minuscule weight family is equivariant for the `E₆` diagram symmetry.** This is
 the hypothesis `wt (π i) (τ k) = wt i k` under which a numbered symmetry of a Kostant toral-closure
 carrier extends to an automorphism of the carrier, and it is what
-`e6MinusculeWeight_zero_comp_graphPermE6_notMem_range` denies to the minuscule family alone. -/
+`e6MinusculeWeight_comp_graphPermE6_notMem_range` denies to the minuscule family alone. -/
 theorem e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm (x : Fin 27 ⊕ Fin 27) (i : Fin 6) :
     e6DoubledMinusculeWeight (e6DoubledMinusculeGraphPerm x) i =
       e6DoubledMinusculeWeight x (graphPermE6 i) := by

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/MinusculeWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/MinusculeWeight.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.LinearAlgebra.RootSystem.DiagramPermutations
 public import TauCeti.LinearAlgebra.RootSystem.SimpleReflections
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Reduced
@@ -24,9 +25,20 @@ with the full Weyl orbit, and proves that its weights span the complete characte
 property is what lets the represented weight torus of an admissible minuscule lattice be a closed
 immersion, rather than seeing only the index-three root lattice of the adjoint representation.
 
+The table is *not* stable under the pinned diagram symmetry `TauCeti.graphPermE6`, which exchanges
+`ϖ₁` and `ϖ₆` and so carries the weights of `V(ϖ₁)` to those of `V(ϖ₆) = V(ϖ₁)ˣ`, their negatives.
+The last two sections make that exchange explicit and repair it: `e6MinusculeGraphPerm` is the
+involution of the index set implementing it, and `e6DoubledMinusculeWeight` is the fifty-four-weight
+family of `V(ϖ₁) ⊕ V(ϖ₆)`, which is stable, is still injective, and still spans. A carrier inherits
+a symmetry of its numbered data only when its weight family is equivariant, the hypothesis
+`wt (π i) (τ k) = wt i k` of
+`TauCeti.UniversalEnvelopingAlgebra.kostantToralNumberedSymmetryIso`, which the doubled family
+meets and the minuscule family alone does not.
+
 No representation or group scheme is constructed here. This is the pinned weight-diagram input
 for the type-`E₆` full-weight Chevalley--Demazure carrier in Layer 9 of
-`TauCetiRoadmap/ReductiveGroups/README.md`, consumed by milestone L0 of the CFSG statement roadmap.
+`TauCetiRoadmap/ReductiveGroups/README.md`, consumed by milestone L0 of the CFSG statement roadmap,
+the doubled family being what its graph-twisted family `²E₆(q)` needs where `E₆(q)` does not.
 
 ## Main declarations
 
@@ -35,13 +47,25 @@ for the type-`E₆` full-weight Chevalley--Demazure carrier in Layer 9 of
 * `TauCeti.DynkinType.e6MinusculeWeight_reflection`: the simple-reflection equation.
 * `TauCeti.DynkinType.range_e6MinusculeWeight`: the table is exactly the Weyl orbit of `ϖ₁`.
 * `TauCeti.DynkinType.span_range_e6MinusculeWeight_eq_top`: the weights span the character lattice.
+* `TauCeti.DynkinType.e6MinusculeGraphPerm`: the involution of the index set induced by the diagram
+  symmetry followed by duality, and
+  `TauCeti.DynkinType.e6MinusculeWeight_e6MinusculeGraphPerm` its defining equation.
+* `TauCeti.DynkinType.e6MinusculeWeight_zero_comp_graphPermE6_notMem_range`: the twenty-seven
+  weights are not stable under the diagram symmetry.
+* `TauCeti.DynkinType.e6DoubledMinusculeWeight`: the fifty-four weights of `V(ϖ₁) ⊕ V(ϖ₆)`, with
+  `TauCeti.DynkinType.e6DoubledMinusculeWeight_injective`,
+  `TauCeti.DynkinType.span_range_e6DoubledMinusculeWeight_eq_top` and
+  `TauCeti.DynkinType.e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm`, its equivariance for
+  the diagram symmetry.
 
 ## References
 
 The node numbering and the choice of the minuscule weight `ϖ₁` follow Bourbaki, *Lie Groups and Lie
 Algebras, Chapters 4--6*, Plate V. The minuscule-orbit description of the 27-dimensional
 representation follows J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*,
-§13.4, and J. C. Jantzen, *Representations of Algebraic Groups*, II.2.
+§13.4, and J. C. Jantzen, *Representations of Algebraic Groups*, II.2. That the diagram
+automorphism exchanges the two twenty-seven dimensional representations, and the conventions for
+`²E₆(q)` that makes this relevant to, are R. W. Carter, *Simple Groups of Lie Type*, §12.2.
 -/
 
 public section
@@ -305,5 +329,158 @@ theorem span_range_e6MinusculeWeight_eq_top :
     exact S.sub_mem
       (S.sub_mem (S.sub_mem (S.add_mem (S.add_mem (h 0) (h 1)) (h 2)) (h 3)) (h 5))
       (S.smul_mem 2 (h 9))
+
+/-! ## The diagram symmetry on the weight table -/
+
+/-- The index table of `e6MinusculeGraphPerm`, matching each minuscule weight with the one whose
+negative is its image under the diagram symmetry. -/
+private def e6MinusculeGraphIndex : Fin 27 → Fin 27 :=
+  ![26, 25, 24, 23, 22, 21, 19, 20, 17, 18, 15, 16, 12, 13, 14, 10, 11, 8, 9, 6, 7, 5, 4, 3, 2, 1,
+    0]
+
+private theorem e6MinusculeGraphIndex_involutive :
+    Function.Involutive e6MinusculeGraphIndex := fun _ => by decide +kernel +revert
+
+/-- **The permutation of the twenty-seven minuscule weights induced by the `E₆` diagram
+symmetry.** The symmetry `TauCeti.graphPermE6` does not preserve the weight table, so this
+permutation records the composite of that symmetry with duality: it matches the index `a` with the
+index whose weight is the negative of the image of the `a`-th weight. -/
+def e6MinusculeGraphPerm : Equiv.Perm (Fin 27) :=
+  e6MinusculeGraphIndex_involutive.toPerm
+
+/-- The graph permutation of the minuscule weight table is an involution, as the diagram symmetry
+it realizes is. -/
+@[simp]
+theorem e6MinusculeGraphPerm_apply_apply (a : Fin 27) :
+    e6MinusculeGraphPerm (e6MinusculeGraphPerm a) = a :=
+  e6MinusculeGraphIndex_involutive a
+
+/-- The node table of `TauCeti.graphPermE6`. The permutation itself lives in another module, so
+the kernel cannot evaluate it while checking the weight table below; this table can be evaluated
+and is identified with it by `graphPermE6_apply_eq_e6GraphNode`. -/
+private def e6GraphNode : Fin 6 → Fin 6 := ![5, 1, 4, 3, 2, 0]
+
+private theorem graphPermE6_apply_eq_e6GraphNode (i : Fin 6) : graphPermE6 i = e6GraphNode i := by
+  fin_cases i <;> simp [e6GraphNode]
+
+private theorem e6MinusculeWeight_e6MinusculeGraphIndex_apply (a : Fin 27) (i : Fin 6) :
+    e6MinusculeWeight (e6MinusculeGraphIndex a) i = -e6MinusculeWeight a (e6GraphNode i) := by
+  decide +kernel +revert
+
+/-- **The diagram symmetry carries each minuscule weight to the negative of another one.** The
+symmetry exchanges `ϖ₁` and `ϖ₆`, so on representations it carries `V(ϖ₁)` to
+`V(ϖ₆) = V(ϖ₁)ˣ`, whose weights are the negatives of these. -/
+theorem e6MinusculeWeight_e6MinusculeGraphPerm_apply (a : Fin 27) (i : Fin 6) :
+    e6MinusculeWeight (e6MinusculeGraphPerm a) i = -e6MinusculeWeight a (graphPermE6 i) := by
+  rw [graphPermE6_apply_eq_e6GraphNode]
+  exact e6MinusculeWeight_e6MinusculeGraphIndex_apply a i
+
+/-- The functional form of `e6MinusculeWeight_e6MinusculeGraphPerm_apply`. -/
+theorem e6MinusculeWeight_e6MinusculeGraphPerm (a : Fin 27) :
+    e6MinusculeWeight (e6MinusculeGraphPerm a) = -(e6MinusculeWeight a ∘ graphPermE6) := by
+  funext i
+  simpa using e6MinusculeWeight_e6MinusculeGraphPerm_apply a i
+
+private theorem exists_e6MinusculeWeight_apply_ne_neg (a b : Fin 27) :
+    ∃ i, e6MinusculeWeight a i ≠ -e6MinusculeWeight b i := by
+  decide +kernel +revert
+
+private theorem e6MinusculeGraphPerm_zero : e6MinusculeGraphPerm 0 = 26 := by
+  decide +kernel
+
+/-- **The twenty-seven minuscule weights are not stable under the diagram symmetry.** The image of
+the highest weight `ϖ₁` is `ϖ₆`, which is not a weight of `V(ϖ₁)`. So a carrier built from this
+weight family alone does not inherit the diagram automorphism. -/
+theorem e6MinusculeWeight_zero_comp_graphPermE6_notMem_range :
+    e6MinusculeWeight 0 ∘ graphPermE6 ∉ range e6MinusculeWeight := by
+  rintro ⟨a, ha⟩
+  obtain ⟨i, hi⟩ := exists_e6MinusculeWeight_apply_ne_neg a 26
+  have h26 : e6MinusculeWeight 26 i = -e6MinusculeWeight 0 (graphPermE6 i) := by
+    rw [← e6MinusculeGraphPerm_zero, e6MinusculeWeight_e6MinusculeGraphPerm_apply]
+  -- The assumed witness reads `e6MinusculeWeight a i` as the image of `ϖ₁`, which `h26` reads
+  -- back as the negative of the `26`-th weight, contradicting the choice of `i`.
+  exact hi (by simp [congrFun ha i, h26])
+
+/-! ## The doubled weight family -/
+
+/-- **The fifty-four weights of the type-`E₆` representation `V(ϖ₁) ⊕ V(ϖ₆)`**, in coordinates
+given by the pairings with the six Bourbaki-numbered simple coroots. The left summand carries the
+twenty-seven minuscule weights and the right summand their negatives, which are the weights of the
+dual representation `V(ϖ₆)`. -/
+def e6DoubledMinusculeWeight : Fin 27 ⊕ Fin 27 → Fin 6 → ℤ :=
+  Sum.elim e6MinusculeWeight fun a => -e6MinusculeWeight a
+
+@[simp]
+theorem e6DoubledMinusculeWeight_inl (a : Fin 27) :
+    e6DoubledMinusculeWeight (.inl a) = e6MinusculeWeight a :=
+  (rfl)
+
+@[simp]
+theorem e6DoubledMinusculeWeight_inr (a : Fin 27) :
+    e6DoubledMinusculeWeight (.inr a) = -e6MinusculeWeight a :=
+  (rfl)
+
+/-- The doubled family is closed under negation, which exchanges its two summands. -/
+theorem neg_e6DoubledMinusculeWeight (x : Fin 27 ⊕ Fin 27) :
+    -e6DoubledMinusculeWeight x = e6DoubledMinusculeWeight (Equiv.sumComm _ _ x) := by
+  cases x <;> simp
+
+/-- **The fifty-four weights of `V(ϖ₁) ⊕ V(ϖ₆)` are pairwise distinct.** No minuscule weight is
+the negative of another, all twenty-seven of them lying in one nontrivial coset of the root
+lattice. -/
+theorem e6DoubledMinusculeWeight_injective : Function.Injective e6DoubledMinusculeWeight := by
+  have key (a b : Fin 27) : e6MinusculeWeight a ≠ -e6MinusculeWeight b := by
+    obtain ⟨i, hi⟩ := exists_e6MinusculeWeight_apply_ne_neg a b
+    exact fun h => hi (by simpa using congrFun h i)
+  rintro (a | a) (b | b) h <;>
+    simp only [e6DoubledMinusculeWeight_inl, e6DoubledMinusculeWeight_inr] at h
+  · exact congrArg Sum.inl (e6MinusculeWeight_injective h)
+  · exact absurd h (key a b)
+  · exact absurd h.symm (key b a)
+  · exact congrArg Sum.inr (e6MinusculeWeight_injective (neg_injective h))
+
+/-- The doubled minuscule weight family has fifty-four distinct members. -/
+theorem ncard_range_e6DoubledMinusculeWeight :
+    (range e6DoubledMinusculeWeight).ncard = 54 := by
+  simpa using Set.ncard_range_of_injective e6DoubledMinusculeWeight_injective
+
+/-- **The doubled minuscule weights span the full type-`E₆` character lattice.** They include the
+twenty-seven minuscule weights, which already do. -/
+theorem span_range_e6DoubledMinusculeWeight_eq_top :
+    Submodule.span ℤ (range e6DoubledMinusculeWeight) = ⊤ := by
+  refine top_unique (span_range_e6MinusculeWeight_eq_top ▸ Submodule.span_mono ?_)
+  rintro _ ⟨a, rfl⟩
+  exact ⟨.inl a, rfl⟩
+
+/-- **The permutation of the doubled index set realizing the `E₆` diagram symmetry.** It exchanges
+the two summands along `e6MinusculeGraphPerm`, which is what makes the doubled weight family
+equivariant where the minuscule family alone is not. -/
+def e6DoubledMinusculeGraphPerm : Equiv.Perm (Fin 27 ⊕ Fin 27) :=
+  (Equiv.sumCongr e6MinusculeGraphPerm e6MinusculeGraphPerm).trans (Equiv.sumComm _ _)
+
+@[simp]
+theorem e6DoubledMinusculeGraphPerm_inl (a : Fin 27) :
+    e6DoubledMinusculeGraphPerm (.inl a) = .inr (e6MinusculeGraphPerm a) :=
+  (rfl)
+
+@[simp]
+theorem e6DoubledMinusculeGraphPerm_inr (a : Fin 27) :
+    e6DoubledMinusculeGraphPerm (.inr a) = .inl (e6MinusculeGraphPerm a) :=
+  (rfl)
+
+/-- The permutation realizing the diagram symmetry on the doubled index set is an involution. -/
+@[simp]
+theorem e6DoubledMinusculeGraphPerm_apply_apply (x : Fin 27 ⊕ Fin 27) :
+    e6DoubledMinusculeGraphPerm (e6DoubledMinusculeGraphPerm x) = x := by
+  cases x <;> simp
+
+/-- **The doubled minuscule weight family is equivariant for the `E₆` diagram symmetry.** This is
+the hypothesis `wt (π i) (τ k) = wt i k` under which a numbered symmetry of a Kostant toral-closure
+carrier extends to an automorphism of the carrier, and it is what
+`e6MinusculeWeight_zero_comp_graphPermE6_notMem_range` denies to the minuscule family alone. -/
+theorem e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm (x : Fin 27 ⊕ Fin 27) (i : Fin 6) :
+    e6DoubledMinusculeWeight (e6DoubledMinusculeGraphPerm x) i =
+      e6DoubledMinusculeWeight x (graphPermE6 i) := by
+  cases x <;> simp [e6MinusculeWeight_e6MinusculeGraphPerm_apply]
 
 end TauCeti.DynkinType

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/MinusculeWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/MinusculeWeight.lean
@@ -27,7 +27,7 @@ immersion, rather than seeing only the index-three root lattice of the adjoint r
 
 The table is *not* stable under the pinned diagram symmetry `TauCeti.graphPermE6`, which exchanges
 `ϖ₁` and `ϖ₆` and so carries the weights of `V(ϖ₁)` to those of `V(ϖ₆) = V(ϖ₁)ˣ`, their negatives.
-The last two sections make that exchange explicit and repair it: `e6MinusculeGraphPerm` is the
+The last two sections make that exchange explicit and repair it: `e6MinusculeGraphDualPerm` is the
 involution of the index set implementing it, and `e6DoubledMinusculeWeight` is the fifty-four-weight
 family of `V(ϖ₁) ⊕ V(ϖ₆)`, which is stable, is still injective, and still spans. A carrier inherits
 a symmetry of its numbered data only when its weight family is equivariant, the hypothesis
@@ -47,9 +47,9 @@ the doubled family being what its graph-twisted family `²E₆(q)` needs where `
 * `TauCeti.DynkinType.e6MinusculeWeight_reflection`: the simple-reflection equation.
 * `TauCeti.DynkinType.range_e6MinusculeWeight`: the table is exactly the Weyl orbit of `ϖ₁`.
 * `TauCeti.DynkinType.span_range_e6MinusculeWeight_eq_top`: the weights span the character lattice.
-* `TauCeti.DynkinType.e6MinusculeGraphPerm`: the involution of the index set induced by the diagram
-  symmetry followed by duality, and
-  `TauCeti.DynkinType.e6MinusculeWeight_e6MinusculeGraphPerm` its defining equation.
+* `TauCeti.DynkinType.e6MinusculeGraphDualPerm`: the involution of the index set induced by the
+  diagram symmetry followed by duality, and
+  `TauCeti.DynkinType.e6MinusculeWeight_e6MinusculeGraphDualPerm` its defining equation.
 * `TauCeti.DynkinType.e6MinusculeWeight_zero_comp_graphPermE6_notMem_range`: the twenty-seven
   weights are not stable under the diagram symmetry.
 * `TauCeti.DynkinType.e6DoubledMinusculeWeight`: the fifty-four weights of `V(ϖ₁) ⊕ V(ϖ₆)`, with
@@ -332,28 +332,34 @@ theorem span_range_e6MinusculeWeight_eq_top :
 
 /-! ## The diagram symmetry on the weight table -/
 
-/-- The index table of `e6MinusculeGraphPerm`, matching each minuscule weight with the one whose
+/-- The index table of `e6MinusculeGraphDualPerm`, matching each minuscule weight with the one whose
 negative is its image under the diagram symmetry. -/
-private def e6MinusculeGraphIndex : Fin 27 → Fin 27 :=
+private def e6MinusculeGraphDualIndex : Fin 27 → Fin 27 :=
   ![26, 25, 24, 23, 22, 21, 19, 20, 17, 18, 15, 16, 12, 13, 14, 10, 11, 8, 9, 6, 7, 5, 4, 3, 2, 1,
     0]
 
-private theorem e6MinusculeGraphIndex_involutive :
-    Function.Involutive e6MinusculeGraphIndex := fun _ => by decide +kernel +revert
+private theorem e6MinusculeGraphDualIndex_involutive :
+    Function.Involutive e6MinusculeGraphDualIndex := fun _ => by decide +kernel +revert
 
-/-- **The permutation of the twenty-seven minuscule weights induced by the `E₆` diagram
-symmetry.** The symmetry `TauCeti.graphPermE6` does not preserve the weight table, so this
-permutation records the composite of that symmetry with duality: it matches the index `a` with the
-index whose weight is the negative of the image of the `a`-th weight. -/
-def e6MinusculeGraphPerm : Equiv.Perm (Fin 27) :=
-  e6MinusculeGraphIndex_involutive.toPerm
+/-- **The permutation of the twenty-seven minuscule weights induced by the `E₆` diagram symmetry
+followed by duality.** The symmetry `TauCeti.graphPermE6` does not preserve the weight table, so
+this permutation records the composite of that symmetry with duality: it matches the index `a` with
+the index whose weight is the negative of the image of the `a`-th weight. -/
+def e6MinusculeGraphDualPerm : Equiv.Perm (Fin 27) :=
+  e6MinusculeGraphDualIndex_involutive.toPerm
 
-/-- The graph permutation of the minuscule weight table is an involution, as the diagram symmetry
-it realizes is. -/
+/-- The graph-and-duality permutation of the minuscule weight table is an involution, as the
+diagram symmetry it realizes is. -/
 @[simp]
-theorem e6MinusculeGraphPerm_apply_apply (a : Fin 27) :
-    e6MinusculeGraphPerm (e6MinusculeGraphPerm a) = a :=
-  e6MinusculeGraphIndex_involutive a
+theorem e6MinusculeGraphDualPerm_apply_apply (a : Fin 27) :
+    e6MinusculeGraphDualPerm (e6MinusculeGraphDualPerm a) = a :=
+  e6MinusculeGraphDualIndex_involutive a
+
+/-- The graph-and-duality permutation of the minuscule weight table is its own inverse. -/
+@[simp]
+theorem e6MinusculeGraphDualPerm_symm :
+    e6MinusculeGraphDualPerm.symm = e6MinusculeGraphDualPerm :=
+  e6MinusculeGraphDualIndex_involutive.toPerm_symm
 
 /-- The node table of `TauCeti.graphPermE6`. The permutation itself lives in another module, so
 the kernel cannot evaluate it while checking the weight table below; this table can be evaluated
@@ -363,29 +369,29 @@ private def e6GraphNode : Fin 6 → Fin 6 := ![5, 1, 4, 3, 2, 0]
 private theorem graphPermE6_apply_eq_e6GraphNode (i : Fin 6) : graphPermE6 i = e6GraphNode i := by
   fin_cases i <;> simp [e6GraphNode]
 
-private theorem e6MinusculeWeight_e6MinusculeGraphIndex_apply (a : Fin 27) (i : Fin 6) :
-    e6MinusculeWeight (e6MinusculeGraphIndex a) i = -e6MinusculeWeight a (e6GraphNode i) := by
+private theorem e6MinusculeWeight_e6MinusculeGraphDualIndex_apply (a : Fin 27) (i : Fin 6) :
+    e6MinusculeWeight (e6MinusculeGraphDualIndex a) i = -e6MinusculeWeight a (e6GraphNode i) := by
   decide +kernel +revert
 
 /-- **The diagram symmetry carries each minuscule weight to the negative of another one.** The
 symmetry exchanges `ϖ₁` and `ϖ₆`, so on representations it carries `V(ϖ₁)` to
 `V(ϖ₆) = V(ϖ₁)ˣ`, whose weights are the negatives of these. -/
-theorem e6MinusculeWeight_e6MinusculeGraphPerm_apply (a : Fin 27) (i : Fin 6) :
-    e6MinusculeWeight (e6MinusculeGraphPerm a) i = -e6MinusculeWeight a (graphPermE6 i) := by
+theorem e6MinusculeWeight_e6MinusculeGraphDualPerm_apply (a : Fin 27) (i : Fin 6) :
+    e6MinusculeWeight (e6MinusculeGraphDualPerm a) i = -e6MinusculeWeight a (graphPermE6 i) := by
   rw [graphPermE6_apply_eq_e6GraphNode]
-  exact e6MinusculeWeight_e6MinusculeGraphIndex_apply a i
+  exact e6MinusculeWeight_e6MinusculeGraphDualIndex_apply a i
 
-/-- The functional form of `e6MinusculeWeight_e6MinusculeGraphPerm_apply`. -/
-theorem e6MinusculeWeight_e6MinusculeGraphPerm (a : Fin 27) :
-    e6MinusculeWeight (e6MinusculeGraphPerm a) = -(e6MinusculeWeight a ∘ graphPermE6) := by
+/-- The functional form of `e6MinusculeWeight_e6MinusculeGraphDualPerm_apply`. -/
+theorem e6MinusculeWeight_e6MinusculeGraphDualPerm (a : Fin 27) :
+    e6MinusculeWeight (e6MinusculeGraphDualPerm a) = -(e6MinusculeWeight a ∘ graphPermE6) := by
   funext i
-  simpa using e6MinusculeWeight_e6MinusculeGraphPerm_apply a i
+  simpa using e6MinusculeWeight_e6MinusculeGraphDualPerm_apply a i
 
 private theorem exists_e6MinusculeWeight_apply_ne_neg (a b : Fin 27) :
     ∃ i, e6MinusculeWeight a i ≠ -e6MinusculeWeight b i := by
   decide +kernel +revert
 
-private theorem e6MinusculeGraphPerm_zero : e6MinusculeGraphPerm 0 = 26 := by
+private theorem e6MinusculeGraphDualPerm_zero : e6MinusculeGraphDualPerm 0 = 26 := by
   decide +kernel
 
 /-- **The twenty-seven minuscule weights are not stable under the diagram symmetry.** The image of
@@ -396,7 +402,7 @@ theorem e6MinusculeWeight_zero_comp_graphPermE6_notMem_range :
   rintro ⟨a, ha⟩
   obtain ⟨i, hi⟩ := exists_e6MinusculeWeight_apply_ne_neg a 26
   have h26 : e6MinusculeWeight 26 i = -e6MinusculeWeight 0 (graphPermE6 i) := by
-    rw [← e6MinusculeGraphPerm_zero, e6MinusculeWeight_e6MinusculeGraphPerm_apply]
+    rw [← e6MinusculeGraphDualPerm_zero, e6MinusculeWeight_e6MinusculeGraphDualPerm_apply]
   -- The assumed witness reads `e6MinusculeWeight a i` as the image of `ϖ₁`, which `h26` reads
   -- back as the negative of the `26`-th weight, contradicting the choice of `i`.
   exact hi (by simp [congrFun ha i, h26])
@@ -453,19 +459,19 @@ theorem span_range_e6DoubledMinusculeWeight_eq_top :
   exact ⟨.inl a, rfl⟩
 
 /-- **The permutation of the doubled index set realizing the `E₆` diagram symmetry.** It exchanges
-the two summands along `e6MinusculeGraphPerm`, which is what makes the doubled weight family
+the two summands along `e6MinusculeGraphDualPerm`, which is what makes the doubled weight family
 equivariant where the minuscule family alone is not. -/
 def e6DoubledMinusculeGraphPerm : Equiv.Perm (Fin 27 ⊕ Fin 27) :=
-  (Equiv.sumCongr e6MinusculeGraphPerm e6MinusculeGraphPerm).trans (Equiv.sumComm _ _)
+  (Equiv.sumCongr e6MinusculeGraphDualPerm e6MinusculeGraphDualPerm).trans (Equiv.sumComm _ _)
 
 @[simp]
 theorem e6DoubledMinusculeGraphPerm_inl (a : Fin 27) :
-    e6DoubledMinusculeGraphPerm (.inl a) = .inr (e6MinusculeGraphPerm a) :=
+    e6DoubledMinusculeGraphPerm (.inl a) = .inr (e6MinusculeGraphDualPerm a) :=
   (rfl)
 
 @[simp]
 theorem e6DoubledMinusculeGraphPerm_inr (a : Fin 27) :
-    e6DoubledMinusculeGraphPerm (.inr a) = .inl (e6MinusculeGraphPerm a) :=
+    e6DoubledMinusculeGraphPerm (.inr a) = .inl (e6MinusculeGraphDualPerm a) :=
   (rfl)
 
 /-- The permutation realizing the diagram symmetry on the doubled index set is an involution. -/
@@ -474,6 +480,13 @@ theorem e6DoubledMinusculeGraphPerm_apply_apply (x : Fin 27 ⊕ Fin 27) :
     e6DoubledMinusculeGraphPerm (e6DoubledMinusculeGraphPerm x) = x := by
   cases x <;> simp
 
+/-- The permutation realizing the diagram symmetry on the doubled index set is its own inverse. -/
+@[simp]
+theorem e6DoubledMinusculeGraphPerm_symm :
+    e6DoubledMinusculeGraphPerm.symm = e6DoubledMinusculeGraphPerm :=
+  Equiv.ext fun x => by
+    rw [Equiv.symm_apply_eq, e6DoubledMinusculeGraphPerm_apply_apply]
+
 /-- **The doubled minuscule weight family is equivariant for the `E₆` diagram symmetry.** This is
 the hypothesis `wt (π i) (τ k) = wt i k` under which a numbered symmetry of a Kostant toral-closure
 carrier extends to an automorphism of the carrier, and it is what
@@ -481,6 +494,6 @@ carrier extends to an automorphism of the carrier, and it is what
 theorem e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm (x : Fin 27 ⊕ Fin 27) (i : Fin 6) :
     e6DoubledMinusculeWeight (e6DoubledMinusculeGraphPerm x) i =
       e6DoubledMinusculeWeight x (graphPermE6 i) := by
-  cases x <;> simp [e6MinusculeWeight_e6MinusculeGraphPerm_apply]
+  cases x <;> simp [e6MinusculeWeight_e6MinusculeGraphDualPerm_apply]
 
 end TauCeti.DynkinType


### PR DESCRIPTION
This PR records how the pinned type-`E₆` diagram symmetry `TauCeti.graphPermE6` acts on the twenty-seven minuscule weights, and supplies the weight family that survives it. `TauCeti.DynkinType.e6MinusculeGraphDualPerm` is the involution of the index set with `e6MinusculeWeight (e6MinusculeGraphDualPerm a) i = -e6MinusculeWeight a (graphPermE6 i)`: the symmetry exchanges `ϖ₁` and `ϖ₆`, so it carries the weights of `V(ϖ₁)` to those of `V(ϖ₆) = V(ϖ₁)ˣ`, their negatives. `e6MinusculeWeight_comp_graphPermE6_notMem_range` is the resulting negative result, that the twenty-seven weights are not a stable family: the symmetry moves every one of them off the table. `e6DoubledMinusculeWeight` then adjoins the negatives, giving the fifty-four weights of `V(ϖ₁) ⊕ V(ϖ₆)`; `e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm` is its equivariance, `e6DoubledMinusculeWeight_injective` and `ncard_range_e6DoubledMinusculeWeight` say the fifty-four are distinct, and `span_range_e6DoubledMinusculeWeight_eq_top` says they still generate the full simply connected character lattice. All three statements are then read on the pinned root datum itself, against `TauCeti.DynkinType.diagramAut`, in `E6/GraphAutomorphism.lean`.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, "The Chevalley--Demazure construction" together with "Pinnings", within the milestone of pinned Chevalley--Demazure group schemes over `ℤ`: the pinned simply connected type-`E₆` carrier that carries the diagram automorphism has to be built from a weight family the diagram automorphism permutes, and the roadmap makes the pinning, hence "the" graph automorphism, data rather than a property.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

Dependency edge: `CFSGStatement` milestone L0, "explicit pinned Chevalley--Demazure groups", needs `ValidLieTypeIndex.AmbientGroup` and `ValidLieTypeIndex.simpleRootSubgroup` on the `twistedE6` constructor, and milestone L1 needs `GraphTwistedIndex.graphAut` there with `γ (x_α(t)) = x_{γ α}(t)`; both consume the ReductiveGroups Layer 9 pinned carrier and its diagram automorphism for the `E₆` diagram. The construction that turns a numbered symmetry of such a carrier into an automorphism of it is `TauCeti.UniversalEnvelopingAlgebra.kostantToralNumberedSymmetryIso`, already on `main`, whose hypothesis on the weight family is exactly `wt (π i) (τ k) = wt i k`. This PR shows the landed twenty-seven-weight minuscule family fails that hypothesis for `τ = graphPermE6` and that the doubled family meets it, so it is the weight-diagram input the `²E₆(q)` branch needs where `E₆(q)` does not. After this PR the `E₆` diagram still needs its admissible doubled lattice and the carrier built from it before L0 can close that branch.

Placement follows the landed parallel case: `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean` makes the same kind of choice for type `D`, using both half-spin parities rather than one, and states it as weight-table data with a spanning theorem. The new material lives in the existing `E6/MinusculeWeight.lean` beside the table it is about, since the twenty-seven-row table is not `@[expose]`d and the kernel computations here need it; the root-datum readings live in `E6/GraphAutomorphism.lean`, which is about that automorphism. One supporting lemma is added at its canonical home rather than locally: `graphPermE6_symm` in `DiagramPermutations.lean`, beside the existing `graphPermD_symm` and `graphPermE6_sq`. The root-datum readings go through the existing `diagramAut_weightMap`.

Nothing here constructs a representation, a lattice, or a group scheme, and nothing asserts that the doubled family is admissible for the Kostant `ℤ`-form; those are the next steps. No Mathlib or Tau Ceti material is vendored. The mathematics follows Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate V for the numbering, and R. W. Carter, *Simple Groups of Lie Type*, §12.2 for the exchange of the two twenty-seven dimensional representations and the `²E₆(q)` conventions it serves.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e6-dual-minuscule-weight"}-->

🤖 Prepared with Claude Code



