### PR TITLE
feat: specialize the unitarian trick and Maschke to a finite group

### DIFF
--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -5,7 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.RepresentationTheory.AsModule
 public import TauCeti.RepresentationTheory.Compact.Intertwiner.Dimension
+public import TauCeti.RepresentationTheory.Compact.UnitaryModel
+public import TauCeti.RepresentationTheory.Continuous.OrthogonalDecomposition
 public import Mathlib.MeasureTheory.Measure.Count
 public import Mathlib.Probability.UniformOn
 import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
@@ -81,6 +84,14 @@ measure computation has just identified.
 * `ContRepresentation.character_orthonormal_distinct_sum`: **the off-diagonal branch of the first
   (row) character orthogonality relation as a finite average**. (The column sum over the irreducible
   characters, the second orthogonality relation, is not treated here.)
+* `ContRepresentation.inner_gramOperator_eq_inv_mul_sum`: **the invariant form the unitarian trick
+  averages into existence is the finite average** `|G|⁻¹ ∑ g, ⟪π g v, π g w⟫`, with
+  `ContRepresentation.gramOperator_eq_smul_sum` the same identity at the level of the operator
+  representing it and `ContRepresentation.inner_gramOperator_self_eq_inv_mul_sum` its diagonal.
+* `ContRepresentation.exists_isUnitary_congr_of_finite`: **the unitarian trick for a finite group**,
+  every finite-dimensional representation being conjugate to a unitary one.
+* `ContRepresentation.exists_orthogonal_irreducible_decomposition_of_finite`: **Maschke's theorem in
+  orthogonal form**, the finite shadow of complete reducibility.
 
 The counting identity `|G|⁻¹ ∑ g, χ_π g = dim V^G` that the compact-group character integral
 generalizes then costs one rewrite. It is not given a name: Mathlib already proves it, as
@@ -142,10 +153,13 @@ Schur and character-orthonormality part of that item: `L²(G)` is `G → 𝕜` b
 `schur_orthogonality_self`, `schur_orthogonality_distinct` and
 `schur_orthogonality` become the classical orthogonality relations for matrix coefficients, and
 `character_orthonormal_self` and `character_orthonormal_distinct` become the two branches of
-Mathlib's `Representation.char_orthonormal`, exhibited by the two anonymous `example`s closing the
-file. The two specializations the roadmap item asks for that are still missing are Maschke (the
-finite shadow of complete reducibility) and Peter-Weyl
-(that `peterWeylBasis` is the matrix-coefficient basis of `k[G]`); neither is proved here.
+Mathlib's `Representation.char_orthonormal`, exhibited by two anonymous `example`s. It is finally
+the Maschke part of that item: `exists_orthogonal_irreducible_decomposition` specializes, through
+the finite unitarian trick, to
+`TauCeti.ContRepresentation.exists_orthogonal_irreducible_decomposition_of_finite`, and Mathlib's
+plain semisimplicity is recovered from it in the `example` closing the file. The one specialization
+the roadmap item asks for that is still missing is Peter-Weyl (that `peterWeylBasis` is the
+matrix-coefficient basis of `k[G]`); it is not proved here.
 -/
 
 public section
@@ -676,5 +690,129 @@ example (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (hunitary : IsU
     rw [character_apply_inv ρ hρ hunitary, mul_comm])
 
 end CharacterOrthogonality
+
+/-! ### The unitarian trick and Maschke -/
+
+section Unitarization
+
+variable {𝕜 G V : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSpace G]
+  [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+
+/-- As in the trace section above, completeness of `V` is not an extra hypothesis but a consequence
+of finite-dimensionality, installed locally because Mathlib keeps `FiniteDimensional.complete` out
+of the global instance set. -/
+local instance instCompleteSpaceUnitarization : CompleteSpace V :=
+  FiniteDimensional.complete 𝕜 V
+
+variable (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+
+include hπ
+
+/-- **The averaged invariant form of a finite group is the group average**
+`⟪v, w⟫_G = |G|⁻¹ ∑ g, ⟪π g v, π g w⟫`. This is the form Weyl's unitarian trick averages into
+existence, read off the Gram operator that represents it
+(`TauCeti.ContRepresentation.inner_gramOperator`) through
+`TauCeti.integral_haarProb_eq_inv_mul_sum`; for a finite group it is the classical averaging
+`⟪·, ·⟫ ↦ |G|⁻¹ ∑ g, ⟪π g ·, π g ·⟫` of the finite-group proof, and the normalization `|G|⁻¹` is
+the one that fixes the form on the invariants. -/
+theorem inner_gramOperator_eq_inv_mul_sum (v w : V) :
+    ⟪v, gramOperator π hπ w⟫_𝕜 = (Nat.card G : 𝕜)⁻¹ * ∑ g, ⟪π g v, π g w⟫_𝕜 := by
+  rw [inner_gramOperator, integral_haarProb_eq_inv_mul_sum]
+
+/-- **The averaged form of a finite group on the diagonal is the average of `‖π g v‖ ^ 2`.** This is
+the finite form of the positive definiteness that makes the unitarian trick work: the average of
+`|G|` nonnegative reals, one of which is `‖v‖ ^ 2` at `g = 1`, is positive for `v ≠ 0`. Compactness
+of `G` enters the general statement `TauCeti.ContRepresentation.inner_gramOperator_self` twice, once
+to integrate and once to bound the operator norms from below; a finite group needs neither. -/
+theorem inner_gramOperator_self_eq_inv_mul_sum (v : V) :
+    ⟪gramOperator π hπ v, v⟫_𝕜 = (((Nat.card G : ℝ)⁻¹ * ∑ g, ‖π g v‖ ^ 2 : ℝ) : 𝕜) := by
+  rw [inner_gramOperator_self, integral_haarProb, smul_eq_mul]
+
+/-- **The Gram operator of a finite group is the averaged sum of the operators `(π g)† ∘ (π g)`.**
+This is `TauCeti.ContRepresentation.inner_gramOperator_eq_inv_mul_sum` at the level of operators:
+each summand is the Gram operator of the pulled-back form `(v, w) ↦ ⟪π g v, π g w⟫`, and the Haar
+average of the family is their group average. -/
+theorem gramOperator_eq_smul_sum :
+    gramOperator π hπ =
+      (Nat.card G : 𝕜)⁻¹ • ∑ g, (ContinuousLinearMap.adjoint (π g)).comp (π g) := by
+  refine ContinuousLinearMap.ext fun w ↦ ext_inner_left 𝕜 fun v ↦ ?_
+  rw [inner_gramOperator_eq_inv_mul_sum, smul_apply, sum_apply, inner_smul_right, inner_sum]
+  exact congrArg _ (Finset.sum_congr rfl fun g _ ↦
+    (ContinuousLinearMap.adjoint_inner_right (π g) v (π g w)).symm)
+
+end Unitarization
+
+section Maschke
+
+variable {𝕜 G V : Type*} [RCLike 𝕜] [Group G] [Finite G] [TopologicalSpace G]
+  [DiscreteTopology G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+
+/-- **The unitarian trick for a finite group.** Every finite-dimensional representation of a finite
+discrete group on an inner product space is conjugate, by a continuous linear automorphism of the
+carrier, to one preserving the inner product.
+
+This is `TauCeti.ContRepresentation.exists_isUnitary_congr` with the compactness hypotheses
+discharged: a finite discrete group is compact, every representation of it is continuous by
+`continuous_of_discreteTopology`, and the statement mentions no measure, so the proof installs the
+Borel structure it averages against and the caller is left with a bare finite discrete group. The
+form being averaged is the explicit `|G|⁻¹ ∑ g, ⟪π g ·, π g ·⟫` of
+`TauCeti.ContRepresentation.inner_gramOperator_eq_inv_mul_sum`. -/
+theorem exists_isUnitary_congr_of_finite (π : ContRepresentation 𝕜 G V) :
+    ∃ e : V ≃L[𝕜] V, IsUnitary (congr e π) := by
+  let _ : MeasurableSpace G := borel G
+  have _ : BorelSpace G := ⟨rfl⟩
+  exact exists_isUnitary_congr π continuous_of_discreteTopology
+
+/-- **Maschke's theorem in orthogonal form.** A finite-dimensional representation of a finite
+discrete group on an inner product space becomes, after conjugating by a continuous linear
+automorphism `e` of the carrier, a *unitary* representation that is an orthogonal internal direct
+sum of finitely many irreducible subrepresentations, of dimensions adding up to `dim V`.
+
+This is the finite shadow of complete reducibility: unitarity is not assumed but produced, by the
+finite unitarian trick `TauCeti.ContRepresentation.exists_isUnitary_congr_of_finite`, and the
+decomposition is then
+`TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition` with no further
+hypotheses. Conjugating by `e` is unavoidable and is what "Maschke" costs here: Lean fixes one
+inner product on `V`, and a representation of a finite group need not preserve it, only the average
+`|G|⁻¹ ∑ g, ⟪π g ·, π g ·⟫` of its translates. It is the orthogonality that the compact theory
+contributes over Mathlib's Maschke, which produces complements but no inner product; the plain
+semisimplicity is recovered from the unitary model in the `example` below. -/
+theorem exists_orthogonal_irreducible_decomposition_of_finite (π : ContRepresentation 𝕜 G V) :
+    ∃ (e : V ≃L[𝕜] V) (n : ℕ) (U : Fin n → Subrepresentation (congr e π).toRepresentation),
+      IsUnitary (congr e π) ∧
+      (∀ i, (U i).toRepresentation.IsIrreducible) ∧
+      OrthogonalFamily 𝕜 (fun i ↦ (U i).toSubmodule) (fun i ↦ ((U i).toSubmodule).subtypeₗᵢ) ∧
+      DirectSum.IsInternal (fun i ↦ (U i).toSubmodule) ∧
+      Module.finrank 𝕜 V = ∑ i, Module.finrank 𝕜 (U i).toSubmodule := by
+  obtain ⟨e, he⟩ := exists_isUnitary_congr_of_finite π
+  obtain ⟨n, U, hirr, horth, hinternal, hdim⟩ := he.exists_orthogonal_irreducible_decomposition
+  exact ⟨e, n, U, he, hirr, horth, hinternal, hdim⟩
+
+/- **Maschke's theorem.** Every finite-dimensional representation of a finite discrete group on an
+inner product space is semisimple: every subrepresentation has a complement.
+
+No name is claimed, for the same reason as in the counting and orthogonality identities above: this
+is already an instance in Mathlib, for any field in which `|G|` is invertible. What the compact
+theory contributes is the derivation — the unitary model of
+`exists_orthogonal_irreducible_decomposition_of_finite`, whose orthogonal complements are the
+complements Maschke asks for, carried back to `π` along `e`, which is an equivalence of
+representations onto the model by the definition
+`TauCeti.ContRepresentation.congr_apply` of the transported action. That is the sense in which the
+compact complete reducibility of Layer 2 specializes to Maschke. -/
+example (π : ContRepresentation 𝕜 G V) :
+    Representation.IsSemisimpleRepresentation π.toRepresentation := by
+  obtain ⟨e, he⟩ := exists_isUnitary_congr_of_finite π
+  have φ : π.toRepresentation.Equiv (congr e π).toRepresentation :=
+    Representation.Equiv.mk (e : V ≃ₗ[𝕜] V) fun g ↦ LinearMap.ext fun v ↦ by
+      simp [_root_.ContRepresentation.toMonoidHom_apply]
+  have _ := he.isSemisimpleModule_asModule
+  rw [Representation.isSemisimpleRepresentation_iff_isSemisimpleModule_asModule]
+  exact .congr (TauCeti.Representation.asModuleLinearEquivOfEquiv φ)
+
+end Maschke
 
 end ContRepresentation

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -143,28 +143,27 @@ The scalar in the averaged sums is real, not `𝕜`: the Bochner integral being 
 
 ## References
 
-This is the measure-identification and character-count part of the worked example "finite groups
-recover the character theory" of the
-[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md):
-`haarProb G` is the normalized counting measure `|G|⁻¹ • count`, and the counting identity
+The compact-group theory specialized here is the one developed in the
+[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
+and each statement below is the finite case of the compact one named beside it. `haarProb G` is the
+normalized counting measure `|G|⁻¹ • count`, and the counting identity
 `dim V^G = |G|⁻¹ ∑ g, χ_π g` is the finite shadow of
 `ContRepresentation.integral_character_eq_finrank_invariants`, matching Mathlib's
-`FDRep.average_char_eq_finrank_invariants` for the purely algebraic theory. It is also the `L²`,
-Schur and character-orthonormality part of that item: `L²(G)` is `G → 𝕜` by
+`FDRep.average_char_eq_finrank_invariants` for the purely algebraic theory. `L²(G)` is `G → 𝕜` by
 `TauCeti.lpHaarProbEquivFun` and `⟪·, ·⟫_{L²(G)}` becomes the finite Hermitian pairing on it,
 `schur_orthogonality_self`, `schur_orthogonality_distinct` and
 `schur_orthogonality` become the classical orthogonality relations for matrix coefficients, and
 `character_orthonormal_self` and `character_orthonormal_distinct` become the two branches of
-Mathlib's `Representation.char_orthonormal`, exhibited by two anonymous `example`s. It is finally
-the Maschke part of that item: `exists_orthogonal_irreducible_decomposition` specializes, through
-the finite unitarian trick, to
+Mathlib's `Representation.char_orthonormal`, exhibited by two anonymous `example`s. Finally
+`exists_orthogonal_irreducible_decomposition` specializes, through the finite unitarian trick, to
 `ContRepresentation.exists_orthogonal_irreducible_decomposition_of_finite`, whose blocks are
 subrepresentations of the given representation, carried back along the unitarizing equivalence
-`ContRepresentation.congrEquiv`. What that specialization adds to Mathlib's Maschke — which is
-already an instance, for every field in which `|G|` is invertible, and hence is not restated
-here — is the orthogonality of the summands, which needs the inner product Mathlib's complements
-do not see. The one specialization the roadmap item asks for that is still missing is Peter-Weyl
-(that `peterWeylBasis` is the matrix-coefficient basis of `k[G]`); it is not proved here.
+`ContRepresentation.congrEquiv`. What that specialization adds to Mathlib's Maschke is the
+orthogonality of the summands, which needs the inner product Mathlib's complements do not see; the
+purely algebraic conclusion, that `π.toRepresentation.asModule` is a semisimple
+`MonoidAlgebra 𝕜 G`-module whenever `|G|` is invertible in `𝕜`, is Mathlib's own instance and is
+neither restated nor reproved here. Peter-Weyl for a finite group, that `peterWeylBasis` is the
+matrix-coefficient basis of `k[G]`, is not proved here either.
 -/
 
 public section
@@ -676,8 +675,7 @@ is discharged by the vanishing half of Schur's lemma,
 `TauCeti.ContRepresentation.eq_zero_of_isEmpty_equiv`, exactly as `orthonormal_characterLp`
 discharges it in the compact theory. So the substantive vanishing statement is reached, not
 assumed: `character_orthonormal_distinct_sum` keeps the hypothesis of the compact theorem
-`character_orthonormal_distinct` it specializes, as the roadmap's "without new hypotheses"
-criterion asks, and irreducibility enters here.
+`character_orthonormal_distinct` it specializes, and irreducibility enters here.
 
 No name is claimed, for the same reason as above and in the two counting identities: with both
 representations irreducible and inequivalent this is Mathlib's `Representation.char_orthonormal`

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -775,13 +775,13 @@ subrepresentations, of dimensions adding up to `dim V`, which are moreover pairw
 for an invariant inner product `⟪e ·, e ·⟫` obtained from the given one by a continuous linear
 automorphism `e` of the carrier.
 
-This is the finite shadow of complete reducibility: unitarity is not assumed but produced, by the
-finite unitarian trick `ContRepresentation.exists_isUnitary_congr_of_finite`, the decomposition of
-the resulting unitary model is
-`TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition` with no further
-hypotheses, and every block is then pulled back along `e`, which is an equivalence of
-representations `π ≃ congr e π` by `ContRepresentation.congrEquiv`. The blocks are therefore
-subrepresentations of `π` itself.
+This is the finite shadow of complete reducibility, and all that is finite about it is the
+production of `e`: unitarity is not assumed but produced, by the finite unitarian trick
+`ContRepresentation.exists_isUnitary_congr_of_finite`, and the decomposition of `π` itself is then
+`TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition_of_congr`, which
+decomposes the unitary model and carries every block back along the equivalence of representations
+`ContRepresentation.congrEquiv : π.Equiv (congr e π)` for an arbitrary group. The blocks are
+therefore subrepresentations of `π` itself.
 
 Distorting the inner product by `e` is unavoidable and is what "Maschke" costs here: Lean fixes one
 inner product on `V`, and a representation of a finite group need not preserve it, only the average
@@ -799,41 +799,8 @@ theorem exists_orthogonal_irreducible_decomposition_of_finite (π : ContRepresen
       DirectSum.IsInternal (fun i ↦ (U i).toSubmodule) ∧
       Module.finrank 𝕜 V = ∑ i, Module.finrank 𝕜 (U i).toSubmodule := by
   obtain ⟨e, he⟩ := exists_isUnitary_congr_of_finite π
-  obtain ⟨n, U, hirr, horth, hinternal, hdim⟩ := he.exists_orthogonal_irreducible_decomposition
-  -- `e` intertwines `π` with `congr e π` — that is `ContRepresentation.congrEquiv` — so a block
-  -- of the unitary model pulls back along `e` to a subrepresentation of `π` itself.
-  have hint : ∀ (g : G) (v : V),
-      ((congr e π).toRepresentation : Representation 𝕜 G V) g ((e : V ≃ₗ[𝕜] V) v)
-        = (e : V ≃ₗ[𝕜] V) ((π.toRepresentation : Representation 𝕜 G V) g v) := fun g v ↦ by
-    simp [_root_.ContRepresentation.toMonoidHom_apply]
-  have hmem : ∀ (i : Fin n) (v : V),
-      v ∈ (U i).toSubmodule.map ((e : V ≃ₗ[𝕜] V).symm : V →ₗ[𝕜] V) ↔
-        (e : V ≃ₗ[𝕜] V) v ∈ (U i).toSubmodule := fun i v ↦ Submodule.mem_map_equiv _
-  have hinv : ∀ (i : Fin n) (g : G) ⦃v : V⦄,
-      v ∈ (U i).toSubmodule.map ((e : V ≃ₗ[𝕜] V).symm : V →ₗ[𝕜] V) →
-        (π.toRepresentation : Representation 𝕜 G V) g v ∈
-          (U i).toSubmodule.map ((e : V ≃ₗ[𝕜] V).symm : V →ₗ[𝕜] V) := by
-    intro i g v hv
-    refine (hmem i _).mpr ?_
-    rw [← hint g v]
-    exact (U i).apply_mem_toSubmodule g ((hmem i v).mp hv)
-  refine ⟨e, n, fun i ↦ ⟨(U i).toSubmodule.map ((e : V ≃ₗ[𝕜] V).symm : V →ₗ[𝕜] V), hinv i⟩,
-    he, fun i ↦ ?_, fun i j hij v hv w hw ↦ ?_, ?_, ?_⟩
-  · exact Representation.isIrreducible_of_linearEquiv
-      ((e : V ≃ₗ[𝕜] V).symm.submoduleMap (U i).toSubmodule)
-      (fun g x ↦ Subtype.ext (by
-        conv_rhs => rw [Subrepresentation.toRepresentation_apply]
-        simp [Subrepresentation.toRepresentation_apply, LinearEquiv.submoduleMap_apply,
-          LinearMap.coe_restrict_apply, _root_.ContRepresentation.toMonoidHom_apply])) (hirr i)
-  · exact horth hij ⟨_, (hmem i v).mp hv⟩ ⟨_, (hmem j w).mp hw⟩
-  · obtain ⟨hindep, htop⟩ :=
-      (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mp hinternal
-    refine (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mpr
-      ⟨hindep.map_orderIso (Submodule.orderIsoMapComap (e : V ≃ₗ[𝕜] V).symm), ?_⟩
-    rw [← Submodule.map_iSup, htop, Submodule.map_top, LinearEquiv.range]
-  · rw [hdim]
-    exact Finset.sum_congr rfl fun i _ ↦
-      ((e : V ≃ₗ[𝕜] V).symm.submoduleMap (U i).toSubmodule).finrank_eq
+  obtain ⟨n, U, hU⟩ := he.exists_orthogonal_irreducible_decomposition_of_congr
+  exact ⟨e, n, U, he, hU⟩
 
 end Maschke
 

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -90,7 +90,8 @@ measure computation has just identified.
 * `ContRepresentation.exists_isUnitary_congr_of_finite`: **the unitarian trick for a finite group**,
   every finite-dimensional representation being conjugate to a unitary one.
 * `ContRepresentation.exists_orthogonal_irreducible_decomposition_of_finite`: **Maschke's theorem in
-  orthogonal form**, the finite shadow of complete reducibility.
+  orthogonal form**, the finite shadow of complete reducibility: `π` itself is an internal direct
+  sum of irreducible subrepresentations, orthogonal for the averaged inner product.
 
 The counting identity `|G|⁻¹ ∑ g, χ_π g = dim V^G` that the compact-group character integral
 generalizes then costs one rewrite. It is not given a name: Mathlib already proves it, as
@@ -132,9 +133,8 @@ character one uses Mathlib's `Representation.character`, which is by
 `TauCeti.ContRepresentation.coe_character` the function underlying `character π hπ`. Those
 statements mention no measure either, so they ask for no measurable structure on `G`: their proofs
 install `borel G` themselves, and the caller is left with a bare finite discrete group. The two
-Maschke statements go one step further: being about the transported representations `congr e π`,
-they mention no topology on `G` at all, so their proof installs the discrete topology as well and
-the caller is left with a bare finite group.
+Maschke statements go one step further: mentioning no topology on `G` at all, they have their proof
+install the discrete topology as well, and the caller is left with a bare finite group.
 
 The scalar in the averaged sums is real, not `𝕜`: the Bochner integral being specialized is an
 `ℝ`-integral, and `V` is not assumed to be an `ℝ`-`𝕜`-scalar tower. The conversion is confined to
@@ -158,12 +158,13 @@ Schur and character-orthonormality part of that item: `L²(G)` is `G → 𝕜` b
 Mathlib's `Representation.char_orthonormal`, exhibited by two anonymous `example`s. It is finally
 the Maschke part of that item: `exists_orthogonal_irreducible_decomposition` specializes, through
 the finite unitarian trick, to
-`ContRepresentation.exists_orthogonal_irreducible_decomposition_of_finite`. What that
-specialization adds to Mathlib's Maschke — which is already an instance, for every field in which
-`|G|` is invertible, and hence is not restated here — is the orthogonality of the summands, which
-needs the inner product Mathlib's complements do not see. The one specialization the roadmap item
-asks for that is still missing is Peter-Weyl (that `peterWeylBasis` is the matrix-coefficient basis
-of `k[G]`); it is not proved here.
+`ContRepresentation.exists_orthogonal_irreducible_decomposition_of_finite`, whose blocks are
+subrepresentations of the given representation, carried back along the unitarizing equivalence
+`ContRepresentation.congrEquiv`. What that specialization adds to Mathlib's Maschke — which is
+already an instance, for every field in which `|G|` is invertible, and hence is not restated
+here — is the orthogonality of the summands, which needs the inner product Mathlib's complements
+do not see. The one specialization the roadmap item asks for that is still missing is Peter-Weyl
+(that `peterWeylBasis` is the matrix-coefficient basis of `k[G]`); it is not proved here.
 -/
 
 public section
@@ -722,8 +723,10 @@ theorem inner_gramOperator_eq_inv_mul_sum (v w : V) :
 /-- **The averaged form of a finite group on the diagonal is the average of `‖π g v‖ ^ 2`.** This is
 the finite form of the positive definiteness that makes the unitarian trick work: the average of
 `|G|` nonnegative reals, one of which is `‖v‖ ^ 2` at `g = 1`, is positive for `v ≠ 0`. Compactness
-of `G` enters the general statement `TauCeti.ContRepresentation.inner_gramOperator_self` twice, once
-to integrate and once to bound the operator norms from below; a finite group needs neither. -/
+of `G` enters the general statement `TauCeti.ContRepresentation.inner_gramOperator_self` only to
+make `g ↦ ‖π g v‖ ^ 2` integrable; it is the *strict* positivity
+`TauCeti.ContRepresentation.re_inner_gramOperator_self_pos` that also needs the compactness bound
+on the operator norms from below. A finite group needs neither. -/
 theorem inner_gramOperator_self_eq_inv_mul_sum (v : V) :
     ⟪gramOperator π hπ v, v⟫_𝕜 = (((Nat.card G : ℝ)⁻¹ * ∑ g, ‖π g v‖ ^ 2 : ℝ) : 𝕜) := by
   rw [inner_gramOperator_self, integral_haarProb, smul_eq_mul]
@@ -766,33 +769,71 @@ theorem exists_isUnitary_congr_of_finite (π : ContRepresentation 𝕜 G V) :
   have _ : BorelSpace G := ⟨rfl⟩
   exact exists_isUnitary_congr π continuous_of_discreteTopology
 
-/-- **Maschke's theorem in orthogonal form.** A finite-dimensional representation of a finite
-group on an inner product space becomes, after conjugating by a continuous linear automorphism `e`
-of the carrier, a *unitary* representation that is an orthogonal internal direct sum of finitely
-many irreducible subrepresentations, of dimensions adding up to `dim V`.
+/-- **Maschke's theorem in orthogonal form.** A finite-dimensional representation `π` of a finite
+group on an inner product space is an internal direct sum of finitely many irreducible
+subrepresentations, of dimensions adding up to `dim V`, which are moreover pairwise *orthogonal*
+for an invariant inner product `⟪e ·, e ·⟫` obtained from the given one by a continuous linear
+automorphism `e` of the carrier.
 
 This is the finite shadow of complete reducibility: unitarity is not assumed but produced, by the
-finite unitarian trick `ContRepresentation.exists_isUnitary_congr_of_finite`, and the decomposition
-is then
+finite unitarian trick `ContRepresentation.exists_isUnitary_congr_of_finite`, the decomposition of
+the resulting unitary model is
 `TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition` with no further
-hypotheses. Conjugating by `e` is unavoidable and is what "Maschke" costs here: Lean fixes one
+hypotheses, and every block is then pulled back along `e`, which is an equivalence of
+representations `π ≃ congr e π` by `ContRepresentation.congrEquiv`. The blocks are therefore
+subrepresentations of `π` itself.
+
+Distorting the inner product by `e` is unavoidable and is what "Maschke" costs here: Lean fixes one
 inner product on `V`, and a representation of a finite group need not preserve it, only the average
-`|G|⁻¹ ∑ g, ⟪π g ·, π g ·⟫` of its translates. It is the orthogonality that the compact theory
-contributes over Mathlib's Maschke, which produces complements but no inner product; the plain
-semisimplicity is not restated here, being already a Mathlib instance for every field in which
-`|G|` is invertible. A statement about the model is carried back to `π` along `e`, which is an
-equivalence of representations `π ≃ congr e π` by the definition
-`TauCeti.ContRepresentation.congr_apply` of the transported action. -/
+`|G|⁻¹ ∑ g, ⟪π g ·, π g ·⟫` of its translates. So the blocks need not be orthogonal for `⟪·, ·⟫`,
+and orthogonality is stated for the invariant form `⟪e ·, e ·⟫` that the unitarian trick produces —
+equivalently, their images under `e` are the orthogonal family decomposing the unitary model
+`congr e π`. It is that orthogonality which the compact theory contributes over Mathlib's Maschke,
+which produces complements but no inner product; the plain semisimplicity is not restated here,
+being already a Mathlib instance for every field in which `|G|` is invertible. -/
 theorem exists_orthogonal_irreducible_decomposition_of_finite (π : ContRepresentation 𝕜 G V) :
-    ∃ (e : V ≃L[𝕜] V) (n : ℕ) (U : Fin n → Subrepresentation (congr e π).toRepresentation),
+    ∃ (e : V ≃L[𝕜] V) (n : ℕ) (U : Fin n → Subrepresentation π.toRepresentation),
       IsUnitary (congr e π) ∧
       (∀ i, (U i).toRepresentation.IsIrreducible) ∧
-      OrthogonalFamily 𝕜 (fun i ↦ (U i).toSubmodule) (fun i ↦ ((U i).toSubmodule).subtypeₗᵢ) ∧
+      (Pairwise fun i j ↦ ∀ v ∈ (U i).toSubmodule, ∀ w ∈ (U j).toSubmodule, ⟪e v, e w⟫_𝕜 = 0) ∧
       DirectSum.IsInternal (fun i ↦ (U i).toSubmodule) ∧
       Module.finrank 𝕜 V = ∑ i, Module.finrank 𝕜 (U i).toSubmodule := by
   obtain ⟨e, he⟩ := exists_isUnitary_congr_of_finite π
   obtain ⟨n, U, hirr, horth, hinternal, hdim⟩ := he.exists_orthogonal_irreducible_decomposition
-  exact ⟨e, n, U, he, hirr, horth, hinternal, hdim⟩
+  -- `e` intertwines `π` with `congr e π` — that is `ContRepresentation.congrEquiv` — so a block
+  -- of the unitary model pulls back along `e` to a subrepresentation of `π` itself.
+  have hint : ∀ (g : G) (v : V),
+      ((congr e π).toRepresentation : Representation 𝕜 G V) g ((e : V ≃ₗ[𝕜] V) v)
+        = (e : V ≃ₗ[𝕜] V) ((π.toRepresentation : Representation 𝕜 G V) g v) := fun g v ↦ by
+    simp [_root_.ContRepresentation.toMonoidHom_apply]
+  have hmem : ∀ (i : Fin n) (v : V),
+      v ∈ (U i).toSubmodule.map ((e : V ≃ₗ[𝕜] V).symm : V →ₗ[𝕜] V) ↔
+        (e : V ≃ₗ[𝕜] V) v ∈ (U i).toSubmodule := fun i v ↦ Submodule.mem_map_equiv _
+  have hinv : ∀ (i : Fin n) (g : G) ⦃v : V⦄,
+      v ∈ (U i).toSubmodule.map ((e : V ≃ₗ[𝕜] V).symm : V →ₗ[𝕜] V) →
+        (π.toRepresentation : Representation 𝕜 G V) g v ∈
+          (U i).toSubmodule.map ((e : V ≃ₗ[𝕜] V).symm : V →ₗ[𝕜] V) := by
+    intro i g v hv
+    refine (hmem i _).mpr ?_
+    rw [← hint g v]
+    exact (U i).apply_mem_toSubmodule g ((hmem i v).mp hv)
+  refine ⟨e, n, fun i ↦ ⟨(U i).toSubmodule.map ((e : V ≃ₗ[𝕜] V).symm : V →ₗ[𝕜] V), hinv i⟩,
+    he, fun i ↦ ?_, fun i j hij v hv w hw ↦ ?_, ?_, ?_⟩
+  · exact Representation.isIrreducible_of_linearEquiv
+      ((e : V ≃ₗ[𝕜] V).symm.submoduleMap (U i).toSubmodule)
+      (fun g x ↦ Subtype.ext (by
+        conv_rhs => rw [Subrepresentation.toRepresentation_apply]
+        simp [Subrepresentation.toRepresentation_apply, LinearEquiv.submoduleMap_apply,
+          LinearMap.coe_restrict_apply, _root_.ContRepresentation.toMonoidHom_apply])) (hirr i)
+  · exact horth hij ⟨_, (hmem i v).mp hv⟩ ⟨_, (hmem j w).mp hw⟩
+  · obtain ⟨hindep, htop⟩ :=
+      (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mp hinternal
+    refine (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mpr
+      ⟨hindep.map_orderIso (Submodule.orderIsoMapComap (e : V ≃ₗ[𝕜] V).symm), ?_⟩
+    rw [← Submodule.map_iSup, htop, Submodule.map_top, LinearEquiv.range]
+  · rw [hdim]
+    exact Finset.sum_congr rfl fun i _ ↦
+      ((e : V ≃ₗ[𝕜] V).symm.submoduleMap (U i).toSubmodule).finrank_eq
 
 end Maschke
 

--- a/TauCeti/RepresentationTheory/Compact/Finite.lean
+++ b/TauCeti/RepresentationTheory/Compact/Finite.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.RepresentationTheory.AsModule
 public import TauCeti.RepresentationTheory.Compact.Intertwiner.Dimension
 public import TauCeti.RepresentationTheory.Compact.UnitaryModel
 public import TauCeti.RepresentationTheory.Continuous.OrthogonalDecomposition
@@ -132,7 +131,10 @@ relations ask for none: the Schur ones are stated as bare sums `∑ g, ⟪π g v
 character one uses Mathlib's `Representation.character`, which is by
 `TauCeti.ContRepresentation.coe_character` the function underlying `character π hπ`. Those
 statements mention no measure either, so they ask for no measurable structure on `G`: their proofs
-install `borel G` themselves, and the caller is left with a bare finite discrete group.
+install `borel G` themselves, and the caller is left with a bare finite discrete group. The two
+Maschke statements go one step further: being about the transported representations `congr e π`,
+they mention no topology on `G` at all, so their proof installs the discrete topology as well and
+the caller is left with a bare finite group.
 
 The scalar in the averaged sums is real, not `𝕜`: the Bochner integral being specialized is an
 `ℝ`-integral, and `V` is not assumed to be an `ℝ`-`𝕜`-scalar tower. The conversion is confined to
@@ -156,10 +158,12 @@ Schur and character-orthonormality part of that item: `L²(G)` is `G → 𝕜` b
 Mathlib's `Representation.char_orthonormal`, exhibited by two anonymous `example`s. It is finally
 the Maschke part of that item: `exists_orthogonal_irreducible_decomposition` specializes, through
 the finite unitarian trick, to
-`TauCeti.ContRepresentation.exists_orthogonal_irreducible_decomposition_of_finite`, and Mathlib's
-plain semisimplicity is recovered from it in the `example` closing the file. The one specialization
-the roadmap item asks for that is still missing is Peter-Weyl (that `peterWeylBasis` is the
-matrix-coefficient basis of `k[G]`); it is not proved here.
+`ContRepresentation.exists_orthogonal_irreducible_decomposition_of_finite`. What that
+specialization adds to Mathlib's Maschke — which is already an instance, for every field in which
+`|G|` is invertible, and hence is not restated here — is the orthogonality of the summands, which
+needs the inner product Mathlib's complements do not see. The one specialization the roadmap item
+asks for that is still missing is Peter-Weyl (that `peterWeylBasis` is the matrix-coefficient basis
+of `k[G]`); it is not proved here.
 -/
 
 public section
@@ -698,13 +702,7 @@ section Unitarization
 variable {𝕜 G V : Type*} [RCLike 𝕜] [Group G] [Fintype G] [TopologicalSpace G]
   [DiscreteTopology G] [MeasurableSpace G] [BorelSpace G]
   [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
-  [FiniteDimensional 𝕜 V]
-
-/-- As in the trace section above, completeness of `V` is not an extra hypothesis but a consequence
-of finite-dimensionality, installed locally because Mathlib keeps `FiniteDimensional.complete` out
-of the global instance set. -/
-local instance instCompleteSpaceUnitarization : CompleteSpace V :=
-  FiniteDimensional.complete 𝕜 V
+  [CompleteSpace V]
 
 variable (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
 
@@ -731,7 +729,7 @@ theorem inner_gramOperator_self_eq_inv_mul_sum (v : V) :
   rw [inner_gramOperator_self, integral_haarProb, smul_eq_mul]
 
 /-- **The Gram operator of a finite group is the averaged sum of the operators `(π g)† ∘ (π g)`.**
-This is `TauCeti.ContRepresentation.inner_gramOperator_eq_inv_mul_sum` at the level of operators:
+This is `ContRepresentation.inner_gramOperator_eq_inv_mul_sum` at the level of operators:
 each summand is the Gram operator of the pulled-back form `(v, w) ↦ ⟪π g v, π g w⟫`, and the Haar
 average of the family is their group average. -/
 theorem gramOperator_eq_smul_sum :
@@ -746,41 +744,45 @@ end Unitarization
 
 section Maschke
 
-variable {𝕜 G V : Type*} [RCLike 𝕜] [Group G] [Finite G] [TopologicalSpace G]
-  [DiscreteTopology G]
+variable {𝕜 G V : Type*} [RCLike 𝕜] [Group G] [Finite G]
   [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
   [FiniteDimensional 𝕜 V]
 
 /-- **The unitarian trick for a finite group.** Every finite-dimensional representation of a finite
-discrete group on an inner product space is conjugate, by a continuous linear automorphism of the
-carrier, to one preserving the inner product.
+group on an inner product space is conjugate, by a continuous linear automorphism of the carrier,
+to one preserving the inner product.
 
-This is `TauCeti.ContRepresentation.exists_isUnitary_congr` with the compactness hypotheses
-discharged: a finite discrete group is compact, every representation of it is continuous by
-`continuous_of_discreteTopology`, and the statement mentions no measure, so the proof installs the
-Borel structure it averages against and the caller is left with a bare finite discrete group. The
-form being averaged is the explicit `|G|⁻¹ ∑ g, ⟪π g ·, π g ·⟫` of
-`TauCeti.ContRepresentation.inner_gramOperator_eq_inv_mul_sum`. -/
+This is `TauCeti.ContRepresentation.exists_isUnitary_congr` with all of its compact-group
+hypotheses discharged: the statement mentions neither a topology on `G` nor a measure, so the proof
+installs the discrete topology and the Borel structure it averages against — a finite discrete
+group is compact and every representation of it is continuous by `continuous_of_discreteTopology` —
+and the caller is left with a bare finite group. The form being averaged is the explicit
+`|G|⁻¹ ∑ g, ⟪π g ·, π g ·⟫` of `ContRepresentation.inner_gramOperator_eq_inv_mul_sum`. -/
 theorem exists_isUnitary_congr_of_finite (π : ContRepresentation 𝕜 G V) :
     ∃ e : V ≃L[𝕜] V, IsUnitary (congr e π) := by
+  let _ : TopologicalSpace G := ⊥
+  have _ : DiscreteTopology G := ⟨rfl⟩
   let _ : MeasurableSpace G := borel G
   have _ : BorelSpace G := ⟨rfl⟩
   exact exists_isUnitary_congr π continuous_of_discreteTopology
 
 /-- **Maschke's theorem in orthogonal form.** A finite-dimensional representation of a finite
-discrete group on an inner product space becomes, after conjugating by a continuous linear
-automorphism `e` of the carrier, a *unitary* representation that is an orthogonal internal direct
-sum of finitely many irreducible subrepresentations, of dimensions adding up to `dim V`.
+group on an inner product space becomes, after conjugating by a continuous linear automorphism `e`
+of the carrier, a *unitary* representation that is an orthogonal internal direct sum of finitely
+many irreducible subrepresentations, of dimensions adding up to `dim V`.
 
 This is the finite shadow of complete reducibility: unitarity is not assumed but produced, by the
-finite unitarian trick `TauCeti.ContRepresentation.exists_isUnitary_congr_of_finite`, and the
-decomposition is then
+finite unitarian trick `ContRepresentation.exists_isUnitary_congr_of_finite`, and the decomposition
+is then
 `TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition` with no further
 hypotheses. Conjugating by `e` is unavoidable and is what "Maschke" costs here: Lean fixes one
 inner product on `V`, and a representation of a finite group need not preserve it, only the average
 `|G|⁻¹ ∑ g, ⟪π g ·, π g ·⟫` of its translates. It is the orthogonality that the compact theory
 contributes over Mathlib's Maschke, which produces complements but no inner product; the plain
-semisimplicity is recovered from the unitary model in the `example` below. -/
+semisimplicity is not restated here, being already a Mathlib instance for every field in which
+`|G|` is invertible. A statement about the model is carried back to `π` along `e`, which is an
+equivalence of representations `π ≃ congr e π` by the definition
+`TauCeti.ContRepresentation.congr_apply` of the transported action. -/
 theorem exists_orthogonal_irreducible_decomposition_of_finite (π : ContRepresentation 𝕜 G V) :
     ∃ (e : V ≃L[𝕜] V) (n : ℕ) (U : Fin n → Subrepresentation (congr e π).toRepresentation),
       IsUnitary (congr e π) ∧
@@ -791,27 +793,6 @@ theorem exists_orthogonal_irreducible_decomposition_of_finite (π : ContRepresen
   obtain ⟨e, he⟩ := exists_isUnitary_congr_of_finite π
   obtain ⟨n, U, hirr, horth, hinternal, hdim⟩ := he.exists_orthogonal_irreducible_decomposition
   exact ⟨e, n, U, he, hirr, horth, hinternal, hdim⟩
-
-/- **Maschke's theorem.** Every finite-dimensional representation of a finite discrete group on an
-inner product space is semisimple: every subrepresentation has a complement.
-
-No name is claimed, for the same reason as in the counting and orthogonality identities above: this
-is already an instance in Mathlib, for any field in which `|G|` is invertible. What the compact
-theory contributes is the derivation — the unitary model of
-`exists_orthogonal_irreducible_decomposition_of_finite`, whose orthogonal complements are the
-complements Maschke asks for, carried back to `π` along `e`, which is an equivalence of
-representations onto the model by the definition
-`TauCeti.ContRepresentation.congr_apply` of the transported action. That is the sense in which the
-compact complete reducibility of Layer 2 specializes to Maschke. -/
-example (π : ContRepresentation 𝕜 G V) :
-    Representation.IsSemisimpleRepresentation π.toRepresentation := by
-  obtain ⟨e, he⟩ := exists_isUnitary_congr_of_finite π
-  have φ : π.toRepresentation.Equiv (congr e π).toRepresentation :=
-    Representation.Equiv.mk (e : V ≃ₗ[𝕜] V) fun g ↦ LinearMap.ext fun v ↦ by
-      simp [_root_.ContRepresentation.toMonoidHom_apply]
-  have _ := he.isSemisimpleModule_asModule
-  rw [Representation.isSemisimpleRepresentation_iff_isSemisimpleModule_asModule]
-  exact .congr (TauCeti.Representation.asModuleLinearEquivOfEquiv φ)
 
 end Maschke
 

--- a/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
+++ b/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
@@ -83,6 +83,8 @@ namespace ContRepresentation
 
 namespace IsUnitary
 
+section Unitary
+
 variable {𝕜 G V : Type*} [RCLike 𝕜] [Group G] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
   {π : ContRepresentation 𝕜 G V}
 
@@ -210,9 +212,15 @@ theorem exists_orthogonal_irreducible_decomposition (hπ : IsUnitary π) :
     hfamily, hinternal, ?_⟩
   exact finrank_eq_sum_finrank_of_isInternal hinternal
 
+end FiniteDimensional
+
+end Unitary
+
 section Congr
 
-variable {W : Type*} [NormedAddCommGroup W] [InnerProductSpace 𝕜 W]
+variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G]
+  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]
+  [NormedAddCommGroup W] [InnerProductSpace 𝕜 W] {π : ContRepresentation 𝕜 G V}
 
 /-- **Complete reducibility for a unitarizable representation, orthogonal internal form.** If a
 continuous linear equivalence `e : V ≃L[𝕜] W` conjugates `π` into a *unitary* representation
@@ -227,10 +235,12 @@ back to `(U i).toSubmodule.map e.symm`, which is `π`-invariant because `e` inte
 `congr e π`, and irreducibility, internality and the dimension count travel along the linear
 equivalence `e.symm` restricted to it.
 
-Orthogonality cannot be stated for the inner product of `V`: `e` is there precisely because `π`
-need not preserve that one, and the form the blocks are orthogonal for is the invariant
-`⟪e ·, e ·⟫` pulled back from `W`. Nothing here uses finiteness or compactness of the acting group;
-a construction of an `e` is what such a hypothesis is for, Weyl's unitarian trick
+Orthogonality is not stated inside `V`, which carries no inner product here: `e` is there
+precisely because `π` need not preserve one, and the form the blocks are orthogonal for is the
+invariant `⟪e ·, e ·⟫` pulled back from `W`. Only the unitary model needs an inner product, so
+`V` is asked for no more than a finite-dimensional normed space, as
+`TauCeti.ContRepresentation.congr` itself is. Nothing here uses finiteness or compactness of the
+acting group; a construction of an `e` is what such a hypothesis is for, Weyl's unitarian trick
 `TauCeti.ContRepresentation.exists_isUnitary_congr` being one. -/
 theorem exists_orthogonal_irreducible_decomposition_of_congr {e : V ≃L[𝕜] W}
     (he : IsUnitary (ContRepresentation.congr e π)) :
@@ -286,8 +296,6 @@ theorem exists_orthogonal_irreducible_decomposition_of_congr {e : V ≃L[𝕜] W
       ((e : V ≃ₗ[𝕜] W).symm.submoduleMap (U i).toSubmodule).finrank_eq
 
 end Congr
-
-end FiniteDimensional
 
 end IsUnitary
 

--- a/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
+++ b/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
@@ -256,7 +256,7 @@ theorem exists_orthogonal_irreducible_decomposition_of_congr {e : V ≃L[𝕜] W
       (e : V ≃ₗ[𝕜] W) ((π.toRepresentation : Representation 𝕜 G V) g v) =
         ((ContRepresentation.congr e π).toRepresentation : Representation 𝕜 G W) g
           ((e : V ≃ₗ[𝕜] W) v) := fun g v ↦ by
-    have h := (_root_.ContRepresentation.congrEquiv e π).toContIntertwiningMap.isIntertwining g v
+    have h := (_root_.ContRepresentation.congrEquiv π e).toContIntertwiningMap.isIntertwining g v
     simp only [_root_.ContRepresentation.Equiv.coe_toContIntertwiningMap,
       _root_.ContRepresentation.congrEquiv_apply] at h
     exact h

--- a/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
+++ b/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional
 public import TauCeti.LinearAlgebra.Dimension.DirectSum
 public import TauCeti.RepresentationTheory.Continuous.InvariantComplement
+public import TauCeti.RepresentationTheory.Continuous.Transport
 public import TauCeti.RepresentationTheory.Irreducible
 
 /-!
@@ -30,12 +31,19 @@ remainder is a strictly smaller subrepresentation and the descent recurses on it
 No measure, no compactness, and no continuity of the representation are used: the argument runs on
 a `ContRepresentation` only because that is where `TauCeti.ContRepresentation.IsUnitary` lives, and
 the acting group may be arbitrary. For a compact group the unitarity hypothesis is what Weyl's
-unitarian trick in `TauCeti.RepresentationTheory.Compact.Unitarizable` is there to supply.
+unitarian trick in `TauCeti.RepresentationTheory.Compact.Unitarizable` is there to supply. That
+trick does not make `π` itself unitary — it conjugates it into a unitary representation — so the
+decomposition is also recorded in the form that consumes such a conjugation, with the blocks
+carried back to `π` along it.
 
 ## Main results
 
 * `TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition`: complete
   reducibility in orthogonal internal form, with the dimension count that goes with it.
+* `TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition_of_congr`: the
+  same decomposition for a representation that is merely *conjugate* to a unitary one, its blocks
+  carried back along the conjugating equivalence and orthogonal for the inner product that
+  equivalence pulls back.
 
 ## Implementation notes
 
@@ -201,6 +209,83 @@ theorem exists_orthogonal_irreducible_decomposition (hπ : IsUnitary π) :
   refine ⟨n, U, fun i ↦ Representation.isIrreducible_toRepresentation_of_isAtom (hatom i),
     hfamily, hinternal, ?_⟩
   exact finrank_eq_sum_finrank_of_isInternal hinternal
+
+section Congr
+
+variable {W : Type*} [NormedAddCommGroup W] [InnerProductSpace 𝕜 W]
+
+/-- **Complete reducibility for a unitarizable representation, orthogonal internal form.** If a
+continuous linear equivalence `e : V ≃L[𝕜] W` conjugates `π` into a *unitary* representation
+`congr e π`, then `π` itself — not merely its unitary model — is an internal direct sum of finitely
+many irreducible subrepresentations, of dimensions adding up to `dim V`, whose images under `e` are
+pairwise orthogonal.
+
+This is `TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition` carried
+back along the equivalence of continuous representations
+`ContRepresentation.congrEquiv : π.Equiv (congr e π)`: each block `U i` of the unitary model pulls
+back to `(U i).toSubmodule.map e.symm`, which is `π`-invariant because `e` intertwines `π` with
+`congr e π`, and irreducibility, internality and the dimension count travel along the linear
+equivalence `e.symm` restricted to it.
+
+Orthogonality cannot be stated for the inner product of `V`: `e` is there precisely because `π`
+need not preserve that one, and the form the blocks are orthogonal for is the invariant
+`⟪e ·, e ·⟫` pulled back from `W`. Nothing here uses finiteness or compactness of the acting group;
+a construction of an `e` is what such a hypothesis is for, Weyl's unitarian trick
+`TauCeti.ContRepresentation.exists_isUnitary_congr` being one. -/
+theorem exists_orthogonal_irreducible_decomposition_of_congr {e : V ≃L[𝕜] W}
+    (he : IsUnitary (ContRepresentation.congr e π)) :
+    ∃ (n : ℕ) (U : Fin n → Subrepresentation π.toRepresentation),
+      (∀ i, (U i).toRepresentation.IsIrreducible) ∧
+      (Pairwise fun i j ↦ ∀ v ∈ (U i).toSubmodule, ∀ w ∈ (U j).toSubmodule, ⟪e v, e w⟫_𝕜 = 0) ∧
+      DirectSum.IsInternal (fun i ↦ (U i).toSubmodule) ∧
+      Module.finrank 𝕜 V = ∑ i, Module.finrank 𝕜 (U i).toSubmodule := by
+  have _ : FiniteDimensional 𝕜 W := (e : V ≃ₗ[𝕜] W).finiteDimensional
+  obtain ⟨n, U, hirr, horth, hinternal, hdim⟩ := he.exists_orthogonal_irreducible_decomposition
+  -- `e` intertwines `π` with `congr e π`: that is the equivalence `ContRepresentation.congrEquiv`.
+  have hint : ∀ (g : G) (v : V),
+      (e : V ≃ₗ[𝕜] W) ((π.toRepresentation : Representation 𝕜 G V) g v) =
+        ((ContRepresentation.congr e π).toRepresentation : Representation 𝕜 G W) g
+          ((e : V ≃ₗ[𝕜] W) v) := fun g v ↦ by
+    have h := (_root_.ContRepresentation.congrEquiv e π).toContIntertwiningMap.isIntertwining g v
+    simp only [_root_.ContRepresentation.Equiv.coe_toContIntertwiningMap,
+      _root_.ContRepresentation.congrEquiv_apply] at h
+    exact h
+  have hsymm : ∀ (g : G) (w : W),
+      (e : V ≃ₗ[𝕜] W).symm
+          (((ContRepresentation.congr e π).toRepresentation : Representation 𝕜 G W) g w) =
+        (π.toRepresentation : Representation 𝕜 G V) g ((e : V ≃ₗ[𝕜] W).symm w) := by
+    intro g w
+    have h := hint g ((e : V ≃ₗ[𝕜] W).symm w)
+    rw [LinearEquiv.apply_symm_apply] at h
+    rw [← h, LinearEquiv.symm_apply_apply]
+  have hmem : ∀ (i : Fin n) (v : V),
+      v ∈ (U i).toSubmodule.map ((e : V ≃ₗ[𝕜] W).symm : W →ₗ[𝕜] V) ↔
+        (e : V ≃ₗ[𝕜] W) v ∈ (U i).toSubmodule := fun i v ↦ Submodule.mem_map_equiv _
+  have hinv : ∀ (i : Fin n) (g : G) ⦃v : V⦄,
+      v ∈ (U i).toSubmodule.map ((e : V ≃ₗ[𝕜] W).symm : W →ₗ[𝕜] V) →
+        (π.toRepresentation : Representation 𝕜 G V) g v ∈
+          (U i).toSubmodule.map ((e : V ≃ₗ[𝕜] W).symm : W →ₗ[𝕜] V) := by
+    intro i g v hv
+    refine (hmem i _).mpr ?_
+    rw [hint g v]
+    exact (U i).apply_mem_toSubmodule g ((hmem i v).mp hv)
+  refine ⟨n, fun i ↦ ⟨(U i).toSubmodule.map ((e : V ≃ₗ[𝕜] W).symm : W →ₗ[𝕜] V), hinv i⟩,
+    fun i ↦ ?_, fun i j hij v hv w hw ↦ ?_, ?_, ?_⟩
+  · refine Representation.isIrreducible_of_linearEquiv
+      ((e : V ≃ₗ[𝕜] W).symm.submoduleMap (U i).toSubmodule) (fun g x ↦ Subtype.ext ?_) (hirr i)
+    simp only [LinearEquiv.submoduleMap_apply, Subrepresentation.toRepresentation_apply]
+    exact hsymm g x
+  · exact horth hij ⟨_, (hmem i v).mp hv⟩ ⟨_, (hmem j w).mp hw⟩
+  · obtain ⟨hindep, htop⟩ :=
+      (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mp hinternal
+    refine (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mpr
+      ⟨hindep.map_orderIso (Submodule.orderIsoMapComap (e : V ≃ₗ[𝕜] W).symm), ?_⟩
+    rw [← Submodule.map_iSup, htop, Submodule.map_top, LinearEquiv.range]
+  · rw [(e : V ≃ₗ[𝕜] W).finrank_eq, hdim]
+    exact Finset.sum_congr rfl fun i _ ↦
+      ((e : V ≃ₗ[𝕜] W).symm.submoduleMap (U i).toSubmodule).finrank_eq
+
+end Congr
 
 end FiniteDimensional
 

--- a/TauCeti/RepresentationTheory/Continuous/Transport.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Transport.lean
@@ -182,20 +182,25 @@ This is the bundled form of that observation, and it is what carries a statement
 transport back to `π`: an `Equiv` is an isomorphism in the category of continuous representations,
 so `π` and `congr e π` have the same subrepresentation lattice, the same irreducible constituents
 and the same character. It lives in the root `ContRepresentation` namespace, rather than beside
-`congr` in `TauCeti.ContRepresentation`, so that dot notation on Mathlib's `ContRepresentation`
-elaborates. -/
-noncomputable def congrEquiv (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) :
+`congr` in `TauCeti.ContRepresentation`, so that the dot notation `π.congrEquiv e` elaborates;
+`congrEquiv_apply` and `congrEquiv_symm_apply` evaluate it and its inverse as `e` and `e.symm`. -/
+noncomputable def congrEquiv (π : ContRepresentation 𝕜 G V) (e : V ≃L[𝕜] W) :
     π.Equiv (TauCeti.ContRepresentation.congr e π) :=
   .mk e fun g ↦ ContinuousLinearMap.ext fun v ↦ by simp
 
 @[simp]
-theorem congrEquiv_toContinuousLinearEquiv (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) :
-    (congrEquiv e π).toContinuousLinearEquiv = e :=
+theorem congrEquiv_toContinuousLinearEquiv (π : ContRepresentation 𝕜 G V) (e : V ≃L[𝕜] W) :
+    (π.congrEquiv e).toContinuousLinearEquiv = e :=
   (rfl)
 
 @[simp]
-theorem congrEquiv_apply (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) (v : V) :
-    congrEquiv e π v = e v :=
+theorem congrEquiv_apply (π : ContRepresentation 𝕜 G V) (e : V ≃L[𝕜] W) (v : V) :
+    π.congrEquiv e v = e v :=
+  (rfl)
+
+@[simp]
+theorem congrEquiv_symm_apply (π : ContRepresentation 𝕜 G V) (e : V ≃L[𝕜] W) (w : W) :
+    (π.congrEquiv e).symm w = e.symm w :=
   (rfl)
 
 end ContRepresentation

--- a/TauCeti/RepresentationTheory/Continuous/Transport.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Transport.lean
@@ -27,6 +27,8 @@ so nothing is lost by pinning a model.
 ## Main definitions
 
 * `TauCeti.ContRepresentation.congr`: the transported representation `e ∘ π · ∘ e⁻¹`.
+* `ContRepresentation.congrEquiv`: the equivalence of continuous representations `π ≃ congr e π`
+  witnessed by `e` itself, which is what carries a statement about the transport back to `π`.
 
 ## Main statements
 
@@ -167,3 +169,33 @@ end CongrAdjoint
 end ContRepresentation
 
 end TauCeti
+
+namespace ContRepresentation
+
+variable {𝕜 G V W : Type*} [NormedField 𝕜] [Monoid G]
+  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [NormedAddCommGroup W] [NormedSpace 𝕜 W]
+
+/-- **The transport of a representation is equivalent to it**, along `e` itself: `e` intertwines
+`π` with `TauCeti.ContRepresentation.congr e π` by the very definition of the transported action.
+
+This is the bundled form of that observation, and it is what carries a statement about the
+transport back to `π`: an `Equiv` is an isomorphism in the category of continuous representations,
+so `π` and `congr e π` have the same subrepresentation lattice, the same irreducible constituents
+and the same character. It lives in the root `ContRepresentation` namespace, rather than beside
+`congr` in `TauCeti.ContRepresentation`, so that dot notation on Mathlib's `ContRepresentation`
+elaborates. -/
+noncomputable def congrEquiv (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) :
+    π.Equiv (TauCeti.ContRepresentation.congr e π) :=
+  .mk e fun g ↦ ContinuousLinearMap.ext fun v ↦ by simp
+
+@[simp]
+theorem congrEquiv_toContinuousLinearEquiv (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) :
+    (congrEquiv e π).toContinuousLinearEquiv = e :=
+  (rfl)
+
+@[simp]
+theorem congrEquiv_apply (e : V ≃L[𝕜] W) (π : ContRepresentation 𝕜 G V) (v : V) :
+    congrEquiv e π v = e v :=
+  (rfl)
+
+end ContRepresentation


### PR DESCRIPTION
This PR advances the "finite groups recover the character theory" worked example of
`TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md` — the bullet asking that
`exists_orthogonal_irreducible_decomposition` **specializes to** Maschke — by
extending `TauCeti/RepresentationTheory/Compact/Finite.lean`, whose own References paragraph named
that specialization as one of the two still missing from the file. It stays inside that file
because the file *is* the finite specialization of the compact theory: it already carries the
measure identification, the `L²`-as-`G → 𝕜` equivalence, the Schur relations and the character
orthogonality as group averages, and the new material is the same rewriting applied to Layers 1
and 2 instead of Layers 4 and 6. The remaining missing specialization, Peter-Weyl, is untouched and
the file now says so.

`ContRepresentation.inner_gramOperator_eq_inv_mul_sum` computes the invariant form that
Weyl's unitarian trick averages into existence: over a finite discrete group it is the classical
`⟪v, w⟫_G = |G|⁻¹ ∑ g, ⟪π g v, π g w⟫`, obtained by reading the general
`ContRepresentation.inner_gramOperator` through `TauCeti.integral_haarProb_eq_inv_mul_sum`.
`ContRepresentation.gramOperator_eq_smul_sum` states the same identity at the level of the
operator representing that form, `|G|⁻¹ • ∑ g, (π g)† ∘ (π g)`, and
`ContRepresentation.inner_gramOperator_self_eq_inv_mul_sum` its diagonal
`|G|⁻¹ ∑ g, ‖π g v‖ ^ 2`, which is where the positive definiteness the trick needs becomes visible
without any compactness bound on the operator norms. Together they are the sanity check the roadmap
asks the finite case for: the compact normalization `|G|⁻¹` is exactly the finite-group one.

`ContRepresentation.exists_isUnitary_congr_of_finite` is then the unitarian trick with its
compactness hypotheses discharged — a finite discrete group is compact and every representation of
it is continuous, and the statement mentions neither a topology on `G` nor a measure, so the proof
installs the discrete topology and the Borel structure it averages against and the caller is left
with a bare finite group, in the same style as the Schur and character statements already in the
file. `ContRepresentation.exists_orthogonal_irreducible_decomposition_of_finite`
is the summit: a finite-dimensional representation `π` of a finite group on an inner product space
is an internal direct sum of finitely many irreducible subrepresentations **of `π` itself**, whose
dimensions add up to `dim V` and which are pairwise orthogonal for the invariant inner product
`⟪e ·, e ·⟫` that the trick produces from a continuous linear automorphism `e` of the carrier.
Unitarity is produced, not assumed; the distortion by `e` is what Maschke costs here, since Lean
fixes one inner product on `V` and a representation need only preserve the average of its
translates, so orthogonality for the *given* form would be false.

Plain semisimplicity is deliberately not restated: Mathlib's Maschke already supplies it as an
instance for every field in which `|G|` is invertible, so nothing here claims it, and **this PR
does not claim the acceptance criterion is closed** — what it adds is the geometric half. What
this route contributes over Mathlib's Maschke — which produces complements but no inner
product — is the orthogonality of the blocks, and that is the content of the named theorem.

No new file is added, no declaration is renamed, and no Mathlib infrastructure is vendored; the
only additions to `Compact/Finite.lean`'s module header are the two imports the new material needs
(`TauCeti.RepresentationTheory.Compact.UnitaryModel` and
`TauCeti.RepresentationTheory.Continuous.OrthogonalDecomposition`). The one declaration added outside
`Compact/Finite.lean` is `ContRepresentation.congrEquiv` in
`TauCeti/RepresentationTheory/Continuous/Transport.lean`, the bundled equivalence
`π ≃ congr e π` along which the decomposition is carried back.

## Round 1 review

* **reuse**, and the `AsModule` half of **api-design**: the anonymous semisimplicity example is
  deleted, and with it the `TauCeti.RepresentationTheory.AsModule` import it was the only user of.
* **documentation**: the module documentation no longer says that semisimplicity is recovered from
  `exists_orthogonal_irreducible_decomposition_of_finite`; it says what that decomposition adds to
  Mathlib's Maschke instead.
* **generality**: the three averaging identities are now stated under `[CompleteSpace V]`, which is
  all `gramOperator` and its general lemmas ask for, rather than `[FiniteDimensional 𝕜 V]`; and the
  two Maschke statements no longer carry `[TopologicalSpace G]` or `[DiscreteTopology G]`, their
  proof installing the discrete topology alongside the Borel structure it averages against.
* **api-design**, the transport accessor: contested in the thread — the only consumer it would have
  had is the example the reuse finding removes, and the location the finding names fails
  `scripts/lint-dot-notation.py`, since a declaration there is a `TauCeti.ContRepresentation.*` name
  on a Mathlib type.

`lake build`, `lake exe axioms`
(93834 declarations, allowlist only), `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` and a
`#lint` pass over the module are all green.

## Round 2 review

* **correctness** (block), and the transport half of **documentation**: the decomposition is now
  stated for `π`. Every block of the unitary model is pulled back along `e`, so the theorem returns
  `U : Fin n → Subrepresentation π.toRepresentation`, still irreducible, still `DirectSum.IsInternal`
  with the same dimension count, and pairwise orthogonal for `⟪e ·, e ·⟫`. Orthogonality *cannot* be
  stated for `V`'s own inner product — `e` exists precisely because `π` need not preserve it — so the
  `OrthogonalFamily` conjunct became the corresponding `Pairwise` statement about `⟪e ·, e ·⟫`. The
  finding's alternative fix (`IsSemisimpleModule … asModule`) is contested in the thread: it is the
  declaration the **reuse** finding on this same head required deleting, so the two cannot both hold.
* **api-design**: the earlier contest is withdrawn. `ContRepresentation.congrEquiv : π.Equiv (congr e π)`
  is added to `Continuous/Transport.lean`, in the root namespace after `end TauCeti` — the escape
  `Compact/Finite.lean` already uses — with `congrEquiv_toContinuousLinearEquiv` and
  `congrEquiv_apply`. `scripts/lint-dot-notation.py` reports `0 new`, exit 0.
* **documentation**, the Gram-operator bullet: `inner_gramOperator_self`'s docstring no longer
  attributes the operator-norm lower bound to it; compactness enters there only for integrability,
  and the bound belongs to `re_inner_gramOperator_self_pos`.

`lake build`, `lake exe axioms` (93840 declarations, allowlist only), `scripts/lint-style.sh` and
`scripts/lint-dot-notation.py` are all green.

## Round 3 review

* **generality** (and the reusable half of **proof-quality**): the transport is no longer embedded
  in the finite theorem. `TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition_of_congr`
  states it at the general level in `Continuous/OrthogonalDecomposition.lean`, beside the
  decomposition it carries back: for any `e : V ≃L[𝕜] W` with `IsUnitary (congr e π)`, `π` itself
  is an internal direct sum of finitely many irreducible subrepresentations, of dimensions adding
  up to `dim V`, pairwise orthogonal for `⟪e ·, e ·⟫`. It assumes only `[RCLike 𝕜] [Group G]` and
  `[FiniteDimensional 𝕜 V]`; nothing about the group is used, and the target space is allowed to
  differ, matching the generality of `congr`, `isIrreducible_congr` and `IsUnitary.congr`.
  `exists_orthogonal_irreducible_decomposition_of_finite` is now the finite unitarian trick
  followed by that theorem, three lines.
* **reuse** (and the `congrEquiv` half of **proof-quality**): the equivariance is taken from the
  bundled API rather than re-proved — `(ContRepresentation.congrEquiv e π).toContIntertwiningMap.isIntertwining g v`,
  read through the two `@[simp]` accessors that are needed because `congrEquiv`'s body is not
  exposed. `TauCeti.ContRepresentation.congr` is never unfolded and the `conv_rhs` is gone.
* **proof-quality**, the subrepresentation pullback/order equivalence: contested in the thread. It
  would be four or five new public declarations with a single call site in the repository, which is
  the shape `reuse` has twice required deleting on this PR, and it is new general mathematics that
  the roadmap item behind this PR does not name.

`lake build`, `lake exe axioms` (93841 declarations, allowlist only), `scripts/lint-style.sh`,
`scripts/lint-dot-notation.py` (`0 new`) and `scripts/lint-env.sh` (`PASS — no new violations`) are
all green.

## Round 4 review

* **generality**: `IsUnitary.exists_orthogonal_irreducible_decomposition_of_congr` no longer asks
  for an inner product on the source. The `Congr` section is moved out of the block whose variables
  carry `[InnerProductSpace 𝕜 V]` and given its own, so the theorem now assumes
  `[NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]` on the source — matching what
  `TauCeti.ContRepresentation.congr` itself asks — and keeps `[InnerProductSpace 𝕜 W]` on the
  unitary model, which is where every inner product in the statement and the proof is read. The
  proof is unchanged.

`lake build`, `lake exe axioms` (93841 declarations, allowlist only), `scripts/lint-style.sh` and
`scripts/lint-dot-notation.py` (`0 new`) are all green.

## Round 5 review

* **naming**: `ContRepresentation.congrEquiv`, `congrEquiv_toContinuousLinearEquiv` and
  `congrEquiv_apply` now take `π` before `e`, so the dot notation the root-namespace placement is
  for — `π.congrEquiv e` — matches their argument order. The single call site in
  `Continuous/OrthogonalDecomposition.lean` is updated.
* **api-design**: `congrEquiv_symm_apply : (π.congrEquiv e).symm w = e.symm w` is added, `@[simp]`
  and by `(rfl)`, so the inverse direction is usable without unfolding the unexposed body.
  `#lint only simpNF` over `Continuous/Transport.lean` reports `0 errors`.
* **documentation**, and the second alternative offered by **correctness**: the References
  paragraph of `Compact/Finite.lean` no longer says which part of which roadmap item the file is,
  nor that Peter-Weyl is "the one specialization still missing". It keeps the roadmap citation and
  the mathematical correspondences, records that the algebraic conclusion
  (`π.toRepresentation.asModule` semisimple over `MonoidAlgebra 𝕜 G`) is Mathlib's own instance and
  is neither restated nor reproved here, and states plainly that Peter-Weyl is not proved here.
  The roadmap-criterion aside in the character-orthogonality `example` comment goes too.

`lake build` (10124 jobs, completed successfully), `lake exe axioms`
(`audited 93842 TauCeti declaration(s); all within the allowlist`), `scripts/lint-style.sh`
(exit 0) and `scripts/lint-dot-notation.py` (`0 new`, exit 0) are all green.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"maschke-finite-specialization-of-complete-reducibility"}-->

🤖 Prepared with Claude Code





