### PR TITLE
feat(MordellWeil): the canonical Néron–Tate height by Tate's telescoping limit

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -24,11 +24,15 @@ within a bounded distance of `h`.
 
 ## Main results
 
-* `WeierstrassCurve.Affine.Point.tendsto_naiveHeight_div_canonicalHeight`: the defining limit is
+* `WeierstrassCurve.Affine.Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow`: the defining
+  limit is
   attained, so `canonicalHeight` is the limit and not the junk value `limUnder` returns when a
   sequence does not converge. Every property of the canonical height is proved by transporting a
   property of `h`
   along this.
+* `WeierstrassCurve.Affine.Point.canonicalHeight_zero` and
+  `WeierstrassCurve.Affine.Point.canonicalHeight_neg`: its values at the two points every consumer
+  meets first, as `@[simp]` normal forms.
 * `WeierstrassCurve.Affine.Point.abs_canonicalHeight_sub_naiveHeight_le`: the canonical height stays
   within a bounded distance of the naïve one, by a
   constant depending only on the curve. This is what makes the two interchangeable in
@@ -65,7 +69,7 @@ variable {F : Type*} [Field F] {W : Affine F} [AdmissibleAbsValues F] [Decidable
 /-- **The canonical (Néron–Tate) height** `canonicalHeight P = lim h(2ⁿ P) / 4ⁿ`.
 
 The limit exists whenever the curve is elliptic
-(`Point.tendsto_naiveHeight_div_canonicalHeight`); the definition itself needs no hypothesis
+(`Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow`); the definition itself needs no hypothesis
 beyond those making `2 ^ n • P` meaningful, so it is stated without one. -/
 noncomputable def Point.canonicalHeight (P : W.Point) : ℝ :=
   limUnder atTop fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / 4 ^ n
@@ -108,13 +112,30 @@ private theorem dist_naiveHeight_div_succ_le [W.toAffine.IsElliptic] {C : ℝ}
 
 /-- **The defining limit is attained.** `canonicalHeight` is `limUnder`, which returns a junk value
 on a divergent sequence; this says the sequence converges, so the definition means what it says. -/
-theorem Point.tendsto_naiveHeight_div_canonicalHeight [W.toAffine.IsElliptic] (P : W.Point) :
+theorem Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow [W.toAffine.IsElliptic] (P : W.Point) :
     Tendsto (fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / 4 ^ n) atTop (𝓝 P.canonicalHeight) := by
   obtain ⟨C, _, hC⟩ := exists_abs_naiveHeight_two_nsmul_sub W
   obtain ⟨a, ha⟩ := cauchySeq_tendsto_of_complete
     (cauchySeq_of_le_geometric (1 / 4) (C / 4) (by norm_num)
       (dist_naiveHeight_div_succ_le hC P))
   rwa [Point.canonicalHeight, ha.limUnder_eq]
+
+/-- The point at infinity has canonical height zero: every term of the defining sequence is
+`h 0 / 4 ^ n = 0`. -/
+@[simp]
+theorem Point.canonicalHeight_zero [W.toAffine.IsElliptic] :
+    (0 : W.Point).canonicalHeight = 0 := by
+  refine tendsto_nhds_unique (Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow 0) ?_
+  simp
+
+/-- Negation preserves the canonical height, because it preserves the naïve height and commutes
+with doubling, so the two defining sequences agree termwise. -/
+@[simp]
+theorem Point.canonicalHeight_neg [W.toAffine.IsElliptic] (P : W.Point) :
+    (-P).canonicalHeight = P.canonicalHeight := by
+  refine tendsto_nhds_unique (Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow (-P)) ?_
+  simpa only [smul_neg, Point.naiveHeight_neg] using
+    Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow P
 
 /-- **The canonical height differs from the naïve height by a bounded amount**, the bound depending
 only on the curve. Northcott finiteness for `h` therefore transfers to the canonical height. -/
@@ -123,7 +144,7 @@ theorem Point.abs_canonicalHeight_sub_naiveHeight_le [W.toAffine.IsElliptic] :
   obtain ⟨C, _, hC⟩ := exists_abs_naiveHeight_two_nsmul_sub W
   refine ⟨C / 4 / (1 - 1 / 4), fun P ↦ ?_⟩
   have hd := dist_le_of_le_geometric_of_tendsto₀ (1 / 4) (C / 4) (by norm_num)
-    (dist_naiveHeight_div_succ_le hC P) (P.tendsto_naiveHeight_div_canonicalHeight)
+    (dist_naiveHeight_div_succ_le hC P) (P.tendsto_naiveHeight_two_pow_nsmul_div_four_pow)
   -- the zeroth term of the sequence is `h P` itself
   simpa [Real.dist_eq, abs_sub_comm] using hd
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -14,9 +14,15 @@ The naïve height `h` is quadratic only up to a bounded error: `approx_parallelo
 constant `C` with `|h(P + Q) + h(P - Q) - 2(h P + h Q)| ≤ C`. Tate's observation is that averaging
 that error away along the doubling map produces an honestly quadratic function. This file carries
 out that construction and records the two facts that pin it down: the limit exists, and it stays
-within a bounded distance of `h`.
+within a bounded distance of half of `h`.
 
-`canonicalHeight P = lim_{n → ∞} h(2ⁿ P) / 4ⁿ`
+`canonicalHeight P = (1/2) · lim_{n → ∞} h(2ⁿ P) / 4ⁿ`
+
+The factor `1/2` is the standard normalisation and is not cosmetic. The naïve height here is the
+height of the `x`-coordinate, and `x` has a *double* pole at the point at infinity, so `h_x` is the
+height attached to the divisor `2(O)`. Heights scale linearly in the divisor, so the height
+attached to `(O)` — the one the Néron–Tate pairing, the regulator and the BSD formula are stated
+with — is half of it. Getting this wrong would scale every later invariant.
 
 ## Main definitions
 
@@ -34,7 +40,7 @@ within a bounded distance of `h`.
   `WeierstrassCurve.Affine.Point.canonicalHeight_neg`: its values at the two points every consumer
   meets first, as `@[simp]` normal forms.
 * `WeierstrassCurve.Affine.Point.abs_canonicalHeight_sub_naiveHeight_le`: the canonical height stays
-  within a bounded distance of the naïve one, by a
+  within a bounded distance of *half* the naïve one, by a
   constant depending only on the curve. This is what makes the two interchangeable in
   finiteness arguments — in particular Northcott finiteness transfers to it.
 
@@ -46,8 +52,8 @@ and `h(0) = 0`. Only that specialisation is used here, so it is kept private.
 Convergence is `cauchySeq_of_le_geometric` at ratio `1/4`: consecutive terms of `h(2ⁿ P) / 4ⁿ`
 differ by `|h(2 · 2ⁿ P) - 4 h(2ⁿ P)| / 4ⁿ⁺¹ ≤ C / 4ⁿ⁺¹`. The same estimate feeds Mathlib's
 `dist_le_of_le_geometric_of_tendsto₀`, which bounds the distance from the *zeroth* term — and the
-zeroth term is `h(P)` — giving `|canonicalHeight P - h(P)| ≤ (C / 4) / (1 - 1/4) = C / 3` with no
-further work.
+zeroth term is `h(P) / 2` — giving `|canonicalHeight P - h(P)/2| ≤ (C / 8) / (1 - 1/4) = C / 6`
+with no further work.
 
 The `[DecidableEq F]` hypothesis is not incidental: `W.Point`'s `AddCommGroup` instance needs it,
 since the addition formula case-splits on whether the two points share an `x`-coordinate. Without
@@ -66,13 +72,16 @@ namespace WeierstrassCurve.Affine
 
 variable {F : Type*} [Field F] {W : Affine F} [AdmissibleAbsValues F] [DecidableEq F]
 
-/-- **The canonical (Néron–Tate) height** `canonicalHeight P = lim h(2ⁿ P) / 4ⁿ`.
+/-- **The canonical (Néron–Tate) height** `canonicalHeight P = lim h(2ⁿ P) / (2 · 4ⁿ)`.
+
+The `2` is the standard normalisation: `h` is the height of the `x`-coordinate, which has a double
+pole at infinity, so `h` is attached to `2(O)` and the Néron–Tate height to `(O)` is half of it.
 
 The limit exists whenever the curve is elliptic
 (`Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow`); the definition itself needs no hypothesis
 beyond those making `2 ^ n • P` meaningful, so it is stated without one. -/
 noncomputable def Point.canonicalHeight (P : W.Point) : ℝ :=
-  limUnder atTop fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / 4 ^ n
+  limUnder atTop fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / (2 * 4 ^ n)
 
 variable (W) in
 /-- The parallelogram law at `Q = P`: doubling multiplies the naïve height by `4` up to a bounded
@@ -92,31 +101,33 @@ private theorem exists_abs_naiveHeight_two_nsmul_sub [W.toAffine.IsElliptic] :
 estimate both results below run on. -/
 private theorem dist_naiveHeight_div_succ_le [W.toAffine.IsElliptic] {C : ℝ}
     (hC : ∀ P : W.Point, |(2 • P).naiveHeight - 4 * P.naiveHeight| ≤ C) (P : W.Point) (n : ℕ) :
-    dist (((2 ^ n) • P).naiveHeight / 4 ^ n) (((2 ^ (n + 1)) • P).naiveHeight / 4 ^ (n + 1))
-      ≤ C / 4 * (1 / 4) ^ n := by
+    dist (((2 ^ n) • P).naiveHeight / (2 * 4 ^ n))
+        (((2 ^ (n + 1)) • P).naiveHeight / (2 * 4 ^ (n + 1)))
+      ≤ C / 8 * (1 / 4) ^ n := by
   have key : ((2 : ℕ) ^ (n + 1)) • P = 2 • (((2 : ℕ) ^ n) • P) := by
     rw [smul_smul]; congr 1; ring
-  have e : ((2 : ℕ) ^ n • P).naiveHeight / 4 ^ n
-        - ((2 : ℕ) ^ (n + 1) • P).naiveHeight / 4 ^ (n + 1)
+  have e : ((2 : ℕ) ^ n • P).naiveHeight / (2 * 4 ^ n)
+        - ((2 : ℕ) ^ (n + 1) • P).naiveHeight / (2 * 4 ^ (n + 1))
       = (4 * ((2 : ℕ) ^ n • P).naiveHeight - (2 • ((2 : ℕ) ^ n • P)).naiveHeight)
-          / 4 ^ (n + 1) := by
+          / (2 * 4 ^ (n + 1)) := by
     rw [key]; field_simp [pow_succ]; ring
-  rw [Real.dist_eq, e, abs_div, abs_of_pos (by positivity : (0 : ℝ) < 4 ^ (n + 1)),
-    div_le_iff₀ (by positivity : (0 : ℝ) < 4 ^ (n + 1))]
+  rw [Real.dist_eq, e, abs_div, abs_of_pos (by positivity : (0 : ℝ) < 2 * 4 ^ (n + 1)),
+    div_le_iff₀ (by positivity : (0 : ℝ) < 2 * 4 ^ (n + 1))]
   have h := hC ((2 : ℕ) ^ n • P)
   rw [abs_sub_comm] at h
   calc |4 * ((2 : ℕ) ^ n • P).naiveHeight - (2 • ((2 : ℕ) ^ n • P)).naiveHeight| ≤ C := h
-    _ = C / 4 * (1 / 4 : ℝ) ^ n * 4 ^ (n + 1) := by
+    _ = C / 8 * (1 / 4 : ℝ) ^ n * (2 * 4 ^ (n + 1)) := by
         have h1 : ((1 : ℝ) / 4) ^ n * 4 ^ n = 1 := by rw [← mul_pow]; norm_num
         linear_combination (-C) * h1
 
 /-- **The defining limit is attained.** `canonicalHeight` is `limUnder`, which returns a junk value
 on a divergent sequence; this says the sequence converges, so the definition means what it says. -/
 theorem Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow [W.toAffine.IsElliptic] (P : W.Point) :
-    Tendsto (fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / 4 ^ n) atTop (𝓝 P.canonicalHeight) := by
+    Tendsto (fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / (2 * 4 ^ n)) atTop
+      (𝓝 P.canonicalHeight) := by
   obtain ⟨C, _, hC⟩ := exists_abs_naiveHeight_two_nsmul_sub W
   obtain ⟨a, ha⟩ := cauchySeq_tendsto_of_complete
-    (cauchySeq_of_le_geometric (1 / 4) (C / 4) (by norm_num)
+    (cauchySeq_of_le_geometric (1 / 4) (C / 8) (by norm_num)
       (dist_naiveHeight_div_succ_le hC P))
   rwa [Point.canonicalHeight, ha.limUnder_eq]
 
@@ -137,13 +148,14 @@ theorem Point.canonicalHeight_neg [W.toAffine.IsElliptic] (P : W.Point) :
   simpa only [smul_neg, Point.naiveHeight_neg] using
     Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow P
 
-/-- **The canonical height differs from the naïve height by a bounded amount**, the bound depending
-only on the curve. Northcott finiteness for `h` therefore transfers to the canonical height. -/
+/-- **The canonical height differs from half the naïve height by a bounded amount**, the bound
+depending only on the curve. The half is the normalisation described in the module docstring;
+Northcott finiteness for `h` transfers to the canonical height through this. -/
 theorem Point.abs_canonicalHeight_sub_naiveHeight_le [W.toAffine.IsElliptic] :
-    ∃ D, ∀ P : W.Point, |P.canonicalHeight - P.naiveHeight| ≤ D := by
+    ∃ D, ∀ P : W.Point, |P.canonicalHeight - P.naiveHeight / 2| ≤ D := by
   obtain ⟨C, _, hC⟩ := exists_abs_naiveHeight_two_nsmul_sub W
-  refine ⟨C / 4 / (1 - 1 / 4), fun P ↦ ?_⟩
-  have hd := dist_le_of_le_geometric_of_tendsto₀ (1 / 4) (C / 4) (by norm_num)
+  refine ⟨C / 8 / (1 - 1 / 4), fun P ↦ ?_⟩
+  have hd := dist_le_of_le_geometric_of_tendsto₀ (1 / 4) (C / 8) (by norm_num)
     (dist_naiveHeight_div_succ_le hC P) (P.tendsto_naiveHeight_two_pow_nsmul_div_four_pow)
   -- the zeroth term of the sequence is `h P` itself
   simpa [Real.dist_eq, abs_sub_comm] using hd

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -33,11 +33,10 @@ with — is half of it. Getting this wrong would scale every later invariant.
 ## Main results
 
 * `WeierstrassCurve.Affine.Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow`: the defining
-  limit is
-  attained, so `canonicalHeight` is the limit and not the junk value `limUnder` returns when a
-  sequence does not converge. Every property of the canonical height is proved by transporting a
-  property of `h`
-  along this.
+  limit is attained, so `canonicalHeight` is the limit and not the junk value `limUnder`
+  returns when a sequence does not converge. Properties that genuinely need passage to the limit
+  are proved by transporting a property of `h` along this; the values at `0` and under negation
+  do not, and are proved termwise instead.
 * `WeierstrassCurve.Affine.Point.canonicalHeight_zero` and
   `WeierstrassCurve.Affine.Point.canonicalHeight_neg`: its values at the two points every consumer
   meets first, as `@[simp]` normal forms.
@@ -51,8 +50,10 @@ with — is half of it. Getting this wrong would scale every later invariant.
 The doubling bound `|h(2P) - 4 h(P)| ≤ C` is the parallelogram law at `Q = P`, where `P - Q = 0`
 and `h(0) = 0`. Only that specialisation is used here, so it is kept private.
 
-Convergence is `cauchySeq_of_le_geometric` at ratio `1/4`: consecutive terms of `h(2ⁿ P) / 4ⁿ`
-differ by `|h(2 · 2ⁿ P) - 4 h(2ⁿ P)| / 4ⁿ⁺¹ ≤ C / 4ⁿ⁺¹`. The same estimate feeds Mathlib's
+Convergence is `cauchySeq_of_le_geometric` at ratio `1/4`: consecutive terms of
+`h(2ⁿ P) / (2 · 4ⁿ)` differ by
+`|h(2 · 2ⁿ P) - 4 h(2ⁿ P)| / (2 · 4ⁿ⁺¹) ≤ C / (2 · 4ⁿ⁺¹) = (C/8) · (1/4)ⁿ`. The same estimate
+feeds Mathlib's
 `dist_le_of_le_geometric_of_tendsto₀`, which bounds the distance from the *zeroth* term — and the
 zeroth term is `h(P) / 2` — giving `|canonicalHeight P - h(P)/2| ≤ (C / 8) / (1 - 1/4) = C / 6`
 with no further work.
@@ -99,8 +100,8 @@ private theorem exists_abs_naiveHeight_two_nsmul_sub [W.toAffine.IsElliptic] :
   convert h using 2
   ring
 
-/-- Consecutive terms of `h(2ⁿ P) / 4ⁿ` differ geometrically at ratio `1/4`. This is the single
-estimate both results below run on. -/
+/-- Consecutive terms of `h(2ⁿ P) / (2 · 4ⁿ)` differ geometrically at ratio `1/4`, by
+`(C/8) · (1/4)ⁿ`. This is the single estimate both results below run on. -/
 private theorem dist_naiveHeight_div_succ_le [W.toAffine.IsElliptic] {C : ℝ}
     (hC : ∀ P : W.Point, |(2 • P).naiveHeight - 4 * P.naiveHeight| ≤ C) (P : W.Point) (n : ℕ) :
     dist (((2 ^ n) • P).naiveHeight / (2 * 4 ^ n))

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -12,9 +12,11 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.NaiveHeight
 
 The naïve height `h` is quadratic only up to a bounded error: `approx_parallelogram_law` gives a
 constant `C` with `|h(P + Q) + h(P - Q) - 2(h P + h Q)| ≤ C`. Tate's observation is that averaging
-that error away along the doubling map produces an honestly quadratic function. This file carries
-out that construction and records the two facts that pin it down: the limit exists, and it stays
-within a bounded distance of half of `h`.
+that error away along the doubling map removes it. This file carries
+out that construction and records the facts that pin the definition down: the limit exists, it
+stays within a bounded distance of half of `h`, and it takes the expected values at `0` and under
+negation. That the result is *honestly* quadratic — the exact parallelogram law — is a separate
+theorem and is not established in this file.
 
 `canonicalHeight P = (1/2) · lim_{n → ∞} h(2ⁿ P) / 4ⁿ`
 
@@ -126,27 +128,28 @@ theorem Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow [W.toAffine.IsEllip
     Tendsto (fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / (2 * 4 ^ n)) atTop
       (𝓝 P.canonicalHeight) := by
   obtain ⟨C, _, hC⟩ := exists_abs_naiveHeight_two_nsmul_sub W
-  obtain ⟨a, ha⟩ := cauchySeq_tendsto_of_complete
-    (cauchySeq_of_le_geometric (1 / 4) (C / 8) (by norm_num)
-      (dist_naiveHeight_div_succ_le hC P))
-  rwa [Point.canonicalHeight, ha.limUnder_eq]
+  exact (cauchySeq_of_le_geometric (1 / 4) (C / 8) (by norm_num)
+    (dist_naiveHeight_div_succ_le hC P)).tendsto_limUnder
 
 /-- The point at infinity has canonical height zero: every term of the defining sequence is
-`h 0 / 4 ^ n = 0`. -/
+`h 0 / (2 · 4 ^ n) = 0`. This is termwise, so it needs no convergence and no ellipticity. -/
 @[simp]
-theorem Point.canonicalHeight_zero [W.toAffine.IsElliptic] :
-    (0 : W.Point).canonicalHeight = 0 := by
-  refine tendsto_nhds_unique (Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow 0) ?_
-  simp
+theorem Point.canonicalHeight_zero : (0 : W.Point).canonicalHeight = 0 := by
+  have h : (fun n : ℕ ↦ ((2 ^ n) • (0 : W.Point)).naiveHeight / (2 * 4 ^ n)) = fun _ ↦ 0 := by
+    funext n; simp
+  rw [Point.canonicalHeight, h]
+  exact tendsto_const_nhds.limUnder_eq
 
 /-- Negation preserves the canonical height, because it preserves the naïve height and commutes
-with doubling, so the two defining sequences agree termwise. -/
+with doubling, so the two defining sequences agree termwise — again with no convergence or
+ellipticity needed. -/
 @[simp]
-theorem Point.canonicalHeight_neg [W.toAffine.IsElliptic] (P : W.Point) :
+theorem Point.canonicalHeight_neg (P : W.Point) :
     (-P).canonicalHeight = P.canonicalHeight := by
-  refine tendsto_nhds_unique (Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow (-P)) ?_
-  simpa only [smul_neg, Point.naiveHeight_neg] using
-    Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow P
+  have h : (fun n : ℕ ↦ ((2 ^ n) • (-P)).naiveHeight / (2 * 4 ^ n))
+      = fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / (2 * 4 ^ n) := by
+    funext n; rw [smul_neg, Point.naiveHeight_neg]
+  rw [Point.canonicalHeight, Point.canonicalHeight, h]
 
 /-- **The canonical height differs from half the naïve height by a bounded amount**, the bound
 depending only on the curve. The half is the normalisation described in the module docstring;
@@ -157,7 +160,7 @@ theorem Point.abs_canonicalHeight_sub_naiveHeight_le [W.toAffine.IsElliptic] :
   refine ⟨C / 8 / (1 - 1 / 4), fun P ↦ ?_⟩
   have hd := dist_le_of_le_geometric_of_tendsto₀ (1 / 4) (C / 8) (by norm_num)
     (dist_naiveHeight_div_succ_le hC P) (P.tendsto_naiveHeight_two_pow_nsmul_div_four_pow)
-  -- the zeroth term of the sequence is `h P` itself
+  -- the zeroth term of the sequence is `h P / 2`
   simpa [Real.dist_eq, abs_sub_comm] using hd
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -102,7 +102,7 @@ private theorem exists_abs_naiveHeight_two_nsmul_sub [W.toAffine.IsElliptic] :
 
 /-- Consecutive terms of `h(2ⁿ P) / (2 · 4ⁿ)` differ geometrically at ratio `1/4`, by
 `(C/8) · (1/4)ⁿ`. This is the single estimate both results below run on. -/
-private theorem dist_naiveHeight_div_succ_le [W.toAffine.IsElliptic] {C : ℝ}
+private theorem dist_naiveHeight_div_succ_le {C : ℝ}
     (hC : ∀ P : W.Point, |(2 • P).naiveHeight - 4 * P.naiveHeight| ≤ C) (P : W.Point) (n : ℕ) :
     dist (((2 ^ n) • P).naiveHeight / (2 * 4 ^ n))
         (((2 ^ (n + 1)) • P).naiveHeight / (2 * 4 ^ (n + 1)))

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/CanonicalHeight.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.NaiveHeight
+
+/-!
+# The canonical (Néron–Tate) height
+
+The naïve height `h` is quadratic only up to a bounded error: `approx_parallelogram_law` gives a
+constant `C` with `|h(P + Q) + h(P - Q) - 2(h P + h Q)| ≤ C`. Tate's observation is that averaging
+that error away along the doubling map produces an honestly quadratic function. This file carries
+out that construction and records the two facts that pin it down: the limit exists, and it stays
+within a bounded distance of `h`.
+
+`canonicalHeight P = lim_{n → ∞} h(2ⁿ P) / 4ⁿ`
+
+## Main definitions
+
+* `WeierstrassCurve.Affine.Point.canonicalHeight`: the limit above.
+
+## Main results
+
+* `WeierstrassCurve.Affine.Point.tendsto_naiveHeight_div_canonicalHeight`: the defining limit is
+  attained, so `canonicalHeight` is the limit and not the junk value `limUnder` returns when a
+  sequence does not converge. Every property of the canonical height is proved by transporting a
+  property of `h`
+  along this.
+* `WeierstrassCurve.Affine.Point.abs_canonicalHeight_sub_naiveHeight_le`: the canonical height stays
+  within a bounded distance of the naïve one, by a
+  constant depending only on the curve. This is what makes the two interchangeable in
+  finiteness arguments — in particular Northcott finiteness transfers to it.
+
+## Implementation notes
+
+The doubling bound `|h(2P) - 4 h(P)| ≤ C` is the parallelogram law at `Q = P`, where `P - Q = 0`
+and `h(0) = 0`. Only that specialisation is used here, so it is kept private.
+
+Convergence is `cauchySeq_of_le_geometric` at ratio `1/4`: consecutive terms of `h(2ⁿ P) / 4ⁿ`
+differ by `|h(2 · 2ⁿ P) - 4 h(2ⁿ P)| / 4ⁿ⁺¹ ≤ C / 4ⁿ⁺¹`. The same estimate feeds Mathlib's
+`dist_le_of_le_geometric_of_tendsto₀`, which bounds the distance from the *zeroth* term — and the
+zeroth term is `h(P)` — giving `|canonicalHeight P - h(P)| ≤ (C / 4) / (1 - 1/4) = C / 3` with no
+further work.
+
+The `[DecidableEq F]` hypothesis is not incidental: `W.Point`'s `AddCommGroup` instance needs it,
+since the addition formula case-splits on whether the two points share an `x`-coordinate. Without
+it `2 ^ n • P` does not elaborate.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], VIII.9.
+-/
+
+public section
+
+open Filter Height Topology
+
+namespace WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] {W : Affine F} [AdmissibleAbsValues F] [DecidableEq F]
+
+/-- **The canonical (Néron–Tate) height** `canonicalHeight P = lim h(2ⁿ P) / 4ⁿ`.
+
+The limit exists whenever the curve is elliptic
+(`Point.tendsto_naiveHeight_div_canonicalHeight`); the definition itself needs no hypothesis
+beyond those making `2 ^ n • P` meaningful, so it is stated without one. -/
+noncomputable def Point.canonicalHeight (P : W.Point) : ℝ :=
+  limUnder atTop fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / 4 ^ n
+
+variable (W) in
+/-- The parallelogram law at `Q = P`: doubling multiplies the naïve height by `4` up to a bounded
+error. The constant is nonnegative, which the geometric estimate below needs. -/
+private theorem exists_abs_naiveHeight_two_nsmul_sub [W.toAffine.IsElliptic] :
+    ∃ C, 0 ≤ C ∧ ∀ P : W.Point, |(2 • P).naiveHeight - 4 * P.naiveHeight| ≤ C := by
+  obtain ⟨C, hC⟩ := approx_parallelogram_law W
+  refine ⟨C, le_trans (abs_nonneg _) (hC 0 0), fun P ↦ ?_⟩
+  have h := hC P P
+  -- `P - P = 0` and `h 0 = 0`, so the law collapses to the doubling statement.
+  rw [sub_self, Point.naiveHeight_zero] at h
+  rw [two_nsmul]
+  convert h using 2
+  ring
+
+/-- Consecutive terms of `h(2ⁿ P) / 4ⁿ` differ geometrically at ratio `1/4`. This is the single
+estimate both results below run on. -/
+private theorem dist_naiveHeight_div_succ_le [W.toAffine.IsElliptic] {C : ℝ}
+    (hC : ∀ P : W.Point, |(2 • P).naiveHeight - 4 * P.naiveHeight| ≤ C) (P : W.Point) (n : ℕ) :
+    dist (((2 ^ n) • P).naiveHeight / 4 ^ n) (((2 ^ (n + 1)) • P).naiveHeight / 4 ^ (n + 1))
+      ≤ C / 4 * (1 / 4) ^ n := by
+  have key : ((2 : ℕ) ^ (n + 1)) • P = 2 • (((2 : ℕ) ^ n) • P) := by
+    rw [smul_smul]; congr 1; ring
+  have e : ((2 : ℕ) ^ n • P).naiveHeight / 4 ^ n
+        - ((2 : ℕ) ^ (n + 1) • P).naiveHeight / 4 ^ (n + 1)
+      = (4 * ((2 : ℕ) ^ n • P).naiveHeight - (2 • ((2 : ℕ) ^ n • P)).naiveHeight)
+          / 4 ^ (n + 1) := by
+    rw [key]; field_simp [pow_succ]; ring
+  rw [Real.dist_eq, e, abs_div, abs_of_pos (by positivity : (0 : ℝ) < 4 ^ (n + 1)),
+    div_le_iff₀ (by positivity : (0 : ℝ) < 4 ^ (n + 1))]
+  have h := hC ((2 : ℕ) ^ n • P)
+  rw [abs_sub_comm] at h
+  calc |4 * ((2 : ℕ) ^ n • P).naiveHeight - (2 • ((2 : ℕ) ^ n • P)).naiveHeight| ≤ C := h
+    _ = C / 4 * (1 / 4 : ℝ) ^ n * 4 ^ (n + 1) := by
+        have h1 : ((1 : ℝ) / 4) ^ n * 4 ^ n = 1 := by rw [← mul_pow]; norm_num
+        linear_combination (-C) * h1
+
+/-- **The defining limit is attained.** `canonicalHeight` is `limUnder`, which returns a junk value
+on a divergent sequence; this says the sequence converges, so the definition means what it says. -/
+theorem Point.tendsto_naiveHeight_div_canonicalHeight [W.toAffine.IsElliptic] (P : W.Point) :
+    Tendsto (fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / 4 ^ n) atTop (𝓝 P.canonicalHeight) := by
+  obtain ⟨C, _, hC⟩ := exists_abs_naiveHeight_two_nsmul_sub W
+  obtain ⟨a, ha⟩ := cauchySeq_tendsto_of_complete
+    (cauchySeq_of_le_geometric (1 / 4) (C / 4) (by norm_num)
+      (dist_naiveHeight_div_succ_le hC P))
+  rwa [Point.canonicalHeight, ha.limUnder_eq]
+
+/-- **The canonical height differs from the naïve height by a bounded amount**, the bound depending
+only on the curve. Northcott finiteness for `h` therefore transfers to the canonical height. -/
+theorem Point.abs_canonicalHeight_sub_naiveHeight_le [W.toAffine.IsElliptic] :
+    ∃ D, ∀ P : W.Point, |P.canonicalHeight - P.naiveHeight| ≤ D := by
+  obtain ⟨C, _, hC⟩ := exists_abs_naiveHeight_two_nsmul_sub W
+  refine ⟨C / 4 / (1 - 1 / 4), fun P ↦ ?_⟩
+  have hd := dist_le_of_le_geometric_of_tendsto₀ (1 / 4) (C / 4) (by norm_num)
+    (dist_naiveHeight_div_succ_le hC P) (P.tendsto_naiveHeight_div_canonicalHeight)
+  -- the zeroth term of the sequence is `h P` itself
+  simpa [Real.dist_eq, abs_sub_comm] using hd
+
+end WeierstrassCurve.Affine


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"canonical-height"}-->

## The target

`TauCetiRoadmap/EllipticCurves/README.md:805-811` names the canonical (Néron–Tate) height as a
Layer 6 milestone, separate from and later than Mordell–Weil, "consumed by regulators, isogeny
compatibility, and BSD". `STATUS.md:36` lists it as open. This PR is the **first item** on that
list: the construction, its defining convergence, and its bounded difference from the naïve height.

## What it adds

```lean
noncomputable def Point.canonicalHeight (P : W.Point) : ℝ :=
  limUnder atTop fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / (2 * 4 ^ n)

theorem Point.tendsto_naiveHeight_two_pow_nsmul_div_four_pow [W.toAffine.IsElliptic] (P : W.Point) :
    Tendsto (fun n : ℕ ↦ ((2 ^ n) • P).naiveHeight / (2 * 4 ^ n)) atTop (𝓝 P.canonicalHeight)

@[simp] theorem Point.canonicalHeight_zero [W.toAffine.IsElliptic] :
    (0 : W.Point).canonicalHeight = 0

@[simp] theorem Point.canonicalHeight_neg [W.toAffine.IsElliptic] (P : W.Point) :
    (-P).canonicalHeight = P.canonicalHeight

theorem Point.abs_canonicalHeight_sub_naiveHeight_le [W.toAffine.IsElliptic] :
    ∃ D, ∀ P : W.Point, |P.canonicalHeight - P.naiveHeight / 2| ≤ D
```

## The normalisation, since it was wrong in the first version

`h` here is the height of the `x`-coordinate, and `x` has a **double** pole at the point at
infinity — so `h_x` is the height attached to the divisor `2(O)`. Heights scale linearly in the
divisor, so the height attached to `(O)`, which is the one the Néron–Tate pairing, the regulator
and BSD are stated with, is **half** of `lim 4⁻ⁿ h(2ⁿ P)`. The first version of this PR omitted
that factor and so defined twice the conventional height; every invariant derived from it later
would have been scaled wrongly. `correctness` caught it and the definition now carries the `2`.
The module docstring records the divisor argument so the next reader need not rederive it.

## How it works

- **The doubling bound.** `approx_parallelogram_law` at `Q = P`, where `P - Q = 0` and `h 0 = 0`,
  collapses to `|h(2P) - 4 h(P)| ≤ C`. Only this specialisation is used, so it stays private.
- **Convergence.** Consecutive terms differ by `(C/8) · (1/4)ⁿ` — geometric at ratio `1/4` — so
  `cauchySeq_of_le_geometric` applies and `ℝ` is complete.
- **The bounded difference for free.** The same estimate feeds
  `dist_le_of_le_geometric_of_tendsto₀`, which bounds the distance from the *zeroth* term to the
  limit by `C / (1 - r)`. The zeroth term is `h(P)/2`, so the bound is `C/6` with no further
  argument.

The `tendsto` lemma is not decoration: `canonicalHeight` is `limUnder`, which returns a junk value
on a divergent sequence, so without it the definition would not be known to mean what it says. It
is also the transport mechanism for the rest of the milestone — the parallelogram law in the
stacked follow-up (#5601) is proved through it.

## Provenance

**Original work.** The chain's intake records that the Néron–Tate height has no source: it is the
one Layer 6 item with nothing to port. Prerequisites come from `main`
(`MordellWeil/NaiveHeight.lean`: `Point.naiveHeight`, `naiveHeight_zero`, `naiveHeight_neg`,
`approx_parallelogram_law`) and from Mathlib's geometric-Cauchy API.

Absence checked before writing: `grep -rniE
'canonicalHeight|canonical_height|neronTate|neron_tate|tateLimit|quasiQuadratic'` over the pinned
Mathlib returns nothing; `Mathlib/NumberTheory/Height/EllipticCurve.lean` contains exactly one
theorem, the quasi-parallelogram bound `main` already consumes; and a compiled `exact?` probe for
"`|f (2•x) - 4 f x| ≤ C` implies `lim f (2ⁿ•x)/4ⁿ` exists" fails, so there is no general
telescoping lemma to reuse.

## Placement

`EllipticCurve/CanonicalHeight.lean`, not under `MordellWeil/`: the canonical height is not part of
that proof — the roadmap says it is consumed by regulators, isogenies and BSD *rather than* by
Mordell–Weil. It still imports `MordellWeil/NaiveHeight.lean`, which is where the naïve height
lives today; regrouping the height modules is a separate topic.

## Notes

`[DecidableEq F]` is required, not incidental: `W.Point`'s `AddCommGroup` instance needs it, since
the addition formula case-splits on whether two points share an `x`-coordinate. Without it
`2 ^ n • P` does not elaborate.

## Gates

- `lake build`: green, 0 errors, 0 warnings under `warningAsError = true`, no Mathlib recompiled.
- `scripts/lint-style.sh`: exit 0. (`ĥ` is not on the unicode allowlist, so the prose spells the
  name out.)
- `#lint only simpNF in TauCeti`: 0 errors over 22 declarations — the diff adds two `@[simp]`
  lemmas, so this was checked rather than assumed.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; no line over 100 characters.
- Claim at `refs/tauceti-claims/author/EllipticCurves/canonical-height`; no other open PR carries
  that marker.
