### PR TITLE
feat: the different divisor of an extension of function fields

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Different/Divisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Different/Divisor.lean
@@ -1,0 +1,242 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.FunctionField.Different.Basic
+public import TauCeti.FieldTheory.FunctionField.Divisor.Basic
+public import TauCeti.FieldTheory.FunctionField.Place.Extension.Fibre
+public import TauCeti.FieldTheory.FunctionField.Place.Extension.IntegralBasis.AlmostEverywhere
+public import TauCeti.RingTheory.DedekindDomain.Different
+
+/-!
+# The different divisor of an extension of algebraic function fields
+
+Let `F' / k'` be an extension of the algebraic function field `F / k` with `F' / F` finite and
+separable.  Stichtenoth attaches to it the **different divisor**
+
+`Diff(F' / F) = ∑_{P'} d(P' ∣ P) · P'`
+
+of `F' / k'`, the effective divisor whose coefficient at a place `P'` is the different exponent
+of `P'` over the place `P = P'.restrict k F` below it.  The exponents themselves are
+`TauCeti.Place.differentExponent`; what this file supplies is the finiteness that turns the
+family into a divisor, and the divisor itself.
+
+Finiteness is Stichtenoth's Remark 3.4.4, and it is where the almost-everywhere theory of
+integral bases is spent.  Fix an `F`-basis `b` of `F'`.  At a place `P` at which both `b` and its
+trace-dual basis are integral bases, the local model `𝒪'_P` is the `𝒪_P`-span of `b` and its
+complementary module is the span of the trace dual, so the two coincide and the different ideal
+of `𝒪_P ⊆ 𝒪'_P` is the unit ideal: every place of `F' / k'` over such a `P` has different
+exponent `0`.  All but finitely many places of `F / k` are of that kind
+(`TauCeti.Place.finite_setOf_not_isIntegralBasis`), and each of the remaining ones carries only
+finitely many places of `F' / k'` (`TauCeti.Place.finite_setOf_restrict_eq`), so only finitely
+many `P'` have a nonzero exponent.
+
+The step that reads the unit different ideal off a self-dual integral basis has no function-field
+content and is `TauCeti.differentIdeal_eq_top_of_span_eq_one`, in
+`TauCeti/RingTheory/DedekindDomain/Different.lean`; what this file adds to it is the place at
+which to apply it.
+
+No affine model of `F / k` is used, so no normalization theorem is needed: the argument runs over
+the local models `𝒪_P ⊆ 𝒪'_P` only.  In particular this is not an instance of
+`Algebra.finite_compl_unramifiedLocus`, which bounds the ramification locus of a single extension
+of Dedekind domains — here the extension varies with the place, and each individual local model,
+being semi-local, has a finite ramification locus for trivial reasons.
+
+## Main definitions
+
+* `TauCeti.Divisor.different`: the different divisor `Diff(F' / F)` (Stichtenoth,
+  Definition 3.4.3).
+
+## Main results
+
+* `TauCeti.Place.differentIdeal_eq_top_of_isIntegralBasis`: the different ideal of the local
+  model at `P` is the unit ideal as soon as some basis and its trace dual are integral bases
+  at `P`.
+* `TauCeti.Place.finite_setOf_differentExponent_ne_zero`: only finitely many places of `F' / k'`
+  have a nonzero different exponent (Stichtenoth, Remark 3.4.4).
+* `TauCeti.Divisor.zero_le_different`: the different divisor is effective, `Diff(F' / F) ≥ 0`.
+* `TauCeti.Divisor.mem_support_different_iff` and `TauCeti.Divisor.different_eq_zero_iff`: its
+  support consists of the places where the local model is ramified (Stichtenoth,
+  Corollary 3.5.5), so it vanishes exactly when `F' / F` is everywhere unramified.
+
+## Implementation notes
+
+The upper field `F' / k'` is an explicit argument of `TauCeti.Divisor.different` and the lower
+field `F / k` is read off the function-field hypothesis, the convention of
+`TauCeti.Divisor.conorm`.  That hypothesis `IsFunctionField k F` is an explicit argument rather
+than a typeclass, following the rest of this directory; it is what makes the support finite, so
+it cannot be avoided in the definition, and since it is a `Prop`, two spellings of it give the
+same divisor.
+
+Like the conorm, the different divisor is built from its coefficients through
+`Finsupp.ofSupportFinite`, which makes the coefficient formula definitional.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Definition 3.4.3, Remark 3.4.4 and Corollary 3.5.5.
+-/
+
+public section
+
+open Module
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+universe u u' v v'
+
+variable {k : Type u} {k' : Type u'} {F : Type v} {F' : Type v'}
+variable [Field k] [Field F] [Field F'] [Algebra k F] [Algebra F F']
+
+namespace Place
+
+attribute [local instance 10] algebraIntegersExtension isScalarTowerIntegersExtension
+
+section LocalModel
+
+variable [FiniteDimensional F F'] [Algebra.IsSeparable F F'] (P : Place k F)
+
+/-- **The different ideal of the local model at a place with an integral basis is trivial.**  If
+an `F`-basis `b` of `F'` and its trace dual are both integral bases at `P`, then `𝒪'_P` is its own
+complementary module, so `differentIdeal 𝒪_P 𝒪'_P` is the unit ideal. -/
+theorem differentIdeal_eq_top_of_isIntegralBasis {ι : Type*} [Finite ι] [DecidableEq ι]
+    {b : Basis ι F F'} (hb : P.IsIntegralBasis F' b) (hb' : P.IsIntegralBasis F' b.traceDual) :
+    differentIdeal P.integers (integralClosure P.integers F') = ⊤ :=
+  differentIdeal_eq_top_of_span_eq_one P.integers F b
+    (by
+      rw [Subalgebra.restrictScalars_one]
+      exact (isIntegralBasis_iff_span_eq F' P b).mp hb)
+    (by
+      rw [Subalgebra.restrictScalars_one]
+      exact (isIntegralBasis_iff_span_eq F' P b.traceDual).mp hb')
+
+end LocalModel
+
+section Extension
+
+variable [Field k'] [Algebra k k'] [Algebra k' F'] [Algebra k F']
+variable [IsScalarTower k k' F'] [IsScalarTower k F F'] [FiniteDimensional F F']
+variable [Algebra.IsSeparable F F']
+
+variable (k F)
+
+/-- **A place with an integral basis below it is not in the different.**  If an `F`-basis of `F'`
+and its trace dual are integral bases at the place below `P'`, then `d(P' ∣ P) = 0`. -/
+theorem differentExponent_eq_zero_of_isIntegralBasis (P' : Place k' F') {ι : Type*} [Finite ι]
+    [DecidableEq ι] {b : Basis ι F F'} (hb : (P'.restrict k F).IsIntegralBasis F' b)
+    (hb' : (P'.restrict k F).IsIntegralBasis F' b.traceDual) :
+    differentExponent k F P' = 0 := by
+  by_contra h
+  have hdvd := (pow_dvd_differentIdeal_iff_le_differentExponent (n := 1) k F P').mpr
+    (Nat.one_le_iff_ne_zero.mpr h)
+  rw [pow_one, differentIdeal_eq_top_of_isIntegralBasis _ hb hb', Ideal.dvd_iff_le,
+    top_le_iff] at hdvd
+  exact (centerIntegralClosure k F P').isPrime.ne_top hdvd
+
+/-- **Only finitely many places have a nonzero different exponent** (Stichtenoth,
+Remark 3.4.4).  A basis of `F' / F` and its trace dual are integral bases at all but finitely many
+places of `F / k`, no place above such a place contributes, and each of the finitely many
+remaining places of `F / k` has only finitely many places of `F' / k'` above it. -/
+theorem finite_setOf_differentExponent_ne_zero (hF : IsFunctionField k F) :
+    {P' : Place k' F' | differentExponent k F P' ≠ 0}.Finite := by
+  classical
+  set b := finBasis F F'
+  have hbad := (finite_setOf_not_isIntegralBasis hF b).union
+    (finite_setOf_not_isIntegralBasis hF b.traceDual)
+  refine (hbad.biUnion fun P _ ↦ finite_setOf_restrict_eq (k' := k') (F' := F') k F P).subset
+    fun P' hP' ↦ Set.mem_biUnion (x := P'.restrict k F) ?_ rfl
+  by_contra hgood
+  simp only [Set.mem_union, Set.mem_ofPred_eq, not_or, not_not] at hgood
+  exact hP' (differentExponent_eq_zero_of_isIntegralBasis k F P' hgood.1 hgood.2)
+
+end Extension
+
+end Place
+
+namespace Divisor
+
+section Extension
+
+variable [Field k'] [Algebra k k'] [Algebra k' F'] [Algebra k F']
+variable [IsScalarTower k k' F'] [IsScalarTower k F F'] [FiniteDimensional F F']
+variable [Algebra.IsSeparable F F']
+
+variable (k' F')
+
+/-- The different exponents form a finitely supported family of coefficients. -/
+private theorem finite_support_differentCoeff (hF : IsFunctionField k F) :
+    (Function.support fun P' : Place k' F' ↦ (Place.differentExponent k F P' : ℤ)).Finite :=
+  (Place.finite_setOf_differentExponent_ne_zero (k' := k') (F' := F') k F hF).subset
+    fun _ hP' ↦ by simpa using hP'
+
+/-- **The different divisor** `Diff(F' / F) = ∑_{P'} d(P' ∣ P) · P'` of an extension `F' / k'` of
+an algebraic function field `F / k` with `F' / F` finite and separable (Stichtenoth,
+Definition 3.4.3): the divisor of `F' / k'` whose coefficient at a place `P'` is the different
+exponent of `P'` over the place below it. -/
+noncomputable def different (hF : IsFunctionField k F) : Divisor k' F' :=
+  Finsupp.ofSupportFinite (fun P' : Place k' F' ↦ (Place.differentExponent k F P' : ℤ))
+    (finite_support_differentCoeff k' F' hF)
+
+/-- **The defining coefficient formula of the different divisor**: the coefficient of
+`Diff(F' / F)` at a place `P'` is the different exponent `d(P' ∣ P)`. -/
+@[simp]
+theorem coeff_different (hF : IsFunctionField k F) (P' : Place k' F') :
+    (different k' F' hF).coeff P' = Place.differentExponent k F P' := (rfl)
+
+/-- **The different divisor is effective**, `Diff(F' / F) ≥ 0` (Stichtenoth, Definition 3.4.3):
+its coefficients are different exponents, which are natural numbers. -/
+theorem zero_le_different (hF : IsFunctionField k F) : 0 ≤ different k' F' hF :=
+  WeilDivisor.le_iff.mpr fun P' ↦ by
+    rw [WeilDivisor.coeff_zero, coeff_different]
+    exact Int.natCast_nonneg _
+
+/-- The degree of the different divisor is nonnegative. -/
+theorem degree_different_nonneg (hF : IsFunctionField k F) :
+    0 ≤ degree (different k' F' hF) :=
+  degree_nonneg (zero_le_different k' F' hF)
+
+/-- **The support of the different divisor is the ramification locus** (Stichtenoth,
+Corollary 3.5.5): a place lies in it exactly when the local model is ramified there, in Mathlib's
+`Algebra.IsUnramifiedAt` sense, which asks for a separable residue extension as well as
+`e(P' ∣ P) = 1`. -/
+theorem mem_support_different_iff (hF : IsFunctionField k F) {P' : Place k' F'} :
+    P' ∈ (different k' F' hF).support ↔ ¬ Algebra.IsUnramifiedAt ((P'.restrict k F).integers)
+      (Place.centerIntegralClosure k F P').asIdeal := by
+  rw [WeilDivisor.mem_support_iff, coeff_different, ne_eq, Nat.cast_eq_zero,
+    Place.differentExponent_eq_zero_iff]
+
+/-- **The different divisor vanishes exactly for an everywhere unramified extension**
+(Stichtenoth, Corollary 3.5.5). -/
+theorem different_eq_zero_iff (hF : IsFunctionField k F) :
+    different k' F' hF = 0 ↔ ∀ P' : Place k' F',
+      Algebra.IsUnramifiedAt ((P'.restrict k F).integers)
+        (Place.centerIntegralClosure k F P').asIdeal := by
+  refine ⟨fun h P' ↦ ?_, fun h ↦ WeilDivisor.ext fun P' ↦ ?_⟩
+  · have hP' := coeff_different k' F' hF P'
+    rw [h, WeilDivisor.coeff_zero] at hP'
+    rw [← Place.differentExponent_eq_zero_iff]
+    exact_mod_cast hP'.symm
+  · rw [coeff_different, WeilDivisor.coeff_zero, Nat.cast_eq_zero,
+      Place.differentExponent_eq_zero_iff]
+    exact h P'
+
+/-- **A ramified place lies in the different** (Stichtenoth, Corollary 3.5.5): this half needs no
+hypothesis on the residue extension. -/
+theorem mem_support_different_of_one_lt_ramificationIdx (hF : IsFunctionField k F)
+    {P' : Place k' F'} (h : 1 < Place.ramificationIdx F P') :
+    P' ∈ (different k' F' hF).support := by
+  rw [WeilDivisor.mem_support_iff, coeff_different, ne_eq, Nat.cast_eq_zero]
+  exact (Place.differentExponent_pos_of_one_lt_ramificationIdx k F P' h).ne'
+
+end Extension
+
+end Divisor
+
+end TauCeti
+
+end

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis/Basic.lean
@@ -105,6 +105,13 @@ integral closure `𝒪'_P` inside `F'` (Stichtenoth, Section III.3). -/
 def IsIntegralBasis {ι : Type*} (b : Basis ι F F') : Prop :=
   Submodule.span (P.integers) (Set.range b) = (integralClosure (P.integers) F').toSubmodule
 
+/-- Unfolding of `TauCeti.Place.IsIntegralBasis`: a basis is an integral basis at `P` exactly when
+its `𝒪_P`-span is the local integral closure `𝒪'_P`. -/
+theorem isIntegralBasis_iff_span_eq {ι : Type*} (b : Basis ι F F') :
+    P.IsIntegralBasis F' b ↔ Submodule.span (P.integers) (Set.range b) =
+      (integralClosure (P.integers) F').toSubmodule :=
+  (Iff.rfl)
+
 /-- A basis is an integral basis at `P` exactly when integrality over `𝒪_P` is equivalent to all
 of its coordinates lying in `𝒪_P`. -/
 theorem isIntegralBasis_iff_isIntegral_iff_repr_mem {ι : Type*} (b : Basis ι F F') :

--- a/TauCeti/RingTheory/DedekindDomain/Different.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.Different
+
+/-!
+# When the different ideal is the unit ideal
+
+Let `A` be an integrally closed domain with fraction field `K` and let `B` be a Dedekind domain
+with fraction field `L`, integral over `A`, with `L / K` finite and separable.  Mathlib's
+`differentIdeal A B` is the inverse of the trace dual `Bᵛ = {x ∈ L | Tr_{L/K} (x · B) ⊆ A}` of `B`,
+so it is the unit ideal exactly when `B` is its own trace dual.  This file records that criterion
+and the concrete test that decides it: a `K`-basis of `L` that spans `B` over `A` and whose
+trace-dual basis spans `B` as well.
+
+Mathlib's `not_dvd_differentIdeal_iff` decides divisibility of the different ideal by one prime at
+a time; the statements here are the global ones, and dispose of all primes at once.
+
+## Main results
+
+* `TauCeti.differentIdeal_eq_top_iff_traceDual_eq_one`: the different ideal is the unit ideal
+  exactly when `B` is its own trace dual.
+* `TauCeti.differentIdeal_eq_top_of_span_eq_one`: the basis form of that criterion.
+-/
+
+public section
+
+open Module Submodule
+
+open scoped nonZeroDivisors
+
+namespace TauCeti
+
+variable (A K : Type*) {B L : Type*}
+variable [CommRing A] [Field K] [CommRing B] [Field L]
+variable [Algebra A K] [Algebra B L] [Algebra A B] [Algebra K L] [Algebra A L]
+variable [IsScalarTower A K L] [IsScalarTower A B L]
+variable [IsDomain A] [IsFractionRing A K] [IsFractionRing B L]
+variable [IsIntegrallyClosed A] [IsDedekindDomain B] [Module.IsTorsionFree A B]
+variable [FiniteDimensional K L] [Algebra.IsSeparable K L] [IsIntegralClosure B A L]
+
+/-- **The different ideal is the unit ideal exactly when `B` is its own trace dual.**  The
+different ideal is the inverse of the trace dual as a fractional ideal, and inversion is
+injective on the nonzero ones. -/
+theorem differentIdeal_eq_top_iff_traceDual_eq_one :
+    differentIdeal A B = ⊤ ↔ Submodule.traceDual A K (1 : Submodule B L) = 1 := by
+  have hdual : FractionalIdeal.dual A K (1 : FractionalIdeal B⁰ L) = 1 ↔
+      Submodule.traceDual A K (1 : Submodule B L) = 1 := by
+    rw [← FractionalIdeal.coeToSubmodule_inj (J := (1 : FractionalIdeal B⁰ L)),
+      FractionalIdeal.coe_dual_one, FractionalIdeal.coe_one]
+  rw [← hdual, ← Ideal.one_eq_top, ← FractionalIdeal.coeIdeal_eq_one (K := L),
+    coeIdeal_differentIdeal (A := A) (K := K) (L := L) (B := B), inv_eq_one]
+
+/-- **A self-dual integral basis makes the different ideal the unit ideal**: if a `K`-basis of `L`
+spans `B` over `A`, and so does its trace-dual basis, then `B` is its own trace dual, because the
+trace dual of a span is the span of the trace-dual basis. -/
+theorem differentIdeal_eq_top_of_span_eq_one {ι : Type*} [Finite ι] [DecidableEq ι]
+    (b : Basis ι K L)
+    (hb : Submodule.span A (Set.range b) = (1 : Submodule B L).restrictScalars A)
+    (hb' : Submodule.span A (Set.range b.traceDual) = (1 : Submodule B L).restrictScalars A) :
+    differentIdeal A B = ⊤ := by
+  rw [differentIdeal_eq_top_iff_traceDual_eq_one A K (L := L)]
+  refine Submodule.restrictScalars_injective A _ _ ?_
+  rw [Submodule.traceDual_span_of_basis A _ b hb.symm, hb']
+
+end TauCeti
+
+end


### PR DESCRIPTION
This PR assembles the different exponents of an extension `F' / k'` of an algebraic function field `F / k`, with `F' / F` finite and separable, into the **different divisor** `Diff(F' / F) = ∑_{P'} d(P' ∣ P) · P'` of `F' / k'`, and proves it is effective and supported exactly on the ramified places.

The exact target is `TauCetiRoadmap/AlgebraicCurves/README.md`, Layer 7 ("the different and the Hurwitz genus formula"), first bullet "The different exponent and divisor", whose statement of record is `Diff(F′/F) := ∑ d(P′∣P) · P′ ≥ 0` (Stichtenoth, Definition 3.4.3 and Remark 3.4.4) with "finite support via `dvd_differentIdeal_iff`/`Algebra.IsUnramifiedAt` finiteness". The exponent `d(P' ∣ P)` itself is already on `main` as `TauCeti.Place.differentExponent`, together with `e ≤ d + 1` and `d = 0 ↔` unramified; it had no consumer, because the finiteness that turns the family `P' ↦ d(P' ∣ P)` into a divisor was missing. That finiteness is what this PR supplies, and it is the one thing standing between the exponent and every divisor-level statement of the layer.

The proof spends the almost-everywhere theory of integral bases that landed in #5164, whose own module docstring names this as its consumer ("This theorem is the finiteness input for the different divisor"). Fix an `F`-basis `b` of `F'`. Mathlib's `Submodule.traceDual_span_of_basis` computes the trace dual of the `𝒪_P`-span of `b` as the span of `b.traceDual`, so at a place where both `b` and `b.traceDual` are integral bases the local model `𝒪'_P` is its own complementary module, and its different ideal is the unit ideal; every place above such a `P` then has different exponent `0` (`TauCeti.Place.differentIdeal_eq_top_of_isIntegralBasis`, `TauCeti.Place.differentExponent_eq_zero_of_isIntegralBasis`). All but finitely many places of `F / k` are of that kind (`TauCeti.Place.finite_setOf_not_isIntegralBasis`), and each of the remaining ones carries only finitely many places of `F' / k'` (`TauCeti.Place.finite_setOf_restrict_eq`), which gives `TauCeti.Place.finite_setOf_differentExponent_ne_zero`.

That local step mentions no function field, so it lives in a new ring-theory file, `TauCeti/RingTheory/DedekindDomain/Different.lean` (72 lines). It records `TauCeti.differentIdeal_eq_top_iff_traceDual_eq_one` — the different ideal of a Dedekind extension is the unit ideal exactly when `B` is its own trace dual, read off `FractionalIdeal.coeIdeal_differentIdeal` and the fact that inversion of nonzero fractional ideals is injective — and the basis form `TauCeti.differentIdeal_eq_top_of_span_eq_one` used above. Mathlib's `not_dvd_differentIdeal_iff` settles one prime at a time; these settle all of them at once. Neither statement is an instance of `Algebra.finite_compl_unramifiedLocus` (TauCeti, `RingTheory/DedekindDomain/RamificationLocus.lean`), which bounds the ramification locus of a *single* extension of Dedekind domains: here the extension `𝒪_P ⊆ 𝒪'_P` varies with the place, and each individual local model is semi-local, so its own ramification locus is finite for trivial reasons. No affine model of `F / k` is hypothesized anywhere, so nothing waits on Layer 2's finite normalization.

On top of that the PR defines `TauCeti.Divisor.different`, with the definitional coefficient formula `coeff_different`, effectivity `zero_le_different` and the degree bound `degree_different_nonneg` that Hurwitz's corollaries consume, and reads its support back as the ramification locus: `mem_support_different_iff`, `mem_support_different_of_one_lt_ramificationIdx` (the half of Stichtenoth's Corollary 3.5.5 that needs no residue-separability) and `different_eq_zero_iff`. The definition follows the conventions of `TauCeti.Divisor.conorm`: the upper field is explicit, the divisor is built from its coefficients through `Finsupp.ofSupportFinite`, and the function-field hypothesis is an explicit `Prop` argument.

One lemma is added to an existing file: `TauCeti.Place.isIntegralBasis_iff_span_eq`, the unfolding of `TauCeti.Place.IsIntegralBasis` (whose body is not exposed), placed next to the definition in `TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis/Basic.lean`. The new function-field file is `TauCeti/FieldTheory/FunctionField/Different/Divisor.lean` (242 lines), beside the exponent it consumes.

What remains on this milestone after this PR: the exact tame value `d(P' ∣ P) = e(P' ∣ P) − 1` under residue separability (Stichtenoth, Theorem 3.5.1(b)), the reconciliation `v_{P′}(differentIdeal R R′) = d(P′∣P)` with affine models, and then the cotrace of Weil differentials and the Hurwitz genus formula, which additionally wait on the canonical divisor.

No code is copied or adapted from any existing formalization, and in particular not from `vaca22/riemann-roch-function-fields`, which the roadmap's coordination section records as covering Stichtenoth's Chapter I. The mathematics follows H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer 2009, Definition 3.4.3, Remark 3.4.4 and Corollary 3.5.5. The central Mathlib declarations consumed are `Submodule.traceDual_span_of_basis`, `FractionalIdeal.dual`, `FractionalIdeal.coeIdeal_differentIdeal`, `differentIdeal` and `Subalgebra.restrictScalars_one`; no Mathlib PR material is vendored.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"different-divisor"}-->

🤖 Prepared with Claude Code
