### PR TITLE
feat: an indecomposable quiver representation is determined by its dimension vector

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
@@ -48,9 +48,10 @@ dichotomy for indecomposables is supplied by
   representation is carried to the zero representation.
 * `TauCeti.isFinDim_reflectionFunctorList_obj` and `TauCeti.isFinDim_coxeterFunctor_obj`:
   pointwise finite-dimensional vertex spaces stay finite-dimensional.
-* `TauCeti.isZero_coxeterFunctor_obj_iff_isZero_reflectionFunctorList_obj`: the Coxeter functor and
-  the composite it transports annihilate the same representations, so a statement about the
-  endofunctor may be proved one reflection at a time.
+* `TauCeti.isZero_coxeterFunctor_obj_iff_isZero_reflectionFunctorList_obj` and
+  `TauCeti.nonempty_iso_coxeterFunctor_obj_iff`: the Coxeter functor and the composite it
+  transports annihilate the same representations and identify the same pairs of them, so a
+  statement about the endofunctor may be proved one reflection at a time.
 * `TauCeti.indecomposable_and_dimVector_reflectionFunctorList_or_isZero` and
   `TauCeti.indecomposable_and_dimVector_coxeterFunctor_or_isZero`: the dichotomy above, for a
   general sink-admissible list and for the Coxeter functor.
@@ -302,6 +303,15 @@ private theorem indecomposable_transportCodomain_obj {q r : _root_.Quiver.{w} V}
   exact Iff.rfl
 
 omit fV in
+private theorem nonempty_iso_transportCodomain_obj {q r : _root_.Quiver.{w} V} (h : r = q)
+    (F : @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld r)
+    (M N : @QuiverRep.{u, v, w, max v w x} k V fld q) :
+    Nonempty ((transportCodomain h F).obj M ≅ (transportCodomain h F).obj N)
+      ↔ Nonempty (F.obj M ≅ F.obj N) := by
+  subst h
+  exact Iff.rfl
+
+omit fV in
 private theorem isZero_transportCodomain_obj {q r : _root_.Quiver.{w} V} (h : r = q)
     (F : @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld r)
     (M : @QuiverRep.{u, v, w, max v w x} k V fld q) :
@@ -402,6 +412,21 @@ theorem isZero_coxeterFunctor_obj_iff_isZero_reflectionFunctorList_obj (q : _roo
     Limits.IsZero ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M)
       ↔ Limits.IsZero ((reflectionFunctorList k l q hq hl).obj M) :=
   isZero_transportCodomain_obj _ _ M
+
+/-- **The Coxeter functor identifies two representations exactly when the reflection-functor
+composite along the ordering does.** Like
+`TauCeti.isZero_coxeterFunctor_obj_iff_isZero_reflectionFunctorList_obj`, this only undoes the
+transport of the codomain, so that an isomorphism of Coxeter images may be descended one
+reflection at a time. -/
+theorem nonempty_iso_coxeterFunctor_obj_iff (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
+    (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)
+    (M N : @QuiverRep.{u, v, w, max v w x} k V fld q) :
+    Nonempty ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M
+        ≅ (coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj N)
+      ↔ Nonempty ((reflectionFunctorList k l q hq hl).obj M
+        ≅ (reflectionFunctorList k l q hq hl).obj N) :=
+  nonempty_iso_transportCodomain_obj _ _ M N
 
 /-- **The Coxeter functor annihilates the zero representation.** -/
 theorem isZero_coxeterFunctor_obj (q : _root_.Quiver.{w} V)

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
@@ -49,9 +49,10 @@ dichotomy for indecomposables is supplied by
 * `TauCeti.isFinDim_reflectionFunctorList_obj` and `TauCeti.isFinDim_coxeterFunctor_obj`:
   pointwise finite-dimensional vertex spaces stay finite-dimensional.
 * `TauCeti.isZero_coxeterFunctor_obj_iff_isZero_reflectionFunctorList_obj` and
-  `TauCeti.nonempty_iso_coxeterFunctor_obj_iff`: the Coxeter functor and the composite it
-  transports annihilate the same representations and identify the same pairs of them, so a
-  statement about the endofunctor may be proved one reflection at a time.
+  `TauCeti.nonempty_iso_coxeterFunctor_obj_iff_nonempty_iso_reflectionFunctorList_obj`: the
+  Coxeter functor and the composite it transports annihilate the same representations and identify
+  the same pairs of them, so a statement about the endofunctor may be proved one reflection at a
+  time.
 * `TauCeti.indecomposable_and_dimVector_reflectionFunctorList_or_isZero` and
   `TauCeti.indecomposable_and_dimVector_coxeterFunctor_or_isZero`: the dichotomy above, for a
   general sink-admissible list and for the Coxeter functor.
@@ -418,7 +419,8 @@ composite along the ordering does.** Like
 `TauCeti.isZero_coxeterFunctor_obj_iff_isZero_reflectionFunctorList_obj`, this only undoes the
 transport of the codomain, so that an isomorphism of Coxeter images may be descended one
 reflection at a time. -/
-theorem nonempty_iso_coxeterFunctor_obj_iff (q : _root_.Quiver.{w} V)
+theorem nonempty_iso_coxeterFunctor_obj_iff_nonempty_iso_reflectionFunctorList_obj
+    (q : _root_.Quiver.{w} V)
     (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
     (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)
     (M N : @QuiverRep.{u, v, w, max v w x} k V fld q) :

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/FullyFaithful.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/FullyFaithful.lean
@@ -47,6 +47,8 @@ finite-dimensionality is needed for that. It is needed for the other half of the
 * `TauCeti.reflectionFunctor_map_injective`, `TauCeti.reflectionFunctor_map_surjective` and
   `TauCeti.reflectionFunctor_map_bijective`: **the reflection functor at a sink is fully faithful**
   on the representations whose incoming sum there is onto.
+* `TauCeti.nonempty_iso_of_nonempty_iso_reflectRep`: **the reflection functor at a sink reflects
+  isomorphisms** between representations whose incoming sums there are onto.
 * `TauCeti.indecomposable_reflectRep`: **reflection at a sink preserves indecomposability**, under
   the same hypothesis.
 * `TauCeti.indecomposable_reflectRep_of_not_nonempty_iso_simpleRep`: the same statement with the
@@ -375,6 +377,33 @@ every indecomposable representation other than the vertex simple `Sᵢ`. -/
 theorem reflectionFunctor_map_bijective (hs : Function.Surjective (incomingSum M i)) :
     Function.Bijective fun η : M ⟶ N ↦ (reflectionFunctor i hi).map η :=
   ⟨reflectionFunctor_map_injective hi hs, reflectionFunctor_map_surjective hi hs⟩
+
+/-- **The reflection functor at a sink reflects isomorphisms**, between representations whose
+incoming sums there are onto. Fullness produces morphisms `f : M ⟶ N` and `g : N ⟶ M` reflecting
+to the two halves of the given isomorphism, and faithfulness turns the two triangle identities
+downstairs into the two upstairs.
+
+The reflection functor is not fully faithful on all of `TauCeti.QuiverRep k Q` -- it annihilates
+the vertex simple at `i` -- so `CategoryTheory.Functor.ReflectsIsomorphisms` and the machinery
+around it, which ask for `Full` and `Faithful` instances, do not apply, and the argument is made
+directly from `TauCeti.reflectionFunctor_map_surjective` and
+`TauCeti.reflectionFunctor_map_injective`. -/
+theorem nonempty_iso_of_nonempty_iso_reflectRep
+    (hsM : Function.Surjective (incomingSum M i))
+    (hsN : Function.Surjective (incomingSum N i))
+    (h : Nonempty (reflectRep M hi ≅ reflectRep N hi)) : Nonempty (M ≅ N) := by
+  obtain ⟨θ⟩ := h
+  have θ' : (reflectionFunctor i hi).obj M ≅ (reflectionFunctor i hi).obj N :=
+    eqToIso (reflectionFunctor_obj i hi M) ≪≫ θ ≪≫ eqToIso (reflectionFunctor_obj i hi N).symm
+  obtain ⟨f, hf⟩ := reflectionFunctor_map_surjective (M := M) (N := N) hi hsM θ'.hom
+  obtain ⟨g, hg⟩ := reflectionFunctor_map_surjective (M := N) (N := M) hi hsN θ'.inv
+  refine ⟨⟨f, g, ?_, ?_⟩⟩
+  · refine reflectionFunctor_map_injective (M := M) (N := M) hi hsM ?_
+    simp only [Functor.map_comp, hf, hg]
+    exact θ'.hom_inv_id.trans ((reflectionFunctor i hi).map_id M).symm
+  · refine reflectionFunctor_map_injective (M := N) (N := N) hi hsN ?_
+    simp only [Functor.map_comp, hf, hg]
+    exact θ'.inv_hom_id.trans ((reflectionFunctor i hi).map_id N).symm
 
 /-- **Reflection at a sink preserves indecomposability**, as soon as the sum of the arrows into the
 sink is onto. Reflection is additive and bijective on the endomorphisms of `M`, so it matches the

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Representation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Representation.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.RepresentationTheory.Quiver.Reflection.Basic
 public import TauCeti.RepresentationTheory.Quiver.Reflection.DimensionVector
 public import TauCeti.RepresentationTheory.Quiver.Representation.DimensionVector
+public import TauCeti.RepresentationTheory.Quiver.Representation.FiniteDimensional
 public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 import Mathlib.CategoryTheory.PathCategory.MorphismProperty
 
@@ -70,6 +71,10 @@ representation concentrated at `i` whose space at `i` is nontrivial, of which th
   every vertex and on the whole reflection.
 * `TauCeti.finiteDimensional_reflectRep_obj`: reflection preserves finite-dimensionality of the
   vertex spaces.
+* `TauCeti.nonempty_iso_of_isZero_away_of_linearEquiv` and
+  `TauCeti.nonempty_iso_of_dimVector_eq_of_forall_subsingleton`: two representations concentrated
+  at the same sink are isomorphic as soon as their vertex spaces there are, respectively as soon
+  as their dimension vectors agree.
 
 ## Implementation notes
 
@@ -799,5 +804,69 @@ theorem dimVector_reflectRep_self_eq_zero {i : Q} (hi : IsSink i)
   exact Module.finrank_zero_of_subsingleton (R := k)
 
 end Concentrated
+
+/-! ### Comparing two representations concentrated at the same sink -/
+
+section ConcentratedComparison
+
+variable {M N : QuiverRep.{u, v, w, max v w x} k Q} {i : Q}
+
+/-- **Two representations vanishing away from a sink are isomorphic as soon as their vertex spaces
+at that sink are.** Every component away from `i` is a map between zero objects, and there is no
+naturality condition to check at `i`, since no arrow leaves a sink. -/
+theorem nonempty_iso_of_isZero_away_of_linearEquiv (hi : IsSink i)
+    (hM : ∀ a : Q, a ≠ i → Limits.IsZero (M.obj a))
+    (hN : ∀ a : Q, a ≠ i → Limits.IsZero (N.obj a))
+    (e : M.obj ((Paths.of Q).obj i) ≃ₗ[k] N.obj ((Paths.of Q).obj i)) :
+    Nonempty (M ≅ N) := by
+  classical
+  have eIso : M.obj ((Paths.of Q).obj i) ≅ N.obj ((Paths.of Q).obj i) := e.toModuleIso
+  refine ⟨NatIso.ofComponents (fun a ↦ if h : a = (Paths.of Q).obj i then
+      eqToIso (congrArg M.obj h) ≪≫ eIso ≪≫ eqToIso (congrArg N.obj h).symm
+    else (hM a h).iso (hN a h)) fun {a b} p ↦ ?_⟩
+  by_cases ha : a = (Paths.of Q).obj i
+  · -- a path out of a sink is the identity, so the naturality square is trivial
+    subst ha
+    obtain rfl := hi.eq_of_path p
+    have hMp : M.map p = 𝟙 (M.obj a) := by
+      rw [hi.path_self_eq_nil p]
+      exact M.map_id a
+    have hNp : N.map p = 𝟙 (N.obj a) := by
+      rw [hi.path_self_eq_nil p]
+      exact N.map_id a
+    rw [hMp, hNp]
+    simp
+  · exact (hM a ha).eq_of_src _ _
+
+/-- **A representation concentrated at a sink is isomorphic to every finite-dimensional
+representation with the same dimension vector.** Equality of dimension vectors makes the comparison
+representation vanish wherever `M` does, and matches the two vertex spaces at the sink. Only the
+vertex space of `M` at the sink is asked to be finite-dimensional, since `M` is a subsingleton
+everywhere else; `N` is asked for it at every vertex, to read a vanishing dimension vector there as
+a vanishing vertex space. -/
+theorem nonempty_iso_of_dimVector_eq_of_forall_subsingleton (hi : IsSink i)
+    (hsub : ∀ a : Q, a ≠ i → Subsingleton (M.obj a))
+    (hfdM : FiniteDimensional k (M.obj ((Paths.of Q).obj i)))
+    (hfdN : IsFinDim.{u, v, w, max v w x} k Q N)
+    (hd : dimVector M = dimVector N) : Nonempty (M ≅ N) := by
+  have hfdN' := isFinDim_iff.mp hfdN
+  have hNzero : ∀ a : Q, a ≠ i → Limits.IsZero (N.obj a) := by
+    intro a ha
+    have hMa : Subsingleton (M.obj ((Paths.of Q).obj a)) := hsub a ha
+    have hfdNa := hfdN' ((Paths.of Q).obj a)
+    have h0 : Module.finrank k (N.obj ((Paths.of Q).obj a)) = 0 := by
+      rw [← dimVector_apply, ← congrFun hd a, dimVector_apply]
+      exact Module.finrank_zero_of_subsingleton (R := k)
+    have hss : Subsingleton (N.obj ((Paths.of Q).obj a)) := Module.finrank_zero_iff.mp h0
+    exact @ModuleCat.isZero_of_subsingleton k _ (N.obj a) hss
+  have hfdNi := hfdN' ((Paths.of Q).obj i)
+  have hfr : Module.finrank k (M.obj ((Paths.of Q).obj i))
+      = Module.finrank k (N.obj ((Paths.of Q).obj i)) := by
+    rw [← dimVector_apply, ← dimVector_apply, hd]
+  exact nonempty_iso_of_isZero_away_of_linearEquiv hi
+    (fun a ha ↦ @ModuleCat.isZero_of_subsingleton k _ (M.obj a) (hsub a ha)) hNzero
+    (LinearEquiv.ofFinrankEq _ _ hfr)
+
+end ConcentratedComparison
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Uniqueness.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Uniqueness.lean
@@ -32,7 +32,8 @@ this is `TauCeti.nonempty_iso_of_nonempty_iso_reflectRep`. An indecomposable rep
 that hypothesis only by being concentrated at `i`
 (`TauCeti.incomingSum_surjective_or_forall_subsingleton`), and a representation with the same
 dimension vector then vanishes wherever it does and has a vertex space of the same dimension at
-`i`; two such representations are isomorphic, by `TauCeti.nonempty_iso_of_isZero_of_ne`.
+`i`; two such representations are isomorphic, by
+`TauCeti.nonempty_iso_of_isZero_away_of_linearEquiv`.
 
 The comparison at such a stage is made directly, rather than through the vertex simple `Sᵢ` and
 `TauCeti.nonempty_iso_simpleRep_of_forall_subsingleton`: the vertex space of `Sᵢ` is the field
@@ -48,8 +49,8 @@ where it is concentrated at the sink.
 
 ## Main results
 
-* `TauCeti.nonempty_iso_of_isZero_of_ne`: two representations vanishing away from a sink are
-  isomorphic as soon as their vertex spaces at that sink are, and
+* `TauCeti.nonempty_iso_of_isZero_away_of_linearEquiv`: two representations vanishing away from a
+  sink are isomorphic as soon as their vertex spaces at that sink are, and
   `TauCeti.nonempty_iso_of_dimVector_eq_of_forall_subsingleton`: the same conclusion from equality
   of dimension vectors.
 * `TauCeti.nonempty_iso_of_nonempty_iso_reflectRep`: **the reflection functor at a sink reflects
@@ -89,7 +90,7 @@ variable {M N : QuiverRep.{u, v, w, max v w x} k Q} {i : Q}
 /-- **Two representations vanishing away from a sink are isomorphic as soon as their vertex spaces
 at that sink are.** Every component away from `i` is a map between zero objects, and there is no
 naturality condition to check at `i`, since no arrow leaves a sink. -/
-theorem nonempty_iso_of_isZero_of_ne (hi : IsSink i)
+theorem nonempty_iso_of_isZero_away_of_linearEquiv (hi : IsSink i)
     (hM : ∀ a : Q, a ≠ i → Limits.IsZero (M.obj a))
     (hN : ∀ a : Q, a ≠ i → Limits.IsZero (N.obj a))
     (e : M.obj ((Paths.of Q).obj i) ≃ₗ[k] N.obj ((Paths.of Q).obj i)) :
@@ -119,12 +120,15 @@ theorem nonempty_iso_of_isZero_of_ne (hi : IsSink i)
 
 /-- **A representation concentrated at a sink is isomorphic to every finite-dimensional
 representation with the same dimension vector.** Equality of dimension vectors makes the comparison
-representation vanish wherever `M` does, and matches the two vertex spaces at the sink. -/
+representation vanish wherever `M` does, and matches the two vertex spaces at the sink. Only the
+vertex space of `M` at the sink is asked to be finite-dimensional, since `M` is a subsingleton
+everywhere else; `N` is asked for it at every vertex, to read a vanishing dimension vector there as
+a vanishing vertex space. -/
 theorem nonempty_iso_of_dimVector_eq_of_forall_subsingleton (hi : IsSink i)
     (hsub : ∀ a : Q, a ≠ i → Subsingleton (M.obj a))
-    (hfdM : IsFinDim.{u, v, w, max v w x} k Q M) (hfdN : IsFinDim.{u, v, w, max v w x} k Q N)
+    (hfdM : FiniteDimensional k (M.obj ((Paths.of Q).obj i)))
+    (hfdN : IsFinDim.{u, v, w, max v w x} k Q N)
     (hd : dimVector M = dimVector N) : Nonempty (M ≅ N) := by
-  have hfdM' := isFinDim_iff.mp hfdM
   have hfdN' := isFinDim_iff.mp hfdN
   have hNzero : ∀ a : Q, a ≠ i → Limits.IsZero (N.obj a) := by
     intro a ha
@@ -135,12 +139,11 @@ theorem nonempty_iso_of_dimVector_eq_of_forall_subsingleton (hi : IsSink i)
       exact Module.finrank_zero_of_subsingleton (R := k)
     have hss : Subsingleton (N.obj ((Paths.of Q).obj a)) := Module.finrank_zero_iff.mp h0
     exact @ModuleCat.isZero_of_subsingleton k _ (N.obj a) hss
-  have hfdMi := hfdM' ((Paths.of Q).obj i)
   have hfdNi := hfdN' ((Paths.of Q).obj i)
   have hfr : Module.finrank k (M.obj ((Paths.of Q).obj i))
       = Module.finrank k (N.obj ((Paths.of Q).obj i)) := by
     rw [← dimVector_apply, ← dimVector_apply, hd]
-  exact nonempty_iso_of_isZero_of_ne hi
+  exact nonempty_iso_of_isZero_away_of_linearEquiv hi
     (fun a ha ↦ @ModuleCat.isZero_of_subsingleton k _ (M.obj a) (hsub a ha)) hNzero
     (LinearEquiv.ofFinrankEq _ _ hfr)
 
@@ -196,7 +199,7 @@ isomorphism through `TauCeti.nonempty_iso_of_nonempty_iso_reflectRep`; a stage a
 concentrated at its own sink identifies the two on the spot, by
 `TauCeti.nonempty_iso_of_dimVector_eq_of_forall_subsingleton`. The empty list leaves the hypothesis
 itself, whose second alternative an indecomposable representation excludes. -/
-theorem nonempty_iso_of_dimVector_eq_of_reflectionFunctorList :
+private theorem nonempty_iso_of_dimVector_eq_of_reflectionFunctorList :
     ∀ (l : List V) (q : _root_.Quiver.{w} V)
       (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
       (hl : Quiver.IsSinkAdmissible q l)
@@ -245,10 +248,10 @@ theorem nonempty_iso_of_dimVector_eq_of_reflectionFunctorList :
             ((@isFinDim_iff.{u, v, w, max v w x} k V fld (Quiver.reflectAt q i) _).mpr
               (finiteDimensional_reflectRep_obj N hi hfdN')) hdR hyp
         · -- `N` is concentrated at the sink, hence so is `M`
-          exact (nonempty_iso_of_dimVector_eq_of_forall_subsingleton hi hsubN hfdN hfdM
+          exact (nonempty_iso_of_dimVector_eq_of_forall_subsingleton hi hsubN (hfdN' i) hfdM
             hd.symm).map Iso.symm
       · -- `M` is concentrated at the sink, hence so is `N`
-        exact nonempty_iso_of_dimVector_eq_of_forall_subsingleton hi hsubM hfdM hfdN hd
+        exact nonempty_iso_of_dimVector_eq_of_forall_subsingleton hi hsubM (hfdM' i) hfdN hd
 
 /-! ### Uniqueness -/
 
@@ -295,8 +298,10 @@ private theorem nonempty_iso_of_dimVector_eq_of_isZero_iterate
           funext fun j ↦ Nat.cast_inj.mp (congrFun hcast j)
         have hiso := ih _ _ hM1 hN1 (isFinDim_coxeterFunctor_obj q hq hnd hall hl M hfdM)
           (isFinDim_coxeterFunctor_obj q hq hnd hall hl N hfdN) hdC hz
+        have hlist := (nonempty_iso_coxeterFunctor_obj_iff_nonempty_iso_reflectionFunctorList_obj
+          q hq hnd hall hl M N).mp hiso
         exact nonempty_iso_of_dimVector_eq_of_reflectionFunctorList l q hq hl M N hM hN hfdM
-          hfdN hd (Or.inl ((nonempty_iso_coxeterFunctor_obj_iff q hq hnd hall hl M N).mp hiso))
+          hfdN hd (Or.inl hlist)
       · exact (nonempty_iso_of_dimVector_eq_of_reflectionFunctorList l q hq hl N M hN hM hfdN
           hfdM hd.symm (Or.inr
             ((isZero_coxeterFunctor_obj_iff_isZero_reflectionFunctorList_obj q hq hnd hall hl

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Uniqueness.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Uniqueness.lean
@@ -49,12 +49,6 @@ where it is concentrated at the sink.
 
 ## Main results
 
-* `TauCeti.nonempty_iso_of_isZero_away_of_linearEquiv`: two representations vanishing away from a
-  sink are isomorphic as soon as their vertex spaces at that sink are, and
-  `TauCeti.nonempty_iso_of_dimVector_eq_of_forall_subsingleton`: the same conclusion from equality
-  of dimension vectors.
-* `TauCeti.nonempty_iso_of_nonempty_iso_reflectRep`: **the reflection functor at a sink reflects
-  isomorphisms** between representations whose incoming sums there are onto.
 * `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable`: **two finite-dimensional
   indecomposable representations with the same dimension vector are isomorphic**, with
   `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic` the same statement over an
@@ -79,108 +73,6 @@ open CategoryTheory
 open _root_.TauCeti.Quiver
 
 universe u v w x
-
-/-! ### Representations concentrated at a sink -/
-
-section Concentrated
-
-variable {k : Type u} {Q : Type v} [Field k] [Quiver.{w} Q]
-variable {M N : QuiverRep.{u, v, w, max v w x} k Q} {i : Q}
-
-/-- **Two representations vanishing away from a sink are isomorphic as soon as their vertex spaces
-at that sink are.** Every component away from `i` is a map between zero objects, and there is no
-naturality condition to check at `i`, since no arrow leaves a sink. -/
-theorem nonempty_iso_of_isZero_away_of_linearEquiv (hi : IsSink i)
-    (hM : ∀ a : Q, a ≠ i → Limits.IsZero (M.obj a))
-    (hN : ∀ a : Q, a ≠ i → Limits.IsZero (N.obj a))
-    (e : M.obj ((Paths.of Q).obj i) ≃ₗ[k] N.obj ((Paths.of Q).obj i)) :
-    Nonempty (M ≅ N) := by
-  classical
-  have eIso : M.obj ((Paths.of Q).obj i) ≅ N.obj ((Paths.of Q).obj i) := e.toModuleIso
-  refine ⟨NatIso.ofComponents (fun a ↦ if h : a = (Paths.of Q).obj i then
-      eqToIso (congrArg M.obj h) ≪≫ eIso ≪≫ eqToIso (congrArg N.obj h).symm
-    else (hM a h).iso (hN a h)) fun {a b} p ↦ ?_⟩
-  by_cases ha : a = (Paths.of Q).obj i
-  · -- a path out of a sink is the identity, so the naturality square is trivial
-    subst ha
-    obtain rfl := hi.eq_of_path p
-    have hMp : M.map p = 𝟙 (M.obj a) := by
-      rw [hi.path_self_eq_nil p]
-      exact M.map_id a
-    have hNp : N.map p = 𝟙 (N.obj a) := by
-      rw [hi.path_self_eq_nil p]
-      exact N.map_id a
-    rw [hMp, hNp]
-    simp
-  · exact (hM a ha).eq_of_src _ _
-
-/-- **A representation concentrated at a sink is isomorphic to every finite-dimensional
-representation with the same dimension vector.** Equality of dimension vectors makes the comparison
-representation vanish wherever `M` does, and matches the two vertex spaces at the sink. Only the
-vertex space of `M` at the sink is asked to be finite-dimensional, since `M` is a subsingleton
-everywhere else; `N` is asked for it at every vertex, to read a vanishing dimension vector there as
-a vanishing vertex space. -/
-theorem nonempty_iso_of_dimVector_eq_of_forall_subsingleton (hi : IsSink i)
-    (hsub : ∀ a : Q, a ≠ i → Subsingleton (M.obj a))
-    (hfdM : FiniteDimensional k (M.obj ((Paths.of Q).obj i)))
-    (hfdN : IsFinDim.{u, v, w, max v w x} k Q N)
-    (hd : dimVector M = dimVector N) : Nonempty (M ≅ N) := by
-  have hfdN' := isFinDim_iff.mp hfdN
-  have hNzero : ∀ a : Q, a ≠ i → Limits.IsZero (N.obj a) := by
-    intro a ha
-    have hMa : Subsingleton (M.obj ((Paths.of Q).obj a)) := hsub a ha
-    have hfdNa := hfdN' ((Paths.of Q).obj a)
-    have h0 : Module.finrank k (N.obj ((Paths.of Q).obj a)) = 0 := by
-      rw [← dimVector_apply, ← congrFun hd a, dimVector_apply]
-      exact Module.finrank_zero_of_subsingleton (R := k)
-    have hss : Subsingleton (N.obj ((Paths.of Q).obj a)) := Module.finrank_zero_iff.mp h0
-    exact @ModuleCat.isZero_of_subsingleton k _ (N.obj a) hss
-  have hfdNi := hfdN' ((Paths.of Q).obj i)
-  have hfr : Module.finrank k (M.obj ((Paths.of Q).obj i))
-      = Module.finrank k (N.obj ((Paths.of Q).obj i)) := by
-    rw [← dimVector_apply, ← dimVector_apply, hd]
-  exact nonempty_iso_of_isZero_away_of_linearEquiv hi
-    (fun a ha ↦ @ModuleCat.isZero_of_subsingleton k _ (M.obj a) (hsub a ha)) hNzero
-    (LinearEquiv.ofFinrankEq _ _ hfr)
-
-end Concentrated
-
-/-! ### Reflection at a sink reflects isomorphisms -/
-
-section Reflect
-
-variable {k : Type u} {Q : Type v} [Field k] [Quiver.{w} Q] [Fintype Q]
-  [∀ a b : Q, Fintype (a ⟶ b)]
-variable {M N : QuiverRep.{u, v, w, max v w x} k Q} {i : Q}
-
-/-- **The reflection functor at a sink reflects isomorphisms**, between representations whose
-incoming sums there are onto. Fullness produces morphisms `f : M ⟶ N` and `g : N ⟶ M` reflecting
-to the two halves of the given isomorphism, and faithfulness turns the two triangle identities
-downstairs into the two upstairs.
-
-The reflection functor is not fully faithful on all of `TauCeti.QuiverRep k Q` -- it annihilates
-the vertex simple at `i` -- so `CategoryTheory.Functor.ReflectsIsomorphisms` and the machinery
-around it, which ask for `Full` and `Faithful` instances, do not apply, and the argument is made
-directly from `TauCeti.reflectionFunctor_map_surjective` and
-`TauCeti.reflectionFunctor_map_injective`. -/
-theorem nonempty_iso_of_nonempty_iso_reflectRep (hi : IsSink i)
-    (hsM : Function.Surjective (incomingSum M i))
-    (hsN : Function.Surjective (incomingSum N i))
-    (h : Nonempty (reflectRep M hi ≅ reflectRep N hi)) : Nonempty (M ≅ N) := by
-  obtain ⟨θ⟩ := h
-  have θ' : (reflectionFunctor i hi).obj M ≅ (reflectionFunctor i hi).obj N :=
-    eqToIso (reflectionFunctor_obj i hi M) ≪≫ θ ≪≫ eqToIso (reflectionFunctor_obj i hi N).symm
-  obtain ⟨f, hf⟩ := reflectionFunctor_map_surjective (M := M) (N := N) hi hsM θ'.hom
-  obtain ⟨g, hg⟩ := reflectionFunctor_map_surjective (M := N) (N := M) hi hsN θ'.inv
-  refine ⟨⟨f, g, ?_, ?_⟩⟩
-  · refine reflectionFunctor_map_injective (M := M) (N := M) hi hsM ?_
-    simp only [Functor.map_comp, hf, hg]
-    exact θ'.hom_inv_id.trans ((reflectionFunctor i hi).map_id M).symm
-  · refine reflectionFunctor_map_injective (M := N) (N := N) hi hsN ?_
-    simp only [Functor.map_comp, hf, hg]
-    exact θ'.inv_hom_id.trans ((reflectionFunctor i hi).map_id N).symm
-
-end Reflect
 
 /-! ### Uniqueness along a sink-admissible list -/
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Uniqueness.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Uniqueness.lean
@@ -1,0 +1,358 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.Reflection.Root
+
+/-!
+# An indecomposable representation is determined by its dimension vector
+
+Let `Q` be a finite quiver whose Tits form is positive definite, the numerical side of the ADE
+condition in Gabriel's theorem. This file proves that two finite-dimensional indecomposable
+representations of `Q` with the same dimension vector are isomorphic
+(`TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable`), so that `TauCeti.dimVector` is
+injective on the isomorphism classes of indecomposables
+(`TauCeti.nonempty_iso_iff_dimVector_eq_of_indecomposable`).
+
+Together with `TauCeti.titsForm_dimVector_eq_one_of_indecomposable`, which says that the dimension
+vector of an indecomposable is a positive root of the Tits form, this is the injective half of the
+Gabriel correspondence: `M ↦ dim M` is an injection from the isomorphism classes of
+finite-dimensional indecomposables into the positive roots. Its surjectivity, that every positive
+root is realized, is not proved here.
+
+## The argument
+
+The Bernstein-Gelfand-Ponomarev induction is run at `M` and `N` in parallel. The reflection functor
+at a sink `i` is fully faithful on the representations whose incoming sum at `i` is onto
+(`TauCeti.reflectionFunctor_map_bijective`), and a fully faithful functor reflects isomorphisms:
+this is `TauCeti.nonempty_iso_of_nonempty_iso_reflectRep`. An indecomposable representation fails
+that hypothesis only by being concentrated at `i`
+(`TauCeti.incomingSum_surjective_or_forall_subsingleton`), and a representation with the same
+dimension vector then vanishes wherever it does and has a vertex space of the same dimension at
+`i`; two such representations are isomorphic, by `TauCeti.nonempty_iso_of_isZero_of_ne`.
+
+The comparison at such a stage is made directly, rather than through the vertex simple `Sᵢ` and
+`TauCeti.nonempty_iso_simpleRep_of_forall_subsingleton`: the vertex space of `Sᵢ` is the field
+itself, so naming it would force the universe of the vertex spaces to be that of the field, below
+the generality at which `TauCeti.titsForm_dimVector_eq_one_of_indecomposable` states the other half
+of the correspondence.
+
+So at each stage of a sink-admissible list, either both representations are concentrated at the
+current sink and are therefore already identified, or both reflect, with equal dimension vectors
+again. The induction terminates because a power of the Coxeter functor annihilates `M`
+(`TauCeti.exists_isZero_coxeterFunctor_iterate`), and the stage that annihilates it is a stage
+where it is concentrated at the sink.
+
+## Main results
+
+* `TauCeti.nonempty_iso_of_isZero_of_ne`: two representations vanishing away from a sink are
+  isomorphic as soon as their vertex spaces at that sink are, and
+  `TauCeti.nonempty_iso_of_dimVector_eq_of_forall_subsingleton`: the same conclusion from equality
+  of dimension vectors.
+* `TauCeti.nonempty_iso_of_nonempty_iso_reflectRep`: **the reflection functor at a sink reflects
+  isomorphisms** between representations whose incoming sums there are onto.
+* `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable`: **two finite-dimensional
+  indecomposable representations with the same dimension vector are isomorphic**, with
+  `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic` the same statement over an
+  acyclic quiver, where the sink-admissible ordering is chosen internally.
+* `TauCeti.nonempty_iso_iff_dimVector_eq_of_indecomposable`: the resulting characterization of
+  isomorphism of indecomposables by equality of dimension vectors.
+
+## References
+
+This is the uniqueness milestone of Layer 5 ("Gabriel's theorem") of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, that the reflection
+induction transports the dimension vector faithfully. See Bernstein--Gelfand--Ponomarev, *Coxeter
+functors and Gabriel's theorem*, and Derksen--Weyman, *An Introduction to Quiver Representations*,
+Ch. 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+open _root_.TauCeti.Quiver
+
+universe u v w x
+
+/-! ### Representations concentrated at a sink -/
+
+section Concentrated
+
+variable {k : Type u} {Q : Type v} [Field k] [Quiver.{w} Q]
+variable {M N : QuiverRep.{u, v, w, max v w x} k Q} {i : Q}
+
+/-- **Two representations vanishing away from a sink are isomorphic as soon as their vertex spaces
+at that sink are.** Every component away from `i` is a map between zero objects, and there is no
+naturality condition to check at `i`, since no arrow leaves a sink. -/
+theorem nonempty_iso_of_isZero_of_ne (hi : IsSink i)
+    (hM : ∀ a : Q, a ≠ i → Limits.IsZero (M.obj a))
+    (hN : ∀ a : Q, a ≠ i → Limits.IsZero (N.obj a))
+    (e : M.obj ((Paths.of Q).obj i) ≃ₗ[k] N.obj ((Paths.of Q).obj i)) :
+    Nonempty (M ≅ N) := by
+  classical
+  have eIso : M.obj ((Paths.of Q).obj i) ≅ N.obj ((Paths.of Q).obj i) :=
+    { hom := ModuleCat.ofHom e.toLinearMap
+      inv := ModuleCat.ofHom e.symm.toLinearMap
+      hom_inv_id := by ext y; exact e.symm_apply_apply y
+      inv_hom_id := by ext y; exact e.apply_symm_apply y }
+  refine ⟨NatIso.ofComponents (fun a ↦ if h : a = (Paths.of Q).obj i then
+      eqToIso (congrArg M.obj h) ≪≫ eIso ≪≫ eqToIso (congrArg N.obj h).symm
+    else (hM a h).iso (hN a h)) fun {a b} p ↦ ?_⟩
+  by_cases ha : a = (Paths.of Q).obj i
+  · -- a path out of a sink is the identity, so the naturality square is trivial
+    subst ha
+    obtain rfl := hi.eq_of_path p
+    have hMp : M.map p = 𝟙 (M.obj a) := by
+      rw [hi.path_self_eq_nil p]
+      exact M.map_id a
+    have hNp : N.map p = 𝟙 (N.obj a) := by
+      rw [hi.path_self_eq_nil p]
+      exact N.map_id a
+    rw [hMp, hNp]
+    simp
+  · exact (hM a ha).eq_of_src _ _
+
+/-- **A representation concentrated at a sink is isomorphic to every finite-dimensional
+representation with the same dimension vector.** Equality of dimension vectors makes the comparison
+representation vanish wherever `M` does, and matches the two vertex spaces at the sink. -/
+theorem nonempty_iso_of_dimVector_eq_of_forall_subsingleton (hi : IsSink i)
+    (hsub : ∀ a : Q, a ≠ i → Subsingleton (M.obj a))
+    (hfdM : IsFinDim.{u, v, w, max v w x} k Q M) (hfdN : IsFinDim.{u, v, w, max v w x} k Q N)
+    (hd : dimVector M = dimVector N) : Nonempty (M ≅ N) := by
+  have hfdM' := isFinDim_iff.mp hfdM
+  have hfdN' := isFinDim_iff.mp hfdN
+  have hNzero : ∀ a : Q, a ≠ i → Limits.IsZero (N.obj a) := by
+    intro a ha
+    have hMa : Subsingleton (M.obj ((Paths.of Q).obj a)) := hsub a ha
+    have hfdNa := hfdN' ((Paths.of Q).obj a)
+    have h0 : Module.finrank k (N.obj ((Paths.of Q).obj a)) = 0 := by
+      rw [← dimVector_apply, ← congrFun hd a, dimVector_apply]
+      exact Module.finrank_zero_of_subsingleton (R := k)
+    have hss : Subsingleton (N.obj ((Paths.of Q).obj a)) := Module.finrank_zero_iff.mp h0
+    exact @ModuleCat.isZero_of_subsingleton k _ (N.obj a) hss
+  have hfdMi := hfdM' ((Paths.of Q).obj i)
+  have hfdNi := hfdN' ((Paths.of Q).obj i)
+  have hfr : Module.finrank k (M.obj ((Paths.of Q).obj i))
+      = Module.finrank k (N.obj ((Paths.of Q).obj i)) := by
+    rw [← dimVector_apply, ← dimVector_apply, hd]
+  exact nonempty_iso_of_isZero_of_ne hi
+    (fun a ha ↦ @ModuleCat.isZero_of_subsingleton k _ (M.obj a) (hsub a ha)) hNzero
+    (LinearEquiv.ofFinrankEq _ _ hfr)
+
+end Concentrated
+
+/-! ### Reflection at a sink reflects isomorphisms -/
+
+section Reflect
+
+variable {k : Type u} {Q : Type v} [Field k] [Quiver.{w} Q] [Fintype Q]
+  [∀ a b : Q, Fintype (a ⟶ b)]
+variable {M N : QuiverRep.{u, v, w, max v w x} k Q} {i : Q}
+
+/-- **The reflection functor at a sink reflects isomorphisms**, between representations whose
+incoming sums there are onto. Fullness produces morphisms `f : M ⟶ N` and `g : N ⟶ M` reflecting
+to the two halves of the given isomorphism, and faithfulness turns the two triangle identities
+downstairs into the two upstairs.
+
+The reflection functor is not fully faithful on all of `TauCeti.QuiverRep k Q` -- it annihilates
+the vertex simple at `i` -- so `CategoryTheory.Functor.ReflectsIsomorphisms` and the machinery
+around it, which ask for `Full` and `Faithful` instances, do not apply, and the argument is made
+directly from `TauCeti.reflectionFunctor_map_surjective` and
+`TauCeti.reflectionFunctor_map_injective`. -/
+theorem nonempty_iso_of_nonempty_iso_reflectRep (hi : IsSink i)
+    (hsM : Function.Surjective (incomingSum M i))
+    (hsN : Function.Surjective (incomingSum N i))
+    (h : Nonempty (reflectRep M hi ≅ reflectRep N hi)) : Nonempty (M ≅ N) := by
+  obtain ⟨θ⟩ := h
+  have θ' : (reflectionFunctor i hi).obj M ≅ (reflectionFunctor i hi).obj N :=
+    eqToIso (reflectionFunctor_obj i hi M) ≪≫ θ ≪≫ eqToIso (reflectionFunctor_obj i hi N).symm
+  obtain ⟨f, hf⟩ := reflectionFunctor_map_surjective (M := M) (N := N) hi hsM θ'.hom
+  obtain ⟨g, hg⟩ := reflectionFunctor_map_surjective (M := N) (N := M) hi hsN θ'.inv
+  refine ⟨⟨f, g, ?_, ?_⟩⟩
+  · refine reflectionFunctor_map_injective (M := M) (N := M) hi hsM ?_
+    simp only [Functor.map_comp, hf, hg]
+    exact θ'.hom_inv_id.trans ((reflectionFunctor i hi).map_id M).symm
+  · refine reflectionFunctor_map_injective (M := N) (N := N) hi hsN ?_
+    simp only [Functor.map_comp, hf, hg]
+    exact θ'.inv_hom_id.trans ((reflectionFunctor i hi).map_id N).symm
+
+end Reflect
+
+/-! ### Uniqueness along a sink-admissible list -/
+
+section Uniqueness
+
+variable {k : Type u} {V : Type v} [fld : Field k] [fV : Fintype V]
+
+/-- **Two indecomposable representations with the same dimension vector are isomorphic, provided a
+composite of reflection functors identifies or annihilates them.** The induction is on the list of
+sinks. A stage at which both representations reflect passes the hypothesis down and returns an
+isomorphism through `TauCeti.nonempty_iso_of_nonempty_iso_reflectRep`; a stage at which either is
+concentrated at its own sink identifies the two on the spot, by
+`TauCeti.nonempty_iso_of_dimVector_eq_of_forall_subsingleton`. The empty list leaves the hypothesis
+itself, whose second alternative an indecomposable representation excludes. -/
+theorem nonempty_iso_of_dimVector_eq_of_reflectionFunctorList :
+    ∀ (l : List V) (q : _root_.Quiver.{w} V)
+      (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
+      (hl : Quiver.IsSinkAdmissible q l)
+      (M N : @QuiverRep.{u, v, w, max v w x} k V fld q),
+      Indecomposable M → Indecomposable N →
+      @IsFinDim.{u, v, w, max v w x} k V fld q M →
+      @IsFinDim.{u, v, w, max v w x} k V fld q N →
+      @dimVector k V fld q M = @dimVector k V fld q N →
+      (Nonempty ((reflectionFunctorList k l q hq hl).obj M
+            ≅ (reflectionFunctorList k l q hq hl).obj N)
+          ∨ Limits.IsZero ((reflectionFunctorList k l q hq hl).obj M)) →
+      Nonempty (M ≅ N)
+  | [], q, hq, hl, M, _, hM, _, _, _, _, hyp => by
+      rw [reflectionFunctorList_nil] at hyp
+      exact hyp.resolve_right hM.1
+  | i :: l, q, hq, hl, M, N, hM, hN, hfdM, hfdN, hd, hyp => by
+      classical
+      let : _root_.Quiver.{w} V := q
+      let : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b) := hq
+      obtain ⟨hi, hl'⟩ := Quiver.isSinkAdmissible_cons.mp hl
+      have hfdM' : ∀ a : V, FiniteDimensional k (M.obj a) :=
+        (@isFinDim_iff.{u, v, w, max v w x} k V fld q M).mp hfdM
+      have hfdN' : ∀ a : V, FiniteDimensional k (N.obj a) :=
+        (@isFinDim_iff.{u, v, w, max v w x} k V fld q N).mp hfdN
+      rw [reflectionFunctorList_cons_obj i l q hq hl M,
+        reflectionFunctorList_cons_obj i l q hq hl N] at hyp
+      rcases incomingSum_surjective_or_forall_subsingleton hi hM with hsM | hsubM
+      · rcases incomingSum_surjective_or_forall_subsingleton hi hN with hsN | hsubN
+        · -- both stages reflect, so the dimension vectors stay equal and the induction descends
+          refine nonempty_iso_of_nonempty_iso_reflectRep hi hsM hsN ?_
+          have hmid : @vertexPreReflection V q fV hq _ i
+                (fun j : V ↦ (@dimVector k V fld q M j : ℤ))
+              = @vertexPreReflection V q fV hq _ i
+                (fun j : V ↦ (@dimVector k V fld q N j : ℤ)) := by
+            rw [hd]
+          have hcast := (dimVector_reflectRep M hi (fun e ↦ hfdM' e.1) hsM).trans
+            (hmid.trans (dimVector_reflectRep N hi (fun e ↦ hfdN' e.1) hsN).symm)
+          have hdR : @dimVector k V fld (Quiver.reflectAt q i) (reflectRep M hi)
+              = @dimVector k V fld (Quiver.reflectAt q i) (reflectRep N hi) :=
+            funext fun j ↦ Nat.cast_inj.mp (congrFun hcast j)
+          exact nonempty_iso_of_dimVector_eq_of_reflectionFunctorList l (Quiver.reflectAt q i)
+            (@instFintypeReflectHom V q hq i) hl' (reflectRep M hi) (reflectRep N hi)
+            (indecomposable_reflectRep hi hM hsM) (indecomposable_reflectRep hi hN hsN)
+            ((@isFinDim_iff.{u, v, w, max v w x} k V fld (Quiver.reflectAt q i) _).mpr
+              (finiteDimensional_reflectRep_obj M hi hfdM'))
+            ((@isFinDim_iff.{u, v, w, max v w x} k V fld (Quiver.reflectAt q i) _).mpr
+              (finiteDimensional_reflectRep_obj N hi hfdN')) hdR hyp
+        · -- `N` is concentrated at the sink, hence so is `M`
+          exact (nonempty_iso_of_dimVector_eq_of_forall_subsingleton hi hsubN hfdN hfdM
+            hd.symm).map Iso.symm
+      · -- `M` is concentrated at the sink, hence so is `N`
+        exact nonempty_iso_of_dimVector_eq_of_forall_subsingleton hi hsubM hfdM hfdN hd
+
+/-! ### Uniqueness -/
+
+/-- **Two indecomposable representations with the same dimension vector are isomorphic, provided a
+power of the Coxeter functor annihilates one of them.** Each pass either annihilates a
+representation, which sends the argument back to the pass itself through
+`TauCeti.nonempty_iso_of_dimVector_eq_of_reflectionFunctorList`, or carries both representations to
+indecomposables with the same, Coxeter-transformed, dimension vector, where the induction
+hypothesis applies and the pass reflects the isomorphism it produces. -/
+private theorem nonempty_iso_of_dimVector_eq_of_isZero_iterate
+    (q : _root_.Quiver.{w} V) (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
+    {l : List V} (hnd : l.Nodup) (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l) :
+    ∀ (n : ℕ) (M N : @QuiverRep.{u, v, w, max v w x} k V fld q),
+      Indecomposable M → Indecomposable N →
+      @IsFinDim.{u, v, w, max v w x} k V fld q M →
+      @IsFinDim.{u, v, w, max v w x} k V fld q N →
+      @dimVector k V fld q M = @dimVector k V fld q N →
+      Limits.IsZero (((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj)^[n] M) →
+      Nonempty (M ≅ N) := by
+  classical
+  intro n
+  induction n with
+  | zero =>
+    intro M _ hM _ _ _ _ hz
+    rw [Function.iterate_zero_apply] at hz
+    exact absurd hz hM.1
+  | succ n ih =>
+    intro M N hM hN hfdM hfdN hd hz
+    rw [Function.iterate_succ_apply] at hz
+    rcases indecomposable_and_dimVector_coxeterFunctor_or_isZero q hq hnd hall hl M hM
+        ((@isFinDim_iff.{u, v, w, max v w x} k V fld q M).mp hfdM) with ⟨hM1, hdM⟩ | h0
+    · rcases indecomposable_and_dimVector_coxeterFunctor_or_isZero q hq hnd hall hl N hN
+          ((@isFinDim_iff.{u, v, w, max v w x} k V fld q N).mp hfdN) with ⟨hN1, hdN⟩ | h0N
+      · -- both survive the pass, so the induction hypothesis identifies their images
+        have hmid : (@vertexPreReflectionList V q fV hq _ l)
+              (fun j : V ↦ (@dimVector k V fld q M j : ℤ))
+            = (@vertexPreReflectionList V q fV hq _ l)
+              (fun j : V ↦ (@dimVector k V fld q N j : ℤ)) := by
+          rw [hd]
+        have hcast := hdM.trans (hmid.trans hdN.symm)
+        have hdC : @dimVector k V fld q
+              ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M)
+            = @dimVector k V fld q ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj N) :=
+          funext fun j ↦ Nat.cast_inj.mp (congrFun hcast j)
+        have hiso := ih _ _ hM1 hN1 (isFinDim_coxeterFunctor_obj q hq hnd hall hl M hfdM)
+          (isFinDim_coxeterFunctor_obj q hq hnd hall hl N hfdN) hdC hz
+        exact nonempty_iso_of_dimVector_eq_of_reflectionFunctorList l q hq hl M N hM hN hfdM
+          hfdN hd (Or.inl ((nonempty_iso_coxeterFunctor_obj_iff q hq hnd hall hl M N).mp hiso))
+      · exact (nonempty_iso_of_dimVector_eq_of_reflectionFunctorList l q hq hl N M hN hM hfdN
+          hfdM hd.symm (Or.inr
+            ((isZero_coxeterFunctor_obj_iff_isZero_reflectionFunctorList_obj q hq hnd hall hl
+              N).mp h0N))).map Iso.symm
+    · exact nonempty_iso_of_dimVector_eq_of_reflectionFunctorList l q hq hl M N hM hN hfdM hfdN
+        hd (Or.inr ((isZero_coxeterFunctor_obj_iff_isZero_reflectionFunctorList_obj q hq hnd hall
+          hl M).mp h0))
+
+/-- **An indecomposable representation is determined by its dimension vector.** For a quiver with
+positive definite Tits form -- the numerical form of the ADE condition -- and any sink-admissible
+ordering of its vertices, two indecomposable representations with finite-dimensional vertex spaces
+and the same dimension vector are isomorphic.
+
+This is the injectivity half of the Gabriel correspondence; that the dimension vector of an
+indecomposable is a positive root is
+`TauCeti.titsForm_dimVector_eq_one_of_indecomposable`. -/
+theorem nonempty_iso_of_dimVector_eq_of_indecomposable (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
+    (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)
+    (hpd : (@titsForm V q fV hq).PosDef) (M N : @QuiverRep.{u, v, w, max v w x} k V fld q)
+    (hM : Indecomposable M) (hN : Indecomposable N)
+    (hfdM : @IsFinDim.{u, v, w, max v w x} k V fld q M)
+    (hfdN : @IsFinDim.{u, v, w, max v w x} k V fld q N)
+    (hd : @dimVector k V fld q M = @dimVector k V fld q N) :
+    Nonempty (M ≅ N) := by
+  obtain ⟨n, hn⟩ := exists_isZero_coxeterFunctor_iterate q hq hnd hall hl hpd M hM hfdM
+  exact nonempty_iso_of_dimVector_eq_of_isZero_iterate q hq hnd hall hl n M N hM hN hfdM hfdN hd hn
+
+/-- **An indecomposable representation of an acyclic quiver with positive definite Tits form is
+determined by its dimension vector.** This is the consumer-facing form of
+`TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable`: acyclicity produces a sink-admissible
+ordering by `TauCeti.Quiver.IsAcyclic.exists_isSinkAdmissible`, and since the conclusion does not
+mention the ordering, the choice is made here rather than by the caller. -/
+theorem nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic
+    [q : _root_.Quiver.{w} V] [hq : ∀ a b : V, Fintype (a ⟶ b)] (hac : Quiver.IsAcyclic V)
+    (hpd : (titsForm V).PosDef) (M N : QuiverRep.{u, v, w, max v w x} k V)
+    (hM : Indecomposable M) (hN : Indecomposable N)
+    (hfdM : IsFinDim.{u, v, w, max v w x} k V M) (hfdN : IsFinDim.{u, v, w, max v w x} k V N)
+    (hd : dimVector M = dimVector N) :
+    Nonempty (M ≅ N) := by
+  obtain ⟨l, hnd, hall, hl⟩ := hac.exists_isSinkAdmissible
+  exact nonempty_iso_of_dimVector_eq_of_indecomposable q hq hnd hall hl hpd M N hM hN hfdM hfdN hd
+
+/-- **Indecomposable representations of an acyclic quiver with positive definite Tits form are
+isomorphic exactly when their dimension vectors agree.** The forward direction is
+`TauCeti.dimVector_eq_of_iso` and needs none of the hypotheses; the converse is
+`TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic`. -/
+theorem nonempty_iso_iff_dimVector_eq_of_indecomposable
+    [q : _root_.Quiver.{w} V] [hq : ∀ a b : V, Fintype (a ⟶ b)] (hac : Quiver.IsAcyclic V)
+    (hpd : (titsForm V).PosDef) (M N : QuiverRep.{u, v, w, max v w x} k V)
+    (hM : Indecomposable M) (hN : Indecomposable N)
+    (hfdM : IsFinDim.{u, v, w, max v w x} k V M) (hfdN : IsFinDim.{u, v, w, max v w x} k V N) :
+    Nonempty (M ≅ N) ↔ dimVector M = dimVector N :=
+  ⟨fun ⟨e⟩ ↦ dimVector_eq_of_iso e, fun hd ↦
+    nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic hac hpd M N hM hN hfdM hfdN hd⟩
+
+end Uniqueness
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Uniqueness.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Uniqueness.lean
@@ -96,11 +96,7 @@ theorem nonempty_iso_of_isZero_away_of_linearEquiv (hi : IsSink i)
     (e : M.obj ((Paths.of Q).obj i) ≃ₗ[k] N.obj ((Paths.of Q).obj i)) :
     Nonempty (M ≅ N) := by
   classical
-  have eIso : M.obj ((Paths.of Q).obj i) ≅ N.obj ((Paths.of Q).obj i) :=
-    { hom := ModuleCat.ofHom e.toLinearMap
-      inv := ModuleCat.ofHom e.symm.toLinearMap
-      hom_inv_id := by ext y; exact e.symm_apply_apply y
-      inv_hom_id := by ext y; exact e.apply_symm_apply y }
+  have eIso : M.obj ((Paths.of Q).obj i) ≅ N.obj ((Paths.of Q).obj i) := e.toModuleIso
   refine ⟨NatIso.ofComponents (fun a ↦ if h : a = (Paths.of Q).obj i then
       eqToIso (congrArg M.obj h) ≪≫ eIso ≪≫ eqToIso (congrArg N.obj h).symm
     else (hM a h).iso (hN a h)) fun {a b} p ↦ ?_⟩


### PR DESCRIPTION
This PR proves that a finite-dimensional indecomposable representation of a quiver with positive definite Tits form is determined up to isomorphism by its dimension vector: `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable`, with the acyclic form `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic` that chooses the sink-admissible ordering internally, and the resulting characterization `TauCeti.nonempty_iso_iff_dimVector_eq_of_indecomposable`.

The Bernstein-Gelfand-Ponomarev induction is run at the two representations in parallel. The reflection functor at a sink is fully faithful on the representations whose incoming sum there is onto (`TauCeti.reflectionFunctor_map_surjective`, `TauCeti.reflectionFunctor_map_injective`), and that is enough to reflect isomorphisms: `TauCeti.nonempty_iso_of_nonempty_iso_reflectRep`. An indecomposable fails that hypothesis only by being concentrated at the sink, and a representation with the same dimension vector then vanishes wherever it does and has a vertex space of the same dimension at the sink, so the two are already identified by `TauCeti.nonempty_iso_of_dimVector_eq_of_forall_subsingleton`. Since the dimension vectors transform by the same simple reflection at every stage, the two representations are concentrated at the same stage, and `TauCeti.exists_isZero_coxeterFunctor_iterate` guarantees such a stage exists.

This is the uniqueness milestone of Layer 5 ("Gabriel's theorem") of `RepresentationTheory/QuiverRepresentations/README.md`: "**Uniqueness.** The reflection induction transports the dimension vector faithfully, so `dimVector` is injective on indecomposables." With `TauCeti.titsForm_dimVector_eq_one_of_indecomposable` already on `main`, `M ↦ dim M` is now an injection from isomorphism classes of finite-dimensional indecomposables into the positive roots of the Tits form. What remains for the milestone after this PR is the other half of that bijection, that every positive root is the dimension vector of an indecomposable, and, above it, the dichotomy `gabriel_finiteRepType_iff` itself; the brick property (`End = k`) named in the same roadmap bullet is not proved here.

The comparison of two representations concentrated at a sink is made directly rather than through the vertex simple `Sᵢ` and `TauCeti.nonempty_iso_simpleRep_of_forall_subsingleton`: the vertex space of `Sᵢ` is the field itself, so naming it collapses the universe of the vertex spaces onto that of the field, below the generality at which `TauCeti.titsForm_dimVector_eq_one_of_indecomposable` states the other half of the correspondence. Similarly, the reflection functor is not fully faithful on the whole representation category — it annihilates `Sᵢ` — so `CategoryTheory.Functor.ReflectsIsomorphisms` and the instances it asks for do not apply, and the descent is made from the two conditional statements.

`TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean` gains one lemma, `TauCeti.nonempty_iso_coxeterFunctor_obj_iff_nonempty_iso_reflectionFunctorList_obj`, the transport of an isomorphism between Coxeter images back to the reflection-functor composite. It is the exact analogue of the `isZero` transport already there, and belongs beside it because the transport itself is private to that file.

Roadmap: RepresentationTheory

Written against I. N. Bernstein, I. M. Gelfand and V. A. Ponomarev, *Coxeter functors and Gabriel's theorem*, Uspekhi Mat. Nauk 28 (1973), and H. Derksen and J. Weyman, *An Introduction to Quiver Representations*, Ch. 2. Nothing is vendored; Mathlib has no quiver representation theory.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"dimvector-injective-on-indecomposables"}-->

🤖 Prepared with Claude Code

