### PR TITLE
feat: add the type-D spin-weight graph symmetry

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/GraphAutomorphism.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.RootSystem.DiagramPermutations
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.D.SpinWeight
 
 /-!
@@ -332,7 +331,7 @@ theorem typeDGraphAut_weightMap_typeDSpinWeight (hn : 4 ≤ n) (s : Finset (Fin 
       typeDSpinWeight (typeDSpinGraphPerm n (by omega) s) := by
   funext i
   rw [weightMap_typeDGraphAut_apply]
-  exact (typeDSpinWeight_typeDSpinGraphPerm_apply hn s i).symm
+  exact (typeDSpinWeight_typeDSpinGraphPerm_apply (by omega) s i).symm
 
 /-- The root-index action of the type-`D` graph automorphism restricts to the fork swap on the
 pinned simple roots. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/GraphAutomorphism.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.RootSystem.DiagramPermutations
-public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.D.Basic
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.D.SpinWeight
 
 /-!
 # The graph automorphism of the pinned type `Dₙ` root datum
@@ -29,6 +29,8 @@ permutation `TauCeti.graphPermD` used by the graph-twisted finite groups of Lie 
 * `TauCeti.DynkinType.typeDGraphAut`: the resulting automorphism of the pinned simply connected
   root datum.
 * `TauCeti.DynkinType.typeDGraphAut_sq`: the automorphism has square one.
+* `TauCeti.DynkinType.typeDGraphAut_weightMap_typeDSpinWeight`: its weight map toggles the final
+  sign in the spin-weight indexing.
 * `TauCeti.DynkinType.image_typeDGraphAut_indexEquiv_typeDSimplyConnectedBase_support`: the
   pinned base support is preserved.
 
@@ -320,6 +322,17 @@ node coordinates. -/
 @[simp] theorem coweightMap_typeDGraphAut_apply (hn : 4 ≤ n) (x : Fin n → ℤ) (i : Fin n) :
     (typeDGraphAut n hn).coweightMap x i = x (graphPermD n (by omega) i) :=
   typeDGraphLatticeEquiv_apply hn x i
+
+/-- **The type-`D` root-datum graph automorphism permutes the full spin-weight family** by
+toggling the final sign. This is the weight-basis compatibility needed to lift the symmetry to the
+full-weight spin carrier. -/
+@[simp]
+theorem typeDGraphAut_weightMap_typeDSpinWeight (hn : 4 ≤ n) (s : Finset (Fin n)) :
+    (typeDGraphAut n hn).weightMap (typeDSpinWeight s) =
+      typeDSpinWeight (typeDSpinGraphPerm n (by omega) s) := by
+  funext i
+  rw [weightMap_typeDGraphAut_apply]
+  exact (typeDSpinWeight_typeDSpinGraphPerm_apply hn s i).symm
 
 /-- The root-index action of the type-`D` graph automorphism restricts to the fork swap on the
 pinned simple roots. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
@@ -251,6 +251,7 @@ theorem typeDSpinGraphPerm_symm (n : ℕ) (hn : 1 ≤ n) :
 
 /-- The graph permutation exchanges the two half-spin parities: an even sign set is sent to an
 odd one and conversely. -/
+@[simp]
 theorem even_card_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n)
     (s : Finset (Fin n)) :
     Even (typeDSpinGraphPerm n hn s).card ↔ Odd s.card := by
@@ -270,15 +271,50 @@ theorem even_card_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n)
     rw [hcard, Nat.even_add_one, Nat.not_even_iff_odd]
 
 /-- Equivalently, the graph permutation sends odd sign sets to even ones. -/
+@[simp]
 theorem odd_card_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n)
     (s : Finset (Fin n)) :
     Odd (typeDSpinGraphPerm n hn s).card ↔ Even s.card := by
   rw [← Nat.not_even_iff_odd, even_card_typeDSpinGraphPerm_iff,
     Nat.not_odd_iff_even]
 
+/-- Toggling the final sign exchanges the two fork coordinates of a type-`D` spin weight. -/
+private theorem typeDSpinWeight_typeDSpinGraphPerm_fork {n : ℕ} (hn : 4 ≤ n)
+    (s : Finset (Fin n)) :
+    typeDSpinWeight (typeDSpinGraphPerm n (by omega) s) ⟨n - 2, by omega⟩ =
+        typeDSpinWeight s ⟨n - 1, by omega⟩ ∧
+      typeDSpinWeight (typeDSpinGraphPerm n (by omega) s) ⟨n - 1, by omega⟩ =
+        typeDSpinWeight s ⟨n - 2, by omega⟩ := by
+  have hpen_lt : n - 2 + 1 < n := by omega
+  have hlast_not_lt : ¬n - 1 + 1 < n := by omega
+  have hnext :
+      (⟨n - 2 + 1, hpen_lt⟩ : Fin n) = (⟨n - 1, by omega⟩ : Fin n) := by
+    apply Fin.ext
+    dsimp only
+    omega
+  have hprev :
+      (⟨n - 1 - 1, by omega⟩ : Fin n) = (⟨n - 2, by omega⟩ : Fin n) := by
+    apply Fin.ext
+    dsimp only
+    omega
+  have hpen_not_last : n - 2 + 1 ≠ n := by omega
+  have hlast_is_last : n - 1 + 1 = n := Nat.sub_add_cancel (by omega)
+  constructor
+  · rw [typeDSpinWeight_apply, dite_eq_left hpen_lt, hnext,
+      typeDSpinWeight_apply, dite_eq_right hlast_not_lt, hprev]
+    by_cases hp : (⟨n - 2, by omega⟩ : Fin n) ∈ s <;>
+      by_cases hl : (⟨n - 1, by omega⟩ : Fin n) ∈ s <;>
+      simp [mem_typeDSpinGraphPerm_iff, hpen_not_last, hlast_is_last, hp, hl]
+  · rw [typeDSpinWeight_apply, dite_eq_right hlast_not_lt, hprev,
+      typeDSpinWeight_apply, dite_eq_left hpen_lt, hnext]
+    by_cases hp : (⟨n - 2, by omega⟩ : Fin n) ∈ s <;>
+      by_cases hl : (⟨n - 1, by omega⟩ : Fin n) ∈ s <;>
+      simp [mem_typeDSpinGraphPerm_iff, hpen_not_last, hlast_is_last, hp, hl]
+
 /-- **The final-sign toggle realizes the type-`D` graph automorphism on spin weights.** Applying
 the fork-node permutation to the fundamental-weight coordinates of a spin weight gives the weight
 indexed by the sign set with its final membership toggled. -/
+@[simp]
 theorem typeDSpinWeight_typeDSpinGraphPerm_apply {n : ℕ} (hn : 4 ≤ n)
     (s : Finset (Fin n)) (i : Fin n) :
     typeDSpinWeight (typeDSpinGraphPerm n (by omega) s) i =
@@ -301,53 +337,15 @@ theorem typeDSpinWeight_typeDSpinGraphPerm_apply {n : ℕ} (hn : 4 ≤ n)
         apply Fin.ext
         dsimp only
         omega
-      rw [hi]
-      rw [graphPermD_apply_left]
-      have hpen_lt : n - 2 + 1 < n := by omega
-      have hlast_not_lt : ¬n - 1 + 1 < n := by omega
-      have hnext :
-          (⟨n - 2 + 1, hpen_lt⟩ : Fin n) = (⟨n - 1, by omega⟩ : Fin n) := by
-        apply Fin.ext
-        dsimp only
-        omega
-      have hprev :
-          (⟨n - 1 - 1, by omega⟩ : Fin n) = (⟨n - 2, by omega⟩ : Fin n) := by
-        apply Fin.ext
-        dsimp only
-        omega
-      rw [typeDSpinWeight_apply, dite_eq_left hpen_lt, hnext,
-        typeDSpinWeight_apply, dite_eq_right hlast_not_lt, hprev]
-      have hpen_not_last : n - 2 + 1 ≠ n := by omega
-      have hlast_is_last : n - 1 + 1 = n := Nat.sub_add_cancel (by omega)
-      by_cases hp : (⟨n - 2, by omega⟩ : Fin n) ∈ s <;>
-        by_cases hl : (⟨n - 1, by omega⟩ : Fin n) ∈ s <;>
-        simp [mem_typeDSpinGraphPerm_iff, hpen_not_last, hlast_is_last, hp, hl]
+      rw [hi, graphPermD_apply_left]
+      exact (typeDSpinWeight_typeDSpinGraphPerm_fork hn s).1
     · have hlast : (i : ℕ) + 1 = n := by omega
       have hi : i = (⟨n - 1, by omega⟩ : Fin n) := by
         apply Fin.ext
         dsimp only
         omega
-      rw [hi]
-      rw [graphPermD_apply_right]
-      have hlast_not_lt : ¬n - 1 + 1 < n := by omega
-      have hpen_lt : n - 2 + 1 < n := by omega
-      have hprev :
-          (⟨n - 1 - 1, by omega⟩ : Fin n) = (⟨n - 2, by omega⟩ : Fin n) := by
-        apply Fin.ext
-        dsimp only
-        omega
-      have hnext :
-          (⟨n - 2 + 1, hpen_lt⟩ : Fin n) = (⟨n - 1, by omega⟩ : Fin n) := by
-        apply Fin.ext
-        dsimp only
-        omega
-      rw [typeDSpinWeight_apply, dite_eq_right hlast_not_lt, hprev,
-        typeDSpinWeight_apply, dite_eq_left hpen_lt, hnext]
-      have hpen_not_last : n - 2 + 1 ≠ n := by omega
-      have hlast_is_last : n - 1 + 1 = n := Nat.sub_add_cancel (by omega)
-      by_cases hp : (⟨n - 2, by omega⟩ : Fin n) ∈ s <;>
-        by_cases hl : (⟨n - 1, by omega⟩ : Fin n) ∈ s <;>
-        simp [mem_typeDSpinGraphPerm_iff, hpen_not_last, hlast_is_last, hp, hl]
+      rw [hi, graphPermD_apply_right]
+      exact (typeDSpinWeight_typeDSpinGraphPerm_fork hn s).2
 
 /-- The type-`D` graph permutation preserves the full family of spin weights as a set. -/
 theorem image_comp_graphPermD_range_typeDSpinWeight {n : ℕ} (hn : 4 ≤ n) :

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
@@ -190,23 +190,35 @@ def typeDSpinGraphPerm (n : ℕ) (hn : 1 ≤ n) : Equiv.Perm (Finset (Fin n)) :=
   let last : Fin n := ⟨n - 1, by omega⟩
   (symmDiff_left_involutive {last}).toPerm (· ∆ {last})
 
+/-- The type-`D` spin graph permutation acts by symmetric difference with the final index. -/
+theorem typeDSpinGraphPerm_apply (n : ℕ) (hn : 1 ≤ n) (s : Finset (Fin n)) :
+    typeDSpinGraphPerm n hn s = s ∆ {(⟨n - 1, by omega⟩ : Fin n)} :=
+  by simp [typeDSpinGraphPerm]
+
+private theorem symmDiff_singleton_eq_erase_or_insert {α : Type*} [DecidableEq α]
+    (s : Finset α) (a : α) :
+    s ∆ {a} = if a ∈ s then s.erase a else insert a s := by
+  ext x
+  by_cases ha : a ∈ s <;> simp [Finset.mem_symmDiff, ha] <;> aesop
+
 /-- An index belongs to the graph-transformed sign set precisely when its old membership agrees
 with not being the final index. Thus membership is unchanged away from the final coordinate and
 reversed there. -/
 @[simp]
 theorem mem_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n) (s : Finset (Fin n)) (i : Fin n) :
     i ∈ typeDSpinGraphPerm n hn s ↔ (i ∈ s ↔ (i : ℕ) + 1 ≠ n) := by
+  rw [typeDSpinGraphPerm_apply]
   by_cases hi : i = (⟨n - 1, by omega⟩ : Fin n)
   · subst i
     have hval : n - 1 + 1 = n := Nat.sub_add_cancel hn
-    simp [typeDSpinGraphPerm, Finset.mem_symmDiff, hval]
+    simp [Finset.mem_symmDiff, hval]
   · have hilast : (i : ℕ) + 1 ≠ n := by
       intro h
       apply hi
       apply Fin.ext
       dsimp only
       omega
-    simp [typeDSpinGraphPerm, Finset.mem_symmDiff, hi, hilast]
+    simp [Finset.mem_symmDiff, hi, hilast]
 
 /-- Toggling the final sign twice is the identity. -/
 @[simp]
@@ -233,19 +245,13 @@ theorem even_card_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n)
   let last : Fin n := ⟨n - 1, by omega⟩
   by_cases hlast : last ∈ s
   · have hcard : (typeDSpinGraphPerm n hn s).card + 1 = s.card := by
-      have htoggle : s ∆ {last} = s.erase last := by
-        ext i
-        simp only [Finset.mem_symmDiff, Finset.mem_singleton, Finset.mem_erase]
-        aesop
-      simpa only [typeDSpinGraphPerm, Function.Involutive.coe_toPerm, last, htoggle]
+      rw [typeDSpinGraphPerm_apply, symmDiff_singleton_eq_erase_or_insert, ite_eq_left hlast]
+      simpa only [last]
         using Finset.card_erase_add_one hlast
     rw [← hcard, Nat.odd_add_one, Nat.not_odd_iff_even]
   · have hcard : (typeDSpinGraphPerm n hn s).card = s.card + 1 := by
-      have htoggle : s ∆ {last} = insert last s := by
-        ext i
-        simp only [Finset.mem_symmDiff, Finset.mem_singleton, Finset.mem_insert]
-        aesop
-      simpa only [typeDSpinGraphPerm, Function.Involutive.coe_toPerm, last, htoggle]
+      rw [typeDSpinGraphPerm_apply, symmDiff_singleton_eq_erase_or_insert, ite_eq_right hlast]
+      simpa only [last]
         using Finset.card_insert_of_notMem hlast
     rw [hcard, Nat.even_add_one, Nat.not_even_iff_odd]
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
@@ -314,7 +314,6 @@ private theorem typeDSpinWeight_typeDSpinGraphPerm_fork {n : ℕ} (hn : 4 ≤ n)
 /-- **The final-sign toggle realizes the type-`D` graph automorphism on spin weights.** Applying
 the fork-node permutation to the fundamental-weight coordinates of a spin weight gives the weight
 indexed by the sign set with its final membership toggled. -/
-@[simp]
 theorem typeDSpinWeight_typeDSpinGraphPerm_apply {n : ℕ} (hn : 4 ≤ n)
     (s : Finset (Fin n)) (i : Fin n) :
     typeDSpinWeight (typeDSpinGraphPerm n (by omega) s) i =

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
@@ -67,6 +67,7 @@ public section
 namespace TauCeti.DynkinType
 
 open Set Submodule
+open scoped symmDiff
 
 /-! ## Integral spin weights -/
 
@@ -184,24 +185,19 @@ theorem algebraMap_typeDSpinWeight_eq_dotProduct {K : Type*} [CommRing K]
 
 /-- The permutation of the type-`D` spin basis induced by the graph automorphism: toggle the sign
 of the final orthonormal coordinate. A sign is encoded by membership in the indexing finset, so
-this erases the final index when it is present and inserts it when it is absent. -/
+this takes the symmetric difference with the singleton containing the final index. -/
 def typeDSpinGraphPerm (n : ℕ) (hn : 1 ≤ n) : Equiv.Perm (Finset (Fin n)) :=
   let last : Fin n := ⟨n - 1, by omega⟩
-  let toggle := fun s : Finset (Fin n) =>
-    if last ∈ s then s.erase last else insert last s
+  let toggle := fun s : Finset (Fin n) => s ∆ {last}
   {
     toFun := toggle
     invFun := toggle
     left_inv := by
       intro s
-      by_cases hlast : last ∈ s
-      · simp [toggle, hlast]
-      · simp [toggle, hlast]
+      exact symmDiff_symmDiff_cancel_right (a := {last}) (b := s)
     right_inv := by
       intro s
-      by_cases hlast : last ∈ s
-      · simp [toggle, hlast]
-      · simp [toggle, hlast]
+      exact symmDiff_symmDiff_cancel_right (a := {last}) (b := s)
   }
 
 /-- An index belongs to the graph-transformed sign set precisely when its old membership agrees
@@ -210,32 +206,17 @@ reversed there. -/
 @[simp]
 theorem mem_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n) (s : Finset (Fin n)) (i : Fin n) :
     i ∈ typeDSpinGraphPerm n hn s ↔ (i ∈ s ↔ (i : ℕ) + 1 ≠ n) := by
-  by_cases hlast : (⟨n - 1, by omega⟩ : Fin n) ∈ s
-  · simp only [typeDSpinGraphPerm, Equiv.coe_fn_mk, hlast, ite_eq_left,
-      Finset.mem_erase]
-    by_cases hi : i = (⟨n - 1, by omega⟩ : Fin n)
-    · subst i
-      have hval : n - 1 + 1 = n := Nat.sub_add_cancel hn
-      simp [hlast, hval]
-    · have hilast : (i : ℕ) + 1 ≠ n := by
-        intro h
-        apply hi
-        apply Fin.ext
-        dsimp only
-        omega
-      simp [hi, hilast]
-  · simp only [typeDSpinGraphPerm, Equiv.coe_fn_mk, hlast]
-    by_cases hi : i = (⟨n - 1, by omega⟩ : Fin n)
-    · subst i
-      have hval : n - 1 + 1 = n := Nat.sub_add_cancel hn
-      simp [hlast, hval]
-    · have hilast : (i : ℕ) + 1 ≠ n := by
-        intro h
-        apply hi
-        apply Fin.ext
-        dsimp only
-        omega
-      simp [hi, hilast]
+  by_cases hi : i = (⟨n - 1, by omega⟩ : Fin n)
+  · subst i
+    have hval : n - 1 + 1 = n := Nat.sub_add_cancel hn
+    simp [typeDSpinGraphPerm, Finset.mem_symmDiff, hval]
+  · have hilast : (i : ℕ) + 1 ≠ n := by
+      intro h
+      apply hi
+      apply Fin.ext
+      dsimp only
+      omega
+    simp [typeDSpinGraphPerm, Finset.mem_symmDiff, hi, hilast]
 
 /-- Toggling the final sign twice is the identity. -/
 @[simp]
@@ -258,16 +239,20 @@ theorem even_card_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n)
   let last : Fin n := ⟨n - 1, by omega⟩
   by_cases hlast : last ∈ s
   · have hcard : (typeDSpinGraphPerm n hn s).card + 1 = s.card := by
-      simpa only [typeDSpinGraphPerm, Equiv.coe_fn_mk, last, hlast, ite_eq_left]
+      have htoggle : s ∆ {last} = s.erase last := by
+        ext i
+        simp only [Finset.mem_symmDiff, Finset.mem_singleton, Finset.mem_erase]
+        aesop
+      simpa only [typeDSpinGraphPerm, Equiv.coe_fn_mk, last, htoggle]
         using Finset.card_erase_add_one hlast
     rw [← hcard, Nat.odd_add_one, Nat.not_odd_iff_even]
   · have hcard : (typeDSpinGraphPerm n hn s).card = s.card + 1 := by
-      have hlast' : (⟨n - 1, by omega⟩ : Fin n) ∉ s := by
-        simpa only [last] using hlast
-      rw [typeDSpinGraphPerm]
-      dsimp only [Equiv.coe_fn_mk]
-      rw [ite_eq_right hlast']
-      exact Finset.card_insert_of_notMem hlast'
+      have htoggle : s ∆ {last} = insert last s := by
+        ext i
+        simp only [Finset.mem_symmDiff, Finset.mem_singleton, Finset.mem_insert]
+        aesop
+      simpa only [typeDSpinGraphPerm, Equiv.coe_fn_mk, last, htoggle]
+        using Finset.card_insert_of_notMem hlast
     rw [hcard, Nat.even_add_one, Nat.not_even_iff_odd]
 
 /-- Equivalently, the graph permutation sends odd sign sets to even ones. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.LinearAlgebra.RootSystem.DiagramPermutations
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.D.Basic
 public import TauCeti.RepresentationTheory.Spin.Weight
 
@@ -25,6 +26,12 @@ family `TauCeti.DynkinType.typeDSpinWeight`, compares it coordinate by coordinat
 Using all spinor weights is essential in even rank: either half-spin family alone reaches only
 one of the two nonzero spinor cosets of the root lattice.
 
+The type-`D` graph automorphism changes the sign of the final orthonormal coordinate. On the
+sign-set indexing the spin basis, this toggles membership of the final index. The resulting
+permutation exchanges the even and odd half-spin bases and carries each spin weight through the
+fork-node permutation `TauCeti.graphPermD`. Thus the full spin module, rather than either
+half-spin summand by itself, is the weight-stable input for the graph-twisted carrier.
+
 The spanning result is the full-weight input needed to construct the simply connected type `D`
 Chevalley carrier from the spin representation. The adjoint representation supplies only the
 index-four root lattice.
@@ -36,6 +43,8 @@ index-four root lattice.
   orthonormal coordinates of `TauCeti.spinWeight`.
 * `TauCeti.DynkinType.span_range_typeDSpinWeight_eq_top`: the spin weights generate the full
   simply connected character lattice.
+* `TauCeti.DynkinType.typeDSpinGraphPerm`: the graph symmetry on the spin basis, with
+  `TauCeti.DynkinType.typeDSpinWeight_typeDSpinGraphPerm_apply` recording its action on weights.
 
 ## References
 
@@ -48,7 +57,9 @@ PR #4847. The fork coordinate and the use of both half-spin parities are the typ
 
 This advances Layer 9, "The Chevalley--Demazure construction", of the ReductiveGroups roadmap:
 the explicit simply connected type `D` carrier requires an admissible spin lattice whose weights
-generate the full character lattice.
+generate the full character lattice. Its graph automorphism additionally requires the weight-basis
+permutation constructed here; that automorphism is consumed by the `²Dₙ(q)` branch in milestones
+L0 and L1 of the CFSGStatement roadmap.
 -/
 
 public section
@@ -168,6 +179,197 @@ theorem algebraMap_typeDSpinWeight_eq_dotProduct {K : Type*} [CommRing K]
     rw [dotProduct_add, dotProduct_single, dotProduct_single, mul_one, mul_one]
     exact congrArg₂ (· + ·) (congrArg (spinWeight K s) hprev)
       (congrArg (spinWeight K s) hi)
+
+/-! ## The graph automorphism on spin weights -/
+
+/-- The permutation of the type-`D` spin basis induced by the graph automorphism: toggle the sign
+of the final orthonormal coordinate. A sign is encoded by membership in the indexing finset, so
+this erases the final index when it is present and inserts it when it is absent. -/
+def typeDSpinGraphPerm (n : ℕ) (hn : 1 ≤ n) : Equiv.Perm (Finset (Fin n)) :=
+  let last : Fin n := ⟨n - 1, by omega⟩
+  let toggle := fun s : Finset (Fin n) =>
+    if last ∈ s then s.erase last else insert last s
+  {
+    toFun := toggle
+    invFun := toggle
+    left_inv := by
+      intro s
+      by_cases hlast : last ∈ s
+      · simp [toggle, hlast]
+      · simp [toggle, hlast]
+    right_inv := by
+      intro s
+      by_cases hlast : last ∈ s
+      · simp [toggle, hlast]
+      · simp [toggle, hlast]
+  }
+
+/-- An index belongs to the graph-transformed sign set precisely when its old membership agrees
+with not being the final index. Thus membership is unchanged away from the final coordinate and
+reversed there. -/
+@[simp]
+theorem mem_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n) (s : Finset (Fin n)) (i : Fin n) :
+    i ∈ typeDSpinGraphPerm n hn s ↔ (i ∈ s ↔ (i : ℕ) + 1 ≠ n) := by
+  by_cases hlast : (⟨n - 1, by omega⟩ : Fin n) ∈ s
+  · simp only [typeDSpinGraphPerm, Equiv.coe_fn_mk, hlast, ite_eq_left,
+      Finset.mem_erase]
+    by_cases hi : i = (⟨n - 1, by omega⟩ : Fin n)
+    · subst i
+      have hval : n - 1 + 1 = n := Nat.sub_add_cancel hn
+      simp [hlast, hval]
+    · have hilast : (i : ℕ) + 1 ≠ n := by
+        intro h
+        apply hi
+        apply Fin.ext
+        dsimp only
+        omega
+      simp [hi, hilast]
+  · simp only [typeDSpinGraphPerm, Equiv.coe_fn_mk, hlast]
+    by_cases hi : i = (⟨n - 1, by omega⟩ : Fin n)
+    · subst i
+      have hval : n - 1 + 1 = n := Nat.sub_add_cancel hn
+      simp [hlast, hval]
+    · have hilast : (i : ℕ) + 1 ≠ n := by
+        intro h
+        apply hi
+        apply Fin.ext
+        dsimp only
+        omega
+      simp [hi, hilast]
+
+/-- Toggling the final sign twice is the identity. -/
+@[simp]
+theorem typeDSpinGraphPerm_apply_apply (n : ℕ) (hn : 1 ≤ n) (s : Finset (Fin n)) :
+    typeDSpinGraphPerm n hn (typeDSpinGraphPerm n hn s) = s :=
+  (typeDSpinGraphPerm n hn).left_inv s
+
+/-- The permutation which toggles the final sign is an involution. -/
+@[simp]
+theorem typeDSpinGraphPerm_symm (n : ℕ) (hn : 1 ≤ n) :
+    (typeDSpinGraphPerm n hn).symm = typeDSpinGraphPerm n hn :=
+  (rfl)
+
+/-- The graph permutation exchanges the two half-spin parities: an even sign set is sent to an
+odd one and conversely. -/
+theorem even_card_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n)
+    (s : Finset (Fin n)) :
+    Even (typeDSpinGraphPerm n hn s).card ↔ Odd s.card := by
+  let last : Fin n := ⟨n - 1, by omega⟩
+  by_cases hlast : last ∈ s
+  · have hcard : (typeDSpinGraphPerm n hn s).card + 1 = s.card := by
+      simpa only [typeDSpinGraphPerm, Equiv.coe_fn_mk, last, hlast, ite_eq_left]
+        using Finset.card_erase_add_one hlast
+    rw [← hcard, Nat.odd_add_one, Nat.not_odd_iff_even]
+  · have hcard : (typeDSpinGraphPerm n hn s).card = s.card + 1 := by
+      have hlast' : (⟨n - 1, by omega⟩ : Fin n) ∉ s := by
+        simpa only [last] using hlast
+      rw [typeDSpinGraphPerm]
+      dsimp only [Equiv.coe_fn_mk]
+      rw [ite_eq_right hlast']
+      exact Finset.card_insert_of_notMem hlast'
+    rw [hcard, Nat.even_add_one, Nat.not_even_iff_odd]
+
+/-- Equivalently, the graph permutation sends odd sign sets to even ones. -/
+theorem odd_card_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n)
+    (s : Finset (Fin n)) :
+    Odd (typeDSpinGraphPerm n hn s).card ↔ Even s.card := by
+  rw [← Nat.not_even_iff_odd, even_card_typeDSpinGraphPerm_iff,
+    Nat.not_odd_iff_even]
+
+/-- **The final-sign toggle realizes the type-`D` graph automorphism on spin weights.** Applying
+the fork-node permutation to the fundamental-weight coordinates of a spin weight gives the weight
+indexed by the sign set with its final membership toggled. -/
+theorem typeDSpinWeight_typeDSpinGraphPerm_apply {n : ℕ} (hn : 4 ≤ n)
+    (s : Finset (Fin n)) (i : Fin n) :
+    typeDSpinWeight (typeDSpinGraphPerm n (by omega) s) i =
+      typeDSpinWeight s (graphPermD n (by omega) i) := by
+  by_cases hbefore : (i : ℕ) + 2 < n
+  · have hnext : (i : ℕ) + 1 < n := by omega
+    have hilast : (i : ℕ) ≠ n - 1 := by omega
+    have hipenultimate : (i : ℕ) ≠ n - 2 := by omega
+    rw [graphPermD_apply_of_ne_of_ne n (by omega) i hipenultimate hilast,
+      typeDSpinWeight_apply, typeDSpinWeight_apply, dite_eq_left hnext,
+      dite_eq_left hnext]
+    have hi_not_last : (i : ℕ) + 1 ≠ n := by omega
+    have hnext_not_last :
+        ((⟨(i : ℕ) + 1, hnext⟩ : Fin n) : ℕ) + 1 ≠ n := by
+      dsimp only
+      omega
+    simp [mem_typeDSpinGraphPerm_iff, hi_not_last, hnext_not_last]
+  · by_cases hpenultimate : (i : ℕ) + 2 = n
+    · have hi : i = (⟨n - 2, by omega⟩ : Fin n) := by
+        apply Fin.ext
+        dsimp only
+        omega
+      rw [hi]
+      rw [graphPermD_apply_left]
+      have hpen_lt : n - 2 + 1 < n := by omega
+      have hlast_not_lt : ¬n - 1 + 1 < n := by omega
+      have hnext :
+          (⟨n - 2 + 1, hpen_lt⟩ : Fin n) = (⟨n - 1, by omega⟩ : Fin n) := by
+        apply Fin.ext
+        dsimp only
+        omega
+      have hprev :
+          (⟨n - 1 - 1, by omega⟩ : Fin n) = (⟨n - 2, by omega⟩ : Fin n) := by
+        apply Fin.ext
+        dsimp only
+        omega
+      rw [typeDSpinWeight_apply, dite_eq_left hpen_lt, hnext,
+        typeDSpinWeight_apply, dite_eq_right hlast_not_lt, hprev]
+      have hpen_not_last : n - 2 + 1 ≠ n := by omega
+      have hlast_is_last : n - 1 + 1 = n := Nat.sub_add_cancel (by omega)
+      by_cases hp : (⟨n - 2, by omega⟩ : Fin n) ∈ s <;>
+        by_cases hl : (⟨n - 1, by omega⟩ : Fin n) ∈ s <;>
+        simp [mem_typeDSpinGraphPerm_iff, hpen_not_last, hlast_is_last, hp, hl]
+    · have hlast : (i : ℕ) + 1 = n := by omega
+      have hi : i = (⟨n - 1, by omega⟩ : Fin n) := by
+        apply Fin.ext
+        dsimp only
+        omega
+      rw [hi]
+      rw [graphPermD_apply_right]
+      have hlast_not_lt : ¬n - 1 + 1 < n := by omega
+      have hpen_lt : n - 2 + 1 < n := by omega
+      have hprev :
+          (⟨n - 1 - 1, by omega⟩ : Fin n) = (⟨n - 2, by omega⟩ : Fin n) := by
+        apply Fin.ext
+        dsimp only
+        omega
+      have hnext :
+          (⟨n - 2 + 1, hpen_lt⟩ : Fin n) = (⟨n - 1, by omega⟩ : Fin n) := by
+        apply Fin.ext
+        dsimp only
+        omega
+      rw [typeDSpinWeight_apply, dite_eq_right hlast_not_lt, hprev,
+        typeDSpinWeight_apply, dite_eq_left hpen_lt, hnext]
+      have hpen_not_last : n - 2 + 1 ≠ n := by omega
+      have hlast_is_last : n - 1 + 1 = n := Nat.sub_add_cancel (by omega)
+      by_cases hp : (⟨n - 2, by omega⟩ : Fin n) ∈ s <;>
+        by_cases hl : (⟨n - 1, by omega⟩ : Fin n) ∈ s <;>
+        simp [mem_typeDSpinGraphPerm_iff, hpen_not_last, hlast_is_last, hp, hl]
+
+/-- The type-`D` graph permutation preserves the full family of spin weights as a set. -/
+theorem image_comp_graphPermD_range_typeDSpinWeight {n : ℕ} (hn : 4 ≤ n) :
+    (fun wt : Fin n → ℤ => wt ∘ graphPermD n (by omega)) ''
+        Set.range (typeDSpinWeight (n := n)) =
+      Set.range (typeDSpinWeight (n := n)) := by
+  ext wt
+  constructor
+  · rintro ⟨_, ⟨s, rfl⟩, rfl⟩
+    refine ⟨typeDSpinGraphPerm n (by omega) s, ?_⟩
+    funext i
+    simpa only [Function.comp_apply] using
+      typeDSpinWeight_typeDSpinGraphPerm_apply hn s i
+  · rintro ⟨s, rfl⟩
+    refine ⟨typeDSpinWeight (typeDSpinGraphPerm n (by omega) s),
+      ⟨typeDSpinGraphPerm n (by omega) s, rfl⟩, ?_⟩
+    funext i
+    simpa only [Function.comp_apply] using
+      (typeDSpinWeight_typeDSpinGraphPerm_apply hn
+        (typeDSpinGraphPerm n (by omega) s) i).symm.trans
+          (congrArg (fun t => typeDSpinWeight t i)
+            (typeDSpinGraphPerm_apply_apply n (by omega) s))
 
 /-! ## A spanning family -/
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D/SpinWeight.lean
@@ -188,17 +188,7 @@ of the final orthonormal coordinate. A sign is encoded by membership in the inde
 this takes the symmetric difference with the singleton containing the final index. -/
 def typeDSpinGraphPerm (n : ℕ) (hn : 1 ≤ n) : Equiv.Perm (Finset (Fin n)) :=
   let last : Fin n := ⟨n - 1, by omega⟩
-  let toggle := fun s : Finset (Fin n) => s ∆ {last}
-  {
-    toFun := toggle
-    invFun := toggle
-    left_inv := by
-      intro s
-      exact symmDiff_symmDiff_cancel_right (a := {last}) (b := s)
-    right_inv := by
-      intro s
-      exact symmDiff_symmDiff_cancel_right (a := {last}) (b := s)
-  }
+  (symmDiff_left_involutive {last}).toPerm (· ∆ {last})
 
 /-- An index belongs to the graph-transformed sign set precisely when its old membership agrees
 with not being the final index. Thus membership is unchanged away from the final coordinate and
@@ -228,7 +218,11 @@ theorem typeDSpinGraphPerm_apply_apply (n : ℕ) (hn : 1 ≤ n) (s : Finset (Fin
 @[simp]
 theorem typeDSpinGraphPerm_symm (n : ℕ) (hn : 1 ≤ n) :
     (typeDSpinGraphPerm n hn).symm = typeDSpinGraphPerm n hn :=
-  (rfl)
+  by
+    apply Equiv.ext
+    intro s
+    apply (typeDSpinGraphPerm n hn).injective
+    rw [Equiv.apply_symm_apply, typeDSpinGraphPerm_apply_apply]
 
 /-- The graph permutation exchanges the two half-spin parities: an even sign set is sent to an
 odd one and conversely. -/
@@ -243,7 +237,7 @@ theorem even_card_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n)
         ext i
         simp only [Finset.mem_symmDiff, Finset.mem_singleton, Finset.mem_erase]
         aesop
-      simpa only [typeDSpinGraphPerm, Equiv.coe_fn_mk, last, htoggle]
+      simpa only [typeDSpinGraphPerm, Function.Involutive.coe_toPerm, last, htoggle]
         using Finset.card_erase_add_one hlast
     rw [← hcard, Nat.odd_add_one, Nat.not_odd_iff_even]
   · have hcard : (typeDSpinGraphPerm n hn s).card = s.card + 1 := by
@@ -251,7 +245,7 @@ theorem even_card_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n)
         ext i
         simp only [Finset.mem_symmDiff, Finset.mem_singleton, Finset.mem_insert]
         aesop
-      simpa only [typeDSpinGraphPerm, Equiv.coe_fn_mk, last, htoggle]
+      simpa only [typeDSpinGraphPerm, Function.Involutive.coe_toPerm, last, htoggle]
         using Finset.card_insert_of_notMem hlast
     rw [hcard, Nat.even_add_one, Nat.not_even_iff_odd]
 
@@ -264,7 +258,7 @@ theorem odd_card_typeDSpinGraphPerm_iff (n : ℕ) (hn : 1 ≤ n)
     Nat.not_odd_iff_even]
 
 /-- Toggling the final sign exchanges the two fork coordinates of a type-`D` spin weight. -/
-private theorem typeDSpinWeight_typeDSpinGraphPerm_fork {n : ℕ} (hn : 4 ≤ n)
+private theorem typeDSpinWeight_typeDSpinGraphPerm_fork {n : ℕ} (hn : 2 ≤ n)
     (s : Finset (Fin n)) :
     typeDSpinWeight (typeDSpinGraphPerm n (by omega) s) ⟨n - 2, by omega⟩ =
         typeDSpinWeight s ⟨n - 1, by omega⟩ ∧
@@ -299,15 +293,15 @@ private theorem typeDSpinWeight_typeDSpinGraphPerm_fork {n : ℕ} (hn : 4 ≤ n)
 /-- **The final-sign toggle realizes the type-`D` graph automorphism on spin weights.** Applying
 the fork-node permutation to the fundamental-weight coordinates of a spin weight gives the weight
 indexed by the sign set with its final membership toggled. -/
-theorem typeDSpinWeight_typeDSpinGraphPerm_apply {n : ℕ} (hn : 4 ≤ n)
+theorem typeDSpinWeight_typeDSpinGraphPerm_apply {n : ℕ} (hn : 2 ≤ n)
     (s : Finset (Fin n)) (i : Fin n) :
     typeDSpinWeight (typeDSpinGraphPerm n (by omega) s) i =
-      typeDSpinWeight s (graphPermD n (by omega) i) := by
+      typeDSpinWeight s (graphPermD n hn i) := by
   by_cases hbefore : (i : ℕ) + 2 < n
   · have hnext : (i : ℕ) + 1 < n := by omega
     have hilast : (i : ℕ) ≠ n - 1 := by omega
     have hipenultimate : (i : ℕ) ≠ n - 2 := by omega
-    rw [graphPermD_apply_of_ne_of_ne n (by omega) i hipenultimate hilast,
+    rw [graphPermD_apply_of_ne_of_ne n hn i hipenultimate hilast,
       typeDSpinWeight_apply, typeDSpinWeight_apply, dite_eq_left hnext,
       dite_eq_left hnext]
     have hi_not_last : (i : ℕ) + 1 ≠ n := by omega
@@ -332,26 +326,17 @@ theorem typeDSpinWeight_typeDSpinGraphPerm_apply {n : ℕ} (hn : 4 ≤ n)
       exact (typeDSpinWeight_typeDSpinGraphPerm_fork hn s).2
 
 /-- The type-`D` graph permutation preserves the full family of spin weights as a set. -/
-theorem image_comp_graphPermD_range_typeDSpinWeight {n : ℕ} (hn : 4 ≤ n) :
-    (fun wt : Fin n → ℤ => wt ∘ graphPermD n (by omega)) ''
+theorem image_comp_graphPermD_range_typeDSpinWeight {n : ℕ} (hn : 2 ≤ n) :
+    (fun wt : Fin n → ℤ => wt ∘ graphPermD n hn) ''
         Set.range (typeDSpinWeight (n := n)) =
       Set.range (typeDSpinWeight (n := n)) := by
-  ext wt
-  constructor
-  · rintro ⟨_, ⟨s, rfl⟩, rfl⟩
-    refine ⟨typeDSpinGraphPerm n (by omega) s, ?_⟩
-    funext i
-    simpa only [Function.comp_apply] using
-      typeDSpinWeight_typeDSpinGraphPerm_apply hn s i
-  · rintro ⟨s, rfl⟩
-    refine ⟨typeDSpinWeight (typeDSpinGraphPerm n (by omega) s),
-      ⟨typeDSpinGraphPerm n (by omega) s, rfl⟩, ?_⟩
-    funext i
-    simpa only [Function.comp_apply] using
-      (typeDSpinWeight_typeDSpinGraphPerm_apply hn
-        (typeDSpinGraphPerm n (by omega) s) i).symm.trans
-          (congrArg (fun t => typeDSpinWeight t i)
-            (typeDSpinGraphPerm_apply_apply n (by omega) s))
+  rw [← Set.range_comp]
+  have hcomp :
+      (fun wt : Fin n → ℤ => wt ∘ graphPermD n hn) ∘ typeDSpinWeight =
+        typeDSpinWeight ∘ typeDSpinGraphPerm n (by omega) := by
+    funext s i
+    exact (typeDSpinWeight_typeDSpinGraphPerm_apply hn s i).symm
+  rw [hcomp, Set.range_comp, EquivLike.range_eq_univ, Set.image_univ]
 
 /-! ## A spanning family -/
 


### PR DESCRIPTION
This PR equips the full type-`D` spin-weight family with the fork graph symmetry required by ReductiveGroups Layer 9, “The Chevalley–Demazure construction,” specifically the full-weight simply connected type-`D` carrier and its pinned graph automorphism. It defines the involution on spin-basis sign sets by toggling the final sign, proves that it exchanges the two half-spin parities, identifies its action on fundamental-weight coordinates with `graphPermD`, and exposes the resulting compatibility through `typeDGraphAut.weightMap`.

The designated CFSGStatement milestones are L0, the explicit pinned ambient groups, and L1, the graph-Steinberg construction for `²Dₙ(q)`. Their explicit dependency edge is: the `²Dₙ(q)` Steinberg endomorphism consumes the pinned type-`D` graph automorphism, whose construction on the full-weight spin carrier consumes the spin-basis permutation and weight compatibility proved here. Direct remaining CFSGStatement family steps are already in flight or await their Layer 9 carriers, so this is the next distinct prerequisite on that critical path.

The implementation reuses the existing `typeDSpinWeight`, `graphPermD`, `typeDGraphAut`, and Mathlib’s `Finset.erase`/`Finset.insert` API; it vendors no Mathlib infrastructure. The coordinate convention follows Bourbaki, Plate IV, and Fulton–Harris §20.2; the graph-twisted role follows Carter §12.2.

After this PR, the ReductiveGroups milestone still needs the in-flight type-`D` root-generator and Serre-relation work, the integral spin action and Kostant lattice, and assembly of the carrier, group scheme, pinning, and Frobenius. CFSGStatement can then lift this symmetry to the pinned group and identify the corresponding fixed-point family.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-d-spin-weight-graph-symmetry"}-->

🤖 Prepared with Codex
