### PR TITLE
feat: the trace of the Casimir operator on a weight space

### DIFF
--- a/TauCeti/Algebra/Lie/HighestWeight/Casimir.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Casimir.lean
@@ -7,10 +7,7 @@ module
 
 public import Mathlib.Algebra.CharP.Invertible
 public import TauCeti.Algebra.Lie.HighestWeight.Basic
-public import TauCeti.Algebra.Lie.UniversalEnveloping.Casimir
 public import TauCeti.Algebra.Lie.Weights.Casimir
-public import TauCeti.Algebra.Lie.Weights.InvariantForm
-public import TauCeti.Algebra.Lie.Weights.Projection
 public import TauCeti.LinearAlgebra.RootSystem.Weyl.Vector
 
 import TauCeti.Algebra.Lie.UniversalEnveloping.Module

--- a/TauCeti/Algebra/Lie/HighestWeight/Casimir.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Casimir.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.CharP.Invertible
 public import TauCeti.Algebra.Lie.HighestWeight.Basic
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Casimir
+public import TauCeti.Algebra.Lie.Weights.Casimir
 public import TauCeti.Algebra.Lie.Weights.InvariantForm
 public import TauCeti.Algebra.Lie.Weights.Projection
 public import TauCeti.LinearAlgebra.RootSystem.Weyl.Vector
@@ -70,7 +71,7 @@ Killing-dual basis need. The `U(L)`-action is the algebra homomorphism
 `UniversalEnvelopingAlgebra.lift K (LieModule.toEnd K L M)`.
 
 The weight `λ` is extended from `H` to a linear form on the whole of `L` by pairing with the vector
-representing it under the Killing form (`TauCeti.killingExtend` below). That extension agrees with
+representing it under the Killing form (`TauCeti.killingExtend`). That extension agrees with
 `λ` on `H` and vanishes on every root space, which is what lets the zero-weight term be summed
 without a case distinction on whether the zero functional is a weight at all.
 
@@ -127,107 +128,6 @@ private theorem representation_casimirElement_apply {ι : Type*} [DecidableEq ι
   rw [map_mul, Module.End.mul_apply, UniversalEnvelopingAlgebra.representation_ι,
     UniversalEnvelopingAlgebra.representation_ι, casimirBilin_apply]
   simp
-
-/-! ### Extending a weight to the whole Lie algebra -/
-
-/-- The linear form on `L` obtained by pairing with the vector representing `lam` under the Killing
-form. It agrees with `lam` on `H` (`TauCeti.killingExtend_apply_cartan`) and vanishes on every
-root space of a nonzero weight (`TauCeti.killingExtend_apply_eq_zero`). -/
-private noncomputable def killingExtend (lam : Module.Dual K H) : L →ₗ[K] K :=
-  killingForm K L (((IsKilling.cartanEquivDual H).symm lam : H) : L)
-
-omit [CharZero K] [IsTriangularizable K H L] in
-private theorem killingExtend_apply (lam : Module.Dual K H) (x : L) :
-    killingExtend lam x =
-      killingForm K L (((IsKilling.cartanEquivDual H).symm lam : H) : L) x := (rfl)
-
-omit [CharZero K] [IsTriangularizable K H L] in
-/-- On the Cartan subalgebra the extension is the weight itself. -/
-private theorem killingExtend_apply_cartan (lam : Module.Dual K H) (x : H) :
-    killingExtend lam (x : L) = lam x := by
-  have hres : killingForm K L (((IsKilling.cartanEquivDual H).symm lam : H) : L) (x : L) =
-      traceForm K H L ((IsKilling.cartanEquivDual H).symm lam) x := by
-    rw [← LieAlgebra.restrict_killingForm (R := K) (L := L) H,
-      LinearMap.BilinForm.restrict_apply, LinearMap.domRestrict_apply]
-  rw [killingExtend_apply, hres]
-  conv_rhs => rw [← (IsKilling.cartanEquivDual H).apply_symm_apply lam]
-  rw [IsKilling.cartanEquivDual_apply_apply, traceForm_apply_apply, Module.End.mul_eq_comp]
-
-omit [CharZero K] in
-/-- The extension of a weight vanishes on the root space of a nonzero weight, the Cartan
-subalgebra being the zero root space. -/
-private theorem killingExtend_apply_eq_zero (lam : Module.Dual K H) {χ : Weight K H L}
-    (hχ : χ.IsNonZero) {x : L} (hx : x ∈ rootSpace H (χ : H → K)) : killingExtend lam x = 0 := by
-  refine LieAlgebra.killingForm_apply_eq_zero_of_mem_rootSpace_of_add_ne_zero K L H
-    (α := (0 : H → K)) ?_ hx (by simpa using hχ)
-  rw [LieAlgebra.rootSpace_zero_eq, LieSubalgebra.mem_toLieSubmodule]
-  exact ((IsKilling.cartanEquivDual H).symm lam).2
-
-/-! ### Splitting the Casimir sum along the root spaces -/
-
-omit [CharZero K] in
-/-- Opposite root-space projections are a Killing-adjoint pair. -/
-private theorem isAdjointPair_genWeightSpaceProjection (χ : Weight K H L) :
-    LinearMap.IsAdjointPair (killingForm K L) (killingForm K L)
-      (genWeightSpaceProjection K H L (-χ)) (genWeightSpaceProjection K H L χ) := fun x y ↦ by
-  rw [killingForm_genWeightSpaceProjection H (-χ) x y, neg_neg]
-
-omit [CharZero K] in
-/-- **The Casimir sum splits along the root spaces.** Only the opposite pairs of projections
-survive, because the Killing form pairs the `χ`-root space with the `-χ`-root space alone. -/
-private theorem sum_casimirBilin_eq_sum_weight {ι : Type*} [DecidableEq ι] [Fintype ι]
-    (bs : Module.Basis ι K L) (v : M) :
-    ∑ i, casimirBilin K v (bs i) (killingDualBasis bs i) =
-      ∑ χ : Weight K H L, ∑ i, casimirBilin K v (genWeightSpaceProjection K H L χ (bs i))
-        (genWeightSpaceProjection K H L (-χ) (killingDualBasis bs i)) := by
-  have first : ∀ i, casimirBilin K v (bs i) (killingDualBasis bs i) =
-      ∑ χ : Weight K H L,
-        casimirBilin K v (genWeightSpaceProjection K H L χ (bs i)) (killingDualBasis bs i) := by
-    intro i
-    conv_lhs => rw [← sum_genWeightSpaceProjection_apply (K := K) (L := H) (bs i)]
-    rw [map_sum, LinearMap.sum_apply]
-  rw [Finset.sum_congr rfl fun i _ ↦ first i, Finset.sum_comm]
-  refine Finset.sum_congr rfl fun χ _ ↦ ?_
-  have second : ∀ i, casimirBilin K v (genWeightSpaceProjection K H L χ (bs i))
-      (killingDualBasis bs i) = ∑ ψ : Weight K H L,
-        casimirBilin K v (genWeightSpaceProjection K H L χ (bs i))
-          (genWeightSpaceProjection K H L ψ (killingDualBasis bs i)) := by
-    intro i
-    conv_lhs =>
-      rw [← sum_genWeightSpaceProjection_apply (K := K) (L := H) (killingDualBasis bs i)]
-    rw [map_sum]
-  rw [Finset.sum_congr rfl fun i _ ↦ second i, Finset.sum_comm]
-  refine Finset.sum_eq_single (-χ) (fun ψ _ hψ ↦ ?_) (by simp)
-  have hmove := sum_apply_killingDualBasis_of_isAdjointPair
-    ((casimirBilin K v).comp (genWeightSpaceProjection K H L χ)) bs
-    (isAdjointPair_genWeightSpaceProjection ψ)
-  simp only [LinearMap.comp_apply] at hmove
-  rw [← hmove]
-  refine Finset.sum_eq_zero fun i _ ↦ ?_
-  rw [genWeightSpaceProjection_apply_apply_of_ne (fun hc ↦ hψ (by rw [← hc, neg_neg])), map_zero,
-    LinearMap.zero_apply]
-
-omit [CharZero K] in
-/-- The extension of `lam` sees only the zero weight, so the products of its values on the
-projections of two vectors telescope to the product of its values on the vectors. -/
-private theorem sum_killingExtend_genWeightSpaceProjection_mul (lam : Module.Dual K H) (x y : L) :
-    ∑ χ : Weight K H L, killingExtend lam (genWeightSpaceProjection K H L χ x) *
-        killingExtend lam (genWeightSpaceProjection K H L χ y) =
-      killingExtend lam x * killingExtend lam y := by
-  conv_rhs =>
-    rw [← sum_genWeightSpaceProjection_apply (K := K) (L := H) x,
-      ← sum_genWeightSpaceProjection_apply (K := K) (L := H) y]
-  rw [map_sum, map_sum, Finset.sum_mul_sum]
-  refine Finset.sum_congr rfl fun χ _ ↦ (Finset.sum_eq_single
-    (f := fun ψ : Weight K H L ↦ killingExtend lam (genWeightSpaceProjection K H L χ x) *
-      killingExtend lam (genWeightSpaceProjection K H L ψ y))
-    χ (fun ψ _ hψ ↦ ?_) (fun h ↦ absurd (Finset.mem_univ χ) h)).symm
-  by_cases hχ : χ.IsZero
-  · refine mul_eq_zero_of_right _ (killingExtend_apply_eq_zero lam (χ := ψ) ?_
-      (genWeightSpaceProjection_apply_mem ψ y))
-    exact fun hz ↦ hψ (Weight.ext fun z ↦ by rw [hz.eq, hχ.eq])
-  · exact mul_eq_zero_of_left
-      (killingExtend_apply_eq_zero lam hχ (genWeightSpaceProjection_apply_mem χ x)) _
 
 /-! ### The three kinds of term -/
 
@@ -336,19 +236,12 @@ private theorem representation_casimirElement_apply_eq_sum
     rw [killingExtend_apply_eq_zero lam (H.isNonZero_coe_root ⟨χ, hχ⟩)
       (genWeightSpaceProjection_apply_mem χ (bs i)), zero_mul]
   have hu_total : ∑ χ : Weight K H L, u χ = invForm lam lam := by
-    have hswap : ∑ χ : Weight K H L, u χ = ∑ i, killingExtend lam (bs i) *
-        killingExtend lam (ys i) := by
-      rw [hu, Finset.sum_comm]
-      exact Finset.sum_congr rfl fun i _ ↦
-        sum_killingExtend_genWeightSpaceProjection_mul lam (bs i) (ys i)
-    have hrep := congrArg (killingExtend lam)
-      (sum_killingForm_smul_basis bs (((IsKilling.cartanEquivDual H).symm lam : H) : L))
-    rw [map_sum] at hrep
-    simp only [map_smul, smul_eq_mul, ← killingExtend_apply] at hrep
-    rw [hswap, invForm_apply_apply, ← killingExtend_apply_cartan lam, ← hrep]
-    exact Finset.sum_congr rfl fun i _ ↦ mul_comm _ _
+    rw [hu, Finset.sum_comm, ← sum_killingExtend_mul_killingExtend_killingDualBasis lam bs]
+    exact Finset.sum_congr rfl fun i _ ↦
+      sum_killingExtend_genWeightSpaceProjection_mul lam (bs i) (ys i)
   -- Split the sum over the weights into the zero weight and the roots.
-  rw [representation_casimirElement_apply bs v, sum_casimirBilin_eq_sum_weight (H := H) bs v,
+  rw [representation_casimirElement_apply bs v,
+    sum_apply_killingDualBasis_eq_sum_weight H (casimirBilin K v) bs,
     ← Finset.sum_sdiff (Finset.subset_univ H.root)]
   have hpart_zero : ∑ χ ∈ Finset.univ \ H.root, ∑ i,
       casimirBilin K v (genWeightSpaceProjection K H L χ (bs i))

--- a/TauCeti/Algebra/Lie/Weights/Casimir.lean
+++ b/TauCeti/Algebra/Lie/Weights/Casimir.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Casimir
-public import TauCeti.Algebra.Lie.UniversalEnveloping.Module
 public import TauCeti.Algebra.Lie.Weights.InvariantForm
 public import TauCeti.Algebra.Lie.Weights.Projection
 public import TauCeti.Algebra.Lie.Weights.Trace

--- a/TauCeti/Algebra/Lie/Weights/Casimir.lean
+++ b/TauCeti/Algebra/Lie/Weights/Casimir.lean
@@ -1,0 +1,463 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Casimir
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Module
+public import TauCeti.Algebra.Lie.Weights.InvariantForm
+public import TauCeti.Algebra.Lie.Weights.Projection
+public import TauCeti.Algebra.Lie.Weights.Trace
+
+public section
+
+/-!
+# The trace of the Casimir operator on a weight space
+
+Let `L` be a finite-dimensional Lie algebra with non-degenerate Killing form over an algebraically
+closed field of characteristic zero, let `H` be a splitting Cartan subalgebra, and let `M` be a
+finite-dimensional `L`-module. The Casimir element `Ω ∈ U(L)` is central
+(`TauCeti.casimirElement_mem_center`), so the operator it induces on `M` commutes with the action
+and therefore preserves each weight space `Mμ`. This file computes the trace of its restriction:
+
+```text
+tr_{Mμ}(Ω) = dim Mμ · ⟨μ, μ⟩ + ∑_{α ∈ roots} ∑_{j ≥ 1} dim M_{μ + jα} · ⟨μ + jα, α⟩,
+```
+
+with `⟨·,·⟩` the invariant form `TauCeti.invForm` on `Module.Dual K H`.
+
+## The argument
+
+`TauCeti.casimirElement_eq_sum` evaluates `Ω` against any basis `x` of `L` and its Killing-dual
+basis `y`, so the operator `Ω` acts as `∑ᵢ π(xᵢ) π(yᵢ)`. Inserting the root-space projections of
+`TauCeti/Algebra/Lie/Weights/Projection.lean` into both slots and using that the `χ`- and
+`ψ`-root spaces pair to zero under the Killing form unless `χ + ψ = 0` leaves only the opposite
+pairs `(π_χ, π_{-χ})`; this is `TauCeti.sum_apply_killingDualBasis_eq_sum_weight`, stated for an
+arbitrary bilinear map so that both the operator identity here and the Casimir *eigenvalue* of
+`TauCeti/Algebra/Lie/HighestWeight/Casimir.lean` are instances of it.
+
+Each surviving summand acts by a vector of one root space followed by a vector of the opposite
+root space, so it preserves `Mμ` and is a `TauCeti.raiseLowerEnd` of
+`TauCeti/Algebra/Lie/Weights/Trace.lean`. The two kinds of summand are then read off:
+
+* the summands at a **zero** weight are built from two elements of `H`, which act on `Mμ` by the
+  scalars `μ` gives them (the honest weight spaces of
+  `TauCeti/Algebra/Lie/Weights/Diagonalizable.lean`), so their traces sum to
+  `dim Mμ · ⟨μ, μ⟩`;
+* the summands at a **root** `α` have `⁅x, y⁆ = κ(x, y) α^♯`, and the coefficients `κ(x, y)` sum
+  to the trace `1` of a root-space projection, so the string formula
+  `TauCeti.trace_raiseLowerEnd_eq_sum_weightString_erase_zero` turns their traces into
+  `∑_{j ≥ 1} dim M_{μ + jα} · ⟨μ + jα, α⟩`.
+
+## Main definitions
+
+* `TauCeti.killingExtend`: a weight of `H`, extended to a linear form on `L` by pairing with the
+  vector that represents it under the Killing form.
+* `TauCeti.casimirGenWeightSpaceEnd`: the Casimir operator of `M`, restricted to a generalized
+  weight space.
+
+## Main results
+
+* `TauCeti.sum_apply_killingDualBasis_eq_sum_weight`: a sum along a basis and its Killing-dual
+  basis splits along the opposite pairs of root-space projections.
+* `TauCeti.representation_casimirElement_eq_sum_weight`: the Casimir operator of `M`, split along
+  the root spaces.
+* `TauCeti.representation_casimirElement_mem_genWeightSpace`: the Casimir operator preserves every
+  generalized weight space.
+* `TauCeti.casimirGenWeightSpaceEnd_eq_sum`: the restriction to a weight space, as a sum of
+  raise-lower endomorphisms.
+* `TauCeti.trace_casimirGenWeightSpaceEnd`: **the trace of the Casimir operator on a weight
+  space.**
+
+## References
+
+This is the Casimir half of the "Freudenthal's multiplicity recursion" item of Layer 7 of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`; the string half is
+`TauCeti/Algebra/Lie/Weights/Trace.lean`. Combining the trace computed here with the Casimir
+eigenvalue `⟨λ + ρ, λ + ρ⟩ - ⟨ρ, ρ⟩` of a highest weight module is what produces the recursion
+itself.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §22.3.
+-/
+
+namespace TauCeti
+
+open Finset LieAlgebra LieModule Module
+open LinearMap (trace)
+
+universe u v w
+
+variable {K : Type u} {L : Type v} [Field K] [LieRing L] [LieAlgebra K L]
+  [IsKilling K L] [FiniteDimensional K L]
+  {H : LieSubalgebra K L} [H.IsCartanSubalgebra] [IsTriangularizable K H L]
+  {M : Type w} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+
+/-! ### Splitting a Killing-dual-basis sum along the root spaces -/
+
+/-- **Opposite root-space projections are a Killing-adjoint pair.** This is the
+`LinearMap.IsAdjointPair` form of `TauCeti.killingForm_genWeightSpaceProjection`, which is what
+the Killing-dual-basis lemmas consume. -/
+theorem isAdjointPair_genWeightSpaceProjection (χ : Weight K H L) :
+    LinearMap.IsAdjointPair (killingForm K L) (killingForm K L)
+      (genWeightSpaceProjection K H L (-χ)) (genWeightSpaceProjection K H L χ) := fun x y ↦ by
+  rw [killingForm_genWeightSpaceProjection H (-χ) x y, neg_neg]
+
+variable (H) in
+/-- **A Killing-dual-basis sum splits along the root spaces.** For a bilinear map `f`, the sum
+`∑ᵢ f xᵢ yᵢ` along a basis of `L` and its Killing-dual basis is the sum over the weights `χ` of
+`H` on `L` of the same expression with `π_χ` inserted in the first slot and `π_{-χ}` in the
+second. Only these opposite pairs survive, because the Killing form pairs the `χ`-root space with
+the `-χ`-root space alone. -/
+theorem sum_apply_killingDualBasis_eq_sum_weight {W : Type*} [AddCommGroup W] [Module K W]
+    {ι : Type*} [DecidableEq ι] [Fintype ι] (f : L →ₗ[K] L →ₗ[K] W) (bs : Module.Basis ι K L) :
+    ∑ i, f (bs i) (killingDualBasis bs i) =
+      ∑ χ : Weight K H L, ∑ i, f (genWeightSpaceProjection K H L χ (bs i))
+        (genWeightSpaceProjection K H L (-χ) (killingDualBasis bs i)) := by
+  have first : ∀ i, f (bs i) (killingDualBasis bs i) =
+      ∑ χ : Weight K H L, f (genWeightSpaceProjection K H L χ (bs i)) (killingDualBasis bs i) := by
+    intro i
+    conv_lhs => rw [← sum_genWeightSpaceProjection_apply (K := K) (L := H) (bs i)]
+    rw [map_sum, LinearMap.sum_apply]
+  rw [Finset.sum_congr rfl fun i _ ↦ first i, Finset.sum_comm]
+  refine Finset.sum_congr rfl fun χ _ ↦ ?_
+  have second : ∀ i, f (genWeightSpaceProjection K H L χ (bs i)) (killingDualBasis bs i) =
+      ∑ ψ : Weight K H L, f (genWeightSpaceProjection K H L χ (bs i))
+        (genWeightSpaceProjection K H L ψ (killingDualBasis bs i)) := by
+    intro i
+    conv_lhs =>
+      rw [← sum_genWeightSpaceProjection_apply (K := K) (L := H) (killingDualBasis bs i)]
+    rw [map_sum]
+  rw [Finset.sum_congr rfl fun i _ ↦ second i, Finset.sum_comm]
+  refine Finset.sum_eq_single (-χ) (fun ψ _ hψ ↦ ?_) (by simp)
+  have hmove := sum_apply_killingDualBasis_of_isAdjointPair
+    (f.comp (genWeightSpaceProjection K H L χ)) bs (isAdjointPair_genWeightSpaceProjection ψ)
+  simp only [LinearMap.comp_apply] at hmove
+  rw [← hmove]
+  refine Finset.sum_eq_zero fun i _ ↦ ?_
+  rw [genWeightSpaceProjection_apply_apply_of_ne (fun hc ↦ hψ (by rw [← hc, neg_neg])), map_zero,
+    LinearMap.zero_apply]
+
+variable (K M) in
+/-- The `K`-bilinear map sending `(x, y)` to the endomorphism `m ↦ ⁅x, ⁅y, m⁆⁆` of `M`. It is the
+map through which the Casimir operator is split along the root spaces. -/
+private noncomputable def doubleBracketBilin : L →ₗ[K] L →ₗ[K] Module.End K M :=
+  LinearMap.mk₂ K (fun x y : L ↦ toEnd K L M x * toEnd K L M y)
+    (fun x₁ x₂ y ↦ by rw [map_add, add_mul]) (fun c x y ↦ by rw [map_smul, smul_mul_assoc])
+    (fun x y₁ y₂ ↦ by rw [map_add, mul_add]) (fun c x y ↦ by rw [map_smul, mul_smul_comm])
+
+omit [IsKilling K L] [FiniteDimensional K L] in
+@[simp]
+private theorem doubleBracketBilin_apply (x y : L) :
+    doubleBracketBilin K M x y = toEnd K L M x * toEnd K L M y := (rfl)
+
+variable (H) in
+/-- **The Casimir operator, split along the root spaces.** For any basis `x` of `L` and its
+Killing-dual basis `y`, the operator by which the Casimir element acts on `M` is the sum over the
+weights `χ` of `H` on `L` of `∑ᵢ π(π_χ xᵢ) π(π_{-χ} yᵢ)`. -/
+theorem representation_casimirElement_eq_sum_weight {ι : Type*} [DecidableEq ι] [Fintype ι]
+    (bs : Module.Basis ι K L) :
+    UniversalEnvelopingAlgebra.representation K L M (casimirElement K L) =
+      ∑ χ : Weight K H L, ∑ i, toEnd K L M (genWeightSpaceProjection K H L χ (bs i)) *
+        toEnd K L M (genWeightSpaceProjection K H L (-χ) (killingDualBasis bs i)) := by
+  rw [casimirElement_eq_sum bs, map_sum]
+  simp only [map_mul, UniversalEnvelopingAlgebra.representation_ι]
+  simpa only [doubleBracketBilin_apply] using
+    sum_apply_killingDualBasis_eq_sum_weight H (doubleBracketBilin K M) bs
+
+/-! ### The weight extended to the whole Lie algebra -/
+
+/-- **A weight, extended to a linear form on `L`** by pairing with the vector that represents it
+under the Killing form. It agrees with the weight on `H`
+(`TauCeti.killingExtend_apply_cartan`) and vanishes on every root space of a nonzero weight
+(`TauCeti.killingExtend_apply_eq_zero`), so it sees the zero-weight component of a vector and
+nothing else. -/
+noncomputable def killingExtend (lam : Module.Dual K H) : L →ₗ[K] K :=
+  killingForm K L (((IsKilling.cartanEquivDual H).symm lam : H) : L)
+
+omit [IsTriangularizable K H L] in
+/-- The defining formula of the extension: pairing with the vector that represents the weight. -/
+theorem killingExtend_apply (lam : Module.Dual K H) (x : L) :
+    killingExtend lam x =
+      killingForm K L (((IsKilling.cartanEquivDual H).symm lam : H) : L) x := (rfl)
+
+omit [IsTriangularizable K H L] in
+/-- On the Cartan subalgebra the extension is the weight itself. -/
+@[simp]
+theorem killingExtend_apply_cartan (lam : Module.Dual K H) (x : H) :
+    killingExtend lam (x : L) = lam x := by
+  have hres : killingForm K L (((IsKilling.cartanEquivDual H).symm lam : H) : L) (x : L) =
+      traceForm K H L ((IsKilling.cartanEquivDual H).symm lam) x := by
+    rw [← LieAlgebra.restrict_killingForm (R := K) (L := L) H,
+      LinearMap.BilinForm.restrict_apply, LinearMap.domRestrict_apply]
+  rw [killingExtend_apply, hres]
+  conv_rhs => rw [← (IsKilling.cartanEquivDual H).apply_symm_apply lam]
+  rw [IsKilling.cartanEquivDual_apply_apply, traceForm_apply_apply, Module.End.mul_eq_comp]
+
+/-- The extension of a weight vanishes on the root space of a nonzero weight, the Cartan
+subalgebra being the zero root space. -/
+theorem killingExtend_apply_eq_zero (lam : Module.Dual K H) {χ : Weight K H L}
+    (hχ : χ.IsNonZero) {x : L} (hx : x ∈ rootSpace H (χ : H → K)) : killingExtend lam x = 0 := by
+  refine LieAlgebra.killingForm_apply_eq_zero_of_mem_rootSpace_of_add_ne_zero K L H
+    (α := (0 : H → K)) ?_ hx (by simpa using hχ)
+  rw [LieAlgebra.rootSpace_zero_eq, LieSubalgebra.mem_toLieSubmodule]
+  exact ((IsKilling.cartanEquivDual H).symm lam).2
+
+/-- **The extension of a weight sees only the zero weight**, so the products of its values on the
+root-space projections of two vectors telescope to the product of its values on the vectors. -/
+theorem sum_killingExtend_genWeightSpaceProjection_mul (lam : Module.Dual K H) (x y : L) :
+    ∑ χ : Weight K H L, killingExtend lam (genWeightSpaceProjection K H L χ x) *
+        killingExtend lam (genWeightSpaceProjection K H L χ y) =
+      killingExtend lam x * killingExtend lam y := by
+  conv_rhs =>
+    rw [← sum_genWeightSpaceProjection_apply (K := K) (L := H) x,
+      ← sum_genWeightSpaceProjection_apply (K := K) (L := H) y]
+  rw [map_sum, map_sum, Finset.sum_mul_sum]
+  refine Finset.sum_congr rfl fun χ _ ↦ (Finset.sum_eq_single
+    (f := fun ψ : Weight K H L ↦ killingExtend lam (genWeightSpaceProjection K H L χ x) *
+      killingExtend lam (genWeightSpaceProjection K H L ψ y))
+    χ (fun ψ _ hψ ↦ ?_) (fun h ↦ absurd (Finset.mem_univ χ) h)).symm
+  by_cases hχ : χ.IsZero
+  · refine mul_eq_zero_of_right _ (killingExtend_apply_eq_zero lam (χ := ψ) ?_
+      (genWeightSpaceProjection_apply_mem ψ y))
+    exact fun hz ↦ hψ (Weight.ext fun z ↦ by rw [hz.eq, hχ.eq])
+  · exact mul_eq_zero_of_left
+      (killingExtend_apply_eq_zero lam hχ (genWeightSpaceProjection_apply_mem χ x)) _
+
+omit [IsTriangularizable K H L] in
+/-- **The squared length of a weight, read along a Killing-dual pair of bases.** The extension of
+`lam` is the pairing with the vector representing `lam`, so expanding that vector in the basis
+gives `⟨lam, lam⟩`. -/
+theorem sum_killingExtend_mul_killingExtend_killingDualBasis {ι : Type*} [DecidableEq ι]
+    [Fintype ι] (lam : Module.Dual K H) (bs : Module.Basis ι K L) :
+    ∑ i, killingExtend lam (bs i) * killingExtend lam (killingDualBasis bs i) =
+      invForm lam lam := by
+  have hrep := congrArg (killingExtend lam)
+    (sum_killingForm_smul_basis bs (((IsKilling.cartanEquivDual H).symm lam : H) : L))
+  rw [map_sum] at hrep
+  simp only [map_smul, smul_eq_mul, ← killingExtend_apply] at hrep
+  rw [invForm_apply_apply, ← killingExtend_apply_cartan lam, ← hrep]
+  exact Finset.sum_congr rfl fun i _ ↦ mul_comm _ _
+
+/-! ### The Casimir operator on a weight space -/
+
+omit [IsTriangularizable K H L] in
+/-- **The Casimir operator preserves every generalized weight space.** It commutes with the Lie
+action (`TauCeti.representation_casimirElement_lie`), hence with every power of
+`toEnd x - mu x`. -/
+theorem representation_casimirElement_mem_genWeightSpace {mu : H → K} {m : M}
+    (hm : m ∈ genWeightSpace M mu) :
+    UniversalEnvelopingAlgebra.representation K L M (casimirElement K L) m ∈
+      genWeightSpace M mu := by
+  have hcomm : ∀ x : H, Commute (toEnd K H M x - mu x • (1 : Module.End K M))
+      (UniversalEnvelopingAlgebra.representation K L M (casimirElement K L)) := by
+    intro x
+    have h : Commute (toEnd K H M x)
+        (UniversalEnvelopingAlgebra.representation K L M (casimirElement K L)) :=
+      LinearMap.ext fun z ↦ (representation_casimirElement_lie (x : L) z).symm
+    exact h.sub_left ((Commute.one_left _).smul_left _)
+  rw [LieModule.mem_genWeightSpace] at hm ⊢
+  intro x
+  obtain ⟨k, hk⟩ := hm x
+  refine ⟨k, ?_⟩
+  calc ((toEnd K H M x - mu x • (1 : Module.End K M)) ^ k)
+        (UniversalEnvelopingAlgebra.representation K L M (casimirElement K L) m)
+      = (((toEnd K H M x - mu x • (1 : Module.End K M)) ^ k) *
+          UniversalEnvelopingAlgebra.representation K L M (casimirElement K L)) m :=
+        (Module.End.mul_apply _ _ _).symm
+    _ = (UniversalEnvelopingAlgebra.representation K L M (casimirElement K L) *
+          ((toEnd K H M x - mu x • (1 : Module.End K M)) ^ k)) m := by rw [(hcomm x).pow_left k]
+    _ = 0 := by rw [Module.End.mul_apply, hk, map_zero]
+
+variable (M) in
+/-- **The Casimir operator of a weight space**: the operator by which the Casimir element acts on
+`M`, restricted to the generalized `mu`-weight space, which it preserves. -/
+noncomputable def casimirGenWeightSpaceEnd (mu : H → K) : Module.End K (genWeightSpace M mu) :=
+  LinearMap.restrict (UniversalEnvelopingAlgebra.representation K L M (casimirElement K L))
+    fun _ hm ↦ representation_casimirElement_mem_genWeightSpace hm
+
+omit [IsTriangularizable K H L] in
+/-- The Casimir operator of a weight space is the restriction of the Casimir operator of `M`. -/
+@[simp]
+theorem coe_casimirGenWeightSpaceEnd_apply {mu : H → K} (m : genWeightSpace M mu) :
+    (casimirGenWeightSpaceEnd M mu m : M) =
+      UniversalEnvelopingAlgebra.representation K L M (casimirElement K L) (m : M) := (rfl)
+
+variable (H) in
+/-- **The Casimir operator of a weight space, split along the root spaces.** Each summand raises
+by a vector of the `χ`-root space and lowers by one of the `-χ`-root space, so it is a
+`TauCeti.raiseLowerEnd`. -/
+theorem casimirGenWeightSpaceEnd_eq_sum {ι : Type*} [DecidableEq ι] [Fintype ι]
+    (bs : Module.Basis ι K L) (mu : H → K) :
+    casimirGenWeightSpaceEnd M mu =
+      ∑ χ : Weight K H L, ∑ i,
+        raiseLowerEnd M (genWeightSpaceProjection_apply_mem χ (killingDualBasis bs i))
+          (genWeightSpaceProjection_apply_mem (-χ) (bs i)) mu := by
+  have hswap : ∑ χ : Weight K H L, ∑ i,
+      toEnd K L M (genWeightSpaceProjection K H L χ (bs i)) *
+        toEnd K L M (genWeightSpaceProjection K H L (-χ) (killingDualBasis bs i)) =
+      ∑ χ : Weight K H L, ∑ i,
+        toEnd K L M (genWeightSpaceProjection K H L (-χ) (bs i)) *
+          toEnd K L M (genWeightSpaceProjection K H L χ (killingDualBasis bs i)) := by
+    refine (Fintype.sum_equiv (Equiv.neg (Weight K H L)) _ _ fun χ ↦ ?_).symm
+    simp only [Equiv.neg_apply, neg_neg]
+  ext m
+  have hval := DFunLike.congr_fun (representation_casimirElement_eq_sum_weight (M := M) H bs)
+    (m : M)
+  rw [hswap] at hval
+  simp only [LinearMap.sum_apply, Module.End.mul_apply, toEnd_apply_apply] at hval
+  simpa only [coe_casimirGenWeightSpaceEnd_apply, LinearMap.sum_apply,
+    AddSubmonoidClass.coe_finsetSum, coe_raiseLowerEnd_apply] using hval
+
+/-! ### The two kinds of summand -/
+
+section Trace
+
+variable [CharZero K] [IsAlgClosed K] [FiniteDimensional K M]
+
+omit [IsTriangularizable K H L] in
+/-- **The zero-weight summands are scalars.** A raise-lower endomorphism built from two elements
+of the Cartan subalgebra acts on the `mu`-weight space by the scalar `mu` gives them, because the
+weight spaces are honest simultaneous eigenspaces. -/
+theorem trace_raiseLowerEnd_of_eq_zero {mu : Module.Dual K H} {alpha : H → K} (halpha : alpha = 0)
+    {x y : L} (hx : x ∈ rootSpace H alpha) (hy : y ∈ rootSpace H (-alpha)) :
+    trace K _ (raiseLowerEnd M hx hy (mu : H → K)) =
+      finrank K (genWeightSpace M (mu : H → K)) • (killingExtend mu x * killingExtend mu y) := by
+  subst halpha
+  have hxH : x ∈ H := by
+    rwa [LieAlgebra.rootSpace_zero_eq, LieSubalgebra.mem_toLieSubmodule] at hx
+  have hyH : y ∈ H := by
+    rwa [neg_zero, LieAlgebra.rootSpace_zero_eq, LieSubalgebra.mem_toLieSubmodule] at hy
+  have key : raiseLowerEnd M hx hy (mu : H → K) =
+      (killingExtend mu x * killingExtend mu y) • LinearMap.id := by
+    refine LinearMap.ext fun m ↦ Subtype.ext ?_
+    have hm := mem_genWeightSpace_iff_forall_lie_eq_smul.mp m.2
+    rw [coe_raiseLowerEnd_apply, hm ⟨x, hxH⟩, lie_smul, hm ⟨y, hyH⟩, smul_smul,
+      killingExtend_apply_cartan mu ⟨x, hxH⟩, killingExtend_apply_cartan mu ⟨y, hyH⟩]
+    simp
+  rw [key, map_smul, LinearMap.trace_id, smul_eq_mul, nsmul_eq_mul, mul_comm]
+
+omit [IsAlgClosed K] in
+/-- **The summands at a root sum to a string sum.** Each summand at the root `chi` lowers and
+raises by root vectors whose bracket is a multiple of the vector representing `chi`, so the string
+formula applies; the multiples sum to the trace `1` of a root-space projection. -/
+theorem sum_trace_raiseLowerEnd_of_ne_zero {ι : Type*} [DecidableEq ι] [Fintype ι]
+    (bs : Module.Basis ι K L) {chi : Weight K H L} (hchi : (chi : Module.Dual K H) ≠ 0)
+    (mu : Module.Dual K H) :
+    ∑ i, trace K _ (raiseLowerEnd M
+        (genWeightSpaceProjection_apply_mem chi (killingDualBasis bs i))
+        (genWeightSpaceProjection_apply_mem (-chi) (bs i)) (mu : H → K)) =
+      ∑ j ∈ (weightString M hchi mu).erase 0,
+        finrank K (genWeightSpace M ((mu + j • (chi : Module.Dual K H) : Module.Dual K H) : H → K))
+          • invForm (mu + j • (chi : Module.Dual K H)) (chi : Module.Dual K H) := by
+  set alpha : Module.Dual K H := (chi : Module.Dual K H) with halpha
+  set c : ι → K := fun i ↦ killingForm K L (genWeightSpaceProjection K H L chi
+    (killingDualBasis bs i)) (genWeightSpaceProjection K H L (-chi) (bs i)) with hc
+  -- The bracket of the two root vectors is `c i` times the vector representing `chi`.
+  have hstep : ∀ i, trace K _ (raiseLowerEnd M
+      (genWeightSpaceProjection_apply_mem chi (killingDualBasis bs i))
+      (genWeightSpaceProjection_apply_mem (-chi) (bs i)) (mu : H → K)) =
+      ∑ j ∈ (weightString M hchi mu).erase 0,
+        finrank K (genWeightSpace M ((mu + j • alpha : Module.Dual K H) : H → K))
+          • (c i * invForm (mu + j • alpha) alpha) := by
+    intro i
+    have hz : ⁅genWeightSpaceProjection K H L chi (killingDualBasis bs i),
+        genWeightSpaceProjection K H L (-chi) (bs i)⁆ =
+        ((c i • (IsKilling.cartanEquivDual H).symm alpha : H) : L) := by
+      rw [IsKilling.lie_eq_killingForm_smul_of_mem_rootSpace_of_mem_rootSpace_neg
+        (genWeightSpaceProjection_apply_mem chi (killingDualBasis bs i))
+        (genWeightSpaceProjection_apply_mem (-chi) (bs i))]
+      simp [hc, halpha]
+    refine (trace_raiseLowerEnd_eq_sum_weightString_erase_zero (M := M) hchi
+      (genWeightSpaceProjection_apply_mem chi (killingDualBasis bs i))
+      (genWeightSpaceProjection_apply_mem (-chi) (bs i)) hz).trans
+      (Finset.sum_congr rfl fun j _ ↦ ?_)
+    rw [map_smul, smul_eq_mul, invForm_apply_apply]
+  -- The coefficients sum to the trace of the projection onto the `-chi`-root space, which is `1`.
+  have hcsum : ∑ i, c i = 1 := by
+    have hnz : (-chi).IsNonZero := by
+      intro h
+      apply hchi
+      rw [halpha]
+      exact Weight.coe_toLinear_eq_zero_iff.mpr (by simpa using h.neg)
+    have hcoef : ∀ i, c i = killingForm K L (genWeightSpaceProjection K H L (-chi) (bs i))
+        (killingDualBasis bs i) := by
+      intro i
+      have h1 : killingForm K L (genWeightSpaceProjection K H L (-chi) (bs i))
+          (killingDualBasis bs i) =
+          killingForm K L (genWeightSpaceProjection K H L (-chi) (bs i))
+            (genWeightSpaceProjection K H L chi (killingDualBasis bs i)) := by
+        conv_lhs => rw [← genWeightSpaceProjection_apply_apply (-chi) (bs i)]
+        rw [killingForm_genWeightSpaceProjection H (-chi), neg_neg]
+      simp only [hc, h1]
+      apply LieModule.traceForm_comm
+    rw [Finset.sum_congr rfl fun i _ ↦ hcoef i, sum_killingForm_killingDualBasis_eq_trace,
+      trace_genWeightSpaceProjection_eq_one H hnz]
+  rw [Finset.sum_congr rfl fun i _ ↦ hstep i, Finset.sum_comm]
+  refine Finset.sum_congr rfl fun j _ ↦ ?_
+  rw [← Finset.smul_sum, ← Finset.sum_mul, hcsum, one_mul]
+
+/-! ### The trace -/
+
+omit [IsKilling K L] [IsAlgClosed K] [IsTriangularizable K H L] in
+/-- A root, read as a linear form on the Cartan subalgebra, is nonzero. -/
+theorem coe_root_ne_zero (a : H.root) : ((a : Weight K H L) : Module.Dual K H) ≠ 0 :=
+  Weight.coe_toLinear_ne_zero_iff.mpr (H.isNonZero_coe_root a)
+
+variable (M) in
+/-- **The trace of the Casimir operator on a weight space.** For a finite-dimensional module `M`
+over a Killing-semisimple Lie algebra and a linear form `mu` on the Cartan subalgebra, the trace
+of the Casimir operator on the `mu`-weight space of `M` is
+
+`dim M_mu ⟨mu, mu⟩ + ∑_{α ∈ roots} ∑_{j ≥ 1} dim M_{mu + jα} ⟨mu + jα, α⟩`.
+
+The inner sums are over the `α`-strings above `mu` with the bottom rung removed, which is where
+the terms with a zero weight space are already absent. -/
+theorem trace_casimirGenWeightSpaceEnd (mu : Module.Dual K H) :
+    trace K _ (casimirGenWeightSpaceEnd M (mu : H → K)) =
+      finrank K (genWeightSpace M (mu : H → K)) • invForm mu mu +
+        ∑ a : H.root, ∑ j ∈ (weightString M (coe_root_ne_zero a) mu).erase 0,
+          finrank K (genWeightSpace M ((mu + j • ((a : Weight K H L) : Module.Dual K H) :
+              Module.Dual K H) : H → K))
+            • invForm (mu + j • ((a : Weight K H L) : Module.Dual K H))
+              ((a : Weight K H L) : Module.Dual K H) := by
+  classical
+  set bs := Module.finBasis K L
+  set u : Weight K H L → K := fun chi ↦ ∑ i,
+    killingExtend mu (genWeightSpaceProjection K H L chi (killingDualBasis bs i)) *
+      killingExtend mu (genWeightSpaceProjection K H L chi (bs i)) with hu
+  -- `u` vanishes at every root, and its total over all weights is `⟨mu, mu⟩`.
+  have hu_root : ∀ chi ∈ H.root, u chi = 0 := fun chi hchi ↦
+    Finset.sum_eq_zero fun i _ ↦ mul_eq_zero_of_left (killingExtend_apply_eq_zero mu
+      (H.isNonZero_coe_root ⟨chi, hchi⟩)
+      (genWeightSpaceProjection_apply_mem chi (killingDualBasis bs i))) _
+  have hu_total : ∑ chi : Weight K H L, u chi = invForm mu mu := by
+    rw [hu, Finset.sum_comm, ← sum_killingExtend_mul_killingExtend_killingDualBasis mu bs]
+    exact Finset.sum_congr rfl fun i _ ↦ by
+      rw [sum_killingExtend_genWeightSpaceProjection_mul, mul_comm]
+  rw [casimirGenWeightSpaceEnd_eq_sum H bs]
+  simp only [map_sum]
+  rw [← Finset.sum_sdiff (Finset.subset_univ H.root)]
+  congr 1
+  · -- The zero weight contributes `dim M_mu ⟨mu, mu⟩`.
+    have hzero : ∀ chi ∈ Finset.univ \ H.root, ∑ i, trace K _ (raiseLowerEnd M
+        (genWeightSpaceProjection_apply_mem chi (killingDualBasis bs i))
+        (genWeightSpaceProjection_apply_mem (-chi) (bs i)) (mu : H → K)) =
+        finrank K (genWeightSpace M (mu : H → K)) • u chi := by
+      intro chi hchi
+      have hz : chi.IsZero := not_not.mp (by simpa [LieSubalgebra.root] using
+        (Finset.mem_sdiff.mp hchi).2)
+      have hneg : -chi = chi := Weight.ext fun z ↦ by simp [hz.eq]
+      rw [hu, Finset.smul_sum]
+      refine Finset.sum_congr rfl fun i _ ↦ ?_
+      rw [trace_raiseLowerEnd_of_eq_zero hz.eq, hneg]
+    rw [Finset.sum_congr rfl hzero, ← Finset.smul_sum, ← hu_total,
+      ← Finset.sum_sdiff (Finset.subset_univ H.root), Finset.sum_eq_zero hu_root, add_zero]
+  · rw [← Finset.sum_coe_sort H.root]
+    exact Finset.sum_congr rfl fun a _ ↦ sum_trace_raiseLowerEnd_of_ne_zero bs
+      (coe_root_ne_zero a) mu
+
+end Trace
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Weights/Casimir.lean
+++ b/TauCeti/Algebra/Lie/Weights/Casimir.lean
@@ -23,10 +23,13 @@ finite-dimensional `L`-module. The Casimir element `Ω ∈ U(L)` is central
 and therefore preserves each weight space `Mμ`. This file computes the trace of its restriction:
 
 ```text
-tr_{Mμ}(Ω) = dim Mμ · ⟨μ, μ⟩ + ∑_{α ∈ roots} ∑_{j ≥ 1} dim M_{μ + jα} · ⟨μ + jα, α⟩,
+tr_{Mμ}(Ω) = dim Mμ · ⟨μ, μ⟩
+  + ∑_{α ∈ roots} ∑_{j ∈ weightString(M, α, μ) \ {0}} dim M_{μ + jα} · ⟨μ + jα, α⟩,
 ```
 
-with `⟨·,·⟩` the invariant form `TauCeti.invForm` on `Module.Dual K H`.
+with `⟨·,·⟩` the invariant form `TauCeti.invForm` on `Module.Dual K H` and `weightString(M, α, μ)`
+the `α`-string above `μ` of `TauCeti.weightString`, a `Finset ℕ` whose index `j = 0` is the `μ`
+rung itself.
 
 ## The argument
 
@@ -49,12 +52,10 @@ root space, so it preserves `Mμ` and is a `TauCeti.raiseLowerEnd` of
 * the summands at a **root** `α` have `⁅x, y⁆ = κ(x, y) α^♯`, and the coefficients `κ(x, y)` sum
   to the trace `1` of a root-space projection, so the string formula
   `TauCeti.trace_raiseLowerEnd_eq_sum_weightString_erase_zero` turns their traces into
-  `∑_{j ≥ 1} dim M_{μ + jα} · ⟨μ + jα, α⟩`.
+  `∑_{j ∈ weightString(M, α, μ) \ {0}} dim M_{μ + jα} · ⟨μ + jα, α⟩`.
 
 ## Main definitions
 
-* `TauCeti.killingExtend`: a weight of `H`, extended to a linear form on `L` by pairing with the
-  vector that represents it under the Killing form.
 * `TauCeti.casimirGenWeightSpaceEnd`: the Casimir operator of `M`, restricted to a generalized
   weight space.
 
@@ -96,14 +97,6 @@ variable {K : Type u} {L : Type v} [Field K] [LieRing L] [LieAlgebra K L]
 
 /-! ### Splitting a Killing-dual-basis sum along the root spaces -/
 
-/-- **Opposite root-space projections are a Killing-adjoint pair.** This is the
-`LinearMap.IsAdjointPair` form of `TauCeti.killingForm_genWeightSpaceProjection`, which is what
-the Killing-dual-basis lemmas consume. -/
-theorem isAdjointPair_genWeightSpaceProjection (χ : Weight K H L) :
-    LinearMap.IsAdjointPair (killingForm K L) (killingForm K L)
-      (genWeightSpaceProjection K H L (-χ)) (genWeightSpaceProjection K H L χ) := fun x y ↦ by
-  rw [killingForm_genWeightSpaceProjection H (-χ) x y, neg_neg]
-
 variable (H) in
 /-- **A Killing-dual-basis sum splits along the root spaces.** For a bilinear map `f`, the sum
 `∑ᵢ f xᵢ yᵢ` along a basis of `L` and its Killing-dual basis is the sum over the weights `χ` of
@@ -132,7 +125,7 @@ theorem sum_apply_killingDualBasis_eq_sum_weight {W : Type*} [AddCommGroup W] [M
   rw [Finset.sum_congr rfl fun i _ ↦ second i, Finset.sum_comm]
   refine Finset.sum_eq_single (-χ) (fun ψ _ hψ ↦ ?_) (by simp)
   have hmove := sum_apply_killingDualBasis_of_isAdjointPair
-    (f.comp (genWeightSpaceProjection K H L χ)) bs (isAdjointPair_genWeightSpaceProjection ψ)
+    (f.comp (genWeightSpaceProjection K H L χ)) bs (isAdjointPair_genWeightSpaceProjection H ψ)
   simp only [LinearMap.comp_apply] at hmove
   rw [← hmove]
   refine Finset.sum_eq_zero fun i _ ↦ ?_
@@ -166,43 +159,11 @@ theorem representation_casimirElement_eq_sum_weight {ι : Type*} [DecidableEq ι
   simpa only [doubleBracketBilin_apply] using
     sum_apply_killingDualBasis_eq_sum_weight H (doubleBracketBilin K M) bs
 
-/-! ### The weight extended to the whole Lie algebra -/
+/-! ### Sums built from the extended weight
 
-/-- **A weight, extended to a linear form on `L`** by pairing with the vector that represents it
-under the Killing form. It agrees with the weight on `H`
-(`TauCeti.killingExtend_apply_cartan`) and vanishes on every root space of a nonzero weight
-(`TauCeti.killingExtend_apply_eq_zero`), so it sees the zero-weight component of a vector and
-nothing else. -/
-noncomputable def killingExtend (lam : Module.Dual K H) : L →ₗ[K] K :=
-  killingForm K L (((IsKilling.cartanEquivDual H).symm lam : H) : L)
-
-omit [IsTriangularizable K H L] in
-/-- The defining formula of the extension: pairing with the vector that represents the weight. -/
-theorem killingExtend_apply (lam : Module.Dual K H) (x : L) :
-    killingExtend lam x =
-      killingForm K L (((IsKilling.cartanEquivDual H).symm lam : H) : L) x := (rfl)
-
-omit [IsTriangularizable K H L] in
-/-- On the Cartan subalgebra the extension is the weight itself. -/
-@[simp]
-theorem killingExtend_apply_cartan (lam : Module.Dual K H) (x : H) :
-    killingExtend lam (x : L) = lam x := by
-  have hres : killingForm K L (((IsKilling.cartanEquivDual H).symm lam : H) : L) (x : L) =
-      traceForm K H L ((IsKilling.cartanEquivDual H).symm lam) x := by
-    rw [← LieAlgebra.restrict_killingForm (R := K) (L := L) H,
-      LinearMap.BilinForm.restrict_apply, LinearMap.domRestrict_apply]
-  rw [killingExtend_apply, hres]
-  conv_rhs => rw [← (IsKilling.cartanEquivDual H).apply_symm_apply lam]
-  rw [IsKilling.cartanEquivDual_apply_apply, traceForm_apply_apply, Module.End.mul_eq_comp]
-
-/-- The extension of a weight vanishes on the root space of a nonzero weight, the Cartan
-subalgebra being the zero root space. -/
-theorem killingExtend_apply_eq_zero (lam : Module.Dual K H) {χ : Weight K H L}
-    (hχ : χ.IsNonZero) {x : L} (hx : x ∈ rootSpace H (χ : H → K)) : killingExtend lam x = 0 := by
-  refine LieAlgebra.killingForm_apply_eq_zero_of_mem_rootSpace_of_add_ne_zero K L H
-    (α := (0 : H → K)) ?_ hx (by simpa using hχ)
-  rw [LieAlgebra.rootSpace_zero_eq, LieSubalgebra.mem_toLieSubmodule]
-  exact ((IsKilling.cartanEquivDual H).symm lam).2
+The extension `TauCeti.killingExtend` of a weight to a linear form on `L` lives in
+`TauCeti/Algebra/Lie/Weights/InvariantForm.lean`; the two sums below are the ones that need the
+root-space projections and the Killing-dual basis as well. -/
 
 /-- **The extension of a weight sees only the zero weight**, so the products of its values on the
 root-space projections of two vectors telescope to the product of its values on the vectors. -/
@@ -400,24 +361,21 @@ theorem sum_trace_raiseLowerEnd_of_ne_zero {ι : Type*} [DecidableEq ι] [Fintyp
 
 /-! ### The trace -/
 
-omit [IsKilling K L] [IsAlgClosed K] [IsTriangularizable K H L] in
-/-- A root, read as a linear form on the Cartan subalgebra, is nonzero. -/
-theorem coe_root_ne_zero (a : H.root) : ((a : Weight K H L) : Module.Dual K H) ≠ 0 :=
-  Weight.coe_toLinear_ne_zero_iff.mpr (H.isNonZero_coe_root a)
-
 variable (M) in
 /-- **The trace of the Casimir operator on a weight space.** For a finite-dimensional module `M`
 over a Killing-semisimple Lie algebra and a linear form `mu` on the Cartan subalgebra, the trace
 of the Casimir operator on the `mu`-weight space of `M` is
 
-`dim M_mu ⟨mu, mu⟩ + ∑_{α ∈ roots} ∑_{j ≥ 1} dim M_{mu + jα} ⟨mu + jα, α⟩`.
+`dim M_mu ⟨mu, mu⟩ + ∑_{α ∈ roots} ∑_{j ∈ weightString(M, α, mu) \ {0}} dim M_{mu + jα}
+⟨mu + jα, α⟩`.
 
-The inner sums are over the `α`-strings above `mu` with the bottom rung removed, which is where
-the terms with a zero weight space are already absent. -/
+The inner sums run over the `α`-string above `mu` (`TauCeti.weightString`, a `Finset ℕ`) with the
+`mu` rung `j = 0` removed, which is where the terms with a zero weight space are already absent. -/
 theorem trace_casimirGenWeightSpaceEnd (mu : Module.Dual K H) :
     trace K _ (casimirGenWeightSpaceEnd M (mu : H → K)) =
       finrank K (genWeightSpace M (mu : H → K)) • invForm mu mu +
-        ∑ a : H.root, ∑ j ∈ (weightString M (coe_root_ne_zero a) mu).erase 0,
+        ∑ a : H.root, ∑ j ∈ (weightString M
+            (Weight.coe_toLinear_ne_zero_iff.mpr (H.isNonZero_coe_root a)) mu).erase 0,
           finrank K (genWeightSpace M ((mu + j • ((a : Weight K H L) : Module.Dual K H) :
               Module.Dual K H) : H → K))
             • invForm (mu + j • ((a : Weight K H L) : Module.Dual K H))
@@ -456,7 +414,7 @@ theorem trace_casimirGenWeightSpaceEnd (mu : Module.Dual K H) :
       ← Finset.sum_sdiff (Finset.subset_univ H.root), Finset.sum_eq_zero hu_root, add_zero]
   · rw [← Finset.sum_coe_sort H.root]
     exact Finset.sum_congr rfl fun a _ ↦ sum_trace_raiseLowerEnd_of_ne_zero bs
-      (coe_root_ne_zero a) mu
+      (Weight.coe_toLinear_ne_zero_iff.mpr (H.isNonZero_coe_root a)) mu
 
 end Trace
 

--- a/TauCeti/Algebra/Lie/Weights/InvariantForm.lean
+++ b/TauCeti/Algebra/Lie/Weights/InvariantForm.lean
@@ -40,6 +40,8 @@ that can be stated.
 * `TauCeti.rootInvariantForm`: `invForm` packaged as an invariant form on the root system
   `LieAlgebra.IsKilling.rootSystem H`, which makes Mathlib's `RootPairing.InvariantForm` API
   available for it.
+* `TauCeti.killingExtend`: a weight, extended to a linear form on `L` by pairing with the vector
+  that represents it under the Killing form.
 
 ## Main results
 
@@ -54,6 +56,9 @@ that can be stated.
   `⟨λ, α^∨⟩ ⟨α, α⟩ = 2 ⟨λ, α⟩`.
 * `TauCeti.traceForm_coroot_self_mul_invForm_self_eq_four`: `⟨α^∨, α^∨⟩ ⟨α, α⟩ = 4`, so a long
   root has a short coroot.
+* `TauCeti.killingExtend_apply_cartan` and `TauCeti.killingExtend_apply_eq_zero`: the extension of
+  a weight is the weight itself on `H` and vanishes on every root space of a nonzero weight, so it
+  sees the zero-weight component of a vector and nothing else.
 
 The compatibility with `LieAlgebra.IsKilling.rootSystem_pairing_apply` — that a Cartan integer is
 `2 ⟨α, β⟩ / ⟨β, β⟩` — and the orthogonality criterion and reflection invariance of the form are not
@@ -165,6 +170,42 @@ theorem cartanEquivDual_coroot (α : Weight K H L) :
   ext x
   simpa [invForm_apply_apply, Weight.toLinear_apply, mul_assoc, traceForm_apply_apply,
     Module.End.mul_eq_comp] using traceForm_coroot α x
+
+/-! ## A weight, extended to the Lie algebra -/
+
+/-- **A weight, extended to a linear form on `L`** by pairing with the vector that represents it
+under the Killing form. It agrees with the weight on `H`
+(`TauCeti.killingExtend_apply_cartan`) and vanishes on every root space of a nonzero weight
+(`TauCeti.killingExtend_apply_eq_zero`), so it sees the zero-weight component of a vector and
+nothing else. -/
+noncomputable def killingExtend (lam : Module.Dual K H) : L →ₗ[K] K :=
+  killingForm K L (((cartanEquivDual H).symm lam : H) : L)
+
+/-- The defining formula of the extension: pairing with the vector that represents the weight. -/
+theorem killingExtend_apply (lam : Module.Dual K H) (x : L) :
+    killingExtend lam x = killingForm K L (((cartanEquivDual H).symm lam : H) : L) x := (rfl)
+
+/-- On the Cartan subalgebra the extension is the weight itself. -/
+@[simp]
+theorem killingExtend_apply_cartan (lam : Module.Dual K H) (x : H) :
+    killingExtend lam (x : L) = lam x := by
+  have hres : killingForm K L (((cartanEquivDual H).symm lam : H) : L) (x : L) =
+      traceForm K H L ((cartanEquivDual H).symm lam) x := by
+    rw [← LieAlgebra.restrict_killingForm (R := K) (L := L) H,
+      LinearMap.BilinForm.restrict_apply, LinearMap.domRestrict_apply]
+  rw [killingExtend_apply, hres]
+  conv_rhs => rw [← (cartanEquivDual H).apply_symm_apply lam]
+  rw [cartanEquivDual_apply_apply, traceForm_apply_apply, Module.End.mul_eq_comp]
+
+/-- The extension of a weight vanishes on the root space of a nonzero weight, the Cartan
+subalgebra being the zero root space. -/
+theorem killingExtend_apply_eq_zero [LieModule.IsTriangularizable K H L] (lam : Module.Dual K H)
+    {χ : Weight K H L} (hχ : χ.IsNonZero) {x : L} (hx : x ∈ rootSpace H (χ : H → K)) :
+    killingExtend lam x = 0 := by
+  refine LieAlgebra.killingForm_apply_eq_zero_of_mem_rootSpace_of_add_ne_zero K L H
+    (α := (0 : H → K)) ?_ hx (by simpa using hχ)
+  rw [LieAlgebra.rootSpace_zero_eq, LieSubalgebra.mem_toLieSubmodule]
+  exact ((cartanEquivDual H).symm lam).2
 
 /-! ## Roots and coroots -/
 

--- a/TauCeti/Algebra/Lie/Weights/Projection.lean
+++ b/TauCeti/Algebra/Lie/Weights/Projection.lean
@@ -36,7 +36,8 @@ space, which for a root is `1`.
 
 * `TauCeti.sum_genWeightSpaceProjection_apply`: the projections sum to the identity.
 * `TauCeti.killingForm_genWeightSpaceProjection`: `κ (π_χ x) y = κ x (π_{-χ} y)`, so `π_χ` and
-  `π_{-χ}` are Killing-adjoint.
+  `π_{-χ}` are Killing-adjoint; `TauCeti.isAdjointPair_genWeightSpaceProjection` says the same in
+  the `LinearMap.IsAdjointPair` form.
 * `TauCeti.trace_genWeightSpaceProjection`: the trace of a projection is the dimension of the
   weight space it projects onto.
 
@@ -219,6 +220,14 @@ theorem killingForm_genWeightSpaceProjection (χ : Weight K H L) (x y : L) :
   exact killingForm_apply_eq_zero_of_mem_rootSpace_of_add_ne_zero K L H
     (genWeightSpaceProjection_apply_mem ψ x) (genWeightSpaceProjection_apply_mem (-χ) y)
     (weight_add_ne_zero H fun hc ↦ h (by rwa [neg_neg] at hc))
+
+/-- **Opposite root-space projections are a Killing-adjoint pair.** This is the
+`LinearMap.IsAdjointPair` form of `TauCeti.killingForm_genWeightSpaceProjection`, which is what
+the Killing-dual-basis lemmas consume. -/
+theorem isAdjointPair_genWeightSpaceProjection (χ : Weight K H L) :
+    LinearMap.IsAdjointPair (killingForm K L) (killingForm K L)
+      (genWeightSpaceProjection K H L (-χ)) (genWeightSpaceProjection K H L χ) := fun x y ↦ by
+  rw [killingForm_genWeightSpaceProjection H (-χ) x y, neg_neg]
 
 /-- **A root-space projection has trace one.** The root spaces at nonzero weights are lines
 (`LieAlgebra.IsKilling.finrank_rootSpace_eq_one`). -/


### PR DESCRIPTION
This PR computes the trace of the Casimir operator on a weight space. For a finite-dimensional module `M` over a Lie algebra `L` with non-degenerate Killing form over an algebraically closed field of characteristic zero, with `H` a splitting Cartan subalgebra and `mu` a linear form on `H`, the Casimir element `Ω ∈ U(L)` preserves the `mu`-weight space and

```text
tr_{M_mu}(Ω) = dim M_mu ⟨mu, mu⟩ + ∑_{α ∈ roots} ∑_{j ≥ 1} dim M_{mu + jα} ⟨mu + jα, α⟩,
```

where `⟨·,·⟩` is the invariant form `TauCeti.invForm` and the inner sums run over the `α`-string above `mu` with its bottom rung removed (`TauCeti.trace_casimirGenWeightSpaceEnd`).

This serves the "Freudenthal's multiplicity formula" milestone of Layer 7 of `RepresentationTheory/LieHighestWeight/README.md`, which asks for `freudenthal_multiplicity_formula` and directs that it be proved "from the Casimir eigenvalue and the `sl₂`-string action of each `⟨eₐ, hₐ, fₐ⟩` on the weight spaces". TauCeti#5213 supplied the string action, as the trace of a raise-lower endomorphism along a weight string; this PR supplies the Casimir side and joins the two. What remains for the milestone is to substitute the Casimir eigenvalue `⟨λ+ρ, λ+ρ⟩ - ⟨ρ, ρ⟩` of a highest weight module for the left-hand side and to fold the sum over all roots into a sum over the positive ones, using the symmetry of each root string.

The route is the classical one. `TauCeti.casimirElement_eq_sum` evaluates `Ω` against any basis of `L` and its Killing-dual basis; inserting the root-space projections into both slots leaves only the opposite pairs `(π_χ, π_{-χ})`, because the Killing form pairs the `χ`-root space with the `-χ`-root space alone. Each surviving summand raises by a root vector and lowers by an opposite one, so it preserves the weight space and is a `TauCeti.raiseLowerEnd`. The zero-weight summands are built from two elements of `H`, which act on the weight space by the scalars `mu` gives them, and contribute `dim M_mu ⟨mu, mu⟩`; the summands at a root `α` have `⁅x, y⁆ = κ(x, y) α^♯` with the coefficients summing to the trace `1` of a root-space projection, so the string formula turns them into `∑_{j ≥ 1} dim M_{mu + jα} ⟨mu + jα, α⟩`.

The splitting of a Killing-dual-basis sum along the root spaces, and the extension `TauCeti.killingExtend` of a weight to a linear form on `L`, were private to `TauCeti/Algebra/Lie/HighestWeight/Casimir.lean`, where they compute the Casimir eigenvalue on a highest weight vector. They are the same machinery this trace computation needs, so they move to the new file as public declarations, stated for an arbitrary bilinear map rather than for the one the eigenvalue argument uses; the eigenvalue file now consumes them and its private copies are deleted.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"casimir-trace-weight-space"}-->

🤖 Prepared with Claude Code
