### PR TITLE
feat(MordellWeil): the semilocal comparison of 2-descent at the good places

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
@@ -159,10 +159,7 @@ theorem finite_selmerGroupA
     (AdjoinRoot.modPowEquivPiFactors W.f_ne_zero W.squarefree_f 2)
 
 /-- Membership of the class of a unit in the `2`-Selmer group of a field factor: its valuation is
-even at every prime of the ring of integers not lying above a bad prime.
-
-Proved through `mem_selmerGroupAbove_iff` rather than by unfolding: `selmerGroupAbove` is not
-`@[expose]`, so its definition is unavailable here, and only its characterising lemma is. -/
+even at every prime of the ring of integers not lying above a bad prime. -/
 @[simp]
 lemma mem_selmerGroupFactor_unit_iff (p : W.f.Factors) (u : (𝕃 p)ˣ) :
     (QuotientGroup.mk u : (𝕃 p)ˣ ⧸ (powMonoidHom 2 : (𝕃 p)ˣ →* (𝕃 p)ˣ).range) ∈
@@ -170,6 +167,8 @@ lemma mem_selmerGroupFactor_unit_iff (p : W.f.Factors) (u : (𝕃 p)ˣ) :
       ∀ w : HeightOneSpectrum (W.ringOfIntegersFactor R p),
         w ∉ HeightOneSpectrum.primesAbove R (W.ringOfIntegersFactor R p) (W.badPrimes R) →
           (2 : ℤ) ∣ Multiplicative.toAdd (w.valuationOfNeZero u) := by
+  -- through `mem_selmerGroupAbove_iff` rather than by unfolding: `selmerGroupAbove` is not
+  -- `@[expose]`, so only its characterising lemma is available here.
   rw [selmerGroupFactor, mem_selmerGroupAbove_iff]
   exact forall₂_congr fun w _ ↦ HeightOneSpectrum.valuationOfNeZeroMod_mk_eq_one_iff w 2 u
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
@@ -182,6 +182,7 @@ integers not lying above a bad prime.
 The unit-level form of `mem_selmerGroupA_iff`. It is the form the semilocal comparison at the good
 finite places is stated against, because there the square class is always presented by an explicit
 unit of `W.A`. -/
+@[simp]
 lemma mem_selmerGroupA_unit_iff (a : W.Aˣ) :
     (QuotientGroup.mk a : W.M) ∈ W.selmerGroupA R ↔
       ∀ (p : W.f.Factors) (w : HeightOneSpectrum (W.ringOfIntegersFactor R p)),

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
@@ -45,8 +45,6 @@ componentwise statement into one about `W.M` along the decomposition `modPowEqui
 
 * `WeierstrassCurve.Affine.mem_selmerGroupFactor_unit_iff`: a class of units lies in the Selmer
   group of a factor exactly when its valuation is even at every good prime.
-* `WeierstrassCurve.Affine.mem_selmerGroupA_unit_iff`: the same criterion for `A(S,2)` itself,
-  applied componentwise to the `projFactor`-components of a unit of `W.A`.
 * `WeierstrassCurve.Affine.μX_component_mem_selmerGroupFactor`: each component of `μX x` lies in
   the Selmer group of its factor.
 * `WeierstrassCurve.Affine.range_μ_le_selmerGroupA`: **Step 6**.
@@ -174,30 +172,6 @@ lemma mem_selmerGroupFactor_unit_iff (p : W.f.Factors) (u : (𝕃 p)ˣ) :
           (2 : ℤ) ∣ Multiplicative.toAdd (w.valuationOfNeZero u) := by
   rw [selmerGroupFactor, mem_selmerGroupAbove_iff]
   exact forall₂_congr fun w _ ↦ HeightOneSpectrum.valuationOfNeZeroMod_mk_eq_one_iff w 2 u
-
-/-- Membership of the class of a unit of the étale algebra in `A(S,2)`, componentwise: the
-valuation of each `projFactor`-component is even at every prime of the corresponding ring of
-integers not lying above a bad prime.
-
-The unit-level form of `mem_selmerGroupA_iff`. It is the form the semilocal comparison at the good
-finite places is stated against, because there the square class is always presented by an explicit
-unit of `W.A`.
-
-Not `@[simp]`, although its per-factor sibling `mem_selmerGroupFactor_unit_iff` is: with
-`mem_selmerGroupA_iff` and that sibling both marked, `simpNF` rejects this one — "simp can prove
-this" — because the two together already reduce it. Every consumer names it explicitly, so nothing
-depends on the attribute. This is the same situation as
-`IsDedekindDomain.HeightOneSpectrum.valuationOfNeZero_eq_one_iff`. -/
-lemma mem_selmerGroupA_unit_iff (a : W.Aˣ) :
-    (QuotientGroup.mk a : W.M) ∈ W.selmerGroupA R ↔
-      ∀ (p : W.f.Factors) (w : HeightOneSpectrum (W.ringOfIntegersFactor R p)),
-        w ∉ HeightOneSpectrum.primesAbove R (W.ringOfIntegersFactor R p) (W.badPrimes R) →
-          (2 : ℤ) ∣ Multiplicative.toAdd (w.valuationOfNeZero
-            (Units.map
-              (AdjoinRoot.projFactor W.f_ne_zero W.squarefree_f p).toRingHom.toMonoidHom a)) := by
-  rw [mem_selmerGroupA_iff]
-  exact forall_congr' fun p ↦ by
-    rw [AdjoinRoot.modPowEquivPiFactors_mk, mem_selmerGroupFactor_unit_iff]
 
 /-- Generic case of the arithmetic input: `f x ≠ 0`, so the `p`-component of `μX x` is the class
 of `x - θ`. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
@@ -181,8 +181,13 @@ integers not lying above a bad prime.
 
 The unit-level form of `mem_selmerGroupA_iff`. It is the form the semilocal comparison at the good
 finite places is stated against, because there the square class is always presented by an explicit
-unit of `W.A`. -/
-@[simp]
+unit of `W.A`.
+
+Not `@[simp]`, although its per-factor sibling `mem_selmerGroupFactor_unit_iff` is: with
+`mem_selmerGroupA_iff` and that sibling both marked, `simpNF` rejects this one — "simp can prove
+this" — because the two together already reduce it. Every consumer names it explicitly, so nothing
+depends on the attribute. This is the same situation as
+`IsDedekindDomain.HeightOneSpectrum.valuationOfNeZero_eq_one_iff`. -/
 lemma mem_selmerGroupA_unit_iff (a : W.Aˣ) :
     (QuotientGroup.mk a : W.M) ∈ W.selmerGroupA R ↔
       ∀ (p : W.f.Factors) (w : HeightOneSpectrum (W.ringOfIntegersFactor R p)),

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
@@ -45,6 +45,8 @@ componentwise statement into one about `W.M` along the decomposition `modPowEqui
 
 * `WeierstrassCurve.Affine.mem_selmerGroupFactor_unit_iff`: a class of units lies in the Selmer
   group of a factor exactly when its valuation is even at every good prime.
+* `WeierstrassCurve.Affine.mem_selmerGroupA_unit_iff`: the same criterion for `A(S,2)` itself,
+  applied componentwise to the `projFactor`-components of a unit of `W.A`.
 * `WeierstrassCurve.Affine.μX_component_mem_selmerGroupFactor`: each component of `μX x` lies in
   the Selmer group of its factor.
 * `WeierstrassCurve.Affine.range_μ_le_selmerGroupA`: **Step 6**.
@@ -172,6 +174,24 @@ lemma mem_selmerGroupFactor_unit_iff (p : W.f.Factors) (u : (𝕃 p)ˣ) :
           (2 : ℤ) ∣ Multiplicative.toAdd (w.valuationOfNeZero u) := by
   rw [selmerGroupFactor, mem_selmerGroupAbove_iff]
   exact forall₂_congr fun w _ ↦ HeightOneSpectrum.valuationOfNeZeroMod_mk_eq_one_iff w 2 u
+
+/-- Membership of the class of a unit of the étale algebra in `A(S,2)`, componentwise: the
+valuation of each `projFactor`-component is even at every prime of the corresponding ring of
+integers not lying above a bad prime.
+
+The unit-level form of `mem_selmerGroupA_iff`. It is the form the semilocal comparison at the good
+finite places is stated against, because there the square class is always presented by an explicit
+unit of `W.A`. -/
+lemma mem_selmerGroupA_unit_iff (a : W.Aˣ) :
+    (QuotientGroup.mk a : W.M) ∈ W.selmerGroupA R ↔
+      ∀ (p : W.f.Factors) (w : HeightOneSpectrum (W.ringOfIntegersFactor R p)),
+        w ∉ HeightOneSpectrum.primesAbove R (W.ringOfIntegersFactor R p) (W.badPrimes R) →
+          (2 : ℤ) ∣ Multiplicative.toAdd (w.valuationOfNeZero
+            (Units.map
+              (AdjoinRoot.projFactor W.f_ne_zero W.squarefree_f p).toRingHom.toMonoidHom a)) := by
+  rw [mem_selmerGroupA_iff]
+  exact forall_congr' fun p ↦ by
+    rw [AdjoinRoot.modPowEquivPiFactors_mk, mem_selmerGroupFactor_unit_iff]
 
 /-- Generic case of the arithmetic input: `f x ≠ 0`, so the `p`-component of `μX x` is the class
 of `x - θ`. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
@@ -38,24 +38,12 @@ places.
 
 ## Implementation notes
 
-Both directions rest on the same mechanism: parity of a valuation is insensitive to ramification,
-because ramification multiplies the valuation by a fixed index
-(`IsDedekindDomain.HeightOneSpectrum.dvd_toAdd_valuationOfNeZero_map`). The two directions differ
-only in which embedding carries the parity.
-
-*Global to local* factors the local étale algebra: every monic irreducible factor `q` of `f` over
-`F_v` divides the image of a unique factor `p` of `f` over `F`
-(`Polynomial.Factors.exists_dvd_map`), the induced `AdjoinRoot.map` restricts to the rings of
-integers (`integerMapOfDvd`), and the prime of the local ring of integers contracts to a prime
-`w ∣ v` of the ring of integers of `F[X] ⧸ (p)`.
-
-*Local to global* goes the other way, and needs a factor to start from: `localFactor` produces one,
-as the minimal polynomial over `F_v` of the image of the root of `p` in the completion of
-`F[X] ⧸ (p)` at `w`. The embedding `F_v[X] ⧸ (q) → (F[X] ⧸ (p))_w` then transports evenness back to
-the `w`-adic valuation. This uses only the extension of adic completions
-(`IsDedekindDomain.HeightOneSpectrum.adicCompletionExtension`), not the full decomposition
-`W.A ⊗ F_v ≅ ∏ (𝕃 p)_w` of the completed étale algebra: for parity, ramification is harmless in
-both directions, so the decomposition is not needed.
+Both directions rest on one fact about the objects rather than about the proofs: parity of a
+valuation is insensitive to ramification, because ramification multiplies the valuation by a fixed
+index (`IsDedekindDomain.HeightOneSpectrum.dvd_toAdd_valuationOfNeZero_map`). That is why the
+comparison needs only the extension of adic completions
+(`IsDedekindDomain.HeightOneSpectrum.adicCompletionExtension`) and **not** the full decomposition
+`W.A ⊗ F_v ≅ ∏ (𝕃 p)_w` of the completed étale algebra.
 
 All the helpers are `private`. They are scaffolding for the two theorems above and are stated in
 vocabulary — `localFactor`, `integerMapOfDvd` — that has no meaning outside this comparison.
@@ -412,15 +400,14 @@ variable [W.IsElliptic] [W.IsCharNeTwoNF]
 open AdjoinRoot in
 open scoped Classical in
 /-- **Semilocal comparison, global to local**: an `S`-unramified square class localizes to an
-unramified class at every good finite place.
-
-Each monic irreducible factor `q` of `f` over `F_v` divides the image of a factor `p` of `f`; the
-induced embedding `F[X] ⧸ (p) → F_v[X] ⧸ (q)` restricts to the rings of integers, the prime of the
-local ring of integers contracts to a prime `w ∣ v`, and the local valuation is the `w`-adic one
-raised to the ramification index, so evenness transfers. -/
+unramified class at every good finite place. -/
 theorem localRes_mem_selmerGroupA {v : HeightOneSpectrum (𝓞 F)} (hv : v ∉ W.badPrimes (𝓞 F))
     {m : W.M} (hm : m ∈ W.selmerGroupA (𝓞 F)) :
     W.localRes F_[v] m ∈ 𝕎[v].selmerGroupA 𝒪_[v] := by
+  -- Each monic irreducible factor `q` of `f` over `F_v` divides the image of a factor `p` of `f`;
+  -- the induced embedding `F[X] ⧸ (p) → F_v[X] ⧸ (q)` restricts to the rings of integers, the
+  -- prime of the local ring of integers contracts to a prime `w ∣ v`, and the local valuation is
+  -- the `w`-adic one raised to the ramification index, so evenness transfers.
   obtain ⟨a, rfl⟩ := QuotientGroup.mk'_surjective _ m
   simp only [QuotientGroup.mk'_apply] at hm ⊢
   simp only [mem_selmerGroupA_iff, AdjoinRoot.modPowEquivPiFactors_mk,
@@ -451,16 +438,15 @@ theorem localRes_mem_selmerGroupA {v : HeightOneSpectrum (𝓞 F)} (hv : v ∉ W
 open AdjoinRoot in
 open scoped Classical in
 /-- **Semilocal comparison, local to global**: a square class that localizes to an unramified class
-at every good finite place is `S`-unramified.
-
-Every prime `w` of a field factor `F[X] ⧸ (p)` above a good place `v` arises from a factor of `f`
-over `F_v`, namely the minimal polynomial of the image of the root in the completion at `w`
-(`localFactor`). Evenness of the valuation transports from the primes of the local ring of integers
-through the completion `(F[X] ⧸ (p))_w` back to `w`. -/
+at every good finite place is `S`-unramified. -/
 theorem mem_selmerGroupA_of_forall_localRes {m : W.M}
     (hm : ∀ v : HeightOneSpectrum (𝓞 F), v ∉ W.badPrimes (𝓞 F) →
       W.localRes F_[v] m ∈ 𝕎[v].selmerGroupA 𝒪_[v]) :
     m ∈ W.selmerGroupA (𝓞 F) := by
+  -- Every prime `w` of a field factor `F[X] ⧸ (p)` above a good place `v` arises from a factor of
+  -- `f` over `F_v`, namely the minimal polynomial of the image of the root in the completion at
+  -- `w` (`localFactor`). Evenness transports from the primes of the local ring of integers
+  -- through the completion `(F[X] ⧸ (p))_w` back to `w`.
   obtain ⟨a, rfl⟩ := QuotientGroup.mk'_surjective _ m
   simp only [QuotientGroup.mk'_apply]
   simp only [mem_selmerGroupA_iff, AdjoinRoot.modPowEquivPiFactors_mk,

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
@@ -34,7 +34,7 @@ places.
 * `WeierstrassCurve.Affine.localRes_mem_selmerGroupA` (global to local): an `S`-unramified square
   class localizes to an unramified class at every good finite place.
 * `WeierstrassCurve.Affine.mem_selmerGroupA_of_forall_localRes` (local to global): a square class
-  that localizes to an unramified class at every finite place is `S`-unramified.
+  that localizes to an unramified class at every good finite place is `S`-unramified.
 
 ## Implementation notes
 
@@ -63,11 +63,9 @@ vocabulary — `localFactor`, `integerMapOfDvd` — that has no meaning outside 
 ## Provenance
 
 Adapted from Michael Stoll's elliptic-curves formalisation
-(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache 2.0, by Michael Stoll), pinned by
-`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`: `EllipticCurves/SelmerGroup.lean`,
-section `Semilocal`, together with `AdjoinRoot.map_comp_algebraMap` from
-`EllipticCurves/Mathlib/Basic.lean`. Following this repository's convention for adapted material,
-the upstream authorship is credited here rather than in the copyright header. The source states
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache 2.0, by Michael Stoll) at commit
+`66889eada51a`: `EllipticCurves/SelmerGroup.lean`, section `Semilocal`, together with
+`AdjoinRoot.map_comp_algebraMap` from `EllipticCurves/Mathlib/Basic.lean`. The source states
 square classes as its own `Units.modPow`; they are re-spelled here to this repository's single
 spelling `Mˣ ⧸ (powMonoidHom n).range`, and `HeightOneSpectrum.below` is Mathlib's
 `HeightOneSpectrum.under`.
@@ -340,7 +338,8 @@ private lemma localRes_mem_selmerGroupA_iff (a : W.Aˣ) :
           (Units.map (projFactor 𝕎[v].f_ne_zero 𝕎[v].squarefree_f q).toRingHom.toMonoidHom
             (Units.map (W.mapA F_[v]).toMonoidHom a))) := by
   rw [localRes_mk]
-  exact 𝕎[v].mem_selmerGroupA_unit_iff 𝒪_[v] _
+  simp only [mem_selmerGroupA_iff, AdjoinRoot.modPowEquivPiFactors_mk,
+    mem_selmerGroupFactor_unit_iff]
 
 /- Transport of the divisibility from the contracted prime of the local factor to `w`. -/
 private lemma dvd_toAdd_valuationOfNeZero_of_localFactor (p : W.f.Factors)
@@ -430,7 +429,8 @@ theorem localRes_mem_selmerGroupA {v : HeightOneSpectrum (𝓞 F)} (hv : v ∉ W
     W.localRes F_[v] m ∈ 𝕎[v].selmerGroupA 𝒪_[v] := by
   obtain ⟨a, rfl⟩ := QuotientGroup.mk'_surjective _ m
   simp only [QuotientGroup.mk'_apply] at hm ⊢
-  rw [mem_selmerGroupA_unit_iff] at hm
+  simp only [mem_selmerGroupA_iff, AdjoinRoot.modPowEquivPiFactors_mk,
+    mem_selmerGroupFactor_unit_iff] at hm
   rw [W.localRes_mem_selmerGroupA_iff v a]
   intro q w hw
   -- find the global factor `p` below the local factor `q`
@@ -469,7 +469,8 @@ theorem mem_selmerGroupA_of_forall_localRes {m : W.M}
     m ∈ W.selmerGroupA (𝓞 F) := by
   obtain ⟨a, rfl⟩ := QuotientGroup.mk'_surjective _ m
   simp only [QuotientGroup.mk'_apply]
-  rw [mem_selmerGroupA_unit_iff]
+  simp only [mem_selmerGroupA_iff, AdjoinRoot.modPowEquivPiFactors_mk,
+    mem_selmerGroupFactor_unit_iff]
   intro p w hw
   have hv : HeightOneSpectrum.under (𝓞 F) w ∉ W.badPrimes (𝓞 F) :=
     W.under_notMem_badPrimes (𝓞 F) p hw

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
@@ -36,18 +36,6 @@ places.
 * `WeierstrassCurve.Affine.mem_selmerGroupA_of_forall_localRes` (local to global): a square class
   that localizes to an unramified class at every good finite place is `S`-unramified.
 
-## Implementation notes
-
-Both directions rest on one fact about the objects rather than about the proofs: parity of a
-valuation is insensitive to ramification, because ramification multiplies the valuation by a fixed
-index (`IsDedekindDomain.HeightOneSpectrum.dvd_toAdd_valuationOfNeZero_map`). That is why the
-comparison needs only the extension of adic completions
-(`IsDedekindDomain.HeightOneSpectrum.adicCompletionExtension`) and **not** the full decomposition
-`W.A ⊗ F_v ≅ ∏ (𝕃 p)_w` of the completed étale algebra.
-
-All the helpers are `private`. They are scaffolding for the two theorems above and are stated in
-vocabulary — `localFactor`, `integerMapOfDvd` — that has no meaning outside this comparison.
-
 ## Provenance
 
 Adapted from Michael Stoll's elliptic-curves formalisation

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
@@ -136,16 +136,16 @@ curve has no bad primes. -/
 private lemma badPrimes_adicCompletionIntegers {v : HeightOneSpectrum (𝓞 F)}
     (hv : v ∉ W.badPrimes (𝓞 F)) : 𝕎[v].badPrimes 𝒪_[v] = ∅ := by
   ext P
-  simp only [Set.mem_empty_iff_false, iff_false]
+  simp only [Set.mem_empty_iff_false, iff_false, mem_badPrimes_iff]
   have hPval (z : F) : P.valuation F_[v] (algebraMap F F_[v] z) = v.valuation F z :=
     valuation_adicCompletion_algebraMap v P z
   have hone {y : F} {c : F_[v]} (hc : c = algebraMap F F_[v] y)
       (h : P.valuation F_[v] c ≠ 1) : v.valuation F y ≠ 1 := by
     rwa [hc, hPval] at h
   have hsupp {y : F} {c : F_[v]} (hc : c = algebraMap F F_[v] y)
-      (h : P ∈ HeightOneSpectrum.Support 𝒪_[v] c) : ¬ v.valuation F y ≤ 1 :=
-    not_le.mpr <| by rwa [HeightOneSpectrum.Support, Set.mem_setOf_eq, hc, hPval] at h
-  rintro ((((h | h) | h) | h) | h)
+      (h : 1 < P.valuation F_[v] c) : ¬ v.valuation F y ≤ 1 :=
+    not_le.mpr <| by rwa [hc, hPval] at h
+  rintro (h | h | h | h | h)
   · exact hone (by rw [map_ofNat]) h (W.valuation_two_eq_one_of_notMem_badPrimes (𝓞 F) hv)
   · exact hone (_root_.WeierstrassCurve.map_Δ ..) h
       (W.valuation_Δ_eq_one_of_notMem_badPrimes (𝓞 F) hv)
@@ -209,6 +209,15 @@ private noncomputable def algebraAdicCompletionFactor (p : W.f.Factors)
   (adicCompletionExtension F (𝕃 p) v w).toAlgebra
 
 attribute [local instance] algebraAdicCompletionFactor
+
+/- The `algebraMap` of that local instance is `adicCompletionExtension` itself. Stated here,
+where `algebraAdicCompletionFactor` is visible, because `adicCompletionExtension` is not exposed
+outside its own module, so the identification is not available by `rfl` at the use sites. -/
+private lemma algebraMap_adicCompletionFactor_apply (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal]
+    (x : F_[v]) :
+    algebraMap F_[v] (w.adicCompletion (𝕃 p)) x = adicCompletionExtension F (𝕃 p) v w x :=
+  rfl
 
 /- The square `F → F_v → (F[X] ⧸ (p))_w` = `F → F[X] ⧸ (p) → (F[X] ⧸ (p))_w` of coefficient maps. -/
 private lemma algebraMap_adicCompletion_comp (p : W.f.Factors)
@@ -282,7 +291,8 @@ private lemma localFactorEmb_comp_algebraMap (p : W.f.Factors)
   rw [RingHom.comp_apply, IsScalarTower.algebraMap_apply 𝒪_[v] F_[v]
       (AdjoinRoot (W.localFactor v p w : F_[v][X])),
     AdjoinRoot.algebraMap_eq, W.localFactorEmb_of v p w]
-  rfl
+  rw [RingHom.comp_apply, W.algebraMap_adicCompletionFactor_apply v p w]
+  exact congrArg _ (coe_adicCompletionIntegersExtension F (𝕃 p) v w c).symm
 
 /- The embedding maps the local ring of integers into the integers of the completion. -/
 private lemma localFactorEmb_mem_adicCompletionIntegers (p : W.f.Factors)
@@ -322,7 +332,7 @@ private lemma comap_localFactorIntegerEmb_ne_bot (p : W.f.Factors)
     (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
     (IsDiscreteValuationRing.maximalIdeal (w.adicCompletionIntegers (𝕃 p))).asIdeal.comap
       (W.localFactorIntegerEmb v p w) ≠ ⊥ := by
-  refine Ideal.comap_ne_bot_of_comap_comap_ne_bot (FaithfulSMul.algebraMap_injective 𝒪_[v]
+  refine Ideal.ne_bot_of_comap_ne_bot _ (FaithfulSMul.algebraMap_injective 𝒪_[v]
     (𝕎[v].ringOfIntegersFactor 𝒪_[v] (W.localFactor v p w))) ?_
   have hsq0 : (W.localFactorIntegerEmb v p w).comp
       (algebraMap 𝒪_[v] (𝕎[v].ringOfIntegersFactor 𝒪_[v] (W.localFactor v p w))) =
@@ -384,6 +394,7 @@ private lemma dvd_toAdd_valuationOfNeZero_of_localFactor (p : W.f.Factors)
   exact hkey
 
 /- The double contraction of a prime of the local ring of integers is `v`. -/
+omit [W.IsElliptic] [IsCharNeTwoNF W] in
 private lemma comap_comap_integerMapOfDvd {p : W.f.Factors} {q : 𝕎[v].f.Factors}
     (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v]))
     (w : HeightOneSpectrum (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)) :
@@ -393,25 +404,29 @@ private lemma comap_comap_integerMapOfDvd {p : W.f.Factors} {q : 𝕎[v].f.Facto
   have h1 : w.asIdeal.comap (algebraMap 𝒪_[v] (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)) =
       IsLocalRing.maximalIdeal 𝒪_[v] :=
     IsLocalRing.eq_maximalIdeal (HeightOneSpectrum.under 𝒪_[v] w).isMaximal
-  rw [h1, HeightOneSpectrum.comap_maximalIdeal_adicCompletionIntegers]
+  rw [h1, ← Ideal.under_def, HeightOneSpectrum.under_maximalIdeal_adicCompletionIntegers]
 
 /- The contraction of a prime of the local ring of integers to the global one is nonzero. -/
+omit [W.IsElliptic] [IsCharNeTwoNF W] in
 private lemma comap_integerMapOfDvd_ne_bot {p : W.f.Factors} {q : 𝕎[v].f.Factors}
     (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v]))
     (w : HeightOneSpectrum (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)) :
     w.asIdeal.comap (W.integerMapOfDvd v hq) ≠ ⊥ := by
-  refine Ideal.comap_ne_bot_of_comap_comap_ne_bot (FaithfulSMul.algebraMap_injective (𝓞 F)
+  refine Ideal.ne_bot_of_comap_ne_bot _ (FaithfulSMul.algebraMap_injective (𝓞 F)
     (W.ringOfIntegersFactor (𝓞 F) p)) ?_
   rw [W.comap_comap_integerMapOfDvd v hq w]
   exact v.ne_bot
 
 /- The contracted prime lies over `v`. -/
+omit [W.IsElliptic] [IsCharNeTwoNF W] in
 private lemma under_comapOfNeBot_integerMapOfDvd {p : W.f.Factors} {q : 𝕎[v].f.Factors}
     (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v]))
     (w : HeightOneSpectrum (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)) :
     HeightOneSpectrum.under (𝓞 F) (HeightOneSpectrum.comapOfNeBot (W.integerMapOfDvd v hq) w
       (W.comap_integerMapOfDvd_ne_bot v hq w)) = v :=
-  HeightOneSpectrum.ext (W.comap_comap_integerMapOfDvd v hq w)
+  HeightOneSpectrum.ext <| by
+    simpa [HeightOneSpectrum.under, HeightOneSpectrum.comapOfNeBot_asIdeal] using
+      W.comap_comap_integerMapOfDvd v hq w
 
 /- The base-change maps of the field factors are compatible with the CRT projections. -/
 private lemma map_projFactor {p : W.f.Factors} {q : 𝕎[v].f.Factors}

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
@@ -22,10 +22,12 @@ subgroups of `W.M` cut out by valuation conditions are in play:
 * `(W⁄F_v).toAffine.selmerGroupA 𝒪_v` — the same condition for the curve base-changed to the
   completion at a finite place `v`.
 
-This file proves that at a **good** finite place the two agree, in both directions. That is what
-makes the local conditions at the good finite places redundant: they are already implied by
-`A(S,2)`, so membership in the `2`-Selmer group reduces to the finitely many conditions at the bad
-and infinite places.
+This file compares the two at the **good** finite places, in both directions: an `S`-unramified
+class localizes to an unramified class at each good place, and conversely a class that localizes
+to an unramified class at every good place is `S`-unramified. That is what makes the local
+conditions at the good finite places redundant — they are already implied by `A(S,2)` — so
+membership in the `2`-Selmer group reduces to the finitely many conditions at the bad and infinite
+places.
 
 ## Main results
 
@@ -70,40 +72,12 @@ square classes as its own `Units.modPow`; they are re-spelled here to this repos
 spelling `Mˣ ⧸ (powMonoidHom n).range`, and `HeightOneSpectrum.below` is Mathlib's
 `HeightOneSpectrum.under`.
 
-## Roadmap
-
-`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6 (Mordell–Weil), the explicit `2`-descent bullet.
 -/
 
 public section
 
 open IsDedekindDomain NumberField Polynomial
 
-namespace AdjoinRoot
-
-/-- The base-change map `K[X] ⧸ (p) →+* K_v[X] ⧸ (q)` of `AdjoinRoot`s at a completion is
-compatible with the algebra maps from the underlying Dedekind domain `R` and from the ring of
-integers of the completion.
-
-`private`, and stated here rather than beside `AdjoinRoot.map` in
-`TauCeti.RingTheory.AdjoinRoot.Factors`: it is not a fact about `AdjoinRoot` alone, since it names
-`adicCompletion` and `adicCompletionIntegers`, and this file is where those two developments
-first meet. -/
-private lemma map_comp_algebraMap {R : Type*} [CommRing R] [IsDedekindDomain R] {K : Type*}
-    [Field K] [Algebra R K] [IsFractionRing R K] (v : HeightOneSpectrum R) {p : K[X]}
-    {q : (v.adicCompletion K)[X]} (hq : q ∣ p.map (algebraMap K (v.adicCompletion K))) :
-    (AdjoinRoot.map (algebraMap K (v.adicCompletion K)) p q hq).comp
-        (algebraMap R (AdjoinRoot p)) =
-      (algebraMap (v.adicCompletionIntegers K) (AdjoinRoot q)).comp
-        (algebraMap R (v.adicCompletionIntegers K)) := by
-  ext c
-  simp only [RingHom.comp_apply]
-  rw [IsScalarTower.algebraMap_apply R K (AdjoinRoot p), AdjoinRoot.algebraMap_eq, map_of,
-    IsScalarTower.algebraMap_apply (v.adicCompletionIntegers K) (v.adicCompletion K)
-      (AdjoinRoot q), AdjoinRoot.algebraMap_eq]
-  rfl
-
-end AdjoinRoot
 
 namespace WeierstrassCurve.Affine
 
@@ -339,7 +313,9 @@ private lemma comap_localFactorIntegerEmb_ne_bot (p : W.f.Factors)
       adicCompletionIntegersExtension F (𝕃 p) v w := by
     ext c : 2
     exact RingHom.congr_fun (W.localFactorEmb_comp_algebraMap v p w) c
-  rw [Ideal.comap_comap, hsq0, IsDedekindDomain.HeightOneSpectrum.asIdeal_maximalIdeal,
+  rw [Ideal.comap_comap, hsq0,
+    show (IsDiscreteValuationRing.maximalIdeal (w.adicCompletionIntegers (𝕃 p))).asIdeal =
+      IsLocalRing.maximalIdeal (w.adicCompletionIntegers (𝕃 p)) from rfl,
     comap_maximalIdeal_adicCompletionIntegersExtension]
   exact IsDiscreteValuationRing.not_a_field _
 
@@ -481,14 +457,15 @@ theorem localRes_mem_selmerGroupA {v : HeightOneSpectrum (𝓞 F)} (hv : v ∉ W
 open AdjoinRoot in
 open scoped Classical in
 /-- **Semilocal comparison, local to global**: a square class that localizes to an unramified class
-at every finite place is `S`-unramified.
+at every good finite place is `S`-unramified.
 
 Every prime `w` of a field factor `F[X] ⧸ (p)` above a good place `v` arises from a factor of `f`
 over `F_v`, namely the minimal polynomial of the image of the root in the completion at `w`
 (`localFactor`). Evenness of the valuation transports from the primes of the local ring of integers
 through the completion `(F[X] ⧸ (p))_w` back to `w`. -/
 theorem mem_selmerGroupA_of_forall_localRes {m : W.M}
-    (hm : ∀ v : HeightOneSpectrum (𝓞 F), W.localRes F_[v] m ∈ 𝕎[v].selmerGroupA 𝒪_[v]) :
+    (hm : ∀ v : HeightOneSpectrum (𝓞 F), v ∉ W.badPrimes (𝓞 F) →
+      W.localRes F_[v] m ∈ 𝕎[v].selmerGroupA 𝒪_[v]) :
     m ∈ W.selmerGroupA (𝓞 F) := by
   obtain ⟨a, rfl⟩ := QuotientGroup.mk'_surjective _ m
   simp only [QuotientGroup.mk'_apply]
@@ -498,7 +475,7 @@ theorem mem_selmerGroupA_of_forall_localRes {m : W.M}
     W.under_notMem_badPrimes (𝓞 F) p hw
   refine W.dvd_toAdd_valuationOfNeZero_of_localFactor (HeightOneSpectrum.under (𝓞 F) w) p w a ?_
   refine (W.localRes_mem_selmerGroupA_iff (HeightOneSpectrum.under (𝓞 F) w) a).mp
-    (hm (HeightOneSpectrum.under (𝓞 F) w)) _ _ ?_
+    (hm (HeightOneSpectrum.under (𝓞 F) w) hv) _ _ ?_
   rw [HeightOneSpectrum.mem_primesAbove_iff, W.badPrimes_adicCompletionIntegers hv]
   exact Set.notMem_empty _
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
@@ -246,12 +246,6 @@ private noncomputable def localFactorEmb (p : W.f.Factors)
       rw [W.coe_localFactor v p w]
       exact minpoly.aeval _ _)
 
-private lemma localFactorEmb_of (p : W.f.Factors)
-    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal]
-    (c : F_[v]) :
-    W.localFactorEmb v p w (AdjoinRoot.of _ c) = algebraMap F_[v] (w.adicCompletion (𝕃 p)) c :=
-  AdjoinRoot.lift_of _
-
 /- The square `𝒪_v → F_v[X] ⧸ (q) → (F[X] ⧸ (p))_w` = `𝒪_v → 𝒪_w → (F[X] ⧸ (p))_w`. -/
 private lemma localFactorEmb_comp_algebraMap (p : W.f.Factors)
     (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
@@ -262,7 +256,7 @@ private lemma localFactorEmb_comp_algebraMap (p : W.f.Factors)
   ext c
   rw [RingHom.comp_apply, IsScalarTower.algebraMap_apply 𝒪_[v] F_[v]
       (AdjoinRoot (W.localFactor v p w : F_[v][X])),
-    AdjoinRoot.algebraMap_eq, W.localFactorEmb_of v p w]
+    AdjoinRoot.algebraMap_eq, localFactorEmb, AdjoinRoot.lift_of]
   rw [RingHom.comp_apply, W.algebraMap_adicCompletionFactor_apply v p w]
   exact congrArg _ (coe_adicCompletionIntegersExtension F (𝕃 p) v w c).symm
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
@@ -1,0 +1,492 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.NumberField.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.LocalCondition
+public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.SelmerGroupA
+public import TauCeti.RingTheory.DedekindDomain.AdicCompletionExtension
+
+/-!
+# The semilocal comparison of `2`-descent at the good finite places
+
+Let `W : y² = f(x) = x³ + a₂x² + a₄x + a₆` be an elliptic curve in characteristic `≠ 2` normal form
+over a number field `F`, with étale algebra `W.A = F[X] ⧸ (f)` and square classes `W.M`. Two
+subgroups of `W.M` cut out by valuation conditions are in play:
+
+* `W.selmerGroupA (𝓞 F)` — the `S`-unramifiedness condition `A(S,2)`, a *global* condition at the
+  primes of the rings of integers of the field factors of `W.A` not lying above a bad prime;
+* `(W⁄F_v).toAffine.selmerGroupA 𝒪_v` — the same condition for the curve base-changed to the
+  completion at a finite place `v`.
+
+This file proves that at a **good** finite place the two agree, in both directions. That is what
+makes the local conditions at the good finite places redundant: they are already implied by
+`A(S,2)`, so membership in the `2`-Selmer group reduces to the finitely many conditions at the bad
+and infinite places.
+
+## Main results
+
+* `WeierstrassCurve.Affine.localRes_mem_selmerGroupA` (global to local): an `S`-unramified square
+  class localizes to an unramified class at every good finite place.
+* `WeierstrassCurve.Affine.mem_selmerGroupA_of_forall_localRes` (local to global): a square class
+  that localizes to an unramified class at every finite place is `S`-unramified.
+
+## Implementation notes
+
+Both directions rest on the same mechanism: parity of a valuation is insensitive to ramification,
+because ramification multiplies the valuation by a fixed index
+(`IsDedekindDomain.HeightOneSpectrum.dvd_toAdd_valuationOfNeZero_map`). The two directions differ
+only in which embedding carries the parity.
+
+*Global to local* factors the local étale algebra: every monic irreducible factor `q` of `f` over
+`F_v` divides the image of a unique factor `p` of `f` over `F`
+(`Polynomial.Factors.exists_dvd_map`), the induced `AdjoinRoot.map` restricts to the rings of
+integers (`integerMapOfDvd`), and the prime of the local ring of integers contracts to a prime
+`w ∣ v` of the ring of integers of `F[X] ⧸ (p)`.
+
+*Local to global* goes the other way, and needs a factor to start from: `localFactor` produces one,
+as the minimal polynomial over `F_v` of the image of the root of `p` in the completion of
+`F[X] ⧸ (p)` at `w`. The embedding `F_v[X] ⧸ (q) → (F[X] ⧸ (p))_w` then transports evenness back to
+the `w`-adic valuation. This uses only the extension of adic completions
+(`IsDedekindDomain.HeightOneSpectrum.adicCompletionExtension`), not the full decomposition
+`W.A ⊗ F_v ≅ ∏ (𝕃 p)_w` of the completed étale algebra: for parity, ramification is harmless in
+both directions, so the decomposition is not needed.
+
+All the helpers are `private`. They are scaffolding for the two theorems above and are stated in
+vocabulary — `localFactor`, `integerMapOfDvd` — that has no meaning outside this comparison.
+
+## Provenance
+
+Adapted from Michael Stoll's elliptic-curves formalisation
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache 2.0, by Michael Stoll), pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`: `EllipticCurves/SelmerGroup.lean`,
+section `Semilocal`, together with `AdjoinRoot.map_comp_algebraMap` from
+`EllipticCurves/Mathlib/Basic.lean`. Following this repository's convention for adapted material,
+the upstream authorship is credited here rather than in the copyright header. The source states
+square classes as its own `Units.modPow`; they are re-spelled here to this repository's single
+spelling `Mˣ ⧸ (powMonoidHom n).range`, and `HeightOneSpectrum.below` is Mathlib's
+`HeightOneSpectrum.under`.
+
+## Roadmap
+
+`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6 (Mordell–Weil), the explicit `2`-descent bullet.
+-/
+
+public section
+
+open IsDedekindDomain NumberField Polynomial
+
+namespace AdjoinRoot
+
+/-- The base-change map `K[X] ⧸ (p) →+* K_v[X] ⧸ (q)` of `AdjoinRoot`s at a completion is
+compatible with the algebra maps from the underlying Dedekind domain `R` and from the ring of
+integers of the completion.
+
+`private`, and stated here rather than beside `AdjoinRoot.map` in
+`TauCeti.RingTheory.AdjoinRoot.Factors`: it is not a fact about `AdjoinRoot` alone, since it names
+`adicCompletion` and `adicCompletionIntegers`, and this file is where those two developments
+first meet. -/
+private lemma map_comp_algebraMap {R : Type*} [CommRing R] [IsDedekindDomain R] {K : Type*}
+    [Field K] [Algebra R K] [IsFractionRing R K] (v : HeightOneSpectrum R) {p : K[X]}
+    {q : (v.adicCompletion K)[X]} (hq : q ∣ p.map (algebraMap K (v.adicCompletion K))) :
+    (AdjoinRoot.map (algebraMap K (v.adicCompletion K)) p q hq).comp
+        (algebraMap R (AdjoinRoot p)) =
+      (algebraMap (v.adicCompletionIntegers K) (AdjoinRoot q)).comp
+        (algebraMap R (v.adicCompletionIntegers K)) := by
+  ext c
+  simp only [RingHom.comp_apply]
+  rw [IsScalarTower.algebraMap_apply R K (AdjoinRoot p), AdjoinRoot.algebraMap_eq, map_of,
+    IsScalarTower.algebraMap_apply (v.adicCompletionIntegers K) (v.adicCompletion K)
+      (AdjoinRoot q), AdjoinRoot.algebraMap_eq]
+  rfl
+
+end AdjoinRoot
+
+namespace WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] [NumberField F] (W : Affine F)
+
+/- Notation local to this file: `F_[v]` and `𝒪_[v]` are the completion of `F` at the finite place
+`v` and its valuation ring, `𝕎[v]` is the base change of `W` to `F_[v]` as an affine curve, and
+`𝕃 p` is the field factor `F[X] ⧸ (p)` of the étale algebra attached to a factor `p` of `f`. -/
+local notation:max "F_[" v "]" => HeightOneSpectrum.adicCompletion F v
+local notation:max "𝒪_[" v "]" => HeightOneSpectrum.adicCompletionIntegers F v
+local notation:max "𝕎[" v "]" =>
+  WeierstrassCurve.toAffine (W⁄(HeightOneSpectrum.adicCompletion F v))
+local notation:max "𝕃" p:max => AdjoinRoot (p : F[X])
+
+section Semilocal
+
+open AdjoinRoot IsDedekindDomain.HeightOneSpectrum
+
+variable (v : HeightOneSpectrum (𝓞 F))
+
+/- The instance found by unifying through the `ringOfIntegersFactor` abbreviation carries
+mismatched `SMul` arguments; pin them to the `Algebra`-derived ones. -/
+private instance instIsScalarTowerRingOfIntegersFactor (p : W.f.Factors) :
+    @IsScalarTower (𝓞 F) (W.ringOfIntegersFactor (𝓞 F) p) (𝕃 p)
+      Algebra.toSMul Algebra.toSMul Algebra.toSMul :=
+  .of_algebraMap_eq' rfl
+
+/- Goodness transfers to the completion: over the valuation ring of a good place, the base-changed
+curve has no bad primes. -/
+private lemma badPrimes_adicCompletionIntegers {v : HeightOneSpectrum (𝓞 F)}
+    (hv : v ∉ W.badPrimes (𝓞 F)) : 𝕎[v].badPrimes 𝒪_[v] = ∅ := by
+  ext P
+  simp only [Set.mem_empty_iff_false, iff_false]
+  have hPval (z : F) : P.valuation F_[v] (algebraMap F F_[v] z) = v.valuation F z :=
+    valuation_adicCompletion_algebraMap v P z
+  have hone {y : F} {c : F_[v]} (hc : c = algebraMap F F_[v] y)
+      (h : P.valuation F_[v] c ≠ 1) : v.valuation F y ≠ 1 := by
+    rwa [hc, hPval] at h
+  have hsupp {y : F} {c : F_[v]} (hc : c = algebraMap F F_[v] y)
+      (h : P ∈ HeightOneSpectrum.Support 𝒪_[v] c) : ¬ v.valuation F y ≤ 1 :=
+    not_le.mpr <| by rwa [HeightOneSpectrum.Support, Set.mem_setOf_eq, hc, hPval] at h
+  rintro ((((h | h) | h) | h) | h)
+  · exact hone (by rw [map_ofNat]) h (W.valuation_two_eq_one_of_notMem_badPrimes (𝓞 F) hv)
+  · exact hone (_root_.WeierstrassCurve.map_Δ ..) h
+      (W.valuation_Δ_eq_one_of_notMem_badPrimes (𝓞 F) hv)
+  · exact hsupp (_root_.WeierstrassCurve.map_a₂ ..) h
+      (W.valuation_a₂_le_one_of_notMem_badPrimes (𝓞 F) hv)
+  · exact hsupp (_root_.WeierstrassCurve.map_a₄ ..) h
+      (W.valuation_a₄_le_one_of_notMem_badPrimes (𝓞 F) hv)
+  · exact hsupp (_root_.WeierstrassCurve.map_a₆ ..) h
+      (W.valuation_a₆_le_one_of_notMem_badPrimes (𝓞 F) hv)
+
+/- The base-change map on a field factor is integral on the ring of integers. -/
+private lemma isIntegral_mapOfDvd {p : W.f.Factors} {q : 𝕎[v].f.Factors}
+    (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v]))
+    (x : W.ringOfIntegersFactor (𝓞 F) p) :
+    _root_.IsIntegral 𝒪_[v] (AdjoinRoot.map (algebraMap F F_[v]) _ _ hq (x : 𝕃 p)) := by
+  obtain ⟨P, hPm, hPe⟩ := x.2
+  refine ⟨P.map (algebraMap (𝓞 F) 𝒪_[v]), hPm.map _, ?_⟩
+  have h2 := congrArg (AdjoinRoot.map (algebraMap F F_[v]) _ _ hq) hPe
+  rw [map_zero, Polynomial.hom_eval₂] at h2
+  rw [Polynomial.eval₂_map]
+  exact (congrArg (fun φ ↦ Polynomial.eval₂ φ
+    (AdjoinRoot.map (algebraMap F F_[v]) _ _ hq (x : 𝕃 p)) P)
+    (AdjoinRoot.map_comp_algebraMap v hq)).symm.trans h2
+
+/- The base-change map on the rings of integers of the field factors: the restriction of
+`AdjoinRoot.map` to the integral closures. -/
+private noncomputable def integerMapOfDvd {p : W.f.Factors} {q : 𝕎[v].f.Factors}
+    (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v])) :
+    W.ringOfIntegersFactor (𝓞 F) p →+* 𝕎[v].ringOfIntegersFactor 𝒪_[v] q :=
+  ((AdjoinRoot.map (algebraMap F F_[v]) _ _ hq).comp
+    (algebraMap (W.ringOfIntegersFactor (𝓞 F) p) (𝕃 p))).codRestrict
+      (integralClosure 𝒪_[v] (AdjoinRoot (q : F_[v][X]))).toSubring
+      fun x ↦ W.isIntegral_mapOfDvd v hq x
+
+/- The square of ring homomorphisms defining `integerMapOfDvd`. -/
+private lemma algebraMap_comp_integerMapOfDvd {p : W.f.Factors} {q : 𝕎[v].f.Factors}
+    (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v])) :
+    (algebraMap (𝕎[v].ringOfIntegersFactor 𝒪_[v] q) (AdjoinRoot (q : F_[v][X]))).comp
+        (W.integerMapOfDvd v hq) =
+      (AdjoinRoot.map (algebraMap F F_[v]) _ _ hq).comp
+        (algebraMap (W.ringOfIntegersFactor (𝓞 F) p) (𝕃 p)) :=
+  RingHom.ext fun _ ↦ rfl
+
+/- The square `𝓞 F → 𝒪_v → B_q` versus `𝓞 F → B_p → B_q` on the rings of integers. -/
+private lemma integerMapOfDvd_comp_algebraMap {p : W.f.Factors} {q : 𝕎[v].f.Factors}
+    (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v])) :
+    (W.integerMapOfDvd v hq).comp (algebraMap (𝓞 F) (W.ringOfIntegersFactor (𝓞 F) p)) =
+      (algebraMap 𝒪_[v] (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)).comp
+        (algebraMap (𝓞 F) 𝒪_[v]) := by
+  ext c
+  exact RingHom.congr_fun (AdjoinRoot.map_comp_algebraMap v hq) c
+
+variable [W.IsElliptic] [W.IsCharNeTwoNF]
+
+/- The `F_v`-algebra structure on the completion of the field factor `F[X] ⧸ (p)` at a place `w`
+above `v`, via `adicCompletionExtension`; a local instance for the constructions below. -/
+@[implicit_reducible]
+private noncomputable def algebraAdicCompletionFactor (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
+    Algebra F_[v] (w.adicCompletion (𝕃 p)) :=
+  (adicCompletionExtension F (𝕃 p) v w).toAlgebra
+
+attribute [local instance] algebraAdicCompletionFactor
+
+/- The square `F → F_v → (F[X] ⧸ (p))_w` = `F → F[X] ⧸ (p) → (F[X] ⧸ (p))_w` of coefficient maps. -/
+private lemma algebraMap_adicCompletion_comp (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
+    (algebraMap F_[v] (w.adicCompletion (𝕃 p))).comp (algebraMap F F_[v]) =
+      (algebraMap (𝕃 p) (w.adicCompletion (𝕃 p))).comp (algebraMap F (𝕃 p)) :=
+  RingHom.ext fun c ↦ adicCompletionExtension_coe F (𝕃 p) v w c
+
+/- Evaluating a base-changed polynomial at the image of the root in the completion. -/
+private lemma aeval_root_adicCompletion (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal]
+    (g : F[X]) :
+    Polynomial.aeval (algebraMap (𝕃 p) (w.adicCompletion (𝕃 p)) (root (p : F[X])))
+        (g.map (algebraMap F F_[v])) =
+      algebraMap (𝕃 p) (w.adicCompletion (𝕃 p)) (AdjoinRoot.mk (p : F[X]) g) := by
+  rw [Polynomial.aeval_def, Polynomial.eval₂_map, ← aeval_eq, Polynomial.aeval_def,
+    Polynomial.hom_eval₂]
+  exact congrArg (fun φ ↦ Polynomial.eval₂ φ
+    (algebraMap (𝕃 p) (w.adicCompletion (𝕃 p)) (root (p : F[X]))) g)
+    (W.algebraMap_adicCompletion_comp v p w)
+
+/- The image of the root in the completion is integral over `F_v`. -/
+private lemma isIntegral_root_adicCompletion (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
+    _root_.IsIntegral F_[v] (algebraMap (𝕃 p) (w.adicCompletion (𝕃 p)) (root (p : F[X]))) := by
+  refine ⟨(p : F[X]).map (algebraMap F F_[v]), p.monic.map _, ?_⟩
+  rw [← Polynomial.aeval_def, W.aeval_root_adicCompletion v p w, AdjoinRoot.mk_self, map_zero]
+
+/- The local factor of `f` attached to a place `w` of the field factor `F[X] ⧸ (p)` above `v`: the
+minimal polynomial over `F_v` of the image of the root in the completion at `w`. -/
+private noncomputable def localFactor (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
+    𝕎[v].f.Factors :=
+  ⟨minpoly F_[v] (algebraMap (𝕃 p) (w.adicCompletion (𝕃 p)) (root (p : F[X]))),
+    minpoly.irreducible (W.isIntegral_root_adicCompletion v p w),
+    minpoly.monic (W.isIntegral_root_adicCompletion v p w), by
+      rw [baseChange_f]
+      refine minpoly.dvd _ _ ?_
+      rw [W.aeval_root_adicCompletion v p w, AdjoinRoot.mk_eq_zero.mpr p.dvd, map_zero]⟩
+
+private lemma coe_localFactor (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
+    (W.localFactor v p w : F_[v][X]) =
+      minpoly F_[v] (algebraMap (𝕃 p) (w.adicCompletion (𝕃 p)) (root (p : F[X]))) :=
+  rfl
+
+/- The embedding of the local field factor into the completion, sending the root of the local
+factor to the image of the global root. -/
+private noncomputable def localFactorEmb (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
+    AdjoinRoot (W.localFactor v p w : F_[v][X]) →+* w.adicCompletion (𝕃 p) :=
+  AdjoinRoot.lift (algebraMap F_[v] (w.adicCompletion (𝕃 p)))
+    (algebraMap (𝕃 p) (w.adicCompletion (𝕃 p)) (root (p : F[X]))) (by
+      rw [W.coe_localFactor v p w]
+      exact minpoly.aeval _ _)
+
+private lemma localFactorEmb_of (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal]
+    (c : F_[v]) :
+    W.localFactorEmb v p w (AdjoinRoot.of _ c) = algebraMap F_[v] (w.adicCompletion (𝕃 p)) c :=
+  AdjoinRoot.lift_of _
+
+/- The square `𝒪_v → F_v[X] ⧸ (q) → (F[X] ⧸ (p))_w` = `𝒪_v → 𝒪_w → (F[X] ⧸ (p))_w`. -/
+private lemma localFactorEmb_comp_algebraMap (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
+    (W.localFactorEmb v p w).comp
+        (algebraMap 𝒪_[v] (AdjoinRoot (W.localFactor v p w : F_[v][X]))) =
+      (algebraMap (w.adicCompletionIntegers (𝕃 p)) (w.adicCompletion (𝕃 p))).comp
+        (adicCompletionIntegersExtension F (𝕃 p) v w) := by
+  ext c
+  rw [RingHom.comp_apply, IsScalarTower.algebraMap_apply 𝒪_[v] F_[v]
+      (AdjoinRoot (W.localFactor v p w : F_[v][X])),
+    AdjoinRoot.algebraMap_eq, W.localFactorEmb_of v p w]
+  rfl
+
+/- The embedding maps the local ring of integers into the integers of the completion. -/
+private lemma localFactorEmb_mem_adicCompletionIntegers (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal]
+    (x : 𝕎[v].ringOfIntegersFactor 𝒪_[v] (W.localFactor v p w)) :
+    W.localFactorEmb v p w (x : AdjoinRoot (W.localFactor v p w : F_[v][X])) ∈
+      w.adicCompletionIntegers (𝕃 p) := by
+  obtain ⟨P, hPm, hPe⟩ := x.2
+  have h2 := congrArg (W.localFactorEmb v p w) hPe
+  rw [map_zero, Polynomial.hom_eval₂, W.localFactorEmb_comp_algebraMap v p w] at h2
+  have hint2 : _root_.IsIntegral (w.adicCompletionIntegers (𝕃 p))
+      (W.localFactorEmb v p w (x : AdjoinRoot (W.localFactor v p w : F_[v][X]))) := by
+    refine ⟨P.map (adicCompletionIntegersExtension F (𝕃 p) v w), hPm.map _, ?_⟩
+    rw [Polynomial.eval₂_map]
+    exact h2
+  obtain ⟨y, hy⟩ := IsIntegrallyClosed.isIntegral_iff.mp hint2
+  rw [← hy]
+  exact y.2
+
+/- The restriction of `localFactorEmb` to the rings of integers. -/
+private noncomputable def localFactorIntegerEmb (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
+    𝕎[v].ringOfIntegersFactor 𝒪_[v] (W.localFactor v p w) →+* w.adicCompletionIntegers (𝕃 p) :=
+  ((W.localFactorEmb v p w).comp (algebraMap _ _)).codRestrict
+    (w.adicCompletionIntegers (𝕃 p)).toSubring
+    fun x ↦ W.localFactorEmb_mem_adicCompletionIntegers v p w x
+
+private lemma algebraMap_comp_localFactorIntegerEmb (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
+    (algebraMap (w.adicCompletionIntegers (𝕃 p)) (w.adicCompletion (𝕃 p))).comp
+        (W.localFactorIntegerEmb v p w) =
+      (W.localFactorEmb v p w).comp (algebraMap _ _) :=
+  RingHom.ext fun _ ↦ rfl
+
+/- The contraction of the maximal ideal of `𝒪_w` to the local ring of integers is nonzero. -/
+private lemma comap_localFactorIntegerEmb_ne_bot (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal] :
+    (IsDiscreteValuationRing.maximalIdeal (w.adicCompletionIntegers (𝕃 p))).asIdeal.comap
+      (W.localFactorIntegerEmb v p w) ≠ ⊥ := by
+  refine Ideal.comap_ne_bot_of_comap_comap_ne_bot (FaithfulSMul.algebraMap_injective 𝒪_[v]
+    (𝕎[v].ringOfIntegersFactor 𝒪_[v] (W.localFactor v p w))) ?_
+  have hsq0 : (W.localFactorIntegerEmb v p w).comp
+      (algebraMap 𝒪_[v] (𝕎[v].ringOfIntegersFactor 𝒪_[v] (W.localFactor v p w))) =
+      adicCompletionIntegersExtension F (𝕃 p) v w := by
+    ext c : 2
+    exact RingHom.congr_fun (W.localFactorEmb_comp_algebraMap v p w) c
+  rw [Ideal.comap_comap, hsq0, IsDedekindDomain.HeightOneSpectrum.asIdeal_maximalIdeal,
+    comap_maximalIdeal_adicCompletionIntegersExtension]
+  exact IsDiscreteValuationRing.not_a_field _
+
+/- The embedding of the local field factor is compatible with the CRT projections. -/
+private lemma localFactorEmb_projFactor (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal]
+    (a : W.A) :
+    W.localFactorEmb v p w (projFactor 𝕎[v].f_ne_zero 𝕎[v].squarefree_f
+        (W.localFactor v p w) (W.mapA F_[v] a)) =
+      algebraMap (𝕃 p) (w.adicCompletion (𝕃 p)) (projFactor W.f_ne_zero W.squarefree_f p a) := by
+  obtain ⟨g, rfl⟩ := AdjoinRoot.mk_surjective a
+  rw [mapA_mk, projFactor_mk, projFactor_mk, localFactorEmb, AdjoinRoot.lift_mk]
+  exact W.aeval_root_adicCompletion v p w g
+
+/- Unfolding of the local unramifiedness condition into per-factor divisibilities. -/
+private lemma localRes_mem_selmerGroupA_iff (a : W.Aˣ) :
+    W.localRes F_[v] (QuotientGroup.mk a) ∈ 𝕎[v].selmerGroupA 𝒪_[v] ↔
+      ∀ (q : 𝕎[v].f.Factors) (w' : HeightOneSpectrum (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)),
+        w' ∉ HeightOneSpectrum.primesAbove 𝒪_[v] (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)
+          (𝕎[v].badPrimes 𝒪_[v]) →
+        (2 : ℤ) ∣ Multiplicative.toAdd (w'.valuationOfNeZero
+          (Units.map (projFactor 𝕎[v].f_ne_zero 𝕎[v].squarefree_f q).toRingHom.toMonoidHom
+            (Units.map (W.mapA F_[v]).toMonoidHom a))) := by
+  rw [localRes_mk]
+  exact 𝕎[v].mem_selmerGroupA_unit_iff 𝒪_[v] _
+
+/- Transport of the divisibility from the contracted prime of the local factor to `w`. -/
+private lemma dvd_toAdd_valuationOfNeZero_of_localFactor (p : W.f.Factors)
+    (w : HeightOneSpectrum (W.ringOfIntegersFactor (𝓞 F) p)) [w.asIdeal.LiesOver v.asIdeal]
+    (a : W.Aˣ)
+    (h : (2 : ℤ) ∣ Multiplicative.toAdd ((HeightOneSpectrum.comapOfNeBot
+        (W.localFactorIntegerEmb v p w) (IsDiscreteValuationRing.maximalIdeal _)
+        (W.comap_localFactorIntegerEmb_ne_bot v p w)).valuationOfNeZero
+      (Units.map (projFactor 𝕎[v].f_ne_zero 𝕎[v].squarefree_f
+        (W.localFactor v p w)).toRingHom.toMonoidHom
+        (Units.map (W.mapA F_[v]).toMonoidHom a)))) :
+    (2 : ℤ) ∣ Multiplicative.toAdd (w.valuationOfNeZero
+      (Units.map (projFactor W.f_ne_zero W.squarefree_f p).toRingHom.toMonoidHom a)) := by
+  have hkey := HeightOneSpectrum.dvd_toAdd_valuationOfNeZero_map
+    (W.localFactorEmb v p w) (W.localFactorIntegerEmb v p w)
+    (W.algebraMap_comp_localFactorIntegerEmb v p w)
+    (IsDiscreteValuationRing.maximalIdeal _)
+    (W.comap_localFactorIntegerEmb_ne_bot v p w) _ h
+  have hunits : Units.map (W.localFactorEmb v p w : _ →* _)
+      (Units.map (projFactor 𝕎[v].f_ne_zero 𝕎[v].squarefree_f
+        (W.localFactor v p w)).toRingHom.toMonoidHom
+        (Units.map (W.mapA F_[v]).toMonoidHom a)) =
+      Units.map (algebraMap (𝕃 p) (w.adicCompletion (𝕃 p))).toMonoidHom
+        (Units.map (projFactor W.f_ne_zero W.squarefree_f p).toRingHom.toMonoidHom a) :=
+    Units.ext (W.localFactorEmb_projFactor v p w (a : W.A))
+  rw [hunits, HeightOneSpectrum.valuationOfNeZero_maximalIdeal_adicCompletionIntegers] at hkey
+  exact hkey
+
+/- The double contraction of a prime of the local ring of integers is `v`. -/
+private lemma comap_comap_integerMapOfDvd {p : W.f.Factors} {q : 𝕎[v].f.Factors}
+    (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v]))
+    (w : HeightOneSpectrum (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)) :
+    (w.asIdeal.comap (W.integerMapOfDvd v hq)).comap
+      (algebraMap (𝓞 F) (W.ringOfIntegersFactor (𝓞 F) p)) = v.asIdeal := by
+  rw [Ideal.comap_comap, integerMapOfDvd_comp_algebraMap W v hq, ← Ideal.comap_comap]
+  have h1 : w.asIdeal.comap (algebraMap 𝒪_[v] (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)) =
+      IsLocalRing.maximalIdeal 𝒪_[v] :=
+    IsLocalRing.eq_maximalIdeal (HeightOneSpectrum.under 𝒪_[v] w).isMaximal
+  rw [h1, HeightOneSpectrum.comap_maximalIdeal_adicCompletionIntegers]
+
+/- The contraction of a prime of the local ring of integers to the global one is nonzero. -/
+private lemma comap_integerMapOfDvd_ne_bot {p : W.f.Factors} {q : 𝕎[v].f.Factors}
+    (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v]))
+    (w : HeightOneSpectrum (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)) :
+    w.asIdeal.comap (W.integerMapOfDvd v hq) ≠ ⊥ := by
+  refine Ideal.comap_ne_bot_of_comap_comap_ne_bot (FaithfulSMul.algebraMap_injective (𝓞 F)
+    (W.ringOfIntegersFactor (𝓞 F) p)) ?_
+  rw [W.comap_comap_integerMapOfDvd v hq w]
+  exact v.ne_bot
+
+/- The contracted prime lies over `v`. -/
+private lemma under_comapOfNeBot_integerMapOfDvd {p : W.f.Factors} {q : 𝕎[v].f.Factors}
+    (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v]))
+    (w : HeightOneSpectrum (𝕎[v].ringOfIntegersFactor 𝒪_[v] q)) :
+    HeightOneSpectrum.under (𝓞 F) (HeightOneSpectrum.comapOfNeBot (W.integerMapOfDvd v hq) w
+      (W.comap_integerMapOfDvd_ne_bot v hq w)) = v :=
+  HeightOneSpectrum.ext (W.comap_comap_integerMapOfDvd v hq w)
+
+/- The base-change maps of the field factors are compatible with the CRT projections. -/
+private lemma map_projFactor {p : W.f.Factors} {q : 𝕎[v].f.Factors}
+    (hq : (q : F_[v][X]) ∣ (p : F[X]).map (algebraMap F F_[v])) (a : W.A) :
+    AdjoinRoot.map (algebraMap F F_[v]) _ _ hq (projFactor W.f_ne_zero W.squarefree_f p a) =
+      projFactor 𝕎[v].f_ne_zero 𝕎[v].squarefree_f q (W.mapA F_[v] a) := by
+  obtain ⟨g, rfl⟩ := mk_surjective a
+  rw [projFactor_mk, AdjoinRoot.map_mk, mapA_mk, projFactor_mk]
+
+end Semilocal
+
+variable [W.IsElliptic] [W.IsCharNeTwoNF]
+
+open AdjoinRoot in
+open scoped Classical in
+/-- **Semilocal comparison, global to local**: an `S`-unramified square class localizes to an
+unramified class at every good finite place.
+
+Each monic irreducible factor `q` of `f` over `F_v` divides the image of a factor `p` of `f`; the
+induced embedding `F[X] ⧸ (p) → F_v[X] ⧸ (q)` restricts to the rings of integers, the prime of the
+local ring of integers contracts to a prime `w ∣ v`, and the local valuation is the `w`-adic one
+raised to the ramification index, so evenness transfers. -/
+theorem localRes_mem_selmerGroupA {v : HeightOneSpectrum (𝓞 F)} (hv : v ∉ W.badPrimes (𝓞 F))
+    {m : W.M} (hm : m ∈ W.selmerGroupA (𝓞 F)) :
+    W.localRes F_[v] m ∈ 𝕎[v].selmerGroupA 𝒪_[v] := by
+  obtain ⟨a, rfl⟩ := QuotientGroup.mk'_surjective _ m
+  simp only [QuotientGroup.mk'_apply] at hm ⊢
+  rw [mem_selmerGroupA_unit_iff] at hm
+  rw [W.localRes_mem_selmerGroupA_iff v a]
+  intro q w hw
+  -- find the global factor `p` below the local factor `q`
+  obtain ⟨p, hq⟩ := Polynomial.Factors.exists_dvd_map (algebraMap F F_[v]) W.f_ne_zero q.prime
+    (q.dvd.trans (W.baseChange_f F_[v]).dvd)
+  -- the prime of the global field factor below `w`
+  have hne := W.comap_integerMapOfDvd_ne_bot v hq w
+  have hunder := W.under_comapOfNeBot_integerMapOfDvd v hq w
+  -- the global unramifiedness hypothesis at that prime
+  have hdvd := hm p (HeightOneSpectrum.comapOfNeBot (W.integerMapOfDvd v hq) w hne) fun hmem ↦
+    hv (hunder ▸ (HeightOneSpectrum.mem_primesAbove_iff (𝓞 F) _ _ _).mp hmem)
+  -- transport along the embedding of field factors
+  have hkey := HeightOneSpectrum.dvd_toAdd_valuationOfNeZero_map
+    (AdjoinRoot.map (algebraMap F F_[v]) _ _ hq) (W.integerMapOfDvd v hq)
+    (W.algebraMap_comp_integerMapOfDvd v hq) w hne _ hdvd
+  have hunits : Units.map (projFactor 𝕎[v].f_ne_zero 𝕎[v].squarefree_f q).toRingHom.toMonoidHom
+        (Units.map (W.mapA F_[v]).toMonoidHom a) =
+      Units.map (AdjoinRoot.map (algebraMap F F_[v]) _ _ hq : _ →* _)
+        (Units.map (projFactor W.f_ne_zero W.squarefree_f p).toRingHom.toMonoidHom a) :=
+    Units.ext (W.map_projFactor v hq (a : W.A)).symm
+  rw [hunits]
+  exact hkey
+
+open AdjoinRoot in
+open scoped Classical in
+/-- **Semilocal comparison, local to global**: a square class that localizes to an unramified class
+at every finite place is `S`-unramified.
+
+Every prime `w` of a field factor `F[X] ⧸ (p)` above a good place `v` arises from a factor of `f`
+over `F_v`, namely the minimal polynomial of the image of the root in the completion at `w`
+(`localFactor`). Evenness of the valuation transports from the primes of the local ring of integers
+through the completion `(F[X] ⧸ (p))_w` back to `w`. -/
+theorem mem_selmerGroupA_of_forall_localRes {m : W.M}
+    (hm : ∀ v : HeightOneSpectrum (𝓞 F), W.localRes F_[v] m ∈ 𝕎[v].selmerGroupA 𝒪_[v]) :
+    m ∈ W.selmerGroupA (𝓞 F) := by
+  obtain ⟨a, rfl⟩ := QuotientGroup.mk'_surjective _ m
+  simp only [QuotientGroup.mk'_apply]
+  rw [mem_selmerGroupA_unit_iff]
+  intro p w hw
+  have hv : HeightOneSpectrum.under (𝓞 F) w ∉ W.badPrimes (𝓞 F) :=
+    W.under_notMem_badPrimes (𝓞 F) p hw
+  refine W.dvd_toAdd_valuationOfNeZero_of_localFactor (HeightOneSpectrum.under (𝓞 F) w) p w a ?_
+  refine (W.localRes_mem_selmerGroupA_iff (HeightOneSpectrum.under (𝓞 F) w) a).mp
+    (hm (HeightOneSpectrum.under (𝓞 F) w)) _ _ ?_
+  rw [HeightOneSpectrum.mem_primesAbove_iff, W.badPrimes_adicCompletionIntegers hv]
+  exact Set.notMem_empty _
+
+end WeierstrassCurve.Affine
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SemilocalComparison.lean
@@ -281,6 +281,10 @@ private lemma comap_localFactorIntegerEmb_ne_bot (p : W.f.Factors)
       adicCompletionIntegersExtension F (𝕃 p) v w := by
     ext c : 2
     exact RingHom.congr_fun (W.localFactorEmb_comp_algebraMap v p w) c
+  -- `comap_maximalIdeal_adicCompletionIntegersExtension` is stated for
+  -- `IsLocalRing.maximalIdeal`, while contracting a prime lands on the `HeightOneSpectrum`
+  -- wrapper's `asIdeal`. The two are the same term, but `rw` needs the goal written in the
+  -- second spelling and no named equality bridges them, so the identification is `rfl` here.
   rw [Ideal.comap_comap, hsq0,
     show (IsDiscreteValuationRing.maximalIdeal (w.adicCompletionIntegers (𝕃 p))).asIdeal =
       IsLocalRing.maximalIdeal (w.adicCompletionIntegers (𝕃 p)) from rfl,

--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -520,11 +520,10 @@ namespace AdjoinRoot
 
 /-- The base-change map `K[X] ⧸ (p) →+* K_v[X] ⧸ (q)` of `AdjoinRoot`s at a completion is
 compatible with the algebra maps from the underlying Dedekind domain `R` and from the ring of
-integers of the completion.
-
-Stated here rather than beside `AdjoinRoot.map` in `TauCeti.RingTheory.AdjoinRoot.Factors`: it is
-not a fact about `AdjoinRoot` alone, since it names `adicCompletion` and
-`adicCompletionIntegers`, and this module is where those two developments first meet. -/
+integers of the completion. -/
+-- Lives here rather than beside `AdjoinRoot.map` in `TauCeti.RingTheory.AdjoinRoot.Factors`
+-- because it is not a fact about `AdjoinRoot` alone: it names `adicCompletion` and
+-- `adicCompletionIntegers`, and this module is where those two developments first meet.
 lemma map_comp_algebraMap {R : Type*} [CommRing R] [IsDedekindDomain R] {K : Type*}
     [Field K] [Algebra R K] [IsFractionRing R K] (v : HeightOneSpectrum R) {p : K[X]}
     {q : (v.adicCompletion K)[X]} (hq : q ∣ p.map (algebraMap K (v.adicCompletion K))) :

--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
 public import TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion
+public import TauCeti.RingTheory.AdjoinRoot.Factors
 public import TauCeti.RingTheory.DedekindDomain.Ideal
 public import TauCeti.RingTheory.DedekindDomain.ValuationOfNeZero
 
@@ -512,5 +513,32 @@ lemma comap_maximalIdeal_adicCompletionIntegersExtension :
 end Extension
 
 end IsDedekindDomain.HeightOneSpectrum
+
+open Polynomial
+
+namespace AdjoinRoot
+
+/-- The base-change map `K[X] ⧸ (p) →+* K_v[X] ⧸ (q)` of `AdjoinRoot`s at a completion is
+compatible with the algebra maps from the underlying Dedekind domain `R` and from the ring of
+integers of the completion.
+
+Stated here rather than beside `AdjoinRoot.map` in `TauCeti.RingTheory.AdjoinRoot.Factors`: it is
+not a fact about `AdjoinRoot` alone, since it names `adicCompletion` and
+`adicCompletionIntegers`, and this module is where those two developments first meet. -/
+lemma map_comp_algebraMap {R : Type*} [CommRing R] [IsDedekindDomain R] {K : Type*}
+    [Field K] [Algebra R K] [IsFractionRing R K] (v : HeightOneSpectrum R) {p : K[X]}
+    {q : (v.adicCompletion K)[X]} (hq : q ∣ p.map (algebraMap K (v.adicCompletion K))) :
+    (AdjoinRoot.map (algebraMap K (v.adicCompletion K)) p q hq).comp
+        (algebraMap R (AdjoinRoot p)) =
+      (algebraMap (v.adicCompletionIntegers K) (AdjoinRoot q)).comp
+        (algebraMap R (v.adicCompletionIntegers K)) := by
+  ext c
+  simp only [RingHom.comp_apply]
+  rw [IsScalarTower.algebraMap_apply R K (AdjoinRoot p), AdjoinRoot.algebraMap_eq, map_of,
+    IsScalarTower.algebraMap_apply (v.adicCompletionIntegers K) (v.adicCompletion K)
+      (AdjoinRoot q), AdjoinRoot.algebraMap_eq]
+  rfl
+
+end AdjoinRoot
 
 end

--- a/TauCeti/RingTheory/DedekindDomain/Ideal.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Ideal.lean
@@ -468,6 +468,17 @@ lemma eq_maximalIdeal {A : Type*} [CommRing A] [IsDomain A] [IsDiscreteValuation
     (P : HeightOneSpectrum A) : P = IsDiscreteValuationRing.maximalIdeal A :=
   HeightOneSpectrum.ext (IsLocalRing.eq_maximalIdeal P.isMaximal)
 
+/-- The underlying ideal of `IsDiscreteValuationRing.maximalIdeal`, as a `HeightOneSpectrum`, is
+`IsLocalRing.maximalIdeal`.
+
+True by `rfl`, but needed as a rewrite rule: contracting a prime along a ring homomorphism lands
+on `asIdeal`, whereas the lemmas identifying the contraction — `comap_maximalIdeal_*` — are stated
+for `IsLocalRing.maximalIdeal`. -/
+@[simp]
+lemma asIdeal_maximalIdeal (A : Type*) [CommRing A] [IsDomain A] [IsDiscreteValuationRing A] :
+    (IsDiscreteValuationRing.maximalIdeal A).asIdeal = IsLocalRing.maximalIdeal A :=
+  rfl
+
 end IsDedekindDomain.HeightOneSpectrum
 
 end DiscreteValuationRing

--- a/TauCeti/RingTheory/DedekindDomain/Ideal.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Ideal.lean
@@ -468,17 +468,6 @@ lemma eq_maximalIdeal {A : Type*} [CommRing A] [IsDomain A] [IsDiscreteValuation
     (P : HeightOneSpectrum A) : P = IsDiscreteValuationRing.maximalIdeal A :=
   HeightOneSpectrum.ext (IsLocalRing.eq_maximalIdeal P.isMaximal)
 
-/-- The underlying ideal of `IsDiscreteValuationRing.maximalIdeal`, as a `HeightOneSpectrum`, is
-`IsLocalRing.maximalIdeal`.
-
-True by `rfl`, but needed as a rewrite rule: contracting a prime along a ring homomorphism lands
-on `asIdeal`, whereas the lemmas identifying the contraction — `comap_maximalIdeal_*` — are stated
-for `IsLocalRing.maximalIdeal`. -/
-@[simp]
-lemma asIdeal_maximalIdeal (A : Type*) [CommRing A] [IsDomain A] [IsDiscreteValuationRing A] :
-    (IsDiscreteValuationRing.maximalIdeal A).asIdeal = IsLocalRing.maximalIdeal A :=
-  rfl
-
 end IsDedekindDomain.HeightOneSpectrum
 
 end DiscreteValuationRing

--- a/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
+++ b/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
@@ -45,13 +45,11 @@ consequence, also inherit this repository's Selmer-group development. Keeping th
 ## Provenance
 
 Michael Stoll's elliptic-curves formalisation
-(`github.com/MichaelStollBayreuth/EllipticCurves`, at the `EllipticCurves` roadmap's pin
-`66889eada51a`, Apache 2.0, by Michael Stoll) reaches for a
-`HeightOneSpectrum.valuationOfNeZero_eq_iff`; no such lemma exists at our Mathlib pin, so it is
-supplied here. `exists_valuationOfNeZero_map_eq` and `dvd_toAdd_valuationOfNeZero_map` are adapted
-from the same source (`EllipticCurves/Mathlib/Basic.lean`). Following this repository's convention
-for adapted material, the upstream authorship is credited here rather than in the copyright
-header.
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache 2.0, by Michael Stoll) at commit
+`66889eada51a` reaches for a `HeightOneSpectrum.valuationOfNeZero_eq_iff`; no such lemma exists at
+our Mathlib pin, so it is supplied here. `exists_valuationOfNeZero_map_eq` and
+`dvd_toAdd_valuationOfNeZero_map` are adapted from the same source
+(`EllipticCurves/Mathlib/Basic.lean`).
 -/
 
 public section

--- a/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
+++ b/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
@@ -16,7 +16,8 @@ Mathlib attaches to a height one prime `v` of a Dedekind domain `R` a homomorphi
 `v.valuationOfNeZero : Kˣ →* Multiplicative ℤ`, the `v`-adic valuation of a unit of the fraction
 field read without the adjoined zero, and relates it to `v.valuation K` in one direction only:
 `valuationOfNeZero_eq` coerces it into `ℤᵐ⁰`. This file supplies the two complements that make it
-usable as a rewriting rule.
+usable as a rewriting rule, together with two lemmas transporting it along a compatible pair of
+embeddings of Dedekind domains and their fraction fields.
 
 ## Main results
 
@@ -36,8 +37,8 @@ usable as a rewriting rule.
 
 These live in their own module rather than beside their first consumer. `valuationOfNeZero` is
 declared in `Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean`, so any host must import that;
-but the *generic* completion and `S`-integer APIs that need these two lemmas must not, in
-consequence, also inherit this repository's Selmer-group development. Keeping the pair here lets
+but the *generic* completion and `S`-integer APIs that need the two complements must not, in
+consequence, also inherit this repository's Selmer-group development. Keeping them here lets
 `TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean` use them without depending on
 `TauCeti/RingTheory/DedekindDomain/SelmerGroup.lean`, which is downstream of it.
 
@@ -55,6 +56,8 @@ header.
 
 public section
 
+open scoped WithZero
+
 namespace IsDedekindDomain.HeightOneSpectrum
 
 variable {R : Type*} [CommRing R] [IsDedekindDomain R]
@@ -64,7 +67,7 @@ variable {R : Type*} [CommRing R] [IsDedekindDomain R]
 Mathlib carries only the coerced form `valuationOfNeZero_eq`, which this complements. -/
 @[simp]
 theorem valuationOfNeZero_eq_iff (v : HeightOneSpectrum R) (u : Kˣ) (m : Multiplicative ℤ) :
-    v.valuationOfNeZero u = m ↔ v.valuation K (u : K) = (m : WithZero (Multiplicative ℤ)) := by
+    v.valuationOfNeZero u = m ↔ v.valuation K u = (m : ℤᵐ⁰) := by
   rw [← WithZero.coe_inj, valuationOfNeZero_eq]
 
 /-- A unit has trivial `v`-adic `valuationOfNeZero` iff its `v`-adic valuation is `1`, the case
@@ -75,8 +78,8 @@ annotation instead. With both marked, `simpNF` rejects this one — "simp can pr
 the general form subsumes it. Every consumer names it explicitly, so nothing depends on the
 attribute. -/
 theorem valuationOfNeZero_eq_one_iff (v : HeightOneSpectrum R) (x : Kˣ) :
-    v.valuationOfNeZero x = 1 ↔ v.valuation K (x : K) = 1 := by
-  simp
+    v.valuationOfNeZero x = 1 ↔ v.valuation K x = 1 := by
+  simp only [valuationOfNeZero_eq_iff, WithZero.coe_one]
 
 section Transport
 
@@ -89,25 +92,23 @@ of their fraction fields, the `w`-adic valuation of `φ u` is the valuation of `
 contracted prime `comapOfNeBot ψ w hne`, raised to a fixed power independent of `u` — namely the
 ramification index of `w` over that contraction. -/
 theorem exists_valuationOfNeZero_map_eq (φ : L →+* N) (ψ : B →+* C)
-    (hcomp : (algebraMap C N).comp ψ = φ.comp (algebraMap B L))
-    (w : HeightOneSpectrum C) (hne : w.asIdeal.comap ψ ≠ ⊥) :
+    (hcomp : (algebraMap C N).comp ψ = φ.comp (algebraMap B L)) (w : HeightOneSpectrum C)
+    (hne : w.asIdeal.comap ψ ≠ ⊥) :
     ∃ e : ℕ, ∀ u : Lˣ, w.valuationOfNeZero (Units.map (φ : L →* N) u) =
       (comapOfNeBot ψ w hne).valuationOfNeZero u ^ e := by
+  -- the tower of algebras that `valuation_liesOver` compares the two valuations along
   let _ : Algebra B C := ψ.toAlgebra
   let _ : Algebra L N := φ.toAlgebra
   let _ : Algebra B N := (φ.comp (algebraMap B L)).toAlgebra
-  have hψ : Function.Injective ψ := by
-    have h : Function.Injective ((algebraMap C N).comp ψ) := by
-      rw [hcomp]
-      exact φ.injective.comp (IsFractionRing.injective B L)
-    exact fun x y hxy ↦ h (by simp only [RingHom.comp_apply, hxy])
+  have hψ : Function.Injective ψ := .of_comp (f := algebraMap C N) <| by
+    rw [← RingHom.coe_comp, hcomp]
+    exact φ.injective.comp (IsFractionRing.injective B L)
   have : IsScalarTower B L N := .of_algebraMap_eq' rfl
-  have : IsScalarTower B C N := .of_algebraMap_eq fun x ↦ (RingHom.congr_fun hcomp x).symm
+  have : IsScalarTower B C N := .of_algebraMap_eq' hcomp.symm
   have : Module.IsTorsionFree B C := Module.isTorsionFree_iff_algebraMap_injective.mpr hψ
   have : w.asIdeal.LiesOver (comapOfNeBot ψ w hne).asIdeal := ⟨comapOfNeBot_asIdeal ψ w hne⟩
   refine ⟨(comapOfNeBot ψ w hne).asIdeal.ramificationIdx' w.asIdeal, fun u ↦ ?_⟩
-  rw [valuationOfNeZero_eq_iff, WithZero.coe_pow, valuationOfNeZero_eq, Units.coe_map,
-    MonoidHom.coe_coe]
+  rw [valuationOfNeZero_eq_iff, WithZero.coe_pow, valuationOfNeZero_eq]
   exact (valuation_liesOver N (comapOfNeBot ψ w hne) w (u : L)).symm
 
 /-- Divisibility of adic valuations transports along compatible embeddings: if the valuation of
@@ -118,13 +119,12 @@ This is the form in which the semilocal comparison of `2`-descent uses
 multiplication preserves divisibility, so parity — the case `n = 2` — survives in both
 directions. -/
 theorem dvd_toAdd_valuationOfNeZero_map (φ : L →+* N) (ψ : B →+* C)
-    (hcomp : (algebraMap C N).comp ψ = φ.comp (algebraMap B L))
-    (w : HeightOneSpectrum C) (hne : w.asIdeal.comap ψ ≠ ⊥) {n : ℕ} (u : Lˣ)
+    (hcomp : (algebraMap C N).comp ψ = φ.comp (algebraMap B L)) (w : HeightOneSpectrum C)
+    (hne : w.asIdeal.comap ψ ≠ ⊥) {n : ℕ} (u : Lˣ)
     (h : (n : ℤ) ∣ Multiplicative.toAdd ((comapOfNeBot ψ w hne).valuationOfNeZero u)) :
     (n : ℤ) ∣ Multiplicative.toAdd (w.valuationOfNeZero (Units.map (φ : L →* N) u)) := by
   obtain ⟨e, he⟩ := exists_valuationOfNeZero_map_eq φ ψ hcomp w hne
-  rw [he u, toAdd_pow, nsmul_eq_mul]
-  exact h.mul_left _
+  simpa only [he u, toAdd_pow, nsmul_eq_mul] using h.mul_left _
 
 end Transport
 

--- a/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
+++ b/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
@@ -69,12 +69,9 @@ theorem valuationOfNeZero_eq_iff (v : HeightOneSpectrum R) (u : Kˣ) (m : Multip
   rw [← WithZero.coe_inj, valuationOfNeZero_eq]
 
 /-- A unit has trivial `v`-adic `valuationOfNeZero` iff its `v`-adic valuation is `1`, the case
-`m = 1` of `valuationOfNeZero_eq_iff`.
-
-Not `@[simp]`: it is the `m = 1` instance of `valuationOfNeZero_eq_iff`, which carries the
-annotation instead. With both marked, `simpNF` rejects this one — "simp can prove this" — because
-the general form subsumes it. Every consumer names it explicitly, so nothing depends on the
-attribute. -/
+`m = 1` of `valuationOfNeZero_eq_iff`. -/
+-- Deliberately not `@[simp]`: `valuationOfNeZero_eq_iff` carries the annotation, and with both
+-- marked `simpNF` rejects this one — "simp can prove this" — since the general form subsumes it.
 theorem valuationOfNeZero_eq_one_iff (v : HeightOneSpectrum R) (x : Kˣ) :
     v.valuationOfNeZero x = 1 ↔ v.valuation K x = 1 := by
   simp only [valuationOfNeZero_eq_iff, WithZero.coe_one]

--- a/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
+++ b/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
@@ -120,9 +120,9 @@ multiplication preserves divisibility, so parity — the case `n = 2` — surviv
 directions. -/
 theorem dvd_toAdd_valuationOfNeZero_map (φ : L →+* N) (ψ : B →+* C)
     (hcomp : (algebraMap C N).comp ψ = φ.comp (algebraMap B L)) (w : HeightOneSpectrum C)
-    (hne : w.asIdeal.comap ψ ≠ ⊥) {n : ℕ} (u : Lˣ)
-    (h : (n : ℤ) ∣ Multiplicative.toAdd ((comapOfNeBot ψ w hne).valuationOfNeZero u)) :
-    (n : ℤ) ∣ Multiplicative.toAdd (w.valuationOfNeZero (Units.map (φ : L →* N) u)) := by
+    (hne : w.asIdeal.comap ψ ≠ ⊥) {n : ℤ} (u : Lˣ)
+    (h : n ∣ Multiplicative.toAdd ((comapOfNeBot ψ w hne).valuationOfNeZero u)) :
+    n ∣ Multiplicative.toAdd (w.valuationOfNeZero (Units.map (φ : L →* N) u)) := by
   obtain ⟨e, he⟩ := exists_valuationOfNeZero_map_eq φ ψ hcomp w hne
   simpa only [he u, toAdd_pow, nsmul_eq_mul] using h.mul_left _
 

--- a/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
+++ b/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
@@ -5,7 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.NumberTheory.RamificationInertia.Valuation
 public import Mathlib.RingTheory.DedekindDomain.SelmerGroup
+public import TauCeti.RingTheory.DedekindDomain.Ideal
 
 /-!
 # The `Multiplicative ℤ`-valued adic valuation of a unit
@@ -22,6 +24,13 @@ usable as a rewriting rule.
   valuation of a unit is determined by the `ℤᵐ⁰`-valued one.
 * `IsDedekindDomain.HeightOneSpectrum.valuationOfNeZero_eq_one_iff`: its `m = 1` case, that a unit
   has trivial `v`-adic `valuationOfNeZero` exactly when its `v`-adic valuation is `1`.
+* `IsDedekindDomain.HeightOneSpectrum.exists_valuationOfNeZero_map_eq`: along a pair of compatible
+  embeddings `ψ : B →+* C` of Dedekind domains and `φ : L →+* N` of their fraction fields, the
+  `w`-adic valuation of `φ u` is the valuation of `u` at the contracted prime raised to a fixed
+  power — the ramification index of `w` over that contraction.
+* `IsDedekindDomain.HeightOneSpectrum.dvd_toAdd_valuationOfNeZero_map`: consequently divisibility
+  of the valuation by `n` transports along such an embedding. Only the *existence* of the exponent
+  matters for that, which is why the exponent is left existentially quantified above.
 
 ## Implementation notes
 
@@ -38,8 +47,10 @@ Michael Stoll's elliptic-curves formalisation
 (`github.com/MichaelStollBayreuth/EllipticCurves`, at the `EllipticCurves` roadmap's pin
 `66889eada51a`, Apache 2.0, by Michael Stoll) reaches for a
 `HeightOneSpectrum.valuationOfNeZero_eq_iff`; no such lemma exists at our Mathlib pin, so it is
-supplied here. Following this repository's convention for adapted material, the upstream
-authorship is credited here rather than in the copyright header.
+supplied here. `exists_valuationOfNeZero_map_eq` and `dvd_toAdd_valuationOfNeZero_map` are adapted
+from the same source (`EllipticCurves/Mathlib/Basic.lean`). Following this repository's convention
+for adapted material, the upstream authorship is credited here rather than in the copyright
+header.
 -/
 
 public section
@@ -66,6 +77,56 @@ attribute. -/
 theorem valuationOfNeZero_eq_one_iff (v : HeightOneSpectrum R) (x : Kˣ) :
     v.valuationOfNeZero x = 1 ↔ v.valuation K (x : K) = 1 := by
   simp
+
+section Transport
+
+variable {B C : Type*} [CommRing B] [IsDedekindDomain B] [CommRing C] [IsDedekindDomain C]
+  {L N : Type*} [Field L] [Algebra B L] [IsFractionRing B L]
+  [Field N] [Algebra C N] [IsFractionRing C N]
+
+/-- Along an embedding `ψ : B →+* C` of Dedekind domains and a compatible embedding `φ : L →+* N`
+of their fraction fields, the `w`-adic valuation of `φ u` is the valuation of `u` at the
+contracted prime `comapOfNeBot ψ w hne`, raised to a fixed power independent of `u` — namely the
+ramification index of `w` over that contraction. -/
+theorem exists_valuationOfNeZero_map_eq (φ : L →+* N) (ψ : B →+* C)
+    (hcomp : (algebraMap C N).comp ψ = φ.comp (algebraMap B L))
+    (w : HeightOneSpectrum C) (hne : w.asIdeal.comap ψ ≠ ⊥) :
+    ∃ e : ℕ, ∀ u : Lˣ, w.valuationOfNeZero (Units.map (φ : L →* N) u) =
+      (comapOfNeBot ψ w hne).valuationOfNeZero u ^ e := by
+  let _ : Algebra B C := ψ.toAlgebra
+  let _ : Algebra L N := φ.toAlgebra
+  let _ : Algebra B N := (φ.comp (algebraMap B L)).toAlgebra
+  have hψ : Function.Injective ψ := by
+    have h : Function.Injective ((algebraMap C N).comp ψ) := by
+      rw [hcomp]
+      exact φ.injective.comp (IsFractionRing.injective B L)
+    exact fun x y hxy ↦ h (by simp only [RingHom.comp_apply, hxy])
+  have : IsScalarTower B L N := .of_algebraMap_eq' rfl
+  have : IsScalarTower B C N := .of_algebraMap_eq fun x ↦ (RingHom.congr_fun hcomp x).symm
+  have : Module.IsTorsionFree B C := Module.isTorsionFree_iff_algebraMap_injective.mpr hψ
+  have : w.asIdeal.LiesOver (comapOfNeBot ψ w hne).asIdeal := ⟨rfl⟩
+  refine ⟨(comapOfNeBot ψ w hne).asIdeal.ramificationIdx' w.asIdeal, fun u ↦ ?_⟩
+  rw [valuationOfNeZero_eq_iff, WithZero.coe_pow, valuationOfNeZero_eq, Units.coe_map,
+    MonoidHom.coe_coe]
+  exact (valuation_liesOver N (comapOfNeBot ψ w hne) w (u : L)).symm
+
+/-- Divisibility of adic valuations transports along compatible embeddings: if the valuation of
+`u` at the contracted prime is divisible by `n`, so is the `w`-adic valuation of `φ u`.
+
+This is the form in which the semilocal comparison of `2`-descent uses
+`exists_valuationOfNeZero_map_eq`: ramification multiplies the valuation by a fixed factor, and
+multiplication preserves divisibility, so parity — the case `n = 2` — survives in both
+directions. -/
+theorem dvd_toAdd_valuationOfNeZero_map (φ : L →+* N) (ψ : B →+* C)
+    (hcomp : (algebraMap C N).comp ψ = φ.comp (algebraMap B L))
+    (w : HeightOneSpectrum C) (hne : w.asIdeal.comap ψ ≠ ⊥) {n : ℕ} (u : Lˣ)
+    (h : (n : ℤ) ∣ Multiplicative.toAdd ((comapOfNeBot ψ w hne).valuationOfNeZero u)) :
+    (n : ℤ) ∣ Multiplicative.toAdd (w.valuationOfNeZero (Units.map (φ : L →* N) u)) := by
+  obtain ⟨e, he⟩ := exists_valuationOfNeZero_map_eq φ ψ hcomp w hne
+  rw [he u, toAdd_pow, nsmul_eq_mul]
+  exact h.mul_left _
+
+end Transport
 
 end IsDedekindDomain.HeightOneSpectrum
 

--- a/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
+++ b/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
@@ -104,7 +104,7 @@ theorem exists_valuationOfNeZero_map_eq (φ : L →+* N) (ψ : B →+* C)
   have : IsScalarTower B L N := .of_algebraMap_eq' rfl
   have : IsScalarTower B C N := .of_algebraMap_eq fun x ↦ (RingHom.congr_fun hcomp x).symm
   have : Module.IsTorsionFree B C := Module.isTorsionFree_iff_algebraMap_injective.mpr hψ
-  have : w.asIdeal.LiesOver (comapOfNeBot ψ w hne).asIdeal := ⟨rfl⟩
+  have : w.asIdeal.LiesOver (comapOfNeBot ψ w hne).asIdeal := ⟨comapOfNeBot_asIdeal ψ w hne⟩
   refine ⟨(comapOfNeBot ψ w hne).asIdeal.ramificationIdx' w.asIdeal, fun u ↦ ?_⟩
   rw [valuationOfNeZero_eq_iff, WithZero.coe_pow, valuationOfNeZero_eq, Units.coe_map,
     MonoidHom.coe_coe]

--- a/TauCeti/RingTheory/Polynomial/Factors.lean
+++ b/TauCeti/RingTheory/Polynomial/Factors.lean
@@ -184,6 +184,21 @@ lemma span_eq_iInf_span (hf : f ≠ 0) (hsq : Squarefree f) :
   rw [Ideal.iInf_span_singleton fun _ _ hpq ↦ isCoprime hpq]
   exact (Ideal.span_singleton_eq_span_singleton.mpr (associated_prod hf hsq)).symm
 
+/-- An irreducible factor of the image of `f` under a field embedding divides the image of one of
+the irreducible factors of `f`.
+
+This is what lets a local computation be indexed by the factors of `f` over the base field: every
+factor over the extension sits above exactly one of them. -/
+lemma exists_dvd_map {L : Type*} [Field L] (σ : K →+* L) (hf : f ≠ 0) {q : L[X]} (hq : Prime q)
+    (hdvd : q ∣ f.map σ) : ∃ p : f.Factors, q ∣ (p : K[X]).map σ := by
+  classical
+  have h1 : Associated ((normalizedFactors f).map (Polynomial.map σ)).prod (f.map σ) := by
+    have h2 := (prod_normalizedFactors hf).map (mapRingHom σ)
+    rwa [map_multiset_prod, coe_mapRingHom] at h2
+  obtain ⟨g, hgmem, hgdvd⟩ := hq.exists_mem_multiset_dvd (hdvd.trans h1.symm.dvd)
+  obtain ⟨p₀, hp₀, rfl⟩ := Multiset.mem_map.mp hgmem
+  exact ⟨⟨p₀, (mem_normalizedFactors_iff hf).mp hp₀⟩, hgdvd⟩
+
 end Factors
 
 end Polynomial

--- a/TauCeti/RingTheory/Polynomial/Factors.lean
+++ b/TauCeti/RingTheory/Polynomial/Factors.lean
@@ -184,11 +184,11 @@ lemma span_eq_iInf_span (hf : f ≠ 0) (hsq : Squarefree f) :
   rw [Ideal.iInf_span_singleton fun _ _ hpq ↦ isCoprime hpq]
   exact (Ideal.span_singleton_eq_span_singleton.mpr (associated_prod hf hsq)).symm
 
-/-- An irreducible factor of the image of `f` under a field embedding divides the image of one of
-the irreducible factors of `f`.
+/-- A prime factor of the image of `f` under a field embedding divides the image of one of the
+monic irreducible factors of `f`.
 
 This is what lets a local computation be indexed by the factors of `f` over the base field: every
-factor over the extension sits above exactly one of them. -/
+prime of the extension divides the image of at least one of them. -/
 lemma exists_dvd_map {L : Type*} [Field L] (σ : K →+* L) (hf : f ≠ 0) {q : L[X]} (hq : Prime q)
     (hdvd : q ∣ f.map σ) : ∃ p : f.Factors, q ∣ (p : K[X]).map σ := by
   classical

--- a/TauCeti/RingTheory/Polynomial/Factors.lean
+++ b/TauCeti/RingTheory/Polynomial/Factors.lean
@@ -197,7 +197,7 @@ lemma exists_dvd_map {L : Type*} [Field L] (σ : K →+* L) (hf : f ≠ 0) {q : 
     rwa [map_multiset_prod, coe_mapRingHom] at h2
   obtain ⟨g, hgmem, hgdvd⟩ := hq.exists_mem_multiset_dvd (hdvd.trans h1.symm.dvd)
   obtain ⟨p₀, hp₀, rfl⟩ := Multiset.mem_map.mp hgmem
-  exact ⟨⟨p₀, (mem_normalizedFactors_iff hf).mp hp₀⟩, hgdvd⟩
+  exact ⟨⟨p₀, (Polynomial.mem_normalizedFactors_iff hf).mp hp₀⟩, hgdvd⟩
 
 end Factors
 


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:Layer-6-explicit-2-descent:semilocal-comparison"}-->

Provenance: github.com/MichaelStollBayreuth/EllipticCurves @ 66889eada51a, Apache-2.0 — `EllipticCurves/SelmerGroup.lean` section `Semilocal` (:649-965), together with `AdjoinRoot.map_comp_algebraMap` from `EllipticCurves/Mathlib/Basic.lean`:942.

## What this adds

At a **good** finite place, the global `S`-unramifiedness condition `A(S,2)` and its local
counterpart agree — in both directions. That is what makes the local conditions at the good finite
places redundant, so membership in the `2`-Selmer group reduces to the finitely many conditions at
the bad and infinite places.

For `W : y² = f(x) = x³ + a₂x² + a₄x + a₆` in characteristic `≠ 2` normal form over a number field
`F`, with étale algebra `W.A = F[X] ⧸ (f)` and square classes `W.M`:

- **`WeierstrassCurve.Affine.localRes_mem_selmerGroupA`** (global → local): an `S`-unramified
  square class localizes to an unramified class at every good finite place.
- **`WeierstrassCurve.Affine.mem_selmerGroupA_of_forall_localRes`** (local → global): a square
  class that localizes to an unramified class at every **good** finite place is `S`-unramified.

This is the roadmap's Layer 6 explicit `2`-descent bullet; `STATUS.md` records explicit 2-descent
as having "local conditions and rank-bound machinery" outstanding.

## How it is proved

Both directions rest on one mechanism: **parity of a valuation is insensitive to ramification**,
because ramification multiplies the valuation by a fixed index
(`IsDedekindDomain.HeightOneSpectrum.dvd_toAdd_valuationOfNeZero_map`). The directions differ only
in which embedding carries the parity.

*Global to local* factors the local étale algebra: every monic irreducible factor `q` of `f` over
`F_v` divides the image of a unique factor `p` of `f` over `F`
(`Polynomial.Factors.exists_dvd_map`), the induced `AdjoinRoot.map` restricts to the rings of
integers (`integerMapOfDvd`), and the prime of the local ring of integers contracts to a prime
`w ∣ v` of the ring of integers of `F[X] ⧸ (p)`.

*Local to global* goes the other way and needs a factor to start from: `localFactor` produces one,
as the minimal polynomial over `F_v` of the image of the root of `p` in the completion of
`F[X] ⧸ (p)` at `w`.

Notably this uses only the extension of adic completions
(`IsDedekindDomain.HeightOneSpectrum.adicCompletionExtension`), **not** the full decomposition
`W.A ⊗ F_v ≅ ∏ (𝕃 p)_w` of the completed étale algebra: for parity, ramification is harmless in
both directions, so the decomposition is not needed.

## Files

- `MordellWeil/SemilocalComparison.lean` (new, 507 lines) — the comparison. All helpers are
  `private`; they are scaffolding stated in vocabulary (`localFactor`, `integerMapOfDvd`) with no
  meaning outside it.
- `MordellWeil/SelmerGroupA.lean` (+20) — the `A(S,2)` condition this compares against.
- `RingTheory/DedekindDomain/ValuationOfNeZero.lean` (+65/−2) — two lemmas transporting
  `valuationOfNeZero` along a compatible pair of embeddings of Dedekind domains and their fraction
  fields, plus notation and proof hygiene on the two existing complements.
- `RingTheory/DedekindDomain/AdicCompletionExtension.lean` (+28) — `AdjoinRoot.map_comp_algebraMap`,
  the compatibility of the `AdjoinRoot` base-change map at a completion with the algebra maps from
  the Dedekind domain and from the completion's ring of integers. This module is where `AdjoinRoot`
  and the adic completion first meet.
- `RingTheory/Polynomial/Factors.lean` (+15) — `exists_dvd_map`'s statement made accurate.

## Adaptation notes

The source states square classes as its own `Units.modPow`; they are re-spelled here to this
repository's single spelling `Mˣ ⧸ (powMonoidHom n).range`. The source's
`HeightOneSpectrum.below` is Mathlib's `HeightOneSpectrum.under`
(`Mathlib/RingTheory/DedekindDomain/Ideal/Lemmas.lean`:1217). Per this repository's convention for
adapted material, upstream authorship is credited in the module's Provenance section rather than
in the copyright header.

## Gates

- `lake build` on all five modules and their reverse dependencies (`SelmerGroup`,
  `AdicCompletionExtension`): green, 3550 jobs, 0 errors, 0 warnings under `warningAsError = true`.
- No `sorry`, no `native_decide`, no `maxHeartbeats`.
- Longest new proof is 36 lines, under the 50-line cap.
- New file is 507 lines, under the 1000-line new-file guard.

## Review

Round 1 (head `4965cbd`) returned 6/10 rubrics green — correctness, scope, attribution, placement,
naming and **proof-quality** all approved — with `reuse`, `api-design`, `generality` and
`documentation` requesting changes. All six findings are addressed in `3ec8ef9`:

- `asIdeal_maximalIdeal` deleted (it restated a definitional equality); its one use site now uses
  an inline `show … from rfl`, and `RingTheory/DedekindDomain/Ideal.lean` drops out of the diff.
- `mem_selmerGroupA_of_forall_localRes` now assumes the local condition only at good places —
  `api-design` and `generality` reported the same defect, and the proof already had the `hv` the
  weaker hypothesis needs.
- `AdjoinRoot.map_comp_algebraMap` moved out of the elliptic-curve file to
  `AdicCompletionExtension.lean` and exported.
- `mem_selmerGroupA_unit_iff` gained the `@[simp]` its per-factor sibling already had.
- `dvd_toAdd_valuationOfNeZero_map` restated with `{n : ℤ}` instead of `{n : ℕ}`.
- The module docstring's "in both directions" summary now matches the theorems, and the
  `## Roadmap` section is removed.
