### PR TITLE
feat: preserve geometric solvability under base change

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/BaseChange.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Construction
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Reduced
+
+/-!
+# Base change of the solvable radical
+
+Let `H` be a finite-type commutative Hopf algebra over a field `k`. Extension to a field `K`
+sends every connected normal smooth solvable closed subgroup of the affine group represented by
+`H` to another such subgroup. In particular, the base change of the solvable radical is contained
+in the solvable radical formed after base change.
+
+In coordinate rings, closed-subgroup containment reverses the order on defining ideals, so the
+conclusion is
+
+```text
+  solvableRadicalDefiningIdeal (K ⊗[k] H) ≤
+    baseChangeHopfIdeal (solvableRadicalDefiningIdeal H).
+```
+
+The four candidate conditions use their corresponding base-change theorems. The quotient by a
+base-changed ideal is identified with the base change of the original quotient by
+`CommHopfAlgCat.quotientBaseChangeIso`; smoothness promotes geometric solvability to a universal
+derived-word identity, so that condition also survives arbitrary field extension.
+
+Equality requires descent of an arbitrary radical candidate over `K` and is not asserted here.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.IsSolvableRadicalCandidate.baseChange`: scalar extension preserves
+  solvable-radical candidates.
+* `TauCeti.FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_baseChange_le`: the base-changed
+  solvable radical is contained in the radical after base change.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 6.45--6.46.
+* A. Borel, *Linear Algebraic Groups*, Section 11.21.
+
+This advances the scalar-extension compatibility of the radical in Layer 6, "Reductive and
+semisimple groups", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal.IsSolvableRadicalCandidate
+
+variable {k K : Type u} [Field k] [Field K] [Algebra k K]
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k H}
+
+/-- Base change of a solvable-radical candidate is again a solvable-radical candidate. -/
+theorem baseChange (hI : IsSolvableRadicalCandidate H I) :
+    IsSolvableRadicalCandidate
+      (FiniteTypeCommHopfAlgCat.baseChange (K := K) H)
+      (CommHopfAlgCat.baseChangeHopfIdeal (K := K) I) := by
+  let qIso := CommHopfAlgCat.quotientBaseChangeIso (K := K) I
+  refine IsSolvableRadicalCandidate.mk
+    (CommHopfAlgCat.isNormal_baseChangeHopfIdeal hI.isNormal) ?_ ?_ ?_
+  · apply (geometricallyConnectedCommHopfAlgProperty K).prop_of_iso qIso.symm
+    exact geometricallyConnectedCommHopfAlgProperty.baseChange k K _ hI.geometricallyConnected
+  · rw [← smoothCommHopfAlgProperty_iff]
+    apply (smoothCommHopfAlgProperty K).prop_of_iso qIso.symm
+    rw [smoothCommHopfAlgProperty_iff]
+    exact @Algebra.Smooth.baseChange k _
+      (FiniteTypeCommHopfAlgCat.quotient H I) K _ _ _ _ hI.smooth
+  · apply (geometricallySolvablePointsCommHopfAlgProperty K).prop_of_iso qIso.symm
+    exact geometricallySolvablePointsCommHopfAlgProperty.baseChange
+      (CommHopfAlgCat.quotient H.obj I) hI.smooth hI.geometricallySolvable
+
+end HopfIdeal.IsSolvableRadicalCandidate
+
+namespace FiniteTypeCommHopfAlgCat
+
+variable {k K : Type u} [Field k] [Field K] [Algebra k K]
+
+/-- The solvable radical after base change contains the base change of the original solvable
+radical.
+
+The displayed inequality is between defining Hopf ideals, hence has the opposite direction from
+the corresponding inclusion of represented closed subgroups. -/
+theorem solvableRadicalDefiningIdeal_baseChange_le
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    solvableRadicalDefiningIdeal (baseChange (K := K) H) ≤
+      CommHopfAlgCat.baseChangeHopfIdeal (K := K)
+        (solvableRadicalDefiningIdeal H) :=
+  solvableRadicalDefiningIdeal_le _ _
+    (HopfIdeal.IsSolvableRadicalCandidate.baseChange
+      (isSolvableRadicalCandidate_solvableRadicalDefiningIdeal H))
+
+end FiniteTypeCommHopfAlgCat
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/BaseChange.lean
@@ -29,8 +29,8 @@ conclusion is
 
 The four candidate conditions use their corresponding base-change theorems. The quotient by a
 base-changed ideal is identified with the base change of the original quotient by
-`CommHopfAlgCat.quotientBaseChangeIso`; smoothness promotes geometric solvability to a universal
-derived-word identity, so that condition also survives arbitrary field extension.
+`CommHopfAlgCat.quotientBaseChangeIso`; finite-type Nullstellensatz makes the universal
+derived-word defect nilpotent, so that condition also survives arbitrary field extension.
 
 Equality requires descent of an arbitrary radical candidate over `K` and is not asserted here.
 
@@ -80,7 +80,7 @@ theorem baseChange (hI : IsSolvableRadicalCandidate H I) :
       (FiniteTypeCommHopfAlgCat.quotient H I) K _ _ _ _ hI.smooth
   · apply (geometricallySolvablePointsCommHopfAlgProperty K).prop_of_iso qIso.symm
     exact geometricallySolvablePointsCommHopfAlgProperty.baseChange
-      (CommHopfAlgCat.quotient H.obj I) hI.smooth hI.geometricallySolvable
+      (CommHopfAlgCat.quotient H.obj I) hI.geometricallySolvable
 
 end HopfIdeal.IsSolvableRadicalCandidate
 

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Reduced.lean
@@ -26,16 +26,16 @@ makes this algebra reduced, so algebraic-closure-valued points separate its elem
 of `f`, and hence of all its iterated tensor powers, then reflects the universal identity from
 `K` to `H`.
 
-The same universal identity proves that geometric solvability of a smooth affine group survives
-every field extension: specialize it to points over the new algebraic closure, then use the
-standard equivalence between points of a scalar extension and points with scalars restricted.
+For a finite-type affine group, the same argument makes each coordinate of the universal
+derived-word defect nilpotent. Every field-valued point kills that defect, proving that geometric
+solvability survives arbitrary field extension without a smoothness hypothesis.
 
 ## Main declarations
 
 * `TauCeti.geometricallySolvablePointsCommHopfAlgProperty.of_injective_of_smooth`: geometric
   solvability descends along an injective coordinate morphism with smooth codomain.
 * `TauCeti.geometricallySolvablePointsCommHopfAlgProperty.baseChange`: geometric solvability of a
-  smooth affine group is preserved by field extension.
+  finite-type affine group is preserved by field extension.
 
 ## References
 
@@ -111,6 +111,18 @@ private theorem smooth (hH : Algebra.Smooth k H) (n : ℕ) :
       exact Algebra.Smooth.comp k (derivedWordCoordinateAlgebra H n)
         ((derivedWordCoordinateAlgebra H n) ⊗[k]
           (derivedWordCoordinateAlgebra H n))
+
+/-- If the original coordinate algebra is finite type, every universal derived-word value
+algebra is finite type. -/
+private theorem finiteType (hH : Algebra.FiniteType k H) (n : ℕ) :
+    Algebra.FiniteType k (derivedWordCoordinateAlgebra H n) := by
+  induction n with
+  | zero => exact hH
+  | succ n ih =>
+      let _ : Algebra.FiniteType k (derivedWordCoordinateAlgebra H n) := ih
+      exact Algebra.FiniteType.trans (R := k) (S := derivedWordCoordinateAlgebra H n)
+        (A := (derivedWordCoordinateAlgebra H n) ⊗[k]
+          (derivedWordCoordinateAlgebra H n)) inferInstance inferInstance
 
 end derivedWordCoordinateAlgebra
 
@@ -271,15 +283,39 @@ namespace geometricallySolvablePointsCommHopfAlgProperty
 variable {k : Type u} [Field k]
 variable {H K : CommHopfAlgCat.{v} k}
 
+/-- Finite-type geometric solvability makes every coordinate of a universal derived-word defect
+nilpotent. -/
+private theorem exists_universalDerivedWord_sub_one_isNilpotent
+    (hH_finite : Algebra.FiniteType k H)
+    (hH : geometricallySolvablePointsCommHopfAlgProperty k H) :
+    ∃ n, ∀ z, IsNilpotent ((HopfAlgebra.universalDerivedWord H n).ofConv z -
+      algebraMap k (derivedWordCoordinateAlgebra H n) (Coalgebra.counit (R := k) z)) := by
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff,
+    isSolvable_iff_exists_derivedWord_eq_one] at hH
+  obtain ⟨n, hn⟩ := hH
+  refine ⟨n, fun z ↦ ?_⟩
+  let _ : Algebra.FiniteType k (derivedWordCoordinateAlgebra H n) :=
+    derivedWordCoordinateAlgebra.finiteType hH_finite n
+  rw [← TauCeti.forall_algHom_apply_eq_zero_iff_isNilpotent
+    (k := k) (K := AlgebraicClosure k)]
+  intro q
+  let args := HopfAlgebra.derivedWordArgumentsOfAlgHom H n q
+  have hq := HopfAlgebra.mapValue_universalDerivedWord H n args
+  rw [HopfAlgebra.derivedWordEvaluation_argumentsOfAlgHom] at hq
+  have hqz := congrArg (fun g : HopfAlgebra.points (R := k) (H := H)
+    (CommAlgCat.of k (AlgebraicClosure k)) ↦ g.ofConv z) hq
+  rw [hn] at hqz
+  simpa [AlgHom.mapValue_apply, AlgHom.convOne_apply, sub_eq_zero] using hqz
+
 /-- Smooth geometric solvability gives a universal derived-word identity in the coordinate
 algebra. -/
 private theorem exists_universalDerivedWord_eq_one
     (hH_smooth : Algebra.Smooth k H)
     (hH : geometricallySolvablePointsCommHopfAlgProperty k H) :
     ∃ n, HopfAlgebra.universalDerivedWord H n = 1 := by
-  rw [geometricallySolvablePointsCommHopfAlgProperty_iff,
-    isSolvable_iff_exists_derivedWord_eq_one] at hH
-  obtain ⟨n, hn⟩ := hH
+  let _ : Algebra.Smooth k H := hH_smooth
+  obtain ⟨n, hn⟩ := exists_universalDerivedWord_sub_one_isNilpotent
+    (inferInstance : Algebra.FiniteType k H) hH
   refine ⟨n, ?_⟩
   let _ : Algebra.Smooth k (derivedWordCoordinateAlgebra H n) :=
     derivedWordCoordinateAlgebra.smooth hH_smooth n
@@ -288,16 +324,7 @@ private theorem exists_universalDerivedWord_eq_one
   apply WithConv.ofConv_injective
   apply AlgHom.ext
   intro z
-  apply TauCeti.eq_of_forall_algHom_apply_eq
-    (k := k) (K := AlgebraicClosure k)
-  intro q
-  let args := HopfAlgebra.derivedWordArgumentsOfAlgHom H n q
-  have hq := HopfAlgebra.mapValue_universalDerivedWord H n args
-  rw [HopfAlgebra.derivedWordEvaluation_argumentsOfAlgHom] at hq
-  have hqz := congrArg (fun g : HopfAlgebra.points (R := k) (H := H)
-    (CommAlgCat.of k (AlgebraicClosure k)) ↦ g.ofConv z) hq
-  rw [hn] at hqz
-  simpa [AlgHom.mapValue_apply, AlgHom.convOne_apply] using hqz
+  exact sub_eq_zero.mp (isNilpotent_iff_eq_zero.mp (hn z))
 
 /-- A universal derived-word identity makes the points over every value algebra solvable. -/
 private theorem isSolvable_points_of_universalDerivedWord_eq_one
@@ -312,6 +339,23 @@ private theorem isSolvable_points_of_universalDerivedWord_eq_one
   ext z
   simp only [AlgHom.comp_apply, AlgHom.convOne_apply]
   exact (HopfAlgebra.derivedWordEvaluation H n x).commutes _
+
+/-- A coordinatewise nilpotent universal derived-word defect vanishes at every field-valued
+point. -/
+private theorem isSolvable_points_of_universalDerivedWord_sub_one_isNilpotent
+    {A : Type w} [Field A] [Algebra k A] (n : ℕ)
+    (hH : ∀ z, IsNilpotent ((HopfAlgebra.universalDerivedWord H n).ofConv z -
+      algebraMap k (derivedWordCoordinateAlgebra H n) (Coalgebra.counit (R := k) z))) :
+    Group.IsSolvable
+      (HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k A)) := by
+  rw [isSolvable_iff_exists_derivedWord_eq_one]
+  refine ⟨n, fun x ↦ ?_⟩
+  rw [← HopfAlgebra.mapValue_universalDerivedWord H n x]
+  apply WithConv.ofConv_injective
+  ext z
+  have hz := (hH z).map (HopfAlgebra.derivedWordEvaluation H n x)
+  rw [isNilpotent_iff_eq_zero] at hz
+  simpa [AlgHom.convOne_apply, sub_eq_zero] using hz
 
 /-- Geometric solvability descends along an injective morphism of coordinate Hopf algebras whose
 codomain is smooth.
@@ -353,24 +397,26 @@ theorem of_injective_of_smooth (f : H ⟶ K) (hf : Function.Injective f.hom)
         rw [AlgHom.convOne_apply]
   exact isSolvable_points_of_universalDerivedWord_eq_one n hHuniv
 
-/-- Geometric solvability of a smooth affine group is preserved by arbitrary field extension.
+/-- Geometric solvability of a finite-type affine group is preserved by arbitrary field
+extension.
 
-The smoothness hypothesis is used to promote solvability over one algebraic closure to a
-universal derived-word identity. That identity then holds over the algebraic closure of the
-larger field, and the standard base-change equivalence of point groups transfers solvability. -/
+Finite-type Nullstellensatz makes the coordinates of a universal derived-word defect nilpotent.
+They vanish under points valued in the algebraic closure of the larger field, and the standard
+base-change equivalence of point groups transfers solvability. -/
 theorem baseChange {K : Type w} [Field K] [Algebra k K]
-    (H : CommHopfAlgCat.{v} k) (hH_smooth : Algebra.Smooth k H)
+    (H : CommHopfAlgCat.{v} k) [Algebra.FiniteType k H]
     (hH : geometricallySolvablePointsCommHopfAlgProperty k H) :
     geometricallySolvablePointsCommHopfAlgProperty K
       (CommHopfAlgCat.baseChange (K := K) H) := by
   rw [geometricallySolvablePointsCommHopfAlgProperty_iff]
-  obtain ⟨n, hword⟩ := exists_universalDerivedWord_eq_one hH_smooth hH
+  obtain ⟨n, hword⟩ := exists_universalDerivedWord_sub_one_isNilpotent
+    (inferInstance : Algebra.FiniteType k H) hH
   let _ : Algebra k (AlgebraicClosure K) :=
     Algebra.compHom (AlgebraicClosure K) (algebraMap k K)
   have hpoints : Group.IsSolvable
       (HopfAlgebra.points (R := k) (H := H)
         (CommAlgCat.of k (AlgebraicClosure K))) :=
-    isSolvable_points_of_universalDerivedWord_eq_one n hword
+    isSolvable_points_of_universalDerivedWord_sub_one_isNilpotent n hword
   let e := CommHopfAlgCat.baseChangePointsMulEquiv (K := K)
     (CommAlgCat.of K (AlgebraicClosure K)) H
   let _ := hpoints

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Reduced.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.Smooth.Basic
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
 import TauCeti.Algebra.AlgebraicGroup.Hopf.Commutator
 import TauCeti.Algebra.TensorProduct.Injective
@@ -13,7 +14,7 @@ import TauCeti.RingTheory.FiniteType.PointSeparation
 import TauCeti.RingTheory.Smooth.GeometricallyReduced
 
 /-!
-# Solvability under schematically dense affine group morphisms
+# Geometric solvability, dense morphisms, and base change
 
 An injective morphism `f : H ⟶ K` of coordinate Hopf algebras represents a schematically
 dense homomorphism `Spec K ⟶ Spec H` of affine groups. If `K` is smooth over the field `k`,
@@ -25,18 +26,24 @@ makes this algebra reduced, so algebraic-closure-valued points separate its elem
 of `f`, and hence of all its iterated tensor powers, then reflects the universal identity from
 `K` to `H`.
 
-## Main declaration
+The same universal identity proves that geometric solvability of a smooth affine group survives
+every field extension: specialize it to points over the new algebraic closure, then use the
+standard equivalence between points of a scalar extension and points with scalars restricted.
+
+## Main declarations
 
 * `TauCeti.geometricallySolvablePointsCommHopfAlgProperty.of_injective_of_smooth`: geometric
   solvability descends along an injective coordinate morphism with smooth codomain.
+* `TauCeti.geometricallySolvablePointsCommHopfAlgProperty.baseChange`: geometric solvability of a
+  smooth affine group is preserved by field extension.
 
 ## References
 
 * J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
 * T. A. Springer, *Linear Algebraic Groups*, Section 2.4.
 
-This supplies the image-solvability step needed to close solvable-radical candidates under
-scheme-theoretic products in Layer 6 of the ReductiveGroups roadmap.
+These results supply the image-solvability and scalar-extension steps for the solvable radical in
+Layer 6 of the ReductiveGroups roadmap.
 -/
 
 public section
@@ -46,7 +53,7 @@ open scoped commutatorElement TensorProduct
 
 namespace TauCeti
 
-universe u v
+universe u v w
 
 noncomputable section
 
@@ -131,25 +138,25 @@ private def universalDerivedWord : (n : ℕ) →
 
 /-- The `k`-algebra map out of the depth-`n` value algebra determined by a tree of points.
 Composing it with the universal derived word gives the derived word of that tree. -/
-private def derivedWordEvaluation {A : Type u} [CommRing A] [Algebra k A] :
+private def derivedWordEvaluation {A : Type w} [CommRing A] [Algebra k A] :
     (n : ℕ) → DerivedWordArgs (points (R := k) (H := H) (CommAlgCat.of k A)) n →
       derivedWordCoordinateAlgebra H n →ₐ[k] A
   | 0, .leaf g => g.ofConv
   | n + 1, .node x y => Algebra.TensorProduct.productMap
       (derivedWordEvaluation n x) (derivedWordEvaluation n y)
 
-@[simp] private theorem derivedWordEvaluation_leaf {A : Type u} [CommRing A] [Algebra k A]
+@[simp] private theorem derivedWordEvaluation_leaf {A : Type w} [CommRing A] [Algebra k A]
     (g : points (R := k) (H := H) (CommAlgCat.of k A)) :
     derivedWordEvaluation H 0 (.leaf g) = g.ofConv := rfl
 
-@[simp] private theorem derivedWordEvaluation_node {A : Type u} [CommRing A] [Algebra k A]
+@[simp] private theorem derivedWordEvaluation_node {A : Type w} [CommRing A] [Algebra k A]
     (n : ℕ) (x y : DerivedWordArgs (points (R := k) (H := H) (CommAlgCat.of k A)) n) :
     derivedWordEvaluation H (n + 1) (.node x y) = Algebra.TensorProduct.productMap
       (derivedWordEvaluation H n x) (derivedWordEvaluation H n y) := rfl
 
 /-- Decode an algebra homomorphism out of a universal derived-word value algebra into its tree
 of leaf points. -/
-private def derivedWordArgumentsOfAlgHom {A : Type u} [CommRing A] [Algebra k A] :
+private def derivedWordArgumentsOfAlgHom {A : Type w} [CommRing A] [Algebra k A] :
     (n : ℕ) → (derivedWordCoordinateAlgebra H n →ₐ[k] A) →
       DerivedWordArgs (points (R := k) (H := H) (CommAlgCat.of k A)) n
   | 0, q => .leaf (toConv q)
@@ -163,11 +170,11 @@ private def derivedWordArgumentsOfAlgHom {A : Type u} [CommRing A] [Algebra k A]
           (H₁ := derivedWordCoordinateAlgebra H n)
           (H₂ := derivedWordCoordinateAlgebra H n)).toAlgHom)
 
-@[simp] private theorem derivedWordArgumentsOfAlgHom_zero {A : Type u} [CommRing A]
+@[simp] private theorem derivedWordArgumentsOfAlgHom_zero {A : Type w} [CommRing A]
     [Algebra k A] (q : H →ₐ[k] A) :
     derivedWordArgumentsOfAlgHom H 0 q = .leaf (toConv q) := rfl
 
-@[simp] private theorem derivedWordArgumentsOfAlgHom_succ {A : Type u} [CommRing A]
+@[simp] private theorem derivedWordArgumentsOfAlgHom_succ {A : Type w} [CommRing A]
     [Algebra k A] (n : ℕ) (q : derivedWordCoordinateAlgebra H (n + 1) →ₐ[k] A) :
     derivedWordArgumentsOfAlgHom H (n + 1) q = .node
       (derivedWordArgumentsOfAlgHom H n (q.comp
@@ -182,7 +189,7 @@ private def derivedWordArgumentsOfAlgHom {A : Type u} [CommRing A] [Algebra k A]
 /-- Decoding an algebra homomorphism into leaf points and evaluating those leaves recovers the
 homomorphism. -/
 @[simp] private theorem derivedWordEvaluation_argumentsOfAlgHom
-    {A : Type u} [CommRing A] [Algebra k A]
+    {A : Type w} [CommRing A] [Algebra k A]
     (n : ℕ) (q : derivedWordCoordinateAlgebra H n →ₐ[k] A) :
     derivedWordEvaluation H n (derivedWordArgumentsOfAlgHom H n q) = q := by
   induction n with
@@ -195,7 +202,7 @@ homomorphism. -/
         AffineGroup.Product.productMap_restrict q
 
 /-- Evaluating the universal point at a tree of points gives the corresponding derived word. -/
-@[simp] private theorem mapValue_universalDerivedWord {A : Type u} [CommRing A] [Algebra k A]
+@[simp] private theorem mapValue_universalDerivedWord {A : Type w} [CommRing A] [Algebra k A]
     (n : ℕ) (x : DerivedWordArgs (points (R := k) (H := H) (CommAlgCat.of k A)) n) :
     toConv ((derivedWordEvaluation H n x).comp (universalDerivedWord H n).ofConv) =
       derivedWord (points (R := k) (H := H) (CommAlgCat.of k A)) n x := by
@@ -264,6 +271,48 @@ namespace geometricallySolvablePointsCommHopfAlgProperty
 variable {k : Type u} [Field k]
 variable {H K : CommHopfAlgCat.{v} k}
 
+/-- Smooth geometric solvability gives a universal derived-word identity in the coordinate
+algebra. -/
+private theorem exists_universalDerivedWord_eq_one
+    (hH_smooth : Algebra.Smooth k H)
+    (hH : geometricallySolvablePointsCommHopfAlgProperty k H) :
+    ∃ n, HopfAlgebra.universalDerivedWord H n = 1 := by
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff,
+    isSolvable_iff_exists_derivedWord_eq_one] at hH
+  obtain ⟨n, hn⟩ := hH
+  refine ⟨n, ?_⟩
+  let _ : Algebra.Smooth k (derivedWordCoordinateAlgebra H n) :=
+    derivedWordCoordinateAlgebra.smooth hH_smooth n
+  let _ : IsReduced (derivedWordCoordinateAlgebra H n) :=
+    isReduced_of_smooth_of_field k (derivedWordCoordinateAlgebra H n)
+  apply WithConv.ofConv_injective
+  apply AlgHom.ext
+  intro z
+  apply TauCeti.eq_of_forall_algHom_apply_eq
+    (k := k) (K := AlgebraicClosure k)
+  intro q
+  let args := HopfAlgebra.derivedWordArgumentsOfAlgHom H n q
+  have hq := HopfAlgebra.mapValue_universalDerivedWord H n args
+  rw [HopfAlgebra.derivedWordEvaluation_argumentsOfAlgHom] at hq
+  have hqz := congrArg (fun g : HopfAlgebra.points (R := k) (H := H)
+    (CommAlgCat.of k (AlgebraicClosure k)) ↦ g.ofConv z) hq
+  rw [hn] at hqz
+  simpa [AlgHom.mapValue_apply, AlgHom.convOne_apply] using hqz
+
+/-- A universal derived-word identity makes the points over every value algebra solvable. -/
+private theorem isSolvable_points_of_universalDerivedWord_eq_one
+    {A : Type w} [CommRing A] [Algebra k A] (n : ℕ)
+    (hH : HopfAlgebra.universalDerivedWord H n = 1) :
+    Group.IsSolvable
+      (HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k A)) := by
+  rw [isSolvable_iff_exists_derivedWord_eq_one]
+  refine ⟨n, fun x ↦ ?_⟩
+  rw [← HopfAlgebra.mapValue_universalDerivedWord H n x, hH]
+  apply WithConv.ofConv_injective
+  ext z
+  simp only [AlgHom.comp_apply, AlgHom.convOne_apply]
+  exact (HopfAlgebra.derivedWordEvaluation H n x).commutes _
+
 /-- Geometric solvability descends along an injective morphism of coordinate Hopf algebras whose
 codomain is smooth.
 
@@ -275,31 +324,9 @@ theorem of_injective_of_smooth (f : H ⟶ K) (hf : Function.Injective f.hom)
     (hK_smooth : Algebra.Smooth k K)
     (hK : geometricallySolvablePointsCommHopfAlgProperty k K) :
     geometricallySolvablePointsCommHopfAlgProperty k H := by
-  rw [geometricallySolvablePointsCommHopfAlgProperty_iff] at hK ⊢
-  rw [isSolvable_iff_exists_derivedWord_eq_one] at hK ⊢
-  obtain ⟨n, hn⟩ := hK
-  refine ⟨n, fun x ↦ ?_⟩
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff]
   let f₀ := f.hom
-  let _ : Algebra.Smooth k (derivedWordCoordinateAlgebra K n) :=
-    derivedWordCoordinateAlgebra.smooth hK_smooth n
-  let _ : IsReduced (derivedWordCoordinateAlgebra K n) :=
-    isReduced_of_smooth_of_field k (derivedWordCoordinateAlgebra K n)
-  -- Point separation promotes the derived-word identity on geometric points of `K` to an
-  -- identity for its universal derived word.
-  have hKuniv : HopfAlgebra.universalDerivedWord K n = 1 := by
-    apply WithConv.ofConv_injective
-    apply AlgHom.ext
-    intro z
-    apply TauCeti.eq_of_forall_algHom_apply_eq
-      (k := k) (K := AlgebraicClosure k)
-    intro q
-    let args := HopfAlgebra.derivedWordArgumentsOfAlgHom K n q
-    have hq := HopfAlgebra.mapValue_universalDerivedWord K n args
-    rw [HopfAlgebra.derivedWordEvaluation_argumentsOfAlgHom] at hq
-    have hqz := congrArg (fun g : HopfAlgebra.points (R := k) (H := K)
-      (CommAlgCat.of k (AlgebraicClosure k)) ↦ g.ofConv z) hq
-    rw [hn] at hqz
-    simpa [AlgHom.mapValue_apply, AlgHom.convOne_apply] using hqz
+  obtain ⟨n, hKuniv⟩ := exists_universalDerivedWord_eq_one hK_smooth hK
   -- Naturality and injectivity of the iterated tensor power of `f` reflect that universal
   -- identity from `K` to `H`.
   have hHuniv : HopfAlgebra.universalDerivedWord H n = 1 := by
@@ -324,13 +351,30 @@ theorem of_injective_of_smooth (f : H ⟶ K) (hf : Function.Injective f.hom)
       _ = (derivedWordCoordinateAlgebra.map f₀ n) ((1 : HopfAlgebra.points
           (R := k) (H := H) (CommAlgCat.of k (derivedWordCoordinateAlgebra H n))).ofConv z) := by
         rw [AlgHom.convOne_apply]
-  -- Specialize the universal identity for `H` to the requested tree of geometric points.
-  rw [← HopfAlgebra.mapValue_universalDerivedWord (A := AlgebraicClosure k) H n x,
-    hHuniv]
-  apply WithConv.ofConv_injective
-  ext z
-  simp only [AlgHom.comp_apply, AlgHom.convOne_apply]
-  exact (HopfAlgebra.derivedWordEvaluation H n x).commutes _
+  exact isSolvable_points_of_universalDerivedWord_eq_one n hHuniv
+
+/-- Geometric solvability of a smooth affine group is preserved by arbitrary field extension.
+
+The smoothness hypothesis is used to promote solvability over one algebraic closure to a
+universal derived-word identity. That identity then holds over the algebraic closure of the
+larger field, and the standard base-change equivalence of point groups transfers solvability. -/
+theorem baseChange {K : Type w} [Field K] [Algebra k K]
+    (H : CommHopfAlgCat.{v} k) (hH_smooth : Algebra.Smooth k H)
+    (hH : geometricallySolvablePointsCommHopfAlgProperty k H) :
+    geometricallySolvablePointsCommHopfAlgProperty K
+      (CommHopfAlgCat.baseChange (K := K) H) := by
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff]
+  obtain ⟨n, hword⟩ := exists_universalDerivedWord_eq_one hH_smooth hH
+  let _ : Algebra k (AlgebraicClosure K) :=
+    Algebra.compHom (AlgebraicClosure K) (algebraMap k K)
+  have hpoints : Group.IsSolvable
+      (HopfAlgebra.points (R := k) (H := H)
+        (CommAlgCat.of k (AlgebraicClosure K))) :=
+    isSolvable_points_of_universalDerivedWord_eq_one n hword
+  let e := CommHopfAlgCat.baseChangePointsMulEquiv (K := K)
+    (CommAlgCat.of K (AlgebraicClosure K)) H
+  let _ := hpoints
+  exact Group.isSolvable_of_isSolvable_injective (f := e.toMonoidHom) e.injective
 
 end geometricallySolvablePointsCommHopfAlgProperty
 


### PR DESCRIPTION
This PR preserves geometric solvability of a smooth affine group under arbitrary field extension, proves that scalar extension carries every solvable-radical candidate to a solvable-radical candidate, and deduces that the solvable radical formed after base change contains the base change of the original radical.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, “develop the radical `R(G)` (maximal connected normal solvable, geometric).” Its scalar-extension interface consumes `geometricallySolvablePointsCommHopfAlgProperty.baseChange`: normality, geometric connectedness, smoothness, and quotient/base-change transport already existed, while geometric solvability was the one candidate condition that could not yet be transported.

This is the most effective current step because the solvable radical and its universal property are already on `main`, the open isomorphism-invariance work is independent, and this PR turns the existing construction into a field-extension-compatible one rather than adding another auxiliary candidate lemma.

The proof extracts a universal derived-word identity from smooth geometric solvability using finite-type point separation, specializes that identity over the algebraic closure of the larger field, and transports the resulting solvability through `CommHopfAlgCat.baseChangePointsMulEquiv`. The radical result then reuses `CommHopfAlgCat.quotientBaseChangeIso`, base-change preservation of normality and geometric connectedness, Mathlib's `Algebra.Smooth.baseChange`, and the radical's existing least-ideal universal property. No Mathlib infrastructure or external formalization is vendored; the mathematical organization follows Milne, *Algebraic Groups* (2017), Proposition 6.42 and §§6.45–6.46, and Borel, *Linear Algebraic Groups*, §11.21, as cited in the module documentation.

After this PR, the Layer 6 scalar-extension substep still needs the reverse containment—equivalently, descent of an arbitrary solvable-radical candidate over the extension field—to upgrade the canonical containment to equality; the broader milestone then continues with central isogenies and simply-connected and adjoint forms.

Add `TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/BaseChange.lean` (109 lines) and refactor the private universal-word proof in `Solvable/Reduced.lean` while adding its field-extension theorem (88 additions, 44 deletions). No modules are moved or renamed.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geometric-solvability-base-change"}-->

🤖 Prepared with Codex
