### PR TITLE
feat: add the E7 minuscule standard comodule

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean
@@ -170,6 +170,7 @@ theorem rid_lTensor_comp_standardCoact (f : coordinateHopfAlgebra R n →ₗ[R] 
   simp [Matrix.mulVec, dotProduct, Pi.single_apply, Finset.sum_ite_eq']
 
 /-- A base-valued point acts on the standard comodule by multiplication with its matrix. -/
+@[simp]
 theorem basePointsRepresentation_eq_mulVec
     (g : WithConv (coordinateHopfAlgebra R n →ₐ[R] R)) (w : Fin n → R) :
     Comodule.basePointsRepresentation (H := coordinateHopfAlgebra R n) (Fin n → R) g w =

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean
@@ -169,25 +169,31 @@ theorem rid_lTensor_comp_standardCoact (f : coordinateHopfAlgebra R n →ₗ[R] 
   ext i
   simp [Matrix.mulVec, dotProduct, Pi.single_apply, Finset.sum_ite_eq']
 
+/-- A base-valued point acts on the standard comodule by multiplication with its matrix. -/
+theorem basePointsRepresentation_eq_mulVec
+    (g : WithConv (coordinateHopfAlgebra R n →ₐ[R] R)) (w : Fin n → R) :
+    Comodule.basePointsRepresentation (H := coordinateHopfAlgebra R n) (Fin n → R) g w =
+      (pointToGeneralLinear n g : Matrix (Fin n) (Fin n) R) *ᵥ w := by
+  rw [Comodule.basePointsRepresentation_apply, Comodule.endOfPoint_tmul, one_smul,
+    TensorProduct.lid_comm]
+  rw [standardComodule_coact R n]
+  have h := DFunLike.congr_fun
+    (rid_lTensor_comp_standardCoact R n g.ofConv.toLinearMap) w
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe] at h
+  rw [h, Matrix.mulVecLin_apply]
+  congr 1
+  ext i j
+  simp [pointToGeneralLinear_apply]
+
 /-- **A subcomodule of the standard comodule of `GLₙ` is stable under every invertible
 matrix.** -/
 theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
     (g : Matrix.GeneralLinearGroup (Fin n) R) {w : Fin n → R} (hw : w ∈ N) :
     (g : Matrix (Fin n) (Fin n) R) *ᵥ w ∈ N := by
-  have h := N.rid_lTensor_coact_mem
-    (generalLinearToPoint (R := R) n g).ofConv.toLinearMap hw
-  rw [standardComodule_coact R n] at h
-  have hf := DFunLike.congr_fun
-    (rid_lTensor_comp_standardCoact R n (generalLinearToPoint (R := R) n g).ofConv.toLinearMap) w
-  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe] at hf
-  have hmat : (Matrix.of fun i j ↦ (generalLinearToPoint (R := R) n g).ofConv.toLinearMap
-        (coordinateHopfAlgebraAlgEquiv R n
-          (coordinateRingMap R n (MvPolynomial.X (i, j))))) =
-      (g : Matrix (Fin n) (Fin n) R) := by
-    ext i j
-    simp
-  rw [hf, hmat, Matrix.mulVecLin_apply] at h
-  exact h
+  have h := Comodule.basePointsRepresentation_mem N
+    (generalLinearToPoint (R := R) n g) hw
+  simpa only [basePointsRepresentation_eq_mulVec, pointToGeneralLinear_generalLinearToPoint]
+    using h
 
 section PointAction
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -10,6 +10,7 @@ public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
 public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Corestrict
 public import TauCeti.Algebra.Coalgebra.Comodule.PointAction
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Basic
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 
 /-!
@@ -100,6 +101,14 @@ theorem basePointsRepresentation_apply (g : WithConv (H →ₐ[R] R)) (m : M) :
     (pointsRepresentation (R := R) (H := H) (A := R) M g) m = _
   rw [LinearEquiv.conj_apply_apply, pointsRepresentation_apply]
   simp
+
+/-- Every subcomodule is stable under the action of base-valued points. -/
+theorem basePointsRepresentation_mem (N : Subcomodule R H M)
+    (g : WithConv (H →ₐ[R] R)) {m : M} (hm : m ∈ N) :
+    basePointsRepresentation (H := H) M g m ∈ N := by
+  rw [basePointsRepresentation_apply, endOfPoint_tmul, one_smul,
+    TensorProduct.lid_comm]
+  exact N.rid_lTensor_coact_mem g.ofConv.toLinearMap hm
 
 /-- The scalar-extension action of a base-valued point is the pure tensor of its action on the
 original comodule. -/

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
@@ -87,13 +87,6 @@ theorem standardComodule_coact :
   rw [Comodule.corestrictCoact_apply, LinearMap.comp_apply,
     GeneralLinear.standardComodule_coact]
 
-/-- The coaction bundled by `standardComodule` is its defining corestriction. This explicit bridge
-keeps proofs from depending directly on reducibility of the comodule wrapper. -/
-private theorem standardComodule_coact_eq_corestrictCoact :
-    (standardComodule R n).coact =
-      Comodule.corestrictCoact (coordinateMap R n).hom.toCoalgHom :=
-  rfl
-
 /-- **The standard comodule of `SL_n` is faithful.** -/
 theorem isFaithful_standardComodule :
     Comodule.IsFaithful (k := R) (H := coordinateHopfAlgebra R n) (V := Fin n → R) := by
@@ -137,52 +130,24 @@ theorem piScalarRight_comp_endOfPoint
 
 end PointAction
 
-private theorem piScalarRight_comm_eq_rid
-    (t : (Fin n → R) ⊗[R] R) :
-    TensorProduct.piScalarRightHom R R R (Fin n) (TensorProduct.comm R (Fin n → R) R t) =
-      TensorProduct.rid R (Fin n → R) t := by
-  induction t using TensorProduct.induction_on with
-  | zero => simp
-  | tmul v r =>
-      ext i
-      simp [TensorProduct.piScalarRightHom_tmul, mul_comm]
-  | add x y hx hy => simpa only [map_add] using congrArg₂ (fun a b ↦ a + b) hx hy
-
 /-- **A subcomodule of the standard comodule of `SL_n` is stable under every determinant-one
 matrix.** -/
 theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
     (g : Matrix.SpecialLinearGroup (Fin n) R) {w : Fin n → R} (hw : w ∈ N) :
     (g : Matrix (Fin n) (Fin n) R) *ᵥ w ∈ N := by
   let q := (pointsMulEquiv (R := R) (A := R) n).symm g
-  have h :
-      TensorProduct.rid R (Fin n → R)
-          (LinearMap.lTensor (Fin n → R) q.ofConv.toLinearMap
-            ((standardComodule R n).coact w)) ∈ N :=
-    N.rid_lTensor_coact_mem q.ofConv.toLinearMap hw
-  rw [standardComodule_coact_eq_corestrictCoact R n] at h
-  rw [CommHopfAlgCat.hom_mkQuotient] at h
-  rw [standardComodule_coact R n, LinearMap.comp_apply] at h
-  have hcoordinate :
-      (Bialgebra.Quotient.mkBialgHom
-          (R := R) (definingHopfIdeal R n).toIdeal).toCoalgHom.toLinearMap =
-        (Bialgebra.Quotient.mkBialgHom
-          (R := R) (definingHopfIdeal R n).toIdeal).toAlgHom.toLinearMap :=
-    (_root_.BialgHom.toAlgHom_toLinearMap
-      (Bialgebra.Quotient.mkBialgHom (R := R) (definingHopfIdeal R n).toIdeal)).symm
-  rw [hcoordinate] at h
-  have h' :
-      TensorProduct.piScalarRight R R R (Fin n)
-          (Comodule.endOfPoint (Fin n → R) q.ofConv (1 ⊗ₜ[R] w)) ∈ N := by
-    simpa [Comodule.endOfPoint_tmul, TensorProduct.piScalarRight_apply,
-      piScalarRight_comm_eq_rid, LinearMap.lTensor_def, TensorProduct.map_map] using h
-  have haction := DFunLike.congr_fun (piScalarRight_comp_endOfPoint R n q) (1 ⊗ₜ[R] w)
-  simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, Matrix.GeneralLinearGroup.toLin_apply,
-    Matrix.mulVecLin_apply] at haction
-  rw [haction] at h'
-  rw [MulEquiv.apply_symm_apply] at h'
-  simpa only [Matrix.SpecialLinearGroup.coe_GL_coe_matrix,
-    TensorProduct.piScalarRight_apply, TensorProduct.piScalarRightHom_tmul, smul_eq_mul,
-    mul_one] using h'
+  have h := Comodule.basePointsRepresentation_mem N q hw
+  rw [Comodule.basePointsRepresentation_corestrict (coordinateMap R n).hom q,
+    GeneralLinear.basePointsRepresentation_eq_mulVec] at h
+  have hpoint :
+      AlgHom.mapDomain (coordinateMap R n).hom q =
+        CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n)
+          (CommAlgCat.of R R) q := by
+    rw [AlgHom.mapDomain_apply, CommHopfAlgCat.quotientPointsHom_apply]
+  rw [hpoint, ← GeneralLinear.pointsMulEquiv_apply, pointsMulEquiv_toGL,
+    MulEquiv.apply_symm_apply] at h
+  exact h
 
 section Simple
 

--- a/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
@@ -31,6 +31,8 @@ reductive, that its torus is maximal, or that its root datum has been identified
 
 * `TauCeti.E7Minuscule.baseChangeDefiningIdeal`: the transported defining ideal in
   `O(GL₅₆/A)`.
+* `TauCeti.E7Minuscule.coordinateHopfAlgebra` and `TauCeti.E7Minuscule.coordinateMap`: the
+  specialized carrier coordinate algebra and its ambient quotient map.
 * `TauCeti.E7Minuscule.baseChangeCoordinateIso`: its quotient is the scalar extension of the
   integral carrier coordinate Hopf algebra.
 * `TauCeti.E7Minuscule.rootSubgroupToBaseChangeCoordinateMap`: the transported numbered root
@@ -87,6 +89,18 @@ noncomputable def baseChangeDefiningIdeal :
     (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
     rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
     e7MinusculeWeight A
+
+/-- The coordinate Hopf algebra of the full-weight type-`E₇` minuscule carrier after base
+change to `A`. -/
+noncomputable abbrev coordinateHopfAlgebra :=
+  CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra A 56)
+    (baseChangeDefiningIdeal A)
+
+/-- The quotient coordinate morphism `O(GL₅₆) ⟶ O(carrier)`, representing the closed immersion
+of the specialized minuscule carrier into `GL₅₆`. -/
+noncomputable abbrev coordinateMap :
+    GeneralLinear.coordinateHopfAlgebra A 56 ⟶ coordinateHopfAlgebra A :=
+  CommHopfAlgCat.mkQuotient _ _
 
 /-- Membership in the transported defining ideal is membership of the corresponding element in
 the base change of the named integral defining ideal. -/

--- a/TauCeti/Algebra/Lie/E7/Minuscule/Carrier.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/Carrier.lean
@@ -42,6 +42,9 @@ roadmap before milestone L0 of the CFSGStatement roadmap can use this carrier.
   copy of the additive group.
 * `TauCeti.E7Minuscule.isClosedImmersion_weightTorus`: the minuscule weights make the split torus
   a closed subgroup of the carrier.
+* `TauCeti.E7Minuscule.coe_rootSubgroupPoints_inl` and
+  `TauCeti.E7Minuscule.coe_rootSubgroupPoints_inr`: the positive and negative simple-root
+  matrices in the minuscule basis.
 * `TauCeti.E7Minuscule.weightTorus_conj_rootSubgroup`: the scheme-level pinning equation.
 
 ## References
@@ -337,6 +340,81 @@ theorem coe_rootSubgroupPoints (k : Fin 7 ⊕ Fin 7) (A : Type v) [CommRing A]
         lattice.toAddSubgroup rep_kostantForm_mem_lattice k
         (isNilpotent_rep_serreRootGenerator k) latticeBasis
         ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm u) := (rfl)
+
+private theorem nilpotencyClass_rep_rootGenerator_le_two (i : Fin 7 ⊕ Fin 7) :
+    nilpotencyClass
+      (rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+        (TauCeti.serreRootGenerator (CartanMatrix.E 7) i))) ≤ 2 := by
+  rw [nilpotencyClass]
+  exact Nat.sInf_le (pow_two_rep_serreRootGenerator_eq_zero i)
+
+private theorem rep_positiveRootGenerator_latticeBasis_eq_sum (i : Fin 7) (s : Fin 56) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+        (TauCeti.serreRootGenerator (CartanMatrix.E 7) (.inl i)))
+        ((latticeBasis s : lattice) : Fin 56 → ℚ) =
+      ∑ r, raisingMatrix i r s •
+          ((latticeBasis r : lattice) : Fin 56 → ℚ) := by
+  rw [rep_ι_apply]
+  rw [TauCeti.serreRootGenerator_inl, rationalSerreRepresentation_serreE]
+  rw [coe_latticeBasis, Matrix.mulVec_single_one]
+  ext a
+  simp only [Matrix.col_apply, Finset.sum_apply, Pi.smul_apply, coe_latticeBasis,
+    Pi.single_apply]
+  rw [Finset.sum_eq_single a]
+  · simp [raisingMatrixRat_apply, raisingMatrix_apply]
+  · intro b _ hba
+    simp [Ne.symm hba]
+  · simp
+
+private theorem rep_negativeRootGenerator_latticeBasis_eq_sum (i : Fin 7) (s : Fin 56) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+        (TauCeti.serreRootGenerator (CartanMatrix.E 7) (.inr i)))
+        ((latticeBasis s : lattice) : Fin 56 → ℚ) =
+      ∑ r, loweringMatrix i r s •
+          ((latticeBasis r : lattice) : Fin 56 → ℚ) := by
+  rw [rep_ι_apply]
+  rw [TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF]
+  rw [coe_latticeBasis, Matrix.mulVec_single_one]
+  ext a
+  simp only [Matrix.col_apply, Finset.sum_apply, Pi.smul_apply, coe_latticeBasis,
+    Pi.single_apply]
+  rw [Finset.sum_eq_single a]
+  · simp [loweringMatrixRat_apply, loweringMatrix_apply]
+  · intro b _ hba
+    simp [Ne.symm hba]
+  · simp
+
+/-- A positive simple-root point has matrix `1 + uEᵢ` in the minuscule basis. -/
+theorem coe_rootSubgroupPoints_inl (i : Fin 7) (A : Type v) [CommRing A]
+    (u : Multiplicative A) :
+    ((rootSubgroupPoints (.inl i) A u : Matrix.GeneralLinearGroup (Fin 56) A) :
+        Matrix (Fin 56) (Fin 56) A) =
+      1 + Multiplicative.toAdd u • (raisingMatrix i).map (Int.cast : ℤ → A) := by
+  rw [coe_rootSubgroupPoints]
+  simpa only [MulEquiv.apply_symm_apply] using
+    (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul
+      (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+      (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+      rep_kostantForm_mem_lattice (.inl i) (isNilpotent_rep_serreRootGenerator (.inl i))
+      latticeBasis (raisingMatrix i) (nilpotencyClass_rep_rootGenerator_le_two (.inl i))
+      (rep_positiveRootGenerator_latticeBasis_eq_sum i)
+      ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm u))
+
+/-- A negative simple-root point has matrix `1 + uFᵢ` in the minuscule basis. -/
+theorem coe_rootSubgroupPoints_inr (i : Fin 7) (A : Type v) [CommRing A]
+    (u : Multiplicative A) :
+    ((rootSubgroupPoints (.inr i) A u : Matrix.GeneralLinearGroup (Fin 56) A) :
+        Matrix (Fin 56) (Fin 56) A) =
+      1 + Multiplicative.toAdd u • (loweringMatrix i).map (Int.cast : ℤ → A) := by
+  rw [coe_rootSubgroupPoints]
+  simpa only [MulEquiv.apply_symm_apply] using
+    (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul
+      (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+      (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+      rep_kostantForm_mem_lattice (.inr i) (isNilpotent_rep_serreRootGenerator (.inr i))
+      latticeBasis (loweringMatrix i) (nilpotencyClass_rep_rootGenerator_le_two (.inr i))
+      (rep_negativeRootGenerator_latticeBasis_eq_sum i)
+      ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm u))
 
 /-- The split weight torus inside the type-`E₇` minuscule carrier points. -/
 noncomputable def weightTorusPoints (A : Type v) [CommRing A] :

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -61,13 +61,14 @@ noncomputable abbrev coordinateHopfAlgebra :=
   CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 56)
     (baseChangeDefiningIdeal R)
 
-/-- The quotient coordinate morphism from `GL₅₆` to the specialized minuscule carrier. -/
+/-- The quotient coordinate morphism `O(GL₅₆) ⟶ O(carrier)`, representing the closed immersion
+of the specialized minuscule carrier into `GL₅₆`. -/
 noncomputable abbrev coordinateMap :
     GeneralLinear.coordinateHopfAlgebra R 56 ⟶ coordinateHopfAlgebra R :=
   CommHopfAlgCat.mkQuotient _ _
 
 /-- The standard right comodule of the specialized type-`E₇` minuscule carrier. -/
-@[expose, instance_reducible]
+@[instance_reducible]
 noncomputable def standardComodule :
     Comodule R (coordinateHopfAlgebra R) (Fin 56 → R) :=
   let _ := GeneralLinear.standardComodule R 56

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -39,7 +39,8 @@ simple-root elements then move a coordinate vector across the connected minuscul
 * N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate VI.
 
 The corestriction and point-action interface follows
-`TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule`; the specialized point
+`TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule` and is adapted from
+`TauCeti.Algebra.AlgebraicGroup.SpecialLinear.StandardComodule`; the specialized point
 identification uses `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.BaseChange`.
 -/
 
@@ -139,18 +140,6 @@ theorem piScalarRight_comp_endOfPoint
 
 end PointAction
 
-private theorem piScalarRight_comm_eq_rid
-    (t : (Fin 56 → R) ⊗[R] R) :
-    TensorProduct.piScalarRightHom R R R (Fin 56)
-        (TensorProduct.comm R (Fin 56 → R) R t) =
-      TensorProduct.rid R (Fin 56 → R) t := by
-  induction t using TensorProduct.induction_on with
-  | zero => simp
-  | tmul v r =>
-      ext i
-      simp [TensorProduct.piScalarRightHom_tmul, mul_comm]
-  | add x y hx hy => simpa only [map_add] using congrArg₂ (fun a b ↦ a + b) hx hy
-
 /-- **A subcomodule of the standard carrier comodule is stable under every carrier-valued
 point.** -/
 theorem mulVec_mem
@@ -160,29 +149,17 @@ theorem mulVec_mem
         (CommHopfAlgCat.quotientPointsHom
           (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
           (CommAlgCat.of R R) g) : Matrix (Fin 56) (Fin 56) R) *ᵥ w ∈ N := by
-  have h := N.rid_lTensor_coact_mem g.ofConv.toLinearMap hw
-  rw [standardComodule_coact_eq_corestrictCoact R,
-    standardComodule_coact R, LinearMap.comp_apply] at h
-  have hcoordinate :
-      (Bialgebra.Quotient.mkBialgHom
-          (R := R) (baseChangeDefiningIdeal R).toIdeal).toCoalgHom.toLinearMap =
-        (Bialgebra.Quotient.mkBialgHom
-          (R := R) (baseChangeDefiningIdeal R).toIdeal).toAlgHom.toLinearMap :=
-    (_root_.BialgHom.toAlgHom_toLinearMap
-      (Bialgebra.Quotient.mkBialgHom
-        (R := R) (baseChangeDefiningIdeal R).toIdeal)).symm
-  rw [hcoordinate] at h
-  have h' :
-      TensorProduct.piScalarRight R R R (Fin 56)
-          (Comodule.endOfPoint (Fin 56 → R) g.ofConv (1 ⊗ₜ[R] w)) ∈ N := by
-    simpa [Comodule.endOfPoint_tmul, TensorProduct.piScalarRight_apply,
-      piScalarRight_comm_eq_rid, LinearMap.lTensor_def, TensorProduct.map_map] using h
-  have haction := DFunLike.congr_fun (piScalarRight_comp_endOfPoint R g) (1 ⊗ₜ[R] w)
-  simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, Matrix.GeneralLinearGroup.toLin_apply,
-    Matrix.mulVecLin_apply] at haction
-  rw [haction] at h'
-  simpa only [TensorProduct.piScalarRight_apply, TensorProduct.piScalarRightHom_tmul,
-    smul_eq_mul, mul_one] using h'
+  have h := Comodule.basePointsRepresentation_mem N g hw
+  rw [Comodule.basePointsRepresentation_corestrict (coordinateMap R).hom g,
+    GeneralLinear.basePointsRepresentation_eq_mulVec] at h
+  have hpoint :
+      AlgHom.mapDomain (coordinateMap R).hom g =
+        CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
+          (CommAlgCat.of R R) g := by
+    rw [AlgHom.mapDomain_apply, CommHopfAlgCat.quotientPointsHom_apply]
+  rw [hpoint] at h
+  exact h
 
 /-! ## Root matrices -/
 
@@ -265,6 +242,8 @@ section Simple
 
 variable (k : Type u) [Field k]
 
+/-- Base-valued points of the specialized coordinate algebra, identified with points of the
+integral minuscule carrier after base change. -/
 private noncomputable def specializedPointsMulEquiv :
     HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k) (CommAlgCat.of k k) ≃*
       points k :=
@@ -306,6 +285,7 @@ private theorem rootSubgroupPoints_mulVec_mem
     MulEquiv.apply_symm_apply] at h
   exact h
 
+/-- The character of the weight torus corresponding to a minuscule-basis index. -/
 private noncomputable abbrev minusculeCharacter (a : Fin 56) :
     Multiplicative (Fin 7 →₀ ℤ) :=
   Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm (DynkinType.e7MinusculeWeight a))

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -94,15 +94,6 @@ theorem standardComodule_coact :
   rw [Comodule.corestrictCoact_apply, LinearMap.comp_apply,
     GeneralLinear.standardComodule_coact]
 
-/-- The coaction bundled by `standardComodule` is its defining corestriction. -/
-@[simp]
-theorem standardComodule_coact_eq_corestrictCoact :
-    (standardComodule R).coact =
-      Comodule.corestrictCoact
-        (Bialgebra.Quotient.mkBialgHom
-          (R := R) (baseChangeDefiningIdeal R).toIdeal).toCoalgHom :=
-  rfl
-
 /-- **The standard comodule of the specialized type-`E₇` minuscule carrier is faithful.** -/
 theorem isFaithful_standardComodule :
     Comodule.IsFaithful (k := R) (H := coordinateHopfAlgebra R) (V := Fin 56 → R) := by
@@ -303,10 +294,10 @@ private theorem torusCorestrict_eq_ofWeights :
   intro a
   rw [Comodule.ofWeights_coact_basis]
   rw [Pi.basisFun_apply]
-  change Comodule.corestrictCoact
-      (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom (Pi.single a 1) = _
-  rw [Comodule.corestrictCoact_apply, standardComodule_coact_eq_corestrictCoact,
-    standardComodule_coact, LinearMap.comp_apply,
+  rw [Comodule.corestrict_coact_apply
+    (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom]
+  rw [Comodule.corestrict_coact_apply (coordinateMap k).hom.toCoalgHom]
+  rw [GeneralLinear.standardComodule_coact,
     GeneralLinear.standardCoact_apply_basisFun, map_sum]
   simp only [TensorProduct.map_tmul, LinearMap.id_coe, id_eq]
   have hX (i : Fin 56) :
@@ -315,9 +306,7 @@ private theorem torusCorestrict_eq_ofWeights :
             (GeneralLinear.coordinateHopfAlgebraAlgEquiv k 56
               (GeneralLinear.coordinateRingMap k 56 (MvPolynomial.X (i, a))))) =
         if i = a then MonoidAlgebra.single (minusculeCharacter a) (1 : k) else 0 := by
-    change ((coordinateMap k ≫ weightTorusToBaseChangeCoordinateMap k).hom)
-        (GeneralLinear.coordinateHopfAlgebraAlgEquiv k 56
-          (GeneralLinear.coordinateRingMap k 56 (MvPolynomial.X (i, a)))) = _
+    rw [← _root_.BialgHom.comp_apply, ← _root_.CommHopfAlgCat.hom_comp]
     rw [mkQuotient_comp_weightTorusToBaseChangeCoordinateMap]
     rw [GeneralLinear.hom_weightTorusBaseChangeCoordinateMap,
       GeneralLinear.weightTorusCoordinateBialgHom_X]
@@ -331,13 +320,10 @@ private theorem torusCorestrict_eq_ofWeights :
     (_root_.BialgHom.toAlgHom_toLinearMap
       (weightTorusToBaseChangeCoordinateMap k).hom).symm
   have hcoordinateLinear :
-      (Bialgebra.Quotient.mkBialgHom
-          (R := k) (baseChangeDefiningIdeal k).toIdeal).toCoalgHom.toLinearMap =
-        (Bialgebra.Quotient.mkBialgHom
-          (R := k) (baseChangeDefiningIdeal k).toIdeal).toAlgHom.toLinearMap :=
+      (coordinateMap k).hom.toCoalgHom.toLinearMap =
+        (coordinateMap k).hom.toAlgHom.toLinearMap :=
     (_root_.BialgHom.toAlgHom_toLinearMap
-      (Bialgebra.Quotient.mkBialgHom
-        (R := k) (baseChangeDefiningIdeal k).toIdeal)).symm
+      (coordinateMap k).hom).symm
   rw [hweightLinear, hcoordinateLinear]
   simp only [map_sum, TensorProduct.map_tmul, LinearMap.id_coe, id_eq,
     AlgHom.toLinearMap_apply]
@@ -501,11 +487,11 @@ private theorem single_one_mem_of_ne_bot
         simp [hb0]
       · simp [hcb]
     rwa [heq] at hscaled
-  obtain ⟨l, hl⟩ := DynkinType.exists_e7MinusculeReflection_foldl_eq b
+  obtain ⟨l, hl⟩ := DynkinType.exists_foldl_e7MinusculeReflection_eq b
   have hzero : Pi.single (0 : Fin 56) 1 ∈ N := by
     apply single_mem_of_foldl_mem k N l 0
     rwa [hl]
-  obtain ⟨m, hm⟩ := DynkinType.exists_e7MinusculeReflection_foldl_eq a
+  obtain ⟨m, hm⟩ := DynkinType.exists_foldl_e7MinusculeReflection_eq a
   have := single_foldl_mem k N m 0 hzero
   rwa [hm] at this
 

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -67,12 +67,20 @@ noncomputable abbrev coordinateMap :
     GeneralLinear.coordinateHopfAlgebra R 56 ⟶ coordinateHopfAlgebra R :=
   CommHopfAlgCat.mkQuotient _ _
 
+/-- The standard coaction of the specialized type-`E₇` minuscule carrier, obtained by
+corestricting the standard `GL₅₆` coaction along the quotient coordinate morphism. -/
+noncomputable def standardCoact :
+    (Fin 56 → R) →ₗ[R] (Fin 56 → R) ⊗[R] coordinateHopfAlgebra R :=
+  let _ := GeneralLinear.standardComodule R 56
+  Comodule.corestrictCoact (coordinateMap R).hom.toCoalgHom
+
 /-- The standard right comodule of the specialized type-`E₇` minuscule carrier. -/
 @[instance_reducible]
 noncomputable def standardComodule :
     Comodule R (coordinateHopfAlgebra R) (Fin 56 → R) :=
   let _ := GeneralLinear.standardComodule R 56
-  Comodule.Corestrict (coordinateMap R).hom.toCoalgHom
+  { Comodule.Corestrict (coordinateMap R).hom.toCoalgHom with
+    coact := standardCoact R }
 
 attribute [local instance] GeneralLinear.standardComodule standardComodule
 
@@ -80,20 +88,43 @@ attribute [local instance] GeneralLinear.standardComodule standardComodule
 quotient coordinate morphism. -/
 @[simp]
 theorem standardComodule_coact :
-    let _ := GeneralLinear.standardComodule R 56
-    Comodule.corestrictCoact
-        (R := R) (C := GeneralLinear.coordinateHopfAlgebra R 56)
-        (D := coordinateHopfAlgebra R) (M := Fin 56 → R)
-        (Bialgebra.Quotient.mkBialgHom
-          (R := R) (baseChangeDefiningIdeal R).toIdeal).toCoalgHom =
+    (standardComodule R).coact =
       TensorProduct.map LinearMap.id
-          (Bialgebra.Quotient.mkBialgHom
-            (R := R) (baseChangeDefiningIdeal R).toIdeal).toLinearMap ∘ₗ
+          (coordinateMap R).hom.toCoalgHom.toLinearMap ∘ₗ
         GeneralLinear.standardCoact R 56 := by
+  calc
+    (standardComodule R).coact = standardCoact R := rfl
+    _ = _ := by
+      apply LinearMap.ext
+      intro v
+      rw [standardCoact, Comodule.corestrictCoact_apply, LinearMap.comp_apply,
+        GeneralLinear.standardComodule_coact]
+
+private theorem endOfPoint_eq_corestrict {A : Type*} [CommRing A] [Algebra R A]
+    (g : coordinateHopfAlgebra R →ₐ[R] A) :
+    Comodule.endOfPoint (Fin 56 → R) g =
+      (let _ := GeneralLinear.standardComodule R 56
+       let _ : Comodule R (coordinateHopfAlgebra R) (Fin 56 → R) :=
+         Comodule.Corestrict (coordinateMap R).hom.toCoalgHom
+       Comodule.endOfPoint (Fin 56 → R) g) := by
+  apply TensorProduct.AlgebraTensorModule.ext
+  intro a v
+  rw [Comodule.endOfPoint_tmul, Comodule.endOfPoint_tmul, standardComodule_coact,
+    Comodule.corestrict_coact_apply, GeneralLinear.standardComodule_coact,
+    LinearMap.comp_apply]
+
+private theorem basePointsRepresentation_eq_corestrict
+    (g : WithConv (coordinateHopfAlgebra R →ₐ[R] R)) :
+    Comodule.basePointsRepresentation (Fin 56 → R) g =
+      (let _ := GeneralLinear.standardComodule R 56
+       let _ : Comodule R (coordinateHopfAlgebra R) (Fin 56 → R) :=
+         Comodule.Corestrict (coordinateMap R).hom.toCoalgHom
+       Comodule.basePointsRepresentation (Fin 56 → R) g) := by
   apply LinearMap.ext
   intro v
-  rw [Comodule.corestrictCoact_apply, LinearMap.comp_apply,
-    GeneralLinear.standardComodule_coact]
+  rw [Comodule.basePointsRepresentation_apply, Comodule.basePointsRepresentation_apply]
+  exact congrArg (TensorProduct.lid R (Fin 56 → R))
+    (LinearMap.congr_fun (endOfPoint_eq_corestrict R g.ofConv) (1 ⊗ₜ[R] v))
 
 /-- **The standard comodule of the specialized type-`E₇` minuscule carrier is faithful.** -/
 theorem isFaithful_standardComodule :
@@ -119,7 +150,7 @@ theorem piScalarRight_comp_endOfPoint
               (CommAlgCat.of R A) g)) :
           (Fin 56 → A) →ₗ[A] Fin 56 → A).comp
         (TensorProduct.piScalarRight R A A (Fin 56)).toLinearMap := by
-  rw [Comodule.endOfPoint_corestrict]
+  rw [endOfPoint_eq_corestrict, Comodule.endOfPoint_corestrict]
   have hpoint :
       g.ofConv.comp ((coordinateMap R).hom :
         GeneralLinear.coordinateHopfAlgebra R 56 →ₐ[R] coordinateHopfAlgebra R) =
@@ -142,7 +173,8 @@ theorem mulVec_mem
           (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
           (CommAlgCat.of R R) g) : Matrix (Fin 56) (Fin 56) R) *ᵥ w ∈ N := by
   have h := Comodule.basePointsRepresentation_mem N g hw
-  rw [Comodule.basePointsRepresentation_corestrict (coordinateMap R).hom g,
+  rw [basePointsRepresentation_eq_corestrict,
+    Comodule.basePointsRepresentation_corestrict (coordinateMap R).hom g,
     GeneralLinear.basePointsRepresentation_eq_mulVec] at h
   have hpoint :
       AlgHom.mapDomain (coordinateMap R).hom g =
@@ -297,8 +329,7 @@ private theorem torusCorestrict_eq_ofWeights :
   rw [Pi.basisFun_apply]
   rw [Comodule.corestrict_coact_apply
     (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom]
-  rw [Comodule.corestrict_coact_apply (coordinateMap k).hom.toCoalgHom]
-  rw [GeneralLinear.standardComodule_coact,
+  rw [standardComodule_coact, LinearMap.comp_apply,
     GeneralLinear.standardCoact_apply_basisFun, map_sum]
   simp only [TensorProduct.map_tmul, LinearMap.id_coe, id_eq]
   have hX (i : Fin 56) :

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -144,54 +144,54 @@ theorem mulVec_mem
   rw [hpoint] at h
   exact h
 
-/-! ## Simplicity over a field -/
-
-section Simple
-
-variable (k : Type u) [Field k]
-
 /-- Base-valued points of the specialized coordinate algebra, identified with points of the
 integral minuscule carrier after base change. -/
 noncomputable def specializedPointsMulEquiv :
-    HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k) (CommAlgCat.of k k) ≃*
-      points k :=
-  (CommHopfAlgCat.baseChangeIsoPointsMulEquiv (baseChangeCoordinateIso k)
-      (CommAlgCat.of k k)).trans
+    HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R) (CommAlgCat.of R R) ≃*
+      points R :=
+  (CommHopfAlgCat.baseChangeIsoPointsMulEquiv (baseChangeCoordinateIso R)
+      (CommAlgCat.of R R)).trans
     (pointsMulEquiv
-      (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ k) (CommAlgCat.of k k)))
+      (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ R) (CommAlgCat.of R R)))
 
 /-- Under the specialized point equivalence, the quotient point is represented by the carrier
 point's ambient general-linear matrix. -/
-theorem quotientPointsHom_specializedPointsMulEquiv_symm (g : points k) :
+theorem quotientPointsHom_specializedPointsMulEquiv_symm (g : points R) :
     CommHopfAlgCat.quotientPointsHom
-        (GeneralLinear.coordinateHopfAlgebra k 56) (baseChangeDefiningIdeal k)
-        (CommAlgCat.of k k) ((specializedPointsMulEquiv k).symm g) =
-      (GeneralLinear.pointsMulEquiv (R := k) 56).symm
-        (g : Matrix.GeneralLinearGroup (Fin 56) k) := by
+        (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
+        (CommAlgCat.of R R) ((specializedPointsMulEquiv R).symm g) =
+      (GeneralLinear.pointsMulEquiv (R := R) 56).symm
+        (g : Matrix.GeneralLinearGroup (Fin 56) R) := by
   have h :
-      ((specializedPointsMulEquiv k)
-          ((specializedPointsMulEquiv k).symm g) : Matrix.GeneralLinearGroup (Fin 56) k) =
+      ((specializedPointsMulEquiv R)
+          ((specializedPointsMulEquiv R).symm g) : Matrix.GeneralLinearGroup (Fin 56) R) =
         GeneralLinear.pointsMulEquiv 56
           (CommHopfAlgCat.quotientPointsHom
-            (GeneralLinear.coordinateHopfAlgebra k 56) (baseChangeDefiningIdeal k)
-            (CommAlgCat.of k k) ((specializedPointsMulEquiv k).symm g)) := by
+            (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
+            (CommAlgCat.of R R) ((specializedPointsMulEquiv R).symm g)) := by
     rw [specializedPointsMulEquiv, MulEquiv.trans_apply, coe_pointsMulEquiv_apply]
     exact GeneralLinear.pointsMulEquiv_quotientPointsHom_baseChangeIsoPointsMulEquiv
-      56 definingIdeal (baseChangeDefiningIdeal k) (baseChangeCoordinateIso k)
-      (mkQuotient_comp_baseChangeCoordinateIso_hom k) (CommAlgCat.of k k) _
+      56 definingIdeal (baseChangeDefiningIdeal R) (baseChangeCoordinateIso R)
+      (mkQuotient_comp_baseChangeCoordinateIso_hom R) (CommAlgCat.of R R) _
   rw [MulEquiv.apply_symm_apply] at h
   rw [h, MulEquiv.symm_apply_apply]
 
 /-- A subcomodule of the standard carrier comodule is stable under every concrete carrier
 point. -/
 theorem points_mulVec_mem
-    (N : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k))
-    (g : points k) {w : Fin 56 → k} (hw : w ∈ N) :
-    ((g : Matrix.GeneralLinearGroup (Fin 56) k) : Matrix (Fin 56) (Fin 56) k) *ᵥ w ∈ N := by
-  have h := mulVec_mem k N ((specializedPointsMulEquiv k).symm g) hw
+    (N : Subcomodule R (coordinateHopfAlgebra R) (Fin 56 → R))
+    (g : points R) {w : Fin 56 → R} (hw : w ∈ N) :
+    ((g : Matrix.GeneralLinearGroup (Fin 56) R) : Matrix (Fin 56) (Fin 56) R) *ᵥ w ∈ N := by
+  have h := mulVec_mem R N ((specializedPointsMulEquiv R).symm g) hw
   rw [quotientPointsHom_specializedPointsMulEquiv_symm,
     ← GeneralLinear.pointsMulEquiv_apply, MulEquiv.apply_symm_apply] at h
   exact h
+
+/-! ## Simplicity over a field -/
+
+section Simple
+
+variable (k : Type u) [Field k]
 
 private theorem rootSubgroupPoints_mulVec_mem
     (N : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k))

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -29,7 +29,10 @@ simple-root elements then move a coordinate vector across the connected minuscul
 * `TauCeti.E7Minuscule.coordinateHopfAlgebra`: the specialized carrier coordinate Hopf algebra.
 * `TauCeti.E7Minuscule.standardComodule`: its standard comodule on `R⁵⁶`.
 * `TauCeti.E7Minuscule.isFaithful_standardComodule`: faithfulness of the standard comodule.
-* `TauCeti.E7Minuscule.mulVec_mem`: invariant submodules are stable under carrier-valued points.
+* `TauCeti.E7Minuscule.specializedPointsMulEquiv`: specialized coordinate-algebra points are
+  identified with concrete carrier points.
+* `TauCeti.E7Minuscule.points_mulVec_mem`: invariant submodules are stable under concrete carrier
+  points.
 * `TauCeti.E7Minuscule.instIsSimpleOrderSubcomodule`: simplicity over a field.
 
 ## References
@@ -55,18 +58,6 @@ universe u
 
 variable (R : Type u) [CommRing R]
 
-/-- The coordinate Hopf algebra of the full-weight type-`E₇` minuscule carrier after base
-change to `R`. -/
-noncomputable abbrev coordinateHopfAlgebra :=
-  CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 56)
-    (baseChangeDefiningIdeal R)
-
-/-- The quotient coordinate morphism `O(GL₅₆) ⟶ O(carrier)`, representing the closed immersion
-of the specialized minuscule carrier into `GL₅₆`. -/
-noncomputable abbrev coordinateMap :
-    GeneralLinear.coordinateHopfAlgebra R 56 ⟶ coordinateHopfAlgebra R :=
-  CommHopfAlgCat.mkQuotient _ _
-
 /-- The standard right comodule of the specialized type-`E₇` minuscule carrier. -/
 @[instance_reducible]
 noncomputable def standardComodule :
@@ -78,6 +69,7 @@ attribute [local instance] GeneralLinear.standardComodule standardComodule
 
 /-- The standard carrier coaction is the standard general-linear coaction followed by the
 quotient coordinate morphism. -/
+@[simp]
 theorem standardComodule_coact :
     (standardComodule R).coact =
       TensorProduct.map LinearMap.id
@@ -146,81 +138,6 @@ theorem mulVec_mem
   rw [hpoint] at h
   exact h
 
-/-! ## Root matrices -/
-
-private theorem nilpotencyClass_rep_rootGenerator_le_two (i : Fin 7 ⊕ Fin 7) :
-    nilpotencyClass
-      (rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
-        (TauCeti.serreRootGenerator (CartanMatrix.E 7) i))) ≤ 2 := by
-  rw [nilpotencyClass]
-  exact Nat.sInf_le (pow_two_rep_serreRootGenerator_eq_zero i)
-
-private theorem rep_positiveRootGenerator_latticeBasis_eq_sum (i : Fin 7) (s : Fin 56) :
-    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
-        (TauCeti.serreRootGenerator (CartanMatrix.E 7) (.inl i)))
-        ((latticeBasis s : lattice) : Fin 56 → ℚ) =
-      ∑ r, raisingMatrix i r s •
-          ((latticeBasis r : lattice) : Fin 56 → ℚ) := by
-  rw [rep_ι_apply]
-  rw [TauCeti.serreRootGenerator_inl, rationalSerreRepresentation_serreE]
-  rw [coe_latticeBasis, Matrix.mulVec_single_one]
-  ext a
-  simp only [Matrix.col_apply, Finset.sum_apply, Pi.smul_apply, coe_latticeBasis,
-    Pi.single_apply]
-  rw [Finset.sum_eq_single a]
-  · simp [raisingMatrixRat_apply, raisingMatrix_apply]
-  · intro b _ hba
-    simp [Ne.symm hba]
-  · simp
-
-private theorem rep_negativeRootGenerator_latticeBasis_eq_sum (i : Fin 7) (s : Fin 56) :
-    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
-        (TauCeti.serreRootGenerator (CartanMatrix.E 7) (.inr i)))
-        ((latticeBasis s : lattice) : Fin 56 → ℚ) =
-      ∑ r, loweringMatrix i r s •
-          ((latticeBasis r : lattice) : Fin 56 → ℚ) := by
-  rw [rep_ι_apply]
-  rw [TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF]
-  rw [coe_latticeBasis, Matrix.mulVec_single_one]
-  ext a
-  simp only [Matrix.col_apply, Finset.sum_apply, Pi.smul_apply, coe_latticeBasis,
-    Pi.single_apply]
-  rw [Finset.sum_eq_single a]
-  · simp [loweringMatrixRat_apply, loweringMatrix_apply]
-  · intro b _ hba
-    simp [Ne.symm hba]
-  · simp
-
-/-- A positive simple-root point has matrix `1 + uEᵢ` in the minuscule basis. -/
-theorem coe_rootSubgroupPoints_inl (i : Fin 7) (u : Multiplicative R) :
-    ((rootSubgroupPoints (.inl i) R u : Matrix.GeneralLinearGroup (Fin 56) R) :
-        Matrix (Fin 56) (Fin 56) R) =
-      1 + Multiplicative.toAdd u • (raisingMatrix i).map (Int.cast : ℤ → R) := by
-  rw [coe_rootSubgroupPoints]
-  simpa using
-    (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul
-      (TauCeti.serreRootGenerator (CartanMatrix.E 7))
-      (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
-      rep_kostantForm_mem_lattice (.inl i) (isNilpotent_rep_serreRootGenerator (.inl i))
-      latticeBasis (raisingMatrix i) (nilpotencyClass_rep_rootGenerator_le_two (.inl i))
-      (rep_positiveRootGenerator_latticeBasis_eq_sum i)
-      ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := R)).symm u))
-
-/-- A negative simple-root point has matrix `1 + uFᵢ` in the minuscule basis. -/
-theorem coe_rootSubgroupPoints_inr (i : Fin 7) (u : Multiplicative R) :
-    ((rootSubgroupPoints (.inr i) R u : Matrix.GeneralLinearGroup (Fin 56) R) :
-        Matrix (Fin 56) (Fin 56) R) =
-      1 + Multiplicative.toAdd u • (loweringMatrix i).map (Int.cast : ℤ → R) := by
-  rw [coe_rootSubgroupPoints]
-  simpa using
-    (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul
-      (TauCeti.serreRootGenerator (CartanMatrix.E 7))
-      (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
-      rep_kostantForm_mem_lattice (.inr i) (isNilpotent_rep_serreRootGenerator (.inr i))
-      latticeBasis (loweringMatrix i) (nilpotencyClass_rep_rootGenerator_le_two (.inr i))
-      (rep_negativeRootGenerator_latticeBasis_eq_sum i)
-      ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := R)).symm u))
-
 /-! ## Simplicity over a field -/
 
 section Simple
@@ -229,7 +146,7 @@ variable (k : Type u) [Field k]
 
 /-- Base-valued points of the specialized coordinate algebra, identified with points of the
 integral minuscule carrier after base change. -/
-private noncomputable def specializedPointsMulEquiv :
+noncomputable def specializedPointsMulEquiv :
     HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k) (CommAlgCat.of k k) ≃*
       points k :=
   (CommHopfAlgCat.baseChangeIsoPointsMulEquiv (baseChangeCoordinateIso k)
@@ -237,7 +154,9 @@ private noncomputable def specializedPointsMulEquiv :
     (pointsMulEquiv
       (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ k) (CommAlgCat.of k k)))
 
-private theorem quotientPointsHom_specializedPointsMulEquiv_symm (g : points k) :
+/-- Under the specialized point equivalence, the quotient point is represented by the carrier
+point's ambient general-linear matrix. -/
+theorem quotientPointsHom_specializedPointsMulEquiv_symm (g : points k) :
     CommHopfAlgCat.quotientPointsHom
         (GeneralLinear.coordinateHopfAlgebra k 56) (baseChangeDefiningIdeal k)
         (CommAlgCat.of k k) ((specializedPointsMulEquiv k).symm g) =
@@ -257,18 +176,23 @@ private theorem quotientPointsHom_specializedPointsMulEquiv_symm (g : points k) 
   rw [MulEquiv.apply_symm_apply] at h
   rw [h, MulEquiv.symm_apply_apply]
 
+/-- A subcomodule of the standard carrier comodule is stable under every concrete carrier
+point. -/
+theorem points_mulVec_mem
+    (N : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k))
+    (g : points k) {w : Fin 56 → k} (hw : w ∈ N) :
+    ((g : Matrix.GeneralLinearGroup (Fin 56) k) : Matrix (Fin 56) (Fin 56) k) *ᵥ w ∈ N := by
+  have h := mulVec_mem k N ((specializedPointsMulEquiv k).symm g) hw
+  rw [quotientPointsHom_specializedPointsMulEquiv_symm,
+    ← GeneralLinear.pointsMulEquiv_apply, MulEquiv.apply_symm_apply] at h
+  exact h
+
 private theorem rootSubgroupPoints_mulVec_mem
     (N : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k))
     (i : Fin 7 ⊕ Fin 7) {w : Fin 56 → k} (hw : w ∈ N) :
     ((rootSubgroupPoints i k (Multiplicative.ofAdd 1) :
         Matrix.GeneralLinearGroup (Fin 56) k) : Matrix (Fin 56) (Fin 56) k) *ᵥ w ∈ N := by
-  let g := (specializedPointsMulEquiv k).symm
-    (rootSubgroupPoints i k (Multiplicative.ofAdd 1))
-  have h := mulVec_mem k N g hw
-  rw [quotientPointsHom_specializedPointsMulEquiv_symm] at h
-  rw [← GeneralLinear.pointsMulEquiv_apply,
-    MulEquiv.apply_symm_apply] at h
-  exact h
+  exact points_mulVec_mem k N (rootSubgroupPoints i k (Multiplicative.ofAdd 1)) hw
 
 /-- The character of the weight torus corresponding to a minuscule-basis index. -/
 private noncomputable abbrev minusculeCharacter (a : Fin 56) :
@@ -482,11 +406,11 @@ private theorem single_one_mem_of_ne_bot
         simp [hb0]
       · simp [hcb]
     rwa [heq] at hscaled
-  obtain ⟨l, hl⟩ := DynkinType.exists_foldl_e7MinusculeReflection_eq b
+  obtain ⟨l, hl⟩ := DynkinType.exists_e7MinusculeReflections_eq b
   have hzero : Pi.single (0 : Fin 56) 1 ∈ N := by
     apply single_mem_of_foldl_mem k N l 0
     rwa [hl]
-  obtain ⟨m, hm⟩ := DynkinType.exists_foldl_e7MinusculeReflection_eq a
+  obtain ⟨m, hm⟩ := DynkinType.exists_e7MinusculeReflections_eq a
   have := single_foldl_mem k N m 0 hzero
   rwa [hm] at this
 

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -1,0 +1,558 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule
+public import TauCeti.Algebra.Lie.E7.Minuscule.BaseChange
+import TauCeti.Algebra.Coalgebra.Comodule.GroupLike
+import TauCeti.Algebra.Coalgebra.Subcomodule.Corestrict
+import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.BaseChange
+import TauCeti.Algebra.Lie.E7.Minuscule.PointsFunctor
+
+/-!
+# The standard representation of the type-E7 minuscule carrier
+
+The full-weight type-`E₇` minuscule carrier is a closed subgroup of `GL₅₆`.  After base
+change to a commutative ring `R`, its standard representation is therefore the corestriction of
+the standard `O(GL₅₆)`-comodule along the quotient coordinate morphism.
+
+This file proves that the resulting representation is faithful over every commutative ring and
+simple over every field.  For simplicity, restriction to the rank-seven weight torus separates a
+nonzero invariant vector into its one-dimensional weight components.  The positive and negative
+simple-root elements then move a coordinate vector across the connected minuscule weight graph.
+
+## Main declarations
+
+* `TauCeti.E7Minuscule.coordinateHopfAlgebra`: the specialized carrier coordinate Hopf algebra.
+* `TauCeti.E7Minuscule.standardComodule`: its standard comodule on `R⁵⁶`.
+* `TauCeti.E7Minuscule.isFaithful_standardComodule`: faithfulness of the standard comodule.
+* `TauCeti.E7Minuscule.mulVec_mem`: invariant submodules are stable under carrier-valued points.
+* `TauCeti.E7Minuscule.instIsSimpleOrderSubcomodule`: simplicity over a field.
+
+## References
+
+* J. E. Humphreys, *Linear Algebraic Groups*, §26.
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2 and II.2.
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate VI.
+
+The corestriction and point-action interface follows
+`TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule`; the specialized point
+identification uses `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.BaseChange`.
+-/
+
+public section
+
+open CategoryTheory Module WithConv
+open scoped Matrix TensorProduct
+
+namespace TauCeti.E7Minuscule
+
+universe u
+
+variable (R : Type u) [CommRing R]
+
+/-- The coordinate Hopf algebra of the full-weight type-`E₇` minuscule carrier after base
+change to `R`. -/
+noncomputable abbrev coordinateHopfAlgebra :=
+  CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R 56)
+    (baseChangeDefiningIdeal R)
+
+/-- The quotient coordinate morphism from `GL₅₆` to the specialized minuscule carrier. -/
+noncomputable abbrev coordinateMap :
+    GeneralLinear.coordinateHopfAlgebra R 56 ⟶ coordinateHopfAlgebra R :=
+  CommHopfAlgCat.mkQuotient _ _
+
+/-- The standard right comodule of the specialized type-`E₇` minuscule carrier. -/
+@[expose, instance_reducible]
+noncomputable def standardComodule :
+    Comodule R (coordinateHopfAlgebra R) (Fin 56 → R) :=
+  let _ := GeneralLinear.standardComodule R 56
+  Comodule.Corestrict (coordinateMap R).hom.toCoalgHom
+
+attribute [local instance] GeneralLinear.standardComodule standardComodule
+
+/-- The standard carrier coaction is the standard general-linear coaction followed by the
+quotient coordinate morphism. -/
+@[simp]
+theorem standardComodule_coact :
+    let _ := GeneralLinear.standardComodule R 56
+    Comodule.corestrictCoact
+        (R := R) (C := GeneralLinear.coordinateHopfAlgebra R 56)
+        (D := coordinateHopfAlgebra R) (M := Fin 56 → R)
+        (Bialgebra.Quotient.mkBialgHom
+          (R := R) (baseChangeDefiningIdeal R).toIdeal).toCoalgHom =
+      TensorProduct.map LinearMap.id
+          (Bialgebra.Quotient.mkBialgHom
+            (R := R) (baseChangeDefiningIdeal R).toIdeal).toLinearMap ∘ₗ
+        GeneralLinear.standardCoact R 56 := by
+  apply LinearMap.ext
+  intro v
+  rw [Comodule.corestrictCoact_apply, LinearMap.comp_apply,
+    GeneralLinear.standardComodule_coact]
+
+/-- The coaction bundled by `standardComodule` is its defining corestriction. -/
+@[simp]
+theorem standardComodule_coact_eq_corestrictCoact :
+    (standardComodule R).coact =
+      Comodule.corestrictCoact
+        (Bialgebra.Quotient.mkBialgHom
+          (R := R) (baseChangeDefiningIdeal R).toIdeal).toCoalgHom :=
+  rfl
+
+/-- **The standard comodule of the specialized type-`E₇` minuscule carrier is faithful.** -/
+theorem isFaithful_standardComodule :
+    Comodule.IsFaithful (k := R) (H := coordinateHopfAlgebra R) (V := Fin 56 → R) := by
+  exact Comodule.isFaithful_corestrict_of_surjective (coordinateMap R).hom
+    (CommHopfAlgCat.mkQuotient_surjective _ _)
+    (GeneralLinear.isFaithful_standardComodule R 56)
+
+section PointAction
+
+variable {A : Type*} [CommRing A] [Algebra R A]
+
+/-- Under scalar extension, a carrier-valued point acts on the standard comodule by the matrix
+obtained from its ambient `GL₅₆` point. -/
+theorem piScalarRight_comp_endOfPoint
+    (g : WithConv (coordinateHopfAlgebra R →ₐ[R] A)) :
+    (TensorProduct.piScalarRight R A A (Fin 56)).toLinearMap.comp
+        (Comodule.endOfPoint (Fin 56 → R) g.ofConv) =
+      (Matrix.GeneralLinearGroup.toLin
+          (GeneralLinear.pointToGeneralLinear 56
+            (CommHopfAlgCat.quotientPointsHom
+              (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
+              (CommAlgCat.of R A) g)) :
+          (Fin 56 → A) →ₗ[A] Fin 56 → A).comp
+        (TensorProduct.piScalarRight R A A (Fin 56)).toLinearMap := by
+  rw [Comodule.endOfPoint_corestrict]
+  have hpoint :
+      g.ofConv.comp ((coordinateMap R).hom :
+        GeneralLinear.coordinateHopfAlgebra R 56 →ₐ[R] coordinateHopfAlgebra R) =
+        (CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
+          (CommAlgCat.of R A) g).ofConv := by
+    rw [CommHopfAlgCat.quotientPointsHom_apply]
+  rw [hpoint]
+  exact GeneralLinear.piScalarRight_comp_endOfPoint R 56 _
+
+end PointAction
+
+private theorem piScalarRight_comm_eq_rid
+    (t : (Fin 56 → R) ⊗[R] R) :
+    TensorProduct.piScalarRightHom R R R (Fin 56)
+        (TensorProduct.comm R (Fin 56 → R) R t) =
+      TensorProduct.rid R (Fin 56 → R) t := by
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | tmul v r =>
+      ext i
+      simp [TensorProduct.piScalarRightHom_tmul, mul_comm]
+  | add x y hx hy => simpa only [map_add] using congrArg₂ (fun a b ↦ a + b) hx hy
+
+/-- **A subcomodule of the standard carrier comodule is stable under every carrier-valued
+point.** -/
+theorem mulVec_mem
+    (N : Subcomodule R (coordinateHopfAlgebra R) (Fin 56 → R))
+    (g : WithConv (coordinateHopfAlgebra R →ₐ[R] R)) {w : Fin 56 → R} (hw : w ∈ N) :
+    (GeneralLinear.pointToGeneralLinear 56
+        (CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
+          (CommAlgCat.of R R) g) : Matrix (Fin 56) (Fin 56) R) *ᵥ w ∈ N := by
+  have h := N.rid_lTensor_coact_mem g.ofConv.toLinearMap hw
+  rw [standardComodule_coact_eq_corestrictCoact R,
+    standardComodule_coact R, LinearMap.comp_apply] at h
+  have hcoordinate :
+      (Bialgebra.Quotient.mkBialgHom
+          (R := R) (baseChangeDefiningIdeal R).toIdeal).toCoalgHom.toLinearMap =
+        (Bialgebra.Quotient.mkBialgHom
+          (R := R) (baseChangeDefiningIdeal R).toIdeal).toAlgHom.toLinearMap :=
+    (_root_.BialgHom.toAlgHom_toLinearMap
+      (Bialgebra.Quotient.mkBialgHom
+        (R := R) (baseChangeDefiningIdeal R).toIdeal)).symm
+  rw [hcoordinate] at h
+  have h' :
+      TensorProduct.piScalarRight R R R (Fin 56)
+          (Comodule.endOfPoint (Fin 56 → R) g.ofConv (1 ⊗ₜ[R] w)) ∈ N := by
+    simpa [Comodule.endOfPoint_tmul, TensorProduct.piScalarRight_apply,
+      piScalarRight_comm_eq_rid, LinearMap.lTensor_def, TensorProduct.map_map] using h
+  have haction := DFunLike.congr_fun (piScalarRight_comp_endOfPoint R g) (1 ⊗ₜ[R] w)
+  simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, Matrix.GeneralLinearGroup.toLin_apply,
+    Matrix.mulVecLin_apply] at haction
+  rw [haction] at h'
+  simpa only [TensorProduct.piScalarRight_apply, TensorProduct.piScalarRightHom_tmul,
+    smul_eq_mul, mul_one] using h'
+
+/-! ## Root matrices -/
+
+private theorem nilpotencyClass_rep_rootGenerator_le_two (i : Fin 7 ⊕ Fin 7) :
+    nilpotencyClass
+      (rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+        (TauCeti.serreRootGenerator (CartanMatrix.E 7) i))) ≤ 2 := by
+  rw [nilpotencyClass]
+  exact Nat.sInf_le (pow_two_rep_serreRootGenerator_eq_zero i)
+
+private theorem rep_positiveRootGenerator_latticeBasis_eq_sum (i : Fin 7) (s : Fin 56) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+        (TauCeti.serreRootGenerator (CartanMatrix.E 7) (.inl i)))
+        ((latticeBasis s : lattice) : Fin 56 → ℚ) =
+      ∑ r, raisingMatrix i r s •
+          ((latticeBasis r : lattice) : Fin 56 → ℚ) := by
+  rw [rep_ι_apply]
+  rw [TauCeti.serreRootGenerator_inl, rationalSerreRepresentation_serreE]
+  rw [coe_latticeBasis, Matrix.mulVec_single_one]
+  ext a
+  simp only [Matrix.col_apply, Finset.sum_apply, Pi.smul_apply, coe_latticeBasis,
+    Pi.single_apply]
+  rw [Finset.sum_eq_single a]
+  · simp [raisingMatrixRat_apply, raisingMatrix_apply]
+  · intro b _ hba
+    simp [Ne.symm hba]
+  · simp
+
+private theorem rep_negativeRootGenerator_latticeBasis_eq_sum (i : Fin 7) (s : Fin 56) :
+    rep (_root_.UniversalEnvelopingAlgebra.ι ℚ
+        (TauCeti.serreRootGenerator (CartanMatrix.E 7) (.inr i)))
+        ((latticeBasis s : lattice) : Fin 56 → ℚ) =
+      ∑ r, loweringMatrix i r s •
+          ((latticeBasis r : lattice) : Fin 56 → ℚ) := by
+  rw [rep_ι_apply]
+  rw [TauCeti.serreRootGenerator_inr, rationalSerreRepresentation_serreF]
+  rw [coe_latticeBasis, Matrix.mulVec_single_one]
+  ext a
+  simp only [Matrix.col_apply, Finset.sum_apply, Pi.smul_apply, coe_latticeBasis,
+    Pi.single_apply]
+  rw [Finset.sum_eq_single a]
+  · simp [loweringMatrixRat_apply, loweringMatrix_apply]
+  · intro b _ hba
+    simp [Ne.symm hba]
+  · simp
+
+/-- A positive simple-root point has matrix `1 + uEᵢ` in the minuscule basis. -/
+theorem coe_rootSubgroupPoints_inl (i : Fin 7) (u : Multiplicative R) :
+    ((rootSubgroupPoints (.inl i) R u : Matrix.GeneralLinearGroup (Fin 56) R) :
+        Matrix (Fin 56) (Fin 56) R) =
+      1 + Multiplicative.toAdd u • (raisingMatrix i).map (Int.cast : ℤ → R) := by
+  rw [coe_rootSubgroupPoints]
+  simpa using
+    (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul
+      (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+      (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+      rep_kostantForm_mem_lattice (.inl i) (isNilpotent_rep_serreRootGenerator (.inl i))
+      latticeBasis (raisingMatrix i) (nilpotencyClass_rep_rootGenerator_le_two (.inl i))
+      (rep_positiveRootGenerator_latticeBasis_eq_sum i)
+      ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := R)).symm u))
+
+/-- A negative simple-root point has matrix `1 + uFᵢ` in the minuscule basis. -/
+theorem coe_rootSubgroupPoints_inr (i : Fin 7) (u : Multiplicative R) :
+    ((rootSubgroupPoints (.inr i) R u : Matrix.GeneralLinearGroup (Fin 56) R) :
+        Matrix (Fin 56) (Fin 56) R) =
+      1 + Multiplicative.toAdd u • (loweringMatrix i).map (Int.cast : ℤ → R) := by
+  rw [coe_rootSubgroupPoints]
+  simpa using
+    (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul
+      (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+      (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+      rep_kostantForm_mem_lattice (.inr i) (isNilpotent_rep_serreRootGenerator (.inr i))
+      latticeBasis (loweringMatrix i) (nilpotencyClass_rep_rootGenerator_le_two (.inr i))
+      (rep_negativeRootGenerator_latticeBasis_eq_sum i)
+      ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := R)).symm u))
+
+/-! ## Simplicity over a field -/
+
+section Simple
+
+variable (k : Type u) [Field k]
+
+private noncomputable def specializedPointsMulEquiv :
+    HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k) (CommAlgCat.of k k) ≃*
+      points k :=
+  (CommHopfAlgCat.baseChangeIsoPointsMulEquiv (baseChangeCoordinateIso k)
+      (CommAlgCat.of k k)).trans
+    (pointsMulEquiv
+      (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ k) (CommAlgCat.of k k)))
+
+private theorem quotientPointsHom_specializedPointsMulEquiv_symm (g : points k) :
+    CommHopfAlgCat.quotientPointsHom
+        (GeneralLinear.coordinateHopfAlgebra k 56) (baseChangeDefiningIdeal k)
+        (CommAlgCat.of k k) ((specializedPointsMulEquiv k).symm g) =
+      (GeneralLinear.pointsMulEquiv (R := k) 56).symm
+        (g : Matrix.GeneralLinearGroup (Fin 56) k) := by
+  have h :
+      ((specializedPointsMulEquiv k)
+          ((specializedPointsMulEquiv k).symm g) : Matrix.GeneralLinearGroup (Fin 56) k) =
+        GeneralLinear.pointsMulEquiv 56
+          (CommHopfAlgCat.quotientPointsHom
+            (GeneralLinear.coordinateHopfAlgebra k 56) (baseChangeDefiningIdeal k)
+            (CommAlgCat.of k k) ((specializedPointsMulEquiv k).symm g)) := by
+    rw [specializedPointsMulEquiv, MulEquiv.trans_apply, coe_pointsMulEquiv_apply]
+    exact GeneralLinear.pointsMulEquiv_quotientPointsHom_baseChangeIsoPointsMulEquiv
+      56 definingIdeal (baseChangeDefiningIdeal k) (baseChangeCoordinateIso k)
+      (mkQuotient_comp_baseChangeCoordinateIso_hom k) (CommAlgCat.of k k) _
+  rw [MulEquiv.apply_symm_apply] at h
+  rw [h, MulEquiv.symm_apply_apply]
+
+private theorem rootSubgroupPoints_mulVec_mem
+    (N : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k))
+    (i : Fin 7 ⊕ Fin 7) {w : Fin 56 → k} (hw : w ∈ N) :
+    ((rootSubgroupPoints i k (Multiplicative.ofAdd 1) :
+        Matrix.GeneralLinearGroup (Fin 56) k) : Matrix (Fin 56) (Fin 56) k) *ᵥ w ∈ N := by
+  let g := (specializedPointsMulEquiv k).symm
+    (rootSubgroupPoints i k (Multiplicative.ofAdd 1))
+  have h := mulVec_mem k N g hw
+  rw [quotientPointsHom_specializedPointsMulEquiv_symm] at h
+  rw [← GeneralLinear.pointsMulEquiv_apply,
+    MulEquiv.apply_symm_apply] at h
+  exact h
+
+private noncomputable abbrev minusculeCharacter (a : Fin 56) :
+    Multiplicative (Fin 7 →₀ ℤ) :=
+  Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm (DynkinType.e7MinusculeWeight a))
+
+private theorem torusCorestrict_eq_ofWeights :
+    let _ := standardComodule k
+    Comodule.Corestrict (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom =
+      Comodule.ofWeights (Pi.basisFun k (Fin 56)) minusculeCharacter := by
+  let _ := standardComodule k
+  apply Comodule.ext
+    (rho := Comodule.Corestrict
+      (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom)
+    (sigma := Comodule.ofWeights (Pi.basisFun k (Fin 56)) minusculeCharacter)
+  apply (Pi.basisFun k (Fin 56)).ext
+  intro a
+  rw [Comodule.ofWeights_coact_basis]
+  rw [Pi.basisFun_apply]
+  change Comodule.corestrictCoact
+      (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom (Pi.single a 1) = _
+  rw [Comodule.corestrictCoact_apply, standardComodule_coact_eq_corestrictCoact,
+    standardComodule_coact, LinearMap.comp_apply,
+    GeneralLinear.standardCoact_apply_basisFun, map_sum]
+  simp only [TensorProduct.map_tmul, LinearMap.id_coe, id_eq]
+  have hX (i : Fin 56) :
+      (weightTorusToBaseChangeCoordinateMap k).hom
+          ((coordinateMap k).hom
+            (GeneralLinear.coordinateHopfAlgebraAlgEquiv k 56
+              (GeneralLinear.coordinateRingMap k 56 (MvPolynomial.X (i, a))))) =
+        if i = a then MonoidAlgebra.single (minusculeCharacter a) (1 : k) else 0 := by
+    change ((coordinateMap k ≫ weightTorusToBaseChangeCoordinateMap k).hom)
+        (GeneralLinear.coordinateHopfAlgebraAlgEquiv k 56
+          (GeneralLinear.coordinateRingMap k 56 (MvPolynomial.X (i, a)))) = _
+    rw [mkQuotient_comp_weightTorusToBaseChangeCoordinateMap]
+    rw [GeneralLinear.hom_weightTorusBaseChangeCoordinateMap,
+      GeneralLinear.weightTorusCoordinateBialgHom_X]
+    split_ifs with h
+    · subst i
+      rfl
+    · rfl
+  have hweightLinear :
+      (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom.toLinearMap =
+        (weightTorusToBaseChangeCoordinateMap k).hom.toAlgHom.toLinearMap :=
+    (_root_.BialgHom.toAlgHom_toLinearMap
+      (weightTorusToBaseChangeCoordinateMap k).hom).symm
+  have hcoordinateLinear :
+      (Bialgebra.Quotient.mkBialgHom
+          (R := k) (baseChangeDefiningIdeal k).toIdeal).toCoalgHom.toLinearMap =
+        (Bialgebra.Quotient.mkBialgHom
+          (R := k) (baseChangeDefiningIdeal k).toIdeal).toAlgHom.toLinearMap :=
+    (_root_.BialgHom.toAlgHom_toLinearMap
+      (Bialgebra.Quotient.mkBialgHom
+        (R := k) (baseChangeDefiningIdeal k).toIdeal)).symm
+  rw [hweightLinear, hcoordinateLinear]
+  simp only [map_sum, TensorProduct.map_tmul, LinearMap.id_coe, id_eq,
+    AlgHom.toLinearMap_apply]
+  calc
+    _ = ∑ i, (Pi.single i (1 : k) : Fin 56 → k) ⊗ₜ[k]
+        (if i = a then MonoidAlgebra.single (minusculeCharacter a) (1 : k) else 0) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      exact congrArg (fun z ↦ (Pi.single i (1 : k) : Fin 56 → k) ⊗ₜ[k] z) (hX i)
+    _ = _ := by
+      rw [Finset.sum_eq_single a]
+      · simp
+      · intro i _ hia
+        simp [hia]
+      · simp
+
+private theorem minusculeCharacter_injective : Function.Injective minusculeCharacter := by
+  intro a b h
+  apply DynkinType.e7MinusculeWeight_injective
+  apply Finsupp.equivFunOnFinite.symm.injective
+  exact Multiplicative.ofAdd.injective h
+
+private theorem weightProj_ofWeights_eq_single (a : Fin 56) (v : Fin 56 → k) :
+    let _ : Comodule k (MonoidAlgebra k (Multiplicative (Fin 7 →₀ ℤ))) (Fin 56 → k) :=
+      Comodule.ofWeights (Pi.basisFun k (Fin 56)) minusculeCharacter
+    Comodule.weightProj k (Multiplicative (Fin 7 →₀ ℤ)) (Fin 56 → k)
+        (minusculeCharacter a) v = Pi.single a (v a) := by
+  let _ : Comodule k (MonoidAlgebra k (Multiplicative (Fin 7 →₀ ℤ))) (Fin 56 → k) :=
+    Comodule.ofWeights (Pi.basisFun k (Fin 56)) minusculeCharacter
+  dsimp only
+  have hv : v = ∑ b, v b • (Pi.single b (1 : k) : Fin 56 → k) := by
+    ext b
+    simp [Pi.single_apply]
+  rw [hv]
+  simp only [map_sum]
+  rw [Finset.sum_eq_single a]
+  · rw [map_smul, Comodule.weightProj_of_mem]
+    · ext b
+      simp [Pi.single_apply]
+    · simpa only [Pi.basisFun_apply] using
+        (Comodule.basis_mem_weightSpace_ofWeights
+          (Pi.basisFun k (Fin 56)) minusculeCharacter a)
+  · intro b _ hba
+    rw [map_smul, Comodule.weightProj_of_mem_of_ne]
+    · simp
+    · exact fun hab ↦ hba (minusculeCharacter_injective hab).symm
+    · simpa only [Pi.basisFun_apply] using
+        (Comodule.basis_mem_weightSpace_ofWeights
+          (Pi.basisFun k (Fin 56)) minusculeCharacter b)
+  · simp
+
+/-- Restriction to the weight torus shows that every coordinate component of an invariant
+vector remains in the invariant submodule. -/
+private theorem single_self_mem
+    (N : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k))
+    {v : Fin 56 → k} (hv : v ∈ N) (a : Fin 56) : Pi.single a (v a) ∈ N := by
+  let _ := standardComodule k
+  let f := (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom
+  let _ : Comodule k (MonoidAlgebra k (Multiplicative (Fin 7 →₀ ℤ))) (Fin 56 → k) :=
+    Comodule.Corestrict f
+  have hvtorus : v ∈ N.corestrict f :=
+    (Subcomodule.mem_corestrict f N v).2 hv
+  have hp := Comodule.weightProj_mem_subcomodule (N.corestrict f)
+    (minusculeCharacter a) hvtorus
+  have hcomodule := torusCorestrict_eq_ofWeights k
+  have hpN :
+      Comodule.weightProj k (Multiplicative (Fin 7 →₀ ℤ)) (Fin 56 → k)
+          (minusculeCharacter a) v ∈ N :=
+    (Subcomodule.mem_corestrict f N _).1 hp
+  have hproj :
+      (let _ : Comodule k (MonoidAlgebra k (Multiplicative (Fin 7 →₀ ℤ)))
+          (Fin 56 → k) := Comodule.Corestrict f;
+        Comodule.weightProj k (Multiplicative (Fin 7 →₀ ℤ)) (Fin 56 → k)
+          (minusculeCharacter a) v) =
+      (let _ : Comodule k (MonoidAlgebra k (Multiplicative (Fin 7 →₀ ℤ)))
+          (Fin 56 → k) :=
+          Comodule.ofWeights (Pi.basisFun k (Fin 56)) minusculeCharacter;
+        Comodule.weightProj k (Multiplicative (Fin 7 →₀ ℤ)) (Fin 56 → k)
+          (minusculeCharacter a) v) :=
+    congrArg (fun c : Comodule k (MonoidAlgebra k (Multiplicative (Fin 7 →₀ ℤ)))
+      (Fin 56 → k) ↦
+        let _ := c;
+        Comodule.weightProj k (Multiplicative (Fin 7 →₀ ℤ)) (Fin 56 → k)
+          (minusculeCharacter a) v) hcomodule
+  rw [hproj, weightProj_ofWeights_eq_single] at hpN
+  exact hpN
+
+private theorem positiveRoot_mulVec_single_sub (i : Fin 7) (a : Fin 56)
+    (ha : DynkinType.e7MinusculeWeight a i = -1) :
+    (((rootSubgroupPoints (.inl i) k (Multiplicative.ofAdd 1) :
+        Matrix.GeneralLinearGroup (Fin 56) k) : Matrix (Fin 56) (Fin 56) k) *ᵥ
+          Pi.single a 1) - Pi.single a 1 =
+      Pi.single (DynkinType.e7MinusculeReflection i a) 1 := by
+  rw [coe_rootSubgroupPoints_inl]
+  ext b
+  simp [Matrix.one_apply, Pi.single_apply, raisingMatrix_apply, ha]
+
+private theorem negativeRoot_mulVec_single_sub (i : Fin 7) (a : Fin 56)
+    (ha : DynkinType.e7MinusculeWeight a i = 1) :
+    (((rootSubgroupPoints (.inr i) k (Multiplicative.ofAdd 1) :
+        Matrix.GeneralLinearGroup (Fin 56) k) : Matrix (Fin 56) (Fin 56) k) *ᵥ
+          Pi.single a 1) - Pi.single a 1 =
+      Pi.single (DynkinType.e7MinusculeReflection i a) 1 := by
+  rw [coe_rootSubgroupPoints_inr]
+  ext b
+  simp [Matrix.one_apply, Pi.single_apply, loweringMatrix_apply, ha]
+
+/-- Invariance under the two simple-root points makes membership of coordinate basis vectors
+stable under every simple reflection. -/
+private theorem single_reflection_mem
+    (N : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k))
+    (a : Fin 56) (i : Fin 7) (ha : Pi.single a 1 ∈ N) :
+    Pi.single (DynkinType.e7MinusculeReflection i a) 1 ∈ N := by
+  rcases DynkinType.e7MinusculeWeight_apply_eq_neg_one_or_eq_zero_or_eq_one a i with
+    hneg | hzero | hpos
+  · have hact := rootSubgroupPoints_mulVec_mem k N (.inl i) ha
+    have hsub := N.toSubmodule.sub_mem hact ha
+    rwa [positiveRoot_mulVec_single_sub k i a hneg] at hsub
+  · rw [(DynkinType.e7MinusculeReflection_eq_self_iff i a).2 hzero]
+    exact ha
+  · have hact := rootSubgroupPoints_mulVec_mem k N (.inr i) ha
+    have hsub := N.toSubmodule.sub_mem hact ha
+    rwa [negativeRoot_mulVec_single_sub k i a hpos] at hsub
+
+private theorem single_foldl_mem
+    (N : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k))
+    (l : List (Fin 7)) (a : Fin 56) (ha : Pi.single a 1 ∈ N) :
+    Pi.single (l.foldl (fun b i ↦ DynkinType.e7MinusculeReflection i b) a) 1 ∈ N := by
+  induction l generalizing a with
+  | nil => exact ha
+  | cons i l ih =>
+      exact ih _ (single_reflection_mem k N a i ha)
+
+private theorem single_mem_of_foldl_mem
+    (N : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k))
+    (l : List (Fin 7)) (a : Fin 56)
+    (ha : Pi.single (l.foldl
+      (fun b i ↦ DynkinType.e7MinusculeReflection i b) a) 1 ∈ N) :
+    Pi.single a 1 ∈ N := by
+  induction l generalizing a with
+  | nil => exact ha
+  | cons i l ih =>
+      have hreflected := ih (DynkinType.e7MinusculeReflection i a) ha
+      have hback := single_reflection_mem k N
+        (DynkinType.e7MinusculeReflection i a) i hreflected
+      simpa using hback
+
+private theorem single_one_mem_of_ne_bot
+    (N : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k)) (hN : N ≠ ⊥)
+    (a : Fin 56) : Pi.single a 1 ∈ N := by
+  obtain ⟨v, hv, hv0⟩ := N.ne_bot_iff.mp hN
+  obtain ⟨b, hb⟩ := Function.ne_iff.mp hv0
+  have hb0 : v b ≠ 0 := by simpa using hb
+  have hbmem := single_self_mem k N hv b
+  have hseed : Pi.single b 1 ∈ N := by
+    have hscaled := N.toSubmodule.smul_mem (v b)⁻¹ hbmem
+    have heq : (v b)⁻¹ • Pi.single b (v b) = (Pi.single b 1 : Fin 56 → k) := by
+      ext c
+      by_cases hcb : c = b
+      · subst c
+        simp [hb0]
+      · simp [hcb]
+    rwa [heq] at hscaled
+  obtain ⟨l, hl⟩ := DynkinType.exists_e7MinusculeReflection_foldl_eq b
+  have hzero : Pi.single (0 : Fin 56) 1 ∈ N := by
+    apply single_mem_of_foldl_mem k N l 0
+    rwa [hl]
+  obtain ⟨m, hm⟩ := DynkinType.exists_e7MinusculeReflection_foldl_eq a
+  have := single_foldl_mem k N m 0 hzero
+  rwa [hm] at this
+
+/-- **The standard comodule of the specialized type-`E₇` minuscule carrier is simple over
+every field.** -/
+instance instIsSimpleOrderSubcomodule :
+    IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k)) := by
+  refine { exists_pair_ne := ⟨⊥, ⊤, ?_⟩, eq_bot_or_eq_top := ?_ }
+  · intro h
+    have hone : (Pi.single (0 : Fin 56) (1 : k) : Fin 56 → k) ∈
+        (⊥ : Subcomodule k (coordinateHopfAlgebra k) (Fin 56 → k)) :=
+      h ▸ Subcomodule.mem_top _
+    rw [Subcomodule.mem_bot] at hone
+    simpa using congrFun hone (0 : Fin 56)
+  · intro N
+    by_cases hN : N = ⊥
+    · exact Or.inl hN
+    · right
+      apply top_unique
+      intro v _
+      have hv : v = ∑ a, v a • Pi.single a 1 := by
+        ext a
+        simp [Pi.single_apply]
+      rw [hv]
+      exact N.toSubmodule.sum_mem fun a _ ↦
+        N.toSubmodule.smul_mem (v a) (single_one_mem_of_ne_bot k N hN a)
+
+end Simple
+
+end TauCeti.E7Minuscule

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -67,64 +67,26 @@ noncomputable abbrev coordinateMap :
     GeneralLinear.coordinateHopfAlgebra R 56 ⟶ coordinateHopfAlgebra R :=
   CommHopfAlgCat.mkQuotient _ _
 
-/-- The standard coaction of the specialized type-`E₇` minuscule carrier, obtained by
-corestricting the standard `GL₅₆` coaction along the quotient coordinate morphism. -/
-noncomputable def standardCoact :
-    (Fin 56 → R) →ₗ[R] (Fin 56 → R) ⊗[R] coordinateHopfAlgebra R :=
-  let _ := GeneralLinear.standardComodule R 56
-  Comodule.corestrictCoact (coordinateMap R).hom.toCoalgHom
-
 /-- The standard right comodule of the specialized type-`E₇` minuscule carrier. -/
 @[instance_reducible]
 noncomputable def standardComodule :
     Comodule R (coordinateHopfAlgebra R) (Fin 56 → R) :=
   let _ := GeneralLinear.standardComodule R 56
-  { Comodule.Corestrict (coordinateMap R).hom.toCoalgHom with
-    coact := standardCoact R }
+  Comodule.Corestrict (coordinateMap R).hom.toCoalgHom
 
 attribute [local instance] GeneralLinear.standardComodule standardComodule
 
 /-- The standard carrier coaction is the standard general-linear coaction followed by the
 quotient coordinate morphism. -/
-@[simp]
 theorem standardComodule_coact :
     (standardComodule R).coact =
       TensorProduct.map LinearMap.id
           (coordinateMap R).hom.toCoalgHom.toLinearMap ∘ₗ
         GeneralLinear.standardCoact R 56 := by
-  calc
-    (standardComodule R).coact = standardCoact R := rfl
-    _ = _ := by
-      apply LinearMap.ext
-      intro v
-      rw [standardCoact, Comodule.corestrictCoact_apply, LinearMap.comp_apply,
-        GeneralLinear.standardComodule_coact]
-
-private theorem endOfPoint_eq_corestrict {A : Type*} [CommRing A] [Algebra R A]
-    (g : coordinateHopfAlgebra R →ₐ[R] A) :
-    Comodule.endOfPoint (Fin 56 → R) g =
-      (let _ := GeneralLinear.standardComodule R 56
-       let _ : Comodule R (coordinateHopfAlgebra R) (Fin 56 → R) :=
-         Comodule.Corestrict (coordinateMap R).hom.toCoalgHom
-       Comodule.endOfPoint (Fin 56 → R) g) := by
-  apply TensorProduct.AlgebraTensorModule.ext
-  intro a v
-  rw [Comodule.endOfPoint_tmul, Comodule.endOfPoint_tmul, standardComodule_coact,
-    Comodule.corestrict_coact_apply, GeneralLinear.standardComodule_coact,
-    LinearMap.comp_apply]
-
-private theorem basePointsRepresentation_eq_corestrict
-    (g : WithConv (coordinateHopfAlgebra R →ₐ[R] R)) :
-    Comodule.basePointsRepresentation (Fin 56 → R) g =
-      (let _ := GeneralLinear.standardComodule R 56
-       let _ : Comodule R (coordinateHopfAlgebra R) (Fin 56 → R) :=
-         Comodule.Corestrict (coordinateMap R).hom.toCoalgHom
-       Comodule.basePointsRepresentation (Fin 56 → R) g) := by
   apply LinearMap.ext
   intro v
-  rw [Comodule.basePointsRepresentation_apply, Comodule.basePointsRepresentation_apply]
-  exact congrArg (TensorProduct.lid R (Fin 56 → R))
-    (LinearMap.congr_fun (endOfPoint_eq_corestrict R g.ofConv) (1 ⊗ₜ[R] v))
+  rw [Comodule.corestrict_coact_apply, GeneralLinear.standardComodule_coact,
+    LinearMap.comp_apply]
 
 /-- **The standard comodule of the specialized type-`E₇` minuscule carrier is faithful.** -/
 theorem isFaithful_standardComodule :
@@ -150,7 +112,7 @@ theorem piScalarRight_comp_endOfPoint
               (CommAlgCat.of R A) g)) :
           (Fin 56 → A) →ₗ[A] Fin 56 → A).comp
         (TensorProduct.piScalarRight R A A (Fin 56)).toLinearMap := by
-  rw [endOfPoint_eq_corestrict, Comodule.endOfPoint_corestrict]
+  rw [Comodule.endOfPoint_corestrict]
   have hpoint :
       g.ofConv.comp ((coordinateMap R).hom :
         GeneralLinear.coordinateHopfAlgebra R 56 →ₐ[R] coordinateHopfAlgebra R) =
@@ -173,8 +135,7 @@ theorem mulVec_mem
           (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
           (CommAlgCat.of R R) g) : Matrix (Fin 56) (Fin 56) R) *ᵥ w ∈ N := by
   have h := Comodule.basePointsRepresentation_mem N g hw
-  rw [basePointsRepresentation_eq_corestrict,
-    Comodule.basePointsRepresentation_corestrict (coordinateMap R).hom g,
+  rw [Comodule.basePointsRepresentation_corestrict (coordinateMap R).hom g,
     GeneralLinear.basePointsRepresentation_eq_mulVec] at h
   have hpoint :
       AlgHom.mapDomain (coordinateMap R).hom g =
@@ -314,6 +275,21 @@ private noncomputable abbrev minusculeCharacter (a : Fin 56) :
     Multiplicative (Fin 7 →₀ ℤ) :=
   Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm (DynkinType.e7MinusculeWeight a))
 
+private theorem weightTorusToBaseChangeCoordinateMap_coordinate (i a : Fin 56) :
+    (weightTorusToBaseChangeCoordinateMap k).hom
+        ((coordinateMap k).hom
+          (GeneralLinear.coordinateHopfAlgebraAlgEquiv k 56
+            (GeneralLinear.coordinateRingMap k 56 (MvPolynomial.X (i, a))))) =
+      if i = a then MonoidAlgebra.single (minusculeCharacter a) (1 : k) else 0 := by
+  rw [← _root_.BialgHom.comp_apply, ← _root_.CommHopfAlgCat.hom_comp]
+  rw [mkQuotient_comp_weightTorusToBaseChangeCoordinateMap]
+  rw [GeneralLinear.hom_weightTorusBaseChangeCoordinateMap,
+    GeneralLinear.weightTorusCoordinateBialgHom_X]
+  split_ifs with h
+  · subst i
+    rfl
+  · rfl
+
 private theorem torusCorestrict_eq_ofWeights :
     let _ := standardComodule k
     Comodule.Corestrict (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom =
@@ -332,20 +308,6 @@ private theorem torusCorestrict_eq_ofWeights :
   rw [standardComodule_coact, LinearMap.comp_apply,
     GeneralLinear.standardCoact_apply_basisFun, map_sum]
   simp only [TensorProduct.map_tmul, LinearMap.id_coe, id_eq]
-  have hX (i : Fin 56) :
-      (weightTorusToBaseChangeCoordinateMap k).hom
-          ((coordinateMap k).hom
-            (GeneralLinear.coordinateHopfAlgebraAlgEquiv k 56
-              (GeneralLinear.coordinateRingMap k 56 (MvPolynomial.X (i, a))))) =
-        if i = a then MonoidAlgebra.single (minusculeCharacter a) (1 : k) else 0 := by
-    rw [← _root_.BialgHom.comp_apply, ← _root_.CommHopfAlgCat.hom_comp]
-    rw [mkQuotient_comp_weightTorusToBaseChangeCoordinateMap]
-    rw [GeneralLinear.hom_weightTorusBaseChangeCoordinateMap,
-      GeneralLinear.weightTorusCoordinateBialgHom_X]
-    split_ifs with h
-    · subst i
-      rfl
-    · rfl
   have hweightLinear :
       (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom.toLinearMap =
         (weightTorusToBaseChangeCoordinateMap k).hom.toAlgHom.toLinearMap :=
@@ -364,7 +326,8 @@ private theorem torusCorestrict_eq_ofWeights :
         (if i = a then MonoidAlgebra.single (minusculeCharacter a) (1 : k) else 0) := by
       apply Finset.sum_congr rfl
       intro i _
-      exact congrArg (fun z ↦ (Pi.single i (1 : k) : Fin 56 → k) ⊗ₜ[k] z) (hX i)
+      exact congrArg (fun z ↦ (Pi.single i (1 : k) : Fin 56 → k) ⊗ₜ[k] z)
+        (weightTorusToBaseChangeCoordinateMap_coordinate k i a)
     _ = _ := by
       rw [Finset.sum_eq_single a]
       · simp

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -71,14 +71,20 @@ attribute [local instance] GeneralLinear.standardComodule standardComodule
 quotient coordinate morphism. -/
 @[simp]
 theorem standardComodule_coact :
-    (standardComodule R).coact =
+    let _ := GeneralLinear.standardComodule R 56
+    Comodule.corestrictCoact
+        (R := R) (C := GeneralLinear.coordinateHopfAlgebra R 56)
+        (D := coordinateHopfAlgebra R) (M := Fin 56 → R)
+        (Bialgebra.Quotient.mkBialgHom (R := R)
+          (baseChangeDefiningIdeal R).toIdeal).toCoalgHom =
       TensorProduct.map LinearMap.id
-          (coordinateMap R).hom.toCoalgHom.toLinearMap ∘ₗ
+          (Bialgebra.Quotient.mkBialgHom (R := R)
+            (baseChangeDefiningIdeal R).toIdeal).toLinearMap ∘ₗ
         GeneralLinear.standardCoact R 56 := by
   apply LinearMap.ext
   intro v
-  rw [Comodule.corestrict_coact_apply, GeneralLinear.standardComodule_coact,
-    LinearMap.comp_apply]
+  rw [Comodule.corestrictCoact_apply, LinearMap.comp_apply,
+    GeneralLinear.standardComodule_coact]
 
 /-- **The standard comodule of the specialized type-`E₇` minuscule carrier is faithful.** -/
 theorem isFaithful_standardComodule :
@@ -229,6 +235,8 @@ private theorem torusCorestrict_eq_ofWeights :
   rw [Pi.basisFun_apply]
   rw [Comodule.corestrict_coact_apply
     (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom]
+  rw [Comodule.corestrict_coact]
+  simp only [coordinateMap, CategoryTheory.ConcreteCategory.hom_ofHom]
   rw [standardComodule_coact, LinearMap.comp_apply,
     GeneralLinear.standardCoact_apply_basisFun, map_sum]
   simp only [TensorProduct.map_tmul, LinearMap.id_coe, id_eq]
@@ -238,10 +246,13 @@ private theorem torusCorestrict_eq_ofWeights :
     (_root_.BialgHom.toAlgHom_toLinearMap
       (weightTorusToBaseChangeCoordinateMap k).hom).symm
   have hcoordinateLinear :
-      (coordinateMap k).hom.toCoalgHom.toLinearMap =
-        (coordinateMap k).hom.toAlgHom.toLinearMap :=
+      (Bialgebra.Quotient.mkBialgHom (R := k)
+          (baseChangeDefiningIdeal k).toIdeal).toLinearMap =
+        (Bialgebra.Quotient.mkBialgHom (R := k)
+          (baseChangeDefiningIdeal k).toIdeal).toAlgHom.toLinearMap :=
     (_root_.BialgHom.toAlgHom_toLinearMap
-      (coordinateMap k).hom).symm
+      (Bialgebra.Quotient.mkBialgHom (R := k)
+        (baseChangeDefiningIdeal k).toIdeal)).symm
   rw [hweightLinear, hcoordinateLinear]
   simp only [map_sum, TensorProduct.map_tmul, LinearMap.id_coe, id_eq,
     AlgHom.toLinearMap_apply]

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/MinusculeWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/MinusculeWeight.lean
@@ -24,10 +24,6 @@ weights span the complete character lattice. The spanning statement is the input
 weight torus in the eventual integral minuscule carrier be a closed immersion, rather than seeing
 only the index-two root lattice of the adjoint representation.
 
-No representation or group scheme is constructed here. This is the pinned full-weight lattice
-input for the type-`E₇` Chevalley--Demazure construction in Layer 9 of the ReductiveGroups
-roadmap, consumed by the explicit pinned-carrier milestone of the CFSG statement roadmap.
-
 ## Main declarations
 
 * `TauCeti.DynkinType.e7MinusculeWeight`: the fifty-six weights in fundamental coordinates.

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/MinusculeWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/MinusculeWeight.lean
@@ -29,7 +29,7 @@ only the index-two root lattice of the adjoint representation.
 * `TauCeti.DynkinType.e7MinusculeWeight`: the fifty-six weights in fundamental coordinates.
 * `TauCeti.DynkinType.e7MinusculeReflection`: the permutation induced by a simple reflection.
 * `TauCeti.DynkinType.e7MinusculeWeight_reflection`: the simple-reflection equation.
-* `TauCeti.DynkinType.exists_foldl_e7MinusculeReflection_eq`: every table index is reached from
+* `TauCeti.DynkinType.exists_e7MinusculeReflections_eq`: every table index is reached from
   the highest weight by simple reflections.
 * `TauCeti.DynkinType.range_e7MinusculeWeight`: the table is exactly the Weyl orbit of `ϖ₇`.
 * `TauCeti.DynkinType.span_range_e7MinusculeWeight_eq_top`: the weights span the character
@@ -245,7 +245,7 @@ private theorem e7MinusculeWeight_succ_eq_reflection_parent (a : Fin 55) :
 
 /-- Every index in the minuscule weight table is reached from the highest-weight index by a
 finite sequence of simple reflections. -/
-theorem exists_foldl_e7MinusculeReflection_eq (a : Fin 56) :
+theorem exists_e7MinusculeReflections_eq (a : Fin 56) :
     ∃ l : List (Fin 7), l.foldl (fun b i ↦ e7MinusculeReflection i b) 0 = a := by
   have aux : ∀ n, ∀ hn : n < 56,
       ∃ l : List (Fin 7), l.foldl (fun b i ↦ e7MinusculeReflection i b) 0 =
@@ -280,7 +280,7 @@ private theorem e7MinusculeWeight_mem_orbit (a : Fin 56) :
     e7MinusculeWeight a ∈
       MulAction.orbit e7SimplyConnectedRootDatum.weylGroup
         (Pi.single 6 1 : Fin 7 → ℤ) := by
-  obtain ⟨l, hl⟩ := exists_foldl_e7MinusculeReflection_eq a
+  obtain ⟨l, hl⟩ := exists_e7MinusculeReflections_eq a
   rw [← hl]
   clear a hl
   induction l using List.reverseRecOn with

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/MinusculeWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/MinusculeWeight.lean
@@ -247,41 +247,6 @@ private theorem e7MinusculeWeight_succ_eq_reflection_parent (a : Fin 55) :
   rw [e7SimplyConnectedRootDatum_reflection_e7MinusculeWeight]
   fin_cases a <;> decide
 
-private theorem e7MinusculeWeight_mem_orbit (a : Fin 56) :
-    e7MinusculeWeight a ∈
-      MulAction.orbit e7SimplyConnectedRootDatum.weylGroup
-        (Pi.single 6 1 : Fin 7 → ℤ) := by
-  have aux : ∀ n, ∀ hn : n < 56, e7MinusculeWeight ⟨n, hn⟩ ∈
-      MulAction.orbit e7SimplyConnectedRootDatum.weylGroup
-        (Pi.single 6 1 : Fin 7 → ℤ) := by
-    intro n hn
-    induction n using Nat.strong_induction_on with
-    | h n ih =>
-        by_cases hzero : n = 0
-        · subst n
-          -- Expose the zero index so the public highest-weight lemma applies.
-          change e7MinusculeWeight 0 ∈
-            MulAction.orbit e7SimplyConnectedRootDatum.weylGroup
-              (Pi.single 6 1 : Fin 7 → ℤ)
-          rw [e7MinusculeWeight_zero]
-          exact MulAction.mem_orbit_self _
-        · let a : Fin 55 := ⟨n - 1, by omega⟩
-          have hasucc : a.succ = (⟨n, hn⟩ : Fin 56) := by
-            apply Fin.ext
-            simp [a]
-            omega
-          have hparent : (e7MinusculeParent a : ℕ) < n := by
-            have h := e7MinusculeParent_lt_succ a
-            -- The equality of `Fin` values exposes the natural-number endpoint in `h`.
-            rw [show (a.succ : ℕ) = n from congrArg Fin.val hasucc] at h
-            exact h
-          rw [← hasucc, e7MinusculeWeight_succ_eq_reflection_parent]
-          exact MulAction.mem_orbit_of_mem_orbit
-            (RootPairing.weylGroup.ofIdx e7SimplyConnectedRootDatum
-              (e7SimpleIndex (e7MinusculeParentNode a)))
-            (ih (e7MinusculeParent a) hparent (e7MinusculeParent a).isLt)
-  exact aux a a.isLt
-
 /-- Every index in the minuscule weight table is reached from the highest-weight index by a
 finite sequence of simple reflections. -/
 theorem exists_e7MinusculeReflection_foldl_eq (a : Fin 56) :
@@ -313,6 +278,24 @@ theorem exists_e7MinusculeReflection_foldl_eq (a : Fin 56) :
           rw [← hsucc, e7MinusculeWeight_succ_eq_reflection_parent,
             e7SimplyConnectedRootDatum_reflection_e7MinusculeWeight]
   exact aux a a.isLt
+
+private theorem e7MinusculeWeight_mem_orbit (a : Fin 56) :
+    e7MinusculeWeight a ∈
+      MulAction.orbit e7SimplyConnectedRootDatum.weylGroup
+        (Pi.single 6 1 : Fin 7 → ℤ) := by
+  obtain ⟨l, hl⟩ := exists_e7MinusculeReflection_foldl_eq a
+  rw [← hl]
+  clear a hl
+  induction l using List.reverseRecOn with
+  | nil =>
+      rw [List.foldl_nil, e7MinusculeWeight_zero]
+      exact MulAction.mem_orbit_self _
+  | append_singleton l i ih =>
+      rw [List.foldl_append]
+      simp only [List.foldl_cons, List.foldl_nil]
+      rw [← e7SimplyConnectedRootDatum_reflection_e7MinusculeWeight]
+      exact MulAction.mem_orbit_of_mem_orbit
+        (RootPairing.weylGroup.ofIdx e7SimplyConnectedRootDatum (e7SimpleIndex i)) ih
 
 /-- **The explicit table is exactly the Weyl orbit of the seventh fundamental weight `ϖ₇`.** -/
 theorem range_e7MinusculeWeight :

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/MinusculeWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/MinusculeWeight.lean
@@ -33,7 +33,7 @@ roadmap, consumed by the explicit pinned-carrier milestone of the CFSG statement
 * `TauCeti.DynkinType.e7MinusculeWeight`: the fifty-six weights in fundamental coordinates.
 * `TauCeti.DynkinType.e7MinusculeReflection`: the permutation induced by a simple reflection.
 * `TauCeti.DynkinType.e7MinusculeWeight_reflection`: the simple-reflection equation.
-* `TauCeti.DynkinType.exists_e7MinusculeReflection_foldl_eq`: every table index is reached from
+* `TauCeti.DynkinType.exists_foldl_e7MinusculeReflection_eq`: every table index is reached from
   the highest weight by simple reflections.
 * `TauCeti.DynkinType.range_e7MinusculeWeight`: the table is exactly the Weyl orbit of `ϖ₇`.
 * `TauCeti.DynkinType.span_range_e7MinusculeWeight_eq_top`: the weights span the character
@@ -249,7 +249,7 @@ private theorem e7MinusculeWeight_succ_eq_reflection_parent (a : Fin 55) :
 
 /-- Every index in the minuscule weight table is reached from the highest-weight index by a
 finite sequence of simple reflections. -/
-theorem exists_e7MinusculeReflection_foldl_eq (a : Fin 56) :
+theorem exists_foldl_e7MinusculeReflection_eq (a : Fin 56) :
     ∃ l : List (Fin 7), l.foldl (fun b i ↦ e7MinusculeReflection i b) 0 = a := by
   have aux : ∀ n, ∀ hn : n < 56,
       ∃ l : List (Fin 7), l.foldl (fun b i ↦ e7MinusculeReflection i b) 0 =
@@ -268,7 +268,8 @@ theorem exists_e7MinusculeReflection_foldl_eq (a : Fin 56) :
           obtain ⟨l, hl⟩ := ih (e7MinusculeParent c)
             (by
               have hlt := e7MinusculeParent_lt_succ c
-              rw [show (c.succ : ℕ) = n from congrArg Fin.val hsucc] at hlt
+              have hval : (c.succ : ℕ) = n := congrArg Fin.val hsucc
+              rw [hval] at hlt
               exact hlt)
             (e7MinusculeParent c).isLt
           refine ⟨l ++ [e7MinusculeParentNode c], ?_⟩
@@ -283,7 +284,7 @@ private theorem e7MinusculeWeight_mem_orbit (a : Fin 56) :
     e7MinusculeWeight a ∈
       MulAction.orbit e7SimplyConnectedRootDatum.weylGroup
         (Pi.single 6 1 : Fin 7 → ℤ) := by
-  obtain ⟨l, hl⟩ := exists_e7MinusculeReflection_foldl_eq a
+  obtain ⟨l, hl⟩ := exists_foldl_e7MinusculeReflection_eq a
   rw [← hl]
   clear a hl
   induction l using List.reverseRecOn with

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/MinusculeWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E7/MinusculeWeight.lean
@@ -33,6 +33,8 @@ roadmap, consumed by the explicit pinned-carrier milestone of the CFSG statement
 * `TauCeti.DynkinType.e7MinusculeWeight`: the fifty-six weights in fundamental coordinates.
 * `TauCeti.DynkinType.e7MinusculeReflection`: the permutation induced by a simple reflection.
 * `TauCeti.DynkinType.e7MinusculeWeight_reflection`: the simple-reflection equation.
+* `TauCeti.DynkinType.exists_e7MinusculeReflection_foldl_eq`: every table index is reached from
+  the highest weight by simple reflections.
 * `TauCeti.DynkinType.range_e7MinusculeWeight`: the table is exactly the Weyl orbit of `ϖ₇`.
 * `TauCeti.DynkinType.span_range_e7MinusculeWeight_eq_top`: the weights span the character
   lattice.
@@ -278,6 +280,38 @@ private theorem e7MinusculeWeight_mem_orbit (a : Fin 56) :
             (RootPairing.weylGroup.ofIdx e7SimplyConnectedRootDatum
               (e7SimpleIndex (e7MinusculeParentNode a)))
             (ih (e7MinusculeParent a) hparent (e7MinusculeParent a).isLt)
+  exact aux a a.isLt
+
+/-- Every index in the minuscule weight table is reached from the highest-weight index by a
+finite sequence of simple reflections. -/
+theorem exists_e7MinusculeReflection_foldl_eq (a : Fin 56) :
+    ∃ l : List (Fin 7), l.foldl (fun b i ↦ e7MinusculeReflection i b) 0 = a := by
+  have aux : ∀ n, ∀ hn : n < 56,
+      ∃ l : List (Fin 7), l.foldl (fun b i ↦ e7MinusculeReflection i b) 0 =
+        (⟨n, hn⟩ : Fin 56) := by
+    intro n hn
+    induction n using Nat.strong_induction_on with
+    | h n ih =>
+        by_cases hzero : n = 0
+        · subst n
+          exact ⟨[], rfl⟩
+        · let c : Fin 55 := ⟨n - 1, by omega⟩
+          have hsucc : c.succ = (⟨n, hn⟩ : Fin 56) := by
+            apply Fin.ext
+            simp [c]
+            omega
+          obtain ⟨l, hl⟩ := ih (e7MinusculeParent c)
+            (by
+              have hlt := e7MinusculeParent_lt_succ c
+              rw [show (c.succ : ℕ) = n from congrArg Fin.val hsucc] at hlt
+              exact hlt)
+            (e7MinusculeParent c).isLt
+          refine ⟨l ++ [e7MinusculeParentNode c], ?_⟩
+          rw [List.foldl_append, hl]
+          simp only [List.foldl_cons, List.foldl_nil]
+          apply e7MinusculeWeight_injective
+          rw [← hsucc, e7MinusculeWeight_succ_eq_reflection_parent,
+            e7SimplyConnectedRootDatum_reflection_e7MinusculeWeight]
   exact aux a a.isLt
 
 /-- **The explicit table is exactly the Weyl orbit of the seventh fundamental weight `ϖ₇`.** -/


### PR DESCRIPTION
This PR equips the base-changed full-weight type-`E₇` minuscule carrier with its canonical 56-dimensional standard comodule, proves it faithful over every commutative ring, and proves it simple over every field by combining weight-torus projections with the positive and negative simple-root points.

It advances the exact ReductiveGroups Layer 9 target “The Chevalley–Demazure construction: for each root datum, an explicitly constructed split reductive group scheme over `ℤ` realizing it”: the faithful simple minuscule representation is the representation-theoretic input needed to establish reductivity for the already-constructed explicit `E₇` carrier. It serves that Layer 9 Chevalley–Demazure milestone and the `E₇(q)` branch of CFSGStatement milestone L0, which consumes an explicit pinned simply connected carrier rather than a chosen existence witness.

The proof also exposes the exact matrices `1 + uEᵢ` and `1 + uFᵢ`, proves that every minuscule table index is reachable from the highest-weight index by simple reflections, and uses those facts to show that a nonzero invariant submodule contains all 56 coordinate basis vectors. The comodule and point-action interface follows `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule`, while the specialized point identification reuses `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.BaseChange`.

After this PR, the Layer 9 milestone still needs smoothness and geometric connectedness of the `E₇` carrier, maximality and root-datum identification for its weight torus, and the resulting reductivity and full pinned-root-subgroup interface.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e7-minuscule-standard-comodule"}-->

🤖 Prepared with Codex
