### PR TITLE
feat: prove the type A carrier reductive

### DIFF
--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Reductive.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Reductive.lean
@@ -29,8 +29,8 @@ characteristic.
   commutative Hopf algebra.
 * `TauCeti.SlStd.finiteTypeSpecializationSpecialLinearIso`: its canonical isomorphism with the
   coordinate Hopf algebra of `SL_{r+1}` over an algebraically closed field.
-* `TauCeti.SlStd.reductive_finiteTypeSpecialization`: the specialized type `A_r` carrier is
-  reductive.
+* `TauCeti.SlStd.reductiveCommHopfAlgProperty_finiteTypeSpecialization`: the specialized type
+  `A_r` carrier is reductive.
 
 ## References
 
@@ -53,7 +53,11 @@ universe u
 
 noncomputable section
 
-variable (r : ℕ) (k : Type u) [Field k]
+variable (r : ℕ)
+
+section
+
+variable (k : Type u) [CommRing k]
 
 /-- The specialization of the full-weight type `A_r` carrier to `k`, bundled with its finite-type
 property. It is the quotient of `O(GL_{r+1}/k)` by the transported integral carrier equations. -/
@@ -74,7 +78,9 @@ theorem finiteTypeSpecialization_obj :
         (baseChangeDefiningIdeal r k) := by
   rw [finiteTypeSpecialization]
 
-variable [IsAlgClosed k]
+end
+
+variable (k : Type u) [Field k] [IsAlgClosed k]
 
 /-- Over an algebraically closed field, the specialized full-weight type `A_r` carrier is
 canonically isomorphic to the finite-type coordinate Hopf algebra of `SL_{r+1}`. -/
@@ -86,11 +92,21 @@ noncomputable def finiteTypeSpecializationSpecialLinearIso :
       baseChangeCoordinateSpecialLinearIso r k ≪≫
       eqToIso (SpecialLinear.finiteTypeCoordinateHopfAlgebra_obj k (r + 1)).symm)
 
+/-- The underlying coordinate morphism of the finite-type carrier--special-linear isomorphism is
+the canonical composite obtained from the quotient-coordinate isomorphism. -/
+@[simp]
+theorem finiteTypeSpecializationSpecialLinearIso_hom_hom :
+    (finiteTypeSpecializationSpecialLinearIso r k).hom.hom =
+      (eqToIso (finiteTypeSpecialization_obj r k) ≪≫
+        baseChangeCoordinateSpecialLinearIso r k ≪≫
+        eqToIso (SpecialLinear.finiteTypeCoordinateHopfAlgebra_obj k (r + 1)).symm).hom := by
+  rfl
+
 /-- **The full-weight type `A_r` carrier is reductive over every algebraically closed field.**
 
-The statement is valid in arbitrary characteristic. It transports the geometric reductivity of
+The statement is valid in arbitrary characteristic. It transports the reductivity of
 `SL_{r+1}` across the scheme-theoretic identification of the explicit carrier with `SL_{r+1}`. -/
-theorem reductive_finiteTypeSpecialization :
+theorem reductiveCommHopfAlgProperty_finiteTypeSpecialization :
     reductiveCommHopfAlgProperty k (finiteTypeSpecialization r k) :=
   (reductiveCommHopfAlgProperty k).prop_of_iso
     (finiteTypeSpecializationSpecialLinearIso r k).symm

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Reductive.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Reductive.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Reductive
+public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.SpecialLinear
+
+/-!
+# Reductivity of the type A standard carrier
+
+The full-weight type `A_r` standard carrier is an explicit closed subgroup of `GL_{r+1}` over
+`ℤ`, constructed from its numbered root subgroups and weight torus. After specialization to an
+algebraically closed field, its defining Hopf ideal is the determinant-one ideal by
+`TauCeti.SlStd.baseChangeDefiningIdeal_eq_specialLinearDefiningHopfIdeal`. Thus its coordinate
+Hopf algebra is isomorphic to that of `SL_{r+1}`.
+
+This file packages the specialized carrier as a finite-type commutative Hopf algebra, lifts the
+coordinate isomorphism to that category, and transports the reductivity of `SL_{r+1}` across it.
+Consequently the explicit type `A` carrier has the substantive reductive-group property required
+of a Chevalley--Demazure carrier over every algebraically closed field, in arbitrary
+characteristic.
+
+## Main declarations
+
+* `TauCeti.SlStd.finiteTypeSpecialization`: the specialized type `A_r` carrier as a finite-type
+  commutative Hopf algebra.
+* `TauCeti.SlStd.finiteTypeSpecializationSpecialLinearIso`: its canonical isomorphism with the
+  coordinate Hopf algebra of `SL_{r+1}` over an algebraically closed field.
+* `TauCeti.SlStd.reductive_finiteTypeSpecialization`: the specialized type `A_r` carrier is
+  reductive.
+
+## References
+
+* J. E. Humphreys, *Linear Algebraic Groups*, §§26--27.
+* R. Steinberg, *Lectures on Chevalley Groups*, §§3--4.
+
+This advances Layer 9, "The Chevalley--Demazure construction", of the ReductiveGroups roadmap:
+the explicit type `A` carrier is now reductive over the algebraically closed fields on which the
+finite groups of Lie type are constructed. Its consumer is milestone L0, "pinned ambient groups",
+of the CFSGStatement roadmap.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.SlStd
+
+universe u
+
+noncomputable section
+
+variable (r : ℕ) (k : Type u) [Field k]
+
+/-- The specialization of the full-weight type `A_r` carrier to `k`, bundled with its finite-type
+property. It is the quotient of `O(GL_{r+1}/k)` by the transported integral carrier equations. -/
+noncomputable def finiteTypeSpecialization : FiniteTypeCommHopfAlgCat k :=
+  FiniteTypeCommHopfAlgCat.quotient
+    (⟨GeneralLinear.coordinateHopfAlgebra k (r + 1),
+      inferInstanceAs
+        (Algebra.FiniteType k (GeneralLinear.coordinateHopfAlgebra k (r + 1)))⟩ :
+      FiniteTypeCommHopfAlgCat k)
+    (baseChangeDefiningIdeal r k)
+
+/-- The object underlying the finite-type specialization is the quotient coordinate Hopf algebra
+used by the base-change presentation of the carrier. -/
+@[simp]
+theorem finiteTypeSpecialization_obj :
+    (finiteTypeSpecialization r k).obj =
+      CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra k (r + 1))
+        (baseChangeDefiningIdeal r k) := by
+  rw [finiteTypeSpecialization]
+
+variable [IsAlgClosed k]
+
+/-- Over an algebraically closed field, the specialized full-weight type `A_r` carrier is
+canonically isomorphic to the finite-type coordinate Hopf algebra of `SL_{r+1}`. -/
+noncomputable def finiteTypeSpecializationSpecialLinearIso :
+    finiteTypeSpecialization r k ≅
+      SpecialLinear.finiteTypeCoordinateHopfAlgebra k (r + 1) :=
+  ObjectProperty.isoMk (finiteTypeCommHopfAlgProperty k)
+    (eqToIso (finiteTypeSpecialization_obj r k) ≪≫
+      baseChangeCoordinateSpecialLinearIso r k ≪≫
+      eqToIso (SpecialLinear.finiteTypeCoordinateHopfAlgebra_obj k (r + 1)).symm)
+
+/-- **The full-weight type `A_r` carrier is reductive over every algebraically closed field.**
+
+The statement is valid in arbitrary characteristic. It transports the geometric reductivity of
+`SL_{r+1}` across the scheme-theoretic identification of the explicit carrier with `SL_{r+1}`. -/
+theorem reductive_finiteTypeSpecialization :
+    reductiveCommHopfAlgProperty k (finiteTypeSpecialization r k) :=
+  (reductiveCommHopfAlgProperty k).prop_of_iso
+    (finiteTypeSpecializationSpecialLinearIso r k).symm
+    (SpecialLinear.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra k (r + 1))
+
+end
+
+end TauCeti.SlStd

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Reductive.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Reductive.lean
@@ -100,7 +100,8 @@ theorem finiteTypeSpecializationSpecialLinearIso_hom_hom :
       (eqToIso (finiteTypeSpecialization_obj r k) ≪≫
         baseChangeCoordinateSpecialLinearIso r k ≪≫
         eqToIso (SpecialLinear.finiteTypeCoordinateHopfAlgebra_obj k (r + 1)).symm).hom := by
-  rfl
+  simp only [finiteTypeSpecializationSpecialLinearIso, ObjectProperty.isoMk_hom,
+    ObjectProperty.homMk_hom]
 
 /-- **The full-weight type `A_r` carrier is reductive over every algebraically closed field.**
 


### PR DESCRIPTION
This PR packages the algebraically closed-field specialization of the explicit full-weight type-`A_r` carrier as a finite-type commutative Hopf algebra, identifies it canonically with `O(SL_(r+1))`, and transports the existing arbitrary-characteristic reductivity theorem for `SL_(r+1)` across that isomorphism.

The exact ReductiveGroups target is Layer 9, “The Chevalley--Demazure construction,” together with its preceding requirement for split reductive group schemes: the type-`A` carrier now has the reductive-group property over every algebraically closed field used to form finite groups of Lie type. This is the most effective current step because the scheme-theoretic carrier--`SL` identification has just landed, so the result follows canonically without duplicating the normal-unipotent-subgroup argument already proved for `SL`.

The designated consumer is CFSGStatement milestone L0, “pinned ambient groups.” The dependency edge is CFSGStatement L0's type-`A` pinned ambient group ← ReductiveGroups Layer 9's explicit reductive Chevalley--Demazure carrier ← `TauCeti.SlStd.reductive_finiteTypeSpecialization` supplied here.

After this PR, the type-`A` branch still needs the Borel/maximal-torus packaging and the semisimple and simply connected identifications before the uniform pinned-carrier milestone closes; the other Dynkin families remain separate carrier branches.

The proof reuses `TauCeti.SlStd.baseChangeCoordinateSpecialLinearIso`, `TauCeti.SpecialLinear.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`, and object-property invariance under isomorphism. No Mathlib implementation or external formalization is vendored. The mathematical organization follows Humphreys, *Linear Algebraic Groups*, §§26--27, and Steinberg, *Lectures on Chevalley Groups*, §§3--4, as credited in the module documentation.

One 101-line file is added: `TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Reductive.lean`.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-a-carrier-reductive"}-->

🤖 Prepared with Codex
