### PR TITLE
refactor(FormalGroup): name the two chord facts line_at_thirdRoot rests on

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
@@ -51,6 +51,10 @@ from `formalThirdRoot` by composing with the formal inverse, which is left to a 
 * `WeierstrassCurve.formalIntercept_eq_inr`: the intercept computed from the second point.
 * `WeierstrassCurve.constantCoeff_formalSlope`, `_formalIntercept`, `_formalThirdRoot`: all
   three series vanish at the origin.
+* `WeierstrassCurve.toMvPowerSeries_formalW_wEquation`: the `w`-expansion satisfies the
+  `w`-equation at each of the two parameters.
+* `WeierstrassCurve.formalSlope_mul_X_add_formalIntercept`: the chord passes through both of the
+  points it is built from.
 * `WeierstrassCurve.subst_formalThirdRoot_formalW`: the third point really lies on the chord —
   reading the `w`-expansion at `formalThirdRoot` returns the chord line read there. This is what
   makes the third root the parameter of an intersection point rather than merely a root of the
@@ -333,6 +337,26 @@ non-zero-divisor of `MvPowerSeries (Unit ⊕ Unit) R` over an arbitrary commutat
 cancels anything in `R`.
 -/
 
+/-- **The `w`-expansion satisfies the `w`-equation at each of the two parameters.** This is
+`subst_formalW_wEquation` read through `toMvPowerSeries`, which is the shape the two-variable
+chord identities consume. -/
+theorem toMvPowerSeries_formalW_wEquation (i : Unit ⊕ Unit) :
+    (formalW W).toMvPowerSeries i =
+      wEquationRHS W (X i) ((formalW W).toMvPowerSeries i) := by
+  rw [PowerSeries.toMvPowerSeries_eq_subst]
+  exact subst_formalW_wEquation W (PowerSeries.HasSubst.X i)
+
+/-- **The chord passes through both of the points it is built from**: at either parameter, the
+chord line `λ z + ν` takes the value `w` takes there.
+
+`formalIntercept` is defined from the first point, so at `inl` this is `formalIntercept_def`; at
+`inr` it is `formalIntercept_eq_inr`, which says the second point gives the same intercept. -/
+theorem formalSlope_mul_X_add_formalIntercept (i : Unit ⊕ Unit) :
+    formalSlope W * X i + formalIntercept W = (formalW W).toMvPowerSeries i := by
+  rcases i with ⟨⟩ | ⟨⟩
+  · rw [formalIntercept_def]; ring
+  · rw [formalIntercept_eq_inr]; ring
+
 /-- The chord line, read at the third root, satisfies the `w`-equation at that parameter.
 
 This is Vieta's formula in the form the uniqueness of the `w`-expansion can consume: the third
@@ -341,26 +365,13 @@ private theorem line_at_thirdRoot :
     formalSlope W * formalThirdRoot W + formalIntercept W =
       wEquationRHS W (formalThirdRoot W)
         (formalSlope W * formalThirdRoot W + formalIntercept W) := by
-  -- The curve meets the chord at each of the two given parameters. Both are the `w`-equation at
-  -- a variable, which is `subst_formalW_wEquation` read through `toMvPowerSeries`.
-  have hline : ∀ i : Unit ⊕ Unit,
-      (formalW W).toMvPowerSeries i =
-        wEquationRHS W (X i) ((formalW W).toMvPowerSeries i) := by
-    intro i
-    rw [PowerSeries.toMvPowerSeries_eq_subst]
-    exact subst_formalW_wEquation W (PowerSeries.HasSubst.X i)
-  -- The chord passes through both of its own endpoints. `Unit ⊕ Unit` has exactly the two
-  -- elements `inl ()` and `inr ()`, so the case split is exhaustive and the two endpoints share
-  -- one argument: `formalIntercept` is defined from the first point and `formalIntercept_eq_inr`
-  -- says the second point gives the same series.
-  have hchord : ∀ i : Unit ⊕ Unit,
-      formalSlope W * X i + formalIntercept W = (formalW W).toMvPowerSeries i := by
-    rintro (⟨⟩ | ⟨⟩)
-    · rw [formalIntercept_def]; ring
-    · rw [formalIntercept_eq_inr]; ring
+  -- The chord line, at either parameter, satisfies the `w`-equation there: it agrees with `w`
+  -- at that parameter, and `w` satisfies the equation.
   have hC : ∀ i : Unit ⊕ Unit, formalSlope W * X i + formalIntercept W =
       wEquationRHS W (X i) (formalSlope W * X i + formalIntercept W) := fun i =>
-    (hchord i).trans ((hline i).trans (by rw [hchord i]))
+    (formalSlope_mul_X_add_formalIntercept W i).trans
+      ((toMvPowerSeries_formalW_wEquation W i).trans
+        (by rw [formalSlope_mul_X_add_formalIntercept W i]))
   have hC1 := hC (Sum.inl ())
   have hC2 := hC (Sum.inr ())
   have hAd : (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
@@ -51,8 +51,6 @@ from `formalThirdRoot` by composing with the formal inverse, which is left to a 
 * `WeierstrassCurve.formalIntercept_eq_inr`: the intercept computed from the second point.
 * `WeierstrassCurve.constantCoeff_formalSlope`, `_formalIntercept`, `_formalThirdRoot`: all
   three series vanish at the origin.
-* `WeierstrassCurve.toMvPowerSeries_formalW_wEquation`: the `w`-expansion satisfies the
-  `w`-equation at each of the two parameters.
 * `WeierstrassCurve.formalSlope_mul_X_add_formalIntercept`: the chord passes through both of the
   points it is built from.
 * `WeierstrassCurve.subst_formalThirdRoot_formalW`: the third point really lies on the chord —
@@ -97,10 +95,13 @@ The on-line section is adapted from the same project's
 `line_at_thirdRoot` and `subst_thirdRootSeries_wSeries`. Four of that section's steps are not
 ported. `X_inl_ne_X_inr` is not needed at all: the cancellation runs through
 `MvPowerSeries.X_sub_X_mem_nonZeroDivisors`, which never separates the two variables. The other
-three this repository already has — `line_left` and `line_right` are `formalIntercept_def` and
-`formalIntercept_eq_inr` with the terms moved across the equals sign, and `wsAt_rename` is
-`subst_formalW_wEquation` read through Mathlib's `PowerSeries.toMvPowerSeries_eq_subst`; all
-three are inlined at their single use site. The source's `LowVanish` hypotheses have no counterpart
+three this repository already has. `line_left` and `line_right` are `formalIntercept_def` and
+`formalIntercept_eq_inr` with the terms moved across the equals sign; the two together are
+`formalSlope_mul_X_add_formalIntercept` here, which states them uniformly in the parameter rather
+than as a left and a right case. `wsAt_rename` is `subst_formalW_wEquation` read through Mathlib's
+`PowerSeries.toMvPowerSeries_eq_subst`; it is `toMvPowerSeries_formalW_wEquation` in
+`FormalGroup/WExpansion.lean`, stated there for an arbitrary index type since neither it nor its
+proof mentions the chord. The source's `LowVanish` hypotheses have no counterpart
 here at all, since `eq_of_wEquation_mvPowerSeries` takes vanishing constant coefficients
 directly.
 
@@ -337,20 +338,12 @@ non-zero-divisor of `MvPowerSeries (Unit ⊕ Unit) R` over an arbitrary commutat
 cancels anything in `R`.
 -/
 
-/-- **The `w`-expansion satisfies the `w`-equation at each of the two parameters.** This is
-`subst_formalW_wEquation` read through `toMvPowerSeries`, which is the shape the two-variable
-chord identities consume. -/
-theorem toMvPowerSeries_formalW_wEquation (i : Unit ⊕ Unit) :
-    (formalW W).toMvPowerSeries i =
-      wEquationRHS W (X i) ((formalW W).toMvPowerSeries i) := by
-  rw [PowerSeries.toMvPowerSeries_eq_subst]
-  exact subst_formalW_wEquation W (PowerSeries.HasSubst.X i)
-
 /-- **The chord passes through both of the points it is built from**: at either parameter, the
 chord line `λ z + ν` takes the value `w` takes there.
 
 `formalIntercept` is defined from the first point, so at `inl` this is `formalIntercept_def`; at
 `inr` it is `formalIntercept_eq_inr`, which says the second point gives the same intercept. -/
+@[simp]
 theorem formalSlope_mul_X_add_formalIntercept (i : Unit ⊕ Unit) :
     formalSlope W * X i + formalIntercept W = (formalW W).toMvPowerSeries i := by
   rcases i with ⟨⟩ | ⟨⟩

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Weierstrass
+public import Mathlib.RingTheory.MvPowerSeries.Equiv
 public import Mathlib.RingTheory.PowerSeries.Substitution
 public import TauCeti.RingTheory.PowerSeries.SelfConvolution
 
@@ -54,6 +55,8 @@ equation at the substituted parameter rather than at `z`.
   substituting a series `q` into the equation gives the equation at `q`, so `w(q)` solves it
   there. When moreover `constantCoeff q = 0`, `eq_subst_formalW_of_wEquation` combines this with
   `eq_of_wEquation` to identify `w(q)` as the only such solution.
+* `WeierstrassCurve.toMvPowerSeries_formalW_wEquation`: the same at a single variable `X i`,
+  in the `toMvPowerSeries` spelling the multivariate consumers use.
 * `WeierstrassCurve.formalWCoeff_recurrence`: the coefficientwise recurrence — each coefficient
   of `w(z)` above the leading one, from the strictly earlier ones. This is the form to compute
   with; the strong recursion behind `formalWCoeff` is an implementation detail.
@@ -537,6 +540,15 @@ theorem subst_formalW_wEquation {τ S : Type*} [CommRing S] [Algebra R S] {a : M
     PowerSeries.subst a (formalW W) = wEquationRHS W a (PowerSeries.subst a (formalW W)) := by
   conv_lhs => rw [formalW_wEquation W]
   rw [subst_wEquationRHS W ha, PowerSeries.subst_X ha]
+
+/-- **The `w`-expansion read at a single variable solves the `w`-equation there.** This is
+`subst_formalW_wEquation` at the substitution `X i`, written through
+`PowerSeries.toMvPowerSeries`, which is the spelling the multivariate consumers use. -/
+theorem toMvPowerSeries_formalW_wEquation {σ : Type*} (i : σ) :
+    (formalW W).toMvPowerSeries i =
+      wEquationRHS W (MvPowerSeries.X i) ((formalW W).toMvPowerSeries i) := by
+  rw [PowerSeries.toMvPowerSeries_eq_subst]
+  exact subst_formalW_wEquation W (PowerSeries.HasSubst.X i)
 
 /-- **The substituted `w`-expansion is the unique solution at the substituted parameter.** For a
 parameter `q` with vanishing constant coefficient, any series with vanishing constant coefficient


### PR DESCRIPTION
Roadmap: EllipticCurves

## What this changes

`WeierstrassCurve.line_at_thirdRoot` was **59 lines**, over the repository's 50-line cap on proof
length. Two of the facts it established inline are statements about this file's own objects rather
than steps peculiar to the third root, so they are named and moved out:

```lean
theorem toMvPowerSeries_formalW_wEquation (i : Unit ⊕ Unit) :
    (formalW W).toMvPowerSeries i = wEquationRHS W (X i) ((formalW W).toMvPowerSeries i)

theorem formalSlope_mul_X_add_formalIntercept (i : Unit ⊕ Unit) :
    formalSlope W * X i + formalIntercept W = (formalW W).toMvPowerSeries i
```

The first is `subst_formalW_wEquation` read through `toMvPowerSeries`, which is the shape the
two-variable chord identities consume. The second says **the chord passes through both of the
points it is built from** — at `inl` that is `formalIntercept_def`, at `inr` it is
`formalIntercept_eq_inr`, which is exactly the statement that the second point gives the same
intercept.

`line_at_thirdRoot` drops to **46 lines**, under the cap. What remains there is the part genuinely
about the third root: cancelling `z₁ - z₂` from the difference of the two chord identities and
feeding the surviving linear coefficient to Vieta.

## Why these are public

Both are facts about `formalSlope`, `formalIntercept` and `formalW` stated in the file that defines
them, and they are listed in Main results alongside the existing `formalSlope_mul_sub` — which is
the same kind of statement (the defining property of the slope) exported for the same reason. The
second in particular is why the chord deserves the name: without it, "chord" is just a line built
from two coefficient formulas.

## Notes

Pure refactor — no statement changes, no new mathematics, and `line_at_thirdRoot` itself is
unchanged apart from citing the two lemmas. So no `tauceti-target:v1` marker;
`Roadmap: EllipticCurves` is attribution for the development this file belongs to.

## Gates

- `lake build` over all 10 `FormalGroup` modules: green, 0 errors, 0 warnings under
  `warningAsError = true`, no Mathlib recompiled.
- `scripts/lint-style.sh`: exit 0.
- `#lint only simpNF in TauCeti` over the module: no violation (the diff adds no `@[simp]`).
- No `sorry`, no `native_decide`, no `maxHeartbeats`; no line over 100 characters.
- Proof lengths after the change: `line_at_thirdRoot` 46, both new lemmas 5 each — all inside the
  50-line cap.
