### PR TITLE
feat: the p-adic numbers are a nonarchimedean local field

### DIFF
--- a/TauCeti/NumberTheory/LocalField/Padic.lean
+++ b/TauCeti/NumberTheory/LocalField/Padic.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.LocalField.Basic
+public import Mathlib.NumberTheory.Padics.ProperSpace
+public import Mathlib.NumberTheory.Padics.RingHoms
+public import Mathlib.NumberTheory.Padics.ValuativeRel
+public import TauCeti.Topology.Algebra.Valued.NormedValued
+
+/-!
+# The `p`-adic numbers are a nonarchimedean local field
+
+Mathlib equips `ℚ_[p]` with a `ValuativeRel`, coming from `Padic.mulValuation`, but leaves the
+comparison with the `p`-adic metric open: nothing says that the topology of `ℚ_[p]` is the one
+its valuation prescribes. This file supplies that comparison and the resulting instance
+`IsNonarchimedeanLocalField ℚ_[p]`, which is what makes `ℚ_[p]` a model of the general
+local-field theory rather than an unrelated normed field.
+
+Two consequences worth naming are recorded afterwards. The valuation integers `𝒪[ℚ_[p]]` are the
+subring `ℤ_[p]`, and the residue field `𝓀[ℚ_[p]]` is `ZMod p`, so the residue cardinality of
+`ℚ_[p]` is `p`.
+
+## Main results
+
+* `TauCeti.Padic.instIsValuativeTopology`: the `p`-adic metric topology is the valuative topology.
+* `TauCeti.Padic.instIsNonarchimedeanLocalField`: `ℚ_[p]` is a nonarchimedean local field.
+* `TauCeti.Padic.integer_eq_padicIntSubring` and `TauCeti.Padic.integerRingEquiv`: the valuation
+  integers of `ℚ_[p]` are `ℤ_[p]`.
+* `TauCeti.Padic.residueFieldEquiv` and `TauCeti.Padic.card_residueField`: the residue field of
+  `ℚ_[p]` is `ZMod p`, of cardinality `p`.
+
+The uniform structure carried by `ℚ_[p]` is the metric one, whereas the uniform-space
+consequences of `IsNonarchimedeanLocalField` — `CompleteSpace ℚ_[p]`, `CompleteSpace 𝒪[ℚ_[p]]`
+and `IsAdicComplete 𝓂[ℚ_[p]] 𝒪[ℚ_[p]]` — are stated for an arbitrary uniformity making the
+addition uniformly continuous. `IsUniformAddGroup.rightUniformSpace_eq` says that such a
+uniformity is the one of the underlying topological group, so no comparison specific to `ℚ_[p]`
+is needed and those instances are found by inference; the `example`s at the end of the file
+check that they are.
+-/
+
+public section
+
+open ValuativeRel
+
+namespace TauCeti.Padic
+
+variable (p : ℕ) [hp : Fact p.Prime]
+
+/-- The `p`-adic norm defines the same valuative relation on `ℚ_[p]` as `Padic.mulValuation`. -/
+instance instCompatibleNormedFieldValuation :
+    (_root_.NormedField.valuation (K := ℚ_[p])).Compatible where
+  vle_iff_le x y := by
+    rw [Valuation.Compatible.vle_iff_le (v := Padic.mulValuation)]
+    rcases eq_or_ne x 0 with rfl | hx
+    · simp
+    rcases eq_or_ne y 0 with rfl | hy
+    · simp [hx]
+    · rw [_root_.NormedField.valuation_apply, _root_.NormedField.valuation_apply,
+        ← NNReal.coe_le_coe, coe_nnnorm, coe_nnnorm, Padic.norm_eq_zpow_neg_valuation hx,
+        Padic.norm_eq_zpow_neg_valuation hy, zpow_le_zpow_iff_right₀ (mod_cast hp.out.one_lt)]
+      simp [Padic.mulValuation, hx, hy]
+
+/-- The `p`-adic metric topology on `ℚ_[p]` is the topology of its valuation. -/
+instance instIsValuativeTopology : IsValuativeTopology ℚ_[p] :=
+  NormedField.isValuativeTopology
+
+/-- `ℚ_[p]` is a nonarchimedean local field. -/
+instance instIsNonarchimedeanLocalField : IsNonarchimedeanLocalField ℚ_[p] where
+
+/-- The valuation integers of `ℚ_[p]` are the subring `ℤ_[p]` of `ℚ_[p]`. -/
+theorem integer_eq_padicIntSubring : 𝒪[ℚ_[p]] = PadicInt.subring p := by
+  ext x
+  simp [NormedField.mem_integer_iff_norm_le_one]
+
+/-- The ring of integers of the local field `ℚ_[p]` is the ring `ℤ_[p]` of `p`-adic integers. -/
+noncomputable def integerRingEquiv : 𝒪[ℚ_[p]] ≃+* ℤ_[p] :=
+  (RingEquiv.refl ℚ_[p]).restrict _ (PadicInt.subring p) fun _ ↦
+    NormedField.mem_integer_iff_norm_le_one.trans (PadicInt.mem_subring_iff p).symm
+
+/-- `integerRingEquiv` is the identity on the underlying `p`-adic numbers. -/
+@[simp]
+theorem coe_integerRingEquiv (x : 𝒪[ℚ_[p]]) :
+    ((integerRingEquiv p x : ℤ_[p]) : ℚ_[p]) = (x : ℚ_[p]) := (rfl)
+
+/-- The inverse of `integerRingEquiv` is the identity on the underlying `p`-adic numbers. -/
+@[simp]
+theorem coe_integerRingEquiv_symm (x : ℤ_[p]) :
+    (((integerRingEquiv p).symm x : 𝒪[ℚ_[p]]) : ℚ_[p]) = (x : ℚ_[p]) := (rfl)
+
+/-- The residue field of `ℚ_[p]` is `ZMod p`. -/
+noncomputable def residueFieldEquiv : 𝓀[ℚ_[p]] ≃+* ZMod p :=
+  (IsLocalRing.ResidueField.mapEquiv (integerRingEquiv p)).trans PadicInt.residueField
+
+/-- `residueFieldEquiv` sends the residue of `x` to the reduction of `x` modulo `p`. -/
+@[simp]
+theorem residueFieldEquiv_residue (x : 𝒪[ℚ_[p]]) :
+    residueFieldEquiv p (IsLocalRing.residue _ x) = PadicInt.toZMod (integerRingEquiv p x) := by
+  simp [residueFieldEquiv, IsLocalRing.ResidueField.map_residue,
+    PadicInt.toZMod_eq_residueField_comp_residue]
+
+/-- The residue cardinality of `ℚ_[p]` is `p`. -/
+@[simp]
+theorem card_residueField : Nat.card 𝓀[ℚ_[p]] = p := by
+  rw [Nat.card_congr (residueFieldEquiv p).toEquiv, Nat.card_zmod]
+
+-- The uniform-space consequences of `IsNonarchimedeanLocalField` fire for the metric uniformity
+-- of `ℚ_[p]`, with no comparison of uniformities supplied by hand.
+example : CompleteSpace ℚ_[p] := inferInstance
+example : CompleteSpace 𝒪[ℚ_[p]] := inferInstance
+example : IsAdicComplete 𝓂[ℚ_[p]] 𝒪[ℚ_[p]] := inferInstance
+
+end TauCeti.Padic

--- a/TauCeti/NumberTheory/LocalField/Padic.lean
+++ b/TauCeti/NumberTheory/LocalField/Padic.lean
@@ -62,7 +62,7 @@ instance instCompatibleNormedFieldValuation :
     · rw [_root_.NormedField.valuation_apply, _root_.NormedField.valuation_apply,
         ← NNReal.coe_le_coe, coe_nnnorm, coe_nnnorm, Padic.norm_eq_zpow_neg_valuation hx,
         Padic.norm_eq_zpow_neg_valuation hy, zpow_le_zpow_iff_right₀ (mod_cast hp.out.one_lt)]
-      simp [Padic.mulValuation, hx, hy]
+      simp [Padic.mulValuation, hx, hy, inv_le_inv₀]
 
 /-- The `p`-adic metric topology on `ℚ_[p]` is the topology of its valuation. -/
 instance instIsValuativeTopology : IsValuativeTopology ℚ_[p] :=
@@ -102,8 +102,10 @@ theorem residueFieldEquiv_residue (x : 𝒪[ℚ_[p]]) :
   simp [residueFieldEquiv, IsLocalRing.ResidueField.map_residue,
     PadicInt.toZMod_eq_residueField_comp_residue]
 
-/-- The residue cardinality of `ℚ_[p]` is `p`. -/
-@[simp]
+/-- The residue cardinality of `ℚ_[p]` is `p`.
+
+This is not a `simp` lemma: `Nat.card_eq_fintype_card` rewrites the left-hand side, so the
+statement is not in `simp`-normal form. -/
 theorem card_residueField : Nat.card 𝓀[ℚ_[p]] = p := by
   rw [Nat.card_congr (residueFieldEquiv p).toEquiv, Nat.card_zmod]
 

--- a/TauCeti/Topology/Algebra/Valued/NormedValued.lean
+++ b/TauCeti/Topology/Algebra/Valued/NormedValued.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.Valued.NormedValued
+public import Mathlib.Topology.Algebra.Valued.ValuativeRel
+
+/-!
+# The topology of a nonarchimedean normed field is valuative
+
+`Mathlib/Topology/Algebra/Valued/NormedValued.lean` turns an ultrametric normed field `K` into a
+`Valued K ℝ≥0` through its norm, and `Mathlib/Topology/Algebra/Valued/ValuativeRel.lean` records
+the predicate `IsValuativeTopology K` saying that the topology of `K` is the one its
+`ValuativeRel K` prescribes. This file joins the two: if the norm valuation
+`NormedField.valuation` is compatible with a valuative relation already present on `K`, then the
+metric topology of `K` is the valuative topology, and the valuation integers `𝒪[K]` are the
+closed unit ball.
+
+The comparison is what a normed field needs in order to be a model of the valuative theory:
+`Mathlib/NumberTheory/Padics/ValuativeRel.lean`, for instance, builds the valuative relation of
+`ℚ_[p]` from `Padic.mulValuation` and never mentions the `p`-adic metric.
+
+## Main results
+
+* `TauCeti.NormedField.valuation_le_valuation_iff_norm_le_norm`: the valuative order on `K` is
+  the order of the norm.
+* `TauCeti.NormedField.mem_integer_iff_norm_le_one`: `𝒪[K]` is the closed unit ball.
+* `TauCeti.NormedField.isValuativeTopology`: the metric topology is the valuative topology.
+
+No nontriviality of the norm is needed: the trivially normed, hence discrete, case is covered.
+-/
+
+public section
+
+open ValuativeRel
+
+namespace TauCeti.NormedField
+
+variable {K : Type*} [NormedField K] [IsUltrametricDist K] [ValuativeRel K]
+  [(_root_.NormedField.valuation (K := K)).Compatible]
+
+/-- Compatibility of the norm valuation with the valuative relation, read on the norm: the
+valuative order on `K` is the order of the norm. -/
+theorem valuation_le_valuation_iff_norm_le_norm (x y : K) :
+    valuation K x ≤ valuation K y ↔ ‖x‖ ≤ ‖y‖ := by
+  rw [ValuativeRel.isEquiv (valuation K) (_root_.NormedField.valuation (K := K)) x y]
+  simp [← NNReal.coe_le_coe]
+
+/-- The strict form of `TauCeti.NormedField.valuation_le_valuation_iff_norm_le_norm`. -/
+theorem valuation_lt_valuation_iff_norm_lt_norm (x y : K) :
+    valuation K x < valuation K y ↔ ‖x‖ < ‖y‖ := by
+  simp only [← not_le, valuation_le_valuation_iff_norm_le_norm]
+
+/-- The valuation integers of `K` are the elements of norm at most one. -/
+@[simp]
+theorem mem_integer_iff_norm_le_one {x : K} : x ∈ 𝒪[K] ↔ ‖x‖ ≤ 1 := by
+  rw [Valuation.mem_integer_iff, ← map_one (valuation K),
+    valuation_le_valuation_iff_norm_le_norm, norm_one]
+
+/-- The metric topology of an ultrametric normed field whose norm valuation is compatible with a
+valuative relation on it is the valuative topology. All of the content is Mathlib's
+`NormedField.toValued`, whose `is_topological_valuation` field is precisely the hypothesis of
+`IsValuativeTopology.of_mem_nhds_zero_iff_vle`. This is a `theorem` rather than an `instance`:
+the compatibility hypothesis is not something typeclass inference should search for on an
+arbitrary normed field. -/
+theorem isValuativeTopology : IsValuativeTopology K :=
+  letI := _root_.NormedField.toValued (K := K)
+  .of_mem_nhds_zero_iff_vle _ (Valued.is_topological_valuation _)
+
+end TauCeti.NormedField


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"LocalFieldsRamification","id":"is-nonarchimedean-local-field-q-p"}-->

This PR makes `ℚ_[p]` a nonarchimedean local field, closing the first milestone of Layer 0 of the LocalFieldsRamification roadmap, "`ℚ_p` is a local field: prove `IsValuativeTopology ℚ_[p]`, that is, the valuation topology is the norm topology, and derive `IsNonarchimedeanLocalField ℚ_[p]`, for every prime `p`". Mathlib already gives `ℚ_[p]` a `ValuativeRel` built from `Padic.mulValuation`, but it never compares that valuation with the `p`-adic metric, so neither instance existed and none of the general local-field theory applied to `ℚ_[p]`.

`TauCeti/Topology/Algebra/Valued/NormedValued.lean` supplies the comparison in the generality it holds: for an ultrametric normed field `K` whose norm valuation `NormedField.valuation` is compatible with a `ValuativeRel K`, the valuative order is the order of the norm (`TauCeti.NormedField.valuation_le_valuation_iff_norm_le_norm` and its strict form), the valuation integers are the closed unit ball (`TauCeti.NormedField.mem_integer_iff_norm_le_one`), and the metric topology is the valuative topology (`TauCeti.NormedField.isValuativeTopology`). No nontriviality of the norm is assumed, so the trivially normed and hence discrete case is covered. The proof is Mathlib's `NormedField.toValued`, from `Mathlib/Topology/Algebra/Valued/NormedValued.lean` by María Inés de Frutos-Fernández and Filippo A. E. Nuccio: its `is_topological_valuation` field is exactly the hypothesis of `IsValuativeTopology.of_mem_nhds_zero_iff_vle`. Nothing is vendored. The result is a `theorem` rather than an `instance`, because the compatibility hypothesis is not something instance search should look for on an arbitrary normed field.

`TauCeti/NumberTheory/LocalField/Padic.lean` instantiates it. It proves that the `p`-adic norm and `Padic.mulValuation` define the same valuative relation, deduces `IsValuativeTopology ℚ_[p]` and `IsNonarchimedeanLocalField ℚ_[p]` as global instances, and records the two identifications the later layers read off: `𝒪[ℚ_[p]]` is the subring `ℤ_[p]` (`integer_eq_padicIntSubring`, `integerRingEquiv`) and `𝓀[ℚ_[p]]` is `ZMod p`, of cardinality `p` (`residueFieldEquiv`, `card_residueField`). The roadmap flags the instance hygiene of `ℚ_[p]`, which carries a metric `UniformSpace`: the uniform-space consequences of `IsNonarchimedeanLocalField` are stated for any uniformity making the addition uniformly continuous, and `IsUniformAddGroup.rightUniformSpace_eq` already identifies such a uniformity with the one of the underlying topological group, so no comparison specific to `ℚ_[p]` is needed and none is added; three `example`s at the end of the file check that `CompleteSpace ℚ_[p]`, `CompleteSpace 𝒪[ℚ_[p]]` and `IsAdicComplete 𝓂[ℚ_[p]] 𝒪[ℚ_[p]]` are in fact found by inference.

What remains on this milestone after this PR is the normalized valuation of the next Layer 0 milestone, which is where the roadmap asks that `Padic.valuation` be compared with `v_K`, and the corresponding instance for a finite extension of `ℚ_[p]`, which the roadmap routes through Layer 0.III and which the generic theorem above is stated to serve.

Roadmap: LocalFieldsRamification

🤖 Prepared with Claude Code
