### PR TITLE
feat: audit the Ru and Th presentation rows

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HaradaNorton.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HaradaNorton.lean
@@ -41,35 +41,9 @@ The source-to-Lean transcription has been read against both the corrected printe
 machine-readable Magma file. An independent read-through remains part of the S1 review artifact.
 This file asserts no order, finiteness, simplicity, or identification result.
 
-## The letter counts
-
-The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
-relator expressions with their generator indices written out, and the provenance a manifest row
-exists to record. Further decidable checks accompany them. The lengths of the compiled relator
-words, one at a time and in aggregate, record the transcription as written, so a dropped or
-duplicated letter shows up at the relator that carries it. Exactly one compiled word is not reduced:
-the fifth relator `a⁻²(abab³)³` puts the second letter of `a⁻²` against the `a` opening `abab³`, and
-that single cancelling pair is the two letters by which the compiled count `153` exceeds the reduced
-count `151`. Free reduction leaves every relator cyclically reduced, which is what makes the reduced
-figure the one comparable with a published presentation length, since such a length is measured
-after free and cyclic reduction.
-
-No such length is published for this presentation: `HNpb.m` is a Magma file of relator words with no
-letter count, the paper's known-errors record adds none, and Bray's presentation page for `HN` is
-one of the 1997 stubs that print `Length ??`. The figures below therefore state the transcribed
-data for a reviewer to compare with the source, rather than checking it against a recorded number.
-
-## Main definitions and results
+## Main definition
 
 * `TauCeti.Sporadic.hnPresentation`: the Bray--Curtis finite presentation of `HN`.
-* `TauCeti.Sporadic.transcribed_hnPresentation` and the equations for the remaining fields: the
-  characterization of the sealed row.
-* `TauCeti.Sporadic.map_length_relators_hnPresentation` and
-  `TauCeti.Sporadic.totalLength_hnPresentation`: the letter counts of the compiled words.
-* `TauCeti.Sporadic.map_length_reduce_relators_hnPresentation` and
-  `TauCeti.Sporadic.reducedTotalLength_hnPresentation`: the same counts after free reduction.
-* `TauCeti.Sporadic.isCyclicallyReduced_reduce_mem_hnPresentation_relators`: the reduced words are
-  cyclically reduced.
 
 ## References
 
@@ -80,9 +54,6 @@ data for a reviewer to compare with the source, rather than checking it against 
   <https://webspace.maths.qmul.ac.uk/j.n.bray/Papers/HN/HN.html>, and the corrected
   machine-readable presentation,
   <https://webspace.maths.qmul.ac.uk/j.n.bray/Papers/HN/HNpb.m>.
-* J. N. Bray, presentation page for the Harada--Norton group,
-  <https://webspace.maths.qmul.ac.uk/j.n.bray/web/Pres/HN.html>, which records `Length ??` and so
-  publishes no letter count.
 -/
 
 public section
@@ -159,57 +130,6 @@ theorem generatorNames_hnPresentation :
     hnPresentation.generatorNames = ["a", "b", "c", "d", "t"] := by
   simp [hnPresentation]
 
-/-- The source recorded for `HN`. The row's body is sealed, so this equation publishes the citation
-itself, rather than only the row's name, to a downstream audit. -/
-@[simp]
-theorem source_hnPresentation :
-    hnPresentation.source = "J. N. Bray and R. T. Curtis, Monomial modular representations and \
-      symmetric generation of the Harada--Norton group, J. Algebra 268 (2003), 723--743" := by
-  simp [hnPresentation]
-
-/-- The locator recorded for `HN`, naming both the sections of the paper and the corrected Magma
-file that carries the same nineteen relators. -/
-@[simp]
-theorem sourceLocator_hnPresentation :
-    hnPresentation.sourceLocator = "Sections 4--5, especially p. 735; corrected Magma file HNpb.m \
-      at https://webspace.maths.qmul.ac.uk/j.n.bray/Papers/HN/HNpb.m" := by
-  simp [hnPresentation]
-
-/-- The generator convention recorded for `HN`, fixing which generator each relator index names and
-which commutator and conjugation conventions the source uses. -/
-@[simp]
-theorem generatorConvention_hnPresentation :
-    hnPresentation.generatorConvention = "The generators a, b, c, d and t of Bray--Curtis HNpb.m, \
-      in that order, so indices 0 through 4 have those names. Products are read left to right, \
-      negative exponents denote inverses, [r,s] denotes r^-1 s^-1 r s, and r^s denotes \
-      s^-1 r s." := by
-  simp [hnPresentation]
-
-/-- The transcription notes recorded for `HN`, including the correction the authors' known-errors
-record makes to the twelfth relator. -/
-@[simp]
-theorem transcriptionNotes_hnPresentation :
-    hnPresentation.transcriptionNotes = "The nineteen words in the first presentation of the \
-      corrected HNpb.m file are stored as nineteen relators equal to the identity. They agree in \
-      order and spelling with the five-generator presentation displayed in Section 5 of the \
-      corrected paper. The corrected source uses (a*d)^2 as its twelfth relator; the authors' \
-      known-errors record notes that the preprint's [a,d] at this position was wrong. An \
-      independent source-to-Lean read-through remains part of the S1 review artifact." := by
-  simp [hnPresentation]
-
-/-- The generator count `HN`'s source states. With
-`TauCeti.Sporadic.generatorNames_hnPresentation` this makes
-`TauCeti.Sporadic.matchesMetadata_hnPresentation` an equation between two visible numbers. -/
-@[simp]
-theorem expectedGeneratorCount_hnPresentation : hnPresentation.expectedGeneratorCount = 5 := by
-  simp [hnPresentation]
-
-/-- The relator count `HN`'s source states; see
-`TauCeti.Sporadic.expectedGeneratorCount_hnPresentation`. -/
-@[simp]
-theorem expectedRelatorCount_hnPresentation : hnPresentation.expectedRelatorCount = 19 := by
-  simp [hnPresentation]
-
 /-- The relator expressions transcribed for `HN`, with their generator indices written out.
 
 The row's body is sealed, so this is the equation that characterizes it: with
@@ -274,54 +194,5 @@ theorem transcribed_hnPresentation :
 
 /-- The generator and relator counts recorded for `HN` agree with the transcribed data. -/
 theorem matchesMetadata_hnPresentation : hnPresentation.matchesMetadata := by decide
-
-/-! ### The letter counts of the compiled words -/
-
-/-- The lengths of the nineteen compiled relator words for `HN`, in the source's order.
-
-Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
-than only observe one in the total of `TauCeti.Sporadic.totalLength_hnPresentation`. -/
-theorem map_length_relators_hnPresentation :
-    hnPresentation.relators.map List.length =
-      [4, 6, 7, 12, 20, 20, 4, 4, 8, 18, 2, 4, 4, 15, 5, 5, 5, 4, 6] := by
-  simp [GroupPresentation.relators_def, transcribed_hnPresentation]
-
-/-- The compiled relator words for `HN` have `153` letters in total. The fifth of them is not
-reduced, so `TauCeti.Sporadic.reducedTotalLength_hnPresentation` and not this figure is the one to
-compare with a published presentation length. -/
-theorem totalLength_hnPresentation : hnPresentation.totalLength = 153 := by
-  rw [GroupPresentation.totalLength_def, map_length_relators_hnPresentation]
-  decide
-
-/-- The lengths of the nineteen compiled relator words for `HN` after free reduction. Only the fifth
-entry differs from `TauCeti.Sporadic.map_length_relators_hnPresentation`, by the cancelling pair at
-the junction of the two factors of `a⁻²(abab³)³`. -/
-theorem map_length_reduce_relators_hnPresentation :
-    (hnPresentation.relators.map fun w => (FreeGroup.reduce w).length) =
-      [4, 6, 7, 12, 18, 20, 4, 4, 8, 18, 2, 4, 4, 15, 5, 5, 5, 4, 6] := by
-  simp only [GroupPresentation.relators_def, transcribed_hnPresentation, List.map_cons,
-    List.map_nil, Relator.toWord_gen, Relator.toWord_inv, Relator.toWord_mul, Relator.toWord_pow,
-    Relator.toWord_comm]
-  decide
-
-/-- The freely reduced relator words for `HN` have `151` letters in total. No length is recorded for
-this presentation to compare it with, so this figure states the transcribed data for a reviewer to
-check against the source rather than against a published number. -/
-theorem reducedTotalLength_hnPresentation :
-    (hnPresentation.relators.map fun w => (FreeGroup.reduce w).length).sum = 151 := by
-  rw [map_length_reduce_relators_hnPresentation]
-  decide
-
-/-- Free reduction makes every compiled relator word for `HN` cyclically reduced.
-
-This is what makes the letter count of `TauCeti.Sporadic.reducedTotalLength_hnPresentation`
-comparable with a published presentation length, which is measured after free and cyclic reduction
-of each relator. -/
-theorem isCyclicallyReduced_reduce_mem_hnPresentation_relators :
-    ∀ w ∈ hnPresentation.relators, FreeGroup.IsCyclicallyReduced (FreeGroup.reduce w) := by
-  simp only [GroupPresentation.relators_def, transcribed_hnPresentation, List.map_cons,
-    List.map_nil, Relator.toWord_gen, Relator.toWord_inv, Relator.toWord_mul, Relator.toWord_pow,
-    Relator.toWord_comm]
-  decide
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HaradaNorton.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HaradaNorton.lean
@@ -41,9 +41,35 @@ The source-to-Lean transcription has been read against both the corrected printe
 machine-readable Magma file. An independent read-through remains part of the S1 review artifact.
 This file asserts no order, finiteness, simplicity, or identification result.
 
-## Main definition
+## The letter counts
+
+The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
+relator expressions with their generator indices written out, and the provenance a manifest row
+exists to record. Further decidable checks accompany them. The lengths of the compiled relator
+words, one at a time and in aggregate, record the transcription as written, so a dropped or
+duplicated letter shows up at the relator that carries it. Exactly one compiled word is not reduced:
+the fifth relator `a⁻²(abab³)³` puts the second letter of `a⁻²` against the `a` opening `abab³`, and
+that single cancelling pair is the two letters by which the compiled count `153` exceeds the reduced
+count `151`. Free reduction leaves every relator cyclically reduced, which is what makes the reduced
+figure the one comparable with a published presentation length, since such a length is measured
+after free and cyclic reduction.
+
+No such length is published for this presentation: `HNpb.m` is a Magma file of relator words with no
+letter count, the paper's known-errors record adds none, and Bray's presentation page for `HN` is
+one of the 1997 stubs that print `Length ??`. The figures below therefore state the transcribed
+data for a reviewer to compare with the source, rather than checking it against a recorded number.
+
+## Main definitions and results
 
 * `TauCeti.Sporadic.hnPresentation`: the Bray--Curtis finite presentation of `HN`.
+* `TauCeti.Sporadic.transcribed_hnPresentation` and the equations for the remaining fields: the
+  characterization of the sealed row.
+* `TauCeti.Sporadic.map_length_relators_hnPresentation` and
+  `TauCeti.Sporadic.totalLength_hnPresentation`: the letter counts of the compiled words.
+* `TauCeti.Sporadic.map_length_reduce_relators_hnPresentation` and
+  `TauCeti.Sporadic.reducedTotalLength_hnPresentation`: the same counts after free reduction.
+* `TauCeti.Sporadic.isCyclicallyReduced_reduce_mem_hnPresentation_relators`: the reduced words are
+  cyclically reduced.
 
 ## References
 
@@ -54,6 +80,9 @@ This file asserts no order, finiteness, simplicity, or identification result.
   <https://webspace.maths.qmul.ac.uk/j.n.bray/Papers/HN/HN.html>, and the corrected
   machine-readable presentation,
   <https://webspace.maths.qmul.ac.uk/j.n.bray/Papers/HN/HNpb.m>.
+* J. N. Bray, presentation page for the Harada--Norton group,
+  <https://webspace.maths.qmul.ac.uk/j.n.bray/web/Pres/HN.html>, which records `Length ??` and so
+  publishes no letter count.
 -/
 
 public section
@@ -130,6 +159,57 @@ theorem generatorNames_hnPresentation :
     hnPresentation.generatorNames = ["a", "b", "c", "d", "t"] := by
   simp [hnPresentation]
 
+/-- The source recorded for `HN`. The row's body is sealed, so this equation publishes the citation
+itself, rather than only the row's name, to a downstream audit. -/
+@[simp]
+theorem source_hnPresentation :
+    hnPresentation.source = "J. N. Bray and R. T. Curtis, Monomial modular representations and \
+      symmetric generation of the Harada--Norton group, J. Algebra 268 (2003), 723--743" := by
+  simp [hnPresentation]
+
+/-- The locator recorded for `HN`, naming both the sections of the paper and the corrected Magma
+file that carries the same nineteen relators. -/
+@[simp]
+theorem sourceLocator_hnPresentation :
+    hnPresentation.sourceLocator = "Sections 4--5, especially p. 735; corrected Magma file HNpb.m \
+      at https://webspace.maths.qmul.ac.uk/j.n.bray/Papers/HN/HNpb.m" := by
+  simp [hnPresentation]
+
+/-- The generator convention recorded for `HN`, fixing which generator each relator index names and
+which commutator and conjugation conventions the source uses. -/
+@[simp]
+theorem generatorConvention_hnPresentation :
+    hnPresentation.generatorConvention = "The generators a, b, c, d and t of Bray--Curtis HNpb.m, \
+      in that order, so indices 0 through 4 have those names. Products are read left to right, \
+      negative exponents denote inverses, [r,s] denotes r^-1 s^-1 r s, and r^s denotes \
+      s^-1 r s." := by
+  simp [hnPresentation]
+
+/-- The transcription notes recorded for `HN`, including the correction the authors' known-errors
+record makes to the twelfth relator. -/
+@[simp]
+theorem transcriptionNotes_hnPresentation :
+    hnPresentation.transcriptionNotes = "The nineteen words in the first presentation of the \
+      corrected HNpb.m file are stored as nineteen relators equal to the identity. They agree in \
+      order and spelling with the five-generator presentation displayed in Section 5 of the \
+      corrected paper. The corrected source uses (a*d)^2 as its twelfth relator; the authors' \
+      known-errors record notes that the preprint's [a,d] at this position was wrong. An \
+      independent source-to-Lean read-through remains part of the S1 review artifact." := by
+  simp [hnPresentation]
+
+/-- The generator count `HN`'s source states. With
+`TauCeti.Sporadic.generatorNames_hnPresentation` this makes
+`TauCeti.Sporadic.matchesMetadata_hnPresentation` an equation between two visible numbers. -/
+@[simp]
+theorem expectedGeneratorCount_hnPresentation : hnPresentation.expectedGeneratorCount = 5 := by
+  simp [hnPresentation]
+
+/-- The relator count `HN`'s source states; see
+`TauCeti.Sporadic.expectedGeneratorCount_hnPresentation`. -/
+@[simp]
+theorem expectedRelatorCount_hnPresentation : hnPresentation.expectedRelatorCount = 19 := by
+  simp [hnPresentation]
+
 /-- The relator expressions transcribed for `HN`, with their generator indices written out.
 
 The row's body is sealed, so this is the equation that characterizes it: with
@@ -194,5 +274,54 @@ theorem transcribed_hnPresentation :
 
 /-- The generator and relator counts recorded for `HN` agree with the transcribed data. -/
 theorem matchesMetadata_hnPresentation : hnPresentation.matchesMetadata := by decide
+
+/-! ### The letter counts of the compiled words -/
+
+/-- The lengths of the nineteen compiled relator words for `HN`, in the source's order.
+
+Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
+than only observe one in the total of `TauCeti.Sporadic.totalLength_hnPresentation`. -/
+theorem map_length_relators_hnPresentation :
+    hnPresentation.relators.map List.length =
+      [4, 6, 7, 12, 20, 20, 4, 4, 8, 18, 2, 4, 4, 15, 5, 5, 5, 4, 6] := by
+  simp [GroupPresentation.relators_def, transcribed_hnPresentation]
+
+/-- The compiled relator words for `HN` have `153` letters in total. The fifth of them is not
+reduced, so `TauCeti.Sporadic.reducedTotalLength_hnPresentation` and not this figure is the one to
+compare with a published presentation length. -/
+theorem totalLength_hnPresentation : hnPresentation.totalLength = 153 := by
+  rw [GroupPresentation.totalLength_def, map_length_relators_hnPresentation]
+  decide
+
+/-- The lengths of the nineteen compiled relator words for `HN` after free reduction. Only the fifth
+entry differs from `TauCeti.Sporadic.map_length_relators_hnPresentation`, by the cancelling pair at
+the junction of the two factors of `a⁻²(abab³)³`. -/
+theorem map_length_reduce_relators_hnPresentation :
+    (hnPresentation.relators.map fun w => (FreeGroup.reduce w).length) =
+      [4, 6, 7, 12, 18, 20, 4, 4, 8, 18, 2, 4, 4, 15, 5, 5, 5, 4, 6] := by
+  simp only [GroupPresentation.relators_def, transcribed_hnPresentation, List.map_cons,
+    List.map_nil, Relator.toWord_gen, Relator.toWord_inv, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_comm]
+  decide
+
+/-- The freely reduced relator words for `HN` have `151` letters in total. No length is recorded for
+this presentation to compare it with, so this figure states the transcribed data for a reviewer to
+check against the source rather than against a published number. -/
+theorem reducedTotalLength_hnPresentation :
+    (hnPresentation.relators.map fun w => (FreeGroup.reduce w).length).sum = 151 := by
+  rw [map_length_reduce_relators_hnPresentation]
+  decide
+
+/-- Free reduction makes every compiled relator word for `HN` cyclically reduced.
+
+This is what makes the letter count of `TauCeti.Sporadic.reducedTotalLength_hnPresentation`
+comparable with a published presentation length, which is measured after free and cyclic reduction
+of each relator. -/
+theorem isCyclicallyReduced_reduce_mem_hnPresentation_relators :
+    ∀ w ∈ hnPresentation.relators, FreeGroup.IsCyclicallyReduced (FreeGroup.reduce w) := by
+  simp only [GroupPresentation.relators_def, transcribed_hnPresentation, List.map_cons,
+    List.map_nil, Relator.toWord_gen, Relator.toWord_inv, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_comm]
+  decide
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Rudvalis.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Rudvalis.lean
@@ -69,8 +69,8 @@ data for a reviewer to compare with the source, rather than checking it against 
   `TauCeti.Sporadic.ruPresentation_totalLength`: the letter counts of the compiled words.
 * `TauCeti.Sporadic.ruPresentation_map_length_reduce_relators` and
   `TauCeti.Sporadic.ruPresentation_reducedTotalLength`: the same counts after free reduction.
-* `TauCeti.Sporadic.isCyclicallyReduced_reduce_mem_ruPresentation_relators`: the reduced words are
-  cyclically reduced.
+* `TauCeti.Sporadic.isCyclicallyReduced_reduce_of_mem_ruPresentation_relators`: the reduced words
+  are cyclically reduced.
 
 ## References
 
@@ -293,7 +293,7 @@ theorem ruPresentation_reducedTotalLength :
 This is what makes the letter count of `TauCeti.Sporadic.ruPresentation_reducedTotalLength`
 comparable with a published presentation length, which is measured after free and cyclic reduction
 of each relator. -/
-theorem isCyclicallyReduced_reduce_mem_ruPresentation_relators :
+theorem isCyclicallyReduced_reduce_of_mem_ruPresentation_relators :
     ∀ w ∈ ruPresentation.relators, FreeGroup.IsCyclicallyReduced (FreeGroup.reduce w) := by
   simp only [GroupPresentation.relators_def, ruPresentation_transcribed, List.map_cons,
     List.map_nil, Relator.toWord_gen, Relator.toWord_inv, Relator.toWord_mul, Relator.toWord_pow,

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Rudvalis.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Rudvalis.lean
@@ -43,9 +43,34 @@ part of the abstract presentation and are therefore recorded in the metadata but
 relations. This file asserts no order, finiteness, simplicity, or identification result. A separate
 source-to-Lean read-through remains part of the S1 review artifact required by the roadmap.
 
-## Main definition
+## The letter counts
+
+Further decidable checks accompany the count check on the transcribed data. The lengths of the
+compiled relator words, one at a time and in aggregate, record the transcription as written, so a
+dropped or duplicated letter shows up at the relator that carries it. Exactly one of those words is
+not reduced: in the twelfth relator, the tenth source word `(uvtv[(uv)⁻¹tuv,u]²)²`, each of the two
+halves puts the `v` ending its prefix `uvtv` against the `v⁻¹` that opens `[(uv)⁻¹tuv,u]`, and those
+two cancelling pairs are the four letters by which the compiled count `290` exceeds the reduced
+count `286`. Free reduction leaves every relator cyclically reduced, which is what makes the reduced
+figure the one comparable with a published presentation length, since such a length is measured
+after free and cyclic reduction.
+
+No length is recorded to compare it with: none of the five `tcenum` sections described above carries
+a letter count, and Bray's presentation page for `Ru`, which in any case describes a different
+two-generator presentation, prints `Length ??`. The figures below therefore state the transcribed
+data for a reviewer to compare with the source, rather than checking it against a recorded number.
+
+## Main definitions and results
 
 * `TauCeti.Sporadic.ruPresentation`: Soicher's finite presentation of the Rudvalis group `Ru`.
+* `TauCeti.Sporadic.ruPresentation_transcribed` and the equations for the remaining fields: the
+  characterization of the sealed row.
+* `TauCeti.Sporadic.ruPresentation_map_length_relators` and
+  `TauCeti.Sporadic.ruPresentation_totalLength`: the letter counts of the compiled words.
+* `TauCeti.Sporadic.ruPresentation_map_length_reduce_relators` and
+  `TauCeti.Sporadic.ruPresentation_reducedTotalLength`: the same counts after free reduction.
+* `TauCeti.Sporadic.isCyclicallyReduced_reduce_mem_ruPresentation_relators`: the reduced words are
+  cyclically reduced.
 
 ## References
 
@@ -55,6 +80,9 @@ source-to-Lean read-through remains part of the S1 review artifact required by t
 * L. H. Soicher, `tcenum`, presentation file `presentations/Ru`, commit
   `fb9dd89130fca8ad7dc4a92537c96ce7b30b62f1`,
   <https://github.com/lhsoicher/tcenum/blob/fb9dd89130fca8ad7dc4a92537c96ce7b30b62f1/presentations/Ru>.
+* J. N. Bray, presentation page for the Rudvalis group,
+  <https://webspace.maths.qmul.ac.uk/j.n.bray/web/Pres/Ru.html>, which records `Length ??` and so
+  publishes no letter count.
 -/
 
 public section
@@ -222,6 +250,54 @@ theorem ruPresentation_transcribed :
 
 /-- The generator and relator counts recorded for `Ru` agree with the transcribed data. -/
 theorem ruPresentation_matchesMetadata : ruPresentation.matchesMetadata := by
+  decide
+
+/-! ### The letter counts of the compiled words -/
+
+/-- The lengths of the twelve compiled relator words for `Ru`, in the source's order.
+
+Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
+than only observe one in the total of `TauCeti.Sporadic.ruPresentation_totalLength`. -/
+theorem ruPresentation_map_length_relators :
+    ruPresentation.relators.map List.length = [2, 2, 4, 14, 9, 8, 8, 20, 52, 69, 46, 56] := by
+  simp [GroupPresentation.relators_def, ruPresentation_transcribed]
+
+/-- The compiled relator words for `Ru` have `290` letters in total. The twelfth of them is not
+reduced, so `TauCeti.Sporadic.ruPresentation_reducedTotalLength` and not this figure is the one to
+compare with a published presentation length. -/
+theorem ruPresentation_totalLength : ruPresentation.totalLength = 290 := by
+  rw [GroupPresentation.totalLength_def, ruPresentation_map_length_relators]
+  decide
+
+/-- The lengths of the twelve compiled relator words for `Ru` after free reduction. Only the
+twelfth entry differs from `TauCeti.Sporadic.ruPresentation_map_length_relators`, by the two
+cancelling pairs its two halves each contribute. -/
+theorem ruPresentation_map_length_reduce_relators :
+    (ruPresentation.relators.map fun w => (FreeGroup.reduce w).length) =
+      [2, 2, 4, 14, 9, 8, 8, 20, 52, 69, 46, 52] := by
+  simp only [GroupPresentation.relators_def, ruPresentation_transcribed, List.map_cons,
+    List.map_nil, Relator.toWord_gen, Relator.toWord_inv, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_comm]
+  decide
+
+/-- The freely reduced relator words for `Ru` have `286` letters in total. No length is recorded for
+this presentation to compare it with, so this figure states the transcribed data for a reviewer to
+check against the source rather than against a published number. -/
+theorem ruPresentation_reducedTotalLength :
+    (ruPresentation.relators.map fun w => (FreeGroup.reduce w).length).sum = 286 := by
+  rw [ruPresentation_map_length_reduce_relators]
+  decide
+
+/-- Free reduction makes every compiled relator word for `Ru` cyclically reduced.
+
+This is what makes the letter count of `TauCeti.Sporadic.ruPresentation_reducedTotalLength`
+comparable with a published presentation length, which is measured after free and cyclic reduction
+of each relator. -/
+theorem isCyclicallyReduced_reduce_mem_ruPresentation_relators :
+    ∀ w ∈ ruPresentation.relators, FreeGroup.IsCyclicallyReduced (FreeGroup.reduce w) := by
+  simp only [GroupPresentation.relators_def, ruPresentation_transcribed, List.map_cons,
+    List.map_nil, Relator.toWord_gen, Relator.toWord_inv, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_comm]
   decide
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Thompson.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Thompson.lean
@@ -68,6 +68,20 @@ the involutory generators off it as those carrying an explicit square relator, a
 `TauCeti.Sporadic.Thompson.generatorsWithSquareRelator_eq` identifies those five as `a, b, c, d, e`.
 A transposed or dropped power relator would show up in one of these.
 
+The letter counts of the compiled words are checked in the same spirit. Reading them off one relator
+at a time locates a discrepancy at the relator that carries it, rather than only in the total. Three
+of the thirty-nine compiled words are not reduced, and all three are equations `w₁ = w₂` compiled as
+`w₁ w₂⁻¹` whose two sides cancel at the junction: the last relator of group (2), and the last two of
+group (6). Their five cancelling pairs are the ten letters by which the compiled count `300` exceeds
+the reduced count `290`. Free reduction leaves every relator cyclically reduced, which is what makes
+the reduced figure the one comparable with a published presentation length, since such a length is
+measured after free and cyclic reduction.
+
+This row records no such length: none is transcribed from the source into the metadata below, and
+Bray's presentation page for `Th`, which in any case describes a different two-generator
+presentation, prints `Length ??`. The figures below therefore state the transcribed data for a
+reviewer to compare with the source, rather than checking it against a recorded number.
+
 Correctness of the transcription beyond that is a review obligation, exactly as the roadmap
 describes: a reviewer reads the six lists below against Theorem 3.1 of the source. Note that the
 source states that some of its relators are redundant, kept for clarity or to help the enumeration,
@@ -84,6 +98,15 @@ so the list is deliberately not minimal.
 * `TauCeti.Sporadic.Thompson.generatorsWithSquareRelator`: the generators carrying an explicit
   square relator in the transcribed data.
 
+## Main results
+
+* `TauCeti.Sporadic.Thompson.map_length_relators_presentation` and
+  `TauCeti.Sporadic.Thompson.totalLength_presentation`: the letter counts of the compiled words.
+* `TauCeti.Sporadic.Thompson.map_length_reduce_relators_presentation` and
+  `TauCeti.Sporadic.Thompson.reducedTotalLength_presentation`: the same counts after free reduction.
+* `TauCeti.Sporadic.Thompson.isCyclicallyReduced_reduce_mem_presentation_relators`: the reduced
+  words are cyclically reduced.
+
 ## References
 
 This fills one of the twenty-six rows owed by milestone S1 of
@@ -96,6 +119,10 @@ admissible source for each sporadic name. The source is
 
 Theorem 3.1 there states the presentation as relators (1) to (6) and proves that the group it
 presents is `Th`.
+
+* J. N. Bray, presentation page for the Thompson group,
+  <https://webspace.maths.qmul.ac.uk/j.n.bray/web/Pres/Th.html>, which records
+  `Length ??, 2-generator, ?-relator` and so publishes no letter count.
 -/
 
 public section
@@ -324,5 +351,83 @@ of `TauCeti.Sporadic.Thompson.matchesMetadata_presentation` do not see. -/
 theorem cosetTableColumns :
     generatorsWithSquareRelator.length +
       2 * (presentation.generatorCount - generatorsWithSquareRelator.length) = 11 := rfl
+
+/-! ### The letter counts of the compiled words -/
+
+/-- The lengths of the thirty-nine compiled relator words for `Th`, in the order of the source's six
+displayed groups.
+
+Reading the counts off one relator at a time is what lets a reviewer locate a discrepancy, rather
+than only observe one in the total of `TauCeti.Sporadic.Thompson.totalLength_presentation`. -/
+theorem map_length_relators_presentation :
+    presentation.relators.map List.length =
+      [2, 2, 2, 2, 2, 6, 4, 6, 4, 4, 9, 4, 6, 32,
+        7, 4, 4, 4, 4, 11,
+        3, 4, 4, 4, 4, 4, 5,
+        4, 4, 4, 4, 10, 11, 25,
+        4,
+        12, 8, 22, 45] := by
+  simp only [GroupPresentation.relators_def, presentation, relatorList, relatorsOne, relatorsTwo,
+    relatorsThree, relatorsFour, relatorsFive, relatorsSix, sourceCommutator, Relator.conj,
+    Relator.div, List.map_cons, List.map_nil, List.append_assoc, List.cons_append, List.nil_append,
+    Relator.toWord_gen, Relator.toWord_inv, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_comm]
+  decide
+
+/-- The compiled relator words for `Th` have `300` letters in total. Three of them are not reduced,
+so `TauCeti.Sporadic.Thompson.reducedTotalLength_presentation` and not this figure is the one to
+compare with a published presentation length. -/
+theorem totalLength_presentation : presentation.totalLength = 300 := by
+  rw [GroupPresentation.totalLength_def, map_length_relators_presentation]
+  decide
+
+/-- The lengths of the thirty-nine compiled relator words for `Th` after free reduction.
+
+Three entries differ from `TauCeti.Sporadic.Thompson.map_length_relators_presentation`: the last
+relator of group (2) and the last two of group (6), each an equation whose two sides cancel where
+they are concatenated. -/
+theorem map_length_reduce_relators_presentation :
+    (presentation.relators.map fun w => (FreeGroup.reduce w).length) =
+      [2, 2, 2, 2, 2, 6, 4, 6, 4, 4, 9, 4, 6, 32,
+        7, 4, 4, 4, 4, 9,
+        3, 4, 4, 4, 4, 4, 5,
+        4, 4, 4, 4, 10, 11, 25,
+        4,
+        12, 8, 18, 41] := by
+  simp only [GroupPresentation.relators_def, presentation, relatorList, relatorsOne, relatorsTwo,
+    relatorsThree, relatorsFour, relatorsFive, relatorsSix, sourceCommutator, Relator.conj,
+    Relator.div, List.map_cons, List.map_nil, List.append_assoc, List.cons_append, List.nil_append,
+    Relator.toWord_gen, Relator.toWord_inv, Relator.toWord_mul, Relator.toWord_pow,
+    Relator.toWord_comm]
+  decide
+
+/-- The freely reduced relator words for `Th` have `290` letters in total. No length is recorded for
+this presentation to compare it with, so this figure states the transcribed data for a reviewer to
+check against the source rather than against a published number. -/
+theorem reducedTotalLength_presentation :
+    (presentation.relators.map fun w => (FreeGroup.reduce w).length).sum = 290 := by
+  rw [map_length_reduce_relators_presentation]
+  decide
+
+/-- Free reduction makes every compiled relator word for `Th` cyclically reduced.
+
+This is what makes the letter count of
+`TauCeti.Sporadic.Thompson.reducedTotalLength_presentation` comparable with a published
+presentation length, which is measured after free and cyclic reduction of each relator. -/
+theorem isCyclicallyReduced_reduce_mem_presentation_relators :
+    ∀ w ∈ presentation.relators, FreeGroup.IsCyclicallyReduced (FreeGroup.reduce w) := by
+  -- The check runs through `List.all` rather than by `decide` on the bounded quantifier directly.
+  -- The compiled relator list of this row is a large enough term that the `Decidable` instance of
+  -- the quantifier is not synthesized on it, whereas the Boolean equation below needs only the
+  -- decidable equality of `Bool` and the pointwise instance at a single bound word.
+  have h : (presentation.relators.all fun w =>
+      decide (FreeGroup.IsCyclicallyReduced (FreeGroup.reduce w))) = true := by
+    simp only [GroupPresentation.relators_def, presentation, relatorList, relatorsOne, relatorsTwo,
+      relatorsThree, relatorsFour, relatorsFive, relatorsSix, sourceCommutator, Relator.conj,
+      Relator.div, List.map_cons, List.map_nil, List.append_assoc, List.cons_append,
+      List.nil_append, Relator.toWord_gen, Relator.toWord_inv, Relator.toWord_mul,
+      Relator.toWord_pow, Relator.toWord_comm]
+    decide
+  exact fun w hw => of_decide_eq_true (List.all_eq_true.mp h w hw)
 
 end TauCeti.Sporadic.Thompson

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Thompson.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Thompson.lean
@@ -104,7 +104,7 @@ so the list is deliberately not minimal.
   `TauCeti.Sporadic.Thompson.totalLength_presentation`: the letter counts of the compiled words.
 * `TauCeti.Sporadic.Thompson.map_length_reduce_relators_presentation` and
   `TauCeti.Sporadic.Thompson.reducedTotalLength_presentation`: the same counts after free reduction.
-* `TauCeti.Sporadic.Thompson.isCyclicallyReduced_reduce_mem_presentation_relators`: the reduced
+* `TauCeti.Sporadic.Thompson.isCyclicallyReduced_reduce_of_mem_presentation_relators`: the reduced
   words are cyclically reduced.
 
 ## References
@@ -414,7 +414,7 @@ theorem reducedTotalLength_presentation :
 This is what makes the letter count of
 `TauCeti.Sporadic.Thompson.reducedTotalLength_presentation` comparable with a published
 presentation length, which is measured after free and cyclic reduction of each relator. -/
-theorem isCyclicallyReduced_reduce_mem_presentation_relators :
+theorem isCyclicallyReduced_reduce_of_mem_presentation_relators :
     ∀ w ∈ presentation.relators, FreeGroup.IsCyclicallyReduced (FreeGroup.reduce w) := by
   -- The check runs through `List.all` rather than by `decide` on the bounded quantifier directly.
   -- The compiled relator list of this row is a large enough term that the `Decidable` instance of


### PR DESCRIPTION
This PR audits the `Ru` and `Th` rows of the sporadic presentation manifest.

Both rows gain compiled and freely reduced relator lengths, aggregate totals, and proofs that every reduced word is cyclically reduced. The checks identify the precise cancellations:

- for `Ru`, the twelfth relator contributes two cancelling pairs, so the compiled count `290` reduces to `286`;
- for `Th`, the last relator of group (2) and the last two of group (6) contribute five cancelling pairs in total, so `300` reduces to `290`.

Neither source publishes a presentation length for comparison: the `tcenum` sections contain no letter count, and Bray's presentation pages record `Length ??`. These totals therefore make the source-to-Lean transcription auditable one relator at a time without asserting a source figure that is not present.

This advances `CFSGStatement/README.md`, target S1 ("the twenty-six sporadic presentations"), by adding the per-relator and aggregate checks for the `Ru` and `Th` rows. The concurrently developed HN audit is kept in #5304, so this PR no longer changes `HaradaNorton.lean`.

Roadmap: CFSGStatement
<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"ru-th-presentation-row-audit"}-->
