### PR TITLE
chore(ci): wire MATHLIB_CACHE_GET_URL from a repository variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Read endpoint for `lake exe cache get`, wired from a repository variable that an operator
-  # points at https://cache.mathlib.org. The cache tool treats unset and empty alike, so
-  # clearing the variable returns reads to the tool's default endpoints on the next run.
+  # Read endpoint for `lake exe cache get`, wired from a repository variable. The cache tool
+  # treats unset and empty alike, so clearing the variable returns reads to the tool's
+  # default endpoints on the next run.
   MATHLIB_CACHE_GET_URL: ${{ vars.MATHLIB_CACHE_GET_URL }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ concurrency:
   group: main-ci-cache-publisher
   cancel-in-progress: false
 
+env:
+  # Read endpoint for `lake exe cache get`, wired from a repository variable that an operator
+  # points at https://cache.mathlib.org. The cache tool treats unset and empty alike, so
+  # clearing the variable returns reads to the tool's default endpoints on the next run.
+  MATHLIB_CACHE_GET_URL: ${{ vars.MATHLIB_CACHE_GET_URL }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -51,9 +51,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Read endpoint for `lake exe cache get`, wired from a repository variable that an operator
-  # points at https://cache.mathlib.org. The cache tool treats unset and empty alike, so
-  # clearing the variable returns reads to the tool's default endpoints on the next run.
+  # Read endpoint for `lake exe cache get`, wired from a repository variable. The cache tool
+  # treats unset and empty alike, so clearing the variable returns reads to the tool's
+  # default endpoints on the next run.
   MATHLIB_CACHE_GET_URL: ${{ vars.MATHLIB_CACHE_GET_URL }}
 
 jobs:

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -50,6 +50,12 @@ concurrency:
   # from-source build but before the report wastes the expensive part.
   cancel-in-progress: false
 
+env:
+  # Read endpoint for `lake exe cache get`, wired from a repository variable that an operator
+  # points at https://cache.mathlib.org. The cache tool treats unset and empty alike, so
+  # clearing the variable returns reads to the tool's default endpoints on the next run.
+  MATHLIB_CACHE_GET_URL: ${{ vars.MATHLIB_CACHE_GET_URL }}
+
 jobs:
   # No secrets reach this job. It builds and executes repository code, including a build restored
   # from the public cache, so anything it can read is code-reachable. Reporting lives in a separate

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -65,6 +65,10 @@ concurrency:
 env:
   # Run JavaScript actions on Node 24 (Node 20 is deprecated on GitHub runners).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Read endpoint for `lake exe cache get`, wired from a repository variable that an operator
+  # points at https://cache.mathlib.org. The cache tool treats unset and empty alike, so
+  # clearing the variable returns reads to the tool's default endpoints on the next run.
+  MATHLIB_CACHE_GET_URL: ${{ vars.MATHLIB_CACHE_GET_URL }}
 
 jobs:
   # Named `build-site`, not `build`, to keep every job name distinct from the required `build` commit

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -65,9 +65,9 @@ concurrency:
 env:
   # Run JavaScript actions on Node 24 (Node 20 is deprecated on GitHub runners).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Read endpoint for `lake exe cache get`, wired from a repository variable that an operator
-  # points at https://cache.mathlib.org. The cache tool treats unset and empty alike, so
-  # clearing the variable returns reads to the tool's default endpoints on the next run.
+  # Read endpoint for `lake exe cache get`, wired from a repository variable. The cache tool
+  # treats unset and empty alike, so clearing the variable returns reads to the tool's
+  # default endpoints on the next run.
   MATHLIB_CACHE_GET_URL: ${{ vars.MATHLIB_CACHE_GET_URL }}
 
 jobs:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -42,6 +42,12 @@ concurrency:
   group: pr-build-${{ github.event.pull_request.number || inputs.pr || github.event.merge_group.head_sha }}
   cancel-in-progress: true
 
+env:
+  # Read endpoint for `lake exe cache get`, wired from a repository variable that an operator
+  # points at https://cache.mathlib.org. The cache tool treats unset and empty alike, so
+  # clearing the variable returns reads to the tool's default endpoints on the next run.
+  MATHLIB_CACHE_GET_URL: ${{ vars.MATHLIB_CACHE_GET_URL }}
+
 jobs:
   # Name kept distinct from `build` on purpose — see the header note. The required merge check is the
   # `build` commit STATUS posted in the final step, not this job's auto-created check-run.

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -43,9 +43,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Read endpoint for `lake exe cache get`, wired from a repository variable that an operator
-  # points at https://cache.mathlib.org. The cache tool treats unset and empty alike, so
-  # clearing the variable returns reads to the tool's default endpoints on the next run.
+  # Read endpoint for `lake exe cache get`, wired from a repository variable. The cache tool
+  # treats unset and empty alike, so clearing the variable returns reads to the tool's
+  # default endpoints on the next run.
   MATHLIB_CACHE_GET_URL: ${{ vars.MATHLIB_CACHE_GET_URL }}
 
 jobs:

--- a/.github/workflows/pr-profile.yml
+++ b/.github/workflows/pr-profile.yml
@@ -46,9 +46,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Read endpoint for `lake exe cache get`, wired from a repository variable that an operator
-  # points at https://cache.mathlib.org. The cache tool treats unset and empty alike, so
-  # clearing the variable returns reads to the tool's default endpoints on the next run.
+  # Read endpoint for `lake exe cache get`, wired from a repository variable. The cache tool
+  # treats unset and empty alike, so clearing the variable returns reads to the tool's
+  # default endpoints on the next run.
   MATHLIB_CACHE_GET_URL: ${{ vars.MATHLIB_CACHE_GET_URL }}
 
 jobs:

--- a/.github/workflows/pr-profile.yml
+++ b/.github/workflows/pr-profile.yml
@@ -45,6 +45,12 @@ concurrency:
     }}
   cancel-in-progress: true
 
+env:
+  # Read endpoint for `lake exe cache get`, wired from a repository variable that an operator
+  # points at https://cache.mathlib.org. The cache tool treats unset and empty alike, so
+  # clearing the variable returns reads to the tool's default endpoints on the next run.
+  MATHLIB_CACHE_GET_URL: ${{ vars.MATHLIB_CACHE_GET_URL }}
+
 jobs:
   # Deliberately not named `perf`: the authoritative required context is the
   # commit status posted at the end, not this workflow's automatic check-run.

--- a/README.md
+++ b/README.md
@@ -162,14 +162,9 @@ the live documentation describes.
 ## Building
 
 ```bash
-export MATHLIB_CACHE_GET_URL="${MATHLIB_CACHE_GET_URL-https://cache.mathlib.org}"
 lake exe cache get   # fetch prebuilt Mathlib oleans
 lake build
 ```
-
-Cache reads default to `cache.mathlib.org`. To use a different endpoint, define
-`MATHLIB_CACHE_GET_URL` before you run the commands. An empty value also counts as a
-choice: the cache tool treats it as unset and uses its default endpoints.
 
 ## Roadmaps
 

--- a/README.md
+++ b/README.md
@@ -162,9 +162,14 @@ the live documentation describes.
 ## Building
 
 ```bash
+export MATHLIB_CACHE_GET_URL="${MATHLIB_CACHE_GET_URL-https://cache.mathlib.org}"
 lake exe cache get   # fetch prebuilt Mathlib oleans
 lake build
 ```
+
+Cache reads default to `cache.mathlib.org`. To use a different endpoint, define
+`MATHLIB_CACHE_GET_URL` before you run the commands. An empty value also counts as a
+choice: the cache tool treats it as unset and uses its default endpoints.
 
 ## Roadmaps
 

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -40,9 +40,9 @@ Which host serves those downloads is a repository variable. Every workflow that 
 `pages.yml`) exports `MATHLIB_CACHE_GET_URL` from `vars.MATHLIB_CACHE_GET_URL`, which an
 operator points at `https://cache.mathlib.org`. The cache tool treats an empty value as
 unset, so clearing the variable returns reads to the tool's default endpoints on the next
-run, with no code change. For local and radar runs, `scripts/bench/build/run` and the
-README's build instructions default the same variable to `https://cache.mathlib.org`; a
-value defined beforehand (even an empty one) wins over the default.
+run, with no code change. For local and radar runs, `scripts/bench/build/run` defaults the
+same variable to `https://cache.mathlib.org`; a value defined beforehand (even an empty
+one) wins over the default.
 
 ## Cloudflare account
 

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -35,14 +35,15 @@ incompatible, bump `mathlib-ltar-v1` once in
 `gh cache delete <key> --repo TauCetiProject/TauCeti`. A failed fetch also retries once with
 `lake exe cache get!`, which forces every linked file to be downloaded and unpacked again.
 
-Which host serves those downloads is a repository variable. Every workflow that runs
+Which endpoint serves those downloads is a repository variable. Every workflow that runs
 `lake exe cache get` (`ci.yml`, `pr-build.yml`, `pr-profile.yml`, `nightly-verify.yml`,
-`pages.yml`) exports `MATHLIB_CACHE_GET_URL` from `vars.MATHLIB_CACHE_GET_URL`, which an
-operator points at `https://cache.mathlib.org`. The cache tool treats an empty value as
-unset, so clearing the variable returns reads to the tool's default endpoints on the next
-run, with no code change. For local and radar runs, `scripts/bench/build/run` defaults the
-same variable to `https://cache.mathlib.org`; a value defined beforehand (even an empty
-one) wins over the default.
+`pages.yml`) exports `MATHLIB_CACHE_GET_URL` from `vars.MATHLIB_CACHE_GET_URL`. The cache
+tool treats an empty value as unset, so clearing the variable returns reads to the tool's
+default endpoints on the next run, with no code change. The variable bypasses the tool's
+container lookup chain and the tool appends only `/f/<hash>`, so its value must name one
+container namespace — the current write target, not a bare host and not the read-only
+legacy container. For local and radar runs, `scripts/bench/build/run` sets a default for
+the same variable; a value defined beforehand (even an empty one) wins over the default.
 
 ## Cloudflare account
 

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -41,9 +41,9 @@ Which endpoint serves those downloads is a repository variable. Every workflow t
 tool treats an empty value as unset, so clearing the variable returns reads to the tool's
 default endpoints on the next run, with no code change. The variable bypasses the tool's
 container lookup chain and the tool appends only `/f/<hash>`, so its value must name one
-container namespace — the current write target, not a bare host and not the read-only
-legacy container. For local and radar runs, `scripts/bench/build/run` sets a default for
-the same variable; a value defined beforehand (even an empty one) wins over the default.
+artifact namespace on the serving host, not a bare host. For local and radar runs,
+`scripts/bench/build/run` sets a default for the same variable; a value defined beforehand
+(even an empty one) wins over the default.
 
 ## Cloudflare account
 

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -39,9 +39,7 @@ Which endpoint serves those downloads is a repository variable. Every workflow t
 `lake exe cache get` (`ci.yml`, `pr-build.yml`, `pr-profile.yml`, `nightly-verify.yml`,
 `pages.yml`) exports `MATHLIB_CACHE_GET_URL` from `vars.MATHLIB_CACHE_GET_URL`. The cache
 tool treats an empty value as unset, so clearing the variable returns reads to the tool's
-default endpoints on the next run, with no code change. The variable bypasses the tool's
-container lookup chain and the tool appends only `/f/<hash>`, so its value must name one
-artifact namespace on the serving host, not a bare host. For local and radar runs,
+default endpoints on the next run, with no code change. For local and radar runs,
 `scripts/bench/build/run` sets a default for the same variable; a value defined beforehand
 (even an empty one) wins over the default.
 

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -35,6 +35,15 @@ incompatible, bump `mathlib-ltar-v1` once in
 `gh cache delete <key> --repo TauCetiProject/TauCeti`. A failed fetch also retries once with
 `lake exe cache get!`, which forces every linked file to be downloaded and unpacked again.
 
+Which host serves those downloads is a repository variable. Every workflow that runs
+`lake exe cache get` (`ci.yml`, `pr-build.yml`, `pr-profile.yml`, `nightly-verify.yml`,
+`pages.yml`) exports `MATHLIB_CACHE_GET_URL` from `vars.MATHLIB_CACHE_GET_URL`, which an
+operator points at `https://cache.mathlib.org`. The cache tool treats an empty value as
+unset, so clearing the variable returns reads to the tool's default endpoints on the next
+run, with no code change. For local and radar runs, `scripts/bench/build/run` and the
+README's build instructions default the same variable to `https://cache.mathlib.org`; a
+value defined beforehand (even an empty one) wins over the default.
+
 ## Cloudflare account
 
 This table records the required destination. During the 2026 account migration,

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -3,10 +3,12 @@ set -euxo pipefail
 
 BENCH="scripts/bench"
 
-# Prepare build. Mathlib oleans come from cache.mathlib.org; a caller opts out by
-# defining MATHLIB_CACHE_GET_URL first. A defined-but-empty value also counts as a
-# choice: the cache tool treats it as unset and uses its default endpoints.
-export MATHLIB_CACHE_GET_URL="${MATHLIB_CACHE_GET_URL-https://cache.mathlib.org}"
+# Prepare build. A caller opts out of the default read endpoint below by defining
+# MATHLIB_CACHE_GET_URL first. A defined-but-empty value also counts as a choice:
+# the cache tool treats it as unset and uses its default endpoints. The variable
+# bypasses the container lookup chain, so its value must name one container
+# namespace (the tool appends only `/f/<hash>`), not a bare host.
+export MATHLIB_CACHE_GET_URL="${MATHLIB_CACHE_GET_URL-https://cache.mathlib.org/mathlib4-master}"
 lake exe cache get
 
 # Run build

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -3,7 +3,10 @@ set -euxo pipefail
 
 BENCH="scripts/bench"
 
-# Prepare build
+# Prepare build. Mathlib oleans come from cache.mathlib.org; a caller opts out by
+# defining MATHLIB_CACHE_GET_URL first. A defined-but-empty value also counts as a
+# choice: the cache tool treats it as unset and uses its default endpoints.
+export MATHLIB_CACHE_GET_URL="${MATHLIB_CACHE_GET_URL-https://cache.mathlib.org}"
 lake exe cache get
 
 # Run build

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -5,9 +5,7 @@ BENCH="scripts/bench"
 
 # Prepare build. A caller opts out of the default read endpoint below by defining
 # MATHLIB_CACHE_GET_URL first. A defined-but-empty value also counts as a choice:
-# the cache tool treats it as unset and uses its default endpoints. The variable
-# bypasses the container lookup chain, so its value must name one artifact
-# namespace (the tool appends only `/f/<hash>`), not a bare host.
+# the cache tool treats it as unset and uses its default endpoints.
 export MATHLIB_CACHE_GET_URL="${MATHLIB_CACHE_GET_URL-https://cache.mathlib.org/mathlib4}"
 lake exe cache get
 

--- a/scripts/bench/build/run
+++ b/scripts/bench/build/run
@@ -6,9 +6,9 @@ BENCH="scripts/bench"
 # Prepare build. A caller opts out of the default read endpoint below by defining
 # MATHLIB_CACHE_GET_URL first. A defined-but-empty value also counts as a choice:
 # the cache tool treats it as unset and uses its default endpoints. The variable
-# bypasses the container lookup chain, so its value must name one container
+# bypasses the container lookup chain, so its value must name one artifact
 # namespace (the tool appends only `/f/<hash>`), not a bare host.
-export MATHLIB_CACHE_GET_URL="${MATHLIB_CACHE_GET_URL-https://cache.mathlib.org/mathlib4-master}"
+export MATHLIB_CACHE_GET_URL="${MATHLIB_CACHE_GET_URL-https://cache.mathlib.org/mathlib4}"
 lake exe cache get
 
 # Run build


### PR DESCRIPTION
This PR passes the repository variable `MATHLIB_CACHE_GET_URL` to every workflow that reads the Mathlib cache: `ci.yml`, `pr-build.yml`, `pr-profile.yml`, `nightly-verify.yml`, and `pages.yml`. Each workflow exports the variable at the workflow level. An operator sets the variable to move the cache read traffic to a new endpoint, and clears it to move the traffic back. Both changes apply on the next run, with no deploy and no code change.

The cache tool in the pinned Mathlib reads `MATHLIB_CACHE_GET_URL` as the first choice for reads, and treats an empty value as unset. An empty value is what `${{ vars.MATHLIB_CACHE_GET_URL }}` produces while the variable is not defined. The wiring is therefore inert until the operator sets the variable. The canonical read endpoint is `https://cache.mathlib.org/mathlib4`.

The benchmark script gets the same endpoint. The script `scripts/bench/build/run` sets a default value for the variable before `lake exe cache get`. A value that the caller defines before the run wins. An empty value also wins: the cache tool then uses its default endpoints. The document `docs/cache-infrastructure.md` describes the new switch. The build instructions in `README.md` stay unchanged: the default lives only in the automations.

Out of scope: `scripts/lake-cache-get.sh` uses the Lake cache service for TauCeti's own oleans, not the Mathlib cache tool, so it does not change.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)