### PR TITLE
feat(CanonicalHeight): the canonical height is quadratic in the point

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.NaiveHeight
+public import TauCeti.LinearAlgebra.QuadraticForm.OfParallelogram
 
 /-!
 # The canonical (Néron–Tate) height
@@ -46,6 +47,10 @@ with — is half of it. Getting this wrong would scale every later invariant.
   height was approximating.
 * `WeierstrassCurve.Affine.Point.canonicalHeight_two_nsmul`: the doubling normal form
   `canonicalHeight (2 • P) = 4 * canonicalHeight P`, the parallelogram law at `Q = P`.
+* `WeierstrassCurve.Affine.Point.canonicalHeight_zsmul` and
+  `WeierstrassCurve.Affine.Point.canonicalHeight_nsmul`: the value at `n • P` is `n ^ 2` times the
+  value at `P`. This exhibits the canonical height as a quadratic form on `W.Point`; the general
+  statement it specialises lives in `TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean`.
 * `WeierstrassCurve.Affine.Point.canonicalHeight_nonneg`: it is non-negative, read off the
   defining sequence termwise.
 * `WeierstrassCurve.Affine.Point.abs_canonicalHeight_sub_naiveHeight_le`: the canonical height stays
@@ -237,5 +242,29 @@ theorem Point.canonicalHeight_nonneg [W.toAffine.IsElliptic] (P : W.Point) :
     0 ≤ P.canonicalHeight :=
   ge_of_tendsto' P.tendsto_naiveHeight_two_pow_nsmul_div_four_pow fun n ↦
     div_nonneg (Point.naiveHeight_nonneg _) (by positivity)
+
+-- The parallelogram law in the shape `TauCeti.QuadraticMap.map_zsmul_of_parallelogram` consumes:
+-- that statement uses `2 • ·` in an arbitrary abelian group, while `canonicalHeight` lands in `ℝ`
+-- where the natural spelling is `2 * ·`.
+private theorem canonicalHeight_parallelogram_nsmul [W.toAffine.IsElliptic] (P Q : W.Point) :
+    (P + Q).canonicalHeight + (P - Q).canonicalHeight
+      = 2 • P.canonicalHeight + 2 • Q.canonicalHeight := by
+  rw [two_smul, two_smul]
+  linarith [Point.canonicalHeight_parallelogram_law P Q]
+
+/-- **The canonical height is quadratic in the point**: it takes `n • P` to `n ^ 2` times its
+value at `P`, for an integer `n`. -/
+theorem Point.canonicalHeight_zsmul [W.toAffine.IsElliptic] (n : ℤ) (P : W.Point) :
+    (n • P).canonicalHeight = (n : ℝ) ^ 2 * P.canonicalHeight := by
+  rw [TauCeti.QuadraticMap.map_zsmul_of_parallelogram (smul_right_injective ℝ two_ne_zero)
+    canonicalHeight_parallelogram_nsmul n P]
+  ring
+
+/-- **The canonical height is quadratic in the point**, for a natural multiple. -/
+theorem Point.canonicalHeight_nsmul [W.toAffine.IsElliptic] (n : ℕ) (P : W.Point) :
+    (n • P).canonicalHeight = (n : ℝ) ^ 2 * P.canonicalHeight := by
+  rw [← natCast_zsmul, Point.canonicalHeight_zsmul]
+  push_cast
+  ring
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -222,10 +222,12 @@ theorem Point.canonicalHeight_parallelogram_law [W.toAffine.IsElliptic] (P Q : W
       (tendsto_pow_atTop_atTop_of_one_lt (by norm_num : (1 : ℝ) < 4))
   linarith [tendsto_nhds_unique hg hzero]
 
+-- Not `@[simp]`: `canonicalHeight_nsmul` is, and it rewrites `2 • P` first, which would leave
+-- this lemma's left-hand side out of simp-normal form — the environment linter reports exactly
+-- that. Kept as a named lemma because `4 * canonicalHeight P` is the sharper right-hand side and
+-- is what a `rw` wants.
 /-- **Doubling scales the canonical height by four.** The parallelogram law at `Q = P`, where
-`P - Q = 0` contributes nothing. This is the normal form a consumer meets first; the general
-`n`-fold statement is a separate step. -/
-@[simp]
+`P - Q = 0` contributes nothing. -/
 theorem Point.canonicalHeight_two_nsmul [W.toAffine.IsElliptic] (P : W.Point) :
     (2 • P).canonicalHeight = 4 * P.canonicalHeight := by
   have h := canonicalHeight_parallelogram_law P P
@@ -261,12 +263,8 @@ theorem Point.canonicalHeight_zsmul [W.toAffine.IsElliptic] (n : ℤ) (P : W.Poi
     canonicalHeight_parallelogram_nsmul n P]
   ring
 
--- Not `@[simp]`, and that is forced rather than chosen: tagging it makes the existing
--- `canonicalHeight_two_nsmul` non-simp-normal, since `2 • P` would rewrite to
--- `((2 : ℕ) : ℝ) ^ 2 * canonicalHeight P` before the sharper `4 * canonicalHeight P` rule could
--- fire. The environment linter reports exactly that. The integer form below carries the tag, and
--- its left-hand side uses a different `smul` instance, so the two do not compete.
 /-- **The canonical height is quadratic in the point**, for a natural multiple. -/
+@[simp]
 theorem Point.canonicalHeight_nsmul [W.toAffine.IsElliptic] (n : ℕ) (P : W.Point) :
     (n • P).canonicalHeight = (n : ℝ) ^ 2 * P.canonicalHeight := by
   rw [← natCast_zsmul, Point.canonicalHeight_zsmul]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.NaiveHeight
-public import TauCeti.LinearAlgebra.QuadraticForm.OfParallelogram
+import TauCeti.LinearAlgebra.QuadraticForm.OfParallelogram
 
 /-!
 # The canonical (Néron–Tate) height
@@ -254,12 +254,18 @@ private theorem canonicalHeight_parallelogram_nsmul [W.toAffine.IsElliptic] (P Q
 
 /-- **The canonical height is quadratic in the point**: it takes `n • P` to `n ^ 2` times its
 value at `P`, for an integer `n`. -/
+@[simp]
 theorem Point.canonicalHeight_zsmul [W.toAffine.IsElliptic] (n : ℤ) (P : W.Point) :
     (n • P).canonicalHeight = (n : ℝ) ^ 2 * P.canonicalHeight := by
   rw [TauCeti.QuadraticMap.map_zsmul_of_parallelogram (smul_right_injective ℝ two_ne_zero)
     canonicalHeight_parallelogram_nsmul n P]
   ring
 
+-- Not `@[simp]`, and that is forced rather than chosen: tagging it makes the existing
+-- `canonicalHeight_two_nsmul` non-simp-normal, since `2 • P` would rewrite to
+-- `((2 : ℕ) : ℝ) ^ 2 * canonicalHeight P` before the sharper `4 * canonicalHeight P` rule could
+-- fire. The environment linter reports exactly that. The integer form below carries the tag, and
+-- its left-hand side uses a different `smul` instance, so the two do not compete.
 /-- **The canonical height is quadratic in the point**, for a natural multiple. -/
 theorem Point.canonicalHeight_nsmul [W.toAffine.IsElliptic] (n : ℕ) (P : W.Point) :
     (n • P).canonicalHeight = (n : ℝ) ^ 2 * P.canonicalHeight := by


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"canonical-height"}-->

**Rebased onto `main` and rewritten.** #5600, #5601 and #5616 have all landed, so this is no longer
a stacked draft and no longer carries its own induction.

## The target

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 6 lists the canonical-height milestones as
"construction of `ĥ` with bounded difference from the naïve height, **quadraticity**,
nonnegativity, `ĥ(P) = 0 ↔ P` torsion, the Néron–Tate bilinear pairing, …". This is quadraticity
in the `n`-fold form; the parallelogram law (#5601) and the doubling normal form are already on
`main`, and nonnegativity is #5619.

## What it adds

```lean
theorem Point.canonicalHeight_zsmul [W.toAffine.IsElliptic] (n : ℤ) (P : W.Point) :
    (n • P).canonicalHeight = (n : ℝ) ^ 2 * P.canonicalHeight

theorem Point.canonicalHeight_nsmul [W.toAffine.IsElliptic] (n : ℕ) (P : W.Point) :
    (n • P).canonicalHeight = (n : ℝ) ^ 2 * P.canonicalHeight
```

## It is an instance of the general result, not a second induction

An earlier revision of this branch proved this directly, by `Nat.twoStepInduction` on the
parallelogram law. That argument is now the general one — `TauCeti.QuadraticMap.
map_zsmul_of_parallelogram` in `LinearAlgebra/QuadraticForm/OfParallelogram.lean` (#5616) — so
keeping a second copy here would have been exactly the duplication `reuse` deletes. This PR is its
instance at `f = canonicalHeight`, `N = ℝ`, with `smul_right_injective ℝ two_ne_zero` supplying the
doubling-injectivity hypothesis.

The whole proof is now:

```lean
rw [map_zsmul_of_parallelogram (smul_right_injective ℝ two_ne_zero)
  canonicalHeight_parallelogram_nsmul n P]
ring
```

The one piece of glue is `canonicalHeight_parallelogram_nsmul`, kept `private`: the general
statement uses `2 • ·` in an arbitrary abelian group, while `canonicalHeight` lands in `ℝ`, where
`main`'s `canonicalHeight_parallelogram_law` is stated with `2 * ·`. Two `two_smul` rewrites and
`linarith`.

This was verified against #5616's file before that PR merged, so the rewrite is not a guess about
what the general statement would look like.

## Reuse

`map_zsmul_of_parallelogram` (#5616, now on `main`), `canonicalHeight_parallelogram_law` (#5601, now
on `main`), `smul_right_injective`, `natCast_zsmul`. No new machinery and no new induction.

## Placement

`AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean`, alongside the rest of the canonical-height
API, importing the general quadratic-form result.

## Provenance

**Original work.** The chain's intake records that the Néron–Tate height has no source.

## Gates

- `lake build`: green, 0 errors, 0 warnings under `warningAsError = true`, no Mathlib recompiled.
- **`#lint in TauCeti` — the full environment-linter set**: "All linting checks passed", 0 errors in
  38 declarations.
- `scripts/lint-style.sh`: exit 0, all 4338 headers conforming.
- Every `TauCeti.`-qualified name cited in the new docstrings checked to resolve against
  `origin/main` — the check I added after pointing two docstrings at unmerged sibling PRs.
- No `sorry`, no `native_decide`, no `maxHeartbeats`.



## The simp-normal-form decision

`api-design` asked for `@[simp]` on both quadraticity lemmas. **Only one can carry it**, and the
environment linter is what settles which: with `canonicalHeight_nsmul` tagged, `simpNF` reports
that `canonicalHeight_two_nsmul`'s left-hand side *"simplifies from `(2 • P).canonicalHeight` to
`2 ^ 2 * P.canonicalHeight`"* — the general `ℕ` rule fires first and strands the specialisation.

The round that raised this prescribed the resolution: tag the general rule, drop the tag from the
specialisation. Done. `canonicalHeight_zsmul` also carries `@[simp]`; its left-hand side uses the
`ℤ`-`smul` instance, so it never competes.

**The cost, stated rather than glossed:** `simp` alone no longer closes
`(2 • P).canonicalHeight = 4 * canonicalHeight P`. It normalises to
`((2 : ℕ) : ℝ) ^ 2 * canonicalHeight P` and needs `norm_num` after — verified by probe, not
assumed. `canonicalHeight_two_nsmul` remains as a named lemma, because `4 * canonicalHeight P` is
the sharper right-hand side and is what a `rw` wants.

Nothing on `main` imports this module (`git grep -l EllipticCurve.CanonicalHeight origin/main`
returns nothing), so removing that tag cannot break a downstream proof.
