### PR TITLE
refactor(RootSystem): use iff_of_false for the six non-unimodular Cartan determinants

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/RootLattice.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/RootLattice.lean
@@ -95,46 +95,28 @@ theorem isUnit_det_cartanMatrix_iff (t : DynkinType) (ht : t.Valid) :
     have hn : 1 ≤ n := valid_A.mp ht
     have hdet : (A n).cartanMatrix.det = (n : ℤ) + 1 := by
       rw [cartanMatrix_A]; exact CartanMatrix.A_det n
-    refine ⟨fun h => absurd h ?_, fun h => ?_⟩
-    · rw [hdet, Int.isUnit_iff]
-      omega
-    · rcases h with h | h | h <;> simp at h
+    exact iff_of_false (by rw [hdet, Int.isUnit_iff]; omega) (by simp)
   | B n =>
     have hn : 2 ≤ n := valid_B.mp ht
     have hdet : (B n).cartanMatrix.det = 2 := by
       rw [cartanMatrix_B]; exact CartanMatrix.B_det (by omega)
-    refine ⟨fun h => absurd h ?_, fun h => ?_⟩
-    · rw [hdet, Int.isUnit_iff]
-      decide
-    · rcases h with h | h | h <;> simp at h
+    exact iff_of_false (by rw [hdet, Int.isUnit_iff]; decide) (by simp)
   | C n =>
     have hn : 3 ≤ n := valid_C.mp ht
     have hdet : (C n).cartanMatrix.det = 2 := by
       rw [cartanMatrix_C]; exact CartanMatrix.C_det (by omega)
-    refine ⟨fun h => absurd h ?_, fun h => ?_⟩
-    · rw [hdet, Int.isUnit_iff]
-      decide
-    · rcases h with h | h | h <;> simp at h
+    exact iff_of_false (by rw [hdet, Int.isUnit_iff]; decide) (by simp)
   | D n =>
     have hn : 4 ≤ n := valid_D.mp ht
     have hdet : (D n).cartanMatrix.det = 4 := by
       rw [cartanMatrix_D]; exact CartanMatrix.D_det (by omega)
-    refine ⟨fun h => absurd h ?_, fun h => ?_⟩
-    · rw [hdet, Int.isUnit_iff]
-      decide
-    · rcases h with h | h | h <;> simp at h
+    exact iff_of_false (by rw [hdet, Int.isUnit_iff]; decide) (by simp)
   | E6 =>
     have hdet : E6.cartanMatrix.det = 3 := by rw [cartanMatrix_E6]; exact CartanMatrix.E₆_det
-    refine ⟨fun h => absurd h ?_, fun h => ?_⟩
-    · rw [hdet, Int.isUnit_iff]
-      decide
-    · rcases h with h | h | h <;> simp at h
+    exact iff_of_false (by rw [hdet, Int.isUnit_iff]; decide) (by simp)
   | E7 =>
     have hdet : E7.cartanMatrix.det = 2 := by rw [cartanMatrix_E7]; exact CartanMatrix.E₇_det
-    refine ⟨fun h => absurd h ?_, fun h => ?_⟩
-    · rw [hdet, Int.isUnit_iff]
-      decide
-    · rcases h with h | h | h <;> simp at h
+    exact iff_of_false (by rw [hdet, Int.isUnit_iff]; decide) (by simp)
   | E8 =>
     have hdet : E8.cartanMatrix.det = 1 := by rw [cartanMatrix_E8]; exact CartanMatrix.E₈_det
     rw [hdet]


### PR DESCRIPTION
Uses `iff_of_false` where `isUnit_det_cartanMatrix_iff` was open-coding it six times.

## The duplicate

`isUnit_det_cartanMatrix_iff` splits on the nine valid Dynkin types. In the six whose Cartan
determinant is not a unit — `A n`, `B n`, `C n`, `D n`, `E₆`, `E₇` — both sides of the iff are
false, and each case spelled that out with the same four-line scaffold:

```lean
    refine ⟨fun h => absurd h ?_, fun h => ?_⟩
    · rw [hdet, Int.isUnit_iff]
      decide
    · rcases h with h | h | h <;> simp at h
```

Five of the six were byte-identical; the sixth (`A n`, whose determinant is `n + 1`) differed only
in closing with `omega` instead of `decide`.

## The fix

That scaffold is `iff_of_false : ¬a → ¬b → (a ↔ b)`, which Lean core already has
(`Init/Core.lean`). Rather than
extract a local helper that would have wrapped it, each case now names the library lemma directly
and collapses to one line:

```lean
    exact iff_of_false (by rw [hdet, Int.isUnit_iff]; decide) (by simp)
```

Both tactic blocks are the original text: `rw [hdet, Int.isUnit_iff]` followed by `decide`/`omega`
is verbatim what the first bullet ran, and `by simp` replaces `rcases h with h | h | h <;> simp at
h` on the negated disjunction — the same disjunction the three unimodular branches already leave to
`simp`. `iff_of_false` is the only identifier this PR adds to the file; every other name in the new
lines already appeared in the lines they replace.

The single-line `by rw [...]; <tac>` shape is this theorem's own existing idiom — each case's
`hdet` is proved by `by rw [cartanMatrix_X]; exact CartanMatrix.X_det`.

## What is deliberately left alone

The three unimodular cases (`E₈`, `F₄`, `G₂`) keep `rw [hdet]` / `simp`, and both neighbouring
theorems are untouched. Those three branches are two tactic lines each with nothing repeated
between them; rewriting them as `iff_of_true` would widen the diff without removing duplication,
which is the only thing this PR is for.

Nor is there a helper to extract here. The repeated block *is* `iff_of_false` composed with
`Int.isUnit_iff`; a private lemma wrapping it would be a local duplicate of two library results,
and the six copies differ in the `hdet` each one closes over, so a shared helper would have to take
that determinant and its value as parameters — which is `Int.isUnit_iff` again.

## Measured

| | before | after |
|---|---|---|
| `isUnit_det_cartanMatrix_iff` body | 59 | **41** |
| its largest contiguous block | 8 | **6** |
| whole file | 162 | **144** |

The diff is 6 insertions / 24 deletions in one file. No declaration is added, renamed, moved or
restated, no import changes, and no statement changes — the theorem, its docstring and its `@[simp]`
attribute are exactly as they were.

Roadmap: ReductiveGroups
