### PR TITLE
fix: align review status labels with worker

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -14,8 +14,9 @@ name: PR status labels
 # and the review engine's <!--tauceti-review-in-progress--> marker. It assumes nothing about any
 # worker or review harness -- a harness that posts the (optional) in-progress marker gets a
 # review-in-progress label; one that doesn't just shows awaiting-review during review. reconcile is
-# idempotent and convergent, so the trigger only decides *when* to refresh; a forged comment can only
-# TRIGGER a re-derive (from author-association-checked data), never supply a verdict.
+# idempotent and convergent, so the trigger only decides *when* to refresh. Like the worker and
+# auto-merge, status derivation deliberately accepts the newest marked scoreboard from any author;
+# the label is presentation, while trusted build/scope/axiom/bump statuses remain the hard boundary.
 #
 # Runs on pull_request_target so it can label fork PRs, but it NEVER checks out or executes PR head
 # code: it reads only PR metadata via the API and runs the trusted base-branch script under a scoped
@@ -210,11 +211,11 @@ jobs:
           PR: ${{ needs.resolve.outputs.pr }}
         run: python3 scripts/pr_status/labels.py reconcile "$PR"
 
-  # Scheduled backstop: reconcile the PRs currently carrying review-in-progress, so an expired
-  # in-flight marker (a crashed review) drops the label even though nothing else fired. It is the only
-  # label that can go stale with no event; the other five are always refreshed by a build/scoreboard/PR
-  # event. Note the deliberately narrow scope -- this is NOT a general repair pass over every open PR,
-  # so nothing here rescues a PR whose label is wrong for some other reason.
+  # Scheduled backstop: reconcile PRs currently waiting for or undergoing review. This clears an
+  # expired review-in-progress marker even though nothing else fired, self-heals a missed scoreboard
+  # event, and migrates existing awaiting-review labels when the scoreboard selection policy changes.
+  # Keep the scope to these two labels rather than rereading every open PR forever: after a migration
+  # drains, the steady-state cost is just the genuine review queue.
   #
   # Its own concurrency group keeps two sweeps from overlapping. It is a different group from the
   # per-PR one, so a sweep CAN run alongside a per-PR job for a PR it happens to be reconciling. That
@@ -242,17 +243,22 @@ jobs:
         with:
           sparse-checkout: scripts/pr_status
           persist-credentials: false
-      - name: Reconcile PRs holding review-in-progress
+      - name: Reconcile PRs waiting for or undergoing review
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Tolerate the label not existing yet (no review has ever been in progress): an empty/failed
-          # list just means nothing to sweep.
-          prs=$(gh pr list --repo "$REPO" --state open --label review-in-progress \
-                  --json number --jq '.[].number' 2>/dev/null || true)
+          # Tolerate either label not existing yet: an empty/failed list for that label contributes
+          # nothing. De-duplicate defensively even though the status-label invariant says a PR carries
+          # exactly one of them.
+          prs=$(
+            for label in awaiting-review review-in-progress; do
+              gh pr list --repo "$REPO" --state open --label "$label" \
+                --limit 1000 --json number --jq '.[].number' 2>/dev/null || true
+            done | sort -nu
+          )
           for pr in $prs; do
             python3 scripts/pr_status/labels.py reconcile "$pr"
           done

--- a/scripts/housekeeping.py
+++ b/scripts/housekeeping.py
@@ -42,9 +42,9 @@ import sys
 
 REPO = os.environ["REPO"]
 
-# The trusted-scoreboard parse lives once, in the pr_status package; import it rather than keeping a
-# second copy here (the two had drifted on the meta regex). This script is parameterised by $REPO, so
-# point core's reads at the same repo.
+# The scoreboard parse and explicit repo-associated selector live once, in the pr_status package;
+# import them rather than keeping a second copy here (the parsers had drifted before). This script is
+# parameterised by $REPO, so point core's reads at the same repo.
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "pr_status"))
 import core  # noqa: E402
 
@@ -121,10 +121,11 @@ def parse_ts(s: str) -> datetime.datetime:
 def latest_scoreboard_meta(pr: int):
     """The meta block of the newest TRUSTED review scoreboard comment, or None. Trust = the
     `tauceti-scoreboard` marker AND a repo-associated author (so an external author cannot forge a
-    verdict). Delegates to the shared `core.scoreboard_meta` so that parse lives in one place; fails
-    safe (None) on any API/parse error, so a hiccup never causes a wrong close."""
+    verdict). Delegates to the shared `core.repo_associated_scoreboard_meta` so both the parse and the
+    destructive trust policy live in one place; fails safe (None) on any API/parse error, so a hiccup
+    never causes a wrong close."""
     try:
-        return core.scoreboard_meta(pr) or None
+        return core.repo_associated_scoreboard_meta(pr) or None
     except Exception as e:
         print(f"#{pr}: scoreboard fetch failed ({e}); leaving it", file=sys.stderr)
         return None

--- a/scripts/pr_status/README.md
+++ b/scripts/pr_status/README.md
@@ -9,7 +9,7 @@ source of truth:
   carrying emoji that track the same states at a glance.
 
 [`core.py`](core.py) is that source of truth. It derives a PR's status from
-GitHub (PR state, the `build` commit status, the newest repo-associated
+GitHub (PR state, the `build` commit status, the newest
 `<!--tauceti-scoreboard-->` comment's meta JSON, and the review engine's
 `<!--tauceti-review-in-progress-->` marker) and returns a neutral
 `{lifecycle, ci, review, review_inprogress}`. It writes nothing. The two *sinks*
@@ -28,14 +28,17 @@ reactions can never disagree:
 | ci `success`, review pending, no marker | `awaiting-review` | 🟢 |
 
 Both review signals (the scoreboard meta and the in-progress marker) are read
-only from comments by a repo-associated author (OWNER/MEMBER/COLLABORATOR), from
-one comment fetch, so a fork PR author cannot forge status labels or housekeeping
-state. This status-sink policy is deliberately narrower than auto-merge's
-newest-scoreboard policy. Every reconcile
-reads GitHub afresh and drives the sink to the correct state, so the same command
-powers the event-driven workflows and a one-shot backfill, and a transient hiccup
-self-heals on the next event. The only dependencies are python3's standard library
-and an authenticated `gh` CLI, nothing from PyPI.
+from all comments in one fetch. The newest marked scoreboard counts regardless
+of author association, matching the worker and auto-merge: a contributor-posted
+review therefore moves the PR out of `awaiting-review` everywhere at once. Status
+labels and reactions are presentation, not a security boundary; trusted commit
+statuses still enforce build, scope, axiom and bump guards. Destructive
+housekeeping separately calls `core.repo_associated_scoreboard_meta`, retaining
+its OWNER/MEMBER/COLLABORATOR-only close policy. Every reconcile reads GitHub
+afresh and drives the sink to the correct state, so the same command powers the
+event-driven workflows and a one-shot backfill, and a transient hiccup self-heals
+on the next event. The only dependencies are python3's standard library and an
+authenticated `gh` CLI, nothing from PyPI.
 
 ## Labels
 
@@ -53,8 +56,9 @@ in-flight marker (`<!--tauceti-review-in-progress-->`, carrying a `head` and an
 harness MAY post: an unexpired, head-exact marker while the PR is otherwise
 `awaiting-review` shows `review-in-progress`. A harness that posts no marker just
 leaves the PR at `awaiting-review` during review, which is never wrong; and the
-marker's TTL means a crashed review self-heals, since the hourly `sweep` job
-clears the label once the marker expires even if no other event fires.
+marker's TTL means a crashed review self-heals. The hourly `sweep` reconciles
+both review-waiting labels, clearing an expired marker even if no other event
+fires and repairing a missed or newly reinterpreted scoreboard event.
 
 The review verdict itself comes from the scoreboard's durable per-rubric `states`
 map, not the latest round's `runs`: a reply/partial round re-runs only some
@@ -76,8 +80,8 @@ or runs PR head code. Triggers:
   a late `requested` for an old head could force `awaiting-CI` onto a moved PR,
   and a new commit already paints `awaiting-CI` via `synchronize`.)
 - `issue_comment` carrying the scoreboard or in-progress marker.
-- `schedule` (hourly): the `sweep` backstop that clears an expired
-  `review-in-progress`.
+- `schedule` (hourly): the `sweep` backstop for `awaiting-review` and
+  `review-in-progress`, including policy migrations and expired markers.
 - `workflow_dispatch`: manual re-sync of one PR.
 
 ## Zulip reactions

--- a/scripts/pr_status/core.py
+++ b/scripts/pr_status/core.py
@@ -3,8 +3,8 @@
 
 This is the single place that reads what a PR's status *is* -- its lifecycle
 (open / merged / closed), its `build` CI state, and its review state (from the
-newest repo-associated `<!--tauceti-scoreboard-->` comment's meta JSON), plus whether a review
-is in flight right now (from the engine's `<!--tauceti-review-in-progress-->`
+newest `<!--tauceti-scoreboard-->` comment's meta JSON), plus whether a review is
+in flight right now (from the engine's `<!--tauceti-review-in-progress-->`
 marker). Every status *sink* imports it and renders that one truth its own way:
 
   * zulip.py   -> two independent groups of emoji reactions on the PR's message
@@ -13,11 +13,16 @@ marker). Every status *sink* imports it and renders that one truth its own way:
 Keeping the derivation here means the two sinks can never disagree about what a
 PR's state is: they read the same `derive()` and only differ in how they show it.
 
-Everything here reads only trusted GitHub data. The two review signals -- the scoreboard meta and
-the in-progress marker -- are taken only from comments by a repo-associated author
-(OWNER/MEMBER/COLLABORATOR), so a fork PR author cannot forge status labels or housekeeping state.
-This status-sink policy is deliberately narrower than auto-merge's newest-scoreboard policy. Both
-signals are extracted from ONE comment fetch.
+The status sinks deliberately use the same no-author-bar policy as the worker and auto-merge: the
+newest marked scoreboard counts regardless of the comment author's repository association. A review
+posted by a contributor is therefore reflected in labels and Zulip instead of remaining visibly
+`awaiting-review` after the worker has recorded the head as reviewed. The status labels are not a
+security boundary; the build, scope, axiom and bump guards remain trusted commit statuses.
+
+Destructive housekeeping is intentionally stricter. It calls
+`repo_associated_scoreboard_meta`, which accepts only comments by OWNER/MEMBER/COLLABORATOR accounts,
+so an arbitrary commenter cannot make housekeeping close somebody else's PR. Both status review
+signals are extracted from one all-comments fetch.
 
 The module is a pure library -- importing it has no side effects, writes nothing,
 and needs only python3's standard library plus an authenticated `gh` CLI (via
@@ -40,7 +45,7 @@ _META_RE = re.compile(r"<!--tauceti-meta:v1\s+(\{.*\})\s*-->", re.S)
 # `expires_at` (epoch seconds) so a crashed reviewer self-clears. The format is owned by the review
 # engine; we parse only those two fields (mirrors the worker's de-contention read).
 _INPROGRESS_RE = re.compile(r"<!--tauceti-review-in-progress (.*?)-->", re.S)
-_TRUSTED_ASSOC = ("OWNER", "MEMBER", "COLLABORATOR")
+_REPO_ASSOCIATED = ("OWNER", "MEMBER", "COLLABORATOR")
 
 
 # ----- GitHub truth (via the gh CLI, authenticated by GH_TOKEN) ---------------
@@ -103,15 +108,17 @@ def pr_state(pr):
     }
 
 
-def trusted_comments(pr):
-    """Issue comments authored by a repo-associated account (OWNER/MEMBER/COLLABORATOR), as
-    `[{'body','updated'}]`. One paginated fetch, reused for both review signals below, so an
-    untrusted fork-PR comment can never forge review state. The jq emits one compact object per
-    line (valid JSONL across any number of pages)."""
+def issue_comments(pr):
+    """All issue comments as `[{'body','updated','author_association'}]`.
+
+    One paginated fetch is reused for both status review signals below. The jq emits one compact
+    object per line (valid JSONL across any number of pages). Keeping the association in the neutral
+    row lets destructive callers apply the stricter repository-associated policy without duplicating
+    the fetch or the scoreboard parser.
+    """
     out = gh_api(
         f"/repos/{REPO}/issues/{pr}/comments?per_page=100",
-        jq='.[] | select(.author_association|IN("OWNER","MEMBER","COLLABORATOR"))'
-           ' | {body: .body, updated: .updated_at}',
+        jq='.[] | {body: .body, updated: .updated_at, author_association: .author_association}',
         paginate=True,
     )
     rows = []
@@ -126,8 +133,13 @@ def trusted_comments(pr):
     return rows
 
 
+def repo_associated_comments(pr):
+    """Only comments by OWNER/MEMBER/COLLABORATOR accounts, for destructive consumers."""
+    return [c for c in issue_comments(pr) if c.get("author_association") in _REPO_ASSOCIATED]
+
+
 def scoreboard_meta_from(comments):
-    """The newest scoreboard comment's meta JSON ({} if none), from a trusted-comment list."""
+    """The newest scoreboard comment's meta JSON ({} if none) from the supplied comment policy."""
     best = None
     for c in comments:
         if SCOREBOARD_MARKER in (c.get("body") or ""):
@@ -145,12 +157,17 @@ def scoreboard_meta_from(comments):
 
 
 def scoreboard_meta(pr):
-    """Convenience: the scoreboard meta for a PR (fetches trusted comments itself)."""
-    return scoreboard_meta_from(trusted_comments(pr))
+    """Newest marked scoreboard from any author, matching the worker and auto-merge policy."""
+    return scoreboard_meta_from(issue_comments(pr))
+
+
+def repo_associated_scoreboard_meta(pr):
+    """Newest marked scoreboard from a repo-associated author, for destructive consumers."""
+    return scoreboard_meta_from(repo_associated_comments(pr))
 
 
 def inprogress_from(comments, head, now):
-    """True iff some trusted comment carries an UNEXPIRED in-progress marker for exactly `head`.
+    """True iff some supplied comment carries an UNEXPIRED in-progress marker for exactly `head`.
 
     Head-exact (a new push is a new review unit, not covered by an old marker) and TTL-bounded
     (a crashed reviewer's marker self-clears once `expires_at` passes), mirroring the engine's own
@@ -271,7 +288,7 @@ def derive(pr, ci_override=None, state=None, now=None):
             ci = None if ci_override == "none" else ci_override
         else:
             ci = ci_status(st["head"])
-        comments = trusted_comments(pr)
+        comments = issue_comments(pr)
         review = review_state(scoreboard_meta_from(comments), st["head"])
         inprogress = inprogress_from(comments, st["head"], int(time.time()) if now is None else now)
 

--- a/scripts/pr_status/stuck_alerts.py
+++ b/scripts/pr_status/stuck_alerts.py
@@ -472,10 +472,8 @@ def detect_stranded_prs():
         ready_since = min(hours_since(updated), hours_since(applied))
         if ready_since < STRANDED_HOURS:
             continue
-        # This detector deliberately uses the repo-associated scoreboard selected by the status
-        # sinks. Auto-merge instead reads the newest marked scoreboard from any author, so an
-        # external review may merge without this detector ever considering it approved. That makes
-        # the alert best-effort but cannot cause a wrong merge or close.
+        # Use the same newest-any-author scoreboard as the ready-to-merge label and auto-merge. This
+        # detector only alerts; unlike housekeeping, it performs no destructive PR action.
         if core.review_state(core.scoreboard_meta(pr["number"]), head) != "approved":
             continue
         # Filenames are bare strings, not JSON -- gh_lines, not gh_stream.

--- a/scripts/pr_status/test_pr_labels.py
+++ b/scripts/pr_status/test_pr_labels.py
@@ -61,6 +61,14 @@ class ReviewState(unittest.TestCase):
 
 
 class ScoreboardMeta(unittest.TestCase):
+    @staticmethod
+    def board(n, updated, association):
+        return {
+            "body": f'<!--tauceti-scoreboard--><!--tauceti-meta:v1 {{"n":{n}}}-->',
+            "updated": updated,
+            "author_association": association,
+        }
+
     def test_parses_meta_with_nested_states(self):
         # Regression: a lazy `\{.*?\}` truncated at the first inner `}` and dropped the whole meta.
         body = ('<!--tauceti-scoreboard-->\n'
@@ -70,13 +78,39 @@ class ScoreboardMeta(unittest.TestCase):
         self.assertEqual(meta.get("states", {}).get("correctness"), "blocking_block")
         self.assertEqual(meta.get("full_rounds"), 2)
 
-    def test_newest_trusted_comment_wins(self):
+    def test_newest_supplied_comment_wins(self):
         old = {"body": '<!--tauceti-scoreboard--><!--tauceti-meta:v1 {"n":1}-->', "updated": "2026-01-01"}
         new = {"body": '<!--tauceti-scoreboard--><!--tauceti-meta:v1 {"n":2}-->', "updated": "2026-02-01"}
         self.assertEqual(core.scoreboard_meta_from([old, new]).get("n"), 2)
 
     def test_no_marker_is_empty(self):
         self.assertEqual(core.scoreboard_meta_from([{"body": "hi", "updated": "x"}]), {})
+
+    def test_status_scoreboard_accepts_newer_contributor_review(self):
+        comments = [
+            self.board(1, "2026-01-01", "MEMBER"),
+            self.board(2, "2026-02-01", "CONTRIBUTOR"),
+        ]
+        with mock.patch.object(core, "issue_comments", return_value=comments):
+            self.assertEqual(core.scoreboard_meta("9").get("n"), 2)
+
+    def test_destructive_selector_keeps_repo_associated_policy(self):
+        comments = [
+            self.board(1, "2026-01-01", "MEMBER"),
+            self.board(2, "2026-02-01", "CONTRIBUTOR"),
+        ]
+        with mock.patch.object(core, "issue_comments", return_value=comments):
+            self.assertEqual(core.repo_associated_scoreboard_meta("9").get("n"), 1)
+
+    def test_issue_comment_fetch_has_no_author_filter(self):
+        raw = json.dumps({
+            "body": "external review",
+            "updated": "2026-02-01",
+            "author_association": "CONTRIBUTOR",
+        })
+        with mock.patch.object(core, "gh_api", return_value=raw) as gh:
+            self.assertEqual(core.issue_comments("9")[0]["author_association"], "CONTRIBUTOR")
+        self.assertNotIn("select(.author_association", gh.call_args.kwargs["jq"])
 
 
 class RoadmapLabels(unittest.TestCase):
@@ -197,22 +231,35 @@ class DerivedLabel(unittest.TestCase):
 
 
 class Derive(unittest.TestCase):
-    """core.derive glues pr_state/ci_status/trusted_comments together; stub them."""
+    """core.derive glues pr_state/ci_status/issue_comments together; stub them."""
 
     def setUp(self):
-        self._saved = (core.pr_state, core.ci_status, core.trusted_comments)
+        self._saved = (core.pr_state, core.ci_status, core.issue_comments)
 
     def tearDown(self):
-        core.pr_state, core.ci_status, core.trusted_comments = self._saved
+        core.pr_state, core.ci_status, core.issue_comments = self._saved
 
     def stub(self, state="open", merged=False, ci="success", comments=None):
         core.pr_state = lambda pr: {"state": state, "merged": merged, "head": "H", "title": "T"}
         core.ci_status = lambda head: ci
-        core.trusted_comments = lambda pr: (comments or [])
+        core.issue_comments = lambda pr: (comments or [])
 
-    def test_open_plumbs_inprogress(self):
+    def test_contributor_scoreboard_drives_review_state(self):
+        self.stub(comments=[{
+            "body": ('<!--tauceti-scoreboard-->'
+                     '<!--tauceti-meta:v1 {"head_sha":"H",'
+                     '"states":{"correctness":"blocking_request"}}-->'),
+            "updated": "2026-02-01",
+            "author_association": "CONTRIBUTOR",
+        }])
+        self.assertEqual(core.derive("1")["review"], "changes")
+
+    def test_contributor_inprogress_marker_drives_status(self):
         self.stub(ci="success",
-                  comments=[{"body": '<!--tauceti-review-in-progress {"head": "H", "expires_at": 9999999999}-->'}])
+                  comments=[{
+                      "body": '<!--tauceti-review-in-progress {"head": "H", "expires_at": 9999999999}-->',
+                      "author_association": "CONTRIBUTOR",
+                  }])
         d = core.derive("1", now=1_700_000_000)
         self.assertEqual(d["lifecycle"], "open")
         self.assertTrue(d["review_inprogress"])
@@ -235,7 +282,7 @@ class Derive(unittest.TestCase):
 
         core.pr_state = boom
         core.ci_status = lambda head: "running"
-        core.trusted_comments = lambda pr: []
+        core.issue_comments = lambda pr: []
         d = core.derive("1", state={"state": "open", "merged": False, "head": "H", "title": "T"})
         self.assertEqual(d["ci"], "running")
         self.assertEqual(called["n"], 0)


### PR DESCRIPTION
## Summary

- derive labels and Zulip review state from the newest marked scoreboard regardless of author association, matching TauCetiWorker and auto-merge
- retain the repo-associated-only scoreboard policy for destructive housekeeping
- extend the hourly review-label sweep so existing awaiting-review labels migrate automatically
- add regression coverage for contributor scoreboards and the stricter housekeeping selector

## Validation

- python3 -m unittest discover -s scripts -p test_*.py (237 tests)
- workflow YAML parses
- git diff --check