### PR TITLE
feat: base change the doubled E6 minuscule carrier

### DIFF
--- a/TauCeti/Algebra/Lie/E6/DoubledMinuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E6/DoubledMinuscule/BaseChange.lean
@@ -1,0 +1,368 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E6.DoubledMinuscule.GroupScheme
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.GeneralLinearBaseChange
+
+/-!
+# Base change of the full-weight doubled type-E6 minuscule carrier
+
+`TauCeti.E6DoubledMinuscule.groupScheme` is the explicit integral affine group scheme obtained by
+closing the twelve numbered type-`E₆` root subgroups and the fifty-four-weight torus of
+`V(ϖ₁) ⊕ V(ϖ₆)` inside `GL₅₄`. This file specializes the base-change construction for a general
+Kostant toral closure to that pinned carrier.
+
+For every commutative ring `A`, `TauCeti.E6DoubledMinuscule.baseChangeDefiningIdeal` is an ideal in
+`O(GL₅₄/A)` whose quotient is canonically the scalar extension of the integral coordinate Hopf
+algebra. The transported numbered root-subgroup maps and weight-torus map factor through that
+quotient. Thus the integral carrier and its pinned generators base-change together; none of the
+data is chosen anew over `A`.
+
+The defining ideal transported from `ℤ` is contained in the common kernel of the transported
+generators. Equality is not asserted over an arbitrary, possibly non-flat, base: additional
+equations can appear after specialization. Nor does this file assert that the carrier is reductive,
+that its torus is maximal, that its root datum has been identified, or that the `E₆` diagram
+symmetry the doubled index set was assembled to carry acts on it.
+
+## Main declarations
+
+* `TauCeti.E6DoubledMinuscule.baseChangeDefiningIdeal`: the transported defining ideal in
+  `O(GL₅₄/A)`.
+* `TauCeti.E6DoubledMinuscule.baseChangeCoordinateIso`: its quotient is the scalar extension of the
+  integral carrier coordinate Hopf algebra.
+* `TauCeti.E6DoubledMinuscule.rootSubgroupToBaseChangeCoordinateMap`: the transported numbered root
+  subgroup factored through the specialized carrier.
+* `TauCeti.E6DoubledMinuscule.weightTorusToBaseChangeCoordinateMap`: the transported weight torus
+  factored through the specialized carrier.
+
+## Main results
+
+* `TauCeti.E6DoubledMinuscule.mkQuotient_comp_baseChangeCoordinateIso_hom`: the coordinate
+  isomorphism is compatible with the quotient presentations.
+* `TauCeti.E6DoubledMinuscule.baseChangeCoordinateIso_hom_comp_rootSubgroupBaseChangeMap` and
+  `TauCeti.E6DoubledMinuscule.baseChangeCoordinateIso_hom_comp_weightTorusBaseChangeMap`: the
+  pinned generators are the scalar extensions of their integral coordinate maps.
+* `TauCeti.E6DoubledMinuscule.hopfSpec_map_rootSubgroupIntegralCoordinateMap_op` and
+  `TauCeti.E6DoubledMinuscule.hopfSpec_map_weightTorusIntegralCoordinateMap_op`: the integral
+  coordinate maps represent the existing pinned morphisms.
+* `TauCeti.E6DoubledMinuscule.baseChangeDefiningIdeal_le_commonKernel`: the transported carrier
+  contains the subgroup generated after base change by the transported maps.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 12.2.
+* J. E. Humphreys, *Linear Algebraic Groups*, §§26--27.
+* B. Conrad, *Reductive Group Schemes*, §1.
+
+This advances the base-change target in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`. The
+resulting specialized pinned carrier is an input to milestone L0, "pinned ambient groups", of
+`TauCetiRoadmap/CFSGStatement/README.md`, on the branch `²E₆(q)` that the doubled carrier serves.
+
+The declaration structure specializes the formal template in
+`TauCeti.Algebra.Lie.E6.Minuscule.BaseChange`, itself following
+`TauCeti.Algebra.Lie.Symplectic.StandardCarrier.BaseChange`. Every construction below uses the
+generic Kostant base-change API from
+`Kostant/RootSubgroup/Scheme/ToralClosure/GeneralLinearBaseChange.lean`; in particular, none of the
+coordinate-ring calculation is repeated here.
+-/
+
+public section
+
+open CategoryTheory
+open TauCeti.DynkinType
+open TauCeti.UniversalEnvelopingAlgebra
+open scoped Matrix TensorProduct
+
+namespace TauCeti.E6DoubledMinuscule
+
+universe v
+
+noncomputable section
+
+attribute [local instance] TauCeti.moduleNNRat
+attribute [local instance 100] LieRing.ofAssociativeRing
+attribute [local instance high] Algebra.toModule
+
+variable (A : Type v) [CommRing A]
+
+/-- The Hopf ideal in `O(GL₅₄/A)` obtained by transporting the defining ideal of the integral
+full-weight doubled type-`E₆` minuscule carrier along `ℤ → A`. -/
+noncomputable def baseChangeDefiningIdeal :
+    HopfIdeal A (GeneralLinear.coordinateHopfAlgebra A 54) :=
+  kostantToralBaseChangePresentationIdeal
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A
+
+/-- Membership in the transported defining ideal is membership of the corresponding element in the
+base change of the named integral defining ideal. -/
+@[simp]
+theorem mem_baseChangeDefiningIdeal_iff
+    {x : GeneralLinear.coordinateHopfAlgebra A 54} :
+    x ∈ baseChangeDefiningIdeal A ↔
+      (GeneralLinear.coordinateHopfAlgebraBaseChangeIso ℤ A 54).inv.hom x ∈
+        CommHopfAlgCat.baseChangeHopfIdeal (K := A) definingIdeal := by
+  rw [baseChangeDefiningIdeal, mem_kostantToralBaseChangePresentationIdeal_iff,
+    kostantToralBaseChangeIdeal_def, ← definingIdeal_def]
+
+/-- Transporting a pure tensor of a scalar and an integral defining equation produces an equation
+in the transported defining ideal. -/
+theorem map_tmul_mem_baseChangeDefiningIdeal_of_mem (s : A)
+    {y : GeneralLinear.coordinateHopfAlgebra ℤ 54} (hy : y ∈ definingIdeal) :
+    (GeneralLinear.coordinateHopfAlgebraBaseChangeIso ℤ A 54).hom.hom
+        (s ⊗ₜ[ℤ] y) ∈ baseChangeDefiningIdeal A := by
+  rw [baseChangeDefiningIdeal]
+  exact map_tmul_mem_kostantToralBaseChangePresentationIdeal_of_mem
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A s (definingIdeal_def ▸ hy)
+
+/-- The coordinate Hopf algebra cut out over `A` by the transported doubled type-`E₆` defining
+ideal is canonically the scalar extension of the integral coordinate Hopf algebra. -/
+noncomputable def baseChangeCoordinateIso :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra A 54)
+        (baseChangeDefiningIdeal A) ≅
+      CommHopfAlgCat.baseChange (K := A)
+        (CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ 54) definingIdeal) :=
+  kostantToralBaseChangePresentationIsoOfEq
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A definingIdeal_def
+
+/-- The base-change coordinate isomorphism is compatible with the quotient presentation inside
+`GL₅₄`. -/
+@[simp]
+theorem mkQuotient_comp_baseChangeCoordinateIso_hom :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra A 54)
+          (baseChangeDefiningIdeal A) ≫
+        (baseChangeCoordinateIso A).hom =
+      (GeneralLinear.coordinateHopfAlgebraBaseChangeIso ℤ A 54).inv ≫
+        CommHopfAlgCat.baseChangeMap
+          (CommHopfAlgCat.mkQuotient
+            (GeneralLinear.coordinateHopfAlgebra ℤ 54) definingIdeal) := by
+  rw [baseChangeCoordinateIso]
+  exact mkQuotient_comp_kostantToralBaseChangePresentationIsoOfEq_hom
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A definingIdeal_def
+
+/-! ## The transported root subgroups -/
+
+/-- The integral `k`th root-subgroup coordinate map, with source expressed using the named doubled
+type-`E₆` defining ideal. -/
+noncomputable def rootSubgroupIntegralCoordinateMap (k : Fin 6 ⊕ Fin 6) :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ 54) definingIdeal ⟶
+      AdditiveGroup.coordinateHopfAlgebra ℤ :=
+  kostantRootSubgroupToralCoordinateMapOfEq
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight definingIdeal_def k
+
+/-- The integral factored root-subgroup map recovers the represented `k`th root-subgroup coordinate
+map inside `GL₅₄`. -/
+@[simp]
+theorem mkQuotient_comp_rootSubgroupIntegralCoordinateMap (k : Fin 6 ⊕ Fin 6) :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ 54) definingIdeal ≫
+        rootSubgroupIntegralCoordinateMap k =
+      kostantRootSubgroupCoordinateMap
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        rep_kostantForm_mem_lattice k (isNilpotent_rep_serreRootGenerator k) matrixBasis := by
+  rw [rootSubgroupIntegralCoordinateMap]
+  exact mkQuotient_comp_kostantRootSubgroupToralCoordinateMapOfEq
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight definingIdeal_def k
+
+/-- The integral factored root-subgroup coordinate map represents the carrier's `k`th numbered root
+subgroup. -/
+theorem hopfSpec_map_rootSubgroupIntegralCoordinateMap_op (k : Fin 6 ⊕ Fin 6) :
+    (AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).map
+        (rootSubgroupIntegralCoordinateMap k).op =
+      eqToHom (AdditiveGroup.groupScheme_def ℤ).symm ≫
+        rootSubgroup k ≫ eqToHom groupScheme_def := by
+  rw [rootSubgroupIntegralCoordinateMap, rootSubgroup_def]
+  exact hopfSpec_map_kostantRootSubgroupToralCoordinateMapOfEq_op
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight definingIdeal_def k
+
+/-- The base-changed `k`th root-subgroup coordinate map factored through the transported doubled
+type-`E₆` carrier. -/
+noncomputable def rootSubgroupToBaseChangeCoordinateMap (k : Fin 6 ⊕ Fin 6) :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra A 54)
+        (baseChangeDefiningIdeal A) ⟶ AdditiveGroup.coordinateHopfAlgebra A :=
+  kostantRootSubgroupToralBaseChangePresentationCoordinateMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A k
+
+/-- The factored root-subgroup map recovers its ambient transported coordinate map. -/
+@[simp]
+theorem mkQuotient_comp_rootSubgroupToBaseChangeCoordinateMap (k : Fin 6 ⊕ Fin 6) :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra A 54)
+          (baseChangeDefiningIdeal A) ≫
+        rootSubgroupToBaseChangeCoordinateMap A k =
+      kostantRootSubgroupBaseChangePresentationCoordinateMap
+        (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+        (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+        rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis A k := by
+  unfold baseChangeDefiningIdeal rootSubgroupToBaseChangeCoordinateMap
+  exact mkQuotient_comp_kostantRootSubgroupToralBaseChangePresentationCoordinateMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A k
+
+/-- Under the base-change coordinate isomorphism, the factored `k`th root-subgroup map is the
+scalar extension of its integral coordinate map. -/
+@[simp]
+theorem baseChangeCoordinateIso_hom_comp_rootSubgroupBaseChangeMap (k : Fin 6 ⊕ Fin 6) :
+    (baseChangeCoordinateIso A).hom ≫
+          CommHopfAlgCat.baseChangeMap (rootSubgroupIntegralCoordinateMap k) ≫
+        (_root_.CommHopfAlgCat.ofHom
+          (AdditiveGroup.gaScalarTensorBialgEquiv (k := ℤ) (K := A))) =
+      rootSubgroupToBaseChangeCoordinateMap A k := by
+  rw [baseChangeCoordinateIso, rootSubgroupIntegralCoordinateMap,
+    rootSubgroupToBaseChangeCoordinateMap]
+  exact kostantToralBaseChangePresentationIsoOfEq_hom_comp_rootSubgroupBaseChangeMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A definingIdeal_def k
+
+/-! ## The transported weight torus -/
+
+/-- The integral weight-torus coordinate map, with source expressed using the named doubled
+type-`E₆` defining ideal. -/
+noncomputable def weightTorusIntegralCoordinateMap :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ 54) definingIdeal ⟶
+      (DiagonalizableGroup.coordinateRing ℤ
+        (SplitTorus.characterGroup (Fin 6))).obj :=
+  kostantWeightTorusToralCoordinateMapOfEq
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight definingIdeal_def
+
+/-- The integral factored weight-torus map recovers the represented weight-torus coordinate map
+inside `GL₅₄`. -/
+@[simp]
+theorem mkQuotient_comp_weightTorusIntegralCoordinateMap :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ 54) definingIdeal ≫
+        weightTorusIntegralCoordinateMap =
+      GeneralLinear.weightTorusCoordinateMap matrixWeight := by
+  rw [weightTorusIntegralCoordinateMap]
+  exact mkQuotient_comp_kostantWeightTorusToralCoordinateMapOfEq
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight definingIdeal_def
+
+/-- The integral factored weight-torus coordinate map represents the carrier's weight torus. -/
+theorem hopfSpec_map_weightTorusIntegralCoordinateMap_op :
+    (AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).map
+        weightTorusIntegralCoordinateMap.op =
+      eqToHom (DiagonalizableGroup.groupScheme_def ℤ
+          (SplitTorus.characterGroup (Fin 6))).symm ≫
+        weightTorus ≫ eqToHom groupScheme_def := by
+  rw [weightTorusIntegralCoordinateMap, weightTorus_def]
+  exact hopfSpec_map_kostantWeightTorusToralCoordinateMapOfEq_op
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight definingIdeal_def
+
+/-- The base-changed weight-torus coordinate map factored through the transported doubled type-`E₆`
+carrier. -/
+noncomputable def weightTorusToBaseChangeCoordinateMap :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra A 54)
+        (baseChangeDefiningIdeal A) ⟶
+      (DiagonalizableGroup.coordinateRing A
+        (SplitTorus.characterGroup (Fin 6))).obj :=
+  kostantWeightTorusToralBaseChangePresentationCoordinateMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A
+
+/-- The factored weight-torus map recovers its ambient transported coordinate map. -/
+@[simp]
+theorem mkQuotient_comp_weightTorusToBaseChangeCoordinateMap :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra A 54)
+          (baseChangeDefiningIdeal A) ≫
+        weightTorusToBaseChangeCoordinateMap A =
+      GeneralLinear.weightTorusBaseChangeCoordinateMap ℤ A matrixWeight := by
+  unfold baseChangeDefiningIdeal weightTorusToBaseChangeCoordinateMap
+  exact mkQuotient_comp_kostantWeightTorusToralBaseChangePresentationCoordinateMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A
+
+/-- Under the base-change coordinate isomorphism, the factored weight-torus map is the scalar
+extension of its integral coordinate map. -/
+@[simp]
+theorem baseChangeCoordinateIso_hom_comp_weightTorusBaseChangeMap :
+    (baseChangeCoordinateIso A).hom ≫
+          CommHopfAlgCat.baseChangeMap weightTorusIntegralCoordinateMap ≫
+        (_root_.CommHopfAlgCat.ofHom
+          (BialgHomClass.toBialgHom
+            (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv ℤ A
+              (G := SplitTorus.characterGroup (Fin 6))))) =
+      weightTorusToBaseChangeCoordinateMap A := by
+  rw [baseChangeCoordinateIso, weightTorusIntegralCoordinateMap,
+    weightTorusToBaseChangeCoordinateMap]
+  exact kostantToralBaseChangePresentationIsoOfEq_hom_comp_weightTorusBaseChangeMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A definingIdeal_def
+
+/-- The closed subgroup of `GL₅₄/A` generated by the transported numbered root subgroups and weight
+torus lies in the base change of the integral doubled type-`E₆` carrier.
+
+The reverse inclusion is not asserted over an arbitrary base ring. -/
+theorem baseChangeDefiningIdeal_le_commonKernel :
+    let K : Sum (Fin 6 ⊕ Fin 6) Unit → CommHopfAlgCat A
+      | .inl _ => AdditiveGroup.coordinateHopfAlgebra A
+      | .inr _ =>
+          (DiagonalizableGroup.coordinateRing A
+            (SplitTorus.characterGroup (Fin 6))).obj
+    baseChangeDefiningIdeal A ≤
+      CommHopfAlgCat.commonKernelHopfIdeal (K := K)
+        (fun j => match j with
+          | .inl k => kostantRootSubgroupBaseChangePresentationCoordinateMap
+              (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+              (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+              rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis A k
+          | .inr _ =>
+              GeneralLinear.weightTorusBaseChangeCoordinateMap ℤ A matrixWeight) := by
+  have h := kostantToralBaseChangePresentationIdeal_le_commonKernelHopfIdeal
+    (TauCeti.serreRootGenerator (CartanMatrix.E 6)ᵀ)
+    (TauCeti.serreH ℚ (CartanMatrix.E 6)ᵀ) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator matrixBasis
+    matrixWeight A
+  -- The generic containment indexes its generators by a `match` of its own, and neither that
+  -- matcher nor `commonKernelHopfIdeal` is exposed, so compare the two families branchwise.
+  dsimp only at h ⊢
+  rw [CommHopfAlgCat.le_commonKernelHopfIdeal_iff] at h ⊢
+  rintro (k | _)
+  · exact h (.inl k)
+  · exact h (.inr ())
+
+end
+
+end TauCeti.E6DoubledMinuscule


### PR DESCRIPTION
This PR specializes the generic Kostant toral-closure base-change construction to the full-weight
doubled type-`E₆` minuscule carrier, so that the explicit integral group scheme
`TauCeti.E6DoubledMinuscule.groupScheme` and its pinned generators move to an arbitrary commutative
ring together. For every `A`, `baseChangeDefiningIdeal` is the transport along `ℤ → A` of the
carrier's defining Hopf ideal inside `O(GL₅₄/A)`, characterized by `mem_baseChangeDefiningIdeal_iff`
and fed by `map_tmul_mem_baseChangeDefiningIdeal_of_mem`; `baseChangeCoordinateIso` identifies its
quotient with the scalar extension of the integral coordinate Hopf algebra, compatibly with the two
quotient presentations by `mkQuotient_comp_baseChangeCoordinateIso_hom`. The twelve numbered
root-subgroup maps and the rank-six weight torus are then factored through both presentations:
`rootSubgroupIntegralCoordinateMap` and `weightTorusIntegralCoordinateMap` over `ℤ`, shown by
`hopfSpec_map_rootSubgroupIntegralCoordinateMap_op` and
`hopfSpec_map_weightTorusIntegralCoordinateMap_op` to represent the carrier's existing pinned
morphisms `rootSubgroup` and `weightTorus`, and `rootSubgroupToBaseChangeCoordinateMap` and
`weightTorusToBaseChangeCoordinateMap` over `A`, shown by
`baseChangeCoordinateIso_hom_comp_rootSubgroupBaseChangeMap` and
`baseChangeCoordinateIso_hom_comp_weightTorusBaseChangeMap` to be the scalar extensions of the
integral ones. Finally `baseChangeDefiningIdeal_le_commonKernel` places the subgroup generated over
`A` by the transported generators inside the transported carrier. The reverse containment is not
asserted, the base being possibly non-flat, and no reductivity, torus maximality, root-datum
identification, or action of the `E₆` diagram symmetry is claimed.

The exact target is "Base change along `ℤ → k` for any commutative ring `k`, and the compatibility
of the pinning with it", in Layer 9, "pinned Chevalley--Demazure group schemes over `ℤ`", of
`TauCetiRoadmap/ReductiveGroups/README.md`.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

The dependency edge is milestone L0, "pinned ambient groups", of `CFSGStatement/README.md`, which
asks each Lie-type branch for the points of the *pinned* simply connected Chevalley--Demazure group
scheme with its root subgroups, and lists "base change to the prime field and its algebraic closure"
among the Layer 9 declarations it consumes. The branch this carrier serves is `²E₆(q)`: the `E₆`
diagram symmetry exchanges `V(ϖ₁)` with `V(ϖ₆)` rather than preserving either, by the merged
`DynkinType.e6MinusculeWeight_comp_graphPermE6_notMem_range`, so the `27`-dimensional carrier that
`CFSG/TypeE6.lean` runs the recipe on for the untwisted `E₆(q)` cannot carry it and the doubled one
was assembled to. The declaration that consumes this file is the Layer 9 identification of
`E6DoubledMinuscule.groupScheme` with that pinned group scheme, which is stated over a field and so
needs the carrier presented over one; the merged type-`A` chain
`SlStd.baseChangeDefiningIdeal` → `SlStd.baseChangeDefiningIdeal_eq_specialLinearDefiningHopfIdeal`
→ `SlStd.reductiveCommHopfAlgProperty_finiteTypeSpecialization` is that same step carried out on the
type-`A` carrier, and it starts from the base-change file this one supplies for the doubled carrier.

This is the most effective current step in this lane because it is the one module the doubled
carrier still lacks relative to the `27`-dimensional one, whose own
`Algebra/Lie/E6/Minuscule/{Basic, AdmissibleLattice, GroupScheme, ClosedRootSubgroup, PointsFunctor,
BaseChange, Frobenius}` set is the template the doubled carrier has been following through
[#5373](https://github.com/TauCetiProject/TauCeti/pull/5373),
[#5404](https://github.com/TauCetiProject/TauCeti/pull/5404) and
[#5414](https://github.com/TauCetiProject/TauCeti/pull/5414); its Frobenius is in flight as
[#5412](https://github.com/TauCetiProject/TauCeti/pull/5412) and its `²E₆(q)` ambient group as
[#5421](https://github.com/TauCetiProject/TauCeti/pull/5421), and neither of those touches base
change. What remains before the `²E₆(q)` branch of L0 and L3 closes is the group-level graph
automorphism `γ₂` on this carrier, the Layer 9 identification just described, and then L1's
Steinberg map `γ₂ ∘ Frob_q` with L3's `[H_d, H_d] / Z([H_d, H_d])`.

The file adds `TauCeti/Algebra/Lie/E6/DoubledMinuscule/BaseChange.lean` (368 lines) beside the
carrier's existing modules; no existing file changes and no module moves. Nothing is duplicated:
every declaration instantiates the generic API of
`Kostant/RootSubgroup/Scheme/ToralClosure/GeneralLinearBaseChange.lean` at this carrier's
representation, admissible lattice, fifty-four-coordinate basis `matrixBasis` and weight family
`matrixWeight`, and none of the coordinate-ring calculation is repeated. The declaration names and
shapes follow the two merged sibling specializations
`Algebra/Lie/E6/Minuscule/BaseChange.lean` and
`Algebra/Lie/Symplectic/StandardCarrier/BaseChange.lean`, credited in the module documentation; the
per-carrier instantiation is what those files consist of, and factoring them further would need a
bundled carrier-data structure that no carrier on `main` uses. No Mathlib PR material or other
external formalization is vendored. The mathematical conventions follow R. W. Carter, *Simple Groups
of Lie Type*, §§4.4 and 12.2, for the doubled minuscule realization, J. E. Humphreys, *Linear
Algebraic Groups*, §§26--27, and B. Conrad, *Reductive Group Schemes*, §1.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e6-doubled-minuscule-base-change"}-->

🤖 Prepared with Claude Code
