### PR TITLE
feat: identify the Gamma-Poisson mixture

### DIFF
--- a/TauCeti/Probability/Distributions/Gamma/Basic.lean
+++ b/TauCeti/Probability/Distributions/Gamma/Basic.lean
@@ -87,15 +87,16 @@ private lemma gammaPDFReal_of_pos {x : ℝ} (hx : 0 < x) :
 
 /-- An integral against the gamma law is the set integral of the weighted integrand over
 `(0, ∞)`. -/
-theorem integral_gammaMeasure_eq (ha : 0 < a) (hr : 0 < r) (f : ℝ → ℝ) :
+theorem integral_gammaMeasure_eq {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (ha : 0 < a) (hr : 0 < r) (f : ℝ → E) :
     ∫ x, f x ∂gammaMeasure a r =
-      ∫ x in Ioi 0, r ^ a / Real.Gamma a * x ^ (a - 1) * exp (-(r * x)) * f x := by
-  have hcompl : ∀ x ∉ Ici (0 : ℝ), gammaPDFReal a r x * f x = 0 := by
+      ∫ x in Ioi 0, (r ^ a / Real.Gamma a * x ^ (a - 1) * exp (-(r * x))) • f x := by
+  have hcompl : ∀ x ∉ Ici (0 : ℝ), gammaPDFReal a r x • f x = 0 := by
     intro x hx
-    rw [gammaPDFReal, ite_eq_right (by simpa using hx), zero_mul]
+    rw [gammaPDFReal, ite_eq_right (by simpa using hx), zero_smul]
   rw [gammaMeasure, integral_withDensity_eq_integral_toReal_smul
     (Probability.measurable_gammaPDF a r) (ae_of_all _ fun _ ↦ ENNReal.ofReal_lt_top) f]
-  simp_rw [gammaPDF, ENNReal.toReal_ofReal (gammaPDFReal_nonneg ha hr _), smul_eq_mul]
+  simp_rw [gammaPDF, ENNReal.toReal_ofReal (gammaPDFReal_nonneg ha hr _)]
   rw [← setIntegral_eq_integral_of_forall_compl_eq_zero hcompl, integral_Ici_eq_integral_Ioi]
   exact setIntegral_congr_fun measurableSet_Ioi fun x hx ↦ by rw [gammaPDFReal_of_pos hx]
 
@@ -148,7 +149,11 @@ theorem integral_pow_gammaMeasure (ha : 0 < a) (hr : 0 < r) (n : ℕ) :
   have hGa := (Real.Gamma_pos_of_pos ha).ne'
   have hra := (Real.rpow_pos_of_pos hr a).ne'
   have hrn := (pow_pos hr n).ne'
-  rw [integral_gammaMeasure_eq ha hr, setIntegral_congr_fun measurableSet_Ioi hcongr,
+  rw [integral_gammaMeasure_eq ha hr]
+  -- In this real-valued specialization, scalar multiplication is ordinary multiplication.
+  change (∫ x in Ioi 0,
+    (r ^ a / Real.Gamma a * x ^ (a - 1) * exp (-(r * x))) * x ^ n) = _
+  rw [setIntegral_congr_fun measurableSet_Ioi hcongr,
     integral_const_mul_gammaKernel _ _ _ han hr, Real.rpow_add hr, Real.rpow_natCast]
   field_simp
 
@@ -261,8 +266,11 @@ theorem mgf_id_gammaMeasure (ha : 0 < a) (hr : 0 < r) {t : ℝ} (ht : t < r) :
   have hone_sub : (1 : ℝ) - t / r = (r - t) / r := by field_simp
   rw [mgf]
   simp only [id_eq]
-  rw [integral_gammaMeasure_eq ha hr,
-    setIntegral_congr_fun measurableSet_Ioi (fun x _ ↦ gammaWeight_mul_exp a r t x),
+  rw [integral_gammaMeasure_eq ha hr]
+  -- In this real-valued specialization, scalar multiplication is ordinary multiplication.
+  change (∫ x in Ioi 0,
+    (r ^ a / Real.Gamma a * x ^ (a - 1) * exp (-(r * x))) * exp (t * x)) = _
+  rw [setIntegral_congr_fun measurableSet_Ioi (fun x _ ↦ gammaWeight_mul_exp a r t x),
     integral_const_mul_gammaKernel _ _ _ ha hrt, hone_sub,
     Real.rpow_neg (by positivity), Real.div_rpow hrt.le hr.le]
   field_simp

--- a/TauCeti/Probability/Distributions/Gamma/Basic.lean
+++ b/TauCeti/Probability/Distributions/Gamma/Basic.lean
@@ -87,7 +87,7 @@ private lemma gammaPDFReal_of_pos {x : ℝ} (hx : 0 < x) :
 
 /-- An integral against the gamma law is the set integral of the weighted integrand over
 `(0, ∞)`. -/
-private lemma integral_gammaMeasure_eq (ha : 0 < a) (hr : 0 < r) (f : ℝ → ℝ) :
+theorem integral_gammaMeasure_eq (ha : 0 < a) (hr : 0 < r) (f : ℝ → ℝ) :
     ∫ x, f x ∂gammaMeasure a r =
       ∫ x in Ioi 0, r ^ a / Real.Gamma a * x ^ (a - 1) * exp (-(r * x)) * f x := by
   have hcompl : ∀ x ∉ Ici (0 : ℝ), gammaPDFReal a r x * f x = 0 := by

--- a/TauCeti/Probability/Distributions/Gamma/Poisson.lean
+++ b/TauCeti/Probability/Distributions/Gamma/Poisson.lean
@@ -55,6 +55,11 @@ private lemma integral_poissonMass_gammaMeasure {r p : ℝ} (hr : 0 < r) (hp : 0
     ring
   -- Collect the Poisson mass with the Gamma density on its positive support.
   rw [TauCeti.integral_gammaMeasure_eq hr hrate]
+  -- In this real-valued specialization, scalar multiplication is ordinary multiplication.
+  change (∫ x in Ioi 0,
+    ((p / (1 - p)) ^ r / Real.Gamma r * x ^ (r - 1) *
+      Real.exp (-(p / (1 - p) * x))) *
+        (Real.exp (-x) * x ^ k / k.factorial)) = _
   have hcongr : ∀ x ∈ Ioi (0 : ℝ),
       (p / (1 - p)) ^ r / Real.Gamma r * x ^ (r - 1) *
           Real.exp (-(p / (1 - p) * x)) * (Real.exp (-x) * x ^ k / k.factorial) =
@@ -104,6 +109,7 @@ private lemma integral_poissonMass_gammaMeasure {r p : ℝ} (hr : 0 < r) (hp : 0
 If the Poisson rate is mixed according to the Gamma law of shape `r` and rate
 `p / (1 - p)`, the resulting count law is negative-binomial with shape `r` and success
 probability `p`. -/
+@[simp]
 theorem bind_gammaMeasure_poissonMeasure {r p : ℝ} (hr : 0 < r) (hp : 0 < p) (hp1 : p < 1) :
     (gammaMeasure r (p / (1 - p))).bind
         (fun lam => poissonMeasure (Real.toNNReal lam)) =

--- a/TauCeti/Probability/Distributions/Gamma/Poisson.lean
+++ b/TauCeti/Probability/Distributions/Gamma/Poisson.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Probability.Distributions.Gamma.Basic
+public import TauCeti.Probability.Distributions.NegativeBinomial
+public import Mathlib.Probability.Distributions.Poisson.Basic
+import TauCeti.Probability.Distributions.Measurability
+
+/-!
+# Gamma mixtures of Poisson distributions
+
+Mixing a Poisson rate against a Gamma law produces a negative-binomial distribution. More
+precisely, a Gamma mixing law of shape `r` and rate `p / (1 - p)` gives the negative-binomial law
+of shape `r` and success probability `p`.
+
+The proof compares singleton masses. The Poisson mass contributes `exp (-x) * x ^ k / k!` to
+the Gamma density, changing its rate from `p / (1 - p)` to `1 / (1 - p)` and its shape from `r`
+to `r + k`. Euler's Gamma integral then gives exactly the negative-binomial mass.
+
+## Main result
+
+* `TauCeti.Probability.bind_gammaMeasure_poissonMeasure` — a Gamma mixture of Poisson laws is
+  negative-binomial.
+
+## References
+
+* N. L. Johnson, A. W. Kemp, S. Kotz, *Univariate Discrete Distributions*, 3rd ed., Wiley
+  (2005), ch. 6.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory Real Set
+open scoped ENNReal NNReal
+
+namespace TauCeti
+
+namespace Probability
+
+private lemma integral_poissonMass_gammaMeasure {r p : ℝ} (hr : 0 < r) (hp : 0 < p)
+    (hp1 : p < 1) (k : ℕ) :
+    ∫ x, Real.exp (-x) * x ^ k / k.factorial ∂gammaMeasure r (p / (1 - p)) =
+      negativeBinomialWeightReal r p k := by
+  have h1mp : 0 < 1 - p := sub_pos.mpr hp1
+  have hrate : 0 < p / (1 - p) := div_pos hp h1mp
+  have hshape : 0 < r + (k : ℝ) := by positivity
+  have hcombined : p / (1 - p) + 1 = (1 - p)⁻¹ := by
+    field_simp [h1mp.ne']
+    ring
+  -- Collect the Poisson mass with the Gamma density on its positive support.
+  rw [TauCeti.integral_gammaMeasure_eq hr hrate]
+  have hcongr : ∀ x ∈ Ioi (0 : ℝ),
+      (p / (1 - p)) ^ r / Real.Gamma r * x ^ (r - 1) *
+          Real.exp (-(p / (1 - p) * x)) * (Real.exp (-x) * x ^ k / k.factorial) =
+        ((p / (1 - p)) ^ r / (Real.Gamma r * k.factorial)) *
+          (x ^ (r + (k : ℝ) - 1) *
+            Real.exp (-((p / (1 - p) + 1) * x))) := by
+    intro x hx
+    have hxpow : x ^ (r - 1) * x ^ k = x ^ (r + (k : ℝ) - 1) := by
+      rw [← Real.rpow_natCast x k, ← Real.rpow_add hx]
+      congr 1
+      ring
+    have hexp : Real.exp (-(p / (1 - p) * x)) * Real.exp (-x) =
+        Real.exp (-((p / (1 - p) + 1) * x)) := by
+      rw [← Real.exp_add]
+      congr 1
+      ring
+    calc
+      (p / (1 - p)) ^ r / Real.Gamma r * x ^ (r - 1) *
+            Real.exp (-(p / (1 - p) * x)) *
+          (Real.exp (-x) * x ^ k / k.factorial) =
+          ((p / (1 - p)) ^ r / (Real.Gamma r * k.factorial)) *
+            ((x ^ (r - 1) * x ^ k) *
+              (Real.exp (-(p / (1 - p) * x)) * Real.exp (-x))) := by ring
+      _ = _ := by rw [hxpow, hexp]
+  -- Euler's Gamma integral evaluates the kernel with shifted shape `r + k`.
+  rw [setIntegral_congr_fun measurableSet_Ioi hcongr, integral_const_mul,
+    Real.integral_rpow_mul_exp_neg_mul_Ioi hshape (by positivity : 0 < p / (1 - p) + 1),
+    hcombined]
+  -- Normalize the remaining constants to the defining negative-binomial mass.
+  rw [negativeBinomialWeightReal_eq_gamma hr.ne' k]
+  have hrpow_div : (p / (1 - p)) ^ r = p ^ r / (1 - p) ^ r := by
+    exact Real.div_rpow hp.le h1mp.le r
+  have hrpow_add : (1 / (1 - p)⁻¹) ^ (r + (k : ℝ)) =
+      (1 - p) ^ r * (1 - p) ^ k := by
+    rw [one_div, inv_inv, Real.rpow_add h1mp, Real.rpow_natCast]
+  rw [hrpow_div, hrpow_add]
+  have hGamma : Real.Gamma r ≠ 0 := (Real.Gamma_pos_of_pos hr).ne'
+  have hfac : (k.factorial : ℝ) ≠ 0 := by positivity
+  have hpow : (1 - p) ^ r ≠ 0 := (Real.rpow_pos_of_pos h1mp r).ne'
+  have hGammaArg : r + (k : ℝ) = (k : ℝ) + r := by ring
+  rw [hGammaArg]
+  field_simp
+  exact (Real.rpow_eq_pow p r).symm
+
+/-- **A Gamma mixture of Poisson laws is negative-binomial.**
+
+If the Poisson rate is mixed according to the Gamma law of shape `r` and rate
+`p / (1 - p)`, the resulting count law is negative-binomial with shape `r` and success
+probability `p`. -/
+theorem bind_gammaMeasure_poissonMeasure {r p : ℝ} (hr : 0 < r) (hp : 0 < p) (hp1 : p < 1) :
+    (gammaMeasure r (p / (1 - p))).bind
+        (fun lam => poissonMeasure (Real.toNNReal lam)) =
+      negativeBinomialMeasure r p := by
+  have hrate : 0 < p / (1 - p) := div_pos hp (sub_pos.mpr hp1)
+  have hkernelMeas : Measurable (fun lam : ℝ => poissonMeasure (Real.toNNReal lam)) := by
+    fun_prop
+  have hkernel : AEMeasurable (fun lam : ℝ => poissonMeasure (Real.toNNReal lam))
+      (gammaMeasure r (p / (1 - p))) := hkernelMeas.aemeasurable
+  let _ : IsProbabilityMeasure (gammaMeasure r (p / (1 - p))) :=
+    isProbabilityMeasure_gammaMeasure hr hrate
+  let _ : IsProbabilityMeasure
+      ((gammaMeasure r (p / (1 - p))).bind
+        (fun lam => poissonMeasure (Real.toNNReal lam))) :=
+    isProbabilityMeasure_bind hkernel (ae_of_all _ fun _ => inferInstance)
+  let _ : IsProbabilityMeasure (negativeBinomialMeasure r p) :=
+    isProbabilityMeasure_negativeBinomialMeasure hr.le hp hp1.le
+  refine MeasureTheory.ext_iff_measureReal_singleton.mpr fun k => ?_
+  rw [negativeBinomialMeasure_real_singleton hr.le hp hp1.le, measureReal_def,
+    Measure.bind_apply (measurableSet_singleton k) hkernel]
+  have hmassMeas : AEMeasurable
+      (fun lam : ℝ => poissonMeasure (Real.toNNReal lam) {k})
+      (gammaMeasure r (p / (1 - p))) :=
+    ((Measure.measurable_coe (measurableSet_singleton k)).comp hkernelMeas).aemeasurable
+  rw [← integral_toReal hmassMeas (ae_of_all _ fun lam => measure_lt_top _ _)]
+  simp_rw [← measureReal_def, poissonMeasure_real_singleton]
+  rw [integral_congr_ae (by
+    filter_upwards [TauCeti.ae_pos_gammaMeasure r (p / (1 - p))] with lam hlam
+    rw [Real.coe_toNNReal lam hlam.le])]
+  exact integral_poissonMass_gammaMeasure hr hp hp1 k
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/NegativeBinomial.lean
+++ b/TauCeti/Probability/Distributions/NegativeBinomial.lean
@@ -93,6 +93,13 @@ theorem negativeBinomialMeasure_zero {p : ℝ} (hp : 0 < p) (hp1 : p ≤ 1) :
     negativeBinomialMeasure 0 p = Measure.dirac 0 := by
   simp [negativeBinomialMeasure, hp, hp1]
 
+/-- At nonzero shape, the real negative-binomial weight has its defining Gamma-quotient form. -/
+@[simp]
+theorem negativeBinomialWeightReal_eq_gamma (hr : r ≠ 0) (k : ℕ) :
+    negativeBinomialWeightReal r p k =
+      Real.Gamma (k + r) / (k.factorial * Real.Gamma r) * Real.rpow p r * (1 - p) ^ k := by
+  rw [negativeBinomialWeightReal, ite_eq_right hr]
+
 private theorem gamma_ratio_eq_multichoose (hr : 0 < r) (k : ℕ) :
     Real.Gamma (k + r) / (k.factorial * Real.Gamma r) = Ring.multichoose r k := by
   have hpoch : ∀ n : ℕ,
@@ -128,7 +135,7 @@ private theorem gamma_ratio_eq_multichoose (hr : 0 < r) (k : ℕ) :
 theorem negativeBinomialWeightReal_eq_coeff (hr : 0 < r) (k : ℕ) :
     negativeBinomialWeightReal r p k =
       (Ring.multichoose r k : ℝ) * Real.rpow p r * (1 - p) ^ k := by
-  rw [negativeBinomialWeightReal, ite_eq_right hr.ne', gamma_ratio_eq_multichoose hr k]
+  rw [negativeBinomialWeightReal_eq_gamma hr.ne' k, gamma_ratio_eq_multichoose hr k]
 
 private theorem negativeBinomialWeightReal_nonneg (hr : 0 ≤ r) (hp : 0 ≤ p) (hp1 : p ≤ 1)
     (k : ℕ) : 0 ≤ negativeBinomialWeightReal r p k := by


### PR DESCRIPTION
This PR proves the Gamma-mixed Poisson identity `(gammaMeasure r (p / (1 - p))).bind (fun lam => poissonMeasure (Real.toNNReal lam)) = negativeBinomialMeasure r p` for `0 < r` and `0 < p < 1`. It compares singleton masses, removes `Real.toNNReal` on the Gamma law's almost-everywhere positive support, and evaluates the resulting shifted Gamma integral. It exposes the existing Gamma integral reduction and adds the native Gamma-quotient characterization of the opaque negative-binomial weight so the proof reuses stable APIs.

This advances the exact target in `TauCetiRoadmap/StandardDistributions/README.md`, Layer 4, item 5, “Gamma-mixed Poisson law,” and completes the key declaration `bind_gammaMeasure_poissonMeasure`. It is the most effective current step because its explicit Layer 0 parameter-measurability prerequisite and the Gamma and negative-binomial mass APIs have landed on `main`, while neighboring distribution-family work is already in flight.

After this PR, the Gamma-mixed Poisson item is complete; Layer 4 still needs its remaining ratio laws, sums-and-differences results, and finite-extrema results.

The calculation follows N. L. Johnson, A. W. Kemp, and S. Kotz, *Univariate Discrete Distributions*, 3rd ed., Wiley (2005), Chapter 6. No Mathlib infrastructure is vendored.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"bind-gammameasure-poissonmeasure"}-->

🤖 Prepared with Codex
