### PR TITLE
feat(GroupTheory): character-column orthogonality and finite-abelian Fourier inversion

### DIFF
--- a/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
+++ b/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
@@ -61,8 +61,6 @@ left in the source, having no consumer here.
 
 public section
 
-namespace CommGroup
-
 variable {G : Type*} [Finite G] {M : Type*} [CommRing M] [IsDomain M]
 
 /-- The characters of a finite left-cancellative monoid valued in a domain form a `Fintype`.
@@ -72,6 +70,8 @@ invertibility is needed: `Finite (G →* Mˣ)` already holds at `LeftCancelMonoi
 this is stated. -/
 noncomputable instance instFintypeMonoidHomUnits [LeftCancelMonoid G] : Fintype (G →* Mˣ) :=
   Fintype.ofFinite _
+
+namespace CommGroup
 
 variable [CommGroup G] [HasEnoughRootsOfUnity M (Monoid.exponent G)]
 

--- a/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
+++ b/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.FiniteAbelian.Duality
-public import Mathlib.RingTheory.IntegralDomain
 
 /-!
 # Column orthogonality and Fourier inversion for finite commutative groups
@@ -22,8 +21,10 @@ supports.
   over all characters vanishes.
 * `CommGroup.card_mul_eq_sum_of_sum_char_mul_eq_zero`: a function whose nontrivial character
   moments all vanish is recovered from its average.
-* `CommGroup.eq_of_sum_char_mul_eq_zero`: over a characteristic-zero domain the same hypothesis
-  forces the function to be constant.
+* `CommGroup.sum_char_apply_eq_ite`: the same sum in normal form, `#G` at `g = 1` and `0`
+  elsewhere.
+* `CommGroup.eq_of_sum_char_mul_eq_zero`: when the dual cardinality is nonzero in `M`, the same
+  hypothesis forces the function to be constant.
 
 ## Row orthogonality is Mathlib's, and is deliberately not restated here
 
@@ -37,9 +38,14 @@ relation should use the Mathlib lemma directly. (`MulChar.sum_eq_zero_of_ne_one`
 `Mathlib/NumberTheory/MulChar/Basic.lean` is the same content in the `MulChar` vocabulary,
 stated over a finite ring rather than a finite group.)
 
-The column relation genuinely is not in Mathlib in this generality: it appears only in the
-`ZMod n` specialisation `DirichletCharacter.sum_characters_eq_zero`, in
-`Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean`.
+The column relation genuinely is not in Mathlib in this generality. It appears there only in
+specialisations: the `ZMod n` one, `DirichletCharacter.sum_characters_eq_zero` in
+`Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean`, and the finite-additive-group one
+over `ℂ`, `AddChar.sum_apply_eq_ite` in
+`Mathlib/Analysis/Fourier/FiniteAbelian/PontryaginDuality.lean` (with
+`AddChar.sum_apply_eq_zero_iff_ne_zero` beside it). Neither implies the statement below, which is
+multiplicative and valued in an arbitrary domain with enough roots of unity rather than in `ℂ`
+or over `ZMod n`.
 
 ## References
 
@@ -50,7 +56,7 @@ carries the row relation as `sum_char_self_eq_zero_of_ne_one`; that declaration 
 in favour of Mathlib's `sum_hom_units_eq_zero`, as described above.
 -/
 
-@[expose] public section
+public section
 
 namespace CommGroup
 
@@ -68,6 +74,18 @@ theorem sum_char_apply_eq_zero_of_ne_one [Finite G] [HasEnoughRootsOfUnity M (Mo
     fun h ↦ hχ₀ <| Units.val_eq_one.mp <| DFunLike.congr_fun h χ₀
 
 variable [Fintype G] [HasEnoughRootsOfUnity M (Monoid.exponent G)]
+
+/-- **Column orthogonality in normal form**: the character sum is the dual cardinality at the
+identity and vanishes elsewhere. This is the shape indicator-formula consumers want, since it
+covers both cases at once and already converts the dual cardinality to `#G`. -/
+theorem sum_char_apply_eq_ite [Fintype (G →* Mˣ)] [DecidableEq G] (g : G) :
+    ∑ χ : G →* Mˣ, (χ g : M) = if g = 1 then (Fintype.card G : M) else 0 := by
+  have hcard : Fintype.card (G →* Mˣ) = Fintype.card G := by
+    rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card,
+      card_monoidHom_of_hasEnoughRootsOfUnity]
+  split
+  · next hg => subst hg; simp [hcard]
+  · next hg => exact sum_char_apply_eq_zero_of_ne_one hg
 
 /-- **Finite-abelian Fourier inversion.** If every nontrivial character moment of `f : G → M`
 vanishes — `∑ s, χ s * f s = 0` for each `χ ≠ 1` — then `f` is recovered from its average: for
@@ -89,15 +107,16 @@ theorem card_mul_eq_sum_of_sum_char_mul_eq_zero [Fintype (G →* Mˣ)] (f : G �
         (Finset.sum_eq_single_of_mem (1 : G →* Mˣ) (Finset.mem_univ _)
           fun χ _ hχ ↦ by rw [hf χ hχ, mul_zero]).trans (by simp)
 
-/-- **Vanishing nontrivial Fourier coefficients force a constant.** Over a characteristic-zero
-domain, if every nontrivial character moment of `f : G → M` vanishes (`∑ s, χ s * f s = 0` for
-`χ ≠ 1`), then `f` takes the same value at every pair of points. -/
-theorem eq_of_sum_char_mul_eq_zero [CharZero M] (f : G → M)
+/-- **Vanishing nontrivial Fourier coefficients force a constant.** If every nontrivial character
+moment of `f : G → M` vanishes (`∑ s, χ s * f s = 0` for `χ ≠ 1`) and the dual cardinality is
+nonzero in `M`, then `f` takes the same value at every pair of points. -/
+theorem eq_of_sum_char_mul_eq_zero [Fintype (G →* Mˣ)]
+    (hcard : (Fintype.card (G →* Mˣ) : M) ≠ 0) (f : G → M)
     (hf : ∀ χ : G →* Mˣ, χ ≠ 1 → ∑ s : G, (χ s : M) * f s = 0) (u u' : G) : f u = f u' := by
   -- Immediate from `card_mul_eq_sum_of_sum_char_mul_eq_zero` — both values equal the common
-  -- average — after cancelling the nonzero dual cardinality.
-  have : Fintype (G →* Mˣ) := Fintype.ofFinite _
+  -- average — after cancelling the dual cardinality, which `hcard` assumes nonzero. Over a
+  -- characteristic-zero domain `hcard` is automatic from `Fintype.card_ne_zero`.
   have h := card_mul_eq_sum_of_sum_char_mul_eq_zero f hf
-  exact mul_left_cancel₀ (Nat.cast_ne_zero.mpr Fintype.card_ne_zero) <| (h u).trans (h u').symm
+  exact mul_left_cancel₀ hcard <| (h u).trans (h u').symm
 
 end CommGroup

--- a/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
+++ b/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
@@ -24,8 +24,8 @@ relation — the one summed over the character group — in both its punctured a
 
 The file also registers `Fintype (G →* Mˣ)`, which Mathlib leaves at `Finite`; without it a
 consumer's own character sum does not elaborate, and two ad-hoc `Fintype.ofFinite` introductions
-give syntactically distinct sums. That instance needs only `Group G`, so it also serves consumers
-indexing over the characters of a finite noncommutative group.
+give syntactically distinct sums. That instance needs only `LeftCancelMonoid G`, so it also serves
+consumers indexing over the characters of a finite noncommutative group or monoid.
 
 ## Row orthogonality is Mathlib's, and is deliberately not restated here
 
@@ -65,11 +65,12 @@ namespace CommGroup
 
 variable {G : Type*} [Finite G] {M : Type*} [CommRing M] [IsDomain M]
 
-/-- The characters of a finite group valued in a domain form a `Fintype`. Mathlib registers only
-`Finite (G →* Mˣ)`, so a character sum written by a consumer has no `Finset` to range over
-without this; it mirrors `AddChar.instFintype`. Commutativity of `G` is not required: the
-finiteness instance holds for any finite left-cancellative monoid into the units of a domain. -/
-noncomputable instance instFintypeMonoidHomUnits [Group G] : Fintype (G →* Mˣ) :=
+/-- The characters of a finite left-cancellative monoid valued in a domain form a `Fintype`.
+Mathlib registers only `Finite (G →* Mˣ)`, so a character sum written by a consumer has no
+`Finset` to range over without this; it mirrors `AddChar.instFintype`. Neither commutativity nor
+invertibility is needed: `Finite (G →* Mˣ)` already holds at `LeftCancelMonoid`, which is where
+this is stated. -/
+noncomputable instance instFintypeMonoidHomUnits [LeftCancelMonoid G] : Fintype (G →* Mˣ) :=
   Fintype.ofFinite _
 
 variable [CommGroup G] [HasEnoughRootsOfUnity M (Monoid.exponent G)]

--- a/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
+++ b/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.FiniteAbelian.Duality
+public import Mathlib.RingTheory.IntegralDomain
+
+/-!
+# Column orthogonality and Fourier inversion for finite commutative groups
+
+For a finite commutative group `G` and a domain `M` with enough roots of unity, the characters
+of `G` are the monoid homomorphisms `G →* Mˣ`. This file records the *column* orthogonality
+relation — the one summed over the character group — and the Fourier-inversion statement it
+supports.
+
+## Main results
+
+* `CommGroup.sum_char_apply_eq_zero_of_ne_one`: for `g ≠ 1`, the sum `∑ χ : G →* Mˣ, χ g`
+  over all characters vanishes.
+* `CommGroup.card_mul_eq_sum_of_sum_char_mul_eq_zero`: a function whose nontrivial character
+  moments all vanish is recovered from its average.
+* `CommGroup.eq_of_sum_char_mul_eq_zero`: over a characteristic-zero domain the same hypothesis
+  forces the function to be constant.
+
+## Row orthogonality is Mathlib's, and is deliberately not restated here
+
+The companion *row* relation — for a nontrivial `χ : G →* Mˣ`, the sum `∑ g : G, χ g` over the
+group vanishes — is already `sum_hom_units_eq_zero` in
+`Mathlib/RingTheory/IntegralDomain.lean`, which states exactly that for an arbitrary monoid
+homomorphism `G →* R` into a domain. Specialising it to a character is
+`sum_hom_units_eq_zero ((Units.coeHom M).comp χ)`, i.e. the Mathlib lemma composed with the
+unit coercion and nothing else, so no declaration for it is added. Callers wanting the row
+relation should use the Mathlib lemma directly. (`MulChar.sum_eq_zero_of_ne_one` in
+`Mathlib/NumberTheory/MulChar/Basic.lean` is the same content in the `MulChar` vocabulary,
+stated over a finite ring rather than a finite group.)
+
+The column relation genuinely is not in Mathlib in this generality: it appears only in the
+`ZMod n` specialisation `DirichletCharacter.sum_characters_eq_zero`, in
+`Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean`.
+
+## References
+
+Adapted from `CebotarevDensity/ForMathlib/CharacterOrthogonality.lean` of
+[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0,
+Birkbeck--Brasca) at commit `8575c9df1ae0a61120ab5c964c7911414254bec7`. The source file also
+carries the row relation as `sum_char_self_eq_zero_of_ne_one`; that declaration is dropped here
+in favour of Mathlib's `sum_hom_units_eq_zero`, as described above.
+-/
+
+@[expose] public section
+
+namespace CommGroup
+
+variable {G : Type*} [CommGroup G] {M : Type*} [CommRing M] [IsDomain M]
+
+/-- **Character-column orthogonality** for a finite commutative group `G` valued in a domain `M`
+with enough roots of unity: for `g ≠ 1`, the sum of `χ g` over all characters `χ : G →* Mˣ`
+vanishes. -/
+theorem sum_char_apply_eq_zero_of_ne_one [Finite G] [HasEnoughRootsOfUnity M (Monoid.exponent G)]
+    [Fintype (G →* Mˣ)] {g : G} (hg : g ≠ 1) : ∑ χ : G →* Mˣ, (χ g : M) = 0 := by
+  -- A specialisation of `sum_hom_units_eq_zero` on the dual group `G →* Mˣ` along the
+  -- evaluation homomorphism `χ ↦ χ g`.
+  obtain ⟨χ₀, hχ₀⟩ := exists_apply_ne_one_of_hasEnoughRootsOfUnity G M hg
+  exact sum_hom_units_eq_zero ((Units.coeHom M).comp (MonoidHom.eval g))
+    fun h ↦ hχ₀ <| Units.val_eq_one.mp <| DFunLike.congr_fun h χ₀
+
+variable [Fintype G] [HasEnoughRootsOfUnity M (Monoid.exponent G)]
+
+/-- **Finite-abelian Fourier inversion.** If every nontrivial character moment of `f : G → M`
+vanishes — `∑ s, χ s * f s = 0` for each `χ ≠ 1` — then `f` is recovered from its average: for
+every `u`, `(#(G →* Mˣ)) * f u = ∑ s, f s`. -/
+theorem card_mul_eq_sum_of_sum_char_mul_eq_zero [Fintype (G →* Mˣ)] (f : G → M)
+    (hf : ∀ χ : G →* Mˣ, χ ≠ 1 → ∑ s : G, (χ s : M) * f s = 0) (u : G) :
+    (Fintype.card (G →* Mˣ) : M) * f u = ∑ s : G, f s := by
+  -- column orthogonality: every `s ≠ u` term of the double sum below vanishes
+  calc (Fintype.card (G →* Mˣ) : M) * f u
+      = ∑ s : G, ∑ χ : G →* Mˣ, (χ (u⁻¹ * s) : M) * f s := by
+        rw [Finset.sum_eq_single_of_mem u (Finset.mem_univ _) fun s _ hs ↦ by
+          rw [← Finset.sum_mul, sum_char_apply_eq_zero_of_ne_one
+            fun h ↦ hs (inv_mul_eq_one.mp h).symm, zero_mul]]
+        simp
+    _ = ∑ χ : G →* Mˣ, (χ u⁻¹ : M) * ∑ s : G, (χ s : M) * f s :=
+        Finset.sum_comm.trans (by simp [Finset.mul_sum, mul_assoc])
+    -- the hypothesis collapses the character sum to its principal term
+    _ = ∑ s : G, f s :=
+        (Finset.sum_eq_single_of_mem (1 : G →* Mˣ) (Finset.mem_univ _)
+          fun χ _ hχ ↦ by rw [hf χ hχ, mul_zero]).trans (by simp)
+
+/-- **Vanishing nontrivial Fourier coefficients force a constant.** Over a characteristic-zero
+domain, if every nontrivial character moment of `f : G → M` vanishes (`∑ s, χ s * f s = 0` for
+`χ ≠ 1`), then `f` takes the same value at every pair of points. -/
+theorem eq_of_sum_char_mul_eq_zero [CharZero M] (f : G → M)
+    (hf : ∀ χ : G →* Mˣ, χ ≠ 1 → ∑ s : G, (χ s : M) * f s = 0) (u u' : G) : f u = f u' := by
+  -- Immediate from `card_mul_eq_sum_of_sum_char_mul_eq_zero` — both values equal the common
+  -- average — after cancelling the nonzero dual cardinality.
+  have : Fintype (G →* Mˣ) := Fintype.ofFinite _
+  have h := card_mul_eq_sum_of_sum_char_mul_eq_zero f hf
+  exact mul_left_cancel₀ (Nat.cast_ne_zero.mpr Fintype.card_ne_zero) <| (h u).trans (h u').symm
+
+end CommGroup

--- a/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
+++ b/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
@@ -36,8 +36,8 @@ homomorphism `G →* R` into a domain. Specialising it to a character is
 `sum_hom_units_eq_zero ((Units.coeHom M).comp χ)`, i.e. the Mathlib lemma composed with the
 unit coercion and nothing else, so no declaration for it is added. Callers wanting the row
 relation should use the Mathlib lemma directly. (`MulChar.sum_eq_zero_of_ne_one` in
-`Mathlib/NumberTheory/MulChar/Basic.lean` is the same content in the `MulChar` vocabulary,
-stated over a finite ring rather than a finite group.)
+`Mathlib/NumberTheory/MulChar/Basic.lean` is the analogous statement in the `MulChar`
+vocabulary, for a multiplicative character of a finite commutative monoid valued in a domain.)
 
 The column relation genuinely is not in Mathlib in this generality. It appears there only in
 specialisations: the `ZMod n` one, `DirichletCharacter.sum_characters_eq_zero` in
@@ -50,13 +50,10 @@ or over `ZMod n`.
 
 ## References
 
-Adapted from `CebotarevDensity/ForMathlib/CharacterOrthogonality.lean` of
-[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0,
-Birkbeck--Brasca) at commit `8575c9df1ae0a61120ab5c964c7911414254bec7`. Only the column relation
-is taken. The source's row relation `sum_char_self_eq_zero_of_ne_one` is dropped in favour of
-Mathlib's `sum_hom_units_eq_zero`, as described above, and its two Fourier-inversion
-consequences — that a function whose nontrivial character moments all vanish is constant — are
-left in the source, having no consumer here.
+Only `CommGroup.sum_monoidHom_apply_eq_zero_of_ne_one` is adapted from elsewhere: it comes from
+`sum_char_apply_eq_zero_of_ne_one` in `CebotarevDensity/ForMathlib/CharacterOrthogonality.lean`
+of [CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0,
+Birkbeck--Brasca) at commit `8575c9df1ae0a61120ab5c964c7911414254bec7`.
 -/
 
 public section

--- a/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
+++ b/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
@@ -24,7 +24,8 @@ relation — the one summed over the character group — in both its punctured a
 
 The file also registers `Fintype (G →* Mˣ)`, which Mathlib leaves at `Finite`; without it a
 consumer's own character sum does not elaborate, and two ad-hoc `Fintype.ofFinite` introductions
-give syntactically distinct sums.
+give syntactically distinct sums. That instance needs only `Group G`, so it also serves consumers
+indexing over the characters of a finite noncommutative group.
 
 ## Row orthogonality is Mathlib's, and is deliberately not restated here
 
@@ -62,14 +63,16 @@ public section
 
 namespace CommGroup
 
-variable {G : Type*} [CommGroup G] [Finite G] {M : Type*} [CommRing M] [IsDomain M]
+variable {G : Type*} [Finite G] {M : Type*} [CommRing M] [IsDomain M]
 
-/-- The characters of a finite commutative group valued in a domain form a `Fintype`. Mathlib
-registers only `Finite (G →* Mˣ)`, so a character sum written by a consumer has no `Finset` to
-range over without this; it mirrors `AddChar.instFintype`. -/
-noncomputable instance instFintypeMonoidHomUnits : Fintype (G →* Mˣ) := Fintype.ofFinite _
+/-- The characters of a finite group valued in a domain form a `Fintype`. Mathlib registers only
+`Finite (G →* Mˣ)`, so a character sum written by a consumer has no `Finset` to range over
+without this; it mirrors `AddChar.instFintype`. Commutativity of `G` is not required: the
+finiteness instance holds for any finite left-cancellative monoid into the units of a domain. -/
+noncomputable instance instFintypeMonoidHomUnits [Group G] : Fintype (G →* Mˣ) :=
+  Fintype.ofFinite _
 
-variable [HasEnoughRootsOfUnity M (Monoid.exponent G)]
+variable [CommGroup G] [HasEnoughRootsOfUnity M (Monoid.exponent G)]
 
 /-- **Character-column orthogonality** for a finite commutative group `G` valued in a domain `M`
 with enough roots of unity: for `g ≠ 1`, the sum of `χ g` over all characters `χ : G →* Mˣ`

--- a/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
+++ b/TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean
@@ -8,23 +8,23 @@ module
 public import Mathlib.GroupTheory.FiniteAbelian.Duality
 
 /-!
-# Column orthogonality and Fourier inversion for finite commutative groups
+# Column orthogonality for characters of a finite commutative group
 
 For a finite commutative group `G` and a domain `M` with enough roots of unity, the characters
 of `G` are the monoid homomorphisms `G →* Mˣ`. This file records the *column* orthogonality
-relation — the one summed over the character group — and the Fourier-inversion statement it
-supports.
+relation — the one summed over the character group — in both its punctured and its normal form.
 
 ## Main results
 
-* `CommGroup.sum_char_apply_eq_zero_of_ne_one`: for `g ≠ 1`, the sum `∑ χ : G →* Mˣ, χ g`
+* `CommGroup.sum_monoidHom_apply_eq_zero_of_ne_one`: for `g ≠ 1`, the sum `∑ χ : G →* Mˣ, χ g`
   over all characters vanishes.
-* `CommGroup.card_mul_eq_sum_of_sum_char_mul_eq_zero`: a function whose nontrivial character
-  moments all vanish is recovered from its average.
-* `CommGroup.sum_char_apply_eq_ite`: the same sum in normal form, `#G` at `g = 1` and `0`
-  elsewhere.
-* `CommGroup.eq_of_sum_char_mul_eq_zero`: when the dual cardinality is nonzero in `M`, the same
-  hypothesis forces the function to be constant.
+* `CommGroup.sum_monoidHom_apply_eq_ite`: the same sum in normal form, `Nat.card G` at `g = 1`
+  and `0` elsewhere. This is the shape an indicator-formula consumer wants, and it is the `simp`
+  normal form for such a sum.
+
+The file also registers `Fintype (G →* Mˣ)`, which Mathlib leaves at `Finite`; without it a
+consumer's own character sum does not elaborate, and two ad-hoc `Fintype.ofFinite` introductions
+give syntactically distinct sums.
 
 ## Row orthogonality is Mathlib's, and is deliberately not restated here
 
@@ -51,72 +51,51 @@ or over `ZMod n`.
 
 Adapted from `CebotarevDensity/ForMathlib/CharacterOrthogonality.lean` of
 [CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0,
-Birkbeck--Brasca) at commit `8575c9df1ae0a61120ab5c964c7911414254bec7`. The source file also
-carries the row relation as `sum_char_self_eq_zero_of_ne_one`; that declaration is dropped here
-in favour of Mathlib's `sum_hom_units_eq_zero`, as described above.
+Birkbeck--Brasca) at commit `8575c9df1ae0a61120ab5c964c7911414254bec7`. Only the column relation
+is taken. The source's row relation `sum_char_self_eq_zero_of_ne_one` is dropped in favour of
+Mathlib's `sum_hom_units_eq_zero`, as described above, and its two Fourier-inversion
+consequences — that a function whose nontrivial character moments all vanish is constant — are
+left in the source, having no consumer here.
 -/
 
 public section
 
 namespace CommGroup
 
-variable {G : Type*} [CommGroup G] {M : Type*} [CommRing M] [IsDomain M]
+variable {G : Type*} [CommGroup G] [Finite G] {M : Type*} [CommRing M] [IsDomain M]
+
+/-- The characters of a finite commutative group valued in a domain form a `Fintype`. Mathlib
+registers only `Finite (G →* Mˣ)`, so a character sum written by a consumer has no `Finset` to
+range over without this; it mirrors `AddChar.instFintype`. -/
+noncomputable instance instFintypeMonoidHomUnits : Fintype (G →* Mˣ) := Fintype.ofFinite _
+
+variable [HasEnoughRootsOfUnity M (Monoid.exponent G)]
 
 /-- **Character-column orthogonality** for a finite commutative group `G` valued in a domain `M`
 with enough roots of unity: for `g ≠ 1`, the sum of `χ g` over all characters `χ : G →* Mˣ`
 vanishes. -/
-theorem sum_char_apply_eq_zero_of_ne_one [Finite G] [HasEnoughRootsOfUnity M (Monoid.exponent G)]
-    [Fintype (G →* Mˣ)] {g : G} (hg : g ≠ 1) : ∑ χ : G →* Mˣ, (χ g : M) = 0 := by
+theorem sum_monoidHom_apply_eq_zero_of_ne_one {g : G} (hg : g ≠ 1) :
+    ∑ χ : G →* Mˣ, (χ g : M) = 0 := by
   -- A specialisation of `sum_hom_units_eq_zero` on the dual group `G →* Mˣ` along the
   -- evaluation homomorphism `χ ↦ χ g`.
   obtain ⟨χ₀, hχ₀⟩ := exists_apply_ne_one_of_hasEnoughRootsOfUnity G M hg
   exact sum_hom_units_eq_zero ((Units.coeHom M).comp (MonoidHom.eval g))
     fun h ↦ hχ₀ <| Units.val_eq_one.mp <| DFunLike.congr_fun h χ₀
 
-variable [Fintype G] [HasEnoughRootsOfUnity M (Monoid.exponent G)]
-
-/-- **Column orthogonality in normal form**: the character sum is the dual cardinality at the
-identity and vanishes elsewhere. This is the shape indicator-formula consumers want, since it
-covers both cases at once and already converts the dual cardinality to `#G`. -/
-theorem sum_char_apply_eq_ite [Fintype (G →* Mˣ)] [DecidableEq G] (g : G) :
-    ∑ χ : G →* Mˣ, (χ g : M) = if g = 1 then (Fintype.card G : M) else 0 := by
-  have hcard : Fintype.card (G →* Mˣ) = Fintype.card G := by
-    rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card,
-      card_monoidHom_of_hasEnoughRootsOfUnity]
+/-- **Column orthogonality in normal form**: the character sum is `Nat.card G` at the identity
+and vanishes elsewhere. This covers both cases at once, and states the identity value as the
+cardinality of `G` itself rather than of its dual, which is the shape an indicator-formula
+consumer wants. -/
+@[simp]
+theorem sum_monoidHom_apply_eq_ite [DecidableEq G] (g : G) :
+    ∑ χ : G →* Mˣ, (χ g : M) = if g = 1 then (Nat.card G : M) else 0 := by
   split
-  · next hg => subst hg; simp [hcard]
-  · next hg => exact sum_char_apply_eq_zero_of_ne_one hg
-
-/-- **Finite-abelian Fourier inversion.** If every nontrivial character moment of `f : G → M`
-vanishes — `∑ s, χ s * f s = 0` for each `χ ≠ 1` — then `f` is recovered from its average: for
-every `u`, `(#(G →* Mˣ)) * f u = ∑ s, f s`. -/
-theorem card_mul_eq_sum_of_sum_char_mul_eq_zero [Fintype (G →* Mˣ)] (f : G → M)
-    (hf : ∀ χ : G →* Mˣ, χ ≠ 1 → ∑ s : G, (χ s : M) * f s = 0) (u : G) :
-    (Fintype.card (G →* Mˣ) : M) * f u = ∑ s : G, f s := by
-  -- column orthogonality: every `s ≠ u` term of the double sum below vanishes
-  calc (Fintype.card (G →* Mˣ) : M) * f u
-      = ∑ s : G, ∑ χ : G →* Mˣ, (χ (u⁻¹ * s) : M) * f s := by
-        rw [Finset.sum_eq_single_of_mem u (Finset.mem_univ _) fun s _ hs ↦ by
-          rw [← Finset.sum_mul, sum_char_apply_eq_zero_of_ne_one
-            fun h ↦ hs (inv_mul_eq_one.mp h).symm, zero_mul]]
-        simp
-    _ = ∑ χ : G →* Mˣ, (χ u⁻¹ : M) * ∑ s : G, (χ s : M) * f s :=
-        Finset.sum_comm.trans (by simp [Finset.mul_sum, mul_assoc])
-    -- the hypothesis collapses the character sum to its principal term
-    _ = ∑ s : G, f s :=
-        (Finset.sum_eq_single_of_mem (1 : G →* Mˣ) (Finset.mem_univ _)
-          fun χ _ hχ ↦ by rw [hf χ hχ, mul_zero]).trans (by simp)
-
-/-- **Vanishing nontrivial Fourier coefficients force a constant.** If every nontrivial character
-moment of `f : G → M` vanishes (`∑ s, χ s * f s = 0` for `χ ≠ 1`) and the dual cardinality is
-nonzero in `M`, then `f` takes the same value at every pair of points. -/
-theorem eq_of_sum_char_mul_eq_zero [Fintype (G →* Mˣ)]
-    (hcard : (Fintype.card (G →* Mˣ) : M) ≠ 0) (f : G → M)
-    (hf : ∀ χ : G →* Mˣ, χ ≠ 1 → ∑ s : G, (χ s : M) * f s = 0) (u u' : G) : f u = f u' := by
-  -- Immediate from `card_mul_eq_sum_of_sum_char_mul_eq_zero` — both values equal the common
-  -- average — after cancelling the dual cardinality, which `hcard` assumes nonzero. Over a
-  -- characteristic-zero domain `hcard` is automatic from `Fintype.card_ne_zero`.
-  have h := card_mul_eq_sum_of_sum_char_mul_eq_zero f hf
-  exact mul_left_cancel₀ hcard <| (h u).trans (h u').symm
+  · next hg =>
+    subst hg
+    -- the dual of `G` has the cardinality of `G`, by Mathlib's character duality
+    have hcard : Fintype.card (G →* Mˣ) = Nat.card G := by
+      simpa using card_monoidHom_of_hasEnoughRootsOfUnity G M
+    simp [hcard]
+  · next hg => exact sum_monoidHom_apply_eq_zero_of_ne_one hg
 
 end CommGroup

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Basic.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Basic.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.RingTheory.RootsOfUnity.EnoughRootsOfUnity
 public import Mathlib.LinearAlgebra.Eigenspace.Pi
 public import Mathlib.LinearAlgebra.Eigenspace.Semisimple
-public import TauCeti.GroupTheory.FiniteAbelian.CharacterOrthogonality
+import TauCeti.GroupTheory.FiniteAbelian.CharacterOrthogonality
 
 /-!
 # Joint eigenvectors of commuting semisimple families

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Basic.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Basic.lean
@@ -5,10 +5,10 @@ Authors: Chris Birkbeck
 -/
 module
 
-import Mathlib.NumberTheory.MulChar.Duality
 public import Mathlib.RingTheory.RootsOfUnity.EnoughRootsOfUnity
 public import Mathlib.LinearAlgebra.Eigenspace.Pi
 public import Mathlib.LinearAlgebra.Eigenspace.Semisimple
+public import TauCeti.GroupTheory.FiniteAbelian.CharacterOrthogonality
 
 /-!
 # Joint eigenvectors of commuting semisimple families
@@ -314,9 +314,6 @@ variable [CommGroup G] [Finite G]
 private noncomputable instance : Fintype G :=
   Fintype.ofFinite _
 
-private noncomputable instance : Fintype (G →* Kˣ) :=
-  Fintype.ofFinite _
-
 open Finset
 
 variable {ρ : G →* Module.End K V}
@@ -349,41 +346,6 @@ private lemma fourierComponent_mem (χ₀ : G →* Kˣ) (v : V) (g : G) :
 
 variable [HasEnoughRootsOfUnity K (Monoid.exponent G)]
 
-private instance : HasEnoughRootsOfUnity K (Monoid.exponent Gˣ) :=
-  Monoid.exponent_eq_of_mulEquiv (toUnits (G := G)).symm ▸ inferInstance
-
--- the character group of a finite commutative group over a commutative domain with enough
--- roots of unity has the size of the group, by Mathlib's character duality
-omit [IsDomain K] in
-private lemma card_unitHom : Nat.card (G →* Kˣ) = Nat.card G := by
-  rw [Nat.card_congr (MulChar.equivToUnitHom.trans
-      (toUnits (G := G)).monoidHomCongrLeftEquiv.symm).symm,
-    MulChar.card_eq_card_units_of_hasEnoughRootsOfUnity G K,
-    Nat.card_congr (toUnits (G := G)).toEquiv.symm]
-
-/-- Evaluation at `d`, as a multiplicative character of the finite character group `G →* Kˣ`. -/
-private noncomputable def evalCharHom (d : G) : MulChar (G →* Kˣ) K :=
-  MulChar.ofUnitHom ((MonoidHom.eval d).comp (Units.coeHom (G →* Kˣ)))
-
-omit [Finite G] [HasEnoughRootsOfUnity K (Monoid.exponent G)] in
-omit [IsDomain K] in
-private lemma evalCharHom_apply (d : G) (χ : G →* Kˣ) :
-    evalCharHom (K := K) d χ = ((χ d : Kˣ) : K) := by
-  simpa [evalCharHom] using
-    MulChar.ofUnitHom_coe ((MonoidHom.eval d).comp (Units.coeHom (G →* Kˣ))) (toUnits χ)
-
--- second orthogonality, from Mathlib's character-sum vanishing applied to `evalCharHom d`
-private lemma sum_unitHom_apply_eq_zero
-    {d : G} (hd : d ≠ 1) :
-    ∑ χ : G →* Kˣ, ((χ d : Kˣ) : K) = 0 := by
-  obtain ⟨ψ, hψ⟩ := CommGroup.exists_apply_ne_one_of_hasEnoughRootsOfUnity G K hd
-  have hne : evalCharHom (K := K) d ≠ 1 := fun h ↦ hψ <| by
-    have hval := congrArg (fun χ : MulChar (G →* Kˣ) K ↦ χ ψ) h
-    rw [evalCharHom_apply, MulChar.one_apply (Group.isUnit ψ)] at hval
-    exact Units.val_eq_one.mp hval
-  simpa [evalCharHom_apply] using MulChar.sum_eq_zero_of_ne_one hne
-
-
 -- every vector is the sum of its projections, by second orthogonality
 private lemma sum_fourierComponent (hunit : IsUnit (Nat.card G : K)) (v : V) :
     ∑ χ₀ : G →* Kˣ, fourierComponent (ρ := ρ) χ₀ v = v := by
@@ -397,13 +359,13 @@ private lemma sum_fourierComponent (hunit : IsUnit (Nat.card G : K)) (v : V) :
   rw [Finset.sum_congr rfl fun d _ ↦ hcol d]
   have hsplit : ∀ d : G, d ≠ 1 → (∑ χ₀ : G →* Kˣ, ((χ₀ d⁻¹ : Kˣ) : K)) • ρ d v = 0 := by
     intro d hd
-    rw [sum_unitHom_apply_eq_zero (by simpa using hd), zero_smul]
+    rw [CommGroup.sum_monoidHom_apply_eq_zero_of_ne_one (M := K) (by simpa using hd), zero_smul]
   rw [Finset.sum_eq_single 1 (fun d _ hd ↦ hsplit d hd) (by simp)]
   have hone : ∀ χ₀ : G →* Kˣ, ((χ₀ (1 : G)⁻¹ : Kˣ) : K) = 1 := by simp
   rw [Finset.sum_congr rfl fun χ₀ _ ↦ hone χ₀]
   have hcard : (∑ _χ₀ : G →* Kˣ, (1 : K)) = (Nat.card G : K) := by
     rw [Finset.sum_const, card_univ, nsmul_eq_mul, mul_one, ← Nat.card_eq_fintype_card,
-      card_unitHom]
+      CommGroup.card_monoidHom_of_hasEnoughRootsOfUnity G K]
   rw [hcard, map_one, Module.End.one_apply, smul_smul,
     Ring.inverse_mul_cancel _ hunit, one_smul]
 


### PR DESCRIPTION
Adds `TauCeti/GroupTheory/FiniteAbelian/CharacterOrthogonality.lean`: the *column*
orthogonality relation for characters of a finite commutative group, and removes six
private declarations covering the same material from `JointEigenvector/Basic.lean`.

For a finite commutative group `G` and a domain `M` with enough roots of unity, the
characters of `G` are the monoid homomorphisms `G →* Mˣ`. Two public theorems and one
instance:

| declaration | statement |
| --- | --- |
| `CommGroup.instFintypeMonoidHomUnits` | `Fintype (G →* Mˣ)`; Mathlib registers only `Finite`, so a consumer's character sum has no `Finset` to range over |
| `CommGroup.sum_monoidHom_apply_eq_zero_of_ne_one` | for `g ≠ 1`, `∑ χ : G →* Mˣ, χ g = 0` |
| `CommGroup.sum_monoidHom_apply_eq_ite` | the same sum in normal form: `∑ χ : G →* Mˣ, χ g = if g = 1 then (Nat.card G : M) else 0` |

## De-duplication: six private declarations removed

`TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Basic.lean` had proved the same column
relation privately, by a different route (through `MulChar`), as
`sum_unitHom_apply_eq_zero`. It is deleted here along with the two helpers that existed
only to support it (`evalCharHom`, `evalCharHom_apply`) and its private
`Fintype (G →* Kˣ)` instance, which the public instance above supersedes; the single
caller now goes through `sum_monoidHom_apply_eq_zero_of_ne_one`.

While there, `card_unitHom` is deleted too: it states `Nat.card (G →* Kˣ) = Nat.card G`,
which is verbatim Mathlib's `CommGroup.card_monoidHom_of_hasEnoughRootsOfUnity`
(`Mathlib/GroupTheory/FiniteAbelian/Duality.lean:95`), so its one use site now calls the
Mathlib lemma directly.

Those deletions cascade twice more, and both were found by re-grepping the file afterwards
rather than by reading the review: the private instance
`HasEnoughRootsOfUnity K (Monoid.exponent Gˣ)` existed only to feed the `MulChar` route and is
now unreferenced, and `Mathlib.NumberTheory.MulChar.Duality` is left with no remaining use in
the file. Both go as well. The full inventory removed from `JointEigenvector/Basic.lean` is
therefore: `sum_unitHom_apply_eq_zero`, `evalCharHom`, `evalCharHom_apply`, `card_unitHom`, the
private `Fintype (G →* Kˣ)` instance and the private `Monoid.exponent Gˣ` instance, plus that
import.

## Attribution

Adapted from `CebotarevDensity/ForMathlib/CharacterOrthogonality.lean` of
[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density)
(Apache-2.0, Birkbeck--Brasca) at commit `8575c9df1ae0a61120ab5c964c7911414254bec7`.
Only the column relation is taken from that file. Two of its declarations are
deliberately left behind:

- the *row* relation `sum_char_self_eq_zero_of_ne_one`, which is Mathlib's
  `sum_hom_units_eq_zero` composed with the unit coercion — as the source's own docstring
  states — so porting it would be a duplicate; and
- the Fourier-inversion pair (`∑ s, χ s * f s = 0` for all `χ ≠ 1` implies `f` constant),
  which has no consumer on this roadmap. See **Roadmap** below.

One adaptation is worth flagging for anyone re-porting from that pin: the source proof
uses `if_neg`, which is now deprecated and therefore a hard error under
`warningAsError`. The compiler's suggested `ite_eq_right` is *wrong* here — it leaves a
stray second goal — and `ite_cond_eq_false` is itself deprecated. The clean replacement
is the `split` in the file.

## Prior art

Screened by statement (not by name) across all three vocabularies Mathlib uses for this
material — `G →* Mˣ`, `MulChar`, and `AddChar`. The nearest prior art, all cited in the
file or below:

- `sum_hom_units_eq_zero` — `Mathlib/RingTheory/IntegralDomain.lean:186`. **This is the
  dropped row relation.**
- `AddChar.sum_apply_eq_ite` — `Mathlib/Analysis/Fourier/FiniteAbelian/PontryaginDuality.lean:188`.
  Column orthogonality, but additive and valued in `ℂ` only.
- `DirichletCharacter.sum_characters_eq_zero` and `sum_characters_eq` —
  `Mathlib/NumberTheory/DirichletCharacter/Orthogonality.lean:58,68`. The `ZMod n`
  specialisations of the punctured and normal forms.
- `MulChar.sum_eq_zero_of_ne_one` — `Mathlib/NumberTheory/MulChar/Basic.lean:607`. The row
  relation again, in `MulChar` vocabulary over a finite ring.

The generic column relation over an arbitrary domain with `HasEnoughRootsOfUnity` is not
in Mathlib: it appears only in the `ℂ`-valued additive and `ZMod n` specialisations above,
neither of which implies it. Its ingredients *are* all in Mathlib
(`Mathlib/GroupTheory/FiniteAbelian/Duality.lean`), which is why it is a short corollary —
and the in-repo duplicate this PR deletes is direct evidence that the statement is wanted
and currently missing.

## Placement

Under `GroupTheory/FiniteAbelian/`, mirroring Mathlib's
`GroupTheory/FiniteAbelian/Duality.lean` — where the ingredients live and whose `G →* Mˣ`
vocabulary these statements share. Deliberately *not* under a `NumberTheory/Chebotarev/`
directory: the content is generic finite-group character theory with no number-theoretic
hypothesis, and the file imports no number theory.

## Roadmap

Layer 11.4 expands the indicator of `σ` as
`1_{g = σ} = (1/#Gal(F/K)) ∑_χ χ(σ)⁻¹ χ(g)`, and the roadmap states that this identity
"is a theorem about the canonical coefficient, never a hypothesis on an arbitrary
sequence, and it is the only place the character expansion is used". The column relation
in its normal form, `sum_monoidHom_apply_eq_ite`, is what that expansion rests on, stated
in the same `Nat.card` vocabulary as the pinned target `sum_character_indicator`
(`TauCetiRoadmap/Chebotarev/Suggested.lean:133`); the tagged form itself, and the
cyclotomic-specific objects (`cyclotomicCharacterWeight` and its Euler product), are
separate units and are not touched here.

The source's Fourier-inversion pair is left in the source for the same reason: it assumes
vanishing moments of an *arbitrary* sequence, which is the shape the roadmap sentence
above explicitly excludes, so it has no path to a target.

Part of intention TauCetiProject/TauCetiRoadmap#292, which this PR does not close.

Roadmap: Chebotarev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmGskQzGXhqoY3kndbygSn
