### PR TITLE
feat: preserve Hopf isogenies under base change

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
@@ -68,22 +68,26 @@ private instance : isogenyProperty (L := L).RespectsIso := by
     MorphismProperty.RespectsIso.inf @IsFinite (@Flat ⊓ @Surjective)
   infer_instance
 
-private theorem isogenyProperty_iff_schemeMap
-    {G K : Grp (Over (Spec (CommRingCat.of L)))} (f : G ⟶ K) :
-    isogenyProperty (L := L) f ↔
-      IsFinite f.hom.hom.left ∧ Flat f.hom.hom.left ∧ Surjective f.hom.hom.left :=
-  Iff.rfl
-
-private theorem isogenyProperty_iff (f : H ⟶ K) :
-    isogenyProperty (L := k) ((hopfSpec (CommRingCat.of k)).map f.op) ↔ IsIsogeny f :=
-  (isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map f).symm
-
 private theorem isogenyProperty_pullback
     (f : H ⟶ K) (h : isogenyProperty (L := k) ((hopfSpec (CommRingCat.of k)).map f.op)) :
     isogenyProperty (L := L)
       ((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
         ((hopfSpec (CommRingCat.of k)).map f.op)) := by
-  rw [isogenyProperty_iff_schemeMap, Functor.mapGrp_map_hom_hom]
+  change
+    IsFinite ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ∧
+      Flat ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ∧
+        Surjective ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left at h
+  change
+    IsFinite
+        (((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
+          ((hopfSpec (CommRingCat.of k)).map f.op)).hom.hom.left) ∧
+      Flat
+          (((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
+            ((hopfSpec (CommRingCat.of k)).map f.op)).hom.hom.left) ∧
+        Surjective
+          (((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
+            ((hopfSpec (CommRingCat.of k)).map f.op)).hom.hom.left)
+  rw [Functor.mapGrp_map_hom_hom]
   exact ⟨MorphismProperty.overPullbackMap _ _ h.1,
     MorphismProperty.overPullbackMap _ _ h.2.1,
     MorphismProperty.overPullbackMap _ _ h.2.2⟩
@@ -108,9 +112,10 @@ private theorem groupSchemeProperty_hopfSpec_baseChange
 /-- Scalar extension of a coordinate morphism preserves isogenies of affine group schemes. -/
 theorem IsIsogeny.baseChange {f : H ⟶ K} (hf : IsIsogeny f) :
     IsIsogeny (baseChangeMap (K := L) f) := by
-  rw [← isogenyProperty_iff]
+  apply (isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map _).2
   exact groupSchemeProperty_hopfSpec_baseChange isogenyProperty f <|
-    isogenyProperty_pullback f (isogenyProperty_iff f |>.2 hf)
+    isogenyProperty_pullback f <|
+      (isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map f).1 hf
 
 /-- Scalar extension of a coordinate morphism preserves central isogenies of affine group
 schemes. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
@@ -34,6 +34,8 @@ pullback with the spectrum of the scalar-extended coordinate morphism.
 
 * W. C. Waterhouse, *Introduction to Affine Group Schemes*, Sections 4 and 16.
 * J. S. Milne, *Algebraic Groups* (2017), Sections 1.f and 18.a.
+* The coordinate proof structure, including its use of `MorphismProperty.overPullbackMap`, is
+  adapted from `TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.BaseChange`.
 
 This supplies scalar-extension stability for the central-isogeny interface in Layer 6,
 "Reductive and semisimple groups", of the ReductiveGroups roadmap. It is used when comparing

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
@@ -53,47 +53,6 @@ universe u
 variable {k L : Type u} [CommRing k] [CommRing L] [Algebra k L]
 variable {H K : _root_.CommHopfAlgCat.{u} k}
 
-/-- The conjunction of scheme-morphism properties underlying a coordinate isogeny. -/
-private def isogenyProperty : MorphismProperty (Grp (Over (Spec (CommRingCat.of L)))) :=
-  ((@IsFinite ⊓ (@Flat ⊓ @Surjective)) : MorphismProperty Scheme).inverseImage
-    (Grp.forget _ ⋙ Over.forget _)
-
-private instance : isogenyProperty (L := L).RespectsIso := by
-  unfold isogenyProperty
-  let _ : MorphismProperty.RespectsIso
-      (@Flat ⊓ @Surjective : MorphismProperty Scheme) :=
-    MorphismProperty.RespectsIso.inf @Flat @Surjective
-  let _ : MorphismProperty.RespectsIso
-      (@IsFinite ⊓ (@Flat ⊓ @Surjective) : MorphismProperty Scheme) :=
-    MorphismProperty.RespectsIso.inf @IsFinite (@Flat ⊓ @Surjective)
-  infer_instance
-
-private theorem isogenyProperty_pullback
-    (f : H ⟶ K) (h : isogenyProperty (L := k) ((hopfSpec (CommRingCat.of k)).map f.op)) :
-    isogenyProperty (L := L)
-      ((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
-        ((hopfSpec (CommRingCat.of k)).map f.op)) := by
-  -- Unfold the inverse-image/intersection property to the underlying scheme morphisms.
-  -- For the target, this also exposes `hom.hom.left`, where the pullback comparison rewrites.
-  change
-    IsFinite ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ∧
-      Flat ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ∧
-        Surjective ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left at h
-  change
-    IsFinite
-        (((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
-          ((hopfSpec (CommRingCat.of k)).map f.op)).hom.hom.left) ∧
-      Flat
-          (((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
-            ((hopfSpec (CommRingCat.of k)).map f.op)).hom.hom.left) ∧
-        Surjective
-          (((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
-            ((hopfSpec (CommRingCat.of k)).map f.op)).hom.hom.left)
-  rw [Functor.mapGrp_map_hom_hom]
-  exact ⟨MorphismProperty.overPullbackMap _ _ h.1,
-    MorphismProperty.overPullbackMap _ _ h.2.1,
-    MorphismProperty.overPullbackMap _ _ h.2.2⟩
-
 private theorem groupSchemeProperty_hopfSpec_baseChange
     (P : MorphismProperty (Grp (Over (Spec (CommRingCat.of L))))) [P.RespectsIso]
     (f : H ⟶ K)
@@ -115,9 +74,12 @@ private theorem groupSchemeProperty_hopfSpec_baseChange
 theorem IsIsogeny.baseChange {f : H ⟶ K} (hf : IsIsogeny f) :
     IsIsogeny (baseChangeMap (K := L) f) := by
   apply (isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map _).2
-  exact groupSchemeProperty_hopfSpec_baseChange isogenyProperty f <|
-    isogenyProperty_pullback f <|
-      (isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map f).1 hf
+  exact (GroupScheme.isIsogeny_iff _).1 <|
+    groupSchemeProperty_hopfSpec_baseChange (GroupScheme.isogenies L) f <|
+      GroupScheme.IsIsogeny.baseChange
+        (Spec.map (CommRingCat.ofHom (algebraMap k L))) <|
+          (GroupScheme.isIsogeny_iff _).2 <|
+            (isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map f).1 hf
 
 /-- Scalar extension of a coordinate morphism preserves central isogenies of affine group
 schemes. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Isogeny.Basic
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
+import TauCeti.AlgebraicGeometry.AffineGroupScheme.BaseChange.Coordinate
+import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.BaseChange
+import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Isomorphism
+
+/-!
+# Base change of isogenies in Hopf coordinates
+
+Let `f : H ⟶ K` be a morphism of commutative Hopf algebras over a commutative ring `k`.
+Scalar extension along `k → L` gives a coordinate morphism
+`L ⊗[k] H ⟶ L ⊗[k] K`. This file proves that isogenies and central isogenies remain so after
+this scalar extension.
+
+The proof keeps the coordinate and scheme models synchronized. Hopf spectrum turns `f`
+contravariantly into a morphism of affine group schemes; scheme-theoretic pullback preserves
+(central) isogenies, and the natural Hopf-spectrum base-change comparison identifies that
+pullback with the spectrum of the scalar-extended coordinate morphism.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.IsIsogeny.baseChange`: scalar extension preserves isogenies.
+* `TauCeti.CommHopfAlgCat.IsCentralIsogeny.baseChange`: scalar extension preserves central
+  isogenies.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Sections 4 and 16.
+* J. S. Milne, *Algebraic Groups* (2017), Sections 1.f and 18.a.
+
+This supplies scalar-extension stability for the central-isogeny interface in Layer 6,
+"Reductive and semisimple groups", of the ReductiveGroups roadmap. It is used when comparing
+simply connected and adjoint forms after passage to an algebraic closure.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry Opposite
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u
+
+variable {k L : Type u} [CommRing k] [CommRing L] [Algebra k L]
+variable {H K : _root_.CommHopfAlgCat.{u} k}
+
+/-- The conjunction of scheme-morphism properties underlying a coordinate isogeny. -/
+private def isogenyProperty : MorphismProperty (Grp (Over (Spec (CommRingCat.of L)))) :=
+  ((@IsFinite ⊓ (@Flat ⊓ @Surjective)) : MorphismProperty Scheme).inverseImage
+    (Grp.forget _ ⋙ Over.forget _)
+
+private instance : isogenyProperty (L := L).RespectsIso := by
+  unfold isogenyProperty
+  let _ : MorphismProperty.RespectsIso
+      (@Flat ⊓ @Surjective : MorphismProperty Scheme) :=
+    MorphismProperty.RespectsIso.inf @Flat @Surjective
+  let _ : MorphismProperty.RespectsIso
+      (@IsFinite ⊓ (@Flat ⊓ @Surjective) : MorphismProperty Scheme) :=
+    MorphismProperty.RespectsIso.inf @IsFinite (@Flat ⊓ @Surjective)
+  infer_instance
+
+private theorem isogenyProperty_iff_schemeMap
+    {G K : Grp (Over (Spec (CommRingCat.of L)))} (f : G ⟶ K) :
+    isogenyProperty (L := L) f ↔
+      IsFinite f.hom.hom.left ∧ Flat f.hom.hom.left ∧ Surjective f.hom.hom.left :=
+  Iff.rfl
+
+private theorem isogenyProperty_iff (f : H ⟶ K) :
+    isogenyProperty (L := k) ((hopfSpec (CommRingCat.of k)).map f.op) ↔ IsIsogeny f :=
+  (isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map f).symm
+
+private theorem isogenyProperty_pullback
+    (f : H ⟶ K) (h : isogenyProperty (L := k) ((hopfSpec (CommRingCat.of k)).map f.op)) :
+    isogenyProperty (L := L)
+      ((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
+        ((hopfSpec (CommRingCat.of k)).map f.op)) := by
+  rw [isogenyProperty_iff_schemeMap, Functor.mapGrp_map_hom_hom]
+  exact ⟨MorphismProperty.overPullbackMap _ _ h.1,
+    MorphismProperty.overPullbackMap _ _ h.2.1,
+    MorphismProperty.overPullbackMap _ _ h.2.2⟩
+
+private theorem groupSchemeProperty_hopfSpec_baseChange
+    (P : MorphismProperty (Grp (Over (Spec (CommRingCat.of L))))) [P.RespectsIso]
+    (f : H ⟶ K)
+    (h : P
+      ((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
+        ((hopfSpec (CommRingCat.of k)).map f.op))) :
+    P
+      ((hopfSpec (CommRingCat.of L)).map (baseChangeMap (K := L) f).op) := by
+  have hnat := AffineGroupSchemeCat.hopfSpecBaseChangeGrpIso_natural
+    (R := k) (S := L) f
+  have hcomp := MorphismProperty.RespectsIso.postcomp P
+    (AffineGroupSchemeCat.hopfSpecBaseChangeGrpIso (R := k) (S := L) H).hom _ h
+  rw [hnat] at hcomp
+  have hresult := MorphismProperty.RespectsIso.precomp P
+    (AffineGroupSchemeCat.hopfSpecBaseChangeGrpIso (R := k) (S := L) K).inv _ hcomp
+  simpa using hresult
+
+/-- Scalar extension of a coordinate morphism preserves isogenies of affine group schemes. -/
+theorem IsIsogeny.baseChange {f : H ⟶ K} (hf : IsIsogeny f) :
+    IsIsogeny (baseChangeMap (K := L) f) := by
+  rw [← isogenyProperty_iff]
+  exact groupSchemeProperty_hopfSpec_baseChange isogenyProperty f <|
+    isogenyProperty_pullback f (isogenyProperty_iff f |>.2 hf)
+
+/-- Scalar extension of a coordinate morphism preserves central isogenies of affine group
+schemes. -/
+theorem IsCentralIsogeny.baseChange {f : H ⟶ K} (hf : IsCentralIsogeny f) :
+    IsCentralIsogeny (baseChangeMap (K := L) f) := by
+  apply (isCentralIsogeny_iff _).2
+  have hiso := hf.isIsogeny.baseChange (L := L)
+  refine ⟨hiso.finite, hiso.faithfullyFlat, ?_⟩
+  rw [← GroupScheme.hasCentralKernel_hopfSpec_map_iff]
+  apply groupSchemeProperty_hopfSpec_baseChange
+    (GroupScheme.hasCentralKernel (Spec (CommRingCat.of L))) f
+  exact GroupScheme.HasCentralKernel.baseChange
+    (Spec.map (CommRingCat.ofHom (algebraMap k L)))
+    ((GroupScheme.hasCentralKernel_hopfSpec_map_iff f).2
+      hf.isCentral_kernelHopfIdeal)
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
@@ -73,6 +73,8 @@ private theorem isogenyProperty_pullback
     isogenyProperty (L := L)
       ((Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap k L)))).mapGrp.map
         ((hopfSpec (CommRingCat.of k)).map f.op)) := by
+  -- Unfold the inverse-image/intersection property to the underlying scheme morphisms.
+  -- For the target, this also exposes `hom.hom.left`, where the pullback comparison rewrites.
   change
     IsFinite ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ∧
       Flat ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ∧

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
@@ -61,7 +61,7 @@ private theorem groupSchemeProperty_hopfSpec_baseChange
         ((hopfSpec (CommRingCat.of k)).map f.op))) :
     P
       ((hopfSpec (CommRingCat.of L)).map (baseChangeMap (K := L) f).op) := by
-  have hnat := AffineGroupSchemeCat.hopfSpecBaseChangeGrpIso_natural
+  have hnat := AffineGroupSchemeCat.hopfSpecBaseChangeGrpIso_hom_naturality
     (R := k) (S := L) f
   have hcomp := MorphismProperty.RespectsIso.postcomp P
     (AffineGroupSchemeCat.hopfSpecBaseChangeGrpIso (R := k) (S := L) H).hom _ h
@@ -73,27 +73,20 @@ private theorem groupSchemeProperty_hopfSpec_baseChange
 /-- Scalar extension of a coordinate morphism preserves isogenies of affine group schemes. -/
 theorem IsIsogeny.baseChange {f : H ⟶ K} (hf : IsIsogeny f) :
     IsIsogeny (baseChangeMap (K := L) f) := by
-  apply (isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map _).2
-  exact (GroupScheme.isIsogeny_iff _).1 <|
-    groupSchemeProperty_hopfSpec_baseChange (GroupScheme.isogenies L) f <|
-      GroupScheme.IsIsogeny.baseChange
-        (Spec.map (CommRingCat.ofHom (algebraMap k L))) <|
-          (GroupScheme.isIsogeny_iff _).2 <|
-            (isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map f).1 hf
+  apply (isIsogeny_iff_isIsogeny_hopfSpec_map _).2
+  apply groupSchemeProperty_hopfSpec_baseChange (GroupScheme.isogenies L) f
+  exact GroupScheme.IsIsogeny.baseChange
+    (Spec.map (CommRingCat.ofHom (algebraMap k L)))
+    ((isIsogeny_iff_isIsogeny_hopfSpec_map f).1 hf)
 
 /-- Scalar extension of a coordinate morphism preserves central isogenies of affine group
 schemes. -/
 theorem IsCentralIsogeny.baseChange {f : H ⟶ K} (hf : IsCentralIsogeny f) :
     IsCentralIsogeny (baseChangeMap (K := L) f) := by
-  apply (isCentralIsogeny_iff _).2
-  have hiso := hf.isIsogeny.baseChange (L := L)
-  refine ⟨hiso.finite, hiso.faithfullyFlat, ?_⟩
-  rw [← GroupScheme.hasCentralKernel_hopfSpec_map_iff]
-  apply groupSchemeProperty_hopfSpec_baseChange
-    (GroupScheme.hasCentralKernel (Spec (CommRingCat.of L))) f
-  exact GroupScheme.HasCentralKernel.baseChange
+  apply (isCentralIsogeny_iff_isCentralIsogeny_hopfSpec_map _).2
+  apply groupSchemeProperty_hopfSpec_baseChange (GroupScheme.centralIsogenies L) f
+  exact GroupScheme.IsCentralIsogeny.baseChange
     (Spec.map (CommRingCat.ofHom (algebraMap k L)))
-    ((GroupScheme.hasCentralKernel_hopfSpec_map_iff f).2
-      hf.isCentral_kernelHopfIdeal)
+    ((isCentralIsogeny_iff_isCentralIsogeny_hopfSpec_map f).1 hf)
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/BaseChange.lean
@@ -76,7 +76,7 @@ private theorem isogenyProperty_iff_schemeMap
 
 private theorem isogenyProperty_iff (f : H ⟶ K) :
     isogenyProperty (L := k) ((hopfSpec (CommRingCat.of k)).map f.op) ↔ IsIsogeny f :=
-  (isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map f).symm
+  (isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map f).symm
 
 private theorem isogenyProperty_pullback
     (f : H ⟶ K) (h : isogenyProperty (L := k) ((hopfSpec (CommRingCat.of k)).map f.op)) :

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -26,7 +26,7 @@ surjectivity by a weaker statement about points over the base field.
 
 * `TauCeti.CommHopfAlgCat.IsIsogeny`: a finite faithfully flat coordinate morphism.
 * `TauCeti.CommHopfAlgCat.IsCentralIsogeny`: an isogeny with central kernel Hopf ideal.
-* `TauCeti.CommHopfAlgCat.isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map`: the
+* `TauCeti.CommHopfAlgCat.isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map`: the
   coordinate isogeny conditions agree with the corresponding scheme-morphism properties.
 * `TauCeti.CommHopfAlgCat.isIsogeny_iff_isIsogeny_hopfSpec_map`: the coordinate and
   group-scheme definitions agree over a field.
@@ -107,7 +107,7 @@ private lemma isogeny_conditions_hopfSpec_map_iff
 
 /-- A coordinate morphism is an isogeny exactly when its contravariant Hopf-spectrum map is
 finite, flat, and surjective. This criterion works over an arbitrary commutative base ring. -/
-theorem isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map
+theorem isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map
     {H₀ K₀ : _root_.CommHopfAlgCat.{u} R} (f : H₀ ⟶ K₀) :
     IsIsogeny f ↔
       AlgebraicGeometry.IsFinite
@@ -130,7 +130,7 @@ theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
       GroupScheme.IsIsogeny
         ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op) := by
   rw [IsIsogeny, GroupScheme.isIsogeny_iff]
-  exact isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map f
+  exact isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map f
 
 /-- Over a field, the coordinate-algebra definition of a central isogeny agrees with the
 existing group-scheme definition after applying the contravariant Hopf spectrum functor. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -26,6 +26,8 @@ surjectivity by a weaker statement about points over the base field.
 
 * `TauCeti.CommHopfAlgCat.IsIsogeny`: a finite faithfully flat coordinate morphism.
 * `TauCeti.CommHopfAlgCat.IsCentralIsogeny`: an isogeny with central kernel Hopf ideal.
+* `TauCeti.CommHopfAlgCat.isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map`: the
+  coordinate isogeny conditions agree with the corresponding scheme-morphism properties.
 * `TauCeti.CommHopfAlgCat.isIsogeny_iff_isIsogeny_hopfSpec_map`: the coordinate and
   group-scheme definitions agree over a field.
 * `TauCeti.CommHopfAlgCat.isCentralIsogeny_iff_isCentralIsogeny_hopfSpec_map`: the analogous
@@ -81,20 +83,17 @@ theorem isCentralIsogeny_iff (f : H ⟶ K) :
         (kernelHopfIdeal f).IsCentral := by
   rw [IsCentralIsogeny, IsIsogeny, and_assoc]
 
-section Field
-
-variable {k : Type u} [Field k] {H₀ K₀ : _root_.CommHopfAlgCat.{u} k}
-
--- This isolates the definitional computation of Mathlib's bundled `hopfSpec` functor at the
--- morphism-property boundary where the source and target schemes are propositionally aligned.
-private lemma isogeny_conditions_hopfSpec_map_iff (f : H₀ ⟶ K₀) :
-    f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat ↔
+/-- A coordinate morphism is an isogeny exactly when its contravariant Hopf-spectrum map is
+finite, flat, and surjective. This criterion works over an arbitrary commutative base ring. -/
+theorem isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map
+    {H₀ K₀ : _root_.CommHopfAlgCat.{u} R} (f : H₀ ⟶ K₀) :
+    IsIsogeny f ↔
       AlgebraicGeometry.IsFinite
-          ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ∧
+          ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op).hom.hom.left ∧
         AlgebraicGeometry.Flat
-            ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ∧
+            ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op).hom.hom.left ∧
           AlgebraicGeometry.Surjective
-            ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left := by
+            ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op).hom.hom.left := by
   change f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat ↔
     AlgebraicGeometry.IsFinite
       (AlgebraicGeometry.Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ∧
@@ -106,6 +105,10 @@ private lemma isogeny_conditions_hopfSpec_map_iff (f : H₀ ⟶ K₀) :
     AlgebraicGeometry.flat_and_surjective_SpecMap_iff]
   rfl
 
+section Field
+
+variable {k : Type u} [Field k] {H₀ K₀ : _root_.CommHopfAlgCat.{u} k}
+
 /-- Over a field, the coordinate-algebra definition of an isogeny agrees with the existing
 group-scheme definition after applying the contravariant Hopf spectrum functor. -/
 theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
@@ -113,7 +116,7 @@ theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
       GroupScheme.IsIsogeny
         ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op) := by
   rw [IsIsogeny, GroupScheme.isIsogeny_iff]
-  exact isogeny_conditions_hopfSpec_map_iff f
+  exact isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map f
 
 /-- Over a field, the coordinate-algebra definition of a central isogeny agrees with the
 existing group-scheme definition after applying the contravariant Hopf spectrum functor. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -83,11 +83,11 @@ theorem isCentralIsogeny_iff (f : H ⟶ K) :
         (kernelHopfIdeal f).IsCentral := by
   rw [IsCentralIsogeny, IsIsogeny, and_assoc]
 
-/-- A coordinate morphism is an isogeny exactly when its contravariant Hopf-spectrum map is
-finite, flat, and surjective. This criterion works over an arbitrary commutative base ring. -/
-theorem isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map
+-- This isolates the definitional computation of Mathlib's bundled `hopfSpec` functor at the
+-- morphism-property boundary where the source and target schemes are propositionally aligned.
+private lemma isogeny_conditions_hopfSpec_map_iff
     {H₀ K₀ : _root_.CommHopfAlgCat.{u} R} (f : H₀ ⟶ K₀) :
-    IsIsogeny f ↔
+    f.hom.toAlgHom.Finite ∧ f.hom.toAlgHom.toRingHom.FaithfullyFlat ↔
       AlgebraicGeometry.IsFinite
           ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op).hom.hom.left ∧
         AlgebraicGeometry.Flat
@@ -104,6 +104,20 @@ theorem isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map
   rw [AlgebraicGeometry.IsFinite.SpecMap_iff,
     AlgebraicGeometry.flat_and_surjective_SpecMap_iff]
   rfl
+
+/-- A coordinate morphism is an isogeny exactly when its contravariant Hopf-spectrum map is
+finite, flat, and surjective. This criterion works over an arbitrary commutative base ring. -/
+theorem isIsogeny_iff_isFinite_flat_surjective_hopfSpec_map
+    {H₀ K₀ : _root_.CommHopfAlgCat.{u} R} (f : H₀ ⟶ K₀) :
+    IsIsogeny f ↔
+      AlgebraicGeometry.IsFinite
+          ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op).hom.hom.left ∧
+        AlgebraicGeometry.Flat
+            ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op).hom.hom.left ∧
+          AlgebraicGeometry.Surjective
+            ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op).hom.hom.left := by
+  rw [IsIsogeny]
+  exact isogeny_conditions_hopfSpec_map_iff f
 
 section Field
 

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -26,8 +26,6 @@ surjectivity by a weaker statement about points over the base field.
 
 * `TauCeti.CommHopfAlgCat.IsIsogeny`: a finite faithfully flat coordinate morphism.
 * `TauCeti.CommHopfAlgCat.IsCentralIsogeny`: an isogeny with central kernel Hopf ideal.
-* `TauCeti.CommHopfAlgCat.isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map`: the
-  coordinate isogeny conditions agree with the corresponding scheme-morphism properties.
 * `TauCeti.CommHopfAlgCat.isIsogeny_iff_isIsogeny_hopfSpec_map`: the coordinate and
   group-scheme definitions agree over a commutative ring.
 * `TauCeti.CommHopfAlgCat.isCentralIsogeny_iff_isCentralIsogeny_hopfSpec_map`: the analogous
@@ -105,20 +103,6 @@ private lemma isogeny_conditions_hopfSpec_map_iff
     AlgebraicGeometry.flat_and_surjective_SpecMap_iff]
   rfl
 
-/-- A coordinate morphism is an isogeny exactly when its contravariant Hopf-spectrum map is
-finite, flat, and surjective. This criterion works over an arbitrary commutative base ring. -/
-theorem isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map
-    {H₀ K₀ : _root_.CommHopfAlgCat.{u} R} (f : H₀ ⟶ K₀) :
-    IsIsogeny f ↔
-      AlgebraicGeometry.IsFinite
-          ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op).hom.hom.left ∧
-        AlgebraicGeometry.Flat
-            ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op).hom.hom.left ∧
-          AlgebraicGeometry.Surjective
-            ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op).hom.hom.left := by
-  rw [IsIsogeny]
-  exact isogeny_conditions_hopfSpec_map_iff f
-
 section Ring
 
 variable {k : Type u} [CommRing k] {H₀ K₀ : _root_.CommHopfAlgCat.{u} k}
@@ -130,7 +114,7 @@ theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
       GroupScheme.IsIsogeny
         ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op) := by
   rw [IsIsogeny, GroupScheme.isIsogeny_iff]
-  exact isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map f
+  exact isogeny_conditions_hopfSpec_map_iff f
 
 /-- The coordinate-algebra definition of a central isogeny agrees with the group-scheme
 definition after applying the contravariant Hopf spectrum functor. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Isogeny/Basic.lean
@@ -29,7 +29,7 @@ surjectivity by a weaker statement about points over the base field.
 * `TauCeti.CommHopfAlgCat.isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map`: the
   coordinate isogeny conditions agree with the corresponding scheme-morphism properties.
 * `TauCeti.CommHopfAlgCat.isIsogeny_iff_isIsogeny_hopfSpec_map`: the coordinate and
-  group-scheme definitions agree over a field.
+  group-scheme definitions agree over a commutative ring.
 * `TauCeti.CommHopfAlgCat.isCentralIsogeny_iff_isCentralIsogeny_hopfSpec_map`: the analogous
   bridge for central isogenies.
 * `TauCeti.CommHopfAlgCat.IsIsogeny.mapPointsFunctor_app_surjective`: an isogeny is
@@ -119,12 +119,12 @@ theorem isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map
   rw [IsIsogeny]
   exact isogeny_conditions_hopfSpec_map_iff f
 
-section Field
+section Ring
 
-variable {k : Type u} [Field k] {H₀ K₀ : _root_.CommHopfAlgCat.{u} k}
+variable {k : Type u} [CommRing k] {H₀ K₀ : _root_.CommHopfAlgCat.{u} k}
 
-/-- Over a field, the coordinate-algebra definition of an isogeny agrees with the existing
-group-scheme definition after applying the contravariant Hopf spectrum functor. -/
+/-- The coordinate-algebra definition of an isogeny agrees with the group-scheme definition
+after applying the contravariant Hopf spectrum functor. -/
 theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
     IsIsogeny f ↔
       GroupScheme.IsIsogeny
@@ -132,8 +132,8 @@ theorem isIsogeny_iff_isIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
   rw [IsIsogeny, GroupScheme.isIsogeny_iff]
   exact isIsogeny_iff_isFinite_and_flat_and_surjective_hopfSpec_map f
 
-/-- Over a field, the coordinate-algebra definition of a central isogeny agrees with the
-existing group-scheme definition after applying the contravariant Hopf spectrum functor. -/
+/-- The coordinate-algebra definition of a central isogeny agrees with the group-scheme
+definition after applying the contravariant Hopf spectrum functor. -/
 theorem isCentralIsogeny_iff_isCentralIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
     IsCentralIsogeny f ↔
       GroupScheme.IsCentralIsogeny
@@ -141,7 +141,7 @@ theorem isCentralIsogeny_iff_isCentralIsogeny_hopfSpec_map (f : H₀ ⟶ K₀) :
   rw [IsCentralIsogeny, GroupScheme.isCentralIsogeny_hopfSpec_map_iff,
     isIsogeny_iff_isIsogeny_hopfSpec_map]
 
-end Field
+end Ring
 
 namespace IsIsogeny
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
@@ -25,6 +25,8 @@ anti-equivalence.
 
 * `TauCeti.AffineGroupSchemeCat.hopfSpecBaseChangeIso`: pullback of a Hopf spectrum is the
   Hopf spectrum of the scalar-extended coordinate Hopf algebra.
+* `TauCeti.AffineGroupSchemeCat.hopfSpecBaseChangeGrpIso_natural`: the underlying group-object
+  comparison intertwines pullback and coordinate scalar extension on morphisms.
 * `TauCeti.AffineGroupSchemeCat.hopfSpecBaseChangeNatIso`: the comparison is natural in the
   coordinate Hopf algebra.
 
@@ -133,7 +135,9 @@ private theorem pullbackSpecIso'_natural {H K : CommHopfAlgCat.{u} R}
     ext x
     simp
 
-private theorem hopfSpecPullbackIso_natural {H K : CommHopfAlgCat.{u} R}
+/-- The group-object comparison between pullback of Hopf spectra and Hopf spectra of scalar
+extensions intertwines the pullback of a coordinate morphism with its scalar extension. -/
+theorem hopfSpecBaseChangeGrpIso_natural {H K : CommHopfAlgCat.{u} R}
     (f : H ⟶ K) :
     (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap R S)))).mapGrp.map
           ((hopfSpec (CommRingCat.of R)).map f.op) ≫
@@ -160,7 +164,7 @@ private noncomputable def hopfSpecPullbackNatIso :
         hopfSpec (CommRingCat.of S) :=
   NatIso.ofComponents
     (fun H ↦ hopfSpecBaseChangeGrpIso (R := R) (S := S) H.unop)
-    (fun f ↦ hopfSpecPullbackIso_natural (R := R) (S := S) f.unop)
+    (fun f ↦ hopfSpecBaseChangeGrpIso_natural (R := R) (S := S) f.unop)
 
 /-- The base-change comparison after including affine group schemes into all group objects. -/
 private noncomputable def hopfSpecBaseChangeιNatIso :

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
@@ -25,8 +25,8 @@ anti-equivalence.
 
 * `TauCeti.AffineGroupSchemeCat.hopfSpecBaseChangeIso`: pullback of a Hopf spectrum is the
   Hopf spectrum of the scalar-extended coordinate Hopf algebra.
-* `TauCeti.AffineGroupSchemeCat.hopfSpecBaseChangeGrpIso_natural`: the underlying group-object
-  comparison intertwines pullback and coordinate scalar extension on morphisms.
+* `TauCeti.AffineGroupSchemeCat.hopfSpecBaseChangeGrpIso_hom_naturality`: the underlying
+  group-object comparison intertwines pullback and coordinate scalar extension on morphisms.
 * `TauCeti.AffineGroupSchemeCat.hopfSpecBaseChangeNatIso`: the comparison is natural in the
   coordinate Hopf algebra.
 
@@ -137,7 +137,7 @@ private theorem pullbackSpecIso'_natural {H K : CommHopfAlgCat.{u} R}
 
 /-- The group-object comparison between pullback of Hopf spectra and Hopf spectra of scalar
 extensions intertwines the pullback of a coordinate morphism with its scalar extension. -/
-theorem hopfSpecBaseChangeGrpIso_natural {H K : CommHopfAlgCat.{u} R}
+theorem hopfSpecBaseChangeGrpIso_hom_naturality {H K : CommHopfAlgCat.{u} R}
     (f : H ⟶ K) :
     (Over.pullback (Spec.map (CommRingCat.ofHom (algebraMap R S)))).mapGrp.map
           ((hopfSpec (CommRingCat.of R)).map f.op) ≫
@@ -164,7 +164,7 @@ private noncomputable def hopfSpecPullbackNatIso :
         hopfSpec (CommRingCat.of S) :=
   NatIso.ofComponents
     (fun H ↦ hopfSpecBaseChangeGrpIso (R := R) (S := S) H.unop)
-    (fun f ↦ hopfSpecBaseChangeGrpIso_natural (R := R) (S := S) f.unop)
+    (fun f ↦ hopfSpecBaseChangeGrpIso_hom_naturality (R := R) (S := S) f.unop)
 
 /-- The base-change comparison after including affine group schemes into all group objects. -/
 private noncomputable def hopfSpecBaseChangeιNatIso :

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
@@ -12,10 +12,11 @@ public import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Basic
 
 This file proves that central kernels of group-scheme morphisms remain central after arbitrary
 base change, by identifying the point groups before and after base change through the pullback
-adjunction. Consequently, isogenies and central isogenies over a field remain so after base change
-along a morphism between spectra of fields. For a commutative source, the base-changed isogeny is
-central without any centrality hypothesis. The group-scheme base change is the pullback functor on
-the over category, lifted to group objects.
+adjunction. Consequently, isogenies over a commutative ring remain so after base change along a
+morphism between affine bases, while central isogenies over a field remain so after extension of
+the field. For a commutative source, the base-changed isogeny is central without any centrality
+hypothesis. The group-scheme base change is the pullback functor on the over category, lifted to
+group objects.
 
 ## Main declarations
 
@@ -52,21 +53,22 @@ open AlgebraicGeometry
 
 universe u
 
-section Field
+section Ring
 
-variable {k L : Type u} [Field k] [Field L]
-variable {G H : Grp (Over (Spec (CommRingCat.of k)))}
+variable {R S : Type u} [CommRing R] [CommRing S]
+variable {G H : Grp (Over (Spec (CommRingCat.of R)))}
 
-/-- Base change along a morphism between spectra of fields preserves group-scheme isogenies. -/
+/-- Base change along a morphism between spectra of commutative rings preserves group-scheme
+isogenies. -/
 theorem IsIsogeny.baseChange
-    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k)) {f : G ⟶ H}
+    (s : Spec (CommRingCat.of S) ⟶ Spec (CommRingCat.of R)) {f : G ⟶ H}
     (hf : IsIsogeny f) : IsIsogeny ((Over.pullback s).mapGrp.map f) := by
   rw [isIsogeny_iff, Functor.mapGrp_map_hom_hom]
   exact ⟨MorphismProperty.overPullbackMap _ _ hf.isFinite,
     MorphismProperty.overPullbackMap _ _ hf.flat,
     MorphismProperty.overPullbackMap _ _ hf.surjective⟩
 
-end Field
+end Ring
 
 section BaseChange
 

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
@@ -13,8 +13,8 @@ public import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Basic
 This file proves that central kernels of group-scheme morphisms remain central after arbitrary
 base change, by identifying the point groups before and after base change through the pullback
 adjunction. Consequently, isogenies over a commutative ring remain so after base change along a
-morphism between affine bases, while central isogenies over a field remain so after extension of
-the field. For a commutative source, the base-changed isogeny is central without any centrality
+morphism between affine bases, and central isogenies remain so after such a base change. For a
+commutative source, the base-changed isogeny is central without any centrality
 hypothesis. The group-scheme base change is the pullback functor on the over category, lifted to
 group objects.
 
@@ -213,12 +213,13 @@ theorem HasCentralKernel.baseChange
 
 end BaseChange
 
-section Field
+section Ring
 
-variable {k L : Type u} [Field k] [Field L]
+variable {k L : Type u} [CommRing k] [CommRing L]
 variable {G H : Grp (Over (Spec (CommRingCat.of k)))}
 
-/-- Base change along a morphism between spectra of fields preserves central isogenies. -/
+/-- Base change along a morphism between spectra of commutative rings preserves central
+isogenies. -/
 theorem IsCentralIsogeny.baseChange
     (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k)) {f : G ⟶ H}
     (hf : IsCentralIsogeny f) :
@@ -236,6 +237,6 @@ theorem IsIsogeny.baseChange_isCentral_of_isCommMonObj
     exact ((Over.pullback s).mapCommMon.obj (.mk G.X)).comm
   exact (hf.baseChange s).isCentral_of_isCommMonObj
 
-end Field
+end Ring
 
 end TauCeti.GroupScheme

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Basic.lean
@@ -19,10 +19,10 @@ scheme-theoretic kernel is central. We express the latter condition intrinsicall
 functor of points: for every test scheme over the base, every point killed by the homomorphism
 commutes with every other point of the source.
 
-Quantifying over all test schemes is essential. Centrality only on points over the base field
-would miss infinitesimal points and need not describe a central subgroup scheme. The functorial
-definition below is equivalent, by Yoneda, to factorization of the kernel through the
-scheme-theoretic centre once that closed subgroup has been constructed.
+Quantifying over all test schemes is essential. Centrality only on base-ring-valued points would
+miss infinitesimal points and need not describe a central subgroup scheme. The functorial definition
+below is equivalent, by Yoneda, to factorization of the kernel through the scheme-theoretic centre
+once that closed subgroup has been constructed.
 
 The API records the equivalent pointwise statement that the kernel of every induced group
 homomorphism is contained in the ordinary group centre. It also shows that isomorphisms have

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Basic.lean
@@ -13,10 +13,11 @@ public import Mathlib.GroupTheory.Subgroup.Center
 /-!
 # Central isogenies of group schemes
 
-For group schemes over a field, an isogeny is a homomorphism whose underlying scheme morphism is
-finite, flat, and surjective. It is central when its scheme-theoretic kernel is central. We express
-the latter condition intrinsically through the functor of points: for every test scheme over the
-base, every point killed by the homomorphism commutes with every other point of the source.
+For group schemes over the spectrum of a commutative ring, an isogeny is a homomorphism whose
+underlying scheme morphism is finite, flat, and surjective. Over a field, it is central when its
+scheme-theoretic kernel is central. We express the latter condition intrinsically through the
+functor of points: for every test scheme over the base, every point killed by the homomorphism
+commutes with every other point of the source.
 
 Quantifying over all test schemes is essential. Centrality only on points over the base field
 would miss infinitesimal points and need not describe a central subgroup scheme. The functorial
@@ -143,20 +144,22 @@ theorem hasCentralKernel_of_isCommMonObj (f : G ⟶ H) [IsCommMonObj G.X] :
 
 section Isogeny
 
-variable {k : Type u} [Field k]
-variable {G H K : Grp (Over (Spec (CommRingCat.of k)))}
+section Ring
 
-/-- The morphism property of being an isogeny of group schemes over a field: the underlying
-scheme morphism is finite, flat, and surjective. -/
-def isogenies (k : Type u) [Field k] :
-    MorphismProperty (Grp (Over (Spec (CommRingCat.of k)))) :=
+variable {R : Type u} [CommRing R]
+variable {G H K : Grp (Over (Spec (CommRingCat.of R)))}
+
+/-- The morphism property of being an isogeny of group schemes over a commutative ring: the
+underlying scheme morphism is finite, flat, and surjective. -/
+def isogenies (R : Type u) [CommRing R] :
+    MorphismProperty (Grp (Over (Spec (CommRingCat.of R)))) :=
   (@IsFinite ⊓ (@Flat ⊓ @Surjective) : MorphismProperty Scheme).inverseImage
     (Grp.forget _ ⋙ Over.forget _)
 
 /-- A homomorphism of group schemes is an isogeny when its underlying scheme morphism is finite,
 flat, and surjective. -/
 abbrev IsIsogeny (f : G ⟶ H) : Prop :=
-  isogenies k f
+  isogenies R f
 
 /-- A group-scheme morphism is an isogeny exactly when its underlying scheme morphism is finite,
 flat, and surjective. -/
@@ -166,7 +169,7 @@ theorem isIsogeny_iff (f : G ⟶ H) :
   Iff.rfl
 
 /-- Group-scheme isogenies contain identities and are closed under composition. -/
-instance : (isogenies k).IsMultiplicative := by
+instance : (isogenies R).IsMultiplicative := by
   unfold isogenies
   let : (@Flat ⊓ @Surjective : MorphismProperty Scheme).IsMultiplicative :=
     MorphismProperty.IsMultiplicative.inf
@@ -175,7 +178,7 @@ instance : (isogenies k).IsMultiplicative := by
   infer_instance
 
 /-- Being a group-scheme isogeny is invariant under isomorphisms of arrows. -/
-instance : (isogenies k).RespectsIso := by
+instance : (isogenies R).RespectsIso := by
   unfold isogenies
   let _ : MorphismProperty.RespectsIso (@IsFinite : MorphismProperty Scheme) :=
     MorphismProperty.respectsIso_of_isStableUnderComposition
@@ -191,16 +194,16 @@ instance : (isogenies k).RespectsIso := by
     MorphismProperty.RespectsIso.inf @IsFinite (@Flat ⊓ @Surjective)
   exact MorphismProperty.RespectsIso.inverseImage
     (@IsFinite ⊓ (@Flat ⊓ @Surjective) : MorphismProperty Scheme)
-    (Grp.forget (Over (Spec (CommRingCat.of k))) ⋙ Over.forget (Spec (CommRingCat.of k)))
+    (Grp.forget (Over (Spec (CommRingCat.of R))) ⋙ Over.forget (Spec (CommRingCat.of R)))
 
 /-- The identity of a group scheme is an isogeny. -/
 @[simp]
-theorem isIsogeny_id (G : Grp (Over (Spec (CommRingCat.of k)))) : IsIsogeny (𝟙 G) :=
-  (isogenies k).id_mem G
+theorem isIsogeny_id (G : Grp (Over (Spec (CommRingCat.of R)))) : IsIsogeny (𝟙 G) :=
+  (isogenies R).id_mem G
 
 /-- Every isomorphism of group schemes is an isogeny. -/
 theorem isIsogeny_of_isIso (f : G ⟶ H) [IsIso f] : IsIsogeny f :=
-  (isogenies k).of_isIso f
+  (isogenies R).of_isIso f
 
 namespace IsIsogeny
 
@@ -219,9 +222,16 @@ theorem surjective {f : G ⟶ H} (hf : IsIsogeny f) : Surjective f.hom.hom.left 
 /-- A composite of group-scheme isogenies is an isogeny. -/
 theorem comp {f : G ⟶ H} {g : H ⟶ K} (hf : IsIsogeny f) (hg : IsIsogeny g) :
     IsIsogeny (f ≫ g) :=
-  (isogenies k).comp_mem f g hf hg
+  (isogenies R).comp_mem f g hf hg
 
 end IsIsogeny
+
+end Ring
+
+section Field
+
+variable {k : Type u} [Field k]
+variable {G H K : Grp (Over (Spec (CommRingCat.of k)))}
 
 /-- The morphism property of being a central isogeny of group schemes over a field. -/
 def centralIsogenies (k : Type u) [Field k] :
@@ -303,6 +313,8 @@ theorem isCentralIsogeny_id (G : Grp (Over (Spec (CommRingCat.of k)))) :
 theorem isCentralIsogeny_of_isIso (f : G ⟶ H) [IsIso f] : IsCentralIsogeny f :=
   (isCentralIsogeny_iff_isIsogeny_and_hasCentralKernel f).mpr
     ⟨isIsogeny_of_isIso f, hasCentralKernel_of_mono f⟩
+
+end Field
 
 end Isogeny
 

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Basic.lean
@@ -14,7 +14,7 @@ public import Mathlib.GroupTheory.Subgroup.Center
 # Central isogenies of group schemes
 
 For group schemes over the spectrum of a commutative ring, an isogeny is a homomorphism whose
-underlying scheme morphism is finite, flat, and surjective. Over a field, it is central when its
+underlying scheme morphism is finite, flat, and surjective. It is central when its
 scheme-theoretic kernel is central. We express the latter condition intrinsically through the
 functor of points: for every test scheme over the base, every point killed by the homomorphism
 commutes with every other point of the source.
@@ -228,13 +228,13 @@ end IsIsogeny
 
 end Ring
 
-section Field
+section Ring
 
-variable {k : Type u} [Field k]
+variable {k : Type u} [CommRing k]
 variable {G H K : Grp (Over (Spec (CommRingCat.of k)))}
 
-/-- The morphism property of being a central isogeny of group schemes over a field. -/
-def centralIsogenies (k : Type u) [Field k] :
+/-- The morphism property of being a central isogeny of group schemes over a commutative ring. -/
+def centralIsogenies (k : Type u) [CommRing k] :
     MorphismProperty (Grp (Over (Spec (CommRingCat.of k)))) :=
   isogenies k ⊓ hasCentralKernel (Spec (CommRingCat.of k))
 
@@ -314,7 +314,7 @@ theorem isCentralIsogeny_of_isIso (f : G ⟶ H) [IsIso f] : IsCentralIsogeny f :
   (isCentralIsogeny_iff_isIsogeny_and_hasCentralKernel f).mpr
     ⟨isIsogeny_of_isIso f, hasCentralKernel_of_mono f⟩
 
-end Field
+end Ring
 
 end Isogeny
 

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Coordinate.lean
@@ -145,9 +145,9 @@ theorem hasCentralKernel_hopfSpec_map_iff {H K : CommHopfAlgCat.{u} R} (f : H �
   ⟨isCentral_kernelHopfIdeal_of_hasCentralKernel_hopfSpec_map f,
     hasCentralKernel_hopfSpec_map_of_isCentral_kernelHopfIdeal f⟩
 
-section Field
+section Ring
 
-variable {k : Type u} [Field k] {H K : CommHopfAlgCat.{u} k}
+variable {k : Type u} [CommRing k] {H K : CommHopfAlgCat.{u} k}
 
 /-- **Coordinate criterion for a central isogeny.** A Hopf-spectrum morphism is a central
 isogeny exactly when it is an isogeny and its represented kernel Hopf ideal is central. -/
@@ -158,6 +158,6 @@ theorem isCentralIsogeny_hopfSpec_map_iff (f : H ⟶ K) :
   rw [isCentralIsogeny_iff, isIsogeny_iff]
   simp only [and_assoc, hasCentralKernel_hopfSpec_map_iff]
 
-end Field
+end Ring
 
 end TauCeti.GroupScheme

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Isomorphism.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Isomorphism.lean
@@ -107,7 +107,7 @@ instance hasCentralKernel_respectsIso : (hasCentralKernel X).RespectsIso := by
 
 section Isogeny
 
-variable {k : Type u} [Field k]
+variable {k : Type u} [CommRing k]
 variable {G H : Grp (Over (Spec (CommRingCat.of k)))}
 
 namespace IsIsogeny


### PR DESCRIPTION
This PR proves that scalar extension preserves coordinate Hopf-algebra isogenies and central isogenies over arbitrary commutative base rings. It advances the `ReductiveGroups` roadmap's Layer 6 milestone, “Reductive and semisimple groups,” specifically the target “central isogenies, and simply-connected/adjoint forms”; this base-change stability is the next critical-path interface needed to compare those forms after extending the ground field.

The change exposes the naturality square for the existing Hopf-spectrum base-change comparison, generalizes the coordinate/Hopf-spectrum isogeny bridge to arbitrary commutative rings, and transfers the existing scheme-side base-change results back to coordinates by reusing the canonical scheme-level theorems. The proof reuses Mathlib's `IsFinite`, `Flat`, and `Surjective` morphism properties and `MorphismProperty.overPullbackMap`, together with Tau Ceti's existing Hopf-spectrum comparison and central-kernel base-change theorem; no Mathlib implementation is vendored.

After this PR, Layer 6 still needs the construction and universal properties of simply connected covers and adjoint quotients, followed by their root-datum comparison.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"central-isogeny-base-change"}-->

🤖 Prepared with Codex