### PR TITLE
refactor(TypeB): name the adjacent-node bracket in the type-B Serre relations

### DIFF
--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
@@ -135,26 +135,27 @@ private theorem lie_typeBSimpleRootMatrix_castSucc_of_nonadjacent
     simp only [Fin.val_succ, Fin.val_castSucc] at hval
     exact hji hval.symm
 
+private theorem lie_typeBSimpleRootMatrix_castSucc_of_adjacent
+    (i j : Fin n) (hij : i.val + 1 = j.val) (hout : i.castSucc ≠ j.succ) :
+    ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+      typeBSimpleRootMatrix (K := K) j.castSucc⁆ =
+        typeBLongRootMatrix i.castSucc j.succ hout := by
+  simp only [typeBSimpleRootMatrix_castSucc]
+  exact typeBLongRootMatrix_lie_longRootMatrix_chain (K := K)
+    i.castSucc i.succ j.castSucc j.succ (ne_of_lt i.castSucc_lt_succ)
+    (ne_of_lt j.castSucc_lt_succ) (Fin.ext hij) hout
+
 private theorem lie_lie_typeBSimpleRootMatrix_castSucc (i j : Fin n) :
     ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
       ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
         typeBSimpleRootMatrix (K := K) j.castSucc⁆⁆ = 0 := by
   by_cases hij : i.val + 1 = j.val
-  · have hmid : i.succ = j.castSucc := Fin.ext hij
-    have hout : i.castSucc ≠ j.succ := by
+  · have hout : i.castSucc ≠ j.succ := by
       intro h
       have hval := congrArg Fin.val h
       simp only [Fin.val_castSucc, Fin.val_succ] at hval
       omega
-    have hinner :
-        ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
-          typeBSimpleRootMatrix (K := K) j.castSucc⁆ =
-            typeBLongRootMatrix i.castSucc j.succ hout := by
-      simp only [typeBSimpleRootMatrix_castSucc]
-      exact typeBLongRootMatrix_lie_longRootMatrix_chain (K := K)
-        i.castSucc i.succ j.castSucc j.succ (ne_of_lt i.castSucc_lt_succ)
-        (ne_of_lt j.castSucc_lt_succ) hmid hout
-    rw [hinner]
+    rw [lie_typeBSimpleRootMatrix_castSucc_of_adjacent (K := K) i j hij hout]
     simp only [typeBSimpleRootMatrix_castSucc]
     apply typeBLongRootMatrix_lie_longRootMatrix_of_ne
     · intro h
@@ -163,30 +164,17 @@ private theorem lie_lie_typeBSimpleRootMatrix_castSucc (i j : Fin n) :
       omega
     · exact hout
   · by_cases hji : j.val + 1 = i.val
-    · have hmid : j.succ = i.castSucc := Fin.ext hji
-      have hout : j.castSucc ≠ i.succ := by
+    · have hout : j.castSucc ≠ i.succ := by
         intro h
         have hval := congrArg Fin.val h
         simp only [Fin.val_castSucc, Fin.val_succ] at hval
         omega
-      have hreverse :
-          ⁅typeBSimpleRootMatrix (K := K) j.castSucc,
-            typeBSimpleRootMatrix (K := K) i.castSucc⁆ =
-              typeBLongRootMatrix j.castSucc i.succ hout := by
-        simp only [typeBSimpleRootMatrix_castSucc]
-        exact typeBLongRootMatrix_lie_longRootMatrix_chain (K := K)
-          j.castSucc j.succ i.castSucc i.succ (ne_of_lt j.castSucc_lt_succ)
-          (ne_of_lt i.castSucc_lt_succ) hmid hout
       have hinner :
           ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
             typeBSimpleRootMatrix (K := K) j.castSucc⁆ =
               -typeBLongRootMatrix j.castSucc i.succ hout := by
-        calc
-          ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
-              typeBSimpleRootMatrix (K := K) j.castSucc⁆ =
-              -⁅typeBSimpleRootMatrix (K := K) j.castSucc,
-                typeBSimpleRootMatrix (K := K) i.castSucc⁆ := (lie_skew _ _).symm
-          _ = -typeBLongRootMatrix j.castSucc i.succ hout := by rw [hreverse]
+        rw [← lie_typeBSimpleRootMatrix_castSucc_of_adjacent (K := K) j i hji hout]
+        exact (lie_skew _ _).symm
       rw [hinner, lie_neg]
       simp only [typeBSimpleRootMatrix_castSucc, neg_eq_zero]
       apply typeBLongRootMatrix_lie_longRootMatrix_of_ne


### PR DESCRIPTION
Names the argument that `lie_lie_typeBSimpleRootMatrix_castSucc` was making twice inline.

## The duplicate

That proof splits on which of two adjacent Bourbaki nodes comes first, and each branch opens by
computing the same thing: the bracket of the two simple long-root matrices. The two computations
are the *same argument with `i` and `j` swapped* — `hinner` (old lines 149-156) and `hreverse`
(old lines 172-179) have identical proof text:

```lean
simp only [typeBSimpleRootMatrix_castSucc]
exact typeBLongRootMatrix_lie_longRootMatrix_chain (K := K)
  a.castSucc a.succ b.castSucc b.succ (ne_of_lt a.castSucc_lt_succ)
  (ne_of_lt b.castSucc_lt_succ) hmid hout
```

They are also the only two call sites of `typeBLongRootMatrix_lie_longRootMatrix_chain` in the
repository, so the lemma that names this step has **two consumers**, not one.

## The name

The file already names the negative half of exactly this dichotomy —
`lie_typeBSimpleRootMatrix_castSucc_of_nonadjacent`, a few lines above. The positive half had no
name and was spelled out in both branches. This PR adds it, with the matching name:

```lean
private theorem lie_typeBSimpleRootMatrix_castSucc_of_adjacent
    (i j : Fin n) (hij : i.val + 1 = j.val) (hout : i.castSucc ≠ j.succ) :
    ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
      typeBSimpleRootMatrix (K := K) j.castSucc⁆ =
        typeBLongRootMatrix i.castSucc j.succ hout
```

It sits directly beneath `_of_nonadjacent`, in the same layout, `private` like it and — like all
twelve private theorems in this file — without a docstring. Only the file's one private `def`
carries one, so that is the convention being followed rather than an omission.

Hypotheses are re-derived from the helper's own body rather than threaded from the caller: the
two `hmid : i.succ = j.castSucc` bindings disappear from both branches (`hmid` was defined as
`Fin.ext hij`, so the helper takes `hij` in the `Fin.val` form the surrounding `by_cases` and the
sibling `_of_nonadjacent` already use, and applies `Fin.ext` itself). `hout` stays a hypothesis
because it appears in the statement as the proof argument of `typeBLongRootMatrix`, and because
both callers need it for their own later steps regardless — it is not overhead created here. It
*is* derivable from `hij`, but deriving it internally would either need a second named lemma to
supply the proof term or put an anonymous one on the right-hand side at both call sites, where the
caller's own `hout` belongs.

## Measured

| | before | after |
|---|---|---|
| `lie_lie_typeBSimpleRootMatrix_castSucc` body | 58 | **36** |
| its largest contiguous block | 35 | **22** |
| new helper body | — | 4 |
| whole file | 412 | **400** |

The file now has no proof at or above the 55-line mark, and the extraction makes the file *shorter*
rather than trading a smaller headline number for a longer file. The diff is 15 insertions /
27 deletions in one file; no statement is changed, no existing declaration is renamed or moved, and
nothing outside the one proof and its new neighbour is touched.

Roadmap: ReductiveGroups
