### PR TITLE
feat(FunctionField): move a divisor within its class to avoid finitely many places

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Divisor/DisjointSupport.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/DisjointSupport.lean
@@ -48,9 +48,10 @@ variable {k F : Type*} [Field k] [Field F] [Algebra k F]
 
 /-- **Every divisor class has a representative avoiding a given finite set of places.**
 
-This is what lets `TauCeti.Divisor.eval` be applied to a divisor and a function whose zeros and
-poles would otherwise meet: replace the divisor by a linearly equivalent one that avoids them.
-Weil reciprocity and the divisor construction of the Weil pairing both need the move. -/
+Evaluating a function on a divisor requires the divisor's support to miss the function's zeros and
+poles; this is what makes that arrangeable, by replacing the divisor with a linearly equivalent one
+that avoids them. Weil reciprocity and the divisor construction of the Weil pairing both need the
+move. -/
 theorem exists_linearlyEquivalent_disjoint_support (hF : IsFunctionField k F) (D : Divisor k F)
     (s : Finset (Place k F)) :
     ∃ D' : Divisor k F, (Place.orderSystem hF).LinearlyEquivalent D D' ∧
@@ -58,8 +59,10 @@ theorem exists_linearlyEquivalent_disjoint_support (hF : IsFunctionField k F) (D
   -- a function whose order on `s` is exactly minus that of `D`
   obtain ⟨g, hg0, hg⟩ := Place.exists_ne_zero_forall_mem_ord_eq s fun P ↦ -D.coeff P
   refine ⟨D + principal hF (Units.mk0 g hg0), ?_, ?_⟩
-  · rw [linearlyEquivalent_iff hF]
-    exact ⟨(Units.mk0 g hg0)⁻¹, by rw [principal_inv]; abel⟩
+  · have h := (Place.orderSystem hF).linearlyEquivalent_add_principalDivisor D
+      (Additive.ofMul (Units.mk0 g hg0))
+    rw [principalDivisor_eq hF, toMul_ofMul] at h
+    exact h.symm
   · rw [Finset.disjoint_left]
     intro P hP hPs
     rw [WeilDivisor.mem_support_iff, WeilDivisor.coeff_add, coeff_principal] at hP

--- a/TauCeti/FieldTheory/FunctionField/Divisor/DisjointSupport.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/DisjointSupport.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.FunctionField.Divisor.Principal
+public import TauCeti.FieldTheory.FunctionField.Place.Approximation
+
+/-!
+# Moving a divisor within its class to avoid finitely many places
+
+Every divisor class of an algebraic function field contains a representative whose support misses
+any prescribed finite set of places:
+
+```
+∀ D, ∀ s : Finset (Place k F), ∃ D' ~ D, Disjoint D'.support s.
+```
+
+Weak approximation is what makes this true. Finitely many distinct places impose independent
+conditions on `F`, so there is a function whose order at each place of `s` is exactly the negative
+of the coefficient of `D` there; adding its divisor cancels `D` on `s` and changes nothing about
+the class.
+
+## Main results
+
+* `TauCeti.Divisor.exists_linearlyEquivalent_disjoint_support`: the statement above.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Theorem 1.3.1 (weak approximation) and Definition 1.4.3 (linear equivalence).
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.8 — the divisor
+  construction of the Weil pairing, where evaluating one function on another's divisor requires
+  exactly this move.
+-/
+
+public section
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+namespace Divisor
+
+variable {k F : Type*} [Field k] [Field F] [Algebra k F]
+
+/-- **Every divisor class has a representative avoiding a given finite set of places.**
+
+This is what lets `TauCeti.Divisor.eval` be applied to a divisor and a function whose zeros and
+poles would otherwise meet: replace the divisor by a linearly equivalent one that avoids them.
+Weil reciprocity and the divisor construction of the Weil pairing both need the move. -/
+theorem exists_linearlyEquivalent_disjoint_support (hF : IsFunctionField k F) (D : Divisor k F)
+    (s : Finset (Place k F)) :
+    ∃ D' : Divisor k F, (Place.orderSystem hF).LinearlyEquivalent D D' ∧
+      Disjoint D'.support s := by
+  -- a function whose order on `s` is exactly minus that of `D`
+  obtain ⟨g, hg0, hg⟩ := Place.exists_ne_zero_forall_mem_ord_eq s fun P ↦ -D.coeff P
+  refine ⟨D + principal hF (Units.mk0 g hg0), ?_, ?_⟩
+  · rw [linearlyEquivalent_iff hF]
+    exact ⟨(Units.mk0 g hg0)⁻¹, by rw [principal_inv]; abel⟩
+  · rw [Finset.disjoint_left]
+    intro P hP hPs
+    rw [WeilDivisor.mem_support_iff, WeilDivisor.coeff_add, coeff_principal] at hP
+    exact hP (by rw [Units.val_mk0, hg P hPs, add_neg_cancel])
+
+end Divisor
+
+end TauCeti


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divisor-move-disjoint-support"}-->

## The target

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 2, "The Weil pairing — the divisor construction",
lists five named prerequisites:

> existence of a function with divisor `N(P) − N(O)`; **moving a divisor within its class to obtain
> disjoint support**; evaluation of a function on a divisor of disjoint support; **Weil
> reciprocity** `f(div g) = g(div f)`; and independence of every function and divisor choice.

This is the **second**. (#5608 is the third; the two are independent and neither imports the
other.)

## What it adds

```lean
theorem exists_linearlyEquivalent_disjoint_support (hF : IsFunctionField k F) (D : Divisor k F)
    (s : Finset (Place k F)) :
    ∃ D' : Divisor k F, (Place.orderSystem hF).LinearlyEquivalent D D' ∧
      Disjoint D'.support s
```

One theorem, ten lines of proof, in a new leaf module.

## Weak approximation is the whole content

`Place.exists_ne_zero_forall_mem_ord_eq` gives a nonzero `g` with `ord_P g = -(coeff D P)` at every
`P ∈ s` — finitely many distinct places impose independent conditions, which is exactly what that
theorem packages. Then `D' = D + div g` has `coeff D' P = coeff D P + ord_P g = 0` on `s`, so its
support misses `s`; and `D - D' = div (g⁻¹)`, so the two are linearly equivalent by
`linearlyEquivalent_iff`.

Stated for an arbitrary finite set of places rather than for the support of a second function,
which is the form the pairing needs: the general statement specialises to it and costs nothing
extra.

## Reuse

Everything comes from `main`:

- `TauCeti.Place.exists_ne_zero_forall_mem_ord_eq` (`Place/Approximation.lean`) — weak
  approximation in the `ord` vocabulary, with the nonzero witness this needs.
- `TauCeti.Divisor.linearlyEquivalent_iff` and `coeff_principal`, `principal_inv`
  (`Divisor/Principal.lean`).
- `WeilDivisor.mem_support_iff`, `WeilDivisor.coeff_add` (`WeilDivisor/Basic.lean`).

No new machinery, no new definitions.

Absence checked before writing: `git grep -niE 'disjoint.*support|linearlyEquivalent_disjoint|
exists_linearlyEquivalent'` over TauCeti `main` returns only statements about a divisor's *own*
positive and negative parts having disjoint support (`WeilDivisor/Order.lean`,
`PositiveNegativeFixedDegree.lean`) — a different statement about a single divisor, not about
moving one within its class. No open PR carries an overlapping `tauceti-target` marker; of 95 open
PRs the only text match is my own #5608, whose `isUnitAtSupport_iff_disjoint` is about a
*function* being a unit on a divisor's support, not about moving a divisor.

## Placement

A new leaf module `FieldTheory/FunctionField/Divisor/DisjointSupport.lean` rather than an addition
to `Divisor/Principal.lean`, because this is the first divisor result that needs weak
approximation: putting it in `Principal.lean` would pull `Place/Approximation.lean` into
everything that imports the principal-divisor API, which is most of the divisor theory.

There is no elliptic-curve content — this is general function-field material, motivated by the
elliptic roadmap (hence the `Roadmap:` line and the citation above) but stated for any `F/k`.

## Provenance

**Original work.** The argument is the textbook one and is cited in the module docstring
(Stichtenoth Theorem 1.3.1 for the approximation input, Definition 1.4.3 for linear equivalence;
Silverman *AEC* III.8 for the application), but no pinned source carries it: the AINTLIB
`HasseWeil` project at `513e83879e2f` has no divisor-class move, and
MichaelStollBayreuth/EllipticCurves has no divisor theory at all.

Note on the citation format: Stichtenoth is referenced in prose, matching
`Place/Approximation.lean` on `main`; there is no `stichtenoth2009` key in the bibliography, and I
checked that before writing the reference rather than after.

## Gates

- `lake build`: green, 0 errors, 0 warnings under `warningAsError = true`, no Mathlib recompiled.
  New leaf module, no reverse dependencies.
- **`#lint in TauCeti` — the full environment-linter set**: "All linting checks passed", 0 errors
  in 579 declarations.
- `scripts/lint-style.sh`: exit 0, all 4335 headers conforming; no line over 100 characters.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; one file, one theorem.
- Claim at `refs/tauceti-claims/author/EllipticCurves/divisor-move-disjoint-support`.
