### PR TITLE
docs: audit the Co2 and Co3 presentation sources

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Three.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Three.lean
@@ -59,7 +59,7 @@ This is exactly the order and grouping of the twenty-four entries in
 `g(bf)³`, `e(abc)³`, `e(acg)⁴`, and `e(abcf)⁷` lie outside their parenthesized powers in both
 the print and Lean. The paper then states `Length = 174`, agreeing with the checked 150 letters
 plus 24 separators. Its following `Consequences` line separately lists twelve words, from `afaf`
-through `(bcde)⁴`; none is part of the defining-relator list or the Lean row. This checks every
+through `(bede)⁴`; none is part of the defining-relator list or the Lean row. This checks every
 source relator, exponent, binding boundary, and the defining-relator/consequence boundary
 independently of the original transcription and closes this row's S1 source-to-Lean read-through.
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Three.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Three.lean
@@ -39,6 +39,30 @@ from that image to AtlasRep 2.1.9's independent 276-point permutation group for 
 transcription provenance rather than a Lean theorem: the file asserts no order, finiteness,
 simplicity, or identification result.
 
+## Independent source-to-Lean read-through
+
+An independent read-through used Cambridge University Press's 26-page scan of the cited paper,
+whose PDF bytes have SHA-256 digest
+`da209040c860db5c0f3bef11a55d5e434beeae3bf9acf18f488b5c8632b23606`. On printed page 162,
+presentation (13.1) names its generators, in order, as `a,b,c,d,e,f,g`. Reading its defining
+relators from left to right across the two printed lines gives
+
+```text
+a², b², c², d², e², f², g²,
+(ac)², (ad)², (ae)², (bd)², (ce)², (dg)², (eg)²,
+(ab)³, (cd)³, (de)³,
+f(ag)³, g(bf)³, (cfg)³, e(abc)³, e(acg)⁴, (bcfcf)³, e(abcf)⁷.
+```
+
+This is exactly the order and grouping of the twenty-four entries in
+`co3Presentation_transcribed`: in particular, the adjacent leading factors in `f(ag)³`,
+`g(bf)³`, `e(abc)³`, `e(acg)⁴`, and `e(abcf)⁷` lie outside their parenthesized powers in both
+the print and Lean. The paper then states `Length = 174`, agreeing with the checked 150 letters
+plus 24 separators. Its following `Consequences` line separately lists twelve words, from `afaf`
+through `(bcde)⁴`; none is part of the defining-relator list or the Lean row. This checks every
+source relator, exponent, binding boundary, and the defining-relator/consequence boundary
+independently of the original transcription and closes this row's S1 source-to-Lean read-through.
+
 The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
 relator expressions with their generator indices written out, and the provenance a manifest row
 exists to record. Together with `TauCeti.GroupPresentation.relators_def` and

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Three.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Three.lean
@@ -45,23 +45,17 @@ An independent read-through used Cambridge University Press's 26-page scan of th
 whose PDF bytes have SHA-256 digest
 `da209040c860db5c0f3bef11a55d5e434beeae3bf9acf18f488b5c8632b23606`. On printed page 162,
 presentation (13.1) names its generators, in order, as `a,b,c,d,e,f,g`. Reading its defining
-relators from left to right across the two printed lines gives
-
-```text
-a², b², c², d², e², f², g²,
-(ac)², (ad)², (ae)², (bd)², (ce)², (dg)², (eg)²,
-(ab)³, (cd)³, (de)³,
-f(ag)³, g(bf)³, (cfg)³, e(abc)³, e(acg)⁴, (bcfcf)³, e(abcf)⁷.
-```
-
-This is exactly the order and grouping of the twenty-four entries in
-`co3Presentation_transcribed`: in particular, the adjacent leading factors in `f(ag)³`,
-`g(bf)³`, `e(abc)³`, `e(acg)⁴`, and `e(abcf)⁷` lie outside their parenthesized powers in both
-the print and Lean. The paper then states `Length = 174`, agreeing with the checked 150 letters
-plus 24 separators. Its following `Consequences` line separately lists twelve words, from `afaf`
-through `(bede)⁴`; none is part of the defining-relator list or the Lean row. This checks every
-source relator, exponent, binding boundary, and the defining-relator/consequence boundary
-independently of the original transcription and closes this row's S1 source-to-Lean read-through.
+relators from left to right gives the same four consecutive blocks as the list above: the seven
+generator squares; the seven pair squares from `(ac)²` through `(eg)²`; the three pair cubes; and
+the seven remaining mixed words, from `f(ag)³` through `e(abcf)⁷`. This is exactly the order and
+grouping of the twenty-four entries in `co3Presentation_transcribed`. In particular, the adjacent
+leading factors in `f(ag)³`, `g(bf)³`, `e(abc)³`, `e(acg)⁴`, and `e(abcf)⁷` lie outside their
+parenthesized powers in both the print and Lean. The paper then states `Length = 174`, agreeing
+with the checked 150 letters plus 24 separators. Its following `Consequences` line separately
+lists twelve words, from `afaf` through `(bede)⁴`; none is part of the defining-relator list or
+the Lean row. This checks every source relator, exponent, binding boundary, and the
+defining-relator/consequence boundary independently of the original transcription and closes this
+row's S1 source-to-Lean read-through without duplicating the audited list.
 
 The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
 relator expressions with their generator indices written out, and the provenance a manifest row

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Two.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Two.lean
@@ -50,6 +50,30 @@ that is, pairs generating the group with `a` an involution whose centralizer has
 provenance for the transcription, not Lean theorems: this file asserts no order, finiteness,
 simplicity, or identification result.
 
+## Independent source-to-Lean read-through
+
+An independent read-through used the bytes of the ATLAS Magma source `Co2G1-P1.M` whose SHA-256
+digest is `85179f5887ea4f86b3ca5ed0f37cafdca9512f7fb85cbd52d91ad26b27833c5b`. Its constructor
+`G<x,y>` fixes the source generator order, and the assignments `a := x; b := y` immediately after
+the constructor confirm the names used by this Lean row.
+
+Reading the active constructor entries from top to bottom gives
+
+```text
+x², y⁵, (xy²)⁹, [x,y]⁴, [x,y²]⁴, [x,yxy]³,
+[x,yxy²xy]², [x,yxy⁻²]³, [x,y⁻²xyxy⁻²]²,
+(xyxy²xy⁻¹xy⁻²)⁷.
+```
+
+These are exactly the ten entries of `co2Presentation_transcribed`, after identifying `x,y` with
+`a,b`, substituting the four displayed syllable abbreviations, and expanding the source
+commutator `[r,s]` as `r⁻¹s⁻¹rs`. Between the ninth and tenth active entries the Magma file
+comments out `[x,y²xy²]³` with the note "Redundant, but useful."; the presentation page places
+the same word in an HTML element of class `redundant`. It is therefore correctly absent from the
+Lean row. This checks every active source relator, inverse, exponent, and the sole optional-word
+boundary independently of the original transcription and closes this row's S1 source-to-Lean
+read-through.
+
 The row is a sealed definition, so it publishes an equation for each of its fields: the transcribed
 relator expressions with their generator indices written out and this file's private syllable
 abbreviations expanded, and the provenance a manifest row exists to record. Together with


### PR DESCRIPTION
This PR completes the independent source-to-Lean read-through for the `Co₂` and `Co₃` sporadic-presentation rows required by S1 of `TauCetiRoadmap/CFSGStatement/README.md`.

It records immutable SHA-256 digests for the ATLAS Magma source and Cambridge paper scan, then checks every relator, generator order, exponent, and boundary between defining and redundant/consequence words against the corresponding Lean transcription.

Roadmap: CFSGStatement

:robot: Prepared with OpenAI Codex
