### PR TITLE
feat: assemble the E6(q) CFSG candidate

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean
@@ -38,8 +38,10 @@ pinned group; and its order is the superscript in the printed family name, recor
   the Steinberg map of a graph-twisted index composes with the field Frobenius.
 * `TauCeti.GraphTwistedIndex.twistOrder`: the order of that permutation, which is the superscript
   in the family name.
-* `TauCeti.TypeALieIndex.toGraphTwistedIndex`: the two type-A families, `Aₙ(q)` and `²Aₙ(q)`, as
-  indices of that subtype, so that the permutations above are attached to them.
+* `TauCeti.TypeALieIndex.toGraphTwistedIndex` and
+  `TauCeti.TypeE6LieIndex.toGraphTwistedIndex`: the two type-A families, `Aₙ(q)` and `²Aₙ(q)`, and
+  the untwisted family `E₆(q)`, as indices of that subtype, so that the permutations above are
+  attached to them.
 
 ## Main results
 
@@ -339,5 +341,27 @@ abbrev toGraphTwistedIndex (d : TypeALieIndex) : GraphTwistedIndex :=
   ⟨d.1, not_usesHalfFrobenius_of_isTypeA d.2⟩
 
 end TypeALieIndex
+
+/-! ### The untwisted family `E₆(q)` as graph-twisted indices -/
+
+namespace TypeE6LieIndex
+
+open LieTypeIndex (not_usesHalfFrobenius_of_isTypeE6)
+
+/-- The untwisted family `E₆(q)`, regarded as an ordinary-or-graph-twisted index. It uses no
+half-Frobenius, so it carries a diagram permutation, namely the identity. -/
+abbrev toGraphTwistedIndex (d : TypeE6LieIndex) : GraphTwistedIndex :=
+  ⟨d.1, not_usesHalfFrobenius_of_isTypeE6 d.2⟩
+
+/-- **The diagram permutation of the untwisted family `E₆(q)` is the identity**, which is what
+places it in the untwisted row of milestone L1's table, where the Steinberg map is `Frob_q`
+outright. The nontrivial symmetry of the `E₆` diagram belongs to `²E₆(q)`. -/
+@[simp]
+theorem diagramPerm_toGraphTwistedIndex (d : TypeE6LieIndex) :
+    d.toGraphTwistedIndex.diagramPerm = 1 := by
+  obtain ⟨q, rfl⟩ := d.exists_eq_of
+  exact GraphTwistedIndex.diagramPerm_E6 (LieTypeIndex.valid_E6 q)
+
+end TypeE6LieIndex
 
 end TauCeti

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
@@ -34,8 +34,9 @@ order `p ^ (2 * m + 1)`.
 * `TauCeti.LieTypeIndex` and `TauCeti.LieTypeIndex.Valid`: the Lie families and their preferred
   parameter range.
 * `TauCeti.ValidLieTypeIndex`, `TauCeti.SuzukiReeIndex`, `TauCeti.GraphTwistedIndex`,
-  `TauCeti.TypeALieIndex`, `TauCeti.SuzukiLieIndex`, and `TauCeti.UnimodularLieIndex`: the
-  restricted domains consumed by later carrier and endomorphism constructions.
+  `TauCeti.TypeALieIndex`, `TauCeti.TypeE6LieIndex`, `TauCeti.SuzukiLieIndex`, and
+  `TauCeti.UnimodularLieIndex`: the restricted domains consumed by later carrier and endomorphism
+  constructions.
 * `TauCeti.SporadicName`: the conventional twenty-six sporadic names.
 * `TauCeti.CFSGIndex`: cyclic, alternating, Lie-type, and sporadic entries in the classification
   list.
@@ -239,6 +240,36 @@ instance : DecidablePred IsTypeA := fun d => by
 theorem not_usesHalfFrobenius_of_isTypeA {d : LieTypeIndex} (h : d.IsTypeA) :
     ¬ d.UsesHalfFrobenius := by
   cases d <;> simp_all [usesHalfFrobenius_iff]
+
+/-- Whether a Lie-type index names the untwisted exceptional family `E₆(q)`.
+
+This is a constructor selector, not a mathematical property of a group. It is false on the
+graph-twisted family `²E₆(q)`, which shares the `E₆` diagram but takes a different Steinberg map,
+and it asserts no finiteness or simplicity. -/
+def IsTypeE6 : LieTypeIndex → Prop
+  | .E6 _ => True
+  | _ => False
+
+/-- Characterization of the untwisted type-`E₆` constructor. -/
+@[simp] theorem isTypeE6_iff (d : LieTypeIndex) : d.IsTypeE6 ↔
+    match d with
+    | .E6 _ => True
+    | _ => False :=
+  Iff.rfl
+
+instance : DecidablePred IsTypeE6 := fun d => by
+  cases d <;> rw [isTypeE6_iff] <;> infer_instance
+
+/-- The untwisted family `E₆(q)` does not use a half-Frobenius, so it carries a diagram
+automorphism. -/
+theorem not_usesHalfFrobenius_of_isTypeE6 {d : LieTypeIndex} (h : d.IsTypeE6) :
+    ¬ d.UsesHalfFrobenius := by
+  cases d <;> simp_all [usesHalfFrobenius_iff]
+
+/-- **Every `E₆(q)` index is valid.** The `E₆` row of `InStandardRange` is unrestricted, and no
+`E₆` parameter is a duplicate representative, so the family contributes one classification entry
+for each prime power. -/
+theorem valid_E6 (q : PrimePower) : (E6 q).Valid := by simp
 
 /-- Whether a Lie-type index names the Suzuki family `²B₂(2^(2m+1))`.
 
@@ -625,6 +656,14 @@ The outer subtype is important: a raw type-A constructor with an excluded rank o
 is not a `TypeALieIndex`. -/
 abbrev TypeALieIndex : Type _ := {d : ValidLieTypeIndex // d.1.IsTypeA}
 
+/-- A validated index in the untwisted exceptional family `E₆(q)`.
+
+Every `E₆(q)` is valid, by `TauCeti.LieTypeIndex.valid_E6`, so the outer subtype excludes nothing
+here; it is retained because the carrier-valued constructions of milestone L0 take
+`TauCeti.ValidLieTypeIndex`. The graph-twisted family `²E₆(q)`, which shares the diagram, is not of
+this subtype. -/
+abbrev TypeE6LieIndex : Type _ := {d : ValidLieTypeIndex // d.1.IsTypeE6}
+
 /-- A validated index in the Suzuki family `²B₂(2^(2m+1))`.
 
 The outer subtype is important: `²B₂(2)`, the parameter `m = 0`, is excluded from the
@@ -751,6 +790,38 @@ abbrev toSuzukiReeIndex (d : SuzukiLieIndex) : SuzukiReeIndex :=
   ⟨d.1, LieTypeIndex.usesHalfFrobenius_of_isSuzuki d.2⟩
 
 end SuzukiLieIndex
+
+/-! ## The untwisted family `E₆(q)`
+
+This section, like the Suzuki one above, follows `ValidLieTypeIndex` because `rank_eq_six` reads
+the numbered data `TauCeti.ValidLieTypeIndex.rank` defined there. -/
+
+namespace TypeE6LieIndex
+
+/-- Introduce the index `E₆(q)`. No validity hypothesis is taken: every `E₆` parameter is valid by
+`TauCeti.LieTypeIndex.valid_E6`. -/
+abbrev of (q : PrimePower) : TypeE6LieIndex :=
+  ⟨⟨.E6 q, LieTypeIndex.valid_E6 q⟩, (LieTypeIndex.isTypeE6_iff _).mpr trivial⟩
+
+/-- Every untwisted type-`E₆` index is of the introduction form. This is the eliminator matching
+`of`, so a consumer never repeats the case split over the other constructors. -/
+theorem exists_eq_of (d : TypeE6LieIndex) : ∃ q : PrimePower, d = of q := by
+  obtain ⟨⟨d, hvalid⟩, hd⟩ := d
+  revert hvalid hd
+  cases d
+  case E6 q => exact fun _ _ => ⟨q, rfl⟩
+  all_goals exact fun _ hd => ((LieTypeIndex.isTypeE6_iff _).mp hd).elim
+
+/-- The untwisted family `E₆(q)` is built on the diagram `E₆`. -/
+@[simp] theorem dynkinType_eq (d : TypeE6LieIndex) : d.1.dynkinType = .E6 := by
+  obtain ⟨q, rfl⟩ := d.exists_eq_of
+  exact LieTypeIndex.dynkinType_E6 q
+
+/-- The untwisted family `E₆(q)` has rank six, that being the rank of `E₆`. -/
+@[simp] theorem rank_eq_six (d : TypeE6LieIndex) : d.1.rank = 6 :=
+  congrArg DynkinType.rank d.dynkinType_eq
+
+end TypeE6LieIndex
 
 namespace UnimodularLieIndex
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E6.Minuscule.Frobenius
+public import TauCeti.GroupTheory.FixedPointCandidate
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Frobenius
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Assembly
+
+/-!
+# The untwisted family `E₆(q)` on the minuscule carrier
+
+The untwisted exceptional family `E₆(q)` is built on the `E₆` diagram, and Tau Ceti's explicit
+full-weight Chevalley carrier for that diagram is `TauCeti.E6Minuscule.groupScheme`, the Kostant
+toral closure of the `27`-dimensional minuscule representation inside `GL₂₇` over `ℤ`. This file
+runs the classification recipe on it: for a validated `E₆` index it supplies the group of
+algebraic-closure-valued points of that carrier, its Bourbaki-numbered simple root subgroups, the
+Steinberg endomorphism milestone L1 prescribes for an untwisted family, and the candidate group
+milestone L3 builds from it,
+
+```text
+H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d]).
+```
+
+The Steinberg map is the `q`-power Frobenius outright. That is what L1's table asks of an untwisted
+family, and `TauCeti.TypeE6LieIndex.diagramPerm_toGraphTwistedIndex` is the check that the diagram
+permutation this index carries is indeed trivial: the nontrivial symmetry of the `E₆` diagram
+belongs to `²E₆(q)`, a different constructor.
+
+The graph-twisted family `²E₆(q)` is therefore *not* built here, although it is the other
+classification-list family on this diagram. Its Steinberg map composes the Frobenius with the order
+two graph automorphism `γ₂`, which does not act on this carrier at all: the diagram automorphism of
+`E₆` exchanges the minuscule representation with its contragredient rather than preserving either,
+so a carrier realizing it has to carry both, as
+`TauCeti/Algebra/Lie/E6/DoubledMinuscule/Basic.lean` records. Assembling that carrier and that
+automorphism is separate work, and this file adds no index subtype for `²E₆(q)`.
+
+Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
+the pinned simply connected Chevalley--Demazure group scheme of type `E₆`, or that any group below
+is finite, perfect, or simple. What is proved of the carrier against the `E₆` diagram is the
+identification of numbered root characters,
+`TauCeti.TypeE6LieIndex.rootGeneratorWeight_eq_root_simpleIndex`.
+
+## Main declarations
+
+* `TauCeti.TypeE6LieIndex.AmbientGroup`: the algebraic-closure-valued points of the minuscule
+  carrier, the group the recipe is run inside.
+* `TauCeti.TypeE6LieIndex.simpleRootSubgroup`: its positive simple-root subgroup at a
+  Bourbaki-numbered node, with
+  `TauCeti.TypeE6LieIndex.rootGeneratorWeight_eq_root_simpleIndex` identifying the character of
+  that subgroup with the corresponding simple root of the `E₆` root datum.
+* `TauCeti.TypeE6LieIndex.steinberg`: the Steinberg endomorphism of the family, together with its
+  pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)` and the description
+  `TauCeti.TypeE6LieIndex.mem_fixedSubgroup_steinberg_iff` of the group `H_d` it fixes.
+* `TauCeti.TypeE6LieIndex.Group`: the classification candidate `[H_d, H_d] / Z([H_d, H_d])`.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 14.
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17.
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate V, for the numbering of the
+  `E₆` diagram that the root subgroups below are indexed by.
+* The target signatures realized here follow the human-authored formal skeleton
+  `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group, the numbered simple root
+  subgroup, the Steinberg map with its pinned equation, and the fixed-point candidate, all taken
+  on a validated-index subtype.
+
+## Roadmap
+
+Milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md` asks for the points of the *pinned* simply
+connected Chevalley--Demazure group scheme of `TauCeti.DynkinType.simplyConnectedRootDatum` at the
+diagram the index names, with its root subgroups. **This file does not close L0, and the minuscule
+carrier is not offered as a substitute for that pinned group.** The pinned group scheme, its
+pinning, and any identification of a carrier with it are Layer 9 targets of
+`TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap consumes rather than builds; none
+of them is proved of `TauCeti.E6Minuscule.groupScheme` here or in the files this one imports. What
+this file supplies is the branch's explicit carrier, its numbered root characters read in the `E₆`
+root datum, the equation `Frob_q (x_i(u)) = x_i(u ^ q)` that milestone L1 asks of an ordinary
+Frobenius, and the milestone L3 recipe run on it, each in the shape those milestones state it; they
+transfer to the L0 carrier along that Layer 9 identification, and not before. The counterparts on
+the other branches already assembled are
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean` and
+`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace TypeE6LieIndex
+
+open DynkinType
+
+noncomputable section
+
+variable (d : TypeE6LieIndex)
+
+/-! ## The ambient group and its simple root subgroups -/
+
+/-- **The ambient group this file attaches to a validated `E₆` index**: the points of the explicit
+full-weight type-`E₆` minuscule Chevalley carrier over the algebraic closure of its prime field. No
+finiteness, reductivity, pinning or maximality statement is attached to it, and it is not claimed
+to be the pinned `E₆` group scheme's points that milestone L0 asks for, that identification being
+the Layer 9 target described in the module docstring. -/
+abbrev AmbientGroup : Type := E6Minuscule.points d.1.Closure
+
+/-- The positive simple-root subgroup at the Bourbaki-numbered node `i` of the `E₆` diagram. It is
+the carrier's numbered raising subgroup at the same node, the index type `Fin d.1.rank` being the
+upstream Bourbaki index type of the index's own Dynkin type. -/
+def simpleRootSubgroup (i : Fin d.1.rank) : Multiplicative d.1.Closure →* d.AmbientGroup :=
+  E6Minuscule.rootSubgroupPoints (.inl (finCongr d.rank_eq_six i)) d.1.Closure
+
+/-- The simple-root subgroup is the carrier's numbered raising subgroup at the corresponding node.
+This is the equation through which the upstream root-subgroup API reaches `simpleRootSubgroup`. It
+is not a `simp` lemma: `steinberg_simpleRootSubgroup` is the normal form the pinned equations of
+this file are stated against, and unfolding to `TauCeti.E6Minuscule.rootSubgroupPoints` would keep
+it from firing. -/
+theorem simpleRootSubgroup_def (i : Fin d.1.rank) :
+    d.simpleRootSubgroup i =
+      E6Minuscule.rootSubgroupPoints (.inl (finCongr d.rank_eq_six i)) d.1.Closure :=
+  (rfl)
+
+/-- **The simple-root subgroups sit at the simple roots of the `E₆` root datum.** The character by
+which the carrier's split torus rescales the parameter of `simpleRootSubgroup i` is the `i`-th
+simple root of `TauCeti.DynkinType.simplyConnectedRootDatum` at `E₆`, in the same Bourbaki
+numbering. This is the sense in which the minuscule carrier serves the diagram that the index
+names; it is not a claim that the carrier is the pinned group of that diagram, no pinning being
+constructed for it. -/
+theorem rootGeneratorWeight_eq_root_simpleIndex (i : Fin d.1.rank) :
+    E6Minuscule.rootGeneratorWeight (.inl (finCongr d.rank_eq_six i)) =
+      (E6.simplyConnectedRootDatum valid_E6).root
+        (E6.simpleIndex valid_E6 (finCongr d.rank_eq_six i)) := by
+  -- The uniform `root_simpleIndex` is instantiated by hand rather than rewritten with: its index
+  -- argument lives in `Fin E6.rank`, which is only definitionally the `Fin 6` the carrier uses.
+  have h := root_simpleIndex E6 valid_E6 (finCongr d.rank_eq_six i)
+  rw [E6Minuscule.rootGeneratorWeight_inl_eq_e6Root_e6SimpleIndex, root_e6SimpleIndex, h,
+    cartanMatrix_E6]
+
+/-! ## The Steinberg endomorphism -/
+
+/-- **The Steinberg endomorphism of a validated `E₆` index**: the `q`-power Frobenius of the
+ambient group, `q` being the field order the index records. The family is untwisted, so no diagram
+automorphism and no half-Frobenius enters; `diagramPerm_toGraphTwistedIndex` is the check that its
+diagram permutation is trivial. -/
+def steinberg : d.AmbientGroup →* d.AmbientGroup :=
+  E6Minuscule.frobenius d.1.characteristic d.1.fieldExponent d.1.Closure
+
+/-- The Steinberg map of an `E₆` index is the carrier's Frobenius at the exponent the index
+records. This is its unfolding lemma; the definition itself stays sealed.
+
+It is deliberately not a `simp` lemma: `steinberg_simpleRootSubgroup` and `coe_steinberg_apply`
+are the normal forms the pinned equations of this file are stated against, and unfolding to
+`TauCeti.E6Minuscule.frobenius` would keep them from firing. -/
+theorem steinberg_def :
+    d.steinberg = E6Minuscule.frobenius d.1.characteristic d.1.fieldExponent d.1.Closure :=
+  (rfl)
+
+/-- The Steinberg map acts on the ambient group by raising every matrix entry to the `q`-th
+power. -/
+@[simp]
+theorem coe_steinberg_apply (g : d.AmbientGroup) (r c : Fin 27) :
+    ((d.steinberg g : Matrix.GeneralLinearGroup (Fin 27) d.1.Closure) :
+        Matrix (Fin 27) (Fin 27) d.1.Closure) r c =
+      ((g : Matrix.GeneralLinearGroup (Fin 27) d.1.Closure) :
+        Matrix (Fin 27) (Fin 27) d.1.Closure) r c ^ d.1.fieldOrder := by
+  rw [steinberg_def, d.1.fieldOrder_eq_characteristic_pow]
+  exact E6Minuscule.coe_frobenius_apply _ _ _ g r c
+
+/-- **The Steinberg map fixes the Bourbaki numbering of a simple-root subgroup and raises its
+parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation
+milestone L1 asks of the untwisted families. -/
+@[simp]
+theorem steinberg_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.Closure) :
+    d.steinberg (d.simpleRootSubgroup i u) =
+      d.simpleRootSubgroup i
+        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.fieldOrder)) := by
+  rw [steinberg_def, simpleRootSubgroup_def, E6Minuscule.frobenius_rootSubgroupPoints,
+    d.1.fieldOrder_eq_characteristic_pow]
+
+/-- **A point of the ambient group is fixed by the Steinberg map exactly when all of its matrix
+entries lie in the field of definition.** Writing `𝔽_q` for
+`TauCeti.ValidLieTypeIndex.fixedField`, the copy of the field of `q` elements inside the algebraic
+closure, the group `H_d` that the milestone L3 recipe is run on below is therefore the group of
+points of the minuscule carrier whose entries lie in `𝔽_q`.
+
+As for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`, this is not a `simp`
+lemma: `TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites its
+left-hand side to `d.steinberg g = g` through `MonoidHom.mem_eqLocus`, and the `simpNF` linter
+rejects the annotation. -/
+theorem mem_fixedSubgroup_steinberg_iff (g : d.AmbientGroup) :
+    g ∈ fixedSubgroup d.steinberg ↔
+      ∀ r c, ((g : Matrix.GeneralLinearGroup (Fin 27) d.1.Closure) :
+        Matrix (Fin 27) (Fin 27) d.1.Closure) r c ∈ d.1.fixedField := by
+  rw [mem_fixedSubgroup, steinberg_def, E6Minuscule.frobenius_eq_self_iff]
+  simp only [mem_frobeniusFixedSubring, ValidLieTypeIndex.mem_fixedField,
+    d.1.fieldOrder_eq_characteristic_pow]
+
+/-! ## The classification candidate -/
+
+/-- **The candidate simple group of the untwisted family `E₆(q)`**: the derived subgroup of the
+fixed points of its Steinberg map, modulo the centre of that derived subgroup.
+
+This is the milestone L3 recipe on the `E₆` branch, run on the minuscule carrier. Nothing below
+asserts that it is finite, perfect, or simple, nor that the carrier is the one milestone L0 asks
+for. -/
+abbrev Group : Type := FixedPointCandidate d.steinberg
+
+/-- Milestone L3 asks every valid branch to carry a group instance; the quotient construction
+supplies it. -/
+example : _root_.Group d.Group := inferInstance
+
+end
+
+end TypeE6LieIndex
+
+end TauCeti


### PR DESCRIPTION
This PR adds the classification candidate for the untwisted exceptional family `E₆(q)`, the sixth of the seventeen Lie-type constructors to receive one. `TauCeti.TypeE6LieIndex.Group` is the milestone L3 recipe

```text
H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d]),
```

run on the `q`-power Frobenius of the algebraic-closure-valued points of `TauCeti.E6Minuscule.groupScheme`, Tau Ceti's explicit full-weight type-`E₆` Chevalley carrier, the Kostant toral closure of the 27-dimensional minuscule representation inside `GL₂₇` over `ℤ`. `TauCeti.TypeE6LieIndex.mem_fixedSubgroup_steinberg_iff` says that `H_d` is the group of points of that carrier whose matrix entries lie in the copy of `𝔽_q` inside the closure, and `steinberg_simpleRootSubgroup` is the pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)` on the Bourbaki-numbered simple root subgroups. `steinberg` is the Frobenius outright, which is what milestone L1's table prescribes for an untwisted family, and `diagramPerm_toGraphTwistedIndex` is the check that the diagram permutation this index carries is indeed trivial. `LieTypeIndex.valid_E6` records that no parameter is excluded on this branch: the `E₆` row of `InStandardRange` is unrestricted and no `E₆` parameter is a duplicate representative, so the family contributes one entry for every prime power and the introduction form `TypeE6LieIndex.of` takes no validity hypothesis.

The carrier was already on `main`, and its module docstring named this branch as the work left undone: `TauCeti/Algebra/Lie/E6/Minuscule/Frobenius.lean` says that "Milestone L1 of `TauCetiRoadmap/CFSGStatement/README.md` will consume this carrier Frobenius and its root-subgroup equation in a future construction of the ordinary `E₆(p ^ k)` Steinberg map". Nothing upstream is reproved here: `TauCeti.E6Minuscule.frobenius_rootSubgroupPoints`, `coe_frobenius_apply` and `frobenius_eq_self_iff` supply the three equations, and `TauCeti.E6Minuscule.rootGeneratorWeight_inl_eq_e6Root_e6SimpleIndex` together with the uniform `TauCeti.DynkinType.root_simpleIndex` supplies the root-character identification. The index layer is the type-A and Suzuki pattern applied to one more constructor: `LieTypeIndex.IsTypeE6` beside `IsTypeA`, `TypeE6LieIndex` beside `TypeALieIndex`, with `of`, `exists_eq_of`, `dynkinType_eq`, `rank_eq_six` and `toGraphTwistedIndex` in the homes their type-A counterparts occupy.

The graph-twisted family `²E₆(q)` is deliberately not built, although it is the other classification-list family on this diagram. Its Steinberg map composes the Frobenius with the order two graph automorphism, which does not act on this carrier at all: the diagram automorphism of `E₆` exchanges the minuscule representation with its contragredient rather than preserving either, as `TauCeti/Algebra/Lie/E6/DoubledMinuscule/Basic.lean` records, so a carrier realizing it has to carry both. This PR therefore adds no index subtype for `²E₆(q)`.

The roadmap target is milestone L3, "fixed groups", of `CFSGStatement/README.md`, whose completion evidence is "every valid branch has a `Group` instance", together with the untwisted row of L1's table, "`A`, `B`, `C`, `D`, `E₆`, `E₇`, `E₈`, `F₄`, `G₂` | `Frob_q`". Before this PR five of the seventeen Lie-type constructors had a candidate group on `main`: `A_r(q)` and `²A_r(q)` on the type-A carrier, and `E₈(q)`, `F₄(q)` and `G₂(q)` on the Geck carrier. What remains for L3 after this PR is the other eleven. Seven of them, `B_n(q)`, `C_n(q)`, `D_n(q)`, `²D_n(q)`, `³D₄(q)`, `E₇(q)` and `²E₆(q)`, wait on a full-weight carrier for their diagram reaching the point this one has; the remaining four, `²B₂(2^(2m+1))`, `²G₂(3^(2m+1))`, `²F₄(2^(2m+1))` and `²F₄(2)'`, wait on the group-scheme lift of the special isogeny `τ`, which milestone L2 consumes from Layer 9 of `ReductiveGroups/README.md` and which exists in this repository only at the root-datum layer.

As on the type-A branch and the three unimodular branches already on `main`, the carrier used is Tau Ceti's explicit full-weight Chevalley carrier for the diagram and not the pinned Chevalley--Demazure group scheme that milestone L0 asks for; no pinning is constructed for `E6Minuscule.groupScheme` here or in the files this one imports, and the module docstring states in bold that L0 is not closed. What is proved of the carrier against the `E₆` diagram is the identification of numbered root characters, `rootGeneratorWeight_eq_root_simpleIndex`: the character by which the carrier's split torus rescales the parameter of the `i`-th simple root subgroup is the `i`-th simple root of `TauCeti.DynkinType.simplyConnectedRootDatum` at `E₆`. Nothing here asserts that any group constructed is finite, perfect, or simple, and no `Finite` or `IsSimpleGroup` instance is attached to a candidate, milestone I0 having asked that none be.

One module is added, `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` (219 lines), and two existing files are touched: `CFSG/Index.lean` (+73, −2) and `CFSG/GraphTwisted.lean` (+26, −2). The new file joins `TypeA.lean` and `TypeB2.lean` as a flat sibling rather than moving the three into a `Type/` directory: `Type` is a Lean keyword and cannot be a module-path component, and `TauCeti/Algebra/Lie/Orthogonal/TypeB` and `TypeD` on `main` are the existing precedent for the prefix naming each file's Dynkin type rather than a directory-forming subject. No Mathlib PR material is vendored.

The conventions follow R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 14, and *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17; the list and the absence of exclusions on the `E₆` branch follow Gorenstein--Lyons--Solomon, *The Classification of the Finite Simple Groups*, as transcribed by the roadmap; the numbering is the Bourbaki one of the root-systems roadmap, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate V.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"typee6lieindex-group"}-->

🤖 Prepared with Claude Code
