### PR TITLE
feat: the dimension of the Vinberg Z/3-model of split E8

### DIFF
--- a/TauCeti/Algebra/Lie/E8/Vinberg.lean
+++ b/TauCeti/Algebra/Lie/E8/Vinberg.lean
@@ -7,8 +7,9 @@ module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.Finrank
 
-public import Mathlib.LinearAlgebra.Dual.Lemmas
 public import Mathlib.LinearAlgebra.ExteriorPower.Basis
+public import Mathlib.LinearAlgebra.FreeModule.Finite.Matrix
+public import Mathlib.RingTheory.Finiteness.Prod
 
 /-!
 # The dimension of the Vinberg `ℤ/3`-model of split `E₈`
@@ -23,10 +24,11 @@ the three summands have dimensions `80`, `84` and `84`, so the carrier is `248`-
 dimension of `E₈`.
 
 The three inputs are `TauCeti.finrank_sl` for `𝔰𝔩₉`, Mathlib's `exteriorPower.finrank_eq` (which
-gives `(dim K⁹).choose 3 = 84`) for `⋀³(K⁹)`, and `Subspace.dual_finrank_eq` for the dual summand.
-The `84` is a numeric instance of `exteriorPower.finrank_eq` rather than a piece of general
+gives `(dim K⁹).choose 3 = 84`) for `⋀³(K⁹)`, and `Module.finrank_linearMap_self` for the dual
+summand. The `84` is a numeric instance of `exteriorPower.finrank_eq` rather than a piece of general
 exterior-power theory, so it lives here beside the count that consumes it. The direct sum of three
-summands is spelled as an iterated product, the form `Module.finrank_prod` computes with.
+summands is spelled as an iterated product, the form `Module.finrank_prod` computes with. All three
+summands are finite free, so no field is needed anywhere: a nontrivial commutative ring does.
 
 **What is not proved here.** Only the underlying `K`-module is treated: the graded bracket, the
 Jacobi identity for it, Killing-simplicity of type `E₈`, and the comparison with Mathlib's
@@ -72,12 +74,12 @@ theorem finrank_sl_fin_nine (K : Type*) [CommRing K] [StrongRankCondition K] :
 `finrank (𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*) = 80 + 84 + 84 = 248`.
 
 Only the `K`-module is at issue; the graded Lie bracket that makes the sum `E₈` is not built
-here. Unlike the two summand counts, this one is over a field: the dual summand contributes its
-`84` by `Subspace.dual_finrank_eq`, which is a statement about finite-dimensional vector spaces. -/
-theorem finrank_prod_sl_exteriorPower_dual (K : Type*) [Field K] :
+here. Like the two summand counts this needs no more than a nontrivial commutative ring: the dual
+summand is finite free of the same rank as `⋀³(K⁹)` by `Module.finrank_linearMap_self`. -/
+theorem finrank_prod_sl_exteriorPower_dual (K : Type*) [CommRing K] [Nontrivial K] :
     finrank K (SpecialLinear.sl (Fin 9) K ×
         ⋀[K]^3 (Fin 9 → K) × Dual K (⋀[K]^3 (Fin 9 → K))) = 248 := by
-  rw [Module.finrank_prod, Module.finrank_prod, Subspace.dual_finrank_eq,
+  rw [Module.finrank_prod, Module.finrank_prod, Module.finrank_linearMap_self,
     finrank_sl_fin_nine, finrank_exteriorPower_three_nine]
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/E8/Vinberg.lean
+++ b/TauCeti/Algebra/Lie/E8/Vinberg.lean
@@ -32,20 +32,13 @@ summands is spelled as an iterated product, the form `Module.finrank_prod` compu
 Jacobi identity for it, Killing-simplicity of type `E₈`, and the comparison with Mathlib's
 Serre-construction `LieAlgebra.e₈` are all separate statements and none of them is proved here. A
 `248`-dimensional module is of course not by itself `E₈`; the point of the count is that it is the
-arithmetic obstruction the construction must clear, and the roadmap asks for it as a named check.
+arithmetic obstruction the construction must clear.
 
 ## Main results
 
 * `TauCeti.finrank_exteriorPower_three_nine`: `⋀³(K⁹)` is `84`-dimensional.
 * `TauCeti.finrank_sl_fin_nine`: `𝔰𝔩₉` is `80`-dimensional.
 * `TauCeti.finrank_prod_sl_exteriorPower_dual`: `𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*` is `248`-dimensional.
-
-## Roadmap context
-
-This is the dimension check `finrank (𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*) = 248 = 80 + 84 + 84` asked for in
-Layer 8 of the
-[highest-weight roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md),
-whose `finrank_exteriorPower_three_nine` is the `⋀³(K⁹)` summand below.
 
 ## References
 

--- a/TauCeti/Algebra/Lie/E8/Vinberg.lean
+++ b/TauCeti/Algebra/Lie/E8/Vinberg.lean
@@ -61,8 +61,9 @@ theorem finrank_exteriorPower_three_nine (K : Type*) [CommRing K] [Nontrivial K]
   decide
 
 /-- **`𝔰𝔩₉` is `80`-dimensional**, the degree-zero summand of the Vinberg `ℤ/3`-model of split
-`E₈`. -/
-theorem finrank_sl_fin_nine (K : Type*) [Field K] :
+`E₈`. Like the exterior cube above, this needs no more than a commutative ring in which `finrank`
+counts basis vectors. -/
+theorem finrank_sl_fin_nine (K : Type*) [CommRing K] [StrongRankCondition K] :
     finrank K (SpecialLinear.sl (Fin 9) K) = 80 := by
   rw [finrank_sl, Fintype.card_fin]
   decide
@@ -71,7 +72,8 @@ theorem finrank_sl_fin_nine (K : Type*) [Field K] :
 `finrank (𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*) = 80 + 84 + 84 = 248`.
 
 Only the `K`-module is at issue; the graded Lie bracket that makes the sum `E₈` is not built
-here. -/
+here. Unlike the two summand counts, this one is over a field: the dual summand contributes its
+`84` by `Subspace.dual_finrank_eq`, which is a statement about finite-dimensional vector spaces. -/
 theorem finrank_prod_sl_exteriorPower_dual (K : Type*) [Field K] :
     finrank K (SpecialLinear.sl (Fin 9) K ×
         ⋀[K]^3 (Fin 9 → K) × Dual K (⋀[K]^3 (Fin 9 → K))) = 248 := by

--- a/TauCeti/Algebra/Lie/E8/Vinberg.lean
+++ b/TauCeti/Algebra/Lie/E8/Vinberg.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.Finrank
+
+public import Mathlib.LinearAlgebra.Dual.Lemmas
+public import Mathlib.LinearAlgebra.ExteriorPower.Basis
+
+/-!
+# The dimension of the Vinberg `ℤ/3`-model of split `E₈`
+
+Vinberg's `ℤ/3`-graded construction of the split exceptional Lie algebra `E₈` puts
+
+`𝔢₈ = 𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*`,
+
+with the degree-zero piece acting on the two exterior summands and the graded bracket pairing them
+back into `𝔰𝔩₉`. This file checks the dimension arithmetic that the construction has to satisfy:
+the three summands have dimensions `80`, `84` and `84`, so the carrier is `248`-dimensional, the
+dimension of `E₈`.
+
+The three inputs are `TauCeti.finrank_sl` for `𝔰𝔩₉`, Mathlib's `exteriorPower.finrank_eq` (which
+gives `(dim K⁹).choose 3 = 84`) for `⋀³(K⁹)`, and `Subspace.dual_finrank_eq` for the dual summand.
+The `84` is a numeric instance of `exteriorPower.finrank_eq` rather than a piece of general
+exterior-power theory, so it lives here beside the count that consumes it. The direct sum of three
+summands is spelled as an iterated product, the form `Module.finrank_prod` computes with.
+
+**What is not proved here.** Only the underlying `K`-module is treated: the graded bracket, the
+Jacobi identity for it, Killing-simplicity of type `E₈`, and the comparison with Mathlib's
+Serre-construction `LieAlgebra.e₈` are all separate statements and none of them is proved here. A
+`248`-dimensional module is of course not by itself `E₈`; the point of the count is that it is the
+arithmetic obstruction the construction must clear, and the roadmap asks for it as a named check.
+
+## Main results
+
+* `TauCeti.finrank_exteriorPower_three_nine`: `⋀³(K⁹)` is `84`-dimensional.
+* `TauCeti.finrank_sl_fin_nine`: `𝔰𝔩₉` is `80`-dimensional.
+* `TauCeti.finrank_prod_sl_exteriorPower_dual`: `𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*` is `248`-dimensional.
+
+## Roadmap context
+
+This is the dimension check `finrank (𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*) = 248 = 80 + 84 + 84` asked for in
+Layer 8 of the
+[highest-weight roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md),
+whose `finrank_exteriorPower_three_nine` is the `⋀³(K⁹)` summand below.
+
+## References
+
+* È. B. Vinberg, *The Weyl group of a graded Lie algebra*, Izv. Akad. Nauk SSSR 40 (1976).
+* J. C. Baez, *The octonions*, Bull. Amer. Math. Soc. 39 (2002), §4.6, for the `ℤ/3`-model of `E₈`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module LieAlgebra
+
+/-- **`⋀³(K⁹)` is `84`-dimensional**, `84` being `9.choose 3`: the exterior cube of a free module
+of rank `9`. This is the summand of the Vinberg `ℤ/3`-model of split `E₈` that appears twice, once
+as itself and once as its dual. -/
+theorem finrank_exteriorPower_three_nine (K : Type*) [CommRing K] [Nontrivial K] :
+    finrank K (⋀[K]^3 (Fin 9 → K)) = 84 := by
+  rw [exteriorPower.finrank_eq, Module.finrank_fin_fun]
+  decide
+
+/-- **`𝔰𝔩₉` is `80`-dimensional**, the degree-zero summand of the Vinberg `ℤ/3`-model of split
+`E₈`. -/
+theorem finrank_sl_fin_nine (K : Type*) [Field K] :
+    finrank K (SpecialLinear.sl (Fin 9) K) = 80 := by
+  rw [finrank_sl, Fintype.card_fin]
+  decide
+
+/-- **The Vinberg `ℤ/3`-model of split `E₈` is `248`-dimensional**:
+`finrank (𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*) = 80 + 84 + 84 = 248`.
+
+Only the `K`-module is at issue; the graded Lie bracket that makes the sum `E₈` is not built
+here. -/
+theorem finrank_prod_sl_exteriorPower_dual (K : Type*) [Field K] :
+    finrank K (SpecialLinear.sl (Fin 9) K ×
+        ⋀[K]^3 (Fin 9 → K) × Dual K (⋀[K]^3 (Fin 9 → K))) = 248 := by
+  rw [Module.finrank_prod, Module.finrank_prod, Subspace.dual_finrank_eq,
+    finrank_sl_fin_nine, finrank_exteriorPower_three_nine]
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
@@ -33,15 +33,20 @@ by nontriviality. The rank-two case is counted separately, in
 ## Main results
 
 * `TauCeti.finrank_sl`: `sl n R` has rank `(card n) ^ 2 - 1`.
-* `TauCeti.finrank_slIdeal`: the same for the trace-zero ideal of `gl n R`, which by
-  `TauCeti.derivedSeries_one_eq_slIdeal` is the derived ideal `⁅gl n R, gl n R⁆`.
 * `TauCeti.finrank_sl_add_one`: the untruncated form, for a nonempty index type.
+
+The same coordinate system also gives the `Module.Free` and `Module.Finite` instances for `sl n R`
+that any rank computation involving it needs; over a commutative ring these do not come for free
+from finiteness of the matrices.
 
 ## Implementation notes
 
 The coordinate system above is a private linear equivalence, together with the private coordinate
 map, the private matrix it inverts to and their two round-trip lemmas: they exist only to feed
-`Basis.ofEquivFun`, and the public surface of the file is the three rank statements.
+`Basis.ofEquivFun`, and the public surface of the file is the two rank statements and the two
+instances. The trace-zero reading of membership in `sl n R` is likewise a private lemma, obtained
+from the located bridge `TauCeti.slIdeal_toLieSubalgebra_eq_sl` so that no proof here unfolds
+Mathlib's `LieSubalgebra` wrapper by hand.
 -/
 
 public section
@@ -100,9 +105,19 @@ private lemma trace_ofOffDiag (g : {p : n × n // p ≠ (i₀, i₀)} → R) :
   simp only [hdiag]
   exact neg_add_cancel _
 
+/-- Membership in `sl n R` is the vanishing of the trace.
+
+Mathlib builds `LieAlgebra.SpecialLinear.sl` out of `LinearMap.ker (Matrix.traceLinearMap n R R)`,
+so the two readings of membership are definitionally equal; that conversion is crossed once here,
+through the named bridge `TauCeti.slIdeal_toLieSubalgebra_eq_sl`, rather than by unfolding the
+`LieSubalgebra` wrapper at each use. -/
+private lemma mem_sl_iff {A : Matrix n n R} : A ∈ SpecialLinear.sl n R ↔ A.trace = 0 := by
+  rw [← slIdeal_toLieSubalgebra_eq_sl R n]
+  exact mem_slIdeal_iff
+
 private lemma ofOffDiag_mem_sl (g : {p : n × n // p ≠ (i₀, i₀)} → R) :
     ofOffDiag i₀ g ∈ SpecialLinear.sl n R :=
-  LinearMap.mem_ker.mpr (trace_ofOffDiag i₀ g)
+  mem_sl_iff.mpr (trace_ofOffDiag i₀ g)
 
 /-- A trace-zero matrix is recovered from its coordinates: the entry it omits is forced. -/
 private lemma ofOffDiag_offDiagCoords {A : Matrix n n R} (hA : A.trace = 0) :
@@ -133,10 +148,29 @@ private def slEquivFun : SpecialLinear.sl n R ≃ₗ[R] ({p : n × n // p ≠ (i
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
   invFun g := ⟨ofOffDiag i₀ g, ofOffDiag_mem_sl i₀ g⟩
-  left_inv A := Subtype.ext (ofOffDiag_offDiagCoords i₀ (LinearMap.mem_ker.mp A.2))
+  left_inv A := Subtype.ext (ofOffDiag_offDiagCoords i₀ (mem_sl_iff.mp A.2))
   right_inv g := offDiagCoords_ofOffDiag i₀ g
 
 end Coordinates
+
+section FreeFinite
+
+variable [CommRing R]
+
+/-- **`sl n R` is a free module.** For a nonempty index type the coordinates above are a basis of
+it; for an empty one it is the zero module. -/
+instance : Module.Free R (SpecialLinear.sl n R) := by
+  rcases isEmpty_or_nonempty n with hn | ⟨⟨i₀⟩⟩
+  · infer_instance
+  · exact Module.Free.of_basis (Basis.ofEquivFun (slEquivFun i₀))
+
+/-- **`sl n R` is a finite module**, the coordinates above being finite in number. -/
+instance : Module.Finite R (SpecialLinear.sl n R) := by
+  rcases isEmpty_or_nonempty n with hn | ⟨⟨i₀⟩⟩
+  · infer_instance
+  · exact Module.Finite.of_basis (Basis.ofEquivFun (slEquivFun i₀))
+
+end FreeFinite
 
 section Finrank
 
@@ -149,10 +183,9 @@ subtraction `0 - 1` doing the work. -/
 theorem finrank_sl :
     finrank R (SpecialLinear.sl n R) = Fintype.card n ^ 2 - 1 := by
   rcases isEmpty_or_nonempty n with hn | ⟨⟨i₀⟩⟩
-  -- With no indices at all the only matrix is `0`, and `0 - 1 = 0` in `ℕ`.
-  · have hsub : Subsingleton (SpecialLinear.sl n R) :=
-      ⟨fun A B => Subtype.ext (Matrix.ext fun i => isEmptyElim i)⟩
-    have hnt : Nontrivial R := nontrivial_of_invariantBasisNumber R
+  -- With no indices at all the only matrix is `0`, and `0 - 1 = 0` in `ℕ`. `Subsingleton (sl n R)`
+  -- is an instance there; `hnt` installs the other hypothesis of `finrank_zero_of_subsingleton`.
+  · have hnt : Nontrivial R := nontrivial_of_invariantBasisNumber R
     rw [Module.finrank_zero_of_subsingleton, Fintype.card_eq_zero]
     simp
   -- Otherwise the free coordinates are the places other than `(i₀, i₀)`, and there are
@@ -162,15 +195,6 @@ theorem finrank_sl :
     simp only [Fintype.card_option, Fintype.card_prod] at hcard
     rw [sq, ← hcard]
     omega
-
-/-- The trace-zero ideal of `gl n R` has rank `(card n) ^ 2 - 1`: the `TauCeti.slIdeal`
-spelling of `TauCeti.finrank_sl`. By `TauCeti.derivedSeries_one_eq_slIdeal` this is the rank of the
-derived ideal `⁅gl n R, gl n R⁆`. -/
-theorem finrank_slIdeal :
-    finrank R (slIdeal R n) = Fintype.card n ^ 2 - 1 := by
-  rw [← finrank_sl R n]
-  exact LinearEquiv.finrank_eq (LinearEquiv.ofEq _ _
-    (congrArg LieSubalgebra.toSubmodule (slIdeal_toLieSubalgebra_eq_sl R n)))
 
 variable [Nonempty n]
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
@@ -26,9 +26,10 @@ nonemptiness hypothesis, and `TauCeti.finrank_sl_add_one` records the untruncate
 
 No field, characteristic or algebraic closure hypothesis is used: the strong rank condition is all
 that `finrank` needs in order to count the basis vectors, and over a commutative ring it is implied
-by nontriviality. The rank-two case is counted separately, in
-`TauCeti/Algebra/Lie/Sl2/Basic.lean`: there the rank is read off the named basis
-`e`, `f`, `h` (`TauCeti.slFinTwoBasis`) that the `sl₂`-triple calculus of that file needs anyway.
+by nontriviality. This is the only rank statement for `sl n R` in the repository: the rank-two case
+is the instance `n = Fin 2`, and `TauCeti/Algebra/Lie/Sl2/Basic.lean` takes its rank `3` and its
+`Module.Free`/`Module.Finite` instances from here rather than from its own named basis
+`e`, `f`, `h` (`TauCeti.slFinTwoBasis`).
 
 ## Main results
 
@@ -180,6 +181,7 @@ variable (R n) [CommRing R] [StrongRankCondition R]
 
 For an empty index type the matrix algebra is trivial and both sides are `0`, the truncated
 subtraction `0 - 1` doing the work. -/
+@[simp]
 theorem finrank_sl :
     finrank R (SpecialLinear.sl n R) = Fintype.card n ^ 2 - 1 := by
   rcases isEmpty_or_nonempty n with hn | ⟨⟨i₀⟩⟩

--- a/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.Basic
+
+import Mathlib.LinearAlgebra.Dimension.Constructions
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+
+/-!
+# The dimension of the special linear Lie algebra
+
+Over a field, `sl n K` is the kernel of the trace functional on the `n × n` matrices. The trace is
+surjective as soon as there is an index at all — the matrix unit `Eᵢᵢ` scaled by `c` has trace `c` —
+so rank-nullity makes its kernel a hyperplane:
+
+`finrank K (sl n K) = (card n) ^ 2 - 1`.
+
+The truncated subtraction is not a fudge. For an empty index type the matrix algebra is the zero
+ring and both sides are `0`, since `0 - 1 = 0` in `ℕ`. The statement therefore carries no
+nonemptiness hypothesis, and `TauCeti.finrank_sl_add_one` records the untruncated form
+`finrank K (sl n K) + 1 = (card n) ^ 2` where nonemptiness is available.
+
+A field is genuinely used. The same formula holds over any commutative ring, because `sl n R` is
+free on the off-diagonal matrix units together with the differences `Eᵢᵢ - E_{i₀i₀}`, but reading
+it off needs that explicit basis; only its rank-two case is on `main`
+(`TauCeti.slFinTwoBasis`, with `TauCeti.finrank_sl_fin_two` its dimension count over any ring
+satisfying the strong rank condition). Rank-nullity, the argument used here, instead needs the
+kernel to be complemented, hence needs the field.
+
+## Main results
+
+* `TauCeti.surjective_traceLinearMap` and `TauCeti.range_traceLinearMap`: the trace of a square
+  matrix is surjective onto the scalars.
+* `TauCeti.finrank_sl`: `sl n K` has dimension `(card n) ^ 2 - 1`.
+* `TauCeti.finrank_slIdeal`: the same for the trace-zero ideal of `gl n K`.
+* `TauCeti.finrank_sl_add_one`: the untruncated form, for a nonempty index type.
+
+## Roadmap context
+
+Layer 8 of the
+[highest-weight roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md)
+asks for the dimension check `finrank (𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*) = 248 = 80 + 84 + 84` of the
+Vinberg `ℤ/3`-model of split `E₈`. This file supplies the `80`; the check itself is in
+`TauCeti/Algebra/Lie/E8/Vinberg.lean`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Matrix Module LieAlgebra
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable {K : Type*} {n : Type*} [Fintype n]
+
+section Trace
+
+variable (K n) [CommRing K] [Nonempty n]
+
+/-- **The trace is surjective onto the scalars** as soon as there is an index: the matrix unit
+`Eᵢᵢ` scaled by `c` has trace `c`. -/
+theorem surjective_traceLinearMap :
+    Function.Surjective (Matrix.traceLinearMap n K K) := by
+  classical
+  intro c
+  exact ⟨Matrix.single (Classical.arbitrary n) (Classical.arbitrary n) c,
+    Matrix.trace_single_eq_same _ _⟩
+
+/-- The trace has full range: the `LinearMap.range` form of
+`TauCeti.surjective_traceLinearMap`, which is what rank-nullity consumes. -/
+theorem range_traceLinearMap :
+    LinearMap.range (Matrix.traceLinearMap n K K) = ⊤ :=
+  LinearMap.range_eq_top.2 (surjective_traceLinearMap K n)
+
+end Trace
+
+section Finrank
+
+variable (K n) [Field K] [DecidableEq n]
+
+/-- The special linear Lie algebra is, as a subspace, the kernel of the trace. -/
+theorem toSubmodule_sl :
+    (SpecialLinear.sl n K : Submodule K (Matrix n n K))
+      = LinearMap.ker (Matrix.traceLinearMap n K K) :=
+  Submodule.ext fun _ => Iff.rfl
+
+/-- **`sl n K` is a hyperplane in the matrices**: `finrank K (sl n K) = (card n) ^ 2 - 1`.
+
+For an empty index type the matrix algebra is trivial and both sides are `0`, the truncated
+subtraction `0 - 1` doing the work. -/
+theorem finrank_sl :
+    finrank K (SpecialLinear.sl n K) = Fintype.card n ^ 2 - 1 := by
+  have hmatrix : finrank K (Matrix n n K) = Fintype.card n ^ 2 := by
+    rw [Module.finrank_matrix, finrank_self, mul_one, sq]
+  have hrank := LinearMap.finrank_range_add_finrank_ker (Matrix.traceLinearMap n K K)
+  rw [hmatrix] at hrank
+  have hker : finrank K (SpecialLinear.sl n K)
+      = finrank K (LinearMap.ker (Matrix.traceLinearMap n K K)) :=
+    LinearEquiv.finrank_eq (LinearEquiv.ofEq _ _ (toSubmodule_sl K n))
+  rw [hker]
+  rcases isEmpty_or_nonempty n with _ | _
+  · have hcard : Fintype.card n ^ 2 = 0 := by simp [Fintype.card_eq_zero]
+    rw [hcard] at hrank ⊢
+    omega
+  · rw [range_traceLinearMap K n, finrank_top, finrank_self] at hrank
+    omega
+
+/-- The trace-zero ideal of `gl n K` has dimension `(card n) ^ 2 - 1`: the `TauCeti.slIdeal`
+spelling of `TauCeti.finrank_sl`. -/
+theorem finrank_slIdeal :
+    finrank K (slIdeal K n) = Fintype.card n ^ 2 - 1 := by
+  rw [← finrank_sl K n]
+  exact LinearEquiv.finrank_eq (LinearEquiv.ofEq _ _
+    (congrArg LieSubalgebra.toSubmodule (slIdeal_toLieSubalgebra_eq_sl K n)))
+
+variable [Nonempty n]
+
+/-- The untruncated codimension-one statement: `sl n K` is a hyperplane in the matrices. -/
+theorem finrank_sl_add_one :
+    finrank K (SpecialLinear.sl n K) + 1 = Fintype.card n ^ 2 := by
+  have hpos : 1 ≤ Fintype.card n ^ 2 := Nat.one_le_pow _ _ Fintype.card_pos
+  rw [finrank_sl]
+  omega
+
+end Finrank
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
@@ -8,14 +8,14 @@ module
 public import TauCeti.Algebra.Lie.GeneralLinear.Basic
 
 import Mathlib.LinearAlgebra.Dimension.Constructions
-import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+import Mathlib.LinearAlgebra.Dual.Lemmas
 
 /-!
 # The dimension of the special linear Lie algebra
 
 Over a field, `sl n K` is the kernel of the trace functional on the `n × n` matrices. The trace is
 surjective as soon as there is an index at all — the matrix unit `Eᵢᵢ` scaled by `c` has trace `c` —
-so rank-nullity makes its kernel a hyperplane:
+so it is a nonzero functional and its kernel is a hyperplane:
 
 `finrank K (sl n K) = (card n) ^ 2 - 1`.
 
@@ -28,24 +28,16 @@ A field is genuinely used. The same formula holds over any commutative ring, bec
 free on the off-diagonal matrix units together with the differences `Eᵢᵢ - E_{i₀i₀}`, but reading
 it off needs that explicit basis; only its rank-two case is on `main`
 (`TauCeti.slFinTwoBasis`, with `TauCeti.finrank_sl_fin_two` its dimension count over any ring
-satisfying the strong rank condition). Rank-nullity, the argument used here, instead needs the
-kernel to be complemented, hence needs the field.
+satisfying the strong rank condition). The hyperplane argument used here instead goes through
+`Module.Dual.finrank_ker_add_one_of_ne_zero`, and so needs the field.
 
 ## Main results
 
-* `TauCeti.surjective_traceLinearMap` and `TauCeti.range_traceLinearMap`: the trace of a square
-  matrix is surjective onto the scalars.
+* `TauCeti.traceLinearMap_surjective`: the trace of a square matrix is surjective onto the scalars.
 * `TauCeti.finrank_sl`: `sl n K` has dimension `(card n) ^ 2 - 1`.
-* `TauCeti.finrank_slIdeal`: the same for the trace-zero ideal of `gl n K`.
+* `TauCeti.finrank_slIdeal`: the same for the trace-zero ideal of `gl n K`, which by
+  `TauCeti.derivedSeries_one_eq_slIdeal` is the derived ideal `⁅gl n K, gl n K⁆`.
 * `TauCeti.finrank_sl_add_one`: the untruncated form, for a nonempty index type.
-
-## Roadmap context
-
-Layer 8 of the
-[highest-weight roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md)
-asks for the dimension check `finrank (𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*) = 248 = 80 + 84 + 84` of the
-Vinberg `ℤ/3`-model of split `E₈`. This file supplies the `80`; the check itself is in
-`TauCeti/Algebra/Lie/E8/Vinberg.lean`.
 -/
 
 public section
@@ -60,34 +52,20 @@ variable {K : Type*} {n : Type*} [Fintype n]
 
 section Trace
 
-variable (K n) [CommRing K] [Nonempty n]
+variable (K n) [Semiring K] [Nonempty n]
 
 /-- **The trace is surjective onto the scalars** as soon as there is an index: the matrix unit
-`Eᵢᵢ` scaled by `c` has trace `c`. -/
-theorem surjective_traceLinearMap :
-    Function.Surjective (Matrix.traceLinearMap n K K) := by
-  classical
-  intro c
-  exact ⟨Matrix.single (Classical.arbitrary n) (Classical.arbitrary n) c,
-    Matrix.trace_single_eq_same _ _⟩
-
-/-- The trace has full range: the `LinearMap.range` form of
-`TauCeti.surjective_traceLinearMap`, which is what rank-nullity consumes. -/
-theorem range_traceLinearMap :
-    LinearMap.range (Matrix.traceLinearMap n K K) = ⊤ :=
-  LinearMap.range_eq_top.2 (surjective_traceLinearMap K n)
+`Eᵢᵢ` scaled by `c` has trace `c`. This is `Matrix.trace_surjective` for the trace as a linear
+map. -/
+theorem traceLinearMap_surjective :
+    Function.Surjective (Matrix.traceLinearMap n K K) :=
+  Matrix.trace_surjective
 
 end Trace
 
 section Finrank
 
 variable (K n) [Field K] [DecidableEq n]
-
-/-- The special linear Lie algebra is, as a subspace, the kernel of the trace. -/
-theorem toSubmodule_sl :
-    (SpecialLinear.sl n K : Submodule K (Matrix n n K))
-      = LinearMap.ker (Matrix.traceLinearMap n K K) :=
-  Submodule.ext fun _ => Iff.rfl
 
 /-- **`sl n K` is a hyperplane in the matrices**: `finrank K (sl n K) = (card n) ^ 2 - 1`.
 
@@ -97,21 +75,27 @@ theorem finrank_sl :
     finrank K (SpecialLinear.sl n K) = Fintype.card n ^ 2 - 1 := by
   have hmatrix : finrank K (Matrix n n K) = Fintype.card n ^ 2 := by
     rw [Module.finrank_matrix, finrank_self, mul_one, sq]
-  have hrank := LinearMap.finrank_range_add_finrank_ker (Matrix.traceLinearMap n K K)
-  rw [hmatrix] at hrank
+  -- `sl n K` is by definition the kernel of the trace, so the two have the same dimension.
+  have hsub : (SpecialLinear.sl n K : Submodule K (Matrix n n K))
+      = LinearMap.ker (Matrix.traceLinearMap n K K) := Submodule.ext fun _ => Iff.rfl
   have hker : finrank K (SpecialLinear.sl n K)
       = finrank K (LinearMap.ker (Matrix.traceLinearMap n K K)) :=
-    LinearEquiv.finrank_eq (LinearEquiv.ofEq _ _ (toSubmodule_sl K n))
+    LinearEquiv.finrank_eq (LinearEquiv.ofEq _ _ hsub)
   rw [hker]
   rcases isEmpty_or_nonempty n with _ | _
   · have hcard : Fintype.card n ^ 2 = 0 := by simp [Fintype.card_eq_zero]
-    rw [hcard] at hrank ⊢
+    have hle := Submodule.finrank_le (LinearMap.ker (Matrix.traceLinearMap n K K))
     omega
-  · rw [range_traceLinearMap K n, finrank_top, finrank_self] at hrank
+  · have hne : Matrix.traceLinearMap n K K ≠ 0 := fun h => by
+      obtain ⟨A, hA⟩ := traceLinearMap_surjective K n (1 : K)
+      rw [h, LinearMap.zero_apply] at hA
+      exact zero_ne_one hA
+    have hhyp := Module.Dual.finrank_ker_add_one_of_ne_zero hne
     omega
 
 /-- The trace-zero ideal of `gl n K` has dimension `(card n) ^ 2 - 1`: the `TauCeti.slIdeal`
-spelling of `TauCeti.finrank_sl`. -/
+spelling of `TauCeti.finrank_sl`. By `TauCeti.derivedSeries_one_eq_slIdeal` this is the dimension
+of the derived ideal `⁅gl n K, gl n K⁆`. -/
 theorem finrank_slIdeal :
     finrank K (slIdeal K n) = Fintype.card n ^ 2 - 1 := by
   rw [← finrank_sl K n]

--- a/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
@@ -7,36 +7,42 @@ module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.Basic
 
-import Mathlib.LinearAlgebra.Dimension.Constructions
-import Mathlib.LinearAlgebra.Dual.Lemmas
+import Mathlib.LinearAlgebra.Dimension.Finite
+import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 
 /-!
 # The dimension of the special linear Lie algebra
 
-Over a field, `sl n K` is the kernel of the trace functional on the `n × n` matrices. The trace is
-surjective as soon as there is an index at all (`Matrix.trace_surjective`), so it is a nonzero
-functional and its kernel is a hyperplane:
+`sl n R` is the kernel of the trace on the `n × n` matrices, and it is free of rank
+`(card n) ^ 2 - 1` over any commutative ring: after fixing an index `i₀`, the entries away from the
+`(i₀, i₀)` place are free coordinates, and the trace-zero condition determines the `(i₀, i₀)` entry
+as minus the sum of the other diagonal entries. Reading the rank off that coordinate system gives
 
-`finrank K (sl n K) = (card n) ^ 2 - 1`.
+`finrank R (sl n R) = (card n) ^ 2 - 1`.
 
 The truncated subtraction is not a fudge. For an empty index type the matrix algebra is the zero
 ring and both sides are `0`, since `0 - 1 = 0` in `ℕ`. The statement therefore carries no
 nonemptiness hypothesis, and `TauCeti.finrank_sl_add_one` records the untruncated form
-`finrank K (sl n K) + 1 = (card n) ^ 2` where nonemptiness is available.
+`finrank R (sl n R) + 1 = (card n) ^ 2` where nonemptiness is available.
 
-A field is genuinely used. The same formula holds over any commutative ring, because `sl n R` is
-free on the off-diagonal matrix units together with the differences `Eᵢᵢ - E_{i₀i₀}`, but reading
-it off needs that explicit basis; only its rank-two case is on `main`
-(`TauCeti.slFinTwoBasis`, with `TauCeti.finrank_sl_fin_two` its dimension count over any ring
-satisfying the strong rank condition). The hyperplane argument used here instead goes through
-`Module.Dual.finrank_ker_add_one_of_ne_zero`, and so needs the field.
+No field, characteristic or algebraic closure hypothesis is used: the strong rank condition is all
+that `finrank` needs in order to count the basis vectors, and over a commutative ring it is implied
+by nontriviality. The rank-two case is counted separately, in
+`TauCeti/Algebra/Lie/Sl2/Basic.lean`: there the rank is read off the named basis
+`e`, `f`, `h` (`TauCeti.slFinTwoBasis`) that the `sl₂`-triple calculus of that file needs anyway.
 
 ## Main results
 
-* `TauCeti.finrank_sl`: `sl n K` has dimension `(card n) ^ 2 - 1`.
-* `TauCeti.finrank_slIdeal`: the same for the trace-zero ideal of `gl n K`, which by
-  `TauCeti.derivedSeries_one_eq_slIdeal` is the derived ideal `⁅gl n K, gl n K⁆`.
+* `TauCeti.finrank_sl`: `sl n R` has rank `(card n) ^ 2 - 1`.
+* `TauCeti.finrank_slIdeal`: the same for the trace-zero ideal of `gl n R`, which by
+  `TauCeti.derivedSeries_one_eq_slIdeal` is the derived ideal `⁅gl n R, gl n R⁆`.
 * `TauCeti.finrank_sl_add_one`: the untruncated form, for a nonempty index type.
+
+## Implementation notes
+
+The coordinate system above is a private linear equivalence, together with the private matrix it
+inverts to: they exist only to feed `Basis.ofEquivFun`, and the public surface of the file is the
+three rank statements.
 -/
 
 public section
@@ -47,53 +53,111 @@ open Matrix Module LieAlgebra
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
-variable {K : Type*} {n : Type*} [Fintype n]
+variable {R : Type*} {n : Type*} [Fintype n] [DecidableEq n]
+
+section Coordinates
+
+variable [CommRing R] (i₀ : n)
+
+/-- The diagonal place `(k, k)`, for `k ≠ i₀`, as one of the free coordinates of a trace-zero
+matrix. -/
+private def diagIdx (k : {k : n // k ≠ i₀}) : {p : n × n // p ≠ (i₀, i₀)} :=
+  ⟨(k.1, k.1), fun hk => k.2 (congrArg Prod.fst hk)⟩
+
+/-- The matrix with prescribed entries away from the `(i₀, i₀)` place, the entry there being the one
+that makes the trace vanish. -/
+private def ofOffDiag (g : {p : n × n // p ≠ (i₀, i₀)} → R) : Matrix n n R :=
+  Matrix.of fun i j =>
+    if h : (i, j) = (i₀, i₀) then -∑ k : {k : n // k ≠ i₀}, g (diagIdx i₀ k) else g ⟨(i, j), h⟩
+
+private lemma ofOffDiag_apply_of_ne (g : {p : n × n // p ≠ (i₀, i₀)} → R) {i j : n}
+    (h : (i, j) ≠ (i₀, i₀)) : ofOffDiag i₀ g i j = g ⟨(i, j), h⟩ :=
+  dite_eq_right h
+
+private lemma ofOffDiag_apply_self (g : {p : n × n // p ≠ (i₀, i₀)} → R) :
+    ofOffDiag i₀ g i₀ i₀ = -∑ k : {k : n // k ≠ i₀}, g (diagIdx i₀ k) :=
+  dite_eq_left rfl
+
+private lemma trace_ofOffDiag (g : {p : n × n // p ≠ (i₀, i₀)} → R) :
+    (ofOffDiag i₀ g).trace = 0 := by
+  have hdiag : ∀ k : {k : n // k ≠ i₀}, ofOffDiag i₀ g k.1 k.1 = g (diagIdx i₀ k) :=
+    fun k => ofOffDiag_apply_of_ne i₀ g (diagIdx i₀ k).2
+  simp only [Matrix.trace, Matrix.diag_apply]
+  rw [Fintype.sum_eq_add_sum_subtype_ne _ i₀, ofOffDiag_apply_self]
+  simp only [hdiag]
+  exact neg_add_cancel _
+
+private lemma ofOffDiag_mem_sl (g : {p : n × n // p ≠ (i₀, i₀)} → R) :
+    ofOffDiag i₀ g ∈ SpecialLinear.sl n R :=
+  LinearMap.mem_ker.mpr (trace_ofOffDiag i₀ g)
+
+/-- **Coordinates on `sl n R`.** A trace-zero matrix is determined by its entries away from the
+`(i₀, i₀)` place, and those entries are arbitrary: the trace-zero condition reads the remaining
+entry off as minus the sum of the other diagonal ones. -/
+private def slEquivFun : SpecialLinear.sl n R ≃ₗ[R] ({p : n × n // p ≠ (i₀, i₀)} → R) where
+  toFun A p := A.val p.1.1 p.1.2
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+  invFun g := ⟨ofOffDiag i₀ g, ofOffDiag_mem_sl i₀ g⟩
+  left_inv A := by
+    refine Subtype.ext (Matrix.ext fun i j => ?_)
+    change ofOffDiag i₀ (fun p => A.val p.1.1 p.1.2) i j = A.val i j
+    by_cases h : (i, j) = (i₀, i₀)
+    · have hi : i = i₀ := congrArg Prod.fst h
+      have hj : j = i₀ := congrArg Prod.snd h
+      rw [hi, hj, ofOffDiag_apply_self]
+      change -∑ k : {k : n // k ≠ i₀}, A.val k.1 k.1 = A.val i₀ i₀
+      have htr : A.val.trace = 0 := A.2
+      simp only [Matrix.trace, Matrix.diag_apply] at htr
+      rw [Fintype.sum_eq_add_sum_subtype_ne _ i₀] at htr
+      exact neg_eq_of_add_eq_zero_left htr
+    · exact ofOffDiag_apply_of_ne i₀ _ h
+  right_inv g := by
+    funext p
+    change ofOffDiag i₀ g p.1.1 p.1.2 = g p
+    exact ofOffDiag_apply_of_ne i₀ g p.2
+
+end Coordinates
 
 section Finrank
 
-variable (K n) [Field K] [DecidableEq n]
+variable (R n) [CommRing R] [StrongRankCondition R]
 
-/-- **`sl n K` is a hyperplane in the matrices**: `finrank K (sl n K) = (card n) ^ 2 - 1`.
+/-- **The rank of `sl n R`**: `finrank R (sl n R) = (card n) ^ 2 - 1`.
 
 For an empty index type the matrix algebra is trivial and both sides are `0`, the truncated
 subtraction `0 - 1` doing the work. -/
 theorem finrank_sl :
-    finrank K (SpecialLinear.sl n K) = Fintype.card n ^ 2 - 1 := by
-  have hmatrix : finrank K (Matrix n n K) = Fintype.card n ^ 2 := by
-    rw [Module.finrank_matrix, finrank_self, mul_one, sq]
-  -- `sl n K` is by definition the kernel of the trace, so the two have the same dimension.
-  have hsub : (SpecialLinear.sl n K : Submodule K (Matrix n n K))
-      = LinearMap.ker (Matrix.traceLinearMap n K K) := Submodule.ext fun _ => Iff.rfl
-  have hker : finrank K (SpecialLinear.sl n K)
-      = finrank K (LinearMap.ker (Matrix.traceLinearMap n K K)) :=
-    LinearEquiv.finrank_eq (LinearEquiv.ofEq _ _ hsub)
-  rw [hker]
-  rcases isEmpty_or_nonempty n with _ | _
-  · have hcard : Fintype.card n ^ 2 = 0 := by simp [Fintype.card_eq_zero]
-    have hle := Submodule.finrank_le (LinearMap.ker (Matrix.traceLinearMap n K K))
-    omega
-  · have hne : Matrix.traceLinearMap n K K ≠ 0 := fun h => by
-      obtain ⟨A, hA⟩ := Matrix.trace_surjective (n := n) (R := K) (1 : K)
-      have hA' : Matrix.traceLinearMap n K K A = 1 := by simpa using hA
-      rw [h, LinearMap.zero_apply] at hA'
-      exact zero_ne_one hA'
-    have hhyp := Module.Dual.finrank_ker_add_one_of_ne_zero hne
+    finrank R (SpecialLinear.sl n R) = Fintype.card n ^ 2 - 1 := by
+  rcases isEmpty_or_nonempty n with hn | ⟨⟨i₀⟩⟩
+  -- With no indices at all the only matrix is `0`, and `0 - 1 = 0` in `ℕ`.
+  · have hsub : Subsingleton (SpecialLinear.sl n R) :=
+      ⟨fun A B => Subtype.ext (Matrix.ext fun i => isEmptyElim i)⟩
+    have hnt : Nontrivial R := nontrivial_of_invariantBasisNumber R
+    rw [Module.finrank_zero_of_subsingleton, Fintype.card_eq_zero]
+    simp
+  -- Otherwise the free coordinates are the places other than `(i₀, i₀)`, and there are
+  -- `(card n) ^ 2 - 1` of them.
+  · rw [finrank_eq_card_basis (Basis.ofEquivFun (slEquivFun i₀))]
+    have hcard := Fintype.card_congr (Equiv.optionSubtypeNe ((i₀, i₀) : n × n))
+    simp only [Fintype.card_option, Fintype.card_prod] at hcard
+    rw [sq, ← hcard]
     omega
 
-/-- The trace-zero ideal of `gl n K` has dimension `(card n) ^ 2 - 1`: the `TauCeti.slIdeal`
-spelling of `TauCeti.finrank_sl`. By `TauCeti.derivedSeries_one_eq_slIdeal` this is the dimension
-of the derived ideal `⁅gl n K, gl n K⁆`. -/
+/-- The trace-zero ideal of `gl n R` has rank `(card n) ^ 2 - 1`: the `TauCeti.slIdeal`
+spelling of `TauCeti.finrank_sl`. By `TauCeti.derivedSeries_one_eq_slIdeal` this is the rank of the
+derived ideal `⁅gl n R, gl n R⁆`. -/
 theorem finrank_slIdeal :
-    finrank K (slIdeal K n) = Fintype.card n ^ 2 - 1 := by
-  rw [← finrank_sl K n]
+    finrank R (slIdeal R n) = Fintype.card n ^ 2 - 1 := by
+  rw [← finrank_sl R n]
   exact LinearEquiv.finrank_eq (LinearEquiv.ofEq _ _
-    (congrArg LieSubalgebra.toSubmodule (slIdeal_toLieSubalgebra_eq_sl K n)))
+    (congrArg LieSubalgebra.toSubmodule (slIdeal_toLieSubalgebra_eq_sl R n)))
 
 variable [Nonempty n]
 
-/-- The untruncated codimension-one statement: `sl n K` is a hyperplane in the matrices. -/
+/-- The untruncated codimension-one statement: `sl n R` is a hyperplane in the matrices. -/
 theorem finrank_sl_add_one :
-    finrank K (SpecialLinear.sl n K) + 1 = Fintype.card n ^ 2 := by
+    finrank R (SpecialLinear.sl n R) + 1 = Fintype.card n ^ 2 := by
   have hpos : 1 ≤ Fintype.card n ^ 2 := Nat.one_le_pow _ _ Fintype.card_pos
   rw [finrank_sl]
   omega

--- a/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.Algebra.Lie.GeneralLinear.Basic
 
 import Mathlib.LinearAlgebra.Dimension.Finite
-import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 
 /-!
 # The dimension of the special linear Lie algebra
@@ -40,9 +39,9 @@ by nontriviality. The rank-two case is counted separately, in
 
 ## Implementation notes
 
-The coordinate system above is a private linear equivalence, together with the private matrix it
-inverts to: they exist only to feed `Basis.ofEquivFun`, and the public surface of the file is the
-three rank statements.
+The coordinate system above is a private linear equivalence, together with the private coordinate
+map, the private matrix it inverts to and their two round-trip lemmas: they exist only to feed
+`Basis.ofEquivFun`, and the public surface of the file is the three rank statements.
 -/
 
 public section
@@ -63,6 +62,20 @@ variable [CommRing R] (i₀ : n)
 matrix. -/
 private def diagIdx (k : {k : n // k ≠ i₀}) : {p : n × n // p ≠ (i₀, i₀)} :=
   ⟨(k.1, k.1), fun hk => k.2 (congrArg Prod.fst hk)⟩
+
+/-- The coordinates of a matrix: its entries away from the `(i₀, i₀)` place. -/
+private def offDiagCoords (A : Matrix n n R) (p : {p : n × n // p ≠ (i₀, i₀)}) : R :=
+  A p.1.1 p.1.2
+
+omit [Fintype n] [DecidableEq n] [CommRing R] in
+private lemma offDiagCoords_apply (A : Matrix n n R) (p : {p : n × n // p ≠ (i₀, i₀)}) :
+    offDiagCoords i₀ A p = A p.1.1 p.1.2 :=
+  rfl
+
+omit [Fintype n] [DecidableEq n] [CommRing R] in
+private lemma offDiagCoords_diagIdx (A : Matrix n n R) (k : {k : n // k ≠ i₀}) :
+    offDiagCoords i₀ A (diagIdx i₀ k) = A k.1 k.1 :=
+  rfl
 
 /-- The matrix with prescribed entries away from the `(i₀, i₀)` place, the entry there being the one
 that makes the trace vanish. -/
@@ -91,31 +104,37 @@ private lemma ofOffDiag_mem_sl (g : {p : n × n // p ≠ (i₀, i₀)} → R) :
     ofOffDiag i₀ g ∈ SpecialLinear.sl n R :=
   LinearMap.mem_ker.mpr (trace_ofOffDiag i₀ g)
 
+/-- A trace-zero matrix is recovered from its coordinates: the entry it omits is forced. -/
+private lemma ofOffDiag_offDiagCoords {A : Matrix n n R} (hA : A.trace = 0) :
+    ofOffDiag i₀ (offDiagCoords i₀ A) = A := by
+  refine Matrix.ext fun i j => ?_
+  by_cases h : (i, j) = (i₀, i₀)
+  · have hi : i = i₀ := congrArg Prod.fst h
+    have hj : j = i₀ := congrArg Prod.snd h
+    rw [hi, hj, ofOffDiag_apply_self]
+    simp only [offDiagCoords_diagIdx]
+    simp only [Matrix.trace, Matrix.diag_apply] at hA
+    rw [Fintype.sum_eq_add_sum_subtype_ne _ i₀] at hA
+    exact neg_eq_of_add_eq_zero_left hA
+  · rw [ofOffDiag_apply_of_ne i₀ _ h, offDiagCoords_apply]
+
+/-- The coordinates of the matrix built from a prescribed family are that family back again. -/
+private lemma offDiagCoords_ofOffDiag (g : {p : n × n // p ≠ (i₀, i₀)} → R) :
+    offDiagCoords i₀ (ofOffDiag i₀ g) = g := by
+  funext p
+  rw [offDiagCoords_apply]
+  exact ofOffDiag_apply_of_ne i₀ g p.2
+
 /-- **Coordinates on `sl n R`.** A trace-zero matrix is determined by its entries away from the
 `(i₀, i₀)` place, and those entries are arbitrary: the trace-zero condition reads the remaining
 entry off as minus the sum of the other diagonal ones. -/
 private def slEquivFun : SpecialLinear.sl n R ≃ₗ[R] ({p : n × n // p ≠ (i₀, i₀)} → R) where
-  toFun A p := A.val p.1.1 p.1.2
+  toFun A := offDiagCoords i₀ A.val
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
   invFun g := ⟨ofOffDiag i₀ g, ofOffDiag_mem_sl i₀ g⟩
-  left_inv A := by
-    refine Subtype.ext (Matrix.ext fun i j => ?_)
-    change ofOffDiag i₀ (fun p => A.val p.1.1 p.1.2) i j = A.val i j
-    by_cases h : (i, j) = (i₀, i₀)
-    · have hi : i = i₀ := congrArg Prod.fst h
-      have hj : j = i₀ := congrArg Prod.snd h
-      rw [hi, hj, ofOffDiag_apply_self]
-      change -∑ k : {k : n // k ≠ i₀}, A.val k.1 k.1 = A.val i₀ i₀
-      have htr : A.val.trace = 0 := A.2
-      simp only [Matrix.trace, Matrix.diag_apply] at htr
-      rw [Fintype.sum_eq_add_sum_subtype_ne _ i₀] at htr
-      exact neg_eq_of_add_eq_zero_left htr
-    · exact ofOffDiag_apply_of_ne i₀ _ h
-  right_inv g := by
-    funext p
-    change ofOffDiag i₀ g p.1.1 p.1.2 = g p
-    exact ofOffDiag_apply_of_ne i₀ g p.2
+  left_inv A := Subtype.ext (ofOffDiag_offDiagCoords i₀ (LinearMap.mem_ker.mp A.2))
+  right_inv g := offDiagCoords_ofOffDiag i₀ g
 
 end Coordinates
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean
@@ -14,8 +14,8 @@ import Mathlib.LinearAlgebra.Dual.Lemmas
 # The dimension of the special linear Lie algebra
 
 Over a field, `sl n K` is the kernel of the trace functional on the `n × n` matrices. The trace is
-surjective as soon as there is an index at all — the matrix unit `Eᵢᵢ` scaled by `c` has trace `c` —
-so it is a nonzero functional and its kernel is a hyperplane:
+surjective as soon as there is an index at all (`Matrix.trace_surjective`), so it is a nonzero
+functional and its kernel is a hyperplane:
 
 `finrank K (sl n K) = (card n) ^ 2 - 1`.
 
@@ -33,7 +33,6 @@ satisfying the strong rank condition). The hyperplane argument used here instead
 
 ## Main results
 
-* `TauCeti.traceLinearMap_surjective`: the trace of a square matrix is surjective onto the scalars.
 * `TauCeti.finrank_sl`: `sl n K` has dimension `(card n) ^ 2 - 1`.
 * `TauCeti.finrank_slIdeal`: the same for the trace-zero ideal of `gl n K`, which by
   `TauCeti.derivedSeries_one_eq_slIdeal` is the derived ideal `⁅gl n K, gl n K⁆`.
@@ -49,19 +48,6 @@ open Matrix Module LieAlgebra
 attribute [local instance 100] LieRing.ofAssociativeRing
 
 variable {K : Type*} {n : Type*} [Fintype n]
-
-section Trace
-
-variable (K n) [Semiring K] [Nonempty n]
-
-/-- **The trace is surjective onto the scalars** as soon as there is an index: the matrix unit
-`Eᵢᵢ` scaled by `c` has trace `c`. This is `Matrix.trace_surjective` for the trace as a linear
-map. -/
-theorem traceLinearMap_surjective :
-    Function.Surjective (Matrix.traceLinearMap n K K) :=
-  Matrix.trace_surjective
-
-end Trace
 
 section Finrank
 
@@ -87,9 +73,10 @@ theorem finrank_sl :
     have hle := Submodule.finrank_le (LinearMap.ker (Matrix.traceLinearMap n K K))
     omega
   · have hne : Matrix.traceLinearMap n K K ≠ 0 := fun h => by
-      obtain ⟨A, hA⟩ := traceLinearMap_surjective K n (1 : K)
-      rw [h, LinearMap.zero_apply] at hA
-      exact zero_ne_one hA
+      obtain ⟨A, hA⟩ := Matrix.trace_surjective (n := n) (R := K) (1 : K)
+      have hA' : Matrix.traceLinearMap n K K A = 1 := by simpa using hA
+      rw [h, LinearMap.zero_apply] at hA'
+      exact zero_ne_one hA'
     have hhyp := Module.Dual.finrank_ker_add_one_of_ne_zero hne
     omega
 

--- a/TauCeti/Algebra/Lie/Sl2/Basic.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Basic.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Lie.Sl2
-public import TauCeti.Algebra.Lie.GeneralLinear.Basic
+public import TauCeti.Algebra.Lie.GeneralLinear.Finrank
 
 /-!
 # Basic theory of `sl₂` triples
@@ -50,8 +50,9 @@ that composes to zero is already zero.
   `TauCeti.lie_singleSubSingle_single_swap`.
 * `TauCeti.slFinTwoBasis`: the standard basis `(e, f, h)` of `sl (Fin 2) R`, obtained from the
   coordinate isomorphism `TauCeti.slFinTwoEquivFun` and identified vector by vector in
-  `TauCeti.slFinTwoBasis_zero`, `TauCeti.slFinTwoBasis_one` and `TauCeti.slFinTwoBasis_two`, with
-  `TauCeti.finrank_sl_fin_two` reading off the rank `3`.
+  `TauCeti.slFinTwoBasis_zero`, `TauCeti.slFinTwoBasis_one` and `TauCeti.slFinTwoBasis_two`. The
+  rank `3` is the case `n = Fin 2` of `TauCeti.finrank_sl`, and the `Module.Free` and
+  `Module.Finite` instances come from there too.
 * `TauCeti.toLieSubalgebra_isSl2Triple_single_eq_top`: in `sl (Fin 2) R` the subalgebra generated
   by a standard triple is the whole of `sl (Fin 2) R`. The underlying expansion of an arbitrary
   element in the triple is `TauCeti.eq_smul_single_add_smul_single_add_smul_singleSubSingle`.
@@ -272,17 +273,6 @@ theorem slFinTwoBasis_one : slFinTwoBasis R 1 = SpecialLinear.single 1 0 one_ne_
 @[simp]
 theorem slFinTwoBasis_two : slFinTwoBasis R 2 = SpecialLinear.singleSubSingle 0 1 (1 : R) :=
   Subtype.ext <| by simpa using slFinTwoBasis_apply R 2
-
-instance instModuleFreeSlFinTwo : Module.Free R (SpecialLinear.sl (Fin 2) R) :=
-  Module.Free.of_basis (slFinTwoBasis R)
-
-instance instModuleFiniteSlFinTwo : Module.Finite R (SpecialLinear.sl (Fin 2) R) :=
-  Module.Finite.of_basis (slFinTwoBasis R)
-
-/-- `sl₂` is three-dimensional. -/
-theorem finrank_sl_fin_two [StrongRankCondition R] :
-    finrank R (SpecialLinear.sl (Fin 2) R) = 3 := by
-  simpa using finrank_eq_card_basis (slFinTwoBasis R)
 
 variable {R}
 


### PR DESCRIPTION
This PR checks the dimension arithmetic of Vinberg's `ℤ/3`-graded model of split `E₈`,
`𝔢₈ = 𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*`, and supplies the dimension of the special linear Lie algebra that
the check needs. `TauCeti/Algebra/Lie/E8/Vinberg.lean` proves `finrank K (⋀[K]^3 (Fin 9 → K)) = 84`
over any nontrivial commutative ring, `finrank K (𝔰𝔩₉) = 80` over any commutative ring satisfying
the strong rank condition, and the assembled
`finrank K (𝔰𝔩₉ × ⋀³(K⁹) × ⋀³(K⁹)^*) = 248 = 80 + 84 + 84` over any nontrivial commutative ring, the
dual summand being counted by `Module.finrank_linearMap_self` (all three summands are finite free,
so no field is needed anywhere).
`TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean` supplies the `80` in general form:
`finrank R (LieAlgebra.SpecialLinear.sl n R) = (Fintype.card n) ^ 2 - 1` over any commutative ring
in which `finrank` counts basis vectors (`finrank_sl`, tagged `@[simp]` as the
normal form for the rank of `sl n R`, with `finrank_sl_add_one` the
untruncated form for a nonempty index type), together with the `Module.Free` and `Module.Finite`
instances for `sl n R` that the same coordinate system yields and that any rank computation
involving `sl n R` as a summand needs. The proof is the explicit coordinate system on trace-zero matrices: after fixing an index
`i₀`, the entries away from the `(i₀, i₀)` place are free and the trace-zero condition reads the
remaining entry off as minus the sum of the other diagonal entries, so `Basis.ofEquivFun` and
`finrank_eq_card_basis` count the places other than `(i₀, i₀)`. That equivalence, the matrix it
inverts to, and the trace-zero reading of membership in `sl n R` are private: the public surface of
the file is the two rank statements and the two instances. The truncated subtraction is exact rather than a
convention: for an empty index type the matrix algebra is trivial and both sides are `0`, so the
statement needs no nonemptiness hypothesis. Only the underlying `K`-module of the Vinberg model is
treated here: the graded bracket, Killing-simplicity of type `E₈`, and the comparison with
Mathlib's Serre-construction `LieAlgebra.e₈` are separate statements, and each file says so.

The target is Layer 8 of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`, "The
`E`-series `E₆, E₇, E₈`, as explicit constructions": its Vinberg bullet asks for
`𝔢₈ = 𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*` "of dimension `248 = 80 + 84 + 84`" and directs the contributor to
consume `LieAlgebra.SpecialLinear.sl (Fin 9) K` and `exteriorPower`, and its acceptance criterion
names the same check: "For `E₈`, check `finrank (𝔰𝔩₉ ⊕ ⋀³(K⁹) ⊕ ⋀³(K⁹)^*) = 248 = 80 + 84 + 84`".
The corresponding `Suggested.lean` entry is `finrank_exteriorPower_three_nine`, generalized here
from `[Field K] [CharZero K]` to `[CommRing K] [Nontrivial K]`, which is all the exterior-power
basis needs. The roadmap's `## Ordering` paragraph makes Layer 8 the most independent lane and says
the `E`-series constructions "need only the linear-algebra machinery", so nothing earlier gates
this.

Neither Mathlib nor this repository had the dimension of `sl n K`: Mathlib's
`Mathlib/Algebra/Lie/Classical.lean` defines `sl` and its elementary basis vectors but proves no
rank statement, and on `main` only the rank-two case existed, in
`TauCeti/Algebra/Lie/Sl2/Basic.lean`. That duplicate is removed here rather than left beside the
general one: `finrank_sl_fin_two`, `instModuleFreeSlFinTwo` and `instModuleFiniteSlFinTwo` are
deleted, that file now imports `TauCeti/Algebra/Lie/GeneralLinear/Finrank.lean`, and the rank `3`
and the two instances are the case `n = Fin 2` of `finrank_sl` (nothing in the repository
referenced `finrank_sl_fin_two`). `TauCeti.slFinTwoBasis` itself stays, since the `sl₂`-triple
calculus of that file needs the named basis `e`, `f`, `h`; only the rank statement read off it was
redundant. The existing `TauCeti.slIdeal` API of `TauCeti/Algebra/Lie/GeneralLinear/Basic.lean` is
reused rather than duplicated: `slIdeal_toLieSubalgebra_eq_sl` and `mem_slIdeal_iff` are what cross
the `LieSubalgebra`-wrapper conversion here. No Mathlib source was vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"finrank-exteriorpower-three-nine"}-->

🤖 Prepared with Claude Code



