### PR TITLE
feat: compute the negative binomial PGF

### DIFF
--- a/TauCeti/Analysis/Analytic/Binomial.lean
+++ b/TauCeti/Analysis/Analytic/Binomial.lean
@@ -18,6 +18,8 @@ series; divergence on its boundary follows from Mathlib's Abel limit theorem.
 
 ## Main declarations
 
+* `TauCeti.hasSum_multichoose_mul_geometric_of_abs_lt_one` — the multichoose binomial
+  series on the open unit interval.
 * `TauCeti.summable_multichoose_mul_geometric_iff_norm_lt_one` — exact summability of
   `∑ n, multichoose r n * q ^ n` for `0 < r`.
 -/
@@ -28,6 +30,19 @@ open Filter Set
 open scoped ENNReal
 
 namespace TauCeti
+
+/-- The generalized multichoose power series sums to `(1 - x)⁻ʳ` when `|x| < 1`. -/
+theorem hasSum_multichoose_mul_geometric_of_abs_lt_one {r x : ℝ} (hx : |x| < 1) :
+    HasSum (fun n : ℕ => Ring.multichoose r n * x ^ n) (1 / (1 - x) ^ r) := by
+  have hmem : x ∈ Metric.eball (0 : ℝ) (1 : ℝ≥0∞) := by
+    rw [Metric.mem_eball]
+    simpa [edist_dist, Real.dist_0_eq_abs, enorm_eq_nnnorm] using hx
+  have hsum := (Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero r).hasSum_sub hmem
+  simp only [FormalMultilinearSeries.ofScalars_apply_eq, sub_zero, smul_eq_mul] at hsum
+  have hchoose (n : ℕ) :
+      Ring.choose (r + (n : ℝ) - 1) n = Ring.multichoose r n := by
+    rw [Ring.multichoose_eq]
+  simpa only [hchoose] using hsum
 
 /-- For positive real `r`, the generalized multichoose power series is unconditionally summable
 at a real or complex argument `q` exactly when `q` lies in the open unit ball. -/
@@ -40,17 +55,6 @@ theorem summable_multichoose_mul_geometric_iff_norm_lt_one
     rw [nsmul_eq_mul, Polynomial.ascPochhammer_smeval_eq_eval] at h
     apply pos_of_mul_pos_right (by rw [h]; exact ascPochhammer_pos n r hr)
     positivity
-  have hseries {x : ℝ} (hx : |x| < 1) :
-      HasSum (fun n : ℕ => Ring.multichoose r n * x ^ n) (1 / (1 - x) ^ r) := by
-    have hmem : x ∈ Metric.eball (0 : ℝ) (1 : ℝ≥0∞) := by
-      rw [Metric.mem_eball]
-      simpa [edist_dist, Real.dist_0_eq_abs, enorm_eq_nnnorm] using hx
-    have hsum := (Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero r).hasSum_sub hmem
-    simp only [FormalMultilinearSeries.ofScalars_apply_eq, sub_zero, smul_eq_mul] at hsum
-    have hchoose (n : ℕ) :
-        Ring.choose (r + (n : ℝ) - 1) n = Ring.multichoose r n := by
-      rw [Ring.multichoose_eq]
-    simpa only [hchoose] using hsum
   have hnot : ¬ Summable (fun n : ℕ => Ring.multichoose r n) := by
     intro hs
     have habel := Real.tendsto_tsum_powerSeries_nhdsWithin_lt hs.hasSum.tendsto_sum_nat
@@ -74,7 +78,8 @@ theorem summable_multichoose_mul_geometric_iff_norm_lt_one
     have heq : ∀ᶠ x : ℝ in nhdsWithin 1 (Iio 1),
         (∑' n : ℕ, Ring.multichoose r n * x ^ n) = 1 / (1 - x) ^ r := by
       filter_upwards [Ioo_mem_nhdsLT (by norm_num : (-1 : ℝ) < 1)] with x hx
-      exact (hseries (by simpa [abs_lt] using hx)).tsum_eq
+      exact (hasSum_multichoose_mul_geometric_of_abs_lt_one
+        (r := r) (by simpa [abs_lt] using hx)).tsum_eq
     have heq' : Filter.EventuallyEq (nhdsWithin 1 (Iio 1))
         (fun x : ℝ => 1 / (1 - x) ^ r)
         (fun x => ∑' n : ℕ, Ring.multichoose r n * x ^ n) := by
@@ -91,7 +96,8 @@ theorem summable_multichoose_mul_geometric_iff_norm_lt_one
       simpa only [mul_one] using mul_le_mul_of_nonneg_left
         (one_le_pow₀ (le_of_not_gt hq)) (hcoeff_pos n).le
   · intro hq
-    exact (hseries (by simpa only [abs_norm] using hq)).summable
+    exact (hasSum_multichoose_mul_geometric_of_abs_lt_one
+      (r := r) (by simpa only [abs_norm] using hq)).summable
 
 end TauCeti
 

--- a/TauCeti/Analysis/Analytic/Binomial.lean
+++ b/TauCeti/Analysis/Analytic/Binomial.lean
@@ -13,8 +13,8 @@ import Mathlib.Analysis.Complex.AbelLimit
 
 This file determines the exact unconditional summability domain of the power series with
 generalized multichoose coefficients and positive real parameter.  The result applies to both real
-and complex arguments.  Convergence on the open unit ball comes from Mathlib's real binomial power
-series; divergence on its boundary follows from Mathlib's Abel limit theorem.
+and complex arguments.  These results supply the analytic criterion used to determine the exact
+integrability domain of the negative-binomial probability-generating function.
 
 ## Main declarations
 

--- a/TauCeti/Analysis/Analytic/Binomial.lean
+++ b/TauCeti/Analysis/Analytic/Binomial.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Analytic.Binomial
+import Mathlib.Analysis.Complex.AbelLimit
+
+/-!
+# Convergence of multichoose power series
+
+This file determines the exact unconditional summability domain of the power series with
+generalized multichoose coefficients and positive real parameter.  The result applies to both real
+and complex arguments.  Convergence on the open unit ball comes from Mathlib's real binomial power
+series; divergence on its boundary follows from Mathlib's Abel limit theorem.
+
+## Main declarations
+
+* `TauCeti.summable_multichoose_mul_geometric_iff_norm_lt_one` — exact summability of
+  `∑ n, multichoose r n * q ^ n` for `0 < r`.
+-/
+
+public section
+
+open Filter Set
+open scoped ENNReal
+
+namespace TauCeti
+
+/-- For positive real `r`, the generalized multichoose power series is unconditionally summable
+at a real or complex argument `q` exactly when `q` lies in the open unit ball. -/
+@[simp]
+theorem summable_multichoose_mul_geometric_iff_norm_lt_one
+    {𝕂 : Type*} [RCLike 𝕂] {r : ℝ} {q : 𝕂} (hr : 0 < r) :
+    Summable (fun n : ℕ => ((Ring.multichoose r n : ℝ) : 𝕂) * q ^ n) ↔ ‖q‖ < 1 := by
+  have hcoeff_pos (n : ℕ) : 0 < Ring.multichoose r n := by
+    have h := Ring.factorial_nsmul_multichoose_eq_ascPochhammer r n
+    rw [nsmul_eq_mul, Polynomial.ascPochhammer_smeval_eq_eval] at h
+    apply pos_of_mul_pos_right (by rw [h]; exact ascPochhammer_pos n r hr)
+    positivity
+  have hseries {x : ℝ} (hx : |x| < 1) :
+      HasSum (fun n : ℕ => Ring.multichoose r n * x ^ n) (1 / (1 - x) ^ r) := by
+    have hmem : x ∈ Metric.eball (0 : ℝ) (1 : ℝ≥0∞) := by
+      rw [Metric.mem_eball]
+      simpa [edist_dist, Real.dist_0_eq_abs, enorm_eq_nnnorm] using hx
+    have hsum := (Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero r).hasSum_sub hmem
+    simp only [FormalMultilinearSeries.ofScalars_apply_eq, sub_zero, smul_eq_mul] at hsum
+    have hchoose (n : ℕ) :
+        Ring.choose (r + (n : ℝ) - 1) n = Ring.multichoose r n := by
+      rw [Ring.multichoose_eq]
+    simpa only [hchoose] using hsum
+  have hnot : ¬ Summable (fun n : ℕ => Ring.multichoose r n) := by
+    intro hs
+    have habel := Real.tendsto_tsum_powerSeries_nhdsWithin_lt hs.hasSum.tendsto_sum_nat
+    have hsub : Tendsto (fun x : ℝ => 1 - x) (nhdsWithin 1 (Iio 1))
+        (nhdsWithin 0 (Ioi 0)) := by
+      apply tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within
+      · have hc : Tendsto (fun _ : ℝ => (1 : ℝ)) (nhds 1) (nhds 1) :=
+          tendsto_const_nhds
+        have hi : Tendsto (fun x : ℝ => x) (nhds 1) (nhds 1) := tendsto_id
+        have hmono : nhdsWithin (1 : ℝ) (Iio 1) ≤ nhds 1 := inf_le_left
+        simpa only [sub_self] using (hc.sub hi).mono_left hmono
+      · filter_upwards [self_mem_nhdsWithin] with x hx
+        exact sub_pos.mpr (by simpa only [mem_Iio] using hx)
+    have htop : Tendsto (fun x : ℝ => 1 / (1 - x) ^ r)
+        (nhdsWithin 1 (Iio 1)) atTop := by
+      refine ((tendsto_rpow_neg_nhdsGT_zero (neg_lt_zero.mpr hr)).comp hsub).congr' ?_
+      filter_upwards [self_mem_nhdsWithin] with x hx
+      have hx' : x < 1 := by simpa only [mem_Iio] using hx
+      simpa only [Function.comp_apply, one_div] using
+        Real.rpow_neg (sub_nonneg.mpr hx'.le) r
+    have heq : ∀ᶠ x : ℝ in nhdsWithin 1 (Iio 1),
+        (∑' n : ℕ, Ring.multichoose r n * x ^ n) = 1 / (1 - x) ^ r := by
+      filter_upwards [Ioo_mem_nhdsLT (by norm_num : (-1 : ℝ) < 1)] with x hx
+      exact (hseries (by simpa [abs_lt] using hx)).tsum_eq
+    have heq' : Filter.EventuallyEq (nhdsWithin 1 (Iio 1))
+        (fun x : ℝ => 1 / (1 - x) ^ r)
+        (fun x => ∑' n : ℕ, Ring.multichoose r n * x ^ n) := by
+      filter_upwards [heq] with x hx
+      exact hx.symm
+    exact not_tendsto_atTop_of_tendsto_nhds habel (htop.congr' heq')
+  rw [← summable_norm_iff]
+  simp_rw [norm_mul, norm_pow, RCLike.norm_ofReal, abs_of_pos (hcoeff_pos _)]
+  constructor
+  · intro hs
+    by_contra hq
+    apply hnot
+    exact hs.of_nonneg_of_le (fun n => (hcoeff_pos n).le) fun n => by
+      simpa only [mul_one] using mul_le_mul_of_nonneg_left
+        (one_le_pow₀ (le_of_not_gt hq)) (hcoeff_pos n).le
+  · intro hq
+    exact (hseries (by simpa only [abs_norm] using hq)).summable
+
+end TauCeti
+
+end

--- a/TauCeti/Probability/Distributions/NegativeBinomial.lean
+++ b/TauCeti/Probability/Distributions/NegativeBinomial.lean
@@ -255,13 +255,20 @@ theorem pgf_negativeBinomialMeasure {r p : ℝ} (hr : 0 < r) (hp : 0 < p) (hp1 :
   congr with k
   rw [negativeBinomialWeight_toReal hr.le hp.le hp1]
 
-/-- At shape zero, the negative-binomial law is concentrated at zero, so its
-probability-generating function is identically one. -/
+/-- At shape zero, the negative-binomial PGF is one in the valid probability range and zero
+outside it, in accordance with the totalization of `negativeBinomialMeasure`. -/
 @[simp]
-theorem pgf_negativeBinomialMeasure_zero {p : ℝ} (hp : 0 < p) (hp1 : p ≤ 1) (t : ℝ) :
-    pgf id (negativeBinomialMeasure 0 p) t = 1 := by
-  rw [negativeBinomialMeasure_zero hp hp1, pgf_def]
-  simp
+theorem pgf_negativeBinomialMeasure_zero (p t : ℝ) :
+    pgf id (negativeBinomialMeasure 0 p) t = if 0 < p ∧ p ≤ 1 then 1 else 0 := by
+  by_cases h : 0 < p ∧ p ≤ 1
+  · rw [ite_eq_left h, negativeBinomialMeasure_zero h.1 h.2, pgf_def]
+    simp
+  · rw [ite_eq_right h]
+    have hz : negativeBinomialMeasure 0 p = 0 := by
+      apply negativeBinomialMeasure_eq_zero_of_invalid
+      simpa using h
+    rw [hz, pgf_def]
+    simp
 
 end Probability
 

--- a/TauCeti/Probability/Distributions/NegativeBinomial.lean
+++ b/TauCeti/Probability/Distributions/NegativeBinomial.lean
@@ -157,24 +157,8 @@ private theorem hasSum_negativeBinomialWeightReal_mul_pow (hr : 0 < r) (hp : 0 <
     {t : ℝ} (ht : |(1 - p) * t| < 1) :
     HasSum (fun k => negativeBinomialWeightReal r p k * t ^ k)
       (Real.rpow (p / (1 - (1 - p) * t)) r) := by
-  have hseries := Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero r
-  have hmem : ‖((1 - p) * t : ℝ)‖ₑ < (1 : ℝ≥0∞) := by
-    rw [enorm_eq_nnnorm]
-    -- `Metric.mem_eball` uses the extended norm, so first state the NNReal version.
-    exact_mod_cast (show ‖((1 - p) * t : ℝ)‖₊ < (1 : ℝ≥0) by
-      have ht' : ‖((1 - p) * t : ℝ)‖ < 1 := by
-        simpa [Real.norm_eq_abs] using ht
-      exact_mod_cast ht')
-  have hsum := hseries.hasSum_sub (y := (1 - p) * t)
-    (by simpa [Metric.mem_eball] using hmem)
-  simp only [FormalMultilinearSeries.ofScalars_apply_eq, sub_zero, smul_eq_mul] at hsum
-  have hchoose (n : ℕ) :
-      Ring.choose (r + (n : ℝ) - 1) n = Ring.multichoose r n := by
-    rw [Ring.multichoose_eq]
-  have hsum' : HasSum (fun k => (Ring.multichoose r k : ℝ) * ((1 - p) * t) ^ k)
-      (1 / (1 - (1 - p) * t) ^ r) := by
-    simpa only [hchoose] using hsum
-  have hsum'' := hsum'.mul_right (Real.rpow p r)
+  have hsum := hasSum_multichoose_mul_geometric_of_abs_lt_one (r := r) ht
+  have hsum' := hsum.mul_right (Real.rpow p r)
   have hweight (k : ℕ) :
       negativeBinomialWeightReal r p k * t ^ k =
         (Ring.multichoose r k : ℝ) * ((1 - p) * t) ^ k * Real.rpow p r := by
@@ -185,7 +169,7 @@ private theorem hasSum_negativeBinomialWeightReal_mul_pow (hr : 0 < r) (hp : 0 <
   -- Normalize the real-power notation inherited from the analytic-series theorem.
   have hden_rpow : (1 - (1 - p) * t) ^ r =
       Real.rpow (1 - (1 - p) * t) r := rfl
-  rw [hden_rpow] at hsum''
+  rw [hden_rpow] at hsum'
   have hvalue : 1 / Real.rpow (1 - (1 - p) * t) r * Real.rpow p r =
       Real.rpow (p / (1 - (1 - p) * t)) r := by
     calc
@@ -194,8 +178,8 @@ private theorem hasSum_negativeBinomialWeightReal_mul_pow (hr : 0 < r) (hp : 0 <
             rw [one_div, div_eq_mul_inv, mul_comm]
       _ = Real.rpow (p / (1 - (1 - p) * t)) r :=
         (Real.div_rpow hp.le hden r).symm
-  rw [hvalue] at hsum''
-  exact HasSum.congr_fun hsum'' hweight
+  rw [hvalue] at hsum'
+  exact HasSum.congr_fun hsum' hweight
 
 private theorem hasSum_negativeBinomialWeightReal (hr : 0 < r) (hp : 0 < p) (hp1 : p ≤ 1) :
     HasSum (fun k => negativeBinomialWeightReal r p k) 1 := by
@@ -273,6 +257,7 @@ theorem pgf_negativeBinomialMeasure {r p : ℝ} (hr : 0 < r) (hp : 0 < p) (hp1 :
 
 /-- At shape zero, the negative-binomial law is concentrated at zero, so its
 probability-generating function is identically one. -/
+@[simp]
 theorem pgf_negativeBinomialMeasure_zero {p : ℝ} (hp : 0 < p) (hp1 : p ≤ 1) (t : ℝ) :
     pgf id (negativeBinomialMeasure 0 p) t = 1 := by
   rw [negativeBinomialMeasure_zero hp hp1, pgf_def]

--- a/TauCeti/Probability/Distributions/NegativeBinomial.lean
+++ b/TauCeti/Probability/Distributions/NegativeBinomial.lean
@@ -5,9 +5,11 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Analytic.Binomial
 public import Mathlib.Analysis.SpecialFunctions.Gamma.Beta
 public import Mathlib.MeasureTheory.Measure.Dirac.Basic
+public import TauCeti.Analysis.Analytic.Binomial
+public import TauCeti.Probability.GeneratingFunction
+import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
 
 /-!
 # The negative-binomial distribution
@@ -19,9 +21,8 @@ native mass is the Gamma-expression
 
 The definition is totalized explicitly: the positive family is used for `0 < r` and `0 < p ≤ 1`,
 the boundary `r = 0` is a Dirac mass at zero, and every other parameter value gives the zero
-measure.  This first slice supplies the normalized measure and its native singleton interface.  The
-generating-function, convolution, transform, and moment formulas are the next
-part of the roadmap item.
+measure.  The file supplies the normalized measure, its native singleton interface, and the exact
+integrability domain and closed form of its probability-generating function.
 
 The normalization uses Mathlib's real binomial power series, after identifying its coefficients
 with the Gamma quotient.  The distributional convention follows Johnson, Kemp, and Kotz,
@@ -152,47 +153,56 @@ theorem negativeBinomialWeight_toReal (hr : 0 ≤ r) (hp : 0 ≤ p) (hp1 : p ≤
   rw [negativeBinomialWeight, ENNReal.toReal_ofReal]
   exact negativeBinomialWeightReal_nonneg hr hp hp1 k
 
-private theorem hasSum_negativeBinomialWeightReal (hr : 0 < r) (hp : 0 < p) (hp1 : p ≤ 1) :
-    HasSum (fun k => negativeBinomialWeightReal r p k) 1 := by
-  have hq : |1 - p| < 1 := by
-    rw [abs_of_nonneg (by linarith)]
-    linarith
+private theorem hasSum_negativeBinomialWeightReal_mul_pow (hr : 0 < r) (hp : 0 < p)
+    {t : ℝ} (ht : |(1 - p) * t| < 1) :
+    HasSum (fun k => negativeBinomialWeightReal r p k * t ^ k)
+      (Real.rpow (p / (1 - (1 - p) * t)) r) := by
   have hseries := Real.one_div_one_sub_rpow_hasFPowerSeriesOnBall_zero r
-  have hmem : ‖(1 - p : ℝ)‖ₑ < (1 : ℝ≥0∞) := by
+  have hmem : ‖((1 - p) * t : ℝ)‖ₑ < (1 : ℝ≥0∞) := by
     rw [enorm_eq_nnnorm]
     -- `Metric.mem_eball` uses the extended norm, so first state the NNReal version.
-    exact_mod_cast (show ‖(1 - p : ℝ)‖₊ < (1 : ℝ≥0) by
-      have hq' : ‖(1 - p : ℝ)‖ < 1 := by
-        simpa [Real.norm_eq_abs] using hq
-      exact_mod_cast hq')
-  have hsum := hseries.hasSum_sub (y := 1 - p) (by simpa [Metric.mem_eball] using hmem)
+    exact_mod_cast (show ‖((1 - p) * t : ℝ)‖₊ < (1 : ℝ≥0) by
+      have ht' : ‖((1 - p) * t : ℝ)‖ < 1 := by
+        simpa [Real.norm_eq_abs] using ht
+      exact_mod_cast ht')
+  have hsum := hseries.hasSum_sub (y := (1 - p) * t)
+    (by simpa [Metric.mem_eball] using hmem)
   simp only [FormalMultilinearSeries.ofScalars_apply_eq, sub_zero, smul_eq_mul] at hsum
   have hchoose (n : ℕ) :
       Ring.choose (r + (n : ℝ) - 1) n = Ring.multichoose r n := by
     rw [Ring.multichoose_eq]
-  have hsum' : HasSum (fun k => (Ring.multichoose r k : ℝ) * (1 - p) ^ k)
-      (1 / (1 - (1 - p)) ^ r) := by
+  have hsum' : HasSum (fun k => (Ring.multichoose r k : ℝ) * ((1 - p) * t) ^ k)
+      (1 / (1 - (1 - p) * t) ^ r) := by
     simpa only [hchoose] using hsum
-  have hpow : (1 - (1 - p)) ^ r = p ^ r := by ring_nf
-  have hp_rpow : 0 < Real.rpow p r := Real.rpow_pos_of_pos hp r
-  have hsum2 := hsum'.mul_right (Real.rpow p r)
-  rw [hpow] at hsum2
-  have hcancel : 1 / Real.rpow p r * Real.rpow p r = 1 := by
-    rw [one_div]
-    exact inv_mul_cancel₀ hp_rpow.ne'
-  have hcancel' : 1 / p ^ r * Real.rpow p r = 1 := by
-    -- The notation `p ^ r` here is the real-power instance.
-    change 1 / Real.rpow p r * Real.rpow p r = 1
-    exact hcancel
+  have hsum'' := hsum'.mul_right (Real.rpow p r)
   have hweight (k : ℕ) :
-      negativeBinomialWeightReal r p k =
-        (Ring.multichoose r k : ℝ) * (1 - p) ^ k * Real.rpow p r := by
-    rw [negativeBinomialWeightReal_eq_coeff hr k]
+      negativeBinomialWeightReal r p k * t ^ k =
+        (Ring.multichoose r k : ℝ) * ((1 - p) * t) ^ k * Real.rpow p r := by
+    rw [negativeBinomialWeightReal_eq_coeff hr k, mul_pow]
     ring
-  have hsum3 : HasSum
-      (fun k => (Ring.multichoose r k : ℝ) * (1 - p) ^ k * Real.rpow p r) 1 := by
-    simpa only [hcancel'] using hsum2
-  exact HasSum.congr_fun hsum3 hweight
+  have hden : 0 ≤ 1 - (1 - p) * t := by
+    linarith [le_abs_self ((1 - p) * t)]
+  -- Normalize the real-power notation inherited from the analytic-series theorem.
+  have hden_rpow : (1 - (1 - p) * t) ^ r =
+      Real.rpow (1 - (1 - p) * t) r := rfl
+  rw [hden_rpow] at hsum''
+  have hvalue : 1 / Real.rpow (1 - (1 - p) * t) r * Real.rpow p r =
+      Real.rpow (p / (1 - (1 - p) * t)) r := by
+    calc
+      1 / Real.rpow (1 - (1 - p) * t) r * Real.rpow p r =
+          Real.rpow p r / Real.rpow (1 - (1 - p) * t) r := by
+            rw [one_div, div_eq_mul_inv, mul_comm]
+      _ = Real.rpow (p / (1 - (1 - p) * t)) r :=
+        (Real.div_rpow hp.le hden r).symm
+  rw [hvalue] at hsum''
+  exact HasSum.congr_fun hsum'' hweight
+
+private theorem hasSum_negativeBinomialWeightReal (hr : 0 < r) (hp : 0 < p) (hp1 : p ≤ 1) :
+    HasSum (fun k => negativeBinomialWeightReal r p k) 1 := by
+  have ht : |(1 - p) * (1 : ℝ)| < 1 := by
+    rw [mul_one, abs_of_nonneg (by linarith)]
+    linarith
+  simpa [hp.ne'] using (hasSum_negativeBinomialWeightReal_mul_pow hr hp ht)
 
 /-- The negative-binomial measure is a probability measure in its classical parameter range. -/
 theorem isProbabilityMeasure_negativeBinomialMeasure (hr : 0 ≤ r) (hp : 0 < p) (hp1 : p ≤ 1) :
@@ -224,6 +234,49 @@ theorem negativeBinomialMeasure_real_singleton {r p : ℝ} (hr : 0 ≤ r) (hp : 
     (negativeBinomialMeasure r p).real {k} = negativeBinomialWeightReal r p k := by
   rw [measureReal_def, negativeBinomialMeasure_singleton hr hp hp1,
     negativeBinomialWeight_toReal hr hp.le hp1]
+
+/-- For positive shape and valid success probability, the negative-binomial
+probability-generating-function integrand is integrable exactly inside its disk of convergence.
+Thus it is non-integrable both on and beyond the boundary. -/
+theorem integrable_pow_negativeBinomialMeasure_iff {r p : ℝ} (hr : 0 < r)
+    (hp : 0 < p) (hp1 : p ≤ 1) (t : ℝ) :
+    Integrable (fun k : ℕ => t ^ k) (negativeBinomialMeasure r p) ↔
+      |(1 - p) * t| < 1 := by
+  rw [negativeBinomialMeasure_eq_sum_dirac hr.le hp hp1,
+    integrable_sum_dirac_iff (by simp [negativeBinomialWeight])]
+  simp_rw [negativeBinomialWeight_toReal hr.le hp.le hp1, Real.norm_eq_abs, abs_pow]
+  have hp_rpow : 0 < Real.rpow p r := Real.rpow_pos_of_pos hp r
+  have hfun : (fun k : ℕ => negativeBinomialWeightReal r p k * |t| ^ k) =
+      (fun k : ℕ => Real.rpow p r *
+        ((Ring.multichoose r k : ℝ) * |(1 - p) * t| ^ k)) := by
+    funext k
+    rw [negativeBinomialWeightReal_eq_coeff hr k, abs_mul,
+      abs_of_nonneg (by linarith : 0 ≤ 1 - p), mul_pow]
+    ring
+  rw [hfun, summable_mul_left_iff hp_rpow.ne']
+  simpa [Real.norm_eq_abs] using
+    (summable_multichoose_mul_geometric_iff_norm_lt_one
+      (𝕂 := ℝ) (q := |(1 - p) * t|) hr)
+
+/-- The probability-generating function of a negative-binomial law with positive shape, on its
+exact integrability domain. -/
+theorem pgf_negativeBinomialMeasure {r p : ℝ} (hr : 0 < r) (hp : 0 < p) (hp1 : p ≤ 1)
+    {t : ℝ} (ht : |(1 - p) * t| < 1) :
+    pgf id (negativeBinomialMeasure r p) t =
+      Real.rpow (p / (1 - (1 - p) * t)) r := by
+  rw [pgf_def, negativeBinomialMeasure_eq_sum_dirac hr.le hp hp1,
+    integral_sum_dirac (by simp [negativeBinomialWeight])]
+  simp only [id_eq, smul_eq_mul]
+  rw [← (hasSum_negativeBinomialWeightReal_mul_pow hr hp ht).tsum_eq]
+  congr with k
+  rw [negativeBinomialWeight_toReal hr.le hp.le hp1]
+
+/-- At shape zero, the negative-binomial law is concentrated at zero, so its
+probability-generating function is identically one. -/
+theorem pgf_negativeBinomialMeasure_zero {p : ℝ} (hp : 0 < p) (hp1 : p ≤ 1) (t : ℝ) :
+    pgf id (negativeBinomialMeasure 0 p) t = 1 := by
+  rw [negativeBinomialMeasure_zero hp hp1, pgf_def]
+  simp
 
 end Probability
 


### PR DESCRIPTION
This PR computes the negative-binomial probability-generating function required by `TauCetiRoadmap/StandardDistributions/README.md`, Layer 3, “Negative binomial”: for `0 < r` and `0 < p ≤ 1`, it proves the exact integrability criterion `|(1 - p) * t| < 1`, derives `pgf id (negativeBinomialMeasure r p) t = Real.rpow (p / (1 - (1 - p) * t)) r` on that domain, and proves the shape-zero PGF is `1` for every `t`.

The exact boundary argument adds `TauCeti.summable_multichoose_mul_geometric_iff_norm_lt_one`, a real-and-complex analytic prerequisite consumed by `integrable_pow_negativeBinomialMeasure_iff`; it reuses Mathlib’s real binomial power series and Abel-limit theorem, with no Mathlib code vendored or modified.

This advances the Layer 3 negative-binomial PGF milestone. After this PR, the same negative-binomial target still needs native support and convolution, cast moments and exponential/characteristic transforms, cumulative/CDF formulas, and the remaining `r = 0` moment and transform boundary cases.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"negative-binomial-pgf"}-->

🤖 Prepared with Codex
