### PR TITLE
feat: assemble the almost-split sequence

### DIFF
--- a/TauCeti/CategoryTheory/AlmostSplit/Basic.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Basic.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Homology.ShortComplex.Exact
+public import Mathlib.CategoryTheory.Preadditive.Injective.Basic
+public import Mathlib.CategoryTheory.Preadditive.Projective.Basic
 public import TauCeti.CategoryTheory.IrreducibleMorphism
 
 /-!
@@ -21,14 +23,14 @@ absorbs all the inessential maps out of `X`.
 These are the two lifting properties an **almost-split (Auslander-Reiten) sequence**
 `0 → τM → E → M → 0` carries: `E ⟶ M` is right almost split and `τM ⟶ E` is left almost split.
 This file builds them as conditions on a single morphism of an arbitrary category, so that the
-sequence-level notion can be assembled from them — it is, as `TauCeti.IsAlmostSplit` in
-`TauCeti/CategoryTheory/AlmostSplit/Sequence.lean` — and proves the two facts that make the
-indecomposability clauses in the definition of an almost-split sequence redundant: **the target of
-a right almost split morphism is indecomposable**, and dually **the source of a left almost split
-morphism is indecomposable**. Neither end of an almost-split sequence has to be *assumed*
-indecomposable — the lifting properties already force it — and a short complex whose `g` is right
-almost split admits no splitting, so non-splitness is likewise a consequence rather than a
-hypothesis.
+sequence-level notion can be assembled from them — it is, as
+`CategoryTheory.ShortComplex.IsAlmostSplit` in `TauCeti/CategoryTheory/AlmostSplit/Sequence.lean` —
+and proves the two facts that make the indecomposability clauses in the definition of an
+almost-split sequence redundant: **the target of a right almost split morphism is indecomposable**,
+and dually **the source of a left almost split morphism is indecomposable**. Neither end of an
+almost-split sequence has to be *assumed* indecomposable — the lifting properties already force
+it — and a short complex whose `g` is right almost split admits no splitting, so non-splitness is
+likewise a consequence rather than a hypothesis.
 
 The connection to `TauCeti.IsIrreducibleMorphism` is the sharpened factorization
 `TauCeti.IsRightAlmostSplit.exists_isSplitMono_of_isIrreducibleMorphism`: an irreducible morphism
@@ -56,6 +58,9 @@ what ties the sequence to the arrows of the Auslander-Reiten quiver.
   morphism factors through an almost split morphism by a split mono, resp. a split epi.**
 * `TauCeti.IsRightAlmostSplit.epi_of_epi` and `TauCeti.IsLeftAlmostSplit.mono_of_mono`: a right
   almost split morphism is an epimorphism as soon as *some* non-split-epi into its target is one.
+* `TauCeti.IsRightAlmostSplit.not_projective` and `TauCeti.IsLeftAlmostSplit.not_injective`: **the
+  target of an epimorphic right almost split morphism is not projective**, and dually the source of
+  a monomorphic left almost split morphism is not injective.
 * Invariance under isomorphisms of the source and the target,
   `TauCeti.isRightAlmostSplit_comp_iso_iff`, `TauCeti.isRightAlmostSplit_iso_comp_iff` and their
   left-hand analogues, so the notions descend to a skeleton.
@@ -335,6 +340,22 @@ theorem IsLeftAlmostSplit.exists_isSplitEpi_of_isIrreducibleMorphism (hf : IsLef
     ∃ h : Y ⟶ Z, IsSplitEpi h ∧ f ≫ h = g := by
   obtain ⟨h, hh⟩ := hf.factors Z g hg.not_isSplitMono
   exact ⟨h, hg.isSplitEpi_of_not_isSplitMono hh hf.not_isSplitMono, hh⟩
+
+/-! ### Projectivity and injectivity of the almost split end -/
+
+/-- **The target of an epimorphic right almost split morphism is not projective.** Were it
+projective, its identity would factor through the epimorphism `f`, which is exactly a section of
+`f`, and `f` is not a split epimorphism. -/
+theorem IsRightAlmostSplit.not_projective (hf : IsRightAlmostSplit f) [Epi f] : ¬ Projective Y :=
+  fun _ => hf.not_isSplitEpi
+    (IsSplitEpi.mk' ⟨Projective.factorThru (𝟙 Y) f, Projective.factorThru_comp _ _⟩)
+
+/-- **The source of a monomorphic left almost split morphism is not injective**, dually to
+`TauCeti.IsRightAlmostSplit.not_projective`: its identity would factor through the monomorphism
+`f`, retracting it. -/
+theorem IsLeftAlmostSplit.not_injective (hf : IsLeftAlmostSplit f) [Mono f] : ¬ Injective X :=
+  fun _ => hf.not_isSplitMono
+    (IsSplitMono.mk' ⟨Injective.factorThru (𝟙 X) f, Injective.comp_factorThru _ _⟩)
 
 /-! ### Indecomposability of the almost split end -/
 

--- a/TauCeti/CategoryTheory/AlmostSplit/Basic.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Basic.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Homology.ShortComplex.Exact
 public import Mathlib.CategoryTheory.Preadditive.Injective.Basic
 public import Mathlib.CategoryTheory.Preadditive.Projective.Basic
 public import TauCeti.CategoryTheory.IrreducibleMorphism
@@ -29,8 +28,7 @@ and proves the two facts that make the indecomposability clauses in the definiti
 almost-split sequence redundant: **the target of a right almost split morphism is indecomposable**,
 and dually **the source of a left almost split morphism is indecomposable**. Neither end of an
 almost-split sequence has to be *assumed* indecomposable — the lifting properties already force
-it — and a short complex whose `g` is right almost split admits no splitting, so non-splitness is
-likewise a consequence rather than a hypothesis.
+it.
 
 The connection to `TauCeti.IsIrreducibleMorphism` is the sharpened factorization
 `TauCeti.IsRightAlmostSplit.exists_isSplitMono_of_isIrreducibleMorphism`: an irreducible morphism
@@ -50,9 +48,6 @@ what ties the sequence to the arrows of the Auslander-Reiten quiver.
 * `TauCeti.IsRightAlmostSplit.indecomposable`: **the target of a right almost split morphism is
   indecomposable**, and `TauCeti.IsLeftAlmostSplit.indecomposable`: the source of a left almost
   split morphism is indecomposable.
-* `TauCeti.isEmpty_splitting_of_isRightAlmostSplit` and
-  `TauCeti.isEmpty_splitting_of_isLeftAlmostSplit`: a short complex one of whose maps is almost
-  split on the corresponding side has no splitting.
 * `TauCeti.IsRightAlmostSplit.exists_isSplitMono_of_isIrreducibleMorphism` and
   `TauCeti.IsLeftAlmostSplit.exists_isSplitEpi_of_isIrreducibleMorphism`: **an irreducible
   morphism factors through an almost split morphism by a split mono, resp. a split epi.**
@@ -61,6 +56,9 @@ what ties the sequence to the arrows of the Auslander-Reiten quiver.
 * `TauCeti.IsRightAlmostSplit.not_projective` and `TauCeti.IsLeftAlmostSplit.not_injective`: **the
   target of an epimorphic right almost split morphism is not projective**, and dually the source of
   a monomorphic left almost split morphism is not injective.
+* `TauCeti.IsRightAlmostSplit.not_isSplitMono`, `.not_mono` and `.ne_zero` and their left-hand
+  duals: **an epimorphic right almost split morphism is neither a split monomorphism nor — in a
+  balanced category — a monomorphism, and it is nonzero.**
 * Invariance under isomorphisms of the source and the target,
   `TauCeti.isRightAlmostSplit_comp_iso_iff`, `TauCeti.isRightAlmostSplit_iso_comp_iff` and their
   left-hand analogues, so the notions descend to a skeleton.
@@ -84,9 +82,11 @@ representations of the Kronecker quiver that end no almost-split sequence). Inst
 the finite-dimensional subcategory is what recovers the intended notion.
 
 A right almost split morphism may well be zero: over a field, the map `0 ⟶ k` is right almost
-split, every non-split-epi into the simple projective `k` being zero. So there is no analogue here
-of `TauCeti.IsIrreducibleMorphism.ne_zero`, and this is not an oversight — it is the boundary case
-of a projective target, where the almost split morphism is the inclusion of the radical.
+split, every non-split-epi into the simple projective `k` being zero. So there is no unconditional
+analogue here of `TauCeti.IsIrreducibleMorphism.ne_zero`, and this is not an oversight — it is the
+boundary case of a projective target, where the almost split morphism is the inclusion of the
+radical. `TauCeti.IsRightAlmostSplit.ne_zero` therefore assumes `[Epi f]`, which is exactly what
+that boundary case fails.
 
 Indecomposability of the target is proved directly from the definition rather than through
 endomorphism rings, so it needs no additivity, no finiteness and no field: given `Y ≅ A ⊞ B` with
@@ -99,8 +99,8 @@ structure maps then compose to `0`, collapsing the other summand), so both facto
 
 This builds the right and left almost split conditions named in Layer 6 (Auslander-Reiten theory)
 of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md` as the two lifting
-clauses of an almost-split sequence, together with the indecomposability of its ends and its
-non-splitness, which that layer lists as separate requirements on the sequence.
+clauses of an almost-split sequence, together with the indecomposability of its ends, which that
+layer lists as a separate requirement on the sequence.
 
 * M. Auslander, I. Reiten, S. Smalø, *Representation Theory of Artin Algebras*, CUP (1995), V.1.
 * I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
@@ -321,6 +321,40 @@ theorem IsLeftAlmostSplit.mono_of_mono (hf : IsLeftAlmostSplit f) {Z : C} (g : X
   have : Mono (f ≫ h) := hh ▸ ‹Mono g›
   exact _root_.CategoryTheory.mono_of_mono f h
 
+/-- **An epimorphic right almost split morphism is not a split monomorphism**: a splitting on that
+side would make it an isomorphism. -/
+theorem IsRightAlmostSplit.not_isSplitMono (hf : IsRightAlmostSplit f) [Epi f] :
+    ¬ IsSplitMono f := fun _ => hf.not_isIso (isIso_of_epi_of_isSplitMono f)
+
+/-- **A monomorphic left almost split morphism is not a split epimorphism**, dually to
+`TauCeti.IsRightAlmostSplit.not_isSplitMono`. -/
+theorem IsLeftAlmostSplit.not_isSplitEpi (hf : IsLeftAlmostSplit f) [Mono f] :
+    ¬ IsSplitEpi f := fun _ => hf.not_isIso (isIso_of_mono_of_isSplitEpi f)
+
+/-- In a balanced category an epimorphic right almost split morphism is not a monomorphism: it
+would otherwise be an isomorphism. -/
+theorem IsRightAlmostSplit.not_mono [Balanced C] (hf : IsRightAlmostSplit f) [Epi f] :
+    ¬ Mono f := fun _ => hf.not_isIso (isIso_of_mono_of_epi f)
+
+/-- In a balanced category a monomorphic left almost split morphism is not an epimorphism, dually
+to `TauCeti.IsRightAlmostSplit.not_mono`. -/
+theorem IsLeftAlmostSplit.not_epi [Balanced C] (hf : IsLeftAlmostSplit f) [Mono f] :
+    ¬ Epi f := fun _ => hf.not_isIso (isIso_of_mono_of_epi f)
+
+/-- **An epimorphic right almost split morphism is nonzero.** A zero epimorphism forces its target
+to be a zero object, and the zero morphism into a zero object is a split epimorphism. -/
+theorem IsRightAlmostSplit.ne_zero [HasZeroMorphisms C] (hf : IsRightAlmostSplit f) [Epi f] :
+    f ≠ 0 := fun h => by
+  have hid : 𝟙 Y = 0 := (cancel_epi f).mp (by simp [h])
+  exact hf.not_isSplitEpi (IsSplitEpi.mk' ⟨0, by simp [hid]⟩)
+
+/-- **A monomorphic left almost split morphism is nonzero**, dually to
+`TauCeti.IsRightAlmostSplit.ne_zero`. -/
+theorem IsLeftAlmostSplit.ne_zero [HasZeroMorphisms C] (hf : IsLeftAlmostSplit f) [Mono f] :
+    f ≠ 0 := fun h => by
+  have hid : 𝟙 X = 0 := (cancel_mono f).mp (by simp [h])
+  exact hf.not_isSplitMono (IsSplitMono.mk' ⟨0, by simp [hid]⟩)
+
 /-- **An irreducible morphism into the target of a right almost split morphism factors through it
 by a split monomorphism**, so its source is a retract of the source of the almost split morphism.
 
@@ -437,25 +471,5 @@ theorem IsLeftAlmostSplit.indecomposable (hf : IsLeftAlmostSplit f) : Indecompos
   rw [← Category.assoc, key, e.hom_inv_id]
 
 end Indecomposable
-
-/-! ### Almost split maps in a short complex -/
-
-section ShortComplex
-
-variable [Preadditive C] {S : ShortComplex C}
-
-/-- **A short complex whose second map is right almost split does not split.** The `not_split`
-clause in the definition of an almost-split sequence is therefore redundant: it is implied by the
-right almost split clause alone. -/
-theorem isEmpty_splitting_of_isRightAlmostSplit (hg : IsRightAlmostSplit S.g) :
-    IsEmpty S.Splitting :=
-  ⟨fun s => hg.not_isSplitEpi s.isSplitEpi_g⟩
-
-/-- **A short complex whose first map is left almost split does not split.** -/
-theorem isEmpty_splitting_of_isLeftAlmostSplit (hf : IsLeftAlmostSplit S.f) :
-    IsEmpty S.Splitting :=
-  ⟨fun s => hf.not_isSplitMono s.isSplitMono_f⟩
-
-end ShortComplex
 
 end TauCeti

--- a/TauCeti/CategoryTheory/AlmostSplit/Basic.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Basic.lean
@@ -97,11 +97,6 @@ structure maps then compose to `0`, collapsing the other summand), so both facto
 
 ## References
 
-This builds the right and left almost split conditions named in Layer 6 (Auslander-Reiten theory)
-of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md` as the two lifting
-clauses of an almost-split sequence, together with the indecomposability of its ends, which that
-layer lists as a separate requirement on the sequence.
-
 * M. Auslander, I. Reiten, S. Smalø, *Representation Theory of Artin Algebras*, CUP (1995), V.1.
 * I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
   Algebras, Vol. 1*, LMS Student Texts 65, CUP (2006), IV.1.

--- a/TauCeti/CategoryTheory/AlmostSplit/Basic.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Basic.lean
@@ -21,7 +21,8 @@ absorbs all the inessential maps out of `X`.
 These are the two lifting properties an **almost-split (Auslander-Reiten) sequence**
 `0 → τM → E → M → 0` carries: `E ⟶ M` is right almost split and `τM ⟶ E` is left almost split.
 This file builds them as conditions on a single morphism of an arbitrary category, so that the
-sequence-level notion can be assembled from them, and proves the two facts that make the
+sequence-level notion can be assembled from them — it is, as `TauCeti.IsAlmostSplit` in
+`TauCeti/CategoryTheory/AlmostSplit/Sequence.lean` — and proves the two facts that make the
 indecomposability clauses in the definition of an almost-split sequence redundant: **the target of
 a right almost split morphism is indecomposable**, and dually **the source of a left almost split
 morphism is indecomposable**. Neither end of an almost-split sequence has to be *assumed*

--- a/TauCeti/CategoryTheory/AlmostSplit/Sequence.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Sequence.lean
@@ -49,9 +49,6 @@ almost-split sequence is an epimorphism onto a nonzero object and so is never ze
 * `CategoryTheory.ShortComplex.IsAlmostSplit.not_projective_X₃` and `.not_injective_X₁`: **its
   right-hand end is not projective and its left-hand end is not injective.**  A projective
   right-hand end would section the sequence, an injective left-hand end would retract it.
-* `CategoryTheory.ShortComplex.IsAlmostSplit.not_mono_g` and `.not_epi_f`: in a balanced category
-  the second map is an epimorphism that is not a monomorphism, and the first map a monomorphism
-  that is not an epimorphism.
 * `CategoryTheory.ShortComplex.isAlmostSplit_op_iff`: **being almost split is self-dual**, the two
   lifting conditions being exchanged by passage to the opposite category, so every statement about
   the left-hand end dualizes to one about the right-hand end.
@@ -143,18 +140,6 @@ namespace IsAlmostSplit
 
 /-! ### The maps of an almost-split sequence -/
 
-/-- The second map of an almost-split sequence is not a split monomorphism: short exactness makes
-it an epimorphism, so a splitting on that side would make it an isomorphism. -/
-theorem not_isSplitMono_g (hS : IsAlmostSplit S) : ¬ IsSplitMono S.g := by
-  have := hS.shortExact.epi_g
-  exact hS.isRightAlmostSplit_g.not_isSplitMono
-
-/-- The first map of an almost-split sequence is not a split epimorphism, dually to
-`CategoryTheory.ShortComplex.IsAlmostSplit.not_isSplitMono_g`. -/
-theorem not_isSplitEpi_f (hS : IsAlmostSplit S) : ¬ IsSplitEpi S.f := by
-  have := hS.shortExact.mono_f
-  exact hS.isLeftAlmostSplit_f.not_isSplitEpi
-
 /-- **The first map of an almost-split sequence is nonzero**: short exactness makes it a
 monomorphism, and a zero monomorphism has a zero source, whose identity would split it. -/
 theorem ne_zero_f (hS : IsAlmostSplit S) : S.f ≠ 0 := by
@@ -201,24 +186,6 @@ theorem not_injective_X₁ (hS : IsAlmostSplit S) : ¬ Injective S.X₁ := by
   have := hS.shortExact.mono_f
   exact hS.isLeftAlmostSplit_f.not_injective
 
-section Balanced
-
-variable [Balanced C]
-
-/-- In a balanced category the second map of an almost-split sequence is an epimorphism that is not
-a monomorphism: it would otherwise be an isomorphism. -/
-theorem not_mono_g (hS : IsAlmostSplit S) : ¬ Mono S.g := by
-  have := hS.shortExact.epi_g
-  exact hS.isRightAlmostSplit_g.not_mono
-
-/-- In a balanced category the first map of an almost-split sequence is a monomorphism that is not
-an epimorphism, dually to `CategoryTheory.ShortComplex.IsAlmostSplit.not_mono_g`. -/
-theorem not_epi_f (hS : IsAlmostSplit S) : ¬ Epi S.f := by
-  have := hS.shortExact.mono_f
-  exact hS.isLeftAlmostSplit_f.not_epi
-
-end Balanced
-
 /-! ### Duality -/
 
 /-- **The opposite of an almost-split sequence is almost split**: the two lifting clauses are
@@ -252,7 +219,7 @@ theorem isAlmostSplit_unop_iff {S : ShortComplex Cᵒᵖ} : IsAlmostSplit S.unop
 
 /-- **Being almost split is invariant under an isomorphism of short complexes**, so it descends to
 isomorphism classes of sequences. -/
-theorem IsAlmostSplit.of_iso (e : S₁ ≅ S₂) (hS : IsAlmostSplit S₁) : IsAlmostSplit S₂ where
+theorem isAlmostSplit_of_iso (e : S₁ ≅ S₂) (hS : IsAlmostSplit S₁) : IsAlmostSplit S₂ where
   shortExact := ShortComplex.shortExact_of_iso e hS.shortExact
   isLeftAlmostSplit_f := by
     have key : (asIso e.hom.τ₁).symm.hom ≫ S₁.f ≫ (asIso e.hom.τ₂).hom = S₂.f := by
@@ -265,6 +232,6 @@ theorem IsAlmostSplit.of_iso (e : S₁ ≅ S₂) (hS : IsAlmostSplit S₁) : IsA
 
 /-- Being almost split is invariant under an isomorphism of short complexes. -/
 theorem isAlmostSplit_iff_of_iso (e : S₁ ≅ S₂) : IsAlmostSplit S₁ ↔ IsAlmostSplit S₂ :=
-  ⟨IsAlmostSplit.of_iso e, IsAlmostSplit.of_iso e.symm⟩
+  ⟨isAlmostSplit_of_iso e, isAlmostSplit_of_iso e.symm⟩
 
 end CategoryTheory.ShortComplex

--- a/TauCeti/CategoryTheory/AlmostSplit/Sequence.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Sequence.lean
@@ -23,42 +23,40 @@ of the assembly, which is where the two conditions start to interact with exactn
 
 The definition carries only three fields, and this is deliberate: the textbook definition also
 demands that the sequence does not split, that both ends are indecomposable, and that the right-hand
-end is not projective, and **every one of those is a theorem here**, not a hypothesis.
-Non-splitness and indecomposability already follow from the lifting properties alone
-(`TauCeti.isEmpty_splitting_of_isRightAlmostSplit`, `TauCeti.IsRightAlmostSplit.indecomposable`);
-non-projectivity of the right-hand end and non-injectivity of the left-hand end need exactness too,
-and are `TauCeti.IsAlmostSplit.not_projective_X₃` and `TauCeti.IsAlmostSplit.not_injective_X₁`
-below.  Assuming redundant clauses would only make the predicate harder to establish.
+end is not projective, and **every one of those is a theorem**, not a hypothesis.  Non-splitness and
+indecomposability already follow from the lifting properties alone, so they are available from the
+two lifting fields through `TauCeti.isEmpty_splitting_of_isRightAlmostSplit` and
+`TauCeti.IsRightAlmostSplit.indecomposable`; non-projectivity of the right-hand end and
+non-injectivity of the left-hand end need exactness too, and are
+`CategoryTheory.ShortComplex.IsAlmostSplit.not_projective_X₃` and
+`CategoryTheory.ShortComplex.IsAlmostSplit.not_injective_X₁` below.  Assuming redundant clauses
+would only make the predicate harder to establish.
 
 Exactness also removes the degenerate case the morphism-level notions leave open.  A right almost
 split morphism may be zero — over a field, `0 ⟶ k` is right almost split — but the second map of an
 almost-split sequence is an epimorphism onto a nonzero object and so is never zero
-(`TauCeti.IsAlmostSplit.ne_zero_g`), and dually for the first map.
+(`CategoryTheory.ShortComplex.IsAlmostSplit.ne_zero_g`), and dually for the first map.
 
 ## Main definitions
 
-* `TauCeti.IsAlmostSplit`: a short complex is almost split when it is short exact, its first map is
-  left almost split and its second map is right almost split.
+* `CategoryTheory.ShortComplex.IsAlmostSplit`: a short complex is almost split when it is short
+  exact, its first map is left almost split and its second map is right almost split.
 
 ## Main results
 
-* `TauCeti.IsAlmostSplit.indecomposable_X₁` and `TauCeti.IsAlmostSplit.indecomposable_X₃`: **both
-  ends of an almost-split sequence are indecomposable**, and all three of its objects are nonzero.
-* `TauCeti.IsAlmostSplit.isEmpty_splitting`: **an almost-split sequence does not split.**
-* `TauCeti.IsAlmostSplit.not_projective_X₃` and `TauCeti.IsAlmostSplit.not_injective_X₁`: **its
+* `CategoryTheory.ShortComplex.IsAlmostSplit.not_isZero_X₁`, `.not_isZero_X₂` and `.not_isZero_X₃`:
+  **all three objects of an almost-split sequence are nonzero**, because neither of its maps is.
+* `CategoryTheory.ShortComplex.IsAlmostSplit.not_projective_X₃` and `.not_injective_X₁`: **its
   right-hand end is not projective and its left-hand end is not injective.**  A projective
   right-hand end would section the sequence, an injective left-hand end would retract it.
-* `TauCeti.IsAlmostSplit.not_mono_g` and `TauCeti.IsAlmostSplit.not_epi_f`: in a balanced category
-  the two maps are strictly an epimorphism and a monomorphism.
-* `TauCeti.isAlmostSplit_op_iff`: **being almost split is self-dual**, the two lifting conditions
-  being exchanged by passage to the opposite category, so every statement about the left-hand end
-  dualizes to one about the right-hand end.
-* `TauCeti.isAlmostSplit_iff_of_iso`: the notion is invariant under an isomorphism of short
-  complexes, so it descends to isomorphism classes of sequences.
-* `TauCeti.IsAlmostSplit.exists_isSplitMono_comp_g_eq`: **every irreducible morphism into the
-  right-hand end factors through the middle term by a split monomorphism**, which is what makes the
-  middle term of an almost-split sequence the receptacle of the irreducible morphisms into its
-  right-hand end, and ties the sequence to the arrows of the Auslander-Reiten quiver.
+* `CategoryTheory.ShortComplex.IsAlmostSplit.not_mono_g` and `.not_epi_f`: in a balanced category
+  the second map is an epimorphism that is not a monomorphism, and the first map a monomorphism
+  that is not an epimorphism.
+* `CategoryTheory.ShortComplex.isAlmostSplit_op_iff`: **being almost split is self-dual**, the two
+  lifting conditions being exchanged by passage to the opposite category, so every statement about
+  the left-hand end dualizes to one about the right-hand end.
+* `CategoryTheory.ShortComplex.isAlmostSplit_iff_of_iso`: the notion is invariant under an
+  isomorphism of short complexes, so it descends to isomorphism classes of sequences.
 
 ## Implementation notes
 
@@ -70,16 +68,11 @@ recorded.  Nothing in this file constrains `C` beyond what each statement needs,
 at the finite-dimensional subcategory of representations of a finite-dimensional algebra recovers
 the intended notion.
 
-The results needing a `CategoryTheory.ShortComplex.Splitting` sit in their own preadditive section
-rather than in the ambient `CategoryTheory.Limits.HasZeroMorphisms` one: `Splitting` is stated for
-the zero morphisms coming from the additive structure, which is not syntactically the ambient
-instance, so sharing one variable block would leave the two `ShortComplex C`s unequal.
+The declarations sit in the `CategoryTheory.ShortComplex` namespace, so that `hS.op` and
+`S.IsAlmostSplit` read as dot notation on Mathlib's `CategoryTheory.ShortComplex`; the two
+morphism-level lifting conditions they are assembled from stay in `TauCeti`.
 
 ## References
-
-This is the almost-split sequence of Layer 6 (Auslander-Reiten theory, sublayer 6E) of
-`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, together with the properties
-that layer records as clauses of the definition and which are proved here to be consequences of it.
 
 * M. Auslander, I. Reiten, S. Smalø, *Representation Theory of Artin Algebras*, CUP (1995), V.1.
 * I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
@@ -88,26 +81,22 @@ that layer records as clauses of the definition and which are proved here to be 
 
 public section
 
-namespace TauCeti
-
-open CategoryTheory CategoryTheory.Limits
+open CategoryTheory CategoryTheory.Limits TauCeti
 
 universe v u
 
-variable {C : Type u} [Category.{v} C]
+namespace CategoryTheory.ShortComplex
 
-section ZeroMorphisms
-
-variable [HasZeroMorphisms C] {S S₁ S₂ : ShortComplex C}
+variable {C : Type u} [Category.{v} C] [HasZeroMorphisms C] {S S₁ S₂ : ShortComplex C}
 
 /-- **An almost-split (Auslander-Reiten) sequence**: a short exact sequence whose first map is left
 almost split and whose second map is right almost split.
 
 The textbook additional demands — that the sequence does not split, that its two ends are
 indecomposable, and that its right-hand end is not projective — are consequences of these three
-clauses (`TauCeti.IsAlmostSplit.isEmpty_splitting`, `TauCeti.IsAlmostSplit.indecomposable_X₁`,
-`TauCeti.IsAlmostSplit.indecomposable_X₃`, `TauCeti.IsAlmostSplit.not_projective_X₃`) and are
-therefore not fields. -/
+clauses (`TauCeti.isEmpty_splitting_of_isRightAlmostSplit`,
+`TauCeti.IsLeftAlmostSplit.indecomposable`, `TauCeti.IsRightAlmostSplit.indecomposable`,
+`CategoryTheory.ShortComplex.IsAlmostSplit.not_projective_X₃`) and are therefore not fields. -/
 structure IsAlmostSplit (S : ShortComplex C) : Prop where
   /-- An almost-split sequence is a short exact sequence. -/
   shortExact : S.ShortExact
@@ -133,47 +122,31 @@ theorem exact (hS : IsAlmostSplit S) : S.Exact := hS.shortExact.exact
 
 /-! ### The maps of an almost-split sequence -/
 
-/-- The first map of an almost-split sequence is not a split monomorphism, the negative clause of
-the left almost split condition. -/
-theorem not_isSplitMono_f (hS : IsAlmostSplit S) : ¬ IsSplitMono S.f :=
-  hS.isLeftAlmostSplit_f.not_isSplitMono
-
-/-- The second map of an almost-split sequence is not a split epimorphism, the negative clause of
-the right almost split condition. -/
-theorem not_isSplitEpi_g (hS : IsAlmostSplit S) : ¬ IsSplitEpi S.g :=
-  hS.isRightAlmostSplit_g.not_isSplitEpi
-
-/-- The first map of an almost-split sequence is not an isomorphism. -/
-theorem not_isIso_f (hS : IsAlmostSplit S) : ¬ IsIso S.f := hS.isLeftAlmostSplit_f.not_isIso
-
-/-- The second map of an almost-split sequence is not an isomorphism. -/
-theorem not_isIso_g (hS : IsAlmostSplit S) : ¬ IsIso S.g := hS.isRightAlmostSplit_g.not_isIso
-
 /-- The second map of an almost-split sequence is not a split monomorphism: it is an epimorphism,
 so a splitting on that side would make it an isomorphism. -/
 theorem not_isSplitMono_g (hS : IsAlmostSplit S) : ¬ IsSplitMono S.g := fun _ => by
   have := hS.epi_g
-  exact hS.not_isIso_g (isIso_of_epi_of_isSplitMono S.g)
+  exact hS.isRightAlmostSplit_g.not_isIso (isIso_of_epi_of_isSplitMono S.g)
 
 /-- The first map of an almost-split sequence is not a split epimorphism, dually to
-`TauCeti.IsAlmostSplit.not_isSplitMono_g`. -/
+`CategoryTheory.ShortComplex.IsAlmostSplit.not_isSplitMono_g`. -/
 theorem not_isSplitEpi_f (hS : IsAlmostSplit S) : ¬ IsSplitEpi S.f := fun _ => by
   have := hS.mono_f
-  exact hS.not_isIso_f (isIso_of_mono_of_isSplitEpi S.f)
+  exact hS.isLeftAlmostSplit_f.not_isIso (isIso_of_mono_of_isSplitEpi S.f)
 
 /-- **The first map of an almost-split sequence is nonzero.**  A zero monomorphism forces its
 source to be a zero object, and the zero morphism out of a zero object is a split monomorphism. -/
 theorem ne_zero_f (hS : IsAlmostSplit S) : S.f ≠ 0 := fun h => by
   have := hS.mono_f
   have hid : 𝟙 S.X₁ = 0 := (cancel_mono S.f).mp (by simp [h])
-  exact hS.not_isSplitMono_f (IsSplitMono.mk' ⟨0, by simp [hid]⟩)
+  exact hS.isLeftAlmostSplit_f.not_isSplitMono (IsSplitMono.mk' ⟨0, by simp [hid]⟩)
 
 /-- **The second map of an almost-split sequence is nonzero**, dually to
-`TauCeti.IsAlmostSplit.ne_zero_f`. -/
+`CategoryTheory.ShortComplex.IsAlmostSplit.ne_zero_f`. -/
 theorem ne_zero_g (hS : IsAlmostSplit S) : S.g ≠ 0 := fun h => by
   have := hS.epi_g
   have hid : 𝟙 S.X₃ = 0 := (cancel_epi S.g).mp (by simp [h])
-  exact hS.not_isSplitEpi_g (IsSplitEpi.mk' ⟨0, by simp [hid]⟩)
+  exact hS.isRightAlmostSplit_g.not_isSplitEpi (IsSplitEpi.mk' ⟨0, by simp [hid]⟩)
 
 /-! ### The objects of an almost-split sequence -/
 
@@ -192,55 +165,40 @@ second map. -/
 theorem not_isZero_X₃ (hS : IsAlmostSplit S) : ¬ IsZero S.X₃ := fun h =>
   hS.ne_zero_g (h.eq_of_tgt _ _)
 
-section Biproducts
+/-! ### Projectivity and injectivity of the ends -/
 
-variable [HasBinaryBiproducts C]
+/-- **The right-hand end of an almost-split sequence is not projective.**  This is where exactness
+enters: it supplies the epimorphism `S.g` that
+`TauCeti.IsRightAlmostSplit.not_projective` asks for, and a projective right-hand end would then
+section the sequence. -/
+theorem not_projective_X₃ (hS : IsAlmostSplit S) : ¬ Projective S.X₃ := by
+  have := hS.epi_g
+  exact hS.isRightAlmostSplit_g.not_projective
 
-/-- **The left-hand end of an almost-split sequence is indecomposable**, by the left almost split
-clause alone. -/
-theorem indecomposable_X₁ (hS : IsAlmostSplit S) : Indecomposable S.X₁ :=
-  hS.isLeftAlmostSplit_f.indecomposable
-
-/-- **The right-hand end of an almost-split sequence is indecomposable**, by the right almost split
-clause alone. -/
-theorem indecomposable_X₃ (hS : IsAlmostSplit S) : Indecomposable S.X₃ :=
-  hS.isRightAlmostSplit_g.indecomposable
-
-end Biproducts
+/-- **The left-hand end of an almost-split sequence is not injective**, dually to
+`CategoryTheory.ShortComplex.IsAlmostSplit.not_projective_X₃`: exactness supplies the monomorphism
+`S.f`, and an injective left-hand end would retract the sequence. -/
+theorem not_injective_X₁ (hS : IsAlmostSplit S) : ¬ Injective S.X₁ := by
+  have := hS.mono_f
+  exact hS.isLeftAlmostSplit_f.not_injective
 
 section Balanced
 
 variable [Balanced C]
 
-/-- In a balanced category the second map of an almost-split sequence is a strict epimorphism: it
-is not also a monomorphism, since it would then be an isomorphism. -/
+/-- In a balanced category the second map of an almost-split sequence is an epimorphism that is not
+a monomorphism: it would otherwise be an isomorphism. -/
 theorem not_mono_g (hS : IsAlmostSplit S) : ¬ Mono S.g := fun _ => by
   have := hS.epi_g
-  exact hS.not_isIso_g (isIso_of_mono_of_epi S.g)
+  exact hS.isRightAlmostSplit_g.not_isIso (isIso_of_mono_of_epi S.g)
 
-/-- In a balanced category the first map of an almost-split sequence is a strict monomorphism,
-dually to `TauCeti.IsAlmostSplit.not_mono_g`. -/
+/-- In a balanced category the first map of an almost-split sequence is a monomorphism that is not
+an epimorphism, dually to `CategoryTheory.ShortComplex.IsAlmostSplit.not_mono_g`. -/
 theorem not_epi_f (hS : IsAlmostSplit S) : ¬ Epi S.f := fun _ => by
   have := hS.mono_f
-  exact hS.not_isIso_f (isIso_of_mono_of_epi S.f)
+  exact hS.isLeftAlmostSplit_f.not_isIso (isIso_of_mono_of_epi S.f)
 
 end Balanced
-
-/-! ### Irreducible morphisms and an almost-split sequence -/
-
-/-- **An irreducible morphism into the right-hand end of an almost-split sequence factors through
-its middle term by a split monomorphism.**  So the middle term is the receptacle of the irreducible
-morphisms into the right-hand end: each of their sources is a retract of it. -/
-theorem exists_isSplitMono_comp_g_eq (hS : IsAlmostSplit S) {Z : C} {u : Z ⟶ S.X₃}
-    (hu : IsIrreducibleMorphism u) : ∃ v : Z ⟶ S.X₂, IsSplitMono v ∧ v ≫ S.g = u :=
-  hS.isRightAlmostSplit_g.exists_isSplitMono_of_isIrreducibleMorphism hu
-
-/-- **An irreducible morphism out of the left-hand end of an almost-split sequence factors through
-its middle term by a split epimorphism**, dually to
-`TauCeti.IsAlmostSplit.exists_isSplitMono_comp_g_eq`. -/
-theorem exists_isSplitEpi_f_comp_eq (hS : IsAlmostSplit S) {Z : C} {u : S.X₁ ⟶ Z}
-    (hu : IsIrreducibleMorphism u) : ∃ v : S.X₂ ⟶ Z, IsSplitEpi v ∧ S.f ≫ v = u :=
-  hS.isLeftAlmostSplit_f.exists_isSplitEpi_of_isIrreducibleMorphism hu
 
 /-! ### Duality -/
 
@@ -290,34 +248,4 @@ theorem IsAlmostSplit.of_iso (e : S₁ ≅ S₂) (hS : IsAlmostSplit S₁) : IsA
 theorem isAlmostSplit_iff_of_iso (e : S₁ ≅ S₂) : IsAlmostSplit S₁ ↔ IsAlmostSplit S₂ :=
   ⟨IsAlmostSplit.of_iso e, IsAlmostSplit.of_iso e.symm⟩
 
-end ZeroMorphisms
-
-/-! ### Non-splitness, projectivity and injectivity -/
-
-section Preadditive
-
-variable [Preadditive C] {S : ShortComplex C}
-
-namespace IsAlmostSplit
-
-/-- **An almost-split sequence does not split.** -/
-theorem isEmpty_splitting (hS : IsAlmostSplit S) : IsEmpty S.Splitting :=
-  isEmpty_splitting_of_isRightAlmostSplit hS.isRightAlmostSplit_g
-
-variable [Balanced C]
-
-/-- **The right-hand end of an almost-split sequence is not projective.**  A projective right-hand
-end would let the identity factor through the epimorphism `S.g`, splitting the sequence. -/
-theorem not_projective_X₃ (hS : IsAlmostSplit S) : ¬ Projective S.X₃ := fun _ =>
-  hS.isEmpty_splitting.false hS.shortExact.splittingOfProjective
-
-/-- **The left-hand end of an almost-split sequence is not injective.**  An injective left-hand end
-would let the identity factor through the monomorphism `S.f`, splitting the sequence. -/
-theorem not_injective_X₁ (hS : IsAlmostSplit S) : ¬ Injective S.X₁ := fun _ =>
-  hS.isEmpty_splitting.false hS.shortExact.splittingOfInjective
-
-end IsAlmostSplit
-
-end Preadditive
-
-end TauCeti
+end CategoryTheory.ShortComplex

--- a/TauCeti/CategoryTheory/AlmostSplit/Sequence.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Sequence.lean
@@ -57,6 +57,9 @@ almost-split sequence is an epimorphism onto a nonzero object and so is never ze
   the left-hand end dualizes to one about the right-hand end.
 * `CategoryTheory.ShortComplex.isAlmostSplit_iff_of_iso`: the notion is invariant under an
   isomorphism of short complexes, so it descends to isomorphism classes of sequences.
+* `TauCeti.isEmpty_splitting_of_isRightAlmostSplit` and
+  `TauCeti.isEmpty_splitting_of_isLeftAlmostSplit`: **a short complex one of whose maps is almost
+  split on the corresponding side has no splitting**, so an almost-split sequence does not split.
 
 ## Implementation notes
 
@@ -68,9 +71,16 @@ recorded.  Nothing in this file constrains `C` beyond what each statement needs,
 at the finite-dimensional subcategory of representations of a finite-dimensional algebra recovers
 the intended notion.
 
-The declarations sit in the `CategoryTheory.ShortComplex` namespace, so that `hS.op` and
-`S.IsAlmostSplit` read as dot notation on Mathlib's `CategoryTheory.ShortComplex`; the two
-morphism-level lifting conditions they are assembled from stay in `TauCeti`.
+The declarations about an almost-split sequence sit in the `CategoryTheory.ShortComplex` namespace,
+so that `hS.op` and `S.IsAlmostSplit` read as dot notation on Mathlib's
+`CategoryTheory.ShortComplex`; the two morphism-level lifting conditions they are assembled from
+stay in `TauCeti`, and so do the two non-splitting results, which are statements about a short
+complex carrying one almost split map rather than about an almost-split sequence.
+
+Those two results sit in their own preadditive section rather than in the ambient
+`CategoryTheory.Limits.HasZeroMorphisms` one: `CategoryTheory.ShortComplex.Splitting` is stated for
+the zero morphisms coming from the additive structure, which is not syntactically the ambient
+instance, so sharing one variable block would leave the two `ShortComplex C`s unequal.
 
 ## References
 
@@ -84,6 +94,28 @@ public section
 open CategoryTheory CategoryTheory.Limits TauCeti
 
 universe v u
+
+namespace TauCeti
+
+section Splitting
+
+variable {C : Type u} [Category.{v} C] [Preadditive C] {S : ShortComplex C}
+
+/-- **A short complex whose second map is right almost split does not split.** The `not_split`
+clause in the definition of an almost-split sequence is therefore redundant: it is implied by the
+right almost split clause alone. -/
+theorem isEmpty_splitting_of_isRightAlmostSplit (hg : IsRightAlmostSplit S.g) :
+    IsEmpty S.Splitting :=
+  ⟨fun s => hg.not_isSplitEpi s.isSplitEpi_g⟩
+
+/-- **A short complex whose first map is left almost split does not split.** -/
+theorem isEmpty_splitting_of_isLeftAlmostSplit (hf : IsLeftAlmostSplit S.f) :
+    IsEmpty S.Splitting :=
+  ⟨fun s => hf.not_isSplitMono s.isSplitMono_f⟩
+
+end Splitting
+
+end TauCeti
 
 namespace CategoryTheory.ShortComplex
 
@@ -109,44 +141,31 @@ structure IsAlmostSplit (S : ShortComplex C) : Prop where
 
 namespace IsAlmostSplit
 
-/-! ### The exactness data -/
-
-/-- The first map of an almost-split sequence is a monomorphism. -/
-theorem mono_f (hS : IsAlmostSplit S) : Mono S.f := hS.shortExact.mono_f
-
-/-- The second map of an almost-split sequence is an epimorphism. -/
-theorem epi_g (hS : IsAlmostSplit S) : Epi S.g := hS.shortExact.epi_g
-
-/-- An almost-split sequence is exact at its middle term. -/
-theorem exact (hS : IsAlmostSplit S) : S.Exact := hS.shortExact.exact
-
 /-! ### The maps of an almost-split sequence -/
 
-/-- The second map of an almost-split sequence is not a split monomorphism: it is an epimorphism,
-so a splitting on that side would make it an isomorphism. -/
-theorem not_isSplitMono_g (hS : IsAlmostSplit S) : ¬ IsSplitMono S.g := fun _ => by
-  have := hS.epi_g
-  exact hS.isRightAlmostSplit_g.not_isIso (isIso_of_epi_of_isSplitMono S.g)
+/-- The second map of an almost-split sequence is not a split monomorphism: short exactness makes
+it an epimorphism, so a splitting on that side would make it an isomorphism. -/
+theorem not_isSplitMono_g (hS : IsAlmostSplit S) : ¬ IsSplitMono S.g := by
+  have := hS.shortExact.epi_g
+  exact hS.isRightAlmostSplit_g.not_isSplitMono
 
 /-- The first map of an almost-split sequence is not a split epimorphism, dually to
 `CategoryTheory.ShortComplex.IsAlmostSplit.not_isSplitMono_g`. -/
-theorem not_isSplitEpi_f (hS : IsAlmostSplit S) : ¬ IsSplitEpi S.f := fun _ => by
-  have := hS.mono_f
-  exact hS.isLeftAlmostSplit_f.not_isIso (isIso_of_mono_of_isSplitEpi S.f)
+theorem not_isSplitEpi_f (hS : IsAlmostSplit S) : ¬ IsSplitEpi S.f := by
+  have := hS.shortExact.mono_f
+  exact hS.isLeftAlmostSplit_f.not_isSplitEpi
 
-/-- **The first map of an almost-split sequence is nonzero.**  A zero monomorphism forces its
-source to be a zero object, and the zero morphism out of a zero object is a split monomorphism. -/
-theorem ne_zero_f (hS : IsAlmostSplit S) : S.f ≠ 0 := fun h => by
-  have := hS.mono_f
-  have hid : 𝟙 S.X₁ = 0 := (cancel_mono S.f).mp (by simp [h])
-  exact hS.isLeftAlmostSplit_f.not_isSplitMono (IsSplitMono.mk' ⟨0, by simp [hid]⟩)
+/-- **The first map of an almost-split sequence is nonzero**: short exactness makes it a
+monomorphism, and a zero monomorphism has a zero source, whose identity would split it. -/
+theorem ne_zero_f (hS : IsAlmostSplit S) : S.f ≠ 0 := by
+  have := hS.shortExact.mono_f
+  exact hS.isLeftAlmostSplit_f.ne_zero
 
 /-- **The second map of an almost-split sequence is nonzero**, dually to
 `CategoryTheory.ShortComplex.IsAlmostSplit.ne_zero_f`. -/
-theorem ne_zero_g (hS : IsAlmostSplit S) : S.g ≠ 0 := fun h => by
-  have := hS.epi_g
-  have hid : 𝟙 S.X₃ = 0 := (cancel_epi S.g).mp (by simp [h])
-  exact hS.isRightAlmostSplit_g.not_isSplitEpi (IsSplitEpi.mk' ⟨0, by simp [hid]⟩)
+theorem ne_zero_g (hS : IsAlmostSplit S) : S.g ≠ 0 := by
+  have := hS.shortExact.epi_g
+  exact hS.isRightAlmostSplit_g.ne_zero
 
 /-! ### The objects of an almost-split sequence -/
 
@@ -172,14 +191,14 @@ enters: it supplies the epimorphism `S.g` that
 `TauCeti.IsRightAlmostSplit.not_projective` asks for, and a projective right-hand end would then
 section the sequence. -/
 theorem not_projective_X₃ (hS : IsAlmostSplit S) : ¬ Projective S.X₃ := by
-  have := hS.epi_g
+  have := hS.shortExact.epi_g
   exact hS.isRightAlmostSplit_g.not_projective
 
 /-- **The left-hand end of an almost-split sequence is not injective**, dually to
 `CategoryTheory.ShortComplex.IsAlmostSplit.not_projective_X₃`: exactness supplies the monomorphism
 `S.f`, and an injective left-hand end would retract the sequence. -/
 theorem not_injective_X₁ (hS : IsAlmostSplit S) : ¬ Injective S.X₁ := by
-  have := hS.mono_f
+  have := hS.shortExact.mono_f
   exact hS.isLeftAlmostSplit_f.not_injective
 
 section Balanced
@@ -188,15 +207,15 @@ variable [Balanced C]
 
 /-- In a balanced category the second map of an almost-split sequence is an epimorphism that is not
 a monomorphism: it would otherwise be an isomorphism. -/
-theorem not_mono_g (hS : IsAlmostSplit S) : ¬ Mono S.g := fun _ => by
-  have := hS.epi_g
-  exact hS.isRightAlmostSplit_g.not_isIso (isIso_of_mono_of_epi S.g)
+theorem not_mono_g (hS : IsAlmostSplit S) : ¬ Mono S.g := by
+  have := hS.shortExact.epi_g
+  exact hS.isRightAlmostSplit_g.not_mono
 
 /-- In a balanced category the first map of an almost-split sequence is a monomorphism that is not
 an epimorphism, dually to `CategoryTheory.ShortComplex.IsAlmostSplit.not_mono_g`. -/
-theorem not_epi_f (hS : IsAlmostSplit S) : ¬ Epi S.f := fun _ => by
-  have := hS.mono_f
-  exact hS.isLeftAlmostSplit_f.not_isIso (isIso_of_mono_of_epi S.f)
+theorem not_epi_f (hS : IsAlmostSplit S) : ¬ Epi S.f := by
+  have := hS.shortExact.mono_f
+  exact hS.isLeftAlmostSplit_f.not_epi
 
 end Balanced
 

--- a/TauCeti/CategoryTheory/AlmostSplit/Sequence.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit/Sequence.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Homology.ShortComplex.ShortExact
+public import TauCeti.CategoryTheory.AlmostSplit.Basic
+
+/-!
+# Almost-split (Auslander-Reiten) sequences
+
+An **almost-split sequence**, or **Auslander-Reiten sequence**, is a short exact sequence
+`0 ⟶ A ⟶ B ⟶ C ⟶ 0` whose first map is left almost split and whose second map is right almost
+split.  It is the basic object of Auslander-Reiten theory: `B ⟶ C` absorbs every map into `C` that
+is not a split epimorphism, and `A ⟶ B` absorbs every map out of `A` that is not a split
+monomorphism, so the sequence records all the "inessential" maps at both of its ends at once.
+
+`TauCeti/CategoryTheory/AlmostSplit/Basic.lean` builds the two lifting conditions on a single
+morphism; this file assembles them on a `CategoryTheory.ShortComplex` and develops the consequences
+of the assembly, which is where the two conditions start to interact with exactness.
+
+The definition carries only three fields, and this is deliberate: the textbook definition also
+demands that the sequence does not split, that both ends are indecomposable, and that the right-hand
+end is not projective, and **every one of those is a theorem here**, not a hypothesis.
+Non-splitness and indecomposability already follow from the lifting properties alone
+(`TauCeti.isEmpty_splitting_of_isRightAlmostSplit`, `TauCeti.IsRightAlmostSplit.indecomposable`);
+non-projectivity of the right-hand end and non-injectivity of the left-hand end need exactness too,
+and are `TauCeti.IsAlmostSplit.not_projective_X₃` and `TauCeti.IsAlmostSplit.not_injective_X₁`
+below.  Assuming redundant clauses would only make the predicate harder to establish.
+
+Exactness also removes the degenerate case the morphism-level notions leave open.  A right almost
+split morphism may be zero — over a field, `0 ⟶ k` is right almost split — but the second map of an
+almost-split sequence is an epimorphism onto a nonzero object and so is never zero
+(`TauCeti.IsAlmostSplit.ne_zero_g`), and dually for the first map.
+
+## Main definitions
+
+* `TauCeti.IsAlmostSplit`: a short complex is almost split when it is short exact, its first map is
+  left almost split and its second map is right almost split.
+
+## Main results
+
+* `TauCeti.IsAlmostSplit.indecomposable_X₁` and `TauCeti.IsAlmostSplit.indecomposable_X₃`: **both
+  ends of an almost-split sequence are indecomposable**, and all three of its objects are nonzero.
+* `TauCeti.IsAlmostSplit.isEmpty_splitting`: **an almost-split sequence does not split.**
+* `TauCeti.IsAlmostSplit.not_projective_X₃` and `TauCeti.IsAlmostSplit.not_injective_X₁`: **its
+  right-hand end is not projective and its left-hand end is not injective.**  A projective
+  right-hand end would section the sequence, an injective left-hand end would retract it.
+* `TauCeti.IsAlmostSplit.not_mono_g` and `TauCeti.IsAlmostSplit.not_epi_f`: in a balanced category
+  the two maps are strictly an epimorphism and a monomorphism.
+* `TauCeti.isAlmostSplit_op_iff`: **being almost split is self-dual**, the two lifting conditions
+  being exchanged by passage to the opposite category, so every statement about the left-hand end
+  dualizes to one about the right-hand end.
+* `TauCeti.isAlmostSplit_iff_of_iso`: the notion is invariant under an isomorphism of short
+  complexes, so it descends to isomorphism classes of sequences.
+* `TauCeti.IsAlmostSplit.exists_isSplitMono_comp_g_eq`: **every irreducible morphism into the
+  right-hand end factors through the middle term by a split monomorphism**, which is what makes the
+  middle term of an almost-split sequence the receptacle of the irreducible morphisms into its
+  right-hand end, and ties the sequence to the arrows of the Auslander-Reiten quiver.
+
+## Implementation notes
+
+The lifting quantifiers of `TauCeti.IsLeftAlmostSplit` and `TauCeti.IsRightAlmostSplit` range over
+all objects of the ambient category, and the ambient category intended for Auslander-Reiten theory
+is the finite-dimensional one; see the implementation notes of
+`TauCeti/CategoryTheory/AlmostSplit/Basic.lean`, where the failure of the unrestricted form is
+recorded.  Nothing in this file constrains `C` beyond what each statement needs, so instantiating it
+at the finite-dimensional subcategory of representations of a finite-dimensional algebra recovers
+the intended notion.
+
+The results needing a `CategoryTheory.ShortComplex.Splitting` sit in their own preadditive section
+rather than in the ambient `CategoryTheory.Limits.HasZeroMorphisms` one: `Splitting` is stated for
+the zero morphisms coming from the additive structure, which is not syntactically the ambient
+instance, so sharing one variable block would leave the two `ShortComplex C`s unequal.
+
+## References
+
+This is the almost-split sequence of Layer 6 (Auslander-Reiten theory, sublayer 6E) of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, together with the properties
+that layer records as clauses of the definition and which are proved here to be consequences of it.
+
+* M. Auslander, I. Reiten, S. Smalø, *Representation Theory of Artin Algebras*, CUP (1995), V.1.
+* I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
+  Algebras, Vol. 1*, LMS Student Texts 65, CUP (2006), IV.1.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe v u
+
+variable {C : Type u} [Category.{v} C]
+
+section ZeroMorphisms
+
+variable [HasZeroMorphisms C] {S S₁ S₂ : ShortComplex C}
+
+/-- **An almost-split (Auslander-Reiten) sequence**: a short exact sequence whose first map is left
+almost split and whose second map is right almost split.
+
+The textbook additional demands — that the sequence does not split, that its two ends are
+indecomposable, and that its right-hand end is not projective — are consequences of these three
+clauses (`TauCeti.IsAlmostSplit.isEmpty_splitting`, `TauCeti.IsAlmostSplit.indecomposable_X₁`,
+`TauCeti.IsAlmostSplit.indecomposable_X₃`, `TauCeti.IsAlmostSplit.not_projective_X₃`) and are
+therefore not fields. -/
+structure IsAlmostSplit (S : ShortComplex C) : Prop where
+  /-- An almost-split sequence is a short exact sequence. -/
+  shortExact : S.ShortExact
+  /-- Its first map is left almost split: every morphism out of the left-hand end that is not a
+  split monomorphism factors through the middle term. -/
+  isLeftAlmostSplit_f : IsLeftAlmostSplit S.f
+  /-- Its second map is right almost split: every morphism into the right-hand end that is not a
+  split epimorphism factors through the middle term. -/
+  isRightAlmostSplit_g : IsRightAlmostSplit S.g
+
+namespace IsAlmostSplit
+
+/-! ### The exactness data -/
+
+/-- The first map of an almost-split sequence is a monomorphism. -/
+theorem mono_f (hS : IsAlmostSplit S) : Mono S.f := hS.shortExact.mono_f
+
+/-- The second map of an almost-split sequence is an epimorphism. -/
+theorem epi_g (hS : IsAlmostSplit S) : Epi S.g := hS.shortExact.epi_g
+
+/-- An almost-split sequence is exact at its middle term. -/
+theorem exact (hS : IsAlmostSplit S) : S.Exact := hS.shortExact.exact
+
+/-! ### The maps of an almost-split sequence -/
+
+/-- The first map of an almost-split sequence is not a split monomorphism, the negative clause of
+the left almost split condition. -/
+theorem not_isSplitMono_f (hS : IsAlmostSplit S) : ¬ IsSplitMono S.f :=
+  hS.isLeftAlmostSplit_f.not_isSplitMono
+
+/-- The second map of an almost-split sequence is not a split epimorphism, the negative clause of
+the right almost split condition. -/
+theorem not_isSplitEpi_g (hS : IsAlmostSplit S) : ¬ IsSplitEpi S.g :=
+  hS.isRightAlmostSplit_g.not_isSplitEpi
+
+/-- The first map of an almost-split sequence is not an isomorphism. -/
+theorem not_isIso_f (hS : IsAlmostSplit S) : ¬ IsIso S.f := hS.isLeftAlmostSplit_f.not_isIso
+
+/-- The second map of an almost-split sequence is not an isomorphism. -/
+theorem not_isIso_g (hS : IsAlmostSplit S) : ¬ IsIso S.g := hS.isRightAlmostSplit_g.not_isIso
+
+/-- The second map of an almost-split sequence is not a split monomorphism: it is an epimorphism,
+so a splitting on that side would make it an isomorphism. -/
+theorem not_isSplitMono_g (hS : IsAlmostSplit S) : ¬ IsSplitMono S.g := fun _ => by
+  have := hS.epi_g
+  exact hS.not_isIso_g (isIso_of_epi_of_isSplitMono S.g)
+
+/-- The first map of an almost-split sequence is not a split epimorphism, dually to
+`TauCeti.IsAlmostSplit.not_isSplitMono_g`. -/
+theorem not_isSplitEpi_f (hS : IsAlmostSplit S) : ¬ IsSplitEpi S.f := fun _ => by
+  have := hS.mono_f
+  exact hS.not_isIso_f (isIso_of_mono_of_isSplitEpi S.f)
+
+/-- **The first map of an almost-split sequence is nonzero.**  A zero monomorphism forces its
+source to be a zero object, and the zero morphism out of a zero object is a split monomorphism. -/
+theorem ne_zero_f (hS : IsAlmostSplit S) : S.f ≠ 0 := fun h => by
+  have := hS.mono_f
+  have hid : 𝟙 S.X₁ = 0 := (cancel_mono S.f).mp (by simp [h])
+  exact hS.not_isSplitMono_f (IsSplitMono.mk' ⟨0, by simp [hid]⟩)
+
+/-- **The second map of an almost-split sequence is nonzero**, dually to
+`TauCeti.IsAlmostSplit.ne_zero_f`. -/
+theorem ne_zero_g (hS : IsAlmostSplit S) : S.g ≠ 0 := fun h => by
+  have := hS.epi_g
+  have hid : 𝟙 S.X₃ = 0 := (cancel_epi S.g).mp (by simp [h])
+  exact hS.not_isSplitEpi_g (IsSplitEpi.mk' ⟨0, by simp [hid]⟩)
+
+/-! ### The objects of an almost-split sequence -/
+
+/-- **The left-hand end of an almost-split sequence is nonzero**: it is the source of the nonzero
+first map. -/
+theorem not_isZero_X₁ (hS : IsAlmostSplit S) : ¬ IsZero S.X₁ := fun h =>
+  hS.ne_zero_f (h.eq_of_src _ _)
+
+/-- **The middle term of an almost-split sequence is nonzero**: it receives the nonzero first
+map. -/
+theorem not_isZero_X₂ (hS : IsAlmostSplit S) : ¬ IsZero S.X₂ := fun h =>
+  hS.ne_zero_f (h.eq_of_tgt _ _)
+
+/-- **The right-hand end of an almost-split sequence is nonzero**: it is the target of the nonzero
+second map. -/
+theorem not_isZero_X₃ (hS : IsAlmostSplit S) : ¬ IsZero S.X₃ := fun h =>
+  hS.ne_zero_g (h.eq_of_tgt _ _)
+
+section Biproducts
+
+variable [HasBinaryBiproducts C]
+
+/-- **The left-hand end of an almost-split sequence is indecomposable**, by the left almost split
+clause alone. -/
+theorem indecomposable_X₁ (hS : IsAlmostSplit S) : Indecomposable S.X₁ :=
+  hS.isLeftAlmostSplit_f.indecomposable
+
+/-- **The right-hand end of an almost-split sequence is indecomposable**, by the right almost split
+clause alone. -/
+theorem indecomposable_X₃ (hS : IsAlmostSplit S) : Indecomposable S.X₃ :=
+  hS.isRightAlmostSplit_g.indecomposable
+
+end Biproducts
+
+section Balanced
+
+variable [Balanced C]
+
+/-- In a balanced category the second map of an almost-split sequence is a strict epimorphism: it
+is not also a monomorphism, since it would then be an isomorphism. -/
+theorem not_mono_g (hS : IsAlmostSplit S) : ¬ Mono S.g := fun _ => by
+  have := hS.epi_g
+  exact hS.not_isIso_g (isIso_of_mono_of_epi S.g)
+
+/-- In a balanced category the first map of an almost-split sequence is a strict monomorphism,
+dually to `TauCeti.IsAlmostSplit.not_mono_g`. -/
+theorem not_epi_f (hS : IsAlmostSplit S) : ¬ Epi S.f := fun _ => by
+  have := hS.mono_f
+  exact hS.not_isIso_f (isIso_of_mono_of_epi S.f)
+
+end Balanced
+
+/-! ### Irreducible morphisms and an almost-split sequence -/
+
+/-- **An irreducible morphism into the right-hand end of an almost-split sequence factors through
+its middle term by a split monomorphism.**  So the middle term is the receptacle of the irreducible
+morphisms into the right-hand end: each of their sources is a retract of it. -/
+theorem exists_isSplitMono_comp_g_eq (hS : IsAlmostSplit S) {Z : C} {u : Z ⟶ S.X₃}
+    (hu : IsIrreducibleMorphism u) : ∃ v : Z ⟶ S.X₂, IsSplitMono v ∧ v ≫ S.g = u :=
+  hS.isRightAlmostSplit_g.exists_isSplitMono_of_isIrreducibleMorphism hu
+
+/-- **An irreducible morphism out of the left-hand end of an almost-split sequence factors through
+its middle term by a split epimorphism**, dually to
+`TauCeti.IsAlmostSplit.exists_isSplitMono_comp_g_eq`. -/
+theorem exists_isSplitEpi_f_comp_eq (hS : IsAlmostSplit S) {Z : C} {u : S.X₁ ⟶ Z}
+    (hu : IsIrreducibleMorphism u) : ∃ v : S.X₂ ⟶ Z, IsSplitEpi v ∧ S.f ≫ v = u :=
+  hS.isLeftAlmostSplit_f.exists_isSplitEpi_of_isIrreducibleMorphism hu
+
+/-! ### Duality -/
+
+/-- **The opposite of an almost-split sequence is almost split**: the two lifting clauses are
+exchanged by `TauCeti.isLeftAlmostSplit_op_iff` and `TauCeti.isRightAlmostSplit_op_iff`, and the
+opposite of a short exact sequence is short exact. -/
+theorem op (hS : IsAlmostSplit S) : IsAlmostSplit S.op where
+  shortExact := hS.shortExact.op
+  isLeftAlmostSplit_f := isLeftAlmostSplit_op_iff.mpr hS.isRightAlmostSplit_g
+  isRightAlmostSplit_g := isRightAlmostSplit_op_iff.mpr hS.isLeftAlmostSplit_f
+
+/-- **The sequence underlying an almost-split sequence of the opposite category is almost
+split.** -/
+theorem unop {S : ShortComplex Cᵒᵖ} (hS : IsAlmostSplit S) : IsAlmostSplit S.unop where
+  shortExact := hS.shortExact.unop
+  isLeftAlmostSplit_f := isRightAlmostSplit_op_iff.mp hS.isRightAlmostSplit_g
+  isRightAlmostSplit_g := isLeftAlmostSplit_op_iff.mp hS.isLeftAlmostSplit_f
+
+end IsAlmostSplit
+
+/-- **Being almost split is a self-dual condition.** -/
+@[simp]
+theorem isAlmostSplit_op_iff : IsAlmostSplit S.op ↔ IsAlmostSplit S :=
+  ⟨IsAlmostSplit.unop, IsAlmostSplit.op⟩
+
+/-- **Being almost split is a self-dual condition**, read from the opposite category. -/
+@[simp]
+theorem isAlmostSplit_unop_iff {S : ShortComplex Cᵒᵖ} : IsAlmostSplit S.unop ↔ IsAlmostSplit S :=
+  ⟨IsAlmostSplit.op, IsAlmostSplit.unop⟩
+
+/-! ### Invariance under isomorphisms of short complexes -/
+
+/-- **Being almost split is invariant under an isomorphism of short complexes**, so it descends to
+isomorphism classes of sequences. -/
+theorem IsAlmostSplit.of_iso (e : S₁ ≅ S₂) (hS : IsAlmostSplit S₁) : IsAlmostSplit S₂ where
+  shortExact := ShortComplex.shortExact_of_iso e hS.shortExact
+  isLeftAlmostSplit_f := by
+    have key : (asIso e.hom.τ₁).symm.hom ≫ S₁.f ≫ (asIso e.hom.τ₂).hom = S₂.f := by
+      simp [← e.hom.comm₁₂]
+    exact key ▸ (hS.isLeftAlmostSplit_f.comp_iso (asIso e.hom.τ₂)).iso_comp (asIso e.hom.τ₁).symm
+  isRightAlmostSplit_g := by
+    have key : (asIso e.hom.τ₂).symm.hom ≫ S₁.g ≫ (asIso e.hom.τ₃).hom = S₂.g := by
+      simp [← e.hom.comm₂₃]
+    exact key ▸ (hS.isRightAlmostSplit_g.comp_iso (asIso e.hom.τ₃)).iso_comp (asIso e.hom.τ₂).symm
+
+/-- Being almost split is invariant under an isomorphism of short complexes. -/
+theorem isAlmostSplit_iff_of_iso (e : S₁ ≅ S₂) : IsAlmostSplit S₁ ↔ IsAlmostSplit S₂ :=
+  ⟨IsAlmostSplit.of_iso e, IsAlmostSplit.of_iso e.symm⟩
+
+end ZeroMorphisms
+
+/-! ### Non-splitness, projectivity and injectivity -/
+
+section Preadditive
+
+variable [Preadditive C] {S : ShortComplex C}
+
+namespace IsAlmostSplit
+
+/-- **An almost-split sequence does not split.** -/
+theorem isEmpty_splitting (hS : IsAlmostSplit S) : IsEmpty S.Splitting :=
+  isEmpty_splitting_of_isRightAlmostSplit hS.isRightAlmostSplit_g
+
+variable [Balanced C]
+
+/-- **The right-hand end of an almost-split sequence is not projective.**  A projective right-hand
+end would let the identity factor through the epimorphism `S.g`, splitting the sequence. -/
+theorem not_projective_X₃ (hS : IsAlmostSplit S) : ¬ Projective S.X₃ := fun _ =>
+  hS.isEmpty_splitting.false hS.shortExact.splittingOfProjective
+
+/-- **The left-hand end of an almost-split sequence is not injective.**  An injective left-hand end
+would let the identity factor through the monomorphism `S.f`, splitting the sequence. -/
+theorem not_injective_X₁ (hS : IsAlmostSplit S) : ¬ Injective S.X₁ := fun _ =>
+  hS.isEmpty_splitting.false hS.shortExact.splittingOfInjective
+
+end IsAlmostSplit
+
+end Preadditive
+
+end TauCeti


### PR DESCRIPTION
This PR assembles the **almost-split (Auslander-Reiten) sequence** from the two almost split lifting
conditions the repository already has, as the predicate `CategoryTheory.ShortComplex.IsAlmostSplit`
on a `CategoryTheory.ShortComplex`, and proves that the extra clauses the textbook definition
carries are consequences of the three it keeps: all three of its objects are nonzero, its right-hand
end is not projective and its left-hand end is not injective. It also shows the notion is self-dual
(`isAlmostSplit_op_iff`) and invariant under an isomorphism of short complexes
(`isAlmostSplit_iff_of_iso`).

The roadmap target is `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, Layer 6
(Auslander-Reiten theory), sublayer 6E, the bullet "**Almost-split sequences.** `IsAlmostSplit S` for
a `ShortComplex S`, `0 → τM → E → M → 0`, that is `ShortComplex.ShortExact`, non-split, with `M`
indecomposable non-projective and every non-split-epi `X → M` factoring through `E → M` (right
almost split), dually on the left at `τM`." This is the definition half of that bullet; existence and
uniqueness of almost-split sequences, the other half, rest on local endomorphism rings and are not
attempted here. `TauCeti/CategoryTheory/AlmostSplit/Basic.lean` (merged earlier) built the two
lifting conditions on a single morphism explicitly "so that the sequence-level notion can be
assembled from them"; this is that assembly, and it is the first point at which the lifting
conditions meet exactness. The earlier sublayers of Layer 6 that 6E reads after are on `main`: 6A as
`TauCeti/CategoryTheory/IrreducibleMorphism.lean` and `TauCeti/CategoryTheory/Preadditive/Radical.lean`,
6B as `TauCeti/Algebra/Module/MinimalProjectivePresentation.lean`, 6C as
`TauCeti/Algebra/Module/AuslanderReiten/Transpose.lean` and 6D as
`TauCeti/Algebra/Module/AuslanderReiten/Translate.lean`.

The predicate has exactly three fields — short exactness, `IsLeftAlmostSplit S.f`,
`IsRightAlmostSplit S.g` — which is the definition of Auslander-Reiten-Smalø, *Representation Theory
of Artin Algebras*, V.1 and Assem-Simson-Skowroński, *Elements of the Representation Theory of
Associative Algebras I*, IV.1. The non-splitness, indecomposability and non-projectivity clauses
named in the roadmap bullet are available without being assumed: non-splitness and indecomposability
already from the lifting fields alone, as `TauCeti.isEmpty_splitting_of_isRightAlmostSplit
hS.isRightAlmostSplit_g` and `hS.isRightAlmostSplit_g.indecomposable` /
`hS.isLeftAlmostSplit_f.indecomposable`, and non-projectivity as
`IsAlmostSplit.not_projective_X₃` here, which is where exactness enters. There is deliberately no
`τ`-identifying field: the identification of the left-hand end with `D Tr` of the right-hand end is
the content of the Auslander-Reiten existence theorem rather than part of the definition, and the
translate this repository has (`TauCeti.AuslanderReitenTranslate`) is attached to a minimal
projective presentation of a module, not to an object of an abstract category, so such a field is
not expressible at this generality. Each statement carries only the hypotheses it needs:
`HasZeroMorphisms` throughout.

Everything that needs only one of the two lifting conditions together with an `Epi`/`Mono`
instance is proved at morphism level in `AlmostSplit/Basic.lean`:
`TauCeti.IsRightAlmostSplit.not_projective`, `.not_isSplitMono`, `.not_mono` and `.ne_zero` for an
epimorphic right almost split morphism, and `TauCeti.IsLeftAlmostSplit.not_injective`,
`.not_isSplitEpi`, `.not_epi` and `.ne_zero` for a monomorphic left almost split one; each applies
to an almost-split sequence once `hS.shortExact.epi_g` or `.mono_f` supplies the instance, so this
file restates only the two that the sequence-level API names,
`IsAlmostSplit.not_projective_X₃` and `.not_injective_X₁`, together with `.ne_zero_f` and
`.ne_zero_g`, which the nonzero-object results consume.
`TauCeti.isEmpty_splitting_of_isRightAlmostSplit` and
`TauCeti.isEmpty_splitting_of_isLeftAlmostSplit`, statements about a short complex, move from
`AlmostSplit/Basic.lean` into this file, which lets `Basic.lean` drop its
`Mathlib.Algebra.Homology.ShortComplex.Exact` import.

`TauCeti/CategoryTheory/AlmostSplit.lean` moves so that the two files do not sit as flat
`AlmostSplit*` siblings; no declaration is renamed and no other module imported it.

| old module | new module |
| --- | --- |
| `TauCeti.CategoryTheory.AlmostSplit` | `TauCeti.CategoryTheory.AlmostSplit.Basic` |

No Mathlib infrastructure was vendored; the file consumes `CategoryTheory.ShortComplex`,
`ShortComplex.ShortExact`, `CategoryTheory.Projective` and `CategoryTheory.Injective` with their
`factorThru` API, and the opposite-category and balanced-category API.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"isalmostsplit"}-->

🤖 Prepared with Claude Code


