### PR TITLE
feat: the split polarization of a hyperbolic quadratic space

### DIFF
--- a/TauCeti/RepresentationTheory/Spin/Polarization/Hyperbolic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Hyperbolic.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Dual.Lemmas
+public import Mathlib.LinearAlgebra.QuadraticForm.Dual
+public import TauCeti.RepresentationTheory.Spin.Polarization.Basic
+
+/-!
+# The split polarization of a hyperbolic quadratic space
+
+`TauCeti.SpinPolarizationData.ofNondegenerate` produces polarization data for any
+finite-dimensional nondegenerate quadratic space over a separably closed field, but it does so by
+normalizing an arbitrary form, so its two isotropic summands are not given by a formula. A consumer
+that has to exhibit its carrier -- as the Chevalley--Demazure construction of Layer 9 of
+`TauCetiRoadmap/ReductiveGroups/README.md` does -- needs the split case written down instead.
+
+This file writes it down. For a module `M` over a commutative ring `K`, Mathlib's
+`QuadraticForm.dualProd K M` is the hyperbolic form `Q (f, m) = f m` on `Module.Dual K M × M`, and
+its two coordinate summands `Submodule.snd` and `Submodule.fst` are isotropic and dually paired by
+construction:
+
+```text
+polar Q (f, m) (g, x) = f x + g m.
+```
+
+`TauCeti.SpinPolarizationData.hyperbolic` packages them as a `TauCeti.SpinPolarizationData`, with
+the copy of `M` as the exterior summand `W`, the copy of its dual as the contraction summand `W'`,
+and no orthogonal remainder, so the spinor module attached to it is the full exterior algebra of
+`M`. The only hypothesis is that the functionals on `M` separate its points, which is what
+identifies `W'` with the dual of `W`; by `Module.forall_dual_apply_eq_zero_iff` that holds for
+every projective module, in particular over a field.
+
+Nothing here constructs a Clifford action, a Lie algebra or a group: this file supplies the
+decomposition data those constructions take as input, and it asserts nothing about the quadratic
+space beyond the fields of the structure and the nondegeneracy they imply.
+
+## Main definitions
+
+* `TauCeti.SpinPolarizationData.hyperbolicDecomposition`: the direct-sum coordinates of the
+  hyperbolic quadratic space, from Mathlib's `Submodule.prodEquivOfIsCompl`.
+* `TauCeti.SpinPolarizationData.hyperbolic`: the polarization data of `QuadraticForm.dualProd`.
+* `TauCeti.SpinPolarizationData.hyperbolicBasis`: the basis of the exterior summand transported
+  from a basis of `M`.
+
+## Main results
+
+* `TauCeti.polar_dualProd`: the polar form of the hyperbolic form.
+* `TauCeti.isCompl_snd_fst`: the two coordinate summands of a product module are complementary.
+* `TauCeti.SpinPolarizationData.hyperbolic_W`, `hyperbolic_W'` and `hyperbolic_line`: the summands
+  of the constructed data.
+* `TauCeti.SpinPolarizationData.nondegenerate_dualProd`: the hyperbolic form is nondegenerate, the
+  vanishing remainder removing every hypothesis on `2`.
+
+## References
+
+* C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II, for the exterior model attached to
+  a split decomposition.
+* N. Bourbaki, *Algèbre*, Chapter 9, §4, for hyperbolic quadratic spaces.
+
+## Roadmap
+
+Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`, "The Chevalley--Demazure construction",
+requires an explicitly constructed carrier rather than an existence theorem, and the type-`Bₗ` and
+type-`Dₗ` carriers are built on the spinor module of a split quadratic space. This file supplies
+the split decomposition those carriers are built from; the consumer of the type-`D` instance is
+milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md`, whose `Dₙ(q)` and `²Dₙ(q)` branches need
+a traceable pinned simply connected type-`D` carrier.
+-/
+
+public section
+
+open QuadraticMap
+
+namespace TauCeti
+
+universe u v w
+
+variable {K : Type u} [CommRing K] {M : Type v} [AddCommGroup M] [Module K M]
+
+/-! ## The polar form of the hyperbolic form -/
+
+/-- **The polar form of the hyperbolic quadratic form** `Q (f, m) = f m` pairs each coordinate
+summand with the other and neither with itself. -/
+theorem polar_dualProd (p q : Module.Dual K M × M) :
+    polar (QuadraticForm.dualProd K M) p q = p.1 q.2 + q.1 p.2 := by
+  simp only [polar, QuadraticForm.dualProd_apply, Prod.fst_add, Prod.snd_add,
+    LinearMap.add_apply, map_add]
+  ring
+
+/-- **The two coordinate summands of a product module are complementary**, in the order the
+polarization below uses them: the copy of the second factor and then the copy of the first. -/
+theorem isCompl_snd_fst (R : Type u) [Semiring R] (M₁ : Type v) (M₂ : Type w) [AddCommMonoid M₁]
+    [AddCommMonoid M₂] [Module R M₁] [Module R M₂] :
+    IsCompl (Submodule.snd R M₁ M₂) (Submodule.fst R M₁ M₂) :=
+  (⟨disjoint_iff.mpr (Submodule.fst_inf_snd R M₁ M₂),
+    codisjoint_iff.mpr (Submodule.fst_sup_snd R M₁ M₂)⟩ : IsCompl _ _).symm
+
+namespace SpinPolarizationData
+
+/-- The exterior summand of the hyperbolic quadratic space is cut out by the vanishing of the
+first coordinate. -/
+private theorem mem_snd_iff {p : Module.Dual K M × M} :
+    p ∈ Submodule.snd K (Module.Dual K M) M ↔ p.1 = 0 :=
+  Submodule.mem_comap.trans (Submodule.mem_bot K)
+
+/-- The contraction summand of the hyperbolic quadratic space is cut out by the vanishing of the
+second coordinate. -/
+private theorem mem_fst_iff {p : Module.Dual K M × M} :
+    p ∈ Submodule.fst K (Module.Dual K M) M ↔ p.2 = 0 :=
+  Submodule.mem_comap.trans (Submodule.mem_bot K)
+
+/-! ## The polarization data -/
+
+variable (K M)
+
+/-- **The direct-sum coordinates of the hyperbolic quadratic space**: its two coordinate summands
+`Submodule.snd` and `Submodule.fst`, which are complementary, together with a trivial orthogonal
+remainder. -/
+@[expose]
+noncomputable def hyperbolicDecomposition :
+    ((Submodule.snd K (Module.Dual K M) M × Submodule.fst K (Module.Dual K M) M) ×
+        (⊥ : Submodule K (Module.Dual K M × M))) ≃ₗ[K] Module.Dual K M × M :=
+  LinearEquiv.prodUnique ≪≫ₗ
+    Submodule.prodEquivOfIsCompl _ _ (isCompl_snd_fst K (Module.Dual K M) M)
+
+variable {K M}
+
+theorem hyperbolicDecomposition_apply
+    (x : (Submodule.snd K (Module.Dual K M) M × Submodule.fst K (Module.Dual K M) M) ×
+      (⊥ : Submodule K (Module.Dual K M × M))) :
+    hyperbolicDecomposition K M x =
+      (x.1.1 : Module.Dual K M × M) + (x.1.2 : Module.Dual K M × M) := rfl
+
+/-- **The split polarization of a hyperbolic quadratic space.** For a module `M` over a commutative
+ring `K` whose functionals separate points, the hyperbolic form `Q (f, m) = f m` on
+`Module.Dual K M × M` is polarized by its two coordinate summands, with no orthogonal remainder.
+
+The exterior summand `W` is the copy of `M` and the contraction summand `W'` is the copy of its
+dual, so the spinor module attached to this datum is the full exterior algebra of `M`. -/
+@[expose]
+noncomputable def hyperbolic (hM : ∀ m : M, (∀ f : Module.Dual K M, f m = 0) → m = 0) :
+    SpinPolarizationData (QuadraticForm.dualProd K M) where
+  W := Submodule.snd K (Module.Dual K M) M
+  W' := Submodule.fst K (Module.Dual K M) M
+  line := ⊥
+  decompositionEquiv := hyperbolicDecomposition K M
+  decompositionEquiv_apply x := by
+    rw [hyperbolicDecomposition_apply, (Submodule.mem_bot K).mp x.2.2, add_zero]
+  isotropic_W x := by
+    rw [QuadraticForm.dualProd_apply, mem_snd_iff.mp x.2, LinearMap.zero_apply]
+  isotropic_W' y := by
+    rw [QuadraticForm.dualProd_apply, mem_fst_iff.mp y.2, map_zero]
+  pairingEquiv :=
+    (Submodule.fstEquiv K (Module.Dual K M) M) ≪≫ₗ
+      (Submodule.sndEquiv K (Module.Dual K M) M).dualMap
+  pairingEquiv_apply y x := by
+    rw [polar_dualProd, mem_snd_iff.mp x.2, LinearMap.zero_apply, zero_add,
+      LinearEquiv.trans_apply, LinearEquiv.dualMap_apply, Submodule.fstEquiv_apply,
+      Submodule.sndEquiv_apply]
+  pairing_separatingLeft x hx := by
+    refine Subtype.ext (Prod.ext (mem_snd_iff.mp x.2) (hM _ fun f => ?_))
+    have := hx ⟨(f, 0), mem_fst_iff.mpr rfl⟩
+    rwa [polar_dualProd, mem_snd_iff.mp x.2, LinearMap.zero_apply, zero_add] at this
+  lineCoordinate := 0
+  lineCoordinate_injective a b _ := by
+    refine Subtype.ext ?_
+    rw [(Submodule.mem_bot K).mp a.2, (Submodule.mem_bot K).mp b.2]
+  lineCoordinate_sq z := by
+    rw [LinearMap.zero_apply, mul_zero, (Submodule.mem_bot K).mp z.2, map_zero]
+  line_orthogonal_W z x := by
+    rw [(Submodule.mem_bot K).mp z.2, polar_zero_left]
+  line_orthogonal_W' z y := by
+    rw [(Submodule.mem_bot K).mp z.2, polar_zero_left]
+
+variable (hM : ∀ m : M, (∀ f : Module.Dual K M, f m = 0) → m = 0)
+
+@[simp]
+theorem hyperbolic_W : (hyperbolic hM).W = Submodule.snd K (Module.Dual K M) M := rfl
+
+@[simp]
+theorem hyperbolic_W' : (hyperbolic hM).W' = Submodule.fst K (Module.Dual K M) M := rfl
+
+@[simp]
+theorem hyperbolic_line : (hyperbolic hM).line = ⊥ := rfl
+
+/-- **The hyperbolic form is nondegenerate.** It has no orthogonal remainder, so this needs no
+regularity hypothesis on `2`, by
+`TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot`. -/
+theorem nondegenerate_dualProd (hM : ∀ m : M, (∀ f : Module.Dual K M, f m = 0) → m = 0) :
+    (QuadraticForm.dualProd K M).Nondegenerate :=
+  (hyperbolic hM).nondegenerate_of_line_eq_bot rfl
+
+/-! ## The basis of the exterior summand -/
+
+/-- A basis of `M` is a basis of the exterior summand of the hyperbolic polarization, which by
+`TauCeti.SpinPolarizationData.hyperbolic_W` is the copy of `M` in `Module.Dual K M × M`. This is
+the basis the exterior model of the spin representation is coordinatized by. -/
+@[expose]
+noncomputable def hyperbolicBasis {ι : Type w} (b : Module.Basis ι K M) :
+    Module.Basis ι K (Submodule.snd K (Module.Dual K M) M) :=
+  b.map (Submodule.sndEquiv K (Module.Dual K M) M).symm
+
+@[simp]
+theorem coe_hyperbolicBasis_apply {ι : Type w} (b : Module.Basis ι K M) (i : ι) :
+    ((hyperbolicBasis b i : Submodule.snd K (Module.Dual K M) M) : Module.Dual K M × M) =
+      (0, b i) := by
+  rw [hyperbolicBasis, Module.Basis.map_apply]
+  rfl
+
+end SpinPolarizationData
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Hyperbolic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Hyperbolic.lean
@@ -85,6 +85,7 @@ variable {K : Type u} [CommRing K] {M : Type v} [AddCommGroup M] [Module K M]
 
 /-- **The polar form of the hyperbolic quadratic form** `Q (f, m) = f m` pairs each coordinate
 summand with the other and neither with itself. -/
+@[simp]
 theorem polar_dualProd (p q : Module.Dual K M × M) :
     polar (QuadraticForm.dualProd K M) p q = p.1 q.2 + q.1 p.2 := by
   simp only [polar, QuadraticForm.dualProd_apply, Prod.fst_add, Prod.snd_add,
@@ -120,7 +121,6 @@ variable (K M)
 /-- **The direct-sum coordinates of the hyperbolic quadratic space**: its two coordinate summands
 `Submodule.snd` and `Submodule.fst`, which are complementary, together with a trivial orthogonal
 remainder. -/
-@[expose]
 noncomputable def hyperbolicDecomposition :
     ((Submodule.snd K (Module.Dual K M) M × Submodule.fst K (Module.Dual K M) M) ×
         (⊥ : Submodule K (Module.Dual K M × M))) ≃ₗ[K] Module.Dual K M × M :=
@@ -129,11 +129,14 @@ noncomputable def hyperbolicDecomposition :
 
 variable {K M}
 
+@[simp]
 theorem hyperbolicDecomposition_apply
     (x : (Submodule.snd K (Module.Dual K M) M × Submodule.fst K (Module.Dual K M) M) ×
       (⊥ : Submodule K (Module.Dual K M × M))) :
     hyperbolicDecomposition K M x =
-      (x.1.1 : Module.Dual K M × M) + (x.1.2 : Module.Dual K M × M) := rfl
+      (x.1.1 : Module.Dual K M × M) + (x.1.2 : Module.Dual K M × M) :=
+  -- `(rfl)`, not `rfl`: the body of `hyperbolicDecomposition` is not `@[expose]`d.
+  (rfl)
 
 /-- **The split polarization of a hyperbolic quadratic space.** For a module `M` over a commutative
 ring `K` whose functionals separate points, the hyperbolic form `Q (f, m) = f m` on
@@ -141,7 +144,6 @@ ring `K` whose functionals separate points, the hyperbolic form `Q (f, m) = f m`
 
 The exterior summand `W` is the copy of `M` and the contraction summand `W'` is the copy of its
 dual, so the spinor module attached to this datum is the full exterior algebra of `M`. -/
-@[expose]
 noncomputable def hyperbolic (hM : ∀ m : M, (∀ f : Module.Dual K M, f m = 0) → m = 0) :
     SpinPolarizationData (QuadraticForm.dualProd K M) where
   W := Submodule.snd K (Module.Dual K M) M
@@ -179,13 +181,15 @@ noncomputable def hyperbolic (hM : ∀ m : M, (∀ f : Module.Dual K M, f m = 0)
 variable (hM : ∀ m : M, (∀ f : Module.Dual K M, f m = 0) → m = 0)
 
 @[simp]
-theorem hyperbolic_W : (hyperbolic hM).W = Submodule.snd K (Module.Dual K M) M := rfl
+theorem hyperbolic_W : (hyperbolic hM).W = Submodule.snd K (Module.Dual K M) M :=
+  -- `(rfl)`, not `rfl`: the body of `hyperbolic` is not `@[expose]`d.
+  (rfl)
 
 @[simp]
-theorem hyperbolic_W' : (hyperbolic hM).W' = Submodule.fst K (Module.Dual K M) M := rfl
+theorem hyperbolic_W' : (hyperbolic hM).W' = Submodule.fst K (Module.Dual K M) M := (rfl)
 
 @[simp]
-theorem hyperbolic_line : (hyperbolic hM).line = ⊥ := rfl
+theorem hyperbolic_line : (hyperbolic hM).line = ⊥ := (rfl)
 
 /-- **The hyperbolic form is nondegenerate.** It has no orthogonal remainder, so this needs no
 regularity hypothesis on `2`, by
@@ -199,7 +203,6 @@ theorem nondegenerate_dualProd (hM : ∀ m : M, (∀ f : Module.Dual K M, f m = 
 /-- A basis of `M` is a basis of the exterior summand of the hyperbolic polarization, which by
 `TauCeti.SpinPolarizationData.hyperbolic_W` is the copy of `M` in `Module.Dual K M × M`. This is
 the basis the exterior model of the spin representation is coordinatized by. -/
-@[expose]
 noncomputable def hyperbolicBasis {ι : Type w} (b : Module.Basis ι K M) :
     Module.Basis ι K (Submodule.snd K (Module.Dual K M) M) :=
   b.map (Submodule.sndEquiv K (Module.Dual K M) M).symm

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/Split.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/Split.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Spin.Polarization.Hyperbolic
+public import TauCeti.RepresentationTheory.Spin.Polarization.TypeD.KostantLattice
+
+/-!
+# The split type-`Dₙ` spinor module and its Kostant-stable lattice
+
+`TauCeti.SpinPolarizationData.typeDSpinRep` turns any polarized quadratic space into a
+representation of the type-`D` Serre presentation on the exterior algebra of the exterior summand,
+and `typeDSpinRep_serreKostantForm_apply_mem_integralLattice` proves that the coordinate lattice of
+that exterior algebra is stable under the Serre Kostant form. Both are stated for an arbitrary
+`TauCeti.SpinPolarizationData` and an arbitrary basis of its exterior summand, so neither names a
+carrier: a consumer that has to exhibit one still has to choose the quadratic space, the
+decomposition and the basis.
+
+This file makes that choice, once, in the split model. The quadratic space is Mathlib's hyperbolic
+form `QuadraticForm.dualProd ℚ (Fin n → ℚ)` on `Module.Dual ℚ (Fin n → ℚ) × (Fin n → ℚ)`, of
+dimension `2 n`; the decomposition is the coordinate one supplied by
+`TauCeti.SpinPolarizationData.hyperbolic`; and the basis is the standard basis of `Fin n → ℚ`
+carried into the exterior summand. The resulting spinor module is the exterior algebra on `n`
+generators, whose `2 ^ n` coordinate basis vectors are indexed by `Finset (Fin n)` and carry the
+integral weights `TauCeti.DynkinType.typeDSpinWeight`, and the Kostant stability of its coordinate
+lattice becomes a statement with no free parameters other than the rank.
+
+Both half-spin parities occur, which is what makes the weights span the whole simply connected
+type-`D` character lattice rather than the root lattice, so this is the admissible full-weight
+lattice a simply connected type-`D` carrier is built from.
+
+Nothing here builds a group, a group scheme, or a torus, and nothing asserts smoothness or
+reductivity of anything: this file fixes the integral input data those constructions consume.
+
+## Main definitions
+
+* `TauCeti.typeDSplitPolarization`: the split polarization of the `2 n`-dimensional hyperbolic
+  quadratic space over `ℚ`.
+* `TauCeti.typeDSplitBasis`: the standard basis of its exterior summand.
+
+## Main results
+
+* `TauCeti.finrank_typeDSplitPolarization_W`: the exterior summand has dimension `n`, so the
+  quadratic space has dimension `2 n` and the diagram is `Dₙ`.
+* `TauCeti.isCartanWeightVector_typeDSplit`: the coordinate basis of the split spinor module is a
+  Cartan weight basis, with the integral simply connected type-`D` spin weights.
+* `TauCeti.typeDSplit_serreKostantForm_apply_mem_integralLattice`: the Serre Kostant form of
+  `CartanMatrix.D n` preserves the coordinate lattice of the split spinor module.
+
+## References
+
+* C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
+* N. Bourbaki, *Groupes et algèbres de Lie*, Chapters 4--6, Plate IV.
+
+## Roadmap
+
+This is the "concrete split-polarization specialization" left open by the type-`D` spinor-lattice
+construction in `TauCeti/RepresentationTheory/Spin/Polarization/TypeD/KostantLattice.lean`, and it
+serves Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`, "The Chevalley--Demazure
+construction", which asks for an explicitly constructed group scheme from a Chevalley basis and the
+Kostant `ℤ`-form rather than for an existence theorem. What remains of that layer on this branch is
+the toral Kostant group-scheme carrier itself, then its base change, root-datum pinning and
+diagram automorphism.
+
+The consumer is milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md`, "explicit pinned
+Chevalley--Demazure groups": the `Dₙ(q)` and `²Dₙ(q)` branches of
+`TauCeti.ValidLieTypeIndex.AmbientGroup` need a traceable pinned simply connected type-`D` carrier,
+and such a carrier is built from a Kostant-stable full-weight integral representation, which is
+what the declarations below fix.
+-/
+
+public section
+
+namespace TauCeti
+
+/-! ## The split polarization -/
+
+/-- **The split polarization of the `2 n`-dimensional hyperbolic quadratic space over `ℚ`.** Its
+exterior summand is the copy of `Fin n → ℚ` in the second coordinate, its contraction summand is
+the copy of the dual in the first, and there is no orthogonal remainder, so the attached spinor
+module is the exterior algebra on `n` generators. -/
+@[expose]
+noncomputable def typeDSplitPolarization (n : ℕ) :
+    SpinPolarizationData (QuadraticForm.dualProd ℚ (Fin n → ℚ)) :=
+  SpinPolarizationData.hyperbolic fun m h => (Module.forall_dual_apply_eq_zero_iff ℚ m).mp h
+
+/-- The split model has no orthogonal remainder. -/
+@[simp]
+theorem typeDSplitPolarization_line (n : ℕ) : (typeDSplitPolarization n).line = ⊥ := rfl
+
+/-- **The standard basis of the exterior summand of the split model**, carried from the standard
+basis of `Fin n → ℚ`. This is the basis the exterior model of the type-`D` spin representation is
+coordinatized by, and the one the Bourbaki numbering of the simple roots is read against. -/
+@[expose]
+noncomputable def typeDSplitBasis (n : ℕ) :
+    Module.Basis (Fin n) ℚ (typeDSplitPolarization n).W :=
+  SpinPolarizationData.hyperbolicBasis (Pi.basisFun ℚ (Fin n))
+
+@[simp]
+theorem coe_typeDSplitBasis_apply (n : ℕ) (i : Fin n) :
+    (typeDSplitBasis n i : Module.Dual ℚ (Fin n → ℚ) × (Fin n → ℚ)) =
+      (0, Pi.basisFun ℚ (Fin n) i) :=
+  SpinPolarizationData.coe_hyperbolicBasis_apply _ i
+
+/-- **The exterior summand of the split model has dimension `n`.** With
+`TauCeti.SpinPolarizationData.finrank_eq_two_mul_finrank_W_add_finrank_line` and the vanishing
+remainder, this is what says the quadratic space has dimension `2 n`, so that the diagram of the
+construction below is `Dₙ` and not another rank. -/
+theorem finrank_typeDSplitPolarization_W (n : ℕ) :
+    Module.finrank ℚ (typeDSplitPolarization n).W = n := by
+  rw [Module.finrank_eq_card_basis (typeDSplitBasis n), Fintype.card_fin]
+
+/-! ## The split spinor module -/
+
+/-- **The coordinate basis of the split spinor module is a Cartan weight basis**, its
+`Finset (Fin n)`-indexed exterior basis vector carrying the integral simply connected type-`D` spin
+weight of that subset. Both parities occur, so these weights span the whole character lattice. -/
+theorem isCartanWeightVector_typeDSplit {n : ℕ} (hn : 4 ≤ n) (s : Finset (Fin n)) :
+    UniversalEnvelopingAlgebra.IsCartanWeightVector (serreH ℚ (CartanMatrix.D n))
+      ((typeDSplitPolarization n).typeDSpinRep (typeDSplitBasis n) hn)
+      (DynkinType.typeDSpinWeight s)
+      (((ExteriorAlgebra.integralLatticeBasis (typeDSplitBasis n)) s :
+        ExteriorAlgebra.integralLattice (typeDSplitBasis n)) :
+        _root_.ExteriorAlgebra ℚ (typeDSplitPolarization n).W) :=
+  (typeDSplitPolarization n).isCartanWeightVector_typeDSpinRep_integralLatticeBasis
+    (typeDSplitBasis n) hn s
+
+/-- **The coordinate lattice of the split type-`Dₙ` spinor module is stable under the Serre Kostant
+form.** This is the admissible full-weight integral representation that a pinned simply connected
+type-`D` Chevalley--Demazure carrier is built from, with no data left to choose beyond the rank. -/
+theorem typeDSplit_serreKostantForm_apply_mem_integralLattice {n : ℕ} (hn : 4 ≤ n)
+    {u : _root_.UniversalEnvelopingAlgebra ℚ (Matrix.ToLieAlgebra ℚ (CartanMatrix.D n))}
+    (hu : u ∈ serreKostantForm (CartanMatrix.D n))
+    {v : _root_.ExteriorAlgebra ℚ (typeDSplitPolarization n).W}
+    (hv : v ∈ ExteriorAlgebra.integralLattice (typeDSplitBasis n)) :
+    (typeDSplitPolarization n).typeDSpinRep (typeDSplitBasis n) hn u v ∈
+      ExteriorAlgebra.integralLattice (typeDSplitBasis n) :=
+  (typeDSplitPolarization n).typeDSpinRep_serreKostantForm_apply_mem_integralLattice
+    (typeDSplitBasis n) hn hu hv
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/Split.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeD/Split.lean
@@ -43,6 +43,8 @@ reductivity of anything: this file fixes the integral input data those construct
 
 ## Main results
 
+* `TauCeti.typeDSplitPolarization_W`, `typeDSplitPolarization_W'` and
+  `typeDSplitPolarization_line`: the summands of the split polarization.
 * `TauCeti.finrank_typeDSplitPolarization_W`: the exterior summand has dimension `n`, so the
   quadratic space has dimension `2 n` and the diagram is `Dₙ`.
 * `TauCeti.isCartanWeightVector_typeDSplit`: the coordinate basis of the split spinor module is a
@@ -82,33 +84,47 @@ namespace TauCeti
 exterior summand is the copy of `Fin n → ℚ` in the second coordinate, its contraction summand is
 the copy of the dual in the first, and there is no orthogonal remainder, so the attached spinor
 module is the exterior algebra on `n` generators. -/
-@[expose]
 noncomputable def typeDSplitPolarization (n : ℕ) :
     SpinPolarizationData (QuadraticForm.dualProd ℚ (Fin n → ℚ)) :=
   SpinPolarizationData.hyperbolic fun m h => (Module.forall_dual_apply_eq_zero_iff ℚ m).mp h
 
+/-- The exterior summand of the split model is the copy of `Fin n → ℚ`. -/
+@[simp]
+theorem typeDSplitPolarization_W (n : ℕ) : (typeDSplitPolarization n).W =
+    Submodule.snd ℚ (Module.Dual ℚ (Fin n → ℚ)) (Fin n → ℚ) :=
+  SpinPolarizationData.hyperbolic_W _
+
+/-- The contraction summand of the split model is the copy of the dual of `Fin n → ℚ`. -/
+@[simp]
+theorem typeDSplitPolarization_W' (n : ℕ) : (typeDSplitPolarization n).W' =
+    Submodule.fst ℚ (Module.Dual ℚ (Fin n → ℚ)) (Fin n → ℚ) :=
+  SpinPolarizationData.hyperbolic_W' _
+
 /-- The split model has no orthogonal remainder. -/
 @[simp]
-theorem typeDSplitPolarization_line (n : ℕ) : (typeDSplitPolarization n).line = ⊥ := rfl
+theorem typeDSplitPolarization_line (n : ℕ) : (typeDSplitPolarization n).line = ⊥ :=
+  SpinPolarizationData.hyperbolic_line _
 
 /-- **The standard basis of the exterior summand of the split model**, carried from the standard
 basis of `Fin n → ℚ`. This is the basis the exterior model of the type-`D` spin representation is
 coordinatized by, and the one the Bourbaki numbering of the simple roots is read against. -/
-@[expose]
 noncomputable def typeDSplitBasis (n : ℕ) :
     Module.Basis (Fin n) ℚ (typeDSplitPolarization n).W :=
-  SpinPolarizationData.hyperbolicBasis (Pi.basisFun ℚ (Fin n))
+  (SpinPolarizationData.hyperbolicBasis (Pi.basisFun ℚ (Fin n))).map
+    (LinearEquiv.ofEq _ _ (typeDSplitPolarization_W n).symm)
 
 @[simp]
 theorem coe_typeDSplitBasis_apply (n : ℕ) (i : Fin n) :
     (typeDSplitBasis n i : Module.Dual ℚ (Fin n → ℚ) × (Fin n → ℚ)) =
-      (0, Pi.basisFun ℚ (Fin n) i) :=
-  SpinPolarizationData.coe_hyperbolicBasis_apply _ i
+      (0, Pi.basisFun ℚ (Fin n) i) := by
+  rw [typeDSplitBasis, Module.Basis.map_apply, LinearEquiv.coe_ofEq_apply,
+    SpinPolarizationData.coe_hyperbolicBasis_apply]
 
 /-- **The exterior summand of the split model has dimension `n`.** With
 `TauCeti.SpinPolarizationData.finrank_eq_two_mul_finrank_W_add_finrank_line` and the vanishing
 remainder, this is what says the quadratic space has dimension `2 n`, so that the diagram of the
 construction below is `Dₙ` and not another rank. -/
+@[simp]
 theorem finrank_typeDSplitPolarization_W (n : ℕ) :
     Module.finrank ℚ (typeDSplitPolarization n).W = n := by
   rw [Module.finrank_eq_card_basis (typeDSplitBasis n), Fintype.card_fin]


### PR DESCRIPTION
This PR writes down the coordinate polarization of a hyperbolic quadratic space and specializes it to a concrete split type-`Dₙ` spinor module. `TauCeti.SpinPolarizationData.hyperbolic` turns Mathlib's `QuadraticForm.dualProd K M` on `Module.Dual K M × M` into a `TauCeti.SpinPolarizationData`, with the copy of `M` as the exterior summand, the copy of its dual as the contraction summand, and no orthogonal remainder; `TauCeti.polar_dualProd` computes the polar form `f x + g m` that pairs the two, `TauCeti.SpinPolarizationData.nondegenerate_dualProd` records the nondegeneracy the vanishing remainder buys with no hypothesis on `2`, and `TauCeti.SpinPolarizationData.hyperbolicBasis` carries a basis of `M` into the exterior summand. The only hypothesis is that the functionals on `M` separate its points. `TauCeti.typeDSplitPolarization` and `TauCeti.typeDSplitBasis` then fix the rank-`n` case over `ℚ`, and `TauCeti.typeDSplit_serreKostantForm_apply_mem_integralLattice` states, with no data left to choose beyond the rank, that the Serre Kostant form of `CartanMatrix.D n` preserves the coordinate lattice of the resulting exterior algebra, with `TauCeti.isCartanWeightVector_typeDSplit` giving its weight basis and `TauCeti.finrank_typeDSplitPolarization_W` the dimension count that makes the diagram `Dₙ`.

The roadmap target is Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`, "The Chevalley--Demazure construction", which asks for an explicitly constructed split reductive group scheme over `ℤ` built from a Chevalley basis and the Kostant `ℤ`-form, and insists that an existence theorem is not enough. This is the "concrete split-polarization specialization" that https://github.com/TauCetiProject/TauCeti/pull/5320 "feat: make the type D spinor lattice Kostant-stable" named as the next thing that lane needs: that PR proved Kostant stability for an arbitrary `TauCeti.SpinPolarizationData` and an arbitrary basis of its exterior summand, so it names no carrier, and `TauCeti.SpinPolarizationData.ofNondegenerate` is no substitute because it normalizes an arbitrary form and so does not give its summands by a formula. After this PR the type-`D` Layer 9 path still needs the toral Kostant group-scheme carrier itself, then its base change, root-datum pinning and diagram automorphism.

Consumer roadmap: CFSGStatement

The consumer milestone is L0 of `TauCetiRoadmap/CFSGStatement/README.md`, "explicit pinned Chevalley--Demazure groups", whose completion evidence is that every valid family traces to explicit data. The dependency edge is: the `Dₙ(q)` and `²Dₙ(q)` branches of `TauCeti.ValidLieTypeIndex.AmbientGroup` consume a traceable pinned simply connected type-`D` carrier; that Layer 9 carrier consumes a Kostant-stable full-weight integral representation; and a representation is not integral data until its quadratic space, its decomposition and its basis are chosen, which is what the declarations here choose. Both half-spin parities occur in the full exterior algebra, which is why the weights span the whole simply connected character lattice rather than the root lattice. This is also why the branch is not reachable through the Geck carrier that `TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean` uses for `E₈(q)`, `F₄(q)` and `G₂(q)`: the `Dₙ` Cartan matrix is not unimodular.

This was the most effective distinct current step because the type-`D` root bivectors, their Serre relations, the integral exterior lattice, the full-lattice spin weights and the Kostant stability of that lattice are all on `main`, while the open type-`D` and type-`B` work concerns matrix root generators, spin weights and graph symmetry rather than the choice of a concrete quadratic space. Nothing here builds a group, a group scheme or a torus, and nothing asserts smoothness or reductivity.

The files added are `TauCeti/RepresentationTheory/Spin/Polarization/Hyperbolic.lean` (216 lines), beside `Polarization/Basic.lean` which defines the structure and `Polarization/Exists.lean` which gives the non-explicit construction, and `TauCeti/RepresentationTheory/Spin/Polarization/TypeD/Split.lean` (144 lines), beside the type-`D` lattice work it specializes. No Mathlib or Tau Ceti material is vendored or restated: the decomposition is `Submodule.snd`, `Submodule.fst` and `Submodule.prodEquivOfIsCompl` with `Submodule.fst_inf_snd` and `Submodule.fst_sup_snd`, the pairing with the dual is `Submodule.fstEquiv`, `Submodule.sndEquiv` and `LinearEquiv.dualMap`, the separation hypothesis is discharged by `Module.forall_dual_apply_eq_zero_iff`, and the type-`D` statements are `TauCeti.SpinPolarizationData.typeDSpinRep_serreKostantForm_apply_mem_integralLattice` and `isCartanWeightVector_typeDSpinRep_integralLatticeBasis` read at the chosen data. The only new general lemmas are `TauCeti.polar_dualProd` and `TauCeti.isCompl_snd_fst`, neither of which is in the pinned Mathlib.

The conventions follow C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II, for the exterior model of a split decomposition, N. Bourbaki, *Algèbre*, Chapter 9, §4, for hyperbolic quadratic spaces, and N. Bourbaki, *Groupes et algèbres de Lie*, Chapters 4--6, Plate IV, for the type-`D` numbering.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"spinpolarizationdata-hyperbolic"}-->

🤖 Prepared with Claude Code
