### PR TITLE
feat: a regular level set of a Fredholm map is a manifold

### DIFF
--- a/TauCeti/Analysis/Calculus/ContinuousLinearMapInverse.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousLinearMapInverse.lean
@@ -9,17 +9,24 @@ public import Mathlib.Analysis.Calculus.ContDiff.Operations
 public import Mathlib.Analysis.Calculus.Deriv.Mul
 
 /-!
-# Differentiating inverse continuous linear maps
+# Inverting and differentiating continuous linear maps
 
-This file packages the derivative of a differentiable inverse family of continuous linear maps at
-an invertible base point, including its action on a varying vector. The result is the analytic input
-for differentiating a vector-field pullback along a parametric family.
+This file collects two kinds of facts about inverting continuous linear maps. The first is a
+perturbation criterion: a map differing from a continuous linear equivalence `L` by less than
+`‖L⁻¹‖⁻¹` in operator norm is again invertible, by a Neumann series. The second packages the
+derivative of a differentiable inverse family of continuous linear maps at an invertible base
+point, including its action on a varying vector; that is the analytic input for differentiating a
+vector-field pullback along a parametric family.
 
 This supplies a prerequisite for Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
 
 ## Main results
 
+* `ContinuousLinearMap.isInvertible_of_norm_sub_lt` and
+  `ContinuousLinearMap.isInvertible_of_norm_sub_le_half`: a continuous linear map closer to an
+  invertible one than the reciprocal norm of its inverse — or than half of it — is itself
+  invertible.
 * `HasDerivAt.clm_inverse`: differentiates `(A t)⁻¹`.
 * `HasDerivAt.clm_inverse_apply`: differentiates `(A t)⁻¹ (w t)`.
 * `DifferentiableAt.clm_inverse_of_completeSpace`: the inverse of a differentiable family between
@@ -43,7 +50,58 @@ open scoped Topology
 
 variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
   [NormedAddCommGroup E] [NormedSpace 𝕜 E] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-  {t₀ : 𝕜} {A : 𝕜 → E →L[𝕜] F} {A' : E →L[𝕜] F} {w : 𝕜 → F} {w' : F}
+
+section Perturbation
+
+/-- A continuous linear map that differs from a continuous linear equivalence `L` by less than
+`‖L⁻¹‖⁻¹` in operator norm is itself invertible: `L⁻¹A` is close enough to `1` to be a unit of the
+Banach algebra of endomorphisms of `E`. -/
+theorem ContinuousLinearMap.isInvertible_of_norm_sub_lt [CompleteSpace E]
+    (L : E ≃L[𝕜] F) {A : E →L[𝕜] F}
+    (h : ‖A - (L : E →L[𝕜] F)‖₊ < ‖(L.symm : F →L[𝕜] E)‖₊⁻¹) : A.IsInvertible := by
+  have hsymm : ‖(L.symm : F →L[𝕜] E)‖₊ ≠ 0 := by
+    rintro h0
+    rw [h0, inv_zero] at h
+    simp at h
+  have hpos : 0 < ‖(L.symm : F →L[𝕜] E)‖ := by
+    simpa using pos_iff_ne_zero.2 hsymm
+  have hreal : ‖A - (L : E →L[𝕜] F)‖ < ‖(L.symm : F →L[𝕜] E)‖⁻¹ := by
+    rw [← NNReal.coe_lt_coe] at h
+    simpa using h
+  have hnorm : ‖(L.symm : F →L[𝕜] E).comp A - 1‖ < 1 :=
+    calc
+      ‖(L.symm : F →L[𝕜] E).comp A - 1‖ =
+          ‖(L.symm : F →L[𝕜] E).comp (A - (L : E →L[𝕜] F))‖ := by
+        congr 1
+        ext x
+        simp
+      _ ≤ ‖(L.symm : F →L[𝕜] E)‖ * ‖A - (L : E →L[𝕜] F)‖ :=
+          ContinuousLinearMap.opNorm_comp_le _ _
+      _ < ‖(L.symm : F →L[𝕜] E)‖ * ‖(L.symm : F →L[𝕜] E)‖⁻¹ :=
+          mul_lt_mul_of_pos_left hreal hpos
+      _ = 1 := mul_inv_cancel₀ hpos.ne'
+  let _ : Nontrivial E := not_subsingleton_iff_nontrivial.mp (by
+    intro hE
+    let _ := hE
+    exact hpos.ne' (norm_of_subsingleton _))
+  let u : (E →L[𝕜] E)ˣ := Units.ofNearby 1 ((L.symm : F →L[𝕜] E).comp A) (by simpa using hnorm)
+  refine ⟨(ContinuousLinearEquiv.unitsEquiv 𝕜 E u).trans L, ?_⟩
+  ext x
+  simp [u, ContinuousLinearEquiv.unitsEquiv_apply]
+
+/-- A continuous linear map within `‖L⁻¹‖⁻¹ / 2` of a continuous linear equivalence `L` is
+invertible. This is the shape in which Mathlib's inverse function theorem supplies the estimate. -/
+theorem ContinuousLinearMap.isInvertible_of_norm_sub_le_half [CompleteSpace E]
+    (L : E ≃L[𝕜] F) {A : E →L[𝕜] F}
+    (h : ‖A - (L : E →L[𝕜] F)‖₊ ≤ ‖(L.symm : F →L[𝕜] E)‖₊⁻¹ / 2) : A.IsInvertible := by
+  rcases eq_or_ne (‖(L.symm : F →L[𝕜] E)‖₊)⁻¹ 0 with h0 | h0
+  · rw [h0, zero_div, le_zero_iff, nnnorm_eq_zero, sub_eq_zero] at h
+    exact h ▸ ContinuousLinearMap.isInvertible_equiv
+  · exact ContinuousLinearMap.isInvertible_of_norm_sub_lt L (h.trans_lt (NNReal.half_lt_self h0))
+
+end Perturbation
+
+variable {t₀ : 𝕜} {A : 𝕜 → E →L[𝕜] F} {A' : E →L[𝕜] F} {w : 𝕜 → F} {w' : F}
 
 /-- **Invertibility persists where the inverse family is continuous.** If `A t₀` is invertible and
 `t ↦ (A t).inverse` is continuous at `t₀`, then `A t` is invertible for every `t` near `t₀`. -/

--- a/TauCeti/Analysis/Calculus/ImplicitFunctionTheorem.lean
+++ b/TauCeti/Analysis/Calculus/ImplicitFunctionTheorem.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Calculus.Implicit
 public import Mathlib.Analysis.Calculus.ContDiff.Defs
+public import TauCeti.Analysis.Calculus.InverseFunctionTheorem
 import Mathlib.Analysis.Calculus.ContDiff.Operations
 
 /-!
@@ -23,6 +24,14 @@ Mathlib records the strict differentiability of that homeomorphism and of its in
 adds the `C^n` statements, obtained from Mathlib's smooth inverse theorem for an
 `OpenPartialHomeomorph`, `OpenPartialHomeomorph.contDiffAt_symm`, and the value of the inverse
 homeomorphism at `(f a, 0)`.
+
+Smoothness of the inverse at a point of the target needs the derivative of the coordinate map to
+be invertible there. At the base point that is the hypothesis of the theorem; away from it, it is
+supplied by `TauCeti.Analysis.Calculus.InverseFunctionTheorem`, on the open neighbourhood
+`HasStrictFDerivAt.implicitRegularSet` of the base point that the inverse function theorem itself
+produced. So the implicit function is `C^n` on a whole neighbourhood of the origin of the slice,
+not only at the origin: enough to compare two implicit-function charts smoothly, which is what a
+manifold structure on a level set asks for.
 
 Mathlib's `ImplicitFunctionData.contDiffAt_implicitFunction` is a `C^n` implicit function theorem
 for the same data. It is not usable here: it is stated over `[RCLike 𝕜]` and assumes `n ≠ 0`,
@@ -42,12 +51,43 @@ Mathlib's lemma.
   inverse, at the image `(f a, 0)` of the base point.
 * `HasStrictFDerivAt.eventually_implicitFunctionOfComplemented_eq`: near `0`, Mathlib's two
   spellings of the implicit function agree.
+* `ContinuousLinearMap.implicitCoordEquiv`: the derivative `x ↦ (f' x, P x)` of the coordinate
+  map, as a continuous linear equivalence.
+* `HasStrictFDerivAt.implicitRegularSet`: an open neighbourhood of the base point on which the
+  derivative of the coordinate map stays invertible.
+* `HasStrictFDerivAt.contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm_of_mem`: the
+  inverse homeomorphism is `C^n` at every point of the target coming from that neighbourhood.
 -/
 
 public section
 
 open Filter Set
 open scoped ContDiff Topology
+
+namespace ContinuousLinearMap
+
+variable {K E F : Type*} [NontriviallyNormedField K]
+variable [NormedAddCommGroup E] [NormedSpace K E] [CompleteSpace E]
+variable [NormedAddCommGroup F] [NormedSpace K F] [CompleteSpace F]
+
+/-- The derivative at the base point of the implicit-function coordinate map
+`x ↦ (f x, P (x - a))`, as a continuous linear equivalence `E ≃L[K] F × ker f'`: it is
+`x ↦ (f' x, P x)`, where `P` is the projection onto `ker f'` chosen by the complementation
+hypothesis. -/
+noncomputable def implicitCoordEquiv (f' : E →L[K] F) (hf' : f'.range = ⊤)
+    (hker : f'.ker.ClosedComplemented) : E ≃L[K] F × f'.ker :=
+  f'.equivProdOfSurjectiveOfIsCompl (Classical.choose hker) hf'
+    (LinearMap.range_eq_of_proj (Classical.choose_spec hker))
+    (LinearMap.isCompl_of_proj (Classical.choose_spec hker))
+
+@[simp]
+theorem coe_implicitCoordEquiv (f' : E →L[K] F) (hf' : f'.range = ⊤)
+    (hker : f'.ker.ClosedComplemented) :
+    (f'.implicitCoordEquiv hf' hker : E →L[K] F × f'.ker) = f'.prod (Classical.choose hker) :=
+  ContinuousLinearMap.ext fun x ↦ by
+    simp [implicitCoordEquiv, ContinuousLinearMap.equivProdOfSurjectiveOfIsCompl_apply]
+
+end ContinuousLinearMap
 
 namespace HasStrictFDerivAt
 
@@ -83,6 +123,36 @@ theorem contDiffAt_implicitToOpenPartialHomeomorphOfComplemented {n : ℕ∞ω} 
   rw [hf.coe_implicitToOpenPartialHomeomorphOfComplemented hf' hker]
   fun_prop
 
+/-- The implicit-function coordinate map `x ↦ (f x, P (x - a))` is strictly differentiable at the
+base point, with derivative the equivalence `ContinuousLinearMap.implicitCoordEquiv`. -/
+theorem hasStrictFDerivAt_implicitCoord (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤)
+    (hker : f'.ker.ClosedComplemented) :
+    HasStrictFDerivAt (fun x ↦ (f x, Classical.choose hker (x - a)))
+      (f'.implicitCoordEquiv hf' hker : E →L[K] F × f'.ker) a := by
+  rw [ContinuousLinearMap.coe_implicitCoordEquiv]
+  exact hf.prodMk ((Classical.choose hker).hasStrictFDerivAt.comp a
+    ((hasStrictFDerivAt_id a).sub_const a))
+
+/-- **The inverse of the implicit-function homeomorphism is `C^n` wherever the coordinate map has
+invertible derivative.** Mathlib's `OpenPartialHomeomorph.contDiffAt_symm` asks for an invertible
+derivative at the point one inverts around; `A` below is the derivative of the equation there, and
+`(A, P)` is the derivative of the coordinate map. -/
+theorem contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm_of_isInvertible {n : ℕ∞ω}
+    (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤) (hker : f'.ker.ClosedComplemented)
+    {y : F × f'.ker}
+    (hy : y ∈ (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).target)
+    {A : E →L[K] F}
+    (hA : HasFDerivAt f A ((hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y))
+    (hAinv : (A.prod (Classical.choose hker)).IsInvertible)
+    (hcont : ContDiffAt K n f
+      ((hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y)) :
+    ContDiffAt K n (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y := by
+  obtain ⟨M, hM⟩ := hAinv
+  refine (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).contDiffAt_symm
+    (f₀' := M) hy ?_ (hf.contDiffAt_implicitToOpenPartialHomeomorphOfComplemented hcont hf' hker)
+  rw [hf.coe_implicitToOpenPartialHomeomorphOfComplemented hf' hker, hM]
+  exact hA.prodMk ((Classical.choose hker).hasFDerivAt.comp _ ((hasFDerivAt_id _).sub_const a))
+
 /-- The inverse of Mathlib's complemented-kernel implicit-function homeomorphism is as smooth as
 the original map at the image of the base point. -/
 theorem contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm {n : ℕ∞ω}
@@ -90,24 +160,61 @@ theorem contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm {n : ℕ�
     (hf' : f'.range = ⊤) (hker : f'.ker.ClosedComplemented) :
     ContDiffAt K n
       (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm (f a, 0) := by
-  set e := hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker with he
-  -- the derivative of the coordinate change, as the equivalence `x ↦ (f' x, P x)`
-  let L : E ≃L[K] F × f'.ker :=
-    f'.equivProdOfSurjectiveOfIsCompl (Classical.choose hker) hf'
-      (LinearMap.range_eq_of_proj (Classical.choose_spec hker))
-      (LinearMap.isCompl_of_proj (Classical.choose_spec hker))
-  refine e.contDiffAt_symm (f₀' := L)
-    (hf.mem_implicitToOpenPartialHomeomorphOfComplemented_target hf' hker) ?_ ?_
-  · rw [he, hf.implicitToOpenPartialHomeomorphOfComplemented_symm_self hf' hker,
-      hf.coe_implicitToOpenPartialHomeomorphOfComplemented hf' hker]
-    have hL : (L : E →L[K] F × f'.ker) = f'.prod (Classical.choose hker) :=
-      ContinuousLinearMap.ext fun x ↦ by
-        simp [L, ContinuousLinearMap.equivProdOfSurjectiveOfIsCompl_apply]
-    rw [hL]
-    exact (hf.prodMk <| (Classical.choose hker).hasStrictFDerivAt.comp a
-      ((hasStrictFDerivAt_id a).sub_const a)).hasFDerivAt
-  · rw [he, hf.implicitToOpenPartialHomeomorphOfComplemented_symm_self hf' hker]
-    exact hf.contDiffAt_implicitToOpenPartialHomeomorphOfComplemented hcont hf' hker
+  have hbase := hf.implicitToOpenPartialHomeomorphOfComplemented_symm_self hf' hker
+  refine hf.contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm_of_isInvertible hf' hker
+    (hf.mem_implicitToOpenPartialHomeomorphOfComplemented_target hf' hker) (A := f') ?_ ?_ ?_
+  · rw [hbase]; exact hf.hasFDerivAt
+  · exact ⟨f'.implicitCoordEquiv hf' hker, ContinuousLinearMap.coe_implicitCoordEquiv ..⟩
+  · rw [hbase]; exact hcont
+
+/-! ### The neighbourhood on which the coordinate map stays regular -/
+
+/-- An open neighbourhood of the base point on which the derivative of the implicit-function
+coordinate map `x ↦ (f x, P (x - a))` is still invertible: the source of the homeomorphism that
+the inverse function theorem builds from that map. Like Mathlib's implicit-function homeomorphism
+itself, it is a choice, and is described only through the lemmas below. -/
+noncomputable def implicitRegularSet (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤)
+    (hker : f'.ker.ClosedComplemented) : Set E :=
+  ((hf.hasStrictFDerivAt_implicitCoord hf' hker).toOpenPartialHomeomorph
+    fun x ↦ (f x, Classical.choose hker (x - a))).source
+
+theorem isOpen_implicitRegularSet (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤)
+    (hker : f'.ker.ClosedComplemented) : IsOpen (hf.implicitRegularSet hf' hker) :=
+  OpenPartialHomeomorph.open_source _
+
+theorem mem_implicitRegularSet (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤)
+    (hker : f'.ker.ClosedComplemented) : a ∈ hf.implicitRegularSet hf' hker :=
+  HasStrictFDerivAt.mem_toOpenPartialHomeomorph_source _
+
+/-- **The derivative of the coordinate map stays invertible on
+`HasStrictFDerivAt.implicitRegularSet`.** If `f` has derivative `A` at a point of that
+neighbourhood, then `(A, P)` is a continuous linear equivalence, exactly as `(f', P)` is at the
+base point. -/
+theorem isInvertible_prod_of_mem_implicitRegularSet (hf : HasStrictFDerivAt f f' a)
+    (hf' : f'.range = ⊤) (hker : f'.ker.ClosedComplemented) {x : E}
+    (hx : x ∈ hf.implicitRegularSet hf' hker) {A : E →L[K] F} (hA : HasFDerivAt f A x) :
+    (A.prod (Classical.choose hker)).IsInvertible := by
+  have : CompleteSpace f'.ker := hker.isClosed.completeSpace_coe
+  exact (hf.hasStrictFDerivAt_implicitCoord hf'
+    hker).isInvertible_of_mem_toOpenPartialHomeomorph_source hx
+      (hA.prodMk ((Classical.choose hker).hasFDerivAt.comp x ((hasFDerivAt_id x).sub_const a)))
+
+/-- **The implicit function is `C^n` on a whole neighbourhood of the origin of the slice.** The
+inverse of the implicit-function homeomorphism is `C^n` at every point of its target whose
+preimage lies in `HasStrictFDerivAt.implicitRegularSet`. -/
+theorem contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm_of_mem {n : ℕ∞ω}
+    (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤) (hker : f'.ker.ClosedComplemented)
+    {y : F × f'.ker}
+    (hy : y ∈ (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).target)
+    (hmem : (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y ∈
+      hf.implicitRegularSet hf' hker)
+    {A : E →L[K] F}
+    (hA : HasFDerivAt f A ((hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y))
+    (hcont : ContDiffAt K n f
+      ((hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y)) :
+    ContDiffAt K n (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y :=
+  hf.contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm_of_isInvertible hf' hker hy hA
+    (hf.isInvertible_prod_of_mem_implicitRegularSet hf' hker hmem hA) hcont
 
 /- Mathlib names the complemented-kernel implicit function twice, once as
 `HasStrictFDerivAt.implicitFunctionOfComplemented` and once as the inverse of

--- a/TauCeti/Analysis/Calculus/ImplicitFunctionTheorem.lean
+++ b/TauCeti/Analysis/Calculus/ImplicitFunctionTheorem.lean
@@ -28,7 +28,7 @@ homeomorphism at `(f a, 0)`.
 Smoothness of the inverse at a point of the target needs the derivative of the coordinate map to
 be invertible there. At the base point that is the hypothesis of the theorem; away from it, it is
 supplied by `TauCeti.Analysis.Calculus.InverseFunctionTheorem`, on the open neighbourhood
-`HasStrictFDerivAt.implicitRegularSet` of the base point that the inverse function theorem itself
+`HasStrictFDerivAt.implicitCoordSource` of the base point that the inverse function theorem itself
 produced. So the implicit function is `C^n` on a whole neighbourhood of the origin of the slice,
 not only at the origin: enough to compare two implicit-function charts smoothly, which is what a
 manifold structure on a level set asks for.
@@ -53,7 +53,7 @@ Mathlib's lemma.
   spellings of the implicit function agree.
 * `ContinuousLinearMap.implicitCoordEquiv`: the derivative `x ↦ (f' x, P x)` of the coordinate
   map, as a continuous linear equivalence.
-* `HasStrictFDerivAt.implicitRegularSet`: an open neighbourhood of the base point on which the
+* `HasStrictFDerivAt.implicitCoordSource`: an open neighbourhood of the base point on which the
   derivative of the coordinate map stays invertible.
 * `HasStrictFDerivAt.contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm_of_mem`: the
   inverse homeomorphism is `C^n` at every point of the target coming from that neighbourhood.
@@ -167,32 +167,32 @@ theorem contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm {n : ℕ�
   · exact ⟨f'.implicitCoordEquiv hf' hker, ContinuousLinearMap.coe_implicitCoordEquiv ..⟩
   · rw [hbase]; exact hcont
 
-/-! ### The neighbourhood on which the coordinate map stays regular -/
+/-! ### The neighbourhood on which the coordinate map stays invertible -/
 
 /-- An open neighbourhood of the base point on which the derivative of the implicit-function
 coordinate map `x ↦ (f x, P (x - a))` is still invertible: the source of the homeomorphism that
 the inverse function theorem builds from that map. Like Mathlib's implicit-function homeomorphism
 itself, it is a choice, and is described only through the lemmas below. -/
-noncomputable def implicitRegularSet (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤)
+noncomputable def implicitCoordSource (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤)
     (hker : f'.ker.ClosedComplemented) : Set E :=
   ((hf.hasStrictFDerivAt_implicitCoord hf' hker).toOpenPartialHomeomorph
     fun x ↦ (f x, Classical.choose hker (x - a))).source
 
-theorem isOpen_implicitRegularSet (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤)
-    (hker : f'.ker.ClosedComplemented) : IsOpen (hf.implicitRegularSet hf' hker) :=
+theorem isOpen_implicitCoordSource (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤)
+    (hker : f'.ker.ClosedComplemented) : IsOpen (hf.implicitCoordSource hf' hker) :=
   OpenPartialHomeomorph.open_source _
 
-theorem mem_implicitRegularSet (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤)
-    (hker : f'.ker.ClosedComplemented) : a ∈ hf.implicitRegularSet hf' hker :=
+theorem mem_implicitCoordSource (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤)
+    (hker : f'.ker.ClosedComplemented) : a ∈ hf.implicitCoordSource hf' hker :=
   HasStrictFDerivAt.mem_toOpenPartialHomeomorph_source _
 
 /-- **The derivative of the coordinate map stays invertible on
-`HasStrictFDerivAt.implicitRegularSet`.** If `f` has derivative `A` at a point of that
+`HasStrictFDerivAt.implicitCoordSource`.** If `f` has derivative `A` at a point of that
 neighbourhood, then `(A, P)` is a continuous linear equivalence, exactly as `(f', P)` is at the
 base point. -/
-theorem isInvertible_prod_of_mem_implicitRegularSet (hf : HasStrictFDerivAt f f' a)
+theorem isInvertible_prod_of_mem_implicitCoordSource (hf : HasStrictFDerivAt f f' a)
     (hf' : f'.range = ⊤) (hker : f'.ker.ClosedComplemented) {x : E}
-    (hx : x ∈ hf.implicitRegularSet hf' hker) {A : E →L[K] F} (hA : HasFDerivAt f A x) :
+    (hx : x ∈ hf.implicitCoordSource hf' hker) {A : E →L[K] F} (hA : HasFDerivAt f A x) :
     (A.prod (Classical.choose hker)).IsInvertible := by
   have : CompleteSpace f'.ker := hker.isClosed.completeSpace_coe
   exact (hf.hasStrictFDerivAt_implicitCoord hf'
@@ -201,20 +201,20 @@ theorem isInvertible_prod_of_mem_implicitRegularSet (hf : HasStrictFDerivAt f f'
 
 /-- **The implicit function is `C^n` on a whole neighbourhood of the origin of the slice.** The
 inverse of the implicit-function homeomorphism is `C^n` at every point of its target whose
-preimage lies in `HasStrictFDerivAt.implicitRegularSet`. -/
+preimage lies in `HasStrictFDerivAt.implicitCoordSource`. -/
 theorem contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm_of_mem {n : ℕ∞ω}
     (hf : HasStrictFDerivAt f f' a) (hf' : f'.range = ⊤) (hker : f'.ker.ClosedComplemented)
     {y : F × f'.ker}
     (hy : y ∈ (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).target)
     (hmem : (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y ∈
-      hf.implicitRegularSet hf' hker)
+      hf.implicitCoordSource hf' hker)
     {A : E →L[K] F}
     (hA : HasFDerivAt f A ((hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y))
     (hcont : ContDiffAt K n f
       ((hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y)) :
     ContDiffAt K n (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm y :=
   hf.contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm_of_isInvertible hf' hker hy hA
-    (hf.isInvertible_prod_of_mem_implicitRegularSet hf' hker hmem hA) hcont
+    (hf.isInvertible_prod_of_mem_implicitCoordSource hf' hker hmem hA) hcont
 
 /- Mathlib names the complemented-kernel implicit function twice, once as
 `HasStrictFDerivAt.implicitFunctionOfComplemented` and once as the inverse of

--- a/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
+++ b/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
@@ -76,14 +76,7 @@ Fréchet derivative of `f` at an interior point is within `c` of `L` in operator
 theorem ApproximatesLinearOn.norm_sub_le_of_hasFDerivAt {f : E → F} {L A : E →L[𝕜] F} {s : Set E}
     {c : ℝ≥0} (hf : ApproximatesLinearOn f L s c) {x : E} (hs : s ∈ 𝓝 x)
     (hA : HasFDerivAt f A x) : ‖A - L‖ ≤ c := by
-  have hx : x ∈ s := mem_of_mem_nhds hs
-  have hg : HasFDerivAt (fun y ↦ f y - L y) (A - L) x := hA.sub L.hasFDerivAt
-  refine hg.le_of_lip' c.coe_nonneg ?_
-  filter_upwards [hs] with y hy
-  have hsub : f y - L y - (f x - L x) = f y - f x - L (y - x) := by
-    rw [map_sub]; abel
-  rw [hsub]
-  exact hf y hy x hx
+  exact (hA.sub L.hasFDerivAt).le_of_lipschitzOn hs hf.lipschitzOnWith
 
 /-- A continuous linear map that differs from a continuous linear equivalence `L` by less than
 `‖L⁻¹‖⁻¹` in operator norm is itself invertible: `L⁻¹A` is close enough to `1` to be a unit of the

--- a/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
+++ b/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.ContDiff
-import Mathlib.Analysis.Normed.Operator.Banach
+public import TauCeti.Analysis.Calculus.ContinuousLinearMapInverse
 
 /-!
 # The inverse function theorem with a `C^n` inverse on a whole open set
@@ -22,8 +22,8 @@ The invertibility does in fact persist. Mathlib's construction goes through
 `ApproximatesLinearOn`: the source of the homeomorphism is an open set on which the map
 approximates its derivative `L` at the base point with a constant `c` strictly below `‖L⁻¹‖⁻¹`.
 On such a set every Fréchet derivative of the map is within `c` of `L` in norm, hence is still
-invertible. This file extracts that estimate and runs Mathlib's smooth inverse function theorem at
-every point of the target.
+invertible by `ContinuousLinearMap.isInvertible_of_norm_sub_le_half`. This file extracts that
+estimate and runs Mathlib's smooth inverse function theorem at every point of the target.
 
 Two forms are given. The first is about Mathlib's own homeomorphism, over an arbitrary
 nontrivially normed field and from strict differentiability alone; it is the form a consumer that
@@ -36,8 +36,6 @@ a point of an open set `s` restricts to an `OpenPartialHomeomorph` inside `s` wh
 
 * `ApproximatesLinearOn.norm_sub_le_of_hasFDerivAt`: on a set where `f` approximates `L` with
   constant `c`, every derivative of `f` at an interior point is within `c` of `L`.
-* `ContinuousLinearMap.isInvertible_of_norm_sub_lt`: a continuous linear map closer to an
-  invertible one than the reciprocal norm of its inverse is itself invertible.
 * `HasStrictFDerivAt.approximatesLinearOn_toOpenPartialHomeomorph_source`: the source of the
   inverse function theorem's homeomorphism carries the approximation estimate its construction
   chose.
@@ -77,52 +75,6 @@ theorem ApproximatesLinearOn.norm_sub_le_of_hasFDerivAt {f : E → F} {L A : E �
     {c : ℝ≥0} (hf : ApproximatesLinearOn f L s c) {x : E} (hs : s ∈ 𝓝 x)
     (hA : HasFDerivAt f A x) : ‖A - L‖ ≤ c := by
   exact (hA.sub L.hasFDerivAt).le_of_lipschitzOn hs hf.lipschitzOnWith
-
-/-- A continuous linear map that differs from a continuous linear equivalence `L` by less than
-`‖L⁻¹‖⁻¹` in operator norm is itself invertible: `L⁻¹A` is close enough to `1` to be a unit of the
-Banach algebra of endomorphisms of `E`. -/
-theorem ContinuousLinearMap.isInvertible_of_norm_sub_lt [CompleteSpace E]
-    (L : E ≃L[𝕜] F) {A : E →L[𝕜] F}
-    (h : ‖A - (L : E →L[𝕜] F)‖₊ < ‖(L.symm : F →L[𝕜] E)‖₊⁻¹) : A.IsInvertible := by
-  have hsymm : ‖(L.symm : F →L[𝕜] E)‖₊ ≠ 0 := by
-    rintro h0
-    rw [h0, inv_zero] at h
-    simp at h
-  have hpos : 0 < ‖(L.symm : F →L[𝕜] E)‖ := by
-    simpa using pos_iff_ne_zero.2 hsymm
-  have hreal : ‖A - (L : E →L[𝕜] F)‖ < ‖(L.symm : F →L[𝕜] E)‖⁻¹ := by
-    rw [← NNReal.coe_lt_coe] at h
-    simpa using h
-  have hnorm : ‖(L.symm : F →L[𝕜] E).comp A - 1‖ < 1 :=
-    calc
-      ‖(L.symm : F →L[𝕜] E).comp A - 1‖ =
-          ‖(L.symm : F →L[𝕜] E).comp (A - (L : E →L[𝕜] F))‖ := by
-        congr 1
-        ext x
-        simp
-      _ ≤ ‖(L.symm : F →L[𝕜] E)‖ * ‖A - (L : E →L[𝕜] F)‖ :=
-          ContinuousLinearMap.opNorm_comp_le _ _
-      _ < ‖(L.symm : F →L[𝕜] E)‖ * ‖(L.symm : F →L[𝕜] E)‖⁻¹ :=
-          mul_lt_mul_of_pos_left hreal hpos
-      _ = 1 := mul_inv_cancel₀ hpos.ne'
-  let _ : Nontrivial E := not_subsingleton_iff_nontrivial.mp (by
-    intro hE
-    let _ := hE
-    exact hpos.ne' (norm_of_subsingleton _))
-  let u : (E →L[𝕜] E)ˣ := Units.ofNearby 1 ((L.symm : F →L[𝕜] E).comp A) (by simpa using hnorm)
-  refine ⟨(ContinuousLinearEquiv.unitsEquiv 𝕜 E u).trans L, ?_⟩
-  ext x
-  simp [u, ContinuousLinearEquiv.unitsEquiv_apply]
-
-/-- A continuous linear map within `‖L⁻¹‖⁻¹ / 2` of a continuous linear equivalence `L` is
-invertible. This is the shape in which Mathlib's inverse function theorem supplies the estimate. -/
-theorem ContinuousLinearMap.isInvertible_of_norm_sub_le_half [CompleteSpace E]
-    (L : E ≃L[𝕜] F) {A : E →L[𝕜] F}
-    (h : ‖A - (L : E →L[𝕜] F)‖₊ ≤ ‖(L.symm : F →L[𝕜] E)‖₊⁻¹ / 2) : A.IsInvertible := by
-  rcases eq_or_ne (‖(L.symm : F →L[𝕜] E)‖₊)⁻¹ 0 with h0 | h0
-  · rw [h0, zero_div, le_zero_iff, nnnorm_eq_zero, sub_eq_zero] at h
-    exact h ▸ ContinuousLinearMap.isInvertible_equiv
-  · exact ContinuousLinearMap.isInvertible_of_norm_sub_lt L (h.trans_lt (NNReal.half_lt_self h0))
 
 namespace HasStrictFDerivAt
 

--- a/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
+++ b/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
@@ -6,29 +6,54 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.ContDiff
+import Mathlib.Analysis.Normed.Operator.Banach
 
 /-!
 # The inverse function theorem with a `C^n` inverse on a whole open set
 
 Mathlib's `ContDiffAt.toOpenPartialHomeomorph` turns a `C^n` map with invertible derivative at a
 point into an `OpenPartialHomeomorph`, but `ContDiffAt.to_localInverse` only produces a `C^n`
-inverse *at the image point*. Building a partial diffeomorphism of manifolds needs more: the
-inverse has to be `C^n` on the whole target.
+inverse *at the image point*: `OpenPartialHomeomorph.contDiffAt_symm` needs an invertible
+derivative at the point one inverts around, and invertibility is assumed at the base point alone.
+Building a partial diffeomorphism of manifolds, or comparing two implicit-function charts of a
+level set, needs more: the inverse has to be `C^n` on the whole target.
 
-This file supplies that upgrade. Shrinking the source to the open set where the derivative stays
-invertible — invertibility is an open condition by `ContinuousLinearEquiv.isOpen` — makes
-`OpenPartialHomeomorph.contDiffAt_symm` applicable at *every* point of the target.
+The invertibility does in fact persist. Mathlib's construction goes through
+`ApproximatesLinearOn`: the source of the homeomorphism is an open set on which the map
+approximates its derivative `L` at the base point with a constant `c` strictly below `‖L⁻¹‖⁻¹`.
+On such a set every Fréchet derivative of the map is within `c` of `L` in norm, hence is still
+invertible. This file extracts that estimate and runs Mathlib's smooth inverse function theorem at
+every point of the target.
+
+Two forms are given. The first is about Mathlib's own homeomorphism, over an arbitrary
+nontrivially normed field and from strict differentiability alone; it is the form a consumer that
+cannot choose its homeomorphism — such as the implicit-function chart of a level set — needs. The
+second packages the classical statement over `ℝ` or `ℂ`: a `C^n` map with invertible derivative at
+a point of an open set `s` restricts to an `OpenPartialHomeomorph` inside `s` whose inverse is
+`C^n` on its target.
 
 ## Main results
 
-* `TauCeti.isOpen_inter_preimage_range_continuousLinearEquiv_fderiv`: on an open set, the points
-  where a `C^n` map (`1 ≤ n`) has invertible derivative form an open set.
+* `ApproximatesLinearOn.norm_sub_le_of_hasFDerivAt`: on an open set where `f` approximates `L`
+  with constant `c`, every derivative of `f` is within `c` of `L`.
+* `ContinuousLinearMap.isInvertible_of_norm_sub_lt`: a continuous linear map closer to an
+  invertible one than the reciprocal norm of its inverse is itself invertible.
+* `HasStrictFDerivAt.approximatesLinearOn_toOpenPartialHomeomorph_source`: the source of the
+  inverse function theorem's homeomorphism carries the approximation estimate its construction
+  chose.
+* `HasStrictFDerivAt.isInvertible_of_mem_toOpenPartialHomeomorph_source`: hence the derivative of
+  `f` is invertible at every point of that source, not only at the base point.
+* `HasStrictFDerivAt.contDiffAt_toOpenPartialHomeomorph_symm` and
+  `HasStrictFDerivAt.contDiffOn_toOpenPartialHomeomorph_symm`: the local inverse is `C^n` at every
+  point of the target, and hence on the target.
 * `TauCeti.ContDiffOn.exists_openPartialHomeomorph`: a `C^n` map (`1 ≤ n`) on an open set with
   invertible derivative at a point restricts to an `OpenPartialHomeomorph` around that point whose
   inverse is `C^n` on the whole target.
 
 ## References
 
+* D. McDuff, D. Salamon, *J-holomorphic Curves and Symplectic Topology*, 2nd ed., AMS Colloquium
+  Publications 52, 2012, Appendix A.3.
 * [The Hopf--Rinow roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
   Layer 1, "The manifold inverse-function theorem".
 -/
@@ -37,7 +62,124 @@ public section
 
 noncomputable section
 
-open Set
+open Filter Set
+open scoped ContDiff NNReal Topology
+
+section Approximation
+
+variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
+variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+
+/-- On an open set on which `f` approximates the continuous linear map `L` with constant `c`,
+every Fréchet derivative of `f` is within `c` of `L` in operator norm. -/
+theorem ApproximatesLinearOn.norm_sub_le_of_hasFDerivAt {f : E → F} {L A : E →L[𝕜] F} {s : Set E}
+    {c : ℝ≥0} (hf : ApproximatesLinearOn f L s c) (hs : IsOpen s) {x : E} (hx : x ∈ s)
+    (hA : HasFDerivAt f A x) : ‖A - L‖ ≤ c := by
+  have hg : HasFDerivAt (fun y ↦ f y - L y) (A - L) x := hA.sub L.hasFDerivAt
+  refine hg.le_of_lip' c.coe_nonneg ?_
+  filter_upwards [hs.mem_nhds hx] with y hy
+  have hsub : f y - L y - (f x - L x) = f y - f x - L (y - x) := by
+    rw [map_sub]; abel
+  rw [hsub]
+  exact hf y hy x hx
+
+/-- A continuous linear map that differs from a continuous linear equivalence `L` by less than
+`‖L⁻¹‖⁻¹` in operator norm is itself invertible: `L⁻¹A` is then `1` minus a contraction, hence a
+unit of the Banach algebra of endomorphisms of `E`. -/
+theorem ContinuousLinearMap.isInvertible_of_norm_sub_lt [CompleteSpace E]
+    (L : E ≃L[𝕜] F) {A : E →L[𝕜] F}
+    (h : ‖A - (L : E →L[𝕜] F)‖₊ < ‖(L.symm : F →L[𝕜] E)‖₊⁻¹) : A.IsInvertible := by
+  have hsymm : ‖(L.symm : F →L[𝕜] E)‖₊ ≠ 0 := by
+    rintro h0
+    rw [h0, inv_zero] at h
+    simp at h
+  have hpos : 0 < ‖(L.symm : F →L[𝕜] E)‖ := by
+    simpa using pos_iff_ne_zero.2 hsymm
+  have hreal : ‖A - (L : E →L[𝕜] F)‖ < ‖(L.symm : F →L[𝕜] E)‖⁻¹ := by
+    rw [← NNReal.coe_lt_coe] at h
+    simpa using h
+  set t : E →L[𝕜] E := (L.symm : F →L[𝕜] E).comp ((L : E →L[𝕜] F) - A) with ht
+  have hnorm : ‖t‖ < 1 :=
+    calc ‖t‖ ≤ ‖(L.symm : F →L[𝕜] E)‖ * ‖(L : E →L[𝕜] F) - A‖ :=
+          ContinuousLinearMap.opNorm_comp_le _ _
+      _ = ‖(L.symm : F →L[𝕜] E)‖ * ‖A - (L : E →L[𝕜] F)‖ := by rw [norm_sub_rev]
+      _ < ‖(L.symm : F →L[𝕜] E)‖ * ‖(L.symm : F →L[𝕜] E)‖⁻¹ :=
+          mul_lt_mul_of_pos_left hreal hpos
+      _ = 1 := mul_inv_cancel₀ hpos.ne'
+  refine ⟨(ContinuousLinearEquiv.unitsEquiv 𝕜 E (Units.oneSub t hnorm)).trans L, ?_⟩
+  ext x
+  have hx : L (t x) = L x - A x := by simp [ht]
+  simp [ContinuousLinearEquiv.unitsEquiv_apply, hx]
+
+/-- A continuous linear map within `‖L⁻¹‖⁻¹ / 2` of a continuous linear equivalence `L` is
+invertible. This is the shape in which Mathlib's inverse function theorem supplies the estimate. -/
+theorem ContinuousLinearMap.isInvertible_of_norm_sub_le_half [CompleteSpace E]
+    (L : E ≃L[𝕜] F) {A : E →L[𝕜] F}
+    (h : ‖A - (L : E →L[𝕜] F)‖₊ ≤ ‖(L.symm : F →L[𝕜] E)‖₊⁻¹ / 2) : A.IsInvertible := by
+  rcases eq_or_ne (‖(L.symm : F →L[𝕜] E)‖₊)⁻¹ 0 with h0 | h0
+  · rw [h0, zero_div, le_zero_iff, nnnorm_eq_zero, sub_eq_zero] at h
+    exact h ▸ ContinuousLinearMap.isInvertible_equiv
+  · exact ContinuousLinearMap.isInvertible_of_norm_sub_lt L (h.trans_lt (NNReal.half_lt_self h0))
+
+namespace HasStrictFDerivAt
+
+variable [CompleteSpace E] {f : E → F} {L : E ≃L[𝕜] F} {a : E}
+
+/-- On the source of the homeomorphism built by the inverse function theorem, `f` approximates its
+derivative at the base point with the constant `‖L⁻¹‖⁻¹ / 2` that the construction chose. -/
+theorem approximatesLinearOn_toOpenPartialHomeomorph_source
+    (hf : HasStrictFDerivAt f (L : E →L[𝕜] F) a) :
+    ApproximatesLinearOn f (L : E →L[𝕜] F) (hf.toOpenPartialHomeomorph f).source
+      (‖(L.symm : F →L[𝕜] E)‖₊⁻¹ / 2) := by
+  have h := (Classical.choose_spec hf.approximates_deriv_on_open_nhds).2.2
+  convert h using 1
+  exact ApproximatesLinearOn.toOpenPartialHomeomorph_source ..
+
+/-- **The derivative of `f` is invertible throughout the inverse-function neighbourhood.**
+Invertibility of the derivative is assumed at the base point only, but it propagates to every
+point of the source of `HasStrictFDerivAt.toOpenPartialHomeomorph`. -/
+theorem isInvertible_of_mem_toOpenPartialHomeomorph_source
+    (hf : HasStrictFDerivAt f (L : E →L[𝕜] F) a) {x : E}
+    (hx : x ∈ (hf.toOpenPartialHomeomorph f).source) {A : E →L[𝕜] F} (hA : HasFDerivAt f A x) :
+    A.IsInvertible := by
+  refine ContinuousLinearMap.isInvertible_of_norm_sub_le_half L ?_
+  have hbound := hf.approximatesLinearOn_toOpenPartialHomeomorph_source.norm_sub_le_of_hasFDerivAt
+    (hf.toOpenPartialHomeomorph f).open_source hx hA
+  rwa [← NNReal.coe_le_coe, coe_nnnorm]
+
+/-- **The local inverse of the inverse function theorem is `C^n` at every point of its target.**
+Mathlib's `OpenPartialHomeomorph.contDiffAt_symm` gives this at the image of the base point only,
+because that is where invertibility of the derivative is assumed; it holds everywhere on the
+target because the derivative stays invertible on the source. -/
+theorem contDiffAt_toOpenPartialHomeomorph_symm {n : ℕ∞ω}
+    (hf : HasStrictFDerivAt f (L : E →L[𝕜] F) a) {y : F}
+    (hy : y ∈ (hf.toOpenPartialHomeomorph f).target)
+    (hcont : ContDiffAt 𝕜 n f ((hf.toOpenPartialHomeomorph f).symm y)) (hn : n ≠ 0) :
+    ContDiffAt 𝕜 n (hf.toOpenPartialHomeomorph f).symm y := by
+  set x := (hf.toOpenPartialHomeomorph f).symm y with hx
+  have hxs : x ∈ (hf.toOpenPartialHomeomorph f).source :=
+    (hf.toOpenPartialHomeomorph f).map_target hy
+  have hA : HasFDerivAt f (fderiv 𝕜 f x) x := (hcont.differentiableAt hn).hasFDerivAt
+  obtain ⟨A, hA'⟩ := hf.isInvertible_of_mem_toOpenPartialHomeomorph_source hxs hA
+  refine (hf.toOpenPartialHomeomorph f).contDiffAt_symm (f₀' := A) hy ?_ ?_
+  · simpa [hA'] using hA
+  · simpa using hcont
+
+/-- **The inverse function theorem produces a `C^n` inverse.** If `f` is `C^n` on the source of the
+homeomorphism built by the inverse function theorem, then the inverse is `C^n` on the target. -/
+theorem contDiffOn_toOpenPartialHomeomorph_symm {n : ℕ∞ω}
+    (hf : HasStrictFDerivAt f (L : E →L[𝕜] F) a)
+    (hcont : ContDiffOn 𝕜 n f (hf.toOpenPartialHomeomorph f).source) (hn : n ≠ 0) :
+    ContDiffOn 𝕜 n (hf.toOpenPartialHomeomorph f).symm (hf.toOpenPartialHomeomorph f).target := by
+  intro y hy
+  refine (hf.contDiffAt_toOpenPartialHomeomorph_symm hy ?_ hn).contDiffWithinAt
+  exact hcont.contDiffAt ((hf.toOpenPartialHomeomorph f).open_source.mem_nhds
+    ((hf.toOpenPartialHomeomorph f).map_target hy))
+
+end HasStrictFDerivAt
+
+end Approximation
 
 namespace TauCeti
 
@@ -45,15 +187,6 @@ variable {𝕂 : Type*} [RCLike 𝕂]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕂 E] [CompleteSpace E]
   {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕂 F]
   {n : WithTop ℕ∞} {g : E → F} {s : Set E} {a : E}
-
-/-- On an open set on which `g` is `C^n` with `1 ≤ n`, the points where the derivative of `g` is a
-continuous linear equivalence form an open set: the derivative varies continuously, and the
-continuous linear equivalences are open among the continuous linear maps. -/
-theorem isOpen_inter_preimage_range_continuousLinearEquiv_fderiv
-    (hg : ContDiffOn 𝕂 n g s) (hs : IsOpen s) (hn : 1 ≤ n) :
-    IsOpen (s ∩ fderiv 𝕂 g ⁻¹' range ((↑) : (E ≃L[𝕂] F) → E →L[𝕂] F)) :=
-  (hg.continuousOn_fderiv_of_isOpen hs hn).isOpen_inter_preimage hs
-    ContinuousLinearEquiv.isOpen
 
 /-- **The inverse function theorem, with a `C^n` inverse on the whole target.** A map which is
 `C^n` on an open set `s`, with `1 ≤ n`, and whose derivative at `a ∈ s` is a continuous linear
@@ -65,22 +198,17 @@ theorem ContDiffOn.exists_openPartialHomeomorph
     ∃ Θ : OpenPartialHomeomorph E F, (Θ : E → F) = g ∧ a ∈ Θ.source ∧ Θ.source ⊆ s ∧
       ContDiffOn 𝕂 n Θ.symm Θ.target := by
   have hn0 : n ≠ 0 := by rintro rfl; exact absurd hn (by simp)
-  set W := s ∩ fderiv 𝕂 g ⁻¹' range ((↑) : (E ≃L[𝕂] F) → E →L[𝕂] F)
-  have hWopen : IsOpen W := isOpen_inter_preimage_range_continuousLinearEquiv_fderiv hg hs hn
-  have haW : a ∈ W := ⟨ha, e, he⟩
-  -- Every point of `W` has an invertible derivative, witnessed by `HasFDerivAt`.
-  have hderiv : ∀ y ∈ W, ∃ e' : E ≃L[𝕂] F, HasFDerivAt g (e' : E →L[𝕂] F) y := by
-    rintro y ⟨hy, e', he'⟩
-    exact ⟨e', he' ▸ ((hg.differentiableOn hn0).differentiableAt (hs.mem_nhds hy)).hasFDerivAt⟩
   have hgAt : ∀ y ∈ s, ContDiffAt 𝕂 n g y := fun y hy => hg.contDiffAt (hs.mem_nhds hy)
-  obtain ⟨e₀, he₀⟩ := hderiv a haW
-  refine ⟨((hgAt a ha).toOpenPartialHomeomorph g he₀ hn0).restrOpen W hWopen, rfl, ?_, ?_, ?_⟩
-  · exact ⟨(hgAt a ha).mem_toOpenPartialHomeomorph_source he₀ hn0, haW⟩
-  · exact fun y hy => (hy.2 : y ∈ W).1
-  · intro w hw
-    set Θ := ((hgAt a ha).toOpenPartialHomeomorph g he₀ hn0).restrOpen W hWopen
-    have hmem : Θ.symm w ∈ W := (Θ.map_target hw).2
-    obtain ⟨e', he'⟩ := hderiv _ hmem
-    exact (Θ.contDiffAt_symm hw he' (hgAt _ hmem.1)).contDiffWithinAt
+  have he₀ : HasFDerivAt g (e : E →L[𝕂] F) a :=
+    he ▸ ((hg.differentiableOn hn0).differentiableAt (hs.mem_nhds ha)).hasFDerivAt
+  have hstrict := (hgAt a ha).hasStrictFDerivAt' he₀ hn0
+  refine ⟨((hgAt a ha).toOpenPartialHomeomorph g he₀ hn0).restrOpen s hs, rfl,
+    ⟨(hgAt a ha).mem_toOpenPartialHomeomorph_source he₀ hn0, ha⟩, fun y hy => hy.2, ?_⟩
+  intro w hw
+  exact (hstrict.contDiffAt_toOpenPartialHomeomorph_symm hw.1 (hgAt _ hw.2) hn0).contDiffWithinAt
 
 end TauCeti
+
+end
+
+end

--- a/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
+++ b/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
@@ -34,8 +34,8 @@ a point of an open set `s` restricts to an `OpenPartialHomeomorph` inside `s` wh
 
 ## Main results
 
-* `ApproximatesLinearOn.norm_sub_le_of_hasFDerivAt`: on an open set where `f` approximates `L`
-  with constant `c`, every derivative of `f` is within `c` of `L`.
+* `ApproximatesLinearOn.norm_sub_le_of_hasFDerivAt`: on a set where `f` approximates `L` with
+  constant `c`, every derivative of `f` at an interior point is within `c` of `L`.
 * `ContinuousLinearMap.isInvertible_of_norm_sub_lt`: a continuous linear map closer to an
   invertible one than the reciprocal norm of its inverse is itself invertible.
 * `HasStrictFDerivAt.approximatesLinearOn_toOpenPartialHomeomorph_source`: the source of the
@@ -71,14 +71,15 @@ variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
 variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 variable [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 
-/-- On an open set on which `f` approximates the continuous linear map `L` with constant `c`,
-every Fréchet derivative of `f` is within `c` of `L` in operator norm. -/
+/-- On a set on which `f` approximates the continuous linear map `L` with constant `c`, every
+Fréchet derivative of `f` at an interior point is within `c` of `L` in operator norm. -/
 theorem ApproximatesLinearOn.norm_sub_le_of_hasFDerivAt {f : E → F} {L A : E →L[𝕜] F} {s : Set E}
-    {c : ℝ≥0} (hf : ApproximatesLinearOn f L s c) (hs : IsOpen s) {x : E} (hx : x ∈ s)
+    {c : ℝ≥0} (hf : ApproximatesLinearOn f L s c) {x : E} (hs : s ∈ 𝓝 x)
     (hA : HasFDerivAt f A x) : ‖A - L‖ ≤ c := by
+  have hx : x ∈ s := mem_of_mem_nhds hs
   have hg : HasFDerivAt (fun y ↦ f y - L y) (A - L) x := hA.sub L.hasFDerivAt
   refine hg.le_of_lip' c.coe_nonneg ?_
-  filter_upwards [hs.mem_nhds hx] with y hy
+  filter_upwards [hs] with y hy
   have hsub : f y - L y - (f x - L x) = f y - f x - L (y - x) := by
     rw [map_sub]; abel
   rw [hsub]
@@ -145,7 +146,7 @@ theorem isInvertible_of_mem_toOpenPartialHomeomorph_source
     A.IsInvertible := by
   refine ContinuousLinearMap.isInvertible_of_norm_sub_le_half L ?_
   have hbound := hf.approximatesLinearOn_toOpenPartialHomeomorph_source.norm_sub_le_of_hasFDerivAt
-    (hf.toOpenPartialHomeomorph f).open_source hx hA
+    ((hf.toOpenPartialHomeomorph f).open_source.mem_nhds hx) hA
   rwa [← NNReal.coe_le_coe, coe_nnnorm]
 
 /-- **The local inverse of the inverse function theorem is `C^n` at every point of its target.**
@@ -155,8 +156,11 @@ target because the derivative stays invertible on the source. -/
 theorem contDiffAt_toOpenPartialHomeomorph_symm {n : ℕ∞ω}
     (hf : HasStrictFDerivAt f (L : E →L[𝕜] F) a) {y : F}
     (hy : y ∈ (hf.toOpenPartialHomeomorph f).target)
-    (hcont : ContDiffAt 𝕜 n f ((hf.toOpenPartialHomeomorph f).symm y)) (hn : n ≠ 0) :
+    (hcont : ContDiffAt 𝕜 n f ((hf.toOpenPartialHomeomorph f).symm y)) :
     ContDiffAt 𝕜 n (hf.toOpenPartialHomeomorph f).symm y := by
+  rcases eq_or_ne n 0 with rfl | hn
+  · exact contDiffAt_zero.2 ⟨_, (hf.toOpenPartialHomeomorph f).open_target.mem_nhds hy,
+      (hf.toOpenPartialHomeomorph f).continuousOn_symm⟩
   set x := (hf.toOpenPartialHomeomorph f).symm y with hx
   have hxs : x ∈ (hf.toOpenPartialHomeomorph f).source :=
     (hf.toOpenPartialHomeomorph f).map_target hy
@@ -170,10 +174,10 @@ theorem contDiffAt_toOpenPartialHomeomorph_symm {n : ℕ∞ω}
 homeomorphism built by the inverse function theorem, then the inverse is `C^n` on the target. -/
 theorem contDiffOn_toOpenPartialHomeomorph_symm {n : ℕ∞ω}
     (hf : HasStrictFDerivAt f (L : E →L[𝕜] F) a)
-    (hcont : ContDiffOn 𝕜 n f (hf.toOpenPartialHomeomorph f).source) (hn : n ≠ 0) :
+    (hcont : ContDiffOn 𝕜 n f (hf.toOpenPartialHomeomorph f).source) :
     ContDiffOn 𝕜 n (hf.toOpenPartialHomeomorph f).symm (hf.toOpenPartialHomeomorph f).target := by
   intro y hy
-  refine (hf.contDiffAt_toOpenPartialHomeomorph_symm hy ?_ hn).contDiffWithinAt
+  refine (hf.contDiffAt_toOpenPartialHomeomorph_symm hy ?_).contDiffWithinAt
   exact hcont.contDiffAt ((hf.toOpenPartialHomeomorph f).open_source.mem_nhds
     ((hf.toOpenPartialHomeomorph f).map_target hy))
 
@@ -205,7 +209,7 @@ theorem ContDiffOn.exists_openPartialHomeomorph
   refine ⟨((hgAt a ha).toOpenPartialHomeomorph g he₀ hn0).restrOpen s hs, rfl,
     ⟨(hgAt a ha).mem_toOpenPartialHomeomorph_source he₀ hn0, ha⟩, fun y hy => hy.2, ?_⟩
   intro w hw
-  exact (hstrict.contDiffAt_toOpenPartialHomeomorph_symm hw.1 (hgAt _ hw.2) hn0).contDiffWithinAt
+  exact (hstrict.contDiffAt_toOpenPartialHomeomorph_symm hw.1 (hgAt _ hw.2)).contDiffWithinAt
 
 end TauCeti
 

--- a/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
+++ b/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
@@ -26,11 +26,12 @@ invertible by `ContinuousLinearMap.isInvertible_of_norm_sub_le_half`. This file 
 estimate and runs Mathlib's smooth inverse function theorem at every point of the target.
 
 Two forms are given. The first is about Mathlib's own homeomorphism, over an arbitrary
-nontrivially normed field and from strict differentiability alone; it is the form a consumer that
-cannot choose its homeomorphism — such as the implicit-function chart of a level set — needs. The
-second packages the classical statement over `ℝ` or `ℂ`: a `C^n` map with invertible derivative at
-a point of an open set `s` restricts to an `OpenPartialHomeomorph` inside `s` whose inverse is
-`C^n` on its target.
+nontrivially normed field: strict differentiability alone makes derivative invertibility persist,
+while inverse `C^n` regularity also assumes the corresponding `C^n` regularity of the map. It is
+the form a consumer that cannot choose its homeomorphism — such as the implicit-function chart of
+a level set — needs. The second packages the classical statement over `ℝ` or `ℂ`: a `C^n` map with
+invertible derivative at a point of an open set `s` restricts to an `OpenPartialHomeomorph` inside
+`s` whose inverse is `C^n` on its target.
 
 ## Main results
 

--- a/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
+++ b/TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean
@@ -86,8 +86,8 @@ theorem ApproximatesLinearOn.norm_sub_le_of_hasFDerivAt {f : E → F} {L A : E �
   exact hf y hy x hx
 
 /-- A continuous linear map that differs from a continuous linear equivalence `L` by less than
-`‖L⁻¹‖⁻¹` in operator norm is itself invertible: `L⁻¹A` is then `1` minus a contraction, hence a
-unit of the Banach algebra of endomorphisms of `E`. -/
+`‖L⁻¹‖⁻¹` in operator norm is itself invertible: `L⁻¹A` is close enough to `1` to be a unit of the
+Banach algebra of endomorphisms of `E`. -/
 theorem ContinuousLinearMap.isInvertible_of_norm_sub_lt [CompleteSpace E]
     (L : E ≃L[𝕜] F) {A : E →L[𝕜] F}
     (h : ‖A - (L : E →L[𝕜] F)‖₊ < ‖(L.symm : F →L[𝕜] E)‖₊⁻¹) : A.IsInvertible := by
@@ -100,18 +100,26 @@ theorem ContinuousLinearMap.isInvertible_of_norm_sub_lt [CompleteSpace E]
   have hreal : ‖A - (L : E →L[𝕜] F)‖ < ‖(L.symm : F →L[𝕜] E)‖⁻¹ := by
     rw [← NNReal.coe_lt_coe] at h
     simpa using h
-  set t : E →L[𝕜] E := (L.symm : F →L[𝕜] E).comp ((L : E →L[𝕜] F) - A) with ht
-  have hnorm : ‖t‖ < 1 :=
-    calc ‖t‖ ≤ ‖(L.symm : F →L[𝕜] E)‖ * ‖(L : E →L[𝕜] F) - A‖ :=
+  have hnorm : ‖(L.symm : F →L[𝕜] E).comp A - 1‖ < 1 :=
+    calc
+      ‖(L.symm : F →L[𝕜] E).comp A - 1‖ =
+          ‖(L.symm : F →L[𝕜] E).comp (A - (L : E →L[𝕜] F))‖ := by
+        congr 1
+        ext x
+        simp
+      _ ≤ ‖(L.symm : F →L[𝕜] E)‖ * ‖A - (L : E →L[𝕜] F)‖ :=
           ContinuousLinearMap.opNorm_comp_le _ _
-      _ = ‖(L.symm : F →L[𝕜] E)‖ * ‖A - (L : E →L[𝕜] F)‖ := by rw [norm_sub_rev]
       _ < ‖(L.symm : F →L[𝕜] E)‖ * ‖(L.symm : F →L[𝕜] E)‖⁻¹ :=
           mul_lt_mul_of_pos_left hreal hpos
       _ = 1 := mul_inv_cancel₀ hpos.ne'
-  refine ⟨(ContinuousLinearEquiv.unitsEquiv 𝕜 E (Units.oneSub t hnorm)).trans L, ?_⟩
+  let _ : Nontrivial E := not_subsingleton_iff_nontrivial.mp (by
+    intro hE
+    let _ := hE
+    exact hpos.ne' (norm_of_subsingleton _))
+  let u : (E →L[𝕜] E)ˣ := Units.ofNearby 1 ((L.symm : F →L[𝕜] E).comp A) (by simpa using hnorm)
+  refine ⟨(ContinuousLinearEquiv.unitsEquiv 𝕜 E u).trans L, ?_⟩
   ext x
-  have hx : L (t x) = L x - A x := by simp [ht]
-  simp [ContinuousLinearEquiv.unitsEquiv_apply, hx]
+  simp [u, ContinuousLinearEquiv.unitsEquiv_apply]
 
 /-- A continuous linear map within `‖L⁻¹‖⁻¹ / 2` of a continuous linear equivalence `L` is
 invertible. This is the shape in which Mathlib's inverse function theorem supplies the estimate. -/
@@ -150,9 +158,9 @@ theorem isInvertible_of_mem_toOpenPartialHomeomorph_source
   rwa [← NNReal.coe_le_coe, coe_nnnorm]
 
 /-- **The local inverse of the inverse function theorem is `C^n` at every point of its target.**
-Mathlib's `OpenPartialHomeomorph.contDiffAt_symm` gives this at the image of the base point only,
-because that is where invertibility of the derivative is assumed; it holds everywhere on the
-target because the derivative stays invertible on the source. -/
+The original inverse-function hypotheses provide an invertible derivative only at the base point.
+Here we prove the missing invertibility throughout the constructed source, then apply Mathlib's
+`OpenPartialHomeomorph.contDiffAt_symm` pointwise on the target. -/
 theorem contDiffAt_toOpenPartialHomeomorph_symm {n : ℕ∞ω}
     (hf : HasStrictFDerivAt f (L : E →L[𝕜] F) a) {y : F}
     (hy : y ∈ (hf.toOpenPartialHomeomorph f).target)

--- a/TauCeti/Analysis/Fredholm/LevelSet/Basic.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Basic.lean
@@ -9,6 +9,7 @@ public import Mathlib.Analysis.Calculus.Implicit
 public import Mathlib.Analysis.Calculus.FDeriv.Equiv
 public import Mathlib.Geometry.Manifold.ChartedSpace
 public import Mathlib.Topology.DiscreteSubset
+public import TauCeti.Analysis.Calculus.ImplicitFunctionTheorem
 public import TauCeti.Analysis.Fredholm.Criteria
 
 /-!
@@ -47,10 +48,10 @@ point `a` precisely when the index vanishes.
 What is proved is exactly a `ChartedSpace` structure, that is, a covering family of local models;
 nothing more is claimed. In particular this is *not* the assertion that the level set is a
 topological manifold in the usual sense, which would additionally need global hypotheses such as
-second countability, and none are assumed here. Nor are the charts claimed to be smoothly
-compatible: suitable `ContDiff` hypotheses on `f` should give smoothly compatible charts, through
-the `ContDiff` form of the implicit function theorem, but that is left to a later result, so no
-`IsManifold` instance is asserted either.
+second countability, and none are assumed here. Smooth compatibility of the charts, under a
+`ContDiff` hypothesis on `f`, is `TauCeti.isManifold_levelSet` in
+`TauCeti/Analysis/Fredholm/LevelSet/Manifold.lean`; the preferred charts installed below are
+already cut down to `TauCeti.levelSetRegularSet` so that they can be compared smoothly.
 
 ## Main declarations
 
@@ -59,6 +60,8 @@ the `ContDiff` form of the implicit function theorem, but that is left to a late
 * `ContinuousLinearMap.kerModelEquiv`: the identification of `ker f'` with the model space
   `Fin n → 𝕜`, when `ker f'` is finite-dimensional of dimension `n`.
 * `TauCeti.levelSetChartModel`: the chart read through that identification.
+* `TauCeti.levelSetRegularSet`: the neighbourhood of a point of the level set to which the
+  preferred chart there is cut down.
 * `TauCeti.levelSetChartedSpace`: a regular level set on which the index is constantly `n` is a
   charted space modelled on `Fin n → 𝕜`; by
   `TauCeti.ContinuousLinearMap.index_of_surjective` the model dimension is the Fredholm index.
@@ -362,19 +365,67 @@ theorem finrank_ker_eq_of_mem_levelSet
     {x : E} (hx : x ∈ {x | f x = c}) : finrank 𝕜 ↥(D x).ker = n :=
   (ContinuousLinearMap.finrank_ker_eq_iff_index_eq (D x) (hsurj x hx)).2 (hindex x hx)
 
+/-- The neighbourhood of a point `z` of a regular level set to which the preferred chart at `z` is
+cut down: the set on which the coordinate map of the implicit function theorem keeps an invertible
+derivative, `HasStrictFDerivAt.implicitRegularSet`, read inside the level set. -/
+noncomputable def levelSetRegularSet
+    (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
+    (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
+    (hker : ∀ x ∈ {x | f x = c}, (D x).ker.ClosedComplemented)
+    (z : ↥{x | f x = c}) : Set ↥{x | f x = c} :=
+  Subtype.val ⁻¹' (hf z.1 z.2).implicitRegularSet (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
+    (hker z.1 z.2)
+
+omit [CompleteSpace 𝕜] in
+theorem isOpen_levelSetRegularSet
+    (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
+    (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
+    (hker : ∀ x ∈ {x | f x = c}, (D x).ker.ClosedComplemented)
+    (z : ↥{x | f x = c}) : IsOpen (levelSetRegularSet hf hsurj hker z) :=
+  ((hf z.1 z.2).isOpen_implicitRegularSet _ _).preimage continuous_subtype_val
+
+omit [CompleteSpace 𝕜] in
+/-- Membership in `TauCeti.levelSetRegularSet` is membership of the ambient point in
+`HasStrictFDerivAt.implicitRegularSet`. -/
+theorem mem_levelSetRegularSet_iff
+    (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
+    (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
+    (hker : ∀ x ∈ {x | f x = c}, (D x).ker.ClosedComplemented)
+    (z u : ↥{x | f x = c}) :
+    u ∈ levelSetRegularSet hf hsurj hker z ↔
+      (u : E) ∈ (hf z.1 z.2).implicitRegularSet (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
+        (hker z.1 z.2) :=
+  Iff.rfl
+
+omit [CompleteSpace 𝕜] in
+theorem mem_levelSetRegularSet
+    (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
+    (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
+    (hker : ∀ x ∈ {x | f x = c}, (D x).ker.ClosedComplemented)
+    (z : ↥{x | f x = c}) : z ∈ levelSetRegularSet hf hsurj hker z :=
+  (hf z.1 z.2).mem_implicitRegularSet _ _
+
 /-- The preferred chart at a point of a regular level set along which the Fredholm index is
-constantly `n`. -/
+constantly `n`.
+
+It is the implicit-function chart `TauCeti.levelSetChartModel`, cut down to
+`TauCeti.levelSetRegularSet`. That restriction costs nothing — the set is an open neighbourhood of
+the base point — and it buys the smoothness that the inverse chart lacks away from its own centre,
+so that two of these charts can be smoothly compatible. -/
 noncomputable def levelSetChartAt
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
     (hFred : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.IsFredholm (D x))
     (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
     (hindex : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.index (D x) = n)
     (z : ↥{x | f x = c}) : OpenPartialHomeomorph ↥{x | f x = c} (Fin n → 𝕜) :=
-  levelSetChartModel (hf z.1 z.2) (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
+  (levelSetChartModel (hf z.1 z.2) (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
     (hFred z.1 z.2).closedComplemented_ker (hFred z.1 z.2).finite_ker
-    (finrank_ker_eq_of_mem_levelSet hsurj hindex z.2) z.2
+    (finrank_ker_eq_of_mem_levelSet hsurj hindex z.2) z.2).restrOpen
+      (levelSetRegularSet hf hsurj (fun x hx => (hFred x hx).closedComplemented_ker) z)
+      (isOpen_levelSetRegularSet hf hsurj (fun x hx => (hFred x hx).closedComplemented_ker) z)
 
-/-- The source of the preferred chart at `z` is the source of the chart of the level set at `z`. -/
+/-- The source of the preferred chart at `z` is the source of the chart of the level set at `z`,
+cut down to `TauCeti.levelSetRegularSet`. -/
 @[simp]
 theorem levelSetChartAt_source
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
@@ -384,11 +435,13 @@ theorem levelSetChartAt_source
     (z : ↥{x | f x = c}) :
     (levelSetChartAt hf hFred hsurj hindex z).source =
       (levelSetChart (hf z.1 z.2) (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
-        (hFred z.1 z.2).closedComplemented_ker z.2).source :=
-  levelSetChartModel_source _ _ _ _ _ _
+        (hFred z.1 z.2).closedComplemented_ker z.2).source ∩
+        levelSetRegularSet hf hsurj (fun x hx => (hFred x hx).closedComplemented_ker) z := by
+  rw [levelSetChartAt, OpenPartialHomeomorph.restrOpen_source, levelSetChartModel_source]
 
 /-- The target of the preferred chart at `z` is the target of the chart of the level set at `z`,
-pulled back along `ContinuousLinearMap.kerModelEquiv`. -/
+pulled back along `ContinuousLinearMap.kerModelEquiv`, cut down to the part of
+`TauCeti.levelSetRegularSet` that the chart sees. -/
 @[simp]
 theorem levelSetChartAt_target
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
@@ -400,8 +453,12 @@ theorem levelSetChartAt_target
       ((D z.1).kerModelEquiv (hFred z.1 z.2).finite_ker
           (finrank_ker_eq_of_mem_levelSet hsurj hindex z.2)).symm ⁻¹'
         (levelSetChart (hf z.1 z.2) (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
-          (hFred z.1 z.2).closedComplemented_ker z.2).target :=
-  levelSetChartModel_target _ _ _ _ _ _
+          (hFred z.1 z.2).closedComplemented_ker z.2).target ∩
+        (levelSetChartAt hf hFred hsurj hindex z).symm ⁻¹'
+          levelSetRegularSet hf hsurj (fun x hx => (hFred x hx).closedComplemented_ker) z := by
+  rw [levelSetChartAt, OpenPartialHomeomorph.restrOpen_toPartialEquiv,
+    PartialEquiv.restr_target, levelSetChartModel_target]
+  rfl
 
 /-- The preferred chart at `z` is the chart of the level set at `z`, read in the model space
 through `ContinuousLinearMap.kerModelEquiv`. -/
@@ -443,6 +500,16 @@ theorem levelSetChartAt_apply_self
     (z : ↥{x | f x = c}) : levelSetChartAt hf hFred hsurj hindex z z = 0 :=
   levelSetChartModel_apply_self _ _ _ _ _ _
 
+/-- The inverse of the preferred chart at `z` sends the origin of `Fin n → 𝕜` back to `z`. -/
+@[simp]
+theorem levelSetChartAt_symm_zero
+    (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
+    (hFred : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.IsFredholm (D x))
+    (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
+    (hindex : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.index (D x) = n)
+    (z : ↥{x | f x = c}) : (levelSetChartAt hf hFred hsurj hindex z).symm 0 = z := by
+  rw [levelSetChartAt_symm_apply, map_zero, levelSetChart_symm_zero]
+
 /- `mem_levelSetChartAt_source` and `mem_levelSetChartAt_target` are deliberately not `@[simp]`:
 the `@[simp]` lemmas `levelSetChartAt_source` and `levelSetChartAt_target` rewrite the set inside
 their statements first, so their left-hand sides are not in simp normal form and `simpNF` rejects
@@ -455,8 +522,9 @@ theorem mem_levelSetChartAt_source
     (hFred : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.IsFredholm (D x))
     (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
     (hindex : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.index (D x) = n)
-    (z : ↥{x | f x = c}) : z ∈ (levelSetChartAt hf hFred hsurj hindex z).source :=
-  mem_levelSetChartModel_source _ _ _ _ _ z.2
+    (z : ↥{x | f x = c}) : z ∈ (levelSetChartAt hf hFred hsurj hindex z).source := by
+  rw [levelSetChartAt_source]
+  exact ⟨mem_levelSetChart_source _ _ _ z.2, mem_levelSetRegularSet _ _ _ z⟩
 
 /-- The origin of `Fin n → 𝕜`, the value of the preferred chart at its base point, lies in its
 target. -/
@@ -465,8 +533,13 @@ theorem mem_levelSetChartAt_target
     (hFred : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.IsFredholm (D x))
     (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
     (hindex : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.index (D x) = n)
-    (z : ↥{x | f x = c}) : (0 : Fin n → 𝕜) ∈ (levelSetChartAt hf hFred hsurj hindex z).target :=
-  mem_levelSetChartModel_target _ _ _ _ _ z.2
+    (z : ↥{x | f x = c}) : (0 : Fin n → 𝕜) ∈ (levelSetChartAt hf hFred hsurj hindex z).target := by
+  rw [levelSetChartAt_target]
+  refine ⟨?_, ?_⟩
+  · rw [Set.mem_preimage, map_zero]
+    exact mem_levelSetChart_target _ _ _ z.2
+  · rw [Set.mem_preimage, levelSetChartAt_symm_zero]
+    exact mem_levelSetRegularSet _ _ _ z
 
 /-- **A regular level set of a Fredholm map is locally modelled on `Fin n → 𝕜`, `n` its index.**
 If `f` is strictly differentiable at every point of the level set `{x | f x = c}` with surjective

--- a/TauCeti/Analysis/Fredholm/LevelSet/Basic.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Basic.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Calculus.Implicit
 public import Mathlib.Analysis.Calculus.FDeriv.Equiv
 public import Mathlib.Geometry.Manifold.ChartedSpace
 public import Mathlib.Topology.DiscreteSubset
@@ -51,7 +50,7 @@ topological manifold in the usual sense, which would additionally need global hy
 second countability, and none are assumed here. Smooth compatibility of the charts, under a
 `ContDiff` hypothesis on `f`, is `TauCeti.isManifold_levelSet` in
 `TauCeti/Analysis/Fredholm/LevelSet/Manifold.lean`; the preferred charts installed below are
-already cut down to `TauCeti.levelSetRegularSet` so that they can be compared smoothly.
+already cut down to `TauCeti.levelSetImplicitCoordSource` so that they can be compared smoothly.
 
 ## Main declarations
 
@@ -60,7 +59,7 @@ already cut down to `TauCeti.levelSetRegularSet` so that they can be compared sm
 * `ContinuousLinearMap.kerModelEquiv`: the identification of `ker f'` with the model space
   `Fin n → 𝕜`, when `ker f'` is finite-dimensional of dimension `n`.
 * `TauCeti.levelSetChartModel`: the chart read through that identification.
-* `TauCeti.levelSetRegularSet`: the neighbourhood of a point of the level set to which the
+* `TauCeti.levelSetImplicitCoordSource`: the neighbourhood of a point of the level set to which the
   preferred chart there is cut down.
 * `TauCeti.levelSetChartedSpace`: a regular level set on which the index is constantly `n` is a
   charted space modelled on `Fin n → 𝕜`; by
@@ -367,51 +366,51 @@ theorem finrank_ker_eq_of_mem_levelSet
 
 /-- The neighbourhood of a point `z` of a regular level set to which the preferred chart at `z` is
 cut down: the set on which the coordinate map of the implicit function theorem keeps an invertible
-derivative, `HasStrictFDerivAt.implicitRegularSet`, read inside the level set. -/
-noncomputable def levelSetRegularSet
+derivative, `HasStrictFDerivAt.implicitCoordSource`, read inside the level set. -/
+noncomputable def levelSetImplicitCoordSource
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
     (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
     (hker : ∀ x ∈ {x | f x = c}, (D x).ker.ClosedComplemented)
     (z : ↥{x | f x = c}) : Set ↥{x | f x = c} :=
-  Subtype.val ⁻¹' (hf z.1 z.2).implicitRegularSet (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
+  Subtype.val ⁻¹' (hf z.1 z.2).implicitCoordSource (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
     (hker z.1 z.2)
 
 omit [CompleteSpace 𝕜] in
-theorem isOpen_levelSetRegularSet
+theorem isOpen_levelSetImplicitCoordSource
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
     (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
     (hker : ∀ x ∈ {x | f x = c}, (D x).ker.ClosedComplemented)
-    (z : ↥{x | f x = c}) : IsOpen (levelSetRegularSet hf hsurj hker z) :=
-  ((hf z.1 z.2).isOpen_implicitRegularSet _ _).preimage continuous_subtype_val
+    (z : ↥{x | f x = c}) : IsOpen (levelSetImplicitCoordSource hf hsurj hker z) :=
+  ((hf z.1 z.2).isOpen_implicitCoordSource _ _).preimage continuous_subtype_val
 
 omit [CompleteSpace 𝕜] in
-/-- Membership in `TauCeti.levelSetRegularSet` is membership of the ambient point in
-`HasStrictFDerivAt.implicitRegularSet`. -/
-theorem mem_levelSetRegularSet_iff
+/-- Membership in `TauCeti.levelSetImplicitCoordSource` is membership of the ambient point in
+`HasStrictFDerivAt.implicitCoordSource`. -/
+theorem mem_levelSetImplicitCoordSource_iff
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
     (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
     (hker : ∀ x ∈ {x | f x = c}, (D x).ker.ClosedComplemented)
     (z u : ↥{x | f x = c}) :
-    u ∈ levelSetRegularSet hf hsurj hker z ↔
-      (u : E) ∈ (hf z.1 z.2).implicitRegularSet (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
+    u ∈ levelSetImplicitCoordSource hf hsurj hker z ↔
+      (u : E) ∈ (hf z.1 z.2).implicitCoordSource (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
         (hker z.1 z.2) :=
   Iff.rfl
 
 omit [CompleteSpace 𝕜] in
-theorem mem_levelSetRegularSet
+theorem mem_levelSetImplicitCoordSource
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
     (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
     (hker : ∀ x ∈ {x | f x = c}, (D x).ker.ClosedComplemented)
-    (z : ↥{x | f x = c}) : z ∈ levelSetRegularSet hf hsurj hker z :=
-  (hf z.1 z.2).mem_implicitRegularSet _ _
+    (z : ↥{x | f x = c}) : z ∈ levelSetImplicitCoordSource hf hsurj hker z :=
+  (hf z.1 z.2).mem_implicitCoordSource _ _
 
 /-- The preferred chart at a point of a regular level set along which the Fredholm index is
 constantly `n`.
 
 It is the implicit-function chart `TauCeti.levelSetChartModel`, cut down to
-`TauCeti.levelSetRegularSet`. That restriction costs nothing — the set is an open neighbourhood of
-the base point — and it buys the smoothness that the inverse chart lacks away from its own centre,
-so that two of these charts can be smoothly compatible. -/
+`TauCeti.levelSetImplicitCoordSource`. That restriction costs nothing — the set is an open
+neighbourhood of the base point — and it buys the smoothness that the inverse chart lacks away from
+its own centre, so that two of these charts can be smoothly compatible. -/
 noncomputable def levelSetChartAt
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
     (hFred : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.IsFredholm (D x))
@@ -421,11 +420,12 @@ noncomputable def levelSetChartAt
   (levelSetChartModel (hf z.1 z.2) (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
     (hFred z.1 z.2).closedComplemented_ker (hFred z.1 z.2).finite_ker
     (finrank_ker_eq_of_mem_levelSet hsurj hindex z.2) z.2).restrOpen
-      (levelSetRegularSet hf hsurj (fun x hx => (hFred x hx).closedComplemented_ker) z)
-      (isOpen_levelSetRegularSet hf hsurj (fun x hx => (hFred x hx).closedComplemented_ker) z)
+      (levelSetImplicitCoordSource hf hsurj (fun x hx => (hFred x hx).closedComplemented_ker) z)
+      (isOpen_levelSetImplicitCoordSource hf hsurj
+        (fun x hx => (hFred x hx).closedComplemented_ker) z)
 
 /-- The source of the preferred chart at `z` is the source of the chart of the level set at `z`,
-cut down to `TauCeti.levelSetRegularSet`. -/
+cut down to `TauCeti.levelSetImplicitCoordSource`. -/
 @[simp]
 theorem levelSetChartAt_source
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
@@ -436,12 +436,13 @@ theorem levelSetChartAt_source
     (levelSetChartAt hf hFred hsurj hindex z).source =
       (levelSetChart (hf z.1 z.2) (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
         (hFred z.1 z.2).closedComplemented_ker z.2).source ∩
-        levelSetRegularSet hf hsurj (fun x hx => (hFred x hx).closedComplemented_ker) z := by
+        levelSetImplicitCoordSource hf hsurj
+          (fun x hx => (hFred x hx).closedComplemented_ker) z := by
   rw [levelSetChartAt, OpenPartialHomeomorph.restrOpen_source, levelSetChartModel_source]
 
 /-- The target of the preferred chart at `z` is the target of the chart of the level set at `z`,
 pulled back along `ContinuousLinearMap.kerModelEquiv`, cut down to the part of
-`TauCeti.levelSetRegularSet` that the chart sees. -/
+`TauCeti.levelSetImplicitCoordSource` that the chart sees. -/
 @[simp]
 theorem levelSetChartAt_target
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
@@ -455,7 +456,8 @@ theorem levelSetChartAt_target
         (levelSetChart (hf z.1 z.2) (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
           (hFred z.1 z.2).closedComplemented_ker z.2).target ∩
         (levelSetChartAt hf hFred hsurj hindex z).symm ⁻¹'
-          levelSetRegularSet hf hsurj (fun x hx => (hFred x hx).closedComplemented_ker) z := by
+          levelSetImplicitCoordSource hf hsurj
+            (fun x hx => (hFred x hx).closedComplemented_ker) z := by
   rw [levelSetChartAt, OpenPartialHomeomorph.restrOpen_toPartialEquiv,
     PartialEquiv.restr_target, levelSetChartModel_target]
   rfl
@@ -524,7 +526,7 @@ theorem mem_levelSetChartAt_source
     (hindex : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.index (D x) = n)
     (z : ↥{x | f x = c}) : z ∈ (levelSetChartAt hf hFred hsurj hindex z).source := by
   rw [levelSetChartAt_source]
-  exact ⟨mem_levelSetChart_source _ _ _ z.2, mem_levelSetRegularSet _ _ _ z⟩
+  exact ⟨mem_levelSetChart_source _ _ _ z.2, mem_levelSetImplicitCoordSource _ _ _ z⟩
 
 /-- The origin of `Fin n → 𝕜`, the value of the preferred chart at its base point, lies in its
 target. -/
@@ -539,7 +541,7 @@ theorem mem_levelSetChartAt_target
   · rw [Set.mem_preimage, map_zero]
     exact mem_levelSetChart_target _ _ _ z.2
   · rw [Set.mem_preimage, levelSetChartAt_symm_zero]
-    exact mem_levelSetRegularSet _ _ _ z
+    exact mem_levelSetImplicitCoordSource _ _ _ z
 
 /-- **A regular level set of a Fredholm map is locally modelled on `Fin n → 𝕜`, `n` its index.**
 If `f` is strictly differentiable at every point of the level set `{x | f x = c}` with surjective

--- a/TauCeti/Analysis/Fredholm/LevelSet/Basic.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Basic.lean
@@ -386,6 +386,7 @@ theorem isOpen_levelSetImplicitCoordSource
 omit [CompleteSpace 𝕜] in
 /-- Membership in `TauCeti.levelSetImplicitCoordSource` is membership of the ambient point in
 `HasStrictFDerivAt.implicitCoordSource`. -/
+@[simp]
 theorem mem_levelSetImplicitCoordSource_iff
     (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
     (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))

--- a/TauCeti/Analysis/Fredholm/LevelSet/Manifold.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Manifold.lean
@@ -24,14 +24,14 @@ The transition from the chart at `z` to the chart at `w` is
 projection onto `ker (D w)`. So everything reduces to smoothness of the inverse chart as a map
 into `E`, which is `TauCeti.contDiffAt_coe_levelSetChart_symm_of_mem`: the inverse chart is smooth
 at every point of its target, because `TauCeti.levelSetChartAt` was cut down to the neighbourhood
-`TauCeti.levelSetRegularSet` on which the coordinate map of the implicit function theorem keeps an
-invertible derivative.
+`TauCeti.levelSetImplicitCoordSource` on which the coordinate map of the implicit function theorem
+keeps an invertible derivative.
 
-This completes the local half of the "a moduli space is the zero set of a Fredholm section, and at
-a regular point it is a manifold of dimension the index" package of Lane F0 of the analytic
-Heegaard Floer roadmap. As with the charted-space structure it refines, no global hypothesis such
-as second countability is assumed, so `IsManifold` here is the smooth-atlas statement and not the
-assertion that the level set is a topological manifold in the classical sense.
+This is the smooth half of the statement that the zero set of a Fredholm section is, at a regular
+point, a manifold of dimension the index. As with the charted-space structure it refines, no
+global hypothesis such as second countability is assumed, so `IsManifold` here is the smooth-atlas
+statement and not the assertion that the level set is a topological manifold in the classical
+sense.
 
 ## Main results
 
@@ -89,7 +89,7 @@ theorem contDiffOn_coe_levelSetChartAt_symm
     refine contDiffAt_coe_levelSetChart_symm_of_mem _ _ _ _ hk.1 ?_ (A := D u.1)
       ((hf u.1 u.2).hasFDerivAt) (hsmooth u.1 u.2)
     have hmem := hk.2
-    rw [Set.mem_preimage, mem_levelSetRegularSet_iff, hpt k] at hmem
+    rw [Set.mem_preimage, mem_levelSetImplicitCoordSource_iff, hpt k] at hmem
     exact hmem
   exact (hinner.comp k
     ((K.symm : (Fin n → 𝕜) →L[𝕜] ↥(D z.1).ker).contDiff.contDiffAt)).contDiffWithinAt

--- a/TauCeti/Analysis/Fredholm/LevelSet/Manifold.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Manifold.lean
@@ -1,0 +1,161 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Geometry.Manifold.IsManifold.Basic
+public import TauCeti.Analysis.Fredholm.LevelSet.Smooth
+
+/-!
+# A regular level set of a Fredholm map is a manifold
+
+Let `f : E → F` be a map between Banach spaces which, at every point of the level set
+`{x | f x = c}`, is strictly differentiable and `C^m`, with surjective Fredholm derivative of
+index `n`. `TauCeti.levelSetChartedSpace` already makes that level set a charted space modelled on
+`Fin n → 𝕜`, the charts being the implicit-function charts of `TauCeti.levelSetChartAt`. This file
+proves that those charts are smoothly compatible, so the level set is a `C^m` manifold of
+dimension the index.
+
+The transition from the chart at `z` to the chart at `w` is
+`k ↦ Ψ (x k - w)`, where `x k` is the point of the level set with coordinate `k` in the chart at
+`z`, and `Ψ` is the continuous linear map that reads a vector of `E` in the model space through the
+projection onto `ker (D w)`. So everything reduces to smoothness of the inverse chart as a map
+into `E`, which is `TauCeti.contDiffAt_coe_levelSetChart_symm_of_mem`: the inverse chart is smooth
+at every point of its target, because `TauCeti.levelSetChartAt` was cut down to the neighbourhood
+`TauCeti.levelSetRegularSet` on which the coordinate map of the implicit function theorem keeps an
+invertible derivative.
+
+This completes the local half of the "a moduli space is the zero set of a Fredholm section, and at
+a regular point it is a manifold of dimension the index" package of Lane F0 of the analytic
+Heegaard Floer roadmap. As with the charted-space structure it refines, no global hypothesis such
+as second countability is assumed, so `IsManifold` here is the smooth-atlas statement and not the
+assertion that the level set is a topological manifold in the classical sense.
+
+## Main results
+
+* `TauCeti.contDiffOn_coe_levelSetChartAt_symm`: the inverse of a preferred chart, included into
+  the ambient Banach space, is `C^m` on the whole chart target.
+* `TauCeti.contDiffOn_levelSetChartAt_trans`: the transition between two preferred charts is
+  `C^m`.
+* `TauCeti.isManifold_levelSet`: a regular level set of a `C^m` Fredholm map, of constant index
+  `n`, is a `C^m` manifold modelled on `Fin n → 𝕜`.
+
+## References
+
+* D. McDuff, D. Salamon, *J-holomorphic Curves and Symplectic Topology*, 2nd ed., AMS Colloquium
+  Publications 52, 2012, Appendix A.3.
+-/
+
+public section
+
+namespace TauCeti
+
+open Set
+open scoped ContDiff Topology
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] [CompleteSpace F]
+  {f : E → F} {c : F} {D : E → E →L[𝕜] F} {n : ℕ} {m : ℕ∞ω}
+
+/-- **The inverse of a preferred chart is smooth on the whole chart target.** Read into the
+ambient Banach space, the inverse of `TauCeti.levelSetChartAt` is as smooth as the equation is
+along the level set. -/
+theorem contDiffOn_coe_levelSetChartAt_symm
+    (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
+    (hFred : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.IsFredholm (D x))
+    (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
+    (hindex : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.index (D x) = n)
+    (hsmooth : ∀ x ∈ {x | f x = c}, ContDiffAt 𝕜 m f x) (z : ↥{x | f x = c}) :
+    ContDiffOn 𝕜 m
+      (fun k ↦ (((levelSetChartAt hf hFred hsurj hindex z).symm k : ↥{x | f x = c}) : E))
+      (levelSetChartAt hf hFred hsurj hindex z).target := by
+  set K := (D z.1).kerModelEquiv (hFred z.1 z.2).finite_ker
+    (finrank_ker_eq_of_mem_levelSet hsurj hindex z.2)
+  set chart := levelSetChart (hf z.1 z.2) (LinearMap.range_eq_top.2 (hsurj z.1 z.2))
+    (hFred z.1 z.2).closedComplemented_ker z.2
+  have hpt : ∀ j : Fin n → 𝕜,
+      (((levelSetChartAt hf hFred hsurj hindex z).symm j : ↥{x | f x = c}) : E) =
+        ((chart.symm (K.symm j) : ↥{x | f x = c}) : E) := fun j ↦ by
+    rw [levelSetChartAt_symm_apply]
+  refine ContDiffOn.congr ?_ fun j _ ↦ hpt j
+  intro k hk
+  rw [levelSetChartAt_target] at hk
+  set u := (chart.symm (K.symm k) : ↥{x | f x = c})
+  have hinner : ContDiffAt 𝕜 m
+      (fun j ↦ ((chart.symm j : ↥{x | f x = c}) : E)) (K.symm k) := by
+    refine contDiffAt_coe_levelSetChart_symm_of_mem _ _ _ _ hk.1 ?_ (A := D u.1)
+      ((hf u.1 u.2).hasFDerivAt) (hsmooth u.1 u.2)
+    have hmem := hk.2
+    rw [Set.mem_preimage, mem_levelSetRegularSet_iff, hpt k] at hmem
+    exact hmem
+  exact (hinner.comp k
+    ((K.symm : (Fin n → 𝕜) →L[𝕜] ↥(D z.1).ker).contDiff.contDiffAt)).contDiffWithinAt
+
+/-- **Two preferred charts of a regular level set are smoothly compatible.** The transition map is
+the inverse of one chart, followed by the linear reading of a vector of `E` in the model space
+that the other chart is. -/
+theorem contDiffOn_levelSetChartAt_trans
+    (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
+    (hFred : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.IsFredholm (D x))
+    (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
+    (hindex : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.index (D x) = n)
+    (hsmooth : ∀ x ∈ {x | f x = c}, ContDiffAt 𝕜 m f x) (z w : ↥{x | f x = c}) :
+    ContDiffOn 𝕜 m
+      ((levelSetChartAt hf hFred hsurj hindex z).symm.trans
+        (levelSetChartAt hf hFred hsurj hindex w))
+      ((levelSetChartAt hf hFred hsurj hindex z).symm.trans
+        (levelSetChartAt hf hFred hsurj hindex w)).source := by
+  set e := levelSetChartAt hf hFred hsurj hindex z
+  set e' := levelSetChartAt hf hFred hsurj hindex w with he'
+  -- the linear map reading a vector of `E` in the model space of the chart at `w`
+  set Ψ : E →L[𝕜] (Fin n → 𝕜) :=
+    ((D w.1).kerModelEquiv (hFred w.1 w.2).finite_ker
+      (finrank_ker_eq_of_mem_levelSet hsurj hindex w.2) :
+        ↥(D w.1).ker →L[𝕜] (Fin n → 𝕜)).comp
+      (Classical.choose (hFred w.1 w.2).closedComplemented_ker) with hΨ
+  have hsub : (e.symm.trans e').source ⊆ e.target := fun k hk ↦ hk.1
+  have hbase : ContDiffOn 𝕜 m (fun k ↦ ((e.symm k : ↥{x | f x = c}) : E))
+      (e.symm.trans e').source :=
+    (contDiffOn_coe_levelSetChartAt_symm hf hFred hsurj hindex hsmooth z).mono hsub
+  have hconst : ContDiffOn 𝕜 m (fun _ : Fin n → 𝕜 ↦ ((w : ↥{x | f x = c}) : E))
+      (e.symm.trans e').source := contDiffOn_const
+  have h2 : ContDiffOn 𝕜 m
+      (fun k ↦ Ψ (((e.symm k : ↥{x | f x = c}) : E) - ((w : ↥{x | f x = c}) : E)))
+      (e.symm.trans e').source := by
+    simpa only [Function.comp_def] using Ψ.contDiff.comp_contDiffOn (hbase.sub hconst)
+  refine h2.congr fun k _ ↦ ?_
+  simp only [OpenPartialHomeomorph.coe_trans, Function.comp_apply, he', levelSetChartAt_apply,
+    levelSetChart_apply, hΨ, ContinuousLinearMap.coe_comp, Function.comp_apply,
+    ContinuousLinearEquiv.coe_coe]
+
+/-- **A regular level set of a Fredholm map is a `C^m` manifold of dimension its index.** If `f` is
+strictly differentiable and `C^m` at every point of the level set `{x | f x = c}`, with surjective
+Fredholm derivative of index `n` there, then the charted-space structure of
+`TauCeti.levelSetChartedSpace` is a `C^m` atlas.
+
+Together with `TauCeti.levelSetChartedSpace` this is the "the zero set of a Fredholm section is,
+at a regular point, a manifold of dimension the index" statement; as there, no global hypothesis
+is assumed, so this is a statement about the atlas and not about second countability. -/
+theorem isManifold_levelSet
+    (hf : ∀ x ∈ {x | f x = c}, HasStrictFDerivAt f (D x) x)
+    (hFred : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.IsFredholm (D x))
+    (hsurj : ∀ x ∈ {x | f x = c}, Function.Surjective (D x))
+    (hindex : ∀ x ∈ {x | f x = c}, ContinuousLinearMap.index (D x) = n)
+    (hsmooth : ∀ x ∈ {x | f x = c}, ContDiffAt 𝕜 m f x) :
+    letI := levelSetChartedSpace hf hFred hsurj hindex
+    IsManifold (modelWithCornersSelf 𝕜 (Fin n → 𝕜)) m ↥{x | f x = c} := by
+  let _i := levelSetChartedSpace hf hFred hsurj hindex
+  refine isManifold_of_contDiffOn _ _ _ fun e e' he he' ↦ ?_
+  rw [levelSetChartedSpace_atlas] at he he'
+  obtain ⟨z, rfl⟩ := he
+  obtain ⟨w, rfl⟩ := he'
+  simpa only [modelWithCornersSelf_coe, modelWithCornersSelf_coe_symm, Set.range_id,
+    Set.inter_univ, Set.preimage_id, Function.comp_id, Function.id_comp] using
+    contDiffOn_levelSetChartAt_trans hf hFred hsurj hindex hsmooth z w
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Fredholm/LevelSet/Smooth.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Smooth.lean
@@ -27,8 +27,15 @@ geometric organization follows McDuff--Salamon, *J-holomorphic Curves and Symple
 Together with `ContinuousLinearMap.IsFredholm.closedComplemented_ker_coprod`, which supplies the
 complemented kernel of a surjective linearization whose fixed-parameter part is Fredholm, these
 are the pointwise smoothness and derivative computation from which the smooth local input to the
-parameter projection and Sard--Smale arguments in the analytic Heegaard Floer roadmap is to be
-assembled; smooth compatibility of the charts of a whole level set is not proved here.
+parameter projection and Sard--Smale arguments in the analytic Heegaard Floer roadmap is
+assembled.
+
+Smoothness at the origin alone does not let two charts of the same level set be compared; the
+final theorem removes that restriction. It is `C^n` at every point of the chart target whose
+image lies in `HasStrictFDerivAt.implicitRegularSet`, the neighbourhood of the base point on which
+the coordinate map of the implicit function theorem keeps an invertible derivative. Since that
+neighbourhood is open and contains the base point, the inverse chart is smooth on a whole
+neighbourhood of its origin, which is what smooth compatibility of charts needs.
 
 ## Main results
 
@@ -36,6 +43,8 @@ assembled; smooth compatibility of the charts of a whole level set is not proved
   the ambient Banach space, is smooth at its origin.
 * `TauCeti.hasStrictFDerivAt_coe_levelSetChart_symm`: its derivative there is the inclusion of the
   derivative's kernel.
+* `TauCeti.contDiffAt_coe_levelSetChart_symm_of_mem`: it is smooth at every point of the chart
+  target that the coordinate map's regular neighbourhood covers.
 -/
 
 public section
@@ -84,6 +93,48 @@ theorem hasStrictFDerivAt_coe_levelSetChart_symm (hf : HasStrictFDerivAt f f' a)
     (mem_levelSetChart_target hf hf' hker rfl),
     hf.eventually_implicitFunctionOfComplemented_eq hf' hker] with k hk hbridge
   rw [levelSetChart_symm_apply hf hf' hker rfl hk, hbridge]
+
+/-- **The inverse regular-level-set chart is smooth away from its centre as well.** At a point `k`
+of the chart target whose image lies in the neighbourhood
+`HasStrictFDerivAt.implicitRegularSet` on which the implicit-function coordinate map keeps an
+invertible derivative, the inverse chart is as smooth as the equation is there.
+
+`TauCeti.contDiffAt_coe_levelSetChart_symm` is the case `k = 0`, where the hypotheses hold
+automatically. -/
+theorem contDiffAt_coe_levelSetChart_symm_of_mem {n : ℕ∞ω} (hf : HasStrictFDerivAt f f' a)
+    (hf' : f'.range = ⊤) (hker : f'.ker.ClosedComplemented) (ha : f a = c) {k : ↥f'.ker}
+    (hk : k ∈ (levelSetChart hf hf' hker ha).target)
+    (hmem : (((levelSetChart hf hf' hker ha).symm k : ↥{x | f x = c}) : E) ∈
+      hf.implicitRegularSet hf' hker)
+    {A : E →L[K] F}
+    (hA : HasFDerivAt f A (((levelSetChart hf hf' hker ha).symm k : ↥{x | f x = c}) : E))
+    (hcont : ContDiffAt K n f (((levelSetChart hf hf' hker ha).symm k : ↥{x | f x = c}) : E)) :
+    ContDiffAt K n
+      (fun k ↦ (((levelSetChart hf hf' hker ha).symm k : ↥{x | f x = c}) : E)) k := by
+  subst c
+  have hktarget : (f a, k) ∈
+      (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).target := by
+    have hk' := hk
+    rwa [levelSetChart_target, Set.mem_preimage] at hk'
+  have hval : (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm (f a, k) =
+      (((levelSetChart hf hf' hker rfl).symm k : ↥{x | f x = f a}) : E) :=
+    (levelSetChart_symm_apply hf hf' hker rfl hk).symm
+  have hinverse : ContDiffAt K n
+      (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm (f a, k) := by
+    refine hf.contDiffAt_implicitToOpenPartialHomeomorphOfComplemented_symm_of_mem hf' hker
+      hktarget ?_ (A := A) ?_ ?_
+    · rw [hval]; exact hmem
+    · rw [hval]; exact hA
+    · rw [hval]; exact hcont
+  have hslice : ContDiffAt K n
+      (fun k' : ↥f'.ker ↦
+        (hf.implicitToOpenPartialHomeomorphOfComplemented f f' hf' hker).symm (f a, k')) k := by
+    have hinner : ContDiffAt K n (fun k' : ↥f'.ker ↦ (f a, k')) k :=
+      contDiffAt_const.prodMk contDiffAt_id
+    simpa only [Function.comp_def] using hinverse.comp k hinner
+  apply hslice.congr_of_eventuallyEq
+  filter_upwards [(levelSetChart hf hf' hker rfl).open_target.mem_nhds hk] with k' hk'
+  exact levelSetChart_symm_apply hf hf' hker rfl hk'
 
 end TauCeti
 

--- a/TauCeti/Analysis/Fredholm/LevelSet/Smooth.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Smooth.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.Calculus.ImplicitFunctionTheorem
 public import TauCeti.Analysis.Fredholm.LevelSet.Basic
 import Mathlib.Analysis.Calculus.ContDiff.Operations
 
@@ -27,12 +26,11 @@ geometric organization follows McDuff--Salamon, *J-holomorphic Curves and Symple
 Together with `ContinuousLinearMap.IsFredholm.closedComplemented_ker_coprod`, which supplies the
 complemented kernel of a surjective linearization whose fixed-parameter part is Fredholm, these
 are the pointwise smoothness and derivative computation from which the smooth local input to the
-parameter projection and Sard--Smale arguments in the analytic Heegaard Floer roadmap is
-assembled.
+parameter projection and Sard--Smale arguments is assembled.
 
 Smoothness at the origin alone does not let two charts of the same level set be compared; the
 final theorem removes that restriction. It is `C^n` at every point of the chart target whose
-image lies in `HasStrictFDerivAt.implicitRegularSet`, the neighbourhood of the base point on which
+image lies in `HasStrictFDerivAt.implicitCoordSource`, the neighbourhood of the base point on which
 the coordinate map of the implicit function theorem keeps an invertible derivative. Since that
 neighbourhood is open and contains the base point, the inverse chart is smooth on a whole
 neighbourhood of its origin, which is what smooth compatibility of charts needs.
@@ -44,7 +42,7 @@ neighbourhood of its origin, which is what smooth compatibility of charts needs.
 * `TauCeti.hasStrictFDerivAt_coe_levelSetChart_symm`: its derivative there is the inclusion of the
   derivative's kernel.
 * `TauCeti.contDiffAt_coe_levelSetChart_symm_of_mem`: it is smooth at every point of the chart
-  target that the coordinate map's regular neighbourhood covers.
+  target that the coordinate map's invertibility neighbourhood covers.
 -/
 
 public section
@@ -96,7 +94,7 @@ theorem hasStrictFDerivAt_coe_levelSetChart_symm (hf : HasStrictFDerivAt f f' a)
 
 /-- **The inverse regular-level-set chart is smooth away from its centre as well.** At a point `k`
 of the chart target whose image lies in the neighbourhood
-`HasStrictFDerivAt.implicitRegularSet` on which the implicit-function coordinate map keeps an
+`HasStrictFDerivAt.implicitCoordSource` on which the implicit-function coordinate map keeps an
 invertible derivative, the inverse chart is as smooth as the equation is there.
 
 `TauCeti.contDiffAt_coe_levelSetChart_symm` is the case `k = 0`, where the hypotheses hold
@@ -105,7 +103,7 @@ theorem contDiffAt_coe_levelSetChart_symm_of_mem {n : ℕ∞ω} (hf : HasStrictF
     (hf' : f'.range = ⊤) (hker : f'.ker.ClosedComplemented) (ha : f a = c) {k : ↥f'.ker}
     (hk : k ∈ (levelSetChart hf hf' hker ha).target)
     (hmem : (((levelSetChart hf hf' hker ha).symm k : ↥{x | f x = c}) : E) ∈
-      hf.implicitRegularSet hf' hker)
+      hf.implicitCoordSource hf' hker)
     {A : E →L[K] F}
     (hA : HasFDerivAt f A (((levelSetChart hf hf' hker ha).symm k : ↥{x | f x = c}) : E))
     (hcont : ContDiffAt K n f (((levelSetChart hf hf' hker ha).symm k : ↥{x | f x = c}) : E)) :


### PR DESCRIPTION
This PR proves that a regular level set of a Fredholm map is a `C^m` manifold of dimension the Fredholm index: `TauCeti.isManifold_levelSet` shows that the implicit-function charts already installed by `TauCeti.levelSetChartedSpace` are smoothly compatible. It serves Lane F0 of the HeegaardFloer roadmap, whose milestone asks for the "moduli space = zero set of a Fredholm section, generically a manifold of dimension = index" package (McDuff–Salamon, *J-holomorphic Curves and Symplectic Topology*, 2nd ed., Appendix A.3); after this PR that milestone still owes the Fredholm property of `d/ds + A(s)` on the strip with invertible asymptotics, which waits on Lane F1's Sobolev spaces.

The gap this closes is one that both `TauCeti/Analysis/Fredholm/LevelSet/Basic.lean` and `TauCeti/Analysis/Fredholm/LevelSet/Smooth.lean` flagged in their own docstrings: the inverse chart was known to be `C^m` only at its own centre, and a chart whose inverse is smooth at one point cannot be compared smoothly with a neighbouring chart. The obstruction is that Mathlib's `OpenPartialHomeomorph.contDiffAt_symm` needs the derivative to be invertible at the point one inverts around, and the inverse function theorem assumes invertibility at the base point only. It is nevertheless true throughout: Mathlib builds the homeomorphism through `ApproximatesLinearOn`, whose source is an open set on which the map approximates its derivative `L` at the base point with the constant `‖L⁻¹‖⁻¹ / 2`, and on such a set every Fréchet derivative is within that constant of `L`, hence invertible by a Neumann series. So the local inverse is `C^m` on its whole target, with no shrinking, over an arbitrary nontrivially normed field and from strict differentiability alone.

`TauCeti/Analysis/Calculus/InverseFunctionTheorem.lean` gains that chain — `ApproximatesLinearOn.norm_sub_le_of_hasFDerivAt`, `ContinuousLinearMap.isInvertible_of_norm_sub_lt`, `HasStrictFDerivAt.approximatesLinearOn_toOpenPartialHomeomorph_source`, `HasStrictFDerivAt.isInvertible_of_mem_toOpenPartialHomeomorph_source` and `HasStrictFDerivAt.contDiffAt_toOpenPartialHomeomorph_symm` / `contDiffOn_toOpenPartialHomeomorph_symm`. The file's existing `TauCeti.ContDiffOn.exists_openPartialHomeomorph` (Hopf–Rinow Layer 1, unchanged in statement) now takes its inverse smoothness from those results and restricts to the given open set `s` rather than to the locus where the derivative is invertible; that makes its former helper `TauCeti.isOpen_inter_preimage_range_continuousLinearEquiv_fderiv` unnecessary, so it is removed, and the `[CompleteSpace F]` hypothesis is no longer needed anywhere.

`TauCeti/Analysis/Calculus/ImplicitFunctionTheorem.lean` transports this to the complemented-kernel implicit function theorem: `ContinuousLinearMap.implicitCoordEquiv` names the derivative `x ↦ (f' x, P x)` of the coordinate map (previously an anonymous `let` inside one proof), `HasStrictFDerivAt.implicitCoordSource` is the open neighbourhood of the base point on which that derivative stays invertible, and the inverse homeomorphism is `C^m` at every point of the target lying over it. The old base-point statement is now the special case where the invertibility is the theorem's own hypothesis. `TauCeti/Analysis/Fredholm/LevelSet/Smooth.lean` reads this on the level set as `contDiffAt_coe_levelSetChart_symm_of_mem`.

Because the inverse chart is smooth only over `implicitCoordSource`, `TauCeti.levelSetChartAt` — the *preferred* chart of `TauCeti.levelSetChartedSpace` — is now cut down to `TauCeti.levelSetImplicitCoordSource`, that neighbourhood read inside the level set. The restriction costs nothing: the set is open and contains the base point, so the same hypotheses give the same charted space, and `TauCeti.levelSetChart`, `levelSetChartModel` and the parametric Sard–Smale file are untouched. Its `source` and `target` lemmas acquire the intersection; `levelSetChartAt_symm_zero` is added. The new `TauCeti/Analysis/Fredholm/LevelSet/Manifold.lean` then computes the transition map from the chart at `z` to the chart at `w` as `k ↦ Ψ (x k - w)`, with `Ψ` the continuous linear map reading a vector of `E` in the model space through the projection onto `ker (D w)`, and concludes with Mathlib's `isManifold_of_contDiffOn`. As with the charted-space structure it refines, no global hypothesis such as second countability is assumed, so this is the smooth-atlas statement and not the classical topological-manifold one.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"regular-fredholm-level-set-smooth-manifold"}-->

🤖 Prepared with Claude Code

