### PR TITLE
refactor(Exchangeability): separate recurrence reconstruction from de Finetti

### DIFF
--- a/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
@@ -6,10 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.MeasureTheory.MeasurableSpace.List
-public import TauCeti.Probability.DeFinetti.Theorem
 public import TauCeti.Probability.Exchangeability.Excursion
 import TauCeti.Probability.Exchangeability.SuccessorArray
 public import TauCeti.Probability.Recurrent
+import Mathlib.MeasureTheory.Measure.Dirac.Basic
 
 /-!
 # The excursion process of a recurrent Markov exchangeable process
@@ -20,8 +20,9 @@ into an infinite sequence of excursions away from `a₀`. This file assembles th
 proves the theorem the Diaconis–Freedman representation rests on: for a **Markov exchangeable**
 process the excursion process is **exchangeable**
 (`TauCeti.Probability.MarkovExchangeable.exchangeable_excursionProcess`). De Finetti's theorem then
-applies to it, making the excursions conditionally i.i.d.
-(`TauCeti.Probability.MarkovExchangeable.conditionallyIID_excursionProcess`).
+applies to it, making the excursions conditionally i.i.d. — that step is drawn in
+`Recurrence.Representation`, which is where this subtree meets the representation theory, so the
+excursion mechanics here stay independent of it.
 
 ## How the two symmetries meet
 
@@ -60,8 +61,6 @@ countability Markov exchangeability already carries.
   excursions.
 * `TauCeti.Probability.MarkovExchangeable.exchangeable_excursionProcess`: **the excursion process
   of a recurrent Markov exchangeable process is exchangeable**.
-* `TauCeti.Probability.MarkovExchangeable.conditionallyIID_excursionProcess`: de Finetti's theorem
-  applied to it.
 
 ## References
 
@@ -265,19 +264,6 @@ theorem MarkovExchangeable.exchangeable_excursionProcess (h : MarkovExchangeable
   rw [hleft, hright, setOf_forall_excursion_eq, setOf_forall_excursion_eq]
   exact h.measure_setOf_excursionPrefix_eq_of_perm hrec h0
     (Equiv.Perm.ofFn_comp_perm σ.symm v)
-
-/-- **De Finetti for the excursions of a recurrent Markov exchangeable process.** The excursions
-away from the initial state are conditionally i.i.d. finite words.
-
-The value space needs no hypothesis: over a countable state space the finite words form a countable
-discrete space, which is standard Borel and nonempty. -/
-theorem MarkovExchangeable.conditionallyIID_excursionProcess [IsFiniteMeasure μ]
-    (h : MarkovExchangeable μ X) (hrec : Recurrent μ X) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
-    ConditionallyIID μ (excursionProcess X a₀) :=
-  let _ : Countable α := h.countable
-  have : MeasurableSingletonClass α := h.measurableSingletonClass
-  conditionallyIID_of_exchangeable (h.exchangeable_excursionProcess hrec h0)
-    (aemeasurable_excursionProcess h.aemeasurable a₀)
 
 end Exchangeable
 

--- a/TauCeti/Probability/Exchangeability/Recurrence/MarkovChain.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/MarkovChain.lean
@@ -10,7 +10,7 @@ public import TauCeti.Probability.Exchangeability.ConditionallyIID.Const
 public import TauCeti.Probability.Exchangeability.Recurrence.Excursion
 public import TauCeti.Probability.Process.MarkovChain
 -- Non-public: the reconstruction of a path from its excursions is used only inside a proof.
-import TauCeti.Probability.Exchangeability.Recurrence.Representation
+import TauCeti.Probability.Exchangeability.Recurrence.Reconstruction
 
 /-!
 # The excursions of a recurrent Markov chain are i.i.d.

--- a/TauCeti/Probability/Exchangeability/Recurrence/Reconstruction.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Reconstruction.lean
@@ -96,8 +96,6 @@ theorem Recurrent.pathLaw_eq_map_pathOfExcursions [Countable α] [MeasurableSing
   have h := hωinf 0
   rwa [hω0] at h
 
-/-! ## Excursion laws avoid the base state -/
-
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Recurrence/Reconstruction.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Reconstruction.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Probability.Exchangeability.Recurrence.Excursion
--- Non-public: supplies the discrete-measurability instances the change of variables needs.
-import TauCeti.Probability.Exchangeability.MixedIID.Mixture
+import Mathlib.Logic.Equiv.List
+import Mathlib.MeasureTheory.MeasurableSpace.Constructions
 
 /-!
 # Reconstructing a recurrent path from its excursions
@@ -38,6 +38,15 @@ which is the only file in this subtree that reaches the de Finetti summit.
 * `TauCeti.Probability.measurable_pathOfExcursions` — concatenation is measurable;
 * `TauCeti.Probability.pathLaw_eq_map_pathOfExcursions` and its `Recurrent` form — the path law is
   the pushforward of the excursion path law along it.
+
+## References
+
+* P. Diaconis and D. Freedman, "de Finetti's theorem for Markov chains", *Annals of Probability*
+  8 (1980), 115–130.
+* Roadmap: `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, "Markov exchangeability".
+
+No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable rather than
+Markov exchangeable sequences.
 -/
 
 public section
@@ -72,6 +81,10 @@ theorem measurable_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
     refine List.ext_getElem (by simp) fun j hj hj' => ?_
     rw [List.getElem_map, List.getElem_range, List.getElem_ofFn]
   rw [hfac]
+  -- `Fin (i+1) → List α` is discrete: `List α` is countable with measurable singletons, and a
+  -- finite product of such spaces inherits both.
+  have : MeasurableSingletonClass (List α) := inferInstance
+  have : DiscreteMeasurableSpace (Fin (i + 1) → List α) := inferInstance
   exact Measurable.of_discrete.comp (measurable_pi_lambda _ fun j => measurable_pi_apply _)
 
 /-! ## The path law of a recurrent process -/

--- a/TauCeti/Probability/Exchangeability/Recurrence/Reconstruction.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Reconstruction.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.Recurrence.Excursion
+-- Non-public: supplies the discrete-measurability instances the change of variables needs.
+import TauCeti.Probability.Exchangeability.MixedIID.Mixture
+
+/-!
+# Reconstructing a recurrent path from its excursions
+
+A recurrent process that starts at `a₀` returns to it infinitely often, so it is spelled out by its
+excursions and nothing else: reading the excursions off a path and concatenating them back are
+mutually inverse.  This file turns that bijection into an identity of laws,
+
+```text
+pathLaw μ X = (pathLaw of the excursion process).map (pathOfExcursions a₀)
+```
+
+and nothing more.  It is deliberately independent of de Finetti: the reconstruction is a change of
+variables along a measurable bijection, and holds whether or not the excursion law is a mixture.
+The representation theorem that identifies that law as a mixture is in `Recurrence.Representation`,
+which is the only file in this subtree that reaches the de Finetti summit.
+
+## Main results
+
+* `TauCeti.Probability.measurable_pathOfExcursions` — concatenation is measurable;
+* `TauCeti.Probability.pathLaw_eq_map_pathOfExcursions` and its `Recurrent` form — the path law is
+  the pushforward of the excursion path law along it.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+  {μ : Measure Ω} {X : ℕ → Ω → α} {a₀ : α}
+
+/-- **Concatenating a sequence of excursions is measurable.** Each coordinate of the concatenated
+sequence depends on finitely many excursions, and over a countable discrete state space the finite
+words form a countable discrete space, on which every map is measurable. -/
+theorem measurable_pathOfExcursions [Countable α] [MeasurableSingletonClass α] (a₀ : α) :
+    Measurable (pathOfExcursions a₀ : (ℕ → List α) → ℕ → α) := by
+  refine measurable_pi_lambda _ fun i => ?_
+  have hfac : (fun b : ℕ → List α => pathOfExcursions a₀ b i) =
+      (fun v : Fin (i + 1) → List α => loopPathAt a₀ (List.ofFn v) i) ∘
+        fun (b : ℕ → List α) (j : Fin (i + 1)) => b j.val := by
+    funext b
+    have hi : i ≤ loopSteps ((List.range (i + 1)).map b) := by
+      have hle := length_le_loopSteps ((List.range (i + 1)).map b)
+      simp only [List.length_map, List.length_range] at hle
+      omega
+    rw [Function.comp_apply, pathOfExcursions_eq_loopPathAt a₀ b hi]
+    congr 1
+    refine List.ext_getElem (by simp) fun j hj hj' => ?_
+    rw [List.getElem_map, List.getElem_range, List.getElem_ofFn]
+  rw [hfac]
+  exact Measurable.of_discrete.comp (measurable_pi_lambda _ fun j => measurable_pi_apply _)
+
+/-! ## The path law of a recurrent process -/
+
+variable {μ : Measure Ω} {X : ℕ → Ω → α} {a₀ : α}
+
+/-- **The path law of a process returning infinitely often to `a₀` is the image of its excursion
+law.** Almost every sample path starts at and returns infinitely often to `a₀`, so concatenating
+its excursions recovers it. -/
+theorem pathLaw_eq_map_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
+    (hX : ∀ i, AEMeasurable (X i) μ) (hreturns : ∀ᵐ ω ∂μ, {n | X n ω = a₀}.Infinite)
+    (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
+    pathLaw μ X = (pathLaw μ (excursionProcess X a₀)).map (pathOfExcursions a₀) := by
+  have hΦ : AEMeasurable (fun ω k => excursionProcess X a₀ k ω) μ :=
+    aemeasurable_pi_lambda _ fun k => aemeasurable_excursionProcess hX a₀ k
+  have hae : (pathOfExcursions a₀ ∘ fun ω k => excursionProcess X a₀ k ω) =ᵐ[μ]
+      fun ω i => X i ω := by
+    filter_upwards [h0, hreturns] with ω hω0 hωinf
+    simpa [Function.comp_def] using pathOfExcursions_excursion hωinf hω0
+  rw [pathLaw_def, pathLaw_def,
+    AEMeasurable.map_map_of_aemeasurable (measurable_pathOfExcursions a₀).aemeasurable hΦ,
+    Measure.map_congr hae]
+
+/-- **The path law of a recurrent process started at `a₀` is the image of its excursion law.** -/
+theorem Recurrent.pathLaw_eq_map_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
+    (hrec : Recurrent μ X) (hX : ∀ i, AEMeasurable (X i) μ) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
+    pathLaw μ X = (pathLaw μ (excursionProcess X a₀)).map (pathOfExcursions a₀) := by
+  apply TauCeti.Probability.pathLaw_eq_map_pathOfExcursions hX _ h0
+  filter_upwards [h0, hrec.ae_infinite_setOf_eq] with ω hω0 hωinf
+  have h := hωinf 0
+  rwa [hω0] at h
+
+/-! ## Excursion laws avoid the base state -/
+
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/Recurrence/Reconstruction.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Reconstruction.lean
@@ -12,16 +12,24 @@ import TauCeti.Probability.Exchangeability.MixedIID.Mixture
 /-!
 # Reconstructing a recurrent path from its excursions
 
-A recurrent process that starts at `a₀` returns to it infinitely often, so it is spelled out by its
-excursions and nothing else: reading the excursions off a path and concatenating them back are
-mutually inverse.  This file turns that bijection into an identity of laws,
+A recurrent process that starts at `a₀` returns to it infinitely often, so concatenating its
+excursions recovers the path: `pathOfExcursions_excursion` is the identity used here, and it needs
+exactly that recurrence.  This file turns it into an identity of laws,
 
 ```text
 pathLaw μ X = (pathLaw of the excursion process).map (pathOfExcursions a₀)
 ```
 
-and nothing more.  It is deliberately independent of de Finetti: the reconstruction is a change of
-variables along a measurable bijection, and holds whether or not the excursion law is a mixture.
+and nothing more.
+
+Only that direction is established.  Concatenation is not injective on arbitrary excursion
+sequences — a word containing `a₀` is split further when the excursions are read back — so the
+converse `excursion_pathOfExcursions` carries the hypothesis that the words avoid `a₀`, and is not
+used here.  What the identity above needs is a pushforward along a measurable map that is a.e. left
+inverse to reading the excursions off, not a bijection.
+
+The file is deliberately independent of de Finetti: this is a change of variables, and holds
+whether or not the excursion law is a mixture.
 The representation theorem that identifies that law as a mixture is in `Recurrence.Representation`,
 which is the only file in this subtree that reaches the de Finetti summit.
 

--- a/TauCeti/Probability/Exchangeability/Recurrence/Representation.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Representation.lean
@@ -6,7 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Probability.DeFinetti.Barycenter
-public import TauCeti.Probability.Exchangeability.Recurrence.Excursion
+public import TauCeti.Probability.Exchangeability.Recurrence.Reconstruction
+public import TauCeti.Probability.DeFinetti.Theorem
 -- Non-public: the mixture form of a path law is used only inside proofs.
 import TauCeti.Probability.Exchangeability.MixedIID.Mixture
 
@@ -72,61 +73,22 @@ namespace TauCeti
 namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+  {μ : Measure Ω} {X : ℕ → Ω → α} {a₀ : α}
 
 /-! ## Measurability of the concatenation map -/
 
-/-- **Concatenating a sequence of excursions is measurable.** Each coordinate of the concatenated
-sequence depends on finitely many excursions, and over a countable discrete state space the finite
-words form a countable discrete space, on which every map is measurable. -/
-theorem measurable_pathOfExcursions [Countable α] [MeasurableSingletonClass α] (a₀ : α) :
-    Measurable (pathOfExcursions a₀ : (ℕ → List α) → ℕ → α) := by
-  refine measurable_pi_lambda _ fun i => ?_
-  have hfac : (fun b : ℕ → List α => pathOfExcursions a₀ b i) =
-      (fun v : Fin (i + 1) → List α => loopPathAt a₀ (List.ofFn v) i) ∘
-        fun (b : ℕ → List α) (j : Fin (i + 1)) => b j.val := by
-    funext b
-    have hi : i ≤ loopSteps ((List.range (i + 1)).map b) := by
-      have hle := length_le_loopSteps ((List.range (i + 1)).map b)
-      simp only [List.length_map, List.length_range] at hle
-      omega
-    rw [Function.comp_apply, pathOfExcursions_eq_loopPathAt a₀ b hi]
-    congr 1
-    refine List.ext_getElem (by simp) fun j hj hj' => ?_
-    rw [List.getElem_map, List.getElem_range, List.getElem_ofFn]
-  rw [hfac]
-  exact Measurable.of_discrete.comp (measurable_pi_lambda _ fun j => measurable_pi_apply _)
+/-- **De Finetti for the excursions of a recurrent Markov exchangeable process.** The excursions
+away from the initial state are conditionally i.i.d. finite words.
 
-/-! ## The path law of a recurrent process -/
-
-variable {μ : Measure Ω} {X : ℕ → Ω → α} {a₀ : α}
-
-/-- **The path law of a process returning infinitely often to `a₀` is the image of its excursion
-law.** Almost every sample path starts at and returns infinitely often to `a₀`, so concatenating
-its excursions recovers it. -/
-theorem pathLaw_eq_map_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
-    (hX : ∀ i, AEMeasurable (X i) μ) (hreturns : ∀ᵐ ω ∂μ, {n | X n ω = a₀}.Infinite)
-    (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
-    pathLaw μ X = (pathLaw μ (excursionProcess X a₀)).map (pathOfExcursions a₀) := by
-  have hΦ : AEMeasurable (fun ω k => excursionProcess X a₀ k ω) μ :=
-    aemeasurable_pi_lambda _ fun k => aemeasurable_excursionProcess hX a₀ k
-  have hae : (pathOfExcursions a₀ ∘ fun ω k => excursionProcess X a₀ k ω) =ᵐ[μ]
-      fun ω i => X i ω := by
-    filter_upwards [h0, hreturns] with ω hω0 hωinf
-    simpa [Function.comp_def] using pathOfExcursions_excursion hωinf hω0
-  rw [pathLaw_def, pathLaw_def,
-    AEMeasurable.map_map_of_aemeasurable (measurable_pathOfExcursions a₀).aemeasurable hΦ,
-    Measure.map_congr hae]
-
-/-- **The path law of a recurrent process started at `a₀` is the image of its excursion law.** -/
-theorem Recurrent.pathLaw_eq_map_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
-    (hrec : Recurrent μ X) (hX : ∀ i, AEMeasurable (X i) μ) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
-    pathLaw μ X = (pathLaw μ (excursionProcess X a₀)).map (pathOfExcursions a₀) := by
-  apply TauCeti.Probability.pathLaw_eq_map_pathOfExcursions hX _ h0
-  filter_upwards [h0, hrec.ae_infinite_setOf_eq] with ω hω0 hωinf
-  have h := hωinf 0
-  rwa [hω0] at h
-
-/-! ## Excursion laws avoid the base state -/
+The value space needs no hypothesis: over a countable state space the finite words form a countable
+discrete space, which is standard Borel and nonempty. -/
+theorem MarkovExchangeable.conditionallyIID_excursionProcess [IsFiniteMeasure μ]
+    (h : MarkovExchangeable μ X) (hrec : Recurrent μ X) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
+    ConditionallyIID μ (excursionProcess X a₀) :=
+  let _ : Countable α := h.countable
+  have : MeasurableSingletonClass α := h.measurableSingletonClass
+  conditionallyIID_of_exchangeable (h.exchangeable_excursionProcess hrec h0)
+    (aemeasurable_excursionProcess h.aemeasurable a₀)
 
 /-- **A directing measure of an excursion process charges no word through the base state.** An
 excursion never visits the state it is an excursion from, so almost every mixing representative of

--- a/TauCeti/Probability/Exchangeability/Recurrence/Representation.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Representation.lean
@@ -7,21 +7,16 @@ module
 
 public import TauCeti.Probability.DeFinetti.Barycenter
 public import TauCeti.Probability.Exchangeability.Recurrence.Reconstruction
-public import TauCeti.Probability.DeFinetti.Theorem
 -- Non-public: the mixture form of a path law is used only inside proofs.
 import TauCeti.Probability.Exchangeability.MixedIID.Mixture
 
 /-!
 # A recurrent Markov exchangeable process is a mixture of processes with i.i.d. excursions
 
-A recurrent process that starts at a state `a₀` returns to it infinitely often, so it is spelled
-out by its excursions and by nothing else: reading the excursions off the path and concatenating
-them back are mutually inverse (`TauCeti.pathOfExcursions_excursion` and
-`TauCeti.excursion_pathOfExcursions`). This file turns that bijection into an identity of laws.
-The path law of the process is the image of the path law of its excursion process under
-concatenation (`TauCeti.Probability.Recurrent.pathLaw_eq_map_pathOfExcursions`), and for a
-**Markov exchangeable** process the excursion process is exchangeable, hence conditionally i.i.d.
-The resulting representation is
+`Recurrence.Reconstruction` establishes that the path law of a recurrent process is the image of
+its excursion law under concatenation.  This file supplies the other half: for a **Markov
+exchangeable** process the excursion process is exchangeable, hence conditionally i.i.d., so that
+excursion law is a mixture.  Combining the two gives the representation
 
 ```text
 pathLaw μ X = (deFinettiBarycenter π).map (pathOfExcursions a₀)
@@ -42,11 +37,8 @@ remaining input of the Diaconis–Freedman representation
 
 ## Main results
 
-* `TauCeti.Probability.measurable_pathOfExcursions`: concatenating excursions is measurable over a
-  countable discrete state space.
-* `TauCeti.Probability.pathLaw_eq_map_pathOfExcursions`: the path law of a process that almost
-  surely starts at and returns infinitely often to `a₀` is the image of its excursion law under
-  concatenation.
+* `TauCeti.Probability.MarkovExchangeable.conditionallyIID_excursionProcess`: de Finetti applied to
+  the excursion process of a recurrent Markov exchangeable process.
 * `TauCeti.Probability.ConditionallyIIDWith.ae_measure_setOf_mem_eq_zero_of_excursionProcess`: a
   directing measure of an excursion process almost surely charges no word through the base state.
 * `TauCeti.Probability.MarkovExchangeable.exists_pathLaw_eq_map_deFinettiBarycenter`: **a recurrent
@@ -75,7 +67,7 @@ namespace Probability
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
   {μ : Measure Ω} {X : ℕ → Ω → α} {a₀ : α}
 
-/-! ## Measurability of the concatenation map -/
+/-! ## De Finetti for the excursions -/
 
 /-- **De Finetti for the excursions of a recurrent Markov exchangeable process.** The excursions
 away from the initial state are conditionally i.i.d. finite words.


### PR DESCRIPTION
The recurrence subtree reached the de Finetti summit from three files that do not need it. `Excursion.lean` imported it for one terminal corollary; `Representation.lean` mixed generic path reconstruction with the representation theorem; and `MarkovChain.lean` imported `Representation` only to reconstruct a path from its excursions, inheriting the summit along the way.

This separates the three layers. **No new mathematics, no renames** — declarations move unchanged.

- `Recurrence/Reconstruction.lean` (new) receives `measurable_pathOfExcursions`, `pathLaw_eq_map_pathOfExcursions` and `Recurrent.pathLaw_eq_map_pathOfExcursions`. The reconstruction is a change of variables along a measurable bijection and holds whether or not the excursion law is a mixture.
- `MarkovExchangeable.conditionallyIID_excursionProcess` moves from `Excursion.lean` to `Representation.lean`, next to the theorem it feeds.
- `MarkovChain.lean` imports `Reconstruction` instead of `Representation`.
- `Excursion.lean` drops the summit import.

## The closure reduction

Measured before and after, transitively:

| module | `DeFinetti.Theorem` before | after |
|---|---|---|
| `Recurrence.Excursion` | yes | **no** |
| `Recurrence.Reconstruction` | — | **no** |
| `Recurrence.MarkovChain` | yes | **no** |
| `Recurrence.Representation` | yes | yes |

Same for `DeFinetti.Barycenter`. Excursion mechanics and recurrent Markov-chain regeneration are now independent of the representation theory, and `Representation` is the subtree's one deliberate summit consumer.

## Two hidden dependencies surfaced

Removing the summit import from `Excursion.lean` cost it Mathlib's `Measure.ext_of_singleton`, which it had been reaching transitively; it now imports `Mathlib.MeasureTheory.Measure.Dirac.Basic` directly. `Reconstruction.lean` likewise needs the discrete-measurability instances that arrived with the old import set, and takes them non-publicly from `MixedIID.Mixture`.

Both are the split doing its job: the import graph now states what each module actually uses.

## Roadmap

Roadmap: Exchangeability

A dependency-boundary reorganization of existing code, justified by the closure table above. No roadmap target is claimed.

🤖 Directed by Cameron Freer, drafted by Opus 5
