### PR TITLE
feat: base change the E7 minuscule carrier

### DIFF
--- a/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
@@ -1,0 +1,366 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.Lie.E7.Minuscule.Carrier
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.GeneralLinearBaseChange
+
+/-!
+# Base change of the full-weight type-E7 minuscule carrier
+
+`TauCeti.E7Minuscule.groupScheme` is the explicit integral affine group scheme obtained by
+closing the fourteen numbered type-`E₇` root subgroups and the minuscule weight torus inside
+`GL₅₆`. This file specializes the base-change construction for a general Kostant toral closure
+to that pinned carrier.
+
+For every commutative ring `A`, `TauCeti.E7Minuscule.baseChangeDefiningIdeal` is an ideal in
+`O(GL₅₆/A)` whose quotient is canonically the scalar extension of the integral coordinate Hopf
+algebra. The transported numbered root-subgroup maps and weight-torus map factor through that
+quotient. Thus the integral carrier and its pinned generators base-change together; none of the
+data is chosen anew over `A`.
+
+The defining ideal transported from `ℤ` is contained in the common kernel of the transported
+generators. Equality is not asserted over an arbitrary, possibly non-flat, base: additional
+equations can appear after specialization. Nor does this file assert that the carrier is
+reductive, that its torus is maximal, or that its root datum has been identified.
+
+## Main declarations
+
+* `TauCeti.E7Minuscule.baseChangeDefiningIdeal`: the transported defining ideal in
+  `O(GL₅₆/A)`.
+* `TauCeti.E7Minuscule.baseChangeCoordinateIso`: its quotient is the scalar extension of the
+  integral carrier coordinate Hopf algebra.
+* `TauCeti.E7Minuscule.rootSubgroupToBaseChangeCoordinateMap`: the transported numbered root
+  subgroup factored through the specialized carrier.
+* `TauCeti.E7Minuscule.weightTorusToBaseChangeCoordinateMap`: the transported weight torus
+  factored through the specialized carrier.
+
+## Main results
+
+* `TauCeti.E7Minuscule.mkQuotient_comp_baseChangeCoordinateIso_hom`: the coordinate
+  isomorphism is compatible with the quotient presentations.
+* `TauCeti.E7Minuscule.baseChangeCoordinateIso_hom_comp_rootSubgroupBaseChangeMap` and
+  `TauCeti.E7Minuscule.baseChangeCoordinateIso_hom_comp_weightTorusBaseChangeMap`: the pinned
+  generators are the scalar extensions of their integral coordinate maps.
+* `TauCeti.E7Minuscule.hopfSpec_map_rootSubgroupIntegralCoordinateMap_op` and
+  `TauCeti.E7Minuscule.hopfSpec_map_weightTorusIntegralCoordinateMap_op`: the integral
+  coordinate maps represent the existing pinned morphisms.
+* `TauCeti.E7Minuscule.baseChangeDefiningIdeal_le_commonKernel`: the transported carrier
+  contains the subgroup generated after base change by the transported maps.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §4.4.
+* J. E. Humphreys, *Linear Algebraic Groups*, §§26--27.
+* B. Conrad, *Reductive Group Schemes*, §1.
+
+This advances the base-change target in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`.
+The resulting specialized pinned carrier is an input to milestone L0, “pinned ambient groups”,
+of `TauCetiRoadmap/CFSGStatement/README.md`.
+
+The declaration structure follows the type-`E₆` specialization in
+`TauCeti.Algebra.Lie.E6.Minuscule.BaseChange`. Every construction below uses the generic Kostant
+base-change API from
+`Kostant/RootSubgroup/Scheme/ToralClosure/GeneralLinearBaseChange.lean`; in particular, none of
+the coordinate-ring calculation is repeated here.
+-/
+
+public section
+
+open CategoryTheory
+open TauCeti.DynkinType
+open TauCeti.UniversalEnvelopingAlgebra
+open scoped Matrix TensorProduct
+
+namespace TauCeti.E7Minuscule
+
+universe v
+
+noncomputable section
+
+attribute [local instance] TauCeti.moduleNNRat
+attribute [local instance 100] LieRing.ofAssociativeRing
+attribute [local instance high] Algebra.toModule
+
+variable (A : Type v) [CommRing A]
+
+/-- The Hopf ideal in `O(GL₅₆/A)` obtained by transporting the defining ideal of the integral
+full-weight type-`E₇` minuscule carrier along `ℤ → A`. -/
+noncomputable def baseChangeDefiningIdeal :
+    HopfIdeal A (GeneralLinear.coordinateHopfAlgebra A 56) :=
+  kostantToralBaseChangePresentationIdeal
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A
+
+/-- Membership in the transported defining ideal is membership of the corresponding element in
+the base change of the named integral defining ideal. -/
+@[simp]
+theorem mem_baseChangeDefiningIdeal_iff
+    {x : GeneralLinear.coordinateHopfAlgebra A 56} :
+    x ∈ baseChangeDefiningIdeal A ↔
+      (GeneralLinear.coordinateHopfAlgebraBaseChangeIso ℤ A 56).inv.hom x ∈
+        CommHopfAlgCat.baseChangeHopfIdeal (K := A) definingIdeal := by
+  rw [baseChangeDefiningIdeal, mem_kostantToralBaseChangePresentationIdeal_iff,
+    kostantToralBaseChangeIdeal_def, ← definingIdeal_def]
+
+/-- Transporting a pure tensor of a scalar and an integral defining equation produces an equation
+in the transported defining ideal. -/
+theorem map_tmul_mem_baseChangeDefiningIdeal_of_mem (s : A)
+    {y : GeneralLinear.coordinateHopfAlgebra ℤ 56} (hy : y ∈ definingIdeal) :
+    (GeneralLinear.coordinateHopfAlgebraBaseChangeIso ℤ A 56).hom.hom
+        (s ⊗ₜ[ℤ] y) ∈ baseChangeDefiningIdeal A := by
+  rw [baseChangeDefiningIdeal]
+  exact map_tmul_mem_kostantToralBaseChangePresentationIdeal_of_mem
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A s (definingIdeal_def ▸ hy)
+
+/-- The coordinate Hopf algebra cut out over `A` by the transported type-`E₇` defining ideal is
+canonically the scalar extension of the integral coordinate Hopf algebra. -/
+noncomputable def baseChangeCoordinateIso :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra A 56)
+        (baseChangeDefiningIdeal A) ≅
+      CommHopfAlgCat.baseChange (K := A)
+        (CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal) :=
+  kostantToralBaseChangePresentationIsoOfEq
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A definingIdeal_def
+
+/-- The base-change coordinate isomorphism is compatible with the quotient presentation inside
+`GL₅₆`. -/
+@[simp]
+theorem mkQuotient_comp_baseChangeCoordinateIso_hom :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra A 56)
+          (baseChangeDefiningIdeal A) ≫
+        (baseChangeCoordinateIso A).hom =
+      (GeneralLinear.coordinateHopfAlgebraBaseChangeIso ℤ A 56).inv ≫
+        CommHopfAlgCat.baseChangeMap
+          (CommHopfAlgCat.mkQuotient
+            (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal) := by
+  rw [baseChangeCoordinateIso]
+  exact mkQuotient_comp_kostantToralBaseChangePresentationIsoOfEq_hom
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A definingIdeal_def
+
+/-! ## The transported root subgroups -/
+
+/-- The integral `k`th root-subgroup coordinate map, with source expressed using the named
+type-`E₇` defining ideal. -/
+noncomputable def rootSubgroupIntegralCoordinateMap (k : Fin 7 ⊕ Fin 7) :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal ⟶
+      AdditiveGroup.coordinateHopfAlgebra ℤ :=
+  kostantRootSubgroupToralCoordinateMapOfEq
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight definingIdeal_def k
+
+/-- The integral factored root-subgroup map recovers the represented `k`th root-subgroup
+coordinate map inside `GL₅₆`. -/
+@[simp]
+theorem mkQuotient_comp_rootSubgroupIntegralCoordinateMap (k : Fin 7 ⊕ Fin 7) :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal ≫
+        rootSubgroupIntegralCoordinateMap k =
+      kostantRootSubgroupCoordinateMap
+        (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+        (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+        rep_kostantForm_mem_lattice k (isNilpotent_rep_serreRootGenerator k) latticeBasis := by
+  rw [rootSubgroupIntegralCoordinateMap]
+  exact mkQuotient_comp_kostantRootSubgroupToralCoordinateMapOfEq
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight definingIdeal_def k
+
+/-- The integral factored root-subgroup coordinate map represents the carrier's `k`th numbered
+root subgroup. -/
+theorem hopfSpec_map_rootSubgroupIntegralCoordinateMap_op (k : Fin 7 ⊕ Fin 7) :
+    (AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).map
+        (rootSubgroupIntegralCoordinateMap k).op =
+      eqToHom (AdditiveGroup.groupScheme_def ℤ).symm ≫
+        rootSubgroup k ≫ eqToHom groupScheme_def := by
+  rw [rootSubgroupIntegralCoordinateMap, rootSubgroup_def]
+  exact hopfSpec_map_kostantRootSubgroupToralCoordinateMapOfEq_op
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight definingIdeal_def k
+
+/-- The base-changed `k`th root-subgroup coordinate map factored through the transported
+type-`E₇` carrier. -/
+noncomputable def rootSubgroupToBaseChangeCoordinateMap (k : Fin 7 ⊕ Fin 7) :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra A 56)
+        (baseChangeDefiningIdeal A) ⟶ AdditiveGroup.coordinateHopfAlgebra A :=
+  kostantRootSubgroupToralBaseChangePresentationCoordinateMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A k
+
+/-- The factored root-subgroup map recovers its ambient transported coordinate map. -/
+@[simp]
+theorem mkQuotient_comp_rootSubgroupToBaseChangeCoordinateMap (k : Fin 7 ⊕ Fin 7) :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra A 56)
+          (baseChangeDefiningIdeal A) ≫
+        rootSubgroupToBaseChangeCoordinateMap A k =
+      kostantRootSubgroupBaseChangePresentationCoordinateMap
+        (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+        (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+        rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis A k := by
+  unfold baseChangeDefiningIdeal rootSubgroupToBaseChangeCoordinateMap
+  exact mkQuotient_comp_kostantRootSubgroupToralBaseChangePresentationCoordinateMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A k
+
+/-- Under the base-change coordinate isomorphism, the factored `k`th root-subgroup map is the
+scalar extension of its integral coordinate map. -/
+@[simp]
+theorem baseChangeCoordinateIso_hom_comp_rootSubgroupBaseChangeMap (k : Fin 7 ⊕ Fin 7) :
+    (baseChangeCoordinateIso A).hom ≫
+          CommHopfAlgCat.baseChangeMap (rootSubgroupIntegralCoordinateMap k) ≫
+        (_root_.CommHopfAlgCat.ofHom
+          (AdditiveGroup.gaScalarTensorBialgEquiv (k := ℤ) (K := A))) =
+      rootSubgroupToBaseChangeCoordinateMap A k := by
+  rw [baseChangeCoordinateIso, rootSubgroupIntegralCoordinateMap,
+    rootSubgroupToBaseChangeCoordinateMap]
+  exact kostantToralBaseChangePresentationIsoOfEq_hom_comp_rootSubgroupBaseChangeMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A definingIdeal_def k
+
+/-! ## The transported weight torus -/
+
+/-- The integral weight-torus coordinate map, with source expressed using the named type-`E₇`
+defining ideal. -/
+noncomputable def weightTorusIntegralCoordinateMap :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal ⟶
+      (DiagonalizableGroup.coordinateRing ℤ
+        (SplitTorus.characterGroup (Fin 7))).obj :=
+  kostantWeightTorusToralCoordinateMapOfEq
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight definingIdeal_def
+
+/-- The integral factored weight-torus map recovers the represented weight-torus coordinate map
+inside `GL₅₆`. -/
+@[simp]
+theorem mkQuotient_comp_weightTorusIntegralCoordinateMap :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal ≫
+        weightTorusIntegralCoordinateMap =
+      GeneralLinear.weightTorusCoordinateMap e7MinusculeWeight := by
+  rw [weightTorusIntegralCoordinateMap]
+  exact mkQuotient_comp_kostantWeightTorusToralCoordinateMapOfEq
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight definingIdeal_def
+
+/-- The integral factored weight-torus coordinate map represents the carrier's weight torus. -/
+theorem hopfSpec_map_weightTorusIntegralCoordinateMap_op :
+    (AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).map
+        weightTorusIntegralCoordinateMap.op =
+      eqToHom (DiagonalizableGroup.groupScheme_def ℤ
+          (SplitTorus.characterGroup (Fin 7))).symm ≫
+        weightTorus ≫ eqToHom groupScheme_def := by
+  rw [weightTorusIntegralCoordinateMap, weightTorus_def]
+  exact hopfSpec_map_kostantWeightTorusToralCoordinateMapOfEq_op
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight definingIdeal_def
+
+/-- The base-changed weight-torus coordinate map factored through the transported type-`E₇`
+carrier. -/
+noncomputable def weightTorusToBaseChangeCoordinateMap :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra A 56)
+        (baseChangeDefiningIdeal A) ⟶
+      (DiagonalizableGroup.coordinateRing A
+        (SplitTorus.characterGroup (Fin 7))).obj :=
+  kostantWeightTorusToralBaseChangePresentationCoordinateMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A
+
+/-- The factored weight-torus map recovers its ambient transported coordinate map. -/
+@[simp]
+theorem mkQuotient_comp_weightTorusToBaseChangeCoordinateMap :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra A 56)
+          (baseChangeDefiningIdeal A) ≫
+        weightTorusToBaseChangeCoordinateMap A =
+      GeneralLinear.weightTorusBaseChangeCoordinateMap ℤ A e7MinusculeWeight := by
+  unfold baseChangeDefiningIdeal weightTorusToBaseChangeCoordinateMap
+  exact mkQuotient_comp_kostantWeightTorusToralBaseChangePresentationCoordinateMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A
+
+/-- Under the base-change coordinate isomorphism, the factored weight-torus map is the scalar
+extension of its integral coordinate map. -/
+@[simp]
+theorem baseChangeCoordinateIso_hom_comp_weightTorusBaseChangeMap :
+    (baseChangeCoordinateIso A).hom ≫
+          CommHopfAlgCat.baseChangeMap weightTorusIntegralCoordinateMap ≫
+        (_root_.CommHopfAlgCat.ofHom
+          (BialgHomClass.toBialgHom
+            (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv ℤ A
+              (G := SplitTorus.characterGroup (Fin 7))))) =
+      weightTorusToBaseChangeCoordinateMap A := by
+  rw [baseChangeCoordinateIso, weightTorusIntegralCoordinateMap,
+    weightTorusToBaseChangeCoordinateMap]
+  exact kostantToralBaseChangePresentationIsoOfEq_hom_comp_weightTorusBaseChangeMap
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A definingIdeal_def
+
+/-- The closed subgroup of `GL₅₆/A` generated by the transported numbered root subgroups and
+weight torus lies in the base change of the integral type-`E₇` carrier.
+
+The reverse inclusion is not asserted over an arbitrary base ring. -/
+theorem baseChangeDefiningIdeal_le_commonKernel :
+    let K : Sum (Fin 7 ⊕ Fin 7) Unit → CommHopfAlgCat A
+      | .inl _ => AdditiveGroup.coordinateHopfAlgebra A
+      | .inr _ =>
+          (DiagonalizableGroup.coordinateRing A
+            (SplitTorus.characterGroup (Fin 7))).obj
+    baseChangeDefiningIdeal A ≤
+      CommHopfAlgCat.commonKernelHopfIdeal (K := K)
+        (fun j => match j with
+          | .inl k => kostantRootSubgroupBaseChangePresentationCoordinateMap
+              (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+              (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+              rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis A k
+          | .inr _ =>
+              GeneralLinear.weightTorusBaseChangeCoordinateMap ℤ A e7MinusculeWeight) := by
+  have h := kostantToralBaseChangePresentationIdeal_le_commonKernelHopfIdeal
+    (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+    (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+    rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+    e7MinusculeWeight A
+  -- The generic containment indexes its generators by a `match` of its own, and neither that
+  -- matcher nor `commonKernelHopfIdeal` is exposed, so compare the two families branchwise.
+  dsimp only at h ⊢
+  rw [CommHopfAlgCat.le_commonKernelHopfIdeal_iff] at h ⊢
+  rintro (k | _)
+  · exact h (.inl k)
+  · exact h (.inr ())
+
+end
+
+end TauCeti.E7Minuscule

--- a/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
@@ -56,16 +56,6 @@ reductive, that its torus is maximal, or that its root datum has been identified
 * R. W. Carter, *Simple Groups of Lie Type*, §4.4.
 * J. E. Humphreys, *Linear Algebraic Groups*, §§26--27.
 * B. Conrad, *Reductive Group Schemes*, §1.
-
-This advances the base-change target in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`.
-The resulting specialized pinned carrier is an input to milestone L0, “pinned ambient groups”,
-of `TauCetiRoadmap/CFSGStatement/README.md`.
-
-The declaration structure follows the type-`E₆` specialization in
-`TauCeti.Algebra.Lie.E6.Minuscule.BaseChange`. Every construction below uses the generic Kostant
-base-change API from
-`Kostant/RootSubgroup/Scheme/ToralClosure/GeneralLinearBaseChange.lean`; in particular, none of
-the coordinate-ring calculation is repeated here.
 -/
 
 public section

--- a/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
@@ -56,6 +56,7 @@ reductive, that its torus is maximal, or that its root datum has been identified
 * R. W. Carter, *Simple Groups of Lie Type*, §4.4.
 * J. E. Humphreys, *Linear Algebraic Groups*, §§26--27.
 * B. Conrad, *Reductive Group Schemes*, §1.
+* This formalization is adapted from `TauCeti.Algebra.Lie.E6.Minuscule.BaseChange`.
 -/
 
 public section

--- a/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
@@ -14,13 +14,13 @@ public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Schem
 `TauCeti.E7Minuscule.groupScheme` is the explicit integral affine group scheme obtained by
 closing the fourteen numbered type-`E₇` root subgroups and the minuscule weight torus inside
 `GL₅₆`. This file specializes the base-change construction for a general Kostant toral closure
-to that pinned carrier.
+to that toral-closure carrier.
 
 For every commutative ring `A`, `TauCeti.E7Minuscule.baseChangeDefiningIdeal` is an ideal in
 `O(GL₅₆/A)` whose quotient is canonically the scalar extension of the integral coordinate Hopf
 algebra. The transported numbered root-subgroup maps and weight-torus map factor through that
-quotient. Thus the integral carrier and its pinned generators base-change together; none of the
-data is chosen anew over `A`.
+quotient. Thus the integral carrier and its numbered root-subgroup and weight-torus maps base-change
+together; none of the data is chosen anew over `A`.
 
 The defining ideal transported from `ℤ` is contained in the common kernel of the transported
 generators. Equality is not asserted over an arbitrary, possibly non-flat, base: additional
@@ -43,11 +43,11 @@ reductive, that its torus is maximal, or that its root datum has been identified
 * `TauCeti.E7Minuscule.mkQuotient_comp_baseChangeCoordinateIso_hom`: the coordinate
   isomorphism is compatible with the quotient presentations.
 * `TauCeti.E7Minuscule.baseChangeCoordinateIso_hom_comp_rootSubgroupBaseChangeMap` and
-  `TauCeti.E7Minuscule.baseChangeCoordinateIso_hom_comp_weightTorusBaseChangeMap`: the pinned
-  generators are the scalar extensions of their integral coordinate maps.
+  `TauCeti.E7Minuscule.baseChangeCoordinateIso_hom_comp_weightTorusBaseChangeMap`: the numbered
+  root-subgroup and weight-torus maps are the scalar extensions of their integral coordinate maps.
 * `TauCeti.E7Minuscule.hopfSpec_map_rootSubgroupIntegralCoordinateMap_op` and
   `TauCeti.E7Minuscule.hopfSpec_map_weightTorusIntegralCoordinateMap_op`: the integral
-  coordinate maps represent the existing pinned morphisms.
+  coordinate maps represent the existing numbered root-subgroup and weight-torus morphisms.
 * `TauCeti.E7Minuscule.baseChangeDefiningIdeal_le_commonKernel`: the transported carrier
   contains the subgroup generated after base change by the transported maps.
 


### PR DESCRIPTION
This PR specializes the generic Kostant toral-closure base-change construction to the explicit full-weight type-`E₇` minuscule carrier. For every commutative ring `A`, define the transported Hopf ideal in `O(GL₅₆/A)`, identify its quotient with scalar extension of the integral carrier coordinate algebra, and factor the fourteen numbered root-subgroup maps and rank-seven weight-torus map through that quotient. Record the quotient-presentation equations, compatibility of both families with their integral coordinate maps, their scheme-theoretic interpretation, and containment of the subgroup generated after specialization in the transported carrier.

The exact roadmap target is Layer 9, “Base change along `ℤ → k` for any commutative ring `k`, and the compatibility of the pinning with it,” within the “pinned Chevalley–Demazure group schemes over `ℤ`” milestone of `ReductiveGroups/README.md`. The integral `E₇` carrier, its numbered root subgroups, closed weight torus, and functorial points are already on `main`; the in-flight `E₇` work concerns Frobenius and root-character identification, so this is the missing distinct bridge that carries the existing integral equations to arbitrary bases.

The dependency edge is: CFSGStatement milestone L0, “pinned ambient groups,” needs the `E₇(q)` branch of `ValidLieTypeIndex.AmbientGroup` to arise from an explicit pinned simply connected group over the algebraic closure; that construction consumes the ReductiveGroups Layer 9 integral carrier together with precisely this base-change coordinate algebra and the transported root-subgroup and torus maps. After this PR, the type-`E₇` Layer 9 path still needs all-root generation, a compatible Borel and full pinning, reductivity and maximal-torus proofs, and final identification as the pinned simply connected ambient group.

Add `TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean` (366 lines). The implementation reuses the generic Kostant base-change API from `TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.GeneralLinearBaseChange` and follows the established type-`E₆` specialization in `TauCeti.Algebra.Lie.E6.Minuscule.BaseChange`; no Mathlib or external formalization is vendored. The mathematical organization follows Carter, *Simple Groups of Lie Type*, §4.4; Humphreys, *Linear Algebraic Groups*, §§26–27; and Conrad, *Reductive Group Schemes*, §1, as cited in the module documentation.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e7-minuscule-base-change"}-->

🤖 Prepared with Codex
