### PR TITLE
feat(Huber): the ring structure on two-sided restricted series

### DIFF
--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
@@ -84,8 +84,6 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
   `TauCeti.Huber.coe_algebraMap_twoSidedRestrictedSubmodule`: the computation API. The instance
   bodies are not exposed, so these are how a product, the unit, a monomial and the structure map are
   computed outside this module.
-* `TauCeti.Huber.convolution_assoc`: associativity of the coefficient convolution — the one ring
-  axiom Mathlib's `DiscreteConvolution` does not supply.
 
 ## Implementation notes
 
@@ -280,45 +278,41 @@ variable [T0Space A]
 
 namespace twoSidedRestrictedSubmodule
 
-/-- **The coefficient convolution is associative**: both bracketings of `fgh` are the sum of
-`aᵢ bⱼ cₗ` over `{i + j + l = n}`. This is the one ring axiom Mathlib's `DiscreteConvolution` does
-not supply, and it is what `twoSidedRestrictedSubmodule.instRing` is waiting on. It is named for the
-convolution rather than `mul_assoc` so that it neither shadows nor duplicates the standard lemma. -/
-theorem convolution_assoc (f g h : twoSidedRestrictedSubmodule A A) :
-    f * g * h = f * (g * h) := by
-  ext n
-  simp only [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply]
-  -- Index that fibre by `(m, k) ↦ (k, m - k, n - m)`, with `m` the degree of the partial product
-  -- `fg`. It is a subfamily of `(i, j, l) ↦ aᵢbⱼcₗ`, which is summable on all of `ℤ × ℤ × ℤ`.
-  have hF : Summable fun p : ℤ × ℤ ↦
-      (f : ℤ → A) p.2 * (g : ℤ → A) (p.1 - p.2) * (h : ℤ → A) (n - p.1) :=
-    (((mem_twoSidedRestrictedSubmodule_iff_summable.mp f.2).mul_of_nonarchimedean
-      (mem_twoSidedRestrictedSubmodule_iff_summable.mp g.2)).mul_of_nonarchimedean
-      (mem_twoSidedRestrictedSubmodule_iff_summable.mp h.2)).comp_injective
-      (i := fun p : ℤ × ℤ ↦ ((p.2, p.1 - p.2), n - p.1)) fun p q hpq ↦ by grind
-  -- Both bracketings are that single sum, summed in two orders: fibring over `m` gives `((fg)h)ₙ`
-  -- by summing first over `k`, and fibring the reindexed family gives `(f(gh))ₙ`.
-  refine (hF.hasSum.prod_fiberwise fun m ↦ ?_).tsum_eq.trans (HasSum.prod_fiberwise
-      (f := fun q : ℤ × ℤ ↦ (f : ℤ → A) q.1 * ((g : ℤ → A) q.2 * (h : ℤ → A) (n - q.1 - q.2)))
-      ?_ fun k ↦ ?_).tsum_eq.symm
-  -- Fibre of `((fg)h)ₙ` over `m`: the `k`-series computing `(fg)ₘ`, scaled on the right by `h`.
-  · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule f.2 g.2 m).hasSum.mul_right
-      ((h : ℤ → A) (n - m))
-  -- The reindexing `(m, k) ↦ (k, m - k)` is `Equiv.prodComm` followed by a shear; it carries `hF`
-  -- to the family whose fibres give `(f(gh))ₙ`, with `mul_assoc` rebracketing each term.
-  · refine ((Equiv.prodComm ℤ ℤ).trans ((Equiv.refl ℤ).prodShear Equiv.subRight)).hasSum_iff.mp ?_
-    simpa [Function.comp_def, mul_assoc] using hF.hasSum
-  -- Fibre of `(f(gh))ₙ` over `k`: the series computing `(gh)_{n - k}`, scaled on the left by `f`.
-  · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule g.2 h.2 (n - k)).hasSum.mul_left
-      ((f : ℤ → A) k)
-
 /-- **`A⟨X, X⁻¹⟩` is a ring** (Wedhorn, Example 6.39). -/
 noncomputable instance instRing : Ring (twoSidedRestrictedSubmodule A A) where
   __ := Submodule.addCommGroup _
   __ := instMul
   __ := instOne
-  -- Associativity is the one ring axiom Mathlib's `DiscreteConvolution` lacks; it is proved here.
-  mul_assoc := convolution_assoc
+  -- Associativity is the one ring axiom Mathlib's `DiscreteConvolution` lacks, so it is proved
+  -- here rather than inherited. Both bracketings of `fgh` are the sum of `aᵢ bⱼ cₗ` over
+  -- `{i + j + l = n}`; the proof is inline because the statement, once this instance exists, is
+  -- exactly the standard `mul_assoc`.
+  mul_assoc f g h := by
+    ext n
+    simp only [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply]
+    -- Index that fibre by `(m, k) ↦ (k, m - k, n - m)`, with `m` the degree of the partial product
+    -- `fg`. It is a subfamily of `(i, j, l) ↦ aᵢbⱼcₗ`, which is summable on all of `ℤ × ℤ × ℤ`.
+    have hF : Summable fun p : ℤ × ℤ ↦
+        (f : ℤ → A) p.2 * (g : ℤ → A) (p.1 - p.2) * (h : ℤ → A) (n - p.1) :=
+      (((mem_twoSidedRestrictedSubmodule_iff_summable.mp f.2).mul_of_nonarchimedean
+        (mem_twoSidedRestrictedSubmodule_iff_summable.mp g.2)).mul_of_nonarchimedean
+        (mem_twoSidedRestrictedSubmodule_iff_summable.mp h.2)).comp_injective
+        (i := fun p : ℤ × ℤ ↦ ((p.2, p.1 - p.2), n - p.1)) fun p q hpq ↦ by grind
+    -- Both bracketings are that single sum, summed in two orders: fibring over `m` gives `((fg)h)ₙ`
+    -- by summing first over `k`, and fibring the reindexed family gives `(f(gh))ₙ`.
+    refine (hF.hasSum.prod_fiberwise fun m ↦ ?_).tsum_eq.trans (HasSum.prod_fiberwise
+        (f := fun q : ℤ × ℤ ↦ (f : ℤ → A) q.1 * ((g : ℤ → A) q.2 * (h : ℤ → A) (n - q.1 - q.2)))
+        ?_ fun k ↦ ?_).tsum_eq.symm
+    -- Fibre of `((fg)h)ₙ` over `m`: the `k`-series computing `(fg)ₘ`, scaled on the right by `h`.
+    · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule f.2 g.2 m).hasSum.mul_right
+        ((h : ℤ → A) (n - m))
+    -- The reindexing `(m, k) ↦ (k, m - k)` is `Equiv.prodComm` followed by a shear; it carries `hF`
+    -- to the family whose fibres give `(f(gh))ₙ`, with `mul_assoc` rebracketing each term.
+    · refine ((Equiv.prodComm ℤ ℤ).trans ((Equiv.refl ℤ).prodShear Equiv.subRight)).hasSum_iff.mp ?_
+      simpa [Function.comp_def, mul_assoc] using hF.hasSum
+    -- Fibre of `(f(gh))ₙ` over `k`: the series computing `(gh)_{n - k}`, scaled on the left by `f`.
+    · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule g.2 h.2 (n - k)).hasSum.mul_left
+        ((f : ℤ → A) k)
   -- The unit laws are Mathlib's `single_addConvolution` and `addConvolution_single`, reached
   -- through the two coercion `simp` lemmas above.
   one_mul _ := Subtype.ext <| by simp

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
@@ -5,10 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Algebra.Bilinear
 public import Mathlib.Topology.Algebra.InfiniteSum.DiscreteConvolution
 public import Mathlib.Topology.Algebra.InfiniteSum.Nonarchimedean
-public import TauCeti.RingTheory.Huber.Restricted.TwoSidedSeries
+public import TauCeti.RingTheory.Huber.Restricted.TwoSided.Series
 
 /-!
 # The ring of two-sided restricted series `A⟨X, X⁻¹⟩`
@@ -55,6 +54,9 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
   `DiscreteConvolution.addConvolution` along the bilinear map `LinearMap.mul ℤ A`.
 * `TauCeti.Huber.twoSidedRestrictedSubmodule.instRing`, `instCommRing`, `instAlgebra`: **the ring
   structure**, and the `A`-algebra structure of Example 6.39 when `A` is commutative.
+* `TauCeti.Huber.twoSidedMonomial`: the monomial `a Xⁿ`, and with it
+  `TauCeti.Huber.twoSidedX` and `TauCeti.Huber.twoSidedXInv` — the Laurent variable `X` and its
+  inverse, which Wedhorn writes `ζ` and `ζ⁻¹`.
 
 ## Main results
 
@@ -66,11 +68,18 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
 * `TauCeti.Huber.summable_mul_sub_of_mem_twoSidedRestrictedSubmodule` and
   `TauCeti.Huber.addConvolutionExists_of_mem_twoSidedRestrictedSubmodule`: over a complete ring the
   coefficient series of a product converge.
+* `TauCeti.Huber.twoSidedMonomial_mul_twoSidedMonomial`: **monomials add degrees**,
+  `(a Xᵐ)(b Xⁿ) = ab X^{m+n}`, and hence `TauCeti.Huber.twoSidedX_mul_twoSidedXInv`: `X` is a unit
+  with inverse `X⁻¹`. Both hold with no completeness, summability or separation hypothesis, since
+  only one term of the coefficient series survives.
+* `TauCeti.Huber.coe_mul_apply`: the coefficient of a product read off an element of the submodule,
+  `(fg)ₙ = ∑' k, aₖ b_{n-k}`.
 * `TauCeti.Huber.coe_mul_twoSidedRestrictedSubmodule`,
-  `TauCeti.Huber.coe_one_twoSidedRestrictedSubmodule` and
+  `TauCeti.Huber.coe_one_twoSidedRestrictedSubmodule`,
+  `TauCeti.Huber.coe_twoSidedMonomial` and
   `TauCeti.Huber.coe_algebraMap_twoSidedRestrictedSubmodule`: the computation API. The instance
-  bodies are not exposed, so these are how a product, the unit and the structure map are computed
-  outside this module.
+  bodies are not exposed, so these are how a product, the unit, a monomial and the structure map are
+  computed outside this module.
 
 ## Implementation notes
 
@@ -166,7 +175,83 @@ not exposed, so this is how the unit is computed outside this module. -/
 theorem coe_one_twoSidedRestrictedSubmodule :
     ((1 : twoSidedRestrictedSubmodule A A) : ℤ → A) = Pi.single 0 1 := rfl
 
+/-- **The coefficient formula for a product**, on the submodule rather than on raw families:
+`(fg)ₙ = ∑' k, aₖ b_{n-k}`. This is the form a consumer computing with elements of `A⟨X, X⁻¹⟩`
+wants, and it needs no completeness — where the series fails to converge both sides are `0` by the
+`tsum` convention. -/
+@[simp]
+theorem coe_mul_apply (f g : twoSidedRestrictedSubmodule A A) (n : ℤ) :
+    ((f * g : twoSidedRestrictedSubmodule A A) : ℤ → A) n
+      = ∑' k : ℤ, (f : ℤ → A) k * (g : ℤ → A) (n - k) := by
+  rw [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply]
+
+/-- **The monomial `a Xⁿ`** of `A⟨X, X⁻¹⟩`: the family supported at degree `n` with value `a`.
+Restrictedness is `single_mem_twoSidedRestrictedSubmodule`. -/
+@[expose] def twoSidedMonomial (n : ℤ) (a : A) : twoSidedRestrictedSubmodule A A :=
+  ⟨Pi.single n a, single_mem_twoSidedRestrictedSubmodule n a⟩
+
+@[simp, norm_cast]
+theorem coe_twoSidedMonomial (n : ℤ) (a : A) :
+    (twoSidedMonomial n a : ℤ → A) = Pi.single n a := rfl
+
+/-- The unit is the degree-`0` monomial `1 = 1 · X⁰`. -/
+@[simp]
+theorem twoSidedMonomial_zero_one : twoSidedMonomial 0 (1 : A) = 1 := rfl
+
+/-- **The Laurent variable `X`**, the degree-`1` monomial. Wedhorn writes it `ζ`. -/
+@[expose] def twoSidedX : twoSidedRestrictedSubmodule A A := twoSidedMonomial 1 1
+
+/-- **The inverse Laurent variable `X⁻¹`**, the degree-`(-1)` monomial. It is a genuine inverse of
+`twoSidedX` (`twoSidedX_mul_twoSidedXInv`), which is what distinguishes `A⟨X, X⁻¹⟩` from the
+one-sided `A⟨X⟩`. -/
+@[expose] def twoSidedXInv : twoSidedRestrictedSubmodule A A := twoSidedMonomial (-1) 1
+
+@[simp, norm_cast]
+theorem coe_twoSidedX :
+    ((twoSidedX : twoSidedRestrictedSubmodule A A) : ℤ → A) = Pi.single 1 1 := rfl
+
+@[simp, norm_cast]
+theorem coe_twoSidedXInv :
+    ((twoSidedXInv : twoSidedRestrictedSubmodule A A) : ℤ → A) = Pi.single (-1) 1 := rfl
+
 end Convolution
+
+section Monomial
+
+variable {A : Type*} [Ring A] [TopologicalSpace A] [NonarchimedeanRing A]
+
+/-- **Monomials multiply by adding degrees**: `(a Xᵐ)(b Xⁿ) = ab X^{m+n}`.
+
+Only one term of the coefficient series is nonzero, so this needs neither completeness,
+summability, nor a separation axiom — unlike the ring axioms themselves. It is the computation rule
+for the Laurent expressions Wedhorn's §8.2.1 is written in. -/
+@[simp]
+theorem twoSidedMonomial_mul_twoSidedMonomial (m n : ℤ) (a b : A) :
+    twoSidedMonomial m a * twoSidedMonomial n b = twoSidedMonomial (m + n) (a * b) := by
+  ext p
+  -- Only `k = m` contributes to `∑' k, (a Xᵐ)ₖ (b Xⁿ)_{p-k}`.
+  rw [coe_mul_apply, coe_twoSidedMonomial, coe_twoSidedMonomial, coe_twoSidedMonomial,
+    tsum_eq_single m fun k hk ↦ by simp [Pi.single_eq_of_ne hk]]
+  -- What survives is `a · (b Xⁿ)_{p-m}`, which is `ab` exactly when `p = m + n`.
+  rcases eq_or_ne p (m + n) with rfl | hp
+  · simp
+  · rw [Pi.single_eq_of_ne hp, Pi.single_eq_of_ne (by grind : p - m ≠ n), mul_zero]
+
+/-- **`X` and `X⁻¹` are mutually inverse.** This is what distinguishes `A⟨X, X⁻¹⟩` from the
+one-sided `A⟨X⟩`, and it is the fact Wedhorn's Example 6.39 is about. -/
+@[simp]
+theorem twoSidedX_mul_twoSidedXInv :
+    (twoSidedX * twoSidedXInv : twoSidedRestrictedSubmodule A A) = 1 := by
+  rw [twoSidedX, twoSidedXInv, twoSidedMonomial_mul_twoSidedMonomial]
+  norm_num
+
+@[simp]
+theorem twoSidedXInv_mul_twoSidedX :
+    (twoSidedXInv * twoSidedX : twoSidedRestrictedSubmodule A A) = 1 := by
+  rw [twoSidedX, twoSidedXInv, twoSidedMonomial_mul_twoSidedMonomial]
+  norm_num
+
+end Monomial
 
 section Summable
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
@@ -84,6 +84,8 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
   `TauCeti.Huber.coe_algebraMap_twoSidedRestrictedSubmodule`: the computation API. The instance
   bodies are not exposed, so these are how a product, the unit, a monomial and the structure map are
   computed outside this module.
+* `TauCeti.Huber.convolution_assoc`: associativity of the coefficient convolution — the one ring
+  axiom Mathlib's `DiscreteConvolution` does not supply.
 
 ## Implementation notes
 
@@ -191,16 +193,19 @@ theorem coe_mul_apply (f g : twoSidedRestrictedSubmodule A A) (n : ℤ) :
 
 /-- **The monomial `a Xⁿ`** of `A⟨X, X⁻¹⟩`: the family supported at degree `n` with value `a`.
 Restrictedness is `single_mem_twoSidedRestrictedSubmodule`. -/
-@[expose] def twoSidedMonomial (n : ℤ) (a : A) : twoSidedRestrictedSubmodule A A :=
+def twoSidedMonomial (n : ℤ) (a : A) : twoSidedRestrictedSubmodule A A :=
   ⟨Pi.single n a, single_mem_twoSidedRestrictedSubmodule n a⟩
 
+/-- The coefficient family of the monomial `a Xⁿ` is `Pi.single n a`: the value `a` in degree `n`
+and `0` elsewhere. The definition's body is not exposed, so this is how a monomial's coefficients
+are read outside this module. -/
 @[simp, norm_cast]
 theorem coe_twoSidedMonomial (n : ℤ) (a : A) :
-    (twoSidedMonomial n a : ℤ → A) = Pi.single n a := rfl
+    (twoSidedMonomial n a : ℤ → A) = Pi.single n a := (rfl)
 
 /-- The unit is the degree-`0` monomial `1 = 1 · X⁰`. -/
 @[simp]
-theorem twoSidedMonomial_zero_one : twoSidedMonomial 0 (1 : A) = 1 := rfl
+theorem twoSidedMonomial_zero_one : twoSidedMonomial 0 (1 : A) = 1 := (rfl)
 
 end Convolution
 
@@ -275,10 +280,11 @@ variable [T0Space A]
 
 namespace twoSidedRestrictedSubmodule
 
-/-- Both bracketings of a triple product are the sum of `aᵢ bⱼ cₗ` over `{i + j + l = n}`. -/
--- It is the associativity field of `twoSidedRestrictedSubmodule.instRing`. `protected` so that
--- `open twoSidedRestrictedSubmodule` does not shadow `_root_.mul_assoc`.
-protected theorem mul_assoc (f g h : twoSidedRestrictedSubmodule A A) :
+/-- **The coefficient convolution is associative**: both bracketings of `fgh` are the sum of
+`aᵢ bⱼ cₗ` over `{i + j + l = n}`. This is the one ring axiom Mathlib's `DiscreteConvolution` does
+not supply, and it is what `twoSidedRestrictedSubmodule.instRing` is waiting on. It is named for the
+convolution rather than `mul_assoc` so that it neither shadows nor duplicates the standard lemma. -/
+theorem convolution_assoc (f g h : twoSidedRestrictedSubmodule A A) :
     f * g * h = f * (g * h) := by
   ext n
   simp only [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply]
@@ -312,7 +318,7 @@ noncomputable instance instRing : Ring (twoSidedRestrictedSubmodule A A) where
   __ := instMul
   __ := instOne
   -- Associativity is the one ring axiom Mathlib's `DiscreteConvolution` lacks; it is proved here.
-  mul_assoc := twoSidedRestrictedSubmodule.mul_assoc
+  mul_assoc := convolution_assoc
   -- The unit laws are Mathlib's `single_addConvolution` and `addConvolution_single`, reached
   -- through the two coercion `simp` lemmas above.
   one_mul _ := Subtype.ext <| by simp

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
@@ -69,14 +69,13 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
   `TauCeti.Huber.addConvolutionExists_of_mem_twoSidedRestrictedSubmodule`: over a complete ring the
   coefficient series of a product converge.
 * `TauCeti.Huber.twoSidedMonomial_mul_twoSidedMonomial`: **monomials add degrees**,
-  `(a Xᵐ)(b Xⁿ) = ab X^{m+n}`, and hence the two inverse identities
-  `TauCeti.Huber.twoSidedMonomial_one_mul_twoSidedMonomial_neg_one` and
-  `TauCeti.Huber.twoSidedMonomial_neg_one_mul_twoSidedMonomial_one`. All three hold with no
-  completeness, summability or separation hypothesis, since only one term of the coefficient series
-  survives — which is why they are stated as multiplication identities rather than as `IsUnit`,
-  a claim that needs a monoid.
-* `TauCeti.Huber.isUnit_twoSidedMonomial_one`: **the Laurent variable is a unit**, once the ring
-  structure supplies the monoid the statement needs.
+  `(a Xᵐ)(b Xⁿ) = ab X^{m+n}`. It holds with no completeness, summability or separation hypothesis,
+  since only one term of the coefficient series survives, so it is stated well above the ring
+  axioms.
+* `TauCeti.Huber.isUnit_twoSidedMonomial_one`: **the Laurent variable is a unit**, with inverse the
+  degree-`(-1)` monomial — the content of Example 6.39. Both inverse identities are instances of the
+  degree-addition rule, so they get no separate lemmas; `IsUnit` itself needs the monoid that
+  arrives with the ring structure.
 * `TauCeti.Huber.coe_mul_apply`: the coefficient of a product read off an element of the submodule,
   `(fg)ₙ = ∑' k, aₖ b_{n-k}`.
 * `TauCeti.Huber.coe_mul_twoSidedRestrictedSubmodule`,
@@ -226,26 +225,6 @@ theorem twoSidedMonomial_mul_twoSidedMonomial (m n : ℤ) (a b : A) :
   · simp
   · rw [Pi.single_eq_of_ne hp, Pi.single_eq_of_ne (by grind : p - m ≠ n), mul_zero]
 
-/-- **The degree-`1` and degree-`(-1)` monomials are mutually inverse**: `X · X⁻¹ = 1`, where
-`X = twoSidedMonomial 1 1` is Wedhorn's `ζ`. This is what distinguishes `A⟨X, X⁻¹⟩` from the
-one-sided `A⟨X⟩`, and it is the content of Wedhorn's Example 6.39. -/
-@[simp]
-theorem twoSidedMonomial_one_mul_twoSidedMonomial_neg_one :
-    (twoSidedMonomial 1 1 * twoSidedMonomial (-1) 1 : twoSidedRestrictedSubmodule A A) = 1 := by
-  rw [twoSidedMonomial_mul_twoSidedMonomial]
-  norm_num
-
-/-- **The reverse identity** `X⁻¹ · X = 1`. Stated separately from
-`twoSidedMonomial_one_mul_twoSidedMonomial_neg_one` because the ring axioms — and with them
-commutativity of the convolution — are not available in this section: these two identities hold
-with no completeness, summability or separation hypothesis, so neither follows from the other
-here. -/
-@[simp]
-theorem twoSidedMonomial_neg_one_mul_twoSidedMonomial_one :
-    (twoSidedMonomial (-1) 1 * twoSidedMonomial 1 1 : twoSidedRestrictedSubmodule A A) = 1 := by
-  rw [twoSidedMonomial_mul_twoSidedMonomial]
-  norm_num
-
 end Monomial
 
 section Summable
@@ -357,9 +336,9 @@ Wedhorn's Example 6.39 is used in — `A⟨X, X⁻¹⟩` is the ring in which `X
 is stated here rather than beside the two multiplication identities because `IsUnit` needs a monoid,
 which arrives only with `twoSidedRestrictedSubmodule.instRing`. -/
 theorem isUnit_twoSidedMonomial_one : IsUnit (twoSidedMonomial 1 (1 : A)) :=
-  ⟨⟨twoSidedMonomial 1 1, twoSidedMonomial (-1) 1,
-    twoSidedMonomial_one_mul_twoSidedMonomial_neg_one,
-    twoSidedMonomial_neg_one_mul_twoSidedMonomial_one⟩, rfl⟩
+  -- both inverse identities are `twoSidedMonomial_mul_twoSidedMonomial` at `(1, -1)` and `(-1, 1)`,
+  -- finished by `twoSidedMonomial_zero_one`
+  ⟨⟨twoSidedMonomial 1 1, twoSidedMonomial (-1) 1, by simp, by simp⟩, rfl⟩
 
 end Ring
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
@@ -54,9 +54,9 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
   `DiscreteConvolution.addConvolution` along the bilinear map `LinearMap.mul ℤ A`.
 * `TauCeti.Huber.twoSidedRestrictedSubmodule.instRing`, `instCommRing`, `instAlgebra`: **the ring
   structure**, and the `A`-algebra structure of Example 6.39 when `A` is commutative.
-* `TauCeti.Huber.twoSidedMonomial`: the monomial `a Xⁿ`, and with it
-  `TauCeti.Huber.twoSidedX` and `TauCeti.Huber.twoSidedXInv` — the Laurent variable `X` and its
-  inverse, which Wedhorn writes `ζ` and `ζ⁻¹`.
+* `TauCeti.Huber.twoSidedMonomial`: the monomial `a Xⁿ`. The Laurent variable Wedhorn writes `ζ`
+  is `twoSidedMonomial 1 1` and its inverse is `twoSidedMonomial (-1) 1`; neither gets a
+  separate definition, so the only body this file exposes is the monomial's.
 
 ## Main results
 
@@ -69,9 +69,14 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
   `TauCeti.Huber.addConvolutionExists_of_mem_twoSidedRestrictedSubmodule`: over a complete ring the
   coefficient series of a product converge.
 * `TauCeti.Huber.twoSidedMonomial_mul_twoSidedMonomial`: **monomials add degrees**,
-  `(a Xᵐ)(b Xⁿ) = ab X^{m+n}`, and hence `TauCeti.Huber.twoSidedX_mul_twoSidedXInv`: `X` is a unit
-  with inverse `X⁻¹`. Both hold with no completeness, summability or separation hypothesis, since
-  only one term of the coefficient series survives.
+  `(a Xᵐ)(b Xⁿ) = ab X^{m+n}`, and hence the two inverse identities
+  `TauCeti.Huber.twoSidedMonomial_one_mul_twoSidedMonomial_neg_one` and
+  `TauCeti.Huber.twoSidedMonomial_neg_one_mul_twoSidedMonomial_one`. All three hold with no
+  completeness, summability or separation hypothesis, since only one term of the coefficient series
+  survives — which is why they are stated as multiplication identities rather than as `IsUnit`,
+  a claim that needs a monoid.
+* `TauCeti.Huber.isUnit_twoSidedMonomial_one`: **the Laurent variable is a unit**, once the ring
+  structure supplies the monoid the statement needs.
 * `TauCeti.Huber.coe_mul_apply`: the coefficient of a product read off an element of the submodule,
   `(fg)ₙ = ∑' k, aₖ b_{n-k}`.
 * `TauCeti.Huber.coe_mul_twoSidedRestrictedSubmodule`,
@@ -198,22 +203,6 @@ theorem coe_twoSidedMonomial (n : ℤ) (a : A) :
 @[simp]
 theorem twoSidedMonomial_zero_one : twoSidedMonomial 0 (1 : A) = 1 := rfl
 
-/-- **The Laurent variable `X`**, the degree-`1` monomial. Wedhorn writes it `ζ`. -/
-@[expose] def twoSidedX : twoSidedRestrictedSubmodule A A := twoSidedMonomial 1 1
-
-/-- **The inverse Laurent variable `X⁻¹`**, the degree-`(-1)` monomial. It is a genuine inverse of
-`twoSidedX` (`twoSidedX_mul_twoSidedXInv`), which is what distinguishes `A⟨X, X⁻¹⟩` from the
-one-sided `A⟨X⟩`. -/
-@[expose] def twoSidedXInv : twoSidedRestrictedSubmodule A A := twoSidedMonomial (-1) 1
-
-@[simp, norm_cast]
-theorem coe_twoSidedX :
-    ((twoSidedX : twoSidedRestrictedSubmodule A A) : ℤ → A) = Pi.single 1 1 := rfl
-
-@[simp, norm_cast]
-theorem coe_twoSidedXInv :
-    ((twoSidedXInv : twoSidedRestrictedSubmodule A A) : ℤ → A) = Pi.single (-1) 1 := rfl
-
 end Convolution
 
 section Monomial
@@ -237,18 +226,24 @@ theorem twoSidedMonomial_mul_twoSidedMonomial (m n : ℤ) (a b : A) :
   · simp
   · rw [Pi.single_eq_of_ne hp, Pi.single_eq_of_ne (by grind : p - m ≠ n), mul_zero]
 
-/-- **`X` and `X⁻¹` are mutually inverse.** This is what distinguishes `A⟨X, X⁻¹⟩` from the
-one-sided `A⟨X⟩`, and it is the fact Wedhorn's Example 6.39 is about. -/
+/-- **The degree-`1` and degree-`(-1)` monomials are mutually inverse**: `X · X⁻¹ = 1`, where
+`X = twoSidedMonomial 1 1` is Wedhorn's `ζ`. This is what distinguishes `A⟨X, X⁻¹⟩` from the
+one-sided `A⟨X⟩`, and it is the content of Wedhorn's Example 6.39. -/
 @[simp]
-theorem twoSidedX_mul_twoSidedXInv :
-    (twoSidedX * twoSidedXInv : twoSidedRestrictedSubmodule A A) = 1 := by
-  rw [twoSidedX, twoSidedXInv, twoSidedMonomial_mul_twoSidedMonomial]
+theorem twoSidedMonomial_one_mul_twoSidedMonomial_neg_one :
+    (twoSidedMonomial 1 1 * twoSidedMonomial (-1) 1 : twoSidedRestrictedSubmodule A A) = 1 := by
+  rw [twoSidedMonomial_mul_twoSidedMonomial]
   norm_num
 
+/-- **The reverse identity** `X⁻¹ · X = 1`. Stated separately from
+`twoSidedMonomial_one_mul_twoSidedMonomial_neg_one` because the ring axioms — and with them
+commutativity of the convolution — are not available in this section: these two identities hold
+with no completeness, summability or separation hypothesis, so neither follows from the other
+here. -/
 @[simp]
-theorem twoSidedXInv_mul_twoSidedX :
-    (twoSidedXInv * twoSidedX : twoSidedRestrictedSubmodule A A) = 1 := by
-  rw [twoSidedX, twoSidedXInv, twoSidedMonomial_mul_twoSidedMonomial]
+theorem twoSidedMonomial_neg_one_mul_twoSidedMonomial_one :
+    (twoSidedMonomial (-1) 1 * twoSidedMonomial 1 1 : twoSidedRestrictedSubmodule A A) = 1 := by
+  rw [twoSidedMonomial_mul_twoSidedMonomial]
   norm_num
 
 end Monomial
@@ -356,6 +351,15 @@ noncomputable instance instRing : Ring (twoSidedRestrictedSubmodule A A) where
   mul_zero _ := Subtype.ext <| addConvolution_zero _ _
 
 end twoSidedRestrictedSubmodule
+
+/-- **The Laurent variable is a unit**, with inverse the degree-`(-1)` monomial. This is the form
+Wedhorn's Example 6.39 is used in — `A⟨X, X⁻¹⟩` is the ring in which `X` becomes invertible — and it
+is stated here rather than beside the two multiplication identities because `IsUnit` needs a monoid,
+which arrives only with `twoSidedRestrictedSubmodule.instRing`. -/
+theorem isUnit_twoSidedMonomial_one : IsUnit (twoSidedMonomial 1 (1 : A)) :=
+  ⟨⟨twoSidedMonomial 1 1, twoSidedMonomial (-1) 1,
+    twoSidedMonomial_one_mul_twoSidedMonomial_neg_one,
+    twoSidedMonomial_neg_one_mul_twoSidedMonomial_one⟩, rfl⟩
 
 end Ring
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
@@ -97,12 +97,12 @@ We reuse Mathlib's `DiscreteConvolution.addConvolution` rather than defining a `
 convolution: it is the same sum over the same fibre, `addFiber n = {(i, j) | i + j = n}`.
 
 The multiplication and the closure result need only a nonarchimedean ring topology. The ring
-axioms need the coefficient ring to be complete **and** Hausdorff (`[CompleteSpace A] [T0Space A]`):
-completeness so that the coefficient series converge at all, and Hausdorffness so that `tsum` is a
-limit rather than a choice among limits — without it neither distributivity nor associativity is
-provable. This is exactly Wedhorn's convention, whose "complete" means "Hausdorff and every Cauchy
-filter basis converges" (Definition 5.31(4)–(5)), and it is the hypothesis list the neighbouring
-`TauCeti.RingTheory.Huber.Restricted.Laurent` already carries.
+axioms are proved here from the coefficient ring being complete **and** Hausdorff
+(`[CompleteSpace A] [T0Space A]`): the proofs of distributivity and associativity use completeness
+so that the coefficient series converge at all, and Hausdorffness so that `tsum` is a limit rather
+than a choice among limits. This is exactly Wedhorn's convention, whose "complete" means
+"Hausdorff and every Cauchy filter basis converges" (Definition 5.31(4)–(5)), and it is the
+hypothesis list the neighbouring `TauCeti.RingTheory.Huber.Restricted.Laurent` already carries.
 
 ## References
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
@@ -12,10 +12,10 @@ public import TauCeti.RingTheory.Huber.Restricted.TwoSided.Series
 /-!
 # The ring of two-sided restricted series `A⟨X, X⁻¹⟩`
 
-`TauCeti.Huber.twoSidedRestrictedSubmodule` is only the `A`-*module* of coefficient families
-underlying Wedhorn's `A⟨X, X⁻¹⟩` (Example 6.39). This module supplies the multiplication, which
-that file deliberately left out, and makes the coefficient object a ring — a commutative
-`A`-algebra when `A` is commutative, as the source states.
+`TauCeti.Huber.twoSidedRestrictedSubmodule` is the `A`-*module* of coefficient families
+underlying Wedhorn's `A⟨X, X⁻¹⟩` (Example 6.39). This module equips it with the convolution
+multiplication, making the coefficient object a ring — a commutative `A`-algebra when `A` is
+commutative, as the source states.
 
 ## Why this is not the one-sided argument
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Topology.Algebra.InfiniteSum.DiscreteConvolution
 public import Mathlib.Topology.Algebra.InfiniteSum.Nonarchimedean
 public import TauCeti.RingTheory.Huber.Restricted.TwoSided.Series
 public import TauCeti.Topology.Algebra.InfiniteSum.DiscreteConvolution
@@ -75,10 +74,10 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
   `(a Xᵐ)(b Xⁿ) = ab X^{m+n}`. It holds with no completeness, summability or separation hypothesis,
   since only one term of the coefficient series survives, so it is stated well above the ring
   axioms.
-* `TauCeti.Huber.isUnit_twoSidedMonomial_one`: **the Laurent variable is a unit**, with inverse the
-  degree-`(-1)` monomial — the content of Example 6.39. Both inverse identities are instances of the
-  degree-addition rule, so they get no separate lemmas; `IsUnit` itself needs the monoid that
-  arrives with the ring structure.
+* `TauCeti.Huber.isUnit_twoSidedMonomial_one_one`: **the Laurent variable is a unit**, its
+  inverse being the degree-`(-1)` monomial — the content of Example 6.39. Both inverse identities
+  are instances of the degree-addition rule, so they get no separate lemmas; `IsUnit` needs the
+  monoid that arrives with the ring structure.
 * `TauCeti.Huber.coe_mul_apply`: the coefficient of a product read off an element of the submodule,
   `(fg)ₙ = ∑' k, aₖ b_{n-k}`.
 * `TauCeti.Huber.coe_mul_twoSidedRestrictedSubmodule`,
@@ -320,7 +319,7 @@ end twoSidedRestrictedSubmodule
 Wedhorn's Example 6.39 is used in — `A⟨X, X⁻¹⟩` is the ring in which `X` becomes invertible — and it
 is stated here rather than beside the two multiplication identities because `IsUnit` needs a monoid,
 which arrives only with `twoSidedRestrictedSubmodule.instRing`. -/
-theorem isUnit_twoSidedMonomial_one : IsUnit (twoSidedMonomial 1 (1 : A)) :=
+theorem isUnit_twoSidedMonomial_one_one : IsUnit (twoSidedMonomial 1 (1 : A)) :=
   -- both inverse identities are `twoSidedMonomial_mul_twoSidedMonomial` at `(1, -1)` and `(-1, 1)`,
   -- finished by `twoSidedMonomial_zero_one`
   ⟨⟨twoSidedMonomial 1 1, twoSidedMonomial (-1) 1, by simp, by simp⟩, rfl⟩

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
@@ -56,11 +56,12 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
   structure**, and the `A`-algebra structure of Example 6.39 when `A` is commutative.
 * `TauCeti.Huber.twoSidedMonomial`: the monomial `a Xⁿ`. The Laurent variable Wedhorn writes `ζ`
   is `twoSidedMonomial 1 1` and its inverse is `twoSidedMonomial (-1) 1`; neither gets a
-  separate definition, so the only body this file exposes is the monomial's.
+  separate definition. `TauCeti.Huber.coe_twoSidedMonomial` is the coefficient-level API through
+  which a monomial is read outside this module.
 
 ## Main results
 
-* `DiscreteConvolution.addConvolution_mul_apply` (in
+* `DiscreteConvolution.addConvolution_mul_apply_sub` (in
   `TauCeti.Topology.Algebra.InfiniteSum.DiscreteConvolution`, which this module imports): the
   coefficient formula `(fg)ₙ = ∑' k, aₖ b_{n-k}`.
 * `TauCeti.Huber.addConvolution_mem_twoSidedRestrictedSubmodule`: **the closure result** — a
@@ -171,7 +172,7 @@ wants, and it needs no completeness — where the series fails to converge both 
 theorem coe_mul_apply (f g : twoSidedRestrictedSubmodule A A) (n : ℤ) :
     ((f * g : twoSidedRestrictedSubmodule A A) : ℤ → A) n
       = ∑' k : ℤ, (f : ℤ → A) k * (g : ℤ → A) (n - k) := by
-  rw [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply]
+  rw [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply_sub]
 
 /-- **The monomial `a Xⁿ`** of `A⟨X, X⁻¹⟩`: the family supported at degree `n` with value `a`.
 Restrictedness is `single_mem_twoSidedRestrictedSubmodule`. -/
@@ -197,9 +198,9 @@ variable {A : Type*} [Ring A] [TopologicalSpace A] [NonarchimedeanRing A]
 
 /-- **Monomials multiply by adding degrees**: `(a Xᵐ)(b Xⁿ) = ab X^{m+n}`.
 
-Only one term of the coefficient series is nonzero, so this needs neither completeness,
-summability, nor a separation axiom — unlike the ring axioms themselves. It is the computation rule
-for the Laurent expressions Wedhorn's §8.2.1 is written in. -/
+This is the computation rule for the Laurent expressions Wedhorn's §8.2.1 is written in. It asks
+neither completeness, nor summability, nor a separation axiom — unlike the ring axioms
+themselves. -/
 @[simp]
 theorem twoSidedMonomial_mul_twoSidedMonomial (m n : ℤ) (a b : A) :
     twoSidedMonomial m a * twoSidedMonomial n b = twoSidedMonomial (m + n) (a * b) := by
@@ -273,7 +274,7 @@ noncomputable instance instRing : Ring (twoSidedRestrictedSubmodule A A) where
   -- exactly the standard `mul_assoc`.
   mul_assoc f g h := by
     ext n
-    simp only [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply]
+    simp only [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply_sub]
     -- Index that fibre by `(m, k) ↦ (k, m - k, n - m)`, with `m` the degree of the partial product
     -- `fg`. It is a subfamily of `(i, j, l) ↦ aᵢbⱼcₗ`, which is summable on all of `ℤ × ℤ × ℤ`.
     have hF : Summable fun p : ℤ × ℤ ↦

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Ring.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Topology.Algebra.InfiniteSum.DiscreteConvolution
 public import Mathlib.Topology.Algebra.InfiniteSum.Nonarchimedean
 public import TauCeti.RingTheory.Huber.Restricted.TwoSided.Series
+public import TauCeti.Topology.Algebra.InfiniteSum.DiscreteConvolution
 
 /-!
 # The ring of two-sided restricted series `A⟨X, X⁻¹⟩`
@@ -60,7 +61,9 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
 
 ## Main results
 
-* `TauCeti.Huber.addConvolution_mul_apply`: the coefficient formula `(fg)ₙ = ∑' k, aₖ b_{n-k}`.
+* `DiscreteConvolution.addConvolution_mul_apply` (in
+  `TauCeti.Topology.Algebra.InfiniteSum.DiscreteConvolution`, which this module imports): the
+  coefficient formula `(fg)ₙ = ∑' k, aₖ b_{n-k}`.
 * `TauCeti.Huber.addConvolution_mem_twoSidedRestrictedSubmodule`: **the closure result** — a
   convolution of restricted families is restricted.
 * `TauCeti.Huber.mem_twoSidedRestrictedSubmodule_iff_summable`: over a complete group,
@@ -118,24 +121,6 @@ namespace TauCeti.Huber
 section Convolution
 
 variable {A : Type*} [Ring A] [TopologicalSpace A] [NonarchimedeanRing A]
-
--- The antidiagonal `{(i, j) | i + j = n}` in `ℤ × ℤ`, parametrised by its first coordinate. This
--- is where the `ℤ`-indexed picture and Mathlib's fibre picture meet, and it is an `Equiv` rather
--- than a `Finset` precisely because the antidiagonal is infinite.
-private def addFiberEquivInt (n : ℤ) : ℤ ≃ (addFiber n : Set (ℤ × ℤ)) where
-  toFun k := ⟨(k, n - k), by grind⟩
-  invFun ab := ab.1.1
-  left_inv _ := rfl
-  right_inv ab := by grind
-
-omit [NonarchimedeanRing A] in
-/-- **The coefficient formula for the two-sided product**: `(fg)ₙ = ∑' k, aₖ b_{n-k}`, the familiar
-Laurent convolution. -/
-theorem addConvolution_mul_apply (f g : ℤ → A) (n : ℤ) :
-    addConvolution (LinearMap.mul ℤ A) f g n = ∑' k : ℤ, f k * g (n - k) :=
-  -- Reindexing Mathlib's sum over `addFiber n` by the first coordinate is exactly
-  -- `addFiberEquivInt`.
-  ((addFiberEquivInt n).tsum_eq fun ab ↦ f ab.1.1 * g ab.1.2).symm
 
 /-- **The product of two restricted families is restricted**, so `A⟨X, X⁻¹⟩` is closed under the
 convolution. This is what makes it a ring rather than merely a module, and it needs neither

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Series.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Series.lean
@@ -57,7 +57,7 @@ a placement hazard:
 * `TauCeti.Huber.twoSidedRestrictedSubmodule_ext`: coefficientwise extensionality.
 * `TauCeti.Huber.single_mem_twoSidedRestrictedSubmodule`: a family supported at one degree is
   restricted; at `M = A` these are the monomials `a Xⁿ`, and `X⁰ = 1` is the unit of the ring
-  structure built in `TauCeti.RingTheory.Huber.Restricted.TwoSidedRing`.
+  structure built in `TauCeti.RingTheory.Huber.Restricted.TwoSided.Ring`.
 * `TauCeti.Huber.twoSidedRestrictedSubmodule_eq_sup` and
   `TauCeti.Huber.disjoint_twoSidedRestricted_nonneg_neg`: **the degree decomposition and its
   directness** — `A⟨X, X⁻¹⟩` is the sum of its non-negative and negative parts, and that sum is
@@ -76,7 +76,7 @@ a placement hazard:
 ## Implementation notes
 
 Only the additive and `A`-module structure is built here. The **ring** structure lives in
-`TauCeti.RingTheory.Huber.Restricted.TwoSidedRing`: the coefficient convolution
+`TauCeti.RingTheory.Huber.Restricted.TwoSided.Ring`: the coefficient convolution
 `(fg)ₙ = ∑_{i + j = n} aᵢ bⱼ` is a *finite* sum for one-sided series — which is what
 `TauCeti.Huber.IsRestricted.mul` exploits, through `MvPowerSeries.coeff_mul` over a finite
 antidiagonal — but over `ℤ` that antidiagonal is infinite, so multiplication needs a summability

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Series.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Series.lean
@@ -75,13 +75,12 @@ a placement hazard:
 
 ## Implementation notes
 
-Only the additive and `A`-module structure is built here. The **ring** structure lives in
-`TauCeti.RingTheory.Huber.Restricted.TwoSided.Ring`: the coefficient convolution
-`(fg)ₙ = ∑_{i + j = n} aᵢ bⱼ` is a *finite* sum for one-sided series — which is what
-`TauCeti.Huber.IsRestricted.mul` exploits, through `MvPowerSeries.coeff_mul` over a finite
-antidiagonal — but over `ℤ` that antidiagonal is infinite, so multiplication needs a summability
-argument in a complete ring rather than a rearrangement of a finite sum, and that argument is
-separate work.
+This file builds the additive and `A`-module structure; the **ring** structure lives in
+`TauCeti.RingTheory.Huber.Restricted.TwoSided.Ring`, which defines the coefficient convolution
+`(fg)ₙ = ∑_{i + j = n} aᵢ bⱼ`. That convolution is a *finite* sum for one-sided series — which is
+what `TauCeti.Huber.IsRestricted.mul` exploits, through `MvPowerSeries.coeff_mul` over a finite
+antidiagonal — but over `ℤ` the antidiagonal is infinite, so it rests on a summability argument in
+a complete ring rather than on a rearrangement of a finite sum.
 
 ## References
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided/Series.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided/Series.lean
@@ -130,12 +130,9 @@ theorem twoSidedRestrictedSubmodule_ext {f g : twoSidedRestrictedSubmodule A M}
 
 /-- **A family supported at a single degree is restricted**: its support lies in `{n}`, so it is
 eventually zero along the cofinite filter. At `M = A` these are the monomials `a Xⁿ` of
-`A⟨X, X⁻¹⟩`; this is the two-sided counterpart of `TauCeti.Huber.isRestricted_monomial`. Both
-reduce to the support being contained in `{n}`, but by different routes: the one-sided lemma hands
-that to `isRestricted_of_hasFiniteSupport`, whereas this submodule is defined by cofinite
-convergence directly, so the finite support is fed to `tendsto_cofinite_pure_iff`. Not `@[simp]`,
-for the reason given at `mem_twoSidedRestrictedSubmodule_iff_finite_notMem`: the membership lemma
-rewrites this left-hand side first. -/
+`A⟨X, X⁻¹⟩`, and this is the two-sided counterpart of `TauCeti.Huber.isRestricted_monomial`.
+
+Not `@[simp]`, for the reason given at `mem_twoSidedRestrictedSubmodule_iff_finite_notMem`. -/
 theorem single_mem_twoSidedRestrictedSubmodule (n : ℤ) (m : M) :
     Pi.single n m ∈ twoSidedRestrictedSubmodule A M :=
   (tendsto_cofinite_pure_iff.mpr

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedRing.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedRing.lean
@@ -99,44 +99,39 @@ section Convolution
 
 variable {A : Type*} [Ring A] [TopologicalSpace A] [NonarchimedeanRing A]
 
-/-- The antidiagonal `{(i, j) | i + j = n}` in `ℤ × ℤ`, parametrised by its first coordinate.
-
-This is where the `ℤ`-indexed picture and Mathlib's fibre picture meet, and it is an `Equiv` rather
-than a `Finset` precisely because the antidiagonal is infinite. -/
+-- The antidiagonal `{(i, j) | i + j = n}` in `ℤ × ℤ`, parametrised by its first coordinate. This
+-- is where the `ℤ`-indexed picture and Mathlib's fibre picture meet, and it is an `Equiv` rather
+-- than a `Finset` precisely because the antidiagonal is infinite.
 private def addFiberEquivInt (n : ℤ) : ℤ ≃ (addFiber n : Set (ℤ × ℤ)) where
-  toFun k := ⟨(k, n - k), by simp [mem_addFiber]⟩
+  toFun k := ⟨(k, n - k), by grind⟩
   invFun ab := ab.1.1
   left_inv _ := rfl
-  right_inv ab := Subtype.ext (Prod.ext rfl (by have := mem_addFiber.mp ab.2; dsimp only; omega))
+  right_inv ab := by grind
 
 omit [NonarchimedeanRing A] in
 /-- **The coefficient formula for the two-sided product**: `(fg)ₙ = ∑' k, aₖ b_{n-k}`, the familiar
-Laurent convolution. Reindexing Mathlib's sum over `addFiber n` by the first coordinate is exactly
-`addFiberEquivInt`. -/
+Laurent convolution. -/
 theorem addConvolution_mul_apply (f g : ℤ → A) (n : ℤ) :
     addConvolution (LinearMap.mul ℤ A) f g n = ∑' k : ℤ, f k * g (n - k) :=
+  -- Reindexing Mathlib's sum over `addFiber n` by the first coordinate is exactly
+  -- `addFiberEquivInt`.
   ((addFiberEquivInt n).tsum_eq fun ab ↦ f ab.1.1 * g ab.1.2).symm
 
 /-- **The product of two restricted families is restricted**, so `A⟨X, X⁻¹⟩` is closed under the
 convolution. This is what makes it a ring rather than merely a module, and it needs neither
-completeness nor summability:
-`NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiber` sums along the fibres of addition
-`ℤ × ℤ → ℤ`, and `tendsto_mul_cofinite_nhds_zero` supplies its hypothesis on `(i, j) ↦ aᵢbⱼ`. Where
-a coefficient sum fails to converge it is `0` by the `tsum` convention, and `0` lies in every
-subgroup, so the degenerate case costs nothing and no completeness hypothesis is needed to state
-closure. -/
+completeness nor summability. -/
 theorem addConvolution_mem_twoSidedRestrictedSubmodule {f g : ℤ → A}
     (hf : f ∈ twoSidedRestrictedSubmodule A A) (hg : g ∈ twoSidedRestrictedSubmodule A A) :
     addConvolution (LinearMap.mul ℤ A) f g ∈ twoSidedRestrictedSubmodule A A := by
   rw [mem_twoSidedRestrictedSubmodule] at hf hg ⊢
-  have key : addConvolution (LinearMap.mul ℤ A) f g
-      = fun n ↦ ∑' i : {i : ℤ × ℤ // i.1 + i.2 = n}, f i.1.1 * g i.1.2 :=
-    funext fun _ ↦ tsum_congr_set_coe (fun ab : ℤ × ℤ ↦ f ab.1 * g ab.2)
-      (Set.ext fun (_ : ℤ × ℤ) ↦ mem_addFiber)
-  rw [key]
-  exact NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiber
-    (F := fun ab : ℤ × ℤ ↦ f ab.1 * g ab.2) (tendsto_mul_cofinite_nhds_zero hf hg)
-    (fun ab ↦ ab.1 + ab.2)
+  -- Summing along the fibres of addition `ℤ × ℤ → ℤ` preserves cofinite nullity, and the family
+  -- `(i, j) ↦ aᵢbⱼ` is cofinitely null because `f` and `g` are. Where a fibre's sum fails to
+  -- converge it is `0` by the `tsum` convention, and `0` lies in every subgroup, so the degenerate
+  -- case costs nothing and no completeness hypothesis is needed to state closure.
+  refine (NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiber
+    (tendsto_mul_cofinite_nhds_zero hf hg) fun ab ↦ ab.1 + ab.2).congr fun _ ↦ ?_
+  -- Mathlib's fibre `addFiber n` is the antidiagonal `{(i, j) | i + j = n}`.
+  exact tsum_congr_set_coe (fun ab : ℤ × ℤ ↦ f ab.1 * g ab.2) <| Set.ext fun _ ↦ mem_addFiber.symm
 
 /-- **The product on `A⟨X, X⁻¹⟩`**: the coefficient convolution `(fg)ₙ = ∑' k, aₖ b_{n-k}`, which
 lands back in the submodule by `addConvolution_mem_twoSidedRestrictedSubmodule`. Only a
@@ -152,17 +147,17 @@ degree `0`. -/
 instance twoSidedRestrictedSubmodule.instOne : One (twoSidedRestrictedSubmodule A A) where
   one := ⟨Pi.single 0 1, single_mem_twoSidedRestrictedSubmodule 0 1⟩
 
-/-- The product is the convolution of the coefficient families. Its body is not exposed, so this
-is how it is computed outside this module. -/
+/-- The product is the convolution of the coefficient families. The `Mul` instance's body is not
+exposed, so this is how a product is computed outside this module. -/
 @[simp]
 theorem coe_mul_twoSidedRestrictedSubmodule (f g : twoSidedRestrictedSubmodule A A) :
-    ((f * g : twoSidedRestrictedSubmodule A A) : ℤ → A) =
-      addConvolution (LinearMap.mul ℤ A) f g := (rfl)
+    (↑(f * g) : ℤ → A) = addConvolution (LinearMap.mul ℤ A) f g := rfl
 
-/-- The unit is the family supported at degree `0` with value `1`. -/
+/-- The unit is the family supported at degree `0` with value `1`. The `One` instance's body is
+not exposed, so this is how the unit is computed outside this module. -/
 @[simp]
 theorem coe_one_twoSidedRestrictedSubmodule :
-    ((1 : twoSidedRestrictedSubmodule A A) : ℤ → A) = Pi.single 0 1 := (rfl)
+    ((1 : twoSidedRestrictedSubmodule A A) : ℤ → A) = Pi.single 0 1 := rfl
 
 end Convolution
 
@@ -172,13 +167,14 @@ variable {A M : Type*} [Semiring A] [AddCommGroup M] [UniformSpace M] [IsUniform
   [NonarchimedeanAddGroup M] [CompleteSpace M] [Module A M] [ContinuousConstSMul A M]
 
 /-- **Restrictedness is summability** over a complete nonarchimedean group: a family lies in the
-submodule exactly when it is summable. This is
-`NonarchimedeanAddGroup.summable_iff_tendsto_cofinite_zero` read through the membership criterion,
-and it is what turns Wedhorn's "the product of two such series is well defined" into a theorem. -/
+submodule exactly when it is summable. It is what turns Wedhorn's "the product of two such series
+is well defined" into a theorem. -/
 theorem mem_twoSidedRestrictedSubmodule_iff_summable {f : ℤ → M} :
-    f ∈ twoSidedRestrictedSubmodule A M ↔ Summable f := by
-  rw [mem_twoSidedRestrictedSubmodule]
-  exact (NonarchimedeanAddGroup.summable_iff_tendsto_cofinite_zero f).symm
+    f ∈ twoSidedRestrictedSubmodule A M ↔ Summable f :=
+  -- `NonarchimedeanAddGroup.summable_iff_tendsto_cofinite_zero` read through the membership
+  -- criterion: membership unfolds to cofinite nullity, which is that lemma's right-hand side.
+  mem_twoSidedRestrictedSubmodule.trans
+    (NonarchimedeanAddGroup.summable_iff_tendsto_cofinite_zero f).symm
 
 end Summable
 
@@ -188,22 +184,24 @@ variable {A : Type*} [Ring A] [UniformSpace A] [IsUniformAddGroup A] [Nonarchime
   [CompleteSpace A]
 
 /-- **Each coefficient of a product is a convergent series** (Wedhorn's "the convergent series
-`∑_{k + l = n} aₖ bₗ`"): restrictedness *is* summability over a complete nonarchimedean ring, so
-`Summable.mul_of_nonarchimedean` makes `(i, j) ↦ aᵢbⱼ` summable on all of `ℤ × ℤ`, and the
-antidiagonal `k ↦ (k, n - k)` is a subfamily. -/
+`∑_{k + l = n} aₖ bₗ`"). -/
 theorem summable_mul_sub_of_mem_twoSidedRestrictedSubmodule {f g : ℤ → A}
-    (hf : f ∈ twoSidedRestrictedSubmodule A A) (hg : g ∈ twoSidedRestrictedSubmodule A A)
-    (n : ℤ) : Summable fun k ↦ f k * g (n - k) :=
+    (hf : f ∈ twoSidedRestrictedSubmodule A A) (hg : g ∈ twoSidedRestrictedSubmodule A A) (n : ℤ) :
+    Summable fun k ↦ f k * g (n - k) :=
+  -- Restrictedness *is* summability over a complete nonarchimedean ring, so
+  -- `Summable.mul_of_nonarchimedean` makes `(i, j) ↦ aᵢbⱼ` summable on all of `ℤ × ℤ`.
   ((mem_twoSidedRestrictedSubmodule_iff_summable.mp hf).mul_of_nonarchimedean
     (mem_twoSidedRestrictedSubmodule_iff_summable.mp hg)).comp_injective
+    -- The antidiagonal `k ↦ (k, n - k)` is a subfamily of `ℤ × ℤ`.
     (i := fun k ↦ (k, n - k)) fun _ _ hab ↦ (Prod.mk.inj hab).1
 
 /-- **The convolution of two restricted families exists**, in the form Mathlib's distributivity
-lemmas for `DiscreteConvolution.addConvolution` consume: the same subfamily argument as
-`summable_mul_sub_of_mem_twoSidedRestrictedSubmodule`, on Mathlib's fibre `addFiber n`. -/
+lemmas for `DiscreteConvolution.addConvolution` consume. -/
 theorem addConvolutionExists_of_mem_twoSidedRestrictedSubmodule {f g : ℤ → A}
     (hf : f ∈ twoSidedRestrictedSubmodule A A) (hg : g ∈ twoSidedRestrictedSubmodule A A) :
     AddConvolutionExists (LinearMap.mul ℤ A) f g :=
+  -- The same subfamily argument as `summable_mul_sub_of_mem_twoSidedRestrictedSubmodule`, now on
+  -- Mathlib's fibre `addFiber n`: `(i, j) ↦ aᵢbⱼ` is summable on all of `ℤ × ℤ`.
   fun _ ↦ ((mem_twoSidedRestrictedSubmodule_iff_summable.mp hf).mul_of_nonarchimedean
     (mem_twoSidedRestrictedSubmodule_iff_summable.mp hg)).subtype _
 
@@ -211,32 +209,33 @@ variable [T0Space A]
 
 namespace twoSidedRestrictedSubmodule
 
-/-- Both bracketings of a triple product are the sum of `aᵢ bⱼ cₗ` over `{i + j + l = n}`. That
-fibre is indexed by `(m, k) ↦ (k, m - k, n - m)`, with `m` the degree of the partial product `fg`;
-summing first over `k` gives `((fg)h)ₙ`, while after the reindexing `(m, k) ↦ (k, m - k)` summing
-first over the second coordinate gives `(f(gh))ₙ`. -/
+/-- Both bracketings of a triple product are the sum of `aᵢ bⱼ cₗ` over `{i + j + l = n}`. It is
+the associativity field of `twoSidedRestrictedSubmodule.instRing`, so downstream of that instance
+the root `mul_assoc` applies — which is why this one is `protected`. -/
 protected theorem mul_assoc (f g h : twoSidedRestrictedSubmodule A A) :
     f * g * h = f * (g * h) := by
   ext n
   simp only [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply]
+  -- Index that fibre by `(m, k) ↦ (k, m - k, n - m)`, with `m` the degree of the partial product
+  -- `fg`. It is a subfamily of `(i, j, l) ↦ aᵢbⱼcₗ`, which is summable on all of `ℤ × ℤ × ℤ`.
   have hF : Summable fun p : ℤ × ℤ ↦
       (f : ℤ → A) p.2 * (g : ℤ → A) (p.1 - p.2) * (h : ℤ → A) (n - p.1) :=
     (((mem_twoSidedRestrictedSubmodule_iff_summable.mp f.2).mul_of_nonarchimedean
       (mem_twoSidedRestrictedSubmodule_iff_summable.mp g.2)).mul_of_nonarchimedean
       (mem_twoSidedRestrictedSubmodule_iff_summable.mp h.2)).comp_injective
-      (i := fun p : ℤ × ℤ ↦ ((p.2, p.1 - p.2), n - p.1)) fun p q hpq ↦ by
-        simp only [Prod.mk.injEq] at hpq
-        exact Prod.ext (by omega) hpq.1.1
-  refine (hF.hasSum.prod_fiberwise fun m ↦ ?_).tsum_eq.trans
-    (HasSum.prod_fiberwise
+      (i := fun p : ℤ × ℤ ↦ ((p.2, p.1 - p.2), n - p.1)) fun p q hpq ↦ by grind
+  -- Both bracketings are that single sum, summed in two orders: fibring over `m` gives `((fg)h)ₙ`
+  -- by summing first over `k`, and fibring the reindexed family gives `(f(gh))ₙ`.
+  refine (hF.hasSum.prod_fiberwise fun m ↦ ?_).tsum_eq.trans (HasSum.prod_fiberwise
       (f := fun q : ℤ × ℤ ↦ (f : ℤ → A) q.1 * ((g : ℤ → A) q.2 * (h : ℤ → A) (n - q.1 - q.2)))
       ?_ fun k ↦ ?_).tsum_eq.symm
+  -- Fibre of `((fg)h)ₙ` over `m`: the `k`-series computing `(fg)ₘ`, scaled on the right by `h`.
   · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule f.2 g.2 m).hasSum.mul_right _
-  · refine ((Equiv.prodComm ℤ ℤ).trans
-      (Equiv.prodShear (Equiv.refl ℤ) Equiv.subRight)).hasSum_iff.mp ?_
-    convert hF.hasSum using 1
-    funext ⟨m, k⟩
-    simp [mul_assoc]
+  -- The reindexing `(m, k) ↦ (k, m - k)` is `Equiv.prodComm` followed by a shear; it carries `hF`
+  -- to the family whose fibres give `(f(gh))ₙ`, with `mul_assoc` rebracketing each term.
+  · refine ((Equiv.prodComm ℤ ℤ).trans ((Equiv.refl ℤ).prodShear Equiv.subRight)).hasSum_iff.mp ?_
+    simpa [Function.comp_def, mul_assoc] using hF.hasSum
+  -- Fibre of `(f(gh))ₙ` over `k`: the series computing `(gh)_{n - k}`, scaled on the left by `f`.
   · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule g.2 h.2 (n - k)).hasSum.mul_left _
 
 /-- **`A⟨X, X⁻¹⟩` is a ring** (Wedhorn, Example 6.39). The unit, the two annihilation laws and

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedRing.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedRing.lean
@@ -1,0 +1,306 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Algebra.Bilinear
+public import Mathlib.Topology.Algebra.InfiniteSum.DiscreteConvolution
+public import Mathlib.Topology.Algebra.InfiniteSum.Nonarchimedean
+public import TauCeti.RingTheory.Huber.Restricted.TwoSidedSeries
+
+/-!
+# The ring of two-sided restricted series `A⟨X, X⁻¹⟩`
+
+`TauCeti.Huber.twoSidedRestrictedSubmodule` is only the `A`-*module* of coefficient families
+underlying Wedhorn's `A⟨X, X⁻¹⟩` (Example 6.39). This module supplies the multiplication, which
+that file deliberately left out, and makes the coefficient object a ring — a commutative
+`A`-algebra when `A` is commutative, as the source states.
+
+## Why this is not the one-sided argument
+
+For the one-sided `A⟨X₁, …, Xₖ⟩` the coefficient convolution `(fg)ₙ = ∑_{i + j = n} aᵢ bⱼ` is a
+**finite** sum, because `MvPowerSeries.coeff_mul` runs over the antidiagonal of `Fin k →₀ ℕ`, which
+is a `Finset`; that is what `TauCeti.Huber.IsRestricted.mul` rearranges. Over `ℤ` the antidiagonal
+`{(i, j) | i + j = n}` is **infinite**, so the coefficient is a genuine infinite sum and there is
+no rearrangement to perform. Concretely `ℤ` carries no `Finset.HasAntidiagonal` instance and can
+carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at all.
+
+## The facts that replace it
+
+* *Restrictedness is summability.* In a **complete** nonarchimedean group, a family is summable
+  exactly when it tends to `0` along the cofinite filter
+  (`NonarchimedeanAddGroup.summable_iff_tendsto_cofinite_zero`), which is precisely the
+  restrictedness condition: `mem_twoSidedRestrictedSubmodule_iff_summable`.
+* *Existence.* Hence `Summable.mul_of_nonarchimedean` makes `(i, j) ↦ aᵢbⱼ` summable on `ℤ × ℤ`,
+  and each antidiagonal, being a subfamily, is summable too — this is the source's "convergent
+  series `∑_{k + l = n} aₖ bₗ`".
+* *Closure.* That the product is again restricted needs neither completeness nor summability. It is
+  `NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiber` applied to addition `ℤ × ℤ → ℤ`: an
+  open subgroup omits only finitely many `aᵢbⱼ`, hence meets only finitely many antidiagonals, and
+  an antidiagonal all of whose terms lie in an open — hence closed — subgroup sums back into it.
+* *Associativity.* Both `((fg)h)ₙ` and `(f(gh))ₙ` are the sum of `aᵢ bⱼ cₗ` over
+  `{i + j + l = n}`, an infinite family summable by two applications of
+  `Summable.mul_of_nonarchimedean`; summing it fibrewise in the degree of the partial product
+  (`HasSum.prod_fiberwise`) gives the two bracketings, and uniqueness of limits identifies them.
+  Nothing of the sort is in Mathlib's `DiscreteConvolution`, which has the unit, distributivity
+  and commutativity but no associativity.
+
+## Main definitions
+
+* `TauCeti.Huber.twoSidedRestrictedSubmodule.instMul`: the product on `A⟨X, X⁻¹⟩`, Mathlib's
+  `DiscreteConvolution.addConvolution` along the bilinear map `LinearMap.mul ℤ A`.
+* `TauCeti.Huber.twoSidedRestrictedSubmodule.instRing`, `instCommRing`, `instAlgebra`: **the ring
+  structure**, and the `A`-algebra structure of Example 6.39 when `A` is commutative.
+
+## Main results
+
+* `TauCeti.Huber.addConvolution_mul_apply`: the coefficient formula `(fg)ₙ = ∑' k, aₖ b_{n-k}`.
+* `TauCeti.Huber.addConvolution_mem_twoSidedRestrictedSubmodule`: **the closure result** — a
+  convolution of restricted families is restricted.
+* `TauCeti.Huber.mem_twoSidedRestrictedSubmodule_iff_summable`: over a complete group,
+  restrictedness is summability.
+* `TauCeti.Huber.summable_mul_sub_of_mem_twoSidedRestrictedSubmodule` and
+  `TauCeti.Huber.addConvolutionExists_of_mem_twoSidedRestrictedSubmodule`: over a complete ring the
+  coefficient series of a product converge.
+
+## Implementation notes
+
+The product is *not* the pointwise product of `ℤ → A`, so `A⟨X, X⁻¹⟩` is not a subring of `ℤ → A`
+and there is no ambient convolution ring to take a subring of — unlike the one-sided case, where
+`MvPowerSeries` already supplies one and `TauCeti.Huber.restrictedMvPowerSeriesSubring` is a genuine
+`Subring`. The multiplication is therefore installed directly on the submodule's coercion to a type,
+where nothing else claims a `Mul`.
+
+We reuse Mathlib's `DiscreteConvolution.addConvolution` rather than defining a `ℤ`-indexed
+convolution: it is the same sum over the same fibre, `addFiber n = {(i, j) | i + j = n}`.
+
+The multiplication and the closure result need only a nonarchimedean ring topology. The ring
+axioms need the coefficient ring to be complete **and** Hausdorff (`[CompleteSpace A] [T0Space A]`):
+completeness so that the coefficient series converge at all, and Hausdorffness so that `tsum` is a
+limit rather than a choice among limits — without it neither distributivity nor associativity is
+provable. This is exactly Wedhorn's convention, whose "complete" means "Hausdorff and every Cauchy
+filter basis converges" (Definition 5.31(4)–(5)), and it is the hypothesis list the consumer
+`TauCeti.RingTheory.Huber.Restricted.Laurent` already carries.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Example 6.39.
+-/
+
+public section
+
+open Filter Topology DiscreteConvolution
+
+namespace TauCeti.Huber
+
+section Convolution
+
+variable {A : Type*} [Ring A] [TopologicalSpace A] [NonarchimedeanRing A]
+
+/-- The antidiagonal `{(i, j) | i + j = n}` in `ℤ × ℤ`, parametrised by its first coordinate.
+
+This is where the `ℤ`-indexed picture and Mathlib's fibre picture meet, and it is an `Equiv` rather
+than a `Finset` precisely because the antidiagonal is infinite. -/
+private def addFiberEquivInt (n : ℤ) : ℤ ≃ (addFiber n : Set (ℤ × ℤ)) where
+  toFun k := ⟨(k, n - k), by simp [mem_addFiber]⟩
+  invFun ab := ab.1.1
+  left_inv _ := rfl
+  right_inv ab := Subtype.ext (Prod.ext rfl (by have := mem_addFiber.mp ab.2; dsimp only; omega))
+
+omit [NonarchimedeanRing A] in
+/-- **The coefficient formula for the two-sided product**: `(fg)ₙ = ∑' k, aₖ b_{n-k}`, the familiar
+Laurent convolution. Reindexing Mathlib's sum over `addFiber n` by the first coordinate is exactly
+`addFiberEquivInt`. -/
+theorem addConvolution_mul_apply (f g : ℤ → A) (n : ℤ) :
+    addConvolution (LinearMap.mul ℤ A) f g n = ∑' k : ℤ, f k * g (n - k) :=
+  ((addFiberEquivInt n).tsum_eq fun ab ↦ f ab.1.1 * g ab.1.2).symm
+
+/-- **The product of two restricted families is restricted**, so `A⟨X, X⁻¹⟩` is closed under the
+convolution. This is what makes it a ring rather than merely a module, and it needs neither
+completeness nor summability:
+`NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiber` sums along the fibres of addition
+`ℤ × ℤ → ℤ`, and `tendsto_mul_cofinite_nhds_zero` supplies its hypothesis on `(i, j) ↦ aᵢbⱼ`. Where
+a coefficient sum fails to converge it is `0` by the `tsum` convention, and `0` lies in every
+subgroup, so the degenerate case costs nothing and no completeness hypothesis is needed to state
+closure. -/
+theorem addConvolution_mem_twoSidedRestrictedSubmodule {f g : ℤ → A}
+    (hf : f ∈ twoSidedRestrictedSubmodule A A) (hg : g ∈ twoSidedRestrictedSubmodule A A) :
+    addConvolution (LinearMap.mul ℤ A) f g ∈ twoSidedRestrictedSubmodule A A := by
+  rw [mem_twoSidedRestrictedSubmodule] at hf hg ⊢
+  have key : addConvolution (LinearMap.mul ℤ A) f g
+      = fun n ↦ ∑' i : {i : ℤ × ℤ // i.1 + i.2 = n}, f i.1.1 * g i.1.2 :=
+    funext fun _ ↦ tsum_congr_set_coe (fun ab : ℤ × ℤ ↦ f ab.1 * g ab.2)
+      (Set.ext fun (_ : ℤ × ℤ) ↦ mem_addFiber)
+  rw [key]
+  exact NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiber
+    (F := fun ab : ℤ × ℤ ↦ f ab.1 * g ab.2) (tendsto_mul_cofinite_nhds_zero hf hg)
+    (fun ab ↦ ab.1 + ab.2)
+
+/-- **The product on `A⟨X, X⁻¹⟩`**: the coefficient convolution `(fg)ₙ = ∑' k, aₖ b_{n-k}`, which
+lands back in the submodule by `addConvolution_mem_twoSidedRestrictedSubmodule`. Only a
+nonarchimedean ring topology is needed to *define* it; the ring axioms are
+`twoSidedRestrictedSubmodule.instRing`. -/
+noncomputable instance twoSidedRestrictedSubmodule.instMul :
+    Mul (twoSidedRestrictedSubmodule A A) where
+  mul f g := ⟨addConvolution (LinearMap.mul ℤ A) f g,
+    addConvolution_mem_twoSidedRestrictedSubmodule f.2 g.2⟩
+
+/-- **The unit of `A⟨X, X⁻¹⟩`** is the constant series `1 = 1 · X⁰`, i.e. the family supported at
+degree `0`. -/
+instance twoSidedRestrictedSubmodule.instOne : One (twoSidedRestrictedSubmodule A A) where
+  one := ⟨Pi.single 0 1, single_mem_twoSidedRestrictedSubmodule 0 1⟩
+
+/-- The product is the convolution of the coefficient families. Its body is not exposed, so this
+is how it is computed outside this module. -/
+@[simp]
+theorem coe_mul_twoSidedRestrictedSubmodule (f g : twoSidedRestrictedSubmodule A A) :
+    ((f * g : twoSidedRestrictedSubmodule A A) : ℤ → A) =
+      addConvolution (LinearMap.mul ℤ A) f g := (rfl)
+
+/-- The unit is the family supported at degree `0` with value `1`. -/
+@[simp]
+theorem coe_one_twoSidedRestrictedSubmodule :
+    ((1 : twoSidedRestrictedSubmodule A A) : ℤ → A) = Pi.single 0 1 := (rfl)
+
+end Convolution
+
+section Summable
+
+variable {A M : Type*} [Semiring A] [AddCommGroup M] [UniformSpace M] [IsUniformAddGroup M]
+  [NonarchimedeanAddGroup M] [CompleteSpace M] [Module A M] [ContinuousConstSMul A M]
+
+/-- **Restrictedness is summability** over a complete nonarchimedean group: a family lies in the
+submodule exactly when it is summable. This is
+`NonarchimedeanAddGroup.summable_iff_tendsto_cofinite_zero` read through the membership criterion,
+and it is what turns Wedhorn's "the product of two such series is well defined" into a theorem. -/
+theorem mem_twoSidedRestrictedSubmodule_iff_summable {f : ℤ → M} :
+    f ∈ twoSidedRestrictedSubmodule A M ↔ Summable f := by
+  rw [mem_twoSidedRestrictedSubmodule]
+  exact (NonarchimedeanAddGroup.summable_iff_tendsto_cofinite_zero f).symm
+
+end Summable
+
+section Ring
+
+variable {A : Type*} [Ring A] [UniformSpace A] [IsUniformAddGroup A] [NonarchimedeanRing A]
+  [CompleteSpace A]
+
+/-- **Each coefficient of a product is a convergent series** (Wedhorn's "the convergent series
+`∑_{k + l = n} aₖ bₗ`"): restrictedness *is* summability over a complete nonarchimedean ring, so
+`Summable.mul_of_nonarchimedean` makes `(i, j) ↦ aᵢbⱼ` summable on all of `ℤ × ℤ`, and the
+antidiagonal `k ↦ (k, n - k)` is a subfamily. -/
+theorem summable_mul_sub_of_mem_twoSidedRestrictedSubmodule {f g : ℤ → A}
+    (hf : f ∈ twoSidedRestrictedSubmodule A A) (hg : g ∈ twoSidedRestrictedSubmodule A A)
+    (n : ℤ) : Summable fun k ↦ f k * g (n - k) :=
+  ((mem_twoSidedRestrictedSubmodule_iff_summable.mp hf).mul_of_nonarchimedean
+    (mem_twoSidedRestrictedSubmodule_iff_summable.mp hg)).comp_injective
+    (i := fun k ↦ (k, n - k)) fun _ _ hab ↦ (Prod.mk.inj hab).1
+
+/-- **The convolution of two restricted families exists**, in the form Mathlib's distributivity
+lemmas for `DiscreteConvolution.addConvolution` consume: the same subfamily argument as
+`summable_mul_sub_of_mem_twoSidedRestrictedSubmodule`, on Mathlib's fibre `addFiber n`. -/
+theorem addConvolutionExists_of_mem_twoSidedRestrictedSubmodule {f g : ℤ → A}
+    (hf : f ∈ twoSidedRestrictedSubmodule A A) (hg : g ∈ twoSidedRestrictedSubmodule A A) :
+    AddConvolutionExists (LinearMap.mul ℤ A) f g :=
+  fun _ ↦ ((mem_twoSidedRestrictedSubmodule_iff_summable.mp hf).mul_of_nonarchimedean
+    (mem_twoSidedRestrictedSubmodule_iff_summable.mp hg)).subtype _
+
+variable [T0Space A]
+
+namespace twoSidedRestrictedSubmodule
+
+/-- Both bracketings of a triple product are the sum of `aᵢ bⱼ cₗ` over `{i + j + l = n}`. That
+fibre is indexed by `(m, k) ↦ (k, m - k, n - m)`, with `m` the degree of the partial product `fg`;
+summing first over `k` gives `((fg)h)ₙ`, while after the reindexing `(m, k) ↦ (k, m - k)` summing
+first over the second coordinate gives `(f(gh))ₙ`. -/
+protected theorem mul_assoc (f g h : twoSidedRestrictedSubmodule A A) :
+    f * g * h = f * (g * h) := by
+  ext n
+  simp only [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply]
+  have hF : Summable fun p : ℤ × ℤ ↦
+      (f : ℤ → A) p.2 * (g : ℤ → A) (p.1 - p.2) * (h : ℤ → A) (n - p.1) :=
+    (((mem_twoSidedRestrictedSubmodule_iff_summable.mp f.2).mul_of_nonarchimedean
+      (mem_twoSidedRestrictedSubmodule_iff_summable.mp g.2)).mul_of_nonarchimedean
+      (mem_twoSidedRestrictedSubmodule_iff_summable.mp h.2)).comp_injective
+      (i := fun p : ℤ × ℤ ↦ ((p.2, p.1 - p.2), n - p.1)) fun p q hpq ↦ by
+        simp only [Prod.mk.injEq] at hpq
+        exact Prod.ext (by omega) hpq.1.1
+  refine (hF.hasSum.prod_fiberwise fun m ↦ ?_).tsum_eq.trans
+    (HasSum.prod_fiberwise
+      (f := fun q : ℤ × ℤ ↦ (f : ℤ → A) q.1 * ((g : ℤ → A) q.2 * (h : ℤ → A) (n - q.1 - q.2)))
+      ?_ fun k ↦ ?_).tsum_eq.symm
+  · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule f.2 g.2 m).hasSum.mul_right _
+  · refine ((Equiv.prodComm ℤ ℤ).trans
+      (Equiv.prodShear (Equiv.refl ℤ) Equiv.subRight)).hasSum_iff.mp ?_
+    convert hF.hasSum using 1
+    funext ⟨m, k⟩
+    simp [mul_assoc]
+  · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule g.2 h.2 (n - k)).hasSum.mul_left _
+
+/-- **`A⟨X, X⁻¹⟩` is a ring** (Wedhorn, Example 6.39). The unit, the two annihilation laws and
+distributivity are Mathlib's `DiscreteConvolution` lemmas, the latter fed by
+`addConvolutionExists_of_mem_twoSidedRestrictedSubmodule`; associativity is proved here. -/
+noncomputable instance instRing : Ring (twoSidedRestrictedSubmodule A A) where
+  __ := Submodule.addCommGroup _
+  __ := instMul
+  __ := instOne
+  mul_assoc := twoSidedRestrictedSubmodule.mul_assoc
+  one_mul _ := Subtype.ext <| by simp
+  mul_one _ := Subtype.ext <| by simp
+  left_distrib f g h := Subtype.ext <|
+    (addConvolutionExists_of_mem_twoSidedRestrictedSubmodule f.2 g.2).distrib_add _
+      (addConvolutionExists_of_mem_twoSidedRestrictedSubmodule f.2 h.2)
+  right_distrib f g h := Subtype.ext <|
+    (addConvolutionExists_of_mem_twoSidedRestrictedSubmodule f.2 h.2).add_distrib _
+      (addConvolutionExists_of_mem_twoSidedRestrictedSubmodule g.2 h.2)
+  zero_mul f := Subtype.ext (zero_addConvolution _ _)
+  mul_zero f := Subtype.ext (addConvolution_zero _ _)
+
+end twoSidedRestrictedSubmodule
+
+end Ring
+
+section CommRing
+
+variable {A : Type*} [CommRing A] [UniformSpace A] [IsUniformAddGroup A] [NonarchimedeanRing A]
+  [CompleteSpace A] [T0Space A]
+
+namespace twoSidedRestrictedSubmodule
+
+/-- **`A⟨X, X⁻¹⟩` is commutative when `A` is**: swapping the two coordinates of each antidiagonal
+is `DiscreteConvolution.addConvolution_comm`. -/
+noncomputable instance instCommRing : CommRing (twoSidedRestrictedSubmodule A A) where
+  __ := instRing
+  mul_comm f g := Subtype.ext (addConvolution_comm (LinearMap.mul ℤ A) (f : ℤ → A) g mul_comm)
+
+/-- **`A⟨X, X⁻¹⟩` is an `A`-algebra** (Wedhorn, Example 6.39), with the scalar action it already
+carries as a submodule of `ℤ → A`: scalars pass through each coefficient series by
+`Summable.tsum_mul_left`. -/
+noncomputable instance instAlgebra : Algebra A (twoSidedRestrictedSubmodule A A) :=
+  have h : ∀ (r : A) (f g : twoSidedRestrictedSubmodule A A), r • f * g = r • (f * g) :=
+    fun r f g ↦ by
+      ext n
+      simp only [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply, Submodule.coe_smul,
+        Pi.smul_apply, smul_eq_mul]
+      rw [← (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule f.2 g.2 n).tsum_mul_left r]
+      exact tsum_congr fun k ↦ mul_assoc _ _ _
+  Algebra.ofModule h fun r f g ↦ by rw [mul_comm, h, mul_comm]
+
+end twoSidedRestrictedSubmodule
+
+/-- The structure map sends `a` to the constant series `a = a · X⁰`. It characterises
+`twoSidedRestrictedSubmodule.instAlgebra`, whose body is not exposed. -/
+@[simp]
+theorem coe_algebraMap_twoSidedRestrictedSubmodule (a : A) :
+    ((algebraMap A (twoSidedRestrictedSubmodule A A) a : twoSidedRestrictedSubmodule A A) :
+        ℤ → A) = Pi.single 0 a := by
+  -- `Algebra.ofModule` sends `a` to `a • 1`, with the submodule's own scalar action, by definition.
+  change ((a • (1 : twoSidedRestrictedSubmodule A A) : twoSidedRestrictedSubmodule A A) : ℤ → A) = _
+  rw [Submodule.coe_smul, coe_one_twoSidedRestrictedSubmodule, ← Pi.single_smul, smul_eq_mul,
+    mul_one]
+
+end CommRing
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedRing.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedRing.lean
@@ -37,7 +37,7 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
   and each antidiagonal, being a subfamily, is summable too — this is the source's "convergent
   series `∑_{k + l = n} aₖ bₗ`".
 * *Closure.* That the product is again restricted needs neither completeness nor summability. It is
-  `NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiber` applied to addition `ℤ × ℤ → ℤ`: an
+  `NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiberwise` applied to addition `ℤ × ℤ → ℤ`: an
   open subgroup omits only finitely many `aᵢbⱼ`, hence meets only finitely many antidiagonals, and
   an antidiagonal all of whose terms lie in an open — hence closed — subgroup sums back into it.
 * *Associativity.* Both `((fg)h)ₙ` and `(f(gh))ₙ` are the sum of `aᵢ bⱼ cₗ` over
@@ -135,7 +135,7 @@ theorem addConvolution_mem_twoSidedRestrictedSubmodule {f g : ℤ → A}
   -- `(i, j) ↦ aᵢbⱼ` is cofinitely null because `f` and `g` are. Where a fibre's sum fails to
   -- converge it is `0` by the `tsum` convention, and `0` lies in every subgroup, so the degenerate
   -- case costs nothing and no completeness hypothesis is needed to state closure.
-  refine (NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiber
+  refine (NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiberwise
     (tendsto_mul_cofinite_nhds_zero hf hg) fun ab ↦ ab.1 + ab.2).congr fun _ ↦ ?_
   -- Mathlib's fibre `addFiber n` is the antidiagonal `{(i, j) | i + j = n}`.
   exact tsum_congr_set_coe (fun ab : ℤ × ℤ ↦ f ab.1 * g ab.2) <| Set.ext fun _ ↦ mem_addFiber.symm

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedRing.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedRing.lean
@@ -44,12 +44,14 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
   `{i + j + l = n}`, an infinite family summable by two applications of
   `Summable.mul_of_nonarchimedean`; summing it fibrewise in the degree of the partial product
   (`HasSum.prod_fiberwise`) gives the two bracketings, and uniqueness of limits identifies them.
-  Nothing of the sort is in Mathlib's `DiscreteConvolution`, which has the unit, distributivity
-  and commutativity but no associativity.
+  Nothing of the sort is in Mathlib's `DiscreteConvolution`, which supplies the unit, the
+  annihilation laws, distributivity, scalar compatibility and commutativity — every ring axiom
+  except associativity.
 
 ## Main definitions
 
-* `TauCeti.Huber.twoSidedRestrictedSubmodule.instMul`: the product on `A⟨X, X⁻¹⟩`, Mathlib's
+* `TauCeti.Huber.twoSidedRestrictedSubmodule.instMul` and `instOne`: the product and the unit on
+  `A⟨X, X⁻¹⟩`; the product is Mathlib's
   `DiscreteConvolution.addConvolution` along the bilinear map `LinearMap.mul ℤ A`.
 * `TauCeti.Huber.twoSidedRestrictedSubmodule.instRing`, `instCommRing`, `instAlgebra`: **the ring
   structure**, and the `A`-algebra structure of Example 6.39 when `A` is commutative.
@@ -64,6 +66,11 @@ carry none, so the `Finset`-indexed Cauchy-product lemmas do not apply here at a
 * `TauCeti.Huber.summable_mul_sub_of_mem_twoSidedRestrictedSubmodule` and
   `TauCeti.Huber.addConvolutionExists_of_mem_twoSidedRestrictedSubmodule`: over a complete ring the
   coefficient series of a product converge.
+* `TauCeti.Huber.coe_mul_twoSidedRestrictedSubmodule`,
+  `TauCeti.Huber.coe_one_twoSidedRestrictedSubmodule` and
+  `TauCeti.Huber.coe_algebraMap_twoSidedRestrictedSubmodule`: the computation API. The instance
+  bodies are not exposed, so these are how a product, the unit and the structure map are computed
+  outside this module.
 
 ## Implementation notes
 
@@ -81,7 +88,7 @@ axioms need the coefficient ring to be complete **and** Hausdorff (`[CompleteSpa
 completeness so that the coefficient series converge at all, and Hausdorffness so that `tsum` is a
 limit rather than a choice among limits — without it neither distributivity nor associativity is
 provable. This is exactly Wedhorn's convention, whose "complete" means "Hausdorff and every Cauchy
-filter basis converges" (Definition 5.31(4)–(5)), and it is the hypothesis list the consumer
+filter basis converges" (Definition 5.31(4)–(5)), and it is the hypothesis list the neighbouring
 `TauCeti.RingTheory.Huber.Restricted.Laurent` already carries.
 
 ## References
@@ -149,13 +156,13 @@ instance twoSidedRestrictedSubmodule.instOne : One (twoSidedRestrictedSubmodule 
 
 /-- The product is the convolution of the coefficient families. The `Mul` instance's body is not
 exposed, so this is how a product is computed outside this module. -/
-@[simp]
+@[simp, norm_cast]
 theorem coe_mul_twoSidedRestrictedSubmodule (f g : twoSidedRestrictedSubmodule A A) :
     (↑(f * g) : ℤ → A) = addConvolution (LinearMap.mul ℤ A) f g := rfl
 
 /-- The unit is the family supported at degree `0` with value `1`. The `One` instance's body is
 not exposed, so this is how the unit is computed outside this module. -/
-@[simp]
+@[simp, norm_cast]
 theorem coe_one_twoSidedRestrictedSubmodule :
     ((1 : twoSidedRestrictedSubmodule A A) : ℤ → A) = Pi.single 0 1 := rfl
 
@@ -209,9 +216,9 @@ variable [T0Space A]
 
 namespace twoSidedRestrictedSubmodule
 
-/-- Both bracketings of a triple product are the sum of `aᵢ bⱼ cₗ` over `{i + j + l = n}`. It is
-the associativity field of `twoSidedRestrictedSubmodule.instRing`, so downstream of that instance
-the root `mul_assoc` applies — which is why this one is `protected`. -/
+/-- Both bracketings of a triple product are the sum of `aᵢ bⱼ cₗ` over `{i + j + l = n}`. -/
+-- It is the associativity field of `twoSidedRestrictedSubmodule.instRing`. `protected` so that
+-- `open twoSidedRestrictedSubmodule` does not shadow `_root_.mul_assoc`.
 protected theorem mul_assoc (f g h : twoSidedRestrictedSubmodule A A) :
     f * g * h = f * (g * h) := by
   ext n
@@ -230,32 +237,38 @@ protected theorem mul_assoc (f g h : twoSidedRestrictedSubmodule A A) :
       (f := fun q : ℤ × ℤ ↦ (f : ℤ → A) q.1 * ((g : ℤ → A) q.2 * (h : ℤ → A) (n - q.1 - q.2)))
       ?_ fun k ↦ ?_).tsum_eq.symm
   -- Fibre of `((fg)h)ₙ` over `m`: the `k`-series computing `(fg)ₘ`, scaled on the right by `h`.
-  · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule f.2 g.2 m).hasSum.mul_right _
+  · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule f.2 g.2 m).hasSum.mul_right
+      ((h : ℤ → A) (n - m))
   -- The reindexing `(m, k) ↦ (k, m - k)` is `Equiv.prodComm` followed by a shear; it carries `hF`
   -- to the family whose fibres give `(f(gh))ₙ`, with `mul_assoc` rebracketing each term.
   · refine ((Equiv.prodComm ℤ ℤ).trans ((Equiv.refl ℤ).prodShear Equiv.subRight)).hasSum_iff.mp ?_
     simpa [Function.comp_def, mul_assoc] using hF.hasSum
   -- Fibre of `(f(gh))ₙ` over `k`: the series computing `(gh)_{n - k}`, scaled on the left by `f`.
-  · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule g.2 h.2 (n - k)).hasSum.mul_left _
+  · exact (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule g.2 h.2 (n - k)).hasSum.mul_left
+      ((f : ℤ → A) k)
 
-/-- **`A⟨X, X⁻¹⟩` is a ring** (Wedhorn, Example 6.39). The unit, the two annihilation laws and
-distributivity are Mathlib's `DiscreteConvolution` lemmas, the latter fed by
-`addConvolutionExists_of_mem_twoSidedRestrictedSubmodule`; associativity is proved here. -/
+/-- **`A⟨X, X⁻¹⟩` is a ring** (Wedhorn, Example 6.39). -/
 noncomputable instance instRing : Ring (twoSidedRestrictedSubmodule A A) where
   __ := Submodule.addCommGroup _
   __ := instMul
   __ := instOne
+  -- Associativity is the one ring axiom Mathlib's `DiscreteConvolution` lacks; it is proved here.
   mul_assoc := twoSidedRestrictedSubmodule.mul_assoc
+  -- The unit laws are Mathlib's `single_addConvolution` and `addConvolution_single`, reached
+  -- through the two coercion `simp` lemmas above.
   one_mul _ := Subtype.ext <| by simp
   mul_one _ := Subtype.ext <| by simp
+  -- Distributivity is Mathlib's, fed by `addConvolutionExists_of_mem_twoSidedRestrictedSubmodule`:
+  -- the coefficient series converge, so each sum may be split in two.
   left_distrib f g h := Subtype.ext <|
     (addConvolutionExists_of_mem_twoSidedRestrictedSubmodule f.2 g.2).distrib_add _
       (addConvolutionExists_of_mem_twoSidedRestrictedSubmodule f.2 h.2)
   right_distrib f g h := Subtype.ext <|
     (addConvolutionExists_of_mem_twoSidedRestrictedSubmodule f.2 h.2).add_distrib _
       (addConvolutionExists_of_mem_twoSidedRestrictedSubmodule g.2 h.2)
-  zero_mul f := Subtype.ext (zero_addConvolution _ _)
-  mul_zero f := Subtype.ext (addConvolution_zero _ _)
+  -- The two annihilation laws are Mathlib's, and need no convergence hypothesis.
+  zero_mul _ := Subtype.ext <| zero_addConvolution _ _
+  mul_zero _ := Subtype.ext <| addConvolution_zero _ _
 
 end twoSidedRestrictedSubmodule
 
@@ -268,37 +281,36 @@ variable {A : Type*} [CommRing A] [UniformSpace A] [IsUniformAddGroup A] [Nonarc
 
 namespace twoSidedRestrictedSubmodule
 
-/-- **`A⟨X, X⁻¹⟩` is commutative when `A` is**: swapping the two coordinates of each antidiagonal
-is `DiscreteConvolution.addConvolution_comm`. -/
+/-- **`A⟨X, X⁻¹⟩` is commutative when `A` is** (Wedhorn, Example 6.39). -/
 noncomputable instance instCommRing : CommRing (twoSidedRestrictedSubmodule A A) where
   __ := instRing
-  mul_comm f g := Subtype.ext (addConvolution_comm (LinearMap.mul ℤ A) (f : ℤ → A) g mul_comm)
+  -- Commutativity is Mathlib's `addRingConvolution_comm`, which swaps the two coordinates of each
+  -- antidiagonal.
+  mul_comm f g := Subtype.ext <| addRingConvolution_comm (f : ℤ → A) g
 
 /-- **`A⟨X, X⁻¹⟩` is an `A`-algebra** (Wedhorn, Example 6.39), with the scalar action it already
-carries as a submodule of `ℤ → A`: scalars pass through each coefficient series by
-`Summable.tsum_mul_left`. -/
+carries as a submodule of `ℤ → A`. The instance's body is not exposed; its structure map is
+`coe_algebraMap_twoSidedRestrictedSubmodule`. -/
 noncomputable instance instAlgebra : Algebra A (twoSidedRestrictedSubmodule A A) :=
-  have h : ∀ (r : A) (f g : twoSidedRestrictedSubmodule A A), r • f * g = r • (f * g) :=
-    fun r f g ↦ by
-      ext n
-      simp only [coe_mul_twoSidedRestrictedSubmodule, addConvolution_mul_apply, Submodule.coe_smul,
-        Pi.smul_apply, smul_eq_mul]
-      rw [← (summable_mul_sub_of_mem_twoSidedRestrictedSubmodule f.2 g.2 n).tsum_mul_left r]
-      exact tsum_congr fun k ↦ mul_assoc _ _ _
-  Algebra.ofModule h fun r f g ↦ by rw [mul_comm, h, mul_comm]
+  -- Scalars pass through each coefficient series: our product is definitionally Mathlib's
+  -- `addRingConvolution`,
+  -- so `smul_addRingConvolution` and `addRingConvolution_smul` are the two hypotheses, fed by
+  -- `addConvolutionExists_of_mem_twoSidedRestrictedSubmodule`.
+  Algebra.ofModule
+    (fun r f g ↦ Subtype.ext <| smul_addRingConvolution r _ _ <|
+      addConvolutionExists_of_mem_twoSidedRestrictedSubmodule f.2 g.2)
+    fun r f g ↦ Subtype.ext <| addRingConvolution_smul r _ _ <|
+      addConvolutionExists_of_mem_twoSidedRestrictedSubmodule f.2 g.2
 
 end twoSidedRestrictedSubmodule
 
 /-- The structure map sends `a` to the constant series `a = a · X⁰`. It characterises
 `twoSidedRestrictedSubmodule.instAlgebra`, whose body is not exposed. -/
-@[simp]
+@[simp, norm_cast]
 theorem coe_algebraMap_twoSidedRestrictedSubmodule (a : A) :
-    ((algebraMap A (twoSidedRestrictedSubmodule A A) a : twoSidedRestrictedSubmodule A A) :
-        ℤ → A) = Pi.single 0 a := by
-  -- `Algebra.ofModule` sends `a` to `a • 1`, with the submodule's own scalar action, by definition.
-  change ((a • (1 : twoSidedRestrictedSubmodule A A) : twoSidedRestrictedSubmodule A A) : ℤ → A) = _
-  rw [Submodule.coe_smul, coe_one_twoSidedRestrictedSubmodule, ← Pi.single_smul, smul_eq_mul,
-    mul_one]
+    (algebraMap A (twoSidedRestrictedSubmodule A A) a : ℤ → A) = Pi.single 0 a := by
+  -- The structure map is `a • 1` for the submodule's own scalar action, so it is a `Pi.single`.
+  simp [Algebra.algebraMap_eq_smul_one, ← Pi.single_smul]
 
 end CommRing
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -55,6 +55,9 @@ a placement hazard:
   `TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean` because neither direction of it
   looks at the index set or at series.
 * `TauCeti.Huber.twoSidedRestrictedSubmodule_ext`: coefficientwise extensionality.
+* `TauCeti.Huber.single_mem_twoSidedRestrictedSubmodule`: a family supported at one degree is
+  restricted; at `M = A` these are the monomials `a Xⁿ`, and `X⁰ = 1` is the unit of the ring
+  structure built in `TauCeti.RingTheory.Huber.Restricted.TwoSidedRing`.
 * `TauCeti.Huber.twoSidedRestrictedSubmodule_eq_sup` and
   `TauCeti.Huber.disjoint_twoSidedRestricted_nonneg_neg`: **the degree decomposition and its
   directness** — `A⟨X, X⁻¹⟩` is the sum of its non-negative and negative parts, and that sum is
@@ -72,12 +75,13 @@ a placement hazard:
 
 ## Implementation notes
 
-Only the additive and `A`-module structure is built here. The **ring** structure is deliberately
-absent: the coefficient convolution `(fg)ₙ = ∑_{i + j = n} aᵢ bⱼ` is a *finite* sum for one-sided
-series — which is what `TauCeti.Huber.IsRestricted.mul` exploits, through
-`MvPowerSeries.coeff_mul` over a finite antidiagonal — but over `ℤ` that antidiagonal is infinite,
-so multiplication needs a summability argument in a complete ring rather than a rearrangement of a
-finite sum. That is separate work and does not belong to this rung.
+Only the additive and `A`-module structure is built here. The **ring** structure lives in
+`TauCeti.RingTheory.Huber.Restricted.TwoSidedRing`: the coefficient convolution
+`(fg)ₙ = ∑_{i + j = n} aᵢ bⱼ` is a *finite* sum for one-sided series — which is what
+`TauCeti.Huber.IsRestricted.mul` exploits, through `MvPowerSeries.coeff_mul` over a finite
+antidiagonal — but over `ℤ` that antidiagonal is infinite, so multiplication needs a summability
+argument in a complete ring rather than a rearrangement of a finite sum, and that argument is
+separate work.
 
 ## References
 
@@ -124,6 +128,17 @@ map that does not exist until there is a ring structure. -/
 theorem twoSidedRestrictedSubmodule_ext {f g : twoSidedRestrictedSubmodule A M}
     (h : ∀ n, (f : ℤ → M) n = (g : ℤ → M) n) : f = g :=
   Subtype.ext (funext h)
+
+/-- **A family supported at a single degree is restricted**: its support lies in `{n}`, so it is
+eventually zero along the cofinite filter. At `M = A` these are the monomials `a Xⁿ` of
+`A⟨X, X⁻¹⟩`; this is the two-sided counterpart of `TauCeti.Huber.isRestricted_monomial` and is
+proved the same way, through `tendsto_cofinite_pure_iff`. Not `@[simp]`, for the reason given at
+`mem_twoSidedRestrictedSubmodule_iff_finite_notMem`: the membership lemma rewrites this left-hand
+side first. -/
+theorem single_mem_twoSidedRestrictedSubmodule (n : ℤ) (m : M) :
+    Pi.single n m ∈ twoSidedRestrictedSubmodule A M :=
+  (tendsto_cofinite_pure_iff.mpr
+    ((Set.finite_singleton n).subset Pi.support_single_subset)).mono_right (pure_le_nhds 0)
 
 end Submodule
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -131,10 +131,12 @@ theorem twoSidedRestrictedSubmodule_ext {f g : twoSidedRestrictedSubmodule A M}
 
 /-- **A family supported at a single degree is restricted**: its support lies in `{n}`, so it is
 eventually zero along the cofinite filter. At `M = A` these are the monomials `a Xⁿ` of
-`A⟨X, X⁻¹⟩`; this is the two-sided counterpart of `TauCeti.Huber.isRestricted_monomial` and is
-proved the same way, through `tendsto_cofinite_pure_iff`. Not `@[simp]`, for the reason given at
-`mem_twoSidedRestrictedSubmodule_iff_finite_notMem`: the membership lemma rewrites this left-hand
-side first. -/
+`A⟨X, X⁻¹⟩`; this is the two-sided counterpart of `TauCeti.Huber.isRestricted_monomial`. Both
+reduce to the support being contained in `{n}`, but by different routes: the one-sided lemma hands
+that to `isRestricted_of_hasFiniteSupport`, whereas this submodule is defined by cofinite
+convergence directly, so the finite support is fed to `tendsto_cofinite_pure_iff`. Not `@[simp]`,
+for the reason given at `mem_twoSidedRestrictedSubmodule_iff_finite_notMem`: the membership lemma
+rewrites this left-hand side first. -/
 theorem single_mem_twoSidedRestrictedSubmodule (n : ℤ) (m : M) :
     Pi.single n m ∈ twoSidedRestrictedSubmodule A M :=
   (tendsto_cofinite_pure_iff.mpr

--- a/TauCeti/Topology/Algebra/InfiniteSum/DiscreteConvolution.lean
+++ b/TauCeti/Topology/Algebra/InfiniteSum/DiscreteConvolution.lean
@@ -27,21 +27,33 @@ public section
 
 namespace DiscreteConvolution
 
-/-- **The antidiagonal `{(i, j) | i + j = n}` in `ℤ × ℤ`, parametrised by its first
-coordinate.** This is where the `ℤ`-indexed picture and Mathlib's fibre picture meet, and it is
-an `Equiv` rather than a `Finset` precisely because the antidiagonal is infinite. -/
-def intEquivAddFiber (n : ℤ) : ℤ ≃ (addFiber n : Set (ℤ × ℤ)) where
-  toFun k := ⟨(k, n - k), by grind⟩
+/-- **The antidiagonal `{(a, b) | a + b = n}`, parametrised by its first coordinate.** This is
+where an index-set picture and Mathlib's fibre picture meet, and it is an `Equiv` rather than a
+`Finset` because the antidiagonal need not be finite. -/
+def equivAddFiber {G : Type*} [AddGroup G] (n : G) : G ≃ (addFiber n : Set (G × G)) where
+  toFun k := ⟨(k, -k + n), by simp [mem_addFiber]⟩
   invFun ab := ab.1.1
   left_inv _ := rfl
-  right_inv ab := by grind
+  right_inv ab := by
+    obtain ⟨⟨a, b⟩, hab⟩ := ab
+    rw [mem_addFiber] at hab
+    subst hab
+    simp
 
-/-- **The integer convolution is a single sum**: `(f ⋆ g) n = ∑' k, f k * g (n - k)`, the
-familiar Laurent convolution. Reindexing Mathlib's sum over `addFiber n` by the first coordinate
-is exactly `DiscreteConvolution.intEquivAddFiber`. -/
-theorem addConvolution_mul_apply {A : Type*} [Ring A] [TopologicalSpace A] (f g : ℤ → A)
-    (n : ℤ) : addConvolution (LinearMap.mul ℤ A) f g n = ∑' k : ℤ, f k * g (n - k) :=
-  ((intEquivAddFiber n).tsum_eq fun ab ↦ f ab.1.1 * g ab.1.2).symm
+/-- **The convolution over an additive group is a single sum**:
+`(f ⋆ g) n = ∑' k, f k * g (-k + n)`. Reindexing Mathlib's sum over `addFiber n` by the
+first coordinate is exactly `DiscreteConvolution.equivAddFiber`. -/
+theorem addConvolution_mul_apply {G : Type*} [AddGroup G] {A : Type*} [Ring A]
+    [TopologicalSpace A] (f g : G → A) (n : G) :
+    addConvolution (LinearMap.mul ℤ A) f g n = ∑' k : G, f k * g (-k + n) :=
+  ((equivAddFiber n).tsum_eq fun ab ↦ f ab.1.1 * g ab.1.2).symm
+
+/-- **The commutative form**: `(f ⋆ g) n = ∑' k, f k * g (n - k)`, the familiar Laurent
+convolution when the index group is `ℤ`. -/
+theorem addConvolution_mul_apply_sub {G : Type*} [AddCommGroup G] {A : Type*} [Ring A]
+    [TopologicalSpace A] (f g : G → A) (n : G) :
+    addConvolution (LinearMap.mul ℤ A) f g n = ∑' k : G, f k * g (n - k) :=
+  (addConvolution_mul_apply f g n).trans (tsum_congr fun k ↦ by rw [neg_add_eq_sub])
 
 end DiscreteConvolution
 

--- a/TauCeti/Topology/Algebra/InfiniteSum/DiscreteConvolution.lean
+++ b/TauCeti/Topology/Algebra/InfiniteSum/DiscreteConvolution.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Topology.Algebra.InfiniteSum.DiscreteConvolution
+
+/-!
+# Integer discrete convolution as a sum over one index
+
+Mathlib's `DiscreteConvolution.addConvolution` sums over the fibre `addFiber n`, the
+antidiagonal `{(i, j) | i + j = n}`. Over `ℤ` that fibre is parametrised by its first
+coordinate, which turns the convolution into a single sum:
+
+* `DiscreteConvolution.addFiberEquivInt`: the parametrisation `k ↦ (k, n - k)`;
+* `DiscreteConvolution.addConvolution_mul_apply`: `(f ⋆ g) n = ∑' k, f k * g (n - k)`, the
+  familiar Laurent convolution.
+
+The equivalence is an `Equiv` rather than a `Finset` because the antidiagonal in `ℤ × ℤ` is
+infinite. Nothing here is specific to any ring of interest; it is the bridge between Mathlib's
+fibre picture and the `ℤ`-indexed one.
+-/
+
+@[expose] public section
+
+namespace DiscreteConvolution
+
+/-- **The antidiagonal `{(i, j) | i + j = n}` in `ℤ × ℤ`, parametrised by its first
+coordinate.** This is where the `ℤ`-indexed picture and Mathlib's fibre picture meet, and it is
+an `Equiv` rather than a `Finset` precisely because the antidiagonal is infinite. -/
+def addFiberEquivInt (n : ℤ) : ℤ ≃ (addFiber n : Set (ℤ × ℤ)) where
+  toFun k := ⟨(k, n - k), by grind⟩
+  invFun ab := ab.1.1
+  left_inv _ := rfl
+  right_inv ab := by grind
+
+/-- **The integer convolution is a single sum**: `(f ⋆ g) n = ∑' k, f k * g (n - k)`, the
+familiar Laurent convolution. Reindexing Mathlib's sum over `addFiber n` by the first coordinate
+is exactly `DiscreteConvolution.addFiberEquivInt`. -/
+theorem addConvolution_mul_apply {A : Type*} [Ring A] [TopologicalSpace A] (f g : ℤ → A)
+    (n : ℤ) : addConvolution (LinearMap.mul ℤ A) f g n = ∑' k : ℤ, f k * g (n - k) :=
+  ((addFiberEquivInt n).tsum_eq fun ab ↦ f ab.1.1 * g ab.1.2).symm
+
+end DiscreteConvolution
+
+end

--- a/TauCeti/Topology/Algebra/InfiniteSum/DiscreteConvolution.lean
+++ b/TauCeti/Topology/Algebra/InfiniteSum/DiscreteConvolution.lean
@@ -14,7 +14,7 @@ Mathlib's `DiscreteConvolution.addConvolution` sums over the fibre `addFiber n`,
 antidiagonal `{(i, j) | i + j = n}`. Over `ℤ` that fibre is parametrised by its first
 coordinate, which turns the convolution into a single sum:
 
-* `DiscreteConvolution.addFiberEquivInt`: the parametrisation `k ↦ (k, n - k)`;
+* `DiscreteConvolution.intEquivAddFiber`: the parametrisation `k ↦ (k, n - k)`;
 * `DiscreteConvolution.addConvolution_mul_apply`: `(f ⋆ g) n = ∑' k, f k * g (n - k)`, the
   familiar Laurent convolution.
 
@@ -23,14 +23,14 @@ infinite. Nothing here is specific to any ring of interest; it is the bridge bet
 fibre picture and the `ℤ`-indexed one.
 -/
 
-@[expose] public section
+public section
 
 namespace DiscreteConvolution
 
 /-- **The antidiagonal `{(i, j) | i + j = n}` in `ℤ × ℤ`, parametrised by its first
 coordinate.** This is where the `ℤ`-indexed picture and Mathlib's fibre picture meet, and it is
 an `Equiv` rather than a `Finset` precisely because the antidiagonal is infinite. -/
-def addFiberEquivInt (n : ℤ) : ℤ ≃ (addFiber n : Set (ℤ × ℤ)) where
+def intEquivAddFiber (n : ℤ) : ℤ ≃ (addFiber n : Set (ℤ × ℤ)) where
   toFun k := ⟨(k, n - k), by grind⟩
   invFun ab := ab.1.1
   left_inv _ := rfl
@@ -38,10 +38,10 @@ def addFiberEquivInt (n : ℤ) : ℤ ≃ (addFiber n : Set (ℤ × ℤ)) where
 
 /-- **The integer convolution is a single sum**: `(f ⋆ g) n = ∑' k, f k * g (n - k)`, the
 familiar Laurent convolution. Reindexing Mathlib's sum over `addFiber n` by the first coordinate
-is exactly `DiscreteConvolution.addFiberEquivInt`. -/
+is exactly `DiscreteConvolution.intEquivAddFiber`. -/
 theorem addConvolution_mul_apply {A : Type*} [Ring A] [TopologicalSpace A] (f g : ℤ → A)
     (n : ℤ) : addConvolution (LinearMap.mul ℤ A) f g n = ∑' k : ℤ, f k * g (n - k) :=
-  ((addFiberEquivInt n).tsum_eq fun ab ↦ f ab.1.1 * g ab.1.2).symm
+  ((intEquivAddFiber n).tsum_eq fun ab ↦ f ab.1.1 * g ab.1.2).symm
 
 end DiscreteConvolution
 

--- a/TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Order.Filter.ZeroAndBoundedAtFilter
+public import Mathlib.Topology.Algebra.InfiniteSum.Basic
 public import TauCeti.Topology.Algebra.Nonarchimedean.OpenAddSubgroupBasis
 
 /-!
@@ -24,6 +25,7 @@ Nothing here looks at the index type, so it is arbitrary.
 ## Main results
 
 * `NonarchimedeanAddGroup.zeroAtFilter_cofinite_iff_finite_notMem`
+* `NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiber`
 -/
 
 public section
@@ -47,5 +49,29 @@ theorem zeroAtFilter_cofinite_iff_finite_notMem {f : ι → G} :
     ZeroAtFilter cofinite f ↔ ∀ W : OpenAddSubgroup G, {n | f n ∉ (W : Set G)}.Finite := by
   simp only [ZeroAtFilter, (nhds_zero_hasBasis_openAddSubgroup G).tendsto_right_iff, true_implies,
     Filter.eventually_cofinite]
+
+/-- **Summing along the fibres of an arbitrary map preserves cofinite convergence.** If `F` tends
+to `0` along the cofinite filter, then so does `n ↦ ∑' i ∈ p ⁻¹' {n}, F i`, for *any* `p`. No
+hypothesis on `p` is needed and the fibres may well be infinite.
+
+The point is that the two finiteness conditions match up: an open subgroup `W` omits only finitely
+many `F i`, so only finitely many fibres contain an omitted term, and over every other fibre each
+term lies in `W`. Such a fibre sums back into `W` because an open subgroup is also *closed*
+(`OpenAddSubgroup.isClosed`), so it contains the limit of its partial sums (`tsum_mem`) — including
+in the degenerate case where the fibre is not summable, since then the sum is `0 ∈ W` by
+convention.
+
+This is the engine behind convolution: taking `p` to be addition `ι × ι → ι` says that a
+coefficientwise convolution of cofinitely-null families is again cofinitely null, with the infinite
+antidiagonal costing nothing. Mathlib's `HasSum.tsum_fiberwise` regroups a *summable* family along
+the fibres of `p`; this is its cofinite-nullity counterpart, needing neither summability nor a
+separation axiom, which is what lets a convolution be defined before completeness enters. -/
+theorem zeroAtFilter_cofinite_tsum_fiber {κ : Type*} {H : Type*} [AddCommGroup H]
+    [TopologicalSpace H] [NonarchimedeanAddGroup H] {F : ι → H} (hF : ZeroAtFilter cofinite F)
+    (p : ι → κ) : ZeroAtFilter cofinite fun n ↦ ∑' i : {i // p i = n}, F i.1 := by
+  rw [zeroAtFilter_cofinite_iff_finite_notMem] at hF ⊢
+  refine fun W ↦ ((hF W).image p).subset fun n hn ↦ ?_
+  by_contra hnot
+  exact hn (tsum_mem W.isClosed fun i ↦ not_not.mp fun h ↦ hnot ⟨i.1, h, i.2⟩)
 
 end NonarchimedeanAddGroup

--- a/TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean
@@ -25,7 +25,7 @@ Nothing here looks at the index type, so it is arbitrary.
 ## Main results
 
 * `NonarchimedeanAddGroup.zeroAtFilter_cofinite_iff_finite_notMem`
-* `NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiber`
+* `NonarchimedeanAddGroup.zeroAtFilter_cofinite_tsum_fiberwise`
 -/
 
 public section
@@ -54,23 +54,22 @@ theorem zeroAtFilter_cofinite_iff_finite_notMem {f : ι → G} :
 to `0` along the cofinite filter, then so does `n ↦ ∑' i ∈ p ⁻¹' {n}, F i`, for *any* `p`. No
 hypothesis on `p` is needed and the fibres may well be infinite.
 
-The point is that the two finiteness conditions match up: an open subgroup `W` omits only finitely
-many `F i`, so only finitely many fibres contain an omitted term, and over every other fibre each
-term lies in `W`. Such a fibre sums back into `W` because an open subgroup is also *closed*
-(`OpenAddSubgroup.isClosed`), so it contains the limit of its partial sums (`tsum_mem`) — including
-in the degenerate case where the fibre is not summable, since then the sum is `0 ∈ W` by
-convention.
-
 This is the engine behind convolution: taking `p` to be addition `ι × ι → ι` says that a
 coefficientwise convolution of cofinitely-null families is again cofinitely null, with the infinite
 antidiagonal costing nothing. Mathlib's `HasSum.tsum_fiberwise` regroups a *summable* family along
 the fibres of `p`; this is its cofinite-nullity counterpart, needing neither summability nor a
 separation axiom, which is what lets a convolution be defined before completeness enters. -/
-theorem zeroAtFilter_cofinite_tsum_fiber {κ : Type*} {H : Type*} [AddCommGroup H]
-    [TopologicalSpace H] [NonarchimedeanAddGroup H] {F : ι → H} (hF : ZeroAtFilter cofinite F)
-    (p : ι → κ) : ZeroAtFilter cofinite fun n ↦ ∑' i : {i // p i = n}, F i.1 := by
+theorem zeroAtFilter_cofinite_tsum_fiberwise {κ H : Type*} [AddCommGroup H] [TopologicalSpace H]
+    [NonarchimedeanAddGroup H] {F : ι → H} (hF : ZeroAtFilter cofinite F) (p : ι → κ) :
+    ZeroAtFilter cofinite fun n ↦ ∑' i : {i // p i = n}, F i.1 := by
+  -- The criterion turns both sides into finiteness statements about open subgroups.
   rw [zeroAtFilter_cofinite_iff_finite_notMem] at hF ⊢
+  -- `W` omits only finitely many `F i`, so the fibres it omits are among the images under `p` of
+  -- those finitely many indices.
   refine fun W ↦ ((hF W).image p).subset fun n hn ↦ ?_
+  -- Over any other fibre every term lies in `W`, which is closed as well as open, so the fibre
+  -- sums back into it. If the fibre is not summable the sum is `0 ∈ W` by convention, so the
+  -- degenerate case costs nothing.
   by_contra hnot
   exact hn (tsum_mem W.isClosed fun i ↦ not_not.mp fun h ↦ hnot ⟨i.1, h, i.2⟩)
 


### PR DESCRIPTION
Wedhorn's `A⟨X, X⁻¹⟩` (Example 6.39) is an `A`-**module** on main (`twoSidedRestrictedSubmodule`,
#4907), and #6925 added the coefficient **convolution** on it: summability, closure, the bilinear
map `twoSidedRestrictedMul` and its commutativity. Its description leaves "constructing the
unital associative ring" open. This PR supplies exactly that: the unit, **associativity**, the
`Ring`, `CommRing` and `A`-`Algebra` instances, and the monomials `a Xⁿ`, with every monomial whose
coefficient is a unit — in particular the Laurent variable — a unit. The two facts about coefficient
families it rests on, associativity of convolution and the product of single-point families, are
proved in the generality of Mathlib's convolution API.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-4.1-example-6.39-ring"}-->

## What downstream roadmap item needs this

`TauCetiRoadmap/AdicSpaces/README.md`, Layer 4.1, numbered step 5, verbatim:

> 5. Lemma 8.33: prove exactness for a two-piece Laurent cover.

Wedhorn's proof identifies `O_X(U₁ ∩ U₂) = A⟨ζ, ζ⁻¹⟩/(f - ζ)` and chases a 3×3 diagram whose
first row rests on

```text
(f - ζ)A⟨ζ, ζ⁻¹⟩ = (f - ζ)A⟨ζ⟩ + (1 - f ζ⁻¹)A⟨ζ⁻¹⟩.
```

Both are statements about **ideals** of `A⟨ζ, ζ⁻¹⟩`, so they need `A⟨ζ, ζ⁻¹⟩` as a ring, not
only a bilinear product: a quotient `A⟨ζ, ζ⁻¹⟩/(f - ζ)` needs `Ring`, and "`ζ` is a unit" needs
associativity and a unit.

## What is reused and what is proved here

**From main (#6925):** the product *is* its convolution `⋆ᵣ₊`, closed under
`addRingConvolution_mem_twoSidedRestrictedSubmodule`, and distributivity uses its
`addConvolutionExists_of_mem_twoSidedRestrictedSubmodule`. `twoSidedRestrictedMul_apply` identifies
its bilinear `twoSidedRestrictedMul` with the ring product, and the algebra axioms are that map's
bilinearity.

**From Mathlib:** the unit and annihilation laws, distributivity and commutativity
(`DiscreteConvolution.addRingConvolution_comm`) of `addRingConvolution`.

**Proved here.**

* *Associativity.* Mathlib at the pinned revision has no associativity for `ringConvolution` /
  `addRingConvolution` (the only `convolution_assoc` is the measure-theoretic one), and
  `HahnSeries`/`LaurentSeries` do not apply: their support is well-founded, while a restricted
  two-sided series may be supported unboundedly in both directions.
  * `DiscreteConvolution.ringConvolution_assoc` (with its additive version
    `addRingConvolution_assoc`, from `@[to_additive]`) proves it over any monoid, in any `T3`
    topological semiring, when the triple family `f a * g b * h c` over `{a * b * c = x}` is
    summable and so are the convolution sums of `f` with `g` and of `g` with `h`: summing the
    triple family fibrewise in either partial product gives the two sides.
  * `TauCeti.ZeroAtFilter.addRingConvolution_assoc` is the case of families that tend to zero
    cofinitely in a complete `T0` nonarchimedean ring, where every one of those sums converges
    (`ZeroAtFilter.summable_sigma_addFiber_mul_mul` for the triple family). It
    sits next to #6925's `TauCeti.ZeroAtFilter.addRingConvolution` and summability lemmas, and
    `mul_assoc` of the ring instance is one call to it.
* *Single-point families.* `DiscreteConvolution.single_convolution_single` (with its additive
  version `single_addConvolution_single`):
  `Pi.single m a ⋆[L] Pi.single n b = Pi.single (m * n) (L a b)` for any bilinear `L`, over any
  monoid, with no hypothesis on the topology. Its multiplication case
  `single_ringConvolution_single` (additively `single_addRingConvolution_single`) is the monomial
  product rule. All four forms are `@[simp]`. Mathlib has only the unit cases `single_convolution` and
  `single_ringConvolution`.

## Hypotheses

The unit and the monomials, with their additive and scalar laws, need only continuous addition and
scalar multiplication (`twoSidedMonomial_neg` also needs a ring); the product and the monomial
product rule need a nonarchimedean ring topology. The ring axioms assume `[CompleteSpace A] [T0Space A]`, so that coefficient series converge and `tsum` is
their limit. This is Wedhorn's convention (Definition 5.31: "complete" includes Hausdorff); for a
topological ring `T0` and `T2` coincide, and the weaker class is the one stated. `A⟨X, X⁻¹⟩` is not
a subring of `ℤ → A`, since the product is not pointwise, so the instances live on the submodule's
coercion to a type.

## Files

* `TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries/Ring.lean` — new: `instMul`, `instOne`,
  `instRing`, `instCommRing`, `instAlgebra`; `twoSidedMonomial` with `coe_twoSidedMonomial`, the
  coefficient laws `twoSidedMonomial_zero_right`, `twoSidedMonomial_add`, `twoSidedMonomial_neg`
  and `smul_twoSidedMonomial` (`a • b Xⁿ = (ab) Xⁿ`), the degree-zero lemmas `twoSidedMonomial_zero_one` and
  `twoSidedMonomial_zero_left` (`a X⁰ = algebraMap A _ a`), `twoSidedMonomial_mul_twoSidedMonomial`
  and `isUnit_twoSidedMonomial`; `twoSidedRestrictedMul_apply`; and the coercion `simp` lemmas.
* `TauCeti/Topology/Algebra/Nonarchimedean/DiscreteConvolution.lean` — adds
  `ZeroAtFilter.summable_sigma_addFiber_mul_mul` (the triple family is summable) and
  `ZeroAtFilter.addRingConvolution_assoc`.
* `TauCeti/Topology/Algebra/InfiniteSum/DiscreteConvolution.lean` — new: the single-point product
  rule and summability-generic associativity, at the path of the Mathlib file they extend.
* `TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries/Basic.lean` — adds
  `single_mem_twoSidedRestrictedSubmodule`, the membership witness for monomials and the unit, and
  updates two docstrings that said no ring structure exists.
* `TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries/Convolution.lean` — docstring only: it points
  to the ring structure.

## Review status

This PR was reworked onto #6925, which reached main after the last review round; it now adds only
what #6925 does not have. The earlier rounds' findings carry over as follows.

* **scope** asked this PR to wait for Layer 4.1 steps 3–4, "on main or in identified open PRs".
  **Both are now on main.** Step 3, Proposition 8.30: `PairOfDefinition.flat_toCompletionLoc`
  (#6853) makes `A → A⟨T/s⟩` flat for every presentation, and #6521 gives flatness of the rational
  restriction maps. Step 4, Corollary 8.32: #6954 proves faithful flatness and injectivity for any
  finite rational cover.
* **placement** — the ring lives in #6925's `TwoSidedSeries/` directory; the generic lemmas sit
  beside #6925's generic convolution lemmas, and the topology-free single-point rule in the file
  mirroring Mathlib's.
* **api-design** — `twoSidedX`/`twoSidedXInv` stay deleted (the Laurent variable is
  `twoSidedMonomial 1 1`), and nothing is `@[expose]`d. Monomials come with their coefficient laws
  and the degree-zero characterisation, so constants and monomials are manipulated without
  coefficientwise extensionality. The earlier objection to exporting a
  duplicate of ring associativity no longer applies: the exported lemmas are about coefficient
  families, and the ring's `mul_assoc` is derived from them.
* **generality** — associativity is stated for any monoid index under summability hypotheses only,
  with the cofinite-zero case derived from it; the single-point rule for any bilinear map over any
  monoid; and the unit lemma for every monomial with a unit coefficient.
* **naming** — the cofinite-zero associativity is `ZeroAtFilter.addRingConvolution_assoc`, beside
  `ZeroAtFilter.addRingConvolution`.
* **proof-quality** — `twoSidedMonomial_zero_one` is proved from the coercion lemmas rather than by
  unfolding both definitions.
* **reuse** — the convolution, its summability and closure are #6925's, and commutativity is
  Mathlib's; the previous version's own copies (`addConvolution_mem_…`, the `LinearMap.mul ℤ A`
  summability lemma, `zeroAtFilter_cofinite_tsum_fiberwise`, the `ℤ`-reindexing file) are gone.

## Overlap with #7007

#7007, opened on 2026-09-16 under the target id `two-sided-restricted-series-ring`, proposes the
same ring structure on `A⟨X, X⁻¹⟩`, inside `Convolution.lean`. This PR has been open for that
target since 2026-09-03, held back only by the `scope` finding above, and is now rebased onto
#6925. The two cannot both land, and the ids differ, so the duplicate sweeper will not link them;
the choice between them is left to the merge pipeline.

## Verification

* `lake build` of the five touched modules: exit 0.
* `lake exe runLinter` on each of the five modules: passes. The environment linters of
  `scripts/lint-env.sh` (including `simpNF`), run on the changed modules with a positive control:
  no violations.
* `#print axioms` on all new declarations: `propext`, `Classical.choice`, `Quot.sound` only.
* `/cleanup` with one worker per declaration, then a branch-wide `/simplify` and `/buzz`: no tactic
  in any touched file takes over 200 ms to elaborate.

Mathematical source: Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Example 6.39. No code is adapted
from another repository, so there is no `Provenance:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


