### PR TITLE
refactor: give IsPreconnected APIs dot notation

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -236,10 +236,9 @@ theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_
 
 /-- **An image side that meets the inside of such a curve lies inside it.** The side is
 preconnected as a continuous image of a preconnected set and disjoint from `K` by
-`TauCeti.disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image`,
-so `IsPreconnected.subset_filledHull`
-traps it in the bounded component of `Kᶜ` it meets. Instantiate `V` at `U ∩ ball ζ ρ` for the near
-side and at `U \ closedBall ζ ρ` for the far side. -/
+`TauCeti.disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image`, so
+`IsPreconnected.subset_filledHull` traps it in the bounded component of `Kᶜ` it meets. Instantiate
+`V` at `U ∩ ball ζ ρ` for the near side and at `U \ closedBall ζ ρ` for the far side. -/
 private theorem image_subset_filledHull_of_disjoint_inter_sphere {U V K : Set ℂ} (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hVU : V ⊆ U)
     (hV : Disjoint V (U ∩ sphere ζ ρ)) (hVc : IsPreconnected V)

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -237,7 +237,7 @@ theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_
 /-- **An image side that meets the inside of such a curve lies inside it.** The side is
 preconnected as a continuous image of a preconnected set and disjoint from `K` by
 `TauCeti.disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image`,
-so `TauCeti.IsPreconnected.subset_filledHull`
+so `IsPreconnected.subset_filledHull`
 traps it in the bounded component of `Kᶜ` it meets. Instantiate `V` at `U ∩ ball ζ ρ` for the near
 side and at `U \ closedBall ζ ρ` for the far side. -/
 private theorem image_subset_filledHull_of_disjoint_inter_sphere {U V K : Set ℂ} (hUo : IsOpen U)
@@ -245,7 +245,7 @@ private theorem image_subset_filledHull_of_disjoint_inter_sphere {U V K : Set �
     (hV : Disjoint V (U ∩ sphere ζ ρ)) (hVc : IsPreconnected V)
     (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U))
     (hne : (f '' V ∩ filledHull K).Nonempty) : f '' V ⊆ filledHull K :=
-  IsPreconnected.subset_filledHull (hVc.image f (hd.continuousOn.mono hVU))
+  (hVc.image f (hd.continuousOn.mono hVU)).subset_filledHull
     (disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
       hUo hd hinj hVU hV hK) hne
 

--- a/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
+++ b/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
@@ -94,7 +94,7 @@ every theorem added in layers L0–L6, everything below is stated for maps of `�
 that never mention a holomorphic map are stated at their own generality elsewhere, and consumed
 here: `TauCeti.frontier_image_subset_image_union_frontier_image` for maps between arbitrary
 topological spaces, `TauCeti.diam_le_diam_of_frontier_subset` — through `TauCeti.diam_frontier`
-and `TauCeti.IsPreconnected.inter_frontier_nonempty` — for an arbitrary real normed space, and
+and `IsPreconnected.inter_frontier_nonempty` — for an arbitrary real normed space, and
 `TauCeti.subsingleton_clusterSetOn_of_forall_exists` for a map between metric spaces. What
 remains here is exactly the conformal content: the open mapping theorem, and the reading of a
 circular cut as a crosscut.

--- a/TauCeti/Analysis/Normed/Module/DiamFrontier.lean
+++ b/TauCeti/Analysis/Normed/Module/DiamFrontier.lean
@@ -21,7 +21,7 @@ The mechanism is that a ray leaving a bounded set has to cross the frontier, and
 *later* than it passes through a given point of the set. Precisely
 (`TauCeti.exists_mem_frontier_dist_le`), for `x ∈ V` and any base point `y ≠ x` the ray
 `t ↦ y + t • (x - y)`, followed from `t = 1` outwards, eventually leaves the bounded set `V`, and
-the segment it traces is connected, so `TauCeti.IsPreconnected.inter_frontier_nonempty` produces a
+the segment it traces is connected, so `IsPreconnected.inter_frontier_nonempty` produces a
 frontier point `p = y + t • (x - y)` with `t ≥ 1`, whence `dist y p = t * dist y x ≥ dist y x`.
 
 Applying this twice turns a pair of points of `V` into a pair of frontier points at least as far
@@ -62,7 +62,7 @@ through a given point of the set.** For `x` in a bounded set `V` and any base po
 ray from `y` through `x` meets `frontier V` at a point `p` with `dist y x ≤ dist y p`.
 
 The ray is followed from `x` outwards. It leaves `V` because `V` is bounded, the segment traced is
-connected, and `TauCeti.IsPreconnected.inter_frontier_nonempty` therefore hands back a frontier
+connected, and `IsPreconnected.inter_frontier_nonempty` therefore hands back a frontier
 point on it; being beyond `x` on the ray, that point is at least as far from `y` as `x` is. -/
 theorem exists_mem_frontier_dist_le (hV : IsBounded V) (hx : x ∈ V) (hne : y ≠ x) :
     ∃ p ∈ frontier V, dist y x ≤ dist y p := by
@@ -90,7 +90,7 @@ theorem exists_mem_frontier_dist_le (hV : IsBounded V) (hx : x ∈ V) (hne : y �
   have hcont : Continuous γ := by fun_prop
   have hSconn : IsPreconnected (γ '' Icc 1 T) :=
     isPreconnected_Icc.image γ hcont.continuousOn
-  obtain ⟨p, hpS, hpf⟩ := IsPreconnected.inter_frontier_nonempty hSconn
+  obtain ⟨p, hpS, hpf⟩ := hSconn.inter_frontier_nonempty
     ⟨x, ⟨1, ⟨le_rfl, hT1⟩, hγ1⟩, hx⟩ ⟨γ T, ⟨T, ⟨hT1, le_rfl⟩, rfl⟩, hTV⟩
   obtain ⟨t, ht, rfl⟩ := hpS
   refine ⟨γ t, hpf, ?_⟩

--- a/TauCeti/Analysis/Normed/Module/FilledHull.lean
+++ b/TauCeti/Analysis/Normed/Module/FilledHull.lean
@@ -34,12 +34,11 @@ unhypothesised, because `filledHull ∅` is empty in a nontrivial space
 (`TauCeti.filledHull_empty`) and the single point of the zero space otherwise, of diameter `0`
 either way.
 
-Because the width of a filled hull is controlled, so is that of anything inside it. The form used
-below is `IsPreconnected.subset_filledHull`: a preconnected set disjoint from `K` is trapped inside
-the filled hull as soon as it meets it. Their composite,
+Because the width of a filled hull is controlled, so is that of anything inside it, and the shape
+in which this is spent is `IsPreconnected.subset_filledHull`: a preconnected set disjoint from `K`
+is trapped inside the filled hull as soon as it meets it. Their composite,
 `IsPreconnected.diam_le_diam_of_disjoint`, says that *a connected set that a small `K` cuts off
-from infinity is itself small*, with no regularity asked of `K`. The latter extends Mathlib's
-root-level `IsPreconnected` API so it can be invoked directly on the preconnectedness hypothesis.
+from infinity is itself small*, with no regularity asked of `K`.
 
 ## Roadmap role
 

--- a/TauCeti/Analysis/Normed/Module/FilledHull.lean
+++ b/TauCeti/Analysis/Normed/Module/FilledHull.lean
@@ -34,11 +34,12 @@ unhypothesised, because `filledHull ∅` is empty in a nontrivial space
 (`TauCeti.filledHull_empty`) and the single point of the zero space otherwise, of diameter `0`
 either way.
 
-Because the width of a filled hull is controlled, so is that of anything inside it, and the shape
-in which this is spent is `IsPreconnected.subset_filledHull`: a preconnected set disjoint
-from `K` is trapped inside the filled hull as soon as it meets it. Their composite,
-`IsPreconnected.diam_le_diam_of_disjoint`, says that *a connected set that a small `K` cuts
-off from infinity is itself small*, with no regularity asked of `K`.
+Because the width of a filled hull is controlled, so is that of anything inside it. The form used
+below is `IsPreconnected.subset_filledHull`: a preconnected set disjoint from `K` is trapped inside
+the filled hull as soon as it meets it. Their composite,
+`IsPreconnected.diam_le_diam_of_disjoint`, says that *a connected set that a small `K` cuts off
+from infinity is itself small*, with no regularity asked of `K`. The latter extends Mathlib's
+root-level `IsPreconnected` API so it can be invoked directly on the preconnectedness hypothesis.
 
 ## Roadmap role
 
@@ -206,8 +207,7 @@ theorem diam_le_diam_of_subset_filledHull (hK : IsBounded K) (h : S ⊆ filledHu
 preconnected, disjoint from `K`, and meets the filled hull of `K`, then it lies inside that hull by
 `IsPreconnected.subset_filledHull`, which is no wider than `K` by
 `TauCeti.diam_filledHull`. No regularity is asked of `K`. -/
-theorem _root_.IsPreconnected.diam_le_diam_of_disjoint (hS : IsPreconnected S)
-    (hSK : Disjoint S K)
+theorem _root_.IsPreconnected.diam_le_diam_of_disjoint (hS : IsPreconnected S) (hSK : Disjoint S K)
     (hne : (S ∩ filledHull K).Nonempty) (hK : IsBounded K) : diam S ≤ diam K :=
   diam_le_diam_of_subset_filledHull hK (hS.subset_filledHull hSK hne)
 

--- a/TauCeti/Analysis/Normed/Module/FilledHull.lean
+++ b/TauCeti/Analysis/Normed/Module/FilledHull.lean
@@ -35,9 +35,9 @@ unhypothesised, because `filledHull ∅` is empty in a nontrivial space
 either way.
 
 Because the width of a filled hull is controlled, so is that of anything inside it, and the shape
-in which this is spent is `TauCeti.IsPreconnected.subset_filledHull`: a preconnected set disjoint
+in which this is spent is `IsPreconnected.subset_filledHull`: a preconnected set disjoint
 from `K` is trapped inside the filled hull as soon as it meets it. Their composite,
-`TauCeti.IsPreconnected.diam_le_diam_of_disjoint`, says that *a connected set that a small `K` cuts
+`IsPreconnected.diam_le_diam_of_disjoint`, says that *a connected set that a small `K` cuts
 off from infinity is itself small*, with no regularity asked of `K`.
 
 ## Roadmap role
@@ -48,7 +48,7 @@ preconnectedness/winding-number route in `TauCeti/Analysis/Complex/Conformal/Cro
 places one image piece of a crosscut in the filled hull without plane separation. In the diameter
 bound that follows, `TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean` encloses a
 short image crosscut in an arbitrarily small Jordan curve `J`, and
-`TauCeti.IsPreconnected.diam_le_diam_of_disjoint` makes the cut-off piece no wider than `J`.
+`IsPreconnected.diam_le_diam_of_disjoint` makes the cut-off piece no wider than `J`.
 
 This is a different route to a diameter bound from `TauCeti.diam_le_diam_of_frontier_subset` of
 `TauCeti/Analysis/Normed/Module/DiamFrontier.lean`, which bounds a set by *any* bounded set
@@ -68,7 +68,7 @@ used, and the separation argument is the general Hahn–Banach one.
 * `TauCeti.diam_filledHull` and `TauCeti.isBounded_filledHull` — filling preserves the diameter, and
   a filled hull is bounded exactly when the set filled is.
 * `TauCeti.diam_le_diam_of_subset_filledHull` and
-  `TauCeti.IsPreconnected.diam_le_diam_of_disjoint` — a set inside the filled hull of a bounded `K`,
+  `IsPreconnected.diam_le_diam_of_disjoint` — a set inside the filled hull of a bounded `K`,
   in particular a preconnected set that `K` cuts off from infinity, is no wider than `K`.
 * `TauCeti.not_isBounded_halfSpace_lt` — an open half-space cut out by a nonzero continuous
   functional is unbounded, and `TauCeti.isBounded_closedConvexHull`,
@@ -204,11 +204,12 @@ theorem diam_le_diam_of_subset_filledHull (hK : IsBounded K) (h : S ⊆ filledHu
 
 /-- **A preconnected set that a bounded `K` cuts off from infinity is no wider than `K`.** If `S` is
 preconnected, disjoint from `K`, and meets the filled hull of `K`, then it lies inside that hull by
-`TauCeti.IsPreconnected.subset_filledHull`, which is no wider than `K` by
+`IsPreconnected.subset_filledHull`, which is no wider than `K` by
 `TauCeti.diam_filledHull`. No regularity is asked of `K`. -/
-theorem IsPreconnected.diam_le_diam_of_disjoint (hS : IsPreconnected S) (hSK : Disjoint S K)
+theorem _root_.IsPreconnected.diam_le_diam_of_disjoint (hS : IsPreconnected S)
+    (hSK : Disjoint S K)
     (hne : (S ∩ filledHull K).Nonempty) (hK : IsBounded K) : diam S ≤ diam K :=
-  diam_le_diam_of_subset_filledHull hK (IsPreconnected.subset_filledHull hS hSK hne)
+  diam_le_diam_of_subset_filledHull hK (hS.subset_filledHull hSK hne)
 
 variable {x y : E}
 

--- a/TauCeti/Topology/FilledHull.lean
+++ b/TauCeti/Topology/FilledHull.lean
@@ -23,11 +23,11 @@ topology and a bornology, being about components and boundedness and nothing els
 does not make a set wider needs a real normed space and lives in
 `TauCeti/Analysis/Normed/Module/FilledHull.lean`.
 
-The shape in which the structural side is spent is `TauCeti.IsPreconnected.subset_filledHull`: a
+The shape in which the structural side is spent is `IsPreconnected.subset_filledHull`: a
 preconnected set disjoint from `K` is trapped inside the filled hull as soon as it meets it, since
 it then lies in a single bounded component. Together with the width bound of the normed file it
 says that *a connected set that a small `K` cuts off from infinity is itself small*, with no
-regularity asked of `K`; that composite is `TauCeti.IsPreconnected.diam_le_diam_of_disjoint` there.
+regularity asked of `K`; that composite is `IsPreconnected.diam_le_diam_of_disjoint` there.
 
 The negation of membership — that the component of a point in the complement of `K` is *unbounded*
 — already occurs, unfolded, in the winding-number layer: it is the hypothesis of
@@ -59,7 +59,7 @@ separation, or any other regularity of `K`.
   `TauCeti.filledHull_mono` its two structural properties.
 * `TauCeti.filledHull_eq_self` — filling a set whose complement is preconnected and unbounded
   changes nothing.
-* `TauCeti.IsPreconnected.subset_filledHull` — a preconnected set disjoint from `K` that meets the
+* `IsPreconnected.subset_filledHull` — a preconnected set disjoint from `K` that meets the
   filled hull lies in it.
 * `TauCeti.subset_filledHull_of_frontier_subset` — a bounded set whose frontier `K` swallows
   lies in the filled hull, with no connectivity asked of it.
@@ -107,7 +107,7 @@ theorem filledHull_eq_self (h : IsPreconnected Kᶜ) (hu : ¬ IsBounded Kᶜ) : 
 /-- **A preconnected set that a set cuts off from infinity lies in its filled hull.** If `S` is
 preconnected and disjoint from `K`, then `S` lies in a single connected component of `Kᶜ`; meeting
 the filled hull says that component is bounded, so all of `S` is in the hull. -/
-theorem IsPreconnected.subset_filledHull (hS : IsPreconnected S) (hSK : Disjoint S K)
+theorem _root_.IsPreconnected.subset_filledHull (hS : IsPreconnected S) (hSK : Disjoint S K)
     (hne : (S ∩ filledHull K).Nonempty) : S ⊆ filledHull K := by
   obtain ⟨x, hxS, hxH⟩ := hne
   have hScompl : S ⊆ Kᶜ := fun y hy => Set.disjoint_left.mp hSK hy
@@ -119,14 +119,14 @@ theorem IsPreconnected.subset_filledHull (hS : IsPreconnected S) (hSK : Disjoint
 /-- **A bounded set whose frontier lies in `K` is cut off from infinity by `K`.** A point of
 `S \ K` lies in `interior S`, since every non-interior point of `S` lies on `frontier S ⊆ K`. Its
 connected component in `Kᶜ` cannot leave `interior S`: were it to, it would meet
-`frontier (interior S) ⊆ frontier S ⊆ K` by `TauCeti.IsPreconnected.inter_frontier_nonempty`,
+`frontier (interior S) ⊆ frontier S ⊆ K` by `IsPreconnected.inter_frontier_nonempty`,
 while lying in `Kᶜ`. So that component is bounded because `S` is. Points of `S ∩ K` lie in the
 filled hull directly.
 
-Unlike `TauCeti.IsPreconnected.subset_filledHull` this asks nothing of the connectivity of `S` and
+Unlike `IsPreconnected.subset_filledHull` this asks nothing of the connectivity of `S` and
 nothing about the hull being met, at the price of asking `K` to swallow the whole frontier — the
 same trade as between `TauCeti.diam_le_diam_of_frontier_subset` and
-`TauCeti.IsPreconnected.diam_le_diam_of_disjoint`. -/
+`IsPreconnected.diam_le_diam_of_disjoint`. -/
 theorem subset_filledHull_of_frontier_subset (hSb : IsBounded S) (hfr : frontier S ⊆ K) :
     S ⊆ filledHull K := by
   intro x hx
@@ -137,8 +137,8 @@ theorem subset_filledHull_of_frontier_subset (hSb : IsBounded S) (hfr : frontier
   have hcomp : connectedComponentIn Kᶜ x ⊆ interior S := by
     by_contra h
     obtain ⟨y, hy, hyi⟩ := not_subset.mp h
-    obtain ⟨z, hz, hzf⟩ := IsPreconnected.inter_frontier_nonempty
-      isPreconnected_connectedComponentIn ⟨x, mem_connectedComponentIn hxKc, hxi⟩ ⟨y, hy, hyi⟩
+    obtain ⟨z, hz, hzf⟩ := isPreconnected_connectedComponentIn.inter_frontier_nonempty
+      ⟨x, mem_connectedComponentIn hxKc, hxi⟩ ⟨y, hy, hyi⟩
     exact connectedComponentIn_subset _ _ hz (hfr (frontier_interior_subset hzf))
   exact mem_filledHull_iff.mpr (hSb.subset (hcomp.trans interior_subset))
 

--- a/TauCeti/Topology/FilledHull.lean
+++ b/TauCeti/Topology/FilledHull.lean
@@ -25,11 +25,9 @@ does not make a set wider needs a real normed space and lives in
 
 The shape in which the structural side is spent is `IsPreconnected.subset_filledHull`: a
 preconnected set disjoint from `K` is trapped inside the filled hull as soon as it meets it, since
-it then lies in a single bounded component. This theorem extends Mathlib's root-level
-`IsPreconnected` API so that it can be invoked directly on the preconnectedness hypothesis.
-Together with the width bound of the normed file it says that *a connected set that a small `K`
-cuts off from infinity is itself small*, with no regularity asked of `K`; that composite is
-`IsPreconnected.diam_le_diam_of_disjoint` there.
+it then lies in a single bounded component. Together with the width bound of the normed file it
+says that *a connected set that a small `K` cuts off from infinity is itself small*, with no
+regularity asked of `K`; that composite is `IsPreconnected.diam_le_diam_of_disjoint` there.
 
 The negation of membership — that the component of a point in the complement of `K` is *unbounded*
 — already occurs, unfolded, in the winding-number layer: it is the hypothesis of

--- a/TauCeti/Topology/FilledHull.lean
+++ b/TauCeti/Topology/FilledHull.lean
@@ -25,9 +25,11 @@ does not make a set wider needs a real normed space and lives in
 
 The shape in which the structural side is spent is `IsPreconnected.subset_filledHull`: a
 preconnected set disjoint from `K` is trapped inside the filled hull as soon as it meets it, since
-it then lies in a single bounded component. Together with the width bound of the normed file it
-says that *a connected set that a small `K` cuts off from infinity is itself small*, with no
-regularity asked of `K`; that composite is `IsPreconnected.diam_le_diam_of_disjoint` there.
+it then lies in a single bounded component. This theorem extends Mathlib's root-level
+`IsPreconnected` API so that it can be invoked directly on the preconnectedness hypothesis.
+Together with the width bound of the normed file it says that *a connected set that a small `K`
+cuts off from infinity is itself small*, with no regularity asked of `K`; that composite is
+`IsPreconnected.diam_le_diam_of_disjoint` there.
 
 The negation of membership — that the component of a point in the complement of `K` is *unbounded*
 — already occurs, unfolded, in the winding-number layer: it is the hypothesis of

--- a/TauCeti/Topology/Frontier.lean
+++ b/TauCeti/Topology/Frontier.lean
@@ -78,9 +78,6 @@ side of such a crosscut cuts off, whose description as a union of cluster sets i
 statement about a closure. Nothing here is specific to those uses; no lemma mentions a metric, let
 alone a holomorphic map.
 
-`IsPreconnected.inter_frontier_nonempty` extends Mathlib's root-level `IsPreconnected` API, so it
-is declared there and can be invoked directly on a preconnectedness hypothesis.
-
 ## Main results
 
 * `IsPreconnected.inter_frontier_nonempty` — a preconnected set meeting both a set and its

--- a/TauCeti/Topology/Frontier.lean
+++ b/TauCeti/Topology/Frontier.lean
@@ -78,6 +78,9 @@ side of such a crosscut cuts off, whose description as a union of cluster sets i
 statement about a closure. Nothing here is specific to those uses; no lemma mentions a metric, let
 alone a holomorphic map.
 
+`IsPreconnected.inter_frontier_nonempty` extends Mathlib's root-level `IsPreconnected` API, so it
+is declared there and can be invoked directly on a preconnectedness hypothesis.
+
 ## Main results
 
 * `IsPreconnected.inter_frontier_nonempty` — a preconnected set meeting both a set and its
@@ -106,8 +109,7 @@ Nothing is assumed about `V`; the argument is that `(frontier V)ᶜ` is the unio
 open sets `interior V` and `interior Vᶜ`, so a preconnected set missing the frontier is confined to
 one of them and therefore cannot straddle `V`. -/
 theorem _root_.IsPreconnected.inter_frontier_nonempty (hS : IsPreconnected S)
-    (h₁ : (S ∩ V).Nonempty)
-    (h₂ : (S \ V).Nonempty) : (S ∩ frontier V).Nonempty := by
+    (h₁ : (S ∩ V).Nonempty) (h₂ : (S \ V).Nonempty) : (S ∩ frontier V).Nonempty := by
   by_contra hcon
   have hsub : S ⊆ interior V ∪ interior Vᶜ := by
     rw [← compl_frontier_eq_union_interior]

--- a/TauCeti/Topology/Frontier.lean
+++ b/TauCeti/Topology/Frontier.lean
@@ -80,7 +80,7 @@ alone a holomorphic map.
 
 ## Main results
 
-* `TauCeti.IsPreconnected.inter_frontier_nonempty` — a preconnected set meeting both a set and its
+* `IsPreconnected.inter_frontier_nonempty` — a preconnected set meeting both a set and its
   complement meets the frontier of that set.
 * `TauCeti.frontier_image_subset_image_union_frontier_image` — for a set split into two sides with
   disjoint open images plus a remainder, the frontier of the image of the side lying in that set
@@ -105,7 +105,8 @@ preconnected and contains a point of `V` and a point outside `V`, then `S` meets
 Nothing is assumed about `V`; the argument is that `(frontier V)ᶜ` is the union of the two disjoint
 open sets `interior V` and `interior Vᶜ`, so a preconnected set missing the frontier is confined to
 one of them and therefore cannot straddle `V`. -/
-theorem IsPreconnected.inter_frontier_nonempty (hS : IsPreconnected S) (h₁ : (S ∩ V).Nonempty)
+theorem _root_.IsPreconnected.inter_frontier_nonempty (hS : IsPreconnected S)
+    (h₁ : (S ∩ V).Nonempty)
     (h₂ : (S \ V).Nonempty) : (S ∩ frontier V).Nonempty := by
   by_contra hcon
   have hsub : S ⊆ interior V ∪ interior Vᶜ := by


### PR DESCRIPTION
This PR moves three receiver-style theorems from `TauCeti.IsPreconnected` into Mathlib's root-level `IsPreconnected` namespace, updates every in-repository reference, and converts all call sites to receiver notation. The full local build and focused post-review builds pass, and the namespace lint removes three findings with zero new ones. This is one slice of #3547.

Roadmap: none

🤖 Prepared with Claude Code
