### PR TITLE
refactor(RootString): name the vanishing factor outside the G₂ truncation

### DIFF
--- a/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
+++ b/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
@@ -250,6 +250,32 @@ variable {R : Type v} [CommRing R] [Algebra ℤ R]
 -- Match tensor products to the module structure carried by the explicit `ℤ`-algebra.
 attribute [local instance high] Algebra.toModule
 
+/-- Outside the truncation the reordered sextuple already has a vanishing factor: if each family
+`D‹·›` vanishes from its own bound `k‹·›` onwards, then past
+`kx + ky + kz + 2 * kw + 3 * kv + 3 * ks` in either of the two weightings the product is zero.
+This is the vanishing half of `sum_smul_mul_sum_smul_of_chainG2Order`'s hypothesis, stated for
+arbitrary families so that the type-`G₂` proof only has to supply the six bounds. -/
+private theorem prod_eq_zero_of_le_of_chainG2Order {B : Type*} [Ring B]
+    (Dx Dy Dz Dw Dv Ds : ℕ → B) {kx ky kz kw kv ks : ℕ}
+    (hvx : ∀ n, kx ≤ n → Dx n = 0) (hvy : ∀ n, ky ≤ n → Dy n = 0)
+    (hvz : ∀ n, kz ≤ n → Dz n = 0) (hvw : ∀ n, kw ≤ n → Dw n = 0)
+    (hvv : ∀ n, kv ≤ n → Dv n = 0) (hvs : ∀ n, ks ≤ n → Ds n = 0) (a b c d e q : ℕ)
+    (h : kx + ky + kz + 2 * kw + 3 * kv + 3 * ks ≤ a + b + c + d + 2 * e ∨
+      kx + ky + kz + 2 * kw + 3 * kv + 3 * ks ≤ q + b + 2 * c + 3 * d + 3 * e) :
+    Dy a * Dz b * Dw c * Dv d * Ds e * Dx q = 0 := by
+  by_cases ha : ky ≤ a
+  · simp [hvy a ha]
+  · by_cases hq : kx ≤ q
+    · simp [hvx q hq]
+    · by_cases hb : kz ≤ b
+      · simp [hvz b hb]
+      · by_cases hc : kw ≤ c
+        · simp [hvw c hc]
+        · by_cases hd : kv ≤ d
+          · simp [hvv d hd]
+          · -- Every other index is below its bound, so either weighting forces `ks ≤ e`.
+            simp [hvs e (by omega)]
+
 /-- **The Chevalley commutator relation in type `G₂`.** If
 
 ```text
@@ -315,31 +341,13 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul
     simp only [map_mul, map_sum] at h
     exact h
   · -- Outside the truncation the reordered sextuple has a vanishing factor.
-    have hvx := forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) x M hMx hkx
-    have hvy := forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) y M hMy hky
-    have hvz := forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) z M hMz hkz
-    have hvw := forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) w M hMw hkw
-    have hvv := forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) v M hMv hkv
-    have hvs' := forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) s M hMs hks
-    rintro a b c d e q (habc | hqbc)
-    · rcases le_or_gt ky a with ha | ha
-      · simp [hvy a ha]
-      · rcases le_or_gt kz b with hb | hb
-        · simp [hvz b hb]
-        · rcases le_or_gt kw c with hc | hc
-          · simp [hvw c hc]
-          · rcases le_or_gt kv d with hd | hd
-            · simp [hvv d hd]
-            · simp [hvs' e (by omega)]
-    · rcases le_or_gt kx q with hq | hq
-      · simp [hvx q hq]
-      · rcases le_or_gt kz b with hb | hb
-        · simp [hvz b hb]
-        · rcases le_or_gt kw c with hc | hc
-          · simp [hvw c hc]
-          · rcases le_or_gt kv d with hd | hd
-            · simp [hvv d hd]
-            · simp [hvs' e (by omega)]
+    exact prod_eq_zero_of_le_of_chainG2Order _ _ _ _ _ _
+      (forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) x M hMx hkx)
+      (forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) y M hMy hky)
+      (forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) z M hMz hkz)
+      (forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) w M hMw hkw)
+      (forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) v M hMv hkv)
+      (forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) s M hMs hks)
 
 /-- The conjugation form of the Chevalley commutator relation in type `G₂`: conjugating the
 one-parameter subgroup of `y` by that of `x` multiplies it by the one-parameter subgroups of `z`,

--- a/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
+++ b/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
@@ -254,8 +254,9 @@ attribute [local instance high] Algebra.toModule
 `D‹·›` vanishes from its own bound `k‹·›` onwards, then past
 `kx + ky + kz + 2 * kw + 3 * kv + 3 * ks` in either of the two weightings the product is zero.
 This is the vanishing half of `sum_smul_mul_sum_smul_of_chainG2Order`'s hypothesis, stated for
-arbitrary families so that the type-`G₂` proof only has to supply the six bounds. -/
-private theorem prod_eq_zero_of_le_of_chainG2Order {B : Type*} [Ring B]
+arbitrary families over any `MulZeroClass` so that the type-`G₂` proof only has to supply the six
+bounds. -/
+private theorem mul_eq_zero_of_le_of_chainG2Order {B : Type*} [MulZeroClass B]
     (Dx Dy Dz Dw Dv Ds : ℕ → B) {kx ky kz kw kv ks : ℕ}
     (hvx : ∀ n, kx ≤ n → Dx n = 0) (hvy : ∀ n, ky ≤ n → Dy n = 0)
     (hvz : ∀ n, kz ≤ n → Dz n = 0) (hvw : ∀ n, kw ≤ n → Dw n = 0)
@@ -341,7 +342,7 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul
     simp only [map_mul, map_sum] at h
     exact h
   · -- Outside the truncation the reordered sextuple has a vanishing factor.
-    exact prod_eq_zero_of_le_of_chainG2Order _ _ _ _ _ _
+    exact mul_eq_zero_of_le_of_chainG2Order _ _ _ _ _ _
       (forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) x M hMx hkx)
       (forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) y M hMy hky)
       (forall_baseChange_integralDividedPower_eq_zero_of_le (R := R) z M hMz hkz)


### PR DESCRIPTION
Names the vanishing argument that `baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul`
was carrying inline.

## What was there

The theorem discharges `sum_smul_mul_sum_smul_of_chainG2Order`'s second hypothesis

```lean
(hzero : ∀ a b c d e q : ℕ,
  N ≤ a + b + c + d + 2 * e ∨ N ≤ q + b + 2 * c + 3 * d + 3 * e →
  Dy a * Dz b * Dw c * Dv d * Ds e * Dx q = 0)
```

with a nested `rcases le_or_gt` cascade, and its `b`/`c`/`d`/`e` tail was repeated **verbatim** in
both arms of the `rintro … (habc | hqbc)`.

## What this does

That argument says nothing about divided powers: it is a statement about arbitrary families that
vanish from a bound onwards. It becomes a `private` lemma above the theorem,
`mul_eq_zero_of_le_of_chainG2Order`, and the theorem now supplies only the six bounds — the whole
26-line bullet collapses to one `exact`.

**Stating it abstractly also simplified it.** Testing both `ky ≤ a` and `kx ≤ q` up front collapses
the two nested cascades into a single one, and `omega` closes the final step from whichever
disjunct holds — so the duplicated tail disappears rather than being relocated.

| | before | after |
|---|---|---|
| `baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul` body | **58** | **40** |
| its largest contiguous block | 26 | 8 |
| `mul_eq_zero_of_le_of_chainG2Order` body | — | 12 |
| file | 371 | 380 |

Measured with the same block profiler on before/after copies. The diff is 34 insertions /
25 deletions in one file. No existing statement, attribute or import changes, and both
neighbouring theorems are untouched.

## Two things a reviewer will reasonably ask

**Why is the helper stated for arbitrary families rather than for the divided powers at hand?**
Because that is all the proof uses. The bullet never touches `integralDividedPower`; it only needs
"each family is zero from its bound onwards". Specialising it to the divided-power families would
add six `M`/`hM` parameters and a `baseChange` layer that play no part in the argument, and would
make the lemma unusable for the sibling relations in this file. The abstract form is also what lets
the two cascades merge.

**Why the parameter count?** Six families, six bounds, six vanishing hypotheses and six indices is
simply the shape of `hzero`, which is the hypothesis being discharged; the file's own
`sum_smul_mul_sum_smul_of_chainG2Order` already carries a six-family signature for the same reason.
The bounds are implicit, so at the call site the helper takes six vanishing proofs and nothing else.

## Round 1 review

Both blocking findings are fixed at `c6e2a69`, as suggested:

* **generality** — the helper's proof uses only multiplication and zero, so `[Ring B]` is now the
  minimal `[MulZeroClass B]`. This strengthens the abstractness argument above rather than
  qualifying it: the lemma never needed addition, negation or a unit.
* **naming** — Mathlib reserves `prod` for `∏`/collection products, so the six-factor `*` chain is
  named with `mul`: `mul_eq_zero_of_le_of_chainG2Order`, matching this file's own
  `sum_smul_mul_sum_smul_of_chainG2Order`. Its single call site is updated.

The other eight rubrics approved on the previous head; nothing else changed.

Roadmap: ReductiveGroups

