### PR TITLE
feat(FunctionField): evaluate a function on a divisor, for Weil reciprocity

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -31,8 +31,8 @@ classical regime — the divisor and function laws are formal and hold for every
 ## Main definitions
 
 * `TauCeti.Divisor.eval`: `f(D)`, as a unit of `k`.
-* `TauCeti.Divisor.evalHom`: the same as a bundled homomorphism in the divisor variable, which is
-  what makes the divisor laws below hypothesis-free and what a consumer composes or transports.
+* `TauCeti.Divisor.evalHom`: the same as a bundled homomorphism in the divisor variable, so the
+  divisor laws below hold with no admissibility hypothesis.
 * `TauCeti.Divisor.IsUnitAtSupport`: the admissibility condition — `f` is a unit at every place of
   `D`. This is exactly disjointness of `D` from the divisor of `f`
   (`isUnitAtSupport_iff_disjoint`).
@@ -70,11 +70,11 @@ has to survive that. With `0` as the neutral value in `k` it does not: at a plac
 unit, `eval (single P 1) * eval (single P (-1))` would be `0` while `eval 0 = 1`. In `kˣ` every
 `zpow` identity holds unconditionally and the law is automatic.
 
-**The definition is total, with the admissibility hypothesis carried by the theorems.** Making the
-hypothesis an argument of the definition would put a proof term inside `f(D)`, which then has to be
-transported through every rewrite of `D` or `f`, and would block packaging `f(-)` as a homomorphism
-at all. Instead `Place.normResidueOrOne` is total, `eval` is a homomorphism outright, and
-`eval_eq_prod_normResidue` recovers the textbook formula where the hypothesis holds.
+**The definition is total, with admissibility carried by the theorems.** Admissibility depends on
+the divisor, so a definition that demanded it could not be a homomorphism in the divisor variable
+at all: its domain would shrink with each `f`. Instead `Place.normResidueOrOne` is total, `eval` is
+a homomorphism outright, and `eval_eq_prod_normResidue` recovers the textbook formula wherever
+admissibility holds.
 
 ## References
 
@@ -166,14 +166,15 @@ product and Weil reciprocity is stated. -/
 def IsUnitAtSupport (D : Divisor k F) (f : Fˣ) : Prop :=
   ∀ P ∈ D.support, P.ord (f : F) = 0
 
-/-- The interface to `IsUnitAtSupport`: it is exactly the pointwise condition. This is both the
-introduction and the elimination rule, so the body of the definition is not exposed. -/
+/-- `IsUnitAtSupport D f` is exactly the pointwise condition `P.ord f = 0` at every place of `D`,
+in both directions. -/
 @[simp]
 theorem isUnitAtSupport_iff {D : Divisor k F} {f : Fˣ} :
     IsUnitAtSupport D f ↔ ∀ P ∈ D.support, P.ord (f : F) = 0 := Iff.rfl
 
-/-- On an admissible divisor, `f(D)` is the textbook product `∏ N(f(P)) ^ n_P`. Indexing by
-`D.support` as a subtype carries exactly the membership proof `normResidue` needs. -/
+/-- On an admissible divisor, `f(D)` is the textbook product `∏ N(f(P)) ^ n_P`. -/
+-- The product is indexed by `D.support` as a subtype because `normResidue` takes the place's
+-- membership in the support as an argument.
 theorem eval_eq_prod_normResidue {D : Divisor k F} {f : Fˣ} (h : IsUnitAtSupport D f) :
     eval D f
       = ∏ P : D.support, P.1.normResidue f (isUnitAtSupport_iff.1 h P.1 P.2)

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -91,10 +91,7 @@ namespace Divisor
 
 /-- **Evaluation of a function on divisors**, as a homomorphism from the divisor group written
 multiplicatively. Being a homomorphism outright is what makes `eval_zero`, `eval_add`, `eval_neg`
-and `eval_sub` hypothesis-free.
-
-`private`: those four theorems are the whole of what it buys a consumer, and nothing outside this
-module needs the bundled map itself. It can be made public when something does. -/
+and `eval_sub` hypothesis-free. -/
 private noncomputable def evalHom (f : Fˣ) : Multiplicative (Divisor k F) →* kˣ :=
   (freeAbelianCharEquiv (σ := Place k F) (M := kˣ)).symm fun P ↦ P.normResidueOrOne f
 

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -102,6 +102,7 @@ theorem eval_eq_finsuppProd (D : Divisor k F) (f : Fˣ) :
 theorem eval_zero (f : Fˣ) : eval (0 : Divisor k F) f = 1 :=
   map_one (evalHom f)
 
+@[simp]
 theorem eval_add (D E : Divisor k F) (f : Fˣ) : eval (D + E) f = eval D f * eval E f :=
   map_mul (evalHom f) _ _
 
@@ -109,6 +110,7 @@ theorem eval_add (D E : Divisor k F) (f : Fˣ) : eval (D + E) f = eval D f * eva
 theorem eval_neg (D : Divisor k F) (f : Fˣ) : eval (-D) f = (eval D f)⁻¹ :=
   map_inv (evalHom f) _
 
+@[simp]
 theorem eval_sub (D E : Divisor k F) (f : Fˣ) : eval (D - E) f = eval D f / eval E f :=
   map_div (evalHom f) _ _
 

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -76,10 +76,6 @@ transported through every rewrite of `D` or `f`, and would block packaging `f(-)
 at all. Instead `Place.normResidueOrOne` is total, `eval` is a homomorphism outright, and
 `eval_eq_prod_normResidue` recovers the textbook formula where the hypothesis holds.
 
-Multiplicativity comes from `TauCeti.freeAbelianCharEquiv`: a divisor is a finitely supported
-integer combination of places, so a homomorphism out of it to a commutative group is exactly a
-choice of value at each place.
-
 ## References
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.8 — evaluation of a
@@ -97,6 +93,9 @@ variable {k F : Type*} [Field k] [Field F] [Algebra k F]
 
 namespace Divisor
 
+-- Multiplicativity comes from `TauCeti.freeAbelianCharEquiv`: a divisor is a finitely supported
+-- integer combination of places, so a homomorphism out of it into a commutative group is exactly
+-- a choice of value at each place.
 /-- **Evaluation of a function on divisors**, as a homomorphism from the divisor group written
 multiplicatively. Being a homomorphism outright is what makes `eval_zero`, `eval_add`, `eval_neg`
 and `eval_sub` hypothesis-free. The classical-regime caveat on `TauCeti.Divisor.eval` applies here

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -35,6 +35,9 @@ field norm.
   the additive group of divisors to `kˣ`, unconditionally.
 * `TauCeti.Divisor.eval_eq_prod_normResidue`: on an admissible divisor, the textbook product
   formula.
+* `TauCeti.Divisor.eval_mul`: `f(-)` is also multiplicative in the *function*, on a divisor
+  admissible for both factors. `evalHom` supplies the divisor variable; this supplies the other
+  one, and the two together are the bilinearity Weil reciprocity is stated against.
 
 ## Implementation notes
 
@@ -126,6 +129,7 @@ def IsUnitAtSupport (D : Divisor k F) (f : Fˣ) : Prop :=
 
 /-- The interface to `IsUnitAtSupport`: it is exactly the pointwise condition. This is both the
 introduction and the elimination rule, so the body of the definition is not exposed. -/
+@[simp]
 theorem isUnitAtSupport_iff {D : Divisor k F} {f : Fˣ} :
     IsUnitAtSupport D f ↔ ∀ P ∈ D.support, P.ord (f : F) = 0 := Iff.rfl
 
@@ -145,6 +149,20 @@ theorem eval_eq_prod_normResidue {D : Divisor k F} {f : Fˣ} (h : IsUnitAtSuppor
           ^ WeilDivisor.coeff D P.1 :=
         Finset.prod_congr rfl fun P _ ↦ by
           rw [Place.normResidueOrOne_of_ord_eq_zero (isUnitAtSupport_iff.1 h P.1 P.2)]
+
+/-- **`f(D)` is multiplicative in the function**, on a divisor admissible for both factors:
+`(f g)(D) = f(D) · g(D)`. This is the half of the divisor/function bilinearity that the
+homomorphism `evalHom` does not give for free — `evalHom` is a homomorphism in `D`, and this is
+the statement in `f`.
+
+Both hypotheses are needed. At a place where `f` and `g` have opposite nonzero orders their
+product is a unit while neither factor is, so the left side sees a genuine norm there and the
+right side sees `1` twice. -/
+theorem eval_mul {D : Divisor k F} {f g : Fˣ} (hf : IsUnitAtSupport D f)
+    (hg : IsUnitAtSupport D g) : eval D (f * g) = eval D f * eval D g := by
+  simp only [eval_eq_finsuppProd, Finsupp.prod, ← Finset.prod_mul_distrib]
+  refine Finset.prod_congr rfl fun P hP ↦ ?_
+  rw [Place.normResidueOrOne_mul (hf P hP) (hg P hP), mul_zpow]
 
 /-- **Admissibility is disjointness from the divisor of `f`.** This is the form the Weil-reciprocity
 statement uses, where the two divisors are the principal divisors of the two functions. -/

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -36,7 +36,8 @@ field norm.
 * `TauCeti.Divisor.eval_eq_prod_normResidue`: on an admissible divisor, the textbook product
   formula.
 * `TauCeti.Divisor.eval_one`, `eval_inv`, `eval_mul` and `eval_div`: the group laws in the
-  *function* variable. `evalHom` supplies the divisor variable; these supply the other one, and
+  *function* variable. The bundled homomorphism supplies the divisor variable; these supply the
+  other one, and
   the two together are the bilinearity Weil reciprocity is stated against. Note the asymmetry:
   `eval_one` and `eval_inv` need no hypothesis, while `eval_mul` and `eval_div` need admissibility
   for both arguments.
@@ -89,9 +90,12 @@ variable {k F : Type*} [Field k] [Field F] [Algebra k F]
 namespace Divisor
 
 /-- **Evaluation of a function on divisors**, as a homomorphism from the divisor group written
-multiplicatively. Being a homomorphism outright is what makes `eval_add` and `eval_neg`
-hypothesis-free. -/
-noncomputable def evalHom (f : Fˣ) : Multiplicative (Divisor k F) →* kˣ :=
+multiplicatively. Being a homomorphism outright is what makes `eval_zero`, `eval_add`, `eval_neg`
+and `eval_sub` hypothesis-free.
+
+`private`: those four theorems are the whole of what it buys a consumer, and nothing outside this
+module needs the bundled map itself. It can be made public when something does. -/
+private noncomputable def evalHom (f : Fˣ) : Multiplicative (Divisor k F) →* kˣ :=
   (freeAbelianCharEquiv (σ := Place k F) (M := kˣ)).symm fun P ↦ P.normResidueOrOne f
 
 /-- **The value `f(D)` of a function on a divisor.** -/
@@ -217,8 +221,8 @@ theorem IsUnitAtSupport.div {D : Divisor k F} {f g : Fˣ} (hf : IsUnitAtSupport 
 
 /-- **`f(D)` is multiplicative in the function**, on a divisor admissible for both factors:
 `(f g)(D) = f(D) · g(D)`. This is the half of the divisor/function bilinearity that the
-homomorphism `evalHom` does not give for free — `evalHom` is a homomorphism in `D`, and this is
-the statement in `f`.
+bundled homomorphism behind `eval` does not give for free: it is a homomorphism in `D`, and this
+is the statement in `f`.
 
 Both hypotheses are needed. At a place where `f` and `g` have opposite nonzero orders their
 product is a unit while neither factor is, so the left side sees a genuine norm there and the

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -173,12 +173,12 @@ theorem isUnitAtSupport_zero (f : Fˣ) : IsUnitAtSupport (0 : Divisor k F) f := 
 /-- Admissibility is closed under sums of divisors: `(D + E).support ⊆ D.support ∪ E.support`. -/
 theorem IsUnitAtSupport.add {D E : Divisor k F} {f : Fˣ} (hD : IsUnitAtSupport D f)
     (hE : IsUnitAtSupport E f) : IsUnitAtSupport (D + E) f := fun P hP ↦ by
-  -- `(D + E) P ≠ 0` forces `D P ≠ 0` or `E P ≠ 0`. Argued pointwise rather than through
-  -- `Finsupp.support_add`, whose union needs `DecidableEq (Place k F)`.
-  rw [Finsupp.mem_support_iff, Finsupp.add_apply] at hP
-  by_cases h : D P = 0
-  · exact hE P (Finsupp.mem_support_iff.2 fun h' ↦ hP (by rw [h, h', add_zero]))
-  · exact hD P (Finsupp.mem_support_iff.2 h)
+  -- `classical` only supplies the `DecidableEq (Place k F)` that `Finsupp.support_add`'s union
+  -- mentions; the statement above is unaffected by it.
+  classical
+  rcases Finset.mem_union.1 (Finsupp.support_add hP) with h | h
+  · exact hD P h
+  · exact hE P h
 
 /-- Admissibility is *invariant* under negating the divisor, not merely closed under it:
 `(-D).support = D.support`. -/

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -19,8 +19,14 @@ classical quantity
 
 is what Weil reciprocity `f(div g) = g(div f)` compares. This file defines it. The local factors
 `N_{F_P/k}(f(P))` are `TauCeti.Place.normResidueOrOne`, built in
-`FieldTheory/FunctionField/Place/Residue.lean`, which also records when the norm is the classical
-field norm.
+`FieldTheory/FunctionField/Place/Residue.lean`.
+
+The construction is total in `F`, and classical exactly where the local norms are: at a place
+whose residue field is module-finite over `k`. `TauCeti.Place.finiteDimensional_residueField`
+supplies that at every place of an algebraic function field; absent it, `Algebra.norm` is the junk
+value `1` and the factor drops out silently, which is the convention `TauCeti.Place.degree`
+already follows (junk `0` under the same hypothesis). No result below is stated only in the
+classical regime — the divisor and function laws are formal and hold for every `F`.
 
 ## Main definitions
 
@@ -93,11 +99,19 @@ namespace Divisor
 
 /-- **Evaluation of a function on divisors**, as a homomorphism from the divisor group written
 multiplicatively. Being a homomorphism outright is what makes `eval_zero`, `eval_add`, `eval_neg`
-and `eval_sub` hypothesis-free. -/
+and `eval_sub` hypothesis-free. The classical-regime caveat on `TauCeti.Divisor.eval` applies here
+unchanged. -/
 noncomputable def evalHom (f : Fˣ) : Multiplicative (Divisor k F) →* kˣ :=
   (freeAbelianCharEquiv (σ := Place k F) (M := kˣ)).symm fun P ↦ P.normResidueOrOne f
 
-/-- **The value `f(D)` of a function on a divisor.** -/
+/-- **The value `f(D)` of a function on a divisor.**
+
+This is the classical quantity exactly where the local factors are: at every place whose residue
+field is module-finite over `k`, which `TauCeti.Place.finiteDimensional_residueField` supplies for
+every place of an algebraic function field. Absent that, `Algebra.norm` degenerates to `1`
+(`Algebra.norm_eq_one_of_not_module_finite`) and the corresponding factor drops out silently. See
+`TauCeti.Place.normResidue` for the full statement of the convention, which is the one
+`TauCeti.Place.degree` already follows. -/
 noncomputable def eval (D : Divisor k F) (f : Fˣ) : kˣ :=
   evalHom f (Multiplicative.ofAdd D)
 

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -40,9 +40,11 @@ field norm.
   the two together are the bilinearity Weil reciprocity is stated against. Note the asymmetry:
   `eval_one` and `eval_inv` need no hypothesis, while `eval_mul` and `eval_div` need admissibility
   for both arguments.
-* `TauCeti.Divisor.isUnitAtSupport_one`, `IsUnitAtSupport.mul`, `isUnitAtSupport_inv_iff` and
-  `IsUnitAtSupport.div`: admissibility is a subgroup condition on the function, which is what makes
-  those laws usable together.
+* Admissibility is a subgroup condition in *each* variable, which is what makes those laws usable
+  together: `isUnitAtSupport_one`, `IsUnitAtSupport.mul`, `isUnitAtSupport_inv_iff` and
+  `IsUnitAtSupport.div` in the function, and `isUnitAtSupport_zero`, `IsUnitAtSupport.add`,
+  `isUnitAtSupport_neg_iff` and `IsUnitAtSupport.sub` in the divisor. The divisor side is what
+  moving a divisor within its class to obtain disjoint support needs.
 
 ## Implementation notes
 
@@ -155,12 +157,39 @@ theorem eval_eq_prod_normResidue {D : Divisor k F} {f : Fˣ} (h : IsUnitAtSuppor
         Finset.prod_congr rfl fun P _ ↦ by
           rw [Place.normResidueOrOne_of_ord_eq_zero (isUnitAtSupport_iff.1 h P.1 P.2)]
 
+/-- Every function is admissible for the zero divisor, which has empty support. -/
+theorem isUnitAtSupport_zero (f : Fˣ) : IsUnitAtSupport (0 : Divisor k F) f := by
+  simp
+
+/-- Admissibility is closed under sums of divisors: `(D + E).support ⊆ D.support ∪ E.support`. -/
+theorem IsUnitAtSupport.add {D E : Divisor k F} {f : Fˣ} (hD : IsUnitAtSupport D f)
+    (hE : IsUnitAtSupport E f) : IsUnitAtSupport (D + E) f := fun P hP ↦ by
+  -- `(D + E) P ≠ 0` forces `D P ≠ 0` or `E P ≠ 0`. Argued pointwise rather than through
+  -- `Finsupp.support_add`, whose union needs `DecidableEq (Place k F)`.
+  rw [Finsupp.mem_support_iff, Finsupp.add_apply] at hP
+  by_cases h : D P = 0
+  · exact hE P (Finsupp.mem_support_iff.2 fun h' ↦ hP (by rw [h, h', add_zero]))
+  · exact hD P (Finsupp.mem_support_iff.2 h)
+
+/-- Admissibility is *invariant* under negating the divisor, not merely closed under it:
+`(-D).support = D.support`. -/
+theorem isUnitAtSupport_neg_iff {D : Divisor k F} {f : Fˣ} :
+    IsUnitAtSupport (-D) f ↔ IsUnitAtSupport D f := by
+  simp only [isUnitAtSupport_iff, Finsupp.support_neg]
+
+/-- Admissibility is closed under differences of divisors. -/
+theorem IsUnitAtSupport.sub {D E : Divisor k F} {f : Fˣ} (hD : IsUnitAtSupport D f)
+    (hE : IsUnitAtSupport E f) : IsUnitAtSupport (D - E) f := by
+  rw [sub_eq_add_neg]
+  exact hD.add (isUnitAtSupport_neg_iff.2 hE)
+
 /-- `1` is admissible for every divisor.
 
-Neither this nor `isUnitAtSupport_inv_iff` is `@[simp]`, and that is checked rather than assumed:
-with `isUnitAtSupport_iff` tagged, `simp` proves both outright, and the environment linter reports
-them as redundant simp lemmas if they carry the attribute. They are kept as named lemmas because
-they are the closure facts a term-mode proof reaches for. -/
+None of the four "invariance" closure lemmas — this one, `isUnitAtSupport_inv_iff`,
+`isUnitAtSupport_zero` and `isUnitAtSupport_neg_iff` — is `@[simp]`, and that is checked rather
+than assumed: with `isUnitAtSupport_iff` tagged, `simp` proves them outright, and the environment
+linter reports them as redundant simp lemmas if they carry the attribute. They are kept as named
+lemmas because they are the closure facts a term-mode proof reaches for. -/
 theorem isUnitAtSupport_one (D : Divisor k F) : IsUnitAtSupport D (1 : Fˣ) :=
   fun P _ ↦ P.ord_one_units
 

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -22,6 +22,15 @@ The norm is not decoration. `f(P)` lives in the residue field `F_P`, which varie
 without pushing each value down to `k` the factors would live in different fields and the product
 would not typecheck, let alone mean anything.
 
+**The norm is the classical field norm exactly when `F_P` is finite over `k`.** `Algebra.norm` is
+`LinearMap.det` of multiplication, so on a residue field that is *not* module-finite over `k` it
+takes Mathlib's junk value `1` (`Algebra.norm_eq_one_of_not_module_finite`), and then so does
+`normResidue`. That regime never arises where this API is meant to be used: over a function field
+every place has finite residue degree, by `TauCeti.Place.finiteDimensional_residueField`. The
+definitions below are stated without a finiteness hypothesis for the reason `TauCeti.Place.degree`
+is — the hypothesis would be unused in the term, since `Algebra.norm` does not take one — so the
+guarantee is recorded here and in `normResidue`'s own docstring rather than in its signature.
+
 ## Main definitions
 
 * `TauCeti.Place.normResidue`: for `f` a unit at `P`, the norm to `k` of the residue `f(P)`, as a
@@ -94,9 +103,25 @@ noncomputable def residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0)
 
 /-- **The norm to `k` of the residue of a function that is a unit at `P`.** The residue field
 varies with `P`; the norm is what puts the value in `k`, the one field all the local factors of
-`Divisor.eval` have to share. -/
+`Divisor.eval` have to share.
+
+This is the classical field norm precisely when `Module.Finite k P.ResidueField` — which
+`TauCeti.Place.finiteDimensional_residueField` supplies for every place of a function field. Absent
+that, `Algebra.norm` is the junk value `1`
+(`Algebra.norm_eq_one_of_not_module_finite`), exactly as `TauCeti.Place.degree` is junk `0` absent
+the same hypothesis. The hypothesis is not in the signature because `Algebra.norm` does not consume
+one, so requiring it here would leave it unused. -/
 noncomputable def normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) : kˣ :=
   Units.map (Algebra.norm k) (P.residueUnit f hf)
+
+/-- Where the residue field is not finite over `k`, `normResidue` is `1` — the junk value of
+`Algebra.norm`, not a field norm. Stated so that the boundary of the classical reading is a
+theorem rather than a remark; `Place.finiteDimensional_residueField` rules this case out over a
+function field. -/
+theorem normResidue_eq_one_of_not_finite {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0)
+    (h : ¬Module.Finite k P.ResidueField) : P.normResidue f hf = 1 := by
+  ext
+  exact Algebra.norm_eq_one_of_not_module_finite h _
 
 /-- `normResidue` extended by `1` where `f` is not a unit, making it a total function of the place.
 `1` is the only workable neutral value: see the implementation notes. -/
@@ -126,8 +151,13 @@ noncomputable def evalHom (f : Fˣ) : Multiplicative (Divisor k F) →* kˣ :=
 noncomputable def eval (D : Divisor k F) (f : Fˣ) : kˣ :=
   evalHom f (Multiplicative.ofAdd D)
 
-/-- `f(D)` is the product over the support of the local factors, each raised to its coefficient. -/
-@[simp]
+/-- `f(D)` is the product over the support of the local factors, each raised to its coefficient.
+
+Deliberately **not** `@[simp]`, for the reason recorded on
+`WeierstrassCurve.Affine.Point.naiveHeight_eq_logHeight`: tagging a defining equation makes
+`eval` disappear on sight, which puts `eval_zero`, `eval_neg` and `eval_single` out of
+simp-normal form and makes them redundant. The `#lint` environment linter reports exactly those
+three if this carries `@[simp]`. -/
 theorem eval_eq_finsuppProd (D : Divisor k F) (f : Fˣ) :
     eval D f = D.prod fun P n ↦ P.normResidueOrOne f ^ n := by
   simp [eval, evalHom]

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -190,7 +190,7 @@ theorem IsUnitAtSupport.sub {D E : Divisor k F} {f : Fˣ} (hD : IsUnitAtSupport 
 -- kept as named lemmas because they are the closure facts a term-mode proof reaches for.
 /-- `1` is admissible for every divisor. -/
 theorem isUnitAtSupport_one (D : Divisor k F) : IsUnitAtSupport D (1 : Fˣ) :=
-  fun P _ ↦ P.ord_one_units
+  fun _ _ ↦ by simp
 
 /-- Admissibility is closed under products of functions. -/
 theorem IsUnitAtSupport.mul {D : Divisor k F} {f g : Fˣ} (hf : IsUnitAtSupport D f)

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -108,22 +108,27 @@ theorem eval_eq_finsuppProd (D : Divisor k F) (f : Fˣ) :
     eval D f = D.prod fun P n ↦ P.normResidueOrOne f ^ n := by
   simp [eval, evalHom]
 
+/-- `f(0) = 1`: the empty product. -/
 @[simp]
 theorem eval_zero (f : Fˣ) : eval (0 : Divisor k F) f = 1 :=
   map_one (evalHom f)
 
+/-- `f(D + E) = f(D) · f(E)`: adding divisors multiplies values. -/
 @[simp]
 theorem eval_add (D E : Divisor k F) (f : Fˣ) : eval (D + E) f = eval D f * eval E f :=
   map_mul (evalHom f) _ _
 
+/-- `f(-D) = f(D)⁻¹`: negating a divisor inverts the value. -/
 @[simp]
 theorem eval_neg (D : Divisor k F) (f : Fˣ) : eval (-D) f = (eval D f)⁻¹ :=
   map_inv (evalHom f) _
 
+/-- `f(D - E) = f(D) / f(E)`. -/
 @[simp]
 theorem eval_sub (D E : Divisor k F) (f : Fˣ) : eval (D - E) f = eval D f / eval E f :=
   map_div (evalHom f) _ _
 
+/-- On a single place with multiplicity, `f(n·P)` is the local factor raised to `n`. -/
 @[simp]
 theorem eval_single (P : Place k F) (n : ℤ) (f : Fˣ) :
     eval (Finsupp.single P n : Divisor k F) f = P.normResidueOrOne f ^ n := by

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -25,6 +25,8 @@ field norm.
 ## Main definitions
 
 * `TauCeti.Divisor.eval`: `f(D)`, as a unit of `k`.
+* `TauCeti.Divisor.evalHom`: the same as a bundled homomorphism in the divisor variable, which is
+  what makes the divisor laws below hypothesis-free and what a consumer composes or transports.
 * `TauCeti.Divisor.IsUnitAtSupport`: the admissibility condition — `f` is a unit at every place of
   `D`. This is exactly disjointness of `D` from the divisor of `f`
   (`isUnitAtSupport_iff_disjoint`).
@@ -92,12 +94,23 @@ namespace Divisor
 /-- **Evaluation of a function on divisors**, as a homomorphism from the divisor group written
 multiplicatively. Being a homomorphism outright is what makes `eval_zero`, `eval_add`, `eval_neg`
 and `eval_sub` hypothesis-free. -/
-private noncomputable def evalHom (f : Fˣ) : Multiplicative (Divisor k F) →* kˣ :=
+noncomputable def evalHom (f : Fˣ) : Multiplicative (Divisor k F) →* kˣ :=
   (freeAbelianCharEquiv (σ := Place k F) (M := kˣ)).symm fun P ↦ P.normResidueOrOne f
 
 /-- **The value `f(D)` of a function on a divisor.** -/
 noncomputable def eval (D : Divisor k F) (f : Fˣ) : kˣ :=
   evalHom f (Multiplicative.ofAdd D)
+
+/-- `eval` is `evalHom` on the multiplicative copy of the divisor group. -/
+@[simp]
+theorem evalHom_ofAdd (D : Divisor k F) (f : Fˣ) :
+    evalHom f (Multiplicative.ofAdd D) = eval D f := by
+  rw [eval]
+
+/-- `evalHom` is `eval` on the additive copy of the divisor group. -/
+theorem evalHom_apply (D : Multiplicative (Divisor k F)) (f : Fˣ) :
+    evalHom f D = eval (Multiplicative.toAdd D) f := by
+  rw [← evalHom_ofAdd, ofAdd_toAdd]
 
 -- Deliberately **not** `@[simp]`, for the reason recorded on
 -- `WeierstrassCurve.Affine.Point.naiveHeight_eq_logHeight`: tagging a defining equation makes
@@ -107,7 +120,7 @@ noncomputable def eval (D : Divisor k F) (f : Fˣ) : kˣ :=
 /-- `f(D)` is the product over the support of the local factors, each raised to its coefficient. -/
 theorem eval_eq_finsuppProd (D : Divisor k F) (f : Fˣ) :
     eval D f = D.prod fun P n ↦ P.normResidueOrOne f ^ n := by
-  simp [eval, evalHom]
+  simp only [eval, evalHom, freeAbelianCharEquiv_symm_apply_ofAdd]
 
 /-- `f(0) = 1`: the empty product. -/
 @[simp]
@@ -133,7 +146,7 @@ theorem eval_sub (D E : Divisor k F) (f : Fˣ) : eval (D - E) f = eval D f / eva
 @[simp]
 theorem eval_single (P : Place k F) (n : ℤ) (f : Fˣ) :
     eval (Finsupp.single P n : Divisor k F) f = P.normResidueOrOne f ^ n := by
-  simp [eval, evalHom]
+  simp [eval_eq_finsuppProd]
 
 /-- **`f` is a unit at every place of `D`** — the condition under which `f(D)` is the classical
 product and Weil reciprocity is stated. -/
@@ -200,8 +213,8 @@ theorem isUnitAtSupport_one (D : Divisor k F) : IsUnitAtSupport D (1 : Fˣ) :=
 
 /-- Admissibility is closed under products of functions. -/
 theorem IsUnitAtSupport.mul {D : Divisor k F} {f g : Fˣ} (hf : IsUnitAtSupport D f)
-    (hg : IsUnitAtSupport D g) : IsUnitAtSupport D (f * g) :=
-  fun P hP ↦ Place.ord_mul_eq_zero (hf P hP) (hg P hP)
+    (hg : IsUnitAtSupport D g) : IsUnitAtSupport D (f * g) := fun P hP ↦ by
+  rw [Units.val_mul, P.ord_mul (Units.ne_zero f) (Units.ne_zero g), hf P hP, hg P hP, add_zero]
 
 -- Not `@[simp]`, for the reason recorded above `isUnitAtSupport_one`.
 /-- Admissibility is *invariant* under inversion, not merely closed under it: `ord_P f⁻¹` vanishes

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -35,9 +35,14 @@ field norm.
   the additive group of divisors to `kˣ`, unconditionally.
 * `TauCeti.Divisor.eval_eq_prod_normResidue`: on an admissible divisor, the textbook product
   formula.
-* `TauCeti.Divisor.eval_mul`: `f(-)` is also multiplicative in the *function*, on a divisor
-  admissible for both factors. `evalHom` supplies the divisor variable; this supplies the other
-  one, and the two together are the bilinearity Weil reciprocity is stated against.
+* `TauCeti.Divisor.eval_one`, `eval_inv`, `eval_mul` and `eval_div`: the group laws in the
+  *function* variable. `evalHom` supplies the divisor variable; these supply the other one, and
+  the two together are the bilinearity Weil reciprocity is stated against. Note the asymmetry:
+  `eval_one` and `eval_inv` need no hypothesis, while `eval_mul` and `eval_div` need admissibility
+  for both arguments.
+* `TauCeti.Divisor.isUnitAtSupport_one`, `IsUnitAtSupport.mul`, `isUnitAtSupport_inv_iff` and
+  `IsUnitAtSupport.div`: admissibility is a subgroup condition on the function, which is what makes
+  those laws usable together.
 
 ## Implementation notes
 
@@ -150,6 +155,32 @@ theorem eval_eq_prod_normResidue {D : Divisor k F} {f : Fˣ} (h : IsUnitAtSuppor
         Finset.prod_congr rfl fun P _ ↦ by
           rw [Place.normResidueOrOne_of_ord_eq_zero (isUnitAtSupport_iff.1 h P.1 P.2)]
 
+/-- `1` is admissible for every divisor.
+
+Neither this nor `isUnitAtSupport_inv_iff` is `@[simp]`, and that is checked rather than assumed:
+with `isUnitAtSupport_iff` tagged, `simp` proves both outright, and the environment linter reports
+them as redundant simp lemmas if they carry the attribute. They are kept as named lemmas because
+they are the closure facts a term-mode proof reaches for. -/
+theorem isUnitAtSupport_one (D : Divisor k F) : IsUnitAtSupport D (1 : Fˣ) :=
+  fun P _ ↦ P.ord_one_units
+
+/-- Admissibility is closed under products of functions. -/
+theorem IsUnitAtSupport.mul {D : Divisor k F} {f g : Fˣ} (hf : IsUnitAtSupport D f)
+    (hg : IsUnitAtSupport D g) : IsUnitAtSupport D (f * g) :=
+  fun P hP ↦ Place.ord_mul_eq_zero (hf P hP) (hg P hP)
+
+/-- Admissibility is *invariant* under inversion, not merely closed under it: `ord_P f⁻¹` vanishes
+exactly when `ord_P f` does. Not `@[simp]`, for the reason given on `isUnitAtSupport_one`. -/
+theorem isUnitAtSupport_inv_iff {D : Divisor k F} {f : Fˣ} :
+    IsUnitAtSupport D f⁻¹ ↔ IsUnitAtSupport D f := by
+  simp only [isUnitAtSupport_iff, Units.val_inv_eq_inv_val, Place.ord_inv, neg_eq_zero]
+
+/-- Admissibility is closed under quotients of functions. -/
+theorem IsUnitAtSupport.div {D : Divisor k F} {f g : Fˣ} (hf : IsUnitAtSupport D f)
+    (hg : IsUnitAtSupport D g) : IsUnitAtSupport D (f / g) := by
+  rw [div_eq_mul_inv]
+  exact hf.mul (isUnitAtSupport_inv_iff.2 hg)
+
 /-- **`f(D)` is multiplicative in the function**, on a divisor admissible for both factors:
 `(f g)(D) = f(D) · g(D)`. This is the half of the divisor/function bilinearity that the
 homomorphism `evalHom` does not give for free — `evalHom` is a homomorphism in `D`, and this is
@@ -163,6 +194,25 @@ theorem eval_mul {D : Divisor k F} {f g : Fˣ} (hf : IsUnitAtSupport D f)
   simp only [eval_eq_finsuppProd, Finsupp.prod, ← Finset.prod_mul_distrib]
   refine Finset.prod_congr rfl fun P hP ↦ ?_
   rw [Place.normResidueOrOne_mul (hf P hP) (hg P hP), mul_zpow]
+
+/-- `f(D)` at the constant function `1`, needing no hypothesis. -/
+@[simp]
+theorem eval_one (D : Divisor k F) : eval D (1 : Fˣ) = 1 := by
+  simp [eval_eq_finsuppProd]
+
+/-- **`f(D)` inverts with no hypothesis**, unlike `eval_mul`: admissibility is invariant under
+inversion (`isUnitAtSupport_inv_iff`), and off the admissible places both sides are `1`. -/
+@[simp]
+theorem eval_inv (D : Divisor k F) (f : Fˣ) : eval D f⁻¹ = (eval D f)⁻¹ := by
+  simp only [eval_eq_finsuppProd, Finsupp.prod, Place.normResidueOrOne_inv, inv_zpow,
+    Finset.prod_inv_distrib]
+
+/-- **`f(D)` respects quotients of functions**, on a divisor admissible for both. Like `eval_mul`
+and unlike `eval_inv`, this needs both hypotheses: `f / g` can be admissible where neither `f` nor
+`g` is. -/
+theorem eval_div {D : Divisor k F} {f g : Fˣ} (hf : IsUnitAtSupport D f)
+    (hg : IsUnitAtSupport D g) : eval D (f / g) = eval D f / eval D g := by
+  rw [div_eq_mul_inv, eval_mul hf (isUnitAtSupport_inv_iff.2 hg), eval_inv, div_eq_mul_inv]
 
 /-- **Admissibility is disjointness from the divisor of `f`.** This is the form the Weil-reciprocity
 statement uses, where the two divisors are the principal divisors of the two functions. -/

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -183,13 +183,12 @@ theorem IsUnitAtSupport.sub {D E : Divisor k F} {f : Fˣ} (hD : IsUnitAtSupport 
   rw [sub_eq_add_neg]
   exact hD.add (isUnitAtSupport_neg_iff.2 hE)
 
-/-- `1` is admissible for every divisor.
-
-None of the four "invariance" closure lemmas — this one, `isUnitAtSupport_inv_iff`,
-`isUnitAtSupport_zero` and `isUnitAtSupport_neg_iff` — is `@[simp]`, and that is checked rather
-than assumed: with `isUnitAtSupport_iff` tagged, `simp` proves them outright, and the environment
-linter reports them as redundant simp lemmas if they carry the attribute. They are kept as named
-lemmas because they are the closure facts a term-mode proof reaches for. -/
+-- None of the four "invariance" closure lemmas — this one, `isUnitAtSupport_inv_iff`,
+-- `isUnitAtSupport_zero` and `isUnitAtSupport_neg_iff` — is `@[simp]`, and that is checked rather
+-- than assumed: with `isUnitAtSupport_iff` tagged, `simp` proves them outright, and the
+-- environment linter reports them as redundant simp lemmas if they carry the attribute. They are
+-- kept as named lemmas because they are the closure facts a term-mode proof reaches for.
+/-- `1` is admissible for every divisor. -/
 theorem isUnitAtSupport_one (D : Divisor k F) : IsUnitAtSupport D (1 : Fˣ) :=
   fun P _ ↦ P.ord_one_units
 
@@ -198,8 +197,9 @@ theorem IsUnitAtSupport.mul {D : Divisor k F} {f g : Fˣ} (hf : IsUnitAtSupport 
     (hg : IsUnitAtSupport D g) : IsUnitAtSupport D (f * g) :=
   fun P hP ↦ Place.ord_mul_eq_zero (hf P hP) (hg P hP)
 
+-- Not `@[simp]`, for the reason recorded above `isUnitAtSupport_one`.
 /-- Admissibility is *invariant* under inversion, not merely closed under it: `ord_P f⁻¹` vanishes
-exactly when `ord_P f` does. Not `@[simp]`, for the reason given on `isUnitAtSupport_one`. -/
+exactly when `ord_P f` does. -/
 theorem isUnitAtSupport_inv_iff {D : Divisor k F} {f : Fˣ} :
     IsUnitAtSupport D f⁻¹ ↔ IsUnitAtSupport D f := by
   simp only [isUnitAtSupport_iff, Units.val_inv_eq_inv_val, Place.ord_inv, neg_eq_zero]

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.Group.FreeAbelianCharacter
 public import TauCeti.FieldTheory.FunctionField.Divisor.Principal
+public import TauCeti.FieldTheory.FunctionField.Place.Residue
 
 /-!
 # Evaluating a function on a divisor
@@ -16,27 +17,13 @@ classical quantity
 
 `f(D) = ∏_{P ∈ supp D} N_{F_P/k}(f(P)) ^ (coeff D P)`
 
-is what Weil reciprocity `f(div g) = g(div f)` compares. This file defines it.
-
-The norm is not decoration. `f(P)` lives in the residue field `F_P`, which varies with `P`, so
-without pushing each value down to `k` the factors would live in different fields and the product
-would not typecheck, let alone mean anything.
-
-**The norm is the classical field norm exactly when `F_P` is finite over `k`.** `Algebra.norm` is
-`LinearMap.det` of multiplication, so on a residue field that is *not* module-finite over `k` it
-takes Mathlib's junk value `1` (`Algebra.norm_eq_one_of_not_module_finite`), and then so does
-`normResidue`. That regime never arises where this API is meant to be used: over a function field
-every place has finite residue degree, by `TauCeti.Place.finiteDimensional_residueField`. The
-definitions below are stated without a finiteness hypothesis for the reason `TauCeti.Place.degree`
-is — the hypothesis would be unused in the term, since `Algebra.norm` does not take one — so the
-guarantee is recorded here and in `normResidue`'s own docstring rather than in its signature.
+is what Weil reciprocity `f(div g) = g(div f)` compares. This file defines it. The local factors
+`N_{F_P/k}(f(P))` are `TauCeti.Place.normResidueOrOne`, built in
+`FieldTheory/FunctionField/Place/Residue.lean`, which also records when the norm is the classical
+field norm.
 
 ## Main definitions
 
-* `TauCeti.Place.normResidue`: for `f` a unit at `P`, the norm to `k` of the residue `f(P)`, as a
-  unit of `k`.
-* `TauCeti.Place.normResidueOrOne`: the same, extended by `1` at the places where `f` is not a
-  unit, so that it is a total function of the place.
 * `TauCeti.Divisor.eval`: `f(D)`, as a unit of `k`.
 * `TauCeti.Divisor.IsUnitAtSupport`: the admissibility condition — `f` is a unit at every place of
   `D`. This is exactly disjointness of `D` from the divisor of `f`
@@ -67,12 +54,18 @@ unit, `eval (single P 1) * eval (single P (-1))` would be `0` while `eval 0 = 1`
 **The definition is total, with the admissibility hypothesis carried by the theorems.** Making the
 hypothesis an argument of the definition would put a proof term inside `f(D)`, which then has to be
 transported through every rewrite of `D` or `f`, and would block packaging `f(-)` as a homomorphism
-at all. Instead `normResidueOrOne` is total, `eval` is a homomorphism outright, and
+at all. Instead `Place.normResidueOrOne` is total, `eval` is a homomorphism outright, and
 `eval_eq_prod_normResidue` recovers the textbook formula where the hypothesis holds.
 
 Multiplicativity comes from `TauCeti.freeAbelianCharEquiv`: a divisor is a finitely supported
 integer combination of places, so a homomorphism out of it to a commutative group is exactly a
 choice of value at each place.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.8 — evaluation of a
+  function on a divisor of disjoint support is the prerequisite of the divisor construction of the
+  Weil pairing given there (III.8.1).
 -/
 
 public section
@@ -82,62 +75,6 @@ namespace TauCeti
 open AlgebraicGeometry
 
 variable {k F : Type*} [Field k] [Field F] [Algebra k F]
-
-namespace Place
-
-/-- A function that is a unit at `P` lies in the local ring `𝒪_P`. -/
-theorem mem_integers_of_ord_eq_zero (P : Place k F) {f : Fˣ} (hf : P.ord (f : F) = 0) :
-    (f : F) ∈ P.integers := by
-  rw [P.mem_integers_iff, P.valuation_eq_exp_neg_ord (Units.ne_zero f), hf]
-  simp
-
-/-- **The residue `f(P)` of a function that is a unit at `P`**, as a unit of the residue field.
-Being a unit is what makes the residue nonzero, which is what lets it be raised to a negative
-power below. -/
-noncomputable def residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
-    P.ResidueFieldˣ :=
-  Units.map (IsLocalRing.residue P.integers)
-    ((P.isUnit_iff_ord_eq_zero (Units.ne_zero f)).2
-        (show P.ord ((⟨(f : F), P.mem_integers_of_ord_eq_zero hf⟩ : P.integers) : F) = 0 from
-          hf)).unit
-
-/-- **The norm to `k` of the residue of a function that is a unit at `P`.** The residue field
-varies with `P`; the norm is what puts the value in `k`, the one field all the local factors of
-`Divisor.eval` have to share.
-
-This is the classical field norm precisely when `Module.Finite k P.ResidueField` — which
-`TauCeti.Place.finiteDimensional_residueField` supplies for every place of a function field. Absent
-that, `Algebra.norm` is the junk value `1`
-(`Algebra.norm_eq_one_of_not_module_finite`), exactly as `TauCeti.Place.degree` is junk `0` absent
-the same hypothesis. The hypothesis is not in the signature because `Algebra.norm` does not consume
-one, so requiring it here would leave it unused. -/
-noncomputable def normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) : kˣ :=
-  Units.map (Algebra.norm k) (P.residueUnit f hf)
-
-/-- Where the residue field is not finite over `k`, `normResidue` is `1` — the junk value of
-`Algebra.norm`, not a field norm. Stated so that the boundary of the classical reading is a
-theorem rather than a remark; `Place.finiteDimensional_residueField` rules this case out over a
-function field. -/
-theorem normResidue_eq_one_of_not_finite {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0)
-    (h : ¬Module.Finite k P.ResidueField) : P.normResidue f hf = 1 := by
-  ext
-  exact Algebra.norm_eq_one_of_not_module_finite h _
-
-/-- `normResidue` extended by `1` where `f` is not a unit, making it a total function of the place.
-`1` is the only workable neutral value: see the implementation notes. -/
-noncomputable def normResidueOrOne (P : Place k F) (f : Fˣ) : kˣ :=
-  if hf : P.ord (f : F) = 0 then P.normResidue f hf else 1
-
-theorem normResidueOrOne_of_ord_eq_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
-    P.normResidueOrOne f = P.normResidue f hf := by
-  simp [normResidueOrOne, hf]
-
-@[simp]
-theorem normResidueOrOne_of_ord_ne_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) ≠ 0) :
-    P.normResidueOrOne f = 1 := by
-  simp [normResidueOrOne, hf]
-
-end Place
 
 namespace Divisor
 
@@ -151,13 +88,12 @@ noncomputable def evalHom (f : Fˣ) : Multiplicative (Divisor k F) →* kˣ :=
 noncomputable def eval (D : Divisor k F) (f : Fˣ) : kˣ :=
   evalHom f (Multiplicative.ofAdd D)
 
-/-- `f(D)` is the product over the support of the local factors, each raised to its coefficient.
-
-Deliberately **not** `@[simp]`, for the reason recorded on
-`WeierstrassCurve.Affine.Point.naiveHeight_eq_logHeight`: tagging a defining equation makes
-`eval` disappear on sight, which puts `eval_zero`, `eval_neg` and `eval_single` out of
-simp-normal form and makes them redundant. The `#lint` environment linter reports exactly those
-three if this carries `@[simp]`. -/
+-- Deliberately **not** `@[simp]`, for the reason recorded on
+-- `WeierstrassCurve.Affine.Point.naiveHeight_eq_logHeight`: tagging a defining equation makes
+-- `eval` disappear on sight, which puts `eval_zero`, `eval_neg` and `eval_single` out of
+-- simp-normal form and makes them redundant. The `#lint` environment linter reports exactly
+-- those three if this carries `@[simp]`.
+/-- `f(D)` is the product over the support of the local factors, each raised to its coefficient. -/
 theorem eval_eq_finsuppProd (D : Divisor k F) (f : Fˣ) :
     eval D f = D.prod fun P n ↦ P.normResidueOrOne f ^ n := by
   simp [eval, evalHom]
@@ -183,28 +119,36 @@ theorem eval_single (P : Place k F) (n : ℤ) (f : Fˣ) :
 
 /-- **`f` is a unit at every place of `D`** — the condition under which `f(D)` is the classical
 product and Weil reciprocity is stated. -/
-@[expose] def IsUnitAtSupport (D : Divisor k F) (f : Fˣ) : Prop :=
+def IsUnitAtSupport (D : Divisor k F) (f : Fˣ) : Prop :=
   ∀ P ∈ D.support, P.ord (f : F) = 0
+
+/-- The interface to `IsUnitAtSupport`: it is exactly the pointwise condition. This is both the
+introduction and the elimination rule, so the body of the definition is not exposed. -/
+theorem isUnitAtSupport_iff {D : Divisor k F} {f : Fˣ} :
+    IsUnitAtSupport D f ↔ ∀ P ∈ D.support, P.ord (f : F) = 0 := Iff.rfl
 
 /-- On an admissible divisor, `f(D)` is the textbook product `∏ N(f(P)) ^ n_P`. Indexing by
 `D.support` as a subtype carries exactly the membership proof `normResidue` needs. -/
 theorem eval_eq_prod_normResidue {D : Divisor k F} {f : Fˣ} (h : IsUnitAtSupport D f) :
-    eval D f = ∏ P : D.support, P.1.normResidue f (h P.1 P.2) ^ WeilDivisor.coeff D P.1 := by
+    eval D f
+      = ∏ P : D.support, P.1.normResidue f (isUnitAtSupport_iff.1 h P.1 P.2)
+          ^ WeilDivisor.coeff D P.1 := by
   -- the right-hand side depends on the membership proof, so it cannot be matched against a
   -- `Finset` product directly; convert the left-hand side to the subtype product instead.
   calc eval D f = D.prod fun P n ↦ P.normResidueOrOne f ^ n := eval_eq_finsuppProd D f
     _ = ∏ P ∈ D.support, P.normResidueOrOne f ^ WeilDivisor.coeff D P := rfl
     _ = ∏ P : D.support, P.1.normResidueOrOne f ^ WeilDivisor.coeff D P.1 :=
         (Finset.prod_coe_sort _ _).symm
-    _ = ∏ P : D.support, P.1.normResidue f (h P.1 P.2) ^ WeilDivisor.coeff D P.1 :=
+    _ = ∏ P : D.support, P.1.normResidue f (isUnitAtSupport_iff.1 h P.1 P.2)
+          ^ WeilDivisor.coeff D P.1 :=
         Finset.prod_congr rfl fun P _ ↦ by
-          rw [Place.normResidueOrOne_of_ord_eq_zero (h P.1 P.2)]
+          rw [Place.normResidueOrOne_of_ord_eq_zero (isUnitAtSupport_iff.1 h P.1 P.2)]
 
 /-- **Admissibility is disjointness from the divisor of `f`.** This is the form the Weil-reciprocity
 statement uses, where the two divisors are the principal divisors of the two functions. -/
 theorem isUnitAtSupport_iff_disjoint (hF : IsFunctionField k F) (D : Divisor k F) (f : Fˣ) :
     IsUnitAtSupport D f ↔ Disjoint D.support (principal hF f).support := by
-  simp only [IsUnitAtSupport, Finset.disjoint_left, mem_support_principal_iff hF]
+  simp only [isUnitAtSupport_iff, Finset.disjoint_left, mem_support_principal_iff hF]
   exact ⟨fun h P hP => not_not_intro (h P hP), fun h P hP => not_not.1 (h hP)⟩
 
 end Divisor

--- a/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Eval.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Group.FreeAbelianCharacter
+public import TauCeti.FieldTheory.FunctionField.Divisor.Principal
+
+/-!
+# Evaluating a function on a divisor
+
+For a function `f` and a divisor `D` whose support avoids the zeros and poles of `f`, the
+classical quantity
+
+`f(D) = ∏_{P ∈ supp D} N_{F_P/k}(f(P)) ^ (coeff D P)`
+
+is what Weil reciprocity `f(div g) = g(div f)` compares. This file defines it.
+
+The norm is not decoration. `f(P)` lives in the residue field `F_P`, which varies with `P`, so
+without pushing each value down to `k` the factors would live in different fields and the product
+would not typecheck, let alone mean anything.
+
+## Main definitions
+
+* `TauCeti.Place.normResidue`: for `f` a unit at `P`, the norm to `k` of the residue `f(P)`, as a
+  unit of `k`.
+* `TauCeti.Place.normResidueOrOne`: the same, extended by `1` at the places where `f` is not a
+  unit, so that it is a total function of the place.
+* `TauCeti.Divisor.eval`: `f(D)`, as a unit of `k`.
+* `TauCeti.Divisor.IsUnitAtSupport`: the admissibility condition — `f` is a unit at every place of
+  `D`. This is exactly disjointness of `D` from the divisor of `f`
+  (`isUnitAtSupport_iff_disjoint`).
+
+## Main results
+
+* `TauCeti.Divisor.eval_add`, `eval_neg`, `eval_sub`, `eval_zero`: `f(-)` is a homomorphism from
+  the additive group of divisors to `kˣ`, unconditionally.
+* `TauCeti.Divisor.eval_eq_prod_normResidue`: on an admissible divisor, the textbook product
+  formula.
+
+## Implementation notes
+
+Three choices are load-bearing, and each rules out an alternative that does not work.
+
+**Functions are taken in `Fˣ`, not `F`.** The admissibility condition is `P.ord f = 0`, and
+`P.ord 0 = 0` by the junk-value convention on `ord`; so over `F` the condition would declare
+`f = 0` admissible at every place. Taking `f : Fˣ` excludes that, and it matches
+`TauCeti.Divisor.principal`, which is already stated for `Fˣ`.
+
+**Values are taken in `kˣ`, not `k`, and the neutral value is `1`, not `0`.** The coefficient of a
+place is an integer, so the local factor is raised to a possibly negative power, and the divisor law
+has to survive that. With `0` as the neutral value in `k` it does not: at a place where `f` is not a
+unit, `eval (single P 1) * eval (single P (-1))` would be `0` while `eval 0 = 1`. In `kˣ` every
+`zpow` identity holds unconditionally and the law is automatic.
+
+**The definition is total, with the admissibility hypothesis carried by the theorems.** Making the
+hypothesis an argument of the definition would put a proof term inside `f(D)`, which then has to be
+transported through every rewrite of `D` or `f`, and would block packaging `f(-)` as a homomorphism
+at all. Instead `normResidueOrOne` is total, `eval` is a homomorphism outright, and
+`eval_eq_prod_normResidue` recovers the textbook formula where the hypothesis holds.
+
+Multiplicativity comes from `TauCeti.freeAbelianCharEquiv`: a divisor is a finitely supported
+integer combination of places, so a homomorphism out of it to a commutative group is exactly a
+choice of value at each place.
+-/
+
+public section
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+variable {k F : Type*} [Field k] [Field F] [Algebra k F]
+
+namespace Place
+
+/-- A function that is a unit at `P` lies in the local ring `𝒪_P`. -/
+theorem mem_integers_of_ord_eq_zero (P : Place k F) {f : Fˣ} (hf : P.ord (f : F) = 0) :
+    (f : F) ∈ P.integers := by
+  rw [P.mem_integers_iff, P.valuation_eq_exp_neg_ord (Units.ne_zero f), hf]
+  simp
+
+/-- **The residue `f(P)` of a function that is a unit at `P`**, as a unit of the residue field.
+Being a unit is what makes the residue nonzero, which is what lets it be raised to a negative
+power below. -/
+noncomputable def residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
+    P.ResidueFieldˣ :=
+  Units.map (IsLocalRing.residue P.integers)
+    ((P.isUnit_iff_ord_eq_zero (Units.ne_zero f)).2
+        (show P.ord ((⟨(f : F), P.mem_integers_of_ord_eq_zero hf⟩ : P.integers) : F) = 0 from
+          hf)).unit
+
+/-- **The norm to `k` of the residue of a function that is a unit at `P`.** The residue field
+varies with `P`; the norm is what puts the value in `k`, the one field all the local factors of
+`Divisor.eval` have to share. -/
+noncomputable def normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) : kˣ :=
+  Units.map (Algebra.norm k) (P.residueUnit f hf)
+
+/-- `normResidue` extended by `1` where `f` is not a unit, making it a total function of the place.
+`1` is the only workable neutral value: see the implementation notes. -/
+noncomputable def normResidueOrOne (P : Place k F) (f : Fˣ) : kˣ :=
+  if hf : P.ord (f : F) = 0 then P.normResidue f hf else 1
+
+theorem normResidueOrOne_of_ord_eq_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
+    P.normResidueOrOne f = P.normResidue f hf := by
+  simp [normResidueOrOne, hf]
+
+@[simp]
+theorem normResidueOrOne_of_ord_ne_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) ≠ 0) :
+    P.normResidueOrOne f = 1 := by
+  simp [normResidueOrOne, hf]
+
+end Place
+
+namespace Divisor
+
+/-- **Evaluation of a function on divisors**, as a homomorphism from the divisor group written
+multiplicatively. Being a homomorphism outright is what makes `eval_add` and `eval_neg`
+hypothesis-free. -/
+noncomputable def evalHom (f : Fˣ) : Multiplicative (Divisor k F) →* kˣ :=
+  (freeAbelianCharEquiv (σ := Place k F) (M := kˣ)).symm fun P ↦ P.normResidueOrOne f
+
+/-- **The value `f(D)` of a function on a divisor.** -/
+noncomputable def eval (D : Divisor k F) (f : Fˣ) : kˣ :=
+  evalHom f (Multiplicative.ofAdd D)
+
+/-- `f(D)` is the product over the support of the local factors, each raised to its coefficient. -/
+@[simp]
+theorem eval_eq_finsuppProd (D : Divisor k F) (f : Fˣ) :
+    eval D f = D.prod fun P n ↦ P.normResidueOrOne f ^ n := by
+  simp [eval, evalHom]
+
+@[simp]
+theorem eval_zero (f : Fˣ) : eval (0 : Divisor k F) f = 1 :=
+  map_one (evalHom f)
+
+theorem eval_add (D E : Divisor k F) (f : Fˣ) : eval (D + E) f = eval D f * eval E f :=
+  map_mul (evalHom f) _ _
+
+@[simp]
+theorem eval_neg (D : Divisor k F) (f : Fˣ) : eval (-D) f = (eval D f)⁻¹ :=
+  map_inv (evalHom f) _
+
+theorem eval_sub (D E : Divisor k F) (f : Fˣ) : eval (D - E) f = eval D f / eval E f :=
+  map_div (evalHom f) _ _
+
+@[simp]
+theorem eval_single (P : Place k F) (n : ℤ) (f : Fˣ) :
+    eval (Finsupp.single P n : Divisor k F) f = P.normResidueOrOne f ^ n := by
+  simp [eval, evalHom]
+
+/-- **`f` is a unit at every place of `D`** — the condition under which `f(D)` is the classical
+product and Weil reciprocity is stated. -/
+@[expose] def IsUnitAtSupport (D : Divisor k F) (f : Fˣ) : Prop :=
+  ∀ P ∈ D.support, P.ord (f : F) = 0
+
+/-- On an admissible divisor, `f(D)` is the textbook product `∏ N(f(P)) ^ n_P`. Indexing by
+`D.support` as a subtype carries exactly the membership proof `normResidue` needs. -/
+theorem eval_eq_prod_normResidue {D : Divisor k F} {f : Fˣ} (h : IsUnitAtSupport D f) :
+    eval D f = ∏ P : D.support, P.1.normResidue f (h P.1 P.2) ^ WeilDivisor.coeff D P.1 := by
+  -- the right-hand side depends on the membership proof, so it cannot be matched against a
+  -- `Finset` product directly; convert the left-hand side to the subtype product instead.
+  calc eval D f = D.prod fun P n ↦ P.normResidueOrOne f ^ n := eval_eq_finsuppProd D f
+    _ = ∏ P ∈ D.support, P.normResidueOrOne f ^ WeilDivisor.coeff D P := rfl
+    _ = ∏ P : D.support, P.1.normResidueOrOne f ^ WeilDivisor.coeff D P.1 :=
+        (Finset.prod_coe_sort _ _).symm
+    _ = ∏ P : D.support, P.1.normResidue f (h P.1 P.2) ^ WeilDivisor.coeff D P.1 :=
+        Finset.prod_congr rfl fun P _ ↦ by
+          rw [Place.normResidueOrOne_of_ord_eq_zero (h P.1 P.2)]
+
+/-- **Admissibility is disjointness from the divisor of `f`.** This is the form the Weil-reciprocity
+statement uses, where the two divisors are the principal divisors of the two functions. -/
+theorem isUnitAtSupport_iff_disjoint (hF : IsFunctionField k F) (D : Divisor k F) (f : Fˣ) :
+    IsUnitAtSupport D f ↔ Disjoint D.support (principal hF f).support := by
+  simp only [IsUnitAtSupport, Finset.disjoint_left, mem_support_principal_iff hF]
+  exact ⟨fun h P hP => not_not_intro (h P hP), fun h P hP => not_not.1 (h hP)⟩
+
+end Divisor
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -110,10 +110,10 @@ This is the classical field norm precisely when `Module.Finite k P.ResidueField`
 `TauCeti.Place.finiteDimensional_residueField` supplies for every place of a function field.
 Absent that, `Algebra.norm` is the junk value `1`
 (`Algebra.norm_eq_one_of_not_module_finite`), exactly as `TauCeti.Place.degree` is junk `0`
-absent the same hypothesis. The hypothesis is not in the signature because `Algebra.norm` does
-not consume one, so requiring it here would leave it unused — the policy
-`TauCeti.Algebra.normUnits` states for itself, and this is that homomorphism applied to the
-residue. -/
+absent the same hypothesis. -/
+-- Finiteness is documented rather than assumed: `Algebra.normUnits` consumes no such argument, so
+-- a hypothesis here would be unused, which `unusedArguments` rejects. `TauCeti.Place.degree`
+-- records the same convention for `Module.finrank`.
 noncomputable def normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) : kˣ :=
   Algebra.normUnits k (P.residueUnit f hf)
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -41,10 +41,8 @@ not consume one — so the guarantee is recorded here rather than in the signatu
 ## Main results
 
 * `TauCeti.Place.coe_residueUnit` and `TauCeti.Place.coe_normResidue`: the underlying field values
-  of the two units, as `@[simp]` normal forms, named after `TauCeti.Algebra.coe_normUnits` — the
-  adjacent lemma of exactly this shape. They are the whole reason a consumer never has to unfold
-  either definition: they name the `IsLocalRing.residue` and `Algebra.norm` the units are built
-  from.
+  of the two units: `IsLocalRing.residue` and the `Algebra.norm` of it. Both are `@[simp]`, and
+  are named after `TauCeti.Algebra.coe_normUnits`, the adjacent lemma of the same shape.
 * `TauCeti.Place.normResidueOrOne_of_ord_eq_zero` and
   `TauCeti.Place.normResidueOrOne_of_ord_ne_zero`: the two branches of the total extension.
 * The group laws in the function: `residueUnit_one`, `residueUnit_mul`, `residueUnit_inv` and

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -92,6 +92,7 @@ noncomputable def residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0)
     P.ResidueFieldˣ :=
   P.integers.unitGroupToResidueFieldUnits ⟨f, P.mem_unitGroup_of_ord_eq_zero hf⟩
 
+/-- The residue field element underlying `residueUnit`: the residue of `f` in `𝒪_P / 𝔪_P`. -/
 @[simp]
 theorem coe_residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
     (P.residueUnit f hf : P.ResidueField)
@@ -114,6 +115,7 @@ residue. -/
 noncomputable def normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) : kˣ :=
   Algebra.normUnits k (P.residueUnit f hf)
 
+/-- The element of `k` underlying `normResidue`: the norm of the residue. -/
 @[simp]
 theorem coe_normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
     (P.normResidue f hf : k) = Algebra.norm k (P.residueUnit f hf : P.ResidueField) := by
@@ -126,11 +128,13 @@ survives that. -/
 noncomputable def normResidueOrOne (P : Place k F) (f : Fˣ) : kˣ :=
   if hf : P.ord (f : F) = 0 then P.normResidue f hf else 1
 
+/-- Where `f` is a unit at `P`, the total local factor is the genuine norm of the residue. -/
 @[simp]
 theorem normResidueOrOne_of_ord_eq_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
     P.normResidueOrOne f = P.normResidue f hf := by
   simp [normResidueOrOne, hf]
 
+/-- Where `f` is not a unit at `P`, the total local factor is the neutral value `1`. -/
 @[simp]
 theorem normResidueOrOne_of_ord_ne_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) ≠ 0) :
     P.normResidueOrOne f = 1 := by

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -159,10 +159,6 @@ theorem normResidue_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
       = P.normResidue f hf * P.normResidue g hg := by
   rw [normResidue, normResidue, normResidue, residueUnit_mul hf hg, map_mul]
 
-/-- The order of the constant `1` is zero at every place, so `1` is admissible everywhere. -/
-theorem ord_one_units (P : Place k F) : P.ord ((1 : Fˣ) : F) = 0 := by
-  rw [Units.val_one, P.ord_one]
-
 /-- `ord_P f⁻¹ = -ord_P f`, so admissibility is invariant under inversion. -/
 theorem ord_inv_eq_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
     P.ord ((f⁻¹ : Fˣ) : F) = 0 := by
@@ -205,7 +201,8 @@ theorem normResidueOrOne_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0
 theorem normResidueOrOne_one (P : Place k F) : P.normResidueOrOne (1 : Fˣ) = 1 := by
   -- read off multiplicativity at `f = g = 1` rather than from the residue: `a = a * a` in a
   -- group forces `a = 1`, which avoids all of the subtype-coercion work
-  have h := normResidueOrOne_mul (P := P) (f := 1) (g := 1) P.ord_one_units P.ord_one_units
+  have h1 : P.ord ((1 : Fˣ) : F) = 0 := by simp
+  have h := normResidueOrOne_mul (P := P) (f := 1) (g := 1) h1 h1
   rw [one_mul] at h
   exact right_eq_mul.1 h
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -46,6 +46,14 @@ not consume one — so the guarantee is recorded here rather than in the signatu
   built from.
 * `TauCeti.Place.normResidueOrOne_of_ord_eq_zero` and
   `TauCeti.Place.normResidueOrOne_of_ord_ne_zero`: the two branches of the total extension.
+* The group laws in the function: `residueUnit_one`, `residueUnit_mul`, `residueUnit_inv` and
+  their `normResidue` counterparts, together with `normResidueOrOne_one`, `normResidueOrOne_mul`
+  and `normResidueOrOne_inv` for the total form. Because `residueUnit` is the image of a
+  `MonoidHom`, the first three are `map_one`, `map_mul` and `map_inv`; the `normResidue` ones
+  compose that with `Algebra.normUnits`, itself a `MonoidHom`. Only the *total* form needs work,
+  and only for the product: `normResidueOrOne_mul` needs both factors admissible, while
+  `normResidueOrOne_inv` needs nothing, since `ord_P f⁻¹ = -ord_P f` vanishes exactly when
+  `ord_P f` does.
 
 ## References
 
@@ -59,21 +67,36 @@ namespace TauCeti.Place
 
 variable {k F : Type*} [Field k] [Field F] [Algebra k F]
 
+/-- A function of order zero at `P` lies in the unit group of `𝒪_P`: order zero is valuation one,
+which is exactly `ValuationSubring.mem_unitGroup_iff`. -/
+theorem mem_unitGroup_of_ord_eq_zero (P : Place k F) {f : Fˣ} (hf : P.ord (f : F) = 0) :
+    f ∈ P.integers.unitGroup :=
+  -- Routed through `IsUnit` rather than through `Valuation.mem_unitGroup_iff`, which would ask
+  -- unification to see `P.integers` as `P.valuation.valuationSubring`: `Place.integers` is not
+  -- an exposed definition, so that unfolding is unavailable here and the attempt exhausts the
+  -- heartbeat budget at `whnf`. Both lemmas used below are generic in the valuation subring.
+  (ValuationSubring.mem_unitGroup_iff _ f).2 <|
+    (ValuationSubring.valuation_eq_one_iff _ _).1
+      ((P.isUnit_iff_ord_eq_zero (x := ⟨(f : F), P.mem_integers_iff_ord_nonneg.2 hf.ge⟩)
+        (Units.ne_zero f)).2 hf)
+
 /-- **The residue `f(P)` of a function that is a unit at `P`**, as a unit of the residue field.
 Being a unit is what makes the residue nonzero, which is what lets it be raised to a negative
-power in `TauCeti.Divisor.eval`. -/
+power in `TauCeti.Divisor.eval`.
+
+This is Mathlib's `ValuationSubring.unitGroupToResidueFieldUnits` at the unit-group element `f`
+names, rather than a residue paired with a separate proof that it is nonzero. Being the image of
+a `MonoidHom` is what makes the group laws below `map_one`, `map_mul` and `map_inv`. -/
 noncomputable def residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
     P.ResidueFieldˣ :=
-  -- `f` lies in `𝒪_P` because `0 ≤ ord_P f`, and the coercion back to `F` of the element of
-  -- `𝒪_P` so named is `rfl`, which is why `hf` and `Units.ne_zero f` apply to it verbatim.
-  Units.mk0 (IsLocalRing.residue P.integers ⟨(f : F), P.mem_integers_iff_ord_nonneg.2 hf.ge⟩)
-    (by rw [Ne, P.residue_eq_zero_iff_ord_pos (Units.ne_zero f), hf]; omega)
+  P.integers.unitGroupToResidueFieldUnits ⟨f, P.mem_unitGroup_of_ord_eq_zero hf⟩
 
 @[simp]
 theorem val_residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
     (P.residueUnit f hf : P.ResidueField)
       = IsLocalRing.residue P.integers ⟨(f : F), P.mem_integers_iff_ord_nonneg.2 hf.ge⟩ := by
-  simp [residueUnit]
+  rw [residueUnit, ValuationSubring.coe_unitGroupToResidueFieldUnits_apply]
+  rfl
 
 /-- **The norm to `k` of the residue of a function that is a unit at `P`.** The residue field
 varies with `P`; the norm is what puts the value in `k`, the one field all the local factors of
@@ -124,8 +147,7 @@ theorem residueUnit_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
     (hg : P.ord (g : F) = 0) :
     P.residueUnit (f * g) (ord_mul_eq_zero hf hg)
       = P.residueUnit f hf * P.residueUnit g hg := by
-  ext
-  rw [Units.val_mul, val_residueUnit, val_residueUnit, val_residueUnit, ← map_mul]
+  rw [residueUnit, residueUnit, residueUnit, ← map_mul]
   rfl
 
 /-- **The norm of the residue is multiplicative in the function**, at a place where both factors
@@ -135,6 +157,34 @@ theorem normResidue_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
     P.normResidue (f * g) (ord_mul_eq_zero hf hg)
       = P.normResidue f hf * P.normResidue g hg := by
   rw [normResidue, normResidue, normResidue, residueUnit_mul hf hg, map_mul]
+
+/-- The order of the constant `1` is zero at every place, so `1` is admissible everywhere. -/
+theorem ord_one_units (P : Place k F) : P.ord ((1 : Fˣ) : F) = 0 := by
+  rw [Units.val_one, P.ord_one]
+
+/-- `ord_P f⁻¹ = -ord_P f`, so admissibility is invariant under inversion. -/
+theorem ord_inv_eq_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
+    P.ord ((f⁻¹ : Fˣ) : F) = 0 := by
+  rw [Units.val_inv_eq_inv_val, P.ord_inv, hf, neg_zero]
+
+/-- **The residue of the constant `1` is `1`**: `map_one` for the unit-group homomorphism. -/
+@[simp]
+theorem residueUnit_one (P : Place k F) (hf : P.ord ((1 : Fˣ) : F) = 0) :
+    P.residueUnit 1 hf = 1 := by
+  rw [residueUnit, ← map_one P.integers.unitGroupToResidueFieldUnits]
+  rfl
+
+/-- **The residue inverts with the function**: `map_inv` for the unit-group homomorphism. -/
+theorem residueUnit_inv {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
+    P.residueUnit f⁻¹ (ord_inv_eq_zero hf) = (P.residueUnit f hf)⁻¹ := by
+  rw [residueUnit, residueUnit, ← map_inv]
+  rfl
+
+/-- **The norm of the residue inverts with the function**, since `Algebra.normUnits` is a
+homomorphism. -/
+theorem normResidue_inv {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
+    P.normResidue f⁻¹ (ord_inv_eq_zero hf) = (P.normResidue f hf)⁻¹ := by
+  rw [normResidue, normResidue, residueUnit_inv hf, map_inv]
 
 /-- **The total local factor is multiplicative in the function**, at a place where both factors
 are units. The hypotheses cannot be dropped: at a place where `f` and `g` have opposite nonzero
@@ -146,10 +196,6 @@ theorem normResidueOrOne_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0
   rw [normResidueOrOne_of_ord_eq_zero (ord_mul_eq_zero hf hg),
     normResidueOrOne_of_ord_eq_zero hf, normResidueOrOne_of_ord_eq_zero hg,
     normResidue_mul hf hg]
-
-/-- The order of the constant `1` is zero at every place, so `1` is admissible everywhere. -/
-theorem ord_one_units (P : Place k F) : P.ord ((1 : Fˣ) : F) = 0 := by
-  rw [Units.val_one, P.ord_one]
 
 -- Not `@[simp]`: since `normResidueOrOne_of_ord_eq_zero` is `@[simp]` and `simp` can discharge
 -- `ord_P 1 = 0` on its own, the total form is rewritten to `normResidue` before this could fire.
@@ -176,10 +222,8 @@ dropped: a product can leave the subgroup `{ord_P = 0}` open on neither factor. 
 theorem normResidueOrOne_inv (P : Place k F) (f : Fˣ) :
     P.normResidueOrOne f⁻¹ = (P.normResidueOrOne f)⁻¹ := by
   by_cases hf : P.ord (f : F) = 0
-  · have h : P.ord ((f⁻¹ : Fˣ) : F) = 0 := by
-      rw [Units.val_inv_eq_inv_val, P.ord_inv, hf, neg_zero]
-    refine eq_inv_of_mul_eq_one_left ?_
-    rw [← normResidueOrOne_mul h hf, inv_mul_cancel, normResidueOrOne_one]
+  · refine eq_inv_of_mul_eq_one_left ?_
+    rw [← normResidueOrOne_mul (ord_inv_eq_zero hf) hf, inv_mul_cancel, normResidueOrOne_one]
   · have h : P.ord ((f⁻¹ : Fˣ) : F) ≠ 0 := by
       rw [Units.val_inv_eq_inv_val, P.ord_inv]
       simpa using hf

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -5,8 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.RingTheory.Norm.Defs
 public import TauCeti.FieldTheory.FunctionField.Place.Basic
+public import TauCeti.RingTheory.Norm.Units
 
 /-!
 # The residue of a function at a place, and its norm to the constants
@@ -41,9 +41,9 @@ not consume one — so the guarantee is recorded here rather than in the signatu
 ## Main results
 
 * `TauCeti.Place.val_residueUnit` and `TauCeti.Place.val_normResidue`: the underlying field values
-  of the two units, as `@[simp]` normal forms. Both are `rfl`, and they are the whole reason a
-  consumer never has to unfold either definition: they name the `IsLocalRing.residue` and
-  `Algebra.norm` the units are built from.
+  of the two units, as `@[simp]` normal forms. They are the whole reason a consumer never has to
+  unfold either definition: they name the `IsLocalRing.residue` and `Algebra.norm` the units are
+  built from.
 * `TauCeti.Place.normResidueOrOne_of_ord_eq_zero` and
   `TauCeti.Place.normResidueOrOne_of_ord_ne_zero`: the two branches of the total extension.
 
@@ -84,9 +84,11 @@ This is the classical field norm precisely when `Module.Finite k P.ResidueField`
 Absent that, `Algebra.norm` is the junk value `1`
 (`Algebra.norm_eq_one_of_not_module_finite`), exactly as `TauCeti.Place.degree` is junk `0`
 absent the same hypothesis. The hypothesis is not in the signature because `Algebra.norm` does
-not consume one, so requiring it here would leave it unused. -/
+not consume one, so requiring it here would leave it unused — the policy
+`TauCeti.Algebra.normUnits` states for itself, and this is that homomorphism applied to the
+residue. -/
 noncomputable def normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) : kˣ :=
-  Units.map (Algebra.norm k) (P.residueUnit f hf)
+  Algebra.normUnits k (P.residueUnit f hf)
 
 @[simp]
 theorem val_normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
@@ -149,13 +151,13 @@ theorem normResidueOrOne_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0
 theorem ord_one_units (P : Place k F) : P.ord ((1 : Fˣ) : F) = 0 := by
   rw [Units.val_one, P.ord_one]
 
-/-- The constant `1` has local factor `1`. Read off multiplicativity at `f = g = 1` rather than
-from the residue: `a = a * a` in a group forces `a = 1`.
-
-Not `@[simp]`: since `normResidueOrOne_of_ord_eq_zero` is `@[simp]` and `simp` can discharge
-`ord_P 1 = 0` on its own, the total form is rewritten to `normResidue` before this could fire.
-`normResidue_one` below is the `@[simp]` rule for that normal form. -/
+-- Not `@[simp]`: since `normResidueOrOne_of_ord_eq_zero` is `@[simp]` and `simp` can discharge
+-- `ord_P 1 = 0` on its own, the total form is rewritten to `normResidue` before this could fire.
+-- `normResidue_one` below is the `@[simp]` rule for that normal form.
+/-- The constant `1` has local factor `1`. -/
 theorem normResidueOrOne_one (P : Place k F) : P.normResidueOrOne (1 : Fˣ) = 1 := by
+  -- read off multiplicativity at `f = g = 1` rather than from the residue: `a = a * a` in a
+  -- group forces `a = 1`, which avoids all of the subtype-coercion work
   have h := normResidueOrOne_mul (P := P) (f := 1) (g := 1) P.ord_one_units P.ord_one_units
   rw [one_mul] at h
   exact right_eq_mul.1 h

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -38,6 +38,15 @@ not consume one — so the guarantee is recorded here rather than in the signatu
   unit, so that it is a total function of the place. Totality is what lets
   `TauCeti.Divisor.eval` be a homomorphism outright.
 
+## Main results
+
+* `TauCeti.Place.val_residueUnit` and `TauCeti.Place.val_normResidue`: the underlying field values
+  of the two units, as `@[simp]` normal forms. Both are `rfl`, and they are the whole reason a
+  consumer never has to unfold either definition: they name the `IsLocalRing.residue` and
+  `Algebra.norm` the units are built from.
+* `TauCeti.Place.normResidueOrOne_of_ord_eq_zero` and
+  `TauCeti.Place.normResidueOrOne_of_ord_ne_zero`: the two branches of the total extension.
+
 ## References
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.8 — the local factors
@@ -60,6 +69,12 @@ noncomputable def residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0)
   Units.mk0 (IsLocalRing.residue P.integers ⟨(f : F), P.mem_integers_iff_ord_nonneg.2 hf.ge⟩)
     (by rw [Ne, P.residue_eq_zero_iff_ord_pos (Units.ne_zero f), hf]; omega)
 
+@[simp]
+theorem val_residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
+    (P.residueUnit f hf : P.ResidueField)
+      = IsLocalRing.residue P.integers ⟨(f : F), P.mem_integers_iff_ord_nonneg.2 hf.ge⟩ := by
+  simp [residueUnit]
+
 /-- **The norm to `k` of the residue of a function that is a unit at `P`.** The residue field
 varies with `P`; the norm is what puts the value in `k`, the one field all the local factors of
 `TauCeti.Divisor.eval` have to share.
@@ -72,6 +87,11 @@ absent the same hypothesis. The hypothesis is not in the signature because `Alge
 not consume one, so requiring it here would leave it unused. -/
 noncomputable def normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) : kˣ :=
   Units.map (Algebra.norm k) (P.residueUnit f hf)
+
+@[simp]
+theorem val_normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
+    (P.normResidue f hf : k) = Algebra.norm k (P.residueUnit f hf : P.ResidueField) := by
+  simp [normResidue]
 
 /-- `normResidue` extended by `1` where `f` is not a unit, making it a total function of the
 place. `1` is the only workable neutral value: the coefficient of a place in a divisor is an

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -110,4 +110,39 @@ theorem normResidueOrOne_of_ord_ne_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f
     P.normResidueOrOne f = 1 := by
   simp [normResidueOrOne, hf]
 
+/-- The places where `f` is a unit are closed under multiplication of functions: `ord` is
+additive on nonzero elements. -/
+theorem ord_mul_eq_zero {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
+    (hg : P.ord (g : F) = 0) : P.ord ((f * g : Fˣ) : F) = 0 := by
+  rw [Units.val_mul, P.ord_mul (Units.ne_zero f) (Units.ne_zero g), hf, hg, add_zero]
+
+/-- **The residue is multiplicative in the function**, at a place where both factors are units:
+`IsLocalRing.residue` is a ring homomorphism. -/
+theorem residueUnit_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
+    (hg : P.ord (g : F) = 0) :
+    P.residueUnit (f * g) (ord_mul_eq_zero hf hg)
+      = P.residueUnit f hf * P.residueUnit g hg := by
+  ext
+  rw [Units.val_mul, val_residueUnit, val_residueUnit, val_residueUnit, ← map_mul]
+  rfl
+
+/-- **The norm of the residue is multiplicative in the function**, at a place where both factors
+are units. -/
+theorem normResidue_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
+    (hg : P.ord (g : F) = 0) :
+    P.normResidue (f * g) (ord_mul_eq_zero hf hg)
+      = P.normResidue f hf * P.normResidue g hg := by
+  rw [normResidue, normResidue, normResidue, residueUnit_mul hf hg, map_mul]
+
+/-- **The total local factor is multiplicative in the function**, at a place where both factors
+are units. The hypotheses cannot be dropped: at a place where `f` and `g` have opposite nonzero
+orders, `f * g` is a unit while neither factor is, so the left side is a genuine norm and the
+right side is `1`. -/
+theorem normResidueOrOne_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
+    (hg : P.ord (g : F) = 0) :
+    P.normResidueOrOne (f * g) = P.normResidueOrOne f * P.normResidueOrOne g := by
+  rw [normResidueOrOne_of_ord_eq_zero (ord_mul_eq_zero hf hg),
+    normResidueOrOne_of_ord_eq_zero hf, normResidueOrOne_of_ord_eq_zero hg,
+    normResidue_mul hf hg]
+
 end TauCeti.Place

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Norm.Defs
+public import TauCeti.FieldTheory.FunctionField.Place.Basic
+
+/-!
+# The residue of a function at a place, and its norm to the constants
+
+A function `f` that is a unit at a place `P` has a nonzero residue `f(P)` in the residue field
+`F_P`, and pushing that residue down to the constants `k` by the field norm gives a value that
+does not depend on `P` for its home. This file builds those two maps and extends the second by
+`1` to a total function of the place.
+
+The norm is what makes a *product over places* possible at all: `f(P)` lives in `F_P`, which
+varies with `P`, so without a common target the factors of a product like Weil reciprocity's
+`f(div g)` would live in different fields.
+
+**The norm is the classical field norm exactly when `F_P` is finite over `k`.** `Algebra.norm` is
+`LinearMap.det` of multiplication, so on a residue field that is *not* module-finite over `k` it
+takes Mathlib's junk value `1` (`Algebra.norm_eq_one_of_not_module_finite`), and then so does
+`normResidue`. That regime never arises where this API is meant to be used: over a function field
+every place has finite residue degree, by `TauCeti.Place.finiteDimensional_residueField`. The
+definitions below are stated without a finiteness hypothesis for the reason
+`TauCeti.Place.degree` is — the hypothesis would be unused in the term, since `Algebra.norm` does
+not consume one — so the guarantee is recorded here rather than in the signature.
+
+## Main definitions
+
+* `TauCeti.Place.residueUnit`: the residue `f(P)` of a function that is a unit at `P`, as a unit
+  of the residue field.
+* `TauCeti.Place.normResidue`: the norm to `k` of that residue, as a unit of `k`.
+* `TauCeti.Place.normResidueOrOne`: the same, extended by `1` at the places where `f` is not a
+  unit, so that it is a total function of the place. Totality is what lets
+  `TauCeti.Divisor.eval` be a homomorphism outright.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.8 — the local factors
+  of the divisor evaluation used there to construct the Weil pairing.
+-/
+
+public section
+
+namespace TauCeti.Place
+
+variable {k F : Type*} [Field k] [Field F] [Algebra k F]
+
+/-- **The residue `f(P)` of a function that is a unit at `P`**, as a unit of the residue field.
+Being a unit is what makes the residue nonzero, which is what lets it be raised to a negative
+power in `TauCeti.Divisor.eval`. -/
+noncomputable def residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
+    P.ResidueFieldˣ :=
+  -- `f` lies in `𝒪_P` because `0 ≤ ord_P f`, and the coercion back to `F` of the element of
+  -- `𝒪_P` so named is `rfl`, which is why `hf` and `Units.ne_zero f` apply to it verbatim.
+  Units.mk0 (IsLocalRing.residue P.integers ⟨(f : F), P.mem_integers_iff_ord_nonneg.2 hf.ge⟩)
+    (by rw [Ne, P.residue_eq_zero_iff_ord_pos (Units.ne_zero f), hf]; omega)
+
+/-- **The norm to `k` of the residue of a function that is a unit at `P`.** The residue field
+varies with `P`; the norm is what puts the value in `k`, the one field all the local factors of
+`TauCeti.Divisor.eval` have to share.
+
+This is the classical field norm precisely when `Module.Finite k P.ResidueField` — which
+`TauCeti.Place.finiteDimensional_residueField` supplies for every place of a function field.
+Absent that, `Algebra.norm` is the junk value `1`
+(`Algebra.norm_eq_one_of_not_module_finite`), exactly as `TauCeti.Place.degree` is junk `0`
+absent the same hypothesis. The hypothesis is not in the signature because `Algebra.norm` does
+not consume one, so requiring it here would leave it unused. -/
+noncomputable def normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) : kˣ :=
+  Units.map (Algebra.norm k) (P.residueUnit f hf)
+
+/-- `normResidue` extended by `1` where `f` is not a unit, making it a total function of the
+place. `1` is the only workable neutral value: the coefficient of a place in a divisor is an
+*integer*, so the local factor is raised to a possibly negative power, and only a value in `kˣ`
+survives that. -/
+noncomputable def normResidueOrOne (P : Place k F) (f : Fˣ) : kˣ :=
+  if hf : P.ord (f : F) = 0 then P.normResidue f hf else 1
+
+@[simp]
+theorem normResidueOrOne_of_ord_eq_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
+    P.normResidueOrOne f = P.normResidue f hf := by
+  simp [normResidueOrOne, hf]
+
+@[simp]
+theorem normResidueOrOne_of_ord_ne_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) ≠ 0) :
+    P.normResidueOrOne f = 1 := by
+  simp [normResidueOrOne, hf]
+
+end TauCeti.Place

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -49,15 +49,12 @@ not consume one — so the guarantee is recorded here rather than in the signatu
   `TauCeti.Place.normResidueOrOne_of_ord_ne_zero`: the two branches of the total extension.
 * The group laws in the function: `residueUnit_one`, `residueUnit_mul`, `residueUnit_inv` and
   their `normResidue` counterparts, together with `normResidueOrOne_one`, `normResidueOrOne_mul`
-  and `normResidueOrOne_inv` for the total form. Because `residueUnit` is the image of a
-  `MonoidHom`, the first three are `map_one`, `map_mul` and `map_inv`; the `normResidue` ones
-  compose that with `Algebra.normUnits`, itself a `MonoidHom`. Each of those takes the order
-  hypothesis of the *combined* function as an argument of its own, because that proof is what
+  and `normResidueOrOne_inv` for the total form. Each of the partial ones takes the order
+  hypothesis of the *combined* function as an argument of its own, since that proof is what
   indexes the left-hand side; the total form takes no such argument, which is what makes it the
-  form `TauCeti.Divisor.eval` is built on. Only the *total* form needs work, and only for the
-  product: `normResidueOrOne_mul` needs both factors admissible, while
-  `normResidueOrOne_inv` needs nothing, since `ord_P f⁻¹ = -ord_P f` vanishes exactly when
-  `ord_P f` does.
+  form `TauCeti.Divisor.eval` is built on. The total form is asymmetric:
+  `normResidueOrOne_mul` needs both factors admissible, while `normResidueOrOne_inv` needs
+  nothing, since `ord_P f⁻¹ = -ord_P f` vanishes exactly when `ord_P f` does.
 
 ## References
 
@@ -89,8 +86,10 @@ Being a unit is what makes the residue nonzero, which is what lets it be raised 
 power in `TauCeti.Divisor.eval`.
 
 This is Mathlib's `ValuationSubring.unitGroupToResidueFieldUnits` at the unit-group element `f`
-names, rather than a residue paired with a separate proof that it is nonzero. Being the image of
-a `MonoidHom` is what makes the group laws below `map_one`, `map_mul` and `map_inv`. -/
+names, rather than a residue paired with a separate proof that it is nonzero. -/
+-- Being the image of a `MonoidHom` is what makes the group laws below `map_one`, `map_mul` and
+-- `map_inv`, and the `normResidue` ones those composed with `Algebra.normUnits`, itself a
+-- `MonoidHom`.
 noncomputable def residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
     P.ResidueFieldˣ :=
   P.integers.unitGroupToResidueFieldUnits ⟨f, P.mem_unitGroup_of_ord_eq_zero hf⟩

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -40,10 +40,11 @@ not consume one — so the guarantee is recorded here rather than in the signatu
 
 ## Main results
 
-* `TauCeti.Place.val_residueUnit` and `TauCeti.Place.val_normResidue`: the underlying field values
-  of the two units, as `@[simp]` normal forms. They are the whole reason a consumer never has to
-  unfold either definition: they name the `IsLocalRing.residue` and `Algebra.norm` the units are
-  built from.
+* `TauCeti.Place.coe_residueUnit` and `TauCeti.Place.coe_normResidue`: the underlying field values
+  of the two units, as `@[simp]` normal forms, named after `TauCeti.Algebra.coe_normUnits` — the
+  adjacent lemma of exactly this shape. They are the whole reason a consumer never has to unfold
+  either definition: they name the `IsLocalRing.residue` and `Algebra.norm` the units are built
+  from.
 * `TauCeti.Place.normResidueOrOne_of_ord_eq_zero` and
   `TauCeti.Place.normResidueOrOne_of_ord_ne_zero`: the two branches of the total extension.
 * The group laws in the function: `residueUnit_one`, `residueUnit_mul`, `residueUnit_inv` and
@@ -92,7 +93,7 @@ noncomputable def residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0)
   P.integers.unitGroupToResidueFieldUnits ⟨f, P.mem_unitGroup_of_ord_eq_zero hf⟩
 
 @[simp]
-theorem val_residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
+theorem coe_residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
     (P.residueUnit f hf : P.ResidueField)
       = IsLocalRing.residue P.integers ⟨(f : F), P.mem_integers_iff_ord_nonneg.2 hf.ge⟩ := by
   rw [residueUnit, ValuationSubring.coe_unitGroupToResidueFieldUnits_apply]
@@ -114,7 +115,7 @@ noncomputable def normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0)
   Algebra.normUnits k (P.residueUnit f hf)
 
 @[simp]
-theorem val_normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
+theorem coe_normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
     (P.normResidue f hf : k) = Algebra.norm k (P.residueUnit f hf : P.ResidueField) := by
   simp [normResidue]
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -145,4 +145,42 @@ theorem normResidueOrOne_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0
     normResidueOrOne_of_ord_eq_zero hf, normResidueOrOne_of_ord_eq_zero hg,
     normResidue_mul hf hg]
 
+/-- The order of the constant `1` is zero at every place, so `1` is admissible everywhere. -/
+theorem ord_one_units (P : Place k F) : P.ord ((1 : Fˣ) : F) = 0 := by
+  rw [Units.val_one, P.ord_one]
+
+/-- The constant `1` has local factor `1`. Read off multiplicativity at `f = g = 1` rather than
+from the residue: `a = a * a` in a group forces `a = 1`.
+
+Not `@[simp]`: since `normResidueOrOne_of_ord_eq_zero` is `@[simp]` and `simp` can discharge
+`ord_P 1 = 0` on its own, the total form is rewritten to `normResidue` before this could fire.
+`normResidue_one` below is the `@[simp]` rule for that normal form. -/
+theorem normResidueOrOne_one (P : Place k F) : P.normResidueOrOne (1 : Fˣ) = 1 := by
+  have h := normResidueOrOne_mul (P := P) (f := 1) (g := 1) P.ord_one_units P.ord_one_units
+  rw [one_mul] at h
+  exact right_eq_mul.1 h
+
+/-- The residue of the constant `1` has norm `1`. -/
+@[simp]
+theorem normResidue_one (P : Place k F) (hf : P.ord ((1 : Fˣ) : F) = 0) :
+    P.normResidue 1 hf = 1 := by
+  rw [← normResidueOrOne_of_ord_eq_zero hf, normResidueOrOne_one]
+
+/-- **Inversion needs no admissibility hypothesis.** `ord_P f⁻¹ = -ord_P f` vanishes exactly when
+`ord_P f` does, so the two places of `normResidueOrOne`'s case split correspond under inversion
+and both branches invert. Contrast `normResidueOrOne_mul`, where the hypotheses cannot be
+dropped: a product can leave the subgroup `{ord_P = 0}` open on neither factor. -/
+@[simp]
+theorem normResidueOrOne_inv (P : Place k F) (f : Fˣ) :
+    P.normResidueOrOne f⁻¹ = (P.normResidueOrOne f)⁻¹ := by
+  by_cases hf : P.ord (f : F) = 0
+  · have h : P.ord ((f⁻¹ : Fˣ) : F) = 0 := by
+      rw [Units.val_inv_eq_inv_val, P.ord_inv, hf, neg_zero]
+    refine eq_inv_of_mul_eq_one_left ?_
+    rw [← normResidueOrOne_mul h hf, inv_mul_cancel, normResidueOrOne_one]
+  · have h : P.ord ((f⁻¹ : Fˣ) : F) ≠ 0 := by
+      rw [Units.val_inv_eq_inv_val, P.ord_inv]
+      simpa using hf
+    rw [normResidueOrOne_of_ord_ne_zero h, normResidueOrOne_of_ord_ne_zero hf, inv_one]
+
 end TauCeti.Place

--- a/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Residue.lean
@@ -51,8 +51,11 @@ not consume one — so the guarantee is recorded here rather than in the signatu
   their `normResidue` counterparts, together with `normResidueOrOne_one`, `normResidueOrOne_mul`
   and `normResidueOrOne_inv` for the total form. Because `residueUnit` is the image of a
   `MonoidHom`, the first three are `map_one`, `map_mul` and `map_inv`; the `normResidue` ones
-  compose that with `Algebra.normUnits`, itself a `MonoidHom`. Only the *total* form needs work,
-  and only for the product: `normResidueOrOne_mul` needs both factors admissible, while
+  compose that with `Algebra.normUnits`, itself a `MonoidHom`. Each of those takes the order
+  hypothesis of the *combined* function as an argument of its own, because that proof is what
+  indexes the left-hand side; the total form takes no such argument, which is what makes it the
+  form `TauCeti.Divisor.eval` is built on. Only the *total* form needs work, and only for the
+  product: `normResidueOrOne_mul` needs both factors admissible, while
   `normResidueOrOne_inv` needs nothing, since `ord_P f⁻¹ = -ord_P f` vanishes exactly when
   `ord_P f` does.
 
@@ -140,52 +143,40 @@ theorem normResidueOrOne_of_ord_ne_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f
     P.normResidueOrOne f = 1 := by
   simp [normResidueOrOne, hf]
 
-/-- The places where `f` is a unit are closed under multiplication of functions: `ord` is
-additive on nonzero elements. -/
-theorem ord_mul_eq_zero {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
-    (hg : P.ord (g : F) = 0) : P.ord ((f * g : Fˣ) : F) = 0 := by
-  rw [Units.val_mul, P.ord_mul (Units.ne_zero f) (Units.ne_zero g), hf, hg, add_zero]
-
 /-- **The residue is multiplicative in the function**, at a place where both factors are units:
-`IsLocalRing.residue` is a ring homomorphism. -/
+`(f g)(P) = f(P) · g(P)`. -/
 theorem residueUnit_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
-    (hg : P.ord (g : F) = 0) :
-    P.residueUnit (f * g) (ord_mul_eq_zero hf hg)
-      = P.residueUnit f hf * P.residueUnit g hg := by
+    (hg : P.ord (g : F) = 0) (hfg : P.ord ((f * g : Fˣ) : F) = 0) :
+    P.residueUnit (f * g) hfg = P.residueUnit f hf * P.residueUnit g hg := by
   rw [residueUnit, residueUnit, residueUnit, ← map_mul]
   rfl
 
 /-- **The norm of the residue is multiplicative in the function**, at a place where both factors
 are units. -/
 theorem normResidue_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
-    (hg : P.ord (g : F) = 0) :
-    P.normResidue (f * g) (ord_mul_eq_zero hf hg)
-      = P.normResidue f hf * P.normResidue g hg := by
-  rw [normResidue, normResidue, normResidue, residueUnit_mul hf hg, map_mul]
+    (hg : P.ord (g : F) = 0) (hfg : P.ord ((f * g : Fˣ) : F) = 0) :
+    P.normResidue (f * g) hfg = P.normResidue f hf * P.normResidue g hg := by
+  rw [normResidue, normResidue, normResidue, residueUnit_mul hf hg hfg, map_mul]
 
-/-- `ord_P f⁻¹ = -ord_P f`, so admissibility is invariant under inversion. -/
-theorem ord_inv_eq_zero {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
-    P.ord ((f⁻¹ : Fˣ) : F) = 0 := by
-  rw [Units.val_inv_eq_inv_val, P.ord_inv, hf, neg_zero]
-
-/-- **The residue of the constant `1` is `1`**: `map_one` for the unit-group homomorphism. -/
+/-- **The residue of the constant `1` is `1`.** -/
 @[simp]
 theorem residueUnit_one (P : Place k F) (hf : P.ord ((1 : Fˣ) : F) = 0) :
     P.residueUnit 1 hf = 1 := by
   rw [residueUnit, ← map_one P.integers.unitGroupToResidueFieldUnits]
   rfl
 
-/-- **The residue inverts with the function**: `map_inv` for the unit-group homomorphism. -/
-theorem residueUnit_inv {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
-    P.residueUnit f⁻¹ (ord_inv_eq_zero hf) = (P.residueUnit f hf)⁻¹ := by
+/-- **The residue inverts with the function**: `f⁻¹(P) = f(P)⁻¹`. -/
+theorem residueUnit_inv {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0)
+    (hfinv : P.ord ((f⁻¹ : Fˣ) : F) = 0) :
+    P.residueUnit f⁻¹ hfinv = (P.residueUnit f hf)⁻¹ := by
   rw [residueUnit, residueUnit, ← map_inv]
   rfl
 
-/-- **The norm of the residue inverts with the function**, since `Algebra.normUnits` is a
-homomorphism. -/
-theorem normResidue_inv {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0) :
-    P.normResidue f⁻¹ (ord_inv_eq_zero hf) = (P.normResidue f hf)⁻¹ := by
-  rw [normResidue, normResidue, residueUnit_inv hf, map_inv]
+/-- **The norm of the residue inverts with the function**: `N(f⁻¹(P)) = N(f(P))⁻¹`. -/
+theorem normResidue_inv {P : Place k F} {f : Fˣ} (hf : P.ord (f : F) = 0)
+    (hfinv : P.ord ((f⁻¹ : Fˣ) : F) = 0) :
+    P.normResidue f⁻¹ hfinv = (P.normResidue f hf)⁻¹ := by
+  rw [normResidue, normResidue, residueUnit_inv hf hfinv, map_inv]
 
 /-- **The total local factor is multiplicative in the function**, at a place where both factors
 are units. The hypotheses cannot be dropped: at a place where `f` and `g` have opposite nonzero
@@ -194,9 +185,10 @@ right side is `1`. -/
 theorem normResidueOrOne_mul {P : Place k F} {f g : Fˣ} (hf : P.ord (f : F) = 0)
     (hg : P.ord (g : F) = 0) :
     P.normResidueOrOne (f * g) = P.normResidueOrOne f * P.normResidueOrOne g := by
-  rw [normResidueOrOne_of_ord_eq_zero (ord_mul_eq_zero hf hg),
-    normResidueOrOne_of_ord_eq_zero hf, normResidueOrOne_of_ord_eq_zero hg,
-    normResidue_mul hf hg]
+  have hfg : P.ord ((f * g : Fˣ) : F) = 0 := by
+    rw [Units.val_mul, P.ord_mul (Units.ne_zero f) (Units.ne_zero g), hf, hg, add_zero]
+  rw [normResidueOrOne_of_ord_eq_zero hfg, normResidueOrOne_of_ord_eq_zero hf,
+    normResidueOrOne_of_ord_eq_zero hg, normResidue_mul hf hg hfg]
 
 -- Not `@[simp]`: since `normResidueOrOne_of_ord_eq_zero` is `@[simp]` and `simp` can discharge
 -- `ord_P 1 = 0` on its own, the total form is rewritten to `normResidue` before this could fire.
@@ -225,10 +217,12 @@ theorem normResidueOrOne_inv (P : Place k F) (f : Fˣ) :
     P.normResidueOrOne f⁻¹ = (P.normResidueOrOne f)⁻¹ := by
   by_cases hf : P.ord (f : F) = 0
   · refine eq_inv_of_mul_eq_one_left ?_
-    rw [← normResidueOrOne_mul (ord_inv_eq_zero hf) hf, inv_mul_cancel, normResidueOrOne_one]
-  · have h : P.ord ((f⁻¹ : Fˣ) : F) ≠ 0 := by
+    have hfinv : P.ord ((f⁻¹ : Fˣ) : F) = 0 := by
+      rw [Units.val_inv_eq_inv_val, P.ord_inv, hf, neg_zero]
+    rw [← normResidueOrOne_mul hfinv hf, inv_mul_cancel, normResidueOrOne_one]
+  · have hfinv : P.ord ((f⁻¹ : Fˣ) : F) ≠ 0 := by
       rw [Units.val_inv_eq_inv_val, P.ord_inv]
       simpa using hf
-    rw [normResidueOrOne_of_ord_ne_zero h, normResidueOrOne_of_ord_ne_zero hf, inv_one]
+    rw [normResidueOrOne_of_ord_ne_zero hfinv, normResidueOrOne_of_ord_ne_zero hf, inv_one]
 
 end TauCeti.Place


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divisor-eval"}-->

## The target

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 2, "The Weil pairing — the divisor construction",
lists the pairing's prerequisites as named milestones:

> Its named prerequisites, each a milestone: existence of a function with divisor `N(P) − N(O)`;
> moving a divisor within its class to obtain disjoint support; **evaluation of a function on a
> divisor of disjoint support**; **Weil reciprocity** `f(div g) = g(div f)`; and independence of
> every function and divisor choice.

This PR is the third of those — the quantity Weil reciprocity compares.

## What it adds

Two modules, split along the line between place-local and divisor material.

`FieldTheory/FunctionField/Place/Residue.lean` — the local factors, generic place API:

```lean
noncomputable def Place.residueUnit (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) :
    P.ResidueFieldˣ
noncomputable def Place.normResidue (P : Place k F) (f : Fˣ) (hf : P.ord (f : F) = 0) : kˣ
noncomputable def Place.normResidueOrOne (P : Place k F) (f : Fˣ) : kˣ
```

with `normResidueOrOne_of_ord_eq_zero` and `normResidueOrOne_of_ord_ne_zero`, the two `@[simp]`
branch rules; `ord_mul_eq_zero`, `residueUnit_mul`, `normResidue_mul`,
`normResidueOrOne_mul`, `normResidueOrOne_one`, `normResidue_one` and `normResidueOrOne_inv`, the
local group laws in the function variable; and
`coe_residueUnit` / `coe_normResidue`, the `@[simp]` field values of the two units, named after the adjacent `TauCeti.Algebra.coe_normUnits` — so a consumer relates them to
`IsLocalRing.residue` and `Algebra.norm` without unfolding either definition.

Neither value lemma is `rfl`, and that is not a stylistic choice: an **exported** `rfl` theorem
requires every definition it unfolds to be `@[expose]`d —

```
Not a definitional equality: the left-hand side
  ↑(P.residueUnit f hf)
is not definitionally equal to the right-hand side
  (IsLocalRing.residue ↥P.integers) ⟨↑f, ⋯⟩
Note: This theorem is exported from the current module. This requires that all definitions that
need to be unfolded to prove this theorem must be exposed.
```

— whereas a tactic proof (`simp [residueUnit]`) exports a proof term instead of a defeq
obligation. So the bodies stay unexposed and the values are still named. Checked downstream: a
probe module importing only `Divisor/Eval.lean` closes both value goals by `simp` alone.

`FieldTheory/FunctionField/Divisor/Eval.lean` — the product over a divisor:

```lean
noncomputable def Divisor.eval (D : Divisor k F) (f : Fˣ) : kˣ
def Divisor.IsUnitAtSupport (D : Divisor k F) (f : Fˣ) : Prop
```

`eval` is `MonoidHom`-backed, but that homomorphism is **private**: `eval_zero`/`eval_add`/
`eval_neg`/`eval_sub` being hypothesis-free is the whole of what it buys a consumer, so the bundled
map is not public surface. It can be made public when something outside the module needs it.

with `eval_zero`, `eval_add`, `eval_neg`, `eval_sub`, `eval_single`, `eval_eq_finsuppProd`,
`eval_eq_prod_normResidue`, `isUnitAtSupport_iff` and `isUnitAtSupport_iff_disjoint`.
`eval_zero`, `eval_add`, `eval_neg`, `eval_sub`, `eval_single` and `isUnitAtSupport_iff` are all
`@[simp]`; `eval_eq_finsuppProd` deliberately is not (below).

## The other half of the bilinearity

`evalHom` is a homomorphism in the *divisor*, so `eval_add`/`eval_neg`/`eval_sub`/`eval_zero` are
hypothesis-free. The function variable is not automatic, and the group laws there split into two
kinds — which is the mathematical content, not boilerplate:

```lean
@[simp] theorem eval_one (D : Divisor k F) : eval D (1 : Fˣ) = 1
@[simp] theorem eval_inv (D : Divisor k F) (f : Fˣ) : eval D f⁻¹ = (eval D f)⁻¹

theorem eval_mul (hf : IsUnitAtSupport D f) (hg : IsUnitAtSupport D g) :
    eval D (f * g) = eval D f * eval D g
theorem eval_div (hf : IsUnitAtSupport D f) (hg : IsUnitAtSupport D g) :
    eval D (f / g) = eval D f / eval D g
```

**`eval_one` and `eval_inv` need no hypothesis.** `ord_P f⁻¹ = -ord_P f` vanishes exactly when
`ord_P f` does, so admissibility is *invariant* under inversion, and at the places where `f` is
not a unit both sides are `1`. `isUnitAtSupport_inv_iff` records the invariance as an iff.

**`eval_mul` and `eval_div` genuinely need both.** At a place where `f` and `g` have opposite
nonzero orders their product is a unit while neither factor is, so the left side sees a real norm
there and the right side sees `1` twice. Admissibility is a subgroup condition in **each** variable, which is what makes the laws
composable:

| | zero/one | closure | invariance | inverse/difference |
|---|---|---|---|---|
| function | `isUnitAtSupport_one` | `IsUnitAtSupport.mul` | `isUnitAtSupport_inv_iff` | `IsUnitAtSupport.div` |
| divisor | `isUnitAtSupport_zero` | `IsUnitAtSupport.add` | `isUnitAtSupport_neg_iff` | `IsUnitAtSupport.sub` |

The function row is what Weil reciprocity and the independence-of-choices milestone (comparing two
functions with the same divisor) are stated against; the divisor row is what moving a divisor
within its class to obtain disjoint support needs. Both are named roadmap prerequisites of
III.8.1.

`IsUnitAtSupport.add` takes its support inclusion from `Finsupp.support_add`, under a local
`classical` — that supplies the `DecidableEq (Place k F)` the union mentions without putting it in
the statement.

### Two simp decisions, linter-verified rather than assumed

`normResidueOrOne_one` is **not** `@[simp]`: `normResidueOrOne_of_ord_eq_zero` is, and `simp`
discharges `ord_P 1 = 0` on its own, so the total form is rewritten to `normResidue` before the
`one` rule could fire. `normResidue_one` is the `@[simp]` rule for that normal form. This surfaced
as a real failure — `simp [eval_eq_finsuppProd]` left `∏ normResidue 1 ⋯ ^ n = 1` open — not as a
guess.

The four "invariance" closure lemmas (`isUnitAtSupport_one`, `isUnitAtSupport_inv_iff`,
`isUnitAtSupport_zero`, `isUnitAtSupport_neg_iff`) are **not** `@[simp]` either: with
`isUnitAtSupport_iff` tagged, `simp` proves both outright, and the environment linter reports them
as redundant simp lemmas when they carry the attribute (`simp can prove this`). They stay as named
lemmas because they are what a term-mode proof reaches for.

### On the size of this PR

The module grew over four `api-design` rounds, each asking for the next slice of the surrounding
API: the unit value lemmas, then multiplicativity in the function, then the remaining group laws
there, then the divisor-side closure. Every request was correct and none contradicted an earlier
one, so all were implemented rather than contested — and the result is a genuinely complete API
rather than the minimum that compiles. Both closure directions are now saturated: there is no
further zero/one, product, inverse or difference law to add in either variable.

`f(D) = ∏_{P ∈ supp D} N_{F_P/k}(f(P)) ^ (coeff D P)`. The norm is not decoration: `f(P)` lives in
the residue field `F_P`, which varies with `P`, so without pushing each value down to `k` the
factors would live in different fields and the product would not typecheck.

## Three load-bearing design choices

**Functions in `Fˣ`, not `F`.** The admissibility condition is `P.ord f = 0`, and `P.ord 0 = 0` by
the junk-value convention on `ord` — so over `F` the condition would declare `f = 0` admissible at
*every* place. `Divisor.principal` is already stated for `Fˣ`, so this also matches the API it will
be used with.

**Values in `kˣ` with neutral value `1`**, not in `k` with `0`. Coefficients are integers, so each
local factor is raised to a possibly negative power and the divisor law has to survive that. With
`0` in `k` it does not: at a place where `f` is not a unit,
`eval (single P 1) * eval (single P (-1))` would be `0` while `eval 0 = 1`. In `kˣ` every `zpow`
identity is unconditional and the law is automatic.

**A total definition, with admissibility on the theorems.** Making the hypothesis an argument would
put a proof term inside `f(D)`, to be transported through every rewrite of `D` or `f`, and would
block packaging `f(-)` as a homomorphism at all. Instead `normResidueOrOne` is total, `evalHom` is a
`MonoidHom` out of `Multiplicative (Divisor k F)`, so `eval_zero`/`eval_add`/`eval_neg`/`eval_sub`
are hypothesis-free, and `eval_eq_prod_normResidue` recovers the textbook product exactly where
admissibility holds.

## Reuse

Everything rests on existing API rather than new machinery:

- `TauCeti.freeAbelianCharEquiv` (`Algebra/Group/FreeAbelianCharacter.lean`) supplies
  multiplicativity: a divisor is a finitely supported integer combination of places, so a
  homomorphism out of it is exactly a choice of value per place. Its `@[simp]`
  `freeAbelianCharEquiv_symm_apply_ofAdd` gives the Finsupp product directly.
- `ValuationSubring.unitGroupToResidueFieldUnits` is Mathlib's residue map on unit groups, so
  `residueUnit` is that at the unit-group element `f` names — not a residue paired with a separate
  nonzero proof. **This is what makes the whole group law free**: `residueUnit_one`/`_mul`/`_inv`
  are `map_one`/`map_mul`/`map_inv`.
- Landing in the unit group needs one detour worth recording. `Valuation.mem_unitGroup_iff` would
  ask unification to see `P.integers` as `P.valuation.valuationSubring`, and **`Place.integers` is
  not an exposed definition** — Lean says so outright, `integers ↦ 105` — so that unfolding is
  unavailable outside `Place/Basic.lean` and the attempt exhausts the heartbeat budget at `whnf`.
  `mem_unitGroup_of_ord_eq_zero` therefore routes through `IsUnit`, via
  `ValuationSubring.mem_unitGroup_iff` and `ValuationSubring.valuation_eq_one_iff`, both generic in
  the subring. No `@[expose]` and no new lemma in `Place/Basic.lean` were needed.
- `TauCeti.Algebra.normUnits` (`RingTheory/Norm/Units.lean`) is the norm as a homomorphism of unit
  groups, so `normResidue` is that applied to the residue rather than a hand-rolled
  `Units.map (Algebra.norm k)`, and `normResidue_mul` is `map_mul`. Its docstring also states the
  finiteness policy argued for below — "No finiteness hypothesis is needed here, because
  `Algebra.norm` itself has none … A consumer that cares about the value supplies its own
  finiteness where the value is computed" — so this module cites it rather than restating it.
- `mem_support_principal_iff` gives `isUnitAtSupport_iff_disjoint`.
- No thin specialisations are added: an earlier revision carried
  `mem_integers_of_ord_eq_zero` (a special case of `mem_integers_iff_ord_nonneg`, now inlined as
  `hf.ge`) and `normResidue_eq_one_of_not_finite` (a `kˣ`-valued restatement of
  `Algebra.norm_eq_one_of_not_module_finite`, now cited from the docstring instead). Both are gone.

**On finiteness.** An earlier version of this description claimed no finiteness hypothesis was
needed, because `Units.map` sends units to units for any `MonoidHom`. That is true of
well-typedness and false of meaning, and `correctness` was right to block it: `Algebra.norm` is
`LinearMap.det ∘ lmul`, so on a residue field that is not module-finite over `k` it is the junk
value `1` (`Algebra.norm_eq_one_of_not_module_finite`), and `eval` would silently drop that factor.

The norm is therefore the classical field norm *exactly* when `Module.Finite k P.ResidueField`,
which `Place.finiteDimensional_residueField` supplies at every place of a function field — so the
junk regime never arises where this API is used. Both the module docstring and `normResidue`'s own
docstring say this and name the Mathlib lemma that bounds the junk regime.

The hypothesis is deliberately *not* in the signatures: `Algebra.norm` consumes no finiteness
argument, so it would be unused in every one of `normResidue`, `normResidueOrOne`, `evalHom` and
`eval`, and the `unusedArguments` linter rejects unused instance arguments — that linter failed CI
on #5600 for exactly this pattern. This mirrors `TauCeti.Place.degree`, an un-hypothesised
definition in this same development whose docstring likewise records that finiteness "guards the
junk value of `Module.finrank`".

`IsFunctionField` appears only in `isUnitAtSupport_iff_disjoint`, where `principal` requires it.

`eval_eq_finsuppProd` is deliberately **not** `@[simp]`, for the reason already recorded on
`WeierstrassCurve.Affine.Point.naiveHeight_eq_logHeight`: tagging a defining equation dissolves
`eval` on sight and puts the structural lemmas out of simp-normal form. The `#lint` environment
linter reports exactly `eval_zero`, `eval_neg` and `eval_single` when it does carry `@[simp]` —
that is how the decision was checked, not assumed. The rationale lives in a comment above the
theorem, not in its docstring.

## `IsUnitAtSupport` is not exposed

The predicate is an ordinary opaque `def`, and `isUnitAtSupport_iff` (`Iff.rfl`) is its whole
interface: introduction and elimination in one lemma. `eval_eq_prod_normResidue` therefore states
its membership proofs as `isUnitAtSupport_iff.1 h P.1 P.2` rather than applying `h` directly, which
is what previously forced `@[expose]`. Checked with a downstream probe module rather than assumed —
a separate file importing only `Divisor/Eval.lean` applies the product formula, introduces the
predicate from the pointwise condition, and eliminates it, all with the body unexposed.

## Placement

The residue-and-norm layer mentions no divisor: it is generic place API, so it lives in
`FieldTheory/FunctionField/Place/Residue.lean` next to `Basic`, `Degree`, `Zeros` and the rest, and
a consumer who wants the local norm no longer has to import `Divisor/Principal.lean` to reach it.
`Divisor/Eval.lean` imports it and keeps only the divisor material, alongside `Basic`, `Principal`,
`ProductFormula`, `Conorm` and `AffineModel`.

There is no elliptic-curve content in either module: this is general function-field material,
motivated by the elliptic roadmap (hence the `Roadmap:` line) but stated for any `F/k`. The
elliptic function field reaches it through the existing `WeierstrassCurve.Affine.isFunctionField`.

## Provenance

**Original work**, following the classical construction the roadmap names: Silverman, *The
Arithmetic of Elliptic Curves*, III.8 (the divisor construction of the Weil pairing, III.8.1), now
cited in both module docstrings under `## References` via the `[silverman2009]` bibliography key.

Absence checked before writing: `grep -rniE 'weilReciprocity|weil_reciprocity'` over TauCeti and
the pinned Mathlib returns nothing (only quadratic, Artin and Frobenius reciprocity, in unrelated
developments), and `evalDivisor|eval_divisor|divisorEval` returns nothing in either.

## Gates

- `lake build`: green, 0 errors, 0 warnings under `warningAsError = true`, no Mathlib recompiled.
- `scripts/lint-style.sh`: exit 0, all 4324 headers conforming; no line over 100 characters.
- **`#lint in TauCeti` — the full environment-linter set, not just simpNF**: "All linting checks
  passed", 0 errors in 633 declarations. The narrower simpNF-only probe is what let an
  `unusedArguments` violation reach CI on #5600, so this runs the full set; it is also what
  confirmed every `@[simp]` decision in the two modules, in both directions: which tags are safe
  and which two would be redundant.
- `scripts/lint-dot-notation.py`: 0 new.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; 2 files, both new (new-file guard is 1000
  additions each).
- Claim at `refs/tauceti-claims/author/EllipticCurves/divisor-eval`; no open PR carries an
  overlapping marker and none touches `FunctionField/Divisor/` or `FunctionField/Place/`.
