### PR TITLE
feat: the Weyl denominator identity

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/DominantCone.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/DominantCone.lean
@@ -42,6 +42,9 @@ the weight support.
   below a given weight.**
 * `TauCeti.finite_of_forall_reflection_mem_of_sub_mem_posRootCone`: **a set of weights below `lam`,
   integral on the simple coroots and stable under the simple reflections, is finite.**
+* `TauCeti.eq_zero_of_mem_posRootCone_of_forall_coroot'_nonpos`: **the only antidominant member of
+  the positive root cone is zero**, the case `lam = 0` of the first statement applied to all the
+  natural multiples of a member at once.
 
 ## The argument
 
@@ -251,5 +254,56 @@ theorem finite_of_forall_reflection_mem_of_sub_mem_posRootCone {lam : M} {S : Se
   exact mem_of_sub_eq_sum_nsmul_root_of_reflection_stable b hcone hint hrefl hTrefl
     (fun nu hnu hdom => Set.mem_iUnion.mpr ⟨1, nu, ⟨hcone nu hnu, hdom⟩, one_smul _ _⟩)
     _ mu hmu f hf rfl
+
+omit [IsDomain R] in
+/-- **The only antidominant member of the positive root cone is zero.** A nonnegative integer
+combination `nu` of the simple roots on which every simple coroot takes a nonpositive value is
+zero.
+
+The pairings of a member of `Q⁺` with the simple coroots are Cartan integers
+(`TauCeti.exists_intCast_eq_coroot'_of_mem_posRootCone`), so nonpositivity makes every natural
+multiple of `-nu` a dominant weight below `0`. There are only finitely many of those by
+`TauCeti.finite_setOf_dominant_sub_mem_posRootCone`, while the multiples of a nonzero member of
+`Q⁺` are pairwise distinct because their heights are.
+
+This is the statement that separates the dot orbit of `0` from the rest of the negative cone: it
+is what forces the Weyl denominator to be supported on that orbit alone. -/
+theorem eq_zero_of_mem_posRootCone_of_forall_coroot'_nonpos [LinearOrder R]
+    [IsStrictOrderedRing R] {nu : M} (hnu : nu ∈ posRootCone P b)
+    (h : ∀ i ∈ b.support, P.coroot' i nu ≤ 0) : nu = 0 := by
+  by_contra hne
+  -- Nonpositive Cartan integers: every simple coroot takes the value `-n` on `nu` for some `n : ℕ`.
+  have hnat : ∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i nu = -(n : R) := by
+    intro i hi
+    obtain ⟨m, hm⟩ := exists_intCast_eq_coroot'_of_mem_posRootCone P b hnu i
+    have hm0 : m ≤ 0 := by
+      have hle := h i hi
+      rw [hm] at hle
+      exact_mod_cast hle
+    refine ⟨(-m).toNat, ?_⟩
+    rw [hm, ← Int.cast_natCast (R := R) (-m).toNat, Int.toNat_of_nonneg (by omega)]
+    push_cast
+    ring
+  -- The height of `nu` is a positive natural number.
+  obtain ⟨k, hk⟩ := exists_natCast_eq_heightLinearMap_of_mem_posRootCone P b hnu
+  have hk0 : k ≠ 0 := fun hzero =>
+    hne (eq_zero_of_mem_posRootCone_of_heightLinearMap_eq_zero P b hnu (by rw [hk, hzero]; simp))
+  -- All natural multiples of `-nu` are dominant weights below `0`, and they are pairwise distinct.
+  have hmem : ∀ j : ℕ, -(j • nu) ∈ {mu : M | (0 : M) - mu ∈ posRootCone P b ∧
+      ∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i mu = (n : R)} := by
+    intro j
+    refine ⟨by simpa using AddSubmonoid.nsmul_mem _ hnu j, fun i hi => ?_⟩
+    obtain ⟨n, hn⟩ := hnat i hi
+    refine ⟨j * n, ?_⟩
+    rw [map_neg, map_nsmul, hn]
+    push_cast
+    ring
+  have hinj : Function.Injective fun j : ℕ => -(j • nu) := by
+    intro p q hpq
+    have hh := congrArg (heightLinearMap P b) hpq
+    simp only [map_neg, map_nsmul, hk, nsmul_eq_mul, neg_inj] at hh
+    exact_mod_cast mul_right_cancel₀ (Nat.cast_ne_zero.mpr hk0) hh
+  exact Set.infinite_of_injective_forall_mem hinj hmem
+    (finite_setOf_dominant_sub_mem_posRootCone b 0)
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Positive.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Positive.lean
@@ -62,8 +62,14 @@ positive root is a nonnegative integer combination of the simple coroots.
   a natural multiple of a simple root, in the order defined by `Q⁺`, is that simple root itself.
 * `TauCeti.one_le_height_of_mem_posRoots` says every positive root has height at least one, and
   `TauCeti.height_neg_of_mem_negRoots` says every negative root has negative height.
-* `TauCeti.exists_natCast_eq_heightLinearMap_of_mem_posRootCone` says the height functional takes
-  natural-number values on `Q⁺`.
+* `TauCeti.heightLinearMap_sum_nsmul_root` computes the height of a nonnegative integer
+  combination of the simple roots, whence
+  `TauCeti.exists_natCast_eq_heightLinearMap_of_mem_posRootCone`, that the height functional takes
+  natural-number values on `Q⁺`, and
+  `TauCeti.eq_zero_of_mem_posRootCone_of_heightLinearMap_eq_zero`, that zero is the only member of
+  `Q⁺` of height zero.
+* `TauCeti.exists_intCast_eq_coroot'_of_mem_posRootCone` says a coroot functional takes integer
+  values on `Q⁺`.
 * `TauCeti.exists_coroot_eq_sum_nat_of_mem_posRoots` says the coroot of a positive root is a
   nonnegative integer combination of the simple coroots.
 
@@ -287,6 +293,16 @@ theorem root_mem_posRootCone_of_mem_posRoots {i : ι} (hi : i ∈ posRoots P b) 
   (mem_posRootCone P b).mpr ⟨f, hf⟩
 
 omit [CharZero R] in
+/-- **The height of a nonnegative integer combination of the simple roots** is the total number of
+simple roots occurring in it, every simple root having height one. -/
+theorem heightLinearMap_sum_nsmul_root [P.IsRootSystem] (f : ι → ℕ) :
+    heightLinearMap P b (∑ j ∈ b.support, f j • P.root j)
+      = ((∑ j ∈ b.support, f j : ℕ) : R) := by
+  rw [map_sum, Nat.cast_sum]
+  exact Finset.sum_congr rfl fun j hj => by
+    rw [map_nsmul, heightLinearMap_simpleRoot P b ⟨j, hj⟩, nsmul_eq_mul, mul_one]
+
+omit [CharZero R] in
 /-- **The height functional takes natural-number values on the positive root cone**: the height of
 a nonnegative integer combination of simple roots is the total number of simple roots in it, every
 simple root having height one. This is what makes the height of a cone member a legitimate
@@ -294,10 +310,31 @@ induction parameter. -/
 theorem exists_natCast_eq_heightLinearMap_of_mem_posRootCone [P.IsRootSystem] {u : M}
     (hu : u ∈ posRootCone P b) : ∃ n : ℕ, heightLinearMap P b u = (n : R) := by
   obtain ⟨f, rfl⟩ := (mem_posRootCone P b).mp hu
-  refine ⟨∑ j ∈ b.support, f j, ?_⟩
-  rw [map_sum, Nat.cast_sum]
-  exact Finset.sum_congr rfl fun j hj => by
-    rw [map_nsmul, heightLinearMap_simpleRoot P b ⟨j, hj⟩, nsmul_eq_mul, mul_one]
+  exact ⟨∑ j ∈ b.support, f j, heightLinearMap_sum_nsmul_root P b f⟩
+
+/-- **The only member of the positive root cone of height zero is zero.** The height counts the
+simple roots occurring in a member, so a member of height zero has no summand at all. -/
+theorem eq_zero_of_mem_posRootCone_of_heightLinearMap_eq_zero [P.IsRootSystem] {u : M}
+    (hu : u ∈ posRootCone P b) (hheight : heightLinearMap P b u = 0) : u = 0 := by
+  obtain ⟨f, rfl⟩ := (mem_posRootCone P b).mp hu
+  rw [heightLinearMap_sum_nsmul_root P b f, Nat.cast_eq_zero, Finset.sum_eq_zero_iff] at hheight
+  exact Finset.sum_eq_zero fun j hj => by rw [hheight j hj, zero_smul]
+
+omit [CharZero R] in
+/-- **A coroot functional takes integer values on the positive root cone**: a nonnegative integer
+combination of the simple roots pairs with a coroot to the matching combination of Cartan
+integers. -/
+theorem exists_intCast_eq_coroot'_of_mem_posRootCone [P.IsCrystallographic] {u : M}
+    (hu : u ∈ posRootCone P b) (i : ι) : ∃ m : ℤ, P.coroot' i u = (m : R) := by
+  obtain ⟨f, rfl⟩ := (mem_posRootCone P b).mp hu
+  have hpair : ∀ p q : ι, ((P.pairingIn ℤ p q : ℤ) : R) = P.pairing p q := fun p q => by
+    rw [← P.algebraMap_pairingIn ℤ p q]
+    simp
+  refine ⟨∑ j ∈ b.support, (f j : ℤ) * P.pairingIn ℤ j i, ?_⟩
+  rw [map_sum]
+  push_cast
+  exact Finset.sum_congr rfl fun j _ => by
+    rw [map_nsmul, P.root_coroot'_eq_pairing, nsmul_eq_mul, hpair]
 
 /-- **The positive root cone is pointed**: the only member whose negative is again a member is
 zero. Expanding a member and its negative in the simple roots, the total coefficient vector is

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Denominator/Identity.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Denominator/Identity.lean
@@ -1,0 +1,189 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.DominantCone
+public import TauCeti.LinearAlgebra.RootSystem.Weyl.Denominator.Reflection
+public import TauCeti.LinearAlgebra.RootSystem.Weyl.Numerator
+
+public section
+
+/-!
+# The Weyl denominator identity
+
+The **Weyl denominator identity** is the equality
+
+`∏_{α > 0} (1 - e^{-α}) = ∑_{w ∈ W} sgn(w) e^{w ⬝ 0}`
+
+in the integral group algebra `ℤ[M]` of the weight space of a root system: the Weyl denominator
+`TauCeti.weylDenominator` is the Weyl numerator `TauCeti.weylNumerator` of the weight `0`. Written
+without the dot action `w ⬝ 0 = w(ρ) - ρ` it is the familiar
+`∏_{α>0}(1 - e^{-α}) = ∑_w sgn(w) e^{w(ρ) - ρ}`, or, after multiplying by `e^{ρ}`, the symmetric
+form `∏_{α>0}(e^{α/2} - e^{-α/2}) = ∑_w sgn(w) e^{w(ρ)}`.
+
+It is the case `λ = 0` of the Weyl character formula, whose right-hand side is the numerator of a
+dominant weight; the formula divides by this identity, so the identity is proved first and on its
+own, with no representation theory involved.
+
+## The argument
+
+The two sides are compared coefficient by coefficient, and the dot orbit of `0` separates the two
+cases.
+
+* **On the orbit.** The coefficient of `N(0)` at `w ⬝ 0` is `sgn(w)`, because the dot orbit of the
+  dominant weight `0` is free. The coefficient of `Δ` there is the same: `Δ` is alternating for the
+  dot action (`TauCeti.coeff_weylDenominator_dotAction`) and its constant term is `1`
+  (`TauCeti.coeff_weylDenominator_zero`: the empty set is the only set of positive roots summing
+  to `0`).
+* **Off the orbit.** `N(0)` vanishes there by its support statement, and so must `Δ`. Suppose not,
+  and move the weight by the dot action into the dominant region, which changes the coefficient
+  only by a sign; a coefficient of `Δ` on a dot-action wall vanishes
+  (`TauCeti.coeff_weylDenominator_eq_zero_of_coroot'_eq_neg_one`), so the `ρ`-shift of the moved
+  weight is *strictly* dominant. Now the geometric heart of the identity applies: an exponent of
+  `Δ` is `-ν` for a sum `ν` of positive roots, strict dominance of `ρ - ν` bounds every
+  `⟨ν, αᵢ^∨⟩` above by `1`, these pairings are integers, and the only antidominant member of the
+  positive root cone is `0` (`TauCeti.eq_zero_of_mem_posRootCone_of_forall_coroot'_nonpos`). So the
+  moved weight is `0`, which does lie on the orbit — a contradiction.
+
+## Main results
+
+* `TauCeti.coeff_weylDenominator_zero`: the constant term of `Δ` is `1`.
+* `TauCeti.weylDenominator_eq_weylNumerator_zero`: **the Weyl denominator identity**, `Δ = N(0)`.
+* `TauCeti.support_coeff_weylDenominator` and `TauCeti.card_support_coeff_weylDenominator`:
+  consequently `Δ` is supported on the dot orbit of `0` and has exactly `|W|` terms.
+
+## References
+
+This is the "Weyl denominator identity, proved combinatorially" step of Layer 6 ("the Weyl
+character, dimension, and Kostant formulas") of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, Ch. VI, §24.3.
+* J.-P. Serre, *Complex Semisimple Lie Algebras*, Ch. VII, §7.
+-/
+
+namespace TauCeti
+
+universe u v w x
+
+variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  (P : _root_.RootPairing ι R M N) [Finite ι] [CharZero R] (b : P.Base)
+
+/-- **The constant term of the Weyl denominator is `1`.** Expanding `∏_{α>0}(1 - e^{-α})` indexes
+the terms by the sets of positive roots, and the empty set is the only one whose sum vanishes. -/
+@[simp]
+theorem coeff_weylDenominator_zero : (weylDenominator P b).coeff 0 = 1 := by
+  classical
+  simp only [weylDenominator_eq_sum_powerset, AddMonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply,
+    AddMonoidAlgebra.coeff_single]
+  refine (Finset.sum_eq_single_of_mem (∅ : Finset ι) (Finset.empty_mem_powerset _) ?_).trans ?_
+  · intro T hT hTne
+    have hsum : ∑ i ∈ T, P.root i ≠ 0 :=
+      sum_root_ne_zero_of_mem_posRoots P b (Finset.nonempty_iff_ne_empty.mpr hTne)
+        fun i hi => (mem_posRootsFinset P b i).mp (Finset.mem_powerset.mp hT hi)
+    exact Finsupp.single_eq_of_ne (Ne.symm (neg_ne_zero.mpr hsum))
+  · simp
+
+section Cone
+
+variable [LinearOrder R] [IsStrictOrderedRing R] [Invertible (2 : R)] [P.IsCrystallographic]
+  [P.IsReduced] [P.IsRootSystem]
+
+/-- The Weyl denominator vanishes at a weight whose `ρ`-shift is strictly dominant, unless that
+weight is `0`.
+
+An exponent of `Δ` is minus a sum `ν` of positive roots, so strict dominance of `ρ - ν` bounds
+every `⟨ν, αᵢ^∨⟩` above by `1`; these pairings are integers, hence nonpositive, and the only
+antidominant member of the positive root cone is `0`. -/
+private theorem eq_zero_of_coeff_weylDenominator_ne_zero {y : M}
+    (hy : (weylDenominator P b).coeff y ≠ 0)
+    (hdom : y + weylVector P b ∈ openDominantChamber P b) : y = 0 := by
+  obtain ⟨T, hT, hyT⟩ : ∃ T ⊆ posRootsFinset P b, y = -∑ i ∈ T, P.root i := by
+    by_contra hcon
+    push Not at hcon
+    exact hy (coeff_weylDenominator_eq_zero P b hcon)
+  have hcone : (∑ i ∈ T, P.root i) ∈ posRootCone P b :=
+    AddSubmonoid.sum_mem _ fun i hi =>
+      root_mem_posRootCone_of_mem_posRoots P b ((mem_posRootsFinset P b i).mp (hT hi))
+  have hzero : ∑ i ∈ T, P.root i = 0 := by
+    refine eq_zero_of_mem_posRootCone_of_forall_coroot'_nonpos b hcone fun i hi => ?_
+    obtain ⟨m, hm⟩ := exists_intCast_eq_coroot'_of_mem_posRootCone P b hcone i
+    have hlt : P.coroot' i (∑ j ∈ T, P.root j) < 1 := by
+      have h0 := (mem_openDominantChamber P b _).mp hdom i hi
+      rw [coroot'_add_weylVector P b hi, hyT, map_neg] at h0
+      linarith
+    rw [hm] at hlt ⊢
+    have hm1 : m < 1 := by exact_mod_cast hlt
+    exact_mod_cast (by omega : m ≤ 0)
+  rw [hyT, hzero, neg_zero]
+
+end Cone
+
+section Identity
+
+variable [LinearOrder R] [IsStrictOrderedRing R] [Invertible (2 : R)] [P.IsCrystallographic]
+  [P.IsReduced] [P.flip.IsReduced] [P.IsRootSystem] [Fintype P.weylGroup]
+
+/-- **The Weyl denominator identity**: the Weyl denominator is the Weyl numerator of the weight
+`0`,
+
+`∏_{α > 0} (1 - e^{-α}) = ∑_{w ∈ W} sgn(w) e^{w ⬝ 0}`,
+
+an identity in the integral group algebra of the weight space. Written without the dot action, the
+right-hand side is `∑_{w ∈ W} sgn(w) e^{w(ρ) - ρ}`.
+
+This is the case `λ = 0` of the Weyl character formula, in which the character of the trivial
+module is `1`. -/
+theorem weylDenominator_eq_weylNumerator_zero :
+    weylDenominator P b = weylNumerator P b 0 := by
+  refine AddMonoidAlgebra.coeff_inj.mp (Finsupp.ext fun x => ?_)
+  by_cases hx : ∃ v : P.weylGroup, dotAction P b v 0 = x
+  · -- On the dot orbit of `0` both sides have the sign of the translating element.
+    obtain ⟨v, rfl⟩ := hx
+    rw [coeff_weylDenominator_dotAction, coeff_weylDenominator_zero, mul_one,
+      coeff_weylNumerator_dotAction P b (zero_mem_dominantChamber P b) v]
+  · -- Off the dot orbit of `0` the numerator vanishes; so must the denominator.
+    push Not at hx
+    rw [coeff_weylNumerator_eq_zero P b hx]
+    by_contra hne
+    obtain ⟨w, hw⟩ := exists_mem_dominantChamber P b (x + weylVector P b)
+    have hyd : dotAction P b w x + weylVector P b ∈ dominantChamber P b := by
+      rw [dotAction_add_weylVector]
+      exact hw
+    have hyne : (weylDenominator P b).coeff (dotAction P b w x) ≠ 0 := by
+      rw [coeff_weylDenominator_dotAction]
+      exact mul_ne_zero (by exact_mod_cast Units.ne_zero (weylSign P b w)) hne
+    -- A coefficient on a dot-action wall vanishes, so the `ρ`-shift is *strictly* dominant.
+    have hopen : dotAction P b w x + weylVector P b ∈ openDominantChamber P b := by
+      rw [mem_openDominantChamber]
+      intro i hi
+      rcases lt_or_eq_of_le ((mem_dominantChamber P b _).mp hyd i hi) with h | h
+      · exact h
+      · rw [coroot'_add_weylVector P b hi] at h
+        exact absurd (coeff_weylDenominator_eq_zero_of_coroot'_eq_neg_one P b hi
+          (by linarith)) hyne
+    exact hx w⁻¹ (by
+      rw [← eq_zero_of_coeff_weylDenominator_ne_zero P b hyne hopen, dotAction_inv_dotAction])
+
+/-- **The Weyl denominator is supported exactly on the dot orbit of `0`**, one term for each
+element of the Weyl group. -/
+theorem support_coeff_weylDenominator [DecidableEq M] :
+    (weylDenominator P b).coeff.support
+      = Finset.univ.image fun w : P.weylGroup => dotAction P b w 0 := by
+  rw [weylDenominator_eq_weylNumerator_zero]
+  exact support_coeff_weylNumerator P b (zero_mem_dominantChamber P b)
+
+/-- **The Weyl denominator has exactly `|W|` terms.** Expanding the product over the positive roots
+gives `2^{|Φ⁺|}` terms, which collapse to one for each element of the Weyl group. -/
+theorem card_support_coeff_weylDenominator :
+    (weylDenominator P b).coeff.support.card = Fintype.card P.weylGroup := by
+  rw [weylDenominator_eq_weylNumerator_zero]
+  exact card_support_coeff_weylNumerator P b (zero_mem_dominantChamber P b)
+
+end Identity
+
+end TauCeti


### PR DESCRIPTION
This PR proves the **Weyl denominator identity** `∏_{α>0} (1 - e^{-α}) = ∑_{w ∈ W} sgn(w) e^{w ⬝ 0}`, an equality in the integral group algebra `ℤ[M]` of the weight space of a finite crystallographic root system: the Weyl denominator `weylDenominator` is the Weyl numerator `weylNumerator` of the weight `0`. Written without the dot action `w ⬝ 0 = w(ρ) - ρ` this is `∏_{α>0}(1 - e^{-α}) = ∑_w sgn(w) e^{w(ρ)-ρ}`, and after multiplying by `e^{ρ}` the symmetric form `∏_{α>0}(e^{α/2} - e^{-α/2}) = ∑_w sgn(w) e^{w(ρ)}`. Two consequences come with it: `Δ` is supported exactly on the dot orbit of `0`, and it therefore has exactly `|W|` terms rather than the `2^{|Φ⁺|}` the expanded product starts with.

The target is the "prove the Weyl denominator identity combinatorially" step of the **Weyl character formula** milestone, Layer 6 ("the Weyl character, dimension, and Kostant formulas") of `RepresentationTheory/LieHighestWeight/README.md`, which pins the highest-weight/Verma route: "defining Verma characters, proving the Weyl denominator identity combinatorially, and concluding by Weyl alternation". The denominator and numerator themselves already exist on `main` (`weylDenominator`, `weylNumerator`, `dotAction`, `weylSign`, `weylVector`), and `TauCeti/LinearAlgebra/RootSystem/Weyl/Denominator/Reflection.lean` states its own purpose as "the cancellation step behind the Weyl denominator identity `Δ = N(0)`", which this PR is; nothing on `main` or in an open PR consumed either object before now. What remains for the milestone after this PR is the Verma character and the alternation argument that turn `ch L(λ) · Δ = N(λ)` into a theorem.

The proof compares coefficients, with the dot orbit of `0` separating two cases. On the orbit the numerator's coefficient at `w ⬝ 0` is `sgn(w)` because the dot orbit of the dominant weight `0` is free, and the denominator's is the same because `Δ` is alternating for the dot action and has constant term `1`. Off the orbit the numerator vanishes by its support statement, and so must the denominator: move the weight into the dominant region by the dot action, which changes the coefficient only by a sign; a coefficient of `Δ` on a dot-action wall vanishes, so the `ρ`-shift of the moved weight is strictly dominant; and then an exponent `-ν` of `Δ` has `⟨ν, αᵢ^∨⟩ < 1` for every simple root, hence `≤ 0` by integrality, forcing `ν = 0` — which puts the weight back on the orbit, a contradiction.

That last step is the geometric content, and it is supplied by two additions to their canonical homes rather than by the new file. `TauCeti/LinearAlgebra/RootSystem/DominantCone.lean` gains `eq_zero_of_mem_posRootCone_of_forall_coroot'_nonpos`: the only antidominant member of the positive root cone is `0`, because all natural multiples of such a member would be dominant weights below `0`, of which `finite_setOf_dominant_sub_mem_posRootCone` (already in that file) allows only finitely many, while the multiples of a nonzero cone member are pairwise distinct since their heights are. `TauCeti/LinearAlgebra/RootSystem/Positive.lean` gains the two cone facts that argument rests on — `eq_zero_of_mem_posRootCone_of_heightLinearMap_eq_zero` and `exists_intCast_eq_coroot'_of_mem_posRootCone`, that a coroot functional takes integer values on the cone — and factors the height computation shared with the existing `exists_natCast_eq_heightLinearMap_of_mem_posRootCone` out as `heightLinearMap_sum_nsmul_root`.

Everything stays at the level of an abstract root pairing, with no Lie algebra and no representation theory: the identity needs a finite crystallographic reduced root system over a linearly ordered ring with `2` invertible, exactly the hypotheses `weylNumerator` already carries.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"weyl-denominator-identity"}-->

🤖 Prepared with Claude Code
