### PR TITLE
feat(Topology): complete the IsAdic API from the Stoll port

### DIFF
--- a/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -25,8 +25,6 @@ series evaluated at arguments of `I ^ n` is confined to `I ^ n`, in
 
 ## Main results
 
-* `IsAdic.isLinearTopology` : a ring whose topology is `I`-adic is linearly topologized.
-* `IsAdic.nonarchimedeanRing` : a ring whose topology is `I`-adic is nonarchimedean.
 * `IsAdic.isOpen_pow` : in a ring whose topology is `I`-adic, every power of `I` is open.
 * `IsAdic.isClosed_pow` : in a ring whose topology is `I`-adic, every power of `I` is closed —
   an open additive subgroup of a topological group being closed.
@@ -42,7 +40,10 @@ Apache-2.0) at commit `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, file
 `EllipticCurves/Mathlib/Chabauty/AdicTopology.lean`, where these appear under the same names
 among that development's Mathlib-bound material. That file describes its contents as the
 `IsAdic` counterparts of `Ideal.isLinearTopology` and `WithIdeal.isTopologicallyNilpotent_of_mem`,
-which is the reading taken here.
+which is the reading taken here. The source's `IsAdic.isLinearTopology` and
+`IsAdic.nonarchimedeanRing` are deliberately not carried over: `hI ▸ I.isLinearTopology` and
+`hI ▸ I.nonarchimedean` are the whole content, so naming them would add a parallel API rather
+than a result.
 -/
 
 public section
@@ -50,16 +51,6 @@ public section
 namespace IsAdic
 
 variable {R : Type*} [CommRing R] [TopologicalSpace R] {I : Ideal R}
-
-/-- In a ring whose topology is the `I`-adic one, the topology is linear: the powers of `I` form
-a basis of neighbourhoods of zero consisting of ideals. -/
-theorem isLinearTopology (hI : IsAdic I) : IsLinearTopology R R :=
-  hI ▸ I.isLinearTopology
-
-/-- In a ring whose topology is the `I`-adic one, the ring is nonarchimedean: every neighbourhood
-of zero contains an open additive subgroup. -/
-theorem nonarchimedeanRing (hI : IsAdic I) : NonarchimedeanRing R :=
-  hI ▸ I.nonarchimedean
 
 /-- In a ring whose topology is the `I`-adic one, every power of `I` is open. -/
 theorem isOpen_pow (hI : IsAdic I) (n : ℕ) : IsOpen ((I ^ n : Ideal R) : Set R) :=
@@ -69,23 +60,26 @@ theorem isOpen_pow (hI : IsAdic I) (n : ℕ) : IsOpen ((I ^ n : Ideal R) : Set R
 /-- In a ring whose topology is the `I`-adic one, every power of `I` is closed: it is an open
 additive subgroup, and an open subgroup of a topological group is closed. -/
 theorem isClosed_pow (hI : IsAdic I) (n : ℕ) : IsClosed ((I ^ n : Ideal R) : Set R) :=
-  have : NonarchimedeanRing R := hI.nonarchimedeanRing
+  have : NonarchimedeanRing R := hI ▸ I.nonarchimedean
   AddSubgroup.isClosed_of_isOpen (I ^ n).toAddSubgroup (hI.isOpen_pow n)
 
 open Filter Topology in
 /-- In a ring whose topology is the `I`-adic one, a family whose members lie in growing powers of
-`I` tends to zero, provided the exponents tend to infinity. The index filter is arbitrary: `atTop`
-for a sequence, `cofinite` for the decay condition of `MvPowerSeries.HasEval`. For the powers of a
-single element of `I` use `IsAdic.isTopologicallyNilpotent_of_mem` instead. -/
+`I` tends to zero, provided the exponents tend to infinity. Only eventual membership is needed,
+since convergence along `l` cannot see failures outside an `l`-large set; a pointwise caller
+supplies `Filter.Eventually.of_forall`. The index filter is arbitrary: `atTop` for a sequence,
+`cofinite` for the decay condition of `MvPowerSeries.HasEval`. For the powers of a single element
+of `I` use `IsAdic.isTopologicallyNilpotent_of_mem` instead. -/
 theorem tendsto_zero_of_mem_pow (hI : IsAdic I) {γ : Type*} {l : Filter γ} {g : γ → R} {e : γ → ℕ}
-    (hg : ∀ i, g i ∈ I ^ e i) (he : Tendsto e l atTop) : Tendsto g l (𝓝 0) :=
-  hI.hasBasis_nhds_zero.tendsto_right_iff.2 fun k _ ↦
-    (he.eventually_ge_atTop k).mono fun i hi ↦ Ideal.pow_le_pow_right hi (hg i)
+    (hg : ∀ᶠ i in l, g i ∈ I ^ e i) (he : Tendsto e l atTop) : Tendsto g l (𝓝 0) :=
+  hI.hasBasis_nhds_zero.tendsto_right_iff.2 fun k _ ↦ by
+    filter_upwards [hg, he.eventually_ge_atTop k] with i hi hik
+    exact Ideal.pow_le_pow_right hik hi
 
 /-- In a ring whose topology is the `I`-adic one, every element of `I` is topologically
 nilpotent. -/
 theorem isTopologicallyNilpotent_of_mem (hI : IsAdic I) {a : R} (ha : a ∈ I) :
     IsTopologicallyNilpotent a :=
-  hI.tendsto_zero_of_mem_pow (Ideal.pow_mem_pow ha) Filter.tendsto_id
+  hI.tendsto_zero_of_mem_pow (.of_forall (Ideal.pow_mem_pow ha)) Filter.tendsto_id
 
 end IsAdic

--- a/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -40,10 +40,7 @@ Apache-2.0) at commit `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, file
 `EllipticCurves/Mathlib/Chabauty/AdicTopology.lean`, where these appear under the same names
 among that development's Mathlib-bound material. That file describes its contents as the
 `IsAdic` counterparts of `Ideal.isLinearTopology` and `WithIdeal.isTopologicallyNilpotent_of_mem`,
-which is the reading taken here. The source's `IsAdic.isLinearTopology` and
-`IsAdic.nonarchimedeanRing` are deliberately not carried over: `hI ▸ I.isLinearTopology` and
-`hI ▸ I.nonarchimedean` are the whole content, so naming them would add a parallel API rather
-than a result.
+which is the reading taken here.
 -/
 
 public section

--- a/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -25,15 +25,15 @@ series evaluated at arguments of `I ^ n` is confined to `I ^ n`, in
 
 ## Main results
 
+* `IsAdic.isLinearTopology` : a ring whose topology is `I`-adic is linearly topologized.
+* `IsAdic.nonarchimedeanRing` : a ring whose topology is `I`-adic is nonarchimedean.
 * `IsAdic.isOpen_pow` : in a ring whose topology is `I`-adic, every power of `I` is open.
 * `IsAdic.isClosed_pow` : in a ring whose topology is `I`-adic, every power of `I` is closed —
   an open additive subgroup of a topological group being closed.
-* `IsAdic.isTopologicallyNilpotent_of_mem` : in a ring whose topology is `I`-adic, every element
-  of `I` is topologically nilpotent.
-* `IsAdic.isLinearTopology` : a ring whose topology is `I`-adic is linearly topologized.
-* `IsAdic.nonarchimedeanRing` : a ring whose topology is `I`-adic is nonarchimedean.
 * `IsAdic.tendsto_zero_of_mem_pow` : a family whose members lie in growing powers of `I` tends to
   zero, provided the exponents tend to infinity.
+* `IsAdic.isTopologicallyNilpotent_of_mem` : in a ring whose topology is `I`-adic, every element
+  of `I` is topologically nilpotent.
 
 ## Provenance
 
@@ -54,52 +54,38 @@ variable {R : Type*} [CommRing R] [TopologicalSpace R] {I : Ideal R}
 /-- In a ring whose topology is the `I`-adic one, the topology is linear: the powers of `I` form
 a basis of neighbourhoods of zero consisting of ideals. -/
 theorem isLinearTopology (hI : IsAdic I) : IsLinearTopology R R :=
-  IsLinearTopology.mk_of_hasBasis _ hI.hasBasis_nhds_zero
+  hI ▸ I.isLinearTopology
 
 /-- In a ring whose topology is the `I`-adic one, the ring is nonarchimedean: every neighbourhood
 of zero contains an open additive subgroup. -/
-theorem nonarchimedeanRing (hI : IsAdic I) : NonarchimedeanRing R := by
-  simp only [IsAdic] at hI
-  subst hI
-  exact I.nonarchimedean
+theorem nonarchimedeanRing (hI : IsAdic I) : NonarchimedeanRing R :=
+  hI ▸ I.nonarchimedean
 
 /-- In a ring whose topology is the `I`-adic one, every power of `I` is open. -/
-theorem isOpen_pow (hI : IsAdic I) (n : ℕ) : IsOpen ((I ^ n : Ideal R) : Set R) := by
-  simp only [IsAdic] at hI
-  subst hI
-  let : TopologicalSpace R := I.adicTopology
-  exact (I.openAddSubgroup n).isOpen'
+theorem isOpen_pow (hI : IsAdic I) (n : ℕ) : IsOpen ((I ^ n : Ideal R) : Set R) :=
+  letI := I.adicTopology
+  hI ▸ (I.openAddSubgroup n).isOpen
 
 /-- In a ring whose topology is the `I`-adic one, every power of `I` is closed: it is an open
 additive subgroup, and an open subgroup of a topological group is closed. -/
-theorem isClosed_pow (hI : IsAdic I) (n : ℕ) : IsClosed ((I ^ n : Ideal R) : Set R) := by
-  have hopen := hI.isOpen_pow n
-  simp only [IsAdic] at hI
-  subst hI
-  let : TopologicalSpace R := I.adicTopology
-  have : NonarchimedeanRing R := I.nonarchimedean
-  exact AddSubgroup.isClosed_of_isOpen (I ^ n).toAddSubgroup hopen
-
-/-- In a ring whose topology is the `I`-adic one, every element of `I` is topologically
-nilpotent. -/
--- Mathlib proves this for its `WithIdeal` class, whose topology is adic by construction. A ring
--- that merely satisfies `IsAdic I` already carries a topology of its own, so it cannot take that
--- instance without a second one; the argument is therefore run against
--- `IsAdic.hasBasis_nhds_zero`.
-theorem isTopologicallyNilpotent_of_mem (hI : IsAdic I) {a : R} (ha : a ∈ I) :
-    IsTopologicallyNilpotent a := by
-  suffices ∀ m : ℕ, ∃ n₀, ∀ n, n₀ ≤ n → a ^ n ∈ I ^ m by
-    simpa [IsTopologicallyNilpotent, hI.hasBasis_nhds_zero.tendsto_right_iff]
-  exact fun m ↦ ⟨m, fun n hn ↦ Ideal.pow_le_pow_right hn (Ideal.pow_mem_pow ha _)⟩
+theorem isClosed_pow (hI : IsAdic I) (n : ℕ) : IsClosed ((I ^ n : Ideal R) : Set R) :=
+  have : NonarchimedeanRing R := hI.nonarchimedeanRing
+  AddSubgroup.isClosed_of_isOpen (I ^ n).toAddSubgroup (hI.isOpen_pow n)
 
 open Filter Topology in
 /-- In a ring whose topology is the `I`-adic one, a family whose members lie in growing powers of
-`I` tends to zero, provided the exponents tend to infinity. -/
+`I` tends to zero, provided the exponents tend to infinity. The index filter is arbitrary: `atTop`
+for a sequence, `cofinite` for the decay condition of `MvPowerSeries.HasEval`. For the powers of a
+single element of `I` use `IsAdic.isTopologicallyNilpotent_of_mem` instead. -/
 theorem tendsto_zero_of_mem_pow (hI : IsAdic I) {γ : Type*} {l : Filter γ} {g : γ → R} {e : γ → ℕ}
-    (hg : ∀ i, g i ∈ I ^ e i) (he : Tendsto e l atTop) : Tendsto g l (𝓝 0) := by
-  rw [hI.hasBasis_nhds_zero.tendsto_right_iff]
-  intro k _
-  filter_upwards [he.eventually_ge_atTop k] with i hi
-  exact Ideal.pow_le_pow_right hi (hg i)
+    (hg : ∀ i, g i ∈ I ^ e i) (he : Tendsto e l atTop) : Tendsto g l (𝓝 0) :=
+  hI.hasBasis_nhds_zero.tendsto_right_iff.2 fun k _ ↦
+    (he.eventually_ge_atTop k).mono fun i hi ↦ Ideal.pow_le_pow_right hi (hg i)
+
+/-- In a ring whose topology is the `I`-adic one, every element of `I` is topologically
+nilpotent. -/
+theorem isTopologicallyNilpotent_of_mem (hI : IsAdic I) {a : R} (ha : a ∈ I) :
+    IsTopologicallyNilpotent a :=
+  hI.tendsto_zero_of_mem_pow (Ideal.pow_mem_pow ha) Filter.tendsto_id
 
 end IsAdic

--- a/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -30,6 +30,10 @@ series evaluated at arguments of `I ^ n` is confined to `I ^ n`, in
   an open additive subgroup of a topological group being closed.
 * `IsAdic.isTopologicallyNilpotent_of_mem` : in a ring whose topology is `I`-adic, every element
   of `I` is topologically nilpotent.
+* `IsAdic.isLinearTopology` : a ring whose topology is `I`-adic is linearly topologized.
+* `IsAdic.nonarchimedeanRing` : a ring whose topology is `I`-adic is nonarchimedean.
+* `IsAdic.tendsto_zero_of_mem_pow` : a family whose members lie in growing powers of `I` tends to
+  zero, provided the exponents tend to infinity.
 
 ## Provenance
 
@@ -46,6 +50,18 @@ public section
 namespace IsAdic
 
 variable {R : Type*} [CommRing R] [TopologicalSpace R] {I : Ideal R}
+
+/-- In a ring whose topology is the `I`-adic one, the topology is linear: the powers of `I` form
+a basis of neighbourhoods of zero consisting of ideals. -/
+theorem isLinearTopology (hI : IsAdic I) : IsLinearTopology R R :=
+  IsLinearTopology.mk_of_hasBasis _ hI.hasBasis_nhds_zero
+
+/-- In a ring whose topology is the `I`-adic one, the ring is nonarchimedean: every neighbourhood
+of zero contains an open additive subgroup. -/
+theorem nonarchimedeanRing (hI : IsAdic I) : NonarchimedeanRing R := by
+  simp only [IsAdic] at hI
+  subst hI
+  exact I.nonarchimedean
 
 /-- In a ring whose topology is the `I`-adic one, every power of `I` is open. -/
 theorem isOpen_pow (hI : IsAdic I) (n : ℕ) : IsOpen ((I ^ n : Ideal R) : Set R) := by
@@ -75,5 +91,15 @@ theorem isTopologicallyNilpotent_of_mem (hI : IsAdic I) {a : R} (ha : a ∈ I) :
   suffices ∀ m : ℕ, ∃ n₀, ∀ n, n₀ ≤ n → a ^ n ∈ I ^ m by
     simpa [IsTopologicallyNilpotent, hI.hasBasis_nhds_zero.tendsto_right_iff]
   exact fun m ↦ ⟨m, fun n hn ↦ Ideal.pow_le_pow_right hn (Ideal.pow_mem_pow ha _)⟩
+
+open Filter Topology in
+/-- In a ring whose topology is the `I`-adic one, a family whose members lie in growing powers of
+`I` tends to zero, provided the exponents tend to infinity. -/
+theorem tendsto_zero_of_mem_pow (hI : IsAdic I) {γ : Type*} {l : Filter γ} {g : γ → R} {e : γ → ℕ}
+    (hg : ∀ i, g i ∈ I ^ e i) (he : Tendsto e l atTop) : Tendsto g l (𝓝 0) := by
+  rw [hI.hasBasis_nhds_zero.tendsto_right_iff]
+  intro k _
+  filter_upwards [he.eventually_ge_atTop k] with i hi
+  exact Ideal.pow_le_pow_right hi (hg i)
 
 end IsAdic


### PR DESCRIPTION
Roadmap: EllipticCurves

Provenance: github.com/MichaelStollBayreuth/EllipticCurves @ 66889eada51a, Apache-2.0 — `EllipticCurves/Mathlib/Chabauty/AdicTopology.lean`, declaration `IsAdic.tendsto_zero_of_mem_pow` (:64), under the same name as upstream.

## What this adds

**`IsAdic.tendsto_zero_of_mem_pow`** — in a ring whose topology is `I`-adic, a family whose
members eventually lie in growing powers of `I` tends to zero, provided the exponents tend to
infinity. The index filter is arbitrary: `atTop` for a sequence, `cofinite` for the decay
condition of `MvPowerSeries.HasEval`.

This is the general statement behind the existing `isTopologicallyNilpotent_of_mem`, which becomes
a one-line corollary and loses the four-line comment explaining why it could not use Mathlib's
`WithIdeal` route. It is also the form `TauCeti.RingTheory.MvPowerSeries.Evaluation` wants, where
the `cofinite` instantiation is how a power series evaluated at arguments of `I ^ n` is confined to
`I ^ n` — and hence how the formal group's evaluation API is grounded.

## The golfing

`isOpen_pow` and `isClosed_pow` stop re-deriving the transport of the topology equality by hand:

- `isOpen_pow`: `simp only [IsAdic] at hI; subst hI; let := I.adicTopology; exact …` becomes
  `letI := I.adicTopology; hI ▸ (I.openAddSubgroup n).isOpen`.
- `isClosed_pow`: drops its own `subst`/`let` preamble for `have : NonarchimedeanRing R := hI ▸
  I.nonarchimedean`.
- `isTopologicallyNilpotent_of_mem`: becomes
  `hI.tendsto_zero_of_mem_pow (.of_forall (Ideal.pow_mem_pow ha)) tendsto_id`.

Every proof in the file is now term mode, the longest being 4 lines.

## Not carried over from the source

The source also has `IsAdic.isLinearTopology` and `IsAdic.nonarchimedeanRing`. They are
deliberately **not** ported: `hI ▸ I.isLinearTopology` and `hI ▸ I.nonarchimedean` are their whole
content, so naming them would add a parallel API rather than a result. The module's Provenance
section records this.

## Notes

No `tauceti-target:v1` marker: this completes a support API and authors no named roadmap target,
so it has no deterministic target id and inventing one risks a false duplicate match.
`tendsto_zero_of_mem_pow` is a prerequisite of the Layer 1 formal-group evaluation API rather than
a target in its own right.

## Gates

- `lake build` on the module and both reverse dependencies (`FormalGroup.Eval`,
  `MvPowerSeries.Evaluation`): green, 0 errors, 0 warnings under `warningAsError = true`.
- `scripts/lint-style.sh`: exit 0.
- No `sorry`, no `native_decide`, no `maxHeartbeats`.
- Longest proof in the file is 4 lines.

## Review

Round 1 (head `930cd63`) returned 8/10 rubrics green with `reuse` and `generality` requesting
changes; both are addressed in `b5a9eec` — the two transport wrappers are deleted, and
`tendsto_zero_of_mem_pow` now takes eventual rather than pointwise membership.
