### PR TITLE
feat: determine an alternating element by its dominant integral coefficients

### DIFF
--- a/TauCeti/Algebra/Lie/HighestWeight/Basic.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Basic.lean
@@ -49,6 +49,10 @@ combination of the simple coroots.
 
 ## Main results
 
+* `TauCeti.rootSystem_coroot'_apply`: the coroot functional of the abstract root-pairing API is
+  evaluation at the coroot, the dictionary through which the general root-system results apply to
+  dominance and integrality here.
+
 * `TauCeti.isHighestWeightVector_iff_forall_rootSpace`: it is enough to check that each *positive
   root space* annihilates `v`, the positive nilradical being spanned by them.
 * `TauCeti.IsHighestWeightVector.unique`: a vector is a highest weight vector for at most one
@@ -261,6 +265,16 @@ theorem coe_weight (hv : IsHighestWeightVector b lam v) : (hv.weight : H → K) 
 end IsHighestWeightVector
 
 /-! ### Dominant integral weights -/
+
+/-- **The two coroot interfaces agree.** The root system of a splitting Cartan subalgebra pairs a
+weight with a coroot by evaluation, so the coroot functional `RootPairing.coroot' i` of the
+abstract root-pairing API is evaluation at the coroot of `i`.
+
+This is the dictionary between the root-pairing formulation of dominance and integrality, in which
+the general root-system results are stated, and the Lie-theoretic one used below. -/
+theorem rootSystem_coroot'_apply (i : H.root) (chi : Dual K H) :
+    (IsKilling.rootSystem H).coroot' i chi = chi ((IsKilling.rootSystem H).coroot i) := by
+  rw [LinearMap.flip_apply, IsKilling.rootSystem_toLinearMap_apply]
 
 variable (b)
 

--- a/TauCeti/Algebra/Lie/HighestWeight/Basic.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Basic.lean
@@ -272,6 +272,7 @@ abstract root-pairing API is evaluation at the coroot of `i`.
 
 This is the dictionary between the root-pairing formulation of dominance and integrality, in which
 the general root-system results are stated, and the Lie-theoretic one used below. -/
+@[simp]
 theorem rootSystem_coroot'_apply (i : H.root) (chi : Dual K H) :
     (IsKilling.rootSystem H).coroot' i chi = chi ((IsKilling.rootSystem H).coroot i) := by
   rw [LinearMap.flip_apply, IsKilling.rootSystem_toLinearMap_apply]

--- a/TauCeti/Algebra/Lie/HighestWeight/Character.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Character.lean
@@ -51,10 +51,11 @@ the Weyl numerator `N(lam)` therefore comes down to a single further statement, 
 proved here: that no dominant integral weight other than `lam` carries a nonzero coefficient.
 
 The determination is read off from
-`TauCeti.IsDotAlternating.eq_of_forall_coeff_dominant_eq` rather than from the chamber statement
-`TauCeti.IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq`, whose fundamental domain is cut
-out by inequalities and so needs an order on the coefficient ring: the weight space here is a
-vector space over an algebraically closed field, which carries none.
+`TauCeti.IsDotAlternating.eq_of_forall_coeff_dominantIntegral_eq` rather than from the chamber
+statement `TauCeti.IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq`, whose fundamental
+domain is cut out by inequalities and so needs a linear order on the coefficient ring compatible
+with its ring structure: the ring here is an algebraically closed field, which carries no such
+order.
 
 ## Main results
 
@@ -67,8 +68,8 @@ vector space over an algebraically closed field, which carries none.
   and its **coefficient at `lam` is `1`**.
 * `TauCeti.formalCharacter_mul_weylDenominator_eq_of_forall_coeff_isDominantIntegral_eq`: **that
   product is determined by its coefficients at the dominant integral weights**, with
-  `TauCeti.exists_int_coroot'_of_coeff_formalCharacter_mul_weylDenominator_ne_zero` the
-  integrality of its support that the determination consumes.
+  `TauCeti.exists_intCast_eq_coroot'_of_sub_mem_posRootCone` the integrality of the weights below
+  `lam` that the determination consumes.
 
 ## References
 
@@ -212,18 +213,21 @@ theorem coeff_formalCharacter_mul_weylDenominator_eq_one_of_isHighestWeightVecto
 
 /-! ### Determination by the dominant integral coefficients -/
 
-/-- **Every simple coroot takes an integer value on the support of `ch M · Δ`.** The support lies
-in `lam - Q⁺`, where the coroot functionals take integer values
+omit hgen in
+/-- **Every simple coroot takes an integer value on a weight below `lam`.** The difference
+`lam - chi` lies in `Q⁺`, where the coroot functionals take integer values
 (`TauCeti.exists_intCast_eq_coroot'_of_mem_posRootCone`), and `lam` itself takes natural values on
-the simple coroots, being the weight of a highest weight vector in a finite-dimensional module. -/
-theorem exists_int_coroot'_of_coeff_formalCharacter_mul_weylDenominator_ne_zero
-    {chi : Dual K H} (hchi : (formalCharacter K H M *
-      weylDenominator (IsKilling.rootSystem H) b).coeff chi ≠ 0)
+the simple coroots, being the weight of a highest weight vector in a finite-dimensional module.
+
+This is the integrality that `TauCeti.IsDotAlternating.eq_of_forall_coeff_dominantIntegral_eq`
+consumes, and it applies to `ch M · Δ` through
+`TauCeti.sub_mem_posRootCone_of_coeff_formalCharacter_mul_weylDenominator_ne_zero`. -/
+theorem exists_intCast_eq_coroot'_of_sub_mem_posRootCone {chi : Dual K H}
+    (hchi : lam - chi ∈ posRootCone (IsKilling.rootSystem H) b)
     {i : H.root} (hi : i ∈ b.support) :
     ∃ z : ℤ, (IsKilling.rootSystem H).coroot' i chi = (z : K) := by
   obtain ⟨n, hn⟩ := isDominantIntegral_iff.mp hv.isDominantIntegral i hi
-  obtain ⟨m, hm⟩ := exists_intCast_eq_coroot'_of_mem_posRootCone (IsKilling.rootSystem H) b
-    (sub_mem_posRootCone_of_coeff_formalCharacter_mul_weylDenominator_ne_zero hv hgen hchi) i
+  obtain ⟨m, hm⟩ := exists_intCast_eq_coroot'_of_mem_posRootCone (IsKilling.rootSystem H) b hchi i
   rw [map_sub, rootSystem_coroot'_apply, rootSystem_coroot'_apply, hn] at hm
   refine ⟨(n : ℤ) - m, ?_⟩
   rw [rootSystem_coroot'_apply]
@@ -235,27 +239,29 @@ determined by its coefficients at the dominant integral weights.**
 
 This is what reduces the Weyl character formula `ch L(lam) · Δ = N(lam)` to a statement about the
 dominant integral weights alone: the two sides are alternating for the dot action and supported in
-`lam - Q⁺`, so `TauCeti.IsDotAlternating.eq_of_forall_coeff_dominant_eq` identifies them as soon
-as their dominant integral coefficients agree. The three hypotheses on the comparison element `g`
-are exactly the three properties of `ch M · Δ` proved above, so the statement is symmetric in the
-two sides; nothing about the Weyl group is asked of `g`. -/
+`lam - Q⁺`, so `TauCeti.IsDotAlternating.eq_of_forall_coeff_dominantIntegral_eq` identifies them as
+soon as their dominant integral coefficients agree. The two hypotheses on the comparison element
+`g` are exactly the two properties of `ch M · Δ` proved above, so the statement is symmetric in the
+two sides; beyond the dot alternation `hgalt`, no Weyl-orbit and no Weyl-group finiteness
+hypothesis is asked of `g`. Its integrality on the simple coroots is not asked either: it already
+follows from `hgcone`, by `TauCeti.exists_intCast_eq_coroot'_of_sub_mem_posRootCone`. -/
 theorem formalCharacter_mul_weylDenominator_eq_of_forall_coeff_isDominantIntegral_eq
     {g : AddMonoidAlgebra ℤ (Dual K H)} (hgalt : IsDotAlternating (IsKilling.rootSystem H) b g)
     (hgcone : ∀ chi : Dual K H, g.coeff chi ≠ 0 →
       lam - chi ∈ posRootCone (IsKilling.rootSystem H) b)
-    (hgint : ∀ chi : Dual K H, g.coeff chi ≠ 0 → ∀ i ∈ b.support,
-      ∃ z : ℤ, (IsKilling.rootSystem H).coroot' i chi = (z : K))
     (hagree : ∀ nu : Dual K H, IsDominantIntegral b nu →
       (formalCharacter K H M * weylDenominator (IsKilling.rootSystem H) b).coeff nu
         = g.coeff nu) :
     formalCharacter K H M * weylDenominator (IsKilling.rootSystem H) b = g := by
-  refine (isDotAlternating_formalCharacter_mul_weylDenominator b).eq_of_forall_coeff_dominant_eq
-    hgalt (fun _ hchi ↦
+  refine IsDotAlternating.eq_of_forall_coeff_dominantIntegral_eq
+    (isDotAlternating_formalCharacter_mul_weylDenominator b) hgalt
+    (fun _ hchi ↦
       sub_mem_posRootCone_of_coeff_formalCharacter_mul_weylDenominator_ne_zero hv hgen hchi)
     hgcone
-    (fun _ hchi _ hi ↦
-      exists_int_coroot'_of_coeff_formalCharacter_mul_weylDenominator_ne_zero hv hgen hchi hi)
-    hgint fun nu hnu ↦ hagree nu (isDominantIntegral_iff.mpr fun i hi ↦ ?_)
+    (fun _ hchi _ hi ↦ exists_intCast_eq_coroot'_of_sub_mem_posRootCone hv
+      (sub_mem_posRootCone_of_coeff_formalCharacter_mul_weylDenominator_ne_zero hv hgen hchi) hi)
+    (fun _ hchi _ hi ↦ exists_intCast_eq_coroot'_of_sub_mem_posRootCone hv (hgcone _ hchi) hi)
+    fun nu hnu ↦ hagree nu (isDominantIntegral_iff.mpr fun i hi ↦ ?_)
   obtain ⟨n, hn⟩ := hnu i hi
   exact ⟨n, by rwa [← rootSystem_coroot'_apply]⟩
 

--- a/TauCeti/Algebra/Lie/HighestWeight/Character.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Character.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.Lie.HighestWeight.Module
 public import TauCeti.Algebra.Lie.Weights.FormalCharacter
+public import TauCeti.LinearAlgebra.RootSystem.Weyl.IntegralDetermination
 public import TauCeti.LinearAlgebra.RootSystem.Weyl.Invariant
 -- `Invertible (2 : K)`, which the alternating-element API asks of the coefficient ring.
 public import Mathlib.Algebra.CharP.Invertible
@@ -43,11 +44,17 @@ the top weight space of a highest weight module is a line and the constant term 
 the positive root cone is pointed, so `lam` admits only the one decomposition.
 
 Together these are the input to the alternation step of the character formula: `ch M · Δ` is an
-alternating element, supported in `lam - Q⁺`, whose coefficient at `lam` is `1`. Identifying it
-with the Weyl numerator `N(lam)` through `TauCeti.IsDotAlternating.eq_weylNumerator` needs two
-further things, neither of them here: that no other weight of the open chamber of the dot action
-carries a nonzero coefficient, and, that chamber being defined over a linearly ordered coefficient
-ring, a passage to the rational form of the weight space.
+alternating element, supported in `lam - Q⁺`, whose coefficient at `lam` is `1`. Being alternating
+and supported in `lam - Q⁺` already pins the element down completely once its coefficients at the
+**dominant integral** weights are known, and the last result below says so. Identifying it with
+the Weyl numerator `N(lam)` therefore comes down to a single further statement, which is not
+proved here: that no dominant integral weight other than `lam` carries a nonzero coefficient.
+
+The determination is read off from
+`TauCeti.IsDotAlternating.eq_of_forall_coeff_dominant_eq` rather than from the chamber statement
+`TauCeti.IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq`, whose fundamental domain is cut
+out by inequalities and so needs an order on the coefficient ring: the weight space here is a
+vector space over an algebraically closed field, which carries none.
 
 ## Main results
 
@@ -58,6 +65,10 @@ ring, a passage to the rational form of the weight space.
   weight module of weight `lam`, that product is **supported in `lam - Q⁺`**;
 * `coeff_formalCharacter_mul_weylDenominator_eq_one_of_isHighestWeightVector_of_lieSpan_eq_top`:
   and its **coefficient at `lam` is `1`**.
+* `TauCeti.formalCharacter_mul_weylDenominator_eq_of_forall_coeff_isDominantIntegral_eq`: **that
+  product is determined by its coefficients at the dominant integral weights**, with
+  `TauCeti.exists_int_coroot'_of_coeff_formalCharacter_mul_weylDenominator_ne_zero` the
+  integrality of its support that the determination consumes.
 
 ## References
 
@@ -198,5 +209,54 @@ theorem coeff_formalCharacter_mul_weylDenominator_eq_one_of_isHighestWeightVecto
   rw [AddMonoidAlgebra.coeff_mul, Finsupp.sum_eq_single lam houter (fun h ↦ by simp [hchar] at h),
     Finsupp.sum_eq_single 0 hinner (fun h ↦ by rw [mul_zero, ite_self]),
     add_zero, ite_eq_left rfl, hchar, coeff_weylDenominator_zero, one_mul]
+
+/-! ### Determination by the dominant integral coefficients -/
+
+/-- **Every simple coroot takes an integer value on the support of `ch M · Δ`.** The support lies
+in `lam - Q⁺`, where the coroot functionals take integer values
+(`TauCeti.exists_intCast_eq_coroot'_of_mem_posRootCone`), and `lam` itself takes natural values on
+the simple coroots, being the weight of a highest weight vector in a finite-dimensional module. -/
+theorem exists_int_coroot'_of_coeff_formalCharacter_mul_weylDenominator_ne_zero
+    {chi : Dual K H} (hchi : (formalCharacter K H M *
+      weylDenominator (IsKilling.rootSystem H) b).coeff chi ≠ 0)
+    {i : H.root} (hi : i ∈ b.support) :
+    ∃ z : ℤ, (IsKilling.rootSystem H).coroot' i chi = (z : K) := by
+  obtain ⟨n, hn⟩ := isDominantIntegral_iff.mp hv.isDominantIntegral i hi
+  obtain ⟨m, hm⟩ := exists_intCast_eq_coroot'_of_mem_posRootCone (IsKilling.rootSystem H) b
+    (sub_mem_posRootCone_of_coeff_formalCharacter_mul_weylDenominator_ne_zero hv hgen hchi) i
+  rw [map_sub, rootSystem_coroot'_apply, rootSystem_coroot'_apply, hn] at hm
+  refine ⟨(n : ℤ) - m, ?_⟩
+  rw [rootSystem_coroot'_apply]
+  push_cast
+  linear_combination -hm
+
+/-- **The product of the formal character of a highest weight module with the Weyl denominator is
+determined by its coefficients at the dominant integral weights.**
+
+This is what reduces the Weyl character formula `ch L(lam) · Δ = N(lam)` to a statement about the
+dominant integral weights alone: the two sides are alternating for the dot action and supported in
+`lam - Q⁺`, so `TauCeti.IsDotAlternating.eq_of_forall_coeff_dominant_eq` identifies them as soon
+as their dominant integral coefficients agree. The three hypotheses on the comparison element `g`
+are exactly the three properties of `ch M · Δ` proved above, so the statement is symmetric in the
+two sides; nothing about the Weyl group is asked of `g`. -/
+theorem formalCharacter_mul_weylDenominator_eq_of_forall_coeff_isDominantIntegral_eq
+    {g : AddMonoidAlgebra ℤ (Dual K H)} (hgalt : IsDotAlternating (IsKilling.rootSystem H) b g)
+    (hgcone : ∀ chi : Dual K H, g.coeff chi ≠ 0 →
+      lam - chi ∈ posRootCone (IsKilling.rootSystem H) b)
+    (hgint : ∀ chi : Dual K H, g.coeff chi ≠ 0 → ∀ i ∈ b.support,
+      ∃ z : ℤ, (IsKilling.rootSystem H).coroot' i chi = (z : K))
+    (hagree : ∀ nu : Dual K H, IsDominantIntegral b nu →
+      (formalCharacter K H M * weylDenominator (IsKilling.rootSystem H) b).coeff nu
+        = g.coeff nu) :
+    formalCharacter K H M * weylDenominator (IsKilling.rootSystem H) b = g := by
+  refine (isDotAlternating_formalCharacter_mul_weylDenominator b).eq_of_forall_coeff_dominant_eq
+    hgalt (fun _ hchi ↦
+      sub_mem_posRootCone_of_coeff_formalCharacter_mul_weylDenominator_ne_zero hv hgen hchi)
+    hgcone
+    (fun _ hchi _ hi ↦
+      exists_int_coroot'_of_coeff_formalCharacter_mul_weylDenominator_ne_zero hv hgen hchi hi)
+    hgint fun nu hnu ↦ hagree nu (isDominantIntegral_iff.mpr fun i hi ↦ ?_)
+  obtain ⟨n, hn⟩ := hnu i hi
+  exact ⟨n, by rwa [← rootSystem_coroot'_apply]⟩
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/HighestWeight/WeightSupport.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/WeightSupport.lean
@@ -80,13 +80,6 @@ theorem finite_setOf_genWeightSpace_ne_bot_of_isHighestWeightVector
     (hlam : IsDominantIntegral b lam) :
     {chi : H → K | genWeightSpace M chi ≠ ⊥}.Finite := by
   have hgen : LieSubmodule.lieSpan K L {v} = ⊤ := lieSpan_singleton_eq_top_of_ne_zero hv.ne_zero
-  -- The root system of `H` pairs a weight with a coroot by evaluation, so its `coroot'` is
-  -- evaluation at `IsKilling.coroot`; this is the boundary between the two coroot interfaces.
-  have hcoroot' : ∀ (i : H.root) (chi : Dual K H),
-      (IsKilling.rootSystem H).coroot' i chi = chi (IsKilling.coroot (i : Weight K H L)) := by
-    intro i chi
-    rw [LinearMap.flip_apply, IsKilling.rootSystem_toLinearMap_apply,
-      IsKilling.rootSystem_coroot_apply]
   have hS : {chi : Dual K H | genWeightSpace M ((chi : Dual K H) : H → K) ≠ ⊥}.Finite := by
     refine finite_of_forall_reflection_mem_of_sub_mem_posRootCone (lam := lam) b
       (fun chi hchi ↦ ?_) (fun chi hchi i hi ↦ ?_) fun chi hchi i hi ↦ ?_
@@ -94,7 +87,7 @@ theorem finite_setOf_genWeightSpace_ne_bot_of_isHighestWeightVector
         hv hgen hchi
     · obtain ⟨m, hm⟩ := exists_int_apply_coroot_of_genWeightSpace_ne_bot_of_isHighestWeightVector
         hv hlam hi hchi
-      exact ⟨m, by rw [hcoroot' i chi, hm]⟩
+      exact ⟨m, by rw [rootSystem_coroot'_apply, IsKilling.rootSystem_coroot_apply, hm]⟩
     · exact genWeightSpace_rootSystem_reflection_ne_bot hv hlam hi hchi
   refine Set.Finite.subset (hS.image fun psi : Dual K H ↦ (psi : H → K)) fun chi hchi ↦ ?_
   obtain ⟨nu, -, heq⟩ :=

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/IntegralDetermination.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/IntegralDetermination.lean
@@ -17,7 +17,8 @@ An element of the integral group algebra `ℤ[M]` of the weight space of a root 
 the sign character. Such an element is determined by its coefficients on a fundamental domain of
 the dot action, and `TauCeti.IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq` says so with
 the fundamental domain taken to be the open dominant chamber of the dot action. That statement
-needs a `[LinearOrder R]` on the coefficient ring, because a chamber is cut out by inequalities.
+needs a `[LinearOrder R]` on the coefficient ring compatible with its ring structure
+(`[IsStrictOrderedRing R]`), because a chamber is cut out by inequalities.
 
 This file proves the same determination without any order on `R`, for an alternating element whose
 support is **integral** — every simple coroot takes an integer value on it — and lies **below** a
@@ -29,15 +30,16 @@ open dominant chamber of the dot action, read off arithmetically.
 
 Both hypotheses are met by the object the Weyl character formula is about: for a finite-dimensional
 highest weight module of weight `lam`, the product of the formal character with the Weyl
-denominator is alternating and supported in `lam - Q⁺`, while the weight space of a Lie algebra
-over an algebraically closed field carries no order at all.
+denominator is alternating and supported in `lam - Q⁺`, while the coefficient ring there is an
+algebraically closed field, which carries no linear order making it a strictly ordered ring, so
+that the chamber statement does not apply to it.
 
 ## Main results
 
-* `TauCeti.IsDotAlternating.eq_zero_of_forall_coeff_dominant_eq_zero`: **an alternating element
-  below `lam` whose dominant integral coefficients all vanish is zero.**
-* `TauCeti.IsDotAlternating.eq_of_forall_coeff_dominant_eq`: **two alternating elements below
-  `lam` agreeing at every dominant integral weight are equal.**
+* `TauCeti.IsDotAlternating.eq_zero_of_forall_coeff_dominantIntegral_eq_zero`: **an alternating
+  element below `lam` whose dominant integral coefficients all vanish is zero.**
+* `TauCeti.IsDotAlternating.eq_of_forall_coeff_dominantIntegral_eq`: **two alternating elements
+  below `lam` agreeing at every dominant integral weight are equal.**
 
 ## The argument
 
@@ -82,7 +84,7 @@ variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
 namespace IsDotAlternating
 
 /-- The raising induction behind
-`TauCeti.IsDotAlternating.eq_zero_of_forall_coeff_dominant_eq_zero`, run on the height of
+`TauCeti.IsDotAlternating.eq_zero_of_forall_coeff_dominantIntegral_eq_zero`, run on the height of
 `lam - x`: a weight on which some simple coroot takes a value below `-1` is moved by the dot
 reflection in that root to a weight of strictly smaller height and opposite coefficient. -/
 private theorem coeff_eq_zero_of_heightLinearMap_eq (hf : IsDotAlternating P b f)
@@ -135,7 +137,7 @@ The support is assumed to lie in `lam - Q⁺` and to be integral on the simple c
 conclusion is that a coefficient at a weight with a negative simple coroot value is forced to
 vanish as well, either because the weight lies on a wall of the dot action or because the dot
 reflection carries it to a weight strictly closer to `lam`. -/
-theorem eq_zero_of_forall_coeff_dominant_eq_zero (hf : IsDotAlternating P b f)
+theorem eq_zero_of_forall_coeff_dominantIntegral_eq_zero (hf : IsDotAlternating P b f)
     (hcone : ∀ x : M, f.coeff x ≠ 0 → lam - x ∈ posRootCone P b)
     (hint : ∀ x : M, f.coeff x ≠ 0 → ∀ i ∈ b.support, ∃ z : ℤ, P.coroot' i x = (z : R))
     (hdom : ∀ x : M, (∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i x = (n : R)) → f.coeff x = 0) :
@@ -153,7 +155,8 @@ This is the order-free counterpart of
 `TauCeti.IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq`: the dominant integral weights
 replace the open dominant chamber of the dot action, at the cost of the two support hypotheses,
 which the character of a highest weight module satisfies. -/
-theorem eq_of_forall_coeff_dominant_eq (hf : IsDotAlternating P b f) (hg : IsDotAlternating P b g)
+theorem eq_of_forall_coeff_dominantIntegral_eq (hf : IsDotAlternating P b f)
+    (hg : IsDotAlternating P b g)
     (hconef : ∀ x : M, f.coeff x ≠ 0 → lam - x ∈ posRootCone P b)
     (hconeg : ∀ x : M, g.coeff x ≠ 0 → lam - x ∈ posRootCone P b)
     (hintf : ∀ x : M, f.coeff x ≠ 0 → ∀ i ∈ b.support, ∃ z : ℤ, P.coroot' i x = (z : R))
@@ -167,7 +170,7 @@ theorem eq_of_forall_coeff_dominant_eq (hf : IsDotAlternating P b f) (hg : IsDot
     push Not at hc
     exact hxne (by simp [AddMonoidAlgebra.coeff_sub, hc.1, hc.2])
   rw [← sub_eq_zero]
-  refine (hf.sub hg).eq_zero_of_forall_coeff_dominant_eq_zero (lam := lam)
+  refine (hf.sub hg).eq_zero_of_forall_coeff_dominantIntegral_eq_zero (lam := lam)
     (fun x hx ↦ (hsplit x hx).elim (hconef x) (hconeg x))
     (fun x hx ↦ (hsplit x hx).elim (hintf x) (hintg x)) fun x hx ↦ ?_
   simp [AddMonoidAlgebra.coeff_sub, hagree x hx]

--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/IntegralDetermination.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/IntegralDetermination.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.Weyl.Alternating
+
+public section
+
+/-!
+# An alternating element below a weight is determined by its dominant integral coefficients
+
+An element of the integral group algebra `ℤ[M]` of the weight space of a root system is
+*alternating* for the dot action (`TauCeti.IsDotAlternating`) when its coefficients transform by
+the sign character. Such an element is determined by its coefficients on a fundamental domain of
+the dot action, and `TauCeti.IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq` says so with
+the fundamental domain taken to be the open dominant chamber of the dot action. That statement
+needs a `[LinearOrder R]` on the coefficient ring, because a chamber is cut out by inequalities.
+
+This file proves the same determination without any order on `R`, for an alternating element whose
+support is **integral** — every simple coroot takes an integer value on it — and lies **below** a
+fixed weight `lam`, in the sense that `lam - x` is a nonnegative integer combination of the simple
+roots. The fundamental domain is then described arithmetically rather than by inequalities: a
+weight `x` is taken to be *dominant integral* when every simple coroot takes a **natural** value
+on it. Since `⟨ρ, αᵢ^∨⟩ = 1`, that is exactly the condition `⟨x + ρ, αᵢ^∨⟩ > 0` cutting out the
+open dominant chamber of the dot action, read off arithmetically.
+
+Both hypotheses are met by the object the Weyl character formula is about: for a finite-dimensional
+highest weight module of weight `lam`, the product of the formal character with the Weyl
+denominator is alternating and supported in `lam - Q⁺`, while the weight space of a Lie algebra
+over an algebraically closed field carries no order at all.
+
+## Main results
+
+* `TauCeti.IsDotAlternating.eq_zero_of_forall_coeff_dominant_eq_zero`: **an alternating element
+  below `lam` whose dominant integral coefficients all vanish is zero.**
+* `TauCeti.IsDotAlternating.eq_of_forall_coeff_dominant_eq`: **two alternating elements below
+  `lam` agreeing at every dominant integral weight are equal.**
+
+## The argument
+
+Suppose `f.coeff x ≠ 0` and `x` is not dominant integral, so that some simple coroot takes a
+negative integer value `z` on `x`.
+
+* If `z = -1` then `x` lies on the wall of the simple reflection `sᵢ` for the dot action, and an
+  alternating element vanishes there
+  (`TauCeti.IsDotAlternating.coeff_eq_zero_of_coroot'_eq_neg_one`).
+* Otherwise `z ≤ -2` and the dot reflection `sᵢ ⬝ x = x - (z + 1) αᵢ` *raises* `x` by the positive
+  multiple `-(z+1)` of `αᵢ`. Its coefficient is `-f.coeff x`, again nonzero, so it too lies below
+  `lam`, and the height of `lam - sᵢ ⬝ x` is smaller by `-(z+1) ≥ 1`.
+
+Induction on that height — a natural number, because `lam - x` lies in the positive root cone
+(`TauCeti.exists_natCast_eq_heightLinearMap_of_mem_posRootCone`) — therefore reaches a dominant
+integral weight, where the hypothesis applies. No Weyl-group orbit and no finiteness of the Weyl
+group enters: the raising is by a single simple reflection at a time.
+
+## References
+
+This supplies the order-free replacement, named as missing in
+`TauCeti/Algebra/Lie/HighestWeight/Character.lean`, for the chamber step of the Weyl character
+formula of Layer 6 of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`.
+
+The raising induction is the one of `TauCeti/LinearAlgebra/RootSystem/DominantCone.lean`, run for
+the dot action instead of the linear one.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §13.2 and
+  §24.2.
+-/
+
+namespace TauCeti
+
+universe u v w x
+
+variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  {P : _root_.RootPairing ι R M N} [Finite ι] [CharZero R] [IsDomain R] [Invertible (2 : R)]
+  [P.IsRootSystem] [P.IsCrystallographic] [P.IsReduced] {b : P.Base}
+  {lam : M} {f g : AddMonoidAlgebra ℤ M}
+
+namespace IsDotAlternating
+
+/-- The raising induction behind
+`TauCeti.IsDotAlternating.eq_zero_of_forall_coeff_dominant_eq_zero`, run on the height of
+`lam - x`: a weight on which some simple coroot takes a value below `-1` is moved by the dot
+reflection in that root to a weight of strictly smaller height and opposite coefficient. -/
+private theorem coeff_eq_zero_of_heightLinearMap_eq (hf : IsDotAlternating P b f)
+    (hcone : ∀ x : M, f.coeff x ≠ 0 → lam - x ∈ posRootCone P b)
+    (hint : ∀ x : M, f.coeff x ≠ 0 → ∀ i ∈ b.support, ∃ z : ℤ, P.coroot' i x = (z : R))
+    (hdom : ∀ x : M, (∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i x = (n : R)) → f.coeff x = 0) :
+    ∀ n : ℕ, ∀ x : M, heightLinearMap P b (lam - x) = (n : R) → f.coeff x = 0 := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro x hx
+    by_contra hne
+    by_cases hd : ∀ i ∈ b.support, ∃ m : ℕ, P.coroot' i x = (m : R)
+    · exact hne (hdom x hd)
+    push Not at hd
+    obtain ⟨i, hi, hnotnat⟩ := hd
+    obtain ⟨z, hz⟩ := hint x hne i hi
+    have hzneg : z < 0 := by
+      by_contra hc
+      push Not at hc
+      exact hnotnat z.toNat
+        (by rw [hz, ← Int.cast_natCast (R := R) z.toNat, Int.toNat_of_nonneg hc])
+    rcases eq_or_lt_of_le (by omega : z ≤ -1) with hwall | hlt
+    · refine hne (hf.coeff_eq_zero_of_coroot'_eq_neg_one hi ?_)
+      rw [hz, hwall]
+      norm_num
+    -- Below the wall the dot reflection raises `x` strictly.
+    set y := dotAction P b (_root_.RootPairing.weylGroup.ofIdx P i) x with hy
+    have hyx : y = x - ((z : R) + 1) • P.root i := by
+      rw [hy, dotAction_ofIdx P b hi, hz]
+    have hyc : f.coeff y ≠ 0 := by
+      rw [hy, hf.coeff_dotAction, weylSign_ofIdx]
+      simpa using hne
+    obtain ⟨m, hm⟩ := exists_natCast_eq_heightLinearMap_of_mem_posRootCone P b (hcone y hyc)
+    -- The height drops by `-(z+1) ≥ 1`.
+    have hheight : (m : R) = (n : R) + ((z : R) + 1) := by
+      have hsub : lam - y = (lam - x) + ((z : R) + 1) • P.root i := by
+        rw [hyx]; abel
+      rw [← hm, hsub, map_add, map_smul, heightLinearMap_simpleRoot P b ⟨i, hi⟩, hx,
+        smul_eq_mul, mul_one]
+    have hcast : ((m : ℤ) : R) = (((n : ℤ) + z + 1 : ℤ) : R) := by push_cast; rw [hheight]; ring
+    have hmn : (m : ℤ) < (n : ℤ) := by
+      have := Int.cast_injective (α := R) hcast
+      omega
+    exact hyc (ih m (by exact_mod_cast hmn) y hm)
+
+/-- **An alternating element below `lam` whose dominant integral coefficients all vanish is zero.**
+
+The support is assumed to lie in `lam - Q⁺` and to be integral on the simple coroots; the
+conclusion is that a coefficient at a weight with a negative simple coroot value is forced to
+vanish as well, either because the weight lies on a wall of the dot action or because the dot
+reflection carries it to a weight strictly closer to `lam`. -/
+theorem eq_zero_of_forall_coeff_dominant_eq_zero (hf : IsDotAlternating P b f)
+    (hcone : ∀ x : M, f.coeff x ≠ 0 → lam - x ∈ posRootCone P b)
+    (hint : ∀ x : M, f.coeff x ≠ 0 → ∀ i ∈ b.support, ∃ z : ℤ, P.coroot' i x = (z : R))
+    (hdom : ∀ x : M, (∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i x = (n : R)) → f.coeff x = 0) :
+    f = 0 := by
+  rw [← AddMonoidAlgebra.coeff_eq_zero]
+  refine Finsupp.ext fun x ↦ ?_
+  by_cases hne : f.coeff x = 0
+  · simpa using hne
+  obtain ⟨n, hn⟩ := exists_natCast_eq_heightLinearMap_of_mem_posRootCone P b (hcone x hne)
+  exact absurd (hf.coeff_eq_zero_of_heightLinearMap_eq hcone hint hdom n x hn) hne
+
+/-- **Two alternating elements below `lam` agreeing at every dominant integral weight are equal.**
+
+This is the order-free counterpart of
+`TauCeti.IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq`: the dominant integral weights
+replace the open dominant chamber of the dot action, at the cost of the two support hypotheses,
+which the character of a highest weight module satisfies. -/
+theorem eq_of_forall_coeff_dominant_eq (hf : IsDotAlternating P b f) (hg : IsDotAlternating P b g)
+    (hconef : ∀ x : M, f.coeff x ≠ 0 → lam - x ∈ posRootCone P b)
+    (hconeg : ∀ x : M, g.coeff x ≠ 0 → lam - x ∈ posRootCone P b)
+    (hintf : ∀ x : M, f.coeff x ≠ 0 → ∀ i ∈ b.support, ∃ z : ℤ, P.coroot' i x = (z : R))
+    (hintg : ∀ x : M, g.coeff x ≠ 0 → ∀ i ∈ b.support, ∃ z : ℤ, P.coroot' i x = (z : R))
+    (hagree : ∀ x : M, (∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i x = (n : R)) →
+      f.coeff x = g.coeff x) :
+    f = g := by
+  have hsplit : ∀ x : M, (f - g).coeff x ≠ 0 → f.coeff x ≠ 0 ∨ g.coeff x ≠ 0 := by
+    intro x hxne
+    by_contra hc
+    push Not at hc
+    exact hxne (by simp [AddMonoidAlgebra.coeff_sub, hc.1, hc.2])
+  rw [← sub_eq_zero]
+  refine (hf.sub hg).eq_zero_of_forall_coeff_dominant_eq_zero (lam := lam)
+    (fun x hx ↦ (hsplit x hx).elim (hconef x) (hconeg x))
+    (fun x hx ↦ (hsplit x hx).elim (hintf x) (hintg x)) fun x hx ↦ ?_
+  simp [AddMonoidAlgebra.coeff_sub, hagree x hx]
+
+end IsDotAlternating
+
+end TauCeti


### PR DESCRIPTION
This PR proves that an element of the integral group algebra `ℤ[M]` of the weight space of a root system which is alternating for the dot action, takes integer values on the simple coroots throughout its support, and is supported below a weight `lam` (that is, `lam - x ∈ Q⁺` on its support) is **determined by its coefficients at the dominant integral weights**, and reads that determination off for the product `ch M · Δ` of the formal character of a finite-dimensional highest weight module with the Weyl denominator.

The milestone is the Weyl character formula of Layer 6 ("the Weyl character, dimension, and Kostant formulas") of `RepresentationTheory/LieHighestWeight/README.md`, whose target `weyl_character_formula` — `ch L(λ) · ∏_{α>0}(1 - e^{-α}) = ∑_w sgn(w) e^{w(λ+ρ)-ρ}` — is pinned in that roadmap's `Suggested.lean`. `TauCeti/Algebra/Lie/HighestWeight/Character.lean` already establishes on `main` that `ch M · Δ` is alternating for the dot action, is supported in `lam - Q⁺`, and has coefficient `1` at `lam`, and its module docstring names the two things still missing before `TauCeti.IsDotAlternating.eq_weylNumerator` can be applied: "that no other weight of the open chamber of the dot action carries a nonzero coefficient, and, that chamber being defined over a linearly ordered coefficient ring, a passage to the rational form of the weight space". This PR removes the second. What remains of the milestone after it is the first: that no dominant integral weight other than `lam` carries a nonzero coefficient, which is the Casimir-length argument run against `TauCeti.freudenthal_multiplicity_formula`, and then the Weyl dimension and Kostant formulas that specialise the character identity.

The obstruction was real rather than presentational. The existing determination theorem `TauCeti.IsDotAlternating.eq_of_coeff_openDotDominantChamber_eq` describes its fundamental domain as the open dominant chamber of the dot action, cut out by the inequalities `0 ≤ ⟨x, αᵢ^∨⟩`, so it carries `[LinearOrder R]`; the weight space `Module.Dual K H` of a Killing-semisimple Lie algebra is a vector space over an algebraically closed field, which carries no order. The replacement describes the same fundamental domain arithmetically: since `⟨ρ, αᵢ^∨⟩ = 1`, a weight is strictly dominant for the dot action exactly when every simple coroot takes a **natural** value on it, and that is a condition on integers rather than on an order on `R`. This is the same reading of dominance that `TauCeti/LinearAlgebra/RootSystem/DominantCone.lean` already uses.

The proof is a raising induction on the height of `lam - x`, a natural number because `lam - x` lies in the positive root cone. If `x` is in the support and not dominant integral, some simple coroot takes a negative integer value `z` on it. When `z = -1` the weight lies on the wall of the dot reflection `sᵢ`, where an alternating element vanishes by the existing `TauCeti.IsDotAlternating.coeff_eq_zero_of_coroot'_eq_neg_one`. Otherwise `z ≤ -2` and `sᵢ ⬝ x = x - (z+1) αᵢ` raises `x` by the positive multiple `-(z+1)` of `αᵢ`, with coefficient `-f.coeff x`, still nonzero and hence still below `lam`, and with the height of `lam - sᵢ ⬝ x` smaller by at least one. No Weyl-group orbit and no finiteness of the Weyl group is involved; the induction reflects one simple root at a time.

New file `TauCeti/LinearAlgebra/RootSystem/Weyl/IntegralDetermination.lean` states this for a base of a finite reduced crystallographic root system over a characteristic-zero domain with `2` invertible, the generality of the alternating-element API it extends: `IsDotAlternating.eq_zero_of_forall_coeff_dominant_eq_zero` and its comparison form `IsDotAlternating.eq_of_forall_coeff_dominant_eq`.

`TauCeti/Algebra/Lie/HighestWeight/Character.lean` gains the Lie-level reading, `formalCharacter_mul_weylDenominator_eq_of_forall_coeff_isDominantIntegral_eq`, together with `exists_int_coroot'_of_coeff_formalCharacter_mul_weylDenominator_ne_zero`, the integrality of the support of `ch M · Δ` that the determination consumes: the support lies in `lam - Q⁺`, where coroot functionals take integer values, and `lam` is dominant integral because it is the weight of a highest weight vector in a finite-dimensional module. The three hypotheses the comparison element carries are exactly the three properties of `ch M · Δ` proved in that file, so the statement is symmetric in its two sides.

Two small supporting changes. `TauCeti.rootSystem_coroot'_apply` in `TauCeti/Algebra/Lie/HighestWeight/Basic.lean` names the dictionary between the two coroot interfaces — the coroot functional `RootPairing.coroot'` of the abstract API is evaluation at `IsKilling.coroot` — which the root-system statements have to be read through; it was previously an unnamed local `have` inside the proof of `TauCeti.finite_setOf_genWeightSpace_ne_bot_of_isHighestWeightVector`, and `TauCeti/Algebra/Lie/HighestWeight/WeightSupport.lean` now uses the named lemma instead.

The argument is the standard one; it follows J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §13.2 and §24.2, cited in the module docstring. Nothing was vendored or adapted from another formalization.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"formalcharacter-mul-weyldenominator-eq-weylnumerator-iff"}-->

🤖 Prepared with Claude Code
