### PR TITLE
refactor(Exchangeability): name the source-reindexing identity of block laws

### DIFF
--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -110,11 +110,10 @@ theorem blockLaw_def (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
   (rfl)
 
--- Annotated `@[grind =>]` rather than `@[simp]`, for the same reason as the preimage form below:
--- `blockLaw_def` is the simp normal form, and this rule would be shadowed by it.
+-- Not `@[simp]`: `blockLaw_def` is the simp normal form, and this rule would be shadowed by it.
+-- Used by `rw`, as an ordinary equation.
 /-- Reindexing the family along `f` and then selecting the block `k` is selecting the block
 `f ∘ k` of the original family: the two spellings are the same measure. -/
-@[grind =>]
 theorem blockLaw_comp (μ : Measure Ω) (X : ι → Ω → α) (f : κ → ι) {m : ℕ} (k : Fin m → κ) :
     blockLaw μ (fun j ω => X (f j) ω) k = blockLaw μ X (f ∘ k) :=
   (rfl)

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -110,6 +110,15 @@ theorem blockLaw_def (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
   (rfl)
 
+-- Annotated `@[grind =>]` rather than `@[simp]`, for the same reason as the preimage form below:
+-- `blockLaw_def` is the simp normal form, and this rule would be shadowed by it.
+/-- Reindexing the family along `f` and then selecting the block `k` is selecting the block
+`f ∘ k` of the original family: the two spellings are the same measure. -/
+@[grind =>]
+theorem blockLaw_comp (μ : Measure Ω) (X : ι → Ω → α) (f : κ → ι) {m : ℕ} (k : Fin m → κ) :
+    blockLaw μ (fun j ω => X (f j) ω) k = blockLaw μ X (f ∘ k) :=
+  (rfl)
+
 -- Annotated `@[grind =>]` rather than `@[simp]`: `blockLaw_def` already simp-normalizes
 -- `blockLaw μ X k` to `μ.map …` (so a `@[simp]` here would be shadowed), and the preimage form
 -- needs the a.e.-measurability side condition `hXk`, which `simp` cannot discharge.

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -141,12 +141,11 @@ theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contrac
   intro m k hk
   calc
     blockLaw μ (fun n ω => X (φ n) ω) k =
-        blockLaw μ X (φ ∘ k) := by
-      simp only [blockLaw_def, Function.comp_apply]
+        blockLaw μ X (φ ∘ k) := blockLaw_comp μ X φ k
     _ = prefixLaw μ X m := h.map (hφ.comp hk)
     _ = blockLaw μ (fun n ω => X (φ n) ω) (fun i : Fin m => i.val) := by
-      have := (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
-      simpa only [blockLaw_def, Function.comp_apply] using this
+      rw [blockLaw_comp]
+      exact (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
     _ = prefixLaw μ (fun n ω => X (φ n) ω) m := by
       simp only [prefixLaw_def]
 

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -121,8 +121,8 @@ theorem ExchangeableFamily.comp_injective {μ : Measure Ω} {X : ι → Ω → �
     (h : ExchangeableFamily μ X) {f : κ → ι} (hf : Function.Injective f) :
     ExchangeableFamily μ fun j => X (f j) := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
-  simpa only [blockLaw_def, Function.comp_apply] using
-    h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)
+  exact (blockLaw_comp μ X f k).trans
+    ((h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)).trans (blockLaw_comp μ X f l).symm)
 
 /-- **An exchangeable family has one and the same law along any two injective reindexings.** The
 finite-block equalities that define `ExchangeableFamily` are exactly the finite-dimensional laws of

--- a/TauCeti/Probability/Exchangeability/MixedIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Basic.lean
@@ -243,8 +243,7 @@ theorem MixedIIDWith.comp_injective {μ : Measure Ω} {X : ι → Ω → α}
     (hf : Function.Injective f) : MixedIIDWith μ (fun j => X (f j)) ν := by
   refine MixedIIDWith.intro (fun j => h.aemeasurable (f j))
     h.measurable_mixingRepresentative fun m k hk => ?_
-  simpa only [blockLaw_def, Function.comp_apply] using
-    h.blockLaw_eq_mixture (f ∘ k) (hf.comp hk)
+  exact (blockLaw_comp μ X f k).trans (h.blockLaw_eq_mixture (f ∘ k) (hf.comp hk))
 
 /-- **Reindexing a mixed i.i.d. family along an injection**, existential form. -/
 theorem MixedIID.comp_injective {μ : Measure Ω} {X : ι → Ω → α} (h : MixedIID μ X) {f : κ → ι}


### PR DESCRIPTION
Reindexing a family along `f` and then selecting the block `k` is the same measure as selecting the block `f ∘ k` of the original family — definitionally. Three proofs re-derived that by unfolding `blockLaw` with `simp only [blockLaw_def, Function.comp_apply]`, and only in `Exchangeability/Basic.lean` can it be proved by `rfl` at all, since `blockLaw` is not `@[expose]`.

```lean
@[grind =>]
theorem blockLaw_comp (μ : Measure Ω) (X : ι → Ω → α) (f : κ → ι) {m : ℕ} (k : Fin m → κ) :
    blockLaw μ (fun j ω => X (f j) ω) k = blockLaw μ X (f ∘ k)
```

Named beside `blockLaw_def`, and used at all three sites:

- `Contractable.comp` — both `simpa only [blockLaw_def, Function.comp_apply]` steps become the equality directly (one as a term, one as a single `rw` before the existing `h.map`).
- `ExchangeableFamily.comp_injective` and `MixedIIDWith.comp_injective` — each `simpa` becomes an explicit `trans` chain through the block equality. That spelling is deliberate: the goal's family is written `fun j => X (f j)`, and a bare `rw [blockLaw_comp]` unifies the implicit `f` with the identity instead, while the equalities applied as terms match up to eta without unfolding `blockLaw`.

## Not `@[simp]`, no other attribute

`blockLaw_def` is this file's designated simp normal form, and the file already records (at `blockLaw_apply_of_measurable`) that a further `@[simp]` rule about `blockLaw` would be shadowed by it. `blockLaw_comp` is an ordinary equation applied by `rw`; no automation consumes it, so it carries no attribute.

This adds lines rather than removing them — the theorem, its docstring and the simp-policy comment cost more than the three call sites save. The gain is that each migrated step now says what it is instead of unfolding a definition to find out, and that the identity has a name for the further sites the plan expects.

## Roadmap

Roadmap: Exchangeability

Improvement to existing code — a definitional identity named once instead of re-derived. No roadmap target is claimed.

🤖 Directed by Cameron Freer, drafted by Fable 5.1

