### PR TITLE
feat: attach the standard symplectic carrier to a validated type-C index

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
@@ -791,6 +791,15 @@ theorem exists_eq_ofC (d : TypeCLieIndex) :
   case C rank q => exact fun hvalid _ => ⟨rank, q, hvalid, rfl⟩
   all_goals exact fun _ hC => False.elim hC
 
+/-- **The Cartan matrix of the diagram a validated type-`C` index names**, entry by entry: it is
+the type-`C` Cartan matrix at the index's rank. This is the projection of the introduction form
+`TauCeti.TypeCLieIndex.ofC` through `TauCeti.DynkinType.cartanMatrix_C`, stated on entries rather
+than on matrices because the rank occurs in the index types of the two nodes. -/
+theorem dynkinType_cartanMatrix_apply (d : TypeCLieIndex) (i j : Fin d.1.rank) :
+    d.1.dynkinType.cartanMatrix i j = CartanMatrix.C d.1.rank i j := by
+  obtain ⟨rank, q, hvalid, rfl⟩ := d.exists_eq_ofC
+  exact congrFun₂ (DynkinType.cartanMatrix_C rank) i j
+
 /-- The rank of a validated type-`C` index is at least three. -/
 theorem three_le_rank (d : TypeCLieIndex) : 3 ≤ d.1.rank := by
   obtain ⟨rank, q, hvalid, rfl⟩ := d.exists_eq_ofC

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -119,7 +119,10 @@ of rank `r` is the one at `r - 1`. The subtraction never truncates, `r` being at
 identification that recovers `r`. -/
 def carrierRank : ℕ := d.1.rank - 1
 
-/-- The carrier rank of a validated type-`C` index is one less than its rank. -/
+/-- The carrier rank of a validated type-`C` index is one less than its rank. It is oriented
+towards `TauCeti.ValidLieTypeIndex.rank`, so that `simp` normalizes the successor of the carrier
+rank to the rank the index's own Bourbaki index type is built on. -/
+@[simp]
 theorem carrierRank_add_one : d.carrierRank + 1 = d.1.rank := by
   have := d.three_le_rank
   -- The body is unexposed, so the subtraction has to be unfolded before `omega` sees it.
@@ -173,11 +176,18 @@ theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (i j : Fin d.1.rank)
   obtain ⟨n, rfl⟩ : ∃ n, r = n + 1 := by
     have hr : 3 ≤ r := (ofC r q hvalid).three_le_rank
     exact ⟨r - 1, by omega⟩
-  -- Once the rank is presented as `n + 1`, the Dynkin type of `ofC (n + 1) q hvalid` reduces to
-  -- `C (n + 1)`, its rank to `n + 1` and its carrier rank to `n`, so the two `Fin.cast`s are the
-  -- identity and the goal is the upstream identification at the carrier rank `n`. The validity
-  -- proofs are then interchangeable by proof irrelevance.
-  exact congrFun (SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex n _ i) j
+  -- Once the rank is presented as `n + 1` the upstream identification applies at the carrier rank
+  -- `n`, taking as its validity hypothesis the one the index already carries. `convert` leaves the
+  -- two reductions that matching uses, one per side of the equation, rather than discharging both
+  -- of them silently inside a single `exact`.
+  convert congrFun (SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex n
+    (ofC (n + 1) q hvalid).1.dynkinType_valid i) j using 2
+  · -- The carrier side: the carrier rank of `ofC (n + 1) q hvalid` is `n`, so `carrierNode` casts
+    -- `Fin (n + 1)` to itself and both root characters are read at the same node.
+    rfl
+  · -- The datum side: the Dynkin type of `ofC (n + 1) q hvalid` is `C (n + 1)`, and its rank is
+    -- `n + 1`, so both simple roots are read off the same datum at the same node.
+    rfl
 
 /-! ## The Steinberg endomorphism -/
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -177,17 +177,28 @@ theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (i j : Fin d.1.rank)
     have hr : 3 ≤ r := (ofC r q hvalid).three_le_rank
     exact ⟨r - 1, by omega⟩
   -- Once the rank is presented as `n + 1` the upstream identification applies at the carrier rank
-  -- `n`, taking as its validity hypothesis the one the index already carries. `convert` leaves the
-  -- two reductions that matching uses, one per side of the equation, rather than discharging both
-  -- of them silently inside a single `exact`.
-  convert congrFun (SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex n
-    (ofC (n + 1) q hvalid).1.dynkinType_valid i) j using 2
-  · -- The carrier side: the carrier rank of `ofC (n + 1) q hvalid` is `n`, so `carrierNode` casts
-    -- `Fin (n + 1)` to itself and both root characters are read at the same node.
-    rfl
-  · -- The datum side: the Dynkin type of `ofC (n + 1) q hvalid` is `C (n + 1)`, and its rank is
-    -- `n + 1`, so both simple roots are read off the same datum at the same node.
-    rfl
+  -- `n`, taking as its validity hypothesis the one the index already carries. The two index
+  -- transports it is applied across are written out as equations of their own, rather than left to
+  -- the unifier: each is a reduction of the introduction form `ofC (n + 1) q hvalid`, and neither
+  -- can be carried by `rw` or `simp only`, the Dynkin type occurring both in the validity proof and
+  -- in the index type `Fin _.rank` of the nodes. That is the same obstruction the upstream lemma
+  -- records: "the dependent root index prevents rewriting the dispatcher equation directly".
+  -- The carrier side: the carrier rank of `ofC (n + 1) q hvalid` is `n`, so `carrierNode` casts
+  -- `Fin (n + 1)` to itself and both root characters are read at the same node.
+  have hcarrier : SpStd.rootGeneratorWeight (ofC (n + 1) q hvalid).carrierRank
+        (.inl ((ofC (n + 1) q hvalid).carrierNode i)) ((ofC (n + 1) q hvalid).carrierNode j) =
+      SpStd.rootGeneratorWeight n (.inl i) j := rfl
+  -- The datum side: the Dynkin type of `ofC (n + 1) q hvalid` is `C (n + 1)`, of rank `n + 1`, so
+  -- both simple roots are read off the same datum at the same node.
+  have hdatum : ((DynkinType.C (n + 1)).simplyConnectedRootDatum
+        (ofC (n + 1) q hvalid).1.dynkinType_valid).root
+        ((DynkinType.C (n + 1)).simpleIndex (ofC (n + 1) q hvalid).1.dynkinType_valid i) j =
+      ((ofC (n + 1) q hvalid).1.dynkinType.simplyConnectedRootDatum
+        (ofC (n + 1) q hvalid).1.dynkinType_valid).root
+        ((ofC (n + 1) q hvalid).1.dynkinType.simpleIndex
+          (ofC (n + 1) q hvalid).1.dynkinType_valid i) j := rfl
+  exact hcarrier.trans ((congrFun (SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex n
+    (ofC (n + 1) q hvalid).1.dynkinType_valid i) j).trans hdatum)
 
 /-! ## The Steinberg endomorphism -/
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -137,15 +137,6 @@ numbering of the type-`C` diagram that the index names, node for node. -/
 abbrev carrierNode (i : Fin d.1.rank) : Fin (d.carrierRank + 1) :=
   Fin.cast d.carrierRank_add_one.symm i
 
-/-- **The Cartan matrix of the diagram a validated type-`C` index names**, entry by entry: it is
-the type-`C` Cartan matrix at the index's rank. This is the projection of the introduction form
-`TauCeti.TypeCLieIndex.ofC` through `TauCeti.DynkinType.cartanMatrix_C`, stated on entries rather
-than on matrices because the rank occurs in the index types of the two nodes. -/
-theorem dynkinType_cartanMatrix_apply (i j : Fin d.1.rank) :
-    d.1.dynkinType.cartanMatrix i j = CartanMatrix.C d.1.rank i j := by
-  obtain ⟨r, q, hvalid, rfl⟩ := d.exists_eq_ofC
-  exact congrFun₂ (DynkinType.cartanMatrix_C r) i j
-
 /-- **The node correspondence transports the type-`C` Cartan matrix.** The entry at a pair of
 carrier nodes is the entry at the pair of Bourbaki nodes they number: `carrierNode` moves no node
 value, only the rank its index type is built on, and `TauCeti.TypeCLieIndex.carrierRank_add_one`

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -18,8 +18,8 @@ full-weight Chevalley carrier for that diagram is `TauCeti.SpStd.groupScheme`, t
 closure of the standard representation of `sp_(2n)` inside `GL_(2n)` over `ℤ`. This file runs the
 classification recipe on it: for a validated type-`C` index it supplies the group of
 algebraic-closure-valued points of that carrier, its Bourbaki-numbered simple root subgroups, the
-Steinberg endomorphism milestone L1 prescribes for an untwisted family, and the candidate group
-milestone L3 builds from it,
+Steinberg endomorphism milestone L1 prescribes for an untwisted family, and the group milestone L3
+builds from it,
 
 ```text
 H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d]).
@@ -67,7 +67,8 @@ the symplectic group scheme or the pinned simply connected Chevalley--Demazure g
 * `TauCeti.TypeCLieIndex.steinberg`: the Steinberg endomorphism of the family, together with its
   pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)` and the description
   `TauCeti.TypeCLieIndex.mem_fixedSubgroup_steinberg_iff` of the group `H_d` it fixes.
-* `TauCeti.TypeCLieIndex.Group`: the classification candidate `[H_d, H_d] / Z([H_d, H_d])`.
+* `TauCeti.TypeCLieIndex.Group`: the milestone L3 quotient `[H_d, H_d] / Z([H_d, H_d])` of that
+  fixed group, formed on this carrier.
 
 ## References
 
@@ -245,14 +246,16 @@ theorem mem_fixedSubgroup_steinberg_iff (g : d.AmbientGroup) :
   simp only [mem_frobeniusFixedSubring, ValidLieTypeIndex.mem_fixedField,
     d.1.fieldOrder_eq_characteristic_pow]
 
-/-! ## The classification candidate -/
+/-! ## The milestone L3 quotient -/
 
-/-- **The candidate simple group of the untwisted family `Cₙ(q)`**: the derived subgroup of the
-fixed points of its Steinberg map, modulo the centre of that derived subgroup.
+/-- **The milestone L3 quotient on the standard symplectic carrier**: the derived subgroup of the
+fixed points of the Steinberg map above, modulo the centre of that derived subgroup.
 
-This is the milestone L3 recipe on the `C` branch, run on the standard symplectic carrier. Nothing
-below asserts that it is finite, perfect, or simple, nor that the carrier is the one milestone L0
-asks for. -/
+This is the shape milestone L3 asks of the untwisted family `Cₙ(q)`, formed on the standard
+symplectic carrier rather than on the pinned simply connected Chevalley--Demazure group scheme that
+milestone L0 asks for. It becomes the candidate simple group of that family along the Layer 9
+identification of the two carriers described in the module docstring, and not before; it is not
+offered as that candidate here. Nothing below asserts that it is finite, perfect, or simple. -/
 abbrev Group : Type := FixedPointCandidate d.steinberg
 
 /-- Milestone L3 asks every valid branch to carry a group instance; the quotient construction

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -5,25 +5,18 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius
 public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.RootDatum
-public import TauCeti.GroupTheory.FixedPointCandidate
-public import TauCeti.GroupTheory.SpecificGroups.CFSG.Frobenius
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Closure
 
 /-!
-# The untwisted family `Cₙ(q)` on the standard symplectic carrier
+# The standard symplectic carrier of a validated type-`C` index
 
-The untwisted family `Cₙ(q)` is built on the type-`C` diagram of rank `n`, and Tau Ceti's explicit
-full-weight Chevalley carrier for that diagram is `TauCeti.SpStd.groupScheme`, the Kostant toral
-closure of the standard representation of `sp_(2n)` inside `GL_(2n)` over `ℤ`. This file runs the
-classification recipe on it: for a validated type-`C` index it supplies the group of
-algebraic-closure-valued points of that carrier, its Bourbaki-numbered simple root subgroups, the
-Steinberg endomorphism milestone L1 prescribes for an untwisted family, and the group milestone L3
-builds from it,
-
-```text
-H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d]).
-```
+The type-`C` branch of the classification list is built on the type-`C` diagram of rank `n`, and
+Tau Ceti's explicit full-weight Chevalley carrier for that diagram is `TauCeti.SpStd.groupScheme`,
+the Kostant toral closure of the standard representation of `sp_(2n)` inside `GL_(2n)` over `ℤ`.
+This file attaches that carrier to a validated type-`C` index: the group of algebraic-closure-valued
+points of the carrier at the index's rank, its Bourbaki-numbered simple root subgroups, and the
+reading of their root characters in the type-`C` root datum the index names.
 
 The carrier is indexed by `n` in the spelling `C (n + 1)`, so a validated index of rank `r` uses
 the carrier at `TauCeti.TypeCLieIndex.carrierRank`, which is `r - 1`. That subtraction is harmless
@@ -36,51 +29,33 @@ node of the carrier. The two numberings agree node for node, so
 character of the `i`-th raising subgroup as the `i`-th simple root of the type-`C` root datum the
 index names.
 
-The Steinberg map is the `q`-power Frobenius outright. That is what L1's table asks of an untwisted
-family, and `TauCeti.TypeCLieIndex.diagramPerm_eq_one` is the check that the diagram permutation
-this index carries is indeed trivial: the type-`C` diagram has no symmetry, and no classification
-family is graph-twisted over it.
-
 The rank-two member of the same carrier family is *not* reached from here. `TauCeti.DynkinType.C 2`
 is not a valid Dynkin type, the rank-two root system being carried by `B 2`, and correspondingly a
 validated type-`C` index has rank at least three. The rank-two carrier serves the Suzuki family
 instead, in `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean`, where the node correspondence
-acquires the swap of the two Bourbaki nodes. Neither is the untwisted family `Bₙ(q)` built here:
-it is a different classification-list constructor on a different diagram, and in characteristic two
-it coincides with `Cₙ(q)`, which is why `TauCeti.LieTypeIndex.InStandardRange` restricts the `C`
-family to odd characteristic. That restriction is recorded by
-`TauCeti.TypeCLieIndex.characteristic_ne_two` and is not used below: the carrier, its Frobenius and
-the recipe are insensitive to it.
+acquires the swap of the two Bourbaki nodes.
 
 Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
 the symplectic group scheme or the pinned simply connected Chevalley--Demazure group scheme of type
-`Cₙ`, or that any group below is finite, perfect, or simple.
+`Cₙ`, or that its point group is finite.
 
 ## Main declarations
 
 * `TauCeti.TypeCLieIndex.AmbientGroup`: the algebraic-closure-valued points of the standard
-  symplectic carrier at the index's rank, the group the recipe is run inside.
+  symplectic carrier at the index's rank.
 * `TauCeti.TypeCLieIndex.simpleRootSubgroup`: its positive simple-root subgroup at a
   Bourbaki-numbered node, with
   `TauCeti.TypeCLieIndex.rootGeneratorWeight_carrierNode_eq_root_simpleIndex` identifying the
   character of that subgroup with the corresponding simple root of the type-`C` root datum.
-* `TauCeti.TypeCLieIndex.steinberg`: the Steinberg endomorphism of the family, together with its
-  pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)` and the description
-  `TauCeti.TypeCLieIndex.mem_fixedSubgroup_steinberg_iff` of the group `H_d` it fixes.
-* `TauCeti.TypeCLieIndex.FixedPoints`: that group `H_d`, the fixed subgroup of the Steinberg map.
-* `TauCeti.TypeCLieIndex.Group`: the milestone L3 quotient `[H_d, H_d] / Z([H_d, H_d])` of that
-  fixed group, formed on this carrier.
 
 ## References
 
 * R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 11.3.
-* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17.
 * N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate III, for the numbering of the
   type-`C` diagram that the root subgroups below are indexed by.
-* The target signatures realized here follow the human-authored formal skeleton
-  `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group, the numbered simple root
-  subgroup, the Steinberg map with its pinned equation, and the fixed-point candidate, all taken
-  on a validated-index subtype.
+* The signatures realized here follow the human-authored formal skeleton
+  `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group and the numbered simple root
+  subgroup, both taken on a validated-index subtype.
 
 ## Roadmap
 
@@ -91,14 +66,11 @@ and the standard symplectic carrier is not offered as a substitute for that pinn
 pinned group scheme, its pinning, and any identification of a carrier with it are Layer 9 targets of
 `TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap consumes rather than builds; none
 of them is proved of `TauCeti.SpStd.groupScheme` here or in the files this one imports. What this
-file supplies is the branch's explicit carrier, its numbered root characters read in the type-`C`
-root datum, the equation `Frob_q (x_i(u)) = x_i(u ^ q)` that milestone L1 asks of an untwisted
-family, and the milestone L3 recipe run on it, each in the shape those milestones state it; they
-transfer to the L0 carrier along that Layer 9 identification, and not before. The counterparts on
-the other branches already assembled are
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
-`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
+file supplies is the material that identification will be made against on the `C` branch: the
+branch's explicit carrier, its numbered simple root subgroups, and their root characters read as the
+simple roots of the type-`C` root datum. The milestone L1 Steinberg map of the untwisted family
+`Cₙ(q)` and the milestone L3 quotient built from it are *not* stated here; they wait on L0's pinned
+carrier for this branch.
 -/
 
 public section
@@ -156,10 +128,9 @@ theorem cartanMatrix_C_carrierNode (i j : Fin d.1.rank) :
 
 /-- **The ambient group this file attaches to a validated type-`C` index**: the points of the
 explicit full-weight standard symplectic Chevalley carrier at the index's rank, over the algebraic
-closure of its prime field. It is infinite; no finiteness, reductivity, pinning or maximality
-statement is attached to it, and it is not claimed to be the pinned type-`Cₙ` group scheme's points
-that milestone L0 asks for, that identification being the Layer 9 target described in the module
-docstring. -/
+closure of its prime field. No finiteness, reductivity, pinning or maximality statement is attached
+to it, and it is not claimed to be the pinned type-`Cₙ` group scheme's points that milestone L0 asks
+for, that identification being the Layer 9 target described in the module docstring. -/
 abbrev AmbientGroup : Type := SpStd.points d.carrierRank d.1.Closure
 
 /-- The positive simple-root subgroup at the Bourbaki-numbered node `i` of the type-`C` diagram. It
@@ -170,9 +141,7 @@ def simpleRootSubgroup (i : Fin d.1.rank) :
 
 /-- The simple-root subgroup is the carrier's numbered raising subgroup at the corresponding
 carrier node. This is the equation through which the upstream root-subgroup API reaches
-`simpleRootSubgroup`. It is not a `simp` lemma: `steinberg_simpleRootSubgroup` is the normal form
-the pinned equations of this file are stated against, and unfolding to
-`TauCeti.SpStd.rootSubgroupPoints` would keep it from firing. -/
+`simpleRootSubgroup`, whose definition itself stays sealed. -/
 theorem simpleRootSubgroup_def (i : Fin d.1.rank) :
     d.simpleRootSubgroup i =
       SpStd.rootSubgroupPoints d.carrierRank (.inl (d.carrierNode i)) d.1.Closure :=
@@ -196,95 +165,6 @@ theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (i j : Fin d.1.rank)
   rw [SpStd.rootGeneratorWeight_inl]
   simp only [DynkinType.root_simpleIndex]
   rw [d.dynkinType_cartanMatrix_apply, d.cartanMatrix_C_carrierNode]
-
-/-! ## The Steinberg endomorphism -/
-
-/-- **The Steinberg endomorphism of a validated type-`C` index**: the `q`-power Frobenius of the
-ambient group, `q` being the field order the index records. The family is untwisted, so no diagram
-automorphism and no half-Frobenius enters; `TauCeti.TypeCLieIndex.diagramPerm_eq_one` is the check
-that the diagram permutation this index carries is trivial. -/
-def steinberg : d.AmbientGroup →* d.AmbientGroup :=
-  SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure
-
-/-- The Steinberg map of a type-`C` index is the carrier's Frobenius at the exponent the index
-records. This is its unfolding lemma; the definition itself stays sealed.
-
-It is deliberately not a `simp` lemma: `steinberg_simpleRootSubgroup` and `coe_steinberg_apply` are
-the normal forms the pinned equations of this file are stated against, and unfolding to
-`TauCeti.SpStd.frobenius` would keep them from firing. -/
-theorem steinberg_def :
-    d.steinberg = SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure :=
-  (rfl)
-
-/-- The Steinberg map acts on the ambient group by raising every matrix entry to the `q`-th
-power. -/
-@[simp]
-theorem coe_steinberg_apply (g : d.AmbientGroup)
-    (r c : Fin (d.carrierRank + 1 + (d.carrierRank + 1))) :
-    ((d.steinberg g : Matrix.GeneralLinearGroup
-          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
-        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
-          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c =
-      ((g : Matrix.GeneralLinearGroup
-          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
-        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
-          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c ^
-        d.1.fieldOrder := by
-  rw [steinberg_def, d.1.fieldOrder_eq_characteristic_pow]
-  exact SpStd.coe_frobenius_apply _ _ _ _ g r c
-
-/-- **The Steinberg map fixes the Bourbaki numbering of a simple-root subgroup and raises its
-parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation
-milestone L1 asks of the untwisted families. -/
-@[simp]
-theorem steinberg_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.Closure) :
-    d.steinberg (d.simpleRootSubgroup i u) =
-      d.simpleRootSubgroup i
-        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.fieldOrder)) := by
-  rw [steinberg_def, simpleRootSubgroup_def, SpStd.frobenius_rootSubgroupPoints,
-    d.1.fieldOrder_eq_characteristic_pow]
-
-/-- **A point of the ambient group is fixed by the Steinberg map exactly when all of its matrix
-entries lie in the field of definition.** Writing `𝔽_q` for
-`TauCeti.ValidLieTypeIndex.fixedField`, the copy of the field of `q` elements inside the algebraic
-closure, the group `H_d` that the milestone L3 recipe is run on below is therefore the group of
-points of the standard symplectic carrier whose entries lie in `𝔽_q`.
-
-This is not a `simp` lemma: `TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so
-`simp` rewrites its left-hand side to `d.steinberg g = g` through `MonoidHom.mem_eqLocus`, and the
-`simpNF` linter rejects the annotation. -/
-theorem mem_fixedSubgroup_steinberg_iff (g : d.AmbientGroup) :
-    g ∈ fixedSubgroup d.steinberg ↔
-      ∀ r c, ((g : Matrix.GeneralLinearGroup
-          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
-        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
-          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c ∈
-        d.1.fixedField := by
-  rw [mem_fixedSubgroup, steinberg_def, SpStd.frobenius_eq_self_iff]
-  simp only [mem_frobeniusFixedSubring, ValidLieTypeIndex.mem_fixedField,
-    d.1.fieldOrder_eq_characteristic_pow]
-
-/-! ## The milestone L3 quotient -/
-
-/-- **The group `H_d` of the milestone L3 recipe**: the fixed subgroup of the Steinberg map above.
-`TauCeti.TypeCLieIndex.mem_fixedSubgroup_steinberg_iff` describes it as the points of the standard
-symplectic carrier whose matrix entries lie in the field of definition. No finiteness assertion is
-part of this definition. -/
-abbrev FixedPoints : Type := ↥(fixedSubgroup d.steinberg)
-
-/-- **The milestone L3 quotient on the standard symplectic carrier**: the derived subgroup of the
-fixed points of the Steinberg map above, modulo the centre of that derived subgroup.
-
-This is the shape milestone L3 asks of the untwisted family `Cₙ(q)`, formed on the standard
-symplectic carrier rather than on the pinned simply connected Chevalley--Demazure group scheme that
-milestone L0 asks for. It becomes the candidate simple group of that family along the Layer 9
-identification of the two carriers described in the module docstring, and not before; it is not
-offered as that candidate here. Nothing below asserts that it is finite, perfect, or simple. -/
-abbrev Group : Type := FixedPointCandidate d.steinberg
-
-/-- Milestone L3 asks every valid branch to carry a group instance; the quotient construction
-supplies it. -/
-example : _root_.Group d.Group := inferInstance
 
 end
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -67,6 +67,7 @@ the symplectic group scheme or the pinned simply connected Chevalley--Demazure g
 * `TauCeti.TypeCLieIndex.steinberg`: the Steinberg endomorphism of the family, together with its
   pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)` and the description
   `TauCeti.TypeCLieIndex.mem_fixedSubgroup_steinberg_iff` of the group `H_d` it fixes.
+* `TauCeti.TypeCLieIndex.FixedPoints`: that group `H_d`, the fixed subgroup of the Steinberg map.
 * `TauCeti.TypeCLieIndex.Group`: the milestone L3 quotient `[H_d, H_d] / Z([H_d, H_d])` of that
   fixed group, formed on this carrier.
 
@@ -136,6 +137,30 @@ numbering of the type-`C` diagram that the index names, node for node. -/
 abbrev carrierNode (i : Fin d.1.rank) : Fin (d.carrierRank + 1) :=
   Fin.cast d.carrierRank_add_one.symm i
 
+/-- **The Cartan matrix of the diagram a validated type-`C` index names**, entry by entry: it is
+the type-`C` Cartan matrix at the index's rank. This is the projection of the introduction form
+`TauCeti.TypeCLieIndex.ofC` through `TauCeti.DynkinType.cartanMatrix_C`, stated on entries rather
+than on matrices because the rank occurs in the index types of the two nodes. -/
+theorem dynkinType_cartanMatrix_apply (i j : Fin d.1.rank) :
+    d.1.dynkinType.cartanMatrix i j = CartanMatrix.C d.1.rank i j := by
+  obtain ⟨r, q, hvalid, rfl⟩ := d.exists_eq_ofC
+  exact congrFun₂ (DynkinType.cartanMatrix_C r) i j
+
+/-- **The node correspondence transports the type-`C` Cartan matrix.** The entry at a pair of
+carrier nodes is the entry at the pair of Bourbaki nodes they number: `carrierNode` moves no node
+value, only the rank its index type is built on, and `TauCeti.TypeCLieIndex.carrierRank_add_one`
+identifies the two ranks. -/
+theorem cartanMatrix_C_carrierNode (i j : Fin d.1.rank) :
+    CartanMatrix.C (d.carrierRank + 1) (d.carrierNode i) (d.carrierNode j) =
+      CartanMatrix.C d.1.rank i j := by
+  have hrank : d.1.rank - 1 = d.carrierRank := by
+    have := d.carrierRank_add_one
+    omega
+  -- Both sides are the same table of conditions on the two node values, which `carrierNode` leaves
+  -- unchanged, and on the last node, where the two spellings of the rank agree by `hrank`.
+  simp only [CartanMatrix.C, Matrix.of_apply, carrierNode, Fin.ext_iff, Fin.val_cast,
+    Nat.add_sub_cancel, hrank]
+
 /-! ## The ambient group and its simple root subgroups -/
 
 /-- **The ambient group this file attaches to a validated type-`C` index**: the points of the
@@ -172,33 +197,14 @@ theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (i j : Fin d.1.rank)
     SpStd.rootGeneratorWeight d.carrierRank (.inl (d.carrierNode i)) (d.carrierNode j) =
       (d.1.dynkinType.simplyConnectedRootDatum d.1.dynkinType_valid).root
         (d.1.dynkinType.simpleIndex d.1.dynkinType_valid i) j := by
-  obtain ⟨r, q, hvalid, rfl⟩ := d.exists_eq_ofC
-  obtain ⟨n, rfl⟩ : ∃ n, r = n + 1 := by
-    have hr : 3 ≤ r := (ofC r q hvalid).three_le_rank
-    exact ⟨r - 1, by omega⟩
-  -- Once the rank is presented as `n + 1` the upstream identification applies at the carrier rank
-  -- `n`, taking as its validity hypothesis the one the index already carries. The two index
-  -- transports it is applied across are written out as equations of their own, rather than left to
-  -- the unifier: each is a reduction of the introduction form `ofC (n + 1) q hvalid`, and neither
-  -- can be carried by `rw` or `simp only`, the Dynkin type occurring both in the validity proof and
-  -- in the index type `Fin _.rank` of the nodes. That is the same obstruction the upstream lemma
-  -- records: "the dependent root index prevents rewriting the dispatcher equation directly".
-  -- The carrier side: the carrier rank of `ofC (n + 1) q hvalid` is `n`, so `carrierNode` casts
-  -- `Fin (n + 1)` to itself and both root characters are read at the same node.
-  have hcarrier : SpStd.rootGeneratorWeight (ofC (n + 1) q hvalid).carrierRank
-        (.inl ((ofC (n + 1) q hvalid).carrierNode i)) ((ofC (n + 1) q hvalid).carrierNode j) =
-      SpStd.rootGeneratorWeight n (.inl i) j := rfl
-  -- The datum side: the Dynkin type of `ofC (n + 1) q hvalid` is `C (n + 1)`, of rank `n + 1`, so
-  -- both simple roots are read off the same datum at the same node.
-  have hdatum : ((DynkinType.C (n + 1)).simplyConnectedRootDatum
-        (ofC (n + 1) q hvalid).1.dynkinType_valid).root
-        ((DynkinType.C (n + 1)).simpleIndex (ofC (n + 1) q hvalid).1.dynkinType_valid i) j =
-      ((ofC (n + 1) q hvalid).1.dynkinType.simplyConnectedRootDatum
-        (ofC (n + 1) q hvalid).1.dynkinType_valid).root
-        ((ofC (n + 1) q hvalid).1.dynkinType.simpleIndex
-          (ofC (n + 1) q hvalid).1.dynkinType_valid i) j := rfl
-  exact hcarrier.trans ((congrFun (SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex n
-    (ofC (n + 1) q hvalid).1.dynkinType_valid i) j).trans hdatum)
+  -- Both sides are read as entries of the type-`C` Cartan matrix, the carrier's by the upstream
+  -- `SpStd.rootGeneratorWeight_inl` and the datum's by the uniform `DynkinType.root_simpleIndex`,
+  -- which is the same route the upstream identification takes past the dependent root index. The
+  -- two index transports that remain are then the stated equations `cartanMatrix_C_carrierNode`
+  -- and `dynkinType_cartanMatrix_apply`, so no dependent conversion is left to the elaborator.
+  rw [SpStd.rootGeneratorWeight_inl]
+  simp only [DynkinType.root_simpleIndex]
+  rw [d.dynkinType_cartanMatrix_apply, d.cartanMatrix_C_carrierNode]
 
 /-! ## The Steinberg endomorphism -/
 
@@ -268,6 +274,12 @@ theorem mem_fixedSubgroup_steinberg_iff (g : d.AmbientGroup) :
     d.1.fieldOrder_eq_characteristic_pow]
 
 /-! ## The milestone L3 quotient -/
+
+/-- **The group `H_d` of the milestone L3 recipe**: the fixed subgroup of the Steinberg map above.
+`TauCeti.TypeCLieIndex.mem_fixedSubgroup_steinberg_iff` describes it as the points of the standard
+symplectic carrier whose matrix entries lie in the field of definition. No finiteness assertion is
+part of this definition. -/
+abbrev FixedPoints : Type := ↥(fixedSubgroup d.steinberg)
 
 /-- **The milestone L3 quotient on the standard symplectic carrier**: the derived subgroup of the
 fixed points of the Steinberg map above, modulo the centre of that derived subgroup.

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -1,0 +1,266 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius
+public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.RootDatum
+public import TauCeti.GroupTheory.FixedPointCandidate
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Frobenius
+
+/-!
+# The untwisted family `Cₙ(q)` on the standard symplectic carrier
+
+The untwisted family `Cₙ(q)` is built on the type-`C` diagram of rank `n`, and Tau Ceti's explicit
+full-weight Chevalley carrier for that diagram is `TauCeti.SpStd.groupScheme`, the Kostant toral
+closure of the standard representation of `sp_(2n)` inside `GL_(2n)` over `ℤ`. This file runs the
+classification recipe on it: for a validated type-`C` index it supplies the group of
+algebraic-closure-valued points of that carrier, its Bourbaki-numbered simple root subgroups, the
+Steinberg endomorphism milestone L1 prescribes for an untwisted family, and the candidate group
+milestone L3 builds from it,
+
+```text
+H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d]).
+```
+
+The carrier is indexed by `n` in the spelling `C (n + 1)`, so a validated index of rank `r` uses
+the carrier at `TauCeti.TypeCLieIndex.carrierRank`, which is `r - 1`. That subtraction is harmless
+because `TauCeti.TypeCLieIndex.three_le_rank` bounds the rank below by three:
+`TauCeti.TypeCLieIndex.carrierRank_add_one` recovers `r`, and every numbered object below is indexed
+by `Fin d.1.rank`, the upstream Bourbaki index type of the index's own Dynkin type, rather than by a
+node of the carrier. The two numberings agree node for node, so
+`TauCeti.TypeCLieIndex.carrierNode` is the rank identification and nothing more; that is what
+`TauCeti.TypeCLieIndex.rootGeneratorWeight_carrierNode_eq_root_simpleIndex` records, reading the
+character of the `i`-th raising subgroup as the `i`-th simple root of the type-`C` root datum the
+index names.
+
+The Steinberg map is the `q`-power Frobenius outright. That is what L1's table asks of an untwisted
+family, and `TauCeti.TypeCLieIndex.diagramPerm_eq_one` is the check that the diagram permutation
+this index carries is indeed trivial: the type-`C` diagram has no symmetry, and no classification
+family is graph-twisted over it.
+
+The rank-two member of the same carrier family is *not* reached from here. `TauCeti.DynkinType.C 2`
+is not a valid Dynkin type, the rank-two root system being carried by `B 2`, and correspondingly a
+validated type-`C` index has rank at least three. The rank-two carrier serves the Suzuki family
+instead, in `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean`, where the node correspondence
+acquires the swap of the two Bourbaki nodes. Neither is the untwisted family `Bₙ(q)` built here:
+it is a different classification-list constructor on a different diagram, and in characteristic two
+it coincides with `Cₙ(q)`, which is why `TauCeti.LieTypeIndex.InStandardRange` restricts the `C`
+family to odd characteristic. That restriction is recorded by
+`TauCeti.TypeCLieIndex.characteristic_ne_two` and is not used below: the carrier, its Frobenius and
+the recipe are insensitive to it.
+
+Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
+the symplectic group scheme or the pinned simply connected Chevalley--Demazure group scheme of type
+`Cₙ`, or that any group below is finite, perfect, or simple.
+
+## Main declarations
+
+* `TauCeti.TypeCLieIndex.AmbientGroup`: the algebraic-closure-valued points of the standard
+  symplectic carrier at the index's rank, the group the recipe is run inside.
+* `TauCeti.TypeCLieIndex.simpleRootSubgroup`: its positive simple-root subgroup at a
+  Bourbaki-numbered node, with
+  `TauCeti.TypeCLieIndex.rootGeneratorWeight_carrierNode_eq_root_simpleIndex` identifying the
+  character of that subgroup with the corresponding simple root of the type-`C` root datum.
+* `TauCeti.TypeCLieIndex.steinberg`: the Steinberg endomorphism of the family, together with its
+  pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)` and the description
+  `TauCeti.TypeCLieIndex.mem_fixedSubgroup_steinberg_iff` of the group `H_d` it fixes.
+* `TauCeti.TypeCLieIndex.Group`: the classification candidate `[H_d, H_d] / Z([H_d, H_d])`.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 11.3.
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17.
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate III, for the numbering of the
+  type-`C` diagram that the root subgroups below are indexed by.
+* The target signatures realized here follow the human-authored formal skeleton
+  `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group, the numbered simple root
+  subgroup, the Steinberg map with its pinned equation, and the fixed-point candidate, all taken
+  on a validated-index subtype.
+
+## Roadmap
+
+Milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md` asks for the points of the *pinned* simply
+connected Chevalley--Demazure group scheme of `TauCeti.DynkinType.simplyConnectedRootDatum` at the
+diagram the index names, with its root subgroups. **This file does not close L0 on the `C` branch,
+and the standard symplectic carrier is not offered as a substitute for that pinned group.** The
+pinned group scheme, its pinning, and any identification of a carrier with it are Layer 9 targets of
+`TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap consumes rather than builds; none
+of them is proved of `TauCeti.SpStd.groupScheme` here or in the files this one imports. What this
+file supplies is the branch's explicit carrier, its numbered root characters read in the type-`C`
+root datum, the equation `Frob_q (x_i(u)) = x_i(u ^ q)` that milestone L1 asks of an untwisted
+family, and the milestone L3 recipe run on it, each in the shape those milestones state it; they
+transfer to the L0 carrier along that Layer 9 identification, and not before. The counterparts on
+the other branches already assembled are
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
+`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace TypeCLieIndex
+
+variable (d : TypeCLieIndex)
+
+noncomputable section
+
+/-! ## The carrier rank and the node correspondence -/
+
+/-- **The rank parameter of the standard symplectic carrier serving a validated type-`C` index.**
+`TauCeti.SpStd.groupScheme n` is the carrier of type `C (n + 1)`, so the carrier serving an index
+of rank `r` is the one at `r - 1`. The subtraction never truncates, `r` being at least three by
+`TauCeti.TypeCLieIndex.three_le_rank`; `TauCeti.TypeCLieIndex.carrierRank_add_one` is the
+identification that recovers `r`. -/
+def carrierRank : ℕ := d.1.rank - 1
+
+/-- The carrier rank of a validated type-`C` index is one less than its rank. -/
+theorem carrierRank_add_one : d.carrierRank + 1 = d.1.rank := by
+  have := d.three_le_rank
+  -- The body is unexposed, so the subtraction has to be unfolded before `omega` sees it.
+  rw [carrierRank]
+  omega
+
+/-- **The carrier node numbered by a Bourbaki node of the index's diagram.** Unlike the rank-two
+correspondence of the Suzuki family, this is the rank identification and nothing else: the standard
+symplectic carrier at `TauCeti.TypeCLieIndex.carrierRank` numbers its generators by the Bourbaki
+numbering of the type-`C` diagram that the index names, node for node. -/
+abbrev carrierNode (i : Fin d.1.rank) : Fin (d.carrierRank + 1) :=
+  Fin.cast d.carrierRank_add_one.symm i
+
+/-! ## The ambient group and its simple root subgroups -/
+
+/-- **The ambient group this file attaches to a validated type-`C` index**: the points of the
+explicit full-weight standard symplectic Chevalley carrier at the index's rank, over the algebraic
+closure of its prime field. It is infinite; no finiteness, reductivity, pinning or maximality
+statement is attached to it, and it is not claimed to be the pinned type-`Cₙ` group scheme's points
+that milestone L0 asks for, that identification being the Layer 9 target described in the module
+docstring. -/
+abbrev AmbientGroup : Type := SpStd.points d.carrierRank d.1.Closure
+
+/-- The positive simple-root subgroup at the Bourbaki-numbered node `i` of the type-`C` diagram. It
+is the carrier's numbered raising subgroup at the node that `carrierNode` names. -/
+def simpleRootSubgroup (i : Fin d.1.rank) :
+    Multiplicative d.1.Closure →* d.AmbientGroup :=
+  SpStd.rootSubgroupPoints d.carrierRank (.inl (d.carrierNode i)) d.1.Closure
+
+/-- The simple-root subgroup is the carrier's numbered raising subgroup at the corresponding
+carrier node. This is the equation through which the upstream root-subgroup API reaches
+`simpleRootSubgroup`. It is not a `simp` lemma: `steinberg_simpleRootSubgroup` is the normal form
+the pinned equations of this file are stated against, and unfolding to
+`TauCeti.SpStd.rootSubgroupPoints` would keep it from firing. -/
+theorem simpleRootSubgroup_def (i : Fin d.1.rank) :
+    d.simpleRootSubgroup i =
+      SpStd.rootSubgroupPoints d.carrierRank (.inl (d.carrierNode i)) d.1.Closure :=
+  (rfl)
+
+/-- **The simple-root subgroups sit at the simple roots of the type-`C` root datum.** The character
+by which the carrier's split torus rescales the parameter of `simpleRootSubgroup i`, read in the
+same node correspondence, is the `i`-th simple root of
+`TauCeti.DynkinType.simplyConnectedRootDatum` at the Dynkin type the index names. This is the sense
+in which the standard symplectic carrier serves that diagram; it is not a claim that the carrier is
+the pinned group of the diagram, no pinning being constructed for it. -/
+theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (i j : Fin d.1.rank) :
+    SpStd.rootGeneratorWeight d.carrierRank (.inl (d.carrierNode i)) (d.carrierNode j) =
+      (d.1.dynkinType.simplyConnectedRootDatum d.1.dynkinType_valid).root
+        (d.1.dynkinType.simpleIndex d.1.dynkinType_valid i) j := by
+  obtain ⟨r, q, hvalid, rfl⟩ := d.exists_eq_ofC
+  obtain ⟨n, rfl⟩ : ∃ n, r = n + 1 := by
+    have hr : 3 ≤ r := (ofC r q hvalid).three_le_rank
+    exact ⟨r - 1, by omega⟩
+  -- Once the rank is presented as `n + 1`, the Dynkin type of `ofC (n + 1) q hvalid` reduces to
+  -- `C (n + 1)`, its rank to `n + 1` and its carrier rank to `n`, so the two `Fin.cast`s are the
+  -- identity and the goal is the upstream identification at the carrier rank `n`. The validity
+  -- proofs are then interchangeable by proof irrelevance.
+  exact congrFun (SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex n _ i) j
+
+/-! ## The Steinberg endomorphism -/
+
+/-- **The Steinberg endomorphism of a validated type-`C` index**: the `q`-power Frobenius of the
+ambient group, `q` being the field order the index records. The family is untwisted, so no diagram
+automorphism and no half-Frobenius enters; `TauCeti.TypeCLieIndex.diagramPerm_eq_one` is the check
+that the diagram permutation this index carries is trivial. -/
+def steinberg : d.AmbientGroup →* d.AmbientGroup :=
+  SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure
+
+/-- The Steinberg map of a type-`C` index is the carrier's Frobenius at the exponent the index
+records. This is its unfolding lemma; the definition itself stays sealed.
+
+It is deliberately not a `simp` lemma: `steinberg_simpleRootSubgroup` and `coe_steinberg_apply` are
+the normal forms the pinned equations of this file are stated against, and unfolding to
+`TauCeti.SpStd.frobenius` would keep them from firing. -/
+theorem steinberg_def :
+    d.steinberg = SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure :=
+  (rfl)
+
+/-- The Steinberg map acts on the ambient group by raising every matrix entry to the `q`-th
+power. -/
+@[simp]
+theorem coe_steinberg_apply (g : d.AmbientGroup)
+    (r c : Fin (d.carrierRank + 1 + (d.carrierRank + 1))) :
+    ((d.steinberg g : Matrix.GeneralLinearGroup
+          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
+        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
+          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c =
+      ((g : Matrix.GeneralLinearGroup
+          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
+        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
+          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c ^
+        d.1.fieldOrder := by
+  rw [steinberg_def, d.1.fieldOrder_eq_characteristic_pow]
+  exact SpStd.coe_frobenius_apply _ _ _ _ g r c
+
+/-- **The Steinberg map fixes the Bourbaki numbering of a simple-root subgroup and raises its
+parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation
+milestone L1 asks of the untwisted families. -/
+@[simp]
+theorem steinberg_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.Closure) :
+    d.steinberg (d.simpleRootSubgroup i u) =
+      d.simpleRootSubgroup i
+        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.fieldOrder)) := by
+  rw [steinberg_def, simpleRootSubgroup_def, SpStd.frobenius_rootSubgroupPoints,
+    d.1.fieldOrder_eq_characteristic_pow]
+
+/-- **A point of the ambient group is fixed by the Steinberg map exactly when all of its matrix
+entries lie in the field of definition.** Writing `𝔽_q` for
+`TauCeti.ValidLieTypeIndex.fixedField`, the copy of the field of `q` elements inside the algebraic
+closure, the group `H_d` that the milestone L3 recipe is run on below is therefore the group of
+points of the standard symplectic carrier whose entries lie in `𝔽_q`.
+
+This is not a `simp` lemma: `TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so
+`simp` rewrites its left-hand side to `d.steinberg g = g` through `MonoidHom.mem_eqLocus`, and the
+`simpNF` linter rejects the annotation. -/
+theorem mem_fixedSubgroup_steinberg_iff (g : d.AmbientGroup) :
+    g ∈ fixedSubgroup d.steinberg ↔
+      ∀ r c, ((g : Matrix.GeneralLinearGroup
+          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
+        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
+          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c ∈
+        d.1.fixedField := by
+  rw [mem_fixedSubgroup, steinberg_def, SpStd.frobenius_eq_self_iff]
+  simp only [mem_frobeniusFixedSubring, ValidLieTypeIndex.mem_fixedField,
+    d.1.fieldOrder_eq_characteristic_pow]
+
+/-! ## The classification candidate -/
+
+/-- **The candidate simple group of the untwisted family `Cₙ(q)`**: the derived subgroup of the
+fixed points of its Steinberg map, modulo the centre of that derived subgroup.
+
+This is the milestone L3 recipe on the `C` branch, run on the standard symplectic carrier. Nothing
+below asserts that it is finite, perfect, or simple, nor that the carrier is the one milestone L0
+asks for. -/
+abbrev Group : Type := FixedPointCandidate d.steinberg
+
+/-- Milestone L3 asks every valid branch to carry a group instance; the quotient construction
+supplies it. -/
+example : _root_.Group d.Group := inferInstance
+
+end
+
+end TypeCLieIndex
+
+end TauCeti


### PR DESCRIPTION
This PR attaches Tau Ceti's explicit full-weight standard symplectic Chevalley carrier to a
validated type-`C` index, as the material milestone L0's pinned-carrier identification will be made
against on the `C` branch. For such an index it supplies `TypeCLieIndex.AmbientGroup`, the
algebraic-closure-valued points of `SpStd.groupScheme` at the index's rank, and
`TypeCLieIndex.simpleRootSubgroup`, its positive simple-root subgroup at a Bourbaki-numbered node,
with `rootGeneratorWeight_carrierNode_eq_root_simpleIndex` identifying the character of that
subgroup with the corresponding simple root of `DynkinType.simplyConnectedRootDatum` at the Dynkin
type the index names.

`SpStd.groupScheme n` carries the type `C (n + 1)`, so a validated index of rank `r` reaches it at
`TypeCLieIndex.carrierRank`, which is `r - 1`. That subtraction never truncates, `r` being at least
three by the already-merged `TypeCLieIndex.three_le_rank`, and `carrierRank_add_one` recovers `r`, so
every numbered object stays indexed by `Fin d.1.rank`, the upstream Bourbaki index type of the
index's own Dynkin type. Unlike the rank-two correspondence the Suzuki family needs,
`TypeCLieIndex.carrierNode` is that rank identification and nothing else: above rank two the two
numberings agree node for node, which is exactly what
`SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex` says. `TypeCLieIndex.dynkinType_cartanMatrix_apply`,
added to `CFSG/Index.lean`, is the index-only half of that transport.

This serves the `C` branch of milestone L0 of `CFSGStatement/README.md`: the branch's explicit
carrier with its root subgroups, and their root characters read in the type-`C` root datum. What
milestone L0 itself asks for is the *pinned* simply connected Chevalley--Demazure group scheme, whose
construction and identification with a carrier are Layer 9 targets of `ReductiveGroups/README.md`
that this roadmap consumes rather than builds; no declaration here asserts any of them. The milestone
L1 Steinberg map of the untwisted family `Cₙ(q)` and the milestone L3 quotient built from it are not
stated here, and wait on that L0 carrier. The index subtype `TypeCLieIndex` and its range facts came
from milestone I0 and are already on `main`.

Nothing is duplicated from upstream: the carrier, its numbered root subgroups and the root-character
identification are consumed from
`TauCeti/Algebra/Lie/Symplectic/StandardCarrier/{Scheme,RootDatum}.lean`. The rank-two member of the
same carrier family is not reached from here: `DynkinType.C 2` is not a valid Dynkin type, and the
rank-two carrier serves the Suzuki family in `CFSG/TypeB2.lean` instead, where the node
correspondence acquires the swap of the two Bourbaki nodes.

Nothing asserts that the carrier is reductive, that its weight torus is maximal, that it is the
symplectic group scheme, or that its point group is finite.

The conventions follow R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 11.3, with the Bourbaki
Plate III numbering of the type-`C` diagram; the signatures follow the human-authored formal skeleton
`CFSGStatement/Suggested.lean`. No external material is vendored.

The unsupported "independent source-to-Lean read-through" section of
`CFSG/Sporadic/Lyons.lean` is removed, as an earlier round of review on this PR asked.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"typeclieindex-group"}-->

🤖 Prepared with Claude Code
