### PR TITLE
feat: make E7 minuscule points functorial

### DIFF
--- a/TauCeti/Algebra/Lie/E7/Minuscule/PointsFunctor.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/PointsFunctor.lean
@@ -1,0 +1,275 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+public import TauCeti.Algebra.Lie.E7.Minuscule.Carrier
+
+/-!
+# The points of the type-E7 minuscule carrier, functorially
+
+`TauCeti.E7Minuscule.groupScheme` is the explicit full-weight type-`E₇` carrier over `ℤ`, built
+from the `56`-dimensional minuscule representation, and `TauCeti.E7Minuscule.points A` realizes its
+`A`-valued points as a subgroup of `GL₅₆(A)`. This file supplies the homomorphism induced by an
+arbitrary homomorphism of value rings and assembles these point groups into a functor on
+commutative `ℤ`-algebras.
+
+The induced map is entrywise and preserves the two pinned families:
+
+```text
+f (x_k(u)) = x_k(f(u)),        f (t(s)) = t(f ∘ s).
+```
+
+The quotient of the ambient general-linear coordinate Hopf algebra by the minuscule carrier's
+defining ideal represents this functor. Nothing here asserts reductivity, maximality of the
+weight torus, or an identification of the carrier's root datum.
+
+## Main declarations
+
+* `TauCeti.E7Minuscule.pointsMap`: the map on carrier points induced by a ring homomorphism.
+* `TauCeti.E7Minuscule.pointsFunctor`: the group-valued functor of points.
+* `TauCeti.E7Minuscule.pointsMulEquiv`: the pointwise representing isomorphism.
+* `TauCeti.E7Minuscule.pointsFunctorNatIso`: the natural representing isomorphism.
+
+## References
+
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*,
+  Sections 1.15 and 1.17.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1--2.
+
+The interface specializes the carrier-independent functor in
+`TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor`, and follows the formal
+template of `TauCeti.Algebra.Lie.E6.Minuscule.PointsFunctor`, added in
+[TauCetiProject/TauCeti#5265](https://github.com/TauCetiProject/TauCeti/pull/5265), which does the
+same for the `27`-dimensional type-`E₆` carrier, as the analogous full-weight type-`A` and
+type-`C` carrier interfaces do for theirs.
+
+## Roadmap
+
+This advances the target "points over an algebraically closed field as a group, functorially in
+the field" in Layer 9, "pinned Chevalley--Demazure group schemes over `ℤ`", of
+`TauCetiRoadmap/ReductiveGroups/README.md`. Its consumer is the `E₇(q)` branch of milestone L0 of
+`TauCetiRoadmap/CFSGStatement/README.md`, whose Steinberg map is the `q`-power Frobenius, and the
+Frobenius of a carrier is the endomorphism this functoriality induces from the `q`-power map of
+its value ring.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.E7Minuscule
+
+universe v v'
+
+noncomputable section
+
+section Map
+
+variable {A : Type v} {B : Type v'} [CommRing A] [CommRing B]
+
+/-- The map on the points of the type-`E₇` minuscule carrier induced by a homomorphism of value
+rings. It is the entrywise map on `GL₅₆`, restricted to the subgroup cut out by the carrier's
+defining ideal. -/
+def pointsMap (f : A →+* B) : points A →* points B :=
+  ((MulEquiv.subgroupCongr (points_def B)).symm.toMonoidHom).comp
+    ((GeneralLinear.mapHopfIdealPointsSubgroup 56 definingIdeal f.toIntAlgHom).comp
+      (MulEquiv.subgroupCongr (points_def A)).toMonoidHom)
+
+/-- The induced map on type-`E₇` carrier points is the entrywise map. -/
+@[simp]
+theorem coe_pointsMap (f : A →+* B) (g : points A) :
+    (pointsMap f g : Matrix.GeneralLinearGroup (Fin 56) B) =
+      Matrix.GeneralLinearGroup.map f g := by
+  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
+  rw [pointsMap]
+  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
+    MulEquiv.subgroupCongr_apply, hring]
+
+/-- Entrywise, the induced map applies the homomorphism of value rings to each matrix entry. -/
+theorem coe_pointsMap_apply (f : A →+* B) (g : points A) (i j : Fin 56) :
+    ((pointsMap f g : Matrix.GeneralLinearGroup (Fin 56) B) :
+        Matrix (Fin 56) (Fin 56) B) i j =
+      f (((g : Matrix.GeneralLinearGroup (Fin 56) A) : Matrix (Fin 56) (Fin 56) A) i j) := by
+  rw [coe_pointsMap, Matrix.GeneralLinearGroup.map_apply]
+
+/-- The identity homomorphism induces the identity on type-`E₇` carrier points. -/
+@[simp]
+theorem pointsMap_id : pointsMap (RingHom.id A) = MonoidHom.id _ := by
+  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A := AlgHom.ext fun _ ↦ rfl
+  rw [pointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  apply MonoidHom.ext
+  intro g
+  exact (MulEquiv.subgroupCongr (points_def A)).symm_apply_apply g
+
+/-- The induced maps on type-`E₇` carrier points compose. -/
+@[simp]
+theorem pointsMap_comp {C : Type*} [CommRing C] (f : A →+* B) (g : B →+* C) :
+    pointsMap (g.comp f) = (pointsMap g).comp (pointsMap f) := by
+  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
+    AlgHom.ext fun _ ↦ rfl
+  apply MonoidHom.ext
+  intro x
+  simp only [pointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+
+/-- An injective homomorphism of value rings induces an injective map on type-`E₇` carrier
+points. -/
+theorem pointsMap_injective {f : A →+* B} (hf : Function.Injective f) :
+    Function.Injective (pointsMap f) := by
+  rw [pointsMap]
+  exact (MulEquiv.subgroupCongr (points_def B)).symm.injective.comp
+    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective 56 definingIdeal hf).comp
+      (MulEquiv.subgroupCongr (points_def A)).injective)
+
+/-- The induced map carries a numbered root-subgroup parameter along the homomorphism of value
+rings. -/
+@[simp]
+theorem pointsMap_rootSubgroupPoints (f : A →+* B) (k : Fin 7 ⊕ Fin 7)
+    (u : Multiplicative A) :
+    pointsMap f (rootSubgroupPoints k A u) =
+      rootSubgroupPoints k B (Multiplicative.ofAdd (f (Multiplicative.toAdd u))) := by
+  apply Subtype.ext
+  rw [coe_pointsMap, coe_rootSubgroupPoints, coe_rootSubgroupPoints,
+    UniversalEnvelopingAlgebra.map_kostantRootSubgroupMatrix,
+    AdditiveGroup.mapValue_gaPointsMulEquiv_symm_apply, RingHom.toIntAlgHom_apply]
+
+/-- The induced map carries a point of the pinned split weight torus coordinatewise along the
+homomorphism of value rings. -/
+@[simp]
+theorem pointsMap_weightTorusPoints (f : A →+* B) (s : Fin 7 → Aˣ) :
+    pointsMap f (weightTorusPoints A s) =
+      weightTorusPoints B fun i ↦ Units.map (f : A →* B) (s i) := by
+  apply Subtype.ext
+  rw [coe_pointsMap, coe_weightTorusPoints, coe_weightTorusPoints]
+  exact UniversalEnvelopingAlgebra.map_kostantTorusMatrix
+    (M := lattice.toAddSubgroup) (b := latticeBasis)
+      (wt := DynkinType.e7MinusculeWeight) f s
+
+end Map
+
+/-! ## The functor of points -/
+
+/-- The group-valued functor of points of the type-`E₇` minuscule carrier. -/
+def pointsFunctor : CommAlgCat.{v} ℤ ⥤ GrpCat.{v} where
+  obj A := GrpCat.of (points A)
+  map f := GrpCat.ofHom (pointsMap f.hom.toRingHom)
+  map_id _A := congrArg GrpCat.ofHom pointsMap_id
+  map_comp f g := congrArg GrpCat.ofHom
+    (pointsMap_comp f.hom.toRingHom g.hom.toRingHom)
+
+/-- The object part of the type-`E₇` carrier's points functor is its named point group. -/
+@[simp]
+theorem pointsFunctor_obj (A : CommAlgCat.{v} ℤ) :
+    pointsFunctor.obj A = GrpCat.of (points A) :=
+  (rfl)
+
+/-- The morphism part of the type-`E₇` carrier's points functor is the induced entrywise map. -/
+@[simp]
+theorem pointsFunctor_map {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B) :
+    pointsFunctor.map f =
+      eqToHom (pointsFunctor_obj A) ≫ GrpCat.ofHom (pointsMap f.hom.toRingHom) ≫
+        eqToHom (pointsFunctor_obj B).symm :=
+  (rfl)
+
+/-- At a bundled `ℤ`-algebra, the named carrier points are the ambient general-linear subgroup
+cut out by the defining ideal. -/
+private theorem points_eq_hopfIdealPointsSubgroup (A : CommAlgCat.{v} ℤ) :
+    points A = GeneralLinear.hopfIdealPointsSubgroup 56 definingIdeal A := by
+  rw [points_def A]
+  congr 1
+  exact Subsingleton.elim _ _
+
+/-- The points of the quotient coordinate Hopf algebra are the named type-`E₇` carrier points. -/
+def pointsMulEquiv (A : CommAlgCat.{v} ℤ) :
+    HopfAlgebra.points
+        (R := ℤ) (H := CommHopfAlgCat.quotient
+          (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal) A ≃*
+      points A :=
+  (GeneralLinear.hopfIdealPointsSubgroupMulEquiv 56 definingIdeal A).trans
+    (MulEquiv.subgroupCongr (points_eq_hopfIdealPointsSubgroup A)).symm
+
+/-- A quotient point, read through `pointsMulEquiv`, is its ambient point viewed as an invertible
+matrix. -/
+@[simp]
+theorem coe_pointsMulEquiv_apply (A : CommAlgCat.{v} ℤ)
+    (q : HopfAlgebra.points
+      (R := ℤ) (H := CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal) A) :
+    (pointsMulEquiv A q : Matrix.GeneralLinearGroup (Fin 56) A) =
+      GeneralLinear.pointsMulEquiv 56
+        (CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal A q) := by
+  simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]
+  exact GeneralLinear.coe_hopfIdealPointsSubgroupMulEquiv_apply 56 definingIdeal A q
+
+/-- Including the ambient Hopf-algebra point underlying the inverse of `pointsMulEquiv` recovers
+the point corresponding to the underlying matrix. -/
+@[simp]
+theorem quotientPointsHom_pointsMulEquiv_symm (A : CommAlgCat.{v} ℤ) (g : points A) :
+    CommHopfAlgCat.quotientPointsHom
+        (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal A
+        ((pointsMulEquiv A).symm g) =
+      (GeneralLinear.pointsMulEquiv (R := ℤ) 56).symm
+        (g : Matrix.GeneralLinearGroup (Fin 56) A) := by
+  simp only [pointsMulEquiv, MulEquiv.symm_trans_apply, MulEquiv.symm_symm]
+  rw [GeneralLinear.quotientPointsHom_hopfIdealPointsSubgroupMulEquiv_symm,
+    MulEquiv.subgroupCongr_apply]
+
+/-- The pointwise identification with quotient Hopf-algebra points is natural in the value
+algebra. -/
+@[simp]
+theorem pointsMulEquiv_mapPoints {A B : CommAlgCat.{v} ℤ} (f : A ⟶ B)
+    (q : HopfAlgebra.points
+      (R := ℤ) (H := CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal) A) :
+    pointsMulEquiv B
+        (HopfAlgebra.mapPoints
+          (H := CommHopfAlgCat.quotient
+            (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal) f q) =
+      pointsMap f.hom.toRingHom (pointsMulEquiv A q) := by
+  apply Subtype.ext
+  rw [coe_pointsMap]
+  simp only [pointsMulEquiv, MulEquiv.trans_apply, MulEquiv.subgroupCongr_symm_apply]
+  exact (congrArg Subtype.val
+      (GeneralLinear.hopfIdealPointsSubgroupMulEquiv_mapPoints 56 definingIdeal f q)).trans
+    (GeneralLinear.coe_mapHopfIdealPointsSubgroup 56 definingIdeal f.hom _)
+
+/-- The quotient coordinate Hopf algebra represents the points functor of the type-`E₇`
+minuscule carrier. -/
+def pointsFunctorNatIso :
+    HopfAlgebra.pointsFunctor
+        (R := ℤ) (H := CommHopfAlgCat.quotient
+          (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal) ≅
+      pointsFunctor :=
+  NatIso.ofComponents (fun A ↦ (pointsMulEquiv A).toGrpIso)
+    (by
+      intro A B f
+      ext q
+      exact pointsMulEquiv_mapPoints f q)
+
+/-- The forward component of the representing natural isomorphism is the pointwise
+identification. -/
+@[simp]
+theorem pointsFunctorNatIso_hom_app_apply (A : CommAlgCat.{v} ℤ)
+    (q : HopfAlgebra.points
+      (R := ℤ) (H := CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal) A) :
+    eqToHom (pointsFunctor_obj A) (pointsFunctorNatIso.hom.app A q) = pointsMulEquiv A q :=
+  (rfl)
+
+/-- The inverse component of the representing natural isomorphism is the inverse pointwise
+identification. -/
+@[simp]
+theorem pointsFunctorNatIso_inv_app_apply (A : CommAlgCat.{v} ℤ) (g : points A) :
+    pointsFunctorNatIso.inv.app A (eqToHom (pointsFunctor_obj A).symm g) =
+      (pointsMulEquiv A).symm g :=
+  (rfl)
+
+end
+
+end TauCeti.E7Minuscule


### PR DESCRIPTION
This PR makes the explicit full-weight type-`E₇` minuscule carrier's matrix-valued points functorial in the value ring. Define the entrywise point map induced by every homomorphism of commutative rings, prove its identity, composition and injectivity laws, show that it carries the fourteen numbered simple-root subgroups and the rank-seven split weight torus coordinatewise, and package the point groups as a group-valued functor on commutative `ℤ`-algebras that the carrier's quotient coordinate Hopf algebra naturally represents.

The exact roadmap target is Layer 9, "Points over an algebraically closed field as a group, functorially in the field, so that a field endomorphism induces a group endomorphism of the points", within the milestone "pinned Chevalley--Demazure group schemes over `ℤ`" in `TauCetiRoadmap/ReductiveGroups/README.md`. This is the most effective current step because the explicit `56`-dimensional type-`E₇` carrier landed in https://github.com/TauCetiProject/TauCeti/pull/5260 with points but no value-ring map, and `E₇` is the one Lie-type family whose Layer 9 lane no open pull request is advancing, while the type-`A`, type-`C`, type-`D`, Geck and both type-`E₆` carriers already have this interface.

Consumer roadmap: CFSGStatement

Dependency edge: milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md`, "pinned ambient groups: root datum, pinning, points, root subgroups", consumes the `E₇` carrier's algebraic-closure-valued point group as `ValidLieTypeIndex.AmbientGroup` on the `E₇(q)` branch, and milestone L1 consumes its functoriality under the `q`-power field endomorphism: L1's table assigns the untwisted family `E₇` the Steinberg map `Frob_q`, and the Frobenius of a carrier is exactly the endomorphism this functoriality induces from the `q`-power map of the value ring. After this PR the type-`E₇` Layer 9 lane still needs that `q`-power Frobenius specialization and base change to a prime field, then nonsimple-root subgroup maps with the Chevalley relations, and reductivity together with the identification of the carrier with the pinned simply connected `E₇` root datum, before CFSGStatement L0 can assemble the branch.

Add `TauCeti/Algebra/Lie/E7/Minuscule/PointsFunctor.lean` (275 lines); no existing file changes. Reuse the carrier-independent `GeneralLinear.mapHopfIdealPointsSubgroup` with its functorial laws and quotient-point equivalence, and the generic Kostant root-subgroup and torus matrix naturality lemmas `UniversalEnvelopingAlgebra.map_kostantRootSubgroupMatrix` and `map_kostantTorusMatrix`; no Mathlib or other implementation is vendored. Nothing here asserts reductivity, maximality of the weight torus, or an identification of the carrier's root datum. The mathematical interface follows Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §§1.15 and 1.17, and Jantzen, *Representations of Algebraic Groups*, II.1--2, and the formal organization follows the parallel type-`E₆` minuscule points functor of https://github.com/TauCetiProject/TauCeti/pull/5265, with both credits recorded in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e7-minuscule-points-functor"}-->

🤖 Prepared with Claude Code
