### PR TITLE
feat: the Weyl numerators are a basis of the alternating elements

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean
@@ -235,6 +235,7 @@ section Numerator
 variable [P.flip.IsReduced] [Fintype P.weylGroup]
 
 /-- **The numerator of a weight of the open dot chamber has coefficient `1` there.** -/
+@[simp]
 theorem coeff_weylNumerator_self_of_mem_openDotDominantChamber {lam : M}
     (hlam : lam ∈ openDotDominantChamber P b) : (weylNumerator P b lam).coeff lam = 1 := by
   have h := coeff_weylNumerator_dotAction_of_injective P b
@@ -243,6 +244,7 @@ theorem coeff_weylNumerator_self_of_mem_openDotDominantChamber {lam : M}
 
 /-- **The numerator of a weight of the open dot chamber vanishes at every other weight of that
 chamber**: the chamber meets each dot orbit at most once. -/
+@[simp]
 theorem coeff_weylNumerator_eq_zero_of_mem_openDotDominantChamber {lam nu : M}
     (hlam : lam ∈ openDotDominantChamber P b) (hnu : nu ∈ openDotDominantChamber P b)
     (hne : lam ≠ nu) : (weylNumerator P b lam).coeff nu = 0 :=

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean
@@ -1,0 +1,353 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.Weyl.Denominator.Reflection
+public import TauCeti.LinearAlgebra.RootSystem.Weyl.Numerator
+
+public section
+
+/-!
+# Alternating elements of the group algebra of a weight space
+
+An element `f` of the integral group algebra `ℤ[M]` of the weight space of a root pairing is
+**alternating** for the dot action when its coefficients transform by the sign character,
+
+`[e^{w ⬝ x}] f = sgn(w) · [e^x] f`.
+
+Both universal elements of the Weyl character formula are alternating: the Weyl denominator
+`Δ = ∏_{α>0}(1 - e^{-α})` (`TauCeti.coeff_weylDenominator_dotAction`) and the Weyl numerator
+`N(λ) = ∑_{w} sgn(w) e^{w ⬝ λ}` of any weight. This file proves that the numerators exhaust them:
+an alternating element is the sign-symmetrization of its coefficients on a fundamental domain, so
+that `ℤ[M]`'s alternating elements are freely spanned by the numerators. That is the step by which
+the Weyl character formula is concluded: the product `ch L(λ) · Δ` is alternating, being a product
+of a Weyl-invariant and an alternating element, and the formula is then the identification of which
+combination of numerators it is.
+
+The Weyl denominator identity `Δ = N(0)`
+(`TauCeti.weylDenominator_eq_weylNumerator_zero`) is that identification carried out for `Δ`
+itself, and is the case `λ = 0` of the character formula.
+
+## The fundamental domain
+
+The dot action `w ⬝ x = w(x + ρ) - ρ` has its walls at `⟨x, αᵢ^∨⟩ = -1`, so its open chamber is
+`TauCeti.openDotDominantChamber`, the weights whose `ρ`-shift is strictly dominant, which for a
+general coefficient ring is strictly larger than the closed dominant chamber. Two facts about it
+drive everything here. The dot action is **free** on it, so a numerator `N(μ)` with `μ` in the
+chamber has coefficient `1` at `μ` and `0` at every other point of the chamber. And every weight is
+carried into the closed shifted chamber by some Weyl-group element, whose boundary is a union of
+walls, where an alternating element vanishes because an odd element fixes the point. Together these
+say an alternating element is determined by its restriction to the open dot chamber
+(`TauCeti.IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq`), which is the mechanism behind
+every result below.
+
+## Main definitions
+
+* `TauCeti.IsDotAlternating`: the coefficients of `f` transform by the sign character under the dot
+  action. The predicate is not exposed; `TauCeti.isDotAlternating_iff` introduces it and
+  `TauCeti.IsDotAlternating.coeff_dotAction` eliminates it.
+
+## Main results
+
+* `TauCeti.isDotAlternating_weylNumerator` and `TauCeti.isDotAlternating_weylDenominator`: the Weyl
+  numerator of any weight, and the Weyl denominator, are alternating.
+* `TauCeti.IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq`: an alternating element is
+  determined by its coefficients on the open chamber of the dot action.
+* `TauCeti.IsDotAlternating.eq_sum_weylNumerator`: **an alternating element is the sum of the Weyl
+  numerators of the points of the open dot chamber in its support, weighted by its coefficients
+  there**, and `TauCeti.coeff_eq_zero_of_sum_smul_weylNumerator_eq_zero`: those weights are unique.
+  Together: the numerators of the open dot chamber are a basis of the alternating elements.
+* `TauCeti.IsDotAlternating.eq_weylNumerator`: **an alternating element whose only nonvanishing
+  coefficient on the open dot chamber is a `1` at `λ` is `N(λ)`**, the form in which the Weyl
+  character formula consumes all of this.
+
+## References
+
+This is the "concluding by Weyl alternation" step of the Weyl character formula route fixed by
+Layer 6 ("the Weyl character, dimension, and Kostant formulas") of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`. As with `TauCeti.weylNumerator`
+and `TauCeti.weylDenominator`, nothing here needs a Lie algebra, so it is stated for an abstract
+root pairing and the Lie-algebra statement is a specialization rather than a rebuild.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, Ch. VI, §24.2.
+* J.-P. Serre, *Complex Semisimple Lie Algebras*, Ch. VII, §7.
+-/
+
+namespace TauCeti
+
+universe u v w x
+
+variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  (P : _root_.RootPairing ι R M N) [Finite ι] [CharZero R] (b : P.Base)
+
+section Alternating
+
+variable [IsDomain R] [Invertible (2 : R)] [P.IsCrystallographic] [P.IsReduced]
+
+/-- An element of the integral group algebra of the weight space is **alternating** for the dot
+action when its coefficients transform by the sign character of the Weyl group,
+`[e^{w ⬝ x}] f = sgn(w) · [e^x] f`.
+
+The dot action `w ⬝ x = w(x + ρ) - ρ` is used rather than the linear one because that is the
+normalization in which the Weyl denominator `∏_{α>0}(1 - e^{-α})` is alternating: the linear action
+sends it to `sgn(w) e^{w(ρ) - ρ}` times itself. -/
+def IsDotAlternating (f : AddMonoidAlgebra ℤ M) : Prop :=
+  ∀ (w : P.weylGroup) (x : M),
+    f.coeff (dotAction P b w x) = ((weylSign P b w : ℤ)) * f.coeff x
+
+/-- The defining condition of `TauCeti.IsDotAlternating`, as an `Iff`: the predicate is not
+exposed, so this is how it is introduced outside this file, and
+`TauCeti.IsDotAlternating.coeff_dotAction` is how it is eliminated.
+
+Not a `simp` lemma: unfolding the predicate would dissolve `IsDotAlternating` out of the goals its
+own API is stated about. -/
+lemma isDotAlternating_iff (f : AddMonoidAlgebra ℤ M) :
+    IsDotAlternating P b f ↔ ∀ (w : P.weylGroup) (x : M),
+      f.coeff (dotAction P b w x) = ((weylSign P b w : ℤ)) * f.coeff x := Iff.rfl
+
+/-- The zero element is alternating. -/
+theorem isDotAlternating_zero : IsDotAlternating P b (0 : AddMonoidAlgebra ℤ M) := by
+  intro w x
+  simp
+
+/-- **The Weyl denominator is alternating.** This is
+`TauCeti.coeff_weylDenominator_dotAction`, packaged as the predicate. -/
+theorem isDotAlternating_weylDenominator : IsDotAlternating P b (weylDenominator P b) :=
+  coeff_weylDenominator_dotAction P b
+
+/-- **The Weyl numerator of any weight is alternating.** Reindexing the defining sum by `v ↦ w⁻¹v`
+matches the term at `w ⬝ x` with the term at `x`, at the cost of the sign of `w`. -/
+theorem isDotAlternating_weylNumerator [Fintype P.weylGroup] (lam : M) :
+    IsDotAlternating P b (weylNumerator P b lam) := by
+  intro w x
+  simp only [weylNumerator_def, AddMonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply,
+    AddMonoidAlgebra.coeff_single, Finset.mul_sum]
+  refine Fintype.sum_bijective (w⁻¹ * ·) (Group.mulLeft_bijective w⁻¹) _ _ fun v ↦ ?_
+  have hsign : weylSign P b w * weylSign P b (w⁻¹ * v) = weylSign P b v := by
+    rw [← map_mul, mul_inv_cancel_left]
+  have hdot : dotAction P b (w⁻¹ * v) lam = x ↔ dotAction P b v lam = dotAction P b w x := by
+    rw [dotAction_mul]
+    exact ⟨fun h ↦ by rw [← h, dotAction_dotAction_inv],
+      fun h ↦ by rw [h, dotAction_inv_dotAction]⟩
+  by_cases hv : dotAction P b v lam = dotAction P b w x
+  · rw [hv, Finsupp.single_eq_same, (hdot.mpr hv), Finsupp.single_eq_same, ← Units.val_mul, hsign]
+  · rw [Finsupp.single_eq_of_ne (Ne.symm hv),
+      Finsupp.single_eq_of_ne (Ne.symm fun h ↦ hv (hdot.mp h)), mul_zero]
+
+variable {P b} {f g : AddMonoidAlgebra ℤ M}
+
+namespace IsDotAlternating
+
+/-- The defining identity of an alternating element, as an elimination rule. -/
+theorem coeff_dotAction (hf : IsDotAlternating P b f) (w : P.weylGroup) (x : M) :
+    f.coeff (dotAction P b w x) = ((weylSign P b w : ℤ)) * f.coeff x := hf w x
+
+/-- A sum of alternating elements is alternating. -/
+theorem add (hf : IsDotAlternating P b f) (hg : IsDotAlternating P b g) :
+    IsDotAlternating P b (f + g) := by
+  intro w x
+  simp only [AddMonoidAlgebra.coeff_add, Finsupp.add_apply, hf w x, hg w x]
+  ring
+
+/-- The negative of an alternating element is alternating. -/
+theorem neg (hf : IsDotAlternating P b f) : IsDotAlternating P b (-f) := by
+  intro w x
+  simp only [AddMonoidAlgebra.coeff_neg, Finsupp.neg_apply, hf w x]
+  ring
+
+/-- A difference of alternating elements is alternating. -/
+theorem sub (hf : IsDotAlternating P b f) (hg : IsDotAlternating P b g) :
+    IsDotAlternating P b (f - g) := by
+  rw [sub_eq_add_neg]
+  exact hf.add hg.neg
+
+/-- An integer multiple of an alternating element is alternating. -/
+theorem zsmul (hf : IsDotAlternating P b f) (c : ℤ) : IsDotAlternating P b (c • f) := by
+  intro w x
+  simp only [AddMonoidAlgebra.coeff_smul_apply, smul_eq_mul, hf w x]
+  ring
+
+/-- **A coefficient of an alternating element at a weight fixed by an odd Weyl-group element
+vanishes**: the alternating identity turns such a fixed point into `c = -c`. -/
+theorem coeff_eq_zero_of_dotAction_eq_self (hf : IsDotAlternating P b f) {w : P.weylGroup} {x : M}
+    (hw : weylSign P b w = -1) (hx : dotAction P b w x = x) : f.coeff x = 0 := by
+  have h := hf w x
+  rw [hx, hw] at h
+  norm_num at h
+  omega
+
+/-- **A coefficient of an alternating element on a wall of the dot action vanishes.** The wall of
+the simple reflection `sᵢ` is the affine hyperplane `⟨x, αᵢ^∨⟩ = -1`, and a simple reflection is
+odd. -/
+theorem coeff_eq_zero_of_coroot'_eq_neg_one (hf : IsDotAlternating P b f) {i : ι}
+    (hi : i ∈ b.support) {x : M} (hx : P.coroot' i x = -1) : f.coeff x = 0 :=
+  hf.coeff_eq_zero_of_dotAction_eq_self (weylSign_ofIdx P b i)
+    ((dotAction_ofIdx_eq_self_iff P b hi x).mpr hx)
+
+end IsDotAlternating
+
+/-- A finite sum of alternating elements is alternating. -/
+theorem isDotAlternating_sum {α : Type*} {s : Finset α} {g : α → AddMonoidAlgebra ℤ M}
+    (hg : ∀ a ∈ s, IsDotAlternating P b (g a)) : IsDotAlternating P b (∑ a ∈ s, g a) :=
+  Finset.sum_induction g (IsDotAlternating P b) (fun _ _ ha hb ↦ ha.add hb)
+    (isDotAlternating_zero P b) hg
+
+end Alternating
+
+/-! ### The open chamber of the dot action as a fundamental domain
+
+Everything below reads an alternating element off its coefficients on
+`TauCeti.openDotDominantChamber`. The linearly ordered hypotheses already supply `IsDomain R`
+through `IsStrictOrderedRing.isDomain`, so it is not repeated.
+-/
+
+section Dominant
+
+variable [Invertible (2 : R)] [P.IsCrystallographic] [P.IsReduced]
+  [LinearOrder R] [IsStrictOrderedRing R]
+
+section Numerator
+
+variable [P.flip.IsReduced] [Fintype P.weylGroup]
+
+/-- **The numerator of a weight of the open dot chamber has coefficient `1` there.** -/
+theorem coeff_weylNumerator_self_of_mem_openDotDominantChamber {lam : M}
+    (hlam : lam ∈ openDotDominantChamber P b) : (weylNumerator P b lam).coeff lam = 1 := by
+  have h := coeff_weylNumerator_dotAction_of_injective P b
+    (injective_dotAction_of_mem_openDotDominantChamber P b hlam) 1
+  rwa [dotAction_one, map_one, Units.val_one] at h
+
+/-- **The numerator of a weight of the open dot chamber vanishes at every other weight of that
+chamber**: the chamber meets each dot orbit at most once. -/
+theorem coeff_weylNumerator_eq_zero_of_mem_openDotDominantChamber {lam nu : M}
+    (hlam : lam ∈ openDotDominantChamber P b) (hnu : nu ∈ openDotDominantChamber P b)
+    (hne : lam ≠ nu) : (weylNumerator P b lam).coeff nu = 0 :=
+  coeff_weylNumerator_eq_zero P b fun _ hw ↦
+    hne (eq_of_dotAction_eq_of_mem_openDotDominantChamber P b hlam hnu hw).symm
+
+end Numerator
+
+variable {P b} {f g : AddMonoidAlgebra ℤ M}
+
+section Determination
+
+variable [P.IsRootSystem]
+
+/-- **An alternating element vanishing on the open chamber of the dot action vanishes
+identically.**
+
+Every weight is carried by some Weyl-group element to one whose `ρ`-shift is dominant. If that
+shift is strictly dominant the hypothesis applies; otherwise the weight lies on a wall, where an
+alternating element vanishes. Either way the coefficient there vanishes, and it differs from the
+original coefficient by a sign. -/
+theorem IsDotAlternating.coeff_eq_zero_of_forall_mem_openDotDominantChamber
+    (hf : IsDotAlternating P b f) (h : ∀ y ∈ openDotDominantChamber P b, f.coeff y = 0) (x : M) :
+    f.coeff x = 0 := by
+  obtain ⟨w, hw⟩ := exists_mem_dominantChamber P b (x + weylVector P b)
+  have hyd : dotAction P b w x + weylVector P b ∈ dominantChamber P b := by
+    rw [dotAction_add_weylVector]
+    exact hw
+  have hzero : f.coeff (dotAction P b w x) = 0 := by
+    by_cases hopen : dotAction P b w x ∈ openDotDominantChamber P b
+    · exact h _ hopen
+    · rw [mem_openDotDominantChamber, mem_openDominantChamber] at hopen
+      push Not at hopen
+      obtain ⟨i, hi, hle⟩ := hopen
+      refine hf.coeff_eq_zero_of_coroot'_eq_neg_one hi ?_
+      have hwall := le_antisymm hle ((mem_dominantChamber P b _).mp hyd i hi)
+      rw [coroot'_add_weylVector P b hi] at hwall
+      linarith
+  have hcoeff := hf w x
+  rw [hzero] at hcoeff
+  exact (mul_eq_zero.mp hcoeff.symm).resolve_left
+    (by exact_mod_cast Units.ne_zero (weylSign P b w))
+
+/-- **An alternating element is determined by its coefficients on the open chamber of the dot
+action.** -/
+theorem IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq (hf : IsDotAlternating P b f)
+    (hg : IsDotAlternating P b g)
+    (h : ∀ x ∈ openDotDominantChamber P b, f.coeff x = g.coeff x) : f = g := by
+  rw [← sub_eq_zero, ← AddMonoidAlgebra.coeff_eq_zero]
+  refine Finsupp.ext fun x ↦ ?_
+  simpa using (hf.sub hg).coeff_eq_zero_of_forall_mem_openDotDominantChamber
+    (fun y hy ↦ by simp [AddMonoidAlgebra.coeff_sub, h y hy]) x
+
+end Determination
+
+section Basis
+
+variable [P.flip.IsReduced] [P.IsRootSystem] [Fintype P.weylGroup]
+
+/-- **An alternating element is the combination of the Weyl numerators of the weights of the open
+dot chamber in its support**, taken with its own coefficients there as multipliers.
+
+With `TauCeti.coeff_eq_zero_of_sum_smul_weylNumerator_eq_zero`, which says those coefficients are
+uniquely determined, this exhibits the numerators `N(μ)` for `μ` in the open dot chamber as a basis
+of the alternating elements of `ℤ[M]`. -/
+theorem IsDotAlternating.eq_sum_weylNumerator
+    [DecidablePred (· ∈ openDotDominantChamber P b)] (hf : IsDotAlternating P b f) :
+    f = ∑ mu ∈ f.coeff.support.filter (· ∈ openDotDominantChamber P b),
+      f.coeff mu • weylNumerator P b mu := by
+  refine hf.eq_of_coeff_openDotDominantChamber_eq
+    (isDotAlternating_sum fun mu _ ↦ (isDotAlternating_weylNumerator P b mu).zsmul _)
+    fun nu hnu ↦ ?_
+  rw [AddMonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
+  simp only [AddMonoidAlgebra.coeff_smul_apply, smul_eq_mul]
+  by_cases hmem : nu ∈ f.coeff.support.filter (· ∈ openDotDominantChamber P b)
+  · rw [Finset.sum_eq_single_of_mem nu hmem fun mu hmu hne ↦ by
+      rw [coeff_weylNumerator_eq_zero_of_mem_openDotDominantChamber P b
+        (Finset.mem_filter.mp hmu).2 hnu hne, mul_zero],
+      coeff_weylNumerator_self_of_mem_openDotDominantChamber P b hnu, mul_one]
+  · have hzero : f.coeff nu = 0 := by
+      by_contra hne
+      exact hmem (Finset.mem_filter.mpr ⟨Finsupp.mem_support_iff.mpr hne, hnu⟩)
+    rw [hzero]
+    refine (Finset.sum_eq_zero fun mu hmu ↦ ?_).symm
+    rw [coeff_weylNumerator_eq_zero_of_mem_openDotDominantChamber P b
+      (Finset.mem_filter.mp hmu).2 hnu fun hc ↦ hmem (hc ▸ hmu), mul_zero]
+
+omit [P.IsRootSystem] in
+/-- **The Weyl numerators of the weights of the open dot chamber are linearly independent over
+`ℤ`**: a vanishing combination has vanishing multipliers, since the coefficient of the combination
+at `ν` is exactly the multiplier of `N(ν)`. -/
+theorem coeff_eq_zero_of_sum_smul_weylNumerator_eq_zero {s : Finset M} {c : M → ℤ}
+    (hs : ∀ mu ∈ s, mu ∈ openDotDominantChamber P b)
+    (h : ∑ mu ∈ s, c mu • weylNumerator P b mu = 0) {nu : M} (hnu : nu ∈ s) : c nu = 0 := by
+  have h' := congrArg (fun u : AddMonoidAlgebra ℤ M ↦ u.coeff nu) h
+  simp only [AddMonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply,
+    AddMonoidAlgebra.coeff_smul_apply, smul_eq_mul, AddMonoidAlgebra.coeff_zero,
+    Finsupp.coe_zero, Pi.zero_apply] at h'
+  rwa [Finset.sum_eq_single_of_mem nu hnu fun mu hmu hne ↦ by
+      rw [coeff_weylNumerator_eq_zero_of_mem_openDotDominantChamber P b (hs mu hmu) (hs nu hnu)
+        hne, mul_zero],
+    coeff_weylNumerator_self_of_mem_openDotDominantChamber P b (hs nu hnu), mul_one] at h'
+
+/-- **An alternating element whose only nonvanishing coefficient on the open dot chamber is a `1`
+at `λ` is the Weyl numerator of `λ`.**
+
+This is the form in which the Weyl denominator identity
+(`TauCeti.weylDenominator_eq_weylNumerator_zero`) is proved, and the form the Weyl character
+formula is meant to be concluded in: for an alternating element the hypotheses are two coefficient
+computations on the open dot chamber, and nothing else about it is needed. -/
+theorem IsDotAlternating.eq_weylNumerator (hf : IsDotAlternating P b f) {lam : M}
+    (hlam : lam ∈ openDotDominantChamber P b) (hcoeff : f.coeff lam = 1)
+    (hsupp : ∀ x ∈ openDotDominantChamber P b, f.coeff x ≠ 0 → x = lam) :
+    f = weylNumerator P b lam := by
+  refine hf.eq_of_coeff_openDotDominantChamber_eq (isDotAlternating_weylNumerator P b lam)
+    fun nu hnu ↦ ?_
+  by_cases hne : nu = lam
+  · subst hne
+    rw [hcoeff, coeff_weylNumerator_self_of_mem_openDotDominantChamber P b hlam]
+  · rw [coeff_weylNumerator_eq_zero_of_mem_openDotDominantChamber P b hlam hnu (Ne.symm hne)]
+    by_contra hc
+    exact hne (hsupp nu hnu hc)
+
+end Basis
+
+end Dominant
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean
@@ -47,8 +47,9 @@ every result below.
 ## Main definitions
 
 * `TauCeti.IsDotAlternating`: the coefficients of `f` transform by the sign character under the dot
-  action. The predicate is not exposed; `TauCeti.isDotAlternating_iff` introduces it and
-  `TauCeti.IsDotAlternating.coeff_dotAction` eliminates it.
+  action. `TauCeti.isDotAlternating_iff` is the preferred way to introduce it and
+  `TauCeti.IsDotAlternating.coeff_dotAction` the preferred way to eliminate it, so that the
+  definition itself need not be unfolded.
 
 ## Main results
 
@@ -99,9 +100,9 @@ def IsDotAlternating (f : AddMonoidAlgebra ℤ M) : Prop :=
   ∀ (w : P.weylGroup) (x : M),
     f.coeff (dotAction P b w x) = ((weylSign P b w : ℤ)) * f.coeff x
 
-/-- The defining condition of `TauCeti.IsDotAlternating`, as an `Iff`: the predicate is not
-exposed, so this is how it is introduced outside this file, and
-`TauCeti.IsDotAlternating.coeff_dotAction` is how it is eliminated.
+/-- The defining condition of `TauCeti.IsDotAlternating`, as an `Iff`: this is the preferred way to
+introduce the predicate, and `TauCeti.IsDotAlternating.coeff_dotAction` the preferred way to
+eliminate it, so that callers need not unfold the definition.
 
 Not a `simp` lemma: unfolding the predicate would dissolve `IsDotAlternating` out of the goals its
 own API is stated about. -/

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.LinearAlgebra.Basis.Basic
 public import TauCeti.LinearAlgebra.RootSystem.Weyl.Denominator.Reflection
 public import TauCeti.LinearAlgebra.RootSystem.Weyl.Numerator
 
@@ -50,6 +51,9 @@ every result below.
   action. `TauCeti.isDotAlternating_iff` is the preferred way to introduce it and
   `TauCeti.IsDotAlternating.coeff_dotAction` the preferred way to eliminate it, so that the
   definition itself need not be unfolded.
+* `TauCeti.dotAlternatingSubmodule`: the alternating elements as a `ℤ`-submodule of `ℤ[M]`.
+* `TauCeti.weylNumeratorBasis`: its basis of Weyl numerators, indexed by the open dot chamber, whose
+  coordinates are read off by `TauCeti.weylNumeratorBasis_repr_apply`.
 
 ## Main results
 
@@ -60,7 +64,7 @@ every result below.
 * `TauCeti.IsDotAlternating.eq_sum_weylNumerator`: **an alternating element is the sum of the Weyl
   numerators of the points of the open dot chamber in its support, weighted by its coefficients
   there**, and `TauCeti.eq_zero_of_sum_smul_weylNumerator_eq_zero`: those weights are unique.
-  Together: the numerators of the open dot chamber are a basis of the alternating elements.
+  Together they are the spanning and independence halves of `TauCeti.weylNumeratorBasis`.
 * `TauCeti.IsDotAlternating.eq_weylNumerator`: **an alternating element whose only nonvanishing
   coefficient on the open dot chamber is a `1` at `λ` is `N(λ)`**, the form in which the Weyl
   character formula consumes all of this.
@@ -197,6 +201,21 @@ theorem isDotAlternating_sum {α : Type*} {s : Finset α} {g : α → AddMonoidA
   Finset.sum_induction g (IsDotAlternating P b) (fun _ _ ha hb ↦ ha.add hb)
     (isDotAlternating_zero P b) hg
 
+variable (P b) in
+/-- **The alternating elements of the integral group algebra `ℤ[M]`, as a `ℤ`-submodule.** The
+closure properties are `TauCeti.isDotAlternating_zero`, `TauCeti.IsDotAlternating.add` and
+`TauCeti.IsDotAlternating.zsmul`; `TauCeti.weylNumeratorBasis` is its basis of Weyl numerators. -/
+def dotAlternatingSubmodule : Submodule ℤ (AddMonoidAlgebra ℤ M) where
+  carrier := {f | IsDotAlternating P b f}
+  zero_mem' := isDotAlternating_zero P b
+  add_mem' hf hg := hf.add hg
+  smul_mem' c _ hf := hf.zsmul c
+
+/-- Membership in `TauCeti.dotAlternatingSubmodule` is being alternating. -/
+@[simp]
+lemma mem_dotAlternatingSubmodule :
+    f ∈ dotAlternatingSubmodule P b ↔ IsDotAlternating P b f := Iff.rfl
+
 end Alternating
 
 /-! ### The open chamber of the dot action as a fundamental domain
@@ -287,9 +306,10 @@ open scoped Classical in
 /-- **An alternating element is the combination of the Weyl numerators of the weights of the open
 dot chamber in its support**, taken with its own coefficients there as multipliers.
 
-With `TauCeti.eq_zero_of_sum_smul_weylNumerator_eq_zero`, which says those coefficients are
-uniquely determined, this exhibits the numerators `N(μ)` for `μ` in the open dot chamber as a basis
-of the alternating elements of `ℤ[M]`. -/
+This is the spanning half of `TauCeti.weylNumeratorBasis`; with
+`TauCeti.eq_zero_of_sum_smul_weylNumerator_eq_zero`, which says those coefficients are uniquely
+determined, it exhibits the numerators `N(μ)` for `μ` in the open dot chamber as a basis of the
+alternating elements of `ℤ[M]`. -/
 theorem IsDotAlternating.eq_sum_weylNumerator (hf : IsDotAlternating P b f) :
     f = ∑ mu ∈ f.coeff.support.filter (· ∈ openDotDominantChamber P b),
       f.coeff mu • weylNumerator P b mu := by
@@ -326,6 +346,75 @@ theorem eq_zero_of_sum_smul_weylNumerator_eq_zero {s : Finset M} {c : M → ℤ}
       rw [coeff_weylNumerator_eq_zero_of_mem_openDotDominantChamber P b (hs mu hmu) (hs nu hnu)
         hne, mul_zero],
     coeff_weylNumerator_self_of_mem_openDotDominantChamber P b (hs nu hnu), mul_one] at h'
+
+variable (P b) in
+/-- **The Weyl numerators of the weights of the open dot chamber, as a basis of the alternating
+elements of `ℤ[M]`.**
+
+The two halves are `TauCeti.IsDotAlternating.eq_sum_weylNumerator`, which spans, and
+`TauCeti.eq_zero_of_sum_smul_weylNumerator_eq_zero`, which is the independence; those are what
+`Module.Basis.mk` consumes here, and `TauCeti.weylNumeratorBasis_repr_apply` reads the resulting
+coordinates back as the coefficients of the element on the chamber. -/
+noncomputable def weylNumeratorBasis :
+    Module.Basis (openDotDominantChamber P b) ℤ (dotAlternatingSubmodule P b) :=
+  Module.Basis.mk (v := fun mu ↦ ⟨weylNumerator P b mu, isDotAlternating_weylNumerator P b mu⟩)
+    (by
+      classical
+      refine linearIndependent_iff'.mpr fun s g hg mu hmu ↦ ?_
+      -- extend the multipliers, indexed by the chamber, to a function on all of `M`
+      obtain ⟨c, hcval⟩ : ∃ c : M → ℤ, ∀ nu : openDotDominantChamber P b, c nu = g nu :=
+        ⟨fun x ↦ if h : x ∈ openDotDominantChamber P b then g ⟨x, h⟩ else 0, fun nu ↦ by simp⟩
+      have hsum : ∑ nu ∈ s.image ((↑) : openDotDominantChamber P b → M),
+          c nu • weylNumerator P b nu = 0 := by
+        rw [Finset.sum_image fun x _ y _ h ↦ Subtype.ext h]
+        simpa [hcval] using congrArg Subtype.val hg
+      have := eq_zero_of_sum_smul_weylNumerator_eq_zero
+        (fun nu hnu ↦ by obtain ⟨nu, -, rfl⟩ := Finset.mem_image.mp hnu; exact nu.2) hsum
+        (Finset.mem_image_of_mem _ hmu)
+      rwa [hcval] at this)
+    (by
+      classical
+      rintro ⟨f, hf⟩ -
+      have key : (⟨f, hf⟩ : dotAlternatingSubmodule P b) =
+          ∑ mu ∈ (f.coeff.support.filter (· ∈ openDotDominantChamber P b)).attach,
+            f.coeff (mu : M) •
+              (⟨weylNumerator P b mu, isDotAlternating_weylNumerator P b mu⟩ :
+                dotAlternatingSubmodule P b) := by
+        refine Subtype.ext ?_
+        rw [AddSubmonoidClass.coe_finsetSum]
+        simp only [SetLike.val_smul]
+        rw [Finset.sum_attach _ fun mu ↦ f.coeff mu • weylNumerator P b mu]
+        exact hf.eq_sum_weylNumerator
+      rw [key]
+      exact Submodule.sum_mem _ fun mu _ ↦ Submodule.smul_mem _ _
+        (Submodule.subset_span ⟨⟨(mu : M), (Finset.mem_filter.mp mu.2).2⟩, rfl⟩))
+
+variable (P b) in
+/-- The basis vector of `TauCeti.weylNumeratorBasis` at a weight of the open dot chamber is the
+Weyl numerator of that weight. -/
+@[simp]
+lemma coe_weylNumeratorBasis (mu : openDotDominantChamber P b) :
+    (weylNumeratorBasis P b mu : AddMonoidAlgebra ℤ M) = weylNumerator P b mu :=
+  congrArg Subtype.val (Module.Basis.mk_apply _ _ mu)
+
+variable (P b) in
+/-- **The coordinates of an alternating element in the basis of Weyl numerators are its
+coefficients on the open dot chamber.** -/
+@[simp]
+lemma weylNumeratorBasis_repr_apply (f : dotAlternatingSubmodule P b)
+    (mu : openDotDominantChamber P b) :
+    (weylNumeratorBasis P b).repr f mu = (f : AddMonoidAlgebra ℤ M).coeff mu := by
+  classical
+  refine (weylNumeratorBasis P b).repr_apply_eq
+    (fun f mu ↦ (f : AddMonoidAlgebra ℤ M).coeff mu) (fun _ _ ↦ funext fun _ ↦ by simp)
+    (fun _ _ ↦ funext fun _ ↦ by
+      simp only [SetLike.val_smul, AddMonoidAlgebra.coeff_smul_apply, Pi.smul_apply])
+    (fun mu ↦ funext fun nu ↦ ?_) f mu
+  rcases eq_or_ne nu mu with rfl | hne
+  · simp [coeff_weylNumerator_self_of_mem_openDotDominantChamber P b nu.2]
+  · rw [Finsupp.single_eq_of_ne hne]
+    simpa using coeff_weylNumerator_eq_zero_of_mem_openDotDominantChamber P b mu.2 nu.2
+      fun h ↦ hne (Subtype.ext h).symm
 
 /-- **An alternating element whose only nonvanishing coefficient on the open dot chamber is a `1`
 at `λ` is the Weyl numerator of `λ`.**

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean
@@ -35,7 +35,7 @@ itself, and is the case `λ = 0` of the character formula.
 
 The dot action `w ⬝ x = w(x + ρ) - ρ` has its walls at `⟨x, αᵢ^∨⟩ = -1`, so its open chamber is
 `TauCeti.openDotDominantChamber`, the weights whose `ρ`-shift is strictly dominant, which for a
-general coefficient ring is strictly larger than the closed dominant chamber. Two facts about it
+general coefficient ring may be strictly larger than the closed dominant chamber. Two facts about it
 drive everything here. The dot action is **free** on it, so a numerator `N(μ)` with `μ` in the
 chamber has coefficient `1` at `μ` and `0` at every other point of the chamber. And every weight is
 carried into the closed shifted chamber by some Weyl-group element, whose boundary is a union of
@@ -58,7 +58,7 @@ every result below.
   determined by its coefficients on the open chamber of the dot action.
 * `TauCeti.IsDotAlternating.eq_sum_weylNumerator`: **an alternating element is the sum of the Weyl
   numerators of the points of the open dot chamber in its support, weighted by its coefficients
-  there**, and `TauCeti.coeff_eq_zero_of_sum_smul_weylNumerator_eq_zero`: those weights are unique.
+  there**, and `TauCeti.eq_zero_of_sum_smul_weylNumerator_eq_zero`: those weights are unique.
   Together: the numerators of the open dot chamber are a basis of the alternating elements.
 * `TauCeti.IsDotAlternating.eq_weylNumerator`: **an alternating element whose only nonvanishing
   coefficient on the open dot chamber is a `1` at `λ` is `N(λ)`**, the form in which the Weyl
@@ -218,7 +218,7 @@ variable [P.flip.IsReduced] [Fintype P.weylGroup]
 theorem coeff_weylNumerator_self_of_mem_openDotDominantChamber {lam : M}
     (hlam : lam ∈ openDotDominantChamber P b) : (weylNumerator P b lam).coeff lam = 1 := by
   have h := coeff_weylNumerator_dotAction_of_injective P b
-    (injective_dotAction_of_mem_openDotDominantChamber P b hlam) 1
+    (dotAction_injective_of_mem_openDotDominantChamber P b hlam) 1
   rwa [dotAction_one, map_one, Units.val_one] at h
 
 /-- **The numerator of a weight of the open dot chamber vanishes at every other weight of that
@@ -282,14 +282,14 @@ section Basis
 
 variable [P.flip.IsReduced] [P.IsRootSystem] [Fintype P.weylGroup]
 
+open scoped Classical in
 /-- **An alternating element is the combination of the Weyl numerators of the weights of the open
 dot chamber in its support**, taken with its own coefficients there as multipliers.
 
-With `TauCeti.coeff_eq_zero_of_sum_smul_weylNumerator_eq_zero`, which says those coefficients are
+With `TauCeti.eq_zero_of_sum_smul_weylNumerator_eq_zero`, which says those coefficients are
 uniquely determined, this exhibits the numerators `N(μ)` for `μ` in the open dot chamber as a basis
 of the alternating elements of `ℤ[M]`. -/
-theorem IsDotAlternating.eq_sum_weylNumerator
-    [DecidablePred (· ∈ openDotDominantChamber P b)] (hf : IsDotAlternating P b f) :
+theorem IsDotAlternating.eq_sum_weylNumerator (hf : IsDotAlternating P b f) :
     f = ∑ mu ∈ f.coeff.support.filter (· ∈ openDotDominantChamber P b),
       f.coeff mu • weylNumerator P b mu := by
   refine hf.eq_of_coeff_openDotDominantChamber_eq
@@ -314,7 +314,7 @@ omit [P.IsRootSystem] in
 /-- **The Weyl numerators of the weights of the open dot chamber are linearly independent over
 `ℤ`**: a vanishing combination has vanishing multipliers, since the coefficient of the combination
 at `ν` is exactly the multiplier of `N(ν)`. -/
-theorem coeff_eq_zero_of_sum_smul_weylNumerator_eq_zero {s : Finset M} {c : M → ℤ}
+theorem eq_zero_of_sum_smul_weylNumerator_eq_zero {s : Finset M} {c : M → ℤ}
     (hs : ∀ mu ∈ s, mu ∈ openDotDominantChamber P b)
     (h : ∑ mu ∈ s, c mu • weylNumerator P b mu = 0) {nu : M} (hnu : nu ∈ s) : c nu = 0 := by
   have h' := congrArg (fun u : AddMonoidAlgebra ℤ M ↦ u.coeff nu) h

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Denominator/Identity.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Denominator/Identity.lean
@@ -6,8 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.RootSystem.DominantCone
-public import TauCeti.LinearAlgebra.RootSystem.Weyl.Denominator.Reflection
-public import TauCeti.LinearAlgebra.RootSystem.Weyl.Numerator
+public import TauCeti.LinearAlgebra.RootSystem.Weyl.Alternating
 
 public section
 
@@ -30,23 +29,17 @@ own, with no representation theory involved.
 
 ## The argument
 
-The two sides are compared coefficient by coefficient, and the dot orbit of `0` separates the two
-cases.
+`Δ` is alternating for the dot action (`TauCeti.isDotAlternating_weylDenominator`), so
+`TauCeti.IsDotAlternating.eq_weylNumerator` reduces the identity to two coefficient computations on
+the open chamber of the dot action: the constant term of `Δ` is `1`
+(`TauCeti.coeff_weylDenominator_zero`, since the empty set is the only set of positive roots
+summing to `0`), and `0` is the only weight of that chamber where `Δ` does not vanish.
 
-* **On the orbit.** The coefficient of `N(0)` at `w ⬝ 0` is `sgn(w)`, because the dot orbit of the
-  dominant weight `0` is free. The coefficient of `Δ` there is the same: `Δ` is alternating for the
-  dot action (`TauCeti.coeff_weylDenominator_dotAction`) and its constant term is `1`
-  (`TauCeti.coeff_weylDenominator_zero`: the empty set is the only set of positive roots summing
-  to `0`).
-* **Off the orbit.** `N(0)` vanishes there by its support statement, and so must `Δ`. Suppose not,
-  and move the weight by the dot action into the dominant region, which changes the coefficient
-  only by a sign; a coefficient of `Δ` on a dot-action wall vanishes
-  (`TauCeti.coeff_weylDenominator_eq_zero_of_coroot'_eq_neg_one`), so the `ρ`-shift of the moved
-  weight is *strictly* dominant. Now the geometric heart of the identity applies: an exponent of
-  `Δ` is `-ν` for a sum `ν` of positive roots, strict dominance of `ρ - ν` bounds every
-  `⟨ν, αᵢ^∨⟩` above by `1`, these pairings are integers, and the only antidominant member of the
-  positive root cone is `0` (`TauCeti.eq_zero_of_mem_posRootCone_of_forall_coroot'_nonpos`). So the
-  moved weight is `0`, which does lie on the orbit — a contradiction.
+The second computation is the geometric heart of the identity, and is the only step specific to the
+denominator. An exponent of `Δ` is `-ν` for a sum `ν` of positive roots; lying in the open dot
+chamber makes `ρ - ν` strictly dominant, which bounds every `⟨ν, αᵢ^∨⟩` above by `1`; these
+pairings are integers, hence nonpositive; and the only antidominant member of the positive root
+cone is `0` (`TauCeti.eq_zero_of_mem_posRootCone_of_forall_coroot'_nonpos`).
 
 ## Main results
 
@@ -93,7 +86,7 @@ section Cone
 variable [LinearOrder R] [IsStrictOrderedRing R] [Invertible (2 : R)] [P.IsCrystallographic]
   [P.IsReduced] [P.IsRootSystem]
 
-/-- The Weyl denominator vanishes at a weight whose `ρ`-shift is strictly dominant, unless that
+/-- The Weyl denominator vanishes at a weight of the open chamber of the dot action, unless that
 weight is `0`.
 
 An exponent of `Δ` is minus a sum `ν` of positive roots, so strict dominance of `ρ - ν` bounds
@@ -101,7 +94,7 @@ every `⟨ν, αᵢ^∨⟩` above by `1`; these pairings are integers, hence non
 antidominant member of the positive root cone is `0`. -/
 private theorem eq_zero_of_coeff_weylDenominator_ne_zero {y : M}
     (hy : (weylDenominator P b).coeff y ≠ 0)
-    (hdom : y + weylVector P b ∈ openDominantChamber P b) : y = 0 := by
+    (hdom : y ∈ openDotDominantChamber P b) : y = 0 := by
   obtain ⟨T, hT, hyT⟩ : ∃ T ⊆ posRootsFinset P b, y = -∑ i ∈ T, P.root i := by
     by_contra hcon
     push Not at hcon
@@ -113,8 +106,8 @@ private theorem eq_zero_of_coeff_weylDenominator_ne_zero {y : M}
     refine eq_zero_of_mem_posRootCone_of_forall_coroot'_nonpos b hcone fun i hi => ?_
     obtain ⟨m, hm⟩ := exists_intCast_eq_coroot'_of_mem_posRootCone P b hcone i
     have hlt : P.coroot' i (∑ j ∈ T, P.root j) < 1 := by
-      have h0 := (mem_openDominantChamber P b _).mp hdom i hi
-      rw [coroot'_add_weylVector P b hi, hyT, map_neg] at h0
+      have h0 := (mem_openDotDominantChamber_iff_neg_one_lt_coroot' P b y).mp hdom i hi
+      rw [hyT, map_neg] at h0
       linarith
     rw [hm] at hlt ⊢
     have hm1 : m < 1 := by exact_mod_cast hlt
@@ -139,35 +132,10 @@ right-hand side is `∑_{w ∈ W} sgn(w) e^{w(ρ) - ρ}`.
 This is the case `λ = 0` of the Weyl character formula, in which the character of the trivial
 module is `1`. -/
 theorem weylDenominator_eq_weylNumerator_zero :
-    weylDenominator P b = weylNumerator P b 0 := by
-  refine AddMonoidAlgebra.coeff_inj.mp (Finsupp.ext fun x => ?_)
-  by_cases hx : ∃ v : P.weylGroup, dotAction P b v 0 = x
-  · -- On the dot orbit of `0` both sides have the sign of the translating element.
-    obtain ⟨v, rfl⟩ := hx
-    rw [coeff_weylDenominator_dotAction, coeff_weylDenominator_zero, mul_one,
-      coeff_weylNumerator_dotAction P b (zero_mem_dominantChamber P b) v]
-  · -- Off the dot orbit of `0` the numerator vanishes; so must the denominator.
-    push Not at hx
-    rw [coeff_weylNumerator_eq_zero P b hx]
-    by_contra hne
-    obtain ⟨w, hw⟩ := exists_mem_dominantChamber P b (x + weylVector P b)
-    have hyd : dotAction P b w x + weylVector P b ∈ dominantChamber P b := by
-      rw [dotAction_add_weylVector]
-      exact hw
-    have hyne : (weylDenominator P b).coeff (dotAction P b w x) ≠ 0 := by
-      rw [coeff_weylDenominator_dotAction]
-      exact mul_ne_zero (by exact_mod_cast Units.ne_zero (weylSign P b w)) hne
-    -- A coefficient on a dot-action wall vanishes, so the `ρ`-shift is *strictly* dominant.
-    have hopen : dotAction P b w x + weylVector P b ∈ openDominantChamber P b := by
-      rw [mem_openDominantChamber]
-      intro i hi
-      rcases lt_or_eq_of_le ((mem_dominantChamber P b _).mp hyd i hi) with h | h
-      · exact h
-      · rw [coroot'_add_weylVector P b hi] at h
-        exact absurd (coeff_weylDenominator_eq_zero_of_coroot'_eq_neg_one P b hi
-          (by linarith)) hyne
-    exact hx w⁻¹ (by
-      rw [← eq_zero_of_coeff_weylDenominator_ne_zero P b hyne hopen, dotAction_inv_dotAction])
+    weylDenominator P b = weylNumerator P b 0 :=
+  (isDotAlternating_weylDenominator P b).eq_weylNumerator (zero_mem_openDotDominantChamber P b)
+    (coeff_weylDenominator_zero P b)
+    fun _ hx hne => eq_zero_of_coeff_weylDenominator_ne_zero P b hne hx
 
 /-- **The Weyl denominator is supported exactly on the dot orbit of `0`**, one term for each
 element of the Weyl group. -/

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Denominator/Reflection.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Denominator/Reflection.lean
@@ -25,8 +25,12 @@ Consequently its linear action on the integral group algebra sends
 `Δ` to `-e^{αᵢ} Δ`.
 
 The dot action includes the compensating translation by `-αᵢ`, so the coefficients of `Δ` at
-`x` and `sᵢ ⬝ x` are negatives of one another. In particular a coefficient on a dot-action wall
-vanishes.
+`x` and `sᵢ ⬝ x` are negatives of one another.
+
+The consequences of that transformation law — in particular the vanishing of a coefficient at a
+weight fixed by an odd Weyl-group element, so on a dot-action wall — are proved once for every
+alternating element in `TauCeti/LinearAlgebra/RootSystem/Weyl/Alternating.lean`, and reach `Δ`
+through `TauCeti.isDotAlternating_weylDenominator`.
 
 ## Main results
 
@@ -34,8 +38,6 @@ vanishes.
   `-e^{αᵢ} Δ`.
 * `TauCeti.coeff_weylDenominator_dotAction`: the coefficient function of `Δ` transforms by the
   sign character under the dot action of the whole Weyl group.
-* `TauCeti.coeff_weylDenominator_eq_zero_of_coroot'_eq_neg_one`: a coefficient on the dot-action
-  wall `⟨x, αᵢ^∨⟩ = -1` vanishes.
 
 ## References
 
@@ -173,22 +175,5 @@ theorem coeff_weylDenominator_dotAction (w : P.weylGroup) (x : M) :
         coeff_weylDenominator_dotAction_ofIdx P b i.2, ih, map_mul,
         weylSign_ofIdx P b]
       norm_num
-
-/-- A coefficient fixed by an odd Weyl-group element for the dot action vanishes. -/
-theorem coeff_weylDenominator_eq_zero_of_dotAction_eq_self {w : P.weylGroup} {x : M}
-    (hw : weylSign P b w = -1) (hx : dotAction P b w x = x) :
-    (weylDenominator P b).coeff x = 0 := by
-  have h := coeff_weylDenominator_dotAction P b w x
-  rw [hx, hw] at h
-  norm_num at h
-  omega
-
-/-- **A coefficient of the Weyl denominator on a dot-action wall vanishes.** The wall of the
-simple reflection `sᵢ` is the affine hyperplane `⟨x, αᵢ^∨⟩ = -1`. -/
-theorem coeff_weylDenominator_eq_zero_of_coroot'_eq_neg_one {i : ι}
-    (hi : i ∈ b.support) {x : M} (hx : P.coroot' i x = -1) :
-    (weylDenominator P b).coeff x = 0 :=
-  coeff_weylDenominator_eq_zero_of_dotAction_eq_self P b (weylSign_ofIdx P b i)
-    ((dotAction_ofIdx_eq_self_iff P b hi x).mpr hx)
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/DotAction.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/DotAction.lean
@@ -49,9 +49,9 @@ needs: distinct dominant weights lie in distinct dot orbits.
 * `TauCeti.dotAction_ofIdx_eq_self_iff`: the wall of `sᵢ` for the dot action is `⟨x, αᵢ^∨⟩ = -1`.
 * `TauCeti.eq_one_of_dotAction_eq_self_of_mem_openDotDominantChamber`,
   `TauCeti.eq_of_dotAction_eq_of_mem_openDotDominantChamber` and
-  `TauCeti.injective_dotAction_of_mem_openDotDominantChamber`: **the dot action is free on its own
-  open dominant chamber**, which for a general coefficient ring is strictly larger than the closed
-  dominant chamber.
+  `TauCeti.dotAction_injective_of_mem_openDotDominantChamber`: **the dot action is free on its own
+  open dominant chamber**, which for a general coefficient ring may be strictly larger than the
+  closed dominant chamber.
 * `TauCeti.eq_one_of_dotAction_mem_dominantChamber` and
   `TauCeti.eq_one_of_dotAction_eq_self_of_mem_dominantChamber`: **the dot action is free on the
   closed dominant chamber**, and no nontrivial element keeps a dominant weight dominant.
@@ -256,8 +256,9 @@ dominant, equivalently (`TauCeti.mem_openDotDominantChamber_iff_neg_one_lt_coroo
 This, and not `TauCeti.dominantChamber`, is the region the dot action is free on for a general
 coefficient ring: the walls of the dot action sit at `⟨x, αᵢ^∨⟩ = -1`
 (`TauCeti.dotAction_ofIdx_eq_self_iff`), so this is the open chamber the dot action cuts out. Every
-dominant weight lies in it (`TauCeti.dominantChamber_subset_openDotDominantChamber`), and for
-integral weights the two conditions agree, since `-1 < ⟨x, αᵢ^∨⟩` then forces `0 ≤ ⟨x, αᵢ^∨⟩`. -/
+dominant weight lies in it (`TauCeti.dominantChamber_subset_openDotDominantChamber`), and the
+containment may be strict; for integral weights the two conditions agree, since `-1 < ⟨x, αᵢ^∨⟩`
+then forces `0 ≤ ⟨x, αᵢ^∨⟩`. -/
 def openDotDominantChamber : Set M := {x | x + weylVector P b ∈ openDominantChamber P b}
 
 /-- Membership in the open dominant chamber of the dot action, as the strict dominance of the
@@ -330,7 +331,7 @@ theorem eq_of_dotAction_eq_of_mem_openDotDominantChamber {w : P.weylGroup} {x y 
 
 /-- **The dot orbit map of a weight in the open dot chamber is injective**: no two Weyl-group
 elements carry it to the same place. -/
-theorem injective_dotAction_of_mem_openDotDominantChamber {x : M}
+theorem dotAction_injective_of_mem_openDotDominantChamber {x : M}
     (hx : x ∈ openDotDominantChamber P b) :
     Function.Injective fun w : P.weylGroup ↦ dotAction P b w x := by
   intro v w (h : dotAction P b v x = dotAction P b w x)

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/DotAction.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/DotAction.lean
@@ -297,7 +297,7 @@ lemma mem_openDotDominantChamber_iff_neg_one_lt_coroot' (x : M) :
 of a dominant weight is strictly dominant. -/
 lemma dominantChamber_subset_openDotDominantChamber :
     dominantChamber P b ⊆ openDotDominantChamber P b :=
-  fun _ hx ↦ add_weylVector_mem_openDominantChamber P b hx
+  fun x hx ↦ (mem_openDotDominantChamber P b x).mpr (add_weylVector_mem_openDominantChamber P b hx)
 
 /-- The origin lies in the open dominant chamber of the dot action. -/
 lemma zero_mem_openDotDominantChamber : (0 : M) ∈ openDotDominantChamber P b :=
@@ -315,7 +315,8 @@ freeness on the closed dominant chamber below is its special case, since a domin
 strictly dominant `ρ`-shift. -/
 theorem eq_one_of_dotAction_eq_self_of_mem_openDotDominantChamber (w : P.weylGroup) {x : M}
     (hx : x ∈ openDotDominantChamber P b) (hw : dotAction P b w x = x) : w = 1 :=
-  eq_one_of_smul_eq_self_of_mem_openDominantChamber P b w hx ((dotAction_eq_self_iff P b).mp hw)
+  eq_one_of_smul_eq_self_of_mem_openDominantChamber P b w ((mem_openDotDominantChamber P b x).mp hx)
+    ((dotAction_eq_self_iff P b).mp hw)
 
 /-- **A weight in the open chamber of the dot action is the only such weight in its dot orbit.**
 This is the separation statement the alternating elements of the group algebra consume: distinct
@@ -324,9 +325,9 @@ theorem eq_of_dotAction_eq_of_mem_openDotDominantChamber {w : P.weylGroup} {x y 
     (hx : x ∈ openDotDominantChamber P b) (hy : y ∈ openDotDominantChamber P b)
     (h : dotAction P b w x = y) : y = x := by
   have hone : w = 1 :=
-    eq_one_of_smul_mem_dominantChamber P b w hx
+    eq_one_of_smul_mem_dominantChamber P b w ((mem_openDotDominantChamber P b x).mp hx)
       (openDominantChamber_subset_dominantChamber P b
-        (by rw [← dotAction_add_weylVector, h]; exact hy))
+        (by rw [← dotAction_add_weylVector, h]; exact (mem_openDotDominantChamber P b y).mp hy))
   rw [← h, hone, dotAction_one]
 
 /-- **The dot orbit map of a weight in the open dot chamber is injective**: no two Weyl-group

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/DotAction.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/DotAction.lean
@@ -37,6 +37,8 @@ needs: distinct dominant weights lie in distinct dot orbits.
 * `TauCeti.dotActionPerm`: the same, packaged as a group homomorphism into `Equiv.Perm M`. The dot
   action is not registered as a `MulAction` instance, since the weight space already carries the
   linear action of the Weyl group.
+* `TauCeti.openDotDominantChamber`: the open dominant chamber of the dot action, the weights whose
+  `ρ`-shift is strictly dominant, equivalently those with `-1 < ⟨x, αᵢ^∨⟩` for every simple root.
 
 ## Main results
 
@@ -45,6 +47,11 @@ needs: distinct dominant weights lie in distinct dot orbits.
 * `TauCeti.dotAction_ofIdx`: a simple reflection acts by `sᵢ ⬝ x = x - (⟨x, αᵢ^∨⟩ + 1) αᵢ`, and
   `TauCeti.coroot'_dotAction_ofIdx`: it sends the pairing `⟨x, αᵢ^∨⟩` to `-⟨x, αᵢ^∨⟩ - 2`.
 * `TauCeti.dotAction_ofIdx_eq_self_iff`: the wall of `sᵢ` for the dot action is `⟨x, αᵢ^∨⟩ = -1`.
+* `TauCeti.eq_one_of_dotAction_eq_self_of_mem_openDotDominantChamber`,
+  `TauCeti.eq_of_dotAction_eq_of_mem_openDotDominantChamber` and
+  `TauCeti.injective_dotAction_of_mem_openDotDominantChamber`: **the dot action is free on its own
+  open dominant chamber**, which for a general coefficient ring is strictly larger than the closed
+  dominant chamber.
 * `TauCeti.eq_one_of_dotAction_mem_dominantChamber` and
   `TauCeti.eq_one_of_dotAction_eq_self_of_mem_dominantChamber`: **the dot action is free on the
   closed dominant chamber**, and no nontrivial element keeps a dominant weight dominant.
@@ -236,7 +243,32 @@ theorem dotAction_ofIdx_eq_self_iff {i : ι} (hi : i ∈ b.support) (x : M) :
 
 end Reduced
 
-/-! ### Freeness on the dominant chamber -/
+/-! ### The open dominant chamber of the dot action -/
+
+section DotChamber
+
+variable [LinearOrder R]
+
+/-- The **open dominant chamber of the dot action**: the weights whose `ρ`-shift is strictly
+dominant, equivalently (`TauCeti.mem_openDotDominantChamber_iff_neg_one_lt_coroot'`) those with
+`-1 < ⟨x, αᵢ^∨⟩` for every simple root `αᵢ`.
+
+This, and not `TauCeti.dominantChamber`, is the region the dot action is free on for a general
+coefficient ring: the walls of the dot action sit at `⟨x, αᵢ^∨⟩ = -1`
+(`TauCeti.dotAction_ofIdx_eq_self_iff`), so this is the open chamber the dot action cuts out. Every
+dominant weight lies in it (`TauCeti.dominantChamber_subset_openDotDominantChamber`), and for
+integral weights the two conditions agree, since `-1 < ⟨x, αᵢ^∨⟩` then forces `0 ≤ ⟨x, αᵢ^∨⟩`. -/
+def openDotDominantChamber : Set M := {x | x + weylVector P b ∈ openDominantChamber P b}
+
+/-- Membership in the open dominant chamber of the dot action, as the strict dominance of the
+`ρ`-shift. -/
+@[simp]
+lemma mem_openDotDominantChamber (x : M) :
+    x ∈ openDotDominantChamber P b ↔ x + weylVector P b ∈ openDominantChamber P b := Iff.rfl
+
+end DotChamber
+
+/-! ### Freeness on the chambers -/
 
 section Ordered
 
@@ -251,7 +283,64 @@ theorem smul_add_weylVector_mem_dominantChamber {w : P.weylGroup} {x : M}
   exact add_mem_dominantChamber P b hw
     (openDominantChamber_subset_dominantChamber P b (weylVector_mem_openDominantChamber P b))
 
+/-- **The open dominant chamber of the dot action is cut out by `-1 < ⟨x, αᵢ^∨⟩`**, the walls of
+the simple reflections for the dot action (`TauCeti.dotAction_ofIdx_eq_self_iff`). -/
+lemma mem_openDotDominantChamber_iff_neg_one_lt_coroot' (x : M) :
+    x ∈ openDotDominantChamber P b ↔ ∀ i ∈ b.support, -1 < P.coroot' i x := by
+  rw [mem_openDotDominantChamber, mem_openDominantChamber]
+  refine forall₂_congr fun i hi ↦ ?_
+  rw [coroot'_add_weylVector P b hi]
+  constructor <;> intro h <;> linarith
+
+/-- **A dominant weight lies in the open dominant chamber of the dot action**, since the `ρ`-shift
+of a dominant weight is strictly dominant. -/
+lemma dominantChamber_subset_openDotDominantChamber :
+    dominantChamber P b ⊆ openDotDominantChamber P b :=
+  fun _ hx ↦ add_weylVector_mem_openDominantChamber P b hx
+
+/-- The origin lies in the open dominant chamber of the dot action. -/
+lemma zero_mem_openDotDominantChamber : (0 : M) ∈ openDotDominantChamber P b :=
+  dominantChamber_subset_openDotDominantChamber P b (zero_mem_dominantChamber P b)
+
 variable [P.flip.IsReduced]
+
+/-! ### Freeness on the open chamber of the dot action -/
+
+/-- **The dot action is free on its own open dominant chamber**: a Weyl-group element fixing a
+weight with strictly dominant `ρ`-shift is the identity.
+
+This is the linear freeness on the open dominant chamber, transported along the `ρ`-shift; the
+freeness on the closed dominant chamber below is its special case, since a dominant weight has a
+strictly dominant `ρ`-shift. -/
+theorem eq_one_of_dotAction_eq_self_of_mem_openDotDominantChamber (w : P.weylGroup) {x : M}
+    (hx : x ∈ openDotDominantChamber P b) (hw : dotAction P b w x = x) : w = 1 :=
+  eq_one_of_smul_eq_self_of_mem_openDominantChamber P b w hx ((dotAction_eq_self_iff P b).mp hw)
+
+/-- **A weight in the open chamber of the dot action is the only such weight in its dot orbit.**
+This is the separation statement the alternating elements of the group algebra consume: distinct
+weights of the open dot chamber lie in distinct dot orbits. -/
+theorem eq_of_dotAction_eq_of_mem_openDotDominantChamber {w : P.weylGroup} {x y : M}
+    (hx : x ∈ openDotDominantChamber P b) (hy : y ∈ openDotDominantChamber P b)
+    (h : dotAction P b w x = y) : y = x := by
+  have hone : w = 1 :=
+    eq_one_of_smul_mem_dominantChamber P b w hx
+      (openDominantChamber_subset_dominantChamber P b
+        (by rw [← dotAction_add_weylVector, h]; exact hy))
+  rw [← h, hone, dotAction_one]
+
+/-- **The dot orbit map of a weight in the open dot chamber is injective**: no two Weyl-group
+elements carry it to the same place. -/
+theorem injective_dotAction_of_mem_openDotDominantChamber {x : M}
+    (hx : x ∈ openDotDominantChamber P b) :
+    Function.Injective fun w : P.weylGroup ↦ dotAction P b w x := by
+  intro v w (h : dotAction P b v x = dotAction P b w x)
+  have key : dotAction P b (w⁻¹ * v) x = x := by
+    rw [dotAction_mul, h, dotAction_inv_dotAction]
+  have := eq_one_of_dotAction_eq_self_of_mem_openDotDominantChamber P b (w⁻¹ * v) hx key
+  rw [inv_mul_eq_one] at this
+  exact this.symm
+
+/-! ### Freeness on the closed dominant chamber -/
 
 /-- **A Weyl-group element carrying a dominant weight to a dominant weight for the dot action is
 the identity.** Unlike the linear action, where a weight on a wall of the chamber is fixed by the
@@ -266,7 +355,8 @@ theorem eq_one_of_dotAction_mem_dominantChamber (w : P.weylGroup) {x : M}
 dominant weight for the dot action is the identity. -/
 theorem eq_one_of_dotAction_eq_self_of_mem_dominantChamber (w : P.weylGroup) {x : M}
     (hx : x ∈ dominantChamber P b) (hw : dotAction P b w x = x) : w = 1 :=
-  eq_one_of_dotAction_mem_dominantChamber P b w hx (by rw [hw]; exact hx)
+  eq_one_of_dotAction_eq_self_of_mem_openDotDominantChamber P b w
+    (dominantChamber_subset_openDotDominantChamber P b hx) hw
 
 /-- A Weyl-group element carrying a dominant weight to a dominant weight for the dot action fixes
 it. -/


### PR DESCRIPTION
This PR adds `TauCeti.IsDotAlternating`, the condition that the coefficients of an element of the integral group algebra `ℤ[M]` of a weight space transform by the sign character of the Weyl group under the dot action, and proves that the Weyl numerators are a basis of the alternating elements: an alternating element is the combination of the numerators `N(μ)` of the weights `μ` of the open dot chamber in its support, taken with its own coefficients there, and those coefficients are uniquely determined. The basis is bundled: `TauCeti.dotAlternatingSubmodule` is the submodule of alternating elements and `TauCeti.weylNumeratorBasis` is its `Module.Basis` indexed by the open dot chamber, whose coordinates are the coefficients of the element there (`TauCeti.weylNumeratorBasis_repr_apply`). It also records the specialised form the character formula is concluded in, `IsDotAlternating.eq_weylNumerator`: an alternating element whose only nonvanishing coefficient on the open dot chamber is a `1` at `λ` is `N(λ)`.

The region carrying all of this is the open chamber of the dot action, added as `TauCeti.openDotDominantChamber` beside `TauCeti.dotAction`: the weights whose `ρ`-shift is strictly dominant, equivalently those with `-1 < ⟨x, αᵢ^∨⟩` for every simple root, since the walls of the dot action sit at `-1` rather than at `0`. For a general coefficient ring this may be strictly larger than the closed dominant chamber, which is why the fundamental-domain statements are made about it; the existing freeness on the closed dominant chamber is now derived from the new freeness on the open dot chamber, through `dominantChamber_subset_openDotDominantChamber`.

The general theorem subsumes the ad hoc alternation argument in `Weyl/Denominator/Identity.lean`, so `weylDenominator_eq_weylNumerator_zero` is reproved from it in three lines, leaving only the genuinely denominator-specific step (an exponent of `Δ` lying in the open dot chamber is `0`). No statement there changes.

This serves the Weyl character formula of Layer 6 ("the Weyl character, dimension, and Kostant formulas") of `RepresentationTheory/LieHighestWeight/README.md`, whose route the README fixes as "the highest-weight/Verma route, defining Verma characters, proving the Weyl denominator identity combinatorially, and concluding by Weyl alternation": the denominator identity landed in https://github.com/TauCetiProject/TauCeti/pull/5277, and this is the alternation step it is concluded by. What remains for that milestone is the Verma side, namely the character of `M(λ)` against the Kostant partition function and the multiplicity argument that makes `ch L(λ) · Δ` satisfy the hypotheses of `IsDotAlternating.eq_weylNumerator` at `λ`.

Roadmap: RepresentationTheory

Written against J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, Ch. VI, §24.2, and J.-P. Serre, *Complex Semisimple Lie Algebras*, Ch. VII, §7. Nothing is vendored; Mathlib has no group-algebra material under `LinearAlgebra/RootSystem`.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"isdotalternating-eq-sum-weylnumerator"}-->

🤖 Prepared with Claude Code


