### PR TITLE
refactor(OptimalTransport): name the fibrewise cost bound in the coupling lift

### DIFF
--- a/TauCeti/MeasureTheory/Integral/Prod.lean
+++ b/TauCeti/MeasureTheory/Integral/Prod.lean
@@ -6,15 +6,20 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.MeasureTheory.Integral.Prod
+public import Mathlib.Probability.ConditionalProbability
 public import TauCeti.MeasureTheory.Integral.PiSystem
 
 /-!
-# Product-measure helpers: a.e. transfer along the projections, and a Dynkin step for integrals
+# Product-measure helpers
 
-Two small pieces of product-measure theory with no `L²` or inner-product content.
+Small pieces of product-measure theory with no `L²` or inner-product content.
 
 * `TauCeti.ae_of_ae_fst` / `TauCeti.ae_of_ae_snd` transfer an a.e. statement about one factor to the
   product measure, along `Measure.quasiMeasurePreserving_fst` / `_snd`.
+* `TauCeti.lintegral_cond_prod_le` bounds a lower Lebesgue integral against a product of two
+  conditional laws by any bound the integrand satisfies on the rectangle conditioned on: the two
+  a.e. transfers above confine each coordinate to its own set, and
+  `MeasureTheory.lintegral_le_const` finishes.
 * `TauCeti.setIntegral_eq_zero_of_forall_prod` is the binary-product specialization of the Dynkin
   (π-λ) step for Bochner integrals: a function whose integral vanishes on every measurable rectangle
   has vanishing integral on every measurable set. Rectangles are a π-system generating the product
@@ -28,6 +33,7 @@ public section
 namespace TauCeti
 
 open MeasureTheory
+open scoped ENNReal ProbabilityTheory
 
 variable {α β E : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
   {μ : Measure α} {ν : Measure β}
@@ -42,6 +48,21 @@ theorem ae_of_ae_fst [SFinite ν] {p : α → Prop} (hp : ∀ᵐ x ∂μ, p x) :
 theorem ae_of_ae_snd [SFinite ν] {p : β → Prop} (hp : ∀ᵐ y ∂ν, p y) :
     ∀ᵐ q : α × β ∂(μ.prod ν), p q.2 :=
   Measure.quasiMeasurePreserving_snd.tendsto_ae.eventually hp
+
+/-- **A rectangle bound for an integral against a product of conditional laws.** If `f` is bounded
+by `b` on `s ×ˢ t`, then its lower Lebesgue integral against the product of the laws of `μ` and `ν`
+conditioned on `s` and on `t` is at most `b`: conditioning confines each coordinate to its own set
+almost surely, so the bound holds almost everywhere on the product. -/
+theorem lintegral_cond_prod_le [IsFiniteMeasure μ] [IsFiniteMeasure ν] {s : Set α} {t : Set β}
+    (hs : MeasurableSet s) (ht : MeasurableSet t) (hμ : μ s ≠ 0) (hν : ν t ≠ 0)
+    {f : α × β → ℝ≥0∞} {b : ℝ≥0∞} (hf : ∀ x ∈ s, ∀ y ∈ t, f (x, y) ≤ b) :
+    ∫⁻ z, f z ∂((μ[|s]).prod (ν[|t])) ≤ b := by
+  have := ProbabilityTheory.cond_isProbabilityMeasure hμ
+  have := ProbabilityTheory.cond_isProbabilityMeasure hν
+  refine lintegral_le_const ?_
+  filter_upwards [ae_of_ae_fst (ν := ν[|t]) (ProbabilityTheory.ae_cond_mem (μ := μ) hs),
+    ae_of_ae_snd (μ := μ[|s]) (ProbabilityTheory.ae_cond_mem (μ := ν) ht)] with ⟨x, y⟩ hx hy
+  exact hf x hx y hy
 
 /-- **The Dynkin (π-λ) step for Bochner integrals on a product space.** A function whose integral
 vanishes on every measurable rectangle has vanishing integral on every measurable set.

--- a/TauCeti/MeasureTheory/Integral/Prod.lean
+++ b/TauCeti/MeasureTheory/Integral/Prod.lean
@@ -16,10 +16,10 @@ Small pieces of product-measure theory with no `L²` or inner-product content.
 
 * `TauCeti.ae_of_ae_fst` / `TauCeti.ae_of_ae_snd` transfer an a.e. statement about one factor to the
   product measure, along `Measure.quasiMeasurePreserving_fst` / `_snd`.
-* `TauCeti.lintegral_cond_prod_le` bounds a lower Lebesgue integral against a product of two
-  conditional laws by any bound the integrand satisfies on the rectangle conditioned on: the two
-  a.e. transfers above confine each coordinate to its own set, and
-  `MeasureTheory.lintegral_le_const` finishes.
+* `TauCeti.lintegral_cond_prod_le` bounds a lower Lebesgue integral over a product of two
+  conditional laws by any bound the integrand satisfies on the rectangle conditioned on. Use it to
+  estimate an integral against two independently conditioned coordinates when the integrand is
+  controlled only on the pair of sets being conditioned on.
 * `TauCeti.setIntegral_eq_zero_of_forall_prod` is the binary-product specialization of the Dynkin
   (π-λ) step for Bochner integrals: a function whose integral vanishes on every measurable rectangle
   has vanishing integral on every measurable set. Rectangles are a π-system generating the product
@@ -53,12 +53,12 @@ theorem ae_of_ae_snd [SFinite ν] {p : β → Prop} (hp : ∀ᵐ y ∂ν, p y) :
 by `b` on `s ×ˢ t`, then its lower Lebesgue integral against the product of the laws of `μ` and `ν`
 conditioned on `s` and on `t` is at most `b`: conditioning confines each coordinate to its own set
 almost surely, so the bound holds almost everywhere on the product. -/
-theorem lintegral_cond_prod_le [IsFiniteMeasure μ] [IsFiniteMeasure ν] {s : Set α} {t : Set β}
-    (hs : MeasurableSet s) (ht : MeasurableSet t) (hμ : μ s ≠ 0) (hν : ν t ≠ 0)
+theorem lintegral_cond_prod_le {s : Set α} {t : Set β} (hs : MeasurableSet s)
+    (ht : MeasurableSet t) (hμ : μ s ≠ 0) (hμtop : μ s ≠ ∞) (hν : ν t ≠ 0) (hνtop : ν t ≠ ∞)
     {f : α × β → ℝ≥0∞} {b : ℝ≥0∞} (hf : ∀ x ∈ s, ∀ y ∈ t, f (x, y) ≤ b) :
     ∫⁻ z, f z ∂((μ[|s]).prod (ν[|t])) ≤ b := by
-  have := ProbabilityTheory.cond_isProbabilityMeasure hμ
-  have := ProbabilityTheory.cond_isProbabilityMeasure hν
+  have := ProbabilityTheory.cond_isProbabilityMeasure_of_finite hμ hμtop
+  have := ProbabilityTheory.cond_isProbabilityMeasure_of_finite hν hνtop
   refine lintegral_le_const ?_
   filter_upwards [ae_of_ae_fst (ν := ν[|t]) (ProbabilityTheory.ae_cond_mem (μ := μ) hs),
     ae_of_ae_snd (μ := μ[|s]) (ProbabilityTheory.ae_cond_mem (μ := ν) ht)] with ⟨x, y⟩ hx hy

--- a/TauCeti/MeasureTheory/OptimalTransport/Duality/Compact.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Duality/Compact.lean
@@ -259,6 +259,34 @@ private theorem isCoupling_glue {n m : ℕ} {qX : X → Fin n} {qY : Y → Fin m
     rw [hstep]
     exact ProbabilityTheory.sum_meas_smul_cond_fiber hqY ν
 
+/-- On the product of the conditional laws of the fibres `qX ⁻¹' {i}` and `qY ⁻¹' {j}`, a cost
+bounded by `b` on that pair of fibres has `ENNReal.ofReal`-integral at most `ENNReal.ofReal b`.
+Conditioning confines each coordinate to its own fibre almost surely, so the integrand is almost
+surely bounded by the constant. -/
+private theorem lintegral_ofReal_cond_prod_le {n m : ℕ} {qX : X → Fin n} {qY : Y → Fin m}
+    (hqX : Measurable qX) (hqY : Measurable qY) {μ : Measure X} [IsFiniteMeasure μ]
+    {ν : Measure Y} [IsFiniteMeasure ν] {i : Fin n} {j : Fin m}
+    (hi : μ (qX ⁻¹' {i}) ≠ 0) (hj : ν (qY ⁻¹' {j}) ≠ 0) {c : X × Y → ℝ} {b : ℝ}
+    (hb : ∀ x y, qX x = i → qY y = j → c (x, y) ≤ b) :
+    ∫⁻ z, ENNReal.ofReal (c z) ∂((μ[|qX ⁻¹' {i}]).prod (ν[|qY ⁻¹' {j}]))
+      ≤ ENNReal.ofReal b := by
+  have := ProbabilityTheory.cond_isProbabilityMeasure hi
+  have := ProbabilityTheory.cond_isProbabilityMeasure hj
+  have hfib1 : ∀ᵐ z ∂((μ[|qX ⁻¹' {i}]).prod (ν[|qY ⁻¹' {j}])), qX z.1 = i := by
+    refine (Measure.ae_prod_iff_ae_ae ?_).2 ?_
+    · exact (hqX.comp measurable_fst) (MeasurableSet.singleton i)
+    · filter_upwards [ProbabilityTheory.ae_cond_mem (μ := μ)
+        (hqX (MeasurableSet.singleton i))] with x hx
+      exact ae_of_all _ fun _ ↦ hx
+  have hfib2 : ∀ᵐ z ∂((μ[|qX ⁻¹' {i}]).prod (ν[|qY ⁻¹' {j}])), qY z.2 = j := by
+    refine (Measure.ae_prod_iff_ae_ae ?_).2 ?_
+    · exact (hqY.comp measurable_snd) (MeasurableSet.singleton j)
+    · exact ae_of_all _ fun _ ↦ ProbabilityTheory.ae_cond_mem (μ := ν)
+        (hqY (MeasurableSet.singleton j))
+  refine lintegral_le_const ?_
+  filter_upwards [hfib1, hfib2] with ⟨x, y⟩ hx hy
+  exact ENNReal.ofReal_le_ofReal (hb x y hx hy)
+
 /-- **Lifting a finite transportation matrix to a coupling.** Let two measurable maps `qX` and
 `qY` with finite ranges discretise the two marginals, and let `T` be a transportation matrix for
 the discretised masses. Gluing the conditional measures on the fibres of `qX` and `qY` along `T`
@@ -282,26 +310,9 @@ private theorem transportCost_le_ofReal_cost {n m : ℕ} {qX : X → Fin n} {qY 
     intro i j
     rcases eq_or_ne (T i j) 0 with h | h
     · simp [h]
-    · have := ProbabilityTheory.cond_isProbabilityMeasure (row_fiber_ne_zero hpμ T h)
-      have := ProbabilityTheory.cond_isProbabilityMeasure (col_fiber_ne_zero hpν T h)
-      refine mul_le_mul_of_nonneg_left ?_ (by positivity)
-      have hfib1 : ∀ᵐ z ∂((μ[|qX ⁻¹' {i}]).prod (ν[|qY ⁻¹' {j}])), qX z.1 = i := by
-        refine (Measure.ae_prod_iff_ae_ae ?_).2 ?_
-        · exact (hqX.comp measurable_fst) (MeasurableSet.singleton i)
-        · filter_upwards [ProbabilityTheory.ae_cond_mem (μ := μ)
-            (hqX (MeasurableSet.singleton i))] with x hx
-          exact ae_of_all _ fun _ ↦ hx
-      have hfib2 : ∀ᵐ z ∂((μ[|qX ⁻¹' {i}]).prod (ν[|qY ⁻¹' {j}])), qY z.2 = j := by
-        refine (Measure.ae_prod_iff_ae_ae ?_).2 ?_
-        · exact (hqY.comp measurable_snd) (MeasurableSet.singleton j)
-        · exact ae_of_all _ fun _ ↦ ProbabilityTheory.ae_cond_mem (μ := ν)
-            (hqY (MeasurableSet.singleton j))
-      refine le_trans (lintegral_mono_ae ?_) (by rw [lintegral_const, measure_univ, mul_one])
-      filter_upwards [hfib1, hfib2] with z h1 h2
-      refine ENNReal.ofReal_le_ofReal ?_
-      have hz := hC z.1 z.2
-      rw [h1, h2] at hz
-      simpa using hz
+    · exact mul_le_mul_of_nonneg_left (lintegral_ofReal_cond_prod_le hqX hqY
+        (row_fiber_ne_zero hpμ T h) (col_fiber_ne_zero hpν T h)
+        fun x y hx hy ↦ (hC x y).trans_eq (by rw [hx, hy])) (by positivity)
   have hentry : ∀ i j, T i j * ENNReal.ofReal (C (i, j))
       = ENNReal.ofReal (C (i, j) * T.toRealFun (i, j)) := by
     intro i j

--- a/TauCeti/MeasureTheory/OptimalTransport/Duality/Compact.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Duality/Compact.lean
@@ -11,6 +11,7 @@ public import TauCeti.MeasureTheory.MeasurableSpace.Metric
 public import TauCeti.MeasureTheory.OptimalTransport.CTransform.Basic
 public import TauCeti.MeasureTheory.OptimalTransport.Cost.Compact
 public import TauCeti.MeasureTheory.OptimalTransport.Finite.Duality
+import TauCeti.MeasureTheory.Integral.Prod
 
 /-!
 # Strong Kantorovich duality for continuous costs on compact spaces
@@ -259,34 +260,6 @@ private theorem isCoupling_glue {n m : ℕ} {qX : X → Fin n} {qY : Y → Fin m
     rw [hstep]
     exact ProbabilityTheory.sum_meas_smul_cond_fiber hqY ν
 
-/-- On the product of the conditional laws of the fibres `qX ⁻¹' {i}` and `qY ⁻¹' {j}`, a cost
-bounded by `b` on that pair of fibres has `ENNReal.ofReal`-integral at most `ENNReal.ofReal b`.
-Conditioning confines each coordinate to its own fibre almost surely, so the integrand is almost
-surely bounded by the constant. -/
-private theorem lintegral_ofReal_cond_prod_le {n m : ℕ} {qX : X → Fin n} {qY : Y → Fin m}
-    (hqX : Measurable qX) (hqY : Measurable qY) {μ : Measure X} [IsFiniteMeasure μ]
-    {ν : Measure Y} [IsFiniteMeasure ν] {i : Fin n} {j : Fin m}
-    (hi : μ (qX ⁻¹' {i}) ≠ 0) (hj : ν (qY ⁻¹' {j}) ≠ 0) {c : X × Y → ℝ} {b : ℝ}
-    (hb : ∀ x y, qX x = i → qY y = j → c (x, y) ≤ b) :
-    ∫⁻ z, ENNReal.ofReal (c z) ∂((μ[|qX ⁻¹' {i}]).prod (ν[|qY ⁻¹' {j}]))
-      ≤ ENNReal.ofReal b := by
-  have := ProbabilityTheory.cond_isProbabilityMeasure hi
-  have := ProbabilityTheory.cond_isProbabilityMeasure hj
-  have hfib1 : ∀ᵐ z ∂((μ[|qX ⁻¹' {i}]).prod (ν[|qY ⁻¹' {j}])), qX z.1 = i := by
-    refine (Measure.ae_prod_iff_ae_ae ?_).2 ?_
-    · exact (hqX.comp measurable_fst) (MeasurableSet.singleton i)
-    · filter_upwards [ProbabilityTheory.ae_cond_mem (μ := μ)
-        (hqX (MeasurableSet.singleton i))] with x hx
-      exact ae_of_all _ fun _ ↦ hx
-  have hfib2 : ∀ᵐ z ∂((μ[|qX ⁻¹' {i}]).prod (ν[|qY ⁻¹' {j}])), qY z.2 = j := by
-    refine (Measure.ae_prod_iff_ae_ae ?_).2 ?_
-    · exact (hqY.comp measurable_snd) (MeasurableSet.singleton j)
-    · exact ae_of_all _ fun _ ↦ ProbabilityTheory.ae_cond_mem (μ := ν)
-        (hqY (MeasurableSet.singleton j))
-  refine lintegral_le_const ?_
-  filter_upwards [hfib1, hfib2] with ⟨x, y⟩ hx hy
-  exact ENNReal.ofReal_le_ofReal (hb x y hx hy)
-
 /-- **Lifting a finite transportation matrix to a coupling.** Let two measurable maps `qX` and
 `qY` with finite ranges discretise the two marginals, and let `T` be a transportation matrix for
 the discretised masses. Gluing the conditional measures on the fibres of `qX` and `qY` along `T`
@@ -310,9 +283,11 @@ private theorem transportCost_le_ofReal_cost {n m : ℕ} {qX : X → Fin n} {qY 
     intro i j
     rcases eq_or_ne (T i j) 0 with h | h
     · simp [h]
-    · exact mul_le_mul_of_nonneg_left (lintegral_ofReal_cond_prod_le hqX hqY
+    · exact mul_le_mul_of_nonneg_left (lintegral_cond_prod_le
+        (hqX (MeasurableSet.singleton i)) (hqY (MeasurableSet.singleton j))
         (row_fiber_ne_zero hpμ T h) (col_fiber_ne_zero hpν T h)
-        fun x y hx hy ↦ (hC x y).trans_eq (by rw [hx, hy])) (by positivity)
+        fun x hx y hy ↦ ENNReal.ofReal_le_ofReal ((hC x y).trans_eq
+          (by rw [show qX x = i from hx, show qY y = j from hy]))) (by positivity)
   have hentry : ∀ i j, T i j * ENNReal.ofReal (C (i, j))
       = ENNReal.ofReal (C (i, j) * T.toRealFun (i, j)) := by
     intro i j

--- a/TauCeti/MeasureTheory/OptimalTransport/Duality/Compact.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Duality/Compact.lean
@@ -283,11 +283,13 @@ private theorem transportCost_le_ofReal_cost {n m : ℕ} {qX : X → Fin n} {qY 
     intro i j
     rcases eq_or_ne (T i j) 0 with h | h
     · simp [h]
-    · exact mul_le_mul_of_nonneg_left (lintegral_cond_prod_le
+    · refine mul_le_mul_of_nonneg_left (lintegral_cond_prod_le
         (hqX (MeasurableSet.singleton i)) (hqY (MeasurableSet.singleton j))
-        (row_fiber_ne_zero hpμ T h) (col_fiber_ne_zero hpν T h)
-        fun x hx y hy ↦ ENNReal.ofReal_le_ofReal ((hC x y).trans_eq
-          (by rw [show qX x = i from hx, show qY y = j from hy]))) (by positivity)
+        (row_fiber_ne_zero hpμ T h) (measure_ne_top μ _)
+        (col_fiber_ne_zero hpν T h) (measure_ne_top ν _) fun x hx y hy ↦ ?_) (by positivity)
+      have hxi : qX x = i := by simpa only [Set.mem_preimage, Set.mem_singleton_iff] using hx
+      have hyj : qY y = j := by simpa only [Set.mem_preimage, Set.mem_singleton_iff] using hy
+      exact ENNReal.ofReal_le_ofReal ((hC x y).trans_eq (by rw [hxi, hyj]))
   have hentry : ∀ i j, T i j * ENNReal.ofReal (C (i, j))
       = ENNReal.ofReal (C (i, j) * T.toRealFun (i, j)) := by
     intro i j


### PR DESCRIPTION
`transportCost_le_ofReal_cost` lifts a finite transportation matrix to a coupling and bounds the
primal transport cost by the matrix cost. Its central estimate was proved inline as `hblock`: on the
product of the conditional laws of the fibres `qX ⁻¹' {i}` and `qY ⁻¹' {j}`, a cost dominated
fibrewise by `C` integrates to at most the entry `C (i, j)`. That was the dominant block of the proof
— 25 of 50 body lines — and it had no name, even though the file's `Lift` section otherwise names
every step it uses (`integral_comp_eq_sum`, `row_fiber_ne_zero`, `col_fiber_ne_zero`,
`isCoupling_glue`).

This PR makes it the fifth such helper, `lintegral_ofReal_cond_prod_le`, and reuses Mathlib's
`MeasureTheory.lintegral_le_const` for the final step in place of the hand-rolled
`lintegral_mono_ae` / `lintegral_const` / `measure_univ` chain.

### Hypotheses re-derived from the helper's own body, not inherited

The parent's binders were **not** threaded through; each was checked against what the extracted proof
actually uses:

| parent | helper | why |
|---|---|---|
| `[IsProbabilityMeasure μ]`, `[IsProbabilityMeasure ν]` | `[IsFiniteMeasure μ]`, `[IsFiniteMeasure ν]` | only `ProbabilityTheory.cond_isProbabilityMeasure` needs them, and it asks for `IsFiniteMeasure` |
| `T : TransportMatrix pμ pν`, `pμ`, `pν`, `hpμ`, `hpν` | `hi : μ (qX ⁻¹' {i}) ≠ 0`, `hj : ν (qY ⁻¹' {j}) ≠ 0` | the block used `T` only to reach the two fibres' non-nullity via `row_fiber_ne_zero` / `col_fiber_ne_zero`; those calls stay at the call site |
| `hC : ∀ x y, c (x, y) ≤ C (qX x, qY y)` (global) | `hb : ∀ x y, qX x = i → qY y = j → c (x, y) ≤ b` (this pair of fibres only) | the block only ever applies `hC` where both fibre equations hold, so `C` and its index pair drop out entirely |
| `hC0 : ∀ p, 0 ≤ C p` | — | unused by the block; still used by the parent's `hentry` step |

The transport matrix, its `T i j = 0` case split and the `mul_le_mul_of_nonneg_left` scaling are pure
bookkeeping and stay in the parent, where the call site transports the fibre equations in one term:
`fun x y hx hy ↦ (hC x y).trans_eq (by rw [hx, hy])`.

### Effect

- `transportCost_le_ofReal_cost` body: **50 → 33** lines (under the proof-quality threshold).
- New helper body: **16** lines.
- File: 443 → 453 non-blank lines; one file touched; no import changes; no statement changed.

### Note on local gates

The rig's shared Mathlib cache could not gate this diff: `lake build` on the target module found the
cache trace-stale, began recompiling Mathlib from source, and was killed by the build guard
(`Lean exited with code 143`). No local build, `lake exe axioms` or `lake exe module-system` run was
therefore possible, and the sandboxed CI build is the gate — this PR is opened as a **draft** and
will be marked ready only once CI is green. In place of a build the diff was checked by inspection:
every name in the helper except `lintegral_le_const` is carried over verbatim from the block it
replaces, and `MeasureTheory.lintegral_le_const`
(`Mathlib/MeasureTheory/Integral/Lebesgue/Countable.lean:42`) was confirmed reachable through an
all-`public` import chain (`…Duality.Compact` → `…Cost.Compact` → `…Cost.Basic` →
`Mathlib.MeasureTheory.Integral.Lebesgue.Countable`) with `MeasureTheory` opened at the top of the
file, and `Measure.prod.instIsProbabilityMeasure` (`Mathlib/MeasureTheory/Measure/Prod.lean:323`)
supplies the instance it needs.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp


---

## Round 2 — all three findings applied, no contest

They pointed the same way, so they compose into one lemma rather than conflicting.

**generality** asked for measurable sets, an `ℝ≥0∞` integrand and an `ℝ≥0∞` bound instead of
`Fin n`/`Fin m`, fibre maps, singleton indices and `ENNReal.ofReal`. **api-design** asked for a
public conditional-probability/measure-theory module instead of `private` here. **reuse** pointed at
`TauCeti.ae_of_ae_fst` / `TauCeti.ae_of_ae_snd`, which already do the a.e. transfer that `hfib1` and
`hfib2` were rederiving, and asked for `TauCeti.MeasureTheory.Integral.Prod` to be imported.

Those two lemmas *live in* `TauCeti/MeasureTheory/Integral/Prod.lean`, a public module whose stated
subject is product-measure helpers — so hosting the generalised lemma there satisfies all three at
once, and `Compact.lean` needs exactly the one import `reuse` named:

```
theorem lintegral_cond_prod_le [IsFiniteMeasure μ] [IsFiniteMeasure ν] {s : Set α} {t : Set β}
    (hs : MeasurableSet s) (ht : MeasurableSet t) (hμ : μ s ≠ 0) (hν : ν t ≠ 0)
    {f : α × β → ℝ≥0∞} {b : ℝ≥0∞} (hf : ∀ x ∈ s, ∀ y ∈ t, f (x, y) ≤ b) :
    ∫⁻ z, f z ∂((μ[|s]).prod (ν[|t])) ≤ b
```

- Proof drops **16 → 8** lines: the two transfers plus `MeasureTheory.lintegral_le_const`.
- Name loses `ofReal`, which the statement no longer mentions. `naming` approved the old name for a
  statement that no longer exists.
- `Compact.lean` specialises at the two fibre preimages with `f z = ENNReal.ofReal (c z)`, so the
  `ENNReal.ofReal_le_ofReal` step moves to the call site. `transportCost_le_ofReal_cost` keeps its
  33-line body.
- The import is **plain, not `public`** — the lemma is used in a proof body only, the idiom
  `Combinatorics/DenseGraphLimits/Kernel/L2.lean:9` uses.
- `public import Mathlib.Probability.ConditionalProbability` added to `Integral/Prod.lean` for the
  `μ[|s]` notation and `cond_isProbabilityMeasure`. This adds **no** dependency: that module was
  already in `Integral/Prod.lean`'s transitive import closure via
  `Mathlib.MeasureTheory.Integral.Prod`; the import only names what the file now uses directly. No
  import cycle — `Integral/Prod.lean`'s closure contains no `OptimalTransport` module.

### Chain risk, named up front

`placement` approved round 1 **because** the helper was private beside its only consumer, while
`api-design` required exactly the opposite. If `placement` now fires on the new location, that is
the same contradiction #5515 hit, and the answer is the same: it should be contested against
`api-design`'s request, not resolved by moving the lemma back.

## Note on local gates (unchanged)

Still no local build: the rig's shared Mathlib cache is missing 44 oleans after a build guard killed
a recompile, so `lake build` cannot gate this diff and CI is the gate. In place of a build, the new
names were checked by BFS over the import graph: `MeasureTheory.lintegral_le_const` and
`Mathlib.Probability.ConditionalProbability` are both in `Integral/Prod.lean`'s **all-`public`**
closure, `TauCeti.MeasureTheory.Integral.Prod` is in `Compact.lean`'s, and `ℝ≥0∞` / `μ[|s]` are
covered by the `open scoped ENNReal ProbabilityTheory` added alongside the file's existing
`open MeasureTheory`.


---

## Round 3 — all three findings applied, none contested

`api-design`, `reuse` and `placement` are green on this location, so the round-2 move settled those.
The remaining three are applied as directed:

- **generality** — `[IsFiniteMeasure μ] [IsFiniteMeasure ν]` were stronger than the proof needs;
  conditioning on `s` and `t` only requires *those two sets* to have finite measure. They become
  `μ s ≠ ∞` and `ν t ≠ ∞`, discharged with
  `ProbabilityTheory.cond_isProbabilityMeasure_of_finite`. The call site supplies them from
  `measure_ne_top`, so nothing is threaded through that was not already available there.
- **documentation** — the module-docstring entry narrated the proof (which lemmas it chains). It now
  states what the result is for: estimating an integral against two independently conditioned
  coordinates when the integrand is controlled only on the pair of sets conditioned on. The
  *theorem* docstring is unchanged, since the rubric assessed it as accurate.
- **proof-quality** — the call site transported the fibre equations with `show qX x = i from hx`,
  which relies silently on preimage/singleton membership reducing to equality. The equalities are
  now derived by name with `simpa only [Set.mem_preimage, Set.mem_singleton_iff]` and the rewrite
  uses those.

Gated locally before pushing: `lake build TauCeti.MeasureTheory.Integral.Prod
TauCeti.MeasureTheory.OptimalTransport.Duality.Compact` → exit 0, 3035 jobs, zero errors, zero
warnings, no Mathlib recompilation. All lines ≤ 100 characters.
