### PR TITLE
refactor: give Lie ideal quotients dot notation

### DIFF
--- a/TauCeti/Algebra/Lie/Presentation/Basic.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Basic.lean
@@ -19,9 +19,9 @@ presentation is used for: a homomorphism out of the presented algebra is the sam
 of images satisfying the relations. This file supplies the three facts that bridge is made of.
 
 The first is the universal property of the quotient. `LieSubmodule.Quotient.mk'` presents the
-quotient map only as a morphism of Lie *modules*, so `TauCeti.LieIdeal.mkQ` records it as a morphism
-of Lie *algebras*, `TauCeti.LieIdeal.liftQ` factors a homomorphism killing the ideal through it, and
-`TauCeti.LieIdeal.lieHom_qext` says the factorisation is unique. These mirror `Submodule.mkQ`,
+quotient map only as a morphism of Lie *modules*, so `LieIdeal.mkQ` records it as a morphism
+of Lie *algebras*, `LieIdeal.liftQ` factors a homomorphism killing the ideal through it, and
+`LieIdeal.lieHom_qext` says the factorisation is unique. These mirror `Submodule.mkQ`,
 `Submodule.liftQ` and `Submodule.linearMap_qext`, to which the proofs reduce once the bracket is
 checked on representatives, where it is the bracket of representatives by construction.
 
@@ -38,13 +38,13 @@ generate the presented algebra, rather than merely determine maps out of it.
 
 ## Main definitions
 
-* `TauCeti.LieIdeal.mkQ`: the quotient map `L →ₗ⁅R⁆ L ⧸ I`.
-* `TauCeti.LieIdeal.liftQ`: the homomorphism `L ⧸ I →ₗ⁅R⁆ L'` induced by a homomorphism
+* `LieIdeal.mkQ`: the quotient map `L →ₗ⁅R⁆ L ⧸ I`.
+* `LieIdeal.liftQ`: the homomorphism `L ⧸ I →ₗ⁅R⁆ L'` induced by a homomorphism
   `L →ₗ⁅R⁆ L'` whose kernel contains `I`.
 
 ## Main results
 
-* `TauCeti.LieIdeal.liftQ_comp_mkQ` and `TauCeti.LieIdeal.lieHom_qext`: the lifted homomorphism
+* `LieIdeal.liftQ_comp_mkQ` and `LieIdeal.lieHom_qext`: the lifted homomorphism
   restricts to the original one along the quotient map, and is the only homomorphism that does.
 * `TauCeti.LieHom.map_ad_pow`: a homomorphism carries `(ad x) ^ n y` to `(ad (f x)) ^ n (f y)`.
 * `TauCeti.ad_neg_pow_apply_eq_zero`: negating the element acting by `ad` preserves the vanishing of
@@ -54,21 +54,21 @@ generate the presented algebra, rather than merely determine maps out of it.
 
 ## Implementation notes
 
-Neither `TauCeti.LieIdeal.mkQ` nor `TauCeti.LieIdeal.liftQ` is exposed: `TauCeti.LieIdeal.mkQ_apply`
-and `TauCeti.LieIdeal.liftQ_apply_mkQ` characterise them on elements, and
-`TauCeti.LieIdeal.ker_mkQ`, `TauCeti.LieIdeal.liftQ_comp_mkQ` and `TauCeti.LieIdeal.eq_liftQ` say
+Neither `LieIdeal.mkQ` nor `LieIdeal.liftQ` is exposed: `LieIdeal.mkQ_apply`
+and `LieIdeal.liftQ_apply_mkQ` characterise them on elements, and
+`LieIdeal.ker_mkQ`, `LieIdeal.liftQ_comp_mkQ` and `LieIdeal.eq_liftQ` say
 all a consumer needs about their kernel and their factorisation, so nothing downstream has to
 unfold the quotient. Those three
 equations are proved by the parenthesised `(rfl)`, which elaborates against the definitions
 themselves; a bare `rfl` in an exported theorem would demand that they be `@[expose]`d.
 
-`TauCeti.LieIdeal.liftQ_apply_mkQ` is the composite of `TauCeti.LieIdeal.mkQ_apply` and
-`TauCeti.LieIdeal.liftQ_apply_mk`, but only inside this file: unexposed bodies mean that in another
+`LieIdeal.liftQ_apply_mkQ` is the composite of `LieIdeal.mkQ_apply` and
+`LieIdeal.liftQ_apply_mk`, but only inside this file: unexposed bodies mean that in another
 module `mkQ I x` is not defeq to `LieSubmodule.Quotient.mk x`, so a consumer whose goal is stated
 in terms of its own definitions cannot chain the two lemmas there.
 
-Surjectivity of `TauCeti.LieIdeal.mkQ` is not restated: it is Mathlib's
-`LieSubmodule.Quotient.surjective_mk'` transported along `TauCeti.LieIdeal.mkQ_apply`.
+Surjectivity of `LieIdeal.mkQ` is not restated: it is Mathlib's
+`LieSubmodule.Quotient.surjective_mk'` transported along `LieIdeal.mkQ_apply`.
 
 ## Roadmap
 
@@ -79,8 +79,6 @@ of Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`.
 -/
 
 public section
-
-namespace TauCeti
 
 namespace LieIdeal
 
@@ -126,9 +124,9 @@ theorem liftQ_apply_mk (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
 
 /-- The induced homomorphism on the quotient agrees with `f` on the image of the quotient map.
 
-Not a `simp` lemma: `TauCeti.LieIdeal.mkQ_apply` and `TauCeti.LieIdeal.liftQ_apply_mk` already
+Not a `simp` lemma: `LieIdeal.mkQ_apply` and `LieIdeal.liftQ_apply_mk` already
 rewrite the left-hand side here, and `simp` rejects a lemma its own set can prove. It is still
-needed as a lemma, because those two only chain where the body of `TauCeti.LieIdeal.mkQ` is
+needed as a lemma, because those two only chain where the body of `LieIdeal.mkQ` is
 visible: in another module `mkQ I x` is not reducible to `LieSubmodule.Quotient.mk x`. -/
 theorem liftQ_apply_mkQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
     liftQ f h (mkQ I x) = f x := (rfl)
@@ -148,13 +146,15 @@ theorem lieHom_qext {g₁ g₂ : L ⧸ I →ₗ⁅R⁆ L'} (h : ∀ x : L, g₁ 
   induction x using Quotient.inductionOn' with | _ x
   exact h x
 
-/-- The factorisation of `TauCeti.LieIdeal.liftQ` is the only one: a homomorphism out of `L ⧸ I`
-restricting to `f` along the quotient map is `TauCeti.LieIdeal.liftQ f h`. -/
+/-- The factorisation of `LieIdeal.liftQ` is the only one: a homomorphism out of `L ⧸ I`
+restricting to `f` along the quotient map is `LieIdeal.liftQ f h`. -/
 theorem eq_liftQ {f : L →ₗ⁅R⁆ L'} {h : I ≤ f.ker} {g : L ⧸ I →ₗ⁅R⁆ L'}
     (hg : ∀ x : L, g (mkQ I x) = f x) : g = liftQ f h :=
   lieHom_qext fun x => by rw [hg]; simp
 
 end LieIdeal
+
+namespace TauCeti
 
 namespace LieHom
 

--- a/TauCeti/Algebra/Lie/Presentation/Basic.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Basic.lean
@@ -19,8 +19,8 @@ presentation is used for: a homomorphism out of the presented algebra is the sam
 of images satisfying the relations. This file supplies the three facts that bridge is made of.
 
 The first is the universal property of the quotient. `LieSubmodule.Quotient.mk'` presents the
-quotient map only as a morphism of Lie *modules*, so `LieIdeal.mkQ` records it as a morphism
-of Lie *algebras*, `LieIdeal.liftQ` factors a homomorphism killing the ideal through it, and
+quotient map only as a morphism of Lie *modules*, so `LieIdeal.mkQ` records it as a morphism of Lie
+*algebras*, `LieIdeal.liftQ` factors a homomorphism killing the ideal through it, and
 `LieIdeal.lieHom_qext` says the factorisation is unique. These mirror `Submodule.mkQ`,
 `Submodule.liftQ` and `Submodule.linearMap_qext`, to which the proofs reduce once the bracket is
 checked on representatives, where it is the bracket of representatives by construction.
@@ -44,8 +44,8 @@ generate the presented algebra, rather than merely determine maps out of it.
 
 ## Main results
 
-* `LieIdeal.liftQ_comp_mkQ` and `LieIdeal.lieHom_qext`: the lifted homomorphism
-  restricts to the original one along the quotient map, and is the only homomorphism that does.
+* `LieIdeal.liftQ_comp_mkQ` and `LieIdeal.lieHom_qext`: the lifted homomorphism restricts to the
+  original one along the quotient map, and is the only homomorphism that does.
 * `TauCeti.LieHom.map_ad_pow`: a homomorphism carries `(ad x) ^ n y` to `(ad (f x)) ^ n (f y)`.
 * `TauCeti.ad_neg_pow_apply_eq_zero`: negating the element acting by `ad` preserves the vanishing of
   an iterated adjoint action.
@@ -54,18 +54,18 @@ generate the presented algebra, rather than merely determine maps out of it.
 
 ## Implementation notes
 
-Neither `LieIdeal.mkQ` nor `LieIdeal.liftQ` is exposed: `LieIdeal.mkQ_apply`
-and `LieIdeal.liftQ_apply_mkQ` characterise them on elements, and
-`LieIdeal.ker_mkQ`, `LieIdeal.liftQ_comp_mkQ` and `LieIdeal.eq_liftQ` say
-all a consumer needs about their kernel and their factorisation, so nothing downstream has to
-unfold the quotient. Those three
-equations are proved by the parenthesised `(rfl)`, which elaborates against the definitions
-themselves; a bare `rfl` in an exported theorem would demand that they be `@[expose]`d.
+Neither `LieIdeal.mkQ` nor `LieIdeal.liftQ` is exposed: `LieIdeal.mkQ_apply` and
+`LieIdeal.liftQ_apply_mkQ` characterise them on elements, and `LieIdeal.ker_mkQ`,
+`LieIdeal.liftQ_comp_mkQ` and `LieIdeal.eq_liftQ` say all a consumer needs about their kernel and
+their factorisation, so nothing downstream has to unfold the quotient. `LieIdeal.mkQ_apply`,
+`LieIdeal.liftQ_apply_mk` and `LieIdeal.liftQ_apply_mkQ` are proved by the parenthesised `(rfl)`,
+which elaborates against the definitions themselves; a bare `rfl` in an exported theorem would
+demand that they be `@[expose]`d.
 
 `LieIdeal.liftQ_apply_mkQ` is the composite of `LieIdeal.mkQ_apply` and
-`LieIdeal.liftQ_apply_mk`, but only inside this file: unexposed bodies mean that in another
-module `mkQ I x` is not defeq to `LieSubmodule.Quotient.mk x`, so a consumer whose goal is stated
-in terms of its own definitions cannot chain the two lemmas there.
+`LieIdeal.liftQ_apply_mk`, but only inside this file: unexposed bodies mean that in another module
+`I.mkQ x` is not defeq to `LieSubmodule.Quotient.mk x`, so a consumer whose goal is stated in terms
+of its own definitions cannot chain the two lemmas there.
 
 Surjectivity of `LieIdeal.mkQ` is not restated: it is Mathlib's
 `LieSubmodule.Quotient.surjective_mk'` transported along `LieIdeal.mkQ_apply`.
@@ -98,15 +98,13 @@ def mkQ : L →ₗ⁅R⁆ L ⧸ I where
 
 /-- The quotient homomorphism sends an element to its class. -/
 @[simp]
-theorem mkQ_apply (x : L) : mkQ I x = LieSubmodule.Quotient.mk x := (rfl)
+theorem mkQ_apply (x : L) : I.mkQ x = LieSubmodule.Quotient.mk x := (rfl)
 
 /-- The kernel of the quotient homomorphism is the ideal quotiented by. -/
 @[simp]
-theorem ker_mkQ : (mkQ I).ker = I := by
+theorem ker_mkQ : I.mkQ.ker = I := by
   ext x
   simp [LieHom.mem_ker]
-
-variable {I}
 
 /-- The homomorphism `L ⧸ I →ₗ⁅R⁆ L'` induced by a homomorphism `f : L →ₗ⁅R⁆ L'` whose kernel
 contains the ideal `I`. -/
@@ -120,37 +118,37 @@ def liftQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) : L ⧸ I →ₗ⁅R⁆ L' 
 /-- The induced homomorphism on the quotient sends the class of `x` to `f x`. -/
 @[simp]
 theorem liftQ_apply_mk (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
-    liftQ f h (LieSubmodule.Quotient.mk x) = f x := (rfl)
+    I.liftQ f h (LieSubmodule.Quotient.mk x) = f x := (rfl)
 
 /-- The induced homomorphism on the quotient agrees with `f` on the image of the quotient map.
 
 Not a `simp` lemma: `LieIdeal.mkQ_apply` and `LieIdeal.liftQ_apply_mk` already
 rewrite the left-hand side here, and `simp` rejects a lemma its own set can prove. It is still
 needed as a lemma, because those two only chain where the body of `LieIdeal.mkQ` is
-visible: in another module `mkQ I x` is not reducible to `LieSubmodule.Quotient.mk x`. -/
+visible: in another module `I.mkQ x` is not reducible to `LieSubmodule.Quotient.mk x`. -/
 theorem liftQ_apply_mkQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
-    liftQ f h (mkQ I x) = f x := (rfl)
+    I.liftQ f h (I.mkQ x) = f x := (rfl)
 
 /-- The induced homomorphism on the quotient composed with the quotient map is the original
 homomorphism. -/
 @[simp]
-theorem liftQ_comp_mkQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) : (liftQ f h).comp (mkQ I) = f := by
+theorem liftQ_comp_mkQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) : (I.liftQ f h).comp I.mkQ = f := by
   ext x
   simp
 
 /-- Two homomorphisms out of `L ⧸ I` that agree after composition with the quotient map are
 equal. -/
-theorem lieHom_qext {g₁ g₂ : L ⧸ I →ₗ⁅R⁆ L'} (h : ∀ x : L, g₁ (mkQ I x) = g₂ (mkQ I x)) :
+theorem lieHom_qext {g₁ g₂ : L ⧸ I →ₗ⁅R⁆ L'} (h : ∀ x : L, g₁ (I.mkQ x) = g₂ (I.mkQ x)) :
     g₁ = g₂ := by
   ext x
   induction x using Quotient.inductionOn' with | _ x
   exact h x
 
 /-- The factorisation of `LieIdeal.liftQ` is the only one: a homomorphism out of `L ⧸ I`
-restricting to `f` along the quotient map is `LieIdeal.liftQ f h`. -/
+restricting to `f` along the quotient map is `I.liftQ f h`. -/
 theorem eq_liftQ {f : L →ₗ⁅R⁆ L'} {h : I ≤ f.ker} {g : L ⧸ I →ₗ⁅R⁆ L'}
-    (hg : ∀ x : L, g (mkQ I x) = f x) : g = liftQ f h :=
-  lieHom_qext fun x => by rw [hg]; simp
+    (hg : ∀ x : L, g (I.mkQ x) = f x) : g = I.liftQ f h :=
+  I.lieHom_qext fun x => by rw [hg]; simp
 
 end LieIdeal
 

--- a/TauCeti/Algebra/Lie/Presentation/Basic.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Basic.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Lie.Free
-public import TauCeti.Algebra.Lie.Quotient
 
 /-!
 # Presenting a Lie algebra by generators and relations

--- a/TauCeti/Algebra/Lie/Presentation/Basic.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Basic.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Lie.Free
-public import Mathlib.Algebra.Lie.Quotient
+public import TauCeti.Algebra.Lie.Quotient
 
 /-!
 # Presenting a Lie algebra by generators and relations
@@ -16,59 +16,27 @@ A Lie algebra presented by generators `X` and relations `S ⊆ FreeLieAlgebra R 
 construction — the free Lie algebra with its universal property, and the `LieRing`/`LieAlgebra`
 structure on a quotient by a Lie ideal — but not the bridge between them, which is what a
 presentation is used for: a homomorphism out of the presented algebra is the same thing as a family
-of images satisfying the relations. This file supplies the three facts that bridge is made of.
+of images satisfying the relations. The quotient universal property is provided by
+`TauCeti/Algebra/Lie/Quotient.lean`; this file supplies two further facts needed to apply it.
 
-The first is the universal property of the quotient. `LieSubmodule.Quotient.mk'` presents the
-quotient map only as a morphism of Lie *modules*, so `LieIdeal.mkQ` records it as a morphism of Lie
-*algebras*, `LieIdeal.liftQ` factors a homomorphism killing the ideal through it, and
-`LieIdeal.lieHom_qext` says the factorisation is unique. These mirror `Submodule.mkQ`,
-`Submodule.liftQ` and `Submodule.linearMap_qext`, to which the proofs reduce once the bracket is
-checked on representatives, where it is the bracket of representatives by construction.
-
-The second is that a homomorphism transports an iterated adjoint action,
+First, a homomorphism transports an iterated adjoint action,
 `TauCeti.LieHom.map_ad_pow`. Relations of a presentation are frequently written as the vanishing of
 `(ad x) ^ n y` — Serre's relations for a Cartan matrix are the standard example — and such a
 relation says nothing about the presented algebra until it is known to be carried along by the map
 that checks it. The companion `TauCeti.ad_neg_pow_apply_eq_zero` transports such a vanishing result
 from `x` to `-x`.
 
-The third is that a free Lie algebra is generated, as a Lie subalgebra, by its generators:
+Second, a free Lie algebra is generated, as a Lie subalgebra, by its generators:
 `TauCeti.FreeLieAlgebra.lieSpan_range_of_eq_top`. This is what makes the images of the generators
 generate the presented algebra, rather than merely determine maps out of it.
 
-## Main definitions
-
-* `LieIdeal.mkQ`: the quotient map `L →ₗ⁅R⁆ L ⧸ I`.
-* `LieIdeal.liftQ`: the homomorphism `L ⧸ I →ₗ⁅R⁆ L'` induced by a homomorphism
-  `L →ₗ⁅R⁆ L'` whose kernel contains `I`.
-
 ## Main results
 
-* `LieIdeal.liftQ_comp_mkQ` and `LieIdeal.lieHom_qext`: the lifted homomorphism restricts to the
-  original one along the quotient map, and is the only homomorphism that does.
 * `TauCeti.LieHom.map_ad_pow`: a homomorphism carries `(ad x) ^ n y` to `(ad (f x)) ^ n (f y)`.
 * `TauCeti.ad_neg_pow_apply_eq_zero`: negating the element acting by `ad` preserves the vanishing of
   an iterated adjoint action.
 * `TauCeti.FreeLieAlgebra.lieSpan_range_of_eq_top`: the generators of a free Lie algebra generate it
   as a Lie subalgebra.
-
-## Implementation notes
-
-Neither `LieIdeal.mkQ` nor `LieIdeal.liftQ` is exposed: `LieIdeal.mkQ_apply` and
-`LieIdeal.liftQ_apply_mkQ` characterise them on elements, and `LieIdeal.ker_mkQ`,
-`LieIdeal.liftQ_comp_mkQ` and `LieIdeal.eq_liftQ` say all a consumer needs about their kernel and
-their factorisation, so nothing downstream has to unfold the quotient. `LieIdeal.mkQ_apply`,
-`LieIdeal.liftQ_apply_mk` and `LieIdeal.liftQ_apply_mkQ` are proved by the parenthesised `(rfl)`,
-which elaborates against the definitions themselves; a bare `rfl` in an exported theorem would
-demand that they be `@[expose]`d.
-
-`LieIdeal.liftQ_apply_mkQ` is the composite of `LieIdeal.mkQ_apply` and
-`LieIdeal.liftQ_apply_mk`, but only inside this file: unexposed bodies mean that in another module
-`I.mkQ x` is not defeq to `LieSubmodule.Quotient.mk x`, so a consumer whose goal is stated in terms
-of its own definitions cannot chain the two lemmas there.
-
-Surjectivity of `LieIdeal.mkQ` is not restated: it is Mathlib's
-`LieSubmodule.Quotient.surjective_mk'` transported along `LieIdeal.mkQ_apply`.
 
 ## Roadmap
 
@@ -79,78 +47,6 @@ of Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`.
 -/
 
 public section
-
-namespace LieIdeal
-
-variable {R L L' : Type*} [CommRing R] [LieRing L] [LieAlgebra R L] [LieRing L'] [LieAlgebra R L']
-variable (I : LieIdeal R L)
-
-/-- The quotient map `L → L ⧸ I` as a homomorphism of Lie algebras.
-
-This is `LieSubmodule.Quotient.mk'` upgraded from a morphism of Lie modules over `L` to a morphism
-of Lie algebras; the bracket on the quotient is by construction the bracket of representatives, so
-there is nothing to check. -/
-def mkQ : L →ₗ⁅R⁆ L ⧸ I where
-  toFun := LieSubmodule.Quotient.mk
-  map_add' _ _ := rfl
-  map_smul' _ _ := rfl
-  map_lie' := rfl
-
-/-- The quotient homomorphism sends an element to its class. -/
-@[simp]
-theorem mkQ_apply (x : L) : I.mkQ x = LieSubmodule.Quotient.mk x := (rfl)
-
-/-- The kernel of the quotient homomorphism is the ideal quotiented by. -/
-@[simp]
-theorem ker_mkQ : I.mkQ.ker = I := by
-  ext x
-  simp [LieHom.mem_ker]
-
-/-- The homomorphism `L ⧸ I →ₗ⁅R⁆ L'` induced by a homomorphism `f : L →ₗ⁅R⁆ L'` whose kernel
-contains the ideal `I`. -/
-def liftQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) : L ⧸ I →ₗ⁅R⁆ L' where
-  __ := LieSubmodule.toSubmodule I |>.liftQ (f : L →ₗ[R] L') h
-  map_lie' {x y} := by
-    induction x using Quotient.inductionOn' with | _ x
-    induction y using Quotient.inductionOn' with | _ y
-    exact f.map_lie x y
-
-/-- The induced homomorphism on the quotient sends the class of `x` to `f x`. -/
-@[simp]
-theorem liftQ_apply_mk (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
-    I.liftQ f h (LieSubmodule.Quotient.mk x) = f x := (rfl)
-
-/-- The induced homomorphism on the quotient agrees with `f` on the image of the quotient map.
-
-Not a `simp` lemma: `LieIdeal.mkQ_apply` and `LieIdeal.liftQ_apply_mk` already
-rewrite the left-hand side here, and `simp` rejects a lemma its own set can prove. It is still
-needed as a lemma, because those two only chain where the body of `LieIdeal.mkQ` is
-visible: in another module `I.mkQ x` is not reducible to `LieSubmodule.Quotient.mk x`. -/
-theorem liftQ_apply_mkQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
-    I.liftQ f h (I.mkQ x) = f x := (rfl)
-
-/-- The induced homomorphism on the quotient composed with the quotient map is the original
-homomorphism. -/
-@[simp]
-theorem liftQ_comp_mkQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) : (I.liftQ f h).comp I.mkQ = f := by
-  ext x
-  simp
-
-/-- Two homomorphisms out of `L ⧸ I` that agree after composition with the quotient map are
-equal. -/
-theorem lieHom_qext {g₁ g₂ : L ⧸ I →ₗ⁅R⁆ L'} (h : ∀ x : L, g₁ (I.mkQ x) = g₂ (I.mkQ x)) :
-    g₁ = g₂ := by
-  ext x
-  induction x using Quotient.inductionOn' with | _ x
-  exact h x
-
-/-- The factorisation of `LieIdeal.liftQ` is the only one: a homomorphism out of `L ⧸ I`
-restricting to `f` along the quotient map is `I.liftQ f h`. -/
-theorem eq_liftQ {f : L →ₗ⁅R⁆ L'} {h : I ≤ f.ker} {g : L ⧸ I →ₗ⁅R⁆ L'}
-    (hg : ∀ x : L, g (I.mkQ x) = f x) : g = I.liftQ f h :=
-  I.lieHom_qext fun x => by rw [hg]; simp
-
-end LieIdeal
 
 namespace TauCeti
 

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Lie.SerreConstruction
 public import TauCeti.Algebra.Lie.Presentation.Basic
+public import TauCeti.Algebra.Lie.Quotient
 
 /-!
 # The Serre presentation: generators, relations, and the universal property
@@ -402,38 +403,33 @@ noncomputable def serreLift (h : IsSerreSystem R CM H E F) :
   (Relations.toIdeal R CM).liftQ (FreeLieAlgebra.lift R (serreGeneratorMap H E F))
     (toIdeal_le_ker_lift h)
 
+private theorem serreLift_comp_serreMk (h : IsSerreSystem R CM H E F) :
+    (serreLift h).comp (serreMk R CM) = FreeLieAlgebra.lift R (serreGeneratorMap H E F) :=
+  (Relations.toIdeal R CM).liftQ_mkQ _ _
+
 /-- The homomorphism determined by a Serre system sends `Hᵢ` to `H i`. -/
 @[simp]
 theorem serreLift_serreH (h : IsSerreSystem R CM H E F) (i : B) :
-    serreLift h (serreH R CM i) = H i :=
-  calc
-    _ = (((Relations.toIdeal R CM).liftQ (FreeLieAlgebra.lift R (serreGeneratorMap H E F))
-          (toIdeal_le_ker_lift h)).comp (Relations.toIdeal R CM).mkQ)
-          (FreeLieAlgebra.of R (Generators.H i)) := rfl
-    _ = _ := DFunLike.congr_fun ((Relations.toIdeal R CM).liftQ_mkQ _ _) _
-    _ = _ := FreeLieAlgebra.lift_of_apply _ _
+    serreLift h (serreH R CM i) = H i := by
+  rw [← serreMk_of_H R CM i]
+  exact (DFunLike.congr_fun (serreLift_comp_serreMk h) _).trans
+    (FreeLieAlgebra.lift_of_apply _ _)
 
 /-- The homomorphism determined by a Serre system sends `Eᵢ` to `E i`. -/
 @[simp]
 theorem serreLift_serreE (h : IsSerreSystem R CM H E F) (i : B) :
-    serreLift h (serreE R CM i) = E i :=
-  calc
-    _ = (((Relations.toIdeal R CM).liftQ (FreeLieAlgebra.lift R (serreGeneratorMap H E F))
-          (toIdeal_le_ker_lift h)).comp (Relations.toIdeal R CM).mkQ)
-          (FreeLieAlgebra.of R (Generators.E i)) := rfl
-    _ = _ := DFunLike.congr_fun ((Relations.toIdeal R CM).liftQ_mkQ _ _) _
-    _ = _ := FreeLieAlgebra.lift_of_apply _ _
+    serreLift h (serreE R CM i) = E i := by
+  rw [← serreMk_of_E R CM i]
+  exact (DFunLike.congr_fun (serreLift_comp_serreMk h) _).trans
+    (FreeLieAlgebra.lift_of_apply _ _)
 
 /-- The homomorphism determined by a Serre system sends `Fᵢ` to `F i`. -/
 @[simp]
 theorem serreLift_serreF (h : IsSerreSystem R CM H E F) (i : B) :
-    serreLift h (serreF R CM i) = F i :=
-  calc
-    _ = (((Relations.toIdeal R CM).liftQ (FreeLieAlgebra.lift R (serreGeneratorMap H E F))
-          (toIdeal_le_ker_lift h)).comp (Relations.toIdeal R CM).mkQ)
-          (FreeLieAlgebra.of R (Generators.F i)) := rfl
-    _ = _ := DFunLike.congr_fun ((Relations.toIdeal R CM).liftQ_mkQ _ _) _
-    _ = _ := FreeLieAlgebra.lift_of_apply _ _
+    serreLift h (serreF R CM i) = F i := by
+  rw [← serreMk_of_F R CM i]
+  exact (DFunLike.congr_fun (serreLift_comp_serreMk h) _).trans
+    (FreeLieAlgebra.lift_of_apply _ _)
 
 /-- A nonzero Cartan element in a Serre system has a nonzero preimage among the presented Cartan
 generators. -/

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -67,14 +67,6 @@ one, which is not proved here (see the Roadmap section below).
 * `TauCeti.serreLift_eq_id`: lifting the generators along their own Serre system is the identity.
 * `TauCeti.lieSpan_serreGenerators_eq_top`: the generators generate the presented algebra.
 
-## Implementation notes
-
-None of the definitions is exposed: `TauCeti.serreMk_of_H` and its companions, the individual
-relations, and `TauCeti.serreLift_serreH` and its companions together with `TauCeti.eq_serreLift`
-characterise them, so nothing downstream has to unfold the quotient. This follows the API design
-of `TauCeti/Algebra/Lie/Quotient.lean`: downstream proofs use the characterisation lemmas rather
-than unfolded definitions.
-
 ## Roadmap
 
 This is a prerequisite for the Chevalley--Demazure construction, Layer 9 of

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -114,9 +114,8 @@ noncomputable def serreMk :
 theorem ker_serreMk : (serreMk R CM).ker = Relations.toIdeal R CM := LieIdeal.ker_mkQ _
 
 /-- Every element of the presented algebra is the class of an element of the free Lie algebra. -/
-theorem serreMk_surjective : Function.Surjective (serreMk R CM) := fun y => by
-  obtain ⟨x, hx⟩ := LieSubmodule.Quotient.surjective_mk' (Relations.toIdeal R CM) y
-  exact ⟨x, (LieIdeal.mkQ_apply _ x).trans hx⟩
+theorem serreMk_surjective : Function.Surjective (serreMk R CM) :=
+  (Relations.toIdeal R CM).mkQ_surjective
 
 /-- A relator of Serre's presentation becomes zero in the presented algebra. -/
 theorem serreMk_eq_zero_of_mem_toSet {x : FreeLieAlgebra R (Generators B)}

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -70,10 +70,9 @@ one, which is not proved here (see the Roadmap section below).
 
 None of the definitions is exposed: `TauCeti.serreMk_of_H` and its companions, the individual
 relations, and `TauCeti.serreLift_serreH` and its companions together with `TauCeti.eq_serreLift`
-characterise them, so nothing downstream has to unfold the quotient. As in
-`TauCeti/Algebra/Lie/Quotient.lean`, the equations that hold by definition are proved by the
-parenthesised `(rfl)`, which elaborates against the definitions rather than demanding that they be
-`@[expose]`d.
+characterise them, so nothing downstream has to unfold the quotient. This follows the API design
+of `TauCeti/Algebra/Lie/Quotient.lean`: downstream proofs use the characterisation lemmas rather
+than unfolded definitions.
 
 ## Roadmap
 

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -407,19 +407,34 @@ noncomputable def serreLift (h : IsSerreSystem R CM H E F) :
 @[simp]
 theorem serreLift_serreH (h : IsSerreSystem R CM H E F) (i : B) :
     serreLift h (serreH R CM i) = H i :=
-  ((Relations.toIdeal R CM).liftQ_apply_mkQ _ _ _).trans (FreeLieAlgebra.lift_of_apply _ _)
+  calc
+    _ = (((Relations.toIdeal R CM).liftQ (FreeLieAlgebra.lift R (serreGeneratorMap H E F))
+          (toIdeal_le_ker_lift h)).comp (Relations.toIdeal R CM).mkQ)
+          (FreeLieAlgebra.of R (Generators.H i)) := rfl
+    _ = _ := DFunLike.congr_fun ((Relations.toIdeal R CM).liftQ_mkQ _ _) _
+    _ = _ := FreeLieAlgebra.lift_of_apply _ _
 
 /-- The homomorphism determined by a Serre system sends `Eᵢ` to `E i`. -/
 @[simp]
 theorem serreLift_serreE (h : IsSerreSystem R CM H E F) (i : B) :
     serreLift h (serreE R CM i) = E i :=
-  ((Relations.toIdeal R CM).liftQ_apply_mkQ _ _ _).trans (FreeLieAlgebra.lift_of_apply _ _)
+  calc
+    _ = (((Relations.toIdeal R CM).liftQ (FreeLieAlgebra.lift R (serreGeneratorMap H E F))
+          (toIdeal_le_ker_lift h)).comp (Relations.toIdeal R CM).mkQ)
+          (FreeLieAlgebra.of R (Generators.E i)) := rfl
+    _ = _ := DFunLike.congr_fun ((Relations.toIdeal R CM).liftQ_mkQ _ _) _
+    _ = _ := FreeLieAlgebra.lift_of_apply _ _
 
 /-- The homomorphism determined by a Serre system sends `Fᵢ` to `F i`. -/
 @[simp]
 theorem serreLift_serreF (h : IsSerreSystem R CM H E F) (i : B) :
     serreLift h (serreF R CM i) = F i :=
-  ((Relations.toIdeal R CM).liftQ_apply_mkQ _ _ _).trans (FreeLieAlgebra.lift_of_apply _ _)
+  calc
+    _ = (((Relations.toIdeal R CM).liftQ (FreeLieAlgebra.lift R (serreGeneratorMap H E F))
+          (toIdeal_le_ker_lift h)).comp (Relations.toIdeal R CM).mkQ)
+          (FreeLieAlgebra.of R (Generators.F i)) := rfl
+    _ = _ := DFunLike.congr_fun ((Relations.toIdeal R CM).liftQ_mkQ _ _) _
+    _ = _ := FreeLieAlgebra.lift_of_apply _ _
 
 /-- A nonzero Cartan element in a Serre system has a nonzero preimage among the presented Cartan
 generators. -/

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -71,9 +71,9 @@ one, which is not proved here (see the Roadmap section below).
 None of the definitions is exposed: `TauCeti.serreMk_of_H` and its companions, the individual
 relations, and `TauCeti.serreLift_serreH` and its companions together with `TauCeti.eq_serreLift`
 characterise them, so nothing downstream has to unfold the quotient. As in
-`TauCeti/Algebra/Lie/Presentation/Basic.lean`, the equations that hold by definition are proved by
-the parenthesised `(rfl)`, which elaborates against the definitions rather than demanding that they
-be `@[expose]`d.
+`TauCeti/Algebra/Lie/Quotient.lean`, the equations that hold by definition are proved by the
+parenthesised `(rfl)`, which elaborates against the definitions rather than demanding that they be
+`@[expose]`d.
 
 ## Roadmap
 

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -401,25 +401,26 @@ private theorem toIdeal_le_ker_lift (h : IsSerreSystem R CM H E F) :
 property of the presentation. -/
 noncomputable def serreLift (h : IsSerreSystem R CM H E F) :
     Matrix.ToLieAlgebra R CM →ₗ⁅R⁆ L :=
-  LieIdeal.liftQ (FreeLieAlgebra.lift R (serreGeneratorMap H E F)) (toIdeal_le_ker_lift h)
+  (Relations.toIdeal R CM).liftQ (FreeLieAlgebra.lift R (serreGeneratorMap H E F))
+    (toIdeal_le_ker_lift h)
 
 /-- The homomorphism determined by a Serre system sends `Hᵢ` to `H i`. -/
 @[simp]
 theorem serreLift_serreH (h : IsSerreSystem R CM H E F) (i : B) :
     serreLift h (serreH R CM i) = H i :=
-  (LieIdeal.liftQ_apply_mkQ _ _ _).trans (FreeLieAlgebra.lift_of_apply _ _)
+  ((Relations.toIdeal R CM).liftQ_apply_mkQ _ _ _).trans (FreeLieAlgebra.lift_of_apply _ _)
 
 /-- The homomorphism determined by a Serre system sends `Eᵢ` to `E i`. -/
 @[simp]
 theorem serreLift_serreE (h : IsSerreSystem R CM H E F) (i : B) :
     serreLift h (serreE R CM i) = E i :=
-  (LieIdeal.liftQ_apply_mkQ _ _ _).trans (FreeLieAlgebra.lift_of_apply _ _)
+  ((Relations.toIdeal R CM).liftQ_apply_mkQ _ _ _).trans (FreeLieAlgebra.lift_of_apply _ _)
 
 /-- The homomorphism determined by a Serre system sends `Fᵢ` to `F i`. -/
 @[simp]
 theorem serreLift_serreF (h : IsSerreSystem R CM H E F) (i : B) :
     serreLift h (serreF R CM i) = F i :=
-  (LieIdeal.liftQ_apply_mkQ _ _ _).trans (FreeLieAlgebra.lift_of_apply _ _)
+  ((Relations.toIdeal R CM).liftQ_apply_mkQ _ _ _).trans (FreeLieAlgebra.lift_of_apply _ _)
 
 /-- A nonzero Cartan element in a Serre system has a nonzero preimage among the presented Cartan
 generators. -/
@@ -460,7 +461,7 @@ theorem serre_hom_ext {g₁ g₂ : Matrix.ToLieAlgebra R CM →ₗ⁅R⁆ L}
     | H i => exact hH i
     | E i => exact hE i
     | F i => exact hF i
-  refine LieIdeal.lieHom_qext fun x => ?_
+  refine (Relations.toIdeal R CM).lieHom_qext fun x => ?_
   exact congrArg (fun ψ : FreeLieAlgebra R (Generators B) →ₗ⁅R⁆ L => ψ x) hcomp
 
 /-- Two equivalences out of `Matrix.ToLieAlgebra R CM` agreeing on the generators are equal. -/

--- a/TauCeti/Algebra/Lie/Quotient.lean
+++ b/TauCeti/Algebra/Lie/Quotient.lean
@@ -37,10 +37,7 @@ receiver notation on the ideal.
 Neither `LieIdeal.mkQ` nor `LieIdeal.liftQ` is exposed: `LieIdeal.mkQ_apply` and
 `LieIdeal.liftQ_apply_mkQ` characterize them on elements, and `LieIdeal.ker_mkQ`,
 `LieIdeal.liftQ_mkQ` and `LieIdeal.eq_liftQ` say all a consumer needs about their kernel and their
-factorization, so nothing downstream has to unfold the quotient. `LieIdeal.mkQ_apply`,
-`LieIdeal.liftQ_apply_mk` and `LieIdeal.liftQ_apply_mkQ` are proved by the parenthesized `(rfl)`,
-which elaborates against the definitions themselves; a bare `rfl` in an exported theorem would
-demand that they be `@[expose]`d.
+factorization, so nothing downstream has to unfold the quotient.
 
 `LieIdeal.liftQ_apply_mkQ` is the composite of `LieIdeal.mkQ_apply` and
 `LieIdeal.liftQ_apply_mk`, but only inside this file: unexposed bodies mean that in another module

--- a/TauCeti/Algebra/Lie/Quotient.lean
+++ b/TauCeti/Algebra/Lie/Quotient.lean
@@ -33,13 +33,6 @@ receiver notation on the ideal.
 * `LieIdeal.lieHom_qext`: two homomorphisms from the quotient are equal when they agree after the
   quotient map.
 * `LieIdeal.eq_liftQ`: the lifted homomorphism is the unique such factorization.
-
-## Implementation notes
-
-Neither `LieIdeal.mkQ` nor `LieIdeal.liftQ` is exposed: `LieIdeal.mkQ_apply` and
-`LieIdeal.liftQ_apply` characterize them on representatives, and `LieIdeal.ker_mkQ`,
-`LieIdeal.mkQ_surjective`, `LieIdeal.liftQ_mkQ` and `LieIdeal.eq_liftQ` give its elimination and
-factorization properties, so nothing downstream has to unfold the quotient.
 -/
 
 public section
@@ -98,9 +91,9 @@ equal. -/
 @[ext high]
 theorem lieHom_qext {g₁ g₂ : L ⧸ I →ₗ⁅R⁆ L'} (h : ∀ x : L, g₁ (I.mkQ x) = g₂ (I.mkQ x)) :
     g₁ = g₂ := by
-  ext x
-  induction x using Quotient.inductionOn' with | _ x
-  exact h x
+  apply LieHom.ext
+  exact LinearMap.congr_fun <|
+    Submodule.quot_hom_ext I.toSubmodule g₁.toLinearMap g₂.toLinearMap fun x => h x
 
 /-- The factorization of `LieIdeal.liftQ` is the only one: a homomorphism out of `L ⧸ I`
 restricting to `f` along the quotient map is `I.liftQ f h`. -/

--- a/TauCeti/Algebra/Lie/Quotient.lean
+++ b/TauCeti/Algebra/Lie/Quotient.lean
@@ -51,9 +51,8 @@ variable (I : LieIdeal R L)
 
 /-- The quotient map `L → L ⧸ I` as a homomorphism of Lie algebras.
 
-This is `LieSubmodule.Quotient.mk'` upgraded from a morphism of Lie modules over `L` to a morphism
-of Lie algebras; the bracket on the quotient is by construction the bracket of representatives, so
-there is nothing to check. -/
+Its underlying function is Mathlib's `LieSubmodule.Quotient.mk`, sending each element to its
+quotient class. -/
 def mkQ : L →ₗ⁅R⁆ L ⧸ I where
   toFun := LieSubmodule.Quotient.mk
   map_add' _ _ := rfl

--- a/TauCeti/Algebra/Lie/Quotient.lean
+++ b/TauCeti/Algebra/Lie/Quotient.lean
@@ -26,6 +26,8 @@ receiver notation on the ideal.
 
 ## Main results
 
+* `LieIdeal.mkQ_surjective`: every quotient class has a representative in the original Lie
+  algebra.
 * `LieIdeal.liftQ_mkQ`: the lifted homomorphism restricts to the original one along the quotient
   map.
 * `LieIdeal.lieHom_qext`: two homomorphisms from the quotient are equal when they agree after the
@@ -36,11 +38,8 @@ receiver notation on the ideal.
 
 Neither `LieIdeal.mkQ` nor `LieIdeal.liftQ` is exposed: `LieIdeal.mkQ_apply` and
 `LieIdeal.liftQ_apply_mk` characterize them on representatives, and `LieIdeal.ker_mkQ`,
-`LieIdeal.liftQ_mkQ` and `LieIdeal.eq_liftQ` say all a consumer needs about their kernel and their
-factorization, so nothing downstream has to unfold the quotient.
-
-Surjectivity of `LieIdeal.mkQ` is not restated: it is Mathlib's
-`LieSubmodule.Quotient.surjective_mk'` transported along `LieIdeal.mkQ_apply`.
+`LieIdeal.mkQ_surjective`, `LieIdeal.liftQ_mkQ` and `LieIdeal.eq_liftQ` give its elimination and
+factorization properties, so nothing downstream has to unfold the quotient.
 -/
 
 public section
@@ -64,6 +63,11 @@ def mkQ : L →ₗ⁅R⁆ L ⧸ I where
 /-- The quotient homomorphism sends an element to its class. -/
 @[simp]
 theorem mkQ_apply (x : L) : I.mkQ x = LieSubmodule.Quotient.mk x := (rfl)
+
+/-- Every element of the quotient has a representative in the original Lie algebra. -/
+theorem mkQ_surjective : Function.Surjective I.mkQ := fun y => by
+  obtain ⟨x, hx⟩ := LieSubmodule.Quotient.surjective_mk' I y
+  exact ⟨x, (I.mkQ_apply x).trans hx⟩
 
 /-- The kernel of the quotient homomorphism is the ideal quotiented by. -/
 @[simp]

--- a/TauCeti/Algebra/Lie/Quotient.lean
+++ b/TauCeti/Algebra/Lie/Quotient.lean
@@ -35,14 +35,9 @@ receiver notation on the ideal.
 ## Implementation notes
 
 Neither `LieIdeal.mkQ` nor `LieIdeal.liftQ` is exposed: `LieIdeal.mkQ_apply` and
-`LieIdeal.liftQ_apply_mkQ` characterize them on elements, and `LieIdeal.ker_mkQ`,
+`LieIdeal.liftQ_apply_mk` characterize them on representatives, and `LieIdeal.ker_mkQ`,
 `LieIdeal.liftQ_mkQ` and `LieIdeal.eq_liftQ` say all a consumer needs about their kernel and their
 factorization, so nothing downstream has to unfold the quotient.
-
-`LieIdeal.liftQ_apply_mkQ` is the composite of `LieIdeal.mkQ_apply` and
-`LieIdeal.liftQ_apply_mk`, but only inside this file: unexposed bodies mean that in another module
-`I.mkQ x` is not definitionally equal to `LieSubmodule.Quotient.mk x`, so a consumer whose goal is
-stated in terms of its own definitions cannot chain the two lemmas there.
 
 Surjectivity of `LieIdeal.mkQ` is not restated: it is Mathlib's
 `LieSubmodule.Quotient.surjective_mk'` transported along `LieIdeal.mkQ_apply`.
@@ -90,15 +85,6 @@ def liftQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) : L ⧸ I →ₗ⁅R⁆ L' 
 theorem liftQ_apply_mk (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
     I.liftQ f h (LieSubmodule.Quotient.mk x) = f x := (rfl)
 
-/-- The induced homomorphism on the quotient agrees with `f` on the image of the quotient map.
-
-Not a `simp` lemma: `LieIdeal.mkQ_apply` and `LieIdeal.liftQ_apply_mk` already rewrite the left-hand
-side here, and `simp` rejects a lemma its own set can prove. It is still needed as a lemma, because
-those two only chain where the body of `LieIdeal.mkQ` is visible: in another module `I.mkQ x` is not
-reducible to `LieSubmodule.Quotient.mk x`. -/
-theorem liftQ_apply_mkQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
-    I.liftQ f h (I.mkQ x) = f x := (rfl)
-
 /-- The induced homomorphism on the quotient composed with the quotient map is the original
 homomorphism. -/
 @[simp]
@@ -108,6 +94,7 @@ theorem liftQ_mkQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) : (I.liftQ f h).com
 
 /-- Two homomorphisms out of `L ⧸ I` that agree after composition with the quotient map are
 equal. -/
+@[ext high]
 theorem lieHom_qext {g₁ g₂ : L ⧸ I →ₗ⁅R⁆ L'} (h : ∀ x : L, g₁ (I.mkQ x) = g₂ (I.mkQ x)) :
     g₁ = g₂ := by
   ext x

--- a/TauCeti/Algebra/Lie/Quotient.lean
+++ b/TauCeti/Algebra/Lie/Quotient.lean
@@ -54,9 +54,7 @@ variable (I : LieIdeal R L)
 Its underlying function is Mathlib's `LieSubmodule.Quotient.mk`, sending each element to its
 quotient class. -/
 def mkQ : L →ₗ⁅R⁆ L ⧸ I where
-  toFun := LieSubmodule.Quotient.mk
-  map_add' _ _ := rfl
-  map_smul' _ _ := rfl
+  __ := I.toSubmodule.mkQ
   map_lie' := rfl
 
 /-- The quotient homomorphism sends an element to its class. -/

--- a/TauCeti/Algebra/Lie/Quotient.lean
+++ b/TauCeti/Algebra/Lie/Quotient.lean
@@ -37,7 +37,7 @@ receiver notation on the ideal.
 ## Implementation notes
 
 Neither `LieIdeal.mkQ` nor `LieIdeal.liftQ` is exposed: `LieIdeal.mkQ_apply` and
-`LieIdeal.liftQ_apply_mk` characterize them on representatives, and `LieIdeal.ker_mkQ`,
+`LieIdeal.liftQ_apply` characterize them on representatives, and `LieIdeal.ker_mkQ`,
 `LieIdeal.mkQ_surjective`, `LieIdeal.liftQ_mkQ` and `LieIdeal.eq_liftQ` give its elimination and
 factorization properties, so nothing downstream has to unfold the quotient.
 -/
@@ -83,7 +83,7 @@ def liftQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) : L ⧸ I →ₗ⁅R⁆ L' 
 
 /-- The induced homomorphism on the quotient sends the class of `x` to `f x`. -/
 @[simp]
-theorem liftQ_apply_mk (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
+theorem liftQ_apply (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
     I.liftQ f h (LieSubmodule.Quotient.mk x) = f x := (rfl)
 
 /-- The induced homomorphism on the quotient composed with the quotient map is the original

--- a/TauCeti/Algebra/Lie/Quotient.lean
+++ b/TauCeti/Algebra/Lie/Quotient.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.Quotient
+
+/-!
+# Homomorphisms from quotients by Lie ideals
+
+Mathlib equips the quotient of a Lie algebra by a Lie ideal with its Lie algebra structure and
+provides the quotient map as a morphism of Lie modules. This file records that map as a
+homomorphism of Lie algebras and gives its universal property: a homomorphism killing the ideal
+factors uniquely through the quotient.
+
+These declarations live in the root `LieIdeal` namespace, extending Mathlib's API and supporting
+receiver notation on the ideal.
+
+## Main definitions
+
+* `LieIdeal.mkQ`: the quotient map `L →ₗ⁅R⁆ L ⧸ I`.
+* `LieIdeal.liftQ`: the homomorphism `L ⧸ I →ₗ⁅R⁆ L'` induced by a homomorphism
+  `L →ₗ⁅R⁆ L'` whose kernel contains `I`.
+
+## Main results
+
+* `LieIdeal.liftQ_mkQ`: the lifted homomorphism restricts to the original one along the quotient
+  map.
+* `LieIdeal.lieHom_qext`: two homomorphisms from the quotient are equal when they agree after the
+  quotient map.
+* `LieIdeal.eq_liftQ`: the lifted homomorphism is the unique such factorization.
+
+## Implementation notes
+
+Neither `LieIdeal.mkQ` nor `LieIdeal.liftQ` is exposed: `LieIdeal.mkQ_apply` and
+`LieIdeal.liftQ_apply_mkQ` characterize them on elements, and `LieIdeal.ker_mkQ`,
+`LieIdeal.liftQ_mkQ` and `LieIdeal.eq_liftQ` say all a consumer needs about their kernel and their
+factorization, so nothing downstream has to unfold the quotient. `LieIdeal.mkQ_apply`,
+`LieIdeal.liftQ_apply_mk` and `LieIdeal.liftQ_apply_mkQ` are proved by the parenthesized `(rfl)`,
+which elaborates against the definitions themselves; a bare `rfl` in an exported theorem would
+demand that they be `@[expose]`d.
+
+`LieIdeal.liftQ_apply_mkQ` is the composite of `LieIdeal.mkQ_apply` and
+`LieIdeal.liftQ_apply_mk`, but only inside this file: unexposed bodies mean that in another module
+`I.mkQ x` is not definitionally equal to `LieSubmodule.Quotient.mk x`, so a consumer whose goal is
+stated in terms of its own definitions cannot chain the two lemmas there.
+
+Surjectivity of `LieIdeal.mkQ` is not restated: it is Mathlib's
+`LieSubmodule.Quotient.surjective_mk'` transported along `LieIdeal.mkQ_apply`.
+-/
+
+public section
+
+namespace LieIdeal
+
+variable {R L L' : Type*} [CommRing R] [LieRing L] [LieAlgebra R L] [LieRing L'] [LieAlgebra R L']
+variable (I : LieIdeal R L)
+
+/-- The quotient map `L → L ⧸ I` as a homomorphism of Lie algebras.
+
+This is `LieSubmodule.Quotient.mk'` upgraded from a morphism of Lie modules over `L` to a morphism
+of Lie algebras; the bracket on the quotient is by construction the bracket of representatives, so
+there is nothing to check. -/
+def mkQ : L →ₗ⁅R⁆ L ⧸ I where
+  toFun := LieSubmodule.Quotient.mk
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+  map_lie' := rfl
+
+/-- The quotient homomorphism sends an element to its class. -/
+@[simp]
+theorem mkQ_apply (x : L) : I.mkQ x = LieSubmodule.Quotient.mk x := (rfl)
+
+/-- The kernel of the quotient homomorphism is the ideal quotiented by. -/
+@[simp]
+theorem ker_mkQ : I.mkQ.ker = I := by
+  ext x
+  simp [LieHom.mem_ker]
+
+/-- The homomorphism `L ⧸ I →ₗ⁅R⁆ L'` induced by a homomorphism `f : L →ₗ⁅R⁆ L'` whose kernel
+contains the ideal `I`. -/
+def liftQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) : L ⧸ I →ₗ⁅R⁆ L' where
+  __ := LieSubmodule.toSubmodule I |>.liftQ (f : L →ₗ[R] L') h
+  map_lie' {x y} := by
+    induction x using Quotient.inductionOn' with | _ x
+    induction y using Quotient.inductionOn' with | _ y
+    exact f.map_lie x y
+
+/-- The induced homomorphism on the quotient sends the class of `x` to `f x`. -/
+@[simp]
+theorem liftQ_apply_mk (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
+    I.liftQ f h (LieSubmodule.Quotient.mk x) = f x := (rfl)
+
+/-- The induced homomorphism on the quotient agrees with `f` on the image of the quotient map.
+
+Not a `simp` lemma: `LieIdeal.mkQ_apply` and `LieIdeal.liftQ_apply_mk` already rewrite the left-hand
+side here, and `simp` rejects a lemma its own set can prove. It is still needed as a lemma, because
+those two only chain where the body of `LieIdeal.mkQ` is visible: in another module `I.mkQ x` is not
+reducible to `LieSubmodule.Quotient.mk x`. -/
+theorem liftQ_apply_mkQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) (x : L) :
+    I.liftQ f h (I.mkQ x) = f x := (rfl)
+
+/-- The induced homomorphism on the quotient composed with the quotient map is the original
+homomorphism. -/
+@[simp]
+theorem liftQ_mkQ (f : L →ₗ⁅R⁆ L') (h : I ≤ f.ker) : (I.liftQ f h).comp I.mkQ = f := by
+  ext x
+  simp
+
+/-- Two homomorphisms out of `L ⧸ I` that agree after composition with the quotient map are
+equal. -/
+theorem lieHom_qext {g₁ g₂ : L ⧸ I →ₗ⁅R⁆ L'} (h : ∀ x : L, g₁ (I.mkQ x) = g₂ (I.mkQ x)) :
+    g₁ = g₂ := by
+  ext x
+  induction x using Quotient.inductionOn' with | _ x
+  exact h x
+
+/-- The factorization of `LieIdeal.liftQ` is the only one: a homomorphism out of `L ⧸ I`
+restricting to `f` along the quotient map is `I.liftQ f h`. -/
+theorem eq_liftQ {f : L →ₗ⁅R⁆ L'} {h : I ≤ f.ker} {g : L ⧸ I →ₗ⁅R⁆ L'}
+    (hg : ∀ x : L, g (I.mkQ x) = f x) : g = I.liftQ f h :=
+  I.lieHom_qext fun x => by rw [hg]; simp
+
+end LieIdeal


### PR DESCRIPTION
Moves the Lie-ideal quotient universal-property API from the recreated `TauCeti.LieIdeal` namespace into Mathlib’s canonical root `LieIdeal` namespace, in the focused `TauCeti/Algebra/Lie/Quotient.lean` module. The ideal is an explicit receiver throughout, so the complete family elaborates with notation such as `I.mkQ`, `I.mkQ_surjective`, `I.liftQ`, `I.liftQ_mkQ`, and `I.lieHom_qext`.

The Serre-presentation consumer imports the generic quotient module directly and now uses receiver notation. Its surjectivity theorem consumes `LieIdeal.mkQ_surjective`, and a shared private factorization lemma derives its generator computations from `LieIdeal.liftQ_mkQ`. The quotient extensionality theorem is registered with `@[ext high]`. All nine target names were checked against the pinned Mathlib environment with no collisions; no compatibility aliases are retained. The adjacent `TauCeti.LieHom.map_ad_pow` finding is intentionally excluded as a separate namespace slice.

The quotient eliminator supports the Serre-presentation prerequisite for `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, the Chevalley--Demazure construction.

Part of #3547.

Locally verified with:
- `lake build` (10,339 jobs)
- `lake exe axioms`
- `lake exe module-system`
- `bash scripts/lint-env.sh`
- `bash scripts/lint-style.sh`
- `python3 scripts/lean_source.py` (1,089 to 1,080 findings, zero new violations)
- direct elaboration checks across the complete `I.mkQ` / `I.liftQ` receiver API

The nine now-stale dot-notation baseline entries are intentionally left for a later human-owned baseline-pruning change.

Roadmap: ReductiveGroups

:robot: Prepared with OpenAI Codex
