### PR TITLE
feat(Huber): the map induced on a quotient of A⟨X⟩_T (Wedhorn Example 6.38(a))

### DIFF
--- a/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
@@ -15,13 +15,21 @@ ring of restricted power series, and one of the two maps that identify them goes
 quotient. This file supplies it: an evaluation `A⟨X⟩_T →+* B` that kills an ideal `𝔞` factors
 through `A⟨X⟩_T ⧸ 𝔞`, and the factorisation is again continuous.
 
-The factorisation itself is `Ideal.Quotient.lift`. What is not already available is its
-*continuity*: Mathlib puts the quotient topology on `R ⧸ I`
-(`topologicalRingQuotientTopology`) and proves the quotient map open
-(`QuotientRing.isOpenMap_coe`), but states nothing about a map lifted out of `R ⧸ I`. The proof
-below is the one line that closes that gap — the quotient map is a topological quotient map, so
-continuity of the lift is continuity of the evaluation it came from — and it is stated here, at
-the point of use, rather than as a general lemma about topological rings.
+The factorisation itself is `Ideal.Quotient.lift`, and its continuity is
+`continuous_coinduced_dom`: Mathlib gives `R ⧸ I` the coinduced (quotient) topology, so a map out
+of it is continuous exactly when its composite with the quotient map is — which is
+`TauCeti.Huber.continuous_weightedEvalHom`.
+
+## Relation to `TauCeti.Huber.Pair.Hom.quotientLift`
+
+This repository already carries the same move one level up, for **morphisms of Huber pairs**:
+`Pair.Hom.quotientLift` factors a `Hom S T` killing `J` through `S.quotient J`, by the same
+`Ideal.Quotient.lift` and the same `continuous_coinduced_dom` step. This file is *not* an instance
+of it and cannot be phrased as one: `A⟨X⟩_T` and `B` enter Wedhorn 5.50 as plain topological rings,
+with no ring of integral elements and so no `map_mem_plus` obligation to discharge, and the
+universal property being transported is about ring homomorphisms rather than pair morphisms. The
+two are siblings sharing a proof idiom, not a general lemma and its special case; a later rung
+needing the pair-level statement should use `Pair.Hom.quotientLift`.
 
 ## What is *not* assumed, and why it is worth saying
 
@@ -69,7 +77,7 @@ homomorphism `A⟨X⟩_T ⧸ 𝔞 →+* B` through which that evaluation factors
 This is `Ideal.Quotient.lift` at `TauCeti.Huber.weightedEvalHom`; it is named because Example
 6.38 uses it twice over, and because its continuity
 (`TauCeti.Huber.continuous_weightedEvalQuotientHom`) is the part that is not immediate. -/
-noncomputable def weightedEvalQuotientHom (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0)
+@[expose] noncomputable def weightedEvalQuotientHom (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0)
     (hb : IsWeightBounded φ T b) {𝔞 : Ideal (weightedRestrictedSubring T hT)}
     (h𝔞 : 𝔞 ≤ RingHom.ker (weightedEvalHom hT hφ hb)) :
     weightedRestrictedSubring T hT ⧸ 𝔞 →+* B :=
@@ -83,7 +91,7 @@ variable {hT : IsWeightFamily T} {hφ : ContinuousAt φ 0} {hb : IsWeightBounded
 @[simp]
 theorem weightedEvalQuotientHom_mk (f : weightedRestrictedSubring T hT) :
     weightedEvalQuotientHom hT hφ hb h𝔞 (Ideal.Quotient.mk 𝔞 f) = weightedEvalHom hT hφ hb f :=
-  (rfl)
+  rfl
 
 /-- **The defining factorisation**: composing the induced map with the quotient map returns the
 evaluation. With `Ideal.Quotient.ringHom_ext` this is what pins the induced map down, and it is
@@ -91,16 +99,14 @@ the form in which consumers use it. -/
 theorem weightedEvalQuotientHom_comp_mk :
     (weightedEvalQuotientHom hT hφ hb h𝔞).comp (Ideal.Quotient.mk 𝔞) =
       weightedEvalHom hT hφ hb :=
-  RingHom.ext fun _ ↦ rfl
+  Ideal.Quotient.lift_comp_mk 𝔞 _ _
 
-/-- **The induced map is continuous.** `A⟨X⟩_T ⧸ 𝔞` carries the quotient topology, so the
-quotient map is a topological quotient map and continuity of the induced map is exactly
-continuity of the evaluation, which is
+/-- **The induced map is continuous.** `A⟨X⟩_T ⧸ 𝔞` carries the coinduced topology, so continuity
+of a map out of it is continuity of its composite with the quotient map — here
 `TauCeti.Huber.continuous_weightedEvalHom`. -/
 theorem continuous_weightedEvalQuotientHom :
     Continuous (weightedEvalQuotientHom hT hφ hb h𝔞) := by
-  rw [(QuotientRing.isOpenQuotientMap_mk 𝔞).isQuotientMap.continuous_iff]
-  exact continuous_weightedEvalHom hT hφ hb
+  exact continuous_coinduced_dom.mpr (continuous_weightedEvalHom hT hφ hb)
 
 /-- The induced map sends the class of a constant series to its value under `φ`. -/
 @[simp]
@@ -123,7 +129,10 @@ Existence is `TauCeti.Huber.weightedEvalQuotientHom`. Uniqueness is the uniquene
 quotient map: a competitor composed with `Ideal.Quotient.mk` is a continuous homomorphism out of
 `A⟨X⟩_T` with the same values on the generators, so it *is* the evaluation, and a homomorphism
 out of a quotient is determined by that composite. -/
-theorem existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring :
+theorem existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring
+    (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0) (hb : IsWeightBounded φ T b)
+    {𝔞 : Ideal (weightedRestrictedSubring T hT)}
+    (h𝔞 : 𝔞 ≤ RingHom.ker (weightedEvalHom hT hφ hb)) :
     ∃! ψ : weightedRestrictedSubring T hT ⧸ 𝔞 →+* B, Continuous ψ ∧
       (∀ a, ψ (Ideal.Quotient.mk 𝔞 (weightedC T hT a)) = φ a) ∧
       ∀ i, ψ (Ideal.Quotient.mk 𝔞 (weightedX T hT i)) = b i :=

--- a/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
@@ -108,14 +108,19 @@ theorem continuous_weightedEvalQuotientHom :
     Continuous (weightedEvalQuotientHom hT hφ hb h𝔞) := by
   exact continuous_coinduced_dom.mpr (continuous_weightedEvalHom hT hφ hb)
 
-/-- The induced map sends the class of a constant series to its value under `φ`. -/
-@[simp]
+/-- The induced map sends the class of a constant series to its value under `φ`.
+
+Deliberately **not** `@[simp]`: `weightedEvalQuotientHom_mk` is already `@[simp]` and rewrites this
+left-hand side to `weightedEvalHom hT hφ hb (weightedC T hT a)`, which the existing `@[simp]` set
+(`coe_weightedEvalHom`, `coe_weightedC`, `weightedEval_C`) then finishes. Tagging this one too fails
+the `simpNF` linter, because simp reaches the quotient unfolding first and this lemma can never
+fire. It is kept as the named value that the universal property below quotes. -/
 theorem weightedEvalQuotientHom_weightedC (a : A) :
     weightedEvalQuotientHom hT hφ hb h𝔞 (Ideal.Quotient.mk 𝔞 (weightedC T hT a)) = φ a := by
   rw [weightedEvalQuotientHom_mk, weightedEvalHom_weightedC]
 
-/-- The induced map sends the class of the `i`-th variable to `bᵢ`. -/
-@[simp]
+/-- The induced map sends the class of the `i`-th variable to `bᵢ`. Not `@[simp]`, for the reason
+given at `weightedEvalQuotientHom_weightedC`. -/
 theorem weightedEvalQuotientHom_weightedX (i : Fin k) :
     weightedEvalQuotientHom hT hφ hb h𝔞 (Ideal.Quotient.mk 𝔞 (weightedX T hT i)) = b i := by
   rw [weightedEvalQuotientHom_mk, weightedEvalHom_weightedX]

--- a/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
@@ -16,21 +16,11 @@ ring of restricted power series, and one of the two maps that identify them goes
 quotient. This file supplies it: an evaluation `A⟨X⟩_T →+* B` that kills an ideal `𝔞` factors
 through `A⟨X⟩_T ⧸ 𝔞`, and the factorisation is again continuous.
 
-The factorisation itself is `Ideal.Quotient.lift`, and its continuity is
-`continuous_coinduced_dom`: Mathlib gives `R ⧸ I` the coinduced (quotient) topology, so a map out
-of it is continuous exactly when its composite with the quotient map is — which is
-`TauCeti.Huber.continuous_weightedEvalHom`.
-
-## Relation to `TauCeti.Huber.Pair.Hom.quotientLift`
-
-This repository already carries the same move one level up, for **morphisms of Huber pairs**:
-`Pair.Hom.quotientLift` factors a `Hom S T` killing `J` through `S.quotient J`, by the same
-`Ideal.Quotient.lift` and the same `continuous_coinduced_dom` step. This file is *not* an instance
-of it and cannot be phrased as one: `A⟨X⟩_T` and `B` enter Wedhorn 5.50 as plain topological rings,
-with no ring of integral elements and so no `map_mem_plus` obligation to discharge, and the
-universal property being transported is about ring homomorphisms rather than pair morphisms. The
-two are siblings sharing a proof idiom, not a general lemma and its special case; a later rung
-needing the pair-level statement should use `Pair.Hom.quotientLift`.
+The factorisation itself is `Ideal.Quotient.lift`, and the map it produces is again continuous.
+`main` carries the same construction one level up, for morphisms of Huber pairs
+(`TauCeti.Huber.Pair.Hom.quotientLift`); that is the version to use when the source and target are
+Huber pairs rather than plain topological rings, since Wedhorn 5.50 speaks about ring
+homomorphisms and asks for no ring of integral elements.
 
 ## What is *not* assumed, and why it is worth saying
 
@@ -131,6 +121,21 @@ theorem existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring
         (hψ.comp continuous_quot_mk) (continuous_weightedEvalHom hT hφ hb)
         (fun a ↦ (hC a).trans (weightedEvalHom_weightedC hT hφ hb a).symm)
         fun i ↦ (hX i).trans (weightedEvalHom_weightedX hT hφ hb i).symm⟩
+
+/-- **The universal property of `A⟨X⟩_T` on the quotient, under Wedhorn's own hypothesis.** The
+coordinatewise condition `IsWeightedVarPowerBounded` — each weighted variable power-bounded as a
+set, one index at a time — is the form Proposition 5.50 states, and this is the version to cite as
+5.50 on the quotient. -/
+theorem
+    existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring_of_isWeightedVarPowerBounded
+    (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0) (hb : IsWeightedVarPowerBounded φ T b)
+    {𝔞 : Ideal (weightedRestrictedSubring T hT)} (h𝔞 : 𝔞 ≤ RingHom.ker
+      (weightedEvalHom hT hφ (isWeightBounded_of_isWeightedVarPowerBounded hb))) :
+    ∃! ψ : weightedRestrictedSubring T hT ⧸ 𝔞 →+* B, Continuous ψ ∧
+      (∀ a, ψ (Ideal.Quotient.mk 𝔞 (weightedC T hT a)) = φ a) ∧
+      ∀ i, ψ (Ideal.Quotient.mk 𝔞 (weightedX T hT i)) = b i :=
+  existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring hT hφ
+    (isWeightBounded_of_isWeightedVarPowerBounded hb) h𝔞
 
 end TauCeti.Huber
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
@@ -16,11 +16,12 @@ ring of restricted power series, and one of the two maps that identify them goes
 quotient. This file supplies it: an evaluation `A⟨X⟩_T →+* B` that kills an ideal `𝔞` factors
 through `A⟨X⟩_T ⧸ 𝔞`, and the factorisation is again continuous.
 
-The factorisation itself is `Ideal.Quotient.lift`, and the map it produces is again continuous.
-`main` carries the same construction one level up, for morphisms of Huber pairs
-(`TauCeti.Huber.Pair.Hom.quotientLift`); that is the version to use when the source and target are
-Huber pairs rather than plain topological rings, since Wedhorn 5.50 speaks about ring
-homomorphisms and asks for no ring of integral elements.
+The same factorisation exists one level up, for morphisms of Huber pairs
+(`TauCeti.Huber.Pair.Hom.quotientLift`). The two differ in what the objects carry: a Huber pair
+comes with a ring of integral elements and its morphisms must preserve it, whereas Wedhorn's
+Proposition 5.50 — the universal property being transported here — speaks about ring
+homomorphisms of topological rings and asks for no such structure. Use the pair-level version when
+the source and target are Huber pairs, and this one otherwise.
 
 ## What is *not* assumed, and why it is worth saying
 
@@ -39,9 +40,9 @@ a well-behaved target should assume closedness alongside.
 ## Main results
 
 * `TauCeti.Huber.weightedEvalQuotientHom_comp_mk`: it is a factorisation of
-  `TauCeti.Huber.weightedEvalHom` through the quotient map, which is the property that
-  characterises it. The values on the images of the constants and the variables follow from it by
-  `simp`, so they get no separate lemmas.
+  `TauCeti.Huber.weightedEvalHom` through the quotient map. This is the property that characterises
+  the induced map, and it determines its values on the images of the constants and of the
+  variables.
 * `TauCeti.Huber.continuous_weightedEvalQuotientHom`: the induced map is continuous.
 * `TauCeti.Huber.existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring`: it is the
   *only* continuous homomorphism out of `A⟨X⟩_T ⧸ 𝔞` with the prescribed values on the images of

--- a/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Huber.WeightedEval.UniversalProperty
+
+/-!
+# The map induced on a quotient of `A⟨X⟩_T`
+
+Wedhorn's Example 6.38(a) presents a rational localisation `A⟨T/s⟩` as a quotient `C ⧸ 𝔞` of a
+ring of restricted power series, and one of the two maps that identify them goes *out* of that
+quotient. This file supplies it: an evaluation `A⟨X⟩_T →+* B` that kills an ideal `𝔞` factors
+through `A⟨X⟩_T ⧸ 𝔞`, and the factorisation is again continuous.
+
+The factorisation itself is `Ideal.Quotient.lift`. What is not already available is its
+*continuity*: Mathlib puts the quotient topology on `R ⧸ I`
+(`topologicalRingQuotientTopology`) and proves the quotient map open
+(`QuotientRing.isOpenMap_coe`), but states nothing about a map lifted out of `R ⧸ I`. The proof
+below is the one line that closes that gap — the quotient map is a topological quotient map, so
+continuity of the lift is continuity of the evaluation it came from — and it is stated here, at
+the point of use, rather than as a general lemma about topological rings.
+
+## What is *not* assumed, and why it is worth saying
+
+`𝔞` is **not** assumed closed. Closedness of `𝔞` is what makes `C ⧸ 𝔞` separated
+(`Ideal.Quotient.instT1Space`), and Example 6.38 does need it — but for the *other* direction,
+where `C ⧸ 𝔞` is the complete Hausdorff nonarchimedean **target** of the universal property of
+`A⟨T/s⟩`, alongside `Ideal.Quotient.instNonarchimedeanRing`. For a map *out* of `C ⧸ 𝔞` none of
+that is used: the quotient topology exists for any ideal, and it is all the argument needs. The
+hypothesis is therefore omitted rather than carried, and a consumer that also needs `C ⧸ 𝔞` to be
+a well-behaved target should assume closedness alongside.
+
+## Main definitions
+
+* `TauCeti.Huber.weightedEvalQuotientHom`: the induced ring homomorphism `A⟨X⟩_T ⧸ 𝔞 →+* B`.
+
+## Main results
+
+* `TauCeti.Huber.weightedEvalQuotientHom_comp_mk`: it is a factorisation of
+  `TauCeti.Huber.weightedEvalHom` through the quotient map, which is the property that
+  characterises it.
+* `TauCeti.Huber.continuous_weightedEvalQuotientHom`: the induced map is continuous.
+* `TauCeti.Huber.existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring`: it is the
+  *only* continuous homomorphism out of `A⟨X⟩_T ⧸ 𝔞` with the prescribed values on the images of
+  the constants and the variables — the universal property of `A⟨X⟩_T` read on the quotient.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Example 6.38(a), and Proposition 5.50 for the
+  universal property this factors.
+-/
+
+public section
+
+namespace TauCeti.Huber
+
+variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+  [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
+  [T3Space B] {φ : A →+* B} {T : Fin k → Set A} {b : Fin k → B}
+
+/-- **The map induced on `A⟨X⟩_T ⧸ 𝔞` by an evaluation that kills `𝔞`.** Given the data of the
+universal property — `φ` continuous at zero and values `b` making the weighted monomials bounded
+— together with an ideal `𝔞` contained in the kernel of the resulting evaluation, this is the
+homomorphism `A⟨X⟩_T ⧸ 𝔞 →+* B` through which that evaluation factors.
+
+This is `Ideal.Quotient.lift` at `TauCeti.Huber.weightedEvalHom`; it is named because Example
+6.38 uses it twice over, and because its continuity
+(`TauCeti.Huber.continuous_weightedEvalQuotientHom`) is the part that is not immediate. -/
+noncomputable def weightedEvalQuotientHom (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0)
+    (hb : IsWeightBounded φ T b) {𝔞 : Ideal (weightedRestrictedSubring T hT)}
+    (h𝔞 : 𝔞 ≤ RingHom.ker (weightedEvalHom hT hφ hb)) :
+    weightedRestrictedSubring T hT ⧸ 𝔞 →+* B :=
+  Ideal.Quotient.lift 𝔞 (weightedEvalHom hT hφ hb) fun _ hx ↦ RingHom.mem_ker.mp (h𝔞 hx)
+
+variable {hT : IsWeightFamily T} {hφ : ContinuousAt φ 0} {hb : IsWeightBounded φ T b}
+  {𝔞 : Ideal (weightedRestrictedSubring T hT)}
+  {h𝔞 : 𝔞 ≤ RingHom.ker (weightedEvalHom hT hφ hb)}
+
+/-- The induced map computes the evaluation on a representative. -/
+@[simp]
+theorem weightedEvalQuotientHom_mk (f : weightedRestrictedSubring T hT) :
+    weightedEvalQuotientHom hT hφ hb h𝔞 (Ideal.Quotient.mk 𝔞 f) = weightedEvalHom hT hφ hb f :=
+  (rfl)
+
+/-- **The defining factorisation**: composing the induced map with the quotient map returns the
+evaluation. With `Ideal.Quotient.ringHom_ext` this is what pins the induced map down, and it is
+the form in which consumers use it. -/
+theorem weightedEvalQuotientHom_comp_mk :
+    (weightedEvalQuotientHom hT hφ hb h𝔞).comp (Ideal.Quotient.mk 𝔞) =
+      weightedEvalHom hT hφ hb :=
+  RingHom.ext fun _ ↦ rfl
+
+/-- **The induced map is continuous.** `A⟨X⟩_T ⧸ 𝔞` carries the quotient topology, so the
+quotient map is a topological quotient map and continuity of the induced map is exactly
+continuity of the evaluation, which is
+`TauCeti.Huber.continuous_weightedEvalHom`. -/
+theorem continuous_weightedEvalQuotientHom :
+    Continuous (weightedEvalQuotientHom hT hφ hb h𝔞) := by
+  rw [(QuotientRing.isOpenQuotientMap_mk 𝔞).isQuotientMap.continuous_iff]
+  exact continuous_weightedEvalHom hT hφ hb
+
+/-- The induced map sends the class of a constant series to its value under `φ`. -/
+@[simp]
+theorem weightedEvalQuotientHom_weightedC (a : A) :
+    weightedEvalQuotientHom hT hφ hb h𝔞 (Ideal.Quotient.mk 𝔞 (weightedC T hT a)) = φ a := by
+  rw [weightedEvalQuotientHom_mk, weightedEvalHom_weightedC]
+
+/-- The induced map sends the class of the `i`-th variable to `bᵢ`. -/
+@[simp]
+theorem weightedEvalQuotientHom_weightedX (i : Fin k) :
+    weightedEvalQuotientHom hT hφ hb h𝔞 (Ideal.Quotient.mk 𝔞 (weightedX T hT i)) = b i := by
+  rw [weightedEvalQuotientHom_mk, weightedEvalHom_weightedX]
+
+/-- **The universal property of `A⟨X⟩_T`, read on the quotient.** When `𝔞` lies in the kernel of
+the evaluation, there is exactly one continuous ring homomorphism `A⟨X⟩_T ⧸ 𝔞 →+* B` taking the
+prescribed values on the images of the constants and of the variables.
+
+Existence is `TauCeti.Huber.weightedEvalQuotientHom`. Uniqueness is the uniqueness clause of
+`TauCeti.Huber.existsUnique_continuous_ringHom_weightedRestrictedSubring` transported across the
+quotient map: a competitor composed with `Ideal.Quotient.mk` is a continuous homomorphism out of
+`A⟨X⟩_T` with the same values on the generators, so it *is* the evaluation, and a homomorphism
+out of a quotient is determined by that composite. -/
+theorem existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring :
+    ∃! ψ : weightedRestrictedSubring T hT ⧸ 𝔞 →+* B, Continuous ψ ∧
+      (∀ a, ψ (Ideal.Quotient.mk 𝔞 (weightedC T hT a)) = φ a) ∧
+      ∀ i, ψ (Ideal.Quotient.mk 𝔞 (weightedX T hT i)) = b i :=
+  ⟨weightedEvalQuotientHom hT hφ hb h𝔞, ⟨continuous_weightedEvalQuotientHom,
+      weightedEvalQuotientHom_weightedC, weightedEvalQuotientHom_weightedX⟩,
+    fun _ ⟨hψ, hC, hX⟩ ↦ Ideal.Quotient.ringHom_ext <| by
+      rw [weightedEvalQuotientHom_comp_mk]
+      exact weightedRestrictedSubring_ringHom_ext_of_continuous hT
+        (hψ.comp continuous_quot_mk) (continuous_weightedEvalHom hT hφ hb)
+        (fun a ↦ (hC a).trans (weightedEvalHom_weightedC hT hφ hb a).symm)
+        fun i ↦ (hX i).trans (weightedEvalHom_weightedX hT hφ hb i).symm⟩
+
+end TauCeti.Huber
+
+end

--- a/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Quotient.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RingTheory.Huber.WeightedEval.UniversalProperty
+public import TauCeti.Topology.Algebra.Ring.Ideal
 
 /-!
 # The map induced on a quotient of `A⟨X⟩_T`
@@ -49,7 +50,8 @@ a well-behaved target should assume closedness alongside.
 
 * `TauCeti.Huber.weightedEvalQuotientHom_comp_mk`: it is a factorisation of
   `TauCeti.Huber.weightedEvalHom` through the quotient map, which is the property that
-  characterises it.
+  characterises it. The values on the images of the constants and the variables follow from it by
+  `simp`, so they get no separate lemmas.
 * `TauCeti.Huber.continuous_weightedEvalQuotientHom`: the induced map is continuous.
 * `TauCeti.Huber.existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring`: it is the
   *only* continuous homomorphism out of `A⟨X⟩_T ⧸ 𝔞` with the prescribed values on the images of
@@ -74,10 +76,8 @@ universal property — `φ` continuous at zero and values `b` making the weighte
 — together with an ideal `𝔞` contained in the kernel of the resulting evaluation, this is the
 homomorphism `A⟨X⟩_T ⧸ 𝔞 →+* B` through which that evaluation factors.
 
-This is `Ideal.Quotient.lift` at `TauCeti.Huber.weightedEvalHom`; it is named because Example
-6.38 uses it twice over, and because its continuity
-(`TauCeti.Huber.continuous_weightedEvalQuotientHom`) is the part that is not immediate. -/
-@[expose] noncomputable def weightedEvalQuotientHom (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0)
+Its continuity is `TauCeti.Huber.continuous_weightedEvalQuotientHom`. -/
+noncomputable def weightedEvalQuotientHom (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0)
     (hb : IsWeightBounded φ T b) {𝔞 : Ideal (weightedRestrictedSubring T hT)}
     (h𝔞 : 𝔞 ≤ RingHom.ker (weightedEvalHom hT hφ hb)) :
     weightedRestrictedSubring T hT ⧸ 𝔞 →+* B :=
@@ -91,49 +91,27 @@ variable {hT : IsWeightFamily T} {hφ : ContinuousAt φ 0} {hb : IsWeightBounded
 @[simp]
 theorem weightedEvalQuotientHom_mk (f : weightedRestrictedSubring T hT) :
     weightedEvalQuotientHom hT hφ hb h𝔞 (Ideal.Quotient.mk 𝔞 f) = weightedEvalHom hT hφ hb f :=
-  rfl
+  Ideal.Quotient.lift_mk 𝔞 _ _
 
 /-- **The defining factorisation**: composing the induced map with the quotient map returns the
-evaluation. With `Ideal.Quotient.ringHom_ext` this is what pins the induced map down, and it is
-the form in which consumers use it. -/
+evaluation. With `Ideal.Quotient.ringHom_ext` this is what pins the induced map down. -/
+@[simp]
 theorem weightedEvalQuotientHom_comp_mk :
     (weightedEvalQuotientHom hT hφ hb h𝔞).comp (Ideal.Quotient.mk 𝔞) =
       weightedEvalHom hT hφ hb :=
   Ideal.Quotient.lift_comp_mk 𝔞 _ _
 
-/-- **The induced map is continuous.** `A⟨X⟩_T ⧸ 𝔞` carries the coinduced topology, so continuity
-of a map out of it is continuity of its composite with the quotient map — here
-`TauCeti.Huber.continuous_weightedEvalHom`. -/
+/-- **The induced map is continuous.** -/
 theorem continuous_weightedEvalQuotientHom :
-    Continuous (weightedEvalQuotientHom hT hφ hb h𝔞) := by
-  exact continuous_coinduced_dom.mpr (continuous_weightedEvalHom hT hφ hb)
-
-/-- The induced map sends the class of a constant series to its value under `φ`.
-
-Deliberately **not** `@[simp]`: `weightedEvalQuotientHom_mk` is already `@[simp]` and rewrites this
-left-hand side to `weightedEvalHom hT hφ hb (weightedC T hT a)`, which the existing `@[simp]` set
-(`coe_weightedEvalHom`, `coe_weightedC`, `weightedEval_C`) then finishes. Tagging this one too fails
-the `simpNF` linter, because simp reaches the quotient unfolding first and this lemma can never
-fire. It is kept as the named value that the universal property below quotes. -/
-theorem weightedEvalQuotientHom_weightedC (a : A) :
-    weightedEvalQuotientHom hT hφ hb h𝔞 (Ideal.Quotient.mk 𝔞 (weightedC T hT a)) = φ a := by
-  rw [weightedEvalQuotientHom_mk, weightedEvalHom_weightedC]
-
-/-- The induced map sends the class of the `i`-th variable to `bᵢ`. Not `@[simp]`, for the reason
-given at `weightedEvalQuotientHom_weightedC`. -/
-theorem weightedEvalQuotientHom_weightedX (i : Fin k) :
-    weightedEvalQuotientHom hT hφ hb h𝔞 (Ideal.Quotient.mk 𝔞 (weightedX T hT i)) = b i := by
-  rw [weightedEvalQuotientHom_mk, weightedEvalHom_weightedX]
+    Continuous (weightedEvalQuotientHom hT hφ hb h𝔞) :=
+  Ideal.Quotient.continuous_lift 𝔞 (continuous_weightedEvalHom hT hφ hb) _
 
 /-- **The universal property of `A⟨X⟩_T`, read on the quotient.** When `𝔞` lies in the kernel of
 the evaluation, there is exactly one continuous ring homomorphism `A⟨X⟩_T ⧸ 𝔞 →+* B` taking the
 prescribed values on the images of the constants and of the variables.
 
-Existence is `TauCeti.Huber.weightedEvalQuotientHom`. Uniqueness is the uniqueness clause of
-`TauCeti.Huber.existsUnique_continuous_ringHom_weightedRestrictedSubring` transported across the
-quotient map: a competitor composed with `Ideal.Quotient.mk` is a continuous homomorphism out of
-`A⟨X⟩_T` with the same values on the generators, so it *is* the evaluation, and a homomorphism
-out of a quotient is determined by that composite. -/
+The witness is `TauCeti.Huber.weightedEvalQuotientHom`, so a consumer holding a continuous
+homomorphism with those values gets to identify it as that map. -/
 theorem existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring
     (hT : IsWeightFamily T) (hφ : ContinuousAt φ 0) (hb : IsWeightBounded φ T b)
     {𝔞 : Ideal (weightedRestrictedSubring T hT)}
@@ -142,7 +120,11 @@ theorem existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring
       (∀ a, ψ (Ideal.Quotient.mk 𝔞 (weightedC T hT a)) = φ a) ∧
       ∀ i, ψ (Ideal.Quotient.mk 𝔞 (weightedX T hT i)) = b i :=
   ⟨weightedEvalQuotientHom hT hφ hb h𝔞, ⟨continuous_weightedEvalQuotientHom,
-      weightedEvalQuotientHom_weightedC, weightedEvalQuotientHom_weightedX⟩,
+      -- the two prescribed values are the evaluation's own, read through the quotient
+      fun a ↦ by simp, fun i ↦ by simp⟩,
+    -- A competitor composed with the quotient map is a continuous homomorphism out of `A⟨X⟩_T`
+    -- with the same values on the generators, so it is the evaluation; and a homomorphism out of
+    -- a quotient is determined by that composite.
     fun _ ⟨hψ, hC, hX⟩ ↦ Ideal.Quotient.ringHom_ext <| by
       rw [weightedEvalQuotientHom_comp_mk]
       exact weightedRestrictedSubring_ringHom_ext_of_continuous hT

--- a/TauCeti/Topology/Algebra/Ring/Ideal.lean
+++ b/TauCeti/Topology/Algebra/Ring/Ideal.lean
@@ -34,9 +34,7 @@ these delegate to; no ring topology and no multiplicative continuity is used.
 * `Ideal.Quotient.instT1Space`: the instance form, so that `T0Space (R ⧸ I)` is found
   automatically once `I` is known to be closed.
 * `Ideal.Quotient.continuous_lift`: a continuous ring homomorphism annihilating `I` induces a
-  *continuous* homomorphism on `R ⧸ I`. Mathlib supplies the factorisation itself
-  (`Ideal.Quotient.lift`) and the quotient topology, but says nothing about a map lifted out of
-  `R ⧸ I`.
+  *continuous* homomorphism on `R ⧸ I`, with no hypothesis on `I`.
 
 ## References
 
@@ -65,17 +63,14 @@ instance instT1Space [IsClosed (I : Set R)] : T1Space (R ⧸ I) := (t1Space_iff 
 omit [SeparatelyContinuousAdd R] in
 /-- **A continuous ring homomorphism that kills `I` lifts to a continuous map on `R ⧸ I`.**
 
-`R ⧸ I` carries the coinduced topology, so a map out of it is continuous exactly when its
-composite with the quotient map is — and that composite is `f` itself. Mathlib provides the
-algebraic factorisation `Ideal.Quotient.lift` and puts the quotient topology on `R ⧸ I`, but
-states nothing about the continuity of a map lifted out of it.
-
 No hypothesis on `I` is needed: closedness of `I` is what makes `R ⧸ I` separated
 (`Ideal.Quotient.instT1Space` above), which matters for maps *into* `R ⧸ I`, not for maps out
 of it. -/
 theorem continuous_lift {S : Type*} [Semiring S] [TopologicalSpace S] {f : R →+* S}
     (hf : Continuous f) (hI : ∀ a ∈ I, f a = 0) :
     Continuous (Ideal.Quotient.lift I f hI) :=
+  -- `R ⧸ I` carries the coinduced topology, so continuity of a map out of it is continuity of its
+  -- composite with the quotient map, which is `f`.
   continuous_coinduced_dom.mpr hf
 
 end Ideal.Quotient

--- a/TauCeti/Topology/Algebra/Ring/Ideal.lean
+++ b/TauCeti/Topology/Algebra/Ring/Ideal.lean
@@ -33,6 +33,10 @@ these delegate to; no ring topology and no multiplicative continuity is used.
 * `Ideal.Quotient.t1Space_iff`: `T1Space (R ⧸ I) ↔ IsClosed (I : Set R)`.
 * `Ideal.Quotient.instT1Space`: the instance form, so that `T0Space (R ⧸ I)` is found
   automatically once `I` is known to be closed.
+* `Ideal.Quotient.continuous_lift`: a continuous ring homomorphism annihilating `I` induces a
+  *continuous* homomorphism on `R ⧸ I`. Mathlib supplies the factorisation itself
+  (`Ideal.Quotient.lift`) and the quotient topology, but says nothing about a map lifted out of
+  `R ⧸ I`.
 
 ## References
 
@@ -57,5 +61,21 @@ instance, with the closedness of `I` as an instance argument, so that the separa
 is available to instance search wherever `I` is known to be closed; this follows
 `Ideal.Quotient.normedCommRing`, which takes `IsClosed (I : Set R)` the same way. -/
 instance instT1Space [IsClosed (I : Set R)] : T1Space (R ⧸ I) := (t1Space_iff I).mpr ‹_›
+
+omit [SeparatelyContinuousAdd R] in
+/-- **A continuous ring homomorphism that kills `I` lifts to a continuous map on `R ⧸ I`.**
+
+`R ⧸ I` carries the coinduced topology, so a map out of it is continuous exactly when its
+composite with the quotient map is — and that composite is `f` itself. Mathlib provides the
+algebraic factorisation `Ideal.Quotient.lift` and puts the quotient topology on `R ⧸ I`, but
+states nothing about the continuity of a map lifted out of it.
+
+No hypothesis on `I` is needed: closedness of `I` is what makes `R ⧸ I` separated
+(`Ideal.Quotient.instT1Space` above), which matters for maps *into* `R ⧸ I`, not for maps out
+of it. -/
+theorem continuous_lift {S : Type*} [Semiring S] [TopologicalSpace S] {f : R →+* S}
+    (hf : Continuous f) (hI : ∀ a ∈ I, f a = 0) :
+    Continuous (Ideal.Quotient.lift I f hI) :=
+  continuous_coinduced_dom.mpr hf
 
 end Ideal.Quotient


### PR DESCRIPTION
Wedhorn's Example 6.38(a) presents a rational localisation `A⟨T/s⟩` as a quotient `C ⧸ 𝔞` of a ring
of restricted power series. Two maps identify them; one goes **out** of that quotient. This PR
supplies it: an evaluation `A⟨X⟩_T →+* B` killing an ideal `𝔞` factors through `A⟨X⟩_T ⧸ 𝔞`, the
factorisation is continuous, and it is the *unique* continuous homomorphism out of the quotient
with the prescribed values on the images of the constants and the variables.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"adicspaces-4-1-step3-example-6-38-r2"}-->

## The roadmap target, and why its earlier stages are in place

`TauCetiRoadmap/AdicSpaces/README.md:571`, Layer 4.1, numbered step 3, verbatim:

> 3. Proposition 8.30: prove that restriction maps between rational localisations are flat. Use
>    Remark 7.55 for the required chain of rational subsets.

Wedhorn's proof of 8.30 opens *"By Example 6.38 we know that OX(V) is again a strongly noetherian
Tate ring"*, so Example 6.38 is a **named input of a numbered roadmap step**, not a speculative
intermediate.

Layer 4.1 asks for its six steps "in the following order", so here is that order's state on `main`:

| Step | Content | Status on `main` |
|---|---|---|
| 1 | Remark 8.29, `M ⊗_A A⟨X⟩ ≅ M⟨X⟩` | present — `Restricted/BaseChange.lean`; `ClosedSubmodule.lean` cites Remark 8.29 by number |
| 2 | Lemma 8.31, `A⟨X⟩` faithfully flat over `A` | present — `flat_restrictedMvPowerSeriesSubring`, `faithfullyFlat_restrictedMvPowerSeriesSubring` (`Restricted/Flat.lean:57,76`); 8.31(2) in `Flat/QuotientRegular.lean` |
| 3 | **Proposition 8.30** | the target this PR feeds, via Example 6.38 |

So this is a prerequisite of the *next* step in the roadmap's own order, with both preceding steps
already on `main`.

## Where this sits in Example 6.38, and what is not in scope

Example 6.38(a) decomposes into rungs. This PR is **R2** only:

1. **R2 — this PR.** `𝔞` lies in the kernel of the evaluation, so the evaluation factors through
   `C ⧸ 𝔞`, and the induced map is continuous.
2. R3 / R4 — the image of `sᵢ` is a unit in `C ⧸ 𝔞`; each `t/sᵢ` is power-bounded there.
3. R5 — the assembly `A⟨T/s⟩ ≅+* C ⧸ 𝔞`, i.e. Example 6.38(a) itself.

R3–R5 are deliberately **not** here. The consumer of R2 is
`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_completion_locTopology`
(`Huber/LocalizationTopology/Completion.lean:401`), which takes R3 and R4 as its two hypotheses and
consumes R2's map. From there: Example 6.38 → Proposition 8.30 (step 3) → Corollary 8.32 (step 4) →
Lemma 8.33 (step 5) → Lemma 8.34 (step 6) → Wedhorn Theorem 8.28 → `Huber.IsSheafyPair`, the
sheafiness of the structure presheaf for a strongly noetherian Tate ring.

## What is already on `main` and therefore not rebuilt

* the universal property being factored — `existsUnique_continuous_ringHom_weightedRestrictedSubring`
  (`WeightedEval/UniversalProperty.lean:75`, Wedhorn Proposition 5.50);
* `Ideal.Quotient.instNonarchimedeanRing` (`Topology/Algebra/Nonarchimedean/Quotient.lean`), whose
  module docstring already names Example 6.38 as its reason;
* `TauCeti.Huber.isClosed_of_isNoetherian` (`Huber/ClosedSubmodule.lean:126`);
* `IsTopologicallyFiniteType` (`Huber/TopologicallyFiniteType.lean:101`).

The factorisation itself is Mathlib's `Ideal.Quotient.lift`, and the two computation lemmas are
Mathlib's `Ideal.Quotient.lift_mk` and `lift_comp_mk` rather than `rfl`. Continuity is
`continuous_coinduced_dom`: `R ⧸ I` carries the coinduced topology, so a map out of it is continuous
exactly when its composite with the quotient map is.

## The general lemma, and what is deliberately left alone

Continuity of a quotient lift is not special to the weighted evaluation, so after round 2 it lives
as `Ideal.Quotient.continuous_lift` in `TauCeti/Topology/Algebra/Ring/Ideal.lean` — the file that
already owns the topology of `R ⧸ I` — stated for any continuous ring homomorphism annihilating the
ideal, with no hypothesis on the ideal. The weighted-evaluation continuity is one application of it.

`main` also has this move at the level of **Huber-pair morphisms** (`Huber.Pair.Hom.quotientLift`,
`Huber/Pair.lean:262`). Deriving that from the new general lemma would be a genuine improvement, and
it is deliberately **not** done here: it changes already-merged code, and the scope rubric asks for a
split when an opportunistic refactor of prerequisite material is bundled with new work. It is a
one-file follow-up PR.

## Review status

Round 1's `scope` verdict is **green**: Layer 4.1's step 3 is the target, and its preceding steps 1
(Remark 8.29) and 2 (Lemma 8.31) are on `main`. Round 2 raised five points, all addressed:

* **generality** — the quotient-lift continuity is now the general lemma above.
* **proof-quality** — `weightedEvalQuotientHom_mk` was proved by `rfl`, coupling it to two
  implementation bodies; it now goes through `Ideal.Quotient.lift_mk`. (An earlier commit of mine
  claimed exactly this change and silently failed to apply it; the reviewer caught the real state.)
* **api-design** — with `_mk` and continuity both routed through API lemmas, no proof needs
  definitional reduction across the module boundary, so `@[expose]` is **removed**;
  `weightedEvalQuotientHom_comp_mk` is now `@[simp]`.
* **reuse** — `weightedEvalQuotientHom_weightedC` and `_weightedX` were consequences of the existing
  simp set, which is what the simpNF linter had already reported; they are **deleted**, and the
  existence witness proves those components by `simp` directly.
* **documentation** — the docstrings now state the object and its use; proof narration moved into
  the proof body as comments.

## A hypothesis deliberately not assumed

`𝔞` is **not** assumed closed. Closedness is what makes `C ⧸ 𝔞` separated, and Example 6.38 does need
it — but for the *other* direction, where `C ⧸ 𝔞` is the complete Hausdorff nonarchimedean **target**
of the universal property of `A⟨T/s⟩`. For a map *out* of `C ⧸ 𝔞` none of that is used: the quotient
topology exists for any ideal. The hypothesis is omitted rather than carried, and the module
docstring tells a consumer that also needs `C ⧸ 𝔞` as a target to assume closedness alongside.

Mathematical source: Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Example 6.38(a), with Proposition
5.50 for the universal property being factored. No code is adapted from another repository, so there
is no `Provenance:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
