### PR TITLE
refactor(StandardDistributions): reuse exponential-decay integrals for Laplace moments

### DIFF
--- a/TauCeti/Probability/Distributions/Laplace.lean
+++ b/TauCeti/Probability/Distributions/Laplace.lean
@@ -12,7 +12,6 @@ public import Mathlib.Probability.Moments.Basic
 public import Mathlib.Probability.Moments.IntegrableExpMul
 public import Mathlib.Probability.Moments.Variance
 import TauCeti.Analysis.Fourier.ExpNegAbs
-import TauCeti.MeasureTheory.Integral.ExpDecay
 import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
 import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 import Mathlib.MeasureTheory.Function.JacobianOneDim
@@ -68,10 +67,10 @@ mass `1` is the sum of the two halves at `x = μ`.
 The moments take a different route. Translating by the location with
 `MeasureTheory.integral_sub_right_eq_self` makes the integrand a function of `|x|`, and Mathlib's
 `integral_comp_abs` folds that onto the positive half-line, where the moment is the polynomially
-weighted exponential integral `TauCeti.integral_pow_mul_exp_neg_mul_Ioi`. The mean is *not* computed
-from a first
-moment: the translated integrand is odd, so the whole integral vanishes by the reflection
-invariance of Lebesgue measure, and the variance is the second absolute central moment.
+weighted exponential integral `TauCeti.integral_pow_mul_exp_neg_mul_Ioi`. The mean is *not*
+computed from a first moment: the translated integrand is odd, so the whole integral vanishes by
+the reflection invariance of Lebesgue measure, and the variance is the second absolute central
+moment.
 
 ## References
 

--- a/TauCeti/Probability/Distributions/Laplace.lean
+++ b/TauCeti/Probability/Distributions/Laplace.lean
@@ -12,9 +12,9 @@ public import Mathlib.Probability.Moments.Basic
 public import Mathlib.Probability.Moments.IntegrableExpMul
 public import Mathlib.Probability.Moments.Variance
 import TauCeti.Analysis.Fourier.ExpNegAbs
+import TauCeti.MeasureTheory.Integral.ExpDecay
 import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
 import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
-import Mathlib.MeasureTheory.Integral.Gamma
 import Mathlib.MeasureTheory.Function.JacobianOneDim
 import Mathlib.MeasureTheory.Measure.Lebesgue.Integral
 
@@ -67,8 +67,9 @@ mass `1` is the sum of the two halves at `x = μ`.
 
 The moments take a different route. Translating by the location with
 `MeasureTheory.integral_sub_right_eq_self` makes the integrand a function of `|x|`, and Mathlib's
-`integral_comp_abs` folds that onto the positive half-line, where the moment is Euler's integral
-`MeasureTheory.integral_rpow_mul_exp_neg_mul_rpow`. The mean is *not* computed from a first
+`integral_comp_abs` folds that onto the positive half-line, where the moment is the polynomially
+weighted exponential integral `TauCeti.integral_pow_mul_exp_neg_mul_Ioi`. The mean is *not* computed
+from a first
 moment: the translated integrand is odd, so the whole integral vanishes by the reflection
 invariance of Lebesgue measure, and the variance is the second absolute central moment.
 
@@ -344,26 +345,6 @@ theorem cdf_laplaceMeasure_eq (hb : 0 < b) (μ x : ℝ) :
 
 /-! ### Moments -/
 
-/-- Euler's integral in the form used below: the `n`-th moment of a decaying exponential on the
-positive half-line. -/
-private lemma integral_pow_mul_exp_neg_inv_mul_Ioi (hb : 0 < b) (n : ℕ) :
-    ∫ y in Ioi (0 : ℝ), y ^ n * Real.exp (-b⁻¹ * y) = n ! * b ^ (n + 1) := by
-  have hb' : (0 : ℝ) < b⁻¹ := inv_pos.mpr hb
-  have hq : (-1 : ℝ) < (n : ℝ) := lt_of_lt_of_le (by norm_num) (Nat.cast_nonneg n)
-  have h := integral_rpow_mul_exp_neg_mul_rpow (p := 1) (q := (n : ℝ)) (b := b⁻¹) one_pos hq hb'
-  simp only [Real.rpow_one, Real.rpow_natCast, div_one, mul_one] at h
-  rw [h, Real.Gamma_nat_eq_factorial, Real.rpow_neg hb'.le, Real.inv_rpow hb.le, inv_inv,
-    ← Nat.cast_one, ← Nat.cast_add, Real.rpow_natCast]
-  ring
-
-/-- The integrand of `integral_pow_mul_exp_neg_inv_mul_Ioi` is integrable. -/
-private lemma integrableOn_pow_mul_exp_neg_inv_mul_Ioi (hb : 0 < b) (n : ℕ) :
-    IntegrableOn (fun y : ℝ => y ^ n * Real.exp (-b⁻¹ * y)) (Ioi 0) := by
-  have hb' : (0 : ℝ) < b⁻¹ := inv_pos.mpr hb
-  have hq : (-1 : ℝ) < (n : ℝ) := lt_of_lt_of_le (by norm_num) (Nat.cast_nonneg n)
-  have h := integrableOn_rpow_mul_exp_neg_mul_rpow (p := 1) (s := (n : ℝ)) (b := b⁻¹) hq one_pos hb'
-  simpa only [Real.rpow_one, Real.rpow_natCast] using h
-
 /-- An even function integrable on the positive half-line is integrable on the whole line. -/
 private lemma integrable_comp_abs {f : ℝ → ℝ} (hf : IntegrableOn f (Ioi 0)) :
     Integrable fun y : ℝ => f |y| := by
@@ -406,9 +387,14 @@ theorem integral_pow_abs_sub_laplaceMeasure (hb : 0 < b) (μ : ℝ) (n : ℕ) :
     _ = 2 * ((2 * b)⁻¹ * ∫ t in Ioi (0 : ℝ), t ^ n * Real.exp (-b⁻¹ * t)) := by
         rw [integral_const_mul]
     _ = n ! * b ^ n := by
-        rw [integral_pow_mul_exp_neg_inv_mul_Ioi hb n]
+        have hrate : (fun t : ℝ => t ^ n * Real.exp (-b⁻¹ * t))
+            = fun t : ℝ => t ^ n * Real.exp (-(b⁻¹ * t)) := by
+          funext t
+          rw [neg_mul]
+        rw [hrate, TauCeti.integral_pow_mul_exp_neg_mul_Ioi n (inv_pos.mpr hb)]
         field_simp
-        ring
+        rw [one_div, inv_pow, pow_succ]
+        field_simp
 
 /-- The absolute central moments of a Laplace law are finite for every scale. -/
 theorem integrable_pow_abs_sub_laplaceMeasure (μ : ℝ) (n : ℕ) :
@@ -421,7 +407,8 @@ theorem integrable_pow_abs_sub_laplaceMeasure (μ : ℝ) (n : ℕ) :
     have hIoi : IntegrableOn
         (fun t : ℝ => (2 * b)⁻¹ * Real.exp (-t / b) * t ^ n) (Ioi 0) := by
       refine IntegrableOn.congr_fun
-        ((integrableOn_pow_mul_exp_neg_inv_mul_Ioi hb n).const_mul ((2 * b)⁻¹))
+        (((TauCeti.integrableOn_pow_mul_exp_neg_mul_Ioi n (inv_pos.mpr hb)).congr_fun
+          (fun t _ => by rw [← neg_mul]) measurableSet_Ioi).const_mul ((2 * b)⁻¹))
         (fun t _ => ?_) measurableSet_Ioi
       rw [neg_div_eq_neg_inv_mul]
       ring


### PR DESCRIPTION
`Laplace.lean` carried two private lemmas that rebuild, at natural powers, exactly what `TauCeti/MeasureTheory/Integral/ExpDecay.lean` already provides:

| private in `Laplace.lean` | already in `ExpDecay.lean` |
|---|---|
| `integral_pow_mul_exp_neg_inv_mul_Ioi` | `integral_pow_mul_exp_neg_mul_Ioi` |
| `integrableOn_pow_mul_exp_neg_inv_mul_Ioi` | `integrableOn_pow_mul_exp_neg_mul_Ioi` |

Both local versions went through `integral_rpow_mul_exp_neg_mul_rpow` and `integrableOn_rpow_mul_exp_neg_mul_rpow` — the real-exponent forms — and then specialised back to natural powers with `Real.rpow_natCast` and `Gamma_nat_eq_factorial`. That is the work `ExpDecay` does once.

Both are deleted and their two consumers rewired. The only friction is that the generic lemmas are stated at rate `-(a * t)` while the Laplace proofs carry `-b⁻¹ * t`, so each site converts with `neg_mul`.

## Import boundary

`Mathlib.MeasureTheory.Integral.Gamma` was imported solely for those two reconstructions and is dropped. No import replaces it: `TauCeti.Analysis.Fourier.ExpNegAbs`, which this file already imports, publicly imports `ExpDecay`, so the reused API is in scope already.

The module docstring credited `integral_rpow_mul_exp_neg_mul_rpow` as the route the moments take, which is no longer true, and now names the lemma actually used.

## Roadmap

Roadmap: StandardDistributions

Improvement to existing code: a duplicated derivation is replaced by the generic one it duplicates. No roadmap target is claimed.

🤖 Directed by Cameron Freer, drafted by Opus 5

