### PR TITLE
docs: audit the Held and HN presentation sources

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HaradaNorton.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HaradaNorton.lean
@@ -45,6 +45,31 @@ the freely cancelling boundary `a⁻²a`; the checks below therefore record the 
 letters alongside the freely reduced length of each relator, and prove that every reduced word is
 cyclically reduced. This file asserts no order, finiteness, simplicity, or identification result.
 
+## Independent source-to-Lean read-through
+
+The independent read-through used the bytes of the corrected machine-readable source `HNpb.m`
+whose SHA-256 digest is
+`69a39c69670aa28dd28f2b3c9ec8f44c35086174d97ba4fc073a16ad7ecec596`. The first constructor is
+`G<a,b,c,d,t>`, fixing exactly the generator names and order used by the Lean row. Reading that
+constructor from top to bottom gives
+
+```text
+a⁴, [a²,b], b⁷, (ab²)⁴, a⁻²(abab³)³, ((ab)³ab⁻³)²,
+c²a², [a,c], [bab,c], (bab³c)³,
+d², (ad)², [b,d], d^(cbcb⁻¹)(cd)³,
+t⁵, t^a t², t^c t⁻², [t,b], (dt)³.
+```
+
+These are exactly the nineteen entries of `hnPresentation_transcribed`. In particular, the Lean
+row preserves the corrected twelfth word `(ad)²`; expands the Magma conjugates using
+`r^s = s⁻¹rs`, including the full conjugator `cbcb⁻¹` in the fourteenth word; and uses the source
+commutator `[r,s] = r⁻¹s⁻¹rs`. The same file contains a second nineteen-relator constructor whose
+only changed entry is the fifth, replaced there by `[a,b³]³`; the row explicitly transcribes the
+first presentation and therefore correctly retains `a⁻²(abab³)³`. There are no commented or
+optional entries inside that first constructor. This checks every source relator, inverse,
+exponent, conjugation boundary, and constructor boundary independently of the original
+transcription and closes this row's S1 source-to-Lean read-through.
+
 ## Main definitions and results
 
 * `TauCeti.Sporadic.hnPresentation`: the Bray--Curtis finite presentation of `HN`.

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
@@ -35,6 +35,29 @@ ATLAS 2058-point standard generators; those generators yield a simple group of o
 `4030387200`. This computation is provenance for the transcription, not a Lean theorem. This file
 asserts no order, finiteness, simplicity, or identification result.
 
+## Independent source-to-Lean read-through
+
+An independent read-through used the bytes of the ATLAS Magma source `HeG1-P1.M` whose SHA-256
+digest is `6ab1294d2599ce209cb9ef53e433cdb40342244ac387c425d0682be6ab55e374`. Its constructor
+`G<x,y>` and following assignments `a := x; b := y` fix the source generator order.
+
+The rendered presentation page lists the seven active words in this order:
+
+```text
+x², y⁷, (xy)¹⁷, [x,y]⁶, [x,y³]⁵,
+[x,yxyxy⁻¹xyxy],
+(xy)⁴xy²xy⁻³xyxyxy⁻¹xy³xy⁻²xy².
+```
+
+These are exactly the seven entries of `hePresentation_transcribed`, after expanding the source
+commutator `[r,s]` as `r⁻¹s⁻¹rs` and the two private long-word abbreviations. The Magma
+constructor contains the same active words, but places the long commutator before `[x,y³]⁵` and
+`[x,y]⁶`; the Lean row deliberately follows the rendered page's order. The constructor also
+comments out three other words, marking each redundant and two of them possibly useful, so none
+belongs to the active relator list. This checks every source relator, inverse, exponent, both
+source-order renderings, and the active/commented boundary independently of the original
+transcription and closes this row's S1 source-to-Lean read-through.
+
 ## Independent comparison with the ATLAS permutation data
 
 The independent comparison used the ATLAS representation `HeG1-p2058B0`, a primitive action on

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
@@ -44,15 +44,15 @@ digest is `6ab1294d2599ce209cb9ef53e433cdb40342244ac387c425d0682be6ab55e374`. It
 The rendered presentation page lists the seven active words in this order:
 
 ```text
-x², y⁷, (xy)¹⁷, [x,y]⁶, [x,y³]⁵,
-[x,yxyxy⁻¹xyxy],
-(xy)⁴xy²xy⁻³xyxyxy⁻¹xy³xy⁻²xy².
+a², b⁷, (ab)¹⁷, [a,b]⁶, [a,b³]⁵,
+[a,babab⁻¹abab],
+(ab)⁴ab²ab⁻³ababab⁻¹ab³ab⁻²ab².
 ```
 
 These are exactly the seven entries of `hePresentation_transcribed`, after expanding the source
 commutator `[r,s]` as `r⁻¹s⁻¹rs` and the two private long-word abbreviations. The Magma
-constructor contains the same active words, but places the long commutator before `[x,y³]⁵` and
-`[x,y]⁶`; the Lean row deliberately follows the rendered page's order. The constructor also
+constructor writes the same active words in `x,y`, but places the long commutator before
+`[x,y³]⁵` and `[x,y]⁶`; the Lean row deliberately follows the rendered page's order. It also
 comments out three other words, marking each redundant and two of them possibly useful, so none
 belongs to the active relator list. This checks every source relator, inverse, exponent, both
 source-order renderings, and the active/commented boundary independently of the original


### PR DESCRIPTION
This PR completes the independent source-to-Lean read-through for the `He` and `HN` sporadic-presentation rows required by S1 of `TauCetiRoadmap/CFSGStatement/README.md`.

It records SHA-256 digests for the ATLAS and corrected Bray--Curtis machine sources, then checks every relator, generator convention, ordering difference, conjugation boundary, and active/alternate-constructor boundary against the corresponding Lean transcription.

Roadmap: CFSGStatement

:robot: Prepared with OpenAI Codex
