### PR TITLE
feat: trivialize algebraic joint-weight actions

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/ConstantGroup/Points.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/ConstantGroup/Points.lean
@@ -83,13 +83,6 @@ theorem pointsMulEquiv_apply (G : Type v) [Group G] [Finite G] (g : G) :
   apply ofConv_injective
   exact toPoints_apply k G g
 
-/-- The inverse point equivalence sends evaluation at `g` back to `g`. -/
-@[simp]
-theorem pointsMulEquiv_symm_apply_eval (G : Type v) [Group G] [Finite G] (g : G) :
-    (pointsMulEquiv k G).symm (toConv (eval k G g)) = g := by
-  rw [← pointsMulEquiv_apply]
-  exact (pointsMulEquiv k G).symm_apply_apply g
-
 variable {H : Type w} [CommRing H] [Bialgebra k H]
 
 /-- A coordinate bialgebra morphism from the function algebra of a finite group to `H` induces
@@ -139,6 +132,17 @@ theorem pointHom_coordinateBialgHom
   simpa only [coordinateBialgHom_toAlgHom] using
     eval_comp_coordinateMap k F G q x
 
+/-- Pointwise, the morphism on points induced by a finite-group homomorphism is that
+homomorphism. -/
+@[simp]
+theorem pointHom_coordinateBialgHom_apply
+    {G : Type v} [Group G] [Finite G]
+    {F : Type w} [Group F] [Finite F] (q : F →* G) (x : F) :
+    pointHom (coordinateBialgHom k F G q) (toConv (eval k F x)) = q x := by
+  rw [← pointsMulEquiv_apply]
+  convert DFunLike.congr_fun (pointHom_coordinateBialgHom (k := k) q) x using 1
+  rfl
+
 /-- A connected affine group's homomorphism to a finite constant group is trivial on base-valued
 points. -/
 theorem pointHom_eq_one_of_connected {G : Type v} [Group G] [Finite G]
@@ -150,14 +154,6 @@ theorem pointHom_eq_one_of_connected {G : Type v} [Group G] [Finite G]
   apply (pointsMulEquiv k G).injective
   rw [pointsMulEquiv_pointHom, MonoidHom.one_apply, map_one]
   exact point_comp_eq_one_of_connected G hconnected f p.ofConv
-
-/-- Pointwise form of `pointHom_eq_one_of_connected`. -/
-theorem pointHom_apply_eq_one_of_connected {G : Type v} [Group G] [Finite G]
-    (hconnected : ConnectedSpace (PrimeSpectrum H))
-    (f : coordinateRing k G →ₐc[k] H)
-    (p : WithConv (H →ₐ[k] k)) :
-    pointHom f p = 1 := by
-  rw [pointHom_eq_one_of_connected hconnected f, MonoidHom.one_apply]
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/ConstantGroup/Points.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/ConstantGroup/Points.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.ConstantGroup.Connected
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
+import TauCeti.Algebra.Algebra.Pi
+
+/-!
+# Rational points of finite constant groups
+
+Let `G` be a finite group and `k` a field. The `k`-valued points of the constant group attached
+to `G` are canonically `G` itself. Indeed, every `k`-algebra homomorphism from the function
+algebra `k^G` to `k` is evaluation at a unique element of `G`.
+
+This identification turns a coordinate bialgebra morphism `k^G \to H` into a group homomorphism
+from the `k`-valued points of `Spec H` to `G`. If `Spec H` is connected, that homomorphism is
+trivial by `ConstantGroup.point_comp_eq_one_of_connected`.
+
+The point-level formulation is the interface needed by the Lie--Kolchin argument. Its finite
+permutation action is naturally stated as a homomorphism to a finite symmetric group, whereas
+connectedness applies to the corresponding morphism of affine group schemes.
+
+## Main declarations
+
+* `TauCeti.ConstantGroup.pointsMulEquiv`: the canonical multiplicative equivalence between a
+  finite group and the base-valued points of its constant group.
+* `TauCeti.ConstantGroup.pointHom`: the homomorphism on base-valued points induced by a coordinate
+  bialgebra morphism to a finite constant group.
+* `TauCeti.ConstantGroup.pointHom_eq_one_of_connected`: connected affine groups have no nontrivial
+  algebraic homomorphism to a finite constant group.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 1.34.
+* T. A. Springer, *Linear Algebraic Groups*, Theorem 6.3.1.
+
+This advances the "Lie--Kolchin; solvable groups" milestone in Layer 5 of the ReductiveGroups
+roadmap.
+-/
+
+public section
+
+open WithConv
+
+namespace TauCeti.ConstantGroup
+
+universe u v w
+
+noncomputable section
+
+variable {k : Type u} [Field k]
+variable (G : Type v) [Group G] [Finite G]
+
+private theorem toPoints_surjective :
+    Function.Surjective (toPoints k G) := by
+  intro p
+  let e := functionAlgEquiv k G
+  obtain ⟨g, hg⟩ := (Pi.evalAlgHomEquiv k G).surjective (p.ofConv.comp e.symm.toAlgHom)
+  refine ⟨g, ?_⟩
+  apply ofConv_injective
+  rw [toPoints_apply]
+  ext a
+  rw [eval_apply]
+  have ha := DFunLike.congr_fun hg (e a)
+  change e a g = p.ofConv a
+  rw [Pi.evalAlgHomEquiv_apply, Pi.evalAlgHom_apply, AlgHom.comp_apply] at ha
+  change e a g = p.ofConv (e.symm (e a)) at ha
+  rw [e.symm_apply_apply] at ha
+  exact ha
+
+/-- The base-valued points of the constant group attached to a finite group `G` are canonically
+`G` itself. -/
+noncomputable def pointsMulEquiv :
+    G ≃* WithConv (coordinateRing k G →ₐ[k] k) :=
+  MulEquiv.ofBijective (toPoints k G)
+    ⟨toPoints_injective k G, toPoints_surjective G⟩
+
+/-- The canonical equivalence from a finite group to its constant-group points is evaluation. -/
+@[simp]
+theorem pointsMulEquiv_apply (g : G) :
+    pointsMulEquiv (k := k) G g = toConv (eval k G g) := by
+  change toPoints k G g = toConv (eval k G g)
+  apply ofConv_injective
+  rw [toPoints_apply]
+
+/-- The inverse point equivalence sends evaluation at `g` back to `g`. -/
+@[simp]
+theorem pointsMulEquiv_symm_apply_eval (g : G) :
+    (pointsMulEquiv (k := k) G).symm (toConv (eval k G g)) = g := by
+  rw [← pointsMulEquiv_apply]
+  exact (pointsMulEquiv (k := k) G).symm_apply_apply g
+
+variable {H : Type w} [CommRing H] [Bialgebra k H]
+
+/-- A coordinate bialgebra morphism from the function algebra of a finite group to `H` induces
+a homomorphism from the base-valued points of `Spec H` to that finite group. -/
+noncomputable def pointHom (f : coordinateRing k G →ₐc[k] H) :
+    WithConv (H →ₐ[k] k) →* G :=
+  (pointsMulEquiv (k := k) G).symm.toMonoidHom.comp (AlgHom.mapDomain f)
+
+/-- The point homomorphism induced by `f` is characterized by evaluation after precomposition
+with `f`. -/
+theorem pointsMulEquiv_pointHom (f : coordinateRing k G →ₐc[k] H)
+    (p : WithConv (H →ₐ[k] k)) :
+    pointsMulEquiv (k := k) G (pointHom G f p) = AlgHom.mapDomain f p := by
+  exact (pointsMulEquiv (k := k) G).apply_symm_apply (AlgHom.mapDomain f p)
+
+/-- Pointwise, the coordinate map induced by `pointHom f p` is precomposition with `f`. -/
+theorem eval_pointHom (f : coordinateRing k G →ₐc[k] H)
+    (p : WithConv (H →ₐ[k] k)) :
+    eval k G (pointHom G f p) = p.ofConv.comp f.toAlgHom := by
+  have h := congrArg ofConv (pointsMulEquiv_pointHom G f p)
+  simpa only [pointsMulEquiv_apply, ofConv_toConv, AlgHom.mapDomain_apply] using h
+
+/-- A coordinate morphism induced contravariantly by a homomorphism of finite groups recovers
+that homomorphism on base-valued points. -/
+@[simp]
+theorem pointHom_coordinateBialgHom
+    {F : Type w} [Group F] [Finite F] (q : F →* G) :
+    (pointHom G (coordinateBialgHom k F G q)).comp
+      (pointsMulEquiv (k := k) F) = q := by
+  apply MonoidHom.ext
+  intro x
+  rw [MonoidHom.comp_apply]
+  apply (pointsMulEquiv (k := k) G).injective
+  rw [pointsMulEquiv_pointHom, pointsMulEquiv_apply]
+  change AlgHom.mapDomain (coordinateBialgHom k F G q)
+    (pointsMulEquiv (k := k) F x) = toConv (eval k G (q x))
+  rw [pointsMulEquiv_apply, AlgHom.mapDomain_apply]
+  apply ofConv_injective
+  simpa only [ofConv_toConv, coordinateBialgHom_toAlgHom] using
+    eval_comp_coordinateMap k F G q x
+
+/-- A connected affine group's homomorphism to a finite constant group is trivial on base-valued
+points. -/
+theorem pointHom_eq_one_of_connected
+    (hconnected : ConnectedSpace (PrimeSpectrum H))
+    (f : coordinateRing k G →ₐc[k] H) :
+    pointHom G f = 1 := by
+  apply MonoidHom.ext
+  intro p
+  apply (pointsMulEquiv (k := k) G).injective
+  rw [pointsMulEquiv_pointHom, MonoidHom.one_apply, map_one]
+  exact point_comp_eq_one_of_connected G hconnected f p.ofConv
+
+/-- Pointwise form of `pointHom_eq_one_of_connected`. -/
+theorem pointHom_apply_eq_one_of_connected
+    (hconnected : ConnectedSpace (PrimeSpectrum H))
+    (f : coordinateRing k G →ₐc[k] H)
+    (p : WithConv (H →ₐ[k] k)) :
+    pointHom G f p = 1 := by
+  rw [pointHom_eq_one_of_connected G hconnected f, MonoidHom.one_apply]
+
+end
+
+end TauCeti.ConstantGroup

--- a/TauCeti/Algebra/AlgebraicGroup/ConstantGroup/Points.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/ConstantGroup/Points.lean
@@ -53,107 +53,111 @@ universe u v w
 noncomputable section
 
 variable {k : Type u} [Field k]
-variable (G : Type v) [Group G] [Finite G]
 
-private theorem toPoints_surjective :
+private theorem toPoints_surjective (G : Type v) [Group G] [Finite G] :
     Function.Surjective (toPoints k G) := by
   intro p
-  let e := functionAlgEquiv k G
-  obtain ⟨g, hg⟩ := (Pi.evalAlgHomEquiv k G).surjective (p.ofConv.comp e.symm.toAlgHom)
+  obtain ⟨g, hg⟩ := (Pi.evalAlgHomEquiv k G).surjective
+    (p.ofConv.comp (functionAlgEquiv k G).symm.toAlgHom)
   refine ⟨g, ?_⟩
   apply ofConv_injective
   rw [toPoints_apply]
   ext a
   rw [eval_apply]
-  have ha := DFunLike.congr_fun hg (e a)
-  change e a g = p.ofConv a
+  have ha := DFunLike.congr_fun hg (functionAlgEquiv k G a)
   rw [Pi.evalAlgHomEquiv_apply, Pi.evalAlgHom_apply, AlgHom.comp_apply] at ha
-  change e a g = p.ofConv (e.symm (e a)) at ha
-  rw [e.symm_apply_apply] at ha
-  exact ha
+  exact ha.trans (congrArg p.ofConv ((functionAlgEquiv k G).symm_apply_apply a))
 
 /-- The base-valued points of the constant group attached to a finite group `G` are canonically
 `G` itself. -/
-noncomputable def pointsMulEquiv :
+noncomputable def pointsMulEquiv (k : Type u) [Field k]
+    (G : Type v) [Group G] [Finite G] :
     G ≃* WithConv (coordinateRing k G →ₐ[k] k) :=
   MulEquiv.ofBijective (toPoints k G)
     ⟨toPoints_injective k G, toPoints_surjective G⟩
 
 /-- The canonical equivalence from a finite group to its constant-group points is evaluation. -/
 @[simp]
-theorem pointsMulEquiv_apply (g : G) :
-    pointsMulEquiv (k := k) G g = toConv (eval k G g) := by
-  change toPoints k G g = toConv (eval k G g)
+theorem pointsMulEquiv_apply (G : Type v) [Group G] [Finite G] (g : G) :
+    pointsMulEquiv k G g = toConv (eval k G g) := by
   apply ofConv_injective
-  rw [toPoints_apply]
+  exact toPoints_apply k G g
 
 /-- The inverse point equivalence sends evaluation at `g` back to `g`. -/
 @[simp]
-theorem pointsMulEquiv_symm_apply_eval (g : G) :
-    (pointsMulEquiv (k := k) G).symm (toConv (eval k G g)) = g := by
+theorem pointsMulEquiv_symm_apply_eval (G : Type v) [Group G] [Finite G] (g : G) :
+    (pointsMulEquiv k G).symm (toConv (eval k G g)) = g := by
   rw [← pointsMulEquiv_apply]
-  exact (pointsMulEquiv (k := k) G).symm_apply_apply g
+  exact (pointsMulEquiv k G).symm_apply_apply g
 
 variable {H : Type w} [CommRing H] [Bialgebra k H]
 
 /-- A coordinate bialgebra morphism from the function algebra of a finite group to `H` induces
 a homomorphism from the base-valued points of `Spec H` to that finite group. -/
-noncomputable def pointHom (f : coordinateRing k G →ₐc[k] H) :
+noncomputable def pointHom {G : Type v} [Group G] [Finite G]
+    (f : coordinateRing k G →ₐc[k] H) :
     WithConv (H →ₐ[k] k) →* G :=
-  (pointsMulEquiv (k := k) G).symm.toMonoidHom.comp (AlgHom.mapDomain f)
+  (pointsMulEquiv k G).symm.toMonoidHom.comp (AlgHom.mapDomain f)
 
 /-- The point homomorphism induced by `f` is characterized by evaluation after precomposition
 with `f`. -/
-theorem pointsMulEquiv_pointHom (f : coordinateRing k G →ₐc[k] H)
+theorem pointsMulEquiv_pointHom {G : Type v} [Group G] [Finite G]
+    (f : coordinateRing k G →ₐc[k] H)
     (p : WithConv (H →ₐ[k] k)) :
-    pointsMulEquiv (k := k) G (pointHom G f p) = AlgHom.mapDomain f p := by
-  exact (pointsMulEquiv (k := k) G).apply_symm_apply (AlgHom.mapDomain f p)
+    pointsMulEquiv k G (pointHom f p) = AlgHom.mapDomain f p := by
+  exact (pointsMulEquiv k G).apply_symm_apply (AlgHom.mapDomain f p)
 
 /-- Pointwise, the coordinate map induced by `pointHom f p` is precomposition with `f`. -/
-theorem eval_pointHom (f : coordinateRing k G →ₐc[k] H)
+@[simp]
+theorem eval_pointHom {G : Type v} [Group G] [Finite G]
+    (f : coordinateRing k G →ₐc[k] H)
     (p : WithConv (H →ₐ[k] k)) :
-    eval k G (pointHom G f p) = p.ofConv.comp f.toAlgHom := by
-  have h := congrArg ofConv (pointsMulEquiv_pointHom G f p)
+    eval k G (pointHom f p) = p.ofConv.comp f.toAlgHom := by
+  have h := congrArg ofConv (pointsMulEquiv_pointHom f p)
   simpa only [pointsMulEquiv_apply, ofConv_toConv, AlgHom.mapDomain_apply] using h
 
 /-- A coordinate morphism induced contravariantly by a homomorphism of finite groups recovers
 that homomorphism on base-valued points. -/
 @[simp]
 theorem pointHom_coordinateBialgHom
+    {G : Type v} [Group G] [Finite G]
     {F : Type w} [Group F] [Finite F] (q : F →* G) :
-    (pointHom G (coordinateBialgHom k F G q)).comp
-      (pointsMulEquiv (k := k) F) = q := by
+    (pointHom (coordinateBialgHom k F G q)).comp (pointsMulEquiv k F) = q := by
   apply MonoidHom.ext
   intro x
   rw [MonoidHom.comp_apply]
-  apply (pointsMulEquiv (k := k) G).injective
+  apply (pointsMulEquiv k G).injective
   rw [pointsMulEquiv_pointHom, pointsMulEquiv_apply]
-  change AlgHom.mapDomain (coordinateBialgHom k F G q)
-    (pointsMulEquiv (k := k) F x) = toConv (eval k G (q x))
-  rw [pointsMulEquiv_apply, AlgHom.mapDomain_apply]
-  apply ofConv_injective
-  simpa only [ofConv_toConv, coordinateBialgHom_toAlgHom] using
+  rw [AlgHom.mapDomain_apply]
+  apply congrArg toConv
+  have hx : (pointsMulEquiv k F x).ofConv = eval k F x :=
+    congrArg ofConv (pointsMulEquiv_apply (k := k) F x)
+  -- Normalize the `MulEquiv` coercion so that the pointwise equality `hx` can rewrite.
+  change (pointsMulEquiv k F x).ofConv.comp (coordinateBialgHom k F G q).toAlgHom =
+    eval k G (q x)
+  rw [hx]
+  simpa only [coordinateBialgHom_toAlgHom] using
     eval_comp_coordinateMap k F G q x
 
 /-- A connected affine group's homomorphism to a finite constant group is trivial on base-valued
 points. -/
-theorem pointHom_eq_one_of_connected
+theorem pointHom_eq_one_of_connected {G : Type v} [Group G] [Finite G]
     (hconnected : ConnectedSpace (PrimeSpectrum H))
     (f : coordinateRing k G →ₐc[k] H) :
-    pointHom G f = 1 := by
+    pointHom f = 1 := by
   apply MonoidHom.ext
   intro p
-  apply (pointsMulEquiv (k := k) G).injective
+  apply (pointsMulEquiv k G).injective
   rw [pointsMulEquiv_pointHom, MonoidHom.one_apply, map_one]
   exact point_comp_eq_one_of_connected G hconnected f p.ofConv
 
 /-- Pointwise form of `pointHom_eq_one_of_connected`. -/
-theorem pointHom_apply_eq_one_of_connected
+theorem pointHom_apply_eq_one_of_connected {G : Type v} [Group G] [Finite G]
     (hconnected : ConnectedSpace (PrimeSpectrum H))
     (f : coordinateRing k G →ₐc[k] H)
     (p : WithConv (H →ₐ[k] k)) :
-    pointHom G f p = 1 := by
-  rw [pointHom_eq_one_of_connected G hconnected f, MonoidHom.one_apply]
+    pointHom f p = 1 := by
+  rw [pointHom_eq_one_of_connected hconnected f, MonoidHom.one_apply]
 
 end
 

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Normal/Connected.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Normal/Connected.lean
@@ -58,14 +58,6 @@ variable {V : Type w} [AddCommGroup V] [Module k V] [FiniteDimensional k V]
 variable (N : Subgroup (WithConv (H →ₐ[k] k))) [N.Normal]
 variable (ρ : WithConv (H →ₐ[k] k) →* Module.End k V)
 
-/-- The type of characters of a normal subgroup whose joint weight space is nonzero. -/
-abbrev NonzeroJointWeight :=
-  {χ : N →* kˣ // (⨅ n : N, (ρ n).eigenspace (χ n)) ≠ ⊥}
-
-/-- Finiteness of the nonzero joint weights, specialized to a normal subgroup. -/
-local instance : Finite (NonzeroJointWeight N ρ) :=
-  finite_nonzeroJointWeights (ρ.comp N.subtype)
-
 /-- A finite indexing type for the nonzero joint weights. -/
 local instance : Fintype (NonzeroJointWeight N ρ) :=
   Fintype.ofFinite _
@@ -77,10 +69,10 @@ theorem nonzeroJointWeightAction_eq_one_of_coordinate
     (hconnected : ConnectedSpace (PrimeSpectrum H))
     (f : ConstantGroup.coordinateRing k (Equiv.Perm (NonzeroJointWeight N ρ)) →ₐc[k] H)
     (hcoordinate : nonzeroJointWeightAction N ρ =
-      ConstantGroup.pointHom (Equiv.Perm (NonzeroJointWeight N ρ)) f) :
+      ConstantGroup.pointHom f) :
     nonzeroJointWeightAction N ρ = 1 := by
   rw [hcoordinate]
-  exact ConstantGroup.pointHom_eq_one_of_connected _ hconnected f
+  exact ConstantGroup.pointHom_eq_one_of_connected hconnected f
 
 /-- Under a coordinate realization of the finite joint-weight action, every point of a connected
 affine group fixes every nonzero normal-subgroup joint weight. -/
@@ -88,7 +80,7 @@ theorem nonzeroJointWeightAction_apply_eq_self_of_coordinate
     (hconnected : ConnectedSpace (PrimeSpectrum H))
     (f : ConstantGroup.coordinateRing k (Equiv.Perm (NonzeroJointWeight N ρ)) →ₐc[k] H)
     (hcoordinate : nonzeroJointWeightAction N ρ =
-      ConstantGroup.pointHom (Equiv.Perm (NonzeroJointWeight N ρ)) f)
+      ConstantGroup.pointHom f)
     (g : WithConv (H →ₐ[k] k)) (χ : NonzeroJointWeight N ρ) :
     nonzeroJointWeightAction N ρ g χ = χ := by
   rw [nonzeroJointWeightAction_eq_one_of_coordinate N ρ hconnected f hcoordinate]
@@ -100,7 +92,7 @@ theorem map_iInf_eigenspace_unitHom_eq_self_of_coordinate
     (hconnected : ConnectedSpace (PrimeSpectrum H))
     (f : ConstantGroup.coordinateRing k (Equiv.Perm (NonzeroJointWeight N ρ)) →ₐc[k] H)
     (hcoordinate : nonzeroJointWeightAction N ρ =
-      ConstantGroup.pointHom (Equiv.Perm (NonzeroJointWeight N ρ)) f)
+      ConstantGroup.pointHom f)
     (g : WithConv (H →ₐ[k] k)) (χ : NonzeroJointWeight N ρ) :
     (⨅ n : N, (ρ n).eigenspace (χ.1 n)).map (ρ g) =
       ⨅ n : N, (ρ n).eigenspace (χ.1 n) := by

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Normal/Connected.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Normal/Connected.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.ConstantGroup.Points
+public import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Normal.Finite
+
+/-!
+# Connected algebraic actions on normal-subgroup joint weights
+
+Let `H` be the coordinate ring of a connected affine group over a field `k`, acting linearly on a
+finite-dimensional vector space. A normal subgroup of the base-valued point group determines a
+finite set of characters with nonzero joint weight space, and the ambient point group permutes
+those characters.
+
+If this permutation action is represented by a coordinate bialgebra morphism to the corresponding
+finite constant symmetric group, connectedness forces it to be trivial. Consequently every
+nonzero joint weight space is preserved by every ambient point.
+
+This isolates the connectedness half of the Lie--Kolchin induction. To apply it to a connected
+solvable affine group, it remains to construct the coordinate morphism representing the
+joint-weight permutation; the finiteness and pointwise action are already supplied by
+`finiteIndex_ker_nonzeroJointWeightAction` and `nonzeroJointWeightAction`.
+
+## Main declarations
+
+* `TauCeti.nonzeroJointWeightAction_eq_one_of_coordinate`: a coordinate realization of the
+  finite joint-weight action of a connected affine group is trivial.
+* `TauCeti.map_iInf_eigenspace_unitHom_eq_self_of_coordinate`: every ambient point preserves each
+  nonzero normal-subgroup joint weight space.
+
+## References
+
+* A. Borel, *Linear Algebraic Groups*, §10.5.
+* J. E. Humphreys, *Linear Algebraic Groups*, §17.6.
+
+This advances the "Lie--Kolchin; solvable groups" milestone in Layer 5 of the ReductiveGroups
+roadmap.
+-/
+
+public section
+
+open WithConv
+
+namespace TauCeti
+
+universe u v w x
+
+noncomputable section
+
+variable {k : Type u} [Field k]
+variable {H : Type v} [CommRing H] [HopfAlgebra k H]
+variable {V : Type w} [AddCommGroup V] [Module k V] [FiniteDimensional k V]
+
+variable (N : Subgroup (WithConv (H →ₐ[k] k))) [N.Normal]
+variable (ρ : WithConv (H →ₐ[k] k) →* Module.End k V)
+
+/-- The type of characters of a normal subgroup whose joint weight space is nonzero. -/
+abbrev NonzeroJointWeight :=
+  {χ : N →* kˣ // (⨅ n : N, (ρ n).eigenspace (χ n)) ≠ ⊥}
+
+/-- Finiteness of the nonzero joint weights, specialized to a normal subgroup. -/
+local instance : Finite (NonzeroJointWeight N ρ) :=
+  finite_nonzeroJointWeights (ρ.comp N.subtype)
+
+/-- A finite indexing type for the nonzero joint weights. -/
+local instance : Fintype (NonzeroJointWeight N ρ) :=
+  Fintype.ofFinite _
+
+/-- If the permutation of nonzero normal-subgroup joint weights is represented by a coordinate
+morphism to the corresponding finite constant symmetric group, connectedness makes the
+permutation action trivial. -/
+theorem nonzeroJointWeightAction_eq_one_of_coordinate
+    (hconnected : ConnectedSpace (PrimeSpectrum H))
+    (f : ConstantGroup.coordinateRing k (Equiv.Perm (NonzeroJointWeight N ρ)) →ₐc[k] H)
+    (hcoordinate : nonzeroJointWeightAction N ρ =
+      ConstantGroup.pointHom (Equiv.Perm (NonzeroJointWeight N ρ)) f) :
+    nonzeroJointWeightAction N ρ = 1 := by
+  rw [hcoordinate]
+  exact ConstantGroup.pointHom_eq_one_of_connected _ hconnected f
+
+/-- Under a coordinate realization of the finite joint-weight action, every point of a connected
+affine group fixes every nonzero normal-subgroup joint weight. -/
+theorem nonzeroJointWeightAction_apply_eq_self_of_coordinate
+    (hconnected : ConnectedSpace (PrimeSpectrum H))
+    (f : ConstantGroup.coordinateRing k (Equiv.Perm (NonzeroJointWeight N ρ)) →ₐc[k] H)
+    (hcoordinate : nonzeroJointWeightAction N ρ =
+      ConstantGroup.pointHom (Equiv.Perm (NonzeroJointWeight N ρ)) f)
+    (g : WithConv (H →ₐ[k] k)) (χ : NonzeroJointWeight N ρ) :
+    nonzeroJointWeightAction N ρ g χ = χ := by
+  rw [nonzeroJointWeightAction_eq_one_of_coordinate N ρ hconnected f hcoordinate]
+  rfl
+
+/-- Under a coordinate realization of the finite joint-weight action, every point of a connected
+affine group preserves every nonzero normal-subgroup joint weight space. -/
+theorem map_iInf_eigenspace_unitHom_eq_self_of_coordinate
+    (hconnected : ConnectedSpace (PrimeSpectrum H))
+    (f : ConstantGroup.coordinateRing k (Equiv.Perm (NonzeroJointWeight N ρ)) →ₐc[k] H)
+    (hcoordinate : nonzeroJointWeightAction N ρ =
+      ConstantGroup.pointHom (Equiv.Perm (NonzeroJointWeight N ρ)) f)
+    (g : WithConv (H →ₐ[k] k)) (χ : NonzeroJointWeight N ρ) :
+    (⨅ n : N, (ρ n).eigenspace (χ.1 n)).map (ρ g) =
+      ⨅ n : N, (ρ n).eigenspace (χ.1 n) := by
+  apply map_iInf_eigenspace_unitHom_eq_self_of_nonzeroJointWeightAction_eq N ρ g χ
+  exact nonzeroJointWeightAction_apply_eq_self_of_coordinate
+    N ρ hconnected f hcoordinate g χ
+
+end
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Normal/Connected.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Normal/Connected.lean
@@ -27,10 +27,10 @@ joint-weight permutation; the finiteness and pointwise action are already suppli
 
 ## Main declarations
 
-* `TauCeti.nonzeroJointWeightAction_eq_one_of_coordinate`: a coordinate realization of the
+* `TauCeti.nonzeroJointWeightAction_eq_one_of_eq_pointHom`: a coordinate realization of the
   finite joint-weight action of a connected affine group is trivial.
-* `TauCeti.map_iInf_eigenspace_unitHom_eq_self_of_coordinate`: every ambient point preserves each
-  nonzero normal-subgroup joint weight space.
+* `TauCeti.map_iInf_eigenspace_unitHom_eq_self_of_eq_pointHom`: every ambient point preserves
+  each nonzero normal-subgroup joint weight space.
 
 ## References
 
@@ -65,7 +65,7 @@ local instance : Fintype (NonzeroJointWeight N ρ) :=
 /-- If the permutation of nonzero normal-subgroup joint weights is represented by a coordinate
 morphism to the corresponding finite constant symmetric group, connectedness makes the
 permutation action trivial. -/
-theorem nonzeroJointWeightAction_eq_one_of_coordinate
+theorem nonzeroJointWeightAction_eq_one_of_eq_pointHom
     (hconnected : ConnectedSpace (PrimeSpectrum H))
     (f : ConstantGroup.coordinateRing k (Equiv.Perm (NonzeroJointWeight N ρ)) →ₐc[k] H)
     (hcoordinate : nonzeroJointWeightAction N ρ =
@@ -75,20 +75,8 @@ theorem nonzeroJointWeightAction_eq_one_of_coordinate
   exact ConstantGroup.pointHom_eq_one_of_connected hconnected f
 
 /-- Under a coordinate realization of the finite joint-weight action, every point of a connected
-affine group fixes every nonzero normal-subgroup joint weight. -/
-theorem nonzeroJointWeightAction_apply_eq_self_of_coordinate
-    (hconnected : ConnectedSpace (PrimeSpectrum H))
-    (f : ConstantGroup.coordinateRing k (Equiv.Perm (NonzeroJointWeight N ρ)) →ₐc[k] H)
-    (hcoordinate : nonzeroJointWeightAction N ρ =
-      ConstantGroup.pointHom f)
-    (g : WithConv (H →ₐ[k] k)) (χ : NonzeroJointWeight N ρ) :
-    nonzeroJointWeightAction N ρ g χ = χ := by
-  rw [nonzeroJointWeightAction_eq_one_of_coordinate N ρ hconnected f hcoordinate]
-  rfl
-
-/-- Under a coordinate realization of the finite joint-weight action, every point of a connected
 affine group preserves every nonzero normal-subgroup joint weight space. -/
-theorem map_iInf_eigenspace_unitHom_eq_self_of_coordinate
+theorem map_iInf_eigenspace_unitHom_eq_self_of_eq_pointHom
     (hconnected : ConnectedSpace (PrimeSpectrum H))
     (f : ConstantGroup.coordinateRing k (Equiv.Perm (NonzeroJointWeight N ρ)) →ₐc[k] H)
     (hcoordinate : nonzeroJointWeightAction N ρ =
@@ -97,8 +85,8 @@ theorem map_iInf_eigenspace_unitHom_eq_self_of_coordinate
     (⨅ n : N, (ρ n).eigenspace (χ.1 n)).map (ρ g) =
       ⨅ n : N, (ρ n).eigenspace (χ.1 n) := by
   apply map_iInf_eigenspace_unitHom_eq_self_of_nonzeroJointWeightAction_eq N ρ g χ
-  exact nonzeroJointWeightAction_apply_eq_self_of_coordinate
-    N ρ hconnected f hcoordinate g χ
+  rw [nonzeroJointWeightAction_eq_one_of_eq_pointHom N ρ hconnected f hcoordinate]
+  rfl
 
 end
 

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Normal/Finite.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Normal/Finite.lean
@@ -19,8 +19,9 @@ index. Each element of that kernel preserves every nonzero joint weight space by
 This is the finite-action bridge in the Lie--Kolchin argument. The remaining connectedness step is
 to show that the ambient algebraic group acts trivially on this finite set.
 
-## Main declaration
+## Main declarations
 
+* `NonzeroJointWeight`: the characters whose joint weight space is nonzero.
 * `finiteIndex_ker_nonzeroJointWeightAction`: for a normal subgroup, the kernel of the ambient
   permutation action on its nonzero joint weights has finite index.
 
@@ -38,14 +39,21 @@ namespace TauCeti
 
 variable {G K V : Type*} [Group G] [Field K] [AddCommGroup V] [Module K V]
 
+/-- The characters of a subgroup whose joint weight space in a representation is nonzero. -/
+abbrev NonzeroJointWeight (N : Subgroup G) (ρ : G →* Module.End K V) :=
+  {χ : N →* Kˣ // (⨅ n : N, (ρ n).eigenspace (χ n)) ≠ ⊥}
+
+/-- A finite-dimensional representation has only finitely many nonzero joint weights. -/
+instance instFiniteNonzeroJointWeight [FiniteDimensional K V]
+    (N : Subgroup G) (ρ : G →* Module.End K V) : Finite (NonzeroJointWeight N ρ) :=
+  finite_nonzeroJointWeights (ρ.comp N.subtype)
+
 /-- The kernel of the permutation action on nonzero normal-subgroup weights has finite index in
 the ambient group. -/
 theorem finiteIndex_ker_nonzeroJointWeightAction [FiniteDimensional K V]
     (N : Subgroup G) [N.Normal]
     (ρ : G →* Module.End K V) :
     (nonzeroJointWeightAction N ρ).ker.FiniteIndex := by
-  let _ : Finite {χ : N →* Kˣ // (⨅ n : N, (ρ n).eigenspace (χ n)) ≠ ⊥} :=
-    finite_nonzeroJointWeights (ρ.comp N.subtype)
   exact Subgroup.finiteIndex_ker (nonzeroJointWeightAction N ρ)
 
 end TauCeti


### PR DESCRIPTION
This PR identifies the base-valued points of a finite constant group with the original finite group and trivializes every coordinate-realized permutation of nonzero normal-subgroup joint weights for a connected affine group. It advances the exact `TauCetiRoadmap/ReductiveGroups/README.md` Layer 5 target “Lie–Kolchin; solvable groups” by connecting the finite joint-weight action to the existing connected-to-constant-group theorem.

The new point equivalence is proved from the existing finite-power algebra-homomorphism classification, its induced point homomorphism is checked against coordinate maps of finite groups, and the joint-weight consumer concludes both triviality of the permutation action and invariance of every nonzero joint weight space.

After this PR, the milestone still needs the coordinate morphism representing the joint-weight permutation for an algebraic representation, followed by the derived-series induction constructing invariant lines and flags.

No external code is vendored; the proof reuses Mathlib’s `AlgHom.eq_piEvalAlgHom` through Tau Ceti’s existing `Pi.evalAlgHomEquiv` interface.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"connected-nonzero-joint-weight-action"}-->

🤖 Prepared with Codex
