### PR TITLE
feat: characterize and audit the four Janko presentation rows

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Four.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Four.lean
@@ -44,9 +44,29 @@ This computation is provenance rather than a Lean theorem: the file asserts no o
 simplicity, or identification result. The independent `FiniteSimpleGroups` development named by
 the roadmap does not cover `J₄`, so no cross-check against that development is available.
 
-## Main definition
+The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
+relator expressions with their generator indices written out, and the provenance a manifest row
+exists to record. Together with `TauCeti.GroupPresentation.relators_def` and
+`TauCeti.GroupPresentation.mem_relatorSet_iff` the first of those determines the compiled words and
+the relations defining the presented group, so a consumer reasons about the row without unfolding
+it.
+
+Three decidable checks accompany those equations. The relator lengths and their total record the
+compiled data one word at a time and in aggregate, and cyclic reducedness is what makes such a
+letter count comparable with a published presentation length, since both are measured after free
+and cyclic reduction of each relator. This row records no published length, so the total here
+states the transcription for a reviewer to compare with the source, rather than checking it against
+a recorded number.
+
+## Main definitions and results
 
 * `TauCeti.Sporadic.j4Presentation`: John Bray's ATLAS finite presentation of `J₄`.
+* `TauCeti.Sporadic.j4Presentation_transcribed` and the equations for the remaining fields: the
+  characterization of the sealed row.
+* `TauCeti.Sporadic.j4Presentation_map_length_relators`,
+  `TauCeti.Sporadic.j4Presentation_totalLength` and
+  `TauCeti.Sporadic.j4Presentation_relatorsCyclicallyReduced`: the three checks on the compiled
+  words.
 
 ## References
 
@@ -134,8 +154,154 @@ def j4Presentation : GroupPresentation where
       .pow (.pow (y ⬝ x ⬝ y ⬝ x ⬝ y ⬝ x ⬝ y) 3 ⬝ t ⬝
         sourceConj t secondConjugator) 2 ]
 
+/-- The generator names recorded for `J₄`. The row's body is sealed, so this is what lets a
+consumer see that it is a three-generator presentation. -/
+@[simp]
+theorem j4Presentation_generatorNames : j4Presentation.generatorNames = ["x", "y", "t"] := by
+  simp [j4Presentation]
+
+/-- The source recorded for `J₄`. The row's body is sealed, so this equation is what publishes the
+citation itself, rather than only the row's name, to a downstream audit. -/
+@[simp]
+theorem j4Presentation_source :
+    j4Presentation.source = "S. W. Bolt, J. N. Bray, and R. T. Curtis, Symmetric presentation of \
+      the Janko group J4, J. London Math. Soc. 76 (2007), 683-701; R. A. Wilson, R. A. Parker, \
+      J. N. Bray et al., ATLAS of Finite Group Representations, version 3" := by
+  simp [j4Presentation]
+
+/-- The locator recorded for `J₄`, pointing at the presentation inside its sources. -/
+@[simp]
+theorem j4Presentation_sourceLocator :
+    j4Presentation.sourceLocator = "Bolt-Bray-Curtis, Section 5, doi:10.1112/jlms/jdm086; ATLAS \
+      presentation J4G2-P1, https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/J4G2-P1; relator list \
+      and enumeration notes, https://brauer.maths.qmul.ac.uk/Atlas/spor/J4/mag/J4G2-P1.M" := by
+  simp [j4Presentation]
+
+/-- The generator convention recorded for `J₄`, fixing which generator each relator index names and
+which commutator and conjugation conventions the source uses. -/
+@[simp]
+theorem j4Presentation_generatorConvention :
+    j4Presentation.generatorConvention = "The ATLAS type II standard generators x, y, and t of \
+      J4, in that order, so indices 0, 1, and 2 are x, y, and t. Products are read left to right, \
+      negative exponents denote inverses, [r,s] denotes r^-1 s^-1 r s, and r^s denotes \
+      s^-1 r s." := by
+  simp [j4Presentation]
+
+/-- The transcription notes recorded for `J₄`. -/
+@[simp]
+theorem j4Presentation_transcriptionNotes :
+    j4Presentation.transcriptionNotes = "The twelve words are stored in the order of the ATLAS \
+      Magma file; none is marked redundant. Source conjugates are expanded as s^-1*r*s, while \
+      products and natural powers remain structured. GAP 4.15.1 with AtlasRep 2.1.9 checks the \
+      twelve compiled words on type II generators obtained by the ATLAS restandardization program \
+      from the 112-dimensional characteristic-two matrix representation of J4. The source's \
+      double-coset route enumerates 3980549947 cosets of the involution centralizer." := by
+  simp [j4Presentation]
+
+/-- The generator count `J₄`'s source states. With
+`TauCeti.Sporadic.j4Presentation_generatorNames` this is what makes
+`TauCeti.Sporadic.j4Presentation_matchesMetadata` an equation between two visible numbers. -/
+@[simp]
+theorem j4Presentation_expectedGeneratorCount : j4Presentation.expectedGeneratorCount = 3 := by
+  simp [j4Presentation]
+
+/-- The relator count `J₄`'s source states; see
+`TauCeti.Sporadic.j4Presentation_expectedGeneratorCount`. -/
+@[simp]
+theorem j4Presentation_expectedRelatorCount : j4Presentation.expectedRelatorCount = 12 := by
+  simp [j4Presentation]
+
+/-- The relator expressions transcribed for `J₄`, with their generator indices written out and the
+private abbreviations of this file expanded.
+
+The row's body is sealed, so this is the equation that characterizes it: with
+`TauCeti.GroupPresentation.relators_def` it determines the compiled words, and with
+`TauCeti.GroupPresentation.mem_relatorSet_iff` it determines the relations defining
+`TauCeti.GroupPresentation.Group`, so a consumer never has to unfold the row. Indices `0`, `1` and
+`2` are the generators `x`, `y` and `t`, and the bounds come from
+`TauCeti.Sporadic.j4Presentation_generatorNames`. Each source conjugate `r^s` appears as the
+bracketed `s⁻¹rs`, since the stored expression is a tree and not a flat word. -/
+@[simp]
+theorem j4Presentation_transcribed :
+    j4Presentation.transcribed =
+      [ -- x²
+        .pow (.gen ⟨0, by simp⟩) 2,
+        -- y³
+        .pow (.gen ⟨1, by simp⟩) 3,
+        -- (xy)²³
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 23,
+        -- [x,y]¹², in the source's commutator convention
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩)) (.inv (.gen ⟨1, by simp⟩))) 12,
+        -- [x,yxy]⁵
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩))
+          (.inv (.gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩))) 5,
+        -- (xyxyxy⁻¹)³(xyxy⁻¹xy⁻¹)³
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝
+          .gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) 3 ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝
+            .inv (.gen ⟨1, by simp⟩) ⬝ .gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) 3,
+        -- (xy(xyxy⁻¹)³)⁴
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝
+            .inv (.gen ⟨1, by simp⟩)) 3) 4,
+        -- t²
+        .pow (.gen ⟨2, by simp⟩) 2,
+        -- [t,x]
+        .comm (.inv (.gen ⟨2, by simp⟩)) (.inv (.gen ⟨0, by simp⟩)),
+        -- [t,yxy(xy⁻¹)²(xy)³]
+        .comm (.inv (.gen ⟨2, by simp⟩))
+          (.inv (.gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝
+            .pow (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) 2 ⬝
+            .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 3)),
+        -- (y t^(yxy⁻¹xyxy⁻¹x))³
+        .pow (.gen ⟨1, by simp⟩ ⬝
+          (.inv (.gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩) ⬝
+              .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝
+              .inv (.gen ⟨1, by simp⟩) ⬝ .gen ⟨0, by simp⟩) ⬝
+            .gen ⟨2, by simp⟩ ⬝
+            (.gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩) ⬝
+              .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝
+              .inv (.gen ⟨1, by simp⟩) ⬝ .gen ⟨0, by simp⟩))) 3,
+        -- ((yxyxyxy)³ t t^((xy)³y(xy)⁶y))²
+        .pow (.pow (.gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝
+            .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 3 ⬝
+          .gen ⟨2, by simp⟩ ⬝
+          (.inv (.pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 3 ⬝ .gen ⟨1, by simp⟩ ⬝
+              .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 6 ⬝ .gen ⟨1, by simp⟩) ⬝
+            .gen ⟨2, by simp⟩ ⬝
+            (.pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 3 ⬝ .gen ⟨1, by simp⟩ ⬝
+              .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 6 ⬝ .gen ⟨1, by simp⟩))) 2 ] := by
+  simp [j4Presentation]
+
 /-- The generator and relator counts recorded for `J₄` agree with the transcribed data. -/
-theorem matchesMetadata_j4Presentation : j4Presentation.matchesMetadata := by
+theorem j4Presentation_matchesMetadata : j4Presentation.matchesMetadata := by
+  decide
+
+/-- The lengths of the twelve compiled relator words for `J₄`, in the order of the ATLAS Magma
+file.
+
+Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
+than only observe one in the total of `TauCeti.Sporadic.j4Presentation_totalLength`. -/
+theorem j4Presentation_map_length_relators :
+    j4Presentation.relators.map List.length =
+      [2, 3, 46, 48, 40, 36, 56, 2, 4, 28, 54, 126] := by
+  simp [GroupPresentation.relators_def, j4Presentation]
+
+/-- The compiled relator words for `J₄` have `445` letters in total. The row records no published
+length, so this figure states the transcribed data for a reviewer to compare with the source,
+rather than checking it against a recorded number. -/
+theorem j4Presentation_totalLength : j4Presentation.totalLength = 445 := by
+  rw [GroupPresentation.totalLength_def, j4Presentation_map_length_relators]
+  decide
+
+/-- Every compiled relator word for `J₄` is cyclically reduced. This is what makes the letter count
+of `TauCeti.Sporadic.j4Presentation_totalLength` comparable with a published presentation length,
+which is measured after free and cyclic reduction of each relator. -/
+theorem j4Presentation_relatorsCyclicallyReduced :
+    j4Presentation.relatorsCyclicallyReduced := by
+  simp only [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def,
+    j4Presentation, List.map_cons, List.map_nil, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_inv, Relator.toWord_comm, Relator.toWord_gen]
   decide
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/One.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/One.lean
@@ -34,9 +34,29 @@ GAP constructs an isomorphism from its permutation image to the ATLAS group. Thi
 provenance for the transcription, not a Lean theorem. This file asserts no order, finiteness,
 simplicity, or identification result.
 
-## Main definition
+The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
+relator expressions with their generator indices written out, and the provenance a manifest row
+exists to record. Together with `TauCeti.GroupPresentation.relators_def` and
+`TauCeti.GroupPresentation.mem_relatorSet_iff` the first of those determines the compiled words and
+the relations defining the presented group, so a consumer reasons about the row without unfolding
+it.
+
+Three decidable checks accompany those equations. The relator lengths and their total record the
+compiled data one word at a time and in aggregate, and cyclic reducedness is what makes such a
+letter count comparable with a published presentation length, since both are measured after free
+and cyclic reduction of each relator. This row records no published length, so the total here
+states the transcription for a reviewer to compare with the source, rather than checking it against
+a recorded number.
+
+## Main definitions and results
 
 * `TauCeti.Sporadic.j1Presentation`: the ATLAS finite presentation of `J₁`.
+* `TauCeti.Sporadic.j1Presentation_transcribed` and the equations for the remaining fields: the
+  characterization of the sealed row.
+* `TauCeti.Sporadic.j1Presentation_map_length_relators`,
+  `TauCeti.Sporadic.j1Presentation_totalLength` and
+  `TauCeti.Sporadic.j1Presentation_relatorsCyclicallyReduced`: the three checks on the compiled
+  words.
 
 ## References
 
@@ -94,7 +114,113 @@ def j1Presentation : GroupPresentation where
       .pow fifthPowerBase 5,
       .pow squareBase 2 ]
 
+/-- The generator names recorded for `J₁`. The row's body is sealed, so this is what lets a
+consumer see that it is a two-generator presentation. -/
+@[simp]
+theorem j1Presentation_generatorNames : j1Presentation.generatorNames = ["a", "b"] := by
+  simp [j1Presentation]
+
+/-- The source recorded for `J₁`. The row's body is sealed, so this equation is what publishes the
+citation itself, rather than only the row's name, to a downstream audit. -/
+@[simp]
+theorem j1Presentation_source :
+    j1Presentation.source = "R. A. Wilson, R. A. Parker, and J. N. Bray, ATLAS of Finite Group \
+      Representations, version 3" := by
+  simp [j1Presentation]
+
+/-- The locator recorded for `J₁`, pointing at the presentation inside its source. -/
+@[simp]
+theorem j1Presentation_sourceLocator :
+    j1Presentation.sourceLocator =
+      "J_1 page, Presentation section, https://brauer.maths.qmul.ac.uk/Atlas/v3/spor/J1/" := by
+  simp [j1Presentation]
+
+/-- The generator convention recorded for `J₁`, fixing which generator each relator index names. -/
+@[simp]
+theorem j1Presentation_generatorConvention :
+    j1Presentation.generatorConvention = "The ATLAS standard generators a and b, in that order, \
+      so index 0 is a and index 1 is b. Products are read left to right and negative exponents \
+      denote inverses." := by
+  simp [j1Presentation]
+
+/-- The transcription notes recorded for `J₁`. -/
+@[simp]
+theorem j1Presentation_transcriptionNotes :
+    j1Presentation.transcriptionNotes = "The five displayed words are stored as five relators \
+      equal to the identity. GAP 4.15.1 checks them on the independent ATLAS 266-point \
+      generators; enumeration of this abstract presentation gives order 175560 and an isomorphism \
+      to the ATLAS group." := by
+  simp [j1Presentation]
+
+/-- The generator count `J₁`'s source states. With
+`TauCeti.Sporadic.j1Presentation_generatorNames` this is what makes
+`TauCeti.Sporadic.j1Presentation_matchesMetadata` an equation between two visible numbers. -/
+@[simp]
+theorem j1Presentation_expectedGeneratorCount : j1Presentation.expectedGeneratorCount = 2 := by
+  simp [j1Presentation]
+
+/-- The relator count `J₁`'s source states; see
+`TauCeti.Sporadic.j1Presentation_expectedGeneratorCount`. -/
+@[simp]
+theorem j1Presentation_expectedRelatorCount : j1Presentation.expectedRelatorCount = 5 := by
+  simp [j1Presentation]
+
+/-- The relator expressions transcribed for `J₁`, with their generator indices written out and the
+private abbreviations of this file expanded.
+
+The row's body is sealed, so this is the equation that characterizes it: with
+`TauCeti.GroupPresentation.relators_def` it determines the compiled words, and with
+`TauCeti.GroupPresentation.mem_relatorSet_iff` it determines the relations defining
+`TauCeti.GroupPresentation.Group`, so a consumer never has to unfold the row. Index `0` is the
+generator `a` and index `1` is `b`, and the bounds come from
+`TauCeti.Sporadic.j1Presentation_generatorNames`. -/
+@[simp]
+theorem j1Presentation_transcribed :
+    j1Presentation.transcribed =
+      [ -- a²
+        .pow (.gen ⟨0, by simp⟩) 2,
+        -- b³
+        .pow (.gen ⟨1, by simp⟩) 3,
+        -- (ab)⁷
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 7,
+        -- (ab(abab⁻¹)³)⁵
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝
+            .inv (.gen ⟨1, by simp⟩)) 3) 5,
+        -- (ab(abab⁻¹)⁶abab(ab⁻¹)²)²
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝
+            .inv (.gen ⟨1, by simp⟩)) 6 ⬝
+          .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) 2) 2 ] := by
+  simp [j1Presentation]
+
 /-- The generator and relator counts recorded for `J₁` agree with the transcribed data. -/
 theorem j1Presentation_matchesMetadata : j1Presentation.matchesMetadata := by decide
+
+/-- The lengths of the five compiled relator words for `J₁`, in the order of the source.
+
+Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
+than only observe one in the total of `TauCeti.Sporadic.j1Presentation_totalLength`. -/
+theorem j1Presentation_map_length_relators :
+    j1Presentation.relators.map List.length = [2, 3, 14, 70, 68] := by
+  simp [GroupPresentation.relators_def, j1Presentation]
+
+/-- The compiled relator words for `J₁` have `157` letters in total. The row records no published
+length, so this figure states the transcribed data for a reviewer to compare with the source,
+rather than checking it against a recorded number. -/
+theorem j1Presentation_totalLength : j1Presentation.totalLength = 157 := by
+  rw [GroupPresentation.totalLength_def, j1Presentation_map_length_relators]
+  decide
+
+/-- Every compiled relator word for `J₁` is cyclically reduced. This is what makes the letter count
+of `TauCeti.Sporadic.j1Presentation_totalLength` comparable with a published presentation length,
+which is measured after free and cyclic reduction of each relator. -/
+theorem j1Presentation_relatorsCyclicallyReduced :
+    j1Presentation.relatorsCyclicallyReduced := by
+  simp only [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def,
+    j1Presentation, List.map_cons, List.map_nil, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_inv, Relator.toWord_gen]
+  decide
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Three.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Three.lean
@@ -57,10 +57,30 @@ transcription, not Lean theorems: this file asserts no order, finiteness, simpli
 identification result. The roadmap's further cross-check against the `FiniteSimpleGroups`
 permutation development is unavailable for `J₃`, which that development does not cover.
 
-## Main definition
+The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
+relator expressions with their generator indices written out, and the provenance a manifest row
+exists to record. Together with `TauCeti.GroupPresentation.relators_def` and
+`TauCeti.GroupPresentation.mem_relatorSet_iff` the first of those determines the compiled words and
+the relations defining the presented group, so a consumer reasons about the row without unfolding
+it.
+
+Three decidable checks accompany those equations. The relator lengths and their total record the
+compiled data one word at a time and in aggregate, and cyclic reducedness is what makes such a
+letter count comparable with a published presentation length, since both are measured after free
+and cyclic reduction of each relator. This row records no published length, so the total here
+states the transcription for a reviewer to compare with the source, rather than checking it against
+a recorded number.
+
+## Main definitions and results
 
 * `TauCeti.Sporadic.j3Presentation`: the ATLAS finite presentation of `J₃`, for which the ATLAS
   records no individual contributor.
+* `TauCeti.Sporadic.j3Presentation_transcribed` and the equations for the remaining fields: the
+  characterization of the sealed row.
+* `TauCeti.Sporadic.j3Presentation_map_length_relators`,
+  `TauCeti.Sporadic.j3Presentation_totalLength` and
+  `TauCeti.Sporadic.j3Presentation_relatorsCyclicallyReduced`: the three checks on the compiled
+  words.
 
 ## References
 
@@ -138,7 +158,144 @@ def j3Presentation : GroupPresentation where
       seventhWord,
       .pow (.pow ab1 3 ⬝ .pow (ab1 ⬝ abNeg1) 2) 4 ]
 
+/-- The generator names recorded for `J₃`. The row's body is sealed, so this is what lets a
+consumer see that it is a two-generator presentation. -/
+@[simp]
+theorem j3Presentation_generatorNames : j3Presentation.generatorNames = ["a", "b"] := by
+  simp [j3Presentation]
+
+/-- The source recorded for `J₃`. The row's body is sealed, so this equation is what publishes the
+citation itself, rather than only the row's name, to a downstream audit. -/
+@[simp]
+theorem j3Presentation_source :
+    j3Presentation.source = "R. A. Wilson, R. A. Parker, J. N. Bray et al., ATLAS of Finite Group \
+      Representations, version 3; individual presentation contributor not recorded" := by
+  simp [j3Presentation]
+
+/-- The locator recorded for `J₃`, pointing at the presentation inside its source. -/
+@[simp]
+theorem j3Presentation_sourceLocator :
+    j3Presentation.sourceLocator = "J3G1-P1, \
+      https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/J3G1-P1, with the relator list and the \
+      demonstration of correctness in the Magma source file \
+      https://brauer.maths.qmul.ac.uk/Atlas/spor/J3/mag/J3G1-P1.M" := by
+  simp [j3Presentation]
+
+/-- The generator convention recorded for `J₃`, fixing which generator each relator index names and
+which commutator convention the source uses. -/
+@[simp]
+theorem j3Presentation_generatorConvention :
+    j3Presentation.generatorConvention = "The ATLAS standard generators a and b of J3, that is, a \
+      in class 2A and b in class 3A with ab of order 19, in that order, so index 0 is a and index \
+      1 is b. Products are read left to right, negative exponents denote inverses, and [r,s] \
+      denotes r^-1 s^-1 r s." := by
+  simp [j3Presentation]
+
+/-- The transcription notes recorded for `J₃`. -/
+@[simp]
+theorem j3Presentation_transcriptionNotes :
+    j3Presentation.transcriptionNotes = "The eight words of the source's relator list are stored \
+      as eight relators equal to the identity, in the order of the Magma file; the ATLAS page \
+      records no individual contributor for this presentation. The presentation page displays the \
+      same eight words with (x,y)^9 and (x*y)^19 interchanged. No word is marked redundant in \
+      either rendering. The source demonstrates correctness by the coset enumeration \
+      19*Index(G,K1) over the cyclic subgroup K1 = <a*b> of order 19, returning the order \
+      50232960 of J3. GAP 4.15.1 reproduces that enumeration from the eight compiled words, \
+      obtaining the index 2643840, and checks that the same eight words vanish on the ATLAS \
+      6156-point standard generators of J3, which have a an involution with centralizer of order \
+      1920, b of order 3 with centralizer of order 1080, ab of order 19, and which generate a \
+      simple group of order 50232960." := by
+  simp [j3Presentation]
+
+/-- The generator count `J₃`'s source states. With
+`TauCeti.Sporadic.j3Presentation_generatorNames` this is what makes
+`TauCeti.Sporadic.j3Presentation_matchesMetadata` an equation between two visible numbers. -/
+@[simp]
+theorem j3Presentation_expectedGeneratorCount : j3Presentation.expectedGeneratorCount = 2 := by
+  simp [j3Presentation]
+
+/-- The relator count `J₃`'s source states; see
+`TauCeti.Sporadic.j3Presentation_expectedGeneratorCount`. -/
+@[simp]
+theorem j3Presentation_expectedRelatorCount : j3Presentation.expectedRelatorCount = 8 := by
+  simp [j3Presentation]
+
+/-- The relator expressions transcribed for `J₃`, with their generator indices written out and the
+private abbreviations of this file expanded.
+
+The row's body is sealed, so this is the equation that characterizes it: with
+`TauCeti.GroupPresentation.relators_def` it determines the compiled words, and with
+`TauCeti.GroupPresentation.mem_relatorSet_iff` it determines the relations defining
+`TauCeti.GroupPresentation.Group`, so a consumer never has to unfold the row. Index `0` is the
+generator `a` and index `1` is `b`, and the bounds come from
+`TauCeti.Sporadic.j3Presentation_generatorNames`. Every occurrence of a syllable `ab` or `ab⁻¹` is
+bracketed, since the stored expression is a tree and not a flat word. -/
+@[simp]
+theorem j3Presentation_transcribed :
+    j3Presentation.transcribed =
+      [ -- a²
+        .pow (.gen ⟨0, by simp⟩) 2,
+        -- b³
+        .pow (.gen ⟨1, by simp⟩) 3,
+        -- [a,b]⁹, in the source's commutator convention
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩)) (.inv (.gen ⟨1, by simp⟩))) 9,
+        -- (ab)¹⁹
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 19,
+        -- ((ab)⁶(ab⁻¹)⁵)²
+        .pow (.pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 6 ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) 5) 2,
+        -- ((abab ab⁻¹)² ab ab⁻¹ ab⁻¹ ab ab⁻¹)²
+        .pow (.pow ((.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+              (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+              (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩))) 2 ⬝
+            (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+            (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+            (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+            (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+            (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩))) 2,
+        -- abab (abab⁻¹)³ abab (abab⁻¹)⁴ ab⁻¹ (abab⁻¹)³
+        (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow ((.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+            (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩))) 3 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow ((.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+            (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩))) 4 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          .pow ((.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+            (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩))) 3,
+        -- ((ab)³(abab⁻¹)²)⁴
+        .pow (.pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 3 ⬝
+          .pow ((.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+            (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩))) 2) 4 ] := by
+  simp [j3Presentation]
+
 /-- The generator and relator counts recorded for `J₃` agree with the transcribed data. -/
 theorem j3Presentation_matchesMetadata : j3Presentation.matchesMetadata := by decide
+
+/-- The lengths of the eight compiled relator words for `J₃`, in the order of the Magma source
+file.
+
+Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
+than only observe one in the total of `TauCeti.Sporadic.j3Presentation_totalLength`. -/
+theorem j3Presentation_map_length_relators :
+    j3Presentation.relators.map List.length = [2, 3, 36, 38, 44, 44, 50, 56] := by
+  simp [GroupPresentation.relators_def, j3Presentation]
+
+/-- The compiled relator words for `J₃` have `273` letters in total. The row records no published
+length, so this figure states the transcribed data for a reviewer to compare with the source,
+rather than checking it against a recorded number. -/
+theorem j3Presentation_totalLength : j3Presentation.totalLength = 273 := by
+  rw [GroupPresentation.totalLength_def, j3Presentation_map_length_relators]
+  decide
+
+/-- Every compiled relator word for `J₃` is cyclically reduced. This is what makes the letter count
+of `TauCeti.Sporadic.j3Presentation_totalLength` comparable with a published presentation length,
+which is measured after free and cyclic reduction of each relator. -/
+theorem j3Presentation_relatorsCyclicallyReduced :
+    j3Presentation.relatorsCyclicallyReduced := by
+  simp only [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def,
+    j3Presentation, List.map_cons, List.map_nil, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_inv, Relator.toWord_comm, Relator.toWord_gen]
+  decide
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Two.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Two.lean
@@ -36,15 +36,34 @@ expressions preserve the source's powers and display each relation in the same l
 `Relator.toWord_toFreeGroup` is the already-proved audit boundary from those expressions to the
 signed words used by `PresentedGroup`.
 
+Three further decidable checks record the compiled words: their lengths one relator at a time,
+their total, and cyclic reducedness, which is what makes such a letter count comparable with a
+published presentation length, since both are measured after free and cyclic reduction of each
+relator. This row records no published length, so the total here states the transcription for a
+reviewer to compare with the source, rather than checking it against a recorded number.
+
+The row is a sealed definition, so it also publishes an equation for each of its fields: the
+transcribed relator expressions with their generator indices written out, and the provenance a
+manifest row exists to record. Together with `TauCeti.GroupPresentation.relators_def` and
+`TauCeti.GroupPresentation.mem_relatorSet_iff` the first of those determines the compiled words and
+the relations defining the presented group, so a consumer reasons about the row without unfolding
+it.
+
 As an independent transcription check, the exact three relators below were enumerated with GAP
 4.15.1 over the trivial subgroup; the resulting finitely presented group has order `604800`,
 agreeing with both the paper and GAP's Atlas group `J2`. This computation is provenance for the
 transcription, not a Lean theorem, and this file asserts no order, finiteness, simplicity, or
 identification result.
 
-## Main definition
+## Main definitions and results
 
 * `TauCeti.Sporadic.j2Presentation`: Stoytchev's finite presentation of `J₂`.
+* `TauCeti.Sporadic.j2Presentation_transcribed` and the equations for the remaining fields: the
+  characterization of the sealed row.
+* `TauCeti.Sporadic.j2Presentation_map_length_relators`,
+  `TauCeti.Sporadic.j2Presentation_totalLength` and
+  `TauCeti.Sporadic.j2Presentation_relatorsCyclicallyReduced`: the three checks on the compiled
+  words.
 
 ## References
 
@@ -92,7 +111,108 @@ def j2Presentation : GroupPresentation where
       a ⬝ .pow b 2 ⬝ a ⬝ .pow (.inv b) 5,
       .pow j2Word 3 ⬝ .pow a 7 ]
 
+/-- The generator names recorded for `J₂`. The row's body is sealed, so this is what lets a
+consumer see that it is a two-generator presentation. -/
+@[simp]
+theorem j2Presentation_generatorNames : j2Presentation.generatorNames = ["a", "b"] := by
+  simp [j2Presentation]
+
+/-- The source recorded for `J₂`. The row's body is sealed, so this equation is what publishes the
+citation itself, rather than only the row's name, to a downstream audit. -/
+@[simp]
+theorem j2Presentation_source :
+    j2Presentation.source = "O. Stoytchev, A Class of Efficient Presentations of Finite Simple \
+      Groups, arXiv:2011.05660v1 (2020)" := by
+  simp [j2Presentation]
+
+/-- The locator recorded for `J₂`, pointing at the presentation inside its source. -/
+@[simp]
+theorem j2Presentation_sourceLocator :
+    j2Presentation.sourceLocator =
+      "Section 3, n = 7, order 604800 entry (the presentation labelled J_2)" := by
+  simp [j2Presentation]
+
+/-- The generator convention recorded for `J₂`, fixing which generator each relator index names. -/
+@[simp]
+theorem j2Presentation_generatorConvention :
+    j2Presentation.generatorConvention = "The generators a and b of the source, in that order, so \
+      index 0 is a and index 1 is b. Products are read left to right, negative exponents denote \
+      inverses, and each displayed equality is imposed as a relator equal to the identity." := by
+  simp [j2Presentation]
+
+/-- The transcription notes recorded for `J₂`, including the choice of sign left open by the
+source's last relation. -/
+@[simp]
+theorem j2Presentation_transcriptionNotes :
+    j2Presentation.transcriptionNotes = "The relations aba = bab and ab^2 a = b^5 are transcribed \
+      as aba(bab)^-1 and ab^2 a b^-5. For the source's final relation \
+      (a b^-1 a b^-3 a^3 b^-1)^(+/-3) a^7 = 1, this row chooses the positive exponent +3. \
+      GAP 4.15.1 independently enumerates these exact three relators to order 604800." := by
+  simp [j2Presentation]
+
+/-- The generator count `J₂`'s source states. With
+`TauCeti.Sporadic.j2Presentation_generatorNames` this is what makes
+`TauCeti.Sporadic.j2Presentation_matchesMetadata` an equation between two visible numbers. -/
+@[simp]
+theorem j2Presentation_expectedGeneratorCount : j2Presentation.expectedGeneratorCount = 2 := by
+  simp [j2Presentation]
+
+/-- The relator count `J₂`'s source states; see
+`TauCeti.Sporadic.j2Presentation_expectedGeneratorCount`. -/
+@[simp]
+theorem j2Presentation_expectedRelatorCount : j2Presentation.expectedRelatorCount = 3 := by
+  simp [j2Presentation]
+
+/-- The relator expressions transcribed for `J₂`, with their generator indices written out and the
+private abbreviation of this file expanded.
+
+The row's body is sealed, so this is the equation that characterizes it: with
+`TauCeti.GroupPresentation.relators_def` it determines the compiled words, and with
+`TauCeti.GroupPresentation.mem_relatorSet_iff` it determines the relations defining
+`TauCeti.GroupPresentation.Group`, so a consumer never has to unfold the row. Index `0` is the
+generator `a` and index `1` is `b`, and the bounds come from
+`TauCeti.Sporadic.j2Presentation_generatorNames`. -/
+@[simp]
+theorem j2Presentation_transcribed :
+    j2Presentation.transcribed =
+      [ -- aba(bab)⁻¹
+        .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝
+          .inv (.gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩),
+        -- ab²ab⁻⁵
+        .gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2 ⬝ .gen ⟨0, by simp⟩ ⬝
+          .pow (.inv (.gen ⟨1, by simp⟩)) 5,
+        -- (ab⁻¹ab⁻³a³b⁻¹)³a⁷
+        .pow (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩) ⬝ .gen ⟨0, by simp⟩ ⬝
+          .pow (.inv (.gen ⟨1, by simp⟩)) 3 ⬝ .pow (.gen ⟨0, by simp⟩) 3 ⬝
+          .inv (.gen ⟨1, by simp⟩)) 3 ⬝ .pow (.gen ⟨0, by simp⟩) 7 ] := by
+  simp [j2Presentation]
+
 /-- The generator and relator counts recorded for `J₂` agree with the transcribed data. -/
 theorem j2Presentation_matchesMetadata : j2Presentation.matchesMetadata := by decide
+
+/-- The lengths of the three compiled relator words for `J₂`, in the order of the source.
+
+Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
+than only observe one in the total of `TauCeti.Sporadic.j2Presentation_totalLength`. -/
+theorem j2Presentation_map_length_relators :
+    j2Presentation.relators.map List.length = [6, 9, 37] := by
+  simp [GroupPresentation.relators_def, j2Presentation]
+
+/-- The compiled relator words for `J₂` have `52` letters in total. The row records no published
+length, so this figure states the transcribed data for a reviewer to compare with the source,
+rather than checking it against a recorded number. -/
+theorem j2Presentation_totalLength : j2Presentation.totalLength = 52 := by
+  rw [GroupPresentation.totalLength_def, j2Presentation_map_length_relators]
+  decide
+
+/-- Every compiled relator word for `J₂` is cyclically reduced. This is what makes the letter count
+of `TauCeti.Sporadic.j2Presentation_totalLength` comparable with a published presentation length,
+which is measured after free and cyclic reduction of each relator. -/
+theorem j2Presentation_relatorsCyclicallyReduced :
+    j2Presentation.relatorsCyclicallyReduced := by
+  simp only [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def,
+    j2Presentation, List.map_cons, List.map_nil, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_inv, Relator.toWord_gen]
+  decide
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
@@ -108,7 +108,7 @@ theorem presentation_matchesMetadata (s : SporadicName) :
   | J1 => exact Sporadic.j1Presentation_matchesMetadata
   | J2 => exact Sporadic.j2Presentation_matchesMetadata
   | J3 => exact Sporadic.j3Presentation_matchesMetadata
-  | J4 => exact Sporadic.matchesMetadata_j4Presentation
+  | J4 => exact Sporadic.j4Presentation_matchesMetadata
   | HS => exact Sporadic.matchesMetadata_hsPresentation
   | McL => exact Sporadic.matchesMetadata_mclPresentation
   | He => exact Sporadic.hePresentation_matchesMetadata


### PR DESCRIPTION
This PR gives the four Janko rows of the sporadic presentation manifest the characteristic equations their sealed bodies otherwise hide, and three decidable checks on the words those rows compile to. Each of `TauCeti.Sporadic.j1Presentation`, `j2Presentation`, `j3Presentation` and `j4Presentation` now publishes an equation for every one of its fields — the generator names, the source, the locator, the generator convention, the transcription notes, the two stated counts, and the transcribed relator expressions with their generator indices written out and this file's private syllable abbreviations expanded — and, beside the existing count check, the per-relator lengths of the compiled words, their total, and the fact that every compiled word is cyclically reduced. The totals are `157`, `52`, `273` and `445` letters.

This serves milestone S1, "the twenty-six sporadic presentations", of `TauCetiRoadmap/CFSGStatement/README.md`, whose completion evidence is that "relator counts match the manifest" and that each row survives "an independent source-to-Lean read-through". That read-through is exactly what these equations make possible: before this PR a Janko row published only its name and `matchesMetadata`, whose two sides were both invisible, so neither a consumer nor a reviewer could see the relators, the citation, or the counts without unfolding the row. The same interface is already carried by the `M11`, `M12`, `M22`, `Ly`, `M`, `O'Nan`, `Ru`, `Suz` and `Fi24'` rows, whose module docstrings state the rationale; these four rows lacked it entirely. What remains for S1 is the same interface on the rows that still lack it — `M23`, `M24`, `HS`, `McL`, `He`, `Co1`, `Co2`, `Co3`, `Fi22`, `Fi23`, `HN`, `Th`, `B` — together with the roadmap's cross-check against the `FiniteSimpleGroups` permutation development, which is a review artifact rather than a Lean target and is unavailable for `J3` and `J4`.

The mathematical content is the three checks, and what they do and do not establish is worth being exact about. A relator length is read off the transcribed expression rather than the compiled list, through `TauCeti.Relator.length_toWord`, which is the declaration this repository already provides for exactly this purpose: it multiplies at a `Relator.pow` instead of expanding it, so `(xy)^23` costs one multiplication rather than forty-six letter constructors. Cyclic reducedness is what makes such a letter count comparable with a length published by a source, since a published length is measured after free and cyclic reduction of each relator; none of these four rows records a published length, so the totals state the transcription for a reviewer to compare with the source rather than checking it against a recorded number. Nothing here asserts that any presented group is nontrivial, finite, or simple, that it has any particular order, or that it is isomorphic to any other construction of a Janko group, and no `Finite` or `IsSimpleGroup` instance is added.

One rename accompanies the new declarations. `TauCeti.Sporadic.matchesMetadata_j4Presentation` becomes `TauCeti.Sporadic.j4Presentation_matchesMetadata`, matching the three sibling rows and the ten new lemmas in the same file; its only use, in `TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean`, moves with it, and no alias is left behind.

The construction reuses `TauCeti.GroupPresentation.relators_def`, `totalLength_def`, `relatorsCyclicallyReduced_iff` and its decidability instance, and `TauCeti.Relator.length_toWord` with the five `Relator.length` equations; no Mathlib or Tau Ceti material is vendored or restated. The sources of the four rows are unchanged and are cited in the rows themselves: the ATLAS of Finite Group Representations version 3 for `J1`, `J3` and `J4`, Bolt, Bray and Curtis, *Symmetric presentation of the Janko group J4*, J. London Math. Soc. **76** (2007) 683-701 for `J4`, and O. Stoytchev, *A Class of Efficient Presentations of Finite Simple Groups*, arXiv:2011.05660v1 for `J2`. The layout of the added equations follows the merged `M11`, `M12` and `M22` rows in `TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu.lean`.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"janko-presentation-relator-audit"}-->

🤖 Prepared with Claude Code
