### PR TITLE
feat: prove that projective covers exist over a semiprimary ring

### DIFF
--- a/TauCeti/Algebra/Module/Injective/Envelope.lean
+++ b/TauCeti/Algebra/Module/Injective/Envelope.lean
@@ -13,7 +13,7 @@ public import TauCeti.Algebra.Module.Submodule.Essential
 
 An **injective envelope** of a module `M` is an embedding `f : M →ₗ[R] Q` into an injective module
 whose image is essential in `Q` (`TauCeti.IsEssential`). This is the notion dual to the projective
-cover of `TauCeti/Algebra/Module/ProjectiveCover.lean`; Mathlib has injective objects but no
+cover of `TauCeti/Algebra/Module/ProjectiveCover/Basic.lean`; Mathlib has injective objects but no
 injective envelopes, and this file supplies the predicate together with the two facts everything
 downstream rests on.
 
@@ -74,7 +74,7 @@ as an extension target; it is automatic whenever `R` and that module live in the
 This implements the injective-envelope half of the "projective covers and injective envelopes"
 bullet of Layer 3 of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`
 ("dually `injectiveEnvelope M`"), whose projective half is
-`TauCeti/Algebra/Module/ProjectiveCover.lean`. As on the projective side, the bullet is not
+`TauCeti/Algebra/Module/ProjectiveCover/Basic.lean`. As on the projective side, the bullet is not
 discharged by this file: existence of envelopes, and hence a canonical `injectiveEnvelope M`
 chosen by it, remains.
 

--- a/TauCeti/Algebra/Module/LinearMap/EndQuotient.lean
+++ b/TauCeti/Algebra/Module/LinearMap/EndQuotient.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Module.Projective
+public import Mathlib.RingTheory.Ideal.Maps
+public import Mathlib.RingTheory.Ideal.Operations
+
+/-!
+# Reduction of endomorphisms modulo `I • M`
+
+An endomorphism of a module `M` carries `I • M` into itself, so it descends to the quotient
+`M ⧸ I • M`, and the descent is a ring homomorphism `Ideal.endMapQ I M`. This file constructs that
+reduction map and proves the two properties that make idempotents lift along it: it is surjective
+when `M` is projective, and its kernel consists of nilpotent elements when `I` is nilpotent.
+
+The kernel is characterized by `Ideal.mem_ker_endMapQ_iff`: an endomorphism dies under reduction
+exactly when its image lies in `I • M`. Iterating that containment is what makes the kernel nil,
+the image of the `k`-th power lying in `I ^ k • M`.
+
+## Main definitions
+
+* `Ideal.endMapQ`: reduction of endomorphisms modulo `I • M`, as a ring homomorphism
+  `Module.End R M →+* Module.End R (M ⧸ I • ⊤)`.
+
+## Main results
+
+* `Ideal.mem_ker_endMapQ_iff`: the kernel of the reduction map consists of the endomorphisms with
+  image inside `I • M`.
+* `Ideal.endMapQ_surjective`: reduction is onto when `M` is projective.
+* `Ideal.range_pow_le_of_mem_ker_endMapQ` and `Ideal.isNilpotent_of_mem_ker_endMapQ`: an
+  endomorphism killed by reduction has `k`-th power with image inside `I ^ k • M`, hence is
+  nilpotent as soon as `I` is.
+-/
+
+public section
+
+namespace Ideal
+
+universe u v
+
+variable {R : Type u} [Ring R]
+
+/-- **Reduction of endomorphisms modulo `I • M`.** An endomorphism of `M` carries `I • M` into
+itself, so it descends to the quotient `M ⧸ I • M`, and the descent is a ring homomorphism. -/
+def endMapQ (I : Ideal R) (M : Type v) [AddCommGroup M] [Module R M] :
+    Module.End R M →+* Module.End R (M ⧸ I • (⊤ : Submodule R M)) where
+  toFun f := Submodule.mapQ _ _ f (Submodule.map_le_iff_le_comap.mp
+    (by rw [Submodule.map_smul'']; exact Submodule.smul_mono le_rfl le_top))
+  -- Each law is checked on the classes `Submodule.Quotient.mk x`, where `Submodule.mapQ_apply`
+  -- evaluates both sides.
+  map_one' := Submodule.linearMap_qext _ (by ext x; simp)
+  map_mul' _ _ := Submodule.linearMap_qext _ (by ext x; simp)
+  map_zero' := Submodule.linearMap_qext _ (by ext x; simp)
+  map_add' _ _ := Submodule.linearMap_qext _ (by ext x; simp)
+
+variable (I : Ideal R) (M : Type v) [AddCommGroup M] [Module R M]
+
+@[simp]
+theorem endMapQ_mk (f : Module.End R M) (x : M) :
+    endMapQ I M f (Submodule.Quotient.mk x) = Submodule.Quotient.mk (f x) := by
+  simp [endMapQ]
+
+/-- Every endomorphism of `M ⧸ I • M` is the reduction of an endomorphism of `M`, provided `M` is
+projective: lift the composite `M ↠ M ⧸ I • M → M ⧸ I • M` through the quotient map. -/
+theorem endMapQ_surjective [Module.Projective R M] : Function.Surjective (endMapQ I M) := by
+  intro g
+  obtain ⟨f, hf⟩ := Module.projective_lifting_property (I • (⊤ : Submodule R M)).mkQ
+    (g ∘ₗ (I • (⊤ : Submodule R M)).mkQ) (Submodule.mkQ_surjective _)
+  refine ⟨f, LinearMap.ext fun x => ?_⟩
+  obtain ⟨y, rfl⟩ := Submodule.Quotient.mk_surjective _ x
+  exact LinearMap.congr_fun hf y
+
+/-- **The kernel of the reduction map.** An endomorphism reduces to zero exactly when its image
+lies in `I • M`, membership in the kernel being tested on the classes of `M ⧸ I • M`. -/
+theorem mem_ker_endMapQ_iff {f : Module.End R M} :
+    f ∈ RingHom.ker (endMapQ I M) ↔ LinearMap.range f ≤ I • (⊤ : Submodule R M) := by
+  rw [RingHom.mem_ker]
+  constructor
+  · rintro hf _ ⟨y, rfl⟩
+    refine (Submodule.Quotient.mk_eq_zero _).mp ?_
+    rw [← endMapQ_mk I M f y, hf, LinearMap.zero_apply]
+  · intro hf
+    refine Submodule.linearMap_qext _ (LinearMap.ext fun x => ?_)
+    simpa using (Submodule.Quotient.mk_eq_zero _).mpr (hf ⟨x, rfl⟩)
+
+/-- An endomorphism killed by the reduction map has image inside `I • M`, hence `k`-th power with
+image inside `I ^ k • M`. -/
+theorem range_pow_le_of_mem_ker_endMapQ {f : Module.End R M}
+    (hf : f ∈ RingHom.ker (endMapQ I M)) (k : ℕ) :
+    LinearMap.range (f ^ k) ≤ I ^ k • (⊤ : Submodule R M) := by
+  have hrange : LinearMap.range f ≤ I • (⊤ : Submodule R M) := (mem_ker_endMapQ_iff I M).mp hf
+  induction k with
+  | zero =>
+      rw [Submodule.pow_zero, Ideal.one_eq_top, Submodule.top_smul]
+      exact le_top
+  | succ k ih =>
+      rw [pow_succ', Module.End.mul_eq_comp, LinearMap.range_comp]
+      calc Submodule.map f (LinearMap.range (f ^ k))
+          ≤ Submodule.map f (I ^ k • (⊤ : Submodule R M)) := Submodule.map_mono ih
+        _ = I ^ k • Submodule.map f ⊤ := by rw [Submodule.map_smul'']
+        _ = I ^ k • LinearMap.range f := by rw [Submodule.map_top]
+        _ ≤ I ^ k • (I • (⊤ : Submodule R M)) := Submodule.smul_mono le_rfl hrange
+        _ = I ^ (k + 1) • (⊤ : Submodule R M) := by
+            rw [Submodule.pow_succ, Submodule.mul_smul]
+
+/-- **The kernel of the reduction map is nil** when `I` is nilpotent: an endomorphism with image in
+`I • M` has a vanishing power, because `I ^ k • M` vanishes. -/
+theorem isNilpotent_of_mem_ker_endMapQ (hI : IsNilpotent I) {f : Module.End R M}
+    (hf : f ∈ RingHom.ker (endMapQ I M)) : IsNilpotent f := by
+  obtain ⟨m, hm⟩ := hI
+  refine ⟨m, LinearMap.range_eq_bot.mp (le_bot_iff.mp ?_)⟩
+  simpa [hm] using range_pow_le_of_mem_ker_endMapQ I M hf m
+
+end Ideal

--- a/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
+++ b/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Exact.Basic
-public import TauCeti.Algebra.Module.ProjectiveCover
+public import TauCeti.Algebra.Module.ProjectiveCover.Basic
 
 /-!
 # Minimal projective presentations
@@ -44,12 +44,13 @@ is conditional on a presentation being given, and
 one presentation.
 
 The file is layered by the coefficients each part needs, as
-`TauCeti/Algebra/Module/ProjectiveCover.lean` is. The predicate itself and the two cover-form
+`TauCeti/Algebra/Module/ProjectiveCover/Basic.lean` is. The predicate itself and the two cover-form
 readings of it need only a semiring and additive monoids. The degeneration over a projective
 module needs the presented module to be an additive group, that being what uniqueness of covers
 needs. The comparison and uniqueness theorems need a ring, which the syzygy forces rather than the
-proofs choosing it: they apply the cover statements of `TauCeti/Algebra/Module/ProjectiveCover.lean`
-to the syzygy `ker p₀` as the *covered* module, and those are stated for a covered module that is
+proofs choosing it: they apply the cover statements of
+`TauCeti/Algebra/Module/ProjectiveCover/Basic.lean` to the syzygy `ker p₀` as the *covered* module,
+and those are stated for a covered module that is
 an additive group. A submodule of an additive group is itself an additive group only once the
 scalars form a ring — `Submodule.addCommGroup` is a `[Ring R]` instance, and over a semiring a
 submodule need not be closed under negation, as `ℕ ⊆ ℤ` shows — so over a semiring
@@ -91,7 +92,7 @@ of Layer 6 of
 the prerequisite it names for the transpose `Tr` and the Auslander-Reiten translate `τ = D Tr`
 ("it is well-defined only up to projectives, through minimal presentations and duality on
 finite-dimensional modules"). The injective co-presentation is the remaining half, as the injective
-envelope is the remaining half of `TauCeti/Algebra/Module/ProjectiveCover.lean`.
+envelope is the remaining half of `TauCeti/Algebra/Module/ProjectiveCover/Basic.lean`.
 
 * M. Auslander, I. Reiten, S. O. Smalø, *Representation Theory of Artin Algebras*, Cambridge
   University Press (1995), Section I.2 and Section IV.1.

--- a/TauCeti/Algebra/Module/ProjectiveCover/Basic.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover/Basic.lean
@@ -66,12 +66,11 @@ Nothing here proves or assumes it; every statement below is conditional on a cov
 
 ## References
 
-This implements the projective-cover half of the "projective covers and injective envelopes"
-bullet of Layer 3 of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`
-("`projectiveCover M`: a projective `P` with an essential epimorphism `P ↠ M` (superfluous
-kernel), unique up to isomorphism"). Existence is
-`TauCeti/Algebra/Module/ProjectiveCover/Existence.lean`, and the dual injective envelope is the
-remaining half.
+Uniqueness, proved here, is what makes "the" projective cover of a module a well-defined object;
+that a cover exists at all is a condition on the ring, established for a semiprimary ring — a
+finite-dimensional algebra among them — in
+`TauCeti/Algebra/Module/ProjectiveCover/Existence.lean`. The dual notion, an injective envelope,
+is an essential monomorphism into an injective module; nothing here is used for it.
 
 See I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
 Algebras, Vol. 1*, Section I.5.

--- a/TauCeti/Algebra/Module/ProjectiveCover/Basic.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover/Basic.lean
@@ -32,11 +32,11 @@ covering maps (`TauCeti.IsProjectiveCover.exists_linearEquiv`). Uniqueness is wh
 projective cover a well-defined object, and hence what makes the Cartan matrix `Cᵢⱼ = [Pᵢ : Sⱼ]` of
 a finite-dimensional algebra well defined.
 
-*Existence* of projective covers is a separate matter: over a semiperfect (in particular a
-finite-dimensional) algebra every *finitely generated* module has one — for a finite-dimensional
-algebra, every finite-dimensional module — while existence for arbitrary modules is a strictly
-stronger condition on the ring. None of this is proved here, and nothing below assumes it; every
-statement is conditional on a cover being given.
+*Existence* of projective covers is a separate matter: over a semiperfect ring every *finitely
+generated* module has one, while existence for arbitrary modules is a strictly stronger condition
+on the ring, met for instance by a semiprimary ring — a finite-dimensional algebra among them.
+Nothing here proves or assumes it; every statement below is conditional on a cover being given, and
+`TauCeti/Algebra/Module/ProjectiveCover/Existence.lean` supplies covers over a semiprimary ring.
 
 ## Main definitions
 
@@ -69,8 +69,9 @@ statement is conditional on a cover being given.
 This implements the projective-cover half of the "projective covers and injective envelopes"
 bullet of Layer 3 of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`
 ("`projectiveCover M`: a projective `P` with an essential epimorphism `P ↠ M` (superfluous
-kernel), unique up to isomorphism"). Existence for finitely generated modules over a semiperfect
-algebra, and the dual injective envelope, are the remaining halves.
+kernel), unique up to isomorphism"). Existence is
+`TauCeti/Algebra/Module/ProjectiveCover/Existence.lean`, and the dual injective envelope is the
+remaining half.
 
 See I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
 Algebras, Vol. 1*, Section I.5.

--- a/TauCeti/Algebra/Module/ProjectiveCover/Existence.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover/Existence.lean
@@ -61,7 +61,7 @@ the kernel of the reduction map nil, which is what lets the idempotent lift.
 * `TauCeti.exists_isProjectiveCover_comp_subtype`: over a semiprimary ring, a surjection onto `M`
   from a projective module restricts to a projective cover of `M` on a submodule of its source.
 * `TauCeti.exists_isProjectiveCover`: **every module over a semiprimary ring has a projective
-  cover**, realized as a direct summand of a free module.
+  cover**, carried by a submodule of the free module on its underlying set.
 * `TauCeti.exists_isProjectiveCover_of_finiteDimensional`: the same statement for a module over a
   finite-dimensional algebra, which is a semiprimary ring.
 
@@ -84,8 +84,8 @@ variable {R : Type u} [Ring R] {M : Type v} [AddCommGroup M] [Module R M]
 
 /-- **A projective cover is cut out of any projective presentation by an idempotent.** Over a
 semiprimary ring, a surjection `p : N ↠ M` from a projective module restricts to a projective cover
-of `M` on a suitable submodule `P` of `N` — a direct summand, the image of an idempotent lifted
-from the radical quotient. See the module docstring for the argument. -/
+of `M` on a suitable submodule `P` of `N`; that cover property is all the statement records about
+`P`. See the module docstring for how `P` is produced. -/
 theorem exists_isProjectiveCover_comp_subtype [IsSemiprimaryRing R] {N : Type w} [AddCommGroup N]
     [Module R N] [Module.Projective R N] (p : N →ₗ[R] M) (hp : Function.Surjective p) :
     ∃ P : Submodule R N, IsProjectiveCover (p ∘ₗ P.subtype) := by
@@ -171,8 +171,8 @@ variable (R M)
 
 /-- **Every module over a semiprimary ring has a projective cover.**
 
-The cover is a direct summand of the free module on the underlying set of `M`. No finiteness is
-assumed of `M`: a semiprimary ring is left perfect, so it covers every module, not only the
+The covering module is a submodule of the free module on the underlying set of `M`. No finiteness
+is assumed of `M`: a semiprimary ring is left perfect, so it covers every module, not only the
 finitely generated ones. -/
 theorem exists_isProjectiveCover [IsSemiprimaryRing R] :
     ∃ P : Submodule R (M →₀ R),

--- a/TauCeti/Algebra/Module/ProjectiveCover/Existence.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover/Existence.lean
@@ -5,13 +5,13 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Module.Torsion.Basic
 public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.LinearAlgebra.Projection
 public import Mathlib.RingTheory.Artinian.Module
 public import Mathlib.RingTheory.Idempotents
-public import Mathlib.RingTheory.Jacobson.Semiprimary
+public import TauCeti.Algebra.Module.LinearMap.EndQuotient
 public import TauCeti.Algebra.Module.ProjectiveCover.Basic
+public import TauCeti.RingTheory.Jacobson.Semiprimary
 
 /-!
 # Existence of projective covers over a semiprimary ring
@@ -39,9 +39,9 @@ idempotent, in three steps.
   `C`, and the projection onto `C` along `ker q` is an idempotent `ē` of `End (N ⧸ J • N)` with
   `range ē = C`.
 * **The idempotent lifts.** Reduction of endomorphisms modulo `J • N` is a ring homomorphism
-  `TauCeti.endMapQ J N : End N →+* End (N ⧸ J • N)`. It is surjective because `N` is projective
-  (`TauCeti.endMapQ_surjective`), and every element of its kernel is nilpotent because `J` is
-  (`TauCeti.isNilpotent_of_mem_ker_endMapQ`): a map with image inside `J • N` has `k`-th power with
+  `Ideal.endMapQ J N : End N →+* End (N ⧸ J • N)`. It is surjective because `N` is projective
+  (`Ideal.endMapQ_surjective`), and every element of its kernel is nilpotent because `J` is
+  (`Ideal.isNilpotent_of_mem_ker_endMapQ`): a map with image inside `J • N` has `k`-th power with
   image inside `J ^ k • N`. Mathlib's `exists_isIdempotentElem_eq_of_ker_isNilpotent` therefore
   lifts `ē` to an idempotent `e` of `End N`.
 * **The cover is the image of the lift.** `P = range e` is a direct summand of the free module `N`,
@@ -58,23 +58,14 @@ the kernel of the reduction map nil, which is what lets the idempotent lift.
 
 ## Main statements
 
-* `TauCeti.endMapQ`: reduction of endomorphisms modulo `I • M`, as a ring homomorphism, with
-  `TauCeti.endMapQ_surjective` and `TauCeti.isNilpotent_of_mem_ker_endMapQ` the two properties that
-  make idempotents lift along it, the latter refining
-  `TauCeti.range_pow_le_of_mem_ker_endMapQ`.
-* `TauCeti.isSemisimpleModule_quotient_jacobson_smul_top`: the radical quotient of any module over
-  a semiprimary ring is a semisimple module.
+* `TauCeti.exists_isProjectiveCover_comp_subtype`: over a semiprimary ring, a surjection onto `M`
+  from a projective module restricts to a projective cover of `M` on a submodule of its source.
 * `TauCeti.exists_isProjectiveCover`: **every module over a semiprimary ring has a projective
   cover**, realized as a direct summand of a free module.
-* `TauCeti.exists_isProjectiveCover_of_finiteDimensional`: the finite-dimensional-algebra reading,
-  which is the form the roadmap states.
+* `TauCeti.exists_isProjectiveCover_of_finiteDimensional`: the same statement for a module over a
+  finite-dimensional algebra, which is a semiprimary ring.
 
 ## References
-
-This is the existence half of the "projective covers and injective envelopes" bullet of Layer 3 of
-`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose uniqueness half is
-`TauCeti/Algebra/Module/ProjectiveCover/Basic.lean`; the roadmap asks for existence over a
-finite-dimensional algebra, "existing because `A` is semiperfect (finite-dimensional)".
 
 See T. Y. Lam, *A First Course in Noncommutative Rings*, §24 (semiperfect and semiprimary rings,
 idempotent lifting, and projective covers), and I. Assem, D. Simson, A. Skowroński, *Elements of
@@ -87,85 +78,9 @@ namespace TauCeti
 
 universe u v w
 
-section Reduction
-
-variable {R : Type u} [Ring R]
-
-/-- **Reduction of endomorphisms modulo `I • M`.** An endomorphism of `M` carries `I • M` into
-itself, so it descends to the quotient `M ⧸ I • M`, and the descent is a ring homomorphism. -/
-def endMapQ (I : Ideal R) (M : Type v) [AddCommGroup M] [Module R M] :
-    Module.End R M →+* Module.End R (M ⧸ I • (⊤ : Submodule R M)) where
-  toFun f := Submodule.mapQ _ _ f (Submodule.map_le_iff_le_comap.mp
-    (by rw [Submodule.map_smul'']; exact Submodule.smul_mono le_rfl le_top))
-  -- Each law is checked on the classes `Submodule.Quotient.mk x`, where it is definitional.
-  map_one' := Submodule.linearMap_qext _ (rfl)
-  map_mul' _ _ := Submodule.linearMap_qext _ (rfl)
-  map_zero' := Submodule.linearMap_qext _ (rfl)
-  map_add' _ _ := Submodule.linearMap_qext _ (rfl)
-
-variable (I : Ideal R) (M : Type v) [AddCommGroup M] [Module R M]
-
-@[simp]
-theorem endMapQ_mk (f : Module.End R M) (x : M) :
-    endMapQ I M f (Submodule.Quotient.mk x) = Submodule.Quotient.mk (f x) :=
-  (rfl)
-
-/-- Every endomorphism of `M ⧸ I • M` is the reduction of an endomorphism of `M`, provided `M` is
-projective: lift the composite `M ↠ M ⧸ I • M → M ⧸ I • M` through the quotient map. -/
-theorem endMapQ_surjective [Module.Projective R M] : Function.Surjective (endMapQ I M) := by
-  intro g
-  obtain ⟨f, hf⟩ := Module.projective_lifting_property (I • (⊤ : Submodule R M)).mkQ
-    (g ∘ₗ (I • (⊤ : Submodule R M)).mkQ) (Submodule.mkQ_surjective _)
-  refine ⟨f, LinearMap.ext fun x => ?_⟩
-  obtain ⟨y, rfl⟩ := Submodule.Quotient.mk_surjective _ x
-  exact LinearMap.congr_fun hf y
-
-/-- An endomorphism killed by the reduction map has image inside `I • M`, hence `k`-th power with
-image inside `I ^ k • M`. -/
-theorem range_pow_le_of_mem_ker_endMapQ {f : Module.End R M}
-    (hf : f ∈ RingHom.ker (endMapQ I M)) (k : ℕ) :
-    LinearMap.range (f ^ k) ≤ I ^ k • (⊤ : Submodule R M) := by
-  have hrange : LinearMap.range f ≤ I • (⊤ : Submodule R M) := by
-    rintro _ ⟨y, rfl⟩
-    refine (Submodule.Quotient.mk_eq_zero _).mp ?_
-    rw [← endMapQ_mk I M f y, RingHom.mem_ker.mp hf, LinearMap.zero_apply]
-  induction k with
-  | zero =>
-      rw [Submodule.pow_zero, Ideal.one_eq_top, Submodule.top_smul]
-      exact le_top
-  | succ k ih =>
-      rw [pow_succ', Module.End.mul_eq_comp, LinearMap.range_comp]
-      calc Submodule.map f (LinearMap.range (f ^ k))
-          ≤ Submodule.map f (I ^ k • (⊤ : Submodule R M)) := Submodule.map_mono ih
-        _ = I ^ k • Submodule.map f ⊤ := by rw [Submodule.map_smul'']
-        _ = I ^ k • LinearMap.range f := by rw [Submodule.map_top]
-        _ ≤ I ^ k • (I • (⊤ : Submodule R M)) := Submodule.smul_mono le_rfl hrange
-        _ = I ^ (k + 1) • (⊤ : Submodule R M) := by
-            rw [Submodule.pow_succ, Submodule.mul_smul]
-
-/-- **The kernel of the reduction map is nil** when `I` is nilpotent: an endomorphism with image in
-`I • M` has a vanishing power, because `I ^ k • M` vanishes. -/
-theorem isNilpotent_of_mem_ker_endMapQ (hI : IsNilpotent I) {f : Module.End R M}
-    (hf : f ∈ RingHom.ker (endMapQ I M)) : IsNilpotent f := by
-  obtain ⟨m, hm⟩ := hI
-  refine ⟨m, LinearMap.range_eq_bot.mp (le_bot_iff.mp ?_)⟩
-  simpa [hm] using range_pow_le_of_mem_ker_endMapQ I M hf m
-
-end Reduction
-
 section Semiprimary
 
-variable (R : Type u) [Ring R] (M : Type v) [AddCommGroup M] [Module R M]
-
-/-- **The radical quotient of a module over a semiprimary ring is semisimple.** It is a module over
-the semisimple ring `R ⧸ Ring.jacobson R`, and semisimplicity is insensitive to which of the two
-rings the scalars are read in. -/
-theorem isSemisimpleModule_quotient_jacobson_smul_top [IsSemiprimaryRing R] :
-    IsSemisimpleModule R (M ⧸ Ring.jacobson R • (⊤ : Submodule R M)) :=
-  (Module.isTorsionBySet_quotient_ideal_smul M (Ring.jacobson R)).isSemisimpleModule_iff.mp
-    inferInstance
-
-variable {R M}
+variable {R : Type u} [Ring R] {M : Type v} [AddCommGroup M] [Module R M]
 
 /-- **A projective cover is cut out of any projective presentation by an idempotent.** Over a
 semiprimary ring, a surjection `p : N ↠ M` from a projective module restricts to a projective cover
@@ -182,12 +97,13 @@ theorem exists_isProjectiveCover_comp_subtype [IsSemiprimaryRing R] {N : Type w}
     exact Submodule.smul_mono le_rfl le_top
   set q : (N ⧸ Ring.jacobson R • (⊤ : Submodule R N)) →ₗ[R]
       M ⧸ Ring.jacobson R • (⊤ : Submodule R M) := Submodule.mapQ _ _ p hcomap
-  have hq : ∀ n : N, q (Submodule.Quotient.mk n) = Submodule.Quotient.mk (p n) := fun _ => rfl
+  have hq : ∀ n : N, q (Submodule.Quotient.mk n) = Submodule.Quotient.mk (p n) := fun n =>
+    Submodule.mapQ_apply _ _ p n
   have hqsurj : Function.Surjective q := by
     intro z
     obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective _ z
     obtain ⟨n, rfl⟩ := hp x
-    exact ⟨Submodule.Quotient.mk n, rfl⟩
+    exact ⟨Submodule.Quotient.mk n, hq n⟩
   -- The kernel of `q` splits off, because the radical quotient of `N` is semisimple.
   have hss := isSemisimpleModule_quotient_jacobson_smul_top R N
   obtain ⟨C, hC⟩ := exists_isCompl (LinearMap.ker q)
@@ -197,16 +113,17 @@ theorem exists_isProjectiveCover_comp_subtype [IsSemiprimaryRing R] {N : Type w}
   have hrangebar : LinearMap.range ebar = C := Submodule.range_projection _
   have hsub : ∀ x, x - ebar x ∈ LinearMap.ker q := fun x => Submodule.sub_projection_mem hC.symm x
   -- Lift `ebar`: the reduction map is onto with nil kernel.
-  obtain ⟨e, he, hee⟩ := exists_isIdempotentElem_eq_of_ker_isNilpotent (endMapQ (Ring.jacobson R) N)
-    (fun _ hg => isNilpotent_of_mem_ker_endMapQ _ N IsSemiprimaryRing.isNilpotent hg)
-    ebar (RingHom.mem_range.mpr (endMapQ_surjective _ N ebar)) hebar
+  obtain ⟨e, he, hee⟩ := exists_isIdempotentElem_eq_of_ker_isNilpotent
+    (Ideal.endMapQ (Ring.jacobson R) N)
+    (fun _ hg => Ideal.isNilpotent_of_mem_ker_endMapQ _ N IsSemiprimaryRing.isNilpotent hg)
+    ebar (RingHom.mem_range.mpr (Ideal.endMapQ_surjective _ N ebar)) hebar
   have hfix : ∀ x ∈ LinearMap.range e, e x = x := by
     rintro _ ⟨y, rfl⟩
     exact (Module.End.mul_apply e e y).symm.trans (DFunLike.congr_fun he.eq y)
   have hebar_mk : ∀ n : N, ebar (Submodule.Quotient.mk n) = Submodule.Quotient.mk (e n) := by
     intro n
     rw [← hee]
-    exact endMapQ_mk _ N e n
+    exact Ideal.endMapQ_mk _ N e n
   -- Nakayama: the radical multiple of any module is superfluous in it.
   have hsuperM : IsSuperfluous (Ring.jacobson R • (⊤ : Submodule R M)) :=
     isSuperfluous_smul_top_of_isNilpotent IsSemiprimaryRing.isNilpotent
@@ -266,10 +183,9 @@ end Semiprimary
 
 section FiniteDimensional
 
-/-- **Every module over a finite-dimensional algebra has a projective cover**, the form in which the
-roadmap states the theorem. A finite-dimensional algebra is an Artinian ring, hence semiprimary, so
-this is `TauCeti.exists_isProjectiveCover` read through that instance; in particular no finiteness
-is required of the module. -/
+/-- **Every module over a finite-dimensional algebra has a projective cover.** A finite-dimensional
+algebra is an Artinian ring, hence semiprimary, so this is `TauCeti.exists_isProjectiveCover` read
+through that instance; in particular no finiteness is required of the module. -/
 theorem exists_isProjectiveCover_of_finiteDimensional (k : Type w) [Field k] (A : Type u) [Ring A]
     [Algebra k A] [FiniteDimensional k A] (V : Type v) [AddCommGroup V] [Module A V] :
     ∃ P : Submodule A (V →₀ A),

--- a/TauCeti/Algebra/Module/ProjectiveCover/Existence.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover/Existence.lean
@@ -56,6 +56,11 @@ module — which is what removes every finiteness hypothesis, and is why a semip
 *all* modules and not only the finitely generated ones a semiperfect ring covers — and once to make
 the kernel of the reduction map nil, which is what lets the idempotent lift.
 
+Semiperfectness itself is `TauCeti.IsSemiperfectRing`, in
+`TauCeti/RingTheory/Jacobson/Semiperfect.lean`: the second use of nilpotence above, made at the
+level of the ring rather than of `End N`, is exactly the statement that a semiprimary ring is
+semiperfect.
+
 ## Main statements
 
 * `TauCeti.exists_isProjectiveCover_comp_subtype`: over a semiprimary ring, a surjection onto `M`

--- a/TauCeti/Algebra/Module/ProjectiveCover/Existence.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover/Existence.lean
@@ -1,0 +1,282 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Module.Torsion.Basic
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+public import Mathlib.LinearAlgebra.Projection
+public import Mathlib.RingTheory.Artinian.Module
+public import Mathlib.RingTheory.Idempotents
+public import Mathlib.RingTheory.Jacobson.Semiprimary
+public import TauCeti.Algebra.Module.ProjectiveCover.Basic
+
+/-!
+# Existence of projective covers over a semiprimary ring
+
+`TauCeti/Algebra/Module/ProjectiveCover/Basic.lean` develops the projective cover of a module as a
+*given* datum: it is unique, and it receives every projective presentation, but nothing there
+produces one. This file supplies the existence theorem. Over a **semiprimary** ring — Mathlib's
+`IsSemiprimaryRing`, a ring whose Jacobson radical is nilpotent and whose radical quotient is
+semisimple, as a finite-dimensional algebra over a field is — **every** module has a projective
+cover (`TauCeti.exists_isProjectiveCover`), with no finiteness hypothesis on the module.
+
+Some hypothesis on the ring is genuinely needed: `ℤ ⧸ 2ℤ` has no projective cover as a `ℤ`-module,
+although it has finite length.
+
+## The construction
+
+Write `J` for the radical and `M ↦ M ⧸ J • M` for passage to the radical quotient. Fix a free
+module `N` with a surjection `p : N ↠ M` — the free module on the underlying set of `M` will do —
+and let `q : N ⧸ J • N ↠ M ⧸ J • M` be the induced surjection. The cover is cut out of `N` by an
+idempotent, in three steps.
+
+* **The radical quotient is semisimple.** `N ⧸ J • N` is a module over `R ⧸ J`, which is a
+  semisimple ring, so it is a semisimple `R ⧸ J`-module and hence a semisimple `R`-module
+  (`TauCeti.isSemisimpleModule_quotient_jacobson_smul_top`). Therefore `ker q` has a complement
+  `C`, and the projection onto `C` along `ker q` is an idempotent `ē` of `End (N ⧸ J • N)` with
+  `range ē = C`.
+* **The idempotent lifts.** Reduction of endomorphisms modulo `J • N` is a ring homomorphism
+  `TauCeti.endMapQ J N : End N →+* End (N ⧸ J • N)`. It is surjective because `N` is projective
+  (`TauCeti.endMapQ_surjective`), and every element of its kernel is nilpotent because `J` is
+  (`TauCeti.isNilpotent_of_mem_ker_endMapQ`): a map with image inside `J • N` has `k`-th power with
+  image inside `J ^ k • N`. Mathlib's `exists_isIdempotentElem_eq_of_ker_isNilpotent` therefore
+  lifts `ē` to an idempotent `e` of `End N`.
+* **The cover is the image of the lift.** `P = range e` is a direct summand of the free module `N`,
+  so it is projective, and `π = p|_P` is the cover. It is onto because its image spans `M` modulo
+  `J • M` — that is what `ker ē = ker q` says — and `J • M` is superfluous
+  (`TauCeti.isSuperfluous_smul_top_of_isNilpotent`, Nakayama for a nilpotent ideal). Its kernel is
+  superfluous because an element of it reduces into `C ⊓ ker q = ⊥`, hence lies in `J • N`, hence,
+  being fixed by `e`, lies in `J • P`.
+
+Nilpotence of `J` is used twice, and differently: once to make `J • M` superfluous in an arbitrary
+module — which is what removes every finiteness hypothesis, and is why a semiprimary ring covers
+*all* modules and not only the finitely generated ones a semiperfect ring covers — and once to make
+the kernel of the reduction map nil, which is what lets the idempotent lift.
+
+## Main statements
+
+* `TauCeti.endMapQ`: reduction of endomorphisms modulo `I • M`, as a ring homomorphism, with
+  `TauCeti.endMapQ_surjective` and `TauCeti.isNilpotent_of_mem_ker_endMapQ` the two properties that
+  make idempotents lift along it, the latter refining
+  `TauCeti.range_pow_le_of_mem_ker_endMapQ`.
+* `TauCeti.isSemisimpleModule_quotient_jacobson_smul_top`: the radical quotient of any module over
+  a semiprimary ring is a semisimple module.
+* `TauCeti.exists_isProjectiveCover`: **every module over a semiprimary ring has a projective
+  cover**, realized as a direct summand of a free module.
+* `TauCeti.exists_isProjectiveCover_of_finiteDimensional`: the finite-dimensional-algebra reading,
+  which is the form the roadmap states.
+
+## References
+
+This is the existence half of the "projective covers and injective envelopes" bullet of Layer 3 of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose uniqueness half is
+`TauCeti/Algebra/Module/ProjectiveCover/Basic.lean`; the roadmap asks for existence over a
+finite-dimensional algebra, "existing because `A` is semiperfect (finite-dimensional)".
+
+See T. Y. Lam, *A First Course in Noncommutative Rings*, §24 (semiperfect and semiprimary rings,
+idempotent lifting, and projective covers), and I. Assem, D. Simson, A. Skowroński, *Elements of
+the Representation Theory of Associative Algebras, Vol. 1*, Section I.5.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w
+
+section Reduction
+
+variable {R : Type u} [Ring R]
+
+/-- **Reduction of endomorphisms modulo `I • M`.** An endomorphism of `M` carries `I • M` into
+itself, so it descends to the quotient `M ⧸ I • M`, and the descent is a ring homomorphism. -/
+def endMapQ (I : Ideal R) (M : Type v) [AddCommGroup M] [Module R M] :
+    Module.End R M →+* Module.End R (M ⧸ I • (⊤ : Submodule R M)) where
+  toFun f := Submodule.mapQ _ _ f (Submodule.map_le_iff_le_comap.mp
+    (by rw [Submodule.map_smul'']; exact Submodule.smul_mono le_rfl le_top))
+  -- Each law is checked on the classes `Submodule.Quotient.mk x`, where it is definitional.
+  map_one' := Submodule.linearMap_qext _ (rfl)
+  map_mul' _ _ := Submodule.linearMap_qext _ (rfl)
+  map_zero' := Submodule.linearMap_qext _ (rfl)
+  map_add' _ _ := Submodule.linearMap_qext _ (rfl)
+
+variable (I : Ideal R) (M : Type v) [AddCommGroup M] [Module R M]
+
+@[simp]
+theorem endMapQ_mk (f : Module.End R M) (x : M) :
+    endMapQ I M f (Submodule.Quotient.mk x) = Submodule.Quotient.mk (f x) :=
+  (rfl)
+
+/-- Every endomorphism of `M ⧸ I • M` is the reduction of an endomorphism of `M`, provided `M` is
+projective: lift the composite `M ↠ M ⧸ I • M → M ⧸ I • M` through the quotient map. -/
+theorem endMapQ_surjective [Module.Projective R M] : Function.Surjective (endMapQ I M) := by
+  intro g
+  obtain ⟨f, hf⟩ := Module.projective_lifting_property (I • (⊤ : Submodule R M)).mkQ
+    (g ∘ₗ (I • (⊤ : Submodule R M)).mkQ) (Submodule.mkQ_surjective _)
+  refine ⟨f, LinearMap.ext fun x => ?_⟩
+  obtain ⟨y, rfl⟩ := Submodule.Quotient.mk_surjective _ x
+  exact LinearMap.congr_fun hf y
+
+/-- An endomorphism killed by the reduction map has image inside `I • M`, hence `k`-th power with
+image inside `I ^ k • M`. -/
+theorem range_pow_le_of_mem_ker_endMapQ {f : Module.End R M}
+    (hf : f ∈ RingHom.ker (endMapQ I M)) (k : ℕ) :
+    LinearMap.range (f ^ k) ≤ I ^ k • (⊤ : Submodule R M) := by
+  have hrange : LinearMap.range f ≤ I • (⊤ : Submodule R M) := by
+    rintro _ ⟨y, rfl⟩
+    refine (Submodule.Quotient.mk_eq_zero _).mp ?_
+    rw [← endMapQ_mk I M f y, RingHom.mem_ker.mp hf, LinearMap.zero_apply]
+  induction k with
+  | zero =>
+      rw [Submodule.pow_zero, Ideal.one_eq_top, Submodule.top_smul]
+      exact le_top
+  | succ k ih =>
+      rw [pow_succ', Module.End.mul_eq_comp, LinearMap.range_comp]
+      calc Submodule.map f (LinearMap.range (f ^ k))
+          ≤ Submodule.map f (I ^ k • (⊤ : Submodule R M)) := Submodule.map_mono ih
+        _ = I ^ k • Submodule.map f ⊤ := by rw [Submodule.map_smul'']
+        _ = I ^ k • LinearMap.range f := by rw [Submodule.map_top]
+        _ ≤ I ^ k • (I • (⊤ : Submodule R M)) := Submodule.smul_mono le_rfl hrange
+        _ = I ^ (k + 1) • (⊤ : Submodule R M) := by
+            rw [Submodule.pow_succ, Submodule.mul_smul]
+
+/-- **The kernel of the reduction map is nil** when `I` is nilpotent: an endomorphism with image in
+`I • M` has a vanishing power, because `I ^ k • M` vanishes. -/
+theorem isNilpotent_of_mem_ker_endMapQ (hI : IsNilpotent I) {f : Module.End R M}
+    (hf : f ∈ RingHom.ker (endMapQ I M)) : IsNilpotent f := by
+  obtain ⟨m, hm⟩ := hI
+  refine ⟨m, LinearMap.range_eq_bot.mp (le_bot_iff.mp ?_)⟩
+  simpa [hm] using range_pow_le_of_mem_ker_endMapQ I M hf m
+
+end Reduction
+
+section Semiprimary
+
+variable (R : Type u) [Ring R] (M : Type v) [AddCommGroup M] [Module R M]
+
+/-- **The radical quotient of a module over a semiprimary ring is semisimple.** It is a module over
+the semisimple ring `R ⧸ Ring.jacobson R`, and semisimplicity is insensitive to which of the two
+rings the scalars are read in. -/
+theorem isSemisimpleModule_quotient_jacobson_smul_top [IsSemiprimaryRing R] :
+    IsSemisimpleModule R (M ⧸ Ring.jacobson R • (⊤ : Submodule R M)) :=
+  (Module.isTorsionBySet_quotient_ideal_smul M (Ring.jacobson R)).isSemisimpleModule_iff.mp
+    inferInstance
+
+variable {R M}
+
+/-- **A projective cover is cut out of any projective presentation by an idempotent.** Over a
+semiprimary ring, a surjection `p : N ↠ M` from a projective module restricts to a projective cover
+of `M` on a suitable submodule `P` of `N` — a direct summand, the image of an idempotent lifted
+from the radical quotient. See the module docstring for the argument. -/
+theorem exists_isProjectiveCover_comp_subtype [IsSemiprimaryRing R] {N : Type w} [AddCommGroup N]
+    [Module R N] [Module.Projective R N] (p : N →ₗ[R] M) (hp : Function.Surjective p) :
+    ∃ P : Submodule R N, IsProjectiveCover (p ∘ₗ P.subtype) := by
+  classical
+  -- `p` descends to a surjection of radical quotients.
+  have hcomap : Ring.jacobson R • (⊤ : Submodule R N) ≤
+      (Ring.jacobson R • (⊤ : Submodule R M)).comap p := by
+    rw [← Submodule.map_le_iff_le_comap, Submodule.map_smul'']
+    exact Submodule.smul_mono le_rfl le_top
+  set q : (N ⧸ Ring.jacobson R • (⊤ : Submodule R N)) →ₗ[R]
+      M ⧸ Ring.jacobson R • (⊤ : Submodule R M) := Submodule.mapQ _ _ p hcomap
+  have hq : ∀ n : N, q (Submodule.Quotient.mk n) = Submodule.Quotient.mk (p n) := fun _ => rfl
+  have hqsurj : Function.Surjective q := by
+    intro z
+    obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective _ z
+    obtain ⟨n, rfl⟩ := hp x
+    exact ⟨Submodule.Quotient.mk n, rfl⟩
+  -- The kernel of `q` splits off, because the radical quotient of `N` is semisimple.
+  have hss := isSemisimpleModule_quotient_jacobson_smul_top R N
+  obtain ⟨C, hC⟩ := exists_isCompl (LinearMap.ker q)
+  set ebar : Module.End R (N ⧸ Ring.jacobson R • (⊤ : Submodule R N)) :=
+    C.projection (LinearMap.ker q) hC.symm
+  have hebar : IsIdempotentElem ebar := Submodule.isIdempotentElem_projection _
+  have hrangebar : LinearMap.range ebar = C := Submodule.range_projection _
+  have hsub : ∀ x, x - ebar x ∈ LinearMap.ker q := fun x => Submodule.sub_projection_mem hC.symm x
+  -- Lift `ebar`: the reduction map is onto with nil kernel.
+  obtain ⟨e, he, hee⟩ := exists_isIdempotentElem_eq_of_ker_isNilpotent (endMapQ (Ring.jacobson R) N)
+    (fun _ hg => isNilpotent_of_mem_ker_endMapQ _ N IsSemiprimaryRing.isNilpotent hg)
+    ebar (RingHom.mem_range.mpr (endMapQ_surjective _ N ebar)) hebar
+  have hfix : ∀ x ∈ LinearMap.range e, e x = x := by
+    rintro _ ⟨y, rfl⟩
+    exact (Module.End.mul_apply e e y).symm.trans (DFunLike.congr_fun he.eq y)
+  have hebar_mk : ∀ n : N, ebar (Submodule.Quotient.mk n) = Submodule.Quotient.mk (e n) := by
+    intro n
+    rw [← hee]
+    exact endMapQ_mk _ N e n
+  -- Nakayama: the radical multiple of any module is superfluous in it.
+  have hsuperM : IsSuperfluous (Ring.jacobson R • (⊤ : Submodule R M)) :=
+    isSuperfluous_smul_top_of_isNilpotent IsSemiprimaryRing.isNilpotent
+  refine ⟨LinearMap.range e, ?_, ?_, ?_⟩
+  · -- `range e` is a direct summand of the projective module `N`, hence projective.
+    exact Module.Projective.of_split (LinearMap.range e).subtype
+      (e.codRestrict (LinearMap.range e) fun x => LinearMap.mem_range_self e x)
+      (LinearMap.ext fun x => Subtype.ext (hfix _ x.2))
+  · -- The image of `P` spans `M` modulo the superfluous `J • M`, hence is all of `M`.
+    rw [← LinearMap.range_eq_top, LinearMap.range_comp, Submodule.range_subtype]
+    refine hsuperM.eq_top_of_sup_eq_top (top_le_iff.mp fun x _ => ?_)
+    obtain ⟨z, hz⟩ := hqsurj (Submodule.Quotient.mk x)
+    obtain ⟨n, rfl⟩ := Submodule.Quotient.mk_surjective _ z
+    have hzz : (Submodule.Quotient.mk x : M ⧸ Ring.jacobson R • (⊤ : Submodule R M))
+        = Submodule.Quotient.mk (p (e n)) := by
+      rw [← hq, ← hebar_mk, ← hz]
+      have hker := hsub (Submodule.Quotient.mk n)
+      rw [LinearMap.mem_ker, map_sub, sub_eq_zero] at hker
+      exact hker
+    exact Submodule.mem_sup.mpr ⟨x - p (e n), (Submodule.Quotient.eq _).mp hzz,
+      p (e n), Submodule.mem_map_of_mem ⟨n, rfl⟩, by abel⟩
+  · -- An element of the kernel reduces into `C ⊓ ker q = ⊥`, so lies in `J • N`, so in `J • P`.
+    refine (isSuperfluous_smul_top_of_isNilpotent
+      (M := ↥(LinearMap.range e)) IsSemiprimaryRing.isNilpotent).mono ?_
+    rintro ⟨x, hx⟩ hker
+    have hpx : p x = 0 := LinearMap.mem_ker.mp hker
+    have hmemC : (Submodule.Quotient.mk x : N ⧸ Ring.jacobson R • (⊤ : Submodule R N)) ∈ C := by
+      obtain ⟨y, rfl⟩ := hx
+      exact hrangebar ▸ ⟨Submodule.Quotient.mk y, hebar_mk y⟩
+    have hmemker : (Submodule.Quotient.mk x : N ⧸ Ring.jacobson R • (⊤ : Submodule R N))
+        ∈ LinearMap.ker q := by
+      rw [LinearMap.mem_ker, hq, hpx]
+      exact Submodule.Quotient.mk_zero _
+    have hinf : (Submodule.Quotient.mk x : N ⧸ Ring.jacobson R • (⊤ : Submodule R N))
+        ∈ C ⊓ LinearMap.ker q := ⟨hmemC, hmemker⟩
+    rw [hC.symm.inf_eq_bot, Submodule.mem_bot] at hinf
+    have hxJN : x ∈ Ring.jacobson R • (⊤ : Submodule R N) :=
+      (Submodule.Quotient.mk_eq_zero _).mp hinf
+    rw [Submodule.mem_smul_top_iff]
+    have hmap : x ∈ Submodule.map e (Ring.jacobson R • (⊤ : Submodule R N)) :=
+      ⟨x, hxJN, hfix x hx⟩
+    rwa [Submodule.map_smul'', Submodule.map_top] at hmap
+
+variable (R M)
+
+/-- **Every module over a semiprimary ring has a projective cover.**
+
+The cover is a direct summand of the free module on the underlying set of `M`. No finiteness is
+assumed of `M`: a semiprimary ring is left perfect, so it covers every module, not only the
+finitely generated ones. -/
+theorem exists_isProjectiveCover [IsSemiprimaryRing R] :
+    ∃ P : Submodule R (M →₀ R),
+      IsProjectiveCover (Finsupp.linearCombination R id ∘ₗ P.subtype) :=
+  exists_isProjectiveCover_comp_subtype _ fun x => ⟨Finsupp.single x 1, by simp⟩
+
+end Semiprimary
+
+section FiniteDimensional
+
+/-- **Every module over a finite-dimensional algebra has a projective cover**, the form in which the
+roadmap states the theorem. A finite-dimensional algebra is an Artinian ring, hence semiprimary, so
+this is `TauCeti.exists_isProjectiveCover` read through that instance; in particular no finiteness
+is required of the module. -/
+theorem exists_isProjectiveCover_of_finiteDimensional (k : Type w) [Field k] (A : Type u) [Ring A]
+    [Algebra k A] [FiniteDimensional k A] (V : Type v) [AddCommGroup V] [Module A V] :
+    ∃ P : Submodule A (V →₀ A),
+      IsProjectiveCover (Finsupp.linearCombination A id ∘ₗ P.subtype) := by
+  have : IsArtinianRing A := IsArtinianRing.of_finite k A
+  exact exists_isProjectiveCover A V
+
+end FiniteDimensional
+
+end TauCeti

--- a/TauCeti/Algebra/Module/ProjectiveCover/ModuleCat.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover/ModuleCat.lean
@@ -16,8 +16,8 @@ public import TauCeti.CategoryTheory.Projective.Cover
 with superfluous kernel — and `TauCeti.IsEssentialEpi` is its categorical counterpart, an
 epimorphism `π` such that every morphism `g` into its source with `g ≫ π` an epimorphism is itself
 one. This file is the bridge between the two over `ModuleCat`: a linear map that is a projective
-cover is an essential epimorphism of `ModuleCat` from a projective object
-(`TauCeti.IsProjectiveCover.isEssentialEpi`), and consequently the existence theorem of
+cover is an essential epimorphism of `ModuleCat` from a projective object, and conversely
+(`TauCeti.isProjectiveCover_iff_projective_and_isEssentialEpi`), so the existence theorem of
 `TauCeti/Algebra/Module/ProjectiveCover/Existence.lean` reads as a statement about objects of
 `ModuleCat`.
 
@@ -34,6 +34,9 @@ fix a single universe for the ring and the category.
 
 * `TauCeti.IsProjectiveCover.isEssentialEpi`: a module-level projective cover is an essential
   epimorphism of `ModuleCat`.
+* `TauCeti.isProjectiveCover_iff_projective_and_isEssentialEpi`: the two readings agree — a
+  morphism of `ModuleCat` is a projective cover of modules exactly when its source is a projective
+  object and it is an essential epimorphism.
 * `TauCeti.exists_essentialEpi_projective`: **every object of `ModuleCat R` over a semiprimary ring
   receives an essential epimorphism from a projective object.**
 * `TauCeti.exists_projectiveCover`: the same for a module over a finite-dimensional algebra.
@@ -73,6 +76,29 @@ theorem IsProjectiveCover.projective_obj {π : P ⟶ M} (h : IsProjectiveCover �
     Projective P :=
   have : Module.Projective R P := h.projective
   inferInstance
+
+/-- **The two readings of a projective cover agree.** A morphism of `ModuleCat` is a projective
+cover of modules exactly when its source is a projective object and it is an essential
+epimorphism. The backward direction recovers the module-level API — surjectivity and a superfluous
+kernel — from the categorical data: a map into the source is tested through its range, a submodule
+of the source and so again an object of `ModuleCat`. -/
+theorem isProjectiveCover_iff_projective_and_isEssentialEpi [Small.{v} R] {π : P ⟶ M} :
+    IsProjectiveCover π.hom ↔ Projective P ∧ IsEssentialEpi π := by
+  refine ⟨fun h => ⟨h.projective_obj, h.isEssentialEpi⟩, fun ⟨hP, hπ⟩ => ?_⟩
+  have hmod : Module.Projective R P := (IsProjective.iff_projective (R := R) ↥P).mpr hP
+  have hsurj : Function.Surjective π.hom := (ModuleCat.epi_iff_surjective π).mp hπ.epi
+  refine (isProjectiveCover_iff_forall_surjective hsurj).mpr fun {P'} _ _ h hcomp => ?_
+  -- The range of `h` is a submodule of `P`, so essentiality applies to its inclusion.
+  have hrange : Function.Surjective (π.hom ∘ₗ (LinearMap.range h).subtype) := fun y => by
+    obtain ⟨x, hx⟩ := hcomp y
+    exact ⟨⟨h x, LinearMap.mem_range_self h x⟩, hx⟩
+  have hepi : Epi (ModuleCat.ofHom (LinearMap.range h).subtype ≫ π) := by
+    rw [ModuleCat.epi_iff_surjective]
+    simpa [ModuleCat.hom_comp] using hrange
+  have hsub : Function.Surjective (LinearMap.range h).subtype :=
+    (ModuleCat.epi_iff_surjective _).mp (hπ.epi_of_epi_comp _ hepi)
+  rw [← LinearMap.range_eq_top]
+  exact (Submodule.range_subtype _).symm.trans (LinearMap.range_eq_top.mpr hsub)
 
 end Bridge
 

--- a/TauCeti/Algebra/Module/ProjectiveCover/ModuleCat.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover/ModuleCat.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Projective
+public import TauCeti.Algebra.Module.ProjectiveCover.Existence
+public import TauCeti.CategoryTheory.Projective.Cover
+
+/-!
+# Projective covers in `ModuleCat`
+
+`TauCeti.IsProjectiveCover` is the module-level predicate — a surjection from a projective module
+with superfluous kernel — and `TauCeti.IsEssentialEpi` is its categorical counterpart, an
+epimorphism `π` such that every morphism `g` into its source with `g ≫ π` an epimorphism is itself
+one. This file is the bridge between the two over `ModuleCat`: a linear map that is a projective
+cover is an essential epimorphism of `ModuleCat` from a projective object
+(`TauCeti.IsProjectiveCover.isEssentialEpi`), and consequently the existence theorem of
+`TauCeti/Algebra/Module/ProjectiveCover/Existence.lean` reads as a statement about objects of
+`ModuleCat`.
+
+The two translations used are Mathlib's: an epimorphism of `ModuleCat` is a surjection
+(`ModuleCat.epi_iff_surjective`), and a projective object of `ModuleCat` is a projective module
+(`IsProjective.iff_projective`). The module-level content of essentiality is
+`TauCeti.isProjectiveCover_iff_forall_surjective`.
+
+The covering module produced here is a submodule of a free module on the underlying set of the
+module covered, so it lives in the same universe as that module; this is why the statements below
+fix a single universe for the ring and the category.
+
+## Main results
+
+* `TauCeti.IsProjectiveCover.isEssentialEpi`: a module-level projective cover is an essential
+  epimorphism of `ModuleCat`.
+* `TauCeti.exists_essentialEpi_projective`: **every object of `ModuleCat R` over a semiprimary ring
+  receives an essential epimorphism from a projective object.**
+* `TauCeti.exists_projectiveCover`: the same for a module over a finite-dimensional algebra.
+
+## References
+
+See I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
+Algebras, Vol. 1*, Section I.5.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u v
+
+section Bridge
+
+variable {R : Type u} [Ring R] {P M : ModuleCat.{v} R}
+
+/-- **A projective cover of modules is an essential epimorphism.** The two conditions agree over
+`ModuleCat`: surjectivity is `Epi` and the minimality of a superfluous kernel is exactly the
+essentiality clause, by `TauCeti.isProjectiveCover_iff_forall_surjective`. -/
+theorem IsProjectiveCover.isEssentialEpi {π : P ⟶ M} (h : IsProjectiveCover π.hom) :
+    IsEssentialEpi π where
+  epi := (ModuleCat.epi_iff_surjective π).mpr h.surjective
+  epi_of_epi_comp g hg := by
+    have : Module.Projective R P := h.projective
+    rw [ModuleCat.epi_iff_surjective] at hg ⊢
+    refine (isProjectiveCover_iff_forall_surjective h.surjective).mp h g.hom ?_
+    simpa [ModuleCat.hom_comp] using hg
+
+/-- A projective cover of modules has a projective source, read in `ModuleCat`. -/
+theorem IsProjectiveCover.projective_obj {π : P ⟶ M} (h : IsProjectiveCover π.hom) :
+    Projective P :=
+  have : Module.Projective R P := h.projective
+  inferInstance
+
+end Bridge
+
+section Existence
+
+/-- **Every object of `ModuleCat R` over a semiprimary ring has a projective cover**: it receives
+an essential epimorphism from a projective object. Unfolding `TauCeti.IsEssentialEpi`, this says
+that `π` is an epimorphism and that every `i : X ⟶ P` with `i ≫ π` an epimorphism is one. -/
+theorem exists_essentialEpi_projective (R : Type u) [Ring R] [IsSemiprimaryRing R]
+    (M : ModuleCat.{u} R) :
+    ∃ (P : ModuleCat.{u} R) (π : P ⟶ M), Projective P ∧ IsEssentialEpi π := by
+  obtain ⟨P, hP⟩ := exists_isProjectiveCover R (↥M)
+  -- The cover of the underlying module, read as a morphism of `ModuleCat` onto `M`.
+  have hcov : IsProjectiveCover
+      ((ModuleCat.ofHom (Finsupp.linearCombination R id ∘ₗ P.subtype) :
+        ModuleCat.of R ↥P ⟶ M)).hom := by
+    rwa [ModuleCat.hom_ofHom]
+  exact ⟨_, _, hcov.projective_obj, hcov.isEssentialEpi⟩
+
+/-- **Every object of `ModuleCat A` over a finite-dimensional algebra `A` has a projective
+cover.** A finite-dimensional algebra is an Artinian ring, hence semiprimary, so this is
+`TauCeti.exists_essentialEpi_projective` read through that instance; no finiteness is required of
+the module. -/
+theorem exists_projectiveCover (k : Type v) [Field k] (A : Type u) [Ring A] [Algebra k A]
+    [FiniteDimensional k A] (M : ModuleCat.{u} A) :
+    ∃ (P : ModuleCat.{u} A) (π : P ⟶ M), Projective P ∧ IsEssentialEpi π := by
+  have : IsArtinianRing A := IsArtinianRing.of_finite k A
+  exact exists_essentialEpi_projective A M
+
+end Existence
+
+end TauCeti

--- a/TauCeti/Algebra/Module/ProjectiveCover/ModuleCat.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover/ModuleCat.lean
@@ -39,7 +39,8 @@ fix a single universe for the ring and the category.
   object and it is an essential epimorphism.
 * `TauCeti.exists_essentialEpi_projective`: **every object of `ModuleCat R` over a semiprimary ring
   receives an essential epimorphism from a projective object.**
-* `TauCeti.exists_projectiveCover`: the same for a module over a finite-dimensional algebra.
+* `TauCeti.exists_projectiveCover`: the same for a module over a finite-dimensional algebra, with
+  the two clauses of essentiality written out.
 
 ## References
 
@@ -121,12 +122,15 @@ theorem exists_essentialEpi_projective (R : Type u) [Ring R] [IsSemiprimaryRing 
 /-- **Every object of `ModuleCat A` over a finite-dimensional algebra `A` has a projective
 cover.** A finite-dimensional algebra is an Artinian ring, hence semiprimary, so this is
 `TauCeti.exists_essentialEpi_projective` read through that instance; no finiteness is required of
-the module. -/
-theorem exists_projectiveCover (k : Type v) [Field k] (A : Type u) [Ring A] [Algebra k A]
+the module. Essentiality is spelled out here as its two clauses, so that the statement is usable
+without unfolding `TauCeti.IsEssentialEpi`. -/
+theorem exists_projectiveCover {k : Type v} [Field k] {A : Type u} [Ring A] [Algebra k A]
     [FiniteDimensional k A] (M : ModuleCat.{u} A) :
-    ∃ (P : ModuleCat.{u} A) (π : P ⟶ M), Projective P ∧ IsEssentialEpi π := by
+    ∃ (P : ModuleCat.{u} A) (π : P ⟶ M), Projective P ∧ Epi π ∧
+      ∀ (X : ModuleCat.{u} A) (i : X ⟶ P), Epi (i ≫ π) → Epi i := by
   have : IsArtinianRing A := IsArtinianRing.of_finite k A
-  exact exists_essentialEpi_projective A M
+  obtain ⟨P, π, hP, hπ⟩ := exists_essentialEpi_projective A M
+  exact ⟨P, π, hP, hπ.epi, fun _ i => hπ.epi_of_epi_comp i⟩
 
 end Existence
 

--- a/TauCeti/Algebra/Module/Submodule/Superfluous.lean
+++ b/TauCeti/Algebra/Module/Submodule/Superfluous.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.RingTheory.Ideal.Operations
 public import TauCeti.RingTheory.Jacobson.Module
 
 /-!
@@ -47,6 +48,8 @@ contained in the radical `Module.jacobson`.
   particular over a finitely generated module — the converse holds, so the superfluous submodules
   are exactly the submodules of the radical, and
   `TauCeti.isSuperfluous_jacobson` records that the radical itself is then superfluous.
+* `TauCeti.isSuperfluous_smul_top_of_isNilpotent`: the form of Nakayama's lemma that needs no
+  hypothesis on the module at all — a nilpotent ideal times any module is superfluous in it.
 
 ## References
 
@@ -154,6 +157,35 @@ theorem IsSuperfluous.le_coatom {N m : Submodule R M} (hN : IsSuperfluous N) (hm
     rw [heq]
     exact le_sup_left
   exact hm.1 (hN.eq_top_of_sup_eq_top (hm.2 _ hlt))
+
+/-- **Nakayama's lemma for a nilpotent ideal.** If `I` is a nilpotent ideal then `I • M` is
+superfluous in `M`.
+
+Unlike `TauCeti.isSuperfluous_jacobson`, which asks the submodule lattice of `M` to be coatomic
+(for instance `M` finitely generated) and takes the radical of `M`, nilpotence of `I` buys the
+conclusion for an arbitrary module: a submodule `K` with `I • M ⊔ K = ⊤` absorbs `I ^ k • M` into
+`I ^ (k + 1) • M` for every `k`, and a power of `I` vanishes. -/
+theorem isSuperfluous_smul_top_of_isNilpotent {I : Ideal R} (hI : IsNilpotent I) :
+    IsSuperfluous (I • (⊤ : Submodule R M)) := by
+  obtain ⟨m, hm⟩ := hI
+  intro K hK
+  -- Multiplying `hK` by `I ^ k` trades the `k`-th power of `I` for the `(k + 1)`-st.
+  have step : ∀ k : ℕ, I ^ k • (⊤ : Submodule R M) ≤ K ⊔ I ^ (k + 1) • (⊤ : Submodule R M) := by
+    intro k
+    calc I ^ k • (⊤ : Submodule R M)
+        = I ^ k • (I • (⊤ : Submodule R M) ⊔ K) := by rw [hK]
+      _ = I ^ k • (I • (⊤ : Submodule R M)) ⊔ I ^ k • K := Submodule.smul_sup ..
+      _ = I ^ (k + 1) • (⊤ : Submodule R M) ⊔ I ^ k • K := by
+            rw [Submodule.pow_succ, Submodule.mul_smul]
+      _ ≤ I ^ (k + 1) • (⊤ : Submodule R M) ⊔ K := sup_le_sup_left Submodule.smul_le_right _
+      _ = K ⊔ I ^ (k + 1) • (⊤ : Submodule R M) := sup_comm ..
+  -- So `K` together with any power of `I` still spans, and the `m`-th power is zero.
+  have key : ∀ k : ℕ, (⊤ : Submodule R M) ≤ K ⊔ I ^ k • (⊤ : Submodule R M) := by
+    intro k
+    induction k with
+    | zero => rw [Submodule.pow_zero, Ideal.one_eq_top, Submodule.top_smul, sup_top_eq]
+    | succ k ih => exact ih.trans (sup_le le_sup_left ((step k).trans (by simp)))
+  simpa [hm] using key m
 
 end Semiring
 

--- a/TauCeti/CategoryTheory/Projective/Cover.lean
+++ b/TauCeti/CategoryTheory/Projective/Cover.lean
@@ -30,7 +30,7 @@ and it is the epimorphism condition, not the subobject one, that the results bel
 Mathlib has projective objects (`CategoryTheory.Projective`) and projective *presentations*
 (`CategoryTheory.ProjectivePresentation`, an epimorphism from a projective with no minimality
 demanded), but neither essential epimorphisms nor projective covers. The module-level notion is
-`TauCeti.IsProjectiveCover` in `TauCeti.Algebra.Module.ProjectiveCover`, phrased through the
+`TauCeti.IsProjectiveCover` in `TauCeti.Algebra.Module.ProjectiveCover.Basic`, phrased through the
 superfluousness of the kernel; `TauCeti.isProjectiveCover_iff_forall_surjective` shows that over an
 additive group it is exactly the condition used here, so this file is the categorical reading of
 the same notion, available in categories with no ambient kernel or subobject theory.

--- a/TauCeti/RingTheory/Jacobson/Semiperfect.lean
+++ b/TauCeti/RingTheory/Jacobson/Semiperfect.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+public import Mathlib.RingTheory.Artinian.Module
+public import Mathlib.RingTheory.Ideal.Quotient.Operations
+public import Mathlib.RingTheory.Idempotents
+public import Mathlib.RingTheory.Jacobson.Semiprimary
+
+/-!
+# Semiperfect rings
+
+A ring is **semiperfect** when its radical quotient `R ⧸ Ring.jacobson R` is a semisimple ring and
+idempotents lift modulo the radical. This is the hypothesis under which projective covers of
+finitely generated modules exist, and it is the property of a finite-dimensional algebra that
+`TauCeti/Algebra/Module/ProjectiveCover/Existence.lean` uses in its sharper, nilpotent form.
+
+Mathlib packages the neighbouring notion, `IsSemiprimaryRing`: the radical is *nilpotent* and the
+radical quotient is semisimple. Nilpotence of the radical makes its elements nil, so idempotents
+lift along `R ↠ R ⧸ Ring.jacobson R` by Mathlib's
+`exists_isIdempotentElem_eq_of_ker_isNilpotent`; a semiprimary ring is therefore semiperfect
+(`TauCeti.IsSemiperfectRing.of_isSemiprimaryRing`), and a finite-dimensional algebra over a field,
+being an Artinian ring, is semiprimary and hence semiperfect
+(`TauCeti.isSemiperfectRing_of_finiteDimensional`).
+
+Bass' characterization — `R` is semiperfect exactly when every finitely generated `R`-module has a
+projective cover — is not proved here. The existence half of it over a semiprimary ring, in the
+stronger form that covers *every* module, is
+`TauCeti.exists_isProjectiveCover`.
+
+## Main definitions
+
+* `TauCeti.IsSemiperfectRing`: the radical quotient is semisimple and idempotents lift modulo the
+  radical.
+
+## Main results
+
+* `TauCeti.IsSemiperfectRing.of_isSemiprimaryRing`: a semiprimary ring is semiperfect.
+* `TauCeti.isSemiperfectRing_of_finiteDimensional`: a finite-dimensional algebra over a field is
+  semiperfect.
+
+## References
+
+See T. Y. Lam, *A First Course in Noncommutative Rings*, §23-24.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v
+
+variable (R : Type u) [Ring R]
+
+/-- A ring is **semiperfect** if its quotient by the Jacobson radical is a semisimple ring and
+every idempotent of that quotient is the class of an idempotent of the ring. -/
+class IsSemiperfectRing : Prop where
+  /-- The radical quotient of a semiperfect ring is a semisimple ring. -/
+  isSemisimpleRing : IsSemisimpleRing (R ⧸ Ring.jacobson R)
+  /-- Idempotents lift modulo the Jacobson radical. -/
+  exists_isIdempotentElem_eq (e : R ⧸ Ring.jacobson R) (he : IsIdempotentElem e) :
+    ∃ f : R, IsIdempotentElem f ∧ Ideal.Quotient.mk (Ring.jacobson R) f = e
+
+attribute [instance] IsSemiperfectRing.isSemisimpleRing
+
+/-- **A semiprimary ring is semiperfect.** Its radical quotient is semisimple by definition, and
+every element of its radical is nilpotent because the radical is, so idempotents lift along
+`R ↠ R ⧸ Ring.jacobson R` by `exists_isIdempotentElem_eq_of_ker_isNilpotent`. -/
+instance IsSemiperfectRing.of_isSemiprimaryRing [IsSemiprimaryRing R] : IsSemiperfectRing R where
+  isSemisimpleRing := inferInstance
+  exists_isIdempotentElem_eq e he := by
+    refine exists_isIdempotentElem_eq_of_ker_isNilpotent (Ideal.Quotient.mk (Ring.jacobson R))
+      (fun x hx => ?_) e (RingHom.mem_range.mpr (Ideal.Quotient.mk_surjective e)) he
+    obtain ⟨n, hn⟩ := IsSemiprimaryRing.isNilpotent (R := R)
+    rw [Ideal.mk_ker] at hx
+    refine ⟨n, ?_⟩
+    have := Ideal.pow_mem_pow hx n
+    rwa [hn, Ideal.zero_eq_bot, Submodule.mem_bot] at this
+
+/-- **A finite-dimensional algebra is semiperfect.** It is an Artinian ring, hence semiprimary,
+hence semiperfect. -/
+theorem isSemiperfectRing_of_finiteDimensional (k : Type v) [Field k] (A : Type u) [Ring A]
+    [Algebra k A] [FiniteDimensional k A] : IsSemiperfectRing A := by
+  have : IsArtinianRing A := IsArtinianRing.of_finite k A
+  infer_instance
+
+end TauCeti

--- a/TauCeti/RingTheory/Jacobson/Semiprimary.lean
+++ b/TauCeti/RingTheory/Jacobson/Semiprimary.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Module.Torsion.Basic
+public import Mathlib.RingTheory.Jacobson.Semiprimary
+
+/-!
+# The radical quotient of a module over a semiprimary ring
+
+A ring is **semiprimary** when its Jacobson radical is nilpotent and the quotient by it is a
+semisimple ring. Mathlib records that the ring `R ⧸ Ring.jacobson R` is then semisimple, but not
+the module-level consequence: for *any* `R`-module `M`, the radical quotient `M ⧸ J • M` is a
+semisimple module. It is a module over `R ⧸ J`, annihilated by `J`, and semisimplicity does not
+depend on which of the two rings the scalars are read in.
+
+## Main results
+
+* `TauCeti.isSemisimpleModule_quotient_jacobson_smul_top`: the radical quotient of any module over
+  a semiprimary ring is a semisimple module.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v
+
+variable (R : Type u) [Ring R] (M : Type v) [AddCommGroup M] [Module R M]
+
+/-- **The radical quotient of a module over a semiprimary ring is semisimple.** It is a module over
+the semisimple ring `R ⧸ Ring.jacobson R`, and semisimplicity is insensitive to which of the two
+rings the scalars are read in. -/
+theorem isSemisimpleModule_quotient_jacobson_smul_top [IsSemiprimaryRing R] :
+    IsSemisimpleModule R (M ⧸ Ring.jacobson R • (⊤ : Submodule R M)) :=
+  (Module.isTorsionBySet_quotient_ideal_smul M (Ring.jacobson R)).isSemisimpleModule_iff.mp
+    inferInstance
+
+end TauCeti

--- a/TauCeti/RingTheory/Jacobson/Semiprimary.lean
+++ b/TauCeti/RingTheory/Jacobson/Semiprimary.lean
@@ -11,14 +11,20 @@ public import Mathlib.RingTheory.Jacobson.Semiprimary
 /-!
 # The radical quotient of a module over a semiprimary ring
 
+Let `I` be a two-sided ideal of `R` with `R ⧸ I` a semisimple ring. Then for *any* `R`-module `M`
+the quotient `M ⧸ I • M` is a semisimple module: it is a module over `R ⧸ I`, annihilated by `I`,
+and semisimplicity does not depend on which of the two rings the scalars are read in. Nothing about
+`I` beyond semisimplicity of the quotient ring enters.
+
 A ring is **semiprimary** when its Jacobson radical is nilpotent and the quotient by it is a
-semisimple ring. Mathlib records that the ring `R ⧸ Ring.jacobson R` is then semisimple, but not
-the module-level consequence: for *any* `R`-module `M`, the radical quotient `M ⧸ J • M` is a
-semisimple module. It is a module over `R ⧸ J`, annihilated by `J`, and semisimplicity does not
-depend on which of the two rings the scalars are read in.
+semisimple ring. Mathlib records that the ring `R ⧸ Ring.jacobson R` is then semisimple; the
+special case of the above at `I = Ring.jacobson R` is the module-level consequence, that the
+radical quotient of any module over a semiprimary ring is semisimple.
 
 ## Main results
 
+* `TauCeti.isSemisimpleModule_quotient_smul_top`: `M ⧸ I • M` is a semisimple `R`-module whenever
+  `R ⧸ I` is a semisimple ring.
 * `TauCeti.isSemisimpleModule_quotient_jacobson_smul_top`: the radical quotient of any module over
   a semiprimary ring is a semisimple module.
 -/
@@ -29,14 +35,22 @@ namespace TauCeti
 
 universe u v
 
-variable (R : Type u) [Ring R] (M : Type v) [AddCommGroup M] [Module R M]
+variable (R : Type u) [Ring R]
 
-/-- **The radical quotient of a module over a semiprimary ring is semisimple.** It is a module over
-the semisimple ring `R ⧸ Ring.jacobson R`, and semisimplicity is insensitive to which of the two
-rings the scalars are read in. -/
-theorem isSemisimpleModule_quotient_jacobson_smul_top [IsSemiprimaryRing R] :
+/-- **A module quotient by a semisimple ideal multiple is semisimple.** If `R ⧸ I` is a semisimple
+ring then `M ⧸ I • M` is a semisimple `R`-module: it is a module over `R ⧸ I`, and semisimplicity
+is insensitive to which of the two rings the scalars are read in. -/
+theorem isSemisimpleModule_quotient_smul_top (I : Ideal R) [I.IsTwoSided] [IsSemisimpleRing (R ⧸ I)]
+    (M : Type v) [AddCommGroup M] [Module R M] :
+    IsSemisimpleModule R (M ⧸ I • (⊤ : Submodule R M)) :=
+  (Module.isTorsionBySet_quotient_ideal_smul M I).isSemisimpleModule_iff.mp inferInstance
+
+/-- **The radical quotient of a module over a semiprimary ring is semisimple.** The radical
+quotient of a semiprimary ring is a semisimple ring, so this is
+`TauCeti.isSemisimpleModule_quotient_smul_top` for the Jacobson radical. -/
+theorem isSemisimpleModule_quotient_jacobson_smul_top (M : Type v) [AddCommGroup M] [Module R M]
+    [IsSemiprimaryRing R] :
     IsSemisimpleModule R (M ⧸ Ring.jacobson R • (⊤ : Submodule R M)) :=
-  (Module.isTorsionBySet_quotient_ideal_smul M (Ring.jacobson R)).isSemisimpleModule_iff.mp
-    inferInstance
+  isSemisimpleModule_quotient_smul_top R (Ring.jacobson R) M
 
 end TauCeti


### PR DESCRIPTION
This PR proves that **every module over a semiprimary ring has a projective cover**, supplying the existence half of the "projective covers and injective envelopes" bullet of Layer 3 of [`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/RepresentationTheory/QuiverRepresentations/README.md) — "Build `projectiveCover M`: a projective `P` with an essential epimorphism `P ↠ M` (superfluous kernel), **unique up to isomorphism**, existing because `A` is semiperfect (finite-dimensional)" — whose pinned signature is `exists_projectiveCover` in that roadmap's `Suggested.lean`. `TauCeti/Algebra/Module/ProjectiveCover/Basic.lean` already had the uniqueness half and said in as many words that existence "is a separate matter … None of this is proved here"; this fills exactly that gap, and the docstring is updated to point at the new file.

`TauCeti.exists_isProjectiveCover_comp_subtype` is the sharp statement: over a semiprimary ring, any surjection `p : N ↠ M` from a projective module restricts to a projective cover of `M` on a submodule `P ≤ N`. Writing `J` for the radical, the proof splits `ker (N ⧸ J•N ↠ M ⧸ J•M)` off — the radical quotient is a module over the semisimple ring `R ⧸ J`, hence semisimple (`TauCeti.isSemisimpleModule_quotient_jacobson_smul_top`) — and lifts the resulting idempotent along the reduction ring homomorphism `Ideal.endMapQ J N : End N →+* End (N ⧸ J•N)`, which is surjective by projectivity of `N` and has nil kernel because a map with image in `J•N` has `k`-th power with image in `J^k•N` (`Ideal.isNilpotent_of_mem_ker_endMapQ`); Mathlib's `exists_isIdempotentElem_eq_of_ker_isNilpotent` does the lifting. `P` is the image of the lifted idempotent, a direct summand of `N`, and the two cover conditions are read off `ker ē = ker q` and `C ⊓ ker q = ⊥`. `TauCeti.exists_isProjectiveCover` specializes to the free module on the underlying set of `M`, and `TauCeti.exists_isProjectiveCover_of_finiteDimensional` is the finite-dimensional-algebra reading the roadmap states, obtained through `IsArtinianRing.of_finite` and Mathlib's `IsArtinianRing → IsSemiprimaryRing` instance.

Two deliberate generality choices. The hypothesis is Mathlib's `IsSemiprimaryRing` rather than "finite-dimensional algebra": that is the property the argument actually uses, a finite-dimensional algebra satisfies it, and stating it there avoids carrying a base field the proof never touches. And **no finiteness is assumed of the module** — a semiprimary ring is left perfect, so it covers every module and not only the finitely generated ones a semiperfect ring covers. That strengthening is bought by the one new lemma outside the new file, `TauCeti.isSuperfluous_smul_top_of_isNilpotent` in `TauCeti/Algebra/Module/Submodule/Superfluous.lean`: Nakayama's lemma for a nilpotent ideal, which needs no hypothesis on the module, unlike the existing `TauCeti.isSuperfluous_jacobson` which asks the submodule lattice to be coatomic. It is placed beside the other superfluity/Nakayama statements rather than in the new file because it is a fact about superfluous submodules, not about covers. Some hypothesis on the ring is genuinely needed: `ℤ ⧸ 2ℤ` has no projective cover as a `ℤ`-module even though it has finite length.

The core statements are made against the repository's own `TauCeti.IsProjectiveCover` (surjective, projective source, superfluous kernel), the predicate the uniqueness half is already stated for and the one every existing consumer uses. `TauCeti/Algebra/Module/ProjectiveCover/ModuleCat.lean` then carries them across the module/`ModuleCat` boundary, so the pinned `Suggested.lean` shape is available too: `TauCeti.IsProjectiveCover.isEssentialEpi` and `TauCeti.IsProjectiveCover.projective_obj` translate a cover into a projective object with an essential epimorphism (`TauCeti.IsEssentialEpi`, whose two fields are exactly the `Epi π` and `∀ X (i : X ⟶ P), Epi (i ≫ π) → Epi i` of the pinned statement), and `TauCeti.isProjectiveCover_iff_projective_and_isEssentialEpi` is the equivalence, so the module-level cover API can also be read off categorical data, `TauCeti.exists_essentialEpi_projective` is the semiprimary existence theorem in that form, and `TauCeti.exists_projectiveCover` is the finite-dimensional one stated as the roadmap pins it: the base field and the algebra implicit, and essentiality written out as `Epi π ∧ ∀ X i, Epi (i ≫ π) → Epi i` rather than bundled. The pinned signature's `IsFiniteLength` hypothesis is dropped rather than carried: the proof does not use it, and an unused binder is rejected twice over by this repository's CI — as a `warningAsError` build failure from `unusedVariables` and as an `unusedArguments` environment-linter failure.

Because the tree would otherwise hold both `ProjectiveCover.lean` and a `ProjectiveCover/` directory, the existing flat file is moved in this same PR; only imports and docstring paths change, no declaration is renamed:

| old module | new module |
| --- | --- |
| `TauCeti.Algebra.Module.ProjectiveCover` | `TauCeti.Algebra.Module.ProjectiveCover.Basic` |

Two pieces of the existence proof are generic and live outside it. `Ideal.endMapQ`, the reduction of endomorphisms modulo `I • M`, together with `Ideal.mem_ker_endMapQ_iff`, `Ideal.endMapQ_surjective`, `Ideal.range_pow_le_of_mem_ker_endMapQ` and `Ideal.isNilpotent_of_mem_ker_endMapQ`, is quotient infrastructure mentioning neither covers nor semiprimary rings, so it sits in `TauCeti/Algebra/Module/LinearMap/EndQuotient.lean`, in the namespace of its first explicit argument. `TauCeti.isSemisimpleModule_quotient_jacobson_smul_top` is a statement about the radical quotient of an arbitrary module over a semiprimary ring, so it sits in `TauCeti/RingTheory/Jacobson/Semiprimary.lean`, beside the general form it specializes, `TauCeti.isSemisimpleModule_quotient_smul_top`: `M ⧸ I • M` is a semisimple `R`-module whenever `I` is two-sided with `R ⧸ I` semisimple.

`TauCeti/RingTheory/Jacobson/Semiperfect.lean` lands the one Layer 3A item of the roadmap's "before covers" list that was not already on `main`: `TauCeti.IsSemiperfectRing`, the standard definition (Lam §23-24) that the radical quotient is a semisimple ring and idempotents lift modulo the radical. `TauCeti.IsSemiperfectRing.of_isSemiprimaryRing` is the instance from a semiprimary ring — a nilpotent radical is nil, so `exists_isIdempotentElem_eq_of_ker_isNilpotent` lifts along `R ↠ R ⧸ Ring.jacobson R` — and `TauCeti.isSemiperfectRing_of_finiteDimensional` reads it for a finite-dimensional algebra through `IsArtinianRing.of_finite`. This is the ring-level shadow of the second use of nilpotence in the existence proof, which lifts an idempotent of `End (N ⧸ J • N)` rather than of `R`; it is placed beside Mathlib's `Mathlib/RingTheory/Jacobson/Semiprimary.lean`, which defines the neighbouring `IsSemiprimaryRing`. Bass' converse — semiperfect exactly when every finitely generated module has a projective cover — is not proved here, and the file's docstring says so.

Nothing is vendored from Mathlib; the proof consumes `exists_isIdempotentElem_eq_of_ker_isNilpotent`, `IsSemiprimaryRing`, `Module.isTorsionBySet_quotient_ideal_smul`, `Submodule.projection`, and `Module.Projective.of_split` as they stand upstream.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"exists-projectivecover"}-->

🤖 Prepared with Claude Code




