### PR TITLE
refactor: give quadratic form APIs dot notation

### DIFF
--- a/TauCeti/Analysis/Calculus/Morse/Index.lean
+++ b/TauCeti/Analysis/Calculus/Morse/Index.lean
@@ -23,7 +23,7 @@ The Hessian quadratic form used here is
 
 Some statements of the Morse lemma put a factor `2⁻¹` in front of this form.  That positive factor
 does not change its negative index, by
-`TauCeti.QuadraticForm.sigNeg_smul_of_pos`.  In particular the convention agrees with the normal
+`QuadraticForm.sigNeg_smul_of_pos`.  In particular the convention agrees with the normal
 form in `TauCeti.Analysis.Calculus.Morse.NormalForm`.
 
 The definition is made at every point, not only at a critical point, since the index of the
@@ -167,7 +167,7 @@ index is zero. -/
 theorem IsNondegenerateCriticalPoint.hessianQuadraticForm_posDef_iff_morseIndex_eq_zero
     [FiniteDimensional ℝ E] (h : IsNondegenerateCriticalPoint f x) :
     (hessianQuadraticForm f x).PosDef ↔ morseIndex f x = 0 := by
-  rw [TauCeti.QuadraticForm.posDef_iff_sigNeg_eq_zero_and_radical_eq_bot,
+  rw [QuadraticForm.posDef_iff_sigNeg_eq_zero_and_radical_eq_bot,
     h.hessianQuadraticForm_nondegenerate.radical_eq_bot, morseIndex_def]
   simp only [eq_self, and_true]
 
@@ -176,7 +176,7 @@ index is the dimension of the ambient space. -/
 theorem IsNondegenerateCriticalPoint.neg_hessianQuadraticForm_posDef_iff_morseIndex_eq_finrank
     [FiniteDimensional ℝ E] (h : IsNondegenerateCriticalPoint f x) :
     (-hessianQuadraticForm f x).PosDef ↔ morseIndex f x = Module.finrank ℝ E := by
-  rw [TauCeti.QuadraticForm.posDef_iff_sigNeg_eq_zero_and_radical_eq_bot,
+  rw [QuadraticForm.posDef_iff_sigNeg_eq_zero_and_radical_eq_bot,
     QuadraticMap.radical_neg, h.hessianQuadraticForm_nondegenerate.radical_eq_bot, sigNeg_neg]
   simp only [eq_self, and_true]
   have hsum := h.sigPos_hessianQuadraticForm_add_morseIndex_eq_finrank

--- a/TauCeti/LinearAlgebra/BilinearForm/PosSemidef.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/PosSemidef.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.BilinearForm.Properties
+
+/-!
+# Positive-semidefinite bilinear forms
+
+This file records a pointwise characterization of positive semidefiniteness for symmetric
+bilinear forms.
+
+## Main results
+
+* `LinearMap.BilinForm.isPosSemidef_iff_forall_nonneg`: a symmetric bilinear form is
+  positive-semidefinite exactly when its diagonal values are nonnegative.
+-/
+
+public section
+
+namespace LinearMap.BilinForm
+
+variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M] [LE R]
+
+/-- A symmetric bilinear form is positive-semidefinite if and only if its values on all vectors
+are nonnegative. -/
+@[grind =]
+theorem isPosSemidef_iff_forall_nonneg (B : LinearMap.BilinForm R M) (hB : B.IsSymm) :
+    B.IsPosSemidef ↔ ∀ x, 0 ≤ B x x := by
+  rw [LinearMap.BilinForm.isPosSemidef_def, LinearMap.BilinForm.isNonneg_def]
+  simp only [hB, true_and]
+
+end LinearMap.BilinForm

--- a/TauCeti/LinearAlgebra/BilinearForm/PosSemidef.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/PosSemidef.lean
@@ -11,7 +11,8 @@ public import Mathlib.LinearAlgebra.BilinearForm.Properties
 # Positive-semidefinite bilinear forms
 
 This file records a pointwise characterization of positive semidefiniteness for symmetric
-bilinear forms.
+bilinear forms. It converts `IsPosSemidef` into diagonal nonnegativity, the form consumed by
+quadratic-form signature criteria and other pointwise positivity arguments.
 
 ## Main results
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -361,7 +361,7 @@ theorem sigPos_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
   let _ := L.finiteDimensional
   let _ := M.finiteDimensional
   rw [sigPos, orthogonalSum_form, orthogonalSumForm_toQuadraticMap,
-    TauCeti.QuadraticForm.sigPos_prod]
+    QuadraticForm.sigPos_prod]
 
 /-- The negative index of an orthogonal sum is the sum of the negative indices. -/
 @[simp]
@@ -370,7 +370,7 @@ theorem sigNeg_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
   let _ := L.finiteDimensional
   let _ := M.finiteDimensional
   rw [sigNeg, orthogonalSum_form, orthogonalSumForm_toQuadraticMap,
-    TauCeti.QuadraticForm.sigNeg_prod]
+    QuadraticForm.sigNeg_prod]
 
 /-- The null index of an orthogonal sum is the sum of the null indices. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/RadicalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RadicalQuotient.lean
@@ -225,7 +225,7 @@ theorem sigPos_radicalQuotient : L.radicalQuotient.sigPos = L.sigPos := by
   dsimp only [sigPos]
   rw [radicalQuotient_form, radicalQuotientForm,
     QuadraticMap.toQuadraticMap_associated ℚ]
-  exact TauCeti.QuadraticForm.sigPos_lift_of_eq_radical L.form.toQuadraticMap L.radical
+  exact QuadraticForm.sigPos_lift_of_eq_radical L.form.toQuadraticMap L.radical
     L.radical_toQuadraticMap.symm
 
 /-- The negative index is unchanged after quotienting by the radical. -/
@@ -235,7 +235,7 @@ theorem sigNeg_radicalQuotient : L.radicalQuotient.sigNeg = L.sigNeg := by
   dsimp only [sigNeg]
   rw [radicalQuotient_form, radicalQuotientForm,
     QuadraticMap.toQuadraticMap_associated ℚ]
-  exact TauCeti.QuadraticForm.sigNeg_lift_of_eq_radical L.form.toQuadraticMap L.radical
+  exact QuadraticForm.sigNeg_lift_of_eq_radical L.form.toQuadraticMap L.radical
     L.radical_toQuadraticMap.symm
 
 /-- The radical quotient has the same positive and negative indices as the original lattice and

--- a/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
@@ -27,25 +27,25 @@ Finally, both indices are additive under orthogonal products.
 
 ## Main results
 
-* `TauCeti.QuadraticForm.forall_nonneg_iff_sigNeg_eq_zero`: nonnegativity is characterized by
+* `QuadraticForm.forall_nonneg_iff_sigNeg_eq_zero`: nonnegativity is characterized by
   vanishing negative index of inertia.
-* `TauCeti.QuadraticForm.forall_nonpos_iff_sigPos_eq_zero`: nonpositivity is characterized by
+* `QuadraticForm.forall_nonpos_iff_sigPos_eq_zero`: nonpositivity is characterized by
   vanishing positive index of inertia.
-* `TauCeti.QuadraticForm.sigPos_restrict_le`: restriction to a subspace cannot increase the
+* `QuadraticForm.sigPos_restrict_le`: restriction to a subspace cannot increase the
   positive index of inertia.
-* `TauCeti.QuadraticForm.sigNeg_restrict_le`: restriction to a subspace cannot increase the
+* `QuadraticForm.sigNeg_restrict_le`: restriction to a subspace cannot increase the
   negative index of inertia.
-* `TauCeti.QuadraticForm.sigPos_smul_of_pos` and
-  `TauCeti.QuadraticForm.sigNeg_smul_of_pos`: positive scaling preserves both indices.
-* `TauCeti.QuadraticForm.sigPos_smul_of_neg` and
-  `TauCeti.QuadraticForm.sigNeg_smul_of_neg`: negative scaling exchanges the two indices.
-* `TauCeti.QuadraticForm.sigPos_lift_radical`: quotienting by the radical preserves the positive
+* `QuadraticForm.sigPos_smul_of_pos` and `QuadraticForm.sigNeg_smul_of_pos`: positive scaling
+  preserves both indices.
+* `QuadraticForm.sigPos_smul_of_neg` and `QuadraticForm.sigNeg_smul_of_neg`: negative scaling
+  exchanges the two indices.
+* `QuadraticForm.sigPos_lift_radical`: quotienting by the radical preserves the positive
   index of inertia.
-* `TauCeti.QuadraticForm.sigNeg_lift_radical`: quotienting by the radical preserves the negative
+* `QuadraticForm.sigNeg_lift_radical`: quotienting by the radical preserves the negative
   index of inertia.
-* `TauCeti.QuadraticForm.sigPos_prod` and `TauCeti.QuadraticForm.sigNeg_prod`: the indices of
+* `QuadraticForm.sigPos_prod` and `QuadraticForm.sigNeg_prod`: the indices of
   inertia are additive under orthogonal products.
-* `TauCeti.QuadraticForm.posDef_iff_sigNeg_eq_zero_and_radical_eq_bot`: positive-definiteness
+* `QuadraticForm.posDef_iff_sigNeg_eq_zero_and_radical_eq_bot`: positive-definiteness
   is characterized by vanishing negative index and trivial radical.
 
 ## References
@@ -57,11 +57,7 @@ public section
 
 open Finset QuadraticMap
 
-namespace TauCeti
-
 namespace QuadraticForm
-
-open _root_.QuadraticForm
 
 variable {K M : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
   [AddCommGroup M] [Module K M] [FiniteDimensional K M]
@@ -256,8 +252,6 @@ end QuadraticForm
 
 namespace QuadraticForm
 
-open _root_.QuadraticForm
-
 variable {K M : Type*} [Field K] [AddCommGroup M] [Module K M]
 
 /-- An arbitrarily chosen complement to the radical, used only to compare inertia indices. -/
@@ -438,5 +432,3 @@ theorem posDef_toQuadraticMap_iff_finrank_ker_eq_zero_and_sigNeg_eq_zero
     Submodule.finrank_eq_zero, and_comm]
 
 end LinearMap.BilinForm
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
@@ -5,10 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.BilinearForm.Properties
 public import Mathlib.LinearAlgebra.Matrix.BilinearForm
 import Mathlib.LinearAlgebra.Projection
 public import Mathlib.LinearAlgebra.QuadraticForm.Signature
+public import TauCeti.LinearAlgebra.BilinearForm.PosSemidef
 public import TauCeti.LinearAlgebra.QuadraticForm.Radical
 public import TauCeti.LinearAlgebra.Submodule.Prod
 
@@ -381,20 +381,6 @@ end QuadraticForm
 namespace LinearMap.BilinForm
 
 open _root_.QuadraticForm
-
-section Semiring
-
-variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M] [LE R]
-
-/-- A symmetric bilinear form is positive-semidefinite if and only if its values on all vectors
-are nonnegative. -/
-@[grind =]
-theorem isPosSemidef_iff_forall_nonneg (B : LinearMap.BilinForm R M) (hB : B.IsSymm) :
-    B.IsPosSemidef ↔ ∀ x, 0 ≤ B x x := by
-  rw [LinearMap.BilinForm.isPosSemidef_def, LinearMap.BilinForm.isNonneg_def]
-  simp only [hB, true_and]
-
-end Semiring
 
 variable {K M : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
   [AddCommGroup M] [Module K M] [FiniteDimensional K M]


### PR DESCRIPTION
This PR moves the declarations extending Mathlib's `QuadraticForm` and `LinearMap.BilinForm` out of the recreated `TauCeti` wrapper in `QuadraticForm/Signature.lean`, then updates all in-repository references. The 26 target names were checked against the pinned Mathlib environment with no collisions.

This is another namespace-migration slice of #3547. Locally verified with the full `lake build` (10,306 jobs), builds of all four changed modules after rebasing, and the dot-notation lint (`1148` to `1122` findings, zero new violations). No compatibility aliases are retained. The now-stale lint-baseline entries are intentionally left for a later human-owned baseline-pruning change.

Roadmap: none

:robot: Prepared with OpenAI Codex
