### PR TITLE
feat: define central isogenies

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
@@ -81,19 +81,18 @@ of `Spec H`.
 
 Commuting with the points over `A` alone is a strictly weaker condition and does not describe a
 subgroup scheme; this is why the value algebra is quantified over. The quantified value algebras
-live in the same universe `Type w` as `A`. When the coordinate and value algebras are in the same
-universe,
-`TauCeti.HopfAlgebra.isCentralPoint_iff_commute_includeRight` shows that the single value algebra
-`A ⊗[R] H` already decides centrality. -/
+live in `Type (max v w)`, which contains the universal test algebra `A ⊗[R] H`.
+`TauCeti.HopfAlgebra.isCentralPoint_iff_commute_includeRight` shows, when the coordinate and value
+algebras are in the same universe, that this single value algebra already decides centrality. -/
 def IsCentralPoint (g : WithConv (H →ₐ[R] A)) : Prop :=
-  ∀ ⦃B : Type w⦄ [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
+  ∀ ⦃B : Type (max v w)⦄ [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
     (h : WithConv (H →ₐ[R] B)),
     Commute (AlgHom.mapValue φ g) h
 
 /-- Centrality, restated as the defining condition. -/
 theorem isCentralPoint_def (g : WithConv (H →ₐ[R] A)) :
     IsCentralPoint g ↔
-      ∀ ⦃B : Type w⦄ [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
+      ∀ ⦃B : Type (max v w)⦄ [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
         (h : WithConv (H →ₐ[R] B)),
         Commute (AlgHom.mapValue φ g) h :=
   Iff.rfl
@@ -101,11 +100,19 @@ theorem isCentralPoint_def (g : WithConv (H →ₐ[R] A)) :
 /-- A central point commutes with every point over its own value algebra. -/
 theorem IsCentralPoint.commute {g : WithConv (H →ₐ[R] A)} (hg : IsCentralPoint g)
     (h : WithConv (H →ₐ[R] A)) : Commute g h := by
-  simpa using hg (AlgHom.id R A) h
+  let e : A ≃ₐ[R] ULift.{v} A := ULift.algEquiv.symm
+  have hc := hg e.toAlgHom (AlgHom.mapValue e.toAlgHom h)
+  have hc' := hc.map (AlgHom.mapValue (H := H) e.symm.toAlgHom)
+  have hback (x : WithConv (H →ₐ[R] A)) :
+      AlgHom.mapValue (H := H) e.symm.toAlgHom (AlgHom.mapValue e.toAlgHom x) = x := by
+    apply ofConv_injective
+    ext a
+    simp [AlgHom.mapValue_apply, e]
+  simpa only [hback] using hc'
 
 /-- Centrality is preserved by change of value algebra. -/
 theorem IsCentralPoint.mapValue {g : WithConv (H →ₐ[R] A)} (hg : IsCentralPoint g)
-    {B : Type w} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B) :
+    {B : Type (max v w)} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B) :
     IsCentralPoint (AlgHom.mapValue φ g) := by
   intro C _ _ ψ h
   rw [← MonoidHom.comp_apply, ← AlgHom.mapValue_comp]
@@ -208,7 +215,8 @@ noncomputable instance instIsMulCommutativeCenter : IsMulCommutative (center R H
   IsMulCommutative.of_setLike_mul_comm fun _ ha b _ ↦ ((mem_center.mp ha).commute b).eq
 
 /-- The center is natural in the value algebra. -/
-theorem mapValue_mem_center {B : Type w} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
+theorem mapValue_mem_center {B : Type (max v w)} [CommRing B] [Algebra R B]
+    (φ : A →ₐ[R] B)
     {g : WithConv (H →ₐ[R] A)} (hg : g ∈ center R H A) :
     AlgHom.mapValue φ g ∈ center R H B :=
   (mem_center.mp hg).mapValue φ

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
@@ -68,11 +68,11 @@ namespace TauCeti
 
 namespace HopfAlgebra
 
-universe u v
+universe u v w
 
 section Definition
 
-variable {R : Type u} {H : Type v} {A : Type v}
+variable {R : Type u} {H : Type v} {A : Type w}
 variable [CommRing R] [Ring H] [_root_.Bialgebra R H] [CommRing A] [Algebra R A]
 
 /-- A point `g` of `Spec H` with values in `A` is **central** when, for every `R`-algebra map
@@ -80,17 +80,21 @@ variable [CommRing R] [Ring H] [_root_.Bialgebra R H] [CommRing A] [Algebra R A]
 of `Spec H`.
 
 Commuting with the points over `A` alone is a strictly weaker condition and does not describe a
-subgroup scheme; this is why the value algebra is quantified over. Restricting the quantifier to
-`Type v` loses nothing: `TauCeti.HopfAlgebra.isCentralPoint_iff_commute_includeRight` shows that
-the single value algebra `A ⊗[R] H` already decides centrality. -/
+subgroup scheme; this is why the value algebra is quantified over. The quantified value algebras
+live in the same universe `Type w` as `A`. When the coordinate and value algebras are in the same
+universe,
+`TauCeti.HopfAlgebra.isCentralPoint_iff_commute_includeRight` shows that the single value algebra
+`A ⊗[R] H` already decides centrality. -/
 def IsCentralPoint (g : WithConv (H →ₐ[R] A)) : Prop :=
-  ∀ ⦃B : Type v⦄ [CommRing B] [Algebra R B] (φ : A →ₐ[R] B) (h : WithConv (H →ₐ[R] B)),
+  ∀ ⦃B : Type w⦄ [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
+    (h : WithConv (H →ₐ[R] B)),
     Commute (AlgHom.mapValue φ g) h
 
 /-- Centrality, restated as the defining condition. -/
 theorem isCentralPoint_def (g : WithConv (H →ₐ[R] A)) :
     IsCentralPoint g ↔
-      ∀ ⦃B : Type v⦄ [CommRing B] [Algebra R B] (φ : A →ₐ[R] B) (h : WithConv (H →ₐ[R] B)),
+      ∀ ⦃B : Type w⦄ [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
+        (h : WithConv (H →ₐ[R] B)),
         Commute (AlgHom.mapValue φ g) h :=
   Iff.rfl
 
@@ -101,7 +105,7 @@ theorem IsCentralPoint.commute {g : WithConv (H →ₐ[R] A)} (hg : IsCentralPoi
 
 /-- Centrality is preserved by change of value algebra. -/
 theorem IsCentralPoint.mapValue {g : WithConv (H →ₐ[R] A)} (hg : IsCentralPoint g)
-    {B : Type v} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B) :
+    {B : Type w} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B) :
     IsCentralPoint (AlgHom.mapValue φ g) := by
   intro C _ _ ψ h
   rw [← MonoidHom.comp_apply, ← AlgHom.mapValue_comp]
@@ -167,7 +171,7 @@ end Definition
 
 section Group
 
-variable {R : Type u} {H : Type v} {A : Type v}
+variable {R : Type u} {H : Type v} {A : Type w}
 variable [CommRing R] [Ring H] [_root_.HopfAlgebra R H] [CommRing A] [Algebra R A]
 
 /-- The inverse of a central point is central. -/
@@ -204,7 +208,7 @@ noncomputable instance instIsMulCommutativeCenter : IsMulCommutative (center R H
   IsMulCommutative.of_setLike_mul_comm fun _ ha b _ ↦ ((mem_center.mp ha).commute b).eq
 
 /-- The center is natural in the value algebra. -/
-theorem mapValue_mem_center {B : Type v} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
+theorem mapValue_mem_center {B : Type w} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
     {g : WithConv (H →ₐ[R] A)} (hg : g ∈ center R H A) :
     AlgHom.mapValue φ g ∈ center R H B :=
   (mem_center.mp hg).mapValue φ

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -69,7 +69,7 @@ open TensorProduct WithConv
 
 namespace TauCeti
 
-universe u v
+universe u v w
 
 namespace HopfIdeal
 
@@ -142,7 +142,7 @@ variable {R : Type u} [CommRing R]
 /-- Every point cut out by a central Hopf ideal is a central point of the ambient group, over
 every value algebra. -/
 theorem isCentralPoint_of_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
-    (I : HopfIdeal R H) (hI : I.IsCentral) (A : CommAlgCat.{v} R)
+    (I : HopfIdeal R H) (hI : I.IsCentral) (A : CommAlgCat.{w} R)
     {g : HopfAlgebra.points (R := R) (H := H) A} (hg : g ∈ quotientPointsSubgroup H I A) :
     HopfAlgebra.IsCentralPoint g := by
   rw [HopfAlgebra.isCentralPoint_def]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Kernel.Basic
 
@@ -25,8 +24,6 @@ functors.
 
 * `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff`: the points-level kernel
   property.
-* `TauCeti.CommHopfAlgCat.isCentralPoint_of_isCentral_kernelHopfIdeal_of_mapPoints_eq_one`:
-  a point in a central kernel is central.
 -/
 
 public section
@@ -74,15 +71,6 @@ theorem mapPointsFunctor_app_eq_one_iff (f : H ⟶ K) (A : CommAlgCat.{w} R)
     ext a
     simp only [AlgHom.comp_apply, Algebra.ofId_apply, Bialgebra.counitAlgHom_apply]
     exact (AlgHom.convOne_apply a).symm
-
-/-- Every point in the kernel of a morphism with central kernel Hopf ideal is central in its
-source group. -/
-theorem isCentralPoint_of_isCentral_kernelHopfIdeal_of_mapPoints_eq_one
-    {f : H ⟶ K} (hf : (kernelHopfIdeal f).IsCentral) (A : CommAlgCat.{w} R)
-    (g : HopfAlgebra.points (R := R) (H := K) A)
-    (hg : (mapPointsFunctor f).app A g = 1) : HopfAlgebra.IsCentralPoint g := by
-  apply isCentralPoint_of_mem_quotientPointsSubgroup K (kernelHopfIdeal f) hf A
-  exact (mapPointsFunctor_app_eq_one_iff f A g).mp hg
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
@@ -25,7 +25,7 @@ functors.
 
 * `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff`: the points-level kernel
   property.
-* `TauCeti.CommHopfAlgCat.isCentralPoint_of_mapPoints_eq_one_of_isCentral_kernelHopfIdeal`:
+* `TauCeti.CommHopfAlgCat.isCentralPoint_of_isCentral_kernelHopfIdeal_of_mapPoints_eq_one`:
   a point in a central kernel is central.
 -/
 
@@ -77,8 +77,8 @@ theorem mapPointsFunctor_app_eq_one_iff (f : H ⟶ K) (A : CommAlgCat.{w} R)
 
 /-- Every point in the kernel of a morphism with central kernel Hopf ideal is central in its
 source group. -/
-theorem isCentralPoint_of_mapPoints_eq_one_of_isCentral_kernelHopfIdeal
-    {f : H ⟶ K} (hf : (kernelHopfIdeal f).IsCentral) (A : CommAlgCat.{v} R)
+theorem isCentralPoint_of_isCentral_kernelHopfIdeal_of_mapPoints_eq_one
+    {f : H ⟶ K} (hf : (kernelHopfIdeal f).IsCentral) (A : CommAlgCat.{w} R)
     (g : HopfAlgebra.points (R := R) (H := K) A)
     (hg : (mapPointsFunctor f).app A g = 1) : HopfAlgebra.IsCentralPoint g := by
   apply isCentralPoint_of_mem_quotientPointsSubgroup K (kernelHopfIdeal f) hf A

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Kernel.Basic
 
@@ -24,6 +25,8 @@ functors.
 
 * `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff`: the points-level kernel
   property.
+* `TauCeti.CommHopfAlgCat.isCentralPoint_of_mapPoints_eq_one_of_isCentral_kernelHopfIdeal`:
+  a point in a central kernel is central.
 -/
 
 public section
@@ -32,11 +35,11 @@ open CategoryTheory WithConv
 
 namespace TauCeti
 
-universe u w
+universe u v w
 
 namespace CommHopfAlgCat
 
-variable {R : Type u} [CommRing R] {H K : _root_.CommHopfAlgCat.{u} R}
+variable {R : Type u} [CommRing R] {H K : _root_.CommHopfAlgCat.{v} R}
 
 /-- Kernel semantics on functors of points: for every commutative `R`-algebra `A`, an
 `A`-point of the source is sent to the unit point exactly when it lies in the subgroup of
@@ -71,6 +74,15 @@ theorem mapPointsFunctor_app_eq_one_iff (f : H ⟶ K) (A : CommAlgCat.{w} R)
     ext a
     simp only [AlgHom.comp_apply, Algebra.ofId_apply, Bialgebra.counitAlgHom_apply]
     exact (AlgHom.convOne_apply a).symm
+
+/-- Every point in the kernel of a morphism with central kernel Hopf ideal is central in its
+source group. -/
+theorem isCentralPoint_of_mapPoints_eq_one_of_isCentral_kernelHopfIdeal
+    {f : H ⟶ K} (hf : (kernelHopfIdeal f).IsCentral) (A : CommAlgCat.{v} R)
+    (g : HopfAlgebra.points (R := R) (H := K) A)
+    (hg : (mapPointsFunctor f).app A g = 1) : HopfAlgebra.IsCentralPoint g := by
+  apply isCentralPoint_of_mem_quotientPointsSubgroup K (kernelHopfIdeal f) hf A
+  exact (mapPointsFunctor_app_eq_one_iff f A g).mp hg
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Basic.lean
@@ -83,6 +83,19 @@ theorem mem_kernelHopfIdeal_of_mem_augmentation (f : H ⟶ K) {x : H}
     (hx : Coalgebra.counit (R := R) x = 0) : f.hom x ∈ kernelHopfIdeal f :=
   HopfIdeal.mem_map_of_mem f.hom ((HopfIdeal.mem_augmentation R H).mpr hx)
 
+/-- The kernel Hopf ideal of a surjective coordinate morphism is the augmentation ideal.
+This applies in particular to isomorphisms and identifies their group-scheme kernel with the
+trivial subgroup. -/
+theorem kernelHopfIdeal_eq_augmentation_of_surjective (f : H ⟶ K)
+    (hf : Function.Surjective f.hom) :
+    kernelHopfIdeal f = HopfIdeal.augmentation R K := by
+  apply le_antisymm
+    (HopfIdeal.le_augmentation (R := R) K (kernelHopfIdeal f)) fun y hy ↦ ?_
+  obtain ⟨x, rfl⟩ := hf y
+  rw [HopfIdeal.mem_augmentation] at hy
+  apply mem_kernelHopfIdeal_of_mem_augmentation f
+  simpa only [CoalgHomClass.counit_comp_apply] using hy
+
 -- Mathlib has no application lemma for `Bialgebra.unitBialgHom`; this contains its
 -- definitional unfolding to `algebraMap` in one place (upstream candidate).
 private lemma unitBialgHom_apply {A : Type*} [Semiring A] [Bialgebra R A] (r : R) :

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.FaithfullyFlatPoints
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel
 
 /-!
@@ -72,12 +71,6 @@ is represented by the quotient of `K` by `kernelHopfIdeal f`, so centrality is i
 that Hopf ideal. -/
 def IsCentralIsogeny (f : H ⟶ K) : Prop :=
   IsIsogeny f ∧ (kernelHopfIdeal f).IsCentral
-
-/-- Restatement of the coordinate-algebra conditions defining an isogeny. -/
-theorem isIsogeny_iff (f : H ⟶ K) :
-    IsIsogeny f ↔
-      f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat :=
-  Iff.rfl
 
 /-- Restatement of the coordinate-algebra conditions defining a central isogeny. -/
 theorem isCentralIsogeny_iff (f : H ⟶ K) :
@@ -203,10 +196,10 @@ variable {H₀ K₀ : _root_.CommHopfAlgCat.{v} R} {f₀ : H₀ ⟶ K₀}
 /-- Every point in the kernel of a central isogeny is central in its source group. This is
 the functor-of-points meaning of the central-kernel condition. -/
 theorem IsCentralIsogeny.isCentralPoint_of_mapPoints_eq_one
-    (hf : IsCentralIsogeny f₀) (A : CommAlgCat.{v} R)
+    (hf : IsCentralIsogeny f₀) (A : CommAlgCat.{w} R)
     (g : HopfAlgebra.points (R := R) (H := K₀) A)
     (hg : (mapPointsFunctor f₀).app A g = 1) : HopfAlgebra.IsCentralPoint g := by
-  exact isCentralPoint_of_mapPoints_eq_one_of_isCentral_kernelHopfIdeal
+  exact isCentralPoint_of_isCentral_kernelHopfIdeal_of_mapPoints_eq_one
     hf.isCentral_kernelHopfIdeal A g hg
 
 end KernelPoints

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.FaithfullyFlatPoints
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel
+public import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Coordinate
 
 /-!
 # Isogenies of affine group schemes
@@ -26,6 +27,10 @@ surjectivity by a weaker statement about points over the base field.
 
 * `TauCeti.CommHopfAlgCat.IsIsogeny`: a finite faithfully flat coordinate morphism.
 * `TauCeti.CommHopfAlgCat.IsCentralIsogeny`: an isogeny with central kernel Hopf ideal.
+* `TauCeti.CommHopfAlgCat.isIsogeny_iff_isIsogeny_hopfSpec_map`: the coordinate and
+  group-scheme definitions agree over a field.
+* `TauCeti.CommHopfAlgCat.isCentralIsogeny_iff_isCentralIsogeny_hopfSpec_map`: the analogous
+  bridge for central isogenies.
 * `TauCeti.CommHopfAlgCat.IsIsogeny.mapPointsFunctor_app_surjective`: an isogeny is
   surjective on points over algebraically closed fields.
 * `TauCeti.CommHopfAlgCat.IsCentralIsogeny.isCentralPoint_of_mapPoints_eq_one`: every
@@ -78,6 +83,39 @@ theorem isCentralIsogeny_iff (f : H ⟶ K) :
       f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat ∧
         (kernelHopfIdeal f).IsCentral := by
   rw [IsCentralIsogeny, IsIsogeny, and_assoc]
+
+section Field
+
+variable {k : Type u} [Field k] {H₀ K₀ : _root_.CommHopfAlgCat.{u} k}
+
+/-- Over a field, the coordinate-algebra definition of an isogeny agrees with the existing
+group-scheme definition after applying the contravariant Hopf spectrum functor. -/
+theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
+    IsIsogeny f ↔
+      GroupScheme.IsIsogeny
+        ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op) := by
+  rw [IsIsogeny, GroupScheme.isIsogeny_iff]
+  change f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat ↔
+    AlgebraicGeometry.IsFinite
+      (AlgebraicGeometry.Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ∧
+    AlgebraicGeometry.Flat
+      (AlgebraicGeometry.Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ∧
+    AlgebraicGeometry.Surjective
+      (AlgebraicGeometry.Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))
+  rw [AlgebraicGeometry.IsFinite.SpecMap_iff,
+    AlgebraicGeometry.flat_and_surjective_SpecMap_iff]
+  rfl
+
+/-- Over a field, the coordinate-algebra definition of a central isogeny agrees with the
+existing group-scheme definition after applying the contravariant Hopf spectrum functor. -/
+theorem isCentralIsogeny_iff_isCentralIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
+    IsCentralIsogeny f ↔
+      GroupScheme.IsCentralIsogeny
+        ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op) := by
+  rw [IsCentralIsogeny, GroupScheme.isCentralIsogeny_hopfSpec_map_iff,
+    isIsogeny_iff_isIsogeny_hopfSpec_map]
+
+end Field
 
 namespace IsIsogeny
 
@@ -169,6 +207,20 @@ theorem isCentralIsogeny_of_bijective (f : H ⟶ K) (hf : Function.Bijective f.h
   rw [kernelHopfIdeal_eq_augmentation_of_surjective f hf.2]
   exact isCentral_augmentation K
 
+/-- The structure morphism from a finite faithfully flat commutative affine group scheme to the
+trivial group is a central isogeny. Its kernel is the whole source group, so nontrivial choices of
+`K` give central isogenies with nontrivial kernel. -/
+theorem isCentralIsogeny_unit_of_isCocomm (K : _root_.CommHopfAlgCat.{u} R)
+    [Module.Finite R K] [Module.FaithfullyFlat R K] [Coalgebra.IsCocomm R K] :
+    IsCentralIsogeny
+      (CommHopfAlgCat.ofHom (Bialgebra.unitBialgHom R K)) := by
+  refine ⟨⟨?_, ?_⟩, ?_⟩
+  · change (algebraMap R K).Finite
+    exact RingHom.finite_algebraMap.mpr inferInstance
+  · change (algebraMap R K).FaithfullyFlat
+    exact RingHom.faithfullyFlat_algebraMap_iff.mpr inferInstance
+  · exact (HopfIdeal.isCentral_bot_iff_isCocomm.mpr inferInstance).mono bot_le
+
 /-- Every categorical isomorphism of commutative Hopf algebras is an isogeny. -/
 theorem isIsogeny_of_isIso (f : H ⟶ K) [IsIso f] : IsIsogeny f :=
   isIsogeny_of_bijective f (ConcreteCategory.bijective_of_isIso f)
@@ -199,8 +251,9 @@ theorem IsCentralIsogeny.isCentralPoint_of_mapPoints_eq_one
     (hf : IsCentralIsogeny f₀) (A : CommAlgCat.{w} R)
     (g : HopfAlgebra.points (R := R) (H := K₀) A)
     (hg : (mapPointsFunctor f₀).app A g = 1) : HopfAlgebra.IsCentralPoint g := by
-  exact isCentralPoint_of_isCentral_kernelHopfIdeal_of_mapPoints_eq_one
-    hf.isCentral_kernelHopfIdeal A g hg
+  apply isCentralPoint_of_mem_quotientPointsSubgroup K₀ (kernelHopfIdeal f₀)
+    hf.isCentral_kernelHopfIdeal A
+  exact (mapPointsFunctor_app_eq_one_iff f₀ A g).mp hg
 
 end KernelPoints
 

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.FaithfullyFlatPoints
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel
 public import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Coordinate
 
 /-!
@@ -33,8 +32,6 @@ surjectivity by a weaker statement about points over the base field.
   bridge for central isogenies.
 * `TauCeti.CommHopfAlgCat.IsIsogeny.mapPointsFunctor_app_surjective`: an isogeny is
   surjective on points over algebraically closed fields.
-* `TauCeti.CommHopfAlgCat.IsCentralIsogeny.isCentralPoint_of_mapPoints_eq_one`: every
-  point in the kernel of a central isogeny is central.
 * `TauCeti.CommHopfAlgCat.isCentralIsogeny_of_isIso`: every isomorphism is a central
   isogeny.
 
@@ -244,23 +241,5 @@ theorem IsIsogeny.mapPointsFunctor_app_surjective (hf : IsIsogeny f)
     (F : Type w) [Field F] [Algebra R F] [IsAlgClosed F] :
     Function.Surjective ((mapPointsFunctor f).app (CommAlgCat.of R F)) :=
   mapPointsFunctor_app_surjective_of_faithfullyFlat F f hf.finiteType hf.faithfullyFlat
-
-section KernelPoints
-
-variable {H₀ K₀ : _root_.CommHopfAlgCat.{v} R} {f₀ : H₀ ⟶ K₀}
-
-/-- Every point in the kernel of a central isogeny is central in its source group. This is
-the functor-of-points meaning of the central-kernel condition. For a morphism assumed only to have
-central kernel, combine `mapPointsFunctor_app_eq_one_iff` with
-`isCentralPoint_of_mem_quotientPointsSubgroup`. -/
-theorem IsCentralIsogeny.isCentralPoint_of_mapPoints_eq_one
-    (hf : IsCentralIsogeny f₀) (A : CommAlgCat.{w} R)
-    (g : HopfAlgebra.points (R := R) (H := K₀) A)
-    (hg : (mapPointsFunctor f₀).app A g = 1) : HopfAlgebra.IsCentralPoint g := by
-  apply isCentralPoint_of_mem_quotientPointsSubgroup K₀ (kernelHopfIdeal f₀)
-    hf.isCentral_kernelHopfIdeal A
-  exact (mapPointsFunctor_app_eq_one_iff f₀ A g).mp hg
-
-end KernelPoints
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -95,6 +95,8 @@ theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
       GroupScheme.IsIsogeny
         ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op) := by
   rw [IsIsogeny, GroupScheme.isIsogeny_iff]
+  -- The underlying scheme morphism of `hopfSpec.map f.op` reduces definitionally to the
+  -- `Spec.map` induced by the underlying ring homomorphism of `f`.
   change f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat ↔
     AlgebraicGeometry.IsFinite
       (AlgebraicGeometry.Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ∧
@@ -215,6 +217,8 @@ theorem isCentralIsogeny_unit_of_isCocomm (K : _root_.CommHopfAlgCat.{u} R)
     IsCentralIsogeny
       (CommHopfAlgCat.ofHom (Bialgebra.unitBialgHom R K)) := by
   refine ⟨⟨?_, ?_⟩, ?_⟩
+  -- Mathlib has no lemma identifying the ring-hom carrier of `unitBialgHom`; both goals
+  -- reduce definitionally to the corresponding properties of the algebra map.
   · change (algebraMap R K).Finite
     exact RingHom.finite_algebraMap.mpr inferInstance
   · change (algebraMap R K).FaithfullyFlat

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -38,6 +38,10 @@ surjectivity by a weaker statement about points over the base field.
 
 * J. S. Milne, *Algebraic Groups* (2017), Definition 2.20 and §23.
 
+The isogeny and central-kernel interfaces and their proof organization are adapted from the prior
+formalizations in `TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Basic` and
+`TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Coordinate`.
+
 This supplies the central-isogeny interface requested in Layer 6, "Reductive and semisimple
 groups", of `TauCetiRoadmap/ReductiveGroups/README.md`. It builds on the existing
 scheme-theoretic kernel and central Hopf-ideal APIs.

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.FaithfullyFlatPoints
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel
+
+/-!
+# Isogenies of affine group schemes
+
+A morphism `f : H ⟶ K` of commutative Hopf algebras represents, contravariantly, a
+morphism `Spec K ⟶ Spec H` of affine group schemes. We call this morphism an isogeny when
+its coordinate map is finite and faithfully flat. These two conditions respectively say that
+the group-scheme morphism is finite and fppf-surjective. A central isogeny is an isogeny whose
+scheme-theoretic kernel is central.
+
+The definitions are stated over an arbitrary commutative base ring. Over a field, for affine
+algebraic groups of finite type, this is the coordinate-algebra form of the usual finite
+surjective group morphism. Keeping faithful flatness explicit avoids replacing scheme-theoretic
+surjectivity by a weaker statement about points over the base field.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.IsIsogeny`: a finite faithfully flat coordinate morphism.
+* `TauCeti.CommHopfAlgCat.IsCentralIsogeny`: an isogeny with central kernel Hopf ideal.
+* `TauCeti.CommHopfAlgCat.IsIsogeny.mapPointsFunctor_app_surjective`: an isogeny is
+  surjective on points over algebraically closed fields.
+* `TauCeti.CommHopfAlgCat.IsCentralIsogeny.isCentralPoint_of_mapPoints_eq_one`: every
+  point in the kernel of a central isogeny is central.
+* `TauCeti.CommHopfAlgCat.isCentralIsogeny_of_isIso`: every isomorphism is a central
+  isogeny.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Definition 2.20 and §23.
+
+This supplies the central-isogeny interface requested in Layer 6, "Reductive and semisimple
+groups", of `TauCetiRoadmap/ReductiveGroups/README.md`. It builds on the existing
+scheme-theoretic kernel and central Hopf-ideal APIs.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u v w
+
+variable {R : Type u} [CommRing R]
+variable {H K L : _root_.CommHopfAlgCat.{v} R}
+
+/-- A morphism of affine group schemes is an **isogeny** when its coordinate morphism is
+finite and faithfully flat.
+
+For `f : H ⟶ K`, this predicate concerns the contravariant group-scheme morphism
+`Spec K ⟶ Spec H`. Finiteness is therefore finiteness of `K` as an `H`-module through
+`f`, while faithful flatness is the scheme-theoretic surjectivity condition. -/
+def IsIsogeny (f : H ⟶ K) : Prop :=
+  f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat
+
+/-- A **central isogeny** is an isogeny whose scheme-theoretic kernel is central. The kernel
+is represented by the quotient of `K` by `kernelHopfIdeal f`, so centrality is imposed on
+that Hopf ideal. -/
+def IsCentralIsogeny (f : H ⟶ K) : Prop :=
+  IsIsogeny f ∧ (kernelHopfIdeal f).IsCentral
+
+/-- Restatement of the coordinate-algebra conditions defining an isogeny. -/
+theorem isIsogeny_iff (f : H ⟶ K) :
+    IsIsogeny f ↔
+      f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat :=
+  Iff.rfl
+
+/-- Restatement of the coordinate-algebra conditions defining a central isogeny. -/
+theorem isCentralIsogeny_iff (f : H ⟶ K) :
+    IsCentralIsogeny f ↔
+      f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat ∧
+        (kernelHopfIdeal f).IsCentral := by
+  rw [IsCentralIsogeny, IsIsogeny, and_assoc]
+
+namespace IsIsogeny
+
+variable {f : H ⟶ K}
+
+/-- The coordinate algebra of the source of an isogeny is finite over that of the target. -/
+theorem finite (hf : IsIsogeny f) : f.hom.toAlgHom.Finite :=
+  hf.1
+
+/-- The coordinate map of an isogeny is faithfully flat. -/
+theorem faithfullyFlat (hf : IsIsogeny f) :
+    f.hom.toAlgHom.toRingHom.FaithfullyFlat :=
+  hf.2
+
+/-- The coordinate map of an isogeny is injective. -/
+theorem injective (hf : IsIsogeny f) : Function.Injective f.hom :=
+  hf.faithfullyFlat.injective
+
+/-- A finite coordinate morphism is in particular of finite type. -/
+theorem finiteType (hf : IsIsogeny f) : f.hom.toAlgHom.FiniteType :=
+  hf.finite.finiteType
+
+/-- A composite of isogenies is an isogeny. -/
+theorem comp {f : H ⟶ K} {g : K ⟶ L} (hg : IsIsogeny g) (hf : IsIsogeny f) :
+    IsIsogeny (f ≫ g) := by
+  rw [IsIsogeny, _root_.CommHopfAlgCat.hom_comp]
+  exact ⟨AlgHom.Finite.comp hg.finite hf.finite,
+    RingHom.FaithfullyFlat.stableUnderComposition _ _ hf.faithfullyFlat
+      hg.faithfullyFlat⟩
+
+end IsIsogeny
+
+namespace IsCentralIsogeny
+
+variable {f : H ⟶ K}
+
+/-- Forgetting centrality from a central isogeny gives an isogeny. -/
+theorem isIsogeny (hf : IsCentralIsogeny f) : IsIsogeny f :=
+  hf.1
+
+/-- The kernel Hopf ideal of a central isogeny is central. -/
+theorem isCentral_kernelHopfIdeal (hf : IsCentralIsogeny f) :
+    (kernelHopfIdeal f).IsCentral :=
+  hf.2
+
+/-- The kernel Hopf ideal of a central isogeny is normal. -/
+theorem isNormal_kernelHopfIdeal (hf : IsCentralIsogeny f) :
+    (kernelHopfIdeal f).IsNormal :=
+  hf.isCentral_kernelHopfIdeal.isNormal
+
+/-- The coordinate ring of the kernel of a central isogeny is cocommutative. Equivalently,
+the kernel group scheme is commutative. -/
+theorem isCocomm_quotient_kernelHopfIdeal (hf : IsCentralIsogeny f) :
+    _root_.Coalgebra.IsCocomm R (quotient K (kernelHopfIdeal f)) :=
+  hf.isCentral_kernelHopfIdeal.isCocomm_quotient
+
+/-- A central isogeny is finite on coordinate algebras. -/
+theorem finite (hf : IsCentralIsogeny f) : f.hom.toAlgHom.Finite :=
+  hf.isIsogeny.finite
+
+/-- A central isogeny is faithfully flat on coordinate algebras. -/
+theorem faithfullyFlat (hf : IsCentralIsogeny f) :
+    f.hom.toAlgHom.toRingHom.FaithfullyFlat :=
+  hf.isIsogeny.faithfullyFlat
+
+/-- The coordinate map of a central isogeny is injective. -/
+theorem injective (hf : IsCentralIsogeny f) : Function.Injective f.hom :=
+  hf.isIsogeny.injective
+
+end IsCentralIsogeny
+
+/-- The identity morphism is an isogeny. -/
+theorem isIsogeny_id (H : _root_.CommHopfAlgCat.{v} R) : IsIsogeny (𝟙 H) := by
+  rw [IsIsogeny, _root_.CommHopfAlgCat.hom_id]
+  exact ⟨AlgHom.Finite.id R H, Module.FaithfullyFlat.self H⟩
+
+/-- The kernel Hopf ideal of a surjective coordinate morphism is the augmentation ideal.
+This applies in particular to isomorphisms and identifies their group-scheme kernel with the
+trivial subgroup. -/
+theorem kernelHopfIdeal_eq_augmentation_of_surjective (f : H ⟶ K)
+    (hf : Function.Surjective f.hom) :
+    kernelHopfIdeal f = HopfIdeal.augmentation R K := by
+  apply le_antisymm
+    (HopfIdeal.le_augmentation (R := R) K (kernelHopfIdeal f)) fun y hy ↦ ?_
+  obtain ⟨x, rfl⟩ := hf y
+  rw [HopfIdeal.mem_augmentation] at hy
+  apply mem_kernelHopfIdeal_of_mem_augmentation f
+  simpa only [CoalgHomClass.counit_comp_apply] using hy
+
+/-- A bijective coordinate morphism is an isogeny. -/
+theorem isIsogeny_of_bijective (f : H ⟶ K) (hf : Function.Bijective f.hom) :
+    IsIsogeny f :=
+  ⟨AlgHom.Finite.of_surjective f.hom.toAlgHom hf.2,
+    RingHom.FaithfullyFlat.of_bijective hf⟩
+
+/-- A bijective coordinate morphism is a central isogeny. Its kernel Hopf ideal is the
+augmentation ideal, hence cuts out the trivial central subgroup. -/
+theorem isCentralIsogeny_of_bijective (f : H ⟶ K) (hf : Function.Bijective f.hom) :
+    IsCentralIsogeny f := by
+  refine ⟨isIsogeny_of_bijective f hf, ?_⟩
+  rw [kernelHopfIdeal_eq_augmentation_of_surjective f hf.2]
+  exact isCentral_augmentation K
+
+/-- Every categorical isomorphism of commutative Hopf algebras is an isogeny. -/
+theorem isIsogeny_of_isIso (f : H ⟶ K) [IsIso f] : IsIsogeny f :=
+  isIsogeny_of_bijective f (ConcreteCategory.bijective_of_isIso f)
+
+/-- Every categorical isomorphism of commutative Hopf algebras is a central isogeny. -/
+theorem isCentralIsogeny_of_isIso (f : H ⟶ K) [IsIso f] : IsCentralIsogeny f :=
+  isCentralIsogeny_of_bijective f (ConcreteCategory.bijective_of_isIso f)
+
+/-- The identity morphism is a central isogeny. -/
+theorem isCentralIsogeny_id (H : _root_.CommHopfAlgCat.{v} R) :
+    IsCentralIsogeny (𝟙 H) :=
+  isCentralIsogeny_of_isIso (𝟙 H)
+
+/-- An isogeny is surjective on points valued in an algebraically closed field. -/
+theorem IsIsogeny.mapPointsFunctor_app_surjective (hf : IsIsogeny f)
+    (F : Type w) [Field F] [Algebra R F] [IsAlgClosed F] :
+    Function.Surjective ((mapPointsFunctor f).app (CommAlgCat.of R F)) :=
+  mapPointsFunctor_app_surjective_of_faithfullyFlat F f hf.finiteType hf.faithfullyFlat
+
+section KernelPoints
+
+variable {H₀ K₀ : _root_.CommHopfAlgCat.{u} R} {f₀ : H₀ ⟶ K₀}
+
+/-- Every point in the kernel of a central isogeny is central in its source group. This is
+the functor-of-points meaning of the central-kernel condition. -/
+theorem IsCentralIsogeny.isCentralPoint_of_mapPoints_eq_one
+    (hf : IsCentralIsogeny f₀) (A : CommAlgCat.{u} R)
+    (g : HopfAlgebra.points (R := R) (H := K₀) A)
+    (hg : (mapPointsFunctor f₀).app A g = 1) : HopfAlgebra.IsCentralPoint g := by
+  apply isCentralPoint_of_mem_quotientPointsSubgroup K₀ (kernelHopfIdeal f₀)
+    hf.isCentral_kernelHopfIdeal A
+  exact (mapPointsFunctor_app_eq_one_iff f₀ A g).mp hg
+
+end KernelPoints
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -15,8 +15,8 @@ public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel
 A morphism `f : H ⟶ K` of commutative Hopf algebras represents, contravariantly, a
 morphism `Spec K ⟶ Spec H` of affine group schemes. We call this morphism an isogeny when
 its coordinate map is finite and faithfully flat. These two conditions respectively say that
-the group-scheme morphism is finite and fppf-surjective. A central isogeny is an isogeny whose
-scheme-theoretic kernel is central.
+the group-scheme morphism is finite and faithfully flat (hence fpqc-surjective). A central
+isogeny is an isogeny whose scheme-theoretic kernel is central.
 
 The definitions are stated over an arbitrary commutative base ring. Over a field, for affine
 algebraic groups of finite type, this is the coordinate-algebra form of the usual finite
@@ -157,6 +157,7 @@ theorem injective (hf : IsCentralIsogeny f) : Function.Injective f.hom :=
 end IsCentralIsogeny
 
 /-- The identity morphism is an isogeny. -/
+@[simp]
 theorem isIsogeny_id (H : _root_.CommHopfAlgCat.{v} R) : IsIsogeny (𝟙 H) := by
   rw [IsIsogeny, _root_.CommHopfAlgCat.hom_id]
   exact ⟨AlgHom.Finite.id R H, Module.FaithfullyFlat.self H⟩
@@ -184,6 +185,7 @@ theorem isCentralIsogeny_of_isIso (f : H ⟶ K) [IsIso f] : IsCentralIsogeny f :
   isCentralIsogeny_of_bijective f (ConcreteCategory.bijective_of_isIso f)
 
 /-- The identity morphism is a central isogeny. -/
+@[simp]
 theorem isCentralIsogeny_id (H : _root_.CommHopfAlgCat.{v} R) :
     IsCentralIsogeny (𝟙 H) :=
   isCentralIsogeny_of_isIso (𝟙 H)
@@ -196,17 +198,16 @@ theorem IsIsogeny.mapPointsFunctor_app_surjective (hf : IsIsogeny f)
 
 section KernelPoints
 
-variable {H₀ K₀ : _root_.CommHopfAlgCat.{u} R} {f₀ : H₀ ⟶ K₀}
+variable {H₀ K₀ : _root_.CommHopfAlgCat.{v} R} {f₀ : H₀ ⟶ K₀}
 
 /-- Every point in the kernel of a central isogeny is central in its source group. This is
 the functor-of-points meaning of the central-kernel condition. -/
 theorem IsCentralIsogeny.isCentralPoint_of_mapPoints_eq_one
-    (hf : IsCentralIsogeny f₀) (A : CommAlgCat.{u} R)
+    (hf : IsCentralIsogeny f₀) (A : CommAlgCat.{v} R)
     (g : HopfAlgebra.points (R := R) (H := K₀) A)
     (hg : (mapPointsFunctor f₀).app A g = 1) : HopfAlgebra.IsCentralPoint g := by
-  apply isCentralPoint_of_mem_quotientPointsSubgroup K₀ (kernelHopfIdeal f₀)
-    hf.isCentral_kernelHopfIdeal A
-  exact (mapPointsFunctor_app_eq_one_iff f₀ A g).mp hg
+  exact isCentralPoint_of_mapPoints_eq_one_of_isCentral_kernelHopfIdeal
+    hf.isCentral_kernelHopfIdeal A g hg
 
 end KernelPoints
 

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -85,15 +85,16 @@ section Field
 
 variable {k : Type u} [Field k] {H₀ K₀ : _root_.CommHopfAlgCat.{u} k}
 
-/-- Over a field, the coordinate-algebra definition of an isogeny agrees with the existing
-group-scheme definition after applying the contravariant Hopf spectrum functor. -/
-theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
-    IsIsogeny f ↔
-      GroupScheme.IsIsogeny
-        ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op) := by
-  rw [IsIsogeny, GroupScheme.isIsogeny_iff]
-  -- The underlying scheme morphism of `hopfSpec.map f.op` reduces definitionally to the
-  -- `Spec.map` induced by the underlying ring homomorphism of `f`.
+-- This isolates the definitional computation of Mathlib's bundled `hopfSpec` functor at the
+-- morphism-property boundary where the source and target schemes are propositionally aligned.
+private lemma isogeny_conditions_hopfSpec_map_iff (f : H₀ ⟶ K₀) :
+    f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat ↔
+      AlgebraicGeometry.IsFinite
+          ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ∧
+        AlgebraicGeometry.Flat
+            ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ∧
+          AlgebraicGeometry.Surjective
+            ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left := by
   change f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat ↔
     AlgebraicGeometry.IsFinite
       (AlgebraicGeometry.Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ∧
@@ -104,6 +105,15 @@ theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
   rw [AlgebraicGeometry.IsFinite.SpecMap_iff,
     AlgebraicGeometry.flat_and_surjective_SpecMap_iff]
   rfl
+
+/-- Over a field, the coordinate-algebra definition of an isogeny agrees with the existing
+group-scheme definition after applying the contravariant Hopf spectrum functor. -/
+theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
+    IsIsogeny f ↔
+      GroupScheme.IsIsogeny
+        ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op) := by
+  rw [IsIsogeny, GroupScheme.isIsogeny_iff]
+  exact isogeny_conditions_hopfSpec_map_iff f
 
 /-- Over a field, the coordinate-algebra definition of a central isogeny agrees with the
 existing group-scheme definition after applying the contravariant Hopf spectrum functor. -/
@@ -206,6 +216,18 @@ theorem isCentralIsogeny_of_bijective (f : H ⟶ K) (hf : Function.Bijective f.h
   rw [kernelHopfIdeal_eq_augmentation_of_surjective f hf.2]
   exact isCentral_augmentation K
 
+-- These lemmas isolate the definitional identification of `unitBialgHom` with `algebraMap`.
+private lemma unitBialgHom_finite (K : _root_.CommHopfAlgCat.{u} R) [Module.Finite R K] :
+    (Bialgebra.unitBialgHom R K).toAlgHom.Finite := by
+  change (algebraMap R K).Finite
+  exact RingHom.finite_algebraMap.mpr inferInstance
+
+private lemma unitBialgHom_faithfullyFlat (K : _root_.CommHopfAlgCat.{u} R)
+    [Module.FaithfullyFlat R K] :
+    (Bialgebra.unitBialgHom R K).toAlgHom.toRingHom.FaithfullyFlat := by
+  change (algebraMap R K).FaithfullyFlat
+  exact RingHom.faithfullyFlat_algebraMap_iff.mpr inferInstance
+
 /-- The structure morphism from a finite faithfully flat commutative affine group scheme to the
 trivial group is a central isogeny. Its kernel is the whole source group, so nontrivial choices of
 `K` give central isogenies with nontrivial kernel. -/
@@ -213,14 +235,8 @@ theorem isCentralIsogeny_unit_of_isCocomm (K : _root_.CommHopfAlgCat.{u} R)
     [Module.Finite R K] [Module.FaithfullyFlat R K] [Coalgebra.IsCocomm R K] :
     IsCentralIsogeny
       (CommHopfAlgCat.ofHom (Bialgebra.unitBialgHom R K)) := by
-  refine ⟨⟨?_, ?_⟩, ?_⟩
-  -- Mathlib has no lemma identifying the ring-hom carrier of `unitBialgHom`; both goals
-  -- reduce definitionally to the corresponding properties of the algebra map.
-  · change (algebraMap R K).Finite
-    exact RingHom.finite_algebraMap.mpr inferInstance
-  · change (algebraMap R K).FaithfullyFlat
-    exact RingHom.faithfullyFlat_algebraMap_iff.mpr inferInstance
-  · exact (HopfIdeal.isCentral_bot_iff_isCocomm.mpr inferInstance).mono bot_le
+  exact ⟨⟨unitBialgHom_finite K, unitBialgHom_faithfullyFlat K⟩,
+    (HopfIdeal.isCentral_bot_iff_isCocomm.mpr inferInstance).mono bot_le⟩
 
 /-- Every categorical isomorphism of commutative Hopf algebras is an isogeny. -/
 theorem isIsogeny_of_isIso (f : H ⟶ K) [IsIso f] : IsIsogeny f :=

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -108,7 +108,7 @@ theorem finiteType (hf : IsIsogeny f) : f.hom.toAlgHom.FiniteType :=
   hf.finite.finiteType
 
 /-- A composite of isogenies is an isogeny. -/
-theorem comp {f : H ⟶ K} {g : K ⟶ L} (hg : IsIsogeny g) (hf : IsIsogeny f) :
+theorem comp {f : H ⟶ K} {g : K ⟶ L} (hf : IsIsogeny f) (hg : IsIsogeny g) :
     IsIsogeny (f ≫ g) := by
   rw [IsIsogeny, _root_.CommHopfAlgCat.hom_comp]
   exact ⟨AlgHom.Finite.comp hg.finite hf.finite,
@@ -160,19 +160,6 @@ end IsCentralIsogeny
 theorem isIsogeny_id (H : _root_.CommHopfAlgCat.{v} R) : IsIsogeny (𝟙 H) := by
   rw [IsIsogeny, _root_.CommHopfAlgCat.hom_id]
   exact ⟨AlgHom.Finite.id R H, Module.FaithfullyFlat.self H⟩
-
-/-- The kernel Hopf ideal of a surjective coordinate morphism is the augmentation ideal.
-This applies in particular to isomorphisms and identifies their group-scheme kernel with the
-trivial subgroup. -/
-theorem kernelHopfIdeal_eq_augmentation_of_surjective (f : H ⟶ K)
-    (hf : Function.Surjective f.hom) :
-    kernelHopfIdeal f = HopfIdeal.augmentation R K := by
-  apply le_antisymm
-    (HopfIdeal.le_augmentation (R := R) K (kernelHopfIdeal f)) fun y hy ↦ ?_
-  obtain ⟨x, rfl⟩ := hf y
-  rw [HopfIdeal.mem_augmentation] at hy
-  apply mem_kernelHopfIdeal_of_mem_augmentation f
-  simpa only [CoalgHomClass.counit_comp_apply] using hy
 
 /-- A bijective coordinate morphism is an isogeny. -/
 theorem isIsogeny_of_bijective (f : H ⟶ K) (hf : Function.Bijective f.hom) :

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -250,7 +250,9 @@ section KernelPoints
 variable {H₀ K₀ : _root_.CommHopfAlgCat.{v} R} {f₀ : H₀ ⟶ K₀}
 
 /-- Every point in the kernel of a central isogeny is central in its source group. This is
-the functor-of-points meaning of the central-kernel condition. -/
+the functor-of-points meaning of the central-kernel condition. For a morphism assumed only to have
+central kernel, combine `mapPointsFunctor_app_eq_one_iff` with
+`isCentralPoint_of_mem_quotientPointsSubgroup`. -/
 theorem IsCentralIsogeny.isCentralPoint_of_mapPoints_eq_one
     (hf : IsCentralIsogeny f₀) (A : CommAlgCat.{w} R)
     (g : HopfAlgebra.points (R := R) (H := K₀) A)


### PR DESCRIPTION
This PR defines isogenies of affine group schemes in coordinate form as finite faithfully flat morphisms of commutative Hopf algebras, and defines a central isogeny by requiring its scheme-theoretic kernel Hopf ideal to be central. Over a field, it proves that these predicates agree with the existing `GroupScheme.IsIsogeny` and `GroupScheme.IsCentralIsogeny` predicates after applying the contravariant Hopf-spectrum functor. It supplies constructor and elimination lemmas, closure of isogenies under composition, identity and isomorphism witnesses, a nontrivial-kernel family from finite faithfully flat commutative group schemes, the augmentation-ideal description of an isomorphism's kernel, surjectivity on algebraically closed points, and the pointwise statement that every kernel point of a central isogeny is central.

It advances the ReductiveGroups Layer 6 milestone, “Develop radical, centre, derived group, central isogenies, simply-connected/adjoint forms,” at its central-isogenies target. In particular, it synchronizes the Hopf-algebra and group-scheme views as required by `TauCetiRoadmap/ReductiveGroups/README.md` and provides a coordinate interface for the remaining Layer 6 structure theorems. The simply-connected and adjoint-form definitions are already on `main`; the remaining gap is the structure theory relating those forms by central isogenies. The implementation reuses Mathlib's `AlgHom.Finite`, `RingHom.FaithfullyFlat`, and affine-spectrum morphism criteria together with Tau Ceti's existing scheme-theoretic kernel and central Hopf-ideal APIs; no infrastructure is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"central-isogeny"}-->

🤖 Prepared with Codex
