### PR TITLE
docs: remove FieldTheory roadmap narrative

### DIFF
--- a/TauCeti/FieldTheory/Finite/Frobenius.lean
+++ b/TauCeti/FieldTheory/Finite/Frobenius.lean
@@ -20,13 +20,12 @@ of the `q`-power endomorphism of `L` is a subfield over which `L` is purely inse
 * `TauCeti.FiniteField.isPurelyInseparable_fieldRange_frobeniusAlgHom`: `L` is purely
   inseparable over the field range of `FiniteField.frobeniusAlgHom K L`.
 
-## Roadmap
+## Mathematical context
 
-This is the field-theoretic input to the Frobenius isogeny in Layer 1 of
-`TauCetiRoadmap/EllipticCurves/README.md`, which requires `π_q` to be purely inseparable of degree
-`q`. Stating it before specializing to a curve keeps the argument independent of the particular
-function field, just as the degree computation first identifies the field range of the same
-`q`-power map.
+This is the field-theoretic input to proving that the Frobenius isogeny `π_q` is purely inseparable
+of degree `q`. Stating it before specializing to a curve keeps the argument independent of the
+particular function field, just as the degree computation first identifies the field range of the
+same `q`-power map.
 
 ## References
 

--- a/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
+++ b/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
@@ -29,18 +29,13 @@ rather than the single `q`-power map.
 Nothing is assumed of `L` beyond being a field extension: in particular it need not be
 algebraically closed, which is the only case the source states.
 
-This belongs to the **Hasse-bound strand** of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 3
-("elliptic curves over finite fields"). That roadmap's §Ordering splits the layer: "the Hasse bound
-is the earliest PR, its existing proof self-contained; the zeta strand needs Layer 1's Frobenius
-identities". This is the self-contained side — the elementary field-theoretic input to the
-Silverman V.1 route, saying that the `K`-rational coordinates are exactly the Frobenius-fixed ones.
-In the roadmap's pinned Hasse provenance the corresponding file sits inside the import closure of
-the capstone `hasse_bound` proof, not in the zeta material.
+This is the elementary field-theoretic input to the Silverman V.1 route to the Hasse bound: it says
+that the `K`-rational coordinates are exactly the Frobenius-fixed ones.
 
 ## Provenance
 
-Ported from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by
-that roadmap at `dev/hasse-weil @ 513e83879e2f`),
+Ported from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
+`dev/hasse-weil @ 513e83879e2f`),
 `HasseWeil/Curves/FrobeniusFixedLocus.lean`, declaration `frobenius_fixed_iff_mem_baseField`.
 
 Changes from the source. It is stated there only for `L = AlgebraicClosure K`; here `L` is an

--- a/TauCeti/FieldTheory/Finite/SepClosedSubfield.lean
+++ b/TauCeti/FieldTheory/Finite/SepClosedSubfield.lean
@@ -40,11 +40,10 @@ extension of the prime field.
 ## References
 
 This is the field-theoretic half of "the fixed points of the `q`-power Frobenius are the
-`𝔽_q`-points", the ring-theoretic half being `TauCeti.frobeniusFixedSubring` itself. It is a
-prerequisite of the "points over an algebraically closed field, functorially in the field" target
-of Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`, and of milestone L1 of
-`TauCetiRoadmap/CFSGStatement/README.md`, whose ordinary and graph-twisted Steinberg maps start
-from the `q`-power Frobenius of an algebraic closure of `ZMod p`.
+`𝔽_q`-points", the ring-theoretic half being `TauCeti.frobeniusFixedSubring` itself. It supplies
+the finite-field input for studying points over an algebraically closed field and for ordinary and
+graph-twisted Steinberg maps, which start from the `q`-power Frobenius of an algebraic closure of
+`ZMod p`.
 
 * S. Lang, *Algebra*, 3rd ed., V.5.
 * R. Lidl and H. Niederreiter, *Finite Fields*, §2.1.

--- a/TauCeti/FieldTheory/FunctionField/ConstantField.lean
+++ b/TauCeti/FieldTheory/FunctionField/ConstantField.lean
@@ -135,9 +135,8 @@ theorem IsFunctionField.algebraicClosure (hF : IsFunctionField k F) :
   simpa using h
 
 /-- The normalization device: every algebraic function field is, over a finite extension of its
-base field, an algebraic function field with an exact field of constants. Later layers, whose
-statements are stated under the exactness hypothesis, are applied to a general function field
-through this. -/
+base field, an algebraic function field with an exact field of constants. Results stated under
+the exactness hypothesis can therefore be applied to a general function field through this. -/
 theorem IsFunctionField.exists_intermediateField_isIntegrallyClosedIn (hF : IsFunctionField k F) :
     ∃ k' : IntermediateField k F,
       FiniteDimensional k k' ∧ IsFunctionField k' F ∧ IsIntegrallyClosedIn k' F :=

--- a/TauCeti/FieldTheory/FunctionField/Divisor/AffineModel.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/AffineModel.lean
@@ -41,8 +41,8 @@ model sits inside `Divisor k F` as the divisors supported on the finite chart; c
 Ceti's `fractionalIdealDivisorAddEquiv` turns divisors of the model into invertible fractional
 ideals, so no fractional-ideal calculus is redeveloped here.
 
-This is the affine-bridge subsection of Stichtenoth's Section I.4, in the form the roadmap pins:
-the Dedekind factorization calculus of the model computes divisors on its chart.
+This is the affine-model bridge of Stichtenoth's Section I.4: the Dedekind factorization calculus
+of the model computes divisors on its chart.
 
 ## Main definitions
 

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Principal.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Principal.lean
@@ -57,10 +57,10 @@ the places themselves.
 
 ## Implementation notes
 
-`div` is defined on `Fˣ`, not on `F` with a nonzero hypothesis: the roadmap pins it as a group
-homomorphism, and `Additive Fˣ →+ Divisor k F` is that statement.  For a nonzero `f : F` the
-divisor is `div (Units.mk0 f hf)`, and `TauCeti.Divisor.coeff_principal` reads its coefficients
-back as orders of the underlying function.
+`div` is defined on `Fˣ`, not on `F` with a nonzero hypothesis, so its multiplicativity is packaged
+as the group homomorphism `Additive Fˣ →+ Divisor k F`.  For a nonzero `f : F` the divisor is
+`div (Units.mk0 f hf)`, and `TauCeti.Divisor.coeff_principal` reads its coefficients back as orders
+of the underlying function.
 
 The function-field hypothesis `IsFunctionField k F` is an explicit argument rather than a
 typeclass, following the rest of this directory; it is what makes the support finite, so it

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis/Basic.lean
@@ -30,7 +30,7 @@ The freeness and rank calculation are specializations of Mathlib's generic integ
 theorems `IsIntegralClosure.module_free` and `IsIntegralClosure.rank`.  The point of this file is
 the function-field interface: the basis is indexed by `Fin [F' : F]`, its vectors are visibly
 integral, and their `𝒪_P`-span inside `F'` is exactly `𝒪'_P`.  These are the forms used by the
-complementary module and different of the next layer.
+subsequent constructions of the complementary module and different.
 
 The basis material is the place-local analogue of Mathlib's `NumberField.integralBasis` API in
 `Mathlib.NumberTheory.NumberField.Basic`, and is built the same way:

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Tower.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Tower.lean
@@ -27,12 +27,11 @@ and the degree identity is the ordinary finrank tower formula for the residue fi
 * `TauCeti.Place.ramificationIdx_restrict_mul`: ramification indices multiply in a tower.
 * `TauCeti.Place.relativeDegree_restrict_mul`: relative residue degrees multiply in a tower.
 
-## Roadmap
+## Mathematical context
 
-`TauCetiRoadmap/AlgebraicCurves/README.md`, Layer 6, "Setup": multiplicativity in towers for
-extensions of places (Stichtenoth, Proposition 3.1.6). The restriction identity is also the
-functoriality required by `TauCetiRoadmap/EllipticCurves/README.md`, Layer 0, `inducedPlace`,
-and by Layer 1's construction of the dual isogeny.
+Multiplicativity in towers for extensions of places is Stichtenoth, Proposition 3.1.6. The
+restriction identity also supplies the functoriality needed to define induced places and to
+construct dual isogenies.
 
 ## References
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Zeros.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Zeros.lean
@@ -67,12 +67,11 @@ proved nonzero.
 
 ## Provenance
 
-The mathematics is Stichtenoth's and the Lean development is independent. The roadmap's
-coordination section records that `vaca22/riemann-roch-function-fields` (Guanghao Li,
-Apache-2.0) carries a complete function-field Riemann–Roch by the same Stichtenoth route, and
-that this roadmap specifies the mathematics rather than that code; no code is copied or adapted
-from it here, and the normalized-`ℤᵐ⁰`-valuation `TauCeti.Place` API this file is written
-against is the deliberate API divergence recorded there.
+The mathematics is Stichtenoth's and the Lean development is independent. The separate
+`vaca22/riemann-roch-function-fields` project (Guanghao Li, Apache-2.0) carries a complete
+function-field Riemann–Roch development by the same Stichtenoth route; no code is copied or
+adapted from it here. In particular, this file uses Tau Ceti's normalized-`ℤᵐ⁰`-valuation
+`TauCeti.Place` API.
 
 ## References
 

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/Genus.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/Genus.lean
@@ -60,10 +60,10 @@ beyond `IsFunctionField k F`.
 ## Provenance
 
 The mathematics is Stichtenoth's and the Lean development is independent, as in
-`TauCeti.FieldTheory.FunctionField.Place.Zeros`.  The roadmap's coordination section records
-that `vaca22/riemann-roch-function-fields` (Guanghao Li, Apache-2.0) carries a complete
-function-field Riemann–Roch by the same Stichtenoth route, and that this roadmap specifies the
-mathematics rather than that code; no code is copied or adapted from it here.
+`TauCeti.FieldTheory.FunctionField.Place.Zeros`. The separate
+`vaca22/riemann-roch-function-fields` project (Guanghao Li, Apache-2.0) carries a complete
+function-field Riemann–Roch development by the same Stichtenoth route; no code is copied or
+adapted from it here.
 
 ## References
 

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/RatFunc.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/RatFunc.lean
@@ -55,10 +55,10 @@ classification.
 ## Provenance
 
 The mathematics is Stichtenoth's and the Lean development is independent, as in
-`TauCeti.FieldTheory.FunctionField.RiemannRoch.Genus`.  The roadmap's coordination section
-records that `vaca22/riemann-roch-function-fields` (Guanghao Li, Apache-2.0) carries a complete
-function-field Riemann–Roch by the same Stichtenoth route, and that this roadmap specifies the
-mathematics rather than that code; no code is copied or adapted from it here.
+`TauCeti.FieldTheory.FunctionField.RiemannRoch.Genus`. The separate
+`vaca22/riemann-roch-function-fields` project (Guanghao Li, Apache-2.0) carries a complete
+function-field Riemann–Roch development by the same Stichtenoth route; no code is copied or
+adapted from it here.
 
 ## References
 

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/Uniqueness.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/Uniqueness.lean
@@ -61,11 +61,10 @@ consequences to that witness recovers `g(k(x)) = 0`, `ℓ(-2 · P_∞) = 0` and
 
 ## Provenance
 
-The mathematics is Stichtenoth's and the Lean development is independent.  The roadmap's
-coordination section records that `vaca22/riemann-roch-function-fields` (Guanghao Li,
-Apache-2.0) carries a complete function-field Riemann–Roch by the same Stichtenoth route, and
-that this roadmap specifies the mathematics rather than that code; no code is copied or adapted
-from it here.
+The mathematics is Stichtenoth's and the Lean development is independent. The separate
+`vaca22/riemann-roch-function-fields` project (Guanghao Li, Apache-2.0) carries a complete
+function-field Riemann–Roch development by the same Stichtenoth route; no code is copied or
+adapted from it here.
 
 ## References
 

--- a/TauCeti/FieldTheory/Galois/AbsoluteGaloisGroup.lean
+++ b/TauCeti/FieldTheory/Galois/AbsoluteGaloisGroup.lean
@@ -45,10 +45,6 @@ legitimate to state a theorem for one and use it for the other.
 * `TauCeti.mem_perfectClosure_iff_fixed`: the fixed field of `Gal(E/F)` for a normal
   extension `E/F` is the relative perfect closure of `F` in `E`.
 
-This is the "the group, fixed once" milestone of Layer 9 of the human-authored roadmap at
-`TauCetiRoadmap/ProfiniteCohomology/README.md`; that layer's warning about the algebraic closure is
-`mem_perfectClosure_iff_fixed` here.
-
 ## References
 
 * J. Neukirch, A. Schmidt, K. Wingberg, *Cohomology of Number Fields*, 2nd ed., Ch. VI §1, for the

--- a/TauCeti/FieldTheory/Galois/Basic.lean
+++ b/TauCeti/FieldTheory/Galois/Basic.lean
@@ -33,18 +33,16 @@ finite and normal (`Algebra.IsQuadraticExtension.normal`), hence Galois with sep
 (`Algebra.IsQuadraticExtension.isGalois`); `IsGalois.card_aut_eq_finrank` counts the
 automorphisms and `IsGalois.mem_range_algebraMap_iff_fixed` characterises the base field.
 
-These are the descent inputs for the quadratic-twist layer of
-`TauCetiRoadmap/EllipticCurves/README.md` (§Layer 5), consumed by
+These are the descent inputs for quadratic twists, consumed by
 `TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean` and by
 `TauCeti/RingTheory/Norm/Quadratic.lean`, which expresses the trace and norm of a
 separable quadratic extension through its nontrivial automorphism.
 
 Adapted from the FLT project (`ImperialCollegeLondon/FLT`,
-`FLT/Mathlib/FieldTheory/Galois/Basic.lean` at the roadmap's pin `bc2fe8ff7396`, FLT PR #1088,
+`FLT/Mathlib/FieldTheory/Galois/Basic.lean` at `bc2fe8ff7396`, FLT PR #1088,
 Apache 2.0). That file's own header reads `Authors: Kevin Buzzard, Claude`; following this
 repository's convention for adapted material, the upstream authorship is credited here rather
-than in the copyright header. Only the results consumed downstream are ported; the rest of
-the source file is deferred to the Tau Ceti PRs that consume it.
+than in the copyright header. Only the results consumed downstream are adapted here.
 -/
 
 public section

--- a/TauCeti/FieldTheory/GaloisGroups/Degree.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Degree.lean
@@ -35,9 +35,7 @@ factorial of the polynomial degree.
 
 The proofs reuse Mathlib's `Polynomial.card_rootSet_eq_natDegree`,
 `Polynomial.Gal.galActionHom_injective`, `MonoidHom.ofInjective`, and Lagrange's theorem. This is
-the "Degree bookkeeping" milestone of Layer 0 in
-`TauCetiRoadmap/PolynomialGaloisGroups/README.md`; its root numbering is consumed by the
-orbit-to-factor dictionary and the later low-degree label predicates.
+the degree bookkeeping used by the orbit-to-factor dictionary and by low-degree label predicates.
 -/
 
 public section

--- a/TauCeti/FieldTheory/IntermediateField/Adjoin/EqTop.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Adjoin/EqTop.lean
@@ -16,7 +16,7 @@ whole-field counterpart of Mathlib's `IntermediateField.algHom_ext_of_eq_adjoin`
 compares homomorphisms out of the *subfield* `adjoin F s`), obtained from it by transporting
 along `adjoin F s ≃ₐ[F] E` rather than repeating the adjoin induction.
 
-It is the extensionality step shared by the multiquadratic Layer 1 arguments: the splitting
+It is the extensionality step shared by the multiquadratic arguments: the splitting
 law shows a decomposition-group element fixes every generator `√dᵢ` and concludes it is
 trivial, and the Frobenius computation concludes the same when every Legendre symbol is `1`.
 

--- a/TauCeti/FieldTheory/IntermediateField/Adjoin/Roots.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Adjoin/Roots.lean
@@ -29,9 +29,8 @@ extension as a hypothesis rather than building one, so it does not use this lemm
 
 ## Provenance
 
-Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
-(`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
-`RingTheory/IntegralClosure/NormalizationFinite`.
+The construction is the finite root-adjoining step appearing in Stacks, Lemma 10.161.13
+(tag 032O), in the normalization-finiteness argument described above.
 -/
 
 public section

--- a/TauCeti/FieldTheory/Normal/FixedField.lean
+++ b/TauCeti/FieldTheory/Normal/FixedField.lean
@@ -28,10 +28,8 @@ of a polynomial ring in a separable extension is no longer a polynomial ring.
 
 ## Provenance
 
-Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
-(`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
-`RingTheory/IntegralClosure/NormalizationFinite`. The mathematics is Stacks, Fields,
-Lemma 9.27.3(2) (tag 030M), the splitting used by Stacks 10.161.12 (tag 032N).
+The mathematics is Stacks, Fields, Lemma 9.27.3(2) (tag 030M), the splitting used by Stacks
+10.161.12 (tag 032N) in its normalization-finiteness argument.
 -/
 
 public section

--- a/TauCeti/FieldTheory/PurelyInseparable/Embedding.lean
+++ b/TauCeti/FieldTheory/PurelyInseparable/Embedding.lean
@@ -33,11 +33,9 @@ inseparable extensions.
 
 ## Provenance
 
-Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
-(`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
-`RingTheory/IntegralClosure/NormalizationFinite`. The mathematics is the field-theoretic half of
-the "some details omitted" sentence of Stacks 10.161.13 (tag 032O): there is a finite purely
-inseparable `L' / K` and `q = p ^ e` with `L ⊂ L'(x^{1/q})`.
+The mathematics is the field-theoretic half of the "some details omitted" sentence of Stacks
+10.161.13 (tag 032O): there is a finite purely inseparable `L' / K` and `q = p ^ e` with
+`L ⊂ L'(x^{1/q})`.
 -/
 
 public section

--- a/TauCeti/FieldTheory/RatFunc/Frobenius.lean
+++ b/TauCeti/FieldTheory/RatFunc/Frobenius.lean
@@ -24,28 +24,19 @@ subfield `K(X^q)`, and `K(X)` has degree exactly `q` over it.
 
 Both are `@[simp]`.
 
-## Roadmap
+## Application to Frobenius isogenies
 
-`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 1**, the Frobenius isogeny — "the key input to
-Layer 3". The layer seeds
-
-```lean
-noncomputable def Isogeny.degree (φ : Isogeny W₁ W₂) : ℕ :=
-  Module.finrank φ.fieldPullback.fieldRange W₁.FunctionField
-theorem degree_frobeniusIsogeny [Finite F] (W : WeierstrassCurve.Affine F) :
-    (frobeniusIsogeny W).degree = Nat.card F
-```
-
-so the target is `Module.finrank` of `K(W)` over the field range of the `q`-power map. This file
-proves that statement for the rational function field. It is what the seeded degree is computed
-from: `K(x^q)` sits below both `K(x)` and `K(W)^q` inside `K(W)`, the two intermediate degrees
+Computing the degree of a Frobenius isogeny requires the `Module.finrank` of `K(W)` over the field
+range of the `q`-power map. This file proves the corresponding statement for the rational function
+field. It supplies the inner degree in the comparison: `K(x^q)` sits below both `K(x)` and
+`K(W)^q` inside `K(W)`, the two intermediate degrees
 `[K(W) : K(x)]` and `[K(W)^q : K(x^q)]` are both `2`, and the tower law along the two routes reads
 `[K(W) : K(W)^q] · 2 = 2 · [K(x) : K(x^q)]`. The right-hand factor is the `q` proved here.
 
 ## Provenance
 
-Ported from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by
-that roadmap at `dev/hasse-weil @ 513e83879e2f`), `HasseWeil/FrobeniusIsogeny.lean`, declarations
+Ported from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
+`dev/hasse-weil @ 513e83879e2f`), `HasseWeil/FrobeniusIsogeny.lean`, declarations
 `frobenius_fieldRange_ratFunc` and `finrank_ratFunc_frobenius`.
 
 Changes from the source. Both are `private` there, inside the file that builds the Frobenius

--- a/TauCeti/FieldTheory/RatFunc/PowerTower.lean
+++ b/TauCeti/FieldTheory/RatFunc/PowerTower.lean
@@ -17,15 +17,15 @@ For a field `K` and an exponent `n`, this file computes the degree of `K(X)` ove
 
 * `TauCeti.RatFunc.finrank_adjoin_X_pow`: `[K(X) : K(X ^ n)] = n`.
 
-## Roadmap
+## Mathematical context
 
-`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 1**. The relative and finite-field Frobenius
-degree computations use this as the inner degree in the tower `K(W) / K(x) / K(x^n)`.
+Relative and finite-field Frobenius degree computations use this as the inner degree in the tower
+`K(W) / K(x) / K(x^n)`.
 
 ## Provenance
 
 The statement was extracted while porting the finite-field Frobenius tower from the AINTLIB
-`HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by that roadmap at
+`HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
 `dev/hasse-weil @ 513e83879e2f`). The source proves only the finite-field exponent; the arbitrary
 field and exponent statement here is new, and follows directly from Mathlib's rational-function
 degree formula.


### PR DESCRIPTION
This PR removes roadmap targets, layer numbers, milestone ordering, and process language from docstrings under `TauCeti/FieldTheory`, while preserving the mathematical motivation and source provenance. It also replaces three layer-only references that a roadmap-text scan would miss. All 21 affected modules build locally, and the dot-notation lint reports zero new violations.

Roadmap: none

:robot: Prepared with OpenAI Codex