### PR TITLE
docs: add a "Contributing with the worker CLI" section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,103 @@ genus theory. When asked to work here, read the roadmap first (see `AGENTS.md`).
 Before starting a substantial piece of roadmap work, register and claim your intention so you
 don't collide with others; see [Coordinating work: intentions and claims](https://github.com/TauCetiProject/TauCetiRoadmap#coordinating-work-intentions-and-claims).
 
+## Contributing with the worker CLI
+
+The reviews above can be run one PR at a time, but most contribution here happens through a
+*worker*: a loop that picks one piece of work, does it, and stops. The exemplar is
+[`kim-em/TauCetiWorker`](https://github.com/kim-em/TauCetiWorker). With
+[uv](https://docs.astral.sh/uv/):
+
+```bash
+uv tool install git+https://github.com/kim-em/TauCetiWorker.git
+gh auth login     # the worker acts as this account, and tends its PRs
+tauceti doctor    # checklist of everything it needs
+```
+
+`tauceti doctor` is the place to start: it prints a row per prerequisite and tells you what is
+missing. You need `gh`, `git`, `uv/uvx`, `jq`, an authenticated `gh`, and `lake`, plus
+credentials for whichever agent you run (Codex or Claude). The `bubble`, `incus`, `pi` and
+`kiro` rows can stay missing unless you want the sandbox or an alternative agent.
+
+Then survey before you act:
+
+```bash
+tauceti status    # read-only: what work is available, and your quota
+tauceti work      # ONE unit of work, then exit
+tauceti work --loop
+```
+
+Run a bare `tauceti work` before ever using `--loop`, so you see one complete round end to end.
+
+**A round does exactly one thing.** It walks a fixed cascade and takes the first job that
+applies:
+
+```
+rebase → bump → progress → fix-ci → fix → review → roadmap
+```
+
+Maintenance deliberately outranks authoring, so if one of your PRs has a conflict or red CI, the
+worker fixes that *before* opening anything new. That is intended: PRs already in flight should
+not be starved by opening more of them. `tauceti work --dry-run` shows what a round would pick
+without acting.
+
+### Only review
+
+If you would rather review than author:
+
+```bash
+tauceti work --loop --only review
+```
+
+`--only` pins the round to a subset of the cascade and `--skip` drops one, and the two combine by
+subtraction. So `--skip roadmap` is "everything except opening new PRs" — a good setting if you
+want to help existing work land without adding to the queue.
+
+### Only one roadmap area
+
+Roadmap rounds pick a random area each time unless you say otherwise. To steer to one:
+
+```bash
+tauceti work --only roadmap --roadmap-only ReductiveGroups
+```
+
+The area is a subdirectory of the [TauCetiRoadmap](https://github.com/TauCetiProject/TauCetiRoadmap)
+repo. Conversely `--roadmap-skip AREA[,AREA...]` excludes areas, which is how concurrent workers
+divide the roadmap between them. Before starting substantial roadmap work, register your
+intention so you do not collide with others — the worker reads the intentions board and avoids
+claimed targets by default.
+
+### Pacing, so you don't burn your whole quota
+
+By default the worker paces itself against your subscription quota with the rule *used% must stay
+below elapsed%* — that is, it spreads usage evenly across the window rather than spending it all
+at once. You can shape that curve with `--pace`, given as `time%:budget%` control points:
+
+```bash
+# stay under 10% until the window is half gone, then allow up to 70%
+tauceti work --loop --pace 0:10,50:70,90:90
+```
+
+Points are linearly interpolated; an unspecified time 0 defaults to budget 0 and time 100 to
+budget 100. So a conservative curve keeps a reserve for your own interactive use, while a
+flatter one lets the worker work harder early. `$TAUCETI_PACE` sets a default, and the flag
+overrides it for one run.
+
+Two related notes. `--ignore-quota` skips the *pacer* but not the hard blocks — a window at 100%,
+or unreadable usage, still backs off. And if you want several workers on one machine, give each a
+distinct identity, which namespaces its state, checkout, review store and logs:
+
+```bash
+tauceti work --loop --worker-id alice --only review
+tauceti work --loop --worker-id bob   --only roadmap
+```
+
+With no `--worker-id`, each terminal auto-assigns the lowest free slot, so several can coexist
+without hand-numbering.
+
+Finally: merging, abandoning and de-duplicating PRs is the repo's CI, not the worker. Your job
+ends when a PR is green and reviewed.
+
 ---
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ missing. You need `gh`, `git`, `uv/uvx`, `jq`, an authenticated `gh`, and `lake`
 credentials for whichever agent you run (Codex or Claude). The `bubble`, `incus`, `pi` and
 `kiro` rows can stay missing unless you want the sandbox or an alternative agent.
 
+By default, agents run with unrestricted host access; see
+[sandboxing with `--bubble`](https://github.com/kim-em/TauCetiWorker/blob/main/docs/sandbox.md)
+for isolation.
+
 Then survey before you act:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ don't collide with others; see [Coordinating work: intentions and claims](https:
 ## Contributing with the worker CLI
 
 The reviews above can be run one PR at a time, but most contribution here happens through a
-*worker*: a loop that picks one piece of work, does it, and stops. The exemplar is
+*worker*. A single round picks one piece of work, does it, and stops; `--loop` runs rounds
+repeatedly until you interrupt it. The exemplar is
 [`kim-em/TauCetiWorker`](https://github.com/kim-em/TauCetiWorker). With
 [uv](https://docs.astral.sh/uv/):
 
@@ -263,8 +264,10 @@ keeps a reserve for your own interactive use, while the clock-rate curve spreads
 across the window. `$TAUCETI_PACE` sets a default, and the flag overrides it for one run.
 
 Two related notes. `--ignore-quota` skips the *pacer* but not the hard blocks — a window at 100%,
-or unreadable usage, still backs off. And if you want several workers on one machine, give each a
-distinct identity, which namespaces its state, checkout, review store and logs:
+or unreadable usage, still backs off; it also needs an explicit agent, since `auto` cannot choose
+without the pacer, as in `tauceti work --agent codex --ignore-quota`. And if you want several
+workers on one machine, give each a distinct identity, which namespaces its state, checkout,
+review store and logs:
 
 ```bash
 tauceti work --loop --worker-id alice --only review

--- a/README.md
+++ b/README.md
@@ -205,17 +205,14 @@ tauceti work --loop
 
 Run a bare `tauceti work` before ever using `--loop`, so you see one complete round end to end.
 
-**A round does exactly one thing.** It walks a fixed cascade and takes the first job that
-applies:
+Each round prioritizes maintenance and review before new formalization work; see
+[the cascade](https://github.com/kim-em/TauCetiWorker#what-a-round-does).
+`tauceti work --dry-run` shows what a round would pick without acting.
 
-```
-rebase → bump → progress → fix-ci → fix → review → roadmap
-```
-
-Maintenance deliberately outranks authoring, so if one of your PRs has a conflict or red CI, the
-worker fixes that *before* opening anything new. That is intended: PRs already in flight should
-not be starved by opening more of them. `tauceti work --dry-run` shows what a round would pick
-without acting.
+Subscription pacing can be controlled via
+[`--pace`](https://github.com/kim-em/TauCetiWorker#pacing-against-quota).
+For running several workers, see
+[the worker documentation](https://github.com/kim-em/TauCetiWorker#persistent-workers).
 
 ### Only review
 
@@ -225,57 +222,25 @@ If you would rather review than author:
 tauceti work --loop --only review
 ```
 
-`--only` pins the round to a subset of the cascade and `--skip` drops one, and the two combine by
-subtraction. So `--skip roadmap` is "everything except opening new PRs" — a good setting if you
-want to help existing work land without adding to the queue.
+`--skip roadmap` is "everything except opening new formalization PRs" — a good setting if you
+want to help existing work land.
 
 ### Only one roadmap area
 
 Roadmap rounds pick a random area each time unless you say otherwise. To steer to one:
 
 ```bash
-tauceti work --only roadmap --roadmap-only ReductiveGroups
+tauceti work --roadmap-only ReductiveGroups
 ```
+
+This keeps maintenance and review enabled. We discourage `--only roadmap`: it skips both,
+leaving existing PRs untended while opening new ones.
 
 The area is a subdirectory of the [TauCetiRoadmap](https://github.com/TauCetiProject/TauCetiRoadmap)
 repo. Conversely `--roadmap-skip AREA[,AREA...]` excludes areas, which is how concurrent workers
 divide the roadmap between them. Before starting substantial roadmap work, register your
 intention so you do not collide with others — the worker reads the intentions board and avoids
 claimed targets by default.
-
-### Pacing, so you don't burn your whole quota
-
-By default the worker paces itself against your subscription quota along the curve `60:40`: it
-may spend 40% of the quota by the time 60% of the window has elapsed, then ramps to the full quota
-by the reset, which holds back a reserve for work that arrives late in a window. You can shape
-that curve with `--pace`, given as `time%:budget%` control points:
-
-```bash
-# stay under 10% until the window is half gone, then allow up to 70%
-tauceti work --loop --pace 0:10,50:70,90:90
-
-# spend at clock rate: the plain "used% must stay below elapsed%" rule
-tauceti work --loop --pace 0:0,100:100
-```
-
-Points are linearly interpolated; an unspecified time 0 defaults to budget 0 and time 100 to
-budget 100, and usage must stay strictly below the interpolated budget. So a conservative curve
-keeps a reserve for your own interactive use, while the clock-rate curve spreads usage evenly
-across the window. `$TAUCETI_PACE` sets a default, and the flag overrides it for one run.
-
-Two related notes. `--ignore-quota` skips the *pacer* but not the hard blocks — a window at 100%,
-or unreadable usage, still backs off; it also needs an explicit agent, since `auto` cannot choose
-without the pacer, as in `tauceti work --agent codex --ignore-quota`. And if you want several
-workers on one machine, give each a distinct identity, which namespaces its state, checkout,
-review store and logs:
-
-```bash
-tauceti work --loop --worker-id alice --only review
-tauceti work --loop --worker-id bob   --only roadmap
-```
-
-With no `--worker-id`, each terminal auto-assigns the lowest free slot, so several can coexist
-without hand-numbering.
 
 Finally: merging, abandoning and de-duplicating PRs is the repo's CI, not the worker. Your job
 ends when a PR is green and reviewed.

--- a/README.md
+++ b/README.md
@@ -244,19 +244,23 @@ claimed targets by default.
 
 ### Pacing, so you don't burn your whole quota
 
-By default the worker paces itself against your subscription quota with the rule *used% must stay
-below elapsed%* — that is, it spreads usage evenly across the window rather than spending it all
-at once. You can shape that curve with `--pace`, given as `time%:budget%` control points:
+By default the worker paces itself against your subscription quota along the curve `60:40`: it
+may spend 40% of the quota by the time 60% of the window has elapsed, then ramps to the full quota
+by the reset, which holds back a reserve for work that arrives late in a window. You can shape
+that curve with `--pace`, given as `time%:budget%` control points:
 
 ```bash
 # stay under 10% until the window is half gone, then allow up to 70%
 tauceti work --loop --pace 0:10,50:70,90:90
+
+# spend at clock rate: the plain "used% must stay below elapsed%" rule
+tauceti work --loop --pace 0:0,100:100
 ```
 
 Points are linearly interpolated; an unspecified time 0 defaults to budget 0 and time 100 to
-budget 100. So a conservative curve keeps a reserve for your own interactive use, while a
-flatter one lets the worker work harder early. `$TAUCETI_PACE` sets a default, and the flag
-overrides it for one run.
+budget 100, and usage must stay strictly below the interpolated budget. So a conservative curve
+keeps a reserve for your own interactive use, while the clock-rate curve spreads usage evenly
+across the window. `$TAUCETI_PACE` sets a default, and the flag overrides it for one run.
 
 Two related notes. `--ignore-quota` skips the *pacer* but not the hard blocks — a window at 100%,
 or unreadable usage, still backs off. And if you want several workers on one machine, give each a


### PR DESCRIPTION
The README explains how to run a one-off review with `tauceti-review`, but not how to run a **worker** — which is how most ongoing contribution actually happens. This adds a section covering that, placed after Roadmaps so the roadmap concepts it refers to are already introduced.

It documents:

- **Install and first run** — `uv tool install git+https://github.com/kim-em/TauCetiWorker.git`, `gh auth login`, then `tauceti doctor`, which prints a per-prerequisite checklist. Recommends `tauceti status` and a bare `tauceti work` before ever using `--loop`, so a newcomer sees one complete round end to end.
- **The cascade** — `rebase → bump → progress → fix-ci → fix → review → roadmap`, one job per round, and *why* maintenance outranks authoring (PRs in flight shouldn't be starved by opening more).
- **Reviewing only** — `--only review`, and `--skip roadmap` for "help existing work land without adding to the queue".
- **A single roadmap area** — `--roadmap-only AREA` and `--roadmap-skip`, with a pointer to registering intentions first.
- **Pacing** — the default *used% < elapsed%* rule and how to shape it with `--pace 0:10,50:70,90:90`, so contributors can keep a reserve of their subscription quota for their own interactive use. Also notes that `--ignore-quota` skips the pacer but not the hard blocks, and how `--worker-id` namespaces concurrent workers.

Every flag and the cascade order are taken from `tauceti work -h` as installed, not from memory. Docs only — no code or Lean changes.

Happy to trim if this is more detail than the README wants; it could equally live in TauCetiWorker with a short pointer from here.