### PR TITLE
doc: give contributors the Tau Ceti olean cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,21 @@ the live documentation describes.
 ## Building
 
 ```bash
-lake exe cache get   # fetch prebuilt Mathlib oleans
+lake exe cache get                 # Mathlib's oleans
+bash scripts/lake-cache-get.sh .   # Tau Ceti's own oleans
 lake build
 ```
+
+Both fetches matter, and they come from different places. `lake exe cache get` is Mathlib's own
+cache and covers only Mathlib. Tau Ceti's oleans live in a separate public cache that
+`scripts/lake-cache-get.sh` reads, anonymously and with no setup; without that second line
+`lake build` compiles the whole library from source, which takes hours. A miss is never fatal: the
+script discards a partial fetch and leaves you exactly where a from-scratch build would.
+
+The cache stores each revision's outputs under the toolchain that built them, and the script looks
+back through ancestors of your checkout to find the nearest published one. So expect a full rebuild
+right after a `lean-toolchain` bump, when no ancestor has been published under the new toolchain
+yet, and expect a hit at other times.
 
 ## Roadmaps
 

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -80,6 +80,27 @@ Lake service names: `tauceti-public` for reads, `tauceti-r2` for uploads. Object
 `artifacts/TauCetiProject/TauCeti/<hash>.art`, so the endpoint variables hold only the prefix and
 Lake appends the scope.
 
+## Contributors
+
+The read endpoints above are anonymous and are not secrets, so `scripts/lake-cache-get.sh` defaults
+to them and a contributor needs no configuration:
+
+```bash
+bash scripts/lake-cache-get.sh .
+```
+
+This is the second half of a working local build and the README documents it as such. Skipping it
+does not fail anything; it compiles the whole library from source instead, which is why its absence
+went unnoticed for as long as it did. CI keeps passing the endpoints explicitly from the
+`LAKE_CACHE_*_PUBLIC` repo variables and reaches the script only when those are set, so the defaults
+never decide what CI does.
+
+Anything else reading this cache, including the worker exemplar in
+[`kim-em/TauCetiWorker`](https://github.com/kim-em/TauCetiWorker), must use the custom domain rather
+than the bucket's `pub-<id>.r2.dev` development URL. Public access on that development URL is off and
+it answers 401 for every path, which a caller whose cache miss is non-fatal cannot tell from a cold
+revision.
+
 ## Why the upload is its own job
 
 `ci.yml` publishes in two jobs. `build` compiles main and *stages* the artifacts; the separate

--- a/scripts/lake-cache-get.sh
+++ b/scripts/lake-cache-get.sh
@@ -6,7 +6,11 @@
 # Usage: bash scripts/lake-cache-get.sh <project-dir>
 #
 # Reads PUBLIC_ARTIFACT_ENDPOINT / PUBLIC_REVISION_ENDPOINT from the environment (the
-# LAKE_CACHE_*_PUBLIC repo variables). Expects LAKE_CACHE_DIR to be <project-dir>/.lake/cache.
+# LAKE_CACHE_*_PUBLIC repo variables), defaulting to the public cache both this project's CI and
+# its contributors read. The defaults exist so a contributor can run this from a checkout with no
+# setup: the endpoints are public, anonymous and not secret. CI still passes them explicitly, and
+# reaches this script only when those repo variables are set, so the defaults never decide what CI
+# does. Expects LAKE_CACHE_DIR to be <project-dir>/.lake/cache.
 # On an unclean outcome it discards the cache and appends the LAKE_* disable lines to
 # $GITHUB_ENV, so the caller's build proceeds exactly as if the cache were switched off.
 #
@@ -35,8 +39,8 @@
 set -euo pipefail
 
 PROJECT_DIR="${1:?usage: lake-cache-get.sh <project-dir>}"
-: "${PUBLIC_ARTIFACT_ENDPOINT:?PUBLIC_ARTIFACT_ENDPOINT is required}"
-: "${PUBLIC_REVISION_ENDPOINT:?PUBLIC_REVISION_ENDPOINT is required}"
+PUBLIC_ARTIFACT_ENDPOINT="${PUBLIC_ARTIFACT_ENDPOINT:-https://cache.taucetiproject.org/artifacts}"
+PUBLIC_REVISION_ENDPOINT="${PUBLIC_REVISION_ENDPOINT:-https://cache.taucetiproject.org/revisions}"
 LAKE_CACHE_MAX_REVS="${LAKE_CACHE_MAX_REVS:-100}"
 case "$LAKE_CACHE_MAX_REVS" in
   ''|*[!0-9]*) echo "::error::LAKE_CACHE_MAX_REVS must be a natural number"; exit 1 ;;


### PR DESCRIPTION
This PR documents the second half of a local build and lets it run with no configuration. `lake exe cache get` fetches Mathlib's oleans only; Tau Ceti's own oleans live in a separate public cache that `scripts/lake-cache-get.sh` reads. Nothing pointed a contributor at it. The README's build instructions were `lake exe cache get` followed by `lake build`, so every local build compiled all 4,208 modules from source while the cache that would have prevented it was read by CI alone.

`scripts/lake-cache-get.sh` was already factored out of `pr-build.yml` so more than one caller could use it, already takes a project dir, and already degrades outside Actions (`${GITHUB_ENV:-/dev/null}`, `${RUNNER_TEMP:-/tmp}`). It only ever needed the two endpoints and a mention. Those endpoints are anonymous and are not secrets, so they become the script's defaults:

```bash
lake exe cache get                 # Mathlib's oleans
bash scripts/lake-cache-get.sh .   # Tau Ceti's own oleans
lake build
```

CI is unaffected. Every workflow reaches the script only when `TAUCETI_CACHE_ENABLED` is set, which requires both `LAKE_CACHE_*_PUBLIC` repo variables to be non-empty, and each still passes them explicitly. The defaults decide nothing there.

`docs/cache-infrastructure.md` gains a section for readers outside CI, including the note that the custom domain is the one to use: the bucket's `pub-<id>.r2.dev` development URL has public access switched off and answers 401 for every path, which a caller whose cache miss is non-fatal cannot distinguish from a cold revision.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)