### PR TITLE
feat: extend unipotence across algebraic closures

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
@@ -67,19 +67,6 @@ private theorem charpoly_conjugate {B : Type w} [CommRing B] [Algebra R B]
     simp [LinearEquiv.conj_apply, Comodule.pointsAction_toLinearMap]
   rw [hEnd, LinearEquiv.charpoly_conj]
 
-private theorem charpoly_endOfPoint_comp {B D : Type w} [CommRing B] [Algebra R B]
-    [CommRing D] [Algebra R D] (M : FGComoduleCat.{u, v, u} R H)
-    (b : Basis (Module.Free.ChooseBasisIndex R M) R M) (g : H →ₐ[R] B) (f : B →ₐ[R] D) :
-    (Comodule.endOfPoint M (f.comp g)).charpoly =
-      (Comodule.endOfPoint M g).charpoly.map f := by
-  rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M (f.comp g)) (b.baseChange D),
-    ← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g) (b.baseChange B),
-    Comodule.toMatrix_endOfPoint, Comodule.toMatrix_endOfPoint, ← Matrix.charpoly_map,
-    Matrix.map_map]
-  apply congrArg Matrix.charpoly
-  ext i j
-  simp [Matrix.map_apply]
-
 /-- Every point of the dynamic unipotent subgroup attached to a cocharacter is unipotent in
 every finite-dimensional representation. -/
 theorem isUnipotentPoint_of_mem_unipotent
@@ -132,7 +119,7 @@ theorem isUnipotentPoint_of_mem_unipotent
         rw [conjugate_apply, charpoly_conjugate]
       _ = (Comodule.endOfPoint M (f.comp g.ofConv)).charpoly := by rw [constPoint_apply]
       _ = (Comodule.endOfPoint M g.ofConv).charpoly.map f :=
-        charpoly_endOfPoint_comp M b g.ofConv f
+        Comodule.charpoly_endOfPoint_comp b g.ofConv f
       _ = G.charpoly.map LaurentPolynomial.C := by
         rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv) (b.baseChange A),
           Comodule.toMatrix_endOfPoint, hf]

--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
@@ -119,7 +119,7 @@ theorem isUnipotentPoint_of_mem_unipotent
         rw [conjugate_apply, charpoly_conjugate]
       _ = (Comodule.endOfPoint M (f.comp g.ofConv)).charpoly := by rw [constPoint_apply]
       _ = (Comodule.endOfPoint M g.ofConv).charpoly.map f :=
-        Comodule.charpoly_endOfPoint_comp b g.ofConv f
+        Comodule.charpoly_endOfPoint_comp g.ofConv f
       _ = G.charpoly.map LaurentPolynomial.C := by
         rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv) (b.baseChange A),
           Comodule.toMatrix_endOfPoint, hf]

--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
@@ -10,7 +10,6 @@ public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.ClosedSubgroup
 import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.PointAction
-import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 
 /-!
 # Unipotence of the dynamic unipotent subgroup

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -172,14 +172,13 @@ theorem of_injective_of_reduced (f : H ⟶ K) (hf : Function.Injective f.hom)
   intro M
   let b := Module.Free.chooseBasis k M
   let C := Comodule.coefficientMatrix (C := H) b
-  let D := C.map f.hom
   let d := Module.finrank k M
   let P : Polynomial k := (Polynomial.X - 1) ^ d
   -- Point separation turns the characteristic polynomial identity at every source point into
   -- an identity for the universal coefficient matrix over the source coordinate algebra.
   let _ : Comodule k K M := Comodule.Corestrict f.hom.toCoalgHom
   let N : FGComoduleCat.{u, v, u} k K := FGComoduleCat.of (R := k) (C := K) M
-  have hDcharpoly : D.charpoly = P.map (algebraMap k K) := by
+  have hDcharpoly : (C.map f.hom.toAlgHom.toRingHom).charpoly = P.map (algebraMap k K) := by
     have hcharpoly := coefficientMatrix_charpoly_eq hK N b
     rw [Comodule.coefficientMatrix_corestrict b f.hom.toCoalgHom] at hcharpoly
     exact hcharpoly
@@ -187,8 +186,6 @@ theorem of_injective_of_reduced (f : H ⟶ K) (hf : Function.Injective f.hom)
   have hCcharpoly : C.charpoly = P.map (algebraMap k H) := by
     apply Polynomial.map_injective f.hom.toAlgHom.toRingHom hf
     rw [← Matrix.charpoly_map]
-    -- Expose the local name for the mapped coefficient matrix.
-    change D.charpoly = _
     rw [hDcharpoly]
     rw [Polynomial.map_map]
     congr 1

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
 import Mathlib.LinearAlgebra.Charpoly.ToMatrix
+import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Naturality
 import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.PointAction
 import TauCeti.RingTheory.FiniteType.PointSeparation
 import TauCeti.RingTheory.Smooth.GeometricallyReduced
@@ -28,8 +29,12 @@ commutative algebra over the ground field is unipotent.
   unipotence descends along an injective coordinate morphism with reduced finite-type codomain.
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint`: geometric
   unipotence can be evaluated in any commutative algebra.
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.iff_forall_isUnipotentPoint`:
+  geometric unipotence can be characterized over any algebraically closed extension.
 * `TauCeti.smoothUnipotentCommHopfAlgProperty.isUnipotentPoint`: the smooth finite-type
   specialization, where reducedness follows from smoothness.
+* `TauCeti.smoothUnipotentCommHopfAlgProperty.iff_smooth_and_forall_isUnipotentPoint`:
+  the corresponding characterization for smooth unipotence.
 
 ## References
 
@@ -119,7 +124,7 @@ private theorem isUnipotent_pointsAction_of_coefficientMatrix_charpoly_eq
       (Comodule.endOfPoint M g.ofConv).charpoly =
           (Comodule.endOfPoint M e).charpoly.map g.ofConv := by
         simpa only [e, AlgHom.comp_id] using
-          (Comodule.charpoly_endOfPoint_comp b e g.ofConv)
+          (Comodule.charpoly_endOfPoint_comp e g.ofConv)
       _ = C.charpoly.map g.ofConv := by
         congr 1
         rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M e) (b.baseChange A),
@@ -152,6 +157,23 @@ theorem isUnipotentPoint
   let b := Module.Free.chooseBasis k M
   exact isUnipotent_pointsAction_of_coefficientMatrix_charpoly_eq M g b
     (coefficientMatrix_charpoly_eq hA M b)
+
+/-- A reduced finite-type Hopf algebra is geometrically unipotent if and only if every point
+valued in any fixed algebraically closed extension is unipotent. -/
+theorem iff_forall_isUnipotentPoint
+    {A : _root_.CommHopfAlgCat.{v} k} [Algebra.FiniteType k A] [IsReduced A]
+    (L : Type w) [Field L] [Algebra k L] [IsAlgClosed L] :
+    geometricallyUnipotentPointsCommHopfAlgProperty k A ↔
+      ∀ g : WithConv (A →ₐ[k] L), HopfAlgebra.IsUnipotentPoint g := by
+  constructor
+  · intro hA g
+    exact isUnipotentPoint hA g
+  · intro hL
+    rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff]
+    intro g
+    let φ : AlgebraicClosure k →ₐ[k] L := IsAlgClosed.lift
+    exact (HopfAlgebra.isUnipotentPoint_mapValue_iff_of_injective g φ φ.injective).mp
+      (hL (AlgHom.mapValue (H := A) φ g))
 
 /-- Geometric unipotence descends along an injective morphism of coordinate Hopf algebras whose
 codomain is reduced and finite type.
@@ -217,6 +239,30 @@ theorem isUnipotentPoint
     exact hA'.2
   exact geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint
     (A := A.obj) (L := L) hgeom g
+
+/-- A finite-type Hopf algebra is smooth unipotent if and only if it is smooth and every point
+valued in any fixed algebraically closed extension is unipotent. -/
+theorem iff_smooth_and_forall_isUnipotentPoint
+    (L : Type w) [Field L] [Algebra k L] [IsAlgClosed L] :
+    smoothUnipotentCommHopfAlgProperty k A ↔
+      Algebra.Smooth k A ∧
+        ∀ g : WithConv (A →ₐ[k] L), HopfAlgebra.IsUnipotentPoint g := by
+  constructor
+  · intro hA
+    have hA' := (smoothUnipotentCommHopfAlgProperty_iff k A).mp hA
+    let _ : Algebra.Smooth k A := hA'.1
+    let _ : IsReduced A := isReduced_of_smooth_of_field k A
+    refine ⟨hA'.1, ?_⟩
+    exact (geometricallyUnipotentPointsCommHopfAlgProperty.iff_forall_isUnipotentPoint
+      (A := A.obj) L).mp
+        ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k A.obj).mpr hA'.2)
+  · rintro ⟨hsm, hL⟩
+    rw [smoothUnipotentCommHopfAlgProperty_iff]
+    refine ⟨hsm, ?_⟩
+    intro g
+    let φ : AlgebraicClosure k →ₐ[k] L := IsAlgClosed.lift
+    exact (HopfAlgebra.isUnipotentPoint_mapValue_iff_of_injective g φ φ.injective).mp
+      (hL (AlgHom.mapValue (H := A) φ g))
 
 end smoothUnipotentCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -250,12 +250,7 @@ theorem iff_smooth_and_forall_isUnipotentPoint
   constructor
   · intro hA
     have hA' := (smoothUnipotentCommHopfAlgProperty_iff k A).mp hA
-    let _ : Algebra.Smooth k A := hA'.1
-    let _ : IsReduced A := isReduced_of_smooth_of_field k A
-    refine ⟨hA'.1, ?_⟩
-    exact (geometricallyUnipotentPointsCommHopfAlgProperty.iff_forall_isUnipotentPoint
-      (A := A.obj) L).mp
-        ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k A.obj).mpr hA'.2)
+    exact ⟨hA'.1, fun g ↦ isUnipotentPoint hA g⟩
   · rintro ⟨hsm, hL⟩
     let _ : Algebra.Smooth k A := hsm
     let _ : IsReduced A := isReduced_of_smooth_of_field k A

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -181,7 +181,10 @@ theorem of_injective_of_reduced (f : H ⟶ K) (hf : Function.Injective f.hom)
   have hDcharpoly : (C.map f.hom.toAlgHom.toRingHom).charpoly = P.map (algebraMap k K) := by
     have hcharpoly := coefficientMatrix_charpoly_eq hK N b
     rw [Comodule.coefficientMatrix_corestrict b f.hom.toCoalgHom] at hcharpoly
-    exact hcharpoly
+    have hmap : (f.hom.toCoalgHom : H → K) = f.hom.toAlgHom.toRingHom := by
+      ext
+      rfl
+    simpa only [hmap] using hcharpoly
   -- Injectivity reflects the universal characteristic polynomial identity to the target.
   have hCcharpoly : C.charpoly = P.map (algebraMap k H) := by
     apply Polynomial.map_injective f.hom.toAlgHom.toRingHom hf

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -9,19 +9,28 @@ public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
 import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.PointAction
 import TauCeti.RingTheory.FiniteType.PointSeparation
+import TauCeti.RingTheory.Smooth.GeometricallyReduced
 
 /-!
-# Unipotence under injective morphisms into reduced Hopf algebras
+# Unipotence over reduced Hopf algebras
 
 An injective morphism `H ⟶ K` of coordinate Hopf algebras represents a schematically dense
 homomorphism `Spec K ⟶ Spec H`. When `K` is reduced and finite type, its geometric points separate
 elements. Applying this to the coefficients of the characteristic polynomial of every
 representation shows that geometric unipotence descends from `K` to `H`.
 
-## Main declaration
+The same universal characteristic-polynomial identity also shows that the chosen algebraic
+closure in the definition is immaterial: every point valued in any algebraically closed extension
+of the ground field is unipotent.
+
+## Main declarations
 
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.of_injective_of_reduced`: geometric
   unipotence descends along an injective coordinate morphism with reduced finite-type codomain.
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint_of_isAlgClosed`:
+  geometric unipotence can be evaluated in any algebraically closed extension field.
+* `TauCeti.smoothUnipotentCommHopfAlgProperty.isUnipotentPoint_of_isAlgClosed`: the smooth
+  finite-type specialization, where reducedness follows from smoothness.
 
 ## References
 
@@ -38,7 +47,7 @@ open scoped TensorProduct
 
 namespace TauCeti
 
-universe u v
+universe u v w
 
 namespace geometricallyUnipotentPointsCommHopfAlgProperty
 
@@ -46,6 +55,90 @@ variable {k : Type u} [Field k]
 variable {H K : _root_.CommHopfAlgCat.{v} k}
 
 attribute [local instance 1100] Module.Free.of_divisionRing
+
+private theorem coefficientMatrix_charpoly_eq
+    {A : _root_.CommHopfAlgCat.{v} k} [Algebra.FiniteType k A] [IsReduced A]
+    (hA : geometricallyUnipotentPointsCommHopfAlgProperty k A)
+    (M : FGComoduleCat.{u, v, u} k A) {ι : Type w} [Fintype ι] [DecidableEq ι]
+    (b : _root_.Module.Basis ι k M) :
+    (Comodule.coefficientMatrix (C := A) b).charpoly =
+      ((Polynomial.X - (1 : Polynomial k)) ^ Module.finrank k M).map
+        (algebraMap k A) := by
+  let C := Comodule.coefficientMatrix (C := A) b
+  let P : Polynomial k := (Polynomial.X - 1) ^ Module.finrank k M
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hA
+  apply Polynomial.ext
+  intro r
+  apply TauCeti.eq_of_forall_algHom_apply_eq (k := k) (K := AlgebraicClosure k)
+  intro q
+  have hq := (HopfAlgebra.isUnipotentPoint_def (WithConv.toConv q)).mp
+    (hA (WithConv.toConv q)) M
+  have hqcharpoly : (Comodule.endOfPoint M q).charpoly =
+      P.map (algebraMap k (AlgebraicClosure k)) := by
+    have hcoe :
+        ((LinearMap.GeneralLinearGroup.ofLinearEquiv
+          (Comodule.pointsAction M (WithConv.toConv q))) : Module.End _ _) =
+            Comodule.endOfPoint M q :=
+      Comodule.pointsAction_toLinearMap M (WithConv.toConv q)
+    rw [← hcoe]
+    have hcharpoly := (LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly _).mp hq
+    rw [Module.finrank_baseChange] at hcharpoly
+    exact hcharpoly.trans (by simp [P])
+  have hmatrix : C.map q =
+      LinearMap.toMatrix (b.baseChange (AlgebraicClosure k))
+        (b.baseChange (AlgebraicClosure k)) (Comodule.endOfPoint M q) := by
+    rw [Comodule.toMatrix_endOfPoint]
+  rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M q)
+    (b.baseChange (AlgebraicClosure k)), ← hmatrix] at hqcharpoly
+  calc
+    q (C.charpoly.coeff r) = (C.charpoly.map q).coeff r := by
+      exact (Polynomial.coeff_map q.toRingHom r).symm
+    _ = (C.map q).charpoly.coeff r :=
+      congrArg (fun p ↦ p.coeff r) (Matrix.charpoly_map C q.toRingHom).symm
+    _ = (P.map (algebraMap k (AlgebraicClosure k))).coeff r :=
+      congrArg (fun p ↦ p.coeff r) hqcharpoly
+    _ = q ((P.map (algebraMap k A)).coeff r) := by
+      rw [Polynomial.coeff_map, Polynomial.coeff_map]
+      exact (q.commutes (P.coeff r)).symm
+
+/-- If a reduced finite-type Hopf algebra is geometrically unipotent, every point valued in any
+algebraically closed extension of the ground field is unipotent.
+
+Thus the particular algebraic closure used in
+`geometricallyUnipotentPointsCommHopfAlgProperty` does not affect the property. -/
+theorem isUnipotentPoint_of_isAlgClosed
+    {A : _root_.CommHopfAlgCat.{v} k} [Algebra.FiniteType k A] [IsReduced A]
+    (hA : geometricallyUnipotentPointsCommHopfAlgProperty k A)
+    {L : Type w} [Field L] [Algebra k L] [IsAlgClosed L]
+    (g : WithConv (A →ₐ[k] L)) : HopfAlgebra.IsUnipotentPoint g := by
+  rw [HopfAlgebra.isUnipotentPoint_def]
+  intro M
+  let b := Module.Free.chooseBasis k M
+  let C := Comodule.coefficientMatrix (C := A) b
+  let d := Module.finrank k M
+  let P : Polynomial k := (Polynomial.X - 1) ^ d
+  have hCcharpoly : C.charpoly = P.map (algebraMap k A) :=
+    coefficientMatrix_charpoly_eq hA M b
+  have hgcharpoly : (Comodule.endOfPoint M g.ofConv).charpoly =
+      P.map (algebraMap k L) := by
+    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv) (b.baseChange L),
+      Comodule.toMatrix_endOfPoint]
+    change (C.map g.ofConv).charpoly = _
+    calc
+      (C.map g.ofConv).charpoly = C.charpoly.map g.ofConv.toRingHom :=
+        Matrix.charpoly_map C g.ofConv.toRingHom
+      _ = _ := by
+        rw [hCcharpoly, Polynomial.map_map]
+        congr 1
+        ext x
+        exact g.ofConv.commutes x
+  apply LinearMap.GeneralLinearGroup.isUnipotent_of_charpoly_eq (n := d)
+  have hcoe :
+      ((LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+        Module.End _ _) = Comodule.endOfPoint M g.ofConv :=
+    Comodule.pointsAction_toLinearMap M g
+  rw [hcoe]
+  exact hgcharpoly.trans (by simp [P])
 
 /-- Geometric unipotence descends along an injective morphism of coordinate Hopf algebras whose
 codomain is reduced and finite type.
@@ -60,64 +153,23 @@ theorem of_injective_of_reduced (f : H ⟶ K) (hf : Function.Injective f.hom)
     [Algebra.FiniteType k K] [IsReduced K]
     (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K) :
     geometricallyUnipotentPointsCommHopfAlgProperty k H := by
-  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hK ⊢
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at ⊢
   intro g
   rw [HopfAlgebra.isUnipotentPoint_def]
   intro M
   let b := Module.Free.chooseBasis k M
   let C := Comodule.coefficientMatrix (C := H) b
   let D := C.map f.hom
-  let d := Module.finrank (AlgebraicClosure k) (AlgebraicClosure k ⊗[k] M)
+  let d := Module.finrank k M
   let P : Polynomial k := (Polynomial.X - 1) ^ d
   -- Point separation turns the characteristic polynomial identity at every source point into
   -- an identity for the universal coefficient matrix over the source coordinate algebra.
+  let _ : Comodule k K M := Comodule.Corestrict f.hom.toCoalgHom
+  let N : FGComoduleCat.{u, v, u} k K := FGComoduleCat.of (R := k) (C := K) M
   have hDcharpoly : D.charpoly = P.map (algebraMap k K) := by
-    apply Polynomial.ext
-    intro r
-    apply TauCeti.eq_of_forall_algHom_apply_eq
-      (k := k) (K := AlgebraicClosure k)
-    intro q
-    let _ : Comodule k K M := Comodule.Corestrict f.hom.toCoalgHom
-    let N : FGComoduleCat.{u, v, u} k K := FGComoduleCat.of (R := k) (C := K) M
-    have hq := (HopfAlgebra.isUnipotentPoint_def (WithConv.toConv q)).mp
-      (hK (WithConv.toConv q)) N
-    have hqcharpoly : (Comodule.endOfPoint M q).charpoly =
-        P.map (algebraMap k (AlgebraicClosure k)) := by
-      have hcoe :
-          ((LinearMap.GeneralLinearGroup.ofLinearEquiv
-            (Comodule.pointsAction N (WithConv.toConv q))) : Module.End _ _) =
-              Comodule.endOfPoint M q :=
-        Comodule.pointsAction_toLinearMap N (WithConv.toConv q)
-      rw [← hcoe]
-      have hcharpoly := (LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly _).mp hq
-      let e : N ≃ₗ[k] M := LinearEquiv.refl k M
-      have hd : Module.finrank (AlgebraicClosure k)
-          (AlgebraicClosure k ⊗[k] N) = d :=
-        LinearEquiv.finrank_eq (e.baseChange k (AlgebraicClosure k) N M)
-      rw [hd] at hcharpoly
-      exact hcharpoly.trans (by simp [P])
-    have hmatrix : D.map q =
-        LinearMap.toMatrix (b.baseChange (AlgebraicClosure k))
-          (b.baseChange (AlgebraicClosure k)) (Comodule.endOfPoint N q) := by
-      rw [Comodule.toMatrix_endOfPoint]
-      rw [Comodule.coefficientMatrix_corestrict b f.hom.toCoalgHom]
-      -- Unfold the local names so `Matrix.map_map` sees the two successive coefficient maps.
-      change (C.map f.hom).map q = _
-      rw [Matrix.map_map]
-      ext i j
-      rfl
-    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint N q)
-      (b.baseChange (AlgebraicClosure k)), ← hmatrix] at hqcharpoly
-    calc
-      q (D.charpoly.coeff r) = (D.charpoly.map q).coeff r := by
-        exact (Polynomial.coeff_map q.toRingHom r).symm
-      _ = (D.map q).charpoly.coeff r :=
-        congrArg (fun p ↦ p.coeff r) (Matrix.charpoly_map D q.toRingHom).symm
-      _ = (P.map (algebraMap k (AlgebraicClosure k))).coeff r :=
-        congrArg (fun p ↦ p.coeff r) hqcharpoly
-      _ = q ((P.map (algebraMap k K)).coeff r) := by
-        rw [Polynomial.coeff_map, Polynomial.coeff_map]
-        exact (q.commutes (P.coeff r)).symm
+    have hcharpoly := coefficientMatrix_charpoly_eq hK N b
+    rw [Comodule.coefficientMatrix_corestrict b f.hom.toCoalgHom] at hcharpoly
+    exact hcharpoly
   -- Injectivity reflects the universal characteristic polynomial identity to the target.
   have hCcharpoly : C.charpoly = P.map (algebraMap k H) := by
     apply Polynomial.map_injective f.hom.toAlgHom.toRingHom hf
@@ -155,5 +207,27 @@ theorem of_injective_of_reduced (f : H ⟶ K) (hf : Function.Injective f.hom)
   exact hgcharpoly.trans (by simp [P])
 
 end geometricallyUnipotentPointsCommHopfAlgProperty
+
+namespace smoothUnipotentCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+variable {A : FiniteTypeCommHopfAlgCat.{u, v} k}
+
+/-- Every point of a smooth geometrically unipotent affine group valued in an algebraically
+closed extension of the ground field is unipotent. -/
+theorem isUnipotentPoint_of_isAlgClosed
+    (hA : smoothUnipotentCommHopfAlgProperty k A)
+    {L : Type w} [Field L] [Algebra k L] [IsAlgClosed L]
+    (g : WithConv (A →ₐ[k] L)) : HopfAlgebra.IsUnipotentPoint g := by
+  have hA' := (smoothUnipotentCommHopfAlgProperty_iff k A).mp hA
+  let _ : Algebra.Smooth k A := hA'.1
+  let _ : IsReduced A := isReduced_of_smooth_of_field k A
+  have hgeom : geometricallyUnipotentPointsCommHopfAlgProperty k A.obj := by
+    rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff]
+    exact hA'.2
+  exact geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint_of_isAlgClosed
+    (A := A.obj) (L := L) hgeom g
+
+end smoothUnipotentCommHopfAlgProperty
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -20,17 +20,17 @@ elements. Applying this to the coefficients of the characteristic polynomial of 
 representation shows that geometric unipotence descends from `K` to `H`.
 
 The same universal characteristic-polynomial identity also shows that the chosen algebraic
-closure in the definition is immaterial: every point valued in any algebraically closed extension
-of the ground field is unipotent.
+closure in the definition is immaterial: every point valued in any extension field of the ground
+field is unipotent.
 
 ## Main declarations
 
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.of_injective_of_reduced`: geometric
   unipotence descends along an injective coordinate morphism with reduced finite-type codomain.
-* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint_of_isAlgClosed`:
-  geometric unipotence can be evaluated in any algebraically closed extension field.
-* `TauCeti.smoothUnipotentCommHopfAlgProperty.isUnipotentPoint_of_isAlgClosed`: the smooth
-  finite-type specialization, where reducedness follows from smoothness.
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint`: geometric
+  unipotence can be evaluated in any extension field.
+* `TauCeti.smoothUnipotentCommHopfAlgProperty.isUnipotentPoint`: the smooth finite-type
+  specialization, where reducedness follows from smoothness.
 
 ## References
 
@@ -102,14 +102,14 @@ private theorem coefficientMatrix_charpoly_eq
       exact (q.commutes (P.coeff r)).symm
 
 /-- If a reduced finite-type Hopf algebra is geometrically unipotent, every point valued in any
-algebraically closed extension of the ground field is unipotent.
+extension field of the ground field is unipotent.
 
 Thus the particular algebraic closure used in
 `geometricallyUnipotentPointsCommHopfAlgProperty` does not affect the property. -/
-theorem isUnipotentPoint_of_isAlgClosed
+theorem isUnipotentPoint
     {A : _root_.CommHopfAlgCat.{v} k} [Algebra.FiniteType k A] [IsReduced A]
     (hA : geometricallyUnipotentPointsCommHopfAlgProperty k A)
-    {L : Type w} [Field L] [Algebra k L] [IsAlgClosed L]
+    {L : Type w} [Field L] [Algebra k L]
     (g : WithConv (A →ₐ[k] L)) : HopfAlgebra.IsUnipotentPoint g := by
   rw [HopfAlgebra.isUnipotentPoint_def]
   intro M
@@ -213,11 +213,11 @@ namespace smoothUnipotentCommHopfAlgProperty
 variable {k : Type u} [Field k]
 variable {A : FiniteTypeCommHopfAlgCat.{u, v} k}
 
-/-- Every point of a smooth geometrically unipotent affine group valued in an algebraically
-closed extension of the ground field is unipotent. -/
-theorem isUnipotentPoint_of_isAlgClosed
+/-- Every point of a smooth geometrically unipotent affine group valued in an extension field of
+the ground field is unipotent. -/
+theorem isUnipotentPoint
     (hA : smoothUnipotentCommHopfAlgProperty k A)
-    {L : Type w} [Field L] [Algebra k L] [IsAlgClosed L]
+    {L : Type w} [Field L] [Algebra k L]
     (g : WithConv (A →ₐ[k] L)) : HopfAlgebra.IsUnipotentPoint g := by
   have hA' := (smoothUnipotentCommHopfAlgProperty_iff k A).mp hA
   let _ : Algebra.Smooth k A := hA'.1
@@ -225,7 +225,7 @@ theorem isUnipotentPoint_of_isAlgClosed
   have hgeom : geometricallyUnipotentPointsCommHopfAlgProperty k A.obj := by
     rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff]
     exact hA'.2
-  exact geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint_of_isAlgClosed
+  exact geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint
     (A := A.obj) (L := L) hgeom g
 
 end smoothUnipotentCommHopfAlgProperty

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -114,12 +114,17 @@ private theorem isUnipotent_pointsAction_of_coefficientMatrix_charpoly_eq
   let P : Polynomial k := (Polynomial.X - 1) ^ d
   have hgcharpoly : (Comodule.endOfPoint M g.ofConv).charpoly =
       P.map (algebraMap k L) := by
-    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv) (b.baseChange L),
-      Comodule.toMatrix_endOfPoint]
-    change (C.map g.ofConv).charpoly = _
+    let e : A →ₐ[k] A := AlgHom.id k A
     calc
-      (C.map g.ofConv).charpoly = C.charpoly.map g.ofConv.toRingHom :=
-        Matrix.charpoly_map C g.ofConv.toRingHom
+      (Comodule.endOfPoint M g.ofConv).charpoly =
+          (Comodule.endOfPoint M e).charpoly.map g.ofConv := by
+        simpa only [e, AlgHom.comp_id] using
+          (Comodule.charpoly_endOfPoint_comp b e g.ofConv)
+      _ = C.charpoly.map g.ofConv := by
+        congr 1
+        rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M e) (b.baseChange A),
+          Comodule.toMatrix_endOfPoint]
+        congr 1
       _ = _ := by
         rw [hCcharpoly, Polynomial.map_map]
         congr 1
@@ -134,10 +139,9 @@ private theorem isUnipotent_pointsAction_of_coefficientMatrix_charpoly_eq
   exact hgcharpoly.trans (by simp [P])
 
 /-- If a reduced finite-type Hopf algebra is geometrically unipotent, every point valued in any
-commutative algebra over the ground field is unipotent.
-
-Thus the particular algebraic closure used in
-`geometricallyUnipotentPointsCommHopfAlgProperty` does not affect the property. -/
+commutative algebra over the ground field is unipotent. In particular, the defining hypothesis
+over the chosen algebraic closure implies unipotence for points over every other algebraically
+closed extension. -/
 theorem isUnipotentPoint
     {A : _root_.CommHopfAlgCat.{v} k} [Algebra.FiniteType k A] [IsReduced A]
     (hA : geometricallyUnipotentPointsCommHopfAlgProperty k A)

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -19,16 +19,15 @@ homomorphism `Spec K ⟶ Spec H`. When `K` is reduced and finite type, its geome
 elements. Applying this to the coefficients of the characteristic polynomial of every
 representation shows that geometric unipotence descends from `K` to `H`.
 
-The same universal characteristic-polynomial identity also shows that the chosen algebraic
-closure in the definition is immaterial: every point valued in any extension field of the ground
-field is unipotent.
+The same universal characteristic-polynomial identity also shows that every point valued in any
+commutative algebra over the ground field is unipotent.
 
 ## Main declarations
 
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.of_injective_of_reduced`: geometric
   unipotence descends along an injective coordinate morphism with reduced finite-type codomain.
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint`: geometric
-  unipotence can be evaluated in any extension field.
+  unipotence can be evaluated in any commutative algebra.
 * `TauCeti.smoothUnipotentCommHopfAlgProperty.isUnipotentPoint`: the smooth finite-type
   specialization, where reducedness follows from smoothness.
 
@@ -101,24 +100,18 @@ private theorem coefficientMatrix_charpoly_eq
       rw [Polynomial.coeff_map, Polynomial.coeff_map]
       exact (q.commutes (P.coeff r)).symm
 
-/-- If a reduced finite-type Hopf algebra is geometrically unipotent, every point valued in any
-extension field of the ground field is unipotent.
-
-Thus the particular algebraic closure used in
-`geometricallyUnipotentPointsCommHopfAlgProperty` does not affect the property. -/
-theorem isUnipotentPoint
-    {A : _root_.CommHopfAlgCat.{v} k} [Algebra.FiniteType k A] [IsReduced A]
-    (hA : geometricallyUnipotentPointsCommHopfAlgProperty k A)
-    {L : Type w} [Field L] [Algebra k L]
-    (g : WithConv (A →ₐ[k] L)) : HopfAlgebra.IsUnipotentPoint g := by
-  rw [HopfAlgebra.isUnipotentPoint_def]
-  intro M
-  let b := Module.Free.chooseBasis k M
+private theorem isUnipotent_pointsAction_of_coefficientMatrix_charpoly_eq
+    {A : _root_.CommHopfAlgCat.{v} k} {L : Type w} [CommRing L] [Algebra k L]
+    (M : FGComoduleCat.{u, v, u} k A) (g : WithConv (A →ₐ[k] L))
+    {ι : Type*} [Fintype ι] [DecidableEq ι] (b : _root_.Module.Basis ι k M)
+    (hCcharpoly : (Comodule.coefficientMatrix (C := A) b).charpoly =
+      ((Polynomial.X - (1 : Polynomial k)) ^ Module.finrank k M).map
+        (algebraMap k A)) :
+    LinearMap.GeneralLinearGroup.IsUnipotent
+      (LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) := by
   let C := Comodule.coefficientMatrix (C := A) b
   let d := Module.finrank k M
   let P : Polynomial k := (Polynomial.X - 1) ^ d
-  have hCcharpoly : C.charpoly = P.map (algebraMap k A) :=
-    coefficientMatrix_charpoly_eq hA M b
   have hgcharpoly : (Comodule.endOfPoint M g.ofConv).charpoly =
       P.map (algebraMap k L) := by
     rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv) (b.baseChange L),
@@ -139,6 +132,22 @@ theorem isUnipotentPoint
     Comodule.pointsAction_toLinearMap M g
   rw [hcoe]
   exact hgcharpoly.trans (by simp [P])
+
+/-- If a reduced finite-type Hopf algebra is geometrically unipotent, every point valued in any
+commutative algebra over the ground field is unipotent.
+
+Thus the particular algebraic closure used in
+`geometricallyUnipotentPointsCommHopfAlgProperty` does not affect the property. -/
+theorem isUnipotentPoint
+    {A : _root_.CommHopfAlgCat.{v} k} [Algebra.FiniteType k A] [IsReduced A]
+    (hA : geometricallyUnipotentPointsCommHopfAlgProperty k A)
+    {L : Type w} [CommRing L] [Algebra k L]
+    (g : WithConv (A →ₐ[k] L)) : HopfAlgebra.IsUnipotentPoint g := by
+  rw [HopfAlgebra.isUnipotentPoint_def]
+  intro M
+  let b := Module.Free.chooseBasis k M
+  exact isUnipotent_pointsAction_of_coefficientMatrix_charpoly_eq M g b
+    (coefficientMatrix_charpoly_eq hA M b)
 
 /-- Geometric unipotence descends along an injective morphism of coordinate Hopf algebras whose
 codomain is reduced and finite type.
@@ -181,30 +190,7 @@ theorem of_injective_of_reduced (f : H ⟶ K) (hf : Function.Injective f.hom)
     congr 1
     ext x
     exact (f.hom.toAlgHom.commutes x).symm
-  -- Evaluating the reflected identity proves the required statement at an arbitrary target point.
-  have hgcharpoly :
-      (Comodule.endOfPoint M g.ofConv).charpoly =
-        P.map (algebraMap k (AlgebraicClosure k)) := by
-    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv)
-      (b.baseChange (AlgebraicClosure k)), Comodule.toMatrix_endOfPoint]
-    -- Expose the local name for the target coefficient matrix before applying `charpoly_map`.
-    change (C.map g.ofConv).charpoly = _
-    calc
-      (C.map g.ofConv).charpoly = C.charpoly.map g.ofConv.toRingHom :=
-        Matrix.charpoly_map C g.ofConv.toRingHom
-      _ = _ := by
-        rw [hCcharpoly, Polynomial.map_map]
-        congr 1
-        ext x
-        exact g.ofConv.commutes x
-  apply LinearMap.GeneralLinearGroup.isUnipotent_of_charpoly_eq (n := d)
-  have hcoe :
-      ((LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
-        Module.End _ _) =
-          Comodule.endOfPoint M g.ofConv :=
-    Comodule.pointsAction_toLinearMap M g
-  rw [hcoe]
-  exact hgcharpoly.trans (by simp [P])
+  exact isUnipotent_pointsAction_of_coefficientMatrix_charpoly_eq M g b hCcharpoly
 
 end geometricallyUnipotentPointsCommHopfAlgProperty
 
@@ -213,11 +199,11 @@ namespace smoothUnipotentCommHopfAlgProperty
 variable {k : Type u} [Field k]
 variable {A : FiniteTypeCommHopfAlgCat.{u, v} k}
 
-/-- Every point of a smooth geometrically unipotent affine group valued in an extension field of
-the ground field is unipotent. -/
+/-- Every point of a smooth geometrically unipotent affine group valued in a commutative algebra
+over the ground field is unipotent. -/
 theorem isUnipotentPoint
     (hA : smoothUnipotentCommHopfAlgProperty k A)
-    {L : Type w} [Field L] [Algebra k L]
+    {L : Type w} [CommRing L] [Algebra k L]
     (g : WithConv (A →ₐ[k] L)) : HopfAlgebra.IsUnipotentPoint g := by
   have hA' := (smoothUnipotentCommHopfAlgProperty_iff k A).mp hA
   let _ : Algebra.Smooth k A := hA'.1

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
-import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Naturality
 import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.PointAction
 import TauCeti.RingTheory.FiniteType.PointSeparation
@@ -129,7 +128,8 @@ private theorem isUnipotent_pointsAction_of_coefficientMatrix_charpoly_eq
         congr 1
         rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M e) (b.baseChange A),
           Comodule.toMatrix_endOfPoint]
-        congr 1
+        exact congrArg Matrix.charpoly (by
+          simpa only [e, AlgHom.coe_id] using Matrix.map_id C)
       _ = _ := by
         rw [hCcharpoly, Polynomial.map_map]
         congr 1

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -257,12 +257,13 @@ theorem iff_smooth_and_forall_isUnipotentPoint
       (A := A.obj) L).mp
         ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k A.obj).mpr hA'.2)
   · rintro ⟨hsm, hL⟩
+    let _ : Algebra.Smooth k A := hsm
+    let _ : IsReduced A := isReduced_of_smooth_of_field k A
     rw [smoothUnipotentCommHopfAlgProperty_iff]
     refine ⟨hsm, ?_⟩
-    intro g
-    let φ : AlgebraicClosure k →ₐ[k] L := IsAlgClosed.lift
-    exact (HopfAlgebra.isUnipotentPoint_mapValue_iff_of_injective g φ φ.injective).mp
-      (hL (AlgHom.mapValue (H := A) φ g))
+    exact (geometricallyUnipotentPointsCommHopfAlgProperty_iff k A.obj).mp
+      ((geometricallyUnipotentPointsCommHopfAlgProperty.iff_forall_isUnipotentPoint
+        (A := A.obj) L).mpr hL)
 
 end smoothUnipotentCommHopfAlgProperty
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/PointAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/PointAction.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 public import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.Matrix
 public import TauCeti.Algebra.Coalgebra.Comodule.PointsAction
 public import TauCeti.LinearAlgebra.Matrix.Triangular
@@ -29,6 +30,8 @@ found on geometric points to an actual flag by subcomodules.
 
 * `TauCeti.Comodule.toMatrix_endOfPoint`: the matrix of a point action is the evaluated
   coefficient matrix.
+* `TauCeti.Comodule.charpoly_endOfPoint_comp`: characteristic polynomials of point actions
+  commute with scalar extension.
 * `TauCeti.Comodule.coefficientMatrix_isUpperTriangular_iff_forall_toMatrix_endOfPoint`:
   pointwise detection of upper triangularity.
 * `TauCeti.Comodule.coefficientMatrix_isUpperUnitriangular_iff_forall_toMatrix_endOfPoint`:
@@ -77,6 +80,30 @@ theorem toMatrix_endOfPoint (b : Basis i R M) (g : C →ₐ[R] A) :
   simp [Finsupp.single_apply]
 
 end Matrix
+
+section Charpoly
+
+variable {R : Type u} {C : Type v} {M : Type w} {i : Type y}
+variable [CommSemiring R] [Semiring C] [Algebra R C] [Coalgebra R C]
+variable [AddCommMonoid M] [Module R M] [Comodule R C M]
+variable [Finite i]
+
+/-- Composing a point with a morphism of value algebras maps the characteristic polynomial of
+its action along that morphism. -/
+theorem charpoly_endOfPoint_comp [Module.Free R M] [Module.Finite R M]
+    {B D : Type*} [CommRing B] [Algebra R B]
+    [CommRing D] [Algebra R D] (b : Basis i R M) (g : C →ₐ[R] B) (f : B →ₐ[R] D) :
+    (endOfPoint M (f.comp g)).charpoly = (endOfPoint M g).charpoly.map f := by
+  classical
+  let _ := Fintype.ofFinite i
+  rw [← LinearMap.charpoly_toMatrix (endOfPoint M (f.comp g)) (b.baseChange D),
+    ← LinearMap.charpoly_toMatrix (endOfPoint M g) (b.baseChange B),
+    toMatrix_endOfPoint, toMatrix_endOfPoint, ← Matrix.charpoly_map, Matrix.map_map]
+  apply congrArg Matrix.charpoly
+  ext p q
+  simp [Matrix.map_apply]
+
+end Charpoly
 
 section PointSeparation
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/PointAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/PointAction.lean
@@ -83,19 +83,19 @@ end Matrix
 
 section Charpoly
 
-variable {R : Type u} {C : Type v} {M : Type w} {i : Type y}
+variable {R : Type u} {C : Type v} {M : Type w}
 variable [CommSemiring R] [Semiring C] [Algebra R C] [Coalgebra R C]
 variable [AddCommMonoid M] [Module R M] [Comodule R C M]
-variable [Finite i]
 
 /-- Composing a point with a morphism of value algebras maps the characteristic polynomial of
 its action along that morphism. -/
+@[simp]
 theorem charpoly_endOfPoint_comp [Module.Free R M] [Module.Finite R M]
     {B D : Type*} [CommRing B] [Algebra R B]
-    [CommRing D] [Algebra R D] (b : Basis i R M) (g : C →ₐ[R] B) (f : B →ₐ[R] D) :
+    [CommRing D] [Algebra R D] (g : C →ₐ[R] B) (f : B →ₐ[R] D) :
     (endOfPoint M (f.comp g)).charpoly = (endOfPoint M g).charpoly.map f := by
   classical
-  let _ := Fintype.ofFinite i
+  let b := Module.Free.chooseBasis R M
   rw [← LinearMap.charpoly_toMatrix (endOfPoint M (f.comp g)) (b.baseChange D),
     ← LinearMap.charpoly_toMatrix (endOfPoint M g) (b.baseChange B),
     toMatrix_endOfPoint, toMatrix_endOfPoint, ← Matrix.charpoly_map, Matrix.map_map]


### PR DESCRIPTION
This PR proves that geometric unipotence of a reduced finite-type commutative Hopf algebra can be evaluated on points valued in any algebraically closed extension of the ground field, rather than only the chosen `AlgebraicClosure`. It adds the smooth finite-type specialization, where smoothness supplies reducedness, and factors the existing injective-descent proof through the same universal characteristic-polynomial lemma.

The exact target is Layer 5, “Unipotent groups (correct, geometric definition),” of `TauCetiRoadmap/ReductiveGroups/README.md`. The milestone served is “solvable and unipotent groups; the unipotent radical”: scalar-extension comparison for the newly constructed `unipotentRadicalDefiningIdeal` must compare its geometric points across the two base fields, and `smoothUnipotentCommHopfAlgProperty.isUnipotentPoint_of_isAlgClosed` supplies the old-fibre side of that comparison.

This is the most effective current step because the unipotent radical and its maximality property are on `main`, the in-flight characteristic theorem explicitly leaves scalar-extension comparison next, and the existing geometric-unipotence API only exposed points over one chosen algebraic closure. After this PR, the milestone still needs coordinate-base-change invariance of geometric unipotence (including transport of a faithful representation to the extended coordinate Hopf algebra), then the resulting containment of the base-changed radical in the radical after base change and the perfect-field descent/equality theorem.

The proof uses reduced finite-type point separation to turn unipotence of all chosen-algebraic-closure points into a characteristic-polynomial identity for every universal coefficient matrix; evaluation transports that identity to an arbitrary algebraically closed extension. The private identity is also reused by `of_injective_of_reduced`, replacing its duplicated calculation. No Mathlib infrastructure or external formalization is vendored.

The change modifies `TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean` (233 lines total; +125/-51).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"unipotent-points-algebraically-closed-extension"}-->

🤖 Prepared with Codex
