### PR TITLE
feat(DedekindDomain): the adic completion integers are a complete adic Henselian local ring

### DIFF
--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
+public import Mathlib.RingTheory.AdicCompletion.Topology
+public import Mathlib.RingTheory.Henselian
 public import TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion
 public import TauCeti.RingTheory.DedekindDomain.Ideal
 public import TauCeti.RingTheory.DedekindDomain.ValuationOfNeZero
@@ -50,6 +52,10 @@ global étale algebra with its images in the completions passes through exactly 
 * `IsDedekindDomain.HeightOneSpectrum.exists_unit_not_isSquare`: at such a place, with finite
   residue field, `𝒪_v` carries a unit that is not a square in `K_v`. This is the input the
   local image count at a good odd place needs.
+* `IsDedekindDomain.HeightOneSpectrum.henselianLocalRing_adicCompletionIntegers`: the ring of
+  integers `𝒪_v` of a completion is a Henselian local ring, via
+  `isAdic_maximalIdeal_adicCompletionIntegers` (its subspace topology is the `𝔪`-adic one) and
+  `completeSpace_adicCompletionIntegers`.
 * `IsDedekindDomain.HeightOneSpectrum.valued_adicCompletionExtension`: along the extension the
   valuation is raised to the ramification index.
 * `IsDedekindDomain.HeightOneSpectrum.comap_maximalIdeal_adicCompletionIntegersExtension`: the
@@ -93,9 +99,14 @@ its proof: the source contracts the maximal ideal with its own
 same thing about the ordered value monoid in one line. The odd-residue-characteristic step is split
 out as `ringChar_residueField_adicCompletionIntegers_ne_two`, which the source keeps inline.
 
-Only the part the `2`-descent consumes is ported: the Henselian and completeness chain of the
-source, which serves other consumers, is deliberately left out. The source is written against Lean
-`v4.32.0`; this is a forward port.
+The Henselian and completeness chain of the source — `mem_maximalIdeal_pow_iff` and the
+`𝔪`-adic, completeness, `𝔪`-adic-completeness and Henselian results below — is ported here too;
+it serves consumers beyond the `2`-descent, notably the formal-group filtration. The source's
+`valued_irreducible_adicCompletionIntegers` is *not* ported: this repository already states it as
+`valued_algebraMap_eq_exp_neg_one_of_irreducible` above, and that is what the chain uses. One
+adaptation was needed against this repository's Mathlib: the source's two uses of `Set.mem_setOf`
+are deprecated here in favour of `Set.mem_ofPred`. The source is written against Lean `v4.32.0`;
+this is a forward port.
 
 ## Implementation notes
 
@@ -229,6 +240,24 @@ theorem span_singleton_eq_maximalIdeal_pow {x : v.adicCompletionIntegers K} {e :
   rw [Ideal.span_singleton_eq_span_singleton.mpr (associated_unit_mul_left _ _ u.isUnit),
     ← Ideal.span_singleton_pow, hπ.maximalIdeal_eq]
 
+/-- An element of `𝒪_v` lies in the `n`-th power of the maximal ideal exactly when its valuation
+is at most `exp (-n)`.
+
+This identifies the ideal filtration of `𝒪_v` with the valuation filtration it inherits from
+`K_v`, which is what makes the subspace topology visibly `𝔪`-adic below. -/
+theorem mem_maximalIdeal_pow_iff {x : v.adicCompletionIntegers K} {n : ℕ} :
+    x ∈ IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n ↔
+      Valued.v (x : v.adicCompletion K) ≤ exp (-(n : ℤ)) := by
+  obtain ⟨π, hπ⟩ := IsDiscreteValuationRing.exists_irreducible (v.adicCompletionIntegers K)
+  have hπn : Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) (π ^ n)) =
+      exp (-(n : ℤ)) := by
+    rw [map_pow, map_pow, v.valued_algebraMap_eq_exp_neg_one_of_irreducible hπ, ← exp_nsmul]
+    simp
+  rw [← span_singleton_eq_maximalIdeal_pow v hπn, Ideal.mem_span_singleton]
+  have hint := Valuation.valuationSubring.integers (v := (Valued.v : Valuation
+    (v.adicCompletion K) ℤᵐ⁰))
+  exact ⟨fun h ↦ (hint.le_of_dvd h).trans hπn.le, fun h ↦ hint.dvd_of_le (h.trans_eq hπn.symm)⟩
+
 /-- Any element of the ring of integers of the completion is congruent to an element of `R`
 modulo the maximal ideal — equivalently, `R` surjects onto the residue field of `𝒪_v`.
 
@@ -356,6 +385,92 @@ theorem exists_unit_not_isSquare [Finite (R ⧸ v.asIdeal)] (hv2 : (2 : R) ∉ v
   have hx_eq : x = (⟨d, hdmem⟩ : v.adicCompletionIntegers K) * ⟨d, hdmem⟩ :=
     hint.hom_inj (by rw [map_mul]; exact hd)
   exact ha ⟨IsLocalRing.residue _ ⟨d, hdmem⟩, by rw [hx_eq, map_mul]⟩
+
+/-! ### `𝒪_v` is a complete adic Henselian local ring
+
+The subspace topology `𝒪_v` inherits from `K_v` is the `𝔪`-adic one, and `𝒪_v` is closed in the
+complete field `K_v`, hence complete. Being complete for the `𝔪`-adic topology it is `𝔪`-adically
+complete, and a local ring that is complete with respect to its maximal ideal is Henselian.
+-/
+
+/-- The ring of integers of an adic completion is a topological ring, as a subring of `K_v`. -/
+instance isTopologicalRing_adicCompletionIntegers :
+    IsTopologicalRing (v.adicCompletionIntegers K) :=
+  inferInstanceAs (IsTopologicalRing
+    (Valued.v (R := v.adicCompletion K)).valuationSubring.toSubring)
+
+/-- The subspace topology on the ring of integers `𝒪_v` of an adic completion is the `𝔪`-adic
+topology of its maximal ideal.
+
+Both inclusions come from `mem_maximalIdeal_pow_iff`: it exhibits each `𝔪 ^ n` as the preimage of
+a closed ball, which is open, and conversely lets a neighbourhood of `0` cut out by a valuation
+bound be undercut by some `𝔪 ^ n`. -/
+theorem isAdic_maximalIdeal_adicCompletionIntegers :
+    IsAdic (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)) := by
+  rw [isAdic_iff]
+  constructor
+  · -- each `𝔪 ^ n` is open: it is the preimage of a closed ball
+    intro n
+    obtain ⟨z, hz⟩ := v.valuedAdicCompletion_surjective K (exp (-(n : ℤ)))
+    have hr0 : Valued.v.restrict z ≠ 0 := by
+      intro h
+      have h0 : Valued.v z = 0 := by rw [← Valuation.embedding_restrict, h, map_zero]
+      rw [hz] at h0
+      exact exp_ne_zero h0
+    have : ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
+          Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) =
+        (fun x : v.adicCompletionIntegers K ↦ (x : v.adicCompletion K)) ⁻¹'
+          {y | Valued.v.restrict y ≤ Valued.v.restrict z} := by
+      ext x
+      rw [Set.mem_preimage, Set.mem_ofPred, Valuation.restrict_le_iff_le_embedding,
+        Valuation.embedding_restrict, hz]
+      exact v.mem_maximalIdeal_pow_iff (K := K)
+    rw [this]
+    exact (Valued.isOpen_closedBall _ hr0).preimage continuous_subtype_val
+  · -- each neighbourhood of `0` contains some `𝔪 ^ n`
+    intro s hs
+    obtain ⟨t, ht, hts⟩ := mem_nhds_subtype _ _ _ |>.mp hs
+    rw [ZeroMemClass.coe_zero] at ht
+    obtain ⟨γ, hγ⟩ := Valued.mem_nhds_zero.mp ht
+    obtain ⟨m, hm⟩ : ∃ m : ℤ, exp m < MonoidWithZeroHom.ValueGroup₀.embedding γ.1 := by
+      obtain ⟨a, ha⟩ :=
+        WithZero.ne_zero_iff_exists.mp (MonoidWithZeroHom.ValueGroup₀.embedding_unit_ne_zero γ)
+      refine ⟨Multiplicative.toAdd a - 1, ?_⟩
+      rw [← ha, show (a : ℤᵐ⁰) = exp (Multiplicative.toAdd a) from rfl]
+      exact exp_lt_exp.mpr (by lia)
+    refine ⟨(-m).toNat, fun x hx ↦ hts ?_⟩
+    refine Set.mem_preimage.mpr (hγ ?_)
+    have h1 := v.mem_maximalIdeal_pow_iff (K := K) |>.mp hx
+    refine Set.mem_ofPred.mpr ((Valuation.restrict_lt_iff_lt_embedding (v := Valued.v)).mpr
+      (h1.trans_lt ?_))
+    calc exp (-(((-m).toNat : ℤ))) ≤ exp m := exp_le_exp.mpr (by lia)
+      _ < _ := hm
+
+/-- `𝒪_v` is complete: it is a closed subset of the complete field `K_v`. -/
+instance completeSpace_adicCompletionIntegers : CompleteSpace (v.adicCompletionIntegers K) :=
+  (Valued.isClosed_valuationSubring (v.adicCompletion K)).completeSpace_coe
+
+/-- `𝒪_v` is a uniform additive group, as an additive subgroup of `K_v`. -/
+instance isUniformAddGroup_adicCompletionIntegers :
+    IsUniformAddGroup (v.adicCompletionIntegers K) :=
+  ((Valued.v (R := v.adicCompletion K)).valuationSubring.toSubring.toAddSubgroup).isUniformAddGroup
+
+/-- `𝒪_v` is `𝔪`-adically complete: its topology is the `𝔪`-adic one and it is complete. -/
+instance isAdicComplete_adicCompletionIntegers :
+    IsAdicComplete (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K))
+      (v.adicCompletionIntegers K) :=
+  -- `IsAdic` unfolds to an equality of topologies, so dot notation on it would resolve against
+  -- `Eq`; the lemma is `protected` and must be named in full.
+  (IsAdic.isAdicComplete_iff (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))).mpr
+    ⟨inferInstance, inferInstance⟩
+
+/-- **The ring of integers of an adic completion is a Henselian local ring.** It is a local ring
+that is complete with respect to its maximal ideal, and such rings are Henselian. -/
+instance henselianLocalRing_adicCompletionIntegers :
+    HenselianLocalRing (v.adicCompletionIntegers K) where
+  is_henselian f hf a₀ h₁ h₂ :=
+    (IsAdicComplete.henselianRing _
+      (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K))).is_henselian f hf a₀ h₁ (h₂.map _)
 
 end IsDedekindDomain.HeightOneSpectrum
 

--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -399,52 +399,57 @@ instance isTopologicalRing_adicCompletionIntegers :
   inferInstanceAs (IsTopologicalRing
     (Valued.v (R := v.adicCompletion K)).valuationSubring.toSubring)
 
-/-- The subspace topology on the ring of integers `𝒪_v` of an adic completion is the `𝔪`-adic
-topology of its maximal ideal.
+/-- **Each power of the maximal ideal of `𝒪_v` is open**: `𝔪 ^ n` is the preimage under the
+inclusion `𝒪_v → K_v` of a closed valuation ball, and those are open. -/
+theorem isOpen_maximalIdeal_pow_adicCompletionIntegers (n : ℕ) :
+    IsOpen ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
+      Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) := by
+  obtain ⟨z, hz⟩ := v.valuedAdicCompletion_surjective K (exp (-(n : ℤ)))
+  have hr0 : Valued.v.restrict z ≠ 0 := by
+    intro h
+    have h0 : Valued.v z = 0 := by rw [← Valuation.embedding_restrict, h, map_zero]
+    rw [hz] at h0
+    exact exp_ne_zero h0
+  have : ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
+        Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) =
+      (fun x : v.adicCompletionIntegers K ↦ (x : v.adicCompletion K)) ⁻¹'
+        {y | Valued.v.restrict y ≤ Valued.v.restrict z} := by
+    ext x
+    rw [Set.mem_preimage, Set.mem_ofPred, Valuation.restrict_le_iff_le_embedding,
+      Valuation.embedding_restrict, hz]
+    exact v.mem_maximalIdeal_pow_iff (K := K)
+  rw [this]
+  exact (Valued.isOpen_closedBall _ hr0).preimage continuous_subtype_val
 
-Both inclusions come from `mem_maximalIdeal_pow_iff`: it exhibits each `𝔪 ^ n` as the preimage of
-a closed ball, which is open, and conversely lets a neighbourhood of `0` cut out by a valuation
-bound be undercut by some `𝔪 ^ n`. -/
+/-- **Every neighbourhood of `0` in `𝒪_v` contains a power of the maximal ideal.** A neighbourhood
+is cut out by a valuation bound, and `exp` takes some integer below that bound; the corresponding
+`𝔪 ^ n` is then undercut by it. -/
+theorem exists_maximalIdeal_pow_subset_of_mem_nhds {s : Set (v.adicCompletionIntegers K)}
+    (hs : s ∈ nhds 0) : ∃ n : ℕ, ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
+      Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) ⊆ s := by
+  obtain ⟨t, ht, hts⟩ := mem_nhds_subtype _ _ _ |>.mp hs
+  rw [ZeroMemClass.coe_zero] at ht
+  obtain ⟨γ, hγ⟩ := Valued.mem_nhds_zero.mp ht
+  obtain ⟨m, hm⟩ : ∃ m : ℤ, exp m < MonoidWithZeroHom.ValueGroup₀.embedding γ.1 := by
+    obtain ⟨a, ha⟩ :=
+      WithZero.ne_zero_iff_exists.mp (MonoidWithZeroHom.ValueGroup₀.embedding_unit_ne_zero γ)
+    refine ⟨Multiplicative.toAdd a - 1, ?_⟩
+    rw [← ha, show (a : ℤᵐ⁰) = exp (Multiplicative.toAdd a) from rfl]
+    exact exp_lt_exp.mpr (by lia)
+  refine ⟨(-m).toNat, fun x hx ↦ hts ?_⟩
+  refine Set.mem_preimage.mpr (hγ ?_)
+  have h1 := v.mem_maximalIdeal_pow_iff (K := K) |>.mp hx
+  refine Set.mem_ofPred.mpr ((Valuation.restrict_lt_iff_lt_embedding (v := Valued.v)).mpr
+    (h1.trans_lt ?_))
+  calc exp (-(((-m).toNat : ℤ))) ≤ exp m := exp_le_exp.mpr (by lia)
+    _ < _ := hm
+
+/-- The subspace topology on the ring of integers `𝒪_v` of an adic completion is the `𝔪`-adic
+topology of its maximal ideal. -/
 theorem isAdic_maximalIdeal_adicCompletionIntegers :
-    IsAdic (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)) := by
-  rw [isAdic_iff]
-  constructor
-  · -- each `𝔪 ^ n` is open: it is the preimage of a closed ball
-    intro n
-    obtain ⟨z, hz⟩ := v.valuedAdicCompletion_surjective K (exp (-(n : ℤ)))
-    have hr0 : Valued.v.restrict z ≠ 0 := by
-      intro h
-      have h0 : Valued.v z = 0 := by rw [← Valuation.embedding_restrict, h, map_zero]
-      rw [hz] at h0
-      exact exp_ne_zero h0
-    have : ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
-          Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) =
-        (fun x : v.adicCompletionIntegers K ↦ (x : v.adicCompletion K)) ⁻¹'
-          {y | Valued.v.restrict y ≤ Valued.v.restrict z} := by
-      ext x
-      rw [Set.mem_preimage, Set.mem_ofPred, Valuation.restrict_le_iff_le_embedding,
-        Valuation.embedding_restrict, hz]
-      exact v.mem_maximalIdeal_pow_iff (K := K)
-    rw [this]
-    exact (Valued.isOpen_closedBall _ hr0).preimage continuous_subtype_val
-  · -- each neighbourhood of `0` contains some `𝔪 ^ n`
-    intro s hs
-    obtain ⟨t, ht, hts⟩ := mem_nhds_subtype _ _ _ |>.mp hs
-    rw [ZeroMemClass.coe_zero] at ht
-    obtain ⟨γ, hγ⟩ := Valued.mem_nhds_zero.mp ht
-    obtain ⟨m, hm⟩ : ∃ m : ℤ, exp m < MonoidWithZeroHom.ValueGroup₀.embedding γ.1 := by
-      obtain ⟨a, ha⟩ :=
-        WithZero.ne_zero_iff_exists.mp (MonoidWithZeroHom.ValueGroup₀.embedding_unit_ne_zero γ)
-      refine ⟨Multiplicative.toAdd a - 1, ?_⟩
-      rw [← ha, show (a : ℤᵐ⁰) = exp (Multiplicative.toAdd a) from rfl]
-      exact exp_lt_exp.mpr (by lia)
-    refine ⟨(-m).toNat, fun x hx ↦ hts ?_⟩
-    refine Set.mem_preimage.mpr (hγ ?_)
-    have h1 := v.mem_maximalIdeal_pow_iff (K := K) |>.mp hx
-    refine Set.mem_ofPred.mpr ((Valuation.restrict_lt_iff_lt_embedding (v := Valued.v)).mpr
-      (h1.trans_lt ?_))
-    calc exp (-(((-m).toNat : ℤ))) ≤ exp m := exp_le_exp.mpr (by lia)
-      _ < _ := hm
+    IsAdic (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)) :=
+  isAdic_iff.mpr ⟨isOpen_maximalIdeal_pow_adicCompletionIntegers (K := K) v,
+    fun _ hs ↦ exists_maximalIdeal_pow_subset_of_mem_nhds (K := K) v hs⟩
 
 /-- `𝒪_v` is complete: it is a closed subset of the complete field `K_v`. -/
 instance completeSpace_adicCompletionIntegers : CompleteSpace (v.adicCompletionIntegers K) :=

--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -6,8 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
-public import Mathlib.RingTheory.AdicCompletion.Topology
-public import Mathlib.RingTheory.Henselian
 public import TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion
 public import TauCeti.RingTheory.DedekindDomain.Ideal
 public import TauCeti.RingTheory.DedekindDomain.ValuationOfNeZero
@@ -52,10 +50,6 @@ global étale algebra with its images in the completions passes through exactly 
 * `IsDedekindDomain.HeightOneSpectrum.exists_unit_not_isSquare`: at such a place, with finite
   residue field, `𝒪_v` carries a unit that is not a square in `K_v`. This is the input the
   local image count at a good odd place needs.
-* `IsDedekindDomain.HeightOneSpectrum.henselianLocalRing_adicCompletionIntegers`: the ring of
-  integers `𝒪_v` of a completion is a Henselian local ring, via
-  `isAdic_maximalIdeal_adicCompletionIntegers` (its subspace topology is the `𝔪`-adic one) and
-  `completeSpace_adicCompletionIntegers`.
 * `IsDedekindDomain.HeightOneSpectrum.valued_adicCompletionExtension`: along the extension the
   valuation is raised to the ramification index.
 * `IsDedekindDomain.HeightOneSpectrum.comap_maximalIdeal_adicCompletionIntegersExtension`: the
@@ -65,12 +59,12 @@ global étale algebra with its images in the completions passes through exactly 
   continuous, and is the only continuous ring homomorphism `K_v →+* L_w` extending `K → L`. Together
   these are its universal property, usable without unfolding the definition.
 
-## Roadmap
+## Motivation
 
-`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, lines 813–822: the "Explicit 2-descent (core,
-this layer)" bullet. The semilocal comparison behind it — matching the unramifiedness of a square
-class at the primes of the field factors with unramifiedness over the valuation ring of `K_v` —
-consumes every result here. Nothing in this file mentions a curve.
+Every result here is consumed by a semilocal comparison in explicit `2`-descent: matching the
+unramifiedness of a square class at the primes of the field factors with unramifiedness over the
+valuation ring of `K_v`. Nothing in this file mentions a curve — each statement is about a
+Dedekind domain and one of its completions.
 
 ## Provenance
 
@@ -99,15 +93,13 @@ its proof: the source contracts the maximal ideal with its own
 same thing about the ordered value monoid in one line. The odd-residue-characteristic step is split
 out as `ringChar_residueField_adicCompletionIntegers_ne_two`, which the source keeps inline.
 
-The Henselian and completeness chain — `mem_maximalIdeal_pow_iff` and the `𝔪`-adic,
-completeness, `𝔪`-adic-completeness and Henselian results below — comes from that same Stoll file.
-Where the source states `valued_irreducible_adicCompletionIntegers`, this repository already has
-`valued_algebraMap_eq_exp_neg_one_of_irreducible` above, and that is what the chain uses.
+The Henselian and completeness chain from that same Stoll file lives in
+`TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion`, with the single-completion
+valuation results it rests on.
 
 ## Implementation notes
 
-Three Mathlib modules are imported directly.
-`Mathlib.NumberTheory.NumberField.Completion.FinitePlace` is needed
+`Mathlib.NumberTheory.NumberField.Completion.FinitePlace` is the sole Mathlib import. It is needed
 for two instances — `IsDiscreteValuationRing (v.adicCompletionIntegers K)` and
 `(Valued.v : Valuation (v.adicCompletion K) ℤᵐ⁰).IsRankOneDiscrete`. Both are stated there for an
 arbitrary Dedekind domain and its fraction field, not for number fields, so nothing in this file
@@ -116,9 +108,7 @@ reason so the placement of a `NumberTheory` import inside `RingTheory` is not mi
 layering slip.
 
 It also transitively supplies the ramification-valuation and adic-valuation modules, so those are
-not imported directly. The other two carry the vocabulary of the final section:
-`Mathlib.RingTheory.AdicCompletion.Topology` defines `IsAdic` and `IsAdicComplete`, and
-`Mathlib.RingTheory.Henselian` defines `HenselianLocalRing`.
+not imported directly.
 -/
 
 public section
@@ -129,20 +119,6 @@ namespace IsDedekindDomain.HeightOneSpectrum
 
 variable {R : Type*} [CommRing R] [IsDedekindDomain R]
   {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K] (v : HeightOneSpectrum R)
-
-/-- An irreducible element of the ring of integers of a completion has valuation `exp (-1)`. -/
-theorem valued_algebraMap_eq_exp_neg_one_of_irreducible {π : v.adicCompletionIntegers K}
-    (hπ : Irreducible π) :
-    Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) π) = exp (-1) := by
-  -- `v.adicCompletionIntegers K` is by definition `Valued.v.valuationSubring`, which is what lets
-  -- `π`'s maximal ideal be retyped as an ideal of the valuation subring here.
-  have hgen : IsLocalRing.maximalIdeal (Valued.v : Valuation (v.adicCompletion K)
-      ℤᵐ⁰).valuationSubring = Ideal.span {π} := hπ.maximalIdeal_eq
-  have huni := Valuation.isUniformizer_of_maximalIdeal_eq_span
-    (v := (Valued.v : Valuation (v.adicCompletion K) ℤᵐ⁰)) hgen
-  rwa [Valuation.IsUniformizer.iff,
-    Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_surjective
-      (v.valuedAdicCompletion_surjective K)] at huni
 
 /-- The valuation associated to the maximal ideal of the ring of integers of an adic completion is
 the valuation of the completion.
@@ -238,25 +214,6 @@ theorem span_singleton_eq_maximalIdeal_pow {x : v.adicCompletionIntegers K} {e :
   subst hx
   rw [Ideal.span_singleton_eq_span_singleton.mpr (associated_unit_mul_left _ _ u.isUnit),
     ← Ideal.span_singleton_pow, hπ.maximalIdeal_eq]
-
-/-- An element of `𝒪_v` lies in the `n`-th power of the maximal ideal exactly when its valuation
-is at most `exp (-n)`.
-
-This identifies the ideal filtration of `𝒪_v` with the valuation filtration it inherits from
-`K_v`, which is what makes the subspace topology visibly `𝔪`-adic below. -/
-@[simp]
-theorem mem_maximalIdeal_pow_iff {x : v.adicCompletionIntegers K} {n : ℕ} :
-    x ∈ IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n ↔
-      Valued.v (x : v.adicCompletion K) ≤ exp (-(n : ℤ)) := by
-  obtain ⟨π, hπ⟩ := IsDiscreteValuationRing.exists_irreducible (v.adicCompletionIntegers K)
-  have hπn : Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) (π ^ n)) =
-      exp (-(n : ℤ)) := by
-    rw [map_pow, map_pow, v.valued_algebraMap_eq_exp_neg_one_of_irreducible hπ, ← exp_nsmul]
-    simp
-  have hint := Valuation.valuationSubring.integers (v := (Valued.v : Valuation
-    (v.adicCompletion K) ℤᵐ⁰))
-  rw [← span_singleton_eq_maximalIdeal_pow v hπn, ← hπn]
-  exact Set.ext_iff.mp (hint.coe_span_singleton_eq_setOfPred_le_v_algebraMap (π ^ n)) x
 
 /-- Any element of the ring of integers of the completion is congruent to an element of `R`
 modulo the maximal ideal — equivalently, `R` surjects onto the residue field of `𝒪_v`.
@@ -385,95 +342,6 @@ theorem exists_unit_not_isSquare [Finite (R ⧸ v.asIdeal)] (hv2 : (2 : R) ∉ v
   have hx_eq : x = (⟨d, hdmem⟩ : v.adicCompletionIntegers K) * ⟨d, hdmem⟩ :=
     hint.hom_inj (by rw [map_mul]; exact hd)
   exact ha ⟨IsLocalRing.residue _ ⟨d, hdmem⟩, by rw [hx_eq, map_mul]⟩
-
-/-! ### `𝒪_v` is a complete adic Henselian local ring
-
-The subspace topology `𝒪_v` inherits from `K_v` is the `𝔪`-adic one, and `𝒪_v` is closed in the
-complete field `K_v`, hence complete. Being complete for the `𝔪`-adic topology it is `𝔪`-adically
-complete, and a local ring that is complete with respect to its maximal ideal is Henselian.
--/
-
-/-- The ring of integers of an adic completion is a topological ring, as a subring of `K_v`. -/
-instance isTopologicalRing_adicCompletionIntegers :
-    IsTopologicalRing (v.adicCompletionIntegers K) :=
-  inferInstanceAs (IsTopologicalRing
-    (Valued.v (R := v.adicCompletion K)).valuationSubring.toSubring)
-
-/-- **Each power of the maximal ideal of `𝒪_v` is open**: `𝔪 ^ n` is the preimage under the
-inclusion `𝒪_v → K_v` of a closed valuation ball, and those are open. -/
-theorem isOpen_maximalIdeal_pow_adicCompletionIntegers (n : ℕ) :
-    IsOpen ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
-      Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) := by
-  obtain ⟨z, hz⟩ := v.valuedAdicCompletion_surjective K (exp (-(n : ℤ)))
-  have hr0 : Valued.v.restrict z ≠ 0 := by
-    intro h
-    have h0 : Valued.v z = 0 := by rw [← Valuation.embedding_restrict, h, map_zero]
-    rw [hz] at h0
-    exact exp_ne_zero h0
-  have : ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
-        Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) =
-      (fun x : v.adicCompletionIntegers K ↦ (x : v.adicCompletion K)) ⁻¹'
-        {y | Valued.v.restrict y ≤ Valued.v.restrict z} := by
-    ext x
-    rw [Set.mem_preimage, Set.mem_ofPred, Valuation.restrict_le_iff_le_embedding,
-      Valuation.embedding_restrict, hz]
-    exact v.mem_maximalIdeal_pow_iff (K := K)
-  rw [this]
-  exact (Valued.isOpen_closedBall _ hr0).preimage continuous_subtype_val
-
-/-- **Every neighbourhood of `0` in `𝒪_v` contains a power of the maximal ideal.** A neighbourhood
-is cut out by a valuation bound, and `exp` takes some integer below that bound; the corresponding
-`𝔪 ^ n` is then undercut by it. -/
-theorem exists_maximalIdeal_pow_subset_of_mem_nhds {s : Set (v.adicCompletionIntegers K)}
-    (hs : s ∈ nhds 0) : ∃ n : ℕ, ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
-      Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) ⊆ s := by
-  obtain ⟨t, ht, hts⟩ := mem_nhds_subtype _ _ _ |>.mp hs
-  rw [ZeroMemClass.coe_zero] at ht
-  obtain ⟨γ, hγ⟩ := Valued.mem_nhds_zero.mp ht
-  obtain ⟨m, hm⟩ : ∃ m : ℤ, exp m < MonoidWithZeroHom.ValueGroup₀.embedding γ.1 := by
-    refine ⟨log (MonoidWithZeroHom.ValueGroup₀.embedding γ.1) - 1, ?_⟩
-    conv_rhs => rw [← exp_log (MonoidWithZeroHom.ValueGroup₀.embedding_unit_ne_zero γ)]
-    exact exp_lt_exp.mpr (by lia)
-  refine ⟨(-m).toNat, fun x hx ↦ hts ?_⟩
-  refine Set.mem_preimage.mpr (hγ ?_)
-  have h1 := v.mem_maximalIdeal_pow_iff (K := K) |>.mp hx
-  refine Set.mem_ofPred.mpr ((Valuation.restrict_lt_iff_lt_embedding (v := Valued.v)).mpr
-    (h1.trans_lt ?_))
-  calc exp (-(((-m).toNat : ℤ))) ≤ exp m := exp_le_exp.mpr (by lia)
-    _ < _ := hm
-
-/-- The subspace topology on the ring of integers `𝒪_v` of an adic completion is the `𝔪`-adic
-topology of its maximal ideal. -/
-theorem isAdic_maximalIdeal_adicCompletionIntegers :
-    IsAdic (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)) :=
-  isAdic_iff.mpr ⟨isOpen_maximalIdeal_pow_adicCompletionIntegers (K := K) v,
-    fun _ hs ↦ exists_maximalIdeal_pow_subset_of_mem_nhds (K := K) v hs⟩
-
-/-- `𝒪_v` is complete: it is a closed subset of the complete field `K_v`. -/
-instance completeSpace_adicCompletionIntegers : CompleteSpace (v.adicCompletionIntegers K) :=
-  (Valued.isClosed_valuationSubring (v.adicCompletion K)).completeSpace_coe
-
-/-- `𝒪_v` is a uniform additive group, as an additive subgroup of `K_v`. -/
-instance isUniformAddGroup_adicCompletionIntegers :
-    IsUniformAddGroup (v.adicCompletionIntegers K) :=
-  ((Valued.v (R := v.adicCompletion K)).valuationSubring.toSubring.toAddSubgroup).isUniformAddGroup
-
-/-- `𝒪_v` is `𝔪`-adically complete: its topology is the `𝔪`-adic one and it is complete. -/
-instance isAdicComplete_adicCompletionIntegers :
-    IsAdicComplete (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K))
-      (v.adicCompletionIntegers K) :=
-  -- `IsAdic` unfolds to an equality of topologies, so dot notation on it would resolve against
-  -- `Eq`; the lemma is `protected` and must be named in full.
-  (IsAdic.isAdicComplete_iff (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))).mpr
-    ⟨inferInstance, inferInstance⟩
-
-/-- **The ring of integers of an adic completion is a Henselian local ring.** It is a local ring
-that is complete with respect to its maximal ideal, and such rings are Henselian. -/
-instance henselianLocalRing_adicCompletionIntegers :
-    HenselianLocalRing (v.adicCompletionIntegers K) where
-  is_henselian f hf a₀ h₁ h₂ :=
-    (IsAdicComplete.henselianRing _
-      (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K))).is_henselian f hf a₀ h₁ (h₂.map _)
 
 end IsDedekindDomain.HeightOneSpectrum
 

--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
 public import TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion
 public import TauCeti.RingTheory.DedekindDomain.Ideal
 public import TauCeti.RingTheory.DedekindDomain.ValuationOfNeZero
@@ -99,16 +98,9 @@ valuation results it rests on.
 
 ## Implementation notes
 
-`Mathlib.NumberTheory.NumberField.Completion.FinitePlace` is the sole Mathlib import. It is needed
-for two instances — `IsDiscreteValuationRing (v.adicCompletionIntegers K)` and
-`(Valued.v : Valuation (v.adicCompletion K) ℤᵐ⁰).IsRankOneDiscrete`. Both are stated there for an
-arbitrary Dedekind domain and its fraction field, not for number fields, so nothing in this file
-depends on number-field theory; they simply live in that module upstream. This note records the
-reason so the placement of a `NumberTheory` import inside `RingTheory` is not mistaken for a
-layering slip.
-
-It also transitively supplies the ramification-valuation and adic-valuation modules, so those are
-not imported directly.
+Every Mathlib module this file needs arrives through
+`TauCeti.RingTheory.DedekindDomain.AdicValuation.Completion`, which is imported for the
+single-completion results and publicly re-exports them.
 -/
 
 public section

--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -99,18 +99,15 @@ its proof: the source contracts the maximal ideal with its own
 same thing about the ordered value monoid in one line. The odd-residue-characteristic step is split
 out as `ringChar_residueField_adicCompletionIntegers_ne_two`, which the source keeps inline.
 
-The Henselian and completeness chain of the source — `mem_maximalIdeal_pow_iff` and the
-`𝔪`-adic, completeness, `𝔪`-adic-completeness and Henselian results below — is ported here too;
-it serves consumers beyond the `2`-descent, notably the formal-group filtration. The source's
-`valued_irreducible_adicCompletionIntegers` is *not* ported: this repository already states it as
-`valued_algebraMap_eq_exp_neg_one_of_irreducible` above, and that is what the chain uses. One
-adaptation was needed against this repository's Mathlib: the source's two uses of `Set.mem_setOf`
-are deprecated here in favour of `Set.mem_ofPred`. The source is written against Lean `v4.32.0`;
-this is a forward port.
+The Henselian and completeness chain — `mem_maximalIdeal_pow_iff` and the `𝔪`-adic,
+completeness, `𝔪`-adic-completeness and Henselian results below — comes from that same Stoll file.
+Where the source states `valued_irreducible_adicCompletionIntegers`, this repository already has
+`valued_algebraMap_eq_exp_neg_one_of_irreducible` above, and that is what the chain uses.
 
 ## Implementation notes
 
-`Mathlib.NumberTheory.NumberField.Completion.FinitePlace` is the sole Mathlib import. It is needed
+Three Mathlib modules are imported directly.
+`Mathlib.NumberTheory.NumberField.Completion.FinitePlace` is needed
 for two instances — `IsDiscreteValuationRing (v.adicCompletionIntegers K)` and
 `(Valued.v : Valuation (v.adicCompletion K) ℤᵐ⁰).IsRankOneDiscrete`. Both are stated there for an
 arbitrary Dedekind domain and its fraction field, not for number fields, so nothing in this file
@@ -119,7 +116,9 @@ reason so the placement of a `NumberTheory` import inside `RingTheory` is not mi
 layering slip.
 
 It also transitively supplies the ramification-valuation and adic-valuation modules, so those are
-not imported directly.
+not imported directly. The other two carry the vocabulary of the final section:
+`Mathlib.RingTheory.AdicCompletion.Topology` defines `IsAdic` and `IsAdicComplete`, and
+`Mathlib.RingTheory.Henselian` defines `HenselianLocalRing`.
 -/
 
 public section
@@ -245,6 +244,7 @@ is at most `exp (-n)`.
 
 This identifies the ideal filtration of `𝒪_v` with the valuation filtration it inherits from
 `K_v`, which is what makes the subspace topology visibly `𝔪`-adic below. -/
+@[simp]
 theorem mem_maximalIdeal_pow_iff {x : v.adicCompletionIntegers K} {n : ℕ} :
     x ∈ IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n ↔
       Valued.v (x : v.adicCompletion K) ≤ exp (-(n : ℤ)) := by
@@ -253,10 +253,10 @@ theorem mem_maximalIdeal_pow_iff {x : v.adicCompletionIntegers K} {n : ℕ} :
       exp (-(n : ℤ)) := by
     rw [map_pow, map_pow, v.valued_algebraMap_eq_exp_neg_one_of_irreducible hπ, ← exp_nsmul]
     simp
-  rw [← span_singleton_eq_maximalIdeal_pow v hπn, Ideal.mem_span_singleton]
   have hint := Valuation.valuationSubring.integers (v := (Valued.v : Valuation
     (v.adicCompletion K) ℤᵐ⁰))
-  exact ⟨fun h ↦ (hint.le_of_dvd h).trans hπn.le, fun h ↦ hint.dvd_of_le (h.trans_eq hπn.symm)⟩
+  rw [← span_singleton_eq_maximalIdeal_pow v hπn, ← hπn]
+  exact Set.ext_iff.mp (hint.coe_span_singleton_eq_setOfPred_le_v_algebraMap (π ^ n)) x
 
 /-- Any element of the ring of integers of the completion is congruent to an element of `R`
 modulo the maximal ideal — equivalently, `R` surjects onto the residue field of `𝒪_v`.
@@ -431,10 +431,8 @@ theorem exists_maximalIdeal_pow_subset_of_mem_nhds {s : Set (v.adicCompletionInt
   rw [ZeroMemClass.coe_zero] at ht
   obtain ⟨γ, hγ⟩ := Valued.mem_nhds_zero.mp ht
   obtain ⟨m, hm⟩ : ∃ m : ℤ, exp m < MonoidWithZeroHom.ValueGroup₀.embedding γ.1 := by
-    obtain ⟨a, ha⟩ :=
-      WithZero.ne_zero_iff_exists.mp (MonoidWithZeroHom.ValueGroup₀.embedding_unit_ne_zero γ)
-    refine ⟨Multiplicative.toAdd a - 1, ?_⟩
-    rw [← ha, show (a : ℤᵐ⁰) = exp (Multiplicative.toAdd a) from rfl]
+    refine ⟨log (MonoidWithZeroHom.ValueGroup₀.embedding γ.1) - 1, ?_⟩
+    conv_rhs => rw [← exp_log (MonoidWithZeroHom.ValueGroup₀.embedding_unit_ne_zero γ)]
     exact exp_lt_exp.mpr (by lia)
   refine ⟨(-m).toNat, fun x hx ↦ hts ?_⟩
   refine Set.mem_preimage.mpr (hγ ?_)

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
@@ -32,6 +32,15 @@ Everything here concerns one completion. The comparison of two completions along
 * `IsDedekindDomain.HeightOneSpectrum.henselianLocalRing_adicCompletionIntegers`: `𝒪_v` is a
   Henselian local ring, being local and complete for its maximal ideal.
 
+## Implementation notes
+
+`Mathlib.NumberTheory.NumberField.Completion.FinitePlace` supplies two instances used throughout —
+`IsDiscreteValuationRing (v.adicCompletionIntegers K)` and
+`(Valued.v : Valuation (v.adicCompletion K) ℤᵐ⁰).IsRankOneDiscrete`. Both are stated there for an
+arbitrary Dedekind domain and its fraction field, not for number fields, so nothing here depends on
+number-field theory; they simply live in that module upstream. This note records the reason so the
+placement of a `NumberTheory` import inside `RingTheory` is not mistaken for a layering slip.
+
 ## Motivation
 
 These results are consumed by a semilocal comparison in explicit `2`-descent, which matches a

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
@@ -5,38 +5,53 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
+public import Mathlib.RingTheory.AdicCompletion.Topology
 public import Mathlib.RingTheory.DedekindDomain.AdicValuation
+public import Mathlib.RingTheory.Henselian
 
 /-!
-# The prime under the maximal ideal of an adic completion
+# The ring of integers of a single adic completion
 
-The ring of integers of the completion `K_v` of the fraction field of a Dedekind domain `R` at a
-height-one prime `v` is a local ring, and its maximal ideal contracts to `v` itself. This is what
-identifies a condition imposed at the maximal ideal of `𝒪_v` with the condition at `v` upstairs.
+The ring of integers `𝒪_v` of the completion `K_v` of the fraction field of a Dedekind domain `R`
+at a height-one prime `v` is a local ring, and this file collects what it is: its maximal ideal
+contracts to `v` itself, its ideal filtration is the valuation filtration `K_v` induces on it, and
+in the subspace topology it is a complete `𝔪`-adic — hence Henselian — local ring.
+
+Everything here concerns one completion. The comparison of two completions along an extension
+`w ∣ v` is `TauCeti.RingTheory.DedekindDomain.AdicCompletionExtension`.
 
 ## Main results
 
 * `IsDedekindDomain.HeightOneSpectrum.under_maximalIdeal_adicCompletionIntegers`: `v` is the
   prime lying under the maximal ideal of `𝒪_v`.
+* `IsDedekindDomain.HeightOneSpectrum.mem_maximalIdeal_pow_iff`: membership in `𝔪 ^ n` is the
+  valuation bound `≤ exp (-n)`, identifying the ideal filtration with the valuation filtration.
+* `IsDedekindDomain.HeightOneSpectrum.isAdic_maximalIdeal_adicCompletionIntegers`: the subspace
+  topology on `𝒪_v` is the `𝔪`-adic one.
+* `IsDedekindDomain.HeightOneSpectrum.henselianLocalRing_adicCompletionIntegers`: `𝒪_v` is a
+  Henselian local ring, being local and complete for its maximal ideal.
 
-## Roadmap
+## Motivation
 
-`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, lines 813–822: the "Explicit 2-descent (core,
-this layer)" bullet. Its semilocal half compares a square class of a global étale algebra with its
-images in the completions, and this contraction is what matches the local condition to the global
-prime. Nothing here mentions a curve.
+These results are consumed by a semilocal comparison in explicit `2`-descent, which matches a
+square class of a global étale algebra with its images in the completions. Nothing here mentions
+a curve — each statement is about a Dedekind domain and one of its completions.
 
 ## Provenance
 
 Adapted, with the author's proof, from Michael Stoll's `EllipticCurves` project
 (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
 `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
-`EllipticCurves/Mathlib/Basic.lean` line 594. The source states the contraction with `Ideal.comap`
-of an `algebraMap`; Mathlib spells that `Ideal.under`, which is used here. The source is written
-against Lean `v4.32.0`; this is a forward port.
+`EllipticCurves/Mathlib/Basic.lean` line 594, and
+`EllipticCurves/Mathlib/AdicCompletionExtension.lean` for the filtration and Henselian results.
+The source states the contraction with `Ideal.comap` of an `algebraMap`; Mathlib spells that
+`Ideal.under`, which is used here.
 -/
 
 public section
+
+open WithZero
 
 namespace IsDedekindDomain.HeightOneSpectrum
 
@@ -55,6 +70,134 @@ lemma under_maximalIdeal_adicCompletionIntegers (v : HeightOneSpectrum R) :
   refine (Valuation.mem_maximalIdeal_iff (v := (Valued.v : Valuation (v.adicCompletion K)
     (WithZero (Multiplicative ℤ))))).trans ?_
   rw [algebraMap_adicCompletionIntegers_apply, valuedAdicCompletion_eq_valuation']
+
+section SingleCompletion
+
+variable (v : HeightOneSpectrum R)
+
+/-- An irreducible element of the ring of integers of a completion has valuation `exp (-1)`. -/
+theorem valued_algebraMap_eq_exp_neg_one_of_irreducible {π : v.adicCompletionIntegers K}
+    (hπ : Irreducible π) :
+    Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) π) = exp (-1) := by
+  -- `v.adicCompletionIntegers K` is by definition `Valued.v.valuationSubring`, which is what lets
+  -- `π`'s maximal ideal be retyped as an ideal of the valuation subring here.
+  have hgen : IsLocalRing.maximalIdeal (Valued.v : Valuation (v.adicCompletion K)
+      ℤᵐ⁰).valuationSubring = Ideal.span {π} := hπ.maximalIdeal_eq
+  have huni := Valuation.isUniformizer_of_maximalIdeal_eq_span
+    (v := (Valued.v : Valuation (v.adicCompletion K) ℤᵐ⁰)) hgen
+  rwa [Valuation.IsUniformizer.iff,
+    Valuation.IsRankOneDiscrete.generator_eq_exp_neg_one_of_surjective
+      (v.valuedAdicCompletion_surjective K)] at huni
+
+/-- An element of `𝒪_v` lies in the `n`-th power of the maximal ideal exactly when its valuation
+is at most `exp (-n)`.
+
+This identifies the ideal filtration of `𝒪_v` with the valuation filtration it inherits from
+`K_v`, which is what makes the subspace topology visibly `𝔪`-adic below. -/
+@[simp]
+theorem mem_maximalIdeal_pow_iff {x : v.adicCompletionIntegers K} {n : ℕ} :
+    x ∈ IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n ↔
+      Valued.v (x : v.adicCompletion K) ≤ exp (-(n : ℤ)) := by
+  obtain ⟨π, hπ⟩ := IsDiscreteValuationRing.exists_irreducible (v.adicCompletionIntegers K)
+  have hint := Valuation.valuationSubring.integers (v := (Valued.v : Valuation
+    (v.adicCompletion K) ℤᵐ⁰))
+  have hπn : Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) π) ^ n =
+      exp (-(n : ℤ)) := by
+    rw [v.valued_algebraMap_eq_exp_neg_one_of_irreducible hπ, ← exp_nsmul]
+    simp
+  rw [← hπn]
+  exact Set.ext_iff.mp (hint.maximalIdeal_pow_eq_setOfPred_le_v_algebraMap_pow hπ n) x
+
+/-! ### `𝒪_v` is a complete adic Henselian local ring
+
+The subspace topology `𝒪_v` inherits from `K_v` is the `𝔪`-adic one, and `𝒪_v` is closed in the
+complete field `K_v`, hence complete. Being complete for the `𝔪`-adic topology it is `𝔪`-adically
+complete, and a local ring that is complete with respect to its maximal ideal is Henselian.
+-/
+
+/-- The ring of integers of an adic completion is a topological ring, as a subring of `K_v`. -/
+instance isTopologicalRing_adicCompletionIntegers :
+    IsTopologicalRing (v.adicCompletionIntegers K) :=
+  inferInstanceAs (IsTopologicalRing
+    (Valued.v (R := v.adicCompletion K)).valuationSubring.toSubring)
+
+/-- **Each power of the maximal ideal of `𝒪_v` is open**: `𝔪 ^ n` is the preimage under the
+inclusion `𝒪_v → K_v` of a closed valuation ball, and those are open. -/
+theorem isOpen_maximalIdeal_pow_adicCompletionIntegers (n : ℕ) :
+    IsOpen ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
+      Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) := by
+  obtain ⟨z, hz⟩ := v.valuedAdicCompletion_surjective K (exp (-(n : ℤ)))
+  have hr0 : Valued.v.restrict z ≠ 0 := by
+    intro h
+    have h0 : Valued.v z = 0 := by rw [← Valuation.embedding_restrict, h, map_zero]
+    rw [hz] at h0
+    exact exp_ne_zero h0
+  have : ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
+        Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) =
+      (fun x : v.adicCompletionIntegers K ↦ (x : v.adicCompletion K)) ⁻¹'
+        {y | Valued.v.restrict y ≤ Valued.v.restrict z} := by
+    ext x
+    rw [Set.mem_preimage, Set.mem_ofPred, Valuation.restrict_le_iff_le_embedding,
+      Valuation.embedding_restrict, hz]
+    exact v.mem_maximalIdeal_pow_iff (K := K)
+  rw [this]
+  exact (Valued.isOpen_closedBall _ hr0).preimage continuous_subtype_val
+
+/-- **Every neighbourhood of `0` in `𝒪_v` contains a power of the maximal ideal.** A neighbourhood
+is cut out by a valuation bound, and `exp` takes some integer below that bound; the corresponding
+`𝔪 ^ n` is then undercut by it. -/
+theorem exists_maximalIdeal_pow_subset_of_mem_nhds {s : Set (v.adicCompletionIntegers K)}
+    (hs : s ∈ nhds 0) : ∃ n : ℕ, ((IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) ^ n :
+      Ideal (v.adicCompletionIntegers K)) : Set (v.adicCompletionIntegers K)) ⊆ s := by
+  obtain ⟨t, ht, hts⟩ := mem_nhds_subtype _ _ _ |>.mp hs
+  rw [ZeroMemClass.coe_zero] at ht
+  obtain ⟨γ, hγ⟩ := Valued.mem_nhds_zero.mp ht
+  obtain ⟨m, hm⟩ : ∃ m : ℤ, exp m < MonoidWithZeroHom.ValueGroup₀.embedding γ.1 := by
+    refine ⟨log (MonoidWithZeroHom.ValueGroup₀.embedding γ.1) - 1, ?_⟩
+    conv_rhs => rw [← exp_log (MonoidWithZeroHom.ValueGroup₀.embedding_unit_ne_zero γ)]
+    exact exp_lt_exp.mpr (by lia)
+  refine ⟨(-m).toNat, fun x hx ↦ hts ?_⟩
+  refine Set.mem_preimage.mpr (hγ ?_)
+  have h1 := v.mem_maximalIdeal_pow_iff (K := K) |>.mp hx
+  refine Set.mem_ofPred.mpr ((Valuation.restrict_lt_iff_lt_embedding (v := Valued.v)).mpr
+    (h1.trans_lt ?_))
+  calc exp (-(((-m).toNat : ℤ))) ≤ exp m := exp_le_exp.mpr (by lia)
+    _ < _ := hm
+
+/-- The subspace topology on the ring of integers `𝒪_v` of an adic completion is the `𝔪`-adic
+topology of its maximal ideal. -/
+theorem isAdic_maximalIdeal_adicCompletionIntegers :
+    IsAdic (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)) :=
+  isAdic_iff.mpr ⟨isOpen_maximalIdeal_pow_adicCompletionIntegers (K := K) v,
+    fun _ hs ↦ exists_maximalIdeal_pow_subset_of_mem_nhds (K := K) v hs⟩
+
+/-- `𝒪_v` is complete: it is a closed subset of the complete field `K_v`. -/
+instance completeSpace_adicCompletionIntegers : CompleteSpace (v.adicCompletionIntegers K) :=
+  (Valued.isClosed_valuationSubring (v.adicCompletion K)).completeSpace_coe
+
+/-- `𝒪_v` is a uniform additive group, as an additive subgroup of `K_v`. -/
+instance isUniformAddGroup_adicCompletionIntegers :
+    IsUniformAddGroup (v.adicCompletionIntegers K) :=
+  ((Valued.v (R := v.adicCompletion K)).valuationSubring.toSubring.toAddSubgroup).isUniformAddGroup
+
+/-- `𝒪_v` is `𝔪`-adically complete: its topology is the `𝔪`-adic one and it is complete. -/
+instance isAdicComplete_adicCompletionIntegers :
+    IsAdicComplete (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K))
+      (v.adicCompletionIntegers K) :=
+  -- `IsAdic` unfolds to an equality of topologies, so dot notation on it would resolve against
+  -- `Eq`; the lemma is `protected` and must be named in full.
+  (IsAdic.isAdicComplete_iff (v.isAdic_maximalIdeal_adicCompletionIntegers (K := K))).mpr
+    ⟨inferInstance, inferInstance⟩
+
+/-- **The ring of integers of an adic completion is a Henselian local ring.** It is a local ring
+that is complete with respect to its maximal ideal, and such rings are Henselian. -/
+instance henselianLocalRing_adicCompletionIntegers :
+    HenselianLocalRing (v.adicCompletionIntegers K) where
+  is_henselian f hf a₀ h₁ h₂ :=
+    (IsAdicComplete.henselianRing _
+      (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K))).is_henselian f hf a₀ h₁ (h₂.map _)
+
+end SingleCompletion
 
 end IsDedekindDomain.HeightOneSpectrum
 


### PR DESCRIPTION
`main` already carries `TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean` — the
valuation-theoretic half of Stoll's file of the same name, merged earlier. It did not take the
**topological** block. This completes it: the ring of integers `𝒪_v` of an adic completion is a
complete `𝔪`-adic Henselian local ring.

Roadmap: EllipticCurves

Provenance: github.com/MichaelStollBayreuth/EllipticCurves @ 66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e,
Apache-2.0, `EllipticCurves/Mathlib/AdicCompletionExtension.lean` (declarations at source lines 244,
257, 264, 305, 308, 312, 318).

## What it adds

* `mem_maximalIdeal_pow_iff` — membership of `𝔪 ^ n` in terms of the valuation, which both
  topological statements below run on;
* `isTopologicalRing_adicCompletionIntegers` — `𝒪_v` is a topological ring, as a subring of `K_v`;
* `isAdic_maximalIdeal_adicCompletionIntegers` — its subspace topology **is** the `𝔪`-adic one;
* `completeSpace_adicCompletionIntegers`, `isUniformAddGroup_adicCompletionIntegers`,
  `isAdicComplete_adicCompletionIntegers` — completeness, in the topological and the adic senses;
* `henselianLocalRing_adicCompletionIntegers` — and hence Henselian.

The `IsAdic` proof is an iff whose two directions are independently useful, so each is a named
theorem rather than a branch: `isOpen_maximalIdeal_pow_adicCompletionIntegers` (each `𝔪 ^ n` is the
preimage of a closed valuation ball) and `exists_maximalIdeal_pow_subset_of_mem_nhds` (a
neighbourhood of `0` is cut out by a valuation bound, which some `𝔪 ^ n` undercuts).

## Why it is wanted

The file's own `## Roadmap` section, which predates this PR, cites
`TauCetiRoadmap/EllipticCurves/README.md` Layer 6, lines 813–822, the "Explicit 2-descent (core,
this layer)" bullet: the semilocal comparison behind it — matching unramifiedness of a square class
at the primes of the field factors with unramifiedness over the valuation ring of `K_v` — consumes
these results. `isAdic_…` together with the two completeness instances are also exactly the
hypothesis "complete adic local ring" that the formal-group filtration work needs.

Note `HenselianLocalRing` had no occurrences under `TauCeti/` before this PR, so this is the
repository's first Henselian content. It is stated exactly as the source does, and not generalised.

## Absence, measured

All eight source declarations return zero files on `main`; the control `adicCompletionIntegers`
fires in four files, including the target file, so the zeros are real rather than a broken probe.
No overlap with any of the 98 open PRs.

## Attribution

The file already carries a `## Provenance` section crediting Stoll at this pin and, transitively,
the FLT project (`FLT/DedekindDomain/Completion/BaseChange.lean`, by Kevin Buzzard, Andrew Yang and
Matthew Jasper) for the completion-extension material. This PR extends that same port, so it needs
no attribution beyond what is already recorded there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
