### PR TITLE
refactor(CompletelyMonotone): name the two-sided bound of the mollified function

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Mollify.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Mollify.lean
@@ -34,6 +34,10 @@ monotone `g` with `f (t + ε) ≤ g t ≤ f t` on `[0, ∞)`.
 * `TauCeti.IsDifferenceCompletelyMonotone.exists_isCompletelyMonotone_between_shift`: a function
   that is completely monotone in the finite-difference sense is squeezed between the shift
   `f (· + ε)` and `f` by a completely monotone function, for every `ε > 0`.
+* `TauCeti.integral_kernel_mem_Icc_of_antitoneOn`: averaging a function against a probability
+  density supported in `(-ε, 0)` lands in `[F (t + ε), F t]`, whenever `F` is antitone on the
+  sampled interval. This is the order half of the argument and is independent of the difference
+  condition.
 
 ## References
 
@@ -110,30 +114,36 @@ private theorem isDifferenceCompletelyMonotone_integral_kernel {ψ : ℝ → ℝ
     exact mul_nonneg (hψ0 s) hsign
 
 /-- Averaging an antitone function against a probability density supported in `(-ε, 0)` samples it
-only on `(t, t + ε)`, so the average is squeezed between `F (t + ε)` and `F t`. -/
-private theorem integral_kernel_mem_Icc_of_antitone {ψ F : ℝ → ℝ} {ε t : ℝ} (hFanti : Antitone F)
-    (hψ0 : ∀ s, 0 ≤ ψ s) (hψint : ∫ s, ψ s = 1) (hψi : Integrable ψ volume)
-    (hintF : Integrable (fun s => ψ s * F (t - s)) volume)
+only on `(t, t + ε)`, so the average is squeezed between `F (t + ε)` and `F t`.
+
+Antitonicity is only asked for on `Icc t (t + ε)`, the interval the kernel actually samples. -/
+theorem integral_kernel_mem_Icc_of_antitoneOn {ψ F : ℝ → ℝ} {ε t : ℝ} (hε : 0 ≤ ε)
+    (hFanti : AntitoneOn F (Icc t (t + ε))) (hψ0 : ∀ s, 0 ≤ ψ s) (hψint : ∫ s, ψ s = 1)
+    (hψi : Integrable ψ volume) (hintF : Integrable (fun s => ψ s * F (t - s)) volume)
     (hsupp : ∀ s : ℝ, ψ s ≠ 0 → -ε < s ∧ s < 0) :
     (∫ s, ψ s * F (t - s)) ∈ Icc (F (t + ε)) (F t) := by
   have hmass : ∀ c : ℝ, ∫ s, ψ s * c = c := by
     intro c
     rw [integral_mul_const, hψint, one_mul]
+  have hsample : ∀ s : ℝ, -ε < s → s < 0 → t - s ∈ Icc t (t + ε) := fun s h1 h2 =>
+    ⟨by linarith, by linarith⟩
+  have hlo : t ∈ Icc t (t + ε) := ⟨le_rfl, by linarith⟩
+  have hhi : t + ε ∈ Icc t (t + ε) := ⟨by linarith, le_rfl⟩
   refine mem_Icc.mpr ⟨?_, ?_⟩
   · have hle : ∀ s : ℝ, ψ s * F (t + ε) ≤ ψ s * F (t - s) := by
       intro s
       rcases eq_or_ne (ψ s) 0 with h0 | h0
       · simp [h0]
-      · have hs1 := (hsupp s h0).1
-        exact mul_le_mul_of_nonneg_left (hFanti (by linarith)) (hψ0 s)
+      · obtain ⟨hs1, hs2⟩ := hsupp s h0
+        exact mul_le_mul_of_nonneg_left (hFanti (hsample s hs1 hs2) hhi (by linarith)) (hψ0 s)
     calc F (t + ε) = ∫ s, ψ s * F (t + ε) := (hmass _).symm
       _ ≤ ∫ s, ψ s * F (t - s) := integral_mono (hψi.mul_const _) hintF hle
   · have hle : ∀ s : ℝ, ψ s * F (t - s) ≤ ψ s * F t := by
       intro s
       rcases eq_or_ne (ψ s) 0 with h0 | h0
       · simp [h0]
-      · have hs2 := (hsupp s h0).2
-        exact mul_le_mul_of_nonneg_left (hFanti (by linarith)) (hψ0 s)
+      · obtain ⟨hs1, hs2⟩ := hsupp s h0
+        exact mul_le_mul_of_nonneg_left (hFanti hlo (hsample s hs1 hs2) (by linarith)) (hψ0 s)
     calc ∫ s, ψ s * F (t - s) ≤ ∫ s, ψ s * F t := integral_mono hintF (hψi.mul_const _) hle
       _ = F t := hmass _
 
@@ -184,6 +194,7 @@ theorem IsDifferenceCompletelyMonotone.exists_isCompletelyMonotone_between_shift
     have hintF : Integrable (fun s => ψ s * F (t - s)) volume :=
       hψc.convolutionExists_left (ContinuousLinearMap.mul ℝ ℝ) hψcont hFloc t
     rw [← hFeq _ (by linarith : (0 : ℝ) ≤ t + ε), ← hFeq t ht]
-    exact mem_Icc.mp (integral_kernel_mem_Icc_of_antitone hFanti hψ0 hψint hψi hintF hsupp)
+    exact mem_Icc.mp (integral_kernel_mem_Icc_of_antitoneOn hε.le (hFanti.antitoneOn _) hψ0
+      hψint hψi hintF hsupp)
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Mollify.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Mollify.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.Calculus.BumpFunction.FiniteDimension
 public import Mathlib.Analysis.Calculus.BumpFunction.Normed
 public import TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Basic
+import TauCeti.MeasureTheory.Integral.Bochner.Basic
 
 /-!
 # Smoothing a finite-difference completely monotone function
@@ -23,7 +24,8 @@ only ever evaluates `f` on `[t, t + ε]`, so on `[0, ∞)` it never leaves the h
 hypothesis lives. The average is `C^∞` because it is a convolution with a smooth compactly
 supported kernel, and every mixed forward difference of `g` is the same average of the
 corresponding difference of `f`, so the sign condition passes to `g` verbatim. Since `f` is
-nonincreasing, `g` is squeezed between `f (· + ε)` and `f`.
+nonincreasing, `g` is squeezed between `f (· + ε)` and `f`, by the general kernel-average bound
+`TauCeti.MeasureTheory.integral_kernel_mem_Icc_of_antitoneOn`.
 
 The outcome,
 `TauCeti.IsDifferenceCompletelyMonotone.exists_isCompletelyMonotone_between_shift`, is a completely
@@ -34,10 +36,6 @@ monotone `g` with `f (t + ε) ≤ g t ≤ f t` on `[0, ∞)`.
 * `TauCeti.IsDifferenceCompletelyMonotone.exists_isCompletelyMonotone_between_shift`: a function
   that is completely monotone in the finite-difference sense is squeezed between the shift
   `f (· + ε)` and `f` by a completely monotone function, for every `ε > 0`.
-* `TauCeti.integral_kernel_mem_Icc_of_antitoneOn`: averaging a function against a probability
-  density supported in `(-ε, 0)` lands in `[F (t + ε), F t]`, whenever `F` is antitone on the
-  sampled interval. This is the order half of the argument and is independent of the difference
-  condition.
 
 ## References
 
@@ -113,40 +111,6 @@ private theorem isDifferenceCompletelyMonotone_integral_kernel {ψ : ℝ → ℝ
     rw [key]
     exact mul_nonneg (hψ0 s) hsign
 
-/-- Averaging an antitone function against a probability density supported in `(-ε, 0)` samples it
-only on `(t, t + ε)`, so the average is squeezed between `F (t + ε)` and `F t`.
-
-Antitonicity is only asked for on `Icc t (t + ε)`, the interval the kernel actually samples. -/
-theorem integral_kernel_mem_Icc_of_antitoneOn {ψ F : ℝ → ℝ} {ε t : ℝ} (hε : 0 ≤ ε)
-    (hFanti : AntitoneOn F (Icc t (t + ε))) (hψ0 : ∀ s, 0 ≤ ψ s) (hψint : ∫ s, ψ s = 1)
-    (hψi : Integrable ψ volume) (hintF : Integrable (fun s => ψ s * F (t - s)) volume)
-    (hsupp : ∀ s : ℝ, ψ s ≠ 0 → -ε < s ∧ s < 0) :
-    (∫ s, ψ s * F (t - s)) ∈ Icc (F (t + ε)) (F t) := by
-  have hmass : ∀ c : ℝ, ∫ s, ψ s * c = c := by
-    intro c
-    rw [integral_mul_const, hψint, one_mul]
-  have hsample : ∀ s : ℝ, -ε < s → s < 0 → t - s ∈ Icc t (t + ε) := fun s h1 h2 =>
-    ⟨by linarith, by linarith⟩
-  have hlo : t ∈ Icc t (t + ε) := ⟨le_rfl, by linarith⟩
-  have hhi : t + ε ∈ Icc t (t + ε) := ⟨by linarith, le_rfl⟩
-  refine mem_Icc.mpr ⟨?_, ?_⟩
-  · have hle : ∀ s : ℝ, ψ s * F (t + ε) ≤ ψ s * F (t - s) := by
-      intro s
-      rcases eq_or_ne (ψ s) 0 with h0 | h0
-      · simp [h0]
-      · obtain ⟨hs1, hs2⟩ := hsupp s h0
-        exact mul_le_mul_of_nonneg_left (hFanti (hsample s hs1 hs2) hhi (by linarith)) (hψ0 s)
-    calc F (t + ε) = ∫ s, ψ s * F (t + ε) := (hmass _).symm
-      _ ≤ ∫ s, ψ s * F (t - s) := integral_mono (hψi.mul_const _) hintF hle
-  · have hle : ∀ s : ℝ, ψ s * F (t - s) ≤ ψ s * F t := by
-      intro s
-      rcases eq_or_ne (ψ s) 0 with h0 | h0
-      · simp [h0]
-      · obtain ⟨hs1, hs2⟩ := hsupp s h0
-        exact mul_le_mul_of_nonneg_left (hFanti hlo (hsample s hs1 hs2) (by linarith)) (hψ0 s)
-    calc ∫ s, ψ s * F (t - s) ≤ ∫ s, ψ s * F t := integral_mono hintF (hψi.mul_const _) hle
-      _ = F t := hmass _
-
 /-- **Smoothing a finite-difference completely monotone function.** If all mixed forward
 differences of `f` with nonnegative steps alternate in sign on `[0, ∞)`, then for every `ε > 0`
 there is a genuinely completely monotone `g` with
@@ -194,7 +158,7 @@ theorem IsDifferenceCompletelyMonotone.exists_isCompletelyMonotone_between_shift
     have hintF : Integrable (fun s => ψ s * F (t - s)) volume :=
       hψc.convolutionExists_left (ContinuousLinearMap.mul ℝ ℝ) hψcont hFloc t
     rw [← hFeq _ (by linarith : (0 : ℝ) ≤ t + ε), ← hFeq t ht]
-    exact mem_Icc.mp (integral_kernel_mem_Icc_of_antitoneOn hε.le (hFanti.antitoneOn _) hψ0
-      hψint hψi hintF hsupp)
+    exact mem_Icc.mp (MeasureTheory.integral_kernel_mem_Icc_of_antitoneOn hε.le
+      (hFanti.antitoneOn _) hψ0 hψint hψi hintF fun s hs => ⟨(hsupp s hs).1.le, (hsupp s hs).2.le⟩)
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Mollify.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Mollify.lean
@@ -109,6 +109,34 @@ private theorem isDifferenceCompletelyMonotone_integral_kernel {ψ : ℝ → ℝ
     rw [key]
     exact mul_nonneg (hψ0 s) hsign
 
+/-- Averaging an antitone function against a probability density supported in `(-ε, 0)` samples it
+only on `(t, t + ε)`, so the average is squeezed between `F (t + ε)` and `F t`. -/
+private theorem integral_kernel_mem_Icc_of_antitone {ψ F : ℝ → ℝ} {ε t : ℝ} (hFanti : Antitone F)
+    (hψ0 : ∀ s, 0 ≤ ψ s) (hψint : ∫ s, ψ s = 1) (hψi : Integrable ψ volume)
+    (hintF : Integrable (fun s => ψ s * F (t - s)) volume)
+    (hsupp : ∀ s : ℝ, ψ s ≠ 0 → -ε < s ∧ s < 0) :
+    (∫ s, ψ s * F (t - s)) ∈ Icc (F (t + ε)) (F t) := by
+  have hmass : ∀ c : ℝ, ∫ s, ψ s * c = c := by
+    intro c
+    rw [integral_mul_const, hψint, one_mul]
+  refine mem_Icc.mpr ⟨?_, ?_⟩
+  · have hle : ∀ s : ℝ, ψ s * F (t + ε) ≤ ψ s * F (t - s) := by
+      intro s
+      rcases eq_or_ne (ψ s) 0 with h0 | h0
+      · simp [h0]
+      · have hs1 := (hsupp s h0).1
+        exact mul_le_mul_of_nonneg_left (hFanti (by linarith)) (hψ0 s)
+    calc F (t + ε) = ∫ s, ψ s * F (t + ε) := (hmass _).symm
+      _ ≤ ∫ s, ψ s * F (t - s) := integral_mono (hψi.mul_const _) hintF hle
+  · have hle : ∀ s : ℝ, ψ s * F (t - s) ≤ ψ s * F t := by
+      intro s
+      rcases eq_or_ne (ψ s) 0 with h0 | h0
+      · simp [h0]
+      · have hs2 := (hsupp s h0).2
+        exact mul_le_mul_of_nonneg_left (hFanti (by linarith)) (hψ0 s)
+    calc ∫ s, ψ s * F (t - s) ≤ ∫ s, ψ s * F t := integral_mono hintF (hψi.mul_const _) hle
+      _ = F t := hmass _
+
 /-- **Smoothing a finite-difference completely monotone function.** If all mixed forward
 differences of `f` with nonnegative steps alternate in sign on `[0, ∞)`, then for every `ε > 0`
 there is a genuinely completely monotone `g` with
@@ -155,30 +183,7 @@ theorem IsDifferenceCompletelyMonotone.exists_isCompletelyMonotone_between_shift
   · -- The two-sided bound, from monotonicity of `F` and the normalization of `ψ`.
     have hintF : Integrable (fun s => ψ s * F (t - s)) volume :=
       hψc.convolutionExists_left (ContinuousLinearMap.mul ℝ ℝ) hψcont hFloc t
-    have hmass : ∀ c : ℝ, ∫ s, ψ s * c = c := by
-      intro c
-      rw [integral_mul_const, hψint, one_mul]
-    constructor
-    · have hle : ∀ s : ℝ, ψ s * F (t + ε) ≤ ψ s * F (t - s) := by
-        intro s
-        rcases eq_or_ne (ψ s) 0 with h0 | h0
-        · simp [h0]
-        · obtain ⟨hs1, hs2⟩ := hsupp s h0
-          exact mul_le_mul_of_nonneg_left
-            (hFcm.antitoneOn (mem_Ici.mpr (by linarith)) (mem_Ici.mpr (by linarith))
-              (by linarith)) (hψ0 s)
-      calc f (t + ε) = ∫ s, ψ s * F (t + ε) := by
-              rw [hmass, hFeq _ (by linarith)]
-        _ ≤ ∫ s, ψ s * F (t - s) := integral_mono (hψi.mul_const _) hintF hle
-    · have hle : ∀ s : ℝ, ψ s * F (t - s) ≤ ψ s * F t := by
-        intro s
-        rcases eq_or_ne (ψ s) 0 with h0 | h0
-        · simp [h0]
-        · obtain ⟨hs1, hs2⟩ := hsupp s h0
-          exact mul_le_mul_of_nonneg_left
-            (hFcm.antitoneOn (mem_Ici.mpr ht) (mem_Ici.mpr (by linarith)) (by linarith))
-            (hψ0 s)
-      calc ∫ s, ψ s * F (t - s) ≤ ∫ s, ψ s * F t := integral_mono hintF (hψi.mul_const _) hle
-        _ = f t := by rw [hmass, hFeq t ht]
+    rw [← hFeq _ (by linarith : (0 : ℝ) ≤ t + ε), ← hFeq t ht]
+    exact mem_Icc.mp (integral_kernel_mem_Icc_of_antitone hFanti hψ0 hψint hψi hintF hsupp)
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/TauCeti/MeasureTheory/Integral/Bochner/Basic.lean
@@ -35,6 +35,12 @@ in the seminorm form `eLpNorm (f i - g) 1 μ → 0` (for instance by
 
 The conversion is `MeasureTheory.ofReal_integral_norm_eq_lintegral_enorm`, whose home is
 `Mathlib.MeasureTheory.Integral.Bochner.Basic`, plus continuity of `ENNReal.ofReal` at `0`.
+
+## Kernel averages on the real line
+
+* `integral_kernel_mem_Icc_of_antitoneOn` squeezes the average of a function against a probability
+  density supported in `[-ε, 0]` between the function's values at `t + ε` and `t`, given only
+  antitonicity on the sampled interval `[t, t + ε]`.
 -/
 
 public section
@@ -108,6 +114,43 @@ theorem tendsto_eLpNorm_one_of_tendsto_integral_norm_sub {Ω E ι : Type*} [Meas
     simp [Pi.sub_apply]
   simp_rw [heq]
   simpa [Function.comp_def] using (ENNReal.continuous_ofReal.tendsto 0).comp h
+
+/-- **Averaging against a kernel supported in `[-ε, 0]` samples only `[t, t + ε]`.** If `ψ` is a
+nonnegative probability density with respect to `μ` vanishing outside `[-ε, 0]`, and `F` is antitone
+on `[t, t + ε]`, then the average `∫ s, ψ s * F (t - s) ∂μ` lies between `F (t + ε)` and `F t`.
+
+Use this to bound a mollification of a monotone function by two of its values; no regularity of
+`F` beyond antitonicity on the sampled interval is needed. -/
+theorem integral_kernel_mem_Icc_of_antitoneOn {μ : Measure ℝ} {ψ F : ℝ → ℝ} {ε t : ℝ}
+    (hε : 0 ≤ ε) (hFanti : AntitoneOn F (Set.Icc t (t + ε))) (hψ0 : ∀ s, 0 ≤ ψ s)
+    (hψint : ∫ s, ψ s ∂μ = 1) (hψi : Integrable ψ μ)
+    (hintF : Integrable (fun s => ψ s * F (t - s)) μ)
+    (hsupp : ∀ s : ℝ, ψ s ≠ 0 → s ∈ Set.Icc (-ε) 0) :
+    (∫ s, ψ s * F (t - s) ∂μ) ∈ Set.Icc (F (t + ε)) (F t) := by
+  have hmass : ∀ c : ℝ, ∫ s, ψ s * c ∂μ = c := by
+    intro c
+    rw [integral_mul_const, hψint, one_mul]
+  have hsample : ∀ s : ℝ, -ε ≤ s → s ≤ 0 → t - s ∈ Set.Icc t (t + ε) := fun s h1 h2 =>
+    ⟨by linarith, by linarith⟩
+  have hlo : t ∈ Set.Icc t (t + ε) := ⟨le_rfl, by linarith⟩
+  have hhi : t + ε ∈ Set.Icc t (t + ε) := ⟨by linarith, le_rfl⟩
+  refine Set.mem_Icc.mpr ⟨?_, ?_⟩
+  · have hle : ∀ s : ℝ, ψ s * F (t + ε) ≤ ψ s * F (t - s) := by
+      intro s
+      rcases eq_or_ne (ψ s) 0 with h0 | h0
+      · simp [h0]
+      · obtain ⟨hs1, hs2⟩ := hsupp s h0
+        exact mul_le_mul_of_nonneg_left (hFanti (hsample s hs1 hs2) hhi (by linarith)) (hψ0 s)
+    calc F (t + ε) = ∫ s, ψ s * F (t + ε) ∂μ := (hmass _).symm
+      _ ≤ ∫ s, ψ s * F (t - s) ∂μ := integral_mono (hψi.mul_const _) hintF hle
+  · have hle : ∀ s : ℝ, ψ s * F (t - s) ≤ ψ s * F t := by
+      intro s
+      rcases eq_or_ne (ψ s) 0 with h0 | h0
+      · simp [h0]
+      · obtain ⟨hs1, hs2⟩ := hsupp s h0
+        exact mul_le_mul_of_nonneg_left (hFanti hlo (hsample s hs1 hs2) (by linarith)) (hψ0 s)
+    calc ∫ s, ψ s * F (t - s) ∂μ ≤ ∫ s, ψ s * F t ∂μ := integral_mono hintF (hψi.mul_const _) hle
+      _ = F t := hmass _
 
 end MeasureTheory
 


### PR DESCRIPTION
Names the two-sided bound that
`IsDifferenceCompletelyMonotone.exists_isCompletelyMonotone_between_shift` was carrying inline,
and places it with the general Bochner-integral lemmas.

## What was there

The theorem builds the mollification `g u = ∫ s, ψ s * F (u - s)` and then proves two things about
it: that it is completely monotone (one short bullet, delegated to the file's existing
`isDifferenceCompletelyMonotone_integral_kernel`), and that it is squeezed between `f (· + ε)` and
`f`. The second bullet was **28 of the theorem's 60 body lines** — a single contiguous block, and
by some margin the largest thing in the file.

## What this does

That block says nothing about complete monotonicity, mollifiers, or bump functions. It says:

> if `F` is antitone on `[t, t + ε]` and `ψ` is a probability density vanishing outside `[-ε, 0]`,
> then averaging `F` against `ψ` only ever samples `F` on `[t, t + ε]`, so the average lands in
> `[F (t + ε), F t]`.

That becomes `TauCeti.MeasureTheory.integral_kernel_mem_Icc_of_antitoneOn` in
`TauCeti/MeasureTheory/Integral/Bochner/Basic.lean`, the module that already holds this
project's general-purpose Bochner-integral lemmas, and the 28-line bullet in `Mollify.lean`
collapses to five: build the integrability witness, transport along `hFeq` from `f` to `F`, and
apply the lemma. `Mollify.lean` gains one plain `import` of that module (proof-body use only, the
same idiom `Combinatorics/DenseGraphLimits/Kernel/L2.lean` uses for it); nothing new is
re-exported.

**Stating it abstractly also simplified it.** Inline, each of the two halves reached for
`hFcm.antitoneOn` and had to feed it two `mem_Ici` membership proofs plus the comparison — three
`by linarith` side conditions per half. The extracted statement takes its antitonicity hypothesis
on `Icc t (t + ε)` directly, so all four of the block's `mem_Ici.mpr` wrappers go (the file's
remaining two are elsewhere and untouched), replaced by three `Icc` memberships stated once each.
The helper needs neither `ht` nor `0 < ε`: it is not a statement about the half-line.

| | before | after |
|---|---|---|
| `exists_isCompletelyMonotone_between_shift` proof body | **60** | **38** |
| its largest contiguous block | **28** | **8** |
| its block-profile classification | `prime` | `assembly` |
| `integral_kernel_mem_Icc_of_antitoneOn` proof body | — | 24 (largest block 8, `assembly`) |
| `Mollify.lean` (non-blank lines) | 165 | 145 |
| `Integral/Bochner/Basic.lean` (non-blank lines) | 92 | 131 |

Measured with a block profiler on before/after copies of the file. On the "after" copy
`Mollify.lean` contains no `prime` proof at all: nothing left in it has a liftable dominant
block. No statement change to any pre-existing declaration; the three existing private helpers
are untouched.

## Round 2 review: both requests applied

**api-design — moved to `TauCeti/MeasureTheory/Integral/Bochner/Basic.lean` (applied).** Round 1
had kept the lemma in `Mollify.lean` because the destination suggested then did not exist. Round 2
named one that does — *"Move it to a general integral module such as
`TauCeti/MeasureTheory/Integral/Bochner/Basic.lean` (under the corresponding general namespace),
then import that module here"* — and that is done exactly: the lemma now lives under
`TauCeti.MeasureTheory` beside `sq_setIntegral_le_measureReal_mul_setIntegral_sq` and
`ofReal_integral_le_lintegral_ofReal`, with its own entry in that file's module docstring. Since
the proof never used anything specific to Lebesgue measure, the moved statement is over an
arbitrary `μ : Measure ℝ` like its new neighbours; the call site instantiates `μ := volume` by
unification and passes nothing extra. Round 1's `placement` approval was for the old location
and is superseded by this move; if `placement` now prefers the single-consumer location, that is
the finding `api-design` has requested twice in a row and I will contest whichever fires second
rather than move the lemma back and forth.

**generality — closed support `Icc (-ε) 0` (applied).** `hsupp` is now
`∀ s, ψ s ≠ 0 → s ∈ Icc (-ε) 0`; `hsample` takes the weak inequalities and the three `linarith`
calls are unchanged. The parent keeps its strict `-ε < s ∧ s < 0` (the sign lemma
`isDifferenceCompletelyMonotone_integral_kernel` genuinely needs `s < 0`) and weakens it inline at
the call site.

## Round 1 review: both requests applied

**generality — `AntitoneOn` instead of `Antitone` (applied).** The round-1 body posed exactly this
choice and offered to switch; the rubric weighed it the other way, so it is switched. The helper
takes `AntitoneOn F (Icc t (t + ε))` — the interval the kernel actually samples — plus `0 ≤ ε` to
place the endpoint `t + ε` in that interval, and the call site passes `hε.le` and
`hFanti.antitoneOn _`, both already in hand.

**api-design — no longer `private` (applied in round 1; relocation applied in round 2, above).**

**Why the name?** `integral_kernel` names the kernel average `∫ s, ψ s * F (t - s)` the statement is
about (the term `Mollify.lean` also uses for it in `fwdDiffList_integral_kernel` and
`isDifferenceCompletelyMonotone_integral_kernel`); `mem_Icc` is the conclusion and `of_antitoneOn`
the hypothesis carrying it, so the suffix tracks the hypothesis that actually appears.

Roadmap: OneParameterSemigroups
