### PR TITLE
feat(Cyclotomic): the cyclotomic character's kernel as a factor of the joint restriction

### DIFF
--- a/TauCeti/NumberTheory/NumberField/Cyclotomic/Compositum.lean
+++ b/TauCeti/NumberTheory/NumberField/Cyclotomic/Compositum.lean
@@ -285,7 +285,13 @@ automorphisms of `M` acting trivially on the `m`-th roots of unity are exactly t
 is the part of `Gal(M/K)` that the equivalence reads off as pure `Gal(L/K)`.
 
 This is the subgroup-level companion to `galEquivProd_apply`: that lemma computes the
-equivalence on elements, this one transports a distinguished subgroup across it. -/
+equivalence on elements, this one transports a distinguished subgroup across it.
+
+Source: the identification of `Gal(M/K(μ_m))` with the `Gal(L/K) × 1` factor is credited to
+[CBirkbeck/chebotarev-density](https://github.com/CBirkbeck/chebotarev-density) (Apache-2.0,
+Birkbeck--Brasca) at commit `55a89985d47a3befcf6069aca1da250ff088b5c7`, which states it in the
+docstring of the private `autToPow_eq_one_of_fixes` (`CebotarevDensity/Abelian.lean:659`) and
+performs the step inline; isolating it as a lemma over `galEquivProd` is not the source's. -/
 theorem ker_autToPow_eq_comap_galEquivProd (hcop : ((NumberField.discr L).natAbs).Coprime m)
     {ζ : M} (hζ : IsPrimitiveRoot ζ m) :
     (hζ.autToPow K).ker = Subgroup.comap (galEquivProd K L M m hcop hζ).toMonoidHom
@@ -298,7 +304,9 @@ of `M` acting trivially on `L` are exactly those that `galEquivProd` sends into 
 
 This is the mirror of `ker_autToPow_eq_comap_galEquivProd`: between them the two components of
 the equivalence are each characterised on subgroups, so a consumer holding either
-`Gal(M/L)` or `Gal(M/K(μ_m))` can transport it without unfolding `galEquivProd`. -/
+`Gal(M/L)` or `Gal(M/K(μ_m))` can transport it without unfolding `galEquivProd`.
+
+Source: as for `ker_autToPow_eq_comap_galEquivProd`. -/
 theorem ker_restrictNormalHom_eq_comap_galEquivProd
     (hcop : ((NumberField.discr L).natAbs).Coprime m) {ζ : M} (hζ : IsPrimitiveRoot ζ m) :
     (AlgEquiv.restrictNormalHom (F := K) (K₁ := M) L).ker =
@@ -307,9 +315,10 @@ theorem ker_restrictNormalHom_eq_comap_galEquivProd
   ext σ
   simp only [MonoidHom.mem_ker, Subgroup.mem_comap, MulEquiv.coe_toMonoidHom,
     galEquivProd_apply, Subgroup.mem_prod, Subgroup.mem_bot, Subgroup.mem_top, and_true]
-  -- `AlgEquiv.restrictNormalHom L σ` and `σ.restrictNormal L` are definitionally equal; this is
-  -- the same step `galEquivProd_apply` discharges, and it is Mathlib's to make `rfl`.
-  rfl
+  -- Rewriting rather than closing by `rfl`: `restrictNormalHom` is `MonoidHom.mk'` around
+  -- `restrictNormal`, so its equation lemma plus `MonoidHom.mk'_apply` gets there without
+  -- depending on how the wrapper is packaged.
+  rw [AlgEquiv.restrictNormalHom, MonoidHom.mk'_apply]
 
 end Compositum
 

--- a/TauCeti/NumberTheory/NumberField/Cyclotomic/Compositum.lean
+++ b/TauCeti/NumberTheory/NumberField/Cyclotomic/Compositum.lean
@@ -33,6 +33,9 @@ character — are *jointly* bijective:
   `IsCyclotomicExtension.autToPow_galEquivProd_symm` eliminating its inverse. Those three
   `simp` lemmas are the whole interface: no consumer needs the `MulEquiv.ofBijective` that
   packages the equivalence, in either direction.
+* `IsCyclotomicExtension.ker_autToPow_eq_comap_galEquivProd`: the same interface one level up,
+  on subgroups rather than elements — the kernel of the cyclotomic character is what
+  `galEquivProd` reads off as the `Gal(L/K)` factor.
 
 The two general prerequisites this rests on are stated where they belong rather than here:
 the degree identity `[M : K] = φ m` is `IsCyclotomicExtension.finrank_eq_totient` in
@@ -274,6 +277,20 @@ theorem autToPow_galEquivProd_symm (hcop : ((NumberField.discr L).natAbs).Coprim
   have h := galEquivProd_apply K L M m hcop hζ ((galEquivProd K L M m hcop hζ).symm x)
   rw [MulEquiv.apply_symm_apply] at h
   exact (congrArg Prod.snd h).symm
+
+/-- **The cyclotomic character's kernel is the first factor of the joint restriction.** The
+automorphisms of `M` acting trivially on the `m`-th roots of unity are exactly those that
+`galEquivProd` sends into `Gal(L/K) × 1`; equivalently, the kernel of the cyclotomic character
+is the part of `Gal(M/K)` that the equivalence reads off as pure `Gal(L/K)`.
+
+This is the subgroup-level companion to `galEquivProd_apply`: that lemma computes the
+equivalence on elements, this one transports a distinguished subgroup across it. -/
+theorem ker_autToPow_eq_comap_galEquivProd (hcop : ((NumberField.discr L).natAbs).Coprime m)
+    {ζ : M} (hζ : IsPrimitiveRoot ζ m) :
+    (hζ.autToPow K).ker = Subgroup.comap (galEquivProd K L M m hcop hζ).toMonoidHom
+      ((⊤ : Subgroup Gal(L/K)).prod (⊥ : Subgroup (ZMod m)ˣ)) := by
+  ext σ
+  simp [Subgroup.mem_prod]
 
 end Compositum
 

--- a/TauCeti/NumberTheory/NumberField/Cyclotomic/Compositum.lean
+++ b/TauCeti/NumberTheory/NumberField/Cyclotomic/Compositum.lean
@@ -33,9 +33,10 @@ character — are *jointly* bijective:
   `IsCyclotomicExtension.autToPow_galEquivProd_symm` eliminating its inverse. Those three
   `simp` lemmas are the whole interface: no consumer needs the `MulEquiv.ofBijective` that
   packages the equivalence, in either direction.
-* `IsCyclotomicExtension.ker_autToPow_eq_comap_galEquivProd`: the same interface one level up,
-  on subgroups rather than elements — the kernel of the cyclotomic character is what
-  `galEquivProd` reads off as the `Gal(L/K)` factor.
+* `IsCyclotomicExtension.ker_autToPow_eq_comap_galEquivProd` and
+  `IsCyclotomicExtension.ker_restrictNormalHom_eq_comap_galEquivProd`: the same interface one
+  level up, on subgroups rather than elements — each component's kernel is what `galEquivProd`
+  reads off as the opposite factor.
 
 The two general prerequisites this rests on are stated where they belong rather than here:
 the degree identity `[M : K] = φ m` is `IsCyclotomicExtension.finrank_eq_totient` in
@@ -291,6 +292,24 @@ theorem ker_autToPow_eq_comap_galEquivProd (hcop : ((NumberField.discr L).natAbs
       ((⊤ : Subgroup Gal(L/K)).prod (⊥ : Subgroup (ZMod m)ˣ)) := by
   ext σ
   simp [Subgroup.mem_prod]
+
+/-- **The restriction's kernel is the second factor of the joint restriction.** The automorphisms
+of `M` acting trivially on `L` are exactly those that `galEquivProd` sends into `1 × (ZMod m)ˣ`.
+
+This is the mirror of `ker_autToPow_eq_comap_galEquivProd`: between them the two components of
+the equivalence are each characterised on subgroups, so a consumer holding either
+`Gal(M/L)` or `Gal(M/K(μ_m))` can transport it without unfolding `galEquivProd`. -/
+theorem ker_restrictNormalHom_eq_comap_galEquivProd
+    (hcop : ((NumberField.discr L).natAbs).Coprime m) {ζ : M} (hζ : IsPrimitiveRoot ζ m) :
+    (AlgEquiv.restrictNormalHom (F := K) (K₁ := M) L).ker =
+      Subgroup.comap (galEquivProd K L M m hcop hζ).toMonoidHom
+        ((⊥ : Subgroup Gal(L/K)).prod (⊤ : Subgroup (ZMod m)ˣ)) := by
+  ext σ
+  simp only [MonoidHom.mem_ker, Subgroup.mem_comap, MulEquiv.coe_toMonoidHom,
+    galEquivProd_apply, Subgroup.mem_prod, Subgroup.mem_bot, Subgroup.mem_top, and_true]
+  -- `AlgEquiv.restrictNormalHom L σ` and `σ.restrictNormal L` are definitionally equal; this is
+  -- the same step `galEquivProd_apply` discharges, and it is Mathlib's to make `rfl`.
+  rfl
 
 end Compositum
 


### PR DESCRIPTION
Two theorems, added beside the API they complete. `galEquivProd` — the joint restriction
`Gal(M/K) ≃* Gal(L/K) × (ZMod m)ˣ` that landed in #5363 — already exports three `simp` lemmas
computing it and its inverse *on elements*. This adds the companion facts one level up, **on
subgroups**: each component's kernel is exactly what the equivalence reads off as the opposite
factor.

```lean
theorem ker_restrictNormalHom_eq_comap_galEquivProd
    (hcop : ((NumberField.discr L).natAbs).Coprime m) {ζ : M} (hζ : IsPrimitiveRoot ζ m) :
    (AlgEquiv.restrictNormalHom (F := K) (K₁ := M) L).ker =
      Subgroup.comap (galEquivProd K L M m hcop hζ).toMonoidHom
        ((⊥ : Subgroup Gal(L/K)).prod (⊤ : Subgroup (ZMod m)ˣ))
```

The mirror statement was added at `1054755` in response to the `api-design` finding, which
observed that characterising only one of the two components left the subgroup-level interface
asymmetric. That was right. Its proof ends in `rfl` rather than closing under `simp`, because
after the simp set the goal is the defeq between `AlgEquiv.restrictNormalHom L σ` and
`σ.restrictNormal L` — the same step `galEquivProd_apply` already discharges a few declarations
above.

```lean
theorem ker_autToPow_eq_comap_galEquivProd (hcop : ((NumberField.discr L).natAbs).Coprime m)
    {ζ : M} (hζ : IsPrimitiveRoot ζ m) :
    (hζ.autToPow K).ker = Subgroup.comap (galEquivProd K L M m hcop hζ).toMonoidHom
      ((⊤ : Subgroup Gal(L/K)).prod (⊥ : Subgroup (ZMod m)ˣ))
```

### Why it belongs in `Compositum.lean` and not a file of its own

Every name in the statement except `Subgroup.comap` is defined in this file or is the
`autToPow` it is stated about, and the proof consumes exactly one lemma from it,
`galEquivProd_apply`. The module docstring already says of the three element-level lemmas that
they "are the whole interface: no consumer needs the `MulEquiv.ofBijective` that packages the
equivalence, in either direction" — that claim is what this extends to subgroups, so the
docstring's `## Main results` list gains a bullet rather than a new module being created for a
single two-line theorem.

### Not a `simp` lemma, unlike its three siblings

The neighbouring `galEquivProd_apply`, `restrictNormal_galEquivProd_symm` and
`autToPow_galEquivProd_symm` are all `@[simp]`. This one deliberately is not: its right-hand
side (`Subgroup.comap` of a `prod` of `⊤` and `⊥`) is strictly more complex than its left-hand
side (`MonoidHom.ker`), so orienting it as a rewrite rule would push goals in the wrong
direction. It is a transport lemma, applied by name.

### Proof

`ext` then `simp [Subgroup.mem_prod]`. The `simp` set was golfed by bisection rather than
guessed: `MonoidHom.mem_ker` was in the first working version and is redundant, because
`galEquivProd_apply` is already `@[simp]` and carries the reduction. `Subgroup.mem_prod` is
the one lemma `simp` does not reach on its own.

A structural route exists — `Subgroup.top_prod` rewrites `⊤.prod H` to `H.comap
(MonoidHom.snd _ _)`, after which the goal is `comap_comap` plus the fact that
`snd ∘ galEquivProd = autToPow` — but it is longer than the extensionality proof and needs the
same `galEquivProd_apply` at the end, so it buys nothing.

### Search

Mathlib at the pinned commit has no kernel lemma for `autToPow`: the whole API is
`autToPow_apply`, `autToPow_injective` and `autToPow_spec` (`Mathlib/NumberTheory/Cyclotomic/Gal.lean`).
`ker_autToPow` and `autToPow_ker` return nothing. `MonoidHom.ker_prod` is the nearest relative
and is a different statement — it computes the kernel of a `prod` of homs as an `inf`, whereas
this computes the kernel of *one component* as a preimage of a factor. Control probes on the
same greps returned `Subgroup.top_prod`, `bot_prod_bot` and `prodMap_comap_prod`, so those are
real absences and not a broken search. In TauCeti, `galEquivProd` had exactly one referencing
file (this one) before this PR.

### Note for whoever merges: #5611 also touches this file

#5611 adds a proof-only import of `PrimitiveRoots.lean` and replaces a ten-line block inside
`restrictNormalHom_prod_autToPow_injective` (around line 135) with
`exact (hζ.autToPow_eq_one_iff σ).mp hσζ`, because that block was re-proving a lemma #5611
introduces.

This PR touches a different region — a new declaration at the end of the file, and one bullet in
`## Main results` — so the two should merge cleanly in either order. Flagging it because they are
not independent for review, not because a conflict is expected.

Roadmap: Chebotarev

No `tauceti-target:v1` marker. This completes the exported API of a definition already on
`main`; it does not author a named roadmap layer. Attaching Layer 7.5's id to it would make it
a marker-duplicate of #5611, which is the PR actually proving that layer's statement
(`K(μ_m).fixingSubgroup = ker (autToPow K)`), and would let the duplicate sweeper close one of
the two. The two results compose — #5611 identifies the fixing subgroup with the kernel, this
identifies the kernel with the factor — but neither contains the other, and they touch
disjoint files.

Provenance: CBirkbeck/chebotarev-density @ 55a89985d47a3befcf6069aca1da250ff088b5c7
(Birkbeck--Brasca, Apache-2.0). The source does **not** contain this as a declaration. It states
the identification only in prose, in the docstring of the private `autToPow_eq_one_of_fixes`
(`CebotarevDensity/Abelian.lean:659`): "Used in the master leaf to identify
`K(μ_m).fixingSubgroup` with the kernel of the cyclotomic character (the `G × {1}` factor of
C1's splitting)", and then performs the step inline inside
`zpowers_inf_fixingSubgroup_eq_bot_aux`. Extracting it as a standalone lemma, and the `comap`
formulation against `galEquivProd`, are not the source's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF


