### PR TITLE
feat: add the E6 minuscule Frobenius

### DIFF
--- a/TauCeti/Algebra/Lie/E6/Minuscule/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/Frobenius.lean
@@ -5,9 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.E6.Minuscule.GroupScheme
-public import
-  TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius
+public import TauCeti.Algebra.Lie.E6.Minuscule.PointsFunctor
+public import TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear
 
 /-!
 # The Frobenius of the full-weight type-E6 minuscule carrier
@@ -34,6 +33,7 @@ simplicity statement is involved.
 
 * `TauCeti.E6Minuscule.frobenius`: the `p ^ k`-power Frobenius on the carrier's points.
 * `TauCeti.E6Minuscule.coe_frobenius` and `coe_frobenius_apply`: its matrix and entrywise actions.
+* `TauCeti.E6Minuscule.frobenius_eq_pointsMap`: its identification with the functorial point map.
 * `TauCeti.E6Minuscule.frobenius_rootSubgroupPoints`: its action on every numbered simple-root
   subgroup.
 * `TauCeti.E6Minuscule.frobenius_weightTorusPoints`: its action on the split weight torus.
@@ -47,15 +47,15 @@ simplicity statement is involved.
 * J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
 * The formal organization follows the carrier specializations
   `TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.Frobenius` and
-  `TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius`; all mathematical content is
-  transported from the generic
-  `TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius` API.
+  `TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius` and uses the carrier's functorial
+  points API.
 
 This advances the Layer 9 target "points over an algebraically closed field as a group,
 functorially in the field" of `TauCetiRoadmap/ReductiveGroups/README.md`, which names the
 `q`-power Frobenius as its first consumer-facing case. Milestone L1 of
-`TauCetiRoadmap/CFSGStatement/README.md` consumes this endomorphism and its root-subgroup equation
-as the ordinary `E₆(q)` Steinberg map.
+`TauCetiRoadmap/CFSGStatement/README.md` will consume this carrier Frobenius and its root-subgroup
+equation in a future construction of the ordinary `E₆(q)` Steinberg map. The identification of
+this carrier with the required pinned simply connected reductive group remains pending.
 -/
 
 public section
@@ -73,65 +73,12 @@ open TauCeti.DynkinType
 
 variable (p k : ℕ) (A : Type v) [CommRing A] [ExpChar A p]
 
-private theorem points_eq_kostantToralPointsSubgroup :
-    points A =
-      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup
-        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-          rw [TauCeti.serreKostantForm_def]
-          exact hu) hv)
-        isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight A := by
-  ext g
-  rw [mem_points_iff, definingIdeal_def,
-    TauCeti.UniversalEnvelopingAlgebra.mem_kostantToralPointsSubgroup_iff]
-
-/-- The presentation of the named minuscule-carrier points as the generic Kostant toral-closure
-points. -/
-private def pointsEquivKostantToralPoints :
-    points A ≃*
-      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup
-        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-          rw [TauCeti.serreKostantForm_def]
-          exact hu) hv)
-        isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight A :=
-  MulEquiv.subgroupCongr (points_eq_kostantToralPointsSubgroup A)
-
-@[simp]
-private theorem coe_pointsEquivKostantToralPoints (g : points A) :
-    (pointsEquivKostantToralPoints A g :
-      _root_.Matrix.GeneralLinearGroup (Fin 27) A) = g :=
-  rfl
-
 /-- **The `p ^ k`-power Frobenius endomorphism of the full-weight type-`E₆` minuscule carrier.**
 
-For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the Frobenius component
-of the ordinary `E₆(p ^ k)` Steinberg map. -/
+For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the carrier Frobenius
+intended for a future construction of the ordinary `E₆(p ^ k)` Steinberg map. -/
 def frobenius : points A →* points A :=
-  (pointsEquivKostantToralPoints A).symm.toMonoidHom.comp
-    ((TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius
-      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A).comp
-        (pointsEquivKostantToralPoints A).toMonoidHom)
-
-private theorem pointsEquivKostantToralPoints_frobenius (g : points A) :
-    pointsEquivKostantToralPoints A (frobenius p k A g) =
-      TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius
-        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-          rw [TauCeti.serreKostantForm_def]
-          exact hu) hv)
-        isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A
-        (pointsEquivKostantToralPoints A g) := by
-  simp only [frobenius, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    MulEquiv.apply_symm_apply]
+  pointsMap (iterateFrobenius A p k)
 
 /-- The Frobenius endomorphism of the minuscule carrier acts by entrywise Frobenius.
 
@@ -140,9 +87,13 @@ normal form. -/
 theorem coe_frobenius (g : points A) :
     (frobenius p k A g : _root_.Matrix.GeneralLinearGroup (Fin 27) A) =
       _root_.Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
-  have h := congrArg Subtype.val (pointsEquivKostantToralPoints_frobenius p k A g)
-  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
-  simpa only [coe_pointsEquivKostantToralPoints] using h
+  rw [frobenius, coe_pointsMap]
+
+/-- The carrier Frobenius is the functorial map on points induced by the iterated Frobenius
+endomorphism of the value ring. -/
+theorem frobenius_eq_pointsMap :
+    frobenius p k A = pointsMap (iterateFrobenius A p k) := by
+  rw [frobenius]
 
 /-- Entrywise, the Frobenius endomorphism raises each matrix coefficient to its `p ^ k`-th
 power. -/
@@ -152,16 +103,7 @@ theorem coe_frobenius_apply (g : points A) (i j : Fin 27) :
         _root_.Matrix (Fin 27) (Fin 27) A) i j =
       ((g : _root_.Matrix.GeneralLinearGroup (Fin 27) A) :
         _root_.Matrix (Fin 27) (Fin 27) A) i j ^ p ^ k := by
-  have h := TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius_apply
-      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A
-      (pointsEquivKostantToralPoints A g) i j
-  rw [← pointsEquivKostantToralPoints_frobenius] at h
-  simpa only [coe_pointsEquivKostantToralPoints] using h
+  rw [coe_frobenius, _root_.Matrix.GeneralLinearGroup.map_apply, iterateFrobenius_def]
 
 /-- **Frobenius raises the parameter of every numbered type-`E₆` simple-root subgroup to its
 `p ^ k`-th power.** -/
@@ -170,79 +112,29 @@ theorem frobenius_rootSubgroupPoints (i : Fin 6 ⊕ Fin 6) (u : Multiplicative A
     frobenius p k A (rootSubgroupPoints i A u) =
       rootSubgroupPoints i A
         (Multiplicative.ofAdd (Multiplicative.toAdd u ^ p ^ k)) := by
-  apply (pointsEquivKostantToralPoints A).injective
-  rw [pointsEquivKostantToralPoints_frobenius]
-  apply Subtype.ext
-  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius,
-    coe_pointsEquivKostantToralPoints, coe_rootSubgroupPoints,
-    coe_pointsEquivKostantToralPoints, coe_rootSubgroupPoints]
-  have h := congrArg Subtype.val
-    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_kostantRootSubgroupMatrix
-      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A i u)
-  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
-  exact h
+  rw [frobenius, pointsMap_rootSubgroupPoints]
+  exact Subtype.ext (by rw [iterateFrobenius_def])
 
 /-- **Frobenius raises every coordinate of the pinned split torus to its `p ^ k`-th power.** -/
 @[simp]
 theorem frobenius_weightTorusPoints (s : Fin 6 → Aˣ) :
     frobenius p k A (weightTorusPoints A s) = weightTorusPoints A (s ^ p ^ k) := by
-  apply (pointsEquivKostantToralPoints A).injective
-  rw [pointsEquivKostantToralPoints_frobenius]
-  apply Subtype.ext
-  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius,
-    coe_pointsEquivKostantToralPoints, coe_weightTorusPoints,
-    coe_pointsEquivKostantToralPoints, coe_weightTorusPoints]
-  have h := congrArg Subtype.val
-    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_kostantTorusMatrix
-      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A s)
-  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
-  simpa only [TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] using h
+  have hs : (fun j => Units.map (iterateFrobenius A p k : A →* A) (s j)) = s ^ p ^ k := by
+    funext j
+    exact Units.ext (by
+      rw [Units.coe_map, MonoidHom.coe_coe, iterateFrobenius_def, Pi.pow_apply,
+        Units.val_pow_eq_pow_val])
+  rw [frobenius, pointsMap_weightTorusPoints, hs]
 
 /-- The zeroth Frobenius iterate is the identity on the minuscule carrier's point group. -/
 @[simp]
 theorem frobenius_zero : frobenius p 0 A = MonoidHom.id _ := by
-  apply MonoidHom.ext
-  intro g
-  apply (pointsEquivKostantToralPoints A).injective
-  rw [pointsEquivKostantToralPoints_frobenius, MonoidHom.id_apply]
-  have h := DFunLike.congr_fun
-    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_zero
-      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p A)
-    (pointsEquivKostantToralPoints A g)
-  simpa only [MonoidHom.id_apply] using h
+  rw [frobenius, iterateFrobenius_zero, pointsMap_id]
 
 /-- Frobenius iterates add under composition on the minuscule carrier's point group. -/
 theorem frobenius_add (m : ℕ) :
     frobenius p (k + m) A = (frobenius p k A).comp (frobenius p m A) := by
-  apply MonoidHom.ext
-  intro g
-  apply (pointsEquivKostantToralPoints A).injective
-  rw [pointsEquivKostantToralPoints_frobenius, MonoidHom.comp_apply,
-    pointsEquivKostantToralPoints_frobenius, pointsEquivKostantToralPoints_frobenius]
-  exact DFunLike.congr_fun
-    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_add
-      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A m)
-    (pointsEquivKostantToralPoints A g)
+  rw [frobenius, frobenius, frobenius, iterateFrobenius_add, pointsMap_comp]
 
 /-- A minuscule-carrier point is fixed by Frobenius exactly when all of its matrix entries lie in
 the Frobenius-fixed subring. -/
@@ -251,21 +143,8 @@ theorem frobenius_eq_self_iff (g : points A) :
     frobenius p k A g = g ↔
       ∀ i j, ((g : _root_.Matrix.GeneralLinearGroup (Fin 27) A) :
         _root_.Matrix (Fin 27) (Fin 27) A) i j ∈ frobeniusFixedSubring A p k := by
-  have h := TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_eq_self_iff
-      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A
-      (pointsEquivKostantToralPoints A g)
-  rw [← pointsEquivKostantToralPoints_frobenius] at h
-  simp only [coe_pointsEquivKostantToralPoints] at h
-  constructor
-  · intro hg
-    exact h.mp (congrArg (pointsEquivKostantToralPoints A) hg)
-  · intro hg
-    exact (pointsEquivKostantToralPoints A).injective (h.mpr hg)
+  rw [← SetLike.coe_eq_coe, coe_frobenius,
+    _root_.Matrix.GeneralLinearGroup.map_iterateFrobenius_eq_self_iff]
 
 /-- **The Frobenius-fixed points of the full-weight minuscule carrier are its points over the
 Frobenius-fixed subring.** -/
@@ -274,17 +153,8 @@ theorem map_subtype_fixedSubgroup_frobenius_eq :
       (points ↥(frobeniusFixedSubring A p k)).map
         (_root_.Matrix.GeneralLinearGroup.map (frobeniusFixedSubring A p k).subtype) := by
   rw [TauCeti.map_subtype_fixedSubgroup_of_coe_eq (frobenius p k A) _
-    (coe_frobenius p k A)]
-  rw [points_eq_kostantToralPointsSubgroup, points_eq_kostantToralPointsSubgroup]
-  rw [← TauCeti.UniversalEnvelopingAlgebra.map_subtype_fixedSubgroup_kostantToralFrobenius]
-  exact
-    TauCeti.UniversalEnvelopingAlgebra.map_subtype_fixedSubgroup_kostantToralFrobenius_eq
-      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A
+      (coe_frobenius p k A), points_def A, points_def ↥(frobeniusFixedSubring A p k),
+    TauCeti.GeneralLinear.map_hopfIdealPointsSubgroup_frobeniusFixedSubring]
 
 end
 

--- a/TauCeti/Algebra/Lie/E6/Minuscule/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/Frobenius.lean
@@ -1,0 +1,292 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E6.Minuscule.GroupScheme
+public import
+  TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius
+
+/-!
+# The Frobenius of the full-weight type-E6 minuscule carrier
+
+The type-`E₆` minuscule carrier is the explicit Kostant toral closure over `ℤ` built from the
+27-dimensional minuscule representation and its admissible full-weight lattice. Over a commutative
+ring `A` of exponential characteristic `p`, entrywise `p ^ k`-th powers preserve its defining Hopf
+ideal and therefore give a group endomorphism of its `A`-valued points.
+
+This file names that endomorphism `TauCeti.E6Minuscule.frobenius` and records its characteristic
+equations:
+
+```text
+F (g)ᵢⱼ = gᵢⱼ ^ (p ^ k),
+F (xᵢ(u)) = xᵢ(u ^ (p ^ k)),
+F (t(s)) = t(s ^ (p ^ k)).
+```
+
+The zeroth iterate is the identity and exponents add under composition. The fixed points are the
+points of the same carrier over the Frobenius-fixed subring. No reductivity, finiteness, or
+simplicity statement is involved.
+
+## Main declarations
+
+* `TauCeti.E6Minuscule.frobenius`: the `p ^ k`-power Frobenius on the carrier's points.
+* `TauCeti.E6Minuscule.coe_frobenius` and `coe_frobenius_apply`: its matrix and entrywise actions.
+* `TauCeti.E6Minuscule.frobenius_rootSubgroupPoints`: its action on every numbered simple-root
+  subgroup.
+* `TauCeti.E6Minuscule.frobenius_weightTorusPoints`: its action on the split weight torus.
+* `TauCeti.E6Minuscule.frobenius_zero` and `frobenius_add`: its iteration laws.
+* `TauCeti.E6Minuscule.map_subtype_fixedSubgroup_frobenius_eq`: the identification of its fixed
+  points with points over the fixed subring.
+
+## References
+
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+* The formal organization follows the carrier specializations
+  `TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.Frobenius` and
+  `TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius`; all mathematical content is
+  transported from the generic
+  `TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius` API.
+
+This advances the Layer 9 target "points over an algebraically closed field as a group,
+functorially in the field" of `TauCetiRoadmap/ReductiveGroups/README.md`, which names the
+`q`-power Frobenius as its first consumer-facing case. Milestone L1 of
+`TauCetiRoadmap/CFSGStatement/README.md` consumes this endomorphism and its root-subgroup equation
+as the ordinary `E₆(q)` Steinberg map.
+-/
+
+public section
+
+open WithConv
+open scoped Matrix
+
+namespace TauCeti.E6Minuscule
+
+universe v
+
+noncomputable section
+
+open TauCeti.DynkinType
+
+variable (p k : ℕ) (A : Type v) [CommRing A] [ExpChar A p]
+
+private theorem points_eq_kostantToralPointsSubgroup :
+    points A =
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+          rw [TauCeti.serreKostantForm_def]
+          exact hu) hv)
+        isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight A := by
+  ext g
+  rw [mem_points_iff, definingIdeal_def,
+    TauCeti.UniversalEnvelopingAlgebra.mem_kostantToralPointsSubgroup_iff]
+
+/-- The presentation of the named minuscule-carrier points as the generic Kostant toral-closure
+points. -/
+private def pointsEquivKostantToralPoints :
+    points A ≃*
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+          rw [TauCeti.serreKostantForm_def]
+          exact hu) hv)
+        isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight A :=
+  MulEquiv.subgroupCongr (points_eq_kostantToralPointsSubgroup A)
+
+@[simp]
+private theorem coe_pointsEquivKostantToralPoints (g : points A) :
+    (pointsEquivKostantToralPoints A g :
+      _root_.Matrix.GeneralLinearGroup (Fin 27) A) = g :=
+  rfl
+
+/-- **The `p ^ k`-power Frobenius endomorphism of the full-weight type-`E₆` minuscule carrier.**
+
+For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the Frobenius component
+of the ordinary `E₆(p ^ k)` Steinberg map. -/
+def frobenius : points A →* points A :=
+  (pointsEquivKostantToralPoints A).symm.toMonoidHom.comp
+    ((TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A).comp
+        (pointsEquivKostantToralPoints A).toMonoidHom)
+
+private theorem pointsEquivKostantToralPoints_frobenius (g : points A) :
+    pointsEquivKostantToralPoints A (frobenius p k A g) =
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+          rw [TauCeti.serreKostantForm_def]
+          exact hu) hv)
+        isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A
+        (pointsEquivKostantToralPoints A g) := by
+  simp only [frobenius, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    MulEquiv.apply_symm_apply]
+
+/-- The Frobenius endomorphism of the minuscule carrier acts by entrywise Frobenius.
+
+This is not a `simp` lemma because `coe_frobenius_apply` is the canonical coefficient-level
+normal form. -/
+theorem coe_frobenius (g : points A) :
+    (frobenius p k A g : _root_.Matrix.GeneralLinearGroup (Fin 27) A) =
+      _root_.Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
+  have h := congrArg Subtype.val (pointsEquivKostantToralPoints_frobenius p k A g)
+  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
+  simpa only [coe_pointsEquivKostantToralPoints] using h
+
+/-- Entrywise, the Frobenius endomorphism raises each matrix coefficient to its `p ^ k`-th
+power. -/
+@[simp]
+theorem coe_frobenius_apply (g : points A) (i j : Fin 27) :
+    ((frobenius p k A g : _root_.Matrix.GeneralLinearGroup (Fin 27) A) :
+        _root_.Matrix (Fin 27) (Fin 27) A) i j =
+      ((g : _root_.Matrix.GeneralLinearGroup (Fin 27) A) :
+        _root_.Matrix (Fin 27) (Fin 27) A) i j ^ p ^ k := by
+  have h := TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius_apply
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A
+      (pointsEquivKostantToralPoints A g) i j
+  rw [← pointsEquivKostantToralPoints_frobenius] at h
+  simpa only [coe_pointsEquivKostantToralPoints] using h
+
+/-- **Frobenius raises the parameter of every numbered type-`E₆` simple-root subgroup to its
+`p ^ k`-th power.** -/
+@[simp]
+theorem frobenius_rootSubgroupPoints (i : Fin 6 ⊕ Fin 6) (u : Multiplicative A) :
+    frobenius p k A (rootSubgroupPoints i A u) =
+      rootSubgroupPoints i A
+        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ p ^ k)) := by
+  apply (pointsEquivKostantToralPoints A).injective
+  rw [pointsEquivKostantToralPoints_frobenius]
+  apply Subtype.ext
+  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius,
+    coe_pointsEquivKostantToralPoints, coe_rootSubgroupPoints,
+    coe_pointsEquivKostantToralPoints, coe_rootSubgroupPoints]
+  have h := congrArg Subtype.val
+    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_kostantRootSubgroupMatrix
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A i u)
+  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
+  exact h
+
+/-- **Frobenius raises every coordinate of the pinned split torus to its `p ^ k`-th power.** -/
+@[simp]
+theorem frobenius_weightTorusPoints (s : Fin 6 → Aˣ) :
+    frobenius p k A (weightTorusPoints A s) = weightTorusPoints A (s ^ p ^ k) := by
+  apply (pointsEquivKostantToralPoints A).injective
+  rw [pointsEquivKostantToralPoints_frobenius]
+  apply Subtype.ext
+  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius,
+    coe_pointsEquivKostantToralPoints, coe_weightTorusPoints,
+    coe_pointsEquivKostantToralPoints, coe_weightTorusPoints]
+  have h := congrArg Subtype.val
+    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_kostantTorusMatrix
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A s)
+  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
+  simpa only [TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] using h
+
+/-- The zeroth Frobenius iterate is the identity on the minuscule carrier's point group. -/
+@[simp]
+theorem frobenius_zero : frobenius p 0 A = MonoidHom.id _ := by
+  apply MonoidHom.ext
+  intro g
+  apply (pointsEquivKostantToralPoints A).injective
+  rw [pointsEquivKostantToralPoints_frobenius, MonoidHom.id_apply]
+  have h := DFunLike.congr_fun
+    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_zero
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p A)
+    (pointsEquivKostantToralPoints A g)
+  simpa only [MonoidHom.id_apply] using h
+
+/-- Frobenius iterates add under composition on the minuscule carrier's point group. -/
+theorem frobenius_add (m : ℕ) :
+    frobenius p (k + m) A = (frobenius p k A).comp (frobenius p m A) := by
+  apply MonoidHom.ext
+  intro g
+  apply (pointsEquivKostantToralPoints A).injective
+  rw [pointsEquivKostantToralPoints_frobenius, MonoidHom.comp_apply,
+    pointsEquivKostantToralPoints_frobenius, pointsEquivKostantToralPoints_frobenius]
+  exact DFunLike.congr_fun
+    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_add
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A m)
+    (pointsEquivKostantToralPoints A g)
+
+/-- A minuscule-carrier point is fixed by Frobenius exactly when all of its matrix entries lie in
+the Frobenius-fixed subring. -/
+@[simp]
+theorem frobenius_eq_self_iff (g : points A) :
+    frobenius p k A g = g ↔
+      ∀ i j, ((g : _root_.Matrix.GeneralLinearGroup (Fin 27) A) :
+        _root_.Matrix (Fin 27) (Fin 27) A) i j ∈ frobeniusFixedSubring A p k := by
+  have h := TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_eq_self_iff
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A
+      (pointsEquivKostantToralPoints A g)
+  rw [← pointsEquivKostantToralPoints_frobenius] at h
+  simp only [coe_pointsEquivKostantToralPoints] at h
+  constructor
+  · intro hg
+    exact h.mp (congrArg (pointsEquivKostantToralPoints A) hg)
+  · intro hg
+    exact (pointsEquivKostantToralPoints A).injective (h.mpr hg)
+
+/-- **The Frobenius-fixed points of the full-weight minuscule carrier are its points over the
+Frobenius-fixed subring.** -/
+theorem map_subtype_fixedSubgroup_frobenius_eq :
+    (fixedSubgroup (frobenius p k A)).map (points A).subtype =
+      (points ↥(frobeniusFixedSubring A p k)).map
+        (_root_.Matrix.GeneralLinearGroup.map (frobeniusFixedSubring A p k).subtype) := by
+  rw [TauCeti.map_subtype_fixedSubgroup_of_coe_eq (frobenius p k A) _
+    (coe_frobenius p k A)]
+  rw [points_eq_kostantToralPointsSubgroup, points_eq_kostantToralPointsSubgroup]
+  rw [← TauCeti.UniversalEnvelopingAlgebra.map_subtype_fixedSubgroup_kostantToralFrobenius]
+  exact
+    TauCeti.UniversalEnvelopingAlgebra.map_subtype_fixedSubgroup_kostantToralFrobenius_eq
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      isNilpotent_rep_serreRootGenerator latticeBasis e6MinusculeWeight p k A
+
+end
+
+
+end TauCeti.E6Minuscule

--- a/TauCeti/Algebra/Lie/E6/Minuscule/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/Frobenius.lean
@@ -33,7 +33,6 @@ simplicity statement is involved.
 
 * `TauCeti.E6Minuscule.frobenius`: the `p ^ k`-power Frobenius on the carrier's points.
 * `TauCeti.E6Minuscule.coe_frobenius` and `coe_frobenius_apply`: its matrix and entrywise actions.
-* `TauCeti.E6Minuscule.frobenius_eq_pointsMap`: its identification with the functorial point map.
 * `TauCeti.E6Minuscule.frobenius_rootSubgroupPoints`: its action on every numbered simple-root
   subgroup.
 * `TauCeti.E6Minuscule.frobenius_weightTorusPoints`: its action on the split weight torus.
@@ -88,12 +87,6 @@ theorem coe_frobenius (g : points A) :
     (frobenius p k A g : _root_.Matrix.GeneralLinearGroup (Fin 27) A) =
       _root_.Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
   rw [frobenius, coe_pointsMap]
-
-/-- The carrier Frobenius is the functorial map on points induced by the iterated Frobenius
-endomorphism of the value ring. -/
-theorem frobenius_eq_pointsMap :
-    frobenius p k A = pointsMap (iterateFrobenius A p k) := by
-  rw [frobenius]
 
 /-- Entrywise, the Frobenius endomorphism raises each matrix coefficient to its `p ^ k`-th
 power. -/


### PR DESCRIPTION
This PR equips the explicit full-weight type-`E₆` minuscule carrier with its `p ^ k`-power Frobenius on points. Transport the generic Kostant-toral Frobenius through the named carrier point group, identify it entrywise with coefficientwise Frobenius, prove its pinned actions `F(x_i(u)) = x_i(u^(p^k))` and `F(t(s)) = t(s^(p^k))`, record its zero and addition laws, and identify its fixed points with carrier points over the Frobenius-fixed subring.

The exact roadmap target is ReductiveGroups Layer 9, “Points over an algebraically closed field as a group, functorially in the field, so that a field endomorphism induces a group endomorphism of the points,” specifically its named first consumer case, the `q`-power Frobenius, within the milestone of pinned Chevalley–Demazure group schemes over `ℤ`. This is the most effective current step because the explicit full-weight `E₆` carrier is on `main`, while its sealed named point group had no Frobenius API and therefore could not yet be consumed as the ordinary `E₆(q)` Steinberg ambient group.

Consumer roadmap: CFSGStatement

The dependency edge is that CFSGStatement milestone L1, “ordinary and graph Steinberg maps,” takes `Frob_q` as the Steinberg map of the ordinary `E₆(q)` family and requires exactly the simple-root-subgroup equation proved here; milestone L3 then takes the fixed subgroup and its derived central quotient. After this PR, the ordinary `E₆(q)` branch still needs this map read against `ValidLieTypeIndex` and assembled into the L3 candidate, while ReductiveGroups Layer 9 still owes nonsimple-root subgroup maps and Chevalley relations, reductivity and root-datum identification; the separate open points-functor PR supplies arbitrary value-ring maps rather than this Frobenius specialization.

Add `TauCeti/Algebra/Lie/E6/Minuscule/Frobenius.lean` (292 lines). Reuse `TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius` and transport all results across the carrier's existing point-subgroup characterization; no Mathlib or other implementation is vendored. The mathematical conventions follow Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17, and Jantzen, *Representations of Algebraic Groups*, II.1, while the formal organization follows the existing type-`A` and type-`C` carrier Frobenius modules, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e6-minuscule-frobenius"}-->

🤖 Prepared with Codex
