### PR TITLE
refactor(CentralSimple): name the four-dimensional case of Frobenius' theorem

### DIFF
--- a/TauCeti/Algebra/CentralSimple/Real.lean
+++ b/TauCeti/Algebra/CentralSimple/Real.lean
@@ -63,6 +63,8 @@ needed; the rest is the elementary Frobenius argument.
 * `TauCeti.exists_mul_self_eq_neg_one_and_mul_eq_neg_mul`: a square root of `-1` that is not
   central has an anticommuting partner, again a square root of `-1`.
 * `TauCeti.Algebra.deg_le_two`: **a real central division algebra has degree at most `2`.**
+* `TauCeti.nonempty_algEquiv_quaternion_of_finrank_eq_four`: a four-dimensional real central
+  division algebra is `ℍ[ℝ]`.
 * `TauCeti.nonempty_algEquiv_real_or_quaternion`: **Frobenius' theorem**, a real central division
   algebra is `ℝ` or `ℍ[ℝ]`.
 
@@ -287,14 +289,55 @@ end Algebra
 
 /-! ### Frobenius' theorem -/
 
+/-- A four-dimensional central division algebra over `ℝ` is `ℝ`-isomorphic to the Hamilton
+quaternions `ℍ[ℝ]`.
+
+A square root `i` of `-1` exists, and centrality supplies an `x` not commuting with it, so
+`TauCeti.exists_mul_self_eq_neg_one_and_mul_eq_neg_mul` produces an anticommuting second square
+root. The pair is a quaternion basis, and the resulting map `ℍ[ℝ] →ₐ[ℝ] D` is bijective by a
+dimension count. -/
+theorem nonempty_algEquiv_quaternion_of_finrank_eq_four (D : Type*) [DivisionRing D] [Algebra ℝ D]
+    [Algebra.IsCentral ℝ D] [FiniteDimensional ℝ D] (h4 : finrank ℝ D = 4) :
+    Nonempty (D ≃ₐ[ℝ] ℍ[ℝ]) := by
+  obtain ⟨i, hi⟩ := exists_mul_self_eq_neg_one (D := D) (by omega)
+  -- `i` is not central, because `-1` is not a square in `ℝ`.
+  have hinotbot : i ∉ (⊥ : Subalgebra ℝ D) := by
+    intro hmem
+    obtain ⟨t, ht⟩ := Algebra.mem_bot.1 hmem
+    have ht2 : algebraMap ℝ D (t * t) = algebraMap ℝ D (-1) := by
+      rw [map_mul, ht, hi, map_neg, map_one]
+    nlinarith [mul_self_nonneg t, (algebraMap ℝ D).injective ht2]
+  obtain ⟨x, hx⟩ : ∃ x : D, x * i ≠ i * x := by
+    by_contra hc
+    refine hinotbot ?_
+    have hmem : i ∈ Subalgebra.center ℝ D := Subalgebra.mem_center_iff.2 fun c ↦ by
+      by_contra hcc
+      exact hc ⟨c, hcc⟩
+    rwa [Algebra.IsCentral.center_eq_bot] at hmem
+  -- The anticommuting partner, and the quaternion basis the pair forms.
+  obtain ⟨j, hj, hanti⟩ := exists_mul_self_eq_neg_one_and_mul_eq_neg_mul hi hx
+  have hanti' : j * i = -(i * j) := by rw [hanti]; abel
+  let q : QuaternionAlgebra.Basis D (-1 : ℝ) 0 (-1) :=
+    { i := i, j := j, k := i * j
+      i_mul_i := by rw [hi]; simp
+      j_mul_j := by rw [hj]; simp
+      i_mul_j := rfl
+      j_mul_i := by rw [hanti']; simp }
+  have f : ℍ[ℝ] →ₐ[ℝ] D := q.liftHom
+  have hinj : Function.Injective f := f.toRingHom.injective
+  have hfr : finrank ℝ ℍ[ℝ] = finrank ℝ D := by
+    rw [_root_.Quaternion.finrank_eq_four, h4]
+  have hsurj : Function.Surjective f :=
+    (LinearMap.injective_iff_surjective_of_finrank_eq_finrank
+      (f := f.toLinearMap) hfr).1 hinj
+  exact ⟨(AlgEquiv.ofBijective f ⟨hinj, hsurj⟩).symm⟩
+
 /-- **Frobenius' theorem.** A finite-dimensional division algebra over `ℝ` with centre `ℝ` is
 `ℝ`-isomorphic either to `ℝ` or to the Hamilton quaternions `ℍ[ℝ]`.
 
 The degree bound leaves `finrank ℝ D` equal to `1` or `4`. In the first case `D` is its own copy of
-`ℝ`. In the second, a square root `i` of `-1` exists and centrality supplies an `x` not commuting
-with it, so `TauCeti.exists_mul_self_eq_neg_one_and_mul_eq_neg_mul` produces an anticommuting
-second square root; the pair is a quaternion basis, and the resulting map `ℍ[ℝ] →ₐ[ℝ] D` is
-bijective by a dimension count. -/
+`ℝ`; in the second it is the quaternions, by
+`TauCeti.nonempty_algEquiv_quaternion_of_finrank_eq_four`. -/
 theorem nonempty_algEquiv_real_or_quaternion (D : Type*) [DivisionRing D] [Algebra ℝ D]
     [Algebra.IsCentral ℝ D] [FiniteDimensional ℝ D] :
     Nonempty (D ≃ₐ[ℝ] ℝ) ∨ Nonempty (D ≃ₐ[ℝ] ℍ[ℝ]) := by
@@ -311,41 +354,9 @@ theorem nonempty_algEquiv_real_or_quaternion (D : Type*) [DivisionRing D] [Algeb
     have hbot : (⊥ : Subalgebra ℝ D) = ⊤ := Subalgebra.bot_eq_top_iff_finrank_eq_one.2 h1
     exact ⟨Subalgebra.topEquiv.symm.trans
       ((Subalgebra.equivOfEq _ _ hbot.symm).trans (Algebra.botEquiv ℝ D))⟩
-  · -- `finrank ℝ D = 4`: build a quaternion basis.
+  · -- `finrank ℝ D = 4`: the quaternions.
     right
     rw [hd] at hsq
-    have h4 : finrank ℝ D = 4 := by omega
-    obtain ⟨i, hi⟩ := exists_mul_self_eq_neg_one (D := D) (by omega)
-    -- `i` is not central, because `-1` is not a square in `ℝ`.
-    have hinotbot : i ∉ (⊥ : Subalgebra ℝ D) := by
-      intro hmem
-      obtain ⟨t, ht⟩ := Algebra.mem_bot.1 hmem
-      have ht2 : algebraMap ℝ D (t * t) = algebraMap ℝ D (-1) := by
-        rw [map_mul, ht, hi, map_neg, map_one]
-      nlinarith [mul_self_nonneg t, (algebraMap ℝ D).injective ht2]
-    obtain ⟨x, hx⟩ : ∃ x : D, x * i ≠ i * x := by
-      by_contra hc
-      refine hinotbot ?_
-      have hmem : i ∈ Subalgebra.center ℝ D := Subalgebra.mem_center_iff.2 fun c ↦ by
-        by_contra hcc
-        exact hc ⟨c, hcc⟩
-      rwa [Algebra.IsCentral.center_eq_bot] at hmem
-    -- The anticommuting partner, and the quaternion basis the pair forms.
-    obtain ⟨j, hj, hanti⟩ := exists_mul_self_eq_neg_one_and_mul_eq_neg_mul hi hx
-    have hanti' : j * i = -(i * j) := by rw [hanti]; abel
-    let q : QuaternionAlgebra.Basis D (-1 : ℝ) 0 (-1) :=
-      { i := i, j := j, k := i * j
-        i_mul_i := by rw [hi]; simp
-        j_mul_j := by rw [hj]; simp
-        i_mul_j := rfl
-        j_mul_i := by rw [hanti']; simp }
-    have f : ℍ[ℝ] →ₐ[ℝ] D := q.liftHom
-    have hinj : Function.Injective f := f.toRingHom.injective
-    have hfr : finrank ℝ ℍ[ℝ] = finrank ℝ D := by
-      rw [_root_.Quaternion.finrank_eq_four, h4]
-    have hsurj : Function.Surjective f :=
-      (LinearMap.injective_iff_surjective_of_finrank_eq_finrank
-        (f := f.toLinearMap) hfr).1 hinj
-    exact ⟨(AlgEquiv.ofBijective f ⟨hinj, hsurj⟩).symm⟩
+    exact nonempty_algEquiv_quaternion_of_finrank_eq_four D (by omega)
 
 end TauCeti

--- a/TauCeti/Algebra/CentralSimple/Real.lean
+++ b/TauCeti/Algebra/CentralSimple/Real.lean
@@ -296,7 +296,7 @@ dimension over a field.
 This is the substantive half of Frobenius' theorem, and the form to reach for once the dimension is
 known: `TauCeti.nonempty_algEquiv_real_or_quaternion` re-derives the degree bound and hands back a
 disjunction that still has to be eliminated. The absence of zero divisors is what rules out the
-other central four-dimensional `ℝ`-algebra, `Matrix (Fin 2) (Fin 2) ℝ`. -/
+split central simple algebra `Matrix (Fin 2) (Fin 2) ℝ`. -/
 theorem nonempty_algEquiv_quaternion_of_finrank_eq_four (D : Type*) [Ring D] [IsDomain D]
     [Algebra ℝ D] [Algebra.IsCentral ℝ D] (h4 : finrank ℝ D = 4) :
     Nonempty (D ≃ₐ[ℝ] ℍ[ℝ]) := by

--- a/TauCeti/Algebra/CentralSimple/Real.lean
+++ b/TauCeti/Algebra/CentralSimple/Real.lean
@@ -289,16 +289,18 @@ end Algebra
 
 /-! ### Frobenius' theorem -/
 
-/-- A four-dimensional central division algebra over `ℝ` is `ℝ`-isomorphic to the Hamilton
-quaternions `ℍ[ℝ]`.
+/-- A four-dimensional central `ℝ`-algebra without zero divisors is `ℝ`-isomorphic to the Hamilton
+quaternions `ℍ[ℝ]`. Such an algebra is automatically a division algebra, being a domain of finite
+dimension over a field.
 
-A square root `i` of `-1` exists, and centrality supplies an `x` not commuting with it, so
-`TauCeti.exists_mul_self_eq_neg_one_and_mul_eq_neg_mul` produces an anticommuting second square
-root. The pair is a quaternion basis, and the resulting map `ℍ[ℝ] →ₐ[ℝ] D` is bijective by a
-dimension count. -/
-theorem nonempty_algEquiv_quaternion_of_finrank_eq_four (D : Type*) [DivisionRing D] [Algebra ℝ D]
-    [Algebra.IsCentral ℝ D] [FiniteDimensional ℝ D] (h4 : finrank ℝ D = 4) :
+This is the substantive half of Frobenius' theorem, and the form to reach for once the dimension is
+known: `TauCeti.nonempty_algEquiv_real_or_quaternion` re-derives the degree bound and hands back a
+disjunction that still has to be eliminated. The absence of zero divisors is what rules out the
+other central four-dimensional `ℝ`-algebra, `Matrix (Fin 2) (Fin 2) ℝ`. -/
+theorem nonempty_algEquiv_quaternion_of_finrank_eq_four (D : Type*) [Ring D] [IsDomain D]
+    [Algebra ℝ D] [Algebra.IsCentral ℝ D] (h4 : finrank ℝ D = 4) :
     Nonempty (D ≃ₐ[ℝ] ℍ[ℝ]) := by
+  have : FiniteDimensional ℝ D := .of_finrank_pos (by omega)
   obtain ⟨i, hi⟩ := exists_mul_self_eq_neg_one (D := D) (by omega)
   -- `i` is not central, because `-1` is not a square in `ℝ`.
   have hinotbot : i ∉ (⊥ : Subalgebra ℝ D) := by
@@ -335,9 +337,9 @@ theorem nonempty_algEquiv_quaternion_of_finrank_eq_four (D : Type*) [DivisionRin
 /-- **Frobenius' theorem.** A finite-dimensional division algebra over `ℝ` with centre `ℝ` is
 `ℝ`-isomorphic either to `ℝ` or to the Hamilton quaternions `ℍ[ℝ]`.
 
-The degree bound leaves `finrank ℝ D` equal to `1` or `4`. In the first case `D` is its own copy of
-`ℝ`; in the second it is the quaternions, by
-`TauCeti.nonempty_algEquiv_quaternion_of_finrank_eq_four`. -/
+This is the classification to use when nothing is known about `D` beyond the hypotheses. If
+`finrank ℝ D = 4` is already in hand, `TauCeti.nonempty_algEquiv_quaternion_of_finrank_eq_four`
+gives the quaternion isomorphism directly, with no disjunction to discharge. -/
 theorem nonempty_algEquiv_real_or_quaternion (D : Type*) [DivisionRing D] [Algebra ℝ D]
     [Algebra.IsCentral ℝ D] [FiniteDimensional ℝ D] :
     Nonempty (D ≃ₐ[ℝ] ℝ) ∨ Nonempty (D ≃ₐ[ℝ] ℍ[ℝ]) := by


### PR DESCRIPTION
`nonempty_algEquiv_real_or_quaternion` — Frobenius' theorem — splits into two `rcases` branches, and
the second one carried 36 of its 49 body lines. That branch proves a self-contained statement the
file never named: **a four-dimensional real central division algebra is `ℍ[ℝ]`**. This PR gives that
argument a name and calls it.

`TauCeti.nonempty_algEquiv_quaternion_of_finrank_eq_four` takes `finrank ℝ D = 4` and concludes
`Nonempty (D ≃ₐ[ℝ] ℍ[ℝ])`. Its proof is the former branch verbatim, less the three lines that select
the disjunct and derive `finrank ℝ D = 4` from the degree bound; those stay in the parent, which now
discharges its second case in a single `exact`.

No mathematics is added or changed. Every step, lemma and instance is the one that was already
there, and the hypothesis the branch derived is now the hypothesis the lemma takes.

Measured with `blockprof.py` over the before and after copies of the file:

|                                              | before     | after        |
| -------------------------------------------- | ---------- | ------------ |
| `nonempty_algEquiv_real_or_quaternion` body   | 49         | 17           |
| its largest top-level block                   | 36         | 7            |
| its verdict                                   | `prime`    | `assembly`   |
| proofs in the file classified `prime`         | 1          | 0            |

The new lemma's own body is 33 lines with a largest block of 7, so it too classifies `assembly`: a
sequence of small steps, not a monolith moved sideways. The parent's largest remaining block is the
`finrank ℝ D = 1` branch, at 7 lines.

The extraction follows the file's own idiom. `exists_mul_self_eq_neg_one`,
`exists_mul_self_eq_neg_one_and_mul_eq_neg_mul` and `Algebra.deg_le_two` are already named steps of
this same proof, each listed under "Main results"; the new lemma is added to that list in proof
order, and the parent's docstring now points at it instead of restating its argument.

The `finrank ℝ D = 1` branch is deliberately left inline: at 7 lines it is not a block worth naming,
and lifting it would relocate code rather than collapse a proof.

## Round 1 review: both requests applied

**generality — `[Ring D] [IsDomain D]`, and `FiniteDimensional` derived (applied).** The finding is
right, and the evidence is in the file itself: the `variable` line these helpers already live under
is `[Ring D] [IsDomain D] [Algebra ℝ D] [FiniteDimensional ℝ D]`. The extraction had opted *out* of
that into `[DivisionRing D]` — the lift inherited the parent's binders instead of the file's, which
is stronger than anything the proof uses. It now matches the file, and `[FiniteDimensional ℝ D]` is
dropped in favour of `have : FiniteDimensional ℝ D := .of_finrank_pos (by omega)`, since
`finrank ℝ D = 4` already carries it. Costs one line; the statement is strictly more general.

`nonempty_algEquiv_real_or_quaternion` keeps `[DivisionRing D]` — that is the classical statement of
Frobenius' theorem and is untouched by this PR; the call site still typechecks because a division
ring supplies both `Ring` and `IsDomain`.

**documentation — role and use instead of proof narration (applied).** Both docstrings are rewritten
to say what the result is for and when to use it, in place of the construction narration. Worth
noting where that narration came from: it was the *parent's* docstring on `main`, moved along with
the block it described. A verbatim lift inherits the original's documentation debt and it resurfaces
as a finding on the new declaration, which is exactly what happened here.

Roadmap: RepresentationTheory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7voLqau7CDz65nop56MoG

