### PR TITLE
feat: add Student's t distribution

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Beta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Beta.lean
@@ -307,12 +307,6 @@ theorem integrable_one_add_sq_rpow (hs : 1 / 2 < s) :
   simp only [Real.norm_eq_abs, sq_abs]
   ring_nf
 
-/-- The Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` is integrable on the positive half-line when
-`1 / 2 < s`. -/
-theorem integrableOn_one_add_sq_rpow_Ioi (hs : 1 / 2 < s) :
-    IntegrableOn (fun x : ℝ => (1 + x ^ 2) ^ (-s)) (Ioi 0) :=
-  (integrable_one_add_sq_rpow hs).integrableOn
-
 /-- The total mass of the Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` is `Β(1/2, s - 1/2)`. -/
 theorem integral_one_add_sq_rpow (hs : 1 / 2 < s) :
     ∫ x : ℝ, (1 + x ^ 2) ^ (-s) = beta (1 / 2) (s - 1 / 2) := by

--- a/TauCeti/Analysis/SpecialFunctions/Beta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Beta.lean
@@ -6,9 +6,11 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Probability.Distributions.Beta
+import Mathlib.MeasureTheory.Function.JacobianOneDim
+import Mathlib.MeasureTheory.Measure.Lebesgue.Integral
 
 /-!
-# Euler's beta integral, in real-valued interval form
+# Euler's beta integrals, in real-valued form
 
 Mathlib defines Euler's beta function `ProbabilityTheory.beta` by the Gamma quotient, and proves
 that it is the value of `Complex.betaIntegral`, the complex-valued interval integral of
@@ -19,9 +21,15 @@ integral over `[0, 1]`, the derivative of the kernel `t ^ a * (1 - t) ^ b` it pr
 the splitting of the integrand that raises the second parameter by one. Two parameter identities
 for `Β` itself — symmetry and the unit step in the first parameter — are recorded alongside.
 
+It also records Euler's *second* beta integral, the half-line form
+`∫ x in Ioi 0, x ^ (a - 1) * (1 + x) ^ (-(a + b)) = Β(a, b)`, together with its integrability
+statement, and specialises it to the Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` on the whole line.
+
 These are the analytic prerequisites of
-`TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean`, and
-`TauCeti/Probability/Distributions/Beta/Basic.lean` uses the beta integral for its moment formula.
+`TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean`;
+`TauCeti/Probability/Distributions/Beta/Basic.lean` uses the beta integral for its moment formula,
+and `TauCeti/Probability/Distributions/StudentT.lean` normalizes its density with the
+`(1 + x ^ 2) ^ (-s)` form of the second integral.
 
 ## Main results
 
@@ -32,6 +40,12 @@ These are the analytic prerequisites of
 * `TauCeti.hasDerivAt_rpow_mul_one_sub_rpow` — the derivative of `t ^ a * (1 - t) ^ b`;
 * `TauCeti.integral_rpow_mul_one_sub_rpow_add_one_right` — raising the second parameter by one
   splits the integral as a difference;
+* `TauCeti.integrableOn_rpow_mul_one_add_rpow` and `TauCeti.integral_rpow_mul_one_add_rpow` —
+  Euler's second beta integral,
+  `∫ x in Ioi 0, x ^ (a - 1) * (1 + x) ^ (-(a + b)) = Β(a, b)`;
+* `TauCeti.integrable_one_add_sq_rpow` and `TauCeti.integral_one_add_sq_rpow` — the Cauchy-type
+  kernel `(1 + x ^ 2) ^ (-s)` is integrable on the line for `1 / 2 < s`, with total mass
+  `Β(1 / 2, s - 1 / 2)`;
 * `ProbabilityTheory.beta_comm` — symmetry of `Β`;
 * `ProbabilityTheory.beta_one_right` — the value `Β(a, 1) = 1 / a`;
 * `ProbabilityTheory.beta_add_one_left` — the unit step `Β(a + 1, b) = a / (a + b) * Β(a, b)`.
@@ -47,10 +61,18 @@ the right half from the left one by the reflection `t ↦ 1 - t`. The proof of
 `ProbabilityTheory.betaMeasure` in Mathlib, `ProbabilityTheory.lintegral_betaPDF_eq_one`:
 descend from `Complex.betaIntegral` by taking real parts.
 
+Both halves of the second integral are one-dimensional changes of variables, run through
+`MeasureTheory.integral_image_eq_integral_abs_deriv_smul` and its integrability companion. The
+chart `u ↦ u / (1 - u)` carries `(0, 1)` onto `(0, ∞)` and turns the first integrand into the
+second; the chart `t ↦ √t` carries `(0, ∞)` onto itself and turns `(1 + x ^ 2) ^ (-s)` into the
+second integrand with first parameter `1 / 2`. The two halves of the line are folded together by
+`MeasureTheory.integral_comp_abs`, whose reflection argument is reused for integrability below
+`0`.
+
 ## References
 
 * Tau Ceti roadmap, `StandardDistributions`, Layer 2, "Regularized incomplete beta", for which
-  these are the prerequisites.
+  these are the prerequisites, and Layer 3, **Student's t**, which needs the second integral.
 * [NIST Digital Library of Mathematical Functions, §5.12](https://dlmf.nist.gov/5.12).
 -/
 
@@ -147,6 +169,175 @@ theorem integral_rpow_mul_one_sub_rpow_add_one_right (ha : 0 < a) (hb : 0 < b)
   · have h1t : (0 : ℝ) < 1 - t := by linarith
     rw [Real.rpow_sub_one ht0.ne' a, Real.rpow_sub_one h1t.ne' b]
     field_simp
+
+/-! ### Euler's second beta integral -/
+
+section SecondIntegral
+
+variable {s : ℝ}
+
+/-- The chart `u ↦ u / (1 - u)` carries the open unit interval onto the positive half-line. -/
+private lemma image_div_one_sub : (fun u : ℝ => u / (1 - u)) '' Ioo 0 1 = Ioi 0 := by
+  ext x
+  constructor
+  · rintro ⟨u, ⟨hu0, hu1⟩, rfl⟩
+    exact div_pos hu0 (by linarith)
+  · intro hx
+    rw [mem_Ioi] at hx
+    have h1 : (0 : ℝ) < 1 + x := by linarith
+    refine ⟨x / (1 + x), ⟨by positivity, ?_⟩, ?_⟩
+    · rw [div_lt_one h1]
+      linarith
+    · change x / (1 + x) / (1 - x / (1 + x)) = x
+      rw [show (1 : ℝ) - x / (1 + x) = (1 + x)⁻¹ by field_simp; ring]
+      field_simp
+
+/-- The chart `u ↦ u / (1 - u)` is injective on the open unit interval. -/
+private lemma injOn_div_one_sub : InjOn (fun u : ℝ => u / (1 - u)) (Ioo (0 : ℝ) 1) := by
+  intro u hu v hv huv
+  have h1 : (0 : ℝ) < 1 - u := by linarith [hu.2]
+  have h2 : (0 : ℝ) < 1 - v := by linarith [hv.2]
+  rw [show (fun u : ℝ => u / (1 - u)) u = u / (1 - u) from rfl,
+    show (fun u : ℝ => u / (1 - u)) v = v / (1 - v) from rfl,
+    div_eq_div_iff h1.ne' h2.ne'] at huv
+  nlinarith
+
+/-- The derivative of the chart `u ↦ u / (1 - u)`. -/
+private lemma hasDerivAt_div_one_sub {u : ℝ} (hu : u ≠ 1) :
+    HasDerivAt (fun t : ℝ => t / (1 - t)) ((1 - u) ^ 2)⁻¹ u := by
+  have h : (1 : ℝ) - u ≠ 0 := sub_ne_zero_of_ne (Ne.symm hu)
+  have hd : HasDerivAt (fun t : ℝ => 1 - t) (-1) u := by
+    simpa using (hasDerivAt_id u).const_sub (1 : ℝ)
+  refine ((hasDerivAt_id' (x := u)).div hd h).congr_deriv ?_
+  rw [show (1 : ℝ) * (1 - u) - u * -1 = 1 by ring, one_div]
+
+/-- Under the chart `u ↦ u / (1 - u)` the integrand of Euler's second beta integral becomes the
+integrand of Euler's first one. -/
+private lemma abs_deriv_smul_one_add_rpow (a b : ℝ) {u : ℝ} (hu : u ∈ Ioo (0 : ℝ) 1) :
+    |((1 - u) ^ 2)⁻¹| • ((u / (1 - u)) ^ (a - 1) * (1 + u / (1 - u)) ^ (-(a + b))) =
+      u ^ (a - 1) * (1 - u) ^ (b - 1) := by
+  obtain ⟨hu0, hu1⟩ := hu
+  have h1u : (0 : ℝ) < 1 - u := by linarith
+  have hbase : (1 : ℝ) + u / (1 - u) = (1 - u)⁻¹ := by field_simp; ring
+  have e1 : ((1 - u) ^ (2 : ℕ))⁻¹ = (1 - u) ^ (-2 : ℝ) := by
+    rw [show (-2 : ℝ) = -(2 : ℕ) by norm_num, Real.rpow_neg h1u.le, Real.rpow_natCast]
+  have e2 : ((1 - u)⁻¹) ^ (-(a + b)) = (1 - u) ^ (a + b) := by
+    rw [Real.inv_rpow h1u.le, ← Real.rpow_neg h1u.le, neg_neg]
+  have e3 : (1 - u) ^ (-2 : ℝ) * (((1 - u) ^ (a - 1))⁻¹ * (1 - u) ^ (a + b)) =
+      (1 - u) ^ (b - 1) := by
+    rw [← Real.rpow_neg h1u.le, ← Real.rpow_add h1u, ← Real.rpow_add h1u]
+    congr 1
+    ring
+  rw [smul_eq_mul, abs_of_nonneg (by positivity), hbase, Real.div_rpow hu0.le h1u.le, e1, e2,
+    div_eq_mul_inv]
+  calc (1 - u) ^ (-2 : ℝ) * (u ^ (a - 1) * ((1 - u) ^ (a - 1))⁻¹ * (1 - u) ^ (a + b))
+      = u ^ (a - 1) *
+        ((1 - u) ^ (-2 : ℝ) * (((1 - u) ^ (a - 1))⁻¹ * (1 - u) ^ (a + b))) := by ring
+    _ = u ^ (a - 1) * (1 - u) ^ (b - 1) := by rw [e3]
+
+/-- The integrand of Euler's second beta integral is integrable on the positive half-line
+whenever both parameters are positive. -/
+theorem integrableOn_rpow_mul_one_add_rpow (ha : 0 < a) (hb : 0 < b) :
+    IntegrableOn (fun x : ℝ => x ^ (a - 1) * (1 + x) ^ (-(a + b))) (Ioi 0) := by
+  have hIoo : IntegrableOn (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) (Ioo 0 1) := by
+    refine IntegrableOn.mono_set ?_ Ioo_subset_Ioc_self
+    exact (intervalIntegrable_iff_integrableOn_Ioc_of_le (zero_le_one : (0 : ℝ) ≤ 1)).mp
+      (intervalIntegrable_rpow_mul_one_sub_rpow ha hb ⟨le_rfl, zero_le_one⟩
+        ⟨zero_le_one, le_rfl⟩)
+  rw [← image_div_one_sub,
+    integrableOn_image_iff_integrableOn_abs_deriv_smul measurableSet_Ioo
+      (fun u hu => (hasDerivAt_div_one_sub (ne_of_lt hu.2)).hasDerivWithinAt) injOn_div_one_sub]
+  exact hIoo.congr_fun (fun u hu => (abs_deriv_smul_one_add_rpow a b hu).symm) measurableSet_Ioo
+
+/-- **Euler's second beta integral**: for positive parameters the integral of
+`x ^ (a - 1) * (1 + x) ^ (-(a + b))` over the positive half-line is `Β(a, b)`. -/
+theorem integral_rpow_mul_one_add_rpow (ha : 0 < a) (hb : 0 < b) :
+    ∫ x in Ioi (0 : ℝ), x ^ (a - 1) * (1 + x) ^ (-(a + b)) = beta a b := by
+  rw [← image_div_one_sub,
+    integral_image_eq_integral_abs_deriv_smul measurableSet_Ioo
+      (fun u hu => (hasDerivAt_div_one_sub (ne_of_lt hu.2)).hasDerivWithinAt) injOn_div_one_sub,
+    setIntegral_congr_fun measurableSet_Ioo (fun u hu => abs_deriv_smul_one_add_rpow a b hu),
+    ← integral_rpow_mul_one_sub_rpow ha hb,
+    intervalIntegral.integral_of_le (zero_le_one : (0 : ℝ) ≤ 1)]
+  exact setIntegral_congr_set Ioo_ae_eq_Ioc
+
+/-! ### The Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` -/
+
+/-- The square root carries the positive half-line onto itself. -/
+private lemma image_sqrt_Ioi : Real.sqrt '' Ioi 0 = Ioi 0 := by
+  ext x
+  constructor
+  · rintro ⟨t, ht, rfl⟩
+    exact Real.sqrt_pos.mpr ht
+  · intro hx
+    exact ⟨x ^ 2, mem_Ioi.mpr (pow_pos (mem_Ioi.mp hx) 2), Real.sqrt_sq (mem_Ioi.mp hx).le⟩
+
+/-- The square root is injective on the positive half-line. -/
+private lemma injOn_sqrt_Ioi : InjOn Real.sqrt (Ioi 0) := by
+  intro u hu v hv huv
+  have := congrArg (· ^ 2) huv
+  simpa [Real.sq_sqrt (mem_Ioi.mp hu).le, Real.sq_sqrt (mem_Ioi.mp hv).le] using this
+
+/-- Under the square root the kernel `(1 + x ^ 2) ^ (-s)` becomes the integrand of Euler's second
+beta integral with first parameter `1 / 2`. -/
+private lemma abs_deriv_sqrt_smul (s : ℝ) {t : ℝ} (ht : t ∈ Ioi (0 : ℝ)) :
+    |1 / (2 * Real.sqrt t)| • ((1 + Real.sqrt t ^ 2) ^ (-s)) =
+      2⁻¹ * (t ^ (-(1 / 2) : ℝ) * (1 + t) ^ (-s)) := by
+  have ht0 : (0 : ℝ) < t := ht
+  have hst : (0 : ℝ) < Real.sqrt t := Real.sqrt_pos.mpr ht0
+  have hpow : t ^ (-(1 / 2) : ℝ) = (Real.sqrt t)⁻¹ := by
+    rw [Real.rpow_neg ht0.le, Real.sqrt_eq_rpow]
+  rw [smul_eq_mul, Real.sq_sqrt ht0.le, abs_of_nonneg (by positivity), hpow]
+  field_simp
+
+/-- The Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` is integrable on the positive half-line when
+`1 / 2 < s`. -/
+theorem integrableOn_one_add_sq_rpow_Ioi (hs : 1 / 2 < s) :
+    IntegrableOn (fun x : ℝ => (1 + x ^ 2) ^ (-s)) (Ioi 0) := by
+  have hb : (0 : ℝ) < s - 1 / 2 := by linarith
+  have hbp := integrableOn_rpow_mul_one_add_rpow (a := 1 / 2) (b := s - 1 / 2) (by norm_num) hb
+  rw [show (1 / 2 : ℝ) + (s - 1 / 2) = s by ring, show (1 / 2 : ℝ) - 1 = -(1 / 2) by norm_num]
+    at hbp
+  rw [← image_sqrt_Ioi,
+    integrableOn_image_iff_integrableOn_abs_deriv_smul measurableSet_Ioi
+      (fun t ht => (Real.hasDerivAt_sqrt (ne_of_gt (mem_Ioi.mp ht))).hasDerivWithinAt)
+      injOn_sqrt_Ioi]
+  refine IntegrableOn.congr_fun (hbp.const_mul 2⁻¹) ?_ measurableSet_Ioi
+  intro t ht
+  exact (abs_deriv_sqrt_smul s ht).symm
+
+/-- The Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` is integrable on the line when `1 / 2 < s`. -/
+theorem integrable_one_add_sq_rpow (hs : 1 / 2 < s) :
+    Integrable (fun x : ℝ => (1 + x ^ 2) ^ (-s)) := by
+  have hIoi := integrableOn_one_add_sq_rpow_Ioi hs
+  have hIic : IntegrableOn (fun x : ℝ => (1 + x ^ 2) ^ (-s)) (Iic 0) := by
+    have m : MeasurableEmbedding fun x : ℝ => -x := (Homeomorph.neg ℝ).measurableEmbedding
+    rw [← Measure.map_neg_eq_self (volume : Measure ℝ), m.integrableOn_map_iff]
+    simp only [Function.comp_def, neg_sq, neg_preimage, neg_Iic, neg_zero]
+    exact Iff.mpr integrableOn_Ici_iff_integrableOn_Ioi hIoi
+  rw [← integrableOn_univ, ← Iic_union_Ioi (a := (0 : ℝ))]
+  exact hIic.union hIoi
+
+/-- The total mass of the Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` is `Β(1/2, s - 1/2)`. -/
+theorem integral_one_add_sq_rpow (hs : 1 / 2 < s) :
+    ∫ x : ℝ, (1 + x ^ 2) ^ (-s) = beta (1 / 2) (s - 1 / 2) := by
+  have hb : (0 : ℝ) < s - 1 / 2 := by linarith
+  have hbp := integral_rpow_mul_one_add_rpow (a := 1 / 2) (b := s - 1 / 2) (by norm_num) hb
+  rw [show (1 / 2 : ℝ) + (s - 1 / 2) = s by ring, show (1 / 2 : ℝ) - 1 = -(1 / 2) by norm_num]
+    at hbp
+  have habs : ∫ x : ℝ, (1 + x ^ 2) ^ (-s) = 2 * ∫ x in Ioi (0 : ℝ), (1 + x ^ 2) ^ (-s) := by
+    have h := integral_comp_abs (f := fun y : ℝ => (1 + y ^ 2) ^ (-s))
+    simp only [sq_abs] at h
+    exact h
+  rw [habs, ← image_sqrt_Ioi,
+    integral_image_eq_integral_abs_deriv_smul measurableSet_Ioi
+      (fun t ht => (Real.hasDerivAt_sqrt (ne_of_gt (mem_Ioi.mp ht))).hasDerivWithinAt)
+      injOn_sqrt_Ioi,
+    setIntegral_congr_fun measurableSet_Ioi (fun t ht => abs_deriv_sqrt_smul s ht),
+    integral_const_mul, hbp]
+  ring
+
+end SecondIntegral
 
 end TauCeti
 

--- a/TauCeti/Analysis/SpecialFunctions/Beta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Beta.lean
@@ -188,18 +188,20 @@ private lemma image_div_one_sub : (fun u : ℝ => u / (1 - u)) '' Ioo 0 1 = Ioi 
     refine ⟨x / (1 + x), ⟨by positivity, ?_⟩, ?_⟩
     · rw [div_lt_one h1]
       linarith
-    · change x / (1 + x) / (1 - x / (1 + x)) = x
-      rw [show (1 : ℝ) - x / (1 + x) = (1 + x)⁻¹ by field_simp; ring]
-      field_simp
+    · have hden : (1 : ℝ) - x / (1 + x) = (1 + x)⁻¹ := by
+        field_simp
+        ring
+      have himage : x / (1 + x) / (1 - x / (1 + x)) = x := by
+        rw [hden]
+        field_simp
+      exact himage
 
 /-- The chart `u ↦ u / (1 - u)` is injective on the open unit interval. -/
 private lemma injOn_div_one_sub : InjOn (fun u : ℝ => u / (1 - u)) (Ioo (0 : ℝ) 1) := by
   intro u hu v hv huv
   have h1 : (0 : ℝ) < 1 - u := by linarith [hu.2]
   have h2 : (0 : ℝ) < 1 - v := by linarith [hv.2]
-  rw [show (fun u : ℝ => u / (1 - u)) u = u / (1 - u) from rfl,
-    show (fun u : ℝ => u / (1 - u)) v = v / (1 - v) from rfl,
-    div_eq_div_iff h1.ne' h2.ne'] at huv
+  rw [div_eq_div_iff h1.ne' h2.ne'] at huv
   nlinarith
 
 /-- The derivative of the chart `u ↦ u / (1 - u)`. -/
@@ -209,7 +211,8 @@ private lemma hasDerivAt_div_one_sub {u : ℝ} (hu : u ≠ 1) :
   have hd : HasDerivAt (fun t : ℝ => 1 - t) (-1) u := by
     simpa using (hasDerivAt_id u).const_sub (1 : ℝ)
   refine ((hasDerivAt_id' (x := u)).div hd h).congr_deriv ?_
-  rw [show (1 : ℝ) * (1 - u) - u * -1 = 1 by ring, one_div]
+  have hnum : (1 : ℝ) * (1 - u) - u * -1 = 1 := by ring
+  rw [hnum, one_div]
 
 /-- Under the chart `u ↦ u / (1 - u)` the integrand of Euler's second beta integral becomes the
 integrand of Euler's first one. -/
@@ -220,7 +223,8 @@ private lemma abs_deriv_smul_one_add_rpow (a b : ℝ) {u : ℝ} (hu : u ∈ Ioo 
   have h1u : (0 : ℝ) < 1 - u := by linarith
   have hbase : (1 : ℝ) + u / (1 - u) = (1 - u)⁻¹ := by field_simp; ring
   have e1 : ((1 - u) ^ (2 : ℕ))⁻¹ = (1 - u) ^ (-2 : ℝ) := by
-    rw [show (-2 : ℝ) = -(2 : ℕ) by norm_num, Real.rpow_neg h1u.le, Real.rpow_natCast]
+    have hneg : (-2 : ℝ) = -(2 : ℕ) := by norm_num
+    rw [hneg, Real.rpow_neg h1u.le, Real.rpow_natCast]
   have e2 : ((1 - u)⁻¹) ^ (-(a + b)) = (1 - u) ^ (a + b) := by
     rw [Real.inv_rpow h1u.le, ← Real.rpow_neg h1u.le, neg_neg]
   have e3 : (1 - u) ^ (-2 : ℝ) * (((1 - u) ^ (a - 1))⁻¹ * (1 - u) ^ (a + b)) =
@@ -296,8 +300,9 @@ theorem integrableOn_one_add_sq_rpow_Ioi (hs : 1 / 2 < s) :
     IntegrableOn (fun x : ℝ => (1 + x ^ 2) ^ (-s)) (Ioi 0) := by
   have hb : (0 : ℝ) < s - 1 / 2 := by linarith
   have hbp := integrableOn_rpow_mul_one_add_rpow (a := 1 / 2) (b := s - 1 / 2) (by norm_num) hb
-  rw [show (1 / 2 : ℝ) + (s - 1 / 2) = s by ring, show (1 / 2 : ℝ) - 1 = -(1 / 2) by norm_num]
-    at hbp
+  have hsum : (1 / 2 : ℝ) + (s - 1 / 2) = s := by ring
+  have hsub : (1 / 2 : ℝ) - 1 = -(1 / 2) := by norm_num
+  rw [hsum, hsub] at hbp
   rw [← image_sqrt_Ioi,
     integrableOn_image_iff_integrableOn_abs_deriv_smul measurableSet_Ioi
       (fun t ht => (Real.hasDerivAt_sqrt (ne_of_gt (mem_Ioi.mp ht))).hasDerivWithinAt)
@@ -323,8 +328,9 @@ theorem integral_one_add_sq_rpow (hs : 1 / 2 < s) :
     ∫ x : ℝ, (1 + x ^ 2) ^ (-s) = beta (1 / 2) (s - 1 / 2) := by
   have hb : (0 : ℝ) < s - 1 / 2 := by linarith
   have hbp := integral_rpow_mul_one_add_rpow (a := 1 / 2) (b := s - 1 / 2) (by norm_num) hb
-  rw [show (1 / 2 : ℝ) + (s - 1 / 2) = s by ring, show (1 / 2 : ℝ) - 1 = -(1 / 2) by norm_num]
-    at hbp
+  have hsum : (1 / 2 : ℝ) + (s - 1 / 2) = s := by ring
+  have hsub : (1 / 2 : ℝ) - 1 = -(1 / 2) := by norm_num
+  rw [hsum, hsub] at hbp
   have habs : ∫ x : ℝ, (1 + x ^ 2) ^ (-s) = 2 * ∫ x in Ioi (0 : ℝ), (1 + x ^ 2) ^ (-s) := by
     have h := integral_comp_abs (f := fun y : ℝ => (1 + y ^ 2) ^ (-s))
     simp only [sq_abs] at h

--- a/TauCeti/Analysis/SpecialFunctions/Beta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Beta.lean
@@ -43,9 +43,10 @@ and `TauCeti/Probability/Distributions/StudentT.lean` normalizes its density wit
 * `TauCeti.integrableOn_rpow_mul_one_add_rpow` and `TauCeti.integral_rpow_mul_one_add_rpow` —
   Euler's second beta integral,
   `∫ x in Ioi 0, x ^ (a - 1) * (1 + x) ^ (-(a + b)) = Β(a, b)`;
-* `TauCeti.integrable_one_add_sq_rpow` and `TauCeti.integral_one_add_sq_rpow` — the Cauchy-type
-  kernel `(1 + x ^ 2) ^ (-s)` is integrable on the line for `1 / 2 < s`, with total mass
-  `Β(1 / 2, s - 1 / 2)`;
+* `TauCeti.integrable_one_add_sq_rpow`, `TauCeti.integral_one_add_sq_rpow`,
+  `TauCeti.integrable_one_add_sq_div_rpow`, and `TauCeti.integral_one_add_sq_div_rpow` — the
+  Cauchy-type kernel `(1 + x ^ 2 / ν) ^ (-s)` is integrable on the line for `0 < ν` and
+  `1 / 2 < s`, with total mass `√ν * Β(1 / 2, s - 1 / 2)`;
 * `ProbabilityTheory.beta_comm` — symmetry of `Β`;
 * `ProbabilityTheory.beta_one_right` — the value `Β(a, 1) = 1 / a`;
 * `ProbabilityTheory.beta_add_one_left` — the unit step `Β(a + 1, b) = a / (a + b) * Β(a, b)`.
@@ -61,13 +62,13 @@ the right half from the left one by the reflection `t ↦ 1 - t`. The proof of
 `ProbabilityTheory.betaMeasure` in Mathlib, `ProbabilityTheory.lintegral_betaPDF_eq_one`:
 descend from `Complex.betaIntegral` by taking real parts.
 
-Both halves of the second integral are one-dimensional changes of variables, run through
+Both changes of variables for the second integral are one-dimensional, run through
 `MeasureTheory.integral_image_eq_integral_abs_deriv_smul` and its integrability companion. The
 chart `u ↦ u / (1 - u)` carries `(0, 1)` onto `(0, ∞)` and turns the first integrand into the
 second; the chart `t ↦ √t` carries `(0, ∞)` onto itself and turns `(1 + x ^ 2) ^ (-s)` into the
-second integrand with first parameter `1 / 2`. The two halves of the line are folded together by
-`MeasureTheory.integral_comp_abs`, whose reflection argument is reused for integrability below
-`0`.
+second integrand with first parameter `1 / 2`. Full-line integrability is an instance of Mathlib's
+`integrable_rpow_neg_one_add_norm_sq`, and the integral value folds the two halves of the line
+together with `MeasureTheory.integral_comp_abs`.
 
 ## References
 
@@ -294,34 +295,23 @@ private lemma abs_deriv_sqrt_smul (s : ℝ) {t : ℝ} (ht : t ∈ Ioi (0 : ℝ))
   rw [smul_eq_mul, Real.sq_sqrt ht0.le, abs_of_nonneg (by positivity), hpow]
   field_simp
 
-/-- The Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` is integrable on the positive half-line when
-`1 / 2 < s`. -/
-theorem integrableOn_one_add_sq_rpow_Ioi (hs : 1 / 2 < s) :
-    IntegrableOn (fun x : ℝ => (1 + x ^ 2) ^ (-s)) (Ioi 0) := by
-  have hb : (0 : ℝ) < s - 1 / 2 := by linarith
-  have hbp := integrableOn_rpow_mul_one_add_rpow (a := 1 / 2) (b := s - 1 / 2) (by norm_num) hb
-  have hsum : (1 / 2 : ℝ) + (s - 1 / 2) = s := by ring
-  have hsub : (1 / 2 : ℝ) - 1 = -(1 / 2) := by norm_num
-  rw [hsum, hsub] at hbp
-  rw [← image_sqrt_Ioi,
-    integrableOn_image_iff_integrableOn_abs_deriv_smul measurableSet_Ioi
-      (fun t ht => (Real.hasDerivAt_sqrt (ne_of_gt (mem_Ioi.mp ht))).hasDerivWithinAt)
-      injOn_sqrt_Ioi]
-  refine IntegrableOn.congr_fun (hbp.const_mul 2⁻¹) ?_ measurableSet_Ioi
-  intro t ht
-  exact (abs_deriv_sqrt_smul s ht).symm
-
 /-- The Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` is integrable on the line when `1 / 2 < s`. -/
 theorem integrable_one_add_sq_rpow (hs : 1 / 2 < s) :
     Integrable (fun x : ℝ => (1 + x ^ 2) ^ (-s)) := by
-  have hIoi := integrableOn_one_add_sq_rpow_Ioi hs
-  have hIic : IntegrableOn (fun x : ℝ => (1 + x ^ 2) ^ (-s)) (Iic 0) := by
-    have m : MeasurableEmbedding fun x : ℝ => -x := (Homeomorph.neg ℝ).measurableEmbedding
-    rw [← Measure.map_neg_eq_self (volume : Measure ℝ), m.integrableOn_map_iff]
-    simp only [Function.comp_def, neg_sq, neg_preimage, neg_Iic, neg_zero]
-    exact Iff.mpr integrableOn_Ici_iff_integrableOn_Ioi hIoi
-  rw [← integrableOn_univ, ← Iic_union_Ioi (a := (0 : ℝ))]
-  exact hIic.union hIoi
+  have hrs : (Module.finrank ℝ ℝ : ℝ) < 2 * s := by
+    simp only [Module.finrank_self]
+    norm_num at hs ⊢
+    linarith
+  convert integrable_rpow_neg_one_add_norm_sq (E := ℝ) (μ := volume) hrs using 1
+  funext x
+  simp only [Real.norm_eq_abs, sq_abs]
+  ring_nf
+
+/-- The Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` is integrable on the positive half-line when
+`1 / 2 < s`. -/
+theorem integrableOn_one_add_sq_rpow_Ioi (hs : 1 / 2 < s) :
+    IntegrableOn (fun x : ℝ => (1 + x ^ 2) ^ (-s)) (Ioi 0) :=
+  (integrable_one_add_sq_rpow hs).integrableOn
 
 /-- The total mass of the Cauchy-type kernel `(1 + x ^ 2) ^ (-s)` is `Β(1/2, s - 1/2)`. -/
 theorem integral_one_add_sq_rpow (hs : 1 / 2 < s) :
@@ -342,6 +332,27 @@ theorem integral_one_add_sq_rpow (hs : 1 / 2 < s) :
     setIntegral_congr_fun measurableSet_Ioi (fun t ht => abs_deriv_sqrt_smul s ht),
     integral_const_mul, hbp]
   ring
+
+/-- Rescaling by `√ν` turns `(1 + x ^ 2 / ν) ^ (-s)` into the Cauchy-type kernel. -/
+private lemma one_add_sq_div_eq {ν : ℝ} (hν : 0 < ν) (s x : ℝ) :
+    (1 + ((√ν)⁻¹ * x) ^ 2) ^ (-s) = (1 + x ^ 2 / ν) ^ (-s) := by
+  rw [mul_pow, inv_pow, Real.sq_sqrt hν.le, inv_mul_eq_div]
+
+/-- The rescaled Cauchy-type kernel is integrable on the line. -/
+theorem integrable_one_add_sq_div_rpow {ν s : ℝ} (hν : 0 < ν) (hs : 1 / 2 < s) :
+    Integrable fun x : ℝ => (1 + x ^ 2 / ν) ^ (-s) := by
+  have hsν : (√ν)⁻¹ ≠ 0 := inv_ne_zero (Real.sqrt_pos.mpr hν).ne'
+  have h := (integrable_comp_mul_left_iff
+    (fun y : ℝ => (1 + y ^ 2) ^ (-s)) hsν).mpr (integrable_one_add_sq_rpow hs)
+  simpa only [one_add_sq_div_eq hν] using h
+
+/-- **The total mass of a rescaled Cauchy-type kernel.** Rescaling by `√ν` reduces it to
+Euler's second beta integral. -/
+theorem integral_one_add_sq_div_rpow {ν s : ℝ} (hν : 0 < ν) (hs : 1 / 2 < s) :
+    ∫ x : ℝ, (1 + x ^ 2 / ν) ^ (-s) = √ν * beta (1 / 2) (s - 1 / 2) := by
+  have h := Measure.integral_comp_inv_mul_left (fun y : ℝ => (1 + y ^ 2) ^ (-s)) √ν
+  simp only [one_add_sq_div_eq hν, abs_of_nonneg (Real.sqrt_nonneg ν), smul_eq_mul] at h
+  rw [h, integral_one_add_sq_rpow hs]
 
 end SecondIntegral
 

--- a/TauCeti/Probability/Distributions/StudentT.lean
+++ b/TauCeti/Probability/Distributions/StudentT.lean
@@ -168,38 +168,6 @@ theorem measurable_studentTPDFReal (ν : ℝ) : Measurable (studentTPDFReal ν) 
 theorem measurable_studentTPDF (ν : ℝ) : Measurable (studentTPDF ν) :=
   (measurable_studentTPDFReal ν).ennreal_ofReal
 
-/-! ### Normalization -/
-
-/-- Rescaling by `√ν` turns the Student t kernel into the Cauchy-type kernel of
-`TauCeti.integral_one_add_sq_rpow`. -/
-private lemma one_add_sq_div_eq (hν : 0 < ν) (s x : ℝ) :
-    (1 + ((√ν)⁻¹ * x) ^ 2) ^ (-s) = (1 + x ^ 2 / ν) ^ (-s) := by
-  rw [mul_pow, inv_pow, Real.sq_sqrt hν.le, inv_mul_eq_div]
-
-/-- The Student t kernel is integrable on the line. -/
-theorem integrable_one_add_sq_div_rpow (hν : 0 < ν) :
-    Integrable fun x : ℝ => (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) := by
-  have hs : (1 : ℝ) / 2 < (ν + 1) / 2 := by linarith
-  have hsν : (√ν)⁻¹ ≠ 0 := inv_ne_zero (Real.sqrt_pos.mpr hν).ne'
-  have h := (integrable_comp_mul_left_iff
-    (fun y : ℝ => (1 + y ^ 2) ^ (-((ν + 1) / 2))) hsν).mpr (integrable_one_add_sq_rpow hs)
-  simpa only [one_add_sq_div_eq hν] using h
-
-/-- **The total mass of the Student t kernel.** Rescaling by `√ν` reduces it to Euler's second
-beta integral. -/
-theorem integral_one_add_sq_div_rpow (hν : 0 < ν) :
-    ∫ x : ℝ, (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) =
-      √(ν * π) * Real.Gamma (ν / 2) / Real.Gamma ((ν + 1) / 2) := by
-  have hs : (1 : ℝ) / 2 < (ν + 1) / 2 := by linarith
-  have h := Measure.integral_comp_inv_mul_left
-    (fun y : ℝ => (1 + y ^ 2) ^ (-((ν + 1) / 2))) √ν
-  simp only [one_add_sq_div_eq hν, abs_of_nonneg (Real.sqrt_nonneg ν), smul_eq_mul] at h
-  have hsub : (ν + 1) / 2 - 1 / 2 = ν / 2 := by ring
-  have hsum : (1 : ℝ) / 2 + ν / 2 = (ν + 1) / 2 := by ring
-  rw [h, integral_one_add_sq_rpow hs, hsub, ProbabilityTheory.beta,
-    Real.Gamma_one_half_eq, hsum, Real.sqrt_mul hν.le]
-  ring
-
 /-! ### The measure and its total mass -/
 
 /-- Student's t probability measure with `ν` degrees of freedom.
@@ -221,7 +189,8 @@ theorem studentTMeasure_of_nonpos (hν : ν ≤ 0) : studentTMeasure ν = 0 := b
 /-- The Student t density is integrable on the whole line for every parameter. -/
 theorem integrable_studentTPDFReal (ν : ℝ) : Integrable (studentTPDFReal ν) := by
   by_cases hν : 0 < ν
-  · have h := (integrable_one_add_sq_div_rpow hν).const_mul
+  · have hs : (1 : ℝ) / 2 < (ν + 1) / 2 := by linarith
+    have h := (integrable_one_add_sq_div_rpow hν hs).const_mul
       (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)))
     exact (integrable_congr (ae_of_all _ fun y => studentTPDFReal_of_pos hν y)).mpr h
   · have h : studentTPDFReal ν = fun _ => (0 : ℝ) :=
@@ -231,11 +200,15 @@ theorem integrable_studentTPDFReal (ν : ℝ) : Integrable (studentTPDFReal ν) 
 
 /-- The Student t density integrates to `1`. -/
 theorem integral_studentTPDFReal (hν : 0 < ν) : ∫ x, studentTPDFReal ν x = 1 := by
+  have hs : (1 : ℝ) / 2 < (ν + 1) / 2 := by linarith
   have hG1 : Real.Gamma ((ν + 1) / 2) ≠ 0 := (Real.Gamma_pos_of_pos (by linarith)).ne'
   have hG2 : Real.Gamma (ν / 2) ≠ 0 := (Real.Gamma_pos_of_pos (by linarith)).ne'
   have hsq : √(ν * π) ≠ 0 := (Real.sqrt_pos.mpr (by positivity)).ne'
+  have hsub : (ν + 1) / 2 - 1 / 2 = ν / 2 := by ring
+  have hsum : (1 : ℝ) / 2 + ν / 2 = (ν + 1) / 2 := by ring
   simp_rw [studentTPDFReal_of_pos hν]
-  rw [integral_const_mul, integral_one_add_sq_div_rpow hν]
+  rw [integral_const_mul, integral_one_add_sq_div_rpow hν hs, hsub, ProbabilityTheory.beta,
+    Real.Gamma_one_half_eq, hsum, Real.sqrt_mul hν.le]
   field_simp
 
 /-- The `ℝ≥0∞`-valued Student t density has total mass `1`. -/

--- a/TauCeti/Probability/Distributions/StudentT.lean
+++ b/TauCeti/Probability/Distributions/StudentT.lean
@@ -5,8 +5,9 @@ Authors: Claude
 -/
 module
 
-public import TauCeti.Analysis.SpecialFunctions.Beta
+import TauCeti.Analysis.SpecialFunctions.Beta
 public import TauCeti.Probability.Density
+public import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
 public import Mathlib.Probability.Distributions.Cauchy
 import TauCeti.Analysis.SpecialFunctions.Gamma
 import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
@@ -86,11 +87,6 @@ def studentTPDFReal (ν x : ℝ) : ℝ :=
 def studentTPDF (ν x : ℝ) : ℝ≥0∞ :=
   ENNReal.ofReal (studentTPDFReal ν x)
 
-/-- The `ℝ≥0∞`-valued Student t density is the coercion of the real-valued one. -/
-theorem studentTPDF_eq_ofReal (ν x : ℝ) :
-    studentTPDF ν x = ENNReal.ofReal (studentTPDFReal ν x) := by
-  rw [studentTPDF]
-
 /-- Outside the valid parameter range the density vanishes. -/
 @[simp]
 theorem studentTPDFReal_of_nonpos (hν : ν ≤ 0) (x : ℝ) : studentTPDFReal ν x = 0 := by
@@ -104,10 +100,19 @@ theorem studentTPDFReal_of_pos (hν : 0 < ν) (x : ℝ) :
         (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) := by
   rw [studentTPDFReal, ite_eq_left hν]
 
+/-- For a positive number of degrees of freedom the `ℝ≥0∞`-valued density is the Student t
+formula. -/
+@[simp]
+theorem studentTPDF_of_pos (hν : 0 < ν) (x : ℝ) :
+    studentTPDF ν x = ENNReal.ofReal
+      (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)) *
+        (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) := by
+  rw [studentTPDF, studentTPDFReal_of_pos hν]
+
 /-- Outside the valid parameter range the `ℝ≥0∞`-valued density vanishes. -/
 @[simp]
 theorem studentTPDF_of_nonpos (hν : ν ≤ 0) (x : ℝ) : studentTPDF ν x = 0 := by
-  rw [studentTPDF_eq_ofReal, studentTPDFReal_of_nonpos hν, ENNReal.ofReal_zero]
+  rw [studentTPDF, studentTPDFReal_of_nonpos hν, ENNReal.ofReal_zero]
 
 /-- The normalizing constant of Student's t law is positive. -/
 theorem studentT_const_pos (hν : 0 < ν) :
@@ -140,7 +145,7 @@ theorem studentTPDFReal_neg (ν x : ℝ) : studentTPDFReal ν (-x) = studentTPDF
 /-- The `ℝ≥0∞`-valued Student t density is even in the sample point. -/
 @[simp]
 theorem studentTPDF_neg (ν x : ℝ) : studentTPDF ν (-x) = studentTPDF ν x := by
-  rw [studentTPDF_eq_ofReal, studentTPDF_eq_ofReal, studentTPDFReal_neg]
+  rw [studentTPDF, studentTPDF, studentTPDFReal_neg]
 
 /-- The real-valued Student t density is measurable. -/
 @[fun_prop]
@@ -189,9 +194,10 @@ theorem integral_one_add_sq_div_rpow (hν : 0 < ν) :
   have h := Measure.integral_comp_inv_mul_left
     (fun y : ℝ => (1 + y ^ 2) ^ (-((ν + 1) / 2))) √ν
   simp only [one_add_sq_div_eq hν, abs_of_nonneg (Real.sqrt_nonneg ν), smul_eq_mul] at h
-  rw [h, integral_one_add_sq_rpow hs, show (ν + 1) / 2 - 1 / 2 = ν / 2 by ring,
-    ProbabilityTheory.beta, Real.Gamma_one_half_eq, show (1 : ℝ) / 2 + ν / 2 = (ν + 1) / 2 by ring,
-    Real.sqrt_mul hν.le]
+  have hsub : (ν + 1) / 2 - 1 / 2 = ν / 2 := by ring
+  have hsum : (1 : ℝ) / 2 + ν / 2 = (ν + 1) / 2 := by ring
+  rw [h, integral_one_add_sq_rpow hs, hsub, ProbabilityTheory.beta,
+    Real.Gamma_one_half_eq, hsum, Real.sqrt_mul hν.le]
   ring
 
 /-! ### The measure and its total mass -/
@@ -203,11 +209,6 @@ For `ν ≤ 0` this is the zero measure, not a probability measure; see
 def studentTMeasure (ν : ℝ) : Measure ℝ :=
   volume.withDensity (studentTPDF ν)
 
-/-- The defining presentation of Student's t law as a `MeasureTheory.Measure.withDensity`. -/
-theorem studentTMeasure_eq_withDensity (ν : ℝ) :
-    studentTMeasure ν = volume.withDensity (studentTPDF ν) := by
-  rw [studentTMeasure]
-
 /-- Outside the valid parameter range Student's t law is the zero measure. -/
 @[simp]
 theorem studentTMeasure_of_nonpos (hν : ν ≤ 0) : studentTMeasure ν = 0 := by
@@ -215,7 +216,7 @@ theorem studentTMeasure_of_nonpos (hν : ν ≤ 0) : studentTMeasure ν = 0 := b
     funext y
     rw [studentTPDF_of_nonpos hν]
     rfl
-  rw [studentTMeasure_eq_withDensity, h, withDensity_zero]
+  rw [studentTMeasure, h, withDensity_zero]
 
 /-- The Student t density is integrable on the whole line for every parameter. -/
 theorem integrable_studentTPDFReal (ν : ℝ) : Integrable (studentTPDFReal ν) := by
@@ -239,7 +240,7 @@ theorem integral_studentTPDFReal (hν : 0 < ν) : ∫ x, studentTPDFReal ν x = 
 
 /-- The `ℝ≥0∞`-valued Student t density has total mass `1`. -/
 theorem lintegral_studentTPDF_eq_one (hν : 0 < ν) : ∫⁻ x, studentTPDF ν x = 1 := by
-  simp_rw [studentTPDF_eq_ofReal]
+  simp_rw [studentTPDF]
   rw [← ofReal_integral_eq_lintegral_ofReal (integrable_studentTPDFReal ν)
       (ae_of_all _ fun y => studentTPDFReal_nonneg ν y),
     integral_studentTPDFReal hν, ENNReal.ofReal_one]
@@ -248,7 +249,7 @@ theorem lintegral_studentTPDF_eq_one (hν : 0 < ν) : ∫⁻ x, studentTPDF ν x
 theorem isProbabilityMeasure_studentTMeasure (hν : 0 < ν) :
     IsProbabilityMeasure (studentTMeasure ν) := by
   constructor
-  rw [studentTMeasure_eq_withDensity, withDensity_apply _ MeasurableSet.univ,
+  rw [studentTMeasure, withDensity_apply _ MeasurableSet.univ,
     Measure.restrict_univ, lintegral_studentTPDF_eq_one hν]
 
 /-! ### Absolute continuity -/
@@ -278,7 +279,7 @@ theorem studentTMeasure_map_neg (ν : ℝ) :
     (studentTMeasure ν).map (fun x => -x) = studentTMeasure ν := by
   refine Measure.ext fun t ht => ?_
   have hpre : MeasurableSet ((fun x : ℝ => -x) ⁻¹' t) := ht.preimage measurable_neg
-  rw [Measure.map_apply measurable_neg ht, studentTMeasure_eq_withDensity,
+  rw [Measure.map_apply measurable_neg ht, studentTMeasure,
     withDensity_apply _ hpre, withDensity_apply _ ht]
   have h := (Measure.measurePreserving_neg (volume : Measure ℝ)).setLIntegral_comp_preimage_emb
     (Homeomorph.neg ℝ).measurableEmbedding (studentTPDF ν) t
@@ -298,10 +299,10 @@ theorem studentTPDFReal_one (x : ℝ) : studentTPDFReal 1 x = cauchyPDFReal 0 1 
 
 /-- **Student's t law with one degree of freedom is the standard Cauchy law.** -/
 theorem studentTMeasure_one : studentTMeasure 1 = cauchyMeasure 0 1 := by
-  rw [studentTMeasure_eq_withDensity, cauchyMeasure_of_scale_ne_zero 0 one_ne_zero]
+  rw [studentTMeasure, cauchyMeasure_of_scale_ne_zero 0 one_ne_zero]
   congr 1
   funext x
-  rw [studentTPDF_eq_ofReal, studentTPDFReal_one, cauchyPDF]
+  rw [studentTPDF, studentTPDFReal_one, cauchyPDF]
 
 /-! ### Parameter measurability -/
 
@@ -314,7 +315,7 @@ theorem measurable_uncurry_studentTPDF :
         Real.Gamma ((q.1 + 1) / 2) / (√(q.1 * π) * Real.Gamma (q.1 / 2)) *
           Real.exp (Real.log (1 + q.2 ^ 2 / q.1) * (-((q.1 + 1) / 2))) else 0) := by
     funext q
-    rw [studentTPDF_eq_ofReal, studentTPDFReal]
+    rw [studentTPDF, studentTPDFReal]
     split_ifs with h
     · rw [Real.rpow_def_of_pos (by positivity)]
     · rfl

--- a/TauCeti/Probability/Distributions/StudentT.lean
+++ b/TauCeti/Probability/Distributions/StudentT.lean
@@ -1,0 +1,339 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Analysis.SpecialFunctions.Beta
+public import TauCeti.Probability.Density
+public import Mathlib.Probability.Distributions.Cauchy
+import TauCeti.Analysis.SpecialFunctions.Gamma
+import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
+
+/-!
+# Student's t distribution
+
+Student's t law with `ν` degrees of freedom is the symmetric law on the line with density
+proportional to `(1 + x ^ 2 / ν) ^ (-(ν + 1) / 2)`. This file defines it, proves that it is a
+probability measure for `0 < ν`, identifies it as a `MeasureTheory.HasPDF` law with that density,
+records its reflection symmetry, and identifies the one degree of freedom member of the family
+with the standard Cauchy law.
+
+**Boundary.** The number of degrees of freedom must be positive for the density to normalize, so
+both `studentTPDFReal` and `studentTMeasure` are *defined* to vanish for `ν ≤ 0`
+(`studentTMeasure_of_nonpos`); every formula describing the probability law carries `0 < ν` as a
+hypothesis.
+
+## Main definitions
+
+* `TauCeti.Probability.studentTPDFReal` — the real-valued density;
+* `TauCeti.Probability.studentTPDF` — its `ℝ≥0∞`-valued companion;
+* `TauCeti.Probability.studentTMeasure` — the law, as `volume.withDensity studentTPDF`.
+
+## Main results
+
+* `isProbabilityMeasure_studentTMeasure` — it is a probability measure when `0 < ν`;
+* `hasPDF_of_hasLaw_studentTMeasure`, `pdf_eq_studentTPDF_of_hasLaw_studentTMeasure` and
+  `rnDeriv_studentTMeasure` — the `HasPDF` bridge, the density, and the Radon–Nikodym derivative;
+* `studentTMeasure_map_neg` — the law is invariant under reflection in the origin;
+* `studentTMeasure_one` — one degree of freedom gives the standard Cauchy law
+  `ProbabilityTheory.cauchyMeasure 0 1`;
+* `measurable_studentTMeasure` — the family is measurable in its parameter, so it can be used as a
+  kernel.
+
+## Implementation
+
+The whole analytic content is the normalization. Scaling by `√ν` with
+`MeasureTheory.integral_comp_mul_left` reduces the total mass of `(1 + x ^ 2 / ν) ^ (-(ν + 1) / 2)`
+to that of the Cauchy-type kernel `(1 + x ^ 2) ^ (-(ν + 1) / 2)`, which is
+`TauCeti.integral_one_add_sq_rpow`: the value `Β(1 / 2, ν / 2)` of Euler's second beta integral.
+Writing that value as a quotient of Gamma values cancels the normalizing constant exactly.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 3, the **Student's t** target.
+* N. L. Johnson, S. Kotz, N. Balakrishnan, *Continuous Univariate Distributions*, vol. 2, 2nd ed.,
+  Wiley (1995), ch. 28.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory Set
+
+open scoped ENNReal Real
+
+namespace TauCeti
+
+namespace Probability
+
+variable {ν x : ℝ}
+
+/-! ### The density -/
+
+/-- The density of Student's t law with `ν` degrees of freedom, as a real-valued function.
+
+For `ν ≤ 0` there is no such law and the density is `0`. -/
+def studentTPDFReal (ν x : ℝ) : ℝ :=
+  if 0 < ν then
+    Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)) *
+      (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))
+  else 0
+
+/-- The density of Student's t law, as a function valued in `ℝ≥0∞`. -/
+def studentTPDF (ν x : ℝ) : ℝ≥0∞ :=
+  ENNReal.ofReal (studentTPDFReal ν x)
+
+/-- The `ℝ≥0∞`-valued Student t density is the coercion of the real-valued one. -/
+theorem studentTPDF_eq_ofReal (ν x : ℝ) :
+    studentTPDF ν x = ENNReal.ofReal (studentTPDFReal ν x) := by
+  rw [studentTPDF]
+
+/-- Outside the valid parameter range the density vanishes. -/
+@[simp]
+theorem studentTPDFReal_of_nonpos (hν : ν ≤ 0) (x : ℝ) : studentTPDFReal ν x = 0 := by
+  rw [studentTPDFReal, ite_eq_right (not_lt.mpr hν)]
+
+/-- For a positive number of degrees of freedom the density is the Student t formula. -/
+@[simp]
+theorem studentTPDFReal_of_pos (hν : 0 < ν) (x : ℝ) :
+    studentTPDFReal ν x =
+      Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)) *
+        (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) := by
+  rw [studentTPDFReal, ite_eq_left hν]
+
+/-- Outside the valid parameter range the `ℝ≥0∞`-valued density vanishes. -/
+@[simp]
+theorem studentTPDF_of_nonpos (hν : ν ≤ 0) (x : ℝ) : studentTPDF ν x = 0 := by
+  rw [studentTPDF_eq_ofReal, studentTPDFReal_of_nonpos hν, ENNReal.ofReal_zero]
+
+/-- The normalizing constant of Student's t law is positive. -/
+theorem studentT_const_pos (hν : 0 < ν) :
+    0 < Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)) :=
+  div_pos (Real.Gamma_pos_of_pos (by linarith))
+    (mul_pos (Real.sqrt_pos.mpr (by positivity)) (Real.Gamma_pos_of_pos (by linarith)))
+
+/-- For a positive number of degrees of freedom the density is strictly positive everywhere: the
+Student t law has no vanishing tail. -/
+theorem studentTPDFReal_pos (hν : 0 < ν) (x : ℝ) : 0 < studentTPDFReal ν x := by
+  rw [studentTPDFReal_of_pos hν]
+  exact mul_pos (studentT_const_pos hν) (Real.rpow_pos_of_pos (by positivity) _)
+
+/-- The Student t density is nonnegative at every parameter, valid or not. -/
+theorem studentTPDFReal_nonneg (ν x : ℝ) : 0 ≤ studentTPDFReal ν x := by
+  rcases lt_or_ge 0 ν with hν | hν
+  · exact (studentTPDFReal_pos hν x).le
+  · rw [studentTPDFReal_of_nonpos hν]
+
+/-- The two Student t densities agree under `ENNReal.toReal`; the density is never infinite. -/
+@[simp]
+theorem toReal_studentTPDF (ν x : ℝ) : (studentTPDF ν x).toReal = studentTPDFReal ν x :=
+  ENNReal.toReal_ofReal (studentTPDFReal_nonneg ν x)
+
+/-- The Student t density is even in the sample point. -/
+@[simp]
+theorem studentTPDFReal_neg (ν x : ℝ) : studentTPDFReal ν (-x) = studentTPDFReal ν x := by
+  rw [studentTPDFReal, studentTPDFReal, neg_sq]
+
+/-- The `ℝ≥0∞`-valued Student t density is even in the sample point. -/
+@[simp]
+theorem studentTPDF_neg (ν x : ℝ) : studentTPDF ν (-x) = studentTPDF ν x := by
+  rw [studentTPDF_eq_ofReal, studentTPDF_eq_ofReal, studentTPDFReal_neg]
+
+/-- The real-valued Student t density is measurable. -/
+@[fun_prop]
+theorem measurable_studentTPDFReal (ν : ℝ) : Measurable (studentTPDFReal ν) := by
+  by_cases hν : 0 < ν
+  · have h : studentTPDFReal ν = fun y =>
+        Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)) *
+          Real.exp (Real.log (1 + y ^ 2 / ν) * (-((ν + 1) / 2))) := by
+      funext y
+      rw [studentTPDFReal_of_pos hν, Real.rpow_def_of_pos (by positivity)]
+    rw [h]
+    fun_prop
+  · have h : studentTPDFReal ν = fun _ => (0 : ℝ) :=
+      funext fun y => studentTPDFReal_of_nonpos (not_lt.mp hν) y
+    rw [h]
+    exact measurable_const
+
+/-- The `ℝ≥0∞`-valued Student t density is measurable. -/
+@[fun_prop]
+theorem measurable_studentTPDF (ν : ℝ) : Measurable (studentTPDF ν) :=
+  (measurable_studentTPDFReal ν).ennreal_ofReal
+
+/-! ### Normalization -/
+
+/-- Rescaling by `√ν` turns the Student t kernel into the Cauchy-type kernel of
+`TauCeti.integral_one_add_sq_rpow`. -/
+private lemma one_add_sq_div_eq (hν : 0 < ν) (s x : ℝ) :
+    (1 + ((√ν)⁻¹ * x) ^ 2) ^ (-s) = (1 + x ^ 2 / ν) ^ (-s) := by
+  rw [mul_pow, inv_pow, Real.sq_sqrt hν.le, inv_mul_eq_div]
+
+/-- The Student t kernel is integrable on the line. -/
+theorem integrable_one_add_sq_div_rpow (hν : 0 < ν) :
+    Integrable fun x : ℝ => (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) := by
+  have hs : (1 : ℝ) / 2 < (ν + 1) / 2 := by linarith
+  have hsν : (√ν)⁻¹ ≠ 0 := inv_ne_zero (Real.sqrt_pos.mpr hν).ne'
+  have h := (integrable_comp_mul_left_iff
+    (fun y : ℝ => (1 + y ^ 2) ^ (-((ν + 1) / 2))) hsν).mpr (integrable_one_add_sq_rpow hs)
+  simpa only [one_add_sq_div_eq hν] using h
+
+/-- **The total mass of the Student t kernel.** Rescaling by `√ν` reduces it to Euler's second
+beta integral. -/
+theorem integral_one_add_sq_div_rpow (hν : 0 < ν) :
+    ∫ x : ℝ, (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) =
+      √(ν * π) * Real.Gamma (ν / 2) / Real.Gamma ((ν + 1) / 2) := by
+  have hs : (1 : ℝ) / 2 < (ν + 1) / 2 := by linarith
+  have h := Measure.integral_comp_inv_mul_left
+    (fun y : ℝ => (1 + y ^ 2) ^ (-((ν + 1) / 2))) √ν
+  simp only [one_add_sq_div_eq hν, abs_of_nonneg (Real.sqrt_nonneg ν), smul_eq_mul] at h
+  rw [h, integral_one_add_sq_rpow hs, show (ν + 1) / 2 - 1 / 2 = ν / 2 by ring,
+    ProbabilityTheory.beta, Real.Gamma_one_half_eq, show (1 : ℝ) / 2 + ν / 2 = (ν + 1) / 2 by ring,
+    Real.sqrt_mul hν.le]
+  ring
+
+/-! ### The measure and its total mass -/
+
+/-- Student's t probability measure with `ν` degrees of freedom.
+
+For `ν ≤ 0` this is the zero measure, not a probability measure; see
+`studentTMeasure_of_nonpos`. -/
+def studentTMeasure (ν : ℝ) : Measure ℝ :=
+  volume.withDensity (studentTPDF ν)
+
+/-- The defining presentation of Student's t law as a `MeasureTheory.Measure.withDensity`. -/
+theorem studentTMeasure_eq_withDensity (ν : ℝ) :
+    studentTMeasure ν = volume.withDensity (studentTPDF ν) := by
+  rw [studentTMeasure]
+
+/-- Outside the valid parameter range Student's t law is the zero measure. -/
+@[simp]
+theorem studentTMeasure_of_nonpos (hν : ν ≤ 0) : studentTMeasure ν = 0 := by
+  have h : studentTPDF ν = 0 := by
+    funext y
+    rw [studentTPDF_of_nonpos hν]
+    rfl
+  rw [studentTMeasure_eq_withDensity, h, withDensity_zero]
+
+/-- The Student t density is integrable on the whole line for every parameter. -/
+theorem integrable_studentTPDFReal (ν : ℝ) : Integrable (studentTPDFReal ν) := by
+  by_cases hν : 0 < ν
+  · have h := (integrable_one_add_sq_div_rpow hν).const_mul
+      (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)))
+    exact (integrable_congr (ae_of_all _ fun y => studentTPDFReal_of_pos hν y)).mpr h
+  · have h : studentTPDFReal ν = fun _ => (0 : ℝ) :=
+      funext fun y => studentTPDFReal_of_nonpos (not_lt.mp hν) y
+    rw [h]
+    exact integrable_zero ℝ ℝ volume
+
+/-- The Student t density integrates to `1`. -/
+theorem integral_studentTPDFReal (hν : 0 < ν) : ∫ x, studentTPDFReal ν x = 1 := by
+  have hG1 : Real.Gamma ((ν + 1) / 2) ≠ 0 := (Real.Gamma_pos_of_pos (by linarith)).ne'
+  have hG2 : Real.Gamma (ν / 2) ≠ 0 := (Real.Gamma_pos_of_pos (by linarith)).ne'
+  have hsq : √(ν * π) ≠ 0 := (Real.sqrt_pos.mpr (by positivity)).ne'
+  simp_rw [studentTPDFReal_of_pos hν]
+  rw [integral_const_mul, integral_one_add_sq_div_rpow hν]
+  field_simp
+
+/-- The `ℝ≥0∞`-valued Student t density has total mass `1`. -/
+theorem lintegral_studentTPDF_eq_one (hν : 0 < ν) : ∫⁻ x, studentTPDF ν x = 1 := by
+  simp_rw [studentTPDF_eq_ofReal]
+  rw [← ofReal_integral_eq_lintegral_ofReal (integrable_studentTPDFReal ν)
+      (ae_of_all _ fun y => studentTPDFReal_nonneg ν y),
+    integral_studentTPDFReal hν, ENNReal.ofReal_one]
+
+/-- **For a positive number of degrees of freedom Student's t law is a probability measure.** -/
+theorem isProbabilityMeasure_studentTMeasure (hν : 0 < ν) :
+    IsProbabilityMeasure (studentTMeasure ν) := by
+  constructor
+  rw [studentTMeasure_eq_withDensity, withDensity_apply _ MeasurableSet.univ,
+    Measure.restrict_univ, lintegral_studentTPDF_eq_one hν]
+
+/-! ### Absolute continuity -/
+
+variable {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω} {X : Ω → ℝ}
+
+/-- A random variable with a Student t law has a density. -/
+theorem hasPDF_of_hasLaw_studentTMeasure (hX : HasLaw X (studentTMeasure ν) P) :
+    HasPDF X P volume :=
+  hasPDF_of_hasLaw_withDensity (measurable_studentTPDF ν).aemeasurable hX
+
+/-- The density of a Student t law is `studentTPDF`. -/
+theorem pdf_eq_studentTPDF_of_hasLaw_studentTMeasure (hX : HasLaw X (studentTMeasure ν) P) :
+    pdf X P volume =ᵐ[volume] studentTPDF ν :=
+  pdf_eq_of_hasLaw_withDensity (measurable_studentTPDF ν).aemeasurable hX
+
+/-- The Radon–Nikodym derivative of a Student t law against Lebesgue measure is `studentTPDF`. -/
+theorem rnDeriv_studentTMeasure (ν : ℝ) :
+    (studentTMeasure ν).rnDeriv volume =ᵐ[volume] studentTPDF ν :=
+  Measure.rnDeriv_withDensity volume (measurable_studentTPDF ν)
+
+/-! ### Symmetry -/
+
+/-- Student's t law is invariant under reflection in the origin: its density is even and Lebesgue
+measure is reflection invariant. -/
+theorem studentTMeasure_map_neg (ν : ℝ) :
+    (studentTMeasure ν).map (fun x => -x) = studentTMeasure ν := by
+  refine Measure.ext fun t ht => ?_
+  have hpre : MeasurableSet ((fun x : ℝ => -x) ⁻¹' t) := ht.preimage measurable_neg
+  rw [Measure.map_apply measurable_neg ht, studentTMeasure_eq_withDensity,
+    withDensity_apply _ hpre, withDensity_apply _ ht]
+  have h := (Measure.measurePreserving_neg (volume : Measure ℝ)).setLIntegral_comp_preimage_emb
+    (Homeomorph.neg ℝ).measurableEmbedding (studentTPDF ν) t
+  simpa only [studentTPDF_neg] using h
+
+/-! ### One degree of freedom -/
+
+/-- With one degree of freedom the Student t density is the standard Cauchy density. -/
+theorem studentTPDFReal_one (x : ℝ) : studentTPDFReal 1 x = cauchyPDFReal 0 1 x := by
+  have h1 : ((1 : ℝ) + 1) / 2 = 1 := by norm_num
+  rw [studentTPDFReal_of_pos one_pos, cauchyPDFReal, h1, Real.Gamma_one,
+    Real.sqrt_mul zero_le_one, Real.sqrt_one, one_mul, Real.Gamma_one_half_eq,
+    Real.rpow_neg_one, Real.mul_self_sqrt Real.pi_pos.le]
+  push_cast
+  rw [div_one, sub_zero, one_pow, add_comm (x ^ 2) 1]
+  ring
+
+/-- **Student's t law with one degree of freedom is the standard Cauchy law.** -/
+theorem studentTMeasure_one : studentTMeasure 1 = cauchyMeasure 0 1 := by
+  rw [studentTMeasure_eq_withDensity, cauchyMeasure_of_scale_ne_zero 0 one_ne_zero]
+  congr 1
+  funext x
+  rw [studentTPDF_eq_ofReal, studentTPDFReal_one, cauchyPDF]
+
+/-! ### Parameter measurability -/
+
+/-- The Student t density is jointly measurable in the degrees of freedom and the sample point. -/
+@[fun_prop]
+theorem measurable_uncurry_studentTPDF :
+    Measurable fun q : ℝ × ℝ => studentTPDF q.1 q.2 := by
+  have heq : (fun q : ℝ × ℝ => studentTPDF q.1 q.2) = fun q =>
+      ENNReal.ofReal (if 0 < q.1 then
+        Real.Gamma ((q.1 + 1) / 2) / (√(q.1 * π) * Real.Gamma (q.1 / 2)) *
+          Real.exp (Real.log (1 + q.2 ^ 2 / q.1) * (-((q.1 + 1) / 2))) else 0) := by
+    funext q
+    rw [studentTPDF_eq_ofReal, studentTPDFReal]
+    split_ifs with h
+    · rw [Real.rpow_def_of_pos (by positivity)]
+    · rfl
+  rw [heq]
+  refine (Measurable.ite ?_ ?_ measurable_const).ennreal_ofReal
+  · exact measurableSet_lt (measurable_const : Measurable fun _ : ℝ × ℝ => (0 : ℝ)) measurable_fst
+  · have hG1 : Measurable fun q : ℝ × ℝ => Real.Gamma ((q.1 + 1) / 2) :=
+      Real.measurable_Gamma.comp (by fun_prop)
+    have hG2 : Measurable fun q : ℝ × ℝ => Real.Gamma (q.1 / 2) :=
+      Real.measurable_Gamma.comp (by fun_prop)
+    have hsqrt : Measurable fun q : ℝ × ℝ => √(q.1 * π) :=
+      Real.continuous_sqrt.measurable.comp (by fun_prop)
+    exact (hG1.div (hsqrt.mul hG2)).mul (by fun_prop)
+
+/-- The Student t family is measurable in its degrees of freedom. -/
+@[fun_prop]
+theorem measurable_studentTMeasure : Measurable fun ν : ℝ => studentTMeasure ν :=
+  measurable_withDensity (μ := volume) measurable_uncurry_studentTPDF
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR defines Student's t distribution and proves that it is a probability measure. It adds
`TauCeti/Probability/Distributions/StudentT.lean` with `studentTPDFReal`, `studentTPDF` and
`studentTMeasure ν = volume.withDensity (studentTPDF ν)`, the density being the roadmap's
`Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)) * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))`
for `0 < ν` and `0` otherwise, and proves `isProbabilityMeasure_studentTMeasure`, the `HasPDF`
bridge and Radon–Nikodym derivative required of every family, reflection invariance
`studentTMeasure_map_neg`, the parameter measurability `measurable_studentTMeasure` that a kernel
consumer needs, and the roadmap's completion check `studentTMeasure_one : studentTMeasure 1 =
cauchyMeasure 0 1`.

The target is the **Student's t** entry of Layer 3 ("new scalar families") in
`TauCetiRoadmap/StandardDistributions/README.md`, whose key declaration `studentTMeasure` this
supplies; Layer 3 is the roadmap's live block, and Student's t was the last of its named families
with no file and no open PR. What remains for that entry after this PR: the mean `0` for `1 < ν`
and variance `ν / (ν - 2)` for `2 < ν` with the matching non-integrability results at `ν ≤ 1` and
`ν ≤ 2`, the cdf in terms of `regularizedIncompleteBeta (ν / 2) (1 / 2)`, and
`integrableExpSet id (studentTMeasure ν) = {0}`.

The whole analytic content is the normalization, and it needs Euler's *second* beta integral,
which neither Mathlib nor Tau Ceti had. That is added to the existing
`TauCeti/Analysis/SpecialFunctions/Beta.lean`, next to the first one it is derived from:
`integral_rpow_mul_one_add_rpow` proves
`∫ x in Ioi 0, x ^ (a - 1) * (1 + x) ^ (-(a + b)) = Β(a, b)` by pushing the chart
`u ↦ u / (1 - u)` from `(0, 1)` onto `(0, ∞)` through
`MeasureTheory.integral_image_eq_integral_abs_deriv_smul`, with
`integrableOn_rpow_mul_one_add_rpow` its integrability companion; the chart `t ↦ √t` then
specialises it to the Cauchy-type kernel, giving `integral_one_add_sq_rpow`
`∫ x : ℝ, (1 + x ^ 2) ^ (-s) = Β(1 / 2, s - 1 / 2)` for `1 / 2 < s` and
`integrable_one_add_sq_rpow`. Rescaling by `√ν` reduces the Student t kernel to that one, and the
Gamma quotient cancels the normalizing constant exactly. These four lemmas are stated for general
parameters because Layer 3's Fisher–Snedecor entry needs the half-line form and Layer 2's beta
material is their natural home.

Nothing is vendored. The proof of `integrable_one_add_sq_rpow` reuses the reflection argument of
Mathlib's `MeasureTheory.integral_comp_abs` — mapping `Iic 0` to `Ici 0` through
`Measure.map_neg_eq_self` and a measurable embedding — to transport integrability from the
positive half-line, and that reuse is recorded in the file's implementation notes. The
distributional API follows the shape of `TauCeti/Probability/Distributions/Laplace.lean`, and the
`HasPDF` bridge goes through `TauCeti.Probability.hasPDF_of_hasLaw_withDensity` rather than being
re-proved.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"studenttmeasure"}-->

🤖 Prepared with Claude Code
