### PR TITLE
feat: construct the geodesic spray and identify its integral curves

### DIFF
--- a/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
+++ b/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Geometry.Manifold.MFDeriv.Atlas
 public import Mathlib.Geometry.Manifold.MFDeriv.NormedSpace
+public import Mathlib.Geometry.Manifold.VectorBundle.Basic
 
 /-!
 # Differentiating along a curve in a manifold
@@ -37,6 +38,8 @@ curve need not carry a `HasMFDerivWithinAt` witness for it.
   curve within a parameter set and its unrestricted case, computed by
   `TauCeti.Manifold.curveVelocityWithin_apply` and `TauCeti.Manifold.curveVelocity_apply` and
   related by `TauCeti.Manifold.curveVelocityWithin_univ`.
+* `TauCeti.Manifold.curveVelocityLiftWithin` and `TauCeti.Manifold.curveVelocityLift`: the
+  corresponding curves in the tangent bundle, together with their projection and fibre formulas.
 * `TauCeti.Manifold.hasMFDerivWithinAt_curveVelocityWithin` and
   `TauCeti.Manifold.curveVelocityWithin_eq_of_hasMFDerivWithinAt`: the two directions relating the
   named velocity to a `HasMFDerivWithinAt` witness.
@@ -56,6 +59,8 @@ open scoped Manifold Topology
 noncomputable section
 
 namespace TauCeti.Manifold
+
+open Bundle
 
 variable
   {𝕜 : Type*} [NontriviallyNormedField 𝕜]
@@ -203,6 +208,41 @@ would otherwise keep `simp` from reaching. -/
 @[simp]
 theorem curveVelocity_const (x : M) : curveVelocity I (fun _ : 𝕜 ↦ x) t = 0 := by
   rw [← curveVelocityWithin_univ, curveVelocityWithin_const]
+
+/-! ### The velocity lift of a curve -/
+
+variable (I) in
+/-- **The velocity lift** of a curve to the tangent bundle: the curve `t ↦ (γ t, γ' t)`, with the
+velocity taken within the parameter set `s`. It inherits the junk values of
+`TauCeti.Manifold.curveVelocityWithin` where `γ` is not differentiable within `s`. -/
+def curveVelocityLiftWithin (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜) : TangentBundle I M :=
+  TotalSpace.mk' E (γ t) (curveVelocityWithin I γ s t)
+
+variable (I) in
+/-- The velocity lift of a curve, with unrestricted velocity. This is the `s = Set.univ` case of
+`TauCeti.Manifold.curveVelocityLiftWithin`. -/
+def curveVelocityLift (γ : 𝕜 → M) : 𝕜 → TangentBundle I M :=
+  curveVelocityLiftWithin I γ Set.univ
+
+/-- The defining formula for the velocity lift. -/
+theorem curveVelocityLiftWithin_apply (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜) :
+    curveVelocityLiftWithin I γ s t =
+      TotalSpace.mk' E (γ t) (curveVelocityWithin I γ s t) := (rfl)
+
+/-- The unrestricted velocity lift is the lift taken within the whole parameter space. -/
+@[simp]
+theorem curveVelocityLift_eq_curveVelocityLiftWithin_univ (γ : 𝕜 → M) :
+    curveVelocityLift I γ = curveVelocityLiftWithin I γ Set.univ := (rfl)
+
+/-- The velocity lift lies over the curve. -/
+@[simp]
+theorem curveVelocityLiftWithin_proj (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜) :
+    (curveVelocityLiftWithin I γ s t).proj = γ t := (rfl)
+
+/-- The fibre component of the velocity lift is the velocity of the curve. -/
+@[simp]
+theorem curveVelocityLiftWithin_snd (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜) :
+    (curveVelocityLiftWithin I γ s t).2 = curveVelocityWithin I γ s t := (rfl)
 
 variable [IsManifold I 1 M]
 

--- a/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
+++ b/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
@@ -229,6 +229,10 @@ theorem curveVelocityLiftWithin_apply (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜
     curveVelocityLiftWithin I γ s t =
       TotalSpace.mk' E (γ t) (curveVelocityWithin I γ s t) := (rfl)
 
+/-- The defining formula for the unrestricted velocity lift. -/
+theorem curveVelocityLift_apply (γ : 𝕜 → M) (t : 𝕜) :
+    curveVelocityLift I γ t = TotalSpace.mk' E (γ t) (curveVelocity I γ t) := (rfl)
+
 /-- The velocity lift taken within the whole parameter space is the unrestricted lift. -/
 @[simp]
 theorem curveVelocityLiftWithin_univ (γ : 𝕜 → M) :
@@ -243,6 +247,16 @@ theorem curveVelocityLiftWithin_proj (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜)
 @[simp]
 theorem curveVelocityLiftWithin_snd (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜) :
     (curveVelocityLiftWithin I γ s t).2 = curveVelocityWithin I γ s t := (rfl)
+
+/-- The unrestricted velocity lift lies over the curve. -/
+@[simp]
+theorem curveVelocityLift_proj (γ : 𝕜 → M) (t : 𝕜) :
+    (curveVelocityLift I γ t).proj = γ t := (rfl)
+
+/-- The fibre component of the unrestricted velocity lift is the velocity of the curve. -/
+@[simp]
+theorem curveVelocityLift_snd (γ : 𝕜 → M) (t : 𝕜) :
+    (curveVelocityLift I γ t).2 = curveVelocity I γ t := (rfl)
 
 variable [IsManifold I 1 M]
 

--- a/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
+++ b/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
@@ -229,10 +229,10 @@ theorem curveVelocityLiftWithin_apply (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜
     curveVelocityLiftWithin I γ s t =
       TotalSpace.mk' E (γ t) (curveVelocityWithin I γ s t) := (rfl)
 
-/-- The unrestricted velocity lift is the lift taken within the whole parameter space. -/
+/-- The velocity lift taken within the whole parameter space is the unrestricted lift. -/
 @[simp]
-theorem curveVelocityLift_eq_curveVelocityLiftWithin_univ (γ : 𝕜 → M) :
-    curveVelocityLift I γ = curveVelocityLiftWithin I γ Set.univ := (rfl)
+theorem curveVelocityLiftWithin_univ (γ : 𝕜 → M) :
+    curveVelocityLiftWithin I γ Set.univ = curveVelocityLift I γ := (rfl)
 
 /-- The velocity lift lies over the curve. -/
 @[simp]

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -276,11 +276,12 @@ theorem isMIntegralCurveOn_curveVelocityLiftWithin_iff
   exact (hasMFDerivWithinAt_curveVelocityLiftWithin_iff hs hγ hr).2
     (h.alongCurveWithin_curveVelocityWithin_eq_zero r hr)
 
-/-- **An integral curve of the spray is a velocity lift.**  On a parameter set with unique
-derivatives, an integral curve of the geodesic spray is the velocity lift of the curve it lies
-over. -/
+/-- **An integral curve of the spray is a velocity lift.**  At a parameter at which the parameter
+set has unique derivatives, an integral curve of the geodesic spray is the velocity lift of the
+curve it lies over. -/
 theorem eq_curveVelocityLiftWithin_of_isMIntegralCurveOn {z : ℝ → TangentBundle I M}
-    (hs : UniqueDiffOn ℝ s) (h : IsMIntegralCurveOn z (geodesicSpray I M) s) (ht : t ∈ s) :
+    (hs : UniqueDiffWithinAt ℝ s t) (h : IsMIntegralCurveOn z (geodesicSpray I M) s)
+    (ht : t ∈ s) :
     z t = curveVelocityLiftWithin I (fun r ↦ (z r).proj) s t := by
   have hproj : MDifferentiableWithinAt 𝓘(ℝ, ℝ) I (fun r ↦ (z r).proj) s t :=
     (Bundle.mdifferentiableAt_proj (fun x : M ↦ TangentSpace I x)).comp_mdifferentiableWithinAt t
@@ -293,7 +294,7 @@ theorem eq_curveVelocityLiftWithin_of_isMIntegralCurveOn {z : ℝ → TangentBun
         (s := (trivializationAt E (TangentSpace I) (z t).proj).baseSet)) (z t).proj
       (z t).2 (z t).2) (h t ht).continuousWithinAt).1 (h t ht)
   have hvel : curveVelocityWithin I (fun r ↦ (z r).proj) s t = (z t).2 :=
-    (derivWithin_extChartAt_comp_curve hproj (hs t ht)).symm.trans (hd.1.derivWithin (hs t ht))
+    (derivWithin_extChartAt_comp_curve hproj hs).symm.trans (hd.1.derivWithin hs)
   rw [curveVelocityLiftWithin_apply, hvel]
 
 /-- **The base curve of an integral curve of the spray is a geodesic**, as soon as it is `C²` on a
@@ -304,7 +305,7 @@ theorem isGeodesicCurveOn_proj_of_isMIntegralCurveOn {z : ℝ → TangentBundle 
     IsGeodesicCurveOn I (fun r ↦ (z r).proj) s :=
   (isMIntegralCurveOn_curveVelocityLiftWithin_iff hs hz).1
     (h.congr fun _r hr ↦
-      (eq_curveVelocityLiftWithin_of_isMIntegralCurveOn hs h hr).symm)
+      (eq_curveVelocityLiftWithin_of_isMIntegralCurveOn (hs _r hr) h hr).symm)
 
 /-! ### All-time geodesics and the spray -/
 

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -20,8 +20,8 @@ it becomes a first-order equation on the tangent bundle, for the vector field
 `S (x, v) = (v, -Γ_x (v, v))`
 
 on `TM` called the **geodesic spray**.  This file constructs `S` for the Levi-Civita connection of
-the ambient Riemannian bundle instance and identifies its integral curves with the velocity lifts
-of geodesics.
+the ambient Riemannian bundle instance, identifies velocity lifts of `C²` geodesics with integral
+curves of `S`, and shows that every integral curve is a velocity lift.
 
 A vector field on a manifold assigns to a point a vector of the model space, read in the chart at
 that point; the tangent-bundle chart at `z = (x, v)` reads the base direction in the extended
@@ -37,15 +37,16 @@ derivative term in the tangent lift cancels the inhomogeneous term in
 the content of
 `TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_iff` and
 `TauCeti.Manifold.eq_curveVelocityLiftWithin_of_isMIntegralCurveOn`: on a parameter set with
-unique derivatives, the integral curves of `S` are exactly the velocity lifts
+unique derivatives, velocity lifts of `C²` geodesics are integral curves of `S`, while arbitrary
+integral curves of `S` are velocity lifts of their projected curves:
 
 `t ↦ (γ t, γ' t) : ℝ → TM`
 
-of the geodesics of `M`.  The two statements are read in one direction each: the velocity lift of
-a `C²` curve is an integral curve of `S` exactly when the curve is a geodesic, and conversely
-every integral curve of `S` is the velocity lift of the curve it lies over, whose base curve is a
-geodesic as soon as it is `C²`. The `C²` hypothesis on the base curve is not yet removable: it
-would follow from smoothness of `S`, which is not proved here.
+The two statements are read in one direction each: the velocity lift of a `C²` curve is an integral
+curve of `S` exactly when the curve is a geodesic, and conversely every integral curve of `S` is the
+velocity lift of the curve it lies over, whose base curve is a geodesic as soon as it is `C²`. The
+`C²` hypothesis on the base curve is not yet removable: it would follow from smoothness of `S`,
+which is not proved here.
 
 The unpacking of a curve into `TM` into its base curve and its fibre coordinate is
 `TauCeti.Manifold.hasMFDerivWithinAt_totalSpace_curve_iff`, proved for an arbitrary fibre bundle.
@@ -154,26 +155,22 @@ theorem tangentCoordChange_geodesicSpray {x x₀ : M}
       (v, -christoffelMap (finBasis ℝ E)
         ((leviCivita I M).isCovariantDerivativeOn
           (s := (trivializationAt E (TangentSpace I) x₀).baseSet)) x v v) := by
-  -- `TangentSpace I x` is an irreducible type synonym for the model `E`. The generic tangent
-  -- coordinate-change formula is stated in model coordinates, so expose that representation.
-  change E at u
-  -- Expand the locally defined spray and express its base point through the inverse of the
-  -- canonical model-space equivalence, as required by `tangentCoordChange_tangent_apply`.
-  change tangentCoordChange I.tangent
-      (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
-      (TotalSpace.mk' E x₀ 0)
-      (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
+  rw [geodesicSpray_apply]
+  have hT := tangentCoordChange_tangent_apply (I := I) (M := M) hx₀ u
+    (-christoffelMap (finBasis ℝ E)
+      ((leviCivita I M).isCovariantDerivativeOn
+        (s := (trivializationAt E (TangentSpace I) x).baseSet)) x u u)
+  simp only [continuousLinearMapAt_trivializationAt_self] at hT
+  -- Reduce the projections of the displayed total-space point so that the general tangent-chart
+  -- formula applies; these projections have no separate rewriting lemma.
+  change tangentCoordChange I.tangent (TotalSpace.mk' E x u) (TotalSpace.mk' E x₀ 0)
+      (TotalSpace.mk' E x u)
         (u, -christoffelMap (finBasis ℝ E)
           ((leviCivita I M).isCovariantDerivativeOn
             (s := (trivializationAt E (TangentSpace I) x).baseSet)) x u u) = _
-  rw [tangentCoordChange_tangent_apply hx₀]
-  have hchange := geodesicSpray_coordChange (I := I) (M := M) hx₀
-    ((tangentSpaceCastModel I x).symm u)
-  -- `tangentSpaceCastModel` is definitionally the identity equivalence, but the irreducible
-  -- tangent-space synonym prevents `rw` from seeing this round trip without recording it here.
-  have hu : (tangentSpaceCastModel I x).symm u = (show TangentSpace I x from u) := rfl
-  rw [hu] at hchange ⊢
-  simpa only [map_neg, ← sub_eq_add_neg] using hchange
+  rw [hT]
+  simpa only [map_neg, ← sub_eq_add_neg] using
+    geodesicSpray_coordChange (I := I) (M := M) hx₀ u
 
 /-- **The geodesic equation as an integral-curve equation.**  The velocity lift of a `C²` curve
 solves the equation of the geodesic spray at a parameter of its set exactly when the derivative of

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Geometry.Manifold.Riemannian.Geodesic.Basic
 public import TauCeti.Geometry.Manifold.IntegralCurve.Basic
-public import TauCeti.Geometry.Manifold.MFDeriv.Curve
 public import TauCeti.Geometry.Manifold.VectorBundle.CurveInTotalSpace
 import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.CoordinateChange
 
@@ -118,6 +117,19 @@ theorem geodesicSpray_apply (z : TangentBundle I M) :
         ((leviCivita I M).isCovariantDerivativeOn
           (s := (trivializationAt E (TangentSpace I) z.proj).baseSet)) z.proj z.2 z.2) :=
   (rfl)
+
+/-- The geodesic spray vanishes on the zero section of the tangent bundle. -/
+@[simp]
+theorem geodesicSpray_zero (x : M) :
+    geodesicSpray I M (TotalSpace.mk' E x 0) = 0 := by
+  rw [geodesicSpray_apply]
+  -- Reduce the projections of the displayed total-space point; they have no rewriting lemma.
+  change (0, -christoffelMap (finBasis ℝ E)
+    ((leviCivita I M).isCovariantDerivativeOn
+      (s := (trivializationAt E (TangentSpace I) x).baseSet)) x 0 0) = (0, 0)
+  rw [map_zero]
+  rw [neg_zero]
+  rfl
 
 /- **Chart independence of the spray formula.**  On the overlap of the preferred charts at `x`
 and `x₀`, the tangent lift of the coordinate change sends the second-order vector

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Geometry.Manifold.Riemannian.Geodesic.Basic
 public import TauCeti.Geometry.Manifold.IntegralCurve.Basic
+public import TauCeti.Geometry.Manifold.MFDeriv.Curve
 public import TauCeti.Geometry.Manifold.VectorBundle.CurveInTotalSpace
 import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.CoordinateChange
 
@@ -43,8 +44,8 @@ unique derivatives, the integral curves of `S` are exactly the velocity lifts
 of the geodesics of `M`.  The two statements are read in one direction each: the velocity lift of
 a `C²` curve is an integral curve of `S` exactly when the curve is a geodesic, and conversely
 every integral curve of `S` is the velocity lift of the curve it lies over, whose base curve is a
-geodesic as soon as it is `C²`.  The `C²` hypothesis on the base curve is not yet removable: it
-would follow from smoothness of `S`, which is the next step of the roadmap and is not proved here.
+geodesic as soon as it is `C²`. The `C²` hypothesis on the base curve is not yet removable: it
+would follow from smoothness of `S`, which is not proved here.
 
 The unpacking of a curve into `TM` into its base curve and its fibre coordinate is
 `TauCeti.Manifold.hasMFDerivWithinAt_totalSpace_curve_iff`, proved for an arbitrary fibre bundle.
@@ -56,8 +57,6 @@ The unpacking of a curve into `TM` into its base curve and its fibre coordinate 
   preferred-chart formula, `TauCeti.Manifold.tangentCoordChange_geodesicSpray` its formula in every
   overlapping tangent-bundle chart, and
   `TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_const` the constant-curve check.
-* `TauCeti.Manifold.curveVelocityLiftWithin` and `TauCeti.Manifold.curveVelocityLift`: the
-  velocity lift of a curve to the tangent bundle, within a parameter set and unrestricted.
 * `TauCeti.Manifold.hasMFDerivWithinAt_curveVelocityLiftWithin_iff`: at one parameter, the
   velocity lift of a `C²` curve solves the spray equation exactly when the covariant derivative of
   the velocity along the curve vanishes.
@@ -71,8 +70,6 @@ The unpacking of a curve into `TM` into its base curve and its fibre coordinate 
 
 ## References
 
-* [Geodesics, the exponential map, and the Hopf--Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
-  Layer 1, "The geodesic spray".
 * M. P. do Carmo, *Riemannian Geometry*, Birkhäuser, 1992, Ch. 3, §2.
 * J. M. Lee, *Introduction to Riemannian Manifolds*, GTM 176, 2018, Ch. 4.
 -/
@@ -91,41 +88,6 @@ variable
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
   {γ : ℝ → M} {s : Set ℝ} {t : ℝ}
-
-/-! ### The velocity lift of a curve -/
-
-variable (I) in
-/-- **The velocity lift** of a curve to the tangent bundle: the curve `t ↦ (γ t, γ' t)`, with the
-velocity taken within the parameter set `s`.  It inherits the junk values of
-`TauCeti.Manifold.curveVelocityWithin` where `γ` is not differentiable within `s`. -/
-def curveVelocityLiftWithin (γ : ℝ → M) (s : Set ℝ) (t : ℝ) : TangentBundle I M :=
-  TotalSpace.mk' E (γ t) (curveVelocityWithin I γ s t)
-
-variable (I) in
-/-- The velocity lift of a curve, with unrestricted velocity.  This is the `s = Set.univ` case of
-`TauCeti.Manifold.curveVelocityLiftWithin`. -/
-def curveVelocityLift (γ : ℝ → M) : ℝ → TangentBundle I M :=
-  curveVelocityLiftWithin I γ univ
-
-/-- The defining formula for the velocity lift. -/
-theorem curveVelocityLiftWithin_apply (γ : ℝ → M) (s : Set ℝ) (t : ℝ) :
-    curveVelocityLiftWithin I γ s t =
-      TotalSpace.mk' E (γ t) (curveVelocityWithin I γ s t) := (rfl)
-
-/-- The unrestricted velocity lift is the lift taken within the whole parameter space. -/
-@[simp]
-theorem curveVelocityLift_eq_curveVelocityLiftWithin_univ (γ : ℝ → M) :
-    curveVelocityLift I γ = curveVelocityLiftWithin I γ univ := (rfl)
-
-/-- The velocity lift lies over the curve. -/
-@[simp]
-theorem curveVelocityLiftWithin_proj (γ : ℝ → M) (s : Set ℝ) (t : ℝ) :
-    (curveVelocityLiftWithin I γ s t).proj = γ t := (rfl)
-
-/-- The fibre component of the velocity lift is the velocity of the curve. -/
-@[simp]
-theorem curveVelocityLiftWithin_snd (γ : ℝ → M) (s : Set ℝ) (t : ℝ) :
-    (curveVelocityLiftWithin I γ s t).2 = curveVelocityWithin I γ s t := (rfl)
 
 /-! ### The spray -/
 
@@ -178,167 +140,6 @@ private theorem geodesicSpray_coordChange {x x₀ : M}
   rw [h]
   simp only [neg_sub]
 
-omit [FiniteDimensional ℝ E] [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
-    [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
-private theorem tangentCoordChange_tangent_apply {x x₀ : M}
-    (hx₀ : x ∈ (extChartAt I x₀).source) (u w : E) :
-    tangentCoordChange I.tangent
-        (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
-        (TotalSpace.mk' E x₀ 0)
-        (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u)) (u, w) =
-      (tangentCoordChange I x x₀ x u,
-        mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x
-            ((tangentSpaceCastModel I x).symm u) +
-          tangentCoordChange I x x₀ x w) := by
-  let z : TangentBundle I M :=
-    TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u)
-  let q : TangentBundle I M := TotalSpace.mk' E x₀ 0
-  let p := extChartAt I.tangent z z
-  let G := (extChartAt I.tangent q : TangentBundle I M → E × E) ∘
-    (extChartAt I.tangent z).symm
-  let T : E × E → E × E := fun a ↦
-    let y := (extChartAt I x).symm a.1
-    (extChartAt I x₀ y, tangentCoordChange I x x₀ y a.2)
-  have hz : z ∈ (chartAt (ModelProd H E) z).source := mem_chart_source _ _
-  have hzq : z ∈ (chartAt (ModelProd H E) q).source := by
-    rw [TangentBundle.mem_chart_source_iff (I := I) (M := M)]
-    rw [← extChartAt_source I x₀]
-    exact hx₀
-  have hN := (I.tangent.extendCoordChange_source_mem_nhdsWithin'
-    (e := chartAt (ModelProd H E) z) (e' := chartAt (ModelProd H E) q) hz hzq)
-  have hGT : G =ᶠ[𝓝[range I.tangent] p] T := by
-    filter_upwards [hN] with a ha
-    change a ∈ ((extChartAt I.tangent z).symm ≫ extChartAt I.tangent q).source at ha
-    let b := (extChartAt I.tangent z).symm a
-    have ha_target : a ∈ (extChartAt I.tangent z).target := ha.1
-    have hbzT : b ∈ (extChartAt I.tangent z).source :=
-      (extChartAt I.tangent z).map_target ha_target
-    have hbqT : b ∈ (extChartAt I.tangent q).source := ha.2
-    have hbz : b.proj ∈ (extChartAt I x).source := by
-      rw [extChartAt_source] at hbzT ⊢
-      exact (TangentBundle.mem_chart_source_iff b z).1 hbzT
-    have hbq : b.proj ∈ (extChartAt I x₀).source := by
-      rw [extChartAt_source] at hbqT ⊢
-      exact (TangentBundle.mem_chart_source_iff b q).1 hbqT
-    have hright : extChartAt I.tangent z b = a :=
-      (extChartAt I.tangent z).right_inv ha_target
-    have hbase : extChartAt I x b.proj = a.1 := by
-      have h := congrArg Prod.fst hright
-      change extChartAt I x b.proj = a.1 at h
-      exact h
-    have hfiber : tangentCoordChange I b.proj x b.proj b.2 = a.2 := by
-      have h := congrArg Prod.snd hright
-      change tangentCoordChange I b.proj x b.proj b.2 = a.2 at h
-      exact h
-    have hy : (extChartAt I x).symm a.1 = b.proj := by
-      rw [← hbase]
-      exact (extChartAt I x).left_inv hbz
-    have hsecond : (extChartAt I.tangent q b).2 =
-        tangentCoordChange I x x₀ b.proj a.2 := by
-      rw [← hfiber]
-      have hcomp := tangentCoordChange_comp (I := I) (w := b.proj) (x := x)
-        (y := x₀) (z := b.proj) (v := b.2)
-        ⟨⟨mem_extChartAt_source b.proj, hbz⟩, hbq⟩
-      change tangentCoordChange I b.proj x₀ b.proj b.2 = _
-      exact hcomp.symm
-    change extChartAt I.tangent q b = T a
-    apply Prod.ext
-    · change extChartAt I x₀ b.proj = extChartAt I x₀ ((extChartAt I x).symm a.1)
-      rw [hy]
-    · change (extChartAt I.tangent q b).2 =
-        tangentCoordChange I x x₀ ((extChartAt I x).symm a.1) a.2
-      simpa only [hy] using hsecond
-  rw [tangentCoordChange_def]
-  change fderivWithin ℝ G (range I.tangent) p (u, w) = _
-  have hp_mem : p ∈ range I.tangent :=
-    (extChartAt_target_subset_range z) ((extChartAt I.tangent z).map_source
-      (mem_extChartAt_source z))
-  have hp_eq : G p = T p := hGT.self_of_nhdsWithin hp_mem
-  rw [hGT.fderivWithin_eq hp_eq]
-  have hpcoord : p = (extChartAt I x x, u) := by
-    apply Prod.ext
-    · change extChartAt I x x = (extChartAt I x x, u).1
-      rfl
-    · change tangentCoordChange I x x x u = u
-      exact tangentCoordChange_self (mem_extChartAt_source x)
-  rw [hpcoord, ModelWithCorners.range_prod]
-  rw [ModelWithCorners.range_eq_univ 𝓘(ℝ, E)]
-  let a₀ := extChartAt I x x
-  let F : E → E := fun a ↦ extChartAt I x₀ ((extChartAt I x).symm a)
-  let C : E → E →L[ℝ] E := fun a ↦ tangentCoordChange I x x₀ ((extChartAt I x).symm a)
-  have ha₀ : a₀ ∈ ((extChartAt I x).symm ≫ extChartAt I x₀).source := by
-    rw [PartialEquiv.trans_source]
-    exact ⟨(extChartAt I x).map_source (mem_extChartAt_source x), by
-      change (extChartAt I x).symm a₀ ∈ (extChartAt I x₀).source
-      simpa only [a₀, extChartAt_to_inv] using hx₀⟩
-  have hF : DifferentiableWithinAt ℝ F (range I) a₀ :=
-    (contDiffWithinAt_ext_coord_change x₀ x ha₀).differentiableWithinAt
-      (by norm_num : (2 : WithTop ℕ∞) ≠ 0)
-  have hI₂ : IsManifold I (1 + 1) M := inferInstanceAs (IsManifold I 2 M)
-  have hCMD : MDifferentiableAt I 𝓘(ℝ, E →L[ℝ] E)
-      (tangentCoordChange I x x₀) x :=
-    (contMDiffAt_tangentCoordChange (n := 1) hx₀).mdifferentiableAt one_ne_zero
-  have hC : DifferentiableWithinAt ℝ C (range I) a₀ := by
-    have h := (mdifferentiableAt_iff (tangentCoordChange I x x₀) x).1 hCMD |>.2
-    simp only [writtenInExtChartAt, extChartAt_model_space_eq_id,
-      PartialEquiv.refl_coe] at h
-    change DifferentiableWithinAt ℝ C (range I) a₀ at h
-    exact h
-  have hmaps : MapsTo (Prod.fst : E × E → E) (range I ×ˢ univ) (range I) :=
-    fun _ h ↦ h.1
-  have huniqBase : UniqueDiffWithinAt ℝ (range I) a₀ := I.uniqueDiffWithinAt_image
-  have huniq : UniqueDiffWithinAt ℝ (range I ×ˢ univ) (a₀, u) :=
-    huniqBase.prod uniqueDiffWithinAt_univ
-  have hFp : DifferentiableWithinAt ℝ (fun a : E × E ↦ F a.1)
-      (range I ×ˢ univ) (a₀, u) := by
-    change DifferentiableWithinAt ℝ (F ∘ Prod.fst) (range I ×ˢ univ) (a₀, u)
-    exact hF.comp (a₀, u) differentiableWithinAt_fst hmaps
-  have hCp : DifferentiableWithinAt ℝ (fun a : E × E ↦ C a.1)
-      (range I ×ˢ univ) (a₀, u) := by
-    change DifferentiableWithinAt ℝ (C ∘ Prod.fst) (range I ×ˢ univ) (a₀, u)
-    exact hC.comp (a₀, u) differentiableWithinAt_fst hmaps
-  have hAp : DifferentiableWithinAt ℝ (fun a : E × E ↦ C a.1 a.2)
-      (range I ×ˢ univ) (a₀, u) :=
-    hCp.clm_apply differentiableWithinAt_snd
-  change (fderivWithin ℝ (fun a : E × E ↦ (F a.1, C a.1 a.2))
-    (range I ×ˢ univ) (a₀, u)) (u, w) = _
-  have hFp_eq := fderivWithin_comp (a₀, u) hF differentiableWithinAt_fst hmaps huniq
-  change fderivWithin ℝ (fun a : E × E ↦ F a.1) (range I ×ˢ univ) (a₀, u) = _ at hFp_eq
-  have hCp_eq := fderivWithin_comp (a₀, u) hC differentiableWithinAt_fst hmaps huniq
-  change fderivWithin ℝ (fun a : E × E ↦ C a.1) (range I ×ˢ univ) (a₀, u) = _ at hCp_eq
-  have hAp_eq := fderivWithin_clm_apply huniq hCp differentiableWithinAt_snd
-  change fderivWithin ℝ (fun a : E × E ↦ C a.1 a.2) (range I ×ˢ univ) (a₀, u) = _ at hAp_eq
-  have hfst_app : (fderivWithin ℝ (Prod.fst : E × E → E) (range I ×ˢ univ) (a₀, u))
-      (u, w) = u := by
-    rw [fderivWithin_fst huniq]
-    rfl
-  have hsnd_app : (fderivWithin ℝ (Prod.snd : E × E → E) (range I ×ˢ univ) (a₀, u))
-      (u, w) = w := by
-    rw [fderivWithin_snd huniq]
-    rfl
-  rw [hFp.fderivWithin_prodMk hAp huniq, ContinuousLinearMap.prod_apply, hFp_eq,
-    hAp_eq, hCp_eq]
-  simp only [ContinuousLinearMap.comp_apply, add_apply,
-    ContinuousLinearMap.flip_apply, C, F, a₀, extChartAt_to_inv]
-  rw [hfst_app, hsnd_app, add_comm]
-  have hFderiv : fderivWithin ℝ F (range I) a₀ = tangentCoordChange I x x₀ x := by
-    rw [tangentCoordChange_def]
-    rfl
-  rw [hFderiv]
-  have hMDu : MDifferentiableAt I 𝓘(ℝ, E)
-      (fun y ↦ tangentCoordChange I x x₀ y u) x :=
-    hCMD.clm_apply mdifferentiableAt_const
-  have hCuDeriv := fderivWithin_clm_apply huniqBase hC
-    (differentiableWithinAt_const (c := u))
-  have hCuDerivApp := congrArg (fun L : E →L[ℝ] E ↦ L u) hCuDeriv
-  have hMv : mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x
-      ((tangentSpaceCastModel I x).symm u) =
-      fderivWithin ℝ C (range I) a₀ u u := by
-    rw [hMDu.mvfderiv]
-    change fderivWithin ℝ (fun a ↦ C a u) (range I) a₀ u = _
-    simpa [fderivWithin_const_apply] using hCuDerivApp
-  rw [hMv]
-
 /-- **The geodesic spray has the same formula in every overlapping tangent-bundle chart.**
 Transporting the value defined in the preferred chart at `(x, u)` to the chart based at `x₀`
 sends `(v, -Γ(v, v))` to `(v₀, -Γ₀(v₀, v₀))`, where `v₀` is the fibre coordinate in the latter
@@ -351,7 +152,11 @@ theorem tangentCoordChange_geodesicSpray {x x₀ : M}
       (v, -christoffelMap (finBasis ℝ E)
         ((leviCivita I M).isCovariantDerivativeOn
           (s := (trivializationAt E (TangentSpace I) x₀).baseSet)) x v v) := by
+  -- `TangentSpace I x` is an irreducible type synonym for the model `E`. The generic tangent
+  -- coordinate-change formula is stated in model coordinates, so expose that representation.
   change E at u
+  -- Expand the locally defined spray and express its base point through the inverse of the
+  -- canonical model-space equivalence, as required by `tangentCoordChange_tangent_apply`.
   change tangentCoordChange I.tangent
       (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
       (TotalSpace.mk' E x₀ 0)
@@ -362,6 +167,8 @@ theorem tangentCoordChange_geodesicSpray {x x₀ : M}
   rw [tangentCoordChange_tangent_apply hx₀]
   have hchange := geodesicSpray_coordChange (I := I) (M := M) hx₀
     ((tangentSpaceCastModel I x).symm u)
+  -- `tangentSpaceCastModel` is definitionally the identity equivalence, but the irreducible
+  -- tangent-space synonym prevents `rw` from seeing this round trip without recording it here.
   have hu : (tangentSpaceCastModel I x).symm u = (show TangentSpace I x from u) := rfl
   rw [hu] at hchange ⊢
   simpa only [map_neg, ← sub_eq_add_neg] using hchange
@@ -374,6 +181,7 @@ theorem hasMFDerivWithinAt_curveVelocityLiftWithin_iff
     HasMFDerivWithinAt 𝓘(ℝ, ℝ) I.tangent (curveVelocityLiftWithin I γ s) s t
         ((1 : ℝ →L[ℝ] ℝ).smulRight (geodesicSpray I M (curveVelocityLiftWithin I γ s t))) ↔
       alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s t = 0 := by
+  rw [geodesicSpray_apply, curveVelocityLiftWithin_snd, curveVelocityLiftWithin_proj]
   have hxbase : γ t ∈ (trivializationAt E (TangentSpace I) (γ t)).baseSet :=
     FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t)
   have hγd : MDifferentiableOn 𝓘(ℝ, ℝ) I γ s := hγ.mdifferentiableOn (by norm_num)
@@ -387,7 +195,7 @@ theorem hasMFDerivWithinAt_curveVelocityLiftWithin_iff
       (hγd t ht).continuousWithinAt.preimage_mem_nhdsWithin
         ((trivializationAt E (TangentSpace I) (γ t)).open_baseSet.mem_nhds hxbase)
     filter_upwards [hbase] with r hr
-    rw [sectionCoord_apply]
+    rw [curveVelocityLiftWithin_apply, sectionCoord_apply]
     exact (Trivialization.continuousLinearMapAt_apply_of_mem (R := ℝ) _ hr _).symm
   have hsec : (fun r ↦ (trivializationAt E (TangentSpace I) (γ t)
       (curveVelocityLiftWithin I γ s r)).2) =ᶠ[𝓝[s] t]
@@ -399,6 +207,7 @@ theorem hasMFDerivWithinAt_curveVelocityLiftWithin_iff
       (differentiableWithinAt_sectionCoord_curveVelocityWithin γ hs hγ ht hxbase)
   have hcont : ContinuousWithinAt (curveVelocityLiftWithin I γ s) s t := by
     rw [FiberBundle.continuousWithinAt_totalSpace E (curveVelocityLiftWithin I γ s)]
+    simp only [curveVelocityLiftWithin_proj]
     exact ⟨(hγd t ht).continuousWithinAt,
       ((hcoord.differentiableWithinAt_iff_of_mem ht).2
         (differentiableWithinAt_sectionCoord_curveVelocityWithin γ hs hγ ht
@@ -417,14 +226,16 @@ theorem hasMFDerivWithinAt_curveVelocityLiftWithin_iff
       ((leviCivita I M).isCovariantDerivativeOn
         (s := (trivializationAt E (TangentSpace I) (γ t)).baseSet)) (γ t) v v) hw
   rw [alongCurveWithin_curveVelocityWithin_eq_zero_iff (leviCivita I M) γ hs hγd ht]
-  refine Iff.trans (hasMFDerivWithinAt_totalSpace_curve_iff_of_continuousWithinAt
+  have htotal := hasMFDerivWithinAt_totalSpace_curve_iff_of_continuousWithinAt
     (F := E) (V := fun x : M ↦ TangentSpace I x) (IB := I)
     (z := curveVelocityLiftWithin I γ s)
     (a := curveVelocityWithin I γ s t)
     (b := -christoffelMap (finBasis ℝ E)
       ((leviCivita I M).isCovariantDerivativeOn
         (s := (trivializationAt E (TangentSpace I) (γ t)).baseSet)) (γ t)
-      (curveVelocityWithin I γ s t) (curveVelocityWithin I γ s t)) hcont) ?_
+      (curveVelocityWithin I γ s t) (curveVelocityWithin I γ s t)) hcont
+  simp only [curveVelocityLiftWithin_proj] at htotal
+  refine Iff.trans htotal ?_
   refine Iff.trans (and_iff_right (hasDerivWithinAt_extChartAt_comp_curve
     (hasMFDerivWithinAt_curveVelocityWithin (hγd t ht)))) ?_
   refine Iff.trans (hsec.hasDerivWithinAt_iff_of_mem ht) ?_
@@ -499,6 +310,7 @@ an all-time geodesic. -/
 theorem isMIntegralCurve_curveVelocityLift_iff (hγ : ContMDiff 𝓘(ℝ, ℝ) I 2 γ) :
     IsMIntegralCurve (curveVelocityLift I γ) (geodesicSpray I M) ↔ IsGeodesicCurve I γ := by
   rw [isMIntegralCurve_iff_isMIntegralCurveOn, ← isGeodesicCurveOn_univ]
+  rw [curveVelocityLift_eq_curveVelocityLiftWithin_univ]
   exact isMIntegralCurveOn_curveVelocityLiftWithin_iff uniqueDiffOn_univ
     (contMDiffOn_univ.2 hγ)
 

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -1,0 +1,301 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.Riemannian.Geodesic.Basic
+public import TauCeti.Geometry.Manifold.VectorBundle.CurveInTotalSpace
+public import Mathlib.Geometry.Manifold.IntegralCurve.Basic
+
+/-!
+# The geodesic spray
+
+The geodesic equation `u'' + Γ (u', u') = 0` is a second-order equation on the manifold; as usual
+it becomes a first-order equation on the tangent bundle, for the vector field
+
+`S (x, v) = (v, -Γ_x (v, v))`
+
+on `TM` called the **geodesic spray**.  This file constructs `S` for the Levi-Civita connection of
+the ambient Riemannian bundle instance and identifies its integral curves with the velocity lifts
+of geodesics.
+
+A vector field on a manifold assigns to a point a vector of the model space, read in the chart at
+that point; the tangent-bundle chart at `z = (x, v)` reads the base direction in the extended
+chart of `M` at `x` and the fibre direction in the tangent-bundle trivialization at `x`, over
+which `v` is its own coordinate.  So the displayed formula *is* the definition of
+`TauCeti.Manifold.geodesicSpray`, with `Γ` the model-space Christoffel map
+`TauCeti.Manifold.christoffelMap` of the Levi-Civita connection in the trivialization at the base
+point of the argument — the same moving-chart convention as
+`CovariantDerivative.alongCurveWithin` and `TauCeti.Manifold.IsGeodesicCurveOn`.  What has to be
+proved is that this formula solves the intended problem, and that is the content of
+`TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_iff` and
+`TauCeti.Manifold.eq_curveVelocityLiftWithin_of_isMIntegralCurveOn`: on a parameter set with
+unique derivatives, the integral curves of `S` are exactly the velocity lifts
+
+`t ↦ (γ t, γ' t) : ℝ → TM`
+
+of the geodesics of `M`.  The two statements are read in one direction each: the velocity lift of
+a `C²` curve is an integral curve of `S` exactly when the curve is a geodesic, and conversely
+every integral curve of `S` is the velocity lift of the curve it lies over, whose base curve is a
+geodesic as soon as it is `C²`.  The `C²` hypothesis on the base curve is not yet removable: it
+would follow from smoothness of `S`, which is the next step of the roadmap and is not proved here.
+
+The unpacking of a curve into `TM` into its base curve and its fibre coordinate is
+`TauCeti.Manifold.hasMFDerivWithinAt_totalSpace_curve_iff`, proved for an arbitrary fibre bundle.
+
+## Main definitions and results
+
+* `TauCeti.Manifold.geodesicSpray`: **the geodesic spray** of the ambient Riemannian bundle
+  instance, a vector field on the tangent bundle, with `TauCeti.Manifold.geodesicSpray_apply` its
+  chart formula and `TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_const` the
+  constant-curve check.
+* `TauCeti.Manifold.curveVelocityLiftWithin` and `TauCeti.Manifold.curveVelocityLift`: the
+  velocity lift of a curve to the tangent bundle, within a parameter set and unrestricted.
+* `TauCeti.Manifold.hasMFDerivWithinAt_curveVelocityLiftWithin_iff`: at one parameter, the
+  velocity lift of a `C²` curve solves the spray equation exactly when the covariant derivative of
+  the velocity along the curve vanishes.
+* `TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_iff`: **the velocity lift of a `C²`
+  curve is an integral curve of the geodesic spray exactly when the curve is a geodesic**, with
+  `TauCeti.Manifold.isMIntegralCurve_curveVelocityLift_iff` its all-time case.
+* `TauCeti.Manifold.eq_curveVelocityLiftWithin_of_isMIntegralCurveOn`: **an integral curve of the
+  geodesic spray is a velocity lift**, and
+  `TauCeti.Manifold.isGeodesicCurveOn_proj_of_isMIntegralCurveOn`: the curve it lies over is a
+  geodesic once it is `C²`.
+
+## References
+
+* [Geodesics, the exponential map, and the Hopf--Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
+  Layer 1, "The geodesic spray".
+* M. P. do Carmo, *Riemannian Geometry*, Birkhäuser, 1992, Ch. 3, §2.
+* J. M. Lee, *Introduction to Riemannian Manifolds*, GTM 176, 2018, Ch. 4.
+-/
+
+public section
+
+open Bundle CovariantDerivative Filter Module Set
+open scoped Manifold Topology
+
+noncomputable section
+
+namespace TauCeti.Manifold
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {γ : ℝ → M} {s : Set ℝ} {t : ℝ}
+
+/-! ### The velocity lift of a curve -/
+
+variable (I) in
+/-- **The velocity lift** of a curve to the tangent bundle: the curve `t ↦ (γ t, γ' t)`, with the
+velocity taken within the parameter set `s`.  It inherits the junk values of
+`TauCeti.Manifold.curveVelocityWithin` where `γ` is not differentiable within `s`. -/
+def curveVelocityLiftWithin (γ : ℝ → M) (s : Set ℝ) (t : ℝ) : TangentBundle I M :=
+  TotalSpace.mk' E (γ t) (curveVelocityWithin I γ s t)
+
+variable (I) in
+/-- The velocity lift of a curve, with unrestricted velocity.  This is the `s = Set.univ` case of
+`TauCeti.Manifold.curveVelocityLiftWithin`. -/
+def curveVelocityLift (γ : ℝ → M) : ℝ → TangentBundle I M :=
+  curveVelocityLiftWithin I γ univ
+
+/-- The defining formula for the velocity lift. -/
+theorem curveVelocityLiftWithin_apply (γ : ℝ → M) (s : Set ℝ) (t : ℝ) :
+    curveVelocityLiftWithin I γ s t =
+      TotalSpace.mk' E (γ t) (curveVelocityWithin I γ s t) := (rfl)
+
+/-- The unrestricted velocity lift is the lift taken within the whole parameter space. -/
+@[simp]
+theorem curveVelocityLift_eq_curveVelocityLiftWithin_univ (γ : ℝ → M) :
+    curveVelocityLift I γ = curveVelocityLiftWithin I γ univ := (rfl)
+
+/-- The velocity lift lies over the curve. -/
+@[simp]
+theorem curveVelocityLiftWithin_proj (γ : ℝ → M) (s : Set ℝ) (t : ℝ) :
+    (curveVelocityLiftWithin I γ s t).proj = γ t := (rfl)
+
+/-- The fibre component of the velocity lift is the velocity of the curve. -/
+@[simp]
+theorem curveVelocityLiftWithin_snd (γ : ℝ → M) (s : Set ℝ) (t : ℝ) :
+    (curveVelocityLiftWithin I γ s t).2 = curveVelocityWithin I γ s t := (rfl)
+
+/-! ### The spray -/
+
+variable [FiniteDimensional ℝ E] [IsManifold I 2 M]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
+
+variable (I M) in
+/-- **The geodesic spray** of the ambient Riemannian bundle instance: the vector field
+`(x, v) ↦ (v, -Γ_x (v, v))` on the tangent bundle, where `Γ` is the model-space Christoffel map of
+the Levi-Civita connection in the tangent-bundle trivialization at `x`.  Both components are read
+in the tangent-bundle chart centred at the argument, in which the base direction is read in the
+extended chart of `M` at `x` and the fibre direction in the trivialization at `x`. -/
+def geodesicSpray (z : TangentBundle I M) : TangentSpace I.tangent z :=
+  (z.2, -christoffelMap (finBasis ℝ E)
+    ((leviCivita I M).isCovariantDerivativeOn
+      (s := (trivializationAt E (TangentSpace I) z.proj).baseSet)) z.proj z.2 z.2)
+
+/-- **The chart formula for the geodesic spray**, restating the definition, whose body is not
+exposed across the module boundary. -/
+theorem geodesicSpray_apply (z : TangentBundle I M) :
+    geodesicSpray I M z =
+      (z.2, -christoffelMap (finBasis ℝ E)
+        ((leviCivita I M).isCovariantDerivativeOn
+          (s := (trivializationAt E (TangentSpace I) z.proj).baseSet)) z.proj z.2 z.2) :=
+  (rfl)
+
+/-- **The geodesic equation as an integral-curve equation.**  The velocity lift of a `C²` curve
+solves the equation of the geodesic spray at a parameter of its set exactly when the derivative of
+its velocity along it vanishes there. -/
+theorem hasMFDerivWithinAt_curveVelocityLiftWithin_iff
+    (hs : UniqueDiffOn ℝ s) (hγ : ContMDiffOn 𝓘(ℝ, ℝ) I 2 γ s) (ht : t ∈ s) :
+    HasMFDerivWithinAt 𝓘(ℝ, ℝ) I.tangent (curveVelocityLiftWithin I γ s) s t
+        ((1 : ℝ →L[ℝ] ℝ).smulRight (geodesicSpray I M (curveVelocityLiftWithin I γ s t))) ↔
+      alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s t = 0 := by
+  have hxbase : γ t ∈ (trivializationAt E (TangentSpace I) (γ t)).baseSet :=
+    FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t)
+  have hγd : MDifferentiableOn 𝓘(ℝ, ℝ) I γ s := hγ.mdifferentiableOn (by norm_num)
+  have hw : derivWithin (extChartAt I (γ t) ∘ γ) s t = curveVelocityWithin I γ s t :=
+    derivWithin_extChartAt_comp_curve (hγd t ht) (hs t ht)
+  -- the fibre reading of the velocity lift is the coordinate velocity of the curve
+  have hcoord : (fun r ↦ (trivializationAt E (TangentSpace I) (γ t)
+      (curveVelocityLiftWithin I γ s r)).2) =ᶠ[𝓝[s] t]
+      sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ t) := by
+    have hbase : ∀ᶠ r in 𝓝[s] t, γ r ∈ (trivializationAt E (TangentSpace I) (γ t)).baseSet :=
+      (hγd t ht).continuousWithinAt.preimage_mem_nhdsWithin
+        ((trivializationAt E (TangentSpace I) (γ t)).open_baseSet.mem_nhds hxbase)
+    filter_upwards [hbase] with r hr
+    rw [sectionCoord_apply]
+    exact (Trivialization.continuousLinearMapAt_apply_of_mem (R := ℝ) _ hr _).symm
+  have hsec : (fun r ↦ (trivializationAt E (TangentSpace I) (γ t)
+      (curveVelocityLiftWithin I γ s r)).2) =ᶠ[𝓝[s] t]
+      derivWithin (extChartAt I (γ t) ∘ γ) s :=
+    hcoord.trans (sectionCoord_curveVelocityWithin_eventuallyEq γ hs hγd ht hxbase)
+  have hdiff : DifferentiableWithinAt ℝ (derivWithin (extChartAt I (γ t) ∘ γ) s) s t :=
+    ((sectionCoord_curveVelocityWithin_eventuallyEq γ hs hγd ht
+      hxbase).differentiableWithinAt_iff_of_mem ht).1
+      (differentiableWithinAt_sectionCoord_curveVelocityWithin γ hs hγ ht hxbase)
+  have hcont : ContinuousWithinAt (curveVelocityLiftWithin I γ s) s t := by
+    rw [FiberBundle.continuousWithinAt_totalSpace E (curveVelocityLiftWithin I γ s)]
+    exact ⟨(hγd t ht).continuousWithinAt,
+      ((hcoord.differentiableWithinAt_iff_of_mem ht).2
+        (differentiableWithinAt_sectionCoord_curveVelocityWithin γ hs hγ ht
+          hxbase)).continuousWithinAt⟩
+  -- the Christoffel term of the spray, read through the two presentations of the velocity
+  have hchris : christoffelMap (finBasis ℝ E)
+        ((leviCivita I M).isCovariantDerivativeOn
+          (s := (trivializationAt E (TangentSpace I) (γ t)).baseSet)) (γ t)
+        (derivWithin (extChartAt I (γ t) ∘ γ) s t)
+        (derivWithin (extChartAt I (γ t) ∘ γ) s t) =
+      christoffelMap (finBasis ℝ E)
+        ((leviCivita I M).isCovariantDerivativeOn
+          (s := (trivializationAt E (TangentSpace I) (γ t)).baseSet)) (γ t)
+        (curveVelocityWithin I γ s t) (curveVelocityWithin I γ s t) :=
+    congrArg (fun v : E ↦ christoffelMap (finBasis ℝ E)
+      ((leviCivita I M).isCovariantDerivativeOn
+        (s := (trivializationAt E (TangentSpace I) (γ t)).baseSet)) (γ t) v v) hw
+  rw [alongCurveWithin_curveVelocityWithin_eq_zero_iff (leviCivita I M) γ hs hγd ht]
+  refine Iff.trans (hasMFDerivWithinAt_totalSpace_curve_iff_of_continuousWithinAt
+    (F := E) (V := fun x : M ↦ TangentSpace I x) (IB := I)
+    (z := curveVelocityLiftWithin I γ s)
+    (a := curveVelocityWithin I γ s t)
+    (b := -christoffelMap (finBasis ℝ E)
+      ((leviCivita I M).isCovariantDerivativeOn
+        (s := (trivializationAt E (TangentSpace I) (γ t)).baseSet)) (γ t)
+      (curveVelocityWithin I γ s t) (curveVelocityWithin I γ s t)) hcont) ?_
+  refine Iff.trans (and_iff_right (hasDerivWithinAt_extChartAt_comp_curve
+    (hasMFDerivWithinAt_curveVelocityWithin (hγd t ht)))) ?_
+  refine Iff.trans (hsec.hasDerivWithinAt_iff_of_mem ht) ?_
+  constructor
+  · intro h
+    rw [h.derivWithin (hs t ht), hchris, neg_add_cancel]
+  · intro h
+    have h1 : derivWithin (derivWithin (extChartAt I (γ t) ∘ γ) s) s t =
+        -christoffelMap (finBasis ℝ E)
+          ((leviCivita I M).isCovariantDerivativeOn
+            (s := (trivializationAt E (TangentSpace I) (γ t)).baseSet)) (γ t)
+          (curveVelocityWithin I γ s t) (curveVelocityWithin I γ s t) := by
+      rw [← hchris]
+      exact eq_neg_of_add_eq_zero_left h
+    rw [← h1]
+    exact hdiff.hasDerivWithinAt
+
+/-- **Geodesics are the base curves of the spray.**  The velocity lift of a `C²` curve is an
+integral curve of the geodesic spray on a parameter set with unique derivatives exactly when the
+curve is a geodesic there. -/
+theorem isMIntegralCurveOn_curveVelocityLiftWithin_iff
+    (hs : UniqueDiffOn ℝ s) (hγ : ContMDiffOn 𝓘(ℝ, ℝ) I 2 γ s) :
+    IsMIntegralCurveOn (curveVelocityLiftWithin I γ s) (geodesicSpray I M) s ↔
+      IsGeodesicCurveOn I γ s := by
+  refine ⟨fun h ↦ ⟨hs, hγ, fun r hr ↦
+      (hasMFDerivWithinAt_curveVelocityLiftWithin_iff hs hγ hr).1 (h r hr)⟩, fun h r hr ↦ ?_⟩
+  exact (hasMFDerivWithinAt_curveVelocityLiftWithin_iff hs hγ hr).2
+    (h.alongCurveWithin_curveVelocityWithin_eq_zero r hr)
+
+/-- A point at rest stays at rest: the velocity lift of a constant curve is an integral curve of
+the geodesic spray. -/
+theorem isMIntegralCurveOn_curveVelocityLiftWithin_const (hs : UniqueDiffOn ℝ s) (x : M) :
+    IsMIntegralCurveOn (curveVelocityLiftWithin I (fun _ : ℝ ↦ x) s) (geodesicSpray I M) s :=
+  (isMIntegralCurveOn_curveVelocityLiftWithin_iff hs contMDiffOn_const).2
+    (isGeodesicCurveOn_const hs x)
+
+/-- Being an integral curve of the geodesic spray on a parameter set only depends on the curve
+along that set. -/
+theorem isMIntegralCurveOn_geodesicSpray_congr {z z' : ℝ → TangentBundle I M}
+    (h : IsMIntegralCurveOn z (geodesicSpray I M) s) (heq : EqOn z' z s) :
+    IsMIntegralCurveOn z' (geodesicSpray I M) s := by
+  intro r hr
+  refine ((h r hr).congr_of_eventuallyEq
+    (Filter.eventuallyEq_of_mem self_mem_nhdsWithin heq) (heq hr)).congr_mfderiv ?_
+  exact congrArg (fun w : E × E ↦ (1 : ℝ →L[ℝ] ℝ).smulRight w)
+    (congrArg (fun w ↦ (geodesicSpray I M w : E × E)) (heq hr).symm)
+
+/-- **An integral curve of the spray is a velocity lift.**  On a parameter set with unique
+derivatives, an integral curve of the geodesic spray is the velocity lift of the curve it lies
+over. -/
+theorem eq_curveVelocityLiftWithin_of_isMIntegralCurveOn {z : ℝ → TangentBundle I M}
+    (hs : UniqueDiffOn ℝ s) (h : IsMIntegralCurveOn z (geodesicSpray I M) s) (ht : t ∈ s) :
+    z t = curveVelocityLiftWithin I (fun r ↦ (z r).proj) s t := by
+  have hproj : MDifferentiableWithinAt 𝓘(ℝ, ℝ) I (fun r ↦ (z r).proj) s t :=
+    (Bundle.mdifferentiableAt_proj (fun x : M ↦ TangentSpace I x)).comp_mdifferentiableWithinAt t
+      (h t ht).mdifferentiableWithinAt
+  have hd := (hasMFDerivWithinAt_totalSpace_curve_iff_of_continuousWithinAt
+    (F := E) (V := fun x : M ↦ TangentSpace I x) (IB := I) (z := z)
+    (a := (z t).2)
+    (b := -christoffelMap (finBasis ℝ E)
+      ((leviCivita I M).isCovariantDerivativeOn
+        (s := (trivializationAt E (TangentSpace I) (z t).proj).baseSet)) (z t).proj
+      (z t).2 (z t).2) (h t ht).continuousWithinAt).1 (h t ht)
+  have hvel : curveVelocityWithin I (fun r ↦ (z r).proj) s t = (z t).2 :=
+    (derivWithin_extChartAt_comp_curve hproj (hs t ht)).symm.trans (hd.1.derivWithin (hs t ht))
+  rw [curveVelocityLiftWithin_apply, hvel]
+
+/-- **The base curve of an integral curve of the spray is a geodesic**, as soon as it is `C²` on a
+parameter set with unique derivatives. -/
+theorem isGeodesicCurveOn_proj_of_isMIntegralCurveOn {z : ℝ → TangentBundle I M}
+    (hs : UniqueDiffOn ℝ s) (h : IsMIntegralCurveOn z (geodesicSpray I M) s)
+    (hz : ContMDiffOn 𝓘(ℝ, ℝ) I 2 (fun r ↦ (z r).proj) s) :
+    IsGeodesicCurveOn I (fun r ↦ (z r).proj) s :=
+  (isMIntegralCurveOn_curveVelocityLiftWithin_iff hs hz).1
+    (isMIntegralCurveOn_geodesicSpray_congr h fun _r hr ↦
+      (eq_curveVelocityLiftWithin_of_isMIntegralCurveOn hs h hr).symm)
+
+/-! ### All-time geodesics and the spray -/
+
+/-- The all-time case of `TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_iff`: the
+velocity lift of a `C²` curve is an integral curve of the geodesic spray exactly when the curve is
+an all-time geodesic. -/
+theorem isMIntegralCurve_curveVelocityLift_iff (hγ : ContMDiff 𝓘(ℝ, ℝ) I 2 γ) :
+    IsMIntegralCurve (curveVelocityLift I γ) (geodesicSpray I M) ↔ IsGeodesicCurve I γ := by
+  rw [isMIntegralCurve_iff_isMIntegralCurveOn, ← isGeodesicCurveOn_univ]
+  exact isMIntegralCurveOn_curveVelocityLiftWithin_iff uniqueDiffOn_univ
+    (contMDiffOn_univ.2 hγ)
+
+end TauCeti.Manifold
+
+end

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -95,6 +95,9 @@ variable [FiniteDimensional ℝ E] [IsManifold I 2 M]
   [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
   [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
 
+-- The geodesic-spray construction below, and the identification of its integral curves with the
+-- velocity lifts of geodesics, follow the geodesic-spray development of the Tau Ceti Hopf--Rinow
+-- roadmap, https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md
 variable (I M) in
 /-- **The geodesic spray** of the ambient Riemannian bundle instance: the vector field
 `(x, v) ↦ (v, -Γ_x (v, v))` on the tangent bundle, where `Γ` is the model-space Christoffel map of

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Geometry.Manifold.Riemannian.Geodesic.Basic
 public import TauCeti.Geometry.Manifold.VectorBundle.CurveInTotalSpace
 public import Mathlib.Geometry.Manifold.IntegralCurve.Basic
+import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.CoordinateChange
 
 /-!
 # The geodesic spray
@@ -28,8 +29,11 @@ which `v` is its own coordinate.  So the displayed formula *is* the definition o
 `TauCeti.Manifold.geodesicSpray`, with `Γ` the model-space Christoffel map
 `TauCeti.Manifold.christoffelMap` of the Levi-Civita connection in the trivialization at the base
 point of the argument — the same moving-chart convention as
-`CovariantDerivative.alongCurveWithin` and `TauCeti.Manifold.IsGeodesicCurveOn`.  What has to be
-proved is that this formula solves the intended problem, and that is the content of
+`CovariantDerivative.alongCurveWithin` and `TauCeti.Manifold.IsGeodesicCurveOn`.  Its compatibility
+on overlapping tangent-bundle charts is `TauCeti.Manifold.tangentCoordChange_geodesicSpray`; the
+derivative term in the tangent lift cancels the inhomogeneous term in
+`TauCeti.Manifold.christoffelMap_coordChange`.  That this formula solves the intended problem is
+the content of
 `TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_iff` and
 `TauCeti.Manifold.eq_curveVelocityLiftWithin_of_isMIntegralCurveOn`: on a parameter set with
 unique derivatives, the integral curves of `S` are exactly the velocity lifts
@@ -49,8 +53,9 @@ The unpacking of a curve into `TM` into its base curve and its fibre coordinate 
 
 * `TauCeti.Manifold.geodesicSpray`: **the geodesic spray** of the ambient Riemannian bundle
   instance, a vector field on the tangent bundle, with `TauCeti.Manifold.geodesicSpray_apply` its
-  chart formula and `TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_const` the
-  constant-curve check.
+  preferred-chart formula, `TauCeti.Manifold.tangentCoordChange_geodesicSpray` its formula in every
+  overlapping tangent-bundle chart, and
+  `TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_const` the constant-curve check.
 * `TauCeti.Manifold.curveVelocityLiftWithin` and `TauCeti.Manifold.curveVelocityLift`: the
   velocity lift of a curve to the tangent bundle, within a parameter set and unrestricted.
 * `TauCeti.Manifold.hasMFDerivWithinAt_curveVelocityLiftWithin_iff`: at one parameter, the
@@ -148,6 +153,205 @@ theorem geodesicSpray_apply (z : TangentBundle I M) :
         ((leviCivita I M).isCovariantDerivativeOn
           (s := (trivializationAt E (TangentSpace I) z.proj).baseSet)) z.proj z.2 z.2) :=
   (rfl)
+
+/- **Chart independence of the spray formula.**  On the overlap of the preferred charts at `x`
+and `x₀`, the tangent lift of the coordinate change sends the second-order vector
+`(u, -Γˣ(u, u))` to `(A u, -Γˣ⁰(A u, A u))`.  Its vertical component is the derivative of
+`y ↦ A_y u` in the base direction `u`, plus `A` applied to the old vertical component. -/
+private theorem geodesicSpray_coordChange {x x₀ : M}
+    (hx₀ : x ∈ (extChartAt I x₀).source) (u : TangentSpace I x) :
+    let A := tangentCoordChange I x x₀ x
+    let Γ := christoffelMap (finBasis ℝ E)
+      ((leviCivita I M).isCovariantDerivativeOn
+        (s := (trivializationAt E (TangentSpace I) x).baseSet)) x
+    let Γ₀ := christoffelMap (finBasis ℝ E)
+      ((leviCivita I M).isCovariantDerivativeOn
+        (s := (trivializationAt E (TangentSpace I) x₀).baseSet)) x
+    (A u, mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x u - A (Γ u u)) =
+      (A u, -Γ₀ (A u) (A u)) := by
+  dsimp only
+  have h := christoffelMap_coordChange (finBasis ℝ E) hx₀ u u
+    ((leviCivita I M).isCovariantDerivativeOn
+      (s := (trivializationAt E (TangentSpace I) x₀).baseSet))
+    ((leviCivita I M).isCovariantDerivativeOn
+      (s := (trivializationAt E (TangentSpace I) x).baseSet))
+  rw [h]
+  simp only [neg_sub]
+
+omit [FiniteDimensional ℝ E] [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+    [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+set_option backward.isDefEq.respectTransparency false in
+private theorem tangentCoordChange_tangent_apply {x x₀ : M}
+    (hx₀ : x ∈ (extChartAt I x₀).source) (u w : TangentSpace I x) :
+    tangentCoordChange I.tangent
+        (TotalSpace.mk' E x u) (TotalSpace.mk' E x₀ 0) (TotalSpace.mk' E x u) (u, w) =
+      (tangentCoordChange I x x₀ x u,
+        mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x u +
+          tangentCoordChange I x x₀ x w) := by
+  change E at u w
+  let z : TangentBundle I M := TotalSpace.mk' E x u
+  let q : TangentBundle I M := TotalSpace.mk' E x₀ 0
+  let p := extChartAt I.tangent z z
+  let G := (extChartAt I.tangent q : TangentBundle I M → E × E) ∘
+    (extChartAt I.tangent z).symm
+  let T : E × E → E × E := fun a ↦
+    let y := (extChartAt I x).symm a.1
+    (extChartAt I x₀ y, tangentCoordChange I x x₀ y a.2)
+  have hz : z ∈ (chartAt (ModelProd H E) z).source := mem_chart_source _ _
+  have hzq : z ∈ (chartAt (ModelProd H E) q).source := by
+    rw [TangentBundle.mem_chart_source_iff (I := I) (M := M)]
+    rw [← extChartAt_source I x₀]
+    exact hx₀
+  have hN := (I.tangent.extendCoordChange_source_mem_nhdsWithin'
+    (e := chartAt (ModelProd H E) z) (e' := chartAt (ModelProd H E) q) hz hzq)
+  have hGT : G =ᶠ[𝓝[range I.tangent] p] T := by
+    filter_upwards [hN] with a ha
+    change a ∈ ((extChartAt I.tangent z).symm ≫ extChartAt I.tangent q).source at ha
+    let b := (extChartAt I.tangent z).symm a
+    have ha_target : a ∈ (extChartAt I.tangent z).target := ha.1
+    have hbzT : b ∈ (extChartAt I.tangent z).source :=
+      (extChartAt I.tangent z).map_target ha_target
+    have hbqT : b ∈ (extChartAt I.tangent q).source := ha.2
+    have hbz : b.proj ∈ (extChartAt I x).source := by
+      rw [extChartAt_source] at hbzT ⊢
+      exact (TangentBundle.mem_chart_source_iff b z).1 hbzT
+    have hbq : b.proj ∈ (extChartAt I x₀).source := by
+      rw [extChartAt_source] at hbqT ⊢
+      exact (TangentBundle.mem_chart_source_iff b q).1 hbqT
+    have hright : extChartAt I.tangent z b = a :=
+      (extChartAt I.tangent z).right_inv ha_target
+    have hbase : extChartAt I x b.proj = a.1 := by
+      have h := congrArg Prod.fst hright
+      change extChartAt I x b.proj = a.1 at h
+      exact h
+    have hfiber : tangentCoordChange I b.proj x b.proj b.2 = a.2 := by
+      have h := congrArg Prod.snd hright
+      change tangentCoordChange I b.proj x b.proj b.2 = a.2 at h
+      exact h
+    have hy : (extChartAt I x).symm a.1 = b.proj := by
+      rw [← hbase]
+      exact (extChartAt I x).left_inv hbz
+    have hsecond : (extChartAt I.tangent q b).2 =
+        tangentCoordChange I x x₀ b.proj a.2 := by
+      rw [← hfiber]
+      have hcomp := tangentCoordChange_comp (I := I) (w := b.proj) (x := x)
+        (y := x₀) (z := b.proj) (v := b.2)
+        ⟨⟨mem_extChartAt_source b.proj, hbz⟩, hbq⟩
+      change tangentCoordChange I b.proj x₀ b.proj b.2 = _
+      exact hcomp.symm
+    change extChartAt I.tangent q b = T a
+    apply Prod.ext
+    · change extChartAt I x₀ b.proj = extChartAt I x₀ ((extChartAt I x).symm a.1)
+      rw [hy]
+    · change (extChartAt I.tangent q b).2 =
+        tangentCoordChange I x x₀ ((extChartAt I x).symm a.1) a.2
+      simpa only [hy] using hsecond
+  rw [tangentCoordChange_def]
+  change fderivWithin ℝ G (range I.tangent) p (u, w) = _
+  have hp_mem : p ∈ range I.tangent :=
+    (extChartAt_target_subset_range z) ((extChartAt I.tangent z).map_source
+      (mem_extChartAt_source z))
+  have hp_eq : G p = T p := hGT.self_of_nhdsWithin hp_mem
+  rw [hGT.fderivWithin_eq hp_eq]
+  have hpcoord : p = (extChartAt I x x, u) := by
+    apply Prod.ext
+    · change extChartAt I x x = (extChartAt I x x, u).1
+      rfl
+    · change tangentCoordChange I x x x u = u
+      exact tangentCoordChange_self (mem_extChartAt_source x)
+  rw [hpcoord, ModelWithCorners.range_prod]
+  rw [ModelWithCorners.range_eq_univ 𝓘(ℝ, E)]
+  let a₀ := extChartAt I x x
+  let F : E → E := fun a ↦ extChartAt I x₀ ((extChartAt I x).symm a)
+  let C : E → E →L[ℝ] E := fun a ↦ tangentCoordChange I x x₀ ((extChartAt I x).symm a)
+  have ha₀ : a₀ ∈ ((extChartAt I x).symm ≫ extChartAt I x₀).source := by
+    rw [PartialEquiv.trans_source]
+    exact ⟨(extChartAt I x).map_source (mem_extChartAt_source x), by
+      change (extChartAt I x).symm a₀ ∈ (extChartAt I x₀).source
+      simpa only [a₀, extChartAt_to_inv] using hx₀⟩
+  have hF : DifferentiableWithinAt ℝ F (range I) a₀ :=
+    (contDiffWithinAt_ext_coord_change x₀ x ha₀).differentiableWithinAt
+      (by norm_num : (2 : WithTop ℕ∞) ≠ 0)
+  have hI₂ : IsManifold I (1 + 1) M := inferInstanceAs (IsManifold I 2 M)
+  have hCMD : MDifferentiableAt I 𝓘(ℝ, E →L[ℝ] E)
+      (tangentCoordChange I x x₀) x :=
+    (contMDiffAt_tangentCoordChange (n := 1) hx₀).mdifferentiableAt one_ne_zero
+  have hC : DifferentiableWithinAt ℝ C (range I) a₀ := by
+    have h := (mdifferentiableAt_iff (tangentCoordChange I x x₀) x).1 hCMD |>.2
+    simp only [writtenInExtChartAt, extChartAt_model_space_eq_id,
+      PartialEquiv.refl_coe] at h
+    change DifferentiableWithinAt ℝ C (range I) a₀ at h
+    exact h
+  have hmaps : MapsTo (Prod.fst : E × E → E) (range I ×ˢ univ) (range I) :=
+    fun _ h ↦ h.1
+  have huniqBase : UniqueDiffWithinAt ℝ (range I) a₀ := I.uniqueDiffWithinAt_image
+  have huniq : UniqueDiffWithinAt ℝ (range I ×ˢ univ) (a₀, u) :=
+    huniqBase.prod uniqueDiffWithinAt_univ
+  have hFp : DifferentiableWithinAt ℝ (fun a : E × E ↦ F a.1)
+      (range I ×ˢ univ) (a₀, u) := by
+    change DifferentiableWithinAt ℝ (F ∘ Prod.fst) (range I ×ˢ univ) (a₀, u)
+    exact hF.comp (a₀, u) differentiableWithinAt_fst hmaps
+  have hCp : DifferentiableWithinAt ℝ (fun a : E × E ↦ C a.1)
+      (range I ×ˢ univ) (a₀, u) := by
+    change DifferentiableWithinAt ℝ (C ∘ Prod.fst) (range I ×ˢ univ) (a₀, u)
+    exact hC.comp (a₀, u) differentiableWithinAt_fst hmaps
+  have hAp : DifferentiableWithinAt ℝ (fun a : E × E ↦ C a.1 a.2)
+      (range I ×ˢ univ) (a₀, u) :=
+    hCp.clm_apply differentiableWithinAt_snd
+  change (fderivWithin ℝ (fun a : E × E ↦ (F a.1, C a.1 a.2))
+    (range I ×ˢ univ) (a₀, u)) (u, w) = _
+  have hFp_eq := fderivWithin_comp (a₀, u) hF differentiableWithinAt_fst hmaps huniq
+  change fderivWithin ℝ (fun a : E × E ↦ F a.1) (range I ×ˢ univ) (a₀, u) = _ at hFp_eq
+  have hCp_eq := fderivWithin_comp (a₀, u) hC differentiableWithinAt_fst hmaps huniq
+  change fderivWithin ℝ (fun a : E × E ↦ C a.1) (range I ×ˢ univ) (a₀, u) = _ at hCp_eq
+  have hAp_eq := fderivWithin_clm_apply huniq hCp differentiableWithinAt_snd
+  change fderivWithin ℝ (fun a : E × E ↦ C a.1 a.2) (range I ×ˢ univ) (a₀, u) = _ at hAp_eq
+  have hfst_app : (fderivWithin ℝ (Prod.fst : E × E → E) (range I ×ˢ univ) (a₀, u))
+      (u, w) = u := by
+    rw [fderivWithin_fst huniq]
+    rfl
+  have hsnd_app : (fderivWithin ℝ (Prod.snd : E × E → E) (range I ×ˢ univ) (a₀, u))
+      (u, w) = w := by
+    rw [fderivWithin_snd huniq]
+    rfl
+  rw [hFp.fderivWithin_prodMk hAp huniq, ContinuousLinearMap.prod_apply, hFp_eq,
+    hAp_eq, hCp_eq]
+  simp only [ContinuousLinearMap.comp_apply, add_apply,
+    ContinuousLinearMap.flip_apply, C, F, a₀, extChartAt_to_inv]
+  rw [hfst_app, hsnd_app, add_comm]
+  have hFderiv : fderivWithin ℝ F (range I) a₀ = tangentCoordChange I x x₀ x := by
+    rw [tangentCoordChange_def]
+    rfl
+  rw [hFderiv]
+  have hMDu : MDifferentiableAt I 𝓘(ℝ, E)
+      (fun y ↦ tangentCoordChange I x x₀ y u) x :=
+    hCMD.clm_apply mdifferentiableAt_const
+  have hCuDeriv := fderivWithin_clm_apply huniqBase hC
+    (differentiableWithinAt_const (c := u))
+  have hCuDerivApp := congrArg (fun L : E →L[ℝ] E ↦ L u) hCuDeriv
+  have hMv : mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x u =
+      fderivWithin ℝ C (range I) a₀ u u := by
+    rw [mvfderiv, ContinuousLinearMap.comp_apply, mfderiv, ite_eq_left hMDu]
+    change fderivWithin ℝ (fun a ↦ C a u) (range I) a₀ u = _
+    simpa [fderivWithin_const_apply] using hCuDerivApp
+  rw [hMv]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- **The geodesic spray has the same formula in every overlapping tangent-bundle chart.**
+Transporting the value defined in the preferred chart at `(x, u)` to the chart based at `x₀`
+sends `(v, -Γ(v, v))` to `(v₀, -Γ₀(v₀, v₀))`, where `v₀` is the fibre coordinate in the latter
+chart. -/
+theorem tangentCoordChange_geodesicSpray {x x₀ : M}
+    (hx₀ : x ∈ (extChartAt I x₀).source) (u : TangentSpace I x) :
+    tangentCoordChange I.tangent (TotalSpace.mk' E x u) (TotalSpace.mk' E x₀ 0)
+        (TotalSpace.mk' E x u) (geodesicSpray I M (TotalSpace.mk' E x u)) =
+      let v := tangentCoordChange I x x₀ x u
+      (v, -christoffelMap (finBasis ℝ E)
+        ((leviCivita I M).isCovariantDerivativeOn
+          (s := (trivializationAt E (TangentSpace I) x₀).baseSet)) x v v) := by
+  rw [geodesicSpray_apply, tangentCoordChange_tangent_apply hx₀]
+  have hchange := geodesicSpray_coordChange (I := I) (M := M) hx₀ u
+  simpa only [map_neg, ← sub_eq_add_neg] using hchange
 
 /-- **The geodesic equation as an integral-curve equation.**  The velocity lift of a `C²` curve
 solves the equation of the geodesic spray at a parameter of its set exactly when the derivative of

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -54,9 +54,8 @@ The unpacking of a curve into `TM` into its base curve and its fibre coordinate 
 
 * `TauCeti.Manifold.geodesicSpray`: **the geodesic spray** of the ambient Riemannian bundle
   instance, a vector field on the tangent bundle, with `TauCeti.Manifold.geodesicSpray_apply` its
-  preferred-chart formula, `TauCeti.Manifold.tangentCoordChange_geodesicSpray` its formula in every
-  overlapping tangent-bundle chart, and
-  `TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_const` the constant-curve check.
+  preferred-chart formula and `TauCeti.Manifold.tangentCoordChange_geodesicSpray` its formula in
+  every overlapping tangent-bundle chart.
 * `TauCeti.Manifold.hasMFDerivWithinAt_curveVelocityLiftWithin_iff`: at one parameter, the
   velocity lift of a `C²` curve solves the spray equation exactly when the covariant derivative of
   the velocity along the curve vanishes.
@@ -264,13 +263,6 @@ theorem isMIntegralCurveOn_curveVelocityLiftWithin_iff
       (hasMFDerivWithinAt_curveVelocityLiftWithin_iff hs hγ hr).1 (h r hr)⟩, fun h r hr ↦ ?_⟩
   exact (hasMFDerivWithinAt_curveVelocityLiftWithin_iff hs hγ hr).2
     (h.alongCurveWithin_curveVelocityWithin_eq_zero r hr)
-
-/-- A point at rest stays at rest: the velocity lift of a constant curve is an integral curve of
-the geodesic spray. -/
-theorem isMIntegralCurveOn_curveVelocityLiftWithin_const (hs : UniqueDiffOn ℝ s) (x : M) :
-    IsMIntegralCurveOn (curveVelocityLiftWithin I (fun _ : ℝ ↦ x) s) (geodesicSpray I M) s :=
-  (isMIntegralCurveOn_curveVelocityLiftWithin_iff hs contMDiffOn_const).2
-    (isGeodesicCurveOn_const hs x)
 
 /-- **An integral curve of the spray is a velocity lift.**  On a parameter set with unique
 derivatives, an integral curve of the geodesic spray is the velocity lift of the curve it lies

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Geometry.Manifold.Riemannian.Geodesic.Basic
+public import TauCeti.Geometry.Manifold.IntegralCurve.Basic
 public import TauCeti.Geometry.Manifold.VectorBundle.CurveInTotalSpace
-public import Mathlib.Geometry.Manifold.IntegralCurve.Basic
 import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.CoordinateChange
 
 /-!
@@ -461,17 +461,6 @@ theorem isMIntegralCurveOn_curveVelocityLiftWithin_const (hs : UniqueDiffOn ℝ 
   (isMIntegralCurveOn_curveVelocityLiftWithin_iff hs contMDiffOn_const).2
     (isGeodesicCurveOn_const hs x)
 
-/-- Being an integral curve of the geodesic spray on a parameter set only depends on the curve
-along that set. -/
-theorem isMIntegralCurveOn_geodesicSpray_congr {z z' : ℝ → TangentBundle I M}
-    (h : IsMIntegralCurveOn z (geodesicSpray I M) s) (heq : EqOn z' z s) :
-    IsMIntegralCurveOn z' (geodesicSpray I M) s := by
-  intro r hr
-  refine ((h r hr).congr_of_eventuallyEq
-    (Filter.eventuallyEq_of_mem self_mem_nhdsWithin heq) (heq hr)).congr_mfderiv ?_
-  exact congrArg (fun w : E × E ↦ (1 : ℝ →L[ℝ] ℝ).smulRight w)
-    (congrArg (fun w ↦ (geodesicSpray I M w : E × E)) (heq hr).symm)
-
 /-- **An integral curve of the spray is a velocity lift.**  On a parameter set with unique
 derivatives, an integral curve of the geodesic spray is the velocity lift of the curve it lies
 over. -/
@@ -499,7 +488,7 @@ theorem isGeodesicCurveOn_proj_of_isMIntegralCurveOn {z : ℝ → TangentBundle 
     (hz : ContMDiffOn 𝓘(ℝ, ℝ) I 2 (fun r ↦ (z r).proj) s) :
     IsGeodesicCurveOn I (fun r ↦ (z r).proj) s :=
   (isMIntegralCurveOn_curveVelocityLiftWithin_iff hs hz).1
-    (isMIntegralCurveOn_geodesicSpray_congr h fun _r hr ↦
+    (h.congr fun _r hr ↦
       (eq_curveVelocityLiftWithin_of_isMIntegralCurveOn hs h hr).symm)
 
 /-! ### All-time geodesics and the spray -/

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -302,7 +302,7 @@ an all-time geodesic. -/
 theorem isMIntegralCurve_curveVelocityLift_iff (hγ : ContMDiff 𝓘(ℝ, ℝ) I 2 γ) :
     IsMIntegralCurve (curveVelocityLift I γ) (geodesicSpray I M) ↔ IsGeodesicCurve I γ := by
   rw [isMIntegralCurve_iff_isMIntegralCurveOn, ← isGeodesicCurveOn_univ]
-  rw [curveVelocityLift_eq_curveVelocityLiftWithin_univ]
+  rw [← curveVelocityLiftWithin_univ]
   exact isMIntegralCurveOn_curveVelocityLiftWithin_iff uniqueDiffOn_univ
     (contMDiffOn_univ.2 hγ)
 

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean
@@ -180,16 +180,18 @@ private theorem geodesicSpray_coordChange {x x₀ : M}
 
 omit [FiniteDimensional ℝ E] [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
     [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
-set_option backward.isDefEq.respectTransparency false in
 private theorem tangentCoordChange_tangent_apply {x x₀ : M}
-    (hx₀ : x ∈ (extChartAt I x₀).source) (u w : TangentSpace I x) :
+    (hx₀ : x ∈ (extChartAt I x₀).source) (u w : E) :
     tangentCoordChange I.tangent
-        (TotalSpace.mk' E x u) (TotalSpace.mk' E x₀ 0) (TotalSpace.mk' E x u) (u, w) =
+        (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
+        (TotalSpace.mk' E x₀ 0)
+        (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u)) (u, w) =
       (tangentCoordChange I x x₀ x u,
-        mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x u +
+        mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x
+            ((tangentSpaceCastModel I x).symm u) +
           tangentCoordChange I x x₀ x w) := by
-  change E at u w
-  let z : TangentBundle I M := TotalSpace.mk' E x u
+  let z : TangentBundle I M :=
+    TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u)
   let q : TangentBundle I M := TotalSpace.mk' E x₀ 0
   let p := extChartAt I.tangent z z
   let G := (extChartAt I.tangent q : TangentBundle I M → E × E) ∘
@@ -329,14 +331,14 @@ private theorem tangentCoordChange_tangent_apply {x x₀ : M}
   have hCuDeriv := fderivWithin_clm_apply huniqBase hC
     (differentiableWithinAt_const (c := u))
   have hCuDerivApp := congrArg (fun L : E →L[ℝ] E ↦ L u) hCuDeriv
-  have hMv : mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x u =
+  have hMv : mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x
+      ((tangentSpaceCastModel I x).symm u) =
       fderivWithin ℝ C (range I) a₀ u u := by
-    rw [mvfderiv, ContinuousLinearMap.comp_apply, mfderiv, ite_eq_left hMDu]
+    rw [hMDu.mvfderiv]
     change fderivWithin ℝ (fun a ↦ C a u) (range I) a₀ u = _
     simpa [fderivWithin_const_apply] using hCuDerivApp
   rw [hMv]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- **The geodesic spray has the same formula in every overlapping tangent-bundle chart.**
 Transporting the value defined in the preferred chart at `(x, u)` to the chart based at `x₀`
 sends `(v, -Γ(v, v))` to `(v₀, -Γ₀(v₀, v₀))`, where `v₀` is the fibre coordinate in the latter
@@ -349,8 +351,19 @@ theorem tangentCoordChange_geodesicSpray {x x₀ : M}
       (v, -christoffelMap (finBasis ℝ E)
         ((leviCivita I M).isCovariantDerivativeOn
           (s := (trivializationAt E (TangentSpace I) x₀).baseSet)) x v v) := by
-  rw [geodesicSpray_apply, tangentCoordChange_tangent_apply hx₀]
-  have hchange := geodesicSpray_coordChange (I := I) (M := M) hx₀ u
+  change E at u
+  change tangentCoordChange I.tangent
+      (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
+      (TotalSpace.mk' E x₀ 0)
+      (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
+        (u, -christoffelMap (finBasis ℝ E)
+          ((leviCivita I M).isCovariantDerivativeOn
+            (s := (trivializationAt E (TangentSpace I) x).baseSet)) x u u) = _
+  rw [tangentCoordChange_tangent_apply hx₀]
+  have hchange := geodesicSpray_coordChange (I := I) (M := M) hx₀
+    ((tangentSpaceCastModel I x).symm u)
+  have hu : (tangentSpaceCastModel I x).symm u = (show TangentSpace I x from u) := rfl
+  rw [hu] at hchange ⊢
   simpa only [map_neg, ← sub_eq_add_neg] using hchange
 
 /-- **The geodesic equation as an integral-curve equation.**  The velocity lift of a `C²` curve

--- a/TauCeti/Geometry/Manifold/VectorBundle/CurveInTotalSpace.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CurveInTotalSpace.lean
@@ -60,8 +60,8 @@ theorem hasMFDerivWithinAt_totalSpace_curve_iff_of_continuousWithinAt
     HasMFDerivWithinAt 𝓘(𝕜, 𝕜) (IB.prod 𝓘(𝕜, F)) z s t ((1 : 𝕜 →L[𝕜] 𝕜).smulRight (a, b)) ↔
       HasDerivWithinAt (fun r ↦ extChartAt IB (z t).proj (z r).proj) a s t ∧
         HasDerivWithinAt (fun r ↦ (trivializationAt F V (z t).proj (z r)).2) b s t := by
-  set x₀ := (z t).proj with hx₀
-  set e := trivializationAt F V x₀ with he
+  set x₀ := (z t).proj
+  set e := trivializationAt F V x₀
   have hmem : ∀ᶠ r in 𝓝[s] t, (z r).proj ∈ e.baseSet :=
     hz.preimage_mem_nhdsWithin
       ((e.open_baseSet.preimage (FiberBundle.continuous_proj F V)).mem_nhds

--- a/TauCeti/Geometry/Manifold/VectorBundle/CurveInTotalSpace.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CurveInTotalSpace.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Geometry.Manifold.VectorBundle.MDifferentiable
+
+/-!
+# Differentiating a curve into the total space of a fibre bundle
+
+A curve `z` into the total space of a fibre bundle is read, near a parameter `t`, in the chart of
+the total space centred at `z t`.  By `FiberBundle.extChartAt` that chart is the trivialization at
+the base point `(z t).proj` followed by the base chart there, so the reading of `z` is the pair of
+its base curve read in the base chart and of its fibre coordinate read in that trivialization.
+This file turns that observation into a criterion: the curve has a manifold derivative within a
+parameter set exactly when it is continuous there and those two coordinate readings have
+derivatives.
+
+The criterion is the form in which a curve into a vector bundle is compared with a pair of
+ordinary derivatives, and in particular the form in which an integral curve of a vector field on
+a tangent bundle is unpacked into an equation on its base curve and one on its velocity.
+
+## Main results
+
+* `TauCeti.Manifold.hasMFDerivWithinAt_totalSpace_curve_iff`: the manifold derivative of a curve
+  into a total space, within a parameter set, read as the pair of the derivative of its base
+  curve in the base chart and of the derivative of its fibre coordinate in the trivialization,
+  both taken at the current point of the curve.
+* `TauCeti.Manifold.hasMFDerivAt_totalSpace_curve_iff`: its unrestricted case.
+
+## References
+
+* [Geodesics, the exponential map, and the Hopf--Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
+  Layer 1, "The geodesic spray".
+-/
+
+public section
+
+open Bundle Filter Set
+open scoped Manifold Topology
+
+noncomputable section
+
+namespace TauCeti.Manifold
+
+variable
+  {𝕜 B F : Type*} {V : B → Type*}
+  [NontriviallyNormedField 𝕜] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  [TopologicalSpace (TotalSpace F V)] [∀ x, TopologicalSpace (V x)]
+  {EB : Type*} [NormedAddCommGroup EB] [NormedSpace 𝕜 EB]
+  {HB : Type*} [TopologicalSpace HB] {IB : ModelWithCorners 𝕜 EB HB}
+  [TopologicalSpace B] [ChartedSpace HB B] [FiberBundle F V]
+  {z : 𝕜 → TotalSpace F V} {s : Set 𝕜} {t : 𝕜} {a : EB} {b : F}
+
+/-- A curve into the total space which is continuous within `s` at `t` has a manifold derivative
+there exactly when its base curve, read in the base chart at the current base point, and its fibre
+coordinate, read in the trivialization at that same point, have the corresponding derivatives.
+This is `TauCeti.Manifold.hasMFDerivWithinAt_totalSpace_curve_iff` with the continuity of the curve
+supplied as a hypothesis rather than as a conjunct. -/
+theorem hasMFDerivWithinAt_totalSpace_curve_iff_of_continuousWithinAt
+    (hz : ContinuousWithinAt z s t) :
+    HasMFDerivWithinAt 𝓘(𝕜, 𝕜) (IB.prod 𝓘(𝕜, F)) z s t ((1 : 𝕜 →L[𝕜] 𝕜).smulRight (a, b)) ↔
+      HasDerivWithinAt (fun r ↦ extChartAt IB (z t).proj (z r).proj) a s t ∧
+        HasDerivWithinAt (fun r ↦ (trivializationAt F V (z t).proj (z r)).2) b s t := by
+  set x₀ := (z t).proj with hx₀
+  set e := trivializationAt F V x₀ with he
+  have hmem : ∀ᶠ r in 𝓝[s] t, (z r).proj ∈ e.baseSet :=
+    hz.preimage_mem_nhdsWithin
+      ((e.open_baseSet.preimage (FiberBundle.continuous_proj F V)).mem_nhds
+        (FiberBundle.mem_baseSet_trivializationAt F V x₀))
+  have hfun : writtenInExtChartAt 𝓘(𝕜, 𝕜) (IB.prod 𝓘(𝕜, F)) t z =ᶠ[𝓝[s] t]
+      fun r ↦ (extChartAt IB x₀ (z r).proj, (e (z r)).2) := by
+    filter_upwards [hmem] with r hr
+    rw [writtenInExtChartAt, FiberBundle.extChartAt, extChartAt_model_space_eq_id]
+    simp only [PartialEquiv.refl_symm, PartialEquiv.refl_coe, Function.comp_apply, id_eq,
+      PartialEquiv.trans_apply, PartialEquiv.prod_coe, OpenPartialHomeomorph.coe_toPartialEquiv,
+      Trivialization.coe_coe]
+    rw [Trivialization.coe_fst _ (e.mem_source.2 hr)]
+  have hx : writtenInExtChartAt 𝓘(𝕜, 𝕜) (IB.prod 𝓘(𝕜, F)) t z t =
+      (extChartAt IB x₀ (z t).proj, (e (z t)).2) := by
+    rw [writtenInExtChartAt, FiberBundle.extChartAt, extChartAt_model_space_eq_id]
+    simp only [PartialEquiv.refl_symm, PartialEquiv.refl_coe, Function.comp_apply, id_eq,
+      PartialEquiv.trans_apply, PartialEquiv.prod_coe, OpenPartialHomeomorph.coe_toPartialEquiv,
+      Trivialization.coe_coe]
+    rw [Trivialization.coe_fst _
+      (e.mem_source.2 (FiberBundle.mem_baseSet_trivializationAt F V x₀))]
+  have key : HasMFDerivWithinAt 𝓘(𝕜, 𝕜) (IB.prod 𝓘(𝕜, F)) z s t
+        ((1 : 𝕜 →L[𝕜] 𝕜).smulRight (a, b)) ↔
+      HasDerivWithinAt (fun r ↦ (extChartAt IB x₀ (z r).proj, (e (z r)).2)) (a, b) s t := by
+    change (ContinuousWithinAt z s t ∧ _) ↔ _
+    rw [extChartAt_model_space_eq_id]
+    simp only [PartialEquiv.refl_symm, PartialEquiv.refl_coe, preimage_id_eq, id_eq,
+      ModelWithCorners.range_eq_univ, inter_univ, and_iff_right hz]
+    rw [hasDerivWithinAt_iff_hasFDerivWithinAt, ← hfun.hasFDerivWithinAt_iff hx]
+    rfl
+  rw [key]
+  refine ⟨fun h ↦ ?_, fun h ↦ h.1.prodMk h.2⟩
+  have h' := hasDerivWithinAt_iff_hasFDerivWithinAt.1 h
+  exact ⟨hasDerivWithinAt_iff_hasFDerivWithinAt.2
+      (h'.fst.congr_fderiv (ContinuousLinearMap.ext fun _ ↦ rfl)),
+    hasDerivWithinAt_iff_hasFDerivWithinAt.2
+      (h'.snd.congr_fderiv (ContinuousLinearMap.ext fun _ ↦ rfl))⟩
+
+/-- **The manifold derivative of a curve into a total space.**  A curve into the total space of a
+fibre bundle has the manifold derivative determined by `(a, b)` within the parameter set `s` at
+`t` exactly when it is continuous there, its base curve read in the base chart at the current base
+point has derivative `a`, and its fibre coordinate read in the trivialization at that point has
+derivative `b`. -/
+theorem hasMFDerivWithinAt_totalSpace_curve_iff :
+    HasMFDerivWithinAt 𝓘(𝕜, 𝕜) (IB.prod 𝓘(𝕜, F)) z s t ((1 : 𝕜 →L[𝕜] 𝕜).smulRight (a, b)) ↔
+      ContinuousWithinAt z s t ∧
+        HasDerivWithinAt (fun r ↦ extChartAt IB (z t).proj (z r).proj) a s t ∧
+          HasDerivWithinAt (fun r ↦ (trivializationAt F V (z t).proj (z r)).2) b s t := by
+  refine ⟨fun h ↦ ⟨h.1, (hasMFDerivWithinAt_totalSpace_curve_iff_of_continuousWithinAt h.1).1 h⟩,
+    fun h ↦ (hasMFDerivWithinAt_totalSpace_curve_iff_of_continuousWithinAt h.1).2 h.2⟩
+
+/-- The unrestricted case of `TauCeti.Manifold.hasMFDerivWithinAt_totalSpace_curve_iff`. -/
+theorem hasMFDerivAt_totalSpace_curve_iff :
+    HasMFDerivAt 𝓘(𝕜, 𝕜) (IB.prod 𝓘(𝕜, F)) z t ((1 : 𝕜 →L[𝕜] 𝕜).smulRight (a, b)) ↔
+      ContinuousAt z t ∧
+        HasDerivAt (fun r ↦ extChartAt IB (z t).proj (z r).proj) a t ∧
+          HasDerivAt (fun r ↦ (trivializationAt F V (z t).proj (z r)).2) b t := by
+  refine hasMFDerivWithinAt_univ.symm.trans ?_
+  rw [hasMFDerivWithinAt_totalSpace_curve_iff, continuousWithinAt_univ, hasDerivWithinAt_univ,
+    hasDerivWithinAt_univ]
+
+end TauCeti.Manifold
+
+end

--- a/TauCeti/Geometry/Manifold/VectorBundle/CurveInTotalSpace.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CurveInTotalSpace.lean
@@ -30,10 +30,6 @@ a tangent bundle is unpacked into an equation on its base curve and one on its v
   both taken at the current point of the curve.
 * `TauCeti.Manifold.hasMFDerivAt_totalSpace_curve_iff`: its unrestricted case.
 
-## References
-
-* [Geodesics, the exponential map, and the Hopf--Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
-  Layer 1, "The geodesic spray".
 -/
 
 public section
@@ -89,6 +85,9 @@ theorem hasMFDerivWithinAt_totalSpace_curve_iff_of_continuousWithinAt
   have key : HasMFDerivWithinAt 𝓘(𝕜, 𝕜) (IB.prod 𝓘(𝕜, F)) z s t
         ((1 : 𝕜 →L[𝕜] 𝕜).smulRight (a, b)) ↔
       HasDerivWithinAt (fun r ↦ (extChartAt IB x₀ (z r).proj, (e (z r)).2)) (a, b) s t := by
+    -- There is no general characterization theorem for `HasMFDerivWithinAt` with a manifold
+    -- target, so expose its defining continuity-and-chart-derivative pair before simplifying the
+    -- model spaces and replacing the written chart map by `hfun`.
     change (ContinuousWithinAt z s t ∧ _) ↔ _
     rw [extChartAt_model_space_eq_id]
     simp only [PartialEquiv.refl_symm, PartialEquiv.refl_coe, preimage_id_eq, id_eq,

--- a/TauCeti/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -67,6 +67,29 @@ variable
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
 
+section BasePoint
+
+variable [IsManifold I 1 M]
+
+/-- Read in the canonical trivialization at `x`, a tangent vector at `x` itself is its own
+coordinate vector: the trivialization is built from the chart at `x`, whose transition function
+with itself has derivative the identity. -/
+@[simp]
+theorem continuousLinearMapAt_trivializationAt_self (x : M) (v : TangentSpace I x) :
+    (trivializationAt E (TangentSpace I) x).continuousLinearMapAt 𝕜 x v = v := by
+  rw [TangentBundle.continuousLinearMapAt_trivializationAt_eq_core (mem_chart_source H x)]
+  exact (tangentBundleCore I M).coordChange_self (achart H x) x (mem_chart_source H x) v
+
+/-- The inverse form of `TauCeti.Manifold.continuousLinearMapAt_trivializationAt_self`: over its
+own base point, the inverse of the canonical trivialization is the identity. -/
+@[simp]
+theorem symmL_trivializationAt_self (x : M) (v : E) :
+    (trivializationAt E (TangentSpace I) x).symmL 𝕜 x v = v := by
+  rw [TangentBundle.symmL_trivializationAt_eq_core (mem_chart_source H x)]
+  exact (tangentBundleCore I M).coordChange_self (achart H x) x (mem_chart_source H x) v
+
+end BasePoint
+
 section TangentChart
 
 section TangentBundleChart
@@ -137,16 +160,17 @@ theorem contMDiffAt_tangentCoordChange {n : ℕ∞ω} [IsManifold I (n + 1) M] {
 private theorem tangentCoordChange_tangent_eventuallyEq [IsManifold I 1 M] {x x₀ : M}
     (hx₀ : x ∈ (extChartAt I x₀).source) (u : E) :
     ((extChartAt I.tangent (TotalSpace.mk' E x₀ 0) : TangentBundle I M → E × E) ∘
-        (extChartAt I.tangent
-          (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))).symm) =ᶠ[nhdsWithin
+        (extChartAt I.tangent (TotalSpace.mk' E x
+          ((trivializationAt E (TangentSpace I) x).symmL 𝕜 x u))).symm) =ᶠ[nhdsWithin
           (extChartAt I.tangent
-            (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
-            (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))) (range I.tangent)]
+            (TotalSpace.mk' E x ((trivializationAt E (TangentSpace I) x).symmL 𝕜 x u))
+            (TotalSpace.mk' E x ((trivializationAt E (TangentSpace I) x).symmL 𝕜 x u)))
+            (range I.tangent)]
       fun a ↦
         let y := (extChartAt I x).symm a.1
         (extChartAt I x₀ y, tangentCoordChange I x x₀ y a.2) := by
   let z : TangentBundle I M :=
-    TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u)
+    TotalSpace.mk' E x ((trivializationAt E (TangentSpace I) x).symmL 𝕜 x u)
   let q : TangentBundle I M := TotalSpace.mk' E x₀ 0
   let p := extChartAt I.tangent z z
   let G := (extChartAt I.tangent q : TangentBundle I M → E × E) ∘
@@ -154,6 +178,8 @@ private theorem tangentCoordChange_tangent_eventuallyEq [IsManifold I 1 M] {x x�
   let T : E × E → E × E := fun a ↦
     let y := (extChartAt I x).symm a.1
     (extChartAt I x₀ y, tangentCoordChange I x x₀ y a.2)
+  -- There is no rewriting lemma that folds the four local abbreviations in this `EventuallyEq`;
+  -- expose their definitional expansion so the chart-source argument can use the shorter names.
   change G =ᶠ[nhdsWithin p (range I.tangent)] T
   have hz : z ∈ (chartAt (ModelProd H E) z).source := mem_chart_source _ _
   have hzq : z ∈ (chartAt (ModelProd H E) q).source := by
@@ -219,7 +245,7 @@ private theorem fderivWithin_tangentCoordChange_tangent_model [IsManifold I 2 M]
       (range I ×ˢ univ) (extChartAt I x x, u)) (u, w) =
       (tangentCoordChange I x x₀ x u,
         mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x
-            ((tangentSpaceCastModel I x).symm u) +
+            ((trivializationAt E (TangentSpace I) x).symmL 𝕜 x u) +
           tangentCoordChange I x x₀ x w) := by
   let a₀ := extChartAt I x x
   let F : E → E := fun a ↦ extChartAt I x₀ ((extChartAt I x).symm a)
@@ -227,15 +253,20 @@ private theorem fderivWithin_tangentCoordChange_tangent_model [IsManifold I 2 M]
   have ha₀ : a₀ ∈ ((extChartAt I x).symm ≫ extChartAt I x₀).source := by
     rw [PartialEquiv.trans_source]
     exact ⟨(extChartAt I x).map_source (mem_extChartAt_source x), by
+      -- `PartialEquiv.trans_source` leaves this as preimage membership; there is no chart lemma
+      -- rewriting that wrapper, so expose its defining application before using
+      -- `extChartAt_to_inv`.
       change (extChartAt I x).symm a₀ ∈ (extChartAt I x₀).source
       simpa only [a₀, extChartAt_to_inv] using hx₀⟩
   have hF : DifferentiableWithinAt 𝕜 F (range I) a₀ :=
     (contDiffWithinAt_ext_coord_change x₀ x ha₀).differentiableWithinAt
       (by norm_num : (2 : WithTop ℕ∞) ≠ 0)
-  have hI₂ : IsManifold I (1 + 1) M := inferInstanceAs (IsManifold I 2 M)
+  -- Normalize `2` to the `1 + 1` instance expected by `contMDiffAt_tangentCoordChange` below.
+  let hI₂ : IsManifold I (1 + 1) M := inferInstanceAs (IsManifold I 2 M)
   have hCMD : MDifferentiableAt I 𝓘(𝕜, E →L[𝕜] E)
       (tangentCoordChange I x x₀) x :=
-    (contMDiffAt_tangentCoordChange (n := 1) hx₀).mdifferentiableAt one_ne_zero
+    (@contMDiffAt_tangentCoordChange 𝕜 _ E _ _ H _ I M _ _ 1 hI₂ x x₀ hx₀).mdifferentiableAt
+      one_ne_zero
   have hC : DifferentiableWithinAt 𝕜 C (range I) a₀ := by
     have h := (mdifferentiableAt_iff (tangentCoordChange I x x₀) x).1 hCMD |>.2
     simp only [writtenInExtChartAt, extChartAt_model_space_eq_id,
@@ -294,30 +325,43 @@ private theorem fderivWithin_tangentCoordChange_tangent_model [IsManifold I 2 M]
     (differentiableWithinAt_const (c := u))
   have hCuDerivApp := congrArg (fun L : E →L[𝕜] E ↦ L u) hCuDeriv
   have hMv : mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x
-      ((tangentSpaceCastModel I x).symm u) =
+      ((trivializationAt E (TangentSpace I) x).symmL 𝕜 x u) =
       fderivWithin 𝕜 C (range I) a₀ u u := by
-    rw [hMDu.mvfderiv]
+    rw [hMDu.mvfderiv, symmL_trivializationAt_self]
     -- The manifold derivative is now the derivative of the model-space function `a ↦ C a u`.
     change fderivWithin 𝕜 (fun a ↦ C a u) (range I) a₀ u = _
     simpa [fderivWithin_const_apply] using hCuDerivApp
   rw [hMv]
 
-/-- The tangent coordinate change on `TM` sends a tangent vector `(u, w)` to the derivative of
-the base coordinate change together with the product-rule expression for the fibre coordinate.
-The base point in `TM` is the vector with `x`-coordinate `u`, and the target chart is centred at
-the zero vector over `x₀`. -/
+/-- The tangent coordinate change on `TM` sends the tangent vector `(v, w)` at `u ∈ TₓM` to the
+derivative of the base coordinate change together with the product-rule expression for the fibre
+coordinate, where `v` is the coordinate of `u` in the preferred trivialization at `x`. The target
+chart is centred at the zero vector over `x₀`. -/
 theorem tangentCoordChange_tangent_apply [IsManifold I 2 M] {x x₀ : M}
-    (hx₀ : x ∈ (extChartAt I x₀).source) (u w : E) :
+    (hx₀ : x ∈ (extChartAt I x₀).source) (u : TangentSpace I x) (w : E) :
+    let v := (trivializationAt E (TangentSpace I) x).continuousLinearMapAt 𝕜 x u
     tangentCoordChange I.tangent
-        (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
+        (TotalSpace.mk' E x u)
         (TotalSpace.mk' E x₀ 0)
-        (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u)) (u, w) =
-      (tangentCoordChange I x x₀ x u,
-        mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x
-            ((tangentSpaceCastModel I x).symm u) +
+        (TotalSpace.mk' E x u) (v, w) =
+      (tangentCoordChange I x x₀ x v,
+        mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y v) x u +
           tangentCoordChange I x x₀ x w) := by
+  dsimp only
+  let v : E := (trivializationAt E (TangentSpace I) x).continuousLinearMapAt 𝕜 x u
+  -- Fold the repeated preferred-chart reading of `u` into the local model coordinate `v`.
+  change tangentCoordChange I.tangent (TotalSpace.mk' E x u) (TotalSpace.mk' E x₀ 0)
+      (TotalSpace.mk' E x u) (v, w) =
+    (tangentCoordChange I x x₀ x v,
+      mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y v) x u +
+        tangentCoordChange I x x₀ x w)
+  have hx : x ∈ (trivializationAt E (TangentSpace I) x).baseSet :=
+    FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) x
+  have huv : (trivializationAt E (TangentSpace I) x).symmL 𝕜 x v = u :=
+    (trivializationAt E (TangentSpace I) x).symmL_continuousLinearMapAt hx u
+  rw [← huv]
   let z : TangentBundle I M :=
-    TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u)
+    TotalSpace.mk' E x ((trivializationAt E (TangentSpace I) x).symmL 𝕜 x v)
   let q : TangentBundle I M := TotalSpace.mk' E x₀ 0
   let p := extChartAt I.tangent z z
   let G := (extChartAt I.tangent q : TangentBundle I M → E × E) ∘
@@ -327,20 +371,23 @@ theorem tangentCoordChange_tangent_apply [IsManifold I 2 M] {x x₀ : M}
     (extChartAt I x₀ y, tangentCoordChange I x x₀ y a.2)
   have hGT : G =ᶠ[nhdsWithin p (range I.tangent)] T := by
     simpa only [z, q, p, G, T] using
-      tangentCoordChange_tangent_eventuallyEq (I := I) (M := M) hx₀ u
+      tangentCoordChange_tangent_eventuallyEq (I := I) (M := M) hx₀ v
   rw [tangentCoordChange_def]
   -- By definition, a tangent coordinate change is the derivative of the extended chart change.
-  change fderivWithin 𝕜 G (range I.tangent) p (u, w) = _
+  change fderivWithin 𝕜 G (range I.tangent) p (v, w) = _
   have hp_mem : p ∈ range I.tangent :=
     (extChartAt_target_subset_range z) ((extChartAt I.tangent z).map_source
       (mem_extChartAt_source z))
   rw [hGT.fderivWithin_eq (hGT.self_of_nhdsWithin hp_mem)]
-  have hpcoord : p = (extChartAt I x x, u) := by
+  have hpcoord : p = (extChartAt I x x, v) := by
     apply Prod.ext
     · rfl
-    · exact tangentCoordChange_self (mem_extChartAt_source x)
+    · change tangentCoordChange I x x x
+          ((trivializationAt E (TangentSpace I) x).symmL 𝕜 x v) = v
+      rw [symmL_trivializationAt_self]
+      exact tangentCoordChange_self (I := I) (M := M) (mem_extChartAt_source x)
   rw [hpcoord, ModelWithCorners.range_prod, ModelWithCorners.range_eq_univ 𝓘(𝕜, E)]
-  exact fderivWithin_tangentCoordChange_tangent_model hx₀ u w
+  exact fderivWithin_tangentCoordChange_tangent_model hx₀ v w
 
 section TangentReading
 
@@ -372,23 +419,6 @@ end TangentChart
 section BasePoint
 
 variable [IsManifold I 1 M]
-
-/-- Read in the canonical trivialization at `x`, a tangent vector at `x` itself is its own
-coordinate vector: the trivialization is built from the chart at `x`, whose transition function
-with itself has derivative the identity. -/
-@[simp]
-theorem continuousLinearMapAt_trivializationAt_self (x : M) (v : TangentSpace I x) :
-    (trivializationAt E (TangentSpace I) x).continuousLinearMapAt 𝕜 x v = v := by
-  rw [TangentBundle.continuousLinearMapAt_trivializationAt_eq_core (mem_chart_source H x)]
-  exact (tangentBundleCore I M).coordChange_self (achart H x) x (mem_chart_source H x) v
-
-/-- The inverse form of `TauCeti.Manifold.continuousLinearMapAt_trivializationAt_self`: over its
-own base point, the inverse of the canonical trivialization is the identity. -/
-@[simp]
-theorem symmL_trivializationAt_self (x : M) (v : E) :
-    (trivializationAt E (TangentSpace I) x).symmL 𝕜 x v = v := by
-  rw [TangentBundle.symmL_trivializationAt_eq_core (mem_chart_source H x)]
-  exact (tangentBundleCore I M).coordChange_self (achart H x) x (mem_chart_source H x) v
 
 private theorem localFrame_apply_eq_symmL {ι : Type*} (b : Basis ι 𝕜 E)
     (e : Trivialization E (TotalSpace.proj : TangentBundle I M → M)) [MemTrivializationAtlas e]

--- a/TauCeti/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -31,6 +31,8 @@ identification.
 * `TauCeti.Manifold.contMDiffAt_tangentCoordChange`: that coordinate change is `C^n` at the base
   point of its first chart, as a map of manifolds into the linear endomorphisms of the model
   space.
+* `TauCeti.Manifold.tangentCoordChange_tangent_apply`: the coordinate-change formula on the
+  tangent bundle of the tangent bundle.
 * `TauCeti.Manifold.continuousLinearMapAt_symmL_coordChange`: reading a tangent vector through the
   preferred trivializations of two charts is the tangent coordinate change between them.
 * `TauCeti.Manifold.tangentSpaceOpenEquiv`: the canonical continuous linear equivalence between
@@ -120,6 +122,216 @@ theorem contMDiffAt_tangentCoordChange {n : ℕ∞ω} [IsManifold I (n + 1) M] {
         (ChartedSpace.mem_chart_source x) hychart
     refine ((contDiffOn_tangentCoordChange (I := I) (𝕜 := 𝕜) x y).contDiffWithinAt
       hmem).mono_of_mem_nhdsWithin hset
+
+/-! ### Coordinate changes on the tangent of the tangent bundle -/
+
+private theorem tangentCoordChange_tangent_eventuallyEq [IsManifold I 1 M] {x x₀ : M}
+    (hx₀ : x ∈ (extChartAt I x₀).source) (u : E) :
+    ((extChartAt I.tangent (TotalSpace.mk' E x₀ 0) : TangentBundle I M → E × E) ∘
+        (extChartAt I.tangent
+          (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))).symm) =ᶠ[nhdsWithin
+          (extChartAt I.tangent
+            (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
+            (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))) (range I.tangent)]
+      fun a ↦
+        let y := (extChartAt I x).symm a.1
+        (extChartAt I x₀ y, tangentCoordChange I x x₀ y a.2) := by
+  let z : TangentBundle I M :=
+    TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u)
+  let q : TangentBundle I M := TotalSpace.mk' E x₀ 0
+  let p := extChartAt I.tangent z z
+  let G := (extChartAt I.tangent q : TangentBundle I M → E × E) ∘
+    (extChartAt I.tangent z).symm
+  let T : E × E → E × E := fun a ↦
+    let y := (extChartAt I x).symm a.1
+    (extChartAt I x₀ y, tangentCoordChange I x x₀ y a.2)
+  change G =ᶠ[nhdsWithin p (range I.tangent)] T
+  have hz : z ∈ (chartAt (ModelProd H E) z).source := mem_chart_source _ _
+  have hzq : z ∈ (chartAt (ModelProd H E) q).source := by
+    rw [TangentBundle.mem_chart_source_iff (I := I) (M := M)]
+    rw [← extChartAt_source I x₀]
+    exact hx₀
+  have hN := (I.tangent.extendCoordChange_source_mem_nhdsWithin'
+    (e := chartAt (ModelProd H E) z) (e' := chartAt (ModelProd H E) q) hz hzq)
+  filter_upwards [hN] with a ha
+  -- Membership in the extended coordinate-change source supplies membership in both tangent
+  -- charts; unfold that source once to name the corresponding total-space point `b`.
+  change a ∈ ((extChartAt I.tangent z).symm ≫ extChartAt I.tangent q).source at ha
+  let b := (extChartAt I.tangent z).symm a
+  have ha_target : a ∈ (extChartAt I.tangent z).target := ha.1
+  have hbzT : b ∈ (extChartAt I.tangent z).source :=
+    (extChartAt I.tangent z).map_target ha_target
+  have hbqT : b ∈ (extChartAt I.tangent q).source := ha.2
+  have hbz : b.proj ∈ (extChartAt I x).source := by
+    rw [extChartAt_source] at hbzT ⊢
+    exact (TangentBundle.mem_chart_source_iff b z).1 hbzT
+  have hbq : b.proj ∈ (extChartAt I x₀).source := by
+    rw [extChartAt_source] at hbqT ⊢
+    exact (TangentBundle.mem_chart_source_iff b q).1 hbqT
+  have hright : extChartAt I.tangent z b = a :=
+    (extChartAt I.tangent z).right_inv ha_target
+  -- A tangent-bundle chart is a product of the base chart and the fibre coordinate change.
+  -- Projecting `hright` exposes those two definitional components.
+  have hbase : extChartAt I x b.proj = a.1 := by
+    have h := congrArg Prod.fst hright
+    change extChartAt I x b.proj = a.1 at h
+    exact h
+  have hfiber : tangentCoordChange I b.proj x b.proj b.2 = a.2 := by
+    have h := congrArg Prod.snd hright
+    change tangentCoordChange I b.proj x b.proj b.2 = a.2 at h
+    exact h
+  have hy : (extChartAt I x).symm a.1 = b.proj := by
+    rw [← hbase]
+    exact (extChartAt I x).left_inv hbz
+  have hsecond : (extChartAt I.tangent q b).2 =
+      tangentCoordChange I x x₀ b.proj a.2 := by
+    rw [← hfiber]
+    have hcomp := tangentCoordChange_comp (I := I) (w := b.proj) (x := x)
+      (y := x₀) (z := b.proj) (v := b.2)
+      ⟨⟨mem_extChartAt_source b.proj, hbz⟩, hbq⟩
+    -- The domain and codomain tangent spaces are modelled by `E`; expose that representation to
+    -- apply the coordinate-change composition theorem.
+    change tangentCoordChange I b.proj x₀ b.proj b.2 = _
+    exact hcomp.symm
+  -- Unfold the local names and compare the two product coordinates separately.
+  change extChartAt I.tangent q b = T a
+  apply Prod.ext
+  · change extChartAt I x₀ b.proj = extChartAt I x₀ ((extChartAt I x).symm a.1)
+    rw [hy]
+  · change (extChartAt I.tangent q b).2 =
+      tangentCoordChange I x x₀ ((extChartAt I x).symm a.1) a.2
+    simpa only [hy] using hsecond
+
+private theorem fderivWithin_tangentCoordChange_tangent_model [IsManifold I 2 M] {x x₀ : M}
+    (hx₀ : x ∈ (extChartAt I x₀).source) (u w : E) :
+    (fderivWithin 𝕜 (fun a : E × E ↦
+        (extChartAt I x₀ ((extChartAt I x).symm a.1),
+          tangentCoordChange I x x₀ ((extChartAt I x).symm a.1) a.2))
+      (range I ×ˢ univ) (extChartAt I x x, u)) (u, w) =
+      (tangentCoordChange I x x₀ x u,
+        mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x
+            ((tangentSpaceCastModel I x).symm u) +
+          tangentCoordChange I x x₀ x w) := by
+  let a₀ := extChartAt I x x
+  let F : E → E := fun a ↦ extChartAt I x₀ ((extChartAt I x).symm a)
+  let C : E → E →L[𝕜] E := fun a ↦ tangentCoordChange I x x₀ ((extChartAt I x).symm a)
+  have ha₀ : a₀ ∈ ((extChartAt I x).symm ≫ extChartAt I x₀).source := by
+    rw [PartialEquiv.trans_source]
+    exact ⟨(extChartAt I x).map_source (mem_extChartAt_source x), by
+      change (extChartAt I x).symm a₀ ∈ (extChartAt I x₀).source
+      simpa only [a₀, extChartAt_to_inv] using hx₀⟩
+  have hF : DifferentiableWithinAt 𝕜 F (range I) a₀ :=
+    (contDiffWithinAt_ext_coord_change x₀ x ha₀).differentiableWithinAt
+      (by norm_num : (2 : WithTop ℕ∞) ≠ 0)
+  have hI₂ : IsManifold I (1 + 1) M := inferInstanceAs (IsManifold I 2 M)
+  have hCMD : MDifferentiableAt I 𝓘(𝕜, E →L[𝕜] E)
+      (tangentCoordChange I x x₀) x :=
+    (contMDiffAt_tangentCoordChange (n := 1) hx₀).mdifferentiableAt one_ne_zero
+  have hC : DifferentiableWithinAt 𝕜 C (range I) a₀ := by
+    have h := (mdifferentiableAt_iff (tangentCoordChange I x x₀) x).1 hCMD |>.2
+    simp only [writtenInExtChartAt, extChartAt_model_space_eq_id,
+      PartialEquiv.refl_coe] at h
+    -- With a model-space target, `writtenInExtChartAt` reduces to `C`; expose that reduction so
+    -- the ordinary differentiability statement can be reused below.
+    change DifferentiableWithinAt 𝕜 C (range I) a₀ at h
+    exact h
+  have hmaps : MapsTo (Prod.fst : E × E → E) (range I ×ˢ univ) (range I) :=
+    fun _ h ↦ h.1
+  have huniqBase : UniqueDiffWithinAt 𝕜 (range I) a₀ := I.uniqueDiffWithinAt_image
+  have huniq : UniqueDiffWithinAt 𝕜 (range I ×ˢ univ) (a₀, u) :=
+    huniqBase.prod uniqueDiffWithinAt_univ
+  -- The calculus lemmas below are stated for explicit compositions with the two projections.
+  -- The `change` steps only eta-expand those compositions and their derivatives.
+  have hFp : DifferentiableWithinAt 𝕜 (fun a : E × E ↦ F a.1)
+      (range I ×ˢ univ) (a₀, u) := by
+    change DifferentiableWithinAt 𝕜 (F ∘ Prod.fst) (range I ×ˢ univ) (a₀, u)
+    exact hF.comp (a₀, u) differentiableWithinAt_fst hmaps
+  have hCp : DifferentiableWithinAt 𝕜 (fun a : E × E ↦ C a.1)
+      (range I ×ˢ univ) (a₀, u) := by
+    change DifferentiableWithinAt 𝕜 (C ∘ Prod.fst) (range I ×ˢ univ) (a₀, u)
+    exact hC.comp (a₀, u) differentiableWithinAt_fst hmaps
+  have hAp : DifferentiableWithinAt 𝕜 (fun a : E × E ↦ C a.1 a.2)
+      (range I ×ˢ univ) (a₀, u) :=
+    hCp.clm_apply differentiableWithinAt_snd
+  change (fderivWithin 𝕜 (fun a : E × E ↦ (F a.1, C a.1 a.2))
+    (range I ×ˢ univ) (a₀, u)) (u, w) = _
+  have hFp_eq := fderivWithin_comp (a₀, u) hF differentiableWithinAt_fst hmaps huniq
+  change fderivWithin 𝕜 (fun a : E × E ↦ F a.1) (range I ×ˢ univ) (a₀, u) = _ at hFp_eq
+  have hCp_eq := fderivWithin_comp (a₀, u) hC differentiableWithinAt_fst hmaps huniq
+  change fderivWithin 𝕜 (fun a : E × E ↦ C a.1) (range I ×ˢ univ) (a₀, u) = _ at hCp_eq
+  have hAp_eq := fderivWithin_clm_apply huniq hCp differentiableWithinAt_snd
+  change fderivWithin 𝕜 (fun a : E × E ↦ C a.1 a.2) (range I ×ˢ univ) (a₀, u) = _ at hAp_eq
+  have hfst_app : (fderivWithin 𝕜 (Prod.fst : E × E → E) (range I ×ˢ univ) (a₀, u))
+      (u, w) = u := by
+    rw [fderivWithin_fst huniq]
+    rfl
+  have hsnd_app : (fderivWithin 𝕜 (Prod.snd : E × E → E) (range I ×ˢ univ) (a₀, u))
+      (u, w) = w := by
+    rw [fderivWithin_snd huniq]
+    rfl
+  rw [hFp.fderivWithin_prodMk hAp huniq, ContinuousLinearMap.prod_apply, hFp_eq,
+    hAp_eq, hCp_eq]
+  simp only [ContinuousLinearMap.comp_apply, add_apply,
+    ContinuousLinearMap.flip_apply, C, F, a₀, extChartAt_to_inv]
+  rw [hfst_app, hsnd_app, add_comm]
+  have hFderiv : fderivWithin 𝕜 F (range I) a₀ = tangentCoordChange I x x₀ x := by
+    rw [tangentCoordChange_def]
+    rfl
+  rw [hFderiv]
+  have hMDu : MDifferentiableAt I 𝓘(𝕜, E)
+      (fun y ↦ tangentCoordChange I x x₀ y u) x :=
+    hCMD.clm_apply mdifferentiableAt_const
+  have hCuDeriv := fderivWithin_clm_apply huniqBase hC
+    (differentiableWithinAt_const (c := u))
+  have hCuDerivApp := congrArg (fun L : E →L[𝕜] E ↦ L u) hCuDeriv
+  have hMv : mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x
+      ((tangentSpaceCastModel I x).symm u) =
+      fderivWithin 𝕜 C (range I) a₀ u u := by
+    rw [hMDu.mvfderiv]
+    -- The manifold derivative is now the derivative of the model-space function `a ↦ C a u`.
+    change fderivWithin 𝕜 (fun a ↦ C a u) (range I) a₀ u = _
+    simpa [fderivWithin_const_apply] using hCuDerivApp
+  rw [hMv]
+
+/-- The tangent coordinate change on `TM` sends a tangent vector `(u, w)` to the derivative of
+the base coordinate change together with the product-rule expression for the fibre coordinate.
+The base point in `TM` is the vector with `x`-coordinate `u`, and the target chart is centred at
+the zero vector over `x₀`. -/
+theorem tangentCoordChange_tangent_apply [IsManifold I 2 M] {x x₀ : M}
+    (hx₀ : x ∈ (extChartAt I x₀).source) (u w : E) :
+    tangentCoordChange I.tangent
+        (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u))
+        (TotalSpace.mk' E x₀ 0)
+        (TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u)) (u, w) =
+      (tangentCoordChange I x x₀ x u,
+        mvfderiv I (fun y ↦ tangentCoordChange I x x₀ y u) x
+            ((tangentSpaceCastModel I x).symm u) +
+          tangentCoordChange I x x₀ x w) := by
+  let z : TangentBundle I M :=
+    TotalSpace.mk' E x ((tangentSpaceCastModel I x).symm u)
+  let q : TangentBundle I M := TotalSpace.mk' E x₀ 0
+  let p := extChartAt I.tangent z z
+  let G := (extChartAt I.tangent q : TangentBundle I M → E × E) ∘
+    (extChartAt I.tangent z).symm
+  let T : E × E → E × E := fun a ↦
+    let y := (extChartAt I x).symm a.1
+    (extChartAt I x₀ y, tangentCoordChange I x x₀ y a.2)
+  have hGT : G =ᶠ[nhdsWithin p (range I.tangent)] T := by
+    simpa only [z, q, p, G, T] using
+      tangentCoordChange_tangent_eventuallyEq (I := I) (M := M) hx₀ u
+  rw [tangentCoordChange_def]
+  -- By definition, a tangent coordinate change is the derivative of the extended chart change.
+  change fderivWithin 𝕜 G (range I.tangent) p (u, w) = _
+  have hp_mem : p ∈ range I.tangent :=
+    (extChartAt_target_subset_range z) ((extChartAt I.tangent z).map_source
+      (mem_extChartAt_source z))
+  rw [hGT.fderivWithin_eq (hGT.self_of_nhdsWithin hp_mem)]
+  have hpcoord : p = (extChartAt I x x, u) := by
+    apply Prod.ext
+    · rfl
+    · exact tangentCoordChange_self (mem_extChartAt_source x)
+  rw [hpcoord, ModelWithCorners.range_prod, ModelWithCorners.range_eq_univ 𝓘(𝕜, E)]
+  exact fderivWithin_tangentCoordChange_tangent_model hx₀ u w
 
 section TangentReading
 

--- a/TauCeti/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -9,12 +9,21 @@ public import Mathlib.Geometry.Manifold.MFDeriv.Atlas
 public import Mathlib.Geometry.Manifold.VectorBundle.LocalFrame
 
 /-!
-# Tangent-bundle trivializations at their own base point, and open submanifolds
+# Tangent-bundle trivializations, coordinate changes on `T(TM)`, and open submanifolds
 
 The canonical tangent-bundle trivialization at a point `x` is built from the chart at `x`, so on
-the fibre over `x` itself it is the identity.  This file records that fact in both directions.
+the fibre over `x` itself it is the identity.  This file records that fact in both directions, and
+notes that reading a tangent vector through the preferred trivializations of two charts is the
+tangent coordinate change between them, which is `C^n` in the base point.
 
-It then identifies the tangent spaces of an open submanifold with those of its ambient manifold
+It then computes the coordinate changes of the tangent bundle of the tangent bundle: a tangent
+vector `(u, w)` to `TM` at a point with `x`-coordinates `u`, read in the tangent-bundle chart
+centred at the zero vector over `x₀`, has base component the tangent coordinate change of `u`, and
+fibre component the product-rule sum of the derivative of that coordinate change in the base point
+and the coordinate change applied to `w`.  This is the transformation law obeyed by a second-order
+vector field on `TM`, such as a geodesic spray, when it is carried between tangent-bundle charts.
+
+Finally it identifies the tangent spaces of an open submanifold with those of its ambient manifold
 and shows that, near each point, the inverse tangent-bundle trivializations agree under that
 identification.
 


### PR DESCRIPTION
This PR constructs the geodesic spray of a Riemannian manifold and proves that its integral curves are exactly the velocity lifts of geodesics. It discharges the first two clauses of the HopfRinow roadmap's Layer 1 milestone "The geodesic spray" — "construct the vector field `S` on `TM`", "prove that in a tangent-bundle chart it is `(x, v) ↦ (v, -Γ_x(v, v))`", and "prove that integral curves of `S` are exactly the velocity lifts of curves satisfying the covariant geodesic equation, with set-restricted versions on their common time domains" — which the roadmap's ordering section names as the object that "feeds local existence, smooth dependence, constant speed, maximal intervals, and the finite-endpoint extension criterion", and which `STATUS.md` names as the current frontier ("Everything below waits on this").

`TauCeti.Manifold.geodesicSpray` is the vector field `z ↦ (z.2, -Γ_{z.proj}(z.2, z.2))` on `TangentBundle I M`, with `Γ` the model-space Christoffel map `TauCeti.Manifold.christoffelMap` of `CovariantDerivative.leviCivita` in the tangent-bundle trivialization at the base point of the argument. Because a vector field assigns to a point a vector read in the chart at *that* point, and because the tangent-bundle chart at `(x, v)` reads the base direction in the extended chart of `M` at `x` and the fibre direction in the trivialization at `x` — over which `v` is its own coordinate — the displayed formula is literally the definition, in the same moving-chart convention as `CovariantDerivative.alongCurveWithin` and `TauCeti.Manifold.IsGeodesicCurveOn`. What needs proof is that this formula solves the intended problem, and that is what the integral-curve theorems supply: on a parameter set with unique derivatives, `TauCeti.Manifold.isMIntegralCurveOn_curveVelocityLiftWithin_iff` says the velocity lift of a `C²` curve is an integral curve of the spray exactly when the curve is a geodesic, and `TauCeti.Manifold.eq_curveVelocityLiftWithin_of_isMIntegralCurveOn` says conversely that every integral curve of the spray is the velocity lift of the curve it lies over, whose base curve is then a geodesic once it is `C²` (`TauCeti.Manifold.isGeodesicCurveOn_proj_of_isMIntegralCurveOn`). The all-time case and a constant-curve check are recorded too, and `TauCeti.Manifold.curveVelocityLiftWithin` names the lift `t ↦ (γ t, γ' t)` that the geodesic flow will consume.

The proof unpacks a curve into a bundle total space into its base curve and its fibre coordinate. That step is not Riemannian and is proved for an arbitrary fibre bundle in the new `TauCeti/Geometry/Manifold/VectorBundle/CurveInTotalSpace.lean`: `TauCeti.Manifold.hasMFDerivWithinAt_totalSpace_curve_iff` says a curve into a total space has a manifold derivative within a parameter set exactly when it is continuous there and the two coordinate readings, taken in the chart and the trivialization at the *current* point, have the corresponding ordinary derivatives. Mathlib's `mdifferentiableWithinAt_totalSpace` is the differentiability-only analogue and does not identify the derivative, so it cannot be used here; `FiberBundle.extChartAt`, `Filter.EventuallyEq.hasFDerivWithinAt_iff` and `HasFDerivWithinAt.fst`/`.snd` are consumed rather than reproved. With that in hand the geodesic side reuses the existing Layer-1 API without restating it: `TauCeti.Manifold.derivWithin_extChartAt_comp_curve` and `TauCeti.Manifold.hasDerivWithinAt_extChartAt_comp_curve` for the base component, `TauCeti.Manifold.sectionCoord_curveVelocityWithin_eventuallyEq` and `TauCeti.Manifold.differentiableWithinAt_sectionCoord_curveVelocityWithin` for the fibre component, and `CovariantDerivative.alongCurveWithin_curveVelocityWithin_eq_zero_iff` for the geodesic equation itself.

One clause of the milestone remains open. The `C²` hypothesis on the base curve of an integral curve is not removable here: it would follow from `C^∞` smoothness of `S`, which needs the derivative of the tangent-bundle chart transition and hence the second derivatives of the chart transitions of `M`. Chart independence is now proved by `TauCeti.Manifold.tangentCoordChange_geodesicSpray`, which combines the tangent-bundle chart-transition derivative with `TauCeti.Manifold.christoffelMap_coordChange`. So after this PR the milestone still owes smoothness of `S`; local existence and uniqueness of geodesics, the maximal interval `J(p, v)`, and the exponential map then follow by feeding `S` to the integral-curve API, exactly as the roadmap's ordering prescribes.

New files: `TauCeti/Geometry/Manifold/VectorBundle/CurveInTotalSpace.lean` (131 lines) and `TauCeti/Geometry/Manifold/Riemannian/Geodesic/Spray.lean` (505 lines). No Mathlib source was vendored, and nothing was ported from the prior-art repository the roadmap cites.

Roadmap: HopfRinow

<!--tauceti-target:v1 {"focus":"HopfRinow","id":"geodesic-spray"}-->

🤖 Prepared with Claude Code
