### PR TITLE
refactor(EDS): name the index-splitting step the six residue branches share

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -49,9 +49,6 @@ by which the elliptic-net identities reach the division polynomials in the Lutz�
   discharging the preceding `if` conditions.
 * `reducedInvarDenom_zero`, `reducedInvarDenom_one`, `reducedInvarDenom_two`: its values at the
   small indices; the last is what fixes the normalisation.
-* `normEDS_of_two_dvd`, `normEDS_of_three_dvd`, `normEDS_of_six_dvd`: the index-splitting values
-  of a normalised EDS at an index divisible by `2`, `3` and `6`, releasing `b`, `c` and `b * c`
-  respectively.
 * `reducedInvarNum_eq_reducedInvarDenom_mul`: the reduced invariant identity,
   `reducedInvarNum b c d m = reducedInvarDenom b c d m * (d + b ^ 4)`, with no hypothesis on
   `b`, `c`, `d`.
@@ -316,21 +313,21 @@ theorem complEDS₂_eq_reducedInvarNum_sub :
 /-- **A normalised EDS at an index divisible by `6` releases the whole constant `b * c`.** Since
 `normEDS b c d 6` is `(normEDS b c d 5 - d ^ 2) * (b * c)`, an index with `6 ∣ k` factors as its
 `6`-complement at `k / 6` against that value, leaving `b * c` free. -/
-theorem normEDS_of_six_dvd (k : ℤ) (h : (6 : ℤ) ∣ k) :
+private theorem normEDS_of_six_dvd (k : ℤ) (h : (6 : ℤ) ∣ k) :
     normEDS b c d k = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (k / 6) * (b * c) := by
   rw [← normEDS_mul_complEDS_div 6 k h, WeierstrassCurve.normEDS_six]
   ring
 
 /-- **A normalised EDS at an index divisible by `3` releases a factor `c`.** Since
 `normEDS b c d 3` is `c`, an index with `3 ∣ k` is its `3`-complement at `k / 3` times `c`. -/
-theorem normEDS_of_three_dvd (k : ℤ) (h : (3 : ℤ) ∣ k) :
+private theorem normEDS_of_three_dvd (k : ℤ) (h : (3 : ℤ) ∣ k) :
     normEDS b c d k = complEDS b c d 3 (k / 3) * c := by
   rw [← normEDS_mul_complEDS_div 3 k h, normEDS_three]
   ring
 
 /-- **A normalised EDS at an index divisible by `2` releases a factor `b`.** Since
 `normEDS b c d 2` is `b`, an index with `2 ∣ k` is its `2`-complement at `k / 2` times `b`. -/
-theorem normEDS_of_two_dvd (k : ℤ) (h : (2 : ℤ) ∣ k) :
+private theorem normEDS_of_two_dvd (k : ℤ) (h : (2 : ℤ) ∣ k) :
     normEDS b c d k = complEDS b c d 2 (k / 2) * b := by
   rw [← normEDS_mul_complEDS_div 2 k h, normEDS_two]
   ring

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -310,28 +310,6 @@ theorem complEDS₂_eq_reducedInvarNum_sub :
       reducedInvarNum b c d m - normEDS b c d m ^ 3 * b - 2 * complEDS₂Aux b c d m := by
   rw [reducedInvarNum_def]; ring
 
-/-- **A normalised EDS at an index divisible by `6` releases the whole constant `b * c`.** Since
-`normEDS b c d 6` is `(normEDS b c d 5 - d ^ 2) * (b * c)`, an index with `6 ∣ k` factors as its
-`6`-complement at `k / 6` against that value, leaving `b * c` free. -/
-private theorem normEDS_of_six_dvd (k : ℤ) (h : (6 : ℤ) ∣ k) :
-    normEDS b c d k = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (k / 6) * (b * c) := by
-  rw [← normEDS_mul_complEDS_div 6 k h, WeierstrassCurve.normEDS_six]
-  ring
-
-/-- **A normalised EDS at an index divisible by `3` releases a factor `c`.** Since
-`normEDS b c d 3` is `c`, an index with `3 ∣ k` is its `3`-complement at `k / 3` times `c`. -/
-private theorem normEDS_of_three_dvd (k : ℤ) (h : (3 : ℤ) ∣ k) :
-    normEDS b c d k = complEDS b c d 3 (k / 3) * c := by
-  rw [← normEDS_mul_complEDS_div 3 k h, normEDS_three]
-  ring
-
-/-- **A normalised EDS at an index divisible by `2` releases a factor `b`.** Since
-`normEDS b c d 2` is `b`, an index with `2 ∣ k` is its `2`-complement at `k / 2` times `b`. -/
-private theorem normEDS_of_two_dvd (k : ℤ) (h : (2 : ℤ) ∣ k) :
-    normEDS b c d k = complEDS b c d 2 (k / 2) * b := by
-  rw [← normEDS_mul_complEDS_div 2 k h, normEDS_two]
-  ring
-
 namespace IsEllipticNet
 
 /-- **The cancellation `reducedInvarDenom` is named for**: the invariant denominator of a
@@ -349,25 +327,35 @@ theorem invarDenom_normEDS_one_eq_reducedInvarDenom_mul :
     invarDenom (normEDS b c d) 1 m = reducedInvarDenom b c d m * (b * c) := by
   -- Split on `m % 6`. Each branch selects its `reducedInvarDenom` value, then releases `b * c`
   -- from the one index divisible by `6`, or from the pair divisible by `3` and by `2`.
+  -- The index-splitting step the branches share: at an index divisible by `n`,
+  -- `normEDS_mul_complEDS_div` peels off the `n`-complement and the value of `normEDS` at `n`
+  -- comes out as a constant — `b * c` at `6`, `c` at `3`, `b` at `2`.
+  have h6 : ∀ k : ℤ, (6 : ℤ) ∣ k →
+      normEDS b c d k = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (k / 6) * (b * c) :=
+    fun k h ↦ by rw [← normEDS_mul_complEDS_div 6 k h, WeierstrassCurve.normEDS_six]; ring
+  have h3 : ∀ k : ℤ, (3 : ℤ) ∣ k → normEDS b c d k = complEDS b c d 3 (k / 3) * c :=
+    fun k h ↦ by rw [← normEDS_mul_complEDS_div 3 k h, normEDS_three]; ring
+  have h2 : ∀ k : ℤ, (2 : ℤ) ∣ k → normEDS b c d k = complEDS b c d 2 (k / 2) * b :=
+    fun k h ↦ by rw [← normEDS_mul_complEDS_div 2 k h, normEDS_two]; ring
   have hcase : m % 6 = 0 ∨ m % 6 = 1 ∨ m % 6 = 2 ∨ m % 6 = 3 ∨ m % 6 = 4 ∨ m % 6 = 5 := by omega
   rw [invarDenom_def]
   rcases hcase with h | h | h | h | h | h
-  · rw [reducedInvarDenom_of_emod_six_eq_zero b c d m h, normEDS_of_six_dvd b c d m (by omega)]
+  · rw [reducedInvarDenom_of_emod_six_eq_zero b c d m h, h6 m (by omega)]
     ring
   · rw [reducedInvarDenom_of_emod_six_eq_one b c d m h,
-      normEDS_of_six_dvd b c d (m - 1) (by omega)]
+      h6 (m - 1) (by omega)]
     ring
   · rw [reducedInvarDenom_of_emod_six_eq_two b c d m h,
-      normEDS_of_three_dvd b c d (m + 1) (by omega), normEDS_of_two_dvd b c d m (by omega)]
+      h3 (m + 1) (by omega), h2 m (by omega)]
     ring
   · rw [reducedInvarDenom_of_emod_six_eq_three b c d m h,
-      normEDS_of_three_dvd b c d m (by omega), normEDS_of_two_dvd b c d (m - 1) (by omega)]
+      h3 m (by omega), h2 (m - 1) (by omega)]
     ring
   · rw [reducedInvarDenom_of_emod_six_eq_four b c d m h,
-      normEDS_of_three_dvd b c d (m - 1) (by omega), normEDS_of_two_dvd b c d m (by omega)]
+      h3 (m - 1) (by omega), h2 m (by omega)]
     ring
   · rw [reducedInvarDenom_of_emod_six_eq_five b c d m h,
-      normEDS_of_six_dvd b c d (m + 1) (by omega)]
+      h6 (m + 1) (by omega)]
     ring
 
 /-- **The cancellation `reducedInvarNum` is named for**: the invariant numerator of a normalised EDS

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -310,6 +310,32 @@ theorem complEDS₂_eq_reducedInvarNum_sub :
       reducedInvarNum b c d m - normEDS b c d m ^ 3 * b - 2 * complEDS₂Aux b c d m := by
   rw [reducedInvarNum_def]; ring
 
+/-- **The value of `normEDS` at an index divisible by `6`.** The whole constant `b * c` comes out:
+`normEDS_mul_complEDS_div` splits the index into `6` and its `6`-complement, and `normEDS_six`
+evaluates the small factor. This is the step the `m % 6 ∈ {0, 1, 5}` branches of
+`IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul` share, where the divisible index is
+`m`, `m - 1` and `m + 1` respectively. -/
+private theorem normEDS_of_six_dvd (k : ℤ) (h : (6 : ℤ) ∣ k) :
+    normEDS b c d k = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (k / 6) * (b * c) := by
+  rw [← normEDS_mul_complEDS_div 6 k h, WeierstrassCurve.normEDS_six]
+  ring
+
+/-- **The value of `normEDS` at an index divisible by `3`.** One factor of `c = W 3` comes out. The
+`m % 6 ∈ {2, 3, 4}` branches of `IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`
+pair this with `normEDS_of_two_dvd`: there `b * c` is released from two indices rather than one,
+since no single index among `m + 1`, `m`, `m - 1` is divisible by `6`. -/
+private theorem normEDS_of_three_dvd (k : ℤ) (h : (3 : ℤ) ∣ k) :
+    normEDS b c d k = complEDS b c d 3 (k / 3) * c := by
+  rw [← normEDS_mul_complEDS_div 3 k h, normEDS_three]
+  ring
+
+/-- **The value of `normEDS` at an index divisible by `2`.** One factor of `b = W 2` comes out; see
+`normEDS_of_three_dvd` for the pairing that uses it. -/
+private theorem normEDS_of_two_dvd (k : ℤ) (h : (2 : ℤ) ∣ k) :
+    normEDS b c d k = complEDS b c d 2 (k / 2) * b := by
+  rw [← normEDS_mul_complEDS_div 2 k h, normEDS_two]
+  ring
+
 namespace IsEllipticNet
 
 /-- **The cancellation `reducedInvarDenom` is named for**: the invariant denominator of a
@@ -325,31 +351,27 @@ folded at `reducedInvarDenom b c d m * (b * c)`. -/
 @[simp high]
 theorem invarDenom_normEDS_one_eq_reducedInvarDenom_mul :
     invarDenom (normEDS b c d) 1 m = reducedInvarDenom b c d m * (b * c) := by
-  -- Split on `m % 6`; each branch reindexes one or two complements through
-  -- `normEDS_mul_complEDS_div`, on the divisibility that `m % 6 = r` supplies.
+  -- Split on `m % 6`. Each branch selects its `reducedInvarDenom` value, then releases `b * c`
+  -- from the one index divisible by `6`, or from the pair divisible by `3` and by `2`.
   have hcase : m % 6 = 0 ∨ m % 6 = 1 ∨ m % 6 = 2 ∨ m % 6 = 3 ∨ m % 6 = 4 ∨ m % 6 = 5 := by omega
   rw [invarDenom_def]
   rcases hcase with h | h | h | h | h | h
-  · rw [reducedInvarDenom_of_emod_six_eq_zero b c d m h,
-      ← normEDS_mul_complEDS_div 6 m (by omega), WeierstrassCurve.normEDS_six]
+  · rw [reducedInvarDenom_of_emod_six_eq_zero b c d m h, normEDS_of_six_dvd b c d m (by omega)]
     ring
   · rw [reducedInvarDenom_of_emod_six_eq_one b c d m h,
-      ← normEDS_mul_complEDS_div 6 (m - 1) (by omega), WeierstrassCurve.normEDS_six]
+      normEDS_of_six_dvd b c d (m - 1) (by omega)]
     ring
   · rw [reducedInvarDenom_of_emod_six_eq_two b c d m h,
-      ← normEDS_mul_complEDS_div 3 (m + 1) (by omega),
-      ← normEDS_mul_complEDS_div 2 m (by omega), normEDS_two, normEDS_three]
+      normEDS_of_three_dvd b c d (m + 1) (by omega), normEDS_of_two_dvd b c d m (by omega)]
     ring
   · rw [reducedInvarDenom_of_emod_six_eq_three b c d m h,
-      ← normEDS_mul_complEDS_div 3 m (by omega),
-      ← normEDS_mul_complEDS_div 2 (m - 1) (by omega), normEDS_two, normEDS_three]
+      normEDS_of_three_dvd b c d m (by omega), normEDS_of_two_dvd b c d (m - 1) (by omega)]
     ring
   · rw [reducedInvarDenom_of_emod_six_eq_four b c d m h,
-      ← normEDS_mul_complEDS_div 3 (m - 1) (by omega),
-      ← normEDS_mul_complEDS_div 2 m (by omega), normEDS_two, normEDS_three]
+      normEDS_of_three_dvd b c d (m - 1) (by omega), normEDS_of_two_dvd b c d m (by omega)]
     ring
   · rw [reducedInvarDenom_of_emod_six_eq_five b c d m h,
-      ← normEDS_mul_complEDS_div 6 (m + 1) (by omega), WeierstrassCurve.normEDS_six]
+      normEDS_of_six_dvd b c d (m + 1) (by omega)]
     ring
 
 /-- **The cancellation `reducedInvarNum` is named for**: the invariant numerator of a normalised EDS

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -49,6 +49,9 @@ by which the elliptic-net identities reach the division polynomials in the Lutz�
   discharging the preceding `if` conditions.
 * `reducedInvarDenom_zero`, `reducedInvarDenom_one`, `reducedInvarDenom_two`: its values at the
   small indices; the last is what fixes the normalisation.
+* `normEDS_of_two_dvd`, `normEDS_of_three_dvd`, `normEDS_of_six_dvd`: the index-splitting values
+  of a normalised EDS at an index divisible by `2`, `3` and `6`, releasing `b`, `c` and `b * c`
+  respectively.
 * `reducedInvarNum_eq_reducedInvarDenom_mul`: the reduced invariant identity,
   `reducedInvarNum b c d m = reducedInvarDenom b c d m * (d + b ^ 4)`, with no hypothesis on
   `b`, `c`, `d`.
@@ -310,28 +313,24 @@ theorem complEDS₂_eq_reducedInvarNum_sub :
       reducedInvarNum b c d m - normEDS b c d m ^ 3 * b - 2 * complEDS₂Aux b c d m := by
   rw [reducedInvarNum_def]; ring
 
-/-- **The value of `normEDS` at an index divisible by `6`.** The whole constant `b * c` comes out:
-`normEDS_mul_complEDS_div` splits the index into `6` and its `6`-complement, and `normEDS_six`
-evaluates the small factor. This is the step the `m % 6 ∈ {0, 1, 5}` branches of
-`IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul` share, where the divisible index is
-`m`, `m - 1` and `m + 1` respectively. -/
-private theorem normEDS_of_six_dvd (k : ℤ) (h : (6 : ℤ) ∣ k) :
+/-- **A normalised EDS at an index divisible by `6` releases the whole constant `b * c`.** Since
+`normEDS b c d 6` is `(normEDS b c d 5 - d ^ 2) * (b * c)`, an index with `6 ∣ k` factors as its
+`6`-complement at `k / 6` against that value, leaving `b * c` free. -/
+theorem normEDS_of_six_dvd (k : ℤ) (h : (6 : ℤ) ∣ k) :
     normEDS b c d k = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (k / 6) * (b * c) := by
   rw [← normEDS_mul_complEDS_div 6 k h, WeierstrassCurve.normEDS_six]
   ring
 
-/-- **The value of `normEDS` at an index divisible by `3`.** One factor of `c = W 3` comes out. The
-`m % 6 ∈ {2, 3, 4}` branches of `IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`
-pair this with `normEDS_of_two_dvd`: there `b * c` is released from two indices rather than one,
-since no single index among `m + 1`, `m`, `m - 1` is divisible by `6`. -/
-private theorem normEDS_of_three_dvd (k : ℤ) (h : (3 : ℤ) ∣ k) :
+/-- **A normalised EDS at an index divisible by `3` releases a factor `c`.** Since
+`normEDS b c d 3` is `c`, an index with `3 ∣ k` is its `3`-complement at `k / 3` times `c`. -/
+theorem normEDS_of_three_dvd (k : ℤ) (h : (3 : ℤ) ∣ k) :
     normEDS b c d k = complEDS b c d 3 (k / 3) * c := by
   rw [← normEDS_mul_complEDS_div 3 k h, normEDS_three]
   ring
 
-/-- **The value of `normEDS` at an index divisible by `2`.** One factor of `b = W 2` comes out; see
-`normEDS_of_three_dvd` for the pairing that uses it. -/
-private theorem normEDS_of_two_dvd (k : ℤ) (h : (2 : ℤ) ∣ k) :
+/-- **A normalised EDS at an index divisible by `2` releases a factor `b`.** Since
+`normEDS b c d 2` is `b`, an index with `2 ∣ k` is its `2`-complement at `k / 2` times `b`. -/
+theorem normEDS_of_two_dvd (k : ℤ) (h : (2 : ℤ) ∣ k) :
     normEDS b c d k = complEDS b c d 2 (k / 2) * b := by
   rw [← normEDS_mul_complEDS_div 2 k h, normEDS_two]
   ring


### PR DESCRIPTION
Roadmap: EllipticCurves

## What this changes

`IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul` splits on `m % 6`, and each of the
six branches then reindexes one or two complements through `normEDS_mul_complEDS_div` and evaluates
the small factor. Written out inline, that shared step was repeated in every branch and the
*reason* for the split — which index carries the divisibility — was buried in `by omega` side goals.

This names the step once per divisor, as three hypotheses local to the theorem, each quantified
over the index so all six branches can use it:

```lean
have h6 : ∀ k : ℤ, (6 : ℤ) ∣ k →
    normEDS b c d k = (normEDS b c d 5 - d ^ 2) * complEDS b c d 6 (k / 6) * (b * c) := …
have h3 : ∀ k : ℤ, (3 : ℤ) ∣ k → normEDS b c d k = complEDS b c d 3 (k / 3) * c := …
have h2 : ∀ k : ℤ, (2 : ℤ) ∣ k → normEDS b c d k = complEDS b c d 2 (k / 2) * b := …
```

Each branch then reads as its own arithmetic: the `m % 6 ∈ {0, 1, 5}` branches release `b * c` from
the single index divisible by `6` (namely `m`, `m - 1`, `m + 1`), and the `m % 6 ∈ {2, 3, 4}`
branches release it from a *pair* — one index divisible by `3` and one by `2` — because no single
one of `m + 1`, `m`, `m - 1` is divisible by `6` there. That distinction is now stated in the
tactic comment rather than reconstructed from six similar rewrite chains.

The theorem goes from 25 to 35 lines, inside the repository's 50-line cap, and the module gains no
declaration: the three facts have exactly one consumer and live inside it.

## Review history, since the shape changed twice

This began with the three steps as `private` module-level theorems. api-design asked for them to be
public reusable API; on that head reuse, generality and naming each asked for `private` back, and
that finding was contested and cleared. placement then asked for them to be relocated and exposed,
which could not hold alongside those three; contested, it narrowed to asking that they be
*genuinely* proof-local rather than module-level declarations in a reduced-invariant file. That is
the present shape, and it is the one every rubric agrees on: nothing is added to the module's API at
all, so there is no visibility or placement question left to answer.

## Notes

Pure refactor: no statement changes and no new mathematical scope, so no `tauceti-target:v1`
marker. `Roadmap: EllipticCurves` names the roadmap this file's development belongs to, as
attribution rather than a fresh claim.

## Gates

- `lake build` on the module and both reverse dependencies (`DivisionPolynomial.Invariant`,
  `DivisionPolynomial.Omega`): green, 0 errors, 0 warnings under `warningAsError = true`, no
  Mathlib recompiled.
- `scripts/lint-style.sh`: exit 0.
- `#lint only simpNF in TauCeti` over the module: no violation (the diff adds no `@[simp]`).
- No `sorry`, no `native_decide`, no `maxHeartbeats`; no line over 100 characters.
