### PR TITLE
feat: pin the E6 minuscule carrier to its root datum

### DIFF
--- a/TauCeti/Algebra/Lie/E6/Minuscule/RootDatum.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/RootDatum.lean
@@ -55,6 +55,12 @@ It packages only the torus-character compatibility that the explicit constructio
 * J. E. Humphreys, *Linear Algebraic Groups*, Sections 26--27.
 * N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate V.
 
+The root-identification proofs and torus-conjugation wrapper patterns are adapted from
+`TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/RootDatum.lean`, added in
+[TauCetiProject/TauCeti#5198](https://github.com/TauCetiProject/TauCeti/pull/5198), and
+`TauCeti/Algebra/Lie/Symplectic/StandardCarrier/RootDatum.lean`, developed in
+[TauCetiProject/TauCeti#5203](https://github.com/TauCetiProject/TauCeti/pull/5203).
+
 This advances the "Pinnings" and "Root subgroup maps" targets of Layer 9 of
 `TauCetiRoadmap/ReductiveGroups/README.md`. Its consumer is milestone L0 of
 `TauCetiRoadmap/CFSGStatement/README.md`: `ValidLieTypeIndex.AmbientGroup` must be traceable through

--- a/TauCeti/Algebra/Lie/E6/Minuscule/RootDatum.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/RootDatum.lean
@@ -9,14 +9,15 @@ public import TauCeti.Algebra.Lie.E6.Minuscule.GroupScheme
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Assembly
 
 /-!
-# The type E6 minuscule carrier is pinned by its named root datum
+# Torus characters of the type E6 minuscule carrier in its named root datum
 
 `TauCeti.E6Minuscule.groupScheme` is the full-weight Chevalley carrier obtained from the
 twenty-seven-dimensional minuscule representation of the type-`E₆` Serre presentation. Its
 numbered raising and lowering subgroups and its rank-six split weight torus are explicit, and
 their conjugation equation is stated in terms of the corresponding row of `CartanMatrix.E 6`.
 
-This file identifies that table with the uniform pinned root datum used by downstream consumers.
+This file identifies that table with the uniform simply connected root datum used by downstream
+consumers.
 For a validity proof `ht : TauCeti.DynkinType.E6.Valid`, the root character of the `i`-th raising
 subgroup is
 
@@ -25,8 +26,8 @@ subgroup is
 ```
 
 and the character of the matching lowering subgroup is its negative. Rewriting the carrier's
-conjugation equation by these identifications gives the two pinning equations against the named
-positive and negative simple roots.
+conjugation equation by these identifications gives the two torus conjugation equations against
+the named positive and negative simple roots.
 
 The distinction from the equations already in `GroupScheme.lean` is the dispatcher in the target:
 `DynkinType.simplyConnectedRootDatum` is the root datum reached from a validated Lie-type index,
@@ -36,18 +37,17 @@ two routes use the same Bourbaki numbering and the same character lattice.
 
 This file does not assert reductivity, maximality of the weight torus, existence of all root
 subgroups, or an identification of the carrier with an independently defined algebraic group.
-It packages only the root-subgroup part of the pinning interface that the explicit construction
-already proves.
+It packages only the torus-character compatibility that the explicit construction already proves.
 
 ## Main results
 
 * `TauCeti.E6Minuscule.rootGeneratorWeight_inl_eq_root_simpleIndex`: the raising-subgroup
-  character is the corresponding simple root of the uniform pinned datum.
+  character is the corresponding simple root of the uniform simply connected datum.
 * `TauCeti.E6Minuscule.rootGeneratorWeight_inr_eq_neg_root_simpleIndex`: the lowering-subgroup
   character is the negative of that simple root.
 * `TauCeti.E6Minuscule.weightTorus_conj_rootSubgroup_root_simpleIndex` and
   `TauCeti.E6Minuscule.weightTorus_conj_rootSubgroup_neg_root_simpleIndex`: the positive and
-  negative simple-root pinning equations.
+  negative simple-root torus conjugation equations.
 
 ## References
 
@@ -59,7 +59,7 @@ This advances the "Pinnings" and "Root subgroup maps" targets of Layer 9 of
 `TauCetiRoadmap/ReductiveGroups/README.md`. Its consumer is milestone L0 of
 `TauCetiRoadmap/CFSGStatement/README.md`: `ValidLieTypeIndex.AmbientGroup` must be traceable through
 `ValidLieTypeIndex.dynkinType` to `DynkinType.simplyConnectedRootDatum`, with its root subgroups
-pinned against that same datum.
+identified by characters of that same datum.
 -/
 
 public section
@@ -73,7 +73,7 @@ open DynkinType
 
 /-! ## The numbered subgroups sit at the named simple roots -/
 
-/-- **The `i`-th raising subgroup sits at the `i`-th simple root of the uniform pinned type-`E₆`
+/-- **The `i`-th raising subgroup sits at the `i`-th simple root of the uniform type-`E₆`
 datum.** Its character for the action of the carrier's split weight torus is the root selected by
 the uniform Bourbaki simple-root index. -/
 theorem rootGeneratorWeight_inl_eq_root_simpleIndex (ht : E6.Valid) (i : Fin 6) :
@@ -85,7 +85,7 @@ theorem rootGeneratorWeight_inl_eq_root_simpleIndex (ht : E6.Valid) (i : Fin 6) 
   rw [rootGeneratorWeight_inl]
 
 /-- **The `i`-th lowering subgroup sits at the negative of the `i`-th simple root of the uniform
-pinned type-`E₆` datum.** -/
+type-`E₆` datum.** -/
 theorem rootGeneratorWeight_inr_eq_neg_root_simpleIndex (ht : E6.Valid) (i : Fin 6) :
     rootGeneratorWeight (.inr i) =
       -(E6.simplyConnectedRootDatum ht).root (E6.simpleIndex ht i) :=
@@ -94,12 +94,12 @@ theorem rootGeneratorWeight_inr_eq_neg_root_simpleIndex (ht : E6.Valid) (i : Fin
     rw [rootGeneratorWeight_inr, Pi.neg_apply, rootGeneratorWeight_inl]
   hneg.trans (congrArg Neg.neg (rootGeneratorWeight_inl_eq_root_simpleIndex ht i))
 
-/-! ## The pinning equation against the named simple roots -/
+/-! ## Torus conjugation equations against the named simple roots -/
 
-/-- **The pinning equation of the minuscule carrier at a named positive simple root.** A point of
+/-- **The torus conjugation equation at a named positive simple root.** A point of
 the split weight torus conjugates the raising-subgroup element of parameter `u` at node `i` to the
 same subgroup with parameter `α_i(s)u`, where `α_i` is the corresponding root of the uniform
-pinned simply connected type-`E₆` datum. -/
+simply connected type-`E₆` datum. -/
 theorem weightTorus_conj_rootSubgroup_root_simpleIndex (ht : E6.Valid) (i : Fin 6)
     (A : Type) [CommRing A]
     (s : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
@@ -119,7 +119,7 @@ theorem weightTorus_conj_rootSubgroup_root_simpleIndex (ht : E6.Valid) (i : Fin 
   rw [← rootGeneratorWeight_inl_eq_root_simpleIndex]
   exact weightTorus_conj_rootSubgroup (.inl i) A s u
 
-/-- **The pinning equation of the minuscule carrier at a named negative simple root.** A point of
+/-- **The torus conjugation equation at a named negative simple root.** A point of
 the split weight torus conjugates the lowering-subgroup element of parameter `u` at node `i` to
 the same subgroup with parameter `(-α_i)(s)u`. -/
 theorem weightTorus_conj_rootSubgroup_neg_root_simpleIndex (ht : E6.Valid) (i : Fin 6)

--- a/TauCeti/Algebra/Lie/E6/Minuscule/RootDatum.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/RootDatum.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E6.Minuscule.GroupScheme
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Assembly
+
+/-!
+# The type E6 minuscule carrier is pinned by its named root datum
+
+`TauCeti.E6Minuscule.groupScheme` is the full-weight Chevalley carrier obtained from the
+twenty-seven-dimensional minuscule representation of the type-`E₆` Serre presentation. Its
+numbered raising and lowering subgroups and its rank-six split weight torus are explicit, and
+their conjugation equation is stated in terms of the corresponding row of `CartanMatrix.E 6`.
+
+This file identifies that table with the uniform pinned root datum used by downstream consumers.
+For a validity proof `ht : TauCeti.DynkinType.E6.Valid`, the root character of the `i`-th raising
+subgroup is
+
+```text
+(E6.simplyConnectedRootDatum ht).root (E6.simpleIndex ht i),
+```
+
+and the character of the matching lowering subgroup is its negative. Rewriting the carrier's
+conjugation equation by these identifications gives the two pinning equations against the named
+positive and negative simple roots.
+
+The distinction from the equations already in `GroupScheme.lean` is the dispatcher in the target:
+`DynkinType.simplyConnectedRootDatum` is the root datum reached from a validated Lie-type index,
+whereas the carrier was constructed directly from the concrete tables
+`TauCeti.DynkinType.e6Root` and `TauCeti.DynkinType.e6SimpleIndex`. These results certify that the
+two routes use the same Bourbaki numbering and the same character lattice.
+
+This file does not assert reductivity, maximality of the weight torus, existence of all root
+subgroups, or an identification of the carrier with an independently defined algebraic group.
+It packages only the root-subgroup part of the pinning interface that the explicit construction
+already proves.
+
+## Main results
+
+* `TauCeti.E6Minuscule.rootGeneratorWeight_inl_eq_root_simpleIndex`: the raising-subgroup
+  character is the corresponding simple root of the uniform pinned datum.
+* `TauCeti.E6Minuscule.rootGeneratorWeight_inr_eq_neg_root_simpleIndex`: the lowering-subgroup
+  character is the negative of that simple root.
+* `TauCeti.E6Minuscule.weightTorus_conj_rootSubgroup_root_simpleIndex` and
+  `TauCeti.E6Minuscule.weightTorus_conj_rootSubgroup_neg_root_simpleIndex`: the positive and
+  negative simple-root pinning equations.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, Sections 4.4 and 7.1.
+* J. E. Humphreys, *Linear Algebraic Groups*, Sections 26--27.
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate V.
+
+This advances the "Pinnings" and "Root subgroup maps" targets of Layer 9 of
+`TauCetiRoadmap/ReductiveGroups/README.md`. Its consumer is milestone L0 of
+`TauCetiRoadmap/CFSGStatement/README.md`: `ValidLieTypeIndex.AmbientGroup` must be traceable through
+`ValidLieTypeIndex.dynkinType` to `DynkinType.simplyConnectedRootDatum`, with its root subgroups
+pinned against that same datum.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.E6Minuscule
+
+open DynkinType
+
+/-! ## The numbered subgroups sit at the named simple roots -/
+
+/-- **The `i`-th raising subgroup sits at the `i`-th simple root of the uniform pinned type-`E₆`
+datum.** Its character for the action of the carrier's split weight torus is the root selected by
+the uniform Bourbaki simple-root index. -/
+theorem rootGeneratorWeight_inl_eq_root_simpleIndex (ht : E6.Valid) (i : Fin 6) :
+    rootGeneratorWeight (.inl i) =
+      (E6.simplyConnectedRootDatum ht).root (E6.simpleIndex ht i) := by
+  refine Eq.trans ?_ (root_simpleIndex E6 ht i).symm
+  rw [cartanMatrix_E6]
+  funext j
+  rw [rootGeneratorWeight_inl]
+
+/-- **The `i`-th lowering subgroup sits at the negative of the `i`-th simple root of the uniform
+pinned type-`E₆` datum.** -/
+theorem rootGeneratorWeight_inr_eq_neg_root_simpleIndex (ht : E6.Valid) (i : Fin 6) :
+    rootGeneratorWeight (.inr i) =
+      -(E6.simplyConnectedRootDatum ht).root (E6.simpleIndex ht i) :=
+  have hneg : rootGeneratorWeight (.inr i) = -rootGeneratorWeight (.inl i) := by
+    funext j
+    rw [rootGeneratorWeight_inr, Pi.neg_apply, rootGeneratorWeight_inl]
+  hneg.trans (congrArg Neg.neg (rootGeneratorWeight_inl_eq_root_simpleIndex ht i))
+
+/-! ## The pinning equation against the named simple roots -/
+
+/-- **The pinning equation of the minuscule carrier at a named positive simple root.** A point of
+the split weight torus conjugates the raising-subgroup element of parameter `u` at node `i` to the
+same subgroup with parameter `α_i(s)u`, where `α_i` is the corresponding root of the uniform
+pinned simply connected type-`E₆` datum. -/
+theorem weightTorus_conj_rootSubgroup_root_simpleIndex (ht : E6.Valid) (i : Fin 6)
+    (A : Type) [CommRing A]
+    (s : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (SplitTorus.groupScheme ℤ (Fin 6)).X)
+    (u : A) :
+    (s ≫ weightTorus.hom.hom) *
+        ((AdditiveGroup.groupSchemePointMulEquiv A)
+            ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+              (Multiplicative.ofAdd u)) ≫ (rootSubgroup (.inl i)).hom.hom) *
+        (s ≫ weightTorus.hom.hom)⁻¹ =
+      (AdditiveGroup.schemePointsMulEquiv A).symm
+          (Multiplicative.ofAdd
+            ((TauCeti.torusCharacter
+                (SplitTorus.schemePointsMulEquiv (R := ℤ) (A := A) s)
+                ((E6.simplyConnectedRootDatum ht).root (E6.simpleIndex ht i)) : A) * u)) ≫
+        (rootSubgroup (.inl i)).hom.hom := by
+  rw [← rootGeneratorWeight_inl_eq_root_simpleIndex]
+  exact weightTorus_conj_rootSubgroup (.inl i) A s u
+
+/-- **The pinning equation of the minuscule carrier at a named negative simple root.** A point of
+the split weight torus conjugates the lowering-subgroup element of parameter `u` at node `i` to
+the same subgroup with parameter `(-α_i)(s)u`. -/
+theorem weightTorus_conj_rootSubgroup_neg_root_simpleIndex (ht : E6.Valid) (i : Fin 6)
+    (A : Type) [CommRing A]
+    (s : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (SplitTorus.groupScheme ℤ (Fin 6)).X)
+    (u : A) :
+    (s ≫ weightTorus.hom.hom) *
+        ((AdditiveGroup.groupSchemePointMulEquiv A)
+            ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+              (Multiplicative.ofAdd u)) ≫ (rootSubgroup (.inr i)).hom.hom) *
+        (s ≫ weightTorus.hom.hom)⁻¹ =
+      (AdditiveGroup.schemePointsMulEquiv A).symm
+          (Multiplicative.ofAdd
+            ((TauCeti.torusCharacter
+                (SplitTorus.schemePointsMulEquiv (R := ℤ) (A := A) s)
+                (-(E6.simplyConnectedRootDatum ht).root (E6.simpleIndex ht i)) : A) * u)) ≫
+        (rootSubgroup (.inr i)).hom.hom := by
+  rw [← rootGeneratorWeight_inr_eq_neg_root_simpleIndex]
+  exact weightTorus_conj_rootSubgroup (.inr i) A s u
+
+end TauCeti.E6Minuscule

--- a/TauCeti/Algebra/Lie/E6/Minuscule/RootDatum.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/RootDatum.lean
@@ -85,20 +85,19 @@ the uniform Bourbaki simple-root index. -/
 theorem rootGeneratorWeight_inl_eq_root_simpleIndex (ht : E6.Valid) (i : Fin 6) :
     rootGeneratorWeight (.inl i) =
       (E6.simplyConnectedRootDatum ht).root (E6.simpleIndex ht i) := by
+  -- The dependent root index blocks rewriting the dispatcher equation directly, so both sides
+  -- are identified with the Cartan-matrix row through the carrier's concrete-table lemma.
   refine Eq.trans ?_ (root_simpleIndex E6 ht i).symm
-  rw [cartanMatrix_E6]
-  funext j
-  rw [rootGeneratorWeight_inl]
+  rw [cartanMatrix_E6, rootGeneratorWeight_inl_eq_e6Root_e6SimpleIndex, root_e6SimpleIndex]
 
 /-- **The `i`-th lowering subgroup sits at the negative of the `i`-th simple root of the uniform
 type-`E₆` datum.** -/
 theorem rootGeneratorWeight_inr_eq_neg_root_simpleIndex (ht : E6.Valid) (i : Fin 6) :
     rootGeneratorWeight (.inr i) =
       -(E6.simplyConnectedRootDatum ht).root (E6.simpleIndex ht i) :=
-  have hneg : rootGeneratorWeight (.inr i) = -rootGeneratorWeight (.inl i) := by
-    funext j
-    rw [rootGeneratorWeight_inr, Pi.neg_apply, rootGeneratorWeight_inl]
-  hneg.trans (congrArg Neg.neg (rootGeneratorWeight_inl_eq_root_simpleIndex ht i))
+  (rootGeneratorWeight_inr_eq_neg_e6Root_e6SimpleIndex i).trans
+    (congrArg Neg.neg ((rootGeneratorWeight_inl_eq_e6Root_e6SimpleIndex i).symm.trans
+      (rootGeneratorWeight_inl_eq_root_simpleIndex ht i)))
 
 /-! ## Torus conjugation equations against the named simple roots -/
 


### PR DESCRIPTION
This PR connects the explicit E6 minuscule carrier to the named simply connected root datum by identifying its raising and lowering torus characters with the positive and negative Bourbaki simple roots, then exposes the corresponding conjugation equations through the uniform `DynkinType.simplyConnectedRootDatum` dispatcher. It advances the exact “Pinnings” and “Root subgroup maps” targets of Layer 9 in `TauCetiRoadmap/ReductiveGroups/README.md` for the E6 minuscule carrier.

CFSGStatement milestone L0 is the consumer: `ValidLieTypeIndex.AmbientGroup` must pass through `ValidLieTypeIndex.dynkinType` to the same pinned root datum used by the carrier. This PR supplies that dependency edge for the E6 family by proving that the carrier's concrete `e6Root`/`e6SimpleIndex` tables agree with `E6.simplyConnectedRootDatum`/`E6.simpleIndex`.

The new module contains four sorry-free theorems: the positive and negative simple-root character identifications and the resulting positive and negative pinning equations. It uses Tau Ceti's existing `DynkinType.root_simpleIndex` and `E6Minuscule.weightTorus_conj_rootSubgroup` infrastructure; no Mathlib infrastructure is vendored.

After this PR, the Layer 9 E6 path still needs its remaining all-root, Borel, and reductivity interfaces plus graph/Frobenius structure and uniform ambient-group assembly before CFSGStatement L0 closes; the Frobenius and diagram-automorphism pieces are already in flight separately.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e6-minuscule-pinned-root-datum-realization"}-->

🤖 Prepared with Codex
