### PR TITLE
feat: close the E6 minuscule root subgroups

### DIFF
--- a/TauCeti/Algebra/Lie/E6/Minuscule/ClosedRootSubgroup.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/ClosedRootSubgroup.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E6.Minuscule.GroupScheme
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.RootInToral
+
+/-!
+# Closed root subgroups of the type-E6 minuscule carrier
+
+The twelve numbered raising and lowering maps into `TauCeti.E6Minuscule.groupScheme` are closed
+copies of the additive group scheme. For every Bourbaki node, one explicit edge in the minuscule
+weight graph recovers the root-subgroup parameter as a matrix coordinate. The raising operator
+carries the basis vector at the negative end of this edge to the basis vector at its positive end
+with coefficient one; the lowering operator traverses the same edge in reverse.
+
+The generic Kostant root-subgroup construction turns this unit-coefficient basis step into a
+surjective map from the carrier's coordinate Hopf algebra to the coordinate algebra of `𝔾ₐ`.
+Consequently each numbered root-subgroup morphism is a closed immersion. Its scheme-theoretic
+image is bundled below as a closed subgroup canonically isomorphic to `𝔾ₐ`.
+
+This supplies the closed-root-subgroup component of a pinning for the explicit full-weight
+type-`E₆` carrier in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`. That carrier is consumed
+by milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md`. No reductivity, Borel, finiteness, or
+simplicity statement is made here.
+
+## Main declarations
+
+* `TauCeti.E6Minuscule.rootSubgroupCoordinateMap_surjective`: every numbered root-subgroup
+  coordinate map is surjective.
+* `TauCeti.E6Minuscule.isClosedImmersion_rootSubgroup`: every numbered root-subgroup morphism is a
+  closed immersion.
+* `TauCeti.E6Minuscule.rootSubgroupClosedSubgroup`: its image as a closed subgroup scheme.
+* `TauCeti.E6Minuscule.rootSubgroupClosedSubgroupIso`: the canonical isomorphism of that image with
+  the additive group scheme.
+
+## References
+
+* J. E. Humphreys, *Linear Algebraic Groups*, §26.
+* R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 7.1.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.2.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory
+open scoped Matrix
+
+namespace TauCeti.E6Minuscule
+
+noncomputable section
+
+/-! ## A unit-coefficient edge at every simple root -/
+
+/-- A weight whose pairing with the given simple coroot is `-1`. The choice is internal to the
+coordinate proof; no public construction depends on which suitable weight is selected. -/
+private noncomputable def negativeWeightIndex (i : Fin 6) : Fin 27 :=
+  (DynkinType.exists_e6MinusculeWeight_apply_eq_neg_one i).choose
+
+private theorem e6MinusculeWeight_negativeWeightIndex (i : Fin 6) :
+    DynkinType.e6MinusculeWeight (negativeWeightIndex i) i = -1 :=
+  (DynkinType.exists_e6MinusculeWeight_apply_eq_neg_one i).choose_spec
+
+/-- The source coordinate of the selected edge for a raising or lowering root generator. -/
+private def rootSource : Fin 6 ⊕ Fin 6 → Fin 27
+  | .inl i => negativeWeightIndex i
+  | .inr i => DynkinType.e6MinusculeReflection i (negativeWeightIndex i)
+
+/-- The target coordinate of the selected edge for a raising or lowering root generator. -/
+private def rootTarget : Fin 6 ⊕ Fin 6 → Fin 27
+  | .inl i => DynkinType.e6MinusculeReflection i (negativeWeightIndex i)
+  | .inr i => negativeWeightIndex i
+
+private theorem rep_serreRootGenerator_latticeBasis (k : Fin 6 ⊕ Fin 6) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ k))
+        ((latticeBasis (rootSource k) : lattice) : Fin 27 → ℚ) =
+      (1 : ℤ) • ((latticeBasis (rootTarget k) : lattice) : Fin 27 → ℚ) := by
+  cases k with
+  | inl i =>
+      rw [TauCeti.serreRootGenerator_inl, rep_ι_apply,
+        rationalSerreRepresentation_serreE, coe_latticeBasis, coe_latticeBasis,
+        Matrix.mulVec_single_one, one_smul]
+      ext a
+      simp [rootSource, rootTarget, raisingMatrixQ_apply, Pi.single_apply,
+        e6MinusculeWeight_negativeWeightIndex]
+  | inr i =>
+      rw [TauCeti.serreRootGenerator_inr, rep_ι_apply,
+        rationalSerreRepresentation_serreF, coe_latticeBasis, coe_latticeBasis,
+        Matrix.mulVec_single_one, one_smul]
+      ext a
+      simp [rootSource, rootTarget, loweringMatrixQ_apply, Pi.single_apply,
+        e6MinusculeWeight_negativeWeightIndex]
+
+private theorem rep_serreRootGenerator_sq_apply_latticeBasis (k : Fin 6 ⊕ Fin 6) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ k))
+      (rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+          (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ k))
+        ((latticeBasis (rootSource k) : lattice) : Fin 27 → ℚ)) = 0 := by
+  have h := congrArg
+    (fun f : Module.End ℚ (Fin 27 → ℚ) =>
+      f ((latticeBasis (rootSource k) : lattice) : Fin 27 → ℚ))
+    (rep_serreRootGenerator_sq k)
+  simpa only [pow_two, Module.End.mul_apply, LinearMap.zero_apply] using h
+
+/-! ## Closed root-subgroup morphisms -/
+
+/-- **The coordinate morphism of every numbered type-`E₆` minuscule root subgroup is
+surjective.** The selected minuscule-weight edge has coefficient one, so one matrix coordinate
+recovers the additive parameter. -/
+theorem rootSubgroupCoordinateMap_surjective (k : Fin 6 ⊕ Fin 6) :
+    Function.Surjective
+      (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        (fun _ hu _ hv => rep_serreKostantForm_mem_lattice (by
+          rw [TauCeti.serreKostantForm_def]
+          exact hu) hv)
+        isNilpotent_rep_serreRootGenerator latticeBasis DynkinType.e6MinusculeWeight k).hom :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap_surjective
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    (fun _ hu _ hv => rep_serreKostantForm_mem_lattice (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
+    k isNilpotent_rep_serreRootGenerator latticeBasis DynkinType.e6MinusculeWeight
+    isUnit_one (rep_serreRootGenerator_latticeBasis k)
+    (rep_serreRootGenerator_sq_apply_latticeBasis k)
+
+/-- **Every numbered root-subgroup map into the type-`E₆` minuscule carrier is a closed
+immersion.** Thus its scheme-theoretic image is a closed copy of `𝔾ₐ`, as required of the root
+subgroups in a pinning. -/
+instance isClosedImmersion_rootSubgroup (k : Fin 6 ⊕ Fin 6) :
+    IsClosedImmersion (rootSubgroup k).hom.hom.left := by
+  rw [rootSubgroup_def]
+  exact
+    TauCeti.UniversalEnvelopingAlgebra.isClosedImmersion_kostantRootSubgroupToToral_of_surjective
+      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+      (fun _ hu _ hv => rep_serreKostantForm_mem_lattice (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      isNilpotent_rep_serreRootGenerator latticeBasis DynkinType.e6MinusculeWeight k
+      (rootSubgroupCoordinateMap_surjective k)
+
+/-- Every numbered root-subgroup map into the type-`E₆` minuscule carrier is a monomorphism. -/
+theorem mono_rootSubgroup (k : Fin 6 ⊕ Fin 6) : Mono (rootSubgroup k) :=
+  mono_of_isClosedImmersion_underlying (rootSubgroup k)
+
+/-- **A numbered type-`E₆` minuscule root subgroup as a closed subgroup scheme of the carrier.** -/
+noncomputable def rootSubgroupClosedSubgroup (k : Fin 6 ⊕ Fin 6) :
+    ClosedSubgroupScheme groupScheme :=
+  ClosedSubgroupScheme.mk (rootSubgroup k)
+
+/-- The bundled closed root subgroup is represented by the numbered root-subgroup morphism. -/
+@[simp]
+theorem coe_rootSubgroupClosedSubgroup (k : Fin 6 ⊕ Fin 6) :
+    (rootSubgroupClosedSubgroup k).1 =
+      letI := mono_rootSubgroup k
+      Subobject.mk (rootSubgroup k) := by
+  exact ClosedSubgroupScheme.coe_mk _
+
+/-- The bundled numbered root subgroup is canonically isomorphic to the additive group scheme. -/
+noncomputable def rootSubgroupClosedSubgroupIso (k : Fin 6 ⊕ Fin 6) :
+    ((rootSubgroupClosedSubgroup k).1 :
+      Grp (Over (Spec (CommRingCat.of ℤ)))) ≅ AdditiveGroup.groupScheme ℤ := by
+  exact eqToIso (congrArg
+      (fun P : Subobject groupScheme =>
+        (P : Grp (Over (Spec (CommRingCat.of ℤ)))))
+      (coe_rootSubgroupClosedSubgroup k)) ≪≫
+    Subobject.underlyingIso (rootSubgroup k)
+
+/-- The canonical parametrization of the bundled closed subgroup followed by its inclusion is the
+numbered type-`E₆` root-subgroup map. -/
+@[simp]
+theorem rootSubgroupClosedSubgroupIso_inv_comp_arrow (k : Fin 6 ⊕ Fin 6) :
+    (rootSubgroupClosedSubgroupIso k).inv ≫ (rootSubgroupClosedSubgroup k).1.arrow =
+      rootSubgroup k := by
+  have harrow :
+      (eqToIso (congrArg
+        (fun P : Subobject groupScheme =>
+          (P : Grp (Over (Spec (CommRingCat.of ℤ)))))
+        (coe_rootSubgroupClosedSubgroup k))).inv ≫
+          (rootSubgroupClosedSubgroup k).1.arrow =
+        (Subobject.mk (rootSubgroup k)).arrow := by
+    exact Subobject.arrow_congr
+      (Subobject.mk (rootSubgroup k))
+      (rootSubgroupClosedSubgroup k).1
+      (coe_rootSubgroupClosedSubgroup k).symm
+  rw [rootSubgroupClosedSubgroupIso, Iso.trans_inv, Category.assoc, harrow,
+    Subobject.underlyingIso_arrow]
+
+end
+
+end TauCeti.E6Minuscule

--- a/TauCeti/Algebra/Lie/E6/Minuscule/ClosedRootSubgroup.lean
+++ b/TauCeti/Algebra/Lie/E6/Minuscule/ClosedRootSubgroup.lean
@@ -137,15 +137,15 @@ subgroups in a pinning. -/
 instance isClosedImmersion_rootSubgroup (k : Fin 6 ⊕ Fin 6) :
     IsClosedImmersion (rootSubgroup k).hom.hom.left := by
   rw [rootSubgroup_def]
-  exact
-    TauCeti.UniversalEnvelopingAlgebra.isClosedImmersion_kostantRootSubgroupToToral_of_surjective
-      (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
-      (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
-      (fun _ hu _ hv => rep_serreKostantForm_mem_lattice (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      isNilpotent_rep_serreRootGenerator latticeBasis DynkinType.e6MinusculeWeight k
-      (rootSubgroupCoordinateMap_surjective k)
+  exact TauCeti.UniversalEnvelopingAlgebra.isClosedImmersion_kostantRootSubgroupToToral
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    (fun _ hu _ hv => rep_serreKostantForm_mem_lattice (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
+    k isNilpotent_rep_serreRootGenerator latticeBasis DynkinType.e6MinusculeWeight
+    isUnit_one (rep_serreRootGenerator_latticeBasis k)
+    (rep_serreRootGenerator_sq_apply_latticeBasis k)
 
 /-- Every numbered root-subgroup map into the type-`E₆` minuscule carrier is a monomorphism. -/
 theorem mono_rootSubgroup (k : Fin 6 ⊕ Fin 6) : Mono (rootSubgroup k) :=
@@ -167,32 +167,16 @@ theorem coe_rootSubgroupClosedSubgroup (k : Fin 6 ⊕ Fin 6) :
 /-- The bundled numbered root subgroup is canonically isomorphic to the additive group scheme. -/
 noncomputable def rootSubgroupClosedSubgroupIso (k : Fin 6 ⊕ Fin 6) :
     ((rootSubgroupClosedSubgroup k).1 :
-      Grp (Over (Spec (CommRingCat.of ℤ)))) ≅ AdditiveGroup.groupScheme ℤ := by
-  exact eqToIso (congrArg
-      (fun P : Subobject groupScheme =>
-        (P : Grp (Over (Spec (CommRingCat.of ℤ)))))
-      (coe_rootSubgroupClosedSubgroup k)) ≪≫
-    Subobject.underlyingIso (rootSubgroup k)
+      Grp (Over (Spec (CommRingCat.of ℤ)))) ≅ AdditiveGroup.groupScheme ℤ :=
+  ClosedSubgroupScheme.mkIso (rootSubgroup k)
 
 /-- The canonical parametrization of the bundled closed subgroup followed by its inclusion is the
 numbered type-`E₆` root-subgroup map. -/
 @[simp]
 theorem rootSubgroupClosedSubgroupIso_inv_comp_arrow (k : Fin 6 ⊕ Fin 6) :
     (rootSubgroupClosedSubgroupIso k).inv ≫ (rootSubgroupClosedSubgroup k).1.arrow =
-      rootSubgroup k := by
-  have harrow :
-      (eqToIso (congrArg
-        (fun P : Subobject groupScheme =>
-          (P : Grp (Over (Spec (CommRingCat.of ℤ)))))
-        (coe_rootSubgroupClosedSubgroup k))).inv ≫
-          (rootSubgroupClosedSubgroup k).1.arrow =
-        (Subobject.mk (rootSubgroup k)).arrow := by
-    exact Subobject.arrow_congr
-      (Subobject.mk (rootSubgroup k))
-      (rootSubgroupClosedSubgroup k).1
-      (coe_rootSubgroupClosedSubgroup k).symm
-  rw [rootSubgroupClosedSubgroupIso, Iso.trans_inv, Category.assoc, harrow,
-    Subobject.underlyingIso_arrow]
+      rootSubgroup k :=
+  ClosedSubgroupScheme.mkIso_inv_comp_arrow (rootSubgroup k)
 
 end
 

--- a/TauCeti/AlgebraicGeometry/GroupScheme/ClosedSubgroup.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/ClosedSubgroup.lean
@@ -26,6 +26,8 @@ specialized constructions that import this generic API.
   schemes.
 * `TauCeti.ClosedSubgroupScheme`: closed subgroup subobjects of a group scheme.
 * `TauCeti.ClosedSubgroupScheme.mk`: the closed subgroup represented by a closed immersion.
+* `TauCeti.ClosedSubgroupScheme.mkIso`: the canonical isomorphism of that closed subgroup with the
+  source of the immersion.
 -/
 
 public section
@@ -101,6 +103,27 @@ lemma coe_mk {K : Grp (Over X)} (i : K ⟶ G)
   by
     unfold mk
     rfl
+
+/-- The closed subgroup represented by a closed immersion is canonically isomorphic to the source
+of that immersion. -/
+noncomputable def mkIso {K : Grp (Over X)} (i : K ⟶ G)
+    [IsClosedImmersion i.hom.hom.left] :
+    ((mk i).1 : Grp (Over X)) ≅ K :=
+  eqToIso (congrArg (fun P : Subobject G => (P : Grp (Over X))) (coe_mk i)) ≪≫
+    Subobject.underlyingIso i
+
+/-- The canonical parametrization of a closed subgroup followed by its inclusion is the closed
+immersion representing it. -/
+@[simp]
+lemma mkIso_inv_comp_arrow {K : Grp (Over X)} (i : K ⟶ G)
+    [IsClosedImmersion i.hom.hom.left] :
+    (mkIso i).inv ≫ (mk i).1.arrow = i := by
+  have harrow :
+      (eqToIso (congrArg (fun P : Subobject G => (P : Grp (Over X))) (coe_mk i))).inv ≫
+          (mk i).1.arrow =
+        (Subobject.mk i).arrow :=
+    Subobject.arrow_congr (Subobject.mk i) (mk i).1 (coe_mk i).symm
+  rw [mkIso, Iso.trans_inv, Category.assoc, harrow, Subobject.underlyingIso_arrow]
 
 end ClosedSubgroupScheme
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/MinusculeWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/MinusculeWeight.lean
@@ -107,6 +107,13 @@ theorem e6MinusculeWeight_apply_eq_neg_one_or_eq_zero_or_eq_one (a : Fin 27) (i 
       e6MinusculeWeight a i = 1 := by
   fin_cases a <;> fin_cases i <;> decide
 
+/-- Every simple-coroot coordinate takes the value `-1` on some weight of the type-`E₆`
+minuscule representation. Equivalently, every positive simple-root operator has a nonzero step
+on the minuscule weight graph. -/
+theorem exists_e6MinusculeWeight_apply_eq_neg_one (i : Fin 6) :
+    ∃ a : Fin 27, e6MinusculeWeight a i = -1 := by
+  fin_cases i <;> decide +kernel
+
 /-! ## Simple reflections -/
 
 private def e6MinusculeReflectionIndex : Fin 6 → Fin 27 → Fin 27 := ![

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/ClosedRootSubgroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/ClosedRootSubgroup.lean
@@ -285,12 +285,8 @@ theorem coe_geckRootSubgroupClosedSubgroup (i : Fin t.rank ⊕ Fin t.rank) :
 /-- The bundled numbered root subgroup is canonically isomorphic to the additive group scheme. -/
 noncomputable def geckRootSubgroupClosedSubgroupIso (i : Fin t.rank ⊕ Fin t.rank) :
     ((t.geckRootSubgroupClosedSubgroup ht i).1 :
-      Grp (Over (Spec (CommRingCat.of ℤ)))) ≅ AdditiveGroup.groupScheme ℤ := by
-  exact eqToIso (congrArg
-      (fun P : Subobject (t.geckGroupScheme ht) =>
-        (P : Grp (Over (Spec (CommRingCat.of ℤ)))))
-      (t.coe_geckRootSubgroupClosedSubgroup ht i)) ≪≫
-    Subobject.underlyingIso (t.geckRootSubgroup ht i)
+      Grp (Over (Spec (CommRingCat.of ℤ)))) ≅ AdditiveGroup.groupScheme ℤ :=
+  ClosedSubgroupScheme.mkIso (t.geckRootSubgroup ht i)
 
 /-- The canonical parametrization of the bundled closed subgroup followed by its inclusion is the
 numbered Geck root-subgroup map. -/
@@ -298,20 +294,8 @@ numbered Geck root-subgroup map. -/
 theorem geckRootSubgroupClosedSubgroupIso_inv_comp_arrow (i : Fin t.rank ⊕ Fin t.rank) :
     (t.geckRootSubgroupClosedSubgroupIso ht i).inv ≫
         (t.geckRootSubgroupClosedSubgroup ht i).1.arrow =
-      t.geckRootSubgroup ht i := by
-  have harrow :
-      (eqToIso (congrArg
-        (fun P : Subobject (t.geckGroupScheme ht) =>
-          (P : Grp (Over (Spec (CommRingCat.of ℤ)))))
-        (t.coe_geckRootSubgroupClosedSubgroup ht i))).inv ≫
-          (t.geckRootSubgroupClosedSubgroup ht i).1.arrow =
-        (Subobject.mk (t.geckRootSubgroup ht i)).arrow := by
-    exact Subobject.arrow_congr
-      (Subobject.mk (t.geckRootSubgroup ht i))
-      (t.geckRootSubgroupClosedSubgroup ht i).1
-      (t.coe_geckRootSubgroupClosedSubgroup ht i).symm
-  rw [geckRootSubgroupClosedSubgroupIso, Iso.trans_inv, Category.assoc, harrow,
-    Subobject.underlyingIso_arrow]
+      t.geckRootSubgroup ht i :=
+  ClosedSubgroupScheme.mkIso_inv_comp_arrow (t.geckRootSubgroup ht i)
 
 end
 


### PR DESCRIPTION
This PR proves that every numbered raising and lowering root-subgroup morphism of the explicit full-weight type-`E₆` minuscule carrier is a closed immersion, and packages its image as a closed subgroup scheme canonically isomorphic to the additive group scheme. It advances Layer 9, “Pinnings” and “Root subgroup maps,” of `TauCetiRoadmap/ReductiveGroups/README.md`: the root maps of a pinning must be closed copies of `𝔾ₐ`, not merely morphisms into the carrier.

The designated consumer is CFSGStatement milestone L0, “explicit pinned Chevalley--Demazure groups.” The dependency edge is: the `E₆(q)` and `²E₆(q)` branches of `ValidLieTypeIndex.AmbientGroup` consume the explicit simply connected pinned type-`E₆` carrier from ReductiveGroups Layer 9; that pinning consumes the closed simple-root subgroups established here.

For each Bourbaki node, `DynkinType.exists_e6MinusculeWeight_apply_eq_neg_one` exhibits a weight at the negative end of a nonzero simple-root edge. The raising matrix traverses that edge with coefficient one and the lowering matrix traverses it in reverse. The proof feeds this unit-coefficient basis step and the existing square-zero theorem into `UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap_surjective`, then reuses the generic closed-immersion criterion and closed-subgroup interface. The coordinate witnesses remain private; the public API consists of coordinate-map surjectivity, the closed-immersion instance, the bundled closed subgroup, and its canonical additive-group isomorphism.

The mathematical construction follows Humphreys, *Linear Algebraic Groups*, §26; Carter, *Simple Groups of Lie Type*, §§4.4 and 7.1; and Jantzen, *Representations of Algebraic Groups*, II.2, as cited in the module documentation. No Mathlib code or external formalization is vendored.

After this PR, the Layer 9 type-`E₆` path still needs all-root and Borel interfaces and the reductivity/root-datum identification before CFSGStatement L0 can assemble the uniform ambient group; base change, Frobenius, and the simple-root character identification are already in flight separately.

The new module `TauCeti/Algebra/Lie/E6/Minuscule/ClosedRootSubgroup.lean` has 199 lines, and the canonical E₆ weight-table module gains the seven-line existence lemma it consumes.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e6-minuscule-closed-root-subgroups"}-->

🤖 Prepared with Codex
