### PR TITLE
feat: the hook-content formula for the Weyl dimension

### DIFF
--- a/TauCeti/Combinatorics/Young/BetaNumbers.lean
+++ b/TauCeti/Combinatorics/Young/BetaNumbers.lean
@@ -5,6 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.BigOperators.Intervals
+public import Mathlib.Algebra.BigOperators.Ring.Finset
 public import Mathlib.Combinatorics.Young.YoungDiagram
 
 /-!
@@ -15,7 +17,8 @@ Fix a Young diagram `μ` and a bound `r` on its number of rows. The `i`-th **bet
 `r - 1 - i` of rows of the bounding `r`-row strip that lie below it. Adding that shift to the weakly
 decreasing row lengths makes the beta-numbers strictly decrease across the indices `i < j < r`
 inside the bound, so those `r` numbers are pairwise distinct; that is the whole point of the
-construction, and it is all this file proves.
+construction.  This file also records that the natural-number product of their differences casts
+to the corresponding integer product.
 
 Beta-numbers are the bookkeeping device behind the Frobenius determinant formula and the
 Frame-Robinson-Thrall route to the hook-length formula. Their relation to hook lengths --- for the
@@ -32,6 +35,8 @@ hook-length API and is developed in `TauCeti/Combinatorics/Young/HookLength/Beta
 * `YoungDiagram.betaNumber_lt_betaNumber`: the beta-numbers strictly decrease across the indices
   `i < j < r` inside the bound.
 * `YoungDiagram.injOn_betaNumber`: the beta-numbers of the indices `i < r` are pairwise distinct.
+* `YoungDiagram.cast_prod_betaNumber_sub`: casts the product of beta-number differences from
+  `ℕ` to `ℤ`.
 
 ## References
 
@@ -76,5 +81,20 @@ theorem strictAntiOn_betaNumber (μ : YoungDiagram) (r : ℕ) :
 theorem injOn_betaNumber (μ : YoungDiagram) (r : ℕ) :
     Set.InjOn (μ.betaNumber r) (Set.Iio r) :=
   (μ.strictAntiOn_betaNumber r).injOn
+
+open Finset
+
+/-- The Vandermonde-style product of the differences of the beta-numbers is computed by the same
+formula over `ℤ`, the differences being nonnegative. -/
+theorem cast_prod_betaNumber_sub (μ : YoungDiagram) (r : ℕ) :
+    ((∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r, (μ.betaNumber r k - μ.betaNumber r l) : ℕ) : ℤ)
+      = ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
+          ((μ.betaNumber r k : ℤ) - (μ.betaNumber r l : ℤ)) := by
+  rw [Nat.cast_prod]
+  refine Finset.prod_congr rfl fun k _ => ?_
+  rw [Nat.cast_prod]
+  refine Finset.prod_congr rfl fun l hl => ?_
+  rw [mem_Ico] at hl
+  exact Nat.cast_sub (μ.betaNumber_lt_betaNumber (by omega) hl.2).le
 
 end YoungDiagram

--- a/TauCeti/Combinatorics/Young/Diagram.lean
+++ b/TauCeti/Combinatorics/Young/Diagram.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+public import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
 public import Mathlib.Combinatorics.Young.YoungDiagram
 public import Mathlib.Data.Finset.Powerset
 public import Mathlib.Data.List.GetD
@@ -23,7 +24,8 @@ the rows exhaust the cells, the row lengths also determine the diagram
 `YoungDiagram.card_filter_fst_lt_filter_snd_eq` counts the cells of the first `k` rows
 lying in a fixed column.  The same row-by-row reading applies to any property of the cells, not
 only to counting them all: `YoungDiagram.card_filter_cells` counts the cells satisfying a
-predicate one row at a time.
+predicate one row at a time, and `YoungDiagram.prod_cells_eq_prod_range` reads a product over the
+cells the same way.
 
 The partial sums are the shape of every dominance statement about partitions, since dominance
 compares partial sums of decreasingly sorted parts, and the sorted parts of a partition are the
@@ -162,6 +164,23 @@ theorem card_filter_cells (μ : _root_.YoungDiagram) (p : ℕ × ℕ → Prop) [
     simp only [Finset.disjoint_left, Finset.mem_image, Finset.mem_filter, Finset.mem_range]
     rintro c ⟨j, -, rfl⟩ ⟨j', -, hj'⟩
     exact hyz (congrArg Prod.fst hj').symm
+
+/-- **A product over the cells of a Young diagram, read row by row.**  The cells are fibred over
+their row index by `Prod.fst`, and the fibre of `i` is the row `YoungDiagram.row μ i`, which is
+`{i} ×ˢ Finset.range (μ.rowLen i)`.  The range of rows is any range containing all of them, as in
+`YoungDiagram.card_eq_sum_range_rowLen`; a row past the last one contributes an empty product. -/
+theorem prod_cells_eq_prod_range {M : Type*} [CommMonoid M] (μ : _root_.YoungDiagram) {N : ℕ}
+    (hN : μ.colLen 0 ≤ N) (f : ℕ × ℕ → M) :
+    ∏ c ∈ μ.cells, f c = ∏ i ∈ Finset.range N, ∏ j ∈ Finset.range (μ.rowLen i), f (i, j) := by
+  have hmaps : ∀ c ∈ μ.cells, c.1 ∈ Finset.range N := by
+    rintro ⟨a, b⟩ hc
+    exact Finset.mem_range.mpr ((_root_.YoungDiagram.mem_iff_lt_colLen.mp hc).trans_le
+      ((μ.colLen_anti 0 b b.zero_le).trans hN))
+  rw [← Finset.prod_fiberwise_of_maps_to hmaps f]
+  refine Finset.prod_congr rfl fun i _ => ?_
+  -- the fibre of `i` is `YoungDiagram.row`, defined as exactly this filter
+  rw [← _root_.YoungDiagram.row, _root_.YoungDiagram.row_eq_prod, Finset.prod_product,
+    Finset.prod_singleton]
 
 /-- The first `k` entries of `YoungDiagram.rowLens` count the cells in the first `k` rows.  This
 is `YoungDiagram.sum_range_rowLen_eq_card_filter_fst` with the truncation taken on the

--- a/TauCeti/Combinatorics/Young/HookLength/BetaNumbers.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/BetaNumbers.lean
@@ -233,20 +233,6 @@ theorem prod_hookLength_row_mul_prod_betaNumber_sub_eq_factorial (hr : μ.colLen
 
 /-! ### The hook-length product -/
 
-/-- A product over the cells of a diagram with at most `r` rows, read row by row: the cells are
-fibred over their row index by `Prod.fst`, and the fibre of `i` is the row `μ.row i`. -/
-private theorem prod_cells_eq_prod_range {M : Type*} [CommMonoid M] (hr : μ.colLen 0 ≤ r)
-    (f : ℕ × ℕ → M) :
-    ∏ c ∈ μ.cells, f c = ∏ i ∈ range r, ∏ c ∈ range (μ.rowLen i), f (i, c) := by
-  have hmaps : ∀ c ∈ μ.cells, c.1 ∈ range r := by
-    rintro ⟨a, b⟩ hc
-    exact mem_range.mpr
-      ((mem_iff_lt_colLen.mp ((mem_cells _).mp hc)).trans_le (colLen_le_of_colLen_zero_le hr b))
-  rw [← prod_fiberwise_of_maps_to hmaps f]
-  refine prod_congr rfl fun i _ => ?_
-  -- the fibre of `i` is `YoungDiagram.row`, defined as exactly this filter
-  rw [← row, row_eq_prod, Finset.prod_product, prod_singleton]
-
 /-- **The hook-length product identity.** For a Young diagram `μ` with at most `r` rows, the
 product of all its hook lengths, multiplied by the Vandermonde-style product of the differences of
 its beta-numbers, is the product of the factorials of its beta-numbers.
@@ -259,7 +245,7 @@ theorem prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial (μ : YoungDia
     ((∏ c ∈ μ.cells, μ.hookLength c) *
         ∏ i ∈ range r, ∏ j ∈ Ico (i + 1) r, (μ.betaNumber r i - μ.betaNumber r j))
       = ∏ i ∈ range r, (μ.betaNumber r i) ! := by
-  rw [prod_cells_eq_prod_range hr, ← prod_mul_distrib]
+  rw [prod_cells_eq_prod_range μ hr, ← prod_mul_distrib]
   exact prod_congr rfl fun i _ => prod_hookLength_row_mul_prod_betaNumber_sub_eq_factorial hr
 
 /-! ### Erasing a corner -/

--- a/TauCeti/Combinatorics/Young/HookLength/Formula.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/Formula.lean
@@ -113,19 +113,6 @@ open Finset Nat YoungDiagram
 
 /-! ### The Frobenius determinant formula -/
 
-/-- The Vandermonde-style product of the differences of the beta-numbers is computed by the same
-formula over `ℤ`, the differences being nonnegative. -/
-private theorem cast_prod_betaNumber_sub (μ : YoungDiagram) (r : ℕ) :
-    ((∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r, (μ.betaNumber r k - μ.betaNumber r l) : ℕ) : ℤ)
-      = ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
-          ((μ.betaNumber r k : ℤ) - (μ.betaNumber r l : ℤ)) := by
-  rw [Nat.cast_prod]
-  refine Finset.prod_congr rfl fun k _ => ?_
-  rw [Nat.cast_prod]
-  refine Finset.prod_congr rfl fun l hl => ?_
-  rw [mem_Ico] at hl
-  exact Nat.cast_sub (μ.betaNumber_lt_betaNumber (by omega) hl.2).le
-
 /-- A row of the diagram carrying no corner contributes nothing to the lowering identity: either
 its beta-number vanishes, or lowering that beta-number by one makes it agree with the next one,
 which puts a zero factor in the product. -/

--- a/TauCeti/Data/Nat/Factorial/SuperFactorial.lean
+++ b/TauCeti/Data/Nat/Factorial/SuperFactorial.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.Nat.Factorial.BigOperators
+public import Mathlib.Data.Nat.Factorial.SuperFactorial
+
+/-!
+# Positivity of the superfactorial
+
+`Nat.superFactorial n = 0! · 1! ⋯ n!` is Mathlib's superfactorial, and
+`Nat.prod_range_succ_factorial` is its expansion as a product of factorials.  Mathlib does not
+record the immediate consequence that the value is positive, which is what lets the superfactorial
+be cancelled from an identity over `ℕ`.
+
+## Main results
+
+* `TauCeti.Nat.superFactorial_pos`: the superfactorial is positive.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Nat
+
+/-- **The superfactorial is positive**, being a product of factorials. -/
+theorem superFactorial_pos (n : ℕ) : 0 < n.superFactorial := by
+  rw [← Nat.prod_range_succ_factorial n]
+  exact Nat.prod_factorial_pos _ id
+
+end Nat
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/HookContent.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/HookContent.lean
@@ -70,7 +70,9 @@ leaves the formula.
 
 namespace TauCeti
 
-open Finset Nat
+-- `_root_.Nat` rather than `Nat`: inside `namespace TauCeti` the latter is ambiguous, `TauCeti.Nat`
+-- being a namespace of this repository too.
+open Finset _root_.Nat
 
 variable {n i : ℕ} {μ : YoungDiagram}
 
@@ -147,7 +149,7 @@ theorem weylDimension_weightOfShape_mul_prod_hookLength (hμ : μ.colLen 0 ≤ n
       ((YoungDiagram.cast_prod_betaNumber_sub μ n).trans
         (prod_betaNumber_sub_eq_weylDimensionNumerator n μ)).symm
     exact_mod_cast this
-  have hsf : 0 < (n - 1).superFactorial := superFactorial_pos (n - 1)
+  have hsf : 0 < (n - 1).superFactorial := Nat.superFactorial_pos (n - 1)
   refine Nat.eq_of_mul_eq_mul_right hsf ?_
   calc weylDimension (weightOfShape n μ) * (∏ c ∈ μ.cells, μ.hookLength c)
         * (n - 1).superFactorial

--- a/TauCeti/RepresentationTheory/ClassicalGroups/HookContent.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/HookContent.lean
@@ -24,7 +24,7 @@ the **hook-content formula**: each cell contributes the quotient of `n` plus its
 its hook length.  This file proves it, in the division-free form
 `TauCeti.weylDimension_weightOfShape_mul_prod_hookLength` and in the quotient form
 `TauCeti.weylDimension_weightOfShape_eq_prod_div`, and extends it to an arbitrary dominant weight
-through the determinant twist (`TauCeti.weylDimension_eq_prod_div`).
+through the determinant twist (`TauCeti.weylDimension_eq_prod_detShiftShape_div_hookLength`).
 
 ## The route
 
@@ -52,10 +52,10 @@ leaves the formula.
 * `TauCeti.weylDimension_weightOfShape_mul_prod_hookLength`: **the hook-content formula**, in
   division-free form over `ℕ`.
 * `TauCeti.weylDimension_weightOfShape_eq_prod_div`: its quotient form over `ℚ`.
-* `TauCeti.weylDimension_eq_prod_div`: the quotient form for an arbitrary dominant weight, whose
-  cells are those of its polynomial part `TauCeti.DominantWeight.detShiftShape`.  The Weyl
-  dimension is unchanged by a determinant twist, and so is each factor, the content and the hook
-  length being read off the same diagram.
+* `TauCeti.weylDimension_eq_prod_detShiftShape_div_hookLength`: the quotient form for an arbitrary
+  dominant weight, whose cells are those of its polynomial part
+  `TauCeti.DominantWeight.detShiftShape`.  The Weyl dimension is unchanged by a determinant twist,
+  and so is each factor, the content and the hook length being read off the same diagram.
 
 ## References
 
@@ -114,16 +114,18 @@ private theorem prod_cells_mul_superFactorial (hμ : μ.colLen 0 ≤ n) :
 differences of the shifted row lengths `λᵢ - i`, the two shifts differing by the constant `n - 1`,
 so the Vandermonde-style product of the former is the numerator of the Weyl dimension formula at
 the weight `μ` determines. -/
-private theorem natCast_prod_betaNumber_sub (n : ℕ) (μ : YoungDiagram) :
-    ((∏ i ∈ range n, ∏ j ∈ Ico (i + 1) n, (μ.betaNumber n i - μ.betaNumber n j) : ℕ) : ℤ)
+private theorem prod_betaNumber_sub_eq_weylDimensionNumerator (n : ℕ) (μ : YoungDiagram) :
+    (∏ i ∈ range n, ∏ j ∈ Ico (i + 1) n,
+        ((μ.betaNumber n i : ℤ) - (μ.betaNumber n j : ℤ)))
       = weylDimensionNumerator (weightOfShape n μ) := by
-  rw [weylDimensionNumerator_eq_prod_prod, Nat.cast_prod,
+  rw [weylDimensionNumerator_eq_prod_prod,
     ← Fin.prod_univ_eq_prod_range
-      (fun i => ((∏ j ∈ Ico (i + 1) n, (μ.betaNumber n i - μ.betaNumber n j) : ℕ) : ℤ)) n]
+      (fun i => ∏ j ∈ Ico (i + 1) n,
+        ((μ.betaNumber n i : ℤ) - (μ.betaNumber n j : ℤ))) n]
   refine Finset.prod_congr rfl fun i _ => ?_
   have hIco : Finset.Ico ((i : ℕ) + 1) n = Finset.Ioo (i : ℕ) n := by
     ext j; simp only [Finset.mem_Ico, Finset.mem_Ioo]; omega
-  rw [Nat.cast_prod, hIco, ← Fin.map_valEmbedding_Ioi, Finset.prod_map]
+  rw [hIco, ← Fin.map_valEmbedding_Ioi, Finset.prod_map]
   refine Finset.prod_congr rfl fun j hj => ?_
   have hij : (i : ℕ) < (j : ℕ) := Fin.lt_def.mp (Finset.mem_Ioi.mp hj)
   have hjn : (j : ℕ) < n := j.isLt
@@ -142,11 +144,10 @@ theorem weylDimension_weightOfShape_mul_prod_hookLength (hμ : μ.colLen 0 ≤ n
   have hnum : weylDimension (weightOfShape n μ) * (n - 1).superFactorial
       = ∏ i ∈ range n, ∏ j ∈ Ico (i + 1) n, (μ.betaNumber n i - μ.betaNumber n j) := by
     have := (weylDimension_mul_superFactorial (weightOfShape n μ)).trans
-      (natCast_prod_betaNumber_sub n μ).symm
+      ((YoungDiagram.cast_prod_betaNumber_sub μ n).trans
+        (prod_betaNumber_sub_eq_weylDimensionNumerator n μ)).symm
     exact_mod_cast this
-  have hsf : 0 < (n - 1).superFactorial := by
-    rw [← prod_range_factorial_sub n]
-    exact Finset.prod_pos fun i _ => Nat.factorial_pos _
+  have hsf : 0 < (n - 1).superFactorial := superFactorial_pos (n - 1)
   refine Nat.eq_of_mul_eq_mul_right hsf ?_
   calc weylDimension (weightOfShape n μ) * (∏ c ∈ μ.cells, μ.hookLength c)
         * (n - 1).superFactorial
@@ -183,7 +184,7 @@ theorem weylDimension_weightOfShape_eq_prod_div (hμ : μ.colLen 0 ≤ n) :
 is a determinant twist of a polynomial one, whose Young diagram is
 `TauCeti.DominantWeight.detShiftShape`; the twist changes neither the Weyl dimension nor the
 diagram, so the hook-content formula holds for every weight, read on that diagram. -/
-theorem weylDimension_eq_prod_div (l : DominantWeight n) :
+theorem weylDimension_eq_prod_detShiftShape_div_hookLength (l : DominantWeight n) :
     (weylDimension l : ℚ)
       = ∏ c ∈ l.detShiftShape.cells,
           (((n : ℚ) + c.2 - c.1) / l.detShiftShape.hookLength c) := by

--- a/TauCeti/RepresentationTheory/ClassicalGroups/HookContent.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/HookContent.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Combinatorics.Young.HookLength.BetaNumbers
+public import TauCeti.RepresentationTheory.ClassicalGroups.WeylDimension
+
+public section
+
+/-!
+# The hook-content formula
+
+`TauCeti.weylDimension` is the value `∏_{i < j} (λᵢ - λⱼ + j - i) / (j - i)` of the Weyl dimension
+formula for `GL n`, a product over the pairs of *rows*.  For a polynomial weight — a Young diagram
+`μ` with at most `n` rows, read as a weight by `TauCeti.weightOfShape` — the same number is a
+product over the *cells* of `μ`,
+
+`weylDimension (weightOfShape n μ) = ∏_{(i, j) ∈ μ} (n + j - i) / hookLength μ (i, j)`,
+
+the **hook-content formula**: each cell contributes the quotient of `n` plus its content `j - i` by
+its hook length.  This file proves it, in the division-free form
+`TauCeti.weylDimension_weightOfShape_mul_prod_hookLength` and in the quotient form
+`TauCeti.weylDimension_weightOfShape_eq_prod_div`, and extends it to an arbitrary dominant weight
+through the determinant twist (`TauCeti.weylDimension_eq_prod_div`).
+
+## The route
+
+Both sides are compared against the beta-numbers `βᵢ = μ.rowLen i + (n - 1 - i)` of
+`TauCeti/Combinatorics/Young/BetaNumbers.lean`, which are the row lengths of `μ` shifted so as to
+be strictly decreasing.  Three identities meet.
+
+* The hook lengths, by `YoungDiagram.prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial`:
+  `(∏_{c ∈ μ} hookLength c) · ∏_{i < j < n} (βᵢ - βⱼ) = ∏_{i < n} βᵢ !`.
+* The contents, proved here: row `i` contributes the cells `(i, 0), …, (i, μ.rowLen i - 1)`, whose
+  contents `n + j - i` are the `μ.rowLen i` consecutive integers starting at `n - i`, so that row
+  contributes `βᵢ ! / (n - 1 - i)!` — and the missing factorials multiply to the superfactorial
+  `sf (n - 1)`.  This is `∏_{c ∈ μ} (n + c₂ - c₁) · sf (n - 1) = ∏_{i < n} βᵢ !`.
+* The Weyl dimension, by `TauCeti.weylDimension_mul_superFactorial`:
+  `weylDimension · sf (n - 1) = ∏_{i < j < n} (βᵢ - βⱼ)`, once the numerator of the Weyl dimension
+  formula is recognized as the Vandermonde-style product of the beta-numbers.  That recognition is
+  the identity `βᵢ - βⱼ = (λᵢ - i) - (λⱼ - j)`: the two shifts differ by the constant `n - 1`.
+
+Cancelling the (positive) superfactorial from
+`(∏ contents) · sf = ∏ βᵢ ! = (∏ hooks) · ∏ (βᵢ - βⱼ) = (∏ hooks) · weylDimension · sf`
+leaves the formula.
+
+## Main results
+
+* `TauCeti.weylDimension_weightOfShape_mul_prod_hookLength`: **the hook-content formula**, in
+  division-free form over `ℕ`.
+* `TauCeti.weylDimension_weightOfShape_eq_prod_div`: its quotient form over `ℚ`.
+* `TauCeti.weylDimension_eq_prod_div`: the quotient form for an arbitrary dominant weight, whose
+  cells are those of its polynomial part `TauCeti.DominantWeight.detShiftShape`.  The Weyl
+  dimension is unchanged by a determinant twist, and so is each factor, the content and the hook
+  length being read off the same diagram.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 5, "The Weyl dimension formula", which asks for the hook-content form of
+  `TauCeti.weylDimension` and for the proof that the two agree.
+* W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), Theorem 6.3 and
+  Exercise 6.4, where the hook-content formula is stated for `GL n`.
+* [I. G. Macdonald, *Symmetric Functions and Hall Polynomials*][macdonald1995], Chapter I,
+  Section 3, Example 4.
+-/
+
+namespace TauCeti
+
+open Finset Nat
+
+variable {n i : ℕ} {μ : YoungDiagram}
+
+/-! ### The product of the contents -/
+
+/-- The cells of row `i` of `μ` have contents `n + j - i` running over the `μ.rowLen i` consecutive
+integers starting at `n - i`, so their product completes `(n - 1 - i)!` to `βᵢ !`. -/
+private theorem factorial_mul_prod_range_rowLen (μ : YoungDiagram) (h : i < n) :
+    (n - 1 - i)! * ∏ j ∈ range (μ.rowLen i), (n - i + j) = (μ.betaNumber n i)! := by
+  have hshift : n - i = (n - 1 - i) + 1 := by omega
+  rw [← Nat.ascFactorial_eq_prod_range, hshift, Nat.factorial_mul_ascFactorial,
+    YoungDiagram.betaNumber_def, Nat.add_comm]
+
+/-- The factorials left over by `TauCeti.factorial_mul_prod_range_rowLen` are `0!, 1!, …, (n-1)!`,
+whose product is the superfactorial. -/
+private theorem prod_range_factorial_sub (n : ℕ) :
+    ∏ i ∈ range n, (n - 1 - i)! = (n - 1).superFactorial := by
+  rw [Finset.prod_range_reflect (fun i => i !) n]
+  cases n with
+  | zero => simp
+  | succ m => exact Nat.prod_range_succ_factorial m
+
+/-- **The content product.** For a Young diagram with at most `n` rows, the product of the contents
+`n + j - i` of its cells, times the superfactorial `sf (n - 1)`, is the product of the factorials of
+its beta-numbers. -/
+private theorem prod_cells_mul_superFactorial (hμ : μ.colLen 0 ≤ n) :
+    (∏ c ∈ μ.cells, (n + c.2 - c.1)) * (n - 1).superFactorial
+      = ∏ i ∈ range n, (μ.betaNumber n i)! := by
+  rw [YoungDiagram.prod_cells_eq_prod_range μ hμ, ← prod_range_factorial_sub n,
+    ← Finset.prod_mul_distrib]
+  refine Finset.prod_congr rfl fun i hi => ?_
+  have hi' : i < n := Finset.mem_range.mp hi
+  have hcontent : ∏ j ∈ range (μ.rowLen i), (n + j - i) = ∏ j ∈ range (μ.rowLen i), (n - i + j) :=
+    Finset.prod_congr rfl fun j _ => by omega
+  rw [hcontent, mul_comm]
+  exact factorial_mul_prod_range_rowLen μ hi'
+
+/-! ### The numerator of the Weyl dimension formula -/
+
+/-- **The Weyl numerator in beta-numbers.** The differences of the beta-numbers of `μ` are the
+differences of the shifted row lengths `λᵢ - i`, the two shifts differing by the constant `n - 1`,
+so the Vandermonde-style product of the former is the numerator of the Weyl dimension formula at
+the weight `μ` determines. -/
+private theorem natCast_prod_betaNumber_sub (n : ℕ) (μ : YoungDiagram) :
+    ((∏ i ∈ range n, ∏ j ∈ Ico (i + 1) n, (μ.betaNumber n i - μ.betaNumber n j) : ℕ) : ℤ)
+      = weylDimensionNumerator (weightOfShape n μ) := by
+  rw [weylDimensionNumerator_eq_prod_prod, Nat.cast_prod,
+    ← Fin.prod_univ_eq_prod_range
+      (fun i => ((∏ j ∈ Ico (i + 1) n, (μ.betaNumber n i - μ.betaNumber n j) : ℕ) : ℤ)) n]
+  refine Finset.prod_congr rfl fun i _ => ?_
+  have hIco : Finset.Ico ((i : ℕ) + 1) n = Finset.Ioo (i : ℕ) n := by
+    ext j; simp only [Finset.mem_Ico, Finset.mem_Ioo]; omega
+  rw [Nat.cast_prod, hIco, ← Fin.map_valEmbedding_Ioi, Finset.prod_map]
+  refine Finset.prod_congr rfl fun j hj => ?_
+  have hij : (i : ℕ) < (j : ℕ) := Fin.lt_def.mp (Finset.mem_Ioi.mp hj)
+  have hjn : (j : ℕ) < n := j.isLt
+  have hrow : μ.rowLen j ≤ μ.rowLen i := μ.rowLen_anti _ _ hij.le
+  simp only [Fin.valEmbedding_apply, YoungDiagram.betaNumber_def, weightOfShape_apply]
+  omega
+
+/-! ### The hook-content formula -/
+
+/-- **The hook-content formula**, in division-free form: for a Young diagram `μ` with at most `n`
+rows, the Weyl dimension of the weight it determines, times the product of the hook lengths of `μ`,
+is the product over the cells of `μ` of `n` plus the content `j - i`. -/
+theorem weylDimension_weightOfShape_mul_prod_hookLength (hμ : μ.colLen 0 ≤ n) :
+    weylDimension (weightOfShape n μ) * ∏ c ∈ μ.cells, μ.hookLength c
+      = ∏ c ∈ μ.cells, (n + c.2 - c.1) := by
+  have hnum : weylDimension (weightOfShape n μ) * (n - 1).superFactorial
+      = ∏ i ∈ range n, ∏ j ∈ Ico (i + 1) n, (μ.betaNumber n i - μ.betaNumber n j) := by
+    have := (weylDimension_mul_superFactorial (weightOfShape n μ)).trans
+      (natCast_prod_betaNumber_sub n μ).symm
+    exact_mod_cast this
+  have hsf : 0 < (n - 1).superFactorial := by
+    rw [← prod_range_factorial_sub n]
+    exact Finset.prod_pos fun i _ => Nat.factorial_pos _
+  refine Nat.eq_of_mul_eq_mul_right hsf ?_
+  calc weylDimension (weightOfShape n μ) * (∏ c ∈ μ.cells, μ.hookLength c)
+        * (n - 1).superFactorial
+      = (∏ c ∈ μ.cells, μ.hookLength c)
+          * (weylDimension (weightOfShape n μ) * (n - 1).superFactorial) := by ring
+    _ = (∏ c ∈ μ.cells, μ.hookLength c)
+          * ∏ i ∈ range n, ∏ j ∈ Ico (i + 1) n, (μ.betaNumber n i - μ.betaNumber n j) := by
+        rw [hnum]
+    _ = ∏ i ∈ range n, (μ.betaNumber n i)! :=
+        YoungDiagram.prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial μ hμ
+    _ = (∏ c ∈ μ.cells, (n + c.2 - c.1)) * (n - 1).superFactorial :=
+        (prod_cells_mul_superFactorial hμ).symm
+
+/-- **The hook-content formula**, in its quotient form over `ℚ`: for a Young diagram `μ` with at
+most `n` rows, the Weyl dimension of the weight it determines is the product over the cells of `μ`
+of `(n + j - i) / hookLength μ (i, j)`. -/
+theorem weylDimension_weightOfShape_eq_prod_div (hμ : μ.colLen 0 ≤ n) :
+    (weylDimension (weightOfShape n μ) : ℚ)
+      = ∏ c ∈ μ.cells, (((n : ℚ) + c.2 - c.1) / μ.hookLength c) := by
+  have hhook : (∏ c ∈ μ.cells, (μ.hookLength c : ℚ)) ≠ 0 :=
+    Finset.prod_ne_zero_iff.mpr fun c _ => by
+      exact_mod_cast (μ.hookLength_pos c).ne'
+  rw [Finset.prod_div_distrib, eq_div_iff hhook, ← Nat.cast_prod, ← Nat.cast_mul,
+    weylDimension_weightOfShape_mul_prod_hookLength hμ, Nat.cast_prod]
+  refine Finset.prod_congr rfl fun c hc => ?_
+  have hc' : c.1 < n :=
+    ((YoungDiagram.mem_iff_lt_colLen.mp ((YoungDiagram.mem_cells c).mp hc)).trans_le
+      ((μ.colLen_anti 0 c.2 c.2.zero_le).trans hμ))
+  have : c.1 ≤ n + c.2 := by omega
+  push_cast [Nat.cast_sub this]
+  ring
+
+/-- **The hook-content formula for an arbitrary dominant weight.** Every dominant weight of `GL n`
+is a determinant twist of a polynomial one, whose Young diagram is
+`TauCeti.DominantWeight.detShiftShape`; the twist changes neither the Weyl dimension nor the
+diagram, so the hook-content formula holds for every weight, read on that diagram. -/
+theorem weylDimension_eq_prod_div (l : DominantWeight n) :
+    (weylDimension l : ℚ)
+      = ∏ c ∈ l.detShiftShape.cells,
+          (((n : ℚ) + c.2 - c.1) / l.detShiftShape.hookLength c) := by
+  rw [← weylDimension_weightOfShape_eq_prod_div l.colLen_zero_detShiftShape_le,
+    DominantWeight.weightOfShape_detShiftShape, weylDimension_shift]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylDimension.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylDimension.lean
@@ -120,7 +120,7 @@ private theorem prod_Ioi_rev {M : Type*} [CommMonoid M] (f : Fin n → Fin n →
 
 /-- The superfactorial is positive: it is a product of factorials.  Mathlib has the superfactorial
 and its factorial-product expansions but not this consequence. -/
-private theorem superFactorial_pos (n : ℕ) : 0 < n.superFactorial := by
+theorem superFactorial_pos (n : ℕ) : 0 < n.superFactorial := by
   rw [← Nat.prod_range_succ_factorial n]
   exact Finset.prod_pos fun i _ => i.factorial_pos
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylDimension.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylDimension.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.Vandermonde
+public import TauCeti.Data.Nat.Factorial.SuperFactorial
 public import TauCeti.RepresentationTheory.ClassicalGroups.DominantWeight
 
 /-!
@@ -118,12 +119,6 @@ private theorem prod_Ioi_rev {M : Type*} [CommMonoid M] (f : Fin n → Fin n →
     ?_ ?_ ?_ ?_ ?_ <;>
     simp +contextual [Finset.mem_sigma, mem_Ioi, Fin.rev_lt_rev, Fin.rev_rev]
 
-/-- The superfactorial is positive: it is a product of factorials.  Mathlib has the superfactorial
-and its factorial-product expansions but not this consequence. -/
-theorem superFactorial_pos (n : ℕ) : 0 < n.superFactorial := by
-  rw [← Nat.prod_range_succ_factorial n]
-  exact Finset.prod_pos fun i _ => i.factorial_pos
-
 /-- The denominator of the Weyl dimension formula, `∏_{i < j} (j - i)`, is the superfactorial
 `sf (n - 1) = 0! · 1! ⋯ (n-1)!`: it is the Vandermonde determinant of the nodes
 `0, 1, …, n - 1`.  Stated over an arbitrary commutative ring, since the formula is used both over
@@ -192,7 +187,7 @@ times the denominator `sf (n - 1)` is the numerator `∏_{i < j} (λᵢ - λⱼ 
 theorem weylDimension_mul_superFactorial (l : DominantWeight n) :
     (weylDimension l : ℤ) * ((n - 1).superFactorial : ℤ) = weylDimensionNumerator l := by
   have hsf : (0 : ℤ) < ((n - 1).superFactorial : ℤ) := by
-    exact_mod_cast superFactorial_pos (n - 1)
+    exact_mod_cast Nat.superFactorial_pos (n - 1)
   have hnonneg : 0 ≤ weylDimensionNumerator l / ((n - 1).superFactorial : ℤ) :=
     Int.ediv_nonneg (weylDimensionNumerator_pos l).le hsf.le
   rw [weylDimension, Int.toNat_of_nonneg hnonneg,
@@ -220,7 +215,7 @@ theorem weylDimension_eq_prod_prod_div (l : DominantWeight n) :
     push_cast
     rfl
   have hsf : ((n - 1).superFactorial : ℚ) ≠ 0 := by
-    exact_mod_cast (superFactorial_pos (n - 1)).ne'
+    exact_mod_cast (Nat.superFactorial_pos (n - 1)).ne'
   simp only [Finset.prod_div_distrib]
   rw [hden, hnum, eq_div_iff hsf]
   exact_mod_cast weylDimension_mul_superFactorial l
@@ -241,7 +236,7 @@ theorem weylDimension_congr {l l' : DominantWeight n}
     (h : ∀ i j, i < j → l.1 i - l.1 j = l'.1 i - l'.1 j) :
     weylDimension l = weylDimension l' := by
   have hsf : (0 : ℤ) < ((n - 1).superFactorial : ℤ) := by
-    exact_mod_cast superFactorial_pos (n - 1)
+    exact_mod_cast Nat.superFactorial_pos (n - 1)
   have h1 : (weylDimension l : ℤ) * ((n - 1).superFactorial : ℤ) =
       (weylDimension l' : ℤ) * ((n - 1).superFactorial : ℤ) :=
     (weylDimension_mul_superFactorial l).trans
@@ -276,7 +271,7 @@ dimension `1`. -/
 theorem weylDimension_eq_one_of_forall_eq {l : DominantWeight n} {c : ℤ} (h : ∀ i, l.1 i = c) :
     weylDimension l = 1 := by
   have hsf : (0 : ℤ) < ((n - 1).superFactorial : ℤ) := by
-    exact_mod_cast superFactorial_pos (n - 1)
+    exact_mod_cast Nat.superFactorial_pos (n - 1)
   have h1 := weylDimension_mul_superFactorial l
   rw [weylDimensionNumerator_eq_superFactorial_of_forall_eq h] at h1
   have h2 : (weylDimension l : ℤ) = 1 := mul_right_cancel₀ hsf.ne' (h1.trans (one_mul _).symm)


### PR DESCRIPTION
This PR proves the **hook-content formula** for the Weyl dimension of `GL n`: for a Young diagram `μ` with at most `n` rows, the number `TauCeti.weylDimension (weightOfShape n μ)` — defined as the row-pair product `∏_{i < j} (λᵢ - λⱼ + j - i) / (j - i)` — is also the cell product

```text
∏_{(i, j) ∈ μ} (n + j - i) / hookLength μ (i, j),
```

each cell contributing `n` plus its content `j - i` over its hook length. It is stated division-free over `ℕ` (`TauCeti.weylDimension_weightOfShape_mul_prod_hookLength`), in quotient form over `ℚ` (`TauCeti.weylDimension_weightOfShape_eq_prod_div`), and, through the determinant twist, for an arbitrary dominant weight read on its polynomial part (`TauCeti.weylDimension_eq_prod_detShiftShape_div_hookLength`).

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"hook-content-formula"}-->

The milestone is Layer 5, "The Weyl dimension formula", of `RepresentationTheory/ClassicalGroups/README.md`, which pins `TauCeti.weylDimension` and then asks, in its own words: "For partitions this is the **hook-content formula** `dim = ∏_{(i,j) ∈ λ} (n + j - i) / hook(i,j)`; prove the two agree." That is exactly what lands here. What remains for the milestone after this PR is its other half, the theorem `finrank ℂ (irreducible n λ) = weylDimension n λ` identifying the formula with an actual dimension, which is downstream of the Layer 4 identification of the `GLₙ` characters with the Schur polynomials and is not attempted here.

Both sides are compared against the beta-numbers `βᵢ = μ.rowLen i + (n - 1 - i)` of `TauCeti/Combinatorics/Young/BetaNumbers.lean`, so that no new combinatorial device is introduced. Three identities meet:

* the hook lengths, by the existing `YoungDiagram.prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial`, namely `(∏ hooks) · ∏_{i < j < n} (βᵢ - βⱼ) = ∏_{i < n} βᵢ !`;
* the contents, proved here: row `i` contributes the `μ.rowLen i` consecutive integers starting at `n - i`, so `(n - 1 - i)! · ∏_{j} (n + j - i) = βᵢ !` by `Nat.factorial_mul_ascFactorial`, and the leftover factorials `0!, …, (n-1)!` multiply to `sf (n - 1)`;
* the Weyl dimension, by the existing `TauCeti.weylDimension_mul_superFactorial`, once the numerator is recognized as `∏_{i < j < n} (βᵢ - βⱼ)`. That recognition is the one-line identity `βᵢ - βⱼ = (λᵢ - i) - (λⱼ - j)`: the two shifts of the row lengths differ by the constant `n - 1`.

Cancelling the positive superfactorial from `(∏ contents) · sf = ∏ βᵢ ! = (∏ hooks) · ∏ (βᵢ - βⱼ) = (∏ hooks) · weylDimension · sf` leaves the formula. The three steps of the comparison are private: each has a single consumer, the formula itself.

New file:

* `TauCeti/RepresentationTheory/ClassicalGroups/HookContent.lean` — the content product, the numerator in beta-numbers, and the three forms of the formula.

One lemma moves. `prod_cells_eq_prod_range`, reading a product over the cells of a diagram row by row, was a `private` helper of `TauCeti/Combinatorics/Young/HookLength/BetaNumbers.lean`; it mentions no hook length, and it now has a second consumer, so it becomes public in `TauCeti/Combinatorics/Young/Diagram.lean`, the file that already counts the cells of a diagram row by row (`YoungDiagram.card_eq_sum_range_rowLen`, `YoungDiagram.card_filter_cells`). Its statement is unchanged apart from making `μ` explicit and the row bound implicit, matching its new neighbours; the `Mathlib.Algebra.BigOperators.Group.Finset.Sigma` import it needs for `Finset.prod_product` comes with it.

The mathematics follows W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), Theorem 6.3 and Exercise 6.4, and Macdonald, *Symmetric Functions and Hall Polynomials*, Chapter I, Section 3, Example 4. Nothing is vendored, and no material was taken from the supplied source snapshot; Mathlib has neither `hookLength` nor a Weyl dimension formula.

🤖 Prepared with Claude Code
