### PR TITLE
feat: check M23 against the source's eight-relator length

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyThree.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyThree.lean
@@ -62,10 +62,11 @@ exists to record. Together with `TauCeti.GroupPresentation.relators_def` and
 the relations defining the presented group, so a consumer reasons about the row without unfolding
 it.
 
-Three decidable checks accompany those equations. The relator lengths and their total record the
-compiled data one word at a time and in aggregate, and cyclic reducedness makes the letter count
-comparable with the source's published length. The nine-word total is `238`, exactly the figure in
-the source header for the version including the useful redundant relator.
+Four decidable checks accompany those equations. The relator lengths and two aggregate totals record
+the compiled data one word at a time and in aggregate, and cyclic reducedness makes the letter
+counts comparable with the source's published lengths. The nine-word total is `238` and deleting the
+useful redundant eighth relator leaves `190`, exactly the two figures in the source header for the
+two versions of the presentation.
 
 ## Main definitions and results
 
@@ -287,7 +288,8 @@ the figures on the source's header lines `Length: 190 [or 238].` and `NoRels: 8 
 bracketed alternatives are exactly the presence of this relator. -/
 theorem m23Presentation_sum_map_length_eraseIdx_relators :
     ((m23Presentation.relators.eraseIdx 7).map List.length).sum = 190 := by
-  simp [GroupPresentation.relators_def, m23Presentation]
+  rw [← List.eraseIdx_map, m23Presentation_map_length_relators]
+  decide
 
 /-- Every compiled relator word for `M₂₃` is cyclically reduced. This is what makes
 `TauCeti.Sporadic.m23Presentation_totalLength` and

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyThree.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyThree.lean
@@ -73,9 +73,11 @@ the source header for the version including the useful redundant relator.
 * `TauCeti.Sporadic.m23Presentation_transcribed` and the equations for the remaining fields: the
   characterization of the sealed row.
 * `TauCeti.Sporadic.m23Presentation_map_length_relators`,
-  `TauCeti.Sporadic.m23Presentation_totalLength` and
-  `TauCeti.Sporadic.m23Presentation_relatorsCyclicallyReduced`: the three checks on the compiled
-  words.
+  `TauCeti.Sporadic.m23Presentation_totalLength`,
+  `TauCeti.Sporadic.m23Presentation_sum_map_length_eraseIdx_relators` and
+  `TauCeti.Sporadic.m23Presentation_relatorsCyclicallyReduced`: the four checks on the compiled
+  words. The two totals are the figures on the source's header line `Length: 190 [or 238].`,
+  whose bracketed alternative is the presence of the redundant eighth relator.
 
 ## References
 
@@ -277,8 +279,20 @@ theorem m23Presentation_totalLength : m23Presentation.totalLength = 238 := by
   rw [GroupPresentation.totalLength_def, m23Presentation_map_length_relators]
   decide
 
+/-- Deleting the redundant eighth relator `(ab·ab²·ab²)⁶` leaves `190` signed letters, which is
+the length the source records for its eight-relator form.
+
+With `TauCeti.Sporadic.m23Presentation_totalLength` this checks the transcription against both of
+the figures on the source's header lines `Length: 190 [or 238].` and `NoRels: 8 [or 9].`, whose
+bracketed alternatives are exactly the presence of this relator. -/
+theorem m23Presentation_sum_map_length_eraseIdx_relators :
+    ((m23Presentation.relators.eraseIdx 7).map List.length).sum = 190 := by
+  simp [GroupPresentation.relators_def, m23Presentation]
+
 /-- Every compiled relator word for `M₂₃` is cyclically reduced. This is what makes
-`TauCeti.Sporadic.m23Presentation_totalLength` comparable with the source's published length. -/
+`TauCeti.Sporadic.m23Presentation_totalLength` and
+`TauCeti.Sporadic.m23Presentation_sum_map_length_eraseIdx_relators` comparable with the source's
+published lengths, which are measured after free and cyclic reduction of each relator. -/
 theorem m23Presentation_relatorsCyclicallyReduced :
     m23Presentation.relatorsCyclicallyReduced := by
   simp only [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def,


### PR DESCRIPTION
This PR checks the transcribed `M₂₃` presentation against the second of the two lengths its source publishes. `TauCeti.Sporadic.m23Presentation_totalLength` already gives the nine compiled words the total `238`; `m23Presentation_sum_map_length_eraseIdx_relators` deletes the eighth word, the redundant `(ab·ab²·ab²)⁶`, and gets `190`. Those are exactly the two figures on the header lines `Length: 190 [or 238].` and `NoRels: 8 [or 9].` of the Magma source file `M23G1-P1.M`, whose bracketed alternatives are the presence of that one relator, so the transcription now reproduces the source's own accounting of both of its forms rather than only the longer one. `m23Presentation_relatorsCyclicallyReduced` is what makes either total comparable with a published length, since such a length is measured after free and cyclic reduction of each relator; its docstring now names both.

The exact target is milestone S1, "the twenty-six sporadic presentations," in `TauCetiRoadmap/CFSGStatement/README.md`, whose completion evidence requires an independent source-to-Lean read-through of every row. The eight-relator length is the one figure the `M₂₃` source publishes that the row did not yet check, so this closes that row's aggregate accounting against its own header. This is the one check missing from https://github.com/TauCetiProject/TauCeti/pull/5285, "feat: audit the M23 and M24 presentations", which landed the rest of the audit.

The new proof derives the erased-list total from `m23Presentation_map_length_relators` through `List.eraseIdx_map`, so it rests on the published length vector rather than recompiling the sealed row.

Roadmap: CFSGStatement

🤖 Prepared with Claude Code
