### PR TITLE
feat: base change coalgebra comodules

### DIFF
--- a/TauCeti/Algebra/Coalgebra/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/BaseChange.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.RingTheory.Coalgebra.TensorProduct
+
+/-!
+# Base change of coalgebras
+
+This file records formulas for the coalgebra structure on a scalar extension `A ⊗[R] H`.
+
+## Main declarations
+
+* `TauCeti.Coalgebra.baseChange_comul_tmul`: the comultiplication of a scalar extension on
+  pure tensors.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.Coalgebra
+
+universe u v w
+
+variable {R : Type u} (A : Type v) {H : Type w}
+variable [CommSemiring R] [CommSemiring A] [Algebra R A]
+variable [AddCommMonoid H] [Module R H] [CoalgebraStruct R H]
+
+/-- The comultiplication of a base-changed coalgebra on a pure tensor. -/
+theorem baseChange_comul_tmul (a : A) (h : H) :
+    Coalgebra.comul (R := A) (A := A ⊗[R] H) (a ⊗ₜ[R] h) =
+      TensorProduct.AlgebraTensorModule.distribBaseChange R A H H
+        (a ⊗ₜ[R] Coalgebra.comul (R := R) (A := H) h) := by
+  rw [TensorProduct.comul_tmul, CommSemiring.comul_apply]
+  induction Coalgebra.comul (R := R) (A := H) h using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
+  | tmul g k =>
+      simp only [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
+        TensorProduct.AlgebraTensorModule.distribBaseChange_tmul]
+      rw [TensorProduct.tmul_eq_smul_one_tmul a g,
+        TensorProduct.tmul_eq_smul_one_tmul a k, TensorProduct.tmul_smul]
+      exact TensorProduct.smul_tmul' a (1 ⊗ₜ[R] g) (1 ⊗ₜ[R] k)
+
+end TauCeti.Coalgebra

--- a/TauCeti/Algebra/Coalgebra/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/BaseChange.lean
@@ -31,6 +31,7 @@ variable [CommSemiring R] [CommSemiring A] [Algebra R A]
 variable [AddCommMonoid H] [Module R H] [CoalgebraStruct R H]
 
 /-- The comultiplication of a base-changed coalgebra on a pure tensor. -/
+@[simp]
 theorem baseChange_comul_tmul (a : A) (h : H) :
     Coalgebra.comul (R := A) (A := A ⊗[R] H) (a ⊗ₜ[R] h) =
       TensorProduct.AlgebraTensorModule.distribBaseChange R A H H

--- a/TauCeti/Algebra/Coalgebra/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/BaseChange.lean
@@ -33,10 +33,10 @@ variable [AddCommMonoid H] [Module R H] [CoalgebraStruct R H]
 /-- The comultiplication of a base-changed coalgebra on a pure tensor. -/
 @[simp]
 theorem baseChange_comul_tmul (a : A) (h : H) :
-    Coalgebra.comul (R := A) (A := A ⊗[R] H) (a ⊗ₜ[R] h) =
+    TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R A R A A A H H
+        (1 ⊗ₜ[A] a ⊗ₜ[R] Coalgebra.comul (R := R) (A := H) h) =
       TensorProduct.AlgebraTensorModule.distribBaseChange R A H H
         (a ⊗ₜ[R] Coalgebra.comul (R := R) (A := H) h) := by
-  rw [TensorProduct.comul_tmul, CommSemiring.comul_apply]
   induction Coalgebra.comul (R := R) (A := H) h using TensorProduct.induction_on with
   | zero => simp
   | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]

--- a/TauCeti/Algebra/Coalgebra/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/BaseChange.lean
@@ -31,12 +31,11 @@ variable [CommSemiring R] [CommSemiring A] [Algebra R A]
 variable [AddCommMonoid H] [Module R H] [CoalgebraStruct R H]
 
 /-- The comultiplication of a base-changed coalgebra on a pure tensor. -/
-@[simp]
 theorem baseChange_comul_tmul (a : A) (h : H) :
-    TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R A R A A A H H
-        (1 ⊗ₜ[A] a ⊗ₜ[R] Coalgebra.comul (R := R) (A := H) h) =
+    Coalgebra.comul (R := A) (A := A ⊗[R] H) (a ⊗ₜ[R] h) =
       TensorProduct.AlgebraTensorModule.distribBaseChange R A H H
         (a ⊗ₜ[R] Coalgebra.comul (R := R) (A := H) h) := by
+  rw [TensorProduct.comul_tmul, CommSemiring.comul_apply]
   induction Coalgebra.comul (R := R) (A := H) h using TensorProduct.induction_on with
   | zero => simp
   | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]

--- a/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
@@ -5,7 +5,7 @@ Authors: Codex
 -/
 module
 
-public import Mathlib.RingTheory.Coalgebra.TensorProduct
+public import TauCeti.Algebra.Coalgebra.BaseChange
 public import TauCeti.Algebra.Coalgebra.Comodule.Basic
 
 /-!
@@ -36,8 +36,6 @@ needed to compare geometric unipotence before and after a field extension.
 * `TauCeti.Comodule.baseChange`: the induced comodule structure over the base-changed
   coefficient coalgebra, selected explicitly as a local instance.
 * `TauCeti.Comodule.baseChangeCoact_tmul`: the coaction formula on pure tensors.
-* `TauCeti.Comodule.comul_one_tmul`: the comultiplication formula for the base-changed
-  coalgebra on tensors whose scalar factor is one.
 * `TauCeti.Comodule.baseChange_self`: base change of the regular comodule agrees with the
   regular comodule of the base-changed coalgebra.
 * `TauCeti.Comodule.Hom.baseChange`: base change of a comodule morphism.
@@ -120,20 +118,6 @@ private theorem collapseTriple_coact (a : A) (z : M ⊗[R] H) :
       exact collapseTriple_tmul (R := R) (H := H) (M := M) A a
         (coact (R := R) (C := H) (M := M) m) h
 
-/-- The comultiplication of the base-changed coalgebra on a pure tensor whose scalar factor is
-one. -/
-theorem comul_one_tmul (h : H) :
-    Coalgebra.comul (R := A) (A := A ⊗[R] H) (1 ⊗ₜ[R] h) =
-      TensorProduct.AlgebraTensorModule.distribBaseChange R A H H
-        (1 ⊗ₜ[R] Coalgebra.comul (R := R) (A := H) h) := by
-  rw [TensorProduct.comul_tmul, CommSemiring.comul_apply]
-  induction Coalgebra.comul (R := R) (A := H) h using TensorProduct.induction_on with
-  | zero => simp
-  | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
-  | tmul g k =>
-      simp only [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
-        TensorProduct.AlgebraTensorModule.distribBaseChange_tmul]
-
 omit [Coalgebra R H] [Comodule R H M] in
 private theorem collapseTriple_comulTensor (a : A) (m : M) (z : H ⊗[R] H) :
     collapseTriple (R := R) (H := H) (M := M) A
@@ -157,7 +141,7 @@ private theorem collapseTriple_comul (a : A) (z : M ⊗[R] H) :
   | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
   | tmul m h =>
       rw [TensorProduct.AlgebraTensorModule.distribBaseChange_tmul,
-        LinearMap.lTensor_tmul, comul_one_tmul,
+        LinearMap.lTensor_tmul, TauCeti.Coalgebra.baseChange_comul_tmul,
         collapseTriple_comulTensor, LinearMap.lTensor_tmul]
 
 omit [Comodule R H M] in
@@ -184,7 +168,7 @@ same scalar morphism gives a comodule over the base-changed coalgebra.
 
 This is deliberately not a global instance because a module can carry multiple coactions.
 Downstream code should select it explicitly, typically as a local instance. -/
-@[expose, instance_reducible]
+@[instance_reducible]
 noncomputable def baseChange : Comodule A (A ⊗[R] H) (A ⊗[R] M) where
   coact := baseChangeCoact (R := R) (H := H) A
   coassoc := by
@@ -209,8 +193,7 @@ followed by distribution across the two tensor factors. -/
 theorem baseChange_coact :
     letI := baseChange (R := R) (H := H) (M := M) A
     coact (R := A) (C := A ⊗[R] H) (M := A ⊗[R] M) =
-      baseChangeCoact (R := R) (H := H) A :=
-  rfl
+      baseChangeCoact (R := R) (H := H) A := (rfl)
 
 /-- Base change of the regular comodule is the regular comodule of the base-changed
 coalgebra. -/
@@ -222,7 +205,8 @@ theorem baseChange_self :
   intro a h
   rw [baseChangeCoact_tmul, instSelf_coact,
     TensorProduct.tmul_eq_smul_one_tmul a (Coalgebra.comul (R := R) (A := H) h),
-    TensorProduct.tmul_eq_smul_one_tmul a h, map_smul, map_smul, comul_one_tmul]
+    TensorProduct.tmul_eq_smul_one_tmul a h, map_smul, map_smul,
+    TauCeti.Coalgebra.baseChange_comul_tmul]
 
 namespace Hom
 
@@ -231,7 +215,7 @@ variable {P : Type z} [AddCommMonoid P] [Module R P] [Comodule R H P]
 
 /-- Base change of a comodule morphism, extending its source and target modules together with its
 coefficient coalgebra along the same scalar morphism. -/
-@[expose] noncomputable def baseChange (f : Hom R H M N) :
+noncomputable def baseChange (f : Hom R H M N) :
     letI := Comodule.baseChange (R := R) (H := H) (M := M) A
     letI := Comodule.baseChange (R := R) (H := H) (M := N) A
     Hom A (A ⊗[R] H) (A ⊗[R] M) (A ⊗[R] N) := by
@@ -256,16 +240,11 @@ underlying linear map. -/
 theorem baseChange_toLinearMap (f : Hom R H M N) :
     letI := Comodule.baseChange (R := R) (H := H) (M := M) A
     letI := Comodule.baseChange (R := R) (H := H) (M := N) A
-    (baseChange A f).toLinearMap = f.toLinearMap.baseChange A :=
-  rfl
+    (baseChange A f).toLinearMap = f.toLinearMap.baseChange A := (rfl)
 
-/-- Base change preserves the identity comodule morphism.
-
-This is not a `simp` lemma: once `ComoduleCat` is imported, the `@[simp]` lemma
-`ComoduleCat.ofHom_id` rewrites the bare `Comodule.Hom.id` in the left-hand side to a categorical
-identity. Since `ComoduleCat.ofHom` is a reducible abbreviation, that rewrite applies even though
-the categorical wrapper is not syntactically present here, so tagging this theorem with `@[simp]`
-would make its left-hand side fail the `simpNF` linter. -/
+/-- Base change preserves the identity comodule morphism. -/
+-- This is not a `simp` lemma: after importing `ComoduleCat`, its `ofHom_id` simp lemma rewrites
+-- the reducibly wrapped `Comodule.Hom.id`, so this theorem would fail the `simpNF` linter.
 theorem baseChange_id :
     letI := Comodule.baseChange (R := R) (H := H) (M := M) A
     baseChange A (id R H M) = id A (A ⊗[R] H) (A ⊗[R] M) := by

--- a/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
@@ -52,7 +52,7 @@ open scoped TensorProduct
 
 namespace TauCeti.Comodule
 
-universe u v w x y
+universe u v w x y z
 
 variable {R : Type u} {H : Type v} {M : Type w} (A : Type x)
 variable [CommSemiring R] [CommSemiring A] [Algebra R A]
@@ -68,6 +68,7 @@ noncomputable def baseChangeCoact :
 
 /-- On a pure tensor, the base-changed coaction applies the old coaction and distributes the
 new scalar across the two extended tensor factors. -/
+@[simp]
 theorem baseChangeCoact_tmul (a : A) (m : M) :
     baseChangeCoact (R := R) (H := H) A (a ⊗ₜ[R] m) =
       (TensorProduct.AlgebraTensorModule.distribBaseChange R A M H)
@@ -123,7 +124,9 @@ private theorem tensorTensorTensorComm_one_one (z : H ⊗[R] H) :
   induction z using TensorProduct.induction_on with
   | zero => simp
   | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
-  | tmul g h => rfl
+  | tmul g h =>
+      simp only [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
+        TensorProduct.AlgebraTensorModule.distribBaseChange_tmul]
 
 private theorem comul_one_tmul (h : H) :
     Coalgebra.comul (R := A) (A := A ⊗[R] H) (1 ⊗ₜ[R] h) =
@@ -178,8 +181,8 @@ private theorem rid_counit_distrib (a : A) (z : M ⊗[R] H) :
       rw [TensorProduct.tmul_smul]
       simp [Algebra.smul_def, mul_comm]
 
-/-- Extending the coefficient Hopf algebra and the underlying module of a comodule along the
-same scalar morphism gives a comodule over the base-changed Hopf algebra. -/
+/-- Extending the coefficient coalgebra and the underlying module of a comodule along the
+same scalar morphism gives a comodule over the base-changed coalgebra. -/
 @[expose, instance_reducible]
 noncomputable def baseChange : Comodule A (A ⊗[R] H) (A ⊗[R] M) where
   coact := baseChangeCoact (R := R) (H := H) A
@@ -201,6 +204,7 @@ noncomputable def baseChange : Comodule A (A ⊗[R] H) (A ⊗[R] M) where
 
 /-- The coaction of the base-changed comodule is scalar extension of the original coaction,
 followed by distribution across the two tensor factors. -/
+@[simp]
 theorem baseChange_coact :
     letI := baseChange (R := R) (H := H) (M := M) A
     coact (R := A) (C := A ⊗[R] H) (M := A ⊗[R] M) =
@@ -212,15 +216,17 @@ theorem baseChange_coact_tmul (a : A) (m : M) :
     letI := baseChange (R := R) (H := H) (M := M) A
     coact (R := A) (C := A ⊗[R] H) (M := A ⊗[R] M) (a ⊗ₜ[R] m) =
       (TensorProduct.AlgebraTensorModule.distribBaseChange R A M H)
-        (a ⊗ₜ[R] coact (R := R) (C := H) (M := M) m) :=
-  baseChangeCoact_tmul (R := R) (H := H) A a m
+        (a ⊗ₜ[R] coact (R := R) (C := H) (M := M) m) := by
+    rw [baseChange_coact]
+    exact baseChangeCoact_tmul (R := R) (H := H) A a m
 
 namespace Hom
 
 variable {N : Type y} [AddCommMonoid N] [Module R N] [Comodule R H N]
+variable {P : Type z} [AddCommMonoid P] [Module R P] [Comodule R H P]
 
-/-- Base change of a comodule morphism, extending both its source and its coefficient coalgebra
-algebra along the same scalar morphism. -/
+/-- Base change of a comodule morphism, extending its source and target modules together with its
+coefficient coalgebra along the same scalar morphism. -/
 @[expose] noncomputable def baseChange (f : Hom R H M N) :
     letI := Comodule.baseChange (R := R) (H := H) (M := M) A
     letI := Comodule.baseChange (R := R) (H := H) (M := N) A
@@ -249,14 +255,44 @@ theorem baseChange_toLinearMap (f : Hom R H M N) :
     (baseChange A f).toLinearMap = f.toLinearMap.baseChange A :=
   rfl
 
+/-- Base change preserves the identity comodule morphism. -/
+@[simp]
+theorem baseChange_id :
+    letI := Comodule.baseChange (R := R) (H := H) (M := M) A
+    baseChange A (id R H M) = id A (A ⊗[R] H) (A ⊗[R] M) := by
+  let _ := Comodule.baseChange (R := R) (H := H) (M := M) A
+  apply ext
+  intro x
+  exact LinearMap.congr_fun (by
+    rw [baseChange_toLinearMap, id_toLinearMap, LinearMap.baseChange_id, id_toLinearMap]) x
+
+/-- Base change preserves composition of comodule morphisms. -/
+@[simp]
+theorem baseChange_comp (g : Hom R H N P) (f : Hom R H M N) :
+    letI := Comodule.baseChange (R := R) (H := H) (M := M) A
+    letI := Comodule.baseChange (R := R) (H := H) (M := N) A
+    letI := Comodule.baseChange (R := R) (H := H) (M := P) A
+    baseChange A (g.comp f) = (baseChange A g).comp (baseChange A f) := by
+  let _ := Comodule.baseChange (R := R) (H := H) (M := M) A
+  let _ := Comodule.baseChange (R := R) (H := H) (M := N) A
+  let _ := Comodule.baseChange (R := R) (H := H) (M := P) A
+  apply ext
+  intro x
+  exact LinearMap.congr_fun (by
+    rw [baseChange_toLinearMap, comp_toLinearMap, LinearMap.baseChange_comp,
+      comp_toLinearMap, baseChange_toLinearMap, baseChange_toLinearMap]) x
+
 /-- A base-changed comodule morphism acts on a pure tensor by applying the original morphism
 to the module factor. -/
 @[simp]
 theorem baseChange_tmul (f : Hom R H M N) (a : A) (m : M) :
     letI := Comodule.baseChange (R := R) (H := H) (M := M) A
     letI := Comodule.baseChange (R := R) (H := H) (M := N) A
-    baseChange A f (a ⊗ₜ[R] m) = a ⊗ₜ[R] f m :=
-  rfl
+    baseChange A f (a ⊗ₜ[R] m) = a ⊗ₜ[R] f m := by
+  let _ := Comodule.baseChange (R := R) (H := H) (M := M) A
+  let _ := Comodule.baseChange (R := R) (H := H) (M := N) A
+  rw [← coe_toLinearMap (baseChange A f), baseChange_toLinearMap,
+    LinearMap.baseChange_tmul, coe_toLinearMap]
 
 end Hom
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
@@ -141,8 +141,7 @@ private theorem collapseTriple_comul (a : A) (z : M ⊗[R] H) :
   | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
   | tmul m h =>
       rw [TensorProduct.AlgebraTensorModule.distribBaseChange_tmul,
-        LinearMap.lTensor_tmul, TensorProduct.comul_tmul, CommSemiring.comul_apply,
-        TauCeti.Coalgebra.baseChange_comul_tmul,
+        LinearMap.lTensor_tmul, TauCeti.Coalgebra.baseChange_comul_tmul,
         collapseTriple_comulTensor, LinearMap.lTensor_tmul]
 
 omit [Comodule R H M] in
@@ -207,7 +206,6 @@ theorem baseChange_self :
   rw [baseChangeCoact_tmul, instSelf_coact,
     TensorProduct.tmul_eq_smul_one_tmul a (Coalgebra.comul (R := R) (A := H) h),
     TensorProduct.tmul_eq_smul_one_tmul a h, map_smul, map_smul,
-    TensorProduct.comul_tmul, CommSemiring.comul_apply,
     TauCeti.Coalgebra.baseChange_comul_tmul]
 
 namespace Hom

--- a/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
@@ -1,0 +1,263 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.RingTheory.Coalgebra.TensorProduct
+public import TauCeti.Algebra.Coalgebra.Comodule.Basic
+
+/-!
+# Base change of comodules and their coefficient coalgebras
+
+Let `H` be a coalgebra over a commutative semiring `R`, let `A` be a commutative
+`R`-algebra, and let `M` be a right `H`-comodule. Extending scalars in both the coefficient
+coalgebra and the underlying module gives a right comodule
+
+```text
+A ⊗[R] M  over  A ⊗[R] H.
+```
+
+The coaction is scalar extension of the original coaction followed by the canonical
+distributivity equivalence
+
+```text
+A ⊗[R] (M ⊗[R] H) ≃ (A ⊗[R] M) ⊗[A] (A ⊗[R] H).
+```
+
+This is coefficient-ring base change, rather than the existing scalar-extension functor that
+only changes the module on which an `H`-valued point acts. It is the representation transport
+needed to compare geometric unipotence before and after a field extension.
+
+## Main declarations
+
+* `TauCeti.Comodule.baseChangeCoact`: the base-changed coaction.
+* `TauCeti.Comodule.baseChange`: the induced comodule structure over the base-changed
+  coefficient coalgebra.
+* `TauCeti.Comodule.baseChangeCoact_tmul`: the coaction formula on pure tensors.
+* `TauCeti.Comodule.Hom.baseChange`: base change of a comodule morphism.
+
+## References
+
+* M. Sweedler, *Hopf Algebras*, Chapter 2.
+
+This supplies a prerequisite for base-change invariance of geometric unipotence and hence for
+comparison of unipotent radicals in Layer 5 of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.Comodule
+
+universe u v w x y
+
+variable {R : Type u} {H : Type v} {M : Type w} (A : Type x)
+variable [CommSemiring R] [CommSemiring A] [Algebra R A]
+variable [AddCommMonoid H] [Module R H] [Coalgebra R H]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+
+/-- The scalar extension of a coaction, with the scalar extension distributed across its two
+tensor factors. -/
+noncomputable def baseChangeCoact :
+    A ⊗[R] M →ₗ[A] (A ⊗[R] M) ⊗[A] (A ⊗[R] H) :=
+  (TensorProduct.AlgebraTensorModule.distribBaseChange R A M H).toLinearMap ∘ₗ
+    (coact (R := R) (C := H) (M := M)).baseChange A
+
+/-- On a pure tensor, the base-changed coaction applies the old coaction and distributes the
+new scalar across the two extended tensor factors. -/
+theorem baseChangeCoact_tmul (a : A) (m : M) :
+    baseChangeCoact (R := R) (H := H) A (a ⊗ₜ[R] m) =
+      (TensorProduct.AlgebraTensorModule.distribBaseChange R A M H)
+        (a ⊗ₜ[R] coact (R := R) (C := H) (M := M) m) := by
+  rw [baseChangeCoact, LinearMap.coe_comp, Function.comp_apply,
+    LinearMap.baseChange_tmul]
+  rfl
+
+/-- Collapse a threefold tensor product of scalar extensions to the scalar extension of the
+original threefold tensor product. -/
+private noncomputable def collapseTriple :
+    (A ⊗[R] M) ⊗[A] ((A ⊗[R] H) ⊗[A] (A ⊗[R] H)) ≃ₗ[A]
+      A ⊗[R] (M ⊗[R] (H ⊗[R] H)) :=
+  (TensorProduct.congr (LinearEquiv.refl A (A ⊗[R] M))
+      (TensorProduct.AlgebraTensorModule.distribBaseChange R A H H).symm).trans
+    (TensorProduct.AlgebraTensorModule.distribBaseChange R A M (H ⊗[R] H)).symm
+
+omit [Coalgebra R H] [Comodule R H M] in
+private theorem collapseTriple_tmul (a : A) (z : M ⊗[R] H) (h : H) :
+    collapseTriple (R := R) (H := H) (M := M) A
+        (TensorProduct.assoc A (A ⊗[R] M) (A ⊗[R] H) (A ⊗[R] H)
+          ((TensorProduct.AlgebraTensorModule.distribBaseChange R A M H
+            (a ⊗ₜ[R] z)) ⊗ₜ[A] (1 ⊗ₜ[R] h))) =
+      a ⊗ₜ[R] TensorProduct.assoc R M H H (z ⊗ₜ[R] h) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy =>
+      simp only [TensorProduct.tmul_add, TensorProduct.add_tmul, map_add, hx, hy]
+  | tmul m g => simp [collapseTriple]
+
+private theorem collapseTriple_coact (a : A) (z : M ⊗[R] H) :
+    collapseTriple (R := R) (H := H) (M := M) A
+        (TensorProduct.assoc A (A ⊗[R] M) (A ⊗[R] H) (A ⊗[R] H)
+          ((baseChangeCoact (R := R) (H := H) A).rTensor (A ⊗[R] H)
+            ((TensorProduct.AlgebraTensorModule.distribBaseChange R A M H)
+              (a ⊗ₜ[R] z)))) =
+      a ⊗ₜ[R] TensorProduct.assoc R M H H
+        ((coact (R := R) (C := H) (M := M)).rTensor H z) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
+  | tmul m h =>
+      rw [TensorProduct.AlgebraTensorModule.distribBaseChange_tmul,
+        LinearMap.rTensor_tmul, baseChangeCoact_tmul, LinearMap.rTensor_tmul]
+      exact collapseTriple_tmul (R := R) (H := H) (M := M) A a
+        (coact (R := R) (C := H) (M := M) m) h
+
+omit [Coalgebra R H] in
+private theorem tensorTensorTensorComm_one_one (z : H ⊗[R] H) :
+    TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R A R A A A H H
+        ((1 ⊗ₜ[A] 1) ⊗ₜ[R] z) =
+      TensorProduct.AlgebraTensorModule.distribBaseChange R A H H (1 ⊗ₜ[R] z) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
+  | tmul g h => rfl
+
+private theorem comul_one_tmul (h : H) :
+    Coalgebra.comul (R := A) (A := A ⊗[R] H) (1 ⊗ₜ[R] h) =
+      TensorProduct.AlgebraTensorModule.distribBaseChange R A H H
+        (1 ⊗ₜ[R] Coalgebra.comul (R := R) (A := H) h) := by
+  rw [TensorProduct.comul_tmul, CommSemiring.comul_apply]
+  exact tensorTensorTensorComm_one_one (R := R) (H := H) A
+    (Coalgebra.comul (R := R) (A := H) h)
+
+omit [Coalgebra R H] [Comodule R H M] in
+private theorem collapseTriple_comulTensor (a : A) (m : M) (z : H ⊗[R] H) :
+    collapseTriple (R := R) (H := H) (M := M) A
+        ((a ⊗ₜ[R] m) ⊗ₜ[A]
+          (TensorProduct.AlgebraTensorModule.distribBaseChange R A H H (1 ⊗ₜ[R] z))) =
+      a ⊗ₜ[R] (m ⊗ₜ[R] z) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
+  | tmul g h => simp [collapseTriple]
+
+omit [Comodule R H M] in
+private theorem collapseTriple_comul (a : A) (z : M ⊗[R] H) :
+    collapseTriple (R := R) (H := H) (M := M) A
+        (Coalgebra.comul.lTensor (A ⊗[R] M)
+          ((TensorProduct.AlgebraTensorModule.distribBaseChange R A M H)
+            (a ⊗ₜ[R] z))) =
+      a ⊗ₜ[R] Coalgebra.comul.lTensor M z := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
+  | tmul m h =>
+      rw [TensorProduct.AlgebraTensorModule.distribBaseChange_tmul,
+        LinearMap.lTensor_tmul, comul_one_tmul,
+        collapseTriple_comulTensor, LinearMap.lTensor_tmul]
+
+omit [Comodule R H M] in
+private theorem rid_counit_distrib (a : A) (z : M ⊗[R] H) :
+    TensorProduct.AlgebraTensorModule.rid A A (A ⊗[R] M)
+        (Coalgebra.counit.lTensor (A ⊗[R] M)
+          ((TensorProduct.AlgebraTensorModule.distribBaseChange R A M H)
+            (a ⊗ₜ[R] z))) =
+      a ⊗ₜ[R] TensorProduct.rid R M (Coalgebra.counit.lTensor M z) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
+  | tmul m h =>
+      rw [TensorProduct.AlgebraTensorModule.distribBaseChange_tmul,
+        LinearMap.lTensor_tmul, TensorProduct.counit_tmul,
+        CommSemiring.counit_apply]
+      rw [TensorProduct.AlgebraTensorModule.rid_tmul,
+        LinearMap.lTensor_tmul, TensorProduct.rid_tmul]
+      rw [TensorProduct.tmul_smul]
+      simp [Algebra.smul_def, mul_comm]
+
+/-- Extending the coefficient Hopf algebra and the underlying module of a comodule along the
+same scalar morphism gives a comodule over the base-changed Hopf algebra. -/
+@[expose, instance_reducible]
+noncomputable def baseChange : Comodule A (A ⊗[R] H) (A ⊗[R] M) where
+  coact := baseChangeCoact (R := R) (H := H) A
+  coassoc := by
+    apply TensorProduct.AlgebraTensorModule.ext
+    intro a m
+    apply (collapseTriple (R := R) (H := H) (M := M) A).injective
+    simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe]
+    rw [baseChangeCoact_tmul]
+    rw [collapseTriple_coact, collapseTriple_comul, coassoc_apply]
+  lTensor_counit_comp_coact := by
+    apply TensorProduct.AlgebraTensorModule.ext
+    intro a m
+    apply (TensorProduct.AlgebraTensorModule.rid A A (A ⊗[R] M)).injective
+    simp only [LinearMap.coe_comp, Function.comp_apply]
+    rw [baseChangeCoact_tmul]
+    rw [rid_counit_distrib, Comodule.lTensor_counit_coact]
+    simp
+
+/-- The coaction of the base-changed comodule is scalar extension of the original coaction,
+followed by distribution across the two tensor factors. -/
+theorem baseChange_coact :
+    letI := baseChange (R := R) (H := H) (M := M) A
+    coact (R := A) (C := A ⊗[R] H) (M := A ⊗[R] M) =
+      baseChangeCoact (R := R) (H := H) A :=
+  rfl
+
+/-- Formula for the coaction of the base-changed comodule on a pure tensor. -/
+theorem baseChange_coact_tmul (a : A) (m : M) :
+    letI := baseChange (R := R) (H := H) (M := M) A
+    coact (R := A) (C := A ⊗[R] H) (M := A ⊗[R] M) (a ⊗ₜ[R] m) =
+      (TensorProduct.AlgebraTensorModule.distribBaseChange R A M H)
+        (a ⊗ₜ[R] coact (R := R) (C := H) (M := M) m) :=
+  baseChangeCoact_tmul (R := R) (H := H) A a m
+
+namespace Hom
+
+variable {N : Type y} [AddCommMonoid N] [Module R N] [Comodule R H N]
+
+/-- Base change of a comodule morphism, extending both its source and its coefficient coalgebra
+algebra along the same scalar morphism. -/
+@[expose] noncomputable def baseChange (f : Hom R H M N) :
+    letI := Comodule.baseChange (R := R) (H := H) (M := M) A
+    letI := Comodule.baseChange (R := R) (H := H) (M := N) A
+    Hom A (A ⊗[R] H) (A ⊗[R] M) (A ⊗[R] N) := by
+  letI := Comodule.baseChange (R := R) (H := H) (M := M) A
+  letI := Comodule.baseChange (R := R) (H := H) (M := N) A
+  refine
+    { toLinearMap := f.toLinearMap.baseChange A
+      map_coact := ?_ }
+  apply TensorProduct.AlgebraTensorModule.ext
+  intro a m
+  simp only [LinearMap.coe_comp, Function.comp_apply, baseChange_coact_tmul,
+    LinearMap.baseChange_tmul]
+  rw [coe_toLinearMap, ← f.map_coact_apply m]
+  induction coact (R := R) (C := H) (M := M) m using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [map_add, TensorProduct.tmul_add, hx, hy]
+  | tmul n h => simp
+
+/-- The underlying linear map of a base-changed comodule morphism is the base change of its
+underlying linear map. -/
+@[simp]
+theorem baseChange_toLinearMap (f : Hom R H M N) :
+    letI := Comodule.baseChange (R := R) (H := H) (M := M) A
+    letI := Comodule.baseChange (R := R) (H := H) (M := N) A
+    (baseChange A f).toLinearMap = f.toLinearMap.baseChange A :=
+  rfl
+
+/-- A base-changed comodule morphism acts on a pure tensor by applying the original morphism
+to the module factor. -/
+@[simp]
+theorem baseChange_tmul (f : Hom R H M N) (a : A) (m : M) :
+    letI := Comodule.baseChange (R := R) (H := H) (M := M) A
+    letI := Comodule.baseChange (R := R) (H := H) (M := N) A
+    baseChange A f (a ⊗ₜ[R] m) = a ⊗ₜ[R] f m :=
+  rfl
+
+end Hom
+
+end TauCeti.Comodule

--- a/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
@@ -255,8 +255,13 @@ theorem baseChange_toLinearMap (f : Hom R H M N) :
     (baseChange A f).toLinearMap = f.toLinearMap.baseChange A :=
   rfl
 
-/-- Base change preserves the identity comodule morphism. -/
-@[simp]
+/-- Base change preserves the identity comodule morphism.
+
+This is not a `simp` lemma: once `ComoduleCat` is imported, the `@[simp]` lemma
+`ComoduleCat.ofHom_id` rewrites the bare `Comodule.Hom.id` in the left-hand side to a categorical
+identity. Since `ComoduleCat.ofHom` is a reducible abbreviation, that rewrite applies even though
+the categorical wrapper is not syntactically present here, so tagging this theorem with `@[simp]`
+would make its left-hand side fail the `simpNF` linter. -/
 theorem baseChange_id :
     letI := Comodule.baseChange (R := R) (H := H) (M := M) A
     baseChange A (id R H M) = id A (A ⊗[R] H) (A ⊗[R] M) := by

--- a/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
@@ -34,8 +34,12 @@ needed to compare geometric unipotence before and after a field extension.
 
 * `TauCeti.Comodule.baseChangeCoact`: the base-changed coaction.
 * `TauCeti.Comodule.baseChange`: the induced comodule structure over the base-changed
-  coefficient coalgebra.
+  coefficient coalgebra, selected explicitly as a local instance.
 * `TauCeti.Comodule.baseChangeCoact_tmul`: the coaction formula on pure tensors.
+* `TauCeti.Comodule.comul_one_tmul`: the comultiplication formula for the base-changed
+  coalgebra on tensors whose scalar factor is one.
+* `TauCeti.Comodule.baseChange_self`: base change of the regular comodule agrees with the
+  regular comodule of the base-changed coalgebra.
 * `TauCeti.Comodule.Hom.baseChange`: base change of a comodule morphism.
 
 ## References
@@ -116,25 +120,19 @@ private theorem collapseTriple_coact (a : A) (z : M ⊗[R] H) :
       exact collapseTriple_tmul (R := R) (H := H) (M := M) A a
         (coact (R := R) (C := H) (M := M) m) h
 
-omit [Coalgebra R H] in
-private theorem tensorTensorTensorComm_one_one (z : H ⊗[R] H) :
-    TensorProduct.AlgebraTensorModule.tensorTensorTensorComm R A R A A A H H
-        ((1 ⊗ₜ[A] 1) ⊗ₜ[R] z) =
-      TensorProduct.AlgebraTensorModule.distribBaseChange R A H H (1 ⊗ₜ[R] z) := by
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
-  | tmul g h =>
-      simp only [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
-        TensorProduct.AlgebraTensorModule.distribBaseChange_tmul]
-
-private theorem comul_one_tmul (h : H) :
+/-- The comultiplication of the base-changed coalgebra on a pure tensor whose scalar factor is
+one. -/
+theorem comul_one_tmul (h : H) :
     Coalgebra.comul (R := A) (A := A ⊗[R] H) (1 ⊗ₜ[R] h) =
       TensorProduct.AlgebraTensorModule.distribBaseChange R A H H
         (1 ⊗ₜ[R] Coalgebra.comul (R := R) (A := H) h) := by
   rw [TensorProduct.comul_tmul, CommSemiring.comul_apply]
-  exact tensorTensorTensorComm_one_one (R := R) (H := H) A
-    (Coalgebra.comul (R := R) (A := H) h)
+  induction Coalgebra.comul (R := R) (A := H) h using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
+  | tmul g k =>
+      simp only [TensorProduct.AlgebraTensorModule.tensorTensorTensorComm_tmul,
+        TensorProduct.AlgebraTensorModule.distribBaseChange_tmul]
 
 omit [Coalgebra R H] [Comodule R H M] in
 private theorem collapseTriple_comulTensor (a : A) (m : M) (z : H ⊗[R] H) :
@@ -182,7 +180,10 @@ private theorem rid_counit_distrib (a : A) (z : M ⊗[R] H) :
       simp [Algebra.smul_def, mul_comm]
 
 /-- Extending the coefficient coalgebra and the underlying module of a comodule along the
-same scalar morphism gives a comodule over the base-changed coalgebra. -/
+same scalar morphism gives a comodule over the base-changed coalgebra.
+
+This is deliberately not a global instance because a module can carry multiple coactions.
+Downstream code should select it explicitly, typically as a local instance. -/
 @[expose, instance_reducible]
 noncomputable def baseChange : Comodule A (A ⊗[R] H) (A ⊗[R] M) where
   coact := baseChangeCoact (R := R) (H := H) A
@@ -211,14 +212,17 @@ theorem baseChange_coact :
       baseChangeCoact (R := R) (H := H) A :=
   rfl
 
-/-- Formula for the coaction of the base-changed comodule on a pure tensor. -/
-theorem baseChange_coact_tmul (a : A) (m : M) :
-    letI := baseChange (R := R) (H := H) (M := M) A
-    coact (R := A) (C := A ⊗[R] H) (M := A ⊗[R] M) (a ⊗ₜ[R] m) =
-      (TensorProduct.AlgebraTensorModule.distribBaseChange R A M H)
-        (a ⊗ₜ[R] coact (R := R) (C := H) (M := M) m) := by
-    rw [baseChange_coact]
-    exact baseChangeCoact_tmul (R := R) (H := H) A a m
+/-- Base change of the regular comodule is the regular comodule of the base-changed
+coalgebra. -/
+theorem baseChange_self :
+    baseChange (R := R) (H := H) (M := H) A = Comodule.instSelf A (A ⊗[R] H) := by
+  apply Comodule.ext
+  rw [baseChange_coact, instSelf_coact]
+  apply TensorProduct.AlgebraTensorModule.ext
+  intro a h
+  rw [baseChangeCoact_tmul, instSelf_coact,
+    TensorProduct.tmul_eq_smul_one_tmul a (Coalgebra.comul (R := R) (A := H) h),
+    TensorProduct.tmul_eq_smul_one_tmul a h, map_smul, map_smul, comul_one_tmul]
 
 namespace Hom
 
@@ -238,8 +242,8 @@ coefficient coalgebra along the same scalar morphism. -/
       map_coact := ?_ }
   apply TensorProduct.AlgebraTensorModule.ext
   intro a m
-  simp only [LinearMap.coe_comp, Function.comp_apply, baseChange_coact_tmul,
-    LinearMap.baseChange_tmul]
+  simp only [LinearMap.coe_comp, Function.comp_apply, baseChange_coact,
+    baseChangeCoact_tmul, LinearMap.baseChange_tmul]
   rw [coe_toLinearMap, ← f.map_coact_apply m]
   induction coact (R := R) (C := H) (M := M) m using TensorProduct.induction_on with
   | zero => simp
@@ -268,8 +272,11 @@ theorem baseChange_id :
   let _ := Comodule.baseChange (R := R) (H := H) (M := M) A
   apply ext
   intro x
-  exact LinearMap.congr_fun (by
-    rw [baseChange_toLinearMap, id_toLinearMap, LinearMap.baseChange_id, id_toLinearMap]) x
+  have hlin : (baseChange A (id R H M)).toLinearMap =
+      (id A (A ⊗[R] H) (A ⊗[R] M)).toLinearMap := by
+    rw [baseChange_toLinearMap, id_toLinearMap, LinearMap.baseChange_id, id_toLinearMap]
+  rw [← coe_toLinearMap (baseChange A (id R H M)),
+    ← coe_toLinearMap (id A (A ⊗[R] H) (A ⊗[R] M)), hlin]
 
 /-- Base change preserves composition of comodule morphisms. -/
 @[simp]
@@ -283,9 +290,12 @@ theorem baseChange_comp (g : Hom R H N P) (f : Hom R H M N) :
   let _ := Comodule.baseChange (R := R) (H := H) (M := P) A
   apply ext
   intro x
-  exact LinearMap.congr_fun (by
+  have hlin : (baseChange A (g.comp f)).toLinearMap =
+      ((baseChange A g).comp (baseChange A f)).toLinearMap := by
     rw [baseChange_toLinearMap, comp_toLinearMap, LinearMap.baseChange_comp,
-      comp_toLinearMap, baseChange_toLinearMap, baseChange_toLinearMap]) x
+      comp_toLinearMap, baseChange_toLinearMap, baseChange_toLinearMap]
+  rw [← coe_toLinearMap (baseChange A (g.comp f)),
+    ← coe_toLinearMap ((baseChange A g).comp (baseChange A f)), hlin]
 
 /-- A base-changed comodule morphism acts on a pure tensor by applying the original morphism
 to the module factor. -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
@@ -141,7 +141,8 @@ private theorem collapseTriple_comul (a : A) (z : M ⊗[R] H) :
   | add x y hx hy => simp only [TensorProduct.tmul_add, map_add, hx, hy]
   | tmul m h =>
       rw [TensorProduct.AlgebraTensorModule.distribBaseChange_tmul,
-        LinearMap.lTensor_tmul, TauCeti.Coalgebra.baseChange_comul_tmul,
+        LinearMap.lTensor_tmul, TensorProduct.comul_tmul, CommSemiring.comul_apply,
+        TauCeti.Coalgebra.baseChange_comul_tmul,
         collapseTriple_comulTensor, LinearMap.lTensor_tmul]
 
 omit [Comodule R H M] in
@@ -206,6 +207,7 @@ theorem baseChange_self :
   rw [baseChangeCoact_tmul, instSelf_coact,
     TensorProduct.tmul_eq_smul_one_tmul a (Coalgebra.comul (R := R) (A := H) h),
     TensorProduct.tmul_eq_smul_one_tmul a h, map_smul, map_smul,
+    TensorProduct.comul_tmul, CommSemiring.comul_apply,
     TauCeti.Coalgebra.baseChange_comul_tmul]
 
 namespace Hom

--- a/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
@@ -76,8 +76,7 @@ theorem baseChangeCoact_tmul (a : A) (m : M) :
       (TensorProduct.AlgebraTensorModule.distribBaseChange R A M H)
         (a ⊗ₜ[R] coact (R := R) (C := H) (M := M) m) := by
   rw [baseChangeCoact, LinearMap.coe_comp, Function.comp_apply,
-    LinearMap.baseChange_tmul]
-  rfl
+    LinearMap.baseChange_tmul, LinearEquiv.coe_coe]
 
 /-- Collapse a threefold tensor product of scalar extensions to the scalar extension of the
 original threefold tensor product. -/
@@ -204,8 +203,6 @@ theorem baseChange_self :
   apply TensorProduct.AlgebraTensorModule.ext
   intro a h
   rw [baseChangeCoact_tmul, instSelf_coact,
-    TensorProduct.tmul_eq_smul_one_tmul a (Coalgebra.comul (R := R) (A := H) h),
-    TensorProduct.tmul_eq_smul_one_tmul a h, map_smul, map_smul,
     TauCeti.Coalgebra.baseChange_comul_tmul]
 
 namespace Hom
@@ -249,13 +246,8 @@ theorem baseChange_id :
     letI := Comodule.baseChange (R := R) (H := H) (M := M) A
     baseChange A (id R H M) = id A (A ⊗[R] H) (A ⊗[R] M) := by
   let _ := Comodule.baseChange (R := R) (H := H) (M := M) A
-  apply ext
-  intro x
-  have hlin : (baseChange A (id R H M)).toLinearMap =
-      (id A (A ⊗[R] H) (A ⊗[R] M)).toLinearMap := by
-    rw [baseChange_toLinearMap, id_toLinearMap, LinearMap.baseChange_id, id_toLinearMap]
-  rw [← coe_toLinearMap (baseChange A (id R H M)),
-    ← coe_toLinearMap (id A (A ⊗[R] H) (A ⊗[R] M)), hlin]
+  apply toLinearMap_injective
+  rw [baseChange_toLinearMap, id_toLinearMap, LinearMap.baseChange_id, id_toLinearMap]
 
 /-- Base change preserves composition of comodule morphisms. -/
 @[simp]
@@ -267,14 +259,9 @@ theorem baseChange_comp (g : Hom R H N P) (f : Hom R H M N) :
   let _ := Comodule.baseChange (R := R) (H := H) (M := M) A
   let _ := Comodule.baseChange (R := R) (H := H) (M := N) A
   let _ := Comodule.baseChange (R := R) (H := H) (M := P) A
-  apply ext
-  intro x
-  have hlin : (baseChange A (g.comp f)).toLinearMap =
-      ((baseChange A g).comp (baseChange A f)).toLinearMap := by
-    rw [baseChange_toLinearMap, comp_toLinearMap, LinearMap.baseChange_comp,
-      comp_toLinearMap, baseChange_toLinearMap, baseChange_toLinearMap]
-  rw [← coe_toLinearMap (baseChange A (g.comp f)),
-    ← coe_toLinearMap ((baseChange A g).comp (baseChange A f)), hlin]
+  apply toLinearMap_injective
+  rw [baseChange_toLinearMap, comp_toLinearMap, LinearMap.baseChange_comp,
+    comp_toLinearMap, baseChange_toLinearMap, baseChange_toLinearMap]
 
 /-- A base-changed comodule morphism acts on a pure tensor by applying the original morphism
 to the module factor. -/
@@ -285,8 +272,8 @@ theorem baseChange_tmul (f : Hom R H M N) (a : A) (m : M) :
     baseChange A f (a ⊗ₜ[R] m) = a ⊗ₜ[R] f m := by
   let _ := Comodule.baseChange (R := R) (H := H) (M := M) A
   let _ := Comodule.baseChange (R := R) (H := H) (M := N) A
-  rw [← coe_toLinearMap (baseChange A f), baseChange_toLinearMap,
-    LinearMap.baseChange_tmul, coe_toLinearMap]
+  change (baseChange A f).toLinearMap (a ⊗ₜ[R] m) = a ⊗ₜ[R] f.toLinearMap m
+  rw [baseChange_toLinearMap, LinearMap.baseChange_tmul]
 
 end Hom
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/BaseChange.lean
@@ -272,8 +272,8 @@ theorem baseChange_tmul (f : Hom R H M N) (a : A) (m : M) :
     baseChange A f (a ⊗ₜ[R] m) = a ⊗ₜ[R] f m := by
   let _ := Comodule.baseChange (R := R) (H := H) (M := M) A
   let _ := Comodule.baseChange (R := R) (H := H) (M := N) A
-  change (baseChange A f).toLinearMap (a ⊗ₜ[R] m) = a ⊗ₜ[R] f.toLinearMap m
-  rw [baseChange_toLinearMap, LinearMap.baseChange_tmul]
+  rw [← coe_toLinearMap (baseChange A f), ← coe_toLinearMap f,
+    baseChange_toLinearMap, LinearMap.baseChange_tmul]
 
 end Hom
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Basic.lean
@@ -261,6 +261,13 @@ theorem coe_mk {f : M →ₗ[R] N} (h) : ((⟨f, h⟩ : Hom R C M N) : M → N) 
 theorem coe_toLinearMap (f : Hom R C M N) : ⇑f.toLinearMap = f :=
   rfl
 
+/-- A comodule morphism is determined by its underlying linear map. -/
+theorem toLinearMap_injective :
+    Function.Injective (Hom.toLinearMap : Hom R C M N → M →ₗ[R] N) := by
+  intro f g h
+  apply DFunLike.coe_injective
+  rw [← coe_toLinearMap f, ← coe_toLinearMap g, h]
+
 /-- Two comodule morphisms are equal when their underlying functions are equal. -/
 @[ext]
 theorem ext {f g : Hom R C M N} (h : ∀ m, f m = g m) : f = g := by


### PR DESCRIPTION
This PR adds coefficient-ring base change for a right coalgebra comodule: extend both the coefficient coalgebra and the underlying module, prove the resulting coaction satisfies coassociativity and the counit law, and transport comodule morphisms through the construction.

It advances the exact `ReductiveGroups/README.md` Layer 5 target “Unipotent groups (correct, geometric definition)” on the critical path to “The unipotent radical `R_u(G)`.” The new `Comodule.baseChange` and `Comodule.Hom.baseChange` declarations are the prerequisite consumed when transporting finite-dimensional representations across a field extension in the proof that geometric unipotence is invariant under base change.

After this PR, the Layer 5 milestone still needs preservation and reflection of geometric unipotence under field extension, followed by comparison of the base-changed unipotent radical (and descent over perfect fields).

The implementation reuses Mathlib’s `TensorProduct.AlgebraTensorModule.distribBaseChange` equivalence and tensor-product coalgebra instance; it vendors no Mathlib infrastructure. It is deliberately more general than the immediate Hopf-algebra consumer, requiring only a coefficient coalgebra over a commutative semiring.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"comodule-coordinate-base-change"}-->

🤖 Prepared with Codex
