### PR TITLE
feat: the primes of a number field ramifying in a finite extension

### DIFF
--- a/TauCeti/NumberTheory/Chebotarev/RamifiedPrimes.lean
+++ b/TauCeti/NumberTheory/Chebotarev/RamifiedPrimes.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.NumberField.Discriminant.Different
+public import Mathlib.RingTheory.DedekindDomain.Factorization
+
+/-!
+# The primes of a number field ramifying in a finite extension
+
+For an extension `L / K` of number fields, a height-one prime `𝔭` of `𝓞 K` is *ramified in `L`*
+when some prime `Q` of `𝓞 L` lying over it is ramified, i.e. when
+
+`¬ ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭.asIdeal], Algebra.IsUnramifiedAt (𝓞 K) Q`.
+
+Only finitely many `𝔭` are ramified, because each of them is the contraction of a prime dividing
+the different ideal `differentIdeal (𝓞 K) (𝓞 L)`, which is nonzero and so has finitely many prime
+divisors. That finiteness is what lets the ramified primes be packaged as a `Finset`, which is the
+form Chebotarev's exceptional set is used in: the density statements discard `ramifiedPrimes K L`
+and argue about the complement.
+
+The ramification condition is spelled out with Mathlib's `Algebra.IsUnramifiedAt` rather than
+wrapped in a named predicate, matching how the roadmap states it. A `Prop`-valued abbreviation for
+"`𝔭` is unramified in `L`" would duplicate `Algebra.IsUnramifiedIn`.
+
+## Main definitions
+
+* `NumberField.Chebotarev.ramifiedPrimes`: the finite set of height-one primes of `𝓞 K` that
+  ramify in `L`.
+
+## Main results
+
+* `NumberField.Chebotarev.finite_setOf_ramified`: only finitely many primes ramify.
+* `NumberField.Chebotarev.mem_ramifiedPrimes_iff`: the defining condition for membership.
+
+## Relation to the absolute `NumberField.ramifiedPrimes`
+
+Both names introduced here already exist one namespace up, and this is deliberate rather than an
+oversight. `TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean` carries
+
+* `NumberField.ramifiedPrimes (K) : Set ℕ`, the *rational* primes ramifying in `K`, and
+* `@[simp] NumberField.mem_ramifiedPrimes_iff`, proved by `Iff.rfl`,
+
+i.e. the same two short names, in the same shape. They are kept apart rather than unified:
+
+* They are the same *shape* — "not `Algebra.IsUnramifiedIn` the top ring at an ideal of the base"
+  — but at different bases. The absolute one is `ℤ`-to-`𝓞 K`; this one is `𝓞 K`-to-`𝓞 L`. Neither
+  is an instance of the other without also transporting the carrier.
+* The carriers genuinely differ: `Set ℕ` against `Finset (HeightOneSpectrum (𝓞 K))`. For `K = ℚ`
+  the two agree only through `𝓞 ℚ ≃ ℤ` and `HeightOneSpectrum ℤ ≃` the rational primes, and
+  neither identification is definitional.
+* Generalising the absolute version instead would change its carrier, and Tau Ceti keeps no
+  compatibility shims, so every use would have to move in this PR — ten files on `main` reference
+  that API, seven of them under `Multiquadratic/`. Its `Set ℕ` packaging is, in its own docstring,
+  "the form in which `t` is counted" for genus theory.
+
+Two consequences to be aware of when using this file. First, `NumberField.Chebotarev` is nested
+inside `NumberField`, so within it a bare `ramifiedPrimes` or `mem_ramifiedPrimes_iff` resolves to
+the declaration here and shadows the absolute one; a `Chebotarev` file that also wants the
+absolute notion must write `_root_.NumberField.ramifiedPrimes`. Second, both `_iff` lemmas are
+`@[simp]`, but their left-hand sides head-match on different types — membership in a `Set ℕ`
+against membership in a `Finset (HeightOneSpectrum (𝓞 K))` — so `simp` never has to choose
+between them.
+
+## References
+
+Adapted from `finite_ramifiedIn` in `CebotarevDensity/Frobenius.lean` of
+[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0,
+Birkbeck--Brasca) at commit `8575c9df1ae0a61120ab5c964c7911414254bec7`, where the statement is a
+`Set.Finite` over `Ideal (𝓞 K)` phrased through a source-local unramifiedness predicate. The
+covering argument through the different ideal is the source's; the carrier is the roadmap's.
+-/
+
+public section
+
+open scoped NumberField
+
+open IsDedekindDomain (HeightOneSpectrum)
+
+namespace NumberField.Chebotarev
+
+variable (K L : Type*) [Field K] [NumberField K] [Field L] [NumberField L] [Algebra K L]
+
+/-- **Only finitely many primes of `K` ramify in `L`.** Each ramified `𝔭` is the contraction of a
+prime of `𝓞 L` dividing the different ideal, and a nonzero ideal has finitely many prime divisors.
+
+Stated for the underlying `Set` rather than for `ramifiedPrimes` itself, because it is what
+*builds* that `Finset`; the absolute analogue `_root_.NumberField.finite_ramifiedPrimes` runs the
+other way round, its `ramifiedPrimes` being a `Set` that this lemma would then cut down. -/
+theorem finite_setOf_ramified : {𝔭 : HeightOneSpectrum (𝓞 K) |
+    ¬ ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭.asIdeal],
+      Algebra.IsUnramifiedAt (𝓞 K) Q}.Finite := by
+  -- The different ideal is nonzero, hence divisible by only finitely many primes of `𝓞 L`.
+  have hbot : differentIdeal (𝓞 K) (𝓞 L) ≠ 0 := by
+    rw [Ideal.zero_eq_bot]; exact differentIdeal_ne_bot
+  -- `asIdeal` is injective, so it suffices to bound the image of the set in `Ideal (𝓞 K)`.
+  refine Set.Finite.of_finite_image ?_ HeightOneSpectrum.asIdeal_injective.injOn
+  -- Each ramified `𝔭` is the contraction of a prime of `𝓞 L` dividing the different.
+  refine Set.Finite.subset ((Ideal.finite_factors hbot).image
+    (fun w : HeightOneSpectrum (𝓞 L) ↦ w.asIdeal.under (𝓞 K))) ?_
+  rintro _ ⟨𝔭, h𝔭, rfl⟩
+  simp only [Set.mem_ofPred_eq, not_forall] at h𝔭
+  obtain ⟨Q, hQp, hQlo, hQnu⟩ := h𝔭
+  exact ⟨⟨Q, hQp, Ideal.ne_bot_of_liesOver_of_ne_bot 𝔭.ne_bot Q⟩,
+    dvd_differentIdeal_iff.mpr hQnu, hQlo.over.symm⟩
+
+/-- **The primes of `K` that ramify in `L`.** The height-one primes `𝔭` of `𝓞 K` for which some
+prime of `𝓞 L` over `𝔭` is ramified, collected into a `Finset` by `finite_setOf_ramified`.
+
+This is the relative notion; `_root_.NumberField.ramifiedPrimes` is the absolute one, over `ℤ`
+and valued in `Set ℕ`. See the module docstring. -/
+noncomputable def ramifiedPrimes : Finset (HeightOneSpectrum (𝓞 K)) :=
+  (finite_setOf_ramified K L).toFinset
+
+variable {K L}
+
+/-- The defining condition for membership in `ramifiedPrimes`. -/
+@[simp]
+theorem mem_ramifiedPrimes_iff (𝔭 : HeightOneSpectrum (𝓞 K)) : 𝔭 ∈ ramifiedPrimes K L ↔
+    ¬ ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭.asIdeal], Algebra.IsUnramifiedAt (𝓞 K) Q :=
+  Set.Finite.mem_toFinset _
+
+end NumberField.Chebotarev

--- a/TauCeti/NumberTheory/Chebotarev/RamifiedPrimes.lean
+++ b/TauCeti/NumberTheory/Chebotarev/RamifiedPrimes.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.NumberField.Discriminant.Different
-public import Mathlib.RingTheory.DedekindDomain.Factorization
+public import TauCeti.RingTheory.DedekindDomain.RamificationLocus
 
 /-!
 # The primes of a number field ramifying in a finite extension
@@ -33,18 +33,18 @@ wrapped in a named predicate, matching how the roadmap states it. A `Prop`-value
 
 ## Main results
 
-* `NumberField.Chebotarev.finite_setOf_ramified`: only finitely many primes ramify.
 * `NumberField.Chebotarev.mem_ramifiedPrimes_iff`: the defining condition for membership.
 
 ## Relation to the absolute `NumberField.ramifiedPrimes`
 
-Both names introduced here already exist one namespace up, and this is deliberate rather than an
+Every name used here already exists one namespace up, and this is deliberate rather than an
 oversight. `TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean` carries
 
-* `NumberField.ramifiedPrimes (K) : Set ℕ`, the *rational* primes ramifying in `K`, and
-* `@[simp] NumberField.mem_ramifiedPrimes_iff`, proved by `Iff.rfl`,
+* `NumberField.ramifiedPrimes (K) : Set ℕ`, the *rational* primes ramifying in `K`,
+* `@[simp] NumberField.mem_ramifiedPrimes_iff`, proved by `Iff.rfl`, and
+* `NumberField.finite_ramifiedPrimes`,
 
-i.e. the same two short names, in the same shape. They are kept apart rather than unified:
+i.e. the same short names, in the same shape. They are kept apart rather than unified:
 
 * They are the same *shape* — "not `Algebra.IsUnramifiedIn` the top ring at an ideal of the base"
   — but at different bases. The absolute one is `ℤ`-to-`𝓞 K`; this one is `𝓞 K`-to-`𝓞 L`. Neither
@@ -60,7 +60,8 @@ i.e. the same two short names, in the same shape. They are kept apart rather tha
 Two consequences to be aware of when using this file. First, `NumberField.Chebotarev` is nested
 inside `NumberField`, so within it a bare `ramifiedPrimes` or `mem_ramifiedPrimes_iff` resolves to
 the declaration here and shadows the absolute one; a `Chebotarev` file that also wants the
-absolute notion must write `_root_.NumberField.ramifiedPrimes`. Second, both `_iff` lemmas are
+absolute notion must write `_root_.NumberField.ramifiedPrimes`. (The finiteness lemma is private,
+so its name collides only inside this file.) Second, both `_iff` lemmas are
 `@[simp]`, but their left-hand sides head-match on different types — membership in a `Set ℕ`
 against membership in a `Finset (HeightOneSpectrum (𝓞 K))` — so `simp` never has to choose
 between them.
@@ -85,35 +86,33 @@ namespace NumberField.Chebotarev
 variable (K L : Type*) [Field K] [NumberField K] [Field L] [NumberField L] [Algebra K L]
 
 /-- **Only finitely many primes of `K` ramify in `L`.** Each ramified `𝔭` is the contraction of a
-prime of `𝓞 L` dividing the different ideal, and a nonzero ideal has finitely many prime divisors.
+ramified prime of `𝓞 L`, and there are finitely many of those.
 
-Stated for the underlying `Set` rather than for `ramifiedPrimes` itself, because it is what
-*builds* that `Finset`; the absolute analogue `_root_.NumberField.finite_ramifiedPrimes` runs the
-other way round, its `ramifiedPrimes` being a `Set` that this lemma would then cut down. -/
-theorem finite_setOf_ramified : {𝔭 : HeightOneSpectrum (𝓞 K) |
+Private, and stated for the underlying `Set` rather than for `ramifiedPrimes` itself, because its
+only role is to *build* that `Finset`; consumers take finiteness from the `Finset` and membership
+from `mem_ramifiedPrimes_iff`. The absolute analogue `_root_.NumberField.finite_ramifiedPrimes`
+runs the other way round, its `ramifiedPrimes` being a `Set` that the lemma then cuts down. -/
+private theorem finite_ramifiedPrimes : {𝔭 : HeightOneSpectrum (𝓞 K) |
     ¬ ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭.asIdeal],
       Algebra.IsUnramifiedAt (𝓞 K) Q}.Finite := by
-  -- The different ideal is nonzero, hence divisible by only finitely many primes of `𝓞 L`.
-  have hbot : differentIdeal (𝓞 K) (𝓞 L) ≠ 0 := by
-    rw [Ideal.zero_eq_bot]; exact differentIdeal_ne_bot
   -- `asIdeal` is injective, so it suffices to bound the image of the set in `Ideal (𝓞 K)`.
   refine Set.Finite.of_finite_image ?_ HeightOneSpectrum.asIdeal_injective.injOn
-  -- Each ramified `𝔭` is the contraction of a prime of `𝓞 L` dividing the different.
-  refine Set.Finite.subset ((Ideal.finite_factors hbot).image
-    (fun w : HeightOneSpectrum (𝓞 L) ↦ w.asIdeal.under (𝓞 K))) ?_
+  -- Each ramified `𝔭` is the contraction of a ramified prime of `𝓞 L`, and the ramification
+  -- locus of `𝓞 L` over `𝓞 K` is finite.
+  refine Set.Finite.subset ((Algebra.finite_compl_unramifiedLocus (𝓞 K) (𝓞 L)).image
+    (fun Q : PrimeSpectrum (𝓞 L) ↦ Q.asIdeal.under (𝓞 K))) ?_
   rintro _ ⟨𝔭, h𝔭, rfl⟩
   simp only [Set.mem_ofPred_eq, not_forall] at h𝔭
   obtain ⟨Q, hQp, hQlo, hQnu⟩ := h𝔭
-  exact ⟨⟨Q, hQp, Ideal.ne_bot_of_liesOver_of_ne_bot 𝔭.ne_bot Q⟩,
-    dvd_differentIdeal_iff.mpr hQnu, hQlo.over.symm⟩
+  exact ⟨⟨Q, hQp⟩, hQnu, hQlo.over.symm⟩
 
 /-- **The primes of `K` that ramify in `L`.** The height-one primes `𝔭` of `𝓞 K` for which some
-prime of `𝓞 L` over `𝔭` is ramified, collected into a `Finset` by `finite_setOf_ramified`.
+prime of `𝓞 L` over `𝔭` is ramified, collected into a `Finset` by `finite_ramifiedPrimes`.
 
 This is the relative notion; `_root_.NumberField.ramifiedPrimes` is the absolute one, over `ℤ`
 and valued in `Set ℕ`. See the module docstring. -/
 noncomputable def ramifiedPrimes : Finset (HeightOneSpectrum (𝓞 K)) :=
-  (finite_setOf_ramified K L).toFinset
+  (finite_ramifiedPrimes K L).toFinset
 
 variable {K L}
 


### PR DESCRIPTION
The finite set of primes of a number field `K` that **ramify in a finite extension `L`**, as a
`Finset (HeightOneSpectrum (𝓞 K))`, together with the membership characterisation:

```
𝔭 ∈ ramifiedPrimes K L ↔
  ¬ ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭.asIdeal], Algebra.IsUnramifiedAt (𝓞 K) Q
```

Finiteness comes from the different ideal: `differentIdeal (𝓞 K) (𝓞 L)` is nonzero, hence has
finitely many prime divisors, and every ramified `𝔭` is the contraction of one of them
(`dvd_differentIdeal_iff`). Because the roadmap's carrier is `HeightOneSpectrum (𝓞 K)` rather
than `Ideal (𝓞 K)`, the covering is run back through `HeightOneSpectrum.asIdeal_injective`.

Roadmap: Chebotarev

<!--tauceti-target:v1 {"focus":"Chebotarev","id":"Chebotarev/README.md:Layer-2-ramifiedPrimes"}-->

## Why this is on the roadmap

Layer 2 of the Chebotarev roadmap — the finite exceptional set. The shape is the one pinned in
`Chebotarev/Suggested.lean:79-84` (`ramifiedPrimes` / `mem_ramifiedPrimes_iff`); the density
statements of Layers 8 and 10 discard `ramifiedPrimes K L` and argue about the complement. This
advances intention #292.

Parent-free: this unit mentions neither `artinSymbol` nor `frobeniusPrimeSet`, so it is
independent of the supplier gate.

## Two departures from the source, both deliberate

**`IsGalois K L` is dropped.** The source states `finite_ramifiedIn` with `[IsGalois K L]`. The
covering argument never uses it — only that `𝓞 L` is a Dedekind domain finite over `𝓞 K` — so the
hypothesis is not carried over. This is a strict generalisation of the source statement.

**The source's `UnramifiedIn` predicate is not ported.** Mathlib already has
`Algebra.IsUnramifiedAt` / `Algebra.IsUnramifiedIn`, and `Suggested.lean` spells the condition out
with `IsUnramifiedAt` directly rather than naming a predicate. A `Prop`-valued wrapper here would
duplicate Mathlib and land on the reuse rubric, so the condition is written out inline.

Hypotheses were drop-tested: `[NumberField L]` is load-bearing (without it `IsDedekindDomain (𝓞 L)`
fails to synthesize), and `[NumberField K]` is needed to state the theorem at all, since
`HeightOneSpectrum (𝓞 K)` presupposes it.

## The name collision with the absolute `ramifiedPrimes`, and why it is deliberate

`main` already carries, one namespace up in
`TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean`:

* `NumberField.ramifiedPrimes (K) : Set ℕ` (`:47`) — the *rational* primes ramifying in `K`; and
* `@[simp] NumberField.mem_ramifiedPrimes_iff` (`:54`), proved by `Iff.rfl`.

So **both** short names introduced here already exist above us, in the same shape. Flagging this
explicitly rather than leaving it to be discovered:

* They are the same *shape* — "not unramified, at an ideal of the base" — but at **different
  bases**: absolute is `ℤ → 𝓞 K`, this one is `𝓞 K → 𝓞 L`. Neither is an instance of the other
  without transporting the carrier too.
* The **carriers differ**: `Set ℕ` versus `Finset (HeightOneSpectrum (𝓞 K))`. For `K = ℚ` they
  agree only through `𝓞 ℚ ≃ ℤ` and `HeightOneSpectrum ℤ ≃` the rational primes, and neither
  identification is definitional.
* **Generalising the absolute version instead was considered and rejected.** It would change that
  version's carrier, and Tau Ceti keeps no compatibility shims, so all ten files on `main` that use
  it — seven of them under `Multiquadratic/` — would have to move in this PR. That is a
  Multiquadratic refactor smuggled inside a Chebotarev rung, and its `Set ℕ` packaging is, in its
  own docstring, "the form in which `t` is counted" for genus theory.

Two consequences, both recorded in the module docstring. `NumberField.Chebotarev` nests **inside**
`NumberField`, so within it a bare `ramifiedPrimes` resolves here and **shadows** the absolute one;
a `Chebotarev` file wanting the absolute notion must write `_root_.NumberField.ramifiedPrimes`.
And both `_iff` lemmas are `@[simp]`, but their left-hand sides head-match on different types
(`Set ℕ` membership versus `Finset` membership), so `simp` never has to choose between them.

The roadmap pins the short names, so they are kept rather than renamed.

## Placement

New file `TauCeti/NumberTheory/Chebotarev/RamifiedPrimes.lean`, namespace
`NumberField.Chebotarev`, as the bead specifies. This creates the `Chebotarev/` directory.

## Quality gauntlet

Run **inline** in the PR worktree rather than via a cleanup-crew session: Gas City cannot bind a
cleanup-crew formula session to a pr-worker's pooled worktree, so the same worker executed every
phase. All eleven phases; `fm-decompose-proof` not triggered (longest proof is 17 lines, well under
the 50-line cap). Findings actually fixed, not just recorded:

* a missing docstring on the public `finite_setOf_ramified` (added);
* two redundant `have := hQp` / `have := hQlo` lines — local hypotheses are already visible to
  typeclass resolution, so both were dead (removed, −2 lines);
* two underpacked signature lines (repacked to 62 and 87/95 codepoints).

`simp only [Set.mem_ofPred_eq, not_forall]` was tested for minimality: `not_forall` alone also
compiles, but `Set.mem_ofPred_eq` genuinely fires and makes the `∃` explicit instead of leaving
`obtain` to see through set-membership by defeq, so both are kept deliberately.

Per the standing build rule no local `lake build` was run at any point — the Lean LSP reports the
file clean at all severities, and CI owns the build, axiom, lint and module-system gates.

## Provenance

Adapted from `finite_ramifiedIn` in `CebotarevDensity/Frobenius.lean` of
[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0,
Birkbeck--Brasca) at commit `8575c9df1ae0a61120ab5c964c7911414254bec7`. Attribution is recorded
in the module docstring as well as here.
