### PR TITLE
refactor(LinearAlgebra): finish the general-linear-group dot-notation migration

### DIFF
--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
@@ -53,13 +53,13 @@ theorem exists_common_fixed_vector_of_pairwise_commute_of_isUnipotent
     (hcomm hij).units_val
   have htri (i : ι) : ⨆ μ, (fEnd i).maxGenEigenspace μ = ⊤ := by
     apply top_unique
-    rw [← TauCeti.GeneralLinearGroup.IsUnipotent.maxGenEigenspace_one_eq_top (hunipotent i)]
+    rw [← (hunipotent i).maxGenEigenspace_one_eq_top]
     exact le_iSup (fun μ ↦ (fEnd i).maxGenEigenspace μ) 1
   obtain ⟨χ, v, hv, heigen⟩ :=
     exists_jointEigenvector_of_pairwise_commute fEnd hcommEnd htri
   refine ⟨v, hv, fun i ↦ ?_⟩
   have hχ : χ i = 1 :=
-    TauCeti.GeneralLinearGroup.IsUnipotent.eigenvalue_eq_one (hunipotent i) hv
+    (hunipotent i).eigenvalue_eq_one hv
       (Module.End.mem_eigenspace_iff.mp (heigen i))
   simpa [fEnd, hχ] using Module.End.mem_eigenspace_iff.mp (heigen i)
 

--- a/TauCeti/LinearAlgebra/Eigenspace/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Unipotent.lean
@@ -16,9 +16,9 @@ no eigenvalues other than one.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.IsUnipotent.maxGenEigenspace_one_eq_top`: the maximal generalized
+* `LinearMap.GeneralLinearGroup.IsUnipotent.maxGenEigenspace_one_eq_top`: the maximal generalized
   `1`-eigenspace of a unipotent automorphism is the whole space.
-* `TauCeti.GeneralLinearGroup.IsUnipotent.eigenvalue_eq_one`: every eigenvalue of a unipotent
+* `LinearMap.GeneralLinearGroup.IsUnipotent.eigenvalue_eq_one`: every eigenvalue of a unipotent
   automorphism is one.
 
 ## References
@@ -28,15 +28,13 @@ no eigenvalues other than one.
 
 public section
 
-namespace TauCeti
-
 open LinearMap
 
 universe u v
 
 noncomputable section
 
-namespace GeneralLinearGroup
+namespace LinearMap.GeneralLinearGroup
 
 variable {K : Type u} {V : Type v}
 
@@ -83,8 +81,7 @@ theorem IsUnipotent.eigenvalue_eq_one {g : GeneralLinearGroup K V}
 
 end IsDomain
 
-end GeneralLinearGroup
+end LinearMap.GeneralLinearGroup
 
 end
 
-end TauCeti


### PR DESCRIPTION
The general-linear-group namespace migration left exactly two declarations behind. `IsUnipotent` moved to `LinearMap.GeneralLinearGroup`, but its two eigenspace consequences stayed under `TauCeti.GeneralLinearGroup`:

- `IsUnipotent.maxGenEigenspace_one_eq_top`
- `IsUnipotent.eigenvalue_eq_one`

Because the predicate and the theorems disagreed on namespace, dot-notation could not reach them: both consumers in `Eigenspace/JointEigenvector/Unipotent.lean` had to spell the full old path.

This moves the two theorems to `LinearMap.GeneralLinearGroup`, matching every migrated sibling (`GeneralLinearGroup/Unipotent.lean`, `JordanChevalley/TensorProduct.lean`, `JordanChevalley/Prod.lean`), and rewrites both call sites as `(hunipotent i).maxGenEigenspace_one_eq_top` and `(hunipotent i).eigenvalue_eq_one hv`. The module docstring's two references follow. **No aliases, no deprecation shims.** `grep -rn "TauCeti.GeneralLinearGroup" TauCeti/` now returns nothing.

Net −3 lines. Tracked by #3547.

## Roadmap

Roadmap: ReductiveGroups

A namespace-hygiene fix to existing code; no roadmap target is claimed.

🤖 Directed by Cameron Freer, drafted by Fable 5.1
