### PR TITLE
refactor(StudentT): collapse the CDF tail's chart reconciliation

### DIFF
--- a/TauCeti/Probability/Distributions/StudentT/Cdf.lean
+++ b/TauCeti/Probability/Distributions/StudentT/Cdf.lean
@@ -71,38 +71,10 @@ private lemma integral_Ioi_studentTPDFReal_eq_betaKernel_tail (hν : 0 < ν) {y 
       image_sq_div_const_Ioi hν hy]
   have h12 : ∫ z in Ioi y, |2 * z / ν| • g1 (z ^ 2 / ν) =
       ∫ z in Ioi y, studentTPDFReal ν z := by
-    apply setIntegral_congr_fun measurableSet_Ioi
-    intro z hz
-    have hz0 : 0 < z := hy.trans_lt hz
-    have h := abs_deriv_smul_studentTPDFReal hν 0 hz0
-    have hhq : ((0 - 1) / 2 : ℝ) = -(1 / 2 : ℝ) := by ring
-    have h' : |2 * z / ν| • g1 (z ^ 2 / ν) = studentTPDFReal ν z := by
-      have hrpow0 : Real.rpow ν (1 / 2 : ℝ) = Real.rpow ν ((0 + 1) / 2) := by
-        congr 1; norm_num
-      have hhs : s = (ν + 1) / 2 := hs.symm
-      have hhqp : studentTBetaKernel ν 0 (z ^ 2 / ν) =
-          (z ^ 2 / ν) ^ (-(1 / 2 : ℝ)) * (1 + z ^ 2 / ν) ^ (-s) := by
-        simp only [studentTBetaKernel, hs, hhq]
-      have hg1 : g1 (z ^ 2 / ν) =
-          Real.Gamma s / (Real.sqrt (ν * Real.pi) * Real.Gamma (ν / 2)) *
-            Real.rpow ν (1 / 2 : ℝ) / 2 *
-            ((z ^ 2 / ν) ^ (-(1 / 2 : ℝ)) * (1 + z ^ 2 / ν) ^ (-s)) := by
-        dsimp only [g1]
-        rw [hC]; rfl
-      have hg1' : g1 (z ^ 2 / ν) =
-          Real.Gamma ((ν + 1) / 2) / (Real.sqrt (ν * Real.pi) * Real.Gamma (ν / 2)) *
-            Real.rpow ν ((0 + 1) / 2) / 2 * studentTBetaKernel ν 0 (z ^ 2 / ν) := by
-        rw [hg1, hhqp, hhs, hrpow0]
-      have h'' : |2 * z / ν| •
-          (Real.Gamma ((ν + 1) / 2) / (Real.sqrt (ν * Real.pi) * Real.Gamma (ν / 2)) *
-            Real.rpow ν ((0 + 1) / 2) / 2 * studentTBetaKernel ν 0 (z ^ 2 / ν)) =
-          studentTPDFReal ν z := by
-        have h3 := h
-        rw [Real.rpow_zero, mul_one] at h3
-        exact h3
-      rw [hg1']
-      exact h''
-    exact h'
+    refine setIntegral_congr_fun measurableSet_Ioi fun z hz => ?_
+    dsimp only [g1]
+    rw [hC, hs]
+    exact abs_deriv_smul_studentTPDFReal_zero hν (hy.trans_lt hz)
   have h1 : ∫ z in Ioi y, studentTPDFReal ν z = ∫ w in Ioi y0, g1 w := by
     rw [← h12, ← h11]
   set K := C * Real.rpow ν (1 / 2 : ℝ) / 2 with hK

--- a/TauCeti/Probability/Distributions/StudentT/Cdf.lean
+++ b/TauCeti/Probability/Distributions/StudentT/Cdf.lean
@@ -72,9 +72,13 @@ private lemma integral_Ioi_studentTPDFReal_eq_betaKernel_tail (hν : 0 < ν) {y 
   have h12 : ∫ z in Ioi y, |2 * z / ν| • g1 (z ^ 2 / ν) =
       ∫ z in Ioi y, studentTPDFReal ν z := by
     refine setIntegral_congr_fun measurableSet_Ioi fun z hz => ?_
+    -- The chart lemma at `q = 0`: its `z ^ (0 : ℝ)` factor disappears, and the beta kernel
+    -- abbreviation unfolds to the explicit powers that `g1` is written with.
+    have h := abs_deriv_smul_studentTPDFReal hν 0 (hy.trans_lt hz)
+    rw [Real.rpow_zero, mul_one] at h
     dsimp only [g1]
-    rw [hC, hs]
-    exact abs_deriv_smul_studentTPDFReal_zero hν (hy.trans_lt hz)
+    rw [hC, hs, ← h, studentTBetaKernel]
+    norm_num
   have h1 : ∫ z in Ioi y, studentTPDFReal ν z = ∫ w in Ioi y0, g1 w := by
     rw [← h12, ← h11]
   set K := C * Real.rpow ν (1 / 2 : ℝ) / 2 with hK

--- a/TauCeti/Probability/Distributions/StudentT/WeightedIntegral.lean
+++ b/TauCeti/Probability/Distributions/StudentT/WeightedIntegral.lean
@@ -144,22 +144,6 @@ lemma abs_deriv_smul_studentTPDFReal (hν : 0 < ν) (q : ℝ) {z : ℝ} (hz : 0 
     rw [hreorder, h7]
   exact hgoal
 
-/-- The `q = 0` case of `abs_deriv_smul_studentTPDFReal`, with the beta kernel written out: under
-the chart `z ↦ z ^ 2 / ν` the unweighted Student t density is the half-line kernel
-`w ^ (-(1 / 2)) * (1 + w) ^ (-((ν + 1) / 2))` scaled by the normalising constant. This is the shape
-the cumulative distribution function needs, where the kernel occurs expanded rather than under its
-abbreviation. -/
-lemma abs_deriv_smul_studentTPDFReal_zero (hν : 0 < ν) {z : ℝ} (hz : 0 < z) :
-    |2 * z / ν| •
-        (Real.Gamma ((ν + 1) / 2) / (Real.sqrt (ν * Real.pi) * Real.Gamma (ν / 2)) *
-          ν ^ (1 / 2 : ℝ) / 2 *
-          ((z ^ 2 / ν) ^ (-(1 / 2 : ℝ)) * (1 + z ^ 2 / ν) ^ (-((ν + 1) / 2)))) =
-      studentTPDFReal ν z := by
-  have h := abs_deriv_smul_studentTPDFReal hν 0 hz
-  rw [Real.rpow_zero, mul_one] at h
-  rw [← h, studentTBetaKernel]
-  norm_num
-
 end Probability
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/StudentT/WeightedIntegral.lean
+++ b/TauCeti/Probability/Distributions/StudentT/WeightedIntegral.lean
@@ -144,6 +144,22 @@ lemma abs_deriv_smul_studentTPDFReal (hν : 0 < ν) (q : ℝ) {z : ℝ} (hz : 0 
     rw [hreorder, h7]
   exact hgoal
 
+/-- The `q = 0` case of `abs_deriv_smul_studentTPDFReal`, with the beta kernel written out: under
+the chart `z ↦ z ^ 2 / ν` the unweighted Student t density is the half-line kernel
+`w ^ (-(1 / 2)) * (1 + w) ^ (-((ν + 1) / 2))` scaled by the normalising constant. This is the shape
+the cumulative distribution function needs, where the kernel occurs expanded rather than under its
+abbreviation. -/
+lemma abs_deriv_smul_studentTPDFReal_zero (hν : 0 < ν) {z : ℝ} (hz : 0 < z) :
+    |2 * z / ν| •
+        (Real.Gamma ((ν + 1) / 2) / (Real.sqrt (ν * Real.pi) * Real.Gamma (ν / 2)) *
+          ν ^ (1 / 2 : ℝ) / 2 *
+          ((z ^ 2 / ν) ^ (-(1 / 2 : ℝ)) * (1 + z ^ 2 / ν) ^ (-((ν + 1) / 2)))) =
+      studentTPDFReal ν z := by
+  have h := abs_deriv_smul_studentTPDFReal hν 0 hz
+  rw [Real.rpow_zero, mul_one] at h
+  rw [← h, studentTBetaKernel]
+  norm_num
+
 end Probability
 
 end TauCeti


### PR DESCRIPTION
The private lemma `integral_Ioi_studentTPDFReal_eq_betaKernel_tail` in `StudentT/Cdf.lean` was
**68 lines**, and **34** of them — half the proof — established a single pointwise identity. Almost
none of that was mathematics: it was notation reconciliation. Unfolding the local `let g1`,
unfolding the `studentTBetaKernel` abbreviation by hand through two intermediate `have`s, and
converting `ν ^ (1 / 2)` into `ν ^ ((0 + 1) / 2)` so the general chart lemma would match.

The block is just `abs_deriv_smul_studentTPDFReal` (`StudentT/WeightedIntegral.lean:119`) at
`q = 0`. Said that way it is four lines:

```lean
  have h12 : ∫ z in Ioi y, |2 * z / ν| • g1 (z ^ 2 / ν) =
      ∫ z in Ioi y, studentTPDFReal ν z := by
    refine setIntegral_congr_fun measurableSet_Ioi fun z hz => ?_
    -- The chart lemma at `q = 0`: its `z ^ (0 : ℝ)` factor disappears, and the beta kernel
    -- abbreviation unfolds to the explicit powers that `g1` is written with.
    have h := abs_deriv_smul_studentTPDFReal hν 0 (hy.trans_lt hz)
    rw [Real.rpow_zero, mul_one] at h
    dsimp only [g1]
    rw [hC, hs, ← h, studentTBetaKernel]
    norm_num
```

**Measured:**

| | before | after |
|---|---|---|
| `integral_Ioi_studentTPDFReal_eq_betaKernel_tail` | 68 lines | **44** |
| the `h12` block | 34 lines | **8** |
| diff | | **one file, +8 −32** |

No new declarations, no new imports, no mathematics added or changed — the same lemma is applied,
just recognised instead of rebuilt.

<details>
<summary>Why this PR no longer adds a helper lemma</summary>

The first version of this branch extracted the `q = 0` case as a named lemma
`abs_deriv_smul_studentTPDFReal_zero` in `WeightedIntegral.lean`. A pre-open dry run blocked it on
`reuse` — *"an unnecessary `q = 0` specialization of an existing general theorem"* — and that was
right, and gave the better result: the reduction came from **recognising** the block, not from
naming it. With the recognition inline, the specialisation earns nothing, so it is gone and
`WeightedIntegral.lean` is untouched.

</details>

Builds clean: `lake build TauCeti.Probability.Distributions.StudentT.Cdf` → exit 0.

Roadmap: StandardDistributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp