### PR TITLE
feat(Ideal): the powers of I are eventually constant

### DIFF
--- a/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
+++ b/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
@@ -121,15 +121,16 @@ commutative ring `B` whose image in a localisation `C` at `1 + I` lies in every 
 This is the closing step of Wedhorn's proof of Proposition 7.49(2), and the reason the localisation
 is introduced there at all. Note what the conclusion does *not* mention: neither `C` nor `1 + I`
 survives it, so a caller who has discharged the hypothesis is left with a statement purely about
-`I`. The two halves are `exists_mem_oneAdd_forall_mul_eq_zero`, which produces the annihilator, and
-`pow_eq_pow_of_forall_mul_eq_zero`, which turns an annihilator of the shape `1 + i` into
-stabilization; membership in `1 + I` is exactly the shape that second lemma expects, which is why
-the submonoid is recorded existentially. -/
+`I`. -/
 theorem exists_forall_pow_eq_pow (hfg : I.FG)
     (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
     ∃ n : ℕ, ∀ k, n ≤ k → I ^ k = I ^ n := by
+  -- The two halves are `exists_mem_oneAdd_forall_mul_eq_zero`, which produces the annihilator,
+  -- and `pow_eq_pow_of_forall_mul_eq_zero`, which turns an annihilator of the shape `1 + i` into
+  -- stabilization; membership in `1 + I` is exactly the shape that second lemma expects, which is
+  -- why the submonoid is recorded existentially.
   obtain ⟨n, s, hs, hann⟩ := exists_mem_oneAdd_forall_mul_eq_zero (C := C) hfg hprime
-  obtain ⟨a, ha, rfl⟩ := hs
+  obtain ⟨a, ha, rfl⟩ := (mem_oneAdd I).mp hs
   exact ⟨n, fun k hk ↦ pow_eq_pow_of_forall_mul_eq_zero ha hann hk⟩
 
 end CommRing

--- a/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
+++ b/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
@@ -9,6 +9,7 @@ public import TauCeti.RingTheory.Ideal.Nilpotent
 public import Mathlib.RingTheory.Localization.Defs
 public import Mathlib.RingTheory.Finiteness.Ideal
 import Mathlib.Tactic.NoncommRing
+import TauCeti.RingTheory.Ideal.PowerStabilization
 
 /-!
 # Localising at `1 + I`
@@ -17,7 +18,11 @@ For an ideal `I` of a semiring `B`, the set `1 + I` is a submonoid of `B`. If `B
 `I` is finitely generated, and its image in a localisation at `1 + I` lies in every prime there,
 then a single element of `1 + I` annihilates a power of `I`.
 
-Only that implication is proved here, and only under `I.FG`; the converse is not stated.
+Over a commutative *ring* that annihilator makes the powers of `I` constant, which is the form
+Wedhorn's argument actually uses and the one stated last below: its conclusion mentions neither the
+localisation nor the submonoid.
+
+Only these implications are proved here, and only under `I.FG`; the converses are not stated.
 
 The nilpotence step is not about localisation at all and lives in
 `TauCeti.RingTheory.Ideal.Nilpotent` as `Ideal.exists_pow_map_eq_bot`. Localisation enters here,
@@ -30,6 +35,8 @@ to turn "the image of `I ^ n` is zero" into an annihilator lying in `1 + I`.
 * `Ideal.exists_mem_oneAdd_forall_mul_eq_zero`: if `I` is finitely generated and its image in a
   localisation `C` at `1 + I` is contained in every prime of `C`, there is a single `s ∈ 1 + I`
   with `s * x = 0` for every `x ∈ I ^ n`.
+* `Ideal.exists_forall_pow_eq_pow`: over a commutative ring, the same hypotheses make the powers
+  of `I` constant from some point on.
 
 ## References
 
@@ -101,5 +108,30 @@ theorem exists_mem_oneAdd_forall_mul_eq_zero (hfg : I.FG)
     | smul c y _ hy => rw [smul_eq_mul, mul_comm c y, ← mul_assoc, hy, zero_mul]
 
 end Localisation
+
+section CommRing
+
+variable {B C : Type*} [CommRing B] [CommSemiring C] [Algebra B C] {I : Ideal B}
+  [IsLocalization (oneAdd I) C]
+
+/-- **The powers of `I` are eventually constant.** If `I` is a finitely generated ideal of a
+commutative ring `B` whose image in a localisation `C` at `1 + I` lies in every prime of `C`, then
+`I ^ k = I ^ n` for some `n` and all `k ≥ n`.
+
+This is the closing step of Wedhorn's proof of Proposition 7.49(2), and the reason the localisation
+is introduced there at all. Note what the conclusion does *not* mention: neither `C` nor `1 + I`
+survives it, so a caller who has discharged the hypothesis is left with a statement purely about
+`I`. The two halves are `exists_mem_oneAdd_forall_mul_eq_zero`, which produces the annihilator, and
+`pow_eq_pow_of_forall_mul_eq_zero`, which turns an annihilator of the shape `1 + i` into
+stabilization; membership in `1 + I` is exactly the shape that second lemma expects, which is why
+the submonoid is recorded existentially. -/
+theorem exists_forall_pow_eq_pow (hfg : I.FG)
+    (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
+    ∃ n : ℕ, ∀ k, n ≤ k → I ^ k = I ^ n := by
+  obtain ⟨n, s, hs, hann⟩ := exists_mem_oneAdd_forall_mul_eq_zero (C := C) hfg hprime
+  obtain ⟨a, ha, rfl⟩ := hs
+  exact ⟨n, fun k hk ↦ pow_eq_pow_of_forall_mul_eq_zero ha hann hk⟩
+
+end CommRing
 
 end Ideal


### PR DESCRIPTION
Wedhorn proves Proposition 7.49(2) by localising at `1 + I`, extracting an annihilator of a power of `I`, and then reading off that the powers of `I` are constant from that point on. This adds the step that reads it off.

### What was already on `main`, and what was missing

The two halves of Wedhorn's closing step landed separately and, until now, neither had a consumer:

| | on `main` | |
|---|---|---|
| produces the annihilator | `Ideal.exists_mem_oneAdd_forall_mul_eq_zero` | `RingTheory/Ideal/OneAddLocalisation.lean:72` (#5095) |
| turns a `1 + i` annihilator into stabilization | `Ideal.pow_eq_pow_of_forall_mul_eq_zero` | `RingTheory/Ideal/PowerStabilization.lean:87` (#5014) |
| the image of `I` is nilpotent | `Ideal.exists_pow_map_eq_bot` | `RingTheory/Ideal/Nilpotent.lean:36` |

Nothing joined them. `Ideal.exists_forall_pow_eq_pow` is that join, and it is the first consumer either of the first two results has had.

### Why the statement is worth having separately

Its conclusion mentions neither `C` nor `1 + I`:

```
∃ n : ℕ, ∀ k, n ≤ k → I ^ k = I ^ n
```

so a caller who has discharged the prime hypothesis is left with a statement purely about `I` in `B`, with the localisation entirely internal to the proof. That is the form Wedhorn's argument consumes.

The join is a destructuring rather than a translation, and deliberately so: `1 + I` records membership existentially as `∃ a ∈ I, x = 1 + a`, which is exactly the shape `pow_eq_pow_of_forall_mul_eq_zero` expects. The two existing lemmas were built to meet here.

The typeclass is `CommRing B` rather than the `CommSemiring` of the surrounding section — `exists_mem_oneAdd_forall_mul_eq_zero` needs commutativity and `pow_eq_pow_of_forall_mul_eq_zero` needs negation, so the join is where both are required. It is placed in its own `CommRing` section for that reason.

### What this does *not* do

**The prime hypothesis is taken as given and is not discharged here.** `∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P` is Wedhorn's "claim", whose proof runs through Lemma 7.45 and the microbial / height-one substrate. That is a separate piece of work and is not touched.

### Roadmap target

`TauCetiRoadmap/AdicSpaces/README.md` §2.3 "The plus ring, emptiness, and analytic points", which asks at line 427 to **"Prove Proposition 7.49(2), including the criterion for this locus to be empty"**. Wedhorn's proof of 7.49(2) closes by showing `A/{0}` is discrete, and the commutative-algebra content of that closing move is exactly the ideal-power stabilization proved here. No roadmap amendment is involved: the target is on roadmap `main` today.

### Placement

Added to `OneAddLocalisation.lean` rather than to `PowerStabilization.lean` or a new file. It inherits that module's hypotheses verbatim — `IsLocalization (oneAdd I) C` plus the prime containment — so its variables are already in scope there. `PowerStabilization.lean` would be the wrong home: its module docstring states that the localisation at `1 + I` is *deliberately* outside it and that nothing in it mentions a localisation.

`TauCeti.RingTheory.Ideal.PowerStabilization` is imported as a plain `import`, not `public import`: it is used only inside the proof and contributes nothing to the exported signature.

### References

* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), proof of Proposition 7.49(2).

Roadmap: AdicSpaces
