### PR TITLE
feat: allow monomial Kostant toral symmetries

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/NumberedSymmetry.lean
@@ -487,6 +487,8 @@ theorem kostantNumberedSymmetryMatrix_conj_diagGL (basisPerm : Equiv.Perm (Fin n
             (basisDiagonal (b.baseChange A) w)) = diagGL w := by
     apply Units.ext
     rw [Units.coe_map]
+    -- The multiplicative-equivalence coercion remains folded after `Units.coe_map`; expose its
+    -- underlying `toMatrix` expression so the basis-diagonal matrix theorem applies.
     change LinearMap.toMatrix (b.baseChange A) (b.baseChange A)
         (basisDiagonal (b.baseChange A) w).toLinearMap = _
     rw [toMatrix_basisDiagonal, diagGL_coe]

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/NumberedSymmetry.lean
@@ -460,20 +460,55 @@ theorem kostantNumberedSymmetryMatrix_conj_diagGL (basisPerm : Equiv.Perm (Fin n
     kostantNumberedSymmetryMatrix M b θ hθM A * diagGL d *
         (kostantNumberedSymmetryMatrix M b θ hθM A)⁻¹ =
       diagGL (fun i => d (basisPerm⁻¹ i)) := by
-  have hinter : kostantNumberedSymmetryMatrix M b θ hθM A * diagGL d =
-      diagGL (fun i => d (basisPerm⁻¹ i)) *
-        kostantNumberedSymmetryMatrix M b θ hθM A := by
+  let Θ : (A ⊗[ℤ] M) ≃ₗ[A] (A ⊗[ℤ] M) :=
+    (AddEquiv.invariantRestrict θ.toAddEquiv M hθM).baseChange ℤ A M M
+  have hbasis' : ∀ i, AddEquiv.invariantRestrict θ.toAddEquiv M hθM (b i) =
+      basisScale i • b (basisPerm i) := by
+    intro i
+    apply Subtype.ext
+    rw [AddEquiv.coe_invariantRestrict_apply]
+    exact hbasis i
+  have hbase : ∀ i, Θ ((b.baseChange A) i) =
+      algebraMap ℤ A (basisScale i) • (b.baseChange A) (basisPerm i) :=
+    AddEquiv.baseChange_invariantRestrict_map_baseChange_basis
+      M b θ.toAddEquiv hθM basisPerm basisScale hbasis'
+  have hconj : Θ * basisDiagonal (b.baseChange A) d * Θ⁻¹ =
+      basisDiagonal (b.baseChange A) (fun i => d (basisPerm⁻¹ i)) :=
+    conj_basisDiagonal_of_map_basis (b.baseChange A) d
+      (fun i => d (basisPerm⁻¹ i)) (fun i => algebraMap ℤ A (basisScale i))
+      basisPerm Θ hbase (fun i => by simp)
+  have hmatrix := congrArg
+    (fun ψ : (A ⊗[ℤ] M) ≃ₗ[A] (A ⊗[ℤ] M) =>
+      Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv ψ)) hconj
+  have hdiag (w : Fin n → Aˣ) :
+      Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv
+            (basisDiagonal (b.baseChange A) w)) = diagGL w := by
     apply Units.ext
-    ext i j
-    simp only [Units.val_mul, diagGL_coe, Matrix.mul_diagonal, Matrix.diagonal_mul]
-    rw [coe_kostantNumberedSymmetryMatrix_apply_of_monomial
-      M b θ hθM basisPerm basisScale hbasis]
-    by_cases hij : i = basisPerm j
-    · subst i
-      simp
-      ring
-    · simp [hij]
-  rw [hinter, mul_assoc, mul_inv_cancel, mul_one]
+    rw [Units.coe_map]
+    change LinearMap.toMatrix (b.baseChange A) (b.baseChange A)
+        (basisDiagonal (b.baseChange A) w).toLinearMap = _
+    rw [toMatrix_basisDiagonal, diagGL_coe]
+  have hΘ :
+      Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
+          (LinearMap.GeneralLinearGroup.ofLinearEquiv Θ) =
+        kostantNumberedSymmetryMatrix M b θ hθM A := by
+    rw [kostantNumberedSymmetryMatrix]
+    apply Units.ext
+    simp only [Units.coe_map]
+    have hval :
+        (LinearMap.GeneralLinearGroup.ofLinearEquiv Θ : Module.End A (A ⊗[ℤ] M)) =
+          (AddEquiv.baseChangeInvariantRestrictUnit
+            (R := A) θ.toAddEquiv M hθM : Module.End A (A ⊗[ℤ] M)) := by
+      apply LinearMap.ext
+      intro z
+      rw [LinearMap.GeneralLinearGroup.coe_ofLinearEquiv,
+        AddEquiv.val_baseChangeInvariantRestrictUnit_apply]
+    exact congrArg (LinearMap.toMatrixAlgEquiv (b.baseChange A)) hval
+  simp only [LinearMap.GeneralLinearGroup.ofLinearEquiv_mul,
+    LinearMap.GeneralLinearGroup.ofLinearEquiv_inv, map_mul, map_inv] at hmatrix
+  rwa [hΘ, hdiag d, hdiag (fun i => d (basisPerm⁻¹ i))] at hmatrix
 
 /-- **A monomial-basis numbered symmetry carries the represented weight torus of a weight family
 to the weight torus of the relabelled family.** The scalar coefficients do not affect diagonal

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/NumberedSymmetry.lean
@@ -28,11 +28,13 @@ in order to inherit it:
 ```
 
 The first says that conjugation permutes the represented Kostant root subgroups without touching
-their additive parameters. The second says that when `θ` permutes the chosen lattice basis by `π`,
-conjugation carries the represented weight torus of a weight family to the weight torus of the
-relabelled family. Preserving a subgroup scheme cut out by both families additionally requires
-weight equivariance identifying that family with the original one, through a permutation of the
-torus index and `GeneralLinear.weightTorusCoordinateMap_reindex`.
+their additive parameters. The second says that when `θ` acts monomially on the chosen lattice
+basis, with coordinate permutation `π` and integral scaling coefficients, conjugation carries the
+represented weight torus of a weight family to the weight torus of the relabelled family. The
+scaling coefficients cancel from diagonal conjugation. Preserving a subgroup scheme cut out by
+both families additionally requires weight equivariance identifying that family with the original
+one, through a permutation of the torus index and
+`GeneralLinear.weightTorusCoordinateMap_reindex`.
 
 Neither identity is available from the construction of the coordinate automorphism, which goes
 through the functor of points: full faithfulness of the functor of points on commutative Hopf
@@ -58,7 +60,7 @@ weights are the weights of an admissible lattice: all of that is supplied by the
   algebra along the naturality of the matrix.
 * `kostantNumberedSymmetryCoordinateIso_hom_comp_rootSubgroupCoordinateMap`: the pinning equation
   `γ ≫ xᵢ = x_{σ i}` on coordinate algebras.
-* `kostantNumberedSymmetryCoordinateIso_hom_comp_weightTorusCoordinateMap`: a basis-permuting
+* `kostantNumberedSymmetryCoordinateIso_hom_comp_weightTorusCoordinateMap`: a monomial-basis
   symmetry carries the represented weight torus to the relabelled weight torus.
 
 All of these live in the `TauCeti.UniversalEnvelopingAlgebra` namespace.
@@ -426,48 +428,64 @@ theorem coe_kostantNumberedSymmetryMatrix_apply (A : Type v) [CommRing A] (i j :
   rw [kostantNumberedSymmetryMatrix, Units.coe_map]
   exact LinearMap.toMatrixAlgEquiv_apply (b.baseChange A) _ i j
 
-/-- **A symmetry permuting the chosen lattice basis has a permutation matrix.** This is the
-hypothesis under which conjugation normalizes the diagonal torus of `GLₙ`, and it holds for the
-coordinate permutation a Dynkin-diagram symmetry induces on Geck's lattice. -/
-theorem coe_kostantNumberedSymmetryMatrix_of_perm (basisPerm : Equiv.Perm (Fin n))
-    (hbasis : ∀ i, θ ((b i : M) : V) = ((b (basisPerm i) : M) : V))
-    (A : Type v) [CommRing A] :
-    (kostantNumberedSymmetryMatrix M b θ hθM A : Matrix (Fin n) (Fin n) A) =
-      (basisPerm⁻¹).permMatrix A := by
-  ext i j
+/-- **The matrix of a symmetry acting monomially on the chosen lattice basis.** Its `j`th column
+has the integral scaling coefficient at row `basisPerm j` and is zero elsewhere. This is the
+hypothesis under which conjugation normalizes the diagonal torus of `GLₙ`; allowing the coefficient
+is necessary for graph symmetries whose pinned lift is a signed coordinate permutation. -/
+theorem coe_kostantNumberedSymmetryMatrix_apply_of_monomial
+    (basisPerm : Equiv.Perm (Fin n)) (basisScale : Fin n → ℤ)
+    (hbasis : ∀ i, θ ((b i : M) : V) =
+      (((basisScale i) • b (basisPerm i) : M) : V))
+    (A : Type v) [CommRing A] (i j : Fin n) :
+    (kostantNumberedSymmetryMatrix M b θ hθM A : Matrix (Fin n) (Fin n) A) i j =
+      if i = basisPerm j then algebraMap ℤ A (basisScale j) else 0 := by
   rw [coe_kostantNumberedSymmetryMatrix_apply, Module.Basis.baseChange_apply]
-  have hval : (AddEquiv.baseChangeInvariantRestrictUnit
-      (R := A) θ.toAddEquiv M hθM).val ((1 : A) ⊗ₜ[ℤ] b j) = (1 : A) ⊗ₜ[ℤ] b (basisPerm j) := by
-    rw [AddEquiv.val_baseChangeInvariantRestrictUnit_tmul]
-    congr 1
-    refine Subtype.ext ?_
+  rw [AddEquiv.val_baseChangeInvariantRestrictUnit_tmul]
+  have hsub : θ.toAddEquiv.invariantRestrict M hθM (b j) =
+      (basisScale j) • b (basisPerm j) := by
+    apply Subtype.ext
     rw [AddEquiv.coe_invariantRestrict_apply]
     exact hbasis j
-  rw [hval, Module.Basis.baseChange_repr_tmul, b.repr_self, Finsupp.single_apply]
-  simp [Equiv.Perm.permMatrix, PEquiv.toMatrix_apply, Equiv.eq_symm_apply, eq_comm]
+  rw [hsub, Module.Basis.baseChange_repr_tmul]
+  simp [Finsupp.single_apply, eq_comm]
 
-/-- **Conjugating a diagonal matrix by a basis-permuting symmetry relabels its entries by the
-inverse permutation.** In particular the diagonal torus of `GLₙ` is normalized. -/
+/-- **Conjugating a diagonal matrix by a monomial basis symmetry relabels its entries by the
+inverse permutation.** The integral scaling coefficients cancel from the conjugation, so in
+particular every signed permutation normalizes the diagonal torus of `GLₙ`. -/
 theorem kostantNumberedSymmetryMatrix_conj_diagGL (basisPerm : Equiv.Perm (Fin n))
-    (hbasis : ∀ i, θ ((b i : M) : V) = ((b (basisPerm i) : M) : V))
+    (basisScale : Fin n → ℤ)
+    (hbasis : ∀ i, θ ((b i : M) : V) =
+      (((basisScale i) • b (basisPerm i) : M) : V))
     (A : Type v) [CommRing A] (d : Fin n → Aˣ) :
     kostantNumberedSymmetryMatrix M b θ hθM A * diagGL d *
         (kostantNumberedSymmetryMatrix M b θ hθM A)⁻¹ =
       diagGL (fun i => d (basisPerm⁻¹ i)) := by
-  rw [mul_diagGL_of_coe_eq_permMatrix
-      (kostantNumberedSymmetryMatrix M b θ hθM A) basisPerm⁻¹
-      (coe_kostantNumberedSymmetryMatrix_of_perm M b θ hθM basisPerm hbasis A) d,
-    mul_assoc, mul_inv_cancel, mul_one]
-  rfl
+  have hinter : kostantNumberedSymmetryMatrix M b θ hθM A * diagGL d =
+      diagGL (fun i => d (basisPerm⁻¹ i)) *
+        kostantNumberedSymmetryMatrix M b θ hθM A := by
+    apply Units.ext
+    ext i j
+    simp only [Units.val_mul, diagGL_coe, Matrix.mul_diagonal, Matrix.diagonal_mul]
+    rw [coe_kostantNumberedSymmetryMatrix_apply_of_monomial
+      M b θ hθM basisPerm basisScale hbasis]
+    by_cases hij : i = basisPerm j
+    · subst i
+      simp
+      ring
+    · simp [hij]
+  rw [hinter, mul_assoc, mul_inv_cancel, mul_one]
 
-/-- **A basis-permuting numbered symmetry carries the represented weight torus of a weight family
-to the weight torus of the relabelled family.** Stability of a closed subgroup scheme cut out by
-the root subgroups and a weight torus additionally requires identifying this relabelled family
-with the original one, via weight equivariance and
+/-- **A monomial-basis numbered symmetry carries the represented weight torus of a weight family
+to the weight torus of the relabelled family.** The scalar coefficients do not affect diagonal
+conjugation. Stability of a closed subgroup scheme cut out by the root subgroups and a weight torus
+additionally requires identifying this relabelled family with the original one, via weight
+equivariance and
 `GeneralLinear.weightTorusCoordinateMap_reindex`. -/
 theorem kostantNumberedSymmetryCoordinateIso_hom_comp_weightTorusCoordinateMap
     {ι : Type} [Finite ι] (wt : Fin n → ι → ℤ) (basisPerm : Equiv.Perm (Fin n))
-    (hbasis : ∀ i, θ ((b i : M) : V) = ((b (basisPerm i) : M) : V)) :
+    (basisScale : Fin n → ℤ)
+    (hbasis : ∀ i, θ ((b i : M) : V) =
+      (((basisScale i) • b (basisPerm i) : M) : V)) :
     (kostantNumberedSymmetryCoordinateIso M b θ hθM).hom ≫
         GeneralLinear.weightTorusCoordinateMap (R := ℤ) wt =
       GeneralLinear.weightTorusCoordinateMap (R := ℤ) (fun i => wt (basisPerm⁻¹ i)) := by
@@ -506,7 +524,8 @@ theorem kostantNumberedSymmetryCoordinateIso_hom_comp_weightTorusCoordinateMap
   have hp : toConv (f.ofConv.comp c.hom.toAlgHom) = g := by
     apply (GeneralLinear.pointsMulEquiv (R := ℤ) (A := CommAlgCat.of ℤ T) n).injective
     rw [pointsMulEquiv_comp_kostantNumberedSymmetryCoordinateIso, htorus_r, htorus_s,
-      kostantNumberedSymmetryMatrix_conj_diagGL M b θ hθM basisPerm hbasis]
+      kostantNumberedSymmetryMatrix_conj_diagGL
+        M b θ hθM basisPerm basisScale hbasis]
   have hx := congrArg (fun p => p.ofConv x) hp
   simp only [f, g, q, AlgHom.id_apply, AlgHom.comp_apply] at hx
   rw [_root_.CommHopfAlgCat.comp_apply]

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/NumberedSymmetry.lean
@@ -20,11 +20,12 @@ construction. This file makes it inherit the automorphism that a symmetry of the
 data induces on `GLₙ`.
 
 Two hypotheses are needed beyond those of the root-generated case, and they are exactly what the
-torus contributes. The rational automorphism `θ` must permute the chosen lattice basis, by a
-permutation `π` of `Fin n`; and the weights must be equivariant for `π` and a permutation `τ` of
-the torus index, `wt (π i) (τ k) = wt i k`. The conjugation is then a permutation matrix, so it
-normalizes the diagonal torus of `GLₙ`, and equivariance identifies the relabelled weight family
-with the original one. On the represented generators the resulting automorphism acts by
+torus contributes. The rational automorphism `θ` must act monomially on the chosen lattice basis,
+by a permutation `π` of `Fin n` and integral scaling coefficients; and the weights must be
+equivariant for `π` and a permutation `τ` of the torus index,
+`wt (π i) (τ k) = wt i k`. The scaling coefficients cancel from diagonal conjugation, so the
+symmetry normalizes the diagonal torus of `GLₙ`, and equivariance identifies the relabelled weight
+family with the original one. On the represented generators the resulting automorphism acts by
 
 ```text
 γ ∘ xᵢ = x_{σ i},        γ ∘ (weight torus) = (weight torus) ∘ relabel(τ⁻¹),
@@ -41,7 +42,8 @@ including into `GLₙ` is that same matrix conjugation.
 
 Both hypotheses hold for the coordinate permutation that a Dynkin-diagram symmetry induces on
 Geck's lattice: it permutes the coordinate basis by the induced permutation of the Cartan
-coordinates and of the roots, and it permutes the Geck weights contragrediently.
+coordinates and of the roots, and it permutes the Geck weights contragrediently. Allowing monomial
+basis actions also covers pinned lifts, such as the doubled `E₆` symmetry, that require signs.
 
 Nothing here assumes that `σ` or `τ` comes from a diagram symmetry, that the weights are those of
 an admissible lattice, or that the carrier is reductive.
@@ -107,7 +109,9 @@ variable (hθe : ∀ i, ∀ v : V,
     ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e (σ i))) (θ v))
 variable (hσ : Function.Surjective σ)
 variable (basisPerm : Equiv.Perm (Fin n))
-variable (hbasis : ∀ i, θ ((b i : M) : V) = ((b (basisPerm i) : M) : V))
+variable (basisScale : Fin n → ℤ)
+variable (hbasis : ∀ i, θ ((b i : M) : V) =
+  (((basisScale i) • b (basisPerm i) : M) : V))
 variable (torusPerm : Equiv.Perm κ)
 variable (hwt : ∀ i k, wt (basisPerm i) (torusPerm k) = wt i k)
 
@@ -130,7 +134,7 @@ private theorem kostantNumberedSymmetryCoordinateIso_hom_comp_weightTorus :
       GeneralLinear.weightTorusCoordinateMap (R := ℤ) wt ≫
         SplitTorus.relabelCoordinateMap ℤ torusPerm⁻¹ := by
   rw [kostantNumberedSymmetryCoordinateIso_hom_comp_weightTorusCoordinateMap
-    M b θ hθM wt basisPerm hbasis,
+    M b θ hθM wt basisPerm basisScale hbasis,
     weight_comp_basisPerm_symm wt basisPerm torusPerm hwt,
     GeneralLinear.weightTorusCoordinateMap_reindex]
 
@@ -148,7 +152,7 @@ private theorem kostantToralDefiningIdeal_comapOfSurjective_numberedSymmetryCoor
   · rw [kostantNumberedSymmetryCoordinateIso_hom_comp_rootSubgroupCoordinateMap
       e h ρ M hM hnil b σ θ hθM hθe (Function.surjInv hσ i), Function.surjInv_eq hσ]
   · exact kostantNumberedSymmetryCoordinateIso_hom_comp_weightTorus
-      M b wt θ hθM basisPerm hbasis torusPerm hwt
+      M b wt θ hθM basisPerm basisScale hbasis torusPerm hwt
 
 include hθe hbasis hwt in
 /-- The inverse ambient symmetry pulls the toral defining ideal into itself. -/
@@ -167,7 +171,7 @@ private theorem kostantToralDefiningIdeal_comapOfSurjective_numberedSymmetryCoor
   · rw [← cancel_epi c.hom]
     simp only [← Category.assoc, c.hom_inv_id, Category.id_comp]
     rw [kostantNumberedSymmetryCoordinateIso_hom_comp_weightTorus
-        M b wt θ hθM basisPerm hbasis torusPerm hwt,
+        M b wt θ hθM basisPerm basisScale hbasis torusPerm hwt,
       Category.assoc, SplitTorus.relabelCoordinateMap_comp, mul_inv_cancel,
       SplitTorus.relabelCoordinateMap_one, Category.comp_id]
 
@@ -185,10 +189,10 @@ private theorem kostantToralDefiningIdeal_comapOfSurjective_numberedSymmetryCoor
   let J := kostantToralDefiningIdeal e h ρ M hM hnil b wt
   have hhom : J.comapOfSurjective c.hom.hom (ConcreteCategory.bijective_of_isIso c.hom).2 ≤ J :=
     kostantToralDefiningIdeal_comapOfSurjective_numberedSymmetryCoordinateIso_hom_le
-      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt
+      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt
   have hinv : J.comapOfSurjective c.inv.hom (ConcreteCategory.bijective_of_isIso c.inv).2 ≤ J :=
     kostantToralDefiningIdeal_comapOfSurjective_numberedSymmetryCoordinateIso_inv_le
-      e h ρ M hM hnil b wt σ θ hθM hθe basisPerm hbasis torusPerm hwt
+      e h ρ M hM hnil b wt σ θ hθM hθe basisPerm basisScale hbasis torusPerm hwt
   exact HopfIdeal.comapOfSurjective_eq_of_hom_le_of_inv_le c J hhom hinv
 
 include hθe hσ hbasis hwt in
@@ -202,7 +206,7 @@ private noncomputable def kostantToralCoordinateNumberedSymmetryIso :
     (kostantNumberedSymmetryCoordinateIso M b θ hθM)
     (kostantToralDefiningIdeal e h ρ M hM hnil b wt)
     (kostantToralDefiningIdeal_comapOfSurjective_numberedSymmetryCoordinateIso
-      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt)
+      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt)
 
 include hθe hσ hbasis hwt in
 /-- The quotient coordinate automorphism is induced by the ambient coordinate automorphism. -/
@@ -210,7 +214,7 @@ private theorem mkQuotient_comp_kostantToralCoordinateNumberedSymmetryIso_hom :
     CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ n)
           (kostantToralDefiningIdeal e h ρ M hM hnil b wt) ≫
         (kostantToralCoordinateNumberedSymmetryIso
-          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).hom =
+          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).hom =
       (kostantNumberedSymmetryCoordinateIso M b θ hθM).hom ≫
         CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ n)
           (kostantToralDefiningIdeal e h ρ M hM hnil b wt) := by
@@ -218,13 +222,13 @@ private theorem mkQuotient_comp_kostantToralCoordinateNumberedSymmetryIso_hom :
     (kostantNumberedSymmetryCoordinateIso M b θ hθM)
     (kostantToralDefiningIdeal e h ρ M hM hnil b wt)
     (kostantToralDefiningIdeal_comapOfSurjective_numberedSymmetryCoordinateIso
-      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt)
+      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt)
 
 include hθe hσ hbasis hwt in
 /-- The quotient coordinate automorphism permutes the factored root-subgroup maps. -/
 private theorem kostantToralCoordinateNumberedSymmetryIso_hom_comp_rootMap (i : I) :
     (kostantToralCoordinateNumberedSymmetryIso
-        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).hom ≫
+        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).hom ≫
       kostantRootSubgroupToralCoordinateMap e h ρ M hM hnil b wt i =
       kostantRootSubgroupToralCoordinateMap e h ρ M hM hnil b wt (σ i) := by
   have hr : (kostantToralDefiningIdeal e h ρ M hM hnil b wt).toIdeal ≤ RingHom.ker
@@ -234,7 +238,7 @@ private theorem kostantToralCoordinateNumberedSymmetryIso_hom_comp_rootMap (i : 
     (kostantToralDefiningIdeal e h ρ M hM hnil b wt)
     (kostantRootSubgroupCoordinateMap e h ρ M hM (σ i) (hnil (σ i)) b) hr
     ((kostantToralCoordinateNumberedSymmetryIso
-        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).hom ≫
+        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).hom ≫
       kostantRootSubgroupToralCoordinateMap e h ρ M hM hnil b wt i) (by
         rw [← Category.assoc,
           mkQuotient_comp_kostantToralCoordinateNumberedSymmetryIso_hom,
@@ -253,7 +257,7 @@ include hθe hσ hbasis hwt in
 composed with the relabelling attached to the torus permutation. -/
 private theorem kostantToralCoordinateNumberedSymmetryIso_hom_comp_torusMap :
     (kostantToralCoordinateNumberedSymmetryIso
-        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).hom ≫
+        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).hom ≫
       kostantWeightTorusToralCoordinateMap e h ρ M hM hnil b wt =
       kostantWeightTorusToralCoordinateMap e h ρ M hM hnil b wt ≫
         SplitTorus.relabelCoordinateMap ℤ torusPerm⁻¹ := by
@@ -273,13 +277,13 @@ private theorem kostantToralCoordinateNumberedSymmetryIso_hom_comp_torusMap :
     (GeneralLinear.weightTorusCoordinateMap (R := ℤ) wt ≫
       SplitTorus.relabelCoordinateMap ℤ torusPerm⁻¹) hr
     ((kostantToralCoordinateNumberedSymmetryIso
-        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).hom ≫
+        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).hom ≫
       kostantWeightTorusToralCoordinateMap e h ρ M hM hnil b wt) (by
         rw [← Category.assoc,
           mkQuotient_comp_kostantToralCoordinateNumberedSymmetryIso_hom,
           Category.assoc, mkQuotient_comp_kostantWeightTorusToralCoordinateMap]
         exact kostantNumberedSymmetryCoordinateIso_hom_comp_weightTorus
-          M b wt θ hθM basisPerm hbasis torusPerm hwt)
+          M b wt θ hθM basisPerm basisScale hbasis torusPerm hwt)
   have hright := CommHopfAlgCat.liftQuotient_unique
     (kostantToralDefiningIdeal e h ρ M hM hnil b wt)
     (GeneralLinear.weightTorusCoordinateMap (R := ℤ) wt ≫
@@ -292,12 +296,12 @@ private theorem kostantToralCoordinateNumberedSymmetryIso_hom_comp_torusMap :
 
 include hθe hσ hbasis hwt in
 /-- **The automorphism of the Kostant toral-closure group scheme induced by a numbered symmetry
-which permutes the chosen lattice basis compatibly with the weights.** -/
+which acts monomially on the chosen lattice basis compatibly with the weights.** -/
 noncomputable def kostantToralNumberedSymmetryIso :
     Aut (kostantToralGroupScheme e h ρ M hM hnil b wt) :=
   (AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).mapIso
     (kostantToralCoordinateNumberedSymmetryIso
-      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).op
+      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).op
 
 include hθe hσ hbasis hwt in
 /-- The toral symmetry carries the `i`th root subgroup to the one numbered `σ i`, without changing
@@ -306,7 +310,7 @@ its additive parameter. -/
 theorem kostantRootSubgroupToToral_comp_numberedSymmetryIso_hom (i : I) :
     kostantRootSubgroupToToral e h ρ M hM hnil b wt i ≫
         (kostantToralNumberedSymmetryIso
-          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).hom =
+          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).hom =
       kostantRootSubgroupToToral e h ρ M hM hnil b wt (σ i) := by
   rw [kostantRootSubgroupToToral_def, kostantToralNumberedSymmetryIso,
     Functor.mapIso_hom, Iso.op_hom, Category.assoc, ← Functor.map_comp, ← op_comp,
@@ -319,12 +323,12 @@ include hθe hσ hbasis hwt in
 theorem kostantRootSubgroupToToral_comp_numberedSymmetryIso_inv (i : I) :
     kostantRootSubgroupToToral e h ρ M hM hnil b wt (σ i) ≫
         (kostantToralNumberedSymmetryIso
-          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).inv =
+          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).inv =
       kostantRootSubgroupToToral e h ρ M hM hnil b wt i := by
   rw [← kostantRootSubgroupToToral_comp_numberedSymmetryIso_hom
-    e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt i,
+    e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt i,
     Category.assoc, (kostantToralNumberedSymmetryIso
-      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).hom_inv_id,
+      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).hom_inv_id,
     Category.comp_id]
 
 include hθe hσ hbasis hwt in
@@ -334,7 +338,7 @@ attached to the torus permutation. -/
 theorem kostantWeightTorusToToral_comp_numberedSymmetryIso_hom :
     kostantWeightTorusToToral e h ρ M hM hnil b wt ≫
         (kostantToralNumberedSymmetryIso
-          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).hom =
+          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).hom =
       SplitTorus.relabel ℤ torusPerm⁻¹ ≫
         kostantWeightTorusToToral e h ρ M hM hnil b wt := by
   rw [kostantWeightTorusToToral_def, kostantToralNumberedSymmetryIso,
@@ -349,16 +353,16 @@ include hθe hσ hbasis hwt in
 theorem kostantWeightTorusToToral_comp_numberedSymmetryIso_inv :
     kostantWeightTorusToToral e h ρ M hM hnil b wt ≫
         (kostantToralNumberedSymmetryIso
-          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).inv =
+          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).inv =
       SplitTorus.relabel ℤ torusPerm ≫
         kostantWeightTorusToToral e h ρ M hM hnil b wt := by
   let γ := kostantToralNumberedSymmetryIso
-    e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt
+    e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt
   have hhom : kostantWeightTorusToToral e h ρ M hM hnil b wt ≫ γ.hom =
       SplitTorus.relabel ℤ torusPerm⁻¹ ≫
         kostantWeightTorusToToral e h ρ M hM hnil b wt :=
     kostantWeightTorusToToral_comp_numberedSymmetryIso_hom
-      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt
+      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt
   -- The local abbreviation `γ` hides the inverse field of the bundled automorphism; expose it
   -- before applying the categorical inverse identities below.
   change kostantWeightTorusToToral e h ρ M hM hnil b wt ≫ γ.inv = _
@@ -382,7 +386,7 @@ from the generated carrier into the toral closure. -/
 theorem kostantGeneratedToToral_comp_numberedSymmetryIso_hom :
     kostantGeneratedToToral e h ρ M hM hnil b wt ≫
         (kostantToralNumberedSymmetryIso
-          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt).hom =
+          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt).hom =
       (kostantGeneratedNumberedSymmetryIso
         e h ρ M hM hnil b σ θ hθM hθe hσ).hom ≫
         kostantGeneratedToToral e h ρ M hM hnil b wt := by
@@ -401,14 +405,14 @@ the corresponding iterate of `σ`. -/
 theorem kostantRootSubgroupToToral_comp_numberedSymmetryIso_pow_hom (m : ℕ) (i : I) :
     kostantRootSubgroupToToral e h ρ M hM hnil b wt i ≫
         ((kostantToralNumberedSymmetryIso
-          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt) ^ m).hom =
+          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt) ^ m).hom =
       kostantRootSubgroupToToral e h ρ M hM hnil b wt ((σ^[m]) i) := by
   exact TauCeti.CategoryTheory.comp_aut_pow_hom_of_comp
     (kostantToralNumberedSymmetryIso
-      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt)
+      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt)
     (kostantRootSubgroupToToral e h ρ M hM hnil b wt) σ
     (kostantRootSubgroupToToral_comp_numberedSymmetryIso_hom
-      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt) m i
+      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt) m i
 
 include hθe hσ hbasis hwt in
 /-- Iterating the toral symmetry acts on the weight torus by the corresponding power of the
@@ -417,11 +421,11 @@ relabelling. -/
 theorem kostantWeightTorusToToral_comp_numberedSymmetryIso_pow_hom (m : ℕ) :
     kostantWeightTorusToToral e h ρ M hM hnil b wt ≫
         ((kostantToralNumberedSymmetryIso
-          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt) ^ m).hom =
+          e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt) ^ m).hom =
       SplitTorus.relabel ℤ (torusPerm⁻¹ ^ m) ≫
         kostantWeightTorusToToral e h ρ M hM hnil b wt := by
   let γ := kostantToralNumberedSymmetryIso
-    e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt
+    e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt
   let F : ℕ → (SplitTorus.groupScheme ℤ κ ⟶
       kostantToralGroupScheme e h ρ M hM hnil b wt) := fun r =>
     SplitTorus.relabel ℤ (torusPerm⁻¹ ^ r) ≫
@@ -444,7 +448,7 @@ therefore produces a symmetry with `γ ^ 2 = 1` or `γ ^ 3 = 1`. -/
 theorem kostantToralNumberedSymmetryIso_pow_eq_one (m : ℕ)
     (hσm : σ^[m] = id) (hτm : torusPerm ^ m = 1) :
     (kostantToralNumberedSymmetryIso
-      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt) ^ m = 1 := by
+      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt) ^ m = 1 := by
   apply Iso.ext
   refine kostantToralGroupScheme_hom_ext e h ρ M hM hnil b wt _ _ (fun i => ?_) ?_
   · rw [kostantRootSubgroupToToral_comp_numberedSymmetryIso_pow_hom, hσm, id_eq]
@@ -468,7 +472,7 @@ private theorem mem_kostantToralDefiningIdeal_numberedSymmetryCoordinateIso_iff
         kostantToralDefiningIdeal e h ρ M hM hnil b wt ↔
       x ∈ kostantToralDefiningIdeal e h ρ M hM hnil b wt := by
   conv_rhs => rw [← kostantToralDefiningIdeal_comapOfSurjective_numberedSymmetryCoordinateIso
-    e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt]
+    e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt]
   rw [HopfIdeal.mem_comapOfSurjective]
 
 include hθe hσ hbasis hwt in
@@ -511,11 +515,11 @@ theorem conj_kostantNumberedSymmetryMatrix_mem_kostantToralPointsSubgroup_iff
     obtain ⟨y, rfl⟩ := hsurj x
     exact (hval y).symm.trans (hall y
       ((mem_kostantToralDefiningIdeal_numberedSymmetryCoordinateIso_iff
-        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt y).1 hx))
+        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt y).1 hx))
   · intro hall x hx
     exact (hval x).trans (hall _
       ((mem_kostantToralDefiningIdeal_numberedSymmetryCoordinateIso_iff
-        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt x).2 hx))
+        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt x).2 hx))
 
 include hθe hσ hbasis hwt in
 /-- **The matrix of a numbered symmetry normalizes the algebra-valued points of the toral
@@ -534,7 +538,7 @@ theorem map_kostantToralPointsSubgroup_conj_numberedSymmetryMatrix (A : Type v) 
     group
   refine Iff.symm (Iff.trans ?_
     (conj_kostantNumberedSymmetryMatrix_mem_kostantToralPointsSubgroup_iff
-      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt A
+      e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt A
       ((kostantNumberedSymmetryMatrix M b θ hθM A)⁻¹ * g *
         kostantNumberedSymmetryMatrix M b θ hθM A)))
   rw [hg]
@@ -580,12 +584,12 @@ private theorem kostantToralSchemePointMulEquiv_comp_numberedSymmetryIso (A : Ty
     (q : WithConv (CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ n)
       (kostantToralDefiningIdeal e h ρ M hM hnil b wt) →ₐ[ℤ] A)) :
     kostantToralSchemePointMulEquiv e h ρ M hM hnil b wt A q ≫
-        (kostantToralNumberedSymmetryIso e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis
-          torusPerm hwt).hom.hom.hom =
+        (kostantToralNumberedSymmetryIso e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm
+          basisScale hbasis torusPerm hwt).hom.hom.hom =
       kostantToralSchemePointMulEquiv e h ρ M hM hnil b wt A
         ((CommHopfAlgCat.mapPointsFunctor
           (kostantToralCoordinateNumberedSymmetryIso e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm
-            hbasis torusPerm hwt).hom).app (CommAlgCat.of ℤ A) q) := by
+            basisScale hbasis torusPerm hwt).hom).app (CommAlgCat.of ℤ A) q) := by
   rw [kostantToralNumberedSymmetryIso, Functor.mapIso_hom, Iso.op_hom]
   exact CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain (R := ℤ) A
     (kostantToralGroupScheme_eq_hopfSpec e h ρ M hM hnil b wt)
@@ -595,7 +599,7 @@ private theorem kostantToralSchemePointMulEquiv_comp_numberedSymmetryIso (A : Ty
     (kostantToralSchemePointMulEquiv_apply_left e h ρ M hM hnil b wt A)
     (kostantToralSchemePointMulEquiv_apply_left e h ρ M hM hnil b wt A)
     (kostantToralCoordinateNumberedSymmetryIso e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm
-      hbasis torusPerm hwt).hom q
+      basisScale hbasis torusPerm hwt).hom q
 
 /-- Including a scheme-valued point of the toral closure into `GLₙ` precomposes its algebra point
 with the quotient coordinate map. -/
@@ -648,8 +652,8 @@ theorem schemePointsMulEquiv_kostantToralNumberedSymmetryIso (A : Type) [CommRin
     (p : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
       (kostantToralGroupScheme e h ρ M hM hnil b wt).X) :
     GeneralLinear.schemePointsMulEquiv n A
-        (p ≫ (kostantToralNumberedSymmetryIso e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis
-              torusPerm hwt).hom.hom.hom ≫
+        (p ≫ (kostantToralNumberedSymmetryIso e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm
+              basisScale hbasis torusPerm hwt).hom.hom.hom ≫
           (kostantToralGroupSchemeι e h ρ M hM hnil b wt).hom.hom) =
       kostantNumberedSymmetryMatrix M b θ hθM A *
           GeneralLinear.schemePointsMulEquiv n A
@@ -657,7 +661,7 @@ theorem schemePointsMulEquiv_kostantToralNumberedSymmetryIso (A : Type) [CommRin
         (kostantNumberedSymmetryMatrix M b θ hθM A)⁻¹ := by
   obtain ⟨q, rfl⟩ := (kostantToralSchemePointMulEquiv e h ρ M hM hnil b wt A).surjective p
   have hsym := kostantToralSchemePointMulEquiv_comp_numberedSymmetryIso
-    e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt A q
+    e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt A q
   have hsymι := congrArg
     (fun f => f ≫ (kostantToralGroupSchemeι e h ρ M hM hnil b wt).hom.hom) hsym
   have hincl := schemePointsMulEquiv_kostantToralSchemePointMulEquiv_comp_toralGroupSchemeι
@@ -666,7 +670,7 @@ theorem schemePointsMulEquiv_kostantToralNumberedSymmetryIso (A : Type) [CommRin
     e h ρ M hM hnil b wt A
     ((CommHopfAlgCat.mapPointsFunctor
       (kostantToralCoordinateNumberedSymmetryIso e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm
-        hbasis torusPerm hwt).hom).app (CommAlgCat.of ℤ A) q)
+        basisScale hbasis torusPerm hwt).hom).app (CommAlgCat.of ℤ A) q)
   rw [← Category.assoc, hsymι, hinclSym, hincl]
   -- The quotient coordinate automorphism is induced by the ambient one, so precomposing a point
   -- with it and then with the quotient map is precomposing with the ambient automorphism.
@@ -675,7 +679,7 @@ theorem schemePointsMulEquiv_kostantToralNumberedSymmetryIso (A : Type) [CommRin
           (kostantToralDefiningIdeal e h ρ M hM hnil b wt))).app (CommAlgCat.of ℤ A)
         ((CommHopfAlgCat.mapPointsFunctor
           (kostantToralCoordinateNumberedSymmetryIso e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm
-            hbasis torusPerm hwt).hom).app (CommAlgCat.of ℤ A) q) =
+            basisScale hbasis torusPerm hwt).hom).app (CommAlgCat.of ℤ A) q) =
       (CommHopfAlgCat.mapPointsFunctor
         (kostantNumberedSymmetryCoordinateIso M b θ hθM).hom).app (CommAlgCat.of ℤ A)
         ((CommHopfAlgCat.mapPointsFunctor
@@ -685,7 +689,7 @@ theorem schemePointsMulEquiv_kostantToralNumberedSymmetryIso (A : Type) [CommRin
     ext z
     exact congrArg (fun f => q.ofConv (f.hom z))
       (mkQuotient_comp_kostantToralCoordinateNumberedSymmetryIso_hom
-        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm hbasis torusPerm hwt)
+        e h ρ M hM hnil b wt σ θ hθM hθe hσ basisPerm basisScale hbasis torusPerm hwt)
   rw [hpoint]
   exact pointsMulEquiv_mapPointsFunctor_kostantNumberedSymmetryCoordinateIso M b θ hθM
     (CommAlgCat.of ℤ A) _

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/NumberedSymmetry.lean
@@ -43,7 +43,8 @@ including into `GLₙ` is that same matrix conjugation.
 Both hypotheses hold for the coordinate permutation that a Dynkin-diagram symmetry induces on
 Geck's lattice: it permutes the coordinate basis by the induced permutation of the Cartan
 coordinates and of the roots, and it permutes the Geck weights contragrediently. Allowing monomial
-basis actions also covers pinned lifts, such as the doubled `E₆` symmetry, that require signs.
+basis actions also covers pinned lifts, such as the graph symmetry used for `²E₆`, that require
+signs.
 
 Nothing here assumes that `σ` or `τ` comes from a diagram symmetry, that the weights are those of
 an admissible lattice, or that the carrier is reductive.

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
@@ -124,18 +124,6 @@ private theorem geckDiagramModuleEquiv_ι_geckRepresentation_rootGenerator
     simpa only [_root_.UniversalEnvelopingAlgebra.ι_apply] using
       t.geckDiagramModuleEquiv_geckRepresentation_rootGenerator ht hsigma i v
 
-/-- The Geck-module symmetry is monomial in the coordinate basis, with every scaling coefficient
-equal to one. -/
-private theorem geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial
-    (hsigma : sigma ∈ t.diagramSymmetry) (i : Fin (t.geckDim ht)) :
-    t.geckDiagramModuleEquiv ht hsigma
-        (((t.geckCoordinateBasisFin ht) i : t.geckCoordinateLattice ht) :
-          t.GeckIndex ht → ℚ) =
-      (((1 : ℤ) • (t.geckCoordinateBasisFin ht) (t.geckDiagramFinPerm ht hsigma i) :
-          t.geckCoordinateLattice ht) : t.GeckIndex ht → ℚ) := by
-  simp only [one_smul]
-  exact t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma i
-
 /-- The Kostant toral-closure symmetry of the pinned Geck data. -/
 private def toralGraphAut (hsigma : sigma ∈ t.diagramSymmetry) :
     Aut (TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupScheme
@@ -156,7 +144,9 @@ private def toralGraphAut (hsigma : sigma ∈ t.diagramSymmetry) :
     (diagramRootGeneratorPerm sigma).surjective
     (t.geckDiagramFinPerm ht hsigma)
     (fun _ => 1)
-    (geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial ht hsigma)
+    (fun i => by
+      simpa only [one_smul] using
+        t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma i)
     sigma (t.geckWeightFin_geckDiagramFinPerm ht hsigma)
 
 /-- **The graph automorphism of the pinned Geck carrier** attached to a symmetry of its
@@ -264,7 +254,9 @@ theorem coe_geckGraphAutMatrix (hsigma : sigma ∈ t.diagramSymmetry) (A : Type 
   rw [geckGraphAutMatrix]
   rw [UniversalEnvelopingAlgebra.coe_kostantNumberedSymmetryMatrix_apply_of_monomial _ _ _ _
       (t.geckDiagramFinPerm ht hsigma) (fun _ => 1)
-      (geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial ht hsigma) A i j]
+      (fun k => by
+        simpa only [one_smul] using
+          t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma k) A i j]
   simp [Equiv.Perm.permMatrix, PEquiv.toMatrix_apply, Equiv.eq_symm_apply, eq_comm]
 
 /-- The matrix of the pinned Geck coordinate permutation commutes with extension of the value
@@ -321,7 +313,9 @@ theorem map_geckPoints_conj_geckGraphAutMatrix (hsigma : sigma ∈ t.diagramSymm
     (diagramRootGeneratorPerm sigma).surjective
     (t.geckDiagramFinPerm ht hsigma)
     (fun _ => 1)
-    (geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial ht hsigma)
+    (fun i => by
+      simpa only [one_smul] using
+        t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma i)
     sigma (t.geckWeightFin_geckDiagramFinPerm ht hsigma) A
 
 /-- The matrix of the pinned coordinate permutation, as an element of the normalizer of the points
@@ -399,7 +393,9 @@ theorem schemePointsMulEquiv_geckGraphAut_comp_geckGroupSchemeι
       (diagramRootGeneratorPerm sigma).surjective
       (t.geckDiagramFinPerm ht hsigma)
       (fun _ => 1)
-      (geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial ht hsigma)
+      (fun i => by
+        simpa only [one_smul] using
+          t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma i)
       sigma (t.geckWeightFin_geckDiagramFinPerm ht hsigma) A
       (p ≫ (eqToHom (t.geckGroupScheme_def ht)).hom.hom)
 
@@ -459,7 +455,9 @@ theorem geckGraphAutPoints_geckTorusMatrix (hsigma : sigma ∈ t.diagramSymmetry
     (t.geckDiagramModuleEquiv_mem_geckCoordinateLattice_iff ht hsigma)
     (t.geckDiagramFinPerm ht hsigma)
     (fun _ => 1)
-    (geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial ht hsigma) A
+    (fun i => by
+      simpa only [one_smul] using
+        t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma i) A
     (fun i => torusCharacter s (t.geckWeightFin ht i))
   refine Subtype.ext ?_
   rw [coe_geckGraphAutPoints]

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
@@ -124,6 +124,18 @@ private theorem geckDiagramModuleEquiv_ι_geckRepresentation_rootGenerator
     simpa only [_root_.UniversalEnvelopingAlgebra.ι_apply] using
       t.geckDiagramModuleEquiv_geckRepresentation_rootGenerator ht hsigma i v
 
+/-- The Geck-module symmetry is monomial in the coordinate basis, with every scaling coefficient
+equal to one. -/
+private theorem geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial
+    (hsigma : sigma ∈ t.diagramSymmetry) (i : Fin (t.geckDim ht)) :
+    t.geckDiagramModuleEquiv ht hsigma
+        (((t.geckCoordinateBasisFin ht) i : t.geckCoordinateLattice ht) :
+          t.GeckIndex ht → ℚ) =
+      (((1 : ℤ) • (t.geckCoordinateBasisFin ht) (t.geckDiagramFinPerm ht hsigma i) :
+          t.geckCoordinateLattice ht) : t.GeckIndex ht → ℚ) := by
+  simp only [one_smul]
+  exact t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma i
+
 /-- The Kostant toral-closure symmetry of the pinned Geck data. -/
 private def toralGraphAut (hsigma : sigma ∈ t.diagramSymmetry) :
     Aut (TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupScheme
@@ -143,7 +155,8 @@ private def toralGraphAut (hsigma : sigma ∈ t.diagramSymmetry) :
     (geckDiagramModuleEquiv_ι_geckRepresentation_rootGenerator ht hsigma)
     (diagramRootGeneratorPerm sigma).surjective
     (t.geckDiagramFinPerm ht hsigma)
-    (t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma)
+    (fun _ => 1)
+    (geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial ht hsigma)
     sigma (t.geckWeightFin_geckDiagramFinPerm ht hsigma)
 
 /-- **The graph automorphism of the pinned Geck carrier** attached to a symmetry of its
@@ -218,7 +231,7 @@ theorem geckGraphAut_pow_eq_one (hsigma : sigma ∈ t.diagramSymmetry) {m : ℕ}
   have hgen : diagramRootGeneratorPerm sigma ^ m = 1 := diagramRootGeneratorPerm_pow_eq_one hm
   have htoral : toralGraphAut ht hsigma ^ m = 1 :=
     TauCeti.UniversalEnvelopingAlgebra.kostantToralNumberedSymmetryIso_pow_eq_one _ _ _ _ _ _ _ _
-      _ _ _ _ _ _ _ _ _ m (by rw [← Equiv.Perm.coe_pow, hgen]; rfl) hm
+      _ _ _ _ _ _ _ _ _ _ m (by rw [← Equiv.Perm.coe_pow, hgen]; rfl) hm
   rw [geckGraphAut, ← map_pow, htoral, map_one]
 
 /-- The identity symmetry of the diagram gives the identity automorphism of the Geck carrier. -/
@@ -246,9 +259,13 @@ finite-ordinal coordinate permutation. -/
 theorem coe_geckGraphAutMatrix (hsigma : sigma ∈ t.diagramSymmetry) (A : Type v) [CommRing A] :
     (t.geckGraphAutMatrix ht hsigma A :
         Matrix (Fin (t.geckDim ht)) (Fin (t.geckDim ht)) A) =
-      (t.geckDiagramFinPerm ht hsigma)⁻¹.permMatrix A :=
-  TauCeti.UniversalEnvelopingAlgebra.coe_kostantNumberedSymmetryMatrix_of_perm _ _ _ _
-    (t.geckDiagramFinPerm ht hsigma) (t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma) A
+      (t.geckDiagramFinPerm ht hsigma)⁻¹.permMatrix A := by
+  ext i j
+  rw [geckGraphAutMatrix]
+  rw [UniversalEnvelopingAlgebra.coe_kostantNumberedSymmetryMatrix_apply_of_monomial _ _ _ _
+      (t.geckDiagramFinPerm ht hsigma) (fun _ => 1)
+      (geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial ht hsigma) A i j]
+  simp [Equiv.Perm.permMatrix, PEquiv.toMatrix_apply, Equiv.eq_symm_apply, eq_comm]
 
 /-- The matrix of the pinned Geck coordinate permutation commutes with extension of the value
 ring. -/
@@ -303,7 +320,8 @@ theorem map_geckPoints_conj_geckGraphAutMatrix (hsigma : sigma ∈ t.diagramSymm
     (geckDiagramModuleEquiv_ι_geckRepresentation_rootGenerator ht hsigma)
     (diagramRootGeneratorPerm sigma).surjective
     (t.geckDiagramFinPerm ht hsigma)
-    (t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma)
+    (fun _ => 1)
+    (geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial ht hsigma)
     sigma (t.geckWeightFin_geckDiagramFinPerm ht hsigma) A
 
 /-- The matrix of the pinned coordinate permutation, as an element of the normalizer of the points
@@ -380,7 +398,8 @@ theorem schemePointsMulEquiv_geckGraphAut_comp_geckGroupSchemeι
       (geckDiagramModuleEquiv_ι_geckRepresentation_rootGenerator ht hsigma)
       (diagramRootGeneratorPerm sigma).surjective
       (t.geckDiagramFinPerm ht hsigma)
-      (t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma)
+      (fun _ => 1)
+      (geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial ht hsigma)
       sigma (t.geckWeightFin_geckDiagramFinPerm ht hsigma) A
       (p ≫ (eqToHom (t.geckGroupScheme_def ht)).hom.hom)
 
@@ -439,7 +458,8 @@ theorem geckGraphAutPoints_geckTorusMatrix (hsigma : sigma ∈ t.diagramSymmetry
     (t.geckDiagramModuleEquiv ht hsigma)
     (t.geckDiagramModuleEquiv_mem_geckCoordinateLattice_iff ht hsigma)
     (t.geckDiagramFinPerm ht hsigma)
-    (t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma) A
+    (fun _ => 1)
+    (geckDiagramModuleEquiv_geckCoordinateBasisFin_monomial ht hsigma) A
     (fun i => torusCharacter s (t.geckWeightFin ht i))
   refine Subtype.ext ?_
   rw [coe_geckGraphAutPoints]


### PR DESCRIPTION
This PR generalizes numbered symmetries of Kostant toral closures from pure basis permutations to integral monomial basis maps. It records the resulting matrix entries explicitly and proves that the scalar coefficients cancel in diagonal conjugation, so the existing root-subgroup and torus automorphism machinery applies to signed coordinate permutations.

The existing Geck specialization is updated with constant scale one. This is the prerequisite for the doubled E₆ pinned graph automorphism required by the Layer 9 pinned-isomorphism target in `TauCetiRoadmap/ReductiveGroups/README.md` and milestone L1 in `TauCetiRoadmap/CFSGStatement/README.md`.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

:robot: Prepared with OpenAI Codex