### PR TITLE
feat: prove the pinned Dynkin Lie algebra is Killing

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/LieAlgebra/Killing.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/LieAlgebra/Killing.lean
@@ -5,8 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Lie.CartanCriterion
-public import Mathlib.LinearAlgebra.RootSystem.GeckConstruction.Semisimple
+import Mathlib.Algebra.Lie.CartanCriterion
+import Mathlib.LinearAlgebra.RootSystem.GeckConstruction.Semisimple
 public import TauCeti.Algebra.Lie.Killing.BaseChange
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.LieAlgebra.BaseChange
 
@@ -64,8 +64,8 @@ instance instIsKillingLieAlgebra : IsKilling ℚ (t.lieAlgebra ht) := by
   have hradical : HasTrivialRadical K (t.lieAlgebraBaseChange ht K) := by
     rw [lieAlgebraBaseChange_def]
     infer_instance
-  have hbase : IsKilling K (t.lieAlgebraBaseChange ht K) :=
-    (hasTrivialRadical_iff_isKilling K (t.lieAlgebraBaseChange ht K)).1 hradical
+  let _ : HasTrivialRadical K (t.lieAlgebraBaseChange ht K) := hradical
+  have hbase : IsKilling K (t.lieAlgebraBaseChange ht K) := inferInstance
   let _ : IsKilling K (t.lieAlgebraBaseChange ht K) := hbase
   have hscalar : IsKilling K (K ⊗[ℚ] t.lieAlgebra ht) := e.symm.isKilling
   let _ : IsKilling K (K ⊗[ℚ] t.lieAlgebra ht) := hscalar

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/LieAlgebra/Killing.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/LieAlgebra/Killing.lean
@@ -5,8 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-import Mathlib.Algebra.Lie.CartanCriterion
-import Mathlib.LinearAlgebra.RootSystem.GeckConstruction.Semisimple
 public import TauCeti.Algebra.Lie.Killing.BaseChange
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.LieAlgebra.BaseChange
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/LieAlgebra/Killing.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/LieAlgebra/Killing.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.CartanCriterion
+public import Mathlib.LinearAlgebra.RootSystem.GeckConstruction.Semisimple
+public import TauCeti.Algebra.Lie.Killing.BaseChange
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.LieAlgebra.BaseChange
+
+/-!
+# The Killing form of the pinned Dynkin-type Lie algebra
+
+For a valid Dynkin type `t`, `TauCeti.DynkinType.lieAlgebra t ht` is the explicit rational
+matrix Lie algebra obtained by applying Geck's construction to
+`TauCeti.DynkinType.simplyConnectedRootDatum t ht`. This file proves that its Killing form is
+nondegenerate.
+
+Mathlib proves that Geck's Lie algebra has trivial solvable radical over an algebraically closed
+field, hence has nondegenerate Killing form in characteristic zero. The rational carrier itself
+does not satisfy the algebraic-closure hypothesis. We therefore extend scalars to
+`AlgebraicClosure ℚ`, identify that scalar extension with Geck's construction over the extended
+root system via `TauCeti.DynkinType.lieAlgebraBaseChangeEquiv`, and descend nondegeneracy along
+`ℚ → AlgebraicClosure ℚ` using `TauCeti.isKilling_of_isKilling_baseChange`.
+
+The result is installed as an instance because the root-space and Chevalley-system APIs take
+`LieAlgebra.IsKilling` as a typeclass assumption. The final instance transports it to
+`TauCeti.DynkinType.lieAlgebraBaseChange t ht K` over every integral domain carrying a rational
+algebra structure; algebraic closedness is needed only once, in the descent argument over `ℚ`.
+
+## Main declarations
+
+* `TauCeti.DynkinType.instIsKillingLieAlgebra`: the rational pinned Dynkin-type Lie algebra has
+  nondegenerate Killing form.
+* `TauCeti.DynkinType.instIsKillingLieAlgebraBaseChange`: its explicit Geck realization after
+  extension to any rational integral domain also has nondegenerate Killing form.
+
+## References
+
+* M. Geck, *On the construction of semisimple Lie algebras and Chevalley groups*,
+  Proc. Amer. Math. Soc. **145** (2017), 3233--3247, Lemma 4.3.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §5.1.
+
+-/
+
+public section
+
+namespace TauCeti.DynkinType
+
+open LieAlgebra
+open scoped TensorProduct
+
+noncomputable section
+
+variable (t : DynkinType) (ht : t.Valid)
+
+/-- **The pinned rational Lie algebra of a valid Dynkin type has nondegenerate Killing form.** -/
+instance instIsKillingLieAlgebra : IsKilling ℚ (t.lieAlgebra ht) := by
+  let K := AlgebraicClosure ℚ
+  let e : (K ⊗[ℚ] t.lieAlgebra ht) ≃ₗ⁅K⁆ t.lieAlgebraBaseChange ht K :=
+    t.lieAlgebraBaseChangeEquiv ht K
+  have hradical : HasTrivialRadical K (t.lieAlgebraBaseChange ht K) := by
+    rw [lieAlgebraBaseChange_def]
+    infer_instance
+  have hbase : IsKilling K (t.lieAlgebraBaseChange ht K) :=
+    (hasTrivialRadical_iff_isKilling K (t.lieAlgebraBaseChange ht K)).1 hradical
+  let _ : IsKilling K (t.lieAlgebraBaseChange ht K) := hbase
+  have hscalar : IsKilling K (K ⊗[ℚ] t.lieAlgebra ht) := e.symm.isKilling
+  let _ : IsKilling K (K ⊗[ℚ] t.lieAlgebra ht) := hscalar
+  exact TauCeti.isKilling_of_isKilling_baseChange ℚ K (t.lieAlgebra ht)
+
+/-- **Every characteristic-zero scalar extension of the pinned Dynkin-type Lie algebra has
+nondegenerate Killing form.** This is stated for the explicit Geck realization over `K`, rather
+than for the tensor product, using `TauCeti.DynkinType.lieAlgebraBaseChangeEquiv`. -/
+instance instIsKillingLieAlgebraBaseChange (K : Type*) [CommRing K] [IsDomain K] [Algebra ℚ K] :
+    IsKilling K (t.lieAlgebraBaseChange ht K) := by
+  let e : (K ⊗[ℚ] t.lieAlgebra ht) ≃ₗ⁅K⁆ t.lieAlgebraBaseChange ht K :=
+    t.lieAlgebraBaseChangeEquiv ht K
+  have hscalar : IsKilling K (K ⊗[ℚ] t.lieAlgebra ht) :=
+    (TauCeti.isKilling_baseChange_iff ℚ K (t.lieAlgebra ht)).2
+      (instIsKillingLieAlgebra t ht)
+  let _ : IsKilling K (K ⊗[ℚ] t.lieAlgebra ht) := hscalar
+  exact e.isKilling
+
+end
+
+end TauCeti.DynkinType


### PR DESCRIPTION
This PR proves that the explicit pinned rational Lie algebra `DynkinType.lieAlgebra t ht` of every valid Dynkin type has nondegenerate Killing form, and installs the same property for its explicit Geck realization after extension to any rational integral domain. Extend scalars to `AlgebraicClosure ℚ`, transport Mathlib's trivial-radical result for Geck's construction through `DynkinType.lieAlgebraBaseChangeEquiv`, use Cartan's criterion in characteristic zero, and descend the Killing form along `ℚ → AlgebraicClosure ℚ`.

The exact roadmap target is ReductiveGroups Layer 9, “The Chevalley–Demazure construction,” specifically the requirement to construct the split group scheme from a Chevalley basis and the Kostant `ℤ`-form. This closes the Killing-form prerequisite explicitly left between `Algebra/Lie/Killing/BaseChange.lean` and `SimplyConnectedRootDatum/LieAlgebra/BaseChange.lean`: the former names `DynkinType.lieAlgebra` as its consumer and the latter supplies the scalar-extension identification its module documentation calls the remaining half. It is the most effective current step because it turns the already-merged algebraic-closure and descent infrastructure into the typeclass instance required by `IsChevalleySystem`, rather than adding another carrier-specific wrapper.

The dependency edge is CFSGStatement milestone L0, “pinned ambient groups,” ← ReductiveGroups Layer 9's explicit pinned Chevalley–Demazure group schemes ← the normalized all-root Chevalley system and Kostant integral form on `DynkinType.lieAlgebra` ← `DynkinType.instIsKillingLieAlgebra` supplied here. This serves every Lie-type carrier branch, including the E₇ path whose simple-root characters are now on `main` and whose base-change and Frobenius interfaces are in flight.

After this PR, Layer 9 still needs the normalized all-root Chevalley system on this pinned Lie algebra, comparison of its all-root Kostant form with the current simple-generator carrier forms, and the resulting reductivity, Borel, maximal-torus, and simply-connected identifications.

Add `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/LieAlgebra/Killing.lean` (89 lines). The proof consumes Mathlib's `RootPairing.GeckConstruction.instHasTrivialRadical` and Cartan criterion, together with Tau Ceti's `DynkinType.lieAlgebraBaseChangeEquiv`, `isKilling_of_isKilling_baseChange`, and `isKilling_baseChange_iff`; no Mathlib code or external formalization is vendored. The mathematical argument follows M. Geck, *On the construction of semisimple Lie algebras and Chevalley groups*, Lemma 4.3, and J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §5.1, as cited in the module documentation.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"dynkin-lie-algebra-killing"}-->

🤖 Prepared with Codex
