### PR TITLE
feat: add supernatural order of profinite groups

### DIFF
--- a/TauCeti/Topology/Algebra/Group/OpenNormalSubgroup.lean
+++ b/TauCeti/Topology/Algebra/Group/OpenNormalSubgroup.lean
@@ -35,10 +35,28 @@ def comap (U : OpenNormalSubgroup H) (f : G →* H) (hf : Continuous f) :
   toOpenSubgroup := U.toOpenSubgroup.comap f hf
   isNormal' := U.isNormal'.comap f
 
+/-- The preimage of an open normal subgroup as a set. -/
+@[simp, norm_cast]
+theorem coe_comap (U : OpenNormalSubgroup H) (f : G →* H) (hf : Continuous f) :
+    (comap U f hf : Set G) = f ⁻¹' U :=
+  (rfl)
+
 /-- The underlying subgroup of the preimage of an open normal subgroup. -/
 @[simp]
 theorem toSubgroup_comap (U : OpenNormalSubgroup H) (f : G →* H)
     (hf : Continuous f) : (comap U f hf).toSubgroup = U.toSubgroup.comap f :=
+  (rfl)
+
+/-- Membership in the preimage of an open normal subgroup. -/
+@[simp]
+theorem mem_comap {U : OpenNormalSubgroup H} {f : G →* H} {hf : Continuous f} {g : G} :
+    g ∈ comap U f hf ↔ f g ∈ U :=
+  Iff.rfl
+
+/-- Taking the preimage of an open normal subgroup twice is the preimage under the composite. -/
+theorem comap_comap {K : Type*} [Group K] [TopologicalSpace K] (U : OpenNormalSubgroup K)
+    (f₂ : H →* K) (hf₂ : Continuous f₂) (f₁ : G →* H) (hf₁ : Continuous f₁) :
+    comap (comap U f₂ hf₂) f₁ hf₁ = comap U (f₂.comp f₁) (hf₂.comp hf₁) :=
   (rfl)
 
 end OpenNormalSubgroup

--- a/TauCeti/Topology/Algebra/Group/OpenNormalSubgroup.lean
+++ b/TauCeti/Topology/Algebra/Group/OpenNormalSubgroup.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.OpenSubgroup
+
+/-!
+# Constructions of open normal subgroups
+
+Two bundled constructions of `OpenNormalSubgroup` that Mathlib provides for `OpenSubgroup`
+but not for its normal variant: the preimage under a continuous group homomorphism, and the
+trivial subgroup of a group with the discrete topology. Both are stated for an arbitrary
+topological space structure on a group; no continuity of the group operations is required.
+
+## Main definitions
+
+* `OpenNormalSubgroup.comap`: the preimage of an open normal subgroup under a continuous
+  group homomorphism.
+* `TauCeti.openNormalSubgroupBot`: the trivial subgroup of a group with the discrete
+  topology, as an open normal subgroup.
+-/
+
+public section
+
+namespace OpenNormalSubgroup
+
+variable {G H : Type*} [Group G] [TopologicalSpace G] [Group H] [TopologicalSpace H]
+
+/-- The preimage of an open normal subgroup under a continuous group homomorphism. -/
+def comap (U : OpenNormalSubgroup H) (f : G →* H) (hf : Continuous f) :
+    OpenNormalSubgroup G where
+  toOpenSubgroup := U.toOpenSubgroup.comap f hf
+  isNormal' := U.isNormal'.comap f
+
+/-- The underlying subgroup of the preimage of an open normal subgroup. -/
+@[simp]
+theorem toSubgroup_comap (U : OpenNormalSubgroup H) (f : G →* H)
+    (hf : Continuous f) : (comap U f hf).toSubgroup = U.toSubgroup.comap f :=
+  (rfl)
+
+end OpenNormalSubgroup
+
+namespace TauCeti
+
+/-- The trivial subgroup of a group with the discrete topology, as an open normal subgroup. -/
+def openNormalSubgroupBot (G : Type*) [Group G] [TopologicalSpace G] [DiscreteTopology G] :
+    OpenNormalSubgroup G where
+  toOpenSubgroup := ⟨⊥, isOpen_discrete _⟩
+  isNormal' := inferInstance
+
+/-- The underlying subgroup of `openNormalSubgroupBot` is `⊥`. -/
+@[simp]
+theorem openNormalSubgroupBot_toSubgroup (G : Type*) [Group G] [TopologicalSpace G]
+    [DiscreteTopology G] : (openNormalSubgroupBot G).toSubgroup = ⊥ :=
+  (rfl)
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
@@ -47,6 +47,38 @@ public section
 
 namespace TauCeti
 
+namespace OpenNormalSubgroup
+
+variable {G H : Type*} [Group G] [TopologicalSpace G] [Group H] [TopologicalSpace H]
+
+/-- The preimage of an open normal subgroup under a continuous group homomorphism. -/
+@[expose]
+def comap (U : _root_.OpenNormalSubgroup H) (f : G →* H) (hf : Continuous f) :
+    _root_.OpenNormalSubgroup G where
+  toOpenSubgroup := U.toOpenSubgroup.comap f hf
+  isNormal' := U.isNormal'.comap f
+
+/-- The underlying subgroup of the preimage of an open normal subgroup. -/
+@[simp]
+theorem toSubgroup_comap (U : _root_.OpenNormalSubgroup H) (f : G →* H)
+    (hf : Continuous f) : (comap U f hf).toSubgroup = U.toSubgroup.comap f :=
+  rfl
+
+/-- The trivial open normal subgroup of a discrete group. -/
+@[expose]
+def bot (G : Type*) [Group G] [TopologicalSpace G] [DiscreteTopology G] :
+    _root_.OpenNormalSubgroup G where
+  toOpenSubgroup := ⟨⊥, isOpen_discrete _⟩
+  isNormal' := inferInstance
+
+/-- The underlying subgroup of the trivial open normal subgroup of a discrete group. -/
+@[simp]
+theorem toSubgroup_bot (G : Type*) [Group G] [TopologicalSpace G] [DiscreteTopology G] :
+    (bot G).toSubgroup = ⊥ :=
+  rfl
+
+end OpenNormalSubgroup
+
 variable {G : Type*} [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
   [TotallyDisconnectedSpace G]
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
@@ -45,38 +45,6 @@ carry the hypothesis, while the clopen-image statement is valid for an arbitrary
 
 public section
 
-namespace OpenNormalSubgroup
-
-variable {G H : Type*} [Group G] [TopologicalSpace G] [Group H] [TopologicalSpace H]
-
-/-- The preimage of an open normal subgroup under a continuous group homomorphism. -/
-@[expose]
-def comap (U : _root_.OpenNormalSubgroup H) (f : G →* H) (hf : Continuous f) :
-    _root_.OpenNormalSubgroup G where
-  toOpenSubgroup := U.toOpenSubgroup.comap f hf
-  isNormal' := U.isNormal'.comap f
-
-/-- The underlying subgroup of the preimage of an open normal subgroup. -/
-@[simp]
-theorem toSubgroup_comap (U : _root_.OpenNormalSubgroup H) (f : G →* H)
-    (hf : Continuous f) : (comap U f hf).toSubgroup = U.toSubgroup.comap f :=
-  rfl
-
-/-- The trivial open normal subgroup of a discrete group. -/
-@[expose]
-def bot (G : Type*) [Group G] [TopologicalSpace G] [DiscreteTopology G] :
-    _root_.OpenNormalSubgroup G where
-  toOpenSubgroup := ⟨⊥, isOpen_discrete _⟩
-  isNormal' := inferInstance
-
-/-- The underlying subgroup of the trivial open normal subgroup of a discrete group. -/
-@[simp]
-theorem toSubgroup_bot (G : Type*) [Group G] [TopologicalSpace G] [DiscreteTopology G] :
-    (bot G).toSubgroup = ⊥ :=
-  rfl
-
-end OpenNormalSubgroup
-
 namespace TauCeti
 
 variable {G : Type*} [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]

--- a/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
@@ -45,8 +45,6 @@ carry the hypothesis, while the clopen-image statement is valid for an arbitrary
 
 public section
 
-namespace TauCeti
-
 namespace OpenNormalSubgroup
 
 variable {G H : Type*} [Group G] [TopologicalSpace G] [Group H] [TopologicalSpace H]
@@ -78,6 +76,8 @@ theorem toSubgroup_bot (G : Type*) [Group G] [TopologicalSpace G] [DiscreteTopol
   rfl
 
 end OpenNormalSubgroup
+
+namespace TauCeti
 
 variable {G : Type*} [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
   [TotallyDisconnectedSpace G]

--- a/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
@@ -166,8 +166,10 @@ theorem profiniteOrder_eq_of_finite :
       simpa [U] using Nat.card_congr QuotientGroup.quotientBot.toEquiv
     exact le_of_eq <| congrArg Supernatural.ofNat <| Subtype.ext hcard.symm
 
-/-- Pointwise form of `profiniteOrder_eq_of_finite`.  This is not a `simp` lemma: `simp`
-already rewrites its left-hand side through `profiniteOrder_apply`. -/
+/-- Pointwise form of `profiniteOrder_eq_of_finite`.  Its `simp` priority is above that of
+`profiniteOrder_apply`, so that a finite discrete group simplifies to the valuation of its
+order rather than to the defining supremum. -/
+@[simp high]
 theorem profiniteOrder_apply_of_finite (p : Nat.Primes) :
     profiniteOrder G p = (padicValNat p (Nat.card G) : ℕ∞) := by
   rw [profiniteOrder_eq_of_finite]

--- a/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Supernatural
+public import TauCeti.Topology.Algebra.Group.Profinite.Basic
+
+/-!
+# The supernatural order of a profinite group
+
+The order of a profinite group is the least common multiple, in the supernatural-number
+lattice, of the orders of all its continuous finite quotients.  We define it primewise using
+the quotients by open normal subgroups and identify it with the supremum of their finite
+supernatural orders.
+
+For a finite group with the discrete topology, the trivial subgroup occurs among the open
+normal subgroups.  Its quotient is the whole group, while every other quotient has order
+dividing the group order.  Consequently the supernatural order recovers the ordinary finite
+order exactly.
+
+## Main results
+
+* `profiniteOrder`: the supernatural order, defined from the finite continuous quotients.
+* `profiniteOrder_eq_iSup_ofNat`: its description as the supremum of the embedded quotient
+  orders.
+* `profiniteOrder_le_of_surjective`: continuous surjections do not increase supernatural
+  order.
+* `profiniteOrder_congr`: topological group isomorphisms preserve supernatural order.
+* `profiniteOrder_eq_of_finite`: agreement with `Nat.card` for a finite discrete group.
+
+## References
+
+* L. Ribes and P. Zalesskii, *Profinite Groups*, Section 2.3.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v
+
+/-- The **order of a profinite group** as a supernatural number.  Its exponent at a prime is
+the supremum of the corresponding valuations of the orders of all quotients by open normal
+subgroups. -/
+noncomputable def profiniteOrder (G : Type u) [Group G] [TopologicalSpace G] : Supernatural :=
+  Supernatural.ofFun fun p ↦
+    ⨆ U : OpenNormalSubgroup G, (padicValNat p (Nat.card (G ⧸ U.toSubgroup)) : ℕ∞)
+
+/-- The exponent of a prime in the supernatural order is the supremum of its valuations in
+the finite continuous quotients. -/
+@[simp]
+theorem profiniteOrder_apply (G : Type u) [Group G] [TopologicalSpace G] (p : Nat.Primes) :
+    profiniteOrder G p =
+      ⨆ U : OpenNormalSubgroup G, (padicValNat p (Nat.card (G ⧸ U.toSubgroup)) : ℕ∞) :=
+  Supernatural.ofFun_apply _ _
+
+section Functoriality
+
+variable {G : Type u} {H : Type v} [Group G] [TopologicalSpace G] [Group H]
+  [TopologicalSpace H]
+
+/-- A continuous surjection of topological groups cannot increase supernatural order.  Every
+finite continuous quotient of the target pulls back to an isomorphic finite continuous quotient
+of the source. -/
+theorem profiniteOrder_le_of_surjective (f : G →* H) (hf : Continuous f)
+    (hsurj : Function.Surjective f) : profiniteOrder H ≤ profiniteOrder G := by
+  refine Supernatural.le_iff.mpr fun p ↦ ?_
+  rw [profiniteOrder_apply]
+  refine iSup_le fun U ↦ ?_
+  let V : OpenNormalSubgroup G :=
+    { toOpenSubgroup := U.toOpenSubgroup.comap f hf
+      isNormal' := U.isNormal'.comap f }
+  let q : G →* H ⧸ U.toSubgroup := (QuotientGroup.mk' U.toSubgroup).comp f
+  have hqsurj : Function.Surjective q :=
+    (QuotientGroup.mk'_surjective U.toSubgroup).comp hsurj
+  have hker : q.ker = V.toSubgroup := by
+    ext g
+    simp [q, V]
+  have hcard : Nat.card (H ⧸ U.toSubgroup) = Nat.card (G ⧸ V.toSubgroup) := by
+    have heq := Nat.card_congr
+      (QuotientGroup.quotientKerEquivOfSurjective q hqsurj).toEquiv
+    simpa only [hker] using heq.symm
+  rw [hcard]
+  rw [profiniteOrder_apply]
+  exact le_iSup
+    (fun W : OpenNormalSubgroup G ↦
+      (padicValNat p (Nat.card (G ⧸ W.toSubgroup)) : ℕ∞)) V
+
+/-- Topologically isomorphic groups have the same supernatural order. -/
+theorem profiniteOrder_congr (e : G ≃ₜ* H) : profiniteOrder G = profiniteOrder H := by
+  apply le_antisymm
+  · exact profiniteOrder_le_of_surjective e.symm.toMulEquiv.toMonoidHom
+      e.symm.continuous e.symm.surjective
+  · exact profiniteOrder_le_of_surjective e.toMulEquiv.toMonoidHom
+      e.continuous e.surjective
+
+/-- Passing to a topological group quotient cannot increase supernatural order. -/
+theorem profiniteOrder_quotient_le (N : Subgroup G) [N.Normal] :
+    profiniteOrder (G ⧸ N) ≤ profiniteOrder G :=
+  profiniteOrder_le_of_surjective (QuotientGroup.mk' N) QuotientGroup.continuous_mk
+    (QuotientGroup.mk'_surjective N)
+
+end Functoriality
+
+section Profinite
+
+variable (G : Type u) [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
+
+/-- The supernatural order is the supremum of the ordinary orders of the finite continuous
+quotients, embedded into the supernatural numbers. -/
+theorem profiniteOrder_eq_iSup_ofNat :
+    profiniteOrder G =
+      ⨆ U : OpenNormalSubgroup G,
+        Supernatural.ofNat
+          (⟨Nat.card (G ⧸ U.toSubgroup), Nat.card_pos⟩ : ℕ+) := by
+  ext p
+  rw [profiniteOrder_apply, Supernatural.iSup_apply]
+  congr 1
+  funext U
+  exact
+    (Supernatural.ofNat_apply
+      (⟨Nat.card (G ⧸ U.toSubgroup), Nat.card_pos⟩ : ℕ+) p).symm
+
+/-- The supernatural order is bounded by `n` exactly when the order of every finite continuous
+quotient is bounded by `n`. -/
+theorem profiniteOrder_le_iff {n : Supernatural} :
+    profiniteOrder G ≤ n ↔
+      ∀ U : OpenNormalSubgroup G,
+        Supernatural.ofNat
+            (⟨Nat.card (G ⧸ U.toSubgroup), Nat.card_pos⟩ : ℕ+) ≤ n := by
+  rw [profiniteOrder_eq_iSup_ofNat]
+  exact iSup_le_iff
+
+/-- The ordinary order of each finite continuous quotient divides the supernatural order of
+the profinite group. -/
+theorem ofNat_card_quotient_le_profiniteOrder (U : OpenNormalSubgroup G) :
+    Supernatural.ofNat (⟨Nat.card (G ⧸ U.toSubgroup), Nat.card_pos⟩ : ℕ+) ≤
+      profiniteOrder G := by
+  rw [profiniteOrder_eq_iSup_ofNat]
+  exact le_iSup
+    (fun V : OpenNormalSubgroup G ↦
+      Supernatural.ofNat (⟨Nat.card (G ⧸ V.toSubgroup), Nat.card_pos⟩ : ℕ+)) U
+
+end Profinite
+
+section Finite
+
+variable (G : Type u) [Group G] [TopologicalSpace G] [DiscreteTopology G] [Finite G]
+
+/-- On a finite group with the discrete topology, supernatural order is the prime
+factorization of the ordinary group order. -/
+@[simp]
+theorem profiniteOrder_eq_of_finite :
+    profiniteOrder G = Supernatural.ofNat (⟨Nat.card G, Nat.card_pos⟩ : ℕ+) := by
+  rw [profiniteOrder_eq_iSup_ofNat]
+  apply le_antisymm
+  · refine iSup_le fun U ↦ (Supernatural.ofNat_le_ofNat_iff).2 ?_
+    apply PNat.dvd_iff.mpr
+    simpa only [PNat.mk_coe, U.toSubgroup.index_eq_card] using
+      U.toSubgroup.index_dvd_card
+  · let U : OpenNormalSubgroup G :=
+      { toOpenSubgroup := ⟨⊥, isOpen_discrete _⟩
+        isNormal' := inferInstance }
+    refine le_iSup_of_le U ?_
+    have hcard : Nat.card (G ⧸ U.toSubgroup) = Nat.card G := by
+      simpa [U] using Nat.card_congr QuotientGroup.quotientBot.toEquiv
+    exact le_of_eq <| congrArg Supernatural.ofNat <| Subtype.ext hcard.symm
+
+/-- Pointwise form of `profiniteOrder_eq_of_finite`. -/
+@[simp]
+theorem profiniteOrder_apply_of_finite (p : Nat.Primes) :
+    profiniteOrder G p = (padicValNat p (Nat.card G) : ℕ∞) := by
+  rw [profiniteOrder_eq_of_finite]
+  exact Supernatural.ofNat_apply _ _
+
+end Finite
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
@@ -169,8 +169,8 @@ theorem profiniteOrder_eq_of_finite :
       simpa [U] using Nat.card_congr QuotientGroup.quotientBot.toEquiv
     exact le_of_eq <| congrArg Supernatural.ofNat <| Subtype.ext hcard.symm
 
-/-- Pointwise form of `profiniteOrder_eq_of_finite`. -/
-@[simp]
+/-- Pointwise form of `profiniteOrder_eq_of_finite`.  This is not a `simp` lemma: `simp`
+already rewrites its left-hand side through `profiniteOrder_apply`. -/
 theorem profiniteOrder_apply_of_finite (p : Nat.Primes) :
     profiniteOrder G p = (padicValNat p (Nat.card G) : ℕ∞) := by
   rw [profiniteOrder_eq_of_finite]

--- a/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
@@ -5,8 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.GroupTheory.Index
 public import TauCeti.NumberTheory.Supernatural
-public import TauCeti.Topology.Algebra.Group.Profinite.Basic
+public import TauCeti.Topology.Algebra.Group.OpenNormalSubgroup
 
 /-!
 # The supernatural order of a profinite group
@@ -63,9 +64,7 @@ section Functoriality
 variable {G : Type u} {H : Type v} [Group G] [TopologicalSpace G] [Group H]
   [TopologicalSpace H]
 
-/-- A continuous surjective homomorphism cannot increase `profiniteOrder`.  Every quotient of the
-target by an open normal subgroup pulls back to a quotient of the source with the same `Nat.card`.
--/
+/-- A continuous surjective homomorphism cannot increase `profiniteOrder`. -/
 theorem profiniteOrder_le_of_surjective (f : G →* H) (hf : Continuous f)
     (hsurj : Function.Surjective f) : profiniteOrder H ≤ profiniteOrder G := by
   refine Supernatural.le_iff.mpr fun p ↦ ?_
@@ -161,7 +160,7 @@ theorem profiniteOrder_eq_of_finite :
     apply PNat.dvd_iff.mpr
     simpa only [PNat.mk_coe, U.toSubgroup.index_eq_card] using
       U.toSubgroup.index_dvd_card
-  · let U := OpenNormalSubgroup.bot G
+  · let U := openNormalSubgroupBot G
     refine le_iSup_of_le U ?_
     have hcard : Nat.card (G ⧸ U.toSubgroup) = Nat.card G := by
       simpa [U] using Nat.card_congr QuotientGroup.quotientBot.toEquiv

--- a/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Order.lean
@@ -23,7 +23,8 @@ order exactly.
 
 ## Main results
 
-* `profiniteOrder`: the supernatural order, defined from the finite continuous quotients.
+* `profiniteOrder`: the supernatural order, defined from the `Nat.card` of quotients by open
+  normal subgroups.
 * `profiniteOrder_eq_iSup_ofNat`: its description as the supremum of the embedded quotient
   orders.
 * `profiniteOrder_le_of_surjective`: continuous surjections do not increase supernatural
@@ -42,15 +43,15 @@ namespace TauCeti
 
 universe u v
 
-/-- The **order of a profinite group** as a supernatural number.  Its exponent at a prime is
-the supremum of the corresponding valuations of the orders of all quotients by open normal
-subgroups. -/
+/-- The supernatural number whose exponent at a prime is the supremum of the corresponding
+valuations of the `Nat.card` of all quotients by open normal subgroups.  For a profinite group,
+this is its order. -/
 noncomputable def profiniteOrder (G : Type u) [Group G] [TopologicalSpace G] : Supernatural :=
   Supernatural.ofFun fun p ↦
     ⨆ U : OpenNormalSubgroup G, (padicValNat p (Nat.card (G ⧸ U.toSubgroup)) : ℕ∞)
 
-/-- The exponent of a prime in the supernatural order is the supremum of its valuations in
-the finite continuous quotients. -/
+/-- The exponent of a prime in `profiniteOrder` is the supremum of the valuations of the
+`Nat.card` of the quotients by open normal subgroups. -/
 @[simp]
 theorem profiniteOrder_apply (G : Type u) [Group G] [TopologicalSpace G] (p : Nat.Primes) :
     profiniteOrder G p =
@@ -62,17 +63,15 @@ section Functoriality
 variable {G : Type u} {H : Type v} [Group G] [TopologicalSpace G] [Group H]
   [TopologicalSpace H]
 
-/-- A continuous surjection of topological groups cannot increase supernatural order.  Every
-finite continuous quotient of the target pulls back to an isomorphic finite continuous quotient
-of the source. -/
+/-- A continuous surjective homomorphism cannot increase `profiniteOrder`.  Every quotient of the
+target by an open normal subgroup pulls back to a quotient of the source with the same `Nat.card`.
+-/
 theorem profiniteOrder_le_of_surjective (f : G →* H) (hf : Continuous f)
     (hsurj : Function.Surjective f) : profiniteOrder H ≤ profiniteOrder G := by
   refine Supernatural.le_iff.mpr fun p ↦ ?_
   rw [profiniteOrder_apply]
   refine iSup_le fun U ↦ ?_
-  let V : OpenNormalSubgroup G :=
-    { toOpenSubgroup := U.toOpenSubgroup.comap f hf
-      isNormal' := U.isNormal'.comap f }
+  let V := OpenNormalSubgroup.comap U f hf
   let q : G →* H ⧸ U.toSubgroup := (QuotientGroup.mk' U.toSubgroup).comp f
   have hqsurj : Function.Surjective q :=
     (QuotientGroup.mk'_surjective U.toSubgroup).comp hsurj
@@ -97,7 +96,7 @@ theorem profiniteOrder_congr (e : G ≃ₜ* H) : profiniteOrder G = profiniteOrd
   · exact profiniteOrder_le_of_surjective e.toMulEquiv.toMonoidHom
       e.continuous e.surjective
 
-/-- Passing to a topological group quotient cannot increase supernatural order. -/
+/-- Passing to a quotient cannot increase `profiniteOrder`. -/
 theorem profiniteOrder_quotient_le (N : Subgroup G) [N.Normal] :
     profiniteOrder (G ⧸ N) ≤ profiniteOrder G :=
   profiniteOrder_le_of_surjective (QuotientGroup.mk' N) QuotientGroup.continuous_mk
@@ -107,7 +106,8 @@ end Functoriality
 
 section Profinite
 
-variable (G : Type u) [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
+variable (G : Type u) [Group G] [TopologicalSpace G] [SeparatelyContinuousMul G]
+  [CompactSpace G]
 
 /-- The supernatural order is the supremum of the ordinary orders of the finite continuous
 quotients, embedded into the supernatural numbers. -/
@@ -126,6 +126,7 @@ theorem profiniteOrder_eq_iSup_ofNat :
 
 /-- The supernatural order is bounded by `n` exactly when the order of every finite continuous
 quotient is bounded by `n`. -/
+@[simp]
 theorem profiniteOrder_le_iff {n : Supernatural} :
     profiniteOrder G ≤ n ↔
       ∀ U : OpenNormalSubgroup G,
@@ -134,8 +135,7 @@ theorem profiniteOrder_le_iff {n : Supernatural} :
   rw [profiniteOrder_eq_iSup_ofNat]
   exact iSup_le_iff
 
-/-- The ordinary order of each finite continuous quotient divides the supernatural order of
-the profinite group. -/
+/-- The ordinary order of each finite continuous quotient divides `profiniteOrder G`. -/
 theorem ofNat_card_quotient_le_profiniteOrder (U : OpenNormalSubgroup G) :
     Supernatural.ofNat (⟨Nat.card (G ⧸ U.toSubgroup), Nat.card_pos⟩ : ℕ+) ≤
       profiniteOrder G := by
@@ -161,9 +161,7 @@ theorem profiniteOrder_eq_of_finite :
     apply PNat.dvd_iff.mpr
     simpa only [PNat.mk_coe, U.toSubgroup.index_eq_card] using
       U.toSubgroup.index_dvd_card
-  · let U : OpenNormalSubgroup G :=
-      { toOpenSubgroup := ⟨⊥, isOpen_discrete _⟩
-        isNormal' := inferInstance }
+  · let U := OpenNormalSubgroup.bot G
     refine le_iSup_of_le U ?_
     have hcard : Nat.card (G ⧸ U.toSubgroup) = Nat.card G := by
       simpa [U] using Nat.card_congr QuotientGroup.quotientBot.toEquiv

--- a/TauCeti/Topology/Algebra/Group/Profinite/ProP.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/ProP.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.PGroup
-public import TauCeti.Topology.Algebra.Group.Profinite.Basic
+public import TauCeti.Topology.Algebra.Group.OpenNormalSubgroup
 
 /-!
 # Pro-p groups
@@ -68,7 +68,11 @@ variable {G : Type u} [Group G] [TopologicalSpace G] [DiscreteTopology G]
 @[simp]
 theorem isProP_iff_isPGroup : IsProP p G ↔ IsPGroup p G := by
   refine ⟨fun hG ↦ ?_, IsPGroup.isProP⟩
-  exact (hG (OpenNormalSubgroup.bot G)).of_equiv QuotientGroup.quotientBot
+  -- The trivial open normal subgroup is `⊥` only through its characterization lemma, so
+  -- reach `G ⧸ ⊥` by rewriting the subgroup rather than by definitional unfolding.
+  exact (hG (openNormalSubgroupBot G)).of_equiv
+    ((QuotientGroup.quotientMulEquivOfEq (openNormalSubgroupBot_toSubgroup G)).trans
+      QuotientGroup.quotientBot)
 
 end Discrete
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/ProP.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/ProP.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.PGroup
-public import Mathlib.Topology.Algebra.OpenSubgroup
+public import TauCeti.Topology.Algebra.Group.Profinite.Basic
 
 /-!
 # Pro-p groups
@@ -68,10 +68,7 @@ variable {G : Type u} [Group G] [TopologicalSpace G] [DiscreteTopology G]
 @[simp]
 theorem isProP_iff_isPGroup : IsProP p G ↔ IsPGroup p G := by
   refine ⟨fun hG ↦ ?_, IsPGroup.isProP⟩
-  let U : OpenNormalSubgroup G :=
-    { toOpenSubgroup := ⟨⊥, isOpen_discrete _⟩
-      isNormal' := inferInstance }
-  exact (hG U).of_equiv QuotientGroup.quotientBot
+  exact (hG (OpenNormalSubgroup.bot G)).of_equiv QuotientGroup.quotientBot
 
 end Discrete
 
@@ -84,15 +81,14 @@ variable {H : Type v} [Group H] [TopologicalSpace H]
 theorem of_surjective (hG : IsProP p G) (f : G →* H) (hf : Continuous f)
     (hsurj : Function.Surjective f) : IsProP p H := by
   intro U
-  let V : OpenNormalSubgroup G :=
-    { toOpenSubgroup := U.toOpenSubgroup.comap f hf
-      isNormal' := U.isNormal'.comap f }
+  let V := OpenNormalSubgroup.comap U f hf
   let _ : V.toSubgroup.Normal := V.isNormal'
+  have hVU : V.toSubgroup ≤ U.toSubgroup.comap f := by simp [V]
   let q : G ⧸ V.toSubgroup →* H ⧸ U.toSubgroup :=
-    QuotientGroup.map V.toSubgroup U.toSubgroup f le_rfl
+    QuotientGroup.map V.toSubgroup U.toSubgroup f hVU
   apply (hG V).of_surjective q
   exact QuotientGroup.map_surjective_of_surjective V.toSubgroup U.toSubgroup f
-    ((QuotientGroup.mk'_surjective U.toSubgroup).comp hsurj) le_rfl
+    ((QuotientGroup.mk'_surjective U.toSubgroup).comp hsurj) hVU
 
 /-- A quotient of a pro-`p` group by a normal subgroup is pro-`p`.
 

--- a/TauCeti/Topology/Algebra/Group/Quotient.lean
+++ b/TauCeti/Topology/Algebra/Group/Quotient.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.GroupTheory.QuotientGroup.Basic
 public import Mathlib.Topology.Algebra.OpenSubgroup
+public import TauCeti.Topology.Algebra.Group.OpenNormalSubgroup
 
 /-!
 # Quotients of topological groups by normal subgroups
@@ -54,44 +55,47 @@ theorem isClopen_image_mk (U : OpenSubgroup G) :
 `G ⧸ N` correspond, as lattices, to the open normal subgroups of `G` containing `N`. -/
 def comapMk'OpenNormalOrderIso (N : Subgroup G) [N.Normal] :
     OpenNormalSubgroup (G ⧸ N) ≃o
-      { U : OpenNormalSubgroup G // (N : Subgroup G) ≤ U.toSubgroup } where
-  toFun U :=
-    ⟨{ toOpenSubgroup :=
-        ⟨Subgroup.comap (QuotientGroup.mk' N) U.toSubgroup,
-          (U.toOpenSubgroup.isOpen').preimage (QuotientGroup.continuous_mk (N := N))⟩ },
-      QuotientGroup.le_comap_mk' N U.toSubgroup⟩
-  invFun U :=
-    { toOpenSubgroup :=
-        ⟨Subgroup.map (QuotientGroup.mk' N) U.1.toSubgroup,
-          QuotientGroup.isOpenMap_coe _ U.1.toOpenSubgroup.isOpen'⟩
-      isNormal' :=
-        Subgroup.Normal.map inferInstance (QuotientGroup.mk' N) (QuotientGroup.mk'_surjective N) }
-  left_inv U := OpenNormalSubgroup.toSubgroup_injective
-    (Subgroup.map_comap_eq_self_of_surjective (QuotientGroup.mk'_surjective N) _)
-  right_inv U := Subtype.ext <| OpenNormalSubgroup.toSubgroup_injective <|
-    by
-      dsimp only
-      rw [QuotientGroup.comap_map_mk']
-      exact sup_eq_right.mpr U.2
-  map_rel_iff' {U V} := by
-    constructor
-    · intro h
-      exact (Subgroup.comap_le_comap_of_surjective (QuotientGroup.mk'_surjective N)).mp h
-    · intro h
-      exact (Subgroup.comap_le_comap_of_surjective (QuotientGroup.mk'_surjective N)).mpr h
+      { U : OpenNormalSubgroup G // (N : Subgroup G) ≤ U.toSubgroup } :=
+  -- `QuotientGroup.continuous_mk` is stated for `QuotientGroup.mk`, and binding it at the
+  -- coerced type `⇑(QuotientGroup.mk' N)` keeps the `comap` terms below reducibly
+  -- type-correct, so that `OpenNormalSubgroup.toSubgroup_comap` rewrites in them.
+  have hmk : Continuous ⇑(QuotientGroup.mk' N) := QuotientGroup.continuous_mk
+  { toFun U := ⟨OpenNormalSubgroup.comap U (QuotientGroup.mk' N) hmk,
+      le_of_le_of_eq (QuotientGroup.le_comap_mk' N U.toSubgroup)
+        (OpenNormalSubgroup.toSubgroup_comap U _ _).symm⟩
+    invFun U :=
+      { toOpenSubgroup :=
+          ⟨Subgroup.map (QuotientGroup.mk' N) U.1.toSubgroup,
+            QuotientGroup.isOpenMap_coe _ U.1.toOpenSubgroup.isOpen'⟩
+        isNormal' :=
+          Subgroup.Normal.map inferInstance (QuotientGroup.mk' N)
+            (QuotientGroup.mk'_surjective N) }
+    left_inv U := OpenNormalSubgroup.toSubgroup_injective <|
+      (congrArg (Subgroup.map (QuotientGroup.mk' N))
+          (OpenNormalSubgroup.toSubgroup_comap U _ _)).trans
+        (Subgroup.map_comap_eq_self_of_surjective (QuotientGroup.mk'_surjective N) _)
+    right_inv U := Subtype.ext <| OpenNormalSubgroup.toSubgroup_injective <|
+      (OpenNormalSubgroup.toSubgroup_comap _ _ _).trans <|
+        (QuotientGroup.comap_map_mk' N U.1.toSubgroup).trans (sup_eq_right.mpr U.2)
+    map_rel_iff' {U V} := by
+      simp only [Equiv.coe_fn_mk, Subtype.mk_le_mk, SetLike.le_def,
+        OpenNormalSubgroup.mem_comap]
+      refine ⟨fun h x hx => ?_, fun h _ hg => h hg⟩
+      obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective N x
+      exact h hx }
 
 @[simp]
 theorem comapMk'OpenNormalOrderIso_apply_toSubgroup (U : OpenNormalSubgroup (G ⧸ N)) :
     (comapMk'OpenNormalOrderIso N U : OpenNormalSubgroup G).toSubgroup =
-      Subgroup.comap (QuotientGroup.mk' N) U.toSubgroup := by
-  simp [comapMk'OpenNormalOrderIso]
+      Subgroup.comap (QuotientGroup.mk' N) U.toSubgroup :=
+  OpenNormalSubgroup.toSubgroup_comap U _ _
 
 @[simp]
 theorem comapMk'OpenNormalOrderIso_symm_apply_toSubgroup
     (U : { V : OpenNormalSubgroup G // (N : Subgroup G) ≤ V.toSubgroup }) :
     ((comapMk'OpenNormalOrderIso N).symm U : OpenNormalSubgroup (G ⧸ N)).toSubgroup =
-      Subgroup.map (QuotientGroup.mk' N) U.1.toSubgroup := by
-  simp [comapMk'OpenNormalOrderIso]
+      Subgroup.map (QuotientGroup.mk' N) U.1.toSubgroup :=
+  (rfl)
 
 end QuotientGroup
 


### PR DESCRIPTION
This PR adds the supernatural order of a profinite group and its characteristic first API. It advances `ProfiniteProPGroups` Layer 1, milestone “The order of a profinite group”: `profiniteOrder G` is the primewise supremum of the valuations of the finite continuous quotient orders, and `profiniteOrder_eq_iSup_ofNat` identifies it with their supremum in the supernatural-number lattice.

This is the next critical-path step after the merged supernatural-number foundation. The Layer 1 pro-`p` support characterization and Lagrange theorem consume this order, and Layer 2 Sylow theory in turn consumes those results. Continuous surjections are proved to decrease supernatural order, so topological group equivalences preserve it and quotients have bounded order; for finite discrete groups, the open normal subgroup `⊥` supplies the whole group as a quotient while every other quotient order divides `Nat.card G`, proving exact agreement with `Supernatural.ofNat`.

After this PR, the milestone still needs the worked computations for `ℤ_p` and `ℤ̂`; Layer 1 then needs the profinite-index definition and API, Lagrange, and the pro-`p` and natural-index characterizations.

The implementation reuses Mathlib’s `OpenNormalSubgroup` pullback, `QuotientGroup.quotientKerEquivOfSurjective`, subgroup index divisibility, and `Nat.card_congr`, together with Tau Ceti’s existing `Supernatural` API. No Mathlib infrastructure or external formalization is vendored. The definition and finite-quotient description follow Ribes–Zalesskii, *Profinite Groups*, §2.3, also cited in the module documentation.

The new file is `TauCeti/Topology/Algebra/Group/Profinite/Order.lean` (181 lines).

Roadmap: ProfiniteProPGroups

<!--tauceti-target:v1 {"focus":"ProfiniteProPGroups","id":"profinite-order"}-->

🤖 Prepared with Codex
