### PR TITLE
feat: recognize double transitivity from a long cycle

### DIFF
--- a/TauCeti/GroupTheory/Perm/Basic.lean
+++ b/TauCeti/GroupTheory/Perm/Basic.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Group.End
 public import Mathlib.GroupTheory.Perm.Support
 import Mathlib.GroupTheory.Perm.ViaEmbedding
 

--- a/TauCeti/GroupTheory/Perm/Basic.lean
+++ b/TauCeti/GroupTheory/Perm/Basic.lean
@@ -6,19 +6,31 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Group.End
+public import Mathlib.GroupTheory.Perm.Support
 import Mathlib.GroupTheory.Perm.ViaEmbedding
 
 /-!
 # Elementary facts about permutations
 
 This file records general-purpose facts about permutations: an identity between transpositions,
-a permutation transported along an injection, and the combination of two permutations transported
-along injections with disjoint ranges.
+a characterization of permutations with a unique fixed point, a permutation transported along an
+injection, and the combination of two permutations transported along injections with disjoint
+ranges.
 -/
 
 public section
 
 namespace TauCeti
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-- A permutation moves all but one point exactly when it has a unique fixed point. -/
+theorem card_support_add_one_eq_card_iff_existsUnique_fixedPoint (σ : Equiv.Perm α) :
+    σ.support.card + 1 = Fintype.card α ↔ ∃! x : α, σ x = x := by
+  have hfixed : (∃! x : α, x ∈ σ.supportᶜ) ↔ ∃! x : α, σ x = x := by
+    simp only [Finset.mem_compl, Equiv.Perm.notMem_support]
+  rw [← hfixed, ← Finset.card_eq_one_iff_existsUnique, Finset.card_compl]
+  omega
 
 /-- Whenever `a` and `c` are both distinct from `b`, the transpositions `(a b)` and `(b c)`
 satisfy the braid relation. The two points `a` and `c` need not be distinct: for `a = c` both

--- a/TauCeti/GroupTheory/Perm/MultipleTransitivity.lean
+++ b/TauCeti/GroupTheory/Perm/MultipleTransitivity.lean
@@ -20,15 +20,18 @@ transitivity of the original action.
 
 * `TauCeti.card_support_add_one_eq_card_iff_existsUnique_fixedPoint`: a permutation moves all but
   one point exactly when it has a unique fixed point.
+* `TauCeti.is_two_pretransitive_of_isCycle_mem_of_existsUnique_fixedPoint`: a transitive
+  permutation group containing a cycle with a unique fixed point is doubly transitive.
+* `TauCeti.isPreprimitive_of_isCycle_mem_of_existsUnique_fixedPoint`: such a group is primitive.
 * `TauCeti.is_two_pretransitive_of_isCycle_mem_of_card_support_add_one_eq_card`: a transitive
-  permutation group that contains such a cycle is doubly transitive.
+  finite permutation group that contains a cycle moving all but one point is doubly transitive.
 * `TauCeti.isPreprimitive_of_isCycle_mem_of_card_support_add_one_eq_card`: such a group is
   primitive.
 
-The second result is one of the generic recognition theorems in Layer 1 of
-`TauCetiRoadmap/PolynomialGaloisGroups/README.md`. It is used there both in the classification of
-transitive groups of degree at most five and in the three-prime construction of polynomials with
-full symmetric Galois group.
+These results are part of the generic recognition package in Layer 1 of
+`TauCetiRoadmap/PolynomialGaloisGroups/README.md`, which supports both the degree-at-most-five
+classification and Layer 9. The long-cycle criterion is used specifically in Layer 9's three-prime
+construction of polynomials with full symmetric Galois group.
 
 ## References
 
@@ -36,8 +39,8 @@ full symmetric Galois group.
 * H. Wielandt, *Finite Permutation Groups*, Chapter II.
 
 The point-stabilizer step is adapted from `Mathlib/GroupTheory/GroupAction/Jordan.lean`, by Antoine
-Chambert-Loir; transitivity on the support uses that file's
-`Equiv.Perm.isPretransitive_of_isCycle_mem`.
+Chambert-Loir; the cycle-transitivity argument generalizes that file's
+`Equiv.Perm.isPretransitive_of_isCycle_mem` from finite support to a unique fixed point.
 -/
 
 public section
@@ -46,7 +49,55 @@ namespace TauCeti
 
 open MulAction
 
-variable {α : Type*} [Fintype α] [DecidableEq α]
+variable {α : Type*}
+
+/-- A transitive permutation group containing a cycle with a unique fixed point is doubly
+transitive. -/
+theorem is_two_pretransitive_of_isCycle_mem_of_existsUnique_fixedPoint
+    (G : Subgroup (Equiv.Perm α)) [IsPretransitive G α] {σ : Equiv.Perm α}
+    (hσ : σ.IsCycle) (hσG : σ ∈ G) (hfix : ∃! x : α, σ x = x) :
+    IsMultiplyPretransitive G α 2 := by
+  obtain ⟨x, hx, hunique⟩ := hfix
+  have hσFixing : (⟨σ, hσG⟩ : G) ∈ fixingSubgroup G ({x} : Set α) := by
+    rw [mem_fixingSubgroup_iff]
+    intro y hy
+    rw [Set.mem_singleton_iff] at hy
+    subst y
+    exact hx
+  let σ' : fixingSubgroup G ({x} : Set α) := ⟨⟨σ, hσG⟩, hσFixing⟩
+  have htrans :
+      IsPretransitive (fixingSubgroup G ({x} : Set α))
+        (SubMulAction.ofFixingSubgroup G ({x} : Set α)) := by
+    refine ⟨?_⟩
+    intro y z
+    rcases y with ⟨y, hy⟩
+    rcases z with ⟨z, hz⟩
+    have hy_ne : y ≠ x := by
+      simpa only [Set.mem_singleton_iff] using
+        (SubMulAction.mem_ofFixingSubgroup_iff G).mp hy
+    have hz_ne : z ≠ x := by
+      simpa only [Set.mem_singleton_iff] using
+        (SubMulAction.mem_ofFixingSubgroup_iff G).mp hz
+    have hσy : σ y ≠ y := fun hy_fixed ↦ hy_ne (hunique y hy_fixed)
+    have hσz : σ z ≠ z := fun hz_fixed ↦ hz_ne (hunique z hz_fixed)
+    obtain ⟨i, hi⟩ := hσ.exists_zpow_eq hσy hσz
+    refine ⟨σ' ^ i, ?_⟩
+    apply Subtype.ext
+    exact hi
+  rw [SubMulAction.ofStabilizer.isMultiplyPretransitive (a := x)]
+  rw [is_one_pretransitive_iff]
+  exact IsPretransitive.of_surjective_map
+    SubMulAction.ofFixingSubgroup_of_singleton_bijective.surjective htrans
+
+/-- A transitive permutation group containing a cycle with a unique fixed point is primitive. -/
+theorem isPreprimitive_of_isCycle_mem_of_existsUnique_fixedPoint
+    (G : Subgroup (Equiv.Perm α)) [IsPretransitive G α] {σ : Equiv.Perm α}
+    (hσ : σ.IsCycle) (hσG : σ ∈ G) (hfix : ∃! x : α, σ x = x) :
+    IsPreprimitive G α :=
+  isPreprimitive_of_is_two_pretransitive
+    (is_two_pretransitive_of_isCycle_mem_of_existsUnique_fixedPoint G hσ hσG hfix)
+
+variable [Fintype α] [DecidableEq α]
 
 /-- A transitive subgroup of a finite symmetric group that contains a cycle moving all but one
 point is doubly transitive. -/
@@ -54,22 +105,9 @@ theorem is_two_pretransitive_of_isCycle_mem_of_card_support_add_one_eq_card
     (G : Subgroup (Equiv.Perm α)) [IsPretransitive G α] {σ : Equiv.Perm α}
     (hσ : σ.IsCycle) (hσG : σ ∈ G)
     (hcard : σ.support.card + 1 = Fintype.card α) :
-    IsMultiplyPretransitive G α 2 := by
-  have hcomplCard : σ.supportᶜ.card = 1 := by
-    rw [Finset.card_compl]
-    omega
-  obtain ⟨x, hx⟩ := Finset.card_eq_one.mp hcomplCard
-  have hcompl : ((σ.support : Set α)ᶜ) = {x} := by
-    rw [← Finset.coe_compl, hx, Finset.coe_singleton]
-  have htrans :
-      IsPretransitive (fixingSubgroup G ({x} : Set α))
-        (SubMulAction.ofFixingSubgroup G ({x} : Set α)) := by
-    rw [← hcompl]
-    exact Equiv.Perm.isPretransitive_of_isCycle_mem hσ hσG
-  rw [SubMulAction.ofStabilizer.isMultiplyPretransitive (a := x)]
-  rw [is_one_pretransitive_iff]
-  exact IsPretransitive.of_surjective_map
-    SubMulAction.ofFixingSubgroup_of_singleton_bijective.surjective htrans
+    IsMultiplyPretransitive G α 2 :=
+  is_two_pretransitive_of_isCycle_mem_of_existsUnique_fixedPoint G hσ hσG
+    ((card_support_add_one_eq_card_iff_existsUnique_fixedPoint σ).mp hcard)
 
 /-- A transitive subgroup of a finite symmetric group that contains a cycle moving all but one
 point is primitive. -/
@@ -78,8 +116,7 @@ theorem isPreprimitive_of_isCycle_mem_of_card_support_add_one_eq_card
     (hσ : σ.IsCycle) (hσG : σ ∈ G)
     (hcard : σ.support.card + 1 = Fintype.card α) :
     IsPreprimitive G α :=
-  isPreprimitive_of_is_two_pretransitive
-    (is_two_pretransitive_of_isCycle_mem_of_card_support_add_one_eq_card
-      G hσ hσG hcard)
+  isPreprimitive_of_isCycle_mem_of_existsUnique_fixedPoint G hσ hσG
+    ((card_support_add_one_eq_card_iff_existsUnique_fixedPoint σ).mp hcard)
 
 end TauCeti

--- a/TauCeti/GroupTheory/Perm/MultipleTransitivity.lean
+++ b/TauCeti/GroupTheory/Perm/MultipleTransitivity.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.GroupAction.Jordan
+
+/-!
+# Long cycles and double transitivity
+
+A transitive permutation group containing a cycle on all but one point is doubly transitive. The
+missing point is the unique fixed point of the cycle. Its stabilizer contains the cycle and is
+therefore transitive on the complement; the usual point-stabilizer criterion then gives double
+transitivity of the original action.
+
+## Main results
+
+* `TauCeti.existsUnique_fixedPoint_of_card_support_add_one_eq`: a permutation moving all but
+  one point has a unique fixed point.
+* `TauCeti.isMultiplyPretransitive_two_of_isCycle_mem`: a transitive permutation group that
+  contains such a cycle is doubly transitive.
+
+The second result is one of the generic recognition theorems in Layer 1 of
+`TauCetiRoadmap/PolynomialGaloisGroups/README.md`. It is used there both in the classification of
+transitive groups of degree at most five and in the three-prime construction of polynomials with
+full symmetric Galois group.
+
+## References
+
+* J. D. Dixon and B. Mortimer, *Permutation Groups*, §2.1.
+* H. Wielandt, *Finite Permutation Groups*, Chapter II.
+-/
+
+public section
+
+namespace TauCeti
+
+open MulAction
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-- A permutation whose support has one fewer element than its finite domain has a unique fixed
+point. -/
+theorem existsUnique_fixedPoint_of_card_support_add_one_eq (σ : Equiv.Perm α)
+    (hcard : σ.support.card + 1 = Fintype.card α) :
+    ∃! x : α, σ x = x := by
+  have hcompl : σ.supportᶜ.card = 1 := by
+    rw [Finset.card_compl]
+    omega
+  obtain ⟨x, hx⟩ := Finset.card_eq_one.mp hcompl
+  refine ⟨x, ?_, fun y hy => ?_⟩
+  · change σ x = x
+    apply Equiv.Perm.notMem_support.mp
+    have : x ∈ σ.supportᶜ := by simp [hx]
+    simpa only [Finset.mem_compl] using this
+  · have hy' : y ∉ σ.support := by simpa only [Equiv.Perm.notMem_support] using hy
+    have hycompl : y ∈ σ.supportᶜ := Finset.mem_compl.mpr hy'
+    simpa [hx] using hycompl
+
+/-- A transitive subgroup of a finite symmetric group that contains a cycle moving all but one
+point is doubly transitive. -/
+theorem isMultiplyPretransitive_two_of_isCycle_mem
+    (G : Subgroup (Equiv.Perm α)) [IsPretransitive G α] {σ : Equiv.Perm α}
+    (hσ : σ.IsCycle) (hσG : σ ∈ G)
+    (hcard : σ.support.card + 1 = Fintype.card α) :
+    IsMultiplyPretransitive G α 2 := by
+  obtain ⟨x, hx, huniq⟩ :=
+    existsUnique_fixedPoint_of_card_support_add_one_eq σ hcard
+  have hcompl : ((σ.support : Set α)ᶜ) = {x} := by
+    ext y
+    simp only [Set.mem_compl_iff, Finset.mem_coe, Equiv.Perm.mem_support,
+      Set.mem_singleton_iff]
+    exact ⟨fun hy => huniq y (not_not.mp hy), fun hy hmove => hmove (hy ▸ hx)⟩
+  have htrans :
+      IsPretransitive (fixingSubgroup G ({x} : Set α))
+        (SubMulAction.ofFixingSubgroup G ({x} : Set α)) := by
+    rw [← hcompl]
+    exact Equiv.Perm.isPretransitive_of_isCycle_mem hσ hσG
+  rw [SubMulAction.ofStabilizer.isMultiplyPretransitive (a := x)]
+  rw [is_one_pretransitive_iff]
+  exact IsPretransitive.of_surjective_map
+    SubMulAction.ofFixingSubgroup_of_singleton_bijective.surjective htrans
+
+end TauCeti

--- a/TauCeti/GroupTheory/Perm/MultipleTransitivity.lean
+++ b/TauCeti/GroupTheory/Perm/MultipleTransitivity.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.GroupAction.Jordan
+public import TauCeti.GroupTheory.Perm.Basic
 
 /-!
 # Long cycles and double transitivity
@@ -46,14 +47,6 @@ namespace TauCeti
 open MulAction
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
-
-/-- A permutation moves all but one point exactly when it has a unique fixed point. -/
-theorem card_support_add_one_eq_card_iff_existsUnique_fixedPoint (σ : Equiv.Perm α) :
-    σ.support.card + 1 = Fintype.card α ↔ ∃! x : α, σ x = x := by
-  have hfixed : (∃! x : α, x ∈ σ.supportᶜ) ↔ ∃! x : α, σ x = x := by
-    simp only [Finset.mem_compl, Equiv.Perm.notMem_support]
-  rw [← hfixed, ← Finset.card_eq_one_iff_existsUnique, Finset.card_compl]
-  omega
 
 /-- A transitive subgroup of a finite symmetric group that contains a cycle moving all but one
 point is doubly transitive. -/

--- a/TauCeti/GroupTheory/Perm/MultipleTransitivity.lean
+++ b/TauCeti/GroupTheory/Perm/MultipleTransitivity.lean
@@ -19,7 +19,7 @@ transitivity of the original action.
 
 * `TauCeti.existsUnique_fixedPoint_of_card_support_add_one_eq`: a permutation moving all but
   one point has a unique fixed point.
-* `TauCeti.isMultiplyPretransitive_two_of_isCycle_mem`: a transitive permutation group that
+* `TauCeti.is_two_pretransitive_of_isCycle_mem`: a transitive permutation group that
   contains such a cycle is doubly transitive.
 
 The second result is one of the generic recognition theorems in Layer 1 of
@@ -51,8 +51,7 @@ theorem existsUnique_fixedPoint_of_card_support_add_one_eq (σ : Equiv.Perm α)
     omega
   obtain ⟨x, hx⟩ := Finset.card_eq_one.mp hcompl
   refine ⟨x, ?_, fun y hy => ?_⟩
-  · change σ x = x
-    apply Equiv.Perm.notMem_support.mp
+  · apply Equiv.Perm.notMem_support.mp
     have : x ∈ σ.supportᶜ := by simp [hx]
     simpa only [Finset.mem_compl] using this
   · have hy' : y ∉ σ.support := by simpa only [Equiv.Perm.notMem_support] using hy
@@ -61,7 +60,7 @@ theorem existsUnique_fixedPoint_of_card_support_add_one_eq (σ : Equiv.Perm α)
 
 /-- A transitive subgroup of a finite symmetric group that contains a cycle moving all but one
 point is doubly transitive. -/
-theorem isMultiplyPretransitive_two_of_isCycle_mem
+theorem is_two_pretransitive_of_isCycle_mem
     (G : Subgroup (Equiv.Perm α)) [IsPretransitive G α] {σ : Equiv.Perm α}
     (hσ : σ.IsCycle) (hσG : σ ∈ G)
     (hcard : σ.support.card + 1 = Fintype.card α) :

--- a/TauCeti/GroupTheory/Perm/MultipleTransitivity.lean
+++ b/TauCeti/GroupTheory/Perm/MultipleTransitivity.lean
@@ -17,10 +17,12 @@ transitivity of the original action.
 
 ## Main results
 
-* `TauCeti.existsUnique_fixedPoint_of_card_support_add_one_eq`: a permutation moving all but
-  one point has a unique fixed point.
-* `TauCeti.is_two_pretransitive_of_isCycle_mem`: a transitive permutation group that
-  contains such a cycle is doubly transitive.
+* `TauCeti.card_support_add_one_eq_card_iff_existsUnique_fixedPoint`: a permutation moves all but
+  one point exactly when it has a unique fixed point.
+* `TauCeti.is_two_pretransitive_of_isCycle_mem_of_card_support_add_one_eq_card`: a transitive
+  permutation group that contains such a cycle is doubly transitive.
+* `TauCeti.isPreprimitive_of_isCycle_mem_of_card_support_add_one_eq_card`: such a group is
+  primitive.
 
 The second result is one of the generic recognition theorems in Layer 1 of
 `TauCetiRoadmap/PolynomialGaloisGroups/README.md`. It is used there both in the classification of
@@ -31,6 +33,10 @@ full symmetric Galois group.
 
 * J. D. Dixon and B. Mortimer, *Permutation Groups*, §2.1.
 * H. Wielandt, *Finite Permutation Groups*, Chapter II.
+
+The point-stabilizer step is adapted from `Mathlib/GroupTheory/GroupAction/Jordan.lean`, by Antoine
+Chambert-Loir; transitivity on the support uses that file's
+`Equiv.Perm.isPretransitive_of_isCycle_mem`.
 -/
 
 public section
@@ -41,37 +47,27 @@ open MulAction
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
-/-- A permutation whose support has one fewer element than its finite domain has a unique fixed
-point. -/
-theorem existsUnique_fixedPoint_of_card_support_add_one_eq (σ : Equiv.Perm α)
-    (hcard : σ.support.card + 1 = Fintype.card α) :
-    ∃! x : α, σ x = x := by
-  have hcompl : σ.supportᶜ.card = 1 := by
-    rw [Finset.card_compl]
-    omega
-  obtain ⟨x, hx⟩ := Finset.card_eq_one.mp hcompl
-  refine ⟨x, ?_, fun y hy => ?_⟩
-  · apply Equiv.Perm.notMem_support.mp
-    have : x ∈ σ.supportᶜ := by simp [hx]
-    simpa only [Finset.mem_compl] using this
-  · have hy' : y ∉ σ.support := by simpa only [Equiv.Perm.notMem_support] using hy
-    have hycompl : y ∈ σ.supportᶜ := Finset.mem_compl.mpr hy'
-    simpa [hx] using hycompl
+/-- A permutation moves all but one point exactly when it has a unique fixed point. -/
+theorem card_support_add_one_eq_card_iff_existsUnique_fixedPoint (σ : Equiv.Perm α) :
+    σ.support.card + 1 = Fintype.card α ↔ ∃! x : α, σ x = x := by
+  have hfixed : (∃! x : α, x ∈ σ.supportᶜ) ↔ ∃! x : α, σ x = x := by
+    simp only [Finset.mem_compl, Equiv.Perm.notMem_support]
+  rw [← hfixed, ← Finset.card_eq_one_iff_existsUnique, Finset.card_compl]
+  omega
 
 /-- A transitive subgroup of a finite symmetric group that contains a cycle moving all but one
 point is doubly transitive. -/
-theorem is_two_pretransitive_of_isCycle_mem
+theorem is_two_pretransitive_of_isCycle_mem_of_card_support_add_one_eq_card
     (G : Subgroup (Equiv.Perm α)) [IsPretransitive G α] {σ : Equiv.Perm α}
     (hσ : σ.IsCycle) (hσG : σ ∈ G)
     (hcard : σ.support.card + 1 = Fintype.card α) :
     IsMultiplyPretransitive G α 2 := by
-  obtain ⟨x, hx, huniq⟩ :=
-    existsUnique_fixedPoint_of_card_support_add_one_eq σ hcard
+  have hcomplCard : σ.supportᶜ.card = 1 := by
+    rw [Finset.card_compl]
+    omega
+  obtain ⟨x, hx⟩ := Finset.card_eq_one.mp hcomplCard
   have hcompl : ((σ.support : Set α)ᶜ) = {x} := by
-    ext y
-    simp only [Set.mem_compl_iff, Finset.mem_coe, Equiv.Perm.mem_support,
-      Set.mem_singleton_iff]
-    exact ⟨fun hy => huniq y (not_not.mp hy), fun hy hmove => hmove (hy ▸ hx)⟩
+    rw [← Finset.coe_compl, hx, Finset.coe_singleton]
   have htrans :
       IsPretransitive (fixingSubgroup G ({x} : Set α))
         (SubMulAction.ofFixingSubgroup G ({x} : Set α)) := by
@@ -81,5 +77,16 @@ theorem is_two_pretransitive_of_isCycle_mem
   rw [is_one_pretransitive_iff]
   exact IsPretransitive.of_surjective_map
     SubMulAction.ofFixingSubgroup_of_singleton_bijective.surjective htrans
+
+/-- A transitive subgroup of a finite symmetric group that contains a cycle moving all but one
+point is primitive. -/
+theorem isPreprimitive_of_isCycle_mem_of_card_support_add_one_eq_card
+    (G : Subgroup (Equiv.Perm α)) [IsPretransitive G α] {σ : Equiv.Perm α}
+    (hσ : σ.IsCycle) (hσG : σ ∈ G)
+    (hcard : σ.support.card + 1 = Fintype.card α) :
+    IsPreprimitive G α :=
+  isPreprimitive_of_is_two_pretransitive
+    (is_two_pretransitive_of_isCycle_mem_of_card_support_add_one_eq_card
+      G hσ hσG hcard)
 
 end TauCeti


### PR DESCRIPTION
This PR proves that a transitive permutation group containing a cycle on all but one point is doubly transitive, and records that such a permutation has a unique fixed point.

The exact target is `TauCetiRoadmap/PolynomialGaloisGroups/README.md`, Layer 1, “The recognition theorems,” specifically: “A transitive group that contains an `(n−1)`-cycle is 2-transitive, and therefore primitive.” The designated milestone is the reusable recognition package feeding both the degree-at-most-five transitive-group classification and Layer 9’s three-prime realization of `Sₙ`. This is the most effective current step because it is independent of the in-flight prime-degree full-cycle theorem in #5276, and that PR explicitly identifies this criterion as the next remaining recognition result.

The preferred `CFSGStatement` roadmap has no viable distinct small step on current `main`: I0 and the sporadic presentation lane are complete, A0 is blocked on unfinished Lie carriers, and the currently buildable L0/Layer 9 carrier units for type `B`, type `C`, type `D`, `E₆`, `E₇`, and Suzuki are already in flight. The independent PolynomialGaloisGroups recognition target is therefore the strongest coherent fallback.

The proof first identifies the complement of the cycle support as a singleton. It then reuses Mathlib’s `Equiv.Perm.isPretransitive_of_isCycle_mem` for transitivity on the support, `SubMulAction.ofFixingSubgroup_of_singleton_bijective` to identify that action with the point-stabilizer action, and `SubMulAction.ofStabilizer.isMultiplyPretransitive` for the point-stabilizer criterion. No Mathlib infrastructure is vendored. The mathematical references are Dixon–Mortimer, *Permutation Groups*, §2.1, and Wielandt, *Finite Permutation Groups*, Chapter II, as recorded in the module documentation.

After this PR, Layer 1’s recognition package still needs the prime-degree transposition criterion, the odd-power-to-transposition criterion, and the block, wreath-product, imprimitivity, and Jordan `p`-cycle developments; the full-cycle-in-prime-degree result remains in flight in #5276.

Add `TauCeti/GroupTheory/Perm/MultipleTransitivity.lean` (86 lines).

Roadmap: PolynomialGaloisGroups

<!--tauceti-target:v1 {"focus":"PolynomialGaloisGroups","id":"transitive-n-minus-one-cycle-two-transitive"}-->

🤖 Prepared with Codex
