### PR TITLE
feat: package the elliptic formal group law

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
@@ -17,13 +17,14 @@ series-level lemma about it is stated in. Mathlib's `FormalGroup`, by contrast, 
 series in `MvPowerSeries (Fin 2) R`. This file transports the two linear coefficients along the
 reindexing `unitSumUnitEquivFinTwo`.
 
-Those two are the `lin_coeff_X` and `lin_coeff_Y` fields of the eventual `FormalGroup` instance.
-The constant coefficient is discharged directly by `simp`, while associativity is transported at
-the construction site by the general `MvPowerSeries.rename_unitSumUnitEquivFinTwo_assoc` theorem.
+Those two are the `lin_coeff_X` and `lin_coeff_Y` fields of the `FormalGroup` structure built by
+`WeierstrassCurve.formalGroup`. The constant coefficient is discharged directly by `simp`, while
+associativity is transported at the construction site by the general
+`MvPowerSeries.rename_unitSumUnitEquivFinTwo_assoc` theorem.
 
 `formalAdd` over `Unit ⊕ Unit` stays the working object: nothing here re-founds it over `Fin 2`,
 and the `Fin 2` presentation is not a second public spelling of the addition series — it exists to
-be the `toPowerSeries` field of the instance.
+be the `toPowerSeries` field of that structure.
 
 ## Main results
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
@@ -18,10 +18,8 @@ series in `MvPowerSeries (Fin 2) R`. This file transports the two linear coeffic
 reindexing `unitSumUnitEquivFinTwo`.
 
 Those two are the `lin_coeff_X` and `lin_coeff_Y` fields of the eventual `FormalGroup` instance.
-The other fields need no lemma of their own: `zero_constantCoeff` is discharged by `simp` from
-`MvPowerSeries.constantCoeff_rename` and `constantCoeff_formalAdd`, and the substitution law that
-will carry associativity into the `assoc` field's shape is the general
-`MvPowerSeries.subst_rename`, applied at the construction site.
+The constant coefficient is discharged directly by `simp`, while associativity is transported at
+the construction site by the general `MvPowerSeries.rename_unitSumUnitEquivFinTwo_assoc` theorem.
 
 `formalAdd` over `Unit ⊕ Unit` stays the working object: nothing here re-founds it over `Fin 2`,
 and the `Fin 2` presentation is not a second public spelling of the addition series — it exists to

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Basic.lean
@@ -9,7 +9,6 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Fin2
 public import Mathlib.RingTheory.FormalGroup.Basic
 import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Assoc
 import TauCeti.RingTheory.MvPowerSeries.Rename
-import TauCeti.RingTheory.MvPowerSeries.Substitution
 
 /-!
 # The formal group law of a Weierstrass curve
@@ -30,7 +29,7 @@ parameters in every multivariate power-series ring.
 
 ## Main results
 
-* `WeierstrassCurve.formalGroup_isComm`: the elliptic formal group law is commutative.
+* `WeierstrassCurve.isComm_formalGroup`: the elliptic formal group law is commutative.
 * `WeierstrassCurve.map_formalGroup`: the construction commutes with base change.
 
 ## References
@@ -54,9 +53,6 @@ open MvPowerSeries
 
 variable {R : Type*} [CommRing R]
 
-private def unitSumUnitSumUnitEquivFinThree : (Unit ⊕ Unit ⊕ Unit) ≃ Fin 3 :=
-  (Equiv.sumCongr finOneEquiv.symm unitSumUnitEquivFinTwo).trans finSumFinEquiv
-
 /-- The one-dimensional commutative formal group law of a Weierstrass curve, obtained by
 reindexing the chord addition series from `Unit ⊕ Unit` to Mathlib's `Fin 2` convention. -/
 noncomputable def formalGroup (W : WeierstrassCurve R) : FormalGroup R where
@@ -64,122 +60,8 @@ noncomputable def formalGroup (W : WeierstrassCurve R) : FormalGroup R where
   zero_constantCoeff := by simp
   lin_coeff_X := coeff_single_zero_rename_unitSumUnitEquivFinTwo_formalAdd W
   lin_coeff_Y := coeff_single_one_rename_unitSumUnitEquivFinTwo_formalAdd W
-  assoc := by
-    -- First expose both nested substitutions through `subst_rename`; these are the two sides of
-    -- Mathlib's `FormalGroup.assoc`, still expressed on the original two-variable index.
-    have hzero : constantCoeff (rename unitSumUnitEquivFinTwo (formalAdd W)) = 0 := by simp
-    obtain hleft := HasSubst.cons_subst_zero_left (0 : Fin 3) 1 2 hzero
-    obtain hright := HasSubst.cons_subst_zero_right (0 : Fin 3) 1 2 hzero
-    rw [MvPowerSeries.subst_rename unitSumUnitEquivFinTwo _ hleft,
-      MvPowerSeries.subst_rename unitSumUnitEquivFinTwo _ hright]
-    rw [MvPowerSeries.subst_rename unitSumUnitEquivFinTwo _ HasSubst.X_X,
-      MvPowerSeries.subst_rename unitSumUnitEquivFinTwo _ HasSubst.X_X]
-    have h₀₁ : HasSubst
-        (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-          (fun _ ↦ X (Sum.inr (Sum.inl ())))) := hasSubst_pair (by simp) (by simp)
-    have h₁₂ : HasSubst
-        (Sum.elim (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
-          MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)) (fun _ ↦ X (Sum.inr (Sum.inr ())))) :=
-      hasSubst_pair (by simp) (by simp)
-    have hz₀₁ : constantCoeff (subst
-        (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-          (fun _ ↦ X (Sum.inr (Sum.inl ())))) (formalAdd W)) = 0 :=
-      constantCoeff_subst_eq_zero h₀₁ (by rintro (u | u) <;> simp) (constantCoeff_formalAdd W)
-    have hz₁₂ : constantCoeff (subst
-        (Sum.elim (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
-          MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)) (fun _ ↦ X (Sum.inr (Sum.inr ()))))
-          (formalAdd W)) = 0 :=
-      constantCoeff_subst_eq_zero h₁₂ (by rintro (u | u) <;> simp) (constantCoeff_formalAdd W)
-    have hsourceLeft : HasSubst
-        (Sum.elim (fun _ ↦ subst
-            (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-              (fun _ ↦ X (Sum.inr (Sum.inl ())))) (formalAdd W))
-          (fun _ ↦ X (Sum.inr (Sum.inr ())))) := hasSubst_pair hz₀₁ (by simp)
-    have hsourceRight : HasSubst
-        (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-          (fun _ ↦ subst
-            (Sum.elim (fun _ ↦ X (Sum.inr (Sum.inl ())))
-              (fun _ ↦ X (Sum.inr (Sum.inr ())))) (formalAdd W))) :=
-      hasSubst_pair (by simp) hz₁₂
-    have hrename : HasSubst
-        (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree) := HasSubst.X_comp _
-    -- Rename the proved three-variable identity. Substitution composition pushes that renaming
-    -- through each outer occurrence of `formalAdd`.
-    have h := congrArg (rename unitSumUnitSumUnitEquivFinThree) (formalAdd_assoc W)
-    simp only [rename_eq_subst] at h
-    rw [subst_comp_subst_apply hsourceLeft hrename,
-      subst_comp_subst_apply hsourceRight hrename] at h
-    -- Expose the outer `finSumFinEquiv` so its left/right evaluation lemmas apply directly.
-    have he₀ : unitSumUnitSumUnitEquivFinThree (Sum.inl ()) = 0 := by
-      change finSumFinEquiv (Sum.inl (finOneEquiv.symm ())) = 0
-      rw [finSumFinEquiv_apply_left]
-      rfl
-    have he₁ : unitSumUnitSumUnitEquivFinThree (Sum.inr (Sum.inl ())) = 1 := by
-      change finSumFinEquiv (Sum.inr (unitSumUnitEquivFinTwo (Sum.inl ()))) = 1
-      rw [unitSumUnitEquivFinTwo_inl]
-      rw [finSumFinEquiv_apply_right]
-      rfl
-    have he₂ : unitSumUnitSumUnitEquivFinThree (Sum.inr (Sum.inr ())) = 2 := by
-      change finSumFinEquiv (Sum.inr (unitSumUnitEquivFinTwo (Sum.inr ()))) = 2
-      rw [unitSumUnitEquivFinTwo_inr]
-      rw [finSumFinEquiv_apply_right]
-      rfl
-    -- The remaining two equalities only say that the chosen equivalences send the named first,
-    -- second, and third variables to `0`, `1`, and `2` respectively.
-    have hfamilyLeft :
-        (![subst (![X 0, X 1] ∘ unitSumUnitEquivFinTwo) (formalAdd W), X 2] ∘
-            unitSumUnitEquivFinTwo) =
-          (fun s ↦ subst (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree)
-            (Sum.elim (fun _ ↦ subst
-                (Sum.elim (fun _ ↦ (X (Sum.inl ()) :
-                  MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-                  (fun _ ↦ X (Sum.inr (Sum.inl ())))) (formalAdd W))
-              (fun _ ↦ X (Sum.inr (Sum.inr ()))) s)) := by
-      funext s
-      rcases s with u | u <;> cases u
-      · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inl, Matrix.cons_val_zero,
-          Sum.elim_inl]
-        rw [subst_comp_subst_apply h₀₁ hrename]
-        congr 1
-        funext t
-        rcases t with v | v <;> cases v
-        · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inl,
-            Matrix.cons_val_zero, Sum.elim_inl]
-          rw [subst_X hrename, Function.comp_apply, he₀]
-        · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inr, Matrix.cons_val_one,
-            Matrix.cons_val_fin_one, Sum.elim_inr]
-          rw [subst_X hrename, Function.comp_apply, he₁]
-      · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inr, Matrix.cons_val_one,
-          Matrix.cons_val_fin_one, Sum.elim_inr]
-        rw [subst_X hrename, Function.comp_apply, he₂]
-    have hfamilyRight :
-        (![X 0, subst (![X 1, X 2] ∘ unitSumUnitEquivFinTwo) (formalAdd W)] ∘
-            unitSumUnitEquivFinTwo) =
-          (fun s ↦ subst (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree)
-            (Sum.elim (fun _ ↦ (X (Sum.inl ()) :
-                MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
-              (fun _ ↦ subst
-                (Sum.elim (fun _ ↦ X (Sum.inr (Sum.inl ())))
-                  (fun _ ↦ X (Sum.inr (Sum.inr ())))) (formalAdd W)) s)) := by
-      funext s
-      rcases s with u | u <;> cases u
-      · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inl, Matrix.cons_val_zero,
-          Sum.elim_inl]
-        rw [subst_X hrename, Function.comp_apply, he₀]
-      · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inr, Matrix.cons_val_one,
-          Matrix.cons_val_fin_one, Sum.elim_inr]
-        rw [subst_comp_subst_apply h₁₂ hrename]
-        congr 1
-        funext t
-        rcases t with v | v <;> cases v
-        · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inl,
-            Matrix.cons_val_zero, Sum.elim_inl]
-          rw [subst_X hrename, Function.comp_apply, he₁]
-        · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inr, Matrix.cons_val_one,
-            Matrix.cons_val_fin_one, Sum.elim_inr]
-          rw [subst_X hrename, Function.comp_apply, he₂]
-    rw [hfamilyLeft, hfamilyRight]
-    exact h
+  assoc := rename_unitSumUnitEquivFinTwo_assoc (formalAdd W) (constantCoeff_formalAdd W)
+    (formalAdd_assoc W)
 
 /-- The underlying `Fin 2`-indexed series of the formal group law is the reindexed chord addition
 series. -/
@@ -197,7 +79,7 @@ theorem map_formalGroup {S : Type*} [CommRing S] (W : WeierstrassCurve R) (φ : 
 
 /-- The formal group law of a Weierstrass curve is commutative. This makes its nilpotent
 power-series-valued points an additive commutative monoid through Mathlib's standard instance. -/
-noncomputable instance formalGroup_isComm (W : WeierstrassCurve R) :
+noncomputable instance isComm_formalGroup (W : WeierstrassCurve R) :
     (formalGroup W).IsComm where
   comm := by
     rw [formalGroup_toPowerSeries,

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Basic.lean
@@ -1,0 +1,212 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Fin2
+public import Mathlib.RingTheory.FormalGroup.Basic
+import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Assoc
+import TauCeti.RingTheory.MvPowerSeries.Rename
+import TauCeti.RingTheory.MvPowerSeries.Substitution
+
+/-!
+# The formal group law of a Weierstrass curve
+
+The chord construction at the point at infinity gives an addition series `formalAdd W`. This file
+packages that series as Mathlib's one-dimensional `FormalGroup`: the two variables are reindexed
+from the named sum `Unit ⊕ Unit` to `Fin 2`, and the previously established constant, linear, and
+associativity identities supply the structure fields.
+
+The resulting formal group is commutative because the chord addition series is symmetric. Thus
+Mathlib's `FormalGroup.Point` construction gives an additive commutative monoid of nilpotent
+parameters in every multivariate power-series ring.
+
+## Main definitions
+
+* `WeierstrassCurve.formalGroup`: the one-dimensional formal group law attached to a Weierstrass
+  curve.
+
+## Main results
+
+* `WeierstrassCurve.formalGroup_isComm`: the elliptic formal group law is commutative.
+* `WeierstrassCurve.map_formalGroup`: the construction commutes with base change.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], IV.1.
+
+## Provenance
+
+The addition series and its laws are adapted in the imported modules from Michael Stoll's
+`EllipticCurves` project (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0) at commit
+`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`. The packaging here is original: that source uses its
+own formal-group-law structure, whereas this development refounds the construction on Mathlib's
+`RingTheory/FormalGroup` API.
+-/
+
+public section
+
+namespace WeierstrassCurve
+
+open MvPowerSeries
+
+variable {R : Type*} [CommRing R]
+
+private def unitSumUnitSumUnitEquivFinThree : (Unit ⊕ Unit ⊕ Unit) ≃ Fin 3 :=
+  (Equiv.sumCongr finOneEquiv.symm unitSumUnitEquivFinTwo).trans finSumFinEquiv
+
+/-- The one-dimensional commutative formal group law of a Weierstrass curve, obtained by
+reindexing the chord addition series from `Unit ⊕ Unit` to Mathlib's `Fin 2` convention. -/
+noncomputable def formalGroup (W : WeierstrassCurve R) : FormalGroup R where
+  toPowerSeries := rename unitSumUnitEquivFinTwo (formalAdd W)
+  zero_constantCoeff := by simp
+  lin_coeff_X := coeff_single_zero_rename_unitSumUnitEquivFinTwo_formalAdd W
+  lin_coeff_Y := coeff_single_one_rename_unitSumUnitEquivFinTwo_formalAdd W
+  assoc := by
+    -- First expose both nested substitutions through `subst_rename`; these are the two sides of
+    -- Mathlib's `FormalGroup.assoc`, still expressed on the original two-variable index.
+    have hzero : constantCoeff (rename unitSumUnitEquivFinTwo (formalAdd W)) = 0 := by simp
+    obtain hleft := HasSubst.cons_subst_zero_left (0 : Fin 3) 1 2 hzero
+    obtain hright := HasSubst.cons_subst_zero_right (0 : Fin 3) 1 2 hzero
+    rw [MvPowerSeries.subst_rename unitSumUnitEquivFinTwo _ hleft,
+      MvPowerSeries.subst_rename unitSumUnitEquivFinTwo _ hright]
+    rw [MvPowerSeries.subst_rename unitSumUnitEquivFinTwo _ HasSubst.X_X,
+      MvPowerSeries.subst_rename unitSumUnitEquivFinTwo _ HasSubst.X_X]
+    have h₀₁ : HasSubst
+        (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+          (fun _ ↦ X (Sum.inr (Sum.inl ())))) := hasSubst_pair (by simp) (by simp)
+    have h₁₂ : HasSubst
+        (Sum.elim (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
+          MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)) (fun _ ↦ X (Sum.inr (Sum.inr ())))) :=
+      hasSubst_pair (by simp) (by simp)
+    have hz₀₁ : constantCoeff (subst
+        (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+          (fun _ ↦ X (Sum.inr (Sum.inl ())))) (formalAdd W)) = 0 :=
+      constantCoeff_subst_eq_zero h₀₁ (by rintro (u | u) <;> simp) (constantCoeff_formalAdd W)
+    have hz₁₂ : constantCoeff (subst
+        (Sum.elim (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
+          MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)) (fun _ ↦ X (Sum.inr (Sum.inr ()))))
+          (formalAdd W)) = 0 :=
+      constantCoeff_subst_eq_zero h₁₂ (by rintro (u | u) <;> simp) (constantCoeff_formalAdd W)
+    have hsourceLeft : HasSubst
+        (Sum.elim (fun _ ↦ subst
+            (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+              (fun _ ↦ X (Sum.inr (Sum.inl ())))) (formalAdd W))
+          (fun _ ↦ X (Sum.inr (Sum.inr ())))) := hasSubst_pair hz₀₁ (by simp)
+    have hsourceRight : HasSubst
+        (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+          (fun _ ↦ subst
+            (Sum.elim (fun _ ↦ X (Sum.inr (Sum.inl ())))
+              (fun _ ↦ X (Sum.inr (Sum.inr ())))) (formalAdd W))) :=
+      hasSubst_pair (by simp) hz₁₂
+    have hrename : HasSubst
+        (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree) := HasSubst.X_comp _
+    -- Rename the proved three-variable identity. Substitution composition pushes that renaming
+    -- through each outer occurrence of `formalAdd`.
+    have h := congrArg (rename unitSumUnitSumUnitEquivFinThree) (formalAdd_assoc W)
+    simp only [rename_eq_subst] at h
+    rw [subst_comp_subst_apply hsourceLeft hrename,
+      subst_comp_subst_apply hsourceRight hrename] at h
+    -- Expose the outer `finSumFinEquiv` so its left/right evaluation lemmas apply directly.
+    have he₀ : unitSumUnitSumUnitEquivFinThree (Sum.inl ()) = 0 := by
+      change finSumFinEquiv (Sum.inl (finOneEquiv.symm ())) = 0
+      rw [finSumFinEquiv_apply_left]
+      rfl
+    have he₁ : unitSumUnitSumUnitEquivFinThree (Sum.inr (Sum.inl ())) = 1 := by
+      change finSumFinEquiv (Sum.inr (unitSumUnitEquivFinTwo (Sum.inl ()))) = 1
+      rw [unitSumUnitEquivFinTwo_inl]
+      rw [finSumFinEquiv_apply_right]
+      rfl
+    have he₂ : unitSumUnitSumUnitEquivFinThree (Sum.inr (Sum.inr ())) = 2 := by
+      change finSumFinEquiv (Sum.inr (unitSumUnitEquivFinTwo (Sum.inr ()))) = 2
+      rw [unitSumUnitEquivFinTwo_inr]
+      rw [finSumFinEquiv_apply_right]
+      rfl
+    -- The remaining two equalities only say that the chosen equivalences send the named first,
+    -- second, and third variables to `0`, `1`, and `2` respectively.
+    have hfamilyLeft :
+        (![subst (![X 0, X 1] ∘ unitSumUnitEquivFinTwo) (formalAdd W), X 2] ∘
+            unitSumUnitEquivFinTwo) =
+          (fun s ↦ subst (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree)
+            (Sum.elim (fun _ ↦ subst
+                (Sum.elim (fun _ ↦ (X (Sum.inl ()) :
+                  MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+                  (fun _ ↦ X (Sum.inr (Sum.inl ())))) (formalAdd W))
+              (fun _ ↦ X (Sum.inr (Sum.inr ()))) s)) := by
+      funext s
+      rcases s with u | u <;> cases u
+      · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inl, Matrix.cons_val_zero,
+          Sum.elim_inl]
+        rw [subst_comp_subst_apply h₀₁ hrename]
+        congr 1
+        funext t
+        rcases t with v | v <;> cases v
+        · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inl,
+            Matrix.cons_val_zero, Sum.elim_inl]
+          rw [subst_X hrename, Function.comp_apply, he₀]
+        · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inr, Matrix.cons_val_one,
+            Matrix.cons_val_fin_one, Sum.elim_inr]
+          rw [subst_X hrename, Function.comp_apply, he₁]
+      · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inr, Matrix.cons_val_one,
+          Matrix.cons_val_fin_one, Sum.elim_inr]
+        rw [subst_X hrename, Function.comp_apply, he₂]
+    have hfamilyRight :
+        (![X 0, subst (![X 1, X 2] ∘ unitSumUnitEquivFinTwo) (formalAdd W)] ∘
+            unitSumUnitEquivFinTwo) =
+          (fun s ↦ subst (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree)
+            (Sum.elim (fun _ ↦ (X (Sum.inl ()) :
+                MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+              (fun _ ↦ subst
+                (Sum.elim (fun _ ↦ X (Sum.inr (Sum.inl ())))
+                  (fun _ ↦ X (Sum.inr (Sum.inr ())))) (formalAdd W)) s)) := by
+      funext s
+      rcases s with u | u <;> cases u
+      · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inl, Matrix.cons_val_zero,
+          Sum.elim_inl]
+        rw [subst_X hrename, Function.comp_apply, he₀]
+      · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inr, Matrix.cons_val_one,
+          Matrix.cons_val_fin_one, Sum.elim_inr]
+        rw [subst_comp_subst_apply h₁₂ hrename]
+        congr 1
+        funext t
+        rcases t with v | v <;> cases v
+        · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inl,
+            Matrix.cons_val_zero, Sum.elim_inl]
+          rw [subst_X hrename, Function.comp_apply, he₁]
+        · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inr, Matrix.cons_val_one,
+            Matrix.cons_val_fin_one, Sum.elim_inr]
+          rw [subst_X hrename, Function.comp_apply, he₂]
+    rw [hfamilyLeft, hfamilyRight]
+    exact h
+
+/-- The underlying `Fin 2`-indexed series of the formal group law is the reindexed chord addition
+series. -/
+@[simp]
+theorem formalGroup_toPowerSeries (W : WeierstrassCurve R) :
+    (formalGroup W).toPowerSeries = rename unitSumUnitEquivFinTwo (formalAdd W) :=
+  by simp [formalGroup]
+
+/-- Base change of a Weierstrass curve commutes with passage to its formal group law. -/
+@[simp]
+theorem map_formalGroup {S : Type*} [CommRing S] (W : WeierstrassCurve R) (φ : R →+* S) :
+    formalGroup (W.map φ) = (formalGroup W).map φ := by
+  apply FormalGroup.ext
+  simp [formalGroup, MvPowerSeries.rename_map]
+
+/-- The formal group law of a Weierstrass curve is commutative. This makes its nilpotent
+power-series-valued points an additive commutative monoid through Mathlib's standard instance. -/
+noncomputable instance formalGroup_isComm (W : WeierstrassCurve R) :
+    (formalGroup W).IsComm where
+  comm := by
+    rw [formalGroup_toPowerSeries,
+      MvPowerSeries.subst_rename unitSumUnitEquivFinTwo _ HasSubst.X_X]
+    nth_rw 1 [← rename_swap_formalAdd W]
+    rw [rename_rename, rename_eq_subst]
+    congr 1
+    funext s
+    rcases s with u | u <;> cases u <;>
+      simp [Function.comp_def]
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Basic.lean
@@ -19,8 +19,8 @@ from the named sum `Unit ⊕ Unit` to `Fin 2`, and the previously established co
 associativity identities supply the structure fields.
 
 The resulting formal group is commutative because the chord addition series is symmetric. Thus
-Mathlib's `FormalGroup.Point` construction gives an additive commutative monoid of nilpotent
-parameters in every multivariate power-series ring.
+Mathlib's `FormalGroup.Point` construction gives an additive commutative monoid of
+power-series-valued points whose constant coefficient is nilpotent.
 
 ## Main definitions
 
@@ -77,8 +77,9 @@ theorem map_formalGroup {S : Type*} [CommRing S] (W : WeierstrassCurve R) (φ : 
   apply FormalGroup.ext
   simp [formalGroup, MvPowerSeries.rename_map]
 
-/-- The formal group law of a Weierstrass curve is commutative. This makes its nilpotent
-power-series-valued points an additive commutative monoid through Mathlib's standard instance. -/
+/-- The formal group law of a Weierstrass curve is commutative. This makes its power-series-valued
+points whose constant coefficient is nilpotent an additive commutative monoid through Mathlib's
+standard instance. -/
 noncomputable instance isComm_formalGroup (W : WeierstrassCurve R) :
     (formalGroup W).IsComm where
   comm := by

--- a/TauCeti/Data/Fin/Sum.lean
+++ b/TauCeti/Data/Fin/Sum.lean
@@ -9,27 +9,30 @@ public import Mathlib.Logic.Equiv.Defs
 import Mathlib.Logic.Equiv.Fin.Basic
 
 /-!
-# The two-element sum as `Fin 2`
+# Iterated two-element sums as `Fin 2` and `Fin 3`
 
-`Unit ⊕ Unit` and `Fin 2` are the two ways a two-element index type arises: one variable per
-named slot, or one variable per numeral. Translating between them is pure bookkeeping, needed
-wherever an object indexed by named slots must be presented against an API indexed by `Fin 2`.
+`Unit ⊕ Unit` and `Fin 2`, or `Unit ⊕ Unit ⊕ Unit` and `Fin 3`, are the two ways a small index
+type arises: one variable per named slot, or one variable per numeral. Translating between them
+is pure bookkeeping, needed wherever an object indexed by named slots must be presented against
+an API indexed by `Fin n`.
 
-This is Mathlib's own composition — `finOneEquiv` on each summand, then `finSumFinEquiv` — given
-a name and the four evaluation lemmas, so that call sites reindexing a two-variable object can
-rewrite rather than unfold it.
+These are Mathlib's own compositions — `finOneEquiv` on each summand, then `finSumFinEquiv` —
+given a name and their evaluation lemmas, so that call sites reindexing a two- or three-variable
+object can rewrite rather than unfold them.
 
 ## Main definitions
 
 * `unitSumUnitEquivFinTwo`: the equivalence `Unit ⊕ Unit ≃ Fin 2`, sending the left summand to
   `0` and the right to `1`.
+* `unitSumUnitSumUnitEquivFinThree`: the equivalence `Unit ⊕ Unit ⊕ Unit ≃ Fin 3`, sending the
+  outer left summand to `0` and the two inner ones to `1` and `2`.
 
 ## Implementation notes
 
-The composition is an implementation detail: the four evaluation lemmas characterise the
-equivalence completely, so `Mathlib.Logic.Equiv.Fin.Basic`, which supplies `finOneEquiv` and
-`finSumFinEquiv` and is used only in the definition body, is imported privately rather than
-re-exported. Only `Mathlib.Logic.Equiv.Defs`, needed for the type of the declaration, is public.
+Each composition is an implementation detail: the evaluation lemmas characterise the equivalence
+completely, so `Mathlib.Logic.Equiv.Fin.Basic`, which supplies `finOneEquiv` and `finSumFinEquiv`
+and is used only in the definition bodies, is imported privately rather than re-exported. Only
+`Mathlib.Logic.Equiv.Defs`, needed for the types of the declarations, is public.
 -/
 
 public section
@@ -55,3 +58,35 @@ theorem unitSumUnitEquivFinTwo_symm_zero :
 @[simp]
 theorem unitSumUnitEquivFinTwo_symm_one :
     unitSumUnitEquivFinTwo.symm 1 = Sum.inr () := by decide
+
+/-- The equivalence `Unit ⊕ Unit ≃ Fin 2` iterated on the right, `Unit ⊕ Unit ⊕ Unit ≃ Fin 3`,
+sending the outer left summand to `0` and the two inner summands to `1` and `2`.
+
+The nesting is the one a three-variable identity meets: an outer variable together with a pair of
+inner ones, matching the shape in which an associativity law names its three slots. -/
+def unitSumUnitSumUnitEquivFinThree : (Unit ⊕ Unit ⊕ Unit) ≃ Fin 3 :=
+  (Equiv.sumCongr finOneEquiv.symm unitSumUnitEquivFinTwo).trans finSumFinEquiv
+
+@[simp]
+theorem unitSumUnitSumUnitEquivFinThree_inl :
+    unitSumUnitSumUnitEquivFinThree (Sum.inl ()) = 0 := by decide
+
+@[simp]
+theorem unitSumUnitSumUnitEquivFinThree_inr_inl :
+    unitSumUnitSumUnitEquivFinThree (Sum.inr (Sum.inl ())) = 1 := by decide
+
+@[simp]
+theorem unitSumUnitSumUnitEquivFinThree_inr_inr :
+    unitSumUnitSumUnitEquivFinThree (Sum.inr (Sum.inr ())) = 2 := by decide
+
+@[simp]
+theorem unitSumUnitSumUnitEquivFinThree_symm_zero :
+    unitSumUnitSumUnitEquivFinThree.symm 0 = Sum.inl () := by decide
+
+@[simp]
+theorem unitSumUnitSumUnitEquivFinThree_symm_one :
+    unitSumUnitSumUnitEquivFinThree.symm 1 = Sum.inr (Sum.inl ()) := by decide
+
+@[simp]
+theorem unitSumUnitSumUnitEquivFinThree_symm_two :
+    unitSumUnitSumUnitEquivFinThree.symm 2 = Sum.inr (Sum.inr ()) := by decide

--- a/TauCeti/RingTheory/MvPowerSeries/Rename.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Rename.lean
@@ -13,8 +13,9 @@ import TauCeti.RingTheory.MvPowerSeries.Substitution
 /-!
 # Renaming the variables of a multivariate power series
 
-Two gaps in Mathlib's `rename` API, both about comparing a renaming with another operation on the
-same series.
+Two gaps in Mathlib's `rename` API, each about comparing a renaming with another operation on the
+same series, and one consequence of them: that reindexing a two-variable series along
+`unitSumUnitEquivFinTwo` carries an associativity identity with it.
 
 Substituting after renaming is the substitution along the renamed index: Mathlib has both
 operations and the law that lets them be compared — `rename_eq_subst`, which says a renaming *is*
@@ -24,6 +25,11 @@ what a caller reindexing a series needs.
 Reading the coefficient of a single-variable monomial through a renaming along an embedding is
 likewise available only through `coeff_embDomain_rename`, which speaks about `Finsupp.embDomain`;
 at one variable raised to an arbitrary power the `single (e i) n` spelling is the more usable one.
+
+Associativity is where the two spellings of a two-variable series genuinely diverge: the named
+form substitutes an already-substituted series through `Sum.elim`, the `Fin 2` form through a
+`Matrix.cons` family over `Fin 3`. Transporting the identity therefore means reindexing the
+three-variable ambient ring as well, along `unitSumUnitSumUnitEquivFinThree`.
 
 ## Main results
 
@@ -36,9 +42,10 @@ at one variable raised to an arbitrary power the `single (e i) n` spelling is th
 
 ## Provenance
 
-No external source: both statements are gaps in Mathlib's `MvPowerSeries` API and each proof is a
-few steps of that same API. They are recorded here rather than inside their callers because they
-carry no elliptic content.
+No external source. The first two statements are gaps in Mathlib's `MvPowerSeries` API and each
+proof is a few steps of that same API; the third is the reindexing they were extracted for, and
+its proof rewrites both sides of the identity through the three-variable renaming. All three are
+recorded here rather than inside their callers because they carry no elliptic content.
 -/
 
 public section
@@ -66,30 +73,6 @@ end CommSemiring
 section CommRing
 
 variable [CommRing R]
-
-private def unitSumUnitSumUnitEquivFinThree : (Unit ⊕ Unit ⊕ Unit) ≃ Fin 3 :=
-  (Equiv.sumCongr finOneEquiv.symm unitSumUnitEquivFinTwo).trans finSumFinEquiv
-
-@[simp]
-private theorem unitSumUnitSumUnitEquivFinThree_inl :
-    unitSumUnitSumUnitEquivFinThree (Sum.inl ()) = 0 := by
-  decide
-
-@[simp]
-private theorem unitSumUnitSumUnitEquivFinThree_inr_inl :
-    unitSumUnitSumUnitEquivFinThree (Sum.inr (Sum.inl ())) = 1 := by
-  -- The private equivalence is opaque, so expose its outer sum equivalence before rewriting.
-  change finSumFinEquiv (Sum.inr (unitSumUnitEquivFinTwo (Sum.inl ()))) = 1
-  rw [unitSumUnitEquivFinTwo_inl, finSumFinEquiv_apply_right]
-  rfl
-
-@[simp]
-private theorem unitSumUnitSumUnitEquivFinThree_inr_inr :
-    unitSumUnitSumUnitEquivFinThree (Sum.inr (Sum.inr ())) = 2 := by
-  -- The private equivalence is opaque, so expose its outer sum equivalence before rewriting.
-  change finSumFinEquiv (Sum.inr (unitSumUnitEquivFinTwo (Sum.inr ()))) = 2
-  rw [unitSumUnitEquivFinTwo_inr, finSumFinEquiv_apply_right]
-  rfl
 
 private theorem rename_unitSumUnitEquivFinTwo_assoc_left_family
     (p : MvPowerSeries (Unit ⊕ Unit) R) :

--- a/TauCeti/RingTheory/MvPowerSeries/Rename.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Rename.lean
@@ -5,8 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Data.Fin.Sum
 public import Mathlib.RingTheory.MvPowerSeries.Rename
 public import Mathlib.RingTheory.MvPowerSeries.Substitution
+import TauCeti.RingTheory.MvPowerSeries.Substitution
 
 /-!
 # Renaming the variables of a multivariate power series
@@ -29,6 +31,8 @@ at one variable raised to an arbitrary power the `single (e i) n` spelling is th
   substituting `g ∘ e` into `p`.
 * `MvPowerSeries.coeff_single_rename`: the coefficient of `rename e p` at the single-variable
   monomial `single (e i) n` is the coefficient of `p` at `single i n`, for any exponent `n`.
+* `MvPowerSeries.rename_unitSumUnitEquivFinTwo_assoc`: reindexing a two-variable associative
+  series from `Unit ⊕ Unit` to `Fin 2` preserves its associativity identity.
 
 ## Provenance
 
@@ -63,6 +67,83 @@ section CommRing
 
 variable [CommRing R]
 
+private def unitSumUnitSumUnitEquivFinThree : (Unit ⊕ Unit ⊕ Unit) ≃ Fin 3 :=
+  (Equiv.sumCongr finOneEquiv.symm unitSumUnitEquivFinTwo).trans finSumFinEquiv
+
+@[simp]
+private theorem unitSumUnitSumUnitEquivFinThree_inl :
+    unitSumUnitSumUnitEquivFinThree (Sum.inl ()) = 0 := by
+  decide
+
+@[simp]
+private theorem unitSumUnitSumUnitEquivFinThree_inr_inl :
+    unitSumUnitSumUnitEquivFinThree (Sum.inr (Sum.inl ())) = 1 := by
+  -- The private equivalence is opaque, so expose its outer sum equivalence before rewriting.
+  change finSumFinEquiv (Sum.inr (unitSumUnitEquivFinTwo (Sum.inl ()))) = 1
+  rw [unitSumUnitEquivFinTwo_inl, finSumFinEquiv_apply_right]
+  rfl
+
+@[simp]
+private theorem unitSumUnitSumUnitEquivFinThree_inr_inr :
+    unitSumUnitSumUnitEquivFinThree (Sum.inr (Sum.inr ())) = 2 := by
+  -- The private equivalence is opaque, so expose its outer sum equivalence before rewriting.
+  change finSumFinEquiv (Sum.inr (unitSumUnitEquivFinTwo (Sum.inr ()))) = 2
+  rw [unitSumUnitEquivFinTwo_inr, finSumFinEquiv_apply_right]
+  rfl
+
+private theorem rename_unitSumUnitEquivFinTwo_assoc_left_family
+    (p : MvPowerSeries (Unit ⊕ Unit) R) :
+    (![subst (![X 0, X 1] ∘ unitSumUnitEquivFinTwo) p, X 2] ∘
+        unitSumUnitEquivFinTwo) =
+      (fun s ↦ subst (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree)
+        (Sum.elim (fun _ ↦ subst
+            (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+              (fun _ ↦ X (Sum.inr (Sum.inl ())))) p)
+          (fun _ ↦ X (Sum.inr (Sum.inr ()))) s)) := by
+  have h₀₁ : HasSubst
+      (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+        (fun _ ↦ X (Sum.inr (Sum.inl ())))) := hasSubst_pair (by simp) (by simp)
+  have hrename : HasSubst
+      (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree) := HasSubst.X_comp _
+  funext s
+  rcases s with u | u <;> cases u
+  · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inl, Matrix.cons_val_zero,
+      Sum.elim_inl]
+    rw [subst_comp_subst_apply h₀₁ hrename]
+    congr 1
+    funext t
+    rcases t with v | v <;> cases v
+    · simp [subst_X hrename]
+    · simp [subst_X hrename]
+  · simp [subst_X hrename]
+
+private theorem rename_unitSumUnitEquivFinTwo_assoc_right_family
+    (p : MvPowerSeries (Unit ⊕ Unit) R) :
+    (![X 0, subst (![X 1, X 2] ∘ unitSumUnitEquivFinTwo) p] ∘
+        unitSumUnitEquivFinTwo) =
+      (fun s ↦ subst (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree)
+        (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+          (fun _ ↦ subst
+            (Sum.elim (fun _ ↦ X (Sum.inr (Sum.inl ())))
+              (fun _ ↦ X (Sum.inr (Sum.inr ())))) p) s)) := by
+  have h₁₂ : HasSubst
+      (Sum.elim (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
+        MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)) (fun _ ↦ X (Sum.inr (Sum.inr ())))) :=
+    hasSubst_pair (by simp) (by simp)
+  have hrename : HasSubst
+      (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree) := HasSubst.X_comp _
+  funext s
+  rcases s with u | u <;> cases u
+  · simp [subst_X hrename]
+  · simp only [Function.comp_apply, unitSumUnitEquivFinTwo_inr, Matrix.cons_val_one,
+      Matrix.cons_val_fin_one, Sum.elim_inr]
+    rw [subst_comp_subst_apply h₁₂ hrename]
+    congr 1
+    funext t
+    rcases t with v | v <;> cases v
+    · simp [subst_X hrename]
+    · simp [subst_X hrename]
+
 /-- **Substituting into a renamed series reindexes the family**: `rename e p` followed by
 substituting `g` is `p` with `g ∘ e` substituted.
 
@@ -75,6 +156,72 @@ theorem subst_rename (e : σ → τ) [TendstoCofinite e] (p : MvPowerSeries σ R
     (rename e p).subst g = p.subst (g ∘ e) := by
   rw [rename_eq_subst, subst_comp_subst_apply (HasSubst.X_comp _) hg]
   simp [subst_X hg, Function.comp_def]
+
+/-- Reindexing an associative two-variable series from `Unit ⊕ Unit` to `Fin 2` preserves
+associativity in Mathlib's three-variable convention.
+
+The source identity uses the named left, middle, and right variables supplied by the nested sum;
+the target is exactly the identity expected by `FormalGroup.assoc`. -/
+theorem rename_unitSumUnitEquivFinTwo_assoc (p : MvPowerSeries (Unit ⊕ Unit) R)
+    (hp : constantCoeff p = 0)
+    (hassoc :
+      subst (Sum.elim
+          (fun _ ↦ subst (Sum.elim
+              (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+              (fun _ ↦ X (Sum.inr (Sum.inl ())))) p)
+          (fun _ ↦ X (Sum.inr (Sum.inr ())))) p =
+        subst (Sum.elim
+          (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+          (fun _ ↦ subst
+            (Sum.elim (fun _ ↦ X (Sum.inr (Sum.inl ())))
+              (fun _ ↦ X (Sum.inr (Sum.inr ())))) p)) p) :
+    subst ![subst ![(X 0 : MvPowerSeries (Fin 3) R), X 1]
+        (rename unitSumUnitEquivFinTwo p), X 2]
+        (rename unitSumUnitEquivFinTwo p) =
+      subst ![(X 0 : MvPowerSeries (Fin 3) R),
+        subst ![X 1, X 2] (rename unitSumUnitEquivFinTwo p)]
+        (rename unitSumUnitEquivFinTwo p) := by
+  have hzero : constantCoeff (rename unitSumUnitEquivFinTwo p) = 0 := by simp [hp]
+  obtain hleft := HasSubst.cons_subst_zero_left (0 : Fin 3) 1 2 hzero
+  obtain hright := HasSubst.cons_subst_zero_right (0 : Fin 3) 1 2 hzero
+  rw [subst_rename unitSumUnitEquivFinTwo _ hleft,
+    subst_rename unitSumUnitEquivFinTwo _ hright]
+  rw [subst_rename unitSumUnitEquivFinTwo _ HasSubst.X_X,
+    subst_rename unitSumUnitEquivFinTwo _ HasSubst.X_X]
+  have h₀₁ : HasSubst
+      (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+        (fun _ ↦ X (Sum.inr (Sum.inl ())))) := hasSubst_pair (by simp) (by simp)
+  have h₁₂ : HasSubst
+      (Sum.elim (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
+        MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)) (fun _ ↦ X (Sum.inr (Sum.inr ())))) :=
+    hasSubst_pair (by simp) (by simp)
+  have hz₀₁ : constantCoeff (subst
+      (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+        (fun _ ↦ X (Sum.inr (Sum.inl ())))) p) = 0 :=
+    constantCoeff_subst_eq_zero h₀₁ (by rintro (u | u) <;> simp) hp
+  have hz₁₂ : constantCoeff (subst
+      (Sum.elim (fun _ ↦ (X (Sum.inr (Sum.inl ())) :
+        MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R)) (fun _ ↦ X (Sum.inr (Sum.inr ())))) p) = 0 :=
+    constantCoeff_subst_eq_zero h₁₂ (by rintro (u | u) <;> simp) hp
+  have hsourceLeft : HasSubst
+      (Sum.elim (fun _ ↦ subst
+          (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+            (fun _ ↦ X (Sum.inr (Sum.inl ())))) p)
+        (fun _ ↦ X (Sum.inr (Sum.inr ())))) := hasSubst_pair hz₀₁ (by simp)
+  have hsourceRight : HasSubst
+      (Sum.elim (fun _ ↦ (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit ⊕ Unit) R))
+        (fun _ ↦ subst
+          (Sum.elim (fun _ ↦ X (Sum.inr (Sum.inl ())))
+            (fun _ ↦ X (Sum.inr (Sum.inr ())))) p)) := hasSubst_pair (by simp) hz₁₂
+  have hrename : HasSubst
+      (X (R := R) ∘ unitSumUnitSumUnitEquivFinThree) := HasSubst.X_comp _
+  have h := congrArg (rename unitSumUnitSumUnitEquivFinThree) hassoc
+  simp only [rename_eq_subst] at h
+  rw [subst_comp_subst_apply hsourceLeft hrename,
+    subst_comp_subst_apply hsourceRight hrename] at h
+  rw [rename_unitSumUnitEquivFinTwo_assoc_left_family p,
+    rename_unitSumUnitEquivFinTwo_assoc_right_family p]
+  exact h
 
 end CommRing
 


### PR DESCRIPTION
This PR packages the completed chord addition series of a Weierstrass curve as Mathlib's `FormalGroup`, supplies the commutativity instance, and proves compatibility with base change. The construction reindexes the existing `Unit ⊕ Unit` series to Mathlib's `Fin 2` convention and transports the already-proved associativity theorem across the corresponding three-variable equivalence.

It advances EllipticCurves Layer 1, milestone (i): “The elliptic formal group law Ê over the coefficient ring, as an instance of Mathlib's `RingTheory/FormalGroup`; [m] on Ê.” The formal-group-law structure is complete after this PR; the remaining part of milestone (i) is the named multiplication-by-integer series `[m]`, followed on the critical path by the log/exp, convergence, and reduction-kernel milestones (ii)–(iv).

This is the next effective critical-path step because the final missing law, associativity, landed in #5558, while the chord series was not yet exposed through Mathlib's formal-group API. The new API consists of `WeierstrassCurve.formalGroup`, its simp theorem for the underlying series, `WeierstrassCurve.map_formalGroup`, and `WeierstrassCurve.formalGroup_isComm`.

The imported chord-law development records its adaptation from Michael Stoll's `EllipticCurves` project at commit `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e` under Apache-2.0. This PR's packaging is original and reuses Mathlib's `FormalGroup`, `FormalGroup.map`, and multivariate-power-series renaming and substitution APIs; no Mathlib source is vendored.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"elliptic-formal-group-law"}-->

🤖 Prepared with Codex
