### PR TITLE
feat: identify the rational localization spectrum

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Homeomorph.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Homeomorph.lean
@@ -70,11 +70,10 @@ noncomputable def spaLocalizationToRationalSubset (P : PairOfDefinition A) (Aplu
   have _ := isTopologicalRing_locTopology P T s S hden
   let Bplus := (integralClosure ↥(Algebra.adjoin Aplus
     (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring
-  have hmem : ∀ x ∈ Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S)),
-      x ∈ Bplus := fun x hx ↦ isIntegral_algebraMap (x := (⟨x, hx⟩ :
-        ↥(Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S)))))
   have hplus : ∀ a ∈ Aplus, algebraMap A S a ∈ Bplus := fun a ha ↦
-    hmem _ (Subalgebra.algebraMap_mem _ (⟨a, ha⟩ : Aplus))
+    Subalgebra.algebraMap_mem (integralClosure _ S)
+      (⟨_, Subalgebra.algebraMap_mem _ (⟨a, ha⟩ : Aplus)⟩ :
+        ↥(Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S))))
   let f : spa Bplus → spa Aplus :=
     spaComap (algebraMap A S) (continuous_algebraMap_locTopology P T s S hden)
       Aplus Bplus hplus

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Homeomorph.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Homeomorph.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Localization.Surjective
+
+/-!
+# The adic spectrum of a topological localization
+
+For a rational subset `R(T/s)` of `Spa(A, A⁺)`, Wedhorn first equips the algebraic localization
+`Aₛ` with a topology for which the fractions `t/s` are power-bounded. Its plus ring is the
+integral closure of `A⁺[T/s]` in `Aₛ`. This file identifies the adic spectrum of that topological
+localization with the rational subset:
+
+```text
+Spa(A(T/s), A(T/s)⁺) ≃ₜ R(T/s).
+```
+
+Pullback along `A → Aₛ` is an embedding because pullback embeds the whole valuation spectrum of a
+localization. Surjectivity is the extension theorem from `Localization.Surjective`. The completed
+coordinate ring `A⟨T/s⟩` requires a further extension of continuous valuations along the dense
+completion map and is intentionally not identified here.
+
+## Main definitions
+
+* `TauCeti.ValuationSpectrum.spaLocalizationToRationalSubset`: pullback from the adic spectrum of
+  `A(T/s)` to `R(T/s)`.
+* `TauCeti.ValuationSpectrum.spaLocalizationHomeomorph`: the resulting natural homeomorphism.
+
+## Main results
+
+* `TauCeti.ValuationSpectrum.spaLocalizationHomeomorph_apply_val`: the forward map is pullback
+  along `A → A(T/s)`.
+* `TauCeti.ValuationSpectrum.comap_spaLocalizationHomeomorph_symm_apply`: the inverse extends a
+  point of the rational subset.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic], arXiv:1910.05934v1, Proposition and Definition 5.51
+  and §8.1.
+
+## Provenance
+
+The construction combines this repository's localization embedding and valuation-extension
+results. It follows no external formalization.
+-/
+
+public section
+
+namespace TauCeti.ValuationSpectrum
+
+open TauCeti.Huber TauCeti.Huber.PairOfDefinition TauCeti.Localization
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
+
+open scoped Classical in
+/-- Pullback along `A → A(T/s)`, corestricted from the adic spectrum of the topological
+localization to the rational subset `R(T/s)`. -/
+noncomputable def spaLocalizationToRationalSubset (P : PairOfDefinition A) (Aplus : Subring A)
+    (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    spa (integralClosure ↥(Algebra.adjoin Aplus (Set.range fun t : T ↦
+        (divBy (t : A) s : S))) S).toSubring →
+      (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)) := by
+  let _ := locTopology P T s S hden
+  have _ := isTopologicalRing_locTopology P T s S hden
+  let Bplus := (integralClosure ↥(Algebra.adjoin Aplus
+    (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring
+  have hmem : ∀ x ∈ Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S)),
+      x ∈ Bplus := fun x hx ↦ isIntegral_algebraMap (x := (⟨x, hx⟩ :
+        ↥(Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S)))))
+  have hplus : ∀ a ∈ Aplus, algebraMap A S a ∈ Bplus := fun a ha ↦
+    hmem _ (Subalgebra.algebraMap_mem _ (⟨a, ha⟩ : Aplus))
+  let f : spa Bplus → spa Aplus :=
+    spaComap (algebraMap A S) (continuous_algebraMap_locTopology P T s S hden)
+      Aplus Bplus hplus
+  exact Set.codRestrict f _ fun v ↦ by
+    have hv := comap_mem_rationalSubset
+      (continuous_algebraMap_locTopology P T s S hden) hplus T s
+      (IsLocalization.Away.mul_invSelf s)
+      (fun t ht ↦ by
+        rw [algebraMap_mul_invSelf]
+        exact hmem _ (Algebra.subset_adjoin ⟨⟨t, ht⟩, rfl⟩)) v.2
+    simpa only [Set.mem_preimage, f, spaComap_val] using hv
+
+/-- The map to the rational subset is pullback along `A → A(T/s)` on underlying valuations. -/
+@[simp]
+theorem spaLocalizationToRationalSubset_apply_val (P : PairOfDefinition A)
+    (Aplus : Subring A) (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S]
+    [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    ∀ v : spa (integralClosure ↥(Algebra.adjoin Aplus
+        (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring,
+      ((spaLocalizationToRationalSubset P Aplus T s S hden v).1 : spa Aplus).1 =
+        comap (algebraMap A S) v.1 := by
+  let _ := locTopology P T s S hden
+  have _ := isTopologicalRing_locTopology P T s S hden
+  intro v
+  unfold spaLocalizationToRationalSubset
+  apply spaComap_val
+
+/-- The canonical map from the localization spectrum to the rational subset is a topological
+embedding. -/
+theorem isEmbedding_spaLocalizationToRationalSubset (P : PairOfDefinition A)
+    (Aplus : Subring A) (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S]
+    [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    Topology.IsEmbedding (spaLocalizationToRationalSubset P Aplus T s S hden) := by
+  let _ := locTopology P T s S hden
+  have _ := isTopologicalRing_locTopology P T s S hden
+  apply (isEmbedding_spaComap _ _ _ _ _
+    (localization_comap_isEmbedding (Submonoid.powers s) S)).codRestrict
+
+/-- Every point of `R(T/s)` is extended by the canonical map from the localization spectrum. -/
+theorem surjective_spaLocalizationToRationalSubset (P : PairOfDefinition A)
+    (Aplus : Subring A) (hP : P.ringOfDefinition ≤ Aplus) (T : Finset A) (s : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    Function.Surjective (spaLocalizationToRationalSubset P Aplus T s S hden) := by
+  let _ := locTopology P T s S hden
+  have _ := isTopologicalRing_locTopology P T s S hden
+  intro v
+  have himage := Set.ext_iff.mp
+    (image_comap_algebraMap_spa_eq_rationalSubset P Aplus hP T s S hden) v.1.1
+  obtain ⟨w, hwspa, hcomp⟩ := himage.mpr v.2
+  refine ⟨⟨w, hwspa⟩, Subtype.ext ?_⟩
+  exact Subtype.ext (by rw [spaLocalizationToRationalSubset_apply_val]; exact hcomp)
+
+/-- The adic spectrum of the topological localization `A(T/s)`, with plus ring the integral
+closure of `A⁺[T/s]`, is naturally homeomorphic to the rational subset `R(T/s)`.
+
+The hypothesis `A₀ ≤ A⁺` ensures that extending a continuous valuation to the localization is
+continuous; a pair of definition satisfying it exists for every ring of integral elements. -/
+noncomputable def spaLocalizationHomeomorph (P : PairOfDefinition A) (Aplus : Subring A)
+    (hP : P.ringOfDefinition ≤ Aplus) (T : Finset A) (s : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    spa (integralClosure ↥(Algebra.adjoin Aplus
+        (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring ≃ₜ
+      (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)) := by
+  let _ := locTopology P T s S hden
+  have _ := isTopologicalRing_locTopology P T s S hden
+  exact (isEmbedding_spaLocalizationToRationalSubset P Aplus T s S hden).toHomeomorphOfSurjective
+    (surjective_spaLocalizationToRationalSubset P Aplus hP T s S hden)
+
+/-- The forward map of `spaLocalizationHomeomorph` is pullback along `A → A(T/s)`. -/
+@[simp]
+theorem spaLocalizationHomeomorph_apply_val (P : PairOfDefinition A) (Aplus : Subring A)
+    (hP : P.ringOfDefinition ≤ Aplus) (T : Finset A) (s : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    ∀ v : spa (integralClosure ↥(Algebra.adjoin Aplus
+        (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring,
+      ((spaLocalizationHomeomorph P Aplus hP T s S hden v).1 : spa Aplus).1 =
+        comap (algebraMap A S) v.1 := by
+  let _ := locTopology P T s S hden
+  have _ := isTopologicalRing_locTopology P T s S hden
+  intro v
+  exact spaLocalizationToRationalSubset_apply_val P Aplus T s S hden v
+
+/-- Pulling the valuation supplied by the inverse homeomorphism back to `A` recovers the
+original point of `R(T/s)`. -/
+@[simp]
+theorem comap_spaLocalizationHomeomorph_symm_apply (P : PairOfDefinition A)
+    (Aplus : Subring A) (hP : P.ringOfDefinition ≤ Aplus) (T : Finset A) (s : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    ∀ v : (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)),
+      comap (algebraMap A S) ((spaLocalizationHomeomorph P Aplus hP T s S hden).symm v).1 =
+        v.1.1 := by
+  let _ := locTopology P T s S hden
+  have _ := isTopologicalRing_locTopology P T s S hden
+  intro v
+  rw [← spaLocalizationHomeomorph_apply_val P Aplus hP T s S hden]
+  exact congrArg (fun w : (Subtype.val ⁻¹' rationalSubset Aplus T s : Set (spa Aplus)) ↦
+    w.1.1) ((spaLocalizationHomeomorph P Aplus hP T s S hden).apply_symm_apply v)
+
+end TauCeti.ValuationSpectrum
+
+end

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Homeomorph.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Homeomorph.lean
@@ -28,7 +28,7 @@ completion map and is intentionally not identified here.
 
 * `TauCeti.ValuationSpectrum.spaLocalizationToRationalSubset`: pullback from the adic spectrum of
   `A(T/s)` to `R(T/s)`.
-* `TauCeti.ValuationSpectrum.spaLocalizationHomeomorph`: the resulting natural homeomorphism.
+* `TauCeti.ValuationSpectrum.spaLocalizationHomeomorph`: the resulting canonical homeomorphism.
 
 ## Main results
 
@@ -79,12 +79,8 @@ noncomputable def spaLocalizationToRationalSubset (P : PairOfDefinition A) (Aplu
     spaComap (algebraMap A S) (continuous_algebraMap_locTopology P T s S hden)
       Aplus Bplus hplus
   exact Set.codRestrict f _ fun v ↦ by
-    have hv := comap_mem_rationalSubset
-      (continuous_algebraMap_locTopology P T s S hden) hplus T s
-      (IsLocalization.Away.mul_invSelf s)
-      (fun t ht ↦ by
-        rw [algebraMap_mul_invSelf]
-        exact hmem _ (Algebra.subset_adjoin ⟨⟨t, ht⟩, rfl⟩)) v.2
+    have hv := image_comap_algebraMap_spa_subset_rationalSubset P Aplus T s S hden
+      ⟨v.1, v.2, rfl⟩
     simpa only [Set.mem_preimage, f, spaComap_val] using hv
 
 /-- The map to the rational subset is pullback along `A → A(T/s)` on underlying valuations. -/
@@ -114,6 +110,7 @@ theorem isEmbedding_spaLocalizationToRationalSubset (P : PairOfDefinition A)
     Topology.IsEmbedding (spaLocalizationToRationalSubset P Aplus T s S hden) := by
   let _ := locTopology P T s S hden
   have _ := isTopologicalRing_locTopology P T s S hden
+  unfold spaLocalizationToRationalSubset
   apply (isEmbedding_spaComap _ _ _ _ _
     (localization_comap_isEmbedding (Submonoid.powers s) S)).codRestrict
 
@@ -134,7 +131,7 @@ theorem surjective_spaLocalizationToRationalSubset (P : PairOfDefinition A)
   exact Subtype.ext (by rw [spaLocalizationToRationalSubset_apply_val]; exact hcomp)
 
 /-- The adic spectrum of the topological localization `A(T/s)`, with plus ring the integral
-closure of `A⁺[T/s]`, is naturally homeomorphic to the rational subset `R(T/s)`.
+closure of `A⁺[T/s]`, is canonically homeomorphic to the rational subset `R(T/s)`.
 
 The hypothesis `A₀ ≤ A⁺` ensures that extending a continuous valuation to the localization is
 continuous; a pair of definition satisfying it exists for every ring of integral elements. -/
@@ -165,6 +162,7 @@ theorem spaLocalizationHomeomorph_apply_val (P : PairOfDefinition A) (Aplus : Su
   let _ := locTopology P T s S hden
   have _ := isTopologicalRing_locTopology P T s S hden
   intro v
+  rw [spaLocalizationHomeomorph, Topology.IsEmbedding.toHomeomorphOfSurjective_apply]
   exact spaLocalizationToRationalSubset_apply_val P Aplus T s S hden v
 
 /-- Pulling the valuation supplied by the inverse homeomorphism back to `A` recovers the

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Surjective.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Surjective.lean
@@ -147,19 +147,17 @@ theorem image_comap_algebraMap_spa_subset_rationalSubset (P : PairOfDefinition A
         (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring ⊆
       rationalSubset Aplus T s := by
   let _ := locTopology P T s S hden
-  -- Every element of the generating subalgebra is integral over it, hence in the plus ring.
-  have hmem : ∀ x ∈ Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S)),
-      x ∈ (integralClosure ↥(Algebra.adjoin Aplus
-        (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring := fun x hx ↦
-    isIntegral_algebraMap (x := (⟨x, hx⟩ :
-      ↥(Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S)))))
   rintro _ ⟨w, hw, rfl⟩
   exact comap_mem_rationalSubset (continuous_algebraMap_locTopology P T s S hden)
-    (fun a ha ↦ hmem _ (Subalgebra.algebraMap_mem _ (⟨a, ha⟩ : Aplus))) T s
+    (fun a ha ↦ Subalgebra.algebraMap_mem (integralClosure _ S)
+      (⟨_, Subalgebra.algebraMap_mem _ (⟨a, ha⟩ : Aplus)⟩ :
+        ↥(Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S))))) T s
     (IsLocalization.Away.mul_invSelf s)
     (fun t ht ↦ by
       rw [algebraMap_mul_invSelf]
-      exact hmem _ (Algebra.subset_adjoin ⟨⟨t, ht⟩, rfl⟩)) hw
+      exact Subalgebra.algebraMap_mem (integralClosure _ S)
+        (⟨_, Algebra.subset_adjoin ⟨⟨t, ht⟩, rfl⟩⟩ :
+          ↥(Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S))))) hw
 
 /-- **The image of the adic spectrum of the rational localisation is exactly `R(T/s)`.** The
 inclusion `⊆` is `image_comap_algebraMap_spa_subset_rationalSubset`; the inclusion `⊇` is

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Surjective.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Surjective.lean
@@ -36,6 +36,8 @@ structure map.
 
 * `TauCeti.ValuationSpectrum.exists_mem_spa_comap_algebraMap_eq`: **every point of `R(T/s)` is
   the pullback of a point of `Spa (Aₛ, Aₛ⁺)`.**
+* `TauCeti.ValuationSpectrum.image_comap_algebraMap_spa_subset_rationalSubset`: pullback sends
+  every point of `Spa (Aₛ, Aₛ⁺)` into `R(T/s)`.
 * `TauCeti.ValuationSpectrum.image_comap_algebraMap_spa_eq_rationalSubset`: the image of
   `Spa (Aₛ, Aₛ⁺)` in `Spa (A, A⁺)` **is** `R(T/s)`.
 
@@ -134,9 +136,34 @@ theorem exists_mem_spa_comap_algebraMap_eq (P : PairOfDefinition A) (Aplus : Sub
     exact Valuation.extendToLocalization_apply_map_apply _
       (Valuation.powers_le_supp_primeCompl hs) S a
 
+/-- Pullback from the adic spectrum of the rational localisation lands in `R(T/s)`. The structure
+map inverts `s` and sends each `t/s` into the plus ring of the localisation. -/
+theorem image_comap_algebraMap_spa_subset_rationalSubset (P : PairOfDefinition A)
+    (Aplus : Subring A) (T : Finset A) (s : A)
+    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locTopology P T s S hden
+    comap (algebraMap A S) '' spa (integralClosure ↥(Algebra.adjoin Aplus
+        (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring ⊆
+      rationalSubset Aplus T s := by
+  let _ := locTopology P T s S hden
+  -- Every element of the generating subalgebra is integral over it, hence in the plus ring.
+  have hmem : ∀ x ∈ Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S)),
+      x ∈ (integralClosure ↥(Algebra.adjoin Aplus
+        (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring := fun x hx ↦
+    isIntegral_algebraMap (x := (⟨x, hx⟩ :
+      ↥(Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S)))))
+  rintro _ ⟨w, hw, rfl⟩
+  exact comap_mem_rationalSubset (continuous_algebraMap_locTopology P T s S hden)
+    (fun a ha ↦ hmem _ (Subalgebra.algebraMap_mem _ (⟨a, ha⟩ : Aplus))) T s
+    (IsLocalization.Away.mul_invSelf s)
+    (fun t ht ↦ by
+      rw [algebraMap_mul_invSelf]
+      exact hmem _ (Algebra.subset_adjoin ⟨⟨t, ht⟩, rfl⟩)) hw
+
 /-- **The image of the adic spectrum of the rational localisation is exactly `R(T/s)`.** The
-inclusion `⊆` holds because the structure map inverts `s` and sends each `t/s` into the plus ring
-of `Aₛ`; the inclusion `⊇` is `exists_mem_spa_comap_algebraMap_eq`.
+inclusion `⊆` is `image_comap_algebraMap_spa_subset_rationalSubset`; the inclusion `⊇` is
+`exists_mem_spa_comap_algebraMap_eq`.
 
 This is the roadmap's homeomorphism `Spa (A_U, A_U⁺) ≃ U` at the level of underlying sets and
 before completion; injectivity, the topological comparison and the passage from `Aₛ` to `A⟨T/s⟩`
@@ -150,22 +177,10 @@ theorem image_comap_algebraMap_spa_eq_rationalSubset (P : PairOfDefinition A) (A
         (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring =
       rationalSubset Aplus T s := by
   let _ := locTopology P T s S hden
-  -- Every element of the generating subalgebra is integral over it, hence in the plus ring.
-  have hmem : ∀ x ∈ Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S)),
-      x ∈ (integralClosure ↥(Algebra.adjoin Aplus
-        (Set.range fun t : T ↦ (divBy (t : A) s : S))) S).toSubring := fun x hx ↦
-    isIntegral_algebraMap (x := (⟨x, hx⟩ :
-      ↥(Algebra.adjoin Aplus (Set.range fun t : T ↦ (divBy (t : A) s : S)))))
-  refine Set.Subset.antisymm ?_ fun v hv ↦ ?_
-  · rintro _ ⟨w, hw, rfl⟩
-    exact comap_mem_rationalSubset (continuous_algebraMap_locTopology P T s S hden)
-      (fun a ha ↦ hmem _ (Subalgebra.algebraMap_mem _ (⟨a, ha⟩ : Aplus))) T s
-      (IsLocalization.Away.mul_invSelf s)
-      (fun t ht ↦ by
-        rw [algebraMap_mul_invSelf]
-        exact hmem _ (Algebra.subset_adjoin ⟨⟨t, ht⟩, rfl⟩)) hw
-  · obtain ⟨w, hw, rfl⟩ := exists_mem_spa_comap_algebraMap_eq P Aplus hP T s S hden hv
-    exact ⟨w, hw, rfl⟩
+  refine Set.Subset.antisymm
+    (image_comap_algebraMap_spa_subset_rationalSubset P Aplus T s S hden) fun v hv ↦ ?_
+  obtain ⟨w, hw, rfl⟩ := exists_mem_spa_comap_algebraMap_eq P Aplus hP T s S hden hv
+  exact ⟨w, hw, rfl⟩
 
 end TauCeti.ValuationSpectrum
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Surjective.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Surjective.lean
@@ -41,17 +41,13 @@ structure map.
 * `TauCeti.ValuationSpectrum.image_comap_algebraMap_spa_eq_rationalSubset`: the image of
   `Spa (Aₛ, Aₛ⁺)` in `Spa (A, A⁺)` **is** `R(T/s)`.
 
-## What remains for the roadmap's homeomorphism
+## Scope: the uncompleted localisation
 
-Injectivity, and with it the homeomorphism `Spa (Aₛ, Aₛ⁺) ≃ₜ R(T/s)` for the uncompleted
-localisation, is supplied downstream in `Localization.Homeomorph`, which upgrades the set-level
-image computation below to a homeomorphism. Two things remain, neither of them claimed here.
-
-* **The passage to the completion.** The roadmap's `A_U` is the *completed* localisation
-  `A⟨T/s⟩`, and every statement below is about `Aₛ` with `locTopology`. Identifying the two adic
-  spectra is a separate theorem about extending continuous valuations along a completion, and it
-  is neither used nor assumed here.
-* **Identification of the rational subsets** on the two sides.
+Every statement below is about `Aₛ` carrying `locTopology`, never about the completed localisation
+`A⟨T/s⟩`: identifying the two adic spectra is a separate theorem about extending continuous
+valuations along a completion, and it is neither used nor assumed here. Injectivity, and with it
+the homeomorphism `Spa (Aₛ, Aₛ⁺) ≃ₜ R(T/s)` for the uncompleted localisation, is supplied in
+`Localization.Homeomorph`, which upgrades the set-level image computation below.
 
 ## The hypothesis `P.ringOfDefinition ≤ A⁺`
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Surjective.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Surjective.lean
@@ -43,10 +43,10 @@ structure map.
 
 ## What remains for the roadmap's homeomorphism
 
-Three things, none of them claimed here.
+Injectivity, and with it the homeomorphism `Spa (Aₛ, Aₛ⁺) ≃ₜ R(T/s)` for the uncompleted
+localisation, is supplied downstream in `Localization.Homeomorph`, which upgrades the set-level
+image computation below to a homeomorphism. Two things remain, neither of them claimed here.
 
-* **Injectivity**, and then that the resulting continuous bijection onto `R(T/s)` is a
-  homeomorphism.
 * **The passage to the completion.** The roadmap's `A_U` is the *completed* localisation
   `A⟨T/s⟩`, and every statement below is about `Aₛ` with `locTopology`. Identifying the two adic
   spectra is a separate theorem about extending continuous valuations along a completion, and it
@@ -164,8 +164,8 @@ inclusion `⊆` is `image_comap_algebraMap_spa_subset_rationalSubset`; the inclu
 `exists_mem_spa_comap_algebraMap_eq`.
 
 This is the roadmap's homeomorphism `Spa (A_U, A_U⁺) ≃ U` at the level of underlying sets and
-before completion; injectivity, the topological comparison and the passage from `Aₛ` to `A⟨T/s⟩`
-are not part of the statement. -/
+before completion; injectivity and the topological comparison are added in
+`Localization.Homeomorph`, and the passage from `Aₛ` to `A⟨T/s⟩` is not part of the statement. -/
 theorem image_comap_algebraMap_spa_eq_rationalSubset (P : PairOfDefinition A) (Aplus : Subring A)
     (hP : P.ringOfDefinition ≤ Aplus) (T : Finset A) (s : A)
     (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Surjective.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/Surjective.lean
@@ -11,11 +11,7 @@ public import TauCeti.RingTheory.Huber.LocalizationTopology.Valuation
 /-!
 # The adic spectrum of a rational localisation covers the rational subset
 
-Roadmap Layer 3.1 asks, for a rational subset `U = R(T/s)` of `X = Spa(A, A⁺)`, for a natural
-homeomorphism between `U` and the adic spectrum of the rational localisation. `Localization.Basic`
-supplies the map and shows it lands in `U`, and closes by saying that the map back — extending a
-point of `U` to the coordinate ring — is "the remaining half of the roadmap's homeomorphism".
-This file supplies that half **before completion**: it shows that the continuous map
+For a rational subset `R(T/s)` of `Spa(A, A⁺)`, this file shows that the continuous map
 
 ```text
 Spa (Aₛ, Aₛ⁺) → Spa (A, A⁺)
@@ -43,11 +39,8 @@ structure map.
 
 ## Scope: the uncompleted localisation
 
-Every statement below is about `Aₛ` carrying `locTopology`, never about the completed localisation
-`A⟨T/s⟩`: identifying the two adic spectra is a separate theorem about extending continuous
-valuations along a completion, and it is neither used nor assumed here. Injectivity, and with it
-the homeomorphism `Spa (Aₛ, Aₛ⁺) ≃ₜ R(T/s)` for the uncompleted localisation, is supplied in
-`Localization.Homeomorph`, which upgrades the set-level image computation below.
+Every statement below is about `Aₛ` carrying `locTopology`, not the completed localisation
+`A⟨T/s⟩`.
 
 ## The hypothesis `P.ringOfDefinition ≤ A⁺`
 
@@ -99,8 +92,7 @@ the denominator, and is `≤ 1` on `A⁺`; extending it along `A → Aₛ` there
 valuation on `Aₛ` that is `≤ 1` on the integral closure of `A⁺[T/s]`, and restricting it back
 along the structure map returns the point.
 
-Here `Aₛ` carries `locTopology`, not the topology of the completion; see the module docstring for
-what that leaves open. -/
+Here `Aₛ` carries `locTopology`, not the topology of the completion. -/
 theorem exists_mem_spa_comap_algebraMap_eq (P : PairOfDefinition A) (Aplus : Subring A)
     (hP : P.ringOfDefinition ≤ Aplus) (T : Finset A) (s : A)
     (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
@@ -157,11 +149,7 @@ theorem image_comap_algebraMap_spa_subset_rationalSubset (P : PairOfDefinition A
 
 /-- **The image of the adic spectrum of the rational localisation is exactly `R(T/s)`.** The
 inclusion `⊆` is `image_comap_algebraMap_spa_subset_rationalSubset`; the inclusion `⊇` is
-`exists_mem_spa_comap_algebraMap_eq`.
-
-This is the roadmap's homeomorphism `Spa (A_U, A_U⁺) ≃ U` at the level of underlying sets and
-before completion; injectivity and the topological comparison are added in
-`Localization.Homeomorph`, and the passage from `Aₛ` to `A⟨T/s⟩` is not part of the statement. -/
+`exists_mem_spa_comap_algebraMap_eq`. -/
 theorem image_comap_algebraMap_spa_eq_rationalSubset (P : PairOfDefinition A) (Aplus : Subring A)
     (hP : P.ringOfDefinition ≤ Aplus) (T : Finset A) (s : A)
     (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
@@ -34,6 +34,8 @@ We define the valuation spectrum `Spv A` following Wedhorn, *Adic Spaces*
   `𝔞 ≤ supp v` to `Spv (A ⧸ 𝔞)`.
 * `TauCeti.ValuationSpectrum.localizationComapSection S B v hS` : Lift `v` to a localization
   `Spv B`.
+* `TauCeti.ValuationSpectrum.vle_mk'_iff` : clear the denominators in a comparison between two
+  localization fractions.
 * `TauCeti.ValuationSpectrum.localization_comap_isEmbedding` : pullback from the valuation
   spectrum of a localization is a topological embedding.
 * `TauCeti.ValuationSpectrum.suppFun` : The continuous support map `Spv A → Spec A`.
@@ -418,7 +420,9 @@ lemma localization_comap_range :
   simpa using ⟨fun ⟨w, hw⟩ ↦ hw ▸ submonoid_le_supp_primeCompl_comap_algebraMap S B w,
     fun h ↦ ⟨localizationComapSection S B v h, comap_localizationComapSection S B v h⟩⟩
 
-private lemma vle_mk'_iff (v : Spv B) (a₁ a₂ : A) (s₁ s₂ : S) :
+/-- A comparison between two fractions in a localization is equivalent to the comparison obtained
+by clearing their denominators. -/
+lemma vle_mk'_iff (v : Spv B) (a₁ a₂ : A) (s₁ s₂ : S) :
     v.toValuativeRel.vle (IsLocalization.mk' B a₁ s₁) (IsLocalization.mk' B a₂ s₂) ↔
       v.toValuativeRel.vle (algebraMap A B (a₁ * s₂)) (algebraMap A B (a₂ * s₁)) := by
   have hs₁ : ¬ v.toValuativeRel.vle (algebraMap A B s₁) 0 :=

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
@@ -34,6 +34,8 @@ We define the valuation spectrum `Spv A` following Wedhorn, *Adic Spaces*
   `𝔞 ≤ supp v` to `Spv (A ⧸ 𝔞)`.
 * `TauCeti.ValuationSpectrum.localizationComapSection S B v hS` : Lift `v` to a localization
   `Spv B`.
+* `TauCeti.ValuationSpectrum.localization_comap_isEmbedding` : pullback from the valuation
+  spectrum of a localization is a topological embedding.
 * `TauCeti.ValuationSpectrum.suppFun` : The continuous support map `Spv A → Spec A`.
 * `TauCeti.ValuationSpectrum.trivialSection` : The continuous section of `suppFun` given by
   the trivial valuation attached to a prime ideal; in particular `suppFun` is surjective
@@ -48,6 +50,10 @@ Ported from the open Mathlib pull request
 [leanprover-community/mathlib4#38009](https://github.com/leanprover-community/mathlib4/pull/38009)
 (which supersedes an earlier draft in AINTLIB `projects/AdicSpaces`); this copy is deleted in
 favour of the Mathlib declarations once that pull request reaches the pinned Mathlib.
+
+The localization embedding follows the organization and generated-topology argument of Mathlib's
+`PrimeSpectrum.localization_comap_isEmbedding`, adapted here from prime ideals to valuative
+relations.
 -/
 
 public section
@@ -411,6 +417,89 @@ lemma localization_comap_range :
   ext v
   simpa using ⟨fun ⟨w, hw⟩ ↦ hw ▸ submonoid_le_supp_primeCompl_comap_algebraMap S B w,
     fun h ↦ ⟨localizationComapSection S B v h, comap_localizationComapSection S B v h⟩⟩
+
+private lemma vle_mk'_iff (v : Spv B) (a₁ a₂ : A) (s₁ s₂ : S) :
+    v.toValuativeRel.vle (IsLocalization.mk' B a₁ s₁) (IsLocalization.mk' B a₂ s₂) ↔
+      v.toValuativeRel.vle (algebraMap A B (a₁ * s₂)) (algebraMap A B (a₂ * s₁)) := by
+  have hs₁ : ¬ v.toValuativeRel.vle (algebraMap A B s₁) 0 :=
+    @TauCeti.ValuativeRel.not_vle_zero_of_isUnit B _ v.toValuativeRel _
+      (IsLocalization.map_units B s₁)
+  have hs₂ : ¬ v.toValuativeRel.vle (algebraMap A B s₂) 0 :=
+    @TauCeti.ValuativeRel.not_vle_zero_of_isUnit B _ v.toValuativeRel _
+      (IsLocalization.map_units B s₂)
+  constructor
+  · intro h
+    have h' := v.toValuativeRel.mul_vle_mul_left
+      (v.toValuativeRel.mul_vle_mul_left h (algebraMap A B s₁)) (algebraMap A B s₂)
+    have h'' : v.toValuativeRel.vle
+        ((IsLocalization.mk' B a₁ s₁ * algebraMap A B s₁) * algebraMap A B s₂)
+        ((IsLocalization.mk' B a₂ s₂ * algebraMap A B s₂) * algebraMap A B s₁) := by
+      simpa only [mul_assoc, mul_comm, mul_left_comm] using h'
+    simpa only [map_mul, IsLocalization.mk'_spec] using h''
+  · intro h
+    have h' : v.toValuativeRel.vle
+        ((IsLocalization.mk' B a₁ s₁ * algebraMap A B s₁) * algebraMap A B s₂)
+        ((IsLocalization.mk' B a₂ s₂ * algebraMap A B s₂) * algebraMap A B s₁) := by
+      simpa only [map_mul, IsLocalization.mk'_spec] using h
+    have h'' : v.toValuativeRel.vle
+        ((IsLocalization.mk' B a₁ s₁ * algebraMap A B s₂) * algebraMap A B s₁)
+        ((IsLocalization.mk' B a₂ s₂ * algebraMap A B s₂) * algebraMap A B s₁) := by
+      simpa only [mul_assoc, mul_comm, mul_left_comm] using h'
+    exact v.toValuativeRel.vle_mul_cancel hs₂ (v.toValuativeRel.vle_mul_cancel hs₁ h'')
+
+include S in
+/-- Pullback of valuative relations along a localization map is injective. -/
+lemma localization_comap_injective : Function.Injective (comap (algebraMap A B)) := by
+  intro v₁ v₂ h
+  refine ext' fun x y ↦ ?_
+  obtain ⟨⟨a₁, s₁⟩, rfl⟩ := IsLocalization.mk'_surjective S x
+  obtain ⟨⟨a₂, s₂⟩, rfl⟩ := IsLocalization.mk'_surjective S y
+  rw [vle_mk'_iff S B, vle_mk'_iff S B]
+  exact iff_of_eq (by
+    simpa only [comap_vle] using
+      (congrArg (fun v ↦ v.toValuativeRel.vle (a₁ * s₂) (a₂ * s₁)) h))
+
+private lemma not_vle_algebraMap_mul_den_zero_iff (v : Spv B) (a : A) (s t : S) :
+    ¬ v.toValuativeRel.vle (algebraMap A B (a * s)) 0 ↔
+      ¬ v.toValuativeRel.vle (IsLocalization.mk' B a t) 0 := by
+  have hs : ¬ v.toValuativeRel.vle (algebraMap A B s) 0 :=
+    @TauCeti.ValuativeRel.not_vle_zero_of_isUnit B _ v.toValuativeRel _
+      (IsLocalization.map_units B s)
+  have hmap : v.toValuativeRel.vle (algebraMap A B (a * s)) 0 ↔
+      v.toValuativeRel.vle (algebraMap A B a) 0 := by
+    simpa only [map_mul, zero_mul] using
+      (v.toValuativeRel.mul_vle_mul_iff_left (x := algebraMap A B a) (y := 0) hs)
+  have hmk := vle_mk'_iff S B v a 0 t 1
+  simp only [Submonoid.coe_one, mul_one, zero_mul, map_zero, IsLocalization.mk'_zero] at hmk
+  exact not_congr (hmap.trans hmk.symm)
+
+private lemma comap_preimage_basicOpen_mk' (a₁ a₂ : A) (s₁ s₂ : S) :
+    comap (algebraMap A B) ⁻¹' basicOpen (a₁ * s₂) (a₂ * s₁) =
+      basicOpen (IsLocalization.mk' B a₁ s₁) (IsLocalization.mk' B a₂ s₂) := by
+  ext v
+  simp only [Set.mem_preimage, mem_basicOpen_iff, comap_vle, map_zero]
+  rw [← vle_mk'_iff S B, not_vle_algebraMap_mul_den_zero_iff S B]
+
+include S in
+/-- Pullback of valuative relations along a localization map induces the source topology. -/
+lemma localization_comap_isInducing : Topology.IsInducing (comap (algebraMap A B)) where
+  eq_induced := by
+    simp only [instTopologicalSpace, induced_generateFrom_eq]
+    congr 1
+    ext U
+    constructor
+    · rintro ⟨f, s, rfl⟩
+      obtain ⟨⟨a₁, s₁⟩, rfl⟩ := IsLocalization.mk'_surjective S f
+      obtain ⟨⟨a₂, s₂⟩, rfl⟩ := IsLocalization.mk'_surjective S s
+      exact ⟨_, ⟨a₁ * s₂, a₂ * s₁, rfl⟩,
+        comap_preimage_basicOpen_mk' S B a₁ a₂ s₁ s₂⟩
+    · rintro ⟨_, ⟨f, s, rfl⟩, rfl⟩
+      exact ⟨_, _, comap_preimage_basicOpen (algebraMap A B) f s⟩
+
+include S in
+/-- Pullback of valuative relations along a localization map is a topological embedding. -/
+lemma localization_comap_isEmbedding : Topology.IsEmbedding (comap (algebraMap A B)) :=
+  ⟨localization_comap_isInducing S B, localization_comap_injective S B⟩
 
 end Localization
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
@@ -463,7 +463,9 @@ lemma localization_comap_injective : Function.Injective (comap (algebraMap A B))
     simpa only [comap_vle] using
       (congrArg (fun v ↦ v.toValuativeRel.vle (a₁ * s₂) (a₂ * s₁)) h))
 
-private lemma not_vle_algebraMap_mul_den_zero_iff (v : Spv B) (a : A) (s t : S) :
+/-- Multiplying a numerator by an element of the localized submonoid or placing it over any
+denominator does not change whether its value is nonzero. -/
+lemma not_vle_algebraMap_mul_den_zero_iff (v : Spv B) (a : A) (s t : S) :
     ¬ v.toValuativeRel.vle (algebraMap A B (a * s)) 0 ↔
       ¬ v.toValuativeRel.vle (IsLocalization.mk' B a t) 0 := by
   have hs : ¬ v.toValuativeRel.vle (algebraMap A B s) 0 :=
@@ -477,7 +479,9 @@ private lemma not_vle_algebraMap_mul_den_zero_iff (v : Spv B) (a : A) (s t : S) 
   simp only [Submonoid.coe_one, mul_one, zero_mul, map_zero, IsLocalization.mk'_zero] at hmk
   exact not_congr (hmap.trans hmk.symm)
 
-private lemma comap_preimage_basicOpen_mk' (a₁ a₂ : A) (s₁ s₂ : S) :
+/-- The preimage under localization pullback of the basic open obtained by clearing denominators
+is the basic open defined by the original fractions. -/
+lemma comap_preimage_basicOpen_mk' (a₁ a₂ : A) (s₁ s₂ : S) :
     comap (algebraMap A B) ⁻¹' basicOpen (a₁ * s₂) (a₂ * s₁) =
       basicOpen (IsLocalization.mk' B a₁ s₁) (IsLocalization.mk' B a₂ s₂) := by
   ext v


### PR DESCRIPTION
This PR identifies the adic spectrum of the uncompleted topological rational localization `A(T/s)`, with plus ring the integral closure of `A⁺[T/s]`, with the rational subset `R(T/s)` by a canonical homeomorphism, and records its forward and inverse valuation formulas.

It advances AdicSpaces milestone 3.1, “Rational localisation of a Huber pair,” specifically the target that the rational coordinate Huber pair's adic spectrum be naturally homeomorphic to `U`. The reusable valuation-spectrum argument proves that pullback along any localization is a topological embedding, which combines with the existing extension/surjectivity theorem to settle the uncompleted case. After this PR, it remains to prove unique extension of continuous valuations across the separated completion `A(T/s) → A⟨T/s⟩`, transport this homeomorphism to the completed coordinate ring, and identify rational subsets under it.

The general localization-embedding proof adapts the generated-topology argument and organization of Mathlib's `PrimeSpectrum.localization_comap_isEmbedding`.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"rational-localization-homeomorphism"}-->

🤖 Prepared with Codex
