### PR TITLE
feat: construct the maximal pro-p quotient of a profinite group

### DIFF
--- a/TauCeti/GroupTheory/PGroup.lean
+++ b/TauCeti/GroupTheory/PGroup.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.PGroup
+public import Mathlib.GroupTheory.QuotientGroup.Defs
+
+/-!
+# Normal subgroups with `p`-group quotient
+
+Mathlib's `IsPGroup.to_quotient` says that every quotient of a `p`-group is again a `p`-group.
+This file records the complementary behaviour, in which the group is fixed and the normal
+subgroup varies: how the property `IsPGroup p (G ⧸ N)` of *the quotient* behaves under
+intersection of normal subgroups and under preimage along a group homomorphism.
+
+Both statements are group-theoretic, with no topology. They are what makes the family of
+normal subgroups with `p`-group quotient usable: `IsPGroup.quotient_inf` says the family is
+closed under binary intersection, hence downward directed, and `IsPGroup.quotient_comap` says
+it is contravariantly functorial. The profinite development uses the first to run a compactness
+argument on the family of open normal subgroups with `p`-group quotient, and the second to see
+that a homomorphism into a pro-`p` group kills their intersection.
+
+## Main results
+
+* `IsPGroup.quotient_inf`: if `G ⧸ M` and `G ⧸ N` are `p`-groups, so is `G ⧸ (M ⊓ N)`.
+* `IsPGroup.quotient_comap`: if `H ⧸ N` is a `p`-group and `f : G →* H`, then `G ⧸ N.comap f`
+  is a `p`-group.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {p : ℕ} {G : Type*} [Group G] {H : Type*} [Group H]
+
+/-- If the quotients of `G` by two normal subgroups `M` and `N` are `p`-groups, then so is the
+quotient by `M ⊓ N`: if `g ^ p ^ m` lies in `M` and `g ^ p ^ n` lies in `N`, then
+`g ^ p ^ (m + n)`, which is a power of each of these, lies in both.
+
+Consequently the normal subgroups of `G` with `p`-group quotient are closed under binary
+intersection, hence downward directed. -/
+theorem _root_.IsPGroup.quotient_inf {M N : Subgroup G} [M.Normal] [N.Normal]
+    (hM : IsPGroup p (G ⧸ M)) (hN : IsPGroup p (G ⧸ N)) : IsPGroup p (G ⧸ M ⊓ N) := by
+  intro x
+  obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective (M ⊓ N) x
+  obtain ⟨m, hm⟩ := hM (QuotientGroup.mk' M g)
+  obtain ⟨n, hn⟩ := hN (QuotientGroup.mk' N g)
+  rw [← map_pow, QuotientGroup.mk'_apply, QuotientGroup.eq_one_iff] at hm hn
+  refine ⟨m + n, ?_⟩
+  rw [← map_pow, QuotientGroup.mk'_apply, QuotientGroup.eq_one_iff, Subgroup.mem_inf]
+  refine ⟨?_, ?_⟩
+  · rw [pow_add, pow_mul]
+    exact Subgroup.pow_mem M hm _
+  · rw [pow_add, mul_comm, pow_mul]
+    exact Subgroup.pow_mem N hn _
+
+/-- If the quotient of `H` by a normal subgroup `N` is a `p`-group, then so is the quotient of
+`G` by the preimage of `N` along any homomorphism `f : G →* H`: the induced map
+`G ⧸ N.comap f →* H ⧸ N` is injective, because `N.comap f` consists of exactly the elements
+that `f` sends into `N`. -/
+theorem _root_.IsPGroup.quotient_comap {N : Subgroup H} [N.Normal] (hN : IsPGroup p (H ⧸ N))
+    (f : G →* H) : IsPGroup p (G ⧸ N.comap f) := by
+  refine hN.of_injective (QuotientGroup.map (N.comap f) N f le_rfl) ?_
+  intro a b hab
+  obtain ⟨x, rfl⟩ := QuotientGroup.mk'_surjective (N.comap f) a
+  obtain ⟨y, rfl⟩ := QuotientGroup.mk'_surjective (N.comap f) b
+  rw [QuotientGroup.mk'_apply, QuotientGroup.mk'_apply, QuotientGroup.map_mk,
+    QuotientGroup.map_mk, QuotientGroup.eq] at hab
+  rw [QuotientGroup.mk'_apply, QuotientGroup.mk'_apply, QuotientGroup.eq]
+  simpa using hab
+
+end TauCeti

--- a/TauCeti/GroupTheory/PGroup.lean
+++ b/TauCeti/GroupTheory/PGroup.lean
@@ -36,12 +36,7 @@ namespace TauCeti
 
 variable {p : ℕ} {G : Type*} [Group G] {H : Type*} [Group H]
 
-/-- If the quotients of `G` by two normal subgroups `M` and `N` are `p`-groups, then so is the
-quotient by `M ⊓ N`: if `g ^ p ^ m` lies in `M` and `g ^ p ^ n` lies in `N`, then
-`g ^ p ^ (m + n)`, which is a power of each of these, lies in both.
-
-Consequently the normal subgroups of `G` with `p`-group quotient are closed under binary
-intersection, hence downward directed. -/
+/-- The normal subgroups of `G` with `p`-group quotient are closed under binary intersection. -/
 theorem _root_.IsPGroup.quotient_inf {M N : Subgroup G} [M.Normal] [N.Normal]
     (hM : IsPGroup p (G ⧸ M)) (hN : IsPGroup p (G ⧸ N)) : IsPGroup p (G ⧸ M ⊓ N) := by
   intro x
@@ -57,19 +52,14 @@ theorem _root_.IsPGroup.quotient_inf {M N : Subgroup G} [M.Normal] [N.Normal]
   · rw [pow_add, mul_comm, pow_mul]
     exact Subgroup.pow_mem N hn _
 
-/-- If the quotient of `H` by a normal subgroup `N` is a `p`-group, then so is the quotient of
-`G` by the preimage of `N` along any homomorphism `f : G →* H`: the induced map
-`G ⧸ N.comap f →* H ⧸ N` is injective, because `N.comap f` consists of exactly the elements
-that `f` sends into `N`. -/
+/-- The preimage of a normal subgroup with `p`-group quotient also has `p`-group quotient. -/
 theorem _root_.IsPGroup.quotient_comap {N : Subgroup H} [N.Normal] (hN : IsPGroup p (H ⧸ N))
     (f : G →* H) : IsPGroup p (G ⧸ N.comap f) := by
-  refine hN.of_injective (QuotientGroup.map (N.comap f) N f le_rfl) ?_
-  intro a b hab
-  obtain ⟨x, rfl⟩ := QuotientGroup.mk'_surjective (N.comap f) a
-  obtain ⟨y, rfl⟩ := QuotientGroup.mk'_surjective (N.comap f) b
-  rw [QuotientGroup.mk'_apply, QuotientGroup.mk'_apply, QuotientGroup.map_mk,
-    QuotientGroup.map_mk, QuotientGroup.eq] at hab
-  rw [QuotientGroup.mk'_apply, QuotientGroup.mk'_apply, QuotientGroup.eq]
-  simpa using hab
+  let φ := (QuotientGroup.mk' N).comp f
+  have hφ : N.comap f = φ.ker := by
+    simpa [φ] using MonoidHom.comap_ker (g := QuotientGroup.mk' N) (f := f)
+  exact (hN.of_injective (QuotientGroup.kerLift φ)
+    (QuotientGroup.kerLift_injective φ)).of_equiv
+      (QuotientGroup.quotientMulEquivOfEq hφ.symm)
 
 end TauCeti

--- a/TauCeti/GroupTheory/PGroup.lean
+++ b/TauCeti/GroupTheory/PGroup.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.PGroup
-public import Mathlib.GroupTheory.QuotientGroup.Defs
 
 /-!
 # Normal subgroups with `p`-group quotient

--- a/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
@@ -1,0 +1,329 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.QuotientGroup.Basic
+public import TauCeti.GroupTheory.PGroup
+public import TauCeti.Topology.Algebra.Group.Profinite.Basic
+public import TauCeti.Topology.Algebra.Group.Profinite.ProP
+
+/-!
+# The maximal pro-`p` quotient of a profinite group
+
+The **pro-`p` kernel** `proPKernel p G` of a topological group `G` is the intersection of the
+open normal subgroups whose quotient is a `p`-group, and the **maximal pro-`p` quotient** is
+`maximalProPQuotient p G = G ⧸ proPKernel p G`. For a profinite `G` this quotient is the
+universal pro-`p` group receiving a continuous homomorphism from `G`.
+
+The one substantial step is that `G(p)` really is pro-`p`. This is a compactness argument
+rather than a formal one: an open normal subgroup `M` of `G` containing `proPKernel p G`
+already contains one member `U` of the defining family, because the sets `U \ M` form a
+downward directed family of closed subsets of the compact space `G` with empty intersection,
+so one of them is empty. Directedness of the family is where `IsPGroup.quotient_inf` enters.
+Once that is known, `G ⧸ M` is a quotient of `G ⧸ U` and hence a `p`-group, and the open
+normal subgroups of `G(p)` are exactly the images of such `M`.
+
+The universal property goes the other way and needs no compactness: if `P` is profinite and
+pro-`p` and `f : G →* P` is continuous, then for each open normal `V ≤ P` the preimage
+`V.comap f` is an open normal subgroup of `G` with `p`-group quotient, so `f` maps
+`proPKernel p G` into every `V`, and the open normal subgroups of a profinite group intersect
+in `1`.
+
+Everything before the compactness lemma is stated for an arbitrary topological group: the
+kernel, its normality, its closedness and its behaviour under continuous homomorphisms all
+hold there. Compactness of `G` is assumed exactly where it is used.
+
+## Main definitions
+
+* `TauCeti.proPKernel`: the intersection of the open normal subgroups with `p`-group quotient.
+* `TauCeti.maximalProPQuotient`: the quotient `G ⧸ proPKernel p G`, written `G(p)` in prose.
+* `TauCeti.maximalProPQuotient.map`: the functorial action on continuous homomorphisms.
+
+## Main results
+
+* `TauCeti.isClosed_proPKernel`: the pro-`p` kernel is closed, so `G(p)` is profinite again.
+* `TauCeti.exists_openNormalSubgroup_isPGroup_le`: an open subgroup containing the pro-`p`
+  kernel contains a member of the defining family.
+* `TauCeti.isProP_maximalProPQuotient`: `G(p)` is pro-`p`.
+* `TauCeti.existsUnique_continuousMonoidHom_maximalProPQuotient`: a continuous homomorphism
+  from `G` to a profinite pro-`p` group factors uniquely and continuously through `G(p)`.
+* `TauCeti.proPKernel_eq_bot_iff`: `G` is pro-`p` if and only if its pro-`p` kernel is trivial;
+  with `TauCeti.proPKernel_maximalProPQuotient_eq_bot` this is idempotence of `G ↦ G(p)`.
+* `TauCeti.proPKernel_map_continuousMulEquiv`: the pro-`p` kernel is characteristic for
+  continuous automorphisms.
+
+## References
+
+* L. Ribes and P. Zalesskii, *Profinite Groups*.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v
+
+section Defs
+
+variable (p : ℕ) (G : Type u) [Group G] [TopologicalSpace G]
+
+/-- The **pro-`p` kernel** of a topological group `G`: the intersection of the open normal
+subgroups of `G` whose quotient is a `p`-group. For profinite `G` it is the kernel of the
+universal continuous homomorphism from `G` to a pro-`p` group. -/
+def proPKernel : Subgroup G :=
+  ⨅ U : {U : OpenNormalSubgroup G // IsPGroup p (G ⧸ U.toSubgroup)}, U.1.toSubgroup
+
+/-- The pro-`p` kernel is normal, being an intersection of normal subgroups. -/
+instance proPKernel_normal : (proPKernel p G).Normal :=
+  Subgroup.normal_iInf_normal fun U ↦ U.1.isNormal'
+
+/-- The **maximal pro-`p` quotient** `G(p) = G ⧸ proPKernel p G`. -/
+abbrev maximalProPQuotient : Type u := G ⧸ proPKernel p G
+
+end Defs
+
+variable {p : ℕ} {G : Type u} [Group G] [TopologicalSpace G]
+variable {H : Type v} [Group H] [TopologicalSpace H]
+
+/-- Membership in the pro-`p` kernel, unfolded over the defining family. -/
+theorem mem_proPKernel_iff {x : G} :
+    x ∈ proPKernel p G ↔
+      ∀ U : OpenNormalSubgroup G, IsPGroup p (G ⧸ U.toSubgroup) → x ∈ U.toSubgroup := by
+  rw [proPKernel, Subgroup.mem_iInf]
+  exact ⟨fun h U hU ↦ h ⟨U, hU⟩, fun h U ↦ h U.1 U.2⟩
+
+/-- The pro-`p` kernel is contained in every open normal subgroup with `p`-group quotient. -/
+theorem proPKernel_le {U : OpenNormalSubgroup G} (hU : IsPGroup p (G ⧸ U.toSubgroup)) :
+    proPKernel p G ≤ U.toSubgroup :=
+  fun _ hx ↦ mem_proPKernel_iff.mp hx U hU
+
+/-- The pro-`p` kernel is closed, being an intersection of open — hence closed — subgroups.
+Together with `QuotientGroup.instTotallyDisconnectedSpace` this is what makes the maximal
+pro-`p` quotient of a profinite group profinite again. -/
+instance isClosed_proPKernel [IsTopologicalGroup G] :
+    IsClosed ((proPKernel p G : Subgroup G) : Set G) := by
+  rw [proPKernel, Subgroup.coe_iInf]
+  exact isClosed_iInter fun U ↦ U.1.toOpenSubgroup.isClosed
+
+/-! ### Functoriality -/
+
+/-- A continuous homomorphism carries the pro-`p` kernel into the pro-`p` kernel: the preimage
+of an open normal subgroup with `p`-group quotient is again one, by
+`IsPGroup.quotient_comap`. No compactness is needed. -/
+theorem proPKernel_le_comap (f : G →* H) (hf : Continuous f) :
+    proPKernel p G ≤ (proPKernel p H).comap f := by
+  intro x hx
+  rw [Subgroup.mem_comap, mem_proPKernel_iff]
+  intro V hV
+  exact mem_proPKernel_iff.mp hx
+    ⟨V.toOpenSubgroup.comap f hf, V.isNormal'.comap f⟩ (hV.quotient_comap f)
+
+/-- The image of the pro-`p` kernel under a continuous homomorphism lies in the pro-`p`
+kernel of the target. -/
+theorem map_proPKernel_le (f : G →* H) (hf : Continuous f) :
+    (proPKernel p G).map f ≤ proPKernel p H :=
+  Subgroup.map_le_iff_le_comap.mpr (proPKernel_le_comap f hf)
+
+/-- The pro-`p` kernel is characteristic for *continuous* automorphisms. Continuity is the
+right hypothesis: the subgroup is defined through the open normal subgroups, and an abstract
+automorphism of a profinite group need not be continuous. -/
+theorem proPKernel_map_continuousMulEquiv (e : G ≃ₜ* G) :
+    (proPKernel p G).map e.toMulEquiv.toMonoidHom = proPKernel p G := by
+  refine le_antisymm (map_proPKernel_le _ e.continuous) fun x hx ↦ ?_
+  have hsymm : e.symm x ∈ proPKernel p G :=
+    map_proPKernel_le e.symm.toMulEquiv.toMonoidHom e.symm.continuous
+      (Subgroup.mem_map_of_mem _ hx)
+  exact ⟨e.symm x, hsymm, e.apply_symm_apply x⟩
+
+/-- The map induced on maximal pro-`p` quotients by a continuous homomorphism. -/
+def maximalProPQuotient.map (f : G →* H) (hf : Continuous f) :
+    maximalProPQuotient p G →* maximalProPQuotient p H :=
+  QuotientGroup.map (proPKernel p G) (proPKernel p H) f (proPKernel_le_comap f hf)
+
+/-- The induced map on maximal pro-`p` quotients is computed on classes by `f`. -/
+@[simp]
+theorem maximalProPQuotient.map_mk (f : G →* H) (hf : Continuous f) (x : G) :
+    maximalProPQuotient.map (p := p) f hf (QuotientGroup.mk x) = QuotientGroup.mk (f x) := by
+  rfl
+
+/-- The induced map on maximal pro-`p` quotients is continuous. -/
+theorem maximalProPQuotient.continuous_map (f : G →* H) (hf : Continuous f) :
+    Continuous (maximalProPQuotient.map (p := p) f hf) :=
+  (QuotientGroup.isQuotientMap_mk (proPKernel p G)).continuous_iff.mpr
+    (QuotientGroup.continuous_mk.comp hf)
+
+/-- Functoriality: the identity induces the identity. -/
+@[simp]
+theorem maximalProPQuotient.map_id :
+    maximalProPQuotient.map (p := p) (MonoidHom.id G) continuous_id = MonoidHom.id _ := by
+  ext x
+  rfl
+
+/-- Functoriality: the induced maps compose. -/
+theorem maximalProPQuotient.map_comp {K : Type u} [Group K] [TopologicalSpace K] (f : G →* H)
+    (hf : Continuous f) (g : H →* K) (hg : Continuous g) :
+    maximalProPQuotient.map (p := p) (g.comp f) (hg.comp hf) =
+      (maximalProPQuotient.map g hg).comp (maximalProPQuotient.map f hf) := by
+  ext x
+  rfl
+
+/-! ### The compactness step -/
+
+section Compact
+
+variable [IsTopologicalGroup G] [CompactSpace G]
+
+/-- **The compactness step.** An open subgroup `M` of a compact topological group containing
+the pro-`p` kernel already contains a single open normal subgroup with `p`-group quotient.
+
+The sets `U \ M`, for `U` running over the open normal subgroups with `p`-group quotient, are
+closed in the compact space `G` and downward directed, because that family of subgroups is
+closed under intersection (`IsPGroup.quotient_inf`) and contains `⊤`. Their intersection is
+`proPKernel p G \ M = ∅`, so by Cantor's intersection theorem one of them is already empty. -/
+theorem exists_openNormalSubgroup_isPGroup_le {M : Subgroup G} (hM : IsOpen (M : Set G))
+    (hKM : proPKernel p G ≤ M) :
+    ∃ U : OpenNormalSubgroup G, IsPGroup p (G ⧸ U.toSubgroup) ∧ U.toSubgroup ≤ M := by
+  -- The defining family, and the closed sets it cuts out outside `M`.
+  let S : Type u := {U : OpenNormalSubgroup G // IsPGroup p (G ⧸ U.toSubgroup)}
+  let t : S → Set G := fun U ↦ (U.1 : Set G) \ (M : Set G)
+  -- The family contains the whole group, so it is nonempty.
+  let topU : OpenNormalSubgroup G := { toOpenSubgroup := ⊤, isNormal' := Subgroup.normal_top }
+  let _ : topU.toSubgroup.Normal := topU.isNormal'
+  have htopP : IsPGroup p (G ⧸ topU.toSubgroup) := by
+    intro x
+    obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective topU.toSubgroup x
+    refine ⟨0, ?_⟩
+    rw [pow_zero, pow_one, QuotientGroup.mk'_apply, QuotientGroup.eq_one_iff]
+    exact Subgroup.mem_top g
+  have htop : S := ⟨topU, htopP⟩
+  have hne : Nonempty S := ⟨htop⟩
+  suffices h : ∃ U : S, t U = ∅ by
+    obtain ⟨U, hU⟩ := h
+    exact ⟨U.1, U.2, fun _ hx ↦ Set.sdiff_eq_empty.mp hU hx⟩
+  by_contra hcon
+  have hnonempty : ∀ U : S, (t U).Nonempty := fun U ↦ by
+    rw [Set.nonempty_iff_ne_empty]
+    exact fun h ↦ hcon ⟨U, h⟩
+  have hclosed : ∀ U : S, IsClosed (t U) := fun U ↦ (U.1.toOpenSubgroup.isClosed).sdiff hM
+  -- The family is closed under intersection, so the sets `t U` are downward directed.
+  have hdirected : Directed (· ⊇ ·) t := fun U V ↦
+    ⟨⟨U.1 ⊓ V.1, U.2.quotient_inf V.2⟩,
+      Set.sdiff_subset_sdiff_left (SetLike.coe_subset_coe.mpr inf_le_left),
+      Set.sdiff_subset_sdiff_left (SetLike.coe_subset_coe.mpr inf_le_right)⟩
+  -- Cantor: their intersection is nonempty, yet it lies in `proPKernel p G \ M = ∅`.
+  obtain ⟨x, hx⟩ := IsCompact.nonempty_iInter_of_directed_nonempty_isCompact_isClosed t
+    hdirected hnonempty (fun U ↦ (hclosed U).isCompact) hclosed
+  rw [Set.mem_iInter] at hx
+  exact (hx htop).2 (hKM (mem_proPKernel_iff.mpr fun U hU ↦ (hx ⟨U, hU⟩).1))
+
+/-- An open normal subgroup containing the pro-`p` kernel has `p`-group quotient: it contains
+a member `V` of the defining family, and `G ⧸ U` is then a quotient of the `p`-group
+`G ⧸ V`. -/
+theorem isPGroup_quotient_of_proPKernel_le {U : OpenNormalSubgroup G}
+    (hU : proPKernel p G ≤ U.toSubgroup) : IsPGroup p (G ⧸ U.toSubgroup) := by
+  obtain ⟨V, hV, hVU⟩ := exists_openNormalSubgroup_isPGroup_le U.toOpenSubgroup.isOpen hU
+  have hle : V.toSubgroup ≤ (U.toSubgroup).comap (MonoidHom.id G) := by
+    simpa using hVU
+  refine hV.of_surjective (QuotientGroup.map V.toSubgroup U.toSubgroup (MonoidHom.id G) hle) ?_
+  exact QuotientGroup.map_surjective_of_surjective V.toSubgroup U.toSubgroup (MonoidHom.id G)
+    (QuotientGroup.mk'_surjective U.toSubgroup) hle
+
+/-- For an open normal subgroup of a compact group, containing the pro-`p` kernel is the same
+as having a `p`-group quotient. -/
+theorem proPKernel_le_iff_isPGroup_quotient {U : OpenNormalSubgroup G} :
+    proPKernel p G ≤ U.toSubgroup ↔ IsPGroup p (G ⧸ U.toSubgroup) :=
+  ⟨isPGroup_quotient_of_proPKernel_le, proPKernel_le⟩
+
+/-- **The maximal pro-`p` quotient is pro-`p`.** An open normal subgroup `M` of `G(p)` pulls
+back to an open normal subgroup `M'` of `G` containing the pro-`p` kernel, so `G ⧸ M'` is a
+`p`-group; and `G(p) ⧸ M` is a quotient of `G ⧸ M'`. -/
+theorem isProP_maximalProPQuotient : IsProP p (maximalProPQuotient p G) := by
+  refine isProP_iff.mpr fun M ↦ ?_
+  let π : G →* maximalProPQuotient p G := QuotientGroup.mk' (proPKernel p G)
+  let M' : OpenNormalSubgroup G :=
+    { toOpenSubgroup := M.toOpenSubgroup.comap π QuotientGroup.continuous_mk
+      isNormal' := M.isNormal'.comap π }
+  let _ : M'.toSubgroup.Normal := M'.isNormal'
+  have hmem : ∀ x : G, x ∈ M'.toSubgroup ↔ π x ∈ M.toSubgroup := fun _ ↦ Iff.rfl
+  have hKM' : proPKernel p G ≤ M'.toSubgroup := by
+    intro x hx
+    rw [hmem]
+    have hx1 : π x = 1 := (QuotientGroup.eq_one_iff x).mpr hx
+    rw [hx1]
+    exact one_mem _
+  have hM' : IsPGroup p (G ⧸ M'.toSubgroup) := isPGroup_quotient_of_proPKernel_le hKM'
+  refine hM'.of_surjective
+    (QuotientGroup.lift M'.toSubgroup ((QuotientGroup.mk' M.toSubgroup).comp π) ?_) ?_
+  · intro x hx
+    exact (QuotientGroup.eq_one_iff (π x)).mpr ((hmem x).mp hx)
+  · rintro y
+    obtain ⟨z, rfl⟩ := QuotientGroup.mk'_surjective M.toSubgroup y
+    obtain ⟨x, rfl⟩ := QuotientGroup.mk'_surjective (proPKernel p G) z
+    exact ⟨QuotientGroup.mk x, rfl⟩
+
+end Compact
+
+/-! ### The universal property -/
+
+section UniversalProperty
+
+variable {P : Type v} [Group P] [TopologicalSpace P] [IsTopologicalGroup P] [CompactSpace P]
+  [TotallyDisconnectedSpace P]
+
+/-- A continuous homomorphism from `G` to a profinite pro-`p` group kills the pro-`p` kernel:
+each open normal subgroup `V` of `P` pulls back to an open normal subgroup of `G` with
+`p`-group quotient, and the open normal subgroups of `P` intersect in `1`. -/
+theorem proPKernel_le_ker (hP : IsProP p P) (f : G →* P) (hf : Continuous f) :
+    proPKernel p G ≤ f.ker := by
+  intro x hx
+  rw [MonoidHom.mem_ker]
+  refine Subgroup.eq_one_of_mem_iInf_openNormalSubgroup fun V ↦ ?_
+  exact mem_proPKernel_iff.mp hx ⟨V.toOpenSubgroup.comap f hf, V.isNormal'.comap f⟩
+    ((isProP_iff.mp hP V).quotient_comap f)
+
+/-- **The universal property of the maximal pro-`p` quotient.** A continuous homomorphism from
+`G` to a profinite pro-`p` group `P` factors through `G(p)` by a unique continuous
+homomorphism. Uniqueness needs no continuity, the quotient map being surjective. -/
+theorem existsUnique_continuousMonoidHom_maximalProPQuotient (hP : IsProP p P) (f : G →* P)
+    (hf : Continuous f) :
+    ∃! g : maximalProPQuotient p G →* P,
+      Continuous g ∧ ∀ x : G, g (QuotientGroup.mk x) = f x := by
+  refine ⟨QuotientGroup.lift (proPKernel p G) f fun x hx ↦ proPKernel_le_ker hP f hf hx,
+    ⟨?_, fun _ ↦ rfl⟩, ?_⟩
+  · exact (QuotientGroup.isQuotientMap_mk (proPKernel p G)).continuous_iff.mpr hf
+  · rintro g ⟨-, hg⟩
+    ext y
+    exact hg y
+
+end UniversalProperty
+
+/-! ### Pro-`p` groups and idempotence -/
+
+section Idempotence
+
+variable [IsTopologicalGroup G] [CompactSpace G] [TotallyDisconnectedSpace G]
+
+/-- A profinite group is pro-`p` exactly when its pro-`p` kernel is trivial. -/
+theorem proPKernel_eq_bot_iff : proPKernel p G = ⊥ ↔ IsProP p G := by
+  refine ⟨fun h ↦ isProP_iff.mpr fun U ↦
+      isPGroup_quotient_of_proPKernel_le (h.trans_le bot_le), fun hG ↦ ?_⟩
+  refine le_antisymm ?_ bot_le
+  rw [← Subgroup.iInf_openNormalSubgroup_eq_bot (G := G)]
+  exact le_iInf fun U ↦ proPKernel_le (isProP_iff.mp hG U)
+
+/-- The pro-`p` kernel of a profinite pro-`p` group is trivial. -/
+theorem IsProP.proPKernel_eq_bot (hG : IsProP p G) : proPKernel p G = ⊥ :=
+  proPKernel_eq_bot_iff.mpr hG
+
+/-- **Idempotence.** Passing to the maximal pro-`p` quotient twice changes nothing: the pro-`p`
+kernel of `G(p)` is already trivial. -/
+theorem proPKernel_maximalProPQuotient_eq_bot :
+    proPKernel p (maximalProPQuotient p G) = ⊥ :=
+  proPKernel_eq_bot_iff.mpr isProP_maximalProPQuotient
+
+end Idempotence
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
@@ -375,7 +375,7 @@ theorem IsProP.proPKernel_eq_bot (hG : IsProP p G) : proPKernel p G = ⊥ :=
 
 /-- The canonical continuous multiplicative equivalence from the maximal pro-`p` quotient of a
 profinite pro-`p` group to the group itself. -/
-abbrev maximalProPQuotient.equivOfIsProP (hG : IsProP p G) :
+def maximalProPQuotient.equivOfIsProP (hG : IsProP p G) :
     maximalProPQuotient p G ≃ₜ* G :=
   ContinuousMulEquiv.mk
     ((QuotientGroup.quotientMulEquivOfEq hG.proPKernel_eq_bot).trans
@@ -388,7 +388,7 @@ to its representative. -/
 @[simp]
 theorem maximalProPQuotient.equivOfIsProP_mk (hG : IsProP p G) (x : G) :
     maximalProPQuotient.equivOfIsProP hG (x : maximalProPQuotient p G) = x :=
-  rfl
+  (rfl)
 
 /-- **Idempotence.** The pro-`p` kernel of a maximal pro-`p` quotient is trivial. -/
 theorem proPKernel_maximalProPQuotient_eq_bot :
@@ -400,6 +400,13 @@ canonically continuously equivalent to applying it once. -/
 def maximalProPQuotient.idempotentEquiv :
     maximalProPQuotient p (maximalProPQuotient p G) ≃ₜ* maximalProPQuotient p G :=
   maximalProPQuotient.equivOfIsProP isProP_maximalProPQuotient
+
+/-- The idempotence equivalence sends each class to its representative. -/
+@[simp]
+theorem maximalProPQuotient.idempotentEquiv_mk (x : maximalProPQuotient p G) :
+    maximalProPQuotient.idempotentEquiv
+      (x : maximalProPQuotient p (maximalProPQuotient p G)) = x :=
+  (rfl)
 
 end Idempotence
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
@@ -207,12 +207,8 @@ theorem exists_openNormalSubgroup_isPGroup_le {M : Subgroup G} (hM : IsOpen (M :
   -- The family contains the whole group, so it is nonempty.
   let topU : OpenNormalSubgroup G := { toOpenSubgroup := ⊤, isNormal' := Subgroup.normal_top }
   let _ : topU.toSubgroup.Normal := topU.isNormal'
-  have htopP : IsPGroup p (G ⧸ topU.toSubgroup) := by
-    intro x
-    obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective topU.toSubgroup x
-    refine ⟨0, ?_⟩
-    rw [pow_zero, pow_one, QuotientGroup.mk'_apply, QuotientGroup.eq_one_iff]
-    exact Subgroup.mem_top g
+  have _ : Subsingleton (G ⧸ topU.toSubgroup) := QuotientGroup.subsingleton_quotient_top
+  have htopP : IsPGroup p (G ⧸ topU.toSubgroup) := .of_subsingleton p _
   have htop : S := ⟨topU, htopP⟩
   have hne : Nonempty S := ⟨htop⟩
   suffices h : ∃ U : S, t U = ∅ by

--- a/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
@@ -41,6 +41,8 @@ hold there. Compactness of `G` is assumed exactly where it is used.
 * `TauCeti.maximalProPQuotient`: the quotient `G ⧸ proPKernel p G`, written `G(p)` in prose.
 * `TauCeti.maximalProPQuotient.mk`: the canonical quotient homomorphism.
 * `TauCeti.maximalProPQuotient.map`: the functorial action on continuous homomorphisms.
+* `TauCeti.maximalProPQuotient.lift`: the canonical factorisation of a continuous homomorphism
+  to a profinite pro-`p` group.
 
 ## Main results
 
@@ -50,6 +52,8 @@ hold there. Compactness of `G` is assumed exactly where it is used.
 * `TauCeti.isProP_maximalProPQuotient`: `G(p)` is pro-`p`.
 * `TauCeti.existsUnique_continuousMonoidHom_maximalProPQuotient`: a continuous homomorphism
   from `G` to a profinite pro-`p` group factors uniquely and continuously through `G(p)`.
+* `TauCeti.maximalProPQuotient.lift_comp_map` and `TauCeti.maximalProPQuotient.comp_lift`: that
+  factorisation is natural in the source and in the target.
 * `TauCeti.proPKernel_eq_bot_iff`: `G` is pro-`p` if and only if its pro-`p` kernel is trivial;
   with `TauCeti.proPKernel_maximalProPQuotient_eq_bot` this is idempotence of `G ↦ G(p)`.
 * `TauCeti.map_proPKernel_eq`: continuous multiplicative equivalences preserve the pro-`p`
@@ -288,18 +292,66 @@ theorem proPKernel_le_ker (hP : IsProP p P) (f : G →* P) (hf : Continuous f) :
   exact mem_proPKernel_iff.mp hx ⟨V.toOpenSubgroup.comap f hf, V.isNormal'.comap f⟩
     ((isProP_iff.mp hP V).quotient_comap f)
 
+/-- The canonical factorisation of a continuous homomorphism to a profinite pro-`p` group
+through the maximal pro-`p` quotient. -/
+def maximalProPQuotient.lift (hP : IsProP p P) (f : G →* P) (hf : Continuous f) :
+    maximalProPQuotient p G →* P :=
+  QuotientGroup.lift (proPKernel p G) f fun _ hx ↦ proPKernel_le_ker hP f hf hx
+
+/-- The factorisation through the maximal pro-`p` quotient computes as `f` on classes. -/
+@[simp]
+theorem maximalProPQuotient.lift_mk (hP : IsProP p P) (f : G →* P) (hf : Continuous f) (x : G) :
+    maximalProPQuotient.lift hP f hf (x : maximalProPQuotient p G) = f x := by
+  rfl
+
+/-- The factorisation through the maximal pro-`p` quotient recovers `f`. -/
+@[simp]
+theorem maximalProPQuotient.lift_comp_mk (hP : IsProP p P) (f : G →* P) (hf : Continuous f) :
+    (maximalProPQuotient.lift hP f hf).comp (maximalProPQuotient.mk p G) = f := by
+  ext x
+  rfl
+
+/-- The factorisation through the maximal pro-`p` quotient is continuous. -/
+theorem maximalProPQuotient.continuous_lift (hP : IsProP p P) (f : G →* P) (hf : Continuous f) :
+    Continuous (maximalProPQuotient.lift hP f hf) :=
+  (QuotientGroup.isQuotientMap_mk (proPKernel p G)).continuous_iff.mpr hf
+
+/-- The factorisation through the maximal pro-`p` quotient is the only homomorphism restricting
+to `f` along the quotient map. -/
+theorem maximalProPQuotient.lift_unique (hP : IsProP p P) (f : G →* P) (hf : Continuous f)
+    {g : maximalProPQuotient p G →* P} (hg : ∀ x : G, g (maximalProPQuotient.mk p G x) = f x) :
+    g = maximalProPQuotient.lift hP f hf := by
+  ext x
+  exact hg x
+
+/-- Naturality in the source: the factorisation of `f ∘ u` is the factorisation of `f`
+precomposed with the map induced by `u`. -/
+theorem maximalProPQuotient.lift_comp_map {G' : Type w} [Group G'] [TopologicalSpace G']
+    (hP : IsProP p P) (f : G →* P) (hf : Continuous f) (u : G' →* G) (hu : Continuous u) :
+    (maximalProPQuotient.lift hP f hf).comp (maximalProPQuotient.map (p := p) u hu) =
+      maximalProPQuotient.lift hP (f.comp u) (hf.comp hu) := by
+  ext x
+  rfl
+
+/-- Naturality in the target: postcomposing the factorisation of `f` with a continuous
+homomorphism of profinite pro-`p` groups gives the factorisation of the composite. -/
+theorem maximalProPQuotient.comp_lift {Q : Type w} [Group Q] [TopologicalSpace Q]
+    [IsTopologicalGroup Q] [CompactSpace Q] [TotallyDisconnectedSpace Q] (hP : IsProP p P)
+    (hQ : IsProP p Q) (f : G →* P) (hf : Continuous f) (v : P →* Q) (hv : Continuous v) :
+    v.comp (maximalProPQuotient.lift hP f hf) =
+      maximalProPQuotient.lift hQ (v.comp f) (hv.comp hf) := by
+  ext x
+  rfl
+
 /-- **The universal property of the maximal pro-`p` quotient.** A continuous homomorphism to a
 profinite pro-`p` group factors uniquely and continuously through the canonical quotient map. -/
 theorem existsUnique_continuousMonoidHom_maximalProPQuotient (hP : IsProP p P) (f : G →* P)
     (hf : Continuous f) :
     ∃! g : maximalProPQuotient p G →* P,
-      Continuous g ∧ ∀ x : G, g (maximalProPQuotient.mk p G x) = f x := by
-  refine ⟨QuotientGroup.lift (proPKernel p G) f fun x hx ↦ proPKernel_le_ker hP f hf hx,
-    ⟨?_, fun _ ↦ rfl⟩, ?_⟩
-  · exact (QuotientGroup.isQuotientMap_mk (proPKernel p G)).continuous_iff.mpr hf
-  · rintro g ⟨-, hg⟩
-    ext y
-    exact hg y
+      Continuous g ∧ ∀ x : G, g (maximalProPQuotient.mk p G x) = f x :=
+  ⟨maximalProPQuotient.lift hP f hf,
+    ⟨maximalProPQuotient.continuous_lift hP f hf, maximalProPQuotient.lift_mk hP f hf⟩,
+    fun _ hg ↦ maximalProPQuotient.lift_unique hP f hf hg.2⟩
 
 end UniversalProperty
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
@@ -160,7 +160,7 @@ def maximalProPQuotient.map (f : G →* H) (hf : Continuous f) :
 /-- The induced map on maximal pro-`p` quotients is computed on classes by `f`. -/
 @[simp]
 theorem maximalProPQuotient.map_mk (f : G →* H) (hf : Continuous f) (x : G) :
-    maximalProPQuotient.map (p := p) f hf (maximalProPQuotient.mk p G x) =
+    maximalProPQuotient.map (p := p) f hf (x : maximalProPQuotient p G) =
       maximalProPQuotient.mk p H (f x) := by
   rfl
 
@@ -335,7 +335,7 @@ abbrev maximalProPQuotient.equivOfIsProP (hG : IsProP p G) :
 to its representative. -/
 @[simp]
 theorem maximalProPQuotient.equivOfIsProP_mk (hG : IsProP p G) (x : G) :
-    maximalProPQuotient.equivOfIsProP hG (maximalProPQuotient.mk p G x) = x :=
+    maximalProPQuotient.equivOfIsProP hG (x : maximalProPQuotient p G) = x :=
   rfl
 
 /-- **Idempotence.** The pro-`p` kernel of a maximal pro-`p` quotient is trivial. -/

--- a/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.GroupTheory.QuotientGroup.Basic
 public import TauCeti.GroupTheory.PGroup
 public import TauCeti.Topology.Algebra.Group.Profinite.Basic
 public import TauCeti.Topology.Algebra.Group.Profinite.ProP
@@ -40,6 +39,7 @@ hold there. Compactness of `G` is assumed exactly where it is used.
 
 * `TauCeti.proPKernel`: the intersection of the open normal subgroups with `p`-group quotient.
 * `TauCeti.maximalProPQuotient`: the quotient `G ⧸ proPKernel p G`, written `G(p)` in prose.
+* `TauCeti.maximalProPQuotient.mk`: the canonical quotient homomorphism.
 * `TauCeti.maximalProPQuotient.map`: the functorial action on continuous homomorphisms.
 
 ## Main results
@@ -52,8 +52,8 @@ hold there. Compactness of `G` is assumed exactly where it is used.
   from `G` to a profinite pro-`p` group factors uniquely and continuously through `G(p)`.
 * `TauCeti.proPKernel_eq_bot_iff`: `G` is pro-`p` if and only if its pro-`p` kernel is trivial;
   with `TauCeti.proPKernel_maximalProPQuotient_eq_bot` this is idempotence of `G ↦ G(p)`.
-* `TauCeti.proPKernel_map_continuousMulEquiv`: the pro-`p` kernel is characteristic for
-  continuous automorphisms.
+* `TauCeti.map_proPKernel_eq`: continuous multiplicative equivalences preserve the pro-`p`
+  kernel.
 
 ## References
 
@@ -64,7 +64,7 @@ public section
 
 namespace TauCeti
 
-universe u v
+universe u v w
 
 section Defs
 
@@ -76,12 +76,31 @@ universal continuous homomorphism from `G` to a pro-`p` group. -/
 def proPKernel : Subgroup G :=
   ⨅ U : {U : OpenNormalSubgroup G // IsPGroup p (G ⧸ U.toSubgroup)}, U.1.toSubgroup
 
-/-- The pro-`p` kernel is normal, being an intersection of normal subgroups. -/
+/-- The pro-`p` kernel is a normal subgroup. -/
 instance proPKernel_normal : (proPKernel p G).Normal :=
   Subgroup.normal_iInf_normal fun U ↦ U.1.isNormal'
 
 /-- The **maximal pro-`p` quotient** `G(p) = G ⧸ proPKernel p G`. -/
 abbrev maximalProPQuotient : Type u := G ⧸ proPKernel p G
+
+/-- The canonical homomorphism from `G` to its maximal pro-`p` quotient. -/
+abbrev maximalProPQuotient.mk : G →* maximalProPQuotient p G :=
+  QuotientGroup.mk' (proPKernel p G)
+
+/-- The canonical quotient homomorphism sends an element to its quotient class. -/
+@[simp]
+theorem maximalProPQuotient.mk_apply (x : G) :
+    maximalProPQuotient.mk p G x = QuotientGroup.mk x :=
+  rfl
+
+/-- The canonical homomorphism to the maximal pro-`p` quotient is surjective. -/
+theorem maximalProPQuotient.mk_surjective :
+    Function.Surjective (maximalProPQuotient.mk p G) :=
+  QuotientGroup.mk'_surjective (proPKernel p G)
+
+/-- The canonical homomorphism to the maximal pro-`p` quotient is continuous. -/
+theorem maximalProPQuotient.continuous_mk : Continuous (maximalProPQuotient.mk p G) :=
+  QuotientGroup.continuous_mk
 
 end Defs
 
@@ -100,9 +119,7 @@ theorem proPKernel_le {U : OpenNormalSubgroup G} (hU : IsPGroup p (G ⧸ U.toSub
     proPKernel p G ≤ U.toSubgroup :=
   fun _ hx ↦ mem_proPKernel_iff.mp hx U hU
 
-/-- The pro-`p` kernel is closed, being an intersection of open — hence closed — subgroups.
-Together with `QuotientGroup.instTotallyDisconnectedSpace` this is what makes the maximal
-pro-`p` quotient of a profinite group profinite again. -/
+/-- The pro-`p` kernel is closed, so its quotient is profinite when `G` is profinite. -/
 instance isClosed_proPKernel [IsTopologicalGroup G] :
     IsClosed ((proPKernel p G : Subgroup G) : Set G) := by
   rw [proPKernel, Subgroup.coe_iInf]
@@ -110,9 +127,7 @@ instance isClosed_proPKernel [IsTopologicalGroup G] :
 
 /-! ### Functoriality -/
 
-/-- A continuous homomorphism carries the pro-`p` kernel into the pro-`p` kernel: the preimage
-of an open normal subgroup with `p`-group quotient is again one, by
-`IsPGroup.quotient_comap`. No compactness is needed. -/
+/-- A continuous homomorphism carries the pro-`p` kernel into the pro-`p` kernel. -/
 theorem proPKernel_le_comap (f : G →* H) (hf : Continuous f) :
     proPKernel p G ≤ (proPKernel p H).comap f := by
   intro x hx
@@ -127,11 +142,10 @@ theorem map_proPKernel_le (f : G →* H) (hf : Continuous f) :
     (proPKernel p G).map f ≤ proPKernel p H :=
   Subgroup.map_le_iff_le_comap.mpr (proPKernel_le_comap f hf)
 
-/-- The pro-`p` kernel is characteristic for *continuous* automorphisms. Continuity is the
-right hypothesis: the subgroup is defined through the open normal subgroups, and an abstract
-automorphism of a profinite group need not be continuous. -/
-theorem proPKernel_map_continuousMulEquiv (e : G ≃ₜ* G) :
-    (proPKernel p G).map e.toMulEquiv.toMonoidHom = proPKernel p G := by
+/-- Continuous multiplicative equivalences identify the pro-`p` kernels of their source and
+target. In particular, the pro-`p` kernel is characteristic under continuous automorphisms. -/
+theorem map_proPKernel_eq (e : G ≃ₜ* H) :
+    (proPKernel p G).map e.toMulEquiv.toMonoidHom = proPKernel p H := by
   refine le_antisymm (map_proPKernel_le _ e.continuous) fun x hx ↦ ?_
   have hsymm : e.symm x ∈ proPKernel p G :=
     map_proPKernel_le e.symm.toMulEquiv.toMonoidHom e.symm.continuous
@@ -146,7 +160,8 @@ def maximalProPQuotient.map (f : G →* H) (hf : Continuous f) :
 /-- The induced map on maximal pro-`p` quotients is computed on classes by `f`. -/
 @[simp]
 theorem maximalProPQuotient.map_mk (f : G →* H) (hf : Continuous f) (x : G) :
-    maximalProPQuotient.map (p := p) f hf (QuotientGroup.mk x) = QuotientGroup.mk (f x) := by
+    maximalProPQuotient.map (p := p) f hf (maximalProPQuotient.mk p G x) =
+      maximalProPQuotient.mk p H (f x) := by
   rfl
 
 /-- The induced map on maximal pro-`p` quotients is continuous. -/
@@ -163,7 +178,8 @@ theorem maximalProPQuotient.map_id :
   rfl
 
 /-- Functoriality: the induced maps compose. -/
-theorem maximalProPQuotient.map_comp {K : Type u} [Group K] [TopologicalSpace K] (f : G →* H)
+@[simp]
+theorem maximalProPQuotient.map_comp {K : Type w} [Group K] [TopologicalSpace K] (f : G →* H)
     (hf : Continuous f) (g : H →* K) (hg : Continuous g) :
     maximalProPQuotient.map (p := p) (g.comp f) (hg.comp hf) =
       (maximalProPQuotient.map g hg).comp (maximalProPQuotient.map f hf) := by
@@ -176,13 +192,8 @@ section Compact
 
 variable [IsTopologicalGroup G] [CompactSpace G]
 
-/-- **The compactness step.** An open subgroup `M` of a compact topological group containing
-the pro-`p` kernel already contains a single open normal subgroup with `p`-group quotient.
-
-The sets `U \ M`, for `U` running over the open normal subgroups with `p`-group quotient, are
-closed in the compact space `G` and downward directed, because that family of subgroups is
-closed under intersection (`IsPGroup.quotient_inf`) and contains `⊤`. Their intersection is
-`proPKernel p G \ M = ∅`, so by Cantor's intersection theorem one of them is already empty. -/
+/-- An open subgroup containing the pro-`p` kernel contains an open normal subgroup with
+`p`-group quotient. -/
 theorem exists_openNormalSubgroup_isPGroup_le {M : Subgroup G} (hM : IsOpen (M : Set G))
     (hKM : proPKernel p G ≤ M) :
     ∃ U : OpenNormalSubgroup G, IsPGroup p (G ⧸ U.toSubgroup) ∧ U.toSubgroup ≤ M := by
@@ -219,9 +230,7 @@ theorem exists_openNormalSubgroup_isPGroup_le {M : Subgroup G} (hM : IsOpen (M :
   rw [Set.mem_iInter] at hx
   exact (hx htop).2 (hKM (mem_proPKernel_iff.mpr fun U hU ↦ (hx ⟨U, hU⟩).1))
 
-/-- An open normal subgroup containing the pro-`p` kernel has `p`-group quotient: it contains
-a member `V` of the defining family, and `G ⧸ U` is then a quotient of the `p`-group
-`G ⧸ V`. -/
+/-- An open normal subgroup containing the pro-`p` kernel has `p`-group quotient. -/
 theorem isPGroup_quotient_of_proPKernel_le {U : OpenNormalSubgroup G}
     (hU : proPKernel p G ≤ U.toSubgroup) : IsPGroup p (G ⧸ U.toSubgroup) := by
   obtain ⟨V, hV, hVU⟩ := exists_openNormalSubgroup_isPGroup_le U.toOpenSubgroup.isOpen hU
@@ -237,12 +246,10 @@ theorem proPKernel_le_iff_isPGroup_quotient {U : OpenNormalSubgroup G} :
     proPKernel p G ≤ U.toSubgroup ↔ IsPGroup p (G ⧸ U.toSubgroup) :=
   ⟨isPGroup_quotient_of_proPKernel_le, proPKernel_le⟩
 
-/-- **The maximal pro-`p` quotient is pro-`p`.** An open normal subgroup `M` of `G(p)` pulls
-back to an open normal subgroup `M'` of `G` containing the pro-`p` kernel, so `G ⧸ M'` is a
-`p`-group; and `G(p) ⧸ M` is a quotient of `G ⧸ M'`. -/
+/-- **The maximal pro-`p` quotient is pro-`p`.** -/
 theorem isProP_maximalProPQuotient : IsProP p (maximalProPQuotient p G) := by
   refine isProP_iff.mpr fun M ↦ ?_
-  let π : G →* maximalProPQuotient p G := QuotientGroup.mk' (proPKernel p G)
+  let π : G →* maximalProPQuotient p G := maximalProPQuotient.mk p G
   let M' : OpenNormalSubgroup G :=
     { toOpenSubgroup := M.toOpenSubgroup.comap π QuotientGroup.continuous_mk
       isNormal' := M.isNormal'.comap π }
@@ -255,14 +262,13 @@ theorem isProP_maximalProPQuotient : IsProP p (maximalProPQuotient p G) := by
     rw [hx1]
     exact one_mem _
   have hM' : IsPGroup p (G ⧸ M'.toSubgroup) := isPGroup_quotient_of_proPKernel_le hKM'
-  refine hM'.of_surjective
-    (QuotientGroup.lift M'.toSubgroup ((QuotientGroup.mk' M.toSubgroup).comp π) ?_) ?_
-  · intro x hx
-    exact (QuotientGroup.eq_one_iff (π x)).mpr ((hmem x).mp hx)
-  · rintro y
-    obtain ⟨z, rfl⟩ := QuotientGroup.mk'_surjective M.toSubgroup y
-    obtain ⟨x, rfl⟩ := QuotientGroup.mk'_surjective (proPKernel p G) z
-    exact ⟨QuotientGroup.mk x, rfl⟩
+  let q := (QuotientGroup.mk' M.toSubgroup).comp π
+  have hq : M'.toSubgroup ≤ q.ker := fun x hx ↦
+    (QuotientGroup.eq_one_iff (π x)).mpr ((hmem x).mp hx)
+  refine hM'.of_surjective (QuotientGroup.lift M'.toSubgroup q hq) ?_
+  exact QuotientGroup.lift_surjective_of_surjective M'.toSubgroup q
+    ((QuotientGroup.mk'_surjective M.toSubgroup).comp
+      (maximalProPQuotient.mk_surjective p G)) hq
 
 end Compact
 
@@ -273,9 +279,7 @@ section UniversalProperty
 variable {P : Type v} [Group P] [TopologicalSpace P] [IsTopologicalGroup P] [CompactSpace P]
   [TotallyDisconnectedSpace P]
 
-/-- A continuous homomorphism from `G` to a profinite pro-`p` group kills the pro-`p` kernel:
-each open normal subgroup `V` of `P` pulls back to an open normal subgroup of `G` with
-`p`-group quotient, and the open normal subgroups of `P` intersect in `1`. -/
+/-- A continuous homomorphism to a profinite pro-`p` group kills the pro-`p` kernel. -/
 theorem proPKernel_le_ker (hP : IsProP p P) (f : G →* P) (hf : Continuous f) :
     proPKernel p G ≤ f.ker := by
   intro x hx
@@ -284,13 +288,12 @@ theorem proPKernel_le_ker (hP : IsProP p P) (f : G →* P) (hf : Continuous f) :
   exact mem_proPKernel_iff.mp hx ⟨V.toOpenSubgroup.comap f hf, V.isNormal'.comap f⟩
     ((isProP_iff.mp hP V).quotient_comap f)
 
-/-- **The universal property of the maximal pro-`p` quotient.** A continuous homomorphism from
-`G` to a profinite pro-`p` group `P` factors through `G(p)` by a unique continuous
-homomorphism. Uniqueness needs no continuity, the quotient map being surjective. -/
+/-- **The universal property of the maximal pro-`p` quotient.** A continuous homomorphism to a
+profinite pro-`p` group factors uniquely and continuously through the canonical quotient map. -/
 theorem existsUnique_continuousMonoidHom_maximalProPQuotient (hP : IsProP p P) (f : G →* P)
     (hf : Continuous f) :
     ∃! g : maximalProPQuotient p G →* P,
-      Continuous g ∧ ∀ x : G, g (QuotientGroup.mk x) = f x := by
+      Continuous g ∧ ∀ x : G, g (maximalProPQuotient.mk p G x) = f x := by
   refine ⟨QuotientGroup.lift (proPKernel p G) f fun x hx ↦ proPKernel_le_ker hP f hf hx,
     ⟨?_, fun _ ↦ rfl⟩, ?_⟩
   · exact (QuotientGroup.isQuotientMap_mk (proPKernel p G)).continuous_iff.mpr hf
@@ -318,11 +321,33 @@ theorem proPKernel_eq_bot_iff : proPKernel p G = ⊥ ↔ IsProP p G := by
 theorem IsProP.proPKernel_eq_bot (hG : IsProP p G) : proPKernel p G = ⊥ :=
   proPKernel_eq_bot_iff.mpr hG
 
-/-- **Idempotence.** Passing to the maximal pro-`p` quotient twice changes nothing: the pro-`p`
-kernel of `G(p)` is already trivial. -/
+/-- The canonical continuous multiplicative equivalence from the maximal pro-`p` quotient of a
+profinite pro-`p` group to the group itself. -/
+abbrev maximalProPQuotient.equivOfIsProP (hG : IsProP p G) :
+    maximalProPQuotient p G ≃ₜ* G :=
+  ContinuousMulEquiv.mk
+    ((QuotientGroup.quotientMulEquivOfEq hG.proPKernel_eq_bot).trans
+      QuotientGroup.quotientBot)
+    ((QuotientGroup.isQuotientMap_mk (proPKernel p G)).continuous_iff.mpr continuous_id)
+    (maximalProPQuotient.continuous_mk p G)
+
+/-- The canonical equivalence from a pro-`p` group's maximal pro-`p` quotient sends each class
+to its representative. -/
+@[simp]
+theorem maximalProPQuotient.equivOfIsProP_mk (hG : IsProP p G) (x : G) :
+    maximalProPQuotient.equivOfIsProP hG (maximalProPQuotient.mk p G x) = x :=
+  rfl
+
+/-- **Idempotence.** The pro-`p` kernel of a maximal pro-`p` quotient is trivial. -/
 theorem proPKernel_maximalProPQuotient_eq_bot :
     proPKernel p (maximalProPQuotient p G) = ⊥ :=
   proPKernel_eq_bot_iff.mpr isProP_maximalProPQuotient
+
+/-- **Idempotence.** Applying the maximal pro-`p` quotient construction twice gives a group
+canonically continuously equivalent to applying it once. -/
+def maximalProPQuotient.idempotentEquiv :
+    maximalProPQuotient p (maximalProPQuotient p G) ≃ₜ* maximalProPQuotient p G :=
+  maximalProPQuotient.equivOfIsProP isProP_maximalProPQuotient
 
 end Idempotence
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean
@@ -47,6 +47,8 @@ hold there. Compactness of `G` is assumed exactly where it is used.
 ## Main results
 
 * `TauCeti.isClosed_proPKernel`: the pro-`p` kernel is closed, so `G(p)` is profinite again.
+* `TauCeti.proPKernel_eq_top_iff`: the pro-`p` kernel is the whole group exactly when every
+  relevant `p`-group quotient is trivial.
 * `TauCeti.exists_openNormalSubgroup_isPGroup_le`: an open subgroup containing the pro-`p`
   kernel contains a member of the defining family.
 * `TauCeti.isProP_maximalProPQuotient`: `G(p)` is pro-`p`.
@@ -128,6 +130,39 @@ instance isClosed_proPKernel [IsTopologicalGroup G] :
     IsClosed ((proPKernel p G : Subgroup G) : Set G) := by
   rw [proPKernel, Subgroup.coe_iInf]
   exact isClosed_iInter fun U ↦ U.1.toOpenSubgroup.isClosed
+
+/-! ### Trivial maximal quotients -/
+
+/-- The pro-`p` kernel is the whole group exactly when every open normal subgroup with
+`p`-group quotient is the whole group. Equivalently, `G` has no nontrivial continuous
+`p`-group quotient. -/
+theorem proPKernel_eq_top_iff : proPKernel p G = ⊤ ↔
+    ∀ U : OpenNormalSubgroup G, IsPGroup p (G ⧸ U.toSubgroup) → U.toSubgroup = ⊤ := by
+  rw [proPKernel, iInf_eq_top]
+  exact ⟨fun h U hU ↦ h ⟨U, hU⟩, fun h U ↦ h U.1 U.2⟩
+
+/-- The maximal pro-`p` quotient is trivial exactly when the pro-`p` kernel is the whole
+group. -/
+theorem maximalProPQuotient.subsingleton_iff :
+    Subsingleton (maximalProPQuotient p G) ↔ proPKernel p G = ⊤ :=
+  QuotientGroup.subsingleton_iff
+
+/-- If `p` does not divide the cardinality of `G`, then its pro-`p` kernel is the whole group.
+For prime `p` this hypothesis forces `G` to be finite. -/
+theorem proPKernel_eq_top_of_not_dvd_card [Fact p.Prime]
+    (hcard : ¬ p ∣ Nat.card G) : proPKernel p G = ⊤ := by
+  rw [proPKernel_eq_top_iff]
+  intro U hU
+  rw [← QuotientGroup.subsingleton_iff]
+  apply (Nat.card_eq_one_iff_unique.mp ?_).1
+  exact hU.card_eq_or_dvd.resolve_right fun hp ↦
+    hcard (hp.trans (Subgroup.card_quotient_dvd_card U.toSubgroup))
+
+/-- If `p` does not divide the cardinality of `G`, then its maximal pro-`p` quotient is
+trivial. For prime `p` this hypothesis forces `G` to be finite. -/
+theorem maximalProPQuotient.subsingleton_of_not_dvd_card [Fact p.Prime]
+    (hcard : ¬ p ∣ Nat.card G) : Subsingleton (maximalProPQuotient p G) :=
+  maximalProPQuotient.subsingleton_iff.mpr (proPKernel_eq_top_of_not_dvd_card hcard)
 
 /-! ### Functoriality -/
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/ProP.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/ProP.lean
@@ -25,6 +25,7 @@ separate topological fact is supplied by `QuotientGroup.instTotallyDisconnectedS
 ## Main results
 
 * `IsProP`: every quotient by an open normal subgroup is a `p`-group.
+* `isProP_iff`: the defining property, as a lemma usable outside this module.
 * `IsPGroup.isProP`: an abstract `p`-group with any topology is pro-`p`.
 * `isProP_iff_isPGroup`: for a discrete topology, pro-`p` agrees with `IsPGroup`.
 * `IsProP.of_surjective`: a continuous surjective image of a pro-`p` group is pro-`p`.
@@ -48,6 +49,12 @@ def IsProP (p : ℕ) (G : Type u) [Group G] [TopologicalSpace G] : Prop :=
   ∀ U : OpenNormalSubgroup G, IsPGroup p (G ⧸ U.toSubgroup)
 
 variable {p : ℕ}
+
+/-- The defining property of `IsProP`, available to modules that only see the declaration and
+not its body. -/
+theorem isProP_iff {G : Type u} [Group G] [TopologicalSpace G] :
+    IsProP p G ↔ ∀ U : OpenNormalSubgroup G, IsPGroup p (G ⧸ U.toSubgroup) :=
+  Iff.rfl
 
 namespace IsPGroup
 


### PR DESCRIPTION
This PR constructs the maximal pro-`p` quotient of a profinite group. It defines the pro-`p`
kernel `proPKernel p G` as the intersection of the open normal subgroups whose quotient is a
`p`-group, defines `maximalProPQuotient p G := G ⧸ proPKernel p G`, and proves what the
roadmap asks be stated once and here: the kernel is normal and closed, it is preserved by
continuous homomorphisms and characteristic for continuous automorphisms, the quotient is
pro-`p`, a continuous homomorphism into a profinite pro-`p` group factors through it by a
unique continuous homomorphism, and the construction is functorial and idempotent.

This is the ProfiniteProPGroups Layer 3 bullet "The maximal pro-`p` quotient": `proPKernel p G`
"is closed, normal, characteristic for continuous automorphisms, and preserved by continuous
homomorphisms. Then `maximalProPQuotient p G := G ⧸ proPKernel p G`, which is pro-`p`, by the
compactness argument that an open normal subgroup containing the kernel already contains a
member of the defining family. State its quotient map, its universal property, its idempotence
on pro-`p` groups, and its functoriality once, here." The names and signatures of `proPKernel`,
`maximalProPQuotient` and the `∃!` factorisation follow the pinned forms in the roadmap's
`Suggested.lean`, and the two milestone prerequisites it names — the Layer 0 quotient theory and
the correspondence between open normal subgroups — are already on `main`.

The mathematical content is the compactness step, `exists_openNormalSubgroup_isPGroup_le`: an
open subgroup `M` of a compact group containing `proPKernel p G` already contains one member of
the defining family. The sets `U \ M`, for `U` in the family, are closed in the compact space
`G` and downward directed, and their intersection is `proPKernel p G \ M = ∅`, so Cantor's
intersection theorem (`IsCompact.nonempty_iInter_of_directed_nonempty_isCompact_isClosed`)
forces one of them to be empty. Directedness is where the new group-theoretic input enters: the
normal subgroups with `p`-group quotient are closed under intersection. That fact, and its
companion for preimages, are general statements with no topology in them, so they go in a
separate module `TauCeti/GroupTheory/PGroup.lean` as `IsPGroup.quotient_inf` and
`IsPGroup.quotient_comap`; Mathlib has `IsPGroup.to_quotient`, which varies the group rather
than the normal subgroup, and nothing in this direction. The universal property runs the other
way and uses no compactness: the preimage of an open normal subgroup of a pro-`p` target has
`p`-group quotient by `IsPGroup.quotient_comap`, so the kernel lands in every open normal
subgroup of the target, and those intersect in `1` by the Layer 0 lemma
`Subgroup.iInf_openNormalSubgroup_eq_bot`.

One small change is made to an existing module. `TauCeti.IsProP` is a `def _ : Prop`, whose body
the Lean module system does not expose outside `Profinite/ProP.lean`, so downstream files cannot
introduce or apply the universally quantified statement it abbreviates. `ProP.lean` gains the
one-line `isProP_iff`, which is what makes `isProP_maximalProPQuotient` and
`proPKernel_eq_bot_iff` statable at all.

`proPKernel` and everything up to the compactness step are stated for an arbitrary topological
group, since none of it needs compactness; `[CompactSpace G]` is assumed exactly in the section
that uses it, and `[TotallyDisconnectedSpace G]` only where the intersection of the open normal
subgroups is required to be trivial. Closedness of the kernel is registered as an instance so
that `QuotientGroup.instTotallyDisconnectedSpace` fires and `maximalProPQuotient p G` is a
profinite group again without further work.

What remains on this milestone after this PR: only the two entries of its API checklist that
name objects from later layers — the comparison `proCKernel (finiteGroupClassP p) G =
proPKernel p G`, which needs the Layer 4 class `C` machinery, and the example
`maximalProPQuotient p ℤ̂ ≅ ℤ_p`, which the roadmap itself defers to Layer 4.

Files added: `TauCeti/GroupTheory/PGroup.lean` (75 lines) and
`TauCeti/Topology/Algebra/Group/Profinite/MaximalProP.lean` (329 lines); one lemma added to
`TauCeti/Topology/Algebra/Group/Profinite/ProP.lean`.

Roadmap: ProfiniteProPGroups

<!--tauceti-target:v1 {"focus":"ProfiniteProPGroups","id":"maximalpropquotient"}-->

🤖 Prepared with Claude Code
