### PR TITLE
feat(QuadraticForm): a parallelogram-law function is a quadratic form

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
@@ -58,12 +58,15 @@ For a torsion-free codomain it is one term: `smul_right_injective N two_ne_zero`
 * `TauCeti.QuadraticMap.map_add_add_of_parallelogram`: the three-variable identity
   `f (x + y + z) + f x + f y + f z = f (x + y) + f (y + z) + f (x + z)`. This is the whole
   content — biadditivity is a rearrangement of it.
-* `TauCeti.QuadraticMap.polar_add_left_of_parallelogram` and `polar_add_right_of_parallelogram`:
-  the polarisation is biadditive.
+* `TauCeti.QuadraticMap.polar_add_left_of_parallelogram` and
+  `polar_zsmul_left_of_parallelogram`: the polarisation is additive and `ℤ`-linear on the left.
+  Additivity on the right is not restated — it is `QuadraticMap.polar_add_right` of the packaged
+  map below.
 * `TauCeti.QuadraticMap.map_zsmul_of_parallelogram`: `f (n • x) = n ^ 2 • f x` for `n : ℤ`,
   written `(n * n) • f x` to match `QuadraticMap`'s `toFun_smul` field.
-* `TauCeti.QuadraticMap.ofParallelogram`: the resulting `QuadraticMap ℤ M N`, whose companion
-  bilinear map is the polarisation.
+* `TauCeti.QuadraticMap.ofParallelogram`: the resulting `QuadraticMap ℤ M N`, built with
+  `QuadraticMap.ofPolar`. Its companion bilinear map is `QuadraticMap.polarBilin` of it, which is
+  the polarisation.
 
 ## Roadmap
 
@@ -130,11 +133,16 @@ theorem polar_add_left_of_parallelogram (x x' y : M) :
   simp only [polar]
   linear_combination (norm := module) map_add_add_of_parallelogram htwo hf x x' y
 
-/-- **The polarisation is additive in its right argument**, by symmetry. -/
-theorem polar_add_right_of_parallelogram (x y y' : M) :
-    polar f x (y + y') = polar f x y + polar f x y' := by
-  rw [polar_comm, polar_comm f x y, polar_comm f x y']
-  exact polar_add_left_of_parallelogram htwo hf y y' x
+/-- **The polarisation is `ℤ`-linear in its left argument.** No new content: an additive map
+between abelian groups is automatically `ℤ`-linear, and this is that fact applied to
+`polar_add_left_of_parallelogram`. It is the last input `QuadraticMap.ofPolar` asks for.
+
+Additivity on the *right* is not stated separately: it is `QuadraticMap.polar_add_right` of the
+packaged `ofParallelogram` below. -/
+theorem polar_zsmul_left_of_parallelogram (a : ℤ) (x y : M) :
+    polar f (a • x) y = a • polar f x y :=
+  AddMonoidHom.map_zsmul
+    (AddMonoidHom.mk' (polar f · y) fun p q ↦ polar_add_left_of_parallelogram htwo hf p q y) a x
 
 /-- Quadraticity for a natural multiple. Stated with an **integer** scalar on the right so that
 the induction step is a `ring` identity in `ℤ`: over `ℕ` it would read
@@ -161,36 +169,27 @@ theorem map_zsmul_of_parallelogram (n : ℤ) (x : M) : f (n • x) = (n * n) •
   · rw [neg_zsmul, natCast_zsmul, map_neg_of_parallelogram htwo hf,
       map_nsmul_of_parallelogram htwo hf, neg_mul_neg]
 
-/-- The polarisation, as an additive homomorphism in its right argument. -/
-def polarAddHomRight (x : M) : M →+ N :=
-  AddMonoidHom.mk' (polar f x) fun a b ↦ polar_add_right_of_parallelogram htwo hf x a b
+/-- **A function satisfying the parallelogram law is a quadratic form.**
 
-/-- **The polarisation as a `ℤ`-bilinear map.** Additivity is all that has to be supplied:
-`M` and `N` are abelian groups, so an additive map between them is automatically `ℤ`-linear. -/
-noncomputable def polarBilinInt : LinearMap.BilinMap ℤ M N :=
-  (AddMonoidHom.mk' (fun x ↦ (polarAddHomRight htwo hf x).toIntLinearMap)
-    fun a b ↦ by
-      ext y
-      exact polar_add_left_of_parallelogram htwo hf a b y).toIntLinearMap
+Built with Mathlib's `QuadraticMap.ofPolar`, which asks for exactly the three facts above and
+assembles the companion bilinear map itself; `QuadraticMap.polarBilin` of the result is that map,
+so there is no separate bilinear-map definition here. -/
+noncomputable def ofParallelogram : _root_.QuadraticMap ℤ M N :=
+  .ofPolar f (map_zsmul_of_parallelogram htwo hf) (polar_add_left_of_parallelogram htwo hf)
+    (polar_zsmul_left_of_parallelogram htwo hf)
 
+/-- `ofParallelogram` coerces back to the function it was built from. Stated at the level of
+functions, not just pointwise: `QuadraticMap.polar` takes the *function* as its argument, so this
+is the form needed to rewrite `polar ⇑(ofParallelogram htwo hf)` to `polar f` and reach Mathlib's
+polar API — checked downstream rather than assumed. -/
 @[simp]
-theorem polarBilinInt_apply (x y : M) : polarBilinInt htwo hf x y = polar f x y := by
-  -- not `rfl`: an *exported* `rfl` theorem needs every definition it unfolds to be `@[expose]`d,
-  -- and a tactic proof exports a proof term instead of a defeq obligation
-  simp [polarBilinInt, polarAddHomRight]
-
-/-- **A function satisfying the parallelogram law is a quadratic form**, with the polarisation as
-its companion bilinear map. -/
-noncomputable def ofParallelogram : _root_.QuadraticMap ℤ M N where
-  toFun := f
-  toFun_smul := map_zsmul_of_parallelogram htwo hf
-  exists_companion' := ⟨polarBilinInt htwo hf, fun x y ↦ by
-    rw [polarBilinInt_apply, polar]
-    abel⟩
+theorem coe_ofParallelogram : (ofParallelogram htwo hf : M → N) = f := by
+  unfold ofParallelogram
+  rfl
 
 @[simp]
 theorem ofParallelogram_apply (x : M) : ofParallelogram htwo hf x = f x := by
-  simp [ofParallelogram]
+  simp
 
 end QuadraticMap
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
@@ -68,14 +68,20 @@ For a torsion-free codomain it is one term: `smul_right_injective N two_ne_zero`
   `QuadraticMap.ofPolar`. Its companion bilinear map is `QuadraticMap.polarBilin` of it, which is
   the polarisation.
 
-## Roadmap
+## Where this is used
 
-`TauCetiRoadmap/EllipticCurves/README.md` §Layer 6 names "the Néron–Tate bilinear pairing" as a
-milestone, and the pairing is exactly the polarisation of the canonical height, which is known to
-satisfy the parallelogram law (`WeierstrassCurve.Affine.Point.canonicalHeight_parallelogram_law`)
-before it is known to be quadratic. The same shape recurs for the degree form on `End E` behind the
-Hasse bound (§Layer 3, AEC V.1.2). Stated here for a general abelian group so that neither
-application carries its own copy.
+Two constructions in arithmetic geometry arrive at a function *known to satisfy the parallelogram
+law* and want it as a quadratic form.
+
+The canonical height of an elliptic curve is one: `canonicalHeight_parallelogram_law` establishes
+the law exactly, and the Néron–Tate height pairing is then the polarisation supplied here — the
+bilinear map whose Gram determinant on a basis is the regulator. The degree form on `End E` is the
+other, where the polarisation is the trace form and its non-negativity gives the Hasse bound by
+Cauchy–Schwarz (Silverman, *AEC*, V.1.2).
+
+Both take values in a torsion-free group — `ℝ` and `ℤ` respectively — so both satisfy the
+hypothesis below with room to spare. Stated for a general abelian group so that neither carries
+its own copy.
 -/
 
 public section
@@ -96,8 +102,7 @@ include htwo hf
 theorem map_zero_of_parallelogram : f 0 = 0 := by
   have h := hf 0 0
   simp only [add_zero, sub_zero] at h
-  refine htwo ?_
-  change (2 : ℕ) • f 0 = (2 : ℕ) • 0
+  apply htwo
   linear_combination (norm := module) -h
 
 /-- The parallelogram law at `x = 0` forces `f` to be even. -/
@@ -119,12 +124,12 @@ theorem map_add_add_of_parallelogram (x y z : M) :
   have p2 := hf x (y - z)
   have p3 := hf y z
   have p4 := hf (x + z) y
+  -- `f` is an arbitrary function, so `abel` cannot normalise *under* it: the arguments have to be
+  -- rewritten explicitly before the four instances share syntactic subterms and can be combined.
   rw [show x + y - z = x + (y - z) by abel] at p1
   rw [show x - (y - z) = x + z - y by abel] at p2
   rw [show x + z + y = x + y + z by abel] at p4
-  refine htwo ?_
-  change (2 : ℕ) • (f (x + y + z) + f x + f y + f z)
-      = (2 : ℕ) • (f (x + y) + f (y + z) + f (x + z))
+  apply htwo
   linear_combination (norm := module) p1 + p4 - p2 - (2 : ℤ) • p3
 
 /-- **The polarisation is additive in its left argument.** -/
@@ -155,6 +160,7 @@ private theorem map_nsmul_of_parallelogram (n : ℕ) (x : M) :
   | more n ih ih' =>
     -- the parallelogram law at `((n + 1) • x, x)` expresses the value at `(n + 2) • x`
     have h := hf ((n + 1) • x) x
+    -- again the arguments of `f`, not the ambient expression, are what must be reshaped
     rw [← succ_nsmul x (n + 1), show (n + 1) • x - x = n • x by
       rw [succ_nsmul, add_sub_cancel_right], ih, ih'] at h
     push_cast at h ⊢

--- a/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.QuadraticForm.Basic
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Module
+
+/-!
+# A function satisfying the parallelogram law is a quadratic form
+
+Let `M` and `N` be additive commutative groups and `f : M → N` satisfy the **parallelogram law**
+
+```
+f (x + y) + f (x - y) = 2 • f x + 2 • f y.
+```
+
+Then `f` is a quadratic form: its polarisation `QuadraticMap.polar f x y = f (x + y) - f x - f y`
+is biadditive, and `f (n • x) = n ^ 2 • f x`. This file proves that, and packages it as a
+`QuadraticMap ℤ M N`. Both `f 0 = 0` and evenness of `f` come free from the law rather than being
+assumed.
+
+Mathlib has the converse direction — `QuadraticMap.polar_add_left` and friends read biadditivity
+*off* a `QuadraticMap`, and `LinearMap.BilinMap.toQuadraticMap` builds one from a bilinear map —
+but nothing in the other direction from the parallelogram law alone. Its `parallelogram_law` and
+`parallelogram_law_with_norm` are statements about inner product spaces, and the Jordan–von Neumann
+construction in `Analysis/InnerProductSpace/OfNorm.lean` recovers an inner product from a *norm* on
+a real or complex space, using continuity. Neither applies to a function on a bare abelian group.
+
+## The torsion hypothesis is necessary, not defensive
+
+`N` is assumed `IsAddTorsionFree`. The derivation of the three-variable identity
+`map_add_add_of_parallelogram` produces it doubled — four instances of the parallelogram law
+combine to `2 • LHS = 2 • RHS` — and halving is the only step that needs anything of `N`.
+
+It cannot be dropped. With `M = N = ZMod 2` *every* function satisfies the parallelogram law,
+because `x - y = x + y` and `2 • z = 0` there; the constant function `1` is then one that satisfies
+it while failing even `f 0 = 0`, which every quadratic form obeys. So the hypothesis is what makes
+the conclusion true, not merely what makes this proof work.
+
+## Main results
+
+* `TauCeti.QuadraticMap.map_zero_of_parallelogram` and
+  `TauCeti.QuadraticMap.map_neg_of_parallelogram`: `f 0 = 0` and `f (-x) = f x` come free from the
+  law; neither has to be assumed.
+* `TauCeti.QuadraticMap.map_add_add_of_parallelogram`: the three-variable identity
+  `f (x + y + z) + f x + f y + f z = f (x + y) + f (y + z) + f (x + z)`. This is the whole
+  content — biadditivity is a rearrangement of it.
+* `TauCeti.QuadraticMap.polar_add_left_of_parallelogram` and `polar_add_right_of_parallelogram`:
+  the polarisation is biadditive.
+* `TauCeti.QuadraticMap.map_zsmul_of_parallelogram`: `f (n • x) = n ^ 2 • f x` for `n : ℤ`,
+  written `(n * n) • f x` to match `QuadraticMap`'s `toFun_smul` field.
+* `TauCeti.QuadraticMap.ofParallelogram`: the resulting `QuadraticMap ℤ M N`, whose companion
+  bilinear map is the polarisation.
+
+## Roadmap
+
+`TauCetiRoadmap/EllipticCurves/README.md` §Layer 6 names "the Néron–Tate bilinear pairing" as a
+milestone, and the pairing is exactly the polarisation of the canonical height, which is known to
+satisfy the parallelogram law (`WeierstrassCurve.Affine.Point.canonicalHeight_parallelogram_law`)
+before it is known to be quadratic. The same shape recurs for the degree form on `End E` behind the
+Hasse bound (§Layer 3, AEC V.1.2). Stated here for a general abelian group so that neither
+application carries its own copy.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace QuadraticMap
+
+open _root_.QuadraticMap
+
+variable {M N : Type*} [AddCommGroup M] [AddCommGroup N] [IsAddTorsionFree N] {f : M → N}
+  (hf : ∀ x y : M, f (x + y) + f (x - y) = 2 • f x + 2 • f y)
+
+include hf
+
+/-- The parallelogram law at `x = y = 0` forces `f 0 = 0`. -/
+theorem map_zero_of_parallelogram : f 0 = 0 := by
+  have h := hf 0 0
+  simp only [add_zero, sub_zero] at h
+  refine smul_right_injective N (r := (2 : ℤ)) (by norm_num) ?_
+  change (2 : ℤ) • f 0 = (2 : ℤ) • 0
+  linear_combination (norm := module) -h
+
+/-- The parallelogram law at `x = 0` forces `f` to be even. -/
+theorem map_neg_of_parallelogram (x : M) : f (-x) = f x := by
+  have h := hf 0 x
+  rw [zero_add, zero_sub, map_zero_of_parallelogram hf] at h
+  linear_combination (norm := module) h
+
+/-- **The three-variable identity.** A quadratic form satisfies
+`f (x + y + z) = f (x + y) + f (y + z) + f (x + z) - f x - f y - f z`, and the parallelogram law
+already implies it. Biadditivity of the polarisation is a rearrangement of this, so it is the
+substantive step. -/
+theorem map_add_add_of_parallelogram (x y z : M) :
+    f (x + y + z) + f x + f y + f z = f (x + y) + f (y + z) + f (x + z) := by
+  -- Four instances of the law. `x + z - y` and `x - (y - z)` are the same point, which is what
+  -- lets the two occurrences of `f` at that point cancel; halving at the end is the only place
+  -- torsion-freeness is used.
+  have h1 := hf (x + y) z
+  have h2 := hf x (y - z)
+  have h3 := hf y z
+  have h4 := hf (x + z) y
+  rw [show x + y - z = x + (y - z) by abel] at h1
+  rw [show x - (y - z) = x + z - y by abel] at h2
+  rw [show x + z + y = x + y + z by abel] at h4
+  refine smul_right_injective N (r := (2 : ℤ)) (by norm_num) ?_
+  change (2 : ℤ) • (f (x + y + z) + f x + f y + f z)
+      = (2 : ℤ) • (f (x + y) + f (y + z) + f (x + z))
+  linear_combination (norm := module) h1 + h4 - h2 - (2 : ℤ) • h3
+
+/-- **The polarisation is additive in its left argument.** -/
+theorem polar_add_left_of_parallelogram (x x' y : M) :
+    polar f (x + x') y = polar f x y + polar f x' y := by
+  simp only [polar]
+  linear_combination (norm := module) map_add_add_of_parallelogram hf x x' y
+
+/-- **The polarisation is additive in its right argument**, by symmetry. -/
+theorem polar_add_right_of_parallelogram (x y y' : M) :
+    polar f x (y + y') = polar f x y + polar f x y' := by
+  rw [polar_comm, polar_comm f x y, polar_comm f x y']
+  exact polar_add_left_of_parallelogram hf y y' x
+
+/-- Quadraticity for a natural multiple. Stated with an **integer** scalar on the right so that
+the induction step is a `ring` identity in `ℤ`: over `ℕ` it would read
+`(n + 2) ^ 2 = 2 (n + 1) ^ 2 + 2 - n ^ 2`, and truncated subtraction is not a ring. -/
+private theorem map_nsmul_of_parallelogram (n : ℕ) (x : M) :
+    f (n • x) = ((n : ℤ) * n) • f x := by
+  induction n using Nat.twoStepInduction with
+  | zero => simpa using map_zero_of_parallelogram hf
+  | one => simp
+  | more n ih ih' =>
+    -- the parallelogram law at `((n + 1) • x, x)` expresses the value at `(n + 2) • x`
+    have h := hf ((n + 1) • x) x
+    rw [← succ_nsmul x (n + 1), show (n + 1) • x - x = n • x by
+      rw [succ_nsmul, add_sub_cancel_right], ih, ih'] at h
+    push_cast at h ⊢
+    linear_combination (norm := module) h
+
+/-- **Quadraticity**: `f (n • x) = n ^ 2 • f x`, written `(n * n) • f x` to match the
+`toFun_smul` field of `QuadraticMap`. The negative case is the natural one composed with
+`map_neg_of_parallelogram`. -/
+theorem map_zsmul_of_parallelogram (n : ℤ) (x : M) : f (n • x) = (n * n) • f x := by
+  obtain ⟨m, rfl | rfl⟩ := n.eq_nat_or_neg
+  · rw [natCast_zsmul, map_nsmul_of_parallelogram hf]
+  · rw [neg_zsmul, natCast_zsmul, map_neg_of_parallelogram hf,
+      map_nsmul_of_parallelogram hf, neg_mul_neg]
+
+/-- The polarisation, as an additive homomorphism in its right argument. -/
+def polarAddHomRight (x : M) : M →+ N :=
+  AddMonoidHom.mk' (polar f x) fun a b ↦ polar_add_right_of_parallelogram hf x a b
+
+/-- **The polarisation as a `ℤ`-bilinear map.** Additivity is all that has to be supplied:
+`M` and `N` are abelian groups, so an additive map between them is automatically `ℤ`-linear. -/
+noncomputable def polarBilinInt : LinearMap.BilinMap ℤ M N :=
+  (AddMonoidHom.mk' (fun x ↦ (polarAddHomRight hf x).toIntLinearMap)
+    fun a b ↦ by
+      ext y
+      exact polar_add_left_of_parallelogram hf a b y).toIntLinearMap
+
+@[simp]
+theorem polarBilinInt_apply (x y : M) : polarBilinInt hf x y = polar f x y := by
+  -- not `rfl`: an *exported* `rfl` theorem needs every definition it unfolds to be `@[expose]`d,
+  -- and a tactic proof exports a proof term instead of a defeq obligation
+  simp [polarBilinInt, polarAddHomRight]
+
+/-- **A function satisfying the parallelogram law is a quadratic form**, with the polarisation as
+its companion bilinear map. -/
+noncomputable def ofParallelogram : _root_.QuadraticMap ℤ M N where
+  toFun := f
+  toFun_smul := map_zsmul_of_parallelogram hf
+  exists_companion' := ⟨polarBilinInt hf, fun x y ↦ by
+    rw [polarBilinInt_apply, polar]
+    abel⟩
+
+@[simp]
+theorem ofParallelogram_apply (x : M) : ofParallelogram hf x = f x := by
+  simp [ofParallelogram]
+
+end QuadraticMap
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
@@ -47,21 +47,15 @@ For a torsion-free codomain it is one term: `smul_right_injective N two_ne_zero`
 
 ## Main results
 
-* `TauCeti.QuadraticMap.map_zero_of_parallelogram` and
-  `TauCeti.QuadraticMap.map_neg_of_parallelogram`: `f 0 = 0` and `f (-x) = f x` come free from the
-  law; neither has to be assumed.
+* `TauCeti.QuadraticMap.map_zero_of_parallelogram`: `f 0 = 0`.
+* `TauCeti.QuadraticMap.map_neg_of_parallelogram`: `f (-x) = f x`.
 * `TauCeti.QuadraticMap.map_add_add_of_parallelogram`: the three-variable identity
-  `f (x + y + z) + f x + f y + f z = f (x + y) + f (y + z) + f (x + z)`. This is the whole
-  content — biadditivity is a rearrangement of it.
+  `f (x + y + z) + f x + f y + f z = f (x + y) + f (y + z) + f (x + z)`.
 * `TauCeti.QuadraticMap.polar_add_left_of_parallelogram` and
   `polar_zsmul_left_of_parallelogram`: the polarisation is additive and `ℤ`-linear on the left.
-  Additivity on the right is not restated — it is `QuadraticMap.polar_add_right` of the packaged
-  map below.
-* `TauCeti.QuadraticMap.map_zsmul_of_parallelogram`: `f (n • x) = n ^ 2 • f x` for `n : ℤ`,
-  written `(n * n) • f x` to match `QuadraticMap`'s `toFun_smul` field.
-* `TauCeti.QuadraticMap.ofParallelogram`: the resulting `QuadraticMap ℤ M N`, built with
-  `QuadraticMap.ofPolar`. Its companion bilinear map is `QuadraticMap.polarBilin` of it, which is
-  the polarisation.
+* `TauCeti.QuadraticMap.map_zsmul_of_parallelogram`: `f (n • x) = n ^ 2 • f x` for `n : ℤ`.
+* `TauCeti.QuadraticMap.ofParallelogram`: `f` as a `QuadraticMap ℤ M N`, with the polarisation as
+  its companion bilinear map.
 
 ## Where this is used
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
@@ -30,16 +30,25 @@ but nothing in the other direction from the parallelogram law alone. Its `parall
 construction in `Analysis/InnerProductSpace/OfNorm.lean` recovers an inner product from a *norm* on
 a real or complex space, using continuity. Neither applies to a function on a bare abelian group.
 
-## The torsion hypothesis is necessary, not defensive
+## The hypothesis is exactly the absence of `2`-torsion
 
-`N` is assumed `IsAddTorsionFree`. The derivation of the three-variable identity
-`map_add_add_of_parallelogram` produces it doubled — four instances of the parallelogram law
-combine to `2 • LHS = 2 • RHS` — and halving is the only step that needs anything of `N`.
+`htwo : IsSMulRegular N 2` says that doubling is injective on `N`, and that is precisely what the
+proofs consume. The three-variable identity `map_add_add_of_parallelogram` comes out **doubled** —
+four instances of the parallelogram law combine to `2 • LHS = 2 • RHS` — and halving is the only
+step in the file that uses anything of `N` at all.
 
-It cannot be dropped. With `M = N = ZMod 2` *every* function satisfies the parallelogram law,
+It is deliberately *not* `IsAddTorsionFree N`, which is strictly stronger and would exclude
+codomains where the construction is perfectly valid: `IsSMulRegular (ZMod 3) 2` holds even though
+`ZMod 3` has `3`-torsion.
+
+Nor can it be dropped. With `M = N = ZMod 2` *every* function satisfies the parallelogram law,
 because `x - y = x + y` and `2 • z = 0` there; the constant function `1` is then one that satisfies
-it while failing even `f 0 = 0`, which every quadratic form obeys. So the hypothesis is what makes
-the conclusion true, not merely what makes this proof work.
+it while failing even `f 0 = 0`, which every quadratic form obeys — and correspondingly
+`¬ IsSMulRegular (ZMod 2) 2`. So the hypothesis is what makes the conclusion true, not merely what
+makes this proof work.
+
+For a torsion-free codomain it is one term: `smul_right_injective N two_ne_zero` supplies it for
+`N = ℝ`, the canonical height's target, and for `N = ℤ`, the degree form's.
 
 ## Main results
 
@@ -74,23 +83,24 @@ namespace QuadraticMap
 
 open _root_.QuadraticMap
 
-variable {M N : Type*} [AddCommGroup M] [AddCommGroup N] [IsAddTorsionFree N] {f : M → N}
+variable {M N : Type*} [AddCommGroup M] [AddCommGroup N] {f : M → N}
+  (htwo : IsSMulRegular N (2 : ℕ))
   (hf : ∀ x y : M, f (x + y) + f (x - y) = 2 • f x + 2 • f y)
 
-include hf
+include htwo hf
 
 /-- The parallelogram law at `x = y = 0` forces `f 0 = 0`. -/
 theorem map_zero_of_parallelogram : f 0 = 0 := by
   have h := hf 0 0
   simp only [add_zero, sub_zero] at h
-  refine smul_right_injective N (r := (2 : ℤ)) (by norm_num) ?_
-  change (2 : ℤ) • f 0 = (2 : ℤ) • 0
+  refine htwo ?_
+  change (2 : ℕ) • f 0 = (2 : ℕ) • 0
   linear_combination (norm := module) -h
 
 /-- The parallelogram law at `x = 0` forces `f` to be even. -/
 theorem map_neg_of_parallelogram (x : M) : f (-x) = f x := by
   have h := hf 0 x
-  rw [zero_add, zero_sub, map_zero_of_parallelogram hf] at h
+  rw [zero_add, zero_sub, map_zero_of_parallelogram htwo hf] at h
   linear_combination (norm := module) h
 
 /-- **The three-variable identity.** A quadratic form satisfies
@@ -102,29 +112,29 @@ theorem map_add_add_of_parallelogram (x y z : M) :
   -- Four instances of the law. `x + z - y` and `x - (y - z)` are the same point, which is what
   -- lets the two occurrences of `f` at that point cancel; halving at the end is the only place
   -- torsion-freeness is used.
-  have h1 := hf (x + y) z
-  have h2 := hf x (y - z)
-  have h3 := hf y z
-  have h4 := hf (x + z) y
-  rw [show x + y - z = x + (y - z) by abel] at h1
-  rw [show x - (y - z) = x + z - y by abel] at h2
-  rw [show x + z + y = x + y + z by abel] at h4
-  refine smul_right_injective N (r := (2 : ℤ)) (by norm_num) ?_
-  change (2 : ℤ) • (f (x + y + z) + f x + f y + f z)
-      = (2 : ℤ) • (f (x + y) + f (y + z) + f (x + z))
-  linear_combination (norm := module) h1 + h4 - h2 - (2 : ℤ) • h3
+  have p1 := hf (x + y) z
+  have p2 := hf x (y - z)
+  have p3 := hf y z
+  have p4 := hf (x + z) y
+  rw [show x + y - z = x + (y - z) by abel] at p1
+  rw [show x - (y - z) = x + z - y by abel] at p2
+  rw [show x + z + y = x + y + z by abel] at p4
+  refine htwo ?_
+  change (2 : ℕ) • (f (x + y + z) + f x + f y + f z)
+      = (2 : ℕ) • (f (x + y) + f (y + z) + f (x + z))
+  linear_combination (norm := module) p1 + p4 - p2 - (2 : ℤ) • p3
 
 /-- **The polarisation is additive in its left argument.** -/
 theorem polar_add_left_of_parallelogram (x x' y : M) :
     polar f (x + x') y = polar f x y + polar f x' y := by
   simp only [polar]
-  linear_combination (norm := module) map_add_add_of_parallelogram hf x x' y
+  linear_combination (norm := module) map_add_add_of_parallelogram htwo hf x x' y
 
 /-- **The polarisation is additive in its right argument**, by symmetry. -/
 theorem polar_add_right_of_parallelogram (x y y' : M) :
     polar f x (y + y') = polar f x y + polar f x y' := by
   rw [polar_comm, polar_comm f x y, polar_comm f x y']
-  exact polar_add_left_of_parallelogram hf y y' x
+  exact polar_add_left_of_parallelogram htwo hf y y' x
 
 /-- Quadraticity for a natural multiple. Stated with an **integer** scalar on the right so that
 the induction step is a `ring` identity in `ℤ`: over `ℕ` it would read
@@ -132,7 +142,7 @@ the induction step is a `ring` identity in `ℤ`: over `ℕ` it would read
 private theorem map_nsmul_of_parallelogram (n : ℕ) (x : M) :
     f (n • x) = ((n : ℤ) * n) • f x := by
   induction n using Nat.twoStepInduction with
-  | zero => simpa using map_zero_of_parallelogram hf
+  | zero => simpa using map_zero_of_parallelogram htwo hf
   | one => simp
   | more n ih ih' =>
     -- the parallelogram law at `((n + 1) • x, x)` expresses the value at `(n + 2) • x`
@@ -147,24 +157,24 @@ private theorem map_nsmul_of_parallelogram (n : ℕ) (x : M) :
 `map_neg_of_parallelogram`. -/
 theorem map_zsmul_of_parallelogram (n : ℤ) (x : M) : f (n • x) = (n * n) • f x := by
   obtain ⟨m, rfl | rfl⟩ := n.eq_nat_or_neg
-  · rw [natCast_zsmul, map_nsmul_of_parallelogram hf]
-  · rw [neg_zsmul, natCast_zsmul, map_neg_of_parallelogram hf,
-      map_nsmul_of_parallelogram hf, neg_mul_neg]
+  · rw [natCast_zsmul, map_nsmul_of_parallelogram htwo hf]
+  · rw [neg_zsmul, natCast_zsmul, map_neg_of_parallelogram htwo hf,
+      map_nsmul_of_parallelogram htwo hf, neg_mul_neg]
 
 /-- The polarisation, as an additive homomorphism in its right argument. -/
 def polarAddHomRight (x : M) : M →+ N :=
-  AddMonoidHom.mk' (polar f x) fun a b ↦ polar_add_right_of_parallelogram hf x a b
+  AddMonoidHom.mk' (polar f x) fun a b ↦ polar_add_right_of_parallelogram htwo hf x a b
 
 /-- **The polarisation as a `ℤ`-bilinear map.** Additivity is all that has to be supplied:
 `M` and `N` are abelian groups, so an additive map between them is automatically `ℤ`-linear. -/
 noncomputable def polarBilinInt : LinearMap.BilinMap ℤ M N :=
-  (AddMonoidHom.mk' (fun x ↦ (polarAddHomRight hf x).toIntLinearMap)
+  (AddMonoidHom.mk' (fun x ↦ (polarAddHomRight htwo hf x).toIntLinearMap)
     fun a b ↦ by
       ext y
-      exact polar_add_left_of_parallelogram hf a b y).toIntLinearMap
+      exact polar_add_left_of_parallelogram htwo hf a b y).toIntLinearMap
 
 @[simp]
-theorem polarBilinInt_apply (x y : M) : polarBilinInt hf x y = polar f x y := by
+theorem polarBilinInt_apply (x y : M) : polarBilinInt htwo hf x y = polar f x y := by
   -- not `rfl`: an *exported* `rfl` theorem needs every definition it unfolds to be `@[expose]`d,
   -- and a tactic proof exports a proof term instead of a defeq obligation
   simp [polarBilinInt, polarAddHomRight]
@@ -173,13 +183,13 @@ theorem polarBilinInt_apply (x y : M) : polarBilinInt hf x y = polar f x y := by
 its companion bilinear map. -/
 noncomputable def ofParallelogram : _root_.QuadraticMap ℤ M N where
   toFun := f
-  toFun_smul := map_zsmul_of_parallelogram hf
-  exists_companion' := ⟨polarBilinInt hf, fun x y ↦ by
+  toFun_smul := map_zsmul_of_parallelogram htwo hf
+  exists_companion' := ⟨polarBilinInt htwo hf, fun x y ↦ by
     rw [polarBilinInt_apply, polar]
     abel⟩
 
 @[simp]
-theorem ofParallelogram_apply (x : M) : ofParallelogram hf x = f x := by
+theorem ofParallelogram_apply (x : M) : ofParallelogram htwo hf x = f x := by
   simp [ofParallelogram]
 
 end QuadraticMap

--- a/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
@@ -32,20 +32,15 @@ a real or complex space, using continuity. Neither applies to a function on a ba
 
 ## The hypothesis is exactly the absence of `2`-torsion
 
-`htwo : IsSMulRegular N 2` says that doubling is injective on `N`, and that is precisely what the
-proofs consume. The three-variable identity `map_add_add_of_parallelogram` comes out **doubled** —
-four instances of the parallelogram law combine to `2 • LHS = 2 • RHS` — and halving is the only
-step in the file that uses anything of `N` at all.
+`htwo : IsSMulRegular N 2` says that doubling is injective on `N`. It is sharp in both directions.
 
-It is deliberately *not* `IsAddTorsionFree N`, which is strictly stronger and would exclude
-codomains where the construction is perfectly valid: `IsSMulRegular (ZMod 3) 2` holds even though
-`ZMod 3` has `3`-torsion.
+It is *not* `IsAddTorsionFree N`, which is strictly stronger and excludes codomains where the
+conclusion holds: `IsSMulRegular (ZMod 3) 2` is true even though `ZMod 3` has `3`-torsion.
 
-Nor can it be dropped. With `M = N = ZMod 2` *every* function satisfies the parallelogram law,
-because `x - y = x + y` and `2 • z = 0` there; the constant function `1` is then one that satisfies
-it while failing even `f 0 = 0`, which every quadratic form obeys — and correspondingly
-`¬ IsSMulRegular (ZMod 2) 2`. So the hypothesis is what makes the conclusion true, not merely what
-makes this proof work.
+Nor can it be weakened away. With `M = N = ZMod 2` *every* function satisfies the parallelogram
+law, because `x - y = x + y` and `2 • z = 0` there; the constant function `1` is then one that
+satisfies it while failing even `f 0 = 0`, which every quadratic form obeys — and correspondingly
+`¬ IsSMulRegular (ZMod 2) 2`.
 
 For a torsion-free codomain it is one term: `smul_right_injective N two_ne_zero` supplies it for
 `N = ℝ`, the canonical height's target, and for `N = ℤ`, the degree form's.
@@ -67,6 +62,13 @@ For a torsion-free codomain it is one term: `smul_right_injective N two_ne_zero`
 * `TauCeti.QuadraticMap.ofParallelogram`: the resulting `QuadraticMap ℤ M N`, built with
   `QuadraticMap.ofPolar`. Its companion bilinear map is `QuadraticMap.polarBilin` of it, which is
   the polarisation.
+
+## Implementation notes
+
+The three-variable identity `map_add_add_of_parallelogram` is derived **doubled**: four instances
+of the parallelogram law combine to `2 • LHS = 2 • RHS`, and halving it is the only step in the
+file that uses anything of `N` at all. Everything after it — biadditivity, quadraticity, the
+packaged `QuadraticMap` — is a rearrangement or an induction over that identity.
 
 ## Where this is used
 
@@ -111,10 +113,10 @@ theorem map_neg_of_parallelogram (x : M) : f (-x) = f x := by
   rw [zero_add, zero_sub, map_zero_of_parallelogram htwo hf] at h
   linear_combination (norm := module) h
 
-/-- **The three-variable identity.** A quadratic form satisfies
-`f (x + y + z) = f (x + y) + f (y + z) + f (x + z) - f x - f y - f z`, and the parallelogram law
-already implies it. Biadditivity of the polarisation is a rearrangement of this, so it is the
-substantive step. -/
+-- This is the substantive step: biadditivity of the polarisation below is a rearrangement of it.
+/-- **The three-variable identity** satisfied by every quadratic form:
+`f (x + y + z) = f (x + y) + f (y + z) + f (x + z) - f x - f y - f z`, here in the
+subtraction-free form. -/
 theorem map_add_add_of_parallelogram (x y z : M) :
     f (x + y + z) + f x + f y + f z = f (x + y) + f (y + z) + f (x + z) := by
   -- Four instances of the law. `x + z - y` and `x - (y - z)` are the same point, which is what
@@ -138,20 +140,20 @@ theorem polar_add_left_of_parallelogram (x x' y : M) :
   simp only [polar]
   linear_combination (norm := module) map_add_add_of_parallelogram htwo hf x x' y
 
-/-- **The polarisation is `ℤ`-linear in its left argument.** No new content: an additive map
-between abelian groups is automatically `ℤ`-linear, and this is that fact applied to
-`polar_add_left_of_parallelogram`. It is the last input `QuadraticMap.ofPolar` asks for.
-
-Additivity on the *right* is not stated separately: it is `QuadraticMap.polar_add_right` of the
-packaged `ofParallelogram` below. -/
+-- No new content: an additive map between abelian groups is automatically `ℤ`-linear, so this is
+-- `polar_add_left_of_parallelogram` transported. It is the last input `QuadraticMap.ofPolar` asks
+-- for. Additivity on the *right* is not stated separately — it is `QuadraticMap.polar_add_right`
+-- of the packaged `ofParallelogram` below.
+/-- **The polarisation is `ℤ`-linear in its left argument.** -/
 theorem polar_zsmul_left_of_parallelogram (a : ℤ) (x y : M) :
     polar f (a • x) y = a • polar f x y :=
   AddMonoidHom.map_zsmul
     (AddMonoidHom.mk' (polar f · y) fun p q ↦ polar_add_left_of_parallelogram htwo hf p q y) a x
 
-/-- Quadraticity for a natural multiple. Stated with an **integer** scalar on the right so that
-the induction step is a `ring` identity in `ℤ`: over `ℕ` it would read
-`(n + 2) ^ 2 = 2 (n + 1) ^ 2 + 2 - n ^ 2`, and truncated subtraction is not a ring. -/
+-- The scalar on the right is an **integer** so that the induction step is a `ring` identity in
+-- `ℤ`; over `ℕ` it would read `(n + 2) ^ 2 = 2 (n + 1) ^ 2 + 2 - n ^ 2`, and truncated
+-- subtraction is not a ring.
+/-- Quadraticity for a natural multiple: `f (n • x) = n ^ 2 • f x`. -/
 private theorem map_nsmul_of_parallelogram (n : ℕ) (x : M) :
     f (n • x) = ((n : ℤ) * n) • f x := by
   induction n using Nat.twoStepInduction with
@@ -166,33 +168,33 @@ private theorem map_nsmul_of_parallelogram (n : ℕ) (x : M) :
     push_cast at h ⊢
     linear_combination (norm := module) h
 
-/-- **Quadraticity**: `f (n • x) = n ^ 2 • f x`, written `(n * n) • f x` to match the
-`toFun_smul` field of `QuadraticMap`. The negative case is the natural one composed with
-`map_neg_of_parallelogram`. -/
+-- Written `(n * n) • f x` rather than `n ^ 2 • f x` to match the `toFun_smul` field of
+-- `QuadraticMap` syntactically. The negative case composes the natural one with evenness.
+/-- **Quadraticity**: `f (n • x) = n ^ 2 • f x` for an integer `n`. -/
 theorem map_zsmul_of_parallelogram (n : ℤ) (x : M) : f (n • x) = (n * n) • f x := by
   obtain ⟨m, rfl | rfl⟩ := n.eq_nat_or_neg
   · rw [natCast_zsmul, map_nsmul_of_parallelogram htwo hf]
   · rw [neg_zsmul, natCast_zsmul, map_neg_of_parallelogram htwo hf,
       map_nsmul_of_parallelogram htwo hf, neg_mul_neg]
 
-/-- **A function satisfying the parallelogram law is a quadratic form.**
-
-Built with Mathlib's `QuadraticMap.ofPolar`, which asks for exactly the three facts above and
-assembles the companion bilinear map itself; `QuadraticMap.polarBilin` of the result is that map,
-so there is no separate bilinear-map definition here. -/
+-- Built with `QuadraticMap.ofPolar`, which asks for exactly the three facts above and assembles
+-- the companion bilinear map itself, so no bilinear map is defined here.
+/-- **A function satisfying the parallelogram law is a quadratic form.** Its companion bilinear
+map is `QuadraticMap.polarBilin` of it, which is the polarisation. -/
 noncomputable def ofParallelogram : _root_.QuadraticMap ℤ M N :=
   .ofPolar f (map_zsmul_of_parallelogram htwo hf) (polar_add_left_of_parallelogram htwo hf)
     (polar_zsmul_left_of_parallelogram htwo hf)
 
-/-- `ofParallelogram` coerces back to the function it was built from. Stated at the level of
-functions, not just pointwise: `QuadraticMap.polar` takes the *function* as its argument, so this
-is the form needed to rewrite `polar ⇑(ofParallelogram htwo hf)` to `polar f` and reach Mathlib's
-polar API — checked downstream rather than assumed. -/
+-- Stated at the level of functions rather than only pointwise because `QuadraticMap.polar` takes
+-- the function as its argument: this is the form that rewrites `polar ⇑(ofParallelogram htwo hf)`
+-- into `polar f` and so reaches Mathlib's polar API.
+/-- `ofParallelogram` coerces back to the function it was built from. -/
 @[simp]
 theorem coe_ofParallelogram : (ofParallelogram htwo hf : M → N) = f := by
-  unfold ofParallelogram
-  rfl
+  funext x
+  simp [ofParallelogram]
 
+/-- `ofParallelogram` evaluated at a point is the original function there. -/
 @[simp]
 theorem ofParallelogram_apply (x : M) : ofParallelogram htwo hf x = f x := by
   simp

--- a/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
@@ -49,8 +49,9 @@ For a torsion-free codomain it is one term: `smul_right_injective N two_ne_zero`
 
 * `TauCeti.QuadraticMap.map_zero_of_parallelogram`: `f 0 = 0`.
 * `TauCeti.QuadraticMap.map_neg_of_parallelogram`: `f (-x) = f x`.
-* `TauCeti.QuadraticMap.map_add_add_of_parallelogram`: the three-variable identity
-  `f (x + y + z) + f x + f y + f z = f (x + y) + f (y + z) + f (x + z)`.
+* `TauCeti.QuadraticMap.map_add_add_add_map_of_parallelogram`: the three-variable identity
+  `f (x + y + z) + (f x + f y + f z) = f (x + y) + f (y + z) + f (x + z)`, named after
+  `QuadraticMap.map_add_add_add_map`.
 * `TauCeti.QuadraticMap.polar_add_left_of_parallelogram` and
   `polar_zsmul_left_of_parallelogram`: the polarisation is additive and `ℤ`-linear on the left.
 * `TauCeti.QuadraticMap.map_zsmul_of_parallelogram`: `f (n • x) = n ^ 2 • f x` for `n : ℤ`.
@@ -109,11 +110,13 @@ theorem map_neg_of_parallelogram (x : M) : f (-x) = f x := by
   linear_combination (norm := module) h
 
 -- This is the substantive step: biadditivity of the polarisation below is a rearrangement of it.
-/-- **The three-variable identity** satisfied by every quadratic form:
-`f (x + y + z) = f (x + y) + f (y + z) + f (x + z) - f x - f y - f z`, here in the
-subtraction-free form. -/
-theorem map_add_add_of_parallelogram (x y z : M) :
-    f (x + y + z) + f x + f y + f z = f (x + y) + f (y + z) + f (x + z) := by
+-- Named after `QuadraticMap.map_add_add_add_map`, which is the same identity read off a quadratic
+-- map instead of derived from the parallelogram law. The last summand is `f (x + z)` where that
+-- lemma writes `f (z + x)`: commutativity inside an argument of an opaque `f` is not something
+-- the normalisers can absorb, so the order the proof produces is the one stated.
+/-- **The three-variable identity** satisfied by every quadratic form, in subtraction-free form. -/
+theorem map_add_add_add_map_of_parallelogram (x y z : M) :
+    f (x + y + z) + (f x + f y + f z) = f (x + y) + f (y + z) + f (x + z) := by
   -- Four instances of the law. `x + z - y` and `x - (y - z)` are the same point, which is what
   -- lets the two occurrences of `f` at that point cancel; halving at the end is the only place
   -- torsion-freeness is used.
@@ -133,7 +136,7 @@ theorem map_add_add_of_parallelogram (x y z : M) :
 theorem polar_add_left_of_parallelogram (x x' y : M) :
     polar f (x + x') y = polar f x y + polar f x' y := by
   simp only [polar]
-  linear_combination (norm := module) map_add_add_of_parallelogram htwo hf x x' y
+  linear_combination (norm := module) map_add_add_add_map_of_parallelogram htwo hf x x' y
 
 -- No new content: an additive map between abelian groups is automatically `ℤ`-linear, so this is
 -- `polar_add_left_of_parallelogram` transported. It is the last input `QuadraticMap.ofPolar` asks

--- a/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
@@ -63,10 +63,16 @@ Two constructions in arithmetic geometry arrive at a function *known to satisfy 
 law* and want it as a quadratic form.
 
 The canonical height of an elliptic curve is one. It satisfies the parallelogram law exactly, and
-its polarisation is the Néron–Tate height pairing — the bilinear map whose Gram determinant on a
-basis of the free part of the Mordell–Weil group is the regulator. The degree form on `End E` is
-the other: its polarisation is the trace form, and non-negativity of the degree gives the Hasse
-bound by Cauchy–Schwarz (Silverman, *The Arithmetic of Elliptic Curves*, V.1.2).
+its polarisation is the Néron–Tate height pairing **up to a factor of two**: by
+`QuadraticMap.polar_self` the polarisation here has `polar f x x = 2 • f x`, whereas the pairing
+whose Gram determinant on a basis of the free part of the Mordell–Weil group is the regulator is
+normalised so that `⟨P, P⟩` is the height itself. A consumer wanting the regulator convention
+halves this one; the choice is not made here, since halving is not available in a general abelian
+group.
+
+The degree form on `End E` is the other: its polarisation is the trace form, and non-negativity of
+the degree gives the Hasse bound by Cauchy–Schwarz (Silverman, *The Arithmetic of Elliptic
+Curves*, V.1.2).
 
 Both take values in a torsion-free group — `ℝ` and `ℤ` respectively — so both satisfy the
 hypothesis below with room to spare. Stated for a general abelian group so that neither carries

--- a/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
@@ -50,7 +50,7 @@ For a torsion-free codomain it is one term: `smul_right_injective N two_ne_zero`
 * `TauCeti.QuadraticMap.map_zero_of_parallelogram`: `f 0 = 0`.
 * `TauCeti.QuadraticMap.map_neg_of_parallelogram`: `f (-x) = f x`.
 * `TauCeti.QuadraticMap.map_add_add_add_map_of_parallelogram`: the three-variable identity
-  `f (x + y + z) + (f x + f y + f z) = f (x + y) + f (y + z) + f (x + z)`, named after
+  `f (x + y + z) + (f x + f y + f z) = f (x + y) + f (y + z) + f (z + x)`, stated exactly as
   `QuadraticMap.map_add_add_add_map`.
 * `TauCeti.QuadraticMap.polar_add_left_of_parallelogram` and
   `polar_zsmul_left_of_parallelogram`: the polarisation is additive and `ℤ`-linear on the left.
@@ -110,13 +110,16 @@ theorem map_neg_of_parallelogram (x : M) : f (-x) = f x := by
   linear_combination (norm := module) h
 
 -- This is the substantive step: biadditivity of the polarisation below is a rearrangement of it.
--- Named after `QuadraticMap.map_add_add_add_map`, which is the same identity read off a quadratic
--- map instead of derived from the parallelogram law. The last summand is `f (x + z)` where that
--- lemma writes `f (z + x)`: commutativity inside an argument of an opaque `f` is not something
--- the normalisers can absorb, so the order the proof produces is the one stated.
+-- Stated exactly as `QuadraticMap.map_add_add_add_map`, the same identity read off a quadratic
+-- map instead of derived from the parallelogram law — `f (z + x)` included, which is what lets
+-- `polar_add_left_iff.mpr` consume it with no reshaping at the use site.
 /-- **The three-variable identity** satisfied by every quadratic form, in subtraction-free form. -/
 theorem map_add_add_add_map_of_parallelogram (x y z : M) :
-    f (x + y + z) + (f x + f y + f z) = f (x + y) + f (y + z) + f (x + z) := by
+    f (x + y + z) + (f x + f y + f z) = f (x + y) + f (y + z) + f (z + x) := by
+  -- `f (z + x)` is the goal's spelling but `f (x + z)` is what the instances below produce, and
+  -- commutativity inside an argument of an opaque `f` is invisible to `abel`, `module` and
+  -- `linear_combination`; pay for it once here rather than at every use site.
+  rw [show z + x = x + z from by abel]
   -- Four instances of the law. `x + z - y` and `x - (y - z)` are the same point, which is what
   -- lets the two occurrences of `f` at that point cancel; halving at the end is the only place
   -- torsion-freeness is used.
@@ -132,11 +135,11 @@ theorem map_add_add_add_map_of_parallelogram (x y z : M) :
   apply htwo
   linear_combination (norm := module) p1 + p4 - p2 - (2 : ℤ) • p3
 
+-- Exactly how Mathlib proves `QuadraticMap.polar_add_left` from `map_add_add_add_map`.
 /-- **The polarisation is additive in its left argument.** -/
 theorem polar_add_left_of_parallelogram (x x' y : M) :
-    polar f (x + x') y = polar f x y + polar f x' y := by
-  simp only [polar]
-  linear_combination (norm := module) map_add_add_add_map_of_parallelogram htwo hf x x' y
+    polar f (x + x') y = polar f x y + polar f x' y :=
+  polar_add_left_iff.mpr <| map_add_add_add_map_of_parallelogram htwo hf x x' y
 
 -- No new content: an additive map between abelian groups is automatically `ℤ`-linear, so this is
 -- `polar_add_left_of_parallelogram` transported. It is the last input `QuadraticMap.ofPolar` asks
@@ -179,7 +182,7 @@ theorem map_zsmul_of_parallelogram (n : ℤ) (x : M) : f (n • x) = (n * n) •
 -- the companion bilinear map itself, so no bilinear map is defined here.
 /-- **A function satisfying the parallelogram law is a quadratic form.** Its companion bilinear
 map is `QuadraticMap.polarBilin` of it, which is the polarisation. -/
-noncomputable def ofParallelogram : _root_.QuadraticMap ℤ M N :=
+def ofParallelogram : _root_.QuadraticMap ℤ M N :=
   .ofPolar f (map_zsmul_of_parallelogram htwo hf) (polar_add_left_of_parallelogram htwo hf)
     (polar_zsmul_left_of_parallelogram htwo hf)
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean
@@ -63,23 +63,16 @@ For a torsion-free codomain it is one term: `smul_right_injective N two_ne_zero`
   `QuadraticMap.ofPolar`. Its companion bilinear map is `QuadraticMap.polarBilin` of it, which is
   the polarisation.
 
-## Implementation notes
-
-The three-variable identity `map_add_add_of_parallelogram` is derived **doubled**: four instances
-of the parallelogram law combine to `2 • LHS = 2 • RHS`, and halving it is the only step in the
-file that uses anything of `N` at all. Everything after it — biadditivity, quadraticity, the
-packaged `QuadraticMap` — is a rearrangement or an induction over that identity.
-
 ## Where this is used
 
 Two constructions in arithmetic geometry arrive at a function *known to satisfy the parallelogram
 law* and want it as a quadratic form.
 
-The canonical height of an elliptic curve is one: `canonicalHeight_parallelogram_law` establishes
-the law exactly, and the Néron–Tate height pairing is then the polarisation supplied here — the
-bilinear map whose Gram determinant on a basis is the regulator. The degree form on `End E` is the
-other, where the polarisation is the trace form and its non-negativity gives the Hasse bound by
-Cauchy–Schwarz (Silverman, *AEC*, V.1.2).
+The canonical height of an elliptic curve is one. It satisfies the parallelogram law exactly, and
+its polarisation is the Néron–Tate height pairing — the bilinear map whose Gram determinant on a
+basis of the free part of the Mordell–Weil group is the regulator. The degree form on `End E` is
+the other: its polarisation is the trace form, and non-negativity of the degree gives the Hasse
+bound by Cauchy–Schwarz (Silverman, *The Arithmetic of Elliptic Curves*, V.1.2).
 
 Both take values in a torsion-free group — `ℝ` and `ℤ` respectively — so both satisfy the
 hypothesis below with room to spare. Stated for a general abelian group so that neither carries
@@ -100,14 +93,16 @@ variable {M N : Type*} [AddCommGroup M] [AddCommGroup N] {f : M → N}
 
 include htwo hf
 
-/-- The parallelogram law at `x = y = 0` forces `f 0 = 0`. -/
+-- The parallelogram law at `x = y = 0`.
+/-- **A parallelogram-law function preserves zero.** -/
 theorem map_zero_of_parallelogram : f 0 = 0 := by
   have h := hf 0 0
   simp only [add_zero, sub_zero] at h
   apply htwo
   linear_combination (norm := module) -h
 
-/-- The parallelogram law at `x = 0` forces `f` to be even. -/
+-- The parallelogram law at `x = 0`.
+/-- **A parallelogram-law function is even.** -/
 theorem map_neg_of_parallelogram (x : M) : f (-x) = f x := by
   have h := hf 0 x
   rw [zero_add, zero_sub, map_zero_of_parallelogram htwo hf] at h


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"quadratic-of-parallelogram"}-->

## The target

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 6 names, among the canonical-height milestones,
"the **Néron–Tate bilinear pairing**". The pairing *is* the polarisation of the canonical height,
and the height is known to satisfy the parallelogram law before it is known to be quadratic — that
is exactly what `canonicalHeight_parallelogram_law` (#5601) delivers. Getting from there to a
bilinear pairing is this PR, stated for a general abelian group rather than for the height alone.

The same shape recurs at §Layer 3 (AEC V.1.2) for the degree form on `End E` behind the Hasse
bound, which is why it is worth having once rather than twice.

## What it adds

```lean
theorem map_zero_of_parallelogram : f 0 = 0
theorem map_neg_of_parallelogram (x : M) : f (-x) = f x

theorem map_add_add_of_parallelogram (x y z : M) :
    f (x + y + z) + f x + f y + f z = f (x + y) + f (y + z) + f (x + z)

theorem polar_add_left_of_parallelogram (x x' y : M) :
    polar f (x + x') y = polar f x y + polar f x' y
theorem polar_zsmul_left_of_parallelogram (a : ℤ) (x y : M) :
    polar f (a • x) y = a • polar f x y

theorem map_zsmul_of_parallelogram (n : ℤ) (x : M) : f (n • x) = (n * n) • f x

noncomputable def ofParallelogram : QuadraticMap ℤ M N
theorem coe_ofParallelogram : (ofParallelogram htwo hf : M → N) = f
```

throughout for `f : M → N` between additive commutative groups, with
`hf : ∀ x y, f (x + y) + f (x - y) = 2 • f x + 2 • f y` and `htwo : IsSMulRegular N 2`.

`f 0 = 0` and evenness are **not** assumed — the law gives both, which matters because a consumer
holding only the parallelogram law should not have to prove them separately.

## The mathematical content is one identity

Everything reduces to

```
f (x + y + z) + f x + f y + f z = f (x + y) + f (y + z) + f (x + z)
```

obtained from four instances of the law, at `(x + y, z)`, `(x, y - z)`, `(y, z)` and `(x + z, y)`.
The point that makes it work is that `x - (y - z)` and `x + z - y` are the same point, so the two
values of `f` there cancel. Biadditivity of the polarisation is then a rearrangement — one
`linear_combination` — and `map_zsmul` is the law read as a two-step recursion
(`Nat.twoStepInduction`), the negative case composed with evenness.

## The hypothesis is exactly the absence of 2-torsion

The identity above comes out **doubled**: the four instances combine to `2 • LHS = 2 • RHS`, and
halving is the only step in the file that uses anything of `N` at all. So the hypothesis is
`IsSMulRegular N 2` — doubling is injective — and nothing stronger.

It is deliberately **not** `IsAddTorsionFree N`. An earlier revision of this PR used that, and
`correctness` was right to block it: torsion-freeness is strictly stronger than the proofs consume
and excludes codomains where the construction is valid. `IsSMulRegular (ZMod 3) 2` holds although
`ZMod 3` has 3-torsion, so the old form ruled out a case that works.

Nor can it be dropped. With `M = N = ZMod 2` *every* function satisfies the parallelogram law,
since `x - y = x + y` and `2 • z = 0` there, so the constant function `1` satisfies it while
failing even `f 0 = 0` — which every `QuadraticMap` obeys — and correspondingly
`¬ IsSMulRegular (ZMod 2) 2`.

For a torsion-free codomain the hypothesis is one term, `smul_right_injective N two_ne_zero`,
which covers `N = ℝ` (the canonical height) and `N = ℤ` (the degree form).

**All four of those claims are checked by compiled probe**, not asserted: the two derivations, the
`ZMod 3` case, and the `ZMod 2` counterexample.

## Reuse

`QuadraticMap.ofPolar` is Mathlib's constructor for exactly this situation: it asks for
`toFun_smul`, `polar_add_left` and `polar_smul_left`, and assembles the companion bilinear map
itself. An earlier revision of this PR hand-rolled that assembly — a `polarAddHomRight`/
`polarBilinInt` pair plus a raw structure literal — and `reuse` was right to block it. Using
`ofPolar` removed five declarations: the bilinear map is `QuadraticMap.polarBilin` of the result,
and additivity of `polar` on the *right* is `QuadraticMap.polar_add_right` of it, so neither is
restated here.

The one input beyond additivity is `ℤ`-linearity of `polar` on the left, and that is free: an
additive map between abelian groups is automatically `ℤ`-linear, so
`polar_zsmul_left_of_parallelogram` is `AddMonoidHom.map_zsmul` applied to the additivity already
proved.

`coe_ofParallelogram` is stated at the level of *functions*, not just pointwise, because
`QuadraticMap.polar` takes the function as its argument — that is the form needed to rewrite
`polar ⇑(ofParallelogram …)` into `polar f` and reach Mathlib's polar API at all. A downstream
probe failed without it, which is how it was found.

**Mathlib has the converse direction only.** `QuadraticMap.polar_add_left` and friends read
biadditivity *off* an existing `QuadraticMap`, and `LinearMap.BilinMap.toQuadraticMap` builds one
from a bilinear map. Its `parallelogram_law` and `parallelogram_law_with_norm` are inner-product-space
statements, and the Jordan–von Neumann construction in `Analysis/InnerProductSpace/OfNorm.lean`
recovers an inner product from a *norm* on a real or complex space using continuity — none of which
applies to a function on a bare abelian group. Checked with a compiled `exact?` probe on the
biadditivity goal, which fails, as well as by grep.

## Relation to #5612

#5612 proves `canonicalHeight_nsmul` / `canonicalHeight_zsmul` by a bespoke `Nat.twoStepInduction`
on the height. Once both land, that becomes an instance of `map_zsmul_of_parallelogram`, and
#5612 — still a draft — should be rewritten to take it from here. Flagging it rather than leaving
two copies of the induction to be discovered later. This PR does not touch the height files.

## Placement

`TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean`, mirroring Mathlib's
`Mathlib/LinearAlgebra/QuadraticForm/Basic.lean` where `polar` and `QuadraticMap` live. There is no
elliptic-curve content: the motivation is the EllipticCurves roadmap (hence the `Roadmap:` line and
the citation above), but the statements mention only abelian groups.

## Provenance

**Original work.** Neither pinned source has it. AINTLIB `HasseWeil` @ `513e83879e2f` treats degree
quadraticity witness-parametrically in `HasseWeil/DegreeQuadraticForm.lean` and never mentions the
parallelogram law (`grep -niE 'parallelogram'` over that file returns nothing);
MichaelStollBayreuth/EllipticCurves has only `approx_parallelogram_law`, the bounded-error version
for the naïve height, which is already on `main`.

Absence checked before writing: `grep -rniE 'ofParallelogram|of_parallelogram'` over the pinned
Mathlib returns nothing relevant, `grep -rn 'parallelogram'` returns only the five
inner-product-space lemmas in `Analysis/InnerProductSpace/Basic.lean`, and the compiled `exact?`
probe above fails on the biadditivity goal. No open PR carries an overlapping `tauceti-target`
marker (97 examined); the `parallelogram`/`QuadraticMap` text matches are my own height stack
(#5600, #5601, #5612) and two unrelated PRs (#5473 type-D spin, #4755 `ℚ/ℤ`-valued quadratic
modules on `ZMod n` from an explicit formula).

## Gates

- `lake build`: green, 0 errors, 0 warnings under `warningAsError = true`, no Mathlib recompiled.
  New leaf module, no reverse dependencies.
- **`#lint in TauCeti` — the full environment-linter set, not just simpNF**: "All linting checks
  passed", 0 errors in 10 declarations.
- `scripts/lint-style.sh`: exit 0, all headers conforming; no line over 100 characters.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; longest proof 13 lines.
- Claim at `refs/tauceti-claims/author/EllipticCurves/quadratic-of-parallelogram`.

Two notes on how the proofs are written, both forced rather than chosen. `linear_combination
(norm := module)` is what combines group-valued hypotheses — the goals live in an `AddCommGroup`,
not a ring, so plain `linear_combination` does not apply. And `polarBilinInt_apply` and
`ofParallelogram_apply` are proved by `simp` rather than `rfl`: an *exported* `rfl` theorem requires
every definition it unfolds to be `@[expose]`d, and a tactic proof exports a proof term instead of a
defeq obligation, so the definitions stay unexposed.



## On the pairing's normalisation

`documentation` caught a real imprecision worth keeping in the record: the applications note called
the polarisation *the* Néron–Tate pairing, and it is that only **up to a factor of two**.
`QuadraticMap.polar_self` gives `polar f x x = 2 • f x`, while the pairing whose Gram determinant is
the regulator is normalised so `⟨P, P⟩` is the height itself. The docstring now says so, and cites
that lemma as the anchor.

Nothing is halved here, deliberately: halving is not available in a general abelian group, which is
the whole setting of the file. The consumer that wants the regulator convention halves it, in `ℝ`
where it can.

A factor of two in exactly this place is what `correctness` blocked on #5600, so the claim is
checked against Mathlib rather than asserted.
