### PR TITLE
feat: powers of a conjugacy class

### DIFF
--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -19,8 +19,8 @@ inverses of the members of `C`, and it has the same size as `C`. A class fixed b
 a **real** class (`TauCeti.IsRealClass`).
 
 Powering likewise commutes with conjugation, so for a **monoid** `M` it too descends to the
-conjugacy classes: `C ^ j` is the class of the `j`-th powers of the members of `C`, recorded as a
-`Pow (ConjClasses M) ℕ` instance.
+conjugacy classes: `ConjClasses.pow C j`, written `C ^ j`, is the class of the `j`-th powers of
+the members of `C`.
 
 The other fact collected here is that the size of a conjugacy class is the index of the centralizer
 of any of its members, and so divides the order of the group: the orbit-stabilizer theorem for the
@@ -42,7 +42,8 @@ conjugation action.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
   the group, with `TauCeti.ConjClasses.card_carrier_cast_ne_zero` the consequence that the size of
   a class is nonzero in any semiring where the group order is.
-* `ConjClasses.mem_carrier_pow_iff`: an element lies in `C ^ j` exactly when it is a
+* `ConjClasses.pow`: the power operation itself, with `C ^ j` its notation.
+* `ConjClasses.mem_pow_iff`: an element lies in `C ^ j` exactly when it is a
   `j`-th power of a member of `C`, with `ConjClasses.mk_pow` the computation rule.
 * `ConjClasses.pow_zero`, `ConjClasses.pow_one` and
   `ConjClasses.pow_mul`: the identity and composition laws for that power.
@@ -52,17 +53,19 @@ conjugation action.
 
 The inversion is an instance rather than a plain function so that the notation `C⁻¹`, the
 involutivity lemma `inv_inv` and the reindexing equivalence `Equiv.inv` are all available for
-conjugacy classes. Powering is an instance for the same reason: it buys the notation `C ^ j` and
-lets the `Monoid.npow`-shaped lemmas below be stated in the usual form. There is still no
+conjugacy classes. Powering is instead a named definition `ConjClasses.pow` with a `Pow` instance
+delegating to it, so that the roadmap's `C.pow j` and the notation `C ^ j` are the same function;
+the lemmas below are all stated in the `^` form. There is still no
 multiplication on `ConjClasses M` — `Pow (ConjClasses M) ℕ` is a bare power operation, not the
 `npow` field of a monoid structure, and none of the lemmas here presuppose one.
 
 The power operation is developed for the Chebotarev roadmap (`Chebotarev/README.md` Layer 1,
 "consumed Frobenius classes and powers of conjugacy classes", whose `Suggested.lean` pins these
 signatures); its consumer there is the von Mangoldt fibre, which sums over the classes `C ^ j`.
-That is also why `ConjClasses.pow_two_cyclicFour` is kept as a regression: a group of
+That is also why a `pow_two_cyclicFour` regression is kept: a group of
 exponent two has no proper nonidentity square, so it cannot separate a correct power operation
-from one that collapses to the identity. This operation is *not* adapted from the
+from one that collapses to the identity. It is `private`, being a check on this development
+rather than reusable conjugacy-class API. This operation is *not* adapted from the
 Birkbeck–Brasca `chebotarev-density` development, which works with `ConjClasses.mk` and
 `Subgroup.zpowers` directly and never forms `C ^ j`.
 -/
@@ -202,28 +205,27 @@ theorem isRealClass_mk_iff {g : G} : IsRealClass (ConjClasses.mk g) ↔ IsConj g
   rw [isRealClass_iff_inv_eq, ConjClasses.inv_mk, ConjClasses.mk_eq_mk_iff_isConj]
   exact ⟨IsConj.symm, IsConj.symm⟩
 
-section Powers
-
-variable {M : Type*} [Monoid M]
-
-/-- **Powers of a conjugacy class.** Powering respects conjugacy (`IsConj.pow`), so it descends
-to the conjugacy classes of a monoid: `C ^ j` is the class of the `j`-th powers of the members
-of `C`. -/
-instance instPowConjClassesNat : Pow (ConjClasses M) ℕ where
-  pow C j := Quotient.map (· ^ j) (fun _ _ h ↦ IsConj.pow j h) C
-
-end Powers
-
 end TauCeti
 
 /-! ### Powers of a conjugacy class
 
 These live in the root `ConjClasses` namespace, not under `TauCeti`, so that dot
-notation on Mathlib's `ConjClasses` type elaborates (`C.pow_zero`, `C.pow_mul`). -/
+notation on Mathlib's `ConjClasses` type elaborates (`C.pow`, `C.pow_zero`, `C.pow_mul`). -/
 
 namespace ConjClasses
 
 variable {M : Type*} [Monoid M]
+
+/-- **The `j`-th power of a conjugacy class.** Powering respects conjugacy (`IsConj.pow`), so it
+descends to the conjugacy classes of a monoid: `C.pow j` is the class of the `j`-th powers of the
+members of `C`. The `Pow` instance below spells it `C ^ j`, which is the form every lemma here
+is stated in. -/
+@[expose]
+def pow (C : ConjClasses M) (j : ℕ) : ConjClasses M :=
+  Quotient.map (· ^ j) (fun _ _ h ↦ IsConj.pow j h) C
+
+instance instPowNat : Pow (ConjClasses M) ℕ :=
+  ⟨ConjClasses.pow⟩
 
 /-- The `j`-th power of the class of `a` is the class of `a ^ j`. -/
 @[simp]
@@ -231,7 +233,8 @@ theorem mk_pow (a : M) (j : ℕ) : ConjClasses.mk a ^ j = ConjClasses.mk (a ^ j)
   rfl
 
 /-- An element lies in `C ^ j` exactly when it is a `j`-th power of a member of `C`. -/
-theorem mem_carrier_pow_iff {C : ConjClasses M} {τ : M} {j : ℕ} :
+@[simp]
+theorem mem_pow_iff {C : ConjClasses M} {τ : M} {j : ℕ} :
     τ ∈ (C ^ j).carrier ↔ ∃ σ ∈ C.carrier, σ ^ j = τ := by
   obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
   simp only [mk_pow, _root_.ConjClasses.mem_carrier_iff_mk_eq,
@@ -245,16 +248,19 @@ theorem mem_carrier_pow_iff {C : ConjClasses M} {τ : M} {j : ℕ} :
   have h2 : (c : M) * τ = a ^ j * ↑c := hc
   exact (Units.mul_right_inj c).mp (h1.trans h2.symm)
 
+/-- The zeroth power of any conjugacy class is the class of `1`. -/
 @[simp]
 theorem pow_zero (C : ConjClasses M) : C ^ 0 = 1 := by
   obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
   rw [mk_pow, _root_.pow_zero, ← _root_.ConjClasses.one_eq_mk_one]
 
+/-- The first power of a conjugacy class is the class itself. -/
 @[simp]
 theorem pow_one (C : ConjClasses M) : C ^ 1 = C := by
   obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
   rw [mk_pow, _root_.pow_one]
 
+/-- Iterated powers compose: raising `C ^ i` to the `j`-th power gives `C ^ (i * j)`. -/
 theorem pow_mul (C : ConjClasses M) (i j : ℕ) : (C ^ i) ^ j = C ^ (i * j) := by
   obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
   rw [mk_pow, mk_pow, mk_pow, _root_.pow_mul]
@@ -270,7 +276,7 @@ theorem map_pow {N : Type*} [Monoid N] (f : M →* N) (C : ConjClasses M) (j : �
 squares to the class of the element of order two. A group of exponent two cannot witness this:
 it has no proper nonidentity square, so it cannot tell a correct power operation from one that
 collapses to the identity. -/
-theorem pow_two_cyclicFour :
+private theorem pow_two_cyclicFour :
     ConjClasses.mk (Multiplicative.ofAdd (1 : ZMod 4)) ^ 2 =
       ConjClasses.mk (Multiplicative.ofAdd (2 : ZMod 4)) := by
   rw [mk_pow, ← ofAdd_nsmul, nsmul_eq_mul, mul_one]

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -220,7 +220,6 @@ variable {M : Type*} [Monoid M]
 descends to the conjugacy classes of a monoid: `C.pow j` is the class of the `j`-th powers of the
 members of `C`. The `Pow` instance below spells it `C ^ j`, which is the form every lemma here
 is stated in. -/
-@[expose]
 def pow (C : ConjClasses M) (j : ℕ) : ConjClasses M :=
   Quotient.map (· ^ j) (fun _ _ h ↦ IsConj.pow j h) C
 
@@ -229,8 +228,13 @@ instance instPowNat : Pow (ConjClasses M) ℕ :=
 
 /-- The `j`-th power of the class of `a` is the class of `a ^ j`. -/
 @[simp]
-theorem mk_pow (a : M) (j : ℕ) : ConjClasses.mk a ^ j = ConjClasses.mk (a ^ j) :=
-  rfl
+theorem mk_pow (a : M) (j : ℕ) : ConjClasses.mk a ^ j = ConjClasses.mk (a ^ j) := by
+  -- `pow` is sealed, so this is no longer `rfl`: a theorem exported from this module may only
+  -- unfold exposed definitions. Go through `pow`'s equation lemma, after which the statement is
+  -- exactly `Quotient`'s computation rule for `Quotient.map`.
+  change ConjClasses.pow (ConjClasses.mk a) j = ConjClasses.mk (a ^ j)
+  rw [ConjClasses.pow]
+  exact Quotient.map_mk _ _ _
 
 /-- An element lies in `C ^ j` exactly when it is a `j`-th power of a member of `C`. -/
 @[simp]

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -264,7 +264,12 @@ theorem pow_one (C : ConjClasses M) : C ^ 1 = C := by
   obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
   rw [mk_pow, _root_.pow_one]
 
-/-- Iterated powers compose: raising `C ^ i` to the `j`-th power gives `C ^ (i * j)`. -/
+/-- Iterated powers compose: raising `C ^ i` to the `j`-th power gives `C ^ (i * j)`. Tagged
+`@[simp]` because the single power is the normal form: it rewrites towards `C ^ (i * j)`, which
+is the direction the rest of this API (`pow_zero`, `pow_one`, `mk_pow`) already normalises to.
+Note this is the mirror image of Mathlib's root-level `pow_mul`, which orients the equation the
+other way for monoid elements. -/
+@[simp]
 theorem pow_mul (C : ConjClasses M) (i j : ℕ) : (C ^ i) ^ j = C ^ (i * j) := by
   obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
   rw [mk_pow, mk_pow, mk_pow, _root_.pow_mul]

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -42,11 +42,11 @@ conjugation action.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
   the group, with `TauCeti.ConjClasses.card_carrier_cast_ne_zero` the consequence that the size of
   a class is nonzero in any semiring where the group order is.
-* `TauCeti.ConjClasses.mem_carrier_pow_iff`: an element lies in `C ^ j` exactly when it is a
-  `j`-th power of a member of `C`, with `TauCeti.ConjClasses.mk_pow` the computation rule.
-* `TauCeti.ConjClasses.pow_zero`, `TauCeti.ConjClasses.pow_one` and
-  `TauCeti.ConjClasses.pow_mul`: the identity and composition laws for that power.
-* `TauCeti.ConjClasses.map_pow`: the power is natural in the monoid.
+* `ConjClasses.mem_carrier_pow_iff`: an element lies in `C ^ j` exactly when it is a
+  `j`-th power of a member of `C`, with `ConjClasses.mk_pow` the computation rule.
+* `ConjClasses.pow_zero`, `ConjClasses.pow_one` and
+  `ConjClasses.pow_mul`: the identity and composition laws for that power.
+* `ConjClasses.map_pow`: the power is natural in the monoid.
 
 ## Implementation notes
 
@@ -60,7 +60,7 @@ multiplication on `ConjClasses M` — `Pow (ConjClasses M) ℕ` is a bare power 
 The power operation is developed for the Chebotarev roadmap (`Chebotarev/README.md` Layer 1,
 "consumed Frobenius classes and powers of conjugacy classes", whose `Suggested.lean` pins these
 signatures); its consumer there is the von Mangoldt fibre, which sums over the classes `C ^ j`.
-That is also why `TauCeti.ConjClasses.pow_two_cyclicFour` is kept as a regression: a group of
+That is also why `ConjClasses.pow_two_cyclicFour` is kept as a regression: a group of
 exponent two has no proper nonidentity square, so it cannot separate a correct power operation
 from one that collapses to the identity. This operation is *not* adapted from the
 Birkbeck–Brasca `chebotarev-density` development, which works with `ConjClasses.mk` and
@@ -212,7 +212,18 @@ of `C`. -/
 instance instPowConjClassesNat : Pow (ConjClasses M) ℕ where
   pow C j := Quotient.map (· ^ j) (fun _ _ h ↦ IsConj.pow j h) C
 
+end Powers
+
+end TauCeti
+
+/-! ### Powers of a conjugacy class
+
+These live in the root `ConjClasses` namespace, not under `TauCeti`, so that dot
+notation on Mathlib's `ConjClasses` type elaborates (`C.pow_zero`, `C.pow_mul`). -/
+
 namespace ConjClasses
+
+variable {M : Type*} [Monoid M]
 
 /-- The `j`-th power of the class of `a` is the class of `a ^ j`. -/
 @[simp]
@@ -266,7 +277,3 @@ theorem pow_two_cyclicFour :
   norm_cast
 
 end ConjClasses
-
-end Powers
-
-end TauCeti

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -274,7 +274,12 @@ theorem pow_mul (C : ConjClasses M) (i j : ℕ) : (C ^ i) ^ j = C ^ (i * j) := b
 theorem map_pow {N : Type*} [Monoid N] (f : M →* N) (C : ConjClasses M) (j : ℕ) :
     ConjClasses.map f (C ^ j) = ConjClasses.map f C ^ j := by
   obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
-  exact congrArg ConjClasses.mk (_root_.map_pow f a j)
+  -- Every reduction here is named rather than left to definitional unfolding. Mathlib has no
+  -- `map_mk` computation lemma for `ConjClasses.map`, which is a `Quotient.lift` and so computes
+  -- on representatives; that single reduction is isolated in `hmap` and used explicitly, after
+  -- which `mk_pow` handles both powers and `map_pow` finishes in `N`.
+  have hmap : ∀ x : M, ConjClasses.map f (ConjClasses.mk x) = ConjClasses.mk (f x) := fun _ ↦ rfl
+  rw [mk_pow, hmap, hmap, mk_pow, _root_.map_pow]
 
 /-- **A nonidentity square in the cyclic group of order four.** The class of the generator
 squares to the class of the element of order two. A group of exponent two cannot witness this:

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -10,13 +10,17 @@ public import Mathlib.Data.Set.Card
 public import Mathlib.GroupTheory.Index
 
 /-!
-# Inversion of conjugacy classes, and the size of a class
+# Inversion and powers of conjugacy classes, and the size of a class
 
 Inversion of a group is compatible with conjugacy: `x` and `y` are conjugate exactly when `x⁻¹` and
 `y⁻¹` are (`TauCeti.isConj_inv_iff`). So inversion descends to the conjugacy classes, where it is an
 involution, recorded here as an `InvolutiveInv (ConjClasses G)` instance; `C⁻¹` is the class of the
 inverses of the members of `C`, and it has the same size as `C`. A class fixed by this involution is
 a **real** class (`TauCeti.IsRealClass`).
+
+Powering likewise commutes with conjugation, so for a **monoid** `M` it too descends to the
+conjugacy classes: `C ^ j` is the class of the `j`-th powers of the members of `C`, recorded as a
+`Pow (ConjClasses M) ℕ` instance.
 
 The other fact collected here is that the size of a conjugacy class is the index of the centralizer
 of any of its members, and so divides the order of the group: the orbit-stabilizer theorem for the
@@ -43,7 +47,10 @@ conjugation action.
 
 The inversion is an instance rather than a plain function so that the notation `C⁻¹`, the
 involutivity lemma `inv_inv` and the reindexing equivalence `Equiv.inv` are all available for
-conjugacy classes. There is no multiplication on `ConjClasses G` for it to interact with.
+conjugacy classes. Powering is an instance for the same reason: it buys the notation `C ^ j` and
+lets the `Monoid.npow`-shaped lemmas below be stated in the usual form. There is still no
+multiplication on `ConjClasses M` — `Pow (ConjClasses M) ℕ` is a bare power operation, not the
+`npow` field of a monoid structure, and none of the lemmas here presuppose one.
 -/
 
 public section
@@ -180,5 +187,72 @@ theorem isRealClass_iff_inv_eq {C : ConjClasses G} : IsRealClass C ↔ C⁻¹ = 
 theorem isRealClass_mk_iff {g : G} : IsRealClass (ConjClasses.mk g) ↔ IsConj g g⁻¹ := by
   rw [isRealClass_iff_inv_eq, ConjClasses.inv_mk, ConjClasses.mk_eq_mk_iff_isConj]
   exact ⟨IsConj.symm, IsConj.symm⟩
+
+section Powers
+
+variable {M : Type*} [Monoid M]
+
+/-- **Powers of a conjugacy class.** Powering respects conjugacy (`IsConj.pow`), so it descends
+to the conjugacy classes of a monoid: `C ^ j` is the class of the `j`-th powers of the members
+of `C`. -/
+instance instPowConjClassesNat : Pow (ConjClasses M) ℕ where
+  pow C j := Quotient.map (· ^ j) (fun _ _ h ↦ IsConj.pow j h) C
+
+namespace ConjClasses
+
+/-- The `j`-th power of the class of `a` is the class of `a ^ j`. -/
+@[simp]
+theorem mk_pow (a : M) (j : ℕ) : ConjClasses.mk a ^ j = ConjClasses.mk (a ^ j) :=
+  rfl
+
+/-- An element lies in `C ^ j` exactly when it is a `j`-th power of a member of `C`. -/
+theorem mem_carrier_pow_iff {C : ConjClasses M} {τ : M} {j : ℕ} :
+    τ ∈ (C ^ j).carrier ↔ ∃ σ ∈ C.carrier, σ ^ j = τ := by
+  obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
+  simp only [mk_pow, _root_.ConjClasses.mem_carrier_iff_mk_eq,
+    _root_.ConjClasses.mk_eq_mk_iff_isConj]
+  refine ⟨fun ⟨c, hc⟩ ↦ ?_, fun ⟨σ, ⟨c, hc⟩, hσ⟩ ↦ hσ ▸ ⟨c, hc.pow_right j⟩⟩
+  -- Conjugating `a` back by `c` produces a member of `C` whose `j`-th power is `τ`.
+  have hσ : SemiconjBy (c : M) (↑c⁻¹ * a * ↑c) a := by
+    simp [SemiconjBy, ← mul_assoc]
+  refine ⟨↑c⁻¹ * a * ↑c, ⟨c, hσ⟩, ?_⟩
+  have h1 : (c : M) * (↑c⁻¹ * a * ↑c) ^ j = a ^ j * ↑c := hσ.pow_right j
+  have h2 : (c : M) * τ = a ^ j * ↑c := hc
+  exact (Units.mul_right_inj c).mp (h1.trans h2.symm)
+
+@[simp]
+theorem pow_zero (C : ConjClasses M) : C ^ 0 = 1 := by
+  obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
+  rw [mk_pow, _root_.pow_zero, ← _root_.ConjClasses.one_eq_mk_one]
+
+@[simp]
+theorem pow_one (C : ConjClasses M) : C ^ 1 = C := by
+  obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
+  rw [mk_pow, _root_.pow_one]
+
+theorem pow_mul (C : ConjClasses M) (i j : ℕ) : (C ^ i) ^ j = C ^ (i * j) := by
+  obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
+  rw [mk_pow, mk_pow, mk_pow, _root_.pow_mul]
+
+/-- Powering a conjugacy class is natural in the monoid. -/
+@[simp]
+theorem map_pow {N : Type*} [Monoid N] (f : M →* N) (C : ConjClasses M) (j : ℕ) :
+    ConjClasses.map f (C ^ j) = ConjClasses.map f C ^ j := by
+  obtain ⟨a, rfl⟩ := ConjClasses.exists_rep C
+  exact congrArg ConjClasses.mk (_root_.map_pow f a j)
+
+/-- **A nonidentity square in the cyclic group of order four.** The class of the generator
+squares to the class of the element of order two. A group of exponent two cannot witness this:
+it has no proper nonidentity square, so it cannot tell a correct power operation from one that
+collapses to the identity. -/
+theorem pow_two_cyclicFour :
+    ConjClasses.mk (Multiplicative.ofAdd (1 : ZMod 4)) ^ 2 =
+      ConjClasses.mk (Multiplicative.ofAdd (2 : ZMod 4)) := by
+  rw [mk_pow, ← ofAdd_nsmul, nsmul_eq_mul, mul_one]
+  norm_cast
+
+end ConjClasses
+
+end Powers
 
 end TauCeti

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -42,6 +42,11 @@ conjugation action.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
   the group, with `TauCeti.ConjClasses.card_carrier_cast_ne_zero` the consequence that the size of
   a class is nonzero in any semiring where the group order is.
+* `TauCeti.ConjClasses.mem_carrier_pow_iff`: an element lies in `C ^ j` exactly when it is a
+  `j`-th power of a member of `C`, with `TauCeti.ConjClasses.mk_pow` the computation rule.
+* `TauCeti.ConjClasses.pow_zero`, `TauCeti.ConjClasses.pow_one` and
+  `TauCeti.ConjClasses.pow_mul`: the identity and composition laws for that power.
+* `TauCeti.ConjClasses.map_pow`: the power is natural in the monoid.
 
 ## Implementation notes
 
@@ -51,6 +56,15 @@ conjugacy classes. Powering is an instance for the same reason: it buys the nota
 lets the `Monoid.npow`-shaped lemmas below be stated in the usual form. There is still no
 multiplication on `ConjClasses M` — `Pow (ConjClasses M) ℕ` is a bare power operation, not the
 `npow` field of a monoid structure, and none of the lemmas here presuppose one.
+
+The power operation is developed for the Chebotarev roadmap (`Chebotarev/README.md` Layer 1,
+"consumed Frobenius classes and powers of conjugacy classes", whose `Suggested.lean` pins these
+signatures); its consumer there is the von Mangoldt fibre, which sums over the classes `C ^ j`.
+That is also why `TauCeti.ConjClasses.pow_two_cyclicFour` is kept as a regression: a group of
+exponent two has no proper nonidentity square, so it cannot separate a correct power operation
+from one that collapses to the identity. This operation is *not* adapted from the
+Birkbeck–Brasca `chebotarev-density` development, which works with `ConjClasses.mk` and
+`Subgroup.zpowers` directly and never forms `C ^ j`.
 -/
 
 public section


### PR DESCRIPTION
Powering commutes with conjugation, so it descends to conjugacy classes. This adds that power
operation on `ConjClasses M` for a monoid `M`, together with the membership, identity,
composition and functoriality API the roadmap names, and the pinned regression test.

Roadmap: Chebotarev

<!--tauceti-target:v1 {"focus":"Chebotarev","id":"Chebotarev/README.md:Layer-1"}-->

Advances intention #292 (not closed by this PR — only the final endpoint PR closes it).
Roadmap target: `TauCetiRoadmap/Chebotarev`, `README.md` **Layer 1: consumed Frobenius classes
and powers of conjugacy classes**, which asks to

> Define the power operation on conjugacy classes of a monoid and prove its membership,
> composition, identity, and functoriality API. In particular,
> `τ ∈ C.pow j ↔ ∃ σ ∈ C, σ^j = τ`.

Shapes are pinned in that roadmap's `Suggested.lean` (lines 34–57).

### Contents

All in the existing `TauCeti/Algebra/Group/Conj.lean` (+76/−2).

| declaration | statement |
| --- | --- |
| `instPowConjClassesNat` | `Pow (ConjClasses M) ℕ`, the power operation itself |
| `ConjClasses.mk_pow` | `@[simp]` — the class of `a` to the `j` is the class of `a ^ j` |
| `ConjClasses.mem_carrier_pow_iff` | `τ ∈ (C ^ j).carrier ↔ ∃ σ ∈ C.carrier, σ ^ j = τ` |
| `ConjClasses.pow_zero`, `pow_one` | `@[simp]`, as pinned |
| `ConjClasses.pow_mul` | `(C ^ i) ^ j = C ^ (i * j)`, as pinned |
| `ConjClasses.map_pow` | `@[simp]` — functoriality along a `MonoidHom` |
| `ConjClasses.pow_two_cyclicFour` | the pinned `C₄` regression |

### Prior art

Searched Mathlib @ the pinned commit, then TauCeti `main`, then the source repo.

Mathlib has the `ConjClasses` namespace and `IsConj.pow`
(`Mathlib/Algebra/Group/Conj.lean:32,52` — positive control for the search), but
`grep -rn 'ConjClasses' Mathlib | grep -E '\bpow\b|Pow'` returns **zero** hits: there is no
`ConjClasses.pow`, no `Pow (ConjClasses G) ℕ` instance, and no `Monoid (ConjClasses G)`
instance. None of the four Mathlib files carrying `namespace ConjClasses` defines a power.
TauCeti `main`: same grep, zero hits. The Birkbeck–Brasca source does not have it either — it
works with `ConjClasses.mk σ` and `Subgroup.zpowers σ` directly and never forms `C ^ j`. So
this is genuinely new rather than adapted.

**Reuse:** well-definedness is the whole mathematical content, and it is *not* re-proved here —
descent is `Quotient.map` over Mathlib's `IsConj.pow`, which is exactly the descent hypothesis.
`mem_carrier_pow_iff`'s hard direction runs on `SemiconjBy.pow_right` and
`Units.mul_right_inj`.

### Three design decisions, and why

**An `instance`, not the pinned plain `def`.** `Suggested.lean` pins `noncomputable def pow C j`.
I ship `instance instPowConjClassesNat : Pow (ConjClasses M) ℕ` instead, because the host file
already contains the sibling `InvolutiveInv (ConjClasses G)` instance and an implementation note
arguing for exactly this trade — an instance buys the `C ^ j` notation and lets the
`Monoid.npow`-shaped lemmas be stated in their usual form. A bare `def` next to that instance
would be the inconsistency a reader asks about. The lemma statements are unchanged; only the
spelling of the operation differs from the pin.

**Root `ConjClasses` namespace for the lemmas, `TauCeti` for the instance.** `ConjClasses` is
Mathlib's type, so a lemma at `TauCeti.ConjClasses.pow_zero` cannot be used as `C.pow_zero` —
this is what the repo's dot-notation lint enforces, and it failed the first CI run here. The
whole power API therefore sits in the root `ConjClasses` namespace. `mk_pow` and
`mem_carrier_pow_iff` were not among the names the lint flagged (their `ConjClasses` argument is
implicit or not first) but move with the rest, because splitting one API across two namespaces
to satisfy a linter to the letter would be worse than the problem. The `Pow` instance stays
under `TauCeti`: it is never dot notation, and `TauCeti.instInvolutiveInvConjClasses` directly
above it is the sibling precedent.

Note the pre-existing `TauCeti.ConjClasses` block in this file (`inv_mk`, `ncard_carrier_inv`,
…) has the same defect and is grandfathered in the lint baseline. It is deliberately **not**
touched here: moving it would rename already-merged API and belongs in its own PR.

**Placement in the existing file, not a new one.** `ConjClasses` inversion already lives in
`TauCeti/Algebra/Group/Conj.lean`, in the same namespace, and this is the same kind of fact
about the same type. That file's stale sentence "There is no multiplication on `ConjClasses G`
for it to interact with" is corrected in this PR rather than left to contradict the new
instance: it now explains that `Pow (ConjClasses M) ℕ` is a *bare* power operation and not the
`npow` field of a monoid structure — there is still no multiplication, and no lemma here
presupposes one.

**`pow_mul` is oriented as the roadmap pins it,** `(C ^ i) ^ j = C ^ (i * j)`, which is the
*reverse* of Mathlib's `pow_mul : a ^ (m * n) = (a ^ m) ^ n`. That is deliberate: `Suggested.lean:48`
pins `pow (pow C i) j = pow C (i * j)`. Flagging it so the mismatch with the Mathlib convention
reads as a choice rather than an oversight; happy to flip it if the naming rubric prefers
Mathlib's orientation.

### The regression test

`pow_two_cyclicFour` is pinned by the roadmap and kept verbatim: in `C₄` the class of the
generator squares to the class of the element of order two. The roadmap chose `C₄` deliberately
— a group of exponent two has no proper nonidentity square, so it cannot distinguish a correct
power operation from one collapsing to the identity. It costs no new imports: `ZMod 4` and
`Multiplicative` already resolve in this file's import closure.

### Scope

The consumer of this API is Layer 11.4's von Mangoldt fibre, which is a later layer of the same
roadmap and not in this PR. There is deliberately no manufactured in-repo consumer; the
justification is that README Layer 1 requires this API by name and `Suggested.lean` pins these
exact signatures as the Layer 1 milestone.
