### PR TITLE
refactor(DenseGraphLimits): name the cut norm's subtraction symmetry

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Stability.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Stability.lean
@@ -105,11 +105,7 @@ theorem abs_cutDist_sub_left_le_cutNorm (U U' : Graphon Ω₁ μ₁) (W : Grapho
   rw [abs_le]
   refine ⟨?_, cutDist_sub_le_cutNorm_left U U' W⟩
   have h := cutDist_sub_le_cutNorm_left U' U W
-  have hnorm :
-      cutNorm μ₁ (U'.toSymmKernel - U.toSymmKernel) =
-        cutNorm μ₁ (U.toSymmKernel - U'.toSymmKernel) := by
-    rw [← neg_sub, cutNorm_neg]
-  rw [hnorm] at h
+  rw [cutNorm_sub_comm] at h
   linarith
 
 /-- **Stability under replacement on the right carrier.**  If `W` and `W'` are graphons on the
@@ -158,13 +154,9 @@ theorem cutDist_le_add_two_mul_cutNorm_of_le_add (U : Graphon Ω₁ μ₁)
     (h : cutDist U X ≤ cutDist U W' + cutDist W' X) :
     cutDist U X ≤ cutDist U W + cutDist W X +
       2 * cutNorm μ₂ (W.toSymmKernel - W'.toSymmKernel) := by
-  have hnorm :
-      cutNorm μ₂ (W'.toSymmKernel - W.toSymmKernel) =
-        cutNorm μ₂ (W.toSymmKernel - W'.toSymmKernel) := by
-    rw [← neg_sub, cutNorm_neg]
   have hleft := abs_cutDist_sub_right_le_cutNorm U W' W
   have hright := abs_cutDist_sub_left_le_cutNorm W' W X
-  rw [hnorm] at hleft hright
+  rw [cutNorm_sub_comm] at hleft hright
   linarith [le_abs_self (cutDist U W' - cutDist U W),
     le_abs_self (cutDist W' X - cutDist W X)]
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Stability.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Stability.lean
@@ -105,7 +105,7 @@ theorem abs_cutDist_sub_left_le_cutNorm (U U' : Graphon Ω₁ μ₁) (W : Grapho
   rw [abs_le]
   refine ⟨?_, cutDist_sub_le_cutNorm_left U U' W⟩
   have h := cutDist_sub_le_cutNorm_left U' U W
-  rw [cutNorm_sub_comm] at h
+  rw [cutNorm_sub_rev] at h
   linarith
 
 /-- **Stability under replacement on the right carrier.**  If `W` and `W'` are graphons on the
@@ -156,7 +156,7 @@ theorem cutDist_le_add_two_mul_cutNorm_of_le_add (U : Graphon Ω₁ μ₁)
       2 * cutNorm μ₂ (W.toSymmKernel - W'.toSymmKernel) := by
   have hleft := abs_cutDist_sub_right_le_cutNorm U W' W
   have hright := abs_cutDist_sub_left_le_cutNorm W' W X
-  rw [cutNorm_sub_comm] at hleft hright
+  rw [cutNorm_sub_rev] at hleft hright
   linarith [le_abs_self (cutDist U W' - cutDist U W),
     le_abs_self (cutDist W' X - cutDist W X)]
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/CutNorm.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/CutNorm.lean
@@ -458,6 +458,13 @@ theorem cutNorm_neg (K : SymmKernel Ω μ) : cutNorm μ (-K) = cutNorm μ K := b
   rw [cutNorm_eq_cutNormSet, cutNormSet_def, cutNorm_eq_cutNormSet, cutNormSet_def]
   simp
 
+/-- The cut norm of a difference is symmetric in its two arguments: `‖K - L‖□ = ‖L - K‖□`.
+
+Deliberately not `@[simp]`: neither orientation is normal, so a rewrite rule here would loop. -/
+theorem cutNorm_sub_comm (K L : SymmKernel Ω μ) :
+    cutNorm μ (K - L) = cutNorm μ (L - K) := by
+  rw [← neg_sub L K, cutNorm_neg]
+
 /-- The cut norm satisfies the triangle inequality. -/
 theorem cutNorm_add_le (K L : SymmKernel Ω μ) :
     cutNorm μ (K + L) ≤ cutNorm μ K + cutNorm μ L := by

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/CutNorm.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/CutNorm.lean
@@ -458,10 +458,11 @@ theorem cutNorm_neg (K : SymmKernel Ω μ) : cutNorm μ (-K) = cutNorm μ K := b
   rw [cutNorm_eq_cutNormSet, cutNormSet_def, cutNorm_eq_cutNormSet, cutNormSet_def]
   simp
 
-/-- The cut norm of a difference is symmetric in its two arguments: `‖K - L‖□ = ‖L - K‖□`.
+/-- Reversing a difference does not change its cut norm: `‖K - L‖□ = ‖L - K‖□`.
 
-Deliberately not `@[simp]`: neither orientation is normal, so a rewrite rule here would loop. -/
-theorem cutNorm_sub_comm (K L : SymmKernel Ω μ) :
+Deliberately not `@[simp]`: neither argument order is a meaningful canonical form, so there is
+nothing for such a rule to normalize towards. -/
+theorem cutNorm_sub_rev (K L : SymmKernel Ω μ) :
     cutNorm μ (K - L) = cutNorm μ (L - K) := by
   rw [← neg_sub L K, cutNorm_neg]
 


### PR DESCRIPTION
`CutMetric/Stability.lean` derived `‖K - L‖□ = ‖L - K‖□` inline, twice, character for character:

```lean
have hnorm : cutNorm μ (W'.toSymmKernel - W.toSymmKernel)
    = cutNorm μ (W.toSymmKernel - W'.toSymmKernel) := by
  rw [← neg_sub, cutNorm_neg]
```

This adds the fact once, beside the evenness lemma it follows from, and uses it at both sites.

```lean
theorem cutNorm_sub_rev (K L : SymmKernel Ω μ) :
    cutNorm μ (K - L) = cutNorm μ (L - K)
```

Both consumers then reduce to a single `rw [cutNorm_sub_rev] at …`, one of them rewriting two hypotheses at once.

## Not `@[simp]`

Neither argument order of `K - L` is a meaningful canonical form, so there is nothing for such a rule to normalize towards. The docstring records that, since the surrounding seminorm laws — `cutNorm_zero`, `cutNorm_neg`, `cutNorm_smul` — *are* tagged, and the asymmetry would otherwise look like an oversight.

(An earlier revision said a `@[simp]` tag here would *loop*. That was wrong: Lean orders permutative rewrites rather than diverging on them. The reason to omit the tag is the absence of a canonical orientation, not nontermination.)

## Placement

Next to `cutNorm_neg`, which supplies its one-line proof, and before `cutNorm_add_le` / `cutNorm_sub_le`, so the seminorm laws stay contiguous.

## Roadmap

Roadmap: DenseGraphLimits

Improvement to existing code: one lemma added with two immediate consumers, and a derivation that appeared twice now appears once. No roadmap target is claimed.

🤖 Directed by Cameron Freer, drafted by Opus 5

