### PR TITLE
feat: the Fourier monomials as the irreducible characters of the circle

### DIFF
--- a/TauCeti/Analysis/Fourier/AddCircle.lean
+++ b/TauCeti/Analysis/Fourier/AddCircle.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Fourier.AddCircle
+
+/-!
+# The Fourier monomials as characters of the additive circle
+
+Mathlib's `fourier n : C(AddCircle T, ℂ)` is developed as a family of `L²` monomials: the lemmas
+about it record how it behaves in the *index* `n` (`fourier_add`, `fourier_neg`) and what it
+contributes to the Fourier basis. This file records the two facts about the family that read it in
+the other direction, as a family of group homomorphisms `AddCircle T → ℂˣ` indexed by `n`:
+
+* each `fourier n` is multiplicative in its circle argument, so `x ↦ fourier n x` is a character of
+  `AddCircle T`;
+* distinct indices give distinct characters.
+
+Both are immediate from Mathlib — the first from `AddCircle.toCircle_add`, the second from
+`fourierCoeff_fourier` — but neither is stated there, and the character-theoretic reading is what a
+representation-theoretic consumer needs.
+
+## Main statements
+
+* `TauCeti.fourier_apply_add`: `fourier n (x + y) = fourier n x * fourier n y`.
+* `TauCeti.fourier_injective`: `n ↦ fourier n` is injective, so distinct indices give distinct
+  characters.
+
+## Tags
+
+Fourier, additive circle, character
+-/
+
+public section
+
+namespace TauCeti
+
+variable {T : ℝ}
+
+/-- **The Fourier monomial is multiplicative in its circle argument.** Together with
+`AddCircle.fourier_eval_zero` this says that `x ↦ fourier n x` is a homomorphism from
+`AddCircle T` to the unit circle of `ℂ`, i.e. a character of the circle group; Mathlib's
+`fourier_add` is the companion additivity in the *index*. -/
+theorem fourier_apply_add (n : ℤ) (x y : AddCircle T) :
+    fourier n (x + y) = fourier n x * fourier n y := by
+  simp [fourier_apply, smul_add, AddCircle.toCircle_add]
+
+variable [hT : Fact (0 < T)]
+
+/-- **Distinct indices give distinct Fourier monomials.** The `m`-th Fourier coefficient of
+`fourier n` is `1` when `m = n` and `0` otherwise, so the coefficient functions of two monomials
+with different indices already differ. -/
+theorem fourier_injective : Function.Injective (fourier (T := T)) := by
+  intro m n hmn
+  by_contra hne
+  have h : fourierCoeff (T := T) (fourier m) m = fourierCoeff (T := T) (fourier n) m :=
+    congrFun (congrArg (fun f : C(AddCircle T, ℂ) => fourierCoeff (⇑f)) hmn) m
+  rw [fourierCoeff_fourier, fourierCoeff_fourier] at h
+  simp [hne] at h
+
+end TauCeti

--- a/TauCeti/Analysis/Fourier/AddCircle.lean
+++ b/TauCeti/Analysis/Fourier/AddCircle.lean
@@ -8,24 +8,21 @@ module
 public import Mathlib.Analysis.Fourier.AddCircle
 
 /-!
-# The Fourier monomials as characters of the additive circle
+# Distinct Fourier monomials
 
 Mathlib's `fourier n : C(AddCircle T, ℂ)` is developed as a family of `L²` monomials: the lemmas
 about it record how it behaves in the *index* `n` (`fourier_add`, `fourier_neg`) and what it
-contributes to the Fourier basis. This file records the two facts about the family that read it in
-the other direction, as a family of group homomorphisms `AddCircle T → ℂˣ` indexed by `n`:
+contributes to the Fourier basis. Read the other way, as a family of characters of `AddCircle T`
+indexed by `n`, the first thing a representation-theoretic consumer needs is that the family is
+*faithful*: distinct indices give distinct characters, so the corresponding one-dimensional
+representations are pairwise inequivalent.
 
-* each `fourier n` is multiplicative in its circle argument, so `x ↦ fourier n x` is a character of
-  `AddCircle T`;
-* distinct indices give distinct characters.
-
-Both are immediate from Mathlib — the first from `AddCircle.toCircle_add`, the second from
-`fourierCoeff_fourier` — but neither is stated there, and the character-theoretic reading is what a
-representation-theoretic consumer needs.
+That is the single fact recorded here. Multiplicativity in the circle argument needs no lemma of
+its own: it is Mathlib's `AddCircle.toCircle_addChar`, the bundled additive character underlying
+`fourier`.
 
 ## Main statements
 
-* `TauCeti.fourier_apply_add`: `fourier n (x + y) = fourier n x * fourier n y`.
 * `TauCeti.fourier_injective`: `n ↦ fourier n` is injective, so distinct indices give distinct
   characters.
 
@@ -40,25 +37,29 @@ namespace TauCeti
 
 variable {T : ℝ}
 
-/-- **The Fourier monomial is multiplicative in its circle argument.** Together with
-`AddCircle.fourier_eval_zero` this says that `x ↦ fourier n x` is a homomorphism from
-`AddCircle T` to the unit circle of `ℂ`, i.e. a character of the circle group; Mathlib's
-`fourier_add` is the companion additivity in the *index*. -/
-theorem fourier_apply_add (n : ℤ) (x y : AddCircle T) :
-    fourier n (x + y) = fourier n x * fourier n y := by
-  simp [fourier_apply, smul_add, AddCircle.toCircle_add]
-
-variable [hT : Fact (0 < T)]
-
-/-- **Distinct indices give distinct Fourier monomials.** The `m`-th Fourier coefficient of
-`fourier n` is `1` when `m = n` and `0` otherwise, so the coefficient functions of two monomials
-with different indices already differ. -/
-theorem fourier_injective : Function.Injective (fourier (T := T)) := by
+/-- **Distinct indices give distinct Fourier monomials.** At the point `T / 2 / (m - n)` the two
+monomials `fourier m` and `fourier n` differ by `Complex.exp (π * I) = -1`, so they are already
+different there. Only `T ≠ 0` is needed: for `T = 0` the circle is trivial and every monomial is
+the constant `1`. -/
+theorem fourier_injective (hT : T ≠ 0) : Function.Injective (fourier (T := T)) := by
   intro m n hmn
   by_contra hne
-  have h : fourierCoeff (T := T) (fourier m) m = fourierCoeff (T := T) (fourier n) m :=
-    congrFun (congrArg (fun f : C(AddCircle T, ℂ) => fourierCoeff (⇑f)) hmn) m
-  rw [fourierCoeff_fourier, fourierCoeff_fourier] at h
-  simp [hne] at h
+  have hd : ((m : ℂ) - n) ≠ 0 := sub_ne_zero.mpr (by exact_mod_cast hne)
+  have hT' : (T : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hT
+  set y : ℝ := T / 2 / ((m : ℝ) - n) with hy
+  have hx : fourier m (y : AddCircle T) = fourier n (y : AddCircle T) := by rw [hmn]
+  rw [fourier_coe_apply, fourier_coe_apply] at hx
+  have he : 2 * (Real.pi : ℂ) * Complex.I * m * y / T
+      - 2 * (Real.pi : ℂ) * Complex.I * n * y / T = (Real.pi : ℂ) * Complex.I := by
+    rw [hy]
+    push_cast
+    field_simp
+  have hcontra : (-1 : ℂ) = 1 := by
+    calc (-1 : ℂ) = Complex.exp ((Real.pi : ℂ) * Complex.I) := Complex.exp_pi_mul_I.symm
+      _ = Complex.exp (2 * (Real.pi : ℂ) * Complex.I * m * y / T)
+            / Complex.exp (2 * (Real.pi : ℂ) * Complex.I * n * y / T) := by
+          rw [← Complex.exp_sub, he]
+      _ = 1 := by rw [hx, div_self (Complex.exp_ne_zero _)]
+  norm_num at hcontra
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Group/TypeTags.lean
+++ b/TauCeti/MeasureTheory/Group/TypeTags.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Haar.Basic
+public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
+
+/-!
+# Measure theory on the multiplicative type tag
+
+`Multiplicative α` is the type `α` with its addition renamed to multiplication. Mathlib transports
+the algebraic and topological structure of `α` along that renaming, but not the measurable
+structure, so an additive group carrying a Haar measure is not usable as a *multiplicative* group
+with a Haar measure. This file supplies the missing transport: the measurable space, the Borel
+property, the three measure-theoretic size conditions, and left invariance, from which the
+`IsHaarMeasure` instance follows.
+
+Everything here is definitional — `Multiplicative α` and `α` are the same type, with the same
+topology and the same σ-algebra — so each instance is the corresponding instance on `α`, and
+`Measure.IsMulLeftInvariant` is `Measure.IsAddLeftInvariant` read through
+`Multiplicative.toAdd`. What the instances add is that typeclass search can find them: a class
+whose argument is the *type* `Multiplicative α` (`MeasurableSpace`, `BorelSpace`,
+`IsMulLeftInvariant`) is keyed on that head symbol and no instance for `α` will match, and even a
+class whose only argument is the measure (`IsProbabilityMeasure`,
+`IsFiniteMeasureOnCompacts`, `IsOpenPosMeasure`) is stated with the ambient type fixed by the
+measure's spelling, so it must be restated once the measure is read as a measure on
+`Multiplicative α`.
+
+Only the `Multiplicative` direction is built, because that is the direction a consumer needs: the
+representation theory of a group is stated for a multiplicative group, while Mathlib's circle,
+`AddCircle T`, is additive. The `Additive` analogues are the same one-line transports and are
+omitted until something asks for them.
+
+## Main definitions
+
+* `TauCeti.instMeasurableSpaceMultiplicative`: the σ-algebra of `Multiplicative α` is that of `α`.
+* `TauCeti.instIsMulLeftInvariantMultiplicative`: a left-invariant measure for the addition of `α`
+  is left invariant for the multiplication of `Multiplicative α`.
+* `TauCeti.instIsHaarMeasureMultiplicative`: an additive Haar measure on `α` is a Haar measure on
+  `Multiplicative α`.
+
+## Tags
+
+multiplicative, type tag, Haar measure, measurable space
+-/
+
+public section
+
+open MeasureTheory
+
+namespace TauCeti
+
+variable {α : Type*}
+
+/-- `Multiplicative α` carries the σ-algebra of `α`. -/
+instance instMeasurableSpaceMultiplicative [m : MeasurableSpace α] :
+    MeasurableSpace (Multiplicative α) := m
+
+/-- `Multiplicative α` inherits the Borel property, since it has both the topology and the
+σ-algebra of `α`. -/
+instance instBorelSpaceMultiplicative [TopologicalSpace α] [MeasurableSpace α] [h : BorelSpace α] :
+    BorelSpace (Multiplicative α) := h
+
+/-- A probability measure on `α` is a probability measure on `Multiplicative α`. -/
+instance instIsProbabilityMeasureMultiplicative [MeasurableSpace α] (μ : Measure α)
+    [h : IsProbabilityMeasure μ] : IsProbabilityMeasure (α := Multiplicative α) μ := h
+
+/-- A measure finite on the compact sets of `α` is finite on the compact sets of
+`Multiplicative α`. -/
+instance instIsFiniteMeasureOnCompactsMultiplicative [TopologicalSpace α] [MeasurableSpace α]
+    (μ : Measure α) [h : IsFiniteMeasureOnCompacts μ] :
+    IsFiniteMeasureOnCompacts (α := Multiplicative α) μ := h
+
+/-- A measure positive on the nonempty open sets of `α` is positive on the nonempty open sets of
+`Multiplicative α`. -/
+instance instIsOpenPosMeasureMultiplicative [TopologicalSpace α] [MeasurableSpace α]
+    (μ : Measure α) [h : μ.IsOpenPosMeasure] :
+    Measure.IsOpenPosMeasure (X := Multiplicative α) μ := h
+
+/-- Left invariance for the addition of `α` **is** left invariance for the multiplication of
+`Multiplicative α`: the two translations are the same map. -/
+instance instIsMulLeftInvariantMultiplicative [Add α] [MeasurableSpace α] (μ : Measure α)
+    [h : μ.IsAddLeftInvariant] : Measure.IsMulLeftInvariant (G := Multiplicative α) μ :=
+  ⟨h.map_add_left_eq_self⟩
+
+/-- **An additive Haar measure is a Haar measure on the multiplicative type tag.** The three
+constituents — finiteness on compacts, left invariance, positivity on nonempty opens — are the
+instances above; only the assembly into `IsHaarMeasure` is new, because a structure class is not
+found from its fields by typeclass search. -/
+instance instIsHaarMeasureMultiplicative [TopologicalSpace α] [AddGroup α] [MeasurableSpace α]
+    (μ : Measure α) [μ.IsAddHaarMeasure] : Measure.IsHaarMeasure (G := Multiplicative α) μ where
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Group/TypeTags.lean
+++ b/TauCeti/MeasureTheory/Group/TypeTags.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.MeasureTheory.Measure.Haar.Basic
-public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 
 /-!
 # Measure theory on the multiplicative type tag

--- a/TauCeti/RepresentationTheory/Compact/Circle.lean
+++ b/TauCeti/RepresentationTheory/Compact/Circle.lean
@@ -8,8 +8,8 @@ module
 public import TauCeti.Analysis.Fourier.AddCircle
 public import TauCeti.MeasureTheory.Group.TypeTags
 public import TauCeti.RepresentationTheory.Compact.Character.Basic
-public import TauCeti.RepresentationTheory.Irreducible
-public import Mathlib.Analysis.Complex.Polynomial.Basic
+public import TauCeti.RepresentationTheory.LinearCharacter
+public import Mathlib.Analysis.SpecialFunctions.Complex.CircleAddChar
 
 /-!
 # The circle group: Fourier monomials are its irreducible characters
@@ -36,6 +36,8 @@ theory's normalization, not new API, and naming them would duplicate
 
 ## Main definitions
 
+* `TauCeti.fourierChar`: the `n`-th Fourier monomial as a linear character
+  `Multiplicative (AddCircle T) →* ℂˣ` of the circle group.
 * `TauCeti.fourierRep`: the `n`-th Fourier monomial as a one-dimensional continuous representation
   of the circle group.
 
@@ -46,15 +48,20 @@ theory's normalization, not new API, and naming them would duplicate
 * `TauCeti.isUnitary_fourierRep`, `TauCeti.isIrreducible_fourierRep`: each `fourierRep T n` is a
   unitary irreducible representation.
 * `TauCeti.character_fourierRep_apply`: the character of `fourierRep T n` is `fourier n`.
-* `TauCeti.eq_zero_of_contIntertwiningMap_fourierRep`: for `m ≠ n` there is no nonzero continuous
-  intertwiner `fourierRep T n → fourierRep T m`, so the Fourier representations are pairwise
-  inequivalent.
-* `TauCeti.orthonormal_characterLp_fourierRep`: **the acceptance criterion.** The characters of the
-  `fourierRep T n` are an orthonormal family in `L²` of the circle group for normalized Haar
-  measure; this is `AddCircle.orthonormal_fourier` read through the general compact-group
-  packaging.
+* `TauCeti.contIntertwiningMap_fourierRep_eq_zero_of_ne`: for `m ≠ n` there is no nonzero
+  continuous intertwiner `fourierRep T n → fourierRep T m`, so the Fourier representations are
+  pairwise inequivalent.
+* `TauCeti.orthonormal_characterLp_fourierRep`: **the character-orthonormality half of the
+  acceptance criterion.** The characters of the `fourierRep T n` are an orthonormal family in `L²`
+  of the circle group for normalized Haar measure; this is `AddCircle.orthonormal_fourier` read
+  through the general compact-group packaging.
 
 ## Implementation notes
+
+`fourierRep T n` acts by the scalar `fourierChar T n`, so its underlying representation is
+`Representation.ofLinearCharacter (fourierChar T n)`
+(`TauCeti.toRepresentation_fourierRep`); irreducibility and the character are then the
+corresponding facts about a linear character, not fresh one-dimensional computations.
 
 `ContRepresentation` is stated for a multiplicative monoid, while `AddCircle T` is additive, so the
 group here is `Multiplicative (AddCircle T)`. The measure-theoretic instances that makes that type
@@ -91,30 +98,45 @@ namespace TauCeti
 
 variable (T : ℝ)
 
-/-- **The `n`-th Fourier character of the circle group**, as a one-dimensional continuous
-representation on `ℂ`: the group element `x` acts by multiplication by `fourier n x`.
+/-- **The `n`-th Fourier monomial as a linear character of the circle group.** It is Mathlib's
+`AddCircle.toCircle_addChar` precomposed with multiplication by `n`, read as a multiplicative
+character valued in `ℂˣ`; `TauCeti.coe_fourierChar` identifies its value with `fourier n`. -/
+noncomputable def fourierChar (n : ℤ) : Multiplicative (AddCircle T) →* ℂˣ :=
+  Circle.toUnits.comp (toCircle_addChar.compAddMonoidHom (zsmulAddGroupHom n)).toMonoidHom
 
-Multiplicativity in `x` is `TauCeti.fourier_apply_add`; the value at the identity is
-`AddCircle.fourier_eval_zero`. -/
+@[simp]
+theorem coe_fourierChar (n : ℤ) (x : Multiplicative (AddCircle T)) :
+    (fourierChar T n x : ℂ) = fourier n (Multiplicative.toAdd x) := (rfl)
+
+/-- **The `n`-th Fourier character of the circle group**, as a one-dimensional continuous
+representation on `ℂ`: the group element `x` acts by multiplication by `fourier n x`. -/
 noncomputable def fourierRep (n : ℤ) : ContRepresentation ℂ (Multiplicative (AddCircle T)) ℂ :=
   .ofMonoidHom
-    { toFun := fun x => (fourier n (Multiplicative.toAdd x) : ℂ) • (1 : ℂ →L[ℂ] ℂ)
+    { toFun := fun x => (fourierChar T n x : ℂ) • (1 : ℂ →L[ℂ] ℂ)
       map_one' := ContinuousLinearMap.ext fun z => by simp
       map_mul' := fun x y => ContinuousLinearMap.ext fun z => by
-        simp only [toAdd_mul, fourier_apply_add]
         simp [mul_assoc] }
 
 @[simp]
 theorem fourierRep_apply (n : ℤ) (x : Multiplicative (AddCircle T)) (z : ℂ) :
     fourierRep T n x z = fourier n (Multiplicative.toAdd x) * z := (rfl)
 
+/-- **The Fourier representation is the one-dimensional representation of its linear character.**
+Everything about it that only depends on the scalar action -- irreducibility, the character -- is
+read off from `Representation.ofLinearCharacter` through this identification. -/
+theorem toRepresentation_fourierRep (n : ℤ) :
+    (fourierRep T n).toRepresentation = Representation.ofLinearCharacter (fourierChar T n) :=
+  MonoidHom.ext fun x => LinearMap.ext fun z => by
+    rw [Representation.ofLinearCharacter_apply, coe_fourierChar]
+    exact fourierRep_apply T n x z
+
 /-- The Fourier representation is continuous: its action operator depends on the group element
 through the continuous map `fourier n`. -/
-theorem continuous_fourierRep (n : ℤ) : Continuous (fourierRep T n) := by
-  have h : ⇑(fourierRep T n) = fun x : Multiplicative (AddCircle T) =>
-      (fourier n (Multiplicative.toAdd x) : ℂ) • (1 : ℂ →L[ℂ] ℂ) := (rfl)
-  rw [h]
-  exact ((fourier n).continuous.comp continuous_id).smul continuous_const
+theorem continuous_fourierRep (n : ℤ) : Continuous (fourierRep T n) :=
+  Continuous.congr (f := fun x : Multiplicative (AddCircle T) =>
+      (fourier n (Multiplicative.toAdd x) : ℂ) • (1 : ℂ →L[ℂ] ℂ))
+    (((fourier n).continuous.comp continuous_id).smul continuous_const)
+    fun _ => ContinuousLinearMap.ext fun _ => by simp
 
 /-- The Fourier representation is unitary: multiplication by a number of modulus one is an
 isometry of `ℂ`. -/
@@ -123,24 +145,23 @@ theorem isUnitary_fourierRep (n : ℤ) : ContRepresentation.IsUnitary (fourierRe
   intro x z
   rw [fourierRep_apply, norm_mul, fourier_apply, Circle.norm_coe, one_mul]
 
-/-- The Fourier representation is irreducible, being one-dimensional. -/
+/-- The Fourier representation is irreducible, being the one-dimensional representation of a
+linear character. -/
 theorem isIrreducible_fourierRep (n : ℤ) :
-    Representation.IsIrreducible (fourierRep T n).toRepresentation :=
-  Representation.isIrreducible_of_finrank_eq_one _ (Module.finrank_self ℂ)
+    Representation.IsIrreducible (fourierRep T n).toRepresentation := by
+  rw [toRepresentation_fourierRep]
+  infer_instance
 
 /-- **The character of the `n`-th Fourier representation is `fourier n`.** A one-dimensional
-representation is its own character: the trace of multiplication by `c` on `ℂ` is `c`. -/
+representation is its own character; this is `Representation.char_ofLinearCharacter` read through
+`TauCeti.toRepresentation_fourierRep`. -/
 theorem character_fourierRep_apply (n : ℤ) (x : Multiplicative (AddCircle T)) :
     ContRepresentation.character (fourierRep T n) (continuous_fourierRep T n) x =
       fourier n (Multiplicative.toAdd x) := by
-  rw [ContRepresentation.character_apply]
-  have h : ((fourierRep T n x : ℂ →L[ℂ] ℂ) : ℂ →ₗ[ℂ] ℂ) =
-      fourier n (Multiplicative.toAdd x) • LinearMap.id :=
-    LinearMap.ext fun z => by simp
-  rw [h, map_smul, LinearMap.trace_id, Module.finrank_self]
-  simp
-
-variable [hT : Fact (0 < T)]
+  have h : ContRepresentation.character (fourierRep T n) (continuous_fourierRep T n) x =
+      (fourierRep T n).toRepresentation.character x :=
+    congrFun (ContRepresentation.coe_character _ _) x
+  rw [h, toRepresentation_fourierRep, Representation.char_ofLinearCharacter, coe_fourierChar]
 
 /-- **The Fourier representations are pairwise inequivalent.** For `m ≠ n` every continuous
 intertwiner `fourierRep T n → fourierRep T m` vanishes: such a map is multiplication by its value
@@ -149,14 +170,14 @@ by `TauCeti.fourier_injective`.
 
 This is the hypothesis of the general second orthogonality relation
 `TauCeti.ContRepresentation.character_orthonormal_distinct`. -/
-theorem eq_zero_of_contIntertwiningMap_fourierRep {m n : ℤ} (h : m ≠ n)
+theorem contIntertwiningMap_fourierRep_eq_zero_of_ne (hT : T ≠ 0) {m n : ℤ} (h : m ≠ n)
     (f : ContIntertwiningMap (fourierRep T n) (fourierRep T m)) :
     f.toContinuousLinearMap = 0 := by
   have hlin : ∀ c : ℂ, f.toContinuousLinearMap c = c * f.toContinuousLinearMap 1 := fun c => by
     simpa using f.toContinuousLinearMap.map_smul c (1 : ℂ)
   have hone : f.toContinuousLinearMap (1 : ℂ) = 0 := by
     by_contra hne
-    refine (fun hc => h (fourier_injective (T := T) hc)) ?_
+    refine (fun hc => h (fourier_injective (T := T) hT hc)) ?_
     ext x
     have hx := congrArg (fun g : ℂ →L[ℂ] ℂ => g 1)
       (f.isIntertwining' (Multiplicative.ofAdd x))
@@ -168,6 +189,8 @@ theorem eq_zero_of_contIntertwiningMap_fourierRep {m n : ℤ} (h : m ≠ n)
       _ = fourier m x * f.toContinuousLinearMap 1 := hx
   refine ContinuousLinearMap.ext fun z => ?_
   simp [hlin z, hone]
+
+variable [hT : Fact (0 < T)]
 
 /-- **Normalized Haar measure on the circle group is Mathlib's `AddCircle.haarAddCircle`.** Both
 are Haar probability measures on a compact group, and there is only one such. -/
@@ -194,9 +217,11 @@ theorem inner_characterLp_fourierRep (m n : ℤ) :
   simp only [character_fourierRep_apply]
   exact key
 
-/-- **The acceptance criterion.** The characters of the Fourier representations are an orthonormal
-family in `L²` of the circle group for normalized Haar measure: the general compact-group character
-theory, specialized to the circle, is Mathlib's `AddCircle.orthonormal_fourier`. -/
+/-- **The character-orthonormality half of the acceptance criterion.** The characters of the
+Fourier representations are an orthonormal family in `L²` of the circle group for normalized Haar
+measure: the general compact-group character theory, specialized to the circle, is Mathlib's
+`AddCircle.orthonormal_fourier`. The remaining half, the identification of `peterWeylBasis` with
+`AddCircle.fourierBasis`, is not proved here. -/
 theorem orthonormal_characterLp_fourierRep :
     Orthonormal ℂ fun n : ℤ =>
       ContRepresentation.characterLp (fourierRep T n) (continuous_fourierRep T n) :=
@@ -213,6 +238,6 @@ example {m n : ℤ} (h : m ≠ n) :
     ⟪ContRepresentation.characterLp (fourierRep T m) (continuous_fourierRep T m),
       ContRepresentation.characterLp (fourierRep T n) (continuous_fourierRep T n)⟫_ℂ = 0 :=
   ContRepresentation.character_orthonormal_distinct _ _ _ _ (isUnitary_fourierRep T m)
-    (eq_zero_of_contIntertwiningMap_fourierRep T h)
+    (contIntertwiningMap_fourierRep_eq_zero_of_ne T hT.out.ne' h)
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Compact/Circle.lean
+++ b/TauCeti/RepresentationTheory/Compact/Circle.lean
@@ -47,7 +47,7 @@ theory's normalization, not new API, and naming them would duplicate
   `AddCircle.haarAddCircle`.
 * `TauCeti.isUnitary_fourierRep`, `TauCeti.isIrreducible_fourierRep`: each `fourierRep T n` is a
   unitary irreducible representation.
-* `TauCeti.character_fourierRep_apply`: the character of `fourierRep T n` is `fourier n`.
+* `TauCeti.character_fourierRep`: the character of `fourierRep T n` is `fourier n`.
 * `TauCeti.contIntertwiningMap_fourierRep_eq_zero_of_ne`: for `m ≠ n` there is no nonzero
   continuous intertwiner `fourierRep T n → fourierRep T m`, so the Fourier representations are
   pairwise inequivalent.
@@ -154,14 +154,24 @@ theorem isIrreducible_fourierRep (n : ℤ) :
 
 /-- **The character of the `n`-th Fourier representation is `fourier n`.** A one-dimensional
 representation is its own character; this is `Representation.char_ofLinearCharacter` read through
-`TauCeti.toRepresentation_fourierRep`. -/
-theorem character_fourierRep_apply (n : ℤ) (x : Multiplicative (AddCircle T)) :
-    ContRepresentation.character (fourierRep T n) (continuous_fourierRep T n) x =
-      fourier n (Multiplicative.toAdd x) := by
-  have h : ContRepresentation.character (fourierRep T n) (continuous_fourierRep T n) x =
-      (fourierRep T n).toRepresentation.character x :=
-    congrFun (ContRepresentation.coe_character _ _) x
-  rw [h, toRepresentation_fourierRep, Representation.char_ofLinearCharacter, coe_fourierChar]
+`TauCeti.toRepresentation_fourierRep`.
+
+The equation is stated between continuous maps rather than pointwise because that is the spelling
+`simp` can normalize with: `TauCeti.ContRepresentation.character_apply` is itself `@[simp]`, so a
+pointwise `character (fourierRep T n) _ x = _` is not in simp-normal form and `simpNF` rejects the
+tag on it, whereas the unapplied left-hand side is a subterm of the pointwise one and rewrites it
+too. This is how `TauCeti.SU2.character_symPowerModel` is stated for the same reason. -/
+@[simp]
+theorem character_fourierRep (n : ℤ) :
+    ContRepresentation.character (fourierRep T n) (continuous_fourierRep T n) = fourier n :=
+  ContinuousMap.ext fun x => by
+    have h : ContRepresentation.character (fourierRep T n) (continuous_fourierRep T n) x =
+        (fourierRep T n).toRepresentation.character x :=
+      congrFun (ContRepresentation.coe_character _ _) x
+    rw [h, toRepresentation_fourierRep, Representation.char_ofLinearCharacter]
+    -- `Multiplicative (AddCircle T)` is `AddCircle T`, so `fourier n (Multiplicative.toAdd x)`
+    -- and `fourier n x` are the same term.
+    exact coe_fourierChar T n x
 
 /-- **The Fourier representations are pairwise inequivalent.** For `m ≠ n` every continuous
 intertwiner `fourierRep T n → fourierRep T m` vanishes: such a map is multiplication by its value
@@ -214,7 +224,7 @@ theorem inner_characterLp_fourierRep (m n : ℤ) :
     exact orthonormal_iff_ite.mp orthonormal_fourier m n
   rw [ContRepresentation.characterLp_def, ContRepresentation.characterLp_def,
     ContinuousMap.inner_toLp, haarProb_eq_haarAddCircle]
-  simp only [character_fourierRep_apply]
+  simp only [character_fourierRep]
   exact key
 
 /-- **The character-orthonormality half of the acceptance criterion.** The characters of the

--- a/TauCeti/RepresentationTheory/Compact/Circle.lean
+++ b/TauCeti/RepresentationTheory/Compact/Circle.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Fourier.AddCircle
+public import TauCeti.MeasureTheory.Group.TypeTags
+public import TauCeti.RepresentationTheory.Compact.Character.Basic
+public import TauCeti.RepresentationTheory.Irreducible
+public import Mathlib.Analysis.Complex.Polynomial.Basic
+
+/-!
+# The circle group: Fourier monomials are its irreducible characters
+
+The circle `AddCircle T` is a compact abelian group, so every irreducible representation of it is
+one-dimensional and its own character. This file builds those representations from Mathlib's
+Fourier monomials and checks that the general compact-group theory, specialized to the circle,
+returns Mathlib's Fourier analysis on the nose.
+
+Concretely, `fourierRep T n` is the continuous representation of the circle on `ℂ` in which the
+group element `x` acts by multiplication by `fourier n x`. It is one-dimensional, hence
+irreducible, and unitary because `fourier n x` has modulus one; its character is `fourier n` again.
+Under those identifications:
+
+* the `L²` inner product of two of these characters, computed for the normalized Haar measure of
+  `TauCeti/RepresentationTheory/Compact/Haar.lean`, is Mathlib's `AddCircle.orthonormal_fourier`;
+* the general first orthogonality relation `character_orthonormal_self` and the general second
+  orthogonality relation `character_orthonormal_distinct` return the diagonal and off-diagonal
+  halves of that same statement.
+
+The last two are recorded as anonymous `example`s: they are consistency checks on the general
+theory's normalization, not new API, and naming them would duplicate
+`TauCeti.inner_characterLp_fourierRep`.
+
+## Main definitions
+
+* `TauCeti.fourierRep`: the `n`-th Fourier monomial as a one-dimensional continuous representation
+  of the circle group.
+
+## Main statements
+
+* `TauCeti.haarProb_eq_haarAddCircle`: the normalized Haar measure of the circle group is Mathlib's
+  `AddCircle.haarAddCircle`.
+* `TauCeti.isUnitary_fourierRep`, `TauCeti.isIrreducible_fourierRep`: each `fourierRep T n` is a
+  unitary irreducible representation.
+* `TauCeti.character_fourierRep_apply`: the character of `fourierRep T n` is `fourier n`.
+* `TauCeti.eq_zero_of_contIntertwiningMap_fourierRep`: for `m ≠ n` there is no nonzero continuous
+  intertwiner `fourierRep T n → fourierRep T m`, so the Fourier representations are pairwise
+  inequivalent.
+* `TauCeti.orthonormal_characterLp_fourierRep`: **the acceptance criterion.** The characters of the
+  `fourierRep T n` are an orthonormal family in `L²` of the circle group for normalized Haar
+  measure; this is `AddCircle.orthonormal_fourier` read through the general compact-group
+  packaging.
+
+## Implementation notes
+
+`ContRepresentation` is stated for a multiplicative monoid, while `AddCircle T` is additive, so the
+group here is `Multiplicative (AddCircle T)`. The measure-theoretic instances that makes that type
+usable as a compact group with Haar measure are in
+`TauCeti/MeasureTheory/Group/TypeTags.lean`; they are definitional, so
+`haarProb_eq_haarAddCircle` is just the uniqueness of a Haar probability measure applied on the
+multiplicative side. Because `Multiplicative (AddCircle T)` and `AddCircle T` are the same type
+with the same topology and σ-algebra, an integral over one is literally an integral over the other,
+which is what lets `inner_characterLp_fourierRep` end in Mathlib's orthonormality statement.
+
+What is *not* done here is the full Peter-Weyl half of the roadmap's circle acceptance criterion —
+identifying `peterWeylBasis` with `AddCircle.fourierBasis` under the indexing equivalence
+`Σ π, Fin 1 × Fin 1 ≃ ℤ`. That needs the exhaustion of the irreducibles of the circle, which is not
+proved here: the statements below say that the `fourierRep T n` are pairwise inequivalent
+irreducibles with orthonormal characters, not that there are no others.
+
+This is the circle bullet of the `## Worked examples (acceptance criteria)` section of the
+[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
+whose Layer 6 character theory is in
+`TauCeti/RepresentationTheory/Compact/Character/Basic.lean`. The mathematical development follows
+Daniel Bump, *Lie Groups*, second edition, Chapter 2.
+
+## Tags
+
+circle group, Fourier series, character, Peter-Weyl
+-/
+
+public section
+
+open MeasureTheory AddCircle
+open scoped ComplexConjugate InnerProductSpace
+
+namespace TauCeti
+
+variable (T : ℝ)
+
+/-- **The `n`-th Fourier character of the circle group**, as a one-dimensional continuous
+representation on `ℂ`: the group element `x` acts by multiplication by `fourier n x`.
+
+Multiplicativity in `x` is `TauCeti.fourier_apply_add`; the value at the identity is
+`AddCircle.fourier_eval_zero`. -/
+noncomputable def fourierRep (n : ℤ) : ContRepresentation ℂ (Multiplicative (AddCircle T)) ℂ :=
+  .ofMonoidHom
+    { toFun := fun x => (fourier n (Multiplicative.toAdd x) : ℂ) • (1 : ℂ →L[ℂ] ℂ)
+      map_one' := ContinuousLinearMap.ext fun z => by simp
+      map_mul' := fun x y => ContinuousLinearMap.ext fun z => by
+        simp only [toAdd_mul, fourier_apply_add]
+        simp [mul_assoc] }
+
+@[simp]
+theorem fourierRep_apply (n : ℤ) (x : Multiplicative (AddCircle T)) (z : ℂ) :
+    fourierRep T n x z = fourier n (Multiplicative.toAdd x) * z := (rfl)
+
+/-- The Fourier representation is continuous: its action operator depends on the group element
+through the continuous map `fourier n`. -/
+theorem continuous_fourierRep (n : ℤ) : Continuous (fourierRep T n) := by
+  have h : ⇑(fourierRep T n) = fun x : Multiplicative (AddCircle T) =>
+      (fourier n (Multiplicative.toAdd x) : ℂ) • (1 : ℂ →L[ℂ] ℂ) := (rfl)
+  rw [h]
+  exact ((fourier n).continuous.comp continuous_id).smul continuous_const
+
+/-- The Fourier representation is unitary: multiplication by a number of modulus one is an
+isometry of `ℂ`. -/
+theorem isUnitary_fourierRep (n : ℤ) : ContRepresentation.IsUnitary (fourierRep T n) := by
+  rw [ContRepresentation.isUnitary_iff_norm_map]
+  intro x z
+  rw [fourierRep_apply, norm_mul, fourier_apply, Circle.norm_coe, one_mul]
+
+/-- The Fourier representation is irreducible, being one-dimensional. -/
+theorem isIrreducible_fourierRep (n : ℤ) :
+    Representation.IsIrreducible (fourierRep T n).toRepresentation :=
+  Representation.isIrreducible_of_finrank_eq_one _ (Module.finrank_self ℂ)
+
+/-- **The character of the `n`-th Fourier representation is `fourier n`.** A one-dimensional
+representation is its own character: the trace of multiplication by `c` on `ℂ` is `c`. -/
+theorem character_fourierRep_apply (n : ℤ) (x : Multiplicative (AddCircle T)) :
+    ContRepresentation.character (fourierRep T n) (continuous_fourierRep T n) x =
+      fourier n (Multiplicative.toAdd x) := by
+  rw [ContRepresentation.character_apply]
+  have h : ((fourierRep T n x : ℂ →L[ℂ] ℂ) : ℂ →ₗ[ℂ] ℂ) =
+      fourier n (Multiplicative.toAdd x) • LinearMap.id :=
+    LinearMap.ext fun z => by simp
+  rw [h, map_smul, LinearMap.trace_id, Module.finrank_self]
+  simp
+
+variable [hT : Fact (0 < T)]
+
+/-- **The Fourier representations are pairwise inequivalent.** For `m ≠ n` every continuous
+intertwiner `fourierRep T n → fourierRep T m` vanishes: such a map is multiplication by its value
+`c` at `1`, and intertwining forces `fourier n x * c = fourier m x * c` for every `x`, so `c = 0`
+by `TauCeti.fourier_injective`.
+
+This is the hypothesis of the general second orthogonality relation
+`TauCeti.ContRepresentation.character_orthonormal_distinct`. -/
+theorem eq_zero_of_contIntertwiningMap_fourierRep {m n : ℤ} (h : m ≠ n)
+    (f : ContIntertwiningMap (fourierRep T n) (fourierRep T m)) :
+    f.toContinuousLinearMap = 0 := by
+  have hlin : ∀ c : ℂ, f.toContinuousLinearMap c = c * f.toContinuousLinearMap 1 := fun c => by
+    simpa using f.toContinuousLinearMap.map_smul c (1 : ℂ)
+  have hone : f.toContinuousLinearMap (1 : ℂ) = 0 := by
+    by_contra hne
+    refine (fun hc => h (fourier_injective (T := T) hc)) ?_
+    ext x
+    have hx := congrArg (fun g : ℂ →L[ℂ] ℂ => g 1)
+      (f.isIntertwining' (Multiplicative.ofAdd x))
+    simp only [ContinuousLinearMap.coe_comp, Function.comp_apply, fourierRep_apply,
+      mul_one] at hx
+    refine (mul_right_cancel₀ hne ?_).symm
+    calc fourier n x * f.toContinuousLinearMap 1
+        = f.toContinuousLinearMap (fourier n x) := (hlin _).symm
+      _ = fourier m x * f.toContinuousLinearMap 1 := hx
+  refine ContinuousLinearMap.ext fun z => ?_
+  simp [hlin z, hone]
+
+/-- **Normalized Haar measure on the circle group is Mathlib's `AddCircle.haarAddCircle`.** Both
+are Haar probability measures on a compact group, and there is only one such. -/
+theorem haarProb_eq_haarAddCircle :
+    haarProb (Multiplicative (AddCircle T)) = haarAddCircle :=
+  (eq_haarProb_of_isHaarMeasure_of_isProbabilityMeasure
+    (G := Multiplicative (AddCircle T)) haarAddCircle).symm
+
+/-- **The `L²` inner product of two Fourier characters is Mathlib's Fourier orthonormality.** Both
+sides are the Haar integral of `fourier n · conj (fourier m)`; the left is that integral written
+for the general compact-group packaging of
+`TauCeti/RepresentationTheory/Compact/Character/Basic.lean`, the right is
+`AddCircle.orthonormal_fourier`. -/
+theorem inner_characterLp_fourierRep (m n : ℤ) :
+    ⟪ContRepresentation.characterLp (fourierRep T m) (continuous_fourierRep T m),
+      ContRepresentation.characterLp (fourierRep T n) (continuous_fourierRep T n)⟫_ℂ =
+      if m = n then 1 else 0 := by
+  have key : ∫ x : AddCircle T, fourier n x * conj (fourier m x) ∂haarAddCircle =
+      if m = n then 1 else 0 := by
+    rw [← ContinuousMap.inner_toLp haarAddCircle (fourier m) (fourier n)]
+    exact orthonormal_iff_ite.mp orthonormal_fourier m n
+  rw [ContRepresentation.characterLp_def, ContRepresentation.characterLp_def,
+    ContinuousMap.inner_toLp, haarProb_eq_haarAddCircle]
+  simp only [character_fourierRep_apply]
+  exact key
+
+/-- **The acceptance criterion.** The characters of the Fourier representations are an orthonormal
+family in `L²` of the circle group for normalized Haar measure: the general compact-group character
+theory, specialized to the circle, is Mathlib's `AddCircle.orthonormal_fourier`. -/
+theorem orthonormal_characterLp_fourierRep :
+    Orthonormal ℂ fun n : ℤ =>
+      ContRepresentation.characterLp (fourierRep T n) (continuous_fourierRep T n) :=
+  orthonormal_iff_ite.mpr fun m n => inner_characterLp_fourierRep T m n
+
+-- The general first orthogonality relation returns the diagonal half of `orthonormal_fourier`.
+example (n : ℤ) :
+    ‖ContRepresentation.characterLp (fourierRep T n) (continuous_fourierRep T n)‖ = 1 :=
+  ContRepresentation.norm_characterLp_eq_one _ _ (isUnitary_fourierRep T n)
+    (isIrreducible_fourierRep T n)
+
+-- The general second orthogonality relation returns the off-diagonal half.
+example {m n : ℤ} (h : m ≠ n) :
+    ⟪ContRepresentation.characterLp (fourierRep T m) (continuous_fourierRep T m),
+      ContRepresentation.characterLp (fourierRep T n) (continuous_fourierRep T n)⟫_ℂ = 0 :=
+  ContRepresentation.character_orthonormal_distinct _ _ _ _ (isUnitary_fourierRep T m)
+    (eq_zero_of_contIntertwiningMap_fourierRep T h)
+
+end TauCeti


### PR DESCRIPTION
This PR builds the Fourier monomials of the circle as one-dimensional continuous representations, and checks that the general compact-group character theory returns Mathlib's Fourier analysis when specialized to them. `TauCeti.fourierRep T n` is the representation of `Multiplicative (AddCircle T)` on `ℂ` in which `x` acts by multiplication by `fourier n x`; it is continuous, unitary (its action operators have modulus one), irreducible (one-dimensional), and its character is `fourier n` again. Distinct indices give inequivalent representations: `TauCeti.contIntertwiningMap_fourierRep_eq_zero_of_ne` shows every continuous intertwiner between two of them with different indices vanishes. The payoff is `TauCeti.orthonormal_characterLp_fourierRep`, the character-orthonormality half of the acceptance criterion, which says the characters of the `fourierRep T n` are an orthonormal family in `L²` of the circle group for the normalized Haar measure of `TauCeti/RepresentationTheory/Compact/Haar.lean` — this is exactly Mathlib's `AddCircle.orthonormal_fourier`, read through the general packaging. Two anonymous `example`s then confirm that the general first and second orthogonality relations (`character_orthonormal_self` via `norm_characterLp_eq_one`, and `character_orthonormal_distinct`) reproduce the diagonal and off-diagonal halves of that same statement, which is the normalization check the roadmap asks for.

This is the circle bullet of the `## Worked examples (acceptance criteria)` section of `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md` ("**The circle `S¹` and Fourier series are Peter-Weyl**"), whose stated acceptance is that the general statements, specialized to `AddCircle 1`, are Mathlib's Fourier statements. `TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean` records that this convention check "waits on the `AddCircle` material", and no `AddCircle` appeared anywhere under `TauCeti/RepresentationTheory/` before this PR. The half of that bullet this PR does **not** do is the Peter-Weyl identification `peterWeylBasis = fourierBasis` under `Σ π, Fin 1 × Fin 1 ≃ ℤ`, which needs the exhaustion of the circle's irreducibles; the module docstring says so explicitly, and everything proved here is stated for a general period `T` with `Fact (0 < T)` rather than only for `T = 1`.

Two small prerequisites ship alongside, each in its own file because neither is about representations. `TauCeti/MeasureTheory/Group/TypeTags.lean` transports the measurable structure of an additive group to `Multiplicative` of it — the σ-algebra, the Borel property, the three measure-size conditions, left invariance, and the assembled `IsHaarMeasure` instance. All are definitional (`Multiplicative α` is `α`), but Mathlib declares none of them, so an additive group with a Haar measure is otherwise unusable as a multiplicative group with a Haar measure; `ContRepresentation` is stated for a multiplicative monoid, so the circle has to be read that way. `TauCeti/Analysis/Fourier/AddCircle.lean` adds the one fact about `fourier` that reads it as a *character* rather than as an `L²` monomial: `fourier_injective`, that distinct indices give distinct monomials, proved from `fourier_coe_apply` by evaluating at `T / 2 / (m - n)` where the two monomials differ by `Complex.exp (π * I) = -1`. Only `T ≠ 0` is needed. Mathlib's own `fourier` lemmas all record behaviour in the index `n` instead, so the statement does not exist there. Multiplicativity in the circle argument needs no lemma of its own: `TauCeti.fourierChar` bundles Mathlib's `AddCircle.toCircle_addChar` into a linear character `Multiplicative (AddCircle T) →* ℂˣ`, and `TauCeti.toRepresentation_fourierRep` identifies the underlying representation of `fourierRep T n` with `Representation.ofLinearCharacter (fourierChar T n)`, so irreducibility and the character are read off from that shared API.

No Mathlib source was vendored; the development consumes Mathlib's `Analysis/Fourier/AddCircle.lean` (`fourier`, `fourier_coe_apply`, `haarAddCircle`, `orthonormal_fourier`), `AddCircle.toCircle_addChar`, `ContinuousMap.inner_toLp`, and `Measure.isHaarMeasure_eq_of_isProbabilityMeasure` through this repository's `eq_haarProb_of_isHaarMeasure_of_isProbabilityMeasure`. `lake build` and `lake exe axioms` are green (93893 declarations audited, allowlist only), as are `scripts/lint-style.sh`, the dot-notation ratchet, and the `lint-env.sh` linter set run over the new module.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"circle-fourier-series-are-peter-weyl"}-->

🤖 Prepared with Claude Code

