### PR TITLE
feat(AdicSpace): rational subsets are closed under finite intersections (Wedhorn 7.35(2))

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -28,10 +28,17 @@ openness of `T · A` implies admissibility for `IA`; conversely, an admissible p
 has open numerator ideal after inserting `s` among the numerators, which does not change its
 rational subset. This comparison also transports closure under intersections and quasi-compactness.
 
-Closure under intersection is proved twice over: `inter_mem_spaRationalFamily` is the binary
-statement of Remark 7.30(5), and `biInter_mem_spaRationalFamily` iterates it to the finite
-intersections that Theorem 7.35(2) asserts and that Wedhorn's own proof of that theorem uses.
-The finite form is what a common refinement of a finite rational cover consumes.
+Closure under intersection appears in two strengths. Remark 7.30(5) is the binary statement,
+recorded here as `inter_mem_spaRationalFamily`; Theorem 7.35(2) asserts the stronger claim that
+the basis is stable under *finite* intersection, and `biInter_mem_spaRationalFamily` supplies it
+by iterating the binary lemma. The finite form is the one a common refinement of a finite
+rational cover consumes.
+
+Mathlib's `IsPiSystem.biInter_mem` is not usable for this. It is indexed by a `Finset (Set X)`
+rather than by a family, and it assumes both that the index set and the intersection itself are
+nonempty. The rational family is closed under intersection with no nonemptiness hypothesis, so
+the statements here carry none either, and the empty intersection is covered by
+`univ_mem_spaRationalFamily`.
 
 The plus ring is arbitrary here. The additional condition that it be a ring of integral
 elements is part of calling the resulting space the adic spectrum of a Huber pair, but none of
@@ -52,9 +59,8 @@ the basis arguments uses it.
   intersections, which is the stability clause of Wedhorn Theorem 7.35(2). It is stated over a
   `Finset` index, with `TauCeti.ValuationSpectrum.iInter_mem_spaRationalFamily` for a finite index
   type and `TauCeti.ValuationSpectrum.sInter_mem_spaRationalFamily` for a finite subfamily, the
-  form a refinement argument produces. The binary lemma is the step this iterates; neither implies
-  the other formally, since the induction also needs `univ_mem_spaRationalFamily` at the empty
-  stage.
+  form a refinement argument produces. The binary lemma stays the primitive: the induction proving
+  the finite form runs on it, with `univ_mem_spaRationalFamily` at the empty stage.
 * `TauCeti.ValuationSpectrum.inf_mem_spaRationalOpens` and
   `TauCeti.ValuationSpectrum.finsetInf_mem_spaRationalOpens`: the same two closure statements in
   the bundled `Opens` form, together with `TauCeti.ValuationSpectrum.top_mem_spaRationalOpens`.
@@ -183,7 +189,6 @@ theorem inter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A}
   (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
     fun P ↦ inter_mem_spaRationalFamily_of_pairOfDefinition P hU hV
 
-
 /-- **Wedhorn Theorem 7.35(2), finite-intersection half**, from a specified pair of definition:
 an intersection of finitely many rational subsets with open numerator ideal is again one. The
 induction is over the index set, with `univ_mem_spaRationalFamily` at the empty stage and
@@ -205,7 +210,9 @@ theorem biInter_mem_spaRationalFamily_of_pairOfDefinition (P : PairOfDefinition 
 /-- **Wedhorn Theorem 7.35(2), finite-intersection half.** Over a Huber ring the rational family
 is closed under intersections indexed by a `Finset`. This is the form Wedhorn's Theorem 7.35(2)
 states — "a basis of quasi-compact open subsets which is stable under finite intersection" —
-whereas `inter_mem_spaRationalFamily` gives only the binary step it iterates. -/
+whereas `inter_mem_spaRationalFamily` gives only the binary step it iterates. Wedhorn's proof of
+7.35(2) cites Remark 7.30(4) for the stability, but 7.30(4) is the statement that `R(T/s)` is
+rational for a unit `s`; the binary intersection used here is 7.30(5). -/
 theorem biInter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A} {ι : Type*}
     (s : Finset ι) {U : ι → Set (spa Aplus)}
     (h : ∀ i ∈ s, U i ∈ spaRationalFamily Aplus) :
@@ -347,12 +354,11 @@ theorem isBasis_spaRationalOpens [IsHuberRing A] (Aplus : Subring A) :
   TauCeti.TopologicalSpace.Opens.isBasis_of_isTopologicalBasis
     (isTopologicalBasis_spaRationalFamily Aplus)
 
-
 omit [IsTopologicalRing A] in
 /-- The whole space is a rational open, presented as `R({1}/1)`. -/
 theorem top_mem_spaRationalOpens (Aplus : Subring A) :
     (⊤ : Opens (spa Aplus)) ∈ spaRationalOpens Aplus :=
-  univ_mem_spaRationalFamily Aplus
+  mem_spaRationalOpens.mpr (univ_mem_spaRationalFamily Aplus)
 
 /-- **Wedhorn Remark 7.30(5)** in the bundled form: the rational opens are closed under binary
 meet. Meet of `Opens` is intersection of the underlying sets, so this is
@@ -360,7 +366,8 @@ meet. Meet of `Opens` is intersection of the underlying sets, so this is
 theorem inf_mem_spaRationalOpens [IsHuberRing A] {Aplus : Subring A}
     {U V : Opens (spa Aplus)} (hU : U ∈ spaRationalOpens Aplus)
     (hV : V ∈ spaRationalOpens Aplus) : U ⊓ V ∈ spaRationalOpens Aplus :=
-  inter_mem_spaRationalFamily hU hV
+  mem_spaRationalOpens.mpr
+    (inter_mem_spaRationalFamily (mem_spaRationalOpens.mp hU) (mem_spaRationalOpens.mp hV))
 
 /-- **Wedhorn Theorem 7.35(2), finite-intersection half**, in the bundled form: the rational
 opens are closed under `Finset.inf`. This is the shape a sheaf criterion on the basis takes,

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -81,6 +81,10 @@ the basis arguments uses it.
 
 * T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.29, Remark 7.30, Theorem 7.35,
   Corollary 7.53, and Lemma 6.6.
+
+One correction to the source: Wedhorn's proof of Theorem 7.35(2) cites Remark 7.30(4) for
+stability under finite intersection, but 7.30(4) is the statement that `R(T/s)` is rational
+for a unit `s`. The binary intersection this file iterates is Remark 7.30(5).
 -/
 
 public section
@@ -103,18 +107,17 @@ This is Wedhorn Lemma 6.6 applied to the inclusion of the numerator span into th
 after adjoining the denominator. -/
 theorem isAdmissible_extendedIdealOfDefinition_of_isOpen_span (P : PairOfDefinition A)
     {T : Finset A} {s : A} (hT : IsOpen (Ideal.span (T : Set A) : Set A)) :
-    IsAdmissible P.extendedIdealOfDefinition T s := by
-  rw [isAdmissible_iff]
-  refine (P.isOpen_iff_le_radical _).mp hT |>.trans (Ideal.radical_mono ?_)
-  exact Ideal.span_mono (Set.subset_insert s (T : Set A))
+    IsAdmissible P.extendedIdealOfDefinition T s :=
+  isAdmissible_iff.mpr <| ((P.isOpen_iff_le_radical _).mp hT).trans <|
+    Ideal.radical_mono <| Ideal.span_mono <| Set.subset_insert s (T : Set A)
 
 /-- An admissible numerator set becomes an open numerator ideal after adjoining its denominator.
-The rational subset itself is unchanged by this operation. -/
+The rational subset itself is unchanged by this operation. This is not a converse of
+`isAdmissible_extendedIdealOfDefinition_of_isOpen_span`, which assumes the span of `T` open. -/
 theorem isOpen_span_insert_of_isAdmissible_extendedIdealOfDefinition (P : PairOfDefinition A)
     {T : Finset A} {s : A} (hT : IsAdmissible P.extendedIdealOfDefinition T s) :
-    IsOpen (Ideal.span (insert s (T : Set A)) : Set A) := by
-  rw [P.isOpen_iff_le_radical]
-  exact isAdmissible_iff.mp hT
+    IsOpen (Ideal.span (insert s (T : Set A)) : Set A) :=
+  (P.isOpen_iff_le_radical _).mpr <| isAdmissible_iff.mp hT
 
 end TopologicalRing
 
@@ -153,11 +156,9 @@ open Classical in
 numerator sets after adjoining their respective denominators. This is the admissibility half of
 the intersection formula for rational subsets. -/
 private theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A)
-    {T₁ T₂ : Finset A} {s₁ s₂ : A}
-    (hT₁ : IsOpen (Ideal.span (T₁ : Set A) : Set A))
+    {T₁ T₂ : Finset A} {s₁ s₂ : A} (hT₁ : IsOpen (Ideal.span (T₁ : Set A) : Set A))
     (hT₂ : IsOpen (Ideal.span (T₂ : Set A) : Set A)) :
     IsOpen (Ideal.span ((insert s₁ T₁ * insert s₂ T₂ : Finset A) : Set A) : Set A) := by
-  classical
   rw [P.isOpen_iff_le_radical]
   have hmul :=
     (isAdmissible_extendedIdealOfDefinition_of_isOpen_span (s := s₁) P hT₁).mul
@@ -171,8 +172,7 @@ private theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A)
 intersection. The set identity is `rationalSubset_inter`; admissibility is multiplicative in
 `Spv(A,IA)`, and adjoining the product denominator turns it back into openness. -/
 theorem inter_mem_spaRationalFamily_of_pairOfDefinition (P : PairOfDefinition A)
-    {Aplus : Subring A}
-    {U V : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus)
+    {Aplus : Subring A} {U V : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus)
     (hV : V ∈ spaRationalFamily Aplus) : U ∩ V ∈ spaRationalFamily Aplus := by
   classical
   obtain ⟨T₁, s₁, hT₁, rfl⟩ := hU
@@ -196,8 +196,7 @@ induction is over the index set, with `univ_mem_spaRationalFamily` at the empty 
 throughout, so no choice is made inside the induction. -/
 theorem biInter_mem_spaRationalFamily_of_pairOfDefinition (P : PairOfDefinition A)
     {Aplus : Subring A} {ι : Type*} (s : Finset ι) {U : ι → Set (spa Aplus)}
-    (h : ∀ i ∈ s, U i ∈ spaRationalFamily Aplus) :
-    (⋂ i ∈ s, U i) ∈ spaRationalFamily Aplus := by
+    (h : ∀ i ∈ s, U i ∈ spaRationalFamily Aplus) : (⋂ i ∈ s, U i) ∈ spaRationalFamily Aplus := by
   classical
   induction s using Finset.induction_on with
   | empty => simpa using univ_mem_spaRationalFamily Aplus
@@ -210,12 +209,9 @@ theorem biInter_mem_spaRationalFamily_of_pairOfDefinition (P : PairOfDefinition 
 /-- **Wedhorn Theorem 7.35(2), finite-intersection half.** Over a Huber ring the rational family
 is closed under intersections indexed by a `Finset`. This is the form Wedhorn's Theorem 7.35(2)
 states — "a basis of quasi-compact open subsets which is stable under finite intersection" —
-whereas `inter_mem_spaRationalFamily` gives only the binary step it iterates. Wedhorn's proof of
-7.35(2) cites Remark 7.30(4) for the stability, but 7.30(4) is the statement that `R(T/s)` is
-rational for a unit `s`; the binary intersection used here is 7.30(5). -/
+whereas `inter_mem_spaRationalFamily` gives only the binary step it iterates. -/
 theorem biInter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A} {ι : Type*}
-    (s : Finset ι) {U : ι → Set (spa Aplus)}
-    (h : ∀ i ∈ s, U i ∈ spaRationalFamily Aplus) :
+    (s : Finset ι) {U : ι → Set (spa Aplus)} (h : ∀ i ∈ s, U i ∈ spaRationalFamily Aplus) :
     (⋂ i ∈ s, U i) ∈ spaRationalFamily Aplus :=
   (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
     fun P ↦ biInter_mem_spaRationalFamily_of_pairOfDefinition P s h
@@ -375,13 +371,8 @@ where the finite intersections of a cover are formed in `Opens` rather than in `
 theorem finsetInf_mem_spaRationalOpens [IsHuberRing A] {Aplus : Subring A} {ι : Type*}
     (s : Finset ι) {U : ι → Opens (spa Aplus)}
     (h : ∀ i ∈ s, U i ∈ spaRationalOpens Aplus) : s.inf U ∈ spaRationalOpens Aplus := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simpa using top_mem_spaRationalOpens Aplus
-  | insert a s ha ih =>
-    rw [Finset.inf_insert]
-    exact inf_mem_spaRationalOpens (h a (Finset.mem_insert_self a s))
-      (ih fun i hi ↦ h i (Finset.mem_insert_of_mem hi))
+  rw [mem_spaRationalOpens, Opens.coe_finset_inf, Finset.inf_set_eq_iInter]
+  exact biInter_mem_spaRationalFamily s fun i hi ↦ mem_spaRationalOpens.mp (h i hi)
 
 /-! ### Finite rational refinements -/
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -30,15 +30,8 @@ rational subset. This comparison also transports closure under intersections and
 
 Closure under intersection appears in two strengths. Remark 7.30(5) is the binary statement,
 recorded here as `inter_mem_spaRationalFamily`; Theorem 7.35(2) asserts the stronger claim that
-the basis is stable under *finite* intersection, and `biInter_mem_spaRationalFamily` supplies it
-by iterating the binary lemma. The finite form is the one a common refinement of a finite
-rational cover consumes.
-
-Mathlib's `IsPiSystem.biInter_mem` is not usable for this. It is indexed by a `Finset (Set X)`
-rather than by a family, and it assumes both that the index set and the intersection itself are
-nonempty. The rational family is closed under intersection with no nonemptiness hypothesis, so
-the statements here carry none either, and the empty intersection is covered by
-`univ_mem_spaRationalFamily`.
+the basis is stable under *finite* intersection. The finite form is the one a common refinement
+of a finite rational cover consumes, and it carries no nonemptiness hypothesis.
 
 The plus ring is arbitrary here. The additional condition that it be a ring of integral
 elements is part of calling the resulting space the adic spectrum of a Huber pair, but none of
@@ -59,8 +52,9 @@ the basis arguments uses it.
   intersections, which is the stability clause of Wedhorn Theorem 7.35(2). It is stated over a
   `Finset` index, with `TauCeti.ValuationSpectrum.iInter_mem_spaRationalFamily` for a finite index
   type and `TauCeti.ValuationSpectrum.sInter_mem_spaRationalFamily` for a finite subfamily, the
-  form a refinement argument produces. The binary lemma stays the primitive: the induction proving
-  the finite form runs on it, with `univ_mem_spaRationalFamily` at the empty stage.
+  form a refinement argument produces.
+* `TauCeti.ValuationSpectrum.finiteInter_spaRationalFamily`: the same closure as Mathlib's
+  `FiniteInter` structure, which the three forms above are read off.
 * `TauCeti.ValuationSpectrum.inf_mem_spaRationalOpens` and
   `TauCeti.ValuationSpectrum.finsetInf_mem_spaRationalOpens`: the same two closure statements in
   the bundled `Opens` form, together with `TauCeti.ValuationSpectrum.top_mem_spaRationalOpens`.
@@ -193,32 +187,38 @@ theorem inter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A}
   (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
     fun P ↦ inter_mem_spaRationalFamily_of_pairOfDefinition P hU hV
 
-/-- **Wedhorn Theorem 7.35(2), finite-intersection half**, from a specified pair of definition:
-an intersection of finitely many rational subsets with open numerator ideal is again one. The
-induction is over the index set, with `univ_mem_spaRationalFamily` at the empty stage and
-`inter_mem_spaRationalFamily_of_pairOfDefinition` at each step; the pair `P` is fixed
-throughout, so no choice is made inside the induction. -/
-theorem biInter_mem_spaRationalFamily_of_pairOfDefinition (P : PairOfDefinition A)
-    {Aplus : Subring A} {ι : Type*} (s : Finset ι) {U : ι → Set (spa Aplus)}
-    (h : ∀ i ∈ s, U i ∈ spaRationalFamily Aplus) : (⋂ i ∈ s, U i) ∈ spaRationalFamily Aplus := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simpa using univ_mem_spaRationalFamily Aplus
-  | insert a s ha ih =>
-    rw [Finset.set_biInter_insert]
-    exact inter_mem_spaRationalFamily_of_pairOfDefinition P
-      (h a (Finset.mem_insert_self a s))
-      (ih fun i hi ↦ h i (Finset.mem_insert_of_mem hi))
+/-- **The rational family is closed under finite intersection**, from a specified pair of
+definition, as Mathlib's `FiniteInter` structure. -/
+theorem finiteInter_spaRationalFamily_of_pairOfDefinition (P : PairOfDefinition A)
+    (Aplus : Subring A) : FiniteInter (spaRationalFamily Aplus) where
+  univ_mem := univ_mem_spaRationalFamily Aplus
+  inter_mem _ hU _ hV := inter_mem_spaRationalFamily_of_pairOfDefinition P hU hV
 
-/-- **Wedhorn Theorem 7.35(2), finite-intersection half.** Over a Huber ring the rational family
-is closed under intersections indexed by a `Finset`. This is the form Wedhorn's Theorem 7.35(2)
-states — "a basis of quasi-compact open subsets which is stable under finite intersection" —
-whereas `inter_mem_spaRationalFamily` gives only the binary step it iterates. -/
+/-- **The rational family is closed under finite intersection**, over a Huber ring. -/
+theorem finiteInter_spaRationalFamily [IsHuberRing A] (Aplus : Subring A) :
+    FiniteInter (spaRationalFamily Aplus) :=
+  (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
+    fun P ↦ finiteInter_spaRationalFamily_of_pairOfDefinition P Aplus
+
+/-- **Wedhorn Theorem 7.35(2), finite-intersection half**, for a finite subfamily: an intersection
+of finitely many rational subsets is again rational. This is the unindexed form, and the one a
+refinement argument produces, where the finite family comes out of quasi-compactness rather than
+out of an index type — see `exists_finite_spaRationalFamily_refinement`. -/
+theorem sInter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A}
+    {𝒮 : Set (Set (spa Aplus))} (h𝒮 : 𝒮.Finite) (h : 𝒮 ⊆ spaRationalFamily Aplus) :
+    ⋂₀ 𝒮 ∈ spaRationalFamily Aplus := by
+  rw [← h𝒮.coe_toFinset] at h ⊢
+  exact (finiteInter_spaRationalFamily Aplus).finiteInter_mem _ h
+
+/-- **Wedhorn Theorem 7.35(2), finite-intersection half**, indexed by a `Finset`. This is the form
+Wedhorn's Theorem 7.35(2) states — "a basis of quasi-compact open subsets which is stable under
+finite intersection" — whereas `inter_mem_spaRationalFamily` gives only the binary case. -/
 theorem biInter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A} {ι : Type*}
     (s : Finset ι) {U : ι → Set (spa Aplus)} (h : ∀ i ∈ s, U i ∈ spaRationalFamily Aplus) :
-    (⋂ i ∈ s, U i) ∈ spaRationalFamily Aplus :=
-  (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
-    fun P ↦ biInter_mem_spaRationalFamily_of_pairOfDefinition P s h
+    (⋂ i ∈ s, U i) ∈ spaRationalFamily Aplus := by
+  rw [← Finset.set_biInter_coe, ← Set.sInter_image]
+  exact sInter_mem_spaRationalFamily (s.finite_toSet.image U)
+    (Set.image_subset_iff.mpr fun i hi ↦ h i hi)
 
 /-- **Wedhorn Theorem 7.35(2), finite-intersection half**, for a finite index type. -/
 theorem iInter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A} {ι : Type*} [Finite ι]
@@ -227,19 +227,6 @@ theorem iInter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A} {ι : T
   classical
   cases nonempty_fintype ι
   simpa using biInter_mem_spaRationalFamily Finset.univ (U := U) fun i _ ↦ h i
-
-/-- **Wedhorn Theorem 7.35(2), finite-intersection half**, for a finite subfamily. This is the
-unindexed form: the intersection of a finite set of rational subsets is rational. It is the shape
-a refinement argument takes, where the finite family comes out of quasi-compactness rather than
-out of an index type — see `exists_finite_spaRationalFamily_refinement`. -/
-theorem sInter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A}
-    {𝒮 : Set (Set (spa Aplus))} (h𝒮 : 𝒮.Finite) (h : 𝒮 ⊆ spaRationalFamily Aplus) :
-    ⋂₀ 𝒮 ∈ spaRationalFamily Aplus := by
-  classical
-  have hrw : ⋂₀ 𝒮 = ⋂ U ∈ h𝒮.toFinset, U := by
-    simp [Set.sInter_eq_biInter]
-  rw [hrw]
-  exact biInter_mem_spaRationalFamily _ fun U hU ↦ h (h𝒮.mem_toFinset.mp hU)
 
 /-! ### Basis and quasi-compactness -/
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -28,6 +28,11 @@ openness of `T · A` implies admissibility for `IA`; conversely, an admissible p
 has open numerator ideal after inserting `s` among the numerators, which does not change its
 rational subset. This comparison also transports closure under intersections and quasi-compactness.
 
+Closure under intersection is proved twice over: `inter_mem_spaRationalFamily` is the binary
+statement of Remark 7.30(5), and `biInter_mem_spaRationalFamily` iterates it to the finite
+intersections that Theorem 7.35(2) asserts and that Wedhorn's own proof of that theorem uses.
+The finite form is what a common refinement of a finite rational cover consumes.
+
 The plus ring is arbitrary here. The additional condition that it be a ring of integral
 elements is part of calling the resulting space the adic spectrum of a Huber pair, but none of
 the basis arguments uses it.
@@ -42,7 +47,17 @@ the basis arguments uses it.
 ## Main results
 
 * `TauCeti.ValuationSpectrum.inter_mem_spaRationalFamily`: the family is closed under binary
-  intersections, completing Wedhorn Remark 7.30(5).
+  intersections, which is Wedhorn Remark 7.30(5).
+* `TauCeti.ValuationSpectrum.biInter_mem_spaRationalFamily`: the family is closed under *finite*
+  intersections, which is the stability clause of Wedhorn Theorem 7.35(2). It is stated over a
+  `Finset` index, with `TauCeti.ValuationSpectrum.iInter_mem_spaRationalFamily` for a finite index
+  type and `TauCeti.ValuationSpectrum.sInter_mem_spaRationalFamily` for a finite subfamily, the
+  form a refinement argument produces. The binary lemma is the step this iterates; neither implies
+  the other formally, since the induction also needs `univ_mem_spaRationalFamily` at the empty
+  stage.
+* `TauCeti.ValuationSpectrum.inf_mem_spaRationalOpens` and
+  `TauCeti.ValuationSpectrum.finsetInf_mem_spaRationalOpens`: the same two closure statements in
+  the bundled `Opens` form, together with `TauCeti.ValuationSpectrum.top_mem_spaRationalOpens`.
 * `TauCeti.ValuationSpectrum.isTopologicalBasis_spaRationalFamily`: the family is a basis for
   the topology of `spa Aplus`, with `TauCeti.ValuationSpectrum.isBasis_spaRationalOpens` the same
   statement in the `Opens.IsBasis` form.
@@ -168,6 +183,57 @@ theorem inter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A}
   (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
     fun P ↦ inter_mem_spaRationalFamily_of_pairOfDefinition P hU hV
 
+
+/-- **Wedhorn Theorem 7.35(2), finite-intersection half**, from a specified pair of definition:
+an intersection of finitely many rational subsets with open numerator ideal is again one. The
+induction is over the index set, with `univ_mem_spaRationalFamily` at the empty stage and
+`inter_mem_spaRationalFamily_of_pairOfDefinition` at each step; the pair `P` is fixed
+throughout, so no choice is made inside the induction. -/
+theorem biInter_mem_spaRationalFamily_of_pairOfDefinition (P : PairOfDefinition A)
+    {Aplus : Subring A} {ι : Type*} (s : Finset ι) {U : ι → Set (spa Aplus)}
+    (h : ∀ i ∈ s, U i ∈ spaRationalFamily Aplus) :
+    (⋂ i ∈ s, U i) ∈ spaRationalFamily Aplus := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => simpa using univ_mem_spaRationalFamily Aplus
+  | insert a s ha ih =>
+    rw [Finset.set_biInter_insert]
+    exact inter_mem_spaRationalFamily_of_pairOfDefinition P
+      (h a (Finset.mem_insert_self a s))
+      (ih fun i hi ↦ h i (Finset.mem_insert_of_mem hi))
+
+/-- **Wedhorn Theorem 7.35(2), finite-intersection half.** Over a Huber ring the rational family
+is closed under intersections indexed by a `Finset`. This is the form Wedhorn's Theorem 7.35(2)
+states — "a basis of quasi-compact open subsets which is stable under finite intersection" —
+whereas `inter_mem_spaRationalFamily` gives only the binary step it iterates. -/
+theorem biInter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A} {ι : Type*}
+    (s : Finset ι) {U : ι → Set (spa Aplus)}
+    (h : ∀ i ∈ s, U i ∈ spaRationalFamily Aplus) :
+    (⋂ i ∈ s, U i) ∈ spaRationalFamily Aplus :=
+  (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
+    fun P ↦ biInter_mem_spaRationalFamily_of_pairOfDefinition P s h
+
+/-- **Wedhorn Theorem 7.35(2), finite-intersection half**, for a finite index type. -/
+theorem iInter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A} {ι : Type*} [Finite ι]
+    {U : ι → Set (spa Aplus)} (h : ∀ i, U i ∈ spaRationalFamily Aplus) :
+    (⋂ i, U i) ∈ spaRationalFamily Aplus := by
+  classical
+  cases nonempty_fintype ι
+  simpa using biInter_mem_spaRationalFamily Finset.univ (U := U) fun i _ ↦ h i
+
+/-- **Wedhorn Theorem 7.35(2), finite-intersection half**, for a finite subfamily. This is the
+unindexed form: the intersection of a finite set of rational subsets is rational. It is the shape
+a refinement argument takes, where the finite family comes out of quasi-compactness rather than
+out of an index type — see `exists_finite_spaRationalFamily_refinement`. -/
+theorem sInter_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A}
+    {𝒮 : Set (Set (spa Aplus))} (h𝒮 : 𝒮.Finite) (h : 𝒮 ⊆ spaRationalFamily Aplus) :
+    ⋂₀ 𝒮 ∈ spaRationalFamily Aplus := by
+  classical
+  have hrw : ⋂₀ 𝒮 = ⋂ U ∈ h𝒮.toFinset, U := by
+    simp [Set.sInter_eq_biInter]
+  rw [hrw]
+  exact biInter_mem_spaRationalFamily _ fun U hU ↦ h (h𝒮.mem_toFinset.mp hU)
+
 /-! ### Basis and quasi-compactness -/
 
 /-- **Rational subsets form a basis of `Spa(A,A⁺)`.** The statement is made from an explicit
@@ -280,6 +346,35 @@ theorem isBasis_spaRationalOpens [IsHuberRing A] (Aplus : Subring A) :
     Opens.IsBasis (spaRationalOpens Aplus) :=
   TauCeti.TopologicalSpace.Opens.isBasis_of_isTopologicalBasis
     (isTopologicalBasis_spaRationalFamily Aplus)
+
+
+omit [IsTopologicalRing A] in
+/-- The whole space is a rational open, presented as `R({1}/1)`. -/
+theorem top_mem_spaRationalOpens (Aplus : Subring A) :
+    (⊤ : Opens (spa Aplus)) ∈ spaRationalOpens Aplus :=
+  univ_mem_spaRationalFamily Aplus
+
+/-- **Wedhorn Remark 7.30(5)** in the bundled form: the rational opens are closed under binary
+meet. Meet of `Opens` is intersection of the underlying sets, so this is
+`inter_mem_spaRationalFamily` read through `mem_spaRationalOpens`. -/
+theorem inf_mem_spaRationalOpens [IsHuberRing A] {Aplus : Subring A}
+    {U V : Opens (spa Aplus)} (hU : U ∈ spaRationalOpens Aplus)
+    (hV : V ∈ spaRationalOpens Aplus) : U ⊓ V ∈ spaRationalOpens Aplus :=
+  inter_mem_spaRationalFamily hU hV
+
+/-- **Wedhorn Theorem 7.35(2), finite-intersection half**, in the bundled form: the rational
+opens are closed under `Finset.inf`. This is the shape a sheaf criterion on the basis takes,
+where the finite intersections of a cover are formed in `Opens` rather than in `Set`. -/
+theorem finsetInf_mem_spaRationalOpens [IsHuberRing A] {Aplus : Subring A} {ι : Type*}
+    (s : Finset ι) {U : ι → Opens (spa Aplus)}
+    (h : ∀ i ∈ s, U i ∈ spaRationalOpens Aplus) : s.inf U ∈ spaRationalOpens Aplus := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => simpa using top_mem_spaRationalOpens Aplus
+  | insert a s ha ih =>
+    rw [Finset.inf_insert]
+    exact inf_mem_spaRationalOpens (h a (Finset.mem_insert_self a s))
+      (ih fun i hi ↦ h i (Finset.mem_insert_of_mem hi))
 
 /-! ### Finite rational refinements -/
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -107,17 +107,18 @@ This is Wedhorn Lemma 6.6 applied to the inclusion of the numerator span into th
 after adjoining the denominator. -/
 theorem isAdmissible_extendedIdealOfDefinition_of_isOpen_span (P : PairOfDefinition A)
     {T : Finset A} {s : A} (hT : IsOpen (Ideal.span (T : Set A) : Set A)) :
-    IsAdmissible P.extendedIdealOfDefinition T s :=
-  isAdmissible_iff.mpr <| ((P.isOpen_iff_le_radical _).mp hT).trans <|
-    Ideal.radical_mono <| Ideal.span_mono <| Set.subset_insert s (T : Set A)
+    IsAdmissible P.extendedIdealOfDefinition T s := by
+  rw [isAdmissible_iff]
+  refine (P.isOpen_iff_le_radical _).mp hT |>.trans (Ideal.radical_mono ?_)
+  exact Ideal.span_mono (Set.subset_insert s (T : Set A))
 
 /-- An admissible numerator set becomes an open numerator ideal after adjoining its denominator.
-The rational subset itself is unchanged by this operation. This is not a converse of
-`isAdmissible_extendedIdealOfDefinition_of_isOpen_span`, which assumes the span of `T` open. -/
+The rational subset itself is unchanged by this operation. -/
 theorem isOpen_span_insert_of_isAdmissible_extendedIdealOfDefinition (P : PairOfDefinition A)
     {T : Finset A} {s : A} (hT : IsAdmissible P.extendedIdealOfDefinition T s) :
-    IsOpen (Ideal.span (insert s (T : Set A)) : Set A) :=
-  (P.isOpen_iff_le_radical _).mpr <| isAdmissible_iff.mp hT
+    IsOpen (Ideal.span (insert s (T : Set A)) : Set A) := by
+  rw [P.isOpen_iff_le_radical]
+  exact isAdmissible_iff.mp hT
 
 end TopologicalRing
 
@@ -156,9 +157,11 @@ open Classical in
 numerator sets after adjoining their respective denominators. This is the admissibility half of
 the intersection formula for rational subsets. -/
 private theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A)
-    {T₁ T₂ : Finset A} {s₁ s₂ : A} (hT₁ : IsOpen (Ideal.span (T₁ : Set A) : Set A))
+    {T₁ T₂ : Finset A} {s₁ s₂ : A}
+    (hT₁ : IsOpen (Ideal.span (T₁ : Set A) : Set A))
     (hT₂ : IsOpen (Ideal.span (T₂ : Set A) : Set A)) :
     IsOpen (Ideal.span ((insert s₁ T₁ * insert s₂ T₂ : Finset A) : Set A) : Set A) := by
+  classical
   rw [P.isOpen_iff_le_radical]
   have hmul :=
     (isAdmissible_extendedIdealOfDefinition_of_isOpen_span (s := s₁) P hT₁).mul
@@ -172,7 +175,8 @@ private theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A)
 intersection. The set identity is `rationalSubset_inter`; admissibility is multiplicative in
 `Spv(A,IA)`, and adjoining the product denominator turns it back into openness. -/
 theorem inter_mem_spaRationalFamily_of_pairOfDefinition (P : PairOfDefinition A)
-    {Aplus : Subring A} {U V : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus)
+    {Aplus : Subring A}
+    {U V : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus)
     (hV : V ∈ spaRationalFamily Aplus) : U ∩ V ∈ spaRationalFamily Aplus := by
   classical
   obtain ⟨T₁, s₁, hT₁, rfl⟩ := hU


### PR DESCRIPTION
`main` proves that the rational subsets of `Spa(A,A⁺)` are closed under **binary** intersection
(`inter_mem_spaRationalFamily`). Wedhorn's Theorem 7.35(2) asserts the stronger **finite** form, and
the roadmap asks for it by name. This PR supplies it, together with the bundled `Opens` companions.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-2.2-theorem-7.35-2-finite-intersections"}-->

## The roadmap target

`TauCetiRoadmap/AdicSpaces/README.md`, section **2.2 Rational subsets** (heading at line 372), at
line 382, verbatim:

> Prove the five parts of Remark 7.30 — including part (5), finite intersections of rational
> subsets, which Theorem 7.35's own proof consumes … Prove that rational subsets form a basis of
> quasi-compact opens and are closed under finite intersections.

This is the target itself, not a prerequisite of something later: the roadmap commissions "closed
under finite intersections" in those words. It sits in **Layer 2**, whose preceding material is long
since on `main` — `inter_mem_spaRationalFamily` and `univ_mem_spaRationalFamily`, the only two inputs,
are both there and unconditional.

## What `main` has, and what it does not

| | |
|---|---|
| `inter_mem_spaRationalFamily` (`Basis.lean`) | the **binary** closure — Wedhorn Remark 7.30(5) |
| `univ_mem_spaRationalFamily` (`Basis.lean`) | `Set.univ` is rational — the empty-intersection case |
| **finite** closure in any form | **absent** |

Two near misses a reviewer's own grep will hit, and why neither is this statement:

* `rationalSubset_eq_biInter_singleton` (`RationalSubset/Basic.lean:287`) writes `R(T/s)` as
  `⋂ t ∈ T, R({t}/s)` — an intersection at a **fixed denominator**, not closure of the family under
  intersection.
* `basicOpenFinset_inter` (`ValuationSpectrum.lean:550`) is a set identity on `Spv A` basic opens,
  and despite a docstring that says "stable under finite intersection" the lemma is **binary**. It is
  also about `Spv A` rather than `spa A⁺`.

## What this adds

* `finiteInter_spaRationalFamily` — the closure itself, as Mathlib's `FiniteInter` structure
  (`Data/Set/Constructions.lean`), whose two fields are exactly `univ_mem_spaRationalFamily` and
  `inter_mem_spaRationalFamily_of_pairOfDefinition`. Everything below is read off it, so there is no
  hand-rolled induction. A `_of_pairOfDefinition` variant fixes the pair, following the file's
  existing pattern.
* `sInter_mem_spaRationalFamily` (finite subfamily) — the primitive, since
  `FiniteInter.finiteInter_mem` is stated for `⋂₀` over a `Finset (Set _)`. It is also the shape a
  refinement argument produces, where the finite family comes out of quasi-compactness rather than
  an index type, as in `exists_finite_spaRationalFamily_refinement`.
* `biInter_mem_spaRationalFamily` (`Finset`-indexed, the form Theorem 7.35(2) states) and
  `iInter_mem_spaRationalFamily` (finite index type), both derived from it through
  `Finset.set_biInter_coe` and `Set.sInter_image`.
* `top_mem_spaRationalOpens`, `inf_mem_spaRationalOpens`, `finsetInf_mem_spaRationalOpens` — the same
  closure statements in the bundled `Opens` form the sheaf criteria consume
  (`isSheaf_iff_isSheafFor_rationalCover`, `RationalSubset/SheafCriterion.lean:51`).

**No nonemptiness hypotheses.** Mathlib's `IsPiSystem.biInter_mem` (`MeasureTheory/PiSystem.lean:144`)
would not have served: it is indexed by a `Finset (Set X)` rather than by a family, and assumes both
`t.Nonempty` and that the intersection is nonempty. `FiniteInter` assumes neither, which is why it is
the right base; the empty intersection is exactly `univ_mem_spaRationalFamily`.

## A documentation correction this forces

`Basis.lean`'s `## Main results` currently describes `inter_mem_spaRationalFamily` as "completing
Wedhorn Remark 7.30(5)". Under the roadmap's wording that is one half of what is asked, so the entry
now says "which is Wedhorn Remark 7.30(5)" and the finite form is listed beside it. Leaving it would
have left `main` asserting completeness the roadmap contradicts.

Separately, a correction to the source is recorded in the `## References` section: Wedhorn's proof of
Theorem 7.35(2) cites Remark 7.30(4) for stability under finite intersection, but 7.30(4) is the
statement that `R(T/s)` is rational for a unit `s`. The binary intersection this file iterates is
Remark 7.30(5).

## One topic

The salvaged branch also carried incidental golfing of four already-merged declarations (two
tactic-to-term rewrites and two signature reflows). Those are reverted in the last commit: they are
welcome improvements, but as their own PR rather than bundled with new material. What remains is the
finite-intersection statements, their `Opens` companions, and the docstring correction the new
material forces.

Mathematical source: Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Theorem 7.35(2) and Remark 7.30(5).
No code is adapted from another repository, so there is no `Provenance:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
