### PR TITLE
feat: construct the flow of a globally Lipschitz vector field

### DIFF
--- a/TauCeti/Analysis/Calculus/Morse/FlowExistence.lean
+++ b/TauCeti/Analysis/Calculus/Morse/FlowExistence.lean
@@ -5,39 +5,36 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.Calculus.Morse.SplitModel
+public import TauCeti.Analysis.Calculus.Morse.GradientFlow
 public import TauCeti.Dynamics.Flow.OfLipschitz
 
 /-!
 # Existence of the negative gradient flow
 
-The dynamical route to Morse homology reads its trajectory spaces off a *flow*: the stable and
-unstable sets of `TauCeti/Dynamics/Flow/Stable.lean`, and the Lyapunov theory of
-`TauCeti/Analysis/Calculus/Morse/GradientFlow.lean`, are all statements about a
-`Flow.IsNegativeGradient` flow. Until now the only such flow available was the explicit
-hyperbolic one of the split quadratic model. This file produces one for every function whose
+The dynamical description of Morse theory reads its trajectory spaces off a *flow*: stable and
+unstable sets, and the Lyapunov theory of a decreasing function along trajectories, are statements
+about a `Flow.IsNegativeGradient` flow. This file produces such a flow for every function whose
 gradient is globally Lipschitz, by feeding `-∇ f` to `Flow.ofLipschitz`.
 
-Global Lipschitz continuity of `∇ f` is exactly what rules out escape to infinity in finite time;
-it holds for instance whenever `f` is `C²` with a bounded second derivative, and in particular for
-the split quadratic model, whose explicit flow is recovered here as a special case.
+Global Lipschitz continuity of `∇ f` is a sufficient hypothesis for the trajectories to exist for
+all time; it holds for instance whenever `f` is `C²` with a bounded second derivative, and in
+particular for the split quadratic model.
 
 ## Main declarations
 
 * `TauCeti.negativeGradientFlow`: the negative gradient flow of a function with globally Lipschitz
   gradient.
 * `TauCeti.isNegativeGradient_negativeGradientFlow`: it is a negative gradient flow of `f`.
+* `TauCeti.eq_negativeGradientFlow`: every global negative gradient trajectory is one of its
+  orbits.
+* `TauCeti.negativeGradientFlow_congr`: it does not depend on the chosen Lipschitz bound.
 * `TauCeti.forall_negativeGradientFlow_eq_self_iff`: its rest points are the critical points
   of `f`.
-* `TauCeti.negativeGradientFlow_splitQuadratic`: for the split quadratic model it is the explicit
-  hyperbolic flow.
 
 ## References
 
 * M. Audin and M. Damian, *Morse Theory and Floer Homology*, Springer Universitext, 2014,
   Chapter 2.
-* [Heegaard Floer homology roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HeegaardFloer/README.md),
-  Lane M, "Morse homology".
 -/
 
 public section
@@ -67,29 +64,15 @@ theorem eq_negativeGradientFlow (f : E → ℝ) (hf : LipschitzWith K (∇ f)) {
     γ t = negativeGradientFlow f hf t (γ 0) :=
   _root_.Flow.eq_ofLipschitz hf.neg hγ t
 
+/-- **Independence of the Lipschitz bound.** Two Lipschitz witnesses for `∇ f`, with possibly
+different constants, produce the same negative gradient flow. -/
+theorem negativeGradientFlow_congr (f : E → ℝ) {K' : ℝ≥0} (hf : LipschitzWith K (∇ f))
+    (hf' : LipschitzWith K' (∇ f)) : negativeGradientFlow f hf = negativeGradientFlow f hf' :=
+  _root_.Flow.ofLipschitz_congr hf.neg hf'.neg
+
 /-- **The rest points of the negative gradient flow are the critical points of `f`.** -/
 theorem forall_negativeGradientFlow_eq_self_iff (f : E → ℝ) (hf : LipschitzWith K (∇ f)) (x : E) :
     (∀ t, negativeGradientFlow f hf t x = x) ↔ ∇ f x = 0 := by
   rw [negativeGradientFlow, _root_.Flow.forall_ofLipschitz_eq_self_iff, neg_eq_zero]
-
-section SplitModel
-
-variable {Eₛ Eᵤ : Type*} [NormedAddCommGroup Eₛ] [NormedAddCommGroup Eᵤ]
-  [InnerProductSpace ℝ Eₛ] [InnerProductSpace ℝ Eᵤ] [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
-
-/-- On the split quadratic model the abstract construction returns the explicit hyperbolic flow,
-which is the acceptance check that `TauCeti.negativeGradientFlow` is the intended object. -/
-theorem negativeGradientFlow_splitQuadratic :
-    negativeGradientFlow (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ))
-        lipschitzWith_gradient_splitQuadratic = splitQuadraticFlow := by
-  refine _root_.Flow.ext fun t z ↦ ?_
-  have hγ := (Flow.isNegativeGradient_splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ)).isIntegralCurve z
-  have h := eq_negativeGradientFlow (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ))
-    lipschitzWith_gradient_splitQuadratic hγ t
-  have h0 : splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ) 0 z = z := _root_.Flow.map_zero_apply _ z
-  rw [h0] at h
-  exact h.symm
-
-end SplitModel
 
 end TauCeti

--- a/TauCeti/Analysis/Calculus/Morse/FlowExistence.lean
+++ b/TauCeti/Analysis/Calculus/Morse/FlowExistence.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Calculus.Morse.SplitModel
+public import TauCeti.Dynamics.Flow.OfLipschitz
+
+/-!
+# Existence of the negative gradient flow
+
+The dynamical route to Morse homology reads its trajectory spaces off a *flow*: the stable and
+unstable sets of `TauCeti/Dynamics/Flow/Stable.lean`, and the Lyapunov theory of
+`TauCeti/Analysis/Calculus/Morse/GradientFlow.lean`, are all statements about a
+`Flow.IsNegativeGradient` flow. Until now the only such flow available was the explicit
+hyperbolic one of the split quadratic model. This file produces one for every function whose
+gradient is globally Lipschitz, by feeding `-∇ f` to `Flow.ofLipschitz`.
+
+Global Lipschitz continuity of `∇ f` is exactly what rules out escape to infinity in finite time;
+it holds for instance whenever `f` is `C²` with a bounded second derivative, and in particular for
+the split quadratic model, whose explicit flow is recovered here as a special case.
+
+## Main declarations
+
+* `TauCeti.negativeGradientFlow`: the negative gradient flow of a function with globally Lipschitz
+  gradient.
+* `TauCeti.isNegativeGradient_negativeGradientFlow`: it is a negative gradient flow of `f`.
+* `TauCeti.forall_negativeGradientFlow_eq_self_iff`: its rest points are the critical points
+  of `f`.
+* `TauCeti.negativeGradientFlow_splitQuadratic`: for the split quadratic model it is the explicit
+  hyperbolic flow.
+
+## References
+
+* M. Audin and M. Damian, *Morse Theory and Floer Homology*, Springer Universitext, 2014,
+  Chapter 2.
+* [Heegaard Floer homology roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HeegaardFloer/README.md),
+  Lane M, "Morse homology".
+-/
+
+public section
+
+open InnerProductSpace
+open scoped Gradient NNReal
+
+namespace TauCeti
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteSpace E]
+  {f : E → ℝ} {K : ℝ≥0}
+
+/-- **The negative gradient flow** of a function whose gradient is globally Lipschitz. -/
+noncomputable def negativeGradientFlow (f : E → ℝ) {K : ℝ≥0} (hf : LipschitzWith K (∇ f)) :
+    _root_.Flow ℝ E :=
+  _root_.Flow.ofLipschitz (fun x ↦ -∇ f x) hf.neg
+
+/-- **The negative gradient flow is a negative gradient flow**: each of its orbits solves
+`γ' = -∇f(γ)`. -/
+theorem isNegativeGradient_negativeGradientFlow (f : E → ℝ) (hf : LipschitzWith K (∇ f)) :
+    Flow.IsNegativeGradient (negativeGradientFlow f hf) f :=
+  Flow.isNegativeGradient_iff.2 fun x ↦ _root_.Flow.isIntegralCurve_ofLipschitz hf.neg x
+
+/-- **Every global negative gradient trajectory is an orbit** of the negative gradient flow. -/
+theorem eq_negativeGradientFlow (f : E → ℝ) (hf : LipschitzWith K (∇ f)) {γ : ℝ → E}
+    (hγ : IsIntegralCurve γ fun _ y ↦ -∇ f y) (t : ℝ) :
+    γ t = negativeGradientFlow f hf t (γ 0) :=
+  _root_.Flow.eq_ofLipschitz hf.neg hγ t
+
+/-- **The rest points of the negative gradient flow are the critical points of `f`.** -/
+theorem forall_negativeGradientFlow_eq_self_iff (f : E → ℝ) (hf : LipschitzWith K (∇ f)) (x : E) :
+    (∀ t, negativeGradientFlow f hf t x = x) ↔ ∇ f x = 0 := by
+  rw [negativeGradientFlow, _root_.Flow.forall_ofLipschitz_eq_self_iff, neg_eq_zero]
+
+section SplitModel
+
+variable {Eₛ Eᵤ : Type*} [NormedAddCommGroup Eₛ] [NormedAddCommGroup Eᵤ]
+  [InnerProductSpace ℝ Eₛ] [InnerProductSpace ℝ Eᵤ] [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
+
+/-- On the split quadratic model the abstract construction returns the explicit hyperbolic flow,
+which is the acceptance check that `TauCeti.negativeGradientFlow` is the intended object. -/
+theorem negativeGradientFlow_splitQuadratic :
+    negativeGradientFlow (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ))
+        lipschitzWith_gradient_splitQuadratic = splitQuadraticFlow := by
+  refine _root_.Flow.ext fun t z ↦ ?_
+  have hγ := (Flow.isNegativeGradient_splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ)).isIntegralCurve z
+  have h := eq_negativeGradientFlow (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ))
+    lipschitzWith_gradient_splitQuadratic hγ t
+  have h0 : splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ) 0 z = z := _root_.Flow.map_zero_apply _ z
+  rw [h0] at h
+  exact h.symm
+
+end SplitModel
+
+end TauCeti

--- a/TauCeti/Analysis/Calculus/Morse/FlowExistence.lean
+++ b/TauCeti/Analysis/Calculus/Morse/FlowExistence.lean
@@ -14,7 +14,7 @@ public import TauCeti.Dynamics.Flow.OfLipschitz
 The dynamical description of Morse theory reads its trajectory spaces off a *flow*: stable and
 unstable sets, and the Lyapunov theory of a decreasing function along trajectories, are statements
 about a `Flow.IsNegativeGradient` flow. This file produces such a flow for every function whose
-gradient is globally Lipschitz, by feeding `-∇ f` to `Flow.ofLipschitz`.
+gradient is globally Lipschitz, by feeding `-∇ f` to `TauCeti.flowOfLipschitz`.
 
 Global Lipschitz continuity of `∇ f` is a sufficient hypothesis for the trajectories to exist for
 all time; it holds for instance whenever `f` is `C²` with a bounded second derivative, and in
@@ -25,8 +25,8 @@ wherever `f` is not differentiable.  What is constructed below is therefore the 
 field `-∇ f`, and no differentiability of `f` is assumed for it, exactly as the predicate
 `Flow.IsNegativeGradient` it witnesses assumes none.  Differentiability of `f` is what makes that
 field the gradient field of `f`, and it enters where the flow is used as a *gradient* flow rather
-than as the flow of a Lipschitz field: `TauCeti.negativeGradientFlow_orbit_antitone` records the
-Lyapunov descent of a differentiable `f` along the orbits.
+than as the flow of a Lipschitz field: `TauCeti.negativeGradientFlow_orbit_antitone` records
+Lyapunov descent along any orbit on which `f` is differentiable.
 
 ## Main declarations
 
@@ -37,7 +37,8 @@ Lyapunov descent of a differentiable `f` along the orbits.
   orbits.
 * `TauCeti.negativeGradientFlow_congr`: it does not depend on the chosen Lipschitz bound.
 * `TauCeti.forall_negativeGradientFlow_eq_self_iff`: its rest points are the zeros of `∇ f`.
-* `TauCeti.negativeGradientFlow_orbit_antitone`: a differentiable `f` decreases along its orbits.
+* `TauCeti.negativeGradientFlow_orbit_antitone`: `f` decreases along an orbit on which it is
+  differentiable.
 
 ## References
 
@@ -63,38 +64,38 @@ differentiable everywhere it is the flow of Mathlib's totalized gradient field, 
 object the hypothesis `LipschitzWith K (∇ f)` speaks about. -/
 noncomputable def negativeGradientFlow (f : E → ℝ) {K : ℝ≥0} (hf : LipschitzWith K (∇ f)) :
     _root_.Flow ℝ E :=
-  _root_.Flow.ofLipschitz (fun x ↦ -∇ f x) hf.neg
+  flowOfLipschitz (fun x ↦ -∇ f x) hf.neg
 
 /-- **The negative gradient flow is a negative gradient flow**: each of its orbits solves
 `γ' = -∇f(γ)`. -/
 theorem isNegativeGradient_negativeGradientFlow (f : E → ℝ) (hf : LipschitzWith K (∇ f)) :
     Flow.IsNegativeGradient (negativeGradientFlow f hf) f :=
-  Flow.isNegativeGradient_iff.2 fun x ↦ _root_.Flow.isIntegralCurve_ofLipschitz hf.neg x
+  Flow.isNegativeGradient_iff.2 fun x ↦ isIntegralCurve_flowOfLipschitz hf.neg x
 
 /-- **Every global negative gradient trajectory is an orbit** of the negative gradient flow. -/
 theorem eq_negativeGradientFlow (f : E → ℝ) (hf : LipschitzWith K (∇ f)) {γ : ℝ → E}
     (hγ : IsIntegralCurve γ fun _ y ↦ -∇ f y) (t : ℝ) :
     γ t = negativeGradientFlow f hf t (γ 0) :=
-  _root_.Flow.eq_ofLipschitz hf.neg hγ t
+  eq_flowOfLipschitz hf.neg hγ t
 
 /-- **Independence of the Lipschitz bound.** Two Lipschitz witnesses for `∇ f`, with possibly
 different constants, produce the same negative gradient flow. -/
 theorem negativeGradientFlow_congr (f : E → ℝ) {K' : ℝ≥0} (hf : LipschitzWith K (∇ f))
     (hf' : LipschitzWith K' (∇ f)) : negativeGradientFlow f hf = negativeGradientFlow f hf' :=
-  _root_.Flow.ofLipschitz_congr hf.neg hf'.neg
+  flowOfLipschitz_congr hf.neg hf'.neg
 
 /-- **The rest points of the negative gradient flow are the zeros of `∇ f`**, that is, the
 critical points of a differentiable `f`. -/
 theorem forall_negativeGradientFlow_eq_self_iff (f : E → ℝ) (hf : LipschitzWith K (∇ f)) (x : E) :
     (∀ t, negativeGradientFlow f hf t x = x) ↔ ∇ f x = 0 := by
-  rw [negativeGradientFlow, _root_.Flow.forall_ofLipschitz_eq_self_iff, neg_eq_zero]
+  rw [negativeGradientFlow, forall_flowOfLipschitz_eq_self_iff, neg_eq_zero]
 
-/-- **Lyapunov descent along the negative gradient flow**: a differentiable function decreases
-along every orbit of its negative gradient flow.  This is the point at which differentiability of
-`f` is needed, the construction of the flow itself only seeing the vector field `-∇ f`. -/
+/-- **Lyapunov descent along the negative gradient flow**: a function decreases along any orbit
+on which it is differentiable.  This is the point at which differentiability of `f` is needed, the
+construction of the flow itself only seeing the vector field `-∇ f`. -/
 theorem negativeGradientFlow_orbit_antitone (f : E → ℝ) (hf : LipschitzWith K (∇ f))
-    (hf' : Differentiable ℝ f) (x : E) :
+    (x : E) (hf' : ∀ t, DifferentiableAt ℝ f (negativeGradientFlow f hf t x)) :
     Antitone fun t ↦ f (negativeGradientFlow f hf t x) :=
-  (isNegativeGradient_negativeGradientFlow f hf).orbit_antitone x fun _ ↦ hf' _
+  (isNegativeGradient_negativeGradientFlow f hf).orbit_antitone x hf'
 
 end TauCeti

--- a/TauCeti/Analysis/Calculus/Morse/FlowExistence.lean
+++ b/TauCeti/Analysis/Calculus/Morse/FlowExistence.lean
@@ -20,6 +20,14 @@ Global Lipschitz continuity of `∇ f` is a sufficient hypothesis for the trajec
 all time; it holds for instance whenever `f` is `C²` with a bounded second derivative, and in
 particular for the split quadratic model.
 
+Throughout, `∇ f` is Mathlib's gradient: a function defined for every `f`, taking the value `0`
+wherever `f` is not differentiable.  What is constructed below is therefore the flow of the vector
+field `-∇ f`, and no differentiability of `f` is assumed for it, exactly as the predicate
+`Flow.IsNegativeGradient` it witnesses assumes none.  Differentiability of `f` is what makes that
+field the gradient field of `f`, and it enters where the flow is used as a *gradient* flow rather
+than as the flow of a Lipschitz field: `TauCeti.negativeGradientFlow_orbit_antitone` records the
+Lyapunov descent of a differentiable `f` along the orbits.
+
 ## Main declarations
 
 * `TauCeti.negativeGradientFlow`: the negative gradient flow of a function with globally Lipschitz
@@ -28,8 +36,8 @@ particular for the split quadratic model.
 * `TauCeti.eq_negativeGradientFlow`: every global negative gradient trajectory is one of its
   orbits.
 * `TauCeti.negativeGradientFlow_congr`: it does not depend on the chosen Lipschitz bound.
-* `TauCeti.forall_negativeGradientFlow_eq_self_iff`: its rest points are the critical points
-  of `f`.
+* `TauCeti.forall_negativeGradientFlow_eq_self_iff`: its rest points are the zeros of `∇ f`.
+* `TauCeti.negativeGradientFlow_orbit_antitone`: a differentiable `f` decreases along its orbits.
 
 ## References
 
@@ -47,7 +55,12 @@ namespace TauCeti
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteSpace E]
   {f : E → ℝ} {K : ℝ≥0}
 
-/-- **The negative gradient flow** of a function whose gradient is globally Lipschitz. -/
+/-- **The negative gradient flow** of a function whose gradient is globally Lipschitz.
+
+This is the flow of the vector field `-∇ f`.  For a differentiable `f` that field is the negative
+gradient field and this is the negative gradient flow in the usual sense; for an `f` that is not
+differentiable everywhere it is the flow of Mathlib's totalized gradient field, which is the
+object the hypothesis `LipschitzWith K (∇ f)` speaks about. -/
 noncomputable def negativeGradientFlow (f : E → ℝ) {K : ℝ≥0} (hf : LipschitzWith K (∇ f)) :
     _root_.Flow ℝ E :=
   _root_.Flow.ofLipschitz (fun x ↦ -∇ f x) hf.neg
@@ -70,9 +83,18 @@ theorem negativeGradientFlow_congr (f : E → ℝ) {K' : ℝ≥0} (hf : Lipschit
     (hf' : LipschitzWith K' (∇ f)) : negativeGradientFlow f hf = negativeGradientFlow f hf' :=
   _root_.Flow.ofLipschitz_congr hf.neg hf'.neg
 
-/-- **The rest points of the negative gradient flow are the critical points of `f`.** -/
+/-- **The rest points of the negative gradient flow are the zeros of `∇ f`**, that is, the
+critical points of a differentiable `f`. -/
 theorem forall_negativeGradientFlow_eq_self_iff (f : E → ℝ) (hf : LipschitzWith K (∇ f)) (x : E) :
     (∀ t, negativeGradientFlow f hf t x = x) ↔ ∇ f x = 0 := by
   rw [negativeGradientFlow, _root_.Flow.forall_ofLipschitz_eq_self_iff, neg_eq_zero]
+
+/-- **Lyapunov descent along the negative gradient flow**: a differentiable function decreases
+along every orbit of its negative gradient flow.  This is the point at which differentiability of
+`f` is needed, the construction of the flow itself only seeing the vector field `-∇ f`. -/
+theorem negativeGradientFlow_orbit_antitone (f : E → ℝ) (hf : LipschitzWith K (∇ f))
+    (hf' : Differentiable ℝ f) (x : E) :
+    Antitone fun t ↦ f (negativeGradientFlow f hf t x) :=
+  (isNegativeGradient_negativeGradientFlow f hf).orbit_antitone x fun _ ↦ hf' _
 
 end TauCeti

--- a/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
+++ b/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
@@ -9,7 +9,6 @@ public import Mathlib.Analysis.InnerProductSpace.ProdL2
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 public import TauCeti.Analysis.Calculus.Morse.Basic
 public import TauCeti.Analysis.Calculus.Morse.FlowExistence
-public import TauCeti.Analysis.Calculus.Morse.GradientFlow
 public import TauCeti.Analysis.Calculus.Morse.Stable
 import Mathlib.Analysis.InnerProductSpace.Calculus
 import Mathlib.Analysis.InnerProductSpace.Dual

--- a/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
+++ b/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.InnerProductSpace.ProdL2
-public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 public import TauCeti.Analysis.Calculus.Morse.Basic
 public import TauCeti.Analysis.Calculus.Morse.FlowExistence
 public import TauCeti.Analysis.Calculus.Morse.Stable

--- a/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
+++ b/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.InnerProductSpace.ProdL2
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 public import TauCeti.Analysis.Calculus.Morse.Basic
+public import TauCeti.Analysis.Calculus.Morse.FlowExistence
 public import TauCeti.Analysis.Calculus.Morse.GradientFlow
 public import TauCeti.Analysis.Calculus.Morse.Stable
 import Mathlib.Analysis.InnerProductSpace.Calculus
@@ -40,6 +41,8 @@ and Hessian determine the corresponding linearized gradient flow and its contrac
 * `TauCeti.isNondegenerateCriticalPoint_splitQuadratic_zero`: the origin is nondegenerate.
 * `TauCeti.splitQuadraticFlow`: its explicit negative-gradient flow.
 * `Flow.isNegativeGradient_splitQuadraticFlow`: the flow solves the negative-gradient equation.
+* `TauCeti.negativeGradientFlow_splitQuadratic`: the general construction of the negative gradient
+  flow returns this explicit flow.
 * `Flow.stableSet_splitQuadraticFlow_zero`: the stable set is the first coordinate plane.
 * `Flow.unstableSet_splitQuadraticFlow_zero`: the unstable set is the second coordinate plane.
 
@@ -206,6 +209,24 @@ theorem Flow.isNegativeGradient_splitQuadraticFlow
     rw [TauCeti.gradient_splitQuadratic]
     apply WithLp.ofLp_injective
     ext <;> simp
+
+namespace TauCeti
+
+/-- On the split quadratic model, the negative gradient flow built from a globally Lipschitz
+gradient is the explicit hyperbolic flow. -/
+theorem negativeGradientFlow_splitQuadratic [InnerProductSpace ℝ Eₛ] [InnerProductSpace ℝ Eᵤ]
+    [CompleteSpace Eₛ] [CompleteSpace Eᵤ] :
+    negativeGradientFlow (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ))
+        lipschitzWith_gradient_splitQuadratic = splitQuadraticFlow := by
+  refine _root_.Flow.ext fun t z ↦ ?_
+  have hγ := (Flow.isNegativeGradient_splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ)).isIntegralCurve z
+  have h := eq_negativeGradientFlow (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ))
+    lipschitzWith_gradient_splitQuadratic hγ t
+  have h0 : splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ) 0 z = z := _root_.Flow.map_zero_apply _ z
+  rw [h0] at h
+  exact h.symm
+
+end TauCeti
 
 variable [NormedSpace ℝ Eₛ] [NormedSpace ℝ Eᵤ]
 

--- a/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
+++ b/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
@@ -36,6 +36,7 @@ and Hessian determine the corresponding linearized gradient flow and its contrac
 
 * `TauCeti.splitQuadratic`: the standard split quadratic function.
 * `TauCeti.gradient_splitQuadratic`: its gradient is `(x, -y)`.
+* `TauCeti.lipschitzWith_gradient_splitQuadratic`: its gradient is globally `1`-Lipschitz.
 * `TauCeti.isNondegenerateCriticalPoint_splitQuadratic_zero`: the origin is nondegenerate.
 * `TauCeti.splitQuadraticFlow`: its explicit negative-gradient flow.
 * `Flow.isNegativeGradient_splitQuadraticFlow`: the flow solves the negative-gradient equation.
@@ -110,6 +111,17 @@ theorem gradient_splitQuadratic_eq_zero_iff [InnerProductSpace ℝ Eₛ] [InnerP
     · simpa using congrArg WithLp.snd h
   · rintro rfl
     simp
+
+/-- The gradient of the split quadratic function is an isometry of the underlying space, hence in
+particular globally `1`-Lipschitz.  This is the hypothesis under which the negative gradient flow
+of a function exists on the whole line. -/
+theorem lipschitzWith_gradient_splitQuadratic [InnerProductSpace ℝ Eₛ] [InnerProductSpace ℝ Eᵤ]
+    [CompleteSpace Eₛ] [CompleteSpace Eᵤ] :
+    LipschitzWith 1 (∇ (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ))) := by
+  refine LipschitzWith.of_dist_le_mul fun z w ↦ ?_
+  rw [NNReal.coe_one, one_mul, gradient_splitQuadratic, gradient_splitQuadratic,
+    WithLp.prod_dist_eq_of_L2, WithLp.prod_dist_eq_of_L2]
+  simp
 
 /-- The origin is a nondegenerate critical point of the split quadratic function. -/
 theorem isNondegenerateCriticalPoint_splitQuadratic_zero

--- a/TauCeti/Analysis/ODE/GlobalSolution.lean
+++ b/TauCeti/Analysis/ODE/GlobalSolution.lean
@@ -10,7 +10,6 @@ public import Mathlib.Analysis.ODE.ExistUnique
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 public import Mathlib.Topology.ContinuousMap.Bounded.Normed
-public import Mathlib.Topology.MetricSpace.Contracting
 
 /-!
 # The global solution of a globally Lipschitz autonomous ODE

--- a/TauCeti/Analysis/ODE/GlobalSolution.lean
+++ b/TauCeti/Analysis/ODE/GlobalSolution.lean
@@ -1,0 +1,386 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.ODE.Basic
+public import Mathlib.Analysis.ODE.ExistUnique
+public import Mathlib.Analysis.ODE.Gronwall
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+public import Mathlib.MeasureTheory.Integral.DominatedConvergence
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+public import Mathlib.Topology.ContinuousMap.Bounded.Normed
+public import Mathlib.Topology.MetricSpace.Contracting
+
+/-!
+# The global solution of a globally Lipschitz autonomous ODE
+
+Picard--Lindelöf solves `γ' = v ∘ γ` only on a small time interval, because a solution can escape
+to infinity in finite time. When the vector field is *globally* Lipschitz no such escape happens,
+and through every initial point there is exactly one solution defined on all of `ℝ`. This file
+constructs it, as `ODE.globalSolution`.
+
+The construction is the Picard iteration performed once and for all on the whole line, in the
+weighted norm that makes it a contraction there. Writing `w t = cosh (2 k t)` for a Lipschitz
+constant `k > 0` of `v`, a curve is presented as `γ t = x + w t • u t` with `u : ℝ →ᵇ E` bounded
+continuous, and the Picard operator becomes
+
+`(P u) t = (w t)⁻¹ • ∫ s in 0..t, v (x + w s • u s)`.
+
+Since `∫ s in 0..t, w s = sinh (2 k t) / (2 k)` and `|sinh| ≤ cosh`, the operator `P` maps
+`ℝ →ᵇ E` to itself and halves distances, for either sign of `t`, so there is no need to glue local
+solutions: `P` has a unique fixed point on the whole line. The associated curve
+satisfies `γ t = x + ∫ s in 0..t, v (γ s)`, hence solves the differential equation. Uniqueness is
+Mathlib's `ODE_solution_unique_univ`, and the fixed point depends on the initial condition
+`1`-Lipschitzly, which gives joint continuity in time and initial condition.
+
+## Main declarations
+
+* `ODE.globalSolution`: the solution of `γ' = v ∘ γ` with `γ 0 = x` on all of `ℝ`.
+* `ODE.globalSolution_eq_integral`: it satisfies the integral equation of the initial value
+  problem.
+* `ODE.globalSolution_zero` and `ODE.hasDerivAt_globalSolution`: it is a solution.
+* `ODE.eq_globalSolution`: every global solution with the same initial value is equal to it.
+* `ODE.globalSolution_neg`: reversing time solves the negated field.
+* `ODE.dist_globalSolution_le`: two solutions drift apart at most exponentially.
+* `ODE.continuous_globalSolution`: joint continuity in time and initial condition.
+
+## References
+
+* J. Dieudonné, *Foundations of Modern Analysis*, Academic Press, 1969, Chapter X.
+* [Heegaard Floer homology roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HeegaardFloer/README.md),
+  Lane M, "Morse homology".
+-/
+
+public section
+
+open Filter MeasureTheory Set Topology
+open scoped BoundedContinuousFunction NNReal
+
+namespace ODE
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- The hyperbolic sine is dominated by the hyperbolic cosine. -/
+private theorem abs_sinh_le_cosh (y : ℝ) : |Real.sinh y| ≤ Real.cosh y := by
+  rw [abs_le, Real.sinh_eq, Real.cosh_eq]
+  constructor <;> nlinarith [Real.exp_pos y, Real.exp_pos (-y)]
+
+/-- The estimate that drives the whole construction: an integrand dominated by `C * cosh (2 k ·)`
+has a primitive dominated by `C * cosh (2 k ·) / (2 k)`, with no restriction on the sign of the
+upper limit. -/
+private theorem norm_integral_le_cosh {k C : ℝ} (hk : 0 < k) (hC : 0 ≤ C) {F : ℝ → E}
+    (hF : ∀ s, ‖F s‖ ≤ C * Real.cosh (2 * k * s)) (t : ℝ) :
+    ‖∫ s in (0 : ℝ)..t, F s‖ ≤ C * Real.cosh (2 * k * t) / (2 * k) := by
+  have hk2 : (0 : ℝ) < 2 * k := by linarith
+  have hg : Continuous fun s : ℝ ↦ C * Real.cosh (2 * k * s) := by fun_prop
+  have hderiv : ∀ s : ℝ, HasDerivAt (fun s : ℝ ↦ C * Real.sinh (2 * k * s) / (2 * k))
+      (C * Real.cosh (2 * k * s)) s := by
+    intro s
+    have h1 : HasDerivAt (fun s : ℝ ↦ 2 * k * s) (2 * k) s := by
+      simpa using (hasDerivAt_id s).const_mul (2 * k)
+    have h2 : HasDerivAt (fun s : ℝ ↦ Real.sinh (2 * k * s))
+        (Real.cosh (2 * k * s) * (2 * k)) s := (Real.hasDerivAt_sinh (2 * k * s)).comp s h1
+    have h3 : HasDerivAt (fun s : ℝ ↦ C * Real.sinh (2 * k * s) / (2 * k))
+        (C * (Real.cosh (2 * k * s) * (2 * k)) / (2 * k)) s := (h2.const_mul C).div_const (2 * k)
+    have hval : C * (Real.cosh (2 * k * s) * (2 * k)) / (2 * k) = C * Real.cosh (2 * k * s) := by
+      rw [div_eq_iff hk2.ne']
+      ring
+    rwa [hval] at h3
+  have hcalc : ∫ s in (0 : ℝ)..t, C * Real.cosh (2 * k * s) =
+      C * Real.sinh (2 * k * t) / (2 * k) := by
+    rw [intervalIntegral.integral_eq_sub_of_hasDerivAt (fun s _ ↦ hderiv s)
+      (hg.intervalIntegrable _ _)]
+    simp
+  calc ‖∫ s in (0 : ℝ)..t, F s‖
+      ≤ |∫ s in (0 : ℝ)..t, C * Real.cosh (2 * k * s)| :=
+        intervalIntegral.norm_integral_le_abs_of_norm_le (.of_forall fun s ↦ hF s)
+          (hg.intervalIntegrable _ _)
+    _ = C * |Real.sinh (2 * k * t)| / (2 * k) := by
+        rw [hcalc, abs_div, abs_mul, abs_of_nonneg hC, abs_of_pos hk2]
+    _ ≤ C * Real.cosh (2 * k * t) / (2 * k) := by
+        gcongr
+        exact abs_sinh_le_cosh _
+
+/-- The curve carried by a bounded continuous profile `u`, weighted so that the Picard operator
+below is a contraction on the whole line. -/
+private noncomputable def picardCurve (k : ℝ) (x : E) (u : ℝ →ᵇ E) (t : ℝ) : E :=
+  x + Real.cosh (2 * k * t) • u t
+
+private theorem continuous_picardCurve (k : ℝ) (x : E) (u : ℝ →ᵇ E) :
+    Continuous (picardCurve k x u) := by
+  have hu : Continuous (⇑u) := u.continuous
+  unfold picardCurve
+  fun_prop
+
+private theorem norm_picardCurve_sub_le (k : ℝ) (x : E) (u : ℝ →ᵇ E) (t : ℝ) :
+    ‖picardCurve k x u t - x‖ ≤ Real.cosh (2 * k * t) * ‖u‖ := by
+  have h : picardCurve k x u t - x = Real.cosh (2 * k * t) • u t := by
+    simp [picardCurve]
+  rw [h, norm_smul, Real.norm_eq_abs, abs_of_pos (Real.cosh_pos _)]
+  exact mul_le_mul_of_nonneg_left (u.norm_coe_le_norm t) (Real.cosh_pos _).le
+
+private theorem picardCurve_sub (k : ℝ) (x : E) (u₁ u₂ : ℝ →ᵇ E) (t : ℝ) :
+    picardCurve k x u₁ t - picardCurve k x u₂ t = Real.cosh (2 * k * t) • (u₁ t - u₂ t) := by
+  simp [picardCurve, smul_sub]
+
+private theorem picardCurve_sub_const (k : ℝ) (x y : E) (u : ℝ →ᵇ E) (t : ℝ) :
+    picardCurve k x u t - picardCurve k y u t = x - y := by
+  simp [picardCurve]
+
+/-- The Picard operator, as a plain function; it is packaged as a self-map of `ℝ →ᵇ E` below. -/
+private noncomputable def picardMap (v : E → E) (k : ℝ) (x : E) (u : ℝ →ᵇ E) (t : ℝ) : E :=
+  (Real.cosh (2 * k * t))⁻¹ • ∫ s in (0 : ℝ)..t, v (picardCurve k x u s)
+
+private theorem continuous_picardMap {v : E → E} (hvc : Continuous v) (k : ℝ) (x : E)
+    (u : ℝ →ᵇ E) : Continuous (picardMap v k x u) := by
+  have hcomp : Continuous fun s ↦ v (picardCurve k x u s) :=
+    hvc.comp (continuous_picardCurve k x u)
+  have hint : Continuous fun t : ℝ ↦ ∫ s in (0 : ℝ)..t, v (picardCurve k x u s) :=
+    intervalIntegral.continuous_primitive (fun a b ↦ hcomp.intervalIntegrable a b) 0
+  have hinv : Continuous fun t : ℝ ↦ (Real.cosh (2 * k * t))⁻¹ :=
+    Continuous.inv₀ (by fun_prop) fun t ↦ (Real.cosh_pos _).ne'
+  exact hinv.smul hint
+
+private theorem norm_picardMap_le {v : E → E} {k : ℝ} (hk : 0 < k)
+    (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x : E) (u : ℝ →ᵇ E) (t : ℝ) :
+    ‖picardMap v k x u t‖ ≤ (‖v x‖ + k * ‖u‖) / (2 * k) := by
+  have hCnn : (0 : ℝ) ≤ ‖v x‖ + k * ‖u‖ := by positivity
+  have hbound : ∀ s : ℝ,
+      ‖v (picardCurve k x u s)‖ ≤ (‖v x‖ + k * ‖u‖) * Real.cosh (2 * k * s) := by
+    intro s
+    have h1 : ‖v (picardCurve k x u s) - v x‖ ≤ k * (Real.cosh (2 * k * s) * ‖u‖) :=
+      (hv _ _).trans
+        (mul_le_mul_of_nonneg_left (norm_picardCurve_sub_le k x u s) hk.le)
+    have h2 := norm_sub_norm_le (v (picardCurve k x u s)) (v x)
+    have h3 : (1 : ℝ) ≤ Real.cosh (2 * k * s) := Real.one_le_cosh _
+    nlinarith [norm_nonneg (v x), norm_nonneg u, hk.le, mul_nonneg hk.le (norm_nonneg u)]
+  have hstep : ‖∫ s in (0 : ℝ)..t, v (picardCurve k x u s)‖ ≤
+      (‖v x‖ + k * ‖u‖) * Real.cosh (2 * k * t) / (2 * k) :=
+    norm_integral_le_cosh hk hCnn hbound t
+  have hcosh : (0 : ℝ) < Real.cosh (2 * k * t) := Real.cosh_pos _
+  rw [picardMap, norm_smul, Real.norm_eq_abs, abs_of_pos (inv_pos.2 hcosh)]
+  rw [inv_mul_le_iff₀ hcosh]
+  refine hstep.trans_eq ?_
+  field_simp
+
+/-- The Picard operator attached to `v`, the initial point `x` and the weight `cosh (2 k ·)`. -/
+private noncomputable def picardOp {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)
+    (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x : E) (u : ℝ →ᵇ E) : ℝ →ᵇ E :=
+  BoundedContinuousFunction.ofNormedAddCommGroup (picardMap v k x u)
+    (continuous_picardMap hvc k x u) _ (norm_picardMap_le hk hv x u)
+
+private theorem picardOp_apply {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)
+    (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x : E) (u : ℝ →ᵇ E) (t : ℝ) :
+    picardOp hvc hk hv x u t = picardMap v k x u t := rfl
+
+/-- The Picard operator halves distances, uniformly in the initial point. -/
+private theorem contractingWith_picardOp {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)
+    (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x : E) :
+    ContractingWith (1 / 2 : ℝ≥0) (picardOp hvc hk hv x) := by
+  refine ⟨by norm_num, LipschitzWith.of_dist_le_mul fun u₁ u₂ ↦ ?_⟩
+  have hd : (0 : ℝ) ≤ dist u₁ u₂ := dist_nonneg
+  have hcast : ((1 / 2 : ℝ≥0) : ℝ) = 1 / 2 := by norm_num
+  rw [hcast, BoundedContinuousFunction.dist_le (by positivity)]
+  intro t
+  have hcosh : (0 : ℝ) < Real.cosh (2 * k * t) := Real.cosh_pos _
+  have hi₁ : ∀ a b : ℝ, IntervalIntegrable (fun s ↦ v (picardCurve k x u₁ s)) volume a b :=
+    fun a b ↦ ((hvc.comp (continuous_picardCurve k x u₁)).intervalIntegrable a b)
+  have hi₂ : ∀ a b : ℝ, IntervalIntegrable (fun s ↦ v (picardCurve k x u₂ s)) volume a b :=
+    fun a b ↦ ((hvc.comp (continuous_picardCurve k x u₂)).intervalIntegrable a b)
+  have hbound : ∀ s : ℝ, ‖v (picardCurve k x u₁ s) - v (picardCurve k x u₂ s)‖ ≤
+      (k * dist u₁ u₂) * Real.cosh (2 * k * s) := by
+    intro s
+    refine (hv _ _).trans ?_
+    rw [picardCurve_sub, norm_smul, Real.norm_eq_abs, abs_of_pos (Real.cosh_pos _)]
+    have : ‖u₁ s - u₂ s‖ ≤ dist u₁ u₂ := by
+      rw [← dist_eq_norm]
+      exact u₁.dist_coe_le_dist s
+    calc k * (Real.cosh (2 * k * s) * ‖u₁ s - u₂ s‖)
+        ≤ k * (Real.cosh (2 * k * s) * dist u₁ u₂) := by
+          gcongr
+      _ = k * dist u₁ u₂ * Real.cosh (2 * k * s) := by ring
+  have hsub : ∫ s in (0 : ℝ)..t, (v (picardCurve k x u₁ s) - v (picardCurve k x u₂ s)) =
+      (∫ s in (0 : ℝ)..t, v (picardCurve k x u₁ s)) -
+        ∫ s in (0 : ℝ)..t, v (picardCurve k x u₂ s) :=
+    intervalIntegral.integral_sub (hi₁ 0 t) (hi₂ 0 t)
+  have hint := norm_integral_le_cosh (F := fun s ↦
+    v (picardCurve k x u₁ s) - v (picardCurve k x u₂ s)) hk
+    (by positivity) hbound t
+  rw [hsub] at hint
+  rw [dist_eq_norm, picardOp_apply, picardOp_apply, picardMap, picardMap, ← smul_sub, norm_smul,
+    Real.norm_eq_abs, abs_of_pos (inv_pos.2 hcosh), inv_mul_le_iff₀ hcosh]
+  refine hint.trans_eq ?_
+  field_simp
+
+variable [CompleteSpace E]
+
+/-- The fixed point of the Picard operator. -/
+private noncomputable def picardFixedPoint {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)
+    (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x : E) : ℝ →ᵇ E :=
+  ContractingWith.fixedPoint _ (contractingWith_picardOp hvc hk hv x)
+
+/-- The curve attached to the Picard fixed point satisfies the integral equation. -/
+private theorem picardCurve_fixedPoint {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)
+    (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x : E) (t : ℝ) :
+    picardCurve k x (picardFixedPoint hvc hk hv x) t =
+      x + ∫ s in (0 : ℝ)..t, v (picardCurve k x (picardFixedPoint hvc hk hv x) s) := by
+  have hfix : picardOp hvc hk hv x (picardFixedPoint hvc hk hv x) =
+      picardFixedPoint hvc hk hv x :=
+    ContractingWith.fixedPoint_isFixedPt _
+  have hpt := congrArg (fun w : ℝ →ᵇ E ↦ w t) hfix
+  simp only [picardOp_apply, picardMap] at hpt
+  rw [picardCurve, ← hpt, smul_inv_smul₀ (Real.cosh_pos (2 * k * t)).ne']
+
+private theorem k_pos (K : ℝ≥0) : (0 : ℝ) < (K : ℝ) + 1 := by positivity
+
+omit [NormedSpace ℝ E] [CompleteSpace E] in
+private theorem norm_sub_le_of_lipschitzWith {v : E → E} {K : ℝ≥0} (hv : LipschitzWith K v)
+    (y z : E) : ‖v y - v z‖ ≤ ((K : ℝ) + 1) * ‖y - z‖ := by
+  have h := hv.dist_le_mul y z
+  rw [dist_eq_norm, dist_eq_norm] at h
+  nlinarith [norm_nonneg (y - z)]
+
+/-- **The global solution of a globally Lipschitz autonomous ODE.** For a Lipschitz vector field
+`v` on a Banach space, `ODE.globalSolution v hv x` is the unique curve `γ : ℝ → E` defined on the
+whole line with `γ 0 = x` and `γ' t = v (γ t)` for every `t`. -/
+noncomputable def globalSolution (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) (x : E) : ℝ → E :=
+  picardCurve ((K : ℝ) + 1) x
+    (picardFixedPoint hv.continuous (k_pos K) (norm_sub_le_of_lipschitzWith hv) x)
+
+/-- The global solution satisfies the integral equation of the initial value problem. -/
+theorem globalSolution_eq_integral (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) (x : E) (t : ℝ) :
+    globalSolution v hv x t = x + ∫ s in (0 : ℝ)..t, v (globalSolution v hv x s) :=
+  picardCurve_fixedPoint _ _ _ x t
+
+/-- The global solution starts at the prescribed initial point. -/
+@[simp]
+theorem globalSolution_zero (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) (x : E) :
+    globalSolution v hv x 0 = x := by
+  simpa using globalSolution_eq_integral v hv x 0
+
+/-- The global solution is continuous. -/
+theorem continuous_globalSolution_apply (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) (x : E) :
+    Continuous (globalSolution v hv x) :=
+  continuous_picardCurve _ _ _
+
+/-- **The global solution solves the differential equation** at every time. -/
+theorem hasDerivAt_globalSolution (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) (x : E) (t : ℝ) :
+    HasDerivAt (globalSolution v hv x) (v (globalSolution v hv x t)) t := by
+  have hcomp : Continuous fun s ↦ v (globalSolution v hv x s) :=
+    hv.continuous.comp (continuous_globalSolution_apply v hv x)
+  have hprim : HasDerivAt (fun r : ℝ ↦ ∫ s in (0 : ℝ)..r, v (globalSolution v hv x s))
+      (v (globalSolution v hv x t)) t :=
+    intervalIntegral.integral_hasDerivAt_right (hcomp.intervalIntegrable _ _)
+      (hcomp.stronglyMeasurableAtFilter _ _) hcomp.continuousAt
+  exact (hprim.const_add x).congr_of_eventuallyEq
+    (.of_forall fun r ↦ globalSolution_eq_integral v hv x r)
+
+/-- The global solution is an integral curve of `v`, read as a time-independent vector field. -/
+theorem isIntegralCurve_globalSolution (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) (x : E) :
+    IsIntegralCurve (globalSolution v hv x) fun _ y ↦ v y :=
+  hasDerivAt_globalSolution v hv x
+
+/-- **Uniqueness.** Any curve defined on the whole line that solves `γ' = v ∘ γ` is the global
+solution through its own initial value. -/
+theorem eq_globalSolution (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) {γ : ℝ → E}
+    (hγ : ∀ t, HasDerivAt γ (v (γ t)) t) : γ = globalSolution v hv (γ 0) :=
+  ODE_solution_unique_univ (v := fun _ y ↦ v y) (s := fun _ ↦ univ) (t₀ := 0)
+    (fun _ ↦ hv.lipschitzOnWith) (fun t ↦ ⟨hγ t, trivial⟩)
+    (fun t ↦ ⟨hasDerivAt_globalSolution v hv (γ 0) t, trivial⟩)
+    (by rw [globalSolution_zero])
+
+/-- The Picard fixed point depends on the initial condition `1`-Lipschitzly. -/
+private theorem dist_picardFixedPoint_le {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)
+    (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x y : E) :
+    dist (picardFixedPoint hvc hk hv x) (picardFixedPoint hvc hk hv y) ≤ ‖x - y‖ := by
+  have hC : ∀ u : ℝ →ᵇ E,
+      dist (picardOp hvc hk hv x u) (picardOp hvc hk hv y u) ≤ ‖x - y‖ / 2 := by
+    intro u
+    rw [BoundedContinuousFunction.dist_le (by positivity)]
+    intro t
+    have hcosh : (0 : ℝ) < Real.cosh (2 * k * t) := Real.cosh_pos _
+    have hi₁ : ∀ a b : ℝ, IntervalIntegrable (fun s ↦ v (picardCurve k x u s)) volume a b :=
+      fun a b ↦ ((hvc.comp (continuous_picardCurve k x u)).intervalIntegrable a b)
+    have hi₂ : ∀ a b : ℝ, IntervalIntegrable (fun s ↦ v (picardCurve k y u s)) volume a b :=
+      fun a b ↦ ((hvc.comp (continuous_picardCurve k y u)).intervalIntegrable a b)
+    have hbound : ∀ s : ℝ, ‖v (picardCurve k x u s) - v (picardCurve k y u s)‖ ≤
+        (k * ‖x - y‖) * Real.cosh (2 * k * s) := by
+      intro s
+      refine (hv _ _).trans ?_
+      rw [picardCurve_sub_const]
+      nlinarith [Real.one_le_cosh (2 * k * s), norm_nonneg (x - y), hk.le,
+        mul_nonneg hk.le (norm_nonneg (x - y))]
+    have hsub : ∫ s in (0 : ℝ)..t, (v (picardCurve k x u s) - v (picardCurve k y u s)) =
+        (∫ s in (0 : ℝ)..t, v (picardCurve k x u s)) -
+          ∫ s in (0 : ℝ)..t, v (picardCurve k y u s) :=
+      intervalIntegral.integral_sub (hi₁ 0 t) (hi₂ 0 t)
+    have hint := norm_integral_le_cosh
+      (F := fun s ↦ v (picardCurve k x u s) - v (picardCurve k y u s)) hk (by positivity)
+      hbound t
+    rw [hsub] at hint
+    rw [dist_eq_norm, picardOp_apply, picardOp_apply, picardMap, picardMap, ← smul_sub, norm_smul,
+      Real.norm_eq_abs, abs_of_pos (inv_pos.2 hcosh), inv_mul_le_iff₀ hcosh]
+    refine hint.trans_eq ?_
+    field_simp
+  have h := ContractingWith.fixedPoint_lipschitz_in_map (contractingWith_picardOp hvc hk hv x)
+    (contractingWith_picardOp hvc hk hv y) hC
+  have hcast : (1 : ℝ) - ((1 / 2 : ℝ≥0) : ℝ) = 1 / 2 := by norm_num
+  rw [hcast] at h
+  simpa [picardFixedPoint] using h.trans_eq (by ring)
+
+/-- **Reversing time** turns the global solution of `v` into the global solution of `-v`. -/
+theorem globalSolution_neg (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) (x : E) (t : ℝ) :
+    globalSolution v hv x (-t) = globalSolution (fun z ↦ -v z) hv.neg x t := by
+  have hγ : ∀ s : ℝ, HasDerivAt (fun s : ℝ ↦ globalSolution v hv x (-s))
+      (-v (globalSolution v hv x (-s))) s := by
+    intro s
+    have h1 : HasDerivAt (fun s : ℝ ↦ -s) (-1 : ℝ) s := by simpa using hasDerivAt_neg s
+    simpa [Function.comp_def] using (hasDerivAt_globalSolution v hv x (-s)).scomp s h1
+  simpa using congrFun (eq_globalSolution (fun z ↦ -v z) hv.neg hγ) t
+
+private theorem dist_globalSolution_le_of_nonneg (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v)
+    (x y : E) {t : ℝ} (ht : 0 ≤ t) :
+    dist (globalSolution v hv x t) (globalSolution v hv y t) ≤ dist x y * Real.exp (K * t) := by
+  have h := dist_le_of_trajectories_ODE (v := fun _ z ↦ v z) (K := K) (a := 0) (b := t)
+    (f := globalSolution v hv x) (g := globalSolution v hv y) (δ := dist x y)
+    (fun _ ↦ hv) (continuous_globalSolution_apply v hv x).continuousOn
+    (fun s _ ↦ (hasDerivAt_globalSolution v hv x s).hasDerivWithinAt)
+    (continuous_globalSolution_apply v hv y).continuousOn
+    (fun s _ ↦ (hasDerivAt_globalSolution v hv y s).hasDerivWithinAt)
+    (by simp) t (by simp [ht])
+  simpa using h
+
+/-- **Continuous dependence on the initial condition.** Two global solutions drift apart at most
+exponentially, at the rate given by the Lipschitz constant of the vector field, in both time
+directions. -/
+theorem dist_globalSolution_le (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) (x y : E) (t : ℝ) :
+    dist (globalSolution v hv x t) (globalSolution v hv y t) ≤ dist x y * Real.exp (K * |t|) := by
+  rcases le_total 0 t with ht | ht
+  · simpa [abs_of_nonneg ht] using dist_globalSolution_le_of_nonneg v hv x y ht
+  · have h := dist_globalSolution_le_of_nonneg (fun z ↦ -v z) hv.neg x y
+      (t := -t) (by linarith)
+    rw [← globalSolution_neg, ← globalSolution_neg] at h
+    simpa [abs_of_nonpos ht] using h
+
+/-- **Joint continuity** of the global solution in time and initial condition. -/
+theorem continuous_globalSolution (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) :
+    Continuous fun p : ℝ × E ↦ globalSolution v hv p.2 p.1 := by
+  have hΦ : Continuous fun x : E ↦
+      picardFixedPoint hv.continuous (k_pos K) (norm_sub_le_of_lipschitzWith hv) x := by
+    refine LipschitzWith.continuous (K := 1) (LipschitzWith.of_dist_le_mul fun x y ↦ ?_)
+    simpa [dist_eq_norm] using dist_picardFixedPoint_le hv.continuous (k_pos K)
+      (norm_sub_le_of_lipschitzWith hv) x y
+  have heval : Continuous fun p : ℝ × E ↦
+      (picardFixedPoint hv.continuous (k_pos K) (norm_sub_le_of_lipschitzWith hv) p.2) p.1 :=
+    (hΦ.comp continuous_snd).eval continuous_fst
+  have hcosh : Continuous fun p : ℝ × E ↦ Real.cosh (2 * ((K : ℝ) + 1) * p.1) := by fun_prop
+  have hmain : Continuous fun p : ℝ × E ↦
+      p.2 + Real.cosh (2 * ((K : ℝ) + 1) * p.1) •
+        (picardFixedPoint hv.continuous (k_pos K) (norm_sub_le_of_lipschitzWith hv) p.2) p.1 :=
+    continuous_snd.add (hcosh.smul heval)
+  simpa [globalSolution, picardCurve] using hmain
+
+end ODE

--- a/TauCeti/Analysis/ODE/GlobalSolution.lean
+++ b/TauCeti/Analysis/ODE/GlobalSolution.lean
@@ -7,9 +7,7 @@ module
 
 public import Mathlib.Analysis.ODE.Basic
 public import Mathlib.Analysis.ODE.ExistUnique
-public import Mathlib.Analysis.ODE.Gronwall
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
-public import Mathlib.MeasureTheory.Integral.DominatedConvergence
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 public import Mathlib.Topology.ContinuousMap.Bounded.Normed
 public import Mathlib.Topology.MetricSpace.Contracting
@@ -43,6 +41,7 @@ Mathlib's `ODE_solution_unique_univ`, and the fixed point depends on the initial
   problem.
 * `ODE.globalSolution_zero` and `ODE.hasDerivAt_globalSolution`: it is a solution.
 * `ODE.eq_globalSolution`: every global solution with the same initial value is equal to it.
+* `ODE.globalSolution_congr`: it does not depend on the chosen Lipschitz bound.
 * `ODE.globalSolution_neg`: reversing time solves the negated field.
 * `ODE.dist_globalSolution_le`: two solutions drift apart at most exponentially.
 * `ODE.continuous_globalSolution`: joint continuity in time and initial condition.
@@ -50,8 +49,6 @@ Mathlib's `ODE_solution_unique_univ`, and the fixed point depends on the initial
 ## References
 
 * J. Dieudonné, *Foundations of Modern Analysis*, Academic Press, 1969, Chapter X.
-* [Heegaard Floer homology roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HeegaardFloer/README.md),
-  Lane M, "Morse homology".
 -/
 
 public section
@@ -62,11 +59,6 @@ open scoped BoundedContinuousFunction NNReal
 namespace ODE
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-
-/-- The hyperbolic sine is dominated by the hyperbolic cosine. -/
-private theorem abs_sinh_le_cosh (y : ℝ) : |Real.sinh y| ≤ Real.cosh y := by
-  rw [abs_le, Real.sinh_eq, Real.cosh_eq]
-  constructor <;> nlinarith [Real.exp_pos y, Real.exp_pos (-y)]
 
 /-- The estimate that drives the whole construction: an integrand dominated by `C * cosh (2 k ·)`
 has a primitive dominated by `C * cosh (2 k ·) / (2 k)`, with no restriction on the sign of the
@@ -102,7 +94,8 @@ private theorem norm_integral_le_cosh {k C : ℝ} (hk : 0 < k) (hC : 0 ≤ C) {F
         rw [hcalc, abs_div, abs_mul, abs_of_nonneg hC, abs_of_pos hk2]
     _ ≤ C * Real.cosh (2 * k * t) / (2 * k) := by
         gcongr
-        exact abs_sinh_le_cosh _
+        rw [Real.abs_sinh, ← Real.cosh_abs (2 * k * t)]
+        exact (Real.sinh_lt_cosh _).le
 
 /-- The curve carried by a bounded continuous profile `u`, weighted so that the Picard operator
 below is a contraction on the whole line. -/
@@ -176,44 +169,50 @@ private theorem picardOp_apply {v : E → E} (hvc : Continuous v) {k : ℝ} (hk 
     (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x : E) (u : ℝ →ᵇ E) (t : ℝ) :
     picardOp hvc hk hv x u t = picardMap v k x u t := rfl
 
-/-- The Picard operator halves distances, uniformly in the initial point. -/
-private theorem contractingWith_picardOp {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)
-    (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x : E) :
-    ContractingWith (1 / 2 : ℝ≥0) (picardOp hvc hk hv x) := by
-  refine ⟨by norm_num, LipschitzWith.of_dist_le_mul fun u₁ u₂ ↦ ?_⟩
-  have hd : (0 : ℝ) ≤ dist u₁ u₂ := dist_nonneg
-  have hcast : ((1 / 2 : ℝ≥0) : ℝ) = 1 / 2 := by norm_num
-  rw [hcast, BoundedContinuousFunction.dist_le (by positivity)]
+/-- The single estimate behind both contraction properties of the Picard operator: a bound on the
+carried curves, in the weight `cosh (2 k ·)`, halves to a bound on the values of the operator. -/
+private theorem dist_picardOp_le {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)
+    (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) {x y : E} {u₁ u₂ : ℝ →ᵇ E} {D : ℝ} (hD : 0 ≤ D)
+    (hb : ∀ s, ‖picardCurve k x u₁ s - picardCurve k y u₂ s‖ ≤ D * Real.cosh (2 * k * s)) :
+    dist (picardOp hvc hk hv x u₁) (picardOp hvc hk hv y u₂) ≤ D / 2 := by
+  rw [BoundedContinuousFunction.dist_le (by linarith)]
   intro t
   have hcosh : (0 : ℝ) < Real.cosh (2 * k * t) := Real.cosh_pos _
   have hi₁ : ∀ a b : ℝ, IntervalIntegrable (fun s ↦ v (picardCurve k x u₁ s)) volume a b :=
-    fun a b ↦ ((hvc.comp (continuous_picardCurve k x u₁)).intervalIntegrable a b)
-  have hi₂ : ∀ a b : ℝ, IntervalIntegrable (fun s ↦ v (picardCurve k x u₂ s)) volume a b :=
-    fun a b ↦ ((hvc.comp (continuous_picardCurve k x u₂)).intervalIntegrable a b)
-  have hbound : ∀ s : ℝ, ‖v (picardCurve k x u₁ s) - v (picardCurve k x u₂ s)‖ ≤
-      (k * dist u₁ u₂) * Real.cosh (2 * k * s) := by
+    fun a b ↦ (hvc.comp (continuous_picardCurve k x u₁)).intervalIntegrable a b
+  have hi₂ : ∀ a b : ℝ, IntervalIntegrable (fun s ↦ v (picardCurve k y u₂ s)) volume a b :=
+    fun a b ↦ (hvc.comp (continuous_picardCurve k y u₂)).intervalIntegrable a b
+  have hbound : ∀ s : ℝ, ‖v (picardCurve k x u₁ s) - v (picardCurve k y u₂ s)‖ ≤
+      k * D * Real.cosh (2 * k * s) := by
     intro s
     refine (hv _ _).trans ?_
-    rw [picardCurve_sub, norm_smul, Real.norm_eq_abs, abs_of_pos (Real.cosh_pos _)]
-    have : ‖u₁ s - u₂ s‖ ≤ dist u₁ u₂ := by
-      rw [← dist_eq_norm]
-      exact u₁.dist_coe_le_dist s
-    calc k * (Real.cosh (2 * k * s) * ‖u₁ s - u₂ s‖)
-        ≤ k * (Real.cosh (2 * k * s) * dist u₁ u₂) := by
-          gcongr
-      _ = k * dist u₁ u₂ * Real.cosh (2 * k * s) := by ring
-  have hsub : ∫ s in (0 : ℝ)..t, (v (picardCurve k x u₁ s) - v (picardCurve k x u₂ s)) =
+    rw [mul_assoc]
+    exact mul_le_mul_of_nonneg_left (hb s) hk.le
+  have hsub : ∫ s in (0 : ℝ)..t, (v (picardCurve k x u₁ s) - v (picardCurve k y u₂ s)) =
       (∫ s in (0 : ℝ)..t, v (picardCurve k x u₁ s)) -
-        ∫ s in (0 : ℝ)..t, v (picardCurve k x u₂ s) :=
+        ∫ s in (0 : ℝ)..t, v (picardCurve k y u₂ s) :=
     intervalIntegral.integral_sub (hi₁ 0 t) (hi₂ 0 t)
   have hint := norm_integral_le_cosh (F := fun s ↦
-    v (picardCurve k x u₁ s) - v (picardCurve k x u₂ s)) hk
-    (by positivity) hbound t
+    v (picardCurve k x u₁ s) - v (picardCurve k y u₂ s)) hk (mul_nonneg hk.le hD) hbound t
   rw [hsub] at hint
   rw [dist_eq_norm, picardOp_apply, picardOp_apply, picardMap, picardMap, ← smul_sub, norm_smul,
     Real.norm_eq_abs, abs_of_pos (inv_pos.2 hcosh), inv_mul_le_iff₀ hcosh]
   refine hint.trans_eq ?_
   field_simp
+
+/-- The Picard operator halves distances, uniformly in the initial point. -/
+private theorem contractingWith_picardOp {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)
+    (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x : E) :
+    ContractingWith (1 / 2 : ℝ≥0) (picardOp hvc hk hv x) := by
+  refine ⟨by norm_num, LipschitzWith.of_dist_le_mul fun u₁ u₂ ↦ ?_⟩
+  have hcast : ((1 / 2 : ℝ≥0) : ℝ) = 1 / 2 := by norm_num
+  rw [hcast]
+  refine (dist_picardOp_le hvc hk hv dist_nonneg fun s ↦ ?_).trans_eq (by ring)
+  rw [picardCurve_sub, norm_smul, Real.norm_eq_abs, abs_of_pos (Real.cosh_pos _),
+    mul_comm (dist u₁ u₂)]
+  gcongr
+  rw [← dist_eq_norm]
+  exact u₁.dist_coe_le_dist s
 
 variable [CompleteSpace E]
 
@@ -292,39 +291,22 @@ theorem eq_globalSolution (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) {
     (fun t ↦ ⟨hasDerivAt_globalSolution v hv (γ 0) t, trivial⟩)
     (by rw [globalSolution_zero])
 
+/-- **Independence of the Lipschitz bound.** Two Lipschitz witnesses for the same vector field,
+with possibly different constants, produce the same global solution. -/
+theorem globalSolution_congr (v : E → E) {K K' : ℝ≥0} (hv : LipschitzWith K v)
+    (hv' : LipschitzWith K' v) (x : E) : globalSolution v hv x = globalSolution v hv' x := by
+  have h := eq_globalSolution v hv' (γ := globalSolution v hv x) (hasDerivAt_globalSolution v hv x)
+  rwa [globalSolution_zero] at h
+
 /-- The Picard fixed point depends on the initial condition `1`-Lipschitzly. -/
 private theorem dist_picardFixedPoint_le {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)
     (hv : ∀ y z, ‖v y - v z‖ ≤ k * ‖y - z‖) (x y : E) :
     dist (picardFixedPoint hvc hk hv x) (picardFixedPoint hvc hk hv y) ≤ ‖x - y‖ := by
   have hC : ∀ u : ℝ →ᵇ E,
-      dist (picardOp hvc hk hv x u) (picardOp hvc hk hv y u) ≤ ‖x - y‖ / 2 := by
-    intro u
-    rw [BoundedContinuousFunction.dist_le (by positivity)]
-    intro t
-    have hcosh : (0 : ℝ) < Real.cosh (2 * k * t) := Real.cosh_pos _
-    have hi₁ : ∀ a b : ℝ, IntervalIntegrable (fun s ↦ v (picardCurve k x u s)) volume a b :=
-      fun a b ↦ ((hvc.comp (continuous_picardCurve k x u)).intervalIntegrable a b)
-    have hi₂ : ∀ a b : ℝ, IntervalIntegrable (fun s ↦ v (picardCurve k y u s)) volume a b :=
-      fun a b ↦ ((hvc.comp (continuous_picardCurve k y u)).intervalIntegrable a b)
-    have hbound : ∀ s : ℝ, ‖v (picardCurve k x u s) - v (picardCurve k y u s)‖ ≤
-        (k * ‖x - y‖) * Real.cosh (2 * k * s) := by
-      intro s
-      refine (hv _ _).trans ?_
+      dist (picardOp hvc hk hv x u) (picardOp hvc hk hv y u) ≤ ‖x - y‖ / 2 := fun u ↦
+    dist_picardOp_le hvc hk hv (norm_nonneg _) fun s ↦ by
       rw [picardCurve_sub_const]
-      nlinarith [Real.one_le_cosh (2 * k * s), norm_nonneg (x - y), hk.le,
-        mul_nonneg hk.le (norm_nonneg (x - y))]
-    have hsub : ∫ s in (0 : ℝ)..t, (v (picardCurve k x u s) - v (picardCurve k y u s)) =
-        (∫ s in (0 : ℝ)..t, v (picardCurve k x u s)) -
-          ∫ s in (0 : ℝ)..t, v (picardCurve k y u s) :=
-      intervalIntegral.integral_sub (hi₁ 0 t) (hi₂ 0 t)
-    have hint := norm_integral_le_cosh
-      (F := fun s ↦ v (picardCurve k x u s) - v (picardCurve k y u s)) hk (by positivity)
-      hbound t
-    rw [hsub] at hint
-    rw [dist_eq_norm, picardOp_apply, picardOp_apply, picardMap, picardMap, ← smul_sub, norm_smul,
-      Real.norm_eq_abs, abs_of_pos (inv_pos.2 hcosh), inv_mul_le_iff₀ hcosh]
-    refine hint.trans_eq ?_
-    field_simp
+      exact le_mul_of_one_le_right (norm_nonneg _) (Real.one_le_cosh _)
   have h := ContractingWith.fixedPoint_lipschitz_in_map (contractingWith_picardOp hvc hk hv x)
     (contractingWith_picardOp hvc hk hv y) hC
   have hcast : (1 : ℝ) - ((1 / 2 : ℝ≥0) : ℝ) = 1 / 2 := by norm_num

--- a/TauCeti/Dynamics/Flow/OfLipschitz.lean
+++ b/TauCeti/Dynamics/Flow/OfLipschitz.lean
@@ -27,14 +27,13 @@ the initial condition, and the joint continuity required by `Flow` is
 * `Flow.hasDerivAt_ofLipschitz` and `Flow.isIntegralCurve_ofLipschitz`: its orbits solve the
   differential equation.
 * `Flow.eq_ofLipschitz`: every global solution is an orbit of the flow.
+* `Flow.ofLipschitz_congr`: it does not depend on the chosen Lipschitz bound.
 * `Flow.forall_ofLipschitz_eq_self_iff`: the rest points of the flow are the zeros of the vector
   field.
 
 ## References
 
 * J. Dieudonné, *Foundations of Modern Analysis*, Academic Press, 1969, Chapter X.
-* [Heegaard Floer homology roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HeegaardFloer/README.md),
-  Lane M, "Morse homology".
 -/
 
 public section
@@ -62,6 +61,12 @@ noncomputable def ofLipschitz (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K 
 @[simp]
 theorem ofLipschitz_apply (hv : LipschitzWith K v) (t : ℝ) (x : E) :
     ofLipschitz v hv t x = ODE.globalSolution v hv x t := (rfl)
+
+/-- **Independence of the Lipschitz bound.** Two Lipschitz witnesses for the same vector field,
+with possibly different constants, produce the same flow. -/
+theorem ofLipschitz_congr {K' : ℝ≥0} (hv : LipschitzWith K v) (hv' : LipschitzWith K' v) :
+    ofLipschitz v hv = ofLipschitz v hv' :=
+  Flow.ext fun t x ↦ congrFun (ODE.globalSolution_congr v hv hv' x) t
 
 /-- Every orbit of the flow solves the differential equation. -/
 theorem hasDerivAt_ofLipschitz (hv : LipschitzWith K v) (x : E) (t : ℝ) :

--- a/TauCeti/Dynamics/Flow/OfLipschitz.lean
+++ b/TauCeti/Dynamics/Flow/OfLipschitz.lean
@@ -23,13 +23,13 @@ the initial condition, and the joint continuity required by `Flow` is
 
 ## Main declarations
 
-* `Flow.ofLipschitz`: the flow of a globally Lipschitz vector field on a Banach space.
-* `Flow.hasDerivAt_ofLipschitz` and `Flow.isIntegralCurve_ofLipschitz`: its orbits solve the
-  differential equation.
-* `Flow.eq_ofLipschitz`: every global solution is an orbit of the flow.
-* `Flow.ofLipschitz_congr`: it does not depend on the chosen Lipschitz bound.
-* `Flow.forall_ofLipschitz_eq_self_iff`: the rest points of the flow are the zeros of the vector
-  field.
+* `TauCeti.flowOfLipschitz`: the flow of a globally Lipschitz vector field on a Banach space.
+* `TauCeti.hasDerivAt_flowOfLipschitz` and `TauCeti.isIntegralCurve_flowOfLipschitz`: its
+  orbits solve the differential equation.
+* `TauCeti.eq_flowOfLipschitz`: every global solution is an orbit of the flow.
+* `TauCeti.flowOfLipschitz_congr`: it does not depend on the chosen Lipschitz bound.
+* `TauCeti.forall_flowOfLipschitz_eq_self_iff`: the rest points of the flow are the zeros of the
+  vector field.
 
 ## References
 
@@ -41,14 +41,14 @@ public section
 open Filter Topology
 open scoped NNReal
 
-namespace Flow
+namespace TauCeti
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
   {v : E → E} {K : ℝ≥0}
 
 /-- **The flow of a globally Lipschitz vector field** on a Banach space: the time-`t` map sends an
 initial point to the value at time `t` of the unique global solution of `γ' = v ∘ γ` through it. -/
-noncomputable def ofLipschitz (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) : Flow ℝ E where
+noncomputable def flowOfLipschitz (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) : Flow ℝ E where
   toFun t x := ODE.globalSolution v hv x t
   cont' := ODE.continuous_globalSolution v hv
   map_add' t₁ t₂ x := by
@@ -59,42 +59,43 @@ noncomputable def ofLipschitz (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K 
   map_zero' x := ODE.globalSolution_zero v hv x
 
 @[simp]
-theorem ofLipschitz_apply (hv : LipschitzWith K v) (t : ℝ) (x : E) :
-    ofLipschitz v hv t x = ODE.globalSolution v hv x t := (rfl)
+theorem flowOfLipschitz_apply (hv : LipschitzWith K v) (t : ℝ) (x : E) :
+    flowOfLipschitz v hv t x = ODE.globalSolution v hv x t := (rfl)
 
 /-- **Independence of the Lipschitz bound.** Two Lipschitz witnesses for the same vector field,
 with possibly different constants, produce the same flow. -/
-theorem ofLipschitz_congr {K' : ℝ≥0} (hv : LipschitzWith K v) (hv' : LipschitzWith K' v) :
-    ofLipschitz v hv = ofLipschitz v hv' :=
+theorem flowOfLipschitz_congr {K' : ℝ≥0} (hv : LipschitzWith K v) (hv' : LipschitzWith K' v) :
+    flowOfLipschitz v hv = flowOfLipschitz v hv' :=
   Flow.ext fun t x ↦ congrFun (ODE.globalSolution_congr v hv hv' x) t
 
 /-- Every orbit of the flow solves the differential equation. -/
-theorem hasDerivAt_ofLipschitz (hv : LipschitzWith K v) (x : E) (t : ℝ) :
-    HasDerivAt (fun t ↦ ofLipschitz v hv t x) (v (ofLipschitz v hv t x)) t :=
+theorem hasDerivAt_flowOfLipschitz (hv : LipschitzWith K v) (x : E) (t : ℝ) :
+    HasDerivAt (fun t ↦ flowOfLipschitz v hv t x) (v (flowOfLipschitz v hv t x)) t :=
   ODE.hasDerivAt_globalSolution v hv x t
 
 /-- Every orbit of the flow is an integral curve of the vector field. -/
-theorem isIntegralCurve_ofLipschitz (hv : LipschitzWith K v) (x : E) :
-    IsIntegralCurve (fun t ↦ ofLipschitz v hv t x) fun _ y ↦ v y :=
+theorem isIntegralCurve_flowOfLipschitz (hv : LipschitzWith K v) (x : E) :
+    IsIntegralCurve (fun t ↦ flowOfLipschitz v hv t x) fun _ y ↦ v y :=
   ODE.isIntegralCurve_globalSolution v hv x
 
 /-- **Every global solution is an orbit** of the flow, namely the one through its initial value. -/
-theorem eq_ofLipschitz (hv : LipschitzWith K v) {γ : ℝ → E}
-    (hγ : ∀ t, HasDerivAt γ (v (γ t)) t) (t : ℝ) : γ t = ofLipschitz v hv t (γ 0) :=
+theorem eq_flowOfLipschitz (hv : LipschitzWith K v) {γ : ℝ → E}
+    (hγ : ∀ t, HasDerivAt γ (v (γ t)) t) (t : ℝ) : γ t = flowOfLipschitz v hv t (γ 0) :=
   congrFun (ODE.eq_globalSolution v hv hγ) t
 
 /-- **The rest points of the flow are the zeros of the vector field.** -/
-theorem forall_ofLipschitz_eq_self_iff (hv : LipschitzWith K v) (x : E) :
-    (∀ t, ofLipschitz v hv t x = x) ↔ v x = 0 := by
+theorem forall_flowOfLipschitz_eq_self_iff (hv : LipschitzWith K v) (x : E) :
+    (∀ t, flowOfLipschitz v hv t x = x) ↔ v x = 0 := by
   refine ⟨fun h ↦ ?_, fun h t ↦ ?_⟩
-  · have h1 : HasDerivAt (fun t ↦ ofLipschitz v hv t x) (v (ofLipschitz v hv 0 x)) 0 :=
-      hasDerivAt_ofLipschitz hv x 0
-    have h2 : HasDerivAt (fun t : ℝ ↦ ofLipschitz v hv t x) 0 0 :=
+  · have h1 : HasDerivAt (fun t ↦ flowOfLipschitz v hv t x)
+        (v (flowOfLipschitz v hv 0 x)) 0 :=
+      hasDerivAt_flowOfLipschitz hv x 0
+    have h2 : HasDerivAt (fun t : ℝ ↦ flowOfLipschitz v hv t x) 0 0 :=
       (hasDerivAt_const (0 : ℝ) x).congr_of_eventuallyEq (.of_forall h)
     have h3 := h1.unique h2
     rwa [h 0] at h3
   · have hconst : ∀ s : ℝ, HasDerivAt (fun _ : ℝ ↦ x) (v ((fun _ : ℝ ↦ x) s)) s := fun s ↦ by
       simpa [h] using hasDerivAt_const s x
-    simpa using (eq_ofLipschitz hv hconst t).symm
+    simpa using (eq_flowOfLipschitz hv hconst t).symm
 
-end Flow
+end TauCeti

--- a/TauCeti/Dynamics/Flow/OfLipschitz.lean
+++ b/TauCeti/Dynamics/Flow/OfLipschitz.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.ODE.Transform
+public import Mathlib.Dynamics.Flow
+public import TauCeti.Analysis.ODE.GlobalSolution
+
+/-!
+# The flow of a globally Lipschitz vector field
+
+A vector field whose solutions may blow up in finite time generates no flow: the group law
+`φ (t₁ + t₂) = φ t₁ ∘ φ t₂` needs solutions defined for all time. A globally Lipschitz vector
+field on a Banach space has them, by `ODE.globalSolution`, and this file assembles them into a
+`Flow ℝ E`.
+
+The group law is uniqueness of solutions applied to the time-translated orbit, the identity law is
+the initial condition, and the joint continuity required by `Flow` is
+`ODE.continuous_globalSolution`.
+
+## Main declarations
+
+* `Flow.ofLipschitz`: the flow of a globally Lipschitz vector field on a Banach space.
+* `Flow.hasDerivAt_ofLipschitz` and `Flow.isIntegralCurve_ofLipschitz`: its orbits solve the
+  differential equation.
+* `Flow.eq_ofLipschitz`: every global solution is an orbit of the flow.
+* `Flow.forall_ofLipschitz_eq_self_iff`: the rest points of the flow are the zeros of the vector
+  field.
+
+## References
+
+* J. Dieudonné, *Foundations of Modern Analysis*, Academic Press, 1969, Chapter X.
+* [Heegaard Floer homology roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HeegaardFloer/README.md),
+  Lane M, "Morse homology".
+-/
+
+public section
+
+open Filter Topology
+open scoped NNReal
+
+namespace Flow
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+  {v : E → E} {K : ℝ≥0}
+
+/-- **The flow of a globally Lipschitz vector field** on a Banach space: the time-`t` map sends an
+initial point to the value at time `t` of the unique global solution of `γ' = v ∘ γ` through it. -/
+noncomputable def ofLipschitz (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) : Flow ℝ E where
+  toFun t x := ODE.globalSolution v hv x t
+  cont' := ODE.continuous_globalSolution v hv
+  map_add' t₁ t₂ x := by
+    have hγ : ∀ t : ℝ, HasDerivAt (fun t : ℝ ↦ ODE.globalSolution v hv x (t + t₂))
+        (v (ODE.globalSolution v hv x (t + t₂))) t :=
+      (ODE.isIntegralCurve_globalSolution v hv x).comp_add t₂
+    simpa using congrFun (ODE.eq_globalSolution v hv hγ) t₁
+  map_zero' x := ODE.globalSolution_zero v hv x
+
+@[simp]
+theorem ofLipschitz_apply (hv : LipschitzWith K v) (t : ℝ) (x : E) :
+    ofLipschitz v hv t x = ODE.globalSolution v hv x t := (rfl)
+
+/-- Every orbit of the flow solves the differential equation. -/
+theorem hasDerivAt_ofLipschitz (hv : LipschitzWith K v) (x : E) (t : ℝ) :
+    HasDerivAt (fun t ↦ ofLipschitz v hv t x) (v (ofLipschitz v hv t x)) t :=
+  ODE.hasDerivAt_globalSolution v hv x t
+
+/-- Every orbit of the flow is an integral curve of the vector field. -/
+theorem isIntegralCurve_ofLipschitz (hv : LipschitzWith K v) (x : E) :
+    IsIntegralCurve (fun t ↦ ofLipschitz v hv t x) fun _ y ↦ v y :=
+  ODE.isIntegralCurve_globalSolution v hv x
+
+/-- **Every global solution is an orbit** of the flow, namely the one through its initial value. -/
+theorem eq_ofLipschitz (hv : LipschitzWith K v) {γ : ℝ → E}
+    (hγ : ∀ t, HasDerivAt γ (v (γ t)) t) (t : ℝ) : γ t = ofLipschitz v hv t (γ 0) :=
+  congrFun (ODE.eq_globalSolution v hv hγ) t
+
+/-- **The rest points of the flow are the zeros of the vector field.** -/
+theorem forall_ofLipschitz_eq_self_iff (hv : LipschitzWith K v) (x : E) :
+    (∀ t, ofLipschitz v hv t x = x) ↔ v x = 0 := by
+  refine ⟨fun h ↦ ?_, fun h t ↦ ?_⟩
+  · have h1 : HasDerivAt (fun t ↦ ofLipschitz v hv t x) (v (ofLipschitz v hv 0 x)) 0 :=
+      hasDerivAt_ofLipschitz hv x 0
+    have h2 : HasDerivAt (fun t : ℝ ↦ ofLipschitz v hv t x) 0 0 :=
+      (hasDerivAt_const (0 : ℝ) x).congr_of_eventuallyEq (.of_forall h)
+    have h3 := h1.unique h2
+    rwa [h 0] at h3
+  · have hconst : ∀ s : ℝ, HasDerivAt (fun _ : ℝ ↦ x) (v ((fun _ : ℝ ↦ x) s)) s := fun s ↦ by
+      simpa [h] using hasDerivAt_const s x
+    simpa using (eq_ofLipschitz hv hconst t).symm
+
+end Flow


### PR DESCRIPTION
This PR constructs the flow of a globally Lipschitz vector field on a Banach space, and from it the
negative gradient flow of a function whose gradient is globally Lipschitz. It serves Lane M
("Morse homology", dynamical route) of the analytic Heegaard Floer roadmap, whose milestone is
Morse homology and its comparison with singular homology. Every Lane M declaration already in the
repository is a statement *about* a negative gradient flow — the stable and unstable sets of
`TauCeti/Dynamics/Flow/Stable.lean`, the Lyapunov monotonicity and energy identity of
`TauCeti/Analysis/Calculus/Morse/GradientFlow.lean`, the trajectory convergence of
`TauCeti/Analysis/Calculus/Morse/Convergence.lean` — and the only flow satisfying that hypothesis
was the explicit hyperbolic one of `TauCeti.splitQuadraticFlow`. Mathlib solves ODEs only locally
(`IsPicardLindelof`, `exists_forall_mem_closedBall_eq_hasDerivWithinAt_lipschitzOnWith`) and has
no construction turning a vector field into a `Flow`, so nothing yet produced the object the lane
runs on.

`ODE.globalSolution` performs the Picard iteration once on the whole real line rather than on a
short interval. Writing `w t = cosh (2 k t)` for a Lipschitz constant `k > 0`, a curve is
presented as `γ t = x + w t • u t` with `u : ℝ →ᵇ E`, and the Picard operator becomes
`(P u) t = (w t)⁻¹ • ∫ s in 0..t, v (x + w s • u s)`. Since `w` integrates to `sinh (2 k ·) / (2 k)`
and `|sinh| ≤ cosh`, the operator maps `ℝ →ᵇ E` to itself and halves distances, for either sign of
`t`, so `ContractingWith.fixedPoint` applies on the whole line at once and no gluing of local
solutions is needed. The resulting curve satisfies `γ t = x + ∫ s in 0..t, v (γ s)`, hence solves
`γ' = v ∘ γ` by the fundamental theorem of calculus; uniqueness is Mathlib's
`ODE_solution_unique_univ`. The fixed point depends `1`-Lipschitzly on the initial condition, which
with `BoundedContinuousFunction`'s joint continuity of evaluation gives the joint continuity in
time and initial condition that `Flow` demands; `ODE.dist_globalSolution_le` then upgrades this to
the sharp two-sided exponential estimate, deduced from Mathlib's `dist_le_of_trajectories_ODE`
forwards and, via `ODE.globalSolution_neg`, backwards.

`Flow.ofLipschitz` assembles these into a `Flow ℝ E`, its group law being uniqueness applied to the
time-translated orbit, and records that every global solution is an orbit and that the rest points
of the flow are exactly the zeros of the field. `TauCeti.negativeGradientFlow` then feeds `-∇ f` to
it: `TauCeti.isNegativeGradient_negativeGradientFlow` discharges `Flow.IsNegativeGradient`, and
`TauCeti.forall_negativeGradientFlow_eq_self_iff` identifies its rest points with the critical
points of `f`. As a check that the abstract construction is the intended object,
`TauCeti.negativeGradientFlow_splitQuadratic` shows it returns exactly `TauCeti.splitQuadraticFlow`
on the split quadratic model, using the new `TauCeti.lipschitzWith_gradient_splitQuadratic`. Each
of the three constructions also comes with a `_congr` lemma showing it does not depend on the
Lipschitz bound chosen.

Files added: `TauCeti/Analysis/ODE/GlobalSolution.lean`, `TauCeti/Dynamics/Flow/OfLipschitz.lean`
and `TauCeti/Analysis/Calculus/Morse/FlowExistence.lean`, together with the split-model additions
to `TauCeti/Analysis/Calculus/Morse/SplitModel.lean`, where
`TauCeti.negativeGradientFlow_splitQuadratic` lives so that the generic existence module does not
depend on the split model. Nothing was vendored from Mathlib.

What remains for the Lane M milestone after this PR: stable and unstable *manifolds* of a
nondegenerate critical point (the stable-manifold theorem), the λ-lemma, Morse–Smale
transversality, broken-trajectory compactness and gluing, before `∂² = 0` and the comparison with
singular homology can be stated.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"flow-of-globally-lipschitz-vector-field"}-->

🤖 Prepared with Claude Code

