### PR TITLE
feat: conjugate maximal tori in Hopf coordinates

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
@@ -95,6 +95,25 @@ noncomputable def innerConjugationPointNatIso
     rw [HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv,
       HopfAlgebra.mapPoints_extendPoint]
 
+/-- The forward component of the natural inner-conjugation isomorphism acts by conjugation. -/
+@[simp]
+theorem innerConjugationPointNatIso_hom_app_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (innerConjugationPointNatIso H g).hom.app A x =
+      extendPoint H A g * x * (extendPoint H A g)⁻¹ :=
+  innerConjugationPointIso_hom_apply H g A x
+
+/-- The inverse component of the natural inner-conjugation isomorphism acts by conjugation by
+the inverse extended point. -/
+@[simp]
+theorem innerConjugationPointNatIso_inv_app_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (innerConjugationPointNatIso H g).inv.app A x =
+      (extendPoint H A g)⁻¹ * x * extendPoint H A g :=
+  innerConjugationPointIso_inv_apply H g A x
+
 private theorem pointNatIso_ext
     {e₁ e₂ : HopfAlgebra.pointsFunctor.{u, u, v} (R := R) (H := H) ≅
       HopfAlgebra.pointsFunctor.{u, u, v} (R := R) (H := H)}
@@ -115,9 +134,7 @@ theorem innerConjugationPointNatIso_one :
       Iso.refl _ := by
   apply pointNatIso_ext
   intro A x
-  -- The extensionality helper has removed the natural-transformation and `GrpCat` wrappers.
-  change (innerConjugationPointIso H 1 A).hom x = x
-  rw [innerConjugationPointIso_hom_apply]
+  rw [innerConjugationPointNatIso_hom_app_apply]
   simp only [map_one, inv_one, one_mul, mul_one]
   exact Eq.refl _
 
@@ -130,12 +147,15 @@ theorem innerConjugationPointNatIso_mul
       (innerConjugationPointNatIso H h).trans (innerConjugationPointNatIso H g) := by
   apply pointNatIso_ext
   intro A x
-  change (innerConjugationPointIso H (g * h) A).hom x =
-    (innerConjugationPointIso H g A).hom ((innerConjugationPointIso H h A).hom x)
-  rw [innerConjugationPointIso_hom_apply, innerConjugationPointIso_hom_apply,
-    innerConjugationPointIso_hom_apply]
+  rw [innerConjugationPointNatIso_hom_app_apply]
+  -- After extensionality, this is the residual application rule for the composite `GrpCat`
+  -- morphism stored by `Iso.trans`; the following rewrites use the public component equations.
+  change extendPoint H A (g * h) * x * (extendPoint H A (g * h))⁻¹ =
+    (innerConjugationPointNatIso H g).hom.app A
+      ((innerConjugationPointNatIso H h).hom.app A x)
+  rw [innerConjugationPointNatIso_hom_app_apply,
+    innerConjugationPointNatIso_hom_app_apply]
   simp only [map_mul, mul_inv_rev, mul_assoc]
-  exact Eq.refl _
 
 /-- Conjugation by an inverse point is inverse to conjugation by the original point. -/
 @[simp]
@@ -144,16 +164,14 @@ theorem innerConjugationPointNatIso_inv_point
     innerConjugationPointNatIso H g⁻¹ = (innerConjugationPointNatIso H g).symm := by
   apply pointNatIso_ext
   intro A x
-  change (innerConjugationPointIso H g⁻¹ A).hom x =
-    (innerConjugationPointIso H g A).inv x
-  rw [innerConjugationPointIso_hom_apply, innerConjugationPointIso_inv_apply, map_inv,
-    inv_inv]
+  rw [innerConjugationPointNatIso_hom_app_apply, Iso.symm_hom,
+    innerConjugationPointNatIso_inv_app_apply, map_inv, inv_inv]
 
 /-- The coordinate Hopf-algebra automorphism representing conjugation by a rational point.
 
 Contravariance means that its underlying coordinate map is the pullback of the pointwise inner
 automorphism. -/
-@[expose] noncomputable def innerConjugationIso
+noncomputable def innerConjugationIso
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) : H ≅ H where
   hom := homOfPointsMap (innerConjugationPointNatIso H g).hom
   inv := homOfPointsMap (innerConjugationPointNatIso H g).inv
@@ -162,19 +180,29 @@ automorphism. -/
   inv_hom_id := by
     rw [← homOfPointsMap_comp, Iso.hom_inv_id, homOfPointsMap_id]
 
+private theorem innerConjugationIso_hom_def
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    (innerConjugationIso H g).hom = homOfPointsMap (innerConjugationPointNatIso H g).hom :=
+  (rfl)
+
+private theorem innerConjugationIso_inv_def
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    (innerConjugationIso H g).inv = homOfPointsMap (innerConjugationPointNatIso H g).inv :=
+  (rfl)
+
 /-- The forward coordinate map underlying `innerConjugationIso`. -/
 @[simp]
 theorem innerConjugationIso_hom
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     (innerConjugationIso H g).hom = homOfPointsMap (innerConjugationPointNatIso H g).hom :=
-  rfl
+  innerConjugationIso_hom_def H g
 
 /-- The inverse coordinate map underlying `innerConjugationIso`. -/
 @[simp]
 theorem innerConjugationIso_inv
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     (innerConjugationIso H g).inv = homOfPointsMap (innerConjugationPointNatIso H g).inv :=
-  rfl
+  innerConjugationIso_inv_def H g
 
 /-- Conjugation by the identity point is the identity coordinate Hopf-algebra automorphism. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
@@ -66,7 +66,8 @@ theorem innerConjugationPointIso_hom_apply
     (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
     (innerConjugationPointIso H g A).hom x =
       extendPoint H A g * x * (extendPoint H A g)⁻¹ := by
-  rfl
+  change MulAut.conj (extendPoint H A g) x = _
+  exact MulAut.conj_apply (extendPoint H A g) x
 
 /-- The inverse inner-conjugation map is conjugation by the inverse of the extended point. -/
 @[simp]
@@ -75,7 +76,8 @@ theorem innerConjugationPointIso_inv_apply
     (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
     (innerConjugationPointIso H g A).inv x =
       (extendPoint H A g)⁻¹ * x * extendPoint H A g := by
-  rfl
+  change (MulAut.conj (extendPoint H A g)).symm x = _
+  exact MulAut.conj_symm_apply (extendPoint H A g) x
 
 /-- Conjugation by a rational point, naturally on the full functor of points. -/
 noncomputable def innerConjugationPointNatIso
@@ -136,7 +138,9 @@ theorem innerConjugationPointNatIso_one :
   intro A x
   rw [innerConjugationPointNatIso_hom_app_apply]
   simp only [map_one, inv_one, one_mul, mul_one]
-  exact Eq.refl _
+  -- The component of the identity natural isomorphism is the identity `GrpCat` morphism.
+  change x = (𝟙 (HopfAlgebra.points (R := R) (H := H) A)) x
+  exact (GrpCat.id_apply _ x).symm
 
 /-- Conjugation by a product is successive conjugation, first by the second point and then by the
 first. -/
@@ -159,7 +163,7 @@ theorem innerConjugationPointNatIso_mul
 
 /-- Conjugation by an inverse point is inverse to conjugation by the original point. -/
 @[simp]
-theorem innerConjugationPointNatIso_inv_point
+theorem innerConjugationPointNatIso_inv
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     innerConjugationPointNatIso H g⁻¹ = (innerConjugationPointNatIso H g).symm := by
   apply pointNatIso_ext
@@ -218,12 +222,12 @@ theorem innerConjugationIso_mul
 /-- The coordinate automorphism for conjugation by an inverse point is the inverse coordinate
 automorphism. -/
 @[simp]
-theorem innerConjugationIso_inv_point
+theorem innerConjugationIso_inv
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     innerConjugationIso H g⁻¹ = (innerConjugationIso H g).symm := by
   apply Iso.ext
   rw [innerConjugationIso_hom_def, Iso.symm_hom, innerConjugationIso_inv_def,
-    innerConjugationPointNatIso_inv_point, Iso.symm_hom]
+    innerConjugationPointNatIso_inv, Iso.symm_hom]
 
 /-- The coordinate algebra map of inner conjugation is obtained from the universal conjugation
 map by evaluating its conjugating variable at the given rational point. -/
@@ -297,7 +301,7 @@ theorem mapPointsFunctor_innerConjugationIso_inv_app_apply
     (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
     (mapPointsFunctor (innerConjugationIso H g).inv).app A x =
       (extendPoint H A g)⁻¹ * x * extendPoint H A g := by
-  rw [← Iso.symm_hom, ← innerConjugationIso_inv_point,
+  rw [← Iso.symm_hom, ← innerConjugationIso_inv,
     mapPointsFunctor_innerConjugationIso_hom_app_apply, map_inv, inv_inv]
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
@@ -59,6 +59,20 @@ noncomputable def innerConjugationPointIso
       (HopfAlgebra.pointsFunctor (R := R) (H := H)).obj A :=
   MulEquiv.toGrpIso (MulAut.conj (extendPoint H A g))
 
+-- Isolate the definitional reduction through `MulEquiv.toGrpIso`; the public application
+-- theorems below depend only on these bridges and the named `MulAut.conj` equations.
+private theorem innerConjugationPointIso_hom_apply_def
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (innerConjugationPointIso H g A).hom x = MulAut.conj (extendPoint H A g) x :=
+  (rfl)
+
+private theorem innerConjugationPointIso_inv_apply_def
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (innerConjugationPointIso H g A).inv x = (MulAut.conj (extendPoint H A g)).symm x :=
+  (rfl)
+
 /-- Inner conjugation acts by `x ↦ g * x * g⁻¹` after extending `g` to the value algebra. -/
 @[simp]
 theorem innerConjugationPointIso_hom_apply
@@ -66,8 +80,7 @@ theorem innerConjugationPointIso_hom_apply
     (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
     (innerConjugationPointIso H g A).hom x =
       extendPoint H A g * x * (extendPoint H A g)⁻¹ := by
-  change MulAut.conj (extendPoint H A g) x = _
-  exact MulAut.conj_apply (extendPoint H A g) x
+  rw [innerConjugationPointIso_hom_apply_def, MulAut.conj_apply]
 
 /-- The inverse inner-conjugation map is conjugation by the inverse of the extended point. -/
 @[simp]
@@ -76,8 +89,7 @@ theorem innerConjugationPointIso_inv_apply
     (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
     (innerConjugationPointIso H g A).inv x =
       (extendPoint H A g)⁻¹ * x * extendPoint H A g := by
-  change (MulAut.conj (extendPoint H A g)).symm x = _
-  exact MulAut.conj_symm_apply (extendPoint H A g) x
+  rw [innerConjugationPointIso_inv_apply_def, MulAut.conj_symm_apply]
 
 /-- Conjugation by a rational point, naturally on the full functor of points. -/
 noncomputable def innerConjugationPointNatIso

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
@@ -190,20 +190,6 @@ private theorem innerConjugationIso_inv_def
     (innerConjugationIso H g).inv = homOfPointsMap (innerConjugationPointNatIso H g).inv :=
   (rfl)
 
-/-- The forward coordinate map underlying `innerConjugationIso`. -/
-@[simp]
-theorem innerConjugationIso_hom
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    (innerConjugationIso H g).hom = homOfPointsMap (innerConjugationPointNatIso H g).hom :=
-  innerConjugationIso_hom_def H g
-
-/-- The inverse coordinate map underlying `innerConjugationIso`. -/
-@[simp]
-theorem innerConjugationIso_inv
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    (innerConjugationIso H g).inv = homOfPointsMap (innerConjugationPointNatIso H g).inv :=
-  innerConjugationIso_inv_def H g
-
 /-- Conjugation by the identity point is the identity coordinate Hopf-algebra automorphism. -/
 @[simp]
 theorem innerConjugationIso_one :
@@ -211,7 +197,7 @@ theorem innerConjugationIso_one :
         (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) =
       Iso.refl H := by
   apply Iso.ext
-  rw [innerConjugationIso_hom]
+  rw [innerConjugationIso_hom_def]
   rw [innerConjugationPointNatIso_one]
   exact homOfPointsMap_id H
 
@@ -223,8 +209,8 @@ theorem innerConjugationIso_mul
     innerConjugationIso H (g * h) =
       (innerConjugationIso H g).trans (innerConjugationIso H h) := by
   apply Iso.ext
-  rw [innerConjugationIso_hom, Iso.trans_hom, innerConjugationIso_hom,
-    innerConjugationIso_hom]
+  rw [innerConjugationIso_hom_def, Iso.trans_hom, innerConjugationIso_hom_def,
+    innerConjugationIso_hom_def]
   have hmul := congrArg Iso.hom (innerConjugationPointNatIso_mul H g h)
   simp only [Iso.trans_hom] at hmul
   rw [hmul, homOfPointsMap_comp]
@@ -236,7 +222,7 @@ theorem innerConjugationIso_inv_point
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     innerConjugationIso H g⁻¹ = (innerConjugationIso H g).symm := by
   apply Iso.ext
-  rw [innerConjugationIso_hom, Iso.symm_hom, innerConjugationIso_inv,
+  rw [innerConjugationIso_hom_def, Iso.symm_hom, innerConjugationIso_inv_def,
     innerConjugationPointNatIso_inv_point, Iso.symm_hom]
 
 /-- The coordinate algebra map of inner conjugation is obtained from the universal conjugation
@@ -254,7 +240,7 @@ theorem innerConjugationIso_hom_toAlgHom
           (toConv (AlgHom.id R H)) =
         extendPoint H (CommAlgCat.of R H) g * toConv (AlgHom.id R H) *
           (extendPoint H (CommAlgCat.of R H) g)⁻¹ := by
-    rw [innerConjugationIso_hom, mapPointsFunctor_homOfPointsMap]
+    rw [innerConjugationIso_hom_def, mapPointsFunctor_homOfPointsMap]
     exact innerConjugationPointIso_hom_apply H g _ _
   have hx := congrArg (fun p : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R H) ↦
     p.ofConv x) hpoint

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
@@ -25,10 +25,14 @@ H --conj#--> H ⊗ H --(g ⊗ id)--> H.
 
 ## Main declarations
 
-* `TauCeti.CommHopfAlgCat.innerConjugationPointIso`: inner conjugation on the functor of points.
+* `TauCeti.CommHopfAlgCat.innerConjugationPointIso`: inner conjugation on `A`-valued points.
+* `TauCeti.CommHopfAlgCat.innerConjugationPointNatIso`: inner conjugation naturally on the
+  functor of points.
 * `TauCeti.CommHopfAlgCat.innerConjugationIso`: the corresponding coordinate Hopf-algebra
   automorphism.
 * `TauCeti.CommHopfAlgCat.innerConjugationIso_hom_toAlgHom`: its explicit coordinate formula.
+* `TauCeti.CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply`: its action on
+  arbitrary algebra-valued points.
 
 ## References
 
@@ -38,7 +42,7 @@ H --conj#--> H ⊗ H --(g ⊗ id)--> H.
 
 public section
 
-open CategoryTheory WithConv
+open CategoryTheory TauCeti.HopfAlgebra WithConv
 
 namespace TauCeti.CommHopfAlgCat
 
@@ -46,61 +50,6 @@ universe u v w
 
 variable {R : Type u} [CommRing R]
 variable (H : _root_.CommHopfAlgCat.{u} R)
-
-/-- Extension of an `R`-valued point to an `A`-valued point along the structure map of `A`. -/
-noncomputable def extendPoint (A : CommAlgCat.{v} R)
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    HopfAlgebra.points (R := R) (H := H) A :=
-  AlgHom.mapValue (Algebra.ofId R A) g
-
-/-- Extending a point to its original value algebra does not change it. -/
-@[simp]
-theorem extendPoint_self
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    extendPoint H (CommAlgCat.of R R) g = g := by
-  apply WithConv.ofConv_injective
-  ext x
-  simp [extendPoint]
-
-/-- The identity rational point extends to the identity point. -/
-@[simp]
-theorem extendPoint_one (A : CommAlgCat.{v} R) :
-    extendPoint H A (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) = 1 := by
-  exact (AlgHom.mapValue (H := H) (Algebra.ofId R A)).map_one
-
-/-- Extension of rational points preserves multiplication. -/
-@[simp]
-theorem extendPoint_mul (A : CommAlgCat.{v} R)
-    (g h : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    extendPoint H A (g * h) = extendPoint H A g * extendPoint H A h := by
-  exact (AlgHom.mapValue (H := H) (Algebra.ofId R A)).map_mul g h
-
-/-- Extension of rational points preserves inverses. -/
-@[simp]
-theorem extendPoint_inv (A : CommAlgCat.{v} R)
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    extendPoint H A g⁻¹ = (extendPoint H A g)⁻¹ := by
-  exact (AlgHom.mapValue (H := H) (Algebra.ofId R A)).map_inv g
-
-/-- Post-composition of an extended ground-ring-valued point is extension to the target algebra. -/
-theorem mapValue_extendPoint {A : CommAlgCat.{v} R} {B : CommAlgCat.{w} R}
-    (f : A →ₐ[R] B)
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    AlgHom.mapValue (H := H) f (extendPoint H A g) = extendPoint H B g := by
-  apply WithConv.ofConv_injective
-  ext x
-  simp only [extendPoint, AlgHom.mapValue_apply,
-    WithConv.ofConv_toConv, AlgHom.comp_apply]
-  exact f.commutes (g.ofConv x)
-
-/-- The categorical point map sends an extended rational point to its extension in the target
-value algebra. -/
-@[simp]
-theorem mapPoints_extendPoint {A B : CommAlgCat.{v} R} (f : A ⟶ B)
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    HopfAlgebra.mapPoints (H := H) f (extendPoint H A g) = extendPoint H B g := by
-  rw [HopfAlgebra.mapPoints_apply]
-  exact mapValue_extendPoint H f.hom g
 
 /-- Conjugation by the extension of a rational point, as an automorphism of `A`-valued points. -/
 noncomputable def innerConjugationPointIso
@@ -119,17 +68,17 @@ theorem innerConjugationPointIso_hom_apply
       extendPoint H A g * x * (extendPoint H A g)⁻¹ := by
   rfl
 
-/-- The inverse inner-conjugation map is conjugation by the inverse point. -/
+/-- The inverse inner-conjugation map is conjugation by the inverse of the extended point. -/
 @[simp]
 theorem innerConjugationPointIso_inv_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
     (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
     (innerConjugationPointIso H g A).inv x =
-      extendPoint H A g⁻¹ * x * extendPoint H A g := by
+      (extendPoint H A g)⁻¹ * x * extendPoint H A g := by
   rfl
 
 /-- Conjugation by a rational point, naturally on the full functor of points. -/
-noncomputable def innerConjugationPointsIso
+noncomputable def innerConjugationPointNatIso
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     HopfAlgebra.pointsFunctor.{u, u, v} (R := R) (H := H) ≅
       HopfAlgebra.pointsFunctor.{u, u, v} (R := R) (H := H) :=
@@ -144,102 +93,88 @@ noncomputable def innerConjugationPointsIso
       HopfAlgebra.mapPoints (H := H) f ((innerConjugationPointIso H g A).hom x')
     rw [innerConjugationPointIso_hom_apply, innerConjugationPointIso_hom_apply]
     rw [HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv,
-      mapPoints_extendPoint]
+      HopfAlgebra.mapPoints_extendPoint]
 
-/-- The hom component of natural inner conjugation acts by conjugation by the extended point. -/
-@[simp]
-theorem innerConjugationPointsIso_hom_app_apply
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
-    (innerConjugationPointsIso H g).hom.app A x =
-      extendPoint H A g * x * (extendPoint H A g)⁻¹ := by
-  exact innerConjugationPointIso_hom_apply H g A x
-
-/-- The inverse component of natural inner conjugation acts by conjugation by the inverse
-extended point. -/
-@[simp]
-theorem innerConjugationPointsIso_inv_app_apply
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
-    (innerConjugationPointsIso H g).inv.app A x =
-      extendPoint H A g⁻¹ * x * extendPoint H A g := by
-  exact innerConjugationPointIso_inv_apply H g A x
-
-/-- Conjugation by the identity point is the identity automorphism of the functor of points. -/
-@[simp]
-theorem innerConjugationPointsIso_one :
-    innerConjugationPointsIso H
-        (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) =
-      Iso.refl _ := by
+private theorem pointNatIso_ext
+    {e₁ e₂ : HopfAlgebra.pointsFunctor.{u, u, v} (R := R) (H := H) ≅
+      HopfAlgebra.pointsFunctor.{u, u, v} (R := R) (H := H)}
+    (h : ∀ (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A),
+      e₁.hom.app A x = e₂.hom.app A x) : e₁ = e₂ := by
   apply Iso.ext
   apply NatTrans.ext
   funext A
   apply GrpCat.hom_ext
   apply MonoidHom.ext
-  intro x
-  let x' : HopfAlgebra.points (R := R) (H := H) A := x
-  -- The components of `innerConjugationPointsIso` are stored as `GrpCat` morphisms; expose the
-  -- underlying conjugation formula before applying its computation lemma.
-  change extendPoint H A 1 * x' * (extendPoint H A 1)⁻¹ = x'
-  simp only [extendPoint_one, inv_one, one_mul, mul_one]
+  exact h A
+
+/-- Conjugation by the identity point is the identity automorphism of the functor of points. -/
+@[simp]
+theorem innerConjugationPointNatIso_one :
+    innerConjugationPointNatIso H
+        (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) =
+      Iso.refl _ := by
+  apply pointNatIso_ext
+  intro A x
+  -- The extensionality helper has removed the natural-transformation and `GrpCat` wrappers.
+  change (innerConjugationPointIso H 1 A).hom x = x
+  rw [innerConjugationPointIso_hom_apply]
+  simp only [map_one, inv_one, one_mul, mul_one]
+  exact Eq.refl _
 
 /-- Conjugation by a product is successive conjugation, first by the second point and then by the
 first. -/
 @[simp]
-theorem innerConjugationPointsIso_mul
+theorem innerConjugationPointNatIso_mul
     (g h : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    innerConjugationPointsIso H (g * h) =
-      (innerConjugationPointsIso H h).trans (innerConjugationPointsIso H g) := by
-  apply Iso.ext
-  apply NatTrans.ext
-  funext A
-  apply GrpCat.hom_ext
-  apply MonoidHom.ext
-  intro x
-  let x' : HopfAlgebra.points (R := R) (H := H) A := x
-  -- As above, remove only the `NatIso.ofComponents`/`GrpCat` wrappers to compare the two
-  -- conjugation automorphisms on an arbitrary point.
-  change (MulAut.conj (extendPoint H A (g * h))) x' =
-    (MulAut.conj (extendPoint H A g)) ((MulAut.conj (extendPoint H A h)) x')
-  rw [extendPoint_mul]
-  exact congrArg (fun f : MulAut _ ↦ f x') ((MulAut.conj : _ →* MulAut _).map_mul
-    (extendPoint H A g) (extendPoint H A h))
+    innerConjugationPointNatIso H (g * h) =
+      (innerConjugationPointNatIso H h).trans (innerConjugationPointNatIso H g) := by
+  apply pointNatIso_ext
+  intro A x
+  change (innerConjugationPointIso H (g * h) A).hom x =
+    (innerConjugationPointIso H g A).hom ((innerConjugationPointIso H h A).hom x)
+  rw [innerConjugationPointIso_hom_apply, innerConjugationPointIso_hom_apply,
+    innerConjugationPointIso_hom_apply]
+  simp only [map_mul, mul_inv_rev, mul_assoc]
+  exact Eq.refl _
 
 /-- Conjugation by an inverse point is inverse to conjugation by the original point. -/
 @[simp]
-theorem innerConjugationPointsIso_inv
+theorem innerConjugationPointNatIso_inv_point
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    innerConjugationPointsIso H g⁻¹ = (innerConjugationPointsIso H g).symm := by
-  apply Iso.ext
-  apply NatTrans.ext
-  funext A
-  apply GrpCat.hom_ext
-  apply MonoidHom.ext
-  intro x
-  let x' : HopfAlgebra.points (R := R) (H := H) A := x
-  -- The two sides are hidden behind the component projections of the natural isomorphisms;
-  -- expose the pointwise formulas so the named hom/inverse computation lemmas apply.
-  change extendPoint H A g⁻¹ * x' * (extendPoint H A g⁻¹)⁻¹ =
-    (innerConjugationPointIso H g A).inv x'
-  rw [innerConjugationPointIso_inv_apply]
-  have h : (extendPoint H A g⁻¹)⁻¹ = extendPoint H A g := by
-    calc
-      (extendPoint H A g⁻¹)⁻¹ = extendPoint H A (g⁻¹)⁻¹ := (extendPoint_inv H A g⁻¹).symm
-      _ = extendPoint H A g := by rw [inv_inv]
-  rw [h]
+    innerConjugationPointNatIso H g⁻¹ = (innerConjugationPointNatIso H g).symm := by
+  apply pointNatIso_ext
+  intro A x
+  change (innerConjugationPointIso H g⁻¹ A).hom x =
+    (innerConjugationPointIso H g A).inv x
+  rw [innerConjugationPointIso_hom_apply, innerConjugationPointIso_inv_apply, map_inv,
+    inv_inv]
 
 /-- The coordinate Hopf-algebra automorphism representing conjugation by a rational point.
 
 Contravariance means that its underlying coordinate map is the pullback of the pointwise inner
 automorphism. -/
-noncomputable def innerConjugationIso
+@[expose] noncomputable def innerConjugationIso
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) : H ≅ H where
-  hom := homOfPointsMap (innerConjugationPointsIso H g).hom
-  inv := homOfPointsMap (innerConjugationPointsIso H g).inv
+  hom := homOfPointsMap (innerConjugationPointNatIso H g).hom
+  inv := homOfPointsMap (innerConjugationPointNatIso H g).inv
   hom_inv_id := by
     rw [← homOfPointsMap_comp, Iso.inv_hom_id, homOfPointsMap_id]
   inv_hom_id := by
     rw [← homOfPointsMap_comp, Iso.hom_inv_id, homOfPointsMap_id]
+
+/-- The forward coordinate map underlying `innerConjugationIso`. -/
+@[simp]
+theorem innerConjugationIso_hom
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    (innerConjugationIso H g).hom = homOfPointsMap (innerConjugationPointNatIso H g).hom :=
+  rfl
+
+/-- The inverse coordinate map underlying `innerConjugationIso`. -/
+@[simp]
+theorem innerConjugationIso_inv
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    (innerConjugationIso H g).inv = homOfPointsMap (innerConjugationPointNatIso H g).inv :=
+  rfl
 
 /-- Conjugation by the identity point is the identity coordinate Hopf-algebra automorphism. -/
 @[simp]
@@ -248,10 +183,8 @@ theorem innerConjugationIso_one :
         (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) =
       Iso.refl H := by
   apply Iso.ext
-  -- `innerConjugationIso` is assembled fieldwise from the recovered coordinate maps, so expose
-  -- its `hom` field before applying their identity law.
-  change homOfPointsMap (innerConjugationPointsIso H 1).hom = 𝟙 H
-  rw [innerConjugationPointsIso_one]
+  rw [innerConjugationIso_hom]
+  rw [innerConjugationPointNatIso_one]
   exact homOfPointsMap_id H
 
 /-- Coordinate pullback reverses the pointwise composition order: the coordinate automorphism for
@@ -262,37 +195,21 @@ theorem innerConjugationIso_mul
     innerConjugationIso H (g * h) =
       (innerConjugationIso H g).trans (innerConjugationIso H h) := by
   apply Iso.ext
-  -- Expose the `homOfPointsMap` fields so its explicit contravariant composition law applies.
-  change homOfPointsMap (innerConjugationPointsIso H (g * h)).hom =
-    homOfPointsMap (innerConjugationPointsIso H g).hom ≫
-      homOfPointsMap (innerConjugationPointsIso H h).hom
-  have hmul := congrArg Iso.hom (innerConjugationPointsIso_mul H g h)
+  rw [innerConjugationIso_hom, Iso.trans_hom, innerConjugationIso_hom,
+    innerConjugationIso_hom]
+  have hmul := congrArg Iso.hom (innerConjugationPointNatIso_mul H g h)
   simp only [Iso.trans_hom] at hmul
   rw [hmul, homOfPointsMap_comp]
 
 /-- The coordinate automorphism for conjugation by an inverse point is the inverse coordinate
 automorphism. -/
 @[simp]
-theorem innerConjugationIso_inv
+theorem innerConjugationIso_inv_point
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     innerConjugationIso H g⁻¹ = (innerConjugationIso H g).symm := by
   apply Iso.ext
-  -- As in the identity and multiplication laws, expose the fieldwise construction before using
-  -- the corresponding functor-of-points equality.
-  change homOfPointsMap (innerConjugationPointsIso H g⁻¹).hom =
-    homOfPointsMap (innerConjugationPointsIso H g).inv
-  rw [innerConjugationPointsIso_inv]
-  rfl
-
-/-- Precomposition by the coordinate inner automorphism is pointwise conjugation. -/
-@[simp]
-theorem mapPointsFunctor_innerConjugationIso_hom
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    (mapPointsFunctor (innerConjugationIso H g).hom :
-      HopfAlgebra.pointsFunctor.{u, u, u} (R := R) (H := H) ⟶
-        HopfAlgebra.pointsFunctor.{u, u, u} (R := R) (H := H)) =
-      (innerConjugationPointsIso.{u, u} H g).hom := by
-  exact mapPointsFunctor_homOfPointsMap _
+  rw [innerConjugationIso_hom, Iso.symm_hom, innerConjugationIso_inv,
+    innerConjugationPointNatIso_inv_point, Iso.symm_hom]
 
 /-- The coordinate algebra map of inner conjugation is obtained from the universal conjugation
 map by evaluating its conjugating variable at the given rational point. -/
@@ -309,7 +226,7 @@ theorem innerConjugationIso_hom_toAlgHom
           (toConv (AlgHom.id R H)) =
         extendPoint H (CommAlgCat.of R H) g * toConv (AlgHom.id R H) *
           (extendPoint H (CommAlgCat.of R H) g)⁻¹ := by
-    rw [mapPointsFunctor_innerConjugationIso_hom]
+    rw [innerConjugationIso_hom, mapPointsFunctor_homOfPointsMap]
     exact innerConjugationPointIso_hom_apply H g _ _
   have hx := congrArg (fun p : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R H) ↦
     p.ofConv x) hpoint
@@ -322,14 +239,19 @@ theorem innerConjugationIso_hom_toAlgHom
     _ = (Algebra.TensorProduct.productMap
           ((Algebra.ofId R H).comp g.ofConv) (AlgHom.id R H)).comp
             (HopfAlgebra.conjugationAlgHom (R := R) (H := H)) x := by
-      simpa only [extendPoint, AlgHom.mapValue_apply, WithConv.ofConv_toConv] using
+      have hext : extendPoint H (CommAlgCat.of R H) g =
+          toConv ((Algebra.ofId R H).comp g.ofConv) := by
+        apply WithConv.ofConv_injective
+        ext y
+        exact HopfAlgebra.extendPoint_ofConv H (CommAlgCat.of R H) g y
+      rw [hext]
+      exact
         DFunLike.congr_fun
           (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := H)
             (toConv ((Algebra.ofId R H).comp g.ofConv)) (toConv (AlgHom.id R H))).symm x
 
 /-- On points over any commutative value algebra, the coordinate inner automorphism acts by
 conjugation by the extended rational point. -/
--- Not `@[simp]`: `mapPointsFunctor_innerConjugationIso_hom` is the preferred same-universe rule.
 theorem mapPointsFunctor_innerConjugationIso_hom_app_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
     (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
@@ -346,7 +268,7 @@ theorem mapPointsFunctor_innerConjugationIso_hom_app_apply
     apply Algebra.TensorProduct.ext'
     intro a b
     simp only [Algebra.TensorProduct.productMap_apply_tmul, AlgHom.comp_apply,
-      AlgHom.id_apply, extendPoint, AlgHom.mapValue_apply, WithConv.ofConv_toConv,
+      AlgHom.id_apply,
       Algebra.ofId_apply, map_mul]
     exact congrArg (fun c : A ↦ c * x.ofConv b) (x.ofConv.commutes (g.ofConv a))
   rw [hprod]

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
@@ -298,6 +298,7 @@ theorem mapPointsFunctor_innerConjugationIso_hom_app_apply
     simp only [Algebra.TensorProduct.productMap_apply_tmul, AlgHom.comp_apply,
       AlgHom.id_apply,
       Algebra.ofId_apply, map_mul]
+    rw [HopfAlgebra.extendPoint_ofConv]
     exact congrArg (fun c : A ↦ c * x.ofConv b) (x.ofConv.commutes (g.ofConv a))
   rw [hprod]
   exact (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := H)

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/InnerConjugation.lean
@@ -290,4 +290,14 @@ theorem mapPointsFunctor_innerConjugationIso_hom_app_apply
   exact (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := H)
     (extendPoint H A g) x)
 
+/-- On points over any commutative value algebra, the inverse coordinate inner automorphism acts
+by conjugation by the inverse of the extended rational point. -/
+theorem mapPointsFunctor_innerConjugationIso_inv_app_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (mapPointsFunctor (innerConjugationIso H g).inv).app A x =
+      (extendPoint H A g)⁻¹ * x * extendPoint H A g := by
+  rw [← Iso.symm_hom, ← innerConjugationIso_inv_point,
+    mapPointsFunctor_innerConjugationIso_hom_app_apply, map_inv, inv_inv]
+
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
-public import TauCeti.Algebra.AlgebraicGroup.Hopf.Conjugation
 
 /-!
 # Inner conjugation in Hopf coordinates
@@ -35,9 +34,6 @@ H --conj#--> H ⊗ H --(g ⊗ id)--> H.
 
 * J. S. Milne, *Algebraic Groups* (2017), §§3.5 and 10.20.
 * A. Borel, *Linear Algebraic Groups*, 2nd ed. (1991), §8.
-
-This is the conjugation operation needed by Layer 7, "Borel subgroups, maximal tori, and their
-conjugacy", of the ReductiveGroups roadmap.
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
@@ -1,0 +1,260 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Conjugation
+
+/-!
+# Inner conjugation in Hopf coordinates
+
+A rational point `g` of an affine group acts on all algebra-valued points by inner
+conjugation. This action is natural in the value algebra and is a group automorphism. Full
+faithfulness of the functor of points therefore recovers a coordinate Hopf-algebra
+automorphism.
+
+The coordinate morphism is characterized both on arbitrary algebra-valued points and as an
+algebra map. The latter is evaluation of the universal conjugation morphism at `g` in its first
+factor:
+
+```text
+H --conj#--> H ⊗ H --(g ⊗ id)--> H.
+```
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.innerConjugationPointIso`: inner conjugation on the functor of points.
+* `TauCeti.CommHopfAlgCat.innerConjugationIso`: the corresponding coordinate Hopf-algebra
+  automorphism.
+* `TauCeti.CommHopfAlgCat.innerConjugationIso_hom_toAlgHom`: its explicit coordinate formula.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§3.5 and 10.20.
+* A. Borel, *Linear Algebraic Groups*, 2nd ed. (1991), §8.
+
+This is the conjugation operation needed by Layer 7, "Borel subgroups, maximal tori, and their
+conjugacy", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u
+
+variable {R : Type u} [CommRing R]
+variable (H : _root_.CommHopfAlgCat.{u} R)
+
+/-- Extension of an `R`-valued point to an `A`-valued point along the structure map of `A`. -/
+noncomputable def extendPoint (A : CommAlgCat.{u} R)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    HopfAlgebra.points (R := R) (H := H) A :=
+  AlgHom.mapValue (Algebra.ofId R A) g
+
+/-- Extending a point to its original value algebra does not change it. -/
+@[simp]
+theorem extendPoint_self
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    extendPoint H (CommAlgCat.of R R) g = g := by
+  apply WithConv.ofConv_injective
+  ext x
+  simp [extendPoint]
+
+/-- The identity rational point extends to the identity point. -/
+@[simp]
+theorem extendPoint_one (A : CommAlgCat.{u} R) :
+    extendPoint H A (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) = 1 := by
+  exact (AlgHom.mapValue (H := H) (Algebra.ofId R A)).map_one
+
+/-- Extension of rational points preserves multiplication. -/
+@[simp]
+theorem extendPoint_mul (A : CommAlgCat.{u} R)
+    (g h : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    extendPoint H A (g * h) = extendPoint H A g * extendPoint H A h := by
+  exact (AlgHom.mapValue (H := H) (Algebra.ofId R A)).map_mul g h
+
+/-- Extension of rational points preserves inverses. -/
+@[simp]
+theorem extendPoint_inv (A : CommAlgCat.{u} R)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    extendPoint H A g⁻¹ = (extendPoint H A g)⁻¹ := by
+  exact (AlgHom.mapValue (H := H) (Algebra.ofId R A)).map_inv g
+
+/-- Extension of a ground-ring-valued point is natural in the value algebra. -/
+theorem mapPoints_extendPoint {A B : CommAlgCat.{u} R} (f : A ⟶ B)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    HopfAlgebra.mapPoints (H := H) f (extendPoint H A g) = extendPoint H B g := by
+  apply WithConv.ofConv_injective
+  ext x
+  change f.hom (algebraMap R A (g.ofConv x)) = algebraMap R B (g.ofConv x)
+  exact f.hom.commutes (g.ofConv x)
+
+/-- Conjugation by the extension of a rational point, as an automorphism of `A`-valued points. -/
+noncomputable def innerConjugationPointIso
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{u} R) :
+    (HopfAlgebra.pointsFunctor (R := R) (H := H)).obj A ≅
+      (HopfAlgebra.pointsFunctor (R := R) (H := H)).obj A :=
+  MulEquiv.toGrpIso (MulAut.conj (extendPoint H A g))
+
+/-- Inner conjugation acts by `x ↦ g * x * g⁻¹` after extending `g` to the value algebra. -/
+@[simp]
+theorem innerConjugationPointIso_hom_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (innerConjugationPointIso H g A).hom x =
+      extendPoint H A g * x * (extendPoint H A g)⁻¹ := by
+  rfl
+
+/-- The inverse inner-conjugation map is conjugation by the inverse point. -/
+@[simp]
+theorem innerConjugationPointIso_inv_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (innerConjugationPointIso H g A).inv x =
+      extendPoint H A g⁻¹ * x * extendPoint H A g := by
+  rfl
+
+/-- Conjugation by a rational point, naturally on the full functor of points. -/
+noncomputable def innerConjugationPointsIso
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    HopfAlgebra.pointsFunctor (R := R) (H := H) ≅
+      HopfAlgebra.pointsFunctor (R := R) (H := H) :=
+  NatIso.ofComponents (innerConjugationPointIso H g) fun {A B} f ↦ by
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro x
+    let x' : HopfAlgebra.points (R := R) (H := H) A := x
+    change (innerConjugationPointIso H g B).hom (HopfAlgebra.mapPoints (H := H) f x') =
+      HopfAlgebra.mapPoints (H := H) f ((innerConjugationPointIso H g A).hom x')
+    rw [innerConjugationPointIso_hom_apply, innerConjugationPointIso_hom_apply,
+      HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv,
+      mapPoints_extendPoint]
+
+/-- Conjugation by the identity point is the identity automorphism of the functor of points. -/
+@[simp]
+theorem innerConjugationPointsIso_one :
+    innerConjugationPointsIso H
+        (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) =
+      Iso.refl _ := by
+  apply Iso.ext
+  apply NatTrans.ext
+  funext A
+  apply GrpCat.hom_ext
+  apply MonoidHom.ext
+  intro x
+  let x' : HopfAlgebra.points (R := R) (H := H) A := x
+  change extendPoint H A 1 * x' * (extendPoint H A 1)⁻¹ = x'
+  simp
+
+/-- Conjugation by an inverse point is inverse to conjugation by the original point. -/
+@[simp]
+theorem innerConjugationPointsIso_inv
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    innerConjugationPointsIso H g⁻¹ = (innerConjugationPointsIso H g).symm := by
+  apply Iso.ext
+  apply NatTrans.ext
+  funext A
+  apply GrpCat.hom_ext
+  apply MonoidHom.ext
+  intro x
+  let x' : HopfAlgebra.points (R := R) (H := H) A := x
+  change extendPoint H A g⁻¹ * x' * (extendPoint H A g⁻¹)⁻¹ =
+    (innerConjugationPointIso H g A).inv x'
+  rw [innerConjugationPointIso_inv_apply]
+  have h : (extendPoint H A g⁻¹)⁻¹ = extendPoint H A g := by
+    calc
+      (extendPoint H A g⁻¹)⁻¹ = extendPoint H A (g⁻¹)⁻¹ := (extendPoint_inv H A g⁻¹).symm
+      _ = extendPoint H A g := by rw [inv_inv]
+  rw [h]
+
+/-- The coordinate Hopf-algebra automorphism representing conjugation by a rational point.
+
+Contravariance means that its underlying coordinate map is the pullback of the pointwise inner
+automorphism. -/
+noncomputable def innerConjugationIso
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) : H ≅ H where
+  hom := homOfPointsMap (innerConjugationPointsIso H g).hom
+  inv := homOfPointsMap (innerConjugationPointsIso H g).inv
+  hom_inv_id := by
+    rw [← homOfPointsMap_comp, Iso.inv_hom_id, homOfPointsMap_id]
+  inv_hom_id := by
+    rw [← homOfPointsMap_comp, Iso.hom_inv_id, homOfPointsMap_id]
+
+/-- Conjugation by the identity point is the identity coordinate Hopf-algebra automorphism. -/
+@[simp]
+theorem innerConjugationIso_one :
+    innerConjugationIso H
+        (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) =
+      Iso.refl H := by
+  apply Iso.ext
+  change homOfPointsMap (innerConjugationPointsIso H 1).hom = 𝟙 H
+  rw [innerConjugationPointsIso_one]
+  exact homOfPointsMap_id H
+
+/-- The coordinate automorphism for conjugation by an inverse point is the inverse coordinate
+automorphism. -/
+@[simp]
+theorem innerConjugationIso_inv
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    innerConjugationIso H g⁻¹ = (innerConjugationIso H g).symm := by
+  apply Iso.ext
+  change homOfPointsMap (innerConjugationPointsIso H g⁻¹).hom =
+    homOfPointsMap (innerConjugationPointsIso H g).inv
+  rw [innerConjugationPointsIso_inv]
+  rfl
+
+/-- Precomposition by the coordinate inner automorphism is pointwise conjugation. -/
+@[simp]
+theorem mapPointsFunctor_innerConjugationIso_hom
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    mapPointsFunctor (innerConjugationIso H g).hom =
+      (innerConjugationPointsIso H g).hom := by
+  exact mapPointsFunctor_homOfPointsMap _
+
+/-- On points, the coordinate inner automorphism acts by conjugation by the extended rational
+point. -/
+@[simp]
+theorem mapPointsFunctor_innerConjugationIso_hom_app_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (mapPointsFunctor (innerConjugationIso H g).hom).app A x =
+      extendPoint H A g * x * (extendPoint H A g)⁻¹ := by
+  rw [mapPointsFunctor_innerConjugationIso_hom]
+  exact innerConjugationPointIso_hom_apply H g A x
+
+/-- The coordinate algebra map of inner conjugation is obtained from the universal conjugation
+map by evaluating its conjugating variable at the given rational point. -/
+theorem innerConjugationIso_hom_toAlgHom
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    (innerConjugationIso H g).hom.hom.toAlgHom =
+      (Algebra.TensorProduct.productMap
+        ((Algebra.ofId R H).comp g.ofConv) (AlgHom.id R H)).comp
+          (HopfAlgebra.conjugationAlgHom (R := R) (H := H)) := by
+  apply AlgHom.ext
+  intro x
+  have hpoint := mapPointsFunctor_innerConjugationIso_hom_app_apply H g
+    (CommAlgCat.of R H) (toConv (AlgHom.id R H))
+  have hx := congrArg (fun p : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R H) ↦
+    p.ofConv x) hpoint
+  rw [mapPointsFunctor_app_apply] at hx
+  calc
+    (innerConjugationIso H g).hom.hom.toAlgHom x =
+        (extendPoint H (CommAlgCat.of R H) g * toConv (AlgHom.id R H) *
+          (extendPoint H (CommAlgCat.of R H) g)⁻¹).ofConv x := by
+      simpa only [AlgHom.comp_apply, AlgHom.id_apply, WithConv.toConv_ofConv] using hx
+    _ = (Algebra.TensorProduct.productMap
+          ((Algebra.ofId R H).comp g.ofConv) (AlgHom.id R H)).comp
+            (HopfAlgebra.conjugationAlgHom (R := R) (H := H)) x := by
+      simpa only [extendPoint, AlgHom.mapValue_apply, WithConv.ofConv_toConv] using
+        DFunLike.congr_fun
+          (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := H)
+            (toConv ((Algebra.ofId R H).comp g.ofConv)) (toConv (AlgHom.id R H))).symm x
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
@@ -102,11 +102,8 @@ private theorem mapPoints_conjugate_extendPoint {A B : CommAlgCat.{v} R} (f : A 
         (extendPoint H A g * x * (extendPoint H A g)⁻¹) =
       extendPoint H B g * HopfAlgebra.mapPoints (H := H) f x * (extendPoint H B g)⁻¹ := by
   rw [HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv]
-  have hext := mapPoints_extendPoint H f.hom g
-  change AlgHom.mapValue (H := H) f.hom (extendPoint H A g) *
-      HopfAlgebra.mapPoints (H := H) f x *
-        (AlgHom.mapValue (H := H) f.hom (extendPoint H A g))⁻¹ = _
-  rw [hext]
+  rw [show HopfAlgebra.mapPoints (H := H) f (extendPoint H A g) = extendPoint H B g from
+    mapPoints_extendPoint H f.hom g]
 
 /-- Conjugation by the extension of a rational point, as an automorphism of `A`-valued points. -/
 noncomputable def innerConjugationPointIso

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
@@ -220,7 +220,8 @@ theorem mapPointsFunctor_innerConjugationIso_hom
 
 /-- On points, the coordinate inner automorphism acts by conjugation by the extended rational
 point. -/
-@[simp]
+-- Not `@[simp]`: `mapPointsFunctor_innerConjugationIso_hom` already rewrites the left-hand
+-- side before this applied form can fire.
 theorem mapPointsFunctor_innerConjugationIso_hom_app_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
     (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
@@ -95,25 +95,12 @@ theorem mapValue_extendPoint {A : CommAlgCat.{v} R} {B : CommAlgCat.{w} R}
 
 /-- The categorical point map sends an extended rational point to its extension in the target
 value algebra. -/
+@[simp]
 theorem mapPoints_extendPoint {A B : CommAlgCat.{v} R} (f : A ⟶ B)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     HopfAlgebra.mapPoints (H := H) f (extendPoint H A g) = extendPoint H B g := by
   rw [HopfAlgebra.mapPoints_apply]
-  apply WithConv.ofConv_injective
-  ext x
-  simp only [extendPoint, AlgHom.mapValue_apply, WithConv.ofConv_toConv, AlgHom.comp_apply]
-  exact f.hom.commutes (g.ofConv x)
-
-/-- Mapping a conjugate by an extended rational point commutes with extension to the target value
-algebra. This isolates the group-homomorphism normalization used in the naturality proof below. -/
-private theorem mapPoints_conjugate_extendPoint {A B : CommAlgCat.{v} R} (f : A ⟶ B)
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (x : HopfAlgebra.points (R := R) (H := H) A) :
-    HopfAlgebra.mapPoints (H := H) f
-        (extendPoint H A g * x * (extendPoint H A g)⁻¹) =
-      extendPoint H B g * HopfAlgebra.mapPoints (H := H) f x * (extendPoint H B g)⁻¹ := by
-  rw [HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv]
-  rw [mapPoints_extendPoint]
+  exact mapValue_extendPoint H f.hom g
 
 /-- Conjugation by the extension of a rational point, as an automorphism of `A`-valued points. -/
 noncomputable def innerConjugationPointIso
@@ -156,7 +143,8 @@ noncomputable def innerConjugationPointsIso
     change (innerConjugationPointIso H g B).hom (HopfAlgebra.mapPoints (H := H) f x') =
       HopfAlgebra.mapPoints (H := H) f ((innerConjugationPointIso H g A).hom x')
     rw [innerConjugationPointIso_hom_apply, innerConjugationPointIso_hom_apply]
-    exact (mapPoints_conjugate_extendPoint H f g x').symm
+    rw [HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv,
+      mapPoints_extendPoint]
 
 /-- The hom component of natural inner conjugation acts by conjugation by the extended point. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
@@ -46,13 +46,13 @@ open CategoryTheory WithConv
 
 namespace TauCeti.CommHopfAlgCat
 
-universe u
+universe u v w
 
 variable {R : Type u} [CommRing R]
 variable (H : _root_.CommHopfAlgCat.{u} R)
 
 /-- Extension of an `R`-valued point to an `A`-valued point along the structure map of `A`. -/
-noncomputable def extendPoint (A : CommAlgCat.{u} R)
+noncomputable def extendPoint (A : CommAlgCat.{v} R)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     HopfAlgebra.points (R := R) (H := H) A :=
   AlgHom.mapValue (Algebra.ofId R A) g
@@ -68,49 +68,54 @@ theorem extendPoint_self
 
 /-- The identity rational point extends to the identity point. -/
 @[simp]
-theorem extendPoint_one (A : CommAlgCat.{u} R) :
+theorem extendPoint_one (A : CommAlgCat.{v} R) :
     extendPoint H A (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) = 1 := by
   exact (AlgHom.mapValue (H := H) (Algebra.ofId R A)).map_one
 
 /-- Extension of rational points preserves multiplication. -/
 @[simp]
-theorem extendPoint_mul (A : CommAlgCat.{u} R)
+theorem extendPoint_mul (A : CommAlgCat.{v} R)
     (g h : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     extendPoint H A (g * h) = extendPoint H A g * extendPoint H A h := by
   exact (AlgHom.mapValue (H := H) (Algebra.ofId R A)).map_mul g h
 
 /-- Extension of rational points preserves inverses. -/
 @[simp]
-theorem extendPoint_inv (A : CommAlgCat.{u} R)
+theorem extendPoint_inv (A : CommAlgCat.{v} R)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     extendPoint H A g⁻¹ = (extendPoint H A g)⁻¹ := by
   exact (AlgHom.mapValue (H := H) (Algebra.ofId R A)).map_inv g
 
 /-- Extension of a ground-ring-valued point is natural in the value algebra. -/
-theorem mapPoints_extendPoint {A B : CommAlgCat.{u} R} (f : A ⟶ B)
+theorem mapPoints_extendPoint {A : CommAlgCat.{v} R} {B : CommAlgCat.{w} R}
+    (f : A →ₐ[R] B)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    HopfAlgebra.mapPoints (H := H) f (extendPoint H A g) = extendPoint H B g := by
+    AlgHom.mapValue (H := H) f (extendPoint H A g) = extendPoint H B g := by
   apply WithConv.ofConv_injective
   ext x
   simp only [extendPoint, AlgHom.mapValue_apply,
     WithConv.ofConv_toConv, AlgHom.comp_apply]
-  exact f.hom.commutes (g.ofConv x)
+  exact f.commutes (g.ofConv x)
 
 /-- Mapping a conjugate by an extended rational point commutes with extension to the target value
 algebra. This isolates the group-homomorphism normalization used in the naturality proof below. -/
-private theorem mapPoints_conjugate_extendPoint {A B : CommAlgCat.{u} R} (f : A ⟶ B)
+private theorem mapPoints_conjugate_extendPoint {A B : CommAlgCat.{v} R} (f : A ⟶ B)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
     (x : HopfAlgebra.points (R := R) (H := H) A) :
     HopfAlgebra.mapPoints (H := H) f
         (extendPoint H A g * x * (extendPoint H A g)⁻¹) =
       extendPoint H B g * HopfAlgebra.mapPoints (H := H) f x * (extendPoint H B g)⁻¹ := by
-  rw [HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv,
-    mapPoints_extendPoint]
+  rw [HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv]
+  have hext := mapPoints_extendPoint H f.hom g
+  change AlgHom.mapValue (H := H) f.hom (extendPoint H A g) *
+      HopfAlgebra.mapPoints (H := H) f x *
+        (AlgHom.mapValue (H := H) f.hom (extendPoint H A g))⁻¹ = _
+  rw [hext]
 
 /-- Conjugation by the extension of a rational point, as an automorphism of `A`-valued points. -/
 noncomputable def innerConjugationPointIso
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (A : CommAlgCat.{u} R) :
+    (A : CommAlgCat.{v} R) :
     (HopfAlgebra.pointsFunctor (R := R) (H := H)).obj A ≅
       (HopfAlgebra.pointsFunctor (R := R) (H := H)).obj A :=
   MulEquiv.toGrpIso (MulAut.conj (extendPoint H A g))
@@ -119,7 +124,7 @@ noncomputable def innerConjugationPointIso
 @[simp]
 theorem innerConjugationPointIso_hom_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
     (innerConjugationPointIso H g A).hom x =
       extendPoint H A g * x * (extendPoint H A g)⁻¹ := by
   rfl
@@ -128,7 +133,7 @@ theorem innerConjugationPointIso_hom_apply
 @[simp]
 theorem innerConjugationPointIso_inv_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
     (innerConjugationPointIso H g A).inv x =
       extendPoint H A g⁻¹ * x * extendPoint H A g := by
   rfl
@@ -136,8 +141,8 @@ theorem innerConjugationPointIso_inv_apply
 /-- Conjugation by a rational point, naturally on the full functor of points. -/
 noncomputable def innerConjugationPointsIso
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    HopfAlgebra.pointsFunctor (R := R) (H := H) ≅
-      HopfAlgebra.pointsFunctor (R := R) (H := H) :=
+    HopfAlgebra.pointsFunctor.{u, u, v} (R := R) (H := H) ≅
+      HopfAlgebra.pointsFunctor.{u, u, v} (R := R) (H := H) :=
   NatIso.ofComponents (innerConjugationPointIso H g) fun {A B} f ↦ by
     apply GrpCat.hom_ext
     apply MonoidHom.ext
@@ -273,21 +278,11 @@ theorem innerConjugationIso_inv
 @[simp]
 theorem mapPointsFunctor_innerConjugationIso_hom
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    mapPointsFunctor (innerConjugationIso H g).hom =
-      (innerConjugationPointsIso H g).hom := by
+    (mapPointsFunctor (innerConjugationIso H g).hom :
+      HopfAlgebra.pointsFunctor.{u, u, u} (R := R) (H := H) ⟶
+        HopfAlgebra.pointsFunctor.{u, u, u} (R := R) (H := H)) =
+      (innerConjugationPointsIso.{u, u} H g).hom := by
   exact mapPointsFunctor_homOfPointsMap _
-
-/-- On points, the coordinate inner automorphism acts by conjugation by the extended rational
-point. -/
--- Not `@[simp]`: `mapPointsFunctor_innerConjugationIso_hom` already rewrites the left-hand
--- side before this applied form can fire.
-theorem mapPointsFunctor_innerConjugationIso_hom_app_apply
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
-    (mapPointsFunctor (innerConjugationIso H g).hom).app A x =
-      extendPoint H A g * x * (extendPoint H A g)⁻¹ := by
-  rw [mapPointsFunctor_innerConjugationIso_hom]
-  exact innerConjugationPointIso_hom_apply H g A x
 
 /-- The coordinate algebra map of inner conjugation is obtained from the universal conjugation
 map by evaluating its conjugating variable at the given rational point. -/
@@ -299,8 +294,13 @@ theorem innerConjugationIso_hom_toAlgHom
           (HopfAlgebra.conjugationAlgHom (R := R) (H := H)) := by
   apply AlgHom.ext
   intro x
-  have hpoint := mapPointsFunctor_innerConjugationIso_hom_app_apply H g
-    (CommAlgCat.of R H) (toConv (AlgHom.id R H))
+  have hpoint :
+      (mapPointsFunctor (innerConjugationIso H g).hom).app (CommAlgCat.of R H)
+          (toConv (AlgHom.id R H)) =
+        extendPoint H (CommAlgCat.of R H) g * toConv (AlgHom.id R H) *
+          (extendPoint H (CommAlgCat.of R H) g)⁻¹ := by
+    rw [mapPointsFunctor_innerConjugationIso_hom]
+    exact innerConjugationPointIso_hom_apply H g _ _
   have hx := congrArg (fun p : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R H) ↦
     p.ofConv x) hpoint
   rw [mapPointsFunctor_app_apply] at hx
@@ -316,5 +316,31 @@ theorem innerConjugationIso_hom_toAlgHom
         DFunLike.congr_fun
           (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := H)
             (toConv ((Algebra.ofId R H).comp g.ofConv)) (toConv (AlgHom.id R H))).symm x
+
+/-- On points over any commutative value algebra, the coordinate inner automorphism acts by
+conjugation by the extended rational point. -/
+-- Not `@[simp]`: `mapPointsFunctor_innerConjugationIso_hom` is the preferred same-universe rule.
+theorem mapPointsFunctor_innerConjugationIso_hom_app_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (mapPointsFunctor (innerConjugationIso H g).hom).app A x =
+      extendPoint H A g * x * (extendPoint H A g)⁻¹ := by
+  apply WithConv.ofConv_injective
+  rw [mapPointsFunctor_app_apply]
+  rw [innerConjugationIso_hom_toAlgHom]
+  rw [← AlgHom.comp_assoc]
+  have hprod :
+      x.ofConv.comp (Algebra.TensorProduct.productMap
+          ((Algebra.ofId R H).comp g.ofConv) (AlgHom.id R H)) =
+        Algebra.TensorProduct.productMap (extendPoint H A g).ofConv x.ofConv := by
+    apply Algebra.TensorProduct.ext'
+    intro a b
+    simp only [Algebra.TensorProduct.productMap_apply_tmul, AlgHom.comp_apply,
+      AlgHom.id_apply, extendPoint, AlgHom.mapValue_apply, WithConv.ofConv_toConv,
+      Algebra.ofId_apply, map_mul]
+    exact congrArg (fun c : A ↦ c * x.ofConv b) (x.ofConv.commutes (g.ofConv a))
+  rw [hprod]
+  exact (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := H)
+    (extendPoint H A g) x)
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
@@ -92,8 +92,20 @@ theorem mapPoints_extendPoint {A B : CommAlgCat.{u} R} (f : A ⟶ B)
     HopfAlgebra.mapPoints (H := H) f (extendPoint H A g) = extendPoint H B g := by
   apply WithConv.ofConv_injective
   ext x
-  change f.hom (algebraMap R A (g.ofConv x)) = algebraMap R B (g.ofConv x)
+  simp only [extendPoint, AlgHom.mapValue_apply,
+    WithConv.ofConv_toConv, AlgHom.comp_apply]
   exact f.hom.commutes (g.ofConv x)
+
+/-- Mapping a conjugate by an extended rational point commutes with extension to the target value
+algebra. This isolates the group-homomorphism normalization used in the naturality proof below. -/
+private theorem mapPoints_conjugate_extendPoint {A B : CommAlgCat.{u} R} (f : A ⟶ B)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (x : HopfAlgebra.points (R := R) (H := H) A) :
+    HopfAlgebra.mapPoints (H := H) f
+        (extendPoint H A g * x * (extendPoint H A g)⁻¹) =
+      extendPoint H B g * HopfAlgebra.mapPoints (H := H) f x * (extendPoint H B g)⁻¹ := by
+  rw [HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv,
+    mapPoints_extendPoint]
 
 /-- Conjugation by the extension of a rational point, as an automorphism of `A`-valued points. -/
 noncomputable def innerConjugationPointIso
@@ -131,11 +143,12 @@ noncomputable def innerConjugationPointsIso
     apply MonoidHom.ext
     intro x
     let x' : HopfAlgebra.points (R := R) (H := H) A := x
+    -- `NatIso.ofComponents` stores this naturality square through the categorical wrappers for
+    -- `GrpCat`; expose its pointwise form so the named point-map laws apply.
     change (innerConjugationPointIso H g B).hom (HopfAlgebra.mapPoints (H := H) f x') =
       HopfAlgebra.mapPoints (H := H) f ((innerConjugationPointIso H g A).hom x')
-    rw [innerConjugationPointIso_hom_apply, innerConjugationPointIso_hom_apply,
-      HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv,
-      mapPoints_extendPoint]
+    rw [innerConjugationPointIso_hom_apply, innerConjugationPointIso_hom_apply]
+    exact (mapPoints_conjugate_extendPoint H f g x').symm
 
 /-- Conjugation by the identity point is the identity automorphism of the functor of points. -/
 @[simp]
@@ -150,8 +163,32 @@ theorem innerConjugationPointsIso_one :
   apply MonoidHom.ext
   intro x
   let x' : HopfAlgebra.points (R := R) (H := H) A := x
+  -- The components of `innerConjugationPointsIso` are stored as `GrpCat` morphisms; expose the
+  -- underlying conjugation formula before applying its computation lemma.
   change extendPoint H A 1 * x' * (extendPoint H A 1)⁻¹ = x'
-  simp
+  simp only [extendPoint_one, inv_one, one_mul, mul_one]
+
+/-- Conjugation by a product is successive conjugation, first by the second point and then by the
+first. -/
+@[simp]
+theorem innerConjugationPointsIso_mul
+    (g h : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    innerConjugationPointsIso H (g * h) =
+      (innerConjugationPointsIso H h).trans (innerConjugationPointsIso H g) := by
+  apply Iso.ext
+  apply NatTrans.ext
+  funext A
+  apply GrpCat.hom_ext
+  apply MonoidHom.ext
+  intro x
+  let x' : HopfAlgebra.points (R := R) (H := H) A := x
+  -- As above, remove only the `NatIso.ofComponents`/`GrpCat` wrappers to compare the two
+  -- conjugation automorphisms on an arbitrary point.
+  change (MulAut.conj (extendPoint H A (g * h))) x' =
+    (MulAut.conj (extendPoint H A g)) ((MulAut.conj (extendPoint H A h)) x')
+  rw [extendPoint_mul]
+  exact congrArg (fun f : MulAut _ ↦ f x') ((MulAut.conj : _ →* MulAut _).map_mul
+    (extendPoint H A g) (extendPoint H A h))
 
 /-- Conjugation by an inverse point is inverse to conjugation by the original point. -/
 @[simp]
@@ -165,6 +202,8 @@ theorem innerConjugationPointsIso_inv
   apply MonoidHom.ext
   intro x
   let x' : HopfAlgebra.points (R := R) (H := H) A := x
+  -- The two sides are hidden behind the component projections of the natural isomorphisms;
+  -- expose the pointwise formulas so the named hom/inverse computation lemmas apply.
   change extendPoint H A g⁻¹ * x' * (extendPoint H A g⁻¹)⁻¹ =
     (innerConjugationPointIso H g A).inv x'
   rw [innerConjugationPointIso_inv_apply]
@@ -194,9 +233,27 @@ theorem innerConjugationIso_one :
         (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) =
       Iso.refl H := by
   apply Iso.ext
+  -- `innerConjugationIso` is assembled fieldwise from the recovered coordinate maps, so expose
+  -- its `hom` field before applying their identity law.
   change homOfPointsMap (innerConjugationPointsIso H 1).hom = 𝟙 H
   rw [innerConjugationPointsIso_one]
   exact homOfPointsMap_id H
+
+/-- Coordinate pullback reverses the pointwise composition order: the coordinate automorphism for
+conjugation by `g * h` is the composite for `g` followed by the one for `h`. -/
+@[simp]
+theorem innerConjugationIso_mul
+    (g h : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    innerConjugationIso H (g * h) =
+      (innerConjugationIso H g).trans (innerConjugationIso H h) := by
+  apply Iso.ext
+  -- Expose the `homOfPointsMap` fields so its explicit contravariant composition law applies.
+  change homOfPointsMap (innerConjugationPointsIso H (g * h)).hom =
+    homOfPointsMap (innerConjugationPointsIso H g).hom ≫
+      homOfPointsMap (innerConjugationPointsIso H h).hom
+  have hmul := congrArg Iso.hom (innerConjugationPointsIso_mul H g h)
+  simp only [Iso.trans_hom] at hmul
+  rw [hmul, homOfPointsMap_comp]
 
 /-- The coordinate automorphism for conjugation by an inverse point is the inverse coordinate
 automorphism. -/
@@ -205,6 +262,8 @@ theorem innerConjugationIso_inv
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     innerConjugationIso H g⁻¹ = (innerConjugationIso H g).symm := by
   apply Iso.ext
+  -- As in the identity and multiplication laws, expose the fieldwise construction before using
+  -- the corresponding functor-of-points equality.
   change homOfPointsMap (innerConjugationPointsIso H g⁻¹).hom =
     homOfPointsMap (innerConjugationPointsIso H g).inv
   rw [innerConjugationPointsIso_inv]

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/InnerConjugation.lean
@@ -82,8 +82,8 @@ theorem extendPoint_inv (A : CommAlgCat.{v} R)
     extendPoint H A g⁻¹ = (extendPoint H A g)⁻¹ := by
   exact (AlgHom.mapValue (H := H) (Algebra.ofId R A)).map_inv g
 
-/-- Extension of a ground-ring-valued point is natural in the value algebra. -/
-theorem mapPoints_extendPoint {A : CommAlgCat.{v} R} {B : CommAlgCat.{w} R}
+/-- Post-composition of an extended ground-ring-valued point is extension to the target algebra. -/
+theorem mapValue_extendPoint {A : CommAlgCat.{v} R} {B : CommAlgCat.{w} R}
     (f : A →ₐ[R] B)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     AlgHom.mapValue (H := H) f (extendPoint H A g) = extendPoint H B g := by
@@ -92,6 +92,17 @@ theorem mapPoints_extendPoint {A : CommAlgCat.{v} R} {B : CommAlgCat.{w} R}
   simp only [extendPoint, AlgHom.mapValue_apply,
     WithConv.ofConv_toConv, AlgHom.comp_apply]
   exact f.commutes (g.ofConv x)
+
+/-- The categorical point map sends an extended rational point to its extension in the target
+value algebra. -/
+theorem mapPoints_extendPoint {A B : CommAlgCat.{v} R} (f : A ⟶ B)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    HopfAlgebra.mapPoints (H := H) f (extendPoint H A g) = extendPoint H B g := by
+  rw [HopfAlgebra.mapPoints_apply]
+  apply WithConv.ofConv_injective
+  ext x
+  simp only [extendPoint, AlgHom.mapValue_apply, WithConv.ofConv_toConv, AlgHom.comp_apply]
+  exact f.hom.commutes (g.ofConv x)
 
 /-- Mapping a conjugate by an extended rational point commutes with extension to the target value
 algebra. This isolates the group-homomorphism normalization used in the naturality proof below. -/
@@ -102,8 +113,7 @@ private theorem mapPoints_conjugate_extendPoint {A B : CommAlgCat.{v} R} (f : A 
         (extendPoint H A g * x * (extendPoint H A g)⁻¹) =
       extendPoint H B g * HopfAlgebra.mapPoints (H := H) f x * (extendPoint H B g)⁻¹ := by
   rw [HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_mul, HopfAlgebra.mapPoints_inv]
-  rw [show HopfAlgebra.mapPoints (H := H) f (extendPoint H A g) = extendPoint H B g from
-    mapPoints_extendPoint H f.hom g]
+  rw [mapPoints_extendPoint]
 
 /-- Conjugation by the extension of a rational point, as an automorphism of `A`-valued points. -/
 noncomputable def innerConjugationPointIso
@@ -147,6 +157,25 @@ noncomputable def innerConjugationPointsIso
       HopfAlgebra.mapPoints (H := H) f ((innerConjugationPointIso H g A).hom x')
     rw [innerConjugationPointIso_hom_apply, innerConjugationPointIso_hom_apply]
     exact (mapPoints_conjugate_extendPoint H f g x').symm
+
+/-- The hom component of natural inner conjugation acts by conjugation by the extended point. -/
+@[simp]
+theorem innerConjugationPointsIso_hom_app_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (innerConjugationPointsIso H g).hom.app A x =
+      extendPoint H A g * x * (extendPoint H A g)⁻¹ := by
+  exact innerConjugationPointIso_hom_apply H g A x
+
+/-- The inverse component of natural inner conjugation acts by conjugation by the inverse
+extended point. -/
+@[simp]
+theorem innerConjugationPointsIso_inv_app_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (innerConjugationPointsIso H g).inv.app A x =
+      extendPoint H A g⁻¹ * x * extendPoint H A g := by
+  exact innerConjugationPointIso_inv_apply H g A x
 
 /-- Conjugation by the identity point is the identity automorphism of the functor of points. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
@@ -144,9 +144,10 @@ noncomputable def conjugateOrderIso
 theorem conjugateOrderIso_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (I : HopfIdeal R H) :
     conjugateOrderIso g I = I.conjugate g := by
-  rw [conjugateOrderIso, comapOrderIso_apply]
-  unfold conjugate
-  rfl
+  exact comapOrderIso_ofBijective_apply
+    (CommHopfAlgCat.innerConjugationIso H g).hom.hom
+    (ConcreteCategory.bijective_of_isIso
+      (CommHopfAlgCat.innerConjugationIso H g).hom) I
 
 /-- Applying the inverse conjugation order isomorphism conjugates by the inverse point. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Hopf.InnerConjugation
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.InnerConjugation
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
 
 /-!
@@ -15,14 +15,13 @@ A Hopf ideal `I` in a commutative Hopf algebra `H` cuts out a closed subgroup of
 group represented by `H`. Pulling `I` back along the coordinate automorphism attached to a
 rational point `g` cuts out the conjugate subgroup `g G_I g⁻¹`.
 
-The characteristic point theorem keeps the contravariance visible: a point `x` belongs to the
-subgroup cut out by `I` exactly when its conjugate by `g` belongs to the subgroup cut out by
-`I.conjugate g`.
+The characteristic point theorem states that a point `x` belongs to the subgroup cut out by `I`
+exactly when its conjugate by `g` belongs to the subgroup cut out by `I.conjugate g`.
 
 ## Main declarations
 
 * `TauCeti.HopfIdeal.conjugate`: the defining Hopf ideal of a conjugate closed subgroup.
-* `TauCeti.HopfIdeal.mem_quotientPointsSubgroup_conjugate_iff`: conjugation identifies the
+* `TauCeti.HopfIdeal.conj_mem_quotientPointsSubgroup_conjugate_iff`: conjugation identifies the
   corresponding algebra-valued point subgroups.
 * `TauCeti.HopfIdeal.conjugateOrderIso`: conjugation as an order automorphism of Hopf ideals.
 
@@ -69,19 +68,28 @@ belongs to the conjugate closed subgroup.
 
 Thus conjugation gives a bijection from the original subgroup's `A`-points to the conjugate
 subgroup's `A`-points, uniformly in the commutative value algebra `A`. -/
-@[simp]
-theorem mem_quotientPointsSubgroup_conjugate_iff (I : HopfIdeal R H)
+theorem conj_mem_quotientPointsSubgroup_conjugate_iff (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
     (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
-    CommHopfAlgCat.extendPoint H A g * x * (CommHopfAlgCat.extendPoint H A g)⁻¹ ∈
+    HopfAlgebra.extendPoint H A g * x * (HopfAlgebra.extendPoint H A g)⁻¹ ∈
         CommHopfAlgCat.quotientPointsSubgroup H (I.conjugate g) A ↔
       x ∈ CommHopfAlgCat.quotientPointsSubgroup H I A := by
   let f := (CommHopfAlgCat.innerConjugationIso H g).hom.hom
   have hf : Function.Bijective f :=
     ConcreteCategory.bijective_of_isIso (CommHopfAlgCat.innerConjugationIso H g).hom
   rw [← CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply H g A x]
-  -- The generic transport theorem reconstructs the categorical Hopf algebra from its carrier;
-  -- expose that presentation together with the point-map wrapper before applying it.
+  rw [CommHopfAlgCat.mapPointsFunctor_app_apply]
+  rw [← AlgHom.mapDomain_apply]
+  change AlgHom.mapDomain f x ∈ CommHopfAlgCat.quotientPointsSubgroup H (I.conjugate g) A ↔
+    x ∈ CommHopfAlgCat.quotientPointsSubgroup H I A
+  have he : (BialgEquiv.ofBijective f hf).toBialgHom = f := by
+    ext y
+    exact congrFun (BialgEquiv.coe_ofBijective f hf) y
+  rw [← he]
+  rw [BialgEquiv.toBialgHom_eq_coe]
+  rw [← AlgHom.mapDomainMulEquiv_apply (BialgEquiv.ofBijective f hf)]
+  -- The generic transport theorem reconstructs the categorical object from its carrier; this
+  -- `change` is only the residual `CommHopfAlgCat.of R ↑H` eta identification.
   change AlgHom.mapDomainMulEquiv (A := A) (BialgEquiv.ofBijective f hf) x ∈
       CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R ↑H)
         (I.comapOfSurjective f hf.2) A ↔
@@ -96,10 +104,10 @@ theorem conjugate_one (I : HopfIdeal R H) :
         (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) = I := by
   ext x
   rw [mem_conjugate_iff, CommHopfAlgCat.innerConjugationIso_one]
-  rfl
+  simp
 
-/-- Successive conjugation first by `g` and then by `h` is conjugation by `h * g`. The reversed
-order comes from the contravariance of defining ideals. -/
+/-- Successive conjugation first by `g` and then by `h` is conjugation by `h * g`, in the usual
+order for the action by inner automorphisms. -/
 @[simp]
 theorem conjugate_conjugate (I : HopfIdeal R H)
     (g h : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
@@ -107,16 +115,16 @@ theorem conjugate_conjugate (I : HopfIdeal R H)
   ext x
   rw [mem_conjugate_iff, mem_conjugate_iff, mem_conjugate_iff,
     CommHopfAlgCat.innerConjugationIso_mul]
-  rfl
+  simp only [Iso.trans_hom, CategoryTheory.ConcreteCategory.comp_apply]
 
 /-- Conjugating by `g⁻¹` undoes conjugation by `g`. -/
-theorem conjugate_inv_conjugate (I : HopfIdeal R H)
+theorem conjugate_conjugate_inv (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     (I.conjugate g).conjugate g⁻¹ = I := by
   rw [conjugate_conjugate, inv_mul_cancel g, conjugate_one]
 
 /-- Conjugating by `g` undoes conjugation by `g⁻¹`. -/
-theorem conjugate_conjugate_inv (I : HopfIdeal R H)
+theorem conjugate_inv_conjugate (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     (I.conjugate g⁻¹).conjugate g = I := by
   rw [conjugate_conjugate, mul_inv_cancel g, conjugate_one]
@@ -124,21 +132,18 @@ theorem conjugate_conjugate_inv (I : HopfIdeal R H)
 /-- Conjugation by a rational point as an order automorphism of defining Hopf ideals. -/
 noncomputable def conjugateOrderIso
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    HopfIdeal R H ≃o HopfIdeal R H where
-  toFun I := I.conjugate g
-  invFun I := I.conjugate g⁻¹
-  left_inv I := conjugate_inv_conjugate I g
-  right_inv I := conjugate_conjugate_inv I g
-  map_rel_iff' := comapOfSurjective_le_comapOfSurjective_iff
+    HopfIdeal R H ≃o HopfIdeal R H :=
+  comapOrderIso (BialgEquiv.ofBijective
     (CommHopfAlgCat.innerConjugationIso H g).hom.hom
-      (ConcreteCategory.bijective_of_isIso
-        (CommHopfAlgCat.innerConjugationIso H g).hom).2
+    (ConcreteCategory.bijective_of_isIso
+      (CommHopfAlgCat.innerConjugationIso H g).hom))
 
 /-- Applying the conjugation order isomorphism conjugates the defining Hopf ideal. -/
 @[simp]
 theorem conjugateOrderIso_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (I : HopfIdeal R H) :
     conjugateOrderIso g I = I.conjugate g := by
+  unfold conjugateOrderIso comapOrderIso conjugate
   rfl
 
 /-- Applying the inverse conjugation order isomorphism conjugates by the inverse point. -/
@@ -146,7 +151,8 @@ theorem conjugateOrderIso_apply
 theorem conjugateOrderIso_symm_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (I : HopfIdeal R H) :
     (conjugateOrderIso g).symm I = I.conjugate g⁻¹ := by
-  rfl
+  apply (conjugateOrderIso g).injective
+  rw [OrderIso.apply_symm_apply, conjugateOrderIso_apply, conjugate_inv_conjugate]
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
@@ -78,21 +78,15 @@ theorem mem_quotientPointsSubgroup_conjugate_iff (I : HopfIdeal R H)
   let f := (CommHopfAlgCat.innerConjugationIso H g).hom.hom
   have hf : Function.Bijective f :=
     ConcreteCategory.bijective_of_isIso (CommHopfAlgCat.innerConjugationIso H g).hom
-  rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff,
-    CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
-  constructor
-  · intro hx y hy
-    obtain ⟨z, rfl⟩ := hf.2 y
-    have hz : z ∈ I.conjugate g := (mem_conjugate_iff I g z).2 hy
-    have haction := congrArg (fun p : HopfAlgebra.points (R := R) (H := H) A ↦ p.ofConv z)
-      (CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply H g A x)
-    rw [CommHopfAlgCat.mapPointsFunctor_app_apply_apply] at haction
-    exact haction.trans (hx z hz)
-  · intro hx y hy
-    have haction := congrArg (fun p : HopfAlgebra.points (R := R) (H := H) A ↦ p.ofConv y)
-      (CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply H g A x)
-    rw [CommHopfAlgCat.mapPointsFunctor_app_apply_apply] at haction
-    exact haction.symm.trans (hx (f y) ((mem_conjugate_iff I g y).1 hy))
+  rw [← CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply H g A x]
+  -- The generic transport theorem reconstructs the categorical Hopf algebra from its carrier;
+  -- expose that presentation together with the point-map wrapper before applying it.
+  change AlgHom.mapDomainMulEquiv (A := A) (BialgEquiv.ofBijective f hf) x ∈
+      CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R ↑H)
+        (I.comapOfSurjective f hf.2) A ↔
+    x ∈ CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R ↑H) I A
+  exact CommHopfAlgCat.mapDomainMulEquiv_mem_quotientPointsSubgroup_comapOfSurjective_iff
+    f hf.1 hf.2 I A x
 
 /-- Conjugating a closed subgroup by the identity point does not change it. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
@@ -68,6 +68,7 @@ belongs to the conjugate closed subgroup.
 
 Thus conjugation gives a bijection from the original subgroup's `A`-points to the conjugate
 subgroup's `A`-points, uniformly in the commutative value algebra `A`. -/
+@[simp]
 theorem conj_mem_quotientPointsSubgroup_conjugate_iff (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
     (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
@@ -77,11 +78,11 @@ theorem conj_mem_quotientPointsSubgroup_conjugate_iff (I : HopfIdeal R H)
   let f := (CommHopfAlgCat.innerConjugationIso H g).hom.hom
   have hf : Function.Bijective f :=
     ConcreteCategory.bijective_of_isIso (CommHopfAlgCat.innerConjugationIso H g).hom
-  rw [← CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply H g A x]
-  rw [CommHopfAlgCat.mapPointsFunctor_app_apply]
-  rw [← AlgHom.mapDomain_apply]
-  change AlgHom.mapDomain f x ∈ CommHopfAlgCat.quotientPointsSubgroup H (I.conjugate g) A ↔
-    x ∈ CommHopfAlgCat.quotientPointsSubgroup H I A
+  have hmap :
+      (CommHopfAlgCat.mapPointsFunctor
+        (CommHopfAlgCat.innerConjugationIso H g).hom).app A x = AlgHom.mapDomain f x := by
+    rw [CommHopfAlgCat.mapPointsFunctor_app_apply, AlgHom.mapDomain_apply]
+  rw [← CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply H g A x, hmap]
   have he : (BialgEquiv.ofBijective f hf).toBialgHom = f := by
     ext y
     exact congrFun (BialgEquiv.coe_ofBijective f hf) y
@@ -143,7 +144,8 @@ noncomputable def conjugateOrderIso
 theorem conjugateOrderIso_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (I : HopfIdeal R H) :
     conjugateOrderIso g I = I.conjugate g := by
-  unfold conjugateOrderIso comapOrderIso conjugate
+  rw [conjugateOrderIso, comapOrderIso_apply]
+  unfold conjugate
   rfl
 
 /-- Applying the inverse conjugation order isomorphism conjugates by the inverse point. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.InnerConjugation
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
+
+/-!
+# Conjugating closed subgroups of affine groups
+
+A Hopf ideal `I` in a commutative Hopf algebra `H` cuts out a closed subgroup of the affine
+group represented by `H`. Pulling `I` back along the coordinate automorphism attached to a
+rational point `g` cuts out the conjugate subgroup `g G_I g⁻¹`.
+
+The characteristic point theorem keeps the contravariance visible: a point `x` belongs to the
+subgroup cut out by `I` exactly when its conjugate by `g` belongs to the subgroup cut out by
+`I.conjugate g`.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.conjugate`: the defining Hopf ideal of a conjugate closed subgroup.
+* `TauCeti.HopfIdeal.mem_quotientPointsSubgroup_conjugate_iff`: conjugation identifies the
+  corresponding algebra-valued point subgroups.
+* `TauCeti.HopfIdeal.conjugateOrderIso`: conjugation as an order automorphism of Hopf ideals.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§3.5 and 10.20.
+* A. Borel, *Linear Algebraic Groups*, 2nd ed. (1991), §8.
+
+This supplies the closed-subgroup conjugation operation required before the Layer 7 conjugacy
+theorems for maximal tori and Borel subgroups in the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u
+
+namespace HopfIdeal
+
+variable {R : Type u} [CommRing R]
+variable {H : _root_.CommHopfAlgCat.{u} R}
+
+/-- The defining ideal of the conjugate by `g` of the closed subgroup cut out by `I`.
+
+The inverse image is taken along the coordinate pullback for `x ↦ g x g⁻¹`. Since coordinate
+rings are contravariant, this ideal cuts out the direct image of the subgroup under that
+automorphism. -/
+noncomputable def conjugate (I : HopfIdeal R H)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) : HopfIdeal R H :=
+  I.comapOfSurjective (CommHopfAlgCat.innerConjugationIso H g).hom.hom
+    (ConcreteCategory.bijective_of_isIso
+      (CommHopfAlgCat.innerConjugationIso H g).hom).2
+
+/-- The conjugate ideal is the inverse image along the coordinate inner automorphism. -/
+theorem conjugate_eq_comapOfSurjective (I : HopfIdeal R H)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    I.conjugate g =
+      I.comapOfSurjective (CommHopfAlgCat.innerConjugationIso H g).hom.hom
+        (ConcreteCategory.bijective_of_isIso
+          (CommHopfAlgCat.innerConjugationIso H g).hom).2 := by
+  rfl
+
+/-- Membership in the conjugate defining ideal is membership after applying the coordinate
+inner automorphism. -/
+@[simp]
+theorem mem_conjugate_iff (I : HopfIdeal R H)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (x : H) :
+    x ∈ I.conjugate g ↔ (CommHopfAlgCat.innerConjugationIso H g).hom.hom x ∈ I := by
+  rw [conjugate_eq_comapOfSurjective, mem_comapOfSurjective]
+
+private theorem mapDomainMulEquiv_innerConjugation_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (hf : Function.Bijective (CommHopfAlgCat.innerConjugationIso H g).hom.hom)
+    (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    AlgHom.mapDomainMulEquiv (A := A)
+        (BialgEquiv.ofBijective (CommHopfAlgCat.innerConjugationIso H g).hom.hom hf) x =
+      CommHopfAlgCat.extendPoint H A g * x * (CommHopfAlgCat.extendPoint H A g)⁻¹ := by
+  have h := CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply H g A x
+  apply WithConv.ofConv_injective
+  exact congrArg WithConv.ofConv h
+
+/-- A point belongs to the closed subgroup cut out by `I` exactly when its conjugate by `g`
+belongs to the conjugate closed subgroup.
+
+Thus conjugation gives a bijection from the original subgroup's `A`-points to the conjugate
+subgroup's `A`-points, uniformly in the commutative value algebra `A`. -/
+theorem mem_quotientPointsSubgroup_conjugate_iff (I : HopfIdeal R H)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    CommHopfAlgCat.extendPoint H A g * x * (CommHopfAlgCat.extendPoint H A g)⁻¹ ∈
+        CommHopfAlgCat.quotientPointsSubgroup H (I.conjugate g) A ↔
+      x ∈ CommHopfAlgCat.quotientPointsSubgroup H I A := by
+  let f := (CommHopfAlgCat.innerConjugationIso H g).hom.hom
+  let hf : Function.Bijective f :=
+    ConcreteCategory.bijective_of_isIso (CommHopfAlgCat.innerConjugationIso H g).hom
+  have h := CommHopfAlgCat.mapDomainMulEquiv_mem_quotientPointsSubgroup_comapOfSurjective_iff
+    f hf.1 hf.2 I A x
+  rw [mapDomainMulEquiv_innerConjugation_apply g hf] at h
+  change _ ∈ CommHopfAlgCat.quotientPointsSubgroup H (I.conjugate g) A ↔ _ at h
+  exact h
+
+/-- Conjugation preserves containment of closed subgroups, expressed in the reversed order on
+their defining Hopf ideals. -/
+theorem conjugate_mono
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    Monotone (fun I : HopfIdeal R H ↦ I.conjugate g) := by
+  intro I J hIJ
+  exact comapOfSurjective_mono _ _ hIJ
+
+/-- Conjugating a closed subgroup by the identity point does not change it. -/
+@[simp]
+theorem conjugate_one (I : HopfIdeal R H) :
+    I.conjugate
+        (1 : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) = I := by
+  ext x
+  rw [mem_conjugate_iff, CommHopfAlgCat.innerConjugationIso_one]
+  rfl
+
+/-- Conjugating by `g⁻¹` undoes conjugation by `g`. -/
+@[simp]
+theorem conjugate_inv_conjugate (I : HopfIdeal R H)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    (I.conjugate g).conjugate g⁻¹ = I := by
+  ext x
+  rw [mem_conjugate_iff, mem_conjugate_iff, CommHopfAlgCat.innerConjugationIso_inv]
+  simp
+
+/-- Conjugating by `g` undoes conjugation by `g⁻¹`. -/
+@[simp]
+theorem conjugate_conjugate_inv (I : HopfIdeal R H)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    (I.conjugate g⁻¹).conjugate g = I := by
+  simpa only [inv_inv] using conjugate_inv_conjugate I g⁻¹
+
+/-- Conjugation by a rational point as an order automorphism of defining Hopf ideals. -/
+noncomputable def conjugateOrderIso
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    HopfIdeal R H ≃o HopfIdeal R H where
+  toFun I := I.conjugate g
+  invFun I := I.conjugate g⁻¹
+  left_inv I := conjugate_inv_conjugate I g
+  right_inv I := conjugate_conjugate_inv I g
+  map_rel_iff' := by
+    intro I J
+    change I.conjugate g ≤ J.conjugate g ↔ I ≤ J
+    constructor
+    · intro h
+      have := conjugate_mono g⁻¹ h
+      change (I.conjugate g).conjugate g⁻¹ ≤ (J.conjugate g).conjugate g⁻¹ at this
+      rw [conjugate_inv_conjugate, conjugate_inv_conjugate] at this
+      exact this
+    · intro h
+      exact conjugate_mono g h
+
+end HopfIdeal
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
@@ -30,9 +30,6 @@ subgroup cut out by `I` exactly when its conjugate by `g` belongs to the subgrou
 
 * J. S. Milne, *Algebraic Groups* (2017), §§3.5 and 10.20.
 * A. Borel, *Linear Algebraic Groups*, 2nd ed. (1991), §8.
-
-This supplies the closed-subgroup conjugation operation required before the Layer 7 conjugacy
-theorems for maximal tori and Borel subgroups in the ReductiveGroups roadmap.
 -/
 
 public section
@@ -147,8 +144,6 @@ noncomputable def conjugateOrderIso
 theorem conjugateOrderIso_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (I : HopfIdeal R H) :
     conjugateOrderIso g I = I.conjugate g := by
-  rw [conjugateOrderIso]
-  change I.conjugate g = I.conjugate g
   rfl
 
 /-- Applying the inverse conjugation order isomorphism conjugates by the inverse point. -/
@@ -156,8 +151,6 @@ theorem conjugateOrderIso_apply
 theorem conjugateOrderIso_symm_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (I : HopfIdeal R H) :
     (conjugateOrderIso g).symm I = I.conjugate g⁻¹ := by
-  rw [conjugateOrderIso]
-  change I.conjugate g⁻¹ = I.conjugate g⁻¹
   rfl
 
 end HopfIdeal

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
@@ -41,7 +41,7 @@ open CategoryTheory WithConv
 
 namespace TauCeti
 
-universe u
+universe u v
 
 namespace HopfIdeal
 
@@ -53,7 +53,7 @@ variable {H : _root_.CommHopfAlgCat.{u} R}
 The inverse image is taken along the coordinate pullback for `x ↦ g x g⁻¹`. Since coordinate
 rings are contravariant, this ideal cuts out the direct image of the subgroup under that
 automorphism. -/
-@[expose] noncomputable def conjugate (I : HopfIdeal R H)
+noncomputable def conjugate (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) : HopfIdeal R H :=
   I.comapOfSurjective (CommHopfAlgCat.innerConjugationIso H g).hom.hom
     (ConcreteCategory.bijective_of_isIso
@@ -67,17 +67,6 @@ theorem mem_conjugate_iff (I : HopfIdeal R H)
     x ∈ I.conjugate g ↔ (CommHopfAlgCat.innerConjugationIso H g).hom.hom x ∈ I := by
   rw [conjugate, mem_comapOfSurjective]
 
-private theorem mapDomainMulEquiv_innerConjugation_apply
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (hf : Function.Bijective (CommHopfAlgCat.innerConjugationIso H g).hom.hom)
-    (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
-    AlgHom.mapDomainMulEquiv (A := A)
-        (BialgEquiv.ofBijective (CommHopfAlgCat.innerConjugationIso H g).hom.hom hf) x =
-      CommHopfAlgCat.extendPoint H A g * x * (CommHopfAlgCat.extendPoint H A g)⁻¹ := by
-  have h := CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply H g A x
-  apply WithConv.ofConv_injective
-  exact congrArg WithConv.ofConv h
-
 /-- A point belongs to the closed subgroup cut out by `I` exactly when its conjugate by `g`
 belongs to the conjugate closed subgroup.
 
@@ -85,28 +74,28 @@ Thus conjugation gives a bijection from the original subgroup's `A`-points to th
 subgroup's `A`-points, uniformly in the commutative value algebra `A`. -/
 theorem mem_quotientPointsSubgroup_conjugate_iff (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (A : CommAlgCat.{u} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
+    (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :
     CommHopfAlgCat.extendPoint H A g * x * (CommHopfAlgCat.extendPoint H A g)⁻¹ ∈
         CommHopfAlgCat.quotientPointsSubgroup H (I.conjugate g) A ↔
       x ∈ CommHopfAlgCat.quotientPointsSubgroup H I A := by
   let f := (CommHopfAlgCat.innerConjugationIso H g).hom.hom
-  let hf : Function.Bijective f :=
+  have hf : Function.Bijective f :=
     ConcreteCategory.bijective_of_isIso (CommHopfAlgCat.innerConjugationIso H g).hom
-  have h := CommHopfAlgCat.mapDomainMulEquiv_mem_quotientPointsSubgroup_comapOfSurjective_iff
-    f hf.1 hf.2 I A x
-  rw [mapDomainMulEquiv_innerConjugation_apply g hf] at h
-  -- The transport theorem reconstructs the bundled coordinate object from its carrier, whereas
-  -- `conjugate` retains the original bundle. Expose their definitionally equal subgroup statement.
-  change _ ∈ CommHopfAlgCat.quotientPointsSubgroup H (I.conjugate g) A ↔ _ at h
-  exact h
-
-/-- Conjugation preserves containment of closed subgroups, expressed in the reversed order on
-their defining Hopf ideals. -/
-theorem conjugate_mono
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    Monotone (fun I : HopfIdeal R H ↦ I.conjugate g) := by
-  intro I J hIJ
-  exact comapOfSurjective_mono _ _ hIJ
+  rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff,
+    CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
+  constructor
+  · intro hx y hy
+    obtain ⟨z, rfl⟩ := hf.2 y
+    have hz : z ∈ I.conjugate g := (mem_conjugate_iff I g z).2 hy
+    have haction := congrArg (fun p : HopfAlgebra.points (R := R) (H := H) A ↦ p.ofConv z)
+      (CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply H g A x)
+    rw [CommHopfAlgCat.mapPointsFunctor_app_apply_apply] at haction
+    exact haction.trans (hx z hz)
+  · intro hx y hy
+    have haction := congrArg (fun p : HopfAlgebra.points (R := R) (H := H) A ↦ p.ofConv y)
+      (CommHopfAlgCat.mapPointsFunctor_innerConjugationIso_hom_app_apply H g A x)
+    rw [CommHopfAlgCat.mapPointsFunctor_app_apply_apply] at haction
+    exact haction.symm.trans (hx (f y) ((mem_conjugate_iff I g y).1 hy))
 
 /-- Conjugating a closed subgroup by the identity point does not change it. -/
 @[simp]
@@ -148,21 +137,28 @@ noncomputable def conjugateOrderIso
   invFun I := I.conjugate g⁻¹
   left_inv I := conjugate_inv_conjugate I g
   right_inv I := conjugate_conjugate_inv I g
-  map_rel_iff' := by
-    intro I J
-    -- `OrderIso` stores this field through `toFun`; expose the displayed conjugation operation
-    -- before applying monotonicity and inverse cancellation.
-    change I.conjugate g ≤ J.conjugate g ↔ I ≤ J
-    constructor
-    · intro h
-      have h' := conjugate_mono g⁻¹ h
-      -- The inferred function arguments of `conjugate_mono` remain hidden in `h'`; expose the
-      -- iterated conjugations so their cancellation lemmas rewrite directly.
-      change (I.conjugate g).conjugate g⁻¹ ≤ (J.conjugate g).conjugate g⁻¹ at h'
-      rw [conjugate_inv_conjugate, conjugate_inv_conjugate] at h'
-      exact h'
-    · intro h
-      exact conjugate_mono g h
+  map_rel_iff' := comapOfSurjective_le_comapOfSurjective_iff
+    (CommHopfAlgCat.innerConjugationIso H g).hom.hom
+      (ConcreteCategory.bijective_of_isIso
+        (CommHopfAlgCat.innerConjugationIso H g).hom).2
+
+/-- Applying the conjugation order isomorphism conjugates the defining Hopf ideal. -/
+@[simp]
+theorem conjugateOrderIso_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (I : HopfIdeal R H) :
+    conjugateOrderIso g I = I.conjugate g := by
+  rw [conjugateOrderIso]
+  change I.conjugate g = I.conjugate g
+  rfl
+
+/-- Applying the inverse conjugation order isomorphism conjugates by the inverse point. -/
+@[simp]
+theorem conjugateOrderIso_symm_apply
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (I : HopfIdeal R H) :
+    (conjugateOrderIso g).symm I = I.conjugate g⁻¹ := by
+  rw [conjugateOrderIso]
+  change I.conjugate g⁻¹ = I.conjugate g⁻¹
+  rfl
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
@@ -53,20 +53,11 @@ variable {H : _root_.CommHopfAlgCat.{u} R}
 The inverse image is taken along the coordinate pullback for `x ↦ g x g⁻¹`. Since coordinate
 rings are contravariant, this ideal cuts out the direct image of the subgroup under that
 automorphism. -/
-noncomputable def conjugate (I : HopfIdeal R H)
+@[expose] noncomputable def conjugate (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) : HopfIdeal R H :=
   I.comapOfSurjective (CommHopfAlgCat.innerConjugationIso H g).hom.hom
     (ConcreteCategory.bijective_of_isIso
       (CommHopfAlgCat.innerConjugationIso H g).hom).2
-
-/-- The conjugate ideal is the inverse image along the coordinate inner automorphism. -/
-theorem conjugate_eq_comapOfSurjective (I : HopfIdeal R H)
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    I.conjugate g =
-      I.comapOfSurjective (CommHopfAlgCat.innerConjugationIso H g).hom.hom
-        (ConcreteCategory.bijective_of_isIso
-          (CommHopfAlgCat.innerConjugationIso H g).hom).2 := by
-  rfl
 
 /-- Membership in the conjugate defining ideal is membership after applying the coordinate
 inner automorphism. -/
@@ -74,7 +65,7 @@ inner automorphism. -/
 theorem mem_conjugate_iff (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (x : H) :
     x ∈ I.conjugate g ↔ (CommHopfAlgCat.innerConjugationIso H g).hom.hom x ∈ I := by
-  rw [conjugate_eq_comapOfSurjective, mem_comapOfSurjective]
+  rw [conjugate, mem_comapOfSurjective]
 
 private theorem mapDomainMulEquiv_innerConjugation_apply
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
@@ -104,6 +95,8 @@ theorem mem_quotientPointsSubgroup_conjugate_iff (I : HopfIdeal R H)
   have h := CommHopfAlgCat.mapDomainMulEquiv_mem_quotientPointsSubgroup_comapOfSurjective_iff
     f hf.1 hf.2 I A x
   rw [mapDomainMulEquiv_innerConjugation_apply g hf] at h
+  -- The transport theorem reconstructs the bundled coordinate object from its carrier, whereas
+  -- `conjugate` retains the original bundle. Expose their definitionally equal subgroup statement.
   change _ ∈ CommHopfAlgCat.quotientPointsSubgroup H (I.conjugate g) A ↔ _ at h
   exact h
 
@@ -124,21 +117,28 @@ theorem conjugate_one (I : HopfIdeal R H) :
   rw [mem_conjugate_iff, CommHopfAlgCat.innerConjugationIso_one]
   rfl
 
-/-- Conjugating by `g⁻¹` undoes conjugation by `g`. -/
+/-- Successive conjugation first by `g` and then by `h` is conjugation by `h * g`. The reversed
+order comes from the contravariance of defining ideals. -/
 @[simp]
+theorem conjugate_conjugate (I : HopfIdeal R H)
+    (g h : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    (I.conjugate g).conjugate h = I.conjugate (h * g) := by
+  ext x
+  rw [mem_conjugate_iff, mem_conjugate_iff, mem_conjugate_iff,
+    CommHopfAlgCat.innerConjugationIso_mul]
+  rfl
+
+/-- Conjugating by `g⁻¹` undoes conjugation by `g`. -/
 theorem conjugate_inv_conjugate (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     (I.conjugate g).conjugate g⁻¹ = I := by
-  ext x
-  rw [mem_conjugate_iff, mem_conjugate_iff, CommHopfAlgCat.innerConjugationIso_inv]
-  simp
+  rw [conjugate_conjugate, inv_mul_cancel g, conjugate_one]
 
 /-- Conjugating by `g` undoes conjugation by `g⁻¹`. -/
-@[simp]
 theorem conjugate_conjugate_inv (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
     (I.conjugate g⁻¹).conjugate g = I := by
-  simpa only [inv_inv] using conjugate_inv_conjugate I g⁻¹
+  rw [conjugate_conjugate, mul_inv_cancel g, conjugate_one]
 
 /-- Conjugation by a rational point as an order automorphism of defining Hopf ideals. -/
 noncomputable def conjugateOrderIso
@@ -150,13 +150,17 @@ noncomputable def conjugateOrderIso
   right_inv I := conjugate_conjugate_inv I g
   map_rel_iff' := by
     intro I J
+    -- `OrderIso` stores this field through `toFun`; expose the displayed conjugation operation
+    -- before applying monotonicity and inverse cancellation.
     change I.conjugate g ≤ J.conjugate g ↔ I ≤ J
     constructor
     · intro h
-      have := conjugate_mono g⁻¹ h
-      change (I.conjugate g).conjugate g⁻¹ ≤ (J.conjugate g).conjugate g⁻¹ at this
-      rw [conjugate_inv_conjugate, conjugate_inv_conjugate] at this
-      exact this
+      have h' := conjugate_mono g⁻¹ h
+      -- The inferred function arguments of `conjugate_mono` remain hidden in `h'`; expose the
+      -- iterated conjugations so their cancellation lemmas rewrite directly.
+      change (I.conjugate g).conjugate g⁻¹ ≤ (J.conjugate g).conjugate g⁻¹ at h'
+      rw [conjugate_inv_conjugate, conjugate_inv_conjugate] at h'
+      exact h'
     · intro h
       exact conjugate_mono g h
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
@@ -156,6 +156,14 @@ theorem conjugateOrderIso_symm_apply
   apply (conjugateOrderIso g).injective
   rw [OrderIso.apply_symm_apply, conjugateOrderIso_apply, conjugate_inv_conjugate]
 
+/-- Conjugation by a rational point reflects inclusion of defining Hopf ideals. -/
+@[simp]
+theorem conjugate_le_conjugate_iff (I J : HopfIdeal R H)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    I.conjugate g ≤ J.conjugate g ↔ I ≤ J := by
+  simpa only [conjugateOrderIso_apply] using
+    (conjugateOrderIso g).le_iff_le (x := I) (y := J)
+
 end HopfIdeal
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Conjugation.lean
@@ -69,6 +69,7 @@ belongs to the conjugate closed subgroup.
 
 Thus conjugation gives a bijection from the original subgroup's `A`-points to the conjugate
 subgroup's `A`-points, uniformly in the commutative value algebra `A`. -/
+@[simp]
 theorem mem_quotientPointsSubgroup_conjugate_iff (I : HopfIdeal R H)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
     (A : CommAlgCat.{v} R) (x : HopfAlgebra.points (R := R) (H := H) A) :

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -24,6 +24,7 @@ functor of points has values `A ↦ (H →ₐ[R] A)` and group law given by conv
 ## Main definitions
 
 * `HopfAlgebra.points`: the bundled group of `A`-points.
+* `HopfAlgebra.extendPoint`: extension of ground-ring-valued points to a value algebra.
 * `HopfAlgebra.mapPoints`: the group homomorphism induced by post-composition in the value
   algebra.
 * `HopfAlgebra.pointsFunctor`: the functor `CommAlgCat R ⥤ GrpCat`.
@@ -46,7 +47,7 @@ namespace TauCeti
 
 namespace HopfAlgebra
 
-universe u v w
+universe u v w x
 
 variable {R : Type u} [CommRing R] {H : Type v} [Semiring H] [_root_.HopfAlgebra R H]
 
@@ -56,6 +57,28 @@ The underlying type is `WithConv (H →ₐ[R] A)`: algebra homomorphisms from `H
 the convolution group structure supplied by the antipode of `H`. -/
 noncomputable abbrev points (A : CommAlgCat.{w} R) : GrpCat.{max v w} :=
   GrpCat.of (WithConv (H →ₐ[R] A))
+
+/-- Extension of ground-ring-valued points to `A`-valued points along the structure map of `A`. -/
+@[expose] noncomputable def extendPoint (H : Type v) [Semiring H] [_root_.HopfAlgebra R H]
+    (A : CommAlgCat.{w} R) :
+    points (H := H) (CommAlgCat.of R R) →* points (H := H) A :=
+  AlgHom.mapValue (Algebra.ofId R A)
+
+/-- Evaluation of an extended point is obtained by applying the value algebra's structure map. -/
+@[simp]
+theorem extendPoint_ofConv (H : Type v) [Semiring H] [_root_.HopfAlgebra R H]
+    (A : CommAlgCat.{w} R) (g : points (H := H) (CommAlgCat.of R R)) (h : H) :
+    (extendPoint H A g).ofConv h = algebraMap R A (g.ofConv h) := by
+  simp only [extendPoint, AlgHom.mapValue_apply, WithConv.ofConv_toConv, AlgHom.comp_apply,
+    Algebra.ofId_apply]
+
+/-- Post-composition of an extended point is extension to the target algebra. -/
+theorem mapValue_extendPoint (H : Type v) [Semiring H] [_root_.HopfAlgebra R H]
+    {A : CommAlgCat.{w} R} {B : CommAlgCat.{x} R} (f : A →ₐ[R] B)
+    (g : points (H := H) (CommAlgCat.of R R)) :
+    AlgHom.mapValue (H := H) f (extendPoint H A g) = extendPoint H B g := by
+  rw [extendPoint, extendPoint, ← MonoidHom.comp_apply, ← AlgHom.mapValue_comp,
+    Algebra.comp_ofId]
 
 /-- The group homomorphism on points induced by a morphism of value algebras.
 
@@ -96,6 +119,14 @@ lemma mapPoints_id (A : CommAlgCat.{w} R) :
 lemma mapPoints_comp {A B C : CommAlgCat.{w} R} (φ : A ⟶ B) (ψ : B ⟶ C) :
     mapPoints (H := H) (φ ≫ ψ) = mapPoints (H := H) φ ≫ mapPoints (H := H) ψ := by
   simp only [mapPoints, CommAlgCat.hom_comp, AlgHom.mapValue_comp, GrpCat.ofHom_comp]
+
+/-- The categorical point map sends an extended point to its extension in the target algebra. -/
+@[simp]
+theorem mapPoints_extendPoint {A B : CommAlgCat.{w} R} (f : A ⟶ B)
+    (g : points (H := H) (CommAlgCat.of R R)) :
+    mapPoints (H := H) f (extendPoint H A g) = extendPoint H B g := by
+  rw [mapPoints_apply]
+  exact mapValue_extendPoint H f.hom g
 
 /-- The functor of points of the affine group object represented by a Hopf algebra.
 

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -59,7 +59,7 @@ noncomputable abbrev points (A : CommAlgCat.{w} R) : GrpCat.{max v w} :=
   GrpCat.of (WithConv (H →ₐ[R] A))
 
 /-- Extension of ground-ring-valued points to `A`-valued points along the structure map of `A`. -/
-@[expose] noncomputable def extendPoint (H : Type v) [Semiring H] [_root_.HopfAlgebra R H]
+noncomputable def extendPoint (H : Type v) [Semiring H] [_root_.HopfAlgebra R H]
     (A : CommAlgCat.{w} R) :
     points (H := H) (CommAlgCat.of R R) →* points (H := H) A :=
   AlgHom.mapValue (Algebra.ofId R A)

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
@@ -45,8 +45,16 @@ maximal torus. -/
 theorem conjugate (hI : IsMaximalTorus k H.obj I)
     (g : HopfAlgebra.points (R := k) (H := H.obj) (CommAlgCat.of k k)) :
     IsMaximalTorus k H.obj (I.conjugate g) := by
-  unfold _root_.TauCeti.HopfIdeal.conjugate
-  exact hI.comapOfIso (ObjectProperty.isoMk (finiteTypeCommHopfAlgProperty k)
-    (CommHopfAlgCat.innerConjugationIso H.obj g))
+  let e := ObjectProperty.isoMk (finiteTypeCommHopfAlgProperty k)
+    (CommHopfAlgCat.innerConjugationIso H.obj g)
+  have heq : I.conjugate g =
+      I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2 := by
+    apply HopfIdeal.ext
+    intro x
+    rw [HopfIdeal.mem_conjugate_iff, HopfIdeal.mem_comapOfSurjective]
+    rfl
+  rw [heq]
+  exact hI.comapOfIso e
 
 end TauCeti.HopfIdeal.IsMaximalTorus

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Conjugation
+public import TauCeti.Algebra.AlgebraicGroup.Torus.Maximal
+
+/-!
+# Conjugating maximal tori
+
+Conjugation by a rational point is an automorphism of an affine group, so it carries every
+maximal torus to another maximal torus. This file states that fact in Hopf coordinates, where a
+closed subgroup is represented contravariantly by its defining Hopf ideal.
+
+## Main declaration
+
+* `TauCeti.HopfIdeal.IsMaximalTorus.conjugate`: a conjugate of a maximal torus is maximal.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §17.
+* A. Borel, *Linear Algebraic Groups*, 2nd ed. (1991), §8.
+
+This is the conjugation-stability prerequisite for Layer 7, "Borel subgroups, maximal tori, and
+their conjugacy", of the ReductiveGroups roadmap. The existence theorem and the assertion that
+any two maximal tori are conjugate remain separate.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.HopfIdeal.IsMaximalTorus
+
+universe u
+
+variable {k : Type u} [Field k]
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k H.obj}
+
+/-- A conjugate of a maximal torus by a rational point of the ambient affine group is again a
+maximal torus. -/
+theorem conjugate (hI : IsMaximalTorus k H.obj I)
+    (g : HopfAlgebra.points (R := k) (H := H.obj) (CommAlgCat.of k k)) :
+    IsMaximalTorus k H.obj (I.conjugate g) := by
+  rw [HopfIdeal.conjugate_eq_comapOfSurjective]
+  exact hI.comapOfIso (ObjectProperty.isoMk (finiteTypeCommHopfAlgProperty k)
+    (CommHopfAlgCat.innerConjugationIso H.obj g))
+
+end TauCeti.HopfIdeal.IsMaximalTorus

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
@@ -45,7 +45,7 @@ maximal torus. -/
 theorem conjugate (hI : IsMaximalTorus k H.obj I)
     (g : HopfAlgebra.points (R := k) (H := H.obj) (CommAlgCat.of k k)) :
     IsMaximalTorus k H.obj (I.conjugate g) := by
-  rw [HopfIdeal.conjugate_eq_comapOfSurjective]
+  unfold _root_.TauCeti.HopfIdeal.conjugate
   exact hI.comapOfIso (ObjectProperty.isoMk (finiteTypeCommHopfAlgProperty k)
     (CommHopfAlgCat.innerConjugationIso H.obj g))
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
@@ -58,4 +58,14 @@ theorem conjugate (hI : IsMaximalTorus k H.obj I)
   rw [heq]
   exact hI.comapOfIso e
 
+/-- Conjugation by a rational point preserves and reflects the maximal-torus property. -/
+theorem conjugate_iff
+    (g : HopfAlgebra.points (R := k) (H := H.obj) (CommAlgCat.of k k)) :
+    IsMaximalTorus k H.obj (I.conjugate g) ↔ IsMaximalTorus k H.obj I := by
+  constructor
+  · intro hI
+    have hI' := hI.conjugate g⁻¹
+    rwa [HopfIdeal.conjugate_conjugate_inv] at hI'
+  · exact fun hI ↦ hI.conjugate g
+
 end TauCeti.HopfIdeal.IsMaximalTorus

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
@@ -23,10 +23,6 @@ closed subgroup is represented contravariantly by its defining Hopf ideal.
 
 * J. S. Milne, *Algebraic Groups* (2017), §17.
 * A. Borel, *Linear Algebraic Groups*, 2nd ed. (1991), §8.
-
-This is the conjugation-stability prerequisite for Layer 7, "Borel subgroups, maximal tori, and
-their conjugacy", of the ReductiveGroups roadmap. The existence theorem and the assertion that
-any two maximal tori are conjugate remain separate.
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Conjugation.lean
@@ -43,13 +43,18 @@ theorem conjugate (hI : IsMaximalTorus k H.obj I)
     IsMaximalTorus k H.obj (I.conjugate g) := by
   let e := ObjectProperty.isoMk (finiteTypeCommHopfAlgProperty k)
     (CommHopfAlgCat.innerConjugationIso H.obj g)
+  have e_hom : e.hom.hom = (CommHopfAlgCat.innerConjugationIso H.obj g).hom := by
+    simp only [e, ObjectProperty.isoMk_hom, ObjectProperty.homMk_hom]
+  have e_bialgHom : FiniteTypeCommHopfAlgCat.toBialgHom e.hom =
+      (CommHopfAlgCat.innerConjugationIso H.obj g).hom.hom := by
+    exact congrArg (fun f ↦ f.hom) e_hom
   have heq : I.conjugate g =
       I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
         (ConcreteCategory.bijective_of_isIso e.hom).2 := by
     apply HopfIdeal.ext
     intro x
     rw [HopfIdeal.mem_conjugate_iff, HopfIdeal.mem_comapOfSurjective]
-    rfl
+    rw [e_bialgHom]
   rw [heq]
   exact hI.comapOfIso e
 

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -286,7 +286,7 @@ theorem comapOfSurjective_bialgEquiv_symm_apply (I : HopfIdeal R H) (e : H ≃�
     e.symm_apply_apply]
 
 /-- Inverse image along a bialgebra equivalence is an order isomorphism of Hopf ideals. -/
-@[expose] noncomputable def comapOrderIso (e : H ≃ₐc[R] K) :
+noncomputable def comapOrderIso (e : H ≃ₐc[R] K) :
     HopfIdeal R K ≃o HopfIdeal R H where
   toFun I := I.comapOfSurjective e.toBialgHom (EquivLike.surjective e)
   invFun I := I.comapOfSurjective e.symm.toBialgHom (EquivLike.surjective e.symm)
@@ -294,6 +294,30 @@ theorem comapOfSurjective_bialgEquiv_symm_apply (I : HopfIdeal R H) (e : H ≃�
   right_inv I := comapOfSurjective_bialgEquiv_symm_apply I e
   map_rel_iff' := comapOfSurjective_le_comapOfSurjective_iff e.toBialgHom
     (EquivLike.surjective e)
+
+private theorem comapOrderIso_apply_def (e : H ≃ₐc[R] K) (I : HopfIdeal R K) :
+    comapOrderIso e I =
+      I.comapOfSurjective e.toBialgHom (EquivLike.surjective e) :=
+  (rfl)
+
+private theorem comapOrderIso_symm_apply_def (e : H ≃ₐc[R] K) (I : HopfIdeal R H) :
+    (comapOrderIso e).symm I =
+      I.comapOfSurjective e.symm.toBialgHom (EquivLike.surjective e.symm) :=
+  (rfl)
+
+/-- The forward map of `comapOrderIso` is inverse image along the equivalence. -/
+@[simp]
+theorem comapOrderIso_apply (e : H ≃ₐc[R] K) (I : HopfIdeal R K) :
+    comapOrderIso e I =
+      I.comapOfSurjective e.toBialgHom (EquivLike.surjective e) :=
+  comapOrderIso_apply_def e I
+
+/-- The inverse map of `comapOrderIso` is inverse image along the inverse equivalence. -/
+@[simp]
+theorem comapOrderIso_symm_apply (e : H ≃ₐc[R] K) (I : HopfIdeal R H) :
+    (comapOrderIso e).symm I =
+      I.comapOfSurjective e.symm.toBialgHom (EquivLike.surjective e.symm) :=
+  comapOrderIso_symm_apply_def e I
 
 section Field
 

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -312,6 +312,21 @@ theorem comapOrderIso_apply (e : H ≃ₐc[R] K) (I : HopfIdeal R K) :
       I.comapOfSurjective e.toBialgHom (EquivLike.surjective e) :=
   comapOrderIso_apply_def e I
 
+-- This bridge isolates the definitional coercions from `BialgEquiv.ofBijective` and the
+-- proof-irrelevant surjectivity fields stored by `comapOrderIso`.
+private theorem comapOrderIso_ofBijective_apply_def (f : H →ₐc[R] K)
+    (hf : Function.Bijective f)
+    (I : HopfIdeal R K) :
+    comapOrderIso (BialgEquiv.ofBijective f hf) I = I.comapOfSurjective f hf.2 :=
+  (rfl)
+
+/-- The order isomorphism built from a bijective morphism acts by inverse image along the original
+morphism. -/
+theorem comapOrderIso_ofBijective_apply (f : H →ₐc[R] K) (hf : Function.Bijective f)
+    (I : HopfIdeal R K) :
+    comapOrderIso (BialgEquiv.ofBijective f hf) I = I.comapOfSurjective f hf.2 :=
+  comapOrderIso_ofBijective_apply_def f hf I
+
 /-- The inverse map of `comapOrderIso` is inverse image along the inverse equivalence. -/
 @[simp]
 theorem comapOrderIso_symm_apply (e : H ≃ₐc[R] K) (I : HopfIdeal R H) :

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -295,29 +295,11 @@ noncomputable def comapOrderIso (e : H ≃ₐc[R] K) :
   map_rel_iff' := comapOfSurjective_le_comapOfSurjective_iff e.toBialgHom
     (EquivLike.surjective e)
 
-private theorem comapOrderIso_apply_def (e : H ≃ₐc[R] K) (I : HopfIdeal R K) :
-    comapOrderIso e I =
-      I.comapOfSurjective e.toBialgHom (EquivLike.surjective e) :=
-  (rfl)
-
-private theorem comapOrderIso_symm_apply_def (e : H ≃ₐc[R] K) (I : HopfIdeal R H) :
-    (comapOrderIso e).symm I =
-      I.comapOfSurjective e.symm.toBialgHom (EquivLike.surjective e.symm) :=
-  (rfl)
-
 /-- The forward map of `comapOrderIso` is inverse image along the equivalence. -/
 @[simp]
 theorem comapOrderIso_apply (e : H ≃ₐc[R] K) (I : HopfIdeal R K) :
     comapOrderIso e I =
       I.comapOfSurjective e.toBialgHom (EquivLike.surjective e) :=
-  comapOrderIso_apply_def e I
-
--- This bridge isolates the definitional coercions from `BialgEquiv.ofBijective` and the
--- proof-irrelevant surjectivity fields stored by `comapOrderIso`.
-private theorem comapOrderIso_ofBijective_apply_def (f : H →ₐc[R] K)
-    (hf : Function.Bijective f)
-    (I : HopfIdeal R K) :
-    comapOrderIso (BialgEquiv.ofBijective f hf) I = I.comapOfSurjective f hf.2 :=
   (rfl)
 
 /-- The order isomorphism built from a bijective morphism acts by inverse image along the original
@@ -325,14 +307,14 @@ morphism. -/
 theorem comapOrderIso_ofBijective_apply (f : H →ₐc[R] K) (hf : Function.Bijective f)
     (I : HopfIdeal R K) :
     comapOrderIso (BialgEquiv.ofBijective f hf) I = I.comapOfSurjective f hf.2 :=
-  comapOrderIso_ofBijective_apply_def f hf I
+  (rfl)
 
 /-- The inverse map of `comapOrderIso` is inverse image along the inverse equivalence. -/
 @[simp]
 theorem comapOrderIso_symm_apply (e : H ≃ₐc[R] K) (I : HopfIdeal R H) :
     (comapOrderIso e).symm I =
       I.comapOfSurjective e.symm.toBialgHom (EquivLike.surjective e.symm) :=
-  comapOrderIso_symm_apply_def e I
+  (rfl)
 
 section Field
 

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -49,6 +49,8 @@ schemes in the affine Hopf-algebra dictionary.
   `TauCeti.HopfIdeal.comapOfSurjective_comapOfSurjective`: identity and composition laws.
 * `TauCeti.HopfIdeal.comapOfSurjective_bialgEquiv_symm_apply`: inverse-image cancellation for a
   bialgebra equivalence.
+* `TauCeti.HopfIdeal.comapOrderIso`: inverse image along a bialgebra equivalence as an order
+  isomorphism of Hopf ideals.
 
 ## References
 
@@ -282,6 +284,16 @@ theorem comapOfSurjective_bialgEquiv_symm_apply (I : HopfIdeal R H) (e : H ≃�
   rw [mem_comapOfSurjective, mem_comapOfSurjective]
   simp only [BialgEquiv.toBialgHom_eq_coe, BialgEquiv.coe_toBialgHom,
     e.symm_apply_apply]
+
+/-- Inverse image along a bialgebra equivalence is an order isomorphism of Hopf ideals. -/
+@[expose] noncomputable def comapOrderIso (e : H ≃ₐc[R] K) :
+    HopfIdeal R K ≃o HopfIdeal R H where
+  toFun I := I.comapOfSurjective e.toBialgHom (EquivLike.surjective e)
+  invFun I := I.comapOfSurjective e.symm.toBialgHom (EquivLike.surjective e.symm)
+  left_inv I := comapOfSurjective_bialgEquiv_symm_apply I e.symm
+  right_inv I := comapOfSurjective_bialgEquiv_symm_apply I e
+  map_rel_iff' := comapOfSurjective_le_comapOfSurjective_iff e.toBialgHom
+    (EquivLike.surjective e)
 
 section Field
 


### PR DESCRIPTION
This PR packages inner conjugation by an `R`-rational point as a coordinate Hopf-algebra isomorphism, uses that isomorphism to conjugate defining Hopf ideals, and proves that maximal-torus ideals remain maximal tori. It advances the exact `ReductiveGroups/README.md` Layer 7 target “Borel subgroups, maximal tori, and their conjugacy.”

At the functor-of-points level, it proves that the represented automorphism acts over every commutative `R`-algebra by `x ↦ g x g⁻¹`, and identifies its coordinate map with `TauCeti.HopfAlgebra.conjugationAlgHom` from `TauCeti/Algebra/AlgebraicGroup/Hopf/Conjugation.lean`. The closed-subgroup layer supplies membership, monotonicity, identity, inverse-cancellation, and order-isomorphism results. The maximal-torus result then follows from the existing intrinsic characterization and its transport across Hopf-algebra isomorphisms.

Milestone: Layer 7, “Borel subgroups, maximal tori, and their conjugacy.” This is the coordinate-level conjugation prerequisite needed to state and prove conjugacy of maximal tori and Borel subgroups.

After this PR, existence of maximal tori and Borel subgroups and the theorem that any two are conjugate still remain.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"inner-conjugation-coordinate-isomorphism"}-->

🤖 Prepared with Codex
