### PR TITLE
feat: tensor multiplicities of irreducible highest weight modules

### DIFF
--- a/TauCeti/Algebra/Lie/Basic.lean
+++ b/TauCeti/Algebra/Lie/Basic.lean
@@ -65,11 +65,9 @@ theorem ofBijective_apply (f : M →ₗ⁅R,L⁆ N) (hf : Function.Bijective f) 
 /-- **An equivalence of `L`-modules is an equivalence of `L'`-modules** for a Lie subalgebra
 `L' ≤ L`, with the same underlying map. This is Mathlib's `LieModuleHom.restrictLie` for
 equivalences. -/
-def restrictLie [LieAlgebra R L] (e : M ≃ₗ⁅R,L⁆ N) (L' : LieSubalgebra R L) : M ≃ₗ⁅R,L'⁆ N where
-  __ := (e : M →ₗ⁅R,L⁆ N).restrictLie L'
-  invFun := e.invFun
-  left_inv := e.left_inv
-  right_inv := e.right_inv
+noncomputable def restrictLie [LieAlgebra R L] (e : M ≃ₗ⁅R,L⁆ N) (L' : LieSubalgebra R L) :
+    M ≃ₗ⁅R,L'⁆ N :=
+  ofBijective ((e : M →ₗ⁅R,L⁆ N).restrictLie L') ⟨e.injective, e.surjective⟩
 
 @[simp]
 theorem coe_restrictLie [LieAlgebra R L] (e : M ≃ₗ⁅R,L⁆ N) (L' : LieSubalgebra R L) :

--- a/TauCeti/Algebra/Lie/Basic.lean
+++ b/TauCeti/Algebra/Lie/Basic.lean
@@ -71,8 +71,11 @@ noncomputable def restrictLie [LieAlgebra R L] (e : M ≃ₗ⁅R,L⁆ N) (L' : L
 
 @[simp]
 theorem coe_restrictLie [LieAlgebra R L] (e : M ≃ₗ⁅R,L⁆ N) (L' : LieSubalgebra R L) :
-    ⇑(restrictLie e L') = e :=
-  (rfl)
+    ⇑(restrictLie e L') = e := by
+  funext m
+  refine (ofBijective_apply ((e : M →ₗ⁅R,L⁆ N).restrictLie L') _ m).trans ?_
+  rw [LieModuleHom.coe_restrictLie]
+  rfl
 
 section CongrRight
 

--- a/TauCeti/Algebra/Lie/Basic.lean
+++ b/TauCeti/Algebra/Lie/Basic.lean
@@ -18,6 +18,8 @@ This file supplies general constructions for Lie modules that are missing from M
 ## Main definitions
 
 * `TauCeti.LieModuleEquiv.ofBijective`: a bijective morphism of Lie modules is an equivalence.
+* `TauCeti.LieModuleEquiv.restrictLie`: an equivalence of Lie modules over a Lie algebra, read as
+  one over a Lie subalgebra.
 * `TauCeti.LieModuleEquiv.congrRight` and `TauCeti.LieModuleEquiv.congrLeft`: postcomposition and
   precomposition with an equivalence of Lie modules, as linear equivalences of morphism spaces.
 * `TauCeti.lieAnnihilator`: the Lie subalgebra of elements annihilating a vector in a Lie
@@ -59,6 +61,20 @@ theorem ofBijective_apply (f : M →ₗ⁅R,L⁆ N) (hf : Function.Bijective f) 
   -- representation boundary before applying the corresponding linear-equivalence interface lemma.
   change (LinearEquiv.ofBijective (f : M →ₗ[R] N) hf) m = f m
   exact LinearEquiv.ofBijective_apply _ _
+
+/-- **An equivalence of `L`-modules is an equivalence of `L'`-modules** for a Lie subalgebra
+`L' ≤ L`, with the same underlying map. This is Mathlib's `LieModuleHom.restrictLie` for
+equivalences. -/
+def restrictLie [LieAlgebra R L] (e : M ≃ₗ⁅R,L⁆ N) (L' : LieSubalgebra R L) : M ≃ₗ⁅R,L'⁆ N where
+  __ := (e : M →ₗ⁅R,L⁆ N).restrictLie L'
+  invFun := e.invFun
+  left_inv := e.left_inv
+  right_inv := e.right_inv
+
+@[simp]
+theorem coe_restrictLie [LieAlgebra R L] (e : M ≃ₗ⁅R,L⁆ N) (L' : LieSubalgebra R L) :
+    ⇑(restrictLie e L') = e :=
+  (rfl)
 
 section CongrRight
 

--- a/TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean
@@ -75,6 +75,15 @@ run over all of `Module.Dual K H`: `TauCeti.irreducibleFormalCharacter` names th
 `TauCeti.irreducibleFormalCharacter_def` unfolds it wherever the finite-dimensionality instance is
 already at hand, so the definition itself never needs unfolding.
 
+The missing Poincaré--Birkhoff--Witt input does not make that character an unknown quantity.
+`TauCeti.irreducibleFormalCharacter_eq_zero_iff` says it vanishes exactly when `M(λ)` does, so a
+weight contributing to a character identity has an irreducible `L(λ)`
+(`TauCeti.isIrreducible_irreducibleQuotient_of_irreducibleFormalCharacter_ne_zero`) and a weight
+not contributing has the zero module, with the zero multiplicity that a decomposition into
+irreducibles gives it. At `λ = 0` the input is available outright, so
+`TauCeti.irreducibleFormalCharacter_zero_ne_zero` is unconditional and the character API is not
+vacuous.
+
 Restricting the sum to the dominant integral weights loses nothing:
 `TauCeti.isotypicMultiplicity_irreducibleQuotient_eq_zero_of_not_isDominantIntegral` says that
 `L(λ)` for a non-dominant `λ` occurs in no finite-dimensional module at all, so every multiplicity
@@ -92,6 +101,12 @@ the sum omits is zero.
   decomposition** `M ≃ ⨁_λ L(λ)^{m λ}`.
 * `TauCeti.isotypicMultiplicity_irreducibleQuotient_eq_zero_of_not_isDominantIntegral`: an
   irreducible highest weight module of non-dominant weight occurs in no finite-dimensional module.
+* `TauCeti.irreducibleFormalCharacter_eq_zero_iff` and
+  `TauCeti.isIrreducible_irreducibleQuotient_of_irreducibleFormalCharacter_ne_zero`: the character
+  of `L(lam)` vanishes exactly when `M(lam)` does, so **a nonzero character is the character of an
+  irreducible module.**
+* `TauCeti.irreducibleFormalCharacter_zero_ne_zero`: **the character of `L(0)` is nonzero**, with
+  no appeal to Poincaré--Birkhoff--Witt.
 * `TauCeti.formalCharacter_eq_finsum_isotypicMultiplicity_smul`: **the character of a
   finite-dimensional module is the multiplicity-weighted sum of the irreducible characters.**
 
@@ -231,6 +246,39 @@ theorem irreducibleFormalCharacter_def
     [FiniteDimensional K (irreducibleQuotient b lam.1)] :
     irreducibleFormalCharacter b lam = formalCharacter K H (irreducibleQuotient b lam.1) :=
   irreducibleFormalCharacter_def_aux b lam
+
+/-- **The character of `L(lam)` vanishes exactly when `M(lam)` does.** The character records the
+dimension of `L(lam)`, and `L(lam)` is the zero module exactly when `M(lam)` is
+(`TauCeti.subsingleton_irreducibleQuotient_iff`). -/
+theorem irreducibleFormalCharacter_eq_zero_iff
+    (lam : {l : Dual K H // IsDominantIntegral b l}) :
+    irreducibleFormalCharacter b lam = 0 ↔ vermaGenerator b lam.1 = 0 := by
+  have _ := finiteDimensional_irreducibleQuotient_of_isDominantIntegral lam.2
+  rw [irreducibleFormalCharacter_def, formalCharacter_eq_zero_iff, Module.finrank_zero_iff,
+    subsingleton_irreducibleQuotient_iff]
+
+/-- **A nonzero character is the character of an honest irreducible module.** The character being
+nonzero says exactly that `M(lam) ≠ 0`, which is what
+`TauCeti.isIrreducible_irreducibleQuotient` asks for; so wherever
+`TauCeti.irreducibleFormalCharacter` contributes to an identity, the module it is the character of
+is irreducible. -/
+theorem isIrreducible_irreducibleQuotient_of_irreducibleFormalCharacter_ne_zero
+    {lam : {l : Dual K H // IsDominantIntegral b l}}
+    (h : irreducibleFormalCharacter b lam ≠ 0) :
+    LieModule.IsIrreducible K L (irreducibleQuotient b lam.1) :=
+  isIrreducible_irreducibleQuotient b lam.1 fun h0 ↦
+    h ((irreducibleFormalCharacter_eq_zero_iff b lam).mpr h0)
+
+/-- **The character of `L(0)` is nonzero, unconditionally.** The trivial one-dimensional module is
+a highest weight module of weight `0`, so `M(0) ≠ 0` with no appeal to
+Poincaré--Birkhoff--Witt (`TauCeti.isHighestWeightVector_vermaGenerator_zero`). With
+`TauCeti.isIrreducible_irreducibleQuotient_of_irreducibleFormalCharacter_ne_zero` this exhibits a
+weight at which `L(lam)` is an honest irreducible with a nonzero character, so no statement about
+`TauCeti.irreducibleFormalCharacter` is vacuous. -/
+theorem irreducibleFormalCharacter_zero_ne_zero :
+    irreducibleFormalCharacter b ⟨0, isDominantIntegral_zero⟩ ≠ 0 := fun h ↦
+  (isHighestWeightVector_vermaGenerator_zero b).ne_zero
+    ((irreducibleFormalCharacter_eq_zero_iff b _).mp h)
 
 /-! ### The multiplicity-weighted sum of irreducible characters -/
 

--- a/TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.HighestWeight.FiniteDimensional
-public import TauCeti.Algebra.Lie.HighestWeight.Verma
 public import TauCeti.Algebra.Lie.Multiplicity
 public import TauCeti.Algebra.Lie.Weights.FormalCharacter
 -- Non-public: these supply the inputs of the proofs, never the vocabulary of a statement.
@@ -68,8 +67,11 @@ Formal characters are additive over an internal decomposition
 (`TauCeti.formalCharacter_eq_sum_of_isInternal`), so the same regrouping turns the decomposition
 into the character identity `ch M = ∑_λ m_λ · ch L(λ)`, the form in which "decompose `M` into
 irreducibles" becomes a computation. The formal character is defined only for a
-finite-dimensional module, while `L(λ)` is finite-dimensional exactly at a dominant integral `λ`
-(`TauCeti.finiteDimensional_iff_isDominantIntegral_of_isHighestWeightVector`), so the sum does not
+finite-dimensional module, and `L(λ)` is finite-dimensional at every dominant integral `λ`
+(`TauCeti.finiteDimensional_irreducibleQuotient_of_isDominantIntegral`); at a non-dominant `λ` it
+is infinite-dimensional as soon as `M(λ) ≠ 0`, that being what gives it a highest weight vector
+(`TauCeti.finiteDimensional_iff_isDominantIntegral_of_isHighestWeightVector`), and otherwise it is
+the zero module, which is finite-dimensional but occurs in nothing. So the sum does not
 run over all of `Module.Dual K H`: `TauCeti.irreducibleFormalCharacter` names the character of
 `L(λ)` as a function of a weight *bundled with its dominance*, and the sum runs over that subtype.
 `TauCeti.irreducibleFormalCharacter_def` unfolds it wherever the finite-dimensionality instance is
@@ -86,8 +88,8 @@ vacuous.
 
 Restricting the sum to the dominant integral weights loses nothing:
 `TauCeti.isotypicMultiplicity_irreducibleQuotient_eq_zero_of_not_isDominantIntegral` says that
-`L(λ)` for a non-dominant `λ` occurs in no finite-dimensional module at all, so every multiplicity
-the sum omits is zero.
+`L(λ)` for a non-dominant `λ` has multiplicity zero in every finite-dimensional module, so every
+multiplicity the sum omits is zero.
 
 ## Main definitions
 
@@ -99,8 +101,8 @@ the sum omits is zero.
   labelled by a dominant integral `λ` are counted by the multiplicity of `L(λ)`.**
 * `TauCeti.nonempty_lieModuleEquiv_directSum_irreducibleQuotient`: **the packaged isotypic
   decomposition** `M ≃ ⨁_λ L(λ)^{m λ}`.
-* `TauCeti.isotypicMultiplicity_irreducibleQuotient_eq_zero_of_not_isDominantIntegral`: an
-  irreducible highest weight module of non-dominant weight occurs in no finite-dimensional module.
+* `TauCeti.isotypicMultiplicity_irreducibleQuotient_eq_zero_of_not_isDominantIntegral`: `L(λ)` of
+  a non-dominant weight `λ` has multiplicity zero in every finite-dimensional module.
 * `TauCeti.irreducibleFormalCharacter_eq_zero_iff` and
   `TauCeti.isIrreducible_irreducibleQuotient_of_irreducibleFormalCharacter_ne_zero`: the character
   of `L(lam)` vanishes exactly when `M(lam)` does, so **a nonzero character is the character of an
@@ -250,6 +252,7 @@ theorem irreducibleFormalCharacter_def
 /-- **The character of `L(lam)` vanishes exactly when `M(lam)` does.** The character records the
 dimension of `L(lam)`, and `L(lam)` is the zero module exactly when `M(lam)` is
 (`TauCeti.subsingleton_irreducibleQuotient_iff`). -/
+@[simp]
 theorem irreducibleFormalCharacter_eq_zero_iff
     (lam : {l : Dual K H // IsDominantIntegral b l}) :
     irreducibleFormalCharacter b lam = 0 ↔ vermaGenerator b lam.1 = 0 := by
@@ -284,9 +287,11 @@ theorem irreducibleFormalCharacter_zero_ne_zero :
 
 variable {b}
 
-/-- **An irreducible highest weight module of non-dominant weight occurs in no finite-dimensional
-module.** A nonzero morphism out of the irreducible `L(lam)` is injective, so it would make
-`L(lam)` finite-dimensional, hence `lam` dominant integral. -/
+/-- **`L(lam)` of a non-dominant weight has multiplicity zero in every finite-dimensional
+module.** A nonzero multiplicity gives a nonzero morphism out of `L(lam)`, which in particular
+makes `L(lam)` nonzero, hence irreducible (`TauCeti.isIrreducible_irreducibleQuotient`); that
+morphism is then injective, so it would make `L(lam)` finite-dimensional, hence `lam` dominant
+integral. -/
 theorem isotypicMultiplicity_irreducibleQuotient_eq_zero_of_not_isDominantIntegral
     [FiniteDimensional K M] {lam : Dual K H} (hlam : ¬ IsDominantIntegral b lam) :
     LieModule.isotypicMultiplicity K L M (irreducibleQuotient b lam) = 0 := by

--- a/TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean
@@ -224,10 +224,15 @@ theorem nonempty_lieModuleEquiv_directSum_irreducibleQuotient [FiniteDimensional
 
 /-! ### The character of the irreducible module of a dominant integral weight -/
 
-/-- **The formal character of the irreducible module `L(lam)`** of a dominant integral weight
+/-- **The formal character of the highest weight module `L(lam)`** of a dominant integral weight
 `lam`, which `TauCeti.finiteDimensional_irreducibleQuotient_of_isDominantIntegral` makes
 finite-dimensional. The weight is bundled with its dominance so that the character is a function of
-a single argument, and can therefore index a sum. -/
+a single argument, and can therefore index a sum.
+
+`L(lam)` is irreducible exactly where it is nonzero, which is exactly where this character is
+nonzero (`TauCeti.irreducibleFormalCharacter_eq_zero_iff` and
+`TauCeti.isIrreducible_irreducibleQuotient_of_irreducibleFormalCharacter_ne_zero`); at a `lam`
+whose Verma module vanishes this is the character `0` of the zero module. -/
 noncomputable def irreducibleFormalCharacter
     (lam : {l : Dual K H // IsDominantIntegral b l}) : AddMonoidAlgebra ℤ (Dual K H) :=
   haveI := finiteDimensional_irreducibleQuotient_of_isDominantIntegral lam.2

--- a/TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean
@@ -5,11 +5,12 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.Lie.HighestWeight.FiniteDimensional
 public import TauCeti.Algebra.Lie.HighestWeight.Verma
 public import TauCeti.Algebra.Lie.Multiplicity
+public import TauCeti.Algebra.Lie.Weights.FormalCharacter
 -- Non-public: these supply the inputs of the proofs, never the vocabulary of a statement.
 import TauCeti.Algebra.Lie.HighestWeight.CompleteReducibility
-import TauCeti.Algebra.Lie.HighestWeight.FiniteDimensional
 import TauCeti.Algebra.Lie.HighestWeight.Irreducible
 import TauCeti.Algebra.Lie.Submodule.Decomposition
 
@@ -61,12 +62,38 @@ is exactly the Poincaré--Birkhoff--Witt input that
 `TauCeti/Algebra/Lie/HighestWeight/Verma.lean` does not have, and the decomposition below is
 stated so as not to need it.
 
+## The decomposition read on characters
+
+Formal characters are additive over an internal decomposition
+(`TauCeti.formalCharacter_eq_sum_of_isInternal`), so the same regrouping turns the decomposition
+into the character identity `ch M = ∑_λ m_λ · ch L(λ)`, the form in which "decompose `M` into
+irreducibles" becomes a computation. The formal character is defined only for a
+finite-dimensional module, while `L(λ)` is finite-dimensional exactly at a dominant integral `λ`
+(`TauCeti.finiteDimensional_iff_isDominantIntegral_of_isHighestWeightVector`), so the sum does not
+run over all of `Module.Dual K H`: `TauCeti.irreducibleFormalCharacter` names the character of
+`L(λ)` as a function of a weight *bundled with its dominance*, and the sum runs over that subtype.
+`TauCeti.irreducibleFormalCharacter_def` unfolds it wherever the finite-dimensionality instance is
+already at hand, so the definition itself never needs unfolding.
+
+Restricting the sum to the dominant integral weights loses nothing:
+`TauCeti.isotypicMultiplicity_irreducibleQuotient_eq_zero_of_not_isDominantIntegral` says that
+`L(λ)` for a non-dominant `λ` occurs in no finite-dimensional module at all, so every multiplicity
+the sum omits is zero.
+
+## Main definitions
+
+* `TauCeti.irreducibleFormalCharacter`: the formal character of `L(λ)`, at a dominant integral `λ`.
+
 ## Main results
 
 * `TauCeti.natCard_eq_isotypicMultiplicity_irreducibleQuotient`: **the summands of a decomposition
   labelled by a dominant integral `λ` are counted by the multiplicity of `L(λ)`.**
 * `TauCeti.nonempty_lieModuleEquiv_directSum_irreducibleQuotient`: **the packaged isotypic
   decomposition** `M ≃ ⨁_λ L(λ)^{m λ}`.
+* `TauCeti.isotypicMultiplicity_irreducibleQuotient_eq_zero_of_not_isDominantIntegral`: an
+  irreducible highest weight module of non-dominant weight occurs in no finite-dimensional module.
+* `TauCeti.formalCharacter_eq_finsum_isotypicMultiplicity_smul`: **the character of a
+  finite-dimensional module is the multiplicity-weighted sum of the irreducible characters.**
 
 ## References
 
@@ -81,7 +108,8 @@ through the enveloping-algebra dictionary" in the Layer 6 decomposition toolkit 
 
 namespace TauCeti
 
-open LieAlgebra Module
+-- `TauCeti.LieModule` exists in the imports, so the root namespace is named explicitly.
+open LieAlgebra _root_.LieModule Module
 
 open scoped DirectSum
 
@@ -176,5 +204,121 @@ theorem nonempty_lieModuleEquiv_directSum_irreducibleQuotient [FiniteDimensional
       ↔ c i = (s : Dual K H) := fun _ ↦ Subtype.ext_iff
   rw [Nat.card_congr (Equiv.subtypeEquivRight hiff)]
   exact natCard_eq_isotypicMultiplicity_irreducibleQuotient b N hint hirr c hcequiv s.2
+
+/-! ### The character of the irreducible module of a dominant integral weight -/
+
+/-- **The formal character of the irreducible module `L(lam)`** of a dominant integral weight
+`lam`, which `TauCeti.finiteDimensional_irreducibleQuotient_of_isDominantIntegral` makes
+finite-dimensional. The weight is bundled with its dominance so that the character is a function of
+a single argument, and can therefore index a sum. -/
+noncomputable def irreducibleFormalCharacter
+    (lam : {l : Dual K H // IsDominantIntegral b l}) : AddMonoidAlgebra ℤ (Dual K H) :=
+  haveI := finiteDimensional_irreducibleQuotient_of_isDominantIntegral lam.2
+  formalCharacter K H (irreducibleQuotient b lam.1)
+
+-- This private reduction is required by Lean's module system: an exported theorem cannot unfold
+-- the opaque exported definition directly while checking its public signature.
+private theorem irreducibleFormalCharacter_def_aux
+    (lam : {l : Dual K H // IsDominantIntegral b l})
+    [FiniteDimensional K (irreducibleQuotient b lam.1)] :
+    irreducibleFormalCharacter b lam = formalCharacter K H (irreducibleQuotient b lam.1) := rfl
+
+/-- **The character of `L(lam)` is the formal character of `L(lam)`.** With the
+finite-dimensionality instance in hand, `TauCeti.irreducibleFormalCharacter` needs no unfolding. -/
+@[simp]
+theorem irreducibleFormalCharacter_def
+    (lam : {l : Dual K H // IsDominantIntegral b l})
+    [FiniteDimensional K (irreducibleQuotient b lam.1)] :
+    irreducibleFormalCharacter b lam = formalCharacter K H (irreducibleQuotient b lam.1) :=
+  irreducibleFormalCharacter_def_aux b lam
+
+/-! ### The multiplicity-weighted sum of irreducible characters -/
+
+variable {b}
+
+/-- **An irreducible highest weight module of non-dominant weight occurs in no finite-dimensional
+module.** A nonzero morphism out of the irreducible `L(lam)` is injective, so it would make
+`L(lam)` finite-dimensional, hence `lam` dominant integral. -/
+theorem isotypicMultiplicity_irreducibleQuotient_eq_zero_of_not_isDominantIntegral
+    [FiniteDimensional K M] {lam : Dual K H} (hlam : ¬ IsDominantIntegral b lam) :
+    LieModule.isotypicMultiplicity K L M (irreducibleQuotient b lam) = 0 := by
+  by_contra hne
+  -- a nonzero multiplicity produces a nonzero morphism out of `L(lam)`
+  have hsub : ¬ Subsingleton (irreducibleQuotient b lam →ₗ⁅K,L⁆ M) := by
+    intro hsub
+    refine hne ?_
+    rw [LieModule.isotypicMultiplicity_def]
+    have := hsub
+    exact finrank_zero_of_subsingleton
+  obtain ⟨f, hf⟩ : ∃ f : irreducibleQuotient b lam →ₗ⁅K,L⁆ M, f ≠ 0 := by
+    rw [not_subsingleton_iff_nontrivial] at hsub
+    exact exists_ne 0
+  -- so `L(lam)` is nonzero, hence irreducible
+  have h0 : vermaGenerator b lam ≠ 0 := fun h0 ↦ by
+    have := (subsingleton_irreducibleQuotient_iff b lam).mpr h0
+    exact hf (LieModuleHom.ext fun x ↦ by rw [Subsingleton.elim x 0]; simp)
+  have := isIrreducible_irreducibleQuotient b lam h0
+  -- and the morphism is injective, so `L(lam)` is finite-dimensional and `lam` is dominant
+  have hker : f.ker = ⊥ := by
+    refine (IsSimpleOrder.eq_bot_or_eq_top f.ker).resolve_right fun htop ↦ hf ?_
+    refine LieModuleHom.ext fun x ↦ ?_
+    simpa using (htop ▸ LieSubmodule.mem_top x : x ∈ f.ker)
+  have : FiniteDimensional K (irreducibleQuotient b lam) :=
+    Module.Finite.of_injective (f : irreducibleQuotient b lam →ₗ[K] M)
+      ((LieModuleHom.ker_eq_bot f).mp hker)
+  exact hlam ((finiteDimensional_iff_isDominantIntegral_of_isHighestWeightVector
+    (isHighestWeightVector_irreducibleQuotientGenerator b lam h0)).mp inferInstance)
+
+variable (b) in
+/-- **The character of a finite-dimensional module is the multiplicity-weighted sum of the
+irreducible characters.** A decomposition into irreducibles labels each summand by the dominant
+integral weight whose `L(lam)` it is a copy of; characters are additive over the decomposition, and
+the summands carrying a given label are counted by the multiplicity of `L(lam)`
+(`TauCeti.natCard_eq_isotypicMultiplicity_irreducibleQuotient`). -/
+theorem formalCharacter_eq_finsum_isotypicMultiplicity_smul [FiniteDimensional K M] :
+    formalCharacter K H M
+      = ∑ᶠ lam : {l : Dual K H // IsDominantIntegral b l},
+          (LieModule.isotypicMultiplicity K L M (irreducibleQuotient b lam.1) : ℤ) •
+            irreducibleFormalCharacter b lam := by
+  classical
+  have := complementedLattice_lieSubmodule_of_isKilling K L M
+  obtain ⟨k, N, hint, hirr⟩ := exists_isInternal_isIrreducible K L M
+  choose c hcdom hcequiv using fun i ↦
+    have := hirr i
+    exists_isDominantIntegral_nonempty_lieModuleEquiv_irreducibleQuotient
+      (M := (N i : Type w)) b
+  -- the labelling of the summands by dominant integral weights
+  set d : Fin k → {l : Dual K H // IsDominantIntegral b l} := fun i ↦ ⟨c i, hcdom i⟩ with hd
+  have hcard : ∀ lam : {l : Dual K H // IsDominantIntegral b l},
+      (Finset.univ.filter fun i ↦ d i = lam).card
+        = LieModule.isotypicMultiplicity K L M (irreducibleQuotient b lam.1) := by
+    intro lam
+    rw [← natCard_eq_isotypicMultiplicity_irreducibleQuotient b N hint hirr c hcequiv lam.2,
+      Nat.card_eq_fintype_card, Fintype.card_subtype]
+    congr 1
+    ext i
+    simp [hd, Subtype.ext_iff]
+  have hchar : ∀ i, formalCharacter K H (N i : Type w) = irreducibleFormalCharacter b (d i) := by
+    intro i
+    have := finiteDimensional_irreducibleQuotient_of_isDominantIntegral (hcdom i)
+    rw [irreducibleFormalCharacter_def]
+    exact formalCharacter_congr (LieModuleEquiv.restrictLie (hcequiv i).some H)
+  -- the summands with a label outside the image of the labelling are absent, so the sum is finite
+  have hsupp : (Function.support fun lam : {l : Dual K H // IsDominantIntegral b l} ↦
+      (LieModule.isotypicMultiplicity K L M (irreducibleQuotient b lam.1) : ℤ) •
+        irreducibleFormalCharacter b lam) ⊆ (Finset.univ.image d : Finset _) := by
+    intro lam hlam
+    by_contra hmem
+    refine hlam ?_
+    have : (Finset.univ.filter fun i ↦ d i = lam).card = 0 := by
+      refine Finset.card_eq_zero.mpr (Finset.eq_empty_of_forall_notMem fun i hi ↦ hmem ?_)
+      exact Finset.mem_coe.mpr
+        (Finset.mem_image.mpr ⟨i, Finset.mem_univ i, (Finset.mem_filter.mp hi).2⟩)
+    simp only [← hcard lam, this, Nat.cast_zero, zero_smul]
+  rw [finsum_eq_finsetSum_of_support_subset _ hsupp, formalCharacter_eq_sum_of_isInternal hint]
+  simp only [hchar]
+  rw [Finset.sum_comp (fun lam ↦ irreducibleFormalCharacter b lam) d]
+  refine Finset.sum_congr rfl fun lam _ ↦ ?_
+  rw [← Nat.cast_smul_eq_nsmul ℤ, hcard lam]
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.HighestWeight.Decomposition
+
+public section
+
+/-!
+# Tensor multiplicities of irreducible modules
+
+Let `L` be a finite-dimensional Lie algebra with non-degenerate Killing form over an algebraically
+closed field of characteristic zero, `H` a Cartan subalgebra and `b` a base of its root system.
+For dominant integral weights `lam` and `mu` the tensor product `L(lam) ⊗ L(mu)` is a
+finite-dimensional `L`-module, so Weyl's theorem decomposes it into irreducibles; the
+**tensor multiplicity** `TauCeti.tensorMultiplicity b lam mu nu` is the number of copies of
+`L(nu)` in that decomposition, the structure constant `c^nu_{lam mu}`.
+
+The theorem about it is the character identity
+
+`ch L(lam) · ch L(mu) = ∑_nu c^nu_{lam mu} · ch L(nu)`,
+
+which combines two facts already in place: formal characters are multiplicative on tensor products
+(`TauCeti.formalCharacter_tensor`), and the character of a finite-dimensional module is the
+multiplicity-weighted sum of the irreducible characters
+(`TauCeti.formalCharacter_eq_finsum_isotypicMultiplicity_smul`). It is what makes the tensor
+multiplicities computable from characters, and the identity a Pieri or Littlewood-Richardson rule
+evaluates.
+
+## Main definitions
+
+* `TauCeti.tensorMultiplicity`: the multiplicity `c^nu_{lam mu}` of `L(nu)` in `L(lam) ⊗ L(mu)`.
+
+## Main results
+
+* `TauCeti.irreducibleFormalCharacter_mul_eq_finsum_tensorMultiplicity_smul`: **the character
+  identity** `ch L(lam) · ch L(mu) = ∑_nu c^nu_{lam mu} · ch L(nu)`.
+
+## References
+
+This is the tensor-multiplicity item of the milestone "tensor multiplicities and the minuscule
+Pieri rule" in the Layer 6 decomposition toolkit of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`, which asks for `c^ν_{λμ}` "with
+the character identity `ch L(λ) · ch L(μ) = Σ_ν c^ν_{λμ} ch L(ν)` through `formalCharacter_tensor`".
+The minuscule Pieri rule itself, which evaluates these multiplicities, awaits the Weyl character
+formula.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, Ch. VI, §24.
+-/
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+open LieAlgebra Module
+
+universe u v
+
+variable {K : Type u} {L : Type v} [Field K] [CharZero K] [IsAlgClosed K]
+  [LieRing L] [LieAlgebra K L] [IsKilling K L] [FiniteDimensional K L]
+  {H : LieSubalgebra K L} [H.IsCartanSubalgebra]
+
+variable (b : (IsKilling.rootSystem H).Base)
+
+/-- **The tensor multiplicity** `c^nu_{lam mu}`: the number of copies of `L(nu)` in the
+decomposition of `L(lam) ⊗ L(mu)` into irreducibles, that is the multiplicity of `L(nu)` in the
+tensor product in the sense of `LieModule.isotypicMultiplicity`. -/
+noncomputable def tensorMultiplicity (lam mu nu : Dual K H) : ℕ :=
+  LieModule.isotypicMultiplicity K L
+    (irreducibleQuotient b lam ⊗[K] irreducibleQuotient b mu) (irreducibleQuotient b nu)
+
+-- This private reduction is required by Lean's module system: an exported theorem cannot unfold
+-- the opaque exported definition directly while checking its public signature.
+private theorem tensorMultiplicity_def_aux (lam mu nu : Dual K H) :
+    tensorMultiplicity b lam mu nu = LieModule.isotypicMultiplicity K L
+      (irreducibleQuotient b lam ⊗[K] irreducibleQuotient b mu) (irreducibleQuotient b nu) :=
+  (rfl)
+
+/-- The tensor multiplicity is the multiplicity of `L(nu)` in the tensor product. -/
+@[simp]
+theorem tensorMultiplicity_def (lam mu nu : Dual K H) :
+    tensorMultiplicity b lam mu nu = LieModule.isotypicMultiplicity K L
+      (irreducibleQuotient b lam ⊗[K] irreducibleQuotient b mu) (irreducibleQuotient b nu) :=
+  tensorMultiplicity_def_aux b lam mu nu
+
+/-- **The character identity for a tensor product of irreducibles**: the product of the characters
+of `L(lam)` and `L(mu)` is the sum of the characters of the `L(nu)`, weighted by the tensor
+multiplicities.
+
+Formal characters are multiplicative on tensor products, so the left-hand side is the character of
+`L(lam) ⊗ L(mu)`; that module is finite-dimensional, so its character is the
+multiplicity-weighted sum of the irreducible characters. -/
+theorem irreducibleFormalCharacter_mul_eq_finsum_tensorMultiplicity_smul
+    (lam mu : {l : Dual K H // IsDominantIntegral b l}) :
+    irreducibleFormalCharacter b lam * irreducibleFormalCharacter b mu
+      = ∑ᶠ nu : {l : Dual K H // IsDominantIntegral b l},
+          (tensorMultiplicity b lam.1 mu.1 nu.1 : ℤ) • irreducibleFormalCharacter b nu := by
+  have _ := finiteDimensional_irreducibleQuotient_of_isDominantIntegral lam.2
+  have _ := finiteDimensional_irreducibleQuotient_of_isDominantIntegral mu.2
+  simp only [tensorMultiplicity_def]
+  rw [irreducibleFormalCharacter_def, irreducibleFormalCharacter_def,
+    ← formalCharacter_tensor]
+  exact formalCharacter_eq_finsum_isotypicMultiplicity_smul b
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
@@ -14,10 +14,11 @@ public section
 
 Let `L` be a finite-dimensional Lie algebra with non-degenerate Killing form over an algebraically
 closed field of characteristic zero, `H` a Cartan subalgebra and `b` a base of its root system.
-For dominant integral weights `lam` and `mu` the tensor product `L(lam) ⊗ L(mu)` is a
-finite-dimensional `L`-module, so Weyl's theorem decomposes it into irreducibles; the
-**tensor multiplicity** `TauCeti.tensorMultiplicity b lam mu nu` is the number of copies of
-`L(nu)` in that decomposition, the structure constant `c^nu_{lam mu}`. The definition itself, and
+The **tensor multiplicity** `TauCeti.tensorMultiplicity b lam mu nu` is the dimension of the space
+of morphisms `L(nu) →ₗ⁅K,L⁆ L(lam) ⊗ L(mu)`. For dominant integral `lam` and `mu` the tensor
+product is a finite-dimensional `L`-module, so Weyl's theorem decomposes it into irreducibles, and
+at a `nu` with `L(nu)` nonzero, hence irreducible, that dimension is the number of copies of
+`L(nu)` in the decomposition, the structure constant `c^nu_{lam mu}`. The definition itself, and
 the lemmas reading irreducibility off a nonzero multiplicity, ask only for a triangularizable
 Cartan subalgebra; algebraic closure enters with the character identity, which calls on Weyl's
 complete reducibility theorem.
@@ -102,9 +103,15 @@ variable {K : Type u} {L : Type v} [Field K] [CharZero K]
 
 variable (b : (IsKilling.rootSystem H).Base)
 
-/-- **The tensor multiplicity** `c^nu_{lam mu}`: the number of copies of `L(nu)` in the
-decomposition of `L(lam) ⊗ L(mu)` into irreducibles, that is the multiplicity of `L(nu)` in the
-tensor product in the sense of `LieModule.isotypicMultiplicity`. -/
+/-- **The tensor multiplicity** `c^nu_{lam mu}`: the multiplicity of `L(nu)` in
+`L(lam) ⊗ L(mu)` in the sense of `LieModule.isotypicMultiplicity`, that is the dimension of the
+space of morphisms `L(nu) →ₗ⁅K,L⁆ L(lam) ⊗ L(mu)`.
+
+It is the number of copies of `L(nu)` in a decomposition of the tensor product into irreducibles
+when that reading is available: `lam` and `mu` dominant integral, so that the tensor product is
+finite-dimensional and completely reducible, and `L(nu)` nonzero, hence irreducible. At a `nu`
+whose Verma module vanishes it is `0`
+(`LieModule.isotypicMultiplicity_eq_zero_of_subsingleton`). -/
 noncomputable def tensorMultiplicity (lam mu nu : Dual K H) : ℕ :=
   LieModule.isotypicMultiplicity K L
     (irreducibleQuotient b lam ⊗[K] irreducibleQuotient b mu) (irreducibleQuotient b nu)
@@ -143,7 +150,7 @@ theorem isIrreducible_irreducibleQuotient_left_of_tensorMultiplicity_ne_zero
   refine isIrreducible_irreducibleQuotient b lam fun h0 ↦ h ?_
   have _ := (subsingleton_irreducibleQuotient_iff b lam).mpr h0
   rw [tensorMultiplicity_def]
-  exact LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_module K L _ _
+  exact LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_codomain K L _ _
 
 /-- **A nonzero tensor multiplicity makes the right factor an honest irreducible.** Were `L(mu)`
 the zero module, so would be `L(lam) ⊗ L(mu)`, in which nothing has a nonzero multiplicity. -/
@@ -153,7 +160,7 @@ theorem isIrreducible_irreducibleQuotient_right_of_tensorMultiplicity_ne_zero
   refine isIrreducible_irreducibleQuotient b mu fun h0 ↦ h ?_
   have _ := (subsingleton_irreducibleQuotient_iff b mu).mpr h0
   rw [tensorMultiplicity_def]
-  exact LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_module K L _ _
+  exact LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_codomain K L _ _
 
 /-! ### The character identity
 
@@ -166,9 +173,10 @@ section CharacterIdentity
 
 variable [IsAlgClosed K]
 
-/-- **The character identity for a tensor product of irreducibles**: the product of the characters
-of `L(lam)` and `L(mu)` is the sum of the characters of the `L(nu)`, weighted by the tensor
-multiplicities.
+/-- **The character identity for a tensor product of highest weight modules**: the product of the
+characters of `L(lam)` and `L(mu)` is the sum of the characters of the `L(nu)`, weighted by the
+tensor multiplicities. The weights at which `L(nu)` is nonzero, hence irreducible, are the ones
+that contribute: elsewhere both the character and the multiplicity vanish.
 
 Formal characters are multiplicative on tensor products, so the left-hand side is the character of
 `L(lam) ⊗ L(mu)`; that module is finite-dimensional, so its character is the

--- a/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
@@ -17,7 +17,10 @@ closed field of characteristic zero, `H` a Cartan subalgebra and `b` a base of i
 For dominant integral weights `lam` and `mu` the tensor product `L(lam) ⊗ L(mu)` is a
 finite-dimensional `L`-module, so Weyl's theorem decomposes it into irreducibles; the
 **tensor multiplicity** `TauCeti.tensorMultiplicity b lam mu nu` is the number of copies of
-`L(nu)` in that decomposition, the structure constant `c^nu_{lam mu}`.
+`L(nu)` in that decomposition, the structure constant `c^nu_{lam mu}`. The definition itself, and
+the lemmas reading irreducibility off a nonzero multiplicity, ask only for a triangularizable
+Cartan subalgebra; algebraic closure enters with the character identity, which calls on Weyl's
+complete reducibility theorem.
 
 The theorem about it is the character identity
 
@@ -90,9 +93,12 @@ open LieAlgebra Module
 
 universe u v
 
-variable {K : Type u} {L : Type v} [Field K] [CharZero K] [IsAlgClosed K]
+-- Algebraic closure is not assumed here: the highest weight theory of
+-- `TauCeti/Algebra/Lie/HighestWeight/Verma.lean` that the definition rests on asks only for a
+-- triangularizable Cartan subalgebra. It is assumed in the character-identity section below.
+variable {K : Type u} {L : Type v} [Field K] [CharZero K]
   [LieRing L] [LieAlgebra K L] [IsKilling K L] [FiniteDimensional K L]
-  {H : LieSubalgebra K L} [H.IsCartanSubalgebra]
+  {H : LieSubalgebra K L} [H.IsCartanSubalgebra] [_root_.LieModule.IsTriangularizable K H L]
 
 variable (b : (IsKilling.rootSystem H).Base)
 
@@ -149,6 +155,17 @@ theorem isIrreducible_irreducibleQuotient_right_of_tensorMultiplicity_ne_zero
   rw [tensorMultiplicity_def]
   exact LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_module K L _ _
 
+/-! ### The character identity
+
+The character of `L(lam)` is the character of a decomposition into irreducibles, so from here on
+the field is algebraically closed: that is what Weyl's complete reducibility theorem is available
+over in `TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean`.
+-/
+
+section CharacterIdentity
+
+variable [IsAlgClosed K]
+
 /-- **The character identity for a tensor product of irreducibles**: the product of the characters
 of `L(lam)` and `L(mu)` is the sum of the characters of the `L(nu)`, weighted by the tensor
 multiplicities.
@@ -179,19 +196,23 @@ theorem exists_tensorMultiplicity_ne_zero (lam mu : {l : Dual K H // IsDominantI
   have _ := finiteDimensional_irreducibleQuotient_of_isDominantIntegral mu.2
   by_contra hall
   push Not at hall
-  have hid := irreducibleFormalCharacter_mul_eq_finsum_tensorMultiplicity_smul b lam mu
+  -- every term of the sum vanishes, so the product of the two characters does
   have hzero : ∀ nu : {l : Dual K H // IsDominantIntegral b l},
       (tensorMultiplicity b lam.1 mu.1 nu.1 : ℤ) • irreducibleFormalCharacter b nu = 0 := by
     intro nu
     rw [hall nu]
     simp
-  -- every term of the sum vanishes, so the product of the two characters does
-  rw [finsum_congr hzero, finsum_zero, irreducibleFormalCharacter_def,
-    irreducibleFormalCharacter_def, ← formalCharacter_tensor, formalCharacter_eq_zero_iff,
-    Module.finrank_tensorProduct, Nat.mul_eq_zero, Module.finrank_zero_iff,
-    Module.finrank_zero_iff, subsingleton_irreducibleQuotient_iff,
-    subsingleton_irreducibleQuotient_iff] at hid
-  exact hid.elim hlam hmu
+  have hprod : irreducibleFormalCharacter b lam * irreducibleFormalCharacter b mu = 0 := by
+    rw [irreducibleFormalCharacter_mul_eq_finsum_tensorMultiplicity_smul b lam mu,
+      finsum_congr hzero, finsum_zero]
+  -- characters are multiplicative on tensor products, so this is the character of `L(lam) ⊗ L(mu)`
+  -- vanishing, which says that the tensor product is zero-dimensional
+  rw [irreducibleFormalCharacter_def, irreducibleFormalCharacter_def, ← formalCharacter_tensor,
+    formalCharacter_eq_zero_iff, Module.finrank_tensorProduct] at hprod
+  -- so one of the two factors is zero-dimensional, that is, one of the Verma modules vanishes
+  rcases Nat.mul_eq_zero.mp hprod with h | h
+  · exact hlam ((subsingleton_irreducibleQuotient_iff b lam.1).mp (Module.finrank_zero_iff.mp h))
+  · exact hmu ((subsingleton_irreducibleQuotient_iff b mu.1).mp (Module.finrank_zero_iff.mp h))
 
 /-- **At the zero weight the hypothesis of `TauCeti.exists_tensorMultiplicity_ne_zero` holds
 outright**, with no appeal to Poincaré--Birkhoff--Witt: the trivial one-dimensional module makes
@@ -203,5 +224,7 @@ theorem exists_tensorMultiplicity_zero_ne_zero :
   exists_tensorMultiplicity_ne_zero b ⟨0, isDominantIntegral_zero⟩ ⟨0, isDominantIntegral_zero⟩
     (isHighestWeightVector_vermaGenerator_zero b).ne_zero
     (isHighestWeightVector_vermaGenerator_zero b).ne_zero
+
+end CharacterIdentity
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
@@ -30,15 +30,24 @@ multiplicity-weighted sum of the irreducible characters
 multiplicities computable from characters, and the identity a Pieri or Littlewood-Richardson rule
 evaluates.
 
-Nothing here asserts that `L(nu)` is nonzero. Whether `M(nu) ≠ 0`, equivalently `L(nu) ≠ 0`
+Nothing here *assumes* that `L(nu)` is nonzero. Whether `M(nu) ≠ 0`, equivalently `L(nu) ≠ 0`
 (`TauCeti.subsingleton_irreducibleQuotient_iff`), is the Poincaré--Birkhoff--Witt input that
 `TauCeti/Algebra/Lie/HighestWeight/Verma.lean` does not have and that the roadmap stages as a
 sub-project of its own; as in `TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean`, the
-statements here are arranged so as not to need it. At a weight whose Verma module vanishes `L(nu)`
-is the zero module and `c^nu_{lam mu}` is `0`
-(`LieModule.isotypicMultiplicity_eq_zero_of_subsingleton`), so that weight contributes nothing and
-the identity holds either way; PBW would sharpen what the identity says about such a weight without
-changing any statement below.
+statements here are arranged so as not to need it. That arrangement does not leave the
+multiplicities undetermined, and it does not make the identity a statement about zero modules:
+
+* at a weight whose Verma module vanishes `L(nu)` is the zero module and `c^nu_{lam mu}` is `0`
+  (`LieModule.isotypicMultiplicity_eq_zero_of_subsingleton`), the correct count of copies of a zero
+  module in a decomposition into irreducibles, so that weight contributes nothing to the sum;
+* conversely every weight that *does* contribute has `M(nu) ≠ 0`, so `L(nu)` there is genuinely
+  irreducible (`TauCeti.isIrreducible_irreducibleQuotient_of_tensorMultiplicity_ne_zero`), and the
+  same holds of the two characters on the left
+  (`TauCeti.isIrreducible_irreducibleQuotient_of_irreducibleFormalCharacter_ne_zero`);
+* and the identity is not vacuous: `TauCeti.irreducibleFormalCharacter_zero_ne_zero` proves
+  without any appeal to PBW that `L(0)` is a nonzero irreducible with a nonzero character.
+
+PBW would enlarge the set of weights known to contribute, without changing any statement below.
 
 ## Main definitions
 
@@ -48,6 +57,8 @@ changing any statement below.
 
 * `TauCeti.irreducibleFormalCharacter_mul_eq_finsum_tensorMultiplicity_smul`: **the character
   identity** `ch L(lam) · ch L(mu) = ∑_nu c^nu_{lam mu} · ch L(nu)`.
+* `TauCeti.isIrreducible_irreducibleQuotient_of_tensorMultiplicity_ne_zero`: a weight with a
+  nonzero tensor multiplicity has an irreducible `L(nu)`.
 
 ## References
 
@@ -95,6 +106,18 @@ theorem tensorMultiplicity_def (lam mu nu : Dual K H) :
     tensorMultiplicity b lam mu nu = LieModule.isotypicMultiplicity K L
       (irreducibleQuotient b lam ⊗[K] irreducibleQuotient b mu) (irreducibleQuotient b nu) :=
   tensorMultiplicity_def_aux b lam mu nu
+
+/-- **A nonzero tensor multiplicity counts copies of an honest irreducible.** Were `L(nu)` the zero
+module, its multiplicity would vanish (`LieModule.isotypicMultiplicity_eq_zero_of_subsingleton`),
+so every weight that contributes to the character identity has `M(nu) ≠ 0`, and `L(nu)` there is
+irreducible. -/
+theorem isIrreducible_irreducibleQuotient_of_tensorMultiplicity_ne_zero {lam mu nu : Dual K H}
+    (h : tensorMultiplicity b lam mu nu ≠ 0) :
+    LieModule.IsIrreducible K L (irreducibleQuotient b nu) := by
+  refine isIrreducible_irreducibleQuotient b nu fun h0 ↦ h ?_
+  have _ := (subsingleton_irreducibleQuotient_iff b nu).mpr h0
+  rw [tensorMultiplicity_def]
+  exact LieModule.isotypicMultiplicity_eq_zero_of_subsingleton K L _ _
 
 /-- **The character identity for a tensor product of irreducibles**: the product of the characters
 of `L(lam)` and `L(mu)` is the sum of the characters of the `L(nu)`, weighted by the tensor

--- a/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
@@ -40,12 +40,17 @@ multiplicities undetermined, and it does not make the identity a statement about
 * at a weight whose Verma module vanishes `L(nu)` is the zero module and `c^nu_{lam mu}` is `0`
   (`LieModule.isotypicMultiplicity_eq_zero_of_subsingleton`), the correct count of copies of a zero
   module in a decomposition into irreducibles, so that weight contributes nothing to the sum;
-* conversely every weight that *does* contribute has `M(nu) ≠ 0`, so `L(nu)` there is genuinely
-  irreducible (`TauCeti.isIrreducible_irreducibleQuotient_of_tensorMultiplicity_ne_zero`), and the
-  same holds of the two characters on the left
-  (`TauCeti.isIrreducible_irreducibleQuotient_of_irreducibleFormalCharacter_ne_zero`);
-* and the identity is not vacuous: `TauCeti.irreducibleFormalCharacter_zero_ne_zero` proves
-  without any appeal to PBW that `L(0)` is a nonzero irreducible with a nonzero character.
+* conversely a nonzero `c^nu_{lam mu}` forces *all three* of `L(lam)`, `L(mu)` and `L(nu)` to be
+  nonzero, hence irreducible
+  (`TauCeti.isIrreducible_irreducibleQuotient_of_tensorMultiplicity_ne_zero` and its two companions
+  for the factors), so a multiplicity that is not visibly `0` counts copies of an honest irreducible
+  inside a tensor product of two honest irreducibles;
+* the identity never degenerates to `0 = 0`: as soon as `M(lam) ≠ 0` and `M(mu) ≠ 0` some
+  `c^nu_{lam mu}` is nonzero (`TauCeti.exists_tensorMultiplicity_ne_zero`), because
+  `L(lam) ⊗ L(mu)` is then a nonzero finite-dimensional module;
+* and that hypothesis is met unconditionally at `lam = mu = 0`
+  (`TauCeti.exists_tensorMultiplicity_zero_ne_zero`), where `M(0) ≠ 0` comes from the trivial
+  module rather than from PBW.
 
 PBW would enlarge the set of weights known to contribute, without changing any statement below.
 
@@ -57,8 +62,13 @@ PBW would enlarge the set of weights known to contribute, without changing any s
 
 * `TauCeti.irreducibleFormalCharacter_mul_eq_finsum_tensorMultiplicity_smul`: **the character
   identity** `ch L(lam) · ch L(mu) = ∑_nu c^nu_{lam mu} · ch L(nu)`.
-* `TauCeti.isIrreducible_irreducibleQuotient_of_tensorMultiplicity_ne_zero`: a weight with a
-  nonzero tensor multiplicity has an irreducible `L(nu)`.
+* `TauCeti.isIrreducible_irreducibleQuotient_of_tensorMultiplicity_ne_zero`,
+  `TauCeti.isIrreducible_irreducibleQuotient_left_of_tensorMultiplicity_ne_zero` and
+  `TauCeti.isIrreducible_irreducibleQuotient_right_of_tensorMultiplicity_ne_zero`: a nonzero tensor
+  multiplicity makes all three of `L(lam)`, `L(mu)`, `L(nu)` irreducible.
+* `TauCeti.exists_tensorMultiplicity_ne_zero`: **some tensor multiplicity is nonzero** whenever the
+  two Verma modules are, so the character identity is not a statement about zero modules.
+* `TauCeti.exists_tensorMultiplicity_zero_ne_zero`: some `c^nu_{0 0}` is nonzero, unconditionally.
 
 ## References
 
@@ -119,6 +129,26 @@ theorem isIrreducible_irreducibleQuotient_of_tensorMultiplicity_ne_zero {lam mu 
   rw [tensorMultiplicity_def]
   exact LieModule.isotypicMultiplicity_eq_zero_of_subsingleton K L _ _
 
+/-- **A nonzero tensor multiplicity makes the left factor an honest irreducible.** Were `L(lam)`
+the zero module, so would be `L(lam) ⊗ L(mu)`, in which nothing has a nonzero multiplicity. -/
+theorem isIrreducible_irreducibleQuotient_left_of_tensorMultiplicity_ne_zero
+    {lam mu nu : Dual K H} (h : tensorMultiplicity b lam mu nu ≠ 0) :
+    LieModule.IsIrreducible K L (irreducibleQuotient b lam) := by
+  refine isIrreducible_irreducibleQuotient b lam fun h0 ↦ h ?_
+  have _ := (subsingleton_irreducibleQuotient_iff b lam).mpr h0
+  rw [tensorMultiplicity_def]
+  exact LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_module K L _ _
+
+/-- **A nonzero tensor multiplicity makes the right factor an honest irreducible.** Were `L(mu)`
+the zero module, so would be `L(lam) ⊗ L(mu)`, in which nothing has a nonzero multiplicity. -/
+theorem isIrreducible_irreducibleQuotient_right_of_tensorMultiplicity_ne_zero
+    {lam mu nu : Dual K H} (h : tensorMultiplicity b lam mu nu ≠ 0) :
+    LieModule.IsIrreducible K L (irreducibleQuotient b mu) := by
+  refine isIrreducible_irreducibleQuotient b mu fun h0 ↦ h ?_
+  have _ := (subsingleton_irreducibleQuotient_iff b mu).mpr h0
+  rw [tensorMultiplicity_def]
+  exact LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_module K L _ _
+
 /-- **The character identity for a tensor product of irreducibles**: the product of the characters
 of `L(lam)` and `L(mu)` is the sum of the characters of the `L(nu)`, weighted by the tensor
 multiplicities.
@@ -137,5 +167,41 @@ theorem irreducibleFormalCharacter_mul_eq_finsum_tensorMultiplicity_smul
   rw [irreducibleFormalCharacter_def, irreducibleFormalCharacter_def,
     ← formalCharacter_tensor]
   exact formalCharacter_eq_finsum_isotypicMultiplicity_smul b
+
+/-- **The character identity is never a statement about zero modules.** If the two Verma modules
+`M(lam)` and `M(mu)` are nonzero then `L(lam) ⊗ L(mu)` is a nonzero finite-dimensional module, so
+at least one tensor multiplicity is nonzero, and the sum
+`ch L(lam) · ch L(mu) = ∑_nu c^nu_{lam mu} · ch L(nu)` has a term that survives. -/
+theorem exists_tensorMultiplicity_ne_zero (lam mu : {l : Dual K H // IsDominantIntegral b l})
+    (hlam : vermaGenerator b lam.1 ≠ 0) (hmu : vermaGenerator b mu.1 ≠ 0) :
+    ∃ nu : {l : Dual K H // IsDominantIntegral b l}, tensorMultiplicity b lam.1 mu.1 nu.1 ≠ 0 := by
+  have _ := finiteDimensional_irreducibleQuotient_of_isDominantIntegral lam.2
+  have _ := finiteDimensional_irreducibleQuotient_of_isDominantIntegral mu.2
+  by_contra hall
+  push Not at hall
+  have hid := irreducibleFormalCharacter_mul_eq_finsum_tensorMultiplicity_smul b lam mu
+  have hzero : ∀ nu : {l : Dual K H // IsDominantIntegral b l},
+      (tensorMultiplicity b lam.1 mu.1 nu.1 : ℤ) • irreducibleFormalCharacter b nu = 0 := by
+    intro nu
+    rw [hall nu]
+    simp
+  -- every term of the sum vanishes, so the product of the two characters does
+  rw [finsum_congr hzero, finsum_zero, irreducibleFormalCharacter_def,
+    irreducibleFormalCharacter_def, ← formalCharacter_tensor, formalCharacter_eq_zero_iff,
+    Module.finrank_tensorProduct, Nat.mul_eq_zero, Module.finrank_zero_iff,
+    Module.finrank_zero_iff, subsingleton_irreducibleQuotient_iff,
+    subsingleton_irreducibleQuotient_iff] at hid
+  exact hid.elim hlam hmu
+
+/-- **At the zero weight the hypothesis of `TauCeti.exists_tensorMultiplicity_ne_zero` holds
+outright**, with no appeal to Poincaré--Birkhoff--Witt: the trivial one-dimensional module makes
+`M(0) ≠ 0` (`TauCeti.isHighestWeightVector_vermaGenerator_zero`). So there is a weight at which the
+character identity relates honest nonzero irreducibles with a nonzero structure constant. -/
+theorem exists_tensorMultiplicity_zero_ne_zero :
+    ∃ nu : {l : Dual K H // IsDominantIntegral b l},
+      tensorMultiplicity b (0 : Dual K H) 0 nu.1 ≠ 0 :=
+  exists_tensorMultiplicity_ne_zero b ⟨0, isDominantIntegral_zero⟩ ⟨0, isDominantIntegral_zero⟩
+    (isHighestWeightVector_vermaGenerator_zero b).ne_zero
+    (isHighestWeightVector_vermaGenerator_zero b).ne_zero
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Tensor.lean
@@ -30,6 +30,16 @@ multiplicity-weighted sum of the irreducible characters
 multiplicities computable from characters, and the identity a Pieri or Littlewood-Richardson rule
 evaluates.
 
+Nothing here asserts that `L(nu)` is nonzero. Whether `M(nu) ≠ 0`, equivalently `L(nu) ≠ 0`
+(`TauCeti.subsingleton_irreducibleQuotient_iff`), is the Poincaré--Birkhoff--Witt input that
+`TauCeti/Algebra/Lie/HighestWeight/Verma.lean` does not have and that the roadmap stages as a
+sub-project of its own; as in `TauCeti/Algebra/Lie/HighestWeight/Decomposition.lean`, the
+statements here are arranged so as not to need it. At a weight whose Verma module vanishes `L(nu)`
+is the zero module and `c^nu_{lam mu}` is `0`
+(`LieModule.isotypicMultiplicity_eq_zero_of_subsingleton`), so that weight contributes nothing and
+the identity holds either way; PBW would sharpen what the identity says about such a weight without
+changing any statement below.
+
 ## Main definitions
 
 * `TauCeti.tensorMultiplicity`: the multiplicity `c^nu_{lam mu}` of `L(nu)` in `L(lam) ⊗ L(mu)`.

--- a/TauCeti/Algebra/Lie/Multiplicity.lean
+++ b/TauCeti/Algebra/Lie/Multiplicity.lean
@@ -64,7 +64,7 @@ enveloping-algebra dictionary lives,
   finite decomposition of `M` into Lie submodules.**
 * `LieModule.isotypicMultiplicity_eq_zero_of_subsingleton`: the zero module occurs with
   multiplicity zero.
-* `LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_module`: everything occurs in the zero
+* `LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_codomain`: everything occurs in the zero
   module with multiplicity zero.
 * `LieModule.isotypicMultiplicity_self`: an irreducible module occurs in itself with multiplicity
   one.
@@ -142,7 +142,7 @@ theorem isotypicMultiplicity_eq_zero_of_subsingleton [Nontrivial R] [Subsingleto
 /-- **Everything occurs in the zero module with multiplicity zero**: the only morphism into it is
 the zero morphism. -/
 @[simp]
-theorem isotypicMultiplicity_eq_zero_of_subsingleton_module [Nontrivial R] [Subsingleton M] :
+theorem isotypicMultiplicity_eq_zero_of_subsingleton_codomain [Nontrivial R] [Subsingleton M] :
     isotypicMultiplicity R L M S = 0 :=
   have _ : Subsingleton (S →ₗ⁅R,L⁆ M) :=
     ⟨fun _ _ ↦ LieModuleHom.ext fun _ ↦ Subsingleton.elim _ _⟩

--- a/TauCeti/Algebra/Lie/Multiplicity.lean
+++ b/TauCeti/Algebra/Lie/Multiplicity.lean
@@ -64,6 +64,8 @@ enveloping-algebra dictionary lives,
   finite decomposition of `M` into Lie submodules.**
 * `LieModule.isotypicMultiplicity_eq_zero_of_subsingleton`: the zero module occurs with
   multiplicity zero.
+* `LieModule.isotypicMultiplicity_eq_zero_of_subsingleton_module`: everything occurs in the zero
+  module with multiplicity zero.
 * `LieModule.isotypicMultiplicity_self`: an irreducible module occurs in itself with multiplicity
   one.
 * `LieModule.isotypicMultiplicity_eq_of_lieModuleEquiv` and
@@ -135,6 +137,15 @@ theorem isotypicMultiplicity_eq_zero_of_subsingleton [Nontrivial R] [Subsingleto
     isotypicMultiplicity R L M S = 0 :=
   have _ : Subsingleton (S →ₗ⁅R,L⁆ M) :=
     ⟨fun f g ↦ LieModuleHom.ext fun x ↦ by rw [Subsingleton.elim x 0, map_zero, map_zero]⟩
+  Module.finrank_zero_of_subsingleton
+
+/-- **Everything occurs in the zero module with multiplicity zero**: the only morphism into it is
+the zero morphism. -/
+@[simp]
+theorem isotypicMultiplicity_eq_zero_of_subsingleton_module [Nontrivial R] [Subsingleton M] :
+    isotypicMultiplicity R L M S = 0 :=
+  have _ : Subsingleton (S →ₗ⁅R,L⁆ M) :=
+    ⟨fun _ _ ↦ LieModuleHom.ext fun _ ↦ Subsingleton.elim _ _⟩
   Module.finrank_zero_of_subsingleton
 
 end Def

--- a/TauCeti/Algebra/Lie/Weights/FormalCharacter.lean
+++ b/TauCeti/Algebra/Lie/Weights/FormalCharacter.lean
@@ -13,6 +13,10 @@ public import TauCeti.Algebra.Lie.Weights.TensorProduct
 public import TauCeti.Algebra.Lie.Weights.WeylInvariance
 public import TauCeti.LinearAlgebra.Dimension.DirectSum
 public import TauCeti.LinearAlgebra.TensorProduct.Decomposition
+-- Non-public: these supply the inputs of the direct-sum additivity proof, never the vocabulary of
+-- a statement.
+import TauCeti.Algebra.Lie.Submodule.DirectSum
+import TauCeti.Algebra.Lie.Submodule.Finrank
 
 public section
 
@@ -59,6 +63,9 @@ multiplicativity on tensor products expressible.
   `TauCeti.genWeightSpace_prod_eq_bot_iff` and
   `TauCeti.instLinearWeightsProd` the consequences a product of modules needs to have a character
   at all.
+* `TauCeti.formalCharacter_eq_sum_of_isInternal`: **additivity over an internal decomposition.**
+  The character of a module decomposed internally by finitely many Lie submodules is the sum of
+  their characters, the character being read on a nilpotent Lie subalgebra of the acting algebra.
 * `TauCeti.formalCharacter_eq_add_of_exact`: **additivity on short exact sequences.** The
   character of the middle module is the sum of the characters of the submodule and quotient.
 * `TauCeti.finrank_genWeightSpace_tensorProduct`: the multiplicity of a tensor-product weight is
@@ -96,7 +103,8 @@ Layer 2 Weyl invariance proved directly from `sl₂`; both are consumed here.
 
 namespace TauCeti
 
-open LieAlgebra LieModule Module
+-- `TauCeti.LieModule` exists in the imports, so the root namespace is named explicitly.
+open LieAlgebra _root_.LieModule Module
 
 universe u v w w₁
 
@@ -284,6 +292,101 @@ theorem formalCharacter_prod :
   simp
 
 end Prod
+
+/-! ### Additivity over an internal decomposition
+
+An `L`-module `M` decomposed internally by Lie submodules has, at every linear form on a nilpotent
+Lie subalgebra `H` of `L`, a weight space that is the direct sum of the weight spaces of the
+summands, so the weight multiplicities add. This is the two-algebra statement the highest weight
+theory calls for: the decomposition is by submodules for the whole of `L`, while the character is
+read on a Cartan subalgebra `H`.
+-/
+
+section InternalDirectSum
+
+open scoped DirectSum
+
+variable {K : Type u} {L : Type v} [Field K] [LieRing L] [LieAlgebra K L]
+  {H : LieSubalgebra K L} [LieRing.IsNilpotent H]
+  {M : Type w} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+  {ι : Type w₁} {N : ι → LieSubmodule K L M}
+
+omit [LieRing.IsNilpotent H] [LieModule K L M] in
+/-- The inclusion of a summand, restricted to a Lie subalgebra, is injective. -/
+private theorem injective_incl_restrictLie (i : ι) :
+    Function.Injective ((N i).incl.restrictLie H) :=
+  fun _ _ hxy ↦ LieSubmodule.injective_incl (N i) hxy
+
+/-- The image in `M` of the `chi`-weight space of a summand is the part of the `chi`-weight space
+of `M` that the summand carries: the inclusion of the summand is injective, and its range is the
+summand itself. -/
+private theorem toSubmodule_map_genWeightSpace_incl (i : ι) (chi : H → K) :
+    ((genWeightSpace (N i : Type w) chi).map ((N i).incl.restrictLie H)).toSubmodule
+      = (genWeightSpace M chi).toSubmodule ⊓ (N i).toSubmodule := by
+  rw [map_genWeightSpace_eq_of_injective (injective_incl_restrictLie i),
+    LieSubmodule.inf_toSubmodule]
+  congr 1
+  ext x
+  simp
+
+/-- Each summand of an internal decomposition contributes its own `chi`-weight space to the
+`chi`-weight space of the ambient module, with the same dimension. -/
+private theorem finrank_inf_genWeightSpace (i : ι) (chi : H → K) :
+    finrank K ((genWeightSpace M chi).toSubmodule ⊓ (N i).toSubmodule : Submodule K M)
+      = finrank K (genWeightSpace (N i : Type w) chi) := by
+  have hequiv := (LieSubmodule.equivMapOfInjective
+    (genWeightSpace (N i : Type w) chi) (injective_incl_restrictLie i)).toLinearEquiv.finrank_eq
+  rw [← toSubmodule_map_genWeightSpace_incl i chi, finrank_toSubmodule, ← hequiv]
+
+/-- **The weight spaces of the summands span the weight space of the ambient module.** The
+projections onto the summands are morphisms of Lie modules, so they carry the `chi`-weight space of
+`M` into the `chi`-weight spaces of the summands; a vector of the `chi`-weight space is therefore
+the sum of its components, each of which lies in the weight space of a summand. -/
+private theorem iSup_inf_genWeightSpace_eq [Finite ι] [DecidableEq ι]
+    (h : DirectSum.IsInternal fun i ↦ (N i).toSubmodule) (chi : H → K) :
+    ⨆ i, ((genWeightSpace M chi).toSubmodule ⊓ (N i).toSubmodule)
+      = (genWeightSpace M chi).toSubmodule := by
+  classical
+  have _ := Fintype.ofFinite ι
+  refine le_antisymm (iSup_le fun i ↦ inf_le_left) fun m hm ↦ ?_
+  set e := DirectSum.lieModuleEquivOfIsInternal N h with he
+  have hcomp : ∀ i, (e.symm m i : (N i : Type w)) ∈ genWeightSpace (N i : Type w) chi := fun i ↦
+    map_genWeightSpace_le (χ := chi)
+      ((((DirectSum.lieModuleComponent K ι L fun j ↦ (N j : Type w)) i).comp
+        (e.symm : M →ₗ⁅K,L⁆ ⨁ j, (N j : Type w))).restrictLie H) ⟨m, hm, rfl⟩
+  have hmem : ∀ i, ((e.symm m i : (N i : Type w)) : M)
+      ∈ (genWeightSpace M chi).toSubmodule ⊓ (N i).toSubmodule := fun i ↦
+    ⟨map_genWeightSpace_le (χ := chi) ((N i).incl.restrictLie H) ⟨_, hcomp i, rfl⟩,
+      (e.symm m i).2⟩
+  have hsum : m = ∑ i, ((e.symm m i : (N i : Type w)) : M) := by
+    conv_lhs => rw [← e.apply_symm_apply m, ← DirectSum.sum_univ_of (e.symm m)]
+    rw [map_sum]
+    exact Finset.sum_congr rfl fun i _ ↦ by simp [he]
+  rw [hsum]
+  exact Submodule.sum_mem _ fun i _ ↦ Submodule.mem_iSup_of_mem i (hmem i)
+
+variable [FiniteDimensional K M] [LinearWeights K H M] [∀ i, LinearWeights K H (N i : Type w)]
+  [Fintype ι] [DecidableEq ι]
+
+/-- **Formal characters are additive over an internal decomposition into Lie submodules.** The
+`chi`-weight space of the ambient module is the direct sum of the `chi`-weight spaces of the
+summands, so the weight multiplicities add. -/
+theorem formalCharacter_eq_sum_of_isInternal
+    (h : DirectSum.IsInternal fun i ↦ (N i).toSubmodule) :
+    formalCharacter K H M = ∑ i, formalCharacter K H (N i : Type w) := by
+  refine AddMonoidAlgebra.ext (Finsupp.ext fun chi ↦ ?_)
+  rw [AddMonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
+  simp only [formalCharacter_coeff]
+  rw [← Nat.cast_sum]
+  refine congrArg _ ?_
+  have hindep : iSupIndep fun i ↦
+      ((genWeightSpace M (chi : H → K)).toSubmodule ⊓ (N i).toSubmodule) :=
+    h.submodule_iSupIndep.mono fun i ↦ inf_le_right
+  rw [← finrank_toSubmodule, ← iSup_inf_genWeightSpace_eq h (chi : H → K),
+    finrank_iSup_eq_sum_finrank_of_iSupIndep hindep]
+  exact Finset.sum_congr rfl fun i _ ↦ finrank_inf_genWeightSpace i (chi : H → K)
+
+end InternalDirectSum
 
 /-! ### Additivity on short exact sequences -/
 

--- a/TauCeti/Algebra/Lie/Weights/FormalCharacter.lean
+++ b/TauCeti/Algebra/Lie/Weights/FormalCharacter.lean
@@ -13,10 +13,9 @@ public import TauCeti.Algebra.Lie.Weights.TensorProduct
 public import TauCeti.Algebra.Lie.Weights.WeylInvariance
 public import TauCeti.LinearAlgebra.Dimension.DirectSum
 public import TauCeti.LinearAlgebra.TensorProduct.Decomposition
--- Non-public: these supply the inputs of the direct-sum additivity proof, never the vocabulary of
+-- Non-public: this supplies the inputs of the direct-sum additivity proof, never the vocabulary of
 -- a statement.
 import TauCeti.Algebra.Lie.Submodule.DirectSum
-import TauCeti.Algebra.Lie.Submodule.Finrank
 
 public section
 


### PR DESCRIPTION
This PR names the tensor multiplicity `c^ν_{λμ}` of `L(ν)` in `L(λ) ⊗ L(μ)` for a Killing-semisimple Lie algebra over an algebraically closed field of characteristic zero, and proves the character identity that computes it, `ch L(λ) · ch L(μ) = ∑_ν c^ν_{λμ} · ch L(ν)`. It supplies the two facts that identity rests on: formal characters are additive over an internal decomposition into Lie submodules, and the character of a finite-dimensional module is the multiplicity-weighted sum of the irreducible characters, `ch M = ∑_λ m_λ · ch L(λ)`.

This advances the milestone "tensor multiplicities and the minuscule Pieri rule" in the Layer 6 decomposition toolkit of `RepresentationTheory/LieHighestWeight/README.md`, which pins `tensorMultiplicity` and asks for it "with the character identity `ch L(λ) · ch L(μ) = Σ_ν c^ν_{λμ} ch L(ν)` through `formalCharacter_tensor`"; `Suggested.lean` pins the same signature as `tensorMultiplicity base lam mu nu`. Its stated prerequisite stages are on `main`: Layer 5 complete reducibility (`exists_isCompl_of_isKilling`), the Layer 4 finite-dimensionality criterion (`finiteDimensional_irreducibleQuotient_of_isDominantIntegral`), the packaged isotypic decomposition (`nonempty_lieModuleEquiv_directSum_irreducibleQuotient`), and `formalCharacter_tensor`. What remains of the milestone after this PR is the minuscule Pieri rule itself, which evaluates these multiplicities and needs the Weyl character formula.

The formal character is defined only for a finite-dimensional module, while `L(λ)` is finite-dimensional exactly at a dominant integral `λ`, so the sums run over the weights bundled with their dominance and `irreducibleFormalCharacter` names the character of `L(λ)` there. `isotypicMultiplicity_irreducibleQuotient_eq_zero_of_not_isDominantIntegral` records that this restriction omits nothing: `L(λ)` for a non-dominant `λ` occurs in no finite-dimensional module.

Additivity over an internal decomposition is stated on `formalCharacter` in its own file, for a decomposition by submodules over the acting algebra and a character read on a nilpotent subalgebra of it; `LieModuleEquiv.restrictLie`, the equivalence counterpart of Mathlib's `LieModuleHom.restrictLie`, joins the general Lie-module infrastructure. Nothing is vendored, and the argument follows Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §6.3 and Ch. VI, §24.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"tensormultiplicity"}-->

🤖 Prepared with Claude Code
