### PR TITLE
feat(Huber): a vertical generization of a continuous valuation is continuous (Wedhorn 7.11(2))

### DIFF
--- a/TauCeti/Algebra/Order/Group/ConvexSubgroup.lean
+++ b/TauCeti/Algebra/Order/Group/ConvexSubgroup.lean
@@ -58,6 +58,8 @@ built from `closure` in the forthcoming valuation-spectrum development of `Spv (
   and `⊤`.
 * `TauCeti.ConvexSubgroup.quotientBotOrderIso` : The quotient by `⊥` is the group itself, as an
   order isomorphism, so order-theoretic properties transfer across it.
+* `TauCeti.ConvexSubgroup.exists_one_lt_quotientMk` : A proper convex subgroup leaves an element
+  above `1` in its quotient.
 
 ## References
 
@@ -651,6 +653,23 @@ theorem quotientMk_lt_one_of_notMem {a : Γ} (ha : a ≤ 1) (haH : a ∉ H) :
     simpa using H.quotientMk_monotone ha
   refine hle.lt_of_ne fun heq ↦ haH ?_
   exact (QuotientGroup.eq_one_iff a).mp (by simpa using heq)
+
+/-- **A proper convex subgroup leaves an element above `1` in its quotient.** Properness is what
+supplies it: `H < ⊤` separates `H` from the whole group by some `z > 1` outside `H`, and `z⁻¹`
+then has class strictly below `1`, so the class of `z` is strictly above it.
+
+This is the order-theoretic content a cofinality argument needs from properness — the coarsening
+map is monotone but not strictly so, and an element above `1` in the quotient is the room that
+recovers a strict inequality. -/
+theorem exists_one_lt_quotientMk (hH : H ≠ ⊤) :
+    ∃ d : Γ, 1 < (QuotientGroup.mk' H.toSubgroup d : Γ ⧸ H.toSubgroup) := by
+  have hlt : H.toSubgroup < (⊤ : Subgroup Γ) :=
+    top_toSubgroup (Γ := Γ) ▸ toSubgroup_lt.mpr (lt_top_iff_ne_top.mpr hH)
+  obtain ⟨z, -, hzH, hz⟩ := Subgroup.exists_one_lt_of_lt hlt
+  refine ⟨z, ?_⟩
+  rw [← inv_lt_one', ← map_inv]
+  exact H.quotientMk_lt_one_of_notMem (inv_le_one'.mpr hz.le) fun hmem ↦
+    hzH (by simpa using inv_mem (mem_toSubgroup.mpr hmem))
 
 /-- **The quotient by `⊥` is the group itself.** `QuotientGroup.quotientBot` identifies the two
 groups once `bot_toSubgroup` has rewritten which subgroup is being quotiented by.

--- a/TauCeti/Algebra/Order/Group/ConvexSubgroup.lean
+++ b/TauCeti/Algebra/Order/Group/ConvexSubgroup.lean
@@ -58,8 +58,6 @@ built from `closure` in the forthcoming valuation-spectrum development of `Spv (
   and `⊤`.
 * `TauCeti.ConvexSubgroup.quotientBotOrderIso` : The quotient by `⊥` is the group itself, as an
   order isomorphism, so order-theoretic properties transfer across it.
-* `TauCeti.ConvexSubgroup.exists_one_lt_quotientMk` : A proper convex subgroup leaves an element
-  above `1` in its quotient.
 
 ## References
 
@@ -72,9 +70,6 @@ API (`Quotient.instLinearOrder` over order-connected fibers) rather than constru
 `quotientMk_monotone` and `quotientMk_lt_one_of_notMem` come from a different AINTLIB file:
 `projects/AdicSpaces/Adic spaces/ValuationCoarsening.lean` at commit `37bbdaeb`, where they are
 the order facts the coarsening construction consumes.
-
-`exists_one_lt_quotientMk` is in neither AINTLIB file. Its statement and proof are new here,
-assembled from `Subgroup.exists_one_lt_of_lt` and `quotientMk_lt_one_of_notMem`.
 -/
 
 public section
@@ -656,23 +651,6 @@ theorem quotientMk_lt_one_of_notMem {a : Γ} (ha : a ≤ 1) (haH : a ∉ H) :
     simpa using H.quotientMk_monotone ha
   refine hle.lt_of_ne fun heq ↦ haH ?_
   exact (QuotientGroup.eq_one_iff a).mp (by simpa using heq)
-
-/-- **A proper convex subgroup leaves an element above `1` in its quotient.** Properness is what
-supplies it: `H < ⊤` separates `H` from the whole group by some `z > 1` outside `H`, and `z⁻¹`
-then has class strictly below `1`, so the class of `z` is strictly above it.
-
-This is the order-theoretic content a cofinality argument needs from properness — the coarsening
-map is monotone but not strictly so, and an element above `1` in the quotient is the room that
-recovers a strict inequality. -/
-theorem exists_one_lt_quotientMk (hH : H ≠ ⊤) :
-    ∃ d : Γ, 1 < (QuotientGroup.mk' H.toSubgroup d : Γ ⧸ H.toSubgroup) := by
-  have hlt : H.toSubgroup < (⊤ : Subgroup Γ) :=
-    top_toSubgroup (Γ := Γ) ▸ toSubgroup_lt.mpr (lt_top_iff_ne_top.mpr hH)
-  obtain ⟨z, -, hzH, hz⟩ := Subgroup.exists_one_lt_of_lt hlt
-  refine ⟨z, ?_⟩
-  rw [← inv_lt_one', ← map_inv]
-  exact H.quotientMk_lt_one_of_notMem (inv_le_one'.mpr hz.le) fun hmem ↦
-    hzH (by simpa using inv_mem (mem_toSubgroup.mpr hmem))
 
 /-- **The quotient by `⊥` is the group itself.** `QuotientGroup.quotientBot` identifies the two
 groups once `bot_toSubgroup` has rewritten which subgroup is being quotiented by.

--- a/TauCeti/Algebra/Order/Group/ConvexSubgroup.lean
+++ b/TauCeti/Algebra/Order/Group/ConvexSubgroup.lean
@@ -72,6 +72,9 @@ API (`Quotient.instLinearOrder` over order-connected fibers) rather than constru
 `quotientMk_monotone` and `quotientMk_lt_one_of_notMem` come from a different AINTLIB file:
 `projects/AdicSpaces/Adic spaces/ValuationCoarsening.lean` at commit `37bbdaeb`, where they are
 the order facts the coarsening construction consumes.
+
+`exists_one_lt_quotientMk` is in neither AINTLIB file. Its statement and proof are new here,
+assembled from `Subgroup.exists_one_lt_of_lt` and `quotientMk_lt_one_of_notMem`.
 -/
 
 public section

--- a/TauCeti/RingTheory/Huber/Continuous/Coarsen.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/Coarsen.lean
@@ -23,35 +23,16 @@ Properness is not decoration. If `H` were all of `Γ_v` the coarsening would tak
 `0` and `1`, so `{a | w a < w b}` would be the support of `v`, and continuity would force that
 support to be open — which it need not be.
 
-## What the argument needs
-
-Continuity is rebuilt from Wedhorn Remark 7.11(1), the cofinal-value criterion, in the form
-`TauCeti.Huber.PairOfDefinition.isContinuous_of_forall_cofinalValue`. Two things have to survive
-the coarsening, and each is one step:
-
-* the bound `v a ≤ 1` on an ideal of definition, which is monotonicity of the coarsening map;
-* cofinality of `v a` there, which is Wedhorn Corollary 1.21 — the statement carried here by
-  `TauCeti.IsCofinalElement.quotientMk`.
-
-Only the second uses properness, and it uses it exactly once: a monotone map gives `≤`, so a
-witness `d ∉ H` with `1 < d` is what turns that into the strict inequality cofinality asks for.
-The target is shrunk by `d⁻¹` before `v`'s own cofinality is invoked, and the resulting slack is
-what survives as strictness downstairs.
-
 ## Main results
 
 * `Valuation.IsContinuous.coarsenByUnits_restrict`: the coarsening of a continuous valuation by a
   proper convex subgroup of its value group is continuous.
+* `Valuation.cofinalValue_coarsenByUnits_restrict`: coarsening by a proper convex subgroup
+  preserves cofinality of a value, which is the half properness is needed for.
 
 ## References
 
 * [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Remark 7.11 and Corollary 1.21.
-
-AINTLIB's `coarsen_maxAvoid_isContinuous_mulArchimedean` is *not* the source of this proof and is
-not a specialization of it: it fixes `H` to be `maxAvoid g₀`, carries a cofinality hypothesis on
-`g₀`, bundles a `MulArchimedean` conclusion, and is proved against a definition of continuity
-quantifying over the whole codomain rather than over attained values. Its direct sublevel-set
-argument does not transfer to this statement.
 -/
 
 public section
@@ -89,12 +70,15 @@ variable {A : Type*} [CommRing A] [TopologicalSpace A]
 variable {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
 
 omit [TopologicalSpace A] in
--- Every positive element of the coarsened value group is a ratio of attained values; shrinking
--- that ratio by `d⁻¹` turns the monotone image of a cofinal power into a strict bound.
-private theorem cofinalValue_coarsenByUnits_restrict {v : Valuation A Γ₀}
-    {H : ConvexSubgroup (ValueGroup₀ (.ofClass v))ˣ} {d : (ValueGroup₀ (.ofClass v))ˣ}
-    (hd : 1 < QuotientGroup.mk' H.toSubgroup d) {a : A} (hcof : CofinalValue v a) :
-    CofinalValue (v.restrict.coarsenByUnits H) a := by
+/-- **Coarsening by a proper convex subgroup preserves cofinality of a value.** This is the half of
+Wedhorn Remark 7.11(2) that properness is needed for: the coarsening map is monotone but not
+strictly so, and properness is exactly what supplies the room to recover a strict inequality. -/
+theorem cofinalValue_coarsenByUnits_restrict {v : Valuation A Γ₀}
+    {H : ConvexSubgroup (ValueGroup₀ (.ofClass v))ˣ} (hH : H ≠ ⊤) {a : A}
+    (hcof : CofinalValue v a) : CofinalValue (v.restrict.coarsenByUnits H) a := by
+  -- Every positive element of the coarsened value group is a ratio of attained values; shrinking
+  -- that ratio by `d⁻¹` turns the monotone image of a cofinal power into a strict bound.
+  obtain ⟨d, hd⟩ := ConvexSubgroup.exists_one_lt_quotientMk hH
   rw [cofinalValue_iff]
   intro γ hγ
   obtain ⟨r, q, hr, hq, hrq⟩ :=
@@ -121,14 +105,12 @@ theorem IsContinuous.coarsenByUnits_restrict [IsTopologicalRing A] [IsHuberRing 
     (hH : H ≠ ⊤) : (v.restrict.coarsenByUnits H).IsContinuous := by
   obtain ⟨P⟩ := IsHuberRing.nonempty_pairOfDefinition (A := A)
   obtain ⟨s, hs⟩ := P.fg_idealOfDefinition
-  -- properness enters only through this witness, which the cofinality branch shrinks by
-  obtain ⟨d, hdq⟩ := ConvexSubgroup.exists_one_lt_quotientMk hH
   refine P.isContinuous_of_forall_cofinalValue _ hs (fun a ha ↦ ?_) fun t ht ↦ ?_
   · rw [coarsenByUnits_apply, ← map_one (coarsenMapOfValueGroup H)]
     exact coarsenMapOfValueGroup_monotone H
       ((v.isEquiv_restrict.isContinuous_iff.mp hv).lt_one_of_isTopologicallyNilpotent
         (P.isTopologicallyNilpotent_of_mem_idealOfDefinition ha)).le
-  · exact cofinalValue_coarsenByUnits_restrict hdq
+  · exact cofinalValue_coarsenByUnits_restrict hH
       (hv.cofinalValue_of_isTopologicallyNilpotent
         (P.isTopologicallyNilpotent_of_mem_idealOfDefinition (hs ▸ Ideal.subset_span ht)))
 

--- a/TauCeti/RingTheory/Huber/Continuous/Coarsen.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/Coarsen.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Huber.Continuous.OfCofinal
+public import TauCeti.RingTheory.Valuation.Coarsen
+import TauCeti.RingTheory.Valuation.Continuous.TopologicallyNilpotent
+
+/-!
+# Continuity of a vertical generization
+
+**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Remark 7.11(2).**
+
+A vertical generization `v/H` of a continuous valuation on a Huber ring is again continuous.
+Wedhorn states the hypothesis as `H ⊊ Γ_v`: the convex subgroup is proper **in the value group**,
+not in the ambient codomain. That is why the coarsening here is applied to `v.restrict`, which is
+the presentation of `v` on its own value group; `H ≠ ⊤` is then literally Wedhorn's properness.
+
+Properness is not decoration. If `H` were all of `Γ_v` the coarsening would take only the values
+`0` and `1`, so `{a | w a < w b}` would be the support of `v`, and continuity would force that
+support to be open — which it need not be.
+
+## What the argument needs
+
+Continuity is rebuilt from Wedhorn Remark 7.11(1), the cofinal-value criterion, in the form
+`TauCeti.Huber.PairOfDefinition.isContinuous_of_forall_cofinalValue`. Two things have to survive
+the coarsening, and each is one step:
+
+* the bound `v a ≤ 1` on an ideal of definition, which is monotonicity of the coarsening map;
+* cofinality of `v a` there, which is Wedhorn Corollary 1.21 — the statement carried here by
+  `TauCeti.IsCofinalElement.quotientMk`.
+
+Only the second uses properness, and it uses it exactly once: a monotone map gives `≤`, so a
+witness `d ∉ H` with `1 < d` is what turns that into the strict inequality cofinality asks for.
+The target is shrunk by `d⁻¹` before `v`'s own cofinality is invoked, and the resulting slack is
+what survives as strictness downstairs.
+
+## Main results
+
+* `Valuation.IsContinuous.coarsenByUnits_restrict`: the coarsening of a continuous valuation by a
+  proper convex subgroup of its value group is continuous.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Remark 7.11 and Corollary 1.21.
+
+AINTLIB's `coarsen_maxAvoid_isContinuous_mulArchimedean` is *not* the source of this proof and is
+not a specialization of it: it fixes `H` to be `maxAvoid g₀`, carries a cofinality hypothesis on
+`g₀`, bundles a `MulArchimedean` conclusion, and is proved against a definition of continuity
+quantifying over the whole codomain rather than over attained values. Its direct sublevel-set
+argument does not transfer to this statement.
+-/
+
+public section
+
+namespace Valuation
+
+open TauCeti TauCeti.Huber MonoidWithZeroHom
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A]
+variable {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
+
+/-- **Wedhorn Remark 7.11(2).** A vertical generization of a continuous valuation by a proper
+convex subgroup of its value group is again continuous.
+
+The coarsening is taken on `v.restrict` rather than on `v`, so that `H ≠ ⊤` is properness in the
+value group, which is the hypothesis Wedhorn states. Properness enters only through the witness
+`d ∉ H` with `1 < d`: coarsening is monotone but not strictly so, and shrinking the target by
+`d⁻¹` is what recovers the strict inequality that cofinality requires. -/
+theorem IsContinuous.coarsenByUnits_restrict [IsTopologicalRing A] [IsHuberRing A]
+    [ContinuousConstSMul Aᵐᵒᵖ A] {v : Valuation A Γ₀} (hv : v.IsContinuous)
+    {H : ConvexSubgroup (ValueGroup₀ (.ofClass v))ˣ} (hH : H ≠ ⊤) :
+    (v.restrict.coarsenByUnits H).IsContinuous := by
+  obtain ⟨P⟩ := IsHuberRing.nonempty_pairOfDefinition (A := A)
+  obtain ⟨s, hs⟩ := P.fg_idealOfDefinition
+  have hv' : v.restrict.IsContinuous := (v.isEquiv_restrict).isContinuous_iff.mp hv
+  obtain ⟨x, -, hxH⟩ := SetLike.exists_of_lt (lt_top_iff_ne_top.mpr hH)
+  have hx1 : x ≠ 1 := fun h ↦ hxH (h ▸ one_mem H)
+  obtain ⟨d, hd1, hdH⟩ : ∃ d : (ValueGroup₀ (.ofClass v))ˣ, 1 < d ∧ d ∉ H := by
+    rcases lt_or_gt_of_ne hx1 with hlt | hgt
+    · exact ⟨x⁻¹, by simpa using hlt, fun hmem ↦ hxH (by simpa using inv_mem hmem)⟩
+    · exact ⟨x, hgt, hxH⟩
+  have hdq : 1 < QuotientGroup.mk' H.toSubgroup d := by
+    have h := H.quotientMk_lt_one_of_notMem (a := d⁻¹) (by simpa using hd1.le)
+      (fun hmem ↦ hdH (by simpa using inv_mem hmem))
+    simpa using h
+  refine P.isContinuous_of_forall_cofinalValue _ hs ?_ ?_
+  · intro a ha
+    rw [coarsenByUnits_apply, ← map_one (coarsenMapOfValueGroup H)]
+    exact coarsenMapOfValueGroup_monotone H
+      (hv'.lt_one_of_isTopologicallyNilpotent
+        (P.isTopologicallyNilpotent_of_mem_idealOfDefinition ha)).le
+  · intro t ht
+    have hnil := P.isTopologicallyNilpotent_of_mem_idealOfDefinition (hs ▸ Ideal.subset_span ht)
+    have hcof : CofinalValue v (t : A) := hv.cofinalValue_of_isTopologicallyNilpotent hnil
+    rw [cofinalValue_iff]
+    intro γ hγ
+    obtain ⟨r, q, hr, hq, hrq⟩ :=
+      (v.restrict.coarsenByUnits H).exists_div_eq_of_unit (Units.mk0 γ hγ.ne')
+    simp only [Units.val_mk0] at hrq
+    have hrv : v.restrict r ≠ 0 := fun h ↦ by
+      rw [coarsenByUnits_apply, h, map_zero] at hr; exact lt_irrefl 0 hr
+    have hqv : v.restrict q ≠ 0 := fun h ↦ by
+      rw [coarsenByUnits_apply, h, map_zero] at hq; exact lt_irrefl 0 hq
+    obtain ⟨n, hn⟩ := cofinalValue_iff.mp hcof
+      (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹)
+      (by simp [zero_lt_iff, hrv, hqv, Units.ne_zero d])
+    refine ⟨n, ?_⟩
+    have hemb : ValueGroup₀.embedding γ =
+        (v.restrict.coarsenByUnits H) r / (v.restrict.coarsenByUnits H) q := by
+      rw [← hrq, map_div₀, Valuation.embedding_restrict, Valuation.embedding_restrict]
+    rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, hemb, coarsenByUnits_apply,
+      coarsenByUnits_apply, coarsenByUnits_apply, map_pow, ← map_div₀]
+    calc coarsenMapOfValueGroup H (v.restrict ↑t ^ n)
+        ≤ coarsenMapOfValueGroup H
+            (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹) :=
+          coarsenMapOfValueGroup_monotone H hn.le
+      _ < coarsenMapOfValueGroup H (v.restrict r / v.restrict q) := by
+          rw [map_mul, map_inv₀, coarsenMapOfValueGroup_apply_coe]
+          refine mul_lt_of_lt_one_right ?_ ?_
+          · refine zero_lt_iff.mpr ?_
+            rw [ne_eq, map_eq_zero, div_eq_zero_iff]
+            push Not
+            exact ⟨hrv, hqv⟩
+          · rw [← WithZero.coe_inv, WithZero.coe_lt_one]
+            simpa using hdq
+
+end Valuation
+
+end

--- a/TauCeti/RingTheory/Huber/Continuous/Coarsen.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/Coarsen.lean
@@ -56,6 +56,31 @@ argument does not transfer to this statement.
 
 public section
 
+namespace TauCeti
+
+-- Properness makes the quotient nontrivial, and a nontrivial linearly ordered commutative group
+-- has an element above `1`; surjectivity of the quotient map pulls that element back to `Γ`.
+private theorem ConvexSubgroup.exists_one_lt_quotientMk {Γ : Type*} [CommGroup Γ] [LinearOrder Γ]
+    [IsOrderedMonoid Γ] {H : ConvexSubgroup Γ} (hH : H ≠ ⊤) :
+    ∃ d : Γ, 1 < QuotientGroup.mk' H.toSubgroup d := by
+  have : Nontrivial (Γ ⧸ H.toSubgroup) :=
+    QuotientGroup.nontrivial_iff.mpr fun h ↦
+      hH (toSubgroup_injective (h.trans top_toSubgroup.symm))
+  obtain ⟨q, hq⟩ := exists_one_lt' (α := Γ ⧸ H.toSubgroup)
+  obtain ⟨d, rfl⟩ := QuotientGroup.mk'_surjective H.toSubgroup q
+  exact ⟨d, hq⟩
+
+-- Coarsening is monotone but not strictly so; shrinking the argument by a `d` whose class
+-- exceeds `1` is what recovers a strict inequality, and is the only use of properness.
+private theorem coarsenMapOfValueGroup_mul_inv_lt {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
+    (H : ConvexSubgroup Γ₀ˣ) {d : Γ₀ˣ} (hd : 1 < QuotientGroup.mk' H.toSubgroup d) {g : Γ₀}
+    (hg : g ≠ 0) : coarsenMapOfValueGroup H (g * (d : Γ₀)⁻¹) < coarsenMapOfValueGroup H g := by
+  rw [map_mul, map_inv₀, coarsenMapOfValueGroup_apply_coe]
+  refine mul_lt_of_lt_one_right (zero_lt_iff.mpr (by simpa using hg)) ?_
+  exact_mod_cast inv_lt_one'.mpr hd
+
+end TauCeti
+
 namespace Valuation
 
 open TauCeti TauCeti.Huber MonoidWithZeroHom
@@ -63,70 +88,49 @@ open TauCeti TauCeti.Huber MonoidWithZeroHom
 variable {A : Type*} [CommRing A] [TopologicalSpace A]
 variable {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
 
-/-- **Wedhorn Remark 7.11(2).** A vertical generization of a continuous valuation by a proper
-convex subgroup of its value group is again continuous.
+omit [TopologicalSpace A] in
+-- Every positive element of the coarsened value group is a ratio of attained values; shrinking
+-- that ratio by `d⁻¹` turns the monotone image of a cofinal power into a strict bound.
+private theorem cofinalValue_coarsenByUnits_restrict {v : Valuation A Γ₀}
+    {H : ConvexSubgroup (ValueGroup₀ (.ofClass v))ˣ} {d : (ValueGroup₀ (.ofClass v))ˣ}
+    (hd : 1 < QuotientGroup.mk' H.toSubgroup d) {a : A} (hcof : CofinalValue v a) :
+    CofinalValue (v.restrict.coarsenByUnits H) a := by
+  rw [cofinalValue_iff]
+  intro γ hγ
+  obtain ⟨r, q, hr, hq, hrq⟩ :=
+    (v.restrict.coarsenByUnits H).exists_div_eq_of_unit (Units.mk0 γ hγ.ne')
+  simp only [Units.val_mk0] at hrq
+  have hrv : v.restrict r ≠ 0 := fun h ↦ by simp [h] at hr
+  have hqv : v.restrict q ≠ 0 := fun h ↦ by simp [h] at hq
+  obtain ⟨n, hn⟩ := cofinalValue_iff.mp hcof
+    (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹)
+    (by simp [zero_lt_iff, hrv, hqv, Units.ne_zero d])
+  refine ⟨n, ?_⟩
+  have hemb : ValueGroup₀.embedding γ =
+      (v.restrict.coarsenByUnits H) r / (v.restrict.coarsenByUnits H) q := by
+    rw [← hrq, map_div₀, Valuation.embedding_restrict, Valuation.embedding_restrict]
+  rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, hemb, coarsenByUnits_apply,
+    coarsenByUnits_apply, coarsenByUnits_apply, map_pow, ← map_div₀]
+  exact (coarsenMapOfValueGroup_monotone H hn.le).trans_lt
+    (coarsenMapOfValueGroup_mul_inv_lt H hd (div_ne_zero hrv hqv))
 
-The coarsening is taken on `v.restrict` rather than on `v`, so that `H ≠ ⊤` is properness in the
-value group, which is the hypothesis Wedhorn states. Properness enters only through the witness
-`d ∉ H` with `1 < d`: coarsening is monotone but not strictly so, and shrinking the target by
-`d⁻¹` is what recovers the strict inequality that cofinality requires. -/
+/-- **Wedhorn Remark 7.11(2).** A vertical generization of a continuous valuation by a proper
+convex subgroup of its value group is again continuous. -/
 theorem IsContinuous.coarsenByUnits_restrict [IsTopologicalRing A] [IsHuberRing A]
-    [ContinuousConstSMul Aᵐᵒᵖ A] {v : Valuation A Γ₀} (hv : v.IsContinuous)
-    {H : ConvexSubgroup (ValueGroup₀ (.ofClass v))ˣ} (hH : H ≠ ⊤) :
-    (v.restrict.coarsenByUnits H).IsContinuous := by
+    {v : Valuation A Γ₀} (hv : v.IsContinuous) {H : ConvexSubgroup (ValueGroup₀ (.ofClass v))ˣ}
+    (hH : H ≠ ⊤) : (v.restrict.coarsenByUnits H).IsContinuous := by
   obtain ⟨P⟩ := IsHuberRing.nonempty_pairOfDefinition (A := A)
   obtain ⟨s, hs⟩ := P.fg_idealOfDefinition
-  have hv' : v.restrict.IsContinuous := (v.isEquiv_restrict).isContinuous_iff.mp hv
-  obtain ⟨x, -, hxH⟩ := SetLike.exists_of_lt (lt_top_iff_ne_top.mpr hH)
-  have hx1 : x ≠ 1 := fun h ↦ hxH (h ▸ one_mem H)
-  obtain ⟨d, hd1, hdH⟩ : ∃ d : (ValueGroup₀ (.ofClass v))ˣ, 1 < d ∧ d ∉ H := by
-    rcases lt_or_gt_of_ne hx1 with hlt | hgt
-    · exact ⟨x⁻¹, by simpa using hlt, fun hmem ↦ hxH (by simpa using inv_mem hmem)⟩
-    · exact ⟨x, hgt, hxH⟩
-  have hdq : 1 < QuotientGroup.mk' H.toSubgroup d := by
-    have h := H.quotientMk_lt_one_of_notMem (a := d⁻¹) (by simpa using hd1.le)
-      (fun hmem ↦ hdH (by simpa using inv_mem hmem))
-    simpa using h
-  refine P.isContinuous_of_forall_cofinalValue _ hs ?_ ?_
-  · intro a ha
-    rw [coarsenByUnits_apply, ← map_one (coarsenMapOfValueGroup H)]
+  -- properness enters only through this witness, which the cofinality branch shrinks by
+  obtain ⟨d, hdq⟩ := ConvexSubgroup.exists_one_lt_quotientMk hH
+  refine P.isContinuous_of_forall_cofinalValue _ hs (fun a ha ↦ ?_) fun t ht ↦ ?_
+  · rw [coarsenByUnits_apply, ← map_one (coarsenMapOfValueGroup H)]
     exact coarsenMapOfValueGroup_monotone H
-      (hv'.lt_one_of_isTopologicallyNilpotent
+      ((v.isEquiv_restrict.isContinuous_iff.mp hv).lt_one_of_isTopologicallyNilpotent
         (P.isTopologicallyNilpotent_of_mem_idealOfDefinition ha)).le
-  · intro t ht
-    have hnil := P.isTopologicallyNilpotent_of_mem_idealOfDefinition (hs ▸ Ideal.subset_span ht)
-    have hcof : CofinalValue v (t : A) := hv.cofinalValue_of_isTopologicallyNilpotent hnil
-    rw [cofinalValue_iff]
-    intro γ hγ
-    obtain ⟨r, q, hr, hq, hrq⟩ :=
-      (v.restrict.coarsenByUnits H).exists_div_eq_of_unit (Units.mk0 γ hγ.ne')
-    simp only [Units.val_mk0] at hrq
-    have hrv : v.restrict r ≠ 0 := fun h ↦ by
-      rw [coarsenByUnits_apply, h, map_zero] at hr; exact lt_irrefl 0 hr
-    have hqv : v.restrict q ≠ 0 := fun h ↦ by
-      rw [coarsenByUnits_apply, h, map_zero] at hq; exact lt_irrefl 0 hq
-    obtain ⟨n, hn⟩ := cofinalValue_iff.mp hcof
-      (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹)
-      (by simp [zero_lt_iff, hrv, hqv, Units.ne_zero d])
-    refine ⟨n, ?_⟩
-    have hemb : ValueGroup₀.embedding γ =
-        (v.restrict.coarsenByUnits H) r / (v.restrict.coarsenByUnits H) q := by
-      rw [← hrq, map_div₀, Valuation.embedding_restrict, Valuation.embedding_restrict]
-    rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, hemb, coarsenByUnits_apply,
-      coarsenByUnits_apply, coarsenByUnits_apply, map_pow, ← map_div₀]
-    calc coarsenMapOfValueGroup H (v.restrict ↑t ^ n)
-        ≤ coarsenMapOfValueGroup H
-            (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹) :=
-          coarsenMapOfValueGroup_monotone H hn.le
-      _ < coarsenMapOfValueGroup H (v.restrict r / v.restrict q) := by
-          rw [map_mul, map_inv₀, coarsenMapOfValueGroup_apply_coe]
-          refine mul_lt_of_lt_one_right ?_ ?_
-          · refine zero_lt_iff.mpr ?_
-            rw [ne_eq, map_eq_zero, div_eq_zero_iff]
-            push Not
-            exact ⟨hrv, hqv⟩
-          · rw [← WithZero.coe_inv, WithZero.coe_lt_one]
-            simpa using hdq
+  · exact cofinalValue_coarsenByUnits_restrict hdq
+      (hv.cofinalValue_of_isTopologicallyNilpotent
+        (P.isTopologicallyNilpotent_of_mem_idealOfDefinition (hs ▸ Ideal.subset_span ht)))
 
 end Valuation
 

--- a/TauCeti/RingTheory/Huber/Continuous/Coarsen.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/Coarsen.lean
@@ -14,7 +14,9 @@ import TauCeti.RingTheory.Valuation.Continuous.TopologicallyNilpotent
 
 **Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Remark 7.11(2).**
 
-A vertical generization `v/H` of a continuous valuation on a Huber ring is again continuous.
+A vertical generization `v/H` of a continuous valuation on a Huber ring is again continuous. The
+cofinality half of the argument is topology-free and lives in
+`TauCeti.RingTheory.Valuation.Coarsen` as `Valuation.cofinalValue_coarsenByUnits_restrict`.
 Wedhorn states the hypothesis as `H ⊊ Γ_v`: the convex subgroup is proper **in the value group**,
 not in the ambient codomain. That is why the coarsening here is applied to `v.restrict`, which is
 the presentation of `v` on its own value group; `H ≠ ⊤` is then literally Wedhorn's properness.
@@ -27,8 +29,6 @@ support to be open — which it need not be.
 
 * `Valuation.IsContinuous.coarsenByUnits_restrict`: the coarsening of a continuous valuation by a
   proper convex subgroup of its value group is continuous.
-* `Valuation.cofinalValue_coarsenByUnits_restrict`: coarsening by a proper convex subgroup
-  preserves cofinality of a value, which is the half properness is needed for.
 
 ## References
 
@@ -37,66 +37,12 @@ support to be open — which it need not be.
 
 public section
 
-namespace TauCeti
-
--- Properness makes the quotient nontrivial, and a nontrivial linearly ordered commutative group
--- has an element above `1`; surjectivity of the quotient map pulls that element back to `Γ`.
-private theorem ConvexSubgroup.exists_one_lt_quotientMk {Γ : Type*} [CommGroup Γ] [LinearOrder Γ]
-    [IsOrderedMonoid Γ] {H : ConvexSubgroup Γ} (hH : H ≠ ⊤) :
-    ∃ d : Γ, 1 < QuotientGroup.mk' H.toSubgroup d := by
-  have : Nontrivial (Γ ⧸ H.toSubgroup) :=
-    QuotientGroup.nontrivial_iff.mpr fun h ↦
-      hH (toSubgroup_injective (h.trans top_toSubgroup.symm))
-  obtain ⟨q, hq⟩ := exists_one_lt' (α := Γ ⧸ H.toSubgroup)
-  obtain ⟨d, rfl⟩ := QuotientGroup.mk'_surjective H.toSubgroup q
-  exact ⟨d, hq⟩
-
--- Coarsening is monotone but not strictly so; shrinking the argument by a `d` whose class
--- exceeds `1` is what recovers a strict inequality, and is the only use of properness.
-private theorem coarsenMapOfValueGroup_mul_inv_lt {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
-    (H : ConvexSubgroup Γ₀ˣ) {d : Γ₀ˣ} (hd : 1 < QuotientGroup.mk' H.toSubgroup d) {g : Γ₀}
-    (hg : g ≠ 0) : coarsenMapOfValueGroup H (g * (d : Γ₀)⁻¹) < coarsenMapOfValueGroup H g := by
-  rw [map_mul, map_inv₀, coarsenMapOfValueGroup_apply_coe]
-  refine mul_lt_of_lt_one_right (zero_lt_iff.mpr (by simpa using hg)) ?_
-  exact_mod_cast inv_lt_one'.mpr hd
-
-end TauCeti
-
 namespace Valuation
 
 open TauCeti TauCeti.Huber MonoidWithZeroHom
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A]
 variable {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
-
-omit [TopologicalSpace A] in
-/-- **Coarsening by a proper convex subgroup preserves cofinality of a value.** This is the half of
-Wedhorn Remark 7.11(2) that properness is needed for: the coarsening map is monotone but not
-strictly so, and properness is exactly what supplies the room to recover a strict inequality. -/
-theorem cofinalValue_coarsenByUnits_restrict {v : Valuation A Γ₀}
-    {H : ConvexSubgroup (ValueGroup₀ (.ofClass v))ˣ} (hH : H ≠ ⊤) {a : A}
-    (hcof : CofinalValue v a) : CofinalValue (v.restrict.coarsenByUnits H) a := by
-  -- Every positive element of the coarsened value group is a ratio of attained values; shrinking
-  -- that ratio by `d⁻¹` turns the monotone image of a cofinal power into a strict bound.
-  obtain ⟨d, hd⟩ := ConvexSubgroup.exists_one_lt_quotientMk hH
-  rw [cofinalValue_iff]
-  intro γ hγ
-  obtain ⟨r, q, hr, hq, hrq⟩ :=
-    (v.restrict.coarsenByUnits H).exists_div_eq_of_unit (Units.mk0 γ hγ.ne')
-  simp only [Units.val_mk0] at hrq
-  have hrv : v.restrict r ≠ 0 := fun h ↦ by simp [h] at hr
-  have hqv : v.restrict q ≠ 0 := fun h ↦ by simp [h] at hq
-  obtain ⟨n, hn⟩ := cofinalValue_iff.mp hcof
-    (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹)
-    (by simp [zero_lt_iff, hrv, hqv, Units.ne_zero d])
-  refine ⟨n, ?_⟩
-  have hemb : ValueGroup₀.embedding γ =
-      (v.restrict.coarsenByUnits H) r / (v.restrict.coarsenByUnits H) q := by
-    rw [← hrq, map_div₀, Valuation.embedding_restrict, Valuation.embedding_restrict]
-  rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, hemb, coarsenByUnits_apply,
-    coarsenByUnits_apply, coarsenByUnits_apply, map_pow, ← map_div₀]
-  exact (coarsenMapOfValueGroup_monotone H hn.le).trans_lt
-    (coarsenMapOfValueGroup_mul_inv_lt H hd (div_ne_zero hrv hqv))
 
 /-- **Wedhorn Remark 7.11(2).** A vertical generization of a continuous valuation by a proper
 convex subgroup of its value group is again continuous. -/

--- a/TauCeti/RingTheory/Valuation/Coarsen.lean
+++ b/TauCeti/RingTheory/Valuation/Coarsen.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.RingTheory.Valuation.Basic
 public import TauCeti.Algebra.Order.Group.ConvexSubgroup
+public import TauCeti.RingTheory.Valuation.CharacteristicGroup
 
 /-!
 # Coarsening a valuation by a convex subgroup
@@ -29,6 +30,11 @@ facts the height-one generization of Wedhorn's Lemma 7.45 consumes.
 * `Valuation.coarsenByUnits_lt_one_of_notMem` : the collapse detects non-membership — a value
   at most `1` whose unit avoids `H` drops strictly below `1`. (Bounds by `1` come from
   `coarsenMapOfValueGroup_monotone` directly; no specialization is exported for them.)
+* `TauCeti.coarsenMapOfValueGroup_mul_inv_lt` : shrinking by a unit whose class exceeds `1`
+  strictly decreases the coarsened value — how a strict inequality is recovered from a map that
+  is only monotone.
+* `Valuation.cofinalValue_coarsenByUnits_restrict` : coarsening by a proper convex subgroup
+  preserves cofinality of a value. This needs no topology on `A`.
 
 ## Provenance
 
@@ -75,6 +81,17 @@ theorem coarsenMapOfValueGroup_apply_coe (H : ConvexSubgroup Γ₀ˣ) (g : Γ₀
   have h : ((OrderMonoidIso.withZeroUnits (α := Γ₀)).symm.toMonoidWithZeroHom (g : Γ₀))
       = (g : WithZero Γ₀ˣ) := WithZero.withZeroUnitsEquiv_symm_apply_coe g
   rw [coarsenMapOfValueGroup, MonoidWithZeroHom.comp_apply, h, WithZero.map'_coe]
+
+open Classical in
+/-- **Shrinking by a unit whose class exceeds `1` strictly decreases the coarsened value.** The
+coarsening map is monotone but not strictly so; this is how a strict inequality is recovered, and
+it is the only place a proper convex subgroup is needed. -/
+theorem coarsenMapOfValueGroup_mul_inv_lt (H : ConvexSubgroup Γ₀ˣ) {d : Γ₀ˣ}
+    (hd : 1 < QuotientGroup.mk' H.toSubgroup d) {g : Γ₀} (hg : g ≠ 0) :
+    coarsenMapOfValueGroup H (g * (d : Γ₀)⁻¹) < coarsenMapOfValueGroup H g := by
+  rw [map_mul, map_inv₀, coarsenMapOfValueGroup_apply_coe]
+  refine mul_lt_of_lt_one_right (zero_lt_iff.mpr (by simpa using hg)) ?_
+  exact_mod_cast inv_lt_one'.mpr hd
 
 end
 
@@ -124,6 +141,39 @@ theorem coarsenByUnits_supp (v : Valuation S Γ₀) (H : ConvexSubgroup Γ₀ˣ)
   simp only [mem_supp_iff, coarsenByUnits_apply, map_eq_zero]
 
 end Supp
+
+open MonoidWithZeroHom in
+/-- **Coarsening by a proper convex subgroup preserves cofinality of a value.** This is the half of
+Wedhorn Remark 7.11(2) that properness is needed for: the coarsening map is monotone but not
+strictly so, and properness is exactly what supplies the room to recover a strict inequality. -/
+theorem cofinalValue_coarsenByUnits_restrict {A : Type*} [Ring A] {v : Valuation A Γ₀}
+    {H : ConvexSubgroup (ValueGroup₀ (.ofClass v))ˣ} (hH : H ≠ ⊤) {a : A}
+    (hcof : CofinalValue v a) : CofinalValue (v.restrict.coarsenByUnits H) a := by
+  -- Every positive element of the coarsened value group is a ratio of attained values; shrinking
+  -- that ratio by `d⁻¹` turns the monotone image of a cofinal power into a strict bound.
+  have hnt : Nontrivial ((ValueGroup₀ (.ofClass v))ˣ ⧸ H.toSubgroup) :=
+    QuotientGroup.nontrivial_iff.mpr fun h ↦ hH (ConvexSubgroup.toSubgroup_injective
+      (h.trans ConvexSubgroup.top_toSubgroup.symm))
+  obtain ⟨x, hx⟩ := exists_one_lt' (α := (ValueGroup₀ (.ofClass v))ˣ ⧸ H.toSubgroup)
+  obtain ⟨d, rfl⟩ := QuotientGroup.mk'_surjective H.toSubgroup x
+  rw [cofinalValue_iff]
+  intro γ hγ
+  obtain ⟨r, q, hr, hq, hrq⟩ :=
+    (v.restrict.coarsenByUnits H).exists_div_eq_of_unit (Units.mk0 γ hγ.ne')
+  simp only [Units.val_mk0] at hrq
+  have hrv : v.restrict r ≠ 0 := fun h ↦ by simp [h] at hr
+  have hqv : v.restrict q ≠ 0 := fun h ↦ by simp [h] at hq
+  obtain ⟨n, hn⟩ := cofinalValue_iff.mp hcof
+    (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹)
+    (by simp [zero_lt_iff, hrv, hqv, Units.ne_zero d])
+  refine ⟨n, ?_⟩
+  have hemb : ValueGroup₀.embedding γ =
+      (v.restrict.coarsenByUnits H) r / (v.restrict.coarsenByUnits H) q := by
+    rw [← hrq, map_div₀, Valuation.embedding_restrict, Valuation.embedding_restrict]
+  rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, hemb, coarsenByUnits_apply,
+    coarsenByUnits_apply, coarsenByUnits_apply, map_pow, ← map_div₀]
+  exact (coarsenMapOfValueGroup_monotone H hn.le).trans_lt
+    (coarsenMapOfValueGroup_mul_inv_lt H hx (div_ne_zero hrv hqv))
 
 end
 

--- a/TauCeti/RingTheory/Valuation/Coarsen.lean
+++ b/TauCeti/RingTheory/Valuation/Coarsen.lean
@@ -6,7 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.RingTheory.Valuation.Basic
-public import TauCeti.Algebra.Order.Group.ConvexSubgroup
+public import TauCeti.Algebra.Order.Group.Cofinal
 public import TauCeti.RingTheory.Valuation.CharacteristicGroup
 
 /-!
@@ -30,9 +30,6 @@ facts the height-one generization of Wedhorn's Lemma 7.45 consumes.
 * `Valuation.coarsenByUnits_lt_one_of_notMem` : the collapse detects non-membership — a value
   at most `1` whose unit avoids `H` drops strictly below `1`. (Bounds by `1` come from
   `coarsenMapOfValueGroup_monotone` directly; no specialization is exported for them.)
-* `TauCeti.coarsenMapOfValueGroup_mul_inv_lt` : shrinking by a unit whose class exceeds `1`
-  strictly decreases the coarsened value — how a strict inequality is recovered from a map that
-  is only monotone.
 * `Valuation.cofinalValue_coarsenByUnits_restrict` : coarsening by a proper convex subgroup
   preserves cofinality of a value. This needs no topology on `A`.
 
@@ -46,11 +43,10 @@ shaped as in Mathlib's own `LinearOrderedCommGroupWithZero` locally-finite insta
 
 `Valuation.cofinalValue_coarsenByUnits_restrict` is not from that development. It is the
 topology-free cofinality ingredient of Wedhorn's Remark 7.11(2), not the remark itself: the
-continuity statement the remark makes is
-`TauCeti.Huber.IsContinuous.coarsenByUnits_restrict` in
+continuity statement the remark makes is `Valuation.IsContinuous.coarsenByUnits_restrict` in
 `TauCeti.RingTheory.Huber.Continuous.Coarsen`, which consumes this one. The order-level step it
-rests on is `TauCeti.coarsenMapOfValueGroup_mul_inv_lt`, together with
-`TauCeti.ConvexSubgroup.exists_one_lt_quotientMk`.
+rests on is `TauCeti.IsCofinalElement.quotientMk`, which is Wedhorn Corollary 1.21 and already on
+hand; nothing about strictness is redone here.
 
 ## References
 
@@ -90,18 +86,6 @@ theorem coarsenMapOfValueGroup_apply_coe (H : ConvexSubgroup Γ₀ˣ) (g : Γ₀
   have h : ((OrderMonoidIso.withZeroUnits (α := Γ₀)).symm.toMonoidWithZeroHom (g : Γ₀))
       = (g : WithZero Γ₀ˣ) := WithZero.withZeroUnitsEquiv_symm_apply_coe g
   rw [coarsenMapOfValueGroup, MonoidWithZeroHom.comp_apply, h, WithZero.map'_coe]
-
-open Classical in
-/-- **Shrinking by a unit whose class exceeds `1` strictly decreases the coarsened value.** The
-coarsening map is monotone but not strictly so; this is the step that recovers a strict
-inequality from it. The unit whose class exceeds `1` is supplied by properness of the convex
-subgroup, which the caller establishes. -/
-theorem coarsenMapOfValueGroup_mul_inv_lt (H : ConvexSubgroup Γ₀ˣ) {d : Γ₀ˣ}
-    (hd : 1 < QuotientGroup.mk' H.toSubgroup d) {g : Γ₀} (hg : g ≠ 0) :
-    coarsenMapOfValueGroup H (g * (d : Γ₀)⁻¹) < coarsenMapOfValueGroup H g := by
-  rw [map_mul, map_inv₀, coarsenMapOfValueGroup_apply_coe]
-  refine mul_lt_of_lt_one_right (zero_lt_iff.mpr (by simpa using hg)) ?_
-  exact_mod_cast inv_lt_one'.mpr hd
 
 end
 
@@ -156,38 +140,43 @@ end Supp
 open MonoidWithZeroHom in
 /-- **Coarsening by a proper convex subgroup preserves cofinality of a value.** This is the half of
 Wedhorn Remark 7.11(2) that properness is needed for: the coarsening map is monotone but not
-strictly so, and properness is exactly what supplies the room to recover a strict inequality. -/
+strictly so, and properness is exactly what supplies the room to recover a strict inequality.
+
+The recovery itself is not redone here. Cofinality of `v a` says that the powers of the unit
+`v a` fall below every element of the value group, which is `TauCeti.IsCofinalElement` for that
+group; `TauCeti.IsCofinalElement.quotientMk` — Wedhorn Corollary 1.21 — carries that to the
+quotient by `H`, and properness is the hypothesis it asks for. What is left is bookkeeping: the
+coarsened value monoid embeds in `WithZero (Γˣ ⧸ H)`, so a cofinal element of the *whole*
+quotient group is in particular below every value the coarsened valuation attains. -/
 theorem cofinalValue_coarsenByUnits_restrict {A : Type*} [Ring A] {v : Valuation A Γ₀}
     {H : ConvexSubgroup (ValueGroup₀ (.ofClass v))ˣ} (hH : H ≠ ⊤) {a : A}
     (hcof : CofinalValue v a) : CofinalValue (v.restrict.coarsenByUnits H) a := by
-  -- Every positive element of the coarsened value group is a ratio of attained values; shrinking
-  -- that ratio by `d⁻¹` turns the monotone image of a cofinal power into a strict bound.
-  obtain ⟨d, hx⟩ := H.exists_one_lt_quotientMk hH
-  rw [cofinalValue_iff]
-  intro γ hγ
-  obtain ⟨r, q, hr, hq, hrq⟩ :=
-    (v.restrict.coarsenByUnits H).exists_div_eq_of_unit (Units.mk0 γ hγ.ne')
-  simp only [Units.val_mk0] at hrq
-  have hrv : v.restrict r ≠ 0 := fun h ↦ by simp [h] at hr
-  have hqv : v.restrict q ≠ 0 := fun h ↦ by simp [h] at hq
-  obtain ⟨n, hn⟩ := cofinalValue_iff.mp hcof
-    (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹)
-    (by simp [zero_lt_iff, hrv, hqv, Units.ne_zero d])
-  refine ⟨n, ?_⟩
-  -- Both sides are coarsenings of values of `v`, so the comparison happens in `Γ₀`'s coarsened
-  -- value monoid: monotonicity carries the cofinal power across, and the `d⁻¹` factor is what
-  -- turns the resulting `≤` into `<`.
-  have hγ' : ValueGroup₀.embedding γ =
-      coarsenMapOfValueGroup H (v.restrict r / v.restrict q) := by
-    rw [← hrq, map_div₀, Valuation.embedding_restrict, coarsenByUnits_apply,
-      Valuation.embedding_restrict, coarsenByUnits_apply, ← map_div₀]
-  rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, hγ']
-  calc (v.restrict.coarsenByUnits H) (a ^ n)
-      = coarsenMapOfValueGroup H (v.restrict a ^ n) := by rw [coarsenByUnits_apply, map_pow]
-    _ ≤ coarsenMapOfValueGroup H (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹) :=
-        coarsenMapOfValueGroup_monotone H hn.le
-    _ < coarsenMapOfValueGroup H (v.restrict r / v.restrict q) :=
-        coarsenMapOfValueGroup_mul_inv_lt H hx (div_ne_zero hrv hqv)
+  rcases eq_or_ne (v.restrict a) 0 with h0 | h0
+  · -- a vanishing value stays vanishing, and `0` is below every positive element
+    rw [cofinalValue_iff]
+    intro γ hγ
+    have hz : (v.restrict.coarsenByUnits H).restrict a = 0 := by
+      rw [Valuation.restrict_eq_zero_iff, coarsenByUnits_apply, h0, map_zero]
+    exact ⟨1, by rwa [pow_one, hz]⟩
+  · set g : (ValueGroup₀ (.ofClass v))ˣ := Units.mk0 (v.restrict a) h0 with hgdef
+    -- cofinality of the value, read in the value group rather than the value monoid
+    have hcofg : TauCeti.IsCofinalElement (⊤ : Subgroup (ValueGroup₀ (.ofClass v))ˣ) g :=
+      isCofinalElement_def.mpr fun h _ ↦ by
+        obtain ⟨n, hn⟩ := cofinalValue_iff.mp hcof (h : ValueGroup₀ (.ofClass v))
+          (zero_lt_iff.mpr h.ne_zero)
+        exact ⟨n, by rwa [← Units.val_lt_val, Units.val_pow_eq_pow_val, hgdef, Units.val_mk0]⟩
+    have hquot := hcofg.quotientMk hH
+    rw [cofinalValue_iff]
+    intro γ hγ
+    -- a positive element of the coarsened value monoid embeds as the class of some `q`
+    have hemb : ValueGroup₀.embedding γ ≠ 0 := by simpa using hγ.ne'
+    obtain ⟨q, hq⟩ := WithZero.ne_zero_iff_exists.mp hemb
+    obtain ⟨n, hn⟩ := isCofinalElement_def.mp hquot q (Subgroup.mem_top q)
+    refine ⟨n, ?_⟩
+    rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, ← hq, coarsenByUnits_apply, map_pow,
+      ← Units.val_mk0 h0, ← hgdef, ← Units.val_pow_eq_pow_val, coarsenMapOfValueGroup_apply_coe,
+      map_pow]
+    exact_mod_cast hn
 
 end
 

--- a/TauCeti/RingTheory/Valuation/Coarsen.lean
+++ b/TauCeti/RingTheory/Valuation/Coarsen.lean
@@ -38,10 +38,15 @@ facts the height-one generization of Wedhorn's Lemma 7.45 consumes.
 
 ## Provenance
 
-Adapted from AINTLIB (see References), `projects/AdicSpaces/Adic spaces/ValuationCoarsening.lean`:
-the constructions and statements are that file's, with its local `WithZero.mapMonoidWithZeroHom`
-block replaced by Mathlib's `WithZero.map'` and the composite shaped as in Mathlib's own
-`LinearOrderedCommGroupWithZero` locally-finite instance.
+The coarsening construction itself is adapted from AINTLIB (see References),
+`projects/AdicSpaces/Adic spaces/ValuationCoarsening.lean`: `TauCeti.coarsenMapOfValueGroup`,
+`Valuation.coarsenByUnits` and the collapse statements about them are that file's, with its local
+`WithZero.mapMonoidWithZeroHom` block replaced by Mathlib's `WithZero.map'` and the composite
+shaped as in Mathlib's own `LinearOrderedCommGroupWithZero` locally-finite instance.
+
+`Valuation.cofinalValue_coarsenByUnits_restrict` is not from that development. It is Wedhorn's
+Remark 7.11(2), proved here from `TauCeti.coarsenMapOfValueGroup_mul_inv_lt` and
+`TauCeti.ConvexSubgroup.exists_one_lt_quotientMk`.
 
 ## References
 
@@ -117,16 +122,6 @@ theorem coarsenByUnits_apply (v : Valuation R Γ₀) (H : ConvexSubgroup Γ₀ˣ
     v.coarsenByUnits H r = coarsenMapOfValueGroup H (v r) :=
   Valuation.map_apply _ _ _ _
 
-open TauCeti MonoidWithZeroHom in
-/-- **The coarsened valuation's own restricted value is the coarsening of `v`'s.** This is the
-bridge between the two presentations: a comparison stated about `v.coarsenByUnits H` on its own
-value group becomes a comparison of coarsened values of `v`. -/
-private theorem embedding_restrict_coarsenByUnits (v : Valuation R Γ₀)
-    (H : ConvexSubgroup Γ₀ˣ) (x : R) :
-    ValueGroup₀.embedding ((v.coarsenByUnits H).restrict x)
-      = coarsenMapOfValueGroup H (v x) := by
-  rw [Valuation.embedding_restrict, coarsenByUnits_apply]
-
 /-- A value at most `1` whose unit avoids `H` lands strictly below `1` after coarsening. -/
 theorem coarsenByUnits_lt_one_of_notMem (v : Valuation R Γ₀) (H : ConvexSubgroup Γ₀ˣ)
     {a : R} (ha_ne : v a ≠ 0) (ha_le : v a ≤ 1)
@@ -180,8 +175,8 @@ theorem cofinalValue_coarsenByUnits_restrict {A : Type*} [Ring A] {v : Valuation
   -- turns the resulting `≤` into `<`.
   have hγ' : ValueGroup₀.embedding γ =
       coarsenMapOfValueGroup H (v.restrict r / v.restrict q) := by
-    rw [← hrq, map_div₀, embedding_restrict_coarsenByUnits, embedding_restrict_coarsenByUnits,
-      ← map_div₀]
+    rw [← hrq, map_div₀, Valuation.embedding_restrict, coarsenByUnits_apply,
+      Valuation.embedding_restrict, coarsenByUnits_apply, ← map_div₀]
   rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, hγ']
   calc (v.restrict.coarsenByUnits H) (a ^ n)
       = coarsenMapOfValueGroup H (v.restrict a ^ n) := by rw [coarsenByUnits_apply, map_pow]

--- a/TauCeti/RingTheory/Valuation/Coarsen.lean
+++ b/TauCeti/RingTheory/Valuation/Coarsen.lean
@@ -121,7 +121,7 @@ open TauCeti MonoidWithZeroHom in
 /-- **The coarsened valuation's own restricted value is the coarsening of `v`'s.** This is the
 bridge between the two presentations: a comparison stated about `v.coarsenByUnits H` on its own
 value group becomes a comparison of coarsened values of `v`. -/
-theorem embedding_restrict_coarsenByUnits (v : Valuation R Γ₀)
+private theorem embedding_restrict_coarsenByUnits (v : Valuation R Γ₀)
     (H : ConvexSubgroup Γ₀ˣ) (x : R) :
     ValueGroup₀.embedding ((v.coarsenByUnits H).restrict x)
       = coarsenMapOfValueGroup H (v x) := by
@@ -144,6 +144,7 @@ section Supp
 variable {S : Type*} [CommRing S] {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
 
 /-- Coarsening preserves the support. -/
+@[simp]
 theorem coarsenByUnits_supp (v : Valuation S Γ₀) (H : ConvexSubgroup Γ₀ˣ) :
     (v.coarsenByUnits H).supp = v.supp := by
   -- the coarsening map is a `→*₀` out of a `GroupWithZero`, so Mathlib's `map_eq_zero` already

--- a/TauCeti/RingTheory/Valuation/Coarsen.lean
+++ b/TauCeti/RingTheory/Valuation/Coarsen.lean
@@ -84,8 +84,9 @@ theorem coarsenMapOfValueGroup_apply_coe (H : ConvexSubgroup Γ₀ˣ) (g : Γ₀
 
 open Classical in
 /-- **Shrinking by a unit whose class exceeds `1` strictly decreases the coarsened value.** The
-coarsening map is monotone but not strictly so; this is how a strict inequality is recovered, and
-it is the only place a proper convex subgroup is needed. -/
+coarsening map is monotone but not strictly so; this is the step that recovers a strict
+inequality from it. The unit whose class exceeds `1` is supplied by properness of the convex
+subgroup, which the caller establishes. -/
 theorem coarsenMapOfValueGroup_mul_inv_lt (H : ConvexSubgroup Γ₀ˣ) {d : Γ₀ˣ}
     (hd : 1 < QuotientGroup.mk' H.toSubgroup d) {g : Γ₀} (hg : g ≠ 0) :
     coarsenMapOfValueGroup H (g * (d : Γ₀)⁻¹) < coarsenMapOfValueGroup H g := by
@@ -115,6 +116,16 @@ noncomputable def coarsenByUnits (v : Valuation R Γ₀) (H : ConvexSubgroup Γ�
 theorem coarsenByUnits_apply (v : Valuation R Γ₀) (H : ConvexSubgroup Γ₀ˣ) (r : R) :
     v.coarsenByUnits H r = coarsenMapOfValueGroup H (v r) :=
   Valuation.map_apply _ _ _ _
+
+open TauCeti MonoidWithZeroHom in
+/-- **The coarsened valuation's own restricted value is the coarsening of `v`'s.** This is the
+bridge between the two presentations: a comparison stated about `v.coarsenByUnits H` on its own
+value group becomes a comparison of coarsened values of `v`. -/
+theorem embedding_restrict_coarsenByUnits (v : Valuation R Γ₀)
+    (H : ConvexSubgroup Γ₀ˣ) (x : R) :
+    ValueGroup₀.embedding ((v.coarsenByUnits H).restrict x)
+      = coarsenMapOfValueGroup H (v x) := by
+  rw [Valuation.embedding_restrict, coarsenByUnits_apply]
 
 /-- A value at most `1` whose unit avoids `H` lands strictly below `1` after coarsening. -/
 theorem coarsenByUnits_lt_one_of_notMem (v : Valuation R Γ₀) (H : ConvexSubgroup Γ₀ˣ)
@@ -167,13 +178,20 @@ theorem cofinalValue_coarsenByUnits_restrict {A : Type*} [Ring A] {v : Valuation
     (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹)
     (by simp [zero_lt_iff, hrv, hqv, Units.ne_zero d])
   refine ⟨n, ?_⟩
-  have hemb : ValueGroup₀.embedding γ =
-      (v.restrict.coarsenByUnits H) r / (v.restrict.coarsenByUnits H) q := by
-    rw [← hrq, map_div₀, Valuation.embedding_restrict, Valuation.embedding_restrict]
-  rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, hemb, coarsenByUnits_apply,
-    coarsenByUnits_apply, coarsenByUnits_apply, map_pow, ← map_div₀]
-  exact (coarsenMapOfValueGroup_monotone H hn.le).trans_lt
-    (coarsenMapOfValueGroup_mul_inv_lt H hx (div_ne_zero hrv hqv))
+  -- Both sides are coarsenings of values of `v`, so the comparison happens in `Γ₀`'s coarsened
+  -- value monoid: monotonicity carries the cofinal power across, and the `d⁻¹` factor is what
+  -- turns the resulting `≤` into `<`.
+  have hγ' : ValueGroup₀.embedding γ =
+      coarsenMapOfValueGroup H (v.restrict r / v.restrict q) := by
+    rw [← hrq, map_div₀, embedding_restrict_coarsenByUnits, embedding_restrict_coarsenByUnits,
+      ← map_div₀]
+  rw [← map_pow, Valuation.restrict_lt_iff_lt_embedding, hγ']
+  calc (v.restrict.coarsenByUnits H) (a ^ n)
+      = coarsenMapOfValueGroup H (v.restrict a ^ n) := by rw [coarsenByUnits_apply, map_pow]
+    _ ≤ coarsenMapOfValueGroup H (v.restrict r / v.restrict q * (d : ValueGroup₀ (.ofClass v))⁻¹) :=
+        coarsenMapOfValueGroup_monotone H hn.le
+    _ < coarsenMapOfValueGroup H (v.restrict r / v.restrict q) :=
+        coarsenMapOfValueGroup_mul_inv_lt H hx (div_ne_zero hrv hqv)
 
 end
 

--- a/TauCeti/RingTheory/Valuation/Coarsen.lean
+++ b/TauCeti/RingTheory/Valuation/Coarsen.lean
@@ -163,11 +163,7 @@ theorem cofinalValue_coarsenByUnits_restrict {A : Type*} [Ring A] {v : Valuation
     (hcof : CofinalValue v a) : CofinalValue (v.restrict.coarsenByUnits H) a := by
   -- Every positive element of the coarsened value group is a ratio of attained values; shrinking
   -- that ratio by `d⁻¹` turns the monotone image of a cofinal power into a strict bound.
-  have hnt : Nontrivial ((ValueGroup₀ (.ofClass v))ˣ ⧸ H.toSubgroup) :=
-    QuotientGroup.nontrivial_iff.mpr fun h ↦ hH (ConvexSubgroup.toSubgroup_injective
-      (h.trans ConvexSubgroup.top_toSubgroup.symm))
-  obtain ⟨x, hx⟩ := exists_one_lt' (α := (ValueGroup₀ (.ofClass v))ˣ ⧸ H.toSubgroup)
-  obtain ⟨d, rfl⟩ := QuotientGroup.mk'_surjective H.toSubgroup x
+  obtain ⟨d, hx⟩ := H.exists_one_lt_quotientMk hH
   rw [cofinalValue_iff]
   intro γ hγ
   obtain ⟨r, q, hr, hq, hrq⟩ :=

--- a/TauCeti/RingTheory/Valuation/Coarsen.lean
+++ b/TauCeti/RingTheory/Valuation/Coarsen.lean
@@ -44,8 +44,12 @@ The coarsening construction itself is adapted from AINTLIB (see References),
 `WithZero.mapMonoidWithZeroHom` block replaced by Mathlib's `WithZero.map'` and the composite
 shaped as in Mathlib's own `LinearOrderedCommGroupWithZero` locally-finite instance.
 
-`Valuation.cofinalValue_coarsenByUnits_restrict` is not from that development. It is Wedhorn's
-Remark 7.11(2), proved here from `TauCeti.coarsenMapOfValueGroup_mul_inv_lt` and
+`Valuation.cofinalValue_coarsenByUnits_restrict` is not from that development. It is the
+topology-free cofinality ingredient of Wedhorn's Remark 7.11(2), not the remark itself: the
+continuity statement the remark makes is
+`TauCeti.Huber.IsContinuous.coarsenByUnits_restrict` in
+`TauCeti.RingTheory.Huber.Continuous.Coarsen`, which consumes this one. The order-level step it
+rests on is `TauCeti.coarsenMapOfValueGroup_mul_inv_lt`, together with
 `TauCeti.ConvexSubgroup.exists_one_lt_quotientMk`.
 
 ## References


### PR DESCRIPTION
A vertical generization `v/H` of a continuous valuation on a Huber ring is again continuous —
Wedhorn's Remark 7.11(2). `main` already has the coarsening construction and the order-level
cofinality it rests on; this supplies the continuity statement, which is what a consumer actually
needs.

parent: #5590

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-2.3-remark-7.11-2"}-->

## The roadmap target

`TauCetiRoadmap/AdicSpaces/README.md`, section **2.3 The plus ring, emptiness, and analytic points**
(heading at line 407), at line 427:

> Prove Proposition 7.49(2), including the criterion for this locus to be empty; Remark 7.50 gives a
> second proof that a complete affinoid with empty analytic locus is discrete

Remark 7.11(2) is what 7.49(2) reaches for when it produces a height-one generization of a
continuous valuation and needs that generization to be a point of `Spa` rather than merely of `Spv`.
This is **Layer 2.3**, so the ordering question that applies to Layer 4.1 material does not arise
here — everything 7.11(2) consumes is on `main` today.

## What `main` has, and the gap

| | |
|---|---|
| `Valuation.coarsenByUnits` (`RingTheory/Valuation/Coarsen.lean:92`) | the coarsening construction itself |
| `TauCeti.IsCofinalElement.quotientMk` | Wedhorn Corollary 1.21, the cofinality step, at the **order** level |
| `PairOfDefinition.isContinuous_of_forall_cofinalValue` | Remark 7.11(1), the cofinal-value criterion |
| continuity of the **coarsened valuation** | **absent** — this PR |

A note on the probe, because this bead has a history of false absences: `main` spells the object
`coarsenByUnits`, not `verticalGeneriz…`. Searching the latter returns nothing and reads as "already
absent" for the wrong reason. The sweep here uses `coarsenByUnits` as the control — it fires at
`Coarsen.lean:92` — and `coarsenByUnits_restrict` returns zero files.

## Where the pieces live

Two files, and no new order-theoretic surface. `Huber/Continuous/Coarsen.lean` holds the continuity
theorem; `RingTheory/Valuation/Coarsen.lean` gains the topology-free cofinality statement beside the
coarsening construction it is about.

Round 3's reuse finding is what shaped this. The cofinality proof no longer recovers strictness for
itself: it reads the value as a unit of the value group, hands that to
`TauCeti.IsCofinalElement.quotientMk` — Wedhorn Corollary 1.21, already on `main` — and then does
only the bookkeeping that gets back to the coarsened value monoid. That deleted the two helper
lemmas the earlier proof needed (`ConvexSubgroup.exists_one_lt_quotientMk` and
`coarsenMapOfValueGroup_mul_inv_lt`), so `Algebra/Order/Group/ConvexSubgroup.lean` is untouched by
this PR now.

The bookkeeping does not need the value group of the coarsened valuation to be identified with
`Γˣ ⧸ H`, which would be a value-group functoriality development in its own right. It needs only
that the coarsened value monoid *embeds* in `WithZero (Γˣ ⧸ H)`: cofinality against the whole
quotient group is the stronger statement, so restricting it to the attained values is free.

## The statement, and why properness is not decoration

`Valuation.IsContinuous.coarsenByUnits_restrict`: the coarsening of a continuous valuation by a
**proper** convex subgroup of its value group is continuous.

Wedhorn states the hypothesis as `H ⊊ Γ_v` — proper in the *value group*, not in the ambient
codomain — which is why the coarsening is applied to `v.restrict`, the presentation of `v` on its own
value group; `H ≠ ⊤` is then literally Wedhorn's condition. If `H` were all of `Γ_v` the coarsening
would take only the values `0` and `1`, so `{a | w a < w b}` would be the support of `v`, and
continuity would force that support to be open, which it need not be.

The proof rebuilds continuity from the cofinal-value criterion. Two things must survive the
coarsening: the bound `v a ≤ 1` on an ideal of definition, which is monotonicity; and cofinality of
`v a` there, which is Corollary 1.21. Only the second uses properness, and exactly once — a monotone
map gives `≤`, and a witness `d ∉ H` with `1 < d` is what turns that into the strict inequality
cofinality asks for.

## Sources

Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Remark 7.11 and Corollary 1.21. Deliberately **not**
routed through Lemma 7.44, which is not an authorized target on this line; 7.44 appears nowhere in
the file. No code is adapted from another repository, so there is no `Provenance:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1

