### PR TITLE
ci: bound the Lake cache ancestor search

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -326,10 +326,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      # Full history is intentional. lake cache get --max-revs=0 walks all available ancestors
-      # until it reaches a published main commit, then Lake's input hashes invalidate only changed
-      # modules and their downstream dependents. The checkout is the immutable event head itself:
-      # no refs/pull/N/merge, no local merge, and no source/config overlay.
+      # Full history is intentional. lake cache get walks ancestors until it reaches a published
+      # main commit, then Lake's input hashes invalidate only changed modules and their downstream
+      # dependents. The cache step below limits how many ancestors it reads. The checkout is the
+      # immutable event head itself: no refs/pull/N/merge, no local merge, and no source/config
+      # overlay.
       - name: Checkout the exact candidate head (untrusted contents, no credentials)
         if: ${{ env.INFRA != '1' }}
         uses: actions/checkout@v4
@@ -604,7 +605,14 @@ jobs:
           # environment variables; the script hands it the endpoints through a `--service` config.
           PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
-          LAKE_CACHE_MAX_REVS: "0"
+          # This limit stops the search after 100 ancestors. The search otherwise stops only when
+          # a lookup succeeds. On a hit the first ancestor that main published succeeds. The
+          # search then reads only the few ancestors between this head and main.
+          #
+          # After a lean-toolchain bump no lookup succeeds. The cache keys each revision map by
+          # toolchain, and no ancestor has a map under the new toolchain. Without this limit, the
+          # search then reads the full history and finds nothing.
+          LAKE_CACHE_MAX_REVS: "100"
         run: bash gate/scripts/lake-cache-get.sh pr
 
       - name: Prepare trusted read-only Lean watchdog toolchain

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -609,10 +609,11 @@ jobs:
           # a lookup succeeds. On a hit the first ancestor that main published succeeds. The
           # search then reads only the few ancestors between this head and main.
           #
-          # The cache keys each revision map by toolchain. No lookup succeeds when no published
-          # ancestor uses the toolchain of this head. A pull request that bumps lean-toolchain
-          # has this shape, because main published every ancestor of it under the old toolchain.
-          # Without this limit, the search then reads the full history and finds nothing.
+          # The cache keys each revision map by toolchain. A lookup therefore succeeds only when
+          # a published ancestor uses the same toolchain as this head. A pull request that bumps
+          # lean-toolchain has no such ancestor, because main published all of its ancestors
+          # under the old toolchain. Without this limit, the search reads the full history and
+          # finds nothing.
           LAKE_CACHE_MAX_REVS: "100"
         run: bash gate/scripts/lake-cache-get.sh pr
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -609,9 +609,10 @@ jobs:
           # a lookup succeeds. On a hit the first ancestor that main published succeeds. The
           # search then reads only the few ancestors between this head and main.
           #
-          # After a lean-toolchain bump no lookup succeeds. The cache keys each revision map by
-          # toolchain, and no ancestor has a map under the new toolchain. Without this limit, the
-          # search then reads the full history and finds nothing.
+          # The cache keys each revision map by toolchain. No lookup succeeds when no published
+          # ancestor uses the toolchain of this head. A pull request that bumps lean-toolchain
+          # has this shape, because main published every ancestor of it under the old toolchain.
+          # Without this limit, the search then reads the full history and finds nothing.
           LAKE_CACHE_MAX_REVS: "100"
         run: bash gate/scripts/lake-cache-get.sh pr
 

--- a/.github/workflows/pr-profile.yml
+++ b/.github/workflows/pr-profile.yml
@@ -330,7 +330,9 @@ jobs:
         env:
           PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
-          LAKE_CACHE_MAX_REVS: "0"
+          # The same limit as pr-build, for the same shared script. This step reads the
+          # comparison base, which main publishes, so the search stops at the first lookup.
+          LAKE_CACHE_MAX_REVS: "100"
         run: |
           set -euo pipefail
           if [ -z "$PUBLIC_ARTIFACT_ENDPOINT" ] || [ -z "$PUBLIC_REVISION_ENDPOINT" ]; then

--- a/scripts/lake-cache-get.sh
+++ b/scripts/lake-cache-get.sh
@@ -19,10 +19,10 @@
 # `lake exe cache get`.
 #
 # Keep the ancestor limit. The search stops only when a lookup succeeds, so a hit reads only the
-# few ancestors between the checkout and main. After a lean-toolchain bump no lookup succeeds.
-# The cache keys each revision map by toolchain, and no ancestor has a map under the new
-# toolchain. The value 0 removes the limit, so the search then reads the full history and finds
-# nothing.
+# few ancestors between the checkout and main. The cache keys each revision map by toolchain, so
+# no lookup succeeds when no published ancestor uses the toolchain of the checkout. A pull
+# request that bumps lean-toolchain has this shape. The value 0 removes the limit, so the search
+# then reads the full history and finds nothing.
 #
 # A TOTAL miss is non-fatal: the build just recompiles from scratch, as when the cache is off.
 # A PARTIAL fetch is non-fatal too, but must not reach the offline build. Since v4.34.0-rc1,

--- a/scripts/lake-cache-get.sh
+++ b/scripts/lake-cache-get.sh
@@ -19,10 +19,10 @@
 # `lake exe cache get`.
 #
 # Keep the ancestor limit. The search stops only when a lookup succeeds, so a hit reads only the
-# few ancestors between the checkout and main. The cache keys each revision map by toolchain, so
-# no lookup succeeds when no published ancestor uses the toolchain of the checkout. A pull
-# request that bumps lean-toolchain has this shape. The value 0 removes the limit, so the search
-# then reads the full history and finds nothing.
+# few ancestors between the checkout and main. The cache keys each revision map by toolchain. A
+# lookup therefore succeeds only when a published ancestor uses the same toolchain as the
+# checkout. A pull request that bumps lean-toolchain has no such ancestor. The value 0 removes
+# the limit, so the search reads the full history and finds nothing.
 #
 # A TOTAL miss is non-fatal: the build just recompiles from scratch, as when the cache is off.
 # A PARTIAL fetch is non-fatal too, but must not reach the offline build. Since v4.34.0-rc1,

--- a/scripts/lake-cache-get.sh
+++ b/scripts/lake-cache-get.sh
@@ -12,11 +12,17 @@
 #
 # Anonymous GETs from the PUBLIC read host (a different host than the S3 API endpoint the
 # trusted upload uses). Looks up the root-package oleans for the checkout's revision --
-# backtracking up to LAKE_CACHE_MAX_REVS ancestors (default 100; 0 means the complete available
-# history), and unpacks them into $LAKE_CACHE_DIR. This is trusted, publisher-built data: no token
+# backtracking up to LAKE_CACHE_MAX_REVS ancestors (default 100), and unpacks them into
+# $LAKE_CACHE_DIR. This is trusted, publisher-built data: no token
 # is in reach and no PR code runs (the caller attests the declarative lakefile first). Mathlib's
 # oleans are NOT here; they come from
 # `lake exe cache get`.
+#
+# Keep the ancestor limit. The search stops only when a lookup succeeds, so a hit reads only the
+# few ancestors between the checkout and main. After a lean-toolchain bump no lookup succeeds.
+# The cache keys each revision map by toolchain, and no ancestor has a map under the new
+# toolchain. The value 0 removes the limit, so the search then reads the full history and finds
+# nothing.
 #
 # A TOTAL miss is non-fatal: the build just recompiles from scratch, as when the cache is off.
 # A PARTIAL fetch is non-fatal too, but must not reach the offline build. Since v4.34.0-rc1,

--- a/scripts/test_profile_workflow.py
+++ b/scripts/test_profile_workflow.py
@@ -34,9 +34,10 @@ def main() -> None:
     require(text, "gate/scripts/check-bump.sh policy base head")
     require(text, "validated pin/toolchain bump; cost ratio intentionally skipped")
 
-    # Cache lookup walks all fetched ancestry, and executable profiling helpers
+    # Cache lookup reads a limited number of ancestors, and executable profiling helpers
     # come from the workflow-pinned trusted checkout rather than the PR.
-    require(text, 'LAKE_CACHE_MAX_REVS: "0"')
+    require(text, 'LAKE_CACHE_MAX_REVS: "100"')
+    forbid(text, 'LAKE_CACHE_MAX_REVS: "0"')
     require(text, "../gate/scripts/profile/measure.sh")
 
     # Do not regress to constructing a synthetic source/configuration overlay.


### PR DESCRIPTION
`lake cache get` searches the ancestors of the checked-out revision. It stops at the first
ancestor that main published. The pr-build and pr-profile workflows set `--max-revs=0`, which
removes the limit. This change sets the limit to 100.

The cache keys each revision map by toolchain. After a lean-toolchain bump, no ancestor has a
map under the new toolchain. No lookup succeeds, so the search reads the full history, one
request at a time. This run shows the effect:
https://github.com/TauCetiProject/TauCeti/actions/runs/33405112267/job/99538105658

The cache step took 20 minutes and 7 seconds and sent 4064 requests. It found nothing, so the
build compiled TauCeti from scratch. The 20 minutes gave no benefit.

The limit does not change a normal pull request. The search reaches the merge base after the
commits of the pull request, so a hit needs only a few requests. All 8 open pull requests hit
at the second ancestor. The largest commit count across 40 merged pull requests was 6.

Only pr-build has the defect, because its step reads the pull request head. The pr-profile step
reads the comparison base, which main publishes, so it always hits at the first lookup. This
change sets the same limit there for consistency, because both steps call the same script. The
pr-profile test changes with it.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
