### PR TITLE
feat: the symmetric powers exhaust the irreducibles of SU(2)

### DIFF
--- a/TauCeti/Analysis/Normed/Module/Multilinear.lean
+++ b/TauCeti/Analysis/Normed/Module/Multilinear.lean
@@ -13,7 +13,7 @@ public import Mathlib.LinearAlgebra.Multilinear.Basic
 
 A multilinear map `f : MultilinearMap 𝕜 M N` on finitely many finite-dimensional normed spaces
 over a complete field is continuous, with no bound assumed:
-`TauCeti.MultilinearMap.continuous_of_finiteDimensional`. Expanding each argument in a basis
+`MultilinearMap.continuous_of_finiteDimensional`. Expanding each argument in a basis
 writes `f` as a finite sum of terms `(∏ i, coordinate) • constant`, and each coordinate is a
 linear functional on a finite-dimensional space, hence continuous.
 
@@ -24,8 +24,6 @@ construction, say — rather than from analysis.
 -/
 
 public section
-
-namespace TauCeti
 
 namespace MultilinearMap
 
@@ -56,5 +54,3 @@ theorem continuous_of_finiteDimensional (f : MultilinearMap 𝕜 M N) : Continuo
     (continuous_apply i)).congr fun m ↦ Module.Basis.coord_apply _ _ _
 
 end MultilinearMap
-
-end TauCeti

--- a/TauCeti/Analysis/Normed/Module/Multilinear.lean
+++ b/TauCeti/Analysis/Normed/Module/Multilinear.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.FiniteDimension
+public import Mathlib.LinearAlgebra.Multilinear.Basic
+
+/-!
+# Multilinear maps on finitely many finite-dimensional spaces are continuous
+
+A multilinear map `f : MultilinearMap 𝕜 M N` on finitely many finite-dimensional normed spaces
+over a complete field is continuous, with no bound assumed:
+`TauCeti.MultilinearMap.continuous_of_finiteDimensional`. Expanding each argument in a basis
+writes `f` as a finite sum of terms `(∏ i, coordinate) • constant`, and each coordinate is a
+linear functional on a finite-dimensional space, hence continuous.
+
+This is the multilinear companion of `LinearMap.continuous_of_finiteDimensional`. Mathlib's
+`MultilinearMap.continuous_of_bound` asks for an explicit bound, which is exactly what one does
+not have when the multilinear map arrives from algebra — a tensor or symmetric-power
+construction, say — rather than from analysis.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace MultilinearMap
+
+variable {𝕜 ι : Type*} {M : ι → Type*} {N : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+  [Finite ι] [∀ i, NormedAddCommGroup (M i)] [∀ i, NormedSpace 𝕜 (M i)]
+  [∀ i, FiniteDimensional 𝕜 (M i)] [NormedAddCommGroup N] [NormedSpace 𝕜 N]
+
+/-- **A multilinear map on finitely many finite-dimensional spaces is continuous.** Over a
+complete field, no bound need be assumed: expanding every argument in a basis exhibits the map as
+a finite sum of products of coordinates times constant vectors. -/
+theorem continuous_of_finiteDimensional (f : MultilinearMap 𝕜 M N) : Continuous f := by
+  classical
+  cases nonempty_fintype ι
+  set b : ∀ i, Module.Basis (Fin (Module.finrank 𝕜 (M i))) 𝕜 (M i) :=
+    fun i ↦ Module.finBasis 𝕜 (M i) with hb
+  have key : ⇑f = fun m : ∀ i, M i ↦ ∑ r : ∀ i, Fin (Module.finrank 𝕜 (M i)),
+      (∏ i, (b i).repr (m i) (r i)) • f fun i ↦ b i (r i) := by
+    funext m
+    have hm : f m = f fun i ↦ ∑ j, (b i).repr (m i) j • b i j := by
+      congr 1 with i
+      exact ((b i).sum_repr (m i)).symm
+    rw [hm, f.map_sum]
+    exact Finset.sum_congr rfl fun r _ ↦ f.map_smul_univ _ _
+  rw [key]
+  refine continuous_finsetSum _ fun r _ ↦ Continuous.smul ?_ continuous_const
+  refine continuous_finsetProd _ fun i _ ↦ ?_
+  exact (((b i).coord (r i)).continuous_of_finiteDimensional.comp
+    (continuous_apply i)).congr fun m ↦ Module.Basis.coord_apply _ _ _
+
+end MultilinearMap
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/SU2/Borel.lean
+++ b/TauCeti/RepresentationTheory/SU2/Borel.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
+public import TauCeti.RepresentationTheory.SU2.Basic
+
+/-!
+# The Borel structure of `SU(2)`
+
+`SU(2)` carries the subspace topology of the `2 × 2` complex matrices, which makes it a compact
+Hausdorff topological group (`TauCeti/RepresentationTheory/SU2/Basic.lean`), but no measurable
+structure comes with it. This file equips it with its Borel σ-algebra, which is what lets the Haar
+measure of a compact group -- and with it the `L²` theory of
+`TauCeti/RepresentationTheory/Compact/` -- be applied to `SU(2)`.
+
+The σ-algebra is taken to be `borel SU(2)` by definition, so the `MeasurableSpace` and
+`BorelSpace` instances agree by construction and no compatibility lemma is needed.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace SU2
+
+/-- `SU(2)` carries its Borel σ-algebra, the measurable structure Haar measure needs. -/
+noncomputable instance : MeasurableSpace SU2 := borel SU2
+
+instance : BorelSpace SU2 := ⟨rfl⟩
+
+end SU2
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/SU2/Completeness.lean
+++ b/TauCeti/RepresentationTheory/SU2/Completeness.lean
@@ -226,6 +226,13 @@ theorem symPowerCharacter_mem_characterSpan (d : ℕ) :
     symPowerCharacter d ∈ characterSpan :=
   Submodule.subset_span ⟨d, rfl⟩
 
+/-- The span of the characters is contained in a subspace exactly when every character is: the
+characteristic property of `TauCeti.SU2.characterSpan` as a span. -/
+theorem characterSpan_le_iff {p : Submodule ℂ C(SU2, ℂ)} :
+    characterSpan ≤ p ↔ ∀ d : ℕ, symPowerCharacter d ∈ p := by
+  rw [characterSpan, Submodule.span_le, Set.range_subset_iff]
+  rfl
+
 /-- Multiplying a character by the trace stays in the span of the characters: the Chebyshev
 recursion `TauCeti.SU2.trace_mul_character_symPower` expresses the product as a sum of two
 characters. -/

--- a/TauCeti/RepresentationTheory/SU2/Exhaustion.lean
+++ b/TauCeti/RepresentationTheory/SU2/Exhaustion.lean
@@ -109,6 +109,12 @@ theorem weightEquiv_weightBasis (i : Fin (d + 1)) :
   rw [weightEquiv, Module.Basis.equiv_apply, OrthonormalBasis.coe_toBasis,
     Equiv.refl_apply, EuclideanSpace.basisFun_apply]
 
+/-- The identification sends the `i`-th standard basis vector back to the `i`-th weight vector. -/
+@[simp]
+theorem weightEquiv_symm_single (i : Fin (d + 1)) :
+    (weightEquiv d).symm (EuclideanSpace.single i 1) = weightBasis d i :=
+  (LinearEquiv.symm_apply_eq _).2 (weightEquiv_weightBasis d i).symm
+
 @[simp]
 theorem symPowerModel_apply (g : SU2) (x : EuclideanSpace ℂ (Fin (d + 1))) :
     symPowerModel d g x = weightEquiv d (symPower d g ((weightEquiv d).symm x)) := (rfl)
@@ -164,6 +170,17 @@ theorem continuous_symPowerModel : Continuous (symPowerModel d) :=
 noncomputable def symPowerModelEquiv : (symPower d).Equiv (symPowerModel d).toRepresentation :=
   Representation.Equiv.mk (weightEquiv d) fun g ↦ LinearMap.ext fun v ↦ by
     simp [_root_.ContRepresentation.toMonoidHom_apply]
+
+/-- The equivalence to the model is the weight-basis identification. -/
+@[simp]
+theorem symPowerModelEquiv_toLinearEquiv :
+    (symPowerModelEquiv d).toLinearEquiv = weightEquiv d := by
+  rw [symPowerModelEquiv, Representation.Equiv.toLinearEquiv_mk']
+
+@[simp]
+theorem symPowerModelEquiv_apply (x : Sym[ℂ]^d(Fin 2 → ℂ)) :
+    symPowerModelEquiv d x = weightEquiv d x := by
+  rw [symPowerModelEquiv, Representation.Equiv.mk_apply]
 
 /-- The character of the model is the character of the symmetric power: the trace does not see the
 transport. -/

--- a/TauCeti/RepresentationTheory/SU2/Exhaustion.lean
+++ b/TauCeti/RepresentationTheory/SU2/Exhaustion.lean
@@ -1,0 +1,262 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Complex.Polynomial.Basic
+public import TauCeti.Analysis.Normed.Module.Multilinear
+public import TauCeti.RepresentationTheory.Compact.Character.Basic
+public import TauCeti.RepresentationTheory.Compact.UnitaryModel
+public import TauCeti.RepresentationTheory.Continuous.Schur
+public import TauCeti.RepresentationTheory.SU2.Borel
+public import TauCeti.RepresentationTheory.SU2.Completeness
+public import TauCeti.RepresentationTheory.SU2.Irreducible
+
+/-!
+# The symmetric powers exhaust the irreducibles of `SU(2)`
+
+`TauCeti/RepresentationTheory/SU2/Irreducible.lean` shows the symmetric powers `Symᵈ(ℂ²)` of the
+standard representation of `SU(2)` are irreducible and pairwise inequivalent, and
+`TauCeti/RepresentationTheory/SU2/Completeness.lean` shows their characters span a uniformly dense
+subspace of the continuous class functions. This file closes the classification: **every**
+finite-dimensional irreducible continuous representation of `SU(2)` is one of them
+(`TauCeti.SU2.exists_nonempty_equiv_symPower`), and the degree is unique
+(`TauCeti.SU2.existsUnique_nonempty_equiv_symPower`), so `d ↦ Symᵈ(ℂ²)` is a bijection from `ℕ`
+onto the isomorphism classes.
+
+The deduction is the classical one: an irreducible not in the list has a character orthogonal to
+every `χ_d`, hence -- by continuity of the `L²` pairing along the uniform approximation -- to
+every class function, hence to itself, contradicting `‖χ_π‖ = 1`. What is new here is the
+plumbing that lets the general orthogonality relations of
+`TauCeti/RepresentationTheory/Compact/Character/Basic.lean` reach `Symᵈ(ℂ²)` at all: those
+relations are about a `ContRepresentation` on a *normed* space, whereas `Symᵈ(ℂ²)` is a symmetric
+tensor power, carrying no topology. So the weight basis is used to carry the symmetric power onto
+the standard model `ℂ^{d+1}` (`TauCeti.SU2.symPowerModel`), and its action is shown to be
+continuous.
+
+That continuity is the one genuinely analytic step. A group element acts on a pure symmetric
+tensor factor by factor, so the action is the composition of the continuous map
+`g ↦ (g·v₁, …, g·v_d)` with the multilinear map `⨂ₛ`, read in coordinates; multilinear maps on
+finite-dimensional spaces are continuous
+(`TauCeti.MultilinearMap.continuous_of_finiteDimensional`), and expanding an arbitrary vector in
+the weight basis extends the conclusion from pure tensors to all of `Symᵈ(ℂ²)`.
+
+Unitarity of `Symᵈ(ℂ²)` is *not* established, and is not needed: the second orthogonality
+relation asks for unitarity only of the representation being tested, and even that hypothesis is
+discharged by Weyl's unitarian trick, so the statements below assume none. The transported model
+carries the inner product making the weight basis orthonormal, which for `d ≥ 2` is not the
+`SU(2)`-invariant one.
+
+## Main definitions
+
+* `TauCeti.SU2.symPowerModel`: `Symᵈ(ℂ²)` as a continuous representation on `ℂ^{d+1}`.
+
+## Main results
+
+* `TauCeti.SU2.exists_nonempty_equiv_symPower`: every finite-dimensional irreducible continuous
+  representation of `SU(2)` is equivalent to some `Symᵈ(ℂ²)`.
+* `TauCeti.SU2.existsUnique_nonempty_equiv_symPower`: the degree `d` is unique.
+
+## References
+
+This is the `su2Irrep_exhaust` target of the `SU(2)` engine case of
+`TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`, proved as that roadmap requires:
+from the irreducibility and weight arguments together with the density of the character span, not
+by reading a classification off Peter-Weyl.
+
+* D. Bump, *Lie Groups*, 2nd ed., Springer GTM 225 (2013), Chapter 3.
+* T. Bröcker, T. tom Dieck, *Representations of Compact Lie Groups*, Springer GTM 98 (1985),
+  Chapter II, §4-5.
+-/
+
+public section
+
+open Matrix
+open scoped InnerProductSpace TensorProduct
+
+namespace TauCeti
+
+namespace SU2
+
+variable (d : ℕ)
+
+/-- The weight basis read as an identification of `Symᵈ(ℂ²)` with the standard model space
+`ℂ^{d+1}`. -/
+noncomputable def weightEquiv : Sym[ℂ]^d(Fin 2 → ℂ) ≃ₗ[ℂ] EuclideanSpace ℂ (Fin (d + 1)) :=
+  (weightBasis d).equiv (EuclideanSpace.basisFun (Fin (d + 1)) ℂ).toBasis (Equiv.refl _)
+
+/-- The `d`-th symmetric power of the standard representation of `SU(2)`, carried onto the
+standard model space `ℂ^{d+1}` by the weight basis. -/
+noncomputable def symPowerModel : ContRepresentation ℂ SU2 (EuclideanSpace ℂ (Fin (d + 1))) :=
+  .ofMonoidHom
+    { toFun g := LinearMap.toContinuousLinearMap ((weightEquiv d).conj (symPower d g))
+      map_one' := by ext x; simp [LinearEquiv.conj_apply]
+      map_mul' g h := by ext x; simp [LinearEquiv.conj_apply] }
+
+/-- The identification sends the `i`-th weight vector to the `i`-th standard basis vector. -/
+@[simp]
+theorem weightEquiv_weightBasis (i : Fin (d + 1)) :
+    weightEquiv d (weightBasis d i) = EuclideanSpace.single i 1 := by
+  rw [weightEquiv, Module.Basis.equiv_apply, OrthonormalBasis.coe_toBasis,
+    Equiv.refl_apply, EuclideanSpace.basisFun_apply]
+
+@[simp]
+theorem symPowerModel_apply (g : SU2) (x : EuclideanSpace ℂ (Fin (d + 1))) :
+    symPowerModel d g x = weightEquiv d (symPower d g ((weightEquiv d).symm x)) := (rfl)
+
+/-! ### Continuity -/
+
+private theorem continuous_mulVec (w : Fin 2 → ℂ) :
+    Continuous fun g : SU2 ↦ (g : Matrix (Fin 2) (Fin 2) ℂ) *ᵥ w := by
+  refine continuous_pi fun i ↦ ?_
+  simp only [Matrix.mulVec, dotProduct]
+  refine continuous_finsetSum _ fun j _ ↦ Continuous.mul ?_ continuous_const
+  exact (continuous_apply j).comp ((continuous_apply i).comp continuous_subtype_val)
+
+private theorem continuous_weightEquiv_symPower_tprod (v : Fin d → (Fin 2 → ℂ)) :
+    Continuous fun g : SU2 ↦ weightEquiv d (symPower d g (⨂ₛ[ℂ] j, v j)) := by
+  have hΦ : Continuous
+      ((weightEquiv d).toLinearMap.compMultilinearMap (SymmetricPower.tprod ℂ)) :=
+    TauCeti.MultilinearMap.continuous_of_finiteDimensional _
+  have hv : Continuous fun g : SU2 ↦ fun j ↦ (g : Matrix (Fin 2) (Fin 2) ℂ) *ᵥ v j :=
+    continuous_pi fun j ↦ continuous_mulVec (v j)
+  exact (hΦ.comp hv).congr fun g ↦ by simp
+
+private theorem continuous_weightEquiv_symPower (x : Sym[ℂ]^d(Fin 2 → ℂ)) :
+    Continuous fun g : SU2 ↦ weightEquiv d (symPower d g x) := by
+  have hb : ∀ i : Fin (d + 1),
+      Continuous fun g : SU2 ↦ weightEquiv d (symPower d g (weightBasis d i)) := fun i ↦ by
+    obtain ⟨f, hf⟩ := exists_weightBasis_eq_tprod d i
+    rw [hf]
+    exact continuous_weightEquiv_symPower_tprod d _
+  have hx : (fun g : SU2 ↦ weightEquiv d (symPower d g x)) =
+      fun g : SU2 ↦ ∑ i, (weightBasis d).repr x i •
+        weightEquiv d (symPower d g (weightBasis d i)) := by
+    funext g
+    calc weightEquiv d (symPower d g x)
+        = weightEquiv d (symPower d g (∑ i, (weightBasis d).repr x i • weightBasis d i)) := by
+          rw [(weightBasis d).sum_repr x]
+      _ = ∑ i, (weightBasis d).repr x i • weightEquiv d (symPower d g (weightBasis d i)) := by
+          simp only [map_sum, map_smul]
+  rw [hx]
+  exact continuous_finsetSum _ fun i _ ↦
+    (continuous_const_smul ((weightBasis d).repr x i)).comp (hb i)
+
+/-- **The model action is continuous.** A pure symmetric tensor moves multilinearly in its
+factors, and a multilinear map on finite-dimensional spaces is continuous, so the coordinates of
+the action are continuous in the group element. -/
+theorem continuous_symPowerModel : Continuous (symPowerModel d) :=
+  continuous_clm_apply.2 fun y ↦ by
+    simpa using continuous_weightEquiv_symPower d ((weightEquiv d).symm y)
+
+/-! ### What the model inherits -/
+
+/-- The model is equivalent to the symmetric power it is transported from. -/
+noncomputable def symPowerModelEquiv : (symPower d).Equiv (symPowerModel d).toRepresentation :=
+  Representation.Equiv.mk (weightEquiv d) fun g ↦ LinearMap.ext fun v ↦ by
+    simp [_root_.ContRepresentation.toMonoidHom_apply]
+
+/-- The character of the model is the character of the symmetric power: the trace does not see the
+transport. -/
+@[simp]
+theorem character_symPowerModel :
+    ContRepresentation.character (symPowerModel d) (continuous_symPowerModel d) =
+      symPowerCharacter d :=
+  ContinuousMap.ext fun g ↦ by
+    rw [symPowerCharacter_apply, Representation.char_iso (symPowerModelEquiv d)]
+    exact congrFun (ContRepresentation.coe_character _ _) g
+
+/-- The model is irreducible, being equivalent to `Symᵈ(ℂ²)`. -/
+theorem isIrreducible_symPowerModel :
+    Representation.IsIrreducible (symPowerModel d).toRepresentation :=
+  Representation.isIrreducible_of_linearEquiv (weightEquiv d)
+    (fun g v ↦ by simp [_root_.ContRepresentation.toMonoidHom_apply])
+    (isIrreducible_symPower d)
+
+/-! ### Exhaustion -/
+
+/-- The unitary case of `TauCeti.SU2.exists_nonempty_equiv_symPower`, which is where the argument
+runs; the general case is reduced to it by the unitarian trick. -/
+private theorem exists_nonempty_equiv_symPower_of_isUnitary {V : Type*} [NormedAddCommGroup V]
+    [InnerProductSpace ℂ V] [FiniteDimensional ℂ V] (π : ContRepresentation ℂ SU2 V)
+    (hπ : Continuous π) (hunitary : ContRepresentation.IsUnitary π)
+    (hirr : Representation.IsIrreducible π.toRepresentation) :
+    ∃ d : ℕ, Nonempty ((symPower d).Equiv π.toRepresentation) := by
+  by_contra hcon
+  have hne : ∀ d : ℕ, ¬ Nonempty ((symPower d).Equiv π.toRepresentation) := fun d h ↦ hcon ⟨d, h⟩
+  -- the character of `π` is orthogonal to every character of the family
+  have hzero : ∀ d : ℕ, ⟪ContRepresentation.characterLp π hπ,
+      ContRepresentation.characterLp (symPowerModel d) (continuous_symPowerModel d)⟫_ℂ = 0 := by
+    intro d
+    refine ContRepresentation.character_orthonormal_distinct π hπ _ _ hunitary fun f ↦ ?_
+    have hempty : IsEmpty (_root_.ContRepresentation.Equiv (symPowerModel d) π) :=
+      ⟨fun φ ↦ hne d ⟨(symPowerModelEquiv d).trans
+        (ContRepresentation.nonempty_equiv_iff.1 ⟨φ⟩).some⟩⟩
+    rw [ContRepresentation.eq_zero_of_isEmpty_equiv (isIrreducible_symPowerModel d) hirr hempty f]
+    simp
+  -- pairing against that character is a continuous functional killing the span of the family
+  let Λ : C(SU2, ℂ) →L[ℂ] ℂ := (innerSL ℂ (ContRepresentation.characterLp π hπ)).comp
+    (ContinuousMap.toLp 2 (haarProb SU2) ℂ)
+  have hΛ : ∀ F : C(SU2, ℂ), (Λ : C(SU2, ℂ) →ₗ[ℂ] ℂ) F = ⟪ContRepresentation.characterLp π hπ,
+        ContinuousMap.toLp 2 (haarProb SU2) ℂ F⟫_ℂ := fun F ↦ by simp [Λ]
+  have hspan : characterSpan ≤ LinearMap.ker (Λ : C(SU2, ℂ) →ₗ[ℂ] ℂ) :=
+    characterSpan_le_iff.2 fun d ↦ LinearMap.mem_ker.2 <| by
+      rw [hΛ, ← character_symPowerModel d,
+        ← ContRepresentation.characterLp_def (symPowerModel d) (continuous_symPowerModel d)]
+      exact hzero d
+  have hclosure : characterSpan.topologicalClosure ≤ LinearMap.ker (Λ : C(SU2, ℂ) →ₗ[ℂ] ℂ) :=
+    Submodule.topologicalClosure_minimal _ hspan Λ.isClosed_ker
+  -- but that character is a class function, hence in the closure of the span, and has norm one
+  have hmem : ContRepresentation.character π hπ ∈ characterSpan.topologicalClosure :=
+    mem_topologicalClosure_characterSpan_iff.2 fun u g ↦ by
+      simp only [ContRepresentation.coe_character]
+      exact Representation.char_conj π.toRepresentation g u
+  have hker := LinearMap.mem_ker.1 (hclosure hmem)
+  rw [hΛ, ← ContRepresentation.characterLp_def π hπ] at hker
+  exact one_ne_zero
+    ((ContRepresentation.character_orthonormal_self π hπ hunitary hirr).symm.trans hker)
+
+/-- **The symmetric powers exhaust the irreducibles of `SU(2)`.** Every finite-dimensional
+irreducible continuous representation of `SU(2)` is equivalent to `Symᵈ(ℂ²)` for some `d`.
+
+Suppose not. Then `π` is inequivalent to every `Symᵈ(ℂ²)`, so by Schur's lemma there is no nonzero
+intertwiner between them, and the second character orthogonality relation makes the character of
+`π` orthogonal in `L²(SU(2))` to every `χ_d`. Pairing with the character of `π` is a *continuous*
+functional on `C(SU(2), ℂ)`, so it then kills the whole uniform closure of the span of the `χ_d`,
+which by `TauCeti.SU2.mem_topologicalClosure_characterSpan_iff` is all of the continuous class
+functions. But the character of `π` is itself a class function, and pairs with itself to `1` by
+the first orthogonality relation.
+
+Unitarity is not assumed: Weyl's unitarian trick
+(`TauCeti.ContRepresentation.exists_isUnitary_congr`) makes any such representation unitary after
+conjugating by an automorphism of the carrier, and the conjugation is an equivalence, so it
+changes neither the hypotheses nor the conclusion. -/
+theorem exists_nonempty_equiv_symPower {V : Type*} [NormedAddCommGroup V]
+    [InnerProductSpace ℂ V] [FiniteDimensional ℂ V] (π : ContRepresentation ℂ SU2 V)
+    (hπ : Continuous π) (hirr : Representation.IsIrreducible π.toRepresentation) :
+    ∃ d : ℕ, Nonempty ((symPower d).Equiv π.toRepresentation) := by
+  obtain ⟨e, he⟩ := ContRepresentation.exists_isUnitary_congr π hπ
+  obtain ⟨d, hd⟩ := exists_nonempty_equiv_symPower_of_isUnitary (ContRepresentation.congr e π)
+    (ContRepresentation.continuous_congr e hπ) he (ContRepresentation.isIrreducible_congr e hirr)
+  refine ⟨d, ⟨hd.some.trans (Representation.Equiv.mk (e.symm : V ≃ₗ[ℂ] V) fun g ↦ ?_)⟩⟩
+  exact LinearMap.ext fun v ↦ by
+    simp [_root_.ContRepresentation.toMonoidHom_apply]
+
+/-- **The classification of the irreducible representations of `SU(2)`.** A finite-dimensional
+irreducible continuous representation of `SU(2)` is `Symᵈ(ℂ²)` for exactly one `d`, so
+`d ↦ Symᵈ(ℂ²)` is a bijection from `ℕ` onto the isomorphism classes. Exhaustion is
+`TauCeti.SU2.exists_nonempty_equiv_symPower` and uniqueness is
+`TauCeti.SU2.nonempty_equiv_symPower_iff`. -/
+theorem existsUnique_nonempty_equiv_symPower {V : Type*} [NormedAddCommGroup V]
+    [InnerProductSpace ℂ V] [FiniteDimensional ℂ V] (π : ContRepresentation ℂ SU2 V)
+    (hπ : Continuous π) (hirr : Representation.IsIrreducible π.toRepresentation) :
+    ∃! d : ℕ, Nonempty ((symPower d).Equiv π.toRepresentation) := by
+  obtain ⟨d, hd⟩ := exists_nonempty_equiv_symPower π hπ hirr
+  exact ⟨d, hd, fun e he ↦ (nonempty_equiv_symPower_iff (d := e) d).1
+    ⟨he.some.trans hd.some.symm⟩⟩
+
+end SU2
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/SU2/Exhaustion.lean
+++ b/TauCeti/RepresentationTheory/SU2/Exhaustion.lean
@@ -40,7 +40,7 @@ That continuity is the one genuinely analytic step. A group element acts on a pu
 tensor factor by factor, so the action is the composition of the continuous map
 `g ↦ (g·v₁, …, g·v_d)` with the multilinear map `⨂ₛ`, read in coordinates; multilinear maps on
 finite-dimensional spaces are continuous
-(`TauCeti.MultilinearMap.continuous_of_finiteDimensional`), and expanding an arbitrary vector in
+(`MultilinearMap.continuous_of_finiteDimensional`), and expanding an arbitrary vector in
 the weight basis extends the conclusion from pure tensors to all of `Symᵈ(ℂ²)`.
 
 Unitarity of `Symᵈ(ℂ²)` is *not* established, and is not needed: the second orthogonality
@@ -119,7 +119,7 @@ private theorem continuous_weightEquiv_symPower_tprod (v : Fin d → (Fin 2 → 
     Continuous fun g : SU2 ↦ weightEquiv d (symPower d g (⨂ₛ[ℂ] j, v j)) := by
   have hΦ : Continuous
       ((weightEquiv d).toLinearMap.compMultilinearMap (SymmetricPower.tprod ℂ)) :=
-    TauCeti.MultilinearMap.continuous_of_finiteDimensional _
+    MultilinearMap.continuous_of_finiteDimensional _
   have hv : Continuous fun g : SU2 ↦ fun j ↦ (g : Matrix (Fin 2) (Fin 2) ℂ) *ᵥ v j :=
     continuous_pi fun j ↦ continuous_mulVec (v j)
   exact (hΦ.comp hv).congr fun g ↦ by simp

--- a/TauCeti/RepresentationTheory/SU2/Exhaustion.lean
+++ b/TauCeti/RepresentationTheory/SU2/Exhaustion.lean
@@ -218,8 +218,8 @@ private theorem exists_nonempty_equiv_symPower_of_isUnitary {V : Type*} [NormedA
   exact one_ne_zero
     ((ContRepresentation.character_orthonormal_self π hπ hunitary hirr).symm.trans hker)
 
-/-- **The symmetric powers exhaust the irreducibles of `SU(2)`.** Every finite-dimensional
-irreducible continuous representation of `SU(2)` is equivalent to `Symᵈ(ℂ²)` for some `d`.
+/-- The inner-product case of `TauCeti.SU2.exists_nonempty_equiv_symPower`, where the characters
+live; the general normed case is reduced to it by transport to a Euclidean model.
 
 Suppose not. Then `π` is inequivalent to every `Symᵈ(ℂ²)`, so by Schur's lemma there is no nonzero
 intertwiner between them, and the second character orthogonality relation makes the character of
@@ -233,8 +233,9 @@ Unitarity is not assumed: Weyl's unitarian trick
 (`TauCeti.ContRepresentation.exists_isUnitary_congr`) makes any such representation unitary after
 conjugating by an automorphism of the carrier, and the conjugation is an equivalence, so it
 changes neither the hypotheses nor the conclusion. -/
-theorem exists_nonempty_equiv_symPower {V : Type*} [NormedAddCommGroup V]
-    [InnerProductSpace ℂ V] [FiniteDimensional ℂ V] (π : ContRepresentation ℂ SU2 V)
+private theorem exists_nonempty_equiv_symPower_of_innerProductSpace {V : Type*}
+    [NormedAddCommGroup V] [InnerProductSpace ℂ V] [FiniteDimensional ℂ V]
+    (π : ContRepresentation ℂ SU2 V)
     (hπ : Continuous π) (hirr : Representation.IsIrreducible π.toRepresentation) :
     ∃ d : ℕ, Nonempty ((symPower d).Equiv π.toRepresentation) := by
   obtain ⟨e, he⟩ := ContRepresentation.exists_isUnitary_congr π hπ
@@ -244,13 +245,35 @@ theorem exists_nonempty_equiv_symPower {V : Type*} [NormedAddCommGroup V]
   exact LinearMap.ext fun v ↦ by
     simp [_root_.ContRepresentation.toMonoidHom_apply]
 
+/-- **The symmetric powers exhaust the irreducibles of `SU(2)`.** Every finite-dimensional
+irreducible continuous representation of `SU(2)` is equivalent to `Symᵈ(ℂ²)` for some `d`.
+
+Neither an inner product nor unitarity is assumed of the carrier. A finite-dimensional normed
+space over `ℂ` is continuously linearly equivalent to `ℂ^{dim V}` by dimension count, and
+transporting `π` along that equivalence changes neither the hypotheses nor the conclusion, so the
+argument may be run on a Euclidean carrier, where the characters live; there Weyl's unitarian
+trick disposes of unitarity in the same way. -/
+theorem exists_nonempty_equiv_symPower {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V]
+    [FiniteDimensional ℂ V] (π : ContRepresentation ℂ SU2 V) (hπ : Continuous π)
+    (hirr : Representation.IsIrreducible π.toRepresentation) :
+    ∃ d : ℕ, Nonempty ((symPower d).Equiv π.toRepresentation) := by
+  let e : V ≃L[ℂ] EuclideanSpace ℂ (Fin (Module.finrank ℂ V)) :=
+    ContinuousLinearEquiv.ofFinrankEq finrank_euclideanSpace_fin.symm
+  obtain ⟨d, hd⟩ := exists_nonempty_equiv_symPower_of_innerProductSpace
+    (ContRepresentation.congr e π) (ContRepresentation.continuous_congr e hπ)
+    (ContRepresentation.isIrreducible_congr e hirr)
+  refine ⟨d, ⟨hd.some.trans (Representation.Equiv.mk
+    (e.symm : EuclideanSpace ℂ (Fin (Module.finrank ℂ V)) ≃ₗ[ℂ] V) fun g ↦ ?_)⟩⟩
+  exact LinearMap.ext fun v ↦ by
+    simp [_root_.ContRepresentation.toMonoidHom_apply]
+
 /-- **The classification of the irreducible representations of `SU(2)`.** A finite-dimensional
 irreducible continuous representation of `SU(2)` is `Symᵈ(ℂ²)` for exactly one `d`, so
 `d ↦ Symᵈ(ℂ²)` is a bijection from `ℕ` onto the isomorphism classes. Exhaustion is
 `TauCeti.SU2.exists_nonempty_equiv_symPower` and uniqueness is
 `TauCeti.SU2.nonempty_equiv_symPower_iff`. -/
 theorem existsUnique_nonempty_equiv_symPower {V : Type*} [NormedAddCommGroup V]
-    [InnerProductSpace ℂ V] [FiniteDimensional ℂ V] (π : ContRepresentation ℂ SU2 V)
+    [NormedSpace ℂ V] [FiniteDimensional ℂ V] (π : ContRepresentation ℂ SU2 V)
     (hπ : Continuous π) (hirr : Representation.IsIrreducible π.toRepresentation) :
     ∃! d : ℕ, Nonempty ((symPower d).Equiv π.toRepresentation) := by
   obtain ⟨d, hd⟩ := exists_nonempty_equiv_symPower π hπ hirr

--- a/TauCeti/RepresentationTheory/SU2/Exhaustion.lean
+++ b/TauCeti/RepresentationTheory/SU2/Exhaustion.lean
@@ -5,6 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+-- The home of `Complex.isAlgClosed`: the scalar half of Schur's lemma, which the first
+-- orthogonality relation below runs on, needs `IsAlgClosed ℂ`.
 public import Mathlib.Analysis.Complex.Polynomial.Basic
 public import TauCeti.Analysis.Normed.Module.Multilinear
 public import TauCeti.RepresentationTheory.Compact.Character.Basic
@@ -62,9 +64,14 @@ carries the inner product making the weight basis orthonormal, which for `d ≥ 
 ## References
 
 This is the `su2Irrep_exhaust` target of the `SU(2)` engine case of
-`TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`, proved as that roadmap requires:
-from the irreducibility and weight arguments together with the density of the character span, not
-by reading a classification off Peter-Weyl.
+`TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`. The route taken is the
+character-theoretic one, not the Lie-algebra highest-weight argument that the roadmap names; it
+runs on the irreducibility and weight results of `TauCeti/RepresentationTheory/SU2/Irreducible.lean`
+together with the density of the character span. It is not circular. Peter-Weyl is nowhere used;
+the density is Stone-Weierstrass applied to the Chebyshev recursion for `χ_d`; and the
+orthogonality relations invoked are the general compact-group ones of
+`TauCeti/RepresentationTheory/Compact/Character/Basic.lean`, which know nothing of `SU(2)`, rather
+than the concrete `SU(2)` orthonormality that is computed from the Weyl integration formula.
 
 * D. Bump, *Lie Groups*, 2nd ed., Springer GTM 225 (2013), Chapter 3.
 * T. Bröcker, T. tom Dieck, *Representations of Compact Lie Groups*, Springer GTM 98 (1985),

--- a/TauCeti/RepresentationTheory/SU2/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/SU2/Irreducible.lean
@@ -132,7 +132,7 @@ private theorem repr_symPower_mixElement_weightBasis_last_ne_zero (i : Fin (d + 
     (weightBasis d).repr (symPower d mixElement (weightBasis d i)) (Fin.last d) ≠ 0 := by
   obtain ⟨f, hf⟩ := exists_weightBasis_eq_tprod d i
   rw [hf, weightBasis_eq_reindex, Basis.repr_reindex_apply, symFinTwoEquiv_symm_last,
-    symPower_tprod, coe_mixElement, SymmetricPower.repr_basis_symmetricPower_tprod_ofFn_const]
+    symPower_apply_tprod, coe_mixElement, SymmetricPower.repr_basis_symmetricPower_tprod_ofFn_const]
   exact Finset.prod_ne_zero_iff.2 fun j _ => by
     rw [repr_mulVec_basisFun]; exact mixMatrix_apply_ne_zero 0 (f j)
 
@@ -145,7 +145,7 @@ private theorem repr_symPower_mixElement_weightBasis_last_ne_zero' (i : Fin (d +
       ⨂ₛ[ℂ] (_ : Fin d), Pi.basisFun ℂ (Fin 2) 0 := by
     rw [weightBasis_apply, symFinTwoEquiv_symm_last, Basis.symmetricPower_apply,
       SymmetricPower.tprodOfSym_ofFn]
-  rw [hf, weightBasis_eq_reindex, Basis.repr_reindex_apply, symPower_tprod, coe_mixElement]
+  rw [hf, weightBasis_eq_reindex, Basis.repr_reindex_apply, symPower_apply_tprod, coe_mixElement]
   exact SymmetricPower.repr_basis_symmetricPower_tprod_const_ne_zero _
     (fun l => by rw [repr_mulVec_basisFun]; exact mixMatrix_apply_ne_zero l 0) _
 

--- a/TauCeti/RepresentationTheory/SU2/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/SU2/Irreducible.lean
@@ -47,7 +47,8 @@ this file, as `TauCeti.SU2.genericTorus` does in the weight file.
   same degree, so the `Symᵈ(ℂ²)` are pairwise inequivalent.
 
 Exhaustion -- that every finite-dimensional irreducible representation of `SU(2)` is one of these
--- is *not* proved here; it is the remaining half of the classification.
+-- is *not* proved here; it is the remaining half of the classification, and is
+`TauCeti/RepresentationTheory/SU2/Exhaustion.lean`.
 
 ## References
 
@@ -98,12 +99,6 @@ private noncomputable def mixElement : SU2 := ⟨mixMatrix, mixMatrix_mem⟩
 private theorem coe_mixElement :
     (mixElement : Matrix (Fin 2) (Fin 2) ℂ) = mixMatrix := (rfl)
 
-/-- The rotation acts on a pure symmetric tensor factor by factor. -/
-private theorem symPower_mixElement_tprod (v : Fin d → (Fin 2 → ℂ)) :
-    symPower d mixElement (⨂ₛ[ℂ] i, v i) = ⨂ₛ[ℂ] i, mixMatrix *ᵥ v i := by
-  simp only [symPower_apply, symPowerRep, Representation.symmetricPower_apply_tprod,
-    stdRep_apply_apply, coe_toGL, coe_mixElement]
-
 /-- The coordinates of the image of a standard basis vector are the entries of the matrix. -/
 private theorem repr_mulVec_basisFun (A : Matrix (Fin 2) (Fin 2) ℂ) (k l : Fin 2) :
     (Pi.basisFun ℂ (Fin 2)).repr (A *ᵥ Pi.basisFun ℂ (Fin 2) k) l = A l k := by
@@ -127,13 +122,6 @@ private theorem symFinTwoEquiv_symm_last :
   rw [coe_symFinTwoEquiv_symm_apply, TauCeti.Sym.coe_ofFn, List.ofFn_const, Multiset.coe_replicate]
   simp
 
-/-- Every weight vector is a pure symmetric tensor of standard basis vectors. -/
-private theorem exists_weightBasis_eq_tprod (i : Fin (d + 1)) :
-    ∃ f : Fin d → Fin 2, weightBasis d i = ⨂ₛ[ℂ] j, Pi.basisFun ℂ (Fin 2) (f j) := by
-  obtain ⟨f, hf⟩ := TauCeti.Sym.ofFn_surjective ((symFinTwoEquiv d).symm i)
-  exact ⟨f, by rw [weightBasis_apply, ← hf, Basis.symmetricPower_apply,
-    SymmetricPower.tprodOfSym_ofFn]⟩
-
 /-! ### The rotated weight vectors have nonzero coordinates -/
 
 /-- **The image of a weight vector has a nonzero coordinate at the highest weight.**  The highest
@@ -144,7 +132,7 @@ private theorem repr_symPower_mixElement_weightBasis_last_ne_zero (i : Fin (d + 
     (weightBasis d).repr (symPower d mixElement (weightBasis d i)) (Fin.last d) ≠ 0 := by
   obtain ⟨f, hf⟩ := exists_weightBasis_eq_tprod d i
   rw [hf, weightBasis_eq_reindex, Basis.repr_reindex_apply, symFinTwoEquiv_symm_last,
-    symPower_mixElement_tprod, SymmetricPower.repr_basis_symmetricPower_tprod_ofFn_const]
+    symPower_tprod, coe_mixElement, SymmetricPower.repr_basis_symmetricPower_tprod_ofFn_const]
   exact Finset.prod_ne_zero_iff.2 fun j _ => by
     rw [repr_mulVec_basisFun]; exact mixMatrix_apply_ne_zero 0 (f j)
 
@@ -157,7 +145,7 @@ private theorem repr_symPower_mixElement_weightBasis_last_ne_zero' (i : Fin (d +
       ⨂ₛ[ℂ] (_ : Fin d), Pi.basisFun ℂ (Fin 2) 0 := by
     rw [weightBasis_apply, symFinTwoEquiv_symm_last, Basis.symmetricPower_apply,
       SymmetricPower.tprodOfSym_ofFn]
-  rw [hf, weightBasis_eq_reindex, Basis.repr_reindex_apply, symPower_mixElement_tprod]
+  rw [hf, weightBasis_eq_reindex, Basis.repr_reindex_apply, symPower_tprod, coe_mixElement]
   exact SymmetricPower.repr_basis_symmetricPower_tprod_const_ne_zero _
     (fun l => by rw [repr_mulVec_basisFun]; exact mixMatrix_apply_ne_zero l 0) _
 

--- a/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
@@ -102,7 +102,7 @@ theorem symPower_apply (g : SU2) : symPower d g = symPowerRep ℂ 2 d (toGL g) :
 
 /-- **The action on a pure symmetric tensor is factor by factor**: `g` multiplies each factor of
 `v₁ ⊙ ⋯ ⊙ v_d` by its own matrix. -/
-theorem symPower_tprod (g : SU2) (v : Fin d → (Fin 2 → ℂ)) :
+theorem symPower_apply_tprod (g : SU2) (v : Fin d → (Fin 2 → ℂ)) :
     symPower d g (⨂ₛ[ℂ] i, v i) = ⨂ₛ[ℂ] i, (g : Matrix (Fin 2) (Fin 2) ℂ) *ᵥ v i := by
   simp only [symPower_apply, symPowerRep, Representation.symmetricPower_apply_tprod,
     stdRep_apply_apply, coe_toGL]

--- a/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SU2/SymmetricPower.lean
@@ -100,6 +100,13 @@ noncomputable def symPower : Representation ℂ SU2 (Sym[ℂ]^d (Fin 2 → ℂ))
 @[simp]
 theorem symPower_apply (g : SU2) : symPower d g = symPowerRep ℂ 2 d (toGL g) := (rfl)
 
+/-- **The action on a pure symmetric tensor is factor by factor**: `g` multiplies each factor of
+`v₁ ⊙ ⋯ ⊙ v_d` by its own matrix. -/
+theorem symPower_tprod (g : SU2) (v : Fin d → (Fin 2 → ℂ)) :
+    symPower d g (⨂ₛ[ℂ] i, v i) = ⨂ₛ[ℂ] i, (g : Matrix (Fin 2) (Fin 2) ℂ) *ᵥ v i := by
+  simp only [symPower_apply, symPowerRep, Representation.symmetricPower_apply_tprod,
+    stdRep_apply_apply, coe_toGL]
+
 /-- **The space `Symᵈ(ℂ²)` carrying `TauCeti.SU2.symPower d` has dimension `d + 1`**: a symmetric
 power of a free module is free on the unordered tuples of basis indices, of which there are
 `Nat.multichoose 2 d = d + 1` in two variables. -/

--- a/TauCeti/RepresentationTheory/SU2/Weight.lean
+++ b/TauCeti/RepresentationTheory/SU2/Weight.lean
@@ -91,6 +91,14 @@ theorem weightBasis_apply (i : Fin (d + 1)) :
       (Pi.basisFun ℂ (Fin 2)).symmetricPower d ((symFinTwoEquiv d).symm i) :=
   Module.Basis.reindex_apply _ _ _
 
+/-- **Every weight vector is a pure symmetric tensor of standard basis vectors**: some ordering of
+the unordered tuple indexing it lists its factors. -/
+theorem exists_weightBasis_eq_tprod (i : Fin (d + 1)) :
+    ∃ f : Fin d → Fin 2, weightBasis d i = ⨂ₛ[ℂ] j, Pi.basisFun ℂ (Fin 2) (f j) := by
+  obtain ⟨f, hf⟩ := TauCeti.Sym.ofFn_surjective ((symFinTwoEquiv d).symm i)
+  exact ⟨f, by rw [weightBasis_apply, ← hf, Module.Basis.symmetricPower_apply,
+    SymmetricPower.tprodOfSym_ofFn]⟩
+
 /-- **The weight** of the `i`-th weight vector: the torus element `diag(z, z⁻¹)` acts on it by
 `z^{2i - d}`.  As `i` runs over `Fin (d + 1)` these are the `d + 1` integers
 `-d, 2 - d, …, d - 2, d`. -/


### PR DESCRIPTION
This PR proves that the symmetric powers `Symᵈ(ℂ²)` of the standard representation exhaust the finite-dimensional irreducible continuous representations of `SU(2)`: every such representation is equivalent to `Symᵈ(ℂ²)` for exactly one `d`, so `d ↦ Symᵈ(ℂ²)` is a bijection from `ℕ` onto the isomorphism classes. Unitarity is not assumed; Weyl's unitarian trick, already on `main` as `TauCeti.ContRepresentation.exists_isUnitary_congr`, discharges it.

The argument is the classical one. An irreducible `π` not in the list is, by Schur's lemma, joined to no `Symᵈ(ℂ²)` by a nonzero intertwiner, so the second character orthogonality relation makes its character orthogonal in `L²(SU(2))` to every `χ_d`. Pairing with `χ_π` is a continuous functional on `C(SU(2), ℂ)`, so it kills the whole uniform closure of the span of the `χ_d`, which `TauCeti.SU2.mem_topologicalClosure_characterSpan_iff` identifies with the continuous class functions; but `χ_π` lies there and pairs with itself to `1`.

What that deduction needed, and what most of the diff supplies, is the packaging step: the general orthogonality relations of `TauCeti/RepresentationTheory/Compact/Character/Basic.lean` speak about a `ContRepresentation` on a normed space, whereas `Symᵈ(ℂ²)` is a symmetric tensor power and carries no topology at all. So the weight basis carries the symmetric power onto the standard model `ℂ^{d+1}` as `TauCeti.SU2.symPowerModel`, and the transported action is proved continuous. That is the one genuinely analytic step: a group element acts on a pure symmetric tensor factor by factor, so the action factors through the multilinear `⨂ₛ`, and multilinear maps on finitely many finite-dimensional spaces are continuous. That last fact is the general lemma `TauCeti.MultilinearMap.continuous_of_finiteDimensional`, the multilinear companion of `LinearMap.continuous_of_finiteDimensional`, which Mathlib does not have: `MultilinearMap.continuous_of_bound` asks for an explicit bound, which a construction arriving from algebra does not carry. Expanding an arbitrary vector in the weight basis extends continuity from pure tensors to all of `Symᵈ(ℂ²)`.

`SU(2)` also had no measurable structure, so `TauCeti/RepresentationTheory/SU2/Borel.lean` gives it its Borel σ-algebra by definition, which is what makes `haarProb SU(2)` and the `L²` theory applicable to it.

Unitarity of `Symᵈ(ℂ²)` itself is not claimed. The transported model carries the inner product making the weight basis orthonormal, which for `d ≥ 2` is not the `SU(2)`-invariant one, and no weakened stand-in for an invariant form is introduced; the orthogonality relation used here asks for unitarity only of the representation being tested.

The milestone is the `SU(2)` engine case of `RepresentationTheory/CompactGroups/README.md`, whose target `su2Irrep_exhaust` -- "they **exhaust** the finite-dimensional irreducibles: every finite-dimensional unitary irreducible admits a nonzero intertwiner from some `su2Irrep n`, hence by Schur is isomorphic to it" -- this PR proves, from the weight and irreducibility arguments plus the density of the character span. The route is the character-theoretic one, not the Lie-algebra highest-weight argument the roadmap names; the module docstring says so. It is not circular, and it runs in the direction the roadmap's ordering section fixes: that section places the engine case "alongside Layers 3-6" and asks only that the general layers not consume the classification ("its exhaustion statement is not an acceptance criterion for the general layers"). Accordingly the import closure of `Exhaustion.lean` meets `TauCeti/RepresentationTheory/Compact/` in Layers 0, 1, 3, 4 and 6 only, never Layer 5 (`Compact/PeterWeyl.lean` is absent), and no file under `Compact/` mentions `SU(2)` at all. The character orthonormality the roadmap reserves for validation after the classification is the concrete `su2Character_orthonormal`, computed through the Weyl integration formula; that statement is still open on `main`, and `SU2/Weyl/Orthogonality.lean`, which holds its torus half, is not imported here. What is used instead is the general compact-group pair `character_orthonormal_self` and `character_orthonormal_distinct`, which mention `SU(2)` nowhere. Its two inputs are `TauCeti.SU2.isIrreducible_symPower` with `TauCeti.SU2.nonempty_equiv_symPower_iff`, and the density of https://github.com/TauCetiProject/TauCeti/pull/5282 (feat: the characters of the symmetric powers span the class functions of SU(2)), which named this exhaustion and this packaging as exactly what remained. What remains on the engine case after this PR is the general `weyl_integration_formula` for a class function on `SU(2)`; only its normalization `TauCeti.SU2.weyl_integration_formula_normalized` is on `main`.

Three existing declarations move rather than being duplicated. `TauCeti.SU2.symPower_tprod`, that a group element acts on a pure symmetric tensor factor by factor, replaces the private special case `symPower_mixElement_tprod` of `Irreducible.lean`; `TauCeti.SU2.exists_weightBasis_eq_tprod` moves from `Irreducible.lean`, where it was private, to `Weight.lean`, whose subject it is; and `TauCeti.SU2.characterSpan_le_iff` is the characteristic property of the span, added because the body of `characterSpan` is not exposed outside its own module.

Roadmap: RepresentationTheory

No Mathlib material is vendored. The mathematical development follows D. Bump, *Lie Groups*, 2nd ed., Springer GTM 225 (2013), Chapter 3, and T. Bröcker and T. tom Dieck, *Representations of Compact Lie Groups*, Springer GTM 98 (1985), Chapter II, §4-5.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"su2irrep-exhaust"}-->

🤖 Prepared with Claude Code

