### PR TITLE
feat: make E6 minuscule points functorial

### DIFF
--- a/TauCeti/Algebra/Lie/E6/Minuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/PointsFunctor.lean
@@ -1,0 +1,265 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+public import TauCeti.Algebra.Lie.E6.Minuscule.GroupScheme
+
+/-!
+# The points of the type-E6 minuscule carrier, functorially
+
+`TauCeti.E6Minuscule.groupScheme` is the explicit full-weight type-`E₆` carrier over `ℤ`, and
+`TauCeti.E6Minuscule.points A` realizes its `A`-valued points as a subgroup of `GL₂₇(A)`. This
+file supplies the homomorphism induced by an arbitrary homomorphism of value rings and assembles
+these point groups into a functor on commutative `ℤ`-algebras.
+
+The induced map is entrywise and preserves the two pinned families:
+
+```text
+f (x_i(u)) = x_i(f(u)),        f (t(s)) = t(f ∘ s).
+```
+
+The quotient of the ambient general-linear coordinate Hopf algebra by the minuscule carrier's
+defining ideal represents this functor. Nothing here asserts reductivity, maximality of the
+weight torus, or an identification of the carrier's root datum.
+
+## Main declarations
+
+* `TauCeti.E6Minuscule.pointsMap`: the map on carrier points induced by a ring homomorphism.
+* `TauCeti.E6Minuscule.pointsFunctor`: the group-valued functor of points.
+* `TauCeti.E6Minuscule.pointsMulEquiv`: the pointwise representing isomorphism.
+* `TauCeti.E6Minuscule.pointsFunctorNatIso`: the natural representing isomorphism.
+
+## References
+
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*,
+  Sections 1.15 and 1.17.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1--2.
+
+The interface specializes the carrier-independent functor in
+`TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor`, following the analogous
+full-weight type-`A` and type-`C` carrier interfaces. This advances the target "points over an
+algebraically closed field as a group, functorially in the field" in Layer 9 of the
+ReductiveGroups roadmap. Its consumer is the type-`E₆` branch of milestone L0 of the
+CFSGStatement roadmap.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.E6Minuscule
+
+universe v v'
+
+noncomputable section
+
+section Map
+
+variable {A : Type v} {B : Type v'} [CommRing A] [CommRing B]
+
+/-- The map on the points of the type-`E₆` minuscule carrier induced by a homomorphism of value
+rings. It is the entrywise map on `GL₂₇`, restricted to the subgroup cut out by the carrier's
+defining ideal. -/
+def pointsMap (f : A →+* B) : points A →* points B :=
+  ((MulEquiv.subgroupCongr (points_def B)).symm.toMonoidHom).comp
+    ((GeneralLinear.mapHopfIdealPointsSubgroup 27 definingIdeal f.toIntAlgHom).comp
+      (MulEquiv.subgroupCongr (points_def A)).toMonoidHom)
+
+/-- The induced map on type-`E₆` carrier points is the entrywise map. -/
+@[simp]
+theorem coe_pointsMap (f : A →+* B) (g : points A) :
+    (pointsMap f g : Matrix.GeneralLinearGroup (Fin 27) B) =
+      Matrix.GeneralLinearGroup.map f g := by
+  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
+  rw [pointsMap]
+  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
+    MulEquiv.subgroupCongr_apply, hring]
+
+/-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
+theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 27) :
+    ((pointsMap f g : Matrix.GeneralLinearGroup (Fin 27) B) :
+        Matrix (Fin 27) (Fin 27) B) i j =
+      f (((g : Matrix.GeneralLinearGroup (Fin 27) A) : Matrix (Fin 27) (Fin 27) A) i j) := by
+  rw [coe_pointsMap, Matrix.GeneralLinearGroup.map_apply]
+
+/-- The identity homomorphism induces the identity on type-`E₆` carrier points. -/
+@[simp]
+theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
+  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A := AlgHom.ext fun _ ↦ rfl
+  rw [pointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  apply MonoidHom.ext
+  intro g
+  exact (MulEquiv.subgroupCongr (points_def A)).symm_apply_apply g
+
+/-- The induced maps on type-`E₆` carrier points compose. -/
+@[simp]
+theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
+    pointsMap (g.comp f) = (pointsMap g).comp (pointsMap f) := by
+  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
+    AlgHom.ext fun _ ↦ rfl
+  apply MonoidHom.ext
+  intro x
+  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+
+/-- An injective homomorphism of value rings induces an injective map on type-`E₆` carrier
+points. -/
+theorem pointsMap_injective {f : A →+* B} (hf : Function.Injective f) :
+    Function.Injective (pointsMap f) := by
+  rw [pointsMap]
+  exact (MulEquiv.subgroupCongr (points_def B)).symm.injective.comp
+    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective 27 definingIdeal hf).comp
+      (MulEquiv.subgroupCongr (points_def A)).injective)
+
+/-- The induced map carries a numbered root-subgroup parameter along the homomorphism of value
+rings. -/
+@[simp]
+theorem pointsMap_rootSubgroupPoints (f : A →+* B) (i : Fin 6 ⊕ Fin 6)
+    (u : Multiplicative A) :
+    pointsMap f (rootSubgroupPoints i A u) =
+      rootSubgroupPoints i B (Multiplicative.ofAdd (f (Multiplicative.toAdd u))) := by
+  apply Subtype.ext
+  rw [coe_pointsMap, coe_rootSubgroupPoints, coe_rootSubgroupPoints,
+    UniversalEnvelopingAlgebra.map_kostantRootSubgroupMatrix,
+    AdditiveGroup.mapValue_gaPointsMulEquiv_symm_apply, RingHom.toIntAlgHom_apply]
+
+/-- The induced map carries a point of the pinned split weight torus coordinatewise along the
+homomorphism of value rings. -/
+@[simp]
+theorem pointsMap_weightTorusPoints (f : A →+* B) (s : Fin 6 → Aˣ) :
+    pointsMap f (weightTorusPoints A s) =
+      weightTorusPoints B fun i ↦ Units.map (f : A →* B) (s i) := by
+  apply Subtype.ext
+  rw [coe_pointsMap, coe_weightTorusPoints, coe_weightTorusPoints]
+  exact UniversalEnvelopingAlgebra.map_kostantTorusMatrix
+    (M := lattice.toAddSubgroup) (b := latticeBasis)
+      (wt := DynkinType.e6MinusculeWeight) f s
+
+end Map
+
+/-! ## The functor of points -/
+
+/-- The group-valued functor of points of the type-`E₆` minuscule carrier. -/
+def pointsFunctor : CommAlgCat.{v} ℤ ⥤ GrpCat.{v} where
+  obj A := GrpCat.of (points A)
+  map f := GrpCat.ofHom (pointsMap f.hom.toRingHom)
+  map_id _A := congrArg GrpCat.ofHom pointsMap_id
+  map_comp f g := congrArg GrpCat.ofHom
+    (pointsMap_comp f.hom.toRingHom g.hom.toRingHom)
+
+/-- The object part of the type-`E₆` carrier's points functor is its named point group. -/
+@[simp]
+theorem pointsFunctor_obj (A : CommAlgCat.{v} ℤ) :
+    pointsFunctor.obj A = GrpCat.of (points A) :=
+  (rfl)
+
+/-- The morphism part of the type-`E₆` carrier's points functor is the induced entrywise map. -/
+@[simp]
+theorem pointsFunctor_map {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B) :
+    pointsFunctor.map f =
+      eqToHom (pointsFunctor_obj A) ≫ GrpCat.ofHom (pointsMap f.hom.toRingHom) ≫
+        eqToHom (pointsFunctor_obj B).symm :=
+  (rfl)
+
+/-- At a bundled `ℤ`-algebra, the named carrier points are the ambient general-linear subgroup
+cut out by the defining ideal. -/
+private theorem points_eq_hopfIdealPointsSubgroup (A : CommAlgCat.{v} ℤ) :
+    points A = GeneralLinear.hopfIdealPointsSubgroup 27 definingIdeal A := by
+  rw [points_def A]
+  congr 1
+  exact Subsingleton.elim _ _
+
+/-- The points of the quotient coordinate Hopf algebra are the named type-`E₆` carrier points. -/
+def pointsMulEquiv (A : CommAlgCat.{v} ℤ) :
+    HopfAlgebra.points
+        (R := ℤ) (H := CommHopfAlgCat.quotient
+          (GeneralLinear.coordinateHopfAlgebra ℤ 27) definingIdeal) A ≃*
+      points A :=
+  (GeneralLinear.hopfIdealPointsSubgroupMulEquiv 27 definingIdeal A).trans
+    (MulEquiv.subgroupCongr (points_eq_hopfIdealPointsSubgroup A)).symm
+
+/-- A quotient point, read through `pointsMulEquiv`, is its ambient point viewed as an invertible
+matrix. -/
+@[simp]
+theorem coe_pointsMulEquiv_apply (A : CommAlgCat.{v} ℤ)
+    (q : HopfAlgebra.points
+      (R := ℤ) (H := CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra ℤ 27) definingIdeal) A) :
+    (pointsMulEquiv A q : Matrix.GeneralLinearGroup (Fin 27) A) =
+      GeneralLinear.pointsMulEquiv 27
+        (CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra ℤ 27) definingIdeal A q) := by
+  simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]
+  exact GeneralLinear.coe_hopfIdealPointsSubgroupMulEquiv_apply 27 definingIdeal A q
+
+/-- Including the ambient Hopf-algebra point underlying the inverse of `pointsMulEquiv` recovers
+the point corresponding to the underlying matrix. -/
+@[simp]
+theorem quotientPointsHom_pointsMulEquiv_symm (A : CommAlgCat.{v} ℤ) (g : points A) :
+    CommHopfAlgCat.quotientPointsHom
+        (GeneralLinear.coordinateHopfAlgebra ℤ 27) definingIdeal A
+        ((pointsMulEquiv A).symm g) =
+      (GeneralLinear.pointsMulEquiv (R := ℤ) 27).symm
+        (g : Matrix.GeneralLinearGroup (Fin 27) A) := by
+  simp only [pointsMulEquiv, MulEquiv.symm_trans_apply, MulEquiv.symm_symm]
+  rw [GeneralLinear.quotientPointsHom_hopfIdealPointsSubgroupMulEquiv_symm,
+    MulEquiv.subgroupCongr_apply]
+
+/-- The pointwise identification with quotient Hopf-algebra points is natural in the value
+algebra. -/
+@[simp]
+theorem pointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B)
+    (q : HopfAlgebra.points
+      (R := ℤ) (H := CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra ℤ 27) definingIdeal) A) :
+    pointsMulEquiv B
+        (HopfAlgebra.mapPoints
+          (H := CommHopfAlgCat.quotient
+            (GeneralLinear.coordinateHopfAlgebra ℤ 27) definingIdeal) f q) =
+      pointsMap f.hom.toRingHom (pointsMulEquiv A q) := by
+  apply Subtype.ext
+  rw [coe_pointsMap]
+  simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]
+  exact (congrArg Subtype.val
+      (GeneralLinear.hopfIdealPointsSubgroupMulEquiv_mapPoints 27 definingIdeal f q)).trans
+    (GeneralLinear.coe_mapHopfIdealPointsSubgroup 27 definingIdeal f.hom _)
+
+/-- The quotient coordinate Hopf algebra represents the points functor of the type-`E₆`
+minuscule carrier. -/
+def pointsFunctorNatIso :
+    HopfAlgebra.pointsFunctor
+        (R := ℤ) (H := CommHopfAlgCat.quotient
+          (GeneralLinear.coordinateHopfAlgebra ℤ 27) definingIdeal) ≅
+      pointsFunctor :=
+  NatIso.ofComponents (fun A ↦ (pointsMulEquiv A).toGrpIso)
+    (by
+      intro A B f
+      ext q
+      exact pointsMulEquiv_mapPoints f q)
+
+/-- The forward component of the representing natural isomorphism is the pointwise
+identification. -/
+@[simp]
+theorem pointsFunctorNatIso_hom_app_apply (A : CommAlgCat.{v} ℤ)
+    (q : HopfAlgebra.points
+      (R := ℤ) (H := CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra ℤ 27) definingIdeal) A) :
+    eqToHom (pointsFunctor_obj A) (pointsFunctorNatIso.hom.app A q) = pointsMulEquiv A q :=
+  (rfl)
+
+/-- The inverse component of the representing natural isomorphism is the inverse pointwise
+identification. -/
+@[simp]
+theorem pointsFunctorNatIso_inv_app_apply (A : CommAlgCat.{v} ℤ) (g : points A) :
+    pointsFunctorNatIso.inv.app A (eqToHom (pointsFunctor_obj A).symm g) =
+      (pointsMulEquiv A).symm g :=
+  (rfl)
+
+end
+
+end TauCeti.E6Minuscule


### PR DESCRIPTION
This PR makes the explicit full-weight type-`E₆` minuscule carrier's matrix-valued points functorial in the value ring. Define the entrywise point map for every homomorphism of commutative rings, prove identity, composition and injectivity, show that it carries the numbered simple-root subgroups and split weight torus coordinatewise, and package the result as a group-valued functor naturally represented by the carrier's quotient coordinate Hopf algebra.

The exact roadmap target is Layer 9, “Points over an algebraically closed field as a group, functorially in the field,” within the milestone “pinned Chevalley–Demazure group schemes over `ℤ`” in `TauCetiRoadmap/ReductiveGroups/README.md`. This is the most effective current step because the explicit full-weight `E₆` carrier has just landed, while its points had no value-ring map and the separate open doubled-minuscule work serves the graph-twisted carrier rather than this ordinary one.

The dependency edge is that CFSGStatement milestone L0, “pinned ambient groups: root datum, pinning, points, root subgroups,” consumes the ordinary `E₆` carrier point group and its numbered root subgroups, and milestone L1 consumes their functoriality under the `q`-power field endomorphism; the declarations here are the representing and naturality interface from which that Frobenius endomorphism is specialized. After this PR, the type-`E₆` Layer 9 lane still needs that `q`-power Frobenius specialization, nonsimple-root subgroup maps and Chevalley relations, and proofs of reductivity and identification with the pinned simply connected root datum.

Add `TauCeti/Algebra/Lie/E6/Minuscule/PointsFunctor.lean` (264 lines). Reuse Tau Ceti's `GeneralLinear.mapHopfIdealPointsSubgroup`, its functorial laws and quotient-point equivalence, together with the generic Kostant root-subgroup and torus matrix naturality; no Mathlib or other implementation is vendored. The mathematical interface follows Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §§1.15 and 1.17, and Jantzen, *Representations of Algebraic Groups*, II.1–2, as cited in the module documentation, while the formal organization follows the existing full-weight type-`A` and type-`C` carrier point functors.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e6-minuscule-points-functor"}-->

🤖 Prepared with Codex
