### PR TITLE
feat: prove the upper-triangular GL₂ subgroup is Borel

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
@@ -123,20 +123,6 @@ theorem isBorel_iff (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{v} k)
     exact ⟨⟨hsmooth, hconnected, hsolvable⟩,
       fun J hJ hJI ↦ hmax J hJ.1 hJ.2.1 hJ.2.2 hJI⟩
 
-/-- The defining minimal-quotient-property form of `IsBorel`, used internally for transport
-across ambient isomorphisms. -/
-private theorem isBorel_iff_minimal_quotientProperty
-    (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{v} k)
-    [Algebra.FiniteType k H] (I : HopfIdeal k H) :
-    let K := AlgebraicClosure k
-    let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K)
-      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
-    let I' := CommHopfAlgCat.baseChangeHopfIdeal (K := K) I
-    IsBorel k H I ↔
-      Minimal (fun J : HopfIdeal K H'.obj ↦
-        borelQuotientProperty K (FiniteTypeCommHopfAlgCat.quotient H' J)) I' :=
-  Iff.rfl
-
 private theorem minimal_borelQuotientProperty_comapOfIso
     {k : Type u} [Field k]
     {H L : FiniteTypeCommHopfAlgCat.{u, v} k} {I : HopfIdeal k L.obj}
@@ -164,8 +150,17 @@ private theorem minimal_borelQuotientProperty_comapOfIso
     (K := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) L)
     (borelQuotientProperty (AlgebraicClosure k))
     (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I) hI eK
-  rw [← FiniteTypeCommHopfAlgCat.baseChangeHopfIdeal_comapOfIso
-    (K := AlgebraicClosure k) I e] at htransport
+  have hbaseChange :
+      CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k)
+          (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+            (ConcreteCategory.bijective_of_isIso e.hom).2) =
+        (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I).comapOfSurjective
+          (FiniteTypeCommHopfAlgCat.toBialgHom eK.hom)
+          (ConcreteCategory.bijective_of_isIso eK.hom).2 :=
+    CommHopfAlgCat.baseChangeHopfIdeal_comapOfIso (K := AlgebraicClosure k) I
+      ((forget₂ (FiniteTypeCommHopfAlgCat.{u, v} k)
+        (_root_.CommHopfAlgCat.{v} k)).mapIso e)
+  rw [hbaseChange]
   exact htransport
 
 namespace IsBorel
@@ -179,9 +174,18 @@ theorem comapOfIso (hI : IsBorel k L.obj I) (e : H ≅ L) :
     IsBorel k H.obj
       (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
         (ConcreteCategory.bijective_of_isIso e.hom).2) := by
-  apply (isBorel_iff_minimal_quotientProperty k H.obj _).mpr
-  exact minimal_borelQuotientProperty_comapOfIso
-    ((isBorel_iff_minimal_quotientProperty k L.obj I).mp hI) e
+  -- `IsBorel` is definitionally this minimal quotient property; no private `Iff.rfl`
+  -- wrapper is retained solely to unfold and refold it for transport.
+  change Minimal
+    (fun J : HopfIdeal (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj ↦
+      borelQuotientProperty (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.quotient
+          (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) J))
+    (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k)
+      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2))
+  exact minimal_borelQuotientProperty_comapOfIso hI e
 
 /-- Borel status is invariant under pulling the defining ideal back across an ambient
 Hopf-algebra isomorphism. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
@@ -1,0 +1,161 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
+
+/-!
+# Borel subgroups in Hopf coordinates
+
+A closed subgroup of a finite-type affine group over a field is encoded contravariantly by a
+Hopf ideal in its coordinate algebra. This file defines a Borel subgroup to be a smooth,
+geometrically connected, geometrically solvable closed subgroup which is maximal among closed
+subgroups with those properties.
+
+Smoothness remains explicit: the ambient affine group need not be smooth, and geometric
+connectedness and solvability alone do not exclude nonreduced subgroup schemes. Because Hopf
+ideals reverse subgroup inclusion, maximality of the represented subgroup is minimality of its
+defining ideal among ideals satisfying the three geometric properties.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.IsBorel`: the Borel-subgroup predicate in Hopf coordinates.
+* `TauCeti.HopfIdeal.IsBorel.comapOfIso`: Borel subgroups transport across isomorphisms of the
+  ambient coordinate Hopf algebra.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Section 17.a.
+* T. A. Springer, *Linear Algebraic Groups*, Sections 6.2--6.3.
+
+This supplies the Borel-subgroup predicate required by Layer 7, "Borel subgroups, maximal tori,
+and their conjugacy", of the ReductiveGroups roadmap. Existence and conjugacy for general
+reductive groups remain downstream.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+namespace HopfIdeal
+
+/-- A Hopf ideal defines a Borel subgroup when its quotient coordinate algebra is smooth,
+geometrically connected, and geometrically solvable, and no strictly larger closed subgroup has
+all three properties.
+
+The order is contravariant: `J ≤ I` says that the subgroup cut out by `I` is contained in the
+subgroup cut out by `J`. -/
+def IsBorel (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{u} k)
+    [Algebra.FiniteType k H] (I : HopfIdeal k H) : Prop :=
+  Minimal (fun J : HopfIdeal k H ↦
+    smoothCommHopfAlgProperty k
+        (FiniteTypeCommHopfAlgCat.quotient
+          ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj ∧
+      geometricallyConnectedCommHopfAlgProperty k
+        (FiniteTypeCommHopfAlgCat.quotient
+          ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj ∧
+      geometricallySolvablePointsCommHopfAlgProperty k
+        (FiniteTypeCommHopfAlgCat.quotient
+          ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj) I
+
+/-- The Hopf-ideal criterion for a Borel subgroup: its quotient is smooth, geometrically
+connected, and geometrically solvable, and it is maximal among such closed subgroups. -/
+@[simp]
+theorem isBorel_iff (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{u} k)
+    [Algebra.FiniteType k H] (I : HopfIdeal k H) :
+    IsBorel k H I ↔
+      smoothCommHopfAlgProperty k
+          (FiniteTypeCommHopfAlgCat.quotient
+            ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I).obj ∧
+        geometricallyConnectedCommHopfAlgProperty k
+          (FiniteTypeCommHopfAlgCat.quotient
+            ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I).obj ∧
+        geometricallySolvablePointsCommHopfAlgProperty k
+          (FiniteTypeCommHopfAlgCat.quotient
+            ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I).obj ∧
+        ∀ J : HopfIdeal k H,
+          smoothCommHopfAlgProperty k
+              (FiniteTypeCommHopfAlgCat.quotient
+                ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj →
+            geometricallyConnectedCommHopfAlgProperty k
+              (FiniteTypeCommHopfAlgCat.quotient
+                ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj →
+            geometricallySolvablePointsCommHopfAlgProperty k
+              (FiniteTypeCommHopfAlgCat.quotient
+                ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj →
+            J ≤ I → I ≤ J := by
+  constructor
+  · rintro ⟨⟨hsmooth, hconnected, hsolvable⟩, hmax⟩
+    exact ⟨hsmooth, hconnected, hsolvable,
+      fun J hJsmooth hJconnected hJsolvable hJI ↦
+        hmax ⟨hJsmooth, hJconnected, hJsolvable⟩ hJI⟩
+  · rintro ⟨hsmooth, hconnected, hsolvable, hmax⟩
+    exact ⟨⟨hsmooth, hconnected, hsolvable⟩,
+      fun J hJ hJI ↦ hmax J hJ.1 hJ.2.1 hJ.2.2 hJI⟩
+
+namespace IsBorel
+
+variable {k : Type u} [Field k]
+variable {H K : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k K.obj}
+
+/-- Pulling a Borel subgroup back across an ambient Hopf-algebra isomorphism gives a Borel
+subgroup in the source. -/
+theorem comapOfIso (hI : IsBorel k K.obj I) (e : H ≅ K) :
+    IsBorel k H.obj
+      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2) := by
+  let f := FiniteTypeCommHopfAlgCat.toBialgHom e.hom
+  let hf := (ConcreteCategory.bijective_of_isIso e.hom).2
+  let g := FiniteTypeCommHopfAlgCat.toBialgHom e.inv
+  let hg := (ConcreteCategory.bijective_of_isIso e.inv).2
+  let forget : FiniteTypeCommHopfAlgCat.{u, u} k ⥤ _root_.CommHopfAlgCat.{u} k :=
+    forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k) (_root_.CommHopfAlgCat.{u} k)
+  rw [isBorel_iff] at hI ⊢
+  refine ⟨(smoothCommHopfAlgProperty k).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.1,
+    (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.2.1,
+    (geometricallySolvablePointsCommHopfAlgProperty k).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.2.2.1, ?_⟩
+  intro J hJsmooth hJconnected hJsolvable hJpulled
+  let J' := J.comapOfSurjective g hg
+  have hJ'smooth : smoothCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient K J').obj :=
+    (smoothCommHopfAlgProperty k).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJsmooth
+  have hJ'connected : geometricallyConnectedCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient K J').obj :=
+    (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJconnected
+  have hJ'solvable : geometricallySolvablePointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient K J').obj :=
+    (geometricallySolvablePointsCommHopfAlgProperty k).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJsolvable
+  have hJ'comap : J'.comapOfSurjective f hf = J :=
+    HopfIdeal.comapOfSurjective_bialgEquiv_symm_apply J
+      (_root_.CommHopfAlgCat.ofIso <| (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+        (_root_.CommHopfAlgCat.{u} k)).mapIso e)
+  have hJ'I : J' ≤ I := by
+    rw [← HopfIdeal.comapOfSurjective_le_comapOfSurjective_iff f hf, hJ'comap]
+    exact hJpulled
+  have hIJ' : I ≤ J' := hI.2.2.2 J' hJ'smooth hJ'connected hJ'solvable hJ'I
+  calc
+    I.comapOfSurjective f hf ≤ J'.comapOfSurjective f hf :=
+      HopfIdeal.comapOfSurjective_mono f hf hIJ'
+    _ = J := hJ'comap
+
+end IsBorel
+
+end HopfIdeal
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
@@ -6,7 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
 public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
 
@@ -15,19 +16,19 @@ public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
 
 A closed subgroup of a finite-type affine group over a field is encoded contravariantly by a
 Hopf ideal in its coordinate algebra. This file defines a Borel subgroup to be a smooth,
-geometrically connected, geometrically solvable closed subgroup which is maximal among closed
-subgroups with those properties.
+geometrically connected, geometrically solvable closed subgroup whose base change to an
+algebraic closure is maximal among closed subgroups with those properties.
 
 Smoothness remains explicit: the ambient affine group need not be smooth, and geometric
 connectedness and solvability alone do not exclude nonreduced subgroup schemes. Because Hopf
 ideals reverse subgroup inclusion, maximality of the represented subgroup is minimality of its
-defining ideal among ideals satisfying the three geometric properties.
+defining ideal among ideals satisfying the three geometric properties after base change to an
+algebraic closure. This geometric maximality is essential over a non-algebraically-closed field:
+maximality only among subgroups defined over the ground field is not the Borel condition.
 
 ## Main declarations
 
 * `TauCeti.HopfIdeal.IsBorel`: the Borel-subgroup predicate in Hopf coordinates.
-* `TauCeti.HopfIdeal.IsBorel.comapOfIso`: Borel subgroups transport across isomorphisms of the
-  ambient coordinate Hopf algebra.
 
 ## References
 
@@ -49,51 +50,60 @@ universe u
 
 namespace HopfIdeal
 
-/-- A Hopf ideal defines a Borel subgroup when its quotient coordinate algebra is smooth,
-geometrically connected, and geometrically solvable, and no strictly larger closed subgroup has
-all three properties.
+/-- A Hopf ideal defines a Borel subgroup when, after base change to an algebraic closure, its
+quotient coordinate algebra is smooth, geometrically connected, and geometrically solvable, and
+no strictly larger closed subgroup has all three properties.
 
 The order is contravariant: `J ≤ I` says that the subgroup cut out by `I` is contained in the
 subgroup cut out by `J`. -/
 def IsBorel (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{u} k)
     [Algebra.FiniteType k H] (I : HopfIdeal k H) : Prop :=
-  Minimal (fun J : HopfIdeal k H ↦
-    smoothCommHopfAlgProperty k
+  let K := AlgebraicClosure k
+  let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K)
+    ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
+  let I' := CommHopfAlgCat.baseChangeHopfIdeal (K := K) I
+  Minimal (fun J : HopfIdeal K H'.obj ↦
+    smoothCommHopfAlgProperty K
         (FiniteTypeCommHopfAlgCat.quotient
-          ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj ∧
-      geometricallyConnectedCommHopfAlgProperty k
+          H' J).obj ∧
+      geometricallyConnectedCommHopfAlgProperty K
         (FiniteTypeCommHopfAlgCat.quotient
-          ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj ∧
-      geometricallySolvablePointsCommHopfAlgProperty k
+          H' J).obj ∧
+      geometricallySolvablePointsCommHopfAlgProperty K
         (FiniteTypeCommHopfAlgCat.quotient
-          ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj) I
+          H' J).obj) I'
 
-/-- The Hopf-ideal criterion for a Borel subgroup: its quotient is smooth, geometrically
-connected, and geometrically solvable, and it is maximal among such closed subgroups. -/
+/-- The Hopf-ideal criterion for a Borel subgroup: after algebraic-closure base change, its
+quotient is smooth, geometrically connected, and geometrically solvable, and it is maximal among
+such closed subgroups. -/
 @[simp]
 theorem isBorel_iff (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{u} k)
     [Algebra.FiniteType k H] (I : HopfIdeal k H) :
+    let K := AlgebraicClosure k
+    let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K)
+      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
+    let I' := CommHopfAlgCat.baseChangeHopfIdeal (K := K) I
     IsBorel k H I ↔
-      smoothCommHopfAlgProperty k
+      smoothCommHopfAlgProperty K
           (FiniteTypeCommHopfAlgCat.quotient
-            ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I).obj ∧
-        geometricallyConnectedCommHopfAlgProperty k
+            H' I').obj ∧
+        geometricallyConnectedCommHopfAlgProperty K
           (FiniteTypeCommHopfAlgCat.quotient
-            ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I).obj ∧
-        geometricallySolvablePointsCommHopfAlgProperty k
+            H' I').obj ∧
+        geometricallySolvablePointsCommHopfAlgProperty K
           (FiniteTypeCommHopfAlgCat.quotient
-            ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I).obj ∧
-        ∀ J : HopfIdeal k H,
-          smoothCommHopfAlgProperty k
+            H' I').obj ∧
+        ∀ J : HopfIdeal K H'.obj,
+          smoothCommHopfAlgProperty K
               (FiniteTypeCommHopfAlgCat.quotient
-                ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj →
-            geometricallyConnectedCommHopfAlgProperty k
+                H' J).obj →
+            geometricallyConnectedCommHopfAlgProperty K
               (FiniteTypeCommHopfAlgCat.quotient
-                ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj →
-            geometricallySolvablePointsCommHopfAlgProperty k
+                H' J).obj →
+            geometricallySolvablePointsCommHopfAlgProperty K
               (FiniteTypeCommHopfAlgCat.quotient
-                ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ J).obj →
-            J ≤ I → I ≤ J := by
+                H' J).obj →
+            J ≤ I' → I' ≤ J := by
   constructor
   · rintro ⟨⟨hsmooth, hconnected, hsolvable⟩, hmax⟩
     exact ⟨hsmooth, hconnected, hsolvable,
@@ -102,59 +112,6 @@ theorem isBorel_iff (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{u} k)
   · rintro ⟨hsmooth, hconnected, hsolvable, hmax⟩
     exact ⟨⟨hsmooth, hconnected, hsolvable⟩,
       fun J hJ hJI ↦ hmax J hJ.1 hJ.2.1 hJ.2.2 hJI⟩
-
-namespace IsBorel
-
-variable {k : Type u} [Field k]
-variable {H K : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k K.obj}
-
-/-- Pulling a Borel subgroup back across an ambient Hopf-algebra isomorphism gives a Borel
-subgroup in the source. -/
-theorem comapOfIso (hI : IsBorel k K.obj I) (e : H ≅ K) :
-    IsBorel k H.obj
-      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
-        (ConcreteCategory.bijective_of_isIso e.hom).2) := by
-  let f := FiniteTypeCommHopfAlgCat.toBialgHom e.hom
-  let hf := (ConcreteCategory.bijective_of_isIso e.hom).2
-  let g := FiniteTypeCommHopfAlgCat.toBialgHom e.inv
-  let hg := (ConcreteCategory.bijective_of_isIso e.inv).2
-  let forget : FiniteTypeCommHopfAlgCat.{u, u} k ⥤ _root_.CommHopfAlgCat.{u} k :=
-    forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k) (_root_.CommHopfAlgCat.{u} k)
-  rw [isBorel_iff] at hI ⊢
-  refine ⟨(smoothCommHopfAlgProperty k).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.1,
-    (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.2.1,
-    (geometricallySolvablePointsCommHopfAlgProperty k).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.2.2.1, ?_⟩
-  intro J hJsmooth hJconnected hJsolvable hJpulled
-  let J' := J.comapOfSurjective g hg
-  have hJ'smooth : smoothCommHopfAlgProperty k
-      (FiniteTypeCommHopfAlgCat.quotient K J').obj :=
-    (smoothCommHopfAlgProperty k).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJsmooth
-  have hJ'connected : geometricallyConnectedCommHopfAlgProperty k
-      (FiniteTypeCommHopfAlgCat.quotient K J').obj :=
-    (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJconnected
-  have hJ'solvable : geometricallySolvablePointsCommHopfAlgProperty k
-      (FiniteTypeCommHopfAlgCat.quotient K J').obj :=
-    (geometricallySolvablePointsCommHopfAlgProperty k).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJsolvable
-  have hJ'comap : J'.comapOfSurjective f hf = J :=
-    HopfIdeal.comapOfSurjective_bialgEquiv_symm_apply J
-      (_root_.CommHopfAlgCat.ofIso <| (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-        (_root_.CommHopfAlgCat.{u} k)).mapIso e)
-  have hJ'I : J' ≤ I := by
-    rw [← HopfIdeal.comapOfSurjective_le_comapOfSurjective_iff f hf, hJ'comap]
-    exact hJpulled
-  have hIJ' : I ≤ J' := hI.2.2.2 J' hJ'smooth hJ'connected hJ'solvable hJ'I
-  calc
-    I.comapOfSurjective f hf ≤ J'.comapOfSurjective f hf :=
-      HopfIdeal.comapOfSurjective_mono f hf hIJ'
-    _ = J := hJ'comap
-
-end IsBorel
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
@@ -29,6 +29,8 @@ maximality only among subgroups defined over the ground field is not the Borel c
 ## Main declarations
 
 * `TauCeti.HopfIdeal.IsBorel`: the Borel-subgroup predicate in Hopf coordinates.
+* `TauCeti.HopfIdeal.IsBorel.comapOfIso_iff`: Borel status is invariant under an ambient
+  Hopf-algebra isomorphism.
 
 ## References
 
@@ -46,9 +48,25 @@ open CategoryTheory
 
 namespace TauCeti
 
-universe u
+universe u v
 
 namespace HopfIdeal
+
+/-- The isomorphism-invariant property imposed on coordinate quotients in the definition of a
+Borel subgroup. -/
+private def borelQuotientProperty (k : Type u) [Field k] :
+    ObjectProperty (FiniteTypeCommHopfAlgCat.{u, v} k) :=
+  ((smoothCommHopfAlgProperty k ⊓
+    (geometricallyConnectedCommHopfAlgProperty k ⊓
+      geometricallySolvablePointsCommHopfAlgProperty k)) :
+    ObjectProperty (_root_.CommHopfAlgCat.{v} k)).inverseImage
+      (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} k) (_root_.CommHopfAlgCat.{v} k))
+
+private instance (k : Type u) [Field k] :
+    (borelQuotientProperty k :
+      ObjectProperty (FiniteTypeCommHopfAlgCat.{u, v} k)).IsClosedUnderIsomorphisms := by
+  unfold borelQuotientProperty
+  infer_instance
 
 /-- A Hopf ideal defines a Borel subgroup when, after base change to an algebraic closure, its
 quotient coordinate algebra is smooth, geometrically connected, and geometrically solvable, and
@@ -56,28 +74,20 @@ no strictly larger closed subgroup has all three properties.
 
 The order is contravariant: `J ≤ I` says that the subgroup cut out by `I` is contained in the
 subgroup cut out by `J`. -/
-def IsBorel (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{u} k)
+def IsBorel (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{v} k)
     [Algebra.FiniteType k H] (I : HopfIdeal k H) : Prop :=
   let K := AlgebraicClosure k
   let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K)
     ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
   let I' := CommHopfAlgCat.baseChangeHopfIdeal (K := K) I
   Minimal (fun J : HopfIdeal K H'.obj ↦
-    smoothCommHopfAlgProperty K
-        (FiniteTypeCommHopfAlgCat.quotient
-          H' J).obj ∧
-      geometricallyConnectedCommHopfAlgProperty K
-        (FiniteTypeCommHopfAlgCat.quotient
-          H' J).obj ∧
-      geometricallySolvablePointsCommHopfAlgProperty K
-        (FiniteTypeCommHopfAlgCat.quotient
-          H' J).obj) I'
+    borelQuotientProperty K (FiniteTypeCommHopfAlgCat.quotient H' J)) I'
 
 /-- The Hopf-ideal criterion for a Borel subgroup: after algebraic-closure base change, its
 quotient is smooth, geometrically connected, and geometrically solvable, and it is maximal among
 such closed subgroups. -/
 @[simp]
-theorem isBorel_iff (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{u} k)
+theorem isBorel_iff (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{v} k)
     [Algebra.FiniteType k H] (I : HopfIdeal k H) :
     let K := AlgebraicClosure k
     let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K)
@@ -112,6 +122,100 @@ theorem isBorel_iff (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{u} k)
   · rintro ⟨hsmooth, hconnected, hsolvable, hmax⟩
     exact ⟨⟨hsmooth, hconnected, hsolvable⟩,
       fun J hJ hJI ↦ hmax J hJ.1 hJ.2.1 hJ.2.2 hJI⟩
+
+/-- The defining minimal-quotient-property form of `IsBorel`, used internally for transport
+across ambient isomorphisms. -/
+private theorem isBorel_iff_minimal_quotientProperty
+    (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{v} k)
+    [Algebra.FiniteType k H] (I : HopfIdeal k H) :
+    let K := AlgebraicClosure k
+    let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K)
+      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
+    let I' := CommHopfAlgCat.baseChangeHopfIdeal (K := K) I
+    IsBorel k H I ↔
+      Minimal (fun J : HopfIdeal K H'.obj ↦
+        borelQuotientProperty K (FiniteTypeCommHopfAlgCat.quotient H' J)) I' :=
+  Iff.rfl
+
+private theorem minimal_borelQuotientProperty_comapOfIso
+    {k : Type u} [Field k]
+    {H L : FiniteTypeCommHopfAlgCat.{u, v} k} {I : HopfIdeal k L.obj}
+    (hI : Minimal
+      (fun J : HopfIdeal (AlgebraicClosure k)
+          (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) L).obj ↦
+        borelQuotientProperty (AlgebraicClosure k)
+          (FiniteTypeCommHopfAlgCat.quotient
+            (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) L) J))
+      (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I))
+    (e : H ≅ L) :
+    Minimal
+      (fun J : HopfIdeal (AlgebraicClosure k)
+          (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj ↦
+        borelQuotientProperty (AlgebraicClosure k)
+          (FiniteTypeCommHopfAlgCat.quotient
+            (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) J))
+      (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k)
+        (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+          (ConcreteCategory.bijective_of_isIso e.hom).2)) := by
+  let eK := (FiniteTypeCommHopfAlgCat.baseChangeFunctor
+    (K := AlgebraicClosure k)).mapIso e
+  have htransport := FiniteTypeCommHopfAlgCat.minimal_quotientProperty_comapOfIso
+    (H := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+    (K := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) L)
+    (borelQuotientProperty (AlgebraicClosure k))
+    (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I) hI eK
+  rw [← FiniteTypeCommHopfAlgCat.baseChangeHopfIdeal_comapOfIso
+    (K := AlgebraicClosure k) I e] at htransport
+  exact htransport
+
+namespace IsBorel
+
+variable {k : Type u} [Field k]
+variable {H L : FiniteTypeCommHopfAlgCat.{u, v} k} {I : HopfIdeal k L.obj}
+
+/-- Pulling a Borel subgroup back across an ambient Hopf-algebra isomorphism gives a Borel
+subgroup in the source. -/
+theorem comapOfIso (hI : IsBorel k L.obj I) (e : H ≅ L) :
+    IsBorel k H.obj
+      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2) := by
+  apply (isBorel_iff_minimal_quotientProperty k H.obj _).mpr
+  exact minimal_borelQuotientProperty_comapOfIso
+    ((isBorel_iff_minimal_quotientProperty k L.obj I).mp hI) e
+
+/-- Borel status is invariant under pulling the defining ideal back across an ambient
+Hopf-algebra isomorphism. -/
+theorem comapOfIso_iff (e : H ≅ L) (I : HopfIdeal k L.obj) :
+    IsBorel k H.obj
+        (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+          (ConcreteCategory.bijective_of_isIso e.hom).2) ↔
+      IsBorel k L.obj I := by
+  constructor
+  · intro hI
+    have hback := hI.comapOfIso e.symm
+    let e' := (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} k)
+      (_root_.CommHopfAlgCat.{v} k)).mapIso e
+    let e'' := _root_.CommHopfAlgCat.ofIso e'
+    -- `toBialgHom` for a finite-type morphism is definitionally the bialgebra morphism of
+    -- its image under this forgetful functor; the full-subcategory wrapper has no separate
+    -- propositional compatibility lemma.
+    change IsBorel k L.obj
+      (HopfIdeal.comapOfSurjective
+        (I.comapOfSurjective e''.toBialgHom
+          (by simpa only [BialgEquiv.toBialgHom_eq_coe, BialgEquiv.coe_toBialgHom] using
+            EquivLike.surjective e''))
+        e''.symm.toBialgHom
+          (by simpa only [BialgEquiv.toBialgHom_eq_coe, BialgEquiv.coe_toBialgHom] using
+            EquivLike.surjective e''.symm)) at hback
+    have he := HopfIdeal.comapOfSurjective_bialgEquiv_symm_apply I e''.symm
+    have he_symm_symm : e''.symm.symm = e'' := by
+      ext
+      rfl
+    simp only [he_symm_symm] at he
+    rwa [he] at hback
+  · exact fun hI ↦ hI.comapOfIso e
+
+end IsBorel
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
@@ -36,10 +36,6 @@ maximality only among subgroups defined over the ground field is not the Borel c
 
 * J. S. Milne, *Algebraic Groups* (2017), Section 17.a.
 * T. A. Springer, *Linear Algebraic Groups*, Sections 6.2--6.3.
-
-This supplies the Borel-subgroup predicate required by Layer 7, "Borel subgroups, maximal tori,
-and their conjugacy", of the ReductiveGroups roadmap. Existence and conjugacy for general
-reductive groups remain downstream.
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/CommHopfAlgCat.lean
@@ -42,38 +42,38 @@ open scoped TensorProduct
 
 namespace TauCeti
 
-universe u
+universe u v
 
 /-- A Hopf algebra remains nontrivial after extension of its base field. -/
 private theorem nontrivial_tensorProduct
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k)
     (K : Type u) [Field K] [Algebra k K] :
-    Nontrivial ((H : Type u) ⊗[k] K) := by
-  let : Nontrivial (H : Type u) := Bialgebra.nontrivial k
+    Nontrivial ((H : Type v) ⊗[k] K) := by
+  let : Nontrivial (H : Type v) := Bialgebra.nontrivial k
   exact Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_flat_left
     k H K (algebraMap k K).injective
 
 /-- A commutative Hopf algebra over a field is geometrically connected when the spectrum of its
 coordinate ring remains connected after every extension of the base field. -/
 def geometricallyConnectedCommHopfAlgProperty (k : Type u) [Field k] :
-    ObjectProperty (CommHopfAlgCat.{u} k) :=
+    ObjectProperty (CommHopfAlgCat.{v} k) :=
   fun H ↦ ∀ (K : Type u) [Field K] [Algebra k K],
-    ConnectedSpace (PrimeSpectrum ((H : Type u) ⊗[k] K))
+    ConnectedSpace (PrimeSpectrum ((H : Type v) ⊗[k] K))
 
 /-- Membership in the geometrically connected commutative-Hopf-algebra object property. -/
 @[simp]
 theorem geometricallyConnectedCommHopfAlgProperty_iff
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k) :
     geometricallyConnectedCommHopfAlgProperty k H ↔
       ∀ (K : Type u) [Field K] [Algebra k K],
-        ConnectedSpace (PrimeSpectrum ((H : Type u) ⊗[k] K)) :=
+        ConnectedSpace (PrimeSpectrum ((H : Type v) ⊗[k] K)) :=
   Iff.rfl
 
 /-- A geometrically connected commutative Hopf algebra has connected prime spectrum. -/
 theorem geometricallyConnectedCommHopfAlgProperty.connectedSpace
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k)
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k)
     (h : geometricallyConnectedCommHopfAlgProperty k H) :
-    ConnectedSpace (PrimeSpectrum (H : Type u)) :=
+    ConnectedSpace (PrimeSpectrum (H : Type v)) :=
   (PrimeSpectrum.homeomorphOfRingEquiv
     (Algebra.TensorProduct.rid k k H).toRingEquiv).connectedSpace_iff.mp (h k)
 
@@ -90,9 +90,9 @@ instance (k : Type u) [Field k] :
 /-- **A commutative Hopf algebra is geometrically connected exactly when, after every extension
 `K / k` of the base field, every idempotent of `H ⊗[k] K` is zero or one.** -/
 theorem geometricallyConnectedCommHopfAlgProperty_iff_idempotent_eq_zero_or_one
-    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k) :
     geometricallyConnectedCommHopfAlgProperty k H ↔
-      ∀ (K : Type u) [Field K] [Algebra k K] (e : (H : Type u) ⊗[k] K),
+      ∀ (K : Type u) [Field K] [Algebra k K] (e : (H : Type v) ⊗[k] K),
         IsIdempotentElem e → e = 0 ∨ e = 1 := by
   rw [geometricallyConnectedCommHopfAlgProperty_iff]
   constructor

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
@@ -263,7 +263,7 @@ private theorem isBorelOverField_definingHopfIdeal :
         (CommAlgCat.of k K)) := hIsolvable
   let _ : Group.IsSolvable P :=
     Group.isSolvable_of_isSolvable_injective (f := e.symm.toMonoidHom) e.symm.injective
-  have hPB : P ≤ GL2Borel K := GL2Borel.le_of_isSolvable P hBP
+  have hPB : P ≤ GL2Borel K := GL2Borel.le_of_isSolvable K P hBP
   let _ : IsReduced (CommHopfAlgCat.quotient H I) :=
     ((smoothCommHopfAlgProperty_iff_geometricallyReduced k
       (CommHopfAlgCat.quotient H I)).mp hIsmooth).isReduced

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
@@ -299,20 +299,6 @@ private theorem isBorelOverField_iff (F : Type u) [Field F]
     exact ⟨⟨hsmooth, hconnected, hsolvable⟩,
       fun J hJ hJI ↦ hmax J hJ.1 hJ.2.1 hJ.2.2 hJI⟩
 
-private theorem isBorelOverField_comapOfIso
-    {F : Type u} [Field F]
-    {H L : FiniteTypeCommHopfAlgCat.{u, u} F} {I : HopfIdeal F L.obj}
-    (hI : isBorelOverField F L I) (e : H ≅ L) :
-    isBorelOverField F H
-      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
-        (ConcreteCategory.bijective_of_isIso e.hom).2) := by
-  exact FiniteTypeCommHopfAlgCat.minimal_quotientProperty_comapOfIso
-    ((smoothCommHopfAlgProperty F ⊓
-      (geometricallyConnectedCommHopfAlgProperty F ⊓
-        geometricallySolvablePointsCommHopfAlgProperty F)).inverseImage
-      (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} F)
-        (_root_.CommHopfAlgCat.{u} F))) I hI e
-
 /-- Over a field, the upper-triangular subgroup of `GL₂` is maximal among smooth geometrically
 connected solvable closed subgroups. -/
 private theorem isBorelOverField_definingHopfIdeal :
@@ -330,6 +316,8 @@ private theorem isBorelOverField_definingHopfIdeal :
   let K := AlgebraicClosure k
   let P := GeneralLinear.hopfIdealPointsSubgroup 2 I K
   have hBP : GL2Borel K ≤ P := by
+    -- `GL2Borel` abbreviates this upper-triangular subgroup; no propositional equality lemma is
+    -- retained solely to restate that definitional equality.
     change upperTriangularGroup (Fin 2) K ≤ P
     rw [← UpperTriangular.hopfIdealPointsSubgroup_eq k 2]
     exact GeneralLinear.hopfIdealPointsSubgroup_le_of_le 2 hIB K
@@ -376,7 +364,17 @@ theorem isBorel_definingHopfIdeal :
   rw [← isBorelOverField_iff K H' I']
   have htarget : isBorelOverField K L (definingHopfIdeal K) := by
     simpa only [L] using (isBorelOverField_definingHopfIdeal (k := K))
-  have hpull := isBorelOverField_comapOfIso htarget e
+  have hpull : isBorelOverField K H'
+      ((definingHopfIdeal K).comapOfSurjective
+        (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2) :=
+    FiniteTypeCommHopfAlgCat.minimal_quotientProperty_comapOfIso
+      (H := H') (K := L)
+      ((smoothCommHopfAlgProperty K ⊓
+        (geometricallyConnectedCommHopfAlgProperty K ⊓
+          geometricallySolvablePointsCommHopfAlgProperty K)).inverseImage
+        (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} K)
+          (_root_.CommHopfAlgCat.{u} K))) (definingHopfIdeal K) htarget e
   let f := FiniteTypeCommHopfAlgCat.toBialgHom e.hom
   have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.hom
   have hmap : I'.map f = definingHopfIdeal K := by

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
@@ -345,9 +345,9 @@ private theorem isBorelOverField_comapOfIso
       HopfIdeal.comapOfSurjective_mono f hf hIJ'
     _ = J := hJ'comap
 
-/-- Over an algebraically closed field, the upper-triangular subgroup of `GL₂` is maximal among
-smooth geometrically connected solvable closed subgroups. -/
-private theorem isBorelOverField_definingHopfIdeal [IsAlgClosed k] :
+/-- Over a field, the upper-triangular subgroup of `GL₂` is maximal among smooth geometrically
+connected solvable closed subgroups. -/
+private theorem isBorelOverField_definingHopfIdeal :
     isBorelOverField k
       ⟨GeneralLinear.coordinateHopfAlgebra k 2,
         (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
@@ -10,6 +10,7 @@ public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.UpperTriangular.Basic
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.UpperTriangular.SmoothConnected
 public import TauCeti.Algebra.AlgebraicGroup.Solvable.UpperTriangular
 import Mathlib.GroupTheory.IsPerfect
+import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Coordinate.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Separation
 import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
 import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Bruhat
@@ -177,6 +178,23 @@ theorem finiteTypeCoordinateHopfAlgebra_obj :
 instance locallyOfFiniteType_groupScheme :
     AlgebraicGeometry.LocallyOfFiniteType (groupScheme R).X.hom := by infer_instance
 
+/-- The general-linear base-change isomorphism carries the scalar extension of the
+upper-triangular defining ideal to the upper-triangular defining ideal over the new field. -/
+private theorem map_baseChangeHopfIdeal_definingHopfIdeal
+    (k K : Type u) [Field k] [Field K] [Algebra k K] :
+    (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (definingHopfIdeal k)).map
+        (GeneralLinear.coordinateHopfAlgebraBaseChangeIso k K 2).hom.hom =
+      definingHopfIdeal K := by
+  refine CommHopfAlgCat.map_baseChangeHopfIdeal_of_toIdeal_eq_span
+    (definingHopfIdeal k) (definingHopfIdeal K)
+    (GeneralLinear.coordinateHopfAlgebraBaseChangeIso k K 2)
+    (definingHopfIdeal_toIdeal k) (definingHopfIdeal_toIdeal K) ?_
+  simp only [Set.image_singleton]
+  congr 1
+  rw [lowerLeftCoordinate_def, lowerLeftCoordinate_def]
+  simpa using GeneralLinear.coordinateHopfAlgebraBaseChangeIso_hom_apply.{u, u}
+    k K 2 1 (MvPolynomial.X ((1 : Fin 2), (0 : Fin 2)))
+
 section Field
 
 variable {k : Type u} [Field k]
@@ -244,12 +262,97 @@ private theorem le_gl2Borel_of_isSolvable
   rw [hPtop]
   exact Subgroup.mem_top g
 
-/-- **The upper-triangular subgroup scheme of `GL₂` is a Borel subgroup over every field.** It is
-smooth, geometrically connected, and geometrically solvable, and every
-smooth geometrically connected solvable closed subgroup containing it is equal to it. -/
-theorem isBorel_definingHopfIdeal :
-    HopfIdeal.IsBorel k (GeneralLinear.coordinateHopfAlgebra k 2) (definingHopfIdeal k) := by
-  rw [HopfIdeal.isBorel_iff]
+/-- The smooth, geometrically connected, geometrically solvable maximality condition over one
+field. This local predicate is used to transport the geometric Borel condition across the
+canonical base-change isomorphism for `GL₂`. -/
+private def isBorelOverField (F : Type u) [Field F]
+    (H : FiniteTypeCommHopfAlgCat.{u, u} F) (I : HopfIdeal F H.obj) : Prop :=
+  Minimal (fun J : HopfIdeal F H.obj ↦
+    smoothCommHopfAlgProperty F (FiniteTypeCommHopfAlgCat.quotient H J).obj ∧
+      geometricallyConnectedCommHopfAlgProperty F
+        (FiniteTypeCommHopfAlgCat.quotient H J).obj ∧
+      geometricallySolvablePointsCommHopfAlgProperty F
+        (FiniteTypeCommHopfAlgCat.quotient H J).obj) I
+
+private theorem isBorelOverField_iff (F : Type u) [Field F]
+    (H : FiniteTypeCommHopfAlgCat.{u, u} F) (I : HopfIdeal F H.obj) :
+    isBorelOverField F H I ↔
+      smoothCommHopfAlgProperty F (FiniteTypeCommHopfAlgCat.quotient H I).obj ∧
+        geometricallyConnectedCommHopfAlgProperty F
+          (FiniteTypeCommHopfAlgCat.quotient H I).obj ∧
+        geometricallySolvablePointsCommHopfAlgProperty F
+          (FiniteTypeCommHopfAlgCat.quotient H I).obj ∧
+        ∀ J : HopfIdeal F H.obj,
+          smoothCommHopfAlgProperty F (FiniteTypeCommHopfAlgCat.quotient H J).obj →
+            geometricallyConnectedCommHopfAlgProperty F
+              (FiniteTypeCommHopfAlgCat.quotient H J).obj →
+            geometricallySolvablePointsCommHopfAlgProperty F
+              (FiniteTypeCommHopfAlgCat.quotient H J).obj →
+            J ≤ I → I ≤ J := by
+  constructor
+  · rintro ⟨⟨hsmooth, hconnected, hsolvable⟩, hmax⟩
+    exact ⟨hsmooth, hconnected, hsolvable,
+      fun J hJsmooth hJconnected hJsolvable hJI ↦
+        hmax ⟨hJsmooth, hJconnected, hJsolvable⟩ hJI⟩
+  · rintro ⟨hsmooth, hconnected, hsolvable, hmax⟩
+    exact ⟨⟨hsmooth, hconnected, hsolvable⟩,
+      fun J hJ hJI ↦ hmax J hJ.1 hJ.2.1 hJ.2.2 hJI⟩
+
+private theorem isBorelOverField_comapOfIso
+    {F : Type u} [Field F]
+    {H L : FiniteTypeCommHopfAlgCat.{u, u} F} {I : HopfIdeal F L.obj}
+    (hI : isBorelOverField F L I) (e : H ≅ L) :
+    isBorelOverField F H
+      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2) := by
+  let f := FiniteTypeCommHopfAlgCat.toBialgHom e.hom
+  let hf := (ConcreteCategory.bijective_of_isIso e.hom).2
+  let g := FiniteTypeCommHopfAlgCat.toBialgHom e.inv
+  let hg := (ConcreteCategory.bijective_of_isIso e.inv).2
+  let forget : FiniteTypeCommHopfAlgCat.{u, u} F ⥤ _root_.CommHopfAlgCat.{u} F :=
+    forget₂ (FiniteTypeCommHopfAlgCat.{u, u} F) (_root_.CommHopfAlgCat.{u} F)
+  rw [isBorelOverField_iff] at hI ⊢
+  refine ⟨(smoothCommHopfAlgProperty F).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.1,
+    (geometricallyConnectedCommHopfAlgProperty F).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.2.1,
+    (geometricallySolvablePointsCommHopfAlgProperty F).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.2.2.1, ?_⟩
+  intro J hJsmooth hJconnected hJsolvable hJpulled
+  let J' := J.comapOfSurjective g hg
+  have hJ'smooth : smoothCommHopfAlgProperty F
+      (FiniteTypeCommHopfAlgCat.quotient L J').obj :=
+    (smoothCommHopfAlgProperty F).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJsmooth
+  have hJ'connected : geometricallyConnectedCommHopfAlgProperty F
+      (FiniteTypeCommHopfAlgCat.quotient L J').obj :=
+    (geometricallyConnectedCommHopfAlgProperty F).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJconnected
+  have hJ'solvable : geometricallySolvablePointsCommHopfAlgProperty F
+      (FiniteTypeCommHopfAlgCat.quotient L J').obj :=
+    (geometricallySolvablePointsCommHopfAlgProperty F).prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJsolvable
+  have hJ'comap : J'.comapOfSurjective f hf = J :=
+    HopfIdeal.comapOfSurjective_bialgEquiv_symm_apply J
+      (_root_.CommHopfAlgCat.ofIso <| (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} F)
+        (_root_.CommHopfAlgCat.{u} F)).mapIso e)
+  have hJ'I : J' ≤ I := by
+    rw [← HopfIdeal.comapOfSurjective_le_comapOfSurjective_iff f hf, hJ'comap]
+    exact hJpulled
+  have hIJ' : I ≤ J' := hI.2.2.2 J' hJ'smooth hJ'connected hJ'solvable hJ'I
+  calc
+    I.comapOfSurjective f hf ≤ J'.comapOfSurjective f hf :=
+      HopfIdeal.comapOfSurjective_mono f hf hIJ'
+    _ = J := hJ'comap
+
+/-- Over an algebraically closed field, the upper-triangular subgroup of `GL₂` is maximal among
+smooth geometrically connected solvable closed subgroups. -/
+private theorem isBorelOverField_definingHopfIdeal [IsAlgClosed k] :
+    isBorelOverField k
+      ⟨GeneralLinear.coordinateHopfAlgebra k 2,
+        (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
+      (definingHopfIdeal k) := by
+  rw [isBorelOverField_iff]
   refine ⟨UpperTriangular.smoothCommHopfAlgProperty_coordinateHopfAlgebra 2 k,
     UpperTriangular.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra 2 k,
     UpperTriangular.geometricallySolvablePointsCommHopfAlgProperty_coordinateHopfAlgebra k 2,
@@ -284,6 +387,37 @@ theorem isBorel_definingHopfIdeal :
   rw [GeneralLinear.mem_hopfIdealPointsSubgroup_iff] at hqB
   rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
   simpa only [MulEquiv.symm_apply_apply] using hqB
+
+/-- **The upper-triangular subgroup scheme of `GL₂` is a Borel subgroup over every field.**
+Its base change to an algebraic closure is smooth, connected, solvable, and maximal among closed
+subgroups with those properties. -/
+theorem isBorel_definingHopfIdeal :
+    HopfIdeal.IsBorel k (GeneralLinear.coordinateHopfAlgebra k 2) (definingHopfIdeal k) := by
+  simp only [HopfIdeal.isBorel_iff]
+  let K := AlgebraicClosure k
+  let H : FiniteTypeCommHopfAlgCat.{u, u} k :=
+    ⟨GeneralLinear.coordinateHopfAlgebra k 2,
+      (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
+  let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K) H
+  let L : FiniteTypeCommHopfAlgCat.{u, u} K :=
+    ⟨GeneralLinear.coordinateHopfAlgebra K 2,
+      (finiteTypeCommHopfAlgProperty_iff _).2 inferInstance⟩
+  let e : H' ≅ L := ObjectProperty.isoMk _
+    (GeneralLinear.coordinateHopfAlgebraBaseChangeIso k K 2)
+  let I' := CommHopfAlgCat.baseChangeHopfIdeal (K := K) (definingHopfIdeal k)
+  rw [← isBorelOverField_iff K H' I']
+  have htarget : isBorelOverField K L (definingHopfIdeal K) := by
+    simpa only [L] using (isBorelOverField_definingHopfIdeal (k := K))
+  have hpull := isBorelOverField_comapOfIso htarget e
+  let f := FiniteTypeCommHopfAlgCat.toBialgHom e.hom
+  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.hom
+  have hmap : I'.map f = definingHopfIdeal K := by
+    exact map_baseChangeHopfIdeal_definingHopfIdeal k K
+  have hcomap :
+      (definingHopfIdeal K).comapOfSurjective f hf.2 = I' := by
+    rw [← hmap]
+    exact HopfIdeal.comapOfSurjective_map_of_bijective I' f hf
+  rwa [hcomap] at hpull
 
 end Field
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
@@ -5,7 +5,14 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.Borel.Basic
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.UpperTriangular.Basic
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.UpperTriangular.SmoothConnected
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.UpperTriangular
+import Mathlib.GroupTheory.IsPerfect
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Separation
+import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Bruhat
 
 /-!
 # The upper-triangular Borel subgroup scheme of `GL₂`
@@ -35,6 +42,8 @@ arbitrary commutative base ring.
 * `TauCeti.GeneralLinear.Borel.coordinateHopfAlgebra`: the quotient coordinate Hopf algebra.
 * `TauCeti.GeneralLinear.Borel.groupScheme`: the resulting closed subgroup scheme of `GL₂`.
 * `TauCeti.GeneralLinear.Borel.inclusion`: its closed immersion into the named `GL₂` group scheme.
+* `TauCeti.GeneralLinear.Borel.isBorel_definingHopfIdeal`: the upper-triangular subgroup is a
+  Borel subgroup over every field.
 
 ## References
 
@@ -167,5 +176,115 @@ theorem finiteTypeCoordinateHopfAlgebra_obj :
 /-- The structural morphism of the Borel subgroup scheme is locally of finite type. -/
 instance locallyOfFiniteType_groupScheme :
     AlgebraicGeometry.LocallyOfFiniteType (groupScheme R).X.hom := by infer_instance
+
+section Field
+
+variable {k : Type u} [Field k]
+
+private theorem not_isSolvable_generalLinear_two
+    (F : Type u) [Field F] [Infinite F] :
+    ¬ Group.IsSolvable (GL (Fin 2) F) := by
+  let S : Set F := {0} ∪ {1} ∪ {-1}
+  let U := {x : F // x ∈ Sᶜ}
+  let _ : Infinite U := (Set.toFinite S).infinite_compl.to_subtype
+  obtain ⟨a, _, _⟩ := exists_pair_ne U
+  have ha0 : (a : F) ≠ 0 := by
+    intro h
+    apply a.property
+    simp [S, h]
+  have ha1 : (a : F) ^ 2 ≠ 1 := by
+    rw [sq_ne_one_iff]
+    constructor
+    · intro h
+      apply a.property
+      simp [S, h]
+    · intro h
+      apply a.property
+      simp [S, h]
+  let _ : Group.IsPerfect (Matrix.SpecialLinearGroup (Fin 2) F) :=
+    ⟨Matrix.SL2.commutator_eq_top ha0 ha1⟩
+  let t : Matrix.SpecialLinearGroup (Fin 2) F :=
+    Matrix.SpecialLinearGroup.transvection (show (0 : Fin 2) ≠ 1 by decide) 1
+  have ht : t ≠ 1 := by
+    intro ht
+    have hentry := congrArg
+      (fun s : Matrix.SpecialLinearGroup (Fin 2) F ↦ (s : Matrix (Fin 2) (Fin 2) F) 0 1) ht
+    simp [t, Matrix.SpecialLinearGroup.transvection_coe, Matrix.single] at hentry
+  let _ : Nontrivial (Matrix.SpecialLinearGroup (Fin 2) F) := ⟨t, 1, ht⟩
+  intro hGL
+  let _ : Group.IsSolvable (GL (Fin 2) F) := hGL
+  exact Group.IsPerfect.not_isSolvable (Matrix.SpecialLinearGroup (Fin 2) F) <|
+    Group.isSolvable_of_isSolvable_injective
+      (f := Matrix.SpecialLinearGroup.toGL) Matrix.SpecialLinearGroup.toGL_injective
+
+private theorem le_gl2Borel_of_isSolvable
+    {F : Type u} [Field F] [Infinite F]
+    (P : Subgroup (GL (Fin 2) F)) [Group.IsSolvable P]
+    (hBP : GL2Borel F ≤ P) : P ≤ GL2Borel F := by
+  by_contra hPB
+  obtain ⟨g, hgP, hgB⟩ := SetLike.not_le_iff_exists.mp hPB
+  obtain ⟨x, hx, y, hy, hxy⟩ :=
+    DoubleCoset.mem_doubleCoset.mp (GL2Borel.mem_doubleCoset_weyl_of_notMem hgB)
+  have hwP : GL2WeylElement F ∈ P := by
+    have hxP := hBP hx
+    have hyP := hBP hy
+    have hprod : x⁻¹ * g * y⁻¹ ∈ P := mul_mem (mul_mem (inv_mem hxP) hgP) (inv_mem hyP)
+    convert hprod using 1
+    rw [hxy]
+    group
+  have hclosure :
+      Subgroup.closure (insert (GL2WeylElement F) (GL2Borel F : Set (GL (Fin 2) F))) ≤ P :=
+    (Subgroup.closure_le P).mpr (Set.insert_subset_iff.mpr ⟨hwP, hBP⟩)
+  rw [GL2Borel.closure_insert_gl2WeylElement_eq_top] at hclosure
+  have hPtop : P = ⊤ := top_unique hclosure
+  apply not_isSolvable_generalLinear_two F
+  apply Group.isSolvable_of_surjective (f := P.subtype)
+  intro g
+  refine ⟨⟨g, ?_⟩, rfl⟩
+  rw [hPtop]
+  exact Subgroup.mem_top g
+
+/-- **The upper-triangular subgroup scheme of `GL₂` is a Borel subgroup over every field.** It is
+smooth, geometrically connected, and geometrically solvable, and every
+smooth geometrically connected solvable closed subgroup containing it is equal to it. -/
+theorem isBorel_definingHopfIdeal :
+    HopfIdeal.IsBorel k (GeneralLinear.coordinateHopfAlgebra k 2) (definingHopfIdeal k) := by
+  rw [HopfIdeal.isBorel_iff]
+  refine ⟨UpperTriangular.smoothCommHopfAlgProperty_coordinateHopfAlgebra 2 k,
+    UpperTriangular.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra 2 k,
+    UpperTriangular.geometricallySolvablePointsCommHopfAlgProperty_coordinateHopfAlgebra k 2,
+    ?_⟩
+  intro I hIsmooth _ hIsolvable hIB
+  let H := GeneralLinear.coordinateHopfAlgebra k 2
+  let K := AlgebraicClosure k
+  let P := GeneralLinear.hopfIdealPointsSubgroup 2 I K
+  have hBP : GL2Borel K ≤ P := by
+    change upperTriangularGroup (Fin 2) K ≤ P
+    rw [← UpperTriangular.hopfIdealPointsSubgroup_eq k 2]
+    exact GeneralLinear.hopfIdealPointsSubgroup_le_of_le 2 hIB K
+  let e := GeneralLinear.hopfIdealPointsSubgroupMulEquiv 2 I (CommAlgCat.of k K)
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff] at hIsolvable
+  let _ : Group.IsSolvable
+      (HopfAlgebra.points (R := k) (H := CommHopfAlgCat.quotient H I)
+        (CommAlgCat.of k K)) := hIsolvable
+  let _ : Group.IsSolvable P :=
+    Group.isSolvable_of_isSolvable_injective (f := e.symm.toMonoidHom) e.symm.injective
+  have hPB : P ≤ GL2Borel K := le_gl2Borel_of_isSolvable P hBP
+  let _ : IsReduced (CommHopfAlgCat.quotient H I) :=
+    ((smoothCommHopfAlgProperty_iff_geometricallyReduced k
+      (CommHopfAlgCat.quotient H I)).mp hIsmooth).isReduced
+  apply HopfIdeal.le_of_quotientPointsSubgroup_le (K := K)
+  intro q hq
+  have hqP : GeneralLinear.pointsMulEquiv 2 q ∈ P :=
+    GeneralLinear.pointsMulEquiv_mem_hopfIdealPointsSubgroup 2 I K q hq
+  have hqB : GeneralLinear.pointsMulEquiv 2 q ∈
+      GeneralLinear.hopfIdealPointsSubgroup 2 (definingHopfIdeal k) K := by
+    rw [UpperTriangular.hopfIdealPointsSubgroup_eq k 2]
+    exact hPB hqP
+  rw [GeneralLinear.mem_hopfIdealPointsSubgroup_iff] at hqB
+  rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
+  simpa only [MulEquiv.symm_apply_apply] using hqB
+
+end Field
 
 end TauCeti.GeneralLinear.Borel

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
@@ -298,11 +298,17 @@ private theorem isBorelOverField_iff (F : Type u) [Field F]
     exact ⟨⟨hsmooth, hconnected, hsolvable⟩,
       fun J hJ hJI ↦ hmax J hJ.1 hJ.2.1 hJ.2.2 hJI⟩
 
-private theorem isBorelOverField_comapOfIso
+/-- A minimal quotient property is preserved when its ambient finite-type Hopf algebra is
+replaced by an isomorphic one. The property itself is transported across the induced quotient
+isomorphism, while competing Hopf ideals are pulled back along the inverse ambient isomorphism. -/
+private theorem minimal_quotientProperty_comapOfIso
     {F : Type u} [Field F]
+    (P : ObjectProperty (_root_.CommHopfAlgCat.{u} F)) [P.IsClosedUnderIsomorphisms]
     {H L : FiniteTypeCommHopfAlgCat.{u, u} F} {I : HopfIdeal F L.obj}
-    (hI : isBorelOverField F L I) (e : H ≅ L) :
-    isBorelOverField F H
+    (hI : Minimal (fun J : HopfIdeal F L.obj ↦
+      P (FiniteTypeCommHopfAlgCat.quotient L J).obj) I) (e : H ≅ L) :
+    Minimal (fun J : HopfIdeal F H.obj ↦
+      P (FiniteTypeCommHopfAlgCat.quotient H J).obj)
       (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
         (ConcreteCategory.bijective_of_isIso e.hom).2) := by
   let f := FiniteTypeCommHopfAlgCat.toBialgHom e.hom
@@ -311,39 +317,47 @@ private theorem isBorelOverField_comapOfIso
   let hg := (ConcreteCategory.bijective_of_isIso e.inv).2
   let forget : FiniteTypeCommHopfAlgCat.{u, u} F ⥤ _root_.CommHopfAlgCat.{u} F :=
     forget₂ (FiniteTypeCommHopfAlgCat.{u, u} F) (_root_.CommHopfAlgCat.{u} F)
-  rw [isBorelOverField_iff] at hI ⊢
-  refine ⟨(smoothCommHopfAlgProperty F).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.1,
-    (geometricallyConnectedCommHopfAlgProperty F).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.2.1,
-    (geometricallySolvablePointsCommHopfAlgProperty F).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.2.2.1, ?_⟩
-  intro J hJsmooth hJconnected hJsolvable hJpulled
+  refine ⟨P.prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.prop, ?_⟩
+  intro J hJ hJpulled
   let J' := J.comapOfSurjective g hg
-  have hJ'smooth : smoothCommHopfAlgProperty F
-      (FiniteTypeCommHopfAlgCat.quotient L J').obj :=
-    (smoothCommHopfAlgProperty F).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJsmooth
-  have hJ'connected : geometricallyConnectedCommHopfAlgProperty F
-      (FiniteTypeCommHopfAlgCat.quotient L J').obj :=
-    (geometricallyConnectedCommHopfAlgProperty F).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJconnected
-  have hJ'solvable : geometricallySolvablePointsCommHopfAlgProperty F
-      (FiniteTypeCommHopfAlgCat.quotient L J').obj :=
-    (geometricallySolvablePointsCommHopfAlgProperty F).prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJsolvable
+  have hJ' : P (FiniteTypeCommHopfAlgCat.quotient L J').obj :=
+    P.prop_of_iso
+      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJ
   have hJ'comap : J'.comapOfSurjective f hf = J :=
     HopfIdeal.comapOfSurjective_bialgEquiv_symm_apply J
-      (_root_.CommHopfAlgCat.ofIso <| (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} F)
-        (_root_.CommHopfAlgCat.{u} F)).mapIso e)
+      (_root_.CommHopfAlgCat.ofIso <| forget.mapIso e)
   have hJ'I : J' ≤ I := by
     rw [← HopfIdeal.comapOfSurjective_le_comapOfSurjective_iff f hf, hJ'comap]
     exact hJpulled
-  have hIJ' : I ≤ J' := hI.2.2.2 J' hJ'smooth hJ'connected hJ'solvable hJ'I
+  have hIJ' : I ≤ J' := hI.le_of_le hJ' hJ'I
   calc
     I.comapOfSurjective f hf ≤ J'.comapOfSurjective f hf :=
       HopfIdeal.comapOfSurjective_mono f hf hIJ'
     _ = J := hJ'comap
+
+private theorem isBorelOverField_comapOfIso
+    {F : Type u} [Field F]
+    {H L : FiniteTypeCommHopfAlgCat.{u, u} F} {I : HopfIdeal F L.obj}
+    (hI : isBorelOverField F L I) (e : H ≅ L) :
+    isBorelOverField F H
+      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2) := by
+  let P : ObjectProperty (_root_.CommHopfAlgCat.{u} F) :=
+    smoothCommHopfAlgProperty F ⊓
+      (geometricallyConnectedCommHopfAlgProperty F ⊓
+        geometricallySolvablePointsCommHopfAlgProperty F)
+  change Minimal (fun J : HopfIdeal F L.obj ↦
+    P (FiniteTypeCommHopfAlgCat.quotient L J).obj) I at hI
+  change Minimal (fun J : HopfIdeal F H.obj ↦
+    P (FiniteTypeCommHopfAlgCat.quotient H J).obj)
+      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2)
+  exact minimal_quotientProperty_comapOfIso P hI e
+
+/-- The named `GL₂` Borel subgroup is the rank-two upper-triangular subgroup. -/
+private theorem gl2Borel_eq_upperTriangularGroup (F : Type u) [CommRing F] :
+    GL2Borel F = upperTriangularGroup (Fin 2) F := rfl
 
 /-- Over a field, the upper-triangular subgroup of `GL₂` is maximal among smooth geometrically
 connected solvable closed subgroups. -/
@@ -362,8 +376,8 @@ private theorem isBorelOverField_definingHopfIdeal :
   let K := AlgebraicClosure k
   let P := GeneralLinear.hopfIdealPointsSubgroup 2 I K
   have hBP : GL2Borel K ≤ P := by
-    change upperTriangularGroup (Fin 2) K ≤ P
-    rw [← UpperTriangular.hopfIdealPointsSubgroup_eq k 2]
+    rw [gl2Borel_eq_upperTriangularGroup,
+      ← UpperTriangular.hopfIdealPointsSubgroup_eq k 2]
     exact GeneralLinear.hopfIdealPointsSubgroup_le_of_le 2 hIB K
   let e := GeneralLinear.hopfIdealPointsSubgroupMulEquiv 2 I (CommAlgCat.of k K)
   rw [geometricallySolvablePointsCommHopfAlgProperty_iff] at hIsolvable

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
@@ -9,7 +9,6 @@ public import TauCeti.Algebra.AlgebraicGroup.Borel.Basic
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.UpperTriangular.Basic
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.UpperTriangular.SmoothConnected
 public import TauCeti.Algebra.AlgebraicGroup.Solvable.UpperTriangular
-import Mathlib.GroupTheory.IsPerfect
 import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Coordinate.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Separation
 import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
@@ -199,70 +198,6 @@ section Field
 
 variable {k : Type u} [Field k]
 
-private theorem not_isSolvable_generalLinear_two
-    (F : Type u) [Field F] [Infinite F] :
-    ¬ Group.IsSolvable (GL (Fin 2) F) := by
-  let S : Set F := {0} ∪ {1} ∪ {-1}
-  let U := {x : F // x ∈ Sᶜ}
-  let _ : Infinite U := (Set.toFinite S).infinite_compl.to_subtype
-  obtain ⟨a, _, _⟩ := exists_pair_ne U
-  have ha0 : (a : F) ≠ 0 := by
-    intro h
-    apply a.property
-    simp [S, h]
-  have ha1 : (a : F) ^ 2 ≠ 1 := by
-    rw [sq_ne_one_iff]
-    constructor
-    · intro h
-      apply a.property
-      simp [S, h]
-    · intro h
-      apply a.property
-      simp [S, h]
-  let _ : Group.IsPerfect (Matrix.SpecialLinearGroup (Fin 2) F) :=
-    ⟨Matrix.SL2.commutator_eq_top ha0 ha1⟩
-  have h01 : (0 : Fin 2) ≠ 1 := by decide
-  let t : Matrix.SpecialLinearGroup (Fin 2) F :=
-    Matrix.SpecialLinearGroup.transvection h01 1
-  have ht : t ≠ 1 := by
-    intro ht
-    have hentry := congrArg
-      (fun s : Matrix.SpecialLinearGroup (Fin 2) F ↦ (s : Matrix (Fin 2) (Fin 2) F) 0 1) ht
-    simp [t, Matrix.SpecialLinearGroup.transvection_coe, Matrix.single] at hentry
-  let _ : Nontrivial (Matrix.SpecialLinearGroup (Fin 2) F) := ⟨t, 1, ht⟩
-  intro hGL
-  let _ : Group.IsSolvable (GL (Fin 2) F) := hGL
-  exact Group.IsPerfect.not_isSolvable (Matrix.SpecialLinearGroup (Fin 2) F) <|
-    Group.isSolvable_of_isSolvable_injective
-      (f := Matrix.SpecialLinearGroup.toGL) Matrix.SpecialLinearGroup.toGL_injective
-
-private theorem le_gl2Borel_of_isSolvable
-    {F : Type u} [Field F] [Infinite F]
-    (P : Subgroup (GL (Fin 2) F)) [Group.IsSolvable P]
-    (hBP : GL2Borel F ≤ P) : P ≤ GL2Borel F := by
-  by_contra hPB
-  obtain ⟨g, hgP, hgB⟩ := SetLike.not_le_iff_exists.mp hPB
-  obtain ⟨x, hx, y, hy, hxy⟩ :=
-    DoubleCoset.mem_doubleCoset.mp (GL2Borel.mem_doubleCoset_weyl_of_notMem hgB)
-  have hwP : GL2WeylElement F ∈ P := by
-    have hxP := hBP hx
-    have hyP := hBP hy
-    have hprod : x⁻¹ * g * y⁻¹ ∈ P := mul_mem (mul_mem (inv_mem hxP) hgP) (inv_mem hyP)
-    convert hprod using 1
-    rw [hxy]
-    group
-  have hclosure :
-      Subgroup.closure (insert (GL2WeylElement F) (GL2Borel F : Set (GL (Fin 2) F))) ≤ P :=
-    (Subgroup.closure_le P).mpr (Set.insert_subset_iff.mpr ⟨hwP, hBP⟩)
-  rw [GL2Borel.closure_insert_gl2WeylElement_eq_top] at hclosure
-  have hPtop : P = ⊤ := top_unique hclosure
-  apply not_isSolvable_generalLinear_two F
-  apply Group.isSolvable_of_surjective (f := P.subtype)
-  intro g
-  refine ⟨⟨g, ?_⟩, rfl⟩
-  rw [hPtop]
-  exact Subgroup.mem_top g
-
 /-- The smooth, geometrically connected, geometrically solvable maximality condition over one
 field. This local predicate is used to transport the geometric Borel condition across the
 canonical base-change isomorphism for `GL₂`. -/
@@ -328,7 +263,7 @@ private theorem isBorelOverField_definingHopfIdeal :
         (CommAlgCat.of k K)) := hIsolvable
   let _ : Group.IsSolvable P :=
     Group.isSolvable_of_isSolvable_injective (f := e.symm.toMonoidHom) e.symm.injective
-  have hPB : P ≤ GL2Borel K := le_gl2Borel_of_isSolvable P hBP
+  have hPB : P ≤ GL2Borel K := GL2Borel.le_of_isSolvable P hBP
   let _ : IsReduced (CommHopfAlgCat.quotient H I) :=
     ((smoothCommHopfAlgProperty_iff_geometricallyReduced k
       (CommHopfAlgCat.quotient H I)).mp hIsmooth).isReduced

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
@@ -221,8 +221,9 @@ private theorem not_isSolvable_generalLinear_two
       simp [S, h]
   let _ : Group.IsPerfect (Matrix.SpecialLinearGroup (Fin 2) F) :=
     ⟨Matrix.SL2.commutator_eq_top ha0 ha1⟩
+  have h01 : (0 : Fin 2) ≠ 1 := by decide
   let t : Matrix.SpecialLinearGroup (Fin 2) F :=
-    Matrix.SpecialLinearGroup.transvection (show (0 : Fin 2) ≠ 1 by decide) 1
+    Matrix.SpecialLinearGroup.transvection h01 1
   have ht : t ≠ 1 := by
     intro ht
     have hentry := congrArg
@@ -298,44 +299,6 @@ private theorem isBorelOverField_iff (F : Type u) [Field F]
     exact ⟨⟨hsmooth, hconnected, hsolvable⟩,
       fun J hJ hJI ↦ hmax J hJ.1 hJ.2.1 hJ.2.2 hJI⟩
 
-/-- A minimal quotient property is preserved when its ambient finite-type Hopf algebra is
-replaced by an isomorphic one. The property itself is transported across the induced quotient
-isomorphism, while competing Hopf ideals are pulled back along the inverse ambient isomorphism. -/
-private theorem minimal_quotientProperty_comapOfIso
-    {F : Type u} [Field F]
-    (P : ObjectProperty (_root_.CommHopfAlgCat.{u} F)) [P.IsClosedUnderIsomorphisms]
-    {H L : FiniteTypeCommHopfAlgCat.{u, u} F} {I : HopfIdeal F L.obj}
-    (hI : Minimal (fun J : HopfIdeal F L.obj ↦
-      P (FiniteTypeCommHopfAlgCat.quotient L J).obj) I) (e : H ≅ L) :
-    Minimal (fun J : HopfIdeal F H.obj ↦
-      P (FiniteTypeCommHopfAlgCat.quotient H J).obj)
-      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
-        (ConcreteCategory.bijective_of_isIso e.hom).2) := by
-  let f := FiniteTypeCommHopfAlgCat.toBialgHom e.hom
-  let hf := (ConcreteCategory.bijective_of_isIso e.hom).2
-  let g := FiniteTypeCommHopfAlgCat.toBialgHom e.inv
-  let hg := (ConcreteCategory.bijective_of_isIso e.inv).2
-  let forget : FiniteTypeCommHopfAlgCat.{u, u} F ⥤ _root_.CommHopfAlgCat.{u} F :=
-    forget₂ (FiniteTypeCommHopfAlgCat.{u, u} F) (_root_.CommHopfAlgCat.{u} F)
-  refine ⟨P.prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I)).symm hI.prop, ?_⟩
-  intro J hJ hJpulled
-  let J' := J.comapOfSurjective g hg
-  have hJ' : P (FiniteTypeCommHopfAlgCat.quotient L J').obj :=
-    P.prop_of_iso
-      (forget.mapIso (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J)).symm hJ
-  have hJ'comap : J'.comapOfSurjective f hf = J :=
-    HopfIdeal.comapOfSurjective_bialgEquiv_symm_apply J
-      (_root_.CommHopfAlgCat.ofIso <| forget.mapIso e)
-  have hJ'I : J' ≤ I := by
-    rw [← HopfIdeal.comapOfSurjective_le_comapOfSurjective_iff f hf, hJ'comap]
-    exact hJpulled
-  have hIJ' : I ≤ J' := hI.le_of_le hJ' hJ'I
-  calc
-    I.comapOfSurjective f hf ≤ J'.comapOfSurjective f hf :=
-      HopfIdeal.comapOfSurjective_mono f hf hIJ'
-    _ = J := hJ'comap
-
 private theorem isBorelOverField_comapOfIso
     {F : Type u} [Field F]
     {H L : FiniteTypeCommHopfAlgCat.{u, u} F} {I : HopfIdeal F L.obj}
@@ -343,21 +306,12 @@ private theorem isBorelOverField_comapOfIso
     isBorelOverField F H
       (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
         (ConcreteCategory.bijective_of_isIso e.hom).2) := by
-  let P : ObjectProperty (_root_.CommHopfAlgCat.{u} F) :=
-    smoothCommHopfAlgProperty F ⊓
+  exact FiniteTypeCommHopfAlgCat.minimal_quotientProperty_comapOfIso
+    ((smoothCommHopfAlgProperty F ⊓
       (geometricallyConnectedCommHopfAlgProperty F ⊓
-        geometricallySolvablePointsCommHopfAlgProperty F)
-  change Minimal (fun J : HopfIdeal F L.obj ↦
-    P (FiniteTypeCommHopfAlgCat.quotient L J).obj) I at hI
-  change Minimal (fun J : HopfIdeal F H.obj ↦
-    P (FiniteTypeCommHopfAlgCat.quotient H J).obj)
-      (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
-        (ConcreteCategory.bijective_of_isIso e.hom).2)
-  exact minimal_quotientProperty_comapOfIso P hI e
-
-/-- The named `GL₂` Borel subgroup is the rank-two upper-triangular subgroup. -/
-private theorem gl2Borel_eq_upperTriangularGroup (F : Type u) [CommRing F] :
-    GL2Borel F = upperTriangularGroup (Fin 2) F := rfl
+        geometricallySolvablePointsCommHopfAlgProperty F)).inverseImage
+      (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} F)
+        (_root_.CommHopfAlgCat.{u} F))) I hI e
 
 /-- Over a field, the upper-triangular subgroup of `GL₂` is maximal among smooth geometrically
 connected solvable closed subgroups. -/
@@ -376,8 +330,8 @@ private theorem isBorelOverField_definingHopfIdeal :
   let K := AlgebraicClosure k
   let P := GeneralLinear.hopfIdealPointsSubgroup 2 I K
   have hBP : GL2Borel K ≤ P := by
-    rw [gl2Borel_eq_upperTriangularGroup,
-      ← UpperTriangular.hopfIdealPointsSubgroup_eq k 2]
+    change upperTriangularGroup (Fin 2) K ≤ P
+    rw [← UpperTriangular.hopfIdealPointsSubgroup_eq k 2]
     exact GeneralLinear.hopfIdealPointsSubgroup_le_of_le 2 hIB K
   let e := GeneralLinear.hopfIdealPointsSubgroupMulEquiv 2 I (CommAlgCat.of k K)
   rw [geometricallySolvablePointsCommHopfAlgProperty_iff] at hIsolvable

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.RingTheory.Flat.FaithfullyFlat.Algebra
 public import TauCeti.Algebra.AlgebraicGroup.BaseChange.CentralPoint
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
-public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.CommonKernel
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.RingTheory.Flat.FaithfullyFlat.Algebra
 public import TauCeti.Algebra.AlgebraicGroup.BaseChange.CentralPoint
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.CommonKernel
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
@@ -46,6 +47,8 @@ along `h ↦ 1 ⊗ h`.
   change reflects containment of Hopf ideals.
 * `TauCeti.CommHopfAlgCat.baseChangeHopfIdeal_injective`: faithfully flat base change reflects
   equality of Hopf ideals.
+* `TauCeti.CommHopfAlgCat.baseChangeHopfIdeal_comapOfIso`: base change commutes with pulling a
+  Hopf ideal back along an ambient isomorphism.
 * `TauCeti.CommHopfAlgCat.baseChangeHopfIdeal_commonKernelHopfIdeal_le`: the subgroup generated
   by a base-changed family sits inside the base change of the subgroup it generates.
 * `TauCeti.CommHopfAlgCat.quotientBaseChangeIso`: the identification
@@ -146,6 +149,51 @@ theorem baseChangeHopfIdeal_mono {J J' : HopfIdeal k H} (hJ : J ≤ J') :
     baseChangeHopfIdeal (K := K) J ≤ baseChangeHopfIdeal (K := K) J' := by
   rw [← HopfIdeal.toIdeal_le_toIdeal, baseChangeHopfIdeal_toIdeal, baseChangeHopfIdeal_toIdeal]
   exact Ideal.map_mono (HopfIdeal.toIdeal_le_toIdeal.mpr hJ)
+
+/-- Base change commutes with pulling a Hopf ideal back along an ambient Hopf-algebra
+isomorphism. -/
+@[simp]
+theorem baseChangeHopfIdeal_comapOfIso (J : HopfIdeal k L) (e : H ≅ L) :
+    baseChangeHopfIdeal (K := K)
+        (J.comapOfSurjective e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2) =
+      (baseChangeHopfIdeal (K := K) J).comapOfSurjective
+        (baseChangeMap (K := K) e.hom).hom
+        (ConcreteCategory.bijective_of_isIso
+          ((baseChangeFunctor (K := K)).mapIso e).hom).2 := by
+  let qIso := quotientIsoOfIso e J
+  let qIsoK := (baseChangeFunctor (K := K)).mapIso qIso
+  have hcomm :
+      baseChangeMap (K := K) (mkQuotient H
+          (J.comapOfSurjective e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2)) ≫
+          qIsoK.hom =
+        baseChangeMap (K := K) e.hom ≫
+          baseChangeMap (K := K) (mkQuotient L J) := by
+    change (baseChangeFunctor (K := K)).map (mkQuotient H
+          (J.comapOfSurjective e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2)) ≫
+        (baseChangeFunctor (K := K)).map qIso.hom =
+      (baseChangeFunctor (K := K)).map e.hom ≫
+        (baseChangeFunctor (K := K)).map (mkQuotient L J)
+    rw [← Functor.map_comp, ← Functor.map_comp]
+    exact congrArg (fun f ↦ (baseChangeFunctor (K := K)).map f)
+      (mkQuotient_comp_quotientIsoOfIso_hom e J)
+  ext x
+  rw [mem_baseChangeHopfIdeal_iff, HopfIdeal.mem_comapOfSurjective,
+    mem_baseChangeHopfIdeal_iff]
+  have hpoint : qIsoK.hom.hom
+        ((baseChangeMap (K := K) (mkQuotient H
+          (J.comapOfSurjective e.hom.hom
+            (ConcreteCategory.bijective_of_isIso e.hom).2))).hom x) =
+      (baseChangeMap (K := K) (mkQuotient L J)).hom
+        ((baseChangeMap (K := K) e.hom).hom x) :=
+    congrArg
+      (fun f : baseChange (K := K) H ⟶ baseChange (K := K) (quotient L J) ↦ f.hom x) hcomm
+  constructor
+  · intro hx
+    rw [hx, map_zero] at hpoint
+    exact hpoint.symm
+  · intro hx
+    apply (ConcreteCategory.bijective_of_isIso qIsoK.hom).1
+    rw [map_zero, hpoint, hx]
 
 /-- Along an injective scalar map, base change reflects containment of Hopf ideals when the
 quotient by the larger ideal is flat over the base. In particular, this applies to every field
@@ -435,6 +483,32 @@ theorem mem_quotientPointsSubgroup_baseChangeHopfIdeal_iff (J : HopfIdeal k H)
     exact RingHom.mem_ker.mp (hle ((HopfIdeal.mem_toIdeal (I := baseChangeHopfIdeal J)).mpr hy))
 
 end TauCeti.CommHopfAlgCat
+
+namespace TauCeti.FiniteTypeCommHopfAlgCat
+
+universe u v w
+
+variable {k : Type u} {K : Type w} [CommRing k] [CommRing K] [Algebra k K]
+variable {H L : FiniteTypeCommHopfAlgCat.{u, v} k}
+
+/-- Base change commutes with pulling a Hopf ideal back along an ambient finite-type
+Hopf-algebra isomorphism. -/
+@[simp]
+theorem baseChangeHopfIdeal_comapOfIso (J : HopfIdeal k L.obj) (e : H ≅ L) :
+    CommHopfAlgCat.baseChangeHopfIdeal (K := K)
+        (J.comapOfSurjective (toBialgHom e.hom)
+          (ConcreteCategory.bijective_of_isIso e.hom).2) =
+      (CommHopfAlgCat.baseChangeHopfIdeal (K := K) J).comapOfSurjective
+        (toBialgHom ((_root_.TauCeti.FiniteTypeCommHopfAlgCat.baseChangeFunctor
+          (K := K)).mapIso e).hom)
+        (ConcreteCategory.bijective_of_isIso
+          ((_root_.TauCeti.FiniteTypeCommHopfAlgCat.baseChangeFunctor
+            (K := K)).mapIso e).hom).2 := by
+  exact CommHopfAlgCat.baseChangeHopfIdeal_comapOfIso (K := K) J
+    ((forget₂ (FiniteTypeCommHopfAlgCat.{u, v} k)
+      (_root_.CommHopfAlgCat.{v} k)).mapIso e)
+
+end TauCeti.FiniteTypeCommHopfAlgCat
 
 namespace TauCeti.CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/BaseChange.lean
@@ -168,6 +168,8 @@ theorem baseChangeHopfIdeal_comapOfIso (J : HopfIdeal k L) (e : H ≅ L) :
           qIsoK.hom =
         baseChangeMap (K := K) e.hom ≫
           baseChangeMap (K := K) (mkQuotient L J) := by
+    -- `baseChangeMap` is the map field of the `baseChangeFunctor` abbreviation. Unfolding
+    -- that wrapper here exposes both composites in the form required by `Functor.map_comp`.
     change (baseChangeFunctor (K := K)).map (mkQuotient H
           (J.comapOfSurjective e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2)) ≫
         (baseChangeFunctor (K := K)).map qIso.hom =
@@ -483,32 +485,6 @@ theorem mem_quotientPointsSubgroup_baseChangeHopfIdeal_iff (J : HopfIdeal k H)
     exact RingHom.mem_ker.mp (hle ((HopfIdeal.mem_toIdeal (I := baseChangeHopfIdeal J)).mpr hy))
 
 end TauCeti.CommHopfAlgCat
-
-namespace TauCeti.FiniteTypeCommHopfAlgCat
-
-universe u v w
-
-variable {k : Type u} {K : Type w} [CommRing k] [CommRing K] [Algebra k K]
-variable {H L : FiniteTypeCommHopfAlgCat.{u, v} k}
-
-/-- Base change commutes with pulling a Hopf ideal back along an ambient finite-type
-Hopf-algebra isomorphism. -/
-@[simp]
-theorem baseChangeHopfIdeal_comapOfIso (J : HopfIdeal k L.obj) (e : H ≅ L) :
-    CommHopfAlgCat.baseChangeHopfIdeal (K := K)
-        (J.comapOfSurjective (toBialgHom e.hom)
-          (ConcreteCategory.bijective_of_isIso e.hom).2) =
-      (CommHopfAlgCat.baseChangeHopfIdeal (K := K) J).comapOfSurjective
-        (toBialgHom ((_root_.TauCeti.FiniteTypeCommHopfAlgCat.baseChangeFunctor
-          (K := K)).mapIso e).hom)
-        (ConcreteCategory.bijective_of_isIso
-          ((_root_.TauCeti.FiniteTypeCommHopfAlgCat.baseChangeFunctor
-            (K := K)).mapIso e).hom).2 := by
-  exact CommHopfAlgCat.baseChangeHopfIdeal_comapOfIso (K := K) J
-    ((forget₂ (FiniteTypeCommHopfAlgCat.{u, v} k)
-      (_root_.CommHopfAlgCat.{v} k)).mapIso e)
-
-end TauCeti.FiniteTypeCommHopfAlgCat
 
 namespace TauCeti.CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Separation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Separation.lean
@@ -11,9 +11,10 @@ public import TauCeti.RingTheory.FiniteType.PointSeparation
 /-!
 # Recovering reduced closed subgroups from geometric points
 
-Let `H` be a commutative Hopf algebra over an algebraically closed field. A Hopf ideal `I`
-cuts out the subgroup of points of `H` that vanish on `I`. If the quotient `H/I` is reduced and
-of finite type, its points separate functions, so this subgroup determines `I`.
+Let `H` be a commutative Hopf algebra over a field and fix an algebraically closed extension. A
+Hopf ideal `I` cuts out the subgroup of extension-valued points of `H` that vanish on `I`. If the
+quotient `H/I` is reduced and of finite type, its points separate functions, so this subgroup
+determines `I`.
 
 The order statement is contravariant: if every point cut out by `J` is also cut out by `I`, then
 `I ≤ J`, provided `H/J` is reduced and of finite type. Applying it in both directions shows that
@@ -42,55 +43,56 @@ open CategoryTheory WithConv
 
 namespace TauCeti
 
-universe u v
+universe u v w
 
 namespace HopfIdeal
 
-variable {k : Type u} [Field k] [IsAlgClosed k]
+variable {k : Type u} [Field k]
+variable {K : Type w} [Field K] [Algebra k K] [IsAlgClosed K]
 variable {H : _root_.CommHopfAlgCat.{v} k} {I J : HopfIdeal k H}
 
 /-- Recover an inclusion of Hopf ideals from the reverse inclusion of their point subgroups.
 
 Only the quotient by the ideal on the right of the conclusion must be reduced and of finite
-type. Those hypotheses make its `k`-valued points separate functions. -/
+type. Those hypotheses make its `K`-valued points separate functions. -/
 theorem le_of_quotientPointsSubgroup_le
     [Algebra.FiniteType k (CommHopfAlgCat.quotient H J)]
     [IsReduced (CommHopfAlgCat.quotient H J)]
-    (hpoints : CommHopfAlgCat.quotientPointsSubgroup H J (CommAlgCat.of k k) ≤
-      CommHopfAlgCat.quotientPointsSubgroup H I (CommAlgCat.of k k)) :
+    (hpoints : CommHopfAlgCat.quotientPointsSubgroup H J (CommAlgCat.of k K) ≤
+      CommHopfAlgCat.quotientPointsSubgroup H I (CommAlgCat.of k K)) :
     I ≤ J := by
   intro x hx
   apply HopfIdeal.mem_toIdeal.mp
   apply Ideal.Quotient.eq_zero_iff_mem.mp
-  apply eq_of_forall_algHom_apply_eq (k := k) (K := k)
+  apply eq_of_forall_algHom_apply_eq (k := k) (K := K)
   intro f
-  let g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k) :=
-    CommHopfAlgCat.quotientPointsHom H J (CommAlgCat.of k k) (toConv f)
-  have hgJ : g ∈ CommHopfAlgCat.quotientPointsSubgroup H J (CommAlgCat.of k k) :=
+  let g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k K) :=
+    CommHopfAlgCat.quotientPointsHom H J (CommAlgCat.of k K) (toConv f)
+  have hgJ : g ∈ CommHopfAlgCat.quotientPointsSubgroup H J (CommAlgCat.of k K) :=
     CommHopfAlgCat.quotientPointsHom_mem_quotientPointsSubgroup H J
-      (CommAlgCat.of k k) (toConv f)
+      (CommAlgCat.of k K) (toConv f)
   have hgI := hpoints hgJ
   rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff] at hgI
   have hzero :
-      ((CommHopfAlgCat.quotientPointsHom H J (CommAlgCat.of k k) (toConv f)).ofConv) x = 0 :=
+      ((CommHopfAlgCat.quotientPointsHom H J (CommAlgCat.of k K) (toConv f)).ofConv) x = 0 :=
     by simpa only [g] using hgI x hx
   rw [CommHopfAlgCat.quotientPointsHom_apply_apply] at hzero
   simpa only [WithConv.ofConv_toConv, map_zero, Ideal.Quotient.mkₐ_eq_mk] using hzero
 
-/-- Two reduced finite-type closed subgroups of an affine group over an algebraically closed
-field have the same defining Hopf ideal when they have the same points. -/
+/-- Two reduced finite-type closed subgroups of an affine group have the same defining Hopf ideal
+when they have the same points over an algebraically closed extension. -/
 theorem eq_of_quotientPointsSubgroup_eq
     [Algebra.FiniteType k (CommHopfAlgCat.quotient H I)]
     [IsReduced (CommHopfAlgCat.quotient H I)]
     [Algebra.FiniteType k (CommHopfAlgCat.quotient H J)]
     [IsReduced (CommHopfAlgCat.quotient H J)]
-    (hpoints : CommHopfAlgCat.quotientPointsSubgroup H I (CommAlgCat.of k k) =
-      CommHopfAlgCat.quotientPointsSubgroup H J (CommAlgCat.of k k)) :
+    (hpoints : CommHopfAlgCat.quotientPointsSubgroup H I (CommAlgCat.of k K) =
+      CommHopfAlgCat.quotientPointsSubgroup H J (CommAlgCat.of k K)) :
     I = J := by
   apply le_antisymm
-  · apply le_of_quotientPointsSubgroup_le
+  · apply le_of_quotientPointsSubgroup_le (K := K)
     rw [hpoints]
-  · apply le_of_quotientPointsSubgroup_le
+  · apply le_of_quotientPointsSubgroup_le (K := K)
     rw [hpoints]
 
 end HopfIdeal

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -68,6 +68,8 @@ the finite-type coordinate-Hopf-algebra category.
   ambient automorphism imply invariance of a Hopf ideal.
 * `TauCeti.FiniteTypeCommHopfAlgCat.quotientIsoOfIso`: an ambient isomorphism induces an
   isomorphism between the corresponding finite-type Hopf-ideal quotients.
+* `TauCeti.FiniteTypeCommHopfAlgCat.minimal_quotientProperty_comapOfIso`: a minimal
+  isomorphism-invariant quotient property is preserved by an ambient isomorphism.
 * `TauCeti.FiniteTypeCommHopfAlgCat.quotientBotIso`: quotienting by the zero Hopf ideal does
   not change a finite-type commutative Hopf algebra.
 
@@ -647,6 +649,38 @@ noncomputable def quotientIsoOfIso (e : H ≅ K) (I : HopfIdeal R K) :
     CommHopfAlgCat.quotientIsoOfIso
       ((forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
         (_root_.CommHopfAlgCat.{v} R)).mapIso e) I
+
+/-- A minimal isomorphism-invariant property of finite-type Hopf-algebra quotients is preserved
+when the ambient Hopf algebra is replaced by an isomorphic one. -/
+theorem minimal_quotientProperty_comapOfIso
+    (P : ObjectProperty (FiniteTypeCommHopfAlgCat.{u, v} R)) [P.IsClosedUnderIsomorphisms]
+    (I : HopfIdeal R K)
+    (hI : Minimal (fun J : HopfIdeal R K ↦ P (quotient K J)) I) (e : H ≅ K) :
+    Minimal (fun J : HopfIdeal R H ↦ P (quotient H J))
+      (I.comapOfSurjective (toBialgHom e.hom)
+        (ConcreteCategory.bijective_of_isIso e.hom).2) := by
+  let f := toBialgHom e.hom
+  let hf := (ConcreteCategory.bijective_of_isIso e.hom).2
+  let g := toBialgHom e.inv
+  let hg := (ConcreteCategory.bijective_of_isIso e.inv).2
+  refine ⟨P.prop_of_iso (quotientIsoOfIso e I).symm hI.prop, ?_⟩
+  intro J hJ hJpulled
+  let J' := J.comapOfSurjective g hg
+  have hJ' : P (quotient K J') :=
+    P.prop_of_iso (quotientIsoOfIso e.symm J).symm hJ
+  have hJ'comap : J'.comapOfSurjective f hf = J :=
+    HopfIdeal.comapOfSurjective_bialgEquiv_symm_apply J
+      (_root_.CommHopfAlgCat.ofIso <|
+        (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+          (_root_.CommHopfAlgCat.{v} R)).mapIso e)
+  have hJ'I : J' ≤ I := by
+    rw [← HopfIdeal.comapOfSurjective_le_comapOfSurjective_iff f hf, hJ'comap]
+    exact hJpulled
+  have hIJ' : I ≤ J' := hI.le_of_le hJ' hJ'I
+  calc
+    I.comapOfSurjective f hf ≤ J'.comapOfSurjective f hf :=
+      HopfIdeal.comapOfSurjective_mono f hf hIJ'
+    _ = J := hJ'comap
 
 /-- Transporting a finite-type quotient object along an equality of Hopf ideals transports its
 quotient morphism. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Maximal.lean
@@ -83,30 +83,8 @@ theorem comapOfIso (hI : IsMaximalTorus k K.obj I) (e : H ≅ K) :
     IsMaximalTorus k H.obj
       (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
         (ConcreteCategory.bijective_of_isIso e.hom).2) := by
-  let f := FiniteTypeCommHopfAlgCat.toBialgHom e.hom
-  let hf := (ConcreteCategory.bijective_of_isIso e.hom).2
-  let g := FiniteTypeCommHopfAlgCat.toBialgHom e.inv
-  let hg := (ConcreteCategory.bijective_of_isIso e.inv).2
-  refine ⟨(torusCommHopfAlgProperty k).prop_of_iso
-    (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e I).symm hI.prop, ?_⟩
-  intro J hJ hJpulled
-  let J' := J.comapOfSurjective g hg
-  have hJ' : torusCommHopfAlgProperty k (FiniteTypeCommHopfAlgCat.quotient K J') :=
-    (torusCommHopfAlgProperty k).prop_of_iso
-      (FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm J).symm hJ
-  have hJ'comap : J'.comapOfSurjective f hf = J := by
-    exact HopfIdeal.comapOfSurjective_bialgEquiv_symm_apply J
-      (_root_.CommHopfAlgCat.ofIso <| (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-        (_root_.CommHopfAlgCat.{u} k)).mapIso e)
-  have hJ'I : J' ≤ I := by
-    rw [← HopfIdeal.comapOfSurjective_le_comapOfSurjective_iff f hf]
-    rw [hJ'comap]
-    exact hJpulled
-  have hIJ' : I ≤ J' := hI.le_of_le hJ' hJ'I
-  calc
-    I.comapOfSurjective f hf ≤ J'.comapOfSurjective f hf :=
-      HopfIdeal.comapOfSurjective_mono f hf hIJ'
-    _ = J := hJ'comap
+  exact FiniteTypeCommHopfAlgCat.minimal_quotientProperty_comapOfIso
+    (torusCommHopfAlgProperty k) I hI e
 
 /-- Maximal-torus status is invariant under pulling the defining ideal back across an ambient
 Hopf-algebra isomorphism. -/

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/SpecialLinear.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/SpecialLinear.lean
@@ -224,7 +224,7 @@ theorem baseChangeDefiningIdeal_eq_specialLinearDefiningHopfIdeal
   let _ : IsReduced (SpecialLinear.coordinateHopfAlgebra k (r + 1)) :=
     isReduced_of_smooth_of_field k _
   apply le_antisymm
-  · apply HopfIdeal.le_of_quotientPointsSubgroup_le
+  · apply HopfIdeal.le_of_quotientPointsSubgroup_le (K := k)
     intro g hg
     rw [mem_baseChangeDefiningPointsSubgroup_iff_mem_points]
     apply (mem_points_iff_det_eq_one (K := k) r _).2

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
@@ -12,10 +12,15 @@ public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Borel
 -- `DoubleCoset.doubleCoset`, `DoubleCoset.mk` and `DoubleCoset.Quotient` occur in the statements
 -- below.
 public import Mathlib.GroupTheory.DoubleCoset
+-- `Group.IsSolvable` occurs in the maximality statements below.
+public import Mathlib.GroupTheory.Solvable
 -- Non-public: the general double-coset identities — when two classes agree, and that the identity
 -- double coset of a subgroup is the subgroup itself — are used only inside the proofs of the
 -- double-coset results below, which are their specializations to the Borel subgroup of `GL₂`.
 import TauCeti.GroupTheory.DoubleCoset.Identity
+-- Non-public: perfect groups are nonsolvable, which proves that `GL₂` over an infinite field is
+-- nonsolvable.
+import Mathlib.GroupTheory.IsPerfect
 -- Non-public: the order of `GL₂` over a finite field is used only inside the proof of the size of
 -- the big cell.
 import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Card
@@ -68,6 +73,9 @@ the Weyl element.
 * `TauCeti.GL2Borel.card_doubleCosetQuotient_eq_two`: `B` has exactly two double cosets in `GL₂`.
 * `TauCeti.GL2Borel.closure_insert_gl2WeylElement_eq_top`: the Borel subgroup and the Weyl element
   generate `GL₂`.
+* `TauCeti.Matrix.GeneralLinearGroup.not_isSolvable_fin_two`: `GL₂` over an infinite field is not
+  solvable, and `TauCeti.GL2Borel.le_of_isSolvable`: every solvable subgroup containing the Borel
+  subgroup equals it.
 * `TauCeti.GL2Borel.ncard_doubleCoset_weyl`: the big cell of `GL₂(𝔽_q)` has `q² (q - 1)²`
   elements.
 
@@ -330,6 +338,77 @@ theorem closure_insert_gl2WeylElement_eq_top :
       (mul_mem (Subgroup.subset_closure (Set.mem_insert_of_mem _ hx))
         (Subgroup.subset_closure (Set.mem_insert _ _)))
       (Subgroup.subset_closure (Set.mem_insert_of_mem _ hy))
+
+end GL2Borel
+
+namespace Matrix.GeneralLinearGroup
+
+/-- The general linear group `GL₂` over an infinite field is not solvable. -/
+theorem not_isSolvable_fin_two [Infinite F] : ¬ Group.IsSolvable (GL (Fin 2) F) := by
+  let S : Set F := {0} ∪ {1} ∪ {-1}
+  let U := {x : F // x ∈ Sᶜ}
+  let _ : Infinite U := (Set.toFinite S).infinite_compl.to_subtype
+  obtain ⟨a, _, _⟩ := exists_pair_ne U
+  have ha0 : (a : F) ≠ 0 := by
+    intro h
+    apply a.property
+    simp [S, h]
+  have ha1 : (a : F) ^ 2 ≠ 1 := by
+    rw [sq_ne_one_iff]
+    constructor
+    · intro h
+      apply a.property
+      simp [S, h]
+    · intro h
+      apply a.property
+      simp [S, h]
+  let _ : Group.IsPerfect (Matrix.SpecialLinearGroup (Fin 2) F) :=
+    ⟨Matrix.SL2.commutator_eq_top ha0 ha1⟩
+  have h01 : (0 : Fin 2) ≠ 1 := by decide
+  let t : Matrix.SpecialLinearGroup (Fin 2) F :=
+    Matrix.SpecialLinearGroup.transvection h01 1
+  have ht : t ≠ 1 := by
+    intro ht
+    have hentry := congrArg
+      (fun s : Matrix.SpecialLinearGroup (Fin 2) F ↦ (s : Matrix (Fin 2) (Fin 2) F) 0 1) ht
+    simp [t, Matrix.SpecialLinearGroup.transvection_coe, Matrix.single] at hentry
+  let _ : Nontrivial (Matrix.SpecialLinearGroup (Fin 2) F) := ⟨t, 1, ht⟩
+  intro hGL
+  let _ : Group.IsSolvable (GL (Fin 2) F) := hGL
+  exact Group.IsPerfect.not_isSolvable (Matrix.SpecialLinearGroup (Fin 2) F) <|
+    Group.isSolvable_of_isSolvable_injective
+      (f := Matrix.SpecialLinearGroup.toGL) Matrix.SpecialLinearGroup.toGL_injective
+
+end Matrix.GeneralLinearGroup
+
+namespace GL2Borel
+
+/-- Every solvable subgroup of `GL₂` over an infinite field that contains the upper-triangular
+subgroup is contained in it. -/
+theorem le_of_isSolvable [Infinite F] (P : Subgroup (GL (Fin 2) F)) [Group.IsSolvable P]
+    (hBP : GL2Borel F ≤ P) : P ≤ GL2Borel F := by
+  by_contra hPB
+  obtain ⟨g, hgP, hgB⟩ := SetLike.not_le_iff_exists.mp hPB
+  obtain ⟨x, hx, y, hy, hxy⟩ :=
+    DoubleCoset.mem_doubleCoset.mp (mem_doubleCoset_weyl_of_notMem hgB)
+  have hwP : GL2WeylElement F ∈ P := by
+    have hxP := hBP hx
+    have hyP := hBP hy
+    have hprod : x⁻¹ * g * y⁻¹ ∈ P := mul_mem (mul_mem (inv_mem hxP) hgP) (inv_mem hyP)
+    convert hprod using 1
+    rw [hxy]
+    group
+  have hclosure :
+      Subgroup.closure (insert (GL2WeylElement F) (GL2Borel F : Set (GL (Fin 2) F))) ≤ P :=
+    (Subgroup.closure_le P).mpr (Set.insert_subset_iff.mpr ⟨hwP, hBP⟩)
+  rw [closure_insert_gl2WeylElement_eq_top] at hclosure
+  have hPtop : P = ⊤ := top_unique hclosure
+  apply Matrix.GeneralLinearGroup.not_isSolvable_fin_two F
+  apply Group.isSolvable_of_surjective (f := P.subtype)
+  intro g
+  refine ⟨⟨g, ?_⟩, rfl⟩
+  rw [hPtop]
+  exact Subgroup.mem_top g
 
 end GL2Borel
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/ProjectiveLine.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/ProjectiveLine.lean
@@ -91,7 +91,7 @@ public section
 
 namespace TauCeti
 
-open Matrix OnePoint
+open _root_.Matrix OnePoint
 open scoped Pointwise
 
 universe u

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/CharacterValues.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/CharacterValues.lean
@@ -67,7 +67,7 @@ public section
 
 namespace TauCeti
 
-open Matrix
+open _root_.Matrix
 
 universe u
 

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/CharacterValues.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/CharacterValues.lean
@@ -71,7 +71,7 @@ public section
 
 namespace TauCeti
 
-open Matrix
+open _root_.Matrix
 
 universe u
 


### PR DESCRIPTION
This PR defines a Borel subgroup in Hopf coordinates as a smooth, geometrically connected, geometrically solvable closed subgroup maximal among such subgroups, and proves that the upper-triangular subgroup scheme of `GL₂` is Borel over every field. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 7, target “Borel subgroups, maximal tori, and their conjugacy.”

The maximality proof works over `AlgebraicClosure k`: Bruhat decomposition forces any matrix subgroup properly containing the upper-triangular subgroup to contain the Weyl element and hence all of `GL₂`, while the embedded perfect group `SL₂` rules out solvability. The generalized algebraically-closed-point separation theorem then recovers the Hopf-ideal inclusion over the original field.

Milestone: Layer 7, “Borel subgroups, maximal tori, and their conjugacy.” After this PR, existence and conjugacy of Borel subgroups and maximal tori for general reductive groups, together with the higher-rank standard Borel theorem, remain.

The implementation reuses `Matrix.SL2.commutator_eq_top` and `Matrix.SpecialLinearGroup.toGL_injective` from Mathlib, and Tau Ceti’s `GL2Borel.mem_doubleCoset_weyl_of_notMem`, `GL2Borel.closure_insert_gl2WeylElement_eq_top`, upper-triangular smoothness/connectedness/solvability, and reduced point separation; no external formalization is vendored. The mathematical organization follows Milne, *Algebraic Groups*, §17.a, and Springer, *Linear Algebraic Groups*, §§6.2–6.3, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"gl2-upper-triangular-borel"}-->

🤖 Prepared with Codex
