### PR TITLE
Move finite PMF marginal lemmas into the PMF API

### DIFF
--- a/TauCeti/MeasureTheory/OptimalTransport/Finite/Gluing.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Finite/Gluing.lean
@@ -73,7 +73,7 @@ private theorem middleMass_eq_zero_iff (π : PMF (α × β)) (b : β) [Finite α
     π.map Prod.snd b = 0 ↔ ∀ a, π (a, b) = 0 := by
   classical
   let _ := Fintype.ofFinite α
-  rw [TauCeti.PMF.map_snd_apply]
+  rw [π.map_snd_apply_fintype]
   simp
 
 omit instFintypeα instFintypeβ instFintypeγ in
@@ -81,7 +81,7 @@ private theorem map_fst_eq_zero_iff (σ : PMF (β × γ)) (b : β) [Finite γ] :
     σ.map Prod.fst b = 0 ↔ ∀ c, σ (b, c) = 0 := by
   classical
   let _ := Fintype.ofFinite γ
-  rw [TauCeti.PMF.map_fst_apply]
+  rw [σ.map_fst_apply_fintype]
   simp
 
 private theorem finiteGluingWeight_sum (π : PMF (α × β)) (σ : PMF (β × γ))
@@ -109,9 +109,9 @@ private theorem finiteGluingWeight_sum (π : PMF (α × β)) (σ : PMF (β × γ
                   simp only [div_eq_mul_inv, Finset.sum_mul]
         _ = π.map Prod.snd b := by
           have hσ : ∑ c, σ (b, c) = π.map Prod.snd b := by
-            rw [← TauCeti.PMF.map_fst_apply σ b, ← hmid b]
+            rw [← σ.map_fst_apply_fintype b, ← hmid b]
           rw [hσ]
-          rw [← TauCeti.PMF.map_snd_apply π b]
+          rw [← π.map_snd_apply_fintype b]
           apply ENNReal.mul_div_cancel_right hb
           exact (π.map Prod.snd).apply_ne_top b
   calc
@@ -225,7 +225,7 @@ theorem map_prodMap_id_fst_finiteGluing (h : π.map Prod.snd = σ.map Prod.fst) 
                 π.map Prod.snd p.2 := by
                   simp only [div_eq_mul_inv, Finset.sum_mul, Finset.mul_sum]
           _ = π p := by
-            rw [← TauCeti.PMF.map_fst_apply σ p.2, ← hmid]
+            rw [← σ.map_fst_apply_fintype p.2, ← hmid]
             apply ENNReal.mul_div_cancel_right hb
             exact (π.map Prod.snd).apply_ne_top p.2
 
@@ -268,7 +268,7 @@ theorem map_snd_finiteGluing (h : π.map Prod.snd = σ.map Prod.fst) :
                 π.map Prod.snd p.1 := by
                   simp only [div_eq_mul_inv, Finset.sum_mul]
           _ = σ p := by
-            rw [← TauCeti.PMF.map_snd_apply π p.1, mul_comm]
+            rw [← π.map_snd_apply_fintype p.1, mul_comm]
             apply ENNReal.mul_div_cancel_right hb
             exact (π.map Prod.snd).apply_ne_top p.1
 

--- a/TauCeti/MeasureTheory/OptimalTransport/Finite/TransportMatrix.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Finite/TransportMatrix.lean
@@ -170,51 +170,6 @@ end TransportMatrix
 
 end Matrix
 
-namespace PMF
-
-section Fst
-
-variable [Fintype κ] (π : PMF (ι × κ))
-
-/-- The first marginal of a finite product PMF is obtained by summing each row of its matrix of
-point masses. -/
-theorem map_fst_apply (i : ι) : π.map Prod.fst i = ∑ j, π (i, j) := by
-  classical
-  rw [PMF.map_apply, ENNReal.tsum_prod']
-  rw [tsum_eq_single i]
-  · simp
-  · intro i' hi
-    simp [hi.symm]
-
-/-- A product PMF has first marginal `μ` exactly when its row sums are `μ`. -/
-theorem map_fst_eq_iff (μ : PMF ι) :
-    π.map Prod.fst = μ ↔ ∀ i, ∑ j, π (i, j) = μ i := by
-  rw [PMF.ext_iff]
-  simp only [map_fst_apply]
-
-end Fst
-
-section Snd
-
-variable [Fintype ι] (π : PMF (ι × κ))
-
-/-- The second marginal of a finite product PMF is obtained by summing each column of its matrix
-of point masses. -/
-theorem map_snd_apply (j : κ) : π.map Prod.snd j = ∑ i, π (i, j) := by
-  classical
-  rw [PMF.map_apply, ENNReal.tsum_prod']
-  simp
-
-/-- A product PMF has second marginal `ν` exactly when its column sums are `ν`. -/
-theorem map_snd_eq_iff (ν : PMF κ) :
-    π.map Prod.snd = ν ↔ ∀ j, ∑ i, π (i, j) = ν j := by
-  rw [PMF.ext_iff]
-  simp only [map_snd_apply]
-
-end Snd
-
-end PMF
-
 namespace TransportMatrix
 
 variable [Fintype ι] [Fintype κ]
@@ -223,20 +178,20 @@ variable {μ : PMF ι} {ν : PMF κ}
 /-- The PMF associated to a transportation matrix has the prescribed first marginal. -/
 @[simp]
 theorem map_fst_toPMF (A : TransportMatrix μ ν) : A.toPMF.map Prod.fst = μ :=
-  (TauCeti.PMF.map_fst_eq_iff A.toPMF μ).2 A.row_sum
+  (A.toPMF.map_fst_eq_iff_fintype μ).2 A.row_sum
 
 /-- The PMF associated to a transportation matrix has the prescribed second marginal. -/
 @[simp]
 theorem map_snd_toPMF (A : TransportMatrix μ ν) : A.toPMF.map Prod.snd = ν :=
-  (TauCeti.PMF.map_snd_eq_iff A.toPMF ν).2 A.col_sum
+  (A.toPMF.map_snd_eq_iff_fintype ν).2 A.col_sum
 
 /-- The transportation matrix obtained by recording the point masses of a finite product PMF
 with prescribed marginals. -/
 def ofPMF (π : PMF (ι × κ)) (hμ : π.map Prod.fst = μ) (hν : π.map Prod.snd = ν) :
     TransportMatrix μ ν where
   matrix i j := π (i, j)
-  row_sum := (TauCeti.PMF.map_fst_eq_iff π μ).1 hμ
-  col_sum := (TauCeti.PMF.map_snd_eq_iff π ν).1 hν
+  row_sum := (π.map_fst_eq_iff_fintype μ).1 hμ
+  col_sum := (π.map_snd_eq_iff_fintype ν).1 hν
 
 @[simp]
 theorem ofPMF_apply (π : PMF (ι × κ)) (hμ : π.map Prod.fst = μ)

--- a/TauCeti/Probability/ProbabilityMassFunction/Finite.lean
+++ b/TauCeti/Probability/ProbabilityMassFunction/Finite.lean
@@ -5,23 +5,22 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Probability.ProbabilityMassFunction.Constructions
+public import TauCeti.Probability.ProbabilityMassFunction.Marginal
 
 /-!
-# Marginals and finite sums for probability mass functions
+# Finite sums for probability mass functions
 
-This file records elementary summation identities for probability mass functions. The marginals
-of a PMF on an arbitrary product are its infinite row and column sums; for finite factors these
-specialize to ordinary finite sums.
+This file records the summation identities for probability mass functions that need a finiteness
+hypothesis: the total mass on a finite type, and the finite-sum specializations of the marginal
+formulas of `TauCeti.Probability.ProbabilityMassFunction.Marginal`.
 
 ## Main results
 
 * `PMF.sum_toReal_eq_one`: the real values of a PMF on a finite type sum to one.
-* `PMF.map_fst_apply`, `PMF.map_snd_apply`: the two marginals of a product PMF are its infinite row
-  and column sums, with `PMF.map_fst_apply_fintype` and `PMF.map_snd_apply_fintype` as their finite
-  specializations.
-* `PMF.map_fst_eq_iff`, `PMF.map_snd_eq_iff`: characterizations of prescribed marginals by those
-  sums, again with finite specializations.
+* `PMF.map_fst_apply_fintype`, `PMF.map_snd_apply_fintype`: the two marginals of a product PMF are
+  its row and column sums whenever the factor being summed over is finite.
+* `PMF.map_fst_eq_iff_fintype`, `PMF.map_snd_eq_iff_fintype`: characterizations of prescribed
+  marginals by those finite sums.
 -/
 
 public section
@@ -42,67 +41,30 @@ theorem sum_toReal_eq_one [Fintype ι] (μ : PMF ι) : ∑ i, (μ i).toReal = 1 
   have h : ∑ i, μ i = 1 := (tsum_fintype fun i ↦ μ i).symm.trans μ.tsum_coe
   rw [← ENNReal.toReal_sum fun i _ ↦ μ.apply_ne_top i, h, ENNReal.toReal_one]
 
-section Fst
-
 variable (π : PMF (ι × κ))
 
-/-- The first marginal of a product PMF is obtained by summing each row of its matrix of point
-masses. -/
-theorem map_fst_apply (i : ι) : π.map Prod.fst i = ∑' j, π (i, j) := by
-  classical
-  rw [PMF.map_apply, ENNReal.tsum_prod']
-  rw [tsum_eq_single i]
-  · simp
-  · intro i' hi
-    simp [hi.symm]
-
-/-- A product PMF has first marginal `μ` exactly when its infinite row sums are `μ`. -/
-theorem map_fst_eq_iff (μ : PMF ι) :
-    π.map Prod.fst = μ ↔ ∀ i, ∑' j, π (i, j) = μ i := by
-  rw [PMF.ext_iff]
-  simp only [map_fst_apply]
-
-/-- The first marginal of a finite product PMF is obtained by summing each row of its matrix of
-point masses. -/
+/-- The first marginal of a product PMF with finite second factor is obtained by summing each row
+of its matrix of point masses. -/
 theorem map_fst_apply_fintype [Fintype κ] (i : ι) : π.map Prod.fst i = ∑ j, π (i, j) := by
   rw [map_fst_apply, tsum_fintype]
 
-/-- A finite product PMF has first marginal `μ` exactly when its row sums are `μ`. -/
+/-- A product PMF with finite second factor has first marginal `μ` exactly when its row sums are
+`μ`. -/
 theorem map_fst_eq_iff_fintype [Fintype κ] (μ : PMF ι) :
     π.map Prod.fst = μ ↔ ∀ i, ∑ j, π (i, j) = μ i := by
   rw [map_fst_eq_iff]
   simp only [tsum_fintype]
 
-end Fst
-
-section Snd
-
-variable (π : PMF (ι × κ))
-
-/-- The second marginal of a product PMF is obtained by summing each column of its matrix of point
-masses. -/
-theorem map_snd_apply (j : κ) : π.map Prod.snd j = ∑' i, π (i, j) := by
-  classical
-  rw [PMF.map_apply, ENNReal.tsum_prod']
-  simp
-
-/-- A product PMF has second marginal `ν` exactly when its infinite column sums are `ν`. -/
-theorem map_snd_eq_iff (ν : PMF κ) :
-    π.map Prod.snd = ν ↔ ∀ j, ∑' i, π (i, j) = ν j := by
-  rw [PMF.ext_iff]
-  simp only [map_snd_apply]
-
-/-- The second marginal of a finite product PMF is obtained by summing each column of its matrix
-of point masses. -/
+/-- The second marginal of a product PMF with finite first factor is obtained by summing each
+column of its matrix of point masses. -/
 theorem map_snd_apply_fintype [Fintype ι] (j : κ) : π.map Prod.snd j = ∑ i, π (i, j) := by
   rw [map_snd_apply, tsum_fintype]
 
-/-- A finite product PMF has second marginal `ν` exactly when its column sums are `ν`. -/
+/-- A product PMF with finite first factor has second marginal `ν` exactly when its column sums are
+`ν`. -/
 theorem map_snd_eq_iff_fintype [Fintype ι] (ν : PMF κ) :
     π.map Prod.snd = ν ↔ ∀ j, ∑ i, π (i, j) = ν j := by
   rw [map_snd_eq_iff]
   simp only [tsum_fintype]
-
-end Snd
 
 end PMF

--- a/TauCeti/Probability/ProbabilityMassFunction/Finite.lean
+++ b/TauCeti/Probability/ProbabilityMassFunction/Finite.lean
@@ -8,18 +8,20 @@ module
 public import Mathlib.Probability.ProbabilityMassFunction.Constructions
 
 /-!
-# Finite sums for probability mass functions
+# Marginals and finite sums for probability mass functions
 
-This file records elementary finite-sum identities for probability mass functions, including the
-row- and column-sum formulas for the marginals of a product PMF on finite types.
+This file records elementary summation identities for probability mass functions. The marginals
+of a PMF on an arbitrary product are its infinite row and column sums; for finite factors these
+specialize to ordinary finite sums.
 
 ## Main results
 
 * `PMF.sum_toReal_eq_one`: the real values of a PMF on a finite type sum to one.
-* `PMF.map_fst_apply_fintype`, `PMF.map_snd_apply_fintype`: the two marginals of a finite
-  product PMF are its row and column sums.
-* `PMF.map_fst_eq_iff_fintype`, `PMF.map_snd_eq_iff_fintype`: characterizations of prescribed
-  marginals by those sums.
+* `PMF.map_fst_apply`, `PMF.map_snd_apply`: the two marginals of a product PMF are its infinite row
+  and column sums, with `PMF.map_fst_apply_fintype` and `PMF.map_snd_apply_fintype` as their finite
+  specializations.
+* `PMF.map_fst_eq_iff`, `PMF.map_snd_eq_iff`: characterizations of prescribed marginals by those
+  sums, again with finite specializations.
 -/
 
 public section
@@ -42,11 +44,11 @@ theorem sum_toReal_eq_one [Fintype ι] (μ : PMF ι) : ∑ i, (μ i).toReal = 1 
 
 section Fst
 
-variable [Fintype κ] (π : PMF (ι × κ))
+variable (π : PMF (ι × κ))
 
-/-- The first marginal of a finite product PMF is obtained by summing each row of its matrix of
-point masses. -/
-theorem map_fst_apply_fintype (i : ι) : π.map Prod.fst i = ∑ j, π (i, j) := by
+/-- The first marginal of a product PMF is obtained by summing each row of its matrix of point
+masses. -/
+theorem map_fst_apply (i : ι) : π.map Prod.fst i = ∑' j, π (i, j) := by
   classical
   rw [PMF.map_apply, ENNReal.tsum_prod']
   rw [tsum_eq_single i]
@@ -54,30 +56,52 @@ theorem map_fst_apply_fintype (i : ι) : π.map Prod.fst i = ∑ j, π (i, j) :=
   · intro i' hi
     simp [hi.symm]
 
-/-- A finite product PMF has first marginal `μ` exactly when its row sums are `μ`. -/
-theorem map_fst_eq_iff_fintype (μ : PMF ι) :
-    π.map Prod.fst = μ ↔ ∀ i, ∑ j, π (i, j) = μ i := by
+/-- A product PMF has first marginal `μ` exactly when its infinite row sums are `μ`. -/
+theorem map_fst_eq_iff (μ : PMF ι) :
+    π.map Prod.fst = μ ↔ ∀ i, ∑' j, π (i, j) = μ i := by
   rw [PMF.ext_iff]
-  simp only [map_fst_apply_fintype]
+  simp only [map_fst_apply]
+
+/-- The first marginal of a finite product PMF is obtained by summing each row of its matrix of
+point masses. -/
+theorem map_fst_apply_fintype [Fintype κ] (i : ι) : π.map Prod.fst i = ∑ j, π (i, j) := by
+  rw [map_fst_apply, tsum_fintype]
+
+/-- A finite product PMF has first marginal `μ` exactly when its row sums are `μ`. -/
+theorem map_fst_eq_iff_fintype [Fintype κ] (μ : PMF ι) :
+    π.map Prod.fst = μ ↔ ∀ i, ∑ j, π (i, j) = μ i := by
+  rw [map_fst_eq_iff]
+  simp only [tsum_fintype]
 
 end Fst
 
 section Snd
 
-variable [Fintype ι] (π : PMF (ι × κ))
+variable (π : PMF (ι × κ))
 
-/-- The second marginal of a finite product PMF is obtained by summing each column of its matrix
-of point masses. -/
-theorem map_snd_apply_fintype (j : κ) : π.map Prod.snd j = ∑ i, π (i, j) := by
+/-- The second marginal of a product PMF is obtained by summing each column of its matrix of point
+masses. -/
+theorem map_snd_apply (j : κ) : π.map Prod.snd j = ∑' i, π (i, j) := by
   classical
   rw [PMF.map_apply, ENNReal.tsum_prod']
   simp
 
-/-- A finite product PMF has second marginal `ν` exactly when its column sums are `ν`. -/
-theorem map_snd_eq_iff_fintype (ν : PMF κ) :
-    π.map Prod.snd = ν ↔ ∀ j, ∑ i, π (i, j) = ν j := by
+/-- A product PMF has second marginal `ν` exactly when its infinite column sums are `ν`. -/
+theorem map_snd_eq_iff (ν : PMF κ) :
+    π.map Prod.snd = ν ↔ ∀ j, ∑' i, π (i, j) = ν j := by
   rw [PMF.ext_iff]
-  simp only [map_snd_apply_fintype]
+  simp only [map_snd_apply]
+
+/-- The second marginal of a finite product PMF is obtained by summing each column of its matrix
+of point masses. -/
+theorem map_snd_apply_fintype [Fintype ι] (j : κ) : π.map Prod.snd j = ∑ i, π (i, j) := by
+  rw [map_snd_apply, tsum_fintype]
+
+/-- A finite product PMF has second marginal `ν` exactly when its column sums are `ν`. -/
+theorem map_snd_eq_iff_fintype [Fintype ι] (ν : PMF κ) :
+    π.map Prod.snd = ν ↔ ∀ j, ∑ i, π (i, j) = ν j := by
+  rw [map_snd_eq_iff]
+  simp only [tsum_fintype]
 
 end Snd
 

--- a/TauCeti/Probability/ProbabilityMassFunction/Finite.lean
+++ b/TauCeti/Probability/ProbabilityMassFunction/Finite.lean
@@ -8,9 +8,18 @@ module
 public import Mathlib.Probability.ProbabilityMassFunction.Constructions
 
 /-!
-# Probability mass functions on finite types
+# Finite sums for probability mass functions
 
-This file records elementary real-valued finite-sum identities for probability mass functions.
+This file records elementary finite-sum identities for probability mass functions, including the
+row- and column-sum formulas for the marginals of a product PMF on finite types.
+
+## Main results
+
+* `PMF.sum_toReal_eq_one`: the real values of a PMF on a finite type sum to one.
+* `PMF.map_fst_apply_fintype`, `PMF.map_snd_apply_fintype`: the two marginals of a finite
+  product PMF are its row and column sums.
+* `PMF.map_fst_eq_iff_fintype`, `PMF.map_snd_eq_iff_fintype`: characterizations of prescribed
+  marginals by those sums.
 -/
 
 public section
@@ -19,16 +28,57 @@ noncomputable section
 
 open scoped BigOperators ENNReal
 
-universe u
+universe u v
 
 namespace PMF
 
-variable {ι : Type u}
+variable {ι : Type u} {κ : Type v}
 
 /-- The real values of a probability mass function on a finite type sum to one. -/
 @[simp]
 theorem sum_toReal_eq_one [Fintype ι] (μ : PMF ι) : ∑ i, (μ i).toReal = 1 := by
   have h : ∑ i, μ i = 1 := (tsum_fintype fun i ↦ μ i).symm.trans μ.tsum_coe
   rw [← ENNReal.toReal_sum fun i _ ↦ μ.apply_ne_top i, h, ENNReal.toReal_one]
+
+section Fst
+
+variable [Fintype κ] (π : PMF (ι × κ))
+
+/-- The first marginal of a finite product PMF is obtained by summing each row of its matrix of
+point masses. -/
+theorem map_fst_apply_fintype (i : ι) : π.map Prod.fst i = ∑ j, π (i, j) := by
+  classical
+  rw [PMF.map_apply, ENNReal.tsum_prod']
+  rw [tsum_eq_single i]
+  · simp
+  · intro i' hi
+    simp [hi.symm]
+
+/-- A finite product PMF has first marginal `μ` exactly when its row sums are `μ`. -/
+theorem map_fst_eq_iff_fintype (μ : PMF ι) :
+    π.map Prod.fst = μ ↔ ∀ i, ∑ j, π (i, j) = μ i := by
+  rw [PMF.ext_iff]
+  simp only [map_fst_apply_fintype]
+
+end Fst
+
+section Snd
+
+variable [Fintype ι] (π : PMF (ι × κ))
+
+/-- The second marginal of a finite product PMF is obtained by summing each column of its matrix
+of point masses. -/
+theorem map_snd_apply_fintype (j : κ) : π.map Prod.snd j = ∑ i, π (i, j) := by
+  classical
+  rw [PMF.map_apply, ENNReal.tsum_prod']
+  simp
+
+/-- A finite product PMF has second marginal `ν` exactly when its column sums are `ν`. -/
+theorem map_snd_eq_iff_fintype (ν : PMF κ) :
+    π.map Prod.snd = ν ↔ ∀ j, ∑ i, π (i, j) = ν j := by
+  rw [PMF.ext_iff]
+  simp only [map_snd_apply_fintype]
+
+end Snd
 
 end PMF

--- a/TauCeti/Probability/ProbabilityMassFunction/Marginal.lean
+++ b/TauCeti/Probability/ProbabilityMassFunction/Marginal.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.ProbabilityMassFunction.Constructions
+
+/-!
+# Marginals of a probability mass function on a product
+
+This file records the two marginals of a probability mass function on an arbitrary product as the
+infinite row and column sums of its matrix of point masses, together with the resulting
+characterizations of a prescribed marginal.
+
+## Main results
+
+* `PMF.map_fst_apply`, `PMF.map_snd_apply`: the two marginals of a product PMF are its infinite row
+  and column sums.
+* `PMF.map_fst_eq_iff`, `PMF.map_snd_eq_iff`: characterizations of prescribed marginals by those
+  sums.
+-/
+
+public section
+
+noncomputable section
+
+open scoped ENNReal
+
+universe u v
+
+namespace PMF
+
+variable {ι : Type u} {κ : Type v} (π : PMF (ι × κ))
+
+/-- The first marginal of a product PMF is obtained by summing each row of its matrix of point
+masses. -/
+theorem map_fst_apply (i : ι) : π.map Prod.fst i = ∑' j, π (i, j) := by
+  classical
+  rw [PMF.map_apply, ENNReal.tsum_prod']
+  rw [tsum_eq_single i]
+  · simp
+  · intro i' hi
+    simp [hi.symm]
+
+/-- A product PMF has first marginal `μ` exactly when its infinite row sums are `μ`. -/
+theorem map_fst_eq_iff (μ : PMF ι) :
+    π.map Prod.fst = μ ↔ ∀ i, ∑' j, π (i, j) = μ i := by
+  rw [PMF.ext_iff]
+  simp only [map_fst_apply]
+
+/-- The second marginal of a product PMF is obtained by summing each column of its matrix of point
+masses. -/
+theorem map_snd_apply (j : κ) : π.map Prod.snd j = ∑' i, π (i, j) := by
+  classical
+  rw [PMF.map_apply, ENNReal.tsum_prod']
+  simp
+
+/-- A product PMF has second marginal `ν` exactly when its infinite column sums are `ν`. -/
+theorem map_snd_eq_iff (ν : PMF κ) :
+    π.map Prod.snd = ν ↔ ∀ j, ∑' i, π (i, j) = ν j := by
+  rw [PMF.ext_iff]
+  simp only [map_snd_apply]
+
+end PMF


### PR DESCRIPTION
This PR moves the four finite-product marginal lemmas from `TauCeti.PMF` into the existing root-`PMF` finite-sum module, renames them to advertise their `Fintype` specialization, and updates transport and gluing proofs to use receiver notation. The full local build passes, the affected dependency cone builds on current `main`, and the namespace lint removes four findings with zero new ones. This is one slice of #3547.

Roadmap: OptimalTransport

:robot: Prepared with OpenAI Codex