### PR TITLE
feat: trivialize smooth connected central subgroups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Semisimple/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Semisimple/Center.lean
@@ -31,8 +31,6 @@ constructed, no separate solvability argument is needed to show that it is trivi
 * `TauCeti.semisimpleCommHopfAlgProperty.eq_augmentation_of_isCentral`: every smooth
   geometrically connected central closed subgroup of a semisimple group's geometric fibre is
   trivial.
-* `TauCeti.semisimpleCommHopfAlgProperty.centerDefiningIdeal_eq_augmentation`: a smooth
-  geometrically connected centre of the geometric fibre is trivial.
 
 ## References
 
@@ -84,34 +82,6 @@ theorem eq_augmentation_of_isCentral
     (AlgebraicClosure k)
       (FiniteTypeCommHopfAlgCat.quotient
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj
-
-/-- If the centre of a semisimple affine group's geometric fibre is smooth and geometrically
-connected, then it is the identity subgroup.
-
-This is the canonical-centre specialization of `eq_augmentation_of_isCentral`. It does not claim
-that centres of semisimple groups are connected or smooth; both properties are explicit because
-they can fail, especially smoothness in positive characteristic. -/
-theorem centerDefiningIdeal_eq_augmentation
-    (hH : semisimpleCommHopfAlgProperty k H)
-    (hconnected : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.quotient
-        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
-        (CommHopfAlgCat.centerDefiningIdeal
-          (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj)).obj)
-    (hsmooth : Algebra.Smooth (AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.quotient
-        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
-        (CommHopfAlgCat.centerDefiningIdeal
-          (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj))) :
-    CommHopfAlgCat.centerDefiningIdeal
-        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj =
-      HopfIdeal.augmentation (AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
-  hH.eq_augmentation_of_isCentral
-    (CommHopfAlgCat.centerDefiningIdeal
-      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj)
-    (CommHopfAlgCat.isCentral_centerDefiningIdeal
-      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) hconnected hsmooth
 
 end semisimpleCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Semisimple/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Semisimple/Center.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Center.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Semisimple.Basic
+
+/-!
+# Central closed subgroups of semisimple affine groups
+
+Let `H` be the coordinate Hopf algebra of a semisimple affine group over a field `k`. This file
+proves that every smooth geometrically connected central closed subgroup of the geometric fibre
+is trivial.
+
+A central Hopf ideal is normal, and its quotient coordinate Hopf algebra is cocommutative.
+Consequently the represented subgroup has a commutative, hence solvable, group of geometric
+points. The defining universal property of semisimplicity then identifies its defining ideal with
+the augmentation ideal.
+
+The theorem deliberately retains smoothness. In positive characteristic a semisimple group can
+have a non-smooth connected central subgroup scheme, such as an infinitesimal subgroup of its
+centre, so removing that hypothesis would be false. The result is the central-subgroup input for
+the finite-centre and adjoint-form steps: once a smooth connected central subgroup has been
+constructed, no separate solvability argument is needed to show that it is trivial.
+
+## Main declarations
+
+* `TauCeti.semisimpleCommHopfAlgProperty.eq_augmentation_of_isCentral`: every smooth
+  geometrically connected central closed subgroup of a semisimple group's geometric fibre is
+  trivial.
+* `TauCeti.semisimpleCommHopfAlgProperty.centerDefiningIdeal_eq_augmentation`: a smooth
+  geometrically connected centre of the geometric fibre is trivial.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§21.10 and 21.15.
+* T. A. Springer, *Linear Algebraic Groups*, §8.1.
+
+This advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap. It is
+the central-subgroup triviality step used in proving that the centre of a semisimple group is
+finite and in constructing its adjoint form.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace semisimpleCommHopfAlgProperty
+
+variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}
+
+/-- **A smooth geometrically connected central closed subgroup of a semisimple affine group's
+geometric fibre is trivial.**
+
+The Hopf ideal `I` cuts out the subgroup contravariantly. Thus triviality is the equality of `I`
+with the augmentation ideal. Centrality supplies both normality and cocommutativity of the
+quotient; the latter makes its geometric point group commutative and therefore solvable. -/
+theorem eq_augmentation_of_isCentral
+    (hH : semisimpleCommHopfAlgProperty k H)
+    (I : HopfIdeal (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H))
+    (hI : I.IsCentral)
+    (hconnected : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj)
+    (hsmooth : Algebra.Smooth (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I)) :
+    I = HopfIdeal.augmentation (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
+  apply hH.eq_augmentation I hI.isNormal hconnected hsmooth
+  let _ : Coalgebra.IsCocomm (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) :=
+    hI.isCocomm_quotient
+  exact geometricallySolvablePointsCommHopfAlgProperty_of_isCocomm
+    (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj
+
+/-- If the centre of a semisimple affine group's geometric fibre is smooth and geometrically
+connected, then it is the identity subgroup.
+
+This is the canonical-centre specialization of `eq_augmentation_of_isCentral`. It does not claim
+that centres of semisimple groups are connected or smooth; both properties are explicit because
+they can fail, especially smoothness in positive characteristic. -/
+theorem centerDefiningIdeal_eq_augmentation
+    (hH : semisimpleCommHopfAlgProperty k H)
+    (hconnected : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+        (CommHopfAlgCat.centerDefiningIdeal
+          (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj)).obj)
+    (hsmooth : Algebra.Smooth (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+        (CommHopfAlgCat.centerDefiningIdeal
+          (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj))) :
+    CommHopfAlgCat.centerDefiningIdeal
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj =
+      HopfIdeal.augmentation (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  hH.eq_augmentation_of_isCentral
+    (CommHopfAlgCat.centerDefiningIdeal
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj)
+    (CommHopfAlgCat.isCentral_centerDefiningIdeal
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) hconnected hsmooth
+
+end semisimpleCommHopfAlgProperty
+
+end
+
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean
@@ -30,6 +30,8 @@ Lie--Kolchin theory and the construction of the solvable radical.
 
 * `TauCeti.geometricallySolvablePointsCommHopfAlgProperty`: solvability of the geometric point
   group.
+* `TauCeti.geometricallySolvablePointsCommHopfAlgProperty_of_isCocomm`: commutative affine
+  groups have solvable geometric points.
 * `TauCeti.geometricallySolvablePointsCommHopfAlgProperty_of_surjective`: closure under closed
   subgroups.
 * `TauCeti.geometricallySolvablePointsCommHopfAlgProperty_tensorProduct_iff`: solvability of a
@@ -70,6 +72,17 @@ theorem geometricallySolvablePointsCommHopfAlgProperty_iff
     geometricallySolvablePointsCommHopfAlgProperty k H ↔
       Group.IsSolvable (WithConv (H →ₐ[k] AlgebraicClosure k)) :=
   Iff.rfl
+
+/-- A cocommutative coordinate Hopf algebra has solvable geometric points.
+
+Cocommutativity makes the convolution group of points commutative over every commutative value
+algebra, so in particular its algebraic-closure-valued point group is solvable. -/
+theorem geometricallySolvablePointsCommHopfAlgProperty_of_isCocomm
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k)
+    [Coalgebra.IsCocomm k H] :
+    geometricallySolvablePointsCommHopfAlgProperty k H := by
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff]
+  exact Group.isSolvable_of_comm mul_comm
 
 /-- Geometric-points solvability is invariant under isomorphisms of commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :


### PR DESCRIPTION
This PR proves that every smooth geometrically connected central closed subgroup of a semisimple affine group's geometric fibre is trivial. It adds the reusable fact that a cocommutative coordinate Hopf algebra has solvable geometric points, then combines the existing centrality-to-normality and centrality-to-cocommutativity results with the semisimple radical criterion.

This advances the `ReductiveGroups/README.md` Layer 6 milestone “Reductive and semisimple groups,” specifically its target to develop the centre `Z(G)`, central isogenies, and adjoint forms. The finite-centre and adjoint-form path consumes `semisimpleCommHopfAlgProperty.eq_augmentation_of_isCentral` when the smooth geometrically connected identity component of the reduced centre is supplied. After this PR, the milestone still needs that reduced-centre construction and its geometric connectedness, finiteness of the full centre including infinitesimal structure, and the adjoint quotient and simply connected cover.

The proof reuses `Group.isSolvable_of_comm`, `HopfIdeal.IsCentral.isNormal`, and `HopfIdeal.IsCentral.isCocomm_quotient`; no Mathlib implementation is vendored. The module documentation attributes the mathematical result to Milne, §§21.10 and 21.15, and Springer, §8.1.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"semisimple-central-subgroup-trivial"}-->

🤖 Prepared with Codex
