### PR TITLE
feat(FormalGroup): associativity of the chord addition series

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.ThirdPoint
 
 /-!
@@ -57,6 +58,26 @@ this repository applies to that development, so `subst_wSeries_ne_zero` is
 `subst_formalW_ne_zero`. `FormalGroup/Add/Inverse.lean` records that the source left that lemma
 unported because its only consumers lay in the source's `Assembly` and `Universal` sections;
 this file is the first of them.
+
+The `Universal` section of the same file (declarations `universal_Δ_ne_zero` and
+`assoc_addSeries_universal`) is `fracCurve_universal_Δ_ne_zero` and `assoc_formalAdd_universal`
+here. Four of that section's nine declarations are not ported, because this repository already
+has them: `universal`, `exists_map_universal` and `universal_Δ_ne_zero` are `Universal.curve`,
+`map_specialize` and `Universal.curve_Δ_ne_zero`, and the source's `X_ne_X` and `X_ne_zero'` are
+Mathlib's `MvPowerSeries.X_inj` and `nonZeroDivisors.ne_zero MvPowerSeries.X_mem_nonzeroDivisors`.
+
+`FormalGroup/Add/Inverse.lean` records that the source's `interceptSeries_ne_zero` and
+`X_pair_intercept_ne_zero` were left unported for want of a consumer, and expects this file to be
+that consumer. It is not, and they stay unported: the source needs them only because it supplies
+the nonvanishing intercept two different ways, an elementary one at a pair of distinct variables
+and `pair_intercept_ne_zero_of_ne` elsewhere. Here `pair_intercept_ne_zero_of_ne` covers the
+variable pairs too, so `thetaPoint_add_of_ne` serves all four chord additions of the assembly and
+the elementary route has no call site.
+
+The assembly also runs two specializations of the three parameters where the source runs one.
+The source separates the middle parameter from the third with `X_ne_X`, a syntactic argument; the
+corresponding hypothesis here is `q₂ ≠ ι(q₃)`, which no syntactic argument reaches, so `χ'` sends
+the middle parameter to `X` and the other two to `0` exactly as `χ` does for the first.
 
 The statement is adapted rather than transcribed, because this repository states the `w`-equation
 differently. Stoll carries a second copy of the equation as a private `def mvWStepAt` and phrases
@@ -550,6 +571,189 @@ private theorem thetaPoint_add_of_ne (hΔ : (fracCurve W σ KK).Δ ≠ 0)
   refine W.thetaPoint_add hΔ h₁ h₂ hq₁0 hq₂0 hN ?_ hF hF0
   rw [subst_pair_formalIntercept_mul_sub W h₁ h₂]
   exact mul_ne_zero hN (sub_ne_zero.mpr hne₁)
+
+/-- A substitution that sends one series to `X` and another to `0` separates them. This is how
+every distinctness hypothesis of the associativity argument is discharged: specialize one of the
+three parameters to `X` and the other two to `0`. -/
+private theorem ne_of_subst_eq_X_of_subst_eq_zero {σ' : Type*}
+    {g : σ' → MvPowerSeries Unit O} {a b : MvPowerSeries σ' O}
+    (ha : subst g a = PowerSeries.X) (hb : subst g b = 0) : a ≠ b := fun hab ↦
+  PowerSeries.X_ne_zero (by rw [← ha, hab]; exact hb)
+
+/-! ### Associativity -/
+
+/-- The universal curve stays nonsingular over the fraction field of its series ring: `Δ` is a
+nonzero polynomial, and both `C` and the localization map are injective. -/
+private theorem fracCurve_universal_Δ_ne_zero (KK : Type*) [Field KK]
+    [Algebra (MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ)) KK]
+    [IsFractionRing (MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ)) KK] :
+    (fracCurve Universal.curve (Unit ⊕ Unit ⊕ Unit) KK).Δ ≠ 0 := by
+  rw [fracCurve, map_Δ]
+  intro h
+  rw [RingHom.comp_apply] at h
+  have h1 : (MvPowerSeries.C Universal.curve.Δ :
+      MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ)) = 0 := by
+    refine IsFractionRing.injective (MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
+      KK ?_
+    rw [map_zero]
+    simpa [MvPowerSeries.c_eq_algebraMap] using h
+  exact Universal.curve_Δ_ne_zero (MvPowerSeries.C_injective (h1.trans (map_zero _).symm))
+
+/-- **Associativity of the addition series for the universal curve.**
+
+The three parameters are the three coordinate variables of
+`ℤ[A₁, ⋯, A₆]⟦t₁, t₂, t₃⟧`, and the two ways of bracketing them are compared as points of the
+honest elliptic curve `fracCurve Universal.curve` over that ring's fraction field: `θ` turns each
+bracketing into a sum of three points, `thetaPoint_add_of_ne` computes both, associativity of the
+curve's group law identifies them, and `thetaPoint_inj` brings the equality back to the series. -/
+private theorem assoc_formalAdd_universal :
+    subst (Sum.elim
+        (fun _ ↦ subst (Sum.elim
+            (fun _ ↦ (X (Sum.inl ()) :
+              MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ)))
+            (fun _ ↦ X (Sum.inr (Sum.inl ()))) :
+              Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
+          (formalAdd Universal.curve))
+        (fun _ ↦ X (Sum.inr (Sum.inr ()))) :
+          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
+      (formalAdd Universal.curve) =
+    subst (Sum.elim
+        (fun _ ↦ (X (Sum.inl ()) :
+          MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ)))
+        (fun _ ↦ subst (Sum.elim
+            (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
+              MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ)))
+            (fun _ ↦ X (Sum.inr (Sum.inr ()))) :
+              Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
+          (formalAdd Universal.curve)) :
+          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) (MvPolynomial Coeff ℤ))
+      (formalAdd Universal.curve) := by
+  classical
+  set R := MvPolynomial Coeff ℤ with hR
+  set KK := FractionRing (MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) with hKK
+  set χ := (Sum.elim (fun _ ↦ (PowerSeries.X : PowerSeries R)) (fun _ ↦ 0) :
+    Unit ⊕ Unit ⊕ Unit → MvPowerSeries Unit R) with hχdef
+  have hχ : HasSubst χ :=
+    hasSubst_of_constantCoeff_zero (by
+      rintro (j | j)
+      · exact PowerSeries.constantCoeff_X
+      · simp [hχdef])
+  have hΔ := fracCurve_universal_Δ_ne_zero KK
+  have hc₁ : constantCoeff (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 :=
+    constantCoeff_X _
+  have hc₂ : constantCoeff (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 :=
+    constantCoeff_X _
+  have hc₃ : constantCoeff (X (Sum.inr (Sum.inr ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 :=
+    constantCoeff_X _
+  have h10 : (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) ≠ 0 :=
+    nonZeroDivisors.ne_zero X_mem_nonzeroDivisors
+  have h20 : (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) ≠ 0 :=
+    nonZeroDivisors.ne_zero X_mem_nonzeroDivisors
+  have h30 : (X (Sum.inr (Sum.inr ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) ≠ 0 :=
+    nonZeroDivisors.ne_zero X_mem_nonzeroDivisors
+  have hχ1 : subst χ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = PowerSeries.X := by
+    rw [subst_X hχ]; rfl
+  have hχ2 : subst χ (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 := by
+    rw [subst_X hχ]; rfl
+  have hχ3 : subst χ (X (Sum.inr (Sum.inr ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 := by
+    rw [subst_X hχ]; rfl
+  have hχ0 : subst χ (0 : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 := by
+    rw [← coe_substAlgHom hχ, map_zero]
+  -- the second specialization, which separates the middle parameter from the third
+  set χ' := (Sum.elim (fun _ ↦ (0 : MvPowerSeries Unit R))
+    (Sum.elim (fun _ ↦ (PowerSeries.X : PowerSeries R)) fun _ ↦ 0) :
+    Unit ⊕ Unit ⊕ Unit → MvPowerSeries Unit R) with hχ'def
+  have hχ' : HasSubst χ' :=
+    hasSubst_of_constantCoeff_zero (by
+      rintro (j | j | j)
+      · simp [hχ'def]
+      · exact PowerSeries.constantCoeff_X
+      · simp [hχ'def])
+  have hχ'2 : subst χ' (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) =
+      PowerSeries.X := by
+    rw [subst_X hχ']; rfl
+  have hχ'3 : subst χ' (X (Sum.inr (Sum.inr ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 := by
+    rw [subst_X hχ']; rfl
+  -- the two inner sums
+  set F₁₂ := subst (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+    (fun _ ↦ X (Sum.inr (Sum.inl ()))) : Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+    (formalAdd Universal.curve) with hF₁₂def
+  set F₂₃ := subst (Sum.elim
+    (fun _ ↦ (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+    (fun _ ↦ X (Sum.inr (Sum.inr ()))) : Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
+    (formalAdd Universal.curve) with hF₂₃def
+  have hF₁₂c : constantCoeff F₁₂ = 0 :=
+    constantCoeff_subst_eq_zero (hasSubst_pair hc₁ hc₂) (by rintro (j | j) <;> simp)
+      (constantCoeff_formalAdd _)
+  have hF₂₃c : constantCoeff F₂₃ = 0 :=
+    constantCoeff_subst_eq_zero (hasSubst_pair hc₂ hc₃) (by rintro (j | j) <;> simp)
+      (constantCoeff_formalAdd _)
+  have hχF₁₂ : subst χ F₁₂ = PowerSeries.X :=
+    subst_subst_pair_formalAdd_eq_X Universal.curve hχ hc₁ hc₂ hχ1 hχ2
+  have hχF₂₃ : subst χ F₂₃ = 0 :=
+    subst_subst_pair_formalAdd_eq_zero Universal.curve hχ hc₂ hc₃ hχ2 hχ3
+  -- the addition series itself is nonzero, and so is the sum of the last two parameters
+  have hFne : formalAdd Universal.curve ≠ 0 := by
+    intro h
+    have h2 := subst_unitR_formalAdd Universal.curve
+    rw [h, ← coe_substAlgHom (hasSubst_of_constantCoeff_zero
+      (by rintro (j | j) <;> simp : ∀ i, constantCoeff
+        ((Sum.elim X (fun _ ↦ 0) : Unit ⊕ Unit → MvPowerSeries Unit R) i) = 0)), map_zero] at h2
+    exact PowerSeries.X_ne_zero h2.symm
+  have hF₁₂0 : F₁₂ ≠ 0 := ne_of_subst_eq_X_of_subst_eq_zero hχF₁₂ hχ0
+  have hF₂₃0 : F₂₃ ≠ 0 := by
+    have hfam : (Sum.elim
+        (fun _ ↦ (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+        (fun _ ↦ X (Sum.inr (Sum.inr ()))) : Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) =
+        X ∘ (Sum.elim (fun _ ↦ Sum.inr (Sum.inl ())) fun _ ↦ Sum.inr (Sum.inr ()) :
+          Unit ⊕ Unit → Unit ⊕ Unit ⊕ Unit) := by
+      funext s
+      rcases s with u | u <;> rfl
+    rw [hF₂₃def, hfam, ← rename_eq_subst]
+    intro h0
+    refine hFne (rename_injective (⟨Sum.elim (fun _ ↦ Sum.inr (Sum.inl ()))
+      fun _ ↦ Sum.inr (Sum.inr ()), ?_⟩ : Unit ⊕ Unit ↪ Unit ⊕ Unit ⊕ Unit) ?_)
+    · rintro (⟨⟩ | ⟨⟩) (⟨⟩ | ⟨⟩) hv
+      · rfl
+      · exact absurd hv (by simp)
+      · exact absurd hv (by simp)
+      · rfl
+    · rw [map_zero]
+      exact h0
+  -- distinctness: each pair is separated by one of the two specializations
+  have hne₁₂ := ne_of_subst_eq_X_of_subst_eq_zero hχ1 hχ2
+  have hne₁₂ι := ne_of_subst_eq_X_of_subst_eq_zero hχ1
+    (subst_subst_formalInverse_eq_zero Universal.curve hχ hc₂ hχ2)
+  have hne₂₃ := ne_of_subst_eq_X_of_subst_eq_zero hχ'2 hχ'3
+  have hne₂₃ι := ne_of_subst_eq_X_of_subst_eq_zero hχ'2
+    (subst_subst_formalInverse_eq_zero Universal.curve hχ' hc₃ hχ'3)
+  have hneL := ne_of_subst_eq_X_of_subst_eq_zero hχF₁₂ hχ3
+  have hneLι := ne_of_subst_eq_X_of_subst_eq_zero hχF₁₂
+    (subst_subst_formalInverse_eq_zero Universal.curve hχ hc₃ hχ3)
+  have hneR := ne_of_subst_eq_X_of_subst_eq_zero hχ1 hχF₂₃
+  have hneRι := ne_of_subst_eq_X_of_subst_eq_zero hχ1
+    (subst_subst_formalInverse_eq_zero Universal.curve hχ hF₂₃c hχF₂₃)
+  -- the two bracketed sums are again legitimate parameters
+  have hLc := constantCoeff_subst_eq_zero (hasSubst_pair hF₁₂c hc₃)
+    (by rintro (j | j) <;> simp [hF₁₂c]) (constantCoeff_formalAdd Universal.curve)
+  have hRc := constantCoeff_subst_eq_zero (hasSubst_pair hc₁ hF₂₃c)
+    (by rintro (j | j) <;> simp [hF₂₃c]) (constantCoeff_formalAdd Universal.curve)
+  have hL0 := ne_of_subst_eq_X_of_subst_eq_zero
+    (subst_subst_pair_formalAdd_eq_X Universal.curve hχ hF₁₂c hc₃ hχF₁₂ hχ3) hχ0
+  have hR0 := ne_of_subst_eq_X_of_subst_eq_zero
+    (subst_subst_pair_formalAdd_eq_X Universal.curve hχ hc₁ hF₂₃c hχ1 hχF₂₃) hχ0
+  -- the θ-chain: both bracketings compute the same sum of three points
+  have e₁₂ := thetaPoint_add_of_ne Universal.curve (KK := KK) hΔ hc₁ hc₂ h10 h20 hne₁₂ hne₁₂ι
+    hF₁₂c hF₁₂0
+  have e₂₃ := thetaPoint_add_of_ne Universal.curve (KK := KK) hΔ hc₂ hc₃ h20 h30 hne₂₃ hne₂₃ι
+    hF₂₃c hF₂₃0
+  have eL := thetaPoint_add_of_ne Universal.curve (KK := KK) hΔ hF₁₂c hc₃ hF₁₂0 h30 hneL hneLι
+    hLc hL0
+  have eR := thetaPoint_add_of_ne Universal.curve (KK := KK) hΔ hc₁ hF₂₃c h10 hF₂₃0 hneR hneRι
+    hRc hR0
+  have hpts : Universal.curve.thetaPoint hΔ hLc hL0 = Universal.curve.thetaPoint hΔ hRc hR0 := by
+    rw [← eL, ← e₁₂, ← eR, ← e₂₃, add_assoc]
+  exact thetaPoint_inj Universal.curve hΔ hLc hRc hL0 hR0 hpts
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
+
+/-!
+# The chord group law over the fraction field of the series ring
+
+Associativity of the chord addition series is proved by transporting the honest group law of a
+Weierstrass curve. The parameters are power series, so the curve has to be read over a field
+containing them: this file base changes `W` along `O → MvPowerSeries σ O → KK` and records the
+`w`-equation there.
+
+## Main definitions
+
+* `WeierstrassCurve.fracCurve` : `W` base changed to a field `KK` over the series ring.
+
+## Main statements
+
+* `WeierstrassCurve.algebraMap_subst_formalW_wEquation` : the substituted `w`-expansion still
+  solves the `w`-equation after being pushed into `KK`, now read on `fracCurve`.
+
+## Provenance
+
+Adapted from Michael Stoll's `EllipticCurves` project
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+`EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`, section `Assembly`, declarations
+`fracCurve` and `rho_weierstrass`.
+
+The statement is adapted rather than transcribed, because this repository states the `w`-equation
+differently. Stoll carries a second copy of the equation as a private `def mvWStepAt` and phrases
+the fixed-point property as `subst_wSeries_fix`; here `wEquationRHS` is already stated over an
+arbitrary algebra, so reading it in `KK` *is* that definition, and `subst_formalW_wEquation`
+supplies the fixed-point property. Stoll's proof is `congrArg` followed by unfolding `mvWStepAt`;
+the corresponding step here has to move the coefficients across the base change instead, which is
+what `fracCurve` in the statement records.
+-/
+
+public section
+
+namespace WeierstrassCurve
+
+open MvPowerSeries
+
+variable {O : Type*} [CommRing O]
+
+/-- The curve `W` base changed to a field `KK` over the series ring `MvPowerSeries σ O`. The
+parameters of the chord construction are series, so the group law they satisfy is the group law of
+this curve. -/
+noncomputable def fracCurve (W : WeierstrassCurve O) (σ : Type*) (KK : Type*) [Field KK]
+    [Algebra (MvPowerSeries σ O) KK] : WeierstrassCurve KK :=
+  W.map ((algebraMap (MvPowerSeries σ O) KK).comp (algebraMap O (MvPowerSeries σ O)))
+
+variable (W : WeierstrassCurve O) {σ : Type*} {KK : Type*} [Field KK]
+  [Algebra (MvPowerSeries σ O) KK]
+
+/-- The `w`-expansion read at a substitutable parameter still solves the `w`-equation after being
+pushed into `KK`, where the equation is the one of `fracCurve W`. -/
+theorem algebraMap_subst_formalW_wEquation {q : MvPowerSeries σ O}
+    (hq : PowerSeries.HasSubst q) :
+    algebraMap (MvPowerSeries σ O) KK (PowerSeries.subst q (formalW W)) =
+      wEquationRHS (fracCurve W σ KK) (algebraMap (MvPowerSeries σ O) KK q)
+        (algebraMap (MvPowerSeries σ O) KK (PowerSeries.subst q (formalW W))) := by
+  conv_lhs => rw [subst_formalW_wEquation W hq]
+  rw [wEquationRHS_def, wEquationRHS_def]
+  simp [fracCurve, map_add, map_mul, map_pow]
+
+end WeierstrassCurve
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -13,10 +13,15 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.ThirdPoint
 /-!
 # The chord group law over the fraction field of the series ring
 
-Associativity of the chord addition series is proved by transporting the honest group law of a
-Weierstrass curve. The parameters are power series, so the curve has to be read over a field
-containing them: this file base changes `W` along `O → MvPowerSeries σ O → KK` and records the
-`w`-equation there.
+**Associativity of the chord addition series**, `F(F(t₁, t₂), t₃) = F(t₁, F(t₂, t₃))`, proved by
+transporting the honest group law of a Weierstrass curve. The parameters are power series, so the
+curve has to be read over a field containing them: this file base changes `W` along
+`O → MvPowerSeries σ O → KK`, records the `w`-equation there, and identifies a parameter with the
+point `(q, w(q))` it names. Chord addition of those points *is* the addition series, so
+associativity of the curve's group law is associativity of the series.
+
+That argument needs a domain, so it runs over the universal curve, whose base `ℤ[A₁, ⋯, A₆]`
+supplies one; `map_specialize` carries the conclusion to every `W` over every commutative ring.
 
 ## Main definitions
 
@@ -33,6 +38,10 @@ containing them: this file base changes `W` along `O → MvPowerSeries σ O → 
   `q₁ w(q₂) - q₂ w(q₁) = ν(q₁, q₂) * (q₁ - q₂)`, which is what the two readings buy.
 * `WeierstrassCurve.subst_pair_formalThirdRoot_ne_zero` : a nonzero intercept forces a nonzero
   third root.
+* `WeierstrassCurve.assoc_formalAdd` : **the associativity of the addition series**, for every
+  Weierstrass curve over every commutative ring. This is the file's terminus, and the last axiom
+  of a commutative formal group law that this development was missing — `Add/Fin2.lean` records
+  how the three variables get reindexed into the shape of Mathlib's `FormalGroup.assoc` field.
 
 ## Provenance
 
@@ -228,6 +237,29 @@ private theorem subst_formalW_subst_formalInverse {q : MvPowerSeries σ O}
   rw [← PowerSeries.subst_comp_subst_apply (hasSubst_formalInverse W) hq,
     subst_formalInverse_formalW, ← PowerSeries.coe_substAlgHom hq]
   simp only [map_neg, map_mul]
+
+/-- The addition series read at a pair of variables again has vanishing constant coefficient, so
+it is itself a legitimate parameter — which is what lets the associativity argument feed one
+bracketed sum into another. -/
+private theorem constantCoeff_subst_pair_X_formalAdd {σ' : Type*} (s₁ s₂ : σ') :
+    constantCoeff (subst (Sum.elim (fun _ ↦ (X s₁ : MvPowerSeries σ' O)) (fun _ ↦ X s₂) :
+      Unit ⊕ Unit → MvPowerSeries σ' O) (formalAdd W)) = 0 :=
+  constantCoeff_subst_eq_zero (hasSubst_pair (constantCoeff_X _) (constantCoeff_X _))
+    (by rintro (j | j) <;> simp) (constantCoeff_formalAdd W)
+
+/-- Base change commutes with reading the addition series at a pair of variables: the variables
+are fixed by `MvPowerSeries.map`, so only `map_formalAdd` is doing any work. -/
+private theorem map_subst_pair_X_formalAdd {σ' S : Type*} [CommRing S] (φ : O →+* S)
+    (s₁ s₂ : σ') :
+    MvPowerSeries.map φ (subst (Sum.elim (fun _ ↦ (X s₁ : MvPowerSeries σ' O)) (fun _ ↦ X s₂) :
+        Unit ⊕ Unit → MvPowerSeries σ' O) (formalAdd W)) =
+      subst (Sum.elim (fun _ ↦ (X s₁ : MvPowerSeries σ' S)) (fun _ ↦ X s₂) :
+        Unit ⊕ Unit → MvPowerSeries σ' S) (formalAdd (W.map φ)) := by
+  rw [MvPowerSeries.map_subst (hasSubst_pair (constantCoeff_X _) (constantCoeff_X _)),
+    map_formalAdd]
+  congr 1
+  funext i
+  rcases i with u | u <;> simp
 
 /-! ### Reading a pair through a further substitution -/
 
@@ -683,11 +715,9 @@ private theorem assoc_formalAdd_universal :
     (fun _ ↦ X (Sum.inr (Sum.inr ()))) : Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
     (formalAdd Universal.curve) with hF₂₃def
   have hF₁₂c : constantCoeff F₁₂ = 0 :=
-    constantCoeff_subst_eq_zero (hasSubst_pair hc₁ hc₂) (by rintro (j | j) <;> simp)
-      (constantCoeff_formalAdd _)
+    constantCoeff_subst_pair_X_formalAdd Universal.curve _ _
   have hF₂₃c : constantCoeff F₂₃ = 0 :=
-    constantCoeff_subst_eq_zero (hasSubst_pair hc₂ hc₃) (by rintro (j | j) <;> simp)
-      (constantCoeff_formalAdd _)
+    constantCoeff_subst_pair_X_formalAdd Universal.curve _ _
   have hχF₁₂ : subst χ F₁₂ = PowerSeries.X :=
     subst_subst_pair_formalAdd_eq_X Universal.curve hχ hc₁ hc₂ hχ1 hχ2
   have hχF₂₃ : subst χ F₂₃ = 0 :=
@@ -754,6 +784,49 @@ private theorem assoc_formalAdd_universal :
   have hpts : Universal.curve.thetaPoint hΔ hLc hL0 = Universal.curve.thetaPoint hΔ hRc hR0 := by
     rw [← eL, ← e₁₂, ← eR, ← e₂₃, add_assoc]
   exact thetaPoint_inj Universal.curve hΔ hLc hRc hL0 hR0 hpts
+
+omit [IsDomain O] in
+/-- **Associativity of the chord addition series**, for every Weierstrass curve over every
+commutative ring: `F(F(t₁, t₂), t₃) = F(t₁, F(t₂, t₃))`.
+
+The chord construction proves this only where the curve has a group law to borrow, so the
+identity is proved for the universal curve — whose base `ℤ[A₁, ⋯, A₆]` is a domain, and whose
+series ring therefore has a fraction field — and `map_specialize` carries it to every `W`.
+
+With `constantCoeff_formalAdd`, `subst_unitR_formalAdd`, `subst_unitL_formalAdd` and
+`rename_swap_formalAdd`, this is the last axiom of a commutative formal group law; reindexing the
+three variables to `Fin 3` is what turns it into Mathlib's `FormalGroup.assoc` field. -/
+theorem assoc_formalAdd :
+    subst (Sum.elim
+        (fun _ ↦ subst (Sum.elim
+            (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O))
+            (fun _ ↦ X (Sum.inr (Sum.inl ()))) :
+              Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
+          (formalAdd W))
+        (fun _ ↦ X (Sum.inr (Sum.inr ()))) :
+          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
+      (formalAdd W) =
+    subst (Sum.elim
+        (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O))
+        (fun _ ↦ subst (Sum.elim
+            (fun _ ↦ (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O))
+            (fun _ ↦ X (Sum.inr (Sum.inr ()))) :
+              Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
+          (formalAdd W)) :
+          Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O)
+      (formalAdd W) := by
+  have h := congrArg (MvPowerSeries.map W.specialize) assoc_formalAdd_universal
+  rw [MvPowerSeries.map_subst (hasSubst_pair
+      (constantCoeff_subst_pair_X_formalAdd Universal.curve _ _) (constantCoeff_X _)),
+    MvPowerSeries.map_subst (hasSubst_pair (constantCoeff_X _)
+      (constantCoeff_subst_pair_X_formalAdd Universal.curve _ _)),
+    ← map_formalAdd] at h
+  refine .trans ?_ (.trans h ?_)
+  all_goals
+    congr 1
+    · funext i
+      rcases i with u | u <;> simp [map_subst_pair_X_formalAdd, map_specialize]
+    · simp [map_specialize]
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -88,42 +88,6 @@ open MvPowerSeries
 
 variable {O : Type*} [CommRing O]
 
-section CoordSpecialize
-
-variable {σ' : Type*} [DecidableEq σ'] [Finite σ']
-
-/-- The substitution sending the coordinate variable `i` to `X` and every other coordinate to `0`.
-
-Specializing to it separates the parameter `i` from all the others, which is how the associativity
-assembly discharges its distinctness hypotheses: by
-`ne_of_subst_eq_X_of_subst_eq_zero`, two series that this substitution sends to `X` and to `0`
-respectively are distinct. -/
-private noncomputable def coordSpecialize (i : σ') : σ' → MvPowerSeries Unit O :=
-  fun j ↦ if j = i then PowerSeries.X else 0
-
-private theorem hasSubst_coordSpecialize (i : σ') : HasSubst (coordSpecialize (O := O) i) :=
-  hasSubst_of_constantCoeff_zero fun j ↦ by
-    simp only [coordSpecialize]
-    split
-    · exact PowerSeries.constantCoeff_X
-    · exact map_zero _
-
-/-- The specialization at `i` sends the `i`-th coordinate to `X`. -/
-private theorem subst_coordSpecialize_X_self (i : σ') :
-    subst (coordSpecialize (O := O) i) (X i : MvPowerSeries σ' O) = PowerSeries.X := by
-  simp [subst_X (hasSubst_coordSpecialize i), coordSpecialize]
-
-/-- The specialization at `i` kills every other coordinate. -/
-private theorem subst_coordSpecialize_X_of_ne {i j : σ'} (h : j ≠ i) :
-    subst (coordSpecialize (O := O) i) (X j : MvPowerSeries σ' O) = 0 := by
-  simp [subst_X (hasSubst_coordSpecialize i), coordSpecialize, h]
-
-/-- The specialization at `i` is a ring map, so it kills `0`. -/
-private theorem subst_coordSpecialize_zero (i : σ') :
-    subst (coordSpecialize (O := O) i) (0 : MvPowerSeries σ' O) = 0 := by
-  rw [← coe_substAlgHom (hasSubst_coordSpecialize i), map_zero]
-
-end CoordSpecialize
 
 /-- The curve `W` base changed to a field `KK` over the series ring `MvPowerSeries σ O`. The
 parameters of the chord construction are series, so the group law they satisfy is the group law of
@@ -349,7 +313,7 @@ private theorem thetaPoint_add (hΔ : (fracCurve W σ KK).Δ ≠ 0)
     rw [← map_mul, ← map_sub]
     exact congrArg ρ (subst_pair_formalIntercept_eq_inl W h₁ h₂)
   have hwTeq : ρ wT = ρ Λp * ρ Tp + ρ Np := by
-    have h := congrArg ρ (subst_pair_online W h₁ h₂)
+    have h := congrArg ρ (subst_pair_formalThirdRoot_formalW W h₁ h₂)
     simp only [map_add, map_mul] at h
     exact h
   have hT₃ : (1 + (fracCurve W σ KK).a₂ * ρ Λp + (fracCurve W σ KK).a₄ * ρ Λp ^ 2 +
@@ -577,13 +541,6 @@ private theorem thetaPoint_add_of_ne (hΔ : (fracCurve W σ KK).Δ ≠ 0)
   rw [subst_pair_formalIntercept_mul_sub W h₁ h₂]
   exact mul_ne_zero hN (sub_ne_zero.mpr hne₁)
 
-/-- A substitution that sends one series to `X` and another to `0` separates them. This is how
-every distinctness hypothesis of the associativity argument is discharged: specialize one of the
-three parameters to `X` and the other two to `0`. -/
-private theorem ne_of_subst_eq_X_of_subst_eq_zero {σ' : Type*}
-    {g : σ' → MvPowerSeries Unit O} {a b : MvPowerSeries σ' O}
-    (ha : subst g a = PowerSeries.X) (hb : subst g b = 0) : a ≠ b := fun hab ↦
-  PowerSeries.X_ne_zero (by rw [← ha, hab]; exact hb)
 
 variable [DecidableEq KK] in
 /-- **The chord addition of parametrized points, from a separating substitution.**

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -77,6 +77,27 @@ theorem algebraMap_subst_formalW_wEquation {q : MvPowerSeries σ O}
   rw [wEquationRHS_def, wEquationRHS_def]
   simp [fracCurve, map_add, map_mul, map_pow]
 
+/-! ### The chord data at the pair -/
+
+/-- The intercept of the chord through the two parametrized points, read at the pair `(q₁, q₂)`:
+`ν(q₁, q₂) = w(q₁) - λ(q₁, q₂) * q₁`. -/
+theorem subst_pair_formalIntercept {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0)
+    (h₂ : constantCoeff q₂ = 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalIntercept W) =
+      PowerSeries.subst q₁ (formalW W) -
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) * q₁ := by
+  have h := congrArg (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+    Unit ⊕ Unit → MvPowerSeries σ O)) (formalIntercept_def W)
+  rw [← coe_substAlgHom (hasSubst_pair h₁ h₂)] at h
+  simp only [map_sub, map_mul] at h
+  simp only [coe_substAlgHom (hasSubst_pair h₁ h₂), subst_pair_toMvPowerSeries_inl W h₁ h₂,
+    subst_X (hasSubst_pair h₁ h₂)] at h
+  have hl : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inl ()) = q₁ := rfl
+  rwa [hl] at h
+
 /-! ### The parametrized point -/
 
 variable [IsDomain O]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -29,6 +29,8 @@ containing them: this file base changes `W` along `O → MvPowerSeries σ O → 
   from either of the two points.
 * `WeierstrassCurve.subst_pair_formalIntercept_mul_sub` : the cross combination
   `q₁ w(q₂) - q₂ w(q₁) = ν(q₁, q₂) * (q₁ - q₂)`, which is what the two readings buy.
+* `WeierstrassCurve.subst_pair_formalThirdRoot_ne_zero` : a nonzero intercept forces a nonzero
+  third root.
 
 ## Provenance
 
@@ -136,6 +138,21 @@ theorem subst_pair_formalIntercept_mul_sub {q₁ q₂ : MvPowerSeries σ O}
         (formalIntercept W) * (q₁ - q₂) := by
   linear_combination q₂ * subst_pair_formalIntercept_eq_inl W h₁ h₂ -
     q₁ * subst_pair_formalIntercept_eq_inr W h₁ h₂
+
+/-- A nonzero intercept forces a nonzero third root: at `z₃ = 0` the on-line identity
+`w(z₃) = λ z₃ + ν` collapses to `0 = ν`, since `w` has no constant term. -/
+theorem subst_pair_formalThirdRoot_ne_zero {q₁ q₂ : MvPowerSeries σ O}
+    (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
+    (hN : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalIntercept W) ≠ 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalThirdRoot W) ≠ 0 := by
+  intro h
+  refine hN ?_
+  have honline := subst_pair_online W h₁ h₂
+  rw [h, show (fun _ : Unit ↦ (0 : MvPowerSeries σ O)) = 0 from rfl,
+    subst_zero_of_constantCoeff_zero (constantCoeff_formalW W)] at honline
+  linear_combination -honline
 
 /-! ### The parametrized point -/
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -38,7 +38,7 @@ supplies one; `map_specialize` carries the conclusion to every `W` over every co
   `q₁ w(q₂) - q₂ w(q₁) = ν(q₁, q₂) * (q₁ - q₂)`, which is what the two readings buy.
 * `WeierstrassCurve.subst_pair_formalThirdRoot_ne_zero` : a nonzero intercept forces a nonzero
   third root.
-* `WeierstrassCurve.assoc_formalAdd` : **the associativity of the addition series**, for every
+* `WeierstrassCurve.formalAdd_assoc` : **the associativity of the addition series**, for every
   Weierstrass curve over every commutative ring. This is the file's terminus, and the last axiom
   of a commutative formal group law that this development was missing — `Add/Fin2.lean` records
   how the three variables get reindexed into the shape of Mathlib's `FormalGroup.assoc` field.
@@ -46,8 +46,8 @@ supplies one; `map_specialize` carries the conclusion to every `W` over every co
 ## Provenance
 
 Adapted from Michael Stoll's `EllipticCurves` project
-(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
-`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0) at commit
+`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`,
 `EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`, sections `Domain` and `Assembly`,
 declarations `subst_wSeries_ne_zero`, `fracCurve`, `rho_weierstrass`, `thetaPoint`,
 `thetaPoint_add`, `thetaPoint_neg`, `thetaPoint_inj` and `pair_intercept_ne_zero_of_ne`, together
@@ -64,9 +64,7 @@ along `PowerSeries.subst q`, not re-derivations of them.
 
 The source's `wSeries` and `vSeries` are `formalW` and `formalU` here, continuing the renaming
 this repository applies to that development, so `subst_wSeries_ne_zero` is
-`subst_formalW_ne_zero`. `FormalGroup/Add/Inverse.lean` records that the source left that lemma
-unported because its only consumers lay in the source's `Assembly` and `Universal` sections;
-this file is the first of them.
+`subst_formalW_ne_zero`.
 
 The `Universal` section of the same file (declarations `universal_Δ_ne_zero` and
 `assoc_addSeries_universal`) is `fracCurve_universal_Δ_ne_zero` and `assoc_formalAdd_universal`
@@ -75,13 +73,11 @@ has them: `universal`, `exists_map_universal` and `universal_Δ_ne_zero` are `Un
 `map_specialize` and `Universal.curve_Δ_ne_zero`, and the source's `X_ne_X` and `X_ne_zero'` are
 Mathlib's `MvPowerSeries.X_inj` and `nonZeroDivisors.ne_zero MvPowerSeries.X_mem_nonzeroDivisors`.
 
-`FormalGroup/Add/Inverse.lean` records that the source's `interceptSeries_ne_zero` and
-`X_pair_intercept_ne_zero` were left unported for want of a consumer, and expects this file to be
-that consumer. It is not, and they stay unported: the source needs them only because it supplies
-the nonvanishing intercept two different ways, an elementary one at a pair of distinct variables
-and `pair_intercept_ne_zero_of_ne` elsewhere. Here `pair_intercept_ne_zero_of_ne` covers the
-variable pairs too, so `thetaPoint_add_of_ne` serves all four chord additions of the assembly and
-the elementary route has no call site.
+The source's `interceptSeries_ne_zero` and `X_pair_intercept_ne_zero` have no counterpart. The
+source needs them only because it supplies the nonvanishing intercept two different ways, an
+elementary one at a pair of distinct variables and `pair_intercept_ne_zero_of_ne` elsewhere; here
+`pair_intercept_ne_zero_of_ne` covers the variable pairs too, so `thetaPoint_add_of_ne` serves
+all four chord additions of the assembly.
 
 The assembly also runs two specializations of the three parameters where the source runs one.
 The source separates the middle parameter from the third with `X_ne_X`, a syntactic argument; the
@@ -146,8 +142,8 @@ end CoordSpecialize
 parameters of the chord construction are series, so the group law they satisfy is the group law of
 this curve. There is no `Algebra O KK` to run `WeierstrassCurve.baseChange` along, so this is the
 composite `map`, and it is Mathlib's `map_*` lemmas that unfolding it exposes. -/
-noncomputable def fracCurve (W : WeierstrassCurve O) (σ : Type*) (KK : Type*) [Field KK]
-    [Algebra (MvPowerSeries σ O) KK] : WeierstrassCurve KK :=
+private noncomputable def fracCurve (W : WeierstrassCurve O) (σ : Type*) (KK : Type*)
+    [CommRing KK] [Algebra (MvPowerSeries σ O) KK] : WeierstrassCurve KK :=
   W.map <| (algebraMap (MvPowerSeries σ O) KK).comp (algebraMap O (MvPowerSeries σ O))
 
 variable (W : WeierstrassCurve O) {σ : Type*} {KK : Type*} [Field KK]
@@ -161,79 +157,13 @@ the parameter and the solution are both read in `KK`, so the coefficients travel
 change too and the curve on the right is `fracCurve W σ KK` rather than `W`. Consumers such as
 `chord_point_nonsingular` want the equation written out, so this is normally applied through
 `simpa [wEquationRHS_def] using …`. -/
-theorem algebraMap_subst_formalW_wEquation {q : MvPowerSeries σ O} (hq : PowerSeries.HasSubst q) :
+private theorem algebraMap_subst_formalW_wEquation {q : MvPowerSeries σ O}
+    (hq : PowerSeries.HasSubst q) :
     algebraMap (MvPowerSeries σ O) KK (PowerSeries.subst q (formalW W)) = wEquationRHS
       (fracCurve W σ KK) (algebraMap (MvPowerSeries σ O) KK q)
       (algebraMap (MvPowerSeries σ O) KK (PowerSeries.subst q (formalW W))) := by
   conv_lhs => rw [subst_formalW_wEquation W hq]
   simp [fracCurve, wEquationRHS_def]
-
-/-! ### The chord data at the pair -/
-
-/-- The intercept of the chord through the two parametrized points, read at the pair `(q₁, q₂)`
-from the first point: `ν(q₁, q₂) = w(q₁) - λ(q₁, q₂) * q₁`.
-
-`subst_pair_formalIntercept_eq_inr` is the same intercept read from the second point; the two
-statements differ only in which parameter appears on the right, and rewriting with either one
-clears the intercept but leaves the slope behind. Combining the two readings is what cancels the
-slope, and that combination is already packaged as `subst_pair_formalIntercept_mul_sub`, so a
-consumer that wants the slope gone should reach for it rather than for these two. -/
-theorem subst_pair_formalIntercept_eq_inl {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0)
-    (h₂ : constantCoeff q₂ = 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-        (formalIntercept W) = PowerSeries.subst q₁ (formalW W) -
-      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-        (formalSlope W) * q₁ := by
-  simp [formalIntercept_def, subst_sub (hasSubst_pair h₁ h₂), subst_mul (hasSubst_pair h₁ h₂),
-    subst_pair_toMvPowerSeries_inl W h₁ h₂, subst_X (hasSubst_pair h₁ h₂)]
-
-/-- The same intercept read from the second point: `ν(q₁, q₂) = w(q₂) - λ(q₁, q₂) * q₂`. Together
-with `subst_pair_formalIntercept_eq_inl` this is what expresses `q₁ * w(q₂) - q₂ * w(q₁)` through
-the intercept alone.
-
-The two readings differ only in which parameter appears on the right, and rewriting with either
-one clears the intercept but leaves the slope behind; a consumer that wants the slope gone should
-reach for `subst_pair_formalIntercept_mul_sub`, which packages the combination that cancels it. -/
-theorem subst_pair_formalIntercept_eq_inr {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0)
-    (h₂ : constantCoeff q₂ = 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-        (formalIntercept W) = PowerSeries.subst q₂ (formalW W) -
-      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-        (formalSlope W) * q₂ := by
-  linear_combination subst_pair_formalIntercept_eq_inl W h₁ h₂ + subst_pair_formalSlope_mul W h₁ h₂
-
-/-- The cross combination `q₁ w(q₂) - q₂ w(q₁)` is expressed through the intercept alone:
-`q₁ w(q₂) - q₂ w(q₁) = ν(q₁, q₂) * (q₁ - q₂)`.
-
-Reading the intercept from *both* points is what makes the slope cancel, so this is the one
-intercept identity with no `λ` in it: `subst_pair_formalIntercept_eq_inl` and
-`subst_pair_formalIntercept_eq_inr` each clear the intercept but leave the slope behind. The
-factored `(q₁ - q₂)` on the right is what the associativity assembly needs in order to know that
-the chord's `x`-coordinates are distinct; reach for it there as a single rewrite rather than
-recombining the two readings by hand. -/
-theorem subst_pair_formalIntercept_mul_sub {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0)
-    (h₂ : constantCoeff q₂ = 0) :
-    q₁ * PowerSeries.subst q₂ (formalW W) - q₂ * PowerSeries.subst q₁ (formalW W) =
-      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-        (formalIntercept W) * (q₁ - q₂) := by
-  -- weighting the two readings by `q₂` and `q₁` makes the `λ` terms coincide and cancel
-  linear_combination q₂ * subst_pair_formalIntercept_eq_inl W h₁ h₂ -
-    q₁ * subst_pair_formalIntercept_eq_inr W h₁ h₂
-
-/-- A nonzero intercept forces a nonzero third root: at `z₃ = 0` the on-line identity
-`w(z₃) = λ z₃ + ν` collapses to `0 = ν`, since `w` has no constant term. -/
-theorem subst_pair_formalThirdRoot_ne_zero {q₁ q₂ : MvPowerSeries σ O}
-    (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
-    (hN : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-      (formalIntercept W) ≠ 0) :
-    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-      (formalThirdRoot W) ≠ 0 := by
-  intro h
-  refine hN ?_
-  have honline := subst_pair_online W h₁ h₂
-  rw [h, show (fun _ : Unit ↦ (0 : MvPowerSeries σ O)) = 0 from rfl,
-    subst_zero_of_constantCoeff_zero (constantCoeff_formalW W)] at honline
-  linear_combination -honline
 
 /-! ### The formal inverse at a parameter -/
 
@@ -816,7 +746,7 @@ series ring therefore has a fraction field — and `map_specialize` carries it t
 With `constantCoeff_formalAdd`, `subst_unitR_formalAdd`, `subst_unitL_formalAdd` and
 `rename_swap_formalAdd`, this is the last axiom of a commutative formal group law; reindexing the
 three variables to `Fin 3` is what turns it into Mathlib's `FormalGroup.assoc` field. -/
-theorem assoc_formalAdd :
+theorem formalAdd_assoc :
     subst (Sum.elim
         (fun _ ↦ subst (Sum.elim
             (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) O))

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -23,25 +23,12 @@ associativity of the curve's group law is associativity of the series.
 That argument needs a domain, so it runs over the universal curve, whose base `ℤ[A₁, ⋯, A₆]`
 supplies one; `map_specialize` carries the conclusion to every `W` over every commutative ring.
 
-## Main definitions
-
-* `WeierstrassCurve.fracCurve` : `W` base changed to a field `KK` over the series ring.
-
 ## Main statements
 
-* `WeierstrassCurve.algebraMap_subst_formalW_wEquation` : the substituted `w`-expansion still
-  solves the `w`-equation after being pushed into `KK`, now read on `fracCurve`.
-* `WeierstrassCurve.subst_pair_formalIntercept_eq_inl`,
-  `WeierstrassCurve.subst_pair_formalIntercept_eq_inr` : the chord's intercept at a pair, read
-  from either of the two points.
-* `WeierstrassCurve.subst_pair_formalIntercept_mul_sub` : the cross combination
-  `q₁ w(q₂) - q₂ w(q₁) = ν(q₁, q₂) * (q₁ - q₂)`, which is what the two readings buy.
-* `WeierstrassCurve.subst_pair_formalThirdRoot_ne_zero` : a nonzero intercept forces a nonzero
-  third root.
 * `WeierstrassCurve.formalAdd_assoc` : **the associativity of the addition series**, for every
-  Weierstrass curve over every commutative ring. This is the file's terminus, and the last axiom
-  of a commutative formal group law that this development was missing — `Add/Fin2.lean` records
-  how the three variables get reindexed into the shape of Mathlib's `FormalGroup.assoc` field.
+  Weierstrass curve over every commutative ring. It is this module's only exported result; the
+  fraction-field base change, the parametrized point `θ` and the chord additions it satisfies are
+  private implementation details of its proof.
 
 ## Provenance
 
@@ -239,6 +226,9 @@ private theorem subst_subst_pair_formalAdd_eq_X {σ' : Type*}
     (hga : subst g a = PowerSeries.X) (hgb : subst g b = 0) :
     subst g (subst (Sum.elim (fun _ ↦ a) (fun _ ↦ b) : Unit ⊕ Unit → MvPowerSeries σ' O)
       (formalAdd W)) = PowerSeries.X := by
+  -- The composite family is pointwise `X` and `0`, but only pointwise: the reshape below is
+  -- `funext`, not a definitional equality, and it is needed because `subst_unitR_formalAdd` is
+  -- stated for the `Sum.elim` spelling that `rw` must match syntactically.
   rw [subst_comp_subst_apply (hasSubst_pair ha hb) hg,
     show (fun s : Unit ⊕ Unit ↦ subst g (Sum.elim (fun _ ↦ a) (fun _ ↦ b) s)) =
       (Sum.elim X (fun _ ↦ 0) : Unit ⊕ Unit → MvPowerSeries Unit O) from
@@ -253,6 +243,8 @@ private theorem subst_subst_pair_formalAdd_eq_zero {σ' : Type*}
     (hga : subst g a = 0) (hgb : subst g b = 0) :
     subst g (subst (Sum.elim (fun _ ↦ a) (fun _ ↦ b) : Unit ⊕ Unit → MvPowerSeries σ' O)
       (formalAdd W)) = 0 := by
+  -- As above, the reshape is `funext` rather than defeq: `g` kills both components pointwise,
+  -- and the zero family is what `subst_zero_of_constantCoeff_zero` is stated against.
   rw [subst_comp_subst_apply (hasSubst_pair ha hb) hg,
     show (fun s : Unit ⊕ Unit ↦ subst g (Sum.elim (fun _ ↦ a) (fun _ ↦ b) s)) =
       (0 : Unit ⊕ Unit → MvPowerSeries Unit O) from
@@ -265,6 +257,7 @@ private theorem subst_subst_formalInverse_eq_zero {σ' : Type*}
     {g : σ' → MvPowerSeries Unit O} (hg : HasSubst g) {a : MvPowerSeries σ' O}
     (ha : constantCoeff a = 0) (hga : subst g a = 0) :
     subst g (subst (fun _ : Unit ↦ a) (formalInverse W)) = 0 := by
+  -- `funext` again, on the one-variable family this time.
   rw [subst_comp_subst_apply (hasSubst_of_constantCoeff_zero fun _ ↦ ha) hg,
     show (fun _ : Unit ↦ subst g a) = (0 : Unit → MvPowerSeries Unit O) from
       funext fun _ ↦ hga]
@@ -395,6 +388,9 @@ private theorem thetaPoint_add (hΔ : (fracCurve W σ KK).Δ ≠ 0)
     hw₁0 hw₂0 hwT0 hxρ
     (chord_point_nonsingular (fracCurve W σ KK) hwq₁ hw₁0 hΔ)
     (chord_point_nonsingular (fracCurve W σ KK) hwq₂ hw₂0 hΔ)
+  -- `hadd` is stated with the coordinates written out, and `thetaPoint` is *by definition* that
+  -- `Affine.Point.some`, so this folds the definition back. Unlike the reshapes above this one
+  -- really is a definitional equality, and it breaks if `thetaPoint` is ever restated.
   refine Eq.trans (show W.thetaPoint hΔ h₁ hq₁0 + W.thetaPoint hΔ h₂ hq₂0 =
     Affine.Point.some _ _ h₃ from hadd) ?_
   -- identify the third point with the point of parameter `F(q₁, q₂)`
@@ -743,9 +739,8 @@ The chord construction proves this only where the curve has a group law to borro
 identity is proved for the universal curve — whose base `ℤ[A₁, ⋯, A₆]` is a domain, and whose
 series ring therefore has a fraction field — and `map_specialize` carries it to every `W`.
 
-With `constantCoeff_formalAdd`, `subst_unitR_formalAdd`, `subst_unitL_formalAdd` and
-`rename_swap_formalAdd`, this is the last axiom of a commutative formal group law; reindexing the
-three variables to `Fin 3` is what turns it into Mathlib's `FormalGroup.assoc` field. -/
+The three variables are indexed by `Unit ⊕ Unit ⊕ Unit`, with the two bracketings written as
+nested substitutions of `formalAdd` into itself. -/
 theorem formalAdd_assoc :
     subst (Sum.elim
         (fun _ ↦ subst (Sum.elim

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -365,6 +365,17 @@ private theorem subst_formalW_ne_zero {q : MvPowerSeries σ O} (hq : constantCoe
 
 variable [IsFractionRing (MvPowerSeries σ O) KK]
 
+/-- The `w`-expansion at a nonzero parameter stays nonzero after being pushed into `KK`: the
+localization map of a fraction field is injective, so it cannot introduce a zero.
+
+Every parametrized point of this file needs its `w`-coordinate invertible in `KK`, so this is the
+form `subst_formalW_ne_zero` is actually used in. -/
+private theorem algebraMap_subst_formalW_ne_zero {q : MvPowerSeries σ O}
+    (hq : constantCoeff q = 0) (hq0 : q ≠ 0) :
+    algebraMap (MvPowerSeries σ O) KK (PowerSeries.subst q (formalW W)) ≠ 0 := fun h ↦
+  W.subst_formalW_ne_zero hq hq0
+    (IsFractionRing.injective (MvPowerSeries σ O) KK (by rw [h, map_zero]))
+
 /-- The point of the base-changed curve carried by the parameter `q`: the solution `(q, w(q))` of
 the `w`-equation, read in `KK` and in the affine coordinates `(q / w, -1 / w)` of the chart. -/
 private noncomputable def thetaPoint (hΔ : (fracCurve W σ KK).Δ ≠ 0)
@@ -375,8 +386,7 @@ private noncomputable def thetaPoint (hΔ : (fracCurve W σ KK).Δ ≠ 0)
       simpa [wEquationRHS_def] using
         W.algebraMap_subst_formalW_wEquation (KK := KK)
           (PowerSeries.HasSubst.of_constantCoeff_zero hq))
-    (fun h ↦ W.subst_formalW_ne_zero hq hq0
-      (IsFractionRing.injective (MvPowerSeries σ O) KK (by rw [h, map_zero])))
+    (W.algebraMap_subst_formalW_ne_zero hq hq0)
     hΔ)
 
 variable [DecidableEq KK] in
@@ -434,10 +444,10 @@ private theorem thetaPoint_add (hΔ : (fracCurve W σ KK).Δ ≠ 0)
     refine subst_pair_thirdRootDenom_ne_zero W h₁ h₂ (hinj ?_)
     simpa [fracCurve, MvPowerSeries.c_eq_algebraMap, map_zero] using h
   have hTp0 : Tp ≠ 0 := subst_pair_formalThirdRoot_ne_zero W h₁ h₂ hN
-  have hw₁0 : ρ w₁ ≠ 0 := fun h ↦ W.subst_formalW_ne_zero h₁ hq₁0 (hinj (by rw [h, map_zero]))
-  have hw₂0 : ρ w₂ ≠ 0 := fun h ↦ W.subst_formalW_ne_zero h₂ hq₂0 (hinj (by rw [h, map_zero]))
+  have hw₁0 : ρ w₁ ≠ 0 := W.algebraMap_subst_formalW_ne_zero h₁ hq₁0
+  have hw₂0 : ρ w₂ ≠ 0 := W.algebraMap_subst_formalW_ne_zero h₂ hq₂0
   have hTc : constantCoeff Tp = 0 := constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
-  have hwT0 : ρ wT ≠ 0 := fun h ↦ W.subst_formalW_ne_zero hTc hTp0 (hinj (by rw [h, map_zero]))
+  have hwT0 : ρ wT ≠ 0 := W.algebraMap_subst_formalW_ne_zero hTc hTp0
   have hxρ : ρ q₁ * ρ w₂ - ρ q₂ * ρ w₁ ≠ 0 := by
     rw [← map_mul, ← map_mul, ← map_sub]
     exact fun h ↦ hx (hinj (by rw [h, map_zero]))
@@ -525,9 +535,8 @@ private theorem thetaPoint_neg (hΔ : (fracCurve W σ KK).Δ ≠ 0)
     have h := congrArg ρ (W.subst_formalInverseDenom_eq hs)
     simp only [map_sub, map_mul, map_one, MvPowerSeries.c_eq_algebraMap] at h
     exact h
-  have hw0 : ρ (PowerSeries.subst q (formalW W)) ≠ 0 := fun h ↦
-    W.subst_formalW_ne_zero hq hq0
-      (IsFractionRing.injective (MvPowerSeries σ O) KK (by rw [h, map_zero]))
+  have hw0 : ρ (PowerSeries.subst q (formalW W)) ≠ 0 :=
+    W.algebraMap_subst_formalW_ne_zero hq hq0
   simp only [thetaPoint, Affine.Point.neg_some, Affine.Point.some.injEq]
   simp only [← hρ]
   constructor
@@ -551,10 +560,10 @@ private theorem thetaPoint_inj (hΔ : (fracCurve W σ KK).Δ ≠ 0)
   have hinj : Function.Injective ρ := IsFractionRing.injective (MvPowerSeries σ O) KK
   simp only [thetaPoint, Affine.Point.some.injEq] at h
   simp only [← hρ] at h
-  have hw₁0 : ρ (PowerSeries.subst q₁ (formalW W)) ≠ 0 := fun hh ↦
-    W.subst_formalW_ne_zero h₁ hq₁0 (hinj (by rw [hh, map_zero]))
-  have hw₂0 : ρ (PowerSeries.subst q₂ (formalW W)) ≠ 0 := fun hh ↦
-    W.subst_formalW_ne_zero h₂ hq₂0 (hinj (by rw [hh, map_zero]))
+  have hw₁0 : ρ (PowerSeries.subst q₁ (formalW W)) ≠ 0 :=
+    W.algebraMap_subst_formalW_ne_zero h₁ hq₁0
+  have hw₂0 : ρ (PowerSeries.subst q₂ (formalW W)) ≠ 0 :=
+    W.algebraMap_subst_formalW_ne_zero h₂ hq₂0
   have hw : ρ (PowerSeries.subst q₁ (formalW W)) = ρ (PowerSeries.subst q₂ (formalW W)) := by
     have h2 := h.2
     field_simp at h2
@@ -585,10 +594,10 @@ private theorem pair_intercept_ne_zero_of_ne (hΔ : (fracCurve W σ KK).Δ ≠ 0
   have hqw : q₁ * PowerSeries.subst q₂ (formalW W) -
       q₂ * PowerSeries.subst q₁ (formalW W) = 0 := by
     rw [subst_pair_formalIntercept_mul_sub W h₁ h₂, h0, zero_mul]
-  have hw₁0 : ρ (PowerSeries.subst q₁ (formalW W)) ≠ 0 := fun hh ↦
-    W.subst_formalW_ne_zero h₁ hq₁0 (hinj (by rw [hh, map_zero]))
-  have hw₂0 : ρ (PowerSeries.subst q₂ (formalW W)) ≠ 0 := fun hh ↦
-    W.subst_formalW_ne_zero h₂ hq₂0 (hinj (by rw [hh, map_zero]))
+  have hw₁0 : ρ (PowerSeries.subst q₁ (formalW W)) ≠ 0 :=
+    W.algebraMap_subst_formalW_ne_zero h₁ hq₁0
+  have hw₂0 : ρ (PowerSeries.subst q₂ (formalW W)) ≠ 0 :=
+    W.algebraMap_subst_formalW_ne_zero h₂ hq₂0
   have hx : ρ q₁ / ρ (PowerSeries.subst q₁ (formalW W)) =
       ρ q₂ / ρ (PowerSeries.subst q₂ (formalW W)) := by
     rw [div_eq_div_iff hw₁0 hw₂0, ← map_mul, ← map_mul]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.ThirdPoint
 
 /-!
@@ -206,6 +207,47 @@ private theorem subst_formalW_subst_formalInverse {q : MvPowerSeries σ O}
   rw [← PowerSeries.subst_comp_subst_apply (hasSubst_formalInverse W) hq,
     subst_formalInverse_formalW, ← PowerSeries.coe_substAlgHom hq]
   simp only [map_neg, map_mul]
+
+/-! ### Reading a pair through a further substitution -/
+
+/-- The addition series at a pair, read through a further substitution `g` that sends the first
+parameter to `X` and the second to `0`: the right unit law makes the result `X`. -/
+private theorem subst_subst_pair_formalAdd_eq_X {σ' : Type*}
+    {g : σ' → MvPowerSeries Unit O} (hg : HasSubst g) {a b : MvPowerSeries σ' O}
+    (ha : constantCoeff a = 0) (hb : constantCoeff b = 0)
+    (hga : subst g a = PowerSeries.X) (hgb : subst g b = 0) :
+    subst g (subst (Sum.elim (fun _ ↦ a) (fun _ ↦ b) : Unit ⊕ Unit → MvPowerSeries σ' O)
+      (formalAdd W)) = PowerSeries.X := by
+  rw [subst_comp_subst_apply (hasSubst_pair ha hb) hg,
+    show (fun s : Unit ⊕ Unit ↦ subst g (Sum.elim (fun _ ↦ a) (fun _ ↦ b) s)) =
+      (Sum.elim X (fun _ ↦ 0) : Unit ⊕ Unit → MvPowerSeries Unit O) from
+      funext fun s ↦ by rcases s with u | u; exacts [hga, hgb]]
+  exact subst_unitR_formalAdd W
+
+/-- The addition series at a pair, read through a further substitution `g` that kills both
+parameters: the result vanishes, since the series has no constant term. -/
+private theorem subst_subst_pair_formalAdd_eq_zero {σ' : Type*}
+    {g : σ' → MvPowerSeries Unit O} (hg : HasSubst g) {a b : MvPowerSeries σ' O}
+    (ha : constantCoeff a = 0) (hb : constantCoeff b = 0)
+    (hga : subst g a = 0) (hgb : subst g b = 0) :
+    subst g (subst (Sum.elim (fun _ ↦ a) (fun _ ↦ b) : Unit ⊕ Unit → MvPowerSeries σ' O)
+      (formalAdd W)) = 0 := by
+  rw [subst_comp_subst_apply (hasSubst_pair ha hb) hg,
+    show (fun s : Unit ⊕ Unit ↦ subst g (Sum.elim (fun _ ↦ a) (fun _ ↦ b) s)) =
+      (0 : Unit ⊕ Unit → MvPowerSeries Unit O) from
+      funext fun s ↦ by rcases s with u | u; exacts [hga, hgb]]
+  exact subst_zero_of_constantCoeff_zero (constantCoeff_formalAdd W)
+
+/-- The formal inverse at a parameter, read through a further substitution `g` that kills that
+parameter: the result vanishes, since the inverse has no constant term. -/
+private theorem subst_subst_formalInverse_eq_zero {σ' : Type*}
+    {g : σ' → MvPowerSeries Unit O} (hg : HasSubst g) {a : MvPowerSeries σ' O}
+    (ha : constantCoeff a = 0) (hga : subst g a = 0) :
+    subst g (subst (fun _ : Unit ↦ a) (formalInverse W)) = 0 := by
+  rw [subst_comp_subst_apply (hasSubst_of_constantCoeff_zero fun _ ↦ ha) hg,
+    show (fun _ : Unit ↦ subst g a) = (0 : Unit → MvPowerSeries Unit O) from
+      funext fun _ ↦ hga]
+  exact subst_zero_of_constantCoeff_zero (constantCoeff_formalInverse W)
 
 /-! ### The parametrized point -/
 
@@ -486,6 +528,28 @@ private theorem pair_intercept_ne_zero_of_ne (hΔ : (fracCurve W σ KK).Δ ≠ 0
     have hc' : W.thetaPoint hΔ h₁ hq₁0 = -W.thetaPoint hΔ h₂ hq₂0 := hc
     rw [← W.thetaPoint_neg hΔ h₂ hq₂0 hi hi0] at hc'
     exact hne₂ (W.thetaPoint_inj hΔ h₁ hi hq₁0 hi0 hc')
+
+variable [DecidableEq KK] in
+/-- **The chord addition of parametrized points, from distinctness alone**: `θ(q₁) + θ(q₂) =
+θ(F(q₁, q₂))` as soon as `q₁` is neither `q₂` nor its formal inverse.
+
+This is the form the associativity argument uses. Both nondegeneracy hypotheses of
+`thetaPoint_add` come out of those two: the intercept is nonzero by
+`pair_intercept_ne_zero_of_ne`, and the cross combination is then nonzero too, since
+`subst_pair_formalIntercept_mul_sub` factors it as `ν(q₁, q₂) (q₁ - q₂)`. -/
+private theorem thetaPoint_add_of_ne (hΔ : (fracCurve W σ KK).Δ ≠ 0)
+    {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
+    (hq₁0 : q₁ ≠ 0) (hq₂0 : q₂ ≠ 0) (hne₁ : q₁ ≠ q₂)
+    (hne₂ : q₁ ≠ PowerSeries.subst q₂ (formalInverse W))
+    (hF : constantCoeff (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) = 0)
+    (hF0 : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalAdd W) ≠ 0) :
+    W.thetaPoint hΔ h₁ hq₁0 + W.thetaPoint hΔ h₂ hq₂0 = W.thetaPoint hΔ hF hF0 := by
+  have hN := W.pair_intercept_ne_zero_of_ne hΔ h₁ h₂ hq₁0 hq₂0 hne₁ hne₂
+  refine W.thetaPoint_add hΔ h₁ h₂ hq₁0 hq₂0 hN ?_ hF hF0
+  rw [subst_pair_formalIntercept_mul_sub W h₁ h₂]
+  exact mul_ne_zero hN (sub_ne_zero.mpr hne₁)
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -345,6 +345,55 @@ private theorem thetaPoint_add (hΔ : (fracCurve W σ KK).Δ ≠ 0)
   · rw [hwFeq, div_eq_div_iff hwT0 (neg_ne_zero.mpr (mul_ne_zero hwT0 hsp0))]
     linear_combination (-(ρ wT)) * hu + (ρ wT * ρ sp) * hueq
 
+/-- **The parametrized point of the inverted parameter is the negative**: `θ(ι(q)) = -θ(q)`.
+
+The formal inverse was built to be the parameter of the reflected point, so this identifies that
+construction with the group inverse of `fracCurve W`. Both coordinates come out of the two
+readings of the inverse, `ι(q) = -(q * u(q)⁻¹)` and `w(ι(q)) = -(w(q) * u(q)⁻¹)`. -/
+private theorem thetaPoint_neg (hΔ : (fracCurve W σ KK).Δ ≠ 0)
+    {q : MvPowerSeries σ O} (hq : constantCoeff q = 0) (hq0 : q ≠ 0)
+    (hi : constantCoeff (PowerSeries.subst q (formalInverse W)) = 0)
+    (hi0 : PowerSeries.subst q (formalInverse W) ≠ 0) :
+    W.thetaPoint hΔ hi hi0 = -W.thetaPoint hΔ hq hq0 := by
+  classical
+  set ρ := algebraMap (MvPowerSeries σ O) KK with hρ
+  have hs : PowerSeries.HasSubst q := PowerSeries.HasSubst.of_constantCoeff_zero hq
+  have hu : ρ (PowerSeries.subst q (formalInverseDenom W)) *
+      ρ (PowerSeries.subst q (PowerSeries.invOfUnit (formalInverseDenom W) 1)) = 1 := by
+    rw [← map_mul, ← map_one ρ]
+    exact congrArg ρ (W.subst_formalInverseDenom_mul hs)
+  have hsp0 : ρ (PowerSeries.subst q (PowerSeries.invOfUnit (formalInverseDenom W) 1)) ≠ 0 := by
+    intro h
+    rw [h, mul_zero] at hu
+    exact one_ne_zero hu.symm
+  have hIeq : ρ (PowerSeries.subst q (formalInverse W)) =
+      -(ρ q * ρ (PowerSeries.subst q (PowerSeries.invOfUnit (formalInverseDenom W) 1))) := by
+    have h := congrArg ρ (W.subst_formalInverse_eq hs)
+    simpa only [map_neg, map_mul] using h
+  have hwIeq : ρ (PowerSeries.subst (PowerSeries.subst q (formalInverse W)) (formalW W)) =
+      -(ρ (PowerSeries.subst q (formalW W)) *
+        ρ (PowerSeries.subst q (PowerSeries.invOfUnit (formalInverseDenom W) 1))) := by
+    have h := congrArg ρ (W.subst_formalW_subst_formalInverse hs)
+    simpa only [map_neg, map_mul] using h
+  have hueq : ρ (PowerSeries.subst q (formalInverseDenom W)) =
+      1 - (fracCurve W σ KK).a₁ * ρ q -
+        (fracCurve W σ KK).a₃ * ρ (PowerSeries.subst q (formalW W)) := by
+    have h := congrArg ρ (W.subst_formalInverseDenom_eq hs)
+    simp only [map_sub, map_mul, map_one, MvPowerSeries.c_eq_algebraMap] at h
+    exact h
+  have hw0 : ρ (PowerSeries.subst q (formalW W)) ≠ 0 := fun h ↦
+    W.subst_formalW_ne_zero hq hq0
+      (IsFractionRing.injective (MvPowerSeries σ O) KK (by rw [h, map_zero]))
+  simp only [thetaPoint, Affine.Point.neg_some, Affine.Point.some.injEq]
+  simp only [← hρ]
+  constructor
+  · rw [hIeq, hwIeq]
+    field_simp
+  · rw [hwIeq, Affine.negY]
+    field_simp
+    linear_combination
+      ρ (PowerSeries.subst q (PowerSeries.invOfUnit (formalInverseDenom W) 1)) * hueq - hu
+
 end WeierstrassCurve
 
 end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -52,7 +52,7 @@ Adapted from Michael Stoll's `EllipticCurves` project
 declarations `subst_wSeries_ne_zero`, `fracCurve`, `rho_weierstrass`, `thetaPoint`,
 `thetaPoint_add`, `thetaPoint_neg`, `thetaPoint_inj` and `pair_intercept_ne_zero_of_ne`, together
 with the single-parameter helpers `single_u_mul`, `single_iota_eq`, `single_u_eq` and
-`single_wIota`.
+`single_wIota` from `EllipticCurves/WeierstrassFormalGroup/ThirdPoint.lean`.
 
 Two of those are proved differently here, because this repository already has the content in a
 more usable form. `pair_intercept_ne_zero_of_ne` collapses the cross combination with the single

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -634,7 +634,8 @@ private theorem assoc_formalAdd_universal :
     (i := (Sum.inl () : Unit ⊕ Unit ⊕ Unit)) (j := Sum.inr (Sum.inl ())) (by simp)
   have hχ3 := subst_coordSpecialize_X_of_ne (O := R)
     (i := (Sum.inl () : Unit ⊕ Unit ⊕ Unit)) (j := Sum.inr (Sum.inr ())) (by simp)
-  have hχ0 := subst_coordSpecialize_zero (O := R) (Sum.inl () : Unit ⊕ Unit ⊕ Unit)
+  have hχ0 : subst χ (0 : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 := by
+    rw [← coe_substAlgHom hχ, map_zero]
   -- the second specialization, which separates the middle parameter from the third
   -- the specialization separating the middle parameter from the other two
   set χ' := coordSpecialize (O := R) (Sum.inr (Sum.inl ()) : Unit ⊕ Unit ⊕ Unit) with hχ'def

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -38,7 +38,18 @@ Adapted from Michael Stoll's `EllipticCurves` project
 (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
 `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
 `EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`, sections `Domain` and `Assembly`,
-declarations `subst_wSeries_ne_zero`, `fracCurve`, `rho_weierstrass` and `thetaPoint`.
+declarations `subst_wSeries_ne_zero`, `fracCurve`, `rho_weierstrass`, `thetaPoint`,
+`thetaPoint_add`, `thetaPoint_neg`, `thetaPoint_inj` and `pair_intercept_ne_zero_of_ne`, together
+with the single-parameter helpers `single_u_mul`, `single_iota_eq`, `single_u_eq` and
+`single_wIota`.
+
+Two of those are proved differently here, because this repository already has the content in a
+more usable form. `pair_intercept_ne_zero_of_ne` collapses the cross combination with the single
+rewrite `subst_pair_formalIntercept_mul_sub` where the source combines its two intercept readings
+by hand; and Stoll's `hA` step inside `thetaPoint_add` argues through the constant coefficient,
+whereas `subst_pair_thirdRootDenom_mul` already exhibits an explicit inverse. The four
+single-parameter helpers are likewise transports of the `FormalGroup/Inverse.lean` identities
+along `PowerSeries.subst q`, not re-derivations of them.
 
 The source's `wSeries` and `vSeries` are `formalW` and `formalU` here, continuing the renaming
 this repository applies to that development, so `subst_wSeries_ne_zero` is
@@ -393,6 +404,88 @@ private theorem thetaPoint_neg (hΔ : (fracCurve W σ KK).Δ ≠ 0)
     field_simp
     linear_combination
       ρ (PowerSeries.subst q (PowerSeries.invOfUnit (formalInverseDenom W) 1)) * hueq - hu
+
+/-- **The parametrized point determines the parameter**: `θ` is injective.
+
+The `y`-coordinate `-1 / w(q)` already pins down `w(q)`, and the `x`-coordinate `q / w(q)` then
+pins down `q`. -/
+private theorem thetaPoint_inj (hΔ : (fracCurve W σ KK).Δ ≠ 0)
+    {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
+    (hq₁0 : q₁ ≠ 0) (hq₂0 : q₂ ≠ 0)
+    (h : W.thetaPoint hΔ h₁ hq₁0 = W.thetaPoint hΔ h₂ hq₂0) : q₁ = q₂ := by
+  classical
+  set ρ := algebraMap (MvPowerSeries σ O) KK with hρ
+  have hinj : Function.Injective ρ := IsFractionRing.injective (MvPowerSeries σ O) KK
+  simp only [thetaPoint, Affine.Point.some.injEq] at h
+  simp only [← hρ] at h
+  have hw₁0 : ρ (PowerSeries.subst q₁ (formalW W)) ≠ 0 := fun hh ↦
+    W.subst_formalW_ne_zero h₁ hq₁0 (hinj (by rw [hh, map_zero]))
+  have hw₂0 : ρ (PowerSeries.subst q₂ (formalW W)) ≠ 0 := fun hh ↦
+    W.subst_formalW_ne_zero h₂ hq₂0 (hinj (by rw [hh, map_zero]))
+  have hw : ρ (PowerSeries.subst q₁ (formalW W)) = ρ (PowerSeries.subst q₂ (formalW W)) := by
+    have h2 := h.2
+    field_simp at h2
+    linear_combination h2
+  refine hinj ?_
+  have h1 := h.1
+  rw [div_eq_div_iff hw₁0 hw₂0, hw] at h1
+  exact mul_right_cancel₀ hw₂0 h1
+
+/-- The intercept at a pair is nonzero as soon as the two parameters are distinct and not
+mutually inverse.
+
+If the intercept vanished, the cross combination `q₁ w(q₂) - q₂ w(q₁)` would vanish with it, so
+the two parametrized points would share an `x`-coordinate and hence agree up to sign. Injectivity
+of `θ` then contradicts one of the two hypotheses. -/
+private theorem pair_intercept_ne_zero_of_ne (hΔ : (fracCurve W σ KK).Δ ≠ 0)
+    {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
+    (hq₁0 : q₁ ≠ 0) (hq₂0 : q₂ ≠ 0) (hne₁ : q₁ ≠ q₂)
+    (hne₂ : q₁ ≠ PowerSeries.subst q₂ (formalInverse W)) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalIntercept W) ≠ 0 := by
+  classical
+  intro h0
+  set ρ := algebraMap (MvPowerSeries σ O) KK with hρ
+  have hinj : Function.Injective ρ := IsFractionRing.injective (MvPowerSeries σ O) KK
+  have hs₂ : PowerSeries.HasSubst q₂ := PowerSeries.HasSubst.of_constantCoeff_zero h₂
+  -- a vanishing intercept collapses the cross combination, so the `x`-coordinates agree
+  have hqw : q₁ * PowerSeries.subst q₂ (formalW W) -
+      q₂ * PowerSeries.subst q₁ (formalW W) = 0 := by
+    rw [subst_pair_formalIntercept_mul_sub W h₁ h₂, h0, zero_mul]
+  have hw₁0 : ρ (PowerSeries.subst q₁ (formalW W)) ≠ 0 := fun hh ↦
+    W.subst_formalW_ne_zero h₁ hq₁0 (hinj (by rw [hh, map_zero]))
+  have hw₂0 : ρ (PowerSeries.subst q₂ (formalW W)) ≠ 0 := fun hh ↦
+    W.subst_formalW_ne_zero h₂ hq₂0 (hinj (by rw [hh, map_zero]))
+  have hx : ρ q₁ / ρ (PowerSeries.subst q₁ (formalW W)) =
+      ρ q₂ / ρ (PowerSeries.subst q₂ (formalW W)) := by
+    rw [div_eq_div_iff hw₁0 hw₂0, ← map_mul, ← map_mul]
+    exact congrArg ρ (by linear_combination hqw)
+  have hcase := (Affine.Point.X_eq_iff
+    (h₁ := chord_point_nonsingular (fracCurve W σ KK)
+      (by
+        simpa [wEquationRHS_def] using W.algebraMap_subst_formalW_wEquation (KK := KK)
+          (PowerSeries.HasSubst.of_constantCoeff_zero h₁))
+      hw₁0 hΔ)
+    (h₂ := chord_point_nonsingular (fracCurve W σ KK)
+      (by simpa [wEquationRHS_def] using W.algebraMap_subst_formalW_wEquation (KK := KK) hs₂)
+      hw₂0 hΔ)).mp hx
+  -- the data carried by the inverted parameter
+  have hs0 : PowerSeries.subst q₂ (PowerSeries.invOfUnit (formalInverseDenom W) 1) ≠ 0 := by
+    intro hh
+    have hmul := W.subst_formalInverseDenom_mul hs₂
+    rw [hh, mul_zero] at hmul
+    exact one_ne_zero hmul.symm
+  have hi : constantCoeff (PowerSeries.subst q₂ (formalInverse W)) = 0 :=
+    PowerSeries.constantCoeff_subst_eq_zero h₂ (formalInverse W) (constantCoeff_formalInverse W)
+  have hi0 : PowerSeries.subst q₂ (formalInverse W) ≠ 0 := by
+    rw [W.subst_formalInverse_eq hs₂]
+    exact neg_ne_zero.mpr (mul_ne_zero hq₂0 hs0)
+  rcases hcase with hc | hc
+  · exact hne₁ (W.thetaPoint_inj hΔ h₁ h₂ hq₁0 hq₂0 hc)
+  · -- `hc` comes out of `X_eq_iff` with `thetaPoint` unfolded, so fold it back before rewriting
+    have hc' : W.thetaPoint hΔ h₁ hq₁0 = -W.thetaPoint hΔ h₂ hq₂0 := hc
+    rw [← W.thetaPoint_neg hΔ h₂ hq₂0 hi hi0] at hc'
+    exact hne₂ (W.thetaPoint_inj hΔ h₁ hi hq₁0 hi0 hc')
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -5,10 +5,11 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
-public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
-public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.ThirdPoint
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Series
+import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
+import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
+import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
+import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.ThirdPoint
 
 /-!
 # The chord group law over the fraction field of the series ring

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -105,6 +105,43 @@ open MvPowerSeries
 
 variable {O : Type*} [CommRing O]
 
+section CoordSpecialize
+
+variable {σ' : Type*} [DecidableEq σ'] [Finite σ']
+
+/-- The substitution sending the coordinate variable `i` to `X` and every other coordinate to `0`.
+
+Specializing to it separates the parameter `i` from all the others, which is how the associativity
+assembly discharges its distinctness hypotheses: by
+`ne_of_subst_eq_X_of_subst_eq_zero`, two series that this substitution sends to `X` and to `0`
+respectively are distinct. -/
+private noncomputable def coordSpecialize (i : σ') : σ' → MvPowerSeries Unit O :=
+  fun j ↦ if j = i then PowerSeries.X else 0
+
+private theorem hasSubst_coordSpecialize (i : σ') : HasSubst (coordSpecialize (O := O) i) :=
+  hasSubst_of_constantCoeff_zero fun j ↦ by
+    simp only [coordSpecialize]
+    split
+    · exact PowerSeries.constantCoeff_X
+    · exact map_zero _
+
+/-- The specialization at `i` sends the `i`-th coordinate to `X`. -/
+private theorem subst_coordSpecialize_X_self (i : σ') :
+    subst (coordSpecialize (O := O) i) (X i : MvPowerSeries σ' O) = PowerSeries.X := by
+  simp [subst_X (hasSubst_coordSpecialize i), coordSpecialize]
+
+/-- The specialization at `i` kills every other coordinate. -/
+private theorem subst_coordSpecialize_X_of_ne {i j : σ'} (h : j ≠ i) :
+    subst (coordSpecialize (O := O) i) (X j : MvPowerSeries σ' O) = 0 := by
+  simp [subst_X (hasSubst_coordSpecialize i), coordSpecialize, h]
+
+/-- The specialization at `i` is a ring map, so it kills `0`. -/
+private theorem subst_coordSpecialize_zero (i : σ') :
+    subst (coordSpecialize (O := O) i) (0 : MvPowerSeries σ' O) = 0 := by
+  rw [← coe_substAlgHom (hasSubst_coordSpecialize i), map_zero]
+
+end CoordSpecialize
+
 /-- The curve `W` base changed to a field `KK` over the series ring `MvPowerSeries σ O`. The
 parameters of the chord construction are series, so the group law they satisfy is the group law of
 this curve. There is no `Algebra O KK` to run `WeierstrassCurve.baseChange` along, so this is the
@@ -613,6 +650,26 @@ private theorem ne_of_subst_eq_X_of_subst_eq_zero {σ' : Type*}
     (ha : subst g a = PowerSeries.X) (hb : subst g b = 0) : a ≠ b := fun hab ↦
   PowerSeries.X_ne_zero (by rw [← ha, hab]; exact hb)
 
+variable [DecidableEq KK] in
+/-- **The chord addition of parametrized points, from a separating substitution.**
+
+A single substitution sending `q₁` to `X` and `q₂` to `0` supplies both distinctness hypotheses of
+`thetaPoint_add_of_ne` at once: `q₁ ≠ q₂` directly, and `q₁ ≠ ι(q₂)` because the formal inverse of
+`q₂` has no constant term either, so the substitution kills it too. This is the form the
+associativity assembly uses, where the separating substitution is a `coordSpecialize`. -/
+private theorem thetaPoint_add_of_subst_separates (hΔ : (fracCurve W σ KK).Δ ≠ 0)
+    {g : σ → MvPowerSeries Unit O} (hg : HasSubst g)
+    {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
+    (hq₁0 : q₁ ≠ 0) (hq₂0 : q₂ ≠ 0)
+    (hg₁ : subst g q₁ = PowerSeries.X) (hg₂ : subst g q₂ = 0)
+    (hF : constantCoeff (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) = 0)
+    (hF0 : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalAdd W) ≠ 0) :
+    W.thetaPoint hΔ h₁ hq₁0 + W.thetaPoint hΔ h₂ hq₂0 = W.thetaPoint hΔ hF hF0 :=
+  W.thetaPoint_add_of_ne hΔ h₁ h₂ hq₁0 hq₂0 (ne_of_subst_eq_X_of_subst_eq_zero hg₁ hg₂)
+    (ne_of_subst_eq_X_of_subst_eq_zero hg₁ (subst_subst_formalInverse_eq_zero W hg h₂ hg₂)) hF hF0
+
 /-! ### Associativity -/
 
 /-- The universal curve stays nonsingular over the fraction field of its series ring: `Δ` is a
@@ -664,13 +721,9 @@ private theorem assoc_formalAdd_universal :
   classical
   set R := MvPolynomial Coeff ℤ with hR
   set KK := FractionRing (MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) with hKK
-  set χ := (Sum.elim (fun _ ↦ (PowerSeries.X : PowerSeries R)) (fun _ ↦ 0) :
-    Unit ⊕ Unit ⊕ Unit → MvPowerSeries Unit R) with hχdef
-  have hχ : HasSubst χ :=
-    hasSubst_of_constantCoeff_zero (by
-      rintro (j | j)
-      · exact PowerSeries.constantCoeff_X
-      · simp [hχdef])
+  -- the specialization separating the first parameter from the other two
+  set χ := coordSpecialize (O := R) (Sum.inl () : Unit ⊕ Unit ⊕ Unit) with hχdef
+  have hχ : HasSubst χ := hasSubst_coordSpecialize _
   have hΔ := fracCurve_universal_Δ_ne_zero KK
   have hc₁ : constantCoeff (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 :=
     constantCoeff_X _
@@ -684,29 +737,19 @@ private theorem assoc_formalAdd_universal :
     nonZeroDivisors.ne_zero X_mem_nonzeroDivisors
   have h30 : (X (Sum.inr (Sum.inr ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) ≠ 0 :=
     nonZeroDivisors.ne_zero X_mem_nonzeroDivisors
-  have hχ1 : subst χ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = PowerSeries.X := by
-    rw [subst_X hχ]; rfl
-  have hχ2 : subst χ (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 := by
-    rw [subst_X hχ]; rfl
-  have hχ3 : subst χ (X (Sum.inr (Sum.inr ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 := by
-    rw [subst_X hχ]; rfl
-  have hχ0 : subst χ (0 : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 := by
-    rw [← coe_substAlgHom hχ, map_zero]
+  have hχ1 := subst_coordSpecialize_X_self (O := R) (Sum.inl () : Unit ⊕ Unit ⊕ Unit)
+  have hχ2 := subst_coordSpecialize_X_of_ne (O := R)
+    (i := (Sum.inl () : Unit ⊕ Unit ⊕ Unit)) (j := Sum.inr (Sum.inl ())) (by simp)
+  have hχ3 := subst_coordSpecialize_X_of_ne (O := R)
+    (i := (Sum.inl () : Unit ⊕ Unit ⊕ Unit)) (j := Sum.inr (Sum.inr ())) (by simp)
+  have hχ0 := subst_coordSpecialize_zero (O := R) (Sum.inl () : Unit ⊕ Unit ⊕ Unit)
   -- the second specialization, which separates the middle parameter from the third
-  set χ' := (Sum.elim (fun _ ↦ (0 : MvPowerSeries Unit R))
-    (Sum.elim (fun _ ↦ (PowerSeries.X : PowerSeries R)) fun _ ↦ 0) :
-    Unit ⊕ Unit ⊕ Unit → MvPowerSeries Unit R) with hχ'def
-  have hχ' : HasSubst χ' :=
-    hasSubst_of_constantCoeff_zero (by
-      rintro (j | j | j)
-      · simp [hχ'def]
-      · exact PowerSeries.constantCoeff_X
-      · simp [hχ'def])
-  have hχ'2 : subst χ' (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) =
-      PowerSeries.X := by
-    rw [subst_X hχ']; rfl
-  have hχ'3 : subst χ' (X (Sum.inr (Sum.inr ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 := by
-    rw [subst_X hχ']; rfl
+  -- the specialization separating the middle parameter from the other two
+  set χ' := coordSpecialize (O := R) (Sum.inr (Sum.inl ()) : Unit ⊕ Unit ⊕ Unit) with hχ'def
+  have hχ' : HasSubst χ' := hasSubst_coordSpecialize _
+  have hχ'2 := subst_coordSpecialize_X_self (O := R) (Sum.inr (Sum.inl ()) : Unit ⊕ Unit ⊕ Unit)
+  have hχ'3 := subst_coordSpecialize_X_of_ne (O := R)
+    (i := (Sum.inr (Sum.inl ()) : Unit ⊕ Unit ⊕ Unit)) (j := Sum.inr (Sum.inr ())) (by simp)
   -- the two inner sums
   set F₁₂ := subst (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
     (fun _ ↦ X (Sum.inr (Sum.inl ()))) : Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)
@@ -723,47 +766,13 @@ private theorem assoc_formalAdd_universal :
     subst_subst_pair_formalAdd_eq_X Universal.curve hχ hc₁ hc₂ hχ1 hχ2
   have hχF₂₃ : subst χ F₂₃ = 0 :=
     subst_subst_pair_formalAdd_eq_zero Universal.curve hχ hc₂ hc₃ hχ2 hχ3
-  -- the addition series itself is nonzero, and so is the sum of the last two parameters
-  have hFne : formalAdd Universal.curve ≠ 0 := by
-    intro h
-    have h2 := subst_unitR_formalAdd Universal.curve
-    rw [h, ← coe_substAlgHom (hasSubst_of_constantCoeff_zero
-      (by rintro (j | j) <;> simp : ∀ i, constantCoeff
-        ((Sum.elim X (fun _ ↦ 0) : Unit ⊕ Unit → MvPowerSeries Unit R) i) = 0)), map_zero] at h2
-    exact PowerSeries.X_ne_zero h2.symm
+  -- each inner sum is nonzero: the specialization that separates its own two parameters
+  -- sends it to `X`, and `X ≠ 0`
+  have hχ'0 : subst χ' (0 : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) = 0 := by
+    rw [← coe_substAlgHom hχ', map_zero]
   have hF₁₂0 : F₁₂ ≠ 0 := ne_of_subst_eq_X_of_subst_eq_zero hχF₁₂ hχ0
-  have hF₂₃0 : F₂₃ ≠ 0 := by
-    have hfam : (Sum.elim
-        (fun _ ↦ (X (Sum.inr (Sum.inl ())) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-        (fun _ ↦ X (Sum.inr (Sum.inr ()))) : Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R) =
-        X ∘ (Sum.elim (fun _ ↦ Sum.inr (Sum.inl ())) fun _ ↦ Sum.inr (Sum.inr ()) :
-          Unit ⊕ Unit → Unit ⊕ Unit ⊕ Unit) := by
-      funext s
-      rcases s with u | u <;> rfl
-    rw [hF₂₃def, hfam, ← rename_eq_subst]
-    intro h0
-    refine hFne (rename_injective (⟨Sum.elim (fun _ ↦ Sum.inr (Sum.inl ()))
-      fun _ ↦ Sum.inr (Sum.inr ()), ?_⟩ : Unit ⊕ Unit ↪ Unit ⊕ Unit ⊕ Unit) ?_)
-    · rintro (⟨⟩ | ⟨⟩) (⟨⟩ | ⟨⟩) hv
-      · rfl
-      · exact absurd hv (by simp)
-      · exact absurd hv (by simp)
-      · rfl
-    · rw [map_zero]
-      exact h0
-  -- distinctness: each pair is separated by one of the two specializations
-  have hne₁₂ := ne_of_subst_eq_X_of_subst_eq_zero hχ1 hχ2
-  have hne₁₂ι := ne_of_subst_eq_X_of_subst_eq_zero hχ1
-    (subst_subst_formalInverse_eq_zero Universal.curve hχ hc₂ hχ2)
-  have hne₂₃ := ne_of_subst_eq_X_of_subst_eq_zero hχ'2 hχ'3
-  have hne₂₃ι := ne_of_subst_eq_X_of_subst_eq_zero hχ'2
-    (subst_subst_formalInverse_eq_zero Universal.curve hχ' hc₃ hχ'3)
-  have hneL := ne_of_subst_eq_X_of_subst_eq_zero hχF₁₂ hχ3
-  have hneLι := ne_of_subst_eq_X_of_subst_eq_zero hχF₁₂
-    (subst_subst_formalInverse_eq_zero Universal.curve hχ hc₃ hχ3)
-  have hneR := ne_of_subst_eq_X_of_subst_eq_zero hχ1 hχF₂₃
-  have hneRι := ne_of_subst_eq_X_of_subst_eq_zero hχ1
-    (subst_subst_formalInverse_eq_zero Universal.curve hχ hF₂₃c hχF₂₃)
+  have hF₂₃0 : F₂₃ ≠ 0 := ne_of_subst_eq_X_of_subst_eq_zero
+    (subst_subst_pair_formalAdd_eq_X Universal.curve hχ' hc₂ hc₃ hχ'2 hχ'3) hχ'0
   -- the two bracketed sums are again legitimate parameters
   have hLc := constantCoeff_subst_eq_zero (hasSubst_pair hF₁₂c hc₃)
     (by rintro (j | j) <;> simp [hF₁₂c]) (constantCoeff_formalAdd Universal.curve)
@@ -773,15 +782,16 @@ private theorem assoc_formalAdd_universal :
     (subst_subst_pair_formalAdd_eq_X Universal.curve hχ hF₁₂c hc₃ hχF₁₂ hχ3) hχ0
   have hR0 := ne_of_subst_eq_X_of_subst_eq_zero
     (subst_subst_pair_formalAdd_eq_X Universal.curve hχ hc₁ hF₂₃c hχ1 hχF₂₃) hχ0
-  -- the θ-chain: both bracketings compute the same sum of three points
-  have e₁₂ := thetaPoint_add_of_ne Universal.curve (KK := KK) hΔ hc₁ hc₂ h10 h20 hne₁₂ hne₁₂ι
-    hF₁₂c hF₁₂0
-  have e₂₃ := thetaPoint_add_of_ne Universal.curve (KK := KK) hΔ hc₂ hc₃ h20 h30 hne₂₃ hne₂₃ι
-    hF₂₃c hF₂₃0
-  have eL := thetaPoint_add_of_ne Universal.curve (KK := KK) hΔ hF₁₂c hc₃ hF₁₂0 h30 hneL hneLι
-    hLc hL0
-  have eR := thetaPoint_add_of_ne Universal.curve (KK := KK) hΔ hc₁ hF₂₃c h10 hF₂₃0 hneR hneRι
-    hRc hR0
+  -- the θ-chain: both bracketings compute the same sum of three points, each addition licensed
+  -- by the specialization that separates its two summands
+  have e₁₂ := thetaPoint_add_of_subst_separates Universal.curve (KK := KK) hΔ hχ hc₁ hc₂ h10 h20
+    hχ1 hχ2 hF₁₂c hF₁₂0
+  have e₂₃ := thetaPoint_add_of_subst_separates Universal.curve (KK := KK) hΔ hχ' hc₂ hc₃ h20 h30
+    hχ'2 hχ'3 hF₂₃c hF₂₃0
+  have eL := thetaPoint_add_of_subst_separates Universal.curve (KK := KK) hΔ hχ hF₁₂c hc₃ hF₁₂0
+    h30 hχF₁₂ hχ3 hLc hL0
+  have eR := thetaPoint_add_of_subst_separates Universal.curve (KK := KK) hΔ hχ hc₁ hF₂₃c h10
+    hF₂₃0 hχ1 hχF₂₃ hRc hR0
   have hpts : Universal.curve.thetaPoint hΔ hLc hL0 = Universal.curve.thetaPoint hΔ hRc hR0 := by
     rw [← eL, ← e₁₂, ← eR, ← e₂₃, add_assoc]
   exact thetaPoint_inj Universal.curve hΔ hLc hRc hL0 hR0 hpts

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -193,6 +193,116 @@ private noncomputable def thetaPoint (hΔ : (fracCurve W σ KK).Δ ≠ 0)
       (IsFractionRing.injective (MvPowerSeries σ O) KK (by rw [h, map_zero])))
     hΔ)
 
+variable [DecidableEq KK] in
+/-- **The chord addition of parametrized points**: `θ(q₁) + θ(q₂) = θ(F(q₁, q₂))`.
+
+The two parametrized points lie on `fracCurve W`, the chord through them meets the curve again at
+the parameter `z₃`, and the addition series is exactly the reflection of that third point. So the
+group law of an honest Weierstrass curve, applied to the two points, computes `F(q₁, q₂)`. -/
+private theorem thetaPoint_add (hΔ : (fracCurve W σ KK).Δ ≠ 0)
+    {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
+    (hq₁0 : q₁ ≠ 0) (hq₂0 : q₂ ≠ 0)
+    (hN : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalIntercept W) ≠ 0)
+    (hx : q₁ * PowerSeries.subst q₂ (formalW W) - q₂ * PowerSeries.subst q₁ (formalW W) ≠ 0)
+    (hF : constantCoeff (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) = 0)
+    (hF0 : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalAdd W) ≠ 0) :
+    W.thetaPoint hΔ h₁ hq₁0 + W.thetaPoint hΔ h₂ hq₂0 = W.thetaPoint hΔ hF hF0 := by
+  classical
+  set ρ := algebraMap (MvPowerSeries σ O) KK with hρ
+  have hinj : Function.Injective ρ := IsFractionRing.injective (MvPowerSeries σ O) KK
+  set Λp := subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+    Unit ⊕ Unit → MvPowerSeries σ O) (formalSlope W) with hΛp
+  set Np := subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+    Unit ⊕ Unit → MvPowerSeries σ O) (formalIntercept W) with hNp
+  set Tp := subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+    Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W) with hTp
+  set w₁ := PowerSeries.subst q₁ (formalW W) with hw₁'
+  set w₂ := PowerSeries.subst q₂ (formalW W) with hw₂'
+  set wT := PowerSeries.subst Tp (formalW W) with hwT'
+  -- the chord identities, read in `KK`
+  have hslope : ρ Λp * (ρ q₂ - ρ q₁) = ρ w₂ - ρ w₁ := by
+    rw [← map_sub, ← map_sub, ← map_mul]
+    exact congrArg ρ (subst_pair_formalSlope_mul W h₁ h₂)
+  have hNint : ρ Np = ρ w₁ - ρ Λp * ρ q₁ := by
+    rw [← map_mul, ← map_sub]
+    exact congrArg ρ (subst_pair_formalIntercept_eq_inl W h₁ h₂)
+  have hwTeq : ρ wT = ρ Λp * ρ Tp + ρ Np := by
+    have h := congrArg ρ (subst_pair_online W h₁ h₂)
+    simp only [map_add, map_mul] at h
+    exact h
+  have hT₃ : (1 + (fracCurve W σ KK).a₂ * ρ Λp + (fracCurve W σ KK).a₄ * ρ Λp ^ 2 +
+      (fracCurve W σ KK).a₆ * ρ Λp ^ 3) * (ρ Tp + ρ q₁ + ρ q₂) =
+      -((fracCurve W σ KK).a₁ * ρ Λp + (fracCurve W σ KK).a₂ * ρ Np +
+        (fracCurve W σ KK).a₃ * ρ Λp ^ 2 + 2 * (fracCurve W σ KK).a₄ * ρ Λp * ρ Np +
+        3 * (fracCurve W σ KK).a₆ * ρ Λp ^ 2 * ρ Np) := by
+    have h := congrArg ρ (subst_pair_formalThirdRoot_relation W h₁ h₂)
+    simp only [map_add, map_mul, map_neg, map_pow, map_one, map_ofNat] at h
+    simpa [fracCurve, MvPowerSeries.c_eq_algebraMap] using h
+  -- nonvanishing
+  have hA : (1 + (fracCurve W σ KK).a₂ * ρ Λp + (fracCurve W σ KK).a₄ * ρ Λp ^ 2 +
+      (fracCurve W σ KK).a₆ * ρ Λp ^ 3) ≠ 0 := by
+    intro h
+    refine subst_pair_thirdRootDenom_ne_zero W h₁ h₂ (hinj ?_)
+    simpa [fracCurve, MvPowerSeries.c_eq_algebraMap, map_zero] using h
+  have hTp0 : Tp ≠ 0 := subst_pair_formalThirdRoot_ne_zero W h₁ h₂ hN
+  have hw₁0 : ρ w₁ ≠ 0 := fun h ↦ W.subst_formalW_ne_zero h₁ hq₁0 (hinj (by rw [h, map_zero]))
+  have hw₂0 : ρ w₂ ≠ 0 := fun h ↦ W.subst_formalW_ne_zero h₂ hq₂0 (hinj (by rw [h, map_zero]))
+  have hTc : constantCoeff Tp = 0 := constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
+  have hwT0 : ρ wT ≠ 0 := fun h ↦ W.subst_formalW_ne_zero hTc hTp0 (hinj (by rw [h, map_zero]))
+  have hxρ : ρ q₁ * ρ w₂ - ρ q₂ * ρ w₁ ≠ 0 := by
+    rw [← map_mul, ← map_mul, ← map_sub]
+    exact fun h ↦ hx (hinj (by rw [h, map_zero]))
+  -- the two parametrized points satisfy the Weierstrass equation of `fracCurve W`
+  have hwq₁ := by
+    simpa [wEquationRHS_def] using
+      W.algebraMap_subst_formalW_wEquation (KK := KK)
+        (PowerSeries.HasSubst.of_constantCoeff_zero h₁)
+  have hwq₂ := by
+    simpa [wEquationRHS_def] using
+      W.algebraMap_subst_formalW_wEquation (KK := KK)
+        (PowerSeries.HasSubst.of_constantCoeff_zero h₂)
+  -- the honest group law of `fracCurve W`, applied to the two points
+  obtain ⟨h₃, hadd⟩ := chord_point_add (fracCurve W σ KK) hwq₁ hwq₂ hslope hNint hT₃ hwTeq hA
+    hw₁0 hw₂0 hwT0 hxρ
+    (chord_point_nonsingular (fracCurve W σ KK) hwq₁ hw₁0 hΔ)
+    (chord_point_nonsingular (fracCurve W σ KK) hwq₂ hw₂0 hΔ)
+  refine Eq.trans (show W.thetaPoint hΔ h₁ hq₁0 + W.thetaPoint hΔ h₂ hq₂0 =
+    Affine.Point.some _ _ h₃ from hadd) ?_
+  -- identify the third point with the point of parameter `F(q₁, q₂)`
+  set sp := PowerSeries.subst Tp (PowerSeries.invOfUnit (formalInverseDenom W) 1) with hsp'
+  have hu : ρ (PowerSeries.subst Tp (formalInverseDenom W)) * ρ sp = 1 := by
+    rw [← map_mul, ← map_one ρ]
+    exact congrArg ρ (subst_pair_formalInverseDenom_mul W h₁ h₂)
+  have hueq : ρ (PowerSeries.subst Tp (formalInverseDenom W)) =
+      1 - (fracCurve W σ KK).a₁ * ρ Tp - (fracCurve W σ KK).a₃ * ρ wT := by
+    have h := congrArg ρ (subst_pair_formalInverseDenom_eq W h₁ h₂)
+    simp only [map_sub, map_mul, map_one, MvPowerSeries.c_eq_algebraMap] at h
+    exact h
+  have hsp0 : ρ sp ≠ 0 := by
+    intro h
+    rw [h, mul_zero] at hu
+    exact one_ne_zero hu.symm
+  have hFeq : ρ (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) = -(ρ Tp * ρ sp) := by
+    have h := congrArg ρ (subst_pair_formalAdd_eq W h₁ h₂)
+    simp only [map_neg, map_mul] at h
+    exact h
+  have hwFeq : ρ (PowerSeries.subst (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) (formalW W)) = -(ρ wT * ρ sp) := by
+    have h := congrArg ρ (subst_pair_formalW_formalAdd W h₁ h₂)
+    simp only [map_neg, map_mul] at h
+    exact h
+  rw [thetaPoint]
+  simp only [Affine.Point.some.injEq]
+  constructor
+  · rw [hFeq, hwFeq]
+    field_simp
+  · rw [hwFeq, div_eq_div_iff hwT0 (neg_ne_zero.mpr (mul_ne_zero hwT0 hsp0))]
+    linear_combination (-(ρ wT)) * hu + (ρ wT * ρ sp) * hueq
+
 end WeierstrassCurve
 
 end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -24,6 +24,11 @@ containing them: this file base changes `W` along `O → MvPowerSeries σ O → 
 
 * `WeierstrassCurve.algebraMap_subst_formalW_wEquation` : the substituted `w`-expansion still
   solves the `w`-equation after being pushed into `KK`, now read on `fracCurve`.
+* `WeierstrassCurve.subst_pair_formalIntercept_eq_inl`,
+  `WeierstrassCurve.subst_pair_formalIntercept_eq_inr` : the chord's intercept at a pair, read
+  from either of the two points.
+* `WeierstrassCurve.subst_pair_formalIntercept_mul_sub` : the cross combination
+  `q₁ w(q₂) - q₂ w(q₁) = ν(q₁, q₂) * (q₁ - q₂)`, which is what the two readings buy.
 
 ## Provenance
 
@@ -117,6 +122,20 @@ theorem subst_pair_formalIntercept_eq_inr {q₁ q₂ : MvPowerSeries σ O} (h₁
   have hr : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
       Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inr ()) = q₂ := rfl
   rwa [hr] at h
+
+/-- The cross combination `q₁ w(q₂) - q₂ w(q₁)` is expressed through the intercept alone:
+`q₁ w(q₂) - q₂ w(q₁) = ν(q₁, q₂) * (q₁ - q₂)`.
+
+Reading the intercept from *both* points is what makes the slope cancel: subtracting the two
+readings weighted by `q₂` and `q₁` removes `λ` entirely. This is the form the associativity
+assembly needs in order to know that the chord's `x`-coordinates are distinct. -/
+theorem subst_pair_formalIntercept_mul_sub {q₁ q₂ : MvPowerSeries σ O}
+    (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    q₁ * PowerSeries.subst q₂ (formalW W) - q₂ * PowerSeries.subst q₁ (formalW W) =
+      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalIntercept W) * (q₁ - q₂) := by
+  linear_combination q₂ * subst_pair_formalIntercept_eq_inl W h₁ h₂ -
+    q₁ * subst_pair_formalIntercept_eq_inr W h₁ h₂
 
 /-! ### The parametrized point -/
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -79,9 +79,9 @@ theorem algebraMap_subst_formalW_wEquation {q : MvPowerSeries σ O}
 
 /-! ### The chord data at the pair -/
 
-/-- The intercept of the chord through the two parametrized points, read at the pair `(q₁, q₂)`:
-`ν(q₁, q₂) = w(q₁) - λ(q₁, q₂) * q₁`. -/
-theorem subst_pair_formalIntercept {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0)
+/-- The intercept of the chord through the two parametrized points, read at the pair `(q₁, q₂)`
+from the first point: `ν(q₁, q₂) = w(q₁) - λ(q₁, q₂) * q₁`. -/
+theorem subst_pair_formalIntercept_eq_inl {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
     subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
         (formalIntercept W) =
@@ -97,6 +97,26 @@ theorem subst_pair_formalIntercept {q₁ q₂ : MvPowerSeries σ O} (h₁ : cons
   have hl : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
       Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inl ()) = q₁ := rfl
   rwa [hl] at h
+
+/-- The same intercept read from the second point: `ν(q₁, q₂) = w(q₂) - λ(q₁, q₂) * q₂`. Together
+with `subst_pair_formalIntercept_eq_inl` this is what expresses `q₁ * w(q₂) - q₂ * w(q₁)` through
+the intercept alone. -/
+theorem subst_pair_formalIntercept_eq_inr {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0)
+    (h₂ : constantCoeff q₂ = 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalIntercept W) =
+      PowerSeries.subst q₂ (formalW W) -
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) * q₂ := by
+  have h := congrArg (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+    Unit ⊕ Unit → MvPowerSeries σ O)) (formalIntercept_eq_inr W)
+  rw [← coe_substAlgHom (hasSubst_pair h₁ h₂)] at h
+  simp only [map_sub, map_mul] at h
+  simp only [coe_substAlgHom (hasSubst_pair h₁ h₂), subst_pair_toMvPowerSeries_inr W h₁ h₂,
+    subst_X (hasSubst_pair h₁ h₂)] at h
+  have hr : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inr ()) = q₂ := rfl
+  rwa [hr] at h
 
 /-! ### The parametrized point -/
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -107,77 +107,79 @@ variable {O : Type*} [CommRing O]
 
 /-- The curve `W` base changed to a field `KK` over the series ring `MvPowerSeries σ O`. The
 parameters of the chord construction are series, so the group law they satisfy is the group law of
-this curve. -/
+this curve. There is no `Algebra O KK` to run `WeierstrassCurve.baseChange` along, so this is the
+composite `map`, and it is Mathlib's `map_*` lemmas that unfolding it exposes. -/
 noncomputable def fracCurve (W : WeierstrassCurve O) (σ : Type*) (KK : Type*) [Field KK]
     [Algebra (MvPowerSeries σ O) KK] : WeierstrassCurve KK :=
-  W.map ((algebraMap (MvPowerSeries σ O) KK).comp (algebraMap O (MvPowerSeries σ O)))
+  W.map <| (algebraMap (MvPowerSeries σ O) KK).comp (algebraMap O (MvPowerSeries σ O))
 
 variable (W : WeierstrassCurve O) {σ : Type*} {KK : Type*} [Field KK]
   [Algebra (MvPowerSeries σ O) KK]
 
 /-- The `w`-expansion read at a substitutable parameter still solves the `w`-equation after being
-pushed into `KK`, where the equation is the one of `fracCurve W`. -/
-theorem algebraMap_subst_formalW_wEquation {q : MvPowerSeries σ O}
-    (hq : PowerSeries.HasSubst q) :
-    algebraMap (MvPowerSeries σ O) KK (PowerSeries.subst q (formalW W)) =
-      wEquationRHS (fracCurve W σ KK) (algebraMap (MvPowerSeries σ O) KK q)
-        (algebraMap (MvPowerSeries σ O) KK (PowerSeries.subst q (formalW W))) := by
+pushed into `KK`, where the equation is the one of `fracCurve W`.
+
+`subst_formalW_wEquation` is the same fixed point one level down, over `MvPowerSeries σ O`; here
+the parameter and the solution are both read in `KK`, so the coefficients travel across the base
+change too and the curve on the right is `fracCurve W σ KK` rather than `W`. Consumers such as
+`chord_point_nonsingular` want the equation written out, so this is normally applied through
+`simpa [wEquationRHS_def] using …`. -/
+theorem algebraMap_subst_formalW_wEquation {q : MvPowerSeries σ O} (hq : PowerSeries.HasSubst q) :
+    algebraMap (MvPowerSeries σ O) KK (PowerSeries.subst q (formalW W)) = wEquationRHS
+      (fracCurve W σ KK) (algebraMap (MvPowerSeries σ O) KK q)
+      (algebraMap (MvPowerSeries σ O) KK (PowerSeries.subst q (formalW W))) := by
   conv_lhs => rw [subst_formalW_wEquation W hq]
-  rw [wEquationRHS_def, wEquationRHS_def]
-  simp [fracCurve, map_add, map_mul, map_pow]
+  simp [fracCurve, wEquationRHS_def]
 
 /-! ### The chord data at the pair -/
 
 /-- The intercept of the chord through the two parametrized points, read at the pair `(q₁, q₂)`
-from the first point: `ν(q₁, q₂) = w(q₁) - λ(q₁, q₂) * q₁`. -/
+from the first point: `ν(q₁, q₂) = w(q₁) - λ(q₁, q₂) * q₁`.
+
+`subst_pair_formalIntercept_eq_inr` is the same intercept read from the second point; the two
+statements differ only in which parameter appears on the right, and rewriting with either one
+clears the intercept but leaves the slope behind. Combining the two readings is what cancels the
+slope, and that combination is already packaged as `subst_pair_formalIntercept_mul_sub`, so a
+consumer that wants the slope gone should reach for it rather than for these two. -/
 theorem subst_pair_formalIntercept_eq_inl {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
     subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-        (formalIntercept W) =
-      PowerSeries.subst q₁ (formalW W) -
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-          (formalSlope W) * q₁ := by
-  have h := congrArg (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-    Unit ⊕ Unit → MvPowerSeries σ O)) (formalIntercept_def W)
-  rw [← coe_substAlgHom (hasSubst_pair h₁ h₂)] at h
-  simp only [map_sub, map_mul] at h
-  simp only [coe_substAlgHom (hasSubst_pair h₁ h₂), subst_pair_toMvPowerSeries_inl W h₁ h₂,
-    subst_X (hasSubst_pair h₁ h₂)] at h
-  have hl : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inl ()) = q₁ := rfl
-  rwa [hl] at h
+        (formalIntercept W) = PowerSeries.subst q₁ (formalW W) -
+      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalSlope W) * q₁ := by
+  simp [formalIntercept_def, subst_sub (hasSubst_pair h₁ h₂), subst_mul (hasSubst_pair h₁ h₂),
+    subst_pair_toMvPowerSeries_inl W h₁ h₂, subst_X (hasSubst_pair h₁ h₂)]
 
 /-- The same intercept read from the second point: `ν(q₁, q₂) = w(q₂) - λ(q₁, q₂) * q₂`. Together
 with `subst_pair_formalIntercept_eq_inl` this is what expresses `q₁ * w(q₂) - q₂ * w(q₁)` through
-the intercept alone. -/
+the intercept alone.
+
+The two readings differ only in which parameter appears on the right, and rewriting with either
+one clears the intercept but leaves the slope behind; a consumer that wants the slope gone should
+reach for `subst_pair_formalIntercept_mul_sub`, which packages the combination that cancels it. -/
 theorem subst_pair_formalIntercept_eq_inr {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
     subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-        (formalIntercept W) =
-      PowerSeries.subst q₂ (formalW W) -
-        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
-          (formalSlope W) * q₂ := by
-  have h := congrArg (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-    Unit ⊕ Unit → MvPowerSeries σ O)) (formalIntercept_eq_inr W)
-  rw [← coe_substAlgHom (hasSubst_pair h₁ h₂)] at h
-  simp only [map_sub, map_mul] at h
-  simp only [coe_substAlgHom (hasSubst_pair h₁ h₂), subst_pair_toMvPowerSeries_inr W h₁ h₂,
-    subst_X (hasSubst_pair h₁ h₂)] at h
-  have hr : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inr ()) = q₂ := rfl
-  rwa [hr] at h
+        (formalIntercept W) = PowerSeries.subst q₂ (formalW W) -
+      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalSlope W) * q₂ := by
+  linear_combination subst_pair_formalIntercept_eq_inl W h₁ h₂ + subst_pair_formalSlope_mul W h₁ h₂
 
 /-- The cross combination `q₁ w(q₂) - q₂ w(q₁)` is expressed through the intercept alone:
 `q₁ w(q₂) - q₂ w(q₁) = ν(q₁, q₂) * (q₁ - q₂)`.
 
-Reading the intercept from *both* points is what makes the slope cancel: subtracting the two
-readings weighted by `q₂` and `q₁` removes `λ` entirely. This is the form the associativity
-assembly needs in order to know that the chord's `x`-coordinates are distinct. -/
-theorem subst_pair_formalIntercept_mul_sub {q₁ q₂ : MvPowerSeries σ O}
-    (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+Reading the intercept from *both* points is what makes the slope cancel, so this is the one
+intercept identity with no `λ` in it: `subst_pair_formalIntercept_eq_inl` and
+`subst_pair_formalIntercept_eq_inr` each clear the intercept but leave the slope behind. The
+factored `(q₁ - q₂)` on the right is what the associativity assembly needs in order to know that
+the chord's `x`-coordinates are distinct; reach for it there as a single rewrite rather than
+recombining the two readings by hand. -/
+theorem subst_pair_formalIntercept_mul_sub {q₁ q₂ : MvPowerSeries σ O} (h₁ : constantCoeff q₁ = 0)
+    (h₂ : constantCoeff q₂ = 0) :
     q₁ * PowerSeries.subst q₂ (formalW W) - q₂ * PowerSeries.subst q₁ (formalW W) =
       subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
         (formalIntercept W) * (q₁ - q₂) := by
+  -- weighting the two readings by `q₂` and `q₁` makes the `λ` terms coincide and cancel
   linear_combination q₂ * subst_pair_formalIntercept_eq_inl W h₁ h₂ -
     q₁ * subst_pair_formalIntercept_eq_inr W h₁ h₂
 
@@ -195,7 +197,6 @@ theorem subst_pair_formalThirdRoot_ne_zero {q₁ q₂ : MvPowerSeries σ O}
   rw [h, show (fun _ : Unit ↦ (0 : MvPowerSeries σ O)) = 0 from rfl,
     subst_zero_of_constantCoeff_zero (constantCoeff_formalW W)] at honline
   linear_combination -honline
-
 
 /-! ### The formal inverse at a parameter -/
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -90,10 +90,13 @@ open MvPowerSeries
 variable {O : Type*} [CommRing O]
 
 
-/-- The curve `W` base changed to a field `KK` over the series ring `MvPowerSeries σ O`. The
-parameters of the chord construction are series, so the group law they satisfy is the group law of
-this curve. There is no `Algebra O KK` to run `WeierstrassCurve.baseChange` along, so this is the
-composite `map`, and it is Mathlib's `map_*` lemmas that unfolding it exposes. -/
+/-- The curve `W` base changed to a commutative ring `KK` over the series ring
+`MvPowerSeries σ O`. The parameters of the chord construction are series, so the group law they
+satisfy is the group law of this curve; the group-law arguments below specialize `KK` to a fraction
+field of the series ring, which is where the chord construction needs division, but the base change
+itself asks only for a commutative algebra. There is no `Algebra O KK` to run
+`WeierstrassCurve.baseChange` along, so this is the composite `map`, and it is Mathlib's `map_*`
+lemmas that unfolding it exposes. -/
 private noncomputable def fracCurve (W : WeierstrassCurve O) (σ : Type*) (KK : Type*)
     [CommRing KK] [Algebra (MvPowerSeries σ O) KK] : WeierstrassCurve KK :=
   W.map <| (algebraMap (MvPowerSeries σ O) KK).comp (algebraMap O (MvPowerSeries σ O))

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -154,6 +154,48 @@ theorem subst_pair_formalThirdRoot_ne_zero {q₁ q₂ : MvPowerSeries σ O}
     subst_zero_of_constantCoeff_zero (constantCoeff_formalW W)] at honline
   linear_combination -honline
 
+
+/-! ### The formal inverse at a parameter -/
+
+/-- The denominator of the formal inverse, read at a parameter, still multiplies its `invOfUnit`
+to `1`: substituting is a ring map, so it carries `mul_invOfUnit_formalInverseDenom` along. -/
+private theorem subst_formalInverseDenom_mul {q : MvPowerSeries σ O}
+    (hq : PowerSeries.HasSubst q) :
+    PowerSeries.subst q (formalInverseDenom W) *
+        PowerSeries.subst q (PowerSeries.invOfUnit (formalInverseDenom W) 1) = 1 := by
+  have h := congrArg (PowerSeries.substAlgHom hq) (mul_invOfUnit_formalInverseDenom W)
+  simp only [map_mul, map_one] at h
+  simpa only [PowerSeries.coe_substAlgHom hq] using h
+
+/-- The formal inverse read at a parameter: `ι(q) = -(q * u(q)⁻¹)`. -/
+private theorem subst_formalInverse_eq {q : MvPowerSeries σ O} (hq : PowerSeries.HasSubst q) :
+    PowerSeries.subst q (formalInverse W) =
+      -(q * PowerSeries.subst q (PowerSeries.invOfUnit (formalInverseDenom W) 1)) := by
+  rw [formalInverse_def, ← PowerSeries.coe_substAlgHom hq]
+  simp only [map_neg, map_mul]
+  rw [PowerSeries.coe_substAlgHom hq, PowerSeries.subst_X hq]
+
+/-- The denominator of the formal inverse read at a parameter, written out. -/
+private theorem subst_formalInverseDenom_eq {q : MvPowerSeries σ O}
+    (hq : PowerSeries.HasSubst q) :
+    PowerSeries.subst q (formalInverseDenom W) =
+      1 - C W.a₁ * q - C W.a₃ * PowerSeries.subst q (formalW W) := by
+  rw [formalInverseDenom_def, ← PowerSeries.coe_substAlgHom hq]
+  simp only [map_sub, map_one, map_mul, PowerSeries.substAlgHom_X,
+    PowerSeries.coe_substAlgHom, PowerSeries.subst_C]
+
+/-- The `w`-expansion at the inverted parameter: `w(ι(q)) = -(w(q) * u(q)⁻¹)`.
+
+This is the one-variable `subst_formalInverse_formalW` carried through the substitution `q`. -/
+private theorem subst_formalW_subst_formalInverse {q : MvPowerSeries σ O}
+    (hq : PowerSeries.HasSubst q) :
+    PowerSeries.subst (PowerSeries.subst q (formalInverse W)) (formalW W) =
+      -(PowerSeries.subst q (formalW W) *
+        PowerSeries.subst q (PowerSeries.invOfUnit (formalInverseDenom W) 1)) := by
+  rw [← PowerSeries.subst_comp_subst_apply (hasSubst_formalInverse W) hq,
+    subst_formalInverse_formalW, ← PowerSeries.coe_substAlgHom hq]
+  simp only [map_neg, map_mul]
+
 /-! ### The parametrized point -/
 
 variable [IsDomain O]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Assoc.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.ThirdPoint
 
 /-!
 # The chord group law over the fraction field of the series ring
@@ -29,8 +30,14 @@ containing them: this file base changes `W` along `O → MvPowerSeries σ O → 
 Adapted from Michael Stoll's `EllipticCurves` project
 (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
 `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
-`EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`, section `Assembly`, declarations
-`fracCurve` and `rho_weierstrass`.
+`EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`, sections `Domain` and `Assembly`,
+declarations `subst_wSeries_ne_zero`, `fracCurve`, `rho_weierstrass` and `thetaPoint`.
+
+The source's `wSeries` and `vSeries` are `formalW` and `formalU` here, continuing the renaming
+this repository applies to that development, so `subst_wSeries_ne_zero` is
+`subst_formalW_ne_zero`. `FormalGroup/Add/Inverse.lean` records that the source left that lemma
+unported because its only consumers lay in the source's `Assembly` and `Universal` sections;
+this file is the first of them.
 
 The statement is adapted rather than transcribed, because this repository states the `w`-equation
 differently. Stoll carries a second copy of the equation as a private `def mvWStepAt` and phrases
@@ -69,6 +76,45 @@ theorem algebraMap_subst_formalW_wEquation {q : MvPowerSeries σ O}
   conv_lhs => rw [subst_formalW_wEquation W hq]
   rw [wEquationRHS_def, wEquationRHS_def]
   simp [fracCurve, map_add, map_mul, map_pow]
+
+/-! ### The parametrized point -/
+
+variable [IsDomain O]
+
+/-- Over a domain the `w`-expansion at a nonzero parameter with vanishing constant coefficient is
+itself nonzero: it factors as `q ^ 3 * u(q)`, and `u` has constant coefficient `1`. -/
+private theorem subst_formalW_ne_zero {q : MvPowerSeries σ O} (hq : constantCoeff q = 0)
+    (hq0 : q ≠ 0) : PowerSeries.subst q (formalW W) ≠ 0 := by
+  have hs : PowerSeries.HasSubst q := PowerSeries.HasSubst.of_constantCoeff_zero hq
+  have hexp : PowerSeries.subst q (formalW W) = q ^ 3 * PowerSeries.subst q (formalU W) := by
+    conv_lhs => rw [formalW_eq_X_pow_mul_formalU]
+    rw [← PowerSeries.coe_substAlgHom hs, map_mul, map_pow, PowerSeries.coe_substAlgHom hs,
+      PowerSeries.subst_X hs]
+  rw [hexp]
+  refine mul_ne_zero (pow_ne_zero 3 hq0) fun h ↦ ?_
+  have hc := congrArg constantCoeff h
+  rw [map_zero, PowerSeries.constantCoeff_subst hs] at hc
+  rw [finsum_eq_single _ 0 fun d hd ↦ ?_] at hc
+  · rw [PowerSeries.coeff_zero_eq_constantCoeff, constantCoeff_formalU, pow_zero, map_one,
+      smul_eq_mul, mul_one] at hc
+    exact one_ne_zero hc
+  · rw [map_pow, hq, zero_pow hd, smul_zero]
+
+variable [IsFractionRing (MvPowerSeries σ O) KK]
+
+/-- The point of the base-changed curve carried by the parameter `q`: the solution `(q, w(q))` of
+the `w`-equation, read in `KK` and in the affine coordinates `(q / w, -1 / w)` of the chart. -/
+private noncomputable def thetaPoint (hΔ : (fracCurve W σ KK).Δ ≠ 0)
+    {q : MvPowerSeries σ O} (hq : constantCoeff q = 0) (hq0 : q ≠ 0) :
+    (fracCurve W σ KK).toAffine.Point :=
+  Affine.Point.some _ _ (chord_point_nonsingular (fracCurve W σ KK)
+    (by
+      simpa [wEquationRHS_def] using
+        W.algebraMap_subst_formalW_wEquation (KK := KK)
+          (PowerSeries.HasSubst.of_constantCoeff_zero hq))
+    (fun h ↦ W.subst_formalW_ne_zero hq hq0
+      (IsFractionRing.injective (MvPowerSeries σ O) KK (by rw [h, map_zero])))
+    hΔ)
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Series
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
 
@@ -85,23 +86,22 @@ variable {O : Type*} [CommRing O] (W : WeierstrassCurve O)
 substitution: both series have vanishing constant coefficient. -/
 private theorem hasSubst_invPair :
     HasSubst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O) :=
-  hasSubst_of_constantCoeff_zero
-    (by rintro (j | j); exacts [constantCoeff_X j, constantCoeff_formalInverse W])
+  hasSubst_pair (constantCoeff_X ()) (constantCoeff_formalInverse W)
 
 /-- The `w`-expansion in the first parameter is unchanged by the specialization. -/
 private theorem subst_invPair_toMvPowerSeries_inl :
     subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
-      ((formalW W).toMvPowerSeries (Sum.inl ())) = formalW W := by
-  rw [PowerSeries.subst_toMvPowerSeries (hasSubst_invPair W), Sum.elim_inl]
-  exact PowerSeries.X_subst (formalW W)
+      ((formalW W).toMvPowerSeries (Sum.inl ())) = formalW W :=
+  (subst_pair_toMvPowerSeries_inl W (constantCoeff_X ()) (constantCoeff_formalInverse W)).trans
+    (PowerSeries.X_subst (formalW W))
 
 /-- The `w`-expansion in the second parameter becomes the `w`-coordinate of the negative point. -/
 private theorem subst_invPair_toMvPowerSeries_inr :
     subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
       ((formalW W).toMvPowerSeries (Sum.inr ())) =
-      -(formalW W * PowerSeries.invOfUnit (formalInverseDenom W) 1) := by
-  rw [PowerSeries.subst_toMvPowerSeries (hasSubst_invPair W), Sum.elim_inr]
-  exact subst_formalInverse_formalW W
+      -(formalW W * PowerSeries.invOfUnit (formalInverseDenom W) 1) :=
+  (subst_pair_toMvPowerSeries_inr W (constantCoeff_X ()) (constantCoeff_formalInverse W)).trans
+    (subst_formalInverse_formalW W)
 
 /-! ### The chord through a point and its formal inverse -/
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
@@ -60,10 +60,9 @@ The source's `addSeries`, `thirdRootSeries`, `slopeSeries`, `interceptSeries`, `
 `formalInverse`, `formalInverseDenom` and `formalW` here, continuing the renaming this repository
 applies to the rest of that development.
 
-The source states its pair lemmas for an arbitrary pair `(q₁, q₂)` of series with vanishing
-constant coefficient, because its later `Assembly` and `Universal` sections reuse them at other
-pairs. Every one of them is used here only at the pair `(z, ι(z))`, so they are stated at that
-pair; the general forms belong with their first general consumer.
+`FormalGroup/Add/PairSubst.lean` proves the chord identities for an arbitrary pair `(q₁, q₂)` of
+series with vanishing constant coefficient; this module specializes them to the pair `(z, ι(z))`,
+which is the case the formal inverse law needs.
 
 The source's `subst_wSeries_ne_zero` is `subst_formalW_ne_zero` in `FormalGroup/Add/Assoc.lean`;
 its `interceptSeries_ne_zero` and `X_pair_intercept_ne_zero` have no counterpart in this

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
@@ -66,10 +66,11 @@ constant coefficient, because its later `Assembly` and `Universal` sections reus
 pairs. Every one of them is used here only at the pair `(z, ι(z))`, so they are stated at that
 pair; the general forms belong with their first general consumer.
 
-The source's `subst_wSeries_ne_zero`, `interceptSeries_ne_zero` and `X_pair_intercept_ne_zero`
-are not ported. Their only consumers are in the source's `Assembly` and `Universal` sections,
-which are not part of this development yet, so here they would be private lemmas with no
-consumer.
+The source's `interceptSeries_ne_zero` and `X_pair_intercept_ne_zero` are not ported. Their only
+consumers are in the source's `Assembly` and `Universal` sections, which are not part of this
+development yet, so here they would be private lemmas with no consumer. The source's
+`subst_wSeries_ne_zero` was held back for that same reason; `FormalGroup/Add/Assoc.lean` is now
+the first of those consumers and carries it there as `subst_formalW_ne_zero`.
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
@@ -51,8 +51,7 @@ in this file, and naming it would add a definition whose unfolding lemma every p
 ## Provenance
 
 Adapted from Michael Stoll's `EllipticCurves` project
-(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
-`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, `66889eada51a`),
 `EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean` lines 118-308, the section `Domain`, and
 `EllipticCurves/WeierstrassFormalGroup/ThirdPoint.lean` lines 372-460, 501-577 and 630-653.
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
@@ -97,45 +97,6 @@ private theorem invPair_eq :
       Sum.elim (fun _ ↦ (X () : MvPowerSeries Unit O)) (fun _ ↦ formalInverse W) :=
   funext fun j ↦ by rcases j with j | j <;> rfl
 
-/-- The defining property of the slope, read at the pair `(z, ι(z))`. -/
-private theorem subst_invPair_formalSlope_mul :
-    subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
-        (formalSlope W) * (formalInverse W - X ()) =
-      -(formalW W * PowerSeries.invOfUnit (formalInverseDenom W) 1) - formalW W := by
-  rw [invPair_eq]
-  refine (subst_pair_formalSlope_mul W (constantCoeff_X ())
-    (constantCoeff_formalInverse W)).trans ?_
-  -- `PowerSeries.X_subst` is stated for `PowerSeries.X`; instantiating the general lemma at
-  -- `q₁ = X ()` leaves the `MvPowerSeries.X ()` spelling of that same term, and the `show`
-  -- only picks which of the two `rw` is looking at.
-  rw [subst_formalInverse_formalW W,
-    show PowerSeries.subst (X () : MvPowerSeries Unit O) (formalW W) = formalW W from
-      PowerSeries.X_subst (formalW W)]
-
-/-- The intercept at the pair `(z, ι(z))`, computed from the first point. -/
-private theorem subst_invPair_formalIntercept_eq_inl :
-    subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
-        (formalIntercept W) =
-      formalW W - subst (Sum.elim X (fun _ ↦ formalInverse W) :
-        Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) * X () := by
-  rw [invPair_eq]
-  refine (subst_pair_formalIntercept_eq_inl W (constantCoeff_X ())
-    (constantCoeff_formalInverse W)).trans ?_
-  rw [show PowerSeries.subst (X () : MvPowerSeries Unit O) (formalW W) = formalW W from
-    PowerSeries.X_subst (formalW W)]
-
-/-- The intercept at the pair `(z, ι(z))`, computed from the second point. -/
-private theorem subst_invPair_formalIntercept_eq_inr :
-    subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
-        (formalIntercept W) =
-      -(formalW W * PowerSeries.invOfUnit (formalInverseDenom W) 1) -
-        subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) * formalInverse W := by
-  rw [invPair_eq]
-  refine (subst_pair_formalIntercept_eq_inr W (constantCoeff_X ())
-    (constantCoeff_formalInverse W)).trans ?_
-  rw [subst_formalInverse_formalW W]
-
 /-- The third root at the pair `(z, ι(z))` vanishes at the origin, so it may itself be
 substituted into a one-variable series. -/
 private theorem constantCoeff_subst_invPair_formalThirdRoot :
@@ -145,58 +106,22 @@ private theorem constantCoeff_subst_invPair_formalThirdRoot :
   exact constantCoeff_subst_pair_formalThirdRoot W (constantCoeff_X ())
     (constantCoeff_formalInverse W)
 
-/-- The defining relation of the third root at the pair `(z, ι(z))`, with the inverse of
-Vieta's denominator eliminated. -/
-private theorem subst_invPair_formalThirdRoot_relation :
-    (1 + C W.a₂ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) +
-        C W.a₄ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) ^ 2 +
-        C W.a₆ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) ^ 3) *
-      (subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalThirdRoot W) + X () + formalInverse W) =
-      -(C W.a₁ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-            Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) +
-        C W.a₂ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-            Unit ⊕ Unit → MvPowerSeries Unit O) (formalIntercept W) +
-        C W.a₃ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-            Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) ^ 2 +
-        2 * C W.a₄ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-            Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) *
-          subst (Sum.elim X (fun _ ↦ formalInverse W) :
-            Unit ⊕ Unit → MvPowerSeries Unit O) (formalIntercept W) +
-        3 * C W.a₆ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-            Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) ^ 2 *
-          subst (Sum.elim X (fun _ ↦ formalInverse W) :
-            Unit ⊕ Unit → MvPowerSeries Unit O) (formalIntercept W)) := by
-  rw [invPair_eq]
-  exact subst_pair_formalThirdRoot_relation W (constantCoeff_X ())
-    (constantCoeff_formalInverse W)
-
-/-- The on-line identity at the pair `(z, ι(z))`: reading the `w`-expansion at the third root
-gives the chord line read there. -/
-private theorem subst_invPair_online :
-    subst (fun _ : Unit ↦ subst (Sum.elim X (fun _ ↦ formalInverse W) :
-        Unit ⊕ Unit → MvPowerSeries Unit O) (formalThirdRoot W)) (formalW W) =
-      subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) *
-        subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalThirdRoot W) +
-        subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalIntercept W) := by
-  rw [invPair_eq]
-  exact subst_pair_formalThirdRoot_formalW W (constantCoeff_X ())
-    (constantCoeff_formalInverse W)
-
 /-- **The chord through a point and its formal inverse passes through the origin**, in the form
 that holds over any base: the intercept at the pair `(z, ι(z))`, multiplied by `ι(z) - z`,
 vanishes. Over a domain the second factor is nonzero, and the intercept itself vanishes. -/
 private theorem subst_invPair_formalIntercept_mul :
     subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
         (formalIntercept W) * (formalInverse W - X ()) = 0 := by
-  have hi₁ := subst_invPair_formalIntercept_eq_inl W
-  have hi₂ := subst_invPair_formalIntercept_eq_inr W
+  -- the two readings of the intercept, taken from `PairSubst` at `(z, ι(z))` and turned back
+  -- into this module's spelling of the pair
+  have hi₁ := subst_pair_formalIntercept_eq_inl W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)
+  have hi₂ := subst_pair_formalIntercept_eq_inr W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)
+  rw [← invPair_eq,
+    show PowerSeries.subst (X () : MvPowerSeries Unit O) (formalW W) = formalW W from
+      PowerSeries.X_subst (formalW W)] at hi₁
+  rw [← invPair_eq, subst_formalInverse_formalW W] at hi₂
   -- `PowerSeries.X` is `MvPowerSeries.X ()`: defeq, but not syntactically equal, so this is
   -- `formalInverse_def` restated in the spelling `linear_combination` will normalize against.
   have hd : formalInverse W = -(X () * PowerSeries.invOfUnit (formalInverseDenom W) 1) :=
@@ -282,9 +207,18 @@ private theorem subst_invPair_formalThirdRoot_of_isDomain (h2 : (2 : O) ≠ 0) :
     subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
       (formalThirdRoot W) = 0 := by
   have hNp := subst_invPair_formalIntercept W (formalInverse_ne_X W h2)
-  have hOL := subst_invPair_online W
-  have hrel := subst_invPair_formalThirdRoot_relation W
-  have hslope := subst_invPair_formalSlope_mul W
+  -- the on-line identity, the third-root relation and the slope identity, taken from `PairSubst`
+  -- at `(z, ι(z))` and turned back into this module's spelling of the pair
+  have hOL := subst_pair_formalThirdRoot_formalW W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)
+  have hrel := subst_pair_formalThirdRoot_relation W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)
+  have hslope := subst_pair_formalSlope_mul W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)
+  rw [← invPair_eq] at hOL hrel
+  rw [← invPair_eq, subst_formalInverse_formalW W,
+    show PowerSeries.subst (X () : MvPowerSeries Unit O) (formalW W) = formalW W from
+      PowerSeries.X_subst (formalW W)] at hslope
   have hTc := constantCoeff_subst_invPair_formalThirdRoot W
   have hfix := subst_formalW_wEquation W (PowerSeries.HasSubst.of_constantCoeff_zero hTc)
   rw [hNp, add_zero] at hOL

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
@@ -5,8 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Series
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
+import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
 
 /-!
 # The inverse law of the chord group law
@@ -85,41 +86,31 @@ private theorem hasSubst_invPair :
     HasSubst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O) :=
   hasSubst_pair (constantCoeff_X ()) (constantCoeff_formalInverse W)
 
-/-- The `w`-expansion in the first parameter is unchanged by the specialization. -/
-private theorem subst_invPair_toMvPowerSeries_inl :
-    subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
-      ((formalW W).toMvPowerSeries (Sum.inl ())) = formalW W :=
-  (subst_pair_toMvPowerSeries_inl W (constantCoeff_X ()) (constantCoeff_formalInverse W)).trans
-    (PowerSeries.X_subst (formalW W))
-
-/-- The `w`-expansion in the second parameter becomes the `w`-coordinate of the negative point. -/
-private theorem subst_invPair_toMvPowerSeries_inr :
-    subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
-      ((formalW W).toMvPowerSeries (Sum.inr ())) =
-      -(formalW W * PowerSeries.invOfUnit (formalInverseDenom W) 1) :=
-  (subst_pair_toMvPowerSeries_inr W (constantCoeff_X ()) (constantCoeff_formalInverse W)).trans
-    (subst_formalInverse_formalW W)
-
 /-! ### The chord through a point and its formal inverse -/
+
+/-- The pair `(z, ι(z))` written in the shape `FormalGroup/Add/PairSubst.lean` states its
+identities in. `Sum.elim X` and `Sum.elim (fun _ ↦ X ())` are the same family — `Unit` has one
+element — but only the second is syntactically an instance of the general `(q₁, q₂)` pattern, so
+rewriting with this is what lets the specializations below be `exact` applications. -/
+private theorem invPair_eq :
+    (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O) =
+      Sum.elim (fun _ ↦ (X () : MvPowerSeries Unit O)) (fun _ ↦ formalInverse W) :=
+  funext fun j ↦ by rcases j with j | j <;> rfl
 
 /-- The defining property of the slope, read at the pair `(z, ι(z))`. -/
 private theorem subst_invPair_formalSlope_mul :
     subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
         (formalSlope W) * (formalInverse W - X ()) =
       -(formalW W * PowerSeries.invOfUnit (formalInverseDenom W) 1) - formalW W := by
-  have h := congrArg (subst
-    (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O))
-    (formalSlope_mul_sub W)
-  rw [← coe_substAlgHom (hasSubst_invPair W)] at h
-  simp only [map_mul, map_sub] at h
-  simp only [coe_substAlgHom (hasSubst_invPair W), subst_invPair_toMvPowerSeries_inl,
-    subst_invPair_toMvPowerSeries_inr, subst_X (hasSubst_invPair W)] at h
-  have h1 : (Sum.elim X (fun _ ↦ formalInverse W) :
-      Unit ⊕ Unit → MvPowerSeries Unit O) (Sum.inr ()) = formalInverse W := rfl
-  have h2 : (Sum.elim X (fun _ ↦ formalInverse W) :
-      Unit ⊕ Unit → MvPowerSeries Unit O) (Sum.inl ()) = X () := rfl
-  rw [h1, h2] at h
-  linear_combination h
+  rw [invPair_eq]
+  refine (subst_pair_formalSlope_mul W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)).trans ?_
+  -- `PowerSeries.X_subst` is stated for `PowerSeries.X`; instantiating the general lemma at
+  -- `q₁ = X ()` leaves the `MvPowerSeries.X ()` spelling of that same term, and the `show`
+  -- only picks which of the two `rw` is looking at.
+  rw [subst_formalInverse_formalW W,
+    show PowerSeries.subst (X () : MvPowerSeries Unit O) (formalW W) = formalW W from
+      PowerSeries.X_subst (formalW W)]
 
 /-- The intercept at the pair `(z, ι(z))`, computed from the first point. -/
 private theorem subst_invPair_formalIntercept_eq_inl :
@@ -127,17 +118,11 @@ private theorem subst_invPair_formalIntercept_eq_inl :
         (formalIntercept W) =
       formalW W - subst (Sum.elim X (fun _ ↦ formalInverse W) :
         Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) * X () := by
-  have h := congrArg (subst
-    (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O))
-    (formalIntercept_def W)
-  rw [← coe_substAlgHom (hasSubst_invPair W)] at h
-  simp only [map_mul, map_sub] at h
-  simp only [coe_substAlgHom (hasSubst_invPair W), subst_invPair_toMvPowerSeries_inl,
-    subst_X (hasSubst_invPair W)] at h
-  have h2 : (Sum.elim X (fun _ ↦ formalInverse W) :
-      Unit ⊕ Unit → MvPowerSeries Unit O) (Sum.inl ()) = X () := rfl
-  rw [h2] at h
-  exact h
+  rw [invPair_eq]
+  refine (subst_pair_formalIntercept_eq_inl W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)).trans ?_
+  rw [show PowerSeries.subst (X () : MvPowerSeries Unit O) (formalW W) = formalW W from
+    PowerSeries.X_subst (formalW W)]
 
 /-- The intercept at the pair `(z, ι(z))`, computed from the second point. -/
 private theorem subst_invPair_formalIntercept_eq_inr :
@@ -146,45 +131,19 @@ private theorem subst_invPair_formalIntercept_eq_inr :
       -(formalW W * PowerSeries.invOfUnit (formalInverseDenom W) 1) -
         subst (Sum.elim X (fun _ ↦ formalInverse W) :
           Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) * formalInverse W := by
-  have h := congrArg (subst
-    (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O))
-    (formalIntercept_eq_inr W)
-  rw [← coe_substAlgHom (hasSubst_invPair W)] at h
-  simp only [map_mul, map_sub] at h
-  simp only [coe_substAlgHom (hasSubst_invPair W), subst_invPair_toMvPowerSeries_inr,
-    subst_X (hasSubst_invPair W)] at h
-  have h1 : (Sum.elim X (fun _ ↦ formalInverse W) :
-      Unit ⊕ Unit → MvPowerSeries Unit O) (Sum.inr ()) = formalInverse W := rfl
-  rw [h1] at h
-  exact h
+  rw [invPair_eq]
+  refine (subst_pair_formalIntercept_eq_inr W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)).trans ?_
+  rw [subst_formalInverse_formalW W]
 
 /-- The third root at the pair `(z, ι(z))` vanishes at the origin, so it may itself be
 substituted into a one-variable series. -/
 private theorem constantCoeff_subst_invPair_formalThirdRoot :
     constantCoeff (subst (Sum.elim X (fun _ ↦ formalInverse W) :
-      Unit ⊕ Unit → MvPowerSeries Unit O) (formalThirdRoot W)) = 0 :=
-  constantCoeff_subst_eq_zero (hasSubst_invPair W)
-    (by rintro (j | j); exacts [constantCoeff_X j, constantCoeff_formalInverse W])
-    (constantCoeff_formalThirdRoot W)
-
-/-- Vieta's denominator, read at the pair `(z, ι(z))`, is still a unit: it times its
-`invOfUnit` is `1`. -/
-private theorem subst_invPair_thirdRootDenom_mul :
-    (1 + C W.a₂ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) +
-        C W.a₄ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) ^ 2 +
-        C W.a₆ * subst (Sum.elim X (fun _ ↦ formalInverse W) :
-          Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) ^ 3) *
-      subst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O)
-        (invOfUnit (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
-          C W.a₆ * formalSlope W ^ 3) 1) = 1 := by
-  have h := congrArg (substAlgHom (hasSubst_invPair W))
-    (mul_invOfUnit (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
-      C W.a₆ * formalSlope W ^ 3) 1 (constantCoeff_formalThirdRootDenom W))
-  simp only [map_mul, map_add, map_one, map_pow] at h
-  simp only [coe_substAlgHom (hasSubst_invPair W), subst_C] at h
-  exact h
+      Unit ⊕ Unit → MvPowerSeries Unit O) (formalThirdRoot W)) = 0 := by
+  rw [invPair_eq]
+  exact constantCoeff_subst_pair_formalThirdRoot W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)
 
 /-- The defining relation of the third root at the pair `(z, ι(z))`, with the inverse of
 Vieta's denominator eliminated. -/
@@ -211,29 +170,9 @@ private theorem subst_invPair_formalThirdRoot_relation :
             Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W) ^ 2 *
           subst (Sum.elim X (fun _ ↦ formalInverse W) :
             Unit ⊕ Unit → MvPowerSeries Unit O) (formalIntercept W)) := by
-  have hexp := congrArg (substAlgHom (hasSubst_invPair W)) (formalThirdRoot_def W)
-  simp only [map_sub, map_neg, map_mul, map_add, map_pow, map_ofNat] at hexp
-  simp only [coe_substAlgHom (hasSubst_invPair W), subst_X (hasSubst_invPair W), subst_C] at hexp
-  have h1 : (Sum.elim X (fun _ ↦ formalInverse W) :
-      Unit ⊕ Unit → MvPowerSeries Unit O) (Sum.inr ()) = formalInverse W := rfl
-  have h2 : (Sum.elim X (fun _ ↦ formalInverse W) :
-      Unit ⊕ Unit → MvPowerSeries Unit O) (Sum.inl ()) = X () := rfl
-  rw [h1, h2] at hexp
-  have hAd := subst_invPair_thirdRootDenom_mul W
-  set Lp := subst (Sum.elim X (fun _ ↦ formalInverse W) :
-    Unit ⊕ Unit → MvPowerSeries Unit O) (formalSlope W)
-  set Np := subst (Sum.elim X (fun _ ↦ formalInverse W) :
-    Unit ⊕ Unit → MvPowerSeries Unit O) (formalIntercept W)
-  set Tp := subst (Sum.elim X (fun _ ↦ formalInverse W) :
-    Unit ⊕ Unit → MvPowerSeries Unit O) (formalThirdRoot W)
-  set dp := subst (Sum.elim X (fun _ ↦ formalInverse W) :
-    Unit ⊕ Unit → MvPowerSeries Unit O)
-    (invOfUnit (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
-      C W.a₆ * formalSlope W ^ 3) 1)
-  clear_value Lp Np Tp dp
-  linear_combination (1 + C W.a₂ * Lp + C W.a₄ * Lp ^ 2 + C W.a₆ * Lp ^ 3) * hexp -
-    (C W.a₁ * Lp + C W.a₂ * Np + C W.a₃ * Lp ^ 2 + 2 * C W.a₄ * Lp * Np +
-      3 * C W.a₆ * Lp ^ 2 * Np) * hAd
+  rw [invPair_eq]
+  exact subst_pair_formalThirdRoot_relation W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)
 
 /-- The on-line identity at the pair `(z, ι(z))`: reading the `w`-expansion at the third root
 gives the chord line read there. -/
@@ -246,10 +185,9 @@ private theorem subst_invPair_online :
           Unit ⊕ Unit → MvPowerSeries Unit O) (formalThirdRoot W) +
         subst (Sum.elim X (fun _ ↦ formalInverse W) :
           Unit ⊕ Unit → MvPowerSeries Unit O) (formalIntercept W) := by
-  have h := congrArg (substAlgHom (hasSubst_invPair W)) (subst_formalThirdRoot_formalW W)
-  simp only [map_add, map_mul] at h
-  simp only [coe_substAlgHom (hasSubst_invPair W)] at h
-  rwa [subst_comp_subst_apply (hasSubst_formalThirdRoot W) (hasSubst_invPair W)] at h
+  rw [invPair_eq]
+  exact subst_pair_formalThirdRoot_formalW W (constantCoeff_X ())
+    (constantCoeff_formalInverse W)
 
 /-- **The chord through a point and its formal inverse passes through the origin**, in the form
 that holds over any base: the intercept at the pair `(z, ι(z))`, multiplied by `ι(z) - z`,

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.PairSubst
-public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Series
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
 
 /-!
@@ -66,11 +65,9 @@ constant coefficient, because its later `Assembly` and `Universal` sections reus
 pairs. Every one of them is used here only at the pair `(z, ι(z))`, so they are stated at that
 pair; the general forms belong with their first general consumer.
 
-The source's `interceptSeries_ne_zero` and `X_pair_intercept_ne_zero` are not ported. Their only
-consumers are in the source's `Assembly` and `Universal` sections, which are not part of this
-development yet, so here they would be private lemmas with no consumer. The source's
-`subst_wSeries_ne_zero` was held back for that same reason; `FormalGroup/Add/Assoc.lean` is now
-the first of those consumers and carries it there as `subst_formalW_ne_zero`.
+The source's `subst_wSeries_ne_zero` is `subst_formalW_ne_zero` in `FormalGroup/Add/Assoc.lean`;
+its `interceptSeries_ne_zero` and `X_pair_intercept_ne_zero` have no counterpart in this
+repository.
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -38,6 +38,11 @@ this file's, specialized; see the Provenance note there.
   read at `z₃`.
 * `WeierstrassCurve.subst_pair_formalW_formalAdd`: the `w`-expansion at the addition series,
   `w(F(q₁, q₂)) = -(w(z₃) * u(z₃)⁻¹)`.
+* `WeierstrassCurve.subst_pair_formalInverseDenom_mul`,
+  `WeierstrassCurve.subst_pair_formalInverseDenom_eq`: the denominator of the formal inverse,
+  read at `z₃`, is a unit and equals `1 - a₁ z₃ - a₃ w(z₃)`.
+* `WeierstrassCurve.subst_pair_formalAdd_eq`: the addition series written out,
+  `F(q₁, q₂) = -(z₃ * u(z₃)⁻¹)`.
 
 ## Implementation notes
 
@@ -300,5 +305,56 @@ theorem subst_pair_formalW_formalAdd (h₁ : constantCoeff q₁ = 0) (h₂ : con
       PowerSeries.subst (formalInverse W) (formalW W) from rfl,
     subst_formalInverse_formalW, ← coe_substAlgHom hT]
   simp only [map_neg, map_mul]
+
+/-- The denominator of the formal inverse, read at the third root `z₃(q₁, q₂)`, is still a unit:
+it times its `invOfUnit` is `1`. -/
+theorem subst_pair_formalInverseDenom_mul (h₁ : constantCoeff q₁ = 0)
+    (h₂ : constantCoeff q₂ = 0) :
+    subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverseDenom W) *
+        subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W))
+          (PowerSeries.invOfUnit (formalInverseDenom W) 1) = 1 := by
+  have hT : HasSubst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) :=
+    hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
+  have h := congrArg (substAlgHom hT) (mul_invOfUnit_formalInverseDenom W)
+  simp only [map_mul, map_one] at h
+  simpa only [coe_substAlgHom hT] using h
+
+/-- The denominator of the formal inverse, read at the third root, written out:
+`u(z₃) = 1 - a₁ z₃ - a₃ w(z₃)`. -/
+theorem subst_pair_formalInverseDenom_eq (h₁ : constantCoeff q₁ = 0)
+    (h₂ : constantCoeff q₂ = 0) :
+    subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+        Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverseDenom W) =
+      1 - C W.a₁ * subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W) -
+        C W.a₃ * subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalW W) := by
+  have hT : HasSubst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) :=
+    hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
+  rw [formalInverseDenom_def, ← coe_substAlgHom hT]
+  simp only [map_sub, map_one, map_mul]
+  rw [coe_substAlgHom hT]
+  simp only [show (PowerSeries.C : O →+* PowerSeries O) = MvPowerSeries.C from rfl,
+    show (PowerSeries.X : PowerSeries O) = MvPowerSeries.X () from rfl, subst_C, subst_X hT]
+
+/-- The addition series at the pair, written out: `F(q₁, q₂) = -(z₃ * u(z₃)⁻¹)`. -/
+theorem subst_pair_formalAdd_eq (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W) =
+      -(subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalThirdRoot W) *
+        subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W))
+          (PowerSeries.invOfUnit (formalInverseDenom W) 1)) := by
+  have hT : HasSubst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) :=
+    hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
+  rw [subst_pair_formalAdd W h₁ h₂, formalInverse_def, ← coe_substAlgHom hT]
+  simp only [map_neg, map_mul]
+  rw [coe_substAlgHom hT,
+    show (PowerSeries.X : PowerSeries O) = MvPowerSeries.X () from rfl, subst_X hT]
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -26,8 +26,8 @@ this file's, specialized; see the Provenance note there.
   `WeierstrassCurve.subst_pair_toMvPowerSeries_inr`: the one-variable `w`-expansion, embedded in
   either variable, becomes `w(q₁)` respectively `w(q₂)`.
 * `WeierstrassCurve.subst_pair_formalSlope_mul`: `λ(q₁, q₂) * (q₂ - q₁) = w(q₂) - w(q₁)`.
-* `WeierstrassCurve.subst_pair_online`: the `w`-expansion at the third root is the chord
-  line read there.
+* `WeierstrassCurve.subst_pair_formalThirdRoot_formalW`: the `w`-expansion at the third root
+  is the chord line read there.
 * `WeierstrassCurve.subst_pair_thirdRootDenom_mul`: Vieta's denominator stays a unit at the
   pair, and `WeierstrassCurve.subst_pair_thirdRootDenom_ne_zero`: in particular it is nonzero.
 * `WeierstrassCurve.subst_pair_formalThirdRoot_relation`: the defining relation of `z₃` at
@@ -80,7 +80,8 @@ from `EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`.
 
 The source's `slopeSeries`, `interceptSeries` and `wSeries` are `formalSlope`, `formalIntercept`
 and `formalW` here, continuing the renaming this repository applies to that development, so
-`pair_slope_identity` and `pair_online` are `subst_pair_formalSlope_mul` and `subst_pair_online`.
+`pair_slope_identity` and `pair_online` are `subst_pair_formalSlope_mul` and
+`subst_pair_formalThirdRoot_formalW`.
 Stoll's `A` for Vieta's denominator is `formalThirdRootDenom` here, so `pair_A_mul` and
 `pair_T₃_relation` are `subst_pair_thirdRootDenom_mul` and
 `subst_pair_formalThirdRoot_relation`.
@@ -151,7 +152,7 @@ theorem subst_pair_formalSlope_mul (h₁ : constantCoeff q₁ = 0) (h₂ : const
 
 /-- The on-line identity at the pair `(q₁, q₂)`: reading the `w`-expansion at the third root
 gives the chord line read there. -/
-theorem subst_pair_online (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+theorem subst_pair_formalThirdRoot_formalW (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
     subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
         Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalW W) =
       subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
@@ -299,7 +300,8 @@ theorem subst_pair_formalAdd (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoe
 
 This is the one-variable `subst_formalInverse_formalW` carried across by `subst_pair_formalAdd`,
 so the group law's `w` at a pair is never recomputed. The third root is spelled as a `Unit`-family
-substitution, matching `subst_pair_online`, so the two rewrite against each other. -/
+substitution, matching `subst_pair_formalThirdRoot_formalW`, so the two rewrite against each
+other. -/
 theorem subst_pair_formalW_formalAdd (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
     subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
         Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) (formalW W) =
@@ -441,7 +443,7 @@ theorem subst_pair_formalThirdRoot_ne_zero (h₁ : constantCoeff q₁ = 0) (h₂
       (formalThirdRoot W) ≠ 0 := by
   intro h
   refine hN ?_
-  have honline := subst_pair_online W h₁ h₂
+  have honline := subst_pair_formalThirdRoot_formalW W h₁ h₂
   -- `rw [h]` leaves the substitution family as the literal `fun _ ↦ 0`, which is the zero
   -- function only definitionally, so it must be folded before
   -- `subst_zero_of_constantCoeff_zero` will match.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -242,4 +242,15 @@ theorem constantCoeff_subst_pair_formalThirdRoot (h₁ : constantCoeff q₁ = 0)
   constantCoeff_subst_eq_zero (hasSubst_pair h₁ h₂) (by rintro (j | j) <;> simpa)
     (constantCoeff_formalThirdRoot W)
 
+/-- The addition series at the pair `(q₁, q₂)` is the formal inverse read at the third root
+`z₃(q₁, q₂)`.
+
+This is `formalAdd_def` pushed through the pair substitution, and it is the bridge that turns any
+one-variable identity about `formalInverse` into a statement about the group law at the pair. -/
+theorem subst_pair_formalAdd (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W) =
+      subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverse W) := by
+  rw [formalAdd_def, subst_comp_subst_apply (hasSubst_formalThirdRoot W) (hasSubst_pair h₁ h₂)]
+
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -70,9 +70,9 @@ Stoll's `A` for Vieta's denominator is `formalThirdRootDenom` here, so `pair_A_m
 
 The source's `pair_intercept_identity₁` and `pair_intercept_identity₂` are not ported here. Their
 consumers lie in the source's `Assembly` section, so they belong with that first consumer rather
-than in this file: `pair_intercept_identity₁` is
-`WeierstrassCurve.subst_pair_formalIntercept` in `FormalGroup/Add/Assoc.lean`, and
-`pair_intercept_identity₂` has no consumer here yet.
+than in this file: `pair_intercept_identity₁` and `pair_intercept_identity₂` are
+`WeierstrassCurve.subst_pair_formalIntercept_eq_inl` and
+`WeierstrassCurve.subst_pair_formalIntercept_eq_inr` in `FormalGroup/Add/Assoc.lean`.
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -29,7 +29,7 @@ this file's, specialized; see the Provenance note there.
 * `WeierstrassCurve.subst_pair_online`: the `w`-expansion at the third root is the chord
   line read there.
 * `WeierstrassCurve.subst_pair_thirdRootDenom_mul`: Vieta's denominator stays a unit at the
-  pair.
+  pair, and `WeierstrassCurve.subst_pair_thirdRootDenom_ne_zero`: in particular it is nonzero.
 * `WeierstrassCurve.subst_pair_formalThirdRoot_relation`: the defining relation of `z₃` at
   the pair, with that inverse cleared.
 * `WeierstrassCurve.constantCoeff_subst_pair_formalThirdRoot`: the third root at the pair again
@@ -191,6 +191,25 @@ theorem subst_pair_thirdRootDenom_mul (h₁ : constantCoeff q₁ = 0) (h₂ : co
   simp only [map_mul, map_add, map_one, map_pow] at h
   simp only [coe_substAlgHom (hasSubst_pair h₁ h₂), subst_C] at h
   exact h
+
+/-- Vieta's denominator at the pair is nonzero, because it has an explicit inverse. Over a
+nontrivial base this is immediate from `subst_pair_thirdRootDenom_mul`; no coefficient
+computation is needed. -/
+theorem subst_pair_thirdRootDenom_ne_zero [Nontrivial O] (h₁ : constantCoeff q₁ = 0)
+    (h₂ : constantCoeff q₂ = 0) :
+    (1 + C W.a₂ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) +
+        C W.a₄ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) ^ 2 +
+        C W.a₆ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) ^ 3) ≠ 0 := by
+  intro h
+  have hmul := subst_pair_thirdRootDenom_mul W h₁ h₂
+  rw [h, zero_mul] at hmul
+  exact zero_ne_one hmul
 
 /-- The defining relation of the third root at the pair `(q₁, q₂)`, with the inverse of Vieta's
 denominator eliminated. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -110,4 +110,22 @@ theorem subst_pair_formalSlope_mul (h₁ : constantCoeff q₁ = 0) (h₂ : const
   rw [h1, h2] at h
   linear_combination h
 
+/-! ### The third point of the chord lies on the curve -/
+
+/-- The on-line identity at the pair `(q₁, q₂)`: reading the `w`-expansion at the third root
+gives the chord line read there. -/
+theorem subst_pair_online (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+        Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalW W) =
+      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalThirdRoot W) +
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalIntercept W) := by
+  have h := congrArg (substAlgHom (hasSubst_pair h₁ h₂)) (subst_formalThirdRoot_formalW W)
+  simp only [map_add, map_mul] at h
+  simp only [coe_substAlgHom (hasSubst_pair h₁ h₂)] at h
+  rwa [subst_comp_subst_apply (hasSubst_formalThirdRoot W) (hasSubst_pair h₁ h₂)] at h
+
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -250,7 +250,37 @@ one-variable identity about `formalInverse` into a statement about the group law
 theorem subst_pair_formalAdd (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
     subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W) =
       subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
-          Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverse W) := by
+        Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverse W) := by
   rw [formalAdd_def, subst_comp_subst_apply (hasSubst_formalThirdRoot W) (hasSubst_pair h₁ h₂)]
+
+/-- The `w`-expansion at the addition series, read at the pair `(q₁, q₂)`:
+`w(F(q₁, q₂)) = -(w(z₃) * u(z₃)⁻¹)`, where `z₃ = z₃(q₁, q₂)` is the third root and `u` is
+`formalInverseDenom`, the denominator of the formal inverse.
+
+This is the one-variable `subst_formalInverse_formalW` carried across by `subst_pair_formalAdd`,
+so the group law's `w` at a pair is never recomputed. The third root is spelled as a `Unit`-family
+substitution, matching `subst_pair_online`, so the two rewrite against each other. -/
+theorem subst_pair_formalW_formalAdd (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+        Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) (formalW W) =
+      -(subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+            Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalW W) *
+        subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+            Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W))
+          (PowerSeries.invOfUnit (formalInverseDenom W) 1)) := by
+  have hT : HasSubst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) :=
+    hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
+  have hfam : (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+        Unit ⊕ Unit → MvPowerSeries σ O) (formalAdd W)) =
+      fun _ : Unit ↦ subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+        Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverse W) :=
+    funext fun _ ↦ subst_pair_formalAdd W h₁ h₂
+  rw [hfam, ← subst_comp_subst_apply (hasSubst_of_constantCoeff_zero
+    fun _ ↦ constantCoeff_formalInverse W) hT,
+    show subst (fun _ : Unit ↦ formalInverse W) (formalW W) =
+      PowerSeries.subst (formalInverse W) (formalW W) from rfl,
+    subst_formalInverse_formalW, ← coe_substAlgHom hT]
+  simp only [map_neg, map_mul]
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -51,11 +51,17 @@ Adapted from Michael Stoll's `EllipticCurves` project
 (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
 `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`, whose full expansion is
 `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`),
-`EllipticCurves/WeierstrassFormalGroup/ThirdPoint.lean`, declarations `hasSubst_pair`,
-`pair_slope_identity`, `pair_intercept_identity₁` and `pair_intercept_identity₂`.
+`EllipticCurves/WeierstrassFormalGroup/ThirdPoint.lean`, declarations `hasSubst_pair` and
+`pair_slope_identity`, together with `pair_online` from
+`EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`.
 
 The source's `slopeSeries`, `interceptSeries` and `wSeries` are `formalSlope`, `formalIntercept`
-and `formalW` here, continuing the renaming this repository applies to that development.
+and `formalW` here, continuing the renaming this repository applies to that development, so
+`pair_slope_identity` and `pair_online` are `subst_pair_formalSlope_mul` and `subst_pair_online`.
+
+The source's `pair_intercept_identity₁` and `pair_intercept_identity₂` are not ported here. Their
+consumers lie in the source's `Assembly` section, so they belong with that first consumer rather
+than in this file.
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Series
+
+/-!
+# The chord construction along an arbitrary pair of parameters
+
+`FormalGroup/Chord.lean` builds the chord data — the slope `λ`, the intercept `ν`, the third
+root `z₃` and the addition series `F` — as two-variable series in `MvPowerSeries (Unit ⊕ Unit) O`,
+and states their defining identities in the two variables themselves. This file substitutes an
+**arbitrary pair** `(q₁, q₂)` of series with vanishing constant coefficient for those variables,
+and carries each identity across.
+
+`FormalGroup/Add/Inverse.lean` already does this for the one pair `(z, ι(z))`. Its versions are
+this file's, specialized; see the Provenance note there.
+
+## Main results
+
+* `WeierstrassCurve.hasSubst_pair`: the pair is a legitimate substitution family.
+* `WeierstrassCurve.subst_pair_toMvPowerSeries_inl`,
+  `WeierstrassCurve.subst_pair_toMvPowerSeries_inr`: the one-variable `w`-expansion, embedded in
+  either variable, becomes `w(q₁)` respectively `w(q₂)`.
+* `WeierstrassCurve.subst_pair_formalSlope_mul`: `λ(q₁, q₂) * (q₂ - q₁) = w(q₂) - w(q₁)`.
+
+## Implementation notes
+
+The pair is the family `Sum.elim (fun _ ↦ q₁) fun _ ↦ q₂` on `Unit ⊕ Unit`, written inline
+throughout as `Add/Inverse.lean` writes its own family inline.
+
+Two of Stoll's helpers in this range are not ported, because this repository already has them in
+a more general form. His `subst_pair_rename`, which pushes the substitution through the
+one-variable-into-two-variable embedding, is Mathlib's `PowerSeries.subst_toMvPowerSeries`
+composed with `Sum.elim_inl`/`Sum.elim_inr` — this repository builds the two-variable series with
+`PowerSeries.toMvPowerSeries` where the source uses `MvPowerSeries.rename`. His
+`subst_wSeries_fix`, that `w` composed with any parameter solves the `w`-equation, is
+`WeierstrassCurve.subst_formalW_wEquation` in `FormalGroup/WExpansion.lean`, stated there over an
+arbitrary algebra.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], IV.1.
+
+## Provenance
+
+Adapted from Michael Stoll's `EllipticCurves` project
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`, whose full expansion is
+`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`),
+`EllipticCurves/WeierstrassFormalGroup/ThirdPoint.lean`, declarations `hasSubst_pair`,
+`pair_slope_identity`, `pair_intercept_identity₁` and `pair_intercept_identity₂`.
+
+The source's `slopeSeries`, `interceptSeries` and `wSeries` are `formalSlope`, `formalIntercept`
+and `formalW` here, continuing the renaming this repository applies to that development.
+-/
+
+public section
+
+namespace WeierstrassCurve
+
+open MvPowerSeries
+
+variable {O : Type*} [CommRing O] (W : WeierstrassCurve O)
+variable {σ : Type*} {q₁ q₂ : MvPowerSeries σ O}
+
+/-! ### The substitution family -/
+
+/-- A pair of parameters with vanishing constant coefficient is a legitimate substitution
+family for the two-variable chord series. -/
+theorem hasSubst_pair (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    HasSubst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O) :=
+  hasSubst_of_constantCoeff_zero (by rintro (j | j) <;> simpa)
+
+/-- The `w`-expansion in the first parameter becomes `w(q₁)`. -/
+theorem subst_pair_toMvPowerSeries_inl (h₁ : constantCoeff q₁ = 0)
+    (h₂ : constantCoeff q₂ = 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      ((formalW W).toMvPowerSeries (Sum.inl ())) = PowerSeries.subst q₁ (formalW W) := by
+  rw [PowerSeries.subst_toMvPowerSeries (hasSubst_pair h₁ h₂), Sum.elim_inl]
+
+/-- The `w`-expansion in the second parameter becomes `w(q₂)`. -/
+theorem subst_pair_toMvPowerSeries_inr (h₁ : constantCoeff q₁ = 0)
+    (h₂ : constantCoeff q₂ = 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      ((formalW W).toMvPowerSeries (Sum.inr ())) = PowerSeries.subst q₂ (formalW W) := by
+  rw [PowerSeries.subst_toMvPowerSeries (hasSubst_pair h₁ h₂), Sum.elim_inr]
+
+/-! ### The chord through the two parametrized points -/
+
+/-- The defining property of the slope, read at the pair `(q₁, q₂)`:
+`λ(q₁, q₂) * (q₂ - q₁) = w(q₂) - w(q₁)`. -/
+theorem subst_pair_formalSlope_mul (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalSlope W) * (q₂ - q₁) =
+      PowerSeries.subst q₂ (formalW W) - PowerSeries.subst q₁ (formalW W) := by
+  have h := congrArg (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+    Unit ⊕ Unit → MvPowerSeries σ O)) (formalSlope_mul_sub W)
+  rw [← coe_substAlgHom (hasSubst_pair h₁ h₂)] at h
+  simp only [map_mul, map_sub] at h
+  simp only [coe_substAlgHom (hasSubst_pair h₁ h₂), subst_pair_toMvPowerSeries_inl W h₁ h₂,
+    subst_pair_toMvPowerSeries_inr W h₁ h₂, subst_X (hasSubst_pair h₁ h₂)] at h
+  have h1 : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inr ()) = q₂ := rfl
+  have h2 : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inl ()) = q₁ := rfl
+  rw [h1, h2] at h
+  linear_combination h
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -231,4 +231,15 @@ theorem subst_pair_formalThirdRoot_relation (h₁ : constantCoeff q₁ = 0)
     (C W.a₁ * Lp + C W.a₂ * Np + C W.a₃ * Lp ^ 2 + 2 * C W.a₄ * Lp * Np +
       3 * C W.a₆ * Lp ^ 2 * Np) * hAd
 
+/-! ### The third root as a parameter in its own right -/
+
+/-- The third root, read at the pair `(q₁, q₂)`, again has vanishing constant coefficient, so it
+is itself a legitimate parameter to substitute into a one-variable series. -/
+theorem constantCoeff_subst_pair_formalThirdRoot (h₁ : constantCoeff q₁ = 0)
+    (h₂ : constantCoeff q₂ = 0) :
+    constantCoeff (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalThirdRoot W)) = 0 :=
+  constantCoeff_subst_eq_zero (hasSubst_pair h₁ h₂) (by rintro (j | j) <;> simpa)
+    (constantCoeff_formalThirdRoot W)
+
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -43,6 +43,13 @@ this file's, specialized; see the Provenance note there.
   read at `z₃`, is a unit and equals `1 - a₁ z₃ - a₃ w(z₃)`.
 * `WeierstrassCurve.subst_pair_formalAdd_eq`: the addition series written out,
   `F(q₁, q₂) = -(z₃ * u(z₃)⁻¹)`.
+* `WeierstrassCurve.subst_pair_formalIntercept_eq_inl`,
+  `WeierstrassCurve.subst_pair_formalIntercept_eq_inr`: the chord's intercept at the pair, read
+  from either of the two points.
+* `WeierstrassCurve.subst_pair_formalIntercept_mul_sub`: the cross combination
+  `q₁ w(q₂) - q₂ w(q₁) = ν(q₁, q₂) * (q₁ - q₂)`, which is what the two readings buy.
+* `WeierstrassCurve.subst_pair_formalThirdRoot_ne_zero`: a nonzero intercept forces a nonzero
+  third root.
 
 ## Implementation notes
 
@@ -65,9 +72,8 @@ arbitrary algebra.
 ## Provenance
 
 Adapted from Michael Stoll's `EllipticCurves` project
-(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
-`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`, whose full expansion is
-`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`),
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0) at commit
+`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`,
 `EllipticCurves/WeierstrassFormalGroup/ThirdPoint.lean`, declarations `hasSubst_pair`,
 `pair_slope_identity`, `pair_A_mul` and `pair_T₃_relation`, together with `pair_online`
 from `EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`.
@@ -91,11 +97,8 @@ pair is the inverse series read at the third root, which here is `formalAdd`'s *
 series — the unit part of the `w`-expansion, `w = z³ u`. Anything ported from the source's `u`
 lemmas must target `formalInverseDenom`.
 
-The source's `pair_intercept_identity₁` and `pair_intercept_identity₂` are not ported here. Their
-consumers lie in the source's `Assembly` section, so they belong with that first consumer rather
-than in this file: `pair_intercept_identity₁` and `pair_intercept_identity₂` are
-`WeierstrassCurve.subst_pair_formalIntercept_eq_inl` and
-`WeierstrassCurve.subst_pair_formalIntercept_eq_inr` in `FormalGroup/Add/Assoc.lean`.
+The source's `pair_intercept_identity₁` and `pair_intercept_identity₂` are
+`subst_pair_formalIntercept_eq_inl` and `subst_pair_formalIntercept_eq_inr` here.
 -/
 
 public section
@@ -277,6 +280,7 @@ theorem subst_pair_formalThirdRoot_relation (h₁ : constantCoeff q₁ = 0)
 
 /-- The third root, read at the pair `(q₁, q₂)`, again has vanishing constant coefficient, so it
 is itself a legitimate parameter to substitute into a one-variable series. -/
+@[simp]
 theorem constantCoeff_subst_pair_formalThirdRoot (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
     constantCoeff (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
@@ -357,6 +361,10 @@ theorem subst_pair_formalInverseDenom_eq (h₁ : constantCoeff q₁ = 0)
   rw [formalInverseDenom_def, ← coe_substAlgHom hT]
   simp only [map_sub, map_one, map_mul]
   rw [coe_substAlgHom hT]
+  -- `PowerSeries O` *is* `MvPowerSeries Unit O`, but the two namespaces name the constant and the
+  -- variable differently, and `subst_C`/`subst_X` are stated in the multivariable spelling. The
+  -- two identifications are `rfl`; there is no rewrite that reaches them, because the goal is
+  -- already syntactically in the univariate spelling.
   simp only [show (PowerSeries.C : O →+* PowerSeries O) = MvPowerSeries.C from rfl,
     show (PowerSeries.X : PowerSeries O) = MvPowerSeries.X () from rfl, subst_C, subst_X hT]
 
@@ -373,7 +381,75 @@ theorem subst_pair_formalAdd_eq (h₁ : constantCoeff q₁ = 0) (h₂ : constant
     hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_subst_pair_formalThirdRoot W h₁ h₂
   rw [subst_pair_formalAdd W h₁ h₂, formalInverse_def, ← coe_substAlgHom hT]
   simp only [map_neg, map_mul]
+  -- as above: `PowerSeries.X` and `MvPowerSeries.X ()` are the same term, and `subst_X` is
+  -- stated for the latter.
   rw [coe_substAlgHom hT,
     show (PowerSeries.X : PowerSeries O) = MvPowerSeries.X () from rfl, subst_X hT]
+
+/-! ### The chord data at the pair, read from either point -/
+
+/-- The intercept of the chord through the two parametrized points, read at the pair `(q₁, q₂)`
+from the first point: `ν(q₁, q₂) = w(q₁) - λ(q₁, q₂) * q₁`.
+
+`subst_pair_formalIntercept_eq_inr` is the same intercept read from the second point; the two
+statements differ only in which parameter appears on the right, and rewriting with either one
+clears the intercept but leaves the slope behind. Combining the two readings is what cancels the
+slope, and that combination is already packaged as `subst_pair_formalIntercept_mul_sub`, so a
+consumer that wants the slope gone should reach for it rather than for these two. -/
+theorem subst_pair_formalIntercept_eq_inl (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalIntercept W) = PowerSeries.subst q₁ (formalW W) -
+      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalSlope W) * q₁ := by
+  simp [formalIntercept_def, subst_sub (hasSubst_pair h₁ h₂), subst_mul (hasSubst_pair h₁ h₂),
+    subst_pair_toMvPowerSeries_inl W h₁ h₂, subst_X (hasSubst_pair h₁ h₂)]
+
+/-- The same intercept read from the second point: `ν(q₁, q₂) = w(q₂) - λ(q₁, q₂) * q₂`. Together
+with `subst_pair_formalIntercept_eq_inl` this is what expresses `q₁ * w(q₂) - q₂ * w(q₁)` through
+the intercept alone.
+
+The two readings differ only in which parameter appears on the right, and rewriting with either
+one clears the intercept but leaves the slope behind; a consumer that wants the slope gone should
+reach for `subst_pair_formalIntercept_mul_sub`, which packages the combination that cancels it. -/
+theorem subst_pair_formalIntercept_eq_inr (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalIntercept W) = PowerSeries.subst q₂ (formalW W) -
+      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalSlope W) * q₂ := by
+  linear_combination subst_pair_formalIntercept_eq_inl W h₁ h₂ + subst_pair_formalSlope_mul W h₁ h₂
+
+/-- The cross combination `q₁ w(q₂) - q₂ w(q₁)` is expressed through the intercept alone:
+`q₁ w(q₂) - q₂ w(q₁) = ν(q₁, q₂) * (q₁ - q₂)`.
+
+Reading the intercept from *both* points is what makes the slope cancel, so this is the one
+intercept identity with no `λ` in it: `subst_pair_formalIntercept_eq_inl` and
+`subst_pair_formalIntercept_eq_inr` each clear the intercept but leave the slope behind. The
+factored `(q₁ - q₂)` on the right is what the associativity assembly needs in order to know that
+the chord's `x`-coordinates are distinct; reach for it there as a single rewrite rather than
+recombining the two readings by hand. -/
+theorem subst_pair_formalIntercept_mul_sub (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    q₁ * PowerSeries.subst q₂ (formalW W) - q₂ * PowerSeries.subst q₁ (formalW W) =
+      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (formalIntercept W) * (q₁ - q₂) := by
+  -- weighting the two readings by `q₂` and `q₁` makes the `λ` terms coincide and cancel
+  linear_combination q₂ * subst_pair_formalIntercept_eq_inl W h₁ h₂ -
+    q₁ * subst_pair_formalIntercept_eq_inr W h₁ h₂
+
+/-- A nonzero intercept forces a nonzero third root: at `z₃ = 0` the on-line identity
+`w(z₃) = λ z₃ + ν` collapses to `0 = ν`, since `w` has no constant term. -/
+theorem subst_pair_formalThirdRoot_ne_zero (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0)
+    (hN : subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalIntercept W) ≠ 0) :
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalThirdRoot W) ≠ 0 := by
+  intro h
+  refine hN ?_
+  have honline := subst_pair_online W h₁ h₂
+  -- `rw [h]` leaves the substitution family as the literal `fun _ ↦ 0`, which is the zero
+  -- function only definitionally, so it must be folded before
+  -- `subst_zero_of_constantCoeff_zero` will match.
+  rw [h, show (fun _ : Unit ↦ (0 : MvPowerSeries σ O)) = 0 from rfl,
+    subst_zero_of_constantCoeff_zero (constantCoeff_formalW W)] at honline
+  linear_combination -honline
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Series
+public import TauCeti.RingTheory.MvPowerSeries.Substitution
 
 /-!
 # The chord construction along an arbitrary pair of parameters
@@ -21,7 +22,6 @@ this file's, specialized; see the Provenance note there.
 
 ## Main results
 
-* `WeierstrassCurve.hasSubst_pair`: the pair is a legitimate substitution family.
 * `WeierstrassCurve.subst_pair_toMvPowerSeries_inl`,
   `WeierstrassCurve.subst_pair_toMvPowerSeries_inr`: the one-variable `w`-expansion, embedded in
   either variable, becomes `w(q₁)` respectively `w(q₂)`.
@@ -110,15 +110,8 @@ open MvPowerSeries
 variable {O : Type*} [CommRing O] (W : WeierstrassCurve O)
 variable {σ : Type*} {q₁ q₂ : MvPowerSeries σ O}
 
-/-! ### The substitution family -/
-
-/-- A pair of parameters with vanishing constant coefficient is a legitimate substitution
-family for the two-variable chord series. -/
-theorem hasSubst_pair (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
-    HasSubst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O) :=
-  hasSubst_of_constantCoeff_zero (by rintro (j | j) <;> simpa)
-
 /-- The `w`-expansion in the first parameter becomes `w(q₁)`. -/
+@[simp]
 theorem subst_pair_toMvPowerSeries_inl (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
     subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
@@ -126,6 +119,7 @@ theorem subst_pair_toMvPowerSeries_inl (h₁ : constantCoeff q₁ = 0)
   rw [PowerSeries.subst_toMvPowerSeries (hasSubst_pair h₁ h₂), Sum.elim_inl]
 
 /-- The `w`-expansion in the second parameter becomes `w(q₂)`. -/
+@[simp]
 theorem subst_pair_toMvPowerSeries_inr (h₁ : constantCoeff q₁ = 0)
     (h₂ : constantCoeff q₂ = 0) :
     subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
@@ -322,6 +316,9 @@ theorem subst_pair_formalW_formalAdd (h₁ : constantCoeff q₁ = 0) (h₂ : con
       fun _ : Unit ↦ subst (fun _ : Unit ↦ subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
         Unit ⊕ Unit → MvPowerSeries σ O) (formalThirdRoot W)) (formalInverse W) :=
     funext fun _ ↦ subst_pair_formalAdd W h₁ h₂
+  -- `PowerSeries.subst` *is* the `Unit`-indexed `MvPowerSeries.subst` by definition, so the
+  -- middle step is `rfl`; it is needed because `subst_formalInverse_formalW` is stated in the
+  -- univariate spelling while `subst_comp_subst_apply` produces the multivariable one.
   rw [hfam, ← subst_comp_subst_apply (hasSubst_of_constantCoeff_zero
     fun _ ↦ constantCoeff_formalInverse W) hT,
     show subst (fun _ : Unit ↦ formalInverse W) (formalW W) =

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -32,6 +32,12 @@ this file's, specialized; see the Provenance note there.
   pair.
 * `WeierstrassCurve.subst_pair_formalThirdRoot_relation`: the defining relation of `z₃` at
   the pair, with that inverse cleared.
+* `WeierstrassCurve.constantCoeff_subst_pair_formalThirdRoot`: the third root at the pair again
+  vanishes at the origin, so it is itself a legitimate parameter.
+* `WeierstrassCurve.subst_pair_formalAdd`: the addition series at the pair is the formal inverse
+  read at `z₃`.
+* `WeierstrassCurve.subst_pair_formalW_formalAdd`: the `w`-expansion at the addition series,
+  `w(F(q₁, q₂)) = -(w(z₃) * u(z₃)⁻¹)`.
 
 ## Implementation notes
 
@@ -67,6 +73,18 @@ and `formalW` here, continuing the renaming this repository applies to that deve
 Stoll's `A` for Vieta's denominator is `formalThirdRootDenom` here, so `pair_A_mul` and
 `pair_T₃_relation` are `subst_pair_thirdRootDenom_mul` and
 `subst_pair_formalThirdRoot_relation`.
+
+Also from that file, `pair_thirdRoot_constantCoeff` is
+`constantCoeff_subst_pair_formalThirdRoot` and `pair_wF` is `subst_pair_formalW_formalAdd`.
+The source's `pair_F_comp` needs no counterpart of its own: it says the addition series at the
+pair is the inverse series read at the third root, which here is `formalAdd`'s *definition*
+(`Add/Series.lean`) pushed through the substitution, and that is `subst_pair_formalAdd`.
+
+**A naming trap worth recording, since the rename map above invites the wrong reading.** Stoll's
+`uSeries` (`Chord.lean:351`, `1 - a₁ z - a₃ w`) is `formalInverseDenom` here
+(`FormalGroup/Inverse.lean`), **not** `formalU`. This repository's `formalU` is a different
+series — the unit part of the `w`-expansion, `w = z³ u`. Anything ported from the source's `u`
+lemmas must target `formalInverseDenom`.
 
 The source's `pair_intercept_identity₁` and `pair_intercept_identity₂` are not ported here. Their
 consumers lie in the source's `Assembly` section, so they belong with that first consumer rather

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/PairSubst.lean
@@ -26,6 +26,12 @@ this file's, specialized; see the Provenance note there.
   `WeierstrassCurve.subst_pair_toMvPowerSeries_inr`: the one-variable `w`-expansion, embedded in
   either variable, becomes `w(q₁)` respectively `w(q₂)`.
 * `WeierstrassCurve.subst_pair_formalSlope_mul`: `λ(q₁, q₂) * (q₂ - q₁) = w(q₂) - w(q₁)`.
+* `WeierstrassCurve.subst_pair_online`: the `w`-expansion at the third root is the chord
+  line read there.
+* `WeierstrassCurve.subst_pair_thirdRootDenom_mul`: Vieta's denominator stays a unit at the
+  pair.
+* `WeierstrassCurve.subst_pair_formalThirdRoot_relation`: the defining relation of `z₃` at
+  the pair, with that inverse cleared.
 
 ## Implementation notes
 
@@ -51,17 +57,22 @@ Adapted from Michael Stoll's `EllipticCurves` project
 (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
 `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`, whose full expansion is
 `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`),
-`EllipticCurves/WeierstrassFormalGroup/ThirdPoint.lean`, declarations `hasSubst_pair` and
-`pair_slope_identity`, together with `pair_online` from
-`EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`.
+`EllipticCurves/WeierstrassFormalGroup/ThirdPoint.lean`, declarations `hasSubst_pair`,
+`pair_slope_identity`, `pair_A_mul` and `pair_T₃_relation`, together with `pair_online`
+from `EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`.
 
 The source's `slopeSeries`, `interceptSeries` and `wSeries` are `formalSlope`, `formalIntercept`
 and `formalW` here, continuing the renaming this repository applies to that development, so
 `pair_slope_identity` and `pair_online` are `subst_pair_formalSlope_mul` and `subst_pair_online`.
+Stoll's `A` for Vieta's denominator is `formalThirdRootDenom` here, so `pair_A_mul` and
+`pair_T₃_relation` are `subst_pair_thirdRootDenom_mul` and
+`subst_pair_formalThirdRoot_relation`.
 
 The source's `pair_intercept_identity₁` and `pair_intercept_identity₂` are not ported here. Their
 consumers lie in the source's `Assembly` section, so they belong with that first consumer rather
-than in this file.
+than in this file: `pair_intercept_identity₁` is
+`WeierstrassCurve.subst_pair_formalIntercept` in `FormalGroup/Add/Assoc.lean`, and
+`pair_intercept_identity₂` has no consumer here yet.
 -/
 
 public section
@@ -133,5 +144,91 @@ theorem subst_pair_online (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff 
   simp only [map_add, map_mul] at h
   simp only [coe_substAlgHom (hasSubst_pair h₁ h₂)] at h
   rwa [subst_comp_subst_apply (hasSubst_formalThirdRoot W) (hasSubst_pair h₁ h₂)] at h
+
+/-! ### Vieta's denominator and the third-root relation -/
+
+/-- Vieta's denominator, read at the pair `(q₁, q₂)`, is still a unit: it times its `invOfUnit`
+is `1`. -/
+theorem subst_pair_thirdRootDenom_mul (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    (1 + C W.a₂ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) +
+        C W.a₄ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) ^ 2 +
+        C W.a₆ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) ^ 3) *
+      subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+        (invOfUnit (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
+      C W.a₆ * formalSlope W ^ 3) 1) = 1 := by
+  have h := congrArg (substAlgHom (hasSubst_pair h₁ h₂))
+    (mul_invOfUnit (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
+      C W.a₆ * formalSlope W ^ 3) 1 (constantCoeff_formalThirdRootDenom W))
+  simp only [map_mul, map_add, map_one, map_pow] at h
+  simp only [coe_substAlgHom (hasSubst_pair h₁ h₂), subst_C] at h
+  exact h
+
+/-- The defining relation of the third root at the pair `(q₁, q₂)`, with the inverse of Vieta's
+denominator eliminated. -/
+theorem subst_pair_formalThirdRoot_relation (h₁ : constantCoeff q₁ = 0)
+    (h₂ : constantCoeff q₂ = 0) :
+    (1 + C W.a₂ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) +
+        C W.a₄ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) ^ 2 +
+        C W.a₆ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) ^ 3) *
+      (subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalThirdRoot W) + q₁ + q₂) =
+      -(C W.a₁ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) +
+        C W.a₂ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalIntercept W) +
+        C W.a₃ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) ^ 2 +
+        2 * C W.a₄ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) *
+          subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+            (formalIntercept W) +
+        3 * C W.a₆ *
+        subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+          (formalSlope W) ^ 2 *
+          subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+            (formalIntercept W)) := by
+  have hexp := congrArg (substAlgHom (hasSubst_pair h₁ h₂)) (formalThirdRoot_def W)
+  simp only [map_sub, map_neg, map_mul, map_add, map_pow, map_ofNat] at hexp
+  simp only [coe_substAlgHom (hasSubst_pair h₁ h₂), subst_X (hasSubst_pair h₁ h₂),
+    subst_C] at hexp
+  have hr : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inr ()) = q₂ := rfl
+  have hl : (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) :
+      Unit ⊕ Unit → MvPowerSeries σ O) (Sum.inl ()) = q₁ := rfl
+  rw [hr, hl] at hexp
+  have hAd := subst_pair_thirdRootDenom_mul W h₁ h₂
+  set Lp :=
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalSlope W)
+  set Np :=
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalIntercept W)
+  set Tp :=
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (formalThirdRoot W)
+  set dp :=
+    subst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O)
+      (invOfUnit (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
+      C W.a₆ * formalSlope W ^ 3) 1)
+  clear_value Lp Np Tp dp
+  linear_combination (1 + C W.a₂ * Lp + C W.a₄ * Lp ^ 2 + C W.a₆ * Lp ^ 3) * hexp -
+    (C W.a₁ * Lp + C W.a₂ * Np + C W.a₃ * Lp ^ 2 + 2 * C W.a₄ * Lp * Np +
+      3 * C W.a₆ * Lp ^ 2 * Np) * hAd
 
 end WeierstrassCurve

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -178,6 +178,8 @@ respectively are distinct. -/
 noncomputable def coordSpecialize (i : σ') : σ' → MvPowerSeries Unit O :=
   fun j ↦ if j = i then PowerSeries.X else 0
 
+/-- The coordinate specialization at `i` is a legitimate substitution family over a finite index
+type: every image is either `X` or `0`, and both have vanishing constant coefficient. -/
 theorem hasSubst_coordSpecialize [Finite σ'] (i : σ') : HasSubst (coordSpecialize (O := O) i) :=
   hasSubst_of_constantCoeff_zero fun j ↦ by
     simp only [coordSpecialize]

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -169,7 +169,7 @@ end HasSubstPair
 
 section CoordSpecialize
 
-variable {O : Type*} [CommRing O] {σ' : Type*} [DecidableEq σ']
+variable {O : Type*} [CommRing O] {σ' : Type*}
 
 /-- The substitution sending the coordinate variable `i` to `X` and every other coordinate to `0`.
 
@@ -177,6 +177,9 @@ Specializing to it separates the coordinate `i` from all the others: with
 `ne_of_subst_eq_X_of_subst_eq_zero`, two series that this substitution sends to `X` and to `0`
 respectively are distinct. -/
 noncomputable def coordSpecialize (i : σ') : σ' → MvPowerSeries Unit O :=
+  -- classical decidability suffices: the definition is noncomputable regardless, so asking the
+  -- caller for `[DecidableEq σ']` would only narrow the API.
+  letI := Classical.decEq σ'
   fun j ↦ if j = i then PowerSeries.X else 0
 
 /-- The coordinate specialization at `i` is a legitimate substitution family, for an index type of

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -132,6 +132,22 @@ theorem aeval_subst {a : σ → MvPowerSeries τ S} {ε : MvPowerSeries τ S →
   simpa only [AlgHom.coe_comp, Function.comp_apply, substAlgHom_apply] using DFunLike.congr_fun
     ((aeval_unique h1).symm.trans (mid.trans (aeval_unique h2'))) f
 
+section HasSubstPair
+
+variable {O : Type*} [CommRing O] {q₁ q₂ : MvPowerSeries σ O}
+
+/-- A pair of series with vanishing constant coefficient is a legitimate substitution family for
+the two variables indexed by `Unit ⊕ Unit`.
+
+This packages the `rintro`-and-`simpa` discharge of `hasSubst_of_constantCoeff_zero`'s hypothesis
+for the two-variable case, which is otherwise repeated at every substitution into a two-variable
+series. -/
+theorem hasSubst_pair (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂ = 0) :
+    HasSubst (Sum.elim (fun _ ↦ q₁) (fun _ ↦ q₂) : Unit ⊕ Unit → MvPowerSeries σ O) :=
+  hasSubst_of_constantCoeff_zero (by rintro (j | j) <;> simpa)
+
+end HasSubstPair
+
 end MvPowerSeries
 
 namespace PowerSeries

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -46,8 +46,9 @@ uniformities are shadowed, so the evaluation the statement is about is never re-
   meets a two-variable evaluation.
 * `MvPowerSeries.hasSubst_pair` : a pair of series with vanishing constant coefficient is a
   legitimate substitution family for the two variables indexed by `Unit ⊕ Unit`.
-* `MvPowerSeries.coordSpecialize` and its `subst_coordSpecialize_*` lemmas : the substitution
-  sending one coordinate variable to `X` and every other to `0`.
+* `MvPowerSeries.coordSpecialize`, `MvPowerSeries.hasSubst_coordSpecialize` and the two
+  `subst_coordSpecialize_X_*` lemmas : the substitution sending one coordinate variable to `X` and
+  every other to `0`, for an index type of any size.
 * `MvPowerSeries.ne_of_subst_eq_X_of_subst_eq_zero` : a substitution sending one series to `X` and
   another to `0` separates them.
 
@@ -178,32 +179,36 @@ respectively are distinct. -/
 noncomputable def coordSpecialize (i : σ') : σ' → MvPowerSeries Unit O :=
   fun j ↦ if j = i then PowerSeries.X else 0
 
-/-- The coordinate specialization at `i` is a legitimate substitution family over a finite index
-type: every image is either `X` or `0`, and both have vanishing constant coefficient. -/
-theorem hasSubst_coordSpecialize [Finite σ'] (i : σ') : HasSubst (coordSpecialize (O := O) i) :=
-  hasSubst_of_constantCoeff_zero fun j ↦ by
-    simp only [coordSpecialize]
-    split
-    · exact PowerSeries.constantCoeff_X
-    · exact map_zero _
+/-- The coordinate specialization at `i` is a legitimate substitution family, for an index type of
+any size: every image is `X` or `0`, so every constant coefficient vanishes, and the coordinates
+carrying a given coefficient all lie in the singleton `{i}`. -/
+theorem hasSubst_coordSpecialize (i : σ') : HasSubst (coordSpecialize (O := O) i) where
+  const_coeff j := by
+    have h : constantCoeff (coordSpecialize (O := O) i j) = 0 := by
+      unfold coordSpecialize
+      split
+      · exact PowerSeries.constantCoeff_X
+      · exact map_zero _
+    rw [h]
+    exact IsNilpotent.zero
+  -- `Finite σ'` would give this immediately, but it is not needed: the family is `0` away from
+  -- `i`, so the coordinates carrying a nonzero coefficient sit inside the singleton `{i}`.
+  coeff_zero d := Set.Finite.subset (Set.finite_singleton i) fun j hj ↦ by
+    simp only [Set.mem_singleton_iff]
+    by_contra hne
+    exact hj (by simp [coordSpecialize, hne])
 
 /-- The specialization at `i` sends the `i`-th coordinate to `X`. -/
 @[simp]
-theorem subst_coordSpecialize_X_self [Finite σ'] (i : σ') :
+theorem subst_coordSpecialize_X_self (i : σ') :
     subst (coordSpecialize (O := O) i) (X i : MvPowerSeries σ' O) = PowerSeries.X := by
   simp [subst_X (hasSubst_coordSpecialize i), coordSpecialize]
 
 /-- The specialization at `i` kills every other coordinate. -/
 @[simp]
-theorem subst_coordSpecialize_X_of_ne [Finite σ'] {i j : σ'} (h : j ≠ i) :
+theorem subst_coordSpecialize_X_of_ne {i j : σ'} (h : j ≠ i) :
     subst (coordSpecialize (O := O) i) (X j : MvPowerSeries σ' O) = 0 := by
   simp [subst_X (hasSubst_coordSpecialize i), coordSpecialize, h]
-
-/-- The specialization at `i` is a ring map, so it kills `0`. -/
-@[simp]
-theorem subst_coordSpecialize_zero [Finite σ'] (i : σ') :
-    subst (coordSpecialize (O := O) i) (0 : MvPowerSeries σ' O) = 0 := by
-  rw [← coe_substAlgHom (hasSubst_coordSpecialize i), map_zero]
 
 end CoordSpecialize
 

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -148,6 +148,52 @@ theorem hasSubst_pair (h₁ : constantCoeff q₁ = 0) (h₂ : constantCoeff q₂
 
 end HasSubstPair
 
+section CoordSpecialize
+
+variable {O : Type*} [CommRing O] {σ' : Type*} [DecidableEq σ'] [Finite σ']
+
+/-- The substitution sending the coordinate variable `i` to `X` and every other coordinate to `0`.
+
+Specializing to it separates the coordinate `i` from all the others: with
+`ne_of_subst_eq_X_of_subst_eq_zero`, two series that this substitution sends to `X` and to `0`
+respectively are distinct. -/
+noncomputable def coordSpecialize (i : σ') : σ' → MvPowerSeries Unit O :=
+  fun j ↦ if j = i then PowerSeries.X else 0
+
+theorem hasSubst_coordSpecialize (i : σ') : HasSubst (coordSpecialize (O := O) i) :=
+  hasSubst_of_constantCoeff_zero fun j ↦ by
+    simp only [coordSpecialize]
+    split
+    · exact PowerSeries.constantCoeff_X
+    · exact map_zero _
+
+/-- The specialization at `i` sends the `i`-th coordinate to `X`. -/
+@[simp]
+theorem subst_coordSpecialize_X_self (i : σ') :
+    subst (coordSpecialize (O := O) i) (X i : MvPowerSeries σ' O) = PowerSeries.X := by
+  simp [subst_X (hasSubst_coordSpecialize i), coordSpecialize]
+
+/-- The specialization at `i` kills every other coordinate. -/
+@[simp]
+theorem subst_coordSpecialize_X_of_ne {i j : σ'} (h : j ≠ i) :
+    subst (coordSpecialize (O := O) i) (X j : MvPowerSeries σ' O) = 0 := by
+  simp [subst_X (hasSubst_coordSpecialize i), coordSpecialize, h]
+
+/-- The specialization at `i` is a ring map, so it kills `0`. -/
+theorem subst_coordSpecialize_zero (i : σ') :
+    subst (coordSpecialize (O := O) i) (0 : MvPowerSeries σ' O) = 0 := by
+  rw [← coe_substAlgHom (hasSubst_coordSpecialize i), map_zero]
+
+end CoordSpecialize
+
+/-- A substitution that sends one series to `X` and another to `0` separates them: it is how a
+distinctness hypothesis is discharged by specializing one coordinate to `X` and the rest to
+`0`. -/
+theorem ne_of_subst_eq_X_of_subst_eq_zero {O : Type*} [CommRing O] [Nontrivial O] {σ' : Type*}
+    {g : σ' → MvPowerSeries Unit O} {a b : MvPowerSeries σ' O}
+    (ha : subst g a = PowerSeries.X) (hb : subst g b = 0) : a ≠ b := fun hab ↦
+  PowerSeries.X_ne_zero (by rw [← ha, hab]; exact hb)
+
 end MvPowerSeries
 
 namespace PowerSeries

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -44,6 +44,24 @@ uniformities are shadowed, so the evaluation the statement is about is never re-
   univariate series viewed in several variables is evaluating it at the matching entry of the
   family — the case of `aeval_subst` at a single variable, which is how a one-variable series
   meets a two-variable evaluation.
+* `MvPowerSeries.hasSubst_pair` : a pair of series with vanishing constant coefficient is a
+  legitimate substitution family for the two variables indexed by `Unit ⊕ Unit`.
+* `MvPowerSeries.coordSpecialize` and its `subst_coordSpecialize_*` lemmas : the substitution
+  sending one coordinate variable to `X` and every other to `0`.
+* `MvPowerSeries.ne_of_subst_eq_X_of_subst_eq_zero` : a substitution sending one series to `X` and
+  another to `0` separates them.
+
+## Separating multivariable parameters
+
+The second group of results above is about *distinguishing* series rather than evaluating them.
+Two series of `MvPowerSeries σ' O` can be told apart by exhibiting a substitution that sends one
+to `X` and the other to `0`, since `X ≠ 0` in a nontrivial coefficient ring; `coordSpecialize i`
+is the substitution that does this for the coordinate variables, specializing `X i` to `X` and
+every other coordinate to `0`. Together they turn a distinctness obligation into a computation
+with `subst`, which is how a multivariable identity proved by comparing parametrized points gets
+its "the parameters are pairwise distinct" hypotheses. `hasSubst_pair` is the companion for the
+two-variable case, packaging the substitutability side condition that every substitution into a
+two-variable series has to discharge.
 
 The two `aeval_subst` results are wanted for the formal group of an elliptic curve over a complete
 local ring, where the group law is a power series over the very ring it is evaluated in: the
@@ -150,7 +168,7 @@ end HasSubstPair
 
 section CoordSpecialize
 
-variable {O : Type*} [CommRing O] {σ' : Type*} [DecidableEq σ'] [Finite σ']
+variable {O : Type*} [CommRing O] {σ' : Type*} [DecidableEq σ']
 
 /-- The substitution sending the coordinate variable `i` to `X` and every other coordinate to `0`.
 
@@ -160,7 +178,7 @@ respectively are distinct. -/
 noncomputable def coordSpecialize (i : σ') : σ' → MvPowerSeries Unit O :=
   fun j ↦ if j = i then PowerSeries.X else 0
 
-theorem hasSubst_coordSpecialize (i : σ') : HasSubst (coordSpecialize (O := O) i) :=
+theorem hasSubst_coordSpecialize [Finite σ'] (i : σ') : HasSubst (coordSpecialize (O := O) i) :=
   hasSubst_of_constantCoeff_zero fun j ↦ by
     simp only [coordSpecialize]
     split
@@ -169,18 +187,19 @@ theorem hasSubst_coordSpecialize (i : σ') : HasSubst (coordSpecialize (O := O) 
 
 /-- The specialization at `i` sends the `i`-th coordinate to `X`. -/
 @[simp]
-theorem subst_coordSpecialize_X_self (i : σ') :
+theorem subst_coordSpecialize_X_self [Finite σ'] (i : σ') :
     subst (coordSpecialize (O := O) i) (X i : MvPowerSeries σ' O) = PowerSeries.X := by
   simp [subst_X (hasSubst_coordSpecialize i), coordSpecialize]
 
 /-- The specialization at `i` kills every other coordinate. -/
 @[simp]
-theorem subst_coordSpecialize_X_of_ne {i j : σ'} (h : j ≠ i) :
+theorem subst_coordSpecialize_X_of_ne [Finite σ'] {i j : σ'} (h : j ≠ i) :
     subst (coordSpecialize (O := O) i) (X j : MvPowerSeries σ' O) = 0 := by
   simp [subst_X (hasSubst_coordSpecialize i), coordSpecialize, h]
 
 /-- The specialization at `i` is a ring map, so it kills `0`. -/
-theorem subst_coordSpecialize_zero (i : σ') :
+@[simp]
+theorem subst_coordSpecialize_zero [Finite σ'] (i : σ') :
     subst (coordSpecialize (O := O) i) (0 : MvPowerSeries σ' O) = 0 := by
   rw [← coe_substAlgHom (hasSubst_coordSpecialize i), map_zero]
 


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:Layer-1-formal-group-(i):assoc_formalAdd"}-->

Provenance: github.com/MichaelStollBayreuth/EllipticCurves @ 66889eada51a, Apache-2.0 — `EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean` sections `Domain` (`subst_wSeries_ne_zero`, :136) and `Assembly` (`fracCurve` :309, `rho_weierstrass` :313, `thetaPoint` :338, `thetaPoint_add` :350, `thetaPoint_neg` :475, `thetaPoint_inj` :525, `pair_intercept_ne_zero_of_ne` :551), plus the single-parameter helpers `single_u_mul`, `single_u_eq`, `single_iota_eq`, `single_wIota` from `EllipticCurves/WeierstrassFormalGroup/ThirdPoint.lean`:584-612.

## What this adds

**`WeierstrassCurve.formalAdd_assoc`** — associativity of the chord addition series,
`F(F(t₁, t₂), t₃) = F(t₁, F(t₂, t₃))`, for every Weierstrass curve over every commutative ring.

Together with `constantCoeff_formalAdd`, `subst_unitR_formalAdd`, `subst_unitL_formalAdd` and
`rename_swap_formalAdd`, which are already on `main`, this is **the last axiom of a commutative
formal group law** that the development was missing. Reindexing the three variables to `Fin 3`
(`Add/Fin2.lean`) is what turns it into Mathlib's `FormalGroup.assoc` field, so this is the
remaining input to the roadmap's Layer 1 milestone (i) — `Ê` as an instance of Mathlib's
`RingTheory/FormalGroup`. `STATUS.md` records Layer 1 as still lacking "a complete elliptic
formal group".

## How it is proved

The parameters are power series, so the curve is read over a field containing them. `Assoc.lean`
base changes `W` along `O → MvPowerSeries σ O → KK`, records the `w`-equation there, and
identifies a parameter `q` with the point `(q, w(q))` it names (`thetaPoint`). Chord addition of
those points *is* the addition series, so associativity of the curve's honest group law becomes
associativity of the series.

That argument needs a domain, so it runs over the universal curve, whose base `ℤ[A₁, ⋯, A₆]`
supplies one (`assoc_formalAdd_universal`); `map_specialize` then carries the conclusion to every
`W` over every commutative ring.

## The two new files

- `FormalGroup/Add/PairSubst.lean` (379 lines) — `FormalGroup/Chord.lean` states the chord data
  (slope `λ`, intercept `ν`, third root `z₃`, addition series `F`) in the two variables of
  `MvPowerSeries (Unit ⊕ Unit) O`. This substitutes an **arbitrary pair** `(q₁, q₂)` of series
  with vanishing constant coefficient and carries each identity across. `Add/Inverse.lean`
  already did this for the single pair `(z, ι(z))`; its versions are now this file's, specialized.
- `FormalGroup/Add/Assoc.lean` (834 lines) — the fraction-field transport and the assembly above.

`Add/Inverse.lean` changes only to route its `hasSubst_invPair` and two
`subst_invPair_toMvPowerSeries_*` lemmas through the new general forms, and to correct a
provenance note: `subst_wSeries_ne_zero` was previously recorded as unported for want of a
consumer, and `Add/Assoc.lean` is now that consumer.

## Divergences from the source

Two proofs differ because this repository already has the content in a more usable form, and
both are noted in the file's Provenance block:

- `pair_intercept_ne_zero_of_ne` collapses the cross combination with the single rewrite
  `subst_pair_formalIntercept_mul_sub`, where the source combines its two intercept readings by
  hand.
- the `hA` step inside `thetaPoint_add` argues through the constant coefficient in the source,
  whereas `subst_pair_thirdRootDenom_mul` here already exhibits an explicit inverse.

The four single-parameter helpers are transports of the `FormalGroup/Inverse.lean` identities
along `PowerSeries.subst q`, not re-derivations. The source's `wSeries`/`vSeries` are `formalW`
and `formalU` here, continuing this repository's renaming of that development, so
`subst_wSeries_ne_zero` is `subst_formalW_ne_zero`. Two of the source's helpers in this range are
not ported because Mathlib already has them more generally (`subst_pair_rename` is
`PowerSeries.subst_toMvPowerSeries` composed with `Sum.elim_inl`/`Sum.elim_inr`).

## Gates

- `lake build` on all three modules: green, 0 errors, 0 warnings under `warningAsError = true`.
- `scripts/lint-style.sh`: exit 0 (4288 headers conforming, no findings).
- No `sorry`, no `native_decide`, no `maxHeartbeats`, no `set_option`.
- New files are 834 and 379 lines, both under the 1000-line new-file guard.
- Nothing imports these modules yet, so they are leaves: no in-repo call sites to update.

## Review

Round 1 (head `9ccd6c4`) returned 3/10 green — correctness, scope and attribution approved — with
seven rubrics requesting changes. Notably **proof-quality did not object to proof length**; its
finding was undocumented definitional-equality steps.

Addressed in `43cf1d7`:

- **naming** — `assoc_formalAdd` → `formalAdd_assoc` (cf. `mul_assoc`, `gradedMul_assoc`).
- **api-design + generality** — `fracCurve` and `algebraMap_subst_formalW_wEquation` are now
  `private` (neither is used outside this module) and `fracCurve` is stated over `[CommRing KK]`,
  since nothing in it needs division. `Assoc.lean`'s public surface is now exactly
  `formalAdd_assoc`.
- **api-design + placement** — the four `subst_pair_formalIntercept_*` /
  `subst_pair_formalThirdRoot_ne_zero` lemmas move to `Add/PairSubst.lean`, their canonical home.
  This also falsified a `PairSubst.lean` provenance claim that they lived in `Assoc.lean`, now
  corrected.
- **api-design** — `@[simp]` on `constantCoeff_subst_pair_formalThirdRoot`.
- **placement** — `Add/Inverse.lean` drops its now-redundant direct `Add.Series` import.
- **proof-quality** — the `show … from rfl` steps bridging the `PowerSeries` and
  `MvPowerSeries Unit` spellings, and the one folding `fun _ ↦ 0` into `0`, now carry comments
  stating what is definitional and why no rewrite reaches it.
- **documentation** — roadmap citations and transient porting/consumer narrative removed from all
  three module docstrings; the source/license/declaration mapping and the mathematical account of
  each divergence remain.

**`reuse` is contested rather than implemented.** It asks for `hasSubst_pair` and the two
`subst_pair_toMvPowerSeries_*` lemmas to be deleted, while `api-design` asks for `@[simp]` on two
of those same three and `naming` asks for the third to be moved to the `MvPowerSeries` namespace
with its 25 call sites requalified. A declaration cannot be both deleted and annotated/relocated.
The contest is posted in the reuse thread with both conflicting quotations; those three
declarations are left in place pending adjudication.
