### PR TITLE
feat: add the type D split spin carrier

### DIFF
--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier.lean
@@ -1,0 +1,329 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Spin.Polarization.SplitEven
+public import TauCeti.RepresentationTheory.Spin.Polarization.TypeD.KostantLattice
+public import
+  TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Points
+import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Rigidity
+import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Torus
+
+/-!
+# The full-weight type-D spin carrier
+
+For `4 ≤ n`, this file specializes the type-`Dₙ` spin representation to the canonical split
+quadratic space `M* × M`, where `M = Fin n → ℚ`. Its exterior coordinate lattice has basis
+indexed by the sign sets `Finset (Fin n)` and is stable under the type-`D` Serre Kostant form.
+The corresponding spin weights span the full simply connected character lattice.
+
+These data are fed into the Kostant toral-closure construction. The result is an explicit affine
+group scheme over `ℤ`, cut out inside `GL_(2^n)` by the largest Hopf ideal killed by the numbered
+simple-root subgroups and the represented rank-`n` split torus. In particular, the construction
+uses the full spin module rather than one half-spin summand, so its weights see both spinor cosets
+of the type-`D` root lattice.
+
+No smoothness, reductivity, maximality of the torus, or identification of the carrier's root datum
+is asserted here. Those are subsequent steps in the pinned Chevalley--Demazure construction.
+
+## Main declarations
+
+* `TauCeti.TypeDSpinCarrier.groupScheme`: the full-weight spin carrier over `ℤ`.
+* `TauCeti.TypeDSpinCarrier.rootSubgroup`: its numbered simple-root subgroup morphisms.
+* `TauCeti.TypeDSpinCarrier.weightTorus`: its closed rank-`n` split torus.
+* `TauCeti.TypeDSpinCarrier.points`: its matrix-valued points over a commutative ring.
+
+## References
+
+* C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27.
+* N. Bourbaki, *Groupes et algèbres de Lie*, Chapters 4--6, Plate IV.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1--2.
+
+The carrier API follows the formal template of
+`TauCeti.Algebra.Lie.E6.Minuscule.GroupScheme`; the split spin representation, exterior lattice,
+and type-`D` weights are specific to this construction. This advances Layer 9, "The
+Chevalley--Demazure construction", of the ReductiveGroups roadmap and supplies the type-`D`
+carrier required by milestone L0 of the CFSGStatement roadmap.
+-/
+
+public section
+
+open scoped Matrix
+
+universe v
+
+namespace TauCeti.TypeDSpinCarrier
+
+open AlgebraicGeometry CategoryTheory
+open TauCeti.UniversalEnvelopingAlgebra
+open scoped CategoryTheory.MonObj TensorProduct
+
+attribute [local instance] TauCeti.moduleNNRat
+attribute [local instance 100] LieRing.ofAssociativeRing
+attribute [local instance high] Algebra.toModule
+
+variable (n : ℕ) (hn : 4 ≤ n)
+
+/-! ## The split spin representation and its lattice -/
+
+/-- The canonical split polarization used by the type-`Dₙ` spin carrier. -/
+noncomputable abbrev polarization := TauCeti.splitEvenPolarization ℚ n
+
+/-- The coordinate basis of the first isotropic summand in the split polarization. -/
+noncomputable abbrev polarizationBasis := TauCeti.splitEvenBasis ℚ n
+
+/-- The rational spin representation of the type-`Dₙ` Serre presentation, extended to its
+universal enveloping algebra. -/
+noncomputable abbrev rep :=
+  (polarization n).typeDSpinRep (polarizationBasis n) hn
+
+/-- The integral exterior coordinate lattice in the split spin module. -/
+noncomputable abbrev lattice :=
+  TauCeti.ExteriorAlgebra.integralLattice (polarizationBasis n)
+
+/-- The dimension of the full spin module, expressed as the cardinality of its exterior basis. -/
+abbrev dimension := Fintype.card (Finset (Fin n))
+
+/-- The exterior coordinate basis, reindexed by a finite ordinal for the general-linear carrier. -/
+noncomputable def latticeBasis :
+    Module.Basis (Fin (dimension n)) ℤ (lattice n).toAddSubgroup :=
+  (TauCeti.ExteriorAlgebra.integralLatticeBasis (polarizationBasis n)).reindex
+    (Fintype.equivFin (Finset (Fin n)))
+
+/-- The sign set represented by a finite-ordinal spin-basis index. -/
+noncomputable abbrev signSet (i : Fin (dimension n)) : Finset (Fin n) :=
+  (Fintype.equivFin (Finset (Fin n))).symm i
+
+/-- The simply connected type-`Dₙ` weight of a finite-ordinal spin-basis vector. -/
+noncomputable abbrev basisWeight (i : Fin (dimension n)) : Fin n → ℤ :=
+  TauCeti.DynkinType.typeDSpinWeight (signSet n i)
+
+/-- A reindexed lattice-basis vector is the exterior basis vector of its sign set. -/
+@[simp]
+theorem coe_latticeBasis (i : Fin (dimension n)) :
+    ((latticeBasis n i : (lattice n).toAddSubgroup) :
+        ExteriorAlgebra ℚ (polarization n).W) =
+      (polarizationBasis n).ExteriorAlgebra (signSet n i) := by
+  rw [latticeBasis, Module.Basis.reindex_apply, signSet]
+  exact TauCeti.ExteriorAlgebra.coe_integralLatticeBasis _ _
+
+/-- Every represented numbered root generator is nilpotent. -/
+theorem isNilpotent_rep_rootGenerator (k : Fin n ⊕ Fin n) :
+    IsNilpotent (rep n hn
+      (_root_.UniversalEnvelopingAlgebra.ι ℚ
+        (TauCeti.serreRootGenerator (CartanMatrix.D n) k))) :=
+  (polarization n).isNilpotent_typeDSpinRep_rootGenerator (polarizationBasis n) hn k
+
+/-- The type-`D` Serre Kostant form preserves the split exterior coordinate lattice. -/
+theorem rep_serreKostantForm_mem_lattice
+    {u : _root_.UniversalEnvelopingAlgebra ℚ
+      (Matrix.ToLieAlgebra ℚ (CartanMatrix.D n))}
+    (hu : u ∈ TauCeti.serreKostantForm (CartanMatrix.D n))
+    {v : ExteriorAlgebra ℚ (polarization n).W} (hv : v ∈ lattice n) :
+    rep n hn u v ∈ lattice n :=
+  (polarization n).typeDSpinRep_serreKostantForm_apply_mem_integralLattice
+    (polarizationBasis n) hn hu hv
+
+/-- Every finite-ordinal exterior basis vector has its named integral type-`D` spin weight. -/
+theorem isCartanWeightVector_latticeBasis (i : Fin (dimension n)) :
+    IsCartanWeightVector (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn)
+      (basisWeight n i)
+      ((latticeBasis n i : (lattice n).toAddSubgroup) :
+        ExteriorAlgebra ℚ (polarization n).W) := by
+  rw [coe_latticeBasis]
+  exact (polarization n).isCartanWeightVector_typeDSpinRep_exteriorBasis
+    (polarizationBasis n) hn (signSet n i)
+
+/-- The weights of the full spin basis span the simply connected type-`D` character lattice. -/
+theorem span_range_basisWeight_eq_top :
+    Submodule.span ℤ (Set.range (basisWeight n)) = ⊤ := by
+  have hrange :
+      Set.range (fun i : Fin (dimension n) ↦
+        TauCeti.DynkinType.typeDSpinWeight (signSet n i)) =
+        Set.range (TauCeti.DynkinType.typeDSpinWeight (n := n)) := by
+    ext w
+    constructor
+    · rintro ⟨i, rfl⟩
+      exact ⟨signSet n i, rfl⟩
+    · rintro ⟨s, rfl⟩
+      exact ⟨Fintype.equivFin (Finset (Fin n)) s, by simp [signSet]⟩
+  rw [hrange, TauCeti.DynkinType.span_range_typeDSpinWeight_eq_top]
+
+/-! ## The closed carrier and its pinned generators -/
+
+/-- The Hopf ideal cutting out the full-weight type-`Dₙ` spin carrier inside `GL_(2^n)`. -/
+noncomputable def definingIdeal (hn : 4 ≤ n) :
+    HopfIdeal ℤ (TauCeti.GeneralLinear.coordinateHopfAlgebra ℤ (dimension n)) :=
+  kostantToralDefiningIdeal
+    (TauCeti.serreRootGenerator (CartanMatrix.D n))
+    (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
+    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n)
+
+/-- The defining ideal is the ideal supplied by the generic Kostant toral-closure construction. -/
+theorem definingIdeal_def :
+    definingIdeal n hn = kostantToralDefiningIdeal
+      (TauCeti.serreRootGenerator (CartanMatrix.D n))
+      (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) := by
+  rw [definingIdeal]
+
+/-- The full-weight type-`Dₙ` spin carrier over `ℤ`, obtained as the smallest closed subgroup
+scheme containing the represented numbered root subgroups and weight torus. -/
+noncomputable abbrev groupScheme (hn : 4 ≤ n) : Grp (Over (Spec (CommRingCat.of ℤ))) :=
+  kostantToralGroupScheme
+    (TauCeti.serreRootGenerator (CartanMatrix.D n))
+    (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
+    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n)
+
+/-- The quotient-spectrum presentation of the type-`Dₙ` spin carrier. -/
+theorem groupScheme_def :
+    groupScheme n hn = CommHopfAlgCat.quotientSpec
+      (TauCeti.GeneralLinear.coordinateHopfAlgebra ℤ (dimension n)) (definingIdeal n hn) := by
+  rw [groupScheme, definingIdeal]
+
+/-- The canonical inclusion of the type-`Dₙ` spin carrier into `GL_(2^n)`. -/
+noncomputable def carrierι (hn : 4 ≤ n) :
+    groupScheme n hn ⟶ TauCeti.GeneralLinear.groupScheme ℤ (dimension n) :=
+  kostantToralGroupSchemeι
+    (TauCeti.serreRootGenerator (CartanMatrix.D n))
+    (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
+    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n)
+
+/-- The carrier inclusion is the one supplied by the generic toral-closure construction. -/
+theorem carrierι_def :
+    carrierι n hn = kostantToralGroupSchemeι
+      (TauCeti.serreRootGenerator (CartanMatrix.D n))
+      (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) := by
+  rw [carrierι]
+
+/-- The type-`Dₙ` spin carrier is a closed subgroup scheme of its ambient general linear group. -/
+instance isClosedImmersion_carrierι : IsClosedImmersion (carrierι n hn).hom.hom.left := by
+  rw [carrierι]
+  exact isClosedImmersion_kostantToralGroupSchemeι _ _ _ _ _ _ _ _
+
+/-- A positive or negative numbered simple-root subgroup of the type-`Dₙ` spin carrier. -/
+noncomputable def rootSubgroup (hn : 4 ≤ n) (k : Fin n ⊕ Fin n) :
+    AdditiveGroup.groupScheme ℤ ⟶ groupScheme n hn :=
+  kostantRootSubgroupToToral
+    (TauCeti.serreRootGenerator (CartanMatrix.D n))
+    (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
+    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) k
+
+/-- A numbered root subgroup is the one supplied by the generic toral-closure construction. -/
+theorem rootSubgroup_def (k : Fin n ⊕ Fin n) :
+    rootSubgroup n hn k = kostantRootSubgroupToToral
+      (TauCeti.serreRootGenerator (CartanMatrix.D n))
+      (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) k := by
+  rw [rootSubgroup]
+
+/-- Including a numbered root subgroup into the ambient general linear group recovers its
+represented Kostant root subgroup. -/
+@[simp]
+theorem rootSubgroup_comp_carrierι (k : Fin n ⊕ Fin n) :
+    rootSubgroup n hn k ≫ carrierι n hn =
+      kostantRootSubgroup
+        (TauCeti.serreRootGenerator (CartanMatrix.D n))
+        (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+          rw [TauCeti.serreKostantForm_def]
+          exact hu) hv) k
+        (isNilpotent_rep_rootGenerator n hn k) (latticeBasis n) := by
+  rw [rootSubgroup, carrierι]
+  exact kostantRootSubgroupToToral_comp_ι _ _ _ _ _ _ _ _ k
+
+/-- The represented rank-`n` split weight torus in the type-`Dₙ` spin carrier. -/
+noncomputable def weightTorus (hn : 4 ≤ n) :
+    SplitTorus.groupScheme ℤ (Fin n) ⟶ groupScheme n hn :=
+  kostantWeightTorusToToral
+    (TauCeti.serreRootGenerator (CartanMatrix.D n))
+    (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
+    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n)
+
+/-- The weight torus is the one supplied by the generic toral-closure construction. -/
+theorem weightTorus_def :
+    weightTorus n hn = kostantWeightTorusToToral
+      (TauCeti.serreRootGenerator (CartanMatrix.D n))
+      (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+        rw [TauCeti.serreKostantForm_def]
+        exact hu) hv)
+      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) := by
+  rw [weightTorus]
+
+/-- Including the weight torus into the ambient general linear group recovers the diagonal torus
+of the spin weights. -/
+@[simp]
+theorem weightTorus_comp_carrierι :
+    weightTorus n hn ≫ carrierι n hn =
+      TauCeti.GeneralLinear.weightTorus (R := ℤ) (basisWeight n) := by
+  rw [weightTorus, carrierι]
+  exact kostantWeightTorusToToral_comp_ι _ _ _ _ _ _ _ _
+
+/-- The full spin weights make the represented split torus a closed subgroup scheme of the
+carrier. -/
+instance isClosedImmersion_weightTorus :
+    IsClosedImmersion (weightTorus n hn).hom.hom.left :=
+  isClosedImmersion_kostantWeightTorusToToral _ _ _ _ _ _ _ _
+    (span_range_basisWeight_eq_top n)
+
+/-- Two morphisms out of the type-`Dₙ` spin carrier agree when they agree on its numbered root
+subgroups and represented split torus. -/
+@[ext]
+theorem groupScheme_hom_ext {Y : _root_.CommHopfAlgCat.{0} ℤ}
+    (f g : groupScheme n hn ⟶
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).obj (Opposite.op Y))
+    (hroot : ∀ k, rootSubgroup n hn k ≫ f = rootSubgroup n hn k ≫ g)
+    (htorus : weightTorus n hn ≫ f = weightTorus n hn ≫ g) : f = g := by
+  exact kostantToralGroupScheme_hom_ext _ _ _ _ _ _ _ _ f g hroot htorus
+
+/-! ## Matrix-valued points -/
+
+/-- The matrix-valued points of the type-`Dₙ` spin carrier. -/
+noncomputable def points (hn : 4 ≤ n) (A : Type v) [CommRing A] :
+    Subgroup (_root_.Matrix.GeneralLinearGroup (Fin (dimension n)) A) :=
+  kostantToralPointsSubgroup
+    (TauCeti.serreRootGenerator (CartanMatrix.D n))
+    (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
+      rw [TauCeti.serreKostantForm_def]
+      exact hu) hv)
+    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) A
+
+/-- The carrier points are exactly the invertible matrices cut out by the defining Hopf ideal. -/
+theorem points_def (A : Type v) [CommRing A] :
+    points n hn A =
+      TauCeti.GeneralLinear.hopfIdealPointsSubgroup (dimension n) (definingIdeal n hn) A := by
+  rw [points, definingIdeal]
+  exact kostantToralPointsSubgroup_def _ _ _ _ _ _ _ _ A
+
+end TauCeti.TypeDSpinCarrier

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier.lean
@@ -128,6 +128,19 @@ theorem rep_serreKostantForm_mem_lattice
   (polarization n).typeDSpinRep_serreKostantForm_apply_mem_integralLattice
     (polarizationBasis n) hn hu hv
 
+/-- The generic Kostant form for the numbered type-`D` generators preserves the split exterior
+coordinate lattice. -/
+theorem rep_kostantForm_mem_lattice
+    (u : _root_.UniversalEnvelopingAlgebra ℚ
+      (Matrix.ToLieAlgebra ℚ (CartanMatrix.D n)))
+    (hu : u ∈ kostantForm (TauCeti.serreRootGenerator (CartanMatrix.D n))
+      (TauCeti.serreH ℚ (CartanMatrix.D n)))
+    (v : ExteriorAlgebra ℚ (polarization n).W) (hv : v ∈ lattice n) :
+    rep n hn u v ∈ lattice n :=
+  rep_serreKostantForm_mem_lattice n hn (by
+    rw [TauCeti.serreKostantForm_def]
+    exact hu) hv
+
 /-- Every finite-ordinal exterior basis vector has its named integral type-`D` spin weight. -/
 theorem isCartanWeightVector_latticeBasis (i : Fin (dimension n)) :
     IsCartanWeightVector (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn)
@@ -161,31 +174,16 @@ noncomputable def definingIdeal (hn : 4 ≤ n) :
   kostantToralDefiningIdeal
     (TauCeti.serreRootGenerator (CartanMatrix.D n))
     (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-      rw [TauCeti.serreKostantForm_def]
-      exact hu) hv)
+    (rep_kostantForm_mem_lattice n hn)
     (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n)
-
-/-- The defining ideal is the ideal supplied by the generic Kostant toral-closure construction. -/
-theorem definingIdeal_def :
-    definingIdeal n hn = kostantToralDefiningIdeal
-      (TauCeti.serreRootGenerator (CartanMatrix.D n))
-      (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) := by
-  rw [definingIdeal]
 
 /-- The full-weight type-`Dₙ` spin carrier over `ℤ`, obtained as the smallest closed subgroup
 scheme containing the represented numbered root subgroups and weight torus. -/
-noncomputable abbrev groupScheme (hn : 4 ≤ n) : Grp (Over (Spec (CommRingCat.of ℤ))) :=
+noncomputable def groupScheme (hn : 4 ≤ n) : Grp (Over (Spec (CommRingCat.of ℤ))) :=
   kostantToralGroupScheme
     (TauCeti.serreRootGenerator (CartanMatrix.D n))
     (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-      rw [TauCeti.serreKostantForm_def]
-      exact hu) hv)
+    (rep_kostantForm_mem_lattice n hn)
     (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n)
 
 /-- The quotient-spectrum presentation of the type-`Dₙ` spin carrier. -/
@@ -197,24 +195,16 @@ theorem groupScheme_def :
 /-- The canonical inclusion of the type-`Dₙ` spin carrier into `GL_(2^n)`. -/
 noncomputable def carrierι (hn : 4 ≤ n) :
     groupScheme n hn ⟶ TauCeti.GeneralLinear.groupScheme ℤ (dimension n) :=
-  kostantToralGroupSchemeι
-    (TauCeti.serreRootGenerator (CartanMatrix.D n))
-    (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-      rw [TauCeti.serreKostantForm_def]
-      exact hu) hv)
-    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n)
-
-/-- The carrier inclusion is the one supplied by the generic toral-closure construction. -/
-theorem carrierι_def :
-    carrierι n hn = kostantToralGroupSchemeι
+  eqToHom (by rfl : groupScheme n hn = kostantToralGroupScheme
       (TauCeti.serreRootGenerator (CartanMatrix.D n))
       (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) := by
-  rw [carrierι]
+      (rep_kostantForm_mem_lattice n hn)
+      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n)) ≫
+    kostantToralGroupSchemeι
+      (TauCeti.serreRootGenerator (CartanMatrix.D n))
+      (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
+      (rep_kostantForm_mem_lattice n hn)
+      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n)
 
 /-- The type-`Dₙ` spin carrier is a closed subgroup scheme of its ambient general linear group. -/
 instance isClosedImmersion_carrierι : IsClosedImmersion (carrierι n hn).hom.hom.left := by
@@ -227,21 +217,14 @@ noncomputable def rootSubgroup (hn : 4 ≤ n) (k : Fin n ⊕ Fin n) :
   kostantRootSubgroupToToral
     (TauCeti.serreRootGenerator (CartanMatrix.D n))
     (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-      rw [TauCeti.serreKostantForm_def]
-      exact hu) hv)
-    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) k
-
-/-- A numbered root subgroup is the one supplied by the generic toral-closure construction. -/
-theorem rootSubgroup_def (k : Fin n ⊕ Fin n) :
-    rootSubgroup n hn k = kostantRootSubgroupToToral
+    (rep_kostantForm_mem_lattice n hn)
+    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) k ≫
+  eqToHom (by rfl : kostantToralGroupScheme
       (TauCeti.serreRootGenerator (CartanMatrix.D n))
       (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) k := by
-  rw [rootSubgroup]
+      (rep_kostantForm_mem_lattice n hn)
+      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) =
+        groupScheme n hn)
 
 /-- Including a numbered root subgroup into the ambient general linear group recovers its
 represented Kostant root subgroup. -/
@@ -251,9 +234,7 @@ theorem rootSubgroup_comp_carrierι (k : Fin n ⊕ Fin n) :
       kostantRootSubgroup
         (TauCeti.serreRootGenerator (CartanMatrix.D n))
         (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-        (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-          rw [TauCeti.serreKostantForm_def]
-          exact hu) hv) k
+        (rep_kostantForm_mem_lattice n hn) k
         (isNilpotent_rep_rootGenerator n hn k) (latticeBasis n) := by
   rw [rootSubgroup, carrierι]
   exact kostantRootSubgroupToToral_comp_ι _ _ _ _ _ _ _ _ k
@@ -264,21 +245,14 @@ noncomputable def weightTorus (hn : 4 ≤ n) :
   kostantWeightTorusToToral
     (TauCeti.serreRootGenerator (CartanMatrix.D n))
     (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-      rw [TauCeti.serreKostantForm_def]
-      exact hu) hv)
-    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n)
-
-/-- The weight torus is the one supplied by the generic toral-closure construction. -/
-theorem weightTorus_def :
-    weightTorus n hn = kostantWeightTorusToToral
+    (rep_kostantForm_mem_lattice n hn)
+    (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) ≫
+  eqToHom (by rfl : kostantToralGroupScheme
       (TauCeti.serreRootGenerator (CartanMatrix.D n))
       (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-      (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-        rw [TauCeti.serreKostantForm_def]
-        exact hu) hv)
-      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) := by
-  rw [weightTorus]
+      (rep_kostantForm_mem_lattice n hn)
+      (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) =
+        groupScheme n hn)
 
 /-- Including the weight torus into the ambient general linear group recovers the diagonal torus
 of the spin weights. -/
@@ -314,9 +288,7 @@ noncomputable def points (hn : 4 ≤ n) (A : Type v) [CommRing A] :
   kostantToralPointsSubgroup
     (TauCeti.serreRootGenerator (CartanMatrix.D n))
     (TauCeti.serreH ℚ (CartanMatrix.D n)) (rep n hn) (lattice n).toAddSubgroup
-    (fun _ hu _ hv ↦ rep_serreKostantForm_mem_lattice n hn (by
-      rw [TauCeti.serreKostantForm_def]
-      exact hu) hv)
+    (rep_kostantForm_mem_lattice n hn)
     (isNilpotent_rep_rootGenerator n hn) (latticeBasis n) (basisWeight n) A
 
 /-- The carrier points are exactly the invertible matrices cut out by the defining Hopf ideal. -/
@@ -325,5 +297,16 @@ theorem points_def (A : Type v) [CommRing A] :
       TauCeti.GeneralLinear.hopfIdealPointsSubgroup (dimension n) (definingIdeal n hn) A := by
   rw [points, definingIdeal]
   exact kostantToralPointsSubgroup_def _ _ _ _ _ _ _ _ A
+
+/-- A matrix is a carrier point exactly when its associated convolution point kills the
+defining Hopf ideal. -/
+@[simp]
+theorem mem_points_iff (A : Type v) [CommRing A]
+    (g : _root_.Matrix.GeneralLinearGroup (Fin (dimension n)) A) :
+    g ∈ points n hn A ↔
+      ∀ x ∈ definingIdeal n hn,
+        ((TauCeti.GeneralLinear.pointsMulEquiv (R := ℤ) (dimension n)).symm g).ofConv x = 0 := by
+  rw [points, definingIdeal]
+  exact mem_kostantToralPointsSubgroup_iff _ _ _ _ _ _ _ _ A g
 
 end TauCeti.TypeDSpinCarrier

--- a/TauCeti/RepresentationTheory/Spin/Polarization/SplitEven.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/SplitEven.lean
@@ -1,0 +1,241 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Spin.Polarization.Basic
+public import Mathlib.LinearAlgebra.QuadraticForm.Dual
+public import Mathlib.LinearAlgebra.StdBasis
+
+/-!
+# The standard split even-dimensional polarization
+
+For a commutative ring `K`, the hyperbolic quadratic space on a finite free module `M` is
+`M* × M` with quadratic form `(f, x) ↦ f x`. This file gives the coordinate instance
+`M = Fin n → K` its canonical polarization: the two coordinate axes are the isotropic summands,
+their polar pairing is evaluation, and the orthogonal remainder is zero.
+
+Unlike the existence construction for a nondegenerate quadratic form over a separably closed
+field, this polarization contains no choices. Its named coordinate basis can therefore be fed
+directly into the spin representation and Kostant-lattice constructions.
+
+## Main declarations
+
+* `TauCeti.SplitEvenSpace`: the standard hyperbolic quadratic space `M* × M`.
+* `TauCeti.splitEvenForm`: its quadratic form `(f, x) ↦ f x`.
+* `TauCeti.splitEvenPolarization`: the canonical polarization by the two coordinate axes.
+* `TauCeti.splitEvenBasis`: the coordinate basis of the first isotropic summand.
+
+## References
+
+* C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
+* N. Bourbaki, *Groupes et algèbres de Lie*, Chapters 4--6, Plate IV.
+
+This is the concrete split-polarization input for the full-weight type-`D` spin carrier in
+Layer 9, "The Chevalley--Demazure construction", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+/-- The standard split even-dimensional quadratic space on `Fin n → K`: the product of its
+dual coordinate module and coordinate module. -/
+abbrev SplitEvenSpace (K : Type u) [CommRing K] (n : ℕ) :=
+  Module.Dual K (Fin n → K) × (Fin n → K)
+
+/-- The standard split quadratic form on `M* × M`, given by `(f, x) ↦ f x`. -/
+def splitEvenForm (K : Type u) [CommRing K] (n : ℕ) :
+    QuadraticForm K (SplitEvenSpace K n) :=
+  QuadraticForm.dualProd K (Fin n → K)
+
+/-- Evaluation formula for the standard split quadratic form. -/
+@[simp]
+theorem splitEvenForm_apply (K : Type u) [CommRing K] (n : ℕ)
+    (x : SplitEvenSpace K n) : splitEvenForm K n x = x.1 x.2 := by
+  simp [splitEvenForm]
+
+/-- Polarization formula for the standard split quadratic form. -/
+@[simp]
+theorem polar_splitEvenForm (K : Type u) [CommRing K] (n : ℕ)
+    (x y : SplitEvenSpace K n) :
+    QuadraticMap.polar (splitEvenForm K n) x y = x.1 y.2 + y.1 x.2 := by
+  simp [QuadraticMap.polar]
+  ring
+
+/-- The canonical polarization of the standard split quadratic space.
+
+The coordinate axis is the first isotropic summand, the dual-coordinate axis is the second,
+and the orthogonal remainder is zero. -/
+noncomputable def splitEvenPolarization (K : Type u) [CommRing K] (n : ℕ) :
+    SpinPolarizationData (splitEvenForm K n) := by
+  let W : Submodule K (SplitEvenSpace K n) :=
+    (⊥ : Submodule K (Module.Dual K (Fin n → K))).prod ⊤
+  let W' : Submodule K (SplitEvenSpace K n) :=
+    (⊤ : Submodule K (Module.Dual K (Fin n → K))).prod ⊥
+  let line : Submodule K (SplitEvenSpace K n) := ⊥
+  let eW : W ≃ₗ[K] Fin n → K :=
+    { toFun := fun x ↦ x.1.2
+      invFun := fun x ↦ ⟨(0, x), by simp [W]⟩
+      left_inv := fun x ↦ by
+        apply Subtype.ext
+        rcases x with ⟨⟨f, x⟩, hx⟩
+        simp only [W, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top, and_true] at hx
+        subst f
+        rfl
+      right_inv := fun _ ↦ rfl
+      map_add' := fun _ _ ↦ rfl
+      map_smul' := fun _ _ ↦ rfl }
+  let eW' : W' ≃ₗ[K] Module.Dual K (Fin n → K) :=
+    { toFun := fun x ↦ x.1.1
+      invFun := fun f ↦ ⟨(f, 0), by simp [W']⟩
+      left_inv := fun x ↦ by
+        apply Subtype.ext
+        rcases x with ⟨⟨f, x⟩, hx⟩
+        simp only [W', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot, true_and] at hx
+        subst x
+        rfl
+      right_inv := fun _ ↦ rfl
+      map_add' := fun _ _ ↦ rfl
+      map_smul' := fun _ _ ↦ rfl }
+  let decomp : ((W × W') × line) ≃ₗ[K] SplitEvenSpace K n :=
+    { toFun := fun x ↦ (x.1.1 : SplitEvenSpace K n) + x.1.2 + x.2
+      invFun := fun x ↦
+        ((⟨(0, x.2), by simp [W]⟩, ⟨(x.1, 0), by simp [W']⟩),
+          ⟨0, by simp [line]⟩)
+      left_inv := fun x ↦ by
+        rcases x with ⟨⟨⟨⟨f, a⟩, ha⟩, ⟨⟨g, b⟩, hb⟩⟩, ⟨⟨h, c⟩, hc⟩⟩
+        simp only [W, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top, and_true] at ha
+        simp only [W', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot, true_and] at hb
+        simp only [line, Submodule.mem_bot, Prod.mk_eq_zero] at hc
+        rcases hc with ⟨rfl, rfl⟩
+        subst f
+        subst b
+        apply Prod.ext
+        · apply Prod.ext
+          · apply Subtype.ext
+            simp
+          · apply Subtype.ext
+            simp
+        · apply Subtype.ext
+          apply Prod.ext <;> rfl
+      right_inv := fun x ↦ by
+        ext <;> simp
+      map_add' := fun x y ↦ by
+        ext <;> simp <;> ring
+      map_smul' := fun a x ↦ by
+        ext <;> simp [smul_add] }
+  let pairing : W' ≃ₗ[K] Module.Dual K W :=
+    eW'.trans eW.dualMap
+  refine
+    { W := W
+      W' := W'
+      line := line
+      decompositionEquiv := decomp
+      decompositionEquiv_apply := fun x ↦ rfl
+      isotropic_W := ?_
+      isotropic_W' := ?_
+      pairingEquiv := pairing
+      pairingEquiv_apply := ?_
+      pairing_separatingLeft := ?_
+      lineCoordinate := 0
+      lineCoordinate_injective := ?_
+      lineCoordinate_sq := ?_
+      line_orthogonal_W := ?_
+      line_orthogonal_W' := ?_ }
+  · rintro ⟨⟨f, x⟩, hx⟩
+    simp only [W, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top, and_true] at hx
+    subst f
+    simp
+  · rintro ⟨⟨f, x⟩, hx⟩
+    simp only [W', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot, true_and] at hx
+    subst x
+    simp
+  · rintro ⟨⟨f, x⟩, hx⟩ ⟨⟨g, y⟩, hy⟩
+    simp only [W', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot, true_and] at hx
+    simp only [W, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top, and_true] at hy
+    subst x
+    subst g
+    rw [LinearEquiv.trans_apply, LinearEquiv.dualMap_apply]
+    simp [eW, eW', polar_splitEvenForm]
+  · intro x hx
+    rcases x with ⟨⟨g, a⟩, hg⟩
+    simp only [W, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top, and_true] at hg
+    subst g
+    apply eW.injective
+    apply (Module.forall_dual_apply_eq_zero_iff K (eW ⟨(0, a), by simp [W]⟩)).1
+    intro f
+    let y : W' := eW'.symm f
+    have hy := hx y
+    simpa [eW, eW', y, polar_splitEvenForm] using hy
+  · intro x y _
+    exact Subsingleton.elim x y
+  · intro z
+    have hz : z = 0 := Subsingleton.elim z 0
+    subst z
+    simp
+  · intro z x
+    have hz : z = 0 := Subsingleton.elim z 0
+    subst z
+    simp
+  · intro z y
+    have hz : z = 0 := Subsingleton.elim z 0
+    subst z
+    simp
+
+/-- The first isotropic summand of the standard split polarization is the coordinate axis. -/
+@[simp]
+theorem splitEvenPolarization_W (K : Type u) [CommRing K] (n : ℕ) :
+    (splitEvenPolarization K n).W =
+      (⊥ : Submodule K (Module.Dual K (Fin n → K))).prod ⊤ := by
+  rw [splitEvenPolarization]
+
+/-- The second isotropic summand of the standard split polarization is the dual-coordinate
+axis. -/
+@[simp]
+theorem splitEvenPolarization_W' (K : Type u) [CommRing K] (n : ℕ) :
+    (splitEvenPolarization K n).W' =
+      (⊤ : Submodule K (Module.Dual K (Fin n → K))).prod ⊥ := by
+  rw [splitEvenPolarization]
+
+/-- The standard split even-dimensional polarization has no orthogonal remainder. -/
+@[simp]
+theorem splitEvenPolarization_line (K : Type u) [CommRing K] (n : ℕ) :
+    (splitEvenPolarization K n).line = ⊥ := by
+  rw [splitEvenPolarization]
+
+/-- The coordinate equivalence from the first isotropic summand of the standard split
+polarization to `Fin n → K`. -/
+noncomputable def splitEvenWEquiv (K : Type u) [CommRing K] (n : ℕ) :
+    (splitEvenPolarization K n).W ≃ₗ[K] Fin n → K :=
+  { toFun := fun x ↦ x.1.2
+    invFun := fun x ↦ ⟨(0, x), by simp⟩
+    left_inv := fun x ↦ by
+      apply Subtype.ext
+      rcases x with ⟨⟨f, x⟩, hx⟩
+      simp only [splitEvenPolarization_W, Submodule.mem_prod, Submodule.mem_bot,
+        Submodule.mem_top, and_true] at hx
+      subst f
+      rfl
+    right_inv := fun _ ↦ rfl
+    map_add' := fun _ _ ↦ rfl
+    map_smul' := fun _ _ ↦ rfl }
+
+/-- The coordinate basis of the first isotropic summand in the standard split polarization. -/
+noncomputable def splitEvenBasis (K : Type u) [CommRing K] (n : ℕ) :
+    Module.Basis (Fin n) K (splitEvenPolarization K n).W :=
+  (Pi.basisFun K (Fin n)).map (splitEvenWEquiv K n).symm
+
+/-- A coordinate-basis vector of the first isotropic summand is the corresponding standard
+coordinate vector on the second axis of the split space. -/
+@[simp]
+theorem coe_splitEvenBasis (K : Type u) [CommRing K] (n : ℕ) (i : Fin n) :
+    ((splitEvenBasis K n i : (splitEvenPolarization K n).W) : SplitEvenSpace K n) =
+      (0, Pi.single i 1) := by
+  simp [splitEvenBasis, splitEvenWEquiv]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Spin/Polarization/SplitEven.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/SplitEven.lean
@@ -67,111 +67,152 @@ theorem polar_splitEvenForm (K : Type u) [CommRing K] (n : ℕ)
   simp [QuadraticMap.polar]
   ring
 
+/-- The coordinate axis in the standard split even-dimensional space. -/
+private abbrev splitEvenW (K : Type u) [CommRing K] (n : ℕ) :
+    Submodule K (SplitEvenSpace K n) :=
+  (⊥ : Submodule K (Module.Dual K (Fin n → K))).prod ⊤
+
+/-- The dual-coordinate axis in the standard split even-dimensional space. -/
+private abbrev splitEvenW' (K : Type u) [CommRing K] (n : ℕ) :
+    Submodule K (SplitEvenSpace K n) :=
+  (⊤ : Submodule K (Module.Dual K (Fin n → K))).prod ⊥
+
+/-- The zero orthogonal remainder in the standard split even-dimensional space. -/
+private abbrev splitEvenLine (K : Type u) [CommRing K] (n : ℕ) :
+    Submodule K (SplitEvenSpace K n) := ⊥
+
+/-- The first coordinate-axis equivalence used by the standard split polarization. -/
+private noncomputable def splitEvenWEquiv (K : Type u) [CommRing K] (n : ℕ) :
+    splitEvenW K n ≃ₗ[K] Fin n → K :=
+  { toFun := fun x ↦ x.1.2
+    invFun := fun x ↦ ⟨(0, x), by simp [splitEvenW]⟩
+    left_inv := fun x ↦ by
+      apply Subtype.ext
+      rcases x with ⟨⟨f, x⟩, hx⟩
+      simp only [splitEvenW, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top,
+        and_true] at hx
+      subst f
+      rfl
+    right_inv := fun _ ↦ rfl
+    map_add' := fun _ _ ↦ rfl
+    map_smul' := fun _ _ ↦ rfl }
+
+/-- The second coordinate-axis equivalence used by the standard split polarization. -/
+private noncomputable def splitEvenW'Equiv (K : Type u) [CommRing K] (n : ℕ) :
+    splitEvenW' K n ≃ₗ[K] Module.Dual K (Fin n → K) :=
+  { toFun := fun x ↦ x.1.1
+    invFun := fun f ↦ ⟨(f, 0), by simp [splitEvenW']⟩
+    left_inv := fun x ↦ by
+      apply Subtype.ext
+      rcases x with ⟨⟨f, x⟩, hx⟩
+      simp only [splitEvenW', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot,
+        true_and] at hx
+      subst x
+      rfl
+    right_inv := fun _ ↦ rfl
+    map_add' := fun _ _ ↦ rfl
+    map_smul' := fun _ _ ↦ rfl }
+
+/-- The coordinate decomposition equivalence used by the standard split polarization. -/
+private noncomputable def splitEvenDecompositionEquiv
+    (K : Type u) [CommRing K] (n : ℕ) :
+    ((splitEvenW K n × splitEvenW' K n) × splitEvenLine K n) ≃ₗ[K] SplitEvenSpace K n :=
+  { toFun := fun x ↦ (x.1.1 : SplitEvenSpace K n) + x.1.2 + x.2
+    invFun := fun x ↦
+      ((⟨(0, x.2), by simp [splitEvenW]⟩, ⟨(x.1, 0), by simp [splitEvenW']⟩),
+        ⟨0, by simp [splitEvenLine]⟩)
+    left_inv := fun x ↦ by
+      rcases x with ⟨⟨⟨⟨f, a⟩, ha⟩, ⟨⟨g, b⟩, hb⟩⟩, ⟨⟨h, c⟩, hc⟩⟩
+      simp only [splitEvenW, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top,
+        and_true] at ha
+      simp only [splitEvenW', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot,
+        true_and] at hb
+      simp only [splitEvenLine, Submodule.mem_bot, Prod.mk_eq_zero] at hc
+      rcases hc with ⟨rfl, rfl⟩
+      subst f
+      subst b
+      apply Prod.ext
+      · apply Prod.ext
+        · apply Subtype.ext
+          simp
+        · apply Subtype.ext
+          simp
+      · apply Subtype.ext
+        apply Prod.ext <;> rfl
+    right_inv := fun x ↦ by
+      ext <;> simp
+    map_add' := fun x y ↦ by
+      ext <;> simp <;> ring
+    map_smul' := fun a x ↦ by
+      ext <;> simp [smul_add] }
+
+/-- The polar pairing equivalence between the two coordinate axes. -/
+private noncomputable def splitEvenPairingEquiv (K : Type u) [CommRing K] (n : ℕ) :
+    splitEvenW' K n ≃ₗ[K] Module.Dual K (splitEvenW K n) :=
+  (splitEvenW'Equiv K n).trans (splitEvenWEquiv K n).dualMap
+
+private theorem splitEvenPairingEquiv_apply (K : Type u) [CommRing K] (n : ℕ)
+    (y : splitEvenW' K n) (x : splitEvenW K n) :
+    splitEvenPairingEquiv K n y x = QuadraticMap.polar (splitEvenForm K n) x y := by
+  rcases x with ⟨⟨f, x⟩, hx⟩
+  rcases y with ⟨⟨g, y⟩, hy⟩
+  simp only [splitEvenW, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top,
+    and_true] at hx
+  simp only [splitEvenW', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot,
+    true_and] at hy
+  subst f
+  subst y
+  rw [splitEvenPairingEquiv, LinearEquiv.trans_apply, LinearEquiv.dualMap_apply]
+  simp [splitEvenWEquiv, splitEvenW'Equiv, polar_splitEvenForm]
+
+private theorem splitEvenPairing_separatingLeft (K : Type u) [CommRing K] (n : ℕ)
+    (x : splitEvenW K n)
+    (hx : ∀ y : splitEvenW' K n, QuadraticMap.polar (splitEvenForm K n) x y = 0) :
+    x = 0 := by
+  rcases x with ⟨⟨g, a⟩, hg⟩
+  simp only [splitEvenW, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top,
+    and_true] at hg
+  subst g
+  apply (splitEvenWEquiv K n).injective
+  apply (Module.forall_dual_apply_eq_zero_iff K
+    (splitEvenWEquiv K n ⟨(0, a), by simp [splitEvenW]⟩)).1
+  intro f
+  let y : splitEvenW' K n := (splitEvenW'Equiv K n).symm f
+  have hy := hx y
+  simpa [splitEvenWEquiv, splitEvenW'Equiv, y, polar_splitEvenForm] using hy
+
 /-- The canonical polarization of the standard split quadratic space.
 
 The coordinate axis is the first isotropic summand, the dual-coordinate axis is the second,
 and the orthogonal remainder is zero. -/
 noncomputable def splitEvenPolarization (K : Type u) [CommRing K] (n : ℕ) :
     SpinPolarizationData (splitEvenForm K n) := by
-  let W : Submodule K (SplitEvenSpace K n) :=
-    (⊥ : Submodule K (Module.Dual K (Fin n → K))).prod ⊤
-  let W' : Submodule K (SplitEvenSpace K n) :=
-    (⊤ : Submodule K (Module.Dual K (Fin n → K))).prod ⊥
-  let line : Submodule K (SplitEvenSpace K n) := ⊥
-  let eW : W ≃ₗ[K] Fin n → K :=
-    { toFun := fun x ↦ x.1.2
-      invFun := fun x ↦ ⟨(0, x), by simp [W]⟩
-      left_inv := fun x ↦ by
-        apply Subtype.ext
-        rcases x with ⟨⟨f, x⟩, hx⟩
-        simp only [W, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top, and_true] at hx
-        subst f
-        rfl
-      right_inv := fun _ ↦ rfl
-      map_add' := fun _ _ ↦ rfl
-      map_smul' := fun _ _ ↦ rfl }
-  let eW' : W' ≃ₗ[K] Module.Dual K (Fin n → K) :=
-    { toFun := fun x ↦ x.1.1
-      invFun := fun f ↦ ⟨(f, 0), by simp [W']⟩
-      left_inv := fun x ↦ by
-        apply Subtype.ext
-        rcases x with ⟨⟨f, x⟩, hx⟩
-        simp only [W', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot, true_and] at hx
-        subst x
-        rfl
-      right_inv := fun _ ↦ rfl
-      map_add' := fun _ _ ↦ rfl
-      map_smul' := fun _ _ ↦ rfl }
-  let decomp : ((W × W') × line) ≃ₗ[K] SplitEvenSpace K n :=
-    { toFun := fun x ↦ (x.1.1 : SplitEvenSpace K n) + x.1.2 + x.2
-      invFun := fun x ↦
-        ((⟨(0, x.2), by simp [W]⟩, ⟨(x.1, 0), by simp [W']⟩),
-          ⟨0, by simp [line]⟩)
-      left_inv := fun x ↦ by
-        rcases x with ⟨⟨⟨⟨f, a⟩, ha⟩, ⟨⟨g, b⟩, hb⟩⟩, ⟨⟨h, c⟩, hc⟩⟩
-        simp only [W, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top, and_true] at ha
-        simp only [W', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot, true_and] at hb
-        simp only [line, Submodule.mem_bot, Prod.mk_eq_zero] at hc
-        rcases hc with ⟨rfl, rfl⟩
-        subst f
-        subst b
-        apply Prod.ext
-        · apply Prod.ext
-          · apply Subtype.ext
-            simp
-          · apply Subtype.ext
-            simp
-        · apply Subtype.ext
-          apply Prod.ext <;> rfl
-      right_inv := fun x ↦ by
-        ext <;> simp
-      map_add' := fun x y ↦ by
-        ext <;> simp <;> ring
-      map_smul' := fun a x ↦ by
-        ext <;> simp [smul_add] }
-  let pairing : W' ≃ₗ[K] Module.Dual K W :=
-    eW'.trans eW.dualMap
   refine
-    { W := W
-      W' := W'
-      line := line
-      decompositionEquiv := decomp
+    { W := splitEvenW K n
+      W' := splitEvenW' K n
+      line := splitEvenLine K n
+      decompositionEquiv := splitEvenDecompositionEquiv K n
       decompositionEquiv_apply := fun x ↦ rfl
       isotropic_W := ?_
       isotropic_W' := ?_
-      pairingEquiv := pairing
-      pairingEquiv_apply := ?_
-      pairing_separatingLeft := ?_
+      pairingEquiv := splitEvenPairingEquiv K n
+      pairingEquiv_apply := splitEvenPairingEquiv_apply K n
+      pairing_separatingLeft := splitEvenPairing_separatingLeft K n
       lineCoordinate := 0
       lineCoordinate_injective := ?_
       lineCoordinate_sq := ?_
       line_orthogonal_W := ?_
       line_orthogonal_W' := ?_ }
   · rintro ⟨⟨f, x⟩, hx⟩
-    simp only [W, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top, and_true] at hx
+    simp only [splitEvenW, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top,
+      and_true] at hx
     subst f
     simp
   · rintro ⟨⟨f, x⟩, hx⟩
-    simp only [W', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot, true_and] at hx
+    simp only [splitEvenW', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot,
+      true_and] at hx
     subst x
     simp
-  · rintro ⟨⟨f, x⟩, hx⟩ ⟨⟨g, y⟩, hy⟩
-    simp only [W', Submodule.mem_prod, Submodule.mem_top, Submodule.mem_bot, true_and] at hx
-    simp only [W, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top, and_true] at hy
-    subst x
-    subst g
-    rw [LinearEquiv.trans_apply, LinearEquiv.dualMap_apply]
-    simp [eW, eW', polar_splitEvenForm]
-  · intro x hx
-    rcases x with ⟨⟨g, a⟩, hg⟩
-    simp only [W, Submodule.mem_prod, Submodule.mem_bot, Submodule.mem_top, and_true] at hg
-    subst g
-    apply eW.injective
-    apply (Module.forall_dual_apply_eq_zero_iff K (eW ⟨(0, a), by simp [W]⟩)).1
-    intro f
-    let y : W' := eW'.symm f
-    have hy := hx y
-    simpa [eW, eW', y, polar_splitEvenForm] using hy
   · intro x y _
     exact Subsingleton.elim x y
   · intro z
@@ -208,27 +249,12 @@ theorem splitEvenPolarization_line (K : Type u) [CommRing K] (n : ℕ) :
     (splitEvenPolarization K n).line = ⊥ := by
   rw [splitEvenPolarization]
 
-/-- The coordinate equivalence from the first isotropic summand of the standard split
-polarization to `Fin n → K`. -/
-noncomputable def splitEvenWEquiv (K : Type u) [CommRing K] (n : ℕ) :
-    (splitEvenPolarization K n).W ≃ₗ[K] Fin n → K :=
-  { toFun := fun x ↦ x.1.2
-    invFun := fun x ↦ ⟨(0, x), by simp⟩
-    left_inv := fun x ↦ by
-      apply Subtype.ext
-      rcases x with ⟨⟨f, x⟩, hx⟩
-      simp only [splitEvenPolarization_W, Submodule.mem_prod, Submodule.mem_bot,
-        Submodule.mem_top, and_true] at hx
-      subst f
-      rfl
-    right_inv := fun _ ↦ rfl
-    map_add' := fun _ _ ↦ rfl
-    map_smul' := fun _ _ ↦ rfl }
-
 /-- The coordinate basis of the first isotropic summand in the standard split polarization. -/
 noncomputable def splitEvenBasis (K : Type u) [CommRing K] (n : ℕ) :
     Module.Basis (Fin n) K (splitEvenPolarization K n).W :=
-  (Pi.basisFun K (Fin n)).map (splitEvenWEquiv K n).symm
+  (Pi.basisFun K (Fin n)).map <|
+    (splitEvenWEquiv K n).symm.trans
+      (LinearEquiv.ofEq _ _ (splitEvenPolarization_W K n).symm)
 
 /-- A coordinate-basis vector of the first isotropic summand is the corresponding standard
 coordinate vector on the second axis of the split space. -/
@@ -236,6 +262,7 @@ coordinate vector on the second axis of the split space. -/
 theorem coe_splitEvenBasis (K : Type u) [CommRing K] (n : ℕ) (i : Fin n) :
     ((splitEvenBasis K n i : (splitEvenPolarization K n).W) : SplitEvenSpace K n) =
       (0, Pi.single i 1) := by
-  simp [splitEvenBasis, splitEvenWEquiv]
+  rw [splitEvenBasis, Module.Basis.map_apply]
+  simp [splitEvenWEquiv]
 
 end TauCeti


### PR DESCRIPTION
This PR constructs the full-weight type-`Dₙ` spin carrier from explicit split data: define the canonical hyperbolic polarization on `M* × M` for `M = Fin n → K`, expose its coordinate basis, specialize the landed type-`D` spin representation and Kostant-stable exterior lattice to it, and feed those data into the generic Kostant toral-closure construction. The resulting affine group scheme over `ℤ` is a closed subgroup of `GL_(2^n)` with named positive and negative simple-root subgroup morphisms, a closed rank-`n` split weight torus, a hom-ext principle, and its matrix-valued point subgroup.

This advances the exact Layer 9 target “The Chevalley–Demazure construction” in `TauCetiRoadmap/ReductiveGroups/README.md`, specifically the milestone to construct an explicit split reductive group scheme over `ℤ` from a Chevalley basis and the Kostant `ℤ`-form. The merged type-`D` root/Serre system and full spin Kostant lattice are already on `main`; this PR performs the concrete split-polarization specialization and toral carrier step that the lattice PR names next.

The dependency edge is: CFSGStatement milestone L0, “explicit pinned Chevalley–Demazure groups,” requires a traceable simply connected type-`D` ambient carrier for the `Dₙ(q)` and `²Dₙ(q)` families; ReductiveGroups Layer 9 supplies that carrier; the construction here supplies its explicit underlying group scheme and full-weight torus. Using the whole exterior module is essential because `DynkinType.span_range_typeDSpinWeight_eq_top` shows that both half-spin parity families together span the simply connected character lattice.

After this PR, the type-`D` Layer 9 milestone still needs the simple-root character/pinning equations, base change and Frobenius interfaces, the lifted diagram automorphism, and proofs that the carrier is smooth and reductive with the intended root datum.

Add `TauCeti/RepresentationTheory/Spin/Polarization/SplitEven.lean` (241 lines) and `TauCeti/Algebra/Lie/Orthogonal/TypeD/SpinCarrier.lean` (329 lines). The implementation reuses Mathlib’s `QuadraticForm.dualProd` and finite-basis API together with Tau Ceti’s generic Kostant toral-closure construction, type-`D` Serre representation, exterior integral lattice, and spin-weight spanning theorem; no Mathlib implementation or external formalization is vendored. The mathematical conventions follow Chevalley, Bourbaki, Humphreys, and Jantzen as cited in both module docstrings.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-d-split-spin-carrier"}-->

🤖 Prepared with Codex
