### PR TITLE
refactor(Exchangeability): infer array-entry measurability from row and column witnesses

### DIFF
--- a/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
@@ -174,6 +174,25 @@ theorem aemeasurable_arrayCol {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
     (hX : ∀ p, AEMeasurable (X p) μ) (j : ℕ) : AEMeasurable (arrayCol X j) μ :=
   aemeasurable_pi_lambda _ fun i => hX (i, j)
 
+/-- **A row-process witness supplies measurability of every array entry.**  The entries are the
+coordinates of the rows, and a mixed i.i.d. witness already forces those to be a.e. measurable, so
+no separate hypothesis is needed alongside one.  Stated at `MixedIIDWith`, so a conditional witness
+reaches it through `mixedIIDWith_of_conditionallyIIDWith`. -/
+theorem aemeasurable_of_mixedIIDWith_arrayRow {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure (ℕ → α)} (h : MixedIIDWith μ (arrayRow X) ν) (p : ℕ × ℕ) :
+    AEMeasurable (X p) μ := by
+  have hentry : AEMeasurable (fun ω => arrayRow X p.1 ω p.2) μ :=
+    (measurable_pi_apply p.2).comp_aemeasurable (h.aemeasurable p.1)
+  simpa [arrayRow_apply] using hentry
+
+/-- The column form of `aemeasurable_of_mixedIIDWith_arrayRow`. -/
+theorem aemeasurable_of_mixedIIDWith_arrayCol {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure (ℕ → α)} (h : MixedIIDWith μ (arrayCol X) ν) (p : ℕ × ℕ) :
+    AEMeasurable (X p) μ := by
+  have hentry : AEMeasurable (fun ω => arrayCol X p.2 ω p.1) μ :=
+    (measurable_pi_apply p.1).comp_aemeasurable (h.aemeasurable p.2)
+  simpa [arrayCol_apply] using hentry
+
 /-! ## The two array symmetries -/
 
 /-- **Separate exchangeability.** The law of the array `X` is unchanged when its two axes are

--- a/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
@@ -174,24 +174,17 @@ theorem aemeasurable_arrayCol {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
     (hX : ∀ p, AEMeasurable (X p) μ) (j : ℕ) : AEMeasurable (arrayCol X j) μ :=
   aemeasurable_pi_lambda _ fun i => hX (i, j)
 
-/-- **A row-process witness supplies measurability of every array entry.**  The entries are the
-coordinates of the rows, and a mixed i.i.d. witness already forces those to be a.e. measurable, so
-no separate hypothesis is needed alongside one.  Stated at `MixedIIDWith`, so a conditional witness
-reaches it through `mixedIIDWith_of_conditionallyIIDWith`. -/
-theorem aemeasurable_of_mixedIIDWith_arrayRow {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
-    {ν : Ω → ProbabilityMeasure (ℕ → α)} (h : MixedIIDWith μ (arrayRow X) ν) (p : ℕ × ℕ) :
-    AEMeasurable (X p) μ := by
-  have hentry : AEMeasurable (fun ω => arrayRow X p.1 ω p.2) μ :=
-    (measurable_pi_apply p.2).comp_aemeasurable (h.aemeasurable p.1)
-  simpa [arrayRow_apply] using hentry
+/-- **Entry measurability from row measurability**, the converse of `aemeasurable_arrayRow`.  The
+entries are the coordinates of the rows, so this needs no probabilistic structure; a caller holding
+a mixed or conditional witness passes its `aemeasurable`. -/
+theorem aemeasurable_entry_of_aemeasurable_arrayRow {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
+    (h : ∀ i, AEMeasurable (arrayRow X i) μ) (p : ℕ × ℕ) : AEMeasurable (X p) μ := by
+  simpa [arrayRow_apply] using (h p.1).eval p.2
 
-/-- The column form of `aemeasurable_of_mixedIIDWith_arrayRow`. -/
-theorem aemeasurable_of_mixedIIDWith_arrayCol {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
-    {ν : Ω → ProbabilityMeasure (ℕ → α)} (h : MixedIIDWith μ (arrayCol X) ν) (p : ℕ × ℕ) :
-    AEMeasurable (X p) μ := by
-  have hentry : AEMeasurable (fun ω => arrayCol X p.2 ω p.1) μ :=
-    (measurable_pi_apply p.1).comp_aemeasurable (h.aemeasurable p.2)
-  simpa [arrayCol_apply] using hentry
+/-- **Entry measurability from column measurability**, the converse of `aemeasurable_arrayCol`. -/
+theorem aemeasurable_entry_of_aemeasurable_arrayCol {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
+    (h : ∀ j, AEMeasurable (arrayCol X j) μ) (p : ℕ × ℕ) : AEMeasurable (X p) μ := by
+  simpa [arrayCol_apply] using (h p.2).eval p.1
 
 /-! ## The two array symmetries -/
 

--- a/TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean
@@ -169,11 +169,13 @@ rows of a separately exchangeable array by `σ` and the columns by `τ`, and pus
 measure forward by `τ`, leaves the joint law of the directing measure and the row process
 unchanged. -/
 theorem SeparatelyExchangeable.jointPathLaw_arrayRow_pairReindex_eq [IsFiniteMeasure μ]
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (h : SeparatelyExchangeable μ X)
     (hν : ConditionallyIIDWith μ (arrayRow X) ν) (σ τ : Equiv.Perm ℕ) :
     jointPathLaw μ (arrayRow fun p => X (σ p.1, τ p.2))
         (fun ω => (ν ω).map (fun x : ℕ → α => fun k => x (τ k)))
       = jointPathLaw μ (arrayRow X) ν := by
+  have hX := aemeasurable_of_mixedIIDWith_arrayRow
+    (mixedIIDWith_of_conditionallyIIDWith hν)
   simp only [arrayRow_eq_entries] at hν ⊢
   exact ((hν.comp_injective σ.injective).map_values
     (measurable_reindex (α := α) τ)).jointPathLaw_eq_of_pathLaw_eq hν
@@ -187,7 +189,7 @@ Rows and columns enter differently, and both asymmetries are real: the rows are 
 the conditionally i.i.d. process that `ν` directs, so permuting them does not disturb `ν`, while
 the columns are coordinates *inside* each row path, so permuting them acts on `ν`. -/
 theorem SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq [IsFiniteMeasure μ]
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (h : SeparatelyExchangeable μ X)
     (hν : ConditionallyIIDWith μ (arrayRow X) ν) (σ τ : Equiv.Perm ℕ) :
     (μ.map fun ω => ((ν ω).map (fun x : ℕ → α => fun k => x (τ k)),
         fun p : ℕ × ℕ => X (σ p.1, τ p.2) ω))
@@ -195,9 +197,13 @@ theorem SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq [IsFiniteMeasure
   have hν' : Measurable fun ω => (ν ω).map (fun x : ℕ → α => fun k => x (τ k)) :=
     (TauCeti.MeasureTheory.measurable_probabilityMeasure_map (measurable_reindex τ)).comp
       hν.measurable_directing
-  rw [← map_uncurry_jointPathLaw_arrayRow (X := fun p => X (σ p.1, τ p.2)) (fun p => hX _) hν',
-    ← map_uncurry_jointPathLaw_arrayRow hX hν.measurable_directing,
-    h.jointPathLaw_arrayRow_pairReindex_eq hX hν σ τ]
+  rw [← map_uncurry_jointPathLaw_arrayRow (X := fun p => X (σ p.1, τ p.2))
+      (fun p => aemeasurable_of_mixedIIDWith_arrayRow
+        (mixedIIDWith_of_conditionallyIIDWith hν) _) hν',
+    ← map_uncurry_jointPathLaw_arrayRow
+      (aemeasurable_of_mixedIIDWith_arrayRow (mixedIIDWith_of_conditionallyIIDWith hν))
+      hν.measurable_directing,
+    h.jointPathLaw_arrayRow_pairReindex_eq hν σ τ]
 
 /-- **Row permutations leave the row directing measure alone.** The rows are the coordinates of the
 process that `ν` directs, so a permutation of them is absorbed by conditional i.i.d.-ness.
@@ -205,23 +211,23 @@ process that `ν` directs, so a permutation of them is absorbed by conditional i
 This is `SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq` at the identity column
 permutation, whose pushforward of `ν` is the identity. -/
 theorem SeparatelyExchangeable.jointLaw_arrayRow_rowReindex_eq [IsFiniteMeasure μ]
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (h : SeparatelyExchangeable μ X)
     (hν : ConditionallyIIDWith μ (arrayRow X) ν) (σ : Equiv.Perm ℕ) :
     (μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X (σ p.1, p.2) ω))
       = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
-  have key := h.jointLaw_arrayRow_pairReindex_eq hX hν σ 1
+  have key := h.jointLaw_arrayRow_pairReindex_eq hν σ 1
   simp only [map_permReindex_one] at key
   simpa only [Equiv.Perm.coe_one, id_eq] using key
 
 /-- **Column permutations push the row directing measure forward.** This is the half of
 `SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq` that carries information about `ν`. -/
 theorem SeparatelyExchangeable.jointLaw_arrayRow_colReindex_eq [IsFiniteMeasure μ]
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (h : SeparatelyExchangeable μ X)
     (hν : ConditionallyIIDWith μ (arrayRow X) ν) (τ : Equiv.Perm ℕ) :
     (μ.map fun ω => ((ν ω).map (fun x : ℕ → α => fun k => x (τ k)),
         fun p : ℕ × ℕ => X (p.1, τ p.2) ω))
       = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) :=
-  h.jointLaw_arrayRow_pairReindex_eq hX hν 1 τ
+  h.jointLaw_arrayRow_pairReindex_eq hν 1 τ
 
 /-- **De Finetti for the rows, with the inherited joint symmetry.** Over a nonempty standard Borel
 state space a separately exchangeable array has a row directing measure whose joint law with the
@@ -238,7 +244,7 @@ theorem SeparatelyExchangeable.exists_directing_arrayRow_jointLaw_equivariant
             fun p : ℕ × ℕ => X (σ p.1, τ p.2) ω))
           = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
   obtain ⟨ν, hν⟩ := (h.conditionallyIID_arrayRow hX).exists_directing
-  exact ⟨ν, hν, fun σ τ => h.jointLaw_arrayRow_pairReindex_eq hX hν σ τ⟩
+  exact ⟨ν, hν, fun σ τ => h.jointLaw_arrayRow_pairReindex_eq hν σ τ⟩
 
 /-! ### The column directing measure -/
 
@@ -246,11 +252,13 @@ theorem SeparatelyExchangeable.exists_directing_arrayRow_jointLaw_equivariant
 transpose of `SeparatelyExchangeable.jointPathLaw_arrayRow_pairReindex_eq`: now the row permutation
 acts on the directing measure and the column permutation is absorbed. -/
 theorem SeparatelyExchangeable.jointPathLaw_arrayCol_pairReindex_eq [IsFiniteMeasure μ]
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (h : SeparatelyExchangeable μ X)
     (hν : ConditionallyIIDWith μ (arrayCol X) ν) (σ τ : Equiv.Perm ℕ) :
     jointPathLaw μ (arrayCol fun p => X (σ p.1, τ p.2))
         (fun ω => (ν ω).map (fun x : ℕ → α => fun k => x (σ k)))
       = jointPathLaw μ (arrayCol X) ν := by
+  have hX := aemeasurable_of_mixedIIDWith_arrayCol
+    (mixedIIDWith_of_conditionallyIIDWith hν)
   simp only [arrayCol_eq_entries] at hν ⊢
   exact ((hν.comp_injective τ.injective).map_values
     (measurable_reindex (α := α) σ)).jointPathLaw_eq_of_pathLaw_eq hν
@@ -259,7 +267,7 @@ theorem SeparatelyExchangeable.jointPathLaw_arrayCol_pairReindex_eq [IsFiniteMea
 /-- **Equivariance of the column directing measure.** The transpose of
 `SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq`. -/
 theorem SeparatelyExchangeable.jointLaw_arrayCol_pairReindex_eq [IsFiniteMeasure μ]
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (h : SeparatelyExchangeable μ X)
     (hν : ConditionallyIIDWith μ (arrayCol X) ν) (σ τ : Equiv.Perm ℕ) :
     (μ.map fun ω => ((ν ω).map (fun x : ℕ → α => fun k => x (σ k)),
         fun p : ℕ × ℕ => X (σ p.1, τ p.2) ω))
@@ -267,29 +275,33 @@ theorem SeparatelyExchangeable.jointLaw_arrayCol_pairReindex_eq [IsFiniteMeasure
   have hν' : Measurable fun ω => (ν ω).map (fun x : ℕ → α => fun k => x (σ k)) :=
     (TauCeti.MeasureTheory.measurable_probabilityMeasure_map (measurable_reindex σ)).comp
       hν.measurable_directing
-  rw [← map_uncurrySwap_jointPathLaw_arrayCol (X := fun p => X (σ p.1, τ p.2)) (fun p => hX _) hν',
-    ← map_uncurrySwap_jointPathLaw_arrayCol hX hν.measurable_directing,
-    h.jointPathLaw_arrayCol_pairReindex_eq hX hν σ τ]
+  rw [← map_uncurrySwap_jointPathLaw_arrayCol (X := fun p => X (σ p.1, τ p.2))
+      (fun p => aemeasurable_of_mixedIIDWith_arrayCol
+        (mixedIIDWith_of_conditionallyIIDWith hν) _) hν',
+    ← map_uncurrySwap_jointPathLaw_arrayCol
+      (aemeasurable_of_mixedIIDWith_arrayCol (mixedIIDWith_of_conditionallyIIDWith hν))
+      hν.measurable_directing,
+    h.jointPathLaw_arrayCol_pairReindex_eq hν σ τ]
 
 /-- **Row permutations push the column directing measure forward.** This is the half of
 `SeparatelyExchangeable.jointLaw_arrayCol_pairReindex_eq` that carries information about `ν`. -/
 theorem SeparatelyExchangeable.jointLaw_arrayCol_rowReindex_eq [IsFiniteMeasure μ]
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (h : SeparatelyExchangeable μ X)
     (hν : ConditionallyIIDWith μ (arrayCol X) ν) (σ : Equiv.Perm ℕ) :
     (μ.map fun ω => ((ν ω).map (fun x : ℕ → α => fun k => x (σ k)),
         fun p : ℕ × ℕ => X (σ p.1, p.2) ω))
       = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) :=
-  h.jointLaw_arrayCol_pairReindex_eq hX hν σ 1
+  h.jointLaw_arrayCol_pairReindex_eq hν σ 1
 
 /-- **Column permutations leave the column directing measure alone.** The columns are the
 coordinates of the process that `ν` directs, so a permutation of them is absorbed by conditional
 i.i.d.-ness. -/
 theorem SeparatelyExchangeable.jointLaw_arrayCol_colReindex_eq [IsFiniteMeasure μ]
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (h : SeparatelyExchangeable μ X)
     (hν : ConditionallyIIDWith μ (arrayCol X) ν) (τ : Equiv.Perm ℕ) :
     (μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X (p.1, τ p.2) ω))
       = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
-  have key := h.jointLaw_arrayCol_pairReindex_eq hX hν 1 τ
+  have key := h.jointLaw_arrayCol_pairReindex_eq hν 1 τ
   simp only [map_permReindex_one] at key
   simpa only [Equiv.Perm.coe_one, id_eq] using key
 
@@ -303,7 +315,7 @@ theorem SeparatelyExchangeable.exists_directing_arrayCol_jointLaw_equivariant
             fun p : ℕ × ℕ => X (σ p.1, τ p.2) ω))
           = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
   obtain ⟨ν, hν⟩ := (h.conditionallyIID_arrayCol hX).exists_directing
-  exact ⟨ν, hν, fun σ τ => h.jointLaw_arrayCol_pairReindex_eq hX hν σ τ⟩
+  exact ⟨ν, hν, fun σ τ => h.jointLaw_arrayCol_pairReindex_eq hν σ τ⟩
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean
@@ -174,8 +174,7 @@ theorem SeparatelyExchangeable.jointPathLaw_arrayRow_pairReindex_eq [IsFiniteMea
     jointPathLaw μ (arrayRow fun p => X (σ p.1, τ p.2))
         (fun ω => (ν ω).map (fun x : ℕ → α => fun k => x (τ k)))
       = jointPathLaw μ (arrayRow X) ν := by
-  have hX := aemeasurable_of_mixedIIDWith_arrayRow
-    (mixedIIDWith_of_conditionallyIIDWith hν)
+  have hX := aemeasurable_entry_of_aemeasurable_arrayRow hν.aemeasurable
   simp only [arrayRow_eq_entries] at hν ⊢
   exact ((hν.comp_injective σ.injective).map_values
     (measurable_reindex (α := α) τ)).jointPathLaw_eq_of_pathLaw_eq hν
@@ -197,12 +196,10 @@ theorem SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq [IsFiniteMeasure
   have hν' : Measurable fun ω => (ν ω).map (fun x : ℕ → α => fun k => x (τ k)) :=
     (TauCeti.MeasureTheory.measurable_probabilityMeasure_map (measurable_reindex τ)).comp
       hν.measurable_directing
+  have hX := aemeasurable_entry_of_aemeasurable_arrayRow hν.aemeasurable
   rw [← map_uncurry_jointPathLaw_arrayRow (X := fun p => X (σ p.1, τ p.2))
-      (fun p => aemeasurable_of_mixedIIDWith_arrayRow
-        (mixedIIDWith_of_conditionallyIIDWith hν) _) hν',
-    ← map_uncurry_jointPathLaw_arrayRow
-      (aemeasurable_of_mixedIIDWith_arrayRow (mixedIIDWith_of_conditionallyIIDWith hν))
-      hν.measurable_directing,
+      (fun p => hX _) hν',
+    ← map_uncurry_jointPathLaw_arrayRow hX hν.measurable_directing,
     h.jointPathLaw_arrayRow_pairReindex_eq hν σ τ]
 
 /-- **Row permutations leave the row directing measure alone.** The rows are the coordinates of the
@@ -257,8 +254,7 @@ theorem SeparatelyExchangeable.jointPathLaw_arrayCol_pairReindex_eq [IsFiniteMea
     jointPathLaw μ (arrayCol fun p => X (σ p.1, τ p.2))
         (fun ω => (ν ω).map (fun x : ℕ → α => fun k => x (σ k)))
       = jointPathLaw μ (arrayCol X) ν := by
-  have hX := aemeasurable_of_mixedIIDWith_arrayCol
-    (mixedIIDWith_of_conditionallyIIDWith hν)
+  have hX := aemeasurable_entry_of_aemeasurable_arrayCol hν.aemeasurable
   simp only [arrayCol_eq_entries] at hν ⊢
   exact ((hν.comp_injective τ.injective).map_values
     (measurable_reindex (α := α) σ)).jointPathLaw_eq_of_pathLaw_eq hν
@@ -275,12 +271,10 @@ theorem SeparatelyExchangeable.jointLaw_arrayCol_pairReindex_eq [IsFiniteMeasure
   have hν' : Measurable fun ω => (ν ω).map (fun x : ℕ → α => fun k => x (σ k)) :=
     (TauCeti.MeasureTheory.measurable_probabilityMeasure_map (measurable_reindex σ)).comp
       hν.measurable_directing
+  have hX := aemeasurable_entry_of_aemeasurable_arrayCol hν.aemeasurable
   rw [← map_uncurrySwap_jointPathLaw_arrayCol (X := fun p => X (σ p.1, τ p.2))
-      (fun p => aemeasurable_of_mixedIIDWith_arrayCol
-        (mixedIIDWith_of_conditionallyIIDWith hν) _) hν',
-    ← map_uncurrySwap_jointPathLaw_arrayCol
-      (aemeasurable_of_mixedIIDWith_arrayCol (mixedIIDWith_of_conditionallyIIDWith hν))
-      hν.measurable_directing,
+      (fun p => hX _) hν',
+    ← map_uncurrySwap_jointPathLaw_arrayCol hX hν.measurable_directing,
     h.jointPathLaw_arrayCol_pairReindex_eq hν σ τ]
 
 /-- **Row permutations push the column directing measure forward.** This is the half of

--- a/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
@@ -98,7 +98,8 @@ theorem mixingLaw_map_permReindex_arrayRow_eq_of_col_invariant
     {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayRow X) ν) :
     μ.map (fun ω ↦ (ν ω).map (fun x : ℕ → α => fun k => x (τ k))) = μ.map ν := by
   -- the witness gives row measurability; the entries are its coordinates
-  have hX : ∀ p : ℕ × ℕ, AEMeasurable (X p) μ := aemeasurable_of_mixedIIDWith_arrayRow hν
+  have hX : ∀ p : ℕ × ℕ, AEMeasurable (X p) μ :=
+    aemeasurable_entry_of_aemeasurable_arrayRow hν.aemeasurable
   apply mixingLaw_map_eq_of_blockLaw_map_eq hν (measurable_reindex τ)
   intro m k _
   rw [blockLaw_def, blockLaw_def]
@@ -137,7 +138,8 @@ theorem mixingLaw_map_permReindex_arrayCol_eq_of_row_invariant
     {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayCol X) ν) :
     μ.map (fun ω ↦ (ν ω).map (fun x : ℕ → α => fun k => x (σ k))) = μ.map ν := by
   -- the witness gives column measurability; the entries are its coordinates
-  have hX : ∀ p : ℕ × ℕ, AEMeasurable (X p) μ := aemeasurable_of_mixedIIDWith_arrayCol hν
+  have hX : ∀ p : ℕ × ℕ, AEMeasurable (X p) μ :=
+    aemeasurable_entry_of_aemeasurable_arrayCol hν.aemeasurable
   apply mixingLaw_map_eq_of_blockLaw_map_eq hν (measurable_reindex σ)
   intro m k _
   rw [blockLaw_def, blockLaw_def]

--- a/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
@@ -98,10 +98,7 @@ theorem mixingLaw_map_permReindex_arrayRow_eq_of_col_invariant
     {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayRow X) ν) :
     μ.map (fun ω ↦ (ν ω).map (fun x : ℕ → α => fun k => x (τ k))) = μ.map ν := by
   -- the witness gives row measurability; the entries are its coordinates
-  have hX : ∀ p : ℕ × ℕ, AEMeasurable (X p) μ := fun p => by
-    have h1 : AEMeasurable (fun ω => arrayRow X p.1 ω p.2) μ :=
-      (measurable_pi_apply p.2).comp_aemeasurable (hν.aemeasurable p.1)
-    simpa [arrayRow_apply] using h1
+  have hX : ∀ p : ℕ × ℕ, AEMeasurable (X p) μ := aemeasurable_of_mixedIIDWith_arrayRow hν
   apply mixingLaw_map_eq_of_blockLaw_map_eq hν (measurable_reindex τ)
   intro m k _
   rw [blockLaw_def, blockLaw_def]
@@ -140,10 +137,7 @@ theorem mixingLaw_map_permReindex_arrayCol_eq_of_row_invariant
     {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayCol X) ν) :
     μ.map (fun ω ↦ (ν ω).map (fun x : ℕ → α => fun k => x (σ k))) = μ.map ν := by
   -- the witness gives column measurability; the entries are its coordinates
-  have hX : ∀ p : ℕ × ℕ, AEMeasurable (X p) μ := fun p => by
-    have h1 : AEMeasurable (fun ω => arrayCol X p.2 ω p.1) μ :=
-      (measurable_pi_apply p.1).comp_aemeasurable (hν.aemeasurable p.2)
-    simpa [arrayCol_apply] using h1
+  have hX : ∀ p : ℕ × ℕ, AEMeasurable (X p) μ := aemeasurable_of_mixedIIDWith_arrayCol hν
   apply mixingLaw_map_eq_of_blockLaw_map_eq hν (measurable_reindex σ)
   intro m k _
   rw [blockLaw_def, blockLaw_def]

--- a/TauCeti/Probability/Exchangeability/Arrays/RowCoding.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/RowCoding.lean
@@ -78,17 +78,6 @@ section CodingLaw
 
 variable [StandardBorelSpace α] [Nonempty α]
 
-omit [StandardBorelSpace α] [Nonempty α] in
-/-- A row-process witness supplies measurability of every array entry. -/
-private theorem aemeasurable_entries_of_conditionallyIIDWith_arrayRow
-    {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
-    {ν : Ω → ProbabilityMeasure (ℕ → α)}
-    (h : ConditionallyIIDWith μ (arrayRow X) ν) (p : ℕ × ℕ) :
-    AEMeasurable (X p) μ := by
-  have hentry : AEMeasurable (fun ω => arrayRow X p.1 ω p.2) μ :=
-    (measurable_pi_apply p.2).comp_aemeasurable (h.aemeasurable p.1)
-  simpa [arrayRow_apply] using hentry
-
 /-- The measurable map which retains a path law and uses one independent uniform variable to
 sample each row from it. -/
 theorem measurable_arrayRowCoding :
@@ -154,7 +143,7 @@ theorem ConditionallyIIDWith.jointLaw_arrayRow_eq_arrayRowCodingLaw
     (μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω)) =
       arrayRowCodingLaw (μ.map ν) := by
   have hX : ∀ p, AEMeasurable (X p) μ :=
-    aemeasurable_entries_of_conditionallyIIDWith_arrayRow h
+    aemeasurable_of_mixedIIDWith_arrayRow (mixedIIDWith_of_conditionallyIIDWith h)
   rw [← map_uncurry_jointPathLaw_arrayRow hX h.measurable_directing,
     h.jointPathLaw_eq_map_unitIntervalCoding, arrayRowCodingLaw_def]
   have hinner : Measurable fun q : ProbabilityMeasure (ℕ → α) × (ℕ → unitInterval) =>
@@ -180,7 +169,7 @@ theorem SeparatelyExchangeable.map_pairReindex_arrayRowCodingLaw_eq
           (q.1.map (fun x : ℕ → α => fun k => x (τ k)), pairReindex σ τ q.2)) =
       arrayRowCodingLaw (μ.map ν) := by
   have hX : ∀ p, AEMeasurable (X p) μ :=
-    aemeasurable_entries_of_conditionallyIIDWith_arrayRow hν
+    aemeasurable_of_mixedIIDWith_arrayRow (mixedIIDWith_of_conditionallyIIDWith hν)
   rw [← hν.jointLaw_arrayRow_eq_arrayRowCodingLaw,
     AEMeasurable.map_map_of_aemeasurable]
   · have hfun :
@@ -195,7 +184,7 @@ theorem SeparatelyExchangeable.map_pairReindex_arrayRowCodingLaw_eq
           funext p
           simp only [pairReindex_apply]
     rw [hfun]
-    exact h.jointLaw_arrayRow_pairReindex_eq hX hν σ τ
+    exact h.jointLaw_arrayRow_pairReindex_eq hν σ τ
   · exact ((TauCeti.MeasureTheory.measurable_probabilityMeasure_map
       (measurable_reindex τ)).comp measurable_fst).prodMk
         ((measurable_pairReindex σ τ).comp measurable_snd) |>.aemeasurable

--- a/TauCeti/Probability/Exchangeability/Arrays/RowCoding.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/RowCoding.lean
@@ -143,7 +143,7 @@ theorem ConditionallyIIDWith.jointLaw_arrayRow_eq_arrayRowCodingLaw
     (μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω)) =
       arrayRowCodingLaw (μ.map ν) := by
   have hX : ∀ p, AEMeasurable (X p) μ :=
-    aemeasurable_of_mixedIIDWith_arrayRow (mixedIIDWith_of_conditionallyIIDWith h)
+    aemeasurable_entry_of_aemeasurable_arrayRow h.aemeasurable
   rw [← map_uncurry_jointPathLaw_arrayRow hX h.measurable_directing,
     h.jointPathLaw_eq_map_unitIntervalCoding, arrayRowCodingLaw_def]
   have hinner : Measurable fun q : ProbabilityMeasure (ℕ → α) × (ℕ → unitInterval) =>
@@ -169,7 +169,7 @@ theorem SeparatelyExchangeable.map_pairReindex_arrayRowCodingLaw_eq
           (q.1.map (fun x : ℕ → α => fun k => x (τ k)), pairReindex σ τ q.2)) =
       arrayRowCodingLaw (μ.map ν) := by
   have hX : ∀ p, AEMeasurable (X p) μ :=
-    aemeasurable_of_mixedIIDWith_arrayRow (mixedIIDWith_of_conditionallyIIDWith hν)
+    aemeasurable_entry_of_aemeasurable_arrayRow hν.aemeasurable
   rw [← hν.jointLaw_arrayRow_eq_arrayRowCodingLaw,
     AEMeasurable.map_map_of_aemeasurable]
   · have hfun :


### PR DESCRIPTION
The array analogue of #4306 and #4401. A witness for the *row* process forces every array *entry* to be a.e. measurable — the entries are the coordinates of the rows — so declarations carrying such a witness need not also ask for entry measurability.

```lean
theorem aemeasurable_entry_of_aemeasurable_arrayRow (h : ∀ i, AEMeasurable (arrayRow X i) μ)
    (p : ℕ × ℕ) : AEMeasurable (X p) μ
theorem aemeasurable_entry_of_aemeasurable_arrayCol (h : ∀ j, AEMeasurable (arrayCol X j) μ)
    (p : ℕ × ℕ) : AEMeasurable (X p) μ
```

These carry **no probabilistic hypothesis**: the entries are literally the coordinates of the rows, so the fact is the converse of the neighbouring `aemeasurable_arrayRow` / `aemeasurable_arrayCol` and needs no witness at all. Any caller holding a mixed or conditional witness passes its `.aemeasurable`, so both layers reach them without a conversion step.

## What changes

| file | change |
|---|---|
| `Arrays/Basic.lean` | the two lemmas |
| `Arrays/JointLaw.lean` | `hX` removed from **8** witness-consuming declarations |
| `Arrays/MixingLaw.lean` | two hand-built entry derivations replaced by the lemma |
| `Arrays/RowCoding.lean` | the private `aemeasurable_entries_of_conditionallyIIDWith_arrayRow` deleted; it is now the public lemma |

Every caller is updated here, since removing a parameter and fixing its call sites cannot be split across PRs without leaving `main` red in between.

## What keeps `hX`

The four `exists_directing_*` declarations — two in `Arrays/DeFinetti.lean`, two in `Arrays/JointLaw.lean` — carry their witness in the **conclusion**, not as a hypothesis: they start from `SeparatelyExchangeable` and *produce* a directing measure. Measurability is genuine input there, and the de Finetti step needs it before any witness exists.

The same boundary as the sequence-level cleanups: representation predicates force measurability, symmetry predicates do not. Nothing in `Basic.lean`'s `SeparatelyExchangeable` / `JointlyExchangeable` API is touched, nor the generic `map_uncurry_*` lemmas, which take no witness.

## Roadmap

Roadmap: Exchangeability

Improvement to existing code: hypotheses now implied by their neighbours are removed, and a derivation that appeared three times appears once. No roadmap target is claimed.

🤖 Directed by Cameron Freer, drafted by Opus 5

