### PR TITLE
feat: attach the rank-two type-C carrier to both families on the B₂ diagram

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean
@@ -57,7 +57,7 @@ pinned group; and its order is the superscript in the printed family name, recor
   `TauCeti.GraphTwistedIndex.twistOrder_pos`: the twist order annihilates the permutation, is
   exactly its order, and is positive.
 * `TauCeti.TypeB2LieIndex.diagramPerm_toGraphTwistedIndex`: the untwisted family on the `B₂`
-  diagram takes the identity, which places it in the untwisted row of the table.
+  diagram takes the identity, the `B₂` diagram having no symmetry to twist by.
 * `TauCeti.TypeE6LieIndex.diagramPerm_toGraphTwistedIndex` and
   `TauCeti.TypeTwistedE6LieIndex.diagramPerm_toGraphTwistedIndex`: the two families on the `E₆`
   diagram take the identity and `TauCeti.graphPermE6` respectively, which is the distinction
@@ -368,10 +368,9 @@ family, is excluded by that same condition. -/
 abbrev toGraphTwistedIndex (d : TypeB2LieIndex) : GraphTwistedIndex :=
   ⟨d.1.1, d.2⟩
 
-/-- **The diagram permutation of the untwisted family `B₂(q)` is the identity**, which is what
-places it in the untwisted row of milestone L1's table, where the Steinberg map is `Frob_q`
-outright. The `B₂` diagram has no symmetry to twist by in any case: its two nodes have different
-root lengths. -/
+/-- **The diagram permutation of the untwisted family `B₂(q)` is the identity**, so its Steinberg
+map composes with no twist and is the `q`-power Frobenius outright. The `B₂` diagram has no
+symmetry to twist by in any case: its two nodes have different root lengths. -/
 @[simp]
 theorem diagramPerm_toGraphTwistedIndex (d : TypeB2LieIndex) :
     d.toGraphTwistedIndex.diagramPerm = 1 := by

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean
@@ -38,13 +38,14 @@ pinned group; and its order is the superscript in the printed family name, recor
   the Steinberg map of a graph-twisted index composes with the field Frobenius.
 * `TauCeti.GraphTwistedIndex.twistOrder`: the order of that permutation, which is the superscript
   in the family name.
-* `TauCeti.TypeALieIndex.toGraphTwistedIndex`, `TauCeti.TypeCLieIndex.toGraphTwistedIndex`,
+* `TauCeti.TypeALieIndex.toGraphTwistedIndex`, `TauCeti.TypeB2LieIndex.toGraphTwistedIndex`,
+  `TauCeti.TypeCLieIndex.toGraphTwistedIndex`,
   `TauCeti.TypeE6LieIndex.toGraphTwistedIndex`,
   `TauCeti.TypeTwistedE6LieIndex.toGraphTwistedIndex` and
   `TauCeti.TypeDDiagramLieIndex.toGraphTwistedIndex`: the two type-A families, `Aₙ(q)` and
-  `²Aₙ(q)`, the untwisted type-C family, the two families on the `E₆` diagram, and the three
-  families on a type-`D` diagram, as indices of that subtype, so that the permutations above are
-  attached to
+  `²Aₙ(q)`, the untwisted rank-two family `B₂(q)`, the untwisted type-C family, the two families on
+  the `E₆` diagram, and the three families on a type-`D` diagram, as indices of that subtype, so
+  that the permutations above are attached to
   them.
 
 ## Main results
@@ -55,6 +56,8 @@ pinned group; and its order is the superscript in the printed family name, recor
   `TauCeti.GraphTwistedIndex.orderOf_diagramPerm` and
   `TauCeti.GraphTwistedIndex.twistOrder_pos`: the twist order annihilates the permutation, is
   exactly its order, and is positive.
+* `TauCeti.TypeB2LieIndex.diagramPerm_toGraphTwistedIndex`: the untwisted family on the `B₂`
+  diagram takes the identity, which places it in the untwisted row of the table.
 * `TauCeti.TypeE6LieIndex.diagramPerm_toGraphTwistedIndex` and
   `TauCeti.TypeTwistedE6LieIndex.diagramPerm_toGraphTwistedIndex`: the two families on the `E₆`
   diagram take the identity and `TauCeti.graphPermE6` respectively, which is the distinction
@@ -353,6 +356,29 @@ abbrev toGraphTwistedIndex (d : TypeALieIndex) : GraphTwistedIndex :=
   ⟨d.1, not_usesHalfFrobenius_of_isTypeA d.2⟩
 
 end TypeALieIndex
+
+/-! ### The untwisted family `B₂(q)` as a graph-twisted index -/
+
+namespace TypeB2LieIndex
+
+/-- The untwisted rank-two family `B₂(q)`, regarded as an ordinary-or-graph-twisted index. Of the
+two classification-list families on the `B₂` diagram it is the one that uses no half-Frobenius,
+which is exactly the membership condition of `TauCeti.GraphTwistedIndex`; the other, the Suzuki
+family, is excluded by that same condition. -/
+abbrev toGraphTwistedIndex (d : TypeB2LieIndex) : GraphTwistedIndex :=
+  ⟨d.1.1, d.2⟩
+
+/-- **The diagram permutation of the untwisted family `B₂(q)` is the identity**, which is what
+places it in the untwisted row of milestone L1's table, where the Steinberg map is `Frob_q`
+outright. The `B₂` diagram has no symmetry to twist by in any case: its two nodes have different
+root lengths. -/
+@[simp]
+theorem diagramPerm_toGraphTwistedIndex (d : TypeB2LieIndex) :
+    d.toGraphTwistedIndex.diagramPerm = 1 := by
+  obtain ⟨q, hvalid, rfl⟩ := d.exists_eq_of
+  exact GraphTwistedIndex.diagramPerm_B hvalid
+
+end TypeB2LieIndex
 
 /-! ### The type-C family as graph-twisted indices -/
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
@@ -1139,6 +1139,13 @@ half-Frobenius. -/
 abbrev toSuzukiReeIndex (d : SuzukiLieIndex) : SuzukiReeIndex :=
   ⟨d.1, LieTypeIndex.usesHalfFrobenius_of_isSuzuki d.2⟩
 
+/-- A Suzuki index is an index on the rank-two diagram `B₂`. This is the reading through which the
+Suzuki family reaches the carrier data that
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean` attaches to that diagram and that it shares
+with the untwisted family `B₂(q)`, the two differing only in the endomorphism taken of it. -/
+abbrev toRankTwoBLieIndex (d : SuzukiLieIndex) : RankTwoBLieIndex :=
+  ⟨d.1, d.dynkinType_eq⟩
+
 end SuzukiLieIndex
 
 /-! ## The untwisted family `E₆(q)`

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean
@@ -39,10 +39,13 @@ table asks of an untwisted family and what `TauCeti.TypeB2LieIndex.diagramPerm_t
 checks: the diagram permutation the index carries is trivial, the `B₂` diagram having no symmetry to
 twist by. On the Suzuki branch it is instead `τ ^ (2m+1)` for the special isogeny `τ` of the pinned
 `B₂` group scheme in characteristic two, which milestone L2 consumes from Layer 9 of the
-reductive-groups roadmap and does not build; what this file supplies towards it is the second factor
-of the relation `τ ^ 2 = Frob_p` that identifies `τ`. Either way the map below is the `q`-power
-Frobenius, at the field order the index records, on the very carrier those fixed points will be
-taken in. A Suzuki index reaches all of it through `TauCeti.SuzukiLieIndex.toRankTwoBLieIndex`.
+reductive-groups roadmap and does not build. That `τ` is identified by the relation
+`τ ^ 2 = Frob_p` in the prime characteristic, and `Frob_p` is not the map supplied here: validity
+forces `1 ≤ m`, so the field order `q = 2 ^ (2m+1)` the index records is larger than the prime.
+What this file supplies is `Frob_q`, the map the odd power `τ ^ (2m+1)` squares to. Either way the
+map below is the `q`-power Frobenius at the field order the index records, on this carrier, which
+becomes the carrier those fixed points are taken in only along the Layer 9 identification described
+below. A Suzuki index reaches all of it through `TauCeti.SuzukiLieIndex.toRankTwoBLieIndex`.
 
 Neither branch gets a Steinberg map or a milestone L3 quotient here, and neither gets a candidate
 simple group. Milestone L1 asks for the Steinberg endomorphism of the points of the *pinned* simply
@@ -184,11 +187,11 @@ theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (ht : (B 2).Valid)
 /-! ## The Frobenius endomorphism -/
 
 /-- **The `q`-power Frobenius endomorphism of the ambient group of an index on the `B₂` diagram**,
-for `q` the field order the index records. It is the map from which the Steinberg endomorphism of
-either family on this diagram is built once the milestone L0 carrier is available: on the untwisted
-family `B₂(q)` that endomorphism is the `q`-power Frobenius outright, and on the Suzuki family it is
-the odd power `τ ^ (2m+1)` of the special isogeny, whose square is the Frobenius. Neither is formed
-here. -/
+for `q` the field order the index records. The map the Steinberg endomorphism of either family on
+this diagram is built from is its counterpart on the milestone L0 carrier: on the untwisted family
+`B₂(q)` that endomorphism is the `q`-power Frobenius outright, and on the Suzuki family it is the
+odd power `τ ^ (2m+1)` of the special isogeny, the map that odd power squares to being the
+`q`-power Frobenius. Neither is formed here. -/
 def frobenius : d.AmbientGroup →* d.AmbientGroup :=
   SpStd.frobenius 1 d.1.characteristic d.1.fieldExponent d.1.Closure
 
@@ -202,7 +205,11 @@ theorem frobenius_def :
     d.frobenius = SpStd.frobenius 1 d.1.characteristic d.1.fieldExponent d.1.Closure :=
   (rfl)
 
-/-- The Frobenius acts on the ambient group by raising every matrix entry to the `q`-th power. -/
+/-- The Frobenius acts on the ambient group by raising every matrix entry to the `q`-th power.
+
+The index type is written `Fin 4`, which is the carrier's own `Fin ((1 + 1) + (1 + 1))` at `n = 1`
+definitionally but not syntactically. Only the binders of `r` and `c` are affected: the entry
+coercions elaborate at the carrier's index type either way. -/
 @[simp]
 theorem coe_frobenius_apply (g : d.AmbientGroup) (r c : Fin 4) :
     ((d.frobenius g : Matrix.GeneralLinearGroup (Fin 4) d.1.Closure) :
@@ -210,6 +217,8 @@ theorem coe_frobenius_apply (g : d.AmbientGroup) (r c : Fin 4) :
       ((g : Matrix.GeneralLinearGroup (Fin 4) d.1.Closure) :
         Matrix (Fin 4) (Fin 4) d.1.Closure) r c ^ d.1.fieldOrder := by
   rw [frobenius_def, d.1.fieldOrder_eq_characteristic_pow]
+  -- The upstream lemma is instantiated by hand rather than rewritten with: its entry arguments
+  -- live in `Fin ((1 + 1) + (1 + 1))`, which is only definitionally the `Fin 4` stated above.
   exact SpStd.coe_frobenius_apply 1 _ _ _ g r c
 
 /-- **The Frobenius fixes the Bourbaki numbering of a simple-root subgroup and raises its parameter
@@ -225,7 +234,9 @@ theorem frobenius_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.
 /-- **A point of the ambient group is fixed by the Frobenius exactly when all of its matrix entries
 lie in the field of definition.** Writing `𝔽_q` for `TauCeti.ValidLieTypeIndex.fixedField`, the copy
 of the field of `q` elements inside the algebraic closure, the Frobenius fixed points are the points
-of the rank-two type-`C` carrier whose entries lie in `𝔽_q`.
+of the rank-two type-`C` carrier whose entries lie in `𝔽_q`. As in `coe_frobenius_apply`, the index
+type is written `Fin 4` for the carrier's own `Fin ((1 + 1) + (1 + 1))` at `n = 1`; here the two
+entry binders are elaborated at the carrier's index type as well.
 
 As for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`, this is not a `simp` lemma:
 `TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites its

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean
@@ -33,33 +33,27 @@ index type of the index's own Dynkin type, rather than by a node of the carrier.
 
 ## What the shared Frobenius is for on each branch
 
-The two families differ exactly in the endomorphism whose fixed points milestone L3 takes. On the
-untwisted branch that endomorphism is the `q`-power Frobenius outright, which is what milestone L1's
-table asks of an untwisted family and what `TauCeti.TypeB2LieIndex.diagramPerm_toGraphTwistedIndex`
-checks: the diagram permutation the index carries is trivial, the `B₂` diagram having no symmetry to
-twist by. On the Suzuki branch it is instead `τ ^ (2m+1)` for the special isogeny `τ` of the pinned
-`B₂` group scheme in characteristic two, which milestone L2 consumes from Layer 9 of the
-reductive-groups roadmap and does not build. That `τ` is identified by the relation
+The two families differ exactly in the endomorphism whose fixed points are taken. On the untwisted
+branch that endomorphism is the `q`-power Frobenius outright, in keeping with the trivial diagram
+permutation that `TauCeti.TypeB2LieIndex.diagramPerm_toGraphTwistedIndex` computes: the `B₂`
+diagram has no symmetry to twist by, its two nodes carrying different root lengths. On the Suzuki
+branch it is instead `τ ^ (2m+1)` for the special isogeny `τ` of the pinned `B₂` group scheme in
+characteristic two, which is not constructed here. That `τ` is identified by the relation
 `τ ^ 2 = Frob_p` in the prime characteristic, and `Frob_p` is not the map supplied here: validity
 forces `1 ≤ m`, so the field order `q = 2 ^ (2m+1)` the index records is larger than the prime.
 What this file supplies is `Frob_q`, the map the odd power `τ ^ (2m+1)` squares to. Either way the
-map below is the `q`-power Frobenius at the field order the index records, on this carrier, which
-becomes the carrier those fixed points are taken in only along the Layer 9 identification described
-below. A Suzuki index reaches all of it through `TauCeti.SuzukiLieIndex.toRankTwoBLieIndex`.
+map below is the `q`-power Frobenius at the field order the index records, taken on this carrier.
+A Suzuki index reaches all of it through `TauCeti.SuzukiLieIndex.toRankTwoBLieIndex`.
 
-Neither branch gets a Steinberg map or a milestone L3 quotient here, and neither gets a candidate
-simple group. Milestone L1 asks for the Steinberg endomorphism of the points of the *pinned* simply
-connected group scheme, and the quotient
-
-```text
-H_d = fixedSubgroup (Steinberg map),        [H_d, H_d] / Z([H_d, H_d])
-```
-
-that milestone L3 forms is taken of the fixed points of that endomorphism, so neither is stated of
-the rank-two type-`C` carrier before the Layer 9 identification of the two carriers exists. What is
-named below is named after what it is: `TauCeti.RankTwoBLieIndex.frobenius` is the Frobenius of this
-carrier, and `TauCeti.RankTwoBLieIndex.mem_fixedSubgroup_frobenius_iff` describes the group it fixes
-as the points whose matrix entries lie in the field of definition `𝔽_q`.
+Neither branch gets a Steinberg endomorphism here, and neither gets a candidate simple group. The
+Steinberg endomorphism of either family is an endomorphism of the points of the *pinned* simply
+connected group scheme of the diagram, and no identification of the carrier below with that pinned
+group is available; so neither that endomorphism, nor the group of its fixed points, nor the
+quotient of the derived subgroup of those fixed points by its centre, is stated of the rank-two
+type-`C` carrier. What is named below is named after what it is:
+`TauCeti.RankTwoBLieIndex.frobenius` is the Frobenius of this carrier, and
+`TauCeti.RankTwoBLieIndex.mem_fixedSubgroup_frobenius_iff` describes the group it fixes as the
+points whose matrix entries lie in the field of definition `𝔽_q`.
 
 Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
 the symplectic group scheme, or that any group below is finite, perfect, or simple. In particular
@@ -67,6 +61,11 @@ the carrier is not claimed to be *the* simply connected Chevalley--Demazure grou
 `B₂`: no pinning datum is constructed for it here or in the files it imports, which say so
 themselves. The identification with the `B₂` diagram proved below is the one on numbered root
 characters stated in `rootGeneratorWeight_carrierNode_eq_root_simpleIndex`.
+
+The same carrier-and-Frobenius material on the branches already assembled is in
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
+`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
 
 ## Main declarations
 
@@ -92,29 +91,7 @@ characters stated in `rootGeneratorWeight_carrierNode_eq_root_simpleIndex`.
   of the two rank-two diagrams that the node correspondence below moves between.
 * The target signatures realized here follow the human-authored formal skeleton
   `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group, the numbered simple root
-  subgroup, and the Frobenius with its pinned equation, all taken on a validated-index subtype. The
-  skeleton's fixed-point recipe is not realized here, its Steinberg map being one of the pinned
-  carrier.
-
-## Roadmap
-
-Milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md` asks for the points of the *pinned* simply
-connected Chevalley--Demazure group scheme of `TauCeti.DynkinType.simplyConnectedRootDatum` at the
-diagram the index names, with its root subgroups. **This file does not close L0 on either `B₂`
-branch, and the rank-two type-`C` carrier is not offered as a substitute for that pinned group.**
-The pinned group scheme, its pinning, and any identification of a carrier with it are Layer 9
-targets of `TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap consumes rather than
-builds; none of them is proved of `TauCeti.SpStd.groupScheme 1` here or in the files this one
-imports. What this file supplies is the branches' explicit carrier, its numbered root characters
-read in the `B₂` root datum, the equation `Frob_q (x_i(u)) = x_i(u ^ q)` that milestone L1 asks of
-an ordinary Frobenius factor, and the field-of-definition description of the points that Frobenius
-fixes, each in the shape those milestones state it; they transfer to the L0 carrier along that
-Layer 9 identification, and not before. Neither the milestone L1 Steinberg map of the untwisted
-family `B₂(q)` nor the milestone L3 quotient built from it is stated here; both wait on that L0
-carrier. The counterparts on the branches already assembled are
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
-`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
+  subgroup, and the Frobenius with its pinned equation, all taken on a validated-index subtype.
 -/
 
 public section
@@ -148,8 +125,8 @@ def carrierNode : Fin d.1.rank ≃ Fin 2 :=
 /-- **The ambient group this file attaches to a validated index on the `B₂` diagram**: the points of
 the explicit full-weight rank-two type-`C` Chevalley carrier over the algebraic closure of its prime
 field. It is infinite; no finiteness, reductivity, pinning or maximality statement is attached to
-it, and it is not claimed to be the pinned `B₂` group scheme's points that milestone L0 asks for,
-that identification being the Layer 9 target described in the module docstring.
+it, and it is not claimed to be the points of the pinned simply connected group scheme of type
+`B₂`; no such identification is available, as the module docstring explains.
 
 It is the same group for the untwisted and the Suzuki family of a given field order, those two
 differing only in the endomorphism taken of it. -/
@@ -175,23 +152,23 @@ same node correspondence, is the `i`-th simple root of
 `TauCeti.DynkinType.simplyConnectedRootDatum` at `B 2`. This is the sense in which the rank-two
 type-`C` carrier serves the diagram that the two rank-two type-`B` families name; it is not a claim
 that the carrier is the pinned group of that diagram, no pinning being constructed for it. -/
-theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (ht : (B 2).Valid)
-    (i j : Fin d.1.rank) :
+theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (i j : Fin d.1.rank) :
     SpStd.rootGeneratorWeight 1 (.inl (d.carrierNode i)) (d.carrierNode j) =
-      ((B 2).simplyConnectedRootDatum ht).root
-        ((B 2).simpleIndex ht (finCongr d.rank_eq_two i)) (finCongr d.rank_eq_two j) := by
+      ((B 2).simplyConnectedRootDatum (valid_B.mpr le_rfl)).root
+        ((B 2).simpleIndex (valid_B.mpr le_rfl) (finCongr d.rank_eq_two i))
+        (finCongr d.rank_eq_two j) := by
   rw [carrierNode_apply, carrierNode_apply,
-    SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex_B_two ht,
+    SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex_B_two (valid_B.mpr le_rfl),
     Equiv.swap_apply_self, Equiv.swap_apply_self]
 
 /-! ## The Frobenius endomorphism -/
 
 /-- **The `q`-power Frobenius endomorphism of the ambient group of an index on the `B₂` diagram**,
 for `q` the field order the index records. The map the Steinberg endomorphism of either family on
-this diagram is built from is its counterpart on the milestone L0 carrier: on the untwisted family
-`B₂(q)` that endomorphism is the `q`-power Frobenius outright, and on the Suzuki family it is the
-odd power `τ ^ (2m+1)` of the special isogeny, the map that odd power squares to being the
-`q`-power Frobenius. Neither is formed here. -/
+this diagram is built from is its counterpart on the pinned simply connected carrier: on the
+untwisted family `B₂(q)` that endomorphism is the `q`-power Frobenius outright, and on the Suzuki
+family it is the odd power `τ ^ (2m+1)` of the special isogeny, the map that odd power squares to
+being the `q`-power Frobenius. Neither is formed here. -/
 def frobenius : d.AmbientGroup →* d.AmbientGroup :=
   SpStd.frobenius 1 d.1.characteristic d.1.fieldExponent d.1.Closure
 
@@ -222,8 +199,8 @@ theorem coe_frobenius_apply (g : d.AmbientGroup) (r c : Fin 4) :
   exact SpStd.coe_frobenius_apply 1 _ _ _ g r c
 
 /-- **The Frobenius fixes the Bourbaki numbering of a simple-root subgroup and raises its parameter
-to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation milestone L1
-asks of an ordinary Frobenius factor. -/
+to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation that pins an
+ordinary Frobenius factor of a Steinberg map on the numbered simple-root subgroups. -/
 @[simp]
 theorem frobenius_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.Closure) :
     d.frobenius (d.simpleRootSubgroup i u) =

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius
 public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.RootDatum
-public import TauCeti.GroupTheory.FixedPointCandidate
 public import TauCeti.GroupTheory.SpecificGroups.CFSG.Frobenius
 
 /-!
@@ -18,8 +17,8 @@ the Suzuki family `²B₂(2^(2m+1))`. They share a diagram, so they share a carr
 `TauCeti.RankTwoBLieIndex` is the subtype that collects exactly them. This file supplies, for every
 such index, the group of algebraic-closure-valued points of Tau Ceti's explicit full-weight type-`C`
 Chevalley carrier at its rank-two member, `TauCeti.SpStd.groupScheme 1`, together with that group's
-Bourbaki-numbered simple root subgroups and its `q`-power Frobenius; and it then runs the milestone
-L3 recipe on the untwisted branch, on that carrier, where the Frobenius *is* the Steinberg map.
+Bourbaki-numbered simple root subgroups, its `q`-power Frobenius, and the description of the points
+that Frobenius fixes.
 
 The rank-two type-`C` carrier is not a substitution for the diagram the families name: the two
 constructor names `B 2` and `C 2` denote the same rank-two root system, which is why
@@ -32,33 +31,32 @@ correspondence `TauCeti.RankTwoBLieIndex.carrierNode` composes the rank equality
 the two nodes, and every numbered object below is indexed by `Fin d.1.rank`, the upstream Bourbaki
 index type of the index's own Dynkin type, rather than by a node of the carrier.
 
-## Why only one of the two branches gets a candidate group
+## What the shared Frobenius is for on each branch
 
 The two families differ exactly in the endomorphism whose fixed points milestone L3 takes. On the
 untwisted branch that endomorphism is the `q`-power Frobenius outright, which is what milestone L1's
 table asks of an untwisted family and what `TauCeti.TypeB2LieIndex.diagramPerm_toGraphTwistedIndex`
 checks: the diagram permutation the index carries is trivial, the `B₂` diagram having no symmetry to
-twist by. So `TauCeti.TypeB2LieIndex.steinberg` is the shared Frobenius, and the recipe
+twist by. On the Suzuki branch it is instead `τ ^ (2m+1)` for the special isogeny `τ` of the pinned
+`B₂` group scheme in characteristic two, which milestone L2 consumes from Layer 9 of the
+reductive-groups roadmap and does not build; what this file supplies towards it is the second factor
+of the relation `τ ^ 2 = Frob_p` that identifies `τ`. Either way the map below is the `q`-power
+Frobenius, at the field order the index records, on the very carrier those fixed points will be
+taken in. A Suzuki index reaches all of it through `TauCeti.SuzukiLieIndex.toRankTwoBLieIndex`.
+
+Neither branch gets a Steinberg map or a milestone L3 quotient here, and neither gets a candidate
+simple group. Milestone L1 asks for the Steinberg endomorphism of the points of the *pinned* simply
+connected group scheme, and the quotient
 
 ```text
-H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d])
+H_d = fixedSubgroup (Steinberg map),        [H_d, H_d] / Z([H_d, H_d])
 ```
 
-runs on this branch, on the rank-two type-`C` carrier. What it produces reads as the candidate
-simple group of `B₂(q)` only along the Layer 9 identification of that carrier with the pinned group
-that milestone L0 asks for, and not before. A validated untwisted index has `4 ≤ q`, by
-`TauCeti.TypeB2LieIndex.four_le_fieldOrder`: the classification list carries the two smaller
-parameters under other names, `B₂(2)` under `A₆` and `B₂(3)` under `²A₃(2)`, so they are dropped
-from the index rather than from the construction.
-
-On the Suzuki branch the Steinberg endomorphism is instead `τ ^ (2m+1)` for the special isogeny `τ`
-of the pinned `B₂` group scheme in characteristic two, which milestone L2 consumes from Layer 9 of
-the reductive-groups roadmap and does not build; no such map is formed here, and hence no candidate
-group either. What this file provides on that path is the second factor of the relation
-`τ ^ 2 = Frob_p` that identifies `τ`: `TauCeti.RankTwoBLieIndex.frobenius` is the `q`-power
-Frobenius, at the field order `q = 2^(2m+1)` a Suzuki index records, on the very carrier the
-Suzuki fixed points will be taken in. A Suzuki index reaches all of it through
-`TauCeti.SuzukiLieIndex.toRankTwoBLieIndex`.
+that milestone L3 forms is taken of the fixed points of that endomorphism, so neither is stated of
+the rank-two type-`C` carrier before the Layer 9 identification of the two carriers exists. What is
+named below is named after what it is: `TauCeti.RankTwoBLieIndex.frobenius` is the Frobenius of this
+carrier, and `TauCeti.RankTwoBLieIndex.mem_fixedSubgroup_frobenius_iff` describes the group it fixes
+as the points whose matrix entries lie in the field of definition `𝔽_q`.
 
 Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
 the symplectic group scheme, or that any group below is finite, perfect, or simple. In particular
@@ -81,9 +79,6 @@ characters stated in `rootGeneratorWeight_carrierNode_eq_root_simpleIndex`.
   description, and its pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)`.
 * `TauCeti.RankTwoBLieIndex.mem_fixedSubgroup_frobenius_iff`: its fixed points are the points whose
   matrix entries lie in the field of definition `𝔽_q`.
-* `TauCeti.TypeB2LieIndex.steinberg` and `TauCeti.TypeB2LieIndex.Group`: the milestone L1 Steinberg
-  endomorphism of the untwisted branch and the milestone L3 quotient formed from it, both on the
-  rank-two type-`C` carrier rather than on the pinned group milestone L0 asks for.
 
 ## References
 
@@ -94,8 +89,9 @@ characters stated in `rootGeneratorWeight_carrierNode_eq_root_simpleIndex`.
   of the two rank-two diagrams that the node correspondence below moves between.
 * The target signatures realized here follow the human-authored formal skeleton
   `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group, the numbered simple root
-  subgroup, the Frobenius with its pinned equation, and the fixed-point recipe, all taken on a
-  validated-index subtype.
+  subgroup, and the Frobenius with its pinned equation, all taken on a validated-index subtype. The
+  skeleton's fixed-point recipe is not realized here, its Steinberg map being one of the pinned
+  carrier.
 
 ## Roadmap
 
@@ -108,9 +104,11 @@ targets of `TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap cons
 builds; none of them is proved of `TauCeti.SpStd.groupScheme 1` here or in the files this one
 imports. What this file supplies is the branches' explicit carrier, its numbered root characters
 read in the `B₂` root datum, the equation `Frob_q (x_i(u)) = x_i(u ^ q)` that milestone L1 asks of
-an ordinary Frobenius factor, and, on the untwisted branch, the milestone L3 recipe run on that
-Frobenius, each in the shape those milestones state it; they transfer to the L0 carrier along that
-Layer 9 identification, and not before. The counterparts on the branches already assembled are
+an ordinary Frobenius factor, and the field-of-definition description of the points that Frobenius
+fixes, each in the shape those milestones state it; they transfer to the L0 carrier along that
+Layer 9 identification, and not before. Neither the milestone L1 Steinberg map of the untwisted
+family `B₂(q)` nor the milestone L3 quotient built from it is stated here; both wait on that L0
+carrier. The counterparts on the branches already assembled are
 `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
 `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
 `TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
@@ -186,10 +184,11 @@ theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (ht : (B 2).Valid)
 /-! ## The Frobenius endomorphism -/
 
 /-- **The `q`-power Frobenius endomorphism of the ambient group of an index on the `B₂` diagram**,
-for `q` the field order the index records. On the untwisted family `B₂(q)` it is the Steinberg map
-itself, by `TauCeti.TypeB2LieIndex.steinberg_def`. On the Suzuki family it is not: there the
-Steinberg map is the odd power `τ ^ (2m+1)` of the special isogeny, and this is the map that odd
-power squares to. -/
+for `q` the field order the index records. It is the map from which the Steinberg endomorphism of
+either family on this diagram is built once the milestone L0 carrier is available: on the untwisted
+family `B₂(q)` that endomorphism is the `q`-power Frobenius outright, and on the Suzuki family it is
+the odd power `τ ^ (2m+1)` of the special isogeny, whose square is the Frobenius. Neither is formed
+here. -/
 def frobenius : d.AmbientGroup →* d.AmbientGroup :=
   SpStd.frobenius 1 d.1.characteristic d.1.fieldExponent d.1.Closure
 
@@ -243,70 +242,5 @@ theorem mem_fixedSubgroup_frobenius_iff (g : d.AmbientGroup) :
 end
 
 end RankTwoBLieIndex
-
-namespace TypeB2LieIndex
-
-noncomputable section
-
-variable (d : TypeB2LieIndex)
-
-/-! ## The Steinberg endomorphism of the untwisted family -/
-
-/-- **The milestone L1 Steinberg endomorphism of a validated untwisted index on the `B₂` diagram,
-formed on the rank-two type-`C` carrier**: the `q`-power Frobenius of the ambient group, `q` being
-the field order the index records. The family is untwisted, so no diagram automorphism and no
-half-Frobenius enters; `diagramPerm_toGraphTwistedIndex` is the check that its diagram permutation
-is trivial.
-
-It is the Steinberg map of `B₂(q)` on the pinned carrier milestone L0 asks for only along the
-Layer 9 identification of the two carriers described in the module docstring, and not before. -/
-def steinberg : d.1.AmbientGroup →* d.1.AmbientGroup := d.1.frobenius
-
-/-- The Steinberg map of an untwisted `B₂` index is the Frobenius that both families on the `B₂`
-diagram share. This is its unfolding lemma; the definition itself stays sealed, and it is through
-this equation that the ambient-group API of `TauCeti.RankTwoBLieIndex` reaches the Steinberg
-map. -/
-theorem steinberg_def : d.steinberg = d.1.frobenius := (rfl)
-
-/-- **The Steinberg map fixes the Bourbaki numbering of a simple-root subgroup and raises its
-parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation
-milestone L1 asks of the untwisted families, on this branch. -/
-@[simp]
-theorem steinberg_simpleRootSubgroup (i : Fin d.1.1.rank) (u : Multiplicative d.1.1.Closure) :
-    d.steinberg (d.1.simpleRootSubgroup i u) =
-      d.1.simpleRootSubgroup i
-        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.1.fieldOrder)) := by
-  rw [steinberg_def]
-  exact d.1.frobenius_simpleRootSubgroup i u
-
-/-- **A point of the ambient group is fixed by the Steinberg map exactly when all of its matrix
-entries lie in the field of definition**, so the group `H_d` that the milestone L3 recipe is run on
-below is the group of points of the rank-two type-`C` carrier whose entries lie in `𝔽_q`. -/
-theorem mem_fixedSubgroup_steinberg_iff (g : d.1.AmbientGroup) :
-    g ∈ fixedSubgroup d.steinberg ↔
-      ∀ r c, ((g : Matrix.GeneralLinearGroup (Fin 4) d.1.1.Closure) :
-        Matrix (Fin 4) (Fin 4) d.1.1.Closure) r c ∈ d.1.1.fixedField := by
-  rw [steinberg_def]
-  exact d.1.mem_fixedSubgroup_frobenius_iff g
-
-/-! ## The milestone L3 quotient -/
-
-/-- **The milestone L3 quotient on the rank-two type-`C` carrier**: the derived subgroup of the
-fixed points of the Steinberg map above, modulo the centre of that derived subgroup.
-
-This is the shape milestone L3 asks of the untwisted family `B₂(q)`, formed on the rank-two type-`C`
-carrier rather than on the pinned simply connected Chevalley--Demazure group scheme that milestone
-L0 asks for. It becomes the candidate simple group of that family along the Layer 9 identification
-of the two carriers described in the module docstring, and not before; it is not offered as that
-candidate here. Nothing below asserts that it is finite, perfect, or simple. -/
-abbrev Group : Type := FixedPointCandidate d.steinberg
-
-/-- Milestone L3 asks every valid branch to carry a group instance; the quotient construction
-supplies it. -/
-example : _root_.Group d.Group := inferInstance
-
-end
-
-end TypeB2LieIndex
 
 end TauCeti

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean
@@ -18,8 +18,8 @@ the Suzuki family `²B₂(2^(2m+1))`. They share a diagram, so they share a carr
 `TauCeti.RankTwoBLieIndex` is the subtype that collects exactly them. This file supplies, for every
 such index, the group of algebraic-closure-valued points of Tau Ceti's explicit full-weight type-`C`
 Chevalley carrier at its rank-two member, `TauCeti.SpStd.groupScheme 1`, together with that group's
-Bourbaki-numbered simple root subgroups and its `q`-power Frobenius; and it then runs the
-classification recipe on the untwisted branch, where the Frobenius *is* the Steinberg map.
+Bourbaki-numbered simple root subgroups and its `q`-power Frobenius; and it then runs the milestone
+L3 recipe on the untwisted branch, on that carrier, where the Frobenius *is* the Steinberg map.
 
 The rank-two type-`C` carrier is not a substitution for the diagram the families name: the two
 constructor names `B 2` and `C 2` denote the same rank-two root system, which is why
@@ -44,7 +44,9 @@ twist by. So `TauCeti.TypeB2LieIndex.steinberg` is the shared Frobenius, and the
 H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d])
 ```
 
-closes on this branch. A validated untwisted index has `4 ≤ q`, by
+runs on this branch, on the rank-two type-`C` carrier. What it produces reads as the candidate
+simple group of `B₂(q)` only along the Layer 9 identification of that carrier with the pinned group
+that milestone L0 asks for, and not before. A validated untwisted index has `4 ≤ q`, by
 `TauCeti.TypeB2LieIndex.four_le_fieldOrder`: the classification list carries the two smaller
 parameters under other names, `B₂(2)` under `A₆` and `B₂(3)` under `²A₃(2)`, so they are dropped
 from the index rather than from the construction.
@@ -79,8 +81,9 @@ characters stated in `rootGeneratorWeight_carrierNode_eq_root_simpleIndex`.
   description, and its pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)`.
 * `TauCeti.RankTwoBLieIndex.mem_fixedSubgroup_frobenius_iff`: its fixed points are the points whose
   matrix entries lie in the field of definition `𝔽_q`.
-* `TauCeti.TypeB2LieIndex.steinberg` and `TauCeti.TypeB2LieIndex.Group`: the Steinberg
-  endomorphism of the untwisted family `B₂(q)` and the candidate group milestone L3 builds from it.
+* `TauCeti.TypeB2LieIndex.steinberg` and `TauCeti.TypeB2LieIndex.Group`: the milestone L1 Steinberg
+  endomorphism of the untwisted branch and the milestone L3 quotient formed from it, both on the
+  rank-two type-`C` carrier rather than on the pinned group milestone L0 asks for.
 
 ## References
 
@@ -249,10 +252,14 @@ variable (d : TypeB2LieIndex)
 
 /-! ## The Steinberg endomorphism of the untwisted family -/
 
-/-- **The Steinberg endomorphism of a validated untwisted index `B₂(q)`**: the `q`-power Frobenius
-of the ambient group, `q` being the field order the index records. The family is untwisted, so no
-diagram automorphism and no half-Frobenius enters; `diagramPerm_toGraphTwistedIndex` is the check
-that its diagram permutation is trivial. -/
+/-- **The milestone L1 Steinberg endomorphism of a validated untwisted index on the `B₂` diagram,
+formed on the rank-two type-`C` carrier**: the `q`-power Frobenius of the ambient group, `q` being
+the field order the index records. The family is untwisted, so no diagram automorphism and no
+half-Frobenius enters; `diagramPerm_toGraphTwistedIndex` is the check that its diagram permutation
+is trivial.
+
+It is the Steinberg map of `B₂(q)` on the pinned carrier milestone L0 asks for only along the
+Layer 9 identification of the two carriers described in the module docstring, and not before. -/
 def steinberg : d.1.AmbientGroup →* d.1.AmbientGroup := d.1.frobenius
 
 /-- The Steinberg map of an untwisted `B₂` index is the Frobenius that both families on the `B₂`
@@ -282,14 +289,16 @@ theorem mem_fixedSubgroup_steinberg_iff (g : d.1.AmbientGroup) :
   rw [steinberg_def]
   exact d.1.mem_fixedSubgroup_frobenius_iff g
 
-/-! ## The classification candidate -/
+/-! ## The milestone L3 quotient -/
 
-/-- **The candidate simple group of the untwisted family `B₂(q)`**: the derived subgroup of the
-fixed points of its Steinberg map, modulo the centre of that derived subgroup.
+/-- **The milestone L3 quotient on the rank-two type-`C` carrier**: the derived subgroup of the
+fixed points of the Steinberg map above, modulo the centre of that derived subgroup.
 
-This is the milestone L3 recipe on the `B₂` branch, run on the rank-two type-`C` carrier. Nothing
-below asserts that it is finite, perfect, or simple, nor that the carrier is the one milestone L0
-asks for. -/
+This is the shape milestone L3 asks of the untwisted family `B₂(q)`, formed on the rank-two type-`C`
+carrier rather than on the pinned simply connected Chevalley--Demazure group scheme that milestone
+L0 asks for. It becomes the candidate simple group of that family along the Layer 9 identification
+of the two carriers described in the module docstring, and not before; it is not offered as that
+candidate here. Nothing below asserts that it is finite, perfect, or simple. -/
 abbrev Group : Type := FixedPointCandidate d.steinberg
 
 /-- Milestone L3 asks every valid branch to carry a group instance; the quotient construction

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean
@@ -7,40 +7,56 @@ module
 
 public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius
 public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.RootDatum
-public import TauCeti.GroupTheory.SpecificGroups.CFSG.Closure
+public import TauCeti.GroupTheory.FixedPointCandidate
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Frobenius
 
 /-!
-# The Suzuki family on the rank-two type-`C` carrier
+# The two families on the rank-two diagram `B₂`
 
-The Suzuki family `²B₂(2^(2m+1))` is built on the rank-two diagram `B₂`. This file supplies, for
-every validated Suzuki index, the group of algebraic-closure-valued points of Tau Ceti's explicit
-full-weight type-`C` Chevalley carrier at its rank-two member, `TauCeti.SpStd.groupScheme 1`,
-together with that group's Bourbaki-numbered simple root subgroups and its `q`-power Frobenius.
+Two classification-list families are built on the rank-two diagram `B₂`: the untwisted `B₂(q)` and
+the Suzuki family `²B₂(2^(2m+1))`. They share a diagram, so they share a carrier, and
+`TauCeti.RankTwoBLieIndex` is the subtype that collects exactly them. This file supplies, for every
+such index, the group of algebraic-closure-valued points of Tau Ceti's explicit full-weight type-`C`
+Chevalley carrier at its rank-two member, `TauCeti.SpStd.groupScheme 1`, together with that group's
+Bourbaki-numbered simple root subgroups and its `q`-power Frobenius; and it then runs the
+classification recipe on the untwisted branch, where the Frobenius *is* the Steinberg map.
 
-The rank-two type-`C` carrier is not a substitution for the diagram the family names: the two
+The rank-two type-`C` carrier is not a substitution for the diagram the families name: the two
 constructor names `B 2` and `C 2` denote the same rank-two root system, which is why
 `TauCeti.DynkinType.Valid` keeps only `B 2` of the two, and the identification is recorded rather
 than assumed. What is recorded is an identification of numbered root characters, not of group
 schemes. `TauCeti.SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex_B_two` shows that
 the character by which the carrier's split torus rescales the parameter of its `k`-th numbered
 raising subgroup is the simple root of the `B₂` root datum at the *other* node. So the node
-correspondence `TauCeti.SuzukiLieIndex.carrierNode` composes the rank equality with the swap of the
-two nodes, and every numbered object below is indexed by `Fin d.1.rank`, the upstream Bourbaki
+correspondence `TauCeti.RankTwoBLieIndex.carrierNode` composes the rank equality with the swap of
+the two nodes, and every numbered object below is indexed by `Fin d.1.rank`, the upstream Bourbaki
 index type of the index's own Dynkin type, rather than by a node of the carrier.
 
-What is *not* here is the Steinberg map, and hence not the finite-group candidate either. The
-Steinberg endomorphism of a Suzuki index is `τ ^ (2m+1)` for the special isogeny `τ` of the pinned
-`B₂` group scheme in characteristic two, which milestone L2 consumes from Layer 9 of the
-reductive-groups roadmap and does not build. What this file provides on that path is the second
-factor of the relation `τ ^ 2 = Frob_p` that identifies `τ`: `TauCeti.SuzukiLieIndex.frobenius` is
-the `q`-power Frobenius on the same ambient group, at the field order `q = 2^(2m+1)` the index
-records.
+## Why only one of the two branches gets a candidate group
 
-Nor is the untwisted family `B₂(q)` built here, although it is the other classification-list family
-on this diagram and would share the carrier. The two families differ in their Steinberg maps: the
-untwisted one takes the `q`-power Frobenius itself, where the Suzuki family takes the odd power
-`τ ^ (2m+1)` of the special isogeny. `TauCeti.TypeB2LieIndex` supplies the untwisted validated index
-subtype, but attaching the L0 carrier and its Steinberg map is separate work.
+The two families differ exactly in the endomorphism whose fixed points milestone L3 takes. On the
+untwisted branch that endomorphism is the `q`-power Frobenius outright, which is what milestone L1's
+table asks of an untwisted family and what `TauCeti.TypeB2LieIndex.diagramPerm_toGraphTwistedIndex`
+checks: the diagram permutation the index carries is trivial, the `B₂` diagram having no symmetry to
+twist by. So `TauCeti.TypeB2LieIndex.steinberg` is the shared Frobenius, and the recipe
+
+```text
+H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d])
+```
+
+closes on this branch. A validated untwisted index has `4 ≤ q`, by
+`TauCeti.TypeB2LieIndex.four_le_fieldOrder`: the classification list carries the two smaller
+parameters under other names, `B₂(2)` under `A₆` and `B₂(3)` under `²A₃(2)`, so they are dropped
+from the index rather than from the construction.
+
+On the Suzuki branch the Steinberg endomorphism is instead `τ ^ (2m+1)` for the special isogeny `τ`
+of the pinned `B₂` group scheme in characteristic two, which milestone L2 consumes from Layer 9 of
+the reductive-groups roadmap and does not build; no such map is formed here, and hence no candidate
+group either. What this file provides on that path is the second factor of the relation
+`τ ^ 2 = Frob_p` that identifies `τ`: `TauCeti.RankTwoBLieIndex.frobenius` is the `q`-power
+Frobenius, at the field order `q = 2^(2m+1)` a Suzuki index records, on the very carrier the
+Suzuki fixed points will be taken in. A Suzuki index reaches all of it through
+`TauCeti.SuzukiLieIndex.toRankTwoBLieIndex`.
 
 Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
 the symplectic group scheme, or that any group below is finite, perfect, or simple. In particular
@@ -51,15 +67,20 @@ characters stated in `rootGeneratorWeight_carrierNode_eq_root_simpleIndex`.
 
 ## Main declarations
 
-* `TauCeti.SuzukiLieIndex.carrierNode`: the node correspondence `Fin d.1.rank ≃ Fin 2` between the
+* `TauCeti.RankTwoBLieIndex.carrierNode`: the node correspondence `Fin d.1.rank ≃ Fin 2` between the
   Bourbaki numbering of `B₂` and the numbering of the rank-two type-`C` carrier.
-* `TauCeti.SuzukiLieIndex.AmbientGroup`: the algebraic-closure-valued points of that carrier.
-* `TauCeti.SuzukiLieIndex.simpleRootSubgroup`: the positive simple-root subgroup at a Bourbaki node.
-* `TauCeti.SuzukiLieIndex.rootGeneratorWeight_carrierNode_eq_root_simpleIndex`: the character of
+* `TauCeti.RankTwoBLieIndex.AmbientGroup`: the algebraic-closure-valued points of that carrier.
+* `TauCeti.RankTwoBLieIndex.simpleRootSubgroup`: the positive simple-root subgroup at a Bourbaki
+  node.
+* `TauCeti.RankTwoBLieIndex.rootGeneratorWeight_carrierNode_eq_root_simpleIndex`: the character of
   that subgroup is the corresponding simple root of the `B₂` root datum.
-* `TauCeti.SuzukiLieIndex.frobenius` and
-  `TauCeti.SuzukiLieIndex.frobenius_simpleRootSubgroup`: the `q`-power Frobenius and its pinned
-  equation `Frob_q (x_i(u)) = x_i(u ^ q)`.
+* `TauCeti.RankTwoBLieIndex.frobenius`, `TauCeti.RankTwoBLieIndex.coe_frobenius_apply` and
+  `TauCeti.RankTwoBLieIndex.frobenius_simpleRootSubgroup`: the `q`-power Frobenius, its entrywise
+  description, and its pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)`.
+* `TauCeti.RankTwoBLieIndex.mem_fixedSubgroup_frobenius_iff`: its fixed points are the points whose
+  matrix entries lie in the field of definition `𝔽_q`.
+* `TauCeti.TypeB2LieIndex.steinberg` and `TauCeti.TypeB2LieIndex.Group`: the Steinberg
+  endomorphism of the untwisted family `B₂(q)` and the candidate group milestone L3 builds from it.
 
 ## References
 
@@ -70,41 +91,45 @@ characters stated in `rootGeneratorWeight_carrierNode_eq_root_simpleIndex`.
   of the two rank-two diagrams that the node correspondence below moves between.
 * The target signatures realized here follow the human-authored formal skeleton
   `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group, the numbered simple root
-  subgroup, and the Frobenius with its pinned equation, all taken on a validated-index subtype.
+  subgroup, the Frobenius with its pinned equation, and the fixed-point recipe, all taken on a
+  validated-index subtype.
 
 ## Roadmap
 
 Milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md` asks for the points of the *pinned* simply
 connected Chevalley--Demazure group scheme of `TauCeti.DynkinType.simplyConnectedRootDatum` at the
-diagram the index names, with its root subgroups. **This file does not close L0 on the `suzuki`
+diagram the index names, with its root subgroups. **This file does not close L0 on either `B₂`
 branch, and the rank-two type-`C` carrier is not offered as a substitute for that pinned group.**
 The pinned group scheme, its pinning, and any identification of a carrier with it are Layer 9
 targets of `TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap consumes rather than
 builds; none of them is proved of `TauCeti.SpStd.groupScheme 1` here or in the files this one
-imports. What this file supplies is the branch's explicit carrier, its numbered root characters read
-in the `B₂` root datum, and the equation `Frob_q (x_i(u)) = x_i(u ^ q)` that milestone L1 asks of an
-ordinary Frobenius factor, each in the shape those milestones state it; they transfer to the L0
-carrier along that Layer 9 identification, and not before. The type-A counterpart is
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`.
+imports. What this file supplies is the branches' explicit carrier, its numbered root characters
+read in the `B₂` root datum, the equation `Frob_q (x_i(u)) = x_i(u ^ q)` that milestone L1 asks of
+an ordinary Frobenius factor, and, on the untwisted branch, the milestone L3 recipe run on that
+Frobenius, each in the shape those milestones state it; they transfer to the L0 carrier along that
+Layer 9 identification, and not before. The counterparts on the branches already assembled are
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
+`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
 -/
 
 public section
 
 namespace TauCeti
 
-namespace SuzukiLieIndex
+namespace RankTwoBLieIndex
 
 open DynkinType
 
 noncomputable section
 
-variable (d : SuzukiLieIndex)
+variable (d : RankTwoBLieIndex)
 
 /-! ## The node correspondence -/
 
 /-- **The rank-two type-`C` carrier node corresponding to a Bourbaki-numbered node of `B₂`**, with
 the inverse equivalence giving the correspondence back. It is the rank equality
-`TauCeti.SuzukiLieIndex.rank_eq_two` followed by the swap of the two nodes, the swap being what
+`TauCeti.RankTwoBLieIndex.rank_eq_two` followed by the swap of the two nodes, the swap being what
 `TauCeti.SpStd.rootGeneratorWeight_inl_eq_root_simpleIndex_B_two` shows the two numberings differ
 by. -/
 def carrierNode : Fin d.1.rank ≃ Fin 2 :=
@@ -116,11 +141,14 @@ def carrierNode : Fin d.1.rank ≃ Fin 2 :=
 
 /-! ## The ambient group and its simple root subgroups -/
 
-/-- **The ambient group this file attaches to a validated Suzuki index**: the points of the explicit
-full-weight rank-two type-`C` Chevalley carrier over the algebraic closure of the field with two
-elements. It is infinite; no finiteness, reductivity, pinning or maximality statement is attached to
+/-- **The ambient group this file attaches to a validated index on the `B₂` diagram**: the points of
+the explicit full-weight rank-two type-`C` Chevalley carrier over the algebraic closure of its prime
+field. It is infinite; no finiteness, reductivity, pinning or maximality statement is attached to
 it, and it is not claimed to be the pinned `B₂` group scheme's points that milestone L0 asks for,
-that identification being the Layer 9 target described in the module docstring. -/
+that identification being the Layer 9 target described in the module docstring.
+
+It is the same group for the untwisted and the Suzuki family of a given field order, those two
+differing only in the endomorphism taken of it. -/
 abbrev AmbientGroup : Type := SpStd.points 1 d.1.Closure
 
 /-- The positive simple-root subgroup at the Bourbaki-numbered node `i` of the `B₂` diagram. It is
@@ -141,8 +169,8 @@ theorem simpleRootSubgroup_def (i : Fin d.1.rank) :
 by which the carrier's split torus rescales the parameter of `simpleRootSubgroup i`, read in the
 same node correspondence, is the `i`-th simple root of
 `TauCeti.DynkinType.simplyConnectedRootDatum` at `B 2`. This is the sense in which the rank-two
-type-`C` carrier serves the diagram that the Suzuki index names; it is not a claim that the
-carrier is the pinned group of that diagram, no pinning being constructed for it. -/
+type-`C` carrier serves the diagram that the two rank-two type-`B` families name; it is not a claim
+that the carrier is the pinned group of that diagram, no pinning being constructed for it. -/
 theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (ht : (B 2).Valid)
     (i j : Fin d.1.rank) :
     SpStd.rootGeneratorWeight 1 (.inl (d.carrierNode i)) (d.carrierNode j) =
@@ -154,17 +182,33 @@ theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (ht : (B 2).Valid)
 
 /-! ## The Frobenius endomorphism -/
 
-/-- **The `q`-power Frobenius endomorphism of the ambient group of a Suzuki index**, for
-`q = 2^(2m+1)` the field order the index records. It is not the Steinberg map of the family, which
-is the odd power `τ ^ (2m+1)` of the special isogeny; it is the map that odd power squares to. -/
+/-- **The `q`-power Frobenius endomorphism of the ambient group of an index on the `B₂` diagram**,
+for `q` the field order the index records. On the untwisted family `B₂(q)` it is the Steinberg map
+itself, by `TauCeti.TypeB2LieIndex.steinberg_def`. On the Suzuki family it is not: there the
+Steinberg map is the odd power `τ ^ (2m+1)` of the special isogeny, and this is the map that odd
+power squares to. -/
 def frobenius : d.AmbientGroup →* d.AmbientGroup :=
   SpStd.frobenius 1 d.1.characteristic d.1.fieldExponent d.1.Closure
 
-/-- The Frobenius of a Suzuki index is the carrier's Frobenius at the exponent the index records.
-This is its unfolding lemma; the definition itself stays sealed. -/
+/-- The Frobenius of an index on the `B₂` diagram is the carrier's Frobenius at the exponent the
+index records. This is its unfolding lemma; the definition itself stays sealed.
+
+It is deliberately not a `simp` lemma: `frobenius_simpleRootSubgroup` and `coe_frobenius_apply` are
+the normal forms the pinned equations of this file are stated against, and unfolding to
+`TauCeti.SpStd.frobenius` would keep them from firing. -/
 theorem frobenius_def :
     d.frobenius = SpStd.frobenius 1 d.1.characteristic d.1.fieldExponent d.1.Closure :=
   (rfl)
+
+/-- The Frobenius acts on the ambient group by raising every matrix entry to the `q`-th power. -/
+@[simp]
+theorem coe_frobenius_apply (g : d.AmbientGroup) (r c : Fin 4) :
+    ((d.frobenius g : Matrix.GeneralLinearGroup (Fin 4) d.1.Closure) :
+        Matrix (Fin 4) (Fin 4) d.1.Closure) r c =
+      ((g : Matrix.GeneralLinearGroup (Fin 4) d.1.Closure) :
+        Matrix (Fin 4) (Fin 4) d.1.Closure) r c ^ d.1.fieldOrder := by
+  rw [frobenius_def, d.1.fieldOrder_eq_characteristic_pow]
+  exact SpStd.coe_frobenius_apply 1 _ _ _ g r c
 
 /-- **The Frobenius fixes the Bourbaki numbering of a simple-root subgroup and raises its parameter
 to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation milestone L1
@@ -176,8 +220,84 @@ theorem frobenius_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.
   rw [frobenius_def, simpleRootSubgroup_def, SpStd.frobenius_rootSubgroupPoints,
     ValidLieTypeIndex.fieldOrder_eq_characteristic_pow]
 
+/-- **A point of the ambient group is fixed by the Frobenius exactly when all of its matrix entries
+lie in the field of definition.** Writing `𝔽_q` for `TauCeti.ValidLieTypeIndex.fixedField`, the copy
+of the field of `q` elements inside the algebraic closure, the Frobenius fixed points are the points
+of the rank-two type-`C` carrier whose entries lie in `𝔽_q`.
+
+As for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`, this is not a `simp` lemma:
+`TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites its
+left-hand side to `d.frobenius g = g` through `MonoidHom.mem_eqLocus`, and the `simpNF` linter
+rejects the annotation. -/
+theorem mem_fixedSubgroup_frobenius_iff (g : d.AmbientGroup) :
+    g ∈ fixedSubgroup d.frobenius ↔
+      ∀ r c, ((g : Matrix.GeneralLinearGroup (Fin 4) d.1.Closure) :
+        Matrix (Fin 4) (Fin 4) d.1.Closure) r c ∈ d.1.fixedField := by
+  rw [mem_fixedSubgroup, frobenius_def, SpStd.frobenius_eq_self_iff]
+  simp only [mem_frobeniusFixedSubring, ValidLieTypeIndex.mem_fixedField,
+    d.1.fieldOrder_eq_characteristic_pow]
+
 end
 
-end SuzukiLieIndex
+end RankTwoBLieIndex
+
+namespace TypeB2LieIndex
+
+noncomputable section
+
+variable (d : TypeB2LieIndex)
+
+/-! ## The Steinberg endomorphism of the untwisted family -/
+
+/-- **The Steinberg endomorphism of a validated untwisted index `B₂(q)`**: the `q`-power Frobenius
+of the ambient group, `q` being the field order the index records. The family is untwisted, so no
+diagram automorphism and no half-Frobenius enters; `diagramPerm_toGraphTwistedIndex` is the check
+that its diagram permutation is trivial. -/
+def steinberg : d.1.AmbientGroup →* d.1.AmbientGroup := d.1.frobenius
+
+/-- The Steinberg map of an untwisted `B₂` index is the Frobenius that both families on the `B₂`
+diagram share. This is its unfolding lemma; the definition itself stays sealed, and it is through
+this equation that the ambient-group API of `TauCeti.RankTwoBLieIndex` reaches the Steinberg
+map. -/
+theorem steinberg_def : d.steinberg = d.1.frobenius := (rfl)
+
+/-- **The Steinberg map fixes the Bourbaki numbering of a simple-root subgroup and raises its
+parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation
+milestone L1 asks of the untwisted families, on this branch. -/
+@[simp]
+theorem steinberg_simpleRootSubgroup (i : Fin d.1.1.rank) (u : Multiplicative d.1.1.Closure) :
+    d.steinberg (d.1.simpleRootSubgroup i u) =
+      d.1.simpleRootSubgroup i
+        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.1.fieldOrder)) := by
+  rw [steinberg_def]
+  exact d.1.frobenius_simpleRootSubgroup i u
+
+/-- **A point of the ambient group is fixed by the Steinberg map exactly when all of its matrix
+entries lie in the field of definition**, so the group `H_d` that the milestone L3 recipe is run on
+below is the group of points of the rank-two type-`C` carrier whose entries lie in `𝔽_q`. -/
+theorem mem_fixedSubgroup_steinberg_iff (g : d.1.AmbientGroup) :
+    g ∈ fixedSubgroup d.steinberg ↔
+      ∀ r c, ((g : Matrix.GeneralLinearGroup (Fin 4) d.1.1.Closure) :
+        Matrix (Fin 4) (Fin 4) d.1.1.Closure) r c ∈ d.1.1.fixedField := by
+  rw [steinberg_def]
+  exact d.1.mem_fixedSubgroup_frobenius_iff g
+
+/-! ## The classification candidate -/
+
+/-- **The candidate simple group of the untwisted family `B₂(q)`**: the derived subgroup of the
+fixed points of its Steinberg map, modulo the centre of that derived subgroup.
+
+This is the milestone L3 recipe on the `B₂` branch, run on the rank-two type-`C` carrier. Nothing
+below asserts that it is finite, perfect, or simple, nor that the carrier is the one milestone L0
+asks for. -/
+abbrev Group : Type := FixedPointCandidate d.steinberg
+
+/-- Milestone L3 asks every valid branch to carry a group instance; the quotient construction
+supplies it. -/
+example : _root_.Group d.Group := inferInstance
+
+end
+
+end TypeB2LieIndex
 
 end TauCeti


### PR DESCRIPTION
This PR attaches Tau Ceti's explicit full-weight rank-two type-`C` Chevalley carrier
`TauCeti.SpStd.groupScheme 1` to every validated index on the rank-two diagram `B₂`, through
`TauCeti.RankTwoBLieIndex`, the subtype that collects exactly the two classification-list families
built on that diagram: the untwisted `B₂(q)` and the Suzuki family `²B₂(2^(2m+1))`. For such an
index it supplies the algebraic-closure-valued points of that carrier, its Bourbaki-numbered simple
root subgroups, the identification of their characters with the simple roots of the `B₂` root datum,
and the `q`-power Frobenius with its pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)`.

`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean` already carried all of that, but stated on
`TauCeti.SuzukiLieIndex`, while every proof there uses only `dynkinType = B 2`. So the API moves to
`RankTwoBLieIndex`, where both families reach it; the `SuzukiLieIndex` copies are deleted, and
`TauCeti.SuzukiLieIndex.toRankTwoBLieIndex` is how the Suzuki branch reaches them. Two lemmas are
added at that level: `coe_frobenius_apply`, the entrywise `q`-power description, and
`mem_fixedSubgroup_frobenius_iff`, which describes the points the Frobenius fixes as those whose
matrix entries lie in the field of definition `𝔽_q`. `TauCeti.TypeB2LieIndex.toGraphTwistedIndex`
and `TauCeti.TypeB2LieIndex.diagramPerm_toGraphTwistedIndex` add the untwisted `B₂(q)` row of
milestone L1's table: its diagram permutation is trivial, the `B₂` diagram having no symmetry to
twist by, its two nodes carrying different root lengths.

The rank-two type-`C` carrier is not a substitution for the diagram the two families name: the
constructor names `B 2` and `C 2` denote the same rank-two root system, which is why
`TauCeti.DynkinType.Valid` keeps only `B 2` of the two, and what is recorded here is an
identification of numbered root characters rather than of group schemes, with the node
correspondence carrying the swap of the two Bourbaki nodes.

Nothing here closes milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md` on either branch, and
the carrier is not offered as a substitute for the pinned simply connected Chevalley--Demazure group
scheme that L0 asks for: that identification is a Layer 9 target of
`TauCetiRoadmap/ReductiveGroups/README.md`, and no reductivity, pinning, maximality, finiteness,
perfection or simplicity statement is proved of anything below. Accordingly neither branch gets a
Steinberg map or a milestone L3 quotient here, and neither gets a candidate simple group: milestone
L1 asks for the Steinberg endomorphism of the points of the pinned group scheme, milestone L3 forms
its quotient from the fixed points of that endomorphism, and both wait on the L0 carrier, as they do
on the type-`C` branch after
https://github.com/TauCetiProject/TauCeti/pull/5411 (feat: attach the standard symplectic carrier to
a validated type-C index). On the Suzuki branch the Steinberg map is in any case the odd power
`τ ^ (2m+1)` of the special isogeny that milestone L2 consumes from that same Layer 9. That `τ` is
identified by `τ ^ 2 = Frob_p` in the prime characteristic, and `Frob_p` is not what is supplied
here: validity forces `1 ≤ m`, so the field order `q = 2 ^ (2m+1)` is larger than the prime, and the
Frobenius supplied is `Frob_q`, the map that odd power squares to.

The conventions followed are those of the roadmap, after Carter, *Simple Groups of Lie Type*,
§§4.4 and 14, Carter, *Finite Groups of Lie Type*, §1.17, Steinberg, *Endomorphisms of linear
algebraic groups*, §11, and the Bourbaki numbering of Plates II and III. Nothing is vendored.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"typeb2lieindex-group"}-->

🤖 Prepared with Claude Code

