### PR TITLE
feat: the Frobenius factor of the ²E₆(q) Steinberg map

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
@@ -92,8 +92,14 @@ imports. What this file supplies is the `²E₆` branch's explicit carrier, its 
 characters read in the `E₆` root datum, the diagram-symmetry data that milestone L1's
 `γ (x_α(t)) = x_{γ α}(t)` will be proved from, and milestone L1's other factor `Frob_q` together
 with its own pinned equation `Frob_q (x_α(t)) = x_α(t ^ q)`; they transfer to the L0 carrier along
-that Layer 9 identification, and not before. The counterparts on the branches already assembled
-are `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
+that Layer 9 identification, and not before. Milestone L0 names
+`TauCeti.ValidLieTypeIndex.AmbientGroup`, its `Group` instance, `TauCeti.ValidLieTypeIndex.Closure`
+and `TauCeti.ValidLieTypeIndex.simpleRootSubgroup` as its output; what this branch contributes to
+the first and the last of those is `TauCeti.TypeTwistedE6LieIndex.AmbientGroup` and
+`TauCeti.TypeTwistedE6LieIndex.simpleRootSubgroup` above, and the Frobenius below is an
+endomorphism of that ambient group whose milestone L1 equation is stated against those simple-root
+subgroups. The counterparts on the branches already assembled are
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
 `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
 `TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`, and the branch that likewise stops short
 of a Steinberg map is `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean`.

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
@@ -88,10 +88,11 @@ its pinning, and any identification of a carrier with it are Layer 9 targets of
 `TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap consumes rather than builds; none
 of them is proved of `TauCeti.E6DoubledMinuscule.groupScheme` here or in the files this one
 imports. What this file supplies is the `²E₆` branch's explicit carrier, its numbered root
-characters read in the `E₆` root datum, the diagram-symmetry data that milestone L1's
-`γ (x_α(t)) = x_{γ α}(t)` will be proved from, and milestone L1's other factor `Frob_q` together
-with its own pinned equation `Frob_q (x_α(t)) = x_α(t ^ q)`; they transfer to the L0 carrier along
-that Layer 9 identification, and not before. The counterparts on the branches already assembled
+characters read in the `E₆` root datum, the diagram-symmetry data that a graph automorphism's
+equation `γ (x_α(t)) = x_{γ α}(t)` will be proved from, and the `q`-power Frobenius `Frob_q`
+together with its own pinned equation `Frob_q (x_α(t)) = x_α(t ^ q)`; they transfer to the points
+of the pinned group along an identification of it with this carrier, and not before. The
+counterparts on the branches already assembled
 are `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
 `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
 `TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`, and the branch that likewise stops short

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
@@ -31,11 +31,10 @@ the branch's Steinberg map, with the pinned equation `Frob_q (x_i(u)) = x_i(u ^ 
 simple-root subgroups and the description of the points it fixes as those all of whose `54 × 54`
 matrix entries lie in the field of definition `𝔽_q`.
 
-The Steinberg map itself is *not* here, and neither is the candidate group of milestone L3. It is
-the composite `γ₂ ∘ Frob_q`, and the factor still owed on this carrier is `γ₂`, the automorphism
-that the coordinate involution induces, whose construction consumes exactly the weight equivariance
-recorded below. Until it exists there is no Steinberg map to take fixed points of, and none is
-taken. In particular `TauCeti.TypeTwistedE6LieIndex.frobenius` is not that map: the twisted branch
+The Steinberg map itself is *not* here, and no fixed-point subgroup of it is formed. That map is
+the composite `γ₂ ∘ Frob_q`, whose other factor `γ₂` is the automorphism of the carrier that the
+coordinate involution induces; constructing it consumes exactly the weight equivariance recorded
+below. In particular `TauCeti.TypeTwistedE6LieIndex.frobenius` is not that map: the twisted branch
 is precisely the one on which the Steinberg map and its Frobenius factor differ.
 
 Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
@@ -57,7 +56,7 @@ mentioned is finite, perfect, or simple.
   subgroup is the corresponding simple root of
   `TauCeti.DynkinType.simplyConnectedRootDatum` at `E₆`.
 * `TauCeti.TypeTwistedE6LieIndex.frobenius_simpleRootSubgroup`: the pinned equation
-  `Frob_q (x_i(u)) = x_i(u ^ q)`, milestone L1's requirement on the Frobenius factor.
+  `Frob_q (x_i(u)) = x_i(u ^ q)` on the numbered simple-root subgroups.
 * `TauCeti.TypeTwistedE6LieIndex.mem_fixedSubgroup_frobenius_iff`: a point is fixed by `Frob_q`
   exactly when all entries of its `54 × 54` matrix lie in the field of definition.
 * `TauCeti.TypeTwistedE6LieIndex.e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm_diagramPerm`:
@@ -92,14 +91,8 @@ imports. What this file supplies is the `²E₆` branch's explicit carrier, its 
 characters read in the `E₆` root datum, the diagram-symmetry data that milestone L1's
 `γ (x_α(t)) = x_{γ α}(t)` will be proved from, and milestone L1's other factor `Frob_q` together
 with its own pinned equation `Frob_q (x_α(t)) = x_α(t ^ q)`; they transfer to the L0 carrier along
-that Layer 9 identification, and not before. Milestone L0 names
-`TauCeti.ValidLieTypeIndex.AmbientGroup`, its `Group` instance, `TauCeti.ValidLieTypeIndex.Closure`
-and `TauCeti.ValidLieTypeIndex.simpleRootSubgroup` as its output; what this branch contributes to
-the first and the last of those is `TauCeti.TypeTwistedE6LieIndex.AmbientGroup` and
-`TauCeti.TypeTwistedE6LieIndex.simpleRootSubgroup` above, and the Frobenius below is an
-endomorphism of that ambient group whose milestone L1 equation is stated against those simple-root
-subgroups. The counterparts on the branches already assembled are
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
+that Layer 9 identification, and not before. The counterparts on the branches already assembled
+are `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
 `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
 `TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`, and the branch that likewise stops short
 of a Steinberg map is `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean`.
@@ -206,18 +199,18 @@ theorem e6DoubledMinusculeGraphPerm_pow_twistOrder :
 /-- **The `q`-power Frobenius endomorphism of the ambient group of a validated `²E₆` index**, `q`
 being the field order the index records.
 
-It is *not* the Steinberg map of the family. Milestone L1 gives the graph-twisted families the
-Steinberg map `γ₂ ∘ Frob_q`, and on this branch the two genuinely differ: the composite acts on the
-simple-root subgroups through the diagram permutation the index carries, which is
-`TauCeti.graphPermE6` by `TauCeti.TypeTwistedE6LieIndex.diagramPerm_toGraphTwistedIndex` and has
-order two by `TauCeti.orderOf_graphPermE6`. This is the right-hand factor of that composite,
-and the subgroup of points it fixes, characterized below, is correspondingly the untwisted one,
-not the `H_d` that milestone L3 runs its recipe on for this branch. -/
+It is *not* the Steinberg map of the family, which for a graph-twisted family is `γ₂ ∘ Frob_q`.
+On this branch the two genuinely differ: the composite acts on the simple-root subgroups through
+the diagram permutation the index carries, which is `TauCeti.graphPermE6` by
+`TauCeti.TypeTwistedE6LieIndex.diagramPerm_toGraphTwistedIndex` and has order two by
+`TauCeti.orderOf_graphPermE6`. This is the right-hand factor of that composite, and the subgroup of
+points it fixes, characterized below, is correspondingly the untwisted one and not the fixed
+subgroup of the composite. -/
 def frobenius : d.AmbientGroup →* d.AmbientGroup :=
   E6DoubledMinuscule.frobenius d.1.characteristic d.1.fieldExponent d.1.Closure
 
-/-- The Frobenius of a `²E₆` index is the doubled minuscule carrier's Frobenius at the exponent the
-index records. This is its unfolding lemma; the definition itself stays sealed. -/
+/-- The Frobenius of a `²E₆` index is the doubled minuscule carrier's Frobenius at the
+characteristic and the exponent the index records. -/
 -- Not `@[simp]`: `frobenius_simpleRootSubgroup` and `coe_frobenius_apply` are the normal forms the
 -- pinned equations of this file are stated against, and unfolding to
 -- `TauCeti.E6DoubledMinuscule.frobenius` would keep them from firing, as it does on the branches
@@ -239,9 +232,9 @@ theorem coe_frobenius_apply (g : d.AmbientGroup) (r c : Fin 54) :
   exact E6DoubledMinuscule.coe_frobenius_apply _ _ _ g r c
 
 /-- **The Frobenius fixes the Bourbaki numbering of a simple-root subgroup and raises its parameter
-to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation milestone L1
-asks of an ordinary Frobenius factor; the diagram permutation of the twisted family enters through
-the other factor `γ₂` and not through this one. -/
+to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. The diagram permutation of the
+twisted family enters through the other factor `γ₂` of the Steinberg map, and not through this
+one. -/
 @[simp]
 theorem frobenius_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.Closure) :
     d.frobenius (d.simpleRootSubgroup i u) =
@@ -254,8 +247,8 @@ theorem frobenius_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.
 `54 × 54` matrix lies in the field of definition.** Writing `𝔽_q` for
 `TauCeti.ValidLieTypeIndex.fixedField`, the copy of the field of `q` elements inside the algebraic
 closure, the Frobenius-fixed subgroup is therefore the group of points of the doubled minuscule
-carrier with coordinates in `𝔽_q`. It is not the group `H_d` that milestone L3 runs its recipe on
-for this branch, which is cut out by the twisted composite `γ₂ ∘ Frob_q` instead. -/
+carrier with coordinates in `𝔽_q`. It is not the group of points fixed by the twisted composite
+`γ₂ ∘ Frob_q`, which is the one the classification recipe for this branch is run inside. -/
 -- Not `@[simp]`, as for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`:
 -- `TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites the
 -- left-hand side to `d.frobenius g = g` through `MonoidHom.mem_eqLocus`, and the `simpNF` linter

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
@@ -28,8 +28,8 @@ character of those subgroups with the corresponding simple root of the `E₆` ro
 that the involution of the fifty-four doubled coordinates realizes on the doubled weight family the
 diagram permutation the index itself carries, and builds the `q`-power Frobenius factor `Frob_q` of
 the branch's Steinberg map, with the pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)` on the numbered
-simple-root subgroups and the description of the points it fixes as those whose fifty-four doubled
-coordinates lie in the field of definition `𝔽_q`.
+simple-root subgroups and the description of the points it fixes as those all of whose `54 × 54`
+matrix entries lie in the field of definition `𝔽_q`.
 
 The Steinberg map itself is *not* here, and neither is the candidate group of milestone L3. It is
 the composite `γ₂ ∘ Frob_q`, and the factor still owed on this carrier is `γ₂`, the automorphism
@@ -59,7 +59,7 @@ mentioned is finite, perfect, or simple.
 * `TauCeti.TypeTwistedE6LieIndex.frobenius_simpleRootSubgroup`: the pinned equation
   `Frob_q (x_i(u)) = x_i(u ^ q)`, milestone L1's requirement on the Frobenius factor.
 * `TauCeti.TypeTwistedE6LieIndex.mem_fixedSubgroup_frobenius_iff`: a point is fixed by `Frob_q`
-  exactly when its fifty-four doubled coordinates lie in the field of definition.
+  exactly when all entries of its `54 × 54` matrix lie in the field of definition.
 * `TauCeti.TypeTwistedE6LieIndex.e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm_diagramPerm`:
   the coordinate involution of the doubled index set is equivariant for the diagram permutation
   that the index itself carries, read in the index's copy `Fin d.1.rank` of the Bourbaki index
@@ -221,8 +221,8 @@ theorem frobenius_def :
     d.frobenius = E6DoubledMinuscule.frobenius d.1.characteristic d.1.fieldExponent d.1.Closure :=
   (rfl)
 
-/-- The Frobenius acts on the ambient group by raising each of the fifty-four doubled matrix
-coordinates to the `q`-th power. This is the coefficient-level form from which the commutation of
+/-- The Frobenius acts on the ambient group by raising each entry of the `54 × 54` matrix of a
+point to the `q`-th power. This is the coefficient-level form from which the commutation of
 `Frob_q` with a coordinate symmetry of the carrier is read. -/
 @[simp]
 theorem coe_frobenius_apply (g : d.AmbientGroup) (r c : Fin 54) :
@@ -245,8 +245,8 @@ theorem frobenius_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.
   rw [frobenius_def, simpleRootSubgroup_def, E6DoubledMinuscule.frobenius_rootSubgroupPoints,
     ValidLieTypeIndex.fieldOrder_eq_characteristic_pow]
 
-/-- **A point of the ambient group is fixed by the Frobenius exactly when all fifty-four of its
-doubled matrix coordinates lie in the field of definition.** Writing `𝔽_q` for
+/-- **A point of the ambient group is fixed by the Frobenius exactly when every entry of its
+`54 × 54` matrix lies in the field of definition.** Writing `𝔽_q` for
 `TauCeti.ValidLieTypeIndex.fixedField`, the copy of the field of `q` elements inside the algebraic
 closure, the Frobenius-fixed subgroup is therefore the group of points of the doubled minuscule
 carrier with coordinates in `𝔽_q`. It is not the group `H_d` that milestone L3 runs its recipe on

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
@@ -5,8 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.E6.DoubledMinuscule.GroupScheme
-public import TauCeti.GroupTheory.SpecificGroups.CFSG.Closure
+public import TauCeti.Algebra.Lie.E6.DoubledMinuscule.Frobenius
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Frobenius
 public import TauCeti.GroupTheory.SpecificGroups.CFSG.GraphTwisted
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Assembly
 
@@ -24,16 +24,19 @@ is `TauCeti.E6DoubledMinuscule.groupScheme`, built on `V(ϖ₁) ⊕ V(ϖ₆)` in
 
 This file attaches that carrier to a validated `²E₆` index. It supplies the group of
 algebraic-closure-valued points and the Bourbaki-numbered simple root subgroups, identifies the
-character of those subgroups with the corresponding simple root of the `E₆` root datum, and records
+character of those subgroups with the corresponding simple root of the `E₆` root datum, records
 that the involution of the fifty-four doubled coordinates realizes on the doubled weight family the
-diagram permutation the index itself carries.
+diagram permutation the index itself carries, and builds the `q`-power Frobenius factor `Frob_q` of
+the branch's Steinberg map, with the pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)` on the numbered
+simple-root subgroups and the description of the points it fixes as those whose fifty-four doubled
+coordinates lie in the field of definition `𝔽_q`.
 
 The Steinberg map itself is *not* here, and neither is the candidate group of milestone L3. It is
-`γ₂ ∘ Frob_q`, and both factors are still owed on this carrier: the Frobenius is the endomorphism
-that `TauCeti.E6DoubledMinuscule.pointsMap` induces from the `q`-power map of the value ring, and
-`γ₂` is the automorphism the coordinate involution induces, whose construction consumes exactly the
-weight equivariance recorded below. Until both exist there is no fixed-point subgroup to form, and
-none is formed.
+the composite `γ₂ ∘ Frob_q`, and the factor still owed on this carrier is `γ₂`, the automorphism
+that the coordinate involution induces, whose construction consumes exactly the weight equivariance
+recorded below. Until it exists there is no Steinberg map to take fixed points of, and none is
+taken. In particular `TauCeti.TypeTwistedE6LieIndex.frobenius` is not that map: the twisted branch
+is precisely the one on which the Steinberg map and its Frobenius factor differ.
 
 Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
 the pinned simply connected Chevalley--Demazure group scheme of type `E₆`, or that any group
@@ -45,12 +48,18 @@ mentioned is finite, perfect, or simple.
   minuscule carrier, the group the classification recipe for `²E₆(q)` will be run inside.
 * `TauCeti.TypeTwistedE6LieIndex.simpleRootSubgroup`: its positive simple-root subgroup at a
   Bourbaki-numbered node.
+* `TauCeti.TypeTwistedE6LieIndex.frobenius`: the `q`-power Frobenius factor of the branch's
+  Steinberg map, at the field order the index records.
 
 ## Main results
 
 * `TauCeti.TypeTwistedE6LieIndex.rootGeneratorWeight_eq_root_simpleIndex`: the character of that
   subgroup is the corresponding simple root of
   `TauCeti.DynkinType.simplyConnectedRootDatum` at `E₆`.
+* `TauCeti.TypeTwistedE6LieIndex.frobenius_simpleRootSubgroup`: the pinned equation
+  `Frob_q (x_i(u)) = x_i(u ^ q)`, milestone L1's requirement on the Frobenius factor.
+* `TauCeti.TypeTwistedE6LieIndex.mem_fixedSubgroup_frobenius_iff`: a point is fixed by `Frob_q`
+  exactly when its fifty-four doubled coordinates lie in the field of definition.
 * `TauCeti.TypeTwistedE6LieIndex.e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm_diagramPerm`:
   the coordinate involution of the doubled index set is equivariant for the diagram permutation
   that the index itself carries, read in the index's copy `Fin d.1.rank` of the Bourbaki index
@@ -80,10 +89,11 @@ its pinning, and any identification of a carrier with it are Layer 9 targets of
 `TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap consumes rather than builds; none
 of them is proved of `TauCeti.E6DoubledMinuscule.groupScheme` here or in the files this one
 imports. What this file supplies is the `²E₆` branch's explicit carrier, its numbered root
-characters read in the `E₆` root datum, and the diagram-symmetry data that milestone L1's
-`γ (x_α(t)) = x_{γ α}(t)` will be proved from; they transfer to the L0 carrier along that Layer 9
-identification, and not before. The counterparts on the other branches already assembled are
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
+characters read in the `E₆` root datum, the diagram-symmetry data that milestone L1's
+`γ (x_α(t)) = x_{γ α}(t)` will be proved from, and milestone L1's other factor `Frob_q` together
+with its own pinned equation `Frob_q (x_α(t)) = x_α(t ^ q)`; they transfer to the L0 carrier along
+that Layer 9 identification, and not before. The counterparts on the branches already assembled
+are `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
 `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
 `TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`, and the branch that likewise stops short
 of a Steinberg map is `TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean`.
@@ -184,6 +194,75 @@ theorem e6DoubledMinusculeGraphPerm_pow_twistOrder :
     e6DoubledMinusculeGraphPerm ^ d.toGraphTwistedIndex.twistOrder = 1 := by
   rw [d.twistOrder_toGraphTwistedIndex, pow_two]
   exact Equiv.ext e6DoubledMinusculeGraphPerm_apply_apply
+
+/-! ## The Frobenius factor of the Steinberg map -/
+
+/-- **The `q`-power Frobenius endomorphism of the ambient group of a validated `²E₆` index**, `q`
+being the field order the index records.
+
+It is *not* the Steinberg map of the family. Milestone L1 gives the graph-twisted families the
+Steinberg map `γ₂ ∘ Frob_q`, and on this branch the two genuinely differ: the composite acts on the
+simple-root subgroups through the diagram permutation the index carries, which is
+`TauCeti.graphPermE6` by `TauCeti.TypeTwistedE6LieIndex.diagramPerm_toGraphTwistedIndex` and has
+order two by `TauCeti.orderOf_graphPermE6`. This is the right-hand factor of that composite,
+and the fixed subgroup formed from it below is correspondingly the untwisted one, not the `H_d`
+that milestone L3 runs its recipe on for this branch. -/
+def frobenius : d.AmbientGroup →* d.AmbientGroup :=
+  E6DoubledMinuscule.frobenius d.1.characteristic d.1.fieldExponent d.1.Closure
+
+/-- The Frobenius of a `²E₆` index is the doubled minuscule carrier's Frobenius at the exponent the
+index records. This is its unfolding lemma; the definition itself stays sealed.
+
+It is deliberately not a `simp` lemma: `frobenius_simpleRootSubgroup` and `coe_frobenius_apply` are
+the normal forms the pinned equations of this file are stated against, and unfolding to
+`TauCeti.E6DoubledMinuscule.frobenius` would keep them from firing, as it does on the branches
+already assembled. -/
+theorem frobenius_def :
+    d.frobenius = E6DoubledMinuscule.frobenius d.1.characteristic d.1.fieldExponent d.1.Closure :=
+  (rfl)
+
+/-- The Frobenius acts on the ambient group by raising each of the fifty-four doubled matrix
+coordinates to the `q`-th power. This is the coefficient-level form from which the commutation of
+`Frob_q` with a coordinate symmetry of the carrier is read. -/
+@[simp]
+theorem coe_frobenius_apply (g : d.AmbientGroup) (r c : Fin 54) :
+    ((d.frobenius g : Matrix.GeneralLinearGroup (Fin 54) d.1.Closure) :
+        Matrix (Fin 54) (Fin 54) d.1.Closure) r c =
+      ((g : Matrix.GeneralLinearGroup (Fin 54) d.1.Closure) :
+        Matrix (Fin 54) (Fin 54) d.1.Closure) r c ^ d.1.fieldOrder := by
+  rw [frobenius_def, d.1.fieldOrder_eq_characteristic_pow]
+  exact E6DoubledMinuscule.coe_frobenius_apply _ _ _ g r c
+
+/-- **The Frobenius fixes the Bourbaki numbering of a simple-root subgroup and raises its parameter
+to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation milestone L1
+asks of an ordinary Frobenius factor; the diagram permutation of the twisted family enters through
+the other factor `γ₂` and not through this one. -/
+@[simp]
+theorem frobenius_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.Closure) :
+    d.frobenius (d.simpleRootSubgroup i u) =
+      d.simpleRootSubgroup i
+        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.fieldOrder)) := by
+  rw [frobenius_def, simpleRootSubgroup_def, E6DoubledMinuscule.frobenius_rootSubgroupPoints,
+    ValidLieTypeIndex.fieldOrder_eq_characteristic_pow]
+
+/-- **A point of the ambient group is fixed by the Frobenius exactly when all fifty-four of its
+doubled matrix coordinates lie in the field of definition.** Writing `𝔽_q` for
+`TauCeti.ValidLieTypeIndex.fixedField`, the copy of the field of `q` elements inside the algebraic
+closure, the Frobenius-fixed subgroup is therefore the group of points of the doubled minuscule
+carrier with coordinates in `𝔽_q`. It is not the group `H_d` that milestone L3 runs its recipe on
+for this branch, which is cut out by the twisted composite `γ₂ ∘ Frob_q` instead.
+
+As for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`, this is not a `simp` lemma:
+`TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites its
+left-hand side to `d.frobenius g = g` through `MonoidHom.mem_eqLocus`, and the `simpNF` linter
+rejects the annotation. -/
+theorem mem_fixedSubgroup_frobenius_iff (g : d.AmbientGroup) :
+    g ∈ fixedSubgroup d.frobenius ↔
+      ∀ r c, ((g : Matrix.GeneralLinearGroup (Fin 54) d.1.Closure) :
+        Matrix (Fin 54) (Fin 54) d.1.Closure) r c ∈ d.1.fixedField := by
+  rw [mem_fixedSubgroup, frobenius_def, E6DoubledMinuscule.frobenius_eq_self_iff]
+  simp only [mem_frobeniusFixedSubring, ValidLieTypeIndex.mem_fixedField,
+    d.1.fieldOrder_eq_characteristic_pow]
 
 end
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean
@@ -205,18 +205,17 @@ Steinberg map `γ₂ ∘ Frob_q`, and on this branch the two genuinely differ: t
 simple-root subgroups through the diagram permutation the index carries, which is
 `TauCeti.graphPermE6` by `TauCeti.TypeTwistedE6LieIndex.diagramPerm_toGraphTwistedIndex` and has
 order two by `TauCeti.orderOf_graphPermE6`. This is the right-hand factor of that composite,
-and the fixed subgroup formed from it below is correspondingly the untwisted one, not the `H_d`
-that milestone L3 runs its recipe on for this branch. -/
+and the subgroup of points it fixes, characterized below, is correspondingly the untwisted one,
+not the `H_d` that milestone L3 runs its recipe on for this branch. -/
 def frobenius : d.AmbientGroup →* d.AmbientGroup :=
   E6DoubledMinuscule.frobenius d.1.characteristic d.1.fieldExponent d.1.Closure
 
 /-- The Frobenius of a `²E₆` index is the doubled minuscule carrier's Frobenius at the exponent the
-index records. This is its unfolding lemma; the definition itself stays sealed.
-
-It is deliberately not a `simp` lemma: `frobenius_simpleRootSubgroup` and `coe_frobenius_apply` are
-the normal forms the pinned equations of this file are stated against, and unfolding to
-`TauCeti.E6DoubledMinuscule.frobenius` would keep them from firing, as it does on the branches
-already assembled. -/
+index records. This is its unfolding lemma; the definition itself stays sealed. -/
+-- Not `@[simp]`: `frobenius_simpleRootSubgroup` and `coe_frobenius_apply` are the normal forms the
+-- pinned equations of this file are stated against, and unfolding to
+-- `TauCeti.E6DoubledMinuscule.frobenius` would keep them from firing, as it does on the branches
+-- already assembled.
 theorem frobenius_def :
     d.frobenius = E6DoubledMinuscule.frobenius d.1.characteristic d.1.fieldExponent d.1.Closure :=
   (rfl)
@@ -250,12 +249,11 @@ theorem frobenius_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.
 `TauCeti.ValidLieTypeIndex.fixedField`, the copy of the field of `q` elements inside the algebraic
 closure, the Frobenius-fixed subgroup is therefore the group of points of the doubled minuscule
 carrier with coordinates in `𝔽_q`. It is not the group `H_d` that milestone L3 runs its recipe on
-for this branch, which is cut out by the twisted composite `γ₂ ∘ Frob_q` instead.
-
-As for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`, this is not a `simp` lemma:
-`TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites its
-left-hand side to `d.frobenius g = g` through `MonoidHom.mem_eqLocus`, and the `simpNF` linter
-rejects the annotation. -/
+for this branch, which is cut out by the twisted composite `γ₂ ∘ Frob_q` instead. -/
+-- Not `@[simp]`, as for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`:
+-- `TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites the
+-- left-hand side to `d.frobenius g = g` through `MonoidHom.mem_eqLocus`, and the `simpNF` linter
+-- rejects the annotation.
 theorem mem_fixedSubgroup_frobenius_iff (g : d.AmbientGroup) :
     g ∈ fixedSubgroup d.frobenius ↔
       ∀ r c, ((g : Matrix.GeneralLinearGroup (Fin 54) d.1.Closure) :


### PR DESCRIPTION
This PR builds the `q`-power Frobenius factor of the Steinberg map of the graph-twisted family
`²E₆(q)`, on the doubled minuscule carrier that
`TauCeti/GroupTheory/SpecificGroups/CFSG/TwistedE6.lean` already attaches to a validated `²E₆`
index. `TauCeti.TypeTwistedE6LieIndex.frobenius` is `TauCeti.E6DoubledMinuscule.frobenius` at the
characteristic and exponent the index records, and it comes with `coe_frobenius_apply`, the entrywise `q`-th power on all
entries of a point's `54 × 54` matrix;
`frobenius_simpleRootSubgroup`, the pinned equation `Frob_q (x_i(u)) = x_i(u ^ q)` on the
Bourbaki-numbered simple root subgroups; and `mem_fixedSubgroup_frobenius_iff`, which describes the
points it fixes as those all of whose matrix entries lie in the field of definition
`TauCeti.ValidLieTypeIndex.fixedField`, the copy of `𝔽_q` inside the algebraic closure.

The milestone is L1, "ordinary and graph Steinberg maps", of
`TauCetiRoadmap/CFSGStatement/README.md`, whose table gives `²E₆` the Steinberg map `γ₂ ∘ Frob_q`.
This PR supplies the right-hand factor and its required equation, in the form the branches already
assembled state it, `TauCeti.TypeE6LieIndex.steinberg_simpleRootSubgroup` and the
`frobenius_simpleRootSubgroup` of
`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean`. What remains on this branch after this PR is
the left-hand factor `γ₂`, the automorphism of the carrier induced by the coordinate involution
whose weight equivariance and order relation the file already records
(`e6DoubledMinusculeWeight_e6DoubledMinusculeGraphPerm_diagramPerm` and
`e6DoubledMinusculeGraphPerm_pow_twistOrder`); once it exists, `γ₂ ∘ Frob_q` and then the L3
recipe `[H, H] / Z([H, H])` follow.

The Frobenius built here is deliberately not named `steinberg`, and no fixed-point candidate group
is formed from it. On this branch the Steinberg map and its Frobenius factor genuinely differ: the
composite moves the simple-root subgroups by the diagram permutation the index carries, which is
`TauCeti.graphPermE6` by `TauCeti.TypeTwistedE6LieIndex.diagramPerm_toGraphTwistedIndex` and has
order two by `TauCeti.orderOf_graphPermE6`. The fixed subgroup described here is correspondingly
the untwisted one and not the `H_d` of milestone L3, and the docstrings say so at both
declarations. The same separation is the one
`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeB2.lean` makes for the Suzuki family, where the
Frobenius is the square of the Steinberg map rather than a factor of it.

Milestone L1's stated dependency, L0, is already discharged for this branch on `main`. The output
`CFSGStatement/README.md` names for L0 is "the actual body of `ValidLieTypeIndex.AmbientGroup`, its
`Group` instance, `ValidLieTypeIndex.Closure`, and `ValidLieTypeIndex.simpleRootSubgroup`"; for
`²E₆` those are `TauCeti.TypeTwistedE6LieIndex.AmbientGroup`, its `Group` instance,
`TauCeti.ValidLieTypeIndex.Closure` and `TauCeti.TypeTwistedE6LieIndex.simpleRootSubgroup`, landed
in https://github.com/TauCetiProject/TauCeti/pull/5421 ("feat: the ²E₆(q) ambient group on the
doubled minuscule carrier") together with
`TauCeti.TypeTwistedE6LieIndex.rootGeneratorWeight_eq_root_simpleIndex`, which reads their
characters in `TauCeti.DynkinType.simplyConnectedRootDatum` at `E₆`. The Frobenius added here is an
endomorphism of exactly that ambient group and its L1 equation is stated against exactly those
simple-root subgroups.

Nothing here adds to milestone L0, and nothing here is offered as the pinned simply connected
Chevalley--Demazure group scheme that L0's construction consumes. That group scheme, its pinning,
and the identification of any carrier with its points are Layer 9 targets of
`TauCetiRoadmap/ReductiveGroups/README.md`, which `CFSGStatement/README.md` lists under "`L0` rests
on two bodies of work owned by other roadmaps" with the instruction "Claim those in the roadmap
that owns them"; no such identification exists in this repository for any Dynkin type, and no
reductivity, pinning, maximality, finiteness, perfection or simplicity statement is proved of
anything below. The
imports move from `TauCeti.Algebra.Lie.E6.DoubledMinuscule.GroupScheme` and
`TauCeti.GroupTheory.SpecificGroups.CFSG.Closure` to the two modules that extend them,
`...DoubledMinuscule.Frobenius` and `...CFSG.Frobenius`; no declaration is renamed or moved and no
other file changes.

The conventions followed are the roadmap's, after R. W. Carter, *Simple Groups of Lie Type*,
§§12.2 and 13, Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*,
§§1.15 and 1.17, and the Bourbaki numbering of Plate V. Nothing is vendored.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"typetwistede6lieindex-frobenius"}-->

🤖 Prepared with Claude Code




