### PR TITLE
feat: a map of covering spaces is a covering map

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Existence.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Existence.lean
@@ -9,6 +9,7 @@ public import TauCeti.AlgebraicTopology.UniversalCover.Classification.SubgroupQu
 public import TauCeti.Topology.Covering.Category
 public import TauCeti.Topology.Covering.Quotient
 import TauCeti.Topology.Homotopy.Monodromy.Functoriality
+import TauCeti.Topology.IsLocalHomeomorph
 
 /-!
 # The covering associated to a subgroup
@@ -65,6 +66,13 @@ theorem isCoveringMap_subgroupQuotientProj [LocallyPathConnectedSpace X]
   IsQuotientCoveringMap.isCoveringMap_of_comp (isQuotientCoveringMap (x₀ := x₀))
     (isQuotientCoveringMap_subgroupQuotientMap x₀ H)
     (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H)
+
+/-- The quotient of the universal cover by a subgroup is locally path-connected, being the total
+space of a covering space of the locally path-connected base `X`. -/
+theorem locallyPathConnectedSpace_subgroupQuotient [LocallyPathConnectedSpace X]
+    [PathConnectedSpace X] [SemilocallySimplyConnectedSpace X] (x₀ : X)
+    (H : Subgroup (FundamentalGroup X x₀)) : LocallyPathConnectedSpace (SubgroupQuotient x₀ H) :=
+  (isCoveringMap_subgroupQuotientProj x₀ H).isLocalHomeomorph.locallyPathConnectedSpace
 
 /-- The connected covering space associated to a subgroup `H ≤ π₁(X, x₀)`, obtained by
 quotienting the universal cover by `H`. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Intermediate.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Intermediate.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Existence
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Pointed
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.RecoveredSubgroup
+public import TauCeti.Topology.Covering.Factorization
+public import TauCeti.Topology.IsLocalHomeomorph
+
+/-!
+# The Galois correspondence is a correspondence of towers of covers
+
+Pointed connected covers of `(X, x)` are classified by the subgroup of `π₁(X, x)` they recover,
+and `TauCeti.IsCoveringMap.exists_continuousMap_comp_eq_iff_range_le` already says that a map of
+pointed covers exists exactly when the recovered subgroups are nested. What that statement leaves
+open is what kind of map it is. This file upgrades it: over a locally connected base the map is
+itself a covering map, so a nesting of subgroups is realized by an intermediate covering and not
+merely by a continuous comparison.
+
+The upgrade is `IsCoveringMap.of_comp_eq`, which needs nothing about the subgroups: any
+continuous map over a locally connected base between two covering spaces of it is a covering map.
+
+Specializing to the covers built from subgroups turns the classification into an order statement.
+For `H, K ≤ π₁(X, x₀)` the cover `UniversalCover x₀ / H` covers `UniversalCover x₀ / K`
+compatibly with basepoints exactly when `H ≤ K`, because those covers recover `H` and `K`. The
+universal cover itself sits above all of them, which is recorded separately because it needs no
+subgroup: its lifting property produces the comparison map to an arbitrary cover, and the
+upgrade above makes that map a covering map.
+
+## Main declarations
+
+* `IsCoveringMap.exists_isCoveringMap_comp_eq_iff_range_le`: **a pointed cover covers another,
+  by a covering map over the base, exactly when the recovered subgroups are nested.**
+* `TauCeti.UniversalCover.exists_isCoveringMap_comp_eq_proj`: **the universal cover covers every
+  covering space of `X`.**
+* `TauCeti.UniversalCover.exists_isCoveringMap_subgroupQuotientProj_comp_eq_iff_le`: **the cover
+  attached to `H` covers the cover attached to `K` exactly when `H ≤ K`.**
+
+## References
+
+This is the order-theoretic half of Stage 2, item 8 of
+`TauCetiRoadmap/UniversalCovers/README.md`, whose bookkeeping asks for the correspondence between
+pointed connected covers and subgroups of the fundamental group. It consumes the based-path
+universal cover adapted from Kim Morrison's
+[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292), the lifting
+criterion in Mathlib's `Topology/Homotopy/Lifting.lean` due to Junyan Xu, and the covers attached
+to subgroups already built here. The mathematics is Hatcher, *Algebraic Topology*, Section 1.3.
+-/
+
+public section
+noncomputable section
+
+namespace TauCeti
+
+open _root_.FundamentalGroup
+
+variable {E F X : Type*} [TopologicalSpace E] [TopologicalSpace F] [TopologicalSpace X]
+  {p : E → X} {q : F → X} {x : X} {e₀ : E} {f₀ : F}
+
+/-- **A pointed cover covers another one, by a covering map over `X`, exactly when the subgroup it
+recovers is contained in the subgroup the other recovers.**
+
+This strengthens `TauCeti.IsCoveringMap.exists_continuousMap_comp_eq_iff_range_le`, which produces
+only a continuous map: over a locally connected base a map of covers is automatically a covering
+map, by `IsCoveringMap.of_comp_eq`. -/
+theorem _root_.IsCoveringMap.exists_isCoveringMap_comp_eq_iff_range_le [LocallyConnectedSpace X]
+    [PathConnectedSpace E] [LocallyPathConnectedSpace E] (hp : IsCoveringMap p)
+    (hq : IsCoveringMap q) (hpe : p e₀ = x) (hqf : q f₀ = x) :
+    (∃ g : C(E, F), IsCoveringMap g ∧ g e₀ = f₀ ∧ q ∘ g = p) ↔
+      (mapOfEq ⟨p, hp.continuous⟩ hpe).range ≤ (mapOfEq ⟨q, hq.continuous⟩ hqf).range := by
+  refine ⟨fun hg => ?_, fun hle => ?_⟩
+  · obtain ⟨g, -, hg₀, hgc⟩ := hg
+    exact (TauCeti.IsCoveringMap.exists_continuousMap_comp_eq_iff_range_le hp.continuous hq hpe
+      hqf).mp ⟨g, hg₀, hgc⟩
+  · obtain ⟨g, ⟨hg₀, hgc⟩, -⟩ :=
+      TauCeti.IsCoveringMap.existsUnique_continuousMap_comp_eq_of_range_le hp.continuous hq hpe
+        hqf hle
+    exact ⟨g, hp.of_comp_eq hq g.continuous hgc, hg₀, hgc⟩
+
+namespace UniversalCover
+
+variable [LocallyPathConnectedSpace X] [PathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
+
+/-- The quotient of the universal cover by a subgroup is locally path-connected, being the total
+space of a covering space of the locally path-connected base `X`. -/
+theorem locallyPathConnectedSpace_subgroupQuotient (x₀ : X)
+    (H : Subgroup (FundamentalGroup X x₀)) : LocallyPathConnectedSpace (SubgroupQuotient x₀ H) :=
+  (isCoveringMap_subgroupQuotientProj x₀ H).isLocalHomeomorph.locallyPathConnectedSpace
+
+/-- **The universal cover covers every covering space of `X`**, by a covering map over `X`
+matching any chosen pair of points in a common fibre.
+
+The comparison map itself is the universal lifting property of the universal cover; what is added
+here is that it is a covering map. -/
+theorem exists_isCoveringMap_comp_eq_proj (x₀ : X) {F : Type*} [TopologicalSpace F] {q : F → X}
+    (hq : IsCoveringMap q) (e₀ : UniversalCover x₀) (f₀ : F) (he : q f₀ = proj e₀) :
+    ∃ g : C(UniversalCover x₀, F), IsCoveringMap g ∧ g e₀ = f₀ ∧ q ∘ g = proj := by
+  have := (isCoveringMap x₀).isLocalHomeomorph.locallyPathConnectedSpace
+  obtain ⟨g, ⟨hg₀, hgc⟩, -⟩ :=
+    hq.existsUnique_continuousMap_lifts ⟨proj, continuous_proj x₀⟩ e₀ f₀ he
+  exact ⟨g, (isCoveringMap x₀).of_comp_eq hq g.continuous hgc, hg₀, hgc⟩
+
+/-- **The cover attached to `H ≤ π₁(X, x₀)` covers the cover attached to `K` exactly when
+`H ≤ K`.** The comparison is a covering map over `X` matching the two distinguished points.
+
+This is the order-preserving half of the Galois correspondence between subgroups of `π₁(X, x₀)`
+and pointed connected covers of `(X, x₀)`. -/
+theorem exists_isCoveringMap_subgroupQuotientProj_comp_eq_iff_le (x₀ : X)
+    (H K : Subgroup (FundamentalGroup X x₀)) :
+    (∃ g : C(SubgroupQuotient x₀ H, SubgroupQuotient x₀ K), IsCoveringMap g ∧
+        g (SubgroupQuotient.basepoint x₀ H) = SubgroupQuotient.basepoint x₀ K ∧
+        subgroupQuotientProj x₀ K ∘ g = subgroupQuotientProj x₀ H) ↔ H ≤ K := by
+  have := locallyPathConnectedSpace_subgroupQuotient x₀ H
+  rw [IsCoveringMap.exists_isCoveringMap_comp_eq_iff_range_le
+    (isCoveringMap_subgroupQuotientProj x₀ H) (isCoveringMap_subgroupQuotientProj x₀ K)
+    (subgroupQuotientProj_basepoint x₀ H) (subgroupQuotientProj_basepoint x₀ K),
+    range_mapOfEq_subgroupQuotientProj, range_mapOfEq_subgroupQuotientProj]
+
+end UniversalCover
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Intermediate.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Intermediate.lean
@@ -9,7 +9,7 @@ public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Existence
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Pointed
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.RecoveredSubgroup
 public import TauCeti.Topology.Covering.Factorization
-public import TauCeti.Topology.IsLocalHomeomorph
+import TauCeti.Topology.IsLocalHomeomorph
 
 /-!
 # The Galois correspondence is a correspondence of towers of covers
@@ -17,35 +17,33 @@ public import TauCeti.Topology.IsLocalHomeomorph
 Pointed connected covers of `(X, x)` are classified by the subgroup of `π₁(X, x)` they recover,
 and `TauCeti.IsCoveringMap.exists_continuousMap_comp_eq_iff_range_le` already says that a map of
 pointed covers exists exactly when the recovered subgroups are nested. What that statement leaves
-open is what kind of map it is. This file upgrades it: over a locally connected base the map is
-itself a covering map, so a nesting of subgroups is realized by an intermediate covering and not
-merely by a continuous comparison.
+open is what kind of map it is. This file upgrades it: when the target cover is locally connected,
+the map is itself a covering map, so a nesting of subgroups is realized by an intermediate
+covering and not merely by a continuous comparison.
 
 The upgrade is `IsCoveringMap.of_comp_eq`, which needs nothing about the subgroups: any
-continuous map over a locally connected base between two covering spaces of it is a covering map.
+continuous map between two covering spaces of the same base is a covering map when its target is
+locally connected.
 
 Specializing to the covers built from subgroups turns the classification into an order statement.
 For `H, K ≤ π₁(X, x₀)` the cover `UniversalCover x₀ / H` covers `UniversalCover x₀ / K`
 compatibly with basepoints exactly when `H ≤ K`, because those covers recover `H` and `K`. The
-universal cover itself sits above all of them, which is recorded separately because it needs no
-subgroup: its lifting property produces the comparison map to an arbitrary cover, and the
-upgrade above makes that map a covering map.
+universal cover itself sits above all nonempty covers after choosing points in a common fibre.
+This is recorded separately because it needs no subgroup: the universal lifting property produces
+the comparison map, and the upgrade above makes that map a covering map.
 
 ## Main declarations
 
 * `IsCoveringMap.exists_isCoveringMap_comp_eq_iff_range_le`: **a pointed cover covers another,
   by a covering map over the base, exactly when the recovered subgroups are nested.**
-* `TauCeti.UniversalCover.exists_isCoveringMap_comp_eq_proj`: **the universal cover covers every
-  covering space of `X`.**
+* `TauCeti.UniversalCover.exists_isCoveringMap_comp_eq_proj`: **the universal cover covers a
+  nonempty covering space of `X` after choosing points in a common fibre.**
 * `TauCeti.UniversalCover.exists_isCoveringMap_subgroupQuotientProj_comp_eq_iff_le`: **the cover
   attached to `H` covers the cover attached to `K` exactly when `H ≤ K`.**
 
 ## References
 
-This is the order-theoretic half of Stage 2, item 8 of
-`TauCetiRoadmap/UniversalCovers/README.md`, whose bookkeeping asks for the correspondence between
-pointed connected covers and subgroups of the fundamental group. It consumes the based-path
-universal cover adapted from Kim Morrison's
+This work consumes the based-path universal cover adapted from Kim Morrison's
 [mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292), the lifting
 criterion in Mathlib's `Topology/Homotopy/Lifting.lean` due to Junyan Xu, and the covers attached
 to subgroups already built here. The mathematics is Hatcher, *Algebraic Topology*, Section 1.3.
@@ -65,9 +63,9 @@ variable {E F X : Type*} [TopologicalSpace E] [TopologicalSpace F] [TopologicalS
 recovers is contained in the subgroup the other recovers.**
 
 This strengthens `TauCeti.IsCoveringMap.exists_continuousMap_comp_eq_iff_range_le`, which produces
-only a continuous map: over a locally connected base a map of covers is automatically a covering
-map, by `IsCoveringMap.of_comp_eq`. -/
-theorem _root_.IsCoveringMap.exists_isCoveringMap_comp_eq_iff_range_le [LocallyConnectedSpace X]
+only a continuous map: when the target is locally connected, a map of covers is automatically a
+covering map, by `IsCoveringMap.of_comp_eq`. -/
+theorem _root_.IsCoveringMap.exists_isCoveringMap_comp_eq_iff_range_le [LocallyConnectedSpace F]
     [PathConnectedSpace E] [LocallyPathConnectedSpace E] (hp : IsCoveringMap p)
     (hq : IsCoveringMap q) (hpe : p e₀ = x) (hqf : q f₀ = x) :
     (∃ g : C(E, F), IsCoveringMap g ∧ g e₀ = f₀ ∧ q ∘ g = p) ↔
@@ -85,14 +83,8 @@ namespace UniversalCover
 
 variable [LocallyPathConnectedSpace X] [PathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
 
-/-- The quotient of the universal cover by a subgroup is locally path-connected, being the total
-space of a covering space of the locally path-connected base `X`. -/
-theorem locallyPathConnectedSpace_subgroupQuotient (x₀ : X)
-    (H : Subgroup (FundamentalGroup X x₀)) : LocallyPathConnectedSpace (SubgroupQuotient x₀ H) :=
-  (isCoveringMap_subgroupQuotientProj x₀ H).isLocalHomeomorph.locallyPathConnectedSpace
-
-/-- **The universal cover covers every covering space of `X`**, by a covering map over `X`
-matching any chosen pair of points in a common fibre.
+/-- **The universal cover covers any nonempty covering space of `X` after choosing points in a
+common fibre**, by a covering map over `X` matching those points.
 
 The comparison map itself is the universal lifting property of the universal cover; what is added
 here is that it is a covering map. -/
@@ -100,6 +92,7 @@ theorem exists_isCoveringMap_comp_eq_proj (x₀ : X) {F : Type*} [TopologicalSpa
     (hq : IsCoveringMap q) (e₀ : UniversalCover x₀) (f₀ : F) (he : q f₀ = proj e₀) :
     ∃ g : C(UniversalCover x₀, F), IsCoveringMap g ∧ g e₀ = f₀ ∧ q ∘ g = proj := by
   have := (isCoveringMap x₀).isLocalHomeomorph.locallyPathConnectedSpace
+  have := hq.isLocalHomeomorph.locallyPathConnectedSpace
   obtain ⟨g, ⟨hg₀, hgc⟩, -⟩ :=
     hq.existsUnique_continuousMap_lifts ⟨proj, continuous_proj x₀⟩ e₀ f₀ he
   exact ⟨g, (isCoveringMap x₀).of_comp_eq hq g.continuous hgc, hg₀, hgc⟩
@@ -115,6 +108,7 @@ theorem exists_isCoveringMap_subgroupQuotientProj_comp_eq_iff_le (x₀ : X)
         g (SubgroupQuotient.basepoint x₀ H) = SubgroupQuotient.basepoint x₀ K ∧
         subgroupQuotientProj x₀ K ∘ g = subgroupQuotientProj x₀ H) ↔ H ≤ K := by
   have := locallyPathConnectedSpace_subgroupQuotient x₀ H
+  have := locallyPathConnectedSpace_subgroupQuotient x₀ K
   rw [IsCoveringMap.exists_isCoveringMap_comp_eq_iff_range_le
     (isCoveringMap_subgroupQuotientProj x₀ H) (isCoveringMap_subgroupQuotientProj x₀ K)
     (subgroupQuotientProj_basepoint x₀ H) (subgroupQuotientProj_basepoint x₀ K),

--- a/TauCeti/Topology/Covering/Clopen.lean
+++ b/TauCeti/Topology/Covering/Clopen.lean
@@ -6,10 +6,11 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Topology.Clopen
+public import Mathlib.Topology.Connected.Clopen
 public import Mathlib.Topology.Covering.Basic
 
 /-!
-# Covering maps onto a clopen subspace
+# Covering maps and clopen sets
 
 A covering map `p : E → ↥s` onto a subspace of `X` is also a covering map `E → X` as soon as `s`
 is clopen: over a point of `s` an evenly covered neighbourhood in `↥s` is one in `X` because `s`
@@ -22,10 +23,18 @@ neighbourhood meeting `s`, so no neighbourhood of it is evenly covered by a surj
 Mathlib's `IsCoveringMap` allows empty fibres, which is exactly what makes the clopen statement
 work without assuming `p` surjective or `s = X`.
 
+Empty fibres are also what makes the *range* of a covering map clopen. It is open because a
+covering map is a local homeomorphism, and closed because a point outside the range has an evenly
+covered neighbourhood whose fibre is empty, so that whole neighbourhood misses the range. Over a
+preconnected base a covering map with nonempty total space is therefore surjective.
+
 ## Main declarations
 
 * `IsCoveringMap.subtypeVal_comp`: the composite of a covering map onto a clopen
   subspace with the subspace inclusion is a covering map.
+* `IsCoveringMap.isClopen_range`: the range of a covering map is clopen.
+* `IsCoveringMap.surjective`: a covering map onto a preconnected base with nonempty total space
+  is surjective.
 -/
 
 public section
@@ -45,5 +54,26 @@ theorem _root_.IsCoveringMap.subtypeVal_comp {p : E → s} (hp : IsCoveringMap p
   · refine IsEvenlyCovered.to_isEvenlyCovered_preimage
       (IsEvenlyCovered.of_preimage_eq_empty Empty (hs.isClosed.isOpen_compl.mem_nhds hx) ?_)
     exact Set.eq_empty_of_forall_notMem fun e he => he (p e).2
+
+/-- **The range of a covering map is clopen.** It is open because a covering map is a local
+homeomorphism, and closed because an evenly covered neighbourhood of a point outside the range
+has empty preimage. -/
+theorem _root_.IsCoveringMap.isClopen_range {p : E → X} (hp : IsCoveringMap p) :
+    IsClopen (Set.range p) := by
+  refine ⟨?_, hp.isLocalHomeomorph.isOpenMap.isOpen_range⟩
+  rw [← isOpen_compl_iff]
+  refine isOpen_iff_forall_mem_open.mpr fun x hx => ?_
+  obtain ⟨-, U, hxU, hU, -, H, -⟩ := hp x
+  have : IsEmpty (p ⁻¹' {x} : Set E) := ⟨fun e => hx ⟨e, e.2⟩⟩
+  have hpU : p ⁻¹' U = ∅ := Set.isEmpty_coe_sort.mp (Function.isEmpty ⇑H)
+  refine ⟨U, fun y hy => ?_, hU, hxU⟩
+  rintro ⟨e, rfl⟩
+  exact Set.eq_empty_iff_forall_notMem.mp hpU e hy
+
+/-- **A covering map onto a preconnected base is surjective** as soon as its total space is
+nonempty: its range is a nonempty clopen subset. -/
+theorem _root_.IsCoveringMap.surjective [PreconnectedSpace X] [Nonempty E] {p : E → X}
+    (hp : IsCoveringMap p) : Function.Surjective p :=
+  Set.range_eq_univ.mp (hp.isClopen_range.eq_univ (Set.range_nonempty p))
 
 end TauCeti

--- a/TauCeti/Topology/Covering/Clopen.lean
+++ b/TauCeti/Topology/Covering/Clopen.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Topology.Clopen
 public import Mathlib.Topology.Connected.Clopen
 public import Mathlib.Topology.Covering.Basic
 

--- a/TauCeti/Topology/Covering/Clopen.lean
+++ b/TauCeti/Topology/Covering/Clopen.lean
@@ -5,11 +5,11 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Topology.Connected.Clopen
+public import Mathlib.Topology.Clopen
 public import Mathlib.Topology.Covering.Basic
 
 /-!
-# Covering maps and clopen sets
+# Covering maps onto a clopen subspace
 
 A covering map `p : E → ↥s` onto a subspace of `X` is also a covering map `E → X` as soon as `s`
 is clopen: over a point of `s` an evenly covered neighbourhood in `↥s` is one in `X` because `s`
@@ -22,18 +22,10 @@ neighbourhood meeting `s`, so no neighbourhood of it is evenly covered by a surj
 Mathlib's `IsCoveringMap` allows empty fibres, which is exactly what makes the clopen statement
 work without assuming `p` surjective or `s = X`.
 
-Empty fibres are also what makes the *range* of a covering map clopen. It is open because a
-covering map is a local homeomorphism, and closed because a point outside the range has an evenly
-covered neighbourhood whose fibre is empty, so that whole neighbourhood misses the range. Over a
-preconnected base a covering map with nonempty total space is therefore surjective.
-
 ## Main declarations
 
 * `IsCoveringMap.subtypeVal_comp`: the composite of a covering map onto a clopen
   subspace with the subspace inclusion is a covering map.
-* `IsCoveringMap.isClopen_range`: the range of a covering map is clopen.
-* `IsCoveringMap.surjective`: a covering map onto a preconnected base with nonempty total space
-  is surjective.
 -/
 
 public section
@@ -53,26 +45,5 @@ theorem _root_.IsCoveringMap.subtypeVal_comp {p : E → s} (hp : IsCoveringMap p
   · refine IsEvenlyCovered.to_isEvenlyCovered_preimage
       (IsEvenlyCovered.of_preimage_eq_empty Empty (hs.isClosed.isOpen_compl.mem_nhds hx) ?_)
     exact Set.eq_empty_of_forall_notMem fun e he => he (p e).2
-
-/-- **The range of a covering map is clopen.** It is open because a covering map is a local
-homeomorphism, and closed because an evenly covered neighbourhood of a point outside the range
-has empty preimage. -/
-theorem _root_.IsCoveringMap.isClopen_range {p : E → X} (hp : IsCoveringMap p) :
-    IsClopen (Set.range p) := by
-  refine ⟨?_, hp.isLocalHomeomorph.isOpenMap.isOpen_range⟩
-  rw [← isOpen_compl_iff]
-  refine isOpen_iff_forall_mem_open.mpr fun x hx => ?_
-  obtain ⟨-, U, hxU, hU, -, H, -⟩ := hp x
-  have : IsEmpty (p ⁻¹' {x} : Set E) := ⟨fun e => hx ⟨e, e.2⟩⟩
-  have hpU : p ⁻¹' U = ∅ := Set.isEmpty_coe_sort.mp (Function.isEmpty ⇑H)
-  refine ⟨U, fun y hy => ?_, hU, hxU⟩
-  rintro ⟨e, rfl⟩
-  exact Set.eq_empty_iff_forall_notMem.mp hpU e hy
-
-/-- **A covering map onto a preconnected base is surjective** as soon as its total space is
-nonempty: its range is a nonempty clopen subset. -/
-theorem _root_.IsCoveringMap.surjective [PreconnectedSpace X] [Nonempty E] {p : E → X}
-    (hp : IsCoveringMap p) : Function.Surjective p :=
-  Set.range_eq_univ.mp (hp.isClopen_range.eq_univ (Set.range_nonempty p))
 
 end TauCeti

--- a/TauCeti/Topology/Covering/Factorization.lean
+++ b/TauCeti/Topology/Covering/Factorization.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Connected.LocallyConnected
+public import TauCeti.Topology.Covering.Clopen
+
+/-!
+# A map between covering spaces of a locally connected base is a covering map
+
+Let `p : E → X` and `q : F → X` be covering maps and let `g : E → F` be a continuous map over
+`X`, that is, `q ∘ g = p`. This file proves that `g` is itself a covering map as soon as `X` is
+locally connected.
+
+The proof is the standard sheet comparison. Around a point `f₀` of `F`, choose a connected open
+set `V` inside the intersection of an evenly covered neighbourhood for `p` with one for `q`, and
+trivialize both projections over it. A sheet of `p` over `V` is the image of `V` under
+`v ↦ tp.symm (v, i)`, so it is connected, and the sheet index of its image under `g` is a
+continuous map from `V` to a discrete space, hence constant. So `g` carries each sheet of `p`
+over `V` onto a single sheet of `q`, and injectively, because `p = q ∘ g` is injective on it.
+The sheet `W` of `q` through `f₀` is therefore evenly covered by `g`, with fibre the set of
+sheets of `p` that land in `W`.
+
+Local connectedness of `X` is what produces the connected `V`. It is used exactly once, to make
+the sheet index locally constant, and that is the step which fails over a base with no small
+connected neighbourhoods.
+
+Neither total space is assumed connected and `g` is not assumed surjective. That is consistent
+because `IsCoveringMap` allows empty fibres: over a sheet of `q` missed by `g` the fibre of `g`
+is empty. Surjectivity is a separate statement, recorded here for a preconnected target: it
+follows from the clopenness of the range of a covering map.
+
+## Main declarations
+
+* `IsCoveringMap.of_comp_eq`: **a continuous map between covering spaces of a locally connected
+  base, commuting with the projections, is a covering map.**
+* `IsCoveringMap.surjective_of_comp_eq`: it is surjective as soon as the target cover is
+  preconnected and the source cover is nonempty.
+-/
+
+public section
+
+namespace TauCeti
+
+open Bundle Set Topology
+
+variable {E F X : Type*} [TopologicalSpace E] [TopologicalSpace F] [TopologicalSpace X]
+  {p : E → X} {q : F → X} {g : E → F}
+
+/-- The evenly covered neighbourhood of `f₀` for a map `g` over `X` between two trivialized
+projections, cut out by a connected open set `V` of the base lying inside both base sets.
+
+The neighbourhood is the sheet of `q` over `V` through `f₀`, and the fibre over it is the set of
+sheet indices of `p` that `g` sends into that sheet. -/
+private theorem isEvenlyCovered_of_trivialization (hq : Continuous q) (hg : Continuous g)
+    (hqg : ∀ e, q (g e) = p e) {I J : Type*} [TopologicalSpace I] [DiscreteTopology I]
+    [TopologicalSpace J] [DiscreteTopology J] (tp : Trivialization I p) (tq : Trivialization J q)
+    (f₀ : F) {V : Set X} (hVopen : IsOpen V) (hVconn : IsPreconnected V)
+    (hVsub : V ⊆ tp.baseSet ∩ tq.baseSet) (hf₀V : q f₀ ∈ V) :
+    IsEvenlyCovered g f₀ (g ⁻¹' {f₀}) := by
+  refine IsEvenlyCovered.to_isEvenlyCovered_preimage
+    (I := {i : I // (tq (g (tp.toOpenPartialHomeomorph.symm (q f₀, i)))).2 = (tq f₀).2}) ?_
+  -- Points of a sheet of `p` over `V` land in `tq.source`, so their sheet index is defined.
+  have hmem : ∀ (i : I) {v : X}, v ∈ V →
+      g (tp.toOpenPartialHomeomorph.symm (v, i)) ∈ tq.source := by
+    intro i v hv
+    rw [tq.mem_source, hqg, tp.proj_symm_apply' (hVsub hv).1]
+    exact (hVsub hv).2
+  have hsnd : ContinuousOn (fun f : F => (tq f).2) tq.source :=
+    continuous_snd.comp_continuousOn tq.continuousOn_toFun
+  -- That index varies continuously along the sheet,
+  have hcont : ∀ i : I,
+      ContinuousOn (fun v => (tq (g (tp.toOpenPartialHomeomorph.symm (v, i)))).2) V := by
+    intro i
+    have h1 : ContinuousOn (fun v => g (tp.toOpenPartialHomeomorph.symm (v, i))) V :=
+      hg.comp_continuousOn (tp.continuousOn_symm_prodMk_left.mono fun v hv => (hVsub hv).1)
+    exact hsnd.comp h1 fun v hv => hmem i hv
+  -- hence is constant, `V` being preconnected and `J` discrete.
+  have hcv : ∀ (i : I) {v : X}, v ∈ V →
+      (tq (g (tp.toOpenPartialHomeomorph.symm (v, i)))).2 =
+        (tq (g (tp.toOpenPartialHomeomorph.symm (q f₀, i)))).2 :=
+    fun i _ hv => hVconn.constant (hcont i) hv hf₀V
+  set j₀ : J := (tq f₀).2 with hj₀
+  set W : Set F := {f | q f ∈ V ∧ (tq f).2 = j₀} with hWdef
+  have hf₀W : f₀ ∈ W := ⟨hf₀V, rfl⟩
+  have hWopen : IsOpen W := by
+    have hW : W = q ⁻¹' V ∩ (tq.source ∩ (fun f => (tq f).2) ⁻¹' {j₀}) := by
+      ext f
+      exact ⟨fun h => ⟨h.1, tq.mem_source.mpr (hVsub h.1).2, h.2⟩, fun h => ⟨h.1, h.2.2⟩⟩
+    rw [hW]
+    exact (hVopen.preimage hq).inter
+      (hsnd.isOpen_inter_preimage tq.open_source (isOpen_discrete {j₀}))
+  -- Membership in `g ⁻¹' W` is read off the sheet index of `p`.
+  have hgW : ∀ e : E, g e ∈ W ↔
+      p e ∈ V ∧ (tq (g (tp.toOpenPartialHomeomorph.symm (q f₀, (tp e).2)))).2 = j₀ := by
+    intro e
+    constructor
+    · rintro ⟨h1, h2⟩
+      rw [hqg] at h1
+      refine ⟨h1, ?_⟩
+      rw [← hcv (tp e).2 h1, tp.symm_apply_mk_proj (tp.mem_source.mpr (hVsub h1).1), h2]
+    · rintro ⟨h1, h2⟩
+      have h3 := hcv (tp e).2 h1
+      rw [tp.symm_apply_mk_proj (tp.mem_source.mpr (hVsub h1).1)] at h3
+      exact ⟨by rw [hqg]; exact h1, by rw [h3, h2]⟩
+  have hfwd : ∀ e : E, g e ∈ W →
+      (tq (g (tp.toOpenPartialHomeomorph.symm (q f₀, (tp e).2)))).2 = j₀ :=
+    fun e he => ((hgW e).mp he).2
+  -- The sheet of `p` through a point of `W` is carried onto that point.
+  have hbwd : ∀ (w : F) (i : I), w ∈ W →
+      (tq (g (tp.toOpenPartialHomeomorph.symm (q f₀, i)))).2 = j₀ →
+      g (tp.toOpenPartialHomeomorph.symm (q w, i)) = w := by
+    intro w i hw hi
+    have hwV : q w ∈ V := hw.1
+    have h1 : q (g (tp.toOpenPartialHomeomorph.symm (q w, i))) = q w := by
+      rw [hqg, tp.proj_symm_apply' (hVsub hwV).1]
+    refine tq.injOn (hmem i hwV) (tq.mem_source.mpr (hVsub hwV).2) (Prod.ext ?_ ?_)
+    · simp only [Trivialization.coe_coe]
+      rw [tq.coe_fst (hmem i hwV), tq.coe_fst (tq.mem_source.mpr (hVsub hwV).2), h1]
+    · simp only [Trivialization.coe_coe]
+      rw [hcv i hwV, hi, hw.2]
+  refine ⟨inferInstance, W, hf₀W, hWopen, hWopen.preimage hg,
+    { toFun := fun e => (⟨g e.1, e.2⟩, ⟨(tp e.1).2, hfwd e.1 e.2⟩)
+      invFun := fun wi => ⟨tp.toOpenPartialHomeomorph.symm (q wi.1.1, wi.2.1), by
+        refine (hgW _).mpr ⟨?_, ?_⟩
+        · rw [tp.proj_symm_apply' (hVsub wi.1.2.1).1]
+          exact wi.1.2.1
+        · rw [tp.apply_symm_apply' (hVsub wi.1.2.1).1]
+          exact wi.2.2⟩
+      left_inv := by
+        rintro ⟨e, he⟩
+        refine Subtype.ext ?_
+        dsimp only
+        rw [hqg e]
+        exact tp.symm_apply_mk_proj (tp.mem_source.mpr (hVsub ((hgW e).mp he).1).1)
+      right_inv := by
+        rintro ⟨⟨w, hw⟩, ⟨i, hi⟩⟩
+        dsimp only
+        refine Prod.ext (Subtype.ext (hbwd w i hw hi)) (Subtype.ext ?_)
+        dsimp only
+        rw [tp.apply_symm_apply' (hVsub hw.1).1]
+      continuous_toFun := by
+        refine Continuous.prodMk (Continuous.subtype_mk (hg.comp continuous_subtype_val) _)
+          (Continuous.subtype_mk ?_ _)
+        refine continuous_snd.comp_continuousOn tp.continuousOn_toFun
+          |>.comp_continuous continuous_subtype_val fun e => ?_
+        exact tp.mem_source.mpr (hVsub ((hgW e.1).mp e.2).1).1
+      continuous_invFun := by
+        refine Continuous.subtype_mk ?_ _
+        refine tp.toOpenPartialHomeomorph.continuousOn_symm.comp_continuous ?_ fun wi => ?_
+        · exact ((hq.comp continuous_subtype_val).comp continuous_fst).prodMk
+            (continuous_subtype_val.comp continuous_snd)
+        · exact tp.mem_target.mpr (hVsub wi.1.2.1).1 },
+    fun _ => rfl⟩
+
+/-- **A map of covering spaces over a locally connected base is a covering map.** If `p : E → X`
+and `q : F → X` are covering maps and `g : E → F` is continuous with `q ∘ g = p`, then `g` is a
+covering map.
+
+Neither total space needs to be connected and `g` need not be surjective; the fibre of `g` over
+a point outside its range is empty, which `IsCoveringMap` permits. -/
+theorem _root_.IsCoveringMap.of_comp_eq [LocallyConnectedSpace X] (hp : IsCoveringMap p)
+    (hq : IsCoveringMap q) (hg : Continuous g) (hgp : q ∘ g = p) : IsCoveringMap g := by
+  have hqg : ∀ e, q (g e) = p e := congrFun hgp
+  intro f₀
+  rcases isEmpty_or_nonempty (p ⁻¹' {q f₀} : Set E) with hemp | hne
+  · -- `p` misses `q f₀`, so `g` misses a whole evenly covered neighbourhood of `f₀`.
+    obtain ⟨-, U, hxU, hU, -, Hp, -⟩ := hp (q f₀)
+    have hpU : p ⁻¹' U = ∅ := Set.isEmpty_coe_sort.mp (Function.isEmpty ⇑Hp)
+    have hgU : g ⁻¹' (q ⁻¹' U) = ∅ := by
+      rw [← Set.preimage_comp, hgp]
+      exact hpU
+    have : IsEmpty (g ⁻¹' {f₀} : Set E) := by
+      refine Set.isEmpty_coe_sort.mpr (Set.eq_empty_of_subset_empty ?_)
+      rw [← hgU]
+      rintro e he
+      rw [Set.mem_preimage, Set.mem_singleton_iff] at he
+      simpa only [Set.mem_preimage, he] using hxU
+    exact IsEvenlyCovered.of_preimage_eq_empty _ ((hU.preimage hq.continuous).mem_nhds hxU) hgU
+  · have : Nonempty (q ⁻¹' {q f₀} : Set F) := ⟨⟨f₀, rfl⟩⟩
+    have := (hp (q f₀)).discreteTopology_fiber
+    have := (hq (q f₀)).discreteTopology_fiber
+    -- `V` is the connected component of `q f₀` in the intersection of the two base sets.
+    set tp := (hp (q f₀)).toTrivialization
+    set tq := (hq (q f₀)).toTrivialization
+    exact isEvenlyCovered_of_trivialization hq.continuous hg hqg tp tq f₀
+      (tp.open_baseSet.inter tq.open_baseSet).connectedComponentIn
+      isPreconnected_connectedComponentIn (connectedComponentIn_subset _ _)
+      (mem_connectedComponentIn
+        ⟨(hp (q f₀)).mem_toTrivialization_baseSet, (hq (q f₀)).mem_toTrivialization_baseSet⟩)
+
+/-- A map of covering spaces over a locally connected base is surjective as soon as the target
+cover is preconnected and the source cover is nonempty. -/
+theorem _root_.IsCoveringMap.surjective_of_comp_eq [LocallyConnectedSpace X] [PreconnectedSpace F]
+    [Nonempty E] (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hg : Continuous g)
+    (hgp : q ∘ g = p) : Function.Surjective g :=
+  (hp.of_comp_eq hq hg hgp).surjective
+
+end TauCeti

--- a/TauCeti/Topology/Covering/Factorization.lean
+++ b/TauCeti/Topology/Covering/Factorization.lean
@@ -6,39 +6,36 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Topology.Connected.LocallyConnected
-public import TauCeti.Topology.Covering.Clopen
+public import Mathlib.Topology.Covering.Basic
 
 /-!
-# A map between covering spaces of a locally connected base is a covering map
+# A map of covering spaces with locally connected target is a covering map
 
 Let `p : E → X` and `q : F → X` be covering maps and let `g : E → F` be a continuous map over
-`X`, that is, `q ∘ g = p`. This file proves that `g` is itself a covering map as soon as `X` is
+`X`, that is, `q ∘ g = p`. This file proves that `g` is itself a covering map as soon as `F` is
 locally connected.
 
 The proof is the standard sheet comparison. Around a point `f₀` of `F`, choose a connected open
-set `V` inside the intersection of an evenly covered neighbourhood for `p` with one for `q`, and
-trivialize both projections over it. A sheet of `p` over `V` is the image of `V` under
+neighbourhood in `F` whose image `V` lies inside the intersection of evenly covered
+neighbourhoods for `p` and `q`, and trivialize both projections over `V`. A sheet of `p` over `V`
+is the image of `V` under
 `v ↦ tp.symm (v, i)`, so it is connected, and the sheet index of its image under `g` is a
 continuous map from `V` to a discrete space, hence constant. So `g` carries each sheet of `p`
 over `V` onto a single sheet of `q`, and injectively, because `p = q ∘ g` is injective on it.
 The sheet `W` of `q` through `f₀` is therefore evenly covered by `g`, with fibre the set of
 sheets of `p` that land in `W`.
 
-Local connectedness of `X` is what produces the connected `V`. It is used exactly once, to make
-the sheet index locally constant, and that is the step which fails over a base with no small
-connected neighbourhoods.
+Local connectedness of `F` produces the connected neighbourhood whose open, connected image is
+`V`. It is used exactly once, to make the sheet index locally constant.
 
 Neither total space is assumed connected and `g` is not assumed surjective. That is consistent
 because `IsCoveringMap` allows empty fibres: over a sheet of `q` missed by `g` the fibre of `g`
-is empty. Surjectivity is a separate statement, recorded here for a preconnected target: it
-follows from the clopenness of the range of a covering map.
+is empty.
 
 ## Main declarations
 
-* `IsCoveringMap.of_comp_eq`: **a continuous map between covering spaces of a locally connected
-  base, commuting with the projections, is a covering map.**
-* `IsCoveringMap.surjective_of_comp_eq`: it is surjective as soon as the target cover is
-  preconnected and the source cover is nonempty.
+* `IsCoveringMap.of_comp_eq`: **a continuous map between covering spaces, with locally connected
+  target and commuting with the projections, is a covering map.**
 -/
 
 public section
@@ -156,13 +153,13 @@ private theorem isEvenlyCovered_of_trivialization (hq : Continuous q) (hg : Cont
         · exact tp.mem_target.mpr (hVsub wi.1.2.1).1 },
     fun _ => rfl⟩
 
-/-- **A map of covering spaces over a locally connected base is a covering map.** If `p : E → X`
+/-- **A map of covering spaces with locally connected target is a covering map.** If `p : E → X`
 and `q : F → X` are covering maps and `g : E → F` is continuous with `q ∘ g = p`, then `g` is a
-covering map.
+covering map provided `F` is locally connected.
 
 Neither total space needs to be connected and `g` need not be surjective; the fibre of `g` over
 a point outside its range is empty, which `IsCoveringMap` permits. -/
-theorem _root_.IsCoveringMap.of_comp_eq [LocallyConnectedSpace X] (hp : IsCoveringMap p)
+theorem _root_.IsCoveringMap.of_comp_eq [LocallyConnectedSpace F] (hp : IsCoveringMap p)
     (hq : IsCoveringMap q) (hg : Continuous g) (hgp : q ∘ g = p) : IsCoveringMap g := by
   have hqg : ∀ e, q (g e) = p e := congrFun hgp
   intro f₀
@@ -183,20 +180,16 @@ theorem _root_.IsCoveringMap.of_comp_eq [LocallyConnectedSpace X] (hp : IsCoveri
   · have : Nonempty (q ⁻¹' {q f₀} : Set F) := ⟨⟨f₀, rfl⟩⟩
     have := (hp (q f₀)).discreteTopology_fiber
     have := (hq (q f₀)).discreteTopology_fiber
-    -- `V` is the connected component of `q f₀` in the intersection of the two base sets.
     set tp := (hp (q f₀)).toTrivialization
     set tq := (hq (q f₀)).toTrivialization
+    obtain ⟨W, hWsub, hWopen, hf₀W, hWconn⟩ :=
+      locallyConnectedSpace_iff_subsets_isOpen_isConnected.mp ‹LocallyConnectedSpace F› f₀
+        (q ⁻¹' (tp.baseSet ∩ tq.baseSet))
+        ((tp.open_baseSet.inter tq.open_baseSet).preimage hq.continuous |>.mem_nhds
+          ⟨(hp (q f₀)).mem_toTrivialization_baseSet,
+            (hq (q f₀)).mem_toTrivialization_baseSet⟩)
     exact isEvenlyCovered_of_trivialization hq.continuous hg hqg tp tq f₀
-      (tp.open_baseSet.inter tq.open_baseSet).connectedComponentIn
-      isPreconnected_connectedComponentIn (connectedComponentIn_subset _ _)
-      (mem_connectedComponentIn
-        ⟨(hp (q f₀)).mem_toTrivialization_baseSet, (hq (q f₀)).mem_toTrivialization_baseSet⟩)
-
-/-- A map of covering spaces over a locally connected base is surjective as soon as the target
-cover is preconnected and the source cover is nonempty. -/
-theorem _root_.IsCoveringMap.surjective_of_comp_eq [LocallyConnectedSpace X] [PreconnectedSpace F]
-    [Nonempty E] (hp : IsCoveringMap p) (hq : IsCoveringMap q) (hg : Continuous g)
-    (hgp : q ∘ g = p) : Function.Surjective g :=
-  (hp.of_comp_eq hq hg hgp).surjective
+      (hq.isOpenMap W hWopen) (hWconn.isPreconnected.image q hq.continuous.continuousOn)
+      (fun x ⟨f, hf, hfx⟩ => hfx ▸ hWsub hf) ⟨f₀, hf₀W, rfl⟩
 
 end TauCeti

--- a/TauCeti/Topology/Covering/Monodromy/Connected.lean
+++ b/TauCeti/Topology/Covering/Monodromy/Connected.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Topology.Covering.Monodromy.Full
 public import TauCeti.Topology.Homotopy.Monodromy.Basic
+public import TauCeti.Topology.IsLocalHomeomorph
 
 /-!
 # Monodromy of connected covering spaces
@@ -124,33 +125,6 @@ namespace ConnectedCoveringSpace
 
 variable {X : TopCat.{u}}
 
-/-- A local homeomorphism with locally path-connected codomain has locally path-connected
-domain. This local form passes local path-connectedness from the base to the total space of a
-covering. -/
-private theorem locallyPathConnectedSpace_of_isLocalHomeomorph
-    {E B : Type u} [TopologicalSpace E] [TopologicalSpace B]
-    [LocallyPathConnectedSpace B] {p : E → B} (hp : IsLocalHomeomorph p) :
-    LocallyPathConnectedSpace E := by
-  constructor
-  intro e
-  rw [Filter.hasBasis_self]
-  intro U hU
-  obtain ⟨W, hWU, hWopen, heW⟩ := mem_nhds_iff.mp hU
-  let φ := hp.localInverseAt e
-  have hpe_source : p e ∈ φ.source := hp.apply_self_mem_localInverseAt_source
-  have hsource : IsOpen (φ.source ∩ φ ⁻¹' W) :=
-    φ.continuousOn_toFun.isOpen_inter_preimage φ.open_source hWopen
-  have hpe : p e ∈ φ.source ∩ φ ⁻¹' W := by
-    refine ⟨hpe_source, ?_⟩
-    simpa only [Set.mem_preimage, φ, hp.localInverseAt_apply_self] using heW
-  obtain ⟨V, ⟨hVopen, hpeV, hVpath⟩, hVsub⟩ :=
-    (isOpen_isPathConnected_basis (p e)).mem_iff.mp (hsource.mem_nhds hpe)
-  refine ⟨φ '' V, ?_, hVpath.image' (φ.continuousOn_toFun.mono fun _ hv => (hVsub hv).1), ?_⟩
-  · exact (φ.isOpen_image_of_subset_source hVopen
-      (hVsub.trans Set.inter_subset_left)).mem_nhds ⟨p e, hpeV, by simp [φ]⟩
-  · rintro z ⟨y, hyV, rfl⟩
-    exact hWU (hVsub hyV).2
-
 /-- The ordinary monodromy functor of a connected cover is pretransitive on every fibre. -/
 theorem monodromy_isFiberwisePretransitive [LocallyPathConnectedSpace X]
     (p : ConnectedCoveringSpace X) :
@@ -161,7 +135,7 @@ theorem monodromy_isFiberwisePretransitive [LocallyPathConnectedSpace X]
   intro x e e'
   rcases x with ⟨x⟩
   let _ : LocallyPathConnectedSpace (p : TopCat) :=
-    locallyPathConnectedSpace_of_isLocalHomeomorph p.isCoveringMap_proj.isLocalHomeomorph
+    p.isCoveringMap_proj.isLocalHomeomorph.locallyPathConnectedSpace
   let _ : PathConnectedSpace (p : TopCat) := PathConnectedSpace.of_locallyPathConnectedSpace
   exact IsCoveringMap.exists_monodromy_eq p.isCoveringMap_proj e e'
 
@@ -176,7 +150,7 @@ theorem isPretransitive_fiberAction [LocallyPathConnectedSpace X] (p : Connected
     letI := p.isCoveringMap_proj.fundamentalGroupMulAction x₀
     MulAction.IsPretransitive (FundamentalGroup X x₀) (⇑p.proj ⁻¹' {x₀}) := by
   let _ : LocallyPathConnectedSpace (p : TopCat) :=
-    locallyPathConnectedSpace_of_isLocalHomeomorph p.isCoveringMap_proj.isLocalHomeomorph
+    p.isCoveringMap_proj.isLocalHomeomorph.locallyPathConnectedSpace
   let _ : PathConnectedSpace (p : TopCat) := PathConnectedSpace.of_locallyPathConnectedSpace
   exact IsCoveringMap.monodromy_isPretransitive p.isCoveringMap_proj x₀
 

--- a/TauCeti/Topology/IsLocalHomeomorph.lean
+++ b/TauCeti/Topology/IsLocalHomeomorph.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Connected.LocallyPathConnected
+public import Mathlib.Topology.IsLocalHomeomorph
+
+/-!
+# Local path-connectedness passes to the domain of a local homeomorphism
+
+A local homeomorphism `p : E → B` identifies a neighbourhood of each point of `E` with an open
+subset of `B`, so `E` inherits any property of `B` that is local and stable under passing to open
+subspaces. This file records that for local path-connectedness.
+
+The intended use is a covering map, whose total space is therefore locally path-connected as soon
+as the base is; this is what lets the covers built over a locally path-connected base be fed back
+into results that require a locally path-connected source, such as the lifting criterion.
+
+## Main results
+
+* `IsLocalHomeomorph.locallyPathConnectedSpace`: the domain of a local homeomorphism into a
+  locally path-connected space is locally path-connected.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {E B : Type*} [TopologicalSpace E] [TopologicalSpace B]
+
+/-- **A local homeomorphism with locally path-connected codomain has locally path-connected
+domain.** In particular the total space of a covering of a locally path-connected space is
+locally path-connected. -/
+theorem _root_.IsLocalHomeomorph.locallyPathConnectedSpace [LocallyPathConnectedSpace B]
+    {p : E → B} (hp : IsLocalHomeomorph p) : LocallyPathConnectedSpace E := by
+  constructor
+  intro e
+  rw [Filter.hasBasis_self]
+  intro U hU
+  obtain ⟨W, hWU, hWopen, heW⟩ := mem_nhds_iff.mp hU
+  let φ := hp.localInverseAt e
+  have hpe_source : p e ∈ φ.source := hp.apply_self_mem_localInverseAt_source
+  have hsource : IsOpen (φ.source ∩ φ ⁻¹' W) :=
+    φ.continuousOn_toFun.isOpen_inter_preimage φ.open_source hWopen
+  have hpe : p e ∈ φ.source ∩ φ ⁻¹' W := by
+    refine ⟨hpe_source, ?_⟩
+    simpa only [Set.mem_preimage, φ, hp.localInverseAt_apply_self] using heW
+  obtain ⟨V, ⟨hVopen, hpeV, hVpath⟩, hVsub⟩ :=
+    (isOpen_isPathConnected_basis (p e)).mem_iff.mp (hsource.mem_nhds hpe)
+  refine ⟨φ '' V, ?_, hVpath.image' (φ.continuousOn_toFun.mono fun _ hv => (hVsub hv).1), ?_⟩
+  · exact (φ.isOpen_image_of_subset_source hVopen
+      (hVsub.trans Set.inter_subset_left)).mem_nhds ⟨p e, hpeV, by simp [φ]⟩
+  · rintro z ⟨y, hyV, rfl⟩
+    exact hWU (hVsub hyV).2
+
+end TauCeti


### PR DESCRIPTION
This PR proves that a continuous map between two covering spaces of the same base, commuting with
the two projections, is itself a covering map as soon as the target cover is locally connected,
and uses that to upgrade the classification of pointed connected covers into a statement about
towers of covers: for `H, K ≤ π₁(X, x₀)` the cover `UniversalCover x₀ / H` covers
`UniversalCover x₀ / K` compatibly with the distinguished basepoints exactly when `H ≤ K`, and
the universal cover covers any nonempty covering space of `X` once points in a common fibre are
chosen.

The milestone is Stage 2, item 8 of `TauCetiRoadmap/UniversalCovers/README.md`, the Galois
correspondence and its bookkeeping. Its two classification theorems, its deck group `N(H)/H` and
its alternative monodromy and Galois-category lenses are already in the repository; what the item
still lacked was its order-theoretic content, because
`TauCeti.IsCoveringMap.exists_continuousMap_comp_eq_iff_range_le` produces only a continuous
comparison map between two pointed covers, and nothing recorded that this map is a covering map.
That is exactly the difference between "one subgroup sits inside another" and "one cover is a
cover of the other". After this PR the remaining bookkeeping for that item is to package the
correspondence as a single order isomorphism between the subgroup lattice of `π₁(X, x₀)` and
isomorphism classes of pointed connected covers, rather than as the family of pointwise
statements it is now.

`TauCeti/Topology/Covering/Factorization.lean` (195 lines) carries the general theorem
`IsCoveringMap.of_comp_eq`. The proof is the standard sheet comparison: around a point of the
target choose a connected neighbourhood whose image `V` lies inside an evenly covered
neighbourhood for each of the two projections, and trivialize both over `V`; a sheet of `p` over
`V` is the image of `V` under `v ↦ tp.symm (v, i)` and so is connected, so the sheet index of its
image under `g`, a continuous map into a discrete space, is constant. Hence `g` carries each
sheet of `p` over `V` onto a single sheet of `q`, and injectively, because `p = q ∘ g` is
injective on it. Local connectedness of the target total space is used exactly once, to produce
that connected neighbourhood. Neither total space is assumed connected and `g` is not assumed
surjective, which costs nothing because `IsCoveringMap` allows empty fibres.

`TauCeti/AlgebraicTopology/UniversalCover/Classification/Intermediate.lean` (119 lines) draws the
roadmap consequences: `IsCoveringMap.exists_isCoveringMap_comp_eq_iff_range_le` strengthens the
existing pointed-cover criterion so that the comparison map is a covering map,
`UniversalCover.exists_isCoveringMap_comp_eq_proj` says the universal cover covers a nonempty
covering space of `X` after choosing points in a common fibre, and
`UniversalCover.exists_isCoveringMap_subgroupQuotientProj_comp_eq_iff_le` is the order-preserving
half of the correspondence, obtained by feeding
`UniversalCover.range_mapOfEq_subgroupQuotientProj` into the criterion. The local
path-connectedness of the subgroup quotients that these need is recorded as
`UniversalCover.locallyPathConnectedSpace_subgroupQuotient`, beside the construction it describes
in `Classification/Existence.lean`.

`TauCeti/Topology/IsLocalHomeomorph.lean` (59 lines) is the one piece of shared infrastructure
this needs. The subgroup quotients have to be known locally path-connected before the lifting
criterion applies to them, and that fact was already proved in this repository, as the private
`locallyPathConnectedSpace_of_isLocalHomeomorph` inside
`TauCeti/Topology/Covering/Monodromy/Connected.lean`. Rather than restate it, this PR promotes it
to the public `IsLocalHomeomorph.locallyPathConnectedSpace` in a file of its own, mirroring
`Mathlib/Topology/IsLocalHomeomorph.lean`, and rewrites its one previous use to call it. The
proof is moved verbatim; no declaration is renamed and no other module changes.

New declarations are placed in the root `IsCoveringMap` and `IsLocalHomeomorph` namespaces, as
`IsCoveringMap.subtypeVal_comp` in `TauCeti/Topology/Covering/Clopen.lean` already is, because
the dot-notation lint baseline is closed to new `TauCeti.IsCoveringMap.*` names.

Mathlib infrastructure consumed rather than vendored: `IsEvenlyCovered` and `Trivialization`
(Thomas Browning and the fiber-bundle library), the lifting criterion in
`Mathlib/Topology/Homotopy/Lifting.lean` (Junyan Xu), and the based-path universal cover in
`TauCeti/AlgebraicTopology/UniversalCover/`, adapted from Kim Morrison's
[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292). The mathematics
follows Hatcher, *Algebraic Topology*, Section 1.3. No external formalization is copied.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"map-of-covering-spaces-is-a-covering-map"}-->

🤖 Prepared with Claude Code
