### PR TITLE
fix: give the sweep pull-requests write, which commenting needs

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -73,8 +73,11 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: TauCetiProject
           repositories: TauCeti
-          permission-issues: write        # the label and the one-off comment
-          permission-pull-requests: read  # open PRs and their mergeability
+          permission-issues: write         # the label, and creating it on first use
+          # WRITE, not read: commenting on a pull request is governed by the pull
+          # requests permission, not issues, even though the endpoint is
+          # /issues/N/comments. With read this failed 403 on every comment.
+          permission-pull-requests: write
       # The trusted base checkout: never PR head code, like every other sink here.
       # `ref` is explicit because workflow_dispatch otherwise checks out the ref it
       # was dispatched from -- which would run a branch's copy of this script with

--- a/scripts/pr_status/conflicts.py
+++ b/scripts/pr_status/conflicts.py
@@ -116,7 +116,11 @@ def log(message):
 def _gh(args):
     result = subprocess.run(["gh", *args], capture_output=True, text=True)
     if result.returncode != 0:
-        raise RuntimeError(f"gh {' '.join(args)} failed: {result.stderr.strip()}")
+        # Summarise the command rather than echoing it: a failing comment would
+        # otherwise reprint the whole comment body into the log, once per PR.
+        shown = " ".join(a.split("=", 1)[0] if a.startswith("-f") or "=" in a else a
+                         for a in args)
+        raise RuntimeError(f"gh {shown} failed: {result.stderr.strip()}")
     return result.stdout
 
 


### PR DESCRIPTION
This PR gives the conflict sweep the `pull-requests: write` permission that commenting on a PR requires. It fixes the first real run of #2033, which failed 403 on every comment.

Roadmap: none

Commenting on a pull request is governed by the **pull requests** permission, not issues, even though the endpoint is `/issues/N/comments`. The evidence is already in this repo: `pr-labels.yml` labels PRs happily with `issues: write` and `pull-requests: read`, while `housekeeping.py`, which comments, runs under a token that requests no scoped permissions at all and so receives the App's full set. The sweep asked for `pull-requests: read` and got `Resource not accessible by integration (HTTP 403)` on every comment.

Nothing was published and no PR was left half-done. The sweep writes the comment *before* the label precisely so that a failed notification leaves no state claiming the author was told; every comment failed, so no label followed, and the next run retries from a clean state. That ordering was argued for on the grounds that losing a notification is worse than repeating one, and this is the case it was for.

Also stops a failing comment reprinting its entire body into the log once per PR, which made the failed run's output almost unreadable.

🤖 Prepared with Claude Code
