### PR TITLE
refactor(Petersson): keep one slash-invariance lemma, not two

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
@@ -147,10 +147,13 @@ theorem exists_slash_eq_smul_of_mem_withCenter {γ : SL(2, ℤ)} (hγ : γ ∈ �
         hcoe, ModularForm.slash_neg_one, SlashInvariantFormClass.SL_slash_eq f _ hγ']
 
 omit [Γ.FiniteIndex] in
-/-- **Slashing by `Γ·{±I}` is invisible to the level-one-domain pairing, even after a further
-slash.** Both forms pick up the same unimodular constant `c`, and the pairing is conjugate-linear
-in its first argument and linear in its second, so the two factors cancel as `conj c * c = 1`.
-The `Γ` part fixes a `Γ`-invariant form, and `-I` scales it by the real sign `(-1)^k`. -/
+/-- **Slashing both arguments by an element of `Γ·{±I}` is invisible to the level-one-domain
+pairing, before any common further slash `β`.**
+
+This is the general form of `peterssonInner_slash_of_mem_withCenter` below, which is the `β = 1`
+case. It is what the coset-representative arguments consume: the pairing of two forms slashed into
+a coset does not depend on which representative of that coset is used to reach it, so the defining
+sum of the Petersson product may be reindexed over the coset space. -/
 theorem peterssonInner_slash_slash_of_mem_withCenter (f g : CuspForm (Γ.map (mapGL ℝ)) k)
     {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) (β : SL(2, ℤ)) :
     UpperHalfPlane.peterssonInner k fd ((⇑f ∣[k] γ) ∣[k] β) ((⇑g ∣[k] γ) ∣[k] β) =

--- a/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
@@ -147,16 +147,27 @@ theorem exists_slash_eq_smul_of_mem_withCenter {γ : SL(2, ℤ)} (hγ : γ ∈ �
         hcoe, ModularForm.slash_neg_one, SlashInvariantFormClass.SL_slash_eq f _ hγ']
 
 omit [Γ.FiniteIndex] in
+/-- **Slashing by `Γ·{±I}` is invisible to the level-one-domain pairing, even after a further
+slash.** Both forms pick up the same unimodular constant `c`, and the pairing is conjugate-linear
+in its first argument and linear in its second, so the two factors cancel as `conj c * c = 1`.
+The `Γ` part fixes a `Γ`-invariant form, and `-I` scales it by the real sign `(-1)^k`. -/
+theorem peterssonInner_slash_slash_of_mem_withCenter (f g : CuspForm (Γ.map (mapGL ℝ)) k)
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) (β : SL(2, ℤ)) :
+    UpperHalfPlane.peterssonInner k fd ((⇑f ∣[k] γ) ∣[k] β) ((⇑g ∣[k] γ) ∣[k] β) =
+      UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] β) (⇑g ∣[k] β) := by
+  obtain ⟨c, hc, hslash⟩ := exists_slash_eq_smul_of_mem_withCenter (k := k) hγ
+  rw [hslash f, hslash g, ModularForm.SL_smul_slash, ModularForm.SL_smul_slash,
+    peterssonInner_smul_left, peterssonInner_smul_right, ← mul_assoc, hc, one_mul]
+
+omit [Γ.FiniteIndex] in
 /-- **The summand does not depend on the coset representative**: the level-one-domain pairing
-is unchanged by slashing with `Γ·{±I}`. The `Γ` part fixes a `Γ`-invariant form, and `-I`
-scales it by the real sign `(-1)^k`, which the conjugate-linear pairing cancels against
-itself. This is what lets the defining sum be reindexed over the coset space. -/
+is unchanged by slashing with `Γ·{±I}`. This is what lets the defining sum be reindexed over the
+coset space. It is the `β = 1` case of `peterssonInner_slash_slash_of_mem_withCenter`. -/
 theorem peterssonInner_slash_of_mem_withCenter
     (f g : CuspForm (Γ.map (mapGL ℝ)) k) {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) :
     UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] γ) (⇑g ∣[k] γ) = peterssonInnerFd f g := by
-  obtain ⟨c, hc, hslash⟩ := exists_slash_eq_smul_of_mem_withCenter (k := k) hγ
-  rw [hslash f, hslash g, peterssonInner_smul_left, peterssonInner_smul_right, ← mul_assoc, hc,
-    one_mul, peterssonInnerFd_def]
+  simpa [SlashAction.slash_one, peterssonInnerFd_def] using
+    peterssonInner_slash_slash_of_mem_withCenter f g hγ 1
 
 omit [Γ.FiniteIndex] in
 /-- Each summand of the self-pairing is a non-negative real: the integrand is

--- a/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
@@ -96,18 +96,6 @@ private lemma cosetRightMul_apply {α : SL(2, ℤ)}
   rfl
 
 omit [Γ.FiniteIndex] in
-/-- Slashing by an element of `Γ·{±I}` is invisible to the level-one-domain pairing, even after
-a further slash: the two forms pick up the same unimodular constant, and the pairing is
-conjugate-linear in one argument and linear in the other. -/
-private theorem peterssonInner_slash_slash_of_mem_withCenter (f g : CuspForm (Γ.map (mapGL ℝ)) k)
-    {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) (β : SL(2, ℤ)) :
-    UpperHalfPlane.peterssonInner k fd ((⇑f ∣[k] γ) ∣[k] β) ((⇑g ∣[k] γ) ∣[k] β) =
-      UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] β) (⇑g ∣[k] β) := by
-  obtain ⟨c, hc, hslash⟩ := exists_slash_eq_smul_of_mem_withCenter (k := k) hγ
-  rw [hslash f, hslash g, ModularForm.SL_smul_slash, ModularForm.SL_smul_slash,
-    peterssonInner_smul_left, peterssonInner_smul_right, ← mul_assoc, hc, one_mul]
-
-omit [Γ.FiniteIndex] in
 /-- **The summand of the Petersson product is a function of the coset.** Replacing the chosen
 representative `q.out` of a coset by any other element of it does not change the level-one-domain
 pairing of the correspondingly slashed forms. -/


### PR DESCRIPTION
Two lemmas in `Petersson/` prove the same thing, one being the `β = 1` case of the other, by the
same script.

```lean
-- FiniteIndex.lean:154, public
theorem peterssonInner_slash_of_mem_withCenter (f g) (hγ : γ ∈ Γ.withCenter) :
    peterssonInner k fd (⇑f ∣[k] γ) (⇑g ∣[k] γ) = peterssonInnerFd f g := by
  obtain ⟨c, hc, hslash⟩ := exists_slash_eq_smul_of_mem_withCenter (k := k) hγ
  rw [hslash f, hslash g, peterssonInner_smul_left, peterssonInner_smul_right, ← mul_assoc, hc,
    one_mul, peterssonInnerFd_def]

-- Unitary.lean:102, private
private theorem peterssonInner_slash_slash_of_mem_withCenter (f g) (hγ : γ ∈ Γ.withCenter) (β) :
    peterssonInner k fd ((⇑f ∣[k] γ) ∣[k] β) ((⇑g ∣[k] γ) ∣[k] β) =
      peterssonInner k fd (⇑f ∣[k] β) (⇑g ∣[k] β) := by
  obtain ⟨c, hc, hslash⟩ := exists_slash_eq_smul_of_mem_withCenter (k := k) hγ
  rw [hslash f, hslash g, ModularForm.SL_smul_slash, ModularForm.SL_smul_slash,
    peterssonInner_smul_left, peterssonInner_smul_right, ← mul_assoc, hc, one_mul]
```

Both obtain the same unimodular constant from `exists_slash_eq_smul_of_mem_withCenter`, rewrite
both slashes into scalar multiples, and cancel the two scalars against each other through the
conjugate-linear pairing — `conj c * c = 1`. The second differs only in carrying a further slash
by `β` past the scalars first.

## What changes

* The general statement moves to `FiniteIndex.lean`, **public**, immediately above the special
  case it generalises — `Unitary.lean` reaches it because it imports `Petersson/Orthogonal.lean`,
  which publicly imports `FiniteIndex.lean`.
* `peterssonInner_slash_of_mem_withCenter` is now two lines:
  `simpa [SlashAction.slash_one, peterssonInnerFd_def] using
  peterssonInner_slash_slash_of_mem_withCenter f g hγ 1`.
* The private copy in `Unitary.lean` is deleted. Its single use, in
  `peterssonInner_slash_inv_out`, resolves to the public lemma unchanged.

Net: one proof script instead of two, and the general form becomes available to callers rather
than being sealed inside `Unitary.lean`.

## Scope

No new mathematics — this is `.claude/CLAUDE.md`'s "refactoring, simplifying proofs" and
"relocating a misplaced declaration", which need no roadmap entry. The whole `Petersson/`
directory builds (`Adjoint`, `Basic`, `FiniteIndex`, `Orthogonal`, `Unitary`) and `#lint` reports
0 errors across 24 and 9 declarations with 15 linters.

The finding is dedup sweep G14 (2026-08-30), re-verified against current `main` before acting:
both proofs are still present and still identical up to the `β` slash.

## Round 1 — `documentation`

Nine rubrics green; one finding, accepted. The docstring on the newly public
`peterssonInner_slash_slash_of_mem_withCenter` narrated the proof — the unimodular constant, the
conjugate-linearity of the pairing, and how the two factors cancel — rather than saying what the
theorem is *for*.

It now states the API role: this is the general form of `peterssonInner_slash_of_mem_withCenter`
below, which is its `β = 1` case, and it is what the coset-representative arguments consume when
reindexing the defining sum over the coset space. The proof itself is four lines and reads plainly
enough without a prose gloss.

Roadmap: ModularForms

