### PR TITLE
feat: relate Gaussian squares to chi-squared laws

### DIFF
--- a/TauCeti/Probability/Distributions/ChiSquared.lean
+++ b/TauCeti/Probability/Distributions/ChiSquared.lean
@@ -380,6 +380,39 @@ theorem chiSquaredMeasure_conv_chiSquaredMeasure (hk : 0 ≤ k) (hl : 0 ≤ l) :
     gammaMeasure_conv_gammaMeasure (by positivity) (by positivity) one_half_pos]
   ring_nf
 
+/-- A finite sum of independent chi-squared variables has the chi-squared law whose degrees of
+freedom are the sum of the individual degrees of freedom. -/
+theorem iIndepFun.hasLaw_sum_chiSquared {ι : Type*} [Fintype ι]
+    {Y : ι → Ω → ℝ} {k : ι → ℝ} (hindep : iIndepFun Y P) (hk : ∀ i, 0 ≤ k i)
+    (hlaw : ∀ i, HasLaw (Y i) (chiSquaredMeasure (k i)) P) :
+    HasLaw (fun ω ↦ ∑ i, Y i ω) (chiSquaredMeasure (∑ i, k i)) P := by
+  classical
+  let _ : IsProbabilityMeasure P := hindep.isProbabilityMeasure
+  have hsum (s : Finset ι) :
+      HasLaw (∑ i ∈ s, Y i) (chiSquaredMeasure (∑ i ∈ s, k i)) P := by
+    induction s using Finset.induction_on with
+    | empty =>
+        simp only [Finset.sum_empty]
+        rw [chiSquaredMeasure_zero]
+        exact hasLaw_dirac_of_ae_eq (Filter.Eventually.of_forall fun _ ↦ rfl)
+    | @insert i s hi ih =>
+        let _ : IsProbabilityMeasure (chiSquaredMeasure (k i)) :=
+          isProbabilityMeasure_chiSquaredMeasure (hk i)
+        let _ : IsProbabilityMeasure (chiSquaredMeasure (∑ j ∈ s, k j)) :=
+          isProbabilityMeasure_chiSquaredMeasure (Finset.sum_nonneg fun j _ ↦ hk j)
+        have hadd :=
+          (hindep.indepFun_finsetSum_of_notMem₀
+            (fun j ↦ (hlaw j).aemeasurable) hi).symm.hasLaw_add
+            (hlaw i) ih
+        rw [chiSquaredMeasure_conv_chiSquaredMeasure (hk i)
+          (Finset.sum_nonneg fun j _ ↦ hk j)] at hadd
+        simpa only [Finset.sum_insert hi] using hadd
+  have hY : (fun ω ↦ ∑ i, Y i ω) = ∑ i, Y i := by
+    funext ω
+    exact (Fintype.sum_apply ω Y).symm
+  rw [hY]
+  exact hsum Finset.univ
+
 /-- Two degrees of freedom give the exponential law of rate `1 / 2`. -/
 theorem chiSquaredMeasure_two : chiSquaredMeasure 2 = expMeasure (1 / 2) := by
   rw [chiSquaredMeasure_eq_gammaMeasure two_pos, expMeasure]

--- a/TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean
@@ -27,7 +27,7 @@ chi-squared law.
 
 ## Main results
 
-* `TauCeti.Probability.map_sq_gaussianReal` — the square of the standard Gaussian measure is
+* `TauCeti.Probability.gaussianReal_map_sq` — the square of the standard Gaussian measure is
   `chiSquaredMeasure 1`;
 * `TauCeti.Probability.iIndepFun.hasLaw_sum_sq_gaussian` — a finite sum of independent squared
   standard Gaussian variables has the corresponding chi-squared law.
@@ -64,7 +64,8 @@ private theorem measureReal_Ioc_standardGaussian {a b : ℝ} (hab : a ≤ b) :
 
 /-- The image of the standard Gaussian law under squaring is the chi-squared law with one degree
 of freedom. -/
-theorem map_sq_gaussianReal :
+@[simp]
+theorem gaussianReal_map_sq :
     (gaussianReal 0 1).map (fun x : ℝ ↦ x ^ 2) = chiSquaredMeasure 1 := by
   let _ : IsProbabilityMeasure (chiSquaredMeasure 1) :=
     isProbabilityMeasure_chiSquaredMeasure zero_le_one
@@ -112,7 +113,7 @@ theorem iIndepFun.hasLaw_sum_sq_gaussian (hindep : iIndepFun X P)
     HasLaw (fun omega ↦ ∑ i, X i omega ^ 2) (chiSquaredMeasure (Fintype.card iota)) P := by
   have hsquareLaw :
       HasLaw (fun x : ℝ ↦ x ^ 2) (chiSquaredMeasure 1) (gaussianReal 0 1) :=
-    ⟨by fun_prop, map_sq_gaussianReal⟩
+    ⟨by fun_prop, gaussianReal_map_sq⟩
   have hlawSq (i : iota) :
       HasLaw (fun omega ↦ X i omega ^ 2) (chiSquaredMeasure 1) P := by
     simpa [Function.comp_def] using hsquareLaw.comp (hlaw i)

--- a/TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+import Mathlib.Probability.Independence.CharacteristicFunction
+public import TauCeti.Probability.Distributions.ChiSquared
+public import TauCeti.Probability.Distributions.Gaussian.Cdf
+
+/-!
+# Squares of standard Gaussian variables
+
+This file identifies the square of a standard real Gaussian variable with the chi-squared law
+of one degree of freedom. It then combines this identification with independence to prove that
+the sum of the squares of a finite independent standard Gaussian family has the chi-squared law
+whose degrees of freedom are the cardinality of the family. The empty family is included: both
+the empty sum and `chiSquaredMeasure 0` are the point mass at zero.
+
+The one-variable result is proved by comparing cumulative distribution functions. For `x ≥ 0`,
+the preimage of `(-∞, x]` under squaring is `[-√x, √x]`; symmetry of the standard Gaussian
+cdf reduces its mass to `Real.erf (√x / √2)`, which is
+`regularizedGamma (1 / 2) (x / 2)`. The finite-family result uses the product formula for the
+characteristic function of an independent sum and the existing characteristic function of the
+chi-squared law.
+
+## Main results
+
+* `TauCeti.Probability.map_sq_gaussianReal` — the square of the standard Gaussian measure is
+  `chiSquaredMeasure 1`;
+* `TauCeti.Probability.iIndepFun.hasLaw_sum_sq_gaussian` — a finite sum of independent squared
+  standard Gaussian variables has the corresponding chi-squared law.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 4, item 1,
+  **Squares of Gaussian variables**.
+* N. L. Johnson, S. Kotz, N. Balakrishnan, *Continuous Univariate Distributions*, vol. 1,
+  2nd ed., Wiley (1994), ch. 18.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory Real Set
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace Probability
+
+private theorem measureReal_Ioc_standardGaussian {a b : ℝ} (hab : a ≤ b) :
+    (gaussianReal 0 1).real (Ioc a b) =
+      cdf (gaussianReal 0 1) b - cdf (gaussianReal 0 1) a := by
+  have hunion :
+      (gaussianReal 0 1).real (Iic a) + (gaussianReal 0 1).real (Ioc a b) =
+        (gaussianReal 0 1).real (Iic b) := by
+    rw [← measureReal_union (Iic_disjoint_Ioc le_rfl) measurableSet_Ioc,
+      Iic_union_Ioc_eq_Iic hab]
+  rw [← cdf_eq_real, ← cdf_eq_real] at hunion
+  linarith
+
+/-- The image of the standard Gaussian law under squaring is the chi-squared law with one degree
+of freedom. -/
+theorem map_sq_gaussianReal :
+    (gaussianReal 0 1).map (fun x : ℝ ↦ x ^ 2) = chiSquaredMeasure 1 := by
+  let _ : IsProbabilityMeasure (chiSquaredMeasure 1) :=
+    isProbabilityMeasure_chiSquaredMeasure zero_le_one
+  apply Measure.eq_of_cdf
+  ext x
+  rw [cdf_eq_real, map_measureReal_apply (by fun_prop) measurableSet_Iic,
+    cdf_chiSquaredMeasure_eq zero_lt_one]
+  by_cases hx : x < 0
+  · have hpreimage : (fun y : ℝ ↦ y ^ 2) ⁻¹' Iic x = ∅ := by
+      ext y
+      simp only [mem_preimage, mem_Iic, mem_empty_iff_false, iff_false]
+      exact fun hy ↦ (not_le_of_gt hx) ((sq_nonneg y).trans hy)
+    rw [hpreimage, measureReal_empty,
+      regularizedGamma_eq_zero_of_nonpos_right (1 / 2) (by linarith)]
+  · have hx' : 0 ≤ x := le_of_not_gt hx
+    have hpreimage : (fun y : ℝ ↦ y ^ 2) ⁻¹' Iic x = Icc (-√x) √x := by
+      ext y
+      simp only [mem_preimage, mem_Iic, mem_Icc]
+      constructor
+      · exact fun hy ↦ abs_le.mp (Real.abs_le_sqrt hy)
+      · intro hy
+        rw [← Real.sq_sqrt hx']
+        exact sq_le_sq' hy.1 hy.2
+    rw [hpreimage]
+    let _ : NullSingletonClass (gaussianReal 0 1) :=
+      nullSingletonClass_gaussianReal one_ne_zero
+    rw [← measureReal_congr (Ioc_ae_eq_Icc (a := -√x) (b := √x)),
+      measureReal_Ioc_standardGaussian (by linarith [Real.sqrt_nonneg x]),
+      cdf_gaussianReal_zero_one, cdf_gaussianReal_zero_one]
+    have hneg : -√x / √2 = -(√x / √2) := by ring
+    rw [hneg, Real.erf_neg]
+    have herf : 0 ≤ √x / √2 := by positivity
+    rw [Real.erf_eq_regularizedGamma_half_sq herf]
+    rw [div_pow, Real.sq_sqrt hx', Real.sq_sqrt (by positivity : (0 : ℝ) ≤ 2)]
+    ring
+
+variable {Omega iota : Type*} [MeasurableSpace Omega] [Fintype iota] {P : Measure Omega}
+  {X : iota → Omega → ℝ}
+
+/-- A finite sum of squares of independent standard Gaussian variables has the chi-squared law
+with one degree of freedom per variable. This includes an empty index type, when both sides are
+the point mass at zero. -/
+theorem iIndepFun.hasLaw_sum_sq_gaussian (hindep : iIndepFun X P)
+    (hlaw : ∀ i, HasLaw (X i) (gaussianReal 0 1) P) :
+    HasLaw (fun omega ↦ ∑ i, X i omega ^ 2) (chiSquaredMeasure (Fintype.card iota)) P := by
+  have hsquareLaw :
+      HasLaw (fun x : ℝ ↦ x ^ 2) (chiSquaredMeasure 1) (gaussianReal 0 1) :=
+    ⟨by fun_prop, map_sq_gaussianReal⟩
+  have hlawSq (i : iota) :
+      HasLaw (fun omega ↦ X i omega ^ 2) (chiSquaredMeasure 1) P := by
+    simpa [Function.comp_def] using hsquareLaw.comp (hlaw i)
+  have hindepSq : iIndepFun (fun i omega ↦ X i omega ^ 2) P := by
+    simpa [Function.comp_def] using
+      hindep.comp (fun (_ : iota) (x : ℝ) ↦ x ^ 2) (fun _ ↦ by fun_prop)
+  let _ : IsProbabilityMeasure P := hindep.isProbabilityMeasure
+  let _ : IsProbabilityMeasure (chiSquaredMeasure (Fintype.card iota)) :=
+    isProbabilityMeasure_chiSquaredMeasure (by positivity)
+  refine ⟨Finset.aemeasurable_fun_sum Finset.univ fun i _ ↦ (hlawSq i).aemeasurable, ?_⟩
+  apply Measure.ext_of_charFun
+  funext t
+  rw [hindepSq.charFun_map_fun_sum_eq_prod fun i ↦ (hlawSq i).aemeasurable,
+    Finset.prod_apply]
+  rw [Finset.prod_congr rfl fun i _ ↦ by
+      rw [(hlawSq i).map_eq, charFun_chiSquaredMeasure zero_le_one],
+    Finset.prod_const, Finset.card_univ,
+    charFun_chiSquaredMeasure (by positivity : (0 : ℝ) ≤ Fintype.card iota)]
+  calc
+    ((1 - 2 * Complex.I * t) ^ (-(1 : ℂ) / 2)) ^ Fintype.card iota =
+        (1 - 2 * Complex.I * t) ^
+          ((Fintype.card iota : ℂ) * (-(1 : ℂ) / 2)) :=
+      (Complex.cpow_nat_mul (1 - 2 * Complex.I * t) (Fintype.card iota)
+        (-(1 : ℂ) / 2)).symm
+    _ = (1 - 2 * Complex.I * t) ^ (-(Fintype.card iota : ℂ) / 2) := by
+      congr 1
+      ring
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean
@@ -5,7 +5,6 @@ Authors: Codex
 -/
 module
 
-import Mathlib.Probability.Independence.CharacteristicFunction
 public import TauCeti.Probability.Distributions.ChiSquared
 public import TauCeti.Probability.Distributions.Gaussian.Cdf
 
@@ -18,12 +17,9 @@ the sum of the squares of a finite independent standard Gaussian family has the 
 whose degrees of freedom are the cardinality of the family. The empty family is included: both
 the empty sum and `chiSquaredMeasure 0` are the point mass at zero.
 
-The one-variable result is proved by comparing cumulative distribution functions. For `x ≥ 0`,
-the preimage of `(-∞, x]` under squaring is `[-√x, √x]`; symmetry of the standard Gaussian
-cdf reduces its mass to `Real.erf (√x / √2)`, which is
-`regularizedGamma (1 / 2) (x / 2)`. The finite-family result uses the product formula for the
-characteristic function of an independent sum and the existing characteristic function of the
-chi-squared law.
+These laws identify Gaussian quadratic statistics with chi-squared distributions. In particular,
+they provide the scalar foundation for distributional results about Gaussian norms and Gaussian
+Gram matrices.
 
 ## Main results
 
@@ -34,8 +30,6 @@ chi-squared law.
 
 ## References
 
-* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 4, item 1,
-  **Squares of Gaussian variables**.
 * N. L. Johnson, S. Kotz, N. Balakrishnan, *Continuous Univariate Distributions*, vol. 1,
   2nd ed., Wiley (1994), ch. 18.
 -/
@@ -118,27 +112,7 @@ theorem iIndepFun.hasLaw_sum_sq_gaussian (hindep : iIndepFun X P)
   have hindepSq : iIndepFun (fun i omega ↦ X i omega ^ 2) P := by
     simpa [Function.comp_def] using
       hindep.comp (fun (_ : iota) (x : ℝ) ↦ x ^ 2) (fun _ ↦ by fun_prop)
-  let _ : IsProbabilityMeasure P := hindep.isProbabilityMeasure
-  let _ : IsProbabilityMeasure (chiSquaredMeasure (Fintype.card iota)) :=
-    isProbabilityMeasure_chiSquaredMeasure (by positivity)
-  refine ⟨Finset.aemeasurable_fun_sum Finset.univ fun i _ ↦ (hlawSq i).aemeasurable, ?_⟩
-  apply Measure.ext_of_charFun
-  funext t
-  rw [hindepSq.charFun_map_fun_sum_eq_prod fun i ↦ (hlawSq i).aemeasurable,
-    Finset.prod_apply]
-  rw [Finset.prod_congr rfl fun i _ ↦ by
-      rw [(hlawSq i).map_eq, charFun_chiSquaredMeasure zero_le_one],
-    Finset.prod_const, Finset.card_univ,
-    charFun_chiSquaredMeasure (by positivity : (0 : ℝ) ≤ Fintype.card iota)]
-  calc
-    ((1 - 2 * Complex.I * t) ^ (-(1 : ℂ) / 2)) ^ Fintype.card iota =
-        (1 - 2 * Complex.I * t) ^
-          ((Fintype.card iota : ℂ) * (-(1 : ℂ) / 2)) :=
-      (Complex.cpow_nat_mul (1 - 2 * Complex.I * t) (Fintype.card iota)
-        (-(1 : ℂ) / 2)).symm
-    _ = (1 - 2 * Complex.I * t) ^ (-(Fintype.card iota : ℂ) / 2) := by
-      congr 1
-      ring
+  simpa using iIndepFun.hasLaw_sum_chiSquared hindepSq (fun _ ↦ zero_le_one) hlawSq
 
 end Probability
 

--- a/TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean
@@ -51,17 +51,6 @@ namespace TauCeti
 
 namespace Probability
 
-private theorem measureReal_Ioc_standardGaussian {a b : ℝ} (hab : a ≤ b) :
-    (gaussianReal 0 1).real (Ioc a b) =
-      cdf (gaussianReal 0 1) b - cdf (gaussianReal 0 1) a := by
-  have hunion :
-      (gaussianReal 0 1).real (Iic a) + (gaussianReal 0 1).real (Ioc a b) =
-        (gaussianReal 0 1).real (Iic b) := by
-    rw [← measureReal_union (Iic_disjoint_Ioc le_rfl) measurableSet_Ioc,
-      Iic_union_Ioc_eq_Iic hab]
-  rw [← cdf_eq_real, ← cdf_eq_real] at hunion
-  linarith
-
 /-- The image of the standard Gaussian law under squaring is the chi-squared law with one degree
 of freedom. -/
 @[simp]
@@ -92,9 +81,18 @@ theorem gaussianReal_map_sq :
     rw [hpreimage]
     let _ : NullSingletonClass (gaussianReal 0 1) :=
       nullSingletonClass_gaussianReal one_ne_zero
+    have hIoc :
+        (gaussianReal 0 1).real (Ioc (-√x) √x) =
+          cdf (gaussianReal 0 1) √x - cdf (gaussianReal 0 1) (-√x) := by
+      calc
+        (gaussianReal 0 1).real (Ioc (-√x) √x) =
+            (cdf (gaussianReal 0 1)).measure.real (Ioc (-√x) √x) := by
+          rw [measure_cdf]
+        _ = cdf (gaussianReal 0 1) √x - cdf (gaussianReal 0 1) (-√x) := by
+          rw [Measure.real, StieltjesFunction.measure_Ioc, ENNReal.toReal_ofReal]
+          exact sub_nonneg.mpr ((cdf (gaussianReal 0 1)).mono (by linarith [Real.sqrt_nonneg x]))
     rw [← measureReal_congr (Ioc_ae_eq_Icc (a := -√x) (b := √x)),
-      measureReal_Ioc_standardGaussian (by linarith [Real.sqrt_nonneg x]),
-      cdf_gaussianReal_zero_one, cdf_gaussianReal_zero_one]
+      hIoc, cdf_gaussianReal_zero_one, cdf_gaussianReal_zero_one]
     have hneg : -√x / √2 = -(√x / √2) := by ring
     rw [hneg, Real.erf_neg]
     have herf : 0 ≤ √x / √2 := by positivity


### PR DESCRIPTION
This PR establishes `(gaussianReal 0 1).map (· ^ 2) = chiSquaredMeasure 1` and proves that the sum of squares of any finite independent standard Gaussian family has `chiSquaredMeasure (Fintype.card ι)`. It advances `TauCetiRoadmap/StandardDistributions/README.md`, Layer 4 item 1, “Squares of Gaussian variables,” including the `k = 0` case where the empty sum and `chiSquaredMeasure 0 = Measure.dirac 0` agree.

The one-variable theorem compares cdfs: the squaring preimage is `[-√x, √x]`, Gaussian atomlessness removes the left endpoint, and `cdf_gaussianReal_zero_one` together with `Real.erf_eq_regularizedGamma_half_sq` yields the chi-squared cdf. The finite-family theorem transports independence through squaring and uses `iIndepFun.charFun_map_fun_sum_eq_prod`, `charFun_chiSquaredMeasure`, and `Complex.cpow_nat_mul`.

This closes Layer 4 item 1. After this PR, the StandardDistributions Layer 4 milestone still needs items 2–5 (ratios, Gamma–Beta independence, sum/difference identities, and the Gamma-mixed Poisson law); Layer 6 can consume these Gaussian-square laws in its one-dimensional Gaussian-Gram theorem.

No Mathlib implementation is vendored; the proof reuses Mathlib's cdf uniqueness, independence, characteristic-function, and complex-power infrastructure, together with Tau Ceti's Gaussian cdf, incomplete-gamma/error-function bridge, and chi-squared theory. The implementation is `TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean` (146 lines).

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"map-sq-gaussianreal"}-->

🤖 Prepared with Codex
