### PR TITLE
feat: count the letters of the Fi24' and B presentation rows

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/BabyMonster.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/BabyMonster.lean
@@ -326,14 +326,17 @@ theorem matchesMetadata_presentation : presentation.matchesMetadata :=
 /-! ### Letter counts -/
 
 /-- The spider relator compiles to `10 · 9 = 90` letters. -/
+@[simp]
 theorem length_toWord_spiderRelator : spiderRelator.toWord.length = 90 := by
   simp [spiderRelator_eq]
 
 /-- The first adjoined relator compiles to `9 · 7 = 63` letters. -/
+@[simp]
 theorem length_toWord_extraRelatorOne : extraRelatorOne.toWord.length = 63 := by
   simp [extraRelatorOne_eq]
 
 /-- The second adjoined relator compiles to `9 · 7 = 63` letters. -/
+@[simp]
 theorem length_toWord_extraRelatorTwo : extraRelatorTwo.toWord.length = 63 := by
   simp [extraRelatorTwo_eq]
 
@@ -342,6 +345,7 @@ contributes `2m`, so the eleven involution relators contribute `2` each, the ten
 and the forty-five remaining pairs of distinct nodes `4` each: `22 + 60 + 180`. Reading the count
 off the Coxeter matrix rather than off the expanded relators is what ties it to the transcribed
 edge list. -/
+@[simp]
 theorem sum_map_length_toWord_coxeterRelators :
     ((coxeterRelators coxeterMatrix).map fun r => r.toWord.length).sum = 262 := by
   rw [coxeterRelators_def, coxeterRelatorsOfList_def, List.map_map]
@@ -356,6 +360,7 @@ the Coxeter relators together with the `90 + 63 + 63` letters of the three adjoi
 The source displays its relations by family and records no presentation length, so this figure
 states the transcribed data for a reviewer to compare with the source rather than checking it
 against a published number. -/
+@[simp]
 theorem presentation_totalLength : presentation.totalLength = 478 := by
   have key : ((relatorList.map Relator.toWord).map List.length).sum = 478 := by
     rw [relatorList_def]
@@ -370,11 +375,7 @@ theorem presentation_totalLength : presentation.totalLength = 478 := by
 /-- **Every expression in the `Y₄₃₃` relator list compiles to a cyclically reduced word.** The
 Coxeter relators are cyclically reduced for any Coxeter matrix, and each adjoined relator is a
 power whose base is a product of generators with no inverse, so no letter of it can cancel against
-its neighbour or against the last letter of the word.
-
-Each alternative is dispatched by the shape of its relator rather than by goal position, and the
-power route is what keeps the three adjoined relators tractable: expanding the tenth power of the
-spider base costs ninety letters where checking the base costs nine. -/
+its neighbour or against the last letter of the word. -/
 theorem isCyclicallyReduced_toWord_of_mem_relatorList (r : Relator (Fin 11))
     (hr : r ∈ relatorList) : FreeGroup.IsCyclicallyReduced r.toWord := by
   rw [relatorList_def, List.mem_append] at hr

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/BabyMonster.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/BabyMonster.lean
@@ -71,6 +71,14 @@ source-to-Lean read-through remains the whole of the S1 review obligation.
   the shape itself.
 * `TauCeti.Sporadic.BabyMonster.length_relatorList` and
   `TauCeti.Sporadic.BabyMonster.matchesMetadata_presentation`: the transcription count checks.
+* `TauCeti.Sporadic.BabyMonster.presentation_totalLength`: the compiled relator words contain `478`
+  letters, of which `262` come from the Coxeter relators, by
+  `TauCeti.Sporadic.BabyMonster.sum_map_length_toWord_coxeterRelators`, and the rest from the three
+  adjoined relators. The source records no presentation length, so this is transcribed data stated
+  for comparison with the source rather than a check against a published figure.
+* `TauCeti.Sporadic.BabyMonster.presentation_relatorsCyclicallyReduced`: every compiled word is
+  cyclically reduced, which is what makes that letter count comparable with a published
+  presentation length at all.
 * `TauCeti.Sporadic.BabyMonster.mulEquivPresentedGroupCoxeterAppend`: the row presents the Coxeter
   group of the diagram cut down by the three adjoined relations, which is the shape of the source's
   statement.
@@ -314,6 +322,86 @@ theorem length_relatorList : relatorList.length = 69 := by
 /-- **The recorded generator and relator counts agree with the transcribed data.** -/
 theorem matchesMetadata_presentation : presentation.matchesMetadata :=
   (GroupPresentation.matchesMetadata_iff presentation).mpr ⟨by decide, length_relatorList⟩
+
+/-! ### Letter counts -/
+
+/-- The spider relator compiles to `10 · 9 = 90` letters. -/
+theorem length_toWord_spiderRelator : spiderRelator.toWord.length = 90 := by
+  simp [spiderRelator_eq]
+
+/-- The first adjoined relator compiles to `9 · 7 = 63` letters. -/
+theorem length_toWord_extraRelatorOne : extraRelatorOne.toWord.length = 63 := by
+  simp [extraRelatorOne_eq]
+
+/-- The second adjoined relator compiles to `9 · 7 = 63` letters. -/
+theorem length_toWord_extraRelatorTwo : extraRelatorTwo.toWord.length = 63 := by
+  simp [extraRelatorTwo_eq]
+
+/-- **The Coxeter relators of the `Y₄₃₃` diagram contain `262` letters.** A relator `(tᵢ tⱼ) ^ m`
+contributes `2m`, so the eleven involution relators contribute `2` each, the ten edges `6` each,
+and the forty-five remaining pairs of distinct nodes `4` each: `22 + 60 + 180`. Reading the count
+off the Coxeter matrix rather than off the expanded relators is what ties it to the transcribed
+edge list. -/
+theorem sum_map_length_toWord_coxeterRelators :
+    ((coxeterRelators coxeterMatrix).map fun r => r.toWord.length).sum = 262 := by
+  rw [coxeterRelators_def, coxeterRelatorsOfList_def, List.map_map]
+  simp_rw [Function.comp_def, length_toWord_coxeterRelator]
+  simp only [coxeterMatrix_apply]
+  rw [edges_eq]
+  decide
+
+/-- **The compiled relator words of the row contain `478` letters in total**, the `262` letters of
+the Coxeter relators together with the `90 + 63 + 63` letters of the three adjoined relators.
+
+The source displays its relations by family and records no presentation length, so this figure
+states the transcribed data for a reviewer to compare with the source rather than checking it
+against a published number. -/
+theorem presentation_totalLength : presentation.totalLength = 478 := by
+  have key : ((relatorList.map Relator.toWord).map List.length).sum = 478 := by
+    rw [relatorList_def]
+    simp only [List.map_append, List.sum_append, List.map_map, Function.comp_def,
+      adjoinedRelators_def, List.map_cons, List.map_nil, List.sum_cons, List.sum_nil,
+      length_toWord_spiderRelator, length_toWord_extraRelatorOne, length_toWord_extraRelatorTwo,
+      sum_map_length_toWord_coxeterRelators]
+    decide
+  rw [GroupPresentation.totalLength_def, GroupPresentation.relators_def, presentation_transcribed]
+  exact key
+
+/-- **Every expression in the `Y₄₃₃` relator list compiles to a cyclically reduced word.** The
+Coxeter relators are cyclically reduced for any Coxeter matrix, and each adjoined relator is a
+power whose base is a product of generators with no inverse, so no letter of it can cancel against
+its neighbour or against the last letter of the word.
+
+Each alternative is dispatched by the shape of its relator rather than by goal position, and the
+power route is what keeps the three adjoined relators tractable: expanding the tenth power of the
+spider base costs ninety letters where checking the base costs nine. -/
+theorem isCyclicallyReduced_toWord_of_mem_relatorList (r : Relator (Fin 11))
+    (hr : r ∈ relatorList) : FreeGroup.IsCyclicallyReduced r.toWord := by
+  rw [relatorList_def, List.mem_append] at hr
+  rcases hr with hr | hr
+  · obtain ⟨i, j, rfl⟩ := mem_coxeterRelators_iff.mp hr
+    exact isCyclicallyReduced_toWord_coxeterRelator coxeterMatrix _ _
+  · simp only [adjoinedRelators_def, List.mem_cons, List.not_mem_nil, or_false] at hr
+    rcases hr with rfl | rfl | rfl
+    · rw [spiderRelator_eq]
+      exact Relator.isCyclicallyReduced_toWord_pow
+        (by simp [FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced]) _
+    · rw [extraRelatorOne_eq]
+      exact Relator.isCyclicallyReduced_toWord_pow
+        (by simp [FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced]) _
+    · rw [extraRelatorTwo_eq]
+      exact Relator.isCyclicallyReduced_toWord_pow
+        (by simp [FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced]) _
+
+/-- **Every compiled relator word of the row is cyclically reduced**, which is what makes the
+letter count of `TauCeti.Sporadic.BabyMonster.presentation_totalLength` comparable with the usual
+presentation-length convention, under which a relator is measured after free and cyclic
+reduction. -/
+theorem presentation_relatorsCyclicallyReduced : presentation.relatorsCyclicallyReduced := by
+  rw [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def]
+  intro w hw
+  obtain ⟨r, hr, rfl⟩ := List.mem_map.mp hw
+  exact isCyclicallyReduced_toWord_of_mem_relatorList r (presentation_transcribed ▸ hr)
 
 /-- **The row presents the Coxeter group of the `Y₄₃₃` diagram cut down by the three adjoined
 relations**, which is the shape in which the source states the presentation: the Coxeter relations

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/BabyMonster.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/BabyMonster.lean
@@ -73,7 +73,7 @@ source-to-Lean read-through remains the whole of the S1 review obligation.
   `TauCeti.Sporadic.BabyMonster.matchesMetadata_presentation`: the transcription count checks.
 * `TauCeti.Sporadic.BabyMonster.presentation_totalLength`: the compiled relator words contain `478`
   letters, of which `262` come from the Coxeter relators, by
-  `TauCeti.Sporadic.BabyMonster.sum_map_length_toWord_coxeterRelators`, and the rest from the three
+  `TauCeti.Sporadic.BabyMonster.sum_map_length_coxeterRelators`, and the rest from the three
   adjoined relators. The source records no presentation length, so this is transcribed data stated
   for comparison with the source rather than a check against a published figure.
 * `TauCeti.Sporadic.BabyMonster.presentation_relatorsCyclicallyReduced`: every compiled word is
@@ -214,7 +214,6 @@ def spiderRelator : Relator (Fin 11) :=
   .pow (t5 ⬝ t4 ⬝ t3 ⬝ t5 ⬝ t6 ⬝ t7 ⬝ t5 ⬝ t9 ⬝ t10) 10
 
 /-- The spider relator spelled out in the numbered alphabet. -/
-@[simp]
 theorem spiderRelator_eq :
     spiderRelator =
       .pow (.gen 4 ⬝ .gen 3 ⬝ .gen 2 ⬝ .gen 4 ⬝ .gen 5 ⬝ .gen 6 ⬝ .gen 4 ⬝ .gen 8 ⬝ .gen 9) 10 := by
@@ -225,7 +224,6 @@ spider relation to pass from `2 × 2·B` to `B`. -/
 def extraRelatorOne : Relator (Fin 11) := .pow (t5 ⬝ t4 ⬝ t3 ⬝ t6 ⬝ t7 ⬝ t8 ⬝ t9) 9
 
 /-- The first adjoined relator spelled out in the numbered alphabet. -/
-@[simp]
 theorem extraRelatorOne_eq :
     extraRelatorOne =
       .pow (.gen 4 ⬝ .gen 3 ⬝ .gen 2 ⬝ .gen 5 ⬝ .gen 6 ⬝ .gen 7 ⬝ .gen 8) 9 := by
@@ -236,7 +234,6 @@ spider relation to pass from `2 × 2·B` to `B`. -/
 def extraRelatorTwo : Relator (Fin 11) := .pow (t5 ⬝ t4 ⬝ t3 ⬝ t6 ⬝ t9 ⬝ t10 ⬝ t11) 9
 
 /-- The second adjoined relator spelled out in the numbered alphabet. -/
-@[simp]
 theorem extraRelatorTwo_eq :
     extraRelatorTwo =
       .pow (.gen 4 ⬝ .gen 3 ⬝ .gen 2 ⬝ .gen 5 ⬝ .gen 8 ⬝ .gen 9 ⬝ .gen 10) 9 := by
@@ -327,17 +324,17 @@ theorem matchesMetadata_presentation : presentation.matchesMetadata :=
 
 /-- The spider relator compiles to `10 · 9 = 90` letters. -/
 @[simp]
-theorem length_toWord_spiderRelator : spiderRelator.toWord.length = 90 := by
+theorem length_spiderRelator : spiderRelator.length = 90 := by
   simp [spiderRelator_eq]
 
 /-- The first adjoined relator compiles to `9 · 7 = 63` letters. -/
 @[simp]
-theorem length_toWord_extraRelatorOne : extraRelatorOne.toWord.length = 63 := by
+theorem length_extraRelatorOne : extraRelatorOne.length = 63 := by
   simp [extraRelatorOne_eq]
 
 /-- The second adjoined relator compiles to `9 · 7 = 63` letters. -/
 @[simp]
-theorem length_toWord_extraRelatorTwo : extraRelatorTwo.toWord.length = 63 := by
+theorem length_extraRelatorTwo : extraRelatorTwo.length = 63 := by
   simp [extraRelatorTwo_eq]
 
 /-- **The Coxeter relators of the `Y₄₃₃` diagram contain `262` letters.** A relator `(tᵢ tⱼ) ^ m`
@@ -346,10 +343,10 @@ and the forty-five remaining pairs of distinct nodes `4` each: `22 + 60 + 180`. 
 off the Coxeter matrix rather than off the expanded relators is what ties it to the transcribed
 edge list. -/
 @[simp]
-theorem sum_map_length_toWord_coxeterRelators :
-    ((coxeterRelators coxeterMatrix).map fun r => r.toWord.length).sum = 262 := by
+theorem sum_map_length_coxeterRelators :
+    ((coxeterRelators coxeterMatrix).map fun r => r.length).sum = 262 := by
   rw [coxeterRelators_def, coxeterRelatorsOfList_def, List.map_map]
-  simp_rw [Function.comp_def, length_toWord_coxeterRelator]
+  simp_rw [Function.comp_def, ← Relator.length_toWord, length_toWord_coxeterRelator]
   simp only [coxeterMatrix_apply]
   rw [edges_eq]
   decide
@@ -366,8 +363,8 @@ theorem presentation_totalLength : presentation.totalLength = 478 := by
     rw [relatorList_def]
     simp only [List.map_append, List.sum_append, List.map_map, Function.comp_def,
       adjoinedRelators_def, List.map_cons, List.map_nil, List.sum_cons, List.sum_nil,
-      length_toWord_spiderRelator, length_toWord_extraRelatorOne, length_toWord_extraRelatorTwo,
-      sum_map_length_toWord_coxeterRelators]
+      Relator.length_toWord, length_spiderRelator, length_extraRelatorOne,
+      length_extraRelatorTwo, sum_map_length_coxeterRelators]
     decide
   rw [GroupPresentation.totalLength_def, GroupPresentation.relators_def, presentation_transcribed]
   exact key

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyFour.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyFour.lean
@@ -385,9 +385,9 @@ representative reached so far. In particular the two rewrites `r` and `a r a` of
 have the same length, the right-hand side not mentioning `positive`. -/
 @[simp]
 theorem length_toWord_fi24SchreierRewrite (positive : Bool) (r : Relator (Fin 12)) :
-    (fi24SchreierRewrite positive r).toWord.length =
+    (fi24SchreierRewrite positive r).length =
       r.toWord.countP fun letter => letter.1 ≠ 0 := by
-  rw [Relator.length_toWord, fi24SchreierRewrite_def]
+  rw [fi24SchreierRewrite_def]
   exact length_foldr_fi24SchreierFactors positive r.toWord
 
 /-- The `136` relators of the index-two subgroup. The square relations are omitted after their
@@ -599,7 +599,7 @@ private theorem sum_map_length_flatMap_fi24SchreierRewrite (l : List (Relator (F
   | nil => simp
   | cons r l ih =>
     rw [List.flatMap_cons, List.map_append, List.sum_append, ih]
-    simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, ← Relator.length_toWord,
+    simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil,
       length_toWord_fi24SchreierRewrite]
     ring
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyFour.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyFour.lean
@@ -383,6 +383,7 @@ distinguished letter `a` is the transversal element, so it contributes no Schrei
 every other source letter contributes one, inverted or not according to the transversal
 representative reached so far. In particular the two rewrites `r` and `a r a` of one source relator
 have the same length, the right-hand side not mentioning `positive`. -/
+@[simp]
 theorem length_toWord_fi24SchreierRewrite (positive : Bool) (r : Relator (Fin 12)) :
     (fi24SchreierRewrite positive r).toWord.length =
       r.toWord.countP fun letter => letter.1 ≠ 0 := by

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyFour.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyFour.lean
@@ -53,6 +53,14 @@ relators on eleven generators. `TauCeti.Sporadic.fi24PrimePresentation_matchesMe
 this count, while `TauCeti.Sporadic.even_length_of_mem_fi24AutomorphismRelators` checks that every
 source relator does lie in the index-two subgroup before the rewrite is applied.
 
+The rewrite drops exactly the source letters equal to `a`, which is
+`TauCeti.Sporadic.length_toWord_fi24SchreierRewrite`, so the letter count of the row is read off
+the source relators rather than off the rewritten ones:
+`TauCeti.Sporadic.fi24PrimePresentation_totalLength` records the `1076` letters they contribute.
+Neither source publishes a presentation length to check that figure against, and the row claims no
+cyclic reduction of its compiled words, so the count states the transcribed data for comparison
+with the source rather than checking it against a published number.
+
 Nothing here asserts that the presented group is nontrivial, finite, simple, of any particular
 order, or isomorphic to another realization. Kim and Michler prove that the commutator subgroup of
 the displayed source presentation is `Fi₂₄'`; Reidemeister--Schreier rewriting transfers that
@@ -353,6 +361,34 @@ theorem fi24SchreierRewrite_def (positive : Bool) (r : Relator (Fin 12)) :
       (fi24SchreierFactors positive r.toWord).foldr .mul (.pow (.gen 0) 0) := by
   simp only [fi24SchreierRewrite, relatorOfFactors]
 
+/-- The assembled rewrite of a source word has one letter for each of its letters other than `a`,
+whichever transversal representative the rewrite starts from. Every emitted factor is a single
+generator or its inverse, and the empty product `(ab)⁰` contributes nothing. -/
+private theorem length_foldr_fi24SchreierFactors (positive : Bool)
+    (w : PresentationWord (Fin 12)) :
+    ((fi24SchreierFactors positive w).foldr Relator.mul ((Relator.gen 0).pow 0)).length =
+      w.countP fun letter => letter.1 ≠ 0 := by
+  induction w generalizing positive with
+  | nil => simp
+  | cons letter w ih =>
+    obtain ⟨i, sign⟩ := letter
+    rw [fi24SchreierFactors_cons, List.countP_cons]
+    by_cases hi : i = 0
+    · subst hi; simpa using ih (!positive)
+    · have h : i.val ≠ 0 := fun hv => hi (Fin.ext hv)
+      cases positive <;> simp [h, hi, ih, Nat.add_comm]
+
+/-- **The Reidemeister--Schreier rewrite keeps exactly the source letters other than `a`.** The
+distinguished letter `a` is the transversal element, so it contributes no Schreier generator, while
+every other source letter contributes one, inverted or not according to the transversal
+representative reached so far. In particular the two rewrites `r` and `a r a` of one source relator
+have the same length, the right-hand side not mentioning `positive`. -/
+theorem length_toWord_fi24SchreierRewrite (positive : Bool) (r : Relator (Fin 12)) :
+    (fi24SchreierRewrite positive r).toWord.length =
+      r.toWord.countP fun letter => letter.1 ≠ 0 := by
+  rw [Relator.length_toWord, fi24SchreierRewrite_def]
+  exact length_foldr_fi24SchreierFactors positive r.toWord
+
 /-- The `136` relators of the index-two subgroup. The square relations are omitted after their
 standard Tietze elimination of the redundant Schreier generators; the `66` off-diagonal Coxeter
 relations and the two additional relations each contribute a rewrite of `r` and of `a r a`. -/
@@ -498,5 +534,91 @@ theorem fi24PrimePresentation_relatorLetters :
 theorem fi24PrimePresentation_matchesMetadata : fi24PrimePresentation.matchesMetadata := by
   rw [GroupPresentation.matchesMetadata_iff]
   exact ⟨rfl, length_fi24PrimeRelators⟩
+
+/-! ## Letter counts
+
+Every count below is read off the source relators through
+`TauCeti.Sporadic.length_toWord_fi24SchreierRewrite` rather than off the rewritten words, which is
+what keeps the arithmetic tied to the eleven-edge diagram a reviewer checks against the source. -/
+
+/-- A repeated list contributes its own count once per repetition. Counting on the base rather than
+on the expansion is what keeps the seventeenth power below tractable. -/
+private theorem countP_flatten_replicate {α : Type*} (p : α → Bool) (n : ℕ) (l : List α) :
+    (List.replicate n l).flatten.countP p = n * l.countP p := by
+  rw [List.countP_flatten, List.map_replicate, List.sum_replicate, smul_eq_mul]
+
+/-- The off-diagonal source relators contain `262` letters other than `a`. A relator `(x y) ^ m`
+contributes `m` letters for each of `x` and `y` different from `a`, so the eleven pairs that use
+`a` contribute `m` and the other fifty-five contribute `2m`. -/
+private theorem sum_countP_fi24SourcePairRelators :
+    (fi24SourcePairRelators.map fun r => r.toWord.countP fun letter => letter.1 ≠ 0).sum = 262 := by
+  rw [fi24SourcePairRelators_def, List.map_map]
+  simp_rw [Function.comp_def, toWord_coxeterRelator, countP_flatten_replicate]
+  simp only [fi24AutomorphismCoxeterMatrix_apply]
+  rw [fi24AutomorphismEdges_def]
+  decide
+
+/-- The source equation for `l` contains `55` letters other than `a`, one for `l` itself and six
+for each of the nine repetitions of `a b c d e f h`. -/
+private theorem countP_toWord_fi24SourceEquationRelator :
+    (fi24SourceEquationRelator.toWord.countP fun letter => letter.1 ≠ 0) = 55 := by
+  have hinv : ∀ w : PresentationWord (Fin 12),
+      ((FreeGroup.invRev w).countP fun letter => letter.1 ≠ 0) =
+        w.countP fun letter => letter.1 ≠ 0 := by
+    intro w; simp [FreeGroup.invRev, Function.comp_def]
+  rw [fi24SourceEquationRelator_def, Relator.toWord_div, List.countP_append, hinv,
+    Relator.toWord_pow, countP_flatten_replicate, fi24SourceEquationWord_def]
+  simp
+
+/-- The final source relation contains `221` letters other than `a`, thirteen for each of the
+seventeen repetitions of `d c b a k l d e f g j d h i`. -/
+private theorem countP_toWord_fi24SourceLongRelator :
+    (fi24SourceLongRelator.toWord.countP fun letter => letter.1 ≠ 0) = 221 := by
+  rw [fi24SourceLongRelator_def, Relator.toWord_pow, countP_flatten_replicate,
+    fi24SourceLongWord_def]
+  simp
+
+/-- The `68` rewritten source relators contain `538` letters other than `a`. -/
+private theorem sum_countP_fi24RewrittenSourceRelators :
+    ((fi24SourcePairRelators ++ fi24AutomorphismAdditionalRelators).map fun r =>
+      r.toWord.countP fun letter => letter.1 ≠ 0).sum = 538 := by
+  rw [List.map_append, List.sum_append, sum_countP_fi24SourcePairRelators,
+    fi24AutomorphismAdditionalRelators_def]
+  simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil,
+    countP_toWord_fi24SourceEquationRelator, countP_toWord_fi24SourceLongRelator]
+  decide
+
+/-- Rewriting a list of source relators doubles the number of surviving letters, since each
+contributes the rewrite of `r` and the rewrite of `a r a`. -/
+private theorem sum_map_length_flatMap_fi24SchreierRewrite (l : List (Relator (Fin 12))) :
+    ((l.flatMap fun r => [fi24SchreierRewrite false r, fi24SchreierRewrite true r]).map
+        Relator.length).sum =
+      2 * (l.map fun r => r.toWord.countP fun letter => letter.1 ≠ 0).sum := by
+  induction l with
+  | nil => simp
+  | cons r l ih =>
+    rw [List.flatMap_cons, List.map_append, List.sum_append, ih]
+    simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, ← Relator.length_toWord,
+      length_toWord_fi24SchreierRewrite]
+    ring
+
+/-- **The compiled relator words of the `Fi₂₄'` row contain `1076` letters in total.**
+
+By `TauCeti.Sporadic.length_toWord_fi24SchreierRewrite` the two rewrites of a source relator have
+the same length, namely its number of letters other than `a`, so the total is twice the `538`
+letters the `68` rewritten source relators contribute: `524` from the off-diagonal Coxeter
+relators, `110` from the source equation for `l`, and `442` from the final source relation.
+
+Neither Kim--Michler nor Hall--Soicher publishes a presentation length, so this figure states the
+transcribed data for a reviewer to compare with the source rather than checking it against a
+recorded number. It is a count of compiled letters and not of reduced ones: unlike the other
+sporadic rows this one claims no cyclic reduction of its words, the Reidemeister--Schreier rewrite
+being what stands between a source relator and the word whose letters are counted. -/
+theorem fi24PrimePresentation_totalLength : fi24PrimePresentation.totalLength = 1076 := by
+  rw [← GroupPresentation.sum_map_length_relatorLetters, fi24PrimePresentation_relatorLetters,
+    List.map_map]
+  simp only [Function.comp_def, List.length_map, Relator.length_toWord]
+  rw [fi24PrimeRelators_def, sum_map_length_flatMap_fi24SchreierRewrite,
+    sum_countP_fi24RewrittenSourceRelators]
 
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyFour.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyFour.lean
@@ -54,7 +54,7 @@ this count, while `TauCeti.Sporadic.even_length_of_mem_fi24AutomorphismRelators`
 source relator does lie in the index-two subgroup before the rewrite is applied.
 
 The rewrite drops exactly the source letters equal to `a`, which is
-`TauCeti.Sporadic.length_toWord_fi24SchreierRewrite`, so the letter count of the row is read off
+`TauCeti.Sporadic.length_fi24SchreierRewrite`, so the letter count of the row is read off
 the source relators rather than off the rewritten ones:
 `TauCeti.Sporadic.fi24PrimePresentation_totalLength` records the `1076` letters they contribute.
 Neither source publishes a presentation length to check that figure against, and the row claims no
@@ -384,7 +384,7 @@ every other source letter contributes one, inverted or not according to the tran
 representative reached so far. In particular the two rewrites `r` and `a r a` of one source relator
 have the same length, the right-hand side not mentioning `positive`. -/
 @[simp]
-theorem length_toWord_fi24SchreierRewrite (positive : Bool) (r : Relator (Fin 12)) :
+theorem length_fi24SchreierRewrite (positive : Bool) (r : Relator (Fin 12)) :
     (fi24SchreierRewrite positive r).length =
       r.toWord.countP fun letter => letter.1 ≠ 0 := by
   rw [fi24SchreierRewrite_def]
@@ -539,7 +539,7 @@ theorem fi24PrimePresentation_matchesMetadata : fi24PrimePresentation.matchesMet
 /-! ## Letter counts
 
 Every count below is read off the source relators through
-`TauCeti.Sporadic.length_toWord_fi24SchreierRewrite` rather than off the rewritten words, which is
+`TauCeti.Sporadic.length_fi24SchreierRewrite` rather than off the rewritten words, which is
 what keeps the arithmetic tied to the eleven-edge diagram a reviewer checks against the source. -/
 
 /-- A repeated list contributes its own count once per repetition. Counting on the base rather than
@@ -600,12 +600,12 @@ private theorem sum_map_length_flatMap_fi24SchreierRewrite (l : List (Relator (F
   | cons r l ih =>
     rw [List.flatMap_cons, List.map_append, List.sum_append, ih]
     simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil,
-      length_toWord_fi24SchreierRewrite]
+      length_fi24SchreierRewrite]
     ring
 
 /-- **The compiled relator words of the `Fi₂₄'` row contain `1076` letters in total.**
 
-By `TauCeti.Sporadic.length_toWord_fi24SchreierRewrite` the two rewrites of a source relator have
+By `TauCeti.Sporadic.length_fi24SchreierRewrite` the two rewrites of a source relator have
 the same length, namely its number of letters other than `a`, so the total is twice the `538`
 letters the `68` rewritten source relators contribute: `524` from the off-diagonal Coxeter
 relators, `110` from the source equation for `l`, and `442` from the final source relation.
@@ -615,6 +615,7 @@ transcribed data for a reviewer to compare with the source rather than checking 
 recorded number. It is a count of compiled letters and not of reduced ones: unlike the other
 sporadic rows this one claims no cyclic reduction of its words, the Reidemeister--Schreier rewrite
 being what stands between a source relator and the word whose letters are counted. -/
+@[simp]
 theorem fi24PrimePresentation_totalLength : fi24PrimePresentation.totalLength = 1076 := by
   rw [← GroupPresentation.sum_map_length_relatorLetters, fi24PrimePresentation_relatorLetters,
     List.map_map]


### PR DESCRIPTION
This PR closes the letter-count audit of the sporadic presentation manifest by covering its last
two rows, `Fi24Prime` and `B`, the only ones not carrying compiled-word counts once the work
already in flight lands.

For `B` the row is the `Y₄₃₃` Coxeter presentation, so its count is read off the Coxeter matrix
rather than off the expanded relators: a relator `(tᵢ tⱼ) ^ m` contributes `2m`, giving `22 + 60 +
180 = 262` for the eleven involution relators, the ten edges and the forty-five remaining pairs,
and the spider and the two adjoined relators contribute `90 + 63 + 63`, for `478` letters in all.
Every compiled word is also proved cyclically reduced, which is what makes a letter count
comparable with a published presentation length; the Coxeter relators are cyclically reduced for
any Coxeter matrix, and each adjoined relator is a power of an inverse-free word, so the check is
made on the nine- and seven-letter bases rather than on their expansions.

For `Fi24Prime` the transcribed relators are Reidemeister–Schreier rewrites, so the count needs a
structural fact first: `length_toWord_fi24SchreierRewrite` says the rewrite keeps exactly the
source letters other than the transversal element `a`, whichever representative it starts from, so
the two rewrites `r` and `a r a` of one source relator have the same length. The total is then
computed from the eleven-edge source diagram rather than from the rewritten words: the sixty-six
off-diagonal Coxeter relators keep `262` letters, the source equation `l = (abcdefh)⁹` keeps `55`
of its `64`, and `(dcbaklddefgjdhi)¹⁷` keeps `221` of its `238`, so the row has `2 · 538 = 1076`
letters. That row claims no cyclic reduction, and the module docstring and the theorem docstring
both say so; neither source publishes a presentation length for either row, so both totals state
transcribed data for a reviewer to compare with the source rather than checking it against a
recorded number.

The milestone is S1 of `TauCetiRoadmap/CFSGStatement/README.md`, "the twenty-six sporadic
presentations", whose closing condition is that each row's counts are checked against the manifest
and its transcription independently reviewed; per-relator and aggregate letter counts are what let
that review locate a discrepancy at the relator carrying it rather than only in the aggregate.
After this PR every one of the twenty-six rows carries letter counts once the three open row
audits (#5306, #5293, #5291) land, and what remains for S1 is the recorded source-to-Lean
read-through for the rows that still lack one.

Nothing here asserts that a presented group is nontrivial, finite, simple, of any particular
order, or isomorphic to any other construction of the named group; the roadmap does not ask S1
for that.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"fi24prime-b-presentation-row-audit"}-->

🤖 Prepared with Claude Code
