### PR TITLE
feat: the Kummer map and its kernel

### DIFF
--- a/TauCeti/Algebra/Group/PowerClassGroup.lean
+++ b/TauCeti/Algebra/Group/PowerClassGroup.lean
@@ -14,13 +14,18 @@ public import TauCeti.Algebra.Group.PowMonoidHom
 For a commutative group `G` the subgroup `Gⁿ` of `n`th powers is the range of `powMonoidHom n`,
 and this file names the quotient `G ⧸ Gⁿ` together with the class of an element. It reuses
 Mathlib's additive quotient `ModN (Additive G) n`; in particular its specialization at `n = 2` is
-definitionally `TauCeti.ElementaryTwoQuotient G`. The Kummer map consumes the additive form, while
-the equality `TauCeti.modNSubgroup_eq_powerSubgroup` identifies its quotient subgroup with `Gⁿ`.
+definitionally `TauCeti.ElementaryTwoQuotient G`. The Kummer map uses the multiplicative quotient,
+while `TauCeti.powerClassEquivQuotient` identifies it with the additive `ModN` model.
+
+This implements target 3 of Layer 9 in the human-authored
+`TauCetiRoadmap/ProfiniteCohomology/README.md` and `Suggested.lean`.
 
 ## Main definitions
 
 * `TauCeti.PowerClassGroup`: the quotient `G ⧸ Gⁿ`, written additively.
-* `TauCeti.powerClass`: the `n`th power class of an element, with
+* `TauCeti.powerSubgroup`, `TauCeti.powerClassQuotient`: the multiplicative subgroup and quotient
+  specified by the roadmap.
+* `TauCeti.powerClass`, `TauCeti.powerClassHom`: the `n`th power class of an element, with
   `TauCeti.powerClass_eq_zero_iff` characterising the trivial class as the `n`th powers.
 -/
 
@@ -30,10 +35,21 @@ namespace TauCeti
 
 variable (G : Type*) [CommGroup G] (n : ℕ)
 
+/-- **The subgroup of `n`th powers** `Gⁿ ≤ G`. -/
+def powerSubgroup : Subgroup G :=
+  (powMonoidHom n : G →* G).range
+
+/-- **The multiplicative quotient by `n`th powers** `G ⧸ Gⁿ`. -/
+abbrev powerClassQuotient : Type _ :=
+  G ⧸ powerSubgroup G n
+
 /-- **The group of `n`th power classes** `G ⧸ Gⁿ`, written additively on `Additive G`. The
 subgroup divided out is the range of `powMonoidHom n`, that is `{g ^ n | g : G}`. -/
 abbrev PowerClassGroup : Type _ :=
   ModN (Additive G) n
+
+instance (priority := 90) [Finite G] : Finite (PowerClassGroup G n) :=
+  Finite.of_surjective (ModN.mkQ n) (Submodule.Quotient.mk_surjective _)
 
 variable {G}
 
@@ -41,10 +57,10 @@ variable {G}
 `n`th powers in `G`. -/
 theorem modNSubgroup_eq_powerSubgroup :
     (LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ))).toAddSubgroup =
-      (powMonoidHom n : G →* G).range.toAddSubgroup := by
+      (powerSubgroup G n).toAddSubgroup := by
   ext a
   simp only [Submodule.mem_toAddSubgroup, LinearMap.mem_range, LinearMap.lsmul_apply,
-    Additive.mem_toAddSubgroup, MonoidHom.mem_range]
+    Additive.mem_toAddSubgroup]
   constructor
   · rintro ⟨b, hb⟩
     refine ⟨b.toMul, ?_⟩
@@ -55,20 +71,67 @@ theorem modNSubgroup_eq_powerSubgroup :
     apply Additive.toMul.injective
     simpa only [powMonoidHom_apply, natCast_zsmul, toMul_nsmul, toMul_ofMul] using hb
 
+/-- Mathlib's additive `ModN` model is canonically equivalent to the additive form of the
+multiplicative quotient `G ⧸ Gⁿ`. -/
+def powerClassEquivQuotient :
+    PowerClassGroup G n ≃+ Additive (powerClassQuotient G n) :=
+  QuotientAddGroup.quotientAddEquivOfEq (modNSubgroup_eq_powerSubgroup (G := G) (n := n))
+
+/-- The multiplicative quotient homomorphism `G → G ⧸ Gⁿ`. -/
+def powerClassHom : G →* powerClassQuotient G n :=
+  QuotientGroup.mk' (powerSubgroup G n)
+
+/-- The multiplicative power-class homomorphism sends `g` to its quotient class. -/
+@[simp]
+theorem powerClassHom_apply (g : G) : powerClassHom n g = QuotientGroup.mk g := by
+  exact QuotientGroup.mk'_apply (powerSubgroup G n) g
+
+/-- An element belongs to `Gⁿ` exactly when it is an `n`th power. -/
+@[simp]
+theorem mem_powerSubgroup_iff {g : G} : g ∈ powerSubgroup G n ↔ ∃ h : G, h ^ n = g := by
+  rw [powerSubgroup, MonoidHom.mem_range]
+  exact exists_congr fun h => by rw [powMonoidHom_apply]
+
+/-- Lift a homomorphism that kills `Gⁿ` to the quotient `G ⧸ Gⁿ`. -/
+def powerClassQuotientLift {H : Type*} [Group H] (f : G →* H)
+    (hf : powerSubgroup G n ≤ f.ker) : powerClassQuotient G n →* H :=
+  QuotientGroup.lift (powerSubgroup G n) f hf
+
+/-- A lift from the power-class quotient agrees with the original homomorphism on
+representatives. -/
+@[simp]
+theorem powerClassQuotientLift_mk {H : Type*} [Group H] (f : G →* H)
+    (hf : powerSubgroup G n ≤ f.ker) (g : G) :
+    powerClassQuotientLift n f hf (powerClassHom n g) = f g := by
+  exact QuotientGroup.lift_mk' (powerSubgroup G n) hf g
+
+/-- The additive quotient homomorphism `Additive G →+ PowerClassGroup G n`. -/
+def powerClassAdd : Additive G →+ PowerClassGroup G n :=
+  ModN.mkQ n
+
 /-- The `n`th power class of an element of `G`. -/
 def powerClass (g : G) : PowerClassGroup G n :=
-  ModN.mkQ n (Additive.ofMul g)
+  powerClassAdd n (Additive.ofMul g)
+
+/-- The canonical equivalence sends the additive `ModN` class of `g` to its multiplicative
+quotient class. -/
+@[simp]
+theorem powerClassEquivQuotient_powerClass (g : G) :
+    powerClassEquivQuotient (G := G) (n := n) (powerClass n g) =
+      Additive.ofMul (powerClassHom n g) := by
+  exact QuotientAddGroup.quotientAddEquivOfEq_mk
+    (modNSubgroup_eq_powerSubgroup (G := G) (n := n)) (Additive.ofMul g)
 
 /-- The power class is the quotient class of the element in Mathlib's `ModN` model. -/
 theorem powerClass_eq_mk (g : G) :
     powerClass n g = Submodule.Quotient.mk (Additive.ofMul g) := by
-  rw [powerClass, ModN.mkQ]
-  rfl
+  exact Submodule.mkQ_apply _ _
 
+/-- Every class in `PowerClassGroup G n` has a representative in `G`. -/
 theorem powerClass_surjective : Function.Surjective (powerClass (G := G) n) := by
   intro x
   obtain ⟨a, rfl⟩ := Submodule.Quotient.mk_surjective _ x
-  exact ⟨a.toMul, rfl⟩
+  exact ⟨a.toMul, by simpa using powerClass_eq_mk n a.toMul⟩
 
 @[simp]
 theorem powerClass_mul (g h : G) : powerClass n (g * h) = powerClass n g + powerClass n h := by
@@ -84,14 +147,38 @@ theorem powerClass_div (g h : G) :
     powerClass n (g / h) = powerClass n g - powerClass n h := by
   simp only [powerClass, ofMul_div, map_sub]
 
+/-- The class of an inverse is the negative of the class. -/
+@[simp]
+theorem powerClass_inv (g : G) : powerClass n g⁻¹ = -powerClass n g := by
+  simp only [powerClass, ofMul_inv, map_neg]
+
+/-- The class of a power is the corresponding multiple of the class. -/
+@[simp]
+theorem powerClass_pow (g : G) (m : ℕ) : powerClass n (g ^ m) = m • powerClass n g := by
+  simp only [powerClass, ofMul_pow, map_nsmul]
+
+/-- The class of a finite product is the sum of the classes. -/
+theorem powerClass_prod {ι : Type*} (s : Finset ι) (g : ι → G) :
+    powerClass n (∏ i ∈ s, g i) = ∑ i ∈ s, powerClass n (g i) := by
+  simp only [powerClass, ofMul_prod, map_sum]
+
+/-- Membership in the submodule defining `ModN (Additive G) n` is membership in `Gⁿ`, expressed
+on multiplicative representatives. -/
+theorem mem_modNSubgroup_iff {g : G} :
+    Additive.ofMul g ∈ LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ)) ↔
+      ∃ h : G, h ^ n = g := by
+  rw [show Additive.ofMul g ∈ LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ)) ↔
+      Additive.ofMul g ∈
+        (LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ))).toAddSubgroup from Iff.rfl]
+  rw [modNSubgroup_eq_powerSubgroup, Additive.mem_toAddSubgroup, powerSubgroup,
+    MonoidHom.mem_range]
+  exact exists_congr fun h => by rw [powMonoidHom_apply]; exact Iff.rfl
+
 /-- **A power class is trivial exactly when its representative is an `n`th power.** -/
 @[simp]
 theorem powerClass_eq_zero_iff {g : G} : powerClass n g = 0 ↔ ∃ h : G, h ^ n = g := by
   rw [powerClass_eq_mk, Submodule.Quotient.mk_eq_zero]
-  change Additive.ofMul g ∈
-    (LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ))).toAddSubgroup ↔ _
-  rw [modNSubgroup_eq_powerSubgroup, Additive.mem_toAddSubgroup, MonoidHom.mem_range]
-  exact exists_congr fun h => by rw [powMonoidHom_apply]; exact Iff.rfl
+  exact mem_modNSubgroup_iff (n := n)
 
 /-- Two elements have the same power class exactly when their ratio is an `n`th power. -/
 theorem powerClass_eq_iff {g h : G} :

--- a/TauCeti/Algebra/Group/PowerClassGroup.lean
+++ b/TauCeti/Algebra/Group/PowerClassGroup.lean
@@ -5,18 +5,17 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Group.Subgroup.Ker
-public import Mathlib.GroupTheory.QuotientGroup.Defs
+public import Mathlib.LinearAlgebra.FreeModule.ModN
+public import TauCeti.Algebra.Group.PowMonoidHom
 
 /-!
 # The group of `n`th power classes `G ⧸ Gⁿ`
 
 For a commutative group `G` the subgroup `Gⁿ` of `n`th powers is the range of `powMonoidHom n`,
-and this file names the quotient `G ⧸ Gⁿ` together with the class of an element. The quotient is
-written **additively**, on `Additive G`, because its consumers are additive: the Kummer map lands
-in a cohomology group, and at `n = 2` the quotient is the `𝔽₂`-vector space
-`TauCeti.SquareClassGroup`, whose subgroup is Mathlib's `Subgroup.square` — the same subgroup by
-`TauCeti.square_eq_powMonoidHom_two_range`.
+and this file names the quotient `G ⧸ Gⁿ` together with the class of an element. It reuses
+Mathlib's additive quotient `ModN (Additive G) n`; in particular its specialization at `n = 2` is
+definitionally `TauCeti.ElementaryTwoQuotient G`. The Kummer map consumes the additive form, while
+the equality `TauCeti.modNSubgroup_eq_powerSubgroup` identifies its quotient subgroup with `Gⁿ`.
 
 ## Main definitions
 
@@ -34,37 +33,64 @@ variable (G : Type*) [CommGroup G] (n : ℕ)
 /-- **The group of `n`th power classes** `G ⧸ Gⁿ`, written additively on `Additive G`. The
 subgroup divided out is the range of `powMonoidHom n`, that is `{g ^ n | g : G}`. -/
 abbrev PowerClassGroup : Type _ :=
-  Additive G ⧸ (powMonoidHom n : G →* G).range.toAddSubgroup
+  ModN (Additive G) n
 
 variable {G}
 
+/-- The subgroup defining Mathlib's `ModN (Additive G) n` is the additive form of the subgroup of
+`n`th powers in `G`. -/
+theorem modNSubgroup_eq_powerSubgroup :
+    (LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ))).toAddSubgroup =
+      (powMonoidHom n : G →* G).range.toAddSubgroup := by
+  ext a
+  simp only [Submodule.mem_toAddSubgroup, LinearMap.mem_range, LinearMap.lsmul_apply,
+    Additive.mem_toAddSubgroup, MonoidHom.mem_range]
+  constructor
+  · rintro ⟨b, hb⟩
+    refine ⟨b.toMul, ?_⟩
+    simpa only [powMonoidHom_apply, natCast_zsmul, toMul_nsmul] using
+      congrArg Additive.toMul hb
+  · rintro ⟨b, hb⟩
+    refine ⟨Additive.ofMul b, ?_⟩
+    apply Additive.toMul.injective
+    simpa only [powMonoidHom_apply, natCast_zsmul, toMul_nsmul, toMul_ofMul] using hb
+
 /-- The `n`th power class of an element of `G`. -/
 def powerClass (g : G) : PowerClassGroup G n :=
-  QuotientAddGroup.mk (Additive.ofMul g)
+  ModN.mkQ n (Additive.ofMul g)
 
-/-- The power class is the quotient class of the element, spelled with `QuotientAddGroup.mk`.
-`TauCeti.powerClass` is a plain definition, so this is what a downstream module rewrites with. -/
+/-- The power class is the quotient class of the element in Mathlib's `ModN` model. -/
 theorem powerClass_eq_mk (g : G) :
-    powerClass n g = QuotientAddGroup.mk (Additive.ofMul g) := (rfl)
+    powerClass n g = Submodule.Quotient.mk (Additive.ofMul g) := by
+  rw [powerClass, ModN.mkQ]
+  rfl
 
-theorem powerClass_surjective : Function.Surjective (powerClass (G := G) n) := fun x =>
-  QuotientAddGroup.induction_on x fun g => ⟨g.toMul, rfl⟩
+theorem powerClass_surjective : Function.Surjective (powerClass (G := G) n) := by
+  intro x
+  obtain ⟨a, rfl⟩ := Submodule.Quotient.mk_surjective _ x
+  exact ⟨a.toMul, rfl⟩
 
 @[simp]
-theorem powerClass_mul (g h : G) : powerClass n (g * h) = powerClass n g + powerClass n h := (rfl)
+theorem powerClass_mul (g h : G) : powerClass n (g * h) = powerClass n g + powerClass n h := by
+  simp only [powerClass, ofMul_mul, map_add]
 
 @[simp]
-theorem powerClass_one : powerClass n (1 : G) = 0 := (rfl)
+theorem powerClass_one : powerClass n (1 : G) = 0 := by
+  simp only [powerClass, ofMul_one, map_zero]
 
 /-- The class of a ratio is the difference of the classes. -/
 @[simp]
 theorem powerClass_div (g h : G) :
-    powerClass n (g / h) = powerClass n g - powerClass n h := (rfl)
+    powerClass n (g / h) = powerClass n g - powerClass n h := by
+  simp only [powerClass, ofMul_div, map_sub]
 
 /-- **A power class is trivial exactly when its representative is an `n`th power.** -/
 @[simp]
 theorem powerClass_eq_zero_iff {g : G} : powerClass n g = 0 ↔ ∃ h : G, h ^ n = g := by
-  rw [powerClass, QuotientAddGroup.eq_zero_iff, Additive.mem_toAddSubgroup, MonoidHom.mem_range]
+  rw [powerClass_eq_mk, Submodule.Quotient.mk_eq_zero]
+  change Additive.ofMul g ∈
+    (LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ))).toAddSubgroup ↔ _
+  rw [modNSubgroup_eq_powerSubgroup, Additive.mem_toAddSubgroup, MonoidHom.mem_range]
   exact exists_congr fun h => by rw [powMonoidHom_apply]; exact Iff.rfl
 
 /-- Two elements have the same power class exactly when their ratio is an `n`th power. -/

--- a/TauCeti/Algebra/Group/PowerClassGroup.lean
+++ b/TauCeti/Algebra/Group/PowerClassGroup.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Group.Subgroup.Ker
+public import Mathlib.GroupTheory.QuotientGroup.Defs
+
+/-!
+# The group of `n`th power classes `G ⧸ Gⁿ`
+
+For a commutative group `G` the subgroup `Gⁿ` of `n`th powers is the range of `powMonoidHom n`,
+and this file names the quotient `G ⧸ Gⁿ` together with the class of an element. The quotient is
+written **additively**, on `Additive G`, because its consumers are additive: the Kummer map lands
+in a cohomology group, and at `n = 2` the quotient is the `𝔽₂`-vector space
+`TauCeti.SquareClassGroup`, whose subgroup is Mathlib's `Subgroup.square` — the same subgroup by
+`TauCeti.square_eq_powMonoidHom_two_range`.
+
+## Main definitions
+
+* `TauCeti.PowerClassGroup`: the quotient `G ⧸ Gⁿ`, written additively.
+* `TauCeti.powerClass`: the `n`th power class of an element, with
+  `TauCeti.powerClass_eq_zero_iff` characterising the trivial class as the `n`th powers.
+-/
+
+public section
+
+namespace TauCeti
+
+variable (G : Type*) [CommGroup G] (n : ℕ)
+
+/-- **The group of `n`th power classes** `G ⧸ Gⁿ`, written additively on `Additive G`. The
+subgroup divided out is the range of `powMonoidHom n`, that is `{g ^ n | g : G}`. -/
+abbrev PowerClassGroup : Type _ :=
+  Additive G ⧸ (powMonoidHom n : G →* G).range.toAddSubgroup
+
+variable {G}
+
+/-- The `n`th power class of an element of `G`. -/
+def powerClass (g : G) : PowerClassGroup G n :=
+  QuotientAddGroup.mk (Additive.ofMul g)
+
+/-- The power class is the quotient class of the element, spelled with `QuotientAddGroup.mk`.
+`TauCeti.powerClass` is a plain definition, so this is what a downstream module rewrites with. -/
+theorem powerClass_eq_mk (g : G) :
+    powerClass n g = QuotientAddGroup.mk (Additive.ofMul g) := (rfl)
+
+theorem powerClass_surjective : Function.Surjective (powerClass (G := G) n) := fun x =>
+  QuotientAddGroup.induction_on x fun g => ⟨g.toMul, rfl⟩
+
+@[simp]
+theorem powerClass_mul (g h : G) : powerClass n (g * h) = powerClass n g + powerClass n h := (rfl)
+
+@[simp]
+theorem powerClass_one : powerClass n (1 : G) = 0 := (rfl)
+
+/-- The class of a ratio is the difference of the classes. -/
+@[simp]
+theorem powerClass_div (g h : G) :
+    powerClass n (g / h) = powerClass n g - powerClass n h := (rfl)
+
+/-- **A power class is trivial exactly when its representative is an `n`th power.** -/
+@[simp]
+theorem powerClass_eq_zero_iff {g : G} : powerClass n g = 0 ↔ ∃ h : G, h ^ n = g := by
+  rw [powerClass, QuotientAddGroup.eq_zero_iff, Additive.mem_toAddSubgroup, MonoidHom.mem_range]
+  exact exists_congr fun h => by rw [powMonoidHom_apply]; exact Iff.rfl
+
+/-- Two elements have the same power class exactly when their ratio is an `n`th power. -/
+theorem powerClass_eq_iff {g h : G} :
+    powerClass n g = powerClass n h ↔ ∃ v : G, v ^ n = g / h := by
+  rw [← sub_eq_zero, ← powerClass_div, powerClass_eq_zero_iff]
+
+end TauCeti

--- a/TauCeti/Algebra/Group/PowerClassGroup.lean
+++ b/TauCeti/Algebra/Group/PowerClassGroup.lean
@@ -14,16 +14,14 @@ For a commutative group `G` the subgroup `Gⁿ` of `n`th powers is the range of 
 and this file names it together with the quotient `G ⧸ Gⁿ` and the class of an element. At `n = 2`
 the subgroup is Mathlib's `Subgroup.square G`, by `TauCeti.square_eq_powMonoidHom_two_range`.
 
-This implements target 3 of Layer 9 in the human-authored
-`TauCetiRoadmap/ProfiniteCohomology/README.md` and `Suggested.lean`, stated for an arbitrary
-commutative group rather than for the units of a field; the Kummer map is its consumer.
-
 ## Main definitions
 
 * `TauCeti.powerSubgroup`: the subgroup `Gⁿ ≤ G`, whose elements are characterised as the `n`th
   powers by `TauCeti.mem_powerSubgroup_iff`.
 * `TauCeti.powerClassQuotient`, `TauCeti.powerClassHom`: the quotient `G ⧸ Gⁿ` and the map taking
-  an element to its power class.
+  an element to its power class. It is surjective (`TauCeti.powerClassHom_surjective`) with kernel
+  `Gⁿ` (`TauCeti.ker_powerClassHom`), so it presents `G ⧸ Gⁿ` as the quotient of `G` by the `n`th
+  powers.
 -/
 
 public section
@@ -43,6 +41,15 @@ abbrev powerClassQuotient : Type _ :=
 /-- The quotient homomorphism `G → G ⧸ Gⁿ`. -/
 def powerClassHom : G →* powerClassQuotient G n :=
   QuotientGroup.mk' (powerSubgroup G n)
+
+/-- The kernel of the power-class homomorphism is the subgroup `Gⁿ` of `n`th powers. -/
+@[simp]
+theorem ker_powerClassHom : (powerClassHom G n).ker = powerSubgroup G n :=
+  QuotientGroup.ker_mk' (powerSubgroup G n)
+
+/-- Every power class is the class of an element: `powerClassHom` is surjective. -/
+theorem powerClassHom_surjective : Function.Surjective (powerClassHom G n) :=
+  QuotientGroup.mk'_surjective (powerSubgroup G n)
 
 variable {G}
 

--- a/TauCeti/Algebra/Group/PowerClassGroup.lean
+++ b/TauCeti/Algebra/Group/PowerClassGroup.lean
@@ -102,7 +102,7 @@ representatives. -/
 @[simp]
 theorem powerClassQuotientLift_mk {H : Type*} [Group H] (f : G →* H)
     (hf : powerSubgroup G n ≤ f.ker) (g : G) :
-    powerClassQuotientLift n f hf (powerClassHom n g) = f g := by
+    powerClassQuotientLift n f hf (QuotientGroup.mk g) = f g := by
   exact QuotientGroup.lift_mk' (powerSubgroup G n) hf g
 
 /-- The additive quotient homomorphism `Additive G →+ PowerClassGroup G n`. -/

--- a/TauCeti/Algebra/Group/PowerClassGroup.lean
+++ b/TauCeti/Algebra/Group/PowerClassGroup.lean
@@ -5,28 +5,25 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.FreeModule.ModN
 public import TauCeti.Algebra.Group.PowMonoidHom
 
 /-!
 # The group of `n`th power classes `G ⧸ Gⁿ`
 
 For a commutative group `G` the subgroup `Gⁿ` of `n`th powers is the range of `powMonoidHom n`,
-and this file names the quotient `G ⧸ Gⁿ` together with the class of an element. It reuses
-Mathlib's additive quotient `ModN (Additive G) n`; in particular its specialization at `n = 2` is
-definitionally `TauCeti.ElementaryTwoQuotient G`. The Kummer map uses the multiplicative quotient,
-while `TauCeti.powerClassEquivQuotient` identifies it with the additive `ModN` model.
+and this file names it together with the quotient `G ⧸ Gⁿ` and the class of an element. At `n = 2`
+the subgroup is Mathlib's `Subgroup.square G`, by `TauCeti.square_eq_powMonoidHom_two_range`.
 
 This implements target 3 of Layer 9 in the human-authored
-`TauCetiRoadmap/ProfiniteCohomology/README.md` and `Suggested.lean`.
+`TauCetiRoadmap/ProfiniteCohomology/README.md` and `Suggested.lean`, stated for an arbitrary
+commutative group rather than for the units of a field; the Kummer map is its consumer.
 
 ## Main definitions
 
-* `TauCeti.PowerClassGroup`: the quotient `G ⧸ Gⁿ`, written additively.
-* `TauCeti.powerSubgroup`, `TauCeti.powerClassQuotient`: the multiplicative subgroup and quotient
-  specified by the roadmap.
-* `TauCeti.powerClass`, `TauCeti.powerClassHom`: the `n`th power class of an element, with
-  `TauCeti.powerClass_eq_zero_iff` characterising the trivial class as the `n`th powers.
+* `TauCeti.powerSubgroup`: the subgroup `Gⁿ ≤ G`, whose elements are characterised as the `n`th
+  powers by `TauCeti.mem_powerSubgroup_iff`.
+* `TauCeti.powerClassQuotient`, `TauCeti.powerClassHom`: the quotient `G ⧸ Gⁿ` and the map taking
+  an element to its power class.
 -/
 
 public section
@@ -39,51 +36,19 @@ variable (G : Type*) [CommGroup G] (n : ℕ)
 def powerSubgroup : Subgroup G :=
   (powMonoidHom n : G →* G).range
 
-/-- **The multiplicative quotient by `n`th powers** `G ⧸ Gⁿ`. -/
+/-- **The group of `n`th power classes** `G ⧸ Gⁿ`. -/
 abbrev powerClassQuotient : Type _ :=
   G ⧸ powerSubgroup G n
 
-/-- **The group of `n`th power classes** `G ⧸ Gⁿ`, written additively on `Additive G`. The
-subgroup divided out is the range of `powMonoidHom n`, that is `{g ^ n | g : G}`. -/
-abbrev PowerClassGroup : Type _ :=
-  ModN (Additive G) n
-
-instance (priority := 90) [Finite G] : Finite (PowerClassGroup G n) :=
-  Finite.of_surjective (ModN.mkQ n) (Submodule.Quotient.mk_surjective _)
-
-variable {G}
-
-/-- The subgroup defining Mathlib's `ModN (Additive G) n` is the additive form of the subgroup of
-`n`th powers in `G`. -/
-theorem modNSubgroup_eq_powerSubgroup :
-    (LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ))).toAddSubgroup =
-      (powerSubgroup G n).toAddSubgroup := by
-  ext a
-  simp only [Submodule.mem_toAddSubgroup, LinearMap.mem_range, LinearMap.lsmul_apply,
-    Additive.mem_toAddSubgroup]
-  constructor
-  · rintro ⟨b, hb⟩
-    refine ⟨b.toMul, ?_⟩
-    simpa only [powMonoidHom_apply, natCast_zsmul, toMul_nsmul] using
-      congrArg Additive.toMul hb
-  · rintro ⟨b, hb⟩
-    refine ⟨Additive.ofMul b, ?_⟩
-    apply Additive.toMul.injective
-    simpa only [powMonoidHom_apply, natCast_zsmul, toMul_nsmul, toMul_ofMul] using hb
-
-/-- Mathlib's additive `ModN` model is canonically equivalent to the additive form of the
-multiplicative quotient `G ⧸ Gⁿ`. -/
-def powerClassEquivQuotient :
-    PowerClassGroup G n ≃+ Additive (powerClassQuotient G n) :=
-  QuotientAddGroup.quotientAddEquivOfEq (modNSubgroup_eq_powerSubgroup (G := G) (n := n))
-
-/-- The multiplicative quotient homomorphism `G → G ⧸ Gⁿ`. -/
+/-- The quotient homomorphism `G → G ⧸ Gⁿ`. -/
 def powerClassHom : G →* powerClassQuotient G n :=
   QuotientGroup.mk' (powerSubgroup G n)
 
-/-- The multiplicative power-class homomorphism sends `g` to its quotient class. -/
+variable {G}
+
+/-- The power-class homomorphism sends `g` to its quotient class. -/
 @[simp]
-theorem powerClassHom_apply (g : G) : powerClassHom n g = QuotientGroup.mk g := by
+theorem powerClassHom_apply (g : G) : powerClassHom G n g = QuotientGroup.mk g := by
   exact QuotientGroup.mk'_apply (powerSubgroup G n) g
 
 /-- An element belongs to `Gⁿ` exactly when it is an `n`th power. -/
@@ -91,98 +56,5 @@ theorem powerClassHom_apply (g : G) : powerClassHom n g = QuotientGroup.mk g := 
 theorem mem_powerSubgroup_iff {g : G} : g ∈ powerSubgroup G n ↔ ∃ h : G, h ^ n = g := by
   rw [powerSubgroup, MonoidHom.mem_range]
   exact exists_congr fun h => by rw [powMonoidHom_apply]
-
-/-- Lift a homomorphism that kills `Gⁿ` to the quotient `G ⧸ Gⁿ`. -/
-def powerClassQuotientLift {H : Type*} [Group H] (f : G →* H)
-    (hf : powerSubgroup G n ≤ f.ker) : powerClassQuotient G n →* H :=
-  QuotientGroup.lift (powerSubgroup G n) f hf
-
-/-- A lift from the power-class quotient agrees with the original homomorphism on
-representatives. -/
-@[simp]
-theorem powerClassQuotientLift_mk {H : Type*} [Group H] (f : G →* H)
-    (hf : powerSubgroup G n ≤ f.ker) (g : G) :
-    powerClassQuotientLift n f hf (QuotientGroup.mk g) = f g := by
-  exact QuotientGroup.lift_mk' (powerSubgroup G n) hf g
-
-/-- The additive quotient homomorphism `Additive G →+ PowerClassGroup G n`. -/
-def powerClassAdd : Additive G →+ PowerClassGroup G n :=
-  ModN.mkQ n
-
-/-- The `n`th power class of an element of `G`. -/
-def powerClass (g : G) : PowerClassGroup G n :=
-  powerClassAdd n (Additive.ofMul g)
-
-/-- The canonical equivalence sends the additive `ModN` class of `g` to its multiplicative
-quotient class. -/
-@[simp]
-theorem powerClassEquivQuotient_powerClass (g : G) :
-    powerClassEquivQuotient (G := G) (n := n) (powerClass n g) =
-      Additive.ofMul (powerClassHom n g) := by
-  exact QuotientAddGroup.quotientAddEquivOfEq_mk
-    (modNSubgroup_eq_powerSubgroup (G := G) (n := n)) (Additive.ofMul g)
-
-/-- The power class is the quotient class of the element in Mathlib's `ModN` model. -/
-theorem powerClass_eq_mk (g : G) :
-    powerClass n g = Submodule.Quotient.mk (Additive.ofMul g) := by
-  exact Submodule.mkQ_apply _ _
-
-/-- Every class in `PowerClassGroup G n` has a representative in `G`. -/
-theorem powerClass_surjective : Function.Surjective (powerClass (G := G) n) := by
-  intro x
-  obtain ⟨a, rfl⟩ := Submodule.Quotient.mk_surjective _ x
-  exact ⟨a.toMul, by simpa using powerClass_eq_mk n a.toMul⟩
-
-@[simp]
-theorem powerClass_mul (g h : G) : powerClass n (g * h) = powerClass n g + powerClass n h := by
-  simp only [powerClass, ofMul_mul, map_add]
-
-@[simp]
-theorem powerClass_one : powerClass n (1 : G) = 0 := by
-  simp only [powerClass, ofMul_one, map_zero]
-
-/-- The class of a ratio is the difference of the classes. -/
-@[simp]
-theorem powerClass_div (g h : G) :
-    powerClass n (g / h) = powerClass n g - powerClass n h := by
-  simp only [powerClass, ofMul_div, map_sub]
-
-/-- The class of an inverse is the negative of the class. -/
-@[simp]
-theorem powerClass_inv (g : G) : powerClass n g⁻¹ = -powerClass n g := by
-  simp only [powerClass, ofMul_inv, map_neg]
-
-/-- The class of a power is the corresponding multiple of the class. -/
-@[simp]
-theorem powerClass_pow (g : G) (m : ℕ) : powerClass n (g ^ m) = m • powerClass n g := by
-  simp only [powerClass, ofMul_pow, map_nsmul]
-
-/-- The class of a finite product is the sum of the classes. -/
-theorem powerClass_prod {ι : Type*} (s : Finset ι) (g : ι → G) :
-    powerClass n (∏ i ∈ s, g i) = ∑ i ∈ s, powerClass n (g i) := by
-  simp only [powerClass, ofMul_prod, map_sum]
-
-/-- Membership in the submodule defining `ModN (Additive G) n` is membership in `Gⁿ`, expressed
-on multiplicative representatives. -/
-theorem mem_modNSubgroup_iff {g : G} :
-    Additive.ofMul g ∈ LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ)) ↔
-      ∃ h : G, h ^ n = g := by
-  rw [show Additive.ofMul g ∈ LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ)) ↔
-      Additive.ofMul g ∈
-        (LinearMap.range (LinearMap.lsmul ℤ (Additive G) (n : ℤ))).toAddSubgroup from Iff.rfl]
-  rw [modNSubgroup_eq_powerSubgroup, Additive.mem_toAddSubgroup, powerSubgroup,
-    MonoidHom.mem_range]
-  exact exists_congr fun h => by rw [powMonoidHom_apply]; exact Iff.rfl
-
-/-- **A power class is trivial exactly when its representative is an `n`th power.** -/
-@[simp]
-theorem powerClass_eq_zero_iff {g : G} : powerClass n g = 0 ↔ ∃ h : G, h ^ n = g := by
-  rw [powerClass_eq_mk, Submodule.Quotient.mk_eq_zero]
-  exact mem_modNSubgroup_iff (n := n)
-
-/-- Two elements have the same power class exactly when their ratio is an `n`th power. -/
-theorem powerClass_eq_iff {g h : G} :
-    powerClass n g = powerClass n h ↔ ∃ v : G, v ^ n = g / h := by
-  rw [← sub_eq_zero, ← powerClass_div, powerClass_eq_zero_iff]
 
 end TauCeti

--- a/TauCeti/FieldTheory/GaloisCohomology/Coefficients.lean
+++ b/TauCeti/FieldTheory/GaloisCohomology/Coefficients.lean
@@ -217,6 +217,13 @@ theorem kummerShortExact_proj (hn : IsUnit (n : K)) :
 
 variable {K}
 
+/-- A unit of the base field is fixed by the absolute Galois group after mapping into the
+separable closure. -/
+theorem smul_units_map_algebraMap (g : AbsoluteGaloisGroup K) (a : Kˣ) :
+    g • Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a =
+      Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a :=
+  Units.ext (AlgEquiv.commutes g (a : K))
+
 /-- **A unit of `Kˢ` fixed by the whole Galois group comes from `Kˣ`.** This is the fixed-field
 theorem for the separable closure read on units: `InfiniteGalois.mem_range_algebraMap_iff_fixed`
 supplies base-field preimages of the unit and of its inverse, and those preimages are inverse to
@@ -249,7 +256,7 @@ theorem mem_H0_unitsCoeff_iff {u : UnitsCoeff K} :
   · rintro ⟨a, ha⟩ σ
     refine Additive.toMul.injective ?_
     rw [Additive.toMul_smul, ← ha]
-    exact Units.ext (AlgEquiv.commutes σ (a : K))
+    exact smul_units_map_algebraMap σ a
 
 variable (K)
 

--- a/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
+++ b/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
@@ -264,28 +264,26 @@ variable (K n)
 it to the Kummer isomorphism. -/
 def kummerClassMap (hn : IsUnit (n : K)) :
     PowerClassGroup Kˣ n →+ H1 (AbsoluteGaloisGroup K) (KummerCoeff K n) :=
-  QuotientAddGroup.lift _ (kummerMap K n hn) (ker_kummerMap hn).ge
+  QuotientAddGroup.lift _ (kummerMap K n hn) <| by
+    rw [modNSubgroup_eq_powerSubgroup]
+    exact (ker_kummerMap hn).ge
 
 @[simp]
 theorem kummerClassMap_mk (hn : IsUnit (n : K)) (c : Additive Kˣ) :
-    kummerClassMap K n hn (QuotientAddGroup.mk c) = kummerMap K n hn c :=
+    kummerClassMap K n hn (ModN.mkQ n c) = kummerMap K n hn c :=
   (rfl)
 
 @[simp]
 theorem kummerClassMap_powerClass (hn : IsUnit (n : K)) (a : Kˣ) :
     kummerClassMap K n hn (powerClass n a) = kummerMap K n hn (Additive.ofMul a) := by
-  rw [powerClass_eq_mk, kummerClassMap_mk]
+  rw [powerClass_eq_mk]
+  rfl
 
 /-- **`Kˣ ⧸ (Kˣ)ⁿ` injects into `H¹(G_K, μₙ)`**, the kernel of the Kummer map being exactly the
 `n`th powers. -/
 theorem kummerClassMap_injective (hn : IsUnit (n : K)) :
     Function.Injective (kummerClassMap K n hn) := by
-  refine (injective_iff_map_eq_zero _).2 fun x hx => ?_
-  induction x using QuotientAddGroup.induction_on with
-  | _ c =>
-    rw [kummerClassMap_mk] at hx
-    refine (QuotientAddGroup.eq_zero_iff _).2 ?_
-    rw [← ker_kummerMap hn]
-    exact AddMonoidHom.mem_ker.2 hx
+  exact (QuotientAddGroup.injective_lift_iff _ _ _).2 <|
+    (modNSubgroup_eq_powerSubgroup (G := Kˣ) (n := n)).trans (ker_kummerMap hn).symm
 
 end TauCeti

--- a/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
+++ b/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
@@ -296,8 +296,8 @@ theorem kummerClassMap_mk (hn : IsUnit (n : K)) (a : Kˣ) :
   exact QuotientGroup.lift_mk' (powerSubgroup Kˣ n) (by rw [ker_kummerMap hn]) a
 
 /-- The quotient Kummer map sends the named power class of `a` to its Kummer class. -/
-theorem kummerClassMap_powerClass (hn : IsUnit (n : K)) (a : Kˣ) :
-    kummerClassMap K n hn (powerClassHom n a) = kummerMap K n hn a := by
+theorem kummerClassMap_powerClassHom (hn : IsUnit (n : K)) (a : Kˣ) :
+    kummerClassMap K n hn (powerClassHom Kˣ n a) = kummerMap K n hn a := by
   rw [powerClassHom_apply, kummerClassMap_mk]
 
 /-- **`Kˣ ⧸ (Kˣ)ⁿ` injects into `H¹(G_K, μₙ)`**, the kernel of the Kummer map being exactly the

--- a/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
+++ b/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
@@ -42,11 +42,15 @@ What is not here is surjectivity, which is Hilbert 90 for `Kˢ/K` and needs the 
 `H¹` as a colimit over the finite quotients of `G_K`. Surjectivity is the only missing input for
 the Kummer isomorphism `Kˣ ⧸ (Kˣ)ⁿ ≅ H¹(G_K, μₙ)`.
 
+This implements targets 4 and 5 and the multiplicativity and kernel parts of target 6 in Layer 9
+of the human-authored `TauCetiRoadmap/ProfiniteCohomology/README.md` and `Suggested.lean`.
+
 ## Main definitions
 
 * `TauCeti.kummerCocycle`: the cocycle `g ↦ g α / α` attached to a choice of `n`th root, and
   `TauCeti.kummerCocycleClass` its class in `H¹(G_K, μₙ)`.
-* `TauCeti.kummerMap`: the Kummer map `Kˣ → H¹(G_K, μₙ)`, written additively on `Additive Kˣ`.
+* `TauCeti.kummerMap`: the multiplicative Kummer map
+  `Kˣ →* Multiplicative (H¹(G_K, μₙ))`.
 * `TauCeti.kummerClassMap`: the induced map on the power classes `Kˣ ⧸ (Kˣ)ⁿ`.
 
 ## Main results
@@ -56,7 +60,7 @@ the Kummer isomorphism `Kˣ ⧸ (Kˣ)ⁿ ≅ H¹(G_K, μₙ)`.
 * `TauCeti.kummerMap_eq_kummerCocycleClass`: the Kummer class of `a` is the class of
   `g ↦ g α / α`.
 * `TauCeti.ker_kummerMap`: the kernel of the Kummer map is `(Kˣ)ⁿ`, with
-  `TauCeti.kummerMap_eq_zero_iff` the pointwise form.
+  `TauCeti.kummerMap_eq_one_iff` the pointwise form.
 * `TauCeti.kummerClassMap_injective`: `Kˣ ⧸ (Kˣ)ⁿ` injects into `H¹(G_K, μₙ)`.
 
 ## References
@@ -79,12 +83,6 @@ variable {K : Type*} [Field K] {n : ℕ}
 
 Nothing in this section needs `n` to be invertible in `K`: the input is a chosen `n`th root of the
 given unit, and invertibility of `n` is only what produces one. -/
-
-/-- A unit of the base field is fixed by the absolute Galois group once pushed into `Kˢ`. -/
-theorem smul_units_map_algebraMap (g : AbsoluteGaloisGroup K) (a : Kˣ) :
-    g • Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a =
-      Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a :=
-  Units.ext (AlgEquiv.commutes g (a : K))
 
 variable {a : Kˣ} {α β : (SeparableClosure K)ˣ}
 
@@ -110,9 +108,8 @@ theorem toMul_kummerCocycle
     ((kummerCocycle hα g).toMul : (SeparableClosure K)ˣ) = g • α * α⁻¹ :=
   (rfl)
 
-/-- The Kummer cocycle lies over the coboundary of `α` in the units of `Kˢ`. This one computation
-is what the cocycle identity, the continuity, and the connecting-map description all run
-through. -/
+/-- The coefficient inclusion of the Kummer cocycle is the coboundary ratio `g • α - α` in the
+units of `Kˢ`. -/
 theorem kummerCoeffIncl_kummerCocycle
     (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a)
     (g : AbsoluteGaloisGroup K) :
@@ -122,9 +119,7 @@ theorem kummerCoeffIncl_kummerCocycle
     rw [toMul_kummerCoeffIncl, toMul_kummerCocycle, toMul_sub, Additive.toMul_smul,
       toMul_ofMul, div_eq_mul_inv]
 
-/-- **The Kummer cocycle is a continuous `1`-cocycle.** Both halves descend along the injection
-`μₙ ↪ (Kˢ)ˣ` from the coboundary `d⁰ α` it lies over: continuity because an injection of discrete
-spaces reflects continuity, and the cocycle identity because `d¹ (d⁰ α) = 0`. -/
+/-- **The Kummer ratio `g ↦ g α / α` is a continuous `1`-cocycle** with values in `μₙ`. -/
 theorem kummerCocycle_mem_Z1
     (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a) :
     kummerCocycle hα ∈ Z1 (AbsoluteGaloisGroup K) (KummerCoeff K n) := by
@@ -177,17 +172,38 @@ theorem kummerCocycleClass_congr
 
 variable (K n)
 
-/-- **The Kummer map** `Kˣ → H¹(G_K, μₙ)`, written additively on `Additive Kˣ`: the degree-zero
-connecting homomorphism of the Kummer sequence, precomposed with the identification of `Kˣ` with
-the invariants of `(Kˢ)ˣ`. -/
-def kummerMap (hn : IsUnit (n : K)) :
+/-- The additive form of the Kummer connecting homomorphism, used to construct `kummerMap`. -/
+def kummerMapAdd (hn : IsUnit (n : K)) :
     Additive Kˣ →+ H1 (AbsoluteGaloisGroup K) (KummerCoeff K n) :=
   (kummerShortExact K n hn).explicitDelta0.comp (baseUnitsEquivInvariants K).toAddMonoidHom
 
-theorem kummerMap_apply (hn : IsUnit (n : K)) (c : Additive Kˣ) :
-    kummerMap K n hn c =
+/-- The additive Kummer map is the degree-zero connecting homomorphism after identifying base
+units with the invariants of the separable-closure units. -/
+theorem kummerMapAdd_apply (hn : IsUnit (n : K)) (c : Additive Kˣ) :
+    kummerMapAdd K n hn c =
       (kummerShortExact K n hn).explicitDelta0 (baseUnitsEquivInvariants K c) :=
   (rfl)
+
+/-- **The Kummer map** `Kˣ →* Multiplicative (H¹(G_K, μₙ))`: the degree-zero connecting
+homomorphism of the Kummer sequence, written in the multiplicative API specified by the roadmap. -/
+def kummerMap (hn : IsUnit (n : K)) :
+    Kˣ →* Multiplicative (H1 (AbsoluteGaloisGroup K) (KummerCoeff K n)) :=
+  (kummerMapAdd K n hn).toMultiplicativeRight
+
+/-- The additive value underlying `kummerMap a` is `kummerMapAdd (Additive.ofMul a)`. -/
+@[simp]
+theorem toAdd_kummerMap_apply (hn : IsUnit (n : K)) (a : Kˣ) :
+    Multiplicative.toAdd (kummerMap K n hn a) =
+      kummerMapAdd K n hn (Additive.ofMul a) := by
+  exact congrArg Multiplicative.toAdd
+    (AddMonoidHom.toMultiplicativeRight_apply_apply (kummerMapAdd K n hn) a)
+
+/-- The multiplicative Kummer map is the type-tagged additive connecting map on each unit. -/
+@[simp]
+theorem kummerMap_apply (hn : IsUnit (n : K)) (a : Kˣ) :
+    kummerMap K n hn a =
+      Multiplicative.ofAdd (kummerMapAdd K n hn (Additive.ofMul a)) := by
+  exact AddMonoidHom.toMultiplicativeRight_apply_apply (kummerMapAdd K n hn) a
 
 variable {K n}
 
@@ -206,8 +222,8 @@ theorem exists_pow_eq_units_map (hn : IsUnit (n : K)) (a : Kˣ) :
 on every unit. -/
 theorem kummerMap_eq_kummerCocycleClass (hn : IsUnit (n : K))
     (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a) :
-    kummerMap K n hn (Additive.ofMul a) = kummerCocycleClass hα := by
-  rw [kummerMap_apply]
+    Multiplicative.toAdd (kummerMap K n hn a) = kummerCocycleClass hα := by
+  rw [toAdd_kummerMap_apply, kummerMapAdd_apply]
   refine (kummerShortExact K n hn).explicitDelta0_apply _
     (b := (Additive.ofMul α : UnitsCoeff K)) (Additive.toMul.injective ?_)
     (kummerCocycle_mem_Z1 hα) fun g => ?_
@@ -229,19 +245,18 @@ theorem explicitCoeff0_baseUnitsEquivInvariants (hn : IsUnit (n : K)) (c : Addit
       toMul_unitsCoeffPow, toMul_coe_baseUnitsEquivInvariants,
       toMul_coe_baseUnitsEquivInvariants, toMul_ofMul, map_pow]
 
-/-- **The kernel of the Kummer map is `(Kˣ)ⁿ`.** Exactness at `H⁰(G_K, (Kˢ)ˣ)` says the kernel of
-`δ⁰` is the image of the `n`th power map on invariants, and
+/-- **The kernel of the additive Kummer map is `(Kˣ)ⁿ`.** Exactness at
+`H⁰(G_K, (Kˢ)ˣ)` says the kernel of `δ⁰` is the image of the `n`th power map on invariants, and
 `TauCeti.explicitCoeff0_baseUnitsEquivInvariants` reads that image off in `Kˣ`. -/
-theorem ker_kummerMap (hn : IsUnit (n : K)) :
-    (kummerMap K n hn).ker = (powMonoidHom n : Kˣ →* Kˣ).range.toAddSubgroup := by
-  have hker : ∀ c : Additive Kˣ, kummerMap K n hn c = 0 ↔
+theorem ker_kummerMapAdd (hn : IsUnit (n : K)) :
+    (kummerMapAdd K n hn).ker = (powerSubgroup Kˣ n).toAddSubgroup := by
+  have hker : ∀ c : Additive Kˣ, kummerMapAdd K n hn c = 0 ↔
       baseUnitsEquivInvariants K c ∈ (explicitCoeff0 (AbsoluteGaloisGroup K) (UnitsCoeff K)
         (kummerShortExact K n hn).projDistribMulActionHom).range := fun c => by
     rw [(kummerShortExact K n hn).explicitLongExact_H0C]
     exact (AddMonoidHom.mem_ker (f := (kummerShortExact K n hn).explicitDelta0)).symm
   ext c
-  rw [AddMonoidHom.mem_ker, hker, Additive.mem_toAddSubgroup, MonoidHom.mem_range]
-  simp only [powMonoidHom_apply]
+  rw [AddMonoidHom.mem_ker, hker, Additive.mem_toAddSubgroup, mem_powerSubgroup_iff]
   refine ⟨fun ⟨u, hu⟩ => ?_, fun ⟨v, hv⟩ => ⟨baseUnitsEquivInvariants K (Additive.ofMul v), ?_⟩⟩
   · obtain ⟨d, rfl⟩ := (baseUnitsEquivInvariants K).surjective u
     rw [explicitCoeff0_baseUnitsEquivInvariants] at hu
@@ -249,11 +264,18 @@ theorem ker_kummerMap (hn : IsUnit (n : K)) :
   · rw [explicitCoeff0_baseUnitsEquivInvariants, toMul_ofMul, hv]
     exact congrArg (baseUnitsEquivInvariants K) (Additive.ofMul.apply_symm_apply c)
 
+/-- **The kernel of the multiplicative Kummer map is `(Kˣ)ⁿ`.** -/
+theorem ker_kummerMap (hn : IsUnit (n : K)) :
+    (kummerMap K n hn).ker = powerSubgroup Kˣ n := by
+  ext a
+  rw [MonoidHom.mem_ker, kummerMap_apply, ofAdd_eq_one, ← AddMonoidHom.mem_ker,
+    ker_kummerMapAdd, Additive.mem_toAddSubgroup]
+  simp only [toMul_ofMul]
+
 /-- **A unit has trivial Kummer class exactly when it is an `n`th power in `K`.** -/
-theorem kummerMap_eq_zero_iff (hn : IsUnit (n : K)) (a : Kˣ) :
-    kummerMap K n hn (Additive.ofMul a) = 0 ↔ ∃ b : Kˣ, b ^ n = a := by
-  rw [← AddMonoidHom.mem_ker, ker_kummerMap, Additive.mem_toAddSubgroup, MonoidHom.mem_range]
-  simp only [powMonoidHom_apply, toMul_ofMul]
+theorem kummerMap_eq_one_iff (hn : IsUnit (n : K)) (a : Kˣ) :
+    kummerMap K n hn a = 1 ↔ ∃ b : Kˣ, b ^ n = a := by
+  rw [← MonoidHom.mem_ker, ker_kummerMap, mem_powerSubgroup_iff]
 
 /-! ### The Kummer map on power classes -/
 
@@ -263,27 +285,27 @@ variable (K n)
 (`TauCeti.kummerClassMap_injective`); surjectivity, which needs Hilbert 90, is what would upgrade
 it to the Kummer isomorphism. -/
 def kummerClassMap (hn : IsUnit (n : K)) :
-    PowerClassGroup Kˣ n →+ H1 (AbsoluteGaloisGroup K) (KummerCoeff K n) :=
-  QuotientAddGroup.lift _ (kummerMap K n hn) <| by
-    rw [modNSubgroup_eq_powerSubgroup]
-    exact (ker_kummerMap hn).ge
+    powerClassQuotient Kˣ n →*
+      Multiplicative (H1 (AbsoluteGaloisGroup K) (KummerCoeff K n)) :=
+  QuotientGroup.lift (powerSubgroup Kˣ n) (kummerMap K n hn) <| by
+    rw [ker_kummerMap hn]
 
+/-- The quotient Kummer map agrees with `kummerMap` on representatives. -/
 @[simp]
-theorem kummerClassMap_mk (hn : IsUnit (n : K)) (c : Additive Kˣ) :
-    kummerClassMap K n hn (ModN.mkQ n c) = kummerMap K n hn c :=
-  (rfl)
+theorem kummerClassMap_mk (hn : IsUnit (n : K)) (a : Kˣ) :
+    kummerClassMap K n hn (QuotientGroup.mk a) = kummerMap K n hn a := by
+  exact QuotientGroup.lift_mk' (powerSubgroup Kˣ n) (by rw [ker_kummerMap hn]) a
 
+/-- The quotient Kummer map sends the named power class of `a` to its Kummer class. -/
 @[simp]
 theorem kummerClassMap_powerClass (hn : IsUnit (n : K)) (a : Kˣ) :
-    kummerClassMap K n hn (powerClass n a) = kummerMap K n hn (Additive.ofMul a) := by
-  rw [powerClass_eq_mk]
-  rfl
+    kummerClassMap K n hn (powerClassHom n a) = kummerMap K n hn a := by
+  rw [powerClassHom_apply, kummerClassMap_mk]
 
 /-- **`Kˣ ⧸ (Kˣ)ⁿ` injects into `H¹(G_K, μₙ)`**, the kernel of the Kummer map being exactly the
 `n`th powers. -/
 theorem kummerClassMap_injective (hn : IsUnit (n : K)) :
     Function.Injective (kummerClassMap K n hn) := by
-  exact (QuotientAddGroup.injective_lift_iff _ _ _).2 <|
-    (modNSubgroup_eq_powerSubgroup (G := Kˣ) (n := n)).trans (ker_kummerMap hn).symm
+  exact (QuotientGroup.injective_lift_iff _ _ _).2 (ker_kummerMap hn).symm
 
 end TauCeti

--- a/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
+++ b/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
@@ -1,0 +1,291 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Group.PowerClassGroup
+public import TauCeti.FieldTheory.GaloisCohomology.Coefficients
+public import TauCeti.RepresentationTheory.Homological.ContCohomology.LongExact
+
+/-!
+# The Kummer map `Kˣ → H¹(G_K, μₙ)`
+
+Let `K` be a field, `Kˢ` a separable closure, `G_K = AbsoluteGaloisGroup K`, and `n` a natural
+number invertible in `K`. The Kummer sequence
+
+```text
+1 ⟶ μₙ ⟶ (Kˢ)ˣ ⟶ (Kˢ)ˣ ⟶ 1
+```
+
+of discrete `G_K`-modules is `TauCeti.kummerShortExact`; its degree-zero connecting map, read
+through the identification `TauCeti.baseUnitsEquivInvariants` of `H⁰(G_K, (Kˢ)ˣ)` with `Kˣ`, is
+the **Kummer map** `Kˣ → H¹(G_K, μₙ)`. This file constructs it, computes it on cocycles, and
+identifies its kernel.
+
+The computation is the classical one. Choose an `n`th root `α ∈ (Kˢ)ˣ` of `a ∈ Kˣ`; then
+`g ↦ g α / α` takes values in `μₙ`, because raising it to the `n` gives `g a / a = 1`, and it is a
+continuous `1`-cocycle, because its image in `(Kˢ)ˣ` is the coboundary `d⁰ α`. Its class is the
+Kummer class of `a`. The class does not depend on the choice of root: two roots differ by an
+element `ζ` of `μₙ`, and the two cocycles differ by the coboundary `d⁰ ζ`. That independence is
+proved directly, with no hypothesis on `n`, so it is available for any `a` that happens to have a
+root.
+
+The kernel is `(Kˣ)ⁿ`. This is exactness of the long exact sequence at `H⁰(G_K, (Kˢ)ˣ)` —
+`explicitLongExact_H0C` — together with the commuting square
+`TauCeti.explicitCoeff0_baseUnitsEquivInvariants`, which says that the `n`th power map on the
+invariants of `(Kˢ)ˣ` is the `n`th power map of `Kˣ`. So the Kummer map descends to an
+**injection** of the power-class group `Kˣ ⧸ (Kˣ)ⁿ` into `H¹(G_K, μₙ)`.
+
+What is not here is surjectivity, which is Hilbert 90 for `Kˢ/K` and needs the description of
+`H¹` as a colimit over the finite quotients of `G_K`. Surjectivity is the only missing input for
+the Kummer isomorphism `Kˣ ⧸ (Kˣ)ⁿ ≅ H¹(G_K, μₙ)`.
+
+## Main definitions
+
+* `TauCeti.kummerCocycle`: the cocycle `g ↦ g α / α` attached to a choice of `n`th root, and
+  `TauCeti.kummerCocycleClass` its class in `H¹(G_K, μₙ)`.
+* `TauCeti.kummerMap`: the Kummer map `Kˣ → H¹(G_K, μₙ)`, written additively on `Additive Kˣ`.
+* `TauCeti.kummerClassMap`: the induced map on the power classes `Kˣ ⧸ (Kˣ)ⁿ`.
+
+## Main results
+
+* `TauCeti.kummerCocycle_mem_Z1`: `g ↦ g α / α` is a continuous `1`-cocycle.
+* `TauCeti.kummerCocycleClass_congr`: independence of the choice of `n`th root.
+* `TauCeti.kummerMap_eq_kummerCocycleClass`: the Kummer class of `a` is the class of
+  `g ↦ g α / α`.
+* `TauCeti.ker_kummerMap`: the kernel of the Kummer map is `(Kˣ)ⁿ`, with
+  `TauCeti.kummerMap_eq_zero_iff` the pointwise form.
+* `TauCeti.kummerClassMap_injective`: `Kˣ ⧸ (Kˣ)ⁿ` injects into `H¹(G_K, μₙ)`.
+
+## References
+
+* J. Neukirch, A. Schmidt, K. Wingberg, *Cohomology of Number Fields*, 2nd ed., (6.2.1) and the
+  display following it.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open ContCohomology
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+/-! ### The cocycle attached to an `n`th root
+
+Nothing in this section needs `n` to be invertible in `K`: the input is a chosen `n`th root of the
+given unit, and invertibility of `n` is only what produces one. -/
+
+/-- A unit of the base field is fixed by the absolute Galois group once pushed into `Kˢ`. -/
+theorem smul_units_map_algebraMap (g : AbsoluteGaloisGroup K) (a : Kˣ) :
+    g • Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a =
+      Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a :=
+  Units.ext (AlgEquiv.commutes g (a : K))
+
+variable {a : Kˣ} {α β : (SeparableClosure K)ˣ}
+
+/-- **The Kummer ratio is an `n`th root of unity**: if `αⁿ = a` with `a` in the base field, then
+`(g α / α)ⁿ = g a / a = 1`. -/
+theorem smul_mul_inv_mem_rootsOfUnity
+    (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a)
+    (g : AbsoluteGaloisGroup K) : g • α * α⁻¹ ∈ rootsOfUnity n (SeparableClosure K) := by
+  rw [mem_rootsOfUnity, mul_pow, ← smul_pow', inv_pow, hα, smul_units_map_algebraMap,
+    mul_inv_cancel]
+
+/-- **The Kummer cocycle** `g ↦ g α / α` of a unit `a` of `K` and a choice of `n`th root `α` of
+`a` in `Kˢ`. Its class is the Kummer class of `a` (`TauCeti.kummerMap_eq_kummerCocycleClass`) and
+is independent of the choice of `α` (`TauCeti.kummerCocycleClass_congr`). -/
+def kummerCocycle (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a) :
+    AbsoluteGaloisGroup K → KummerCoeff K n :=
+  fun g => Additive.ofMul ⟨g • α * α⁻¹, smul_mul_inv_mem_rootsOfUnity hα g⟩
+
+@[simp]
+theorem toMul_kummerCocycle
+    (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a)
+    (g : AbsoluteGaloisGroup K) :
+    ((kummerCocycle hα g).toMul : (SeparableClosure K)ˣ) = g • α * α⁻¹ :=
+  (rfl)
+
+/-- The Kummer cocycle lies over the coboundary of `α` in the units of `Kˢ`. This one computation
+is what the cocycle identity, the continuity, and the connecting-map description all run
+through. -/
+theorem kummerCoeffIncl_kummerCocycle
+    (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a)
+    (g : AbsoluteGaloisGroup K) :
+    kummerCoeffIncl K n (kummerCocycle hα g) =
+      g • (Additive.ofMul α : UnitsCoeff K) - Additive.ofMul α :=
+  Additive.toMul.injective <| by
+    rw [toMul_kummerCoeffIncl, toMul_kummerCocycle, toMul_sub, Additive.toMul_smul,
+      toMul_ofMul, div_eq_mul_inv]
+
+/-- **The Kummer cocycle is a continuous `1`-cocycle.** Both halves descend along the injection
+`μₙ ↪ (Kˢ)ˣ` from the coboundary `d⁰ α` it lies over: continuity because an injection of discrete
+spaces reflects continuity, and the cocycle identity because `d¹ (d⁰ α) = 0`. -/
+theorem kummerCocycle_mem_Z1
+    (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a) :
+    kummerCocycle hα ∈ Z1 (AbsoluteGaloisGroup K) (KummerCoeff K n) := by
+  have hd0 : ∀ g : AbsoluteGaloisGroup K, kummerCoeffIncl K n (kummerCocycle hα g) =
+      d0 (AbsoluteGaloisGroup K) (UnitsCoeff K) (Additive.ofMul α) g := fun g =>
+    (kummerCoeffIncl_kummerCocycle hα g).trans (d0_apply _ g).symm
+  refine mem_Z1_iff.2 ⟨continuous_of_injective_comp (kummerCoeffIncl_injective K n) ?_,
+    fun g h => kummerCoeffIncl_injective K n ?_⟩
+  · simpa only [hd0] using
+      continuous_d0_apply (G := AbsoluteGaloisGroup K) (Additive.ofMul α : UnitsCoeff K)
+  · rw [map_add, kummerCoeffIncl_equivariant, kummerCoeffIncl_kummerCocycle,
+      kummerCoeffIncl_kummerCocycle, kummerCoeffIncl_kummerCocycle, smul_sub, smul_smul]
+    abel
+
+/-- The class in `H¹(G_K, μₙ)` of the Kummer cocycle of a chosen `n`th root. -/
+def kummerCocycleClass
+    (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a) :
+    H1 (AbsoluteGaloisGroup K) (KummerCoeff K n) :=
+  H1pi (AbsoluteGaloisGroup K) (KummerCoeff K n) ⟨kummerCocycle hα, kummerCocycle_mem_Z1 hα⟩
+
+/-- **The Kummer class is independent of the chosen `n`th root.** Two `n`th roots of the same `a`
+differ by an element `ζ` of `μₙ`, and `g (α ζ) / (α ζ) = (g α / α) · (g ζ / ζ)` differs from
+`g α / α` by the coboundary of `ζ`. -/
+theorem kummerCocycleClass_congr
+    (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a)
+    (hβ : β ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a) :
+    kummerCocycleClass hα = kummerCocycleClass hβ := by
+  obtain ⟨ζ, hζ⟩ : ∃ ζ : KummerCoeff K n,
+      kummerCoeffIncl K n ζ = (Additive.ofMul β : UnitsCoeff K) - Additive.ofMul α := by
+    refine ⟨Additive.ofMul ⟨α⁻¹ * β, ?_⟩, Additive.toMul.injective ?_⟩
+    · rw [mem_rootsOfUnity, mul_pow, inv_pow, hα, hβ, inv_mul_cancel]
+    · rw [toMul_kummerCoeffIncl, toMul_sub, toMul_ofMul, toMul_ofMul, toMul_ofMul,
+        div_eq_mul_inv, mul_comm β α⁻¹]
+  have key : kummerCocycle hβ - kummerCocycle hα =
+      d0 (AbsoluteGaloisGroup K) (KummerCoeff K n) ζ := by
+    funext g
+    refine kummerCoeffIncl_injective K n ?_
+    rw [Pi.sub_apply, map_sub, kummerCoeffIncl_kummerCocycle, kummerCoeffIncl_kummerCocycle,
+      map_d0_apply _ (kummerCoeffIncl_equivariant K n), hζ, d0_apply, smul_sub]
+    abel
+  have hB : kummerCocycle hβ - kummerCocycle hα ∈
+      B1 (AbsoluteGaloisGroup K) (KummerCoeff K n) := by
+    rw [key]
+    exact d0_mem_B1 ζ
+  rw [kummerCocycleClass, kummerCocycleClass]
+  exact ((H1pi_eq_iff (f := ⟨kummerCocycle hβ, kummerCocycle_mem_Z1 hβ⟩)
+    (f' := ⟨kummerCocycle hα, kummerCocycle_mem_Z1 hα⟩)).2 hB).symm
+
+/-! ### The Kummer map and its kernel -/
+
+variable (K n)
+
+/-- **The Kummer map** `Kˣ → H¹(G_K, μₙ)`, written additively on `Additive Kˣ`: the degree-zero
+connecting homomorphism of the Kummer sequence, precomposed with the identification of `Kˣ` with
+the invariants of `(Kˢ)ˣ`. -/
+def kummerMap (hn : IsUnit (n : K)) :
+    Additive Kˣ →+ H1 (AbsoluteGaloisGroup K) (KummerCoeff K n) :=
+  (kummerShortExact K n hn).explicitDelta0.comp (baseUnitsEquivInvariants K).toAddMonoidHom
+
+theorem kummerMap_apply (hn : IsUnit (n : K)) (c : Additive Kˣ) :
+    kummerMap K n hn c =
+      (kummerShortExact K n hn).explicitDelta0 (baseUnitsEquivInvariants K c) :=
+  (rfl)
+
+variable {K n}
+
+/-- **Every unit of `K` has an `n`th root in `Kˢ`** when `n` is invertible in `K`; this is
+`TauCeti.unitsCoeffPow_surjective` read on units. -/
+theorem exists_pow_eq_units_map (hn : IsUnit (n : K)) (a : Kˣ) :
+    ∃ α : (SeparableClosure K)ˣ,
+      α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a := by
+  obtain ⟨x, hx⟩ := unitsCoeffPow_surjective K n hn
+    (Additive.ofMul (Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a))
+  refine ⟨x.toMul, ?_⟩
+  rw [← toMul_unitsCoeffPow, hx, toMul_ofMul]
+
+/-- **The Kummer class of `a` is represented by `g ↦ g α / α`**, for any `n`th root `α` of `a` in
+`Kˢ` (NSW (6.2.1)). Together with `TauCeti.exists_pow_eq_units_map` this computes the Kummer map
+on every unit. -/
+theorem kummerMap_eq_kummerCocycleClass (hn : IsUnit (n : K))
+    (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a) :
+    kummerMap K n hn (Additive.ofMul a) = kummerCocycleClass hα := by
+  rw [kummerMap_apply]
+  refine (kummerShortExact K n hn).explicitDelta0_apply _
+    (b := (Additive.ofMul α : UnitsCoeff K)) (Additive.toMul.injective ?_)
+    (kummerCocycle_mem_Z1 hα) fun g => ?_
+  · rw [kummerShortExact_proj, toMul_unitsCoeffPow, toMul_ofMul,
+      toMul_coe_baseUnitsEquivInvariants, toMul_ofMul, hα]
+  · rw [kummerShortExact_incl]
+    exact kummerCoeffIncl_kummerCocycle hα g
+
+/-- **The `n`th power map on invariants is the `n`th power map of `Kˣ`.** This is the commuting
+square that turns exactness of the long exact sequence at `H⁰(G_K, (Kˢ)ˣ)` into the computation of
+the kernel of the Kummer map. -/
+theorem explicitCoeff0_baseUnitsEquivInvariants (hn : IsUnit (n : K)) (c : Additive Kˣ) :
+    explicitCoeff0 (AbsoluteGaloisGroup K) (UnitsCoeff K)
+        (kummerShortExact K n hn).projDistribMulActionHom (baseUnitsEquivInvariants K c) =
+      baseUnitsEquivInvariants K (Additive.ofMul (c.toMul ^ n)) :=
+  Subtype.ext <| Additive.toMul.injective <| by
+    rw [coe_explicitCoeff0, DiscreteShortExact.projDistribMulActionHom_apply,
+      kummerShortExact_proj,
+      toMul_unitsCoeffPow, toMul_coe_baseUnitsEquivInvariants,
+      toMul_coe_baseUnitsEquivInvariants, toMul_ofMul, map_pow]
+
+/-- **The kernel of the Kummer map is `(Kˣ)ⁿ`.** Exactness at `H⁰(G_K, (Kˢ)ˣ)` says the kernel of
+`δ⁰` is the image of the `n`th power map on invariants, and
+`TauCeti.explicitCoeff0_baseUnitsEquivInvariants` reads that image off in `Kˣ`. -/
+theorem ker_kummerMap (hn : IsUnit (n : K)) :
+    (kummerMap K n hn).ker = (powMonoidHom n : Kˣ →* Kˣ).range.toAddSubgroup := by
+  have hker : ∀ c : Additive Kˣ, kummerMap K n hn c = 0 ↔
+      baseUnitsEquivInvariants K c ∈ (explicitCoeff0 (AbsoluteGaloisGroup K) (UnitsCoeff K)
+        (kummerShortExact K n hn).projDistribMulActionHom).range := fun c => by
+    rw [(kummerShortExact K n hn).explicitLongExact_H0C]
+    exact (AddMonoidHom.mem_ker (f := (kummerShortExact K n hn).explicitDelta0)).symm
+  ext c
+  rw [AddMonoidHom.mem_ker, hker, Additive.mem_toAddSubgroup, MonoidHom.mem_range]
+  simp only [powMonoidHom_apply]
+  refine ⟨fun ⟨u, hu⟩ => ?_, fun ⟨v, hv⟩ => ⟨baseUnitsEquivInvariants K (Additive.ofMul v), ?_⟩⟩
+  · obtain ⟨d, rfl⟩ := (baseUnitsEquivInvariants K).surjective u
+    rw [explicitCoeff0_baseUnitsEquivInvariants] at hu
+    exact ⟨d.toMul, congrArg Additive.toMul ((baseUnitsEquivInvariants K).injective hu)⟩
+  · rw [explicitCoeff0_baseUnitsEquivInvariants, toMul_ofMul, hv]
+    exact congrArg (baseUnitsEquivInvariants K) (Additive.ofMul.apply_symm_apply c)
+
+/-- **A unit has trivial Kummer class exactly when it is an `n`th power in `K`.** -/
+theorem kummerMap_eq_zero_iff (hn : IsUnit (n : K)) (a : Kˣ) :
+    kummerMap K n hn (Additive.ofMul a) = 0 ↔ ∃ b : Kˣ, b ^ n = a := by
+  rw [← AddMonoidHom.mem_ker, ker_kummerMap, Additive.mem_toAddSubgroup, MonoidHom.mem_range]
+  simp only [powMonoidHom_apply, toMul_ofMul]
+
+/-! ### The Kummer map on power classes -/
+
+variable (K n)
+
+/-- **The Kummer map on power classes**, `Kˣ ⧸ (Kˣ)ⁿ → H¹(G_K, μₙ)`. It is injective
+(`TauCeti.kummerClassMap_injective`); surjectivity, which needs Hilbert 90, is what would upgrade
+it to the Kummer isomorphism. -/
+def kummerClassMap (hn : IsUnit (n : K)) :
+    PowerClassGroup Kˣ n →+ H1 (AbsoluteGaloisGroup K) (KummerCoeff K n) :=
+  QuotientAddGroup.lift _ (kummerMap K n hn) (ker_kummerMap hn).ge
+
+@[simp]
+theorem kummerClassMap_mk (hn : IsUnit (n : K)) (c : Additive Kˣ) :
+    kummerClassMap K n hn (QuotientAddGroup.mk c) = kummerMap K n hn c :=
+  (rfl)
+
+@[simp]
+theorem kummerClassMap_powerClass (hn : IsUnit (n : K)) (a : Kˣ) :
+    kummerClassMap K n hn (powerClass n a) = kummerMap K n hn (Additive.ofMul a) := by
+  rw [powerClass_eq_mk, kummerClassMap_mk]
+
+/-- **`Kˣ ⧸ (Kˣ)ⁿ` injects into `H¹(G_K, μₙ)`**, the kernel of the Kummer map being exactly the
+`n`th powers. -/
+theorem kummerClassMap_injective (hn : IsUnit (n : K)) :
+    Function.Injective (kummerClassMap K n hn) := by
+  refine (injective_iff_map_eq_zero _).2 fun x hx => ?_
+  induction x using QuotientAddGroup.induction_on with
+  | _ c =>
+    rw [kummerClassMap_mk] at hx
+    refine (QuotientAddGroup.eq_zero_iff _).2 ?_
+    rw [← ker_kummerMap hn]
+    exact AddMonoidHom.mem_ker.2 hx
+
+end TauCeti

--- a/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
+++ b/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
@@ -42,9 +42,6 @@ What is not here is surjectivity, which is Hilbert 90 for `Kˢ/K` and needs the 
 `H¹` as a colimit over the finite quotients of `G_K`. Surjectivity is the only missing input for
 the Kummer isomorphism `Kˣ ⧸ (Kˣ)ⁿ ≅ H¹(G_K, μₙ)`.
 
-This implements targets 4 and 5 and the multiplicativity and kernel parts of target 6 in Layer 9
-of the human-authored `TauCetiRoadmap/ProfiniteCohomology/README.md` and `Suggested.lean`.
-
 ## Main definitions
 
 * `TauCeti.kummerCocycle`: the cocycle `g ↦ g α / α` attached to a choice of `n`th root, and
@@ -186,7 +183,7 @@ private theorem kummerMapAdd_apply (hn : IsUnit (n : K)) (c : Additive Kˣ) :
   (rfl)
 
 /-- **The Kummer map** `Kˣ →* Multiplicative (H¹(G_K, μₙ))`: the degree-zero connecting
-homomorphism of the Kummer sequence, written in the multiplicative API specified by the roadmap. -/
+homomorphism of the Kummer sequence, written multiplicatively on the units of `K`. -/
 def kummerMap (hn : IsUnit (n : K)) :
     Kˣ →* Multiplicative (H1 (AbsoluteGaloisGroup K) (KummerCoeff K n)) :=
   (kummerMapAdd K n hn).toMultiplicativeRight

--- a/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
+++ b/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
@@ -172,14 +172,15 @@ theorem kummerCocycleClass_congr
 
 variable (K n)
 
-/-- The additive form of the Kummer connecting homomorphism, used to construct `kummerMap`. -/
-def kummerMapAdd (hn : IsUnit (n : K)) :
+/-- The additive shape of the Kummer connecting homomorphism. This is an implementation detail
+of `TauCeti.kummerMap`, whose public evaluation lemma `TauCeti.kummerMap_apply` states the same
+equation in terms of `explicitDelta0`. -/
+private def kummerMapAdd (hn : IsUnit (n : K)) :
     Additive Kˣ →+ H1 (AbsoluteGaloisGroup K) (KummerCoeff K n) :=
   (kummerShortExact K n hn).explicitDelta0.comp (baseUnitsEquivInvariants K).toAddMonoidHom
 
-/-- The additive Kummer map is the degree-zero connecting homomorphism after identifying base
-units with the invariants of the separable-closure units. -/
-theorem kummerMapAdd_apply (hn : IsUnit (n : K)) (c : Additive Kˣ) :
+/-- The defining equation of the implementation helper `kummerMapAdd`. -/
+private theorem kummerMapAdd_apply (hn : IsUnit (n : K)) (c : Additive Kˣ) :
     kummerMapAdd K n hn c =
       (kummerShortExact K n hn).explicitDelta0 (baseUnitsEquivInvariants K c) :=
   (rfl)
@@ -190,19 +191,14 @@ def kummerMap (hn : IsUnit (n : K)) :
     Kˣ →* Multiplicative (H1 (AbsoluteGaloisGroup K) (KummerCoeff K n)) :=
   (kummerMapAdd K n hn).toMultiplicativeRight
 
-/-- The additive value underlying `kummerMap a` is `kummerMapAdd (Additive.ofMul a)`. -/
-theorem toAdd_kummerMap_apply (hn : IsUnit (n : K)) (a : Kˣ) :
-    Multiplicative.toAdd (kummerMap K n hn a) =
-      kummerMapAdd K n hn (Additive.ofMul a) := by
-  exact congrArg Multiplicative.toAdd
-    (AddMonoidHom.toMultiplicativeRight_apply_apply (kummerMapAdd K n hn) a)
-
-/-- The multiplicative Kummer map is the type-tagged additive connecting map on each unit. -/
+/-- **The Kummer map is the degree-zero connecting homomorphism** of the Kummer sequence, read on
+the unit `a` through the identification of `Kˣ` with the invariants of `(Kˢ)ˣ`. -/
 @[simp]
 theorem kummerMap_apply (hn : IsUnit (n : K)) (a : Kˣ) :
     kummerMap K n hn a =
-      Multiplicative.ofAdd (kummerMapAdd K n hn (Additive.ofMul a)) := by
-  exact AddMonoidHom.toMultiplicativeRight_apply_apply (kummerMapAdd K n hn) a
+      Multiplicative.ofAdd ((kummerShortExact K n hn).explicitDelta0
+        (baseUnitsEquivInvariants K (Additive.ofMul a))) :=
+  AddMonoidHom.toMultiplicativeRight_apply_apply (kummerMapAdd K n hn) a
 
 variable {K n}
 
@@ -222,7 +218,7 @@ on every unit. -/
 theorem kummerMap_eq_kummerCocycleClass (hn : IsUnit (n : K))
     (hα : α ^ n = Units.map (algebraMap K (SeparableClosure K)).toMonoidHom a) :
     Multiplicative.toAdd (kummerMap K n hn a) = kummerCocycleClass hα := by
-  rw [toAdd_kummerMap_apply, kummerMapAdd_apply]
+  rw [kummerMap_apply, toAdd_ofAdd]
   refine (kummerShortExact K n hn).explicitDelta0_apply _
     (b := (Additive.ofMul α : UnitsCoeff K)) (Additive.toMul.injective ?_)
     (kummerCocycle_mem_Z1 hα) fun g => ?_
@@ -244,10 +240,10 @@ theorem explicitCoeff0_baseUnitsEquivInvariants (hn : IsUnit (n : K)) (c : Addit
       toMul_unitsCoeffPow, toMul_coe_baseUnitsEquivInvariants,
       toMul_coe_baseUnitsEquivInvariants, toMul_ofMul, map_pow]
 
-/-- **The kernel of the additive Kummer map is `(Kˣ)ⁿ`.** Exactness at
-`H⁰(G_K, (Kˢ)ˣ)` says the kernel of `δ⁰` is the image of the `n`th power map on invariants, and
+/-- The additive form of `TauCeti.ker_kummerMap`. Exactness at `H⁰(G_K, (Kˢ)ˣ)` says the kernel
+of `δ⁰` is the image of the `n`th power map on invariants, and
 `TauCeti.explicitCoeff0_baseUnitsEquivInvariants` reads that image off in `Kˣ`. -/
-theorem ker_kummerMapAdd (hn : IsUnit (n : K)) :
+private theorem ker_kummerMapAdd (hn : IsUnit (n : K)) :
     (kummerMapAdd K n hn).ker = (powerSubgroup Kˣ n).toAddSubgroup := by
   have hker : ∀ c : Additive Kˣ, kummerMapAdd K n hn c = 0 ↔
       baseUnitsEquivInvariants K c ∈ (explicitCoeff0 (AbsoluteGaloisGroup K) (UnitsCoeff K)
@@ -267,8 +263,8 @@ theorem ker_kummerMapAdd (hn : IsUnit (n : K)) :
 theorem ker_kummerMap (hn : IsUnit (n : K)) :
     (kummerMap K n hn).ker = powerSubgroup Kˣ n := by
   ext a
-  rw [MonoidHom.mem_ker, kummerMap_apply, ofAdd_eq_one, ← AddMonoidHom.mem_ker,
-    ker_kummerMapAdd, Additive.mem_toAddSubgroup]
+  rw [MonoidHom.mem_ker, kummerMap_apply, ofAdd_eq_one, ← kummerMapAdd_apply,
+    ← AddMonoidHom.mem_ker, ker_kummerMapAdd, Additive.mem_toAddSubgroup]
   simp only [toMul_ofMul]
 
 /-- **A unit has trivial Kummer class exactly when it is an `n`th power in `K`.** -/

--- a/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
+++ b/TauCeti/FieldTheory/GaloisCohomology/Kummer.lean
@@ -191,7 +191,6 @@ def kummerMap (hn : IsUnit (n : K)) :
   (kummerMapAdd K n hn).toMultiplicativeRight
 
 /-- The additive value underlying `kummerMap a` is `kummerMapAdd (Additive.ofMul a)`. -/
-@[simp]
 theorem toAdd_kummerMap_apply (hn : IsUnit (n : K)) (a : Kˣ) :
     Multiplicative.toAdd (kummerMap K n hn a) =
       kummerMapAdd K n hn (Additive.ofMul a) := by
@@ -297,7 +296,6 @@ theorem kummerClassMap_mk (hn : IsUnit (n : K)) (a : Kˣ) :
   exact QuotientGroup.lift_mk' (powerSubgroup Kˣ n) (by rw [ker_kummerMap hn]) a
 
 /-- The quotient Kummer map sends the named power class of `a` to its Kummer class. -/
-@[simp]
 theorem kummerClassMap_powerClass (hn : IsUnit (n : K)) (a : Kˣ) :
     kummerClassMap K n hn (powerClassHom n a) = kummerMap K n hn a := by
   rw [powerClassHom_apply, kummerClassMap_mk]


### PR DESCRIPTION
This PR builds the Kummer map `Kˣ → H¹(G_K, μₙ)` and identifies its kernel, continuing Layer 9 of
`TauCetiRoadmap/ProfiniteCohomology/README.md` ("the Galois interface: Hilbert 90 and Kummer
theory") from where PR #4944 left it. That layer's milestone "The Kummer sequence and isomorphism"
is split by the roadmap into eight ordered agent-sized targets; #4944 landed targets 1 and 2 (the
surjectivity of the `n`th power map on `(Kˢ)ˣ` and `kummerShortExact`), and this PR lands targets
3, 4, 5 and the first two thirds of 6: the subgroup `(Kˣ)ⁿ` and the quotient type `Kˣ ⧸ (Kˣ)ⁿ`,
the connecting map `δ⁰ : Kˣ → H¹(G_K, μₙ)` with its explicit cocycle `g ↦ g α / α`, independence
of the chosen root, and multiplicativity together with the kernel `(Kˣ)ⁿ`. What remains in that
milestone is the third part of target 6, surjectivity, which is Hilbert 90 for `Kˢ/K` and needs
Layer 4's finite-quotient colimit description of `H¹` (in flight as PR #4840); target 7's
`kummerIso` is exactly this PR's injection plus that surjectivity, and target 8 then compares with
the canonical object.

`TauCeti/FieldTheory/GaloisCohomology/Kummer.lean` (291 lines) is the new file. `kummerCocycle hα`
is `g ↦ g α / α` for a chosen `n`th root `α` of a unit `a` of `K`; it takes values in `μₙ` because
its `n`th power is `g a / a = 1`, and `kummerCoeffIncl_kummerCocycle` shows it lies over the
coboundary `d⁰ α` in `(Kˢ)ˣ`. That single equation carries both halves of
`kummerCocycle_mem_Z1`: continuity descends along the injection `μₙ ↪ (Kˢ)ˣ` of discrete spaces by
`continuous_of_injective_comp`, and the cocycle identity descends from `d¹ (d⁰ α) = 0`.
`kummerCocycleClass_congr` proves the class is independent of the root directly — two roots differ
by a `ζ ∈ μₙ` and the two cocycles differ by `d⁰ ζ` — so it carries no hypothesis on `n` at all.
`kummerMapAdd` is `explicitDelta0` of `kummerShortExact` precomposed with
`baseUnitsEquivInvariants`, `kummerMap` is its multiplicative form
`Kˣ →* Multiplicative (H¹(G_K, μₙ))`, and `kummerMap_eq_kummerCocycleClass` identifies it with the
cocycle class through Layer 5's `explicitDelta0_apply`. `ker_kummerMap` is Layer 5's exactness node
`explicitLongExact_H0C` read through the new commuting square
`explicitCoeff0_baseUnitsEquivInvariants`, which says the `n`th power map on the invariants of
`(Kˢ)ˣ` is the `n`th power map of `Kˣ`; `kummerClassMap_injective` is the consequence. Nothing
here relies on a definitional unfolding of the unexposed `C1`, `B1`, `d0` or `explicitDelta0`;
every step goes through the named lemmas of `LowDegree.lean`, `ShortExact.lean` and
`LongExact.lean`.

`TauCeti/Algebra/Group/PowerClassGroup.lean` (60 lines) supplies the roadmap's target 3: the
subgroup `powerSubgroup G n` of `n`th powers, which is the range of `powMonoidHom n`, the quotient
`powerClassQuotient G n = G ⧸ Gⁿ`, the class map `powerClassHom`, and the membership
characterisation `mem_powerSubgroup_iff`. It is stated for an arbitrary commutative group rather
than for `Kˣ`, which is the generality the statements actually use. At `n = 2` the subgroup is
Mathlib's `Subgroup.square G` by the equality already recorded as
`TauCeti.square_eq_powMonoidHom_two_range`; the file's module docstring says so, and no second copy
of that equality or of any `Gⁿ` fact is introduced here.

The hypothesis throughout is `IsUnit (n : K)` rather than `CharZero K`, and the separable closure
rather than the algebraic closure, both as the roadmap requires: over an imperfect field the
invariants of the units of an algebraic closure are strictly larger than `Kˣ`, so the left-hand
side of Kummer theory would be wrong.

Roadmap: ProfiniteCohomology

<!--tauceti-target:v1 {"focus":"ProfiniteCohomology","id":"kummer-map-connecting-cocycle"}-->

🤖 Prepared with Claude Code

