### PR TITLE
feat: preserve adjointness under base change

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Adjoint/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Adjoint/BaseChange.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Adjoint.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Center.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
+
+/-!
+# Base change and adjoint semisimple affine groups
+
+An adjoint semisimple affine group has trivial scheme-theoretic center. Formation of the center
+commutes with extension of the ground field, and field extensions are faithfully flat, so
+adjointness is unchanged by scalar extension whenever the base-changed group is supplied with
+its semisimple structure.
+
+The semisimplicity hypothesis on the base-changed object is explicit. Its construction is a
+separate structure theorem: this file proves that no further argument about the center is needed
+once that hypothesis is available. The result concerns the full center scheme, not only its
+points over either field.
+
+## Main declarations
+
+* `TauCeti.adjointSemisimpleCommHopfAlgProperty.baseChange`: extension of the base field
+  preserves adjointness.
+* `TauCeti.adjointSemisimpleCommHopfAlgProperty.of_baseChange`: adjointness descends from a
+  field extension.
+* `TauCeti.adjointSemisimpleCommHopfAlgProperty_baseChange_iff`: adjointness of a semisimple
+  affine group is equivalent to adjointness after a field extension.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§1.k and 21.4.
+* T. A. Springer, *Linear Algebraic Groups*, §9.6.
+
+This supplies the scalar-extension compatibility needed for adjoint forms in Layer 6,
+"Reductive and semisimple groups", of the ReductiveGroups roadmap. It is the center-theoretic
+input to comparing adjoint forms and their root data over an algebraic closure.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+variable {k K : Type u} [Field k] [Field K] [Algebra k K]
+
+/-- Adjointness is preserved and reflected by a field extension.
+
+The proof that the base-changed finite-type Hopf algebra is semisimple is kept as an explicit
+hypothesis, since preservation of semisimplicity is logically separate from the center
+calculation. -/
+theorem adjointSemisimpleCommHopfAlgProperty_baseChange_iff
+    (H : SemisimpleCommHopfAlgCat.{u} k)
+    (hsemisimple : semisimpleCommHopfAlgProperty K
+      (FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj)) :
+    adjointSemisimpleCommHopfAlgProperty K
+        ⟨FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj, hsemisimple⟩ ↔
+      adjointSemisimpleCommHopfAlgProperty k H := by
+  rw [adjointSemisimpleCommHopfAlgProperty_iff,
+    adjointSemisimpleCommHopfAlgProperty_iff]
+  exact CommHopfAlgCat.centerDefiningIdeal_baseChange_eq_augmentation_iff H.obj.obj
+
+namespace adjointSemisimpleCommHopfAlgProperty
+
+variable {H : SemisimpleCommHopfAlgCat.{u} k}
+
+/-- Extension of the base field preserves adjointness once the base-changed group is known to be
+semisimple. -/
+theorem baseChange (hH : adjointSemisimpleCommHopfAlgProperty k H)
+    (hsemisimple : semisimpleCommHopfAlgProperty K
+      (FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj)) :
+    adjointSemisimpleCommHopfAlgProperty K
+      ⟨FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj, hsemisimple⟩ :=
+  (adjointSemisimpleCommHopfAlgProperty_baseChange_iff H hsemisimple).2 hH
+
+/-- Adjointness after a field extension implies adjointness over the original field. -/
+theorem of_baseChange
+    (hsemisimple : semisimpleCommHopfAlgProperty K
+      (FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj))
+    (hH : adjointSemisimpleCommHopfAlgProperty K
+      ⟨FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj, hsemisimple⟩) :
+    adjointSemisimpleCommHopfAlgProperty k H :=
+  (adjointSemisimpleCommHopfAlgProperty_baseChange_iff H hsemisimple).1 hH
+
+end adjointSemisimpleCommHopfAlgProperty
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Adjoint/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Adjoint/BaseChange.lean
@@ -54,7 +54,6 @@ namespace adjointSemisimpleCommHopfAlgProperty
 The proof that the base-changed finite-type Hopf algebra is semisimple is kept as an explicit
 hypothesis, since preservation of semisimplicity is logically separate from the center
 calculation. -/
-@[simp]
 theorem baseChange_iff
     (H : SemisimpleCommHopfAlgCat.{u} k)
     (hsemisimple : semisimpleCommHopfAlgProperty K

--- a/TauCeti/Algebra/AlgebraicGroup/Adjoint/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Adjoint/BaseChange.lean
@@ -22,12 +22,8 @@ separate structure theorem: this file proves that no further argument about the 
 once that hypothesis is available. The result concerns the full center scheme, not only its
 points over either field.
 
-## Main declarations
+## Main declaration
 
-* `TauCeti.adjointSemisimpleCommHopfAlgProperty.baseChange`: extension of the base field
-  preserves adjointness.
-* `TauCeti.adjointSemisimpleCommHopfAlgProperty.of_baseChange`: adjointness descends from a
-  field extension.
 * `TauCeti.adjointSemisimpleCommHopfAlgProperty.baseChange_iff`: adjointness of a semisimple
   affine group is equivalent to adjointness after a field extension.
 
@@ -58,6 +54,7 @@ namespace adjointSemisimpleCommHopfAlgProperty
 The proof that the base-changed finite-type Hopf algebra is semisimple is kept as an explicit
 hypothesis, since preservation of semisimplicity is logically separate from the center
 calculation. -/
+@[simp]
 theorem baseChange_iff
     (H : SemisimpleCommHopfAlgCat.{u} k)
     (hsemisimple : semisimpleCommHopfAlgProperty K
@@ -68,26 +65,6 @@ theorem baseChange_iff
   rw [adjointSemisimpleCommHopfAlgProperty_iff,
     adjointSemisimpleCommHopfAlgProperty_iff]
   exact CommHopfAlgCat.centerDefiningIdeal_baseChange_eq_augmentation_iff H.obj.obj
-
-variable {H : SemisimpleCommHopfAlgCat.{u} k}
-
-/-- Extension of the base field preserves adjointness once the base-changed group is known to be
-semisimple. -/
-theorem baseChange (hH : adjointSemisimpleCommHopfAlgProperty k H)
-    (hsemisimple : semisimpleCommHopfAlgProperty K
-      (FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj)) :
-    adjointSemisimpleCommHopfAlgProperty K
-      ⟨FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj, hsemisimple⟩ :=
-  (baseChange_iff H hsemisimple).2 hH
-
-/-- Adjointness after a field extension implies adjointness over the original field. -/
-theorem of_baseChange
-    (hsemisimple : semisimpleCommHopfAlgProperty K
-      (FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj))
-    (hH : adjointSemisimpleCommHopfAlgProperty K
-      ⟨FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj, hsemisimple⟩) :
-    adjointSemisimpleCommHopfAlgProperty k H :=
-  (baseChange_iff H hsemisimple).1 hH
 
 end adjointSemisimpleCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Adjoint/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Adjoint/BaseChange.lean
@@ -28,7 +28,7 @@ points over either field.
   preserves adjointness.
 * `TauCeti.adjointSemisimpleCommHopfAlgProperty.of_baseChange`: adjointness descends from a
   field extension.
-* `TauCeti.adjointSemisimpleCommHopfAlgProperty_baseChange_iff`: adjointness of a semisimple
+* `TauCeti.adjointSemisimpleCommHopfAlgProperty.baseChange_iff`: adjointness of a semisimple
   affine group is equivalent to adjointness after a field extension.
 
 ## References
@@ -51,12 +51,14 @@ noncomputable section
 
 variable {k K : Type u} [Field k] [Field K] [Algebra k K]
 
+namespace adjointSemisimpleCommHopfAlgProperty
+
 /-- Adjointness is preserved and reflected by a field extension.
 
 The proof that the base-changed finite-type Hopf algebra is semisimple is kept as an explicit
 hypothesis, since preservation of semisimplicity is logically separate from the center
 calculation. -/
-theorem adjointSemisimpleCommHopfAlgProperty_baseChange_iff
+theorem baseChange_iff
     (H : SemisimpleCommHopfAlgCat.{u} k)
     (hsemisimple : semisimpleCommHopfAlgProperty K
       (FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj)) :
@@ -67,8 +69,6 @@ theorem adjointSemisimpleCommHopfAlgProperty_baseChange_iff
     adjointSemisimpleCommHopfAlgProperty_iff]
   exact CommHopfAlgCat.centerDefiningIdeal_baseChange_eq_augmentation_iff H.obj.obj
 
-namespace adjointSemisimpleCommHopfAlgProperty
-
 variable {H : SemisimpleCommHopfAlgCat.{u} k}
 
 /-- Extension of the base field preserves adjointness once the base-changed group is known to be
@@ -78,7 +78,7 @@ theorem baseChange (hH : adjointSemisimpleCommHopfAlgProperty k H)
       (FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj)) :
     adjointSemisimpleCommHopfAlgProperty K
       ⟨FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj, hsemisimple⟩ :=
-  (adjointSemisimpleCommHopfAlgProperty_baseChange_iff H hsemisimple).2 hH
+  (baseChange_iff H hsemisimple).2 hH
 
 /-- Adjointness after a field extension implies adjointness over the original field. -/
 theorem of_baseChange
@@ -87,7 +87,7 @@ theorem of_baseChange
     (hH : adjointSemisimpleCommHopfAlgProperty K
       ⟨FiniteTypeCommHopfAlgCat.baseChange (K := K) H.obj, hsemisimple⟩) :
     adjointSemisimpleCommHopfAlgProperty k H :=
-  (adjointSemisimpleCommHopfAlgProperty_baseChange_iff H hsemisimple).1 hH
+  (baseChange_iff H hsemisimple).1 hH
 
 end adjointSemisimpleCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Center/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/BaseChange.lean
@@ -94,6 +94,6 @@ theorem centerDefiningIdeal_baseChange_eq_augmentation_iff
       centerDefiningIdeal H = HopfIdeal.augmentation k H := by
   rw [← baseChangeHopfIdeal_centerDefiningIdeal,
     ← baseChangeHopfIdeal_augmentation]
-  exact (baseChangeHopfIdeal_injective (E := K)).eq_iff
+  exact baseChangeHopfIdeal_inj _ _
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Center/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/BaseChange.lean
@@ -87,6 +87,7 @@ theorem baseChangeHopfIdeal_centerDefiningIdeal
 
 The statement uses the augmentation ideal, which cuts out the identity subgroup. Thus it detects
 the full center scheme, including infinitesimal structure invisible on field-valued points. -/
+@[simp]
 theorem centerDefiningIdeal_baseChange_eq_augmentation_iff
     (H : _root_.CommHopfAlgCat.{v} k) :
     centerDefiningIdeal (baseChange (K := K) H) =

--- a/TauCeti/Algebra/AlgebraicGroup/Center/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/BaseChange.lean
@@ -95,6 +95,6 @@ theorem centerDefiningIdeal_baseChange_eq_augmentation_iff
       centerDefiningIdeal H = HopfIdeal.augmentation k H := by
   rw [← baseChangeHopfIdeal_centerDefiningIdeal,
     ← baseChangeHopfIdeal_augmentation]
-  exact baseChangeHopfIdeal_inj _ _
+  exact baseChangeHopfIdeal_injective.eq_iff
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Center/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/BaseChange.lean
@@ -28,6 +28,8 @@ point of `H`, so it kills every equation of the original center.
 
 * `TauCeti.CommHopfAlgCat.baseChangeHopfIdeal_centerDefiningIdeal`: the defining ideal of the
   center commutes with extension of the ground field.
+* `TauCeti.CommHopfAlgCat.centerDefiningIdeal_baseChange_eq_augmentation_iff`: a field extension
+  preserves and reflects triviality of the center.
 
 ## References
 
@@ -80,5 +82,18 @@ theorem baseChangeHopfIdeal_centerDefiningIdeal
             (K := K) A (centerDefiningIdeal H) q).mpr hrestrictMem) y hy))
   · exact (centerDefiningIdeal_le_iff _ _).mpr
       (isCentral_baseChangeHopfIdeal (isCentral_centerDefiningIdeal H))
+
+/-- A field extension preserves and reflects triviality of the scheme-theoretic center.
+
+The statement uses the augmentation ideal, which cuts out the identity subgroup. Thus it detects
+the full center scheme, including infinitesimal structure invisible on field-valued points. -/
+theorem centerDefiningIdeal_baseChange_eq_augmentation_iff
+    (H : _root_.CommHopfAlgCat.{v} k) :
+    centerDefiningIdeal (baseChange (K := K) H) =
+        HopfIdeal.augmentation K (baseChange (K := K) H) ↔
+      centerDefiningIdeal H = HopfIdeal.augmentation k H := by
+  rw [← baseChangeHopfIdeal_centerDefiningIdeal,
+    ← baseChangeHopfIdeal_augmentation]
+  exact (baseChangeHopfIdeal_injective (E := K)).eq_iff
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
@@ -182,7 +182,8 @@ theorem baseChangeHopfIdeal_le_iff_of_faithfullyFlat (J J' : HopfIdeal k H) :
     have hcomp : (Algebra.TensorProduct.comm k K H).toRingHom.comp
         Algebra.TensorProduct.includeRight.toRingHom = algebraMap H (H ⊗[k] K) := by
       ext x
-      rfl
+      exact DFunLike.congr_fun
+        (Algebra.TensorProduct.comm_comp_includeRight k K H) x
     have hmap : J.toIdeal.map (algebraMap H (H ⊗[k] K)) ≤
         J'.toIdeal.map (algebraMap H (H ⊗[k] K)) := by
       rw [← hcomp, ← Ideal.map_map, ← Ideal.map_map]
@@ -199,12 +200,6 @@ theorem baseChangeHopfIdeal_injective :
   fun J J' hJJ' ↦ le_antisymm
     ((baseChangeHopfIdeal_le_iff_of_faithfullyFlat J J').mp hJJ'.le)
     ((baseChangeHopfIdeal_le_iff_of_faithfullyFlat J' J).mp hJJ'.ge)
-
-/-- Faithfully flat base change preserves and reflects equality of Hopf ideals. -/
-@[simp]
-theorem baseChangeHopfIdeal_inj (J J' : HopfIdeal k H) :
-    baseChangeHopfIdeal (K := K) J = baseChangeHopfIdeal (K := K) J' ↔ J = J' :=
-  baseChangeHopfIdeal_injective.eq_iff
 
 end FaithfullyFlat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.RingTheory.Flat.FaithfullyFlat.Algebra
 public import TauCeti.Algebra.AlgebraicGroup.BaseChange.CentralPoint
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.CommonKernel
@@ -41,6 +42,10 @@ along `h ↦ 1 ⊗ h`.
   morphism that kills `J` gives a morphism that kills `J_K`.
 * `TauCeti.CommHopfAlgCat.baseChangeHopfIdeal_augmentation`: base change preserves the
   augmentation ideal, so the identity section base-changes to the identity section.
+* `TauCeti.CommHopfAlgCat.baseChangeHopfIdeal_le_iff_of_faithfullyFlat`: faithfully flat base
+  change reflects containment of Hopf ideals.
+* `TauCeti.CommHopfAlgCat.baseChangeHopfIdeal_injective`: faithfully flat base change reflects
+  equality of Hopf ideals.
 * `TauCeti.CommHopfAlgCat.baseChangeHopfIdeal_commonKernelHopfIdeal_le`: the subgroup generated
   by a base-changed family sits inside the base change of the subgroup it generates.
 * `TauCeti.CommHopfAlgCat.quotientBaseChangeIso`: the identification
@@ -159,20 +164,49 @@ theorem baseChangeHopfIdeal_le_iff (halg : Function.Injective (algebraMap k K))
     exact HopfIdeal.mem_toIdeal.mp ((mkQuotient_eq_zero_iff H J' x).mp hzero)
   · exact baseChangeHopfIdeal_mono
 
-section FieldExtension
+section FaithfullyFlat
 
-variable {F : Type u} {E : Type w} [Field F] [Field E] [Algebra F E]
-variable {A : _root_.CommHopfAlgCat.{v} F}
+variable [Module.FaithfullyFlat k K]
 
-/-- Extension of the ground field reflects equality of Hopf ideals. -/
+/-- Faithfully flat base change preserves and reflects containment of Hopf ideals.
+
+Contravariantly, one closed subgroup scheme is contained in another exactly when the same is true
+after base change. -/
+@[simp]
+theorem baseChangeHopfIdeal_le_iff_of_faithfullyFlat (J J' : HopfIdeal k H) :
+    baseChangeHopfIdeal (K := K) J ≤ baseChangeHopfIdeal (K := K) J' ↔ J ≤ J' := by
+  rw [← HopfIdeal.toIdeal_le_toIdeal, baseChangeHopfIdeal_toIdeal,
+    baseChangeHopfIdeal_toIdeal]
+  constructor
+  · intro hJJ'
+    have hcomp : (Algebra.TensorProduct.comm k K H).toRingHom.comp
+        Algebra.TensorProduct.includeRight.toRingHom = algebraMap H (H ⊗[k] K) := by
+      ext x
+      rfl
+    have hmap : J.toIdeal.map (algebraMap H (H ⊗[k] K)) ≤
+        J'.toIdeal.map (algebraMap H (H ⊗[k] K)) := by
+      rw [← hcomp, ← Ideal.map_map, ← Ideal.map_map]
+      exact Ideal.map_mono hJJ'
+    exact Ideal.le_comap_map.trans <|
+      (Ideal.comap_mono hmap).trans_eq
+        (Ideal.comap_map_eq_self_of_faithfullyFlat J'.toIdeal)
+  · exact Ideal.map_mono
+
+/-- Faithfully flat base change reflects equality of Hopf ideals. -/
 theorem baseChangeHopfIdeal_injective :
     Function.Injective
-      (baseChangeHopfIdeal (K := E) : HopfIdeal F A → HopfIdeal E (baseChange (K := E) A)) :=
+      (baseChangeHopfIdeal (K := K) : HopfIdeal k H → HopfIdeal K (baseChange (K := K) H)) :=
   fun J J' hJJ' ↦ le_antisymm
-    ((baseChangeHopfIdeal_le_iff (algebraMap F E).injective).mp hJJ'.le)
-    ((baseChangeHopfIdeal_le_iff (algebraMap F E).injective).mp hJJ'.ge)
+    ((baseChangeHopfIdeal_le_iff_of_faithfullyFlat J J').mp hJJ'.le)
+    ((baseChangeHopfIdeal_le_iff_of_faithfullyFlat J' J).mp hJJ'.ge)
 
-end FieldExtension
+/-- Faithfully flat base change preserves and reflects equality of Hopf ideals. -/
+@[simp]
+theorem baseChangeHopfIdeal_inj (J J' : HopfIdeal k H) :
+    baseChangeHopfIdeal (K := K) J = baseChangeHopfIdeal (K := K) J' ↔ J = J' :=
+  baseChangeHopfIdeal_injective.eq_iff
+
+end FaithfullyFlat
 
 /-- If a Hopf ideal is killed by a morphism, its base change is killed by the base change of that
 morphism. This is the ideal-theoretic form of compatibility between closed subgroup

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
@@ -159,6 +159,21 @@ theorem baseChangeHopfIdeal_le_iff (halg : Function.Injective (algebraMap k K))
     exact HopfIdeal.mem_toIdeal.mp ((mkQuotient_eq_zero_iff H J' x).mp hzero)
   · exact baseChangeHopfIdeal_mono
 
+section FieldExtension
+
+variable {F : Type u} {E : Type w} [Field F] [Field E] [Algebra F E]
+variable {A : _root_.CommHopfAlgCat.{v} F}
+
+/-- Extension of the ground field reflects equality of Hopf ideals. -/
+theorem baseChangeHopfIdeal_injective :
+    Function.Injective
+      (baseChangeHopfIdeal (K := E) : HopfIdeal F A → HopfIdeal E (baseChange (K := E) A)) :=
+  fun J J' hJJ' ↦ le_antisymm
+    ((baseChangeHopfIdeal_le_iff (algebraMap F E).injective).mp hJJ'.le)
+    ((baseChangeHopfIdeal_le_iff (algebraMap F E).injective).mp hJJ'.ge)
+
+end FieldExtension
+
 /-- If a Hopf ideal is killed by a morphism, its base change is killed by the base change of that
 morphism. This is the ideal-theoretic form of compatibility between closed subgroup
 factorizations and base change. -/


### PR DESCRIPTION
This PR proves that extension of the ground field preserves and reflects containment and equality of Hopf ideals, uses this to characterize triviality of the full scheme-theoretic center after base change, and packages the resulting equivalence for adjoint semisimple affine groups. It advances the ReductiveGroups Layer 6 milestone “Reductive and semisimple groups,” specifically the target to develop the centre, central isogenies, and simply connected and adjoint forms.

The reflection proof consumes Mathlib’s `Module.Flat.tensorProduct_mk_injective`; no Mathlib implementation is vendored. Detecting the center through its defining Hopf ideal and the augmentation ideal includes infinitesimal center structure that field-valued points alone would miss.

After this PR, the Layer 6 path still needs preservation of semisimplicity under field extension, construction and representability of the adjoint quotient, and comparison of adjoint forms and their root data over an algebraic closure.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"center-triviality-base-change"}-->

🤖 Prepared with Codex
