### PR TITLE
feat: identify the upper-triangular unipotent radical

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Unipotent/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Unipotent/Radical.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Levi.DiagonalTorus
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Levi.Kernel
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Parabolic.Geometry
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Unipotent.Geometry
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Unipotent.Pointwise
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.DiagonalizableQuotient
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Isomorphism
@@ -28,7 +28,8 @@ claimed equality of Hopf ideals.
 
 * `TauCeti.GeneralLinear.
     unipotentRadicalDefiningIdeal_weightParabolicFiniteTypeCoordinateHopfAlgebra`:
-  the unipotent radical of an injective-weight parabolic is its weight-unipotent kernel.
+  after identifying the finite-type package's object with the weight-parabolic coordinate
+  algebra, the unipotent radical is its weight-unipotent kernel.
 
 ## References
 
@@ -41,7 +42,7 @@ This completes the unipotent-radical calculation for injective-weight parabolics
 
 public section
 
-open CategoryTheory TauCeti.GeneralLinear.Dynamic
+open CategoryTheory TauCeti.GeneralLinear.Dynamic TauCeti.FiniteTypeCommHopfAlgCat
 
 namespace TauCeti.GeneralLinear
 
@@ -51,29 +52,17 @@ noncomputable section
 
 variable {N : ℕ}
 
-/-- The weight-unipotent ideal, regarded as an ideal in the finite-type package of the
-weight-parabolic coordinate Hopf algebra. -/
-noncomputable def weightUnipotentInParabolicFiniteTypeHopfIdeal
-    (k : Type u) [Field k] (w : Fin N → ℤ) :
-    HopfIdeal k (weightParabolicFiniteTypeCoordinateHopfAlgebra k w).obj :=
-  let H : FiniteTypeCommHopfAlgCat.{u, u} k :=
-    ⟨weightParabolicCoordinateHopfAlgebra k w,
-      weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k w ▸
-        (weightParabolicFiniteTypeCoordinateHopfAlgebra k w).property⟩
-  let e : weightParabolicFiniteTypeCoordinateHopfAlgebra k w ≅ H :=
-    ObjectProperty.isoMk _
-      (eqToIso (weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k w))
-  (weightUnipotentInParabolicHopfIdeal k w).comapOfSurjective
-    (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
-    (ConcreteCategory.bijective_of_isIso e.hom).2
-
-/-- **The unipotent radical of an injective-weight parabolic is its weight-unipotent
-subgroup.** -/
+/-- **The unipotent radical of an injective-weight parabolic is its weight-unipotent subgroup.**
+The pullback along the displayed object equality presents the result in the coordinate algebra
+where the canonical weight-unipotent ideal is defined. -/
 theorem unipotentRadicalDefiningIdeal_weightParabolicFiniteTypeCoordinateHopfAlgebra
     (k : Type u) [Field k] (w : Fin N → ℤ) (hw : Function.Injective w) :
-    FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
-        (weightParabolicFiniteTypeCoordinateHopfAlgebra k w) =
-      weightUnipotentInParabolicFiniteTypeHopfIdeal k w := by
+    (FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+        (weightParabolicFiniteTypeCoordinateHopfAlgebra k w)).comapOfSurjective
+      (eqToHom (weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k w).symm).hom
+      (ConcreteCategory.bijective_of_isIso
+        (eqToHom (weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k w).symm)).2 =
+      weightUnipotentInParabolicHopfIdeal k w := by
   let H : FiniteTypeCommHopfAlgCat.{u, u} k :=
     ⟨weightParabolicCoordinateHopfAlgebra k w,
       weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k w ▸
@@ -113,13 +102,22 @@ theorem unipotentRadicalDefiningIdeal_weightParabolicFiniteTypeCoordinateHopfAlg
   have hRaw : FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal H = I := by
     rw [← hker]
     exact
-      FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_diagonalizable
-        H G f (hker ▸ hI)
+      unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_geometricallySemisimple
+        H (DiagonalizableGroup.coordinateRing k G)
+          (DiagonalizableGroup.geometricallySemisimplePointsCommHopfAlgProperty k G)
+          f (hker ▸ hI)
   let e : weightParabolicFiniteTypeCoordinateHopfAlgebra k w ≅ H :=
     ObjectProperty.isoMk _
       (eqToIso (weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k w))
-  rw [← FiniteTypeCommHopfAlgCat.comapOfSurjective_unipotentRadicalDefiningIdeal e, hRaw]
-  rfl
+  -- The finite-type package is opaque across modules, so align its explicit object isomorphism
+  -- with the pullback displayed in the theorem statement.
+  change
+    (FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+      (weightParabolicFiniteTypeCoordinateHopfAlgebra k w)).comapOfSurjective
+        (FiniteTypeCommHopfAlgCat.toBialgHom e.symm.hom)
+        (ConcreteCategory.bijective_of_isIso e.symm.hom).2 = I
+  rw [FiniteTypeCommHopfAlgCat.comapOfSurjective_unipotentRadicalDefiningIdeal e.symm]
+  exact hRaw
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Unipotent/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Unipotent/Radical.lean
@@ -55,7 +55,7 @@ variable {N : ℕ}
 /-- **The unipotent radical of an injective-weight parabolic is its weight-unipotent subgroup.**
 The pullback along the displayed object equality presents the result in the coordinate algebra
 where the canonical weight-unipotent ideal is defined. -/
-theorem unipotentRadicalDefiningIdeal_weightParabolicFiniteTypeCoordinateHopfAlgebra
+@[simp] theorem unipotentRadicalDefiningIdeal_weightParabolicFiniteTypeCoordinateHopfAlgebra
     (k : Type u) [Field k] (w : Fin N → ℤ) (hw : Function.Injective w) :
     (FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
         (weightParabolicFiniteTypeCoordinateHopfAlgebra k w)).comapOfSurjective

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Unipotent/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Unipotent/Radical.lean
@@ -35,9 +35,6 @@ claimed equality of Hopf ideals.
 
 * J. S. Milne, *Algebraic Groups* (2017), Chapters 13 and 17.
 * T. A. Springer, *Linear Algebraic Groups*, Sections 6.2--6.3.
-
-This completes the unipotent-radical calculation for injective-weight parabolics in Layers 5 and
-7 of the ReductiveGroups roadmap.
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Unipotent/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Unipotent/Radical.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Levi.DiagonalTorus
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Levi.Kernel
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Parabolic.Geometry
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Unipotent.Pointwise
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.DiagonalizableQuotient
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Isomorphism
+
+/-!
+# Unipotent radicals of injective-weight parabolics
+
+For an injective weight `w : Fin N → ℤ`, the dynamic parabolic `P(w)` has diagonal-torus
+Levi quotient and weight-unipotent kernel `U(w)`. This file identifies that kernel with the
+unipotent radical of `P(w)`.
+
+The normality and kernel calculation come from the represented dynamic Levi decomposition.
+The weight-unipotent coordinate algebra is polynomial, hence smooth and geometrically connected,
+and its points are unipotent. The general diagonalizable-quotient criterion then gives the
+claimed equality of Hopf ideals.
+
+## Main declaration
+
+* `TauCeti.GeneralLinear.
+    unipotentRadicalDefiningIdeal_weightParabolicFiniteTypeCoordinateHopfAlgebra`:
+  the unipotent radical of an injective-weight parabolic is its weight-unipotent kernel.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Chapters 13 and 17.
+* T. A. Springer, *Linear Algebraic Groups*, Sections 6.2--6.3.
+
+This completes the unipotent-radical calculation for injective-weight parabolics in Layers 5 and
+7 of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory TauCeti.GeneralLinear.Dynamic
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+noncomputable section
+
+variable {N : ℕ}
+
+/-- The weight-unipotent ideal, regarded as an ideal in the finite-type package of the
+weight-parabolic coordinate Hopf algebra. -/
+noncomputable def weightUnipotentInParabolicFiniteTypeHopfIdeal
+    (k : Type u) [Field k] (w : Fin N → ℤ) :
+    HopfIdeal k (weightParabolicFiniteTypeCoordinateHopfAlgebra k w).obj :=
+  let H : FiniteTypeCommHopfAlgCat.{u, u} k :=
+    ⟨weightParabolicCoordinateHopfAlgebra k w,
+      weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k w ▸
+        (weightParabolicFiniteTypeCoordinateHopfAlgebra k w).property⟩
+  let e : weightParabolicFiniteTypeCoordinateHopfAlgebra k w ≅ H :=
+    ObjectProperty.isoMk _
+      (eqToIso (weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k w))
+  (weightUnipotentInParabolicHopfIdeal k w).comapOfSurjective
+    (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+    (ConcreteCategory.bijective_of_isIso e.hom).2
+
+/-- **The unipotent radical of an injective-weight parabolic is its weight-unipotent
+subgroup.** -/
+theorem unipotentRadicalDefiningIdeal_weightParabolicFiniteTypeCoordinateHopfAlgebra
+    (k : Type u) [Field k] (w : Fin N → ℤ) (hw : Function.Injective w) :
+    FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+        (weightParabolicFiniteTypeCoordinateHopfAlgebra k w) =
+      weightUnipotentInParabolicFiniteTypeHopfIdeal k w := by
+  let H : FiniteTypeCommHopfAlgCat.{u, u} k :=
+    ⟨weightParabolicCoordinateHopfAlgebra k w,
+      weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k w ▸
+        (weightParabolicFiniteTypeCoordinateHopfAlgebra k w).property⟩
+  let I := weightUnipotentInParabolicHopfIdeal k w
+  let hUfinite : Algebra.FiniteType k (weightUnipotentCoordinateHopfAlgebra k w) := by
+    let _ : Algebra.Smooth k (weightUnipotentCoordinateHopfAlgebra k w) := inferInstance
+    infer_instance
+  let U : FiniteTypeCommHopfAlgCat.{u, u} k :=
+    ⟨weightUnipotentCoordinateHopfAlgebra k w, hUfinite⟩
+  let eU : U ≅ FiniteTypeCommHopfAlgCat.quotient H I :=
+    ObjectProperty.isoMk _ (weightUnipotentInParabolicCoordinateIso k w)
+  have hUconnected : geometricallyConnectedCommHopfAlgProperty k U.obj :=
+    geometricallyConnectedCommHopfAlgProperty_weightUnipotentCoordinateHopfAlgebra k w
+  have hUsmoothUnipotent : smoothUnipotentCommHopfAlgProperty k U := by
+    rw [smoothUnipotentCommHopfAlgProperty_iff]
+    refine ⟨inferInstance, ?_⟩
+    exact (geometricallyUnipotentPointsCommHopfAlgProperty_iff k U.obj).mp
+      (geometricallyUnipotentPointsCommHopfAlgProperty_weightUnipotentCoordinateHopfAlgebra w)
+  have hI : HopfIdeal.IsUnipotentRadicalCandidate H I :=
+    HopfIdeal.IsUnipotentRadicalCandidate.mk
+      (isNormal_weightUnipotentInParabolicHopfIdeal k w)
+      ((geometricallyConnectedCommHopfAlgProperty k).prop_of_iso
+        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+          (_root_.CommHopfAlgCat.{u} k)).mapIso eU) hUconnected)
+      ((smoothUnipotentCommHopfAlgProperty k).prop_of_iso eU hUsmoothUnipotent)
+  let G := SplitTorus.characterGroup (ULift.{u} (Fin N))
+  let eL := weightLeviDiagonalCoordinateIso k w hw
+  let fL := weightParabolicLimitCoordinateMap k w
+  let f : (DiagonalizableGroup.coordinateRing k G).obj ⟶ H.obj := eL.inv ≫ fL
+  have hker : CommHopfAlgCat.kernelHopfIdeal f = I := by
+    calc
+      CommHopfAlgCat.kernelHopfIdeal f = CommHopfAlgCat.kernelHopfIdeal fL :=
+        CommHopfAlgCat.kernelHopfIdeal_comp_of_surjective eL.inv
+          (ConcreteCategory.bijective_of_isIso eL.inv).2 fL
+      _ = I := kernelHopfIdeal_weightParabolicLimitCoordinateMap k w
+  have hRaw : FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal H = I := by
+    rw [← hker]
+    exact
+      FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_diagonalizable
+        H G f (hker ▸ hI)
+  let e : weightParabolicFiniteTypeCoordinateHopfAlgebra k w ≅ H :=
+    ObjectProperty.isoMk _
+      (eqToIso (weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k w))
+  rw [← FiniteTypeCommHopfAlgCat.comapOfSurjective_unipotentRadicalDefiningIdeal e, hRaw]
+  rfl
+
+end
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/Basic.lean
@@ -70,6 +70,13 @@ theorem weights_apply (i : Fin n) : weights n i = (n : ℤ) - 1 - (i : ℤ) :=
 theorem weights_lt_weights_iff (i j : Fin n) : weights n i < weights n j ↔ j < i := by
   simp [weights]
 
+/-- The standard upper-triangular weights are pairwise distinct. -/
+theorem weights_injective : Function.Injective (weights n) := by
+  intro i j hij
+  apply Fin.ext
+  rw [weights_apply, weights_apply] at hij
+  omega
+
 /-- The matrix coordinates strictly below the diagonal. -/
 def definingRelationSet : Set (GeneralLinear.coordinateHopfAlgebra R n) :=
   {x | ∃ i j, j < i ∧

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/SmoothConnected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/SmoothConnected.lean
@@ -46,12 +46,6 @@ namespace UpperTriangular
 
 variable (n : ℕ)
 
-private theorem weights_injective : Function.Injective (weights n) := by
-  intro i j hij
-  apply Fin.ext
-  rw [weights_apply, weights_apply] at hij
-  omega
-
 /-- **The standard upper-triangular subgroup of `GL_n` is smooth over every field.** -/
 theorem smoothCommHopfAlgProperty_coordinateHopfAlgebra
     (k : Type u) [Field k] :

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
@@ -31,9 +31,6 @@ the unipotent radical of the upper-triangular affine group.
 
 * J. S. Milne, *Algebraic Groups* (2017), Chapters 13 and 17.
 * T. A. Springer, *Linear Algebraic Groups*, Sections 6.2--6.3.
-
-This supplies the concrete unipotent radical of the standard Borel candidate required by Layers
-5 and 7 of the ReductiveGroups roadmap. Maximal solvability of that candidate remains downstream.
 -/
 
 public section
@@ -48,9 +45,17 @@ noncomputable section
 
 /-- The Hopf ideal in the upper-triangular coordinate algebra cutting out the
 upper-unitriangular subgroup. -/
-noncomputable abbrev upperUnitriangularHopfIdeal
+noncomputable def upperUnitriangularHopfIdeal
     (R : Type u) [CommRing R] (n : ℕ) : HopfIdeal R (coordinateHopfAlgebra R n) :=
   GeneralLinear.Dynamic.weightUnipotentInParabolicHopfIdeal R (weights n)
+
+/-- The upper-unitriangular Hopf ideal is the relative weight-unipotent ideal for the standard
+decreasing weights. -/
+theorem upperUnitriangularHopfIdeal_def
+    (R : Type u) [CommRing R] (n : ℕ) :
+    upperUnitriangularHopfIdeal R n =
+      GeneralLinear.Dynamic.weightUnipotentInParabolicHopfIdeal R (weights n) := by
+  rw [upperUnitriangularHopfIdeal]
 
 /-- The relative weight-unipotent ideal cuts out exactly the existing upper-unitriangular
 matrix group, compatibly with the upper-triangular inclusion into `GL_n`. -/
@@ -63,7 +68,7 @@ theorem mem_upperUnitriangularPointsSubgroup_iff
         (upperUnitriangularHopfIdeal R n) (CommAlgCat.of R A) ↔
       (pointsMulEquiv (R := R) (n := n) (A := A) f : GL (Fin n) A) ∈
         upperUnitriangularGroup (Fin n) A := by
-  rw [upperUnitriangularHopfIdeal,
+  rw [upperUnitriangularHopfIdeal_def,
     GeneralLinear.Dynamic.mem_weightUnipotentInParabolicPointsSubgroup_iff,
     GeneralLinear.mem_weightUnipotentDefiningPointsSubgroup_iff,
     UpperUnitriangularGroup.mem_iff, Matrix.isUpperUnitriangular_def,
@@ -99,6 +104,7 @@ theorem unipotentRadicalDefiningIdeal_finiteTypeCoordinateHopfAlgebra
       (ConcreteCategory.bijective_of_isIso
         (eqToHom (finiteTypeCoordinateHopfAlgebra_obj k n).symm)).2 =
       upperUnitriangularHopfIdeal k n := by
+  rw [upperUnitriangularHopfIdeal_def]
   let e : finiteTypeCoordinateHopfAlgebra k n ≅
       GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra k (weights n) :=
     ObjectProperty.isoMk _ <| eqToIso <|

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
@@ -19,6 +19,9 @@ the unipotent radical of the upper-triangular affine group.
 
 ## Main declaration
 
+* `TauCeti.GeneralLinear.UpperTriangular.mem_upperUnitriangularDefiningPointsSubgroup_iff`:
+  the relative weight-unipotent ideal cuts out exactly the existing upper-unitriangular matrix
+  group over every commutative value algebra.
 * `TauCeti.GeneralLinear.UpperTriangular.unipotentRadicalDefiningIdeal`:
   the relative upper-unitriangular Hopf ideal is the unipotent-radical defining ideal.
 
@@ -37,11 +40,51 @@ open CategoryTheory
 
 namespace TauCeti.GeneralLinear.UpperTriangular
 
-universe u
+universe u v
 
 noncomputable section
 
-/-- The relative upper-unitriangular Hopf ideal in the finite-type coordinate algebra of the
+/-- The Hopf ideal in the upper-triangular coordinate algebra cutting out the
+upper-unitriangular subgroup. -/
+noncomputable abbrev upperUnitriangularDefiningHopfIdeal
+    (R : Type u) [CommRing R] (n : ℕ) : HopfIdeal R (coordinateHopfAlgebra R n) :=
+  GeneralLinear.Dynamic.weightUnipotentInParabolicHopfIdeal R (weights n)
+
+/-- The relative weight-unipotent ideal cuts out exactly the existing upper-unitriangular
+matrix group, compatibly with the upper-triangular inclusion into `GL_n`. -/
+@[simp]
+theorem mem_upperUnitriangularDefiningPointsSubgroup_iff
+    (R : Type u) [CommRing R] (n : ℕ) {A : Type v} [CommRing A] [Algebra R A]
+    (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R n)
+      (CommAlgCat.of R A)) :
+    f ∈ CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R n)
+        (upperUnitriangularDefiningHopfIdeal R n) (CommAlgCat.of R A) ↔
+      (pointsMulEquiv (R := R) (n := n) (A := A) f : GL (Fin n) A) ∈
+        upperUnitriangularGroup (Fin n) A := by
+  rw [upperUnitriangularDefiningHopfIdeal,
+    GeneralLinear.Dynamic.mem_weightUnipotentInParabolicPointsSubgroup_iff,
+    GeneralLinear.mem_weightUnipotentDefiningPointsSubgroup_iff,
+    UpperUnitriangularGroup.mem_iff, Matrix.isUpperUnitriangular_def,
+    GeneralLinear.pointsMulEquiv_apply, pointsMulEquiv_coe]
+  constructor
+  · intro h
+    refine ⟨?_, ?_⟩
+    · intro i j hji
+      have hne : i ≠ j := fun h ↦ hji.ne h.symm
+      have hw : weights n i ≤ weights n j :=
+        (weights_lt_weights_iff n i j).mpr hji |>.le
+      simpa [Matrix.one_apply, hne] using h i j hw
+    · intro i
+      simpa using h i i le_rfl
+  · rintro ⟨htri, hdiag⟩ i j hij
+    rcases hij.eq_or_lt with hij | hij
+    · have : i = j := weights_injective n hij
+      subst j
+      simpa using hdiag i
+    · have hji : j < i := (weights_lt_weights_iff n i j).mp hij
+      simpa [Matrix.one_apply, hji.ne'] using htri hji
+
+/-- The identified upper-unitriangular Hopf ideal in the finite-type coordinate algebra of the
 standard upper-triangular group. -/
 noncomputable def upperUnitriangularHopfIdeal (k : Type u) [Field k] (n : ℕ) :
     HopfIdeal k (finiteTypeCoordinateHopfAlgebra k n).obj :=
@@ -55,8 +98,8 @@ noncomputable def upperUnitriangularHopfIdeal (k : Type u) [Field k] (n : ℕ) :
     (ConcreteCategory.bijective_of_isIso e.hom).2
 
 /-- **The unipotent radical of the standard upper-triangular group is its
-upper-unitriangular subgroup.** The latter is expressed as the relative weight-unipotent Hopf
-ideal in the upper-triangular coordinate algebra. -/
+upper-unitriangular subgroup.** The latter is the finite-type form of the relative ideal
+identified pointwise by `mem_upperUnitriangularDefiningPointsSubgroup_iff`. -/
 theorem unipotentRadicalDefiningIdeal (k : Type u) [Field k] (n : ℕ) :
     FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
         (finiteTypeCoordinateHopfAlgebra k n) =

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
@@ -43,20 +43,6 @@ universe u v
 
 noncomputable section
 
-/-- The Hopf ideal in the upper-triangular coordinate algebra cutting out the
-upper-unitriangular subgroup. -/
-noncomputable def upperUnitriangularHopfIdeal
-    (R : Type u) [CommRing R] (n : ℕ) : HopfIdeal R (coordinateHopfAlgebra R n) :=
-  GeneralLinear.Dynamic.weightUnipotentInParabolicHopfIdeal R (weights n)
-
-/-- The upper-unitriangular Hopf ideal is the relative weight-unipotent ideal for the standard
-decreasing weights. -/
-theorem upperUnitriangularHopfIdeal_def
-    (R : Type u) [CommRing R] (n : ℕ) :
-    upperUnitriangularHopfIdeal R n =
-      GeneralLinear.Dynamic.weightUnipotentInParabolicHopfIdeal R (weights n) := by
-  rw [upperUnitriangularHopfIdeal]
-
 /-- The relative weight-unipotent ideal cuts out exactly the existing upper-unitriangular
 matrix group, compatibly with the upper-triangular inclusion into `GL_n`. -/
 @[simp]
@@ -65,11 +51,11 @@ theorem mem_upperUnitriangularPointsSubgroup_iff
     (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R n)
       (CommAlgCat.of R A)) :
     f ∈ CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R n)
-        (upperUnitriangularHopfIdeal R n) (CommAlgCat.of R A) ↔
+        (GeneralLinear.Dynamic.weightUnipotentInParabolicHopfIdeal R (weights n))
+        (CommAlgCat.of R A) ↔
       (pointsMulEquiv (R := R) (n := n) (A := A) f : GL (Fin n) A) ∈
         upperUnitriangularGroup (Fin n) A := by
-  rw [upperUnitriangularHopfIdeal_def,
-    GeneralLinear.Dynamic.mem_weightUnipotentInParabolicPointsSubgroup_iff,
+  rw [GeneralLinear.Dynamic.mem_weightUnipotentInParabolicPointsSubgroup_iff,
     GeneralLinear.mem_weightUnipotentDefiningPointsSubgroup_iff,
     UpperUnitriangularGroup.mem_iff, Matrix.isUpperUnitriangular_def,
     GeneralLinear.pointsMulEquiv_apply, pointsMulEquiv_coe]
@@ -103,8 +89,7 @@ theorem unipotentRadicalDefiningIdeal_finiteTypeCoordinateHopfAlgebra
       (eqToHom (finiteTypeCoordinateHopfAlgebra_obj k n).symm).hom
       (ConcreteCategory.bijective_of_isIso
         (eqToHom (finiteTypeCoordinateHopfAlgebra_obj k n).symm)).2 =
-      upperUnitriangularHopfIdeal k n := by
-  rw [upperUnitriangularHopfIdeal_def]
+      GeneralLinear.Dynamic.weightUnipotentInParabolicHopfIdeal k (weights n) := by
   let e : finiteTypeCoordinateHopfAlgebra k n ≅
       GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra k (weights n) :=
     ObjectProperty.isoMk _ <| eqToIso <|

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
@@ -120,8 +120,13 @@ theorem unipotentRadicalDefiningIdeal_finiteTypeCoordinateHopfAlgebra
             k (weights n)).symm := by
     simp only [e, ObjectProperty.isoMk_hom, ObjectProperty.homMk_hom, eqToIso.hom]
     rw [eqToHom_trans]
-  change e.hom.hom ((eqToHom (finiteTypeCoordinateHopfAlgebra_obj k n).symm).hom x) ∈ _ ↔ _
-  rw [← ConcreteCategory.comp_apply, hcomp]
+  have hcomp_apply :
+      e.hom.hom ((eqToHom (finiteTypeCoordinateHopfAlgebra_obj k n).symm).hom x) =
+        (eqToHom
+          (GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra_obj
+            k (weights n)).symm).hom x := by
+    rw [← ConcreteCategory.comp_apply, hcomp]
+  rw [hcomp_apply]
   exact iff_of_eq hx
 
 end

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Unipotent.Radical
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.UpperTriangular.Basic
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Isomorphism
+
+/-!
+# The unipotent radical of the upper-triangular group
+
+The standard upper-triangular group is the dynamic parabolic for the injective weights
+`i ↦ n - 1 - i`. Its weight-unipotent subgroup consists exactly of upper-unitriangular
+matrices. Specializing the injective-weight calculation therefore identifies this subgroup with
+the unipotent radical of the upper-triangular affine group.
+
+## Main declaration
+
+* `TauCeti.GeneralLinear.UpperTriangular.unipotentRadicalDefiningIdeal`:
+  the relative upper-unitriangular Hopf ideal is the unipotent-radical defining ideal.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Chapters 13 and 17.
+* T. A. Springer, *Linear Algebraic Groups*, Sections 6.2--6.3.
+
+This supplies the concrete unipotent radical of the standard Borel candidate required by Layers
+5 and 7 of the ReductiveGroups roadmap. Maximal solvability of that candidate remains downstream.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.GeneralLinear.UpperTriangular
+
+universe u
+
+noncomputable section
+
+/-- The relative upper-unitriangular Hopf ideal in the finite-type coordinate algebra of the
+standard upper-triangular group. -/
+noncomputable def upperUnitriangularHopfIdeal (k : Type u) [Field k] (n : ℕ) :
+    HopfIdeal k (finiteTypeCoordinateHopfAlgebra k n).obj :=
+  let e : finiteTypeCoordinateHopfAlgebra k n ≅
+      GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra k (weights n) :=
+    ObjectProperty.isoMk _ <| eqToIso <|
+      finiteTypeCoordinateHopfAlgebra_obj k n |>.trans <|
+        (GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k (weights n)).symm
+  (GeneralLinear.weightUnipotentInParabolicFiniteTypeHopfIdeal k (weights n)).comapOfSurjective
+    (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+    (ConcreteCategory.bijective_of_isIso e.hom).2
+
+/-- **The unipotent radical of the standard upper-triangular group is its
+upper-unitriangular subgroup.** The latter is expressed as the relative weight-unipotent Hopf
+ideal in the upper-triangular coordinate algebra. -/
+theorem unipotentRadicalDefiningIdeal (k : Type u) [Field k] (n : ℕ) :
+    FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+        (finiteTypeCoordinateHopfAlgebra k n) =
+      upperUnitriangularHopfIdeal k n := by
+  let e : finiteTypeCoordinateHopfAlgebra k n ≅
+      GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra k (weights n) :=
+    ObjectProperty.isoMk _ <| eqToIso <|
+      finiteTypeCoordinateHopfAlgebra_obj k n |>.trans <|
+        (GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k (weights n)).symm
+  rw [← FiniteTypeCommHopfAlgCat.comapOfSurjective_unipotentRadicalDefiningIdeal e,
+    unipotentRadicalDefiningIdeal_weightParabolicFiniteTypeCoordinateHopfAlgebra
+      k (weights n) (weights_injective n)]
+  dsimp [e, upperUnitriangularHopfIdeal]
+
+end
+
+end TauCeti.GeneralLinear.UpperTriangular

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/UpperTriangular/UnipotentRadical.lean
@@ -19,11 +19,13 @@ the unipotent radical of the upper-triangular affine group.
 
 ## Main declaration
 
-* `TauCeti.GeneralLinear.UpperTriangular.mem_upperUnitriangularDefiningPointsSubgroup_iff`:
+* `TauCeti.GeneralLinear.UpperTriangular.mem_upperUnitriangularPointsSubgroup_iff`:
   the relative weight-unipotent ideal cuts out exactly the existing upper-unitriangular matrix
   group over every commutative value algebra.
-* `TauCeti.GeneralLinear.UpperTriangular.unipotentRadicalDefiningIdeal`:
-  the relative upper-unitriangular Hopf ideal is the unipotent-radical defining ideal.
+* `TauCeti.GeneralLinear.UpperTriangular.
+    unipotentRadicalDefiningIdeal_finiteTypeCoordinateHopfAlgebra`:
+  after identifying the finite-type package's object with the upper-triangular coordinate
+  algebra, the relative upper-unitriangular Hopf ideal is the unipotent-radical defining ideal.
 
 ## References
 
@@ -46,22 +48,22 @@ noncomputable section
 
 /-- The Hopf ideal in the upper-triangular coordinate algebra cutting out the
 upper-unitriangular subgroup. -/
-noncomputable abbrev upperUnitriangularDefiningHopfIdeal
+noncomputable abbrev upperUnitriangularHopfIdeal
     (R : Type u) [CommRing R] (n : ℕ) : HopfIdeal R (coordinateHopfAlgebra R n) :=
   GeneralLinear.Dynamic.weightUnipotentInParabolicHopfIdeal R (weights n)
 
 /-- The relative weight-unipotent ideal cuts out exactly the existing upper-unitriangular
 matrix group, compatibly with the upper-triangular inclusion into `GL_n`. -/
 @[simp]
-theorem mem_upperUnitriangularDefiningPointsSubgroup_iff
+theorem mem_upperUnitriangularPointsSubgroup_iff
     (R : Type u) [CommRing R] (n : ℕ) {A : Type v} [CommRing A] [Algebra R A]
     (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R n)
       (CommAlgCat.of R A)) :
     f ∈ CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R n)
-        (upperUnitriangularDefiningHopfIdeal R n) (CommAlgCat.of R A) ↔
+        (upperUnitriangularHopfIdeal R n) (CommAlgCat.of R A) ↔
       (pointsMulEquiv (R := R) (n := n) (A := A) f : GL (Fin n) A) ∈
         upperUnitriangularGroup (Fin n) A := by
-  rw [upperUnitriangularDefiningHopfIdeal,
+  rw [upperUnitriangularHopfIdeal,
     GeneralLinear.Dynamic.mem_weightUnipotentInParabolicPointsSubgroup_iff,
     GeneralLinear.mem_weightUnipotentDefiningPointsSubgroup_iff,
     UpperUnitriangularGroup.mem_iff, Matrix.isUpperUnitriangular_def,
@@ -84,35 +86,43 @@ theorem mem_upperUnitriangularDefiningPointsSubgroup_iff
     · have hji : j < i := (weights_lt_weights_iff n i j).mp hij
       simpa [Matrix.one_apply, hji.ne'] using htri hji
 
-/-- The identified upper-unitriangular Hopf ideal in the finite-type coordinate algebra of the
-standard upper-triangular group. -/
-noncomputable def upperUnitriangularHopfIdeal (k : Type u) [Field k] (n : ℕ) :
-    HopfIdeal k (finiteTypeCoordinateHopfAlgebra k n).obj :=
-  let e : finiteTypeCoordinateHopfAlgebra k n ≅
-      GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra k (weights n) :=
-    ObjectProperty.isoMk _ <| eqToIso <|
-      finiteTypeCoordinateHopfAlgebra_obj k n |>.trans <|
-        (GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k (weights n)).symm
-  (GeneralLinear.weightUnipotentInParabolicFiniteTypeHopfIdeal k (weights n)).comapOfSurjective
-    (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
-    (ConcreteCategory.bijective_of_isIso e.hom).2
-
 /-- **The unipotent radical of the standard upper-triangular group is its
-upper-unitriangular subgroup.** The latter is the finite-type form of the relative ideal
-identified pointwise by `mem_upperUnitriangularDefiningPointsSubgroup_iff`. -/
-theorem unipotentRadicalDefiningIdeal (k : Type u) [Field k] (n : ℕ) :
-    FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
-        (finiteTypeCoordinateHopfAlgebra k n) =
+upper-unitriangular subgroup.** The relative ideal is identified pointwise by
+`mem_upperUnitriangularPointsSubgroup_iff`; the pullback presents the finite-type radical in that
+relative coordinate algebra. -/
+@[simp]
+theorem unipotentRadicalDefiningIdeal_finiteTypeCoordinateHopfAlgebra
+    (k : Type u) [Field k] (n : ℕ) :
+    (FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+        (finiteTypeCoordinateHopfAlgebra k n)).comapOfSurjective
+      (eqToHom (finiteTypeCoordinateHopfAlgebra_obj k n).symm).hom
+      (ConcreteCategory.bijective_of_isIso
+        (eqToHom (finiteTypeCoordinateHopfAlgebra_obj k n).symm)).2 =
       upperUnitriangularHopfIdeal k n := by
   let e : finiteTypeCoordinateHopfAlgebra k n ≅
       GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra k (weights n) :=
     ObjectProperty.isoMk _ <| eqToIso <|
       finiteTypeCoordinateHopfAlgebra_obj k n |>.trans <|
         (GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra_obj k (weights n)).symm
-  rw [← FiniteTypeCommHopfAlgCat.comapOfSurjective_unipotentRadicalDefiningIdeal e,
+  have hRadical :=
+    FiniteTypeCommHopfAlgCat.comapOfSurjective_unipotentRadicalDefiningIdeal e
+  have hWeight :=
     unipotentRadicalDefiningIdeal_weightParabolicFiniteTypeCoordinateHopfAlgebra
-      k (weights n) (weights_injective n)]
-  dsimp [e, upperUnitriangularHopfIdeal]
+      k (weights n) (weights_injective n)
+  ext x
+  rw [HopfIdeal.mem_comapOfSurjective, ← hRadical, HopfIdeal.mem_comapOfSurjective]
+  have hx := congrArg (fun I ↦ x ∈ I) hWeight
+  rw [HopfIdeal.mem_comapOfSurjective] at hx
+  have hcomp :
+      eqToHom (finiteTypeCoordinateHopfAlgebra_obj k n).symm ≫ e.hom.hom =
+        eqToHom
+          (GeneralLinear.weightParabolicFiniteTypeCoordinateHopfAlgebra_obj
+            k (weights n)).symm := by
+    simp only [e, ObjectProperty.isoMk_hom, ObjectProperty.homMk_hom, eqToIso.hom]
+    rw [eqToHom_trans]
+  change e.hom.hom ((eqToHom (finiteTypeCoordinateHopfAlgebra_obj k n).symm).hom x) ∈ _ ↔ _
+  rw [← ConcreteCategory.comp_apply, hcomp]
+  exact iff_of_eq hx
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Basic.lean
@@ -96,19 +96,20 @@ theorem kernelHopfIdeal_eq_augmentation_of_surjective (f : H ⟶ K)
   apply mem_kernelHopfIdeal_of_mem_augmentation f
   simpa only [CoalgHomClass.counit_comp_apply] using hy
 
+/-- The kernel Hopf ideal of a composite is the extension of the first morphism's kernel Hopf
+ideal along the second morphism. -/
+theorem kernelHopfIdeal_comp (f : H ⟶ K) {L : _root_.CommHopfAlgCat.{v} R} (g : K ⟶ L) :
+    kernelHopfIdeal (f ≫ g) = (kernelHopfIdeal f).map g.hom := by
+  rw [kernelHopfIdeal_def, kernelHopfIdeal_def, _root_.CommHopfAlgCat.hom_comp,
+    ← HopfIdeal.map_map]
+
 /-- Precomposing a coordinate morphism with a surjective morphism does not change its kernel
 closed subgroup scheme. -/
 theorem kernelHopfIdeal_comp_of_surjective (f : H ⟶ K)
     (hf : Function.Surjective f.hom) {L : _root_.CommHopfAlgCat.{v} R} (g : K ⟶ L) :
     kernelHopfIdeal (f ≫ g) = kernelHopfIdeal g := by
-  rw [kernelHopfIdeal_def, kernelHopfIdeal_def, _root_.CommHopfAlgCat.hom_comp,
-    ← HopfIdeal.map_map]
-  congr 1
-  apply le_antisymm (HopfIdeal.le_augmentation R K _) fun y hy ↦ ?_
-  obtain ⟨x, rfl⟩ := hf y
-  apply HopfIdeal.mem_map_of_mem
-  rw [HopfIdeal.mem_augmentation] at hy ⊢
-  simpa only [CoalgHomClass.counit_comp_apply] using hy
+  rw [kernelHopfIdeal_comp, kernelHopfIdeal_eq_augmentation_of_surjective f hf,
+    ← kernelHopfIdeal_def]
 
 -- Mathlib has no application lemma for `Bialgebra.unitBialgHom`; this contains its
 -- definitional unfolding to `algebraMap` in one place (upstream candidate).

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Basic.lean
@@ -96,6 +96,20 @@ theorem kernelHopfIdeal_eq_augmentation_of_surjective (f : H ⟶ K)
   apply mem_kernelHopfIdeal_of_mem_augmentation f
   simpa only [CoalgHomClass.counit_comp_apply] using hy
 
+/-- Precomposing a coordinate morphism with a surjective morphism does not change its kernel
+closed subgroup scheme. -/
+theorem kernelHopfIdeal_comp_of_surjective (f : H ⟶ K)
+    (hf : Function.Surjective f.hom) {L : _root_.CommHopfAlgCat.{v} R} (g : K ⟶ L) :
+    kernelHopfIdeal (f ≫ g) = kernelHopfIdeal g := by
+  rw [kernelHopfIdeal_def, kernelHopfIdeal_def, _root_.CommHopfAlgCat.hom_comp,
+    ← HopfIdeal.map_map]
+  congr 1
+  apply le_antisymm (HopfIdeal.le_augmentation R K _) fun y hy ↦ ?_
+  obtain ⟨x, rfl⟩ := hf y
+  apply HopfIdeal.mem_map_of_mem
+  rw [HopfIdeal.mem_augmentation] at hy ⊢
+  simpa only [CoalgHomClass.counit_comp_apply] using hy
+
 -- Mathlib has no application lemma for `Bialgebra.unitBialgHom`; this contains its
 -- definitional unfolding to `algebraMap` in one place (upstream candidate).
 private lemma unitBialgHom_apply {A : Type*} [Semiring A] [Bialgebra R A] (r : R) :

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/DiagonalizableQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/DiagonalizableQuotient.lean
@@ -12,21 +12,21 @@ public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Semisimple
 import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
 
 /-!
-# Unipotent radicals from diagonalizable quotients
+# Unipotent radicals from geometrically semisimple quotients
 
-Let `H` represent a finite-type affine group and let a morphism from a diagonalizable coordinate
-algebra to `H` represent a homomorphism from that group to a diagonalizable group. If its kernel
-is connected, normal, smooth, and unipotent, then that kernel is the unipotent radical.
+Let `H` represent a finite-type affine group and let a morphism from a coordinate algebra with
+geometrically semisimple points to `H` represent a quotient homomorphism from that group. If its
+kernel is connected, normal, smooth, and unipotent, then that kernel is the unipotent radical.
 
 Indeed, the kernel is contained in the radical by maximality. In the other direction, the image
-of the smooth unipotent radical in the diagonalizable target is reduced and unipotent, hence
-trivial. This forces the radical to lie in the kernel.
+of the smooth unipotent radical in the geometrically semisimple target is reduced and unipotent,
+hence trivial. This forces the radical to lie in the kernel.
 
 ## Main declaration
 
 * `TauCeti.FiniteTypeCommHopfAlgCat.
-    unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_diagonalizable`:
-  a unipotent kernel with diagonalizable target is the unipotent radical.
+    unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_geometricallySemisimple`:
+  a unipotent kernel with geometrically semisimple target is the unipotent radical.
 
 ## References
 
@@ -51,11 +51,12 @@ namespace FiniteTypeCommHopfAlgCat
 
 variable {k : Type u} [Field k]
 
-/-- A connected normal smooth unipotent kernel of a homomorphism to a diagonalizable group is
-the unipotent radical. -/
-theorem unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_diagonalizable
-    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (G : FGCommGrpCat.{u})
-    (f : (DiagonalizableGroup.coordinateRing k G).obj ⟶ H.obj)
+/-- A connected normal smooth unipotent kernel of a homomorphism to a group with geometrically
+semisimple points is the unipotent radical. -/
+theorem unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_geometricallySemisimple
+    (H D : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hD : geometricallySemisimplePointsCommHopfAlgProperty k D.obj)
+    (f : D.obj ⟶ H.obj)
     (hf : HopfIdeal.IsUnipotentRadicalCandidate H
       (CommHopfAlgCat.kernelHopfIdeal f)) :
     unipotentRadicalDefiningIdeal H = CommHopfAlgCat.kernelHopfIdeal f := by
@@ -65,7 +66,7 @@ theorem unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_diagonalizable
     let J := unipotentRadicalDefiningIdeal H
     let Q := quotient H J
     let q : H.obj ⟶ Q.obj := CommHopfAlgCat.mkQuotient H.obj J
-    let g : (DiagonalizableGroup.coordinateRing k G).obj ⟶ Q.obj := f ≫ q
+    let g : D.obj ⟶ Q.obj := f ≫ q
     have hQ := smoothUnipotent_unipotentRadical H
     have hQ' := (smoothUnipotentCommHopfAlgProperty_iff k Q).mp hQ
     let _ : Algebra.Smooth k Q := hQ'.1
@@ -79,25 +80,22 @@ theorem unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_diagonalizable
     have himage : geometricallyUnipotentPointsCommHopfAlgProperty k
         (CommHopfAlgCat.image g) :=
       geometricallyUnipotentPointsCommHopfAlgProperty.image_of_reduced g hQunipotent
-    have hker : HopfIdeal.ker g.hom =
-        HopfIdeal.augmentation k (DiagonalizableGroup.coordinateRing k G) :=
-      DiagonalizableGroup.eq_augmentation_of_geometricallyUnipotent k G
-        (HopfIdeal.ker g.hom) himage
+    have hker : HopfIdeal.ker g.hom = HopfIdeal.augmentation k D :=
+      eq_augmentation_of_geometricallySemisimple_of_geometricallyUnipotent
+        D (HopfIdeal.ker g.hom)
+        (geometricallySemisimplePointsCommHopfAlgProperty_of_surjective k
+          (mkQuotient D (HopfIdeal.ker g.hom)).hom
+          (Ideal.Quotient.mkₐ_surjective k (HopfIdeal.ker g.hom).toIdeal) hD)
+        himage
     have hg : g = _root_.CommHopfAlgCat.ofHom
         ((Bialgebra.unitBialgHom k Q.obj).comp
-          (Bialgebra.counitBialgHom k (DiagonalizableGroup.coordinateRing k G))) := by
-      apply _root_.CommHopfAlgCat.hom_ext
-      apply BialgHom.coe_fn_injective
-      funext x
-      have hx : x - algebraMap k (DiagonalizableGroup.coordinateRing k G)
-          (Coalgebra.counit (R := k) x) ∈
-          HopfIdeal.augmentation k (DiagonalizableGroup.coordinateRing k G) := by
-        rw [HopfIdeal.mem_augmentation]
-        simp
-      rw [← hker, HopfIdeal.mem_ker] at hx
-      change g.hom x = algebraMap k Q.obj (Coalgebra.counit (R := k) x)
-      rw [← sub_eq_zero]
-      simpa only [map_sub, AlgHomClass.commutes] using hx
+          (Bialgebra.counitBialgHom k D)) := by
+      rw [← Category.id_comp g]
+      apply (CommHopfAlgCat.comp_eq_unit_comp_counit_iff (𝟙 D.obj) g).mpr
+      rw [CommHopfAlgCat.kernelHopfIdeal_eq_augmentation_of_surjective
+          (𝟙 D.obj) Function.surjective_id,
+        ← hker, HopfIdeal.ker_toIdeal]
+      exact fun _ hx ↦ hx
     exact hg
 
 end FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/DiagonalizableQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/DiagonalizableQuotient.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Unipotent
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Kernel.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Construction
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Semisimple
+import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
+
+/-!
+# Unipotent radicals from diagonalizable quotients
+
+Let `H` represent a finite-type affine group and let a morphism from a diagonalizable coordinate
+algebra to `H` represent a homomorphism from that group to a diagonalizable group. If its kernel
+is connected, normal, smooth, and unipotent, then that kernel is the unipotent radical.
+
+Indeed, the kernel is contained in the radical by maximality. In the other direction, the image
+of the smooth unipotent radical in the diagonalizable target is reduced and unipotent, hence
+trivial. This forces the radical to lie in the kernel.
+
+## Main declaration
+
+* `TauCeti.FiniteTypeCommHopfAlgCat.
+    unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_diagonalizable`:
+  a unipotent kernel with diagonalizable target is the unipotent radical.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 12.40 and §§6.45--6.46.
+* A. Borel, *Linear Algebraic Groups*, §11.21.
+
+This is the quotient criterion used to identify concrete unipotent radicals in Layer 5 of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace FiniteTypeCommHopfAlgCat
+
+variable {k : Type u} [Field k]
+
+/-- A connected normal smooth unipotent kernel of a homomorphism to a diagonalizable group is
+the unipotent radical. -/
+theorem unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_diagonalizable
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (G : FGCommGrpCat.{u})
+    (f : (DiagonalizableGroup.coordinateRing k G).obj ⟶ H.obj)
+    (hf : HopfIdeal.IsUnipotentRadicalCandidate H
+      (CommHopfAlgCat.kernelHopfIdeal f)) :
+    unipotentRadicalDefiningIdeal H = CommHopfAlgCat.kernelHopfIdeal f := by
+  apply le_antisymm
+  · exact unipotentRadicalDefiningIdeal_le H _ hf
+  · rw [CommHopfAlgCat.kernelHopfIdeal_le_iff]
+    let J := unipotentRadicalDefiningIdeal H
+    let Q := quotient H J
+    let q : H.obj ⟶ Q.obj := CommHopfAlgCat.mkQuotient H.obj J
+    let g : (DiagonalizableGroup.coordinateRing k G).obj ⟶ Q.obj := f ≫ q
+    have hQ := smoothUnipotent_unipotentRadical H
+    have hQ' := (smoothUnipotentCommHopfAlgProperty_iff k Q).mp hQ
+    let _ : Algebra.Smooth k Q := hQ'.1
+    let _ : IsReduced Q := isReduced_of_smooth_of_field k Q
+    have hQunipotent : geometricallyUnipotentPointsCommHopfAlgProperty k Q.obj := by
+      rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff]
+      exact hQ'.2
+    let _ : IsReduced (CommHopfAlgCat.image g) :=
+      isReduced_of_injective (CommHopfAlgCat.imageι g).hom
+        (CommHopfAlgCat.imageι_injective g)
+    have himage : geometricallyUnipotentPointsCommHopfAlgProperty k
+        (CommHopfAlgCat.image g) :=
+      geometricallyUnipotentPointsCommHopfAlgProperty.image_of_reduced g hQunipotent
+    have hker : HopfIdeal.ker g.hom =
+        HopfIdeal.augmentation k (DiagonalizableGroup.coordinateRing k G) :=
+      DiagonalizableGroup.eq_augmentation_of_geometricallyUnipotent k G
+        (HopfIdeal.ker g.hom) himage
+    have hg : g = _root_.CommHopfAlgCat.ofHom
+        ((Bialgebra.unitBialgHom k Q.obj).comp
+          (Bialgebra.counitBialgHom k (DiagonalizableGroup.coordinateRing k G))) := by
+      apply _root_.CommHopfAlgCat.hom_ext
+      apply BialgHom.coe_fn_injective
+      funext x
+      have hx : x - algebraMap k (DiagonalizableGroup.coordinateRing k G)
+          (Coalgebra.counit (R := k) x) ∈
+          HopfIdeal.augmentation k (DiagonalizableGroup.coordinateRing k G) := by
+        rw [HopfIdeal.mem_augmentation]
+        simp
+      rw [← hker, HopfIdeal.mem_ker] at hx
+      change g.hom x = algebraMap k Q.obj (Coalgebra.counit (R := k) x)
+      rw [← sub_eq_zero]
+      simpa only [map_sub, AlgHomClass.commutes] using hx
+    exact hg
+
+end FiniteTypeCommHopfAlgCat
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/DiagonalizableQuotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/DiagonalizableQuotient.lean
@@ -32,9 +32,6 @@ hence trivial. This forces the radical to lie in the kernel.
 
 * J. S. Milne, *Algebraic Groups* (2017), Proposition 12.40 and §§6.45--6.46.
 * A. Borel, *Linear Algebraic Groups*, §11.21.
-
-This is the quotient criterion used to identify concrete unipotent radicals in Layer 5 of the
-ReductiveGroups roadmap.
 -/
 
 public section


### PR DESCRIPTION
This PR identifies the relative upper-unitriangular subgroup as the unipotent radical of the standard upper-triangular affine group. It advances the ReductiveGroups Layer 5 target “The unipotent radical `R_u(G)`” and supplies the concrete radical calculation needed by the Layer 7 “Borel subgroups, maximal tori” milestone.

The proof first establishes a reusable diagonalizable-quotient criterion: a connected normal smooth unipotent kernel of a morphism to a diagonalizable group is the unipotent radical. It then applies the represented dynamic Levi decomposition to every injective-weight parabolic and specializes the result to the standard decreasing weights. The small kernel-composition lemma and the promoted injectivity theorem expose exactly the existing infrastructure required by those arguments.

The mathematical argument follows the quotient criterion in Milne, *Algebraic Groups*, Proposition 12.40 and Chapters 13 and 17, together with the corresponding structure theory in Springer, *Linear Algebraic Groups*, Sections 6.2–6.3; no Mathlib implementation is vendored.

After this PR, maximal solvability of the standard upper-triangular group and the conjugacy results for Borel subgroups and maximal tori remain for the Layer 7 milestone.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"upper-triangular-unipotent-radical"}-->

🤖 Prepared with Codex
