### PR TITLE
feat(CanonicalHeight): the canonical height is non-negative

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -46,6 +46,8 @@ with — is half of it. Getting this wrong would scale every later invariant.
   height was approximating.
 * `WeierstrassCurve.Affine.Point.canonicalHeight_two_nsmul`: the doubling normal form
   `canonicalHeight (2 • P) = 4 * canonicalHeight P`, the parallelogram law at `Q = P`.
+* `WeierstrassCurve.Affine.Point.canonicalHeight_nonneg`: it is non-negative, read off the
+  defining sequence termwise.
 * `WeierstrassCurve.Affine.Point.abs_canonicalHeight_sub_naiveHeight_le`: the canonical height stays
   within a bounded distance of *half* the naïve one, by a
   constant depending only on the curve. This is what makes the two interchangeable in
@@ -225,5 +227,12 @@ theorem Point.canonicalHeight_two_nsmul [W.toAffine.IsElliptic] (P : W.Point) :
   rw [sub_self, canonicalHeight_zero, add_zero] at h
   rw [two_nsmul]
   linarith
+/-- **The canonical height is non-negative.** Every term of the defining sequence is a quotient of
+non-negative quantities, so the limit is non-negative; no passage through the bounded difference
+from `h` is needed. -/
+theorem Point.canonicalHeight_nonneg [W.toAffine.IsElliptic] (P : W.Point) :
+    0 ≤ P.canonicalHeight :=
+  ge_of_tendsto' P.tendsto_naiveHeight_two_pow_nsmul_div_four_pow fun n ↦
+    div_nonneg (Point.naiveHeight_nonneg _) (by positivity)
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -227,9 +227,12 @@ theorem Point.canonicalHeight_two_nsmul [W.toAffine.IsElliptic] (P : W.Point) :
   rw [sub_self, canonicalHeight_zero, add_zero] at h
   rw [two_nsmul]
   linarith
-/-- **The canonical height is non-negative.** Every term of the defining sequence is a quotient of
-non-negative quantities, so the limit is non-negative; no passage through the bounded difference
-from `h` is needed. -/
+-- Read off the defining sequence termwise: each term is a quotient of non-negative quantities.
+-- The bounded difference from `h` would only give `canonicalHeight P ≥ -C/6`, so it is not used.
+/-- **The canonical height is non-negative.** This is what makes it a candidate for the
+positive-definite form behind the Néron–Tate pairing and the regulator, and what lets
+`canonicalHeight P = 0` be a meaningful characterisation of torsion rather than one inequality
+among two. -/
 theorem Point.canonicalHeight_nonneg [W.toAffine.IsElliptic] (P : W.Point) :
     0 ≤ P.canonicalHeight :=
   ge_of_tendsto' P.tendsto_naiveHeight_two_pow_nsmul_div_four_pow fun n ↦

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/FinitelyGenerated.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/FinitelyGenerated.lean
@@ -92,11 +92,9 @@ theorem fg_point (R : Type*) [CommRing R] [IsDedekindDomain R] [Algebra R F]
     [(p : W.f.Factors) → Finite (ClassGroup (W.ringOfIntegersFactor R p))]
     [(p : W.f.Factors) → Monoid.FG (W.ringOfIntegersFactor R p)ˣ] :
     AddGroup.FG W.Point := by
-  have H₂ (P : W.Point) : 0 ≤ P.naiveHeight := by
-    rw [Point.naiveHeight_eq_logHeight P]
-    positivity
   obtain ⟨C, hC⟩ := approx_parallelogram_law W
-  exact AddCommGroup.fg_of_descent' (W.finiteIndex_range_nsmulAddMonoidHom_two R) H₂ hC
+  exact AddCommGroup.fg_of_descent' (W.finiteIndex_range_nsmulAddMonoidHom_two R)
+    Point.naiveHeight_nonneg hC
 
 /-- **The Mordell–Weil theorem** for an arbitrary Weierstrass curve: `E(K)` is finitely generated,
 given an admissible change of variables `C` bringing `E` into the normal form `y² = f(x)`,

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/NaiveHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/NaiveHeight.lean
@@ -106,6 +106,11 @@ lemma Point.naiveHeight_eq_logHeight₁ {P : W.Point} :
   | 0 => simp [naiveHeight, xRep]
   | some .. => simpa [naiveHeight] using (logHeight₁_eq_logHeight _).symm
 
+/-- **The naïve height is non-negative**, being a logarithmic height. -/
+lemma Point.naiveHeight_nonneg (P : W.Point) : 0 ≤ P.naiveHeight := by
+  rw [naiveHeight_eq_logHeight]
+  positivity
+
 /-- The point at infinity has height zero: its representative is `![1, 0]`. -/
 @[simp]
 lemma Point.naiveHeight_zero : (0 : W.Point).naiveHeight = 0 := by


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"canonical-height"}-->

## The target

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 6 lists the canonical-height milestones in order:

> construction of `ĥ` with bounded difference from the naïve height, quadraticity,
> **nonnegativity**, `ĥ(P) = 0 ↔ P` torsion, the Néron–Tate bilinear pairing, …

The first has landed (#5600). This is the third, and it is independent of the second: it needs
only the defining limit, not the parallelogram law.

## What it adds

```lean
lemma Point.naiveHeight_nonneg (P : W.Point) : 0 ≤ P.naiveHeight

theorem Point.canonicalHeight_nonneg [W.toAffine.IsElliptic] (P : W.Point) :
    0 ≤ P.canonicalHeight
```

Two lines of proof. Every term of the defining sequence is `naiveHeight (2ⁿ • P) / (2 · 4ⁿ)`, a
quotient of non-negative quantities, so `ge_of_tendsto'` applied to
`tendsto_naiveHeight_two_pow_nsmul_div_four_pow` gives the limit directly. In particular the
bounded difference from `h` is *not* used — that route would only give `ĥ ≥ -C/6`.

## The naïve half is named, not re-derived

`0 ≤ P.naiveHeight` was already being derived, inline, inside `FinitelyGenerated.fg_point`:

```lean
have H₂ (P : W.Point) : 0 ≤ P.naiveHeight := by
  rw [Point.naiveHeight_eq_logHeight P]
  positivity
```

With this PR there are two consumers, so it becomes `Point.naiveHeight_nonneg` next to
`naiveHeight_zero` and `naiveHeight_neg` in `NaiveHeight.lean`, and `fg_point` passes it directly
instead of building a local copy — three lines shorter there, and one derivation rather than two.

Naming it is what makes it worth doing; a single-use version would be the thin specialisation this
project deletes on sight. It is deliberately not `@[simp]`: `positivity` already discharges the
goal, so a simp lemma would be redundant surface.

## Reuse

`ge_of_tendsto'`, `div_nonneg` and `positivity`'s `logHeight` extension are Mathlib's; the two
inputs from this development are `tendsto_naiveHeight_two_pow_nsmul_div_four_pow` (#5600) and
`naiveHeight_eq_logHeight` (already on `main`). No new machinery.

Absence checked before writing: `git grep -n 'naiveHeight_nonneg\|canonicalHeight_nonneg'` over
TauCeti `main` returns nothing, and `grep -rn 'logHeight_nonneg'` over the pinned Mathlib finds the
scalar and projective versions this ultimately rests on but nothing about either height here.

## Placement

The naïve lemma goes with the other basic values of `naiveHeight`, in
`MordellWeil/NaiveHeight.lean`; the canonical one goes in `EllipticCurve/CanonicalHeight.lean`,
the file #5600 created. `FinitelyGenerated.lean` is touched only to consume the named lemma.

## Provenance

**Original work.** The chain's intake records that the Néron–Tate height has no source: it is the
one Layer 6 item with nothing to port. `MichaelStollBayreuth/EllipticCurves` has the naïve height
and its approximate parallelogram law, both already on `main`, and no canonical height.

## Gates

- `lake build`: green, 0 errors, 0 warnings under `warningAsError = true`, no Mathlib recompiled.
  Both reverse dependencies of the touched files rebuild clean.
- **`#lint in TauCeti` — the full environment-linter set**: "All linting checks passed", 0 errors in
  668 declarations.
- `scripts/lint-style.sh`: exit 0, all 4334 headers conforming; no line over 100 characters.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; `+16/−4` across 3 files.
- Claim at `refs/tauceti-claims/author/EllipticCurves/canonical-height-nonneg`.
