### PR TITLE
refactor: give CategoryTheory APIs dot notation

### DIFF
--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -123,7 +123,8 @@ lemma cohomologyOnRes_comp (n : ℕ) {U V W : Opens X} (hUV : U ≤ V) (hVW : V 
 /-- The cohomology of the whole space is the cohomology of the scheme. -/
 noncomputable abbrev cohomologyOnTopIso (n : ℕ) :
     cohomologyOn M n ⊤ ≅ AddCommGrpCat.of (Cohomology M n) :=
-  CategoryTheory.Sheaf.cohomologyPresheafObjIsoH n isTerminalTop _
+  ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M).cohomologyPresheafObjIsoH
+    n isTerminalTop
 
 end Opens
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -123,7 +123,7 @@ lemma cohomologyOnRes_comp (n : ℕ) {U V W : Opens X} (hUV : U ≤ V) (hVW : V 
 /-- The cohomology of the whole space is the cohomology of the scheme. -/
 noncomputable abbrev cohomologyOnTopIso (n : ℕ) :
     cohomologyOn M n ⊤ ≅ AddCommGrpCat.of (Cohomology M n) :=
-  TauCeti.CategoryTheory.Sheaf.cohomologyPresheafObjIsoH n isTerminalTop _
+  CategoryTheory.Sheaf.cohomologyPresheafObjIsoH n isTerminalTop _
 
 end Opens
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -116,8 +116,7 @@ theorem epi_mayerVietorisδ (n : ℕ)
     (hU : Subsingleton (cohomologyOn M (n + 1) U))
     (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
     Epi (mayerVietorisδ M U V n (n + 1) rfl) :=
-  TauCeti.CategoryTheory.GrothendieckTopology.MayerVietorisSquare.epi_δ
-    (Opens.mayerVietorisSquare U V)
+  (Opens.mayerVietorisSquare U V).epi_δ
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n (n + 1) rfl hU hV
 
 variable {U V}
@@ -129,8 +128,7 @@ theorem subsingleton_cohomologyOn_sup_succ (n : ℕ)
     (hU : Subsingleton (cohomologyOn M (n + 1) U))
     (hV : Subsingleton (cohomologyOn M (n + 1) V)) :
     Subsingleton (cohomologyOn M (n + 1) (U ⊔ V)) :=
-  TauCeti.CategoryTheory.GrothendieckTopology.MayerVietorisSquare.subsingleton_H'_X₄
-    (Opens.mayerVietorisSquare U V)
+  (Opens.mayerVietorisSquare U V).subsingleton_H'_X₄
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) n (n + 1) rfl hInter hU hV
 
 /-- A scheme covered by two open subsets whose degree `n + 1` cohomology vanishes, and whose

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/MayerVietoris.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/MayerVietoris.lean
@@ -10,12 +10,19 @@ public import Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris
 /-!
 # Vanishing consequences of the Mayer-Vietoris sequence
 
-This file records general consequences of Mathlib's Mayer-Vietoris sequence for sheaf
-cohomology. They are used for the scheme-cohomology vanishing results required by
-`TauCetiRoadmap/JacobianChallenge/README.md`, Layer B.
+For a Mayer-Vietoris square `S` in a site, where `S.X₄` is covered by `S.X₂` and `S.X₃`
+meeting in `S.X₁`, Mathlib provides a long exact sequence relating the cohomology of an abelian
+sheaf `F` on those four objects. This file records the two consequences that a vanishing
+argument needs:
 
-The results extend Mathlib's root-level `CategoryTheory.GrothendieckTopology.MayerVietorisSquare`
-API, so they are declared there and can be invoked directly on a Mayer-Vietoris square.
+* `epi_δ`: the connecting map `Hⁿ⁰(S.X₁) ⟶ Hⁿ¹(S.X₄)` is an epimorphism as soon as the degree
+  `n₁` cohomology of `F` vanishes on `S.X₂` and on `S.X₃`;
+* `subsingleton_H'_X₄`: if in addition the degree `n₀` cohomology of `F` vanishes on `S.X₁`,
+  then its degree `n₁` cohomology vanishes on `S.X₄`.
+
+So the cohomology of a covered object vanishes once it vanishes on the covering objects and on
+their intersection one degree lower; this is the form in which Mayer-Vietoris is applied to a
+scheme covered by two open subsets.
 -/
 
 public section

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/MayerVietoris.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/MayerVietoris.lean
@@ -22,8 +22,6 @@ public section
 
 open CategoryTheory Limits
 
-namespace TauCeti
-
 namespace CategoryTheory.GrothendieckTopology.MayerVietorisSquare
 
 universe w v u
@@ -36,8 +34,7 @@ variable (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
 
 /-- If the cohomology of the two side objects vanishes in degree `n₁`, then the connecting map
 from degree `n₀` to degree `n₁` is an epimorphism. -/
-theorem _root_.CategoryTheory.GrothendieckTopology.MayerVietorisSquare.epi_δ
-    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+theorem epi_δ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
     (h₂ : Subsingleton (F.H' n₁ S.X₂)) (h₃ : Subsingleton (F.H' n₁ S.X₃)) :
     Epi (S.δ F n₀ n₁ h) := by
   have hg : S.toBiprod F n₁ = 0 :=
@@ -49,8 +46,7 @@ theorem _root_.CategoryTheory.GrothendieckTopology.MayerVietorisSquare.epi_δ
 
 /-- If the lower-left and the two side cohomology groups in consecutive degrees vanish, then the
 upper-right cohomology group vanishes. -/
-theorem _root_.CategoryTheory.GrothendieckTopology.MayerVietorisSquare.subsingleton_H'_X₄
-    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+theorem subsingleton_H'_X₄ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
     (h₁ : Subsingleton (F.H' n₀ S.X₁))
     (h₂ : Subsingleton (F.H' n₁ S.X₂)) (h₃ : Subsingleton (F.H' n₁ S.X₃)) :
     Subsingleton (F.H' n₁ S.X₄) := by
@@ -59,5 +55,3 @@ theorem _root_.CategoryTheory.GrothendieckTopology.MayerVietorisSquare.subsingle
   exact hsurj.subsingleton
 
 end CategoryTheory.GrothendieckTopology.MayerVietorisSquare
-
-end TauCeti

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/MayerVietoris.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/MayerVietoris.lean
@@ -13,6 +13,9 @@ public import Mathlib.CategoryTheory.Sites.SheafCohomology.MayerVietoris
 This file records general consequences of Mathlib's Mayer-Vietoris sequence for sheaf
 cohomology. They are used for the scheme-cohomology vanishing results required by
 `TauCetiRoadmap/JacobianChallenge/README.md`, Layer B.
+
+The results extend Mathlib's root-level `CategoryTheory.GrothendieckTopology.MayerVietorisSquare`
+API, so they are declared there and can be invoked directly on a Mayer-Vietoris square.
 -/
 
 public section
@@ -33,7 +36,8 @@ variable (S : J.MayerVietorisSquare) (F : Sheaf J AddCommGrpCat.{v})
 
 /-- If the cohomology of the two side objects vanishes in degree `n₁`, then the connecting map
 from degree `n₀` to degree `n₁` is an epimorphism. -/
-theorem epi_δ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+theorem _root_.CategoryTheory.GrothendieckTopology.MayerVietorisSquare.epi_δ
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
     (h₂ : Subsingleton (F.H' n₁ S.X₂)) (h₃ : Subsingleton (F.H' n₁ S.X₃)) :
     Epi (S.δ F n₀ n₁ h) := by
   have hg : S.toBiprod F n₁ = 0 :=
@@ -45,12 +49,13 @@ theorem epi_δ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
 
 /-- If the lower-left and the two side cohomology groups in consecutive degrees vanish, then the
 upper-right cohomology group vanishes. -/
-theorem subsingleton_H'_X₄ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+theorem _root_.CategoryTheory.GrothendieckTopology.MayerVietorisSquare.subsingleton_H'_X₄
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
     (h₁ : Subsingleton (F.H' n₀ S.X₁))
     (h₂ : Subsingleton (F.H' n₁ S.X₂)) (h₃ : Subsingleton (F.H' n₁ S.X₃)) :
     Subsingleton (F.H' n₁ S.X₄) := by
   have hsurj : Function.Surjective (S.δ F n₀ n₁ h) :=
-    (AddCommGrpCat.epi_iff_surjective _).mp (epi_δ S F n₀ n₁ h h₂ h₃)
+    (AddCommGrpCat.epi_iff_surjective _).mp (S.epi_δ F n₀ n₁ h h₂ h₃)
   exact hsurj.subsingleton
 
 end CategoryTheory.GrothendieckTopology.MayerVietorisSquare

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
@@ -28,18 +28,6 @@ in terms of `Sheaf.H'`, so the comparison is what lets a covering of the whole s
   `Hⁿ(T, F) ≅ Hⁿ(F)` at a terminal object `T`, as an isomorphism of abelian groups;
 * `TauCeti.CategoryTheory.Sheaf.cohomologyPresheafEvaluationIsoFunctorH`: the same comparison as a
   natural isomorphism in the coefficient sheaf.
-
-This settles the first item of the `## TODO` list of
-`Mathlib/CategoryTheory/Sites/SheafCohomology/Basic.lean`. It is used in
-`TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean` to obtain the Mayer-Vietoris sequence
-for the cohomology of a scheme, which is Layer B infrastructure for
-`TauCetiRoadmap/JacobianChallenge/README.md`. No formalization is vendored: the ingredients are
-Mathlib's `CategoryTheory.Limits.IsTerminal.isTerminalObj`, `FreeAbelianGroup.uniqueEquiv`,
-`CategoryTheory.Functor.constComp` and `CategoryTheory.Abelian.extFunctor`.
-
-The object-level comparison extends Mathlib's root-level `CategoryTheory.Sheaf` API. The
-functor-level construction remains in `TauCeti.CategoryTheory.Sheaf`: it takes no explicit sheaf
-argument, so moving it would not enable dot notation.
 -/
 
 public section

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
@@ -24,10 +24,10 @@ in terms of `Sheaf.H'`, so the comparison is what lets a covering of the whole s
 
 ## Main declarations
 
-* `CategoryTheory.Sheaf.cohomologyPresheafObjIsoH`: the comparison
-  `Hⁿ(T, F) ≅ Hⁿ(F)` at a terminal object `T`, as an isomorphism of abelian groups;
-* `TauCeti.CategoryTheory.Sheaf.cohomologyPresheafEvaluationIsoFunctorH`: the same comparison as a
-  natural isomorphism in the coefficient sheaf.
+* `CategoryTheory.Sheaf.cohomologyPresheafEvaluationIsoFunctorH`: the comparison as a natural
+  isomorphism in the coefficient sheaf;
+* `CategoryTheory.Sheaf.cohomologyPresheafObjIsoH`: its specialization
+  `Hⁿ(T, F) ≅ Hⁿ(F)` at a terminal object `T`, as an isomorphism of abelian groups.
 -/
 
 public section
@@ -70,8 +70,6 @@ end
 
 noncomputable section
 
-namespace Sheaf
-
 variable [HasSheafify J AddCommGrpCat.{v}] [HasExt.{w} (Sheaf J AddCommGrpCat.{v})]
 
 -- Mathlib's `functorH` and `extFunctorObj` use definitionally equal object and map data.
@@ -86,28 +84,31 @@ private noncomputable def functorHIso (n : ℕ) :
       ext
       rfl)
 
-variable (J) in
-/-- At a terminal object `T`, the cohomology presheaf evaluated at `T` is the cohomology of the
-site, naturally in the coefficient sheaf. -/
-def cohomologyPresheafEvaluationIsoFunctorH (n : ℕ) {T : C} (hT : IsTerminal T) :
-    _root_.CategoryTheory.Sheaf.cohomologyPresheafFunctor J n ⋙
-        (evaluation Cᵒᵖ AddCommGrpCat.{w}).obj (op T) ≅
-      _root_.CategoryTheory.Sheaf.functorH J n :=
-  (_root_.CategoryTheory.Abelian.extFunctor n).mapIso
-      (freeYonedaSheafIsoConstantSheaf hT).symm.op ≪≫
-    functorHIso n
-
-/-- At a terminal object, the cohomology of the object is the cohomology of the site. -/
-noncomputable abbrev _root_.CategoryTheory.Sheaf.cohomologyPresheafObjIsoH
-    (F : Sheaf J AddCommGrpCat.{v}) (n : ℕ) {T : C} (hT : IsTerminal T) :
-    _root_.CategoryTheory.Sheaf.H' F n T ≅
-      AddCommGrpCat.of (_root_.CategoryTheory.Sheaf.H F n) :=
-  (cohomologyPresheafEvaluationIsoFunctorH J n hT).app F
-
-end Sheaf
-
 end
 
 end CategoryTheory
 
 end TauCeti
+
+namespace CategoryTheory.Sheaf
+
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+  [HasSheafify J AddCommGrpCat.{v}] [HasExt.{w} (Sheaf J AddCommGrpCat.{v})]
+
+variable (J) in
+/-- At a terminal object `T`, the cohomology presheaf evaluated at `T` is the cohomology of the
+site, naturally in the coefficient sheaf. -/
+noncomputable def cohomologyPresheafEvaluationIsoFunctorH (n : ℕ) {T : C} (hT : IsTerminal T) :
+    cohomologyPresheafFunctor J n ⋙ (evaluation Cᵒᵖ AddCommGrpCat.{w}).obj (op T) ≅
+      functorH J n :=
+  (Abelian.extFunctor n).mapIso
+      (TauCeti.CategoryTheory.freeYonedaSheafIsoConstantSheaf hT).symm.op ≪≫
+    TauCeti.CategoryTheory.functorHIso n
+
+/-- At a terminal object, the cohomology of the object is the cohomology of the site. -/
+noncomputable abbrev cohomologyPresheafObjIsoH (F : Sheaf J AddCommGrpCat.{v}) (n : ℕ)
+    {T : C} (hT : IsTerminal T) :
+    H' F n T ≅ AddCommGrpCat.of (H F n) :=
+  (cohomologyPresheafEvaluationIsoFunctorH J n hT).app F
+
+end CategoryTheory.Sheaf

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
@@ -37,9 +37,9 @@ for the cohomology of a scheme, which is Layer B infrastructure for
 Mathlib's `CategoryTheory.Limits.IsTerminal.isTerminalObj`, `FreeAbelianGroup.uniqueEquiv`,
 `CategoryTheory.Functor.constComp` and `CategoryTheory.Abelian.extFunctor`.
 
-The object-level comparison extends Mathlib's root-level `CategoryTheory.Sheaf` API; the
-functor-level construction remains in `TauCeti.CategoryTheory.Sheaf` because it is not attached to
-a particular sheaf.
+The object-level comparison extends Mathlib's root-level `CategoryTheory.Sheaf` API. The
+functor-level construction remains in `TauCeti.CategoryTheory.Sheaf`: it takes no explicit sheaf
+argument, so moving it would not enable dot notation.
 -/
 
 public section
@@ -109,11 +109,9 @@ def cohomologyPresheafEvaluationIsoFunctorH (n : ℕ) {T : C} (hT : IsTerminal T
       (freeYonedaSheafIsoConstantSheaf hT).symm.op ≪≫
     functorHIso n
 
-variable (n : ℕ) {T : C} (hT : IsTerminal T)
-
 /-- At a terminal object, the cohomology of the object is the cohomology of the site. -/
 noncomputable abbrev _root_.CategoryTheory.Sheaf.cohomologyPresheafObjIsoH
-    (F : Sheaf J AddCommGrpCat.{v}) :
+    (F : Sheaf J AddCommGrpCat.{v}) (n : ℕ) {T : C} (hT : IsTerminal T) :
     _root_.CategoryTheory.Sheaf.H' F n T ≅
       AddCommGrpCat.of (_root_.CategoryTheory.Sheaf.H F n) :=
   (cohomologyPresheafEvaluationIsoFunctorH J n hT).app F

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
@@ -24,7 +24,7 @@ in terms of `Sheaf.H'`, so the comparison is what lets a covering of the whole s
 
 ## Main declarations
 
-* `TauCeti.CategoryTheory.Sheaf.cohomologyPresheafObjIsoH`: the comparison
+* `CategoryTheory.Sheaf.cohomologyPresheafObjIsoH`: the comparison
   `Hⁿ(T, F) ≅ Hⁿ(F)` at a terminal object `T`, as an isomorphism of abelian groups;
 * `TauCeti.CategoryTheory.Sheaf.cohomologyPresheafEvaluationIsoFunctorH`: the same comparison as a
   natural isomorphism in the coefficient sheaf.
@@ -36,6 +36,10 @@ for the cohomology of a scheme, which is Layer B infrastructure for
 `TauCetiRoadmap/JacobianChallenge/README.md`. No formalization is vendored: the ingredients are
 Mathlib's `CategoryTheory.Limits.IsTerminal.isTerminalObj`, `FreeAbelianGroup.uniqueEquiv`,
 `CategoryTheory.Functor.constComp` and `CategoryTheory.Abelian.extFunctor`.
+
+The object-level comparison extends Mathlib's root-level `CategoryTheory.Sheaf` API; the
+functor-level construction remains in `TauCeti.CategoryTheory.Sheaf` because it is not attached to
+a particular sheaf.
 -/
 
 public section
@@ -108,7 +112,8 @@ def cohomologyPresheafEvaluationIsoFunctorH (n : ℕ) {T : C} (hT : IsTerminal T
 variable (n : ℕ) {T : C} (hT : IsTerminal T)
 
 /-- At a terminal object, the cohomology of the object is the cohomology of the site. -/
-noncomputable abbrev cohomologyPresheafObjIsoH (F : Sheaf J AddCommGrpCat.{v}) :
+noncomputable abbrev _root_.CategoryTheory.Sheaf.cohomologyPresheafObjIsoH
+    (F : Sheaf J AddCommGrpCat.{v}) :
     _root_.CategoryTheory.Sheaf.H' F n T ≅
       AddCommGrpCat.of (_root_.CategoryTheory.Sheaf.H F n) :=
   (cohomologyPresheafEvaluationIsoFunctorH J n hT).app F

--- a/TauCeti/Topology/Sheaves/Flasque.lean
+++ b/TauCeti/Topology/Sheaves/Flasque.lean
@@ -160,7 +160,7 @@ instance subsingleton_H_succ_of_isFlasque
   have := subsingleton_H'_succ_of_isFlasque F n (⊤ : Opens X)
   exact Function.Injective.subsingleton
     (f := ConcreteCategory.hom
-      (TauCeti.CategoryTheory.Sheaf.cohomologyPresheafObjIsoH (n + 1) isTerminalTop F).inv)
+      (CategoryTheory.Sheaf.cohomologyPresheafObjIsoH (n + 1) isTerminalTop F).inv)
     ((ConcreteCategory.bijective_of_isIso _).injective)
 
 /-- A skyscraper sheaf of abelian groups is flasque. -/

--- a/TauCeti/Topology/Sheaves/Flasque.lean
+++ b/TauCeti/Topology/Sheaves/Flasque.lean
@@ -160,7 +160,7 @@ instance subsingleton_H_succ_of_isFlasque
   have := subsingleton_H'_succ_of_isFlasque F n (⊤ : Opens X)
   exact Function.Injective.subsingleton
     (f := ConcreteCategory.hom
-      (CategoryTheory.Sheaf.cohomologyPresheafObjIsoH (n + 1) isTerminalTop F).inv)
+      (F.cohomologyPresheafObjIsoH (n + 1) isTerminalTop).inv)
     ((ConcreteCategory.bijective_of_isIso _).injective)
 
 /-- A skyscraper sheaf of abelian groups is flasque. -/


### PR DESCRIPTION
This PR moves three sheaf-cohomology declarations from `TauCeti.CategoryTheory` into Mathlib’s root-level `CategoryTheory` namespaces, updates every in-repository reference, and converts the Mayer–Vietoris call sites to receiver notation. The module documentation explains the resulting API placement. The full local build and focused post-rebase builds pass, and the namespace lint removes three findings with zero new ones. This is one slice of #3547.

Roadmap: JacobianChallenge

:robot: Prepared with OpenAI Codex
