### PR TITLE
feat: orthogonal quotients of finite bilinear modules

### DIFF
--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
@@ -40,6 +40,8 @@ restriction to a subgroup can be degenerate.
 
 ## Main results
 
+* `TauCeti.FiniteBilinearModule.radical_restrict`: the radical of a restricted pairing is
+  the part of the orthogonal complement lying in the subgroup.
 * `TauCeti.FiniteBilinearModule.Isometry.map_orthogonalComplement`: an isometry carries
   orthogonal complements to orthogonal complements.
 * `TauCeti.FiniteBilinearModule.Isometry.orthogonalComplementEquiv`: the induced equivalence
@@ -676,6 +678,16 @@ theorem mem_orthogonalComplement_iff (H : AddSubgroup A) (x : A) :
   rw [orthogonalComplement, Submodule.mem_toAddSubgroup, Submodule.mem_orthogonalBilin]
   simp_rw [toBilin_apply, A.pairing_comm]
   exact ⟨fun h y hy ↦ h y hy, fun h y hy ↦ h y hy⟩
+
+/-- **The radical of a restricted pairing.** Restricting the pairing of `A` to a subgroup `S`
+makes degenerate exactly the vectors of `S` which are orthogonal to all of `S`. -/
+@[simp]
+theorem radical_restrict (S : AddSubgroup A) :
+    (A.restrict S).radical = (A.orthogonalComplement S).addSubgroupOf S := by
+  ext x
+  rw [mem_radical_iff, AddSubgroup.mem_addSubgroupOf, A.mem_orthogonalComplement_iff]
+  exact ⟨fun hx y hy ↦ by simpa only [A.restrict_pairing S] using hx ⟨y, hy⟩,
+    fun hx y ↦ by simpa only [A.restrict_pairing S] using hx y.1 y.2⟩
 
 /-- Orthogonal complements reverse inclusions. -/
 theorem orthogonalComplement_anti {H K : AddSubgroup A} (h : H ≤ K) :

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
@@ -18,11 +18,12 @@ only obstruction to recovering `H` from its orthogonal complement:
 H⊥⊥ = H + rad(A).
 ```
 
-The proof first quotients the pairing by its radical.  The induced finite bilinear module is
-nondegenerate, so restriction of characters shows that `|H| |H⊥| = |A|`.  Applying this
-identity in the radical quotient gives the general double-complement formula.  In particular,
-for a nondegenerate module, double orthogonal complementation is the identity and a Lagrangian
-subgroup has order whose square is the order of the ambient group.
+The cardinality identity `|H| |H⊥| = |A|`, which restriction of characters proves, is not
+available for a degenerate `A`; it holds only when `A` is nondegenerate.  The proof therefore
+first quotients the pairing by its radical, applies the identity in that quotient — which is
+nondegenerate — and reads the outcome back in `A`, where it gives the general double-complement
+formula.  In particular, for a nondegenerate module, double orthogonal complementation is the
+identity and a Lagrangian subgroup has order whose square is the order of the ambient group.
 
 The file closes with the degeneracy of a restricted pairing.  Restricting the pairing to a
 subgroup `S` makes exactly the vectors of `S ∩ S⊥` degenerate:

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
@@ -18,12 +18,10 @@ only obstruction to recovering `H` from its orthogonal complement:
 H⊥⊥ = H + rad(A).
 ```
 
-The cardinality identity `|H| |H⊥| = |A|`, which restriction of characters proves, is not
-available for a degenerate `A`; it holds only when `A` is nondegenerate.  The proof therefore
-first quotients the pairing by its radical, applies the identity in that quotient — which is
-nondegenerate — and reads the outcome back in `A`, where it gives the general double-complement
-formula.  In particular, for a nondegenerate module, double orthogonal complementation is the
-identity and a Lagrangian subgroup has order whose square is the order of the ambient group.
+For a nondegenerate `A` the file also has the cardinality identity `|H| |H⊥| = |A|`, which is
+unavailable without nondegeneracy, together with its two consequences: double orthogonal
+complementation is the identity, and a Lagrangian subgroup has order whose square is the order of
+the ambient group.
 
 The file closes with the degeneracy of a restricted pairing.  Restricting the pairing to a
 subgroup `S` makes exactly the vectors of `S ∩ S⊥` degenerate:

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
@@ -33,7 +33,8 @@ rad(A|_S) = S⊥ ∩ S.
 
 Read at `S = H⊥` and combined with the double-complement formula, this says that the pairing
 restricted to `H⊥` has radical `(H + rad(A)) ∩ H⊥`, so in particular it kills the copy of `H`
-sitting inside `H⊥`.  That inclusion is what makes the orthogonal quotient `H⊥ / H` of
+sitting inside `H⊥` when `H` is isotropic.  In general it kills `H ∩ H⊥`, which makes the
+orthogonal quotient `H⊥ / (H ∩ H⊥)` of
 `TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Quotient` well defined.
 
 ## Main declarations
@@ -43,9 +44,8 @@ sitting inside `H⊥`.  That inclusion is what makes the orthogonal quotient `H�
 * `TauCeti.FiniteBilinearModule.IsNondegenerate.card_mul_card_orthogonalComplement`: the
   cardinality identity `|H| |H⊥| = |A|` for a nondegenerate module.
 * `TauCeti.FiniteBilinearModule.IsLagrangian.card_sq`: a Lagrangian has squared order `|A|`.
-* `TauCeti.FiniteBilinearModule.radical_restrict`: the radical of a restricted pairing.
 * `TauCeti.FiniteBilinearModule.addSubgroupOf_orthogonalComplement_le_radical_restrict`: the
-  copy of `H` inside `H⊥` is degenerate for the restricted pairing.
+  part of `H` lying in `H⊥` is degenerate for the restricted pairing.
 
 ## References
 
@@ -192,27 +192,20 @@ theorem IsLagrangian.card_sq (hH : A.IsLagrangian H) (hA : A.IsNondegenerate) :
     _ = Nat.card H * Nat.card (A.orthogonalComplement H) := congrArg _ hcard
     _ = Nat.card A := IsNondegenerate.card_mul_card_orthogonalComplement A hA H
 
-/-! ## The radical of a restricted pairing -/
-
-/-- **The radical of a restricted pairing.**  Restricting the pairing of `A` to a subgroup `S`
-makes degenerate exactly the vectors of `S` which are orthogonal to all of `S`. -/
-theorem radical_restrict (S : AddSubgroup A) :
-    (A.restrict S).radical = (A.orthogonalComplement S).addSubgroupOf S := by
-  ext x
-  rw [mem_radical_iff, AddSubgroup.mem_addSubgroupOf, A.mem_orthogonalComplement_iff]
-  exact ⟨fun hx y hy ↦ hx ⟨y, hy⟩, fun hx y ↦ hx y.1 y.2⟩
+/-! ## The radical of a pairing restricted to an orthogonal complement -/
 
 /-- The radical of the pairing restricted to `H⊥` is the part of `H + rad(A)` lying in `H⊥`.
 
 This is `radical_restrict` at `S = H⊥`, simplified by the double-complement formula. -/
+@[simp]
 theorem radical_restrict_orthogonalComplement (H : AddSubgroup A) :
     (A.restrict (A.orthogonalComplement H)).radical =
       (H ⊔ A.radical).addSubgroupOf (A.orthogonalComplement H) := by
   rw [A.radical_restrict, A.orthogonalComplement_orthogonalComplement]
 
-/-- The copy of `H` inside `H⊥` is degenerate for the pairing restricted to `H⊥`.
+/-- The part of `H` lying in `H⊥` is degenerate for the pairing restricted to `H⊥`.
 
-This is the inclusion which lets the restricted pairing descend to the quotient `H⊥ / H`. -/
+This is the inclusion which lets the restricted pairing descend to `H⊥ / (H ∩ H⊥)`. -/
 theorem addSubgroupOf_orthogonalComplement_le_radical_restrict (H : AddSubgroup A) :
     H.addSubgroupOf (A.orthogonalComplement H) ≤
       (A.restrict (A.orthogonalComplement H)).radical := by

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
@@ -197,7 +197,6 @@ theorem IsLagrangian.card_sq (hH : A.IsLagrangian H) (hA : A.IsNondegenerate) :
 /-- The radical of the pairing restricted to `H⊥` is the part of `H + rad(A)` lying in `H⊥`.
 
 This is `radical_restrict` at `S = H⊥`, simplified by the double-complement formula. -/
-@[simp]
 theorem radical_restrict_orthogonalComplement (H : AddSubgroup A) :
     (A.restrict (A.orthogonalComplement H)).radical =
       (H ⊔ A.radical).addSubgroupOf (A.orthogonalComplement H) := by

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
@@ -196,7 +196,7 @@ theorem IsLagrangian.card_sq (hH : A.IsLagrangian H) (hA : A.IsNondegenerate) :
 
 /-- The radical of the pairing restricted to `H⊥` is the part of `H + rad(A)` lying in `H⊥`.
 
-This is `radical_restrict` at `S = H⊥`, simplified by the double-complement formula. -/
+It identifies the residual degeneracy that is removed when forming the orthogonal quotient. -/
 theorem radical_restrict_orthogonalComplement (H : AddSubgroup A) :
     (A.restrict (A.orthogonalComplement H)).radical =
       (H ⊔ A.radical).addSubgroupOf (A.orthogonalComplement H) := by

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
@@ -43,7 +43,8 @@ orthogonal quotient `H⊥ / (H ∩ H⊥)` of
   `H⊥⊥ = H ⊔ rad(A)`.
 * `TauCeti.FiniteBilinearModule.IsNondegenerate.card_mul_card_orthogonalComplement`: the
   cardinality identity `|H| |H⊥| = |A|` for a nondegenerate module.
-* `TauCeti.FiniteBilinearModule.IsLagrangian.card_sq`: a Lagrangian has squared order `|A|`.
+* `TauCeti.FiniteBilinearModule.IsLagrangian.card_sq`: a Lagrangian subgroup of a nondegenerate
+  module has squared order `|A|`.
 * `TauCeti.FiniteBilinearModule.addSubgroupOf_orthogonalComplement_le_radical_restrict`: the
   part of `H` lying in `H⊥` is degenerate for the restricted pairing.
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Complement.lean
@@ -24,6 +24,18 @@ identity in the radical quotient gives the general double-complement formula.  I
 for a nondegenerate module, double orthogonal complementation is the identity and a Lagrangian
 subgroup has order whose square is the order of the ambient group.
 
+The file closes with the degeneracy of a restricted pairing.  Restricting the pairing to a
+subgroup `S` makes exactly the vectors of `S ∩ S⊥` degenerate:
+
+```text
+rad(A|_S) = S⊥ ∩ S.
+```
+
+Read at `S = H⊥` and combined with the double-complement formula, this says that the pairing
+restricted to `H⊥` has radical `(H + rad(A)) ∩ H⊥`, so in particular it kills the copy of `H`
+sitting inside `H⊥`.  That inclusion is what makes the orthogonal quotient `H⊥ / H` of
+`TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Quotient` well defined.
+
 ## Main declarations
 
 * `TauCeti.FiniteBilinearModule.orthogonalComplement_orthogonalComplement`: the formula
@@ -31,6 +43,9 @@ subgroup has order whose square is the order of the ambient group.
 * `TauCeti.FiniteBilinearModule.IsNondegenerate.card_mul_card_orthogonalComplement`: the
   cardinality identity `|H| |H⊥| = |A|` for a nondegenerate module.
 * `TauCeti.FiniteBilinearModule.IsLagrangian.card_sq`: a Lagrangian has squared order `|A|`.
+* `TauCeti.FiniteBilinearModule.radical_restrict`: the radical of a restricted pairing.
+* `TauCeti.FiniteBilinearModule.addSubgroupOf_orthogonalComplement_le_radical_restrict`: the
+  copy of `H` inside `H⊥` is degenerate for the restricted pairing.
 
 ## References
 
@@ -176,5 +191,33 @@ theorem IsLagrangian.card_sq (hH : A.IsLagrangian H) (hA : A.IsNondegenerate) :
     Nat.card H ^ 2 = Nat.card H * Nat.card H := pow_two _
     _ = Nat.card H * Nat.card (A.orthogonalComplement H) := congrArg _ hcard
     _ = Nat.card A := IsNondegenerate.card_mul_card_orthogonalComplement A hA H
+
+/-! ## The radical of a restricted pairing -/
+
+/-- **The radical of a restricted pairing.**  Restricting the pairing of `A` to a subgroup `S`
+makes degenerate exactly the vectors of `S` which are orthogonal to all of `S`. -/
+theorem radical_restrict (S : AddSubgroup A) :
+    (A.restrict S).radical = (A.orthogonalComplement S).addSubgroupOf S := by
+  ext x
+  rw [mem_radical_iff, AddSubgroup.mem_addSubgroupOf, A.mem_orthogonalComplement_iff]
+  exact ⟨fun hx y hy ↦ hx ⟨y, hy⟩, fun hx y ↦ hx y.1 y.2⟩
+
+/-- The radical of the pairing restricted to `H⊥` is the part of `H + rad(A)` lying in `H⊥`.
+
+This is `radical_restrict` at `S = H⊥`, simplified by the double-complement formula. -/
+theorem radical_restrict_orthogonalComplement (H : AddSubgroup A) :
+    (A.restrict (A.orthogonalComplement H)).radical =
+      (H ⊔ A.radical).addSubgroupOf (A.orthogonalComplement H) := by
+  rw [A.radical_restrict, A.orthogonalComplement_orthogonalComplement]
+
+/-- The copy of `H` inside `H⊥` is degenerate for the pairing restricted to `H⊥`.
+
+This is the inclusion which lets the restricted pairing descend to the quotient `H⊥ / H`. -/
+theorem addSubgroupOf_orthogonalComplement_le_radical_restrict (H : AddSubgroup A) :
+    H.addSubgroupOf (A.orthogonalComplement H) ≤
+      (A.restrict (A.orthogonalComplement H)).radical := by
+  intro x hx
+  rw [A.radical_restrict, AddSubgroup.mem_addSubgroupOf]
+  exact A.le_orthogonalComplement_orthogonalComplement H (AddSubgroup.mem_addSubgroupOf.mp hx)
 
 end TauCeti.FiniteBilinearModule

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
@@ -134,6 +134,15 @@ theorem radical_orthogonalQuotient (H : AddSubgroup A) :
   unfold orthogonalQuotient orthogonalQuotientMk
   rw [radical_quotientOfLeRadical, A.radical_restrict_orthogonalComplement]
 
+/-- **The kernel of the quotient map** onto the orthogonal quotient is the part of `H` that lies
+in `H⊥`. -/
+@[simp]
+theorem orthogonalQuotientMk_ker (H : AddSubgroup A) :
+    (A.orthogonalQuotientMk H).ker = H.addSubgroupOf (A.orthogonalComplement H) :=
+  quotientOfLeRadicalMk_ker (A.restrict (A.orthogonalComplement H))
+    (H.addSubgroupOf (A.orthogonalComplement H))
+    (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H)
+
 /-- An element of `H⊥` has zero class in the orthogonal quotient exactly when it lies in `H`. -/
 @[simp]
 theorem orthogonalQuotientMk_eq_zero_iff (H : AddSubgroup A) (x : A.orthogonalComplement H) :

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
@@ -84,7 +84,10 @@ No isotropy hypothesis is needed: `H ∩ H⊥` is always killed by the restricte
 is isotropic, so that `H ≤ H⊥`, this is the classical `H⊥ / H`.
 
 Exposed for the same reason as `quotientOfLeRadical`, on which it is built: so that its carrier
-reduces to the `Submodule` quotient and maps out of it are definable. -/
+reduces to the `Submodule` quotient and maps out of it are definable with `Submodule.liftQ`,
+`Submodule.mapQ` and `Submodule.Quotient.equiv`.  Exposure is also what identifies this package
+with the quadratic one on the nose, which is how
+`TauCeti.FiniteQuadraticModule.orthogonalQuotient_toFiniteBilinearModule` holds by `rfl`. -/
 @[expose] noncomputable def orthogonalQuotient (H : AddSubgroup A) : FiniteBilinearModule :=
   (A.restrict (A.orthogonalComplement H)).quotientOfLeRadical
     (H.addSubgroupOf (A.orthogonalComplement H))

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
@@ -248,11 +248,6 @@ theorem card_orthogonalQuotient_eq_one_iff_isLagrangian {H : AddSubgroup A}
   exact ⟨fun h ↦ le_antisymm ((A.isIsotropic_iff_le_orthogonalComplement H).mp hH) h,
     fun h ↦ h ▸ le_rfl⟩
 
-/-- The orthogonal quotient of a Lagrangian subgroup is trivial. -/
-theorem IsLagrangian.card_orthogonalQuotient_eq_one {H : AddSubgroup A}
-    (hH : A.IsLagrangian H) : Nat.card (A.orthogonalQuotient H) = 1 :=
-  (A.card_orthogonalQuotient_eq_one_iff_isLagrangian hH.isIsotropic).mpr hH
-
 /-! ## Transport along isometries -/
 
 namespace Isometry
@@ -303,7 +298,17 @@ private theorem orthogonalQuotientAddEquiv_orthogonalQuotientMk (f : Isometry A 
     f.orthogonalQuotientAddEquiv H (A.orthogonalQuotientMk H x) =
       B.orthogonalQuotientMk (H.map f.toAddEquiv)
         (Isometry.orthogonalComplementEquiv A f H x) := by
-  unfold orthogonalQuotientAddEquiv orthogonalQuotientMk quotientOfLeRadicalMk
+  have hx : A.orthogonalQuotientMk H x =
+      (Submodule.Quotient.mk x : A.orthogonalQuotient H) := by
+    unfold orthogonalQuotientMk
+    exact quotientOfLeRadicalMk_apply _ _ _ _
+  have hfx : B.orthogonalQuotientMk (H.map f.toAddEquiv)
+      (Isometry.orthogonalComplementEquiv A f H x) =
+      (Submodule.Quotient.mk (Isometry.orthogonalComplementEquiv A f H x) :
+        B.orthogonalQuotient (H.map f.toAddEquiv)) := by
+    unfold orthogonalQuotientMk
+    exact quotientOfLeRadicalMk_apply _ _ _ _
+  rw [hx, hfx]
   change (Submodule.Quotient.equiv _ _
       (Isometry.orthogonalComplementEquiv A f H).toIntLinearEquiv
       (map_toIntSubmodule_addSubgroupOf_orthogonalComplement f H))

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Complement
+
+/-!
+# Orthogonal quotients of finite bilinear modules
+
+Let `A` be a finite bilinear module and let `H` be an additive subgroup of it.  The pairing of
+`A` restricted to `H⊥` kills the vectors of `H` that lie in `H⊥`, so it descends to the quotient
+
+```text
+H⊥ / (H ∩ H⊥).
+```
+
+For an isotropic `H`, where `H ≤ H⊥`, this is the classical orthogonal quotient `H⊥ / H`.  The
+construction itself needs no isotropy hypothesis, and is given here without one; isotropy is
+assumed exactly in the two places where it is used, namely the order computation and the
+Lagrangian criterion.
+
+The results are the ones the gluing theory of integral lattices asks of this quotient.  It is
+nondegenerate precisely when `H` swallows the radical of `A`, which for nondegenerate `A` is
+automatic.  Its order is the index of `H ∩ H⊥` in `H⊥`, so for nondegenerate `A` and isotropic
+`H` the double-complement cardinality identity `|H| |H⊥| = |A|` of
+`TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Complement` turns into
+
+```text
+|H⊥ / H| · |H|² = |A|.
+```
+
+The quotient is trivial exactly when `H⊥ ≤ H`, hence — for isotropic `H` — exactly when `H` is
+Lagrangian.  Read through the discriminant form of an integral lattice, that last statement is
+the module-level form of "an overlattice glued along a Lagrangian subgroup is unimodular".
+
+The quadratic refinement `TauCeti.FiniteQuadraticModule.orthogonalQuotient` of
+`TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic` carries a quadratic map on the same
+quotient group, and its underlying bilinear module is definitionally the construction of this
+file; `TauCeti.FiniteQuadraticModule.orthogonalQuotient_toFiniteBilinearModule` records that
+identification, and the quadratic nondegeneracy and order theorems are deduced from the bilinear
+ones through it.
+
+## Main declarations
+
+* `TauCeti.FiniteBilinearModule.orthogonalQuotient`: the finite bilinear module induced on
+  `H⊥ / H`.
+* `TauCeti.FiniteBilinearModule.orthogonalQuotient_pairing_mk`: its pairing, on representatives.
+* `TauCeti.FiniteBilinearModule.isNondegenerate_orthogonalQuotient_iff`: it is nondegenerate
+  exactly when `rad(A) ≤ H`.
+* `TauCeti.FiniteBilinearModule.IsNondegenerate.card_orthogonalQuotient_mul_card_sq`: the order
+  computation `|H⊥ / H| · |H|² = |A|`.
+* `TauCeti.FiniteBilinearModule.card_orthogonalQuotient_eq_one_iff_isLagrangian`: the quotient of
+  an isotropic subgroup is trivial exactly when that subgroup is Lagrangian.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.4,
+  Proposition 1.4.1.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+* `TauCetiRoadmap/IntegralLattices/README.md`, Layer 4.
+-/
+
+public section
+
+namespace TauCeti.FiniteBilinearModule
+
+universe u
+
+variable (A : FiniteBilinearModule.{u})
+
+/-! ## The induced pairing on `H⊥ / H` -/
+
+/-- **The orthogonal quotient of a finite bilinear module.**  The pairing of `A` is restricted to
+`H⊥` and then divided by the copy of `H` sitting inside `H⊥`, which is degenerate for the
+restricted pairing by
+`TauCeti.FiniteBilinearModule.addSubgroupOf_orthogonalComplement_le_radical_restrict`.
+
+No isotropy hypothesis is needed: `H ∩ H⊥` is always killed by the restricted pairing.  When `H`
+is isotropic, so that `H ≤ H⊥`, this is the classical `H⊥ / H`.
+
+Exposed for the same reason as `quotientOfLeRadical`, on which it is built: so that its carrier
+reduces to the `Submodule` quotient and maps out of it are definable. -/
+@[expose] noncomputable def orthogonalQuotient (H : AddSubgroup A) : FiniteBilinearModule :=
+  (A.restrict (A.orthogonalComplement H)).quotientOfLeRadical
+    (H.addSubgroupOf (A.orthogonalComplement H))
+    (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H)
+
+/-- The quotient map from `H⊥` onto the orthogonal quotient. -/
+noncomputable def orthogonalQuotientMk (H : AddSubgroup A) :
+    A.orthogonalComplement H →+ A.orthogonalQuotient H :=
+  quotientOfLeRadicalMk (A.restrict (A.orthogonalComplement H))
+    (H.addSubgroupOf (A.orthogonalComplement H))
+    (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H)
+
+/-- The pairing of the orthogonal quotient is the pairing of `A` on representatives. -/
+@[simp]
+theorem orthogonalQuotient_pairing_mk (H : AddSubgroup A) (x y : A.orthogonalComplement H) :
+    (A.orthogonalQuotient H).pairing (A.orthogonalQuotientMk H x)
+      (A.orthogonalQuotientMk H y) = A.pairing x.1 y.1 :=
+  quotientOfLeRadical_pairing_mk (A.restrict (A.orthogonalComplement H))
+    (H.addSubgroupOf (A.orthogonalComplement H))
+    (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H) x y
+
+/-- The quotient map onto the orthogonal quotient is surjective. -/
+theorem orthogonalQuotientMk_surjective (H : AddSubgroup A) :
+    Function.Surjective (A.orthogonalQuotientMk H) :=
+  quotientOfLeRadicalMk_surjective (A.restrict (A.orthogonalComplement H))
+    (H.addSubgroupOf (A.orthogonalComplement H))
+    (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H)
+
+/-- Every element of the orthogonal quotient is the class of an element of `H⊥`. -/
+@[elab_as_elim]
+theorem orthogonalQuotient_induction_on (H : AddSubgroup A)
+    {motive : A.orthogonalQuotient H → Prop} (q : A.orthogonalQuotient H)
+    (mk : ∀ x : A.orthogonalComplement H, motive (A.orthogonalQuotientMk H x)) : motive q := by
+  obtain ⟨x, rfl⟩ := A.orthogonalQuotientMk_surjective H q
+  exact mk x
+
+/-- An element of `H⊥` has zero class in the orthogonal quotient exactly when it lies in `H`. -/
+@[simp]
+theorem orthogonalQuotientMk_eq_zero_iff (H : AddSubgroup A) (x : A.orthogonalComplement H) :
+    A.orthogonalQuotientMk H x = 0 ↔ (x : A) ∈ H :=
+  quotientOfLeRadicalMk_eq_zero_iff (A.restrict (A.orthogonalComplement H))
+    (H.addSubgroupOf (A.orthogonalComplement H))
+    (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H) x
+
+/-- Two elements of `H⊥` have the same class in the orthogonal quotient exactly when they differ
+by an element of `H`. -/
+@[simp]
+theorem orthogonalQuotientMk_eq_iff (H : AddSubgroup A) (x y : A.orthogonalComplement H) :
+    A.orthogonalQuotientMk H x = A.orthogonalQuotientMk H y ↔ (x : A) - y ∈ H :=
+  quotientOfLeRadicalMk_eq_iff (A.restrict (A.orthogonalComplement H))
+    (H.addSubgroupOf (A.orthogonalComplement H))
+    (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H) x y
+
+/-! ## Nondegeneracy -/
+
+/-- **Nondegeneracy of the orthogonal quotient.**  The quotient `H⊥ / H` is nondegenerate exactly
+when `H` contains the radical of `A`.
+
+Only the radical can survive: an element of `H⊥` orthogonal to all of `H⊥` lies in `H⊥⊥`, which
+is `H` enlarged by the radical. -/
+theorem isNondegenerate_orthogonalQuotient_iff (H : AddSubgroup A) :
+    (A.orthogonalQuotient H).IsNondegenerate ↔ A.radical ≤ H := by
+  have hiff := isNondegenerate_quotientOfLeRadical_iff (A.restrict (A.orthogonalComplement H))
+    (H.addSubgroupOf (A.orthogonalComplement H))
+    (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H)
+  rw [A.radical_restrict_orthogonalComplement] at hiff
+  refine hiff.trans ⟨fun hle x hx ↦ ?_, fun hle ↦ ?_⟩
+  · have hxperp : x ∈ A.orthogonalComplement H := by
+      rw [A.mem_orthogonalComplement_iff]
+      exact fun y _ ↦ (A.mem_radical_iff x).mp hx y
+    exact hle (x := ⟨x, hxperp⟩) (AddSubgroup.mem_addSubgroupOf.mpr (AddSubgroup.mem_sup_right hx))
+  · rw [sup_eq_left.mpr hle]
+
+/-- The orthogonal quotient of a nondegenerate finite bilinear module is nondegenerate. -/
+theorem IsNondegenerate.isNondegenerate_orthogonalQuotient (hA : A.IsNondegenerate)
+    (H : AddSubgroup A) : (A.orthogonalQuotient H).IsNondegenerate :=
+  (A.isNondegenerate_orthogonalQuotient_iff H).mpr (hA.radical_eq_bot ▸ bot_le)
+
+/-! ## Order -/
+
+/-- The order of the orthogonal quotient is the index of `H ∩ H⊥` in `H⊥`. -/
+theorem card_orthogonalQuotient (H : AddSubgroup A) :
+    Nat.card (A.orthogonalQuotient H) = (H.addSubgroupOf (A.orthogonalComplement H)).index :=
+  card_quotientOfLeRadical (A.restrict (A.orthogonalComplement H))
+    (H.addSubgroupOf (A.orthogonalComplement H))
+    (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H)
+
+/-- **The order of the orthogonal quotient of an isotropic subgroup.**  In a nondegenerate finite
+bilinear module, `|H⊥ / H| · |H|² = |A|`. -/
+theorem IsNondegenerate.card_orthogonalQuotient_mul_card_sq (hA : A.IsNondegenerate)
+    {H : AddSubgroup A} (hH : A.IsIsotropic H) :
+    Nat.card (A.orthogonalQuotient H) * Nat.card H ^ 2 = Nat.card A := by
+  have hle : H ≤ A.orthogonalComplement H := (A.isIsotropic_iff_le_orthogonalComplement H).mp hH
+  have hcard : Nat.card (H.addSubgroupOf (A.orthogonalComplement H)) = Nat.card H :=
+    Nat.card_congr (AddSubgroup.addSubgroupOfEquivOfLe hle).toEquiv
+  have hquot : Nat.card (A.orthogonalQuotient H) * Nat.card H =
+      Nat.card (A.orthogonalComplement H) := by
+    rw [A.card_orthogonalQuotient H, ← hcard]
+    exact (H.addSubgroupOf (A.orthogonalComplement H)).index_mul_card
+  rw [pow_two, ← mul_assoc, hquot, mul_comm]
+  exact IsNondegenerate.card_mul_card_orthogonalComplement A hA H
+
+/-! ## The Lagrangian criterion -/
+
+/-- The orthogonal quotient is trivial exactly when `H⊥` is contained in `H`.  No hypothesis on
+`A` or on `H` is needed. -/
+theorem card_orthogonalQuotient_eq_one_iff (H : AddSubgroup A) :
+    Nat.card (A.orthogonalQuotient H) = 1 ↔ A.orthogonalComplement H ≤ H := by
+  rw [A.card_orthogonalQuotient H, AddSubgroup.index_eq_one, AddSubgroup.addSubgroupOf_eq_top]
+
+/-- **The Lagrangian criterion.**  The orthogonal quotient of an isotropic subgroup is trivial
+exactly when that subgroup is Lagrangian. -/
+theorem card_orthogonalQuotient_eq_one_iff_isLagrangian {H : AddSubgroup A}
+    (hH : A.IsIsotropic H) :
+    Nat.card (A.orthogonalQuotient H) = 1 ↔ A.IsLagrangian H := by
+  rw [A.card_orthogonalQuotient_eq_one_iff H, A.isLagrangian_def H]
+  exact ⟨fun h ↦ le_antisymm ((A.isIsotropic_iff_le_orthogonalComplement H).mp hH) h,
+    fun h ↦ h ▸ le_rfl⟩
+
+/-- The orthogonal quotient of a Lagrangian subgroup is trivial. -/
+theorem IsLagrangian.card_orthogonalQuotient_eq_one {H : AddSubgroup A}
+    (hH : A.IsLagrangian H) : Nat.card (A.orthogonalQuotient H) = 1 :=
+  (A.card_orthogonalQuotient_eq_one_iff_isLagrangian hH.isIsotropic).mpr hH
+
+end TauCeti.FiniteBilinearModule

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
@@ -53,7 +53,7 @@ ones through it.
 * `TauCeti.FiniteBilinearModule.isNondegenerate_orthogonalQuotient_iff`: it is nondegenerate
   exactly when `rad(A) ≤ H`.
 * `TauCeti.FiniteBilinearModule.IsNondegenerate.card_orthogonalQuotient_mul_card_sq`: the order
-  computation `|H⊥ / H| · |H|² = |A|`.
+  computation `|H⊥ / H| · |H|² = |A|`, for a nondegenerate module and an isotropic subgroup.
 * `TauCeti.FiniteBilinearModule.card_orthogonalQuotient_eq_one_iff_isLagrangian`: the quotient of
   an isotropic subgroup is trivial exactly when that subgroup is Lagrangian.
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
@@ -99,6 +99,12 @@ noncomputable def orthogonalQuotientMk (H : AddSubgroup A) :
     (H.addSubgroupOf (A.orthogonalComplement H))
     (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H)
 
+/-- The orthogonal-quotient map sends an element to its quotient class. -/
+theorem orthogonalQuotientMk_apply (H : AddSubgroup A) (x : A.orthogonalComplement H) :
+    A.orthogonalQuotientMk H x = Submodule.Quotient.mk x := by
+  unfold orthogonalQuotientMk
+  exact quotientOfLeRadicalMk_apply _ _ _ _
+
 /-- The pairing of the orthogonal quotient is the pairing of `A` on representatives. -/
 @[simp]
 theorem orthogonalQuotient_pairing_mk (H : AddSubgroup A) (x y : A.orthogonalComplement H) :
@@ -266,6 +272,9 @@ private theorem map_toIntSubmodule_addSubgroupOf_orthogonalComplement
         (B.orthogonalComplement (H.map f.toAddEquiv))).toIntSubmodule := by
   ext y
   rw [Submodule.mem_map_equiv]
+  -- `mem_map_equiv` exposes membership in the underlying `ℤ`-submodules; normalize those
+  -- coercions to the corresponding `AddSubgroup.addSubgroupOf` memberships so its public lemma
+  -- and the representative formula for `orthogonalComplementEquiv` can be used.
   change (Isometry.orthogonalComplementEquiv A f H).symm y ∈
       H.addSubgroupOf (A.orthogonalComplement H) ↔
     y ∈ (H.map f.toAddEquiv).addSubgroupOf
@@ -278,6 +287,8 @@ private theorem map_toIntSubmodule_addSubgroupOf_orthogonalComplement
   · rintro ⟨x, hx, hxy⟩
     rw [← hxy]
     rw [← Isometry.coe_toAddEquiv (f := f.symm), Isometry.symm_toAddEquiv]
+    -- The preceding isometry lemmas leave an application through the induced `AddEquiv`; expose
+    -- it explicitly so the standard inverse/application cancellation lemma matches.
     change f.toAddEquiv.symm (f.toAddEquiv x) ∈ H
     rw [f.toAddEquiv.symm_apply_apply]
     exact hx
@@ -309,6 +320,8 @@ private theorem orthogonalQuotientAddEquiv_orthogonalQuotientMk (f : Isometry A 
     unfold orthogonalQuotientMk
     exact quotientOfLeRadicalMk_apply _ _ _ _
   rw [hx, hfx]
+  -- After replacing the packaged quotient constructors by `Submodule.Quotient.mk`, expose the
+  -- underlying quotient equivalence so Mathlib's `equiv_apply` and `mapQ_apply` lemmas match.
   change (Submodule.Quotient.equiv _ _
       (Isometry.orthogonalComplementEquiv A f H).toIntLinearEquiv
       (map_toIntSubmodule_addSubgroupOf_orthogonalComplement f H))

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
@@ -19,7 +19,7 @@ H⊥ / (H ∩ H⊥).
 
 For an isotropic `H`, where `H ≤ H⊥`, this is the classical orthogonal quotient `H⊥ / H`.  The
 construction itself needs no isotropy hypothesis, and is given here without one; isotropy is
-assumed exactly in the two places where it is used, namely the order computation and the
+assumed exactly in the two places where it is used, namely the squared-order corollary and the
 Lagrangian criterion.
 
 The results are the ones the gluing theory of integral lattices asks of this quotient.  It is
@@ -55,6 +55,8 @@ identification.
   computation `|H⊥ / H| · |H|² = |A|`, for a nondegenerate module and an isotropic subgroup.
 * `TauCeti.FiniteBilinearModule.card_orthogonalQuotient_eq_one_iff_isLagrangian`: the quotient of
   an isotropic subgroup is trivial exactly when that subgroup is Lagrangian.
+* `TauCeti.FiniteBilinearModule.Isometry.orthogonalQuotientEquiv`: transport of orthogonal
+  quotients along an isometry carrying one subgroup onto another.
 
 ## References
 
@@ -67,7 +69,7 @@ public section
 
 namespace TauCeti.FiniteBilinearModule
 
-universe u
+universe u v
 
 variable (A : FiniteBilinearModule.{u})
 
@@ -157,6 +159,22 @@ theorem orthogonalQuotientMk_eq_iff (H : AddSubgroup A) (x y : A.orthogonalCompl
     (H.addSubgroupOf (A.orthogonalComplement H))
     (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H) x y
 
+/-- Equal subgroups induce the same orthogonal quotient, up to the canonical isometry. -/
+noncomputable def orthogonalQuotientCongr {H K : AddSubgroup A} (h : H = K) :
+    Isometry (A.orthogonalQuotient H) (A.orthogonalQuotient K) := by
+  subst h
+  exact Isometry.refl _
+
+/-- The canonical isometry between orthogonal quotients along equal subgroups is the identity on
+representatives. -/
+@[simp]
+theorem orthogonalQuotientCongr_orthogonalQuotientMk {H K : AddSubgroup A} (h : H = K)
+    (x : A.orthogonalComplement H) :
+    A.orthogonalQuotientCongr h (A.orthogonalQuotientMk H x) =
+      A.orthogonalQuotientMk K ⟨x.1, h ▸ x.2⟩ := by
+  subst h
+  simp only [orthogonalQuotientCongr, Isometry.refl_apply]
+
 /-! ## Nondegeneracy -/
 
 /-- **Nondegeneracy of the orthogonal quotient.** The quotient `H⊥ / (H ∩ H⊥)` is
@@ -191,6 +209,17 @@ theorem card_orthogonalQuotient (H : AddSubgroup A) :
     (H.addSubgroupOf (A.orthogonalComplement H))
     (A.addSubgroupOf_orthogonalComplement_le_radical_restrict H)
 
+/-- **The general order formula for an orthogonal quotient.** In a nondegenerate finite bilinear
+module, the orders of `H⊥ / (H ∩ H⊥)`, `H ∩ H⊥`, and `H` multiply to the order of the
+ambient module. -/
+theorem IsNondegenerate.card_orthogonalQuotient_mul_card_addSubgroupOf_mul_card
+    (hA : A.IsNondegenerate) (H : AddSubgroup A) :
+    Nat.card (A.orthogonalQuotient H) *
+        Nat.card (H.addSubgroupOf (A.orthogonalComplement H)) * Nat.card H = Nat.card A := by
+  rw [A.card_orthogonalQuotient H,
+    (H.addSubgroupOf (A.orthogonalComplement H)).index_mul_card, mul_comm]
+  exact IsNondegenerate.card_mul_card_orthogonalComplement A hA H
+
 /-- **The order of the orthogonal quotient of an isotropic subgroup.**  In a nondegenerate finite
 bilinear module, `|H⊥ / H| · |H|² = |A|`. -/
 theorem IsNondegenerate.card_orthogonalQuotient_mul_card_sq (hA : A.IsNondegenerate)
@@ -199,12 +228,8 @@ theorem IsNondegenerate.card_orthogonalQuotient_mul_card_sq (hA : A.IsNondegener
   have hle : H ≤ A.orthogonalComplement H := (A.isIsotropic_iff_le_orthogonalComplement H).mp hH
   have hcard : Nat.card (H.addSubgroupOf (A.orthogonalComplement H)) = Nat.card H :=
     Nat.card_congr (AddSubgroup.addSubgroupOfEquivOfLe hle).toEquiv
-  have hquot : Nat.card (A.orthogonalQuotient H) * Nat.card H =
-      Nat.card (A.orthogonalComplement H) := by
-    rw [A.card_orthogonalQuotient H, ← hcard]
-    exact (H.addSubgroupOf (A.orthogonalComplement H)).index_mul_card
-  rw [pow_two, ← mul_assoc, hquot, mul_comm]
-  exact IsNondegenerate.card_mul_card_orthogonalComplement A hA H
+  simpa only [hcard, pow_two, mul_assoc] using
+    (IsNondegenerate.card_orthogonalQuotient_mul_card_addSubgroupOf_mul_card A hA H)
 
 /-! ## The Lagrangian criterion -/
 
@@ -227,5 +252,140 @@ theorem card_orthogonalQuotient_eq_one_iff_isLagrangian {H : AddSubgroup A}
 theorem IsLagrangian.card_orthogonalQuotient_eq_one {H : AddSubgroup A}
     (hH : A.IsLagrangian H) : Nat.card (A.orthogonalQuotient H) = 1 :=
   (A.card_orthogonalQuotient_eq_one_iff_isLagrangian hH.isIsotropic).mpr hH
+
+/-! ## Transport along isometries -/
+
+namespace Isometry
+
+variable {A : FiniteBilinearModule.{u}} {B : FiniteBilinearModule.{v}}
+
+/-- An isometry maps the part of `H` in `H⊥` onto the part of its image in the corresponding
+orthogonal complement. -/
+private theorem map_toIntSubmodule_addSubgroupOf_orthogonalComplement
+    (f : Isometry A B) (H : AddSubgroup A) :
+    (H.addSubgroupOf (A.orthogonalComplement H)).toIntSubmodule.map
+        ((Isometry.orthogonalComplementEquiv A f H).toIntLinearEquiv :
+          A.orthogonalComplement H →ₗ[ℤ]
+            B.orthogonalComplement (H.map f.toAddEquiv)) =
+      ((H.map f.toAddEquiv).addSubgroupOf
+        (B.orthogonalComplement (H.map f.toAddEquiv))).toIntSubmodule := by
+  ext y
+  rw [Submodule.mem_map_equiv]
+  change (Isometry.orthogonalComplementEquiv A f H).symm y ∈
+      H.addSubgroupOf (A.orthogonalComplement H) ↔
+    y ∈ (H.map f.toAddEquiv).addSubgroupOf
+      (B.orthogonalComplement (H.map f.toAddEquiv))
+  rw [AddSubgroup.mem_addSubgroupOf, AddSubgroup.mem_addSubgroupOf,
+    Isometry.coe_orthogonalComplementEquiv_symm_apply A f H]
+  constructor
+  · intro hy
+    exact ⟨f.symm (y : B), hy, f.apply_symm_apply (y : B)⟩
+  · rintro ⟨x, hx, hxy⟩
+    rw [← hxy]
+    rw [← Isometry.coe_toAddEquiv (f := f.symm), Isometry.symm_toAddEquiv]
+    change f.toAddEquiv.symm (f.toAddEquiv x) ∈ H
+    rw [f.toAddEquiv.symm_apply_apply]
+    exact hx
+
+/-- The additive equivalence of orthogonal quotients when the target subgroup is exactly the
+image. -/
+private noncomputable def orthogonalQuotientAddEquiv (f : Isometry A B) (H : AddSubgroup A) :
+    A.orthogonalQuotient H ≃+ B.orthogonalQuotient (H.map f.toAddEquiv) :=
+  (Submodule.Quotient.equiv _ _
+    (Isometry.orthogonalComplementEquiv A f H).toIntLinearEquiv
+    (map_toIntSubmodule_addSubgroupOf_orthogonalComplement f H)).toAddEquiv
+
+/-- The image-subgroup additive equivalence sends the class of `x ∈ H⊥` to the class of
+`f x`. -/
+@[simp]
+private theorem orthogonalQuotientAddEquiv_orthogonalQuotientMk (f : Isometry A B)
+    (H : AddSubgroup A) (x : A.orthogonalComplement H) :
+    f.orthogonalQuotientAddEquiv H (A.orthogonalQuotientMk H x) =
+      B.orthogonalQuotientMk (H.map f.toAddEquiv)
+        (Isometry.orthogonalComplementEquiv A f H x) := by
+  unfold orthogonalQuotientAddEquiv orthogonalQuotientMk quotientOfLeRadicalMk
+  change (Submodule.Quotient.equiv _ _
+      (Isometry.orthogonalComplementEquiv A f H).toIntLinearEquiv
+      (map_toIntSubmodule_addSubgroupOf_orthogonalComplement f H))
+      (Submodule.Quotient.mk x) = Submodule.Quotient.mk _
+  rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+  congr 1
+
+/-- The isometry of orthogonal quotients when the target subgroup is exactly the image. -/
+private noncomputable def orthogonalQuotientMap (f : Isometry A B) (H : AddSubgroup A) :
+    Isometry (A.orthogonalQuotient H) (B.orthogonalQuotient (H.map f.toAddEquiv)) where
+  toAddEquiv := f.orthogonalQuotientAddEquiv H
+  map_pairing' q r := by
+    induction q using orthogonalQuotient_induction_on with
+    | mk x =>
+      induction r using orthogonalQuotient_induction_on with
+      | mk y =>
+        rw [orthogonalQuotientAddEquiv_orthogonalQuotientMk,
+          orthogonalQuotientAddEquiv_orthogonalQuotientMk,
+          B.orthogonalQuotient_pairing_mk, A.orthogonalQuotient_pairing_mk,
+          Isometry.coe_orthogonalComplementEquiv_apply A f H,
+          Isometry.coe_orthogonalComplementEquiv_apply A f H,
+          f.map_pairing]
+
+/-- The image-subgroup transport sends the class of `x ∈ H⊥` to the class of `f x`. -/
+@[simp]
+private theorem orthogonalQuotientMap_orthogonalQuotientMk (f : Isometry A B)
+    (H : AddSubgroup A) (x : A.orthogonalComplement H) :
+    f.orthogonalQuotientMap H (A.orthogonalQuotientMk H x) =
+      B.orthogonalQuotientMk (H.map f.toAddEquiv)
+        (Isometry.orthogonalComplementEquiv A f H x) := by
+  rw [orthogonalQuotientMap]
+  exact orthogonalQuotientAddEquiv_orthogonalQuotientMk f H x
+
+/-- **Transport of an orthogonal quotient along an isometry.** An isometry `f : A ≅ B` carrying
+`H` onto `K` induces an isometry `H⊥ / (H ∩ H⊥) ≅ K⊥ / (K ∩ K⊥)`. -/
+noncomputable def orthogonalQuotientEquiv (f : Isometry A B) {H : AddSubgroup A}
+    {K : AddSubgroup B} (h : H.map f.toAddEquiv = K) :
+    Isometry (A.orthogonalQuotient H) (B.orthogonalQuotient K) :=
+  (f.orthogonalQuotientMap H).trans (B.orthogonalQuotientCongr h)
+
+/-- **The representative formula for a transported orthogonal quotient.** The transported
+isometry sends the class of `x ∈ H⊥` to the class of `f x ∈ K⊥`. -/
+@[simp]
+theorem orthogonalQuotientEquiv_orthogonalQuotientMk (f : Isometry A B)
+    {H : AddSubgroup A} {K : AddSubgroup B} (h : H.map f.toAddEquiv = K)
+    (x : A.orthogonalComplement H) :
+    f.orthogonalQuotientEquiv h (A.orthogonalQuotientMk H x) =
+      B.orthogonalQuotientMk K
+        ⟨f (x : A), Isometry.map_mem_orthogonalComplement_of_map_eq A f h x.2⟩ := by
+  rw [orthogonalQuotientEquiv, trans_apply, orthogonalQuotientMap_orthogonalQuotientMk,
+    B.orthogonalQuotientCongr_orthogonalQuotientMk]
+  apply congrArg (B.orthogonalQuotientMk K)
+  exact Subtype.ext (Isometry.coe_orthogonalComplementEquiv_apply A f H x)
+
+/-- **The inverse representative formula for a transported orthogonal quotient.** The inverse
+transport sends the class of `y ∈ K⊥` to the class of `f⁻¹ y ∈ H⊥`. -/
+@[simp]
+theorem orthogonalQuotientEquiv_symm_orthogonalQuotientMk (f : Isometry A B)
+    {H : AddSubgroup A} {K : AddSubgroup B} (h : H.map f.toAddEquiv = K)
+    (y : B.orthogonalComplement K) :
+    (f.orthogonalQuotientEquiv h).symm (B.orthogonalQuotientMk K y) =
+      A.orthogonalQuotientMk H
+        ⟨f.symm (y : B), by
+          rw [A.mem_orthogonalComplement_iff]
+          intro x hx
+          rw [← f.map_pairing, f.apply_symm_apply]
+          exact (B.mem_orthogonalComplement_iff K (y : B)).mp y.2 (f x)
+            (h ▸ ⟨x, hx, rfl⟩)⟩ := by
+  have hforward :
+      f.orthogonalQuotientEquiv h
+          (A.orthogonalQuotientMk H ⟨f.symm (y : B), by
+            rw [A.mem_orthogonalComplement_iff]
+            intro x hx
+            rw [← f.map_pairing, f.apply_symm_apply]
+            exact (B.mem_orthogonalComplement_iff K (y : B)).mp y.2 (f x)
+              (h ▸ ⟨x, hx, rfl⟩)⟩) =
+        B.orthogonalQuotientMk K y := by
+    rw [orthogonalQuotientEquiv_orthogonalQuotientMk]
+    apply congrArg (B.orthogonalQuotientMk K)
+    exact Subtype.ext (f.apply_symm_apply (y : B))
+  rw [← hforward, (f.orthogonalQuotientEquiv h).symm_apply_apply]
+
+end Isometry
 
 end TauCeti.FiniteBilinearModule

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
@@ -40,8 +40,7 @@ The quadratic refinement `TauCeti.FiniteQuadraticModule.orthogonalQuotient` of
 `TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic` carries a quadratic map on the same
 quotient group, and its underlying bilinear module is definitionally the construction of this
 file; `TauCeti.FiniteQuadraticModule.orthogonalQuotient_toFiniteBilinearModule` records that
-identification, and the quadratic nondegeneracy and order theorems are deduced from the bilinear
-ones through it.
+identification.
 
 ## Main declarations
 
@@ -62,7 +61,6 @@ ones through it.
 * V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.4,
   Proposition 1.4.1.
 * W. Ebeling, *Lattices and Codes*, Chapter 1.
-* `TauCetiRoadmap/IntegralLattices/README.md`, Layer 4.
 -/
 
 public section
@@ -85,9 +83,8 @@ is isotropic, so that `H ≤ H⊥`, this is the classical `H⊥ / H`.
 
 Exposed for the same reason as `quotientOfLeRadical`, on which it is built: so that its carrier
 reduces to the `Submodule` quotient and maps out of it are definable with `Submodule.liftQ`,
-`Submodule.mapQ` and `Submodule.Quotient.equiv`.  Exposure is also what identifies this package
-with the quadratic one on the nose, which is how
-`TauCeti.FiniteQuadraticModule.orthogonalQuotient_toFiniteBilinearModule` holds by `rfl`. -/
+`Submodule.mapQ` and `Submodule.Quotient.equiv`, and so that this package is definitionally the
+underlying bilinear module of `TauCeti.FiniteQuadraticModule.orthogonalQuotient`. -/
 @[expose] noncomputable def orthogonalQuotient (H : AddSubgroup A) : FiniteBilinearModule :=
   (A.restrict (A.orthogonalComplement H)).quotientOfLeRadical
     (H.addSubgroupOf (A.orthogonalComplement H))

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Quotient.lean
@@ -46,8 +46,10 @@ ones through it.
 ## Main declarations
 
 * `TauCeti.FiniteBilinearModule.orthogonalQuotient`: the finite bilinear module induced on
-  `H⊥ / H`.
+  `H⊥ / (H ∩ H⊥)`.
 * `TauCeti.FiniteBilinearModule.orthogonalQuotient_pairing_mk`: its pairing, on representatives.
+* `TauCeti.FiniteBilinearModule.radical_orthogonalQuotient`: its radical, as the image of the
+  restricted radical.
 * `TauCeti.FiniteBilinearModule.isNondegenerate_orthogonalQuotient_iff`: it is nondegenerate
   exactly when `rad(A) ≤ H`.
 * `TauCeti.FiniteBilinearModule.IsNondegenerate.card_orthogonalQuotient_mul_card_sq`: the order
@@ -71,11 +73,11 @@ universe u
 
 variable (A : FiniteBilinearModule.{u})
 
-/-! ## The induced pairing on `H⊥ / H` -/
+/-! ## The induced pairing on `H⊥ / (H ∩ H⊥)` -/
 
 /-- **The orthogonal quotient of a finite bilinear module.**  The pairing of `A` is restricted to
-`H⊥` and then divided by the copy of `H` sitting inside `H⊥`, which is degenerate for the
-restricted pairing by
+`H⊥` and then divided by the part of `H` lying in `H⊥`, which is degenerate for the restricted
+pairing by
 `TauCeti.FiniteBilinearModule.addSubgroupOf_orthogonalComplement_le_radical_restrict`.
 
 No isotropy hypothesis is needed: `H ∩ H⊥` is always killed by the restricted pairing.  When `H`
@@ -119,6 +121,16 @@ theorem orthogonalQuotient_induction_on (H : AddSubgroup A)
   obtain ⟨x, rfl⟩ := A.orthogonalQuotientMk_surjective H q
   exact mk x
 
+/-- **The radical of the orthogonal quotient** is the image of the radical of the restricted
+pairing. -/
+@[simp]
+theorem radical_orthogonalQuotient (H : AddSubgroup A) :
+    (A.orthogonalQuotient H).radical =
+      ((H ⊔ A.radical).addSubgroupOf (A.orthogonalComplement H)).map
+        (A.orthogonalQuotientMk H) := by
+  unfold orthogonalQuotient orthogonalQuotientMk
+  rw [radical_quotientOfLeRadical, A.radical_restrict_orthogonalComplement]
+
 /-- An element of `H⊥` has zero class in the orthogonal quotient exactly when it lies in `H`. -/
 @[simp]
 theorem orthogonalQuotientMk_eq_zero_iff (H : AddSubgroup A) (x : A.orthogonalComplement H) :
@@ -138,8 +150,8 @@ theorem orthogonalQuotientMk_eq_iff (H : AddSubgroup A) (x y : A.orthogonalCompl
 
 /-! ## Nondegeneracy -/
 
-/-- **Nondegeneracy of the orthogonal quotient.**  The quotient `H⊥ / H` is nondegenerate exactly
-when `H` contains the radical of `A`.
+/-- **Nondegeneracy of the orthogonal quotient.** The quotient `H⊥ / (H ∩ H⊥)` is
+nondegenerate exactly when `H` contains the radical of `A`.
 
 Only the radical can survive: an element of `H⊥` orthogonal to all of `H⊥` lies in `H⊥⊥`, which
 is `H` enlarged by the radical. -/

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -892,12 +892,9 @@ theorem IsNondegenerate.isNondegenerate_orthogonalQuotient (hA : A.IsNondegenera
 theorem IsNondegenerate.card_orthogonalQuotient_mul_card_sq (hA : A.IsNondegenerate)
     {H : AddSubgroup A} (hH : A.IsIsotropic H) :
     Nat.card (A.orthogonalQuotient H hH) * Nat.card H ^ 2 = Nat.card A := by
-  rw [show Nat.card (A.orthogonalQuotient H hH) =
-      Nat.card (A.toFiniteBilinearModule.orthogonalQuotient H) from
-    congrArg (fun B : FiniteBilinearModule ↦ Nat.card B)
-      (A.orthogonalQuotient_toFiniteBilinearModule H hH)]
-  exact FiniteBilinearModule.IsNondegenerate.card_orthogonalQuotient_mul_card_sq
-    A.toFiniteBilinearModule hA hH.toFiniteBilinearModule
+  simpa only [A.orthogonalQuotient_toFiniteBilinearModule H hH] using
+    (FiniteBilinearModule.IsNondegenerate.card_orthogonalQuotient_mul_card_sq
+      A.toFiniteBilinearModule hA hH.toFiniteBilinearModule)
 
 /-! ### Transport of an orthogonal quotient along an isometry -/
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.FiniteBilinearModule.OrthogonalComplement
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Quotient
 public import Mathlib.Algebra.Group.Subgroup.Map
 public import Mathlib.LinearAlgebra.Isomorphisms
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
@@ -39,7 +39,9 @@ the polar pairing is therefore `B(x, y)` modulo `ℤ`.
 * `TauCeti.FiniteQuadraticModule.IsLagrangian`: a quadratic-isotropic subgroup equal to its
   bilinear orthogonal complement.
 * `TauCeti.FiniteQuadraticModule.orthogonalQuotient`: the quadratic module induced on
-  `H^⊥ / H` by a quadratic-isotropic subgroup `H`.
+  `H^⊥ / H` by a quadratic-isotropic subgroup `H`.  Its underlying bilinear module is
+  `TauCeti.FiniteBilinearModule.orthogonalQuotient`, as recorded by
+  `TauCeti.FiniteQuadraticModule.orthogonalQuotient_toFiniteBilinearModule`.
 * `TauCeti.FiniteQuadraticModule.orthogonalQuotientCongr`: the canonical isometry between the
   orthogonal quotients along equal subgroups.
 * `TauCeti.FiniteQuadraticModule.Isometry.orthogonalQuotientEquiv`: transport of an orthogonal
@@ -747,12 +749,6 @@ theorem mem_subgroupInOrthogonalComplement_iff (H : AddSubgroup A)
     x ∈ A.subgroupInOrthogonalComplement H ↔ (x : A) ∈ H :=
   Iff.rfl
 
-/-- If `H ≤ H^⊥`, its copy inside `H^⊥` is additively equivalent to `H`. -/
-def subgroupInOrthogonalComplementEquiv {H : AddSubgroup A}
-    (hH : H ≤ A.toFiniteBilinearModule.orthogonalComplement H) :
-    A.subgroupInOrthogonalComplement H ≃+ H :=
-  AddSubgroup.addSubgroupOfEquivOfLe hH
-
 /-- The copy of a quadratic-isotropic subgroup in its orthogonal complement remains
 quadratic-isotropic for the restricted form. -/
 theorem isIsotropic_subgroupInOrthogonalComplement {H : AddSubgroup A}
@@ -762,22 +758,6 @@ theorem isIsotropic_subgroupInOrthogonalComplement {H : AddSubgroup A}
   intro x hx
   exact hH x.1 (A.mem_subgroupInOrthogonalComplement_iff H x |>.mp hx)
 
-/-- The elements of `H` lying in `H^⊥` belong to the radical of the pairing restricted to
-`H^⊥`. -/
-theorem subgroupInOrthogonalComplement_le_radical {H : AddSubgroup A}
-    : A.subgroupInOrthogonalComplement H ≤
-      FiniteBilinearModule.radical
-        (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).toFiniteBilinearModule := by
-  intro x hx
-  apply FiniteBilinearModule.mem_radical_iff
-    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).toFiniteBilinearModule x |>.mpr
-  intro y
-  -- The restricted pairing has the same values on the underlying subtype.
-  change A.toFiniteBilinearModule.pairing x.1 y.1 = 0
-  rw [A.toFiniteBilinearModule.pairing_comm]
-  exact A.toFiniteBilinearModule.mem_orthogonalComplement_iff H y.1 |>.mp y.2 x.1
-    (A.mem_subgroupInOrthogonalComplement_iff H x |>.mp hx)
-
 /-- The copy of a quadratic-isotropic subgroup in its orthogonal complement lies in the radical of
 the quadratic map restricted to that complement. -/
 theorem subgroupInOrthogonalComplement_le_quadraticRadical {H : AddSubgroup A}
@@ -786,7 +766,7 @@ theorem subgroupInOrthogonalComplement_le_quadraticRadical {H : AddSubgroup A}
       (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).quadratic.radical :=
   IsIsotropic.toIntSubmodule_le_quadraticRadical _
     (A.isIsotropic_subgroupInOrthogonalComplement hH)
-    A.subgroupInOrthogonalComplement_le_radical
+    (A.toFiniteBilinearModule.addSubgroupOf_orthogonalComplement_le_radical_restrict H)
 
 /-- The finite quadratic module induced on `H^⊥ / H` by a quadratic-isotropic subgroup `H`.
 
@@ -800,6 +780,16 @@ Exposed for the same reason as `quotientOfLeQuadraticRadical`: so that its carri
   (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).quotientOfLeQuadraticRadical
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)
+
+/-- **The underlying bilinear module of a quadratic orthogonal quotient** is the bilinear
+orthogonal quotient.  Both are the restriction of the form to `H^⊥` divided by the copy of `H`
+inside it, so the two constructions agree on the nose; this lemma is what lets the nondegeneracy
+and order theorems below be read off from
+`TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Quotient`. -/
+@[simp]
+theorem orthogonalQuotient_toFiniteBilinearModule (H : AddSubgroup A) (hH : A.IsIsotropic H) :
+    (A.orthogonalQuotient H hH).toFiniteBilinearModule =
+      A.toFiniteBilinearModule.orthogonalQuotient H := (rfl)
 
 /-- The quotient map from `H^⊥` onto its induced quadratic quotient. -/
 noncomputable def orthogonalQuotientMk (H : AddSubgroup A) (hH : A.IsIsotropic H) :
@@ -894,49 +884,20 @@ theorem orthogonalQuotientCongr_orthogonalQuotientMk {H K : AddSubgroup A} (hH :
 theorem IsNondegenerate.isNondegenerate_orthogonalQuotient (hA : A.IsNondegenerate)
     {H : AddSubgroup A} (hH : A.IsIsotropic H) :
     (A.orthogonalQuotient H hH).IsNondegenerate := by
-  apply (isNondegenerate_quotientOfLeQuadraticRadical_iff
-    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
-    (A.subgroupInOrthogonalComplement H)
-    (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)).mpr
-  intro x hx
-  have hx' : (x.1 : A) ∈ A.toFiniteBilinearModule.orthogonalComplement
-      (A.toFiniteBilinearModule.orthogonalComplement H) := by
-    rw [A.toFiniteBilinearModule.mem_orthogonalComplement_iff]
-    intro y hy
-    exact FiniteBilinearModule.mem_radical_iff
-      (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).toFiniteBilinearModule x
-      |>.mp hx ⟨y, hy⟩
-  have hdouble := FiniteBilinearModule.IsNondegenerate.orthogonalComplement_orthogonalComplement
+  rw [FiniteQuadraticModule.IsNondegenerate, A.orthogonalQuotient_toFiniteBilinearModule H hH]
+  exact FiniteBilinearModule.IsNondegenerate.isNondegenerate_orthogonalQuotient
     A.toFiniteBilinearModule hA H
-  rw [hdouble] at hx'
-  exact hx'
 
 /-- For nondegenerate `A`, the order of `H^⊥ / H` multiplied by `|H|²` is `|A|`. -/
 theorem IsNondegenerate.card_orthogonalQuotient_mul_card_sq (hA : A.IsNondegenerate)
     {H : AddSubgroup A} (hH : A.IsIsotropic H) :
     Nat.card (A.orthogonalQuotient H hH) * Nat.card H ^ 2 = Nat.card A := by
-  have hcard : Nat.card (A.subgroupInOrthogonalComplement H) = Nat.card H :=
-    Nat.card_congr (A.subgroupInOrthogonalComplementEquiv hH.le_orthogonalComplement).toEquiv
-  have hindex : Nat.card (A.orthogonalQuotient H hH) =
-      (A.subgroupInOrthogonalComplement H).index := by
-    unfold orthogonalQuotient
-    exact card_quotientOfLeQuadraticRadical
-      (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
-      (A.subgroupInOrthogonalComplement H)
-      (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)
-  have hquot : Nat.card (A.orthogonalQuotient H hH) * Nat.card H =
-      Nat.card (A.toFiniteBilinearModule.orthogonalComplement H) := by
-    calc
-      Nat.card (A.orthogonalQuotient H hH) * Nat.card H =
-          (A.subgroupInOrthogonalComplement H).index * Nat.card H := by
-            rw [hindex]
-      _ = (A.subgroupInOrthogonalComplement H).index *
-          Nat.card (A.subgroupInOrthogonalComplement H) := congrArg _ hcard.symm
-      _ = Nat.card (A.toFiniteBilinearModule.orthogonalComplement H) :=
-        (A.subgroupInOrthogonalComplement H).index_mul_card
-  rw [pow_two, ← mul_assoc, hquot, mul_comm]
-  exact FiniteBilinearModule.IsNondegenerate.card_mul_card_orthogonalComplement
-    A.toFiniteBilinearModule hA H
+  rw [show Nat.card (A.orthogonalQuotient H hH) =
+      Nat.card (A.toFiniteBilinearModule.orthogonalQuotient H) from
+    congrArg (fun B : FiniteBilinearModule ↦ Nat.card B)
+      (A.orthogonalQuotient_toFiniteBilinearModule H hH)]
+  exact FiniteBilinearModule.IsNondegenerate.card_orthogonalQuotient_mul_card_sq
+    A.toFiniteBilinearModule hA hH.toFiniteBilinearModule
 
 /-! ### Transport of an orthogonal quotient along an isometry -/
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -783,9 +783,7 @@ Exposed for the same reason as `quotientOfLeQuadraticRadical`: so that its carri
 
 /-- **The underlying bilinear module of a quadratic orthogonal quotient** is the bilinear
 orthogonal quotient.  Both are the restriction of the form to `H^⊥` divided by the copy of `H`
-inside it, so the two constructions agree on the nose; this lemma is what lets the nondegeneracy
-and order theorems below be read off from
-`TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Quotient`. -/
+inside it, so the two constructions agree. -/
 @[simp]
 theorem orthogonalQuotient_toFiniteBilinearModule (H : AddSubgroup A) (hH : A.IsIsotropic H) :
     (A.orthogonalQuotient H hH).toFiniteBilinearModule =

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -898,61 +898,9 @@ theorem IsNondegenerate.card_orthogonalQuotient_mul_card_sq (hA : A.IsNondegener
 
 namespace Isometry
 
+universe w
+
 variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
-
-/-- The bilinear orthogonal-complement equivalence, with the underlying map normalized to the
-quadratic isometry's additive equivalence. -/
-private def orthogonalComplementEquiv (f : Isometry A B) (H : AddSubgroup A) :
-    A.toFiniteBilinearModule.orthogonalComplement H ≃+
-      B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv) := by
-  refine (FiniteBilinearModule.Isometry.orthogonalComplementEquiv
-    A.toFiniteBilinearModule f.toFiniteBilinearModule H).trans
-      (AddEquiv.addSubgroupCongr ?_)
-  rw [toFiniteBilinearModule_toAddEquiv]
-
-@[simp]
-private theorem coe_orthogonalComplementEquiv_apply (f : Isometry A B) (H : AddSubgroup A)
-    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
-    (f.orthogonalComplementEquiv H x : B) = f (x : A) := by
-  simp only [orthogonalComplementEquiv, AddEquiv.trans_apply,
-    AddEquiv.addSubgroupCongr_apply,
-    FiniteBilinearModule.Isometry.coe_orthogonalComplementEquiv_apply]
-  exact congrArg (fun e : A ≃+ B => e (x : A)) f.toFiniteBilinearModule_toAddEquiv
-
-@[simp]
-private theorem coe_orthogonalComplementEquiv_symm_apply (f : Isometry A B)
-    (H : AddSubgroup A)
-    (y : B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv)) :
-    ((f.orthogonalComplementEquiv H).symm y : A) = f.symm (y : B) := by
-  simp only [orthogonalComplementEquiv, AddEquiv.symm_trans_apply,
-    AddEquiv.addSubgroupCongr_symm_apply,
-    FiniteBilinearModule.Isometry.coe_orthogonalComplementEquiv_symm_apply]
-  rw [← FiniteBilinearModule.Isometry.coe_toAddEquiv,
-    FiniteBilinearModule.Isometry.symm_toAddEquiv, toFiniteBilinearModule_toAddEquiv]
-  exact congrArg (fun e : B ≃ₗ[ℤ] A => e (y : B))
-    (QuadraticMap.IsometryEquiv.coe_symm_toLinearEquiv f)
-
-/-- The copy of `H` inside `H⊥` is carried onto the copy of the image of `H` inside its orthogonal
-complement. This is the hypothesis which makes the two quotients correspond. -/
-private theorem map_toIntSubmodule_subgroupInOrthogonalComplement (f : Isometry A B)
-    (H : AddSubgroup A) :
-    (A.subgroupInOrthogonalComplement H).toIntSubmodule.map
-        ((f.orthogonalComplementEquiv H).toIntLinearEquiv :
-          A.toFiniteBilinearModule.orthogonalComplement H →ₗ[ℤ]
-            B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv)) =
-      (B.subgroupInOrthogonalComplement (H.map f.toAddEquiv)).toIntSubmodule := by
-  ext y
-  rw [Submodule.mem_map_equiv]
-  -- `Submodule.mem_map_equiv` exposes the restricted linear equivalence, while the available
-  -- membership lemmas concern the underlying additive subgroups.  This `change` crosses that
-  -- subtype/coercion boundary so those named lemmas can be used; `rw` cannot unfold the inferred
-  -- `Module ℤ` instances far enough to expose the same goal.
-  change (f.orthogonalComplementEquiv H).symm y ∈
-      A.subgroupInOrthogonalComplement H ↔
-    y ∈ B.subgroupInOrthogonalComplement (H.map f.toAddEquiv)
-  rw [A.mem_subgroupInOrthogonalComplement_iff,
-    B.mem_subgroupInOrthogonalComplement_iff, coe_orthogonalComplementEquiv_symm_apply]
-  exact (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K := H) (x := (y : B))).symm
 
 /-- A quadratic isometry carrying `H` onto `K` transports quadratic isotropy from `H` to `K`. -/
 theorem isIsotropic_of_map_eq (f : Isometry A B) {H : AddSubgroup A} {K : AddSubgroup B}
@@ -960,34 +908,117 @@ theorem isIsotropic_of_map_eq (f : Isometry A B) {H : AddSubgroup A} {K : AddSub
   rw [← h, f.isIsotropic_map_iff]
   exact hH
 
+/-- The additive equivalence from a quadratic orthogonal quotient to its underlying bilinear
+orthogonal quotient. -/
+private noncomputable def orthogonalQuotientUnderlyingEquiv (A : FiniteQuadraticModule.{w})
+    (H : AddSubgroup A) (hH : A.IsIsotropic H) :
+    A.orthogonalQuotient H hH ≃+ A.toFiniteBilinearModule.orthogonalQuotient H := by
+  unfold FiniteQuadraticModule.orthogonalQuotient
+  unfold subgroupInOrthogonalComplement quotientOfLeQuadraticRadical
+  unfold FiniteBilinearModule.orthogonalQuotient
+  exact AddEquiv.refl _
+
+@[simp]
+private theorem orthogonalQuotientUnderlyingEquiv_orthogonalQuotientMk
+    (A : FiniteQuadraticModule.{w}) (H : AddSubgroup A) (hH : A.IsIsotropic H)
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    orthogonalQuotientUnderlyingEquiv A H hH (A.orthogonalQuotientMk H hH x) =
+      A.toFiniteBilinearModule.orthogonalQuotientMk H x := by
+  unfold orthogonalQuotientUnderlyingEquiv FiniteQuadraticModule.orthogonalQuotientMk
+  unfold subgroupInOrthogonalComplement quotientOfLeQuadraticRadicalMk
+  rw [A.toFiniteBilinearModule.orthogonalQuotientMk_apply]
+  exact Submodule.mkQ_apply _ _
+
+/-- The bilinear transport induced by a quadratic isometry. -/
+private noncomputable def orthogonalQuotientBilinearMapAddEquiv (f : Isometry A B)
+    (H : AddSubgroup A) :
+    A.toFiniteBilinearModule.orthogonalQuotient H ≃+
+      B.toFiniteBilinearModule.orthogonalQuotient (H.map f.toAddEquiv) :=
+  ((FiniteBilinearModule.Isometry.orthogonalQuotientEquiv
+      (H := H) f.toFiniteBilinearModule rfl).trans
+    (B.toFiniteBilinearModule.orthogonalQuotientCongr
+      (by rw [f.toFiniteBilinearModule_toAddEquiv]))).toAddEquiv
+
+@[simp]
+private theorem orthogonalQuotientBilinearMapAddEquiv_orthogonalQuotientMk
+    (f : Isometry A B) (H : AddSubgroup A)
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    orthogonalQuotientBilinearMapAddEquiv f H
+        (A.toFiniteBilinearModule.orthogonalQuotientMk H x) =
+      B.toFiniteBilinearModule.orthogonalQuotientMk (H.map f.toAddEquiv)
+        ⟨f (x : A), FiniteBilinearModule.Isometry.map_mem_orthogonalComplement_of_map_eq
+          A.toFiniteBilinearModule f.toFiniteBilinearModule
+          (by rw [f.toFiniteBilinearModule_toAddEquiv]) x.2⟩ := by
+  rw [orthogonalQuotientBilinearMapAddEquiv]
+  -- The definition ends by forgetting a bilinear isometry to its additive equivalence; normalize
+  -- that coercion so the two public representative formulas apply.
+  change ((FiniteBilinearModule.Isometry.orthogonalQuotientEquiv
+      (H := H) f.toFiniteBilinearModule rfl).trans
+      (B.toFiniteBilinearModule.orthogonalQuotientCongr
+        (by rw [f.toFiniteBilinearModule_toAddEquiv])))
+      (A.toFiniteBilinearModule.orthogonalQuotientMk H x) = _
+  rw [
+    FiniteBilinearModule.Isometry.trans_apply,
+    FiniteBilinearModule.Isometry.orthogonalQuotientEquiv_orthogonalQuotientMk,
+    B.toFiniteBilinearModule.orthogonalQuotientCongr_orthogonalQuotientMk]
+  apply congrArg (B.toFiniteBilinearModule.orthogonalQuotientMk (H.map f.toAddEquiv))
+  exact Subtype.ext (congrArg (fun e : A ≃+ B => e (x : A))
+    f.toFiniteBilinearModule_toAddEquiv)
+
+/-- The bilinear transport, viewed on the underlying groups of the quadratic quotients. -/
+private noncomputable def orthogonalQuotientMapAddEquiv (f : Isometry A B)
+    (H : AddSubgroup A) (hH : A.IsIsotropic H)
+    (hK : B.IsIsotropic (H.map f.toAddEquiv)) :
+    A.orthogonalQuotient H hH ≃+
+      B.orthogonalQuotient (H.map f.toAddEquiv) hK := by
+  let eA : A.orthogonalQuotient H hH ≃+
+      A.toFiniteBilinearModule.orthogonalQuotient H :=
+    orthogonalQuotientUnderlyingEquiv A H hH
+  let e : A.toFiniteBilinearModule.orthogonalQuotient H ≃+
+      B.toFiniteBilinearModule.orthogonalQuotient (H.map f.toAddEquiv) :=
+    orthogonalQuotientBilinearMapAddEquiv f H
+  let eB : B.toFiniteBilinearModule.orthogonalQuotient (H.map f.toAddEquiv) ≃+
+      B.orthogonalQuotient (H.map f.toAddEquiv) hK := by
+    unfold FiniteQuadraticModule.orthogonalQuotient
+    unfold subgroupInOrthogonalComplement quotientOfLeQuadraticRadical
+    unfold FiniteBilinearModule.orthogonalQuotient
+    exact AddEquiv.refl _
+  exact (eA.trans e).trans eB
+
+@[simp]
+private theorem orthogonalQuotientMapAddEquiv_orthogonalQuotientMk (f : Isometry A B)
+    (H : AddSubgroup A) (hH : A.IsIsotropic H)
+    (hK : B.IsIsotropic (H.map f.toAddEquiv))
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    orthogonalQuotientMapAddEquiv f H hH hK (A.orthogonalQuotientMk H hH x) =
+      B.orthogonalQuotientMk (H.map f.toAddEquiv) hK
+        ⟨f (x : A), FiniteBilinearModule.Isometry.map_mem_orthogonalComplement_of_map_eq
+          A.toFiniteBilinearModule f.toFiniteBilinearModule
+          (by rw [f.toFiniteBilinearModule_toAddEquiv]) x.2⟩ := by
+  rw [orthogonalQuotientMapAddEquiv, AddEquiv.trans_apply, AddEquiv.trans_apply,
+    orthogonalQuotientUnderlyingEquiv_orthogonalQuotientMk,
+    orthogonalQuotientBilinearMapAddEquiv_orthogonalQuotientMk]
+  unfold FiniteQuadraticModule.orthogonalQuotientMk
+  unfold subgroupInOrthogonalComplement quotientOfLeQuadraticRadicalMk
+  rw [B.toFiniteBilinearModule.orthogonalQuotientMk_apply]
+  exact (Submodule.mkQ_apply _ _).symm
+
 /-- The isometry of orthogonal quotients when the target subgroup is exactly the image. -/
 private noncomputable def orthogonalQuotientMap (f : Isometry A B) (H : AddSubgroup A)
     (hH : A.IsIsotropic H) :
     Isometry (A.orthogonalQuotient H hH)
       (B.orthogonalQuotient (H.map f.toAddEquiv) ((f.isIsotropic_map_iff (H := H)).mpr hH)) where
-  toLinearEquiv := Submodule.Quotient.equiv _ _
-    (f.orthogonalComplementEquiv H).toIntLinearEquiv
-    (map_toIntSubmodule_subgroupInOrthogonalComplement f H)
+  toLinearEquiv := (orthogonalQuotientMapAddEquiv f H hH
+    ((f.isIsotropic_map_iff (H := H)).mpr hH)).toIntLinearEquiv
   map_app' q := by
     induction q using orthogonalQuotient_induction_on with
     | mk x =>
-      -- The quotient is definitionally a `Submodule.Quotient`, but its quadratic map is packaged
-      -- through two exposed finite-quadratic-module constructions.  This `change` reveals the
-      -- quotient representative without asking `rw` or `convert` to identify their distinct
-      -- inferred `Module ℤ` instances.
+      -- Normalize the reflexive coercion from an additive equivalence to its `ℤ`-linear form.
       change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
-          ((Submodule.Quotient.equiv _ _
-            (f.orthogonalComplementEquiv H).toIntLinearEquiv
-            (map_toIntSubmodule_subgroupInOrthogonalComplement f H))
-            (Submodule.Quotient.mk x)) = A.quadratic (x : A)
-      rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
-      -- After evaluating the quotient equivalence, the same representation boundary remains
-      -- between `Submodule.Quotient.mk` and the packaged `orthogonalQuotientMk`; named rewriting
-      -- cannot state that bridge without fixing the otherwise definitionally equal module instance.
-      change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
-          (B.orthogonalQuotientMk (H.map f.toAddEquiv) _
-            (f.orthogonalComplementEquiv H x)) = A.quadratic (x : A)
-      rw [B.orthogonalQuotient_quadratic_mk, coe_orthogonalComplementEquiv_apply]
+          (orthogonalQuotientMapAddEquiv f H hH _ (A.orthogonalQuotientMk H hH x)) =
+        (A.orthogonalQuotient H hH).quadratic (A.orthogonalQuotientMk H hH x)
+      rw [orthogonalQuotientMapAddEquiv_orthogonalQuotientMk,
+        B.orthogonalQuotient_quadratic_mk, A.orthogonalQuotient_quadratic_mk]
       exact f.map_app (x : A)
 
 /-- The image-subgroup transport sends the class of `x ∈ H⊥` to the class of `f x`. -/
@@ -997,16 +1028,14 @@ private theorem orthogonalQuotientMap_orthogonalQuotientMk (f : Isometry A B)
     (x : A.toFiniteBilinearModule.orthogonalComplement H) :
     f.orthogonalQuotientMap H hH (A.orthogonalQuotientMk H hH x) =
       B.orthogonalQuotientMk (H.map f.toAddEquiv) ((f.isIsotropic_map_iff (H := H)).mpr hH)
-        (f.orthogonalComplementEquiv H x) := by
-  -- Both sides are quotient representatives, but their public constructors hide distinct inferred
-  -- `Module ℤ` instances.  Crossing that opaque boundary once here lets the Mathlib quotient-map
-  -- formulas finish the proof; `rw` or `convert` cannot expose a well-typed named bridge.
-  change (Submodule.Quotient.equiv _ _
-      (f.orthogonalComplementEquiv H).toIntLinearEquiv
-      (map_toIntSubmodule_subgroupInOrthogonalComplement f H))
-      (Submodule.Quotient.mk x) = Submodule.Quotient.mk _
-  rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
-  congr 1
+        ⟨f (x : A), FiniteBilinearModule.Isometry.map_mem_orthogonalComplement_of_map_eq
+          A.toFiniteBilinearModule f.toFiniteBilinearModule
+          (by rw [f.toFiniteBilinearModule_toAddEquiv]) x.2⟩ :=
+  by
+    rw [orthogonalQuotientMap]
+    -- Normalize the reflexive coercion from the additive equivalence used by the structure field.
+    change orthogonalQuotientMapAddEquiv f H hH _ (A.orthogonalQuotientMk H hH x) = _
+    exact orthogonalQuotientMapAddEquiv_orthogonalQuotientMk f H hH _ x
 
 /-- **Transport of an orthogonal quotient along an isometry.** An isometry `f : A ≅ B` of finite
 quadratic modules carrying a quadratic-isotropic subgroup `H` of `A` onto `K` induces an isometry
@@ -1035,8 +1064,6 @@ theorem orthogonalQuotientEquiv_orthogonalQuotientMk (f : Isometry A B)
           · exact x.2⟩ := by
   rw [orthogonalQuotientEquiv, trans_apply, orthogonalQuotientMap_orthogonalQuotientMk,
     B.orthogonalQuotientCongr_orthogonalQuotientMk]
-  apply congrArg (B.orthogonalQuotientMk K _)
-  exact Subtype.ext (coe_orthogonalComplementEquiv_apply f H x)
 
 /-- **The inverse representative formula for a transported orthogonal quotient.** The inverse
 transport sends the class of `y ∈ K⊥` to the class of `f.symm y ∈ H⊥`. -/

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/RadicalQuotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/RadicalQuotient.lean
@@ -114,9 +114,14 @@ The package is exposed so that its carrier projection reduces to the `Submodule`
     exact A.pairing_comm x y
 
 /-- The quotient map onto the quotient by a subgroup of the radical. -/
-@[expose] noncomputable def quotientOfLeRadicalMk (K : AddSubgroup A) (hK : K ≤ A.radical) :
+noncomputable def quotientOfLeRadicalMk (K : AddSubgroup A) (hK : K ≤ A.radical) :
     A →+ A.quotientOfLeRadical K hK :=
   K.toIntSubmodule.mkQ.toAddMonoidHom
+
+/-- The quotient map sends an element to its quotient class. -/
+theorem quotientOfLeRadicalMk_apply (K : AddSubgroup A) (hK : K ≤ A.radical) (x : A) :
+    A.quotientOfLeRadicalMk K hK x = Submodule.Quotient.mk x :=
+  Submodule.mkQ_apply K.toIntSubmodule x
 
 /-- The quotient pairing is represented by the original pairing on representatives. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/RadicalQuotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/RadicalQuotient.lean
@@ -114,7 +114,7 @@ The package is exposed so that its carrier projection reduces to the `Submodule`
     exact A.pairing_comm x y
 
 /-- The quotient map onto the quotient by a subgroup of the radical. -/
-noncomputable def quotientOfLeRadicalMk (K : AddSubgroup A) (hK : K ≤ A.radical) :
+@[expose] noncomputable def quotientOfLeRadicalMk (K : AddSubgroup A) (hK : K ≤ A.radical) :
     A →+ A.quotientOfLeRadical K hK :=
   K.toIntSubmodule.mkQ.toAddMonoidHom
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Dual.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Dual.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.FiniteBilinearModule.OrthogonalComplement
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Complement
 public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Naturality
 
 /-!


### PR DESCRIPTION
This PR builds the orthogonal quotient of a finite bilinear module: for a subgroup `H` of a finite bilinear module `A`, restrict the pairing to `H⊥` and divide by the copy of `H` sitting inside it. The construction needs no isotropy hypothesis — `H ∩ H⊥` is always killed by the restricted pairing — and it is given here without one, so that isotropy is assumed exactly where it is used. On top of it the file proves the representative formula for the quotient pairing, the surjectivity and induction principle for the quotient map, nondegeneracy at the exact hypothesis `rad(A) ≤ H`, the order computation `|H⊥ / H| · |H|² = |A|` for a nondegenerate module and an isotropic subgroup, and the hypothesis-free triviality criterion `|H⊥ / H| = 1 ↔ H⊥ ≤ H`, refined for isotropic `H` to the Lagrangian criterion. That last statement is the module-level form of "an overlattice glued along a Lagrangian subgroup is unimodular".

The roadmap target is `TauCetiRoadmap/IntegralLattices/README.md`, Layer 4, fourth bullet, verbatim: "For isotropic `H`, define the induced form on `H^⊥/H` and construct the natural isometry `A_{L_H} ≅ H^⊥/H`, **bilinear in the integral case** and quadratic in the even case." The quadratic case is already on `main`; the bilinear case is the last unbuilt piece of Layer 4, and the module docstring of `TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean` names exactly this gap: "the bilinear analogue for a merely integral overlattice of an odd lattice needs the orthogonal quotient of a finite *bilinear* module, which the library does not yet have." This PR supplies that module-level construction. What remains for the milestone afterwards is the lattice-side comparison itself — the isometry `A_M ≅ H⊥ / H` of finite bilinear modules for a merely integral intermediate carrier `L ≤ M ≤ Lᵛ` — which consumes `FiniteBilinearModule.orthogonalQuotient` in the same way that `IntermediateCarrier.discriminantOrthogonalQuotientIsometry` consumes `FiniteQuadraticModule.orthogonalQuotient` today.

Two supporting facts about restriction go into the complement file rather than the new one, because they mention no quotient. `radical_restrict` computes the radical of a restricted pairing for an arbitrary subgroup, `rad(A|_S) = S⊥ ∩ S`; `radical_restrict_orthogonalComplement` reads it at `S = H⊥` through the double-complement formula `H⊥⊥ = H ⊔ rad(A)`; and `addSubgroupOf_orthogonalComplement_le_radical_restrict` is the inclusion which makes the quotient well defined.

The already-merged quadratic `orthogonalQuotient` is built from the same restriction and the same subgroup, so its underlying bilinear module is definitionally the construction added here. That coincidence is now recorded as `FiniteQuadraticModule.orthogonalQuotient_toFiniteBilinearModule`, and the quadratic nondegeneracy and order theorems are routed through it instead of re-deriving the radical, nondegeneracy and cardinality arguments; `subgroupInOrthogonalComplement_le_radical` becomes a restatement of the new general lemma and is deleted, and `subgroupInOrthogonalComplementEquiv` — a wrapper for Mathlib's `AddSubgroup.addSubgroupOfEquivOfLe`, used only by the order proof that is now a delegation — is deleted with it. Both deletions remove about fifty lines of duplicated proof from `Quadratic.lean`.

`FiniteBilinearModule/OrthogonalComplement.lean` moves to `FiniteBilinearModule/Orthogonal/Complement.lean` so that it and the new file share a directory rather than leaving two flat `Orthogonal*.lean` siblings. The move is otherwise content-preserving; the module table is

| old module | new module |
| --- | --- |
| `TauCeti.LinearAlgebra.FiniteBilinearModule.OrthogonalComplement` | `TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Complement` |

and the two importers, `FiniteBilinearModule/Quadratic.lean` and `IntegralLattice/Overlattice/Dual.lean`, are updated in this PR.

No Mathlib code is vendored. The construction reuses `FiniteBilinearModule.quotientOfLeRadical` and Mathlib's `AddSubgroup.addSubgroupOf`, `addSubgroupOfEquivOfLe`, `index_mul_card`, `index_eq_one` and `addSubgroupOf_eq_top`.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"finitebilinearmodule-orthogonalquotient"}-->

🤖 Prepared with Claude Code
