### PR TITLE
docs: audit the larger Mathieu presentation sources

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyFour.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyFour.lean
@@ -58,6 +58,30 @@ identification result. The cross-check against the `M24` of the
 `TauCetiRoadmap/CFSGStatement/README.md` asks for on the names that development covers, is still
 recorded below.
 
+## Independent source-to-Lean read-through
+
+An independent read-through used the bytes of the ATLAS Magma source `M24G1-P1.M` whose SHA-256
+digest is `3bf09bbeddfa76f9fedd79ba8264cbd2b4d1d22947412b305cddba3a50798114`. Its constructor
+`G<x,y>` fixes the generator order, and the later assignments `a := x; b := y` confirm that the
+source's `x,y` are the presentation generators called `a,b` here.
+
+The seven active constructor entries, in source order, are
+
+```text
+x², y³, (xy)²³, [x,y]¹², [x,yxy]⁵,
+(xy xy xy⁻¹)³ (xy xy⁻¹ xy⁻¹)³,
+(xy (xy xy⁻¹)³)⁴.
+```
+
+They agree in exponent, inverse placement, and source order with the seven entries of
+`m24Presentation_transcribed`, after substituting `s₁ = ab` and `s₋₁ = ab⁻¹` and using the source
+convention `[x,y] = x⁻¹y⁻¹xy`. Between the sixth and seventh active entries, the Magma file has a
+commented line `[x,y⁻¹xyxy]⁵` labelled redundant but useful. Because the comment delimiters keep
+it outside `Group<x,y | ...>`, omitting it from the seven-relator row is exact, and the ATLAS
+presentation page independently displays those same seven active words. This checks every source
+relator and the only commented-word boundary independently of the original transcription and
+closes this row's S1 source-to-Lean read-through.
+
 ## Independent comparison with `FiniteSimpleGroups`
 
 The comparison used `finite-simple-groups-lean` at commit

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyThree.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyThree.lean
@@ -55,6 +55,37 @@ simplicity, or identification result. The cross-check against the `M23` of the
 `TauCetiRoadmap/CFSGStatement/README.md` asks for on the names that development covers, is still
 recorded below.
 
+## Independent source-to-Lean read-through
+
+An independent read-through used the bytes of the ATLAS Magma source `M23G1-P1.M` whose SHA-256
+digest is `3a4a7b8b116ac25b147b94ce0a6c6a73a730420e9865792d60587bd99cdc0e32`. Its constructor
+`G<x,y>` fixes the generator order, and the later assignments `a := x; b := y` confirm that the
+source's `x,y` are the presentation generators called `a,b` here.
+
+Reading the constructor from top to bottom gives the five short relators
+
+```text
+x², y⁴, (xy)²³, (xy²)⁶, [x,y]⁶,
+```
+
+followed by these four words:
+
+```text
+(xy xy⁻¹ xy²)⁴,
+(xy)³ xy⁻¹ xy² (xy xy⁻¹)² (xy)³ (xy⁻¹)³,
+(xy xy² xy²)⁶,
+(xy xy²)³ (xy² xy⁻¹)² xy xy² xy xy⁻¹ xy².
+```
+
+They agree in exponent, inverse placement, and source order with the nine entries of
+`m23Presentation_transcribed`, after substituting `s₁ = ab`, `s₂ = ab²`, and `s₋₁ = ab⁻¹` and
+using the source convention `[x,y] = x⁻¹y⁻¹xy`. The source places the eighth word inside the
+constructor and labels it redundant but useful; it therefore belongs in this row. Its header's
+`8 [or 9]` relators and lengths `190 [or 238]` are exactly the results of deleting or retaining
+that 48-letter entry in `m23Presentation_map_length_relators`. This checks every source relator and
+the only optional-word boundary independently of the original transcription and closes this row's
+S1 source-to-Lean read-through.
+
 ## Independent comparison with `FiniteSimpleGroups`
 
 The comparison used `finite-simple-groups-lean` at commit


### PR DESCRIPTION
This PR records the independent CFSGStatement S1 source-to-Lean read-throughs for the `M₂₃` and `M₂₄` presentation rows. It pins the exact ATLAS Magma-source digests, checks every relator in source order against the sealed Lean rows, and documents the deliberate difference between M23's active redundant relator and M24's commented-out one. It adds no Lean declarations.

Validated with targeted Lake builds and the repository style linter.

Roadmap: CFSGStatement

:robot: Prepared with OpenAI Codex
