### PR TITLE
feat: prove the analytic Euler product over prime ideals

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.NumberTheory.LSeries.Convergence
 public import Mathlib.NumberTheory.LSeries.SumCoeff
 public import Mathlib.NumberTheory.NumberField.Ideal.Asymptotics
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Trivial
 
 /-!
@@ -75,7 +76,7 @@ public section
 namespace TauCeti
 
 open Filter
-open scoped nonZeroDivisors NumberField Topology
+open scoped nonZeroDivisors NumberField Topology ComplexOrder
 
 variable (K : Type*) [Field K] [NumberField K]
 
@@ -409,6 +410,15 @@ theorem LSeriesSummable_normCoeff_one_iff {s : ℂ} :
         (not_LSeriesSummable_normCoeff_one K)
   · rw [abscissaOfAbsConv_normCoeff_one K]
     exact_mod_cast h
+
+/-- The ideal-indexed Dirichlet series of the trivial ideal weight converges absolutely exactly on
+`Re s > 1`. -/
+theorem summable_idealTerm_one_iff {K : Type*} [Field K] [NumberField K] {s : ℂ} :
+    Summable (idealTerm K (1 : IdealArithmeticFunction K) s) ↔ 1 < s.re := by
+  refine ⟨fun h ↦ (LSeriesSummable_normCoeff_one_iff K).mp (LSeriesSummable_normCoeff K h),
+    fun h ↦ ?_⟩
+  exact summable_idealTerm_of_nonneg K 1 (fun _ ↦ zero_le_one)
+    ((LSeriesSummable_normCoeff_one_iff K).mpr h)
 
 /-- **The Dedekind zeta series has abscissa of absolute convergence `1`.** -/
 @[simp]

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -40,8 +40,8 @@ product of the Dedekind zeta function.
   `Re s > 1`.
 
 No nonvanishing statement is made here. An unconditionally convergent product of nonzero factors
-may still vanish, so nonvanishing needs the convergence of the reciprocal product and is left to
-the layer that proves it.
+may still vanish, so nonvanishing requires additional hypotheses such as convergence of the
+reciprocal product.
 
 ## References
 
@@ -122,18 +122,15 @@ theorem norm_idealTerm_supportedPart_le (f : IdealArithmeticFunction K)
     (S : Set (HeightOneSpectrum (𝓞 K))) (s : ℂ) (I : (Ideal (𝓞 K))⁰) :
     ‖idealTerm K (supportedPart f S) s I‖ ≤ ‖idealTerm K f s I‖ := by
   rw [idealTerm_supportedPart]
-  by_cases hI : I ∈ {I : (Ideal (𝓞 K))⁰ | Ideal.IsPrimeTo (I : Ideal (𝓞 K)) Sᶜ}
-  · rw [Set.indicator_of_mem hI]
-  · rw [Set.indicator_of_notMem hI, norm_zero]
-    exact norm_nonneg _
+  exact norm_indicator_le_norm_self _ _
 
 /-- Absolute convergence of the ideal-indexed Dirichlet series is inherited by every restriction
 to a set of primes. -/
 theorem summable_idealTerm_supportedPart (hs : Summable (idealTerm K f s))
     (S : Set (HeightOneSpectrum (𝓞 K))) :
     Summable (idealTerm K (supportedPart f S) s) := by
-  rw [← summable_norm_iff] at hs ⊢
-  exact hs.of_nonneg_of_le (fun _ ↦ norm_nonneg _) (norm_idealTerm_supportedPart_le f S s)
+  rw [idealTerm_supportedPart]
+  exact hs.indicator _
 
 /-- Absolute convergence of the ideal-indexed Dirichlet series makes every local Euler factor an
 absolutely convergent `LSeries`. -/
@@ -284,15 +281,6 @@ theorem hasProd_eulerFactor (hs : Summable (idealTerm K χ.toIdealArithmeticFunc
 end MultiplicativeIdealWeight
 
 /-! ### The Dedekind zeta function -/
-
-/-- The ideal-indexed Dirichlet series of the trivial ideal weight converges absolutely exactly on
-`Re s > 1`. -/
-theorem summable_idealTerm_one_iff {s : ℂ} :
-    Summable (idealTerm K (1 : IdealArithmeticFunction K) s) ↔ 1 < s.re := by
-  refine ⟨fun h ↦ (LSeriesSummable_normCoeff_one_iff K).mp (LSeriesSummable_normCoeff K h),
-    fun h ↦ ?_⟩
-  exact summable_idealTerm_of_nonneg K 1 (fun _ ↦ zero_le_one)
-    ((LSeriesSummable_normCoeff_one_iff K).mpr h)
 
 /-- **The Euler product of the Dedekind zeta function.** For `Re s > 1` the Dedekind zeta function
 of `K` is the unrestricted product over the height-one primes of `𝓞 K` of the local factors

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -9,7 +9,6 @@ public import Mathlib.Analysis.Normed.Group.Tannery
 public import Mathlib.NumberTheory.LSeries.Convolution
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Estimates
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Data
-public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
 
 /-!
 # The analytic Euler product of an ideal arithmetic function
@@ -80,7 +79,7 @@ theorem eulerFactor_def (D : EulerProductData K) (P : HeightOneSpectrum (𝓞 K)
 theorem eulerFactor_eq_tsum (D : EulerProductData K) (P : HeightOneSpectrum (𝓞 K)) (s : ℂ) :
     D.eulerFactor P s =
       ∑' e : ℕ, idealTerm K D.toIdealArithmeticFunction s
-        (primeIdealPow P e) := by
+        (P.primeIdealPow e) := by
   have hsupp : Function.support
       (fun n : ℕ ↦ (D.localArithmeticFactor P n : ℂ) / (n : ℂ) ^ s) ⊆
       Set.range fun e : ℕ ↦ Ideal.absNorm P.asIdeal ^ e := by
@@ -93,7 +92,7 @@ theorem eulerFactor_eq_tsum (D : EulerProductData K) (P : HeightOneSpectrum (�
       (NumberField.HeightOneSpectrum.one_lt_absNorm P)).tsum_eq hsupp]
   refine tsum_congr fun e ↦ ?_
   rw [localArithmeticFactor_apply_pow, idealTerm_def,
-    absNorm_primeIdealPow]
+    P.absNorm_primeIdealPow]
 
 end EulerProductData
 
@@ -232,10 +231,10 @@ geometric progression. -/
 @[simp]
 theorem idealTerm_toIdealArithmeticFunction_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ)
     (s : ℂ) :
-    idealTerm K χ.toIdealArithmeticFunction s (primeIdealPow P e) =
+    idealTerm K χ.toIdealArithmeticFunction s (P.primeIdealPow e) =
       (χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) ^ e := by
   rw [idealTerm_def, toIdealArithmeticFunction_apply,
-    absNorm_primeIdealPow, coe_primeIdealPow,
+    P.absNorm_primeIdealPow, P.coe_primeIdealPow,
     map_pow, Nat.cast_pow, ← Complex.natCast_cpow_natCast_mul,
     Complex.cpow_nat_mul, div_pow]
 
@@ -247,7 +246,7 @@ theorem norm_div_lt_one_of_summable_idealTerm
     (P : HeightOneSpectrum (𝓞 K)) :
     ‖χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s‖ < 1 := by
   rw [← summable_geometric_iff_norm_lt_one]
-  exact (hs.comp_injective (primeIdealPow_injective P)).congr fun e ↦
+  exact (hs.comp_injective P.primeIdealPow_injective).congr fun e ↦
     idealTerm_toIdealArithmeticFunction_primeIdealPow χ P e s
 
 /-- The local Euler factor of a completely multiplicative weight is the geometric closed form

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -94,7 +94,6 @@ theorem coe_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
   (rfl)
 
 /-- The absolute norm is multiplicative on prime powers. -/
-@[simp]
 theorem absNorm_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
     Ideal.absNorm (primeIdealPow P e : Ideal (𝓞 K)) = Ideal.absNorm P.asIdeal ^ e := by
   rw [coe_primeIdealPow, map_pow]

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -80,7 +80,7 @@ theorem eulerFactor_def (D : EulerProductData K) (P : HeightOneSpectrum (𝓞 K)
 theorem eulerFactor_eq_tsum (D : EulerProductData K) (P : HeightOneSpectrum (𝓞 K)) (s : ℂ) :
     D.eulerFactor P s =
       ∑' e : ℕ, idealTerm K D.toIdealArithmeticFunction s
-        (HeightOneSpectrum.primeIdealPow P e) := by
+        (primeIdealPow P e) := by
   have hsupp : Function.support
       (fun n : ℕ ↦ (D.localArithmeticFactor P n : ℂ) / (n : ℂ) ^ s) ⊆
       Set.range fun e : ℕ ↦ Ideal.absNorm P.asIdeal ^ e := by
@@ -93,7 +93,7 @@ theorem eulerFactor_eq_tsum (D : EulerProductData K) (P : HeightOneSpectrum (�
       (NumberField.HeightOneSpectrum.one_lt_absNorm P)).tsum_eq hsupp]
   refine tsum_congr fun e ↦ ?_
   rw [localArithmeticFactor_apply_pow, idealTerm_def,
-    HeightOneSpectrum.absNorm_primeIdealPow]
+    absNorm_primeIdealPow]
 
 end EulerProductData
 
@@ -235,10 +235,10 @@ geometric progression. -/
 @[simp]
 theorem idealTerm_toIdealArithmeticFunction_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ)
     (s : ℂ) :
-    idealTerm K χ.toIdealArithmeticFunction s (HeightOneSpectrum.primeIdealPow P e) =
+    idealTerm K χ.toIdealArithmeticFunction s (primeIdealPow P e) =
       (χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) ^ e := by
   rw [idealTerm_def, toIdealArithmeticFunction_apply,
-    HeightOneSpectrum.absNorm_primeIdealPow, HeightOneSpectrum.coe_primeIdealPow,
+    absNorm_primeIdealPow, coe_primeIdealPow,
     map_pow, Nat.cast_pow, ← Complex.natCast_cpow_natCast_mul,
     Complex.cpow_nat_mul, div_pow]
 
@@ -250,7 +250,7 @@ theorem norm_div_lt_one_of_summable_idealTerm
     (P : HeightOneSpectrum (𝓞 K)) :
     ‖χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s‖ < 1 := by
   rw [← summable_geometric_iff_norm_lt_one]
-  exact (hs.comp_injective (HeightOneSpectrum.primeIdealPow_injective P)).congr fun e ↦
+  exact (hs.comp_injective (primeIdealPow_injective P)).congr fun e ↦
     idealTerm_toIdealArithmeticFunction_primeIdealPow χ P e s
 
 /-- The local Euler factor of a completely multiplicative weight is the geometric closed form

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -8,18 +8,17 @@ module
 public import Mathlib.Analysis.Normed.Group.Tannery
 public import Mathlib.NumberTheory.LSeries.Convolution
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Estimates
-public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Basic
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Data
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
 
 /-!
 # The analytic Euler product of an ideal arithmetic function
 
-`TauCeti.IdealArithmeticFunction.normCoeff_eq_eulerProduct` identifies the norm coefficients of a
-multiplicative ideal arithmetic function with a formal Euler product, coefficient by coefficient.
-This file supplies the analytic statement it does not: where the Dirichlet series indexed by the
-nonzero ideals converges absolutely, the infinite product of the local Euler factors converges,
-in the unrestricted sense of `HasProd` over the height-one primes, to the `LSeries` of the norm
-coefficients.
+`TauCeti.EulerProductData.normCoeff_eq_eulerProduct` identifies the norm coefficients of bundled
+Euler-product data with a formal Euler product, coefficient by coefficient. This file supplies the
+analytic statement it does not: where the Dirichlet series indexed by the nonzero ideals converges
+absolutely, the infinite product of the local Euler factors converges, in the unrestricted sense
+of `HasProd` over the height-one primes, to the `LSeries` of the norm coefficients.
 
 The local factor at a height-one prime `P` is the `LSeries` of the canonical local arithmetic
 factor, equivalently the prime-power Dirichlet series `∑' e, f (P ^ e) / N(P ^ e) ^ s`. For a
@@ -29,39 +28,20 @@ product of the Dedekind zeta function.
 
 ## Main definitions
 
-* `TauCeti.primeIdealPow`: the `e`-th power of a height-one prime, as a nonzero integral ideal.
-* `TauCeti.IdealArithmeticFunction.eulerFactor`: the local Euler factor at a height-one prime.
+* `TauCeti.EulerProductData.eulerFactor`: the local Euler factor at a height-one prime.
 
 ## Main results
 
-* `TauCeti.IdealArithmeticFunction.hasProd_eulerFactor`: the **analytic Euler product**, for a
-  multiplicative ideal arithmetic function whose ideal-indexed Dirichlet series converges
-  absolutely at `s`.
+* `TauCeti.EulerProductData.hasProd_eulerFactor`: the **analytic Euler product**, when the
+  ideal-indexed Dirichlet series converges absolutely at `s`.
 * `TauCeti.MultiplicativeIdealWeight.hasProd_eulerFactor`: the same product, with the local factors
   in the closed geometric form available for a completely multiplicative weight.
 * `TauCeti.hasProd_dedekindZeta`: the **Euler product of the Dedekind zeta function**, valid on
   `Re s > 1`.
 
-## Implementation notes
-
-The finite partial products are handled by regrouping, not by a second combinatorial induction:
-`TauCeti.IdealArithmeticFunction.normCoeff_supportedPart` already writes the restriction of `f`
-to the ideals supported on a finite prime set as a Dirichlet convolution of local factors, and
-Mathlib's `LSeries_mul'` turns that convolution into a product of `LSeries` values. What remains
-is the passage to the limit, and there the partial product is *literally* the ideal-indexed sum
-restricted to the supported ideals, so Tannery's theorem
-(`tendsto_tsum_of_dominated_convergence`) applies with the ideal terms of `f` as the dominating
-bound: each individual ideal is eventually supported, by
-`TauCeti.IdealArithmeticFunction.eventually_isPrimeTo_compl`.
-
 No nonvanishing statement is made here. An unconditionally convergent product of nonzero factors
 may still vanish, so nonvanishing needs the convergence of the reciprocal product and is left to
 the layer that proves it.
-
-## Roadmap role
-
-This is Layer **3.3**, the infinite Euler product, of
-`TauCetiRoadmap/ArithmeticDirichletSeries/README.md`.
 
 ## References
 
@@ -79,69 +59,47 @@ open IsDedekindDomain (HeightOneSpectrum)
 
 variable {K : Type*} [Field K] [NumberField K]
 
-/-! ### Prime powers as nonzero ideals -/
+namespace EulerProductData
 
-/-- The `e`-th power of a height-one prime of `𝓞 K`, as a nonzero integral ideal. This is the
-index carrier of the local Euler factor at that prime. -/
-def primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) : (Ideal (𝓞 K))⁰ :=
-  ⟨P.asIdeal ^ e, mem_nonZeroDivisors_of_ne_zero (pow_ne_zero e P.ne_bot)⟩
+open IdealArithmeticFunction
 
-omit [NumberField K] in
-/-- A prime power, as a nonzero integral ideal, has the expected underlying ideal. -/
-@[simp]
-theorem coe_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
-    (primeIdealPow P e : Ideal (𝓞 K)) = P.asIdeal ^ e :=
-  (rfl)
+variable (D : EulerProductData K) {s : ℂ}
 
-/-- The absolute norm is multiplicative on prime powers. -/
-theorem absNorm_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
-    Ideal.absNorm (primeIdealPow P e : Ideal (𝓞 K)) = Ideal.absNorm P.asIdeal ^ e := by
-  rw [coe_primeIdealPow, map_pow]
+/-! ### The local Euler factor -/
 
-/-- Distinct exponents give distinct prime powers: their absolute norms are distinct powers of an
-integer at least two. -/
-theorem primeIdealPow_injective (P : HeightOneSpectrum (𝓞 K)) :
-    Function.Injective (primeIdealPow P) := fun m n h ↦
-  Nat.pow_right_injective (NumberField.HeightOneSpectrum.one_lt_absNorm P)
-    (by simpa only [absNorm_primeIdealPow] using
-      congrArg (fun I : (Ideal (𝓞 K))⁰ ↦ Ideal.absNorm (I : Ideal (𝓞 K))) h)
+/-- The **local Euler factor** of `D` at a height-one prime `P`, evaluated at `s`. -/
+noncomputable def eulerFactor (D : EulerProductData K) (P : HeightOneSpectrum (𝓞 K)) (s : ℂ) : ℂ :=
+  LSeries (D.localArithmeticFactor P) s
 
-/-- A complex power of a natural-number power splits off the natural exponent. This is the norm
-computation behind the geometric shape of a completely multiplicative local factor. -/
-theorem natCast_pow_cpow (n e : ℕ) (s : ℂ) :
-    ((n ^ e : ℕ) : ℂ) ^ s = ((n : ℂ) ^ s) ^ e := by
-  rw [Nat.cast_pow, ← Complex.natCast_cpow_natCast_mul, Complex.cpow_nat_mul]
+/-- The local Euler factor is the `LSeries` of the canonical local arithmetic factor. -/
+theorem eulerFactor_def (D : EulerProductData K) (P : HeightOneSpectrum (𝓞 K)) (s : ℂ) :
+    D.eulerFactor P s = LSeries (D.localArithmeticFactor P) s := by
+  rw [eulerFactor]
+
+/-- The local Euler factor is the Dirichlet series over the powers of `P`. -/
+theorem eulerFactor_eq_tsum (D : EulerProductData K) (P : HeightOneSpectrum (𝓞 K)) (s : ℂ) :
+    D.eulerFactor P s =
+      ∑' e : ℕ, idealTerm K D.toIdealArithmeticFunction s
+        (HeightOneSpectrum.primeIdealPow P e) := by
+  have hsupp : Function.support
+      (fun n : ℕ ↦ (D.localArithmeticFactor P n : ℂ) / (n : ℂ) ^ s) ⊆
+      Set.range fun e : ℕ ↦ Ideal.absNorm P.asIdeal ^ e := by
+    intro n hn
+    simp only [Function.mem_support, ne_eq, div_eq_zero_iff, not_or] at hn
+    by_contra hpow
+    exact hn.1 (D.localArithmeticFactor_apply_eq_zero_of_not_exists_pow_eq P hpow)
+  rw [eulerFactor_def, LSeries_def₀ (by simp),
+    ← (Nat.pow_right_injective
+      (NumberField.HeightOneSpectrum.one_lt_absNorm P)).tsum_eq hsupp]
+  refine tsum_congr fun e ↦ ?_
+  rw [localArithmeticFactor_apply_pow, idealTerm_def,
+    HeightOneSpectrum.absNorm_primeIdealPow]
+
+end EulerProductData
 
 namespace IdealArithmeticFunction
 
 variable {f : IdealArithmeticFunction K} {s : ℂ}
-
-/-! ### The local Euler factor -/
-
-/-- The **local Euler factor** of `f` at a height-one prime `P`, evaluated at `s`: the `LSeries`
-of the canonical local arithmetic factor `TauCeti.IdealArithmeticFunction.localArithmeticFactor`.
-By `TauCeti.IdealArithmeticFunction.eulerFactor_eq_tsum` this is the prime-power Dirichlet series
-`∑' e, f (P ^ e) / N(P ^ e) ^ s`. -/
-noncomputable def eulerFactor (f : IdealArithmeticFunction K) (P : HeightOneSpectrum (𝓞 K))
-    (s : ℂ) : ℂ :=
-  LSeries (localArithmeticFactor f P) s
-
-/-- The local Euler factor is the Dirichlet series over the powers of `P`. -/
-theorem eulerFactor_eq_tsum (f : IdealArithmeticFunction K) (P : HeightOneSpectrum (𝓞 K))
-    (s : ℂ) :
-    eulerFactor f P s = ∑' e : ℕ, idealTerm K f s (primeIdealPow P e) := by
-  have hsupp : Function.support
-      (fun n : ℕ ↦ (localArithmeticFactor f P n : ℂ) / (n : ℂ) ^ s) ⊆
-      Set.range fun e : ℕ ↦ Ideal.absNorm P.asIdeal ^ e := by
-    intro n hn
-    simp only [Function.mem_support, ne_eq, div_eq_zero_iff, not_or] at hn
-    exact exists_pow_eq_of_localArithmeticFactor_apply_ne_zero f P hn.1
-  rw [eulerFactor, LSeries_def₀ (by simp),
-    ← (Nat.pow_right_injective
-      (NumberField.HeightOneSpectrum.one_lt_absNorm P)).tsum_eq hsupp]
-  refine tsum_congr fun e ↦ ?_
-  rw [localArithmeticFactor_apply_pow, idealTerm_def, absNorm_primeIdealPow]
-  rfl
 
 /-! ### Restriction to a set of primes, analytically -/
 
@@ -185,17 +143,27 @@ theorem LSeriesSummable_localArithmeticFactor (hs : Summable (idealTerm K f s))
   rw [← normCoeff_supportedPart_singleton f P]
   exact LSeriesSummable_normCoeff K (summable_idealTerm_supportedPart hs _)
 
+end IdealArithmeticFunction
+
+namespace EulerProductData
+
+open IdealArithmeticFunction
+
+variable (D : EulerProductData K) {s : ℂ}
+
 /-- **The finite Euler product, analytically.** The `LSeries` of the norm coefficients of the
-restriction of `f` to a finite set `S` of primes is the finite product of the local Euler factors
+restriction of `D` to a finite set `S` of primes is the finite product of the local Euler factors
 over `S`. -/
-theorem LSeries_normCoeff_supportedPart (hf : f.IsMultiplicative)
-    (hs : Summable (idealTerm K f s)) (S : Finset (HeightOneSpectrum (𝓞 K))) :
-    LSeries (normCoeff K (supportedPart f (S : Set (HeightOneSpectrum (𝓞 K))))) s =
-      ∏ P ∈ S, eulerFactor f P s := by
+theorem LSeries_normCoeff_supportedPart
+    (hs : Summable (idealTerm K D.toIdealArithmeticFunction s))
+    (S : Finset (HeightOneSpectrum (𝓞 K))) :
+    LSeries (normCoeff K (supportedPart D.toIdealArithmeticFunction
+      (S : Set (HeightOneSpectrum (𝓞 K))))) s = ∏ P ∈ S, D.eulerFactor P s := by
   classical
   induction S using Finset.induction_on with
   | empty =>
-      rw [Finset.coe_empty, supportedPart_empty hf.map_one, normCoeff_delta, Finset.prod_empty]
+      rw [Finset.coe_empty, supportedPart_empty D.isMultiplicative.map_one, normCoeff_delta,
+        Finset.prod_empty]
       have hone : ⇑(1 : ArithmeticFunction ℂ) = LSeries.delta := by
         funext n
         simp [ArithmeticFunction.one_apply, LSeries.delta]
@@ -205,50 +173,54 @@ theorem LSeries_normCoeff_supportedPart (hf : f.IsMultiplicative)
         (S : Set (HeightOneSpectrum (𝓞 K))))
       have hP := LSeriesSummable_normCoeff K (summable_idealTerm_supportedPart hs
         ({P} : Set (HeightOneSpectrum (𝓞 K))))
-      rw [Finset.coe_insert, supportedPart_insert hf (by simpa using hPS), normCoeff_convolution,
-        ArithmeticFunction.LSeries_mul' hS hP, ih, normCoeff_supportedPart_singleton,
+      rw [Finset.coe_insert, supportedPart_insert D.isMultiplicative (by simpa using hPS),
+        normCoeff_convolution, ArithmeticFunction.LSeries_mul' hS hP, ih,
+        normCoeff_supportedPart_singleton,
         Finset.prod_insert hPS, mul_comm]
-      rfl
+      rw [eulerFactor_def, localArithmeticFactor_eq]
 
 /-! ### The infinite Euler product -/
 
-/-- **The analytic Euler product.** If `f` is multiplicative and its ideal-indexed Dirichlet
-series converges absolutely at `s`, then the local Euler factors of `f` have an unrestricted
+/-- **The analytic Euler product.** If the ideal-indexed Dirichlet series of `D` converges
+absolutely at `s`, then its local Euler factors have an unrestricted
 infinite product over the height-one primes, and that product is the `LSeries` of the norm
-coefficients of `f`.
+coefficients of `D`.
 
 The hypothesis is absolute convergence of the *ideal-indexed* series, not of the regrouped one:
 regrouping can only improve convergence, and the finite partial products of the local factors are
 sums over ideals, not over norms. -/
-theorem hasProd_eulerFactor (hf : f.IsMultiplicative) (hs : Summable (idealTerm K f s)) :
-    HasProd (fun P ↦ eulerFactor f P s) (LSeries (normCoeff K f) s) := by
+theorem hasProd_eulerFactor (hs : Summable (idealTerm K D.toIdealArithmeticFunction s)) :
+    HasProd (fun P ↦ D.eulerFactor P s)
+      (LSeries (normCoeff K D.toIdealArithmeticFunction) s) := by
   have key : ∀ S : Finset (HeightOneSpectrum (𝓞 K)),
-      ∏ P ∈ S, eulerFactor f P s =
-        ∑' I, idealTerm K (supportedPart f (S : Set (HeightOneSpectrum (𝓞 K)))) s I := by
+      ∏ P ∈ S, D.eulerFactor P s =
+        ∑' I, idealTerm K (supportedPart D.toIdealArithmeticFunction
+          (S : Set (HeightOneSpectrum (𝓞 K)))) s I := by
     intro S
-    rw [← LSeries_normCoeff_supportedPart hf hs S,
+    rw [← D.LSeries_normCoeff_supportedPart hs S,
       LSeries_normCoeff K (summable_idealTerm_supportedPart hs _)]
   rw [HasProd, SummationFilter.unconditional_filter, LSeries_normCoeff K hs]
   simp only [key]
-  refine tendsto_tsum_of_dominated_convergence (bound := fun I ↦ ‖idealTerm K f s I‖)
+  refine tendsto_tsum_of_dominated_convergence
+    (bound := fun I ↦ ‖idealTerm K D.toIdealArithmeticFunction s I‖)
     (summable_norm_iff.mpr hs) (fun I ↦ ?_) (Filter.Eventually.of_forall fun S I ↦ ?_)
   · refine Filter.Tendsto.congr' ?_ tendsto_const_nhds
     filter_upwards [eventually_isPrimeTo_compl I] with S hS
     rw [idealTerm_def, idealTerm_def, supportedPart_apply_of_isPrimeTo_compl hS]
-  · exact norm_idealTerm_supportedPart_le f _ s I
+  · exact norm_idealTerm_supportedPart_le D.toIdealArithmeticFunction _ s I
 
-/-- The local Euler factors of a multiplicative ideal arithmetic function are multipliable
-wherever its ideal-indexed Dirichlet series converges absolutely. -/
-theorem multipliable_eulerFactor (hf : f.IsMultiplicative) (hs : Summable (idealTerm K f s)) :
-    Multipliable fun P ↦ eulerFactor f P s :=
-  (hasProd_eulerFactor hf hs).multipliable
+/-- The local Euler factors are multipliable wherever the ideal-indexed Dirichlet series converges
+absolutely. -/
+theorem multipliable_eulerFactor (hs : Summable (idealTerm K D.toIdealArithmeticFunction s)) :
+    Multipliable fun P ↦ D.eulerFactor P s :=
+  (D.hasProd_eulerFactor hs).multipliable
 
 /-- The analytic Euler product, as an equality of the unrestricted product with the `LSeries`. -/
-theorem tprod_eulerFactor (hf : f.IsMultiplicative) (hs : Summable (idealTerm K f s)) :
-    ∏' P, eulerFactor f P s = LSeries (normCoeff K f) s :=
-  (hasProd_eulerFactor hf hs).tprod_eq
+theorem tprod_eulerFactor (hs : Summable (idealTerm K D.toIdealArithmeticFunction s)) :
+    ∏' P, D.eulerFactor P s = LSeries (normCoeff K D.toIdealArithmeticFunction) s :=
+  (D.hasProd_eulerFactor hs).tprod_eq
 
-end IdealArithmeticFunction
+end EulerProductData
 
 /-! ### Completely multiplicative weights -/
 
@@ -260,12 +232,15 @@ variable (χ : MultiplicativeIdealWeight K) {s : ℂ}
 
 /-- The ideal terms of a completely multiplicative weight along the powers of a prime form a
 geometric progression. -/
+@[simp]
 theorem idealTerm_toIdealArithmeticFunction_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ)
     (s : ℂ) :
-    idealTerm K χ.toIdealArithmeticFunction s (primeIdealPow P e) =
+    idealTerm K χ.toIdealArithmeticFunction s (HeightOneSpectrum.primeIdealPow P e) =
       (χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) ^ e := by
-  rw [idealTerm_def, toIdealArithmeticFunction_apply, absNorm_primeIdealPow, coe_primeIdealPow,
-    map_pow, natCast_pow_cpow, div_pow]
+  rw [idealTerm_def, toIdealArithmeticFunction_apply,
+    HeightOneSpectrum.absNorm_primeIdealPow, HeightOneSpectrum.coe_primeIdealPow,
+    map_pow, Nat.cast_pow, ← Complex.natCast_cpow_natCast_mul,
+    Complex.cpow_nat_mul, div_pow]
 
 /-- **The local ratio of a convergent weight is a contraction.** Absolute convergence of the
 ideal-indexed Dirichlet series forces the geometric ratio at each prime to have modulus less than
@@ -275,19 +250,20 @@ theorem norm_div_lt_one_of_summable_idealTerm
     (P : HeightOneSpectrum (𝓞 K)) :
     ‖χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s‖ < 1 := by
   rw [← summable_geometric_iff_norm_lt_one]
-  exact (hs.comp_injective (primeIdealPow_injective P)).congr fun e ↦
+  exact (hs.comp_injective (HeightOneSpectrum.primeIdealPow_injective P)).congr fun e ↦
     idealTerm_toIdealArithmeticFunction_primeIdealPow χ P e s
 
 /-- The local Euler factor of a completely multiplicative weight is the geometric closed form
 `(1 - χ(P) N(P)⁻ˢ)⁻¹`. -/
 theorem eulerFactor_toIdealArithmeticFunction
-    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s))
-    (P : HeightOneSpectrum (𝓞 K)) :
-    eulerFactor χ.toIdealArithmeticFunction P s =
+    (P : HeightOneSpectrum (𝓞 K))
+    (hP : ‖χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s‖ < 1) :
+    (EulerProductData.ofMultiplicativeIdealWeight χ).eulerFactor P s =
       (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)⁻¹ := by
-  rw [eulerFactor_eq_tsum,
+  rw [EulerProductData.eulerFactor_eq_tsum,
+    EulerProductData.toIdealArithmeticFunction_ofMultiplicativeIdealWeight,
     tsum_congr fun e ↦ idealTerm_toIdealArithmeticFunction_primeIdealPow χ P e s]
-  exact tsum_geometric_of_norm_lt_one (norm_div_lt_one_of_summable_idealTerm χ hs P)
+  exact tsum_geometric_of_norm_lt_one hP
 
 /-- **The Euler product of a completely multiplicative ideal weight.** -/
 theorem hasProd_eulerFactor (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
@@ -296,11 +272,14 @@ theorem hasProd_eulerFactor (hs : Summable (idealTerm K χ.toIdealArithmeticFunc
       (LSeries (normCoeff K χ.toIdealArithmeticFunction) s) := by
   have hfun : (fun P : HeightOneSpectrum (𝓞 K) ↦
       (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)⁻¹) =
-      fun P ↦ eulerFactor χ.toIdealArithmeticFunction P s :=
-    funext fun P ↦ (eulerFactor_toIdealArithmeticFunction χ hs P).symm
+      fun P ↦ (EulerProductData.ofMultiplicativeIdealWeight χ).eulerFactor P s :=
+    funext fun P ↦ (eulerFactor_toIdealArithmeticFunction χ P
+      (norm_div_lt_one_of_summable_idealTerm χ hs P)).symm
   rw [hfun]
-  exact IdealArithmeticFunction.hasProd_eulerFactor
-    (isMultiplicative_toIdealArithmeticFunction χ) hs
+  have hprod := (EulerProductData.ofMultiplicativeIdealWeight χ).hasProd_eulerFactor
+    (s := s) (by
+      simpa only [EulerProductData.toIdealArithmeticFunction_ofMultiplicativeIdealWeight] using hs)
+  simpa only [EulerProductData.toIdealArithmeticFunction_ofMultiplicativeIdealWeight] using hprod
 
 end MultiplicativeIdealWeight
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -1,0 +1,346 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Group.Tannery
+public import Mathlib.NumberTheory.LSeries.Convolution
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Estimates
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.EulerProduct.Basic
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
+
+/-!
+# The analytic Euler product of an ideal arithmetic function
+
+`TauCeti.IdealArithmeticFunction.normCoeff_eq_eulerProduct` identifies the norm coefficients of a
+multiplicative ideal arithmetic function with a formal Euler product, coefficient by coefficient.
+This file supplies the analytic statement it does not: where the Dirichlet series indexed by the
+nonzero ideals converges absolutely, the infinite product of the local Euler factors converges,
+in the unrestricted sense of `HasProd` over the height-one primes, to the `LSeries` of the norm
+coefficients.
+
+The local factor at a height-one prime `P` is the `LSeries` of the canonical local arithmetic
+factor, equivalently the prime-power Dirichlet series `∑' e, f (P ^ e) / N(P ^ e) ^ s`. For a
+completely multiplicative weight that series is geometric, and the factor takes the familiar
+closed form `(1 - χ(P) N(P) ^ (-s))⁻¹`; specializing to the trivial weight gives the Euler
+product of the Dedekind zeta function.
+
+## Main definitions
+
+* `TauCeti.primeIdealPow`: the `e`-th power of a height-one prime, as a nonzero integral ideal.
+* `TauCeti.IdealArithmeticFunction.eulerFactor`: the local Euler factor at a height-one prime.
+
+## Main results
+
+* `TauCeti.IdealArithmeticFunction.hasProd_eulerFactor`: the **analytic Euler product**, for a
+  multiplicative ideal arithmetic function whose ideal-indexed Dirichlet series converges
+  absolutely at `s`.
+* `TauCeti.MultiplicativeIdealWeight.hasProd_eulerFactor`: the same product, with the local factors
+  in the closed geometric form available for a completely multiplicative weight.
+* `TauCeti.hasProd_dedekindZeta`: the **Euler product of the Dedekind zeta function**, valid on
+  `Re s > 1`.
+
+## Implementation notes
+
+The finite partial products are handled by regrouping, not by a second combinatorial induction:
+`TauCeti.IdealArithmeticFunction.normCoeff_supportedPart` already writes the restriction of `f`
+to the ideals supported on a finite prime set as a Dirichlet convolution of local factors, and
+Mathlib's `LSeries_mul'` turns that convolution into a product of `LSeries` values. What remains
+is the passage to the limit, and there the partial product is *literally* the ideal-indexed sum
+restricted to the supported ideals, so Tannery's theorem
+(`tendsto_tsum_of_dominated_convergence`) applies with the ideal terms of `f` as the dominating
+bound: each individual ideal is eventually supported, by
+`TauCeti.IdealArithmeticFunction.eventually_isPrimeTo_compl`.
+
+No nonvanishing statement is made here. An unconditionally convergent product of nonzero factors
+may still vanish, so nonvanishing needs the convergence of the reciprocal product and is left to
+the layer that proves it.
+
+## Roadmap role
+
+This is Layer **3.3**, the infinite Euler product, of
+`TauCetiRoadmap/ArithmeticDirichletSeries/README.md`.
+
+## References
+
+* J. Neukirch, *Algebraic Number Theory*, Chapter VII.
+* Mathlib's `EulerProduct` API, whose `Nat.Primes`-indexed statements this file mirrors for the
+  height-one primes of a number field.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped nonZeroDivisors NumberField ComplexOrder
+open IsDedekindDomain (HeightOneSpectrum)
+
+variable {K : Type*} [Field K] [NumberField K]
+
+/-! ### Prime powers as nonzero ideals -/
+
+/-- The `e`-th power of a height-one prime of `𝓞 K`, as a nonzero integral ideal. This is the
+index carrier of the local Euler factor at that prime. -/
+def primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) : (Ideal (𝓞 K))⁰ :=
+  ⟨P.asIdeal ^ e, mem_nonZeroDivisors_of_ne_zero (pow_ne_zero e P.ne_bot)⟩
+
+omit [NumberField K] in
+/-- A prime power, as a nonzero integral ideal, has the expected underlying ideal. -/
+@[simp]
+theorem coe_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
+    (primeIdealPow P e : Ideal (𝓞 K)) = P.asIdeal ^ e :=
+  (rfl)
+
+/-- The absolute norm is multiplicative on prime powers. -/
+@[simp]
+theorem absNorm_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
+    Ideal.absNorm (primeIdealPow P e : Ideal (𝓞 K)) = Ideal.absNorm P.asIdeal ^ e := by
+  rw [coe_primeIdealPow, map_pow]
+
+/-- Distinct exponents give distinct prime powers: their absolute norms are distinct powers of an
+integer at least two. -/
+theorem primeIdealPow_injective (P : HeightOneSpectrum (𝓞 K)) :
+    Function.Injective (primeIdealPow P) := fun m n h ↦
+  Nat.pow_right_injective (NumberField.HeightOneSpectrum.one_lt_absNorm P)
+    (by simpa only [absNorm_primeIdealPow] using
+      congrArg (fun I : (Ideal (𝓞 K))⁰ ↦ Ideal.absNorm (I : Ideal (𝓞 K))) h)
+
+/-- A complex power of a natural-number power splits off the natural exponent. This is the norm
+computation behind the geometric shape of a completely multiplicative local factor. -/
+theorem natCast_pow_cpow (n e : ℕ) (s : ℂ) :
+    ((n ^ e : ℕ) : ℂ) ^ s = ((n : ℂ) ^ s) ^ e := by
+  rw [Nat.cast_pow, ← Complex.natCast_cpow_natCast_mul, Complex.cpow_nat_mul]
+
+namespace IdealArithmeticFunction
+
+variable {f : IdealArithmeticFunction K} {s : ℂ}
+
+/-! ### The local Euler factor -/
+
+/-- The **local Euler factor** of `f` at a height-one prime `P`, evaluated at `s`: the `LSeries`
+of the canonical local arithmetic factor `TauCeti.IdealArithmeticFunction.localArithmeticFactor`.
+By `TauCeti.IdealArithmeticFunction.eulerFactor_eq_tsum` this is the prime-power Dirichlet series
+`∑' e, f (P ^ e) / N(P ^ e) ^ s`. -/
+noncomputable def eulerFactor (f : IdealArithmeticFunction K) (P : HeightOneSpectrum (𝓞 K))
+    (s : ℂ) : ℂ :=
+  LSeries (localArithmeticFactor f P) s
+
+/-- The local Euler factor is the Dirichlet series over the powers of `P`. -/
+theorem eulerFactor_eq_tsum (f : IdealArithmeticFunction K) (P : HeightOneSpectrum (𝓞 K))
+    (s : ℂ) :
+    eulerFactor f P s = ∑' e : ℕ, idealTerm K f s (primeIdealPow P e) := by
+  have hsupp : Function.support
+      (fun n : ℕ ↦ (localArithmeticFactor f P n : ℂ) / (n : ℂ) ^ s) ⊆
+      Set.range fun e : ℕ ↦ Ideal.absNorm P.asIdeal ^ e := by
+    intro n hn
+    simp only [Function.mem_support, ne_eq, div_eq_zero_iff, not_or] at hn
+    exact exists_pow_eq_of_localArithmeticFactor_apply_ne_zero f P hn.1
+  rw [eulerFactor, LSeries_def₀ (by simp),
+    ← (Nat.pow_right_injective
+      (NumberField.HeightOneSpectrum.one_lt_absNorm P)).tsum_eq hsupp]
+  refine tsum_congr fun e ↦ ?_
+  rw [localArithmeticFactor_apply_pow, idealTerm_def, absNorm_primeIdealPow]
+  rfl
+
+/-! ### Restriction to a set of primes, analytically -/
+
+/-- The ideal terms of a restriction of `f` are the ideal terms of `f`, cut off outside the ideals
+supported on the prescribed set of primes. -/
+theorem idealTerm_supportedPart (f : IdealArithmeticFunction K)
+    (S : Set (HeightOneSpectrum (𝓞 K))) (s : ℂ) :
+    idealTerm K (supportedPart f S) s =
+      Set.indicator {I : (Ideal (𝓞 K))⁰ | Ideal.IsPrimeTo (I : Ideal (𝓞 K)) Sᶜ}
+        (idealTerm K f s) := by
+  funext I
+  by_cases hI : I ∈ {I : (Ideal (𝓞 K))⁰ | Ideal.IsPrimeTo (I : Ideal (𝓞 K)) Sᶜ}
+  · rw [Set.indicator_of_mem hI, idealTerm_def, idealTerm_def,
+      supportedPart_apply_of_isPrimeTo_compl hI]
+  · rw [Set.indicator_of_notMem hI, idealTerm_def,
+      supportedPart_apply_of_not_isPrimeTo_compl hI, zero_div]
+
+/-- Restricting to a set of primes never increases an ideal term. -/
+theorem norm_idealTerm_supportedPart_le (f : IdealArithmeticFunction K)
+    (S : Set (HeightOneSpectrum (𝓞 K))) (s : ℂ) (I : (Ideal (𝓞 K))⁰) :
+    ‖idealTerm K (supportedPart f S) s I‖ ≤ ‖idealTerm K f s I‖ := by
+  rw [idealTerm_supportedPart]
+  by_cases hI : I ∈ {I : (Ideal (𝓞 K))⁰ | Ideal.IsPrimeTo (I : Ideal (𝓞 K)) Sᶜ}
+  · rw [Set.indicator_of_mem hI]
+  · rw [Set.indicator_of_notMem hI, norm_zero]
+    exact norm_nonneg _
+
+/-- Absolute convergence of the ideal-indexed Dirichlet series is inherited by every restriction
+to a set of primes. -/
+theorem summable_idealTerm_supportedPart (hs : Summable (idealTerm K f s))
+    (S : Set (HeightOneSpectrum (𝓞 K))) :
+    Summable (idealTerm K (supportedPart f S) s) := by
+  rw [← summable_norm_iff] at hs ⊢
+  exact hs.of_nonneg_of_le (fun _ ↦ norm_nonneg _) (norm_idealTerm_supportedPart_le f S s)
+
+/-- Absolute convergence of the ideal-indexed Dirichlet series makes every local Euler factor an
+absolutely convergent `LSeries`. -/
+theorem LSeriesSummable_localArithmeticFactor (hs : Summable (idealTerm K f s))
+    (P : HeightOneSpectrum (𝓞 K)) :
+    LSeriesSummable (localArithmeticFactor f P) s := by
+  rw [← normCoeff_supportedPart_singleton f P]
+  exact LSeriesSummable_normCoeff K (summable_idealTerm_supportedPart hs _)
+
+/-- **The finite Euler product, analytically.** The `LSeries` of the norm coefficients of the
+restriction of `f` to a finite set `S` of primes is the finite product of the local Euler factors
+over `S`. -/
+theorem LSeries_normCoeff_supportedPart (hf : f.IsMultiplicative)
+    (hs : Summable (idealTerm K f s)) (S : Finset (HeightOneSpectrum (𝓞 K))) :
+    LSeries (normCoeff K (supportedPart f (S : Set (HeightOneSpectrum (𝓞 K))))) s =
+      ∏ P ∈ S, eulerFactor f P s := by
+  classical
+  induction S using Finset.induction_on with
+  | empty =>
+      rw [Finset.coe_empty, supportedPart_empty hf.map_one, normCoeff_delta, Finset.prod_empty]
+      have hone : ⇑(1 : ArithmeticFunction ℂ) = LSeries.delta := by
+        funext n
+        simp [ArithmeticFunction.one_apply, LSeries.delta]
+      rw [hone, LSeries_delta, Pi.one_apply]
+  | insert P S hPS ih =>
+      have hS := LSeriesSummable_normCoeff K (summable_idealTerm_supportedPart hs
+        (S : Set (HeightOneSpectrum (𝓞 K))))
+      have hP := LSeriesSummable_normCoeff K (summable_idealTerm_supportedPart hs
+        ({P} : Set (HeightOneSpectrum (𝓞 K))))
+      rw [Finset.coe_insert, supportedPart_insert hf (by simpa using hPS), normCoeff_convolution,
+        ArithmeticFunction.LSeries_mul' hS hP, ih, normCoeff_supportedPart_singleton,
+        Finset.prod_insert hPS, mul_comm]
+      rfl
+
+/-! ### The infinite Euler product -/
+
+/-- **The analytic Euler product.** If `f` is multiplicative and its ideal-indexed Dirichlet
+series converges absolutely at `s`, then the local Euler factors of `f` have an unrestricted
+infinite product over the height-one primes, and that product is the `LSeries` of the norm
+coefficients of `f`.
+
+The hypothesis is absolute convergence of the *ideal-indexed* series, not of the regrouped one:
+regrouping can only improve convergence, and the finite partial products of the local factors are
+sums over ideals, not over norms. -/
+theorem hasProd_eulerFactor (hf : f.IsMultiplicative) (hs : Summable (idealTerm K f s)) :
+    HasProd (fun P ↦ eulerFactor f P s) (LSeries (normCoeff K f) s) := by
+  have key : ∀ S : Finset (HeightOneSpectrum (𝓞 K)),
+      ∏ P ∈ S, eulerFactor f P s =
+        ∑' I, idealTerm K (supportedPart f (S : Set (HeightOneSpectrum (𝓞 K)))) s I := by
+    intro S
+    rw [← LSeries_normCoeff_supportedPart hf hs S,
+      LSeries_normCoeff K (summable_idealTerm_supportedPart hs _)]
+  rw [HasProd, SummationFilter.unconditional_filter, LSeries_normCoeff K hs]
+  simp only [key]
+  refine tendsto_tsum_of_dominated_convergence (bound := fun I ↦ ‖idealTerm K f s I‖)
+    (summable_norm_iff.mpr hs) (fun I ↦ ?_) (Filter.Eventually.of_forall fun S I ↦ ?_)
+  · refine Filter.Tendsto.congr' ?_ tendsto_const_nhds
+    filter_upwards [eventually_isPrimeTo_compl I] with S hS
+    rw [idealTerm_def, idealTerm_def, supportedPart_apply_of_isPrimeTo_compl hS]
+  · exact norm_idealTerm_supportedPart_le f _ s I
+
+/-- The local Euler factors of a multiplicative ideal arithmetic function are multipliable
+wherever its ideal-indexed Dirichlet series converges absolutely. -/
+theorem multipliable_eulerFactor (hf : f.IsMultiplicative) (hs : Summable (idealTerm K f s)) :
+    Multipliable fun P ↦ eulerFactor f P s :=
+  (hasProd_eulerFactor hf hs).multipliable
+
+/-- The analytic Euler product, as an equality of the unrestricted product with the `LSeries`. -/
+theorem tprod_eulerFactor (hf : f.IsMultiplicative) (hs : Summable (idealTerm K f s)) :
+    ∏' P, eulerFactor f P s = LSeries (normCoeff K f) s :=
+  (hasProd_eulerFactor hf hs).tprod_eq
+
+end IdealArithmeticFunction
+
+/-! ### Completely multiplicative weights -/
+
+namespace MultiplicativeIdealWeight
+
+open IdealArithmeticFunction
+
+variable (χ : MultiplicativeIdealWeight K) {s : ℂ}
+
+/-- The ideal terms of a completely multiplicative weight along the powers of a prime form a
+geometric progression. -/
+theorem idealTerm_toIdealArithmeticFunction_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ)
+    (s : ℂ) :
+    idealTerm K χ.toIdealArithmeticFunction s (primeIdealPow P e) =
+      (χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s) ^ e := by
+  rw [idealTerm_def, toIdealArithmeticFunction_apply, absNorm_primeIdealPow, coe_primeIdealPow,
+    map_pow, natCast_pow_cpow, div_pow]
+
+/-- **The local ratio of a convergent weight is a contraction.** Absolute convergence of the
+ideal-indexed Dirichlet series forces the geometric ratio at each prime to have modulus less than
+one, because the powers of that prime already contribute a geometric subseries. -/
+theorem norm_div_lt_one_of_summable_idealTerm
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s))
+    (P : HeightOneSpectrum (𝓞 K)) :
+    ‖χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s‖ < 1 := by
+  rw [← summable_geometric_iff_norm_lt_one]
+  exact (hs.comp_injective (primeIdealPow_injective P)).congr fun e ↦
+    idealTerm_toIdealArithmeticFunction_primeIdealPow χ P e s
+
+/-- The local Euler factor of a completely multiplicative weight is the geometric closed form
+`(1 - χ(P) N(P)⁻ˢ)⁻¹`. -/
+theorem eulerFactor_toIdealArithmeticFunction
+    (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s))
+    (P : HeightOneSpectrum (𝓞 K)) :
+    eulerFactor χ.toIdealArithmeticFunction P s =
+      (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)⁻¹ := by
+  rw [eulerFactor_eq_tsum,
+    tsum_congr fun e ↦ idealTerm_toIdealArithmeticFunction_primeIdealPow χ P e s]
+  exact tsum_geometric_of_norm_lt_one (norm_div_lt_one_of_summable_idealTerm χ hs P)
+
+/-- **The Euler product of a completely multiplicative ideal weight.** -/
+theorem hasProd_eulerFactor (hs : Summable (idealTerm K χ.toIdealArithmeticFunction s)) :
+    HasProd (fun P : HeightOneSpectrum (𝓞 K) ↦
+        (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)⁻¹)
+      (LSeries (normCoeff K χ.toIdealArithmeticFunction) s) := by
+  have hfun : (fun P : HeightOneSpectrum (𝓞 K) ↦
+      (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)⁻¹) =
+      fun P ↦ eulerFactor χ.toIdealArithmeticFunction P s :=
+    funext fun P ↦ (eulerFactor_toIdealArithmeticFunction χ hs P).symm
+  rw [hfun]
+  exact IdealArithmeticFunction.hasProd_eulerFactor
+    (isMultiplicative_toIdealArithmeticFunction χ) hs
+
+end MultiplicativeIdealWeight
+
+/-! ### The Dedekind zeta function -/
+
+/-- The ideal-indexed Dirichlet series of the trivial ideal weight converges absolutely exactly on
+`Re s > 1`. -/
+theorem summable_idealTerm_one_iff {s : ℂ} :
+    Summable (idealTerm K (1 : IdealArithmeticFunction K) s) ↔ 1 < s.re := by
+  refine ⟨fun h ↦ (LSeriesSummable_normCoeff_one_iff K).mp (LSeriesSummable_normCoeff K h),
+    fun h ↦ ?_⟩
+  exact summable_idealTerm_of_nonneg K 1 (fun _ ↦ zero_le_one)
+    ((LSeriesSummable_normCoeff_one_iff K).mpr h)
+
+/-- **The Euler product of the Dedekind zeta function.** For `Re s > 1` the Dedekind zeta function
+of `K` is the unrestricted product over the height-one primes of `𝓞 K` of the local factors
+`(1 - N(𝔭) ^ (-s))⁻¹`.
+
+This is the ideal-theoretic counterpart of Mathlib's `riemannZeta_eulerProduct_hasProd`, and it
+is not obtained from it: the product is indexed by the primes of `𝓞 K`, whose norms repeat and
+whose count above a rational prime is the splitting behaviour of `K`. -/
+theorem hasProd_dedekindZeta {s : ℂ} (hs : 1 < s.re) :
+    HasProd (fun P : HeightOneSpectrum (𝓞 K) ↦ (1 - (Ideal.absNorm P.asIdeal : ℂ) ^ (-s))⁻¹)
+      (NumberField.dedekindZeta K s) := by
+  have hsum : Summable (idealTerm K
+      (1 : MultiplicativeIdealWeight K).toIdealArithmeticFunction s) := by
+    rw [MultiplicativeIdealWeight.toIdealArithmeticFunction_one]
+    exact summable_idealTerm_one_iff.mpr hs
+  have hprod := MultiplicativeIdealWeight.hasProd_eulerFactor (1 : MultiplicativeIdealWeight K) hsum
+  rw [MultiplicativeIdealWeight.toIdealArithmeticFunction_one,
+    ← dedekindZeta_eq_LSeries_normCoeff_one K s] at hprod
+  have hfun : (fun P : HeightOneSpectrum (𝓞 K) ↦
+      (1 - (Ideal.absNorm P.asIdeal : ℂ) ^ (-s))⁻¹) =
+      fun P : HeightOneSpectrum (𝓞 K) ↦
+        (1 - (1 : MultiplicativeIdealWeight K) P.asIdeal /
+          (Ideal.absNorm P.asIdeal : ℂ) ^ s)⁻¹ := by
+    funext P
+    rw [MultiplicativeIdealWeight.one_apply, ite_eq_right P.ne_bot, Complex.cpow_neg, one_div]
+  rw [hfun]
+  exact hprod
+
+end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean
@@ -35,8 +35,8 @@ product of the Dedekind zeta function.
   ideal-indexed Dirichlet series converges absolutely at `s`.
 * `TauCeti.MultiplicativeIdealWeight.hasProd_eulerFactor`: the same product, with the local factors
   in the closed geometric form available for a completely multiplicative weight.
-* `TauCeti.hasProd_dedekindZeta`: the **Euler product of the Dedekind zeta function**, valid on
-  `Re s > 1`.
+* `TauCeti.dedekindZeta_eulerProduct_hasProd`: the **Euler product of the Dedekind zeta
+  function**, valid on `Re s > 1`.
 
 No nonvanishing statement is made here. An unconditionally convergent product of nonzero factors
 may still vanish, so nonvanishing requires additional hypotheses such as convergence of the
@@ -139,6 +139,13 @@ theorem LSeriesSummable_localArithmeticFactor (hs : Summable (idealTerm K f s))
   rw [← normCoeff_supportedPart_singleton f P]
   exact LSeriesSummable_normCoeff K (summable_idealTerm_supportedPart hs _)
 
+/-- The norm coefficients of the restriction of `f` to no primes are Mathlib's Kronecker delta. -/
+theorem coe_normCoeff_supportedPart_empty (hf : f 1 = 1) :
+    ⇑(normCoeff K (supportedPart f (∅ : Set (HeightOneSpectrum (𝓞 K))))) = LSeries.delta := by
+  rw [supportedPart_empty hf, normCoeff_delta]
+  funext n
+  simp [ArithmeticFunction.one_apply, LSeries.delta]
+
 end IdealArithmeticFunction
 
 namespace EulerProductData
@@ -147,30 +154,60 @@ open IdealArithmeticFunction
 
 variable (D : EulerProductData K) {s : ℂ}
 
-/-- **The finite Euler product, analytically.** The `LSeries` of the norm coefficients of the
-restriction of `D` to a finite set `S` of primes is the finite product of the local Euler factors
-over `S`. -/
-theorem LSeries_normCoeff_supportedPart
+/-- Absolute convergence of the ideal-indexed Dirichlet series makes every bundled local Euler
+factor an absolutely convergent `LSeries`. -/
+theorem LSeriesSummable_localArithmeticFactor
     (hs : Summable (idealTerm K D.toIdealArithmeticFunction s))
-    (S : Finset (HeightOneSpectrum (𝓞 K))) :
+    (P : HeightOneSpectrum (𝓞 K)) :
+    LSeriesSummable (D.localArithmeticFactor P) s := by
+  rw [D.localArithmeticFactor_eq]
+  exact IdealArithmeticFunction.LSeriesSummable_localArithmeticFactor hs P
+
+/-- **Convergence of the finite Euler product.** Where the local Euler factors over a finite set
+`S` of primes are absolutely convergent `LSeries`, so are the norm coefficients of the restriction
+of `D` to `S`. -/
+theorem LSeriesSummable_normCoeff_supportedPart (S : Finset (HeightOneSpectrum (𝓞 K)))
+    (hS : ∀ P ∈ S, LSeriesSummable (D.localArithmeticFactor P) s) :
+    LSeriesSummable (normCoeff K (supportedPart D.toIdealArithmeticFunction
+      (S : Set (HeightOneSpectrum (𝓞 K))))) s := by
+  classical
+  induction S using Finset.induction_on with
+  | empty =>
+      rw [Finset.coe_empty, coe_normCoeff_supportedPart_empty D.isMultiplicative.map_one]
+      refine summable_of_ne_finset_zero (s := {1}) fun n hn ↦ ?_
+      simp only [Finset.mem_singleton] at hn
+      simp [LSeries.term_delta, hn]
+  | insert P S hPS ih =>
+      rw [Finset.coe_insert, supportedPart_insert D.isMultiplicative (by simpa using hPS),
+        normCoeff_convolution, normCoeff_supportedPart_singleton]
+      refine ArithmeticFunction.LSeriesSummable_mul
+        (ih fun Q hQ ↦ hS Q (Finset.mem_insert_of_mem hQ)) ?_
+      rw [← D.localArithmeticFactor_eq P]
+      exact hS P (Finset.mem_insert_self P S)
+
+/-- **The finite Euler product, analytically.** Where the local Euler factors over a finite set `S`
+of primes are absolutely convergent `LSeries`, the `LSeries` of the norm coefficients of the
+restriction of `D` to `S` is their finite product over `S`. -/
+theorem LSeries_normCoeff_supportedPart (S : Finset (HeightOneSpectrum (𝓞 K)))
+    (hS : ∀ P ∈ S, LSeriesSummable (D.localArithmeticFactor P) s) :
     LSeries (normCoeff K (supportedPart D.toIdealArithmeticFunction
       (S : Set (HeightOneSpectrum (𝓞 K))))) s = ∏ P ∈ S, D.eulerFactor P s := by
   classical
   induction S using Finset.induction_on with
   | empty =>
-      rw [Finset.coe_empty, supportedPart_empty D.isMultiplicative.map_one, normCoeff_delta,
-        Finset.prod_empty]
-      have hone : ⇑(1 : ArithmeticFunction ℂ) = LSeries.delta := by
-        funext n
-        simp [ArithmeticFunction.one_apply, LSeries.delta]
-      rw [hone, LSeries_delta, Pi.one_apply]
+      rw [Finset.coe_empty, coe_normCoeff_supportedPart_empty D.isMultiplicative.map_one,
+        LSeries_delta, Pi.one_apply, Finset.prod_empty]
   | insert P S hPS ih =>
-      have hS := LSeriesSummable_normCoeff K (summable_idealTerm_supportedPart hs
-        (S : Set (HeightOneSpectrum (𝓞 K))))
-      have hP := LSeriesSummable_normCoeff K (summable_idealTerm_supportedPart hs
-        ({P} : Set (HeightOneSpectrum (𝓞 K))))
+      have hSsum := D.LSeriesSummable_normCoeff_supportedPart S
+        fun Q hQ ↦ hS Q (Finset.mem_insert_of_mem hQ)
+      have hPsum : LSeriesSummable
+          (normCoeff K (supportedPart D.toIdealArithmeticFunction
+            ({P} : Set (HeightOneSpectrum (𝓞 K))))) s := by
+        rw [normCoeff_supportedPart_singleton, ← D.localArithmeticFactor_eq P]
+        exact hS P (Finset.mem_insert_self P S)
       rw [Finset.coe_insert, supportedPart_insert D.isMultiplicative (by simpa using hPS),
-        normCoeff_convolution, ArithmeticFunction.LSeries_mul' hS hP, ih,
+        normCoeff_convolution, ArithmeticFunction.LSeries_mul' hSsum hPsum,
+        ih fun Q hQ ↦ hS Q (Finset.mem_insert_of_mem hQ),
         normCoeff_supportedPart_singleton,
         Finset.prod_insert hPS, mul_comm]
       rw [eulerFactor_def, localArithmeticFactor_eq]
@@ -193,7 +230,8 @@ theorem hasProd_eulerFactor (hs : Summable (idealTerm K D.toIdealArithmeticFunct
         ∑' I, idealTerm K (supportedPart D.toIdealArithmeticFunction
           (S : Set (HeightOneSpectrum (𝓞 K)))) s I := by
     intro S
-    rw [← D.LSeries_normCoeff_supportedPart hs S,
+    rw [← D.LSeries_normCoeff_supportedPart S
+        fun P _ ↦ D.LSeriesSummable_localArithmeticFactor hs P,
       LSeries_normCoeff K (summable_idealTerm_supportedPart hs _)]
   rw [HasProd, SummationFilter.unconditional_filter, LSeries_normCoeff K hs]
   simp only [key]
@@ -251,7 +289,7 @@ theorem norm_div_lt_one_of_summable_idealTerm
 
 /-- The local Euler factor of a completely multiplicative weight is the geometric closed form
 `(1 - χ(P) N(P)⁻ˢ)⁻¹`. -/
-theorem eulerFactor_toIdealArithmeticFunction
+theorem eulerFactor_ofMultiplicativeIdealWeight
     (P : HeightOneSpectrum (𝓞 K))
     (hP : ‖χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s‖ < 1) :
     (EulerProductData.ofMultiplicativeIdealWeight χ).eulerFactor P s =
@@ -269,7 +307,7 @@ theorem hasProd_eulerFactor (hs : Summable (idealTerm K χ.toIdealArithmeticFunc
   have hfun : (fun P : HeightOneSpectrum (𝓞 K) ↦
       (1 - χ P.asIdeal / (Ideal.absNorm P.asIdeal : ℂ) ^ s)⁻¹) =
       fun P ↦ (EulerProductData.ofMultiplicativeIdealWeight χ).eulerFactor P s :=
-    funext fun P ↦ (eulerFactor_toIdealArithmeticFunction χ P
+    funext fun P ↦ (eulerFactor_ofMultiplicativeIdealWeight χ P
       (norm_div_lt_one_of_summable_idealTerm χ hs P)).symm
   rw [hfun]
   have hprod := (EulerProductData.ofMultiplicativeIdealWeight χ).hasProd_eulerFactor
@@ -288,7 +326,7 @@ of `K` is the unrestricted product over the height-one primes of `𝓞 K` of the
 This is the ideal-theoretic counterpart of Mathlib's `riemannZeta_eulerProduct_hasProd`, and it
 is not obtained from it: the product is indexed by the primes of `𝓞 K`, whose norms repeat and
 whose count above a rational prime is the splitting behaviour of `K`. -/
-theorem hasProd_dedekindZeta {s : ℂ} (hs : 1 < s.re) :
+theorem dedekindZeta_eulerProduct_hasProd {s : ℂ} (hs : 1 < s.re) :
     HasProd (fun P : HeightOneSpectrum (𝓞 K) ↦ (1 - (Ideal.absNorm P.asIdeal : ℂ) ^ (-s))⁻¹)
       (NumberField.dedekindZeta K s) := by
   have hsum : Summable (idealTerm K

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Basic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Basic.lean
@@ -81,10 +81,10 @@ this identity holds for any multiplicative `f` with no further data.
 
 public section
 
-namespace TauCeti
-
 open scoped nonZeroDivisors NumberField
 open IsDedekindDomain (HeightOneSpectrum)
+
+namespace IsDedekindDomain.HeightOneSpectrum
 
 variable {K : Type*} [Field K]
 
@@ -111,6 +111,10 @@ theorem primeIdealPow_injective (P : HeightOneSpectrum (𝓞 K)) :
   Nat.pow_right_injective (NumberField.HeightOneSpectrum.one_lt_absNorm P)
     (by simpa only [absNorm_primeIdealPow] using
       congrArg (fun I : (Ideal (𝓞 K))⁰ ↦ Ideal.absNorm (I : Ideal (𝓞 K))) h)
+
+end IsDedekindDomain.HeightOneSpectrum
+
+namespace TauCeti
 
 /-- **Every nonzero ideal is eventually supported.** A finite set of height-one primes that
 contains all primes of norm at most `Ideal.absNorm A` already contains every prime divisor of `A`,
@@ -152,9 +156,9 @@ omit [NumberField K] in
 theorem coeff_localPowerSeries (f : IdealArithmeticFunction K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     PowerSeries.coeff n (localPowerSeries f P) =
-      f (primeIdealPow P n) := by
+      f (P.primeIdealPow n) := by
   simp only [localPowerSeries, PowerSeries.coeff_mk]
-  exact congrArg f (Subtype.ext (coe_primeIdealPow P n).symm)
+  exact congrArg f (Subtype.ext (P.coe_primeIdealPow n).symm)
 
 omit [NumberField K] in
 /-- The constant coefficient of the canonical local power series is `f 1`. -/
@@ -185,7 +189,7 @@ theorem localArithmeticFactor_def (f : IdealArithmeticFunction K)
 theorem localArithmeticFactor_apply_pow (f : IdealArithmeticFunction K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     localArithmeticFactor f P (Ideal.absNorm P.asIdeal ^ n) =
-      f (primeIdealPow P n) := by
+      f (P.primeIdealPow n) := by
   rw [localArithmeticFactor, ArithmeticFunction.ofPowerSeries_apply_pow
     (NumberField.HeightOneSpectrum.one_lt_absNorm P)]
   exact coeff_localPowerSeries f P n

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Basic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Basic.lean
@@ -412,30 +412,37 @@ theorem normCoeff_supportedPart (hf : f.IsMultiplicative)
       rw [Finset.coe_insert, supportedPart_insert hf (by simpa using hPS), normCoeff_convolution,
         ih, normCoeff_supportedPart_singleton, Finset.prod_insert hPS, mul_comm]
 
+/-- **Every nonzero ideal is eventually supported.** A finite set of height-one primes that
+contains all primes of norm at most `Ideal.absNorm A` already contains every prime divisor of `A`,
+and those bounded-norm sets are cofinal by the Northcott property of the absolute norm. -/
+theorem eventually_isPrimeTo_compl (A : (Ideal (𝓞 K))⁰) :
+    ∀ᶠ S : Finset (HeightOneSpectrum (𝓞 K)) in Filter.atTop,
+      Ideal.IsPrimeTo (A : Ideal (𝓞 K)) (S : Set (HeightOneSpectrum (𝓞 K)))ᶜ := by
+  classical
+  let T : Finset (HeightOneSpectrum (𝓞 K)) :=
+    (Northcott.finite_le (h := fun P : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm P.asIdeal)
+      (Ideal.absNorm (A : Ideal (𝓞 K)))).toFinset
+  filter_upwards [Filter.eventually_ge_atTop T] with S hTS
+  rw [Ideal.isPrimeTo_iff]
+  refine ⟨nonZeroDivisors.coe_ne_zero A, fun P hP hPdvd ↦ hP ?_⟩
+  have hnormP : Ideal.absNorm P.asIdeal ≤ Ideal.absNorm (A : Ideal (𝓞 K)) :=
+    Nat.le_of_dvd (Ideal.absNorm_pos_of_nonZeroDivisors A)
+      (Ideal.absNorm_dvd_absNorm_of_le (Ideal.dvd_iff_le.mp hPdvd))
+  exact hTS ((Northcott.finite_le
+    (h := fun P : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm P.asIdeal)
+    (Ideal.absNorm (A : Ideal (𝓞 K)))).mem_toFinset.mpr hnormP)
+
 /-- At a fixed coefficient, restricting to a sufficiently large finite set of prime ideals does
-not change the norm coefficient. One may take all prime ideals of norm at most `n`: every prime
-divisor of an ideal of norm `n` belongs to that finite set. -/
+not change the norm coefficient: the norm fibre is finite, and each of its members is eventually
+supported. -/
 theorem eventually_normCoeff_supportedPart_eq (f : IdealArithmeticFunction K) (n : ℕ) :
     ∀ᶠ S : Finset (HeightOneSpectrum (𝓞 K)) in Filter.atTop,
       normCoeff K (supportedPart f (S : Set (HeightOneSpectrum (𝓞 K)))) n =
         normCoeff K f n := by
-  classical
-  let T : Finset (HeightOneSpectrum (𝓞 K)) :=
-    (Northcott.finite_le
-      (h := fun P : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm P.asIdeal) n).toFinset
-  filter_upwards [Filter.eventually_ge_atTop T] with S hTS
+  filter_upwards [(Filter.eventually_all_finset (normFiber K n)).mpr
+    fun A _ ↦ eventually_isPrimeTo_compl A] with S hS
   rw [normCoeff_eq_sum_normFiber, normCoeff_eq_sum_normFiber]
-  refine Finset.sum_congr rfl fun A hA ↦ supportedPart_apply_of_isPrimeTo_compl ?_
-  rw [Ideal.isPrimeTo_iff]
-  refine ⟨nonZeroDivisors.coe_ne_zero A, fun P hP hPdvd ↦ hP ?_⟩
-  have hnormP : Ideal.absNorm P.asIdeal ≤ n := by
-    have hnormdvd : Ideal.absNorm P.asIdeal ∣ Ideal.absNorm (A : Ideal (𝓞 K)) :=
-      Ideal.absNorm_dvd_absNorm_of_le (Ideal.dvd_iff_le.mp hPdvd)
-    have hnormA : Ideal.absNorm (A : Ideal (𝓞 K)) = n := (mem_normFiber K).mp hA
-    rw [hnormA] at hnormdvd
-    exact Nat.le_of_dvd (hnormA ▸ Ideal.absNorm_pos_of_nonZeroDivisors A) hnormdvd
-  exact hTS ((Northcott.finite_le
-    (h := fun P : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm P.asIdeal) n).mem_toFinset.mpr hnormP)
+  exact Finset.sum_congr rfl fun A hA ↦ supportedPart_apply_of_isPrimeTo_compl (hS A hA)
 
 /-- **The formal Euler product of norm coefficients.** The norm coefficients of a multiplicative
 ideal arithmetic function are Mathlib's `ArithmeticFunction.eulerProduct` of the canonical local

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Basic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Basic.lean
@@ -86,8 +86,6 @@ namespace TauCeti
 open scoped nonZeroDivisors NumberField
 open IsDedekindDomain (HeightOneSpectrum)
 
-namespace HeightOneSpectrum
-
 variable {K : Type*} [Field K]
 
 /-- The `e`-th power of a height-one prime of `𝓞 K`, as a nonzero integral ideal. -/
@@ -103,7 +101,6 @@ theorem coe_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
 variable [NumberField K]
 
 /-- The absolute norm is multiplicative on prime powers. -/
-@[simp]
 theorem absNorm_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
     Ideal.absNorm (primeIdealPow P e : Ideal (𝓞 K)) = Ideal.absNorm P.asIdeal ^ e := by
   rw [coe_primeIdealPow, map_pow]
@@ -114,8 +111,6 @@ theorem primeIdealPow_injective (P : HeightOneSpectrum (𝓞 K)) :
   Nat.pow_right_injective (NumberField.HeightOneSpectrum.one_lt_absNorm P)
     (by simpa only [absNorm_primeIdealPow] using
       congrArg (fun I : (Ideal (𝓞 K))⁰ ↦ Ideal.absNorm (I : Ideal (𝓞 K))) h)
-
-end HeightOneSpectrum
 
 /-- **Every nonzero ideal is eventually supported.** A finite set of height-one primes that
 contains all primes of norm at most `Ideal.absNorm A` already contains every prime divisor of `A`,
@@ -157,9 +152,9 @@ omit [NumberField K] in
 theorem coeff_localPowerSeries (f : IdealArithmeticFunction K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     PowerSeries.coeff n (localPowerSeries f P) =
-      f (HeightOneSpectrum.primeIdealPow P n) := by
+      f (primeIdealPow P n) := by
   simp only [localPowerSeries, PowerSeries.coeff_mk]
-  exact congrArg f (Subtype.ext (HeightOneSpectrum.coe_primeIdealPow P n).symm)
+  exact congrArg f (Subtype.ext (coe_primeIdealPow P n).symm)
 
 omit [NumberField K] in
 /-- The constant coefficient of the canonical local power series is `f 1`. -/
@@ -190,7 +185,7 @@ theorem localArithmeticFactor_def (f : IdealArithmeticFunction K)
 theorem localArithmeticFactor_apply_pow (f : IdealArithmeticFunction K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     localArithmeticFactor f P (Ideal.absNorm P.asIdeal ^ n) =
-      f (HeightOneSpectrum.primeIdealPow P n) := by
+      f (primeIdealPow P n) := by
   rw [localArithmeticFactor, ArithmeticFunction.ofPowerSeries_apply_pow
     (NumberField.HeightOneSpectrum.one_lt_absNorm P)]
   exact coeff_localPowerSeries f P n

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Basic.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Basic.lean
@@ -86,6 +86,58 @@ namespace TauCeti
 open scoped nonZeroDivisors NumberField
 open IsDedekindDomain (HeightOneSpectrum)
 
+namespace HeightOneSpectrum
+
+variable {K : Type*} [Field K]
+
+/-- The `e`-th power of a height-one prime of `𝓞 K`, as a nonzero integral ideal. -/
+def primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) : (Ideal (𝓞 K))⁰ :=
+  ⟨P.asIdeal ^ e, mem_nonZeroDivisors_of_ne_zero (pow_ne_zero e P.ne_bot)⟩
+
+/-- A prime power, as a nonzero integral ideal, has the expected underlying ideal. -/
+@[simp]
+theorem coe_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
+    (primeIdealPow P e : Ideal (𝓞 K)) = P.asIdeal ^ e :=
+  (rfl)
+
+variable [NumberField K]
+
+/-- The absolute norm is multiplicative on prime powers. -/
+@[simp]
+theorem absNorm_primeIdealPow (P : HeightOneSpectrum (𝓞 K)) (e : ℕ) :
+    Ideal.absNorm (primeIdealPow P e : Ideal (𝓞 K)) = Ideal.absNorm P.asIdeal ^ e := by
+  rw [coe_primeIdealPow, map_pow]
+
+/-- Distinct exponents give distinct prime powers. -/
+theorem primeIdealPow_injective (P : HeightOneSpectrum (𝓞 K)) :
+    Function.Injective (primeIdealPow P) := fun m n h ↦
+  Nat.pow_right_injective (NumberField.HeightOneSpectrum.one_lt_absNorm P)
+    (by simpa only [absNorm_primeIdealPow] using
+      congrArg (fun I : (Ideal (𝓞 K))⁰ ↦ Ideal.absNorm (I : Ideal (𝓞 K))) h)
+
+end HeightOneSpectrum
+
+/-- **Every nonzero ideal is eventually supported.** A finite set of height-one primes that
+contains all primes of norm at most `Ideal.absNorm A` already contains every prime divisor of `A`,
+and those bounded-norm sets are cofinal by the Northcott property of the absolute norm. -/
+theorem eventually_isPrimeTo_compl {K : Type*} [Field K] [NumberField K]
+    (A : (Ideal (𝓞 K))⁰) :
+    ∀ᶠ S : Finset (HeightOneSpectrum (𝓞 K)) in Filter.atTop,
+      Ideal.IsPrimeTo (A : Ideal (𝓞 K)) (S : Set (HeightOneSpectrum (𝓞 K)))ᶜ := by
+  classical
+  let T : Finset (HeightOneSpectrum (𝓞 K)) :=
+    (Northcott.finite_le (h := fun P : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm P.asIdeal)
+      (Ideal.absNorm (A : Ideal (𝓞 K)))).toFinset
+  filter_upwards [Filter.eventually_ge_atTop T] with S hTS
+  rw [Ideal.isPrimeTo_iff]
+  refine ⟨nonZeroDivisors.coe_ne_zero A, fun P hP hPdvd ↦ hP ?_⟩
+  have hnormP : Ideal.absNorm P.asIdeal ≤ Ideal.absNorm (A : Ideal (𝓞 K)) :=
+    Nat.le_of_dvd (Ideal.absNorm_pos_of_nonZeroDivisors A)
+      (Ideal.absNorm_dvd_absNorm_of_le (Ideal.dvd_iff_le.mp hPdvd))
+  exact hTS ((Northcott.finite_le
+    (h := fun P : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm P.asIdeal)
+    (Ideal.absNorm (A : Ideal (𝓞 K)))).mem_toFinset.mpr hnormP)
+
 namespace IdealArithmeticFunction
 
 variable {K : Type*} [Field K]
@@ -105,8 +157,9 @@ omit [NumberField K] in
 theorem coeff_localPowerSeries (f : IdealArithmeticFunction K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     PowerSeries.coeff n (localPowerSeries f P) =
-      f ⟨P.asIdeal ^ n, mem_nonZeroDivisors_of_ne_zero (pow_ne_zero n P.ne_bot)⟩ := by
-  simp [localPowerSeries]
+      f (HeightOneSpectrum.primeIdealPow P n) := by
+  simp only [localPowerSeries, PowerSeries.coeff_mk]
+  exact congrArg f (Subtype.ext (HeightOneSpectrum.coe_primeIdealPow P n).symm)
 
 omit [NumberField K] in
 /-- The constant coefficient of the canonical local power series is `f 1`. -/
@@ -137,7 +190,7 @@ theorem localArithmeticFactor_def (f : IdealArithmeticFunction K)
 theorem localArithmeticFactor_apply_pow (f : IdealArithmeticFunction K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     localArithmeticFactor f P (Ideal.absNorm P.asIdeal ^ n) =
-      f ⟨P.asIdeal ^ n, mem_nonZeroDivisors_of_ne_zero (pow_ne_zero n P.ne_bot)⟩ := by
+      f (HeightOneSpectrum.primeIdealPow P n) := by
   rw [localArithmeticFactor, ArithmeticFunction.ofPowerSeries_apply_pow
     (NumberField.HeightOneSpectrum.one_lt_absNorm P)]
   exact coeff_localPowerSeries f P n
@@ -411,26 +464,6 @@ theorem normCoeff_supportedPart (hf : f.IsMultiplicative)
   | insert P S hPS ih =>
       rw [Finset.coe_insert, supportedPart_insert hf (by simpa using hPS), normCoeff_convolution,
         ih, normCoeff_supportedPart_singleton, Finset.prod_insert hPS, mul_comm]
-
-/-- **Every nonzero ideal is eventually supported.** A finite set of height-one primes that
-contains all primes of norm at most `Ideal.absNorm A` already contains every prime divisor of `A`,
-and those bounded-norm sets are cofinal by the Northcott property of the absolute norm. -/
-theorem eventually_isPrimeTo_compl (A : (Ideal (𝓞 K))⁰) :
-    ∀ᶠ S : Finset (HeightOneSpectrum (𝓞 K)) in Filter.atTop,
-      Ideal.IsPrimeTo (A : Ideal (𝓞 K)) (S : Set (HeightOneSpectrum (𝓞 K)))ᶜ := by
-  classical
-  let T : Finset (HeightOneSpectrum (𝓞 K)) :=
-    (Northcott.finite_le (h := fun P : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm P.asIdeal)
-      (Ideal.absNorm (A : Ideal (𝓞 K)))).toFinset
-  filter_upwards [Filter.eventually_ge_atTop T] with S hTS
-  rw [Ideal.isPrimeTo_iff]
-  refine ⟨nonZeroDivisors.coe_ne_zero A, fun P hP hPdvd ↦ hP ?_⟩
-  have hnormP : Ideal.absNorm P.asIdeal ≤ Ideal.absNorm (A : Ideal (𝓞 K)) :=
-    Nat.le_of_dvd (Ideal.absNorm_pos_of_nonZeroDivisors A)
-      (Ideal.absNorm_dvd_absNorm_of_le (Ideal.dvd_iff_le.mp hPdvd))
-  exact hTS ((Northcott.finite_le
-    (h := fun P : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm P.asIdeal)
-    (Ideal.absNorm (A : Ideal (𝓞 K)))).mem_toFinset.mpr hnormP)
 
 /-- At a fixed coefficient, restricting to a sufficiently large finite set of prime ideals does
 not change the norm coefficient: the norm fibre is finite, and each of its members is eventually

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Data.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Data.lean
@@ -86,13 +86,19 @@ noncomputable def localPowerSeries (D : EulerProductData K)
 theorem coeff_localPowerSeries (D : EulerProductData K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     PowerSeries.coeff n (D.localPowerSeries P) =
-      D ⟨P.asIdeal ^ n, mem_nonZeroDivisors_of_ne_zero (pow_ne_zero n P.ne_bot)⟩ :=
+      D (HeightOneSpectrum.primeIdealPow P n) :=
   IdealArithmeticFunction.coeff_localPowerSeries D.toIdealArithmeticFunction P n
 
 /-- The canonical local arithmetic factor of bundled Euler-product data at a height-one prime. -/
 noncomputable def localArithmeticFactor (D : EulerProductData K)
     (P : HeightOneSpectrum (𝓞 K)) : ArithmeticFunction ℂ :=
   D.toIdealArithmeticFunction.localArithmeticFactor P
+
+/-- The bundled local arithmetic factor is the canonical factor of its coefficient function. -/
+theorem localArithmeticFactor_eq (D : EulerProductData K)
+    (P : HeightOneSpectrum (𝓞 K)) :
+    D.localArithmeticFactor P = D.toIdealArithmeticFunction.localArithmeticFactor P :=
+  (rfl)
 
 /-- The bundled local arithmetic factor is Mathlib's arithmetic function associated to the
 bundled local power series at `P`. -/
@@ -108,7 +114,7 @@ coefficient. -/
 theorem localArithmeticFactor_apply_pow (D : EulerProductData K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     D.localArithmeticFactor P (Ideal.absNorm P.asIdeal ^ n) =
-      D ⟨P.asIdeal ^ n, mem_nonZeroDivisors_of_ne_zero (pow_ne_zero n P.ne_bot)⟩ :=
+      D (HeightOneSpectrum.primeIdealPow P n) :=
   IdealArithmeticFunction.localArithmeticFactor_apply_pow D.toIdealArithmeticFunction P n
 
 /-- Away from the powers of `N(P)`, the bundled local arithmetic factor vanishes. Together with
@@ -133,6 +139,13 @@ noncomputable def ofMultiplicativeIdealWeight (χ : MultiplicativeIdealWeight K)
     EulerProductData K where
   toIdealArithmeticFunction := χ.toIdealArithmeticFunction
   isMultiplicative := χ.isMultiplicative_toIdealArithmeticFunction
+
+/-- The coefficient function underlying the Euler-product data of a multiplicative ideal weight. -/
+@[simp]
+theorem toIdealArithmeticFunction_ofMultiplicativeIdealWeight (χ : MultiplicativeIdealWeight K) :
+    (ofMultiplicativeIdealWeight χ).toIdealArithmeticFunction = χ.toIdealArithmeticFunction := by
+  funext I
+  rfl
 
 @[simp]
 theorem ofMultiplicativeIdealWeight_apply (χ : MultiplicativeIdealWeight K)

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Data.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Data.lean
@@ -86,7 +86,7 @@ noncomputable def localPowerSeries (D : EulerProductData K)
 theorem coeff_localPowerSeries (D : EulerProductData K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     PowerSeries.coeff n (D.localPowerSeries P) =
-      D (primeIdealPow P n) :=
+      D (P.primeIdealPow n) :=
   IdealArithmeticFunction.coeff_localPowerSeries D.toIdealArithmeticFunction P n
 
 /-- The canonical local arithmetic factor of bundled Euler-product data at a height-one prime. -/
@@ -114,7 +114,7 @@ coefficient. -/
 theorem localArithmeticFactor_apply_pow (D : EulerProductData K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     D.localArithmeticFactor P (Ideal.absNorm P.asIdeal ^ n) =
-      D (primeIdealPow P n) :=
+      D (P.primeIdealPow n) :=
   IdealArithmeticFunction.localArithmeticFactor_apply_pow D.toIdealArithmeticFunction P n
 
 /-- Away from the powers of `N(P)`, the bundled local arithmetic factor vanishes. Together with

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Data.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Data.lean
@@ -86,7 +86,7 @@ noncomputable def localPowerSeries (D : EulerProductData K)
 theorem coeff_localPowerSeries (D : EulerProductData K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     PowerSeries.coeff n (D.localPowerSeries P) =
-      D (HeightOneSpectrum.primeIdealPow P n) :=
+      D (primeIdealPow P n) :=
   IdealArithmeticFunction.coeff_localPowerSeries D.toIdealArithmeticFunction P n
 
 /-- The canonical local arithmetic factor of bundled Euler-product data at a height-one prime. -/
@@ -114,7 +114,7 @@ coefficient. -/
 theorem localArithmeticFactor_apply_pow (D : EulerProductData K)
     (P : HeightOneSpectrum (𝓞 K)) (n : ℕ) :
     D.localArithmeticFactor P (Ideal.absNorm P.asIdeal ^ n) =
-      D (HeightOneSpectrum.primeIdealPow P n) :=
+      D (primeIdealPow P n) :=
   IdealArithmeticFunction.localArithmeticFactor_apply_pow D.toIdealArithmeticFunction P n
 
 /-- Away from the powers of `N(P)`, the bundled local arithmetic factor vanishes. Together with


### PR DESCRIPTION
This PR proves the analytic Euler product over the prime ideals of a number field: if a multiplicative ideal arithmetic function `f` has an absolutely convergent ideal-indexed Dirichlet series at `s`, then its local Euler factors have an unrestricted infinite product over `IsDedekindDomain.HeightOneSpectrum (𝓞 K)`, and that product is `LSeries (normCoeff f) s`. This is Layer **3.3** of `TauCetiRoadmap/ArithmeticDirichletSeries/README.md` ("Infinite Euler product: under absolute convergence, pass to the directed limit of finite prime sets and identify the product with `LSeries (normCoeff f)`"), which until now existed only formally: `TauCeti.IdealArithmeticFunction.normCoeff_eq_eulerProduct` matched coefficients with Mathlib's `ArithmeticFunction.eulerProduct` and carried no convergence content. Layer 3 is the roadmap's open link on the path `0 → 1 → 3 → 7.2`, and the all-prime normalization `P_all(s) = log(1/(s-1)) + O(1)` of Layer 7.2 is stated by the README to need exactly this Euler product, the Dedekind-zeta residue alone being insufficient.

The new module is `TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct/Analytic.lean` (346 lines). It defines `TauCeti.primeIdealPow`, the `e`-th power of a height-one prime as a nonzero integral ideal, and `TauCeti.IdealArithmeticFunction.eulerFactor`, the local factor at a prime, shown in `eulerFactor_eq_tsum` to be the prime-power Dirichlet series `∑' e, f (P ^ e) / N(P ^ e) ^ s`. The finite partial products are obtained by regrouping rather than by a second combinatorial induction: the existing `normCoeff_supportedPart` already writes the restriction of `f` to the ideals supported on a finite prime set as a Dirichlet convolution of local factors, and Mathlib's `ArithmeticFunction.LSeries_mul'` turns that convolution into a product of `LSeries` values, giving `LSeries_normCoeff_supportedPart`. The passage to the limit is then Tannery's theorem `tendsto_tsum_of_dominated_convergence`, with the ideal terms of `f` as the dominating bound: each partial product is literally the ideal-indexed sum restricted to the supported ideals, and every fixed ideal is eventually supported. The summit is `hasProd_eulerFactor`, with `multipliable_eulerFactor` and `tprod_eulerFactor` beside it.

For a completely multiplicative weight the prime-power series is geometric, so `MultiplicativeIdealWeight.eulerFactor_ofMultiplicativeIdealWeight` puts the local factor into closed form `(1 - χ(𝔭) N(𝔭)⁻ˢ)⁻¹`; the modulus bound it needs is not assumed but derived, in `norm_div_lt_one_of_summable_idealTerm`, from the geometric subseries the powers of a single prime already contribute. Specializing to the trivial weight and combining with the exact abscissa of Layer 5 gives `TauCeti.dedekindZeta_eulerProduct_hasProd`: for `Re s > 1` the Dedekind zeta function of `K` is the product over the height-one primes of `(1 - N(𝔭)^(-s))⁻¹`. This is the ideal-theoretic counterpart of Mathlib's `riemannZeta_eulerProduct_hasProd` and is not obtained from it, since the product is indexed by the primes of `𝓞 K`, whose norms repeat according to splitting behaviour; Mathlib's `NumberField.dedekindZeta` has no Euler product.

No nonvanishing statement is made. An unconditionally convergent product of nonzero factors can still vanish, so nonvanishing needs convergence of the reciprocal product; the README's Layer 3.3 asks for it only "where absolute convergence of the reciprocal product proves it", and that, together with 3.4 (choice of logarithm and the logarithmic expansion) and 2.3 (the von Mangoldt coefficient identity for the logarithmic derivative), is what remains of Layer 3 after this PR before Layer 7.2 can be attempted.

The one change to an existing file factors the reusable half of `eventually_normCoeff_supportedPart_eq` out as `TauCeti.IdealArithmeticFunction.eventually_isPrimeTo_compl` — every nonzero ideal is supported on all sufficiently large finite sets of primes — and reproves the coefficient statement from it over the finite norm fibre. That lemma is the input to the Tannery argument here; no declaration was renamed or removed.

Verified with `lake build` and `lake exe axioms`, both green.

Roadmap: ArithmeticDirichletSeries

<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"analytic-euler-product-lseries-normcoeff"}-->

🤖 Prepared with Claude Code
