### PR TITLE
feat: sweep on a push to main as well as on the cron

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -44,8 +44,8 @@ on:
   # -- GitHub has just invalidated it for every open PR, so most come back UNKNOWN
   # and are deliberately skipped -- and scheduled dispatches have been observed
   # dropping for hours at a time, so neither trigger can be relied on alone. The
-  # push gives promptness, the cron gives a settled read and covers a scheduler
-  # that skipped.
+  # push gives promptness and still fires when a scheduled dispatch is dropped;
+  # the cron gives the settled read the push cannot.
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -36,6 +36,18 @@ name: Merge conflicts
 # labelled. scripts/pr_status/conflicts.py skips an unknown PR and keeps going.
 
 on:
+  # The base moving is what creates a conflict, so react to it rather than only
+  # waiting for the next quarter hour. This is also the cheapest possible trigger:
+  # a run that finds nothing costs one GraphQL query.
+  #
+  # It does NOT replace the cron. A push is the WORST moment to read mergeability
+  # -- GitHub has just invalidated it for every open PR, so most come back UNKNOWN
+  # and are deliberately skipped -- and scheduled dispatches have been observed
+  # dropping for hours at a time, so neither trigger can be relied on alone. The
+  # push gives promptness, the cron gives a settled read and covers a scheduler
+  # that skipped.
+  push:
+    branches: [main]
   schedule:
     # Every 15 minutes, on the quarter -- the offsets furthest from pr-labels
     # (:05), housekeeping (:20), merge-sweep (:40) and stuck-alerts (:50). The gap

--- a/scripts/pr_status/README.md
+++ b/scripts/pr_status/README.md
@@ -163,10 +163,11 @@ gh api --paginate "/repos/TauCetiProject/TauCeti/issues/N/timeline?per_page=100"
 ```
 
 Read those as **observed label intervals**, not exact conflict durations: the
-boundaries are quantised by the fifteen-minute poll and by GitHub's scheduling, a
-conflict that arises and clears between two runs is never seen at all, and a PR
-closed while labelled has no closing event. The actor distinguishes the bot's own
-transitions from a human's.
+boundaries are quantised by when a sweep last read a definite answer -- by the
+push and cron triggers, by GitHub's scheduling of them, and by when GitHub's lazy
+mergeability computation stops saying UNKNOWN -- a conflict that arises and clears
+between two runs is never seen at all, and a PR closed while labelled has no
+closing event. The actor distinguishes the bot's own transitions from a human's.
 
 Two ordering decisions carry the weight:
 

--- a/scripts/pr_status/README.md
+++ b/scripts/pr_status/README.md
@@ -138,10 +138,10 @@ are blocking under review, so a conflicted-but-approved PR was reaped by nothing
 either. It rotted silently.
 
 [`conflicts.py`](conflicts.py) runs on every push to `main` and every fifteen
-minutes: one GraphQL query reads
-the whole open queue, `merge-conflict` goes on a PR that has stopped merging and
-comes off when it merges again, and the author is told once per episode. The label
-is provisioned on first use, like the status labels.
+minutes: one GraphQL query reads the whole open queue, `merge-conflict` goes on a
+PR that has stopped merging and comes off when it merges again, and the author is
+told once per episode. The label is provisioned on first use, like the status
+labels.
 
 Two properties are why this is a couple of hundred lines rather than a package.
 
@@ -190,10 +190,10 @@ Two ordering decisions carry the weight:
 Both triggers are needed and neither suffices. A push to `main` is what creates a
 conflict, so reacting to it is prompt — but it is also the worst moment to *read*
 mergeability, since GitHub has just invalidated it for every open PR and most come
-back UNKNOWN and are skipped. The cron then reads a settled queue. It is also the
-only cover for the scheduler itself: GitHub has been observed dropping this
-repository's scheduled dispatches for hours at a time, which is why the sweep does
-not depend on them alone.
+back UNKNOWN and are skipped. The cron then reads a settled queue, which the push
+cannot. The push in turn is the only cover for the scheduler itself: GitHub has
+been observed dropping this repository's scheduled dispatches for hours at a time,
+and while that lasts a merge to `main` is the one thing that still starts a sweep.
 
 A PR carrying a hold label (`keep`/`hold`/`wip`/`human`/`do-not-close`/`blocked`,
 matching `stuck_alerts.py`) is left entirely alone rather than labelled-but-silent:

--- a/scripts/pr_status/README.md
+++ b/scripts/pr_status/README.md
@@ -137,7 +137,8 @@ wrongly withheld by the merge path) and `housekeeping.py` only retires PRs that
 are blocking under review, so a conflicted-but-approved PR was reaped by nothing
 either. It rotted silently.
 
-[`conflicts.py`](conflicts.py) runs every fifteen minutes: one GraphQL query reads
+[`conflicts.py`](conflicts.py) runs on every push to `main` and every fifteen
+minutes: one GraphQL query reads
 the whole open queue, `merge-conflict` goes on a PR that has stopped merging and
 comes off when it merges again, and the author is told once per episode. The label
 is provisioned on first use, like the status labels.
@@ -185,6 +186,14 @@ Two ordering decisions carry the weight:
   branch tip sits at `mergeable: null` indefinitely — precisely what
   `stuck_alerts.py`'s `diverged-head` detector exists to catch — so one such PR
   could stop every other conflict being labelled.
+
+Both triggers are needed and neither suffices. A push to `main` is what creates a
+conflict, so reacting to it is prompt — but it is also the worst moment to *read*
+mergeability, since GitHub has just invalidated it for every open PR and most come
+back UNKNOWN and are skipped. The cron then reads a settled queue. It is also the
+only cover for the scheduler itself: GitHub has been observed dropping this
+repository's scheduled dispatches for hours at a time, which is why the sweep does
+not depend on them alone.
 
 A PR carrying a hold label (`keep`/`hold`/`wip`/`human`/`do-not-close`/`blocked`,
 matching `stuck_alerts.py`) is left entirely alone rather than labelled-but-silent:


### PR DESCRIPTION
This PR makes the conflict sweep run on every push to `main`, in addition to its quarter-hourly cron.

Roadmap: none

The base moving is what creates a conflict, so reacting to it is the prompt thing to do, and it is close to free: a run that finds nothing costs a single GraphQL query.

It does not replace the cron, and the point is that the two fail differently. A push is the *worst* moment to read mergeability — GitHub has just invalidated it for every open PR, so most come back `UNKNOWN` and are deliberately skipped — whereas the cron reads a settled queue. Conversely the cron is not dependable on its own: on the day #2033 landed, this repository's scheduled dispatches stopped for four hours across every workflow, with only three scheduled runs repo-wide in a three-hour window. Neither trigger is sufficient; together they cover both the latency and the outage.

Concurrency is unchanged (`group: merge-conflicts`, no cancellation), so a burst of merges queues rather than overlapping.

🤖 Prepared with Claude Code