### PR TITLE
feat: recut a two-step grid rectangle decomposition sharing its initial side

### DIFF
--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -137,6 +137,16 @@ theorem right_notMem_cIoo (a b : Fin n) : b ∉ cIoo a b := by
     | inl hlt => exact hab hlt
     | inr hlt => exact Nat.lt_irrefl b.val hlt
 
+/-- A point in an open cyclic interval differs from its initial endpoint. -/
+theorem ne_left_of_mem_cIoo {a b x : Fin n} (h : x ∈ cIoo a b) : x ≠ a := by
+  rintro rfl
+  exact left_notMem_cIoo _ _ h
+
+/-- A point in an open cyclic interval differs from its terminal endpoint. -/
+theorem ne_right_of_mem_cIoo {a b x : Fin n} (h : x ∈ cIoo a b) : x ≠ b := by
+  rintro rfl
+  exact right_notMem_cIoo _ _ h
+
 /-- The clockwise half-open cyclic interval from `a` to `b` in `Fin n`.
 
 This is the arc that starts at `a` and stops just before `b`, so it is the open arc `cIoo a b`

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -43,6 +43,11 @@ directions before taking products.
 * `TauCeti.Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo`: an interior point cuts a half-open arc
   into two adjacent half-open arcs.
 * `TauCeti.Grid.disjoint_cIco_cIco_of_mem_cIoo`: the two pieces of such a cut are disjoint.
+* `TauCeti.Grid.cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo`: an interior point cuts an open arc
+  into two open arcs and the cutting point itself.
+* `TauCeti.Grid.cIoo_subset_cIoo_of_mem_cIoo_left`,
+  `TauCeti.Grid.cIoo_subset_cIoo_of_mem_cIoo_right`: the two pieces of that cut are contained in
+  the arc they cut.
 * `TauCeti.Grid.Noninterleaving`: two endpoint pairs lie on the same cyclic side of each other.
 * `TauCeti.Grid.noninterleaving_rev`: non-interleaving is preserved by reversing every endpoint
   with `Fin.rev`, exchanging the two endpoints within each pair.
@@ -400,6 +405,26 @@ theorem disjoint_cIco_cIco_of_mem_cIoo {a b c : Fin n} (h : b ∈ cIoo a c) :
   rw [mem_cIco] at hxab hxbc
   rw [mem_cIoo] at h
   split_ifs at h hxab hxbc <;> omega
+
+/-- An interior point cuts a clockwise open arc into two open arcs and the cutting point. -/
+theorem cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo {a b c : Fin n} (h : b ∈ cIoo a c) :
+    cIoo a b ∪ insert b (cIoo b c) = cIoo a c := by
+  ext x
+  rw [mem_cIoo] at h
+  simp only [Finset.mem_union, Finset.mem_insert, mem_cIoo, ne_eq, Fin.ext_iff]
+  split_ifs at h ⊢ <;> omega
+
+/-- The initial piece of a cut open arc is contained in the whole arc. -/
+theorem cIoo_subset_cIoo_of_mem_cIoo_left {a b c : Fin n} (h : b ∈ cIoo a c) :
+    cIoo a b ⊆ cIoo a c := by
+  rw [← cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo h]
+  exact Finset.subset_union_left
+
+/-- The terminal piece of a cut open arc is contained in the whole arc. -/
+theorem cIoo_subset_cIoo_of_mem_cIoo_right {a b c : Fin n} (h : b ∈ cIoo a c) :
+    cIoo b c ⊆ cIoo a c := by
+  rw [← cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo h]
+  exact Finset.subset_union_right.trans' (Finset.subset_insert _ _)
 
 /-- A point outside the clockwise interval from `a` to `b` is either an endpoint or lies in
 the opposite clockwise interval. -/

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -45,8 +45,8 @@ directions before taking products.
 * `TauCeti.Grid.disjoint_cIco_cIco_of_mem_cIoo`: the two pieces of such a cut are disjoint.
 * `TauCeti.Grid.cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo`: an interior point cuts an open arc
   into two open arcs and the cutting point itself.
-* `TauCeti.Grid.cIoo_subset_cIoo_of_mem_cIoo_left`,
-  `TauCeti.Grid.cIoo_subset_cIoo_of_mem_cIoo_right`: the two pieces of that cut are contained in
+* `TauCeti.Grid.cIoo_subset_cIoo_right_of_mem_cIoo`,
+  `TauCeti.Grid.cIoo_subset_cIoo_left_of_mem_cIoo`: the two pieces of that cut are contained in
   the arc they cut.
 * `TauCeti.Grid.Noninterleaving`: two endpoint pairs lie on the same cyclic side of each other.
 * `TauCeti.Grid.noninterleaving_rev`: non-interleaving is preserved by reversing every endpoint
@@ -415,13 +415,13 @@ theorem cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo {a b c : Fin n} (h : b ∈ cI
   split_ifs at h ⊢ <;> omega
 
 /-- The initial piece of a cut open arc is contained in the whole arc. -/
-theorem cIoo_subset_cIoo_of_mem_cIoo_left {a b c : Fin n} (h : b ∈ cIoo a c) :
+theorem cIoo_subset_cIoo_right_of_mem_cIoo {a b c : Fin n} (h : b ∈ cIoo a c) :
     cIoo a b ⊆ cIoo a c := by
   rw [← cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo h]
   exact Finset.subset_union_left
 
 /-- The terminal piece of a cut open arc is contained in the whole arc. -/
-theorem cIoo_subset_cIoo_of_mem_cIoo_right {a b c : Fin n} (h : b ∈ cIoo a c) :
+theorem cIoo_subset_cIoo_left_of_mem_cIoo {a b c : Fin n} (h : b ∈ cIoo a c) :
     cIoo b c ⊆ cIoo a c := by
   rw [← cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo h]
   exact Finset.subset_union_right.trans' (Finset.subset_insert _ _)

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Recut.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Recut.lean
@@ -20,12 +20,13 @@ in the orientation where the two rectangles share their *initial* side column, a
 is again a decomposition by two rectangles the unblocked differential counts, carrying the same
 weight and passing through a different intermediate grid state.
 
-The relation between the two cuts is packaged as `GridRectangleDecomposition.IsRecut`: the
+The relation between the two cuts is packaged as `GridRectangleDecomposition.IsRepartition`: the
 rectangles of each cut cover disjoint sets of squares, and the two unions agree. The geometric
-construction separately proves that the two cuts have different intermediate states. The domain
-relation is exactly the amount of information a weight needs: any multiplicative function of
-squares has the same product on the two cuts, and in particular the `O`-monomials multiply to the
-same polynomial and `X`-avoidance transfers.
+construction separately proves that the two cuts have different intermediate states, and records
+the intermediate state and the side columns of the new cut. The domain relation is exactly the
+amount of information a weight needs: any multiplicative function of squares has the same product
+on the two cuts, and in particular the `O`-monomials multiply to the same polynomial and
+`X`-avoidance transfers.
 
 The geometric input is the cyclic order forced by emptiness
 (`cyclicOrder_of_isEmpty_of_left_eq_left`) and the finite-domain repartition identity for the
@@ -40,23 +41,24 @@ assembly of the disjoint, overlapping and annular cases into `∂⁻ ∘ ∂⁻ 
 
 ## Main definitions
 
-* `TauCeti.GridRectangleDecomposition.IsRecut`: two two-step decompositions with the same
+* `TauCeti.GridRectangleDecomposition.IsRepartition`: two two-step decompositions with the same
   endpoints partition the same set of covered squares.
 
 ## Main results
 
-* `TauCeti.GridRectangleDecomposition.IsRecut.prod_coveredSquares_mul_prod_coveredSquares`: a
-  recut preserves the product of any multiplicative weight on squares.
-* `TauCeti.GridRectangleDecomposition.IsRecut.OMonomial_mul_OMonomial`: a recut preserves the
-  product of the `O`-monomial weights of the unblocked differential.
-* `TauCeti.GridRectangleDecomposition.IsRecut.disjoint_XSet_first`,
-  `TauCeti.GridRectangleDecomposition.IsRecut.disjoint_XSet_second`: `X`-avoidance transfers
-  across a recut.
-* `TauCeti.GridRectangleDecomposition.exists_isRecut_of_left_eq_left`: two composable empty
-  rectangles sharing their initial side column admit a recut by two empty rectangles.
-* `TauCeti.GridRectangleDecomposition.exists_unblockedRectangles_recut_of_left_eq_left`: the
-  resulting pairing of the terms of `∂⁻ ∘ ∂⁻`, with equal weights and distinct intermediate
-  states.
+* `TauCeti.GridRectangleDecomposition.IsRepartition.prod_coveredSquares_mul_prod_coveredSquares`:
+  a repartition preserves the product of any multiplicative weight on squares.
+* `TauCeti.GridRectangleDecomposition.IsRepartition.OMonomial_mul_OMonomial`: a repartition
+  preserves the product of the `O`-monomial weights of the unblocked differential.
+* `TauCeti.GridRectangleDecomposition.IsRepartition.disjoint_first`,
+  `TauCeti.GridRectangleDecomposition.IsRepartition.disjoint_second`: avoidance of a set of
+  squares transfers across a repartition.
+* `TauCeti.GridRectangleDecomposition.exists_recut_of_isEmpty_of_left_eq_left`: two
+  composable empty rectangles sharing their initial side column admit a recut by two empty
+  rectangles, whose intermediate state and side columns are computed.
+* `TauCeti.GridRectangleDecomposition.exists_recut_of_mem_unblockedRectangles_of_left_eq_left`:
+  for each two-step term of `∂⁻ ∘ ∂⁻` whose two rectangles share their initial side column there
+  is a second such term, with the same product of weights and a different intermediate state.
 
 ## References
 
@@ -75,87 +77,132 @@ variable {n : ℕ} {x z : GridState n}
 
 /-! ### Two cuts of the same two-step domain -/
 
-/-- `E` is a *recut* of the two-step decomposition `D`: the two decompositions have the same
+/-- `E` is a *repartition* of the two-step decomposition `D`: the two decompositions have the same
 endpoints, each cuts its domain into two rectangles covering disjoint sets of squares, and the two
 domains agree.
 
-This is the domain relation used by the juxtaposition proof of `∂⁻ ∘ ∂⁻ = 0`; the pairing theorem
-additionally requires the two intermediate states to differ. -/
-structure IsRecut (D E : GridRectangleDecomposition x z) : Prop where
+This is the domain relation used by the juxtaposition proof of `∂⁻ ∘ ∂⁻ = 0`. It says nothing
+about the two cuts being different; the recut construction below produces a repartition through a
+different intermediate state. -/
+structure IsRepartition (D E : GridRectangleDecomposition x z) : Prop where
   /-- The two rectangles of `D` cover disjoint sets of squares. -/
   disjoint_coveredSquares :
     Disjoint D.first.toGridRectangle.coveredSquares D.second.toGridRectangle.coveredSquares
   /-- The two rectangles of `E` cover disjoint sets of squares. -/
-  disjoint_coveredSquares_recut :
+  disjoint_coveredSquares_repartition :
     Disjoint E.first.toGridRectangle.coveredSquares E.second.toGridRectangle.coveredSquares
   /-- The two cuts cover the same squares. -/
   coveredSquares_union_eq :
     E.first.toGridRectangle.coveredSquares ∪ E.second.toGridRectangle.coveredSquares =
       D.first.toGridRectangle.coveredSquares ∪ D.second.toGridRectangle.coveredSquares
 
-namespace IsRecut
+namespace IsRepartition
 
 variable {D E : GridRectangleDecomposition x z}
 
-/-- Being a recut is a symmetric relation. -/
-theorem symm (h : D.IsRecut E) : E.IsRecut D where
-  disjoint_coveredSquares := h.disjoint_coveredSquares_recut
-  disjoint_coveredSquares_recut := h.disjoint_coveredSquares
+/-- Being a repartition is a symmetric relation. -/
+theorem symm (h : D.IsRepartition E) : E.IsRepartition D where
+  disjoint_coveredSquares := h.disjoint_coveredSquares_repartition
+  disjoint_coveredSquares_repartition := h.disjoint_coveredSquares
   coveredSquares_union_eq := h.coveredSquares_union_eq.symm
 
-/-- A recut preserves the product of any multiplicative weight on squares: both cuts partition
-the same finite set of covered squares. -/
-theorem prod_coveredSquares_mul_prod_coveredSquares (h : D.IsRecut E) {M : Type*} [CommMonoid M]
-    (f : Fin n × Fin n → M) :
+/-- A repartition preserves the product of any multiplicative weight on squares: both cuts
+partition the same finite set of covered squares. -/
+theorem prod_coveredSquares_mul_prod_coveredSquares (h : D.IsRepartition E) {M : Type*}
+    [CommMonoid M] (f : Fin n × Fin n → M) :
     (∏ p ∈ E.first.toGridRectangle.coveredSquares, f p) *
         ∏ p ∈ E.second.toGridRectangle.coveredSquares, f p =
       (∏ p ∈ D.first.toGridRectangle.coveredSquares, f p) *
         ∏ p ∈ D.second.toGridRectangle.coveredSquares, f p := by
-  rw [← Finset.prod_union h.disjoint_coveredSquares_recut, h.coveredSquares_union_eq,
+  rw [← Finset.prod_union h.disjoint_coveredSquares_repartition, h.coveredSquares_union_eq,
     Finset.prod_union h.disjoint_coveredSquares]
 
-/-- A recut preserves the product of the `O`-monomial weights that the unblocked differential
-attaches to its two rectangles. -/
-theorem OMonomial_mul_OMonomial (h : D.IsRecut E) (G : GridDiagram n) (R : Type*)
+/-- A repartition preserves the product of the `O`-monomial weights that the unblocked
+differential attaches to its two rectangles. -/
+theorem OMonomial_mul_OMonomial (h : D.IsRepartition E) (G : GridDiagram n) (R : Type*)
     [CommSemiring R] :
     G.OMonomial R E.first.toGridRectangle * G.OMonomial R E.second.toGridRectangle =
       G.OMonomial R D.first.toGridRectangle * G.OMonomial R D.second.toGridRectangle := by
   simp only [G.OMonomial_eq_prod_coveredSquares R]
   exact h.prod_coveredSquares_mul_prod_coveredSquares _
 
-/-- If neither rectangle of `D` covers an `X`-marking, then neither does the first rectangle of a
-recut of `D`. -/
-theorem disjoint_XSet_first (h : D.IsRecut E) {G : GridDiagram n}
-    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares G.XSet)
-    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares G.XSet) :
-    Disjoint E.first.toGridRectangle.coveredSquares G.XSet := by
-  have hunion : Disjoint
-      (E.first.toGridRectangle.coveredSquares ∪ E.second.toGridRectangle.coveredSquares)
-      G.XSet := by
-    rw [h.coveredSquares_union_eq]
-    exact Finset.disjoint_union_left.mpr ⟨h₁, h₂⟩
-  exact (Finset.disjoint_union_left.mp hunion).1
+/-- If neither rectangle of `D` meets a set of squares, then the domain of a repartition of `D`
+does not meet it either. -/
+theorem disjoint_union (h : D.IsRepartition E) {s : Finset (Fin n × Fin n)}
+    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares s)
+    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares s) :
+    Disjoint (E.first.toGridRectangle.coveredSquares ∪
+      E.second.toGridRectangle.coveredSquares) s := by
+  rw [h.coveredSquares_union_eq]
+  exact Finset.disjoint_union_left.mpr ⟨h₁, h₂⟩
 
-/-- If neither rectangle of `D` covers an `X`-marking, then neither does the second rectangle of a
-recut of `D`. -/
-theorem disjoint_XSet_second (h : D.IsRecut E) {G : GridDiagram n}
-    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares G.XSet)
-    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares G.XSet) :
-    Disjoint E.second.toGridRectangle.coveredSquares G.XSet := by
-  have hunion : Disjoint
-      (E.first.toGridRectangle.coveredSquares ∪ E.second.toGridRectangle.coveredSquares)
-      G.XSet := by
-    rw [h.coveredSquares_union_eq]
-    exact Finset.disjoint_union_left.mpr ⟨h₁, h₂⟩
-  exact (Finset.disjoint_union_left.mp hunion).2
+/-- If neither rectangle of `D` meets a set of squares, then neither does the first rectangle of a
+repartition of `D`. Applied to the `X`-markings, this transfers `X`-avoidance across a recut. -/
+theorem disjoint_first (h : D.IsRepartition E) {s : Finset (Fin n × Fin n)}
+    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares s)
+    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares s) :
+    Disjoint E.first.toGridRectangle.coveredSquares s :=
+  (Finset.disjoint_union_left.mp (h.disjoint_union h₁ h₂)).1
 
-end IsRecut
+/-- If neither rectangle of `D` meets a set of squares, then neither does the second rectangle of
+a repartition of `D`. -/
+theorem disjoint_second (h : D.IsRepartition E) {s : Finset (Fin n × Fin n)}
+    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares s)
+    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares s) :
+    Disjoint E.second.toGridRectangle.coveredSquares s :=
+  (Finset.disjoint_union_left.mp (h.disjoint_union h₁ h₂)).2
+
+end IsRepartition
+
+/-! ### The two old rectangles read in the source state -/
+
+/-- The second rectangle of a decomposition whose two rectangles share their initial side column,
+written in terms of the source state: its two horizontal sides are the rows of the source state at
+the terminal columns of the two rectangles. -/
+private theorem toGridRectangle_second_of_left_eq_left (D : GridRectangleDecomposition x z)
+    (hleft : D.first.left = D.second.left) (hright : D.first.right ≠ D.second.right) :
+    D.second.toGridRectangle =
+      { left := D.first.left, right := D.second.right, bottom := x D.first.right,
+        top := x D.second.right } := by
+  have had : D.first.left ≠ D.second.right := by
+    rw [hleft]
+    exact D.second.left_ne_right
+  have hbottom : D.middle D.second.left = x D.first.right := by
+    rw [← hleft]
+    exact D.first.map_left
+  have htop : D.middle D.second.right = x D.second.right :=
+    D.first.map_of_ne _ had.symm hright.symm
+  rw [D.second.toGridRectangle_eq, hbottom, htop, ← hleft]
+
+/-- Emptiness of the second rectangle of a decomposition whose two rectangles share their initial
+side column, read back in the source state.
+
+Away from the two side columns of the first rectangle the intermediate state agrees with the
+source state, so emptiness may be tested against the source state there. -/
+private theorem forall_notMem_cIoo_second_of_left_eq_left (D : GridRectangleDecomposition x z)
+    (hleft : D.first.left = D.second.left) (hright : D.first.right ≠ D.second.right)
+    (hsecond : D.second.IsEmpty) :
+    ∀ c ∈ Grid.cIoo D.first.left D.second.right, c ≠ D.first.left → c ≠ D.first.right →
+      x c ∉ Grid.cIoo (x D.first.right) (x D.second.right) := by
+  have had : D.first.left ≠ D.second.right := by
+    rw [hleft]
+    exact D.second.left_ne_right
+  have hmid_first : D.middle D.first.left = x D.first.right := D.first.map_left
+  have hmid_second : D.middle D.second.right = x D.second.right :=
+    D.first.map_of_ne _ had.symm hright.symm
+  have h := hsecond
+  rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo] at h
+  simp only [GridRectangleBetween.bottom_def, GridRectangleBetween.top_def, ← hleft, hmid_first,
+    hmid_second] at h
+  intro c hc hca hcb
+  have hcm := h c hc
+  rwa [D.first.map_of_ne c hca hcb] at hcm
 
 /-! ### Building the recut -/
 
 /-- If a column belongs to both old column spans, the emptiness of the old rectangles excludes
-its grid-state point from their combined row span. -/
-private theorem notMem_combinedRowSpan_of_mem_bothColumnSpans {a b d c : Fin n}
+its grid-state point from the open arc between the two extreme corner rows. -/
+private theorem notMem_cIoo_of_mem_cIoo_of_mem_cIoo {a b d c : Fin n}
     (hrow : x b ∈ Grid.cIoo (x a) (x d))
     (hfirst : ∀ c ∈ Grid.cIoo a b, x c ∉ Grid.cIoo (x a) (x b))
     (hsecond : ∀ c ∈ Grid.cIoo a d, c ≠ a → c ≠ b →
@@ -183,14 +230,15 @@ inside the column span of the second one.
 
 The two rectangles `{a, b} × {x a, x b}` and `{a, d} × {x b, x d}` are cut apart along the column
 line `b` instead of the row line `x b`. -/
-private theorem exists_recut_columnCut {a b d : Fin n}
+private theorem exists_recut_col_cut {a b d : Fin n}
     (hab : a ≠ b) (had : a ≠ d) (hbd : b ≠ d)
     (hz : z = (x.swapColumns a b).swapColumns a d)
     (hcol : b ∈ Grid.cIoo a d) (hrow : x b ∈ Grid.cIoo (x a) (x d))
     (hfirst : ∀ c ∈ Grid.cIoo a b, x c ∉ Grid.cIoo (x a) (x b))
     (hsecond : ∀ c ∈ Grid.cIoo a d, c ≠ a → c ≠ b → x c ∉ Grid.cIoo (x b) (x d)) :
     ∃ E : GridRectangleDecomposition x z,
-      E.middle = x.swapColumns b d ∧
+      (E.middle = x.swapColumns b d ∧ E.first.left = b ∧ E.first.right = d ∧
+          E.second.left = a ∧ E.second.right = b) ∧
         E.first.toGridRectangle = { left := b, right := d, bottom := x b, top := x d } ∧
           E.second.toGridRectangle = { left := a, right := b, bottom := x a, top := x d } ∧
             E.first.IsEmpty ∧ E.second.IsEmpty := by
@@ -203,13 +251,13 @@ private theorem exists_recut_columnCut {a b d : Fin n}
     rw [GridState.swapColumns_apply, Equiv.swap_apply_left]
   refine ⟨{ middle := x.swapColumns b d
             first := GridRectangleBetween.ofSwapColumns x _ b d hbd rfl
-            second := GridRectangleBetween.ofSwapColumns _ z a b hab hz' }, rfl, by simp,
-          by simp [hmid_a, hmid_b], ?_, ?_⟩
+            second := GridRectangleBetween.ofSwapColumns _ z a b hab hz' },
+          ⟨rfl, by simp, by simp, by simp, by simp⟩, by simp, by simp [hmid_a, hmid_b], ?_, ?_⟩
   · rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo]
     simp only [GridRectangleBetween.ofSwapColumns_left, GridRectangleBetween.ofSwapColumns_right,
       GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top]
     intro c hc
-    have hcad : c ∈ Grid.cIoo a d := Grid.cIoo_subset_cIoo_of_mem_cIoo_right hcol hc
+    have hcad : c ∈ Grid.cIoo a d := Grid.cIoo_subset_cIoo_left_of_mem_cIoo hcol hc
     have hca : c ≠ a := by
       rintro rfl
       exact Grid.left_notMem_cIoo _ _ hcad
@@ -225,26 +273,27 @@ private theorem exists_recut_columnCut {a b d : Fin n}
     have hcb : c ≠ b := by
       rintro rfl
       exact Grid.right_notMem_cIoo _ _ hc
-    have hcad : c ∈ Grid.cIoo a d := Grid.cIoo_subset_cIoo_of_mem_cIoo_left hcol hc
+    have hcad : c ∈ Grid.cIoo a d := Grid.cIoo_subset_cIoo_right_of_mem_cIoo hcol hc
     have hcd : c ≠ d := by
       rintro rfl
       exact Grid.right_notMem_cIoo _ _ hcad
     rw [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hcb hcd] at hmem
-    exact notMem_combinedRowSpan_of_mem_bothColumnSpans hrow hfirst hsecond hc hcad hmem
+    exact notMem_cIoo_of_mem_cIoo_of_mem_cIoo hrow hfirst hsecond hc hcad hmem
 
 /-- The recut in the configuration where the terminal side of the second rectangle lies strictly
 inside the column span of the first one.
 
 The two rectangles `{a, b} × {x a, x b}` and `{a, d} × {x b, x d}` are cut apart along the column
 line `d` instead of the row line `x b`. -/
-private theorem exists_recut_complementaryColumnCut {a b d : Fin n}
+private theorem exists_recut_complementary_col_cut {a b d : Fin n}
     (hab : a ≠ b) (had : a ≠ d) (hbd : b ≠ d)
     (hz : z = (x.swapColumns a b).swapColumns a d)
     (hcol : d ∈ Grid.cIoo a b) (hrow : x b ∈ Grid.cIoo (x a) (x d))
     (hfirst : ∀ c ∈ Grid.cIoo a b, x c ∉ Grid.cIoo (x a) (x b))
     (hsecond : ∀ c ∈ Grid.cIoo a d, c ≠ a → c ≠ b → x c ∉ Grid.cIoo (x b) (x d)) :
     ∃ E : GridRectangleDecomposition x z,
-      E.middle = x.swapColumns a d ∧
+      (E.middle = x.swapColumns a d ∧ E.first.left = a ∧ E.first.right = d ∧
+          E.second.left = d ∧ E.second.right = b) ∧
         E.first.toGridRectangle = { left := a, right := d, bottom := x a, top := x d } ∧
           E.second.toGridRectangle = { left := d, right := b, bottom := x a, top := x b } ∧
             E.first.IsEmpty ∧ E.second.IsEmpty := by
@@ -257,20 +306,20 @@ private theorem exists_recut_complementaryColumnCut {a b d : Fin n}
     rw [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab.symm hbd]
   refine ⟨{ middle := x.swapColumns a d
             first := GridRectangleBetween.ofSwapColumns x _ a d had rfl
-            second := GridRectangleBetween.ofSwapColumns _ z d b hbd.symm hz' }, rfl, by simp,
-          by simp [hmid_d, hmid_b], ?_, ?_⟩
+            second := GridRectangleBetween.ofSwapColumns _ z d b hbd.symm hz' },
+          ⟨rfl, by simp, by simp, by simp, by simp⟩, by simp, by simp [hmid_d, hmid_b], ?_, ?_⟩
   · rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo]
     simp only [GridRectangleBetween.ofSwapColumns_left, GridRectangleBetween.ofSwapColumns_right,
       GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top]
     intro c hc
-    have hcab : c ∈ Grid.cIoo a b := Grid.cIoo_subset_cIoo_of_mem_cIoo_left hcol hc
-    exact notMem_combinedRowSpan_of_mem_bothColumnSpans hrow hfirst hsecond hcab hc
+    have hcab : c ∈ Grid.cIoo a b := Grid.cIoo_subset_cIoo_right_of_mem_cIoo hcol hc
+    exact notMem_cIoo_of_mem_cIoo_of_mem_cIoo hrow hfirst hsecond hcab hc
   · rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo]
     simp only [GridRectangleBetween.ofSwapColumns_left, GridRectangleBetween.ofSwapColumns_right,
       GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top, hmid_d,
       hmid_b]
     intro c hc
-    have hcab : c ∈ Grid.cIoo a b := Grid.cIoo_subset_cIoo_of_mem_cIoo_right hcol hc
+    have hcab : c ∈ Grid.cIoo a b := Grid.cIoo_subset_cIoo_left_of_mem_cIoo hcol hc
     have hca : c ≠ a := by
       rintro rfl
       exact Grid.left_notMem_cIoo _ _ hcab
@@ -286,15 +335,26 @@ private theorem exists_recut_complementaryColumnCut {a b d : Fin n}
 a *recut*: the L-shaped union of their domains has a second decomposition into two empty
 rectangles, through a different intermediate grid state.
 
+The two cyclic orders of the three side columns give the two shapes of the new cut, and in each
+of them the intermediate state and the four side columns of the recut are computed, which by
+`GridRectangleDecomposition.ext` determine it.
+
 Emptiness of both rectangles enters twice. It fixes the cyclic order of the three side columns
 and of the three corner rows, and it then transfers to the two new rectangles: the part of a new
 rectangle below the cut is controlled by the first old rectangle and the part above it by the
 second. -/
-theorem exists_isRecut_of_left_eq_left (D : GridRectangleDecomposition x z)
+theorem exists_recut_of_isEmpty_of_left_eq_left (D : GridRectangleDecomposition x z)
     (hleft : D.first.left = D.second.left) (hright : D.first.right ≠ D.second.right)
     (hfirst : D.first.IsEmpty) (hsecond : D.second.IsEmpty) :
     ∃ E : GridRectangleDecomposition x z,
-      D.IsRecut E ∧ E.middle ≠ D.middle ∧ E.first.IsEmpty ∧ E.second.IsEmpty := by
+      D.IsRepartition E ∧ E.middle ≠ D.middle ∧ E.first.IsEmpty ∧ E.second.IsEmpty ∧
+        E.first.right = D.second.right ∧ E.second.right = D.first.right ∧
+          ((E.middle = x.swapColumns D.first.right D.second.right ∧
+              E.first.left = D.first.right ∧ E.second.left = D.first.left) ∨
+            (E.middle = x.swapColumns D.first.left D.second.right ∧
+              E.first.left = D.first.left ∧ E.second.left = D.second.right)) := by
+  -- The three side columns, the target state and the two old rectangles, all read in the source
+  -- state `x`.
   have hab : D.first.left ≠ D.first.right := D.first.left_ne_right
   have had : D.first.left ≠ D.second.right := by
     rw [hleft]
@@ -315,31 +375,11 @@ theorem exists_isRecut_of_left_eq_left (D : GridRectangleDecomposition x z)
     have h := hfirst
     rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo] at h
     simpa only [GridRectangleBetween.bottom_def, GridRectangleBetween.top_def] using h
-  have hsecond' : ∀ c ∈ Grid.cIoo D.first.left D.second.right, c ≠ D.first.left →
-      c ≠ D.first.right → x c ∉ Grid.cIoo (x D.first.right) (x D.second.right) := by
-    have h := hsecond
-    rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo] at h
-    simp only [GridRectangleBetween.bottom_def, GridRectangleBetween.top_def, ← hleft, hmid_first,
-      hmid_second] at h
-    intro c hc hca hcb
-    have hcm := h c hc
-    rwa [D.first.map_of_ne c hca hcb] at hcm
+  have hsecond' := D.forall_notMem_cIoo_second_of_left_eq_left hleft hright hsecond
   have hD1 : D.first.toGridRectangle =
       { left := D.first.left, right := D.first.right, bottom := x D.first.left,
-        top := x D.first.right } := rfl
-  have hD2 : D.second.toGridRectangle =
-      { left := D.first.left, right := D.second.right, bottom := x D.first.right,
-        top := x D.second.right } := by
-    have hlit : D.second.toGridRectangle =
-        { left := D.second.left, right := D.second.right, bottom := D.second.bottom,
-          top := D.second.top } := rfl
-    have hb2 : D.second.bottom = x D.first.right := by
-      rw [GridRectangleBetween.bottom_def, ← hleft]
-      exact hmid_first
-    have ht2 : D.second.top = x D.second.right := by
-      rw [GridRectangleBetween.top_def]
-      exact hmid_second
-    rw [hlit, hb2, ht2, ← hleft]
+        top := x D.first.right } := D.first.toGridRectangle_eq
+  have hD2 := D.toGridRectangle_second_of_left_eq_left hleft hright
   have hDdisj : Disjoint D.first.toGridRectangle.coveredSquares
       D.second.toGridRectangle.coveredSquares := by
     rw [hD1, hD2]
@@ -347,30 +387,36 @@ theorem exists_isRecut_of_left_eq_left (D : GridRectangleDecomposition x z)
       simpa only [GridRectangle.coveredRows_def] using
         Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
   rcases hcolcase with hcol | hcol
-  · obtain ⟨E, hmidE, hE1, hE2, hEfirst, hEsecond⟩ :=
-      exists_recut_columnCut hab had hright hz hcol hrow hfirst' hsecond'
+  -- The terminal side of the first rectangle lies inside the column span of the second one: the
+  -- new cut runs along that column.
+  · obtain ⟨E, ⟨hmidE, hE1left, hE1right, hE2left, hE2right⟩, hE1, hE2, hEfirst, hEsecond⟩ :=
+      exists_recut_col_cut hab had hright hz hcol hrow hfirst' hsecond'
     have hmiddle : E.middle ≠ D.middle := by
       intro h
       have hval : E.middle D.first.left = D.middle D.first.left := by rw [h]
       rw [hmidE, hmid_first] at hval
       simp only [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab had] at hval
       exact hab (x.toPerm.injective hval)
-    refine ⟨E, ⟨hDdisj, ?_, ?_⟩, hmiddle, hEfirst, hEsecond⟩
+    refine ⟨E, ⟨hDdisj, ?_, ?_⟩, hmiddle, hEfirst, hEsecond, hE1right, hE2right,
+      Or.inl ⟨hmidE, hE1left, hE2left⟩⟩
     · rw [hE1, hE2]
       exact (GridRectangle.disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
         simpa only [GridRectangle.coveredColumns_def] using
           (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol).symm))
     · rw [hE1, hE2, hD1, hD2]
       exact (GridRectangle.coveredSquares_union_eq_of_mem_cIoo hcol hrow).symm
-  · obtain ⟨E, hmidE, hE1, hE2, hEfirst, hEsecond⟩ :=
-      exists_recut_complementaryColumnCut hab had hright hz hcol hrow hfirst' hsecond'
+  -- The terminal side of the second rectangle lies inside the column span of the first one: the
+  -- new cut runs along that column instead.
+  · obtain ⟨E, ⟨hmidE, hE1left, hE1right, hE2left, hE2right⟩, hE1, hE2, hEfirst, hEsecond⟩ :=
+      exists_recut_complementary_col_cut hab had hright hz hcol hrow hfirst' hsecond'
     have hmiddle : E.middle ≠ D.middle := by
       intro h
       have hval : E.middle D.first.right = D.middle D.first.right := by rw [h]
       rw [hmidE, D.first.map_right] at hval
       simp only [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab.symm hright] at hval
       exact hab (x.toPerm.injective hval).symm
-    refine ⟨E, ⟨hDdisj, ?_, ?_⟩, hmiddle, hEfirst, hEsecond⟩
+    refine ⟨E, ⟨hDdisj, ?_, ?_⟩, hmiddle, hEfirst, hEsecond, hE1right, hE2right,
+      Or.inr ⟨hmidE, hE1left, hE2left⟩⟩
     · rw [hE1, hE2]
       exact (GridRectangle.disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
         simpa only [GridRectangle.coveredColumns_def] using
@@ -379,32 +425,35 @@ theorem exists_isRecut_of_left_eq_left (D : GridRectangleDecomposition x z)
       exact (GridRectangle.coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut hcol
         hrow).symm
 
-/-- The pairing of two-step terms of `∂⁻ ∘ ∂⁻` in the orientation where the two rectangles share
-their initial side column.
-
-A pair of composable rectangles that the unblocked differential counts is matched with a second
-such pair, through a different intermediate grid state and with the same product of weights. Over
-a coefficient ring of characteristic two the two terms therefore cancel. -/
-theorem exists_unblockedRectangles_recut_of_left_eq_left (G : GridDiagram n) (R : Type*)
-    [CommSemiring R] (D : GridRectangleDecomposition x z)
+/-- For each two-step term of `∂⁻ ∘ ∂⁻` whose two rectangles share their initial side column there
+is a second such term, through a different intermediate grid state and with the same product of
+weights. Its intermediate state and side columns are computed from the given term, so that the
+second term is identified; over a coefficient ring of characteristic two the two cancel. -/
+theorem exists_recut_of_mem_unblockedRectangles_of_left_eq_left (G : GridDiagram n)
+    (R : Type*) [CommSemiring R] (D : GridRectangleDecomposition x z)
     (hleft : D.first.left = D.second.left) (hright : D.first.right ≠ D.second.right)
     (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
     (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
     ∃ E : GridRectangleDecomposition x z,
-      D.IsRecut E ∧ E.middle ≠ D.middle ∧
+      D.IsRepartition E ∧ E.middle ≠ D.middle ∧
         E.first ∈ G.unblockedRectangles x E.middle ∧
           E.second ∈ G.unblockedRectangles E.middle z ∧
             G.OMonomial R E.first.toGridRectangle * G.OMonomial R E.second.toGridRectangle =
-              G.OMonomial R D.first.toGridRectangle * G.OMonomial R D.second.toGridRectangle := by
-  obtain ⟨E, hrecut, hmiddle, hEfirst, hEsecond⟩ :=
-    D.exists_isRecut_of_left_eq_left hleft hright
+                G.OMonomial R D.first.toGridRectangle * G.OMonomial R D.second.toGridRectangle ∧
+              E.first.right = D.second.right ∧ E.second.right = D.first.right ∧
+                ((E.middle = x.swapColumns D.first.right D.second.right ∧
+                    E.first.left = D.first.right ∧ E.second.left = D.first.left) ∨
+                  (E.middle = x.swapColumns D.first.left D.second.right ∧
+                    E.first.left = D.first.left ∧ E.second.left = D.second.right)) := by
+  obtain ⟨E, hrecut, hmiddle, hEfirst, hEsecond, hE1right, hE2right, hcols⟩ :=
+    D.exists_recut_of_isEmpty_of_left_eq_left hleft hright
     (G.isEmpty_of_mem_unblockedRectangles hfirst) (G.isEmpty_of_mem_unblockedRectangles hsecond)
   have hX₁ := G.disjoint_XSet_of_mem_unblockedRectangles hfirst
   have hX₂ := G.disjoint_XSet_of_mem_unblockedRectangles hsecond
   exact ⟨E, hrecut, hmiddle,
-    (G.mem_unblockedRectangles _).mpr ⟨hEfirst, hrecut.disjoint_XSet_first hX₁ hX₂⟩,
-    (G.mem_unblockedRectangles _).mpr ⟨hEsecond, hrecut.disjoint_XSet_second hX₁ hX₂⟩,
-    hrecut.OMonomial_mul_OMonomial G R⟩
+    (G.mem_unblockedRectangles _).mpr ⟨hEfirst, hrecut.disjoint_first hX₁ hX₂⟩,
+    (G.mem_unblockedRectangles _).mpr ⟨hEsecond, hrecut.disjoint_second hX₁ hX₂⟩,
+    hrecut.OMonomial_mul_OMonomial G R, hE1right, hE2right, hcols⟩
 
 end GridRectangleDecomposition
 

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Recut.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Recut.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.KnotTheory.Grid.Differential.Square.OverlapOrder
+public import TauCeti.KnotTheory.Grid.Differential.Square.Repartition
 public import TauCeti.KnotTheory.Grid.Rectangle.Juxtaposition
-public import TauCeti.KnotTheory.Grid.Unblocked
 
 /-!
 # Recutting a two-step grid rectangle decomposition along its other internal edge
@@ -39,26 +39,14 @@ Three orientations of the shared side column remain: the two rectangles may shar
 side, or the terminal side of one may be the initial side of the other. Those three, and the
 assembly of the disjoint, overlapping and annular cases into `∂⁻ ∘ ∂⁻ = 0`, are separate steps.
 
-## Main definitions
-
-* `TauCeti.GridRectangleDecomposition.IsRepartition`: two two-step decompositions with the same
-  endpoints partition the same set of covered squares.
-
 ## Main results
 
-* `TauCeti.GridRectangleDecomposition.IsRepartition.prod_coveredSquares_mul_prod_coveredSquares`:
-  a repartition preserves the product of any multiplicative weight on squares.
-* `TauCeti.GridRectangleDecomposition.IsRepartition.OMonomial_mul_OMonomial`: a repartition
-  preserves the product of the `O`-monomial weights of the unblocked differential.
-* `TauCeti.GridRectangleDecomposition.IsRepartition.disjoint_first`,
-  `TauCeti.GridRectangleDecomposition.IsRepartition.disjoint_second`: avoidance of a set of
-  squares transfers across a repartition.
-* `TauCeti.GridRectangleDecomposition.exists_recut_of_isEmpty_of_left_eq_left`: two
+* `TauCeti.GridRectangleDecomposition.exists_isRepartition_of_isEmpty_of_left_eq_left`: two
   composable empty rectangles sharing their initial side column admit a recut by two empty
   rectangles, whose intermediate state and side columns are computed.
-* `TauCeti.GridRectangleDecomposition.exists_recut_of_mem_unblockedRectangles_of_left_eq_left`:
+* `GridRectangleDecomposition.exists_isRepartition_of_mem_unblockedRectangles_of_left_eq_left`:
   for each two-step term of `∂⁻ ∘ ∂⁻` whose two rectangles share their initial side column there
-  is a second such term, with the same product of weights and a different intermediate state.
+  is a unique second such term through a different intermediate state.
 
 ## References
 
@@ -75,86 +63,24 @@ namespace GridRectangleDecomposition
 
 variable {n : ℕ} {x z : GridState n}
 
-/-! ### Two cuts of the same two-step domain -/
-
-/-- `E` is a *repartition* of the two-step decomposition `D`: the two decompositions have the same
-endpoints, each cuts its domain into two rectangles covering disjoint sets of squares, and the two
-domains agree.
-
-This is the domain relation used by the juxtaposition proof of `∂⁻ ∘ ∂⁻ = 0`. It says nothing
-about the two cuts being different; the recut construction below produces a repartition through a
-different intermediate state. -/
-structure IsRepartition (D E : GridRectangleDecomposition x z) : Prop where
-  /-- The two rectangles of `D` cover disjoint sets of squares. -/
-  disjoint_coveredSquares :
-    Disjoint D.first.toGridRectangle.coveredSquares D.second.toGridRectangle.coveredSquares
-  /-- The two rectangles of `E` cover disjoint sets of squares. -/
-  disjoint_coveredSquares_repartition :
-    Disjoint E.first.toGridRectangle.coveredSquares E.second.toGridRectangle.coveredSquares
-  /-- The two cuts cover the same squares. -/
-  coveredSquares_union_eq :
-    E.first.toGridRectangle.coveredSquares ∪ E.second.toGridRectangle.coveredSquares =
-      D.first.toGridRectangle.coveredSquares ∪ D.second.toGridRectangle.coveredSquares
-
-namespace IsRepartition
-
-variable {D E : GridRectangleDecomposition x z}
-
-/-- Being a repartition is a symmetric relation. -/
-theorem symm (h : D.IsRepartition E) : E.IsRepartition D where
-  disjoint_coveredSquares := h.disjoint_coveredSquares_repartition
-  disjoint_coveredSquares_repartition := h.disjoint_coveredSquares
-  coveredSquares_union_eq := h.coveredSquares_union_eq.symm
-
-/-- A repartition preserves the product of any multiplicative weight on squares: both cuts
-partition the same finite set of covered squares. -/
-theorem prod_coveredSquares_mul_prod_coveredSquares (h : D.IsRepartition E) {M : Type*}
-    [CommMonoid M] (f : Fin n × Fin n → M) :
-    (∏ p ∈ E.first.toGridRectangle.coveredSquares, f p) *
-        ∏ p ∈ E.second.toGridRectangle.coveredSquares, f p =
-      (∏ p ∈ D.first.toGridRectangle.coveredSquares, f p) *
-        ∏ p ∈ D.second.toGridRectangle.coveredSquares, f p := by
-  rw [← Finset.prod_union h.disjoint_coveredSquares_repartition, h.coveredSquares_union_eq,
-    Finset.prod_union h.disjoint_coveredSquares]
-
-/-- A repartition preserves the product of the `O`-monomial weights that the unblocked
-differential attaches to its two rectangles. -/
-theorem OMonomial_mul_OMonomial (h : D.IsRepartition E) (G : GridDiagram n) (R : Type*)
-    [CommSemiring R] :
-    G.OMonomial R E.first.toGridRectangle * G.OMonomial R E.second.toGridRectangle =
-      G.OMonomial R D.first.toGridRectangle * G.OMonomial R D.second.toGridRectangle := by
-  simp only [G.OMonomial_eq_prod_coveredSquares R]
-  exact h.prod_coveredSquares_mul_prod_coveredSquares _
-
-/-- If neither rectangle of `D` meets a set of squares, then the domain of a repartition of `D`
-does not meet it either. -/
-theorem disjoint_union (h : D.IsRepartition E) {s : Finset (Fin n × Fin n)}
-    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares s)
-    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares s) :
-    Disjoint (E.first.toGridRectangle.coveredSquares ∪
-      E.second.toGridRectangle.coveredSquares) s := by
-  rw [h.coveredSquares_union_eq]
-  exact Finset.disjoint_union_left.mpr ⟨h₁, h₂⟩
-
-/-- If neither rectangle of `D` meets a set of squares, then neither does the first rectangle of a
-repartition of `D`. Applied to the `X`-markings, this transfers `X`-avoidance across a recut. -/
-theorem disjoint_first (h : D.IsRepartition E) {s : Finset (Fin n × Fin n)}
-    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares s)
-    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares s) :
-    Disjoint E.first.toGridRectangle.coveredSquares s :=
-  (Finset.disjoint_union_left.mp (h.disjoint_union h₁ h₂)).1
-
-/-- If neither rectangle of `D` meets a set of squares, then neither does the second rectangle of
-a repartition of `D`. -/
-theorem disjoint_second (h : D.IsRepartition E) {s : Finset (Fin n × Fin n)}
-    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares s)
-    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares s) :
-    Disjoint E.second.toGridRectangle.coveredSquares s :=
-  (Finset.disjoint_union_left.mp (h.disjoint_union h₁ h₂)).2
-
-end IsRepartition
-
 /-! ### The two old rectangles read in the source state -/
+
+/-- When the two rectangles share their initial side, that side differs from the second
+rectangle's terminal side. -/
+private theorem first_left_ne_second_right_of_left_eq_left
+    (D : GridRectangleDecomposition x z)
+    (hleft : D.first.left = D.second.left) : D.first.left ≠ D.second.right := by
+  rw [hleft]
+  exact D.second.left_ne_right
+
+/-- The common initial side and distinct terminal sides determine the source-state values of the
+intermediate state at the common side and the second terminal side. -/
+private theorem middle_apply_of_left_eq_left (D : GridRectangleDecomposition x z)
+    (hleft : D.first.left = D.second.left) (hright : D.first.right ≠ D.second.right) :
+    D.middle D.first.left = x D.first.right ∧
+      D.middle D.second.right = x D.second.right :=
+  ⟨D.first.map_left,
+    D.first.map_of_ne _ (D.first_left_ne_second_right_of_left_eq_left hleft).symm hright.symm⟩
 
 /-- The second rectangle of a decomposition whose two rectangles share their initial side column,
 written in terms of the source state: its two horizontal sides are the rows of the source state at
@@ -164,15 +90,10 @@ private theorem toGridRectangle_second_of_left_eq_left (D : GridRectangleDecompo
     D.second.toGridRectangle =
       { left := D.first.left, right := D.second.right, bottom := x D.first.right,
         top := x D.second.right } := by
-  have had : D.first.left ≠ D.second.right := by
-    rw [hleft]
-    exact D.second.left_ne_right
+  obtain ⟨hmid_first, hmid_second⟩ := D.middle_apply_of_left_eq_left hleft hright
   have hbottom : D.middle D.second.left = x D.first.right := by
-    rw [← hleft]
-    exact D.first.map_left
-  have htop : D.middle D.second.right = x D.second.right :=
-    D.first.map_of_ne _ had.symm hright.symm
-  rw [D.second.toGridRectangle_eq, hbottom, htop, ← hleft]
+    rw [← hleft, hmid_first]
+  rw [D.second.toGridRectangle_eq, hbottom, hmid_second, ← hleft]
 
 /-- Emptiness of the second rectangle of a decomposition whose two rectangles share their initial
 side column, read back in the source state.
@@ -184,12 +105,7 @@ private theorem forall_notMem_cIoo_second_of_left_eq_left (D : GridRectangleDeco
     (hsecond : D.second.IsEmpty) :
     ∀ c ∈ Grid.cIoo D.first.left D.second.right, c ≠ D.first.left → c ≠ D.first.right →
       x c ∉ Grid.cIoo (x D.first.right) (x D.second.right) := by
-  have had : D.first.left ≠ D.second.right := by
-    rw [hleft]
-    exact D.second.left_ne_right
-  have hmid_first : D.middle D.first.left = x D.first.right := D.first.map_left
-  have hmid_second : D.middle D.second.right = x D.second.right :=
-    D.first.map_of_ne _ had.symm hright.symm
+  obtain ⟨hmid_first, hmid_second⟩ := D.middle_apply_of_left_eq_left hleft hright
   have h := hsecond
   rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo] at h
   simp only [GridRectangleBetween.bottom_def, GridRectangleBetween.top_def, ← hleft, hmid_first,
@@ -210,12 +126,8 @@ private theorem notMem_cIoo_of_mem_cIoo_of_mem_cIoo {a b d c : Fin n}
     (hcab : c ∈ Grid.cIoo a b) (hcad : c ∈ Grid.cIoo a d) :
     x c ∉ Grid.cIoo (x a) (x d) := by
   intro hmem
-  have hca : c ≠ a := by
-    rintro rfl
-    exact Grid.left_notMem_cIoo _ _ hcab
-  have hcb : c ≠ b := by
-    rintro rfl
-    exact Grid.right_notMem_cIoo _ _ hcab
+  have hca : c ≠ a := Grid.ne_left_of_mem_cIoo hcab
+  have hcb : c ≠ b := Grid.ne_right_of_mem_cIoo hcab
   have hcut : x c ∈ Grid.cIoo (x a) (x b) ∪ insert (x b) (Grid.cIoo (x b) (x d)) := by
     rw [Grid.cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo hrow]
     exact hmem
@@ -230,7 +142,7 @@ inside the column span of the second one.
 
 The two rectangles `{a, b} × {x a, x b}` and `{a, d} × {x b, x d}` are cut apart along the column
 line `b` instead of the row line `x b`. -/
-private theorem exists_recut_col_cut {a b d : Fin n}
+private theorem exists_isRepartition_col_cut {a b d : Fin n}
     (hab : a ≠ b) (had : a ≠ d) (hbd : b ≠ d)
     (hz : z = (x.swapColumns a b).swapColumns a d)
     (hcol : b ∈ Grid.cIoo a d) (hrow : x b ∈ Grid.cIoo (x a) (x d))
@@ -258,25 +170,17 @@ private theorem exists_recut_col_cut {a b d : Fin n}
       GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top]
     intro c hc
     have hcad : c ∈ Grid.cIoo a d := Grid.cIoo_subset_cIoo_left_of_mem_cIoo hcol hc
-    have hca : c ≠ a := by
-      rintro rfl
-      exact Grid.left_notMem_cIoo _ _ hcad
-    have hcb : c ≠ b := by
-      rintro rfl
-      exact Grid.left_notMem_cIoo _ _ hc
+    have hca : c ≠ a := Grid.ne_left_of_mem_cIoo hcad
+    have hcb : c ≠ b := Grid.ne_left_of_mem_cIoo hc
     exact hsecond c hcad hca hcb
   · rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo]
     simp only [GridRectangleBetween.ofSwapColumns_left, GridRectangleBetween.ofSwapColumns_right,
       GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top, hmid_a,
       hmid_b]
     intro c hc hmem
-    have hcb : c ≠ b := by
-      rintro rfl
-      exact Grid.right_notMem_cIoo _ _ hc
+    have hcb : c ≠ b := Grid.ne_right_of_mem_cIoo hc
     have hcad : c ∈ Grid.cIoo a d := Grid.cIoo_subset_cIoo_right_of_mem_cIoo hcol hc
-    have hcd : c ≠ d := by
-      rintro rfl
-      exact Grid.right_notMem_cIoo _ _ hcad
+    have hcd : c ≠ d := Grid.ne_right_of_mem_cIoo hcad
     rw [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hcb hcd] at hmem
     exact notMem_cIoo_of_mem_cIoo_of_mem_cIoo hrow hfirst hsecond hc hcad hmem
 
@@ -285,7 +189,7 @@ inside the column span of the first one.
 
 The two rectangles `{a, b} × {x a, x b}` and `{a, d} × {x b, x d}` are cut apart along the column
 line `d` instead of the row line `x b`. -/
-private theorem exists_recut_complementary_col_cut {a b d : Fin n}
+private theorem exists_isRepartition_complementary_col_cut {a b d : Fin n}
     (hab : a ≠ b) (had : a ≠ d) (hbd : b ≠ d)
     (hz : z = (x.swapColumns a b).swapColumns a d)
     (hcol : d ∈ Grid.cIoo a b) (hrow : x b ∈ Grid.cIoo (x a) (x d))
@@ -320,12 +224,8 @@ private theorem exists_recut_complementary_col_cut {a b d : Fin n}
       hmid_b]
     intro c hc
     have hcab : c ∈ Grid.cIoo a b := Grid.cIoo_subset_cIoo_left_of_mem_cIoo hcol hc
-    have hca : c ≠ a := by
-      rintro rfl
-      exact Grid.left_notMem_cIoo _ _ hcab
-    have hcd : c ≠ d := by
-      rintro rfl
-      exact Grid.left_notMem_cIoo _ _ hc
+    have hca : c ≠ a := Grid.ne_left_of_mem_cIoo hcab
+    have hcd : c ≠ d := Grid.ne_left_of_mem_cIoo hc
     rw [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hca hcd]
     exact hfirst c hcab
 
@@ -343,27 +243,25 @@ Emptiness of both rectangles enters twice. It fixes the cyclic order of the thre
 and of the three corner rows, and it then transfers to the two new rectangles: the part of a new
 rectangle below the cut is controlled by the first old rectangle and the part above it by the
 second. -/
-theorem exists_recut_of_isEmpty_of_left_eq_left (D : GridRectangleDecomposition x z)
+theorem exists_isRepartition_of_isEmpty_of_left_eq_left (D : GridRectangleDecomposition x z)
     (hleft : D.first.left = D.second.left) (hright : D.first.right ≠ D.second.right)
     (hfirst : D.first.IsEmpty) (hsecond : D.second.IsEmpty) :
-    ∃ E : GridRectangleDecomposition x z,
+    ∃! E : GridRectangleDecomposition x z,
       D.IsRepartition E ∧ E.middle ≠ D.middle ∧ E.first.IsEmpty ∧ E.second.IsEmpty ∧
         E.first.right = D.second.right ∧ E.second.right = D.first.right ∧
-          ((E.middle = x.swapColumns D.first.right D.second.right ∧
-              E.first.left = D.first.right ∧ E.second.left = D.first.left) ∨
-            (E.middle = x.swapColumns D.first.left D.second.right ∧
-              E.first.left = D.first.left ∧ E.second.left = D.second.right)) := by
+          ((D.first.right ∈ Grid.cIoo D.first.left D.second.right ∧
+              E.middle = x.swapColumns D.first.right D.second.right ∧
+                E.first.left = D.first.right ∧ E.second.left = D.first.left) ∨
+            (D.second.right ∈ Grid.cIoo D.first.left D.first.right ∧
+              E.middle = x.swapColumns D.first.left D.second.right ∧
+                E.first.left = D.first.left ∧ E.second.left = D.second.right)) := by
   -- The three side columns, the target state and the two old rectangles, all read in the source
   -- state `x`.
   have hab : D.first.left ≠ D.first.right := D.first.left_ne_right
-  have had : D.first.left ≠ D.second.right := by
-    rw [hleft]
-    exact D.second.left_ne_right
+  have had := D.first_left_ne_second_right_of_left_eq_left hleft
+  obtain ⟨hmid_first, hmid_second⟩ := D.middle_apply_of_left_eq_left hleft hright
   have hmid : D.middle = x.swapColumns D.first.left D.first.right :=
     D.first.target_eq_swapColumns
-  have hmid_first : D.middle D.first.left = x D.first.right := D.first.map_left
-  have hmid_second : D.middle D.second.right = x D.second.right :=
-    D.first.map_of_ne _ had.symm hright.symm
   have hz : z = (x.swapColumns D.first.left D.first.right).swapColumns D.first.left
       D.second.right := by
     rw [← hmid, hleft]
@@ -383,77 +281,115 @@ theorem exists_recut_of_isEmpty_of_left_eq_left (D : GridRectangleDecomposition 
   have hDdisj : Disjoint D.first.toGridRectangle.coveredSquares
       D.second.toGridRectangle.coveredSquares := by
     rw [hD1, hD2]
-    exact (GridRectangle.disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
-      simpa only [GridRectangle.coveredRows_def] using
-        Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
+    exact GridRectangle.disjoint_coveredSquares_of_row_cut hrow
+  have hcol_exclusive : ¬(D.first.right ∈ Grid.cIoo D.first.left D.second.right ∧
+      D.second.right ∈ Grid.cIoo D.first.left D.first.right) := by
+    rw [Grid.mem_cIoo, Grid.mem_cIoo]
+    rintro ⟨⟨_, hfirstRight⟩, ⟨_, hsecondRight⟩⟩
+    split_ifs at hfirstRight hsecondRight <;> omega
   rcases hcolcase with hcol | hcol
   -- The terminal side of the first rectangle lies inside the column span of the second one: the
   -- new cut runs along that column.
   · obtain ⟨E, ⟨hmidE, hE1left, hE1right, hE2left, hE2right⟩, hE1, hE2, hEfirst, hEsecond⟩ :=
-      exists_recut_col_cut hab had hright hz hcol hrow hfirst' hsecond'
+      exists_isRepartition_col_cut hab had hright hz hcol hrow hfirst' hsecond'
     have hmiddle : E.middle ≠ D.middle := by
       intro h
       have hval : E.middle D.first.left = D.middle D.first.left := by rw [h]
       rw [hmidE, hmid_first] at hval
       simp only [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab had] at hval
       exact hab (x.toPerm.injective hval)
-    refine ⟨E, ⟨hDdisj, ?_, ?_⟩, hmiddle, hEfirst, hEsecond, hE1right, hE2right,
-      Or.inl ⟨hmidE, hE1left, hE2left⟩⟩
-    · rw [hE1, hE2]
-      exact (GridRectangle.disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
-        simpa only [GridRectangle.coveredColumns_def] using
-          (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol).symm))
-    · rw [hE1, hE2, hD1, hD2]
+    have hEdisj : Disjoint E.first.toGridRectangle.coveredSquares
+        E.second.toGridRectangle.coveredSquares := by
+      rw [hE1, hE2]
+      exact (GridRectangle.disjoint_coveredSquares_of_col_cut hcol).symm
+    have hunion : E.first.toGridRectangle.coveredSquares ∪
+        E.second.toGridRectangle.coveredSquares =
+          D.first.toGridRectangle.coveredSquares ∪
+            D.second.toGridRectangle.coveredSquares := by
+      rw [hE1, hE2, hD1, hD2]
       exact (GridRectangle.coveredSquares_union_eq_of_mem_cIoo hcol hrow).symm
+    refine ⟨E, ⟨⟨hDdisj, hEdisj, hunion⟩, hmiddle, hEfirst, hEsecond, hE1right,
+      hE2right, Or.inl ⟨hcol, hmidE, hE1left, hE2left⟩⟩, ?_⟩
+    intro E' hE'
+    rcases hE' with ⟨_, _, _, _, hE1right', hE2right', hcols'⟩
+    have hlefts : E'.first.left = D.first.right ∧
+        E'.second.left = D.first.left := by
+      rcases hcols' with ⟨_, _, hE1left', hE2left'⟩ |
+          ⟨hcol', _, _, _⟩
+      · exact ⟨hE1left', hE2left'⟩
+      · exact (hcol_exclusive ⟨hcol, hcol'⟩).elim
+    exact GridRectangleDecomposition.ext (hlefts.1.trans hE1left.symm)
+      (hE1right'.trans hE1right.symm) (hlefts.2.trans hE2left.symm)
+      (hE2right'.trans hE2right.symm)
   -- The terminal side of the second rectangle lies inside the column span of the first one: the
   -- new cut runs along that column instead.
   · obtain ⟨E, ⟨hmidE, hE1left, hE1right, hE2left, hE2right⟩, hE1, hE2, hEfirst, hEsecond⟩ :=
-      exists_recut_complementary_col_cut hab had hright hz hcol hrow hfirst' hsecond'
+      exists_isRepartition_complementary_col_cut hab had hright hz hcol hrow hfirst' hsecond'
     have hmiddle : E.middle ≠ D.middle := by
       intro h
       have hval : E.middle D.first.right = D.middle D.first.right := by rw [h]
       rw [hmidE, D.first.map_right] at hval
       simp only [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab.symm hright] at hval
       exact hab (x.toPerm.injective hval).symm
-    refine ⟨E, ⟨hDdisj, ?_, ?_⟩, hmiddle, hEfirst, hEsecond, hE1right, hE2right,
-      Or.inr ⟨hmidE, hE1left, hE2left⟩⟩
-    · rw [hE1, hE2]
-      exact (GridRectangle.disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
-        simpa only [GridRectangle.coveredColumns_def] using
-          Grid.disjoint_cIco_cIco_of_mem_cIoo hcol))
-    · rw [hE1, hE2, hD1, hD2]
+    have hEdisj : Disjoint E.first.toGridRectangle.coveredSquares
+        E.second.toGridRectangle.coveredSquares := by
+      rw [hE1, hE2]
+      exact GridRectangle.disjoint_coveredSquares_of_col_cut hcol
+    have hunion : E.first.toGridRectangle.coveredSquares ∪
+        E.second.toGridRectangle.coveredSquares =
+          D.first.toGridRectangle.coveredSquares ∪
+            D.second.toGridRectangle.coveredSquares := by
+      rw [hE1, hE2, hD1, hD2]
       exact (GridRectangle.coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut hcol
         hrow).symm
+    refine ⟨E, ⟨⟨hDdisj, hEdisj, hunion⟩, hmiddle, hEfirst, hEsecond, hE1right,
+      hE2right, Or.inr ⟨hcol, hmidE, hE1left, hE2left⟩⟩, ?_⟩
+    intro E' hE'
+    rcases hE' with ⟨_, _, _, _, hE1right', hE2right', hcols'⟩
+    have hlefts : E'.first.left = D.first.left ∧
+        E'.second.left = D.second.right := by
+      rcases hcols' with ⟨hcol', _, _, _⟩ |
+          ⟨_, _, hE1left', hE2left'⟩
+      · exact (hcol_exclusive ⟨hcol', hcol⟩).elim
+      · exact ⟨hE1left', hE2left'⟩
+    exact GridRectangleDecomposition.ext (hlefts.1.trans hE1left.symm)
+      (hE1right'.trans hE1right.symm) (hlefts.2.trans hE2left.symm)
+      (hE2right'.trans hE2right.symm)
 
-/-- For each two-step term of `∂⁻ ∘ ∂⁻` whose two rectangles share their initial side column there
-is a second such term, through a different intermediate grid state and with the same product of
-weights. Its intermediate state and side columns are computed from the given term, so that the
-second term is identified; over a coefficient ring of characteristic two the two cancel. -/
-theorem exists_recut_of_mem_unblockedRectangles_of_left_eq_left (G : GridDiagram n)
-    (R : Type*) [CommSemiring R] (D : GridRectangleDecomposition x z)
+/-- For each two-step term of `∂⁻ ∘ ∂⁻` whose two rectangles share their initial side column
+there is a unique second such term through a different intermediate grid state. Its domain is a
+repartition of the original domain, so its weight agrees over every coefficient ring. -/
+theorem exists_isRepartition_of_mem_unblockedRectangles_of_left_eq_left (G : GridDiagram n)
+    (D : GridRectangleDecomposition x z)
     (hleft : D.first.left = D.second.left) (hright : D.first.right ≠ D.second.right)
     (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
     (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
-    ∃ E : GridRectangleDecomposition x z,
+    ∃! E : GridRectangleDecomposition x z,
       D.IsRepartition E ∧ E.middle ≠ D.middle ∧
         E.first ∈ G.unblockedRectangles x E.middle ∧
           E.second ∈ G.unblockedRectangles E.middle z ∧
-            G.OMonomial R E.first.toGridRectangle * G.OMonomial R E.second.toGridRectangle =
-                G.OMonomial R D.first.toGridRectangle * G.OMonomial R D.second.toGridRectangle ∧
-              E.first.right = D.second.right ∧ E.second.right = D.first.right ∧
-                ((E.middle = x.swapColumns D.first.right D.second.right ∧
+            E.first.right = D.second.right ∧ E.second.right = D.first.right ∧
+              ((D.first.right ∈ Grid.cIoo D.first.left D.second.right ∧
+                  E.middle = x.swapColumns D.first.right D.second.right ∧
                     E.first.left = D.first.right ∧ E.second.left = D.first.left) ∨
-                  (E.middle = x.swapColumns D.first.left D.second.right ∧
+                (D.second.right ∈ Grid.cIoo D.first.left D.first.right ∧
+                  E.middle = x.swapColumns D.first.left D.second.right ∧
                     E.first.left = D.first.left ∧ E.second.left = D.second.right)) := by
-  obtain ⟨E, hrecut, hmiddle, hEfirst, hEsecond, hE1right, hE2right, hcols⟩ :=
-    D.exists_recut_of_isEmpty_of_left_eq_left hleft hright
+  obtain ⟨E, ⟨hrecut, hmiddle, hEfirst, hEsecond, hE1right, hE2right, hcols⟩, hunique⟩ :=
+    D.exists_isRepartition_of_isEmpty_of_left_eq_left hleft hright
     (G.isEmpty_of_mem_unblockedRectangles hfirst) (G.isEmpty_of_mem_unblockedRectangles hsecond)
   have hX₁ := G.disjoint_XSet_of_mem_unblockedRectangles hfirst
   have hX₂ := G.disjoint_XSet_of_mem_unblockedRectangles hsecond
-  exact ⟨E, hrecut, hmiddle,
-    (G.mem_unblockedRectangles _).mpr ⟨hEfirst, hrecut.disjoint_first hX₁ hX₂⟩,
-    (G.mem_unblockedRectangles _).mpr ⟨hEsecond, hrecut.disjoint_second hX₁ hX₂⟩,
-    hrecut.OMonomial_mul_OMonomial G R, hE1right, hE2right, hcols⟩
+  refine ⟨E, ⟨hrecut, hmiddle,
+    (G.mem_unblockedRectangles _).mpr
+      ⟨hEfirst, hrecut.disjoint_coveredSquares_first hX₁ hX₂⟩,
+    (G.mem_unblockedRectangles _).mpr
+      ⟨hEsecond, hrecut.disjoint_coveredSquares_second hX₁ hX₂⟩,
+    hE1right, hE2right, hcols⟩, ?_⟩
+  intro E' hE'
+  apply hunique E'
+  exact ⟨hE'.1, hE'.2.1, (G.mem_unblockedRectangles _).mp hE'.2.2.1 |>.1,
+    (G.mem_unblockedRectangles _).mp hE'.2.2.2.1 |>.1, hE'.2.2.2.2⟩
 
 end GridRectangleDecomposition
 

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Recut.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Recut.lean
@@ -1,0 +1,410 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.KnotTheory.Grid.Differential.Square.OverlapOrder
+public import TauCeti.KnotTheory.Grid.Rectangle.Juxtaposition
+public import TauCeti.KnotTheory.Grid.Unblocked
+
+/-!
+# Recutting a two-step grid rectangle decomposition along its other internal edge
+
+A nondiagonal term in the square of the unblocked grid differential `∂⁻` is a pair of composable
+empty rectangles whose two pairs of side columns are either disjoint or share exactly one column.
+In the second case the two rectangles meet at a corner and their union is an L-shaped hexagon,
+which can be cut into two rectangles in exactly one other way. This file builds that alternate cut
+in the orientation where the two rectangles share their *initial* side column, and shows that it
+is again a decomposition by two rectangles the unblocked differential counts, carrying the same
+weight and passing through a different intermediate grid state.
+
+The relation between the two cuts is packaged as `GridRectangleDecomposition.IsRecut`: the
+rectangles of each cut cover disjoint sets of squares, and the two unions agree. That is exactly
+the amount of information a weight needs: any multiplicative function of squares has the same
+product on the two cuts, and in particular the `O`-monomials multiply to the same polynomial and
+`X`-avoidance transfers.
+
+The geometric input is the cyclic order forced by emptiness
+(`cyclicOrder_of_isEmpty_of_left_eq_left`) and the finite-domain repartition identity for the
+covered squares (`GridRectangle.coveredSquares_union_eq_of_mem_cIoo` and its complementary form).
+Emptiness of the new rectangles is not part of that identity: it is proved here, and it is where
+emptiness of *both* old rectangles is used, one for the columns below the cut and one for the
+columns above it.
+
+Three orientations of the shared side column remain: the two rectangles may share their terminal
+side, or the terminal side of one may be the initial side of the other. Those three, and the
+assembly of the disjoint, overlapping and annular cases into `∂⁻ ∘ ∂⁻ = 0`, are separate steps.
+
+## Main definitions
+
+* `TauCeti.GridRectangleDecomposition.IsRecut`: two two-step decompositions with the same
+  endpoints partition the same set of covered squares, through different intermediate states.
+
+## Main results
+
+* `TauCeti.GridRectangleDecomposition.IsRecut.prod_coveredSquares_mul_prod_coveredSquares`: a
+  recut preserves the product of any multiplicative weight on squares.
+* `TauCeti.GridRectangleDecomposition.IsRecut.OMonomial_mul_OMonomial`: a recut preserves the
+  product of the `O`-monomial weights of the unblocked differential.
+* `TauCeti.GridRectangleDecomposition.IsRecut.disjoint_XSet_first`,
+  `TauCeti.GridRectangleDecomposition.IsRecut.disjoint_XSet_second`: `X`-avoidance transfers
+  across a recut.
+* `TauCeti.GridRectangleDecomposition.exists_isRecut_of_left_eq_left`: two composable empty
+  rectangles sharing their initial side column admit a recut by two empty rectangles.
+* `TauCeti.GridRectangleDecomposition.exists_unblockedRectangles_recut_of_left_eq_left`: the
+  resulting pairing of the terms of `∂⁻ ∘ ∂⁻`, with equal weights and distinct intermediate
+  states.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, "The complexes and
+`∂² = 0`", specifically the overlapping case of its juxtaposition case analysis. The recut follows
+Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.6.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridRectangleDecomposition
+
+variable {n : ℕ} {x z : GridState n}
+
+/-! ### Two cuts of the same two-step domain -/
+
+/-- `E` is a *recut* of the two-step decomposition `D`: the two decompositions have the same
+endpoints, each cuts its domain into two rectangles covering disjoint sets of squares, the two
+domains agree, and the two cuts pass through different intermediate grid states.
+
+This is the pairing relation used by the juxtaposition proof of `∂⁻ ∘ ∂⁻ = 0`: the terms of the
+differential square indexed by `D` and by `E` carry the same weight and cancel in characteristic
+two. -/
+structure IsRecut (D E : GridRectangleDecomposition x z) : Prop where
+  /-- The two cuts pass through different intermediate grid states. -/
+  middle_ne : E.middle ≠ D.middle
+  /-- The two rectangles of `D` cover disjoint sets of squares. -/
+  disjoint_coveredSquares :
+    Disjoint D.first.toGridRectangle.coveredSquares D.second.toGridRectangle.coveredSquares
+  /-- The two rectangles of `E` cover disjoint sets of squares. -/
+  disjoint_coveredSquares_recut :
+    Disjoint E.first.toGridRectangle.coveredSquares E.second.toGridRectangle.coveredSquares
+  /-- The two cuts cover the same squares. -/
+  coveredSquares_union_eq :
+    E.first.toGridRectangle.coveredSquares ∪ E.second.toGridRectangle.coveredSquares =
+      D.first.toGridRectangle.coveredSquares ∪ D.second.toGridRectangle.coveredSquares
+
+namespace IsRecut
+
+variable {D E : GridRectangleDecomposition x z}
+
+/-- Being a recut is a symmetric relation. -/
+theorem symm (h : D.IsRecut E) : E.IsRecut D where
+  middle_ne := h.middle_ne.symm
+  disjoint_coveredSquares := h.disjoint_coveredSquares_recut
+  disjoint_coveredSquares_recut := h.disjoint_coveredSquares
+  coveredSquares_union_eq := h.coveredSquares_union_eq.symm
+
+/-- A recut preserves the product of any multiplicative weight on squares: both cuts partition
+the same finite set of covered squares. -/
+theorem prod_coveredSquares_mul_prod_coveredSquares (h : D.IsRecut E) {M : Type*} [CommMonoid M]
+    (f : Fin n × Fin n → M) :
+    (∏ p ∈ E.first.toGridRectangle.coveredSquares, f p) *
+        ∏ p ∈ E.second.toGridRectangle.coveredSquares, f p =
+      (∏ p ∈ D.first.toGridRectangle.coveredSquares, f p) *
+        ∏ p ∈ D.second.toGridRectangle.coveredSquares, f p := by
+  rw [← Finset.prod_union h.disjoint_coveredSquares_recut, h.coveredSquares_union_eq,
+    Finset.prod_union h.disjoint_coveredSquares]
+
+/-- A recut preserves the product of the `O`-monomial weights that the unblocked differential
+attaches to its two rectangles. -/
+theorem OMonomial_mul_OMonomial (h : D.IsRecut E) (G : GridDiagram n) (R : Type*)
+    [CommSemiring R] :
+    G.OMonomial R E.first.toGridRectangle * G.OMonomial R E.second.toGridRectangle =
+      G.OMonomial R D.first.toGridRectangle * G.OMonomial R D.second.toGridRectangle := by
+  simp only [G.OMonomial_eq_prod_coveredSquares R]
+  exact h.prod_coveredSquares_mul_prod_coveredSquares _
+
+/-- If neither rectangle of `D` covers an `X`-marking, then neither does the first rectangle of a
+recut of `D`. -/
+theorem disjoint_XSet_first (h : D.IsRecut E) {G : GridDiagram n}
+    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares G.XSet)
+    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares G.XSet) :
+    Disjoint E.first.toGridRectangle.coveredSquares G.XSet := by
+  have hunion : Disjoint
+      (E.first.toGridRectangle.coveredSquares ∪ E.second.toGridRectangle.coveredSquares)
+      G.XSet := by
+    rw [h.coveredSquares_union_eq]
+    exact Finset.disjoint_union_left.mpr ⟨h₁, h₂⟩
+  exact (Finset.disjoint_union_left.mp hunion).1
+
+/-- If neither rectangle of `D` covers an `X`-marking, then neither does the second rectangle of a
+recut of `D`. -/
+theorem disjoint_XSet_second (h : D.IsRecut E) {G : GridDiagram n}
+    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares G.XSet)
+    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares G.XSet) :
+    Disjoint E.second.toGridRectangle.coveredSquares G.XSet := by
+  have hunion : Disjoint
+      (E.first.toGridRectangle.coveredSquares ∪ E.second.toGridRectangle.coveredSquares)
+      G.XSet := by
+    rw [h.coveredSquares_union_eq]
+    exact Finset.disjoint_union_left.mpr ⟨h₁, h₂⟩
+  exact (Finset.disjoint_union_left.mp hunion).2
+
+end IsRecut
+
+/-! ### Building the recut -/
+
+/-- The recut in the configuration where the terminal side of the first rectangle lies strictly
+inside the column span of the second one.
+
+The two rectangles `{a, b} × {x a, x b}` and `{a, d} × {x b, x d}` are cut apart along the column
+line `b` instead of the row line `x b`. -/
+private theorem exists_recut_columnCut {a b d : Fin n}
+    (hab : a ≠ b) (had : a ≠ d) (hbd : b ≠ d)
+    (hz : z = (x.swapColumns a b).swapColumns a d)
+    (hcol : b ∈ Grid.cIoo a d) (hrow : x b ∈ Grid.cIoo (x a) (x d))
+    (hfirst : ∀ c ∈ Grid.cIoo a b, x c ∉ Grid.cIoo (x a) (x b))
+    (hsecond : ∀ c ∈ Grid.cIoo a d, c ≠ a → c ≠ b → x c ∉ Grid.cIoo (x b) (x d)) :
+    ∃ E : GridRectangleDecomposition x z,
+      E.middle = x.swapColumns b d ∧
+        E.first.toGridRectangle = { left := b, right := d, bottom := x b, top := x d } ∧
+          E.second.toGridRectangle = { left := a, right := b, bottom := x a, top := x d } ∧
+            E.first.IsEmpty ∧ E.second.IsEmpty := by
+  have hz' : z = (x.swapColumns b d).swapColumns a b := by
+    rw [hz, GridState.swapColumns_swapColumns_conj x b d a b, Equiv.swap_apply_right,
+      Equiv.swap_apply_of_ne_of_ne had.symm hbd.symm]
+  have hmid_a : (x.swapColumns b d) a = x a := by
+    rw [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab had]
+  have hmid_b : (x.swapColumns b d) b = x d := by
+    rw [GridState.swapColumns_apply, Equiv.swap_apply_left]
+  refine ⟨{ middle := x.swapColumns b d
+            first := GridRectangleBetween.ofSwapColumns x _ b d hbd rfl
+            second := GridRectangleBetween.ofSwapColumns _ z a b hab hz' }, rfl, by simp,
+          by simp [hmid_a, hmid_b], ?_, ?_⟩
+  · rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo]
+    simp only [GridRectangleBetween.ofSwapColumns_left, GridRectangleBetween.ofSwapColumns_right,
+      GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top]
+    intro c hc
+    have hcad : c ∈ Grid.cIoo a d := Grid.cIoo_subset_cIoo_of_mem_cIoo_right hcol hc
+    have hca : c ≠ a := by
+      rintro rfl
+      exact Grid.left_notMem_cIoo _ _ hcad
+    have hcb : c ≠ b := by
+      rintro rfl
+      exact Grid.left_notMem_cIoo _ _ hc
+    exact hsecond c hcad hca hcb
+  · rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo]
+    simp only [GridRectangleBetween.ofSwapColumns_left, GridRectangleBetween.ofSwapColumns_right,
+      GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top, hmid_a,
+      hmid_b]
+    intro c hc hmem
+    have hca : c ≠ a := by
+      rintro rfl
+      exact Grid.left_notMem_cIoo _ _ hc
+    have hcb : c ≠ b := by
+      rintro rfl
+      exact Grid.right_notMem_cIoo _ _ hc
+    have hcad : c ∈ Grid.cIoo a d := Grid.cIoo_subset_cIoo_of_mem_cIoo_left hcol hc
+    have hcd : c ≠ d := by
+      rintro rfl
+      exact Grid.right_notMem_cIoo _ _ hcad
+    rw [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hcb hcd] at hmem
+    have hcut : x c ∈ Grid.cIoo (x a) (x b) ∪ insert (x b) (Grid.cIoo (x b) (x d)) := by
+      rw [Grid.cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo hrow]
+      exact hmem
+    rw [Finset.mem_union, Finset.mem_insert] at hcut
+    rcases hcut with hcut | hcut | hcut
+    · exact hfirst c hc hcut
+    · exact hcb (x.toPerm.injective hcut)
+    · exact hsecond c hcad hca hcb hcut
+
+/-- The recut in the configuration where the terminal side of the second rectangle lies strictly
+inside the column span of the first one.
+
+The two rectangles `{a, b} × {x a, x b}` and `{a, d} × {x b, x d}` are cut apart along the column
+line `d` instead of the row line `x b`. -/
+private theorem exists_recut_complementaryColumnCut {a b d : Fin n}
+    (hab : a ≠ b) (had : a ≠ d) (hbd : b ≠ d)
+    (hz : z = (x.swapColumns a b).swapColumns a d)
+    (hcol : d ∈ Grid.cIoo a b) (hrow : x b ∈ Grid.cIoo (x a) (x d))
+    (hfirst : ∀ c ∈ Grid.cIoo a b, x c ∉ Grid.cIoo (x a) (x b))
+    (hsecond : ∀ c ∈ Grid.cIoo a d, c ≠ a → c ≠ b → x c ∉ Grid.cIoo (x b) (x d)) :
+    ∃ E : GridRectangleDecomposition x z,
+      E.middle = x.swapColumns a d ∧
+        E.first.toGridRectangle = { left := a, right := d, bottom := x a, top := x d } ∧
+          E.second.toGridRectangle = { left := d, right := b, bottom := x a, top := x b } ∧
+            E.first.IsEmpty ∧ E.second.IsEmpty := by
+  have hz' : z = (x.swapColumns a d).swapColumns d b := by
+    rw [hz, GridState.swapColumns_swapColumns_conj x a b a d, Equiv.swap_apply_left,
+      Equiv.swap_apply_of_ne_of_ne hab.symm hbd]
+  have hmid_d : (x.swapColumns a d) d = x a := by
+    rw [GridState.swapColumns_apply, Equiv.swap_apply_right]
+  have hmid_b : (x.swapColumns a d) b = x b := by
+    rw [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab.symm hbd]
+  refine ⟨{ middle := x.swapColumns a d
+            first := GridRectangleBetween.ofSwapColumns x _ a d had rfl
+            second := GridRectangleBetween.ofSwapColumns _ z d b hbd.symm hz' }, rfl, by simp,
+          by simp [hmid_d, hmid_b], ?_, ?_⟩
+  · rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo]
+    simp only [GridRectangleBetween.ofSwapColumns_left, GridRectangleBetween.ofSwapColumns_right,
+      GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top]
+    intro c hc hmem
+    have hca : c ≠ a := by
+      rintro rfl
+      exact Grid.left_notMem_cIoo _ _ hc
+    have hcd : c ≠ d := by
+      rintro rfl
+      exact Grid.right_notMem_cIoo _ _ hc
+    have hcab : c ∈ Grid.cIoo a b := Grid.cIoo_subset_cIoo_of_mem_cIoo_left hcol hc
+    have hcb : c ≠ b := by
+      rintro rfl
+      exact Grid.right_notMem_cIoo _ _ hcab
+    have hcut : x c ∈ Grid.cIoo (x a) (x b) ∪ insert (x b) (Grid.cIoo (x b) (x d)) := by
+      rw [Grid.cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo hrow]
+      exact hmem
+    rw [Finset.mem_union, Finset.mem_insert] at hcut
+    rcases hcut with hcut | hcut | hcut
+    · exact hfirst c hcab hcut
+    · exact hcb (x.toPerm.injective hcut)
+    · exact hsecond c hc hca hcb hcut
+  · rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo]
+    simp only [GridRectangleBetween.ofSwapColumns_left, GridRectangleBetween.ofSwapColumns_right,
+      GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top, hmid_d,
+      hmid_b]
+    intro c hc
+    have hcab : c ∈ Grid.cIoo a b := Grid.cIoo_subset_cIoo_of_mem_cIoo_right hcol hc
+    have hca : c ≠ a := by
+      rintro rfl
+      exact Grid.left_notMem_cIoo _ _ hcab
+    have hcd : c ≠ d := by
+      rintro rfl
+      exact Grid.left_notMem_cIoo _ _ hc
+    rw [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hca hcd]
+    exact hfirst c hcab
+
+/-! ### The recut of a decomposition sharing its initial side column -/
+
+/-- Two composable empty rectangles that share their initial side column and no other side admit
+a *recut*: the L-shaped union of their domains has a second decomposition into two empty
+rectangles, through a different intermediate grid state.
+
+Emptiness of both rectangles enters twice. It fixes the cyclic order of the three side columns
+and of the three corner rows, and it then transfers to the two new rectangles: the part of a new
+rectangle below the cut is controlled by the first old rectangle and the part above it by the
+second. -/
+theorem exists_isRecut_of_left_eq_left (D : GridRectangleDecomposition x z)
+    (hleft : D.first.left = D.second.left) (hright : D.first.right ≠ D.second.right)
+    (hfirst : D.first.IsEmpty) (hsecond : D.second.IsEmpty) :
+    ∃ E : GridRectangleDecomposition x z, D.IsRecut E ∧ E.first.IsEmpty ∧ E.second.IsEmpty := by
+  have hab : D.first.left ≠ D.first.right := D.first.left_ne_right
+  have had : D.first.left ≠ D.second.right := by
+    rw [hleft]
+    exact D.second.left_ne_right
+  have hmid : D.middle = x.swapColumns D.first.left D.first.right :=
+    D.first.target_eq_swapColumns
+  have hmid_first : D.middle D.first.left = x D.first.right := D.first.map_left
+  have hmid_second : D.middle D.second.right = x D.second.right :=
+    D.first.map_of_ne _ had.symm hright.symm
+  have hz : z = (x.swapColumns D.first.left D.first.right).swapColumns D.first.left
+      D.second.right := by
+    rw [← hmid, hleft]
+    exact D.second.target_eq_swapColumns
+  obtain ⟨hcolcase, hrow⟩ := D.cyclicOrder_of_isEmpty_of_left_eq_left hleft hright hfirst hsecond
+  simp only [GridRectangleBetween.bottom_def, GridRectangleBetween.top_def, hmid_second] at hrow
+  have hfirst' : ∀ c ∈ Grid.cIoo D.first.left D.first.right,
+      x c ∉ Grid.cIoo (x D.first.left) (x D.first.right) := by
+    have h := hfirst
+    rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo] at h
+    simpa only [GridRectangleBetween.bottom_def, GridRectangleBetween.top_def] using h
+  have hsecond' : ∀ c ∈ Grid.cIoo D.first.left D.second.right, c ≠ D.first.left →
+      c ≠ D.first.right → x c ∉ Grid.cIoo (x D.first.right) (x D.second.right) := by
+    have h := hsecond
+    rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo] at h
+    simp only [GridRectangleBetween.bottom_def, GridRectangleBetween.top_def, ← hleft, hmid_first,
+      hmid_second] at h
+    intro c hc hca hcb
+    have hcm := h c hc
+    rwa [D.first.map_of_ne c hca hcb] at hcm
+  have hD1 : D.first.toGridRectangle =
+      { left := D.first.left, right := D.first.right, bottom := x D.first.left,
+        top := x D.first.right } := rfl
+  have hD2 : D.second.toGridRectangle =
+      { left := D.first.left, right := D.second.right, bottom := x D.first.right,
+        top := x D.second.right } := by
+    have hlit : D.second.toGridRectangle =
+        { left := D.second.left, right := D.second.right, bottom := D.second.bottom,
+          top := D.second.top } := rfl
+    have hb2 : D.second.bottom = x D.first.right := by
+      rw [GridRectangleBetween.bottom_def, ← hleft]
+      exact hmid_first
+    have ht2 : D.second.top = x D.second.right := by
+      rw [GridRectangleBetween.top_def]
+      exact hmid_second
+    rw [hlit, hb2, ht2, ← hleft]
+  have hDdisj : Disjoint D.first.toGridRectangle.coveredSquares
+      D.second.toGridRectangle.coveredSquares := by
+    rw [hD1, hD2]
+    exact (GridRectangle.disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
+      simpa only [GridRectangle.coveredRows_def] using
+        Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
+  rcases hcolcase with hcol | hcol
+  · obtain ⟨E, hmidE, hE1, hE2, hEfirst, hEsecond⟩ :=
+      exists_recut_columnCut hab had hright hz hcol hrow hfirst' hsecond'
+    refine ⟨E, ⟨?_, hDdisj, ?_, ?_⟩, hEfirst, hEsecond⟩
+    · intro h
+      have hval : E.middle D.first.left = D.middle D.first.left := by rw [h]
+      rw [hmidE, hmid_first] at hval
+      simp only [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab had] at hval
+      exact hab (x.toPerm.injective hval)
+    · rw [hE1, hE2]
+      exact (GridRectangle.disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
+        simpa only [GridRectangle.coveredColumns_def] using
+          (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol).symm))
+    · rw [hE1, hE2, hD1, hD2]
+      exact (GridRectangle.coveredSquares_union_eq_of_mem_cIoo hcol hrow).symm
+  · obtain ⟨E, hmidE, hE1, hE2, hEfirst, hEsecond⟩ :=
+      exists_recut_complementaryColumnCut hab had hright hz hcol hrow hfirst' hsecond'
+    refine ⟨E, ⟨?_, hDdisj, ?_, ?_⟩, hEfirst, hEsecond⟩
+    · intro h
+      have hval : E.middle D.first.right = D.middle D.first.right := by rw [h]
+      rw [hmidE, D.first.map_right] at hval
+      simp only [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab.symm hright] at hval
+      exact hab (x.toPerm.injective hval).symm
+    · rw [hE1, hE2]
+      exact (GridRectangle.disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
+        simpa only [GridRectangle.coveredColumns_def] using
+          Grid.disjoint_cIco_cIco_of_mem_cIoo hcol))
+    · rw [hE1, hE2, hD1, hD2]
+      exact (GridRectangle.coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut hcol
+        hrow).symm
+
+/-- The pairing of two-step terms of `∂⁻ ∘ ∂⁻` in the orientation where the two rectangles share
+their initial side column.
+
+A pair of composable rectangles that the unblocked differential counts is matched with a second
+such pair, through a different intermediate grid state and with the same product of weights. Over
+a coefficient ring of characteristic two the two terms therefore cancel. -/
+theorem exists_unblockedRectangles_recut_of_left_eq_left (G : GridDiagram n) (R : Type*)
+    [CommSemiring R] (D : GridRectangleDecomposition x z)
+    (hleft : D.first.left = D.second.left) (hright : D.first.right ≠ D.second.right)
+    (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
+    (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
+    ∃ E : GridRectangleDecomposition x z,
+      E.middle ≠ D.middle ∧ E.first ∈ G.unblockedRectangles x E.middle ∧
+        E.second ∈ G.unblockedRectangles E.middle z ∧
+          G.OMonomial R E.first.toGridRectangle * G.OMonomial R E.second.toGridRectangle =
+            G.OMonomial R D.first.toGridRectangle * G.OMonomial R D.second.toGridRectangle := by
+  obtain ⟨E, hrecut, hEfirst, hEsecond⟩ := D.exists_isRecut_of_left_eq_left hleft hright
+    (G.isEmpty_of_mem_unblockedRectangles hfirst) (G.isEmpty_of_mem_unblockedRectangles hsecond)
+  have hX₁ := G.disjoint_XSet_of_mem_unblockedRectangles hfirst
+  have hX₂ := G.disjoint_XSet_of_mem_unblockedRectangles hsecond
+  exact ⟨E, hrecut.middle_ne,
+    (G.mem_unblockedRectangles _).mpr ⟨hEfirst, hrecut.disjoint_XSet_first hX₁ hX₂⟩,
+    (G.mem_unblockedRectangles _).mpr ⟨hEsecond, hrecut.disjoint_XSet_second hX₁ hX₂⟩,
+    hrecut.OMonomial_mul_OMonomial G R⟩
+
+end GridRectangleDecomposition
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Recut.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Recut.lean
@@ -21,10 +21,11 @@ is again a decomposition by two rectangles the unblocked differential counts, ca
 weight and passing through a different intermediate grid state.
 
 The relation between the two cuts is packaged as `GridRectangleDecomposition.IsRecut`: the
-rectangles of each cut cover disjoint sets of squares, and the two unions agree. That is exactly
-the amount of information a weight needs: any multiplicative function of squares has the same
-product on the two cuts, and in particular the `O`-monomials multiply to the same polynomial and
-`X`-avoidance transfers.
+rectangles of each cut cover disjoint sets of squares, and the two unions agree. The geometric
+construction separately proves that the two cuts have different intermediate states. The domain
+relation is exactly the amount of information a weight needs: any multiplicative function of
+squares has the same product on the two cuts, and in particular the `O`-monomials multiply to the
+same polynomial and `X`-avoidance transfers.
 
 The geometric input is the cyclic order forced by emptiness
 (`cyclicOrder_of_isEmpty_of_left_eq_left`) and the finite-domain repartition identity for the
@@ -40,7 +41,7 @@ assembly of the disjoint, overlapping and annular cases into `∂⁻ ∘ ∂⁻ 
 ## Main definitions
 
 * `TauCeti.GridRectangleDecomposition.IsRecut`: two two-step decompositions with the same
-  endpoints partition the same set of covered squares, through different intermediate states.
+  endpoints partition the same set of covered squares.
 
 ## Main results
 
@@ -75,15 +76,12 @@ variable {n : ℕ} {x z : GridState n}
 /-! ### Two cuts of the same two-step domain -/
 
 /-- `E` is a *recut* of the two-step decomposition `D`: the two decompositions have the same
-endpoints, each cuts its domain into two rectangles covering disjoint sets of squares, the two
-domains agree, and the two cuts pass through different intermediate grid states.
+endpoints, each cuts its domain into two rectangles covering disjoint sets of squares, and the two
+domains agree.
 
-This is the pairing relation used by the juxtaposition proof of `∂⁻ ∘ ∂⁻ = 0`: the terms of the
-differential square indexed by `D` and by `E` carry the same weight and cancel in characteristic
-two. -/
+This is the domain relation used by the juxtaposition proof of `∂⁻ ∘ ∂⁻ = 0`; the pairing theorem
+additionally requires the two intermediate states to differ. -/
 structure IsRecut (D E : GridRectangleDecomposition x z) : Prop where
-  /-- The two cuts pass through different intermediate grid states. -/
-  middle_ne : E.middle ≠ D.middle
   /-- The two rectangles of `D` cover disjoint sets of squares. -/
   disjoint_coveredSquares :
     Disjoint D.first.toGridRectangle.coveredSquares D.second.toGridRectangle.coveredSquares
@@ -101,7 +99,6 @@ variable {D E : GridRectangleDecomposition x z}
 
 /-- Being a recut is a symmetric relation. -/
 theorem symm (h : D.IsRecut E) : E.IsRecut D where
-  middle_ne := h.middle_ne.symm
   disjoint_coveredSquares := h.disjoint_coveredSquares_recut
   disjoint_coveredSquares_recut := h.disjoint_coveredSquares
   coveredSquares_union_eq := h.coveredSquares_union_eq.symm
@@ -156,6 +153,31 @@ end IsRecut
 
 /-! ### Building the recut -/
 
+/-- If a column belongs to both old column spans, the emptiness of the old rectangles excludes
+its grid-state point from their combined row span. -/
+private theorem notMem_combinedRowSpan_of_mem_bothColumnSpans {a b d c : Fin n}
+    (hrow : x b ∈ Grid.cIoo (x a) (x d))
+    (hfirst : ∀ c ∈ Grid.cIoo a b, x c ∉ Grid.cIoo (x a) (x b))
+    (hsecond : ∀ c ∈ Grid.cIoo a d, c ≠ a → c ≠ b →
+      x c ∉ Grid.cIoo (x b) (x d))
+    (hcab : c ∈ Grid.cIoo a b) (hcad : c ∈ Grid.cIoo a d) :
+    x c ∉ Grid.cIoo (x a) (x d) := by
+  intro hmem
+  have hca : c ≠ a := by
+    rintro rfl
+    exact Grid.left_notMem_cIoo _ _ hcab
+  have hcb : c ≠ b := by
+    rintro rfl
+    exact Grid.right_notMem_cIoo _ _ hcab
+  have hcut : x c ∈ Grid.cIoo (x a) (x b) ∪ insert (x b) (Grid.cIoo (x b) (x d)) := by
+    rw [Grid.cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo hrow]
+    exact hmem
+  rw [Finset.mem_union, Finset.mem_insert] at hcut
+  rcases hcut with hcut | hcut | hcut
+  · exact hfirst c hcab hcut
+  · exact hcb (x.toPerm.injective hcut)
+  · exact hsecond c hcad hca hcb hcut
+
 /-- The recut in the configuration where the terminal side of the first rectangle lies strictly
 inside the column span of the second one.
 
@@ -200,9 +222,6 @@ private theorem exists_recut_columnCut {a b d : Fin n}
       GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top, hmid_a,
       hmid_b]
     intro c hc hmem
-    have hca : c ≠ a := by
-      rintro rfl
-      exact Grid.left_notMem_cIoo _ _ hc
     have hcb : c ≠ b := by
       rintro rfl
       exact Grid.right_notMem_cIoo _ _ hc
@@ -211,14 +230,7 @@ private theorem exists_recut_columnCut {a b d : Fin n}
       rintro rfl
       exact Grid.right_notMem_cIoo _ _ hcad
     rw [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hcb hcd] at hmem
-    have hcut : x c ∈ Grid.cIoo (x a) (x b) ∪ insert (x b) (Grid.cIoo (x b) (x d)) := by
-      rw [Grid.cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo hrow]
-      exact hmem
-    rw [Finset.mem_union, Finset.mem_insert] at hcut
-    rcases hcut with hcut | hcut | hcut
-    · exact hfirst c hc hcut
-    · exact hcb (x.toPerm.injective hcut)
-    · exact hsecond c hcad hca hcb hcut
+    exact notMem_combinedRowSpan_of_mem_bothColumnSpans hrow hfirst hsecond hc hcad hmem
 
 /-- The recut in the configuration where the terminal side of the second rectangle lies strictly
 inside the column span of the first one.
@@ -250,25 +262,9 @@ private theorem exists_recut_complementaryColumnCut {a b d : Fin n}
   · rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo]
     simp only [GridRectangleBetween.ofSwapColumns_left, GridRectangleBetween.ofSwapColumns_right,
       GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top]
-    intro c hc hmem
-    have hca : c ≠ a := by
-      rintro rfl
-      exact Grid.left_notMem_cIoo _ _ hc
-    have hcd : c ≠ d := by
-      rintro rfl
-      exact Grid.right_notMem_cIoo _ _ hc
+    intro c hc
     have hcab : c ∈ Grid.cIoo a b := Grid.cIoo_subset_cIoo_of_mem_cIoo_left hcol hc
-    have hcb : c ≠ b := by
-      rintro rfl
-      exact Grid.right_notMem_cIoo _ _ hcab
-    have hcut : x c ∈ Grid.cIoo (x a) (x b) ∪ insert (x b) (Grid.cIoo (x b) (x d)) := by
-      rw [Grid.cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo hrow]
-      exact hmem
-    rw [Finset.mem_union, Finset.mem_insert] at hcut
-    rcases hcut with hcut | hcut | hcut
-    · exact hfirst c hcab hcut
-    · exact hcb (x.toPerm.injective hcut)
-    · exact hsecond c hc hca hcb hcut
+    exact notMem_combinedRowSpan_of_mem_bothColumnSpans hrow hfirst hsecond hcab hc
   · rw [GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo]
     simp only [GridRectangleBetween.ofSwapColumns_left, GridRectangleBetween.ofSwapColumns_right,
       GridRectangleBetween.ofSwapColumns_bottom, GridRectangleBetween.ofSwapColumns_top, hmid_d,
@@ -297,7 +293,8 @@ second. -/
 theorem exists_isRecut_of_left_eq_left (D : GridRectangleDecomposition x z)
     (hleft : D.first.left = D.second.left) (hright : D.first.right ≠ D.second.right)
     (hfirst : D.first.IsEmpty) (hsecond : D.second.IsEmpty) :
-    ∃ E : GridRectangleDecomposition x z, D.IsRecut E ∧ E.first.IsEmpty ∧ E.second.IsEmpty := by
+    ∃ E : GridRectangleDecomposition x z,
+      D.IsRecut E ∧ E.middle ≠ D.middle ∧ E.first.IsEmpty ∧ E.second.IsEmpty := by
   have hab : D.first.left ≠ D.first.right := D.first.left_ne_right
   have had : D.first.left ≠ D.second.right := by
     rw [hleft]
@@ -352,12 +349,13 @@ theorem exists_isRecut_of_left_eq_left (D : GridRectangleDecomposition x z)
   rcases hcolcase with hcol | hcol
   · obtain ⟨E, hmidE, hE1, hE2, hEfirst, hEsecond⟩ :=
       exists_recut_columnCut hab had hright hz hcol hrow hfirst' hsecond'
-    refine ⟨E, ⟨?_, hDdisj, ?_, ?_⟩, hEfirst, hEsecond⟩
-    · intro h
+    have hmiddle : E.middle ≠ D.middle := by
+      intro h
       have hval : E.middle D.first.left = D.middle D.first.left := by rw [h]
       rw [hmidE, hmid_first] at hval
       simp only [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab had] at hval
       exact hab (x.toPerm.injective hval)
+    refine ⟨E, ⟨hDdisj, ?_, ?_⟩, hmiddle, hEfirst, hEsecond⟩
     · rw [hE1, hE2]
       exact (GridRectangle.disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
         simpa only [GridRectangle.coveredColumns_def] using
@@ -366,12 +364,13 @@ theorem exists_isRecut_of_left_eq_left (D : GridRectangleDecomposition x z)
       exact (GridRectangle.coveredSquares_union_eq_of_mem_cIoo hcol hrow).symm
   · obtain ⟨E, hmidE, hE1, hE2, hEfirst, hEsecond⟩ :=
       exists_recut_complementaryColumnCut hab had hright hz hcol hrow hfirst' hsecond'
-    refine ⟨E, ⟨?_, hDdisj, ?_, ?_⟩, hEfirst, hEsecond⟩
-    · intro h
+    have hmiddle : E.middle ≠ D.middle := by
+      intro h
       have hval : E.middle D.first.right = D.middle D.first.right := by rw [h]
       rw [hmidE, D.first.map_right] at hval
       simp only [GridState.swapColumns_apply, Equiv.swap_apply_of_ne_of_ne hab.symm hright] at hval
       exact hab (x.toPerm.injective hval).symm
+    refine ⟨E, ⟨hDdisj, ?_, ?_⟩, hmiddle, hEfirst, hEsecond⟩
     · rw [hE1, hE2]
       exact (GridRectangle.disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
         simpa only [GridRectangle.coveredColumns_def] using
@@ -392,15 +391,17 @@ theorem exists_unblockedRectangles_recut_of_left_eq_left (G : GridDiagram n) (R 
     (hfirst : D.first ∈ G.unblockedRectangles x D.middle)
     (hsecond : D.second ∈ G.unblockedRectangles D.middle z) :
     ∃ E : GridRectangleDecomposition x z,
-      E.middle ≠ D.middle ∧ E.first ∈ G.unblockedRectangles x E.middle ∧
-        E.second ∈ G.unblockedRectangles E.middle z ∧
-          G.OMonomial R E.first.toGridRectangle * G.OMonomial R E.second.toGridRectangle =
-            G.OMonomial R D.first.toGridRectangle * G.OMonomial R D.second.toGridRectangle := by
-  obtain ⟨E, hrecut, hEfirst, hEsecond⟩ := D.exists_isRecut_of_left_eq_left hleft hright
+      D.IsRecut E ∧ E.middle ≠ D.middle ∧
+        E.first ∈ G.unblockedRectangles x E.middle ∧
+          E.second ∈ G.unblockedRectangles E.middle z ∧
+            G.OMonomial R E.first.toGridRectangle * G.OMonomial R E.second.toGridRectangle =
+              G.OMonomial R D.first.toGridRectangle * G.OMonomial R D.second.toGridRectangle := by
+  obtain ⟨E, hrecut, hmiddle, hEfirst, hEsecond⟩ :=
+    D.exists_isRecut_of_left_eq_left hleft hright
     (G.isEmpty_of_mem_unblockedRectangles hfirst) (G.isEmpty_of_mem_unblockedRectangles hsecond)
   have hX₁ := G.disjoint_XSet_of_mem_unblockedRectangles hfirst
   have hX₂ := G.disjoint_XSet_of_mem_unblockedRectangles hsecond
-  exact ⟨E, hrecut.middle_ne,
+  exact ⟨E, hrecut, hmiddle,
     (G.mem_unblockedRectangles _).mpr ⟨hEfirst, hrecut.disjoint_XSet_first hX₁ hX₂⟩,
     (G.mem_unblockedRectangles _).mpr ⟨hEsecond, hrecut.disjoint_XSet_second hX₁ hX₂⟩,
     hrecut.OMonomial_mul_OMonomial G R⟩

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Repartition.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Repartition.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.KnotTheory.Grid.Differential.Square.Decomposition
+public import TauCeti.KnotTheory.Grid.Unblocked
+
+/-!
+# Repartitions of two-step grid rectangle domains
+
+Two two-step grid rectangle decompositions are repartitions when the rectangles in each
+decomposition cover disjoint sets of squares and the unions of those sets agree. This is the
+domain relation used by the juxtaposition proof of `∂⁻ ∘ ∂⁻ = 0`: it transports multiplicative
+weights and avoidance of marked squares without requiring the two cuts to be distinct.
+
+## Main definitions
+
+* `TauCeti.GridRectangleDecomposition.IsRepartition`: two decompositions partition the same set
+  of covered squares.
+
+## Main results
+
+* `TauCeti.GridRectangleDecomposition.IsRepartition.prod_coveredSquares_mul_prod_coveredSquares`:
+  a repartition preserves the product of any multiplicative weight on squares.
+* `TauCeti.GridRectangleDecomposition.IsRepartition.OMonomial_mul_OMonomial`: a repartition
+  preserves the product of the `O`-monomial weights of the unblocked differential.
+* `TauCeti.GridRectangleDecomposition.IsRepartition.disjoint_coveredSquares_first`,
+  `TauCeti.GridRectangleDecomposition.IsRepartition.disjoint_coveredSquares_second`: avoidance
+  of a set of squares transfers across a repartition.
+
+## References
+
+This supplies the shared domain relation for
+`TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, "The complexes and `∂² = 0`".
+The repartition argument follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*,
+Chapter 4.6.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridRectangleDecomposition
+
+variable {n : ℕ} {x z : GridState n}
+
+/-- `E` is a repartition of `D`: the rectangles in each decomposition cover disjoint sets of
+squares, and the two unions agree. -/
+structure IsRepartition (D E : GridRectangleDecomposition x z) : Prop where
+  /-- The two rectangles in the left-hand decomposition cover disjoint sets of squares. -/
+  disjoint_coveredSquares_left :
+    Disjoint D.first.toGridRectangle.coveredSquares D.second.toGridRectangle.coveredSquares
+  /-- The two rectangles in the right-hand decomposition cover disjoint sets of squares. -/
+  disjoint_coveredSquares_right :
+    Disjoint E.first.toGridRectangle.coveredSquares E.second.toGridRectangle.coveredSquares
+  /-- The two decompositions cover the same squares. -/
+  coveredSquares_union_eq :
+    E.first.toGridRectangle.coveredSquares ∪ E.second.toGridRectangle.coveredSquares =
+      D.first.toGridRectangle.coveredSquares ∪ D.second.toGridRectangle.coveredSquares
+
+namespace IsRepartition
+
+variable {D E : GridRectangleDecomposition x z}
+
+/-- Being a repartition is a symmetric relation. -/
+theorem symm (h : D.IsRepartition E) : E.IsRepartition D where
+  disjoint_coveredSquares_left := h.disjoint_coveredSquares_right
+  disjoint_coveredSquares_right := h.disjoint_coveredSquares_left
+  coveredSquares_union_eq := h.coveredSquares_union_eq.symm
+
+/-- A repartition preserves the product of any multiplicative weight on squares: both
+decompositions partition the same finite set of covered squares. -/
+theorem prod_coveredSquares_mul_prod_coveredSquares (h : D.IsRepartition E) {M : Type*}
+    [CommMonoid M] (f : Fin n × Fin n → M) :
+    (∏ p ∈ E.first.toGridRectangle.coveredSquares, f p) *
+        ∏ p ∈ E.second.toGridRectangle.coveredSquares, f p =
+      (∏ p ∈ D.first.toGridRectangle.coveredSquares, f p) *
+        ∏ p ∈ D.second.toGridRectangle.coveredSquares, f p := by
+  rw [← Finset.prod_union h.disjoint_coveredSquares_right, h.coveredSquares_union_eq,
+    Finset.prod_union h.disjoint_coveredSquares_left]
+
+/-- A repartition preserves the product of the `O`-monomial weights that the unblocked
+differential attaches to its two rectangles. -/
+theorem OMonomial_mul_OMonomial (h : D.IsRepartition E) (G : GridDiagram n) (R : Type*)
+    [CommSemiring R] :
+    G.OMonomial R E.first.toGridRectangle * G.OMonomial R E.second.toGridRectangle =
+      G.OMonomial R D.first.toGridRectangle * G.OMonomial R D.second.toGridRectangle := by
+  simp only [G.OMonomial_eq_prod_coveredSquares R]
+  exact h.prod_coveredSquares_mul_prod_coveredSquares _
+
+/-- If neither rectangle of the left-hand decomposition meets a set of squares, then the union
+of the right-hand decomposition does not meet it either. -/
+theorem disjoint_coveredSquares_union (h : D.IsRepartition E) {s : Finset (Fin n × Fin n)}
+    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares s)
+    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares s) :
+    Disjoint (E.first.toGridRectangle.coveredSquares ∪
+      E.second.toGridRectangle.coveredSquares) s := by
+  rw [h.coveredSquares_union_eq]
+  exact Finset.disjoint_union_left.mpr ⟨h₁, h₂⟩
+
+/-- If neither rectangle of the left-hand decomposition meets a set of squares, then neither
+does the first rectangle of the right-hand decomposition. -/
+theorem disjoint_coveredSquares_first (h : D.IsRepartition E) {s : Finset (Fin n × Fin n)}
+    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares s)
+    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares s) :
+    Disjoint E.first.toGridRectangle.coveredSquares s :=
+  (Finset.disjoint_union_left.mp (h.disjoint_coveredSquares_union h₁ h₂)).1
+
+/-- If neither rectangle of the left-hand decomposition meets a set of squares, then neither
+does the second rectangle of the right-hand decomposition. -/
+theorem disjoint_coveredSquares_second (h : D.IsRepartition E) {s : Finset (Fin n × Fin n)}
+    (h₁ : Disjoint D.first.toGridRectangle.coveredSquares s)
+    (h₂ : Disjoint D.second.toGridRectangle.coveredSquares s) :
+    Disjoint E.second.toGridRectangle.coveredSquares s :=
+  (Finset.disjoint_union_left.mp (h.disjoint_coveredSquares_union h₁ h₂)).2
+
+end IsRepartition
+
+end GridRectangleDecomposition
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
@@ -55,8 +55,12 @@ changing it requires a separate update of the blocked-rectangle and small-grid d
 
 ## Main results
 
-* `TauCeti.GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo`: emptiness of an oriented
-  rectangle, quantified over the columns strictly inside it.
+* `TauCeti.GridRectangle.isEmptyFor_iff_forall_notMem_cIoo`: emptiness of a toroidal rectangle
+  for a grid state, quantified over the columns strictly inside it, and
+  `TauCeti.GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo`, its form for an oriented
+  rectangle and its source state.
+* `TauCeti.GridRectangleBetween.toGridRectangle_eq`: the toroidal rectangle underlying an
+  oriented rectangle, in terms of its two side columns.
 
 ## References
 
@@ -264,6 +268,21 @@ theorem isEmptyFor_iff (x : GridState n) :
     subst hpq
     exact h p hp hq
 
+/-- A rectangle is empty for a grid state exactly when the state sends every column strictly
+between its two side columns to a row outside the open arc between its two side rows.
+
+This is the one-dimensional form of emptiness that the rectangle-pairing arguments for the grid
+differential use: it quantifies over columns rather than over grid points. -/
+theorem isEmptyFor_iff_forall_notMem_cIoo (x : GridState n) :
+    R.IsEmptyFor x ↔ ∀ c ∈ Grid.cIoo R.left R.right, x c ∉ Grid.cIoo R.bottom R.top := by
+  rw [isEmptyFor_iff]
+  simp only [GridState.mem_pointSet, mem_interior, mem_columnInterior, mem_rowInterior, not_and]
+  constructor
+  · intro h c hc
+    exact h (c, x c) rfl hc
+  · intro h p hp hc
+    exact hp ▸ h p.1 hc
+
 /-- In a grid of size at most two, every toroidal rectangle is empty for every grid state. -/
 theorem isEmptyFor_of_le_two (hn : n ≤ 2) (R : GridRectangle n) (x : GridState n) :
     R.IsEmptyFor x := by
@@ -463,6 +482,13 @@ theorem toGridRectangle_bottom : R.toGridRectangle.bottom = R.bottom :=
 /-- The associated toroidal rectangle has the same terminal horizontal side. -/
 @[simp]
 theorem toGridRectangle_top : R.toGridRectangle.top = R.top :=
+  rfl
+
+/-- The associated toroidal rectangle in terms of the two side columns: its two horizontal
+sides are the rows the source state assigns to them. -/
+theorem toGridRectangle_eq :
+    R.toGridRectangle =
+      { left := R.left, right := R.right, bottom := x R.left, top := x R.right } :=
   rfl
 
 /-- The opposite oriented rectangle, obtained by reversing the two side columns.
@@ -685,16 +711,8 @@ between its two side columns to a row outside the open arc between its two side 
 This is the one-dimensional form of emptiness that the rectangle-pairing arguments for the grid
 differential use: it quantifies over columns rather than over grid points. -/
 theorem isEmpty_iff_forall_notMem_cIoo :
-    R.IsEmpty ↔ ∀ c ∈ Grid.cIoo R.left R.right, x c ∉ Grid.cIoo R.bottom R.top := by
-  rw [isEmpty_iff]
-  simp only [GridState.mem_pointSet, GridRectangle.mem_interior, GridRectangle.mem_columnInterior,
-    GridRectangle.mem_rowInterior, toGridRectangle_left, toGridRectangle_right,
-    toGridRectangle_bottom, toGridRectangle_top, not_and]
-  constructor
-  · intro h c hc
-    exact h (c, x c) rfl hc
-  · intro h p hp hc
-    exact hp ▸ h p.1 hc
+    R.IsEmpty ↔ ∀ c ∈ Grid.cIoo R.left R.right, x c ∉ Grid.cIoo R.bottom R.top :=
+  R.toGridRectangle.isEmptyFor_iff_forall_notMem_cIoo x
 
 /-- If a target-state point lies on a side column, then it is not in the associated
 rectangle's interior. -/

--- a/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
@@ -53,6 +53,11 @@ changing it requires a separate update of the blocked-rectangle and small-grid d
 * `TauCeti.GridRectangleBetween.all`: all oriented rectangles from `x` to `y`.
 * `TauCeti.GridRectangleBetween.emptyRectangles`: the empty rectangles from `x` to `y`.
 
+## Main results
+
+* `TauCeti.GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo`: emptiness of an oriented
+  rectangle, quantified over the columns strictly inside it.
+
 ## References
 
 This supplies a prerequisite for the Tau Ceti Heegaard Floer roadmap,
@@ -673,6 +678,23 @@ interior. -/
 theorem isEmpty_iff :
     R.IsEmpty ↔ ∀ p ∈ x.pointSet, p ∉ R.toGridRectangle.interior :=
   R.toGridRectangle.isEmptyFor_iff x
+
+/-- A rectangle between states is empty exactly when the source state sends every column strictly
+between its two side columns to a row outside the open arc between its two side rows.
+
+This is the one-dimensional form of emptiness that the rectangle-pairing arguments for the grid
+differential use: it quantifies over columns rather than over grid points. -/
+theorem isEmpty_iff_forall_notMem_cIoo :
+    R.IsEmpty ↔ ∀ c ∈ Grid.cIoo R.left R.right, x c ∉ Grid.cIoo R.bottom R.top := by
+  rw [isEmpty_iff]
+  simp only [GridState.mem_pointSet, GridRectangle.mem_interior, GridRectangle.mem_columnInterior,
+    GridRectangle.mem_rowInterior, toGridRectangle_left, toGridRectangle_right,
+    toGridRectangle_bottom, toGridRectangle_top, not_and]
+  constructor
+  · intro h c hc
+    exact h (c, x c) rfl hc
+  · intro h p hp hc
+    exact hp ▸ h p.1 hc
 
 /-- If a target-state point lies on a side column, then it is not in the associated
 rectangle's interior. -/

--- a/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
@@ -31,6 +31,8 @@ The following results are in the `TauCeti.GridRectangle` namespace:
 * `coveredSquares_union_eq_of_mem_cIoo`: the first L-shaped repartition identity.
 * `coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut`: the complementary column-cut
   orientation of the same identity.
+* `disjoint_coveredSquares_of_row_cut`, `disjoint_coveredSquares_of_col_cut`: the two rectangles
+  on either side of a row or column cut cover disjoint sets of squares.
 
 ## References
 
@@ -52,6 +54,26 @@ private theorem product_union_eq_union_product {s s' : Finset α} {t t' : Finset
     s ×ˢ t ∪ (s ∪ s') ×ˢ t' = s' ×ˢ t' ∪ s ×ˢ (t ∪ t') := by
   rw [Finset.union_product, Finset.product_union]
   ac_rfl
+
+/-- Rectangles on opposite sides of a row cut cover disjoint sets of squares, independently of
+their column spans. -/
+theorem disjoint_coveredSquares_of_row_cut {a b c d u v w : Fin n}
+    (hrow : v ∈ Grid.cIoo u w) :
+    Disjoint
+      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
+      ({ left := c, right := d, bottom := v, top := w } : GridRectangle n).coveredSquares :=
+  (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
+    simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
+
+/-- Rectangles on opposite sides of a column cut cover disjoint sets of squares, independently
+of their row spans. -/
+theorem disjoint_coveredSquares_of_col_cut {a b c u v w t : Fin n}
+    (hcol : b ∈ Grid.cIoo a c) :
+    Disjoint
+      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
+      ({ left := b, right := c, bottom := w, top := t } : GridRectangle n).coveredSquares :=
+  (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
+    simpa only [coveredColumns_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hcol))
 
 /-- If `b` and `v` lie between the corresponding outer sides, the two indicated pairs of
 rectangles are the two cuts of the same L-shaped set of squares. -/

--- a/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 public import TauCeti.KnotTheory.Grid.Rectangle.Squares
 
 /-!
@@ -32,10 +31,6 @@ The following results are in the `TauCeti.GridRectangle` namespace:
 * `coveredSquares_union_eq_of_mem_cIoo`: the first L-shaped repartition identity.
 * `coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut`: the complementary column-cut
   orientation of the same identity.
-* `prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo`: any multiplicative weight is
-  preserved by the first repartition.
-* `prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_complementary_col_cut`: any
-  multiplicative weight is preserved by the complementary column-cut repartition.
 
 ## References
 
@@ -86,62 +81,6 @@ theorem coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut {a b c u v w :
     (product_union_eq_union_product
       (s := Grid.cIco a c) (s' := Grid.cIco c b)
       (t := Grid.cIco v w) (t' := Grid.cIco u v))
-
-/-- Recutting the first L-shaped domain preserves the product of any commutative weight on its
-covered squares. In the unblocked differential, specializing the weight to the variables of the
-covered `O`-markings gives preservation of the product of rectangle monomials. -/
-theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo
-    {a b c u v w : Fin n} {M : Type*} [CommMonoid M] (f : Fin n × Fin n → M)
-    (hcol : b ∈ Grid.cIoo a c) (hrow : v ∈ Grid.cIoo u w) :
-    (∏ p ∈ ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
-        f p) *
-        ∏ p ∈ ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares,
-          f p =
-      (∏ p ∈ ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares,
-          f p) *
-        ∏ p ∈ ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares,
-          f p := by
-  have hleft : Disjoint
-      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
-      ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares :=
-    (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
-      simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
-  have hright : Disjoint
-      ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares
-      ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares :=
-    (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
-      simpa only [coveredColumns_def] using
-        (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol).symm))
-  rw [← Finset.prod_union hleft,
-    coveredSquares_union_eq_of_mem_cIoo hcol hrow,
-    Finset.prod_union hright]
-
-/-- Recutting the complementary L-shaped domain preserves the product of any commutative weight
-on its covered squares. -/
-theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_complementary_col_cut
-    {a b c u v w : Fin n} {M : Type*} [CommMonoid M] (f : Fin n × Fin n → M)
-    (hcol : c ∈ Grid.cIoo a b) (hrow : v ∈ Grid.cIoo u w) :
-    (∏ p ∈ ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
-        f p) *
-        ∏ p ∈ ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares,
-          f p =
-      (∏ p ∈ ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares,
-          f p) *
-        ∏ p ∈ ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
-          f p := by
-  have hleft : Disjoint
-      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
-      ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares :=
-    (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
-      simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
-  have hright : Disjoint
-      ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares
-      ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares :=
-    (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
-      simpa only [coveredColumns_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hcol))
-  rw [← Finset.prod_union hleft,
-    coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut hcol hrow,
-    Finset.prod_union hright]
 
 end GridRectangle
 

--- a/TauCeti/KnotTheory/Grid/Unblocked.lean
+++ b/TauCeti/KnotTheory/Grid/Unblocked.lean
@@ -183,8 +183,7 @@ theorem OMonomial_eq_prod_coveredSquares (r : GridRectangle n) :
       ∏ p ∈ r.coveredSquares,
         if p ∈ G.OSet then MvPolynomial.X p.1 else (1 : MvPolynomial (Fin n) R) := by
   classical
-  rw [OMonomial, ← Finset.prod_filter, Finset.filter_mem_eq_inter, Finset.inter_comm,
-    G.OSet_inter_coveredSquares r,
+  rw [OMonomial, Finset.prod_ite_mem, Finset.inter_comm, G.OSet_inter_coveredSquares r,
     Finset.prod_image fun _ _ _ _ hab => congrArg Prod.fst hab]
 
 /-- The weight of a rectangle has total degree the number of `O`-markings the rectangle covers.

--- a/TauCeti/KnotTheory/Grid/Unblocked.lean
+++ b/TauCeti/KnotTheory/Grid/Unblocked.lean
@@ -183,10 +183,9 @@ theorem OMonomial_eq_prod_coveredSquares (r : GridRectangle n) :
       ∏ p ∈ r.coveredSquares,
         if p ∈ G.OSet then MvPolynomial.X p.1 else (1 : MvPolynomial (Fin n) R) := by
   classical
-  rw [← Finset.prod_filter, Finset.filter_mem_eq_inter, Finset.inter_comm,
+  rw [OMonomial, ← Finset.prod_filter, Finset.filter_mem_eq_inter, Finset.inter_comm,
     G.OSet_inter_coveredSquares r,
     Finset.prod_image fun _ _ _ _ hab => congrArg Prod.fst hab]
-  rfl
 
 /-- The weight of a rectangle has total degree the number of `O`-markings the rectangle covers.
 

--- a/TauCeti/KnotTheory/Grid/Unblocked.lean
+++ b/TauCeti/KnotTheory/Grid/Unblocked.lean
@@ -65,6 +65,8 @@ assignment, a later stage of the roadmap.
   `O`-markings among the covered squares.
 * `TauCeti.GridDiagram.totalDegree_OMonomial`: the weight of a rectangle is a squarefree monomial
   whose degree is the number of `O`-markings the rectangle covers.
+* `TauCeti.GridDiagram.OMonomial_eq_prod_coveredSquares`: the weight of a rectangle as a product
+  over the squares it covers.
 * `TauCeti.GridDiagram.unblockedDifferentialOnGenerator_support_subset`: the differential of a
   generator is supported on the column transpositions of that generator.
 * `TauCeti.GridDiagram.maslovO_sub_two_mul_card_OColumns_eq_maslovO_sub_one`,
@@ -169,6 +171,22 @@ theorem OMonomial_eq_monomial (r : GridRectangle n) :
 theorem OMonomial_ne_zero [Nontrivial R] (r : GridRectangle n) : G.OMonomial R r ≠ 0 := by
   rw [OMonomial_eq_monomial]
   simp
+
+/-- The weight of a rectangle is the product, over the squares it covers, of the variable of the
+square's column at the `O`-marked squares and of `1` elsewhere.
+
+Written this way the weight is a multiplicative function of the covered-square domain alone, so
+any repartition of a union of covered squares into rectangles preserves the product of the
+weights. That is what the recutting arguments for `∂⁻ ∘ ∂⁻ = 0` need. -/
+theorem OMonomial_eq_prod_coveredSquares (r : GridRectangle n) :
+    G.OMonomial R r =
+      ∏ p ∈ r.coveredSquares,
+        if p ∈ G.OSet then MvPolynomial.X p.1 else (1 : MvPolynomial (Fin n) R) := by
+  classical
+  rw [← Finset.prod_filter, Finset.filter_mem_eq_inter, Finset.inter_comm,
+    G.OSet_inter_coveredSquares r,
+    Finset.prod_image fun _ _ _ _ hab => congrArg Prod.fst hab]
+  rfl
 
 /-- The weight of a rectangle has total degree the number of `O`-markings the rectangle covers.
 


### PR DESCRIPTION
This PR recuts a two-step grid rectangle decomposition along the other internal edge of its L-shaped domain, in the orientation where the two rectangles share their initial side column. A nondiagonal term in the square of the unblocked grid differential `∂⁻` is a pair of composable empty rectangles whose side-column pairs are disjoint or share exactly one column; in the second case the two rectangles meet at a corner, their union is an L-shaped hexagon, and cutting it along its other internal edge gives the second decomposition against which the term cancels in characteristic two. `GridRectangleDecomposition.exists_recut_of_isEmpty_of_left_eq_left` builds that second decomposition when the shared column is the initial side of both rectangles, proves both of its rectangles are empty, and computes its intermediate state and its four side columns, which by `GridRectangleDecomposition.ext` determine it; `exists_recut_of_mem_unblockedRectangles_of_left_eq_left` then states what the square-zero argument consumes — the new pair is again counted by `∂⁻`, its two `O`-monomial weights multiply to the same polynomial, and it passes through a different intermediate grid state.

The milestone is `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, "The complexes and `∂² = 0`", whose text asks for exactly this analysis — "`∂² = 0` by the juxtaposition case analysis (disjoint / overlapping / annular pairs of empty rectangles)" — and specifically its overlapping case, the only one of the three still open for `GC⁻`. The annular case landed as #4507 and the disjoint case is in flight as #4670; the geometric prerequisites of the overlapping case landed as #4166 (the side-overlap trichotomy), #4952 (the cyclic order forced by emptiness in this very orientation) and #4927 (the finite-domain repartition identity for the covered squares). After this PR the overlapping case still needs the three remaining orientations of the shared column — the two rectangles sharing their terminal side, and the terminal side of one being the initial side of the other — after which the disjoint, overlapping and annular cases assemble into `∂⁻ ∘ ∂⁻ = 0`.

The mathematical content is the transfer of emptiness, which the merged domain identity does not supply. The recut rectangles are not sub-rectangles of the old ones: each of them straddles the row line where the old cut ran, so ruling out a grid-state point inside one of them needs the first old rectangle below that line and the second old rectangle above it, glued by the new `Grid.cIoo_union_insert_cIoo_eq_cIoo_of_mem_cIoo` and the fact that the state is injective at the corner row itself. The two cyclic configurations allowed by `cyclicOrder_of_isEmpty_of_left_eq_left` are handled separately, since they cut along different column lines and produce different intermediate states; in both, the new intermediate state is checked to differ from the old one by evaluating the two column transpositions at a column where they disagree.

The relation between two cuts of one domain is packaged as `GridRectangleDecomposition.IsRepartition`: same endpoints, each cut covering disjoint sets of squares, and equal unions. It does not itself claim the two cuts differ — that is proved by the construction — so it stays usable as a pure domain relation. That is exactly what a weight needs, so `IsRepartition.prod_coveredSquares_mul_prod_coveredSquares` transports any multiplicative function of squares, `IsRepartition.OMonomial_mul_OMonomial` specializes it to the differential's weights, and `IsRepartition.disjoint_union` with its halves `disjoint_first`/`disjoint_second` transfers avoidance of any set of squares, in particular of the `X`-markings. Being a repartition is symmetric, which is what makes the eventual pairing an involution. The `O`-monomial specialization goes through a new `GridDiagram.OMonomial_eq_prod_coveredSquares`, which rewrites the weight as a product over the covered squares and so makes it a function of the domain alone.

Files: `TauCeti/KnotTheory/Grid/Differential/Square/Recut.lean` is new. `CyclicInterval.lean` gains the open-arc cut identity and the two subset lemmas it implies; `Rectangle/Basic.lean` gains `GridRectangle.isEmptyFor_iff_forall_notMem_cIoo`, the column-quantified form of emptiness that every argument here uses, its oriented-rectangle specialization `GridRectangleBetween.isEmpty_iff_forall_notMem_cIoo`, and `GridRectangleBetween.toGridRectangle_eq`; `Unblocked.lean` gains `OMonomial_eq_prod_coveredSquares`. No Mathlib source is vendored: the proofs consume `Finset.prod_union`, `Finset.prod_filter`, `Finset.prod_image`, `Finset.filter_mem_eq_inter`, `Finset.disjoint_union_left`, `Finset.disjoint_product` and `Equiv.swap_apply_of_ne_of_ne` directly.

Everything added is stated for `GC⁻` over an arbitrary commutative coefficient ring, following the precedent of the merged annular case #4507; no result here is phrased in terms of `GridRectangle.AvoidsMarkings`, and nothing needs restating when the remaining orientations land.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"gridrectangledecomposition-recut"}-->

🤖 Prepared with Claude Code

