### PR TITLE
Migrate periodic derivative lemmas to the canonical namespace

### DIFF
--- a/TauCeti/Analysis/Calculus/PeriodicDeriv.lean
+++ b/TauCeti/Analysis/Calculus/PeriodicDeriv.lean
@@ -20,48 +20,42 @@ hence so is the logarithmic derivative. All three statements are unconditional:
 `fderiv`, `deriv`, and with them `logDeriv` take their junk values at non-differentiable
 points, and the translation identities hold there too.
 
+These extensions of Mathlib's periodicity API live in the root `Function` namespace as
+`Periodic.*`, so that `hf.deriv` and its analogues resolve by receiver notation. They remain
+protected so that opening `Function.Periodic` does not shadow `deriv` and `logDeriv` themselves.
+
 ## Main declarations
 
-* `TauCeti.Function.Periodic.fderiv`: the Fréchet derivative of a periodic function is
+* `Function.Periodic.fderiv`: the Fréchet derivative of a periodic function is
   periodic.
-* `TauCeti.Function.Periodic.deriv`: the derivative of a periodic function is periodic.
-* `TauCeti.Function.Periodic.logDeriv`: the logarithmic derivative of a periodic
+* `Function.Periodic.deriv`: the derivative of a periodic function is periodic.
+* `Function.Periodic.logDeriv`: the logarithmic derivative of a periodic
   function is periodic.
 -/
 
 public section
 
-namespace TauCeti
-
 namespace Function
-
-namespace Periodic
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 
 /-- The Fréchet derivative of a periodic function is periodic. -/
-protected theorem fderiv {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+protected theorem Periodic.fderiv {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
     [NormedAddCommGroup F] [NormedSpace 𝕜 F] {f : E → F} {c : E}
-    (hf : _root_.Function.Periodic f c) :
-    _root_.Function.Periodic (fderiv 𝕜 f) c := fun x ↦ by
+    (hf : Periodic f c) : Periodic (fderiv 𝕜 f) c := fun x ↦ by
   rw [← fderiv_comp_add_right, hf.funext]
 
 /-- The derivative of a periodic function is periodic. -/
-protected theorem deriv {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {f : 𝕜 → F}
-    {c : 𝕜} (hf : _root_.Function.Periodic f c) :
-    _root_.Function.Periodic (_root_.deriv f) c := fun x ↦ by
+protected theorem Periodic.deriv {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+    {f : 𝕜 → F} {c : 𝕜} (hf : Periodic f c) : Periodic (deriv f) c := fun x ↦ by
   rw [← deriv_comp_add_const, hf.funext]
 
 /-- The logarithmic derivative of a periodic function is periodic. -/
-protected theorem logDeriv {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜']
-    {f : 𝕜 → 𝕜'} {c : 𝕜} (hf : _root_.Function.Periodic f c) :
-    _root_.Function.Periodic (_root_.logDeriv f) c :=
-  (Periodic.deriv hf).div hf
-
-end Periodic
+protected theorem Periodic.logDeriv {𝕜' : Type*} [NontriviallyNormedField 𝕜']
+    [NormedAlgebra 𝕜 𝕜'] {f : 𝕜 → 𝕜'} {c : 𝕜} (hf : Periodic f c) :
+    Periodic (logDeriv f) c :=
+  hf.deriv.div hf
 
 end Function
-
-end TauCeti
 
 end

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Assembly.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Assembly.lean
@@ -73,8 +73,7 @@ theorem intervalIntegral_logDeriv_fdBoundary [SlashInvariantFormClass F Γ k] (f
         k * ((Real.pi / 6 : ℝ) * Complex.I) := by
   have hint23 := intervalIntegrable_deriv_smul_logDeriv_comp_ofComplex_fdBoundarySegment3
     f hS hd hne hint12
-  have hint34 := intervalIntegrable_deriv_smul_fdBoundarySegment4
-    (TauCeti.Function.Periodic.logDeriv hper) hint01
+  have hint34 := intervalIntegrable_deriv_smul_fdBoundarySegment4 hper.logDeriv hint01
   have hint13 := hint12.trans hint23
   have hint35 := hint34.trans hint45
   have hint15 := hint13.trans hint35
@@ -82,8 +81,7 @@ theorem intervalIntegral_logDeriv_fdBoundary [SlashInvariantFormClass F Γ k] (f
     ← intervalIntegral.integral_add_adjacent_intervals hint13 hint35,
     ← intervalIntegral.integral_add_adjacent_intervals hint34 hint45,
     intervalIntegral_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc f hS hd hne hint12,
-    intervalIntegral_fdBoundarySegment4_eq_neg_segment1 H
-      (TauCeti.Function.Periodic.logDeriv hper),
+    intervalIntegral_fdBoundarySegment4_eq_neg_segment1 H hper.logDeriv,
     (intervalIntegral_fdBoundarySegment5_eq_circleIntegral_logDeriv_cuspFunction
       hper).trans (circleIntegral_logDeriv_cuspFunction hga hgz)]
   push_cast

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Ceiling/Bridge.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Ceiling/Bridge.lean
@@ -106,8 +106,7 @@ theorem intervalIntegral_fdBoundarySegment5_eq_circleIntegral_logDeriv_cuspFunct
   have hcper : Function.Periodic
       (fun θ ↦ deriv (circleMap 0 R) θ • Lc (circleMap 0 R θ)) (2 * π) := fun θ ↦ by
     simp only []
-    rw [TauCeti.Function.Periodic.deriv (periodic_circleMap 0 R) θ,
-      periodic_circleMap 0 R θ]
+    rw [(periodic_circleMap 0 R).deriv θ, periodic_circleMap 0 R θ]
   -- shift the circle integral to `[-π, π]`
   have h2π : -π + 2 * π = π := by ring
   have h0π : (0 : ℝ) + 2 * π = 2 * π := by ring

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedAssembly.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisedAssembly.lean
@@ -101,8 +101,7 @@ private theorem intervalIntegral_excised_logDeriv_fdBoundary_of_neg_conj_mem
   have hint34 : IntervalIntegrable (fun t ↦ if ∃ s ∈ Sx, ‖fdBoundary H t - s‖ ≤ ε then 0
       else deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t)) volume 3 4 := by
     simpa only [smul_ite, smul_zero] using
-      intervalIntegrable_excised_deriv_smul_fdBoundarySegment4
-        (TauCeti.Function.Periodic.logDeriv hper) hrefl
+      intervalIntegrable_excised_deriv_smul_fdBoundarySegment4 hper.logDeriv hrefl
         (by simpa only [smul_ite, smul_zero] using hint01)
   have hint13 := hint12.trans hint23
   have hint35 := hint34.trans hint45
@@ -111,8 +110,7 @@ private theorem intervalIntegral_excised_logDeriv_fdBoundary_of_neg_conj_mem
       -∫ t in (0 : ℝ)..1, (if ∃ s ∈ Sx, ‖fdBoundary H t - s‖ ≤ ε then 0
         else deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t)) := by
     simpa only [smul_ite, smul_zero] using
-      intervalIntegral_excised_fdBoundarySegment4_eq_neg_segment1 H
-        (TauCeti.Function.Periodic.logDeriv hper) hrefl
+      intervalIntegral_excised_fdBoundarySegment4_eq_neg_segment1 H hper.logDeriv hrefl
   rw [← intervalIntegral.integral_add_adjacent_intervals hint01 (hint13.trans hint35),
     ← intervalIntegral.integral_add_adjacent_intervals hint13 hint35,
     ← intervalIntegral.integral_add_adjacent_intervals hint34 hint45,


### PR DESCRIPTION
This PR moves the Fréchet derivative, derivative, and logarithmic-derivative periodicity lemmas from `TauCeti.Function.Periodic` into Mathlib’s root `Function.Periodic` namespace, updates all modular-form consumers to protected receiver notation, and removes the obsolete namespace surface. The full local build passes, the namespace lint removes three findings with zero new ones, and no pinned-Mathlib name collides. This is one slice of #3547.

Roadmap: ModularForms

:robot: Prepared with OpenAI Codex