### PR TITLE
feat: add the doubled E6 minuscule Frobenius

### DIFF
--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Frobenius.lean
@@ -49,8 +49,7 @@ carrier's root datum, or any finiteness or simplicity statement.
 ## Main declarations
 
 * `TauCeti.E6DoubledMinuscule.frobenius`: the `p ^ k`-power Frobenius on the carrier's points.
-* `TauCeti.E6DoubledMinuscule.frobenius_eq_pointsMap`, `coe_frobenius` and
-  `coe_frobenius_apply`: its description as an induced map on points, and its matrix and entrywise
+* `TauCeti.E6DoubledMinuscule.coe_frobenius` and `coe_frobenius_apply`: its matrix and entrywise
   actions.
 * `TauCeti.E6DoubledMinuscule.frobenius_rootSubgroupPoints`: its action on every numbered
   simple-root subgroup.
@@ -103,18 +102,14 @@ noncomputable section
 variable (p k : ℕ) (A : Type v) [CommRing A] [ExpChar A p]
 
 /-- **The `p ^ k`-power Frobenius endomorphism of the full-weight doubled type-`E₆` minuscule
-carrier.**
+carrier**, the functorial map on points induced by the iterated Frobenius endomorphism of the
+value ring.
 
 For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the Frobenius factor of
 the Steinberg map that a future construction of the twisted family `²E₆(p ^ k)` composes with the
 `E₆` graph automorphism. -/
 def frobenius : points A →* points A :=
   pointsMap (iterateFrobenius A p k)
-
-/-- The carrier Frobenius is the functorial map on points induced by the iterated Frobenius
-endomorphism of the value ring. -/
-theorem frobenius_eq_pointsMap : frobenius p k A = pointsMap (iterateFrobenius A p k) :=
-  (rfl)
 
 /-- The Frobenius endomorphism of the doubled minuscule carrier acts by entrywise Frobenius.
 
@@ -123,7 +118,7 @@ normal form. -/
 theorem coe_frobenius (g : points A) :
     (frobenius p k A g : _root_.Matrix.GeneralLinearGroup (Fin 54) A) =
       _root_.Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
-  rw [frobenius_eq_pointsMap, coe_pointsMap]
+  rw [frobenius, coe_pointsMap]
 
 /-- Entrywise, the Frobenius endomorphism raises each matrix coefficient to its `p ^ k`-th
 power. -/
@@ -142,7 +137,7 @@ theorem frobenius_rootSubgroupPoints (i : Fin 6 ⊕ Fin 6) (u : Multiplicative A
     frobenius p k A (rootSubgroupPoints i A u) =
       rootSubgroupPoints i A
         (Multiplicative.ofAdd (Multiplicative.toAdd u ^ p ^ k)) := by
-  rw [frobenius_eq_pointsMap, pointsMap_rootSubgroupPoints]
+  rw [frobenius, pointsMap_rootSubgroupPoints]
   exact Subtype.ext (by rw [iterateFrobenius_def])
 
 /-- **Frobenius raises every coordinate of the pinned split weight torus to its `p ^ k`-th
@@ -158,13 +153,12 @@ theorem frobenius_weightTorusPoints (s : Fin 6 → Aˣ) :
 group. -/
 @[simp]
 theorem frobenius_zero : frobenius p 0 A = MonoidHom.id _ := by
-  rw [frobenius_eq_pointsMap, iterateFrobenius_zero, pointsMap_id]
+  rw [frobenius, iterateFrobenius_zero, pointsMap_id]
 
 /-- Frobenius iterates add under composition on the doubled minuscule carrier's point group. -/
 theorem frobenius_add (m : ℕ) :
     frobenius p (k + m) A = (frobenius p k A).comp (frobenius p m A) := by
-  rw [frobenius_eq_pointsMap, frobenius_eq_pointsMap, frobenius_eq_pointsMap,
-    iterateFrobenius_add, pointsMap_comp]
+  rw [frobenius, frobenius, frobenius, iterateFrobenius_add, pointsMap_comp]
 
 /-- **Frobenius exponents multiply under taking powers**: the `m`-th power of the `p ^ k`-power
 Frobenius of the doubled minuscule carrier, in the endomorphism monoid of its points, is its

--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Frobenius.lean
@@ -7,7 +7,9 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear
 public import TauCeti.Algebra.Lie.E6.DoubledMinuscule.PointsFunctor
-public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius
+-- The toral-closure Frobenius is used only inside the proof of `frobenius_weightTorusPoints`, so
+-- it is imported privately rather than re-exported to consumers of this module.
+import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius
 
 /-!
 # The Frobenius of the doubled type-E6 minuscule carrier

--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Frobenius.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear
+public import TauCeti.Algebra.Lie.E6.DoubledMinuscule.PointsFunctor
+
+/-!
+# The Frobenius of the doubled type-E6 minuscule carrier
+
+`TauCeti.E6DoubledMinuscule.groupScheme` is the explicit full-weight type-`E₆` carrier over `ℤ`
+built from `V(ϖ₁) ⊕ V(ϖ₆)`, and `TauCeti.E6DoubledMinuscule.points A` realizes its `A`-valued
+points as a subgroup of `GL₅₄(A)`. Over a commutative ring `A` of exponential characteristic `p`,
+entrywise `p ^ k`-th powers are a homomorphism of value rings, so the carrier's functoriality
+turns them into a group endomorphism of its points.
+
+This file names that endomorphism `TauCeti.E6DoubledMinuscule.frobenius` and records its
+characteristic equations:
+
+```text
+F (g)ᵢⱼ = gᵢⱼ ^ (p ^ k),
+F (xᵢ(u)) = xᵢ(u ^ (p ^ k)),
+F (t(s)) = t(s ^ (p ^ k)).
+```
+
+The zeroth iterate is the identity, exponents add under composition and multiply under taking
+powers in the endomorphism monoid, and the fixed points are the points of the same carrier over
+the Frobenius-fixed subring.
+
+The `27`-dimensional carrier already carries a Frobenius, `TauCeti.E6Minuscule.frobenius`, and it
+is the one the untwisted family `E₆(q)` is built from. What the doubled carrier adds is the index
+set on which the `E₆` diagram symmetry acts, by
+`TauCeti.DynkinType.e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm`, whereas that symmetry
+moves every minuscule weight off the twenty-seven-element table by
+`TauCeti.DynkinType.e6MinusculeWeight_comp_graphPermE6_notMem_range`. A Steinberg map composing a
+graph automorphism with a field Frobenius therefore needs the Frobenius of *this* carrier, which
+is what is built here. The graph automorphism itself is not built here, and no declaration below
+mentions the diagram symmetry.
+
+Nothing here asserts reductivity, maximality of the weight torus, an identification of the
+carrier's root datum, or any finiteness or simplicity statement.
+
+## Main declarations
+
+* `TauCeti.E6DoubledMinuscule.frobenius`: the `p ^ k`-power Frobenius on the carrier's points.
+* `TauCeti.E6DoubledMinuscule.frobenius_eq_pointsMap`, `coe_frobenius` and
+  `coe_frobenius_apply`: its description as an induced map on points, and its matrix and entrywise
+  actions.
+* `TauCeti.E6DoubledMinuscule.frobenius_rootSubgroupPoints`: its action on every numbered
+  simple-root subgroup.
+* `TauCeti.E6DoubledMinuscule.frobenius_weightTorusPoints`: its action on the split weight torus.
+* `TauCeti.E6DoubledMinuscule.frobenius_zero`, `frobenius_add` and `frobenius_pow`: its iteration
+  laws.
+* `TauCeti.E6DoubledMinuscule.frobenius_eq_self_iff` and
+  `TauCeti.E6DoubledMinuscule.map_subtype_fixedSubgroup_frobenius_eq`: which points it fixes, and
+  the identification of the fixed subgroup with the points over the Frobenius-fixed subring.
+
+## References
+
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17.
+* R. W. Carter, *Simple Groups of Lie Type*, §12.2, for the doubled minuscule realization on
+  which the twisted family `²E₆(q)` is built.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+* The formal organization follows the carrier specializations
+  `TauCeti.Algebra.Lie.E6.Minuscule.Frobenius`,
+  `TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.Frobenius` and
+  `TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius`, and the power law follows
+  `TauCeti.DynkinType.geckFrobenius_pow` in
+  `TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.Frobenius`. Every
+  general fact used about entrywise Frobenius on the points cut out by a Hopf ideal is consumed
+  from `TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear`.
+
+## Roadmap
+
+This advances the target "points over an algebraically closed field as a group, functorially in
+the field, so that a field endomorphism induces a group endomorphism of the points", whose "the
+`q`-power Frobenius is the case a consumer asks for first", in Layer 9, "pinned
+Chevalley--Demazure group schemes over `ℤ`", of `TauCetiRoadmap/ReductiveGroups/README.md`. Its
+consumer is milestone L1, "ordinary and graph Steinberg maps", of
+`TauCetiRoadmap/CFSGStatement/README.md`, whose Steinberg map for the twisted family `²E₆(q)` is
+`γ₂ ∘ Frob_q` on the points of a carrier for the `E₆` diagram over an algebraic closure of
+`ZMod p`; the identification of this carrier with the pinned simply connected Chevalley--Demazure
+group that milestone requires remains pending, as does the graph automorphism `γ₂`.
+-/
+
+public section
+
+namespace TauCeti.E6DoubledMinuscule
+
+universe v
+
+noncomputable section
+
+variable (p k : ℕ) (A : Type v) [CommRing A] [ExpChar A p]
+
+/-- **The `p ^ k`-power Frobenius endomorphism of the full-weight doubled type-`E₆` minuscule
+carrier.**
+
+For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the Frobenius factor of
+the Steinberg map that a future construction of the twisted family `²E₆(p ^ k)` composes with the
+`E₆` graph automorphism. -/
+def frobenius : points A →* points A :=
+  pointsMap (iterateFrobenius A p k)
+
+/-- The carrier Frobenius is the functorial map on points induced by the iterated Frobenius
+endomorphism of the value ring. -/
+theorem frobenius_eq_pointsMap : frobenius p k A = pointsMap (iterateFrobenius A p k) :=
+  (rfl)
+
+/-- The Frobenius endomorphism of the doubled minuscule carrier acts by entrywise Frobenius.
+
+This is not a `simp` lemma because `coe_frobenius_apply` is the canonical coefficient-level
+normal form. -/
+theorem coe_frobenius (g : points A) :
+    (frobenius p k A g : _root_.Matrix.GeneralLinearGroup (Fin 54) A) =
+      _root_.Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
+  rw [frobenius_eq_pointsMap, coe_pointsMap]
+
+/-- Entrywise, the Frobenius endomorphism raises each matrix coefficient to its `p ^ k`-th
+power. -/
+@[simp]
+theorem coe_frobenius_apply (g : points A) (i j : Fin 54) :
+    ((frobenius p k A g : _root_.Matrix.GeneralLinearGroup (Fin 54) A) :
+        _root_.Matrix (Fin 54) (Fin 54) A) i j =
+      ((g : _root_.Matrix.GeneralLinearGroup (Fin 54) A) :
+        _root_.Matrix (Fin 54) (Fin 54) A) i j ^ p ^ k := by
+  rw [coe_frobenius, _root_.Matrix.GeneralLinearGroup.map_apply, iterateFrobenius_def]
+
+/-- **Frobenius raises the parameter of every numbered doubled type-`E₆` simple-root subgroup to
+its `p ^ k`-th power.** -/
+@[simp]
+theorem frobenius_rootSubgroupPoints (i : Fin 6 ⊕ Fin 6) (u : Multiplicative A) :
+    frobenius p k A (rootSubgroupPoints i A u) =
+      rootSubgroupPoints i A
+        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ p ^ k)) := by
+  rw [frobenius_eq_pointsMap, pointsMap_rootSubgroupPoints]
+  exact Subtype.ext (by rw [iterateFrobenius_def])
+
+/-- **Frobenius raises every coordinate of the pinned split weight torus to its `p ^ k`-th
+power.** -/
+@[simp]
+theorem frobenius_weightTorusPoints (s : Fin 6 → Aˣ) :
+    frobenius p k A (weightTorusPoints A s) = weightTorusPoints A (s ^ p ^ k) := by
+  have hs : (fun j => Units.map (iterateFrobenius A p k : A →* A) (s j)) = s ^ p ^ k := by
+    funext j
+    ext
+    simp [iterateFrobenius_def]
+  rw [frobenius_eq_pointsMap, pointsMap_weightTorusPoints, hs]
+
+/-- The zeroth Frobenius iterate is the identity on the doubled minuscule carrier's point
+group. -/
+@[simp]
+theorem frobenius_zero : frobenius p 0 A = MonoidHom.id _ := by
+  rw [frobenius_eq_pointsMap, iterateFrobenius_zero, pointsMap_id]
+
+/-- Frobenius iterates add under composition on the doubled minuscule carrier's point group. -/
+theorem frobenius_add (m : ℕ) :
+    frobenius p (k + m) A = (frobenius p k A).comp (frobenius p m A) := by
+  rw [frobenius_eq_pointsMap, frobenius_eq_pointsMap, frobenius_eq_pointsMap,
+    iterateFrobenius_add, pointsMap_comp]
+
+/-- **Frobenius exponents multiply under taking powers**: the `m`-th power of the `p ^ k`-power
+Frobenius of the doubled minuscule carrier, in the endomorphism monoid of its points, is its
+`p ^ (k * m)`-power Frobenius. -/
+-- `Monoid.End` is definitionally a bundled `MonoidHom`; the `show` picks its composition monoid
+-- structure before the power is elaborated.
+theorem frobenius_pow (m : ℕ) :
+    (show Monoid.End _ from frobenius p k A) ^ m = frobenius p (k * m) A := by
+  induction m with
+  | zero => rw [pow_zero, Nat.mul_zero, frobenius_zero]; rfl
+  | succ m ih => rw [pow_succ, ih, Nat.mul_succ, frobenius_add p (k * m) A k]; rfl
+
+/-- A doubled minuscule carrier point is fixed by Frobenius exactly when all of its matrix entries
+lie in the Frobenius-fixed subring. -/
+@[simp]
+theorem frobenius_eq_self_iff (g : points A) :
+    frobenius p k A g = g ↔
+      ∀ i j, ((g : _root_.Matrix.GeneralLinearGroup (Fin 54) A) :
+        _root_.Matrix (Fin 54) (Fin 54) A) i j ∈ frobeniusFixedSubring A p k := by
+  rw [← SetLike.coe_eq_coe, coe_frobenius,
+    _root_.Matrix.GeneralLinearGroup.map_iterateFrobenius_eq_self_iff]
+
+/-- **The Frobenius-fixed points of the full-weight doubled minuscule carrier are its points over
+the Frobenius-fixed subring.** -/
+theorem map_subtype_fixedSubgroup_frobenius_eq :
+    (fixedSubgroup (frobenius p k A)).map (points A).subtype =
+      (points ↥(frobeniusFixedSubring A p k)).map
+        (_root_.Matrix.GeneralLinearGroup.map (frobeniusFixedSubring A p k).subtype) := by
+  rw [TauCeti.map_subtype_fixedSubgroup_of_coe_eq (frobenius p k A) _
+      (coe_frobenius p k A), points_def A, points_def ↥(frobeniusFixedSubring A p k),
+    TauCeti.GeneralLinear.map_hopfIdealPointsSubgroup_frobeniusFixedSubring]
+
+end
+
+end TauCeti.E6DoubledMinuscule

--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/Frobenius.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear
 public import TauCeti.Algebra.Lie.E6.DoubledMinuscule.PointsFunctor
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius
 
 /-!
 # The Frobenius of the doubled type-E6 minuscule carrier
@@ -70,8 +71,11 @@ carrier's root datum, or any finiteness or simplicity statement.
   `TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius`, and the power law follows
   `TauCeti.DynkinType.geckFrobenius_pow` in
   `TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.Frobenius`. Every
-  general fact used about entrywise Frobenius on the points cut out by a Hopf ideal is consumed
-  from `TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear`.
+  general fact used about entrywise Frobenius is consumed rather than reproved: the facts about
+  the points cut out by a Hopf ideal from
+  `TauCeti.Algebra.AlgebraicGroup.Frobenius.GeneralLinear`, and the entrywise Frobenius of a
+  weight-torus matrix from
+  `TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius`.
 
 ## Roadmap
 
@@ -143,12 +147,10 @@ theorem frobenius_rootSubgroupPoints (i : Fin 6 ⊕ Fin 6) (u : Multiplicative A
 power.** -/
 @[simp]
 theorem frobenius_weightTorusPoints (s : Fin 6 → Aˣ) :
-    frobenius p k A (weightTorusPoints A s) = weightTorusPoints A (s ^ p ^ k) := by
-  have hs : (fun j => Units.map (iterateFrobenius A p k : A →* A) (s j)) = s ^ p ^ k := by
-    funext j
-    ext
-    simp [iterateFrobenius_def]
-  rw [frobenius_eq_pointsMap, pointsMap_weightTorusPoints, hs]
+    frobenius p k A (weightTorusPoints A s) = weightTorusPoints A (s ^ p ^ k) :=
+  Subtype.ext (by
+    rw [coe_frobenius, coe_weightTorusPoints,
+      UniversalEnvelopingAlgebra.map_iterateFrobenius_kostantTorusMatrix, coe_weightTorusPoints])
 
 /-- The zeroth Frobenius iterate is the identity on the doubled minuscule carrier's point
 group. -/


### PR DESCRIPTION
This PR names the `p ^ k`-power Frobenius endomorphism of the points of the explicit full-weight doubled type-`E₆` minuscule carrier, `TauCeti.E6DoubledMinuscule.frobenius`, as the map that the carrier's already-merged points functor induces from `iterateFrobenius` on the value ring, and records the equations that characterize it: the entrywise action `F (g)ᵢⱼ = gᵢⱼ ^ (p ^ k)`, the two pinned actions `F (xᵢ(u)) = xᵢ(u ^ (p ^ k))` and `F (t(s)) = t(s ^ (p ^ k))` on the twelve numbered simple-root subgroups and on the rank-six split weight torus, the iteration laws `F_0 = id`, `F_(k+m) = F_k ∘ F_m` and `F_k ^ m = F_(k*m)` in the endomorphism monoid, and the identification of the fixed subgroup with the points of the same carrier over the Frobenius-fixed subring.

The exact roadmap target is "Points over an algebraically closed field as a group, functorially in the field, so that a field endomorphism induces a group endomorphism of the points", whose stated first case is "the `q`-power Frobenius", in Layer 9, "pinned Chevalley--Demazure group schemes over `ℤ`", of `ReductiveGroups/README.md`. This is the most effective current step on the doubled carrier because [#5404](https://github.com/TauCetiProject/TauCeti/pull/5404), "feat: make the doubled E6 minuscule points functorial", put `E6DoubledMinuscule.pointsMap` on `main` and named this specialization as its consumer's need, while the carrier's sealed point group had no field-endomorphism API at all.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

The dependency edge is that milestone L1 of `CFSGStatement/README.md`, "ordinary and graph Steinberg maps", prescribes `γ₂ ∘ Frob_q` as the Steinberg map of the twisted family `²E₆(q)` and requires the simple-root-subgroup equation `Frob_q (x_α(t)) = x_α(t ^ q)` on the carrier the composite acts on. That carrier has to be the doubled one: the `E₆` diagram symmetry moves every one of the twenty-seven minuscule weights off the table, by the already-merged `DynkinType.e6MinusculeWeight_comp_graphPermE6_notMem_range`, and permutes the fifty-four doubled weights, by `DynkinType.e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm`, so the `27`-dimensional `E6Minuscule.frobenius` that the untwisted branch `E₆(q)` uses cannot serve the twisted one. The declaration this Frobenius will be consumed by is `TypeTwistedE6LieIndex.steinberg`, the `²E₆(q)` counterpart of the merged `TypeE6LieIndex.steinberg` in `CFSG/TypeE6.lean`, and after it milestone L3's `H_d = fixedSubgroup d.steinberg` and `d.Group = [H_d, H_d] / Z([H_d, H_d])`.

What remains before the `²E₆(q)` branch closes is the other factor of that composite, the graph automorphism `γ₂` realized on this carrier through the numbered-symmetry construction `UniversalEnvelopingAlgebra.kostantToralNumberedSymmetryIso`, together with Layer 9's identification of the carrier with the pinned simply connected Chevalley--Demazure group scheme; neither is asserted here, and no declaration below mentions the diagram symmetry. Nothing here asserts reductivity, maximality of the weight torus, an identification of the carrier's root datum, or any finiteness, perfectness or simplicity statement.

Add `TauCeti/Algebra/Lie/E6/DoubledMinuscule/Frobenius.lean` (198 lines), beside the carrier's existing `Basic`, `AdmissibleLattice`, `GroupScheme` and `PointsFunctor` modules. Every general fact about entrywise Frobenius on the points cut out by a Hopf ideal is consumed rather than reproved, from `TauCeti/Algebra/AlgebraicGroup/Frobenius/GeneralLinear.lean` and `TauCeti/GroupTheory/FixedSubgroup.lean`; the declaration names and shapes follow the three merged carrier specializations `Algebra/Lie/E6/Minuscule/Frobenius.lean`, `Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean` and `Algebra/Lie/Symplectic/StandardCarrier/Frobenius.lean`, and the power law follows `DynkinType.geckFrobenius_pow` in `LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Frobenius.lean`, all credited in the module documentation. No Mathlib PR material or other external formalization is vendored. The mathematical conventions follow R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17, R. W. Carter, *Simple Groups of Lie Type*, §12.2, for the doubled minuscule realization, and J. C. Jantzen, *Representations of Algebraic Groups*, II.1.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e6-doubled-minuscule-frobenius"}-->

🤖 Prepared with Claude Code
