### PR TITLE
refactor(DenseGraphLimits): name the adjacency-preservation indicator

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/FiniteGraph/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/FiniteGraph/Basic.lean
@@ -167,7 +167,7 @@ carried to an edge of `G` by the cell index, and `0` otherwise.
 This is the pointwise identity that makes `homDensity_finiteGraphGraphon` a counting argument: it
 replaces the integrand of the graphon homomorphism density by an indicator, whose integral is then
 the proportion of cell-index tuples that are graph homomorphisms. Use it whenever the edge product
-of a step graphon has to be evaluated at a fixed tuple. -/
+of a finite-graph graphon has to be evaluated at a fixed tuple. -/
 theorem prod_edgeFactor_finiteGraphGraphon (F : SimpleGraph V) [DecidableRel F.Adj]
     (G : SimpleGraph (Fin m)) (x : V → I) :
     ∏ e ∈ F.edgeFinset, edgeFactor (finiteGraphGraphon G) x e

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/FiniteGraph/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/FiniteGraph/Basic.lean
@@ -159,6 +159,41 @@ theorem finiteGraphGraphon_apply_fin (G : SimpleGraph (Fin m)) [DecidableRel G.A
 
 variable {V : Type*} [Fintype V]
 
+open scoped Classical in
+/-- **The edge product is an adjacency-preservation indicator.** For the graphon of a finite graph
+`G`, the product of `edgeFactor` over the edges of `F` is `1` exactly when every edge of `F` is
+carried to an edge of `G` by the cell index, and `0` otherwise.
+
+This is the pointwise identity that makes `homDensity_finiteGraphGraphon` a counting argument: it
+replaces the integrand of the graphon homomorphism density by an indicator, whose integral is then
+the proportion of cell-index tuples that are graph homomorphisms. Use it whenever the edge product
+of a step graphon has to be evaluated at a fixed tuple. -/
+theorem prod_edgeFactor_finiteGraphGraphon (F : SimpleGraph V) [DecidableRel F.Adj]
+    (G : SimpleGraph (Fin m)) (x : V → I) :
+    ∏ e ∈ F.edgeFinset, edgeFactor (finiteGraphGraphon G) x e
+      = if ∀ a b, F.Adj a b → (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b))
+          then (1 : ℝ) else 0 := by
+  let p : Sym2 V → Prop := Sym2.lift
+    ⟨fun a b => (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b)),
+      fun a b => propext (SimpleGraph.adj_comm (G.map Fin.valEmbedding) _ _)⟩
+  have hfac : ∀ e : Sym2 V,
+      edgeFactor (finiteGraphGraphon G) x e = if p e then 1 else 0 := by
+    intro e
+    induction e using Sym2.ind with
+    | _ a b =>
+      rw [edgeFactor_mk, finiteGraphGraphon_apply]
+      exact if_congr (by simp only [p, Sym2.lift_mk]) rfl rfl
+  have hp_iff : (∀ e ∈ F.edgeFinset, p e) ↔
+      ∀ a b, F.Adj a b →
+        (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b)) := by
+    simp only [SimpleGraph.mem_edgeFinset, SimpleGraph.mem_edgeSet, Sym2.forall, p,
+      Sym2.lift_mk]
+  rw [Finset.prod_congr rfl fun e _ => hfac e, Finset.prod_boole]
+  by_cases h : ∀ a b, F.Adj a b →
+      (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b))
+  · rw [ite_eq_left h, ite_eq_left (hp_iff.2 h)]
+  · rw [ite_eq_right h, ite_eq_right fun hp => h (hp_iff.1 hp)]
+
 /-- **Finite-graph compatibility.** The graphon homomorphism density of `F` in the graphon of a
 finite graph `G` on `Fin m` is the finite homomorphism density of `F` in `G`:
 
@@ -171,31 +206,6 @@ theorem homDensity_finiteGraphGraphon (F : SimpleGraph V) [DecidableRel F.Adj] (
     (G : SimpleGraph (Fin m)) :
     homDensity F (finiteGraphGraphon G) = homDensityFin F G := by
   classical
-  -- the integrand is the adjacency-preservation indicator of the tuple of cell indices
-  have hstep : ∀ x : V → I, ∏ e ∈ F.edgeFinset, edgeFactor (finiteGraphGraphon G) x e
-      = if ∀ a b, F.Adj a b → (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b))
-          then (1 : ℝ) else 0 := by
-    intro x
-    let p : Sym2 V → Prop := Sym2.lift
-      ⟨fun a b => (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b)),
-        fun a b => propext (SimpleGraph.adj_comm (G.map Fin.valEmbedding) _ _)⟩
-    have hfac : ∀ e : Sym2 V,
-        edgeFactor (finiteGraphGraphon G) x e = if p e then 1 else 0 := by
-      intro e
-      induction e using Sym2.ind with
-      | _ a b =>
-        rw [edgeFactor_mk, finiteGraphGraphon_apply]
-        exact if_congr (by simp only [p, Sym2.lift_mk]) rfl rfl
-    have hp_iff : (∀ e ∈ F.edgeFinset, p e) ↔
-        ∀ a b, F.Adj a b →
-          (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b)) := by
-      simp only [SimpleGraph.mem_edgeFinset, SimpleGraph.mem_edgeSet, Sym2.forall, p,
-        Sym2.lift_mk]
-    rw [Finset.prod_congr rfl fun e _ => hfac e, Finset.prod_boole]
-    by_cases h : ∀ a b, F.Adj a b →
-        (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b))
-    · rw [ite_eq_left h, ite_eq_left (hp_iff.2 h)]
-    · rw [ite_eq_right h, ite_eq_right fun hp => h (hp_iff.1 hp)]
   -- the resulting finite sum counts the homomorphisms
   have hsum : (∑ ψ : V → Fin m, if ∀ a b, F.Adj a b →
         (G.map Fin.valEmbedding).Adj ((ψ a : ℕ)) ((ψ b : ℕ)) then (1 : ℝ) else 0)
@@ -214,8 +224,9 @@ theorem homDensity_finiteGraphGraphon (F : SimpleGraph V) [DecidableRel F.Adj] (
       (integral_pi_comp_cellIdx_eq_inv_smul_sum (V := V) hm
         (fun ν : V → ℕ => if ∀ a b, F.Adj a b → (G.map Fin.valEmbedding).Adj (ν a) (ν b)
           then (1 : ℝ) else 0))
-  rw [homDensity_def, integral_congr_ae (Filter.Eventually.of_forall hstep), hpi, hsum,
-    homDensityFin_def, Fintype.card_fin]
+  rw [homDensity_def,
+    integral_congr_ae (Filter.Eventually.of_forall (prod_edgeFactor_finiteGraphGraphon F G)),
+    hpi, hsum, homDensityFin_def, Fintype.card_fin]
 
 end DenseGraphLimits
 


### PR DESCRIPTION
Names the adjacency-preservation indicator that `homDensity_finiteGraphGraphon` was carrying inline.

## What was there

`homDensity_finiteGraphGraphon` proves that the graphon homomorphism density of `F` in the graphon
of a finite graph `G` agrees with the finite homomorphism density. It opened with

```lean
have hstep : ∀ x : V → I, ∏ e ∈ F.edgeFinset, edgeFactor (finiteGraphGraphon G) x e
    = if ∀ a b, F.Adj a b → (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b))
        then (1 : ℝ) else 0 := by ...
```

— **24 of the theorem's 46 body lines**, the largest thing in the file, and used exactly once
(at the closing `rw`).

## What this does

That `have` had already written its own statement down, and the statement is a theorem in its own
right, with nothing to do with densities or integrals:

> for the graphon of a finite graph, the product of `edgeFactor` over the edges of `F` is `1`
> exactly when the cell index carries every edge of `F` to an edge of `G`, and `0` otherwise.

So it is lifted to `prod_edgeFactor_finiteGraphGraphon` and cited inline. The parent's closing
`rw` names the lemma where it previously named the local hypothesis; nothing else in the proof
moves.

**The extracted lemma does not need `hm : 0 < m`.** The parent needs positivity of `m` for the
`0 / 0` edge case flagged in its own docstring, but the edge product is an identity about the
integrand, not about the normalisation, so the hypothesis is dropped rather than relocated.

| | before | after |
|---|---|---|
| `homDensity_finiteGraphGraphon` proof body | **46** | **22** |
| its largest contiguous block | **24** | **11** |
| its block-profile classification | `partial` | `assembly` |
| `prod_edgeFactor_finiteGraphGraphon` proof body | — | 20 (largest block 7, `assembly`) |
| file (non-blank lines) | 183 | 192 |

Measured with a block profiler on before/after copies of the file. Neither declaration is `prime`
or `partial` afterwards: nothing left in the file has a liftable dominant block. No statement,
attribute or import changes. Of the nine added non-blank lines, four are the new docstring, which
documents the result and its use rather than narrating the `Sym2.lift` argument that proves it.

## One thing a reviewer will reasonably ask

**Why `open scoped Classical in` on the new lemma?** Because a `have`'s *type* is elaborated inside
the proof, under whatever the tactics have already put in scope, and a top-level statement is not.
The parent runs `classical` as its first tactic, so the `if … then 1 else 0` in `hstep`'s type
picked up `Classical.propDecidable`; lifted verbatim, the same `if` fails with
`failed to synthesize Decidable (∀ a b, F.Adj a b → …)` before any tactic runs.

`open scoped Classical in` is the fix, and it is this file's own idiom rather than an import for
the occasion — the file already prefixes both `finiteGraphGraphon` (line 81) and
`finiteGraphGraphon_apply` (line 104) with exactly that line, for exactly this `if`. The parent
keeps its `classical`, which its remaining steps still use.

**Why the name?** `prod_edgeFactor_finiteGraphGraphon` reads head-symbol-first in the file's
established shape: the sibling result about the same graphon is `homDensity_finiteGraphGraphon`,
and the evaluation lemmas are `finiteGraphGraphon_apply{,_fin,_of_adj,_of_not_adj}`.

Roadmap: DenseGraphLimits
