### PR TITLE
feat: add the Auslander-Reiten translate

### DIFF
--- a/TauCeti/Algebra/Module/AuslanderReiten/Translate.lean
+++ b/TauCeti/Algebra/Module/AuslanderReiten/Translate.lean
@@ -147,8 +147,10 @@ def linearEquiv (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderR
 @[simp]
 theorem linearEquiv_apply (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁)
     (φ : AuslanderReitenTranslate k p₁) (x : AuslanderReitenTranspose q₁) :
-    linearEquiv (k := k) e φ x = φ (e x) :=
-  (rfl)
+    linearEquiv (k := k) e φ x = φ (e x) := by
+  -- unfolding `linearEquiv` leaves `LinearEquiv.dualMap` of `e.restrictScalars k`, evaluated by
+  -- `LinearEquiv.dualMap_apply`
+  simp [linearEquiv, LinearEquiv.dualMap_apply]
 
 @[simp]
 theorem linearEquiv_symm (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁) :

--- a/TauCeti/Algebra/Module/AuslanderReiten/Translate.lean
+++ b/TauCeti/Algebra/Module/AuslanderReiten/Translate.lean
@@ -6,15 +6,14 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Module.AuslanderReiten.Transpose
-public import Mathlib.LinearAlgebra.Dual.Defs
+public import TauCeti.LinearAlgebra.Dual.RightAction
 
 /-!
 # The Auslander--Reiten translate
 
 For an algebra `A` over a commutative ring `k`, the **duality** `D = Hom_k(-, k)` turns a right
-`A`-module into a left `A`-module: a scalar `a` acts on a functional `φ` by precomposition with
-multiplication by `a`, `(a • φ) x = φ (x * a)`.  This file records that action as the ring
-homomorphism `TauCeti.dualRightAction` and uses it to define the **Auslander--Reiten translate**
+`A`-module into a left `A`-module, by `TauCeti.dualRightAction`.  This file applies that duality to
+the Auslander--Reiten transpose to define the **Auslander--Reiten translate**
 
 `τ M = D (Tr M)`
 
@@ -29,8 +28,6 @@ statement, and it is what licenses the notation `τ M`.
 
 ## Main definitions
 
-* `TauCeti.dualRightAction`: the left action of `A` on the `k`-dual of a right `A`-module, as a ring
-  homomorphism into the `k`-linear endomorphisms of the dual.
 * `TauCeti.arTranslate`: the Auslander--Reiten translate `D (Tr)` of a projective presentation,
   carrying the resulting `A`-module structure.
 * `TauCeti.arTranslate.linearEquiv`: the transport of the translate along an isomorphism of
@@ -45,13 +42,10 @@ statement, and it is what licenses the notation `τ M`.
 
 ## Implementation notes
 
-The `A`-action on the dual is *not* installed as an instance on `Module.Dual k N` for a general
-right `A`-module `N`: the underlying type of `Module.Dual k N` is a type of linear maps, which
-already carries the codomain-scaling `Module` instances of `Mathlib.Algebra.Module.LinearMap.Defs`,
-and a second `Module` structure matching every dual would make instance search on those types
-depend on an undetermined right-module structure.  Instead `TauCeti.dualRightAction` is a plain ring
-homomorphism, and the single `Module` instance built from it is the one on the translate, whose
-underlying transpose pins the right-module structure being dualized.
+`TauCeti.dualRightAction` is a plain ring homomorphism rather than a `Module` instance on every
+dual, for the reasons recorded in `TauCeti/LinearAlgebra/Dual/RightAction.lean`; the single
+`Module` instance built from it is the one on the translate, whose underlying transpose pins the
+right-module structure being dualized.
 
 The translate is a reducible abbreviation of the dual rather than a fresh type, so that its
 elements are literally `k`-linear functionals on the transpose and the whole `Module.Dual` API
@@ -61,11 +55,17 @@ finite-dimensionality of a dual are inherited verbatim and are not restated here
 
 ## References
 
-This is sublayer 6D, "the AR translate `τ = D Tr` and AR duality", of Layer 6 of
+This is the `arTranslate M = D (Tr M)` construction of sublayer 6D, "the AR translate `τ = D Tr`
+and AR duality", of Layer 6 of
 [the quiver-representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md),
 which names it as the composite of the transpose of sublayer 6C with the duality
 `D = Hom_k(-, k)`, "well-defined only up to projectives, through minimal presentations and duality
 on finite-dimensional modules".
+
+The other half of 6D — AR duality itself, and the bijection it yields from non-projective
+indecomposables to non-injective indecomposables with inverse `Tr D` — is **not proved here**: it
+needs the finite-dimensional hypotheses and the stable morphism spaces that the rest of sublayer 6C
+supplies, and comes in a later file.
 
 * M. Auslander, I. Reiten, S. O. Smalø, *Representation Theory of Artin Algebras*, Cambridge
   University Press (1995), Section IV.1.
@@ -78,32 +78,6 @@ public section
 namespace TauCeti
 
 universe u v v' w w' x
-
-section Duality
-
-variable (k : Type u) (N : Type w) {A : Type v} [CommSemiring k] [Semiring A] [AddCommMonoid N]
-  [Module k N] [Module Aᵐᵒᵖ N] [SMulCommClass Aᵐᵒᵖ k N]
-
-/-- The **duality** `D = Hom_k(-, k)` turns a right `A`-module `N` into a left `A`-module: the
-scalar `a` sends a functional `φ` to `x ↦ φ (x * a)`.  This records that action as a ring
-homomorphism from `A` to the `k`-linear endomorphisms of `Module.Dual k N`.
-
-Precomposition reverses composition, which is exactly what makes a *right* action on `N` into a
-*left* action on its dual; the hypothesis `SMulCommClass Aᵐᵒᵖ k N` is what makes multiplication by
-`a` a `k`-linear endomorphism of `N` in the first place. -/
-def dualRightAction : A →+* Module.End k (Module.Dual k N) where
-  toFun a := (Module.toModuleEnd k N (MulOpposite.op a)).dualMap
-  map_one' := by ext φ x; simp
-  map_mul' a b := by ext φ x; simp [mul_smul]
-  map_zero' := by ext φ x; simp
-  map_add' a b := by ext φ x; simp [add_smul]
-
-@[simp]
-theorem dualRightAction_apply_apply (a : A) (φ : Module.Dual k N) (x : N) :
-    dualRightAction k N a φ x = φ (MulOpposite.op a • x) :=
-  (rfl)
-
-end Duality
 
 variable {A : Type u} [Ring A] {k : Type x} [CommSemiring k] [Algebra k A]
 
@@ -133,17 +107,14 @@ instance : Module A (arTranslate k p₁) :=
 theorem smul_apply (a : A) (φ : arTranslate k p₁)
     (x : AuslanderReitenTranspose p₁) :
     (a • φ) x = φ (MulOpposite.op a • x) :=
-  (rfl)
+  dualRightAction_apply_apply k (AuslanderReitenTranspose p₁) a φ x
 
 /-- Scalars from `k` act on the translate through `A`, so the two actions on it are the layered
 ones: the `k`-action is the restriction of the `A`-action along the algebra map. -/
 instance : IsScalarTower k A (arTranslate k p₁) where
   smul_assoc c a φ := by
     ext x
-    have hc : MulOpposite.op ((algebraMap k A) c) • x = c • x := by
-      rw [← MulOpposite.algebraMap_apply, algebraMap_smul]
-    rw [LinearMap.smul_apply, smul_apply, smul_apply, Algebra.smul_def,
-      MulOpposite.op_mul, mul_smul, hc, smul_comm, map_smul, smul_eq_mul]
+    simp [Algebra.smul_def, mul_smul]
 
 variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommMonoid Q₀] [Module A Q₀]
   [AddCommMonoid Q₁] [Module A Q₁]
@@ -153,22 +124,14 @@ variable {q₁ : Q₁ →ₗ[A] Q₀}
 `Aᵐᵒᵖ`-linear equivalence `Tr q₁ ≃ Tr p₁` sends a functional on `Tr p₁` to its composite with that
 equivalence.
 
-The result is `A`-linear precisely because the equivalence is `Aᵐᵒᵖ`-linear: the two ways of moving
-a scalar past it are the two sides of `LinearEquiv.map_smul`. -/
+It is `LinearEquiv.dualMap` of the underlying `k`-linear equivalence, upgraded to the `A`-action
+that the translates carry. -/
 def linearEquiv (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁) :
-    arTranslate k p₁ ≃ₗ[A] arTranslate k q₁ where
-  toFun φ := φ ∘ₗ (e.restrictScalars k : _ →ₗ[k] _)
-  map_add' _ _ := rfl
-  map_smul' a φ := by
-    ext x
-    simp
-  invFun ψ := ψ ∘ₗ (e.symm.restrictScalars k : _ →ₗ[k] _)
-  left_inv φ := by
-    ext x
-    simp
-  right_inv ψ := by
-    ext x
-    simp
+    arTranslate k p₁ ≃ₗ[A] arTranslate k q₁ :=
+  { (e.restrictScalars k).dualMap with
+    map_smul' := fun a φ => by
+      ext x
+      simp }
 
 @[simp]
 theorem linearEquiv_apply (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁)
@@ -178,19 +141,17 @@ theorem linearEquiv_apply (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] 
 
 @[simp]
 theorem linearEquiv_symm (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁) :
-    (linearEquiv (k := k) e).symm = linearEquiv e.symm := by
-  refine LinearEquiv.ext fun ψ => ?_
-  ext x
-  rfl
+    (linearEquiv (k := k) e).symm = linearEquiv e.symm :=
+  LinearEquiv.ext fun ψ => DFunLike.congr_fun (LinearEquiv.dualMap_symm (f := e.restrictScalars k))
+    ψ
 
 /-- Transport along the identity equivalence of transposes is the identity. -/
 @[simp]
 theorem linearEquiv_refl :
     linearEquiv (k := k) (LinearEquiv.refl Aᵐᵒᵖ (AuslanderReitenTranspose p₁)) =
-      LinearEquiv.refl A (arTranslate k p₁) := by
-  refine LinearEquiv.ext fun φ => ?_
-  ext x
-  simp
+      LinearEquiv.refl A (arTranslate k p₁) :=
+  LinearEquiv.ext fun φ =>
+    DFunLike.congr_fun (LinearEquiv.dualMap_refl (R := k) (M₁ := AuslanderReitenTranspose p₁)) φ
 
 /-- Dualizing is **contravariant**: transporting along a composite of equivalences of transposes is
 the composite of the transports in the reverse order. -/
@@ -199,10 +160,10 @@ theorem linearEquiv_trans {R₀ : Type*} {R₁ : Type*} [AddCommMonoid R₀] [Mo
     [AddCommMonoid R₁] [Module A R₁] {r₁ : R₁ →ₗ[A] R₀}
     (f : AuslanderReitenTranspose r₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose q₁)
     (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁) :
-    linearEquiv (k := k) (f.trans e) = (linearEquiv (k := k) e).trans (linearEquiv f) := by
-  refine LinearEquiv.ext fun φ => ?_
-  ext x
-  simp
+    linearEquiv (k := k) (f.trans e) = (linearEquiv (k := k) e).trans (linearEquiv f) :=
+  LinearEquiv.ext fun φ =>
+    DFunLike.congr_fun
+      (LinearEquiv.dualMap_trans (f.restrictScalars k) (e.restrictScalars k)).symm φ
 
 end arTranslate
 

--- a/TauCeti/Algebra/Module/AuslanderReiten/Translate.lean
+++ b/TauCeti/Algebra/Module/AuslanderReiten/Translate.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Module.AuslanderReiten.Transpose
+public import Mathlib.LinearAlgebra.Dual.Defs
+
+/-!
+# The Auslander--Reiten translate
+
+For an algebra `A` over a commutative ring `k`, the **duality** `D = Hom_k(-, k)` turns a right
+`A`-module into a left `A`-module: a scalar `a` acts on a functional `φ` by precomposition with
+multiplication by `a`, `(a • φ) x = φ (x * a)`.  This file records that action as the ring
+homomorphism `TauCeti.dualRightAction` and uses it to define the **Auslander--Reiten translate**
+
+`τ M = D (Tr M)`
+
+of a module `M` presented by a minimal projective presentation `P₁ → P₀ → M → 0`, the `k`-dual of
+the Auslander--Reiten transpose `TauCeti.AuslanderReitenTranspose` of that presentation.  The
+transpose is a right `A`-module, so the translate is a left `A`-module again, as `M` was.
+
+The translate is attached to a *presentation*, not directly to `M`: like the transpose it is
+well defined only because a minimal projective presentation is unique up to isomorphism of the whole
+diagram.  `TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_arTranslate` is that
+statement, and it is what licenses the notation `τ M`.
+
+## Main definitions
+
+* `TauCeti.dualRightAction`: the left action of `A` on the `k`-dual of a right `A`-module, as a ring
+  homomorphism into the `k`-linear endomorphisms of the dual.
+* `TauCeti.arTranslate`: the Auslander--Reiten translate `D (Tr)` of a projective presentation,
+  carrying the resulting `A`-module structure.
+* `TauCeti.arTranslate.linearEquiv`: the transport of the translate along an isomorphism of
+  transposes, contravariant by `TauCeti.arTranslate.linearEquiv_trans`.
+
+## Main results
+
+* `TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_arTranslate`: the translate is
+  independent, up to `A`-linear equivalence, of the chosen minimal projective presentation.
+* `TauCeti.IsMinimalProjectivePresentation.subsingleton_arTranslate_of_projective`: the translate of
+  a projective module vanishes.
+
+## Implementation notes
+
+The `A`-action on the dual is *not* installed as an instance on `Module.Dual k N` for a general
+right `A`-module `N`: the underlying type of `Module.Dual k N` is a type of linear maps, which
+already carries the codomain-scaling `Module` instances of `Mathlib.Algebra.Module.LinearMap.Defs`,
+and a second `Module` structure matching every dual would make instance search on those types
+depend on an undetermined right-module structure.  Instead `TauCeti.dualRightAction` is a plain ring
+homomorphism, and the single `Module` instance built from it is the one on the translate, whose
+underlying transpose pins the right-module structure being dualized.
+
+The translate is a reducible abbreviation of the dual rather than a fresh type, so that its
+elements are literally `k`-linear functionals on the transpose and the whole `Module.Dual` API
+applies to it unchanged: extensionality, the dimension count `Subspace.dual_finrank_eq` and the
+finite-dimensionality of a dual are inherited verbatim and are not restated here.  Only the
+`A`-action is new, and it is described by the single lemma `TauCeti.arTranslate.smul_apply`.
+
+## References
+
+This is sublayer 6D, "the AR translate `τ = D Tr` and AR duality", of Layer 6 of
+[the quiver-representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md),
+which names it as the composite of the transpose of sublayer 6C with the duality
+`D = Hom_k(-, k)`, "well-defined only up to projectives, through minimal presentations and duality
+on finite-dimensional modules".
+
+* M. Auslander, I. Reiten, S. O. Smalø, *Representation Theory of Artin Algebras*, Cambridge
+  University Press (1995), Section IV.1.
+* I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
+  Algebras, Vol. 1*, Cambridge University Press (2006), Section IV.2.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v v' w w' x
+
+section Duality
+
+variable (k : Type u) (N : Type w) {A : Type v} [CommSemiring k] [Semiring A] [AddCommMonoid N]
+  [Module k N] [Module Aᵐᵒᵖ N] [SMulCommClass Aᵐᵒᵖ k N]
+
+/-- The **duality** `D = Hom_k(-, k)` turns a right `A`-module `N` into a left `A`-module: the
+scalar `a` sends a functional `φ` to `x ↦ φ (x * a)`.  This records that action as a ring
+homomorphism from `A` to the `k`-linear endomorphisms of `Module.Dual k N`.
+
+Precomposition reverses composition, which is exactly what makes a *right* action on `N` into a
+*left* action on its dual; the hypothesis `SMulCommClass Aᵐᵒᵖ k N` is what makes multiplication by
+`a` a `k`-linear endomorphism of `N` in the first place. -/
+def dualRightAction : A →+* Module.End k (Module.Dual k N) where
+  toFun a := (Module.toModuleEnd k N (MulOpposite.op a)).dualMap
+  map_one' := by ext φ x; simp
+  map_mul' a b := by ext φ x; simp [mul_smul]
+  map_zero' := by ext φ x; simp
+  map_add' a b := by ext φ x; simp [add_smul]
+
+@[simp]
+theorem dualRightAction_apply_apply (a : A) (φ : Module.Dual k N) (x : N) :
+    dualRightAction k N a φ x = φ (MulOpposite.op a • x) :=
+  (rfl)
+
+end Duality
+
+variable {A : Type u} [Ring A] {k : Type x} [CommSemiring k] [Algebra k A]
+
+variable {P₀ : Type v} {P₁ : Type w} [AddCommMonoid P₀] [Module A P₀]
+  [AddCommMonoid P₁] [Module A P₁]
+
+/-- The **Auslander--Reiten translate** `τ = D Tr` of a projective presentation whose first map is
+`p₁ : P₁ → P₀`: the `k`-dual of its Auslander--Reiten transpose.  The transpose is a right
+`A`-module, so `TauCeti.dualRightAction` makes the translate a left `A`-module.
+
+As with the transpose, minimality is not needed to form it; it is used by
+`TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_arTranslate` to show that the result
+is independent, up to equivalence, of the chosen presentation of a module. -/
+abbrev arTranslate (k : Type x) [CommSemiring k] [Algebra k A] (p₁ : P₁ →ₗ[A] P₀) : Type _ :=
+  Module.Dual k (AuslanderReitenTranspose p₁)
+
+namespace arTranslate
+
+variable {p₁ : P₁ →ₗ[A] P₀}
+
+instance : Module A (arTranslate k p₁) :=
+  Module.compHom (Module.Dual k (AuslanderReitenTranspose p₁))
+    (dualRightAction k (AuslanderReitenTranspose p₁))
+
+/-- The `A`-action on the translate is precomposition with the right action on the transpose. -/
+@[simp]
+theorem smul_apply (a : A) (φ : arTranslate k p₁)
+    (x : AuslanderReitenTranspose p₁) :
+    (a • φ) x = φ (MulOpposite.op a • x) :=
+  (rfl)
+
+/-- Scalars from `k` act on the translate through `A`, so the two actions on it are the layered
+ones: the `k`-action is the restriction of the `A`-action along the algebra map. -/
+instance : IsScalarTower k A (arTranslate k p₁) where
+  smul_assoc c a φ := by
+    ext x
+    have hc : MulOpposite.op ((algebraMap k A) c) • x = c • x := by
+      rw [← MulOpposite.algebraMap_apply, algebraMap_smul]
+    rw [LinearMap.smul_apply, smul_apply, smul_apply, Algebra.smul_def,
+      MulOpposite.op_mul, mul_smul, hc, smul_comm, map_smul, smul_eq_mul]
+
+variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommMonoid Q₀] [Module A Q₀]
+  [AddCommMonoid Q₁] [Module A Q₁]
+variable {q₁ : Q₁ →ₗ[A] Q₀}
+
+/-- An equivalence of transposes dualizes to an equivalence of translates, contravariantly: an
+`Aᵐᵒᵖ`-linear equivalence `Tr q₁ ≃ Tr p₁` sends a functional on `Tr p₁` to its composite with that
+equivalence.
+
+The result is `A`-linear precisely because the equivalence is `Aᵐᵒᵖ`-linear: the two ways of moving
+a scalar past it are the two sides of `LinearEquiv.map_smul`. -/
+def linearEquiv (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁) :
+    arTranslate k p₁ ≃ₗ[A] arTranslate k q₁ where
+  toFun φ := φ ∘ₗ (e.restrictScalars k : _ →ₗ[k] _)
+  map_add' _ _ := rfl
+  map_smul' a φ := by
+    ext x
+    simp
+  invFun ψ := ψ ∘ₗ (e.symm.restrictScalars k : _ →ₗ[k] _)
+  left_inv φ := by
+    ext x
+    simp
+  right_inv ψ := by
+    ext x
+    simp
+
+@[simp]
+theorem linearEquiv_apply (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁)
+    (φ : arTranslate k p₁) (x : AuslanderReitenTranspose q₁) :
+    linearEquiv (k := k) e φ x = φ (e x) :=
+  (rfl)
+
+@[simp]
+theorem linearEquiv_symm (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁) :
+    (linearEquiv (k := k) e).symm = linearEquiv e.symm := by
+  refine LinearEquiv.ext fun ψ => ?_
+  ext x
+  rfl
+
+/-- Transport along the identity equivalence of transposes is the identity. -/
+@[simp]
+theorem linearEquiv_refl :
+    linearEquiv (k := k) (LinearEquiv.refl Aᵐᵒᵖ (AuslanderReitenTranspose p₁)) =
+      LinearEquiv.refl A (arTranslate k p₁) := by
+  refine LinearEquiv.ext fun φ => ?_
+  ext x
+  simp
+
+/-- Dualizing is **contravariant**: transporting along a composite of equivalences of transposes is
+the composite of the transports in the reverse order. -/
+@[simp]
+theorem linearEquiv_trans {R₀ : Type*} {R₁ : Type*} [AddCommMonoid R₀] [Module A R₀]
+    [AddCommMonoid R₁] [Module A R₁] {r₁ : R₁ →ₗ[A] R₀}
+    (f : AuslanderReitenTranspose r₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose q₁)
+    (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁) :
+    linearEquiv (k := k) (f.trans e) = (linearEquiv (k := k) e).trans (linearEquiv f) := by
+  refine LinearEquiv.ext fun φ => ?_
+  ext x
+  simp
+
+end arTranslate
+
+namespace IsMinimalProjectivePresentation
+
+variable {M : Type*} [AddCommGroup M] [Module A M]
+variable {P₀ : Type v} [AddCommGroup P₀] [Module A P₀]
+variable {P₁ : Type w} [AddCommGroup P₁] [Module A P₁]
+variable {p₁ : P₁ →ₗ[A] P₀} {p₀ : P₀ →ₗ[A] M}
+
+/-- The Auslander--Reiten translate of a projective module vanishes: its transpose already does,
+and the dual of a subsingleton is a subsingleton. -/
+theorem subsingleton_arTranslate_of_projective [Module.Projective A M]
+    (h : IsMinimalProjectivePresentation p₁ p₀) : Subsingleton (arTranslate k p₁) := by
+  have hs : Subsingleton (AuslanderReitenTranspose p₁) :=
+    h.subsingleton_auslanderReitenTranspose_of_projective
+  refine ⟨fun φ ψ => ?_⟩
+  ext x
+  rw [hs.allEq x 0, map_zero, map_zero]
+
+variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommGroup Q₀] [Module A Q₀]
+  [AddCommGroup Q₁] [Module A Q₁]
+variable {q₁ : Q₁ →ₗ[A] Q₀} {q₀ : Q₀ →ₗ[A] M}
+
+/-- **The Auslander--Reiten translate is well defined**: it is independent, up to `A`-linear
+equivalence, of the chosen minimal projective presentation of a module.  This is the statement that
+licenses writing `τ M` for a module `M`. -/
+theorem nonempty_linearEquiv_arTranslate (h : IsMinimalProjectivePresentation p₁ p₀)
+    (h' : IsMinimalProjectivePresentation q₁ q₀) :
+    Nonempty (arTranslate k p₁ ≃ₗ[A] arTranslate k q₁) :=
+  (h'.nonempty_linearEquiv_auslanderReitenTranspose h).map arTranslate.linearEquiv
+
+end IsMinimalProjectivePresentation
+
+end TauCeti

--- a/TauCeti/Algebra/Module/AuslanderReiten/Translate.lean
+++ b/TauCeti/Algebra/Module/AuslanderReiten/Translate.lean
@@ -11,7 +11,7 @@ public import TauCeti.LinearAlgebra.Dual.RightAction
 /-!
 # The Auslander--Reiten translate
 
-For an algebra `A` over a commutative ring `k`, the **duality** `D = Hom_k(-, k)` turns a right
+For an algebra `A` over a commutative semiring `k`, the **duality** `D = Hom_k(-, k)` turns a right
 `A`-module into a left `A`-module, by `TauCeti.dualRightAction`.  This file applies that duality to
 the Auslander--Reiten transpose to define the **Auslander--Reiten translate**
 
@@ -23,22 +23,26 @@ transpose is a right `A`-module, so the translate is a left `A`-module again, as
 
 The translate is attached to a *presentation*, not directly to `M`: like the transpose it is
 well defined only because a minimal projective presentation is unique up to isomorphism of the whole
-diagram.  `TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_arTranslate` is that
-statement, and it is what licenses the notation `τ M`.
+diagram.  `TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_auslanderReitenTranslate` is
+that statement, and it is what licenses the notation `τ M`.
 
 ## Main definitions
 
-* `TauCeti.arTranslate`: the Auslander--Reiten translate `D (Tr)` of a projective presentation,
-  carrying the resulting `A`-module structure.
-* `TauCeti.arTranslate.linearEquiv`: the transport of the translate along an isomorphism of
-  transposes, contravariant by `TauCeti.arTranslate.linearEquiv_trans`.
+* `TauCeti.AuslanderReitenTranslate`: the `k`-dual `D (Tr)` of the Auslander--Reiten transpose of a
+  linear map `p₁ : P₁ → P₀`, carrying the resulting `A`-module structure.  It is the
+  Auslander--Reiten translate of `M` when `p₁` is the first map of a minimal projective presentation
+  of `M`.
+* `TauCeti.AuslanderReitenTranslate.linearEquiv`: the transport of the translate along an
+  isomorphism of transposes, contravariant by
+  `TauCeti.AuslanderReitenTranslate.linearEquiv_trans`.
 
 ## Main results
 
-* `TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_arTranslate`: the translate is
-  independent, up to `A`-linear equivalence, of the chosen minimal projective presentation.
-* `TauCeti.IsMinimalProjectivePresentation.subsingleton_arTranslate_of_projective`: the translate of
-  a projective module vanishes.
+* `TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_auslanderReitenTranslate`: the
+  translate is independent, up to `A`-linear equivalence, of the chosen minimal projective
+  presentation.
+* `TauCeti.IsMinimalProjectivePresentation.subsingleton_auslanderReitenTranslate_of_projective`: the
+  translate of a projective module vanishes.
 
 ## Implementation notes
 
@@ -51,7 +55,12 @@ The translate is a reducible abbreviation of the dual rather than a fresh type, 
 elements are literally `k`-linear functionals on the transpose and the whole `Module.Dual` API
 applies to it unchanged: extensionality, the dimension count `Subspace.dual_finrank_eq` and the
 finite-dimensionality of a dual are inherited verbatim and are not restated here.  Only the
-`A`-action is new, and it is described by the single lemma `TauCeti.arTranslate.smul_apply`.
+`A`-action is new, and it is described by the single lemma
+`TauCeti.AuslanderReitenTranslate.smul_apply`.
+
+The name `arTranslate` is deliberately left free: the roadmap pins it for the *object-level*
+translate `arTranslate k Q M` of a representation, which this presentation-level construction will
+supply once the stable category is available.
 
 ## References
 
@@ -81,40 +90,43 @@ universe u v v' w w' x
 
 variable {A : Type u} [Ring A] {k : Type x} [CommSemiring k] [Algebra k A]
 
+section Translate
+
 variable {P₀ : Type v} {P₁ : Type w} [AddCommMonoid P₀] [Module A P₀]
   [AddCommMonoid P₁] [Module A P₁]
 
-/-- The **Auslander--Reiten translate** `τ = D Tr` of a projective presentation whose first map is
-`p₁ : P₁ → P₀`: the `k`-dual of its Auslander--Reiten transpose.  The transpose is a right
-`A`-module, so `TauCeti.dualRightAction` makes the translate a left `A`-module.
+/-- The **Auslander--Reiten translate** `τ = D Tr` attached to a linear map `p₁ : P₁ → P₀`: the
+`k`-dual of its Auslander--Reiten transpose.  The transpose is a right `A`-module, so
+`TauCeti.dualRightAction` makes the translate a left `A`-module.
 
-As with the transpose, minimality is not needed to form it; it is used by
-`TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_arTranslate` to show that the result
-is independent, up to equivalence, of the chosen presentation of a module. -/
-abbrev arTranslate (k : Type x) [CommSemiring k] [Algebra k A] (p₁ : P₁ →ₗ[A] P₀) : Type _ :=
+When `p₁` is the first map of a minimal projective presentation `P₁ → P₀ → M → 0`, this is the
+Auslander--Reiten translate of `M`: no exactness or projectivity is needed to form it, and
+minimality enters only through
+`TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_auslanderReitenTranslate`, which shows
+that the result is then independent, up to equivalence, of the chosen presentation. -/
+abbrev AuslanderReitenTranslate (k : Type x) [CommSemiring k] [Algebra k A]
+    (p₁ : P₁ →ₗ[A] P₀) : Type _ :=
   Module.Dual k (AuslanderReitenTranspose p₁)
 
-namespace arTranslate
+namespace AuslanderReitenTranslate
 
 variable {p₁ : P₁ →ₗ[A] P₀}
 
-instance : Module A (arTranslate k p₁) :=
+instance : Module A (AuslanderReitenTranslate k p₁) :=
   Module.compHom (Module.Dual k (AuslanderReitenTranspose p₁))
     (dualRightAction k (AuslanderReitenTranspose p₁))
 
 /-- The `A`-action on the translate is precomposition with the right action on the transpose. -/
 @[simp]
-theorem smul_apply (a : A) (φ : arTranslate k p₁)
+theorem smul_apply (a : A) (φ : AuslanderReitenTranslate k p₁)
     (x : AuslanderReitenTranspose p₁) :
     (a • φ) x = φ (MulOpposite.op a • x) :=
   dualRightAction_apply_apply k (AuslanderReitenTranspose p₁) a φ x
 
 /-- Scalars from `k` act on the translate through `A`, so the two actions on it are the layered
 ones: the `k`-action is the restriction of the `A`-action along the algebra map. -/
-instance : IsScalarTower k A (arTranslate k p₁) where
-  smul_assoc c a φ := by
-    ext x
-    simp [Algebra.smul_def, mul_smul]
+instance : IsScalarTower k A (AuslanderReitenTranslate k p₁) :=
+  IsScalarTower.of_algebraMap_smul fun c φ => by ext x; simp
 
 variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommMonoid Q₀] [Module A Q₀]
   [AddCommMonoid Q₁] [Module A Q₁]
@@ -122,12 +134,11 @@ variable {q₁ : Q₁ →ₗ[A] Q₀}
 
 /-- An equivalence of transposes dualizes to an equivalence of translates, contravariantly: an
 `Aᵐᵒᵖ`-linear equivalence `Tr q₁ ≃ Tr p₁` sends a functional on `Tr p₁` to its composite with that
-equivalence.
-
-It is `LinearEquiv.dualMap` of the underlying `k`-linear equivalence, upgraded to the `A`-action
-that the translates carry. -/
+equivalence. -/
 def linearEquiv (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁) :
-    arTranslate k p₁ ≃ₗ[A] arTranslate k q₁ :=
+    AuslanderReitenTranslate k p₁ ≃ₗ[A] AuslanderReitenTranslate k q₁ :=
+  -- `LinearEquiv.dualMap` of the underlying `k`-linear equivalence, upgraded to the `A`-action that
+  -- the translates carry.
   { (e.restrictScalars k).dualMap with
     map_smul' := fun a φ => by
       ext x
@@ -135,7 +146,7 @@ def linearEquiv (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderR
 
 @[simp]
 theorem linearEquiv_apply (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁)
-    (φ : arTranslate k p₁) (x : AuslanderReitenTranspose q₁) :
+    (φ : AuslanderReitenTranslate k p₁) (x : AuslanderReitenTranspose q₁) :
     linearEquiv (k := k) e φ x = φ (e x) :=
   (rfl)
 
@@ -149,7 +160,7 @@ theorem linearEquiv_symm (e : AuslanderReitenTranspose q₁ ≃ₗ[Aᵐᵒᵖ] A
 @[simp]
 theorem linearEquiv_refl :
     linearEquiv (k := k) (LinearEquiv.refl Aᵐᵒᵖ (AuslanderReitenTranspose p₁)) =
-      LinearEquiv.refl A (arTranslate k p₁) :=
+      LinearEquiv.refl A (AuslanderReitenTranslate k p₁) :=
   LinearEquiv.ext fun φ =>
     DFunLike.congr_fun (LinearEquiv.dualMap_refl (R := k) (M₁ := AuslanderReitenTranspose p₁)) φ
 
@@ -165,25 +176,35 @@ theorem linearEquiv_trans {R₀ : Type*} {R₁ : Type*} [AddCommMonoid R₀] [Mo
     DFunLike.congr_fun
       (LinearEquiv.dualMap_trans (f.restrictScalars k) (e.restrictScalars k)).symm φ
 
-end arTranslate
+end AuslanderReitenTranslate
+
+end Translate
 
 namespace IsMinimalProjectivePresentation
 
 variable {M : Type*} [AddCommGroup M] [Module A M]
 variable {P₀ : Type v} [AddCommGroup P₀] [Module A P₀]
-variable {P₁ : Type w} [AddCommGroup P₁] [Module A P₁]
+
+section Projective
+
+variable {P₁ : Type w} [AddCommMonoid P₁] [Module A P₁]
 variable {p₁ : P₁ →ₗ[A] P₀} {p₀ : P₀ →ₗ[A] M}
 
 /-- The Auslander--Reiten translate of a projective module vanishes: its transpose already does,
 and the dual of a subsingleton is a subsingleton. -/
-theorem subsingleton_arTranslate_of_projective [Module.Projective A M]
-    (h : IsMinimalProjectivePresentation p₁ p₀) : Subsingleton (arTranslate k p₁) := by
-  have hs : Subsingleton (AuslanderReitenTranspose p₁) :=
+theorem subsingleton_auslanderReitenTranslate_of_projective [Module.Projective A M]
+    (h : IsMinimalProjectivePresentation p₁ p₀) :
+    Subsingleton (AuslanderReitenTranslate k p₁) :=
+  let _ : Subsingleton (AuslanderReitenTranspose p₁) :=
     h.subsingleton_auslanderReitenTranspose_of_projective
-  refine ⟨fun φ ψ => ?_⟩
-  ext x
-  rw [hs.allEq x 0, map_zero, map_zero]
+  inferInstance
 
+end Projective
+
+section Comparison
+
+variable {P₁ : Type w} [AddCommGroup P₁] [Module A P₁]
+variable {p₁ : P₁ →ₗ[A] P₀} {p₀ : P₀ →ₗ[A] M}
 variable {Q₀ : Type v'} {Q₁ : Type w'} [AddCommGroup Q₀] [Module A Q₀]
   [AddCommGroup Q₁] [Module A Q₁]
 variable {q₁ : Q₁ →ₗ[A] Q₀} {q₀ : Q₀ →ₗ[A] M}
@@ -191,10 +212,12 @@ variable {q₁ : Q₁ →ₗ[A] Q₀} {q₀ : Q₀ →ₗ[A] M}
 /-- **The Auslander--Reiten translate is well defined**: it is independent, up to `A`-linear
 equivalence, of the chosen minimal projective presentation of a module.  This is the statement that
 licenses writing `τ M` for a module `M`. -/
-theorem nonempty_linearEquiv_arTranslate (h : IsMinimalProjectivePresentation p₁ p₀)
+theorem nonempty_linearEquiv_auslanderReitenTranslate (h : IsMinimalProjectivePresentation p₁ p₀)
     (h' : IsMinimalProjectivePresentation q₁ q₀) :
-    Nonempty (arTranslate k p₁ ≃ₗ[A] arTranslate k q₁) :=
-  (h'.nonempty_linearEquiv_auslanderReitenTranspose h).map arTranslate.linearEquiv
+    Nonempty (AuslanderReitenTranslate k p₁ ≃ₗ[A] AuslanderReitenTranslate k q₁) :=
+  (h'.nonempty_linearEquiv_auslanderReitenTranspose h).map AuslanderReitenTranslate.linearEquiv
+
+end Comparison
 
 end IsMinimalProjectivePresentation
 

--- a/TauCeti/Algebra/Module/AuslanderReiten/Transpose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReiten/Transpose.lean
@@ -98,6 +98,13 @@ instance : IsScalarTower k Aᵐᵒᵖ (AuslanderReitenTranspose p₁) :=
 instance : SMulCommClass Aᵐᵒᵖ k (AuslanderReitenTranspose p₁) :=
   inferInstanceAs (SMulCommClass Aᵐᵒᵖ k (Module.Dual A P₁ ⧸ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)))
 
+/-- A scalar of `k`, viewed in `Aᵐᵒᵖ` through the algebra map, acts on the transpose as it does
+through the `k`-action itself. -/
+@[simp]
+theorem op_algebraMap_smul (c : k) (x : AuslanderReitenTranspose p₁) :
+    MulOpposite.op (algebraMap k A c) • x = c • x := by
+  rw [← MulOpposite.algebraMap_apply, algebraMap_smul]
+
 end Scalars
 
 /-- The quotient map from the dual of the first projective onto its Auslander--Reiten transpose. -/

--- a/TauCeti/Algebra/Module/AuslanderReiten/Transpose.lean
+++ b/TauCeti/Algebra/Module/AuslanderReiten/Transpose.lean
@@ -27,8 +27,11 @@ the uniqueness theorem for minimal presentations then gives
 `IsMinimalProjectivePresentation.nonempty_linearEquiv_auslanderReitenTranspose`.
 
 This supplies the transpose construction in sublayer 6C of the quiver-representations roadmap.
-The remaining part of 6C develops its stable equivalence; sublayer 6D then applies finite-field
-duality `D = Hom_k(-, k)` to construct the Auslander--Reiten translate `τ = D Tr`.
+The remaining part of 6C develops its stable equivalence; sublayer 6D applies the duality
+`D = Hom_k(-, k)` to construct the Auslander--Reiten translate `τ = D Tr`, in
+`TauCeti/Algebra/Module/AuslanderReiten/Translate.lean`.  The scalar structure that duality
+dualizes over — a base ring `k` of `A` acting on the transpose through `Aᵐᵒᵖ` — is supplied here,
+next to the other module structures on the transpose.
 
 ## Main definitions
 
@@ -79,6 +82,23 @@ instance : AddCommGroup (AuslanderReitenTranspose p₁) :=
 
 instance : Module Aᵐᵒᵖ (AuslanderReitenTranspose p₁) :=
   inferInstanceAs (Module Aᵐᵒᵖ (Module.Dual A P₁ ⧸ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)))
+
+section Scalars
+
+variable (k : Type*) [CommSemiring k] [Algebra k A]
+
+/-- A base ring `k` of `A` acts on the transpose, through the algebra map into `Aᵐᵒᵖ`.  This is the
+scalar structure the Auslander--Reiten translate dualizes over. -/
+instance : Module k (AuslanderReitenTranspose p₁) :=
+  inferInstanceAs (Module k (Module.Dual A P₁ ⧸ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)))
+
+instance : IsScalarTower k Aᵐᵒᵖ (AuslanderReitenTranspose p₁) :=
+  inferInstanceAs (IsScalarTower k Aᵐᵒᵖ (Module.Dual A P₁ ⧸ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)))
+
+instance : SMulCommClass Aᵐᵒᵖ k (AuslanderReitenTranspose p₁) :=
+  inferInstanceAs (SMulCommClass Aᵐᵒᵖ k (Module.Dual A P₁ ⧸ LinearMap.range (p₁.lcomp Aᵐᵒᵖ A)))
+
+end Scalars
 
 /-- The quotient map from the dual of the first projective onto its Auslander--Reiten transpose. -/
 def mk : Module.Dual A P₁ →ₗ[Aᵐᵒᵖ] AuslanderReitenTranspose p₁ :=

--- a/TauCeti/LinearAlgebra/Dual/RightAction.lean
+++ b/TauCeti/LinearAlgebra/Dual/RightAction.lean
@@ -10,10 +10,10 @@ public import Mathlib.LinearAlgebra.Dual.Defs
 /-!
 # The dual of a right module as a left module
 
-For a right module `N` over a ring `A` whose right action commutes with a base ring `k`, the
-duality `D = Hom_k(-, k)` turns `N` into a *left* `A`-module: a scalar `a` acts on a functional `φ`
-by precomposition with multiplication by `a`, `(a • φ) x = φ (x * a)`.  Precomposition reverses
-composition, which is exactly what exchanges the two sides.
+For a right module `N` over a semiring `A` whose right action commutes with a base commutative
+semiring `k`, the duality `D = Hom_k(-, k)` turns `N` into a *left* `A`-module: a scalar `a` acts on
+a functional `φ` by precomposition with multiplication by `a`, `(a • φ) x = φ (x * a)`.
+Precomposition reverses composition, which is exactly what exchanges the two sides.
 
 This file records that action as the ring homomorphism `TauCeti.dualRightAction`.
 

--- a/TauCeti/LinearAlgebra/Dual/RightAction.lean
+++ b/TauCeti/LinearAlgebra/Dual/RightAction.lean
@@ -58,7 +58,9 @@ def dualRightAction : A →+* Module.End k (Module.Dual k N) where
 
 @[simp]
 theorem dualRightAction_apply_apply (a : A) (φ : Module.Dual k N) (x : N) :
-    dualRightAction k N a φ x = φ (MulOpposite.op a • x) :=
-  (rfl)
+    dualRightAction k N a φ x = φ (MulOpposite.op a • x) := by
+  -- unfolding `dualRightAction` leaves `LinearMap.dualMap` of multiplication by `a`, evaluated by
+  -- `LinearMap.dualMap_apply`
+  simp [dualRightAction, LinearMap.dualMap_apply]
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/Dual/RightAction.lean
+++ b/TauCeti/LinearAlgebra/Dual/RightAction.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Dual.Defs
+
+/-!
+# The dual of a right module as a left module
+
+For a right module `N` over a ring `A` whose right action commutes with a base ring `k`, the
+duality `D = Hom_k(-, k)` turns `N` into a *left* `A`-module: a scalar `a` acts on a functional `φ`
+by precomposition with multiplication by `a`, `(a • φ) x = φ (x * a)`.  Precomposition reverses
+composition, which is exactly what exchanges the two sides.
+
+This file records that action as the ring homomorphism `TauCeti.dualRightAction`.
+
+## Main definitions
+
+* `TauCeti.dualRightAction`: the left action of `A` on the `k`-dual of a right `A`-module, as a ring
+  homomorphism into the `k`-linear endomorphisms of the dual.
+
+## Implementation notes
+
+The action is deliberately *not* installed as a `Module A (Module.Dual k N)` instance: the
+underlying type of `Module.Dual k N` is a type of linear maps, which already carries the
+codomain-scaling `Module` instances of `Mathlib.Algebra.Module.LinearMap.Defs`, and a second
+`Module` structure matching every dual would make instance search on those types depend on an
+undetermined right-module structure.  A consumer that wants the left module structure on one
+particular dual builds it with `Module.compHom`, which pins the right-module structure being
+dualized.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w
+
+variable (k : Type u) (N : Type w) {A : Type v} [CommSemiring k] [Semiring A] [AddCommMonoid N]
+  [Module k N] [Module Aᵐᵒᵖ N] [SMulCommClass Aᵐᵒᵖ k N]
+
+/-- The **duality** `D = Hom_k(-, k)` turns a right `A`-module `N` into a left `A`-module: the
+scalar `a` sends a functional `φ` to `x ↦ φ (x * a)`.  This records that action as a ring
+homomorphism from `A` to the `k`-linear endomorphisms of `Module.Dual k N`.
+
+Precomposition reverses composition, which is exactly what makes a *right* action on `N` into a
+*left* action on its dual; the hypothesis `SMulCommClass Aᵐᵒᵖ k N` is what makes multiplication by
+`a` a `k`-linear endomorphism of `N` in the first place. -/
+def dualRightAction : A →+* Module.End k (Module.Dual k N) where
+  toFun a := (Module.toModuleEnd k N (MulOpposite.op a)).dualMap
+  map_one' := by ext φ x; simp
+  map_mul' a b := by ext φ x; simp [mul_smul]
+  map_zero' := by ext φ x; simp
+  map_add' a b := by ext φ x; simp [add_smul]
+
+@[simp]
+theorem dualRightAction_apply_apply (a : A) (φ : Module.Dual k N) (x : N) :
+    dualRightAction k N a φ x = φ (MulOpposite.op a • x) :=
+  (rfl)
+
+end TauCeti


### PR DESCRIPTION
This PR builds the **Auslander--Reiten translate** `τ = D Tr`, the `arTranslate M = D (Tr M)`
construction of sublayer 6D of Layer 6 of
`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md` (whose sublayer title is
"the AR translate `τ = D Tr` and AR duality"), which the roadmap describes as the composite of the
transpose of sublayer 6C with the `k`-duality `D = Hom_k(-, k)`, "well-defined only up to
projectives, through minimal presentations and duality on finite-dimensional modules". Sublayer 6B
(`TauCeti/Algebra/Module/MinimalProjectivePresentation.lean`, `.../Injective/Copresentation.lean`)
and the transpose of 6C (`.../AuslanderReitenTranspose.lean`, PR #5217) are already on `main`, and
the transpose file's own header names this as the next step; nothing else in flight covers it.

**Scope of this PR within 6D.** It builds the translate itself and the well-definedness that
licenses writing `τ M`. It deliberately does **not** build the other half of the sublayer — AR
duality, and the bijection it yields from non-projective indecomposables to non-injective
indecomposables with inverse `Tr D`. That half needs the finite-dimensional hypotheses and the
stable morphism spaces that the remaining part of sublayer 6C supplies, none of which is on `main`
yet; it comes in a later file, and the module header records the gap.

`TauCeti.dualRightAction`, in the new generic module
`TauCeti/LinearAlgebra/Dual/RightAction.lean`, records the duality itself: for a right `A`-module
`N` whose right action commutes with a base ring `k`, the ring homomorphism
`A →+* Module.End k (Module.Dual k N)` sending `a` to precomposition with multiplication by `a`.
Precomposition reverses composition, which is exactly what turns a right action on `N` into a left
action on its dual. It is stated at the generality it needs — `[CommSemiring k] [Semiring A]
[AddCommMonoid N]`, with no algebra structure on `A` and no finiteness — and it is a plain ring
homomorphism rather than a `Module` instance on every `Module.Dual k N`, because such an instance
would make instance search on linear-map types depend on an undetermined right-module structure and
would collide with the codomain-scaling instances Mathlib already puts there. It has no
Auslander--Reiten content, so it lives in the generic dual directory rather than in the translate
file.

`TauCeti.AuslanderReitenTranslate k p₁` is then the `k`-dual of the Auslander--Reiten transpose of a projective
presentation, carrying the `A`-module structure `dualRightAction` supplies, so the translate is a
left `A`-module just as the presented module was. It is a reducible abbreviation of the dual rather
than a fresh type, so the whole `Module.Dual` API — extensionality, `Subspace.dual_finrank_eq`,
finite-dimensionality of a dual — is inherited verbatim and nothing about it is restated here; only
the `A`-action is new, and `TauCeti.AuslanderReitenTranslate.smul_apply` is the single lemma describing it.
`TauCeti.AuslanderReitenTranslate.linearEquiv` transports the translate along an `Aᵐᵒᵖ`-linear equivalence of
transposes: it is Mathlib's `LinearEquiv.dualMap` of the underlying `k`-linear equivalence, upgraded
to `A`-linearity, and its contravariance (`linearEquiv_trans`), unitality (`linearEquiv_refl`) and
compatibility with inverses (`linearEquiv_symm`) are read off from Mathlib's
`LinearEquiv.dualMap_trans`, `dualMap_refl` and `dualMap_symm`.

The two theorems the construction exists for are
`TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_auslanderReitenTranslate` — the translate is
independent, up to `A`-linear equivalence, of the chosen minimal projective presentation, which is
what licenses writing `τ M` for a module — and
`TauCeti.IsMinimalProjectivePresentation.subsingleton_auslanderReitenTranslate_of_projective`, the vanishing of
the translate of a projective module.

The scalar structure the duality dualizes over is added to the transpose file, next to the other
module structures on the transpose: a base ring `k` of `A` acts on `AuslanderReitenTranspose p₁`
through the algebra map into `Aᵐᵒᵖ`, with the accompanying `IsScalarTower` and `SMulCommClass`
instances and the bridging simp lemma `AuslanderReitenTranspose.op_algebraMap_smul`. The transpose
is not exposed, so these cannot be added from a downstream module.

The construction is named `AuslanderReitenTranslate p₁`, matching the sibling
`AuslanderReitenTranspose p₁` that it dualizes, and deliberately **not** `arTranslate`: the
roadmap's `Suggested.lean` pins `arTranslate k Q M` as an *object-level* operation on a
`QuiverRep`, so that name is left free for it, as the module header records.

Adding `AuslanderReitenTranslate.lean` beside `AuslanderReitenTranspose.lean` would leave two flat
`AuslanderReiten*.lean` siblings, so both move into an `AuslanderReiten/` directory in this PR;
only imports and module headers change, and no declaration is renamed:

| old module | new module |
| --- | --- |
| `TauCeti.Algebra.Module.AuslanderReitenTranspose` | `TauCeti.Algebra.Module.AuslanderReiten.Transpose` |
| (new) | `TauCeti.Algebra.Module.AuslanderReiten.Translate` |
| (new) | `TauCeti.LinearAlgebra.Dual.RightAction` |

No Mathlib infrastructure is vendored. `lake build`, `lake exe axioms`,
`scripts/lint-style.sh`, `scripts/lint-dot-notation.py` and `scripts/lint-env.sh` are all green.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"artranslate"}-->

🤖 Prepared with Claude Code

