### PR TITLE
feat: generate symplectic roots in all characteristics

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
@@ -26,13 +26,13 @@ n_{i,j} = x_{eᵢ-eⱼ}(1) x_{eⱼ-eᵢ}(-1) x_{eᵢ-eⱼ}(1)
 represents the Weyl reflection exchanging `i` and `j`, so conjugation by it carries
 `x_{±2eⱼ}(c)` to `x_{±2eᵢ}(c)`. The sum roots are then isolated from the multiply-laced
 Chevalley commutator relations. In particular, the numbered adjacent difference roots and the
-final long root generate every root subgroup in all characteristics, including characteristic
-two.
+final pair of opposite long roots generate every root subgroup in all characteristics, including
+characteristic two.
 
 ## Main results
 
 * `TauCeti.GLSymplecticFin.positiveLongRootTransvectionUnit_mem_of_difference_of_long` and its
-  negative analogue propagate one long-root subgroup to every index by Weyl conjugation.
+  negative analogue transport one long-root subgroup to a target index by Weyl conjugation.
 * `TauCeti.GLSymplecticFin.positiveSumShortRootUnit_mem_of_difference_of_long` and its negative
   analogue generate the two sum-root families.
 * `TauCeti.GLSymplecticFin.RootSubgroupIndex.hom_apply_mem_of_difference_of_long` packages the
@@ -63,38 +63,40 @@ universe u
 
 variable {R : Type u} [CommRing R] {m : ℕ} {i j : Fin m}
 
-/-- If a subgroup contains every difference-root element and the positive long-root subgroup at
-`r`, then it contains every positive long-root element. -/
+/-- If a subgroup contains the two difference-root elements forming the Weyl word from `r` to `i`
+and the positive long-root subgroup at `r`, then it contains the positive long-root subgroup at
+`i`. -/
 theorem positiveLongRootTransvectionUnit_mem_of_difference_of_long
-    (H : Subgroup (GLSymplecticFin m R)) (r : Fin m)
-    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
-      differenceShortRootUnit hij c ∈ H)
+    (H : Subgroup (GLSymplecticFin m R)) (r i : Fin m)
+    (hforward : ∀ hir : i ≠ r, differenceShortRootUnit hir 1 ∈ H)
+    (hbackward : ∀ hir : i ≠ r, differenceShortRootUnit hir.symm (-1) ∈ H)
     (hpivot : ∀ c : R, positiveLongRootTransvectionUnit r c ∈ H)
-    (i : Fin m) (c : R) : positiveLongRootTransvectionUnit i c ∈ H := by
+    (c : R) : positiveLongRootTransvectionUnit i c ∈ H := by
   by_cases hir : i = r
   · subst i
     exact hpivot c
   · let w := differenceShortRootWeylElement (R := R) hir
     have hw : w ∈ H := differenceShortRootWeylElement_mem H hir
-      (hdifference hir) (hdifference (Ne.symm hir))
+      (hforward hir) (hbackward hir)
     have hconj := H.mul_mem (H.mul_mem hw (hpivot c)) (H.inv_mem hw)
     simpa only [w, differenceShortRootWeylElement_inv,
       differenceShortRootWeylElement_mul_positiveLongRootTransvectionUnit_mul_inv] using hconj
 
-/-- If a subgroup contains every difference-root element and the negative long-root subgroup at
-`r`, then it contains every negative long-root element. -/
+/-- If a subgroup contains the two difference-root elements forming the Weyl word from `r` to `i`
+and the negative long-root subgroup at `r`, then it contains the negative long-root subgroup at
+`i`. -/
 theorem negativeLongRootTransvectionUnit_mem_of_difference_of_long
-    (H : Subgroup (GLSymplecticFin m R)) (r : Fin m)
-    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
-      differenceShortRootUnit hij c ∈ H)
+    (H : Subgroup (GLSymplecticFin m R)) (r i : Fin m)
+    (hforward : ∀ hir : i ≠ r, differenceShortRootUnit hir 1 ∈ H)
+    (hbackward : ∀ hir : i ≠ r, differenceShortRootUnit hir.symm (-1) ∈ H)
     (hpivot : ∀ c : R, negativeLongRootTransvectionUnit r c ∈ H)
-    (i : Fin m) (c : R) : negativeLongRootTransvectionUnit i c ∈ H := by
+    (c : R) : negativeLongRootTransvectionUnit i c ∈ H := by
   by_cases hir : i = r
   · subst i
     exact hpivot c
   · let w := differenceShortRootWeylElement (R := R) hir
     have hw : w ∈ H := differenceShortRootWeylElement_mem H hir
-      (hdifference hir) (hdifference (Ne.symm hir))
+      (hforward hir) (hbackward hir)
     have hconj := H.mul_mem (H.mul_mem hw (hpivot c)) (H.inv_mem hw)
     simpa only [w, differenceShortRootWeylElement_inv,
       differenceShortRootWeylElement_mul_negativeLongRootTransvectionUnit_mul_inv] using hconj
@@ -141,10 +143,10 @@ theorem hom_apply_mem_of_difference_of_long
     (root : RootSubgroupIndex m) (c : Multiplicative R) : root.hom c ∈ H := by
   have hp (i : Fin m) (a : R) : positiveLongRootTransvectionUnit i a ∈ H :=
     positiveLongRootTransvectionUnit_mem_of_difference_of_long
-      H r hdifference hpositive i a
+      H r i (fun hir => hdifference hir 1) (fun hir => hdifference hir.symm (-1)) hpositive a
   have hn (i : Fin m) (a : R) : negativeLongRootTransvectionUnit i a ∈ H :=
     negativeLongRootTransvectionUnit_mem_of_difference_of_long
-      H r hdifference hnegative i a
+      H r i (fun hir => hdifference hir 1) (fun hir => hdifference hir.symm (-1)) hnegative a
   cases root with
   | positiveLong i =>
       simpa only [hom_positiveLong, positiveLongRootTransvectionHom_apply] using hp i c.toAdd

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
@@ -6,35 +6,39 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.ChevalleyRelations
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Generation
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Weyl
 
 /-!
 # Generating long and sum roots in the symplectic group
 
 This file develops the root-subgroup generation step for the standard type-`C` symplectic group
-beyond its type-`A` subsystem of difference roots. Over a commutative ring in which `2` is a unit,
-the difference-root subgroups and one pair of opposite long-root subgroups generate every long and
-sum root subgroup.
+beyond its type-`A` subsystem of difference roots. Over an arbitrary commutative ring, the
+difference-root subgroups and one pair of opposite long-root subgroups generate every long and sum
+root subgroup.
 
-The long roots are extracted from the multiply-laced Chevalley relation by comparing the parameters
-`1` and `-1`:
+The difference-root word
 
 ```text
-⁅x_{eᵢ-eⱼ}(1),  x_{2eⱼ}(t)⁆  = x_{eᵢ+eⱼ}(t) x_{2eᵢ}(t),
-⁅x_{eᵢ-eⱼ}(-1), x_{2eⱼ}(-t)⁆ = x_{eᵢ+eⱼ}(t) x_{2eᵢ}(-t).
+n_{i,j} = x_{eᵢ-eⱼ}(1) x_{eⱼ-eᵢ}(-1) x_{eᵢ-eⱼ}(1)
 ```
 
-Their quotient is `x_{2eᵢ}(2t)`, since the displayed sum-root subgroup commutes with the long
-root subgroup. Invertibility of `2` makes this every parameter. The negative roots follow from the
-opposite relation, and the sum roots are then isolated from either commutator formula.
+represents the Weyl reflection exchanging `i` and `j`, so conjugation by it carries
+`x_{±2eⱼ}(c)` to `x_{±2eᵢ}(c)`. The sum roots are then isolated from the multiply-laced
+Chevalley commutator relations. In particular, the numbered adjacent difference roots and the
+final long root generate every root subgroup in all characteristics, including characteristic
+two.
 
 ## Main results
 
 * `TauCeti.GLSymplecticFin.positiveLongRootTransvectionUnit_mem_of_difference_of_long` and its
-  negative analogue propagate one long-root subgroup to every index.
+  negative analogue propagate one long-root subgroup to every index by Weyl conjugation.
 * `TauCeti.GLSymplecticFin.positiveSumShortRootUnit_mem_of_difference_of_long` and its negative
   analogue generate the two sum-root families.
 * `TauCeti.GLSymplecticFin.RootSubgroupIndex.hom_apply_mem_of_difference_of_long` packages the
   result for every standard symplectic root subgroup.
+* `TauCeti.GLSymplecticFin.RootSubgroupIndex.hom_apply_mem_of_adjacent_of_long` reduces the
+  hypotheses further to the positive and negative simple-root families.
 
 ## References
 
@@ -42,11 +46,10 @@ opposite relation, and the sum roots are then isolated from either commutator fo
 * R. Steinberg, *Lectures on Chevalley Groups* (1968), §§3--4.
 
 This advances Layer 9, "The Chevalley--Demazure construction", of
-`TauCetiRoadmap/ReductiveGroups/README.md`: together with generation of all difference roots from
-the numbered adjacent roots, it supplies every root subgroup required for the reverse inclusion of
-the full-weight type-`C` carrier in the standard symplectic group. The restriction that `2` be a
-unit matches the odd-characteristic type-`C` branch of milestone L0 in
-`TauCetiRoadmap/CFSGStatement/README.md`.
+`TauCetiRoadmap/ReductiveGroups/README.md`: it supplies every root subgroup required for the
+reverse inclusion of the full-weight type-`C` carrier in the standard symplectic group. Removing
+the former invertibility-of-two hypothesis is necessary for the characteristic-two type-`C`
+branch consumed by milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md`.
 -/
 
 public section
@@ -60,158 +63,41 @@ universe u
 
 variable {R : Type u} [CommRing R] {m : ℕ} {i j : Fin m}
 
-private theorem commute_positiveSumShortRootUnit_positiveLongRootTransvectionUnit
-    (hij : i ≠ j) (a b : R) :
-  Commute (positiveSumShortRootUnit hij a) (positiveLongRootTransvectionUnit i b) := by
-  have hIL : Commute (transvectionUnit (finSumFinEquiv_inl_ne_inr i j) a)
-      (transvectionUnit (finSumFinEquiv_inl_ne_inr i i) b) :=
-    commute_transvectionUnit (finSumFinEquiv_inl_ne_inr i j)
-      (finSumFinEquiv_inl_ne_inr i i) (finSumFinEquiv_inr_ne_inl j i)
-      (finSumFinEquiv_inr_ne_inl i i) a b
-  have hJL : Commute (transvectionUnit (finSumFinEquiv_inl_ne_inr j i) a)
-      (transvectionUnit (finSumFinEquiv_inl_ne_inr i i) b) :=
-    commute_transvectionUnit (finSumFinEquiv_inl_ne_inr j i)
-      (finSumFinEquiv_inl_ne_inr i i) (finSumFinEquiv_inr_ne_inl i i)
-      (finSumFinEquiv_inr_ne_inl i j) a b
-  have hambient :
-      (positiveSumShortRootUnit hij a : GL (Fin (m + m)) R) *
-          (positiveLongRootTransvectionUnit i b : GL (Fin (m + m)) R) =
-        (positiveLongRootTransvectionUnit i b : GL (Fin (m + m)) R) *
-          (positiveSumShortRootUnit hij a : GL (Fin (m + m)) R) := by
-    rw [coe_positiveSumShortRootUnit, coe_positiveLongRootTransvectionUnit]
-    exact hIL.mul_left hJL
-  exact (GLSymplecticFin m R).subtype_injective hambient
-
-private theorem commute_negativeSumShortRootUnit_negativeLongRootTransvectionUnit
-    (hij : i ≠ j) (a b : R) :
-    Commute (negativeSumShortRootUnit hij a) (negativeLongRootTransvectionUnit j b) := by
-  have hIL : Commute (transvectionUnit (finSumFinEquiv_inr_ne_inl i j) a)
-      (transvectionUnit (finSumFinEquiv_inr_ne_inl j j) b) :=
-    commute_transvectionUnit (finSumFinEquiv_inr_ne_inl i j)
-      (finSumFinEquiv_inr_ne_inl j j) (finSumFinEquiv_inl_ne_inr j j)
-      (finSumFinEquiv_inl_ne_inr j i) a b
-  have hJL : Commute (transvectionUnit (finSumFinEquiv_inr_ne_inl j i) a)
-      (transvectionUnit (finSumFinEquiv_inr_ne_inl j j) b) :=
-    commute_transvectionUnit (finSumFinEquiv_inr_ne_inl j i)
-      (finSumFinEquiv_inr_ne_inl j j) (finSumFinEquiv_inl_ne_inr i j)
-      (finSumFinEquiv_inl_ne_inr j j) a b
-  have hambient :
-      (negativeSumShortRootUnit hij a : GL (Fin (m + m)) R) *
-          (negativeLongRootTransvectionUnit j b : GL (Fin (m + m)) R) =
-        (negativeLongRootTransvectionUnit j b : GL (Fin (m + m)) R) *
-          (negativeSumShortRootUnit hij a : GL (Fin (m + m)) R) := by
-    rw [coe_negativeSumShortRootUnit, coe_negativeLongRootTransvectionUnit]
-    exact hIL.mul_left hJL
-  exact (GLSymplecticFin m R).subtype_injective hambient
-
-/-- If a subgroup contains every difference-root element pointing to `r` and the positive
-long-root subgroup at `r`, then it contains every positive long-root element, provided `2` is
-invertible in the coefficient ring. -/
+/-- If a subgroup contains every difference-root element and the positive long-root subgroup at
+`r`, then it contains every positive long-root element. -/
 theorem positiveLongRootTransvectionUnit_mem_of_difference_of_long
-    (H : Subgroup (GLSymplecticFin m R)) (h2 : IsUnit (2 : R)) (r : Fin m)
-    (hdifference : ∀ {i : Fin m} (hir : i ≠ r) (c : R),
-      differenceShortRootUnit hir c ∈ H)
+    (H : Subgroup (GLSymplecticFin m R)) (r : Fin m)
+    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
+      differenceShortRootUnit hij c ∈ H)
     (hpivot : ∀ c : R, positiveLongRootTransvectionUnit r c ∈ H)
     (i : Fin m) (c : R) : positiveLongRootTransvectionUnit i c ∈ H := by
   by_cases hir : i = r
   · subst i
     exact hpivot c
-  · obtain ⟨u, hu⟩ := h2
-    let t : R := ((u⁻¹ : Rˣ) : R) * c
-    have ht : t + t = c := by
-      dsimp only [t]
-      rw [← two_mul, ← hu]
-      simp
-    have hfirst :
-        positiveSumShortRootUnit hir t * positiveLongRootTransvectionUnit i t ∈ H := by
-      have hmem := H.commutator_le_self
-        (Subgroup.commutator_mem_commutator (hdifference hir 1) (hpivot t))
-      rw [commutatorElement_differenceShortRootUnit_positiveLongRootTransvectionUnit] at hmem
-      simpa using hmem
-    have hsecond :
-        positiveSumShortRootUnit hir t * positiveLongRootTransvectionUnit i (-t) ∈ H := by
-      have hmem := H.commutator_le_self
-        (Subgroup.commutator_mem_commutator (hdifference hir (-1)) (hpivot (-t)))
-      rw [commutatorElement_differenceShortRootUnit_positiveLongRootTransvectionUnit] at hmem
-      simpa using hmem
-    have hquotient := H.mul_mem hfirst (H.inv_mem hsecond)
-    have heq :
-        (positiveSumShortRootUnit hir t * positiveLongRootTransvectionUnit i t) *
-            (positiveSumShortRootUnit hir t *
-              positiveLongRootTransvectionUnit i (-t))⁻¹ =
-          positiveLongRootTransvectionUnit i c := by
-      calc
-        _ = positiveSumShortRootUnit hir t *
-              (positiveLongRootTransvectionUnit i t *
-                positiveLongRootTransvectionUnit i t) *
-              (positiveSumShortRootUnit hir t)⁻¹ := by
-            rw [_root_.mul_inv_rev, positiveLongRootTransvectionUnit_inv, neg_neg]
-            group
-        _ = positiveSumShortRootUnit hir t *
-              positiveLongRootTransvectionUnit i (t + t) *
-              (positiveSumShortRootUnit hir t)⁻¹ := by
-            rw [← positiveLongRootTransvectionUnit_add]
-        _ = positiveLongRootTransvectionUnit i (t + t) := by
-            rw [(commute_positiveSumShortRootUnit_positiveLongRootTransvectionUnit
-              hir t (t + t)).eq]
-            group
-        _ = positiveLongRootTransvectionUnit i c := by rw [ht]
-    rwa [heq] at hquotient
+  · let w := differenceShortRootWeylElement (R := R) hir
+    have hw : w ∈ H := differenceShortRootWeylElement_mem H hir
+      (hdifference hir) (hdifference (Ne.symm hir))
+    have hconj := H.mul_mem (H.mul_mem hw (hpivot c)) (H.inv_mem hw)
+    simpa only [w, differenceShortRootWeylElement_inv,
+      differenceShortRootWeylElement_mul_positiveLongRootTransvectionUnit_mul_inv] using hconj
 
-/-- If a subgroup contains every difference-root element pointing from `r` and the negative
-long-root subgroup at `r`, then it contains every negative long-root element, provided `2` is
-invertible in the coefficient ring. -/
+/-- If a subgroup contains every difference-root element and the negative long-root subgroup at
+`r`, then it contains every negative long-root element. -/
 theorem negativeLongRootTransvectionUnit_mem_of_difference_of_long
-    (H : Subgroup (GLSymplecticFin m R)) (h2 : IsUnit (2 : R)) (r : Fin m)
-    (hdifference : ∀ {i : Fin m} (hri : r ≠ i) (c : R),
-      differenceShortRootUnit hri c ∈ H)
+    (H : Subgroup (GLSymplecticFin m R)) (r : Fin m)
+    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
+      differenceShortRootUnit hij c ∈ H)
     (hpivot : ∀ c : R, negativeLongRootTransvectionUnit r c ∈ H)
     (i : Fin m) (c : R) : negativeLongRootTransvectionUnit i c ∈ H := by
   by_cases hir : i = r
   · subst i
     exact hpivot c
-  · obtain ⟨u, hu⟩ := h2
-    let t : R := ((u⁻¹ : Rˣ) : R) * c
-    have ht : t + t = c := by
-      dsimp only [t]
-      rw [← two_mul, ← hu]
-      simp
-    have hri : r ≠ i := Ne.symm hir
-    have hfirst :
-        negativeSumShortRootUnit hri (-t) * negativeLongRootTransvectionUnit i t ∈ H := by
-      have hmem := H.commutator_le_self
-        (Subgroup.commutator_mem_commutator (hdifference hri 1) (hpivot t))
-      rw [commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit] at hmem
-      simpa using hmem
-    have hsecond :
-        negativeSumShortRootUnit hri (-t) * negativeLongRootTransvectionUnit i (-t) ∈ H := by
-      have hmem := H.commutator_le_self
-        (Subgroup.commutator_mem_commutator (hdifference hri (-1)) (hpivot (-t)))
-      rw [commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit] at hmem
-      simpa using hmem
-    have hquotient := H.mul_mem hfirst (H.inv_mem hsecond)
-    have heq :
-        (negativeSumShortRootUnit hri (-t) * negativeLongRootTransvectionUnit i t) *
-            (negativeSumShortRootUnit hri (-t) *
-              negativeLongRootTransvectionUnit i (-t))⁻¹ =
-          negativeLongRootTransvectionUnit i c := by
-      calc
-        _ = negativeSumShortRootUnit hri (-t) *
-              (negativeLongRootTransvectionUnit i t *
-                negativeLongRootTransvectionUnit i t) *
-              (negativeSumShortRootUnit hri (-t))⁻¹ := by
-            rw [_root_.mul_inv_rev, negativeLongRootTransvectionUnit_inv, neg_neg]
-            group
-        _ = negativeSumShortRootUnit hri (-t) *
-              negativeLongRootTransvectionUnit i (t + t) *
-              (negativeSumShortRootUnit hri (-t))⁻¹ := by
-            rw [← negativeLongRootTransvectionUnit_add]
-        _ = negativeLongRootTransvectionUnit i (t + t) := by
-            rw [(commute_negativeSumShortRootUnit_negativeLongRootTransvectionUnit
-              hri (-t) (t + t)).eq]
-            group
-        _ = negativeLongRootTransvectionUnit i c := by rw [ht]
-    rwa [heq] at hquotient
+  · let w := differenceShortRootWeylElement (R := R) hir
+    have hw : w ∈ H := differenceShortRootWeylElement_mem H hir
+      (hdifference hir) (hdifference (Ne.symm hir))
+    have hconj := H.mul_mem (H.mul_mem hw (hpivot c)) (H.inv_mem hw)
+    simpa only [w, differenceShortRootWeylElement_inv,
+      differenceShortRootWeylElement_mul_negativeLongRootTransvectionUnit_mul_inv] using hconj
 
 /-- A positive-sum short-root element lies in a subgroup containing the corresponding
 difference-root element at parameter `1` and the two long-root elements used to isolate it. -/
@@ -244,11 +130,10 @@ theorem negativeSumShortRootUnit_mem_of_difference_of_long
 namespace RootSubgroupIndex
 
 /-- **Difference roots and one opposite pair of long-root subgroups generate every symplectic root
-subgroup when `2` is invertible.** More precisely, if `H` contains every difference-root element
-and both long-root subgroups at one index, then the value of every root one-parameter subgroup lies
-in `H`. -/
+subgroup.** More precisely, if `H` contains every difference-root element and both long-root
+subgroups at one index, then the value of every root one-parameter subgroup lies in `H`. -/
 theorem hom_apply_mem_of_difference_of_long
-    (H : Subgroup (GLSymplecticFin m R)) (h2 : IsUnit (2 : R)) (r : Fin m)
+    (H : Subgroup (GLSymplecticFin m R)) (r : Fin m)
     (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
       differenceShortRootUnit hij c ∈ H)
     (hpositive : ∀ c : R, positiveLongRootTransvectionUnit r c ∈ H)
@@ -256,10 +141,10 @@ theorem hom_apply_mem_of_difference_of_long
     (root : RootSubgroupIndex m) (c : Multiplicative R) : root.hom c ∈ H := by
   have hp (i : Fin m) (a : R) : positiveLongRootTransvectionUnit i a ∈ H :=
     positiveLongRootTransvectionUnit_mem_of_difference_of_long
-      H h2 r hdifference hpositive i a
+      H r hdifference hpositive i a
   have hn (i : Fin m) (a : R) : negativeLongRootTransvectionUnit i a ∈ H :=
     negativeLongRootTransvectionUnit_mem_of_difference_of_long
-      H h2 r hdifference hnegative i a
+      H r hdifference hnegative i a
   cases root with
   | positiveLong i =>
       simpa only [hom_positiveLong, positiveLongRootTransvectionHom_apply] using hp i c.toAdd
@@ -275,6 +160,20 @@ theorem hom_apply_mem_of_difference_of_long
       simpa only [hom_negativeSum, negativeSumShortRootHom_apply] using
         negativeSumShortRootUnit_mem_of_difference_of_long H hij.ne c.toAdd
           (hdifference hij.ne 1) (hn i (-c.toAdd)) (hn j (-c.toAdd))
+
+/-- **The positive and negative simple-root families generate every standard symplectic root
+subgroup.** It is enough for `H` to contain the two orientations of every adjacent difference
+root and one pair of opposite long-root subgroups. This formulation matches the numbered simple
+roots of type `C` and holds over every commutative ring. -/
+theorem hom_apply_mem_of_adjacent_of_long
+    (H : Subgroup (GLSymplecticFin m R)) (r : Fin m)
+    (hadjacent : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
+      i.val + 1 = j.val ∨ j.val + 1 = i.val → differenceShortRootUnit hij c ∈ H)
+    (hpositive : ∀ c : R, positiveLongRootTransvectionUnit r c ∈ H)
+    (hnegative : ∀ c : R, negativeLongRootTransvectionUnit r c ∈ H)
+    (root : RootSubgroupIndex m) (c : Multiplicative R) : root.hom c ∈ H := by
+  apply hom_apply_mem_of_difference_of_long H r _ hpositive hnegative
+  exact differenceShortRootUnit_mem_of_adjacent H hadjacent
 
 end RootSubgroupIndex
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.ChevalleyRelations
 import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Generation
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.SumRootGeneration
 import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Weyl
 
 /-!
@@ -64,40 +65,40 @@ universe u
 variable {R : Type u} [CommRing R] {m : ℕ} {i j : Fin m}
 
 /-- If a subgroup contains the two difference-root elements forming the Weyl word from `r` to `i`
-and the positive long-root subgroup at `r`, then it contains the positive long-root subgroup at
-`i`. -/
+and the positive long-root element at `r`, then it contains the corresponding positive long-root
+element at `i`. -/
 theorem positiveLongRootTransvectionUnit_mem_of_difference_of_long
     (H : Subgroup (GLSymplecticFin m R)) (r i : Fin m)
     (hforward : ∀ hir : i ≠ r, differenceShortRootUnit hir 1 ∈ H)
     (hbackward : ∀ hir : i ≠ r, differenceShortRootUnit hir.symm (-1) ∈ H)
-    (hpivot : ∀ c : R, positiveLongRootTransvectionUnit r c ∈ H)
-    (c : R) : positiveLongRootTransvectionUnit i c ∈ H := by
+    (c : R) (hpivot : positiveLongRootTransvectionUnit r c ∈ H) :
+    positiveLongRootTransvectionUnit i c ∈ H := by
   by_cases hir : i = r
   · subst i
-    exact hpivot c
+    exact hpivot
   · let w := differenceShortRootWeylElement (R := R) hir
     have hw : w ∈ H := differenceShortRootWeylElement_mem H hir
       (hforward hir) (hbackward hir)
-    have hconj := H.mul_mem (H.mul_mem hw (hpivot c)) (H.inv_mem hw)
+    have hconj := H.mul_mem (H.mul_mem hw hpivot) (H.inv_mem hw)
     simpa only [w, differenceShortRootWeylElement_inv,
       differenceShortRootWeylElement_mul_positiveLongRootTransvectionUnit_mul_inv] using hconj
 
 /-- If a subgroup contains the two difference-root elements forming the Weyl word from `r` to `i`
-and the negative long-root subgroup at `r`, then it contains the negative long-root subgroup at
-`i`. -/
+and the negative long-root element at `r`, then it contains the corresponding negative long-root
+element at `i`. -/
 theorem negativeLongRootTransvectionUnit_mem_of_difference_of_long
     (H : Subgroup (GLSymplecticFin m R)) (r i : Fin m)
     (hforward : ∀ hir : i ≠ r, differenceShortRootUnit hir 1 ∈ H)
     (hbackward : ∀ hir : i ≠ r, differenceShortRootUnit hir.symm (-1) ∈ H)
-    (hpivot : ∀ c : R, negativeLongRootTransvectionUnit r c ∈ H)
-    (c : R) : negativeLongRootTransvectionUnit i c ∈ H := by
+    (c : R) (hpivot : negativeLongRootTransvectionUnit r c ∈ H) :
+    negativeLongRootTransvectionUnit i c ∈ H := by
   by_cases hir : i = r
   · subst i
-    exact hpivot c
+    exact hpivot
   · let w := differenceShortRootWeylElement (R := R) hir
     have hw : w ∈ H := differenceShortRootWeylElement_mem H hir
       (hforward hir) (hbackward hir)
-    have hconj := H.mul_mem (H.mul_mem hw (hpivot c)) (H.inv_mem hw)
+    have hconj := H.mul_mem (H.mul_mem hw hpivot) (H.inv_mem hw)
     simpa only [w, differenceShortRootWeylElement_inv,
       differenceShortRootWeylElement_mul_negativeLongRootTransvectionUnit_mul_inv] using hconj
 
@@ -143,25 +144,11 @@ theorem hom_apply_mem_of_difference_of_long
     (root : RootSubgroupIndex m) (c : Multiplicative R) : root.hom c ∈ H := by
   have hp (i : Fin m) (a : R) : positiveLongRootTransvectionUnit i a ∈ H :=
     positiveLongRootTransvectionUnit_mem_of_difference_of_long
-      H r i (fun hir => hdifference hir 1) (fun hir => hdifference hir.symm (-1)) hpositive a
+      H r i (fun hir => hdifference hir 1) (fun hir => hdifference hir.symm (-1)) a (hpositive a)
   have hn (i : Fin m) (a : R) : negativeLongRootTransvectionUnit i a ∈ H :=
     negativeLongRootTransvectionUnit_mem_of_difference_of_long
-      H r i (fun hir => hdifference hir 1) (fun hir => hdifference hir.symm (-1)) hnegative a
-  cases root with
-  | positiveLong i =>
-      simpa only [hom_positiveLong, positiveLongRootTransvectionHom_apply] using hp i c.toAdd
-  | negativeLong i =>
-      simpa only [hom_negativeLong, negativeLongRootTransvectionHom_apply] using hn i c.toAdd
-  | difference i j hij =>
-      simpa only [hom_difference, differenceShortRootHom_apply] using hdifference hij c.toAdd
-  | positiveSum i j hij =>
-      simpa only [hom_positiveSum, positiveSumShortRootHom_apply] using
-        positiveSumShortRootUnit_mem_of_difference_of_long H hij.ne c.toAdd
-          (hdifference hij.ne 1) (hp j c.toAdd) (hp i c.toAdd)
-  | negativeSum i j hij =>
-      simpa only [hom_negativeSum, negativeSumShortRootHom_apply] using
-        negativeSumShortRootUnit_mem_of_difference_of_long H hij.ne c.toAdd
-          (hdifference hij.ne 1) (hn i (-c.toAdd)) (hn j (-c.toAdd))
+      H r i (fun hir => hdifference hir 1) (fun hir => hdifference hir.symm (-1)) a (hnegative a)
+  exact rootSubgroupHom_mem_of_difference_long H hdifference hp hn root c
 
 /-- **The positive and negative simple-root families generate every standard symplectic root
 subgroup.** It is enough for `H` to contain the two orientations of every adjacent difference

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
@@ -34,8 +34,6 @@ characteristic two.
 
 * `TauCeti.GLSymplecticFin.positiveLongRootTransvectionUnit_mem_of_difference_of_long` and its
   negative analogue transport one long-root subgroup to a target index by Weyl conjugation.
-* `TauCeti.GLSymplecticFin.positiveSumShortRootUnit_mem_of_difference_of_long` and its negative
-  analogue generate the two sum-root families.
 * `TauCeti.GLSymplecticFin.RootSubgroupIndex.hom_apply_mem_of_difference_of_long` packages the
   result for every standard symplectic root subgroup.
 * `TauCeti.GLSymplecticFin.RootSubgroupIndex.hom_apply_mem_of_adjacent_of_long` reduces the
@@ -54,9 +52,6 @@ branch consumed by milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md`.
 -/
 
 public section
-
-open Matrix
-open scoped commutatorElement
 
 namespace TauCeti.GLSymplecticFin
 
@@ -101,34 +96,6 @@ theorem negativeLongRootTransvectionUnit_mem_of_difference_of_long
     have hconj := H.mul_mem (H.mul_mem hw hpivot) (H.inv_mem hw)
     simpa only [w, differenceShortRootWeylElement_inv,
       differenceShortRootWeylElement_mul_negativeLongRootTransvectionUnit_mul_inv] using hconj
-
-/-- A positive-sum short-root element lies in a subgroup containing the corresponding
-difference-root element at parameter `1` and the two long-root elements used to isolate it. -/
-theorem positiveSumShortRootUnit_mem_of_difference_of_long
-    (H : Subgroup (GLSymplecticFin m R)) (hij : i ≠ j) (c : R)
-    (hdifference : differenceShortRootUnit hij 1 ∈ H)
-    (hlongj : positiveLongRootTransvectionUnit j c ∈ H)
-    (hlongi : positiveLongRootTransvectionUnit i c ∈ H) :
-    positiveSumShortRootUnit hij c ∈ H := by
-  have hproduct := H.commutator_le_self
-    (Subgroup.commutator_mem_commutator hdifference hlongj)
-  rw [commutatorElement_differenceShortRootUnit_positiveLongRootTransvectionUnit] at hproduct
-  have hisolate := H.mul_mem hproduct (H.inv_mem hlongi)
-  simpa only [one_mul, one_pow, mul_assoc, mul_inv_cancel, mul_one] using hisolate
-
-/-- A negative-sum short-root element lies in a subgroup containing the corresponding
-difference-root element at parameter `1` and the two long-root elements used to isolate it. -/
-theorem negativeSumShortRootUnit_mem_of_difference_of_long
-    (H : Subgroup (GLSymplecticFin m R)) (hij : i ≠ j) (c : R)
-    (hdifference : differenceShortRootUnit hij 1 ∈ H)
-    (hlongi : negativeLongRootTransvectionUnit i (-c) ∈ H)
-    (hlongj : negativeLongRootTransvectionUnit j (-c) ∈ H) :
-    negativeSumShortRootUnit hij c ∈ H := by
-  have hproduct := H.commutator_le_self
-    (Subgroup.commutator_mem_commutator hdifference hlongi)
-  rw [commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit] at hproduct
-  have hisolate := H.mul_mem hproduct (H.inv_mem hlongj)
-  simpa only [one_mul, one_pow, neg_neg, mul_assoc, mul_inv_cancel, mul_one] using hisolate
 
 namespace RootSubgroupIndex
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Weyl.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Weyl.lean
@@ -32,6 +32,8 @@ subgroups. This advances the explicit full-weight type-`C` carrier in Layer 9 of
 
 * `TauCeti.GLSymplecticFin.differenceShortRootWeylElement`: the standard representative of the
   reflection in `e_i-e_j`.
+* `differenceShortRootWeylElement_mem`: both orientations of a difference-root subgroup contain
+  the corresponding Weyl representative.
 * `coe_differenceShortRootWeylElement`: in sum coordinates it is a product of two type-`A` Weyl
   representatives.
 * `differenceShortRootWeylElement_inv`: the representative for the opposite root is its inverse.
@@ -63,6 +65,15 @@ variable {R : Type u} [CommRing R] {m : ℕ} {i j : Fin m}
 def differenceShortRootWeylElement (hij : i ≠ j) : GLSymplecticFin m R :=
   differenceShortRootUnit hij 1 * differenceShortRootUnit hij.symm (-1) *
     differenceShortRootUnit hij 1
+
+/-- A subgroup containing both orientations of a difference-root subgroup contains the
+corresponding Weyl reflection representative. -/
+theorem differenceShortRootWeylElement_mem (H : Subgroup (GLSymplecticFin m R))
+    (hij : i ≠ j) (hforward : ∀ c, differenceShortRootUnit hij c ∈ H)
+    (hbackward : ∀ c, differenceShortRootUnit (Ne.symm hij) c ∈ H) :
+    differenceShortRootWeylElement hij ∈ H := by
+  rw [differenceShortRootWeylElement]
+  exact H.mul_mem (H.mul_mem (hforward 1) (hbackward (-1))) (hforward 1)
 
 /-- In sum coordinates the short-root Weyl representative is the product of the type-`A` Weyl
 representative on the first block and the inverse of the one on the second block. -/

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Weyl.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Weyl.lean
@@ -32,8 +32,8 @@ subgroups. This advances the explicit full-weight type-`C` carrier in Layer 9 of
 
 * `TauCeti.GLSymplecticFin.differenceShortRootWeylElement`: the standard representative of the
   reflection in `e_i-e_j`.
-* `differenceShortRootWeylElement_mem`: both orientations of a difference-root subgroup contain
-  the corresponding Weyl representative.
+* `differenceShortRootWeylElement_mem`: a subgroup containing the two difference-root elements
+  forming a Weyl word contains the corresponding Weyl representative.
 * `coe_differenceShortRootWeylElement`: in sum coordinates it is a product of two type-`A` Weyl
   representatives.
 * `differenceShortRootWeylElement_inv`: the representative for the opposite root is its inverse.
@@ -66,14 +66,14 @@ def differenceShortRootWeylElement (hij : i ≠ j) : GLSymplecticFin m R :=
   differenceShortRootUnit hij 1 * differenceShortRootUnit hij.symm (-1) *
     differenceShortRootUnit hij 1
 
-/-- A subgroup containing both orientations of a difference-root subgroup contains the
+/-- A subgroup containing the two difference-root elements forming a Weyl word contains the
 corresponding Weyl reflection representative. -/
 theorem differenceShortRootWeylElement_mem (H : Subgroup (GLSymplecticFin m R))
-    (hij : i ≠ j) (hforward : ∀ c, differenceShortRootUnit hij c ∈ H)
-    (hbackward : ∀ c, differenceShortRootUnit (Ne.symm hij) c ∈ H) :
+    (hij : i ≠ j) (hforward : differenceShortRootUnit hij 1 ∈ H)
+    (hbackward : differenceShortRootUnit hij.symm (-1) ∈ H) :
     differenceShortRootWeylElement hij ∈ H := by
   rw [differenceShortRootWeylElement]
-  exact H.mul_mem (H.mul_mem (hforward 1) (hbackward (-1))) (hforward 1)
+  exact H.mul_mem (H.mul_mem hforward hbackward) hforward
 
 /-- In sum coordinates the short-root Weyl representative is the product of the type-`A` Weyl
 representative on the first block and the inverse of the one on the second block. -/


### PR DESCRIPTION
This PR generates every standard type-`C` symplectic root subgroup from the positive and negative simple-root families over an arbitrary commutative ring. It replaces the former divide-by-two propagation of long roots with conjugation by the existing short-root Weyl representatives, packages membership of those representatives in a subgroup, and exposes the adjacent-difference-root formulation matching the numbered type-`C` pinning.

The exact roadmap target is Layer 9, “The Chevalley–Demazure construction” and its “Root subgroup maps” interface, in `TauCetiRoadmap/ReductiveGroups/README.md`. This is the most effective current step because the standard type-`C` carrier, its numbered root subgroups, the symplectic Weyl conjugation formulas, and adjacent difference-root generation are already on `main`, while the existing combined generation theorem still assumes `IsUnit (2 : R)` and therefore cannot serve the characteristic-two type-`C` branch. Milestone L0, “explicit pinned Chevalley–Demazure groups,” of `TauCetiRoadmap/CFSGStatement/README.md` consumes that branch through the full-weight symplectic carrier.

The two long-root propagation lemmas now assume both orientations of every difference root—the hypotheses available from the positive and negative simple-root families—and no longer assume that `2` is invertible. `RootSubgroupIndex.hom_apply_mem_of_difference_of_long` consequently holds in every characteristic, while `RootSubgroupIndex.hom_apply_mem_of_adjacent_of_long` combines it with the existing type-`A` adjacent-root generation theorem. The proof reuses `differenceShortRootWeylElement_mul_positiveLongRootTransvectionUnit_mul_inv`, its negative counterpart, the existing Chevalley commutator formulas, and `differenceShortRootUnit_mem_of_adjacent`; no Mathlib infrastructure or external formalization is vendored. The mathematical organization follows Carter, *Simple Groups of Lie Type*, §5.2, and Steinberg, *Lectures on Chevalley Groups*, §§3–4, as cited in the module documentation.

After this PR, the type-`C` Layer 9 path still needs the symplectic Gaussian generation theorem turning root-subgroup generation into generation of all field-valued points, followed by the resulting identification of the full-weight carrier with the pinned simply connected symplectic group scheme.

The change modifies `TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean` (180 lines, +61/−162) and `TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Weyl.lean` (303 lines, +11), replacing 117 lines of characteristic-restricted commutator algebra with the canonical Weyl transport argument.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"symplectic-root-generation-characteristic-free"}-->

🤖 Prepared with Codex
