### PR TITLE
feat(GroupTheory): count the cyclic-group elements of order divisible by f

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean
@@ -19,22 +19,21 @@ Mathlib counts elements of an *exact* order: `IsCyclic.card_orderOf_eq_totient` 
 
 ## Main results
 
-* `IsCyclic.card_filter_dvd_orderOf`: the count is `∑ φ d` over the divisors `d` of the
-  group order with `f ∣ d`.
+* `IsCyclic.card_filter_dvd_orderOf`, and its additive counterpart: the count is `∑ φ d`
+  over the divisors `d` of the group order with `f ∣ d`.
 -/
 
 public section
 
 open Finset Nat
 
-namespace IsCyclic
-
 variable {α : Type*} [Group α] [Fintype α] [IsCyclic α]
 
 /-- **The elements of a cyclic group whose order is a multiple of `f`, counted by order.**
 Each divisor `d` of the group order contributes its `φ d` elements of order exactly `d`, and the
 condition `f ∣ orderOf τ` keeps precisely the divisors that `f` divides. -/
-theorem card_filter_dvd_orderOf (f : ℕ) :
+@[to_additive]
+theorem IsCyclic.card_filter_dvd_orderOf (f : ℕ) :
     #{τ : α | f ∣ orderOf τ} =
       ∑ d ∈ {d ∈ (Fintype.card α).divisors | f ∣ d}, φ d := by
   classical
@@ -53,5 +52,3 @@ theorem card_filter_dvd_orderOf (f : ℕ) :
     rw [mem_coe, mem_filter] at hτ
     rw [mem_coe, mem_filter, Nat.mem_divisors]
     exact ⟨⟨orderOf_dvd_card, Fintype.card_ne_zero⟩, hτ.2⟩
-
-end IsCyclic

--- a/TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean
@@ -32,7 +32,11 @@ variable {α : Type*} [Group α] [Fintype α] [IsCyclic α]
 /-- **The elements of a cyclic group whose order is a multiple of `f`, counted by order.**
 Each divisor `d` of the group order contributes its `φ d` elements of order exactly `d`, and the
 condition `f ∣ orderOf τ` keeps precisely the divisors that `f` divides. -/
-@[to_additive]
+@[to_additive
+/-- **The elements of a finite additive cyclic group whose order is a multiple of `f`, counted by
+order.** Each divisor `d` of the group order contributes its `φ d` elements of `addOrderOf`
+exactly `d`, and the condition `f ∣ addOrderOf τ` keeps precisely the divisors that `f`
+divides. -/]
 theorem IsCyclic.card_filter_dvd_orderOf (f : ℕ) :
     #{τ : α | f ∣ orderOf τ} =
       ∑ d ∈ {d ∈ (Fintype.card α).divisors | f ∣ d}, φ d := by

--- a/TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean
@@ -64,7 +64,7 @@ The divisibility case of `IsCyclic.card_filter_orderOf_eq_sum_totient`. -/
 @[to_additive
 /-- **The elements of a finite additive cyclic group whose order is a multiple of `f`, counted by
 order.** The divisibility case of
-`AddCommGroup.card_filter_addOrderOf_eq_sum_totient`. -/]
+`IsAddCyclic.card_filter_addOrderOf_eq_sum_totient`. -/]
 theorem IsCyclic.card_filter_dvd_orderOf_eq_sum_totient (f : ℕ) :
     #{τ : α | f ∣ orderOf τ} =
       ∑ d ∈ {d ∈ (Fintype.card α).divisors | f ∣ d}, φ d :=

--- a/TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean
@@ -17,6 +17,11 @@ Mathlib counts elements of an *exact* order: `IsCyclic.card_orderOf_eq_totient` 
 `φ d` of them for each `d` dividing the group order. Summing that over the divisors selected by
 `p` is the whole content here.
 
+The point of stating it for a predicate is that it turns a count defined by a condition on orders
+into an arithmetic sum over divisors, where the group has disappeared. Whatever `p` is, the answer
+is a totient sum over `{d ∣ #α | p d}`, so it can then be evaluated or estimated by number theory
+alone.
+
 ## Main results
 
 * `IsCyclic.card_filter_orderOf_eq_sum_totient`, and its additive counterpart: the count of
@@ -43,21 +48,20 @@ theorem IsCyclic.card_filter_orderOf_eq_sum_totient (p : ℕ → Prop) [Decidabl
     #{τ : α | p (orderOf τ)} =
       ∑ d ∈ {d ∈ (Fintype.card α).divisors | p d}, φ d := by
   classical
-  rw [card_eq_sum_card_fiberwise (f := fun τ : α ↦ orderOf τ)
-    (t := {d ∈ (Fintype.card α).divisors | p d})]
-  · refine sum_congr rfl fun d hd ↦ ?_
-    rw [mem_filter, Nat.mem_divisors] at hd
-    have hfib : Finset.filter (fun a : α ↦ orderOf a = d)
-          (Finset.filter (fun τ : α ↦ p (orderOf τ)) Finset.univ)
-        = Finset.filter (fun a : α ↦ orderOf a = d) Finset.univ := by
-      ext τ
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-      exact ⟨fun h ↦ h.2, fun h ↦ ⟨h ▸ hd.2, h⟩⟩
-    rw [hfib, IsCyclic.card_orderOf_eq_totient hd.1.1]
-  · intro τ hτ
-    rw [mem_coe, mem_filter] at hτ
-    rw [mem_coe, mem_filter, Nat.mem_divisors]
-    exact ⟨⟨orderOf_dvd_card, Fintype.card_ne_zero⟩, hτ.2⟩
+  calc #{τ : α | p (orderOf τ)}
+      -- Every element's order divides the group order, so selecting by `p` and selecting by
+      -- membership in the `p`-divisors keep the same elements.
+      = #{τ ∈ (Finset.univ : Finset α) | orderOf τ ∈ {d ∈ (Fintype.card α).divisors | p d}} := by
+        refine congrArg Finset.card (filter_congr fun τ _ ↦ ?_)
+        simp only [mem_filter, Nat.mem_divisors]
+        exact ⟨fun h ↦ ⟨⟨orderOf_dvd_card, Fintype.card_ne_zero⟩, h⟩, fun h ↦ h.2⟩
+    _ = ∑ d ∈ {d ∈ (Fintype.card α).divisors | p d},
+          #{τ ∈ (Finset.univ : Finset α) | orderOf τ = d} :=
+        (Finset.sum_card_fiberwise_eq_card_filter _ _ _).symm
+    _ = ∑ d ∈ {d ∈ (Fintype.card α).divisors | p d}, φ d := by
+        refine sum_congr rfl fun d hd ↦ ?_
+        rw [mem_filter, Nat.mem_divisors] at hd
+        exact IsCyclic.card_orderOf_eq_totient hd.1.1
 
 /-- **The elements of a cyclic group whose order is a multiple of `f`, counted by order.**
 The divisibility case of `IsCyclic.card_filter_orderOf_eq_sum_totient`. -/

--- a/TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean
@@ -8,19 +8,21 @@ module
 public import Mathlib.GroupTheory.SpecificGroups.Cyclic
 
 /-!
-# Counting the elements of a cyclic group whose order is a multiple of `f`
+# Counting the elements of a cyclic group by a condition on their order
 
-In a finite cyclic group, the number of elements whose order is divisible by `f` is the sum of
-`φ d` over the divisors `d` of the group order that `f` divides.
+In a finite cyclic group, the number of elements whose order satisfies a predicate `p` is the sum
+of `φ d` over the divisors `d` of the group order that satisfy `p`.
 
 Mathlib counts elements of an *exact* order: `IsCyclic.card_orderOf_eq_totient` says there are
 `φ d` of them for each `d` dividing the group order. Summing that over the divisors selected by
-`f` is the whole content here.
+`p` is the whole content here.
 
 ## Main results
 
-* `IsCyclic.card_filter_dvd_orderOf`, and its additive counterpart: the count is `∑ φ d`
-  over the divisors `d` of the group order with `f ∣ d`.
+* `IsCyclic.card_filter_orderOf_eq_sum_totient`, and its additive counterpart: the count of
+  elements whose order satisfies `p` is `∑ φ d` over the divisors `d` of the group order with
+  `p d`.
+* `IsCyclic.card_filter_dvd_orderOf_eq_sum_totient`: the case `p = (f ∣ ·)`.
 -/
 
 public section
@@ -29,24 +31,24 @@ open Finset Nat
 
 variable {α : Type*} [Group α] [Fintype α] [IsCyclic α]
 
-/-- **The elements of a cyclic group whose order is a multiple of `f`, counted by order.**
+/-- **The elements of a cyclic group whose order satisfies `p`, counted by order.**
 Each divisor `d` of the group order contributes its `φ d` elements of order exactly `d`, and the
-condition `f ∣ orderOf τ` keeps precisely the divisors that `f` divides. -/
+condition `p (orderOf τ)` keeps precisely the divisors satisfying `p`. -/
 @[to_additive
-/-- **The elements of a finite additive cyclic group whose order is a multiple of `f`, counted by
+/-- **The elements of a finite additive cyclic group whose order satisfies `p`, counted by
 order.** Each divisor `d` of the group order contributes its `φ d` elements of `addOrderOf`
-exactly `d`, and the condition `f ∣ addOrderOf τ` keeps precisely the divisors that `f`
-divides. -/]
-theorem IsCyclic.card_filter_dvd_orderOf (f : ℕ) :
-    #{τ : α | f ∣ orderOf τ} =
-      ∑ d ∈ {d ∈ (Fintype.card α).divisors | f ∣ d}, φ d := by
+exactly `d`, and the condition `p (addOrderOf τ)` keeps precisely the divisors satisfying
+`p`. -/]
+theorem IsCyclic.card_filter_orderOf_eq_sum_totient (p : ℕ → Prop) [DecidablePred p] :
+    #{τ : α | p (orderOf τ)} =
+      ∑ d ∈ {d ∈ (Fintype.card α).divisors | p d}, φ d := by
   classical
   rw [card_eq_sum_card_fiberwise (f := fun τ : α ↦ orderOf τ)
-    (t := {d ∈ (Fintype.card α).divisors | f ∣ d})]
+    (t := {d ∈ (Fintype.card α).divisors | p d})]
   · refine sum_congr rfl fun d hd ↦ ?_
     rw [mem_filter, Nat.mem_divisors] at hd
     have hfib : Finset.filter (fun a : α ↦ orderOf a = d)
-          (Finset.filter (fun τ : α ↦ f ∣ orderOf τ) Finset.univ)
+          (Finset.filter (fun τ : α ↦ p (orderOf τ)) Finset.univ)
         = Finset.filter (fun a : α ↦ orderOf a = d) Finset.univ := by
       ext τ
       simp only [Finset.mem_filter, Finset.mem_univ, true_and]
@@ -56,3 +58,14 @@ theorem IsCyclic.card_filter_dvd_orderOf (f : ℕ) :
     rw [mem_coe, mem_filter] at hτ
     rw [mem_coe, mem_filter, Nat.mem_divisors]
     exact ⟨⟨orderOf_dvd_card, Fintype.card_ne_zero⟩, hτ.2⟩
+
+/-- **The elements of a cyclic group whose order is a multiple of `f`, counted by order.**
+The divisibility case of `IsCyclic.card_filter_orderOf_eq_sum_totient`. -/
+@[to_additive
+/-- **The elements of a finite additive cyclic group whose order is a multiple of `f`, counted by
+order.** The divisibility case of
+`AddCommGroup.card_filter_addOrderOf_eq_sum_totient`. -/]
+theorem IsCyclic.card_filter_dvd_orderOf_eq_sum_totient (f : ℕ) :
+    #{τ : α | f ∣ orderOf τ} =
+      ∑ d ∈ {d ∈ (Fintype.card α).divisors | f ∣ d}, φ d :=
+  IsCyclic.card_filter_orderOf_eq_sum_totient (f ∣ ·)

--- a/TauCeti/GroupTheory/SpecificGroups/CyclicOrderCount.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CyclicOrderCount.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.SpecificGroups.Cyclic
+
+/-!
+# Counting the elements of a cyclic group whose order is a multiple of `f`
+
+In a finite cyclic group, the number of elements whose order is divisible by `f` is the sum of
+`φ d` over the divisors `d` of the group order that `f` divides.
+
+Mathlib counts elements of an *exact* order: `IsCyclic.card_orderOf_eq_totient` says there are
+`φ d` of them for each `d` dividing the group order. Summing that over the divisors selected by
+`f` is the whole content here.
+
+## Main results
+
+* `IsCyclic.card_filter_dvd_orderOf`: the count is `∑ φ d` over the divisors `d` of the
+  group order with `f ∣ d`.
+-/
+
+public section
+
+open Finset Nat
+
+namespace IsCyclic
+
+variable {α : Type*} [Group α] [Fintype α] [IsCyclic α]
+
+/-- **The elements of a cyclic group whose order is a multiple of `f`, counted by order.**
+Each divisor `d` of the group order contributes its `φ d` elements of order exactly `d`, and the
+condition `f ∣ orderOf τ` keeps precisely the divisors that `f` divides. -/
+theorem card_filter_dvd_orderOf (f : ℕ) :
+    #{τ : α | f ∣ orderOf τ} =
+      ∑ d ∈ {d ∈ (Fintype.card α).divisors | f ∣ d}, φ d := by
+  classical
+  rw [card_eq_sum_card_fiberwise (f := fun τ : α ↦ orderOf τ)
+    (t := {d ∈ (Fintype.card α).divisors | f ∣ d})]
+  · refine sum_congr rfl fun d hd ↦ ?_
+    rw [mem_filter, Nat.mem_divisors] at hd
+    have hfib : Finset.filter (fun a : α ↦ orderOf a = d)
+          (Finset.filter (fun τ : α ↦ f ∣ orderOf τ) Finset.univ)
+        = Finset.filter (fun a : α ↦ orderOf a = d) Finset.univ := by
+      ext τ
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      exact ⟨fun h ↦ h.2, fun h ↦ ⟨h ▸ hd.2, h⟩⟩
+    rw [hfib, IsCyclic.card_orderOf_eq_totient hd.1.1]
+  · intro τ hτ
+    rw [mem_coe, mem_filter] at hτ
+    rw [mem_coe, mem_filter, Nat.mem_divisors]
+    exact ⟨⟨orderOf_dvd_card, Fintype.card_ne_zero⟩, hτ.2⟩
+
+end IsCyclic


### PR DESCRIPTION
> [!NOTE]
> **Parked, as offered.** This PR's body asked the `scope` rubric to say plainly if its position was
> that no Layer 9 prerequisite may land before the preceding layers exist, undertaking to re-draft
> and park rather than churn the diff. On `d0ae7e0` it said so: *"Park this PR until Layers 7.2 and
> 8 exist on main or in viable open dependency PRs."* So it is a draft again, and I am not
> re-arguing it.
>
> The other nine rubrics approve on this head.
>
> **What unparks it.** Layer 8 is substantially on `main` already — 8.1's two restriction laws are
> `IsArithFrobAt.restrictNormal` and `NumberField.restrictScalars_eq_pow_inertiaDeg`, and 8.2's
> fixed-field and fibre-count pieces landed in #5812 and #5814. The remaining gap is **Layer 7.2**,
> and specifically its *group identification* rather than its irreducibility. The condition, as
> corrected in the thread on 2026-09-10, is that a consumer in the Chebotarev development actually
> applies `IsCyclotomicExtension.autEquivPow` to `irreducible_cyclotomic_of_unramified` — Layer
> 7.2's conclusion being **used**, not merely named, since the project has deliberately chosen not
> to give the composite a name.
>
> **Re-checked 2026-09-14 against `main` at `2c8bdc7e9`: still unmet on `main`, so the PR stays
> parked — but the gap has narrowed to one named lemma.**
>
> *What was still missing at the last check, and now exists in an open green PR.* The condition has
> two halves. The irreducibility half has been on `main` since 2026-09-08 (#5633):
> `TauCeti/NumberTheory/Chebotarev/AuxiliaryPrime.lean` consumes
> `IsCyclotomicExtension.irreducible_cyclotomic_of_unramified` to discharge the last conjunct of
> `exists_auxiliaryPrime`. The identification half did not exist anywhere — `autEquivPow` appeared
> under `TauCeti/` only in the module docstring of `IrreducibleOfUnramified.lean`. It now does:
> **#6748** adds `TauCeti/NumberTheory/Cyclotomic/Aut.lean` with
> `IsCyclotomicExtension.card_aut_eq_totient` and `IsCyclotomicExtension.isCyclic_aut`, which apply
> `autEquivPow` to an irreducibility hypothesis and identify `Gal(K(ζ_n)/K)` as cyclic of order
> `φ(n)`. That PR is all-green on `49c987d8` and in the merge queue.
>
> *What is still missing.* The **composite**. Nothing yet applies that identification to
> `irreducible_cyclotomic_of_unramified`'s output, and the condition as stated asks for Layer 7.2's
> conclusion to be used rather than merely available. Irreducibility is the *input* to the
> identification, so consuming it does not discharge the condition — the `scope` rubric's wording on
> `3b3f42bd` (2026-09-10), *"the still-incomplete Layer 7.2 cyclotomic-group identification"*, was
> written with `AuxiliaryPrime.lean` already on `main` and already consuming the irreducibility.
>
> *So what unparks this is now a single writable lemma*, not an open-ended wait: for `q` prime and
> unramified in `K`, `Gal(K(ζ_q)/K)` is cyclic of order `q - 1`, by feeding
> `irreducible_cyclotomic_of_unramified` into `card_aut_eq_totient` and `isCyclic_aut` and reducing
> `φ q` by `Nat.totient_prime`. `IrreducibleOfUnramified.lean`'s own docstring names `[K(ζ_q) : K]
> = q - 1` as the point of the theorem, so this is its intended consumer rather than a new
> direction. It becomes writable once #6748 is on `main`; this PR stays a draft until then.
> Recording the check so a later one need not redo it.

---

In a finite cyclic group, the elements whose order is a multiple of `f` are counted by a totient
sum over the divisors that `f` divides.

```lean
theorem IsCyclic.card_filter_dvd_orderOf (f : ℕ) :
    #{τ : α | f ∣ orderOf τ} = ∑ d ∈ {d ∈ (Fintype.card α).divisors | f ∣ d}, φ d
```

Mathlib counts elements of an *exact* order — `IsCyclic.card_orderOf_eq_totient` gives `φ d` of
them for each `d` dividing the group order. Partitioning the tagged set by order and summing that
is the whole content; the proof is `Finset.card_eq_sum_card_fiberwise` plus the observation that
the fibre over `d` is unconstrained, because `orderOf τ = d` already implies `f ∣ orderOf τ` once
`f ∣ d`.

### Why this is a separate unit from Layer 9's count

The Chebotarev roadmap's Layer 9 asks for

```text
#{τ ∈ H | f ∣ orderOf τ} = h * ∏_{p ∣ f} (1 - p^{-(v_p(h) - v_p(f) + 1)}).
```

That splits cleanly in two, and only the first half is group theory. Getting from the totient sum
to the product is an identity about `Nat.factorization` and `Nat.totient` with no group in it, and
it wants inclusion–exclusion over `f.primeFactors`. Shipping the group-theoretic half on its own
keeps each piece checkable against the API it actually uses, and leaves the arithmetic half free
to be stated over `ℕ` rather than about a group.

Consequently this PR carries **no `tauceti-target:v1` marker**: it supplies a prerequisite that
Layer 9 needs rather than authoring Layer 9's declaration. `Suggested.lean` pins that target's
shape as `card_taggedElements_cyclic`, the product formula, which this PR does not prove — so
attaching Layer 9's id here would make this a duplicate of whoever completes it.

### Absence

Mathlib states the exact-order count but not the multiples-of-`f` count; the untruncated greps for
`card_filter_dvd_orderOf`, `dvd_orderOf.*card` and `taggedElements` return nothing, against a
positive control of eight hits for `card_orderOf_eq_totient` in the same file.

The pinned source does not prove this either, which is worth stating precisely because it is a
near miss: it *bounds* the ratio `|H_n|/|H|` — `H_n_ratio_ge`, `H_n_over_H_tends_to_one`,
`ratio_card_dvd_orderOf_tendsto_one` — and never computes the count. The roadmap deliberately asks
for the exact identity instead, so this is new rather than adapted.

### Placement

`TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean`, alongside `Cyclic/Basic.lean` and
mirroring Mathlib's `GroupTheory/SpecificGroups/Cyclic.lean`, in `namespace IsCyclic`. Nothing in
the statement mentions a field, a prime ideal or a Galois group, so it does not belong under a
campaign directory.

### Roadmap ordering, and why this no longer stacks

This PR used to be a draft stacked on #5633 (Layer 7.1), itself stacked on #5538 (Layer 7.2),
because the `scope` rubric had asked for an actual dependency edge rather than "open PRs
alongside". That edge is gone: **#5538 was closed on 2026-09-06 by the queue's round-cap
housekeeping** — "reviewed to the round cap without reaching an all-green review" — not on the
merits of its mathematics. #5633 therefore depends on a retired PR too.

Stacking on a retired PR is worse than not stacking. It made this PR's diff carry 550 lines across
five files it does not use and cannot land, which is a `scope` defect in its own right. So the
branch is now rebased onto `main` and carries only its own commits. The diff has since narrowed
further: the `Cyclic.lean` → `Cyclic/Basic.lean` regrouping that used to be part of it landed
independently on `main` on 2026-09-08 in #5977, so **this PR is now a single new file** —
`TauCeti/GroupTheory/SpecificGroups/Cyclic/OrderCount.lean`, 75 added lines, nothing moved and
nothing else touched.

**The ordering argument for taking it now.** The dependency was always documentary, never
technical: this file's entire import list is one line,
`public import Mathlib.GroupTheory.SpecificGroups.Cyclic`, so it has no TauCeti import at all and
consumes nothing in the repository. What Layers 7.1 and
7.2 supply is Layer 9's *context* — the roadmap's Layer 9 opens "By 7.2, `H_q` is cyclic of order
`q - 1` and `f^r ∣ q - 1`", identifying the group this count is eventually applied to. The
statement proved here quantifies over every finite cyclic group, so it is well-posed and useful
whether or not that identification exists yet, and it cannot be invalidated by how Layers 7.1 and
7.2 are eventually restated. Holding it behind a PR the housekeeping has retired does not make it
more correct; it only means the roadmap's Layer 9 prerequisite waits on a revival that needs a
human decision.

If the reviewing position is instead that no Layer 9 prerequisite may land before Layers 7.1 and
7.2 exist on `main`, say so and I will re-mark this a draft and park it against #5538's revival
rather than churn the diff.

Roadmap: Chebotarev

Provenance: none — no code adapted, for the reason given under **Absence** above. The pinned
source `CBirkbeck/chebotarev-density @ 8575c9df1ae0a61120ab5c964c7911414254bec7`
(Birkbeck--Brasca, Apache-2.0) contains only the asymptotic bounds, not this identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF





