### PR TITLE
docs: audit the J1 and J2 presentation sources

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/One.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/One.lean
@@ -34,6 +34,29 @@ GAP constructs an isomorphism from its permutation image to the ATLAS group. Thi
 provenance for the transcription, not a Lean theorem. This file asserts no order, finiteness,
 simplicity, or identification result.
 
+## Independent source-to-Lean read-through
+
+An independent read-through used the bytes of the ATLAS Magma source `J1G1-P1.M` whose SHA-256
+digest is `d59534c449adee5461053f262627c77b3ffce57e2b25741dcdfecf9c030c9ae4`. Its constructor
+`G<x,y>` fixes the generator order, and the assignments `a := x; b := y` immediately after it
+confirm that these are the standard generators called `a,b` in this row.
+
+The five constructor entries, in source order, are
+
+```text
+x²,
+y³,
+(xy)⁷,
+(xy (xyxy⁻¹)³)⁵,
+(xy (xyxy⁻¹)⁶ xyxy (xy⁻¹)²)².
+```
+
+They agree in every letter, inverse, exponent, and source-order position with
+`j1Presentation_transcribed`: `repeatedWord` is `xyxy⁻¹`, `fifthPowerBase` is the fourth source
+base, and `squareBase` is the fifth. No constructor entry is commented out or marked redundant.
+This comparison was performed from the pinned source bytes independently of the original
+transcription and closes this row's S1 source-to-Lean read-through.
+
 ## Independent comparison with `FiniteSimpleGroups`
 
 The comparison used `finite-simple-groups-lean` at commit

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Two.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Two.lean
@@ -55,6 +55,27 @@ agreeing with both the paper and GAP's Atlas group `J2`. This computation is pro
 transcription, not a Lean theorem, and this file asserts no order, finiteness, simplicity, or
 identification result.
 
+## Independent source-to-Lean read-through
+
+An independent read-through used the bytes of the arXiv v1 PDF whose SHA-256 digest is
+`ecdc292ea95ec143251eef270c892bac9edeb4fbf4302f494cf71db75dbf79f6`. In Section 3, under
+`n = 7 (Hurwitz groups)`, the order-`604800` entry labelled `J₂` first presents
+
+```text
+aba = bab,
+ab²a = b⁵,
+(ab⁻¹ab⁻³a³b⁻¹)^(±3) a⁷ = 1.
+```
+
+The source then gives a second efficient presentation with the long word moved into the
+right-hand side of the second equality; this row deliberately transcribes the first display. Its
+choice of the positive sign gives the third entry of `j2Presentation_transcribed` exactly. For the
+first equality, multiplying by `(bab)⁻¹` gives the stored six-letter relator; for the second,
+multiplying by `b⁻⁵` gives the stored nine-letter relator. Thus the source family, chosen display,
+sign, equation orientation, every exponent, and all three source-order positions agree with the
+sealed row. This comparison was performed from the pinned PDF bytes independently of the original
+transcription and closes this row's S1 source-to-Lean read-through.
+
 ## Independent comparison with `FiniteSimpleGroups`
 
 The comparison used `finite-simple-groups-lean` at commit


### PR DESCRIPTION
This PR records the independent CFSGStatement S1 source-to-Lean read-throughs for the `J₁` and `J₂` presentation rows. It pins the exact ATLAS Magma and arXiv v1 source digests, checks every relator and source-order position, and documents the selected J2 display, sign, and equality orientations. It adds no Lean declarations.

Validated with targeted Lake builds and the repository style linter.

Roadmap: CFSGStatement

:robot: Prepared with OpenAI Codex
