### PR TITLE
feat: make trivial-identity-component groups finite etale

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
@@ -53,6 +53,8 @@ shrinking part.
 * `TauCeti.CommHopfAlgCat.pointsFunctor_faithful` and
   `TauCeti.CommHopfAlgCat.pointsFunctor_full`: points recover coordinate Hopf algebra
   morphisms.
+* `TauCeti.CommHopfAlgCat.isIso_of_isIso_mapPointsFunctor`: a coordinate morphism is an
+  isomorphism when its induced natural map on points is an isomorphism.
 * `TauCeti.CommHopfAlgCat.homOfPointsMap`: the coordinate morphism a natural map of points
   functors comes from, with `TauCeti.CommHopfAlgCat.mapPointsFunctor_homOfPointsMap` its
   defining property, `TauCeti.CommHopfAlgCat.homOfPointsMap_mapPointsFunctor` the converse
@@ -501,6 +503,19 @@ instance pointsFunctor_full :
     dsimp [groupYonedaPointsFunctor]
     infer_instance
   exact Functor.Full.of_iso (groupYonedaPointsFunctorIso (R := R))
+
+/-- A coordinate Hopf-algebra morphism is an isomorphism when its induced natural map on
+points is an isomorphism. -/
+theorem isIso_of_isIso_mapPointsFunctor {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K)
+    [IsIso (mapPointsFunctor.{u, u, u} f)] : IsIso f := by
+  let h : IsIso (mapPointsFunctor.{u, u, u} f) := inferInstance
+  let _ : IsIso ((pointsFunctor.{u, u, u} (R := R)).map f.op) := by
+    rw [pointsFunctor_map, Quiver.Hom.unop_op]
+    exact h
+  let _ : IsIso f.op :=
+    (Functor.FullyFaithful.ofFullyFaithful
+      (pointsFunctor.{u, u, u} (R := R))).isIso_of_isIso_map f.op
+  exact isIso_of_op f
 
 /-- The coordinate Hopf-algebra morphism that a natural transformation of group-valued points
 functors comes from, recovered by fullness of the functor of points.

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/TrivialIdentity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/TrivialIdentity.lean
@@ -105,15 +105,10 @@ private theorem
     (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
       HopfIdeal.augmentation k H) :
     IsIso (componentCoordinateHom H) := by
-  let f := componentCoordinateHom H
-  let _ : IsIso ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := k)).map f.op) := by
-    rw [CommHopfAlgCat.pointsFunctor_map, Quiver.Hom.unop_op]
-    exact isIso_mapPointsFunctor_componentCoordinateHom_of_identityComponentHopfIdealEqAugmentation
+  let _ :=
+    isIso_mapPointsFunctor_componentCoordinateHom_of_identityComponentHopfIdealEqAugmentation
       H hH
-  let _ : IsIso f.op :=
-    (Functor.FullyFaithful.ofFullyFaithful
-      (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := k))).isIso_of_isIso_map f.op
-  exact isIso_of_op f
+  exact CommHopfAlgCat.isIso_of_isIso_mapPointsFunctor (componentCoordinateHom H)
 
 /-- A finite-type affine group over an algebraically closed field with trivial identity
 component is canonically the constant group on the connected components of its spectrum. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/TrivialIdentity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/TrivialIdentity.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
 public import TauCeti.Algebra.AlgebraicGroup.Connected.ComponentGroup.Representable
-import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
 
 /-!
 # Finite groups with trivial identity component

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/TrivialIdentity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/TrivialIdentity.lean
@@ -24,8 +24,8 @@ points then promotes the pointwise isomorphism to an isomorphism of coordinate H
 
 ## Main declarations
 
-* `componentCoordinateIsoOfIdentityComponentEqAugmentation`: a finite-type affine group with
-  trivial identity component is the constant group on its connected components.
+* `componentCoordinateIsoOfIdentityComponentHopfIdealEqAugmentation`: a finite-type affine group
+  with trivial identity component is the constant group on its connected components.
 * `moduleFinite_of_identityComponentHopfIdeal_eq_augmentation`: its coordinate algebra is
   finite-dimensional.
 * `algebraEtale_of_identityComponentHopfIdeal_eq_augmentation`: its coordinate algebra is
@@ -67,7 +67,7 @@ private theorem componentPointsHom_injective_of_identityComponentHopfIdeal_eq_au
   rw [kernelHopfIdeal_componentCoordinateHom, hH] at hmem
   exact CommHopfAlgCat.eq_one_of_mem_quotientPointsSubgroup_augmentation H.obj A hmem
 
-private theorem bijective_componentPointsHom_of_identityComponentHopfIdeal_eq_augmentation
+private theorem componentPointsHom_bijective_of_identityComponentHopfIdeal_eq_augmentation
     (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
       HopfIdeal.augmentation k H) (A : CommAlgCat.{u} k) :
@@ -75,7 +75,8 @@ private theorem bijective_componentPointsHom_of_identityComponentHopfIdeal_eq_au
   ⟨componentPointsHom_injective_of_identityComponentHopfIdeal_eq_augmentation H hH A,
     componentPointsHom_surjective H A⟩
 
-private theorem isIso_mapPointsFunctor_componentCoordinateHom_of_identityComponentEqAugmentation
+private theorem
+    isIso_mapPointsFunctor_componentCoordinateHom_of_identityComponentHopfIdealEqAugmentation
     (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
       HopfIdeal.augmentation k H) :
@@ -88,7 +89,7 @@ private theorem isIso_mapPointsFunctor_componentCoordinateHom_of_identityCompone
         componentPointsHom H A g := by
     rw [CommHopfAlgCat.mapPointsFunctor_app_apply, componentPointsHom_apply]
   have hb :=
-    bijective_componentPointsHom_of_identityComponentHopfIdeal_eq_augmentation H hH A
+    componentPointsHom_bijective_of_identityComponentHopfIdeal_eq_augmentation H hH A
   constructor
   · intro x y hxy
     apply hb.1
@@ -107,7 +108,7 @@ private theorem
   let f := componentCoordinateHom H
   let _ : IsIso ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := k)).map f.op) := by
     rw [CommHopfAlgCat.pointsFunctor_map, Quiver.Hom.unop_op]
-    exact isIso_mapPointsFunctor_componentCoordinateHom_of_identityComponentEqAugmentation
+    exact isIso_mapPointsFunctor_componentCoordinateHom_of_identityComponentHopfIdealEqAugmentation
       H hH
   let _ : IsIso f.op :=
     (Functor.FullyFaithful.ofFullyFaithful
@@ -116,7 +117,7 @@ private theorem
 
 /-- A finite-type affine group over an algebraically closed field with trivial identity
 component is canonically the constant group on the connected components of its spectrum. -/
-noncomputable def componentCoordinateIsoOfIdentityComponentEqAugmentation
+noncomputable def componentCoordinateIsoOfIdentityComponentHopfIdealEqAugmentation
     (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
       HopfIdeal.augmentation k H) :
@@ -129,13 +130,13 @@ noncomputable def componentCoordinateIsoOfIdentityComponentEqAugmentation
 /-- The forward morphism of the component-coordinate isomorphism is the canonical component
 coordinate morphism. -/
 @[simp]
-theorem componentCoordinateIsoOfIdentityComponentEqAugmentation_hom
+theorem componentCoordinateIsoOfIdentityComponentHopfIdealEqAugmentation_hom
     (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
       HopfIdeal.augmentation k H) :
-    (componentCoordinateIsoOfIdentityComponentEqAugmentation H hH).hom =
+    (componentCoordinateIsoOfIdentityComponentHopfIdealEqAugmentation H hH).hom =
       componentCoordinateHom H := by
-  rfl
+  rw [componentCoordinateIsoOfIdentityComponentHopfIdealEqAugmentation, asIso_hom]
 
 /-- The coordinate algebra of a finite-type affine group over an algebraically closed field is
 finite-dimensional when its identity component is the trivial subgroup scheme. -/
@@ -144,7 +145,7 @@ theorem moduleFinite_of_identityComponentHopfIdeal_eq_augmentation
     (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
       HopfIdeal.augmentation k H) :
     Module.Finite k H := by
-  let e := componentCoordinateIsoOfIdentityComponentEqAugmentation H hH
+  let e := componentCoordinateIsoOfIdentityComponentHopfIdealEqAugmentation H hH
   let eLinear : ConstantGroup.coordinateRing k
       (ConnectedComponents (PrimeSpectrum H)) ≃ₗ[k] H :=
     LinearEquiv.ofBijective e.hom.hom.toLinearMap
@@ -158,7 +159,7 @@ theorem algebraEtale_of_identityComponentHopfIdeal_eq_augmentation
     (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
       HopfIdeal.augmentation k H) :
     Algebra.Etale k H := by
-  let e := componentCoordinateIsoOfIdentityComponentEqAugmentation H hH
+  let e := componentCoordinateIsoOfIdentityComponentHopfIdealEqAugmentation H hH
   let eAlg : ConstantGroup.coordinateRing k
       (ConnectedComponents (PrimeSpectrum H)) ≃ₐ[k] H :=
     AlgEquiv.ofBijective e.hom.hom.toAlgHom

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/TrivialIdentity.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/TrivialIdentity.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
+public import TauCeti.Algebra.AlgebraicGroup.Connected.ComponentGroup.Representable
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
+
+/-!
+# Finite groups with trivial identity component
+
+Let `H` be the coordinate Hopf algebra of a finite-type affine group over an algebraically
+closed field. If its identity component is the trivial subgroup scheme, then the canonical
+component morphism identifies the group with the finite constant group of connected components.
+In particular, `H` is finite-dimensional over the ground field.
+
+The proof uses the existing description of the component morphism. It is surjective on points
+over every commutative test algebra, and its scheme-theoretic kernel is the identity component.
+When that kernel is trivial, the point map is also injective. Full faithfulness of the functor of
+points then promotes the pointwise isomorphism to an isomorphism of coordinate Hopf algebras.
+
+## Main declarations
+
+* `componentCoordinateIsoOfIdentityComponentEqAugmentation`: a finite-type affine group with
+  trivial identity component is the constant group on its connected components.
+* `moduleFinite_of_identityComponentHopfIdeal_eq_augmentation`: its coordinate algebra is
+  finite-dimensional.
+* `algebraEtale_of_identityComponentHopfIdeal_eq_augmentation`: its coordinate algebra is
+  etale.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 2.37.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Section 6.7.
+
+This is the component-group input for the Layer 6 theorem that the center of a semisimple affine
+group is finite. Applied to the reduced center, it turns the vanishing of that smooth group's
+identity component into finiteness; finiteness of the original center then follows by controlling
+its nilpotent thickening.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.FiniteTypeCommHopfAlgCat
+
+universe u
+
+variable {k : Type u} [Field k] [IsAlgClosed k]
+
+private theorem componentPointsHom_injective_of_identityComponentHopfIdeal_eq_augmentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
+      HopfIdeal.augmentation k H) (A : CommAlgCat.{u} k) :
+    Function.Injective (componentPointsHom H A) := by
+  rw [injective_iff_map_eq_one]
+  intro g hg
+  rw [componentPointsHom_apply] at hg
+  have hmem : g ∈ CommHopfAlgCat.quotientPointsSubgroup H.obj
+      (CommHopfAlgCat.kernelHopfIdeal (componentCoordinateHom H)) A :=
+    (CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff
+      (componentCoordinateHom H) A g).mp hg
+  rw [kernelHopfIdeal_componentCoordinateHom, hH] at hmem
+  exact CommHopfAlgCat.eq_one_of_mem_quotientPointsSubgroup_augmentation H.obj A hmem
+
+private theorem bijective_componentPointsHom_of_identityComponentHopfIdeal_eq_augmentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
+      HopfIdeal.augmentation k H) (A : CommAlgCat.{u} k) :
+    Function.Bijective (componentPointsHom H A) :=
+  ⟨componentPointsHom_injective_of_identityComponentHopfIdeal_eq_augmentation H hH A,
+    componentPointsHom_surjective H A⟩
+
+private theorem isIso_mapPointsFunctor_componentCoordinateHom_of_identityComponentEqAugmentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
+      HopfIdeal.augmentation k H) :
+    IsIso (CommHopfAlgCat.mapPointsFunctor.{u, u, u} (componentCoordinateHom H)) := by
+  rw [NatTrans.isIso_iff_isIso_app]
+  intro A
+  apply (ConcreteCategory.isIso_iff_bijective _).2
+  have heq (g : HopfAlgebra.points (R := k) (H := H) A) :
+      (CommHopfAlgCat.mapPointsFunctor (componentCoordinateHom H)).app A g =
+        componentPointsHom H A g := by
+    rw [CommHopfAlgCat.mapPointsFunctor_app_apply, componentPointsHom_apply]
+  have hb :=
+    bijective_componentPointsHom_of_identityComponentHopfIdeal_eq_augmentation H hH A
+  constructor
+  · intro x y hxy
+    apply hb.1
+    rw [← heq x, ← heq y]
+    exact hxy
+  · intro y
+    obtain ⟨x, hx⟩ := hb.2 y
+    exact ⟨x, (heq x).trans hx⟩
+
+private theorem
+    isIso_componentCoordinateHom_of_identityComponentHopfIdeal_eq_augmentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
+      HopfIdeal.augmentation k H) :
+    IsIso (componentCoordinateHom H) := by
+  let f := componentCoordinateHom H
+  let _ : IsIso ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := k)).map f.op) := by
+    rw [CommHopfAlgCat.pointsFunctor_map, Quiver.Hom.unop_op]
+    exact isIso_mapPointsFunctor_componentCoordinateHom_of_identityComponentEqAugmentation
+      H hH
+  let _ : IsIso f.op :=
+    (Functor.FullyFaithful.ofFullyFaithful
+      (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := k))).isIso_of_isIso_map f.op
+  exact isIso_of_op f
+
+/-- A finite-type affine group over an algebraically closed field with trivial identity
+component is canonically the constant group on the connected components of its spectrum. -/
+noncomputable def componentCoordinateIsoOfIdentityComponentEqAugmentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
+      HopfIdeal.augmentation k H) :
+    CommHopfAlgCat.of k
+        (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) ≅ H.obj := by
+  let _ : IsIso (componentCoordinateHom H) :=
+    isIso_componentCoordinateHom_of_identityComponentHopfIdeal_eq_augmentation H hH
+  exact asIso (componentCoordinateHom H)
+
+/-- The forward morphism of the component-coordinate isomorphism is the canonical component
+coordinate morphism. -/
+@[simp]
+theorem componentCoordinateIsoOfIdentityComponentEqAugmentation_hom
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
+      HopfIdeal.augmentation k H) :
+    (componentCoordinateIsoOfIdentityComponentEqAugmentation H hH).hom =
+      componentCoordinateHom H := by
+  rfl
+
+/-- The coordinate algebra of a finite-type affine group over an algebraically closed field is
+finite-dimensional when its identity component is the trivial subgroup scheme. -/
+theorem moduleFinite_of_identityComponentHopfIdeal_eq_augmentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
+      HopfIdeal.augmentation k H) :
+    Module.Finite k H := by
+  let e := componentCoordinateIsoOfIdentityComponentEqAugmentation H hH
+  let eLinear : ConstantGroup.coordinateRing k
+      (ConnectedComponents (PrimeSpectrum H)) ≃ₗ[k] H :=
+    LinearEquiv.ofBijective e.hom.hom.toLinearMap
+      (ConcreteCategory.bijective_of_isIso e.hom)
+  exact Module.Finite.equiv eLinear
+
+/-- The coordinate algebra of a finite-type affine group over an algebraically closed field is
+etale when its identity component is the trivial subgroup scheme. -/
+theorem algebraEtale_of_identityComponentHopfIdeal_eq_augmentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H) =
+      HopfIdeal.augmentation k H) :
+    Algebra.Etale k H := by
+  let e := componentCoordinateIsoOfIdentityComponentEqAugmentation H hH
+  let eAlg : ConstantGroup.coordinateRing k
+      (ConnectedComponents (PrimeSpectrum H)) ≃ₐ[k] H :=
+    AlgEquiv.ofBijective e.hom.hom.toAlgHom
+      (ConcreteCategory.bijective_of_isIso e.hom)
+  exact Algebra.Etale.of_equiv eAlg
+
+end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/DiagonalTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/DiagonalTorus.lean
@@ -179,14 +179,10 @@ noncomputable def weightLeviDiagonalCoordinateIso
       CommHopfAlgCat.of R
         (MonoidAlgebra R (Multiplicative (ULift.{u} (Fin N) →₀ ℤ))) := by
   let f := weightLeviDiagonalCoordinateMap R w
-  let _ : IsIso ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R)).map f.op) := by
-    rw [CommHopfAlgCat.pointsFunctor_map, Quiver.Hom.unop_op]
+  let _ : IsIso (CommHopfAlgCat.mapPointsFunctor.{u, u, u} f) := by
     dsimp only [f]
     exact isIso_mapPointsFunctor_weightLeviDiagonalCoordinateMap R w hw
-  let _ : IsIso f.op :=
-    (Functor.FullyFaithful.ofFullyFaithful
-      (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R))).isIso_of_isIso_map f.op
-  let _ : IsIso f := isIso_of_op f
+  let _ : IsIso f := CommHopfAlgCat.isIso_of_isIso_mapPointsFunctor f
   exact asIso f
 
 /-- The injective-weight Levi coordinate isomorphism restricts the ambient general-linear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/SemidirectProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/SemidirectProduct.lean
@@ -418,14 +418,10 @@ noncomputable instance isIso_weightParabolicSemidirectProductCoordinateMap
     (w : Fin N → ℤ) :
     IsIso (weightParabolicSemidirectProductCoordinateMap R w) := by
   let f := weightParabolicSemidirectProductCoordinateMap R w
-  let _ : IsIso ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R)).map f.op) := by
-    rw [CommHopfAlgCat.pointsFunctor_map, Quiver.Hom.unop_op]
+  let _ : IsIso (CommHopfAlgCat.mapPointsFunctor.{u, u, u} f) := by
     dsimp only [f]
     exact isIso_mapPointsFunctor_weightParabolicSemidirectProductCoordinateMap R w
-  let _ : IsIso f.op :=
-    (Functor.FullyFaithful.ofFullyFaithful
-      (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R))).isIso_of_isIso_map f.op
-  exact isIso_of_op f
+  exact CommHopfAlgCat.isIso_of_isIso_mapPointsFunctor f
 
 /-- Multiplication identifies the coordinate Hopf algebra of the weight parabolic with the
 coordinate Hopf algebra of its represented unipotent-by-Levi semidirect product. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -236,21 +236,6 @@ theorem quotientPointsSubgroup_le_center (H : _root_.CommHopfAlgCat.{v} R)
   fun _ hg ↦ HopfAlgebra.mem_center.mpr
     (isCentralPoint_of_mem_quotientPointsSubgroup H I hI A hg)
 
-/-- A point killing the augmentation ideal is the identity point: the trivial subgroup has only
-the identity over every value algebra. -/
-theorem eq_one_of_mem_quotientPointsSubgroup_augmentation (H : _root_.CommHopfAlgCat.{v} R)
-    (A : CommAlgCat.{v} R) {g : HopfAlgebra.points (R := R) (H := H) A}
-    (hg : g ∈ quotientPointsSubgroup H (HopfIdeal.augmentation R ↥H) A) : g = 1 := by
-  refine WithConv.ofConv_injective (AlgHom.ext fun x ↦ ?_)
-  have hx : x - algebraMap R ↥H (Coalgebra.counit (R := R) x) ∈
-      HopfIdeal.augmentation R ↥H := by
-    rw [HopfIdeal.mem_augmentation]
-    simp
-  have hzero := (mem_quotientPointsSubgroup_iff H _ A g).mp hg _ hx
-  rw [map_sub, sub_eq_zero] at hzero
-  rw [hzero, AlgHom.commutes]
-  exact (AlgHom.convOne_apply x).symm
-
 /-- **The trivial subgroup is central.** -/
 theorem isCentral_augmentation (H : _root_.CommHopfAlgCat.{v} R) :
     (HopfIdeal.augmentation R ↥H).IsCentral := by

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
 
 /-!
 # Points of Hopf-ideal quotients
@@ -29,6 +30,8 @@ the point factors uniquely through the quotient algebra.
 * `CommHopfAlgCat.mem_range_quotientPointsHom_iff`: quotient points are exactly ambient
   points killing `I`.
 * `CommHopfAlgCat.quotientPointsSubgroup`: the subgroup of ambient points cut out by `I`.
+* `CommHopfAlgCat.eq_one_of_mem_quotientPointsSubgroup_augmentation`: the subgroup cut out by
+  the augmentation ideal consists only of the identity point.
 * `CommHopfAlgCat.instIsMulCommutativeQuotientPointsSubgroup`: when the quotient Hopf algebra is
   cocommutative, the cut-out point subgroup is commutative.
 * `CommHopfAlgCat.mapDomainMulEquiv_mem_quotientPointsSubgroup_comapOfSurjective_iff`: transport of
@@ -163,6 +166,21 @@ lemma mem_quotientPointsSubgroup_iff (H : _root_.CommHopfAlgCat.{v} R)
     (g : HopfAlgebra.points (R := R) (H := H) A) :
     g ∈ quotientPointsSubgroup H I A ↔ ∀ h : H, h ∈ I → g.ofConv h = 0 :=
   mem_range_quotientPointsHom_iff H I A g
+
+/-- A point killing the augmentation ideal is the identity point: the trivial subgroup has only
+the identity over every value algebra. -/
+theorem eq_one_of_mem_quotientPointsSubgroup_augmentation (H : _root_.CommHopfAlgCat.{v} R)
+    (A : CommAlgCat.{v} R) {g : HopfAlgebra.points (R := R) (H := H) A}
+    (hg : g ∈ quotientPointsSubgroup H (HopfIdeal.augmentation R ↥H) A) : g = 1 := by
+  refine WithConv.ofConv_injective (AlgHom.ext fun x ↦ ?_)
+  have hx : x - algebraMap R ↥H (Coalgebra.counit (R := R) x) ∈
+      HopfIdeal.augmentation R ↥H := by
+    rw [HopfIdeal.mem_augmentation]
+    simp
+  have hzero := (mem_quotientPointsSubgroup_iff H _ A g).mp hg _ hx
+  rw [map_sub, sub_eq_zero] at hzero
+  rw [hzero, AlgHom.commutes]
+  exact (AlgHom.convOne_apply x).symm
 
 /-- Precomposition by a bijective bialgebra morphism identifies the points cut out by a Hopf
 ideal with the points cut out by its pullback. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
@@ -182,6 +182,17 @@ theorem eq_one_of_mem_quotientPointsSubgroup_augmentation (H : _root_.CommHopfAl
   rw [hzero, AlgHom.commutes]
   exact (AlgHom.convOne_apply x).symm
 
+/-- The subgroup of points cut out by the augmentation ideal consists exactly of the identity
+point. -/
+@[simp]
+theorem mem_quotientPointsSubgroup_augmentation_iff (H : _root_.CommHopfAlgCat.{v} R)
+    (A : CommAlgCat.{w} R) (g : HopfAlgebra.points (R := R) (H := H) A) :
+    g ∈ quotientPointsSubgroup H (HopfIdeal.augmentation R H) A ↔ g = 1 := by
+  constructor
+  · exact eq_one_of_mem_quotientPointsSubgroup_augmentation H A
+  · rintro rfl
+    exact Subgroup.one_mem _
+
 /-- Precomposition by a bijective bialgebra morphism identifies the points cut out by a Hopf
 ideal with the points cut out by its pullback. -/
 theorem mapDomainMulEquiv_mem_quotientPointsSubgroup_comapOfSurjective_iff

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
@@ -170,7 +170,7 @@ lemma mem_quotientPointsSubgroup_iff (H : _root_.CommHopfAlgCat.{v} R)
 /-- A point killing the augmentation ideal is the identity point: the trivial subgroup has only
 the identity over every value algebra. -/
 theorem eq_one_of_mem_quotientPointsSubgroup_augmentation (H : _root_.CommHopfAlgCat.{v} R)
-    (A : CommAlgCat.{v} R) {g : HopfAlgebra.points (R := R) (H := H) A}
+    (A : CommAlgCat.{w} R) {g : HopfAlgebra.points (R := R) (H := H) A}
     (hg : g ∈ quotientPointsSubgroup H (HopfIdeal.augmentation R ↥H) A) : g = 1 := by
   refine WithConv.ofConv_injective (AlgHom.ext fun x ↦ ?_)
   have hx : x - algebraMap R ↥H (Coalgebra.counit (R := R) x) ∈


### PR DESCRIPTION
This PR identifies a finite-type affine group over an algebraically closed field whose scheme-theoretic identity component is trivial with the finite constant group on its connected components, and deduces that its coordinate algebra is module-finite and etale. It advances the exact `TauCetiRoadmap/ReductiveGroups/README.md` Layer 6 milestone “reductive and semisimple groups,” specifically the required center and central-isogeny theory: the finite-center theorem for a semisimple group consumes this result after semisimplicity makes the reduced center's identity component trivial.

This is the most effective current step because the component group is already represented as a finite etale constant group and its coordinate morphism is already known to be point-surjective with kernel the identity component; the new theorem closes the missing passage from a trivial kernel to a coordinate Hopf-algebra isomorphism. After this PR, the Layer 6 finite-center step still needs the reduced center constructed as a smooth central subgroup, followed by descent of finiteness from that reduction across the center's nilpotent thickening and geometric base change.

The new `TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/TrivialIdentity.lean` module is 168 lines. It reuses Tau Ceti's component-coordinate morphism and kernel theorem, pointwise surjectivity, augmentation-point characterization, and the full faithfulness of the affine-group functor of points. No Mathlib source is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-etale-trivial-identity-component"}-->

🤖 Prepared with Codex
