### PR TITLE
docs: audit the larger Janko presentation sources

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Four.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Four.lean
@@ -44,6 +44,30 @@ This computation is provenance rather than a Lean theorem: the file asserts no o
 simplicity, or identification result. The independent `FiniteSimpleGroups` development named by
 the roadmap does not cover `J₄`, so no cross-check against that development is available.
 
+## Independent source-to-Lean read-through
+
+An independent read-through used the bytes of the ATLAS Magma source `J4G2-P1.M` whose SHA-256
+digest is `0ed9ed620f24b22490d2cb32f202ecbeb422ff665b4614b9ad8c6a6d7b118135`. Its constructor
+`G<x,y,t>` fixes exactly the three-generator order published by `j4Presentation_generatorNames`.
+
+The first seven constructor entries are, one for one, the seven active `M₂₄`-presentation words
+on `x,y` displayed above. The remaining five entries extend them in this source order:
+
+```text
+t²,
+[t,x],
+[t, yxy (xy⁻¹)² (xy)³],
+(y t^(yxy⁻¹xyxy⁻¹x))³,
+((yxyxyxy)³ t t^((xy)³y(xy)⁶y))².
+```
+
+They agree with entries eight through twelve of `j4Presentation_transcribed`. In the last two,
+expanding each source conjugate `t^s` as `s⁻¹ts` gives precisely `sourceConj t firstConjugator`
+and `sourceConj t secondConjugator`; the two conjugating words agree letter for letter with the
+Magma file. None of the twelve constructor entries is commented out or marked redundant. This
+checks every source relator, inverse, exponent, conjugating word, and source-order position
+independently of the original transcription and closes this row's S1 source-to-Lean read-through.
+
 The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
 relator expressions with their generator indices written out, and the provenance a manifest row
 exists to record. Together with `TauCeti.GroupPresentation.relators_def` and

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Three.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Three.lean
@@ -57,6 +57,28 @@ transcription, not Lean theorems: this file asserts no order, finiteness, simpli
 identification result. The roadmap's further cross-check against the `FiniteSimpleGroups`
 permutation development is unavailable for `J₃`, which that development does not cover.
 
+## Independent source-to-Lean read-through
+
+An independent read-through used the bytes of the ATLAS Magma source `J3G1-P1.M` whose SHA-256
+digest is `db34e17432d777cb96784c78883ff956352f822ae1f9472f60fdff96a26f5082`. Its constructor
+`G<x,y>` and later assignments `a := x; b := y` fix the generator order used by the Lean row.
+
+The source constructor lists, in order,
+
+```text
+x², y³, [x,y]⁹, (xy)¹⁹, ((xy)⁶(xy⁻¹)⁵)²,
+((xyxyxy⁻¹)² xy xy⁻¹ xy⁻¹ xy xy⁻¹)²,
+xyxy (xyxy⁻¹)³ xyxy (xyxy⁻¹)⁴ xy⁻¹ (xyxy⁻¹)³,
+((xy)³(xyxy⁻¹)²)⁴.
+```
+
+These are exactly the eight entries of `j3Presentation_transcribed` after substituting
+`s₁ = ab` and `s₋₁ = ab⁻¹` and expanding the source commutator as `x⁻¹y⁻¹xy`. In particular, the
+Lean row follows the Magma order in placing `[x,y]⁹` before `(xy)¹⁹`; the rendered ATLAS page has
+the same words with those two positions swapped. No constructor entry is commented out or marked
+redundant. This checks every source relator, inverse, exponent, and source-order position
+independently of the original transcription and closes this row's S1 source-to-Lean read-through.
+
 The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
 relator expressions with their generator indices written out, and the provenance a manifest row
 exists to record. Together with `TauCeti.GroupPresentation.relators_def` and


### PR DESCRIPTION
This PR records the independent CFSGStatement S1 source-to-Lean read-throughs for the `J₃` and `J₄` presentation rows. It pins the exact ATLAS Magma-source digests and checks every relator, inverse, exponent, conjugating word, and source-order position against the sealed Lean rows. It adds no Lean declarations.

Validated with targeted Lake builds and the repository style linter.

Roadmap: CFSGStatement

:robot: Prepared with OpenAI Codex
