### PR TITLE
refactor: give linear isometry APIs dot notation

### DIFF
--- a/TauCeti/Geometry/Diffeomorphism/Sphere.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Sphere.lean
@@ -34,40 +34,38 @@ inclusion `O(4) → Diff(S³)` is stateable" is `TauCeti.orthogonalToDiffSphere 
 
 ## Main definitions
 
-* `TauCeti.LinearIsometryEquiv.unitSphereEquiv`: the self-equivalence of the unit sphere
+* `LinearIsometryEquiv.unitSphereEquiv`: the self-equivalence of the unit sphere
   obtained by restricting a linear isometry equivalence.
-* `TauCeti.LinearIsometryEquiv.unitSphereDiffeomorph`: that restriction as a `C^m`
+* `LinearIsometryEquiv.unitSphereDiffeomorph`: that restriction as a `C^m`
   diffeomorphism of the unit sphere, viewed as a manifold modelled on `𝓡 n`.
-* `TauCeti.LinearIsometryEquiv.unitSphereDiffHom`: the group homomorphism
+* `LinearIsometryEquiv.unitSphereDiffHom`: the group homomorphism
   `(E ≃ₗᵢ[ℝ] E) →* Diff (𝓡 n) (sphere (0 : E) 1) m`.
 * `TauCeti.orthogonalToDiffSphere`: the reference inclusion `O(n + 1) → Diff(Sⁿ)`, the case
   `E = EuclideanSpace ℝ (Fin (n + 1))` of `unitSphereDiffHom`.
 
 ## Main results
 
-* `TauCeti.LinearIsometryEquiv.contMDiff_unitSphereEquiv`: the restriction to the unit sphere is
+* `LinearIsometryEquiv.contMDiff_unitSphereEquiv`: the restriction to the unit sphere is
   `C^m` for every smoothness exponent.
-* `TauCeti.LinearIsometryEquiv.isometry_unitSphereEquiv`: it is an isometry for the distance the
+* `LinearIsometryEquiv.isometry_unitSphereEquiv`: it is an isometry for the distance the
   sphere inherits from `E`, so the action is by isometries of the round sphere.
-* `TauCeti.LinearIsometryEquiv.unitSphereDiffeomorph_neg_apply`: the diffeomorphism induced by
+* `LinearIsometryEquiv.unitSphereDiffeomorph_neg_apply`: the diffeomorphism induced by
   `-1 ∈ O(n + 1)` is the antipodal map.
 * `TauCeti.LinearMap.eq_of_eqOn_unitSphere`: a linear map is
   determined by its values on the unit sphere, whence
-  `TauCeti.LinearIsometryEquiv.unitSphereDiffHom_injective` and
+  `LinearIsometryEquiv.unitSphereDiffHom_injective` and
   `TauCeti.orthogonalToDiffSphere_injective`: the inclusion is injective, so `O(n + 1)` is
   realised as a subgroup of `Diff(Sⁿ)`.
 
 ## Implementation notes
 
-The declarations below and the generic unit-sphere API in
-`TauCeti.Geometry.Sphere.LinearIsometry` live in `TauCeti.LinearIsometryEquiv`, mirroring the
-Mathlib namespace of the objects they are about, so they are applied in prefix form
-(`unitSphereEquiv e`) rather than by dot notation.
+The declarations extending `LinearIsometryEquiv` here and in
+`TauCeti.Geometry.Sphere.LinearIsometry` live in Mathlib's root namespace, allowing receiver
+notation. The reference inclusion remains project-owned top-level API in `TauCeti`; the auxiliary
+linear-map lemma remains in `TauCeti.LinearMap` as explained in the generic file.
 -/
 
 public section
-
-namespace TauCeti
 
 open Metric Module
 open scoped Manifold ContDiff
@@ -129,7 +127,8 @@ theorem unitSphereDiffeomorph_neg_apply (x : sphere (0 : E) 1) :
 /-- The inclusion of the linear isometry group of `E` into the group of self-diffeomorphisms of
 its unit sphere. For `E = EuclideanSpace ℝ (Fin (n + 1))` this is the reference inclusion
 `O(n + 1) → Diff(Sⁿ)`; see `TauCeti.orthogonalToDiffSphere`. -/
-def unitSphereDiffHom (m : ℕ∞ω) : (E ≃ₗᵢ[ℝ] E) →* Diff (𝓡 n) (sphere (0 : E) 1) m where
+def unitSphereDiffHom (m : ℕ∞ω) :
+    (E ≃ₗᵢ[ℝ] E) →* TauCeti.Diff (𝓡 n) (sphere (0 : E) 1) m where
   toFun e := unitSphereDiffeomorph e m
   map_one' := _root_.Diffeomorph.ext fun x => by
     apply Subtype.ext
@@ -151,12 +150,14 @@ theorem unitSphereDiffHom_injective :
   rw [unitSphereDiffHom_apply, unitSphereDiffHom_apply] at h
   apply _root_.LinearIsometryEquiv.toLinearEquiv_injective
   apply LinearEquiv.toLinearMap_injective
-  refine LinearMap.eq_of_eqOn_unitSphere fun x hx => ?_
+  refine TauCeti.LinearMap.eq_of_eqOn_unitSphere fun x hx => ?_
   simpa using congrArg Subtype.val (DFunLike.congr_fun h ⟨x, hx⟩)
 
 end InnerProduct
 
 end LinearIsometryEquiv
+
+namespace TauCeti
 
 open scoped EuclideanSpace
 

--- a/TauCeti/Geometry/Diffeomorphism/Sphere.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Sphere.lean
@@ -60,9 +60,10 @@ inclusion `O(4) → Diff(S³)` is stateable" is `TauCeti.orthogonalToDiffSphere 
 ## Implementation notes
 
 The declarations extending `LinearIsometryEquiv` here and in
-`TauCeti.Geometry.Sphere.LinearIsometry` live in Mathlib's root namespace, allowing receiver
-notation. The reference inclusion remains project-owned top-level API in `TauCeti`; the auxiliary
-linear-map lemma remains in `TauCeti.LinearMap` as explained in the generic file.
+`TauCeti.Geometry.Sphere.LinearIsometry` live in the root-level `LinearIsometryEquiv` namespace,
+allowing receiver notation. The reference inclusion remains project-owned top-level API in
+`TauCeti`; the auxiliary linear-map lemma remains in `TauCeti.LinearMap` as explained in the
+generic file.
 -/
 
 public section

--- a/TauCeti/Geometry/Sphere/LinearIsometry.lean
+++ b/TauCeti/Geometry/Sphere/LinearIsometry.lean
@@ -30,9 +30,9 @@ This file develops that restriction independently of the manifold structure on s
 
 ## Implementation notes
 
-The declarations extending `LinearIsometryEquiv` live in Mathlib's root namespace so receiver
-notation elaborates. The separate linear-map lemma remains in `TauCeti.LinearMap`: it is not part
-of this namespace migration and has no explicit `LinearMap` receiver for dot notation.
+The declarations extending `LinearIsometryEquiv` live in the root-level `LinearIsometryEquiv`
+namespace, so receiver notation elaborates. The separate linear-map lemma remains in
+`TauCeti.LinearMap`; it has no explicit `LinearMap` receiver for dot notation.
 -/
 
 public section

--- a/TauCeti/Geometry/Sphere/LinearIsometry.lean
+++ b/TauCeti/Geometry/Sphere/LinearIsometry.lean
@@ -17,21 +17,25 @@ This file develops that restriction independently of the manifold structure on s
 
 ## Main definitions
 
-* `TauCeti.LinearIsometryEquiv.unitSphereEquiv`: the equivalence of unit spheres obtained by
+* `LinearIsometryEquiv.unitSphereEquiv`: the equivalence of unit spheres obtained by
   restricting a linear isometry equivalence.
-* `TauCeti.LinearIsometryEquiv.unitSphereIsometryEquiv`: the isometry equivalence of unit spheres
+* `LinearIsometryEquiv.unitSphereIsometryEquiv`: the isometry equivalence of unit spheres
   obtained by restricting a linear isometry equivalence.
 
 ## Main results
 
-* `TauCeti.LinearIsometryEquiv.isometry_unitSphereEquiv`: the restriction is an isometry.
+* `LinearIsometryEquiv.isometry_unitSphereEquiv`: the restriction is an isometry.
 * `TauCeti.LinearMap.eq_of_eqOn_unitSphere`: a real linear map is determined by its
   values on the unit sphere.
+
+## Implementation notes
+
+The declarations extending `LinearIsometryEquiv` live in Mathlib's root namespace so receiver
+notation elaborates. The separate linear-map lemma remains in `TauCeti.LinearMap`: it is not part
+of this namespace migration and has no explicit `LinearMap` receiver for dot notation.
 -/
 
 public section
-
-namespace TauCeti
 
 open Metric Module
 
@@ -108,6 +112,8 @@ theorem unitSphereIsometryEquiv_trans (e : E ≃ₗᵢ[R] F) (e' : F ≃ₗᵢ[R
 end Seminormed
 
 end LinearIsometryEquiv
+
+namespace TauCeti
 
 namespace LinearMap
 


### PR DESCRIPTION
This PR moves the unit-sphere API from the recreated `TauCeti.LinearIsometryEquiv` namespace into Mathlib's canonical `LinearIsometryEquiv` namespace. It preserves the project-owned `TauCeti.LinearMap`, `TauCeti.Diff`, and orthogonal-to-diffeomorphism declarations explicitly, moves shared `open` commands to file scope, and retains no compatibility aliases. All 21 moved target names were checked against pinned Mathlib with no collisions.

This is another namespace-migration slice of #3547. Locally verified by building both defining modules and the direct sphere importer, running the full dot-notation lint (`1148` to `1132` findings, zero new violations), and directly elaborating receiver notation for the equivalence, isometry, and diffeomorphism APIs. The 16 now-stale lint-baseline entries remain for a later human-owned baseline-pruning change.

Roadmap: GeometricTopology

:robot: Prepared with OpenAI Codex
