### PR TITLE
feat: the discriminant bilinear form of an integral overlattice

### DIFF
--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Dual.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Dual.lean
@@ -168,6 +168,27 @@ theorem discriminantSubgroup_dual (M : L.IntermediateCarrier) :
   exact (L.discriminantBilinearModule_pairing a b).symm.trans
     ((L.discriminantBilinearModule.mem_orthogonalComplement_iff _ a).mp h b hb)
 
+/-- The discriminant class in `A_L` of a vector of the dual carrier of an integral intermediate
+carrier. -/
+noncomputable def IsIntegral.dualClassHom {M : L.IntermediateCarrier} (hM : IsIntegral M) :
+    hM.toIntegralLattice.dualCarrier →ₗ[ℤ] L.DiscriminantGroup :=
+  L.carrierInDual.mkQ.comp (Submodule.inclusion hM.dualCarrier_le)
+
+@[simp]
+theorem IsIntegral.dualClassHom_apply {M : L.IntermediateCarrier} (hM : IsIntegral M)
+    (y : hM.toIntegralLattice.dualCarrier) :
+    hM.dualClassHom y = Submodule.Quotient.mk ⟨(y : V), hM.dualCarrier_le y.2⟩ := (rfl)
+
+/-- The discriminant class of a vector of `Mᵛ` is orthogonal to `H = M / L`, because the dual
+of an intermediate carrier corresponds to the orthogonal complement of its subgroup. -/
+theorem IsIntegral.dualClassHom_mem_orthogonalComplement {M : L.IntermediateCarrier}
+    (hM : IsIntegral M) (y : hM.toIntegralLattice.dualCarrier) :
+    hM.dualClassHom y ∈
+      L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup M) := by
+  rw [← discriminantSubgroup_dual, hM.dualClassHom_apply]
+  exact (L.mk_mem_discriminantSubgroup_iff (dual M) _).mpr
+    (by rw [← hM.toIntegralLattice_dualCarrier]; exact y.2)
+
 /-- **Double duality for intermediate carriers.** -/
 @[simp]
 theorem dual_dual (M : L.IntermediateCarrier) : dual (dual M) = M := by

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Bilinear.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Bilinear.lean
@@ -46,8 +46,7 @@ This is the elementary intermediate-lattice analogue of the even-overlattice com
 `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Quadratic`, and must not be
 read as a statement about the quadratic discriminant form, which an odd lattice does not carry.
 The two comparisons descend the same map, the discriminant class `IsIntegral.dualClassHom` of a
-dual vector of `M` defined below, along the bilinear and the quadratic orthogonal quotient of
-`A_L` respectively.
+dual vector of `M`, along the bilinear and the quadratic orthogonal quotient of `A_L` respectively.
 
 ## Main declarations
 
@@ -85,29 +84,6 @@ variable {L : IntegralLattice V} [L.IsNondegenerate] {M : L.IntermediateCarrier}
 
 namespace IntermediateCarrier
 
-/-- The discriminant class in `A_L` of a vector of `Mᵛ`.
-
-Exposed so that its value reduces to a quotient class, which is what the representative formulas
-downstream compare against. -/
-@[expose] noncomputable def IsIntegral.dualClassHom (hM : IsIntegral M) :
-    hM.toIntegralLattice.dualCarrier →ₗ[ℤ] L.DiscriminantGroup :=
-  L.carrierInDual.mkQ.comp (Submodule.inclusion hM.dualCarrier_le)
-
-@[simp]
-theorem IsIntegral.dualClassHom_apply (hM : IsIntegral M)
-    (y : hM.toIntegralLattice.dualCarrier) :
-    hM.dualClassHom y = Submodule.Quotient.mk ⟨(y : V), hM.dualCarrier_le y.2⟩ := (rfl)
-
-/-- The discriminant class of a vector of `Mᵛ` is orthogonal to `H = M / L`, because the dual
-of an intermediate carrier corresponds to the orthogonal complement of its subgroup. -/
-theorem IsIntegral.dualClassHom_mem_orthogonalComplement (hM : IsIntegral M)
-    (y : hM.toIntegralLattice.dualCarrier) :
-    hM.dualClassHom y ∈
-      L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup M) := by
-  rw [← discriminantSubgroup_dual, hM.dualClassHom_apply]
-  exact (L.mk_mem_discriminantSubgroup_iff (dual M) _).mpr
-    (by rw [← hM.toIntegralLattice_dualCarrier]; exact y.2)
-
 /-! ## The comparison isometry -/
 
 variable (hM : IsIntegral M)
@@ -133,9 +109,12 @@ private theorem dualCarrierToBilinearOrthogonalQuotient_apply
 private theorem dualCarrierToBilinearOrthogonalQuotient_eq_zero_iff
     (y : hM.toIntegralLattice.dualCarrier) :
     dualCarrierToBilinearOrthogonalQuotient hM y = 0 ↔ (y : V) ∈ M.1 :=
-  (L.discriminantBilinearModule.orthogonalQuotientMk_eq_zero_iff (L.discriminantSubgroup M)
-      ⟨hM.dualClassHom y, hM.dualClassHom_mem_orthogonalComplement y⟩).trans
-    (L.mk_mem_discriminantSubgroup_iff M _)
+  (L.discriminantBilinearModule.orthogonalQuotientMk_eq_zero_iff
+      (L.discriminantSubgroup M)
+      ⟨hM.dualClassHom y, hM.dualClassHom_mem_orthogonalComplement y⟩).trans (by
+    change hM.dualClassHom y ∈ L.discriminantSubgroup M ↔ (y : V) ∈ M.1
+    rw [hM.dualClassHom_apply]
+    exact L.mk_mem_discriminantSubgroup_iff M _)
 
 /-- The induced homomorphism `A_M → H⊥ / H` on the discriminant group of the overlattice. -/
 private noncomputable def discriminantBilinearOrthogonalQuotientHom :
@@ -182,10 +161,13 @@ private theorem discriminantBilinearOrthogonalQuotientHom_surjective :
   have hy : (x : V) ∈ hM.toIntegralLattice.dualCarrier := by
     rw [hM.toIntegralLattice_dualCarrier]
     exact hxdual
+  have hclass : hM.dualClassHom ⟨(x : V), hy⟩ = z.1 := by
+    rw [hM.dualClassHom_apply]
+    exact hx
   refine ⟨Submodule.Quotient.mk ⟨(x : V), hy⟩, ?_⟩
   rw [discriminantBilinearOrthogonalQuotientHom_mk,
     dualCarrierToBilinearOrthogonalQuotient_apply]
-  exact congrArg _ (Subtype.ext hx)
+  exact congrArg _ (Subtype.ext hclass)
 
 /-- The pairing in `H⊥ / H` of the classes of two dual vectors of `M` is the ambient form
 modulo `ℤ`. -/
@@ -194,13 +176,14 @@ private theorem pairing_dualCarrierToBilinearOrthogonalQuotient
     (L.discriminantBilinearModule.orthogonalQuotient (L.discriminantSubgroup M)).pairing
         (dualCarrierToBilinearOrthogonalQuotient hM y)
         (dualCarrierToBilinearOrthogonalQuotient hM z) =
-      ((L.form y z : ℚ) : AddCircle (1 : ℚ)) :=
-  (L.discriminantBilinearModule.orthogonalQuotient_pairing_mk (L.discriminantSubgroup M)
-      ⟨hM.dualClassHom y, hM.dualClassHom_mem_orthogonalComplement y⟩
-      ⟨hM.dualClassHom z, hM.dualClassHom_mem_orthogonalComplement z⟩).trans
-    ((L.discriminantBilinearModule_pairing _ _).trans
-      (L.discriminantPairing_mk ⟨(y : V), hM.dualCarrier_le y.2⟩
-        ⟨(z : V), hM.dualCarrier_le z.2⟩))
+      ((L.form y z : ℚ) : AddCircle (1 : ℚ)) := by
+  refine (L.discriminantBilinearModule.orthogonalQuotient_pairing_mk
+    (L.discriminantSubgroup M) _ _).trans ?_
+  refine (L.discriminantBilinearModule_pairing _ _).trans ?_
+  change L.discriminantPairing (hM.dualClassHom y) (hM.dualClassHom z) = _
+  rw [hM.dualClassHom_apply, hM.dualClassHom_apply]
+  exact L.discriminantPairing_mk ⟨(y : V), hM.dualCarrier_le y.2⟩
+    ⟨(z : V), hM.dualCarrier_le z.2⟩
 
 /-- The pairing in `A_M` of the classes of two dual vectors of `M` is the ambient form
 modulo `ℤ`. -/

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Bilinear.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Bilinear.lean
@@ -112,6 +112,7 @@ private theorem dualCarrierToBilinearOrthogonalQuotient_eq_zero_iff
   (L.discriminantBilinearModule.orthogonalQuotientMk_eq_zero_iff
       (L.discriminantSubgroup M)
       ⟨hM.dualClassHom y, hM.dualClassHom_mem_orthogonalComplement y⟩).trans (by
+    -- Remove the exposed discriminant-module carrier and orthogonal-complement subtype projections.
     change hM.dualClassHom y ∈ L.discriminantSubgroup M ↔ (y : V) ∈ M.1
     rw [hM.dualClassHom_apply]
     exact L.mk_mem_discriminantSubgroup_iff M _)
@@ -180,6 +181,7 @@ private theorem pairing_dualCarrierToBilinearOrthogonalQuotient
   refine (L.discriminantBilinearModule.orthogonalQuotient_pairing_mk
     (L.discriminantSubgroup M) _ _).trans ?_
   refine (L.discriminantBilinearModule_pairing _ _).trans ?_
+  -- Remove the exposed discriminant-module carrier and orthogonal-complement subtype projections.
   change L.discriminantPairing (hM.dualClassHom y) (hM.dualClassHom z) = _
   rw [hM.dualClassHom_apply, hM.dualClassHom_apply]
   exact L.discriminantPairing_mk ⟨(y : V), hM.dualCarrier_le y.2⟩

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Bilinear.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Bilinear.lean
@@ -1,0 +1,394 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Quotient
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual
+public import TauCeti.LinearAlgebra.IntegralLattice.Unimodular
+
+/-!
+# The discriminant bilinear form of an integral overlattice
+
+Let `L` be a nondegenerate integral lattice, not assumed even, and let `L ≤ M ≤ Lᵛ` be an integral
+intermediate carrier, that is an integral overlattice of `L` inside the common rational ambient
+space. The correspondence of `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Isotropic`
+attaches to `M` the subgroup `H = M / L` of the discriminant group `A_L = Lᵛ / L`, and integrality
+of `M` is exactly isotropy of `H` for the discriminant *bilinear* form. This file computes the
+discriminant bilinear module of `M` itself:
+
+```text
+A_M ≅ H⊥ / H,   H = M / L ≤ A_L.
+```
+
+The proof is the composite
+
+```text
+Mᵛ ↪ Lᵛ ↠ A_L,
+```
+
+which lands in `H⊥` because the dual of an intermediate carrier corresponds to the orthogonal
+complement of its subgroup, is surjective onto `H⊥` for the same reason, and whose fibre over `H`
+is exactly `M`. The composite therefore descends to an additive bijection `A_M ≃ H⊥ / H`, and it
+preserves the pairing because both sides are represented by `B(x, y)` modulo `ℤ` at the same pair
+of ambient vectors.
+
+Two consequences are recorded. The order of `H⊥ / H` is the discriminant of `M`, and `M` is
+unimodular exactly when `H⊥ / H` is trivial — the quotient-side reading of the Lagrangian
+criterion of `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual`. The isometry is also
+restated for the overlattice `L_H` glued along a bilinear-isotropic subgroup `H ≤ A_L`, and it is
+natural: an isometry `e : L ≅ L'` transports everything in sight and the resulting square
+commutes.
+
+This is the elementary intermediate-lattice analogue of the even-overlattice comparison of
+`TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Quadratic`, and must not be
+read as a statement about the quadratic discriminant form, which an odd lattice does not carry.
+The two comparisons descend the same map, the discriminant class `IsIntegral.dualClassHom` of a
+dual vector of `M` defined below, along the bilinear and the quadratic orthogonal quotient of
+`A_L` respectively.
+
+## Main declarations
+
+* `TauCeti.IntegralLattice.IntermediateCarrier.discriminantBilinearOrthogonalQuotientIsometry`:
+  the isometry `A_M ≅ H⊥ / H` of finite bilinear modules.
+* `TauCeti.IntegralLattice.IntermediateCarrier.discriminantBilinearOrthogonalQuotientIsometry_mk`:
+  its value on the class of a vector of `Mᵛ`.
+* `TauCeti.IntegralLattice.IntermediateCarrier.natCard_discriminantBilinearOrthogonalQuotient`
+  and
+  `subsingleton_discriminantBilinearOrthogonalQuotient_iff_isUnimodular`:
+  the order of `H⊥ / H` is the discriminant of `M`, and `M` is unimodular exactly when
+  `H⊥ / H` is trivial.
+* `TauCeti.IntegralLattice.discriminantBilinearOrthogonalQuotientIsometryOfSubgroup`: the same
+  isometry read as `A_(L_H) ≅ H⊥ / H` for a bilinear-isotropic subgroup `H` of `A_L`.
+* `TauCeti.IntegralLattice.Isometry.discriminantBilinearOrthogonalQuotientIsometry_naturality`:
+  the comparison isometry is natural under a lattice isometry.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.4,
+  Proposition 1.4.1, which is the even refinement of the comparison proved here.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+namespace IntegralLattice
+
+variable {V : Type u} [AddCommGroup V] [Module ℚ V]
+variable {L : IntegralLattice V} [L.IsNondegenerate] {M : L.IntermediateCarrier}
+
+namespace IntermediateCarrier
+
+/-- The discriminant class in `A_L` of a vector of `Mᵛ`.
+
+Exposed so that its value reduces to a quotient class, which is what the representative formulas
+downstream compare against. -/
+@[expose] noncomputable def IsIntegral.dualClassHom (hM : IsIntegral M) :
+    hM.toIntegralLattice.dualCarrier →ₗ[ℤ] L.DiscriminantGroup :=
+  L.carrierInDual.mkQ.comp (Submodule.inclusion hM.dualCarrier_le)
+
+@[simp]
+theorem IsIntegral.dualClassHom_apply (hM : IsIntegral M)
+    (y : hM.toIntegralLattice.dualCarrier) :
+    hM.dualClassHom y = Submodule.Quotient.mk ⟨(y : V), hM.dualCarrier_le y.2⟩ := (rfl)
+
+/-- The discriminant class of a vector of `Mᵛ` is orthogonal to `H = M / L`, because the dual
+of an intermediate carrier corresponds to the orthogonal complement of its subgroup. -/
+theorem IsIntegral.dualClassHom_mem_orthogonalComplement (hM : IsIntegral M)
+    (y : hM.toIntegralLattice.dualCarrier) :
+    hM.dualClassHom y ∈
+      L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup M) := by
+  rw [← discriminantSubgroup_dual, hM.dualClassHom_apply]
+  exact (L.mk_mem_discriminantSubgroup_iff (dual M) _).mpr
+    (by rw [← hM.toIntegralLattice_dualCarrier]; exact y.2)
+
+/-! ## The comparison isometry -/
+
+variable (hM : IsIntegral M)
+
+/-- The homomorphism `Mᵛ → H⊥ / H` sending a dual vector of `M` to the class of its discriminant
+class in `A_L`. -/
+private noncomputable def dualCarrierToBilinearOrthogonalQuotient :
+    hM.toIntegralLattice.dualCarrier →+
+      L.discriminantBilinearModule.orthogonalQuotient (L.discriminantSubgroup M) :=
+  (L.discriminantBilinearModule.orthogonalQuotientMk _).comp
+    (AddMonoidHom.codRestrict hM.dualClassHom.toAddMonoidHom
+      (L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup M))
+      hM.dualClassHom_mem_orthogonalComplement)
+
+/-- The homomorphism `Mᵛ → H⊥ / H` unfolded on a vector of `Mᵛ`. -/
+private theorem dualCarrierToBilinearOrthogonalQuotient_apply
+    (y : hM.toIntegralLattice.dualCarrier) :
+    dualCarrierToBilinearOrthogonalQuotient hM y =
+      L.discriminantBilinearModule.orthogonalQuotientMk _
+        ⟨hM.dualClassHom y, hM.dualClassHom_mem_orthogonalComplement y⟩ := (rfl)
+
+/-- A dual vector of `M` has trivial class in `H⊥ / H` exactly when it already lies in `M`. -/
+private theorem dualCarrierToBilinearOrthogonalQuotient_eq_zero_iff
+    (y : hM.toIntegralLattice.dualCarrier) :
+    dualCarrierToBilinearOrthogonalQuotient hM y = 0 ↔ (y : V) ∈ M.1 :=
+  (L.discriminantBilinearModule.orthogonalQuotientMk_eq_zero_iff (L.discriminantSubgroup M)
+      ⟨hM.dualClassHom y, hM.dualClassHom_mem_orthogonalComplement y⟩).trans
+    (L.mk_mem_discriminantSubgroup_iff M _)
+
+/-- The induced homomorphism `A_M → H⊥ / H` on the discriminant group of the overlattice. -/
+private noncomputable def discriminantBilinearOrthogonalQuotientHom :
+    hM.toIntegralLattice.DiscriminantGroup →ₗ[ℤ]
+      L.discriminantBilinearModule.orthogonalQuotient (L.discriminantSubgroup M) :=
+  Submodule.liftQ _ (dualCarrierToBilinearOrthogonalQuotient hM).toIntLinearMap (by
+    intro y hy
+    rw [LinearMap.mem_ker]
+    refine (dualCarrierToBilinearOrthogonalQuotient_eq_zero_iff hM y).mpr ?_
+    rw [← hM.toIntegralLattice_carrier]
+    exact (hM.toIntegralLattice.mem_carrierInDual_iff y).mp hy)
+
+/-- The induced homomorphism on `A_M` is computed by its representative homomorphism. -/
+private theorem discriminantBilinearOrthogonalQuotientHom_mk
+    (y : hM.toIntegralLattice.dualCarrier) :
+    discriminantBilinearOrthogonalQuotientHom hM (Submodule.Quotient.mk y) =
+      dualCarrierToBilinearOrthogonalQuotient hM y := (rfl)
+
+/-- A vector of `Mᵛ` whose discriminant class lies in `H` already lies in `M`, so the induced
+homomorphism is injective. -/
+private theorem discriminantBilinearOrthogonalQuotientHom_injective :
+    Function.Injective (discriminantBilinearOrthogonalQuotientHom hM) := by
+  refine (injective_iff_map_eq_zero _).mpr fun a ha ↦ ?_
+  induction a using Submodule.Quotient.induction_on with
+  | _ y =>
+    rw [discriminantBilinearOrthogonalQuotientHom_mk,
+      dualCarrierToBilinearOrthogonalQuotient_eq_zero_iff] at ha
+    rw [Submodule.Quotient.mk_eq_zero, hM.toIntegralLattice.mem_carrierInDual_iff,
+      hM.toIntegralLattice_carrier]
+    exact ha
+
+/-- Every class of `H⊥` is the discriminant class of a vector of `Mᵛ`, so the induced
+homomorphism is surjective. -/
+private theorem discriminantBilinearOrthogonalQuotientHom_surjective :
+    Function.Surjective (discriminantBilinearOrthogonalQuotientHom hM) := by
+  intro q
+  obtain ⟨z, rfl⟩ := L.discriminantBilinearModule.orthogonalQuotientMk_surjective
+    (L.discriminantSubgroup M) q
+  obtain ⟨x, hx⟩ := Submodule.Quotient.mk_surjective L.carrierInDual z.1
+  have hxdual : (x : V) ∈ (dual M).1 := by
+    refine (L.mk_mem_discriminantSubgroup_iff (dual M) x).mp ?_
+    rw [discriminantSubgroup_dual, hx]
+    exact z.2
+  have hy : (x : V) ∈ hM.toIntegralLattice.dualCarrier := by
+    rw [hM.toIntegralLattice_dualCarrier]
+    exact hxdual
+  refine ⟨Submodule.Quotient.mk ⟨(x : V), hy⟩, ?_⟩
+  rw [discriminantBilinearOrthogonalQuotientHom_mk,
+    dualCarrierToBilinearOrthogonalQuotient_apply]
+  exact congrArg _ (Subtype.ext hx)
+
+/-- The pairing in `H⊥ / H` of the classes of two dual vectors of `M` is the ambient form
+modulo `ℤ`. -/
+private theorem pairing_dualCarrierToBilinearOrthogonalQuotient
+    (y z : hM.toIntegralLattice.dualCarrier) :
+    (L.discriminantBilinearModule.orthogonalQuotient (L.discriminantSubgroup M)).pairing
+        (dualCarrierToBilinearOrthogonalQuotient hM y)
+        (dualCarrierToBilinearOrthogonalQuotient hM z) =
+      ((L.form y z : ℚ) : AddCircle (1 : ℚ)) :=
+  (L.discriminantBilinearModule.orthogonalQuotient_pairing_mk (L.discriminantSubgroup M)
+      ⟨hM.dualClassHom y, hM.dualClassHom_mem_orthogonalComplement y⟩
+      ⟨hM.dualClassHom z, hM.dualClassHom_mem_orthogonalComplement z⟩).trans
+    ((L.discriminantBilinearModule_pairing _ _).trans
+      (L.discriminantPairing_mk ⟨(y : V), hM.dualCarrier_le y.2⟩
+        ⟨(z : V), hM.dualCarrier_le z.2⟩))
+
+/-- The pairing in `A_M` of the classes of two dual vectors of `M` is the ambient form
+modulo `ℤ`. -/
+theorem pairing_discriminantBilinearModule_toIntegralLattice_mk
+    (y z : hM.toIntegralLattice.dualCarrier) :
+    hM.toIntegralLattice.discriminantBilinearModule.pairing (Submodule.Quotient.mk y)
+        (Submodule.Quotient.mk z) = ((L.form y z : ℚ) : AddCircle (1 : ℚ)) := by
+  rw [discriminantBilinearModule_pairing, discriminantPairing_mk, hM.toIntegralLattice_form]
+
+/-- **The discriminant bilinear form of an integral overlattice.** For an integral overlattice
+`L ≤ M ≤ Lᵛ` with subgroup `H = M / L` of the discriminant group of `L`, the discriminant
+bilinear module of `M` is `H⊥ / H`.
+
+Neither `L` nor `M` is assumed even; this is the elementary bilinear analogue of Nikulin's
+Proposition 1.4.1. -/
+noncomputable def discriminantBilinearOrthogonalQuotientIsometry :
+    FiniteBilinearModule.Isometry hM.toIntegralLattice.discriminantBilinearModule
+      (L.discriminantBilinearModule.orthogonalQuotient (L.discriminantSubgroup M)) where
+  toAddEquiv :=
+    AddEquiv.ofBijective (discriminantBilinearOrthogonalQuotientHom hM).toAddMonoidHom
+      ⟨discriminantBilinearOrthogonalQuotientHom_injective hM,
+        discriminantBilinearOrthogonalQuotientHom_surjective hM⟩
+  map_pairing' a b := by
+    induction a using Submodule.Quotient.induction_on with
+    | _ y =>
+      induction b using Submodule.Quotient.induction_on with
+      | _ z =>
+        exact (pairing_dualCarrierToBilinearOrthogonalQuotient hM y z).trans
+          (pairing_discriminantBilinearModule_toIntegralLattice_mk hM y z).symm
+
+/-- **The representative formula.** The comparison isometry sends the class in `A_M` of a dual
+vector of `M` to the class in `H⊥ / H` of its discriminant class in `A_L`. -/
+@[simp]
+theorem discriminantBilinearOrthogonalQuotientIsometry_mk
+    (y : hM.toIntegralLattice.dualCarrier) :
+    discriminantBilinearOrthogonalQuotientIsometry hM (Submodule.Quotient.mk y) =
+      L.discriminantBilinearModule.orthogonalQuotientMk _
+        ⟨hM.dualClassHom y, hM.dualClassHom_mem_orthogonalComplement y⟩ := (rfl)
+
+/-- The pairing in `H⊥ / H` of the images of the classes of two dual vectors of `M` is the
+ambient form modulo `ℤ`. -/
+theorem pairing_discriminantBilinearOrthogonalQuotientIsometry_mk
+    (y z : hM.toIntegralLattice.dualCarrier) :
+    (L.discriminantBilinearModule.orthogonalQuotient (L.discriminantSubgroup M)).pairing
+        (discriminantBilinearOrthogonalQuotientIsometry hM (Submodule.Quotient.mk y))
+        (discriminantBilinearOrthogonalQuotientIsometry hM (Submodule.Quotient.mk z)) =
+      ((L.form y z : ℚ) : AddCircle (1 : ℚ)) :=
+  pairing_dualCarrierToBilinearOrthogonalQuotient hM y z
+
+/-! ## Numerical consequences -/
+
+/-- **The order of `H⊥ / H` is the discriminant of the overlattice.** -/
+theorem natCard_discriminantBilinearOrthogonalQuotient :
+    Nat.card (L.discriminantBilinearModule.orthogonalQuotient (L.discriminantSubgroup M)) =
+      hM.toIntegralLattice.discriminant :=
+  (Nat.card_congr
+      (discriminantBilinearOrthogonalQuotientIsometry hM).toAddEquiv.toEquiv).symm.trans
+    hM.toIntegralLattice.natCard_discriminantGroup
+
+/-- **An integral overlattice is unimodular exactly when `H⊥ / H` is trivial.** -/
+theorem subsingleton_discriminantBilinearOrthogonalQuotient_iff_isUnimodular :
+    Subsingleton
+        (L.discriminantBilinearModule.orthogonalQuotient (L.discriminantSubgroup M)) ↔
+      hM.toIntegralLattice.IsUnimodular := by
+  rw [hM.toIntegralLattice.isUnimodular_iff_subsingleton_discriminantGroup]
+  exact Equiv.subsingleton_congr
+    (discriminantBilinearOrthogonalQuotientIsometry hM).toAddEquiv.toEquiv.symm
+
+end IntermediateCarrier
+
+open IntermediateCarrier
+
+/-! ## The comparison isometry read on subgroups -/
+
+variable (L)
+
+/-- **The discriminant bilinear form of a glued integral overlattice:** `A_(L_H) ≅ H⊥ / H` for a
+bilinear-isotropic subgroup `H` of the discriminant group of a nondegenerate integral lattice. -/
+noncomputable def discriminantBilinearOrthogonalQuotientIsometryOfSubgroup
+    {H : AddSubgroup L.DiscriminantGroup}
+    (hH : L.discriminantBilinearModule.IsIsotropic H) :
+    let hM := (L.isIntegral_intermediateCarrierOfDiscriminantSubgroup_iff H).mpr hH
+    FiniteBilinearModule.Isometry hM.toIntegralLattice.discriminantBilinearModule
+      (L.discriminantBilinearModule.orthogonalQuotient H) := by
+  let hM := (L.isIntegral_intermediateCarrierOfDiscriminantSubgroup_iff H).mpr hH
+  exact (discriminantBilinearOrthogonalQuotientIsometry hM).trans
+    (L.discriminantBilinearModule.orthogonalQuotientCongr
+      (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H))
+
+/-- The subgroup-level comparison isometry sends a representative to its discriminant class in
+`H⊥ / H`. -/
+@[simp]
+theorem discriminantBilinearOrthogonalQuotientIsometryOfSubgroup_mk
+    {H : AddSubgroup L.DiscriminantGroup}
+    (hH : L.discriminantBilinearModule.IsIsotropic H) :
+    let hM := (L.isIntegral_intermediateCarrierOfDiscriminantSubgroup_iff H).mpr hH
+    ∀ y : hM.toIntegralLattice.dualCarrier,
+      L.discriminantBilinearOrthogonalQuotientIsometryOfSubgroup hH (Submodule.Quotient.mk y) =
+        L.discriminantBilinearModule.orthogonalQuotientMk H
+          ⟨hM.dualClassHom y,
+            by
+              have hmem := hM.dualClassHom_mem_orthogonalComplement y
+              rw [L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup] at hmem
+              exact hmem⟩ := by
+  dsimp only
+  intro y
+  let hM := (L.isIntegral_intermediateCarrierOfDiscriminantSubgroup_iff H).mpr hH
+  rw [discriminantBilinearOrthogonalQuotientIsometryOfSubgroup]
+  refine (FiniteBilinearModule.Isometry.trans_apply _ _ _).trans ?_
+  rw [discriminantBilinearOrthogonalQuotientIsometry_mk]
+  exact L.discriminantBilinearModule.orthogonalQuotientCongr_orthogonalQuotientMk
+    (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)
+    ⟨hM.dualClassHom y, hM.dualClassHom_mem_orthogonalComplement y⟩
+
+/-- **The order of `H⊥ / H` is the discriminant of the overlattice glued along `H`.** -/
+theorem natCard_discriminantBilinearOrthogonalQuotient_of_subgroup
+    {H : AddSubgroup L.DiscriminantGroup}
+    (hH : L.discriminantBilinearModule.IsIsotropic H) :
+    let hM := (L.isIntegral_intermediateCarrierOfDiscriminantSubgroup_iff H).mpr hH
+    Nat.card (L.discriminantBilinearModule.orthogonalQuotient H) =
+      hM.toIntegralLattice.discriminant := by
+  let hM := (L.isIntegral_intermediateCarrierOfDiscriminantSubgroup_iff H).mpr hH
+  exact (Nat.card_congr (L.discriminantBilinearOrthogonalQuotientIsometryOfSubgroup
+      hH).toAddEquiv.toEquiv).symm.trans
+    hM.toIntegralLattice.natCard_discriminantGroup
+
+variable {L}
+
+/-! ## Naturality under a lattice isometry -/
+
+section Naturality
+
+variable {W : Type*} [AddCommGroup W] [Module ℚ W] {L' : IntegralLattice W} [L'.IsNondegenerate]
+
+namespace Isometry
+
+/-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`, on a discriminant class.** The
+equation identifies comparison after transport on `A_M` with transport after comparison. -/
+theorem discriminantBilinearOrthogonalQuotientIsometry_naturality_apply (e : Isometry L L')
+    {P : L.IntermediateCarrier} (hP : IntermediateCarrier.IsIntegral P)
+    (q : hP.toIntegralLattice.DiscriminantGroup) :
+    discriminantBilinearOrthogonalQuotientIsometry
+        ((e.isIntegral_intermediateCarrierEquiv_iff P).mpr hP)
+        ((e.toIntegralLatticeIsometry hP).discriminantBilinearIsometry q) =
+      e.discriminantBilinearIsometry.orthogonalQuotientEquiv
+        (by
+          rw [discriminantBilinearIsometry_toAddEquiv]
+          exact (e.discriminantSubgroup_intermediateCarrierEquiv P).symm)
+        (discriminantBilinearOrthogonalQuotientIsometry hP q) := by
+  symm
+  induction q using Submodule.Quotient.induction_on with
+  | _ y =>
+    rw [discriminantBilinearOrthogonalQuotientIsometry_mk, discriminantBilinearIsometry_mk,
+      discriminantBilinearOrthogonalQuotientIsometry_mk]
+    refine Eq.trans (FiniteBilinearModule.Isometry.orthogonalQuotientEquiv_orthogonalQuotientMk
+      _ _ _) ?_
+    have hclass : e.discriminantBilinearIsometry (hP.dualClassHom y) =
+          ((e.isIntegral_intermediateCarrierEquiv_iff P).mpr hP).dualClassHom
+            ((e.toIntegralLatticeIsometry hP).dualCarrierEquiv y) := by
+      rw [discriminantBilinearIsometry_apply,
+        IntermediateCarrier.IsIntegral.dualClassHom_apply, discriminantGroupEquiv_mk,
+        IntermediateCarrier.IsIntegral.dualClassHom_apply]
+      exact congrArg _ (Subtype.ext (by simp))
+    exact congrArg _ (Subtype.ext hclass)
+
+/-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`.** An isometry `e : L ≅ L'` of
+nondegenerate integral lattices transports an integral intermediate carrier `P` of `L` to one of
+`L'`, and the square built from the two comparison isometries, the induced isometry of the
+discriminant bilinear modules of the two overlattices, and the transported orthogonal quotient
+commutes. -/
+theorem discriminantBilinearOrthogonalQuotientIsometry_naturality (e : Isometry L L')
+    {P : L.IntermediateCarrier} (hP : IntermediateCarrier.IsIntegral P) :
+    ((e.toIntegralLatticeIsometry hP).discriminantBilinearIsometry).trans
+        (discriminantBilinearOrthogonalQuotientIsometry
+          ((e.isIntegral_intermediateCarrierEquiv_iff P).mpr hP)) =
+      (discriminantBilinearOrthogonalQuotientIsometry hP).trans
+        (e.discriminantBilinearIsometry.orthogonalQuotientEquiv
+          (by
+            rw [discriminantBilinearIsometry_toAddEquiv]
+            exact (e.discriminantSubgroup_intermediateCarrierEquiv P).symm)) :=
+  FiniteBilinearModule.Isometry.ext fun q ↦ by
+    rw [FiniteBilinearModule.Isometry.trans_apply, FiniteBilinearModule.Isometry.trans_apply]
+    exact e.discriminantBilinearOrthogonalQuotientIsometry_naturality_apply hP q
+
+end Isometry
+
+end Naturality
+
+end IntegralLattice
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Quadratic.lean
@@ -6,7 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
-public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Bilinear
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual
+public import TauCeti.LinearAlgebra.IntegralLattice.Unimodular
 
 /-!
 # The discriminant form of an even overlattice
@@ -48,7 +49,8 @@ square built from the two comparison isometries commutes.
 
 The bilinear analogue, for a merely integral overlattice of a lattice that need not be even, is
 `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Bilinear`; the discriminant
-class of a dual vector of `M`, which both comparisons are built from, is defined there.
+class of a dual vector of `M`, which both comparisons are built from, is defined in
+`TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual`.
 
 ## Main declarations
 
@@ -118,8 +120,10 @@ private theorem dualCarrierToOrthogonalQuotient_eq_zero_iff
   ((L.discriminantQuadraticModule hL).orthogonalQuotientMk_eq_zero_iff
       (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
       ⟨hM.isIntegral.dualClassHom y,
-        hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩).trans
-    (L.mk_mem_discriminantSubgroup_iff M _)
+        hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩).trans (by
+    change hM.isIntegral.dualClassHom y ∈ L.discriminantSubgroup M ↔ (y : V) ∈ M.1
+    rw [hM.isIntegral.dualClassHom_apply]
+    exact L.mk_mem_discriminantSubgroup_iff M _)
 
 /-- The induced homomorphism `A_M → H⊥ / H` on the discriminant group of the overlattice. -/
 private noncomputable def discriminantOrthogonalQuotientHom :
@@ -167,9 +171,12 @@ private theorem discriminantOrthogonalQuotientHom_surjective :
   have hy : (x : V) ∈ hM.isIntegral.toIntegralLattice.dualCarrier := by
     rw [hM.isIntegral.toIntegralLattice_dualCarrier]
     exact hxdual
+  have hclass : hM.isIntegral.dualClassHom ⟨(x : V), hy⟩ = z.1 := by
+    rw [hM.isIntegral.dualClassHom_apply]
+    exact hx
   refine ⟨Submodule.Quotient.mk ⟨(x : V), hy⟩, ?_⟩
   rw [discriminantOrthogonalQuotientHom_mk, dualCarrierToOrthogonalQuotient_apply]
-  exact congrArg _ (Subtype.ext hx)
+  exact congrArg _ (Subtype.ext hclass)
 
 /-- The quadratic value in `H⊥ / H` of the class of a dual vector of `M` is the ambient
 half-norm. -/
@@ -178,13 +185,16 @@ private theorem quadratic_dualCarrierToOrthogonalQuotient
     ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
         ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)).quadratic
         (dualCarrierToOrthogonalQuotient hL hM y) =
-      ((L.form y y / 2 : ℚ) : AddCircle (1 : ℚ)) :=
-  ((L.discriminantQuadraticModule hL).orthogonalQuotient_quadratic_mk
-      (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
-      ⟨hM.isIntegral.dualClassHom y,
-        hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩).trans
-    ((L.discriminantQuadraticModule_quadratic hL _).trans
-      (L.discriminantQuadraticMap_mk hL ⟨(y : V), hM.isIntegral.dualCarrier_le y.2⟩))
+      ((L.form y y / 2 : ℚ) : AddCircle (1 : ℚ)) := by
+  rw [dualCarrierToOrthogonalQuotient_apply]
+  refine ((L.discriminantQuadraticModule hL).orthogonalQuotient_quadratic_mk
+    (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
+    _).trans ?_
+  change (L.discriminantQuadraticModule hL).quadratic (hM.isIntegral.dualClassHom y) = _
+  rw [L.discriminantQuadraticModule_quadratic]
+  rw [hM.isIntegral.dualClassHom_apply]
+  exact L.discriminantQuadraticMap_mk hL
+    ⟨(y : V), hM.isIntegral.dualCarrier_le y.2⟩
 
 /-- The quadratic value in `A_M` of the class of a dual vector of `M` is the ambient
 half-norm. -/
@@ -246,16 +256,16 @@ theorem pairing_discriminantOrthogonalQuotientIsometry_mk
         ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)).toFiniteBilinearModule.pairing
         (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y))
         (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk z)) =
-      ((L.form y z : ℚ) : AddCircle (1 : ℚ)) :=
-  ((L.discriminantQuadraticModule hL).orthogonalQuotient_pairing_mk
-      (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
-      ⟨hM.isIntegral.dualClassHom y,
-        hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩
-      ⟨hM.isIntegral.dualClassHom z,
-        hM.isIntegral.dualClassHom_mem_orthogonalComplement z⟩).trans
-    ((L.discriminantBilinearModule_pairing _ _).trans
-      (L.discriminantPairing_mk ⟨(y : V), hM.isIntegral.dualCarrier_le y.2⟩
-        ⟨(z : V), hM.isIntegral.dualCarrier_le z.2⟩))
+      ((L.form y z : ℚ) : AddCircle (1 : ℚ)) := by
+  refine ((L.discriminantQuadraticModule hL).orthogonalQuotient_pairing_mk
+    (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
+    _ _).trans ?_
+  refine (L.discriminantBilinearModule_pairing _ _).trans ?_
+  change L.discriminantPairing (hM.isIntegral.dualClassHom y)
+    (hM.isIntegral.dualClassHom z) = _
+  rw [hM.isIntegral.dualClassHom_apply, hM.isIntegral.dualClassHom_apply]
+  exact L.discriminantPairing_mk ⟨(y : V), hM.isIntegral.dualCarrier_le y.2⟩
+    ⟨(z : V), hM.isIntegral.dualCarrier_le z.2⟩
 
 /-! ## Numerical consequences -/
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Quadratic.lean
@@ -121,6 +121,7 @@ private theorem dualCarrierToOrthogonalQuotient_eq_zero_iff
       (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
       ⟨hM.isIntegral.dualClassHom y,
         hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩).trans (by
+    -- Remove the exposed discriminant-module carrier and orthogonal-complement subtype projections.
     change hM.isIntegral.dualClassHom y ∈ L.discriminantSubgroup M ↔ (y : V) ∈ M.1
     rw [hM.isIntegral.dualClassHom_apply]
     exact L.mk_mem_discriminantSubgroup_iff M _)
@@ -190,6 +191,7 @@ private theorem quadratic_dualCarrierToOrthogonalQuotient
   refine ((L.discriminantQuadraticModule hL).orthogonalQuotient_quadratic_mk
     (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
     _).trans ?_
+  -- Remove the orthogonal-complement subtype projection from the quotient representative.
   change (L.discriminantQuadraticModule hL).quadratic (hM.isIntegral.dualClassHom y) = _
   rw [L.discriminantQuadraticModule_quadratic]
   rw [hM.isIntegral.dualClassHom_apply]
@@ -261,6 +263,7 @@ theorem pairing_discriminantOrthogonalQuotientIsometry_mk
     (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
     _ _).trans ?_
   refine (L.discriminantBilinearModule_pairing _ _).trans ?_
+  -- Remove the exposed discriminant-module carrier and orthogonal-complement subtype projections.
   change L.discriminantPairing (hM.isIntegral.dualClassHom y)
     (hM.isIntegral.dualClassHom z) = _
   rw [hM.isIntegral.dualClassHom_apply, hM.isIntegral.dualClassHom_apply]

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/Quadratic.lean
@@ -6,8 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
-public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual
-public import TauCeti.LinearAlgebra.IntegralLattice.Unimodular
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Bilinear
 
 /-!
 # The discriminant form of an even overlattice
@@ -47,9 +46,9 @@ also restricts to an isometry of the overlattices themselves; the discriminant s
 orthogonal complements correspond under the induced isometry of discriminant modules, and the
 square built from the two comparison isometries commutes.
 
-One thing is deliberately left out: the bilinear analogue for a merely integral overlattice of an
-odd lattice needs the orthogonal quotient of a finite *bilinear* module, which the library does
-not yet have.
+The bilinear analogue, for a merely integral overlattice of a lattice that need not be even, is
+`TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Bilinear`; the discriminant
+class of a dual vector of `M`, which both comparisons are built from, is defined there.
 
 ## Main declarations
 
@@ -86,26 +85,6 @@ variable {V : Type u} [AddCommGroup V] [Module ℚ V]
 variable {L : IntegralLattice V} [L.IsNondegenerate] {M : L.IntermediateCarrier}
 
 namespace IntermediateCarrier
-
-/-- The discriminant class in `A_L` of a vector of `Mᵛ`. -/
-noncomputable def IsIntegral.dualClassHom (hM : IsIntegral M) :
-    hM.toIntegralLattice.dualCarrier →ₗ[ℤ] L.DiscriminantGroup :=
-  L.carrierInDual.mkQ.comp (Submodule.inclusion hM.dualCarrier_le)
-
-@[simp]
-theorem IsIntegral.dualClassHom_apply (hM : IsIntegral M)
-    (y : hM.toIntegralLattice.dualCarrier) :
-    hM.dualClassHom y = Submodule.Quotient.mk ⟨(y : V), hM.dualCarrier_le y.2⟩ := (rfl)
-
-/-- The discriminant class of a vector of `Mᵛ` is orthogonal to `H = M / L`, because the dual
-of an intermediate carrier corresponds to the orthogonal complement of its subgroup. -/
-theorem IsIntegral.dualClassHom_mem_orthogonalComplement (hM : IsIntegral M)
-    (y : hM.toIntegralLattice.dualCarrier) :
-    hM.dualClassHom y ∈
-      L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup M) := by
-  rw [← discriminantSubgroup_dual, hM.dualClassHom_apply]
-  exact (L.mk_mem_discriminantSubgroup_iff (dual M) _).mpr
-    (by rw [← hM.toIntegralLattice_dualCarrier]; exact y.2)
 
 /-! ## The comparison isometry -/
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Isometry.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Isometry.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Quadratic
 public import TauCeti.LinearAlgebra.IntegralLattice.RootLattice.D8Plus.Basic
 public import TauCeti.LinearAlgebra.IntegralLattice.RootLattice.TypeE
 public import TauCeti.LinearAlgebra.RootSystem.E8Coordinates


### PR DESCRIPTION
This PR constructs the discriminant bilinear form of an integral overlattice: for a nondegenerate integral lattice `L`, not assumed even, and an integral intermediate carrier `L ≤ M ≤ Lᵛ` with subgroup `H = M / L ≤ A_L`, it builds the isometry of finite bilinear modules `A_M ≅ H⊥ / H`. The comparison is the composite `Mᵛ ↪ Lᵛ ↠ A_L`, which lands in `H⊥` because the dual of an intermediate carrier is the orthogonal complement of its subgroup, is surjective onto `H⊥` for the same reason, and has fibre `M` over `H`; it preserves the pairing because both sides are represented by `B(x, y)` modulo `ℤ` at the same pair of ambient vectors. Alongside the isometry the file proves the representative formula, the pairing formula on representatives, the order computation `#(H⊥ / H) = disc(M)`, the criterion that `M` is unimodular exactly when `H⊥ / H` is trivial, the subgroup-level restatement `A_(L_H) ≅ H⊥ / H` for a bilinear-isotropic `H ≤ A_L`, and naturality of the square under a lattice isometry `e : L ≅ L'`.

The roadmap target is `TauCetiRoadmap/IntegralLattices/README.md`, Layer 4, fourth bullet, verbatim: "For isotropic `H`, define the induced form on `H^⊥/H` and construct the natural isometry `A_{L_H} ≅ H^⊥/H`, **bilinear in the integral case** and quadratic in the even case. Include the representative formula, nondegeneracy, order computation, and compatibility with the index and determinant formulae." The quadratic (even) case is already on `main`; the bilinear case was the last unbuilt piece of that bullet, and the module docstring of the even-case file named exactly this gap. Its module-level prerequisite, `FiniteBilinearModule.orthogonalQuotient`, landed in #5440. With this PR Layer 4 is complete: its five bullets — the intermediate-carrier/subgroup correspondence, the integral and even refinements, the index and discriminant laws, this comparison in both flavours, and naturality — are all on `main`. What remains on the roadmap after it is not in this layer: the Layer 2 invariant-factor divisibility chain, which is recorded only for a positive Gram determinant.

Nondegeneracy of `H⊥ / H` is not restated here: `FiniteBilinearModule.IsNondegenerate.isNondegenerate_orthogonalQuotient` already gives it from nondegeneracy of `A_L`, and the isometry transports it in either direction through `FiniteBilinearModule.Isometry.isNondegenerate_iff`. No isotropy hypothesis is passed to `orthogonalQuotient`, which is defined without one; integrality of `M` enters where it belongs, as the hypothesis that makes `A_M` exist and that identifies `H ∩ H⊥` with `H`.

The one declaration the even case and the integral case genuinely share, the discriminant class map `IsIntegral.dualClassHom` of a dual vector of `M`, moves into the new file, is marked `@[expose]` so its value still reduces to a quotient class in the even-case proofs, and is now consumed by both. The two comparisons are otherwise built separately, and deliberately so: the underlying groups of `FiniteQuadraticModule.orthogonalQuotient` and `FiniteBilinearModule.orthogonalQuotient` agree only definitionally, and that identification (`FiniteQuadraticModule.orthogonalQuotient_toFiniteBilinearModule`, a `rfl`) is unusable outside its own module because `subgroupInOrthogonalComplement` is not exposed. Routing the even case through the integral one would mean exposing that definition and two further ones across three files in order to save about sixty lines of proof, which is the worse trade.

Because the tree would otherwise hold both `Overlattice/OrthogonalQuotient.lean` and a second `OrthogonalQuotient*` sibling, the even-case file moves into a directory alongside the new one. The move changes only the module header and imports, renames no declaration, and its one importer, `IntegralLattice/RootLattice/D8Plus/Isometry.lean`, is updated here. The module table is

| old module | new module |
| --- | --- |
| `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient` | `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Quadratic` |

No Mathlib code is vendored. The construction reuses `FiniteBilinearModule.orthogonalQuotient` and its representative, kernel, surjectivity, congruence and transport API, the intermediate-carrier duality theorem `discriminantSubgroup_dual`, and Mathlib's `AddEquiv.ofBijective`, `Submodule.liftQ` and `Nat.card_congr`.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"discriminant-bilinear-orthogonal-quotient-isometry"}-->

🤖 Prepared with Claude Code
