### PR TITLE
feat: add the doubled E6 minuscule lattice

### DIFF
--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/AdmissibleLattice.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/AdmissibleLattice.lean
@@ -128,35 +128,27 @@ private theorem ad_pow_int_eq_rat
 /-- The rational doubled minuscule matrices satisfy the type-`E₆` Serre relations. -/
 theorem isSerreSystemQ :
     TauCeti.IsSerreSystem ℚ (CartanMatrix.E 6)ᵀ cartanGeneratorMatrixQ raisingMatrixQ
-      loweringMatrixQ where
-  lie_H_H i j := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_H i j)
-    simpa only [LieHom.map_lie, map_zero, cartanGeneratorMatrixQ] using h
-  lie_E_F_self i := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.lie_E_F_self i)
-    simpa only [LieHom.map_lie, raisingMatrixQ, loweringMatrixQ,
-      cartanGeneratorMatrixQ] using h
-  lie_E_F_of_ne i j hij := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.lie_E_F_of_ne i j hij)
-    simpa only [LieHom.map_lie, map_zero, raisingMatrixQ, loweringMatrixQ] using h
-  lie_H_E i j := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_E i j)
-    rw [LieHom.map_lie, map_zsmul] at h
-    simpa only [cartanGeneratorMatrixQ, raisingMatrixQ, Int.cast_smul_eq_zsmul] using h
-  lie_H_F i j := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_F i j)
-    rw [LieHom.map_lie, map_neg, map_zsmul] at h
-    simpa only [cartanGeneratorMatrixQ, loweringMatrixQ, Int.cast_smul_eq_zsmul] using h
-  ad_pow_lie_E_E i j := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.ad_pow_lie_E_E i j)
-    rw [TauCeti.LieHom.map_ad_pow, map_zero] at h
+      loweringMatrixQ := by
+  have h := isSerreSystem.map castMatrixLieHom
+  have hH : castMatrixLieHom ∘ cartanGeneratorMatrix = cartanGeneratorMatrixQ := by
+    funext i
+    rfl
+  have hE : castMatrixLieHom ∘ raisingMatrix = raisingMatrixQ := by
+    funext i
+    rfl
+  have hF : castMatrixLieHom ∘ loweringMatrix = loweringMatrixQ := by
+    funext i
+    rfl
+  rw [hH, hE, hF] at h
+  refine { h with
+    ad_pow_lie_E_E := ?_
+    ad_pow_lie_F_F := ?_ }
+  · intro i j
     rw [← ad_pow_int_eq_rat]
-    simpa only [LieHom.map_lie, raisingMatrixQ] using h
-  ad_pow_lie_F_F i j := by
-    have h := congrArg castMatrixLieHom (isSerreSystem.ad_pow_lie_F_F i j)
-    rw [TauCeti.LieHom.map_ad_pow, map_zero] at h
+    exact h.ad_pow_lie_E_E i j
+  · intro i j
     rw [← ad_pow_int_eq_rat]
-    simpa only [LieHom.map_lie, loweringMatrixQ] using h
+    exact h.ad_pow_lie_F_F i j
 
 /-- The rational `54`-dimensional doubled minuscule representation. -/
 noncomputable def rationalSerreRepresentation :

--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/AdmissibleLattice.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/AdmissibleLattice.lean
@@ -1,0 +1,334 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E6.DoubledMinuscule.Basic
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.CoordinateLattice
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.Serre
+
+/-!
+# The admissible doubled minuscule lattice of type E6
+
+This file extends the integral doubled minuscule representation
+`V(ϖ₁) ⊕ V(ϖ₆)` to the rational type-`E₆` Serre algebra and proves that its coordinate
+`ℤ`-lattice is preserved by the Serre Kostant form. Its raising and lowering matrices are
+square-zero, and its coordinate basis consists of Cartan weight vectors with weights
+`TauCeti.DynkinType.e6DoubledMinusculeWeight`.
+
+The resulting admissible lattice is both full-weight and stable under the type-`E₆` diagram
+symmetry at the level of its weight basis. It is therefore the lattice input for the graph-stable
+type-`E₆` Chevalley--Demazure carrier required by Layer 9 of the ReductiveGroups roadmap and by
+the `²E₆` branch of the CFSGStatement roadmap.
+
+The rationalization and coordinate-lattice argument specialize the formal pattern of
+`TauCeti/Algebra/Lie/E6/Minuscule/AdmissibleLattice.lean`; the mathematical change is the
+contragredient second block and its doubled weight basis.
+
+## Main declarations
+
+* `TauCeti.E6DoubledMinuscule.rationalSerreRepresentation`: the rational doubled minuscule
+  representation.
+* `TauCeti.E6DoubledMinuscule.rep`: its universal-enveloping-algebra representation.
+* `TauCeti.E6DoubledMinuscule.lattice`: the coordinate `ℤ`-lattice.
+* `TauCeti.E6DoubledMinuscule.rep_serreKostantForm_mem_lattice`: the Serre Kostant form preserves
+  the lattice.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate V.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1--2.
+* R. W. Carter, *Simple Groups of Lie Type*, §12.2.
+-/
+
+public section
+
+open scoped Matrix
+
+namespace TauCeti.E6DoubledMinuscule
+
+open TauCeti.DynkinType
+
+attribute [local instance 100] LieRing.ofAssociativeRing LieRing.instLieAlgebra
+
+/-! ## The rational representation -/
+
+/-- Entrywise coercion from integral to rational doubled minuscule matrices. -/
+private noncomputable def castMatrixLieHom :
+    Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℤ →ₗ⁅ℤ⁆
+      Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℚ :=
+  ((Int.castRingHom ℚ).mapMatrix.toIntAlgHom).toLieHom
+
+@[simp]
+private theorem castMatrixLieHom_apply
+    (M : Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℤ)
+    (a b : Fin 27 ⊕ Fin 27) : castMatrixLieHom M a b = (M a b : ℚ) := by
+  simp only [castMatrixLieHom, AlgHom.toLieHom_apply, RingHom.toIntAlgHom_apply,
+    RingHom.mapMatrix_apply, Matrix.map_apply, Int.coe_castRingHom]
+
+/-- The rational raising matrices of the doubled minuscule representation. -/
+noncomputable def raisingMatrixQ (i : Fin 6) :
+    Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℚ :=
+  castMatrixLieHom (raisingMatrix i)
+
+/-- The rational lowering matrices of the doubled minuscule representation. -/
+noncomputable def loweringMatrixQ (i : Fin 6) :
+    Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℚ :=
+  castMatrixLieHom (loweringMatrix i)
+
+/-- The rational Cartan generators of the doubled minuscule representation. -/
+noncomputable def cartanGeneratorMatrixQ (i : Fin 6) :
+    Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℚ :=
+  castMatrixLieHom (cartanGeneratorMatrix i)
+
+/-- Entry formula for a rational raising matrix. -/
+@[simp]
+theorem raisingMatrixQ_apply (i : Fin 6) (a b : Fin 27 ⊕ Fin 27) :
+    raisingMatrixQ i a b =
+      if e6DoubledMinusculeWeight b i = -1 ∧ a = reflection i b
+      then (summandSign b : ℚ) else 0 := by
+  rw [raisingMatrixQ, castMatrixLieHom_apply, raisingMatrix_apply]
+  split_ifs <;> norm_num
+
+/-- Entry formula for a rational lowering matrix. -/
+@[simp]
+theorem loweringMatrixQ_apply (i : Fin 6) (a b : Fin 27 ⊕ Fin 27) :
+    loweringMatrixQ i a b =
+      if e6DoubledMinusculeWeight b i = 1 ∧ a = reflection i b
+      then (summandSign b : ℚ) else 0 := by
+  rw [loweringMatrixQ, castMatrixLieHom_apply, loweringMatrix_apply]
+  split_ifs <;> norm_num
+
+/-- A rational Cartan generator is diagonal with the doubled minuscule weights on its diagonal. -/
+@[simp]
+theorem cartanGeneratorMatrixQ_apply (i : Fin 6) (a b : Fin 27 ⊕ Fin 27) :
+    cartanGeneratorMatrixQ i a b =
+      if a = b then (e6DoubledMinusculeWeight b i : ℚ) else 0 := by
+  rw [cartanGeneratorMatrixQ, castMatrixLieHom_apply, cartanGeneratorMatrix_apply]
+  split_ifs <;> norm_num
+
+private theorem ad_int_apply_eq_rat
+    (x y : Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℚ) :
+    (LieAlgebra.ad ℤ _ x) y = (LieAlgebra.ad ℚ _ x) y := by
+  simp only [LieAlgebra.ad_apply]
+
+private theorem ad_pow_int_eq_rat
+    (x y : Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℚ) (n : ℕ) :
+    (LieAlgebra.ad ℤ _ x ^ n) y = (LieAlgebra.ad ℚ _ x ^ n) y := by
+  induction n generalizing y with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ, pow_succ, Module.End.mul_apply, Module.End.mul_apply,
+        ad_int_apply_eq_rat]
+      exact ih ((LieAlgebra.ad ℚ _ x) y)
+
+/-- The rational doubled minuscule matrices satisfy the type-`E₆` Serre relations. -/
+theorem isSerreSystemQ :
+    TauCeti.IsSerreSystem ℚ (CartanMatrix.E 6)ᵀ cartanGeneratorMatrixQ raisingMatrixQ
+      loweringMatrixQ where
+  lie_H_H i j := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_H i j)
+    simpa only [LieHom.map_lie, map_zero, cartanGeneratorMatrixQ] using h
+  lie_E_F_self i := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.lie_E_F_self i)
+    simpa only [LieHom.map_lie, raisingMatrixQ, loweringMatrixQ,
+      cartanGeneratorMatrixQ] using h
+  lie_E_F_of_ne i j hij := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.lie_E_F_of_ne i j hij)
+    simpa only [LieHom.map_lie, map_zero, raisingMatrixQ, loweringMatrixQ] using h
+  lie_H_E i j := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_E i j)
+    rw [LieHom.map_lie, map_zsmul] at h
+    simpa only [cartanGeneratorMatrixQ, raisingMatrixQ, Int.cast_smul_eq_zsmul] using h
+  lie_H_F i j := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.lie_H_F i j)
+    rw [LieHom.map_lie, map_neg, map_zsmul] at h
+    simpa only [cartanGeneratorMatrixQ, loweringMatrixQ, Int.cast_smul_eq_zsmul] using h
+  ad_pow_lie_E_E i j := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.ad_pow_lie_E_E i j)
+    rw [TauCeti.LieHom.map_ad_pow, map_zero] at h
+    rw [← ad_pow_int_eq_rat]
+    simpa only [LieHom.map_lie, raisingMatrixQ] using h
+  ad_pow_lie_F_F i j := by
+    have h := congrArg castMatrixLieHom (isSerreSystem.ad_pow_lie_F_F i j)
+    rw [TauCeti.LieHom.map_ad_pow, map_zero] at h
+    rw [← ad_pow_int_eq_rat]
+    simpa only [LieHom.map_lie, loweringMatrixQ] using h
+
+/-- The rational `54`-dimensional doubled minuscule representation. -/
+noncomputable def rationalSerreRepresentation :
+    Matrix.ToLieAlgebra ℚ (CartanMatrix.E 6)ᵀ →ₗ⁅ℚ⁆
+      Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℚ :=
+  TauCeti.serreLift isSerreSystemQ
+
+@[simp]
+theorem rationalSerreRepresentation_serreH (i : Fin 6) :
+    rationalSerreRepresentation (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ i) =
+      cartanGeneratorMatrixQ i :=
+  TauCeti.serreLift_serreH isSerreSystemQ i
+
+@[simp]
+theorem rationalSerreRepresentation_serreE (i : Fin 6) :
+    rationalSerreRepresentation (TauCeti.serreE ℚ (CartanMatrix.E 6)ᵀ i) = raisingMatrixQ i :=
+  TauCeti.serreLift_serreE isSerreSystemQ i
+
+@[simp]
+theorem rationalSerreRepresentation_serreF (i : Fin 6) :
+    rationalSerreRepresentation (TauCeti.serreF ℚ (CartanMatrix.E 6)ᵀ i) = loweringMatrixQ i :=
+  TauCeti.serreLift_serreF isSerreSystemQ i
+
+/-! ## The enveloping-algebra action -/
+
+/-- The rational doubled minuscule representation extended to the universal enveloping algebra. -/
+noncomputable def rep :
+    _root_.UniversalEnvelopingAlgebra ℚ
+        (Matrix.ToLieAlgebra ℚ (CartanMatrix.E 6)ᵀ) →ₐ[ℚ]
+      Module.End ℚ ((Fin 27 ⊕ Fin 27) → ℚ) :=
+  _root_.UniversalEnvelopingAlgebra.lift ℚ
+    ((Matrix.toLinAlgEquiv (Pi.basisFun ℚ (Fin 27 ⊕ Fin 27))).toAlgHom.toLieHom.comp
+      rationalSerreRepresentation)
+
+/-- Included Lie elements act by matrix-vector multiplication. -/
+theorem rep_ι_apply (x : Matrix.ToLieAlgebra ℚ (CartanMatrix.E 6)ᵀ)
+    (v : (Fin 27 ⊕ Fin 27) → ℚ) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ x) v = rationalSerreRepresentation x *ᵥ v := by
+  rw [rep, _root_.UniversalEnvelopingAlgebra.lift_ι_apply, LieHom.comp_apply,
+    AlgHom.toLieHom_apply, AlgEquiv.toAlgHom_apply, Matrix.toLinAlgEquiv_apply]
+  exact (Pi.basisFun ℚ (Fin 27 ⊕ Fin 27)).sum_repr (rationalSerreRepresentation x *ᵥ v)
+
+/-- Every rational raising matrix is square-zero. -/
+@[simp]
+theorem raisingMatrixQ_sq (i : Fin 6) : raisingMatrixQ i ^ 2 = 0 := by
+  ext a b
+  simp only [pow_two, Matrix.mul_apply, raisingMatrixQ_apply, Matrix.zero_apply]
+  by_cases hb : e6DoubledMinusculeWeight b i = -1
+  · simp [hb, e6DoubledMinusculeWeight_reflection_apply_self]
+  · simp [hb]
+
+/-- Every rational lowering matrix is square-zero. -/
+@[simp]
+theorem loweringMatrixQ_sq (i : Fin 6) : loweringMatrixQ i ^ 2 = 0 := by
+  ext a b
+  simp only [pow_two, Matrix.mul_apply, loweringMatrixQ_apply, Matrix.zero_apply]
+  by_cases hb : e6DoubledMinusculeWeight b i = 1
+  · simp [hb, e6DoubledMinusculeWeight_reflection_apply_self]
+  · simp [hb]
+
+private theorem mulVec_sq_eq_zero
+    (M : Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℚ) (hM : M ^ 2 = 0)
+    (v : (Fin 27 ⊕ Fin 27) → ℚ) : M *ᵥ M *ᵥ v = 0 := by
+  rw [Matrix.mulVec_mulVec, ← pow_two, hM, Matrix.zero_mulVec]
+
+/-- Every represented positive or negative Serre root generator is square-zero. -/
+theorem rep_serreRootGenerator_sq (k : Fin 6 ⊕ Fin 6) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ k)) ^ 2 = 0 := by
+  apply LinearMap.ext
+  intro v
+  rw [pow_two, Module.End.mul_apply]
+  cases k with
+  | inl i =>
+      simpa only [TauCeti.serreRootGenerator_inl, rep_ι_apply,
+        rationalSerreRepresentation_serreE, LinearMap.zero_apply] using
+        mulVec_sq_eq_zero (raisingMatrixQ i) (raisingMatrixQ_sq i) v
+  | inr i =>
+      simpa only [TauCeti.serreRootGenerator_inr, rep_ι_apply,
+        rationalSerreRepresentation_serreF, LinearMap.zero_apply] using
+        mulVec_sq_eq_zero (loweringMatrixQ i) (loweringMatrixQ_sq i) v
+
+/-- Every represented Serre root generator acts nilpotently. -/
+theorem isNilpotent_rep_serreRootGenerator (k : Fin 6 ⊕ Fin 6) :
+    IsNilpotent (rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ k))) :=
+  ⟨2, rep_serreRootGenerator_sq k⟩
+
+/-! ## The admissible coordinate lattice -/
+
+/-- The coordinate `ℤ`-lattice in the rational doubled minuscule module. -/
+def lattice : Submodule ℤ ((Fin 27 ⊕ Fin 27) → ℚ) :=
+  TauCeti.coordinateLattice (Fin 27 ⊕ Fin 27)
+
+/-- A vector belongs to the doubled minuscule lattice exactly when every coordinate is integral. -/
+@[simp]
+theorem mem_lattice_iff {v : (Fin 27 ⊕ Fin 27) → ℚ} :
+    v ∈ lattice ↔ ∀ a, ∃ z : ℤ, (z : ℚ) = v a :=
+  TauCeti.mem_coordinateLattice_iff (Fin 27 ⊕ Fin 27)
+
+/-- Every standard coordinate vector belongs to the doubled minuscule lattice. -/
+theorem single_mem_lattice (a : Fin 27 ⊕ Fin 27) : Pi.single a (1 : ℚ) ∈ lattice := by
+  rw [← Pi.basisFun_apply]
+  exact TauCeti.basisFun_mem_coordinateLattice (Fin 27 ⊕ Fin 27) a
+
+/-- The coordinate basis of the doubled minuscule lattice. -/
+noncomputable def latticeBasis : Module.Basis (Fin 27 ⊕ Fin 27) ℤ lattice :=
+  TauCeti.coordinateLatticeBasis (Fin 27 ⊕ Fin 27)
+
+/-- Coercing a lattice-basis vector gives the corresponding coordinate vector. -/
+@[simp]
+theorem coe_latticeBasis (a : Fin 27 ⊕ Fin 27) :
+    ((latticeBasis a : lattice) : (Fin 27 ⊕ Fin 27) → ℚ) = Pi.single a 1 := by
+  rw [← Pi.basisFun_apply, latticeBasis]
+  exact TauCeti.coe_coordinateLatticeBasis (Fin 27 ⊕ Fin 27) a
+
+private theorem castMatrix_mulVec_mem_lattice
+    (M : Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℤ)
+    {v : (Fin 27 ⊕ Fin 27) → ℚ} (hv : v ∈ lattice) :
+    castMatrixLieHom M *ᵥ v ∈ lattice := by
+  rw [mem_lattice_iff] at hv ⊢
+  choose z hz using hv
+  intro a
+  refine ⟨∑ b, M a b * z b, ?_⟩
+  simp only [Int.cast_sum, Int.cast_mul, hz, Matrix.mulVec, dotProduct,
+    castMatrixLieHom_apply]
+
+/-- Every represented Serre root generator preserves the doubled minuscule lattice. -/
+theorem rep_serreRootGenerator_mem_lattice (k : Fin 6 ⊕ Fin 6)
+    {v : (Fin 27 ⊕ Fin 27) → ℚ} (hv : v ∈ lattice) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ k)) v ∈ lattice := by
+  rw [rep_ι_apply]
+  cases k with
+  | inl i =>
+      rw [TauCeti.serreRootGenerator_inl, rationalSerreRepresentation_serreE, raisingMatrixQ]
+      exact castMatrix_mulVec_mem_lattice (raisingMatrix i) hv
+  | inr i =>
+      rw [TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF, loweringMatrixQ]
+      exact castMatrix_mulVec_mem_lattice (loweringMatrix i) hv
+
+/-- Every standard coordinate vector has its named doubled minuscule weight. -/
+theorem isCartanWeightVector_single (a : Fin 27 ⊕ Fin 27) :
+    TauCeti.UniversalEnvelopingAlgebra.IsCartanWeightVector
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep (e6DoubledMinusculeWeight a)
+      (Pi.single a 1) := by
+  refine (TauCeti.UniversalEnvelopingAlgebra.isCartanWeightVector_iff
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep).mpr fun i ↦ ?_
+  rw [rep_ι_apply, rationalSerreRepresentation_serreH]
+  ext b
+  simp [Matrix.mulVec, dotProduct, cartanGeneratorMatrixQ_apply, Pi.single_apply]
+
+/-- Every doubled minuscule lattice-basis vector has its named Cartan weight. -/
+theorem isCartanWeightVector_latticeBasis (a : Fin 27 ⊕ Fin 27) :
+    TauCeti.UniversalEnvelopingAlgebra.IsCartanWeightVector
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep (e6DoubledMinusculeWeight a)
+      ((latticeBasis a : lattice) : (Fin 27 ⊕ Fin 27) → ℚ) := by
+  rw [coe_latticeBasis]
+  exact isCartanWeightVector_single a
+
+/-- **The doubled minuscule coordinate lattice is admissible for the type-`E₆` Serre Kostant
+form.** -/
+theorem rep_serreKostantForm_mem_lattice
+    {u : _root_.UniversalEnvelopingAlgebra ℚ
+      (Matrix.ToLieAlgebra ℚ (CartanMatrix.E 6)ᵀ)}
+    (hu : u ∈ TauCeti.serreKostantForm (CartanMatrix.E 6)ᵀ)
+    {v : (Fin 27 ⊕ Fin 27) → ℚ} (hv : v ∈ lattice) : rep u v ∈ lattice := by
+  rw [TauCeti.serreKostantForm_def] at hu
+  exact TauCeti.UniversalEnvelopingAlgebra.kostantForm_apply_mem_coordinateLattice
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep
+    (wt := e6DoubledMinusculeWeight) rep_serreRootGenerator_sq
+    (fun k _ hw ↦ rep_serreRootGenerator_mem_lattice k hw) isCartanWeightVector_single hu hv
+
+end TauCeti.E6DoubledMinuscule

--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Basic.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Basic.lean
@@ -112,7 +112,6 @@ noncomputable def serreRepresentation :
 
 /-- The doubled representation is the block-diagonal sum of the minuscule representation and its
 contragredient. -/
-@[simp]
 private theorem serreRepresentation_apply (x : Matrix.ToLieAlgebra ℤ (CartanMatrix.E 6)ᵀ) :
     serreRepresentation x =
       Matrix.fromBlocks (TauCeti.E6Minuscule.serreRepresentation x) 0 0

--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Basic.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Basic.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E6.Minuscule.Basic
+
+import Mathlib.Data.Matrix.Block
+
+/-!
+# The doubled minuscule representation of type E6
+
+The nontrivial diagram automorphism of type `E₆` exchanges the minuscule representations `V(ϖ₁)`
+and `V(ϖ₆) = V(ϖ₁)ˣ`. Consequently the `27`-dimensional carrier alone does not admit the pinned
+diagram symmetry. This file constructs the graph-stable direct sum `V(ϖ₁) ⊕ V(ϖ₆)` over `ℤ`.
+
+The first block is `TauCeti.E6Minuscule.serreRepresentation`. The second is its contragredient:
+the Cartan matrices are negated and the raising and lowering matrices are exchanged and negated.
+The resulting `54`-dimensional block matrices satisfy the type-`E₆` Serre relations and have the
+weights `TauCeti.DynkinType.e6DoubledMinusculeWeight`.
+
+This is the representation input for the graph-stable full-weight type-`E₆`
+Chevalley--Demazure carrier required by Layer 9 of the ReductiveGroups roadmap.
+
+## Main declarations
+
+* `TauCeti.E6DoubledMinuscule.serreRepresentation`: the integral doubled minuscule
+  representation.
+* `TauCeti.E6DoubledMinuscule.cartanGeneratorMatrix`, `raisingMatrix`, and `loweringMatrix`: its
+  block-diagonal Chevalley generators.
+* `TauCeti.E6DoubledMinuscule.isSerreSystem`: these generators satisfy the type-`E₆` Serre
+  relations.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate V.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§13.4 and 27.
+* R. W. Carter, *Simple Groups of Lie Type*, §12.2.
+-/
+
+public section
+
+open scoped Matrix
+
+namespace TauCeti.E6DoubledMinuscule
+
+open TauCeti.DynkinType
+
+attribute [local instance 100] LieRing.ofAssociativeRing LieRing.instLieAlgebra
+
+/-- The contragredient of the integral minuscule representation. -/
+private noncomputable def dualSerreRepresentation :
+    Matrix.ToLieAlgebra ℤ (CartanMatrix.E 6)ᵀ →ₗ⁅ℤ⁆ Matrix (Fin 27) (Fin 27) ℤ :=
+  TauCeti.serreLift TauCeti.E6Minuscule.isSerreSystem.neg_swap
+
+@[simp]
+private theorem dualSerreRepresentation_serreH (i : Fin 6) :
+    dualSerreRepresentation (TauCeti.serreH ℤ (CartanMatrix.E 6)ᵀ i) =
+      -TauCeti.E6Minuscule.cartanGeneratorMatrix i :=
+  TauCeti.serreLift_serreH TauCeti.E6Minuscule.isSerreSystem.neg_swap i
+
+@[simp]
+private theorem dualSerreRepresentation_serreE (i : Fin 6) :
+    dualSerreRepresentation (TauCeti.serreE ℤ (CartanMatrix.E 6)ᵀ i) =
+      -TauCeti.E6Minuscule.loweringMatrix i :=
+  TauCeti.serreLift_serreE TauCeti.E6Minuscule.isSerreSystem.neg_swap i
+
+@[simp]
+private theorem dualSerreRepresentation_serreF (i : Fin 6) :
+    dualSerreRepresentation (TauCeti.serreF ℤ (CartanMatrix.E 6)ᵀ i) =
+      -TauCeti.E6Minuscule.raisingMatrix i :=
+  TauCeti.serreLift_serreF TauCeti.E6Minuscule.isSerreSystem.neg_swap i
+
+/-- The integral Cartan generators on `V(ϖ₁) ⊕ V(ϖ₆)`. -/
+def cartanGeneratorMatrix (i : Fin 6) :
+    Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℤ :=
+  Matrix.fromBlocks (TauCeti.E6Minuscule.cartanGeneratorMatrix i) 0 0
+    (-TauCeti.E6Minuscule.cartanGeneratorMatrix i)
+
+/-- The integral raising matrices on `V(ϖ₁) ⊕ V(ϖ₆)`. -/
+def raisingMatrix (i : Fin 6) : Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℤ :=
+  Matrix.fromBlocks (TauCeti.E6Minuscule.raisingMatrix i) 0 0
+    (-TauCeti.E6Minuscule.loweringMatrix i)
+
+/-- The integral lowering matrices on `V(ϖ₁) ⊕ V(ϖ₆)`. -/
+def loweringMatrix (i : Fin 6) : Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℤ :=
+  Matrix.fromBlocks (TauCeti.E6Minuscule.loweringMatrix i) 0 0
+    (-TauCeti.E6Minuscule.raisingMatrix i)
+
+/-- The integral `54`-dimensional representation `V(ϖ₁) ⊕ V(ϖ₆)` of the type-`E₆` Serre
+presentation. -/
+noncomputable def serreRepresentation :
+    Matrix.ToLieAlgebra ℤ (CartanMatrix.E 6)ᵀ →ₗ⁅ℤ⁆
+      Matrix (Fin 27 ⊕ Fin 27) (Fin 27 ⊕ Fin 27) ℤ where
+  toFun x := Matrix.fromBlocks (TauCeti.E6Minuscule.serreRepresentation x) 0 0
+    (dualSerreRepresentation x)
+  map_add' x y := by
+    simpa only [map_add, add_zero] using
+      (Matrix.fromBlocks_add (TauCeti.E6Minuscule.serreRepresentation x) 0 0
+        (dualSerreRepresentation x) (TauCeti.E6Minuscule.serreRepresentation y) 0 0
+        (dualSerreRepresentation y)).symm
+  map_smul' c x := by
+    rw [map_smul, map_smul]
+    simpa only [RingHom.id_apply, smul_zero] using
+      (Matrix.fromBlocks_smul c (TauCeti.E6Minuscule.serreRepresentation x) 0 0
+        (dualSerreRepresentation x)).symm
+  map_lie' := by
+    simp [Ring.lie_def, Matrix.fromBlocks_multiply, sub_eq_add_neg,
+      Matrix.fromBlocks_neg, Matrix.fromBlocks_add]
+
+/-- The doubled representation is the block-diagonal sum of the minuscule representation and its
+contragredient. -/
+@[simp]
+private theorem serreRepresentation_apply (x : Matrix.ToLieAlgebra ℤ (CartanMatrix.E 6)ᵀ) :
+    serreRepresentation x =
+      Matrix.fromBlocks (TauCeti.E6Minuscule.serreRepresentation x) 0 0
+        (dualSerreRepresentation x) :=
+  (rfl)
+
+/-- The doubled representation sends a Cartan generator to its block-diagonal Cartan matrix. -/
+@[simp]
+theorem serreRepresentation_serreH (i : Fin 6) :
+    serreRepresentation (TauCeti.serreH ℤ (CartanMatrix.E 6)ᵀ i) = cartanGeneratorMatrix i := by
+  rw [serreRepresentation_apply]
+  simp [dualSerreRepresentation, cartanGeneratorMatrix]
+
+/-- The doubled representation sends a positive generator to its raising matrix. -/
+@[simp]
+theorem serreRepresentation_serreE (i : Fin 6) :
+    serreRepresentation (TauCeti.serreE ℤ (CartanMatrix.E 6)ᵀ i) = raisingMatrix i := by
+  rw [serreRepresentation_apply]
+  simp [dualSerreRepresentation, raisingMatrix]
+
+/-- The doubled representation sends a negative generator to its lowering matrix. -/
+@[simp]
+theorem serreRepresentation_serreF (i : Fin 6) :
+    serreRepresentation (TauCeti.serreF ℤ (CartanMatrix.E 6)ᵀ i) = loweringMatrix i := by
+  rw [serreRepresentation_apply]
+  simp [dualSerreRepresentation, loweringMatrix]
+
+/-- **The integral doubled minuscule matrices satisfy the type-`E₆` Serre relations.** -/
+theorem isSerreSystem :
+    TauCeti.IsSerreSystem ℤ (CartanMatrix.E 6)ᵀ cartanGeneratorMatrix raisingMatrix
+      loweringMatrix := by
+  have h := (TauCeti.isSerreSystem_serre (R := ℤ) (CM := (CartanMatrix.E 6)ᵀ)).map
+    serreRepresentation
+  have hH : serreRepresentation ∘ TauCeti.serreH ℤ (CartanMatrix.E 6)ᵀ =
+      cartanGeneratorMatrix := by
+    funext i
+    exact serreRepresentation_serreH i
+  have hE : serreRepresentation ∘ TauCeti.serreE ℤ (CartanMatrix.E 6)ᵀ = raisingMatrix := by
+    funext i
+    exact serreRepresentation_serreE i
+  have hF : serreRepresentation ∘ TauCeti.serreF ℤ (CartanMatrix.E 6)ᵀ = loweringMatrix := by
+    funext i
+    exact serreRepresentation_serreF i
+  rwa [hH, hE, hF] at h
+
+/-- The simple reflection on the doubled weight basis, preserving each minuscule summand. -/
+def reflection (i : Fin 6) : Equiv.Perm (Fin 27 ⊕ Fin 27) :=
+  Equiv.sumCongr (e6MinusculeReflection i) (e6MinusculeReflection i)
+
+/-- A simple reflection negates the corresponding simple-coroot coordinate of every doubled
+minuscule weight. -/
+@[simp]
+theorem e6DoubledMinusculeWeight_reflection_apply_self (i : Fin 6)
+    (a : Fin 27 ⊕ Fin 27) :
+    e6DoubledMinusculeWeight (reflection i a) i = -e6DoubledMinusculeWeight a i := by
+  cases a <;>
+    simp [reflection, TauCeti.E6Minuscule.e6MinusculeWeight_reflection_apply_self]
+
+/-- Every simple reflection on the doubled minuscule basis is an involution. -/
+@[simp]
+theorem reflection_apply_apply (i : Fin 6) (a : Fin 27 ⊕ Fin 27) :
+    reflection i (reflection i a) = a := by
+  cases a <;> simp [reflection]
+
+/-- The sign of the Chevalley root-matrix coefficient on each minuscule summand. The dual block
+has the negative structure constants. -/
+def summandSign : Fin 27 ⊕ Fin 27 → ℤ
+  | .inl _ => 1
+  | .inr _ => -1
+
+/-- The Cartan generators are diagonal with the doubled minuscule weights on the diagonal. -/
+@[simp]
+theorem cartanGeneratorMatrix_apply (i : Fin 6) (a b : Fin 27 ⊕ Fin 27) :
+    cartanGeneratorMatrix i a b =
+      if a = b then e6DoubledMinusculeWeight b i else 0 := by
+  cases a <;> cases b <;>
+    simp [cartanGeneratorMatrix, Matrix.fromBlocks,
+      TauCeti.E6Minuscule.cartanGeneratorMatrix_apply]
+  all_goals split_ifs <;> simp_all
+
+/-- Entry formula for a simple raising matrix on the doubled minuscule basis. -/
+@[simp]
+theorem raisingMatrix_apply (i : Fin 6) (a b : Fin 27 ⊕ Fin 27) :
+    raisingMatrix i a b =
+      if e6DoubledMinusculeWeight b i = -1 ∧ a = reflection i b then summandSign b else 0 := by
+  cases a <;> cases b <;>
+    simp [raisingMatrix, reflection, summandSign, Matrix.fromBlocks,
+      TauCeti.E6Minuscule.raisingMatrix_apply, TauCeti.E6Minuscule.loweringMatrix_apply]
+  all_goals split_ifs <;> simp_all
+
+/-- Entry formula for a simple lowering matrix on the doubled minuscule basis. -/
+@[simp]
+theorem loweringMatrix_apply (i : Fin 6) (a b : Fin 27 ⊕ Fin 27) :
+    loweringMatrix i a b =
+      if e6DoubledMinusculeWeight b i = 1 ∧ a = reflection i b then summandSign b else 0 := by
+  cases a <;> cases b <;>
+    simp [loweringMatrix, reflection, summandSign, Matrix.fromBlocks,
+      TauCeti.E6Minuscule.raisingMatrix_apply, TauCeti.E6Minuscule.loweringMatrix_apply]
+  all_goals split_ifs <;> omega
+
+end TauCeti.E6DoubledMinuscule

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -60,10 +60,9 @@ one, which is not proved here (see the Roadmap section below).
   `TauCeti.serre_hom_ext`: `TauCeti.serreLift` sends the generators to the given Serre system, and
   is the unique homomorphism doing so; `TauCeti.serre_equiv_ext` is the same extensionality
   principle for equivalences out of the presented algebra.
-* `TauCeti.IsSerreSystem.submatrix`, `TauCeti.IsSerreSystem.perm` and
-  `TauCeti.IsSerreSystem.neg_swap`: a Serre system stays one after reindexing along an injective
-  map of index sets (a permutation preserving the matrix, in the second) or after the signed
-  exchange of the raising and lowering families.
+* `TauCeti.IsSerreSystem.map`, `TauCeti.IsSerreSystem.submatrix`, `TauCeti.IsSerreSystem.perm` and
+  `TauCeti.IsSerreSystem.neg_swap`: Serre systems are preserved by Lie homomorphisms, reindexing,
+  and the signed exchange of the raising and lowering families.
 * `TauCeti.serreLift_eq_id`: lifting the generators along their own Serre system is the identity.
 * `TauCeti.lieSpan_serreGenerators_eq_top`: the generators generate the presented algebra.
 
@@ -288,6 +287,28 @@ algebra; applied to the generators of the presented algebra they give its automo
 section Stability
 
 variable {R CM} {H E F : B → L} {σ : Equiv.Perm B}
+
+omit [DecidableEq B] in
+/-- The image of a Serre system under a Lie algebra homomorphism is a Serre system. -/
+theorem IsSerreSystem.map {L' : Type*} [LieRing L'] [LieAlgebra R L']
+    (h : IsSerreSystem R CM H E F) (f : L →ₗ⁅R⁆ L') :
+    IsSerreSystem R CM (f ∘ H) (f ∘ E) (f ∘ F) where
+  lie_H_H i j := by
+    simp only [Function.comp_apply, ← f.map_lie, h.lie_H_H i j, map_zero]
+  lie_E_F_self i := by
+    simp only [Function.comp_apply, ← f.map_lie, h.lie_E_F_self i]
+  lie_E_F_of_ne i j hij := by
+    simp only [Function.comp_apply, ← f.map_lie, h.lie_E_F_of_ne i j hij, map_zero]
+  lie_H_E i j := by
+    simp only [Function.comp_apply, ← f.map_lie, h.lie_H_E i j, map_zsmul]
+  lie_H_F i j := by
+    simp only [Function.comp_apply, ← f.map_lie, h.lie_H_F i j, map_neg, map_zsmul]
+  ad_pow_lie_E_E i j := by
+    simp only [Function.comp_apply, ← f.map_lie, ← LieHom.map_ad_pow,
+      h.ad_pow_lie_E_E i j, map_zero]
+  ad_pow_lie_F_F i j := by
+    simp only [Function.comp_apply, ← f.map_lie, ← LieHom.map_ad_pow,
+      h.ad_pow_lie_F_F i j, map_zero]
 
 omit [DecidableEq B] in
 /-- Reindexing a Serre system along an injective map of index sets gives a Serre system for the


### PR DESCRIPTION
This PR constructs the integral `54`-dimensional type-`E₆` Serre representation `V(ϖ₁) ⊕ V(ϖ₆)`, extends it to the rational Serre algebra and its universal enveloping algebra, and proves that its coordinate `ℤ`-lattice is preserved by the Serre Kostant form. The Cartan basis has the already-landed doubled minuscule weight family, while the root matrices are square-zero and act integrally, so `TauCeti.E6DoubledMinuscule.rep_serreKostantForm_mem_lattice` supplies the graph-stable admissible lattice needed for the next carrier construction.

The exact roadmap target is Layer 9, “The Chevalley–Demazure construction,” of `TauCetiRoadmap/ReductiveGroups/README.md`: construct each pinned split reductive group scheme explicitly from a Chevalley basis and the Kostant `ℤ`-form. The relevant milestone is the pinned Chevalley–Demazure group scheme over `ℤ` for type `E₆`; this PR supplies its graph-stable full-weight admissible lattice. After this PR, the milestone still needs the toral Kostant carrier and group scheme built from this lattice, followed by its base change, root-datum pinning, and induced diagram automorphism.

The dependency edge is that CFSGStatement milestone L0, “explicit pinned Chevalley–Demazure groups,” consumes the type-`E₆` pinned ambient group, while milestone L1 consumes its graph automorphism for the `²E₆(q)` Steinberg map. The landed `27`-weight carrier serves untwisted `E₆(q)` but cannot carry that diagram symmetry: merged PR #5256 proves that the symmetry exchanges `V(ϖ₁)` and `V(ϖ₆)` and identifies `V(ϖ₁) ⊕ V(ϖ₆)` as the stable full-weight family. This PR is the next step that PR names—constructing the doubled admissible lattice—and no open PR supplies it; the open E6 base-change, pinning, and Frobenius work concerns the original `27`-dimensional carrier.

The construction takes the landed minuscule Serre representation as its first block and its contragredient, obtained from `TauCeti.IsSerreSystem.neg_swap`, as its second. `TauCeti.IsSerreSystem.map` is added at the generic Serre-presentation layer because it is the exact reusable fact that transports the canonical Serre system through this block representation. The rationalization and coordinate-lattice proof specialize the formal pattern of `TauCeti/Algebra/Lie/E6/Minuscule/AdmissibleLattice.lean`; no Mathlib infrastructure or external formalization is vendored. The mathematical conventions follow Bourbaki, *Lie Groups and Lie Algebras, Chapters 4–6*, Plate V; Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§13.4 and 27; Jantzen, *Representations of Algebraic Groups*, II.1–2; and Carter, *Simple Groups of Lie Type*, §12.2, as credited in the module documentation.

Add `TauCeti/Algebra/Lie/E6/DoubledMinuscule/Basic.lean` (216 lines) and `TauCeti/Algebra/Lie/E6/DoubledMinuscule/AdmissibleLattice.lean` (334 lines), and add the 25-line general `TauCeti.IsSerreSystem.map` transport theorem to `TauCeti/Algebra/Lie/Presentation/Serre.lean`.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e6-doubled-minuscule-admissible-lattice"}-->

🤖 Prepared with Codex
