### PR TITLE
feat: add Student t moments

### DIFF
--- a/TauCeti/Probability/Distributions/StudentT.lean
+++ b/TauCeti/Probability/Distributions/StudentT.lean
@@ -41,8 +41,9 @@ hypothesis.
 * `hasPDF_of_hasLaw_studentTMeasure`, `pdf_eq_studentTPDF_of_hasLaw_studentTMeasure` and
   `rnDeriv_studentTMeasure` — the `HasPDF` bridge, the density, and the Radon–Nikodym derivative;
 * `studentTMeasure_map_neg` — the law is invariant under reflection in the origin;
-* `integrable_id_studentTMeasure_iff` and `integral_id_studentTMeasure` — the mean exists exactly
-  when `1 < ν`, and then equals zero;
+* `integrable_id_studentTMeasure_iff` and `integral_id_studentTMeasure` — within the nondegenerate
+  family the mean exists exactly when `1 < ν`, while its Bochner integral is zero for every
+  parameter;
 * `integrable_sq_studentTMeasure_iff`, `integral_sq_studentTMeasure` and
   `variance_id_studentTMeasure` — the second moment exists exactly when `2 < ν`, and then both it
   and the variance equal `ν / (ν - 2)`;
@@ -430,27 +431,24 @@ theorem integrable_id_studentTMeasure_iff (hν : 0 < ν) :
     simpa only [pow_one] using hint'
   · exact integrable_id_studentTMeasure_of_one_lt
 
-/-- The mean of a Student t law with more than one degree of freedom is zero. -/
+/-- The Bochner integral of the identity under a Student t measure is zero for every parameter,
+including by convention when the identity is not integrable. -/
 @[simp]
-theorem integral_id_studentTMeasure (hν : 1 < ν) :
+theorem integral_id_studentTMeasure (ν : ℝ) :
     ∫ x, x ∂studentTMeasure ν = 0 := by
-  have hint_id := integrable_id_studentTMeasure_of_one_lt hν
-  have hint : Integrable (fun x : ℝ => x) (studentTMeasure ν) := by
-    refine hint_id.congr (ae_of_all _ fun x => ?_)
-    rfl
-  have hpres : MeasurePreserving (fun x : ℝ => -x)
-      (studentTMeasure ν) (studentTMeasure ν) :=
-    ⟨measurable_neg, studentTMeasure_map_neg ν⟩
-  have hrefl : ∫ x, -x ∂studentTMeasure ν = ∫ x, x ∂studentTMeasure ν := by
-    simpa only [Function.comp_apply, id_eq] using
-      hpres.integral_comp (Homeomorph.neg ℝ).measurableEmbedding id
-  have hneg : Integrable (fun x : ℝ => -x) (studentTMeasure ν) := by
-    refine hint.neg.congr (ae_of_all _ fun x => ?_)
-    rfl
-  have hsum : (∫ x, x ∂studentTMeasure ν) + ∫ x, -x ∂studentTMeasure ν = 0 := by
-    rw [← integral_add hint hneg]
-    simp
-  linarith
+  by_cases hint : Integrable (fun x : ℝ => x) (studentTMeasure ν)
+  · have hpres : MeasurePreserving (fun x : ℝ => -x)
+        (studentTMeasure ν) (studentTMeasure ν) :=
+      ⟨measurable_neg, studentTMeasure_map_neg ν⟩
+    have hrefl : ∫ x, -x ∂studentTMeasure ν = ∫ x, x ∂studentTMeasure ν := by
+      simpa only [Function.comp_apply, id_eq] using
+        hpres.integral_comp (Homeomorph.neg ℝ).measurableEmbedding id
+    have hneg : Integrable (fun x : ℝ => -x) (studentTMeasure ν) := hint.neg
+    have hsum : (∫ x, x ∂studentTMeasure ν) + ∫ x, -x ∂studentTMeasure ν = 0 := by
+      rw [← integral_add hint hneg]
+      simp
+    linarith
+  · exact integral_undef hint
 
 private lemma studentTKernel_sq (hν : 0 < ν) (x : ℝ) :
     x ^ 2 * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) =
@@ -629,7 +627,7 @@ theorem variance_id_studentTMeasure (hν : 2 < ν) :
       (by simpa using integrable_sq_studentTMeasure_of_two_lt hν)
   rw [variance_eq_sub hmem]
   simp only [Pi.pow_apply, id_eq]
-  rw [integral_sq_studentTMeasure hν, integral_id_studentTMeasure (by linarith)]
+  rw [integral_sq_studentTMeasure hν, integral_id_studentTMeasure]
   ring
 
 /-! ### One degree of freedom -/

--- a/TauCeti/Probability/Distributions/StudentT.lean
+++ b/TauCeti/Probability/Distributions/StudentT.lean
@@ -430,12 +430,6 @@ theorem integrable_id_studentTMeasure_iff (hν : 0 < ν) :
     simpa only [pow_one] using hint'
   · exact integrable_id_studentTMeasure_of_one_lt
 
-/-- At or below one degree of freedom, a nondegenerate Student t law has no finite mean. -/
-theorem not_integrable_id_studentTMeasure (hν : 0 < ν) (hν1 : ν ≤ 1) :
-    ¬ Integrable id (studentTMeasure ν) := by
-  rw [integrable_id_studentTMeasure_iff hν]
-  exact not_lt.mpr hν1
-
 /-- The mean of a Student t law with more than one degree of freedom is zero. -/
 @[simp]
 theorem integral_id_studentTMeasure (hν : 1 < ν) :

--- a/TauCeti/Probability/Distributions/StudentT.lean
+++ b/TauCeti/Probability/Distributions/StudentT.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: Claude, Codex
 -/
 module
 
@@ -9,7 +9,9 @@ import TauCeti.Analysis.SpecialFunctions.Beta
 public import TauCeti.Probability.Density
 public import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
 public import Mathlib.Probability.Distributions.Cauchy
+public import Mathlib.Probability.Moments.Variance
 import TauCeti.Analysis.SpecialFunctions.Gamma
+import Mathlib.Analysis.SpecialFunctions.NonIntegrable
 import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 
 /-!
@@ -18,8 +20,9 @@ import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 Student's t law with `ν` degrees of freedom is the symmetric law on the line with density
 proportional to `(1 + x ^ 2 / ν) ^ (-(ν + 1) / 2)`. This file defines it, proves that it is a
 probability measure for `0 < ν`, identifies it as a `MeasureTheory.HasPDF` law with that density,
-records its reflection symmetry, and identifies the one degree of freedom member of the family
-with the standard Cauchy law.
+records its reflection symmetry, establishes the sharp first- and second-moment thresholds and
+formulas, and identifies the one degree of freedom member of the family with the standard Cauchy
+law.
 
 **Boundary.** The number of degrees of freedom must be positive for the density to normalize, so
 both `studentTPDFReal` and `studentTMeasure` are *defined* to vanish for `ν ≤ 0`
@@ -38,6 +41,11 @@ hypothesis.
 * `hasPDF_of_hasLaw_studentTMeasure`, `pdf_eq_studentTPDF_of_hasLaw_studentTMeasure` and
   `rnDeriv_studentTMeasure` — the `HasPDF` bridge, the density, and the Radon–Nikodym derivative;
 * `studentTMeasure_map_neg` — the law is invariant under reflection in the origin;
+* `integrable_id_studentTMeasure_iff` and `integral_id_studentTMeasure` — the mean exists exactly
+  when `1 < ν`, and then equals zero;
+* `integrable_sq_studentTMeasure_iff`, `integral_sq_studentTMeasure` and
+  `variance_id_studentTMeasure` — the second moment exists exactly when `2 < ν`, and then both it
+  and the variance equal `ν / (ν - 2)`;
 * `studentTMeasure_one` — one degree of freedom gives the standard Cauchy law
   `ProbabilityTheory.cauchyMeasure 0 1`;
 * `measurable_studentTMeasure` — the family is measurable in its parameter, so it can be used as a
@@ -49,7 +57,9 @@ The whole analytic content is the normalization. Scaling by `√ν` with
 `MeasureTheory.integral_comp_mul_left` reduces the total mass of `(1 + x ^ 2 / ν) ^ (-(ν + 1) / 2)`
 to that of the Cauchy-type kernel `(1 + x ^ 2) ^ (-(ν + 1) / 2)`, which is
 `TauCeti.integral_one_add_sq_rpow`: the value `Β(1 / 2, ν / 2)` of Euler's second beta integral.
-Writing that value as a quotient of Gamma values cancels the normalizing constant exactly.
+Writing that value as a quotient of Gamma values cancels the normalizing constant exactly. The
+positive moment results reduce to the same beta integral, while the sharp failures use a positive
+multiple of `x⁻¹` as a lower bound on the corresponding weighted density in the right tail.
 
 ## References
 
@@ -62,7 +72,7 @@ public section
 
 noncomputable section
 
-open MeasureTheory ProbabilityTheory Set
+open Filter MeasureTheory ProbabilityTheory Set
 
 open scoped ENNReal Real
 
@@ -257,6 +267,376 @@ theorem studentTMeasure_map_neg (ν : ℝ) :
   have h := (Measure.measurePreserving_neg (volume : Measure ℝ)).setLIntegral_comp_preimage_emb
     (Homeomorph.neg ℝ).measurableEmbedding (studentTPDF ν) t
   simpa only [studentTPDF_neg] using h
+
+/-! ### Moments -/
+
+private lemma studentTKernel_id_factor (hν : 0 < ν) (x : ℝ) :
+    (x / √(1 + x ^ 2 / ν)) * (1 + x ^ 2 / ν) ^ (-(ν / 2)) =
+      x * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) := by
+  have hbase : 0 < 1 + x ^ 2 / ν := by positivity
+  rw [Real.sqrt_eq_rpow, div_eq_mul_inv, ← Real.rpow_neg hbase.le, mul_assoc,
+    ← Real.rpow_add hbase]
+  congr 2
+  ring
+
+private lemma integrable_id_mul_studentTKernel (hν : 1 < ν) :
+    Integrable (fun x : ℝ =>
+      x * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) := by
+  have hνpos : 0 < ν := lt_trans zero_lt_one hν
+  have hkernel : Integrable (fun x : ℝ => (1 + x ^ 2 / ν) ^ (-(ν / 2))) :=
+    integrable_one_add_sq_div_rpow hνpos (by linarith)
+  have hbounded : ∀ x : ℝ, ‖x / √(1 + x ^ 2 / ν)‖ ≤ √ν := by
+    intro x
+    have hbase : 0 < 1 + x ^ 2 / ν := by positivity
+    rw [Real.norm_eq_abs, abs_div, abs_of_pos (Real.sqrt_pos.mpr hbase),
+      div_le_iff₀ (Real.sqrt_pos.mpr hbase)]
+    have hsq : |x| ^ 2 ≤ (√ν * √(1 + x ^ 2 / ν)) ^ 2 := by
+      rw [sq_abs, mul_pow, Real.sq_sqrt hνpos.le, Real.sq_sqrt hbase.le]
+      have hmul : ν * (1 + x ^ 2 / ν) = ν + x ^ 2 := by field_simp
+      rw [hmul]
+      linarith
+    have hprod_nonneg : 0 ≤ √ν * √(1 + x ^ 2 / ν) :=
+      mul_nonneg (Real.sqrt_nonneg ν) (Real.sqrt_nonneg (1 + x ^ 2 / ν))
+    nlinarith [abs_nonneg x]
+  have hproduct : Integrable (fun x : ℝ =>
+      (x / √(1 + x ^ 2 / ν)) * (1 + x ^ 2 / ν) ^ (-(ν / 2))) :=
+    hkernel.bdd_mul (measurable_id.div
+      (Real.continuous_sqrt.measurable.comp (by fun_prop))).aestronglyMeasurable
+      (ae_of_all _ hbounded)
+  exact hproduct.congr (ae_of_all _ fun x => studentTKernel_id_factor hνpos x)
+
+private theorem integrable_id_studentTMeasure_of_one_lt (hν : 1 < ν) :
+    Integrable id (studentTMeasure ν) := by
+  have hνpos : 0 < ν := lt_trans zero_lt_one hν
+  rw [studentTMeasure, integrable_withDensity_iff (measurable_studentTPDF ν)
+    (ae_of_all _ fun _ => ENNReal.ofReal_lt_top)]
+  simp_rw [id_eq, toReal_studentTPDF, studentTPDFReal_of_pos hνpos]
+  have h := (integrable_id_mul_studentTKernel hν).const_mul
+    (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)))
+  exact h.congr (ae_of_all _ fun x => by ring)
+
+private theorem studentTPDFReal_tail_lower_bound (hν : 0 < ν) (q : ℕ)
+    (hνq : ν ≤ (q : ℝ)) :
+    ∀ᶠ x : ℝ in atTop,
+      (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2))) *
+          (1 + ν⁻¹) ^ (-(((q : ℝ) + 1) / 2)) * x⁻¹ ≤
+        x ^ q * studentTPDFReal ν x := by
+  filter_upwards [eventually_ge_atTop (1 : ℝ)] with x hx
+  have hx0 : 0 < x := zero_lt_one.trans_le hx
+  -- On the right tail, compare the kernel base with a constant multiple of `x²`, then use
+  -- `ν ≤ q` to compare the two negative exponents.
+  have hbase_pos : 0 < 1 + x ^ 2 / ν := by positivity
+  have hbase_one : 1 ≤ 1 + x ^ 2 / ν :=
+    le_add_of_nonneg_right (div_nonneg (sq_nonneg x) hν.le)
+  have hconst_pos : 0 < 1 + ν⁻¹ := by positivity
+  have hdensity_pos :
+      0 < Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)) :=
+    studentT_const_pos hν
+  have hbase_le : 1 + x ^ 2 / ν ≤ (1 + ν⁻¹) * x ^ 2 := by
+    have hx_sq : 1 ≤ x ^ 2 := (one_le_sq_iff₀ hx0.le).2 hx
+    rw [div_eq_mul_inv]
+    nlinarith [mul_nonneg (zero_le_one.trans hx_sq) (inv_nonneg.mpr hν.le)]
+  have hexp : -(((q : ℝ) + 1) / 2) ≤ -((ν + 1) / 2) := by
+    norm_num at hνq ⊢
+    linarith
+  have hpow₁ : (1 + x ^ 2 / ν) ^ (-(((q : ℝ) + 1) / 2)) ≤
+      (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) :=
+    Real.rpow_le_rpow_of_exponent_le hbase_one hexp
+  have hpow₂ : ((1 + ν⁻¹) * x ^ 2) ^ (-(((q : ℝ) + 1) / 2)) ≤
+      (1 + x ^ 2 / ν) ^ (-(((q : ℝ) + 1) / 2)) :=
+    Real.rpow_le_rpow_of_nonpos hbase_pos hbase_le (by
+      have hq : 0 ≤ (q : ℝ) := Nat.cast_nonneg q
+      linarith)
+  -- Splitting the comparison kernel exposes exactly `x ^ q * x ^ (-(q + 1)) = x⁻¹`.
+  have hsplit : ((1 + ν⁻¹) * x ^ 2) ^ (-(((q : ℝ) + 1) / 2)) =
+      (1 + ν⁻¹) ^ (-(((q : ℝ) + 1) / 2)) * x ^ (-((q : ℝ) + 1)) := by
+    rw [Real.mul_rpow hconst_pos.le (sq_nonneg x), ← Real.rpow_two x,
+      ← Real.rpow_mul hx0.le]
+    congr 2
+    ring
+  have hxpow : x ^ (q : ℝ) * x ^ (-((q : ℝ) + 1)) = x⁻¹ := by
+    rw [← Real.rpow_add hx0]
+    have hexponent : (q : ℝ) + -((q : ℝ) + 1) = -1 := by ring
+    rw [hexponent, Real.rpow_neg_one]
+  rw [studentTPDFReal_of_pos hν]
+  calc
+    (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2))) *
+          (1 + ν⁻¹) ^ (-(((q : ℝ) + 1) / 2)) * x⁻¹ =
+        (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2))) *
+          (x ^ q * ((1 + ν⁻¹) * x ^ 2) ^ (-(((q : ℝ) + 1) / 2))) := by
+            rw [hsplit, ← Real.rpow_natCast x q, ← hxpow]
+            ring
+    _ ≤ (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2))) *
+          (x ^ q * (1 + x ^ 2 / ν) ^ (-(((q : ℝ) + 1) / 2))) := by
+            exact mul_le_mul_of_nonneg_left
+              (mul_le_mul_of_nonneg_left hpow₂ (pow_nonneg hx0.le q)) hdensity_pos.le
+    _ ≤ x ^ q *
+          (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)) *
+            (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) := by
+            calc
+              _ ≤ (Real.Gamma ((ν + 1) / 2) /
+                    (√(ν * π) * Real.Gamma (ν / 2))) *
+                  (x ^ q * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) :=
+                mul_le_mul_of_nonneg_left
+                  (mul_le_mul_of_nonneg_left hpow₁ (pow_nonneg hx0.le q))
+                  hdensity_pos.le
+              _ = _ := by ring
+    _ = _ := by ring
+
+private theorem not_integrable_pow_studentTMeasure (hν : 0 < ν) (q : ℕ)
+    (hνq : ν ≤ (q : ℝ)) :
+    ¬ Integrable (fun x : ℝ => x ^ q) (studentTMeasure ν) := by
+  intro hint
+  rw [studentTMeasure, integrable_withDensity_iff (measurable_studentTPDF ν)
+    (ae_of_all _ fun _ => ENNReal.ofReal_lt_top)] at hint
+  simp_rw [toReal_studentTPDF] at hint
+  let c : ℝ :=
+    (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2))) *
+      (1 + ν⁻¹) ^ (-(((q : ℝ) + 1) / 2))
+  have hc : 0 < c := by
+    dsimp [c]
+    positivity
+  have hbound : ∀ᶠ x : ℝ in atTop,
+      c * x⁻¹ ≤ x ^ q * studentTPDFReal ν x := by
+    simpa only [c] using studentTPDFReal_tail_lower_bound hν q hνq
+  obtain ⟨a, ha⟩ := eventually_atTop.mp
+    (hbound.and (eventually_ge_atTop (1 : ℝ)))
+  have hinv : IntegrableOn (fun x : ℝ => x⁻¹) (Ioi a) volume := by
+    refine Integrable.mono' (hint.const_mul c⁻¹).integrableOn (by fun_prop) ?_
+    filter_upwards [ae_restrict_mem measurableSet_Ioi] with x hx
+    rcases ha x hx.le with ⟨hpdf, hx1⟩
+    have hx0 : 0 < x := zero_lt_one.trans_le hx1
+    calc
+      ‖x⁻¹‖ = x⁻¹ := by rw [Real.norm_eq_abs, abs_of_pos (inv_pos.mpr hx0)]
+      _ = c⁻¹ * (c * x⁻¹) := by field_simp
+      _ ≤ c⁻¹ * (x ^ q * studentTPDFReal ν x) :=
+        mul_le_mul_of_nonneg_left hpdf (inv_nonneg.mpr hc.le)
+  exact not_integrableOn_Ioi_inv hinv
+
+/-- The identity is integrable under a nondegenerate Student t law exactly when the number of
+degrees of freedom exceeds one. -/
+@[simp]
+theorem integrable_id_studentTMeasure_iff (hν : 0 < ν) :
+    Integrable id (studentTMeasure ν) ↔ 1 < ν := by
+  constructor
+  · intro hint
+    by_contra h
+    have hnot := not_integrable_pow_studentTMeasure hν 1 (by
+      simpa using (not_lt.mp h : ν ≤ 1))
+    have hint' : Integrable (fun x : ℝ => x) (studentTMeasure ν) := by
+      refine hint.congr (ae_of_all _ fun x => ?_)
+      rfl
+    apply hnot
+    simpa only [pow_one] using hint'
+  · exact integrable_id_studentTMeasure_of_one_lt
+
+/-- At or below one degree of freedom, a nondegenerate Student t law has no finite mean. -/
+theorem not_integrable_id_studentTMeasure (hν : 0 < ν) (hν1 : ν ≤ 1) :
+    ¬ Integrable id (studentTMeasure ν) := by
+  rw [integrable_id_studentTMeasure_iff hν]
+  exact not_lt.mpr hν1
+
+/-- The mean of a Student t law with more than one degree of freedom is zero. -/
+@[simp]
+theorem integral_id_studentTMeasure (hν : 1 < ν) :
+    ∫ x, x ∂studentTMeasure ν = 0 := by
+  have hint_id := integrable_id_studentTMeasure_of_one_lt hν
+  have hint : Integrable (fun x : ℝ => x) (studentTMeasure ν) := by
+    refine hint_id.congr (ae_of_all _ fun x => ?_)
+    rfl
+  have hpres : MeasurePreserving (fun x : ℝ => -x)
+      (studentTMeasure ν) (studentTMeasure ν) :=
+    ⟨measurable_neg, studentTMeasure_map_neg ν⟩
+  have hrefl : ∫ x, -x ∂studentTMeasure ν = ∫ x, x ∂studentTMeasure ν := by
+    simpa only [Function.comp_apply, id_eq] using
+      hpres.integral_comp (Homeomorph.neg ℝ).measurableEmbedding id
+  have hneg : Integrable (fun x : ℝ => -x) (studentTMeasure ν) := by
+    refine hint.neg.congr (ae_of_all _ fun x => ?_)
+    rfl
+  have hsum : (∫ x, x ∂studentTMeasure ν) + ∫ x, -x ∂studentTMeasure ν = 0 := by
+    rw [← integral_add hint hneg]
+    simp
+  linarith
+
+private lemma studentTKernel_sq (hν : 0 < ν) (x : ℝ) :
+    x ^ 2 * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) =
+      ν * ((1 + x ^ 2 / ν) ^ (-((ν - 1) / 2)) -
+        (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) := by
+  have hbase : 0 < 1 + x ^ 2 / ν := by positivity
+  have hshift :
+      (1 + x ^ 2 / ν) ^ (-((ν - 1) / 2)) =
+        (1 + x ^ 2 / ν) * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) := by
+    calc
+      (1 + x ^ 2 / ν) ^ (-((ν - 1) / 2)) =
+          (1 + x ^ 2 / ν) ^ (1 + -((ν + 1) / 2)) := by
+        apply congrArg (fun t : ℝ => (1 + x ^ 2 / ν) ^ t)
+        ring
+      _ = (1 + x ^ 2 / ν) ^ 1 *
+          (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) := Real.rpow_add hbase _ _
+      _ = (1 + x ^ 2 / ν) *
+          (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) := by rw [Real.rpow_one]
+  rw [hshift]
+  field_simp
+  ring
+
+private lemma integrable_sq_mul_studentTKernel (hν : 2 < ν) :
+    Integrable (fun x : ℝ =>
+      x ^ 2 * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) := by
+  have hνpos : 0 < ν := lt_trans zero_lt_two hν
+  have hshift : Integrable (fun x : ℝ =>
+      (1 + x ^ 2 / ν) ^ (-((ν - 1) / 2))) :=
+    integrable_one_add_sq_div_rpow hνpos (by linarith)
+  have hbase : Integrable (fun x : ℝ =>
+      (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) :=
+    integrable_one_add_sq_div_rpow hνpos (by linarith)
+  exact ((hshift.sub hbase).const_mul ν).congr
+    (ae_of_all _ fun x => (studentTKernel_sq hνpos x).symm)
+
+private theorem integrable_sq_studentTMeasure_of_two_lt (hν : 2 < ν) :
+    Integrable (fun x : ℝ => x ^ 2) (studentTMeasure ν) := by
+  have hνpos : 0 < ν := lt_trans zero_lt_two hν
+  rw [studentTMeasure, integrable_withDensity_iff (measurable_studentTPDF ν)
+    (ae_of_all _ fun _ => ENNReal.ofReal_lt_top)]
+  simp_rw [toReal_studentTPDF, studentTPDFReal_of_pos hνpos]
+  have h := (integrable_sq_mul_studentTKernel hν).const_mul
+    (Real.Gamma ((ν + 1) / 2) / (√(ν * π) * Real.Gamma (ν / 2)))
+  exact h.congr (ae_of_all _ fun x => by ring)
+
+private lemma beta_sub_beta_add_one (hν : 2 < ν) :
+    beta (1 / 2) ((ν - 2) / 2) - beta (1 / 2) (ν / 2) =
+      beta (3 / 2) ((ν - 2) / 2) := by
+  let b := (ν - 2) / 2
+  have hb : b ≠ 0 := by
+    dsimp [b]
+    linarith
+  have hsum : b + 1 / 2 ≠ 0 := by
+    dsimp [b]
+    linarith
+  have hright : beta (1 / 2) (b + 1) =
+      b / (b + 1 / 2) * beta (1 / 2) b := by
+    rw [beta_comm (1 / 2) (b + 1), beta_add_one_left hb hsum,
+      beta_comm b (1 / 2)]
+  have hleft : beta (1 / 2 + 1) b =
+      (1 / 2) / (1 / 2 + b) * beta (1 / 2) b :=
+    beta_add_one_left (by norm_num) (by simpa [add_comm] using hsum)
+  have hνdiv : ν / 2 = b + 1 := by
+    dsimp [b]
+    ring
+  have hthree : (3 : ℝ) / 2 = 1 / 2 + 1 := by ring
+  rw [hνdiv, hthree, hright, hleft]
+  have hcoeff : 1 - b / (b + 1 / 2) = (1 / 2) / (1 / 2 + b) := by
+    have hsum' : 1 / 2 + b ≠ 0 := by simpa [add_comm] using hsum
+    have hbhalf : b + 1 / 2 = 1 / 2 + b := by ring
+    rw [hbhalf]
+    apply (eq_div_iff hsum').2
+    rw [sub_mul, one_mul, div_mul_cancel₀ b hsum']
+    ring
+  calc
+    beta (1 / 2) b - b / (b + 1 / 2) * beta (1 / 2) b =
+        (1 - b / (b + 1 / 2)) * beta (1 / 2) b := by ring
+    _ = (1 / 2) / (1 / 2 + b) * beta (1 / 2) b := by rw [hcoeff]
+
+private lemma integral_sq_mul_studentTKernel (hν : 2 < ν) :
+    ∫ x : ℝ, x ^ 2 * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) =
+      ν * √ν * beta (3 / 2) ((ν - 2) / 2) := by
+  have hνpos : 0 < ν := lt_trans zero_lt_two hν
+  have hshift : Integrable (fun x : ℝ =>
+      (1 + x ^ 2 / ν) ^ (-((ν - 1) / 2))) :=
+    integrable_one_add_sq_div_rpow hνpos (by linarith)
+  have hbase : Integrable (fun x : ℝ =>
+      (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) :=
+    integrable_one_add_sq_div_rpow hνpos (by linarith)
+  have hminus : (ν - 1) / 2 - 1 / 2 = (ν - 2) / 2 := by ring
+  have hplus : (ν + 1) / 2 - 1 / 2 = ν / 2 := by ring
+  calc
+    ∫ x : ℝ, x ^ 2 * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) =
+        ∫ x : ℝ, ν * ((1 + x ^ 2 / ν) ^ (-((ν - 1) / 2)) -
+          (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) := by
+      exact integral_congr_ae (ae_of_all _ fun x => studentTKernel_sq hνpos x)
+    _ = ν * ((∫ x : ℝ, (1 + x ^ 2 / ν) ^ (-((ν - 1) / 2))) -
+          ∫ x : ℝ, (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) := by
+      rw [integral_const_mul, integral_sub hshift hbase]
+    _ = ν * (√ν * beta (1 / 2) ((ν - 1) / 2 - 1 / 2) -
+          √ν * beta (1 / 2) ((ν + 1) / 2 - 1 / 2)) := by
+      rw [integral_one_add_sq_div_rpow hνpos (by linarith),
+        integral_one_add_sq_div_rpow hνpos (by linarith)]
+    _ = ν * √ν * beta (3 / 2) ((ν - 2) / 2) := by
+      rw [hminus, hplus, ← mul_sub, beta_sub_beta_add_one hν]
+      ring
+
+/-- The second raw moment of a Student t law is `ν / (ν - 2)` when `2 < ν`. -/
+@[simp]
+theorem integral_sq_studentTMeasure (hν : 2 < ν) :
+    ∫ x, x ^ 2 ∂studentTMeasure ν = ν / (ν - 2) := by
+  have hνpos : 0 < ν := lt_trans zero_lt_two hν
+  have hbpos : 0 < (ν - 2) / 2 := by linarith
+  have hGν : Real.Gamma (ν / 2) ≠ 0 := (Real.Gamma_pos_of_pos (by linarith)).ne'
+  have hGb : Real.Gamma ((ν - 2) / 2) ≠ 0 := (Real.Gamma_pos_of_pos hbpos).ne'
+  have hGs : Real.Gamma ((ν + 1) / 2) ≠ 0 :=
+    (Real.Gamma_pos_of_pos (by linarith)).ne'
+  have hsqrtν : √ν ≠ 0 := (Real.sqrt_pos.mpr hνpos).ne'
+  have hsqrtπ : √π ≠ 0 := (Real.sqrt_pos.mpr Real.pi_pos).ne'
+  have hsub : ν - 2 ≠ 0 := by linarith
+  have hthree : (3 : ℝ) / 2 = 1 / 2 + 1 := by ring
+  have hgammaSum : (1 : ℝ) / 2 + 1 + (ν - 2) / 2 = (ν + 1) / 2 := by ring
+  have hνhalf : ν / 2 = (ν - 2) / 2 + 1 := by ring
+  rw [studentTMeasure, integral_withDensity_eq_integral_toReal_smul
+    (measurable_studentTPDF ν) (ae_of_all _ fun _ => ENNReal.ofReal_lt_top)]
+  simp_rw [toReal_studentTPDF, smul_eq_mul, studentTPDFReal_of_pos hνpos]
+  calc
+    ∫ x : ℝ, (Real.Gamma ((ν + 1) / 2) /
+          (√(ν * π) * Real.Gamma (ν / 2)) *
+          (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2))) * x ^ 2 =
+        Real.Gamma ((ν + 1) / 2) /
+          (√(ν * π) * Real.Gamma (ν / 2)) *
+          ∫ x : ℝ, x ^ 2 * (1 + x ^ 2 / ν) ^ (-((ν + 1) / 2)) := by
+      rw [← integral_const_mul]
+      congr 1
+      funext x
+      ring
+    _ = Real.Gamma ((ν + 1) / 2) /
+          (√(ν * π) * Real.Gamma (ν / 2)) *
+          (ν * √ν * beta (3 / 2) ((ν - 2) / 2)) := by
+      rw [integral_sq_mul_studentTKernel hν]
+    _ = ν / (ν - 2) := by
+      rw [ProbabilityTheory.beta, hthree,
+        Real.Gamma_add_one (by norm_num : (1 : ℝ) / 2 ≠ 0),
+        Real.Gamma_one_half_eq, hgammaSum, hνhalf,
+        Real.Gamma_add_one (ne_of_gt hbpos), Real.sqrt_mul hνpos.le]
+      field_simp
+
+/-- Squaring is integrable under a nondegenerate Student t law exactly when the number of degrees
+of freedom exceeds two. -/
+@[simp]
+theorem integrable_sq_studentTMeasure_iff (hν : 0 < ν) :
+    Integrable (fun x : ℝ => x ^ 2) (studentTMeasure ν) ↔ 2 < ν := by
+  constructor
+  · intro hint
+    by_contra h
+    exact not_integrable_pow_studentTMeasure hν 2 (by
+      simpa using (not_lt.mp h : ν ≤ 2)) hint
+  · exact integrable_sq_studentTMeasure_of_two_lt
+
+/-- At or below two degrees of freedom, the second raw moment of a nondegenerate Student t law
+diverges. -/
+theorem not_integrable_sq_studentTMeasure (hν : 0 < ν) (hν2 : ν ≤ 2) :
+    ¬ Integrable (fun x : ℝ => x ^ 2) (studentTMeasure ν) := by
+  rw [integrable_sq_studentTMeasure_iff hν]
+  exact not_lt.mpr hν2
+
+/-- The variance of a Student t law is `ν / (ν - 2)` when `2 < ν`. -/
+@[simp]
+theorem variance_id_studentTMeasure (hν : 2 < ν) :
+    variance id (studentTMeasure ν) = ν / (ν - 2) := by
+  have _ : IsProbabilityMeasure (studentTMeasure ν) :=
+    isProbabilityMeasure_studentTMeasure (lt_trans zero_lt_two hν)
+  have hmem : MemLp id 2 (studentTMeasure ν) :=
+    (memLp_two_iff_integrable_sq measurable_id'.aestronglyMeasurable).2
+      (by simpa using integrable_sq_studentTMeasure_of_two_lt hν)
+  rw [variance_eq_sub hmem]
+  simp only [Pi.pow_apply, id_eq]
+  rw [integral_sq_studentTMeasure hν, integral_id_studentTMeasure (by linarith)]
+  ring
 
 /-! ### One degree of freedom -/
 


### PR DESCRIPTION
This PR proves the moment portion of the Student's t target in `StandardDistributions/README.md`, Layer 3, “new scalar families”: within the valid family, prove mean zero exactly when the identity is integrable (`1 < ν`), prove non-integrability when `0 < ν ≤ 1`, prove the second moment and variance formula `ν / (ν - 2)` for `2 < ν`, and prove square non-integrability when `0 < ν ≤ 2`. The sharp converses use a private positive-tail comparison with `x⁻¹`, while the finite formulas reuse Tau Ceti's beta-integral infrastructure and the existing reflection invariance.

After this PR, the Student's t target still needs the regularized-incomplete-beta cdf and the exact exponential-integrability domain.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"student-t-moments"}-->

No Mathlib code is vendored; the proof reuses `integrable_withDensity_iff`, `not_integrableOn_Ioi_inv`, `memLp_two_iff_integrable_sq`, and `variance_eq_sub`, together with Tau Ceti's `integrable_one_add_sq_div_rpow` and `integral_one_add_sq_div_rpow`. The formulas follow N. L. Johnson, S. Kotz, and N. Balakrishnan, *Continuous Univariate Distributions*, vol. 2, chapter 28.

🤖 Prepared with Codex
