### PR TITLE
feat(Cyclotomic): the fixers of K(μ_m) are the kernel of the cyclotomic character

### DIFF
--- a/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
+++ b/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
@@ -5,71 +5,42 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.NumberTheory.Cyclotomic.Gal
+public import Mathlib.FieldTheory.Galois.Basic
+public import TauCeti.RingTheory.RootsOfUnity.PrimitiveRoots
 
 /-!
 # The automorphisms fixing the roots of unity
 
-For a primitive `m`-th root of unity `ζ` in `M`, an automorphism of `M / K` fixes every `m`-th root
-of unity exactly when the cyclotomic character sends it to `1`. So `Gal(M/K(μ_m))` is the kernel of
-`IsPrimitiveRoot.autToPow`.
+`Gal(M/K(μ_m))` is the kernel of the cyclotomic character `IsPrimitiveRoot.autToPow`.
 
 ## Main results
 
-* `IsPrimitiveRoot.autToPow_eq_one_iff`: `autToPow K hζ x = 1 ↔ x ζ = ζ`.
-* `IsPrimitiveRoot.fixingSubgroup_adjoin_setOf_pow_eq_one`: the fixers of `K(μ_m)` are that kernel.
+* `IsPrimitiveRoot.fixingSubgroup_adjoin_setOf_pow_eq_one`
+
+## Provenance
+
+Isolated for the Chebotarev roadmap (`TauCetiRoadmap/Chebotarev`), whose Layer 7.5 needs
+`Gal(M/K(ζ_q))` identified with one factor of the Layer 7.4 splitting. The pinned source
+[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0,
+Birkbeck--Brasca) at commit `8575c9df1ae0a61120ab5c964c7911414254bec7` performs that identification
+inline at its assembly site rather than as a named lemma; no code is adapted here.
 -/
 
 public section
 
 open IntermediateField
 
-namespace IsPrimitiveRoot
-
-variable {K M : Type*} [Field K] [Field M] [Algebra K M] {m : ℕ} [NeZero m] {ζ : M}
-
-/-- **The cyclotomic character detects fixing `ζ`.** `autToPow` sends `x` to `1` exactly when `x`
-fixes the chosen primitive root, since `autToPow` is defined by the power to which `x` sends it. -/
-theorem autToPow_eq_one_iff (hζ : IsPrimitiveRoot ζ m) (x : M ≃ₐ[K] M) :
-    hζ.autToPow K x = 1 ↔ x ζ = ζ := by
-  rcases eq_or_lt_of_le (Nat.one_le_iff_ne_zero.mpr (NeZero.ne m)) with hm | hm
-  · -- `m = 1` forces `ζ = 1`, and `(ZMod 1)ˣ` is trivial, so both sides always hold
-    have hζ1 : ζ = 1 := by simpa [← hm] using hζ.pow_eq_one
-    have : Subsingleton (ZMod m)ˣ := by rw [← hm]; infer_instance
-    exact ⟨fun _ ↦ by simp [hζ1], fun _ ↦ Subsingleton.elim _ _⟩
-  · have : Fact (1 < m) := ⟨hm⟩
-    refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-    · have hspec := hζ.autToPow_spec (R := K) x
-      rw [h, Units.val_one, ZMod.val_one, pow_one] at hspec
-      exact hspec.symm
-    · have hspec := hζ.autToPow_spec (R := K) x
-      rw [h] at hspec
-      have hval : (hζ.autToPow K x : ZMod m).val = 1 := by
-        refine hζ.pow_inj (ZMod.val_lt _) hm ?_
-        rw [hspec, pow_one]
-      exact Units.ext (ZMod.val_injective m (by rw [hval, Units.val_one, ZMod.val_one]))
-
 /-- **The fixers of `K(μ_m)` are the kernel of the cyclotomic character.**
 
-Both directions run through the single element `ζ`: fixing every `m`-th root of unity in particular
-fixes `ζ`, and fixing `ζ` fixes every root because each one is a power of `ζ`. -/
-theorem fixingSubgroup_adjoin_setOf_pow_eq_one (hζ : IsPrimitiveRoot ζ m) :
+Use it to move between a condition on `Gal(M/K(μ_m))` and one on the cyclotomic character, which
+is the form a Galois splitting presents. -/
+theorem IsPrimitiveRoot.fixingSubgroup_adjoin_setOf_pow_eq_one {K M : Type*} [Field K] [Field M]
+    [Algebra K M] {m : ℕ} [NeZero m] {ζ : M} (hζ : IsPrimitiveRoot ζ m) :
     (adjoin K {b : M | b ^ m = 1}).fixingSubgroup = (hζ.autToPow K).ker := by
   ext x
   rw [MonoidHom.mem_ker, hζ.autToPow_eq_one_iff, IntermediateField.mem_fixingSubgroup_iff]
-  refine ⟨fun hx ↦ hx ζ (subset_adjoin K _ hζ.pow_eq_one), fun hx y hy ↦ ?_⟩
-  -- `x` fixes each root, so it fixes the field they generate
-  have hle : adjoin K {b : M | b ^ m = 1} ≤ fixedField (Subgroup.zpowers x) := by
-    refine adjoin_le_iff.mpr fun b hb ↦ ?_
-    obtain ⟨i, -, rfl⟩ := hζ.eq_pow_of_pow_eq_one (Set.mem_ofPred_eq ▸ hb)
-    simp only [SetLike.mem_coe, mem_fixedField_iff]
-    intro g hg
-    have hstab : x ∈ MulAction.stabilizer (M ≃ₐ[K] M) (ζ ^ i) := by
-      simpa [MulAction.mem_stabilizer_iff, AlgEquiv.smul_def, map_pow] using congrArg (· ^ i) hx
-    simpa [MulAction.mem_stabilizer_iff, AlgEquiv.smul_def] using
-      Subgroup.zpowers_le.mpr hstab hg
-  have hfix := hle hy
-  simp only [mem_fixedField_iff] at hfix
-  exact hfix x (Subgroup.mem_zpowers x)
-
-end IsPrimitiveRoot
+  simp only [← AlgEquiv.smul_def]
+  rw [IntermediateField.forall_mem_adjoin_smul_eq_self_iff]
+  refine ⟨fun h ↦ by simpa [AlgEquiv.smul_def] using h ζ hζ.pow_eq_one, fun h b hb ↦ ?_⟩
+  obtain ⟨i, -, rfl⟩ := hζ.eq_pow_of_pow_eq_one (Set.mem_ofPred_eq ▸ hb)
+  simp [h]

--- a/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
+++ b/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.Galois.Basic
+public import TauCeti.NumberTheory.Cyclotomic.Adjoin
 public import TauCeti.RingTheory.RootsOfUnity.PrimitiveRoots
 
 /-!
@@ -24,10 +25,7 @@ subgroup is `Gal(M/K(μ_m))`, which is the reading the crossing argument uses.
 
 The identification of `Gal(M/K(μ_m))` with the `G × 1` factor of a Galois splitting is due to the
 Birkbeck--Brasca Chebotarev development,
-[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0), which
-carries it out inline at its assembly site. Isolating it as a statement about the kernel of the
-cyclotomic character, so that it can be applied without unfolding a splitting, is what this file
-adds.
+[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0).
 -/
 
 public section
@@ -43,12 +41,9 @@ theorem IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one_eq_ker_autToP
     (hζ : IsPrimitiveRoot ζ m) :
     (adjoin K {b : M | b ^ m = 1}).fixingSubgroup = (hζ.autToPow K).ker := by
   ext x
-  rw [MonoidHom.mem_ker, hζ.autToPow_eq_one_iff, IntermediateField.mem_fixingSubgroup_iff]
+  -- `K(μ_m) = K(ζ)`, so fixing the whole root-of-unity set is fixing the single generator.
+  rw [MonoidHom.mem_ker, hζ.autToPow_eq_one_iff, ← hζ.adjoin_singleton_eq_adjoin_nth_roots,
+    IntermediateField.mem_fixingSubgroup_iff]
   simp only [← AlgEquiv.smul_def]
   rw [IntermediateField.forall_mem_adjoin_smul_eq_self_iff]
-  refine ⟨fun h ↦ by simpa [AlgEquiv.smul_def] using h ζ hζ.pow_eq_one, fun h b hb ↦ ?_⟩
-  -- `x` fixes `ζ`, so it raises every `m`-th root of unity to the first power: that is
-  -- `map_eq_pow` at `j = 1`, from the file this one already imports.
-  have := TauCeti.IsPrimitiveRoot.map_eq_pow (j := 1) hζ (x : M ≃+* M).toRingHom
-    (by simpa using h) (Set.mem_ofPred_eq ▸ hb)
-  simpa [AlgEquiv.smul_def] using this
+  simp [AlgEquiv.smul_def]

--- a/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
+++ b/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
@@ -19,7 +19,7 @@ subgroup is `Gal(M/K(μ_m))`, which is the reading the crossing argument uses.
 
 ## Main results
 
-* `IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one_eq_ker_autToPow`
+* `IsPrimitiveRoot.fixingSubgroup_adjoin_nth_roots_eq_ker_autToPow`
 
 ## References
 
@@ -36,7 +36,7 @@ open IntermediateField
 
 Use it to move between a condition on `Gal(M/K(μ_m))` and one on the cyclotomic character, which
 is the form a Galois splitting presents. -/
-theorem IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one_eq_ker_autToPow
+theorem IsPrimitiveRoot.fixingSubgroup_adjoin_nth_roots_eq_ker_autToPow
     {K M : Type*} [Field K] [Field M] [Algebra K M] {m : ℕ} [NeZero m] {ζ : M}
     (hζ : IsPrimitiveRoot ζ m) :
     (adjoin K {b : M | b ^ m = 1}).fixingSubgroup = (hζ.autToPow K).ker := by

--- a/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
+++ b/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.FieldTheory.Galois.Basic
 public import TauCeti.NumberTheory.Cyclotomic.Adjoin
 public import TauCeti.RingTheory.RootsOfUnity.PrimitiveRoots
 

--- a/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
+++ b/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
@@ -15,7 +15,7 @@ public import TauCeti.RingTheory.RootsOfUnity.PrimitiveRoots
 
 ## Main results
 
-* `IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one`
+* `IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one_eq_ker_autToPow`
 
 ## References
 
@@ -35,8 +35,9 @@ open IntermediateField
 
 Use it to move between a condition on `Gal(M/K(μ_m))` and one on the cyclotomic character, which
 is the form a Galois splitting presents. -/
-theorem IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one {K M : Type*} [Field K] [Field M]
-    [Algebra K M] {m : ℕ} [NeZero m] {ζ : M} (hζ : IsPrimitiveRoot ζ m) :
+theorem IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one_eq_ker_autToPow
+    {K M : Type*} [Field K] [Field M] [Algebra K M] {m : ℕ} [NeZero m] {ζ : M}
+    (hζ : IsPrimitiveRoot ζ m) :
     (adjoin K {b : M | b ^ m = 1}).fixingSubgroup = (hζ.autToPow K).ker := by
   ext x
   rw [MonoidHom.mem_ker, hζ.autToPow_eq_one_iff, IntermediateField.mem_fixingSubgroup_iff]

--- a/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
+++ b/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
@@ -16,6 +16,15 @@ public import TauCeti.RingTheory.RootsOfUnity.PrimitiveRoots
 ## Main results
 
 * `IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one`
+
+## References
+
+The identification of `Gal(M/K(μ_m))` with the `G × 1` factor of a Galois splitting is due to the
+Birkbeck--Brasca Chebotarev development,
+[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0), which
+carries it out inline at its assembly site. Isolating it as a statement about the kernel of the
+cyclotomic character, so that it can be applied without unfolding a splitting, is what this file
+adds.
 -/
 
 public section

--- a/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
+++ b/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
@@ -11,7 +11,10 @@ public import TauCeti.RingTheory.RootsOfUnity.PrimitiveRoots
 /-!
 # The automorphisms fixing the roots of unity
 
-`Gal(M/K(μ_m))` is the kernel of the cyclotomic character `IsPrimitiveRoot.autToPow`.
+The `K`-automorphisms of `M` fixing `K(μ_m)` pointwise are exactly the kernel of the cyclotomic
+character `IsPrimitiveRoot.autToPow`. No Galois, normality or separability hypothesis is needed —
+only that `M` contains a primitive `m`-th root of unity — although when `M / K` is Galois this
+subgroup is `Gal(M/K(μ_m))`, which is the reading the crossing argument uses.
 
 ## Main results
 
@@ -44,5 +47,8 @@ theorem IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one_eq_ker_autToP
   simp only [← AlgEquiv.smul_def]
   rw [IntermediateField.forall_mem_adjoin_smul_eq_self_iff]
   refine ⟨fun h ↦ by simpa [AlgEquiv.smul_def] using h ζ hζ.pow_eq_one, fun h b hb ↦ ?_⟩
-  obtain ⟨i, -, rfl⟩ := hζ.eq_pow_of_pow_eq_one (Set.mem_ofPred_eq ▸ hb)
-  simp [h]
+  -- `x` fixes `ζ`, so it raises every `m`-th root of unity to the first power: that is
+  -- `map_eq_pow` at `j = 1`, from the file this one already imports.
+  have := TauCeti.IsPrimitiveRoot.map_eq_pow (j := 1) hζ (x : M ≃+* M).toRingHom
+    (by simpa using h) (Set.mem_ofPred_eq ▸ hb)
+  simpa [AlgEquiv.smul_def] using this

--- a/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
+++ b/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
@@ -15,15 +15,7 @@ public import TauCeti.RingTheory.RootsOfUnity.PrimitiveRoots
 
 ## Main results
 
-* `IsPrimitiveRoot.fixingSubgroup_adjoin_setOf_pow_eq_one`
-
-## Provenance
-
-Isolated for the Chebotarev roadmap (`TauCetiRoadmap/Chebotarev`), whose Layer 7.5 needs
-`Gal(M/K(ζ_q))` identified with one factor of the Layer 7.4 splitting. The pinned source
-[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0,
-Birkbeck--Brasca) at commit `8575c9df1ae0a61120ab5c964c7911414254bec7` performs that identification
-inline at its assembly site rather than as a named lemma; no code is adapted here.
+* `IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one`
 -/
 
 public section
@@ -34,7 +26,7 @@ open IntermediateField
 
 Use it to move between a condition on `Gal(M/K(μ_m))` and one on the cyclotomic character, which
 is the form a Galois splitting presents. -/
-theorem IsPrimitiveRoot.fixingSubgroup_adjoin_setOf_pow_eq_one {K M : Type*} [Field K] [Field M]
+theorem IsPrimitiveRoot.fixingSubgroup_adjoin_setOfPred_pow_eq_one {K M : Type*} [Field K] [Field M]
     [Algebra K M] {m : ℕ} [NeZero m] {ζ : M} (hζ : IsPrimitiveRoot ζ m) :
     (adjoin K {b : M | b ^ m = 1}).fixingSubgroup = (hζ.autToPow K).ker := by
   ext x

--- a/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
+++ b/TauCeti/NumberTheory/Cyclotomic/FixingSubgroup.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.Cyclotomic.Gal
+
+/-!
+# The automorphisms fixing the roots of unity
+
+For a primitive `m`-th root of unity `ζ` in `M`, an automorphism of `M / K` fixes every `m`-th root
+of unity exactly when the cyclotomic character sends it to `1`. So `Gal(M/K(μ_m))` is the kernel of
+`IsPrimitiveRoot.autToPow`.
+
+## Main results
+
+* `IsPrimitiveRoot.autToPow_eq_one_iff`: `autToPow K hζ x = 1 ↔ x ζ = ζ`.
+* `IsPrimitiveRoot.fixingSubgroup_adjoin_setOf_pow_eq_one`: the fixers of `K(μ_m)` are that kernel.
+-/
+
+public section
+
+open IntermediateField
+
+namespace IsPrimitiveRoot
+
+variable {K M : Type*} [Field K] [Field M] [Algebra K M] {m : ℕ} [NeZero m] {ζ : M}
+
+/-- **The cyclotomic character detects fixing `ζ`.** `autToPow` sends `x` to `1` exactly when `x`
+fixes the chosen primitive root, since `autToPow` is defined by the power to which `x` sends it. -/
+theorem autToPow_eq_one_iff (hζ : IsPrimitiveRoot ζ m) (x : M ≃ₐ[K] M) :
+    hζ.autToPow K x = 1 ↔ x ζ = ζ := by
+  rcases eq_or_lt_of_le (Nat.one_le_iff_ne_zero.mpr (NeZero.ne m)) with hm | hm
+  · -- `m = 1` forces `ζ = 1`, and `(ZMod 1)ˣ` is trivial, so both sides always hold
+    have hζ1 : ζ = 1 := by simpa [← hm] using hζ.pow_eq_one
+    have : Subsingleton (ZMod m)ˣ := by rw [← hm]; infer_instance
+    exact ⟨fun _ ↦ by simp [hζ1], fun _ ↦ Subsingleton.elim _ _⟩
+  · have : Fact (1 < m) := ⟨hm⟩
+    refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+    · have hspec := hζ.autToPow_spec (R := K) x
+      rw [h, Units.val_one, ZMod.val_one, pow_one] at hspec
+      exact hspec.symm
+    · have hspec := hζ.autToPow_spec (R := K) x
+      rw [h] at hspec
+      have hval : (hζ.autToPow K x : ZMod m).val = 1 := by
+        refine hζ.pow_inj (ZMod.val_lt _) hm ?_
+        rw [hspec, pow_one]
+      exact Units.ext (ZMod.val_injective m (by rw [hval, Units.val_one, ZMod.val_one]))
+
+/-- **The fixers of `K(μ_m)` are the kernel of the cyclotomic character.**
+
+Both directions run through the single element `ζ`: fixing every `m`-th root of unity in particular
+fixes `ζ`, and fixing `ζ` fixes every root because each one is a power of `ζ`. -/
+theorem fixingSubgroup_adjoin_setOf_pow_eq_one (hζ : IsPrimitiveRoot ζ m) :
+    (adjoin K {b : M | b ^ m = 1}).fixingSubgroup = (hζ.autToPow K).ker := by
+  ext x
+  rw [MonoidHom.mem_ker, hζ.autToPow_eq_one_iff, IntermediateField.mem_fixingSubgroup_iff]
+  refine ⟨fun hx ↦ hx ζ (subset_adjoin K _ hζ.pow_eq_one), fun hx y hy ↦ ?_⟩
+  -- `x` fixes each root, so it fixes the field they generate
+  have hle : adjoin K {b : M | b ^ m = 1} ≤ fixedField (Subgroup.zpowers x) := by
+    refine adjoin_le_iff.mpr fun b hb ↦ ?_
+    obtain ⟨i, -, rfl⟩ := hζ.eq_pow_of_pow_eq_one (Set.mem_ofPred_eq ▸ hb)
+    simp only [SetLike.mem_coe, mem_fixedField_iff]
+    intro g hg
+    have hstab : x ∈ MulAction.stabilizer (M ≃ₐ[K] M) (ζ ^ i) := by
+      simpa [MulAction.mem_stabilizer_iff, AlgEquiv.smul_def, map_pow] using congrArg (· ^ i) hx
+    simpa [MulAction.mem_stabilizer_iff, AlgEquiv.smul_def] using
+      Subgroup.zpowers_le.mpr hstab hg
+  have hfix := hle hy
+  simp only [mem_fixedField_iff] at hfix
+  exact hfix x (Subgroup.mem_zpowers x)
+
+end IsPrimitiveRoot

--- a/TauCeti/NumberTheory/NumberField/Cyclotomic/Compositum.lean
+++ b/TauCeti/NumberTheory/NumberField/Cyclotomic/Compositum.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.NumberTheory.Cyclotomic.Gal
 import TauCeti.FieldTheory.IntermediateField.Adjoin.EqTop
 public import TauCeti.NumberTheory.NumberField.Cyclotomic.Finrank
+import TauCeti.RingTheory.RootsOfUnity.PrimitiveRoots
 
 /-!
 # The cyclotomic compositum `M = L(μ_m)` and its joint restriction isomorphism
@@ -136,16 +137,7 @@ theorem restrictNormalHom_prod_autToPow_injective {ζ : M} (hζ : IsPrimitiveRoo
   intro σ hσ
   rw [MonoidHom.prod_apply, Prod.mk_eq_one] at hσ
   obtain ⟨hσL, hσζ⟩ := hσ
-  have hζfix : σ ζ = ζ := by
-    have hspec := hζ.autToPow_spec K σ
-    rw [hσζ] at hspec
-    rw [← hspec, Units.val_one]
-    rcases eq_or_lt_of_le (NeZero.one_le (n := m)) with h1 | h1
-    · have hm1 : m = 1 := h1.symm
-      subst hm1
-      have : ζ = 1 := by simpa using hζ.pow_eq_one
-      simp [this]
-    · rw [ZMod.val_one_eq_one_mod, Nat.mod_eq_of_lt h1, pow_one]
+  have hζfix : σ ζ = ζ := (hζ.autToPow_eq_one_iff σ).mp hσζ
   have hLfix : ∀ x : L, σ (algebraMap L M x) = algebraMap L M x := by
     intro x
     have hcomm := σ.restrictNormal_commutes L x

--- a/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -27,10 +27,9 @@ because the character records nothing but the power the root is sent to.
 
 ## References
 
-`autToPow_eq_one_iff` names an identification that the Birkbeck--Brasca Chebotarev density
-project, [CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density)
-(Apache-2.0), makes inline rather than as a lemma; the statement and proof here are not adapted
-from it.
+The characterisation of the cyclotomic character's kernel by its value on a chosen primitive root
+is due to the Birkbeck--Brasca Chebotarev density project,
+[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0).
 -/
 
 public section

--- a/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -8,11 +8,15 @@ module
 public import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
 
 /-!
-# How a ring endomorphism acts on the roots of unity
+# Maps determined by their value on a primitive root
 
 In a domain the `n`-th roots of unity are exactly the powers of a primitive one, so a ring
 endomorphism is pinned down on all of them by its value on a single primitive `n`-th root: if it
 raises that root to the `j`-th power, it raises every `n`-th root of unity to the `j`-th power.
+
+The same principle characterises when the cyclotomic character `IsPrimitiveRoot.autToPow` is
+trivial: it kills an automorphism exactly when that automorphism fixes the chosen primitive root,
+because the character records nothing but the power the root is sent to.
 
 ## Main results
 
@@ -20,6 +24,16 @@ raises that root to the `j`-th power, it raises every `n`-th root of unity to th
   unity `ζ` to `ζ ^ j` sends every `n`-th root of unity `μ` to `μ ^ j`.
 * `IsPrimitiveRoot.autToPow_eq_one_iff`: the cyclotomic character kills an automorphism exactly
   when it fixes the chosen primitive root.
+
+## References
+
+`autToPow_eq_one_iff` is the argument previously carried inline inside
+`IsCyclotomicExtension.restrictNormalHom_prod_autToPow_injective`
+(`TauCeti/NumberTheory/NumberField/Cyclotomic/Compositum.lean`), which is adapted from the
+Birkbeck--Brasca Chebotarev density project,
+[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0).
+Extracting it here, so that the characterisation is available without a compositum in scope, is
+what this file adds; the credit travels with the proof.
 -/
 
 public section

--- a/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -27,8 +27,10 @@ because the character records nothing but the power the root is sent to.
 
 ## References
 
-`autToPow_eq_one_iff` is adapted from the Birkbeck--Brasca Chebotarev density project,
-[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0).
+`autToPow_eq_one_iff` names an identification that the Birkbeck--Brasca Chebotarev density
+project, [CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density)
+(Apache-2.0), makes inline rather than as a lemma; the statement and proof here are not adapted
+from it.
 -/
 
 public section

--- a/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -18,6 +18,8 @@ raises that root to the `j`-th power, it raises every `n`-th root of unity to th
 
 * `TauCeti.IsPrimitiveRoot.map_eq_pow`: a ring endomorphism sending a primitive `n`-th root of
   unity `ζ` to `ζ ^ j` sends every `n`-th root of unity `μ` to `μ ^ j`.
+* `IsPrimitiveRoot.autToPow_eq_one_iff`: the cyclotomic character kills an automorphism exactly
+  when it fixes the chosen primitive root.
 -/
 
 public section
@@ -37,3 +39,25 @@ theorem IsPrimitiveRoot.map_eq_pow {n j : ℕ} [NeZero n] {ζ : R} (hζ : IsPrim
   rw [map_pow, hσ, ← pow_mul, ← pow_mul, Nat.mul_comm]
 
 end TauCeti
+
+/-- **The cyclotomic character detects fixing `ζ`.** `autToPow` sends `x` to `1` exactly when `x`
+fixes the chosen primitive root, since `autToPow` is defined by the power `x` sends it to. -/
+@[simp]
+theorem _root_.IsPrimitiveRoot.autToPow_eq_one_iff {K M : Type*} [CommRing K] [CommRing M]
+    [IsDomain M] [Algebra K M] {m : ℕ} [NeZero m] {ζ : M} (hζ : IsPrimitiveRoot ζ m)
+    (x : M ≃ₐ[K] M) : hζ.autToPow K x = 1 ↔ x ζ = ζ := by
+  rcases eq_or_lt_of_le (Nat.one_le_iff_ne_zero.mpr (NeZero.ne m)) with hm | hm
+  · -- `m = 1` forces `ζ = 1`, and `(ZMod 1)ˣ` is trivial, so both sides always hold
+    have hζ1 : ζ = 1 := by simpa [← hm] using hζ.pow_eq_one
+    have : Subsingleton (ZMod m)ˣ := by rw [← hm]; infer_instance
+    exact ⟨fun _ ↦ by simp [hζ1], fun _ ↦ Subsingleton.elim _ _⟩
+  · have : Fact (1 < m) := ⟨hm⟩
+    refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+    · have hspec := hζ.autToPow_spec (R := K) x
+      rw [h, Units.val_one, ZMod.val_one, pow_one] at hspec
+      exact hspec.symm
+    · have hspec := hζ.autToPow_spec (R := K) x
+      rw [h] at hspec
+      have hval : (hζ.autToPow K x : ZMod m).val = 1 :=
+        hζ.pow_inj (ZMod.val_lt _) hm (by rw [hspec, pow_one])
+      exact Units.ext (ZMod.val_injective m (by rw [hval, Units.val_one, ZMod.val_one]))

--- a/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -27,13 +27,8 @@ because the character records nothing but the power the root is sent to.
 
 ## References
 
-`autToPow_eq_one_iff` is the argument previously carried inline inside
-`IsCyclotomicExtension.restrictNormalHom_prod_autToPow_injective`
-(`TauCeti/NumberTheory/NumberField/Cyclotomic/Compositum.lean`), which is adapted from the
-Birkbeck--Brasca Chebotarev density project,
+`autToPow_eq_one_iff` is adapted from the Birkbeck--Brasca Chebotarev density project,
 [CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0).
-Extracting it here, so that the characterisation is available without a compositum in scope, is
-what this file adds; the credit travels with the proof.
 -/
 
 public section


### PR DESCRIPTION
The automorphisms fixing every `m`-th root of unity are exactly the kernel of the cyclotomic
character.

```lean
theorem IsPrimitiveRoot.autToPow_eq_one_iff (hζ : IsPrimitiveRoot ζ m) (x : M ≃ₐ[K] M) :
    hζ.autToPow K x = 1 ↔ x ζ = ζ

theorem IsPrimitiveRoot.fixingSubgroup_adjoin_nth_roots_eq_ker_autToPow
    (hζ : IsPrimitiveRoot ζ m) :
    (adjoin K {b : M | b ^ m = 1}).fixingSubgroup = (hζ.autToPow K).ker
```

The second name is long on purpose. A `naming` finding observed that giving only the equality's
left side hides that the result *is* a kernel characterisation, and cited Mathlib's
`rootsOfUnity_eq_ker`; there are eighteen `_eq_ker` names in Mathlib, so that is the convention for
this shape. The literal reading of the precedent would drop `autToPow`, but this subgroup could be
the kernel of more than one map, so naming the hom is what makes the statement findable.

Both directions of the second run through the single element `ζ`: fixing every root in particular
fixes `ζ`, and fixing `ζ` fixes every root because each one is a power of it. The step from "fixes
each generator" to "fixes the generated field" goes through `MulAction.stabilizer` — the stabiliser
of `ζ ^ i` is a subgroup containing `x`, hence contains `Subgroup.zpowers x`, which is what
`IntermediateField.le_iff_le` wants.

### Why the first lemma exists

Mathlib's entire `autToPow` surface is `coe_autToPow_apply` and `autToPow_spec`
(`RingTheory/RootsOfUnity/PrimitiveRoots.lean:816` and `:822`); there is no characterisation of
when it is trivial. `autToPow_eq_one_iff` supplies one, and the fixing-subgroup result rests on it,
which is why they ship together.

It handles `m = 1` separately and deliberately. `ZMod.val_one` needs `Fact (1 < m)`, and at `m = 1`
the unit group is a subsingleton while `ζ = 1`, so both sides of the iff hold for every `x`; the
general branch would not typecheck there.

### Scope

This is the bridge Chebotarev Layer 7.5 needs, to identify `Gal(M/K(ζ_q))` with the `G × 1` side of
the Layer 7.4 splitting `galEquivProd` (already on main, from #5363). But **neither statement
mentions a Galois splitting, a number field, or a prime** — they are facts about a field extension
containing a primitive root of unity, and `FixingSubgroup.lean` imports only
`TauCeti.NumberTheory.Cyclotomic.Adjoin` (already on main) and this PR's own `PrimitiveRoots.lean`.
It is not stacked on anything.

### The fixer proof goes through the canonical adjoin equality

`FixingSubgroup.lean` originally proved by hand that an automorphism fixing `ζ` fixes every `m`-th
root of unity, via `map_eq_pow` at `j = 1`. That duplicated
`IsPrimitiveRoot.adjoin_singleton_eq_adjoin_nth_roots` (`TauCeti/NumberTheory/Cyclotomic/Adjoin.lean`),
which says `K(ζ) = K(μ_m)` outright. Rewriting the fixing subgroup along it reduces the goal to
fixing a single generator, and `IntermediateField.forall_mem_adjoin_smul_eq_self_iff` closes it:
ten proof lines become six, with no hand-rolled root-of-unity argument left.

That lemma landed on `main` in #5597 after this branch was cut, which is why the first revision of
this file could not use it — the branch was 29 commits behind. The rebase onto current `main` is
what made the reuse possible, and it is also what cleared the `api-design` finding asking for these
two forms to be connected.

### The new characterisation has an in-repo consumer

`Compositum.lean`'s `restrictNormalHom_prod_autToPow_injective` was re-proving the forward
direction of `autToPow_eq_one_iff` by hand, `m = 1` split included. Ten lines become
`exact (hζ.autToPow_eq_one_iff σ).mp hσζ`.

That needs `Compositum.lean` to see `PrimitiveRoots.lean`, which it did not, so a plain
(proof-only, not `public`) import is added. `PrimitiveRoots.lean` imports nothing but Mathlib, so
there is no cycle.

(An earlier revision of this section flagged a possible collision with #5617, which also touched
`Compositum.lean`. That PR merged on 2026-09-04, and this branch has since been rebased onto it,
so there is nothing left to coordinate.)

### Absence

Mathlib has neither result; the untruncated greps for `fixingSubgroup.*autToPow`, `autToPow.*ker`
and `autToPow_eq_one` return nothing, against the positive control that `autToPow_spec` is found at
the line cited above.

The pinned source does not have them either: it gates its fixed-field lemma on the meet being
trivial and performs the `G × 1` identification inline at the assembly site, never isolating the
fixers as a kernel.

Roadmap: Chebotarev

Provenance: `CBirkbeck/chebotarev-density @ 8575c9df1ae0a61120ab5c964c7911414254bec7`
(Birkbeck--Brasca, Apache-2.0) — **no code adapted**, for the reason just given: the source
performs the `G × 1` identification inline at its assembly site rather than isolating it as a named
lemma. This attribution used to sit in the module docstring; the `documentation` finding moved it
here, which is the right place for it since a pinned commit in a docstring goes stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF





