### PR TITLE
feat: characterize and audit the He, HS and McL presentation rows

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
@@ -35,15 +35,39 @@ ATLAS 2058-point standard generators; those generators yield a simple group of o
 `4030387200`. This computation is provenance for the transcription, not a Lean theorem. This file
 asserts no order, finiteness, simplicity, or identification result.
 
-## Main definition
+The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
+relator expressions with their generator indices written out, and the provenance a manifest row
+exists to record. Together with `TauCeti.GroupPresentation.relators_def` and
+`TauCeti.GroupPresentation.mem_relatorSet_iff` the first of those determines the compiled words and
+the relations defining the presented group, so a consumer reasons about the row without unfolding
+it.
+
+Three decidable checks accompany those equations. The relator lengths and their total record the
+compiled data one word at a time and in aggregate, and cyclic reducedness is what makes such a
+letter count comparable with a published presentation length, since both are measured after free
+and cyclic reduction of each relator. This row has no published length to check against: Bray's
+presentation page for `He` is one of the 1997 stubs that record `Length ??`, and the ATLAS page and
+its Magma source file give no figure either. The total below therefore states the transcribed data
+for a reviewer to compare with the source, rather than checking it against a recorded number.
+
+## Main definitions and results
 
 * `TauCeti.Sporadic.hePresentation`: John Bray's ATLAS finite presentation of `He`.
+* `TauCeti.Sporadic.hePresentation_transcribed` and the equations for the remaining fields: the
+  characterization of the sealed row.
+* `TauCeti.Sporadic.hePresentation_map_length_relators`,
+  `TauCeti.Sporadic.hePresentation_totalLength` and
+  `TauCeti.Sporadic.hePresentation_relatorsCyclicallyReduced`: the three checks on the compiled
+  words.
 
 ## References
 
 * R. A. Wilson, R. A. Parker, J. N. Bray et al., *ATLAS of Finite Group Representations*,
   version 3, presentation `HeG1-P1`, contributed by John Bray,
   <https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/HeG1-P1>.
+* J. N. Bray, presentation page for the Held group,
+  <https://webspace.maths.qmul.ac.uk/j.n.bray/web/Pres/He.html>, which records `Length ??` and so
+  publishes no letter count for this presentation.
 -/
 
 public section
@@ -97,7 +121,121 @@ def hePresentation : GroupPresentation where
       .comm (.inv a) (.inv commutatorWord),
       finalWord ]
 
+/-- The generator names recorded for `He`. The row's body is sealed, so this is what lets a
+consumer see that it is a two-generator presentation. -/
+@[simp]
+theorem hePresentation_generatorNames : hePresentation.generatorNames = ["a", "b"] := by
+  simp [hePresentation]
+
+/-- The source recorded for `He`. The row's body is sealed, so this equation publishes the citation
+itself, rather than only the row's name, to a downstream audit. -/
+@[simp]
+theorem hePresentation_source :
+    hePresentation.source = "R. A. Wilson, R. A. Parker, J. N. Bray et al., ATLAS of Finite Group \
+      Representations, version 3; presentation contributed by John Bray" := by
+  simp [hePresentation]
+
+/-- The locator recorded for `He`, pointing at the presentation inside its source. -/
+@[simp]
+theorem hePresentation_sourceLocator :
+    hePresentation.sourceLocator =
+      "HeG1-P1, https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/HeG1-P1" := by
+  simp [hePresentation]
+
+/-- The generator convention recorded for `He`, fixing which generator each relator index names and
+which commutator convention the source uses. -/
+@[simp]
+theorem hePresentation_generatorConvention :
+    hePresentation.generatorConvention = "The ATLAS standard generators a and b, in that order, \
+      so index 0 is a and index 1 is b. Products are read left to right, negative exponents denote \
+      inverses, and [r,s] denotes r^-1 s^-1 r s." := by
+  simp [hePresentation]
+
+/-- The transcription notes recorded for `He`. -/
+@[simp]
+theorem hePresentation_transcriptionNotes :
+    hePresentation.transcriptionNotes = "The seven displayed words are stored as seven relators \
+      equal to the identity. ATLAS distinguishes HeG1-P1 from its semi-presentation. GAP 4.15.1 \
+      with AtlasRep 2.1.9 checks these relators on the independent ATLAS 2058-point generators, \
+      which generate a simple group of order 4030387200." := by
+  simp [hePresentation]
+
+/-- The generator count `He`'s source states. With
+`TauCeti.Sporadic.hePresentation_generatorNames` this makes
+`TauCeti.Sporadic.hePresentation_matchesMetadata` an equation between two visible numbers. -/
+@[simp]
+theorem hePresentation_expectedGeneratorCount : hePresentation.expectedGeneratorCount = 2 := by
+  simp [hePresentation]
+
+/-- The relator count `He`'s source states; see
+`TauCeti.Sporadic.hePresentation_expectedGeneratorCount`. -/
+@[simp]
+theorem hePresentation_expectedRelatorCount : hePresentation.expectedRelatorCount = 7 := by
+  simp [hePresentation]
+
+/-- The relator expressions transcribed for `He`, with their generator indices written out and the
+private abbreviations of this file expanded.
+
+The row's body is sealed, so this is the equation that characterizes it: with
+`TauCeti.GroupPresentation.relators_def` it determines the compiled words, and with
+`TauCeti.GroupPresentation.mem_relatorSet_iff` it determines the relations defining
+`TauCeti.GroupPresentation.Group`, so a consumer never has to unfold the row. Index `0` is the
+generator `a` and index `1` is `b`, and the bounds come from
+`TauCeti.Sporadic.hePresentation_generatorNames`. -/
+@[simp]
+theorem hePresentation_transcribed :
+    hePresentation.transcribed =
+      [ -- a²
+        .pow (.gen ⟨0, by simp⟩) 2,
+        -- b⁷
+        .pow (.gen ⟨1, by simp⟩) 7,
+        -- (ab)¹⁷
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 17,
+        -- [a,b]⁶, in the source's commutator convention
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩)) (.inv (.gen ⟨1, by simp⟩))) 6,
+        -- [a,b³]⁵
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩)) (.inv (.pow (.gen ⟨1, by simp⟩) 3))) 5,
+        -- [a, babab⁻¹abab]
+        .comm (.inv (.gen ⟨0, by simp⟩))
+          (.inv (.gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝
+            .inv (.gen ⟨1, by simp⟩) ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝
+            .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩)),
+        -- (ab)⁴ab²ab⁻³ababab⁻¹ab³ab⁻²ab²
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 4 ⬝ .gen ⟨0, by simp⟩ ⬝
+          .pow (.gen ⟨1, by simp⟩) 2 ⬝ .gen ⟨0, by simp⟩ ⬝
+          .pow (.inv (.gen ⟨1, by simp⟩)) 3 ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝
+          .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩) ⬝
+          .gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 3 ⬝ .gen ⟨0, by simp⟩ ⬝
+          .pow (.inv (.gen ⟨1, by simp⟩)) 2 ⬝ .gen ⟨0, by simp⟩ ⬝
+          .pow (.gen ⟨1, by simp⟩) 2 ] := by
+  simp [hePresentation]
+
 /-- The generator and relator counts recorded for `He` agree with the transcribed data. -/
 theorem hePresentation_matchesMetadata : hePresentation.matchesMetadata := by decide
+
+/-- The lengths of the seven compiled relator words for `He`, in the order of the source.
+
+Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
+than only observe one in the total of `TauCeti.Sporadic.hePresentation_totalLength`. -/
+theorem hePresentation_map_length_relators :
+    hePresentation.relators.map List.length = [2, 7, 34, 24, 40, 20, 31] := by
+  simp [GroupPresentation.relators_def, hePresentation]
+
+/-- The compiled relator words for `He` have `158` letters in total. The source records no
+presentation length, so this figure states the transcribed data for a reviewer to compare with the
+source, rather than checking it against a recorded number. -/
+theorem hePresentation_totalLength : hePresentation.totalLength = 158 := by
+  rw [GroupPresentation.totalLength_def, hePresentation_map_length_relators]
+  decide
+
+/-- Every compiled relator word for `He` is cyclically reduced. This is what makes the letter count
+of `TauCeti.Sporadic.hePresentation_totalLength` comparable with a published presentation length,
+which is measured after free and cyclic reduction of each relator. -/
+theorem hePresentation_relatorsCyclicallyReduced :
+    hePresentation.relatorsCyclicallyReduced := by
+  simp only [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def,
+    hePresentation, List.map_cons, List.map_nil, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_inv, Relator.toWord_comm, Relator.toWord_gen]
+  decide
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HigmanSims.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HigmanSims.lean
@@ -48,9 +48,30 @@ centralizer has order `7680`, `b` of order 5 with centralizer of order `500`, an
 `11`. Both computations are provenance for the transcription, not Lean theorems: this file asserts
 no order, finiteness, simplicity, or identification result.
 
-## Main definition
+The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
+relator expressions with their generator indices written out, and the provenance a manifest row
+exists to record. Together with `TauCeti.GroupPresentation.relators_def` and
+`TauCeti.GroupPresentation.mem_relatorSet_iff` the first of those determines the compiled words and
+the relations defining the presented group, so a consumer reasons about the row without unfolding
+it.
+
+Three decidable checks accompany those equations. The relator lengths and their total record the
+compiled data one word at a time and in aggregate, and cyclic reducedness is what makes such a
+letter count comparable with a published presentation length, since both are measured after free
+and cyclic reduction of each relator. This row has no published length to check against: Bray's
+presentation page for `HS` is one of the 1997 stubs that record `Length ??`, and neither the ATLAS
+page nor its Magma source file gives a figure. The total below therefore states the transcribed
+data for a reviewer to compare with the source, rather than checking it against a recorded number.
+
+## Main definitions and results
 
 * `TauCeti.Sporadic.hsPresentation`: John Bray's ATLAS finite presentation of `HS`.
+* `TauCeti.Sporadic.hsPresentation_transcribed` and the equations for the remaining fields: the
+  characterization of the sealed row.
+* `TauCeti.Sporadic.hsPresentation_map_length_relators`,
+  `TauCeti.Sporadic.hsPresentation_totalLength` and
+  `TauCeti.Sporadic.hsPresentation_relatorsCyclicallyReduced`: the three checks on the compiled
+  words.
 
 ## References
 
@@ -59,6 +80,9 @@ no order, finiteness, simplicity, or identification result.
   <https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/HSG1-P1>, with the relators and the demonstration
   of correctness in the Magma source file
   <https://brauer.maths.qmul.ac.uk/Atlas/spor/HS/mag/HSG1-P1.M>.
+* J. N. Bray, presentation page for the Higman--Sims group,
+  <https://webspace.maths.qmul.ac.uk/j.n.bray/web/Pres/HS.html>, which records `Length ??` and so
+  publishes no letter count for this presentation.
 -/
 
 public section
@@ -131,7 +155,184 @@ def hsPresentation : GroupPresentation where
       .pow (ab1 ⬝ ab1 ⬝ ab2) 2 ⬝ ab1 ⬝ ab1 ⬝ abNeg1 ⬝ ab1 ⬝ ab1 ⬝ .pow ab2 3 ⬝ ab1 ⬝ ab1 ⬝ abNeg1,
       ab1 ⬝ .pow (ab1 ⬝ ab2) 3 ⬝ ab1 ⬝ ab1 ⬝ ab2 ⬝ abNeg1 ⬝ ab1 ⬝ abNeg2 ⬝ ab1 ⬝ abNeg1 ⬝ ab2 ]
 
+/-- The generator names recorded for `HS`. The row's body is sealed, so this is what lets a
+consumer see that it is a two-generator presentation. -/
+@[simp]
+theorem hsPresentation_generatorNames : hsPresentation.generatorNames = ["a", "b"] := by
+  simp [hsPresentation]
+
+/-- The source recorded for `HS`. The row's body is sealed, so this equation publishes the citation
+itself, rather than only the row's name, to a downstream audit. -/
+@[simp]
+theorem hsPresentation_source :
+    hsPresentation.source = "R. A. Wilson, R. A. Parker, J. N. Bray et al., ATLAS of Finite Group \
+      Representations, version 3; presentation contributed by John Bray" := by
+  simp [hsPresentation]
+
+/-- The locator recorded for `HS`, pointing at the presentation and its demonstration of
+correctness inside the source. -/
+@[simp]
+theorem hsPresentation_sourceLocator :
+    hsPresentation.sourceLocator = "HSG1-P1, \
+      https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/HSG1-P1, with the relator list and the \
+      demonstration of correctness in the Magma source file \
+      https://brauer.maths.qmul.ac.uk/Atlas/spor/HS/mag/HSG1-P1.M" := by
+  simp [hsPresentation]
+
+/-- The generator convention recorded for `HS`, fixing which generator each relator index names and
+which commutator convention the source uses. -/
+@[simp]
+theorem hsPresentation_generatorConvention :
+    hsPresentation.generatorConvention = "The ATLAS standard generators a and b of HS, that is, a \
+      in class 2A and b in class 5A with ab of order 11, in that order, so index 0 is a and index \
+      1 is b. Products are read left to right, negative exponents denote inverses, and [r,s] \
+      denotes r^-1 s^-1 r s." := by
+  simp [hsPresentation]
+
+/-- The transcription notes recorded for `HS`, including which of the source's relators it flags as
+redundant. -/
+@[simp]
+theorem hsPresentation_transcriptionNotes :
+    hsPresentation.transcriptionNotes = "The thirteen words of the source's relator list are \
+      stored as thirteen relators equal to the identity. The last three, marked R1, R2 and R3 \
+      there, are redundant, and are transcribed because the source runs its coset enumerations \
+      with them. The source demonstrates correctness by enumerating the 5775 cosets of a subgroup \
+      that visibly centralizes a, using (a*b^2)^10 = 1 to exclude the double cover 2.HS. GAP \
+      4.15.1 checks that the thirteen compiled words vanish on five independent standard \
+      generating pairs of the 100-point primitive representation of HS, taking a with centralizer \
+      of order 7680, b of order 5 with centralizer of order 500, and ab of order 11." := by
+  simp [hsPresentation]
+
+/-- The generator count `HS`'s source states. With
+`TauCeti.Sporadic.hsPresentation_generatorNames` this makes
+`TauCeti.Sporadic.hsPresentation_matchesMetadata` an equation between two visible numbers. -/
+@[simp]
+theorem hsPresentation_expectedGeneratorCount : hsPresentation.expectedGeneratorCount = 2 := by
+  simp [hsPresentation]
+
+/-- The relator count `HS`'s source states; see
+`TauCeti.Sporadic.hsPresentation_expectedGeneratorCount`. -/
+@[simp]
+theorem hsPresentation_expectedRelatorCount : hsPresentation.expectedRelatorCount = 13 := by
+  simp [hsPresentation]
+
+/-- The relator expressions transcribed for `HS`, with their generator indices written out and the
+private syllable abbreviations of this file expanded.
+
+The row's body is sealed, so this is the equation that characterizes it: with
+`TauCeti.GroupPresentation.relators_def` it determines the compiled words, and with
+`TauCeti.GroupPresentation.mem_relatorSet_iff` it determines the relations defining
+`TauCeti.GroupPresentation.Group`, so a consumer never has to unfold the row. Index `0` is the
+generator `a` and index `1` is `b`, and the bounds come from
+`TauCeti.Sporadic.hsPresentation_generatorNames`. The comments name each relator in the syllables
+`s₁ = ab`, `s₂ = ab²`, `s₋₁ = ab⁻¹` and `s₋₂ = ab⁻²` of the module docstring. -/
+@[simp]
+theorem hsPresentation_transcribed :
+    hsPresentation.transcribed =
+      [
+        -- a²
+        .pow (.gen ⟨0, by simp⟩) 2,
+        -- b⁵
+        .pow (.gen ⟨1, by simp⟩) 5,
+        -- s₁¹¹
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 11,
+        -- s₂¹⁰
+        .pow (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) 10,
+        -- [a,b]⁵, in the source's commutator convention
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩)) (.inv (.gen ⟨1, by simp⟩))) 5,
+        -- [a,bab]³
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩))
+              (.inv (.gen ⟨1, by simp⟩ ⬝ .gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩))) 3,
+        -- [a,b²]⁶
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩)) (.inv (.pow (.gen ⟨1, by simp⟩) 2))) 6,
+        -- s₁s₁s₂s₋₁s₋₂s₋₁s₂s₁s₁s₋₂⁴
+        (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2) 4,
+        -- s₁(s₂s₋₂²)²s₂s₁s₂(s₋₁s₂)²
+        (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow ((.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2) 2) 2 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          .pow ((.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2)) 2,
+        -- s₁s₁s₂²s₁s₋₁²s₁s₂²s₁s₁s₋₂s₋₁s₋₂
+        (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) 2 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) 2 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) 2 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2),
+        -- (s₁s₁s₂s₋₁s₋₂s₁s₁s₋₁)², the redundant relator R1
+        .pow ((.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩))) 2,
+        -- (s₁s₁s₂)²s₁s₁s₋₁s₁s₁s₂³s₁s₁s₋₁, the redundant relator R2
+        .pow ((.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2)) 2 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) 3 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)),
+        -- s₁(s₁s₂)³s₁s₁s₂s₋₁s₁s₋₂s₁s₋₁s₂, the redundant relator R3
+        (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow ((.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2)) 3 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ] := by
+  simp [hsPresentation]
+
 /-- The generator and relator counts recorded for `HS` agree with the transcribed data. -/
-theorem matchesMetadata_hsPresentation : hsPresentation.matchesMetadata := by decide
+theorem hsPresentation_matchesMetadata : hsPresentation.matchesMetadata := by decide
+
+/-- The lengths of the thirteen compiled relator words for `HS`, in the order of the source.
+
+Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
+than only observe one in the total of `TauCeti.Sporadic.hsPresentation_totalLength`. -/
+theorem hsPresentation_map_length_relators :
+    hsPresentation.relators.map List.length =
+      [2, 5, 22, 30, 20, 24, 36, 33, 38, 36, 36, 39, 38] := by
+  simp [GroupPresentation.relators_def, hsPresentation]
+
+/-- The compiled relator words for `HS` have `359` letters in total. The source records no
+presentation length, so this figure states the transcribed data for a reviewer to compare with the
+source, rather than checking it against a recorded number. -/
+theorem hsPresentation_totalLength : hsPresentation.totalLength = 359 := by
+  rw [GroupPresentation.totalLength_def, hsPresentation_map_length_relators]
+  decide
+
+/-- Every compiled relator word for `HS` is cyclically reduced. This is what makes the letter count
+of `TauCeti.Sporadic.hsPresentation_totalLength` comparable with a published presentation length,
+which is measured after free and cyclic reduction of each relator. -/
+theorem hsPresentation_relatorsCyclicallyReduced :
+    hsPresentation.relatorsCyclicallyReduced := by
+  simp only [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def,
+    hsPresentation, List.map_cons, List.map_nil, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_inv, Relator.toWord_comm, Relator.toWord_gen]
+  decide
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/McLaughlin.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/McLaughlin.lean
@@ -52,9 +52,30 @@ meet the two ATLAS element-order conditions. Both computations are provenance fo
 transcription, not Lean theorems: this file asserts no order, finiteness, simplicity, or
 identification result.
 
-## Main definition
+The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
+relator expressions with their generator indices written out, and the provenance a manifest row
+exists to record. Together with `TauCeti.GroupPresentation.relators_def` and
+`TauCeti.GroupPresentation.mem_relatorSet_iff` the first of those determines the compiled words and
+the relations defining the presented group, so a consumer reasons about the row without unfolding
+it.
+
+Three decidable checks accompany those equations. The relator lengths and their total record the
+compiled data one word at a time and in aggregate, and cyclic reducedness is what makes such a
+letter count comparable with a published presentation length, since both are measured after free
+and cyclic reduction of each relator. This row has no published length to check against: Bray's
+presentation page for `McL` is one of the 1997 stubs that record `Length ??`, and neither the ATLAS
+page nor its Magma source file gives a figure. The total below therefore states the transcribed
+data for a reviewer to compare with the source, rather than checking it against a recorded number.
+
+## Main definitions and results
 
 * `TauCeti.Sporadic.mclPresentation`: John Bray's ATLAS finite presentation of `McL`.
+* `TauCeti.Sporadic.mclPresentation_transcribed` and the equations for the remaining fields: the
+  characterization of the sealed row.
+* `TauCeti.Sporadic.mclPresentation_map_length_relators`,
+  `TauCeti.Sporadic.mclPresentation_totalLength` and
+  `TauCeti.Sporadic.mclPresentation_relatorsCyclicallyReduced`: the three checks on the compiled
+  words.
 
 ## References
 
@@ -63,6 +84,9 @@ identification result.
   <https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/McLG1-P1>, with the relators and the
   demonstration of correctness in the Magma source file
   <https://brauer.maths.qmul.ac.uk/Atlas/spor/McL/mag/McLG1-P1.M>.
+* J. N. Bray, presentation page for the McLaughlin group,
+  <https://webspace.maths.qmul.ac.uk/j.n.bray/web/Pres/McL.html>, which records `Length ??` and so
+  publishes no letter count for this presentation.
 -/
 
 public section
@@ -138,7 +162,174 @@ def mclPresentation : GroupPresentation where
       .pow (sourceComm a (.pow b 2 ⬝ ab1)) 4,
       .pow (sourceComm a (.pow b 2 ⬝ ab2)) 4 ]
 
+/-- The generator names recorded for `McL`. The row's body is sealed, so this is what lets a
+consumer see that it is a two-generator presentation. -/
+@[simp]
+theorem mclPresentation_generatorNames : mclPresentation.generatorNames = ["a", "b"] := by
+  simp [mclPresentation]
+
+/-- The source recorded for `McL`. The row's body is sealed, so this equation publishes the
+citation itself, rather than only the row's name, to a downstream audit. -/
+@[simp]
+theorem mclPresentation_source :
+    mclPresentation.source = "R. A. Wilson, R. A. Parker, J. N. Bray et al., ATLAS of Finite \
+      Group Representations, version 3; presentation contributed by John Bray" := by
+  simp [mclPresentation]
+
+/-- The locator recorded for `McL`, pointing at the presentation and its demonstration of
+correctness inside the source. -/
+@[simp]
+theorem mclPresentation_sourceLocator :
+    mclPresentation.sourceLocator = "McLG1-P1, \
+      https://brauer.maths.qmul.ac.uk/Atlas/v3/pres/McLG1-P1, with the relator list and the \
+      demonstration of correctness in the Magma source file \
+      https://brauer.maths.qmul.ac.uk/Atlas/spor/McL/mag/McLG1-P1.M" := by
+  simp [mclPresentation]
+
+/-- The generator convention recorded for `McL`, fixing which generator each relator index names
+and which commutator convention the source uses. -/
+@[simp]
+theorem mclPresentation_generatorConvention :
+    mclPresentation.generatorConvention = "The ATLAS standard generators a and b of McL, that is, \
+      a in class 2A and b in class 5A with ab of order 11 and ababababbababbabb of order 7, in \
+      that order, so index 0 is a and index 1 is b. Products are read left to right, negative \
+      exponents denote inverses, and [r,s] denotes r^-1 s^-1 r s." := by
+  simp [mclPresentation]
+
+/-- The transcription notes recorded for `McL`, including which of the source's relators it flags
+as redundant. -/
+@[simp]
+theorem mclPresentation_transcriptionNotes :
+    mclPresentation.transcriptionNotes = "The fifteen words of the source's relator list are \
+      stored as fifteen relators equal to the identity. Three of them, marked R0, R1 and R2 \
+      there, are redundant, and are transcribed because the source's coset enumerations are \
+      easier with them. The source demonstrates correctness by enumerating the 22275 cosets of a \
+      subgroup that centralizes a, then excluding the triple cover 3.McL, whose standard \
+      generators have |AB| = 33 rather than 11. GAP 4.15.1 checks that the fifteen compiled words \
+      vanish on five independent standard generating pairs of the 275-point primitive \
+      representation of McL, taking a and b with centralizers of orders 40320 and 750 and \
+      imposing the two ATLAS element-order conditions." := by
+  simp [mclPresentation]
+
+/-- The generator count `McL`'s source states. With
+`TauCeti.Sporadic.mclPresentation_generatorNames` this makes
+`TauCeti.Sporadic.mclPresentation_matchesMetadata` an equation between two visible numbers. -/
+@[simp]
+theorem mclPresentation_expectedGeneratorCount : mclPresentation.expectedGeneratorCount = 2 := by
+  simp [mclPresentation]
+
+/-- The relator count `McL`'s source states; see
+`TauCeti.Sporadic.mclPresentation_expectedGeneratorCount`. -/
+@[simp]
+theorem mclPresentation_expectedRelatorCount : mclPresentation.expectedRelatorCount = 15 := by
+  simp [mclPresentation]
+
+/-- The relator expressions transcribed for `McL`, with their generator indices written out and
+the private syllable abbreviations of this file expanded.
+
+The row's body is sealed, so this is the equation that characterizes it: with
+`TauCeti.GroupPresentation.relators_def` it determines the compiled words, and with
+`TauCeti.GroupPresentation.mem_relatorSet_iff` it determines the relations defining
+`TauCeti.GroupPresentation.Group`, so a consumer never has to unfold the row. Index `0` is the
+generator `a` and index `1` is `b`, and the bounds come from
+`TauCeti.Sporadic.mclPresentation_generatorNames`. The comments name each relator in the syllables
+`s₁ = ab`, `s₂ = ab²`, `s₋₁ = ab⁻¹` and `s₋₂ = ab⁻²` of the module docstring. -/
+@[simp]
+theorem mclPresentation_transcribed :
+    mclPresentation.transcribed =
+      [
+        -- a²
+        .pow (.gen ⟨0, by simp⟩) 2,
+        -- b⁵
+        .pow (.gen ⟨1, by simp⟩) 5,
+        -- [a,b]⁵, in the source's commutator convention
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩)) (.inv (.gen ⟨1, by simp⟩))) 5,
+        -- s₁¹¹
+        .pow (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) 11,
+        -- s₂¹²
+        .pow (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) 12,
+        -- [a,b²]⁶
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩)) (.inv (.pow (.gen ⟨1, by simp⟩) 2))) 6,
+        -- (s₁s₋₂)⁷
+        .pow ((.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2)) 7,
+        -- [a, b⁻²s₁s₁s₂]², the redundant relator R0
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩))
+              (.inv (.pow (.inv (.gen ⟨1, by simp⟩)) 2 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2)))) 2,
+        -- [a, b⁻²s₂s₋₁s₁s₂²s₁s₋₁]
+        .comm (.inv (.gen ⟨0, by simp⟩))
+            (.inv (.pow (.inv (.gen ⟨1, by simp⟩)) 2 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) 2 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)))),
+        -- [a, bs₂³]², the redundant relator R1
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩))
+              (.inv (.gen ⟨1, by simp⟩ ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) 3))) 2,
+        -- [a, b²s₁s₂²]²
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩))
+              (.inv (.pow (.gen ⟨1, by simp⟩) 2 ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          .pow (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) 2))) 2,
+        -- s₁s₂s₋₂s₁s₋₁s₂(s₋₂s₁)²(s₂s₋₂s₂)²
+        (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          .pow ((.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩)) 2 ⬝
+          .pow ((.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.inv (.gen ⟨1, by simp⟩)) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2)) 2,
+        -- [a, b²s₂s₋₁s₂]²
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩))
+              (.inv (.pow (.gen ⟨1, by simp⟩) 2 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .inv (.gen ⟨1, by simp⟩)) ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2)))) 2,
+        -- [a, b²s₁]⁴
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩))
+              (.inv (.pow (.gen ⟨1, by simp⟩) 2 ⬝ (.gen ⟨0, by simp⟩ ⬝ .gen ⟨1, by simp⟩)))) 4,
+        -- [a, b²s₂]⁴, the redundant relator R2
+        .pow (.comm (.inv (.gen ⟨0, by simp⟩))
+              (.inv (.pow (.gen ⟨1, by simp⟩) 2 ⬝
+          (.gen ⟨0, by simp⟩ ⬝ .pow (.gen ⟨1, by simp⟩) 2)))) 4 ] := by
+  simp [mclPresentation]
+
 /-- The generator and relator counts recorded for `McL` agree with the transcribed data. -/
-theorem matchesMetadata_mclPresentation : mclPresentation.matchesMetadata := by decide
+theorem mclPresentation_matchesMetadata : mclPresentation.matchesMetadata := by decide
+
+/-- The lengths of the fifteen compiled relator words for `McL`, in the order of the source.
+
+Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
+than only observe one in the total of `TauCeti.Sporadic.mclPresentation_totalLength`. -/
+theorem mclPresentation_map_length_relators :
+    mclPresentation.relators.map List.length =
+      [2, 5, 20, 22, 36, 36, 35, 40, 40, 44, 44, 43, 44, 40, 48] := by
+  simp [GroupPresentation.relators_def, mclPresentation]
+
+/-- The compiled relator words for `McL` have `499` letters in total. The source records no
+presentation length, so this figure states the transcribed data for a reviewer to compare with the
+source, rather than checking it against a recorded number. -/
+theorem mclPresentation_totalLength : mclPresentation.totalLength = 499 := by
+  rw [GroupPresentation.totalLength_def, mclPresentation_map_length_relators]
+  decide
+
+/-- Every compiled relator word for `McL` is cyclically reduced. This is what makes the letter
+count of `TauCeti.Sporadic.mclPresentation_totalLength` comparable with a published presentation
+length, which is measured after free and cyclic reduction of each relator. -/
+theorem mclPresentation_relatorsCyclicallyReduced :
+    mclPresentation.relatorsCyclicallyReduced := by
+  simp only [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def,
+    mclPresentation, List.map_cons, List.map_nil, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_inv, Relator.toWord_comm, Relator.toWord_gen]
+  decide
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
@@ -109,8 +109,8 @@ theorem presentation_matchesMetadata (s : SporadicName) :
   | J2 => exact Sporadic.j2Presentation_matchesMetadata
   | J3 => exact Sporadic.j3Presentation_matchesMetadata
   | J4 => exact Sporadic.j4Presentation_matchesMetadata
-  | HS => exact Sporadic.matchesMetadata_hsPresentation
-  | McL => exact Sporadic.matchesMetadata_mclPresentation
+  | HS => exact Sporadic.hsPresentation_matchesMetadata
+  | McL => exact Sporadic.mclPresentation_matchesMetadata
   | He => exact Sporadic.hePresentation_matchesMetadata
   | Ru => exact Sporadic.ruPresentation_matchesMetadata
   | Suz => exact Sporadic.suzPresentation_matchesMetadata


### PR DESCRIPTION
This PR characterizes and audits the `He`, `HS` and `McL` rows of the sporadic presentation data. Each row is a sealed definition, so nothing of its contents reaches a consumer; this adds an equation for every field — the transcribed relator expressions with their generator indices written out, alongside the source, locator, generator convention, transcription notes and expected counts — so that with `TauCeti.GroupPresentation.relators_def` and `TauCeti.GroupPresentation.mem_relatorSet_iff` the compiled words and the relations defining `TauCeti.GroupPresentation.Group` are determined without unfolding the row. It also adds the three decidable checks on the compiled data that accompany the count check: the per-relator letter counts, their total, and cyclic reducedness of every compiled word. Nothing here asserts an order, finiteness, simplicity, or identification result for any of the three groups.

`matchesMetadata_hsPresentation` and `matchesMetadata_mclPresentation` become `hsPresentation_matchesMetadata` and `mclPresentation_matchesMetadata`, the convention the other twenty-four rows already use, and the dispatcher in `Sporadic/Presentation.lean` moves to the new names.

The milestone is S1, "the twenty-six sporadic presentations", whose completion evidence in `TauCetiRoadmap/CFSGStatement/README.md` is "relator counts match the manifest; independent transcription review". After this PR the rows still carrying neither characterization nor checks are `M11`, `M12`, `M22`, `Ru`, `Suz`, `ONan`, `Fi24Prime`, `HN`, `Ly`, `Th`, `B` and `M`; the `Fi22`, `Fi23` and three Conway rows are in flight in other pull requests, and the four Janko rows and `M23`, `M24` have already landed.

The independent source-to-Lean read-through S1 asks for was done for all three rows while preparing this. `HS` and `McL` were compared relator by relator, letter by letter, against the relator lists in the ATLAS Magma source files `HSG1-P1.M` and `McLG1-P1.M`, and `He` against the presentation displayed on the ATLAS `HeG1-P1` page; all three agree with their sources, including the sources' commutator convention `[r,s] = r⁻¹s⁻¹rs` and the relators the sources flag as redundant but retain. The letter totals `158`, `359` and `499` are new data rather than a check: none of the three sources publishes a presentation length, since Bray's presentation pages for `He`, `HS` and `McL` are 1997 stubs recording `Length ??` and neither the ATLAS pages nor the Magma files give a figure. The module docstrings say exactly that, so the totals are stated for a reviewer to compare with the source and not presented as matching a recorded number.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"sporadic-presentation-rows-he-hs-mcl"}-->

🤖 Prepared with Claude Code
