### PR TITLE
feat: add negative-binomial convolution

### DIFF
--- a/TauCeti/Probability/Distributions/NegativeBinomial.lean
+++ b/TauCeti/Probability/Distributions/NegativeBinomial.lean
@@ -367,7 +367,7 @@ theorem negativeBinomialMeasure_conv_negativeBinomialMeasure {r s p : ℝ}
     have hbase : 0 < p / (1 - (1 - p) * t) := by
       apply div_pos hp
       exact sub_pos.mpr (lt_of_le_of_lt (le_abs_self _) hdom)
-    rw [pgf_conv _ _ ht_abs.le, pgf_negativeBinomialMeasure hr hp hp1 hdom,
+    rw [Measure.pgf_conv _ _ ht_abs.le, pgf_negativeBinomialMeasure hr hp hp1 hdom,
       pgf_negativeBinomialMeasure hs hp hp1 hdom,
       pgf_negativeBinomialMeasure (add_pos hr hs) hp hp1 hdom]
     exact (Real.rpow_add hbase r s).symm

--- a/TauCeti/Probability/Distributions/NegativeBinomial.lean
+++ b/TauCeti/Probability/Distributions/NegativeBinomial.lean
@@ -339,53 +339,41 @@ theorem pgf_negativeBinomialMeasure_zero (p t : ℝ) :
 
 /-- The convolution of two negative-binomial laws with the same success probability is
 negative-binomial, with the shape parameters added. This includes either shape-zero boundary and
-the success-probability-one Dirac family. -/
+the success-probability-one Dirac family; outside the valid probability range all three measures
+vanish. -/
 @[simp]
 theorem negativeBinomialMeasure_conv_negativeBinomialMeasure {r s p : ℝ}
-    (hr : 0 ≤ r) (hs : 0 ≤ s) (hp : 0 < p) (hp1 : p ≤ 1) :
+    (hr : 0 ≤ r) (hs : 0 ≤ s) :
     negativeBinomialMeasure r p ∗ negativeBinomialMeasure s p =
       negativeBinomialMeasure (r + s) p := by
-  rcases hr.eq_or_lt with rfl | hr
-  · rw [negativeBinomialMeasure_zero hp hp1, Measure.dirac_zero_conv, zero_add]
-  rcases hs.eq_or_lt with rfl | hs
-  · rw [negativeBinomialMeasure_zero hp hp1, Measure.conv_dirac_zero, add_zero]
-  let _ := isProbabilityMeasure_negativeBinomialMeasure hr.le hp hp1
-  let _ := isProbabilityMeasure_negativeBinomialMeasure hs.le hp hp1
-  let _ := isProbabilityMeasure_negativeBinomialMeasure (add_pos hr hs).le hp hp1
-  apply measure_eq_of_pgf_eqOn
-  intro t ht
-  have ht_abs : |t| < 1 := abs_lt.mpr ht
-  have hdom : |(1 - p) * t| < 1 := by
-    rw [abs_mul, abs_of_nonneg (sub_nonneg.mpr hp1)]
-    calc
-      (1 - p) * |t| ≤ 1 * |t| :=
-        mul_le_mul_of_nonneg_right (by linarith : 1 - p ≤ 1) (abs_nonneg t)
-      _ < 1 := by simpa using ht_abs
-  have hbase : 0 < p / (1 - (1 - p) * t) := by
-    apply div_pos hp
-    exact sub_pos.mpr (lt_of_le_of_lt (le_abs_self _) hdom)
-  have hpgf_conv :
-      pgf id (negativeBinomialMeasure r p ∗ negativeBinomialMeasure s p) t =
-        pgf id (negativeBinomialMeasure r p) t *
-          pgf id (negativeBinomialMeasure s p) t := by
-    rw [Measure.conv, pgf_map (by fun_prop)]
-    -- `pgf_map` leaves coordinate addition under a lambda, while
-    -- `IndepFun.pgf_add_of_abs_le_one` expects the definitionally equal pointwise sum.
-    change pgf ((fun z : ℕ × ℕ => z.1) + fun z => z.2)
-      ((negativeBinomialMeasure r p).prod (negativeBinomialMeasure s p)) t = _
-    have hindep : IndepFun (fun z : ℕ × ℕ => z.1) (fun z => z.2)
-        ((negativeBinomialMeasure r p).prod (negativeBinomialMeasure s p)) :=
-      indepFun_prod (μ := negativeBinomialMeasure r p)
-        (ν := negativeBinomialMeasure s p) (X := id) (Y := id)
-        measurable_id measurable_id
-    rw [TauCeti.Probability.IndepFun.pgf_add_of_abs_le_one hindep
-      measurable_fst.aemeasurable measurable_snd.aemeasurable ht_abs.le]
-    rw [← pgf_map measurable_fst.aemeasurable, ← pgf_map measurable_snd.aemeasurable]
-    simp
-  rw [hpgf_conv, pgf_negativeBinomialMeasure hr hp hp1 hdom,
-    pgf_negativeBinomialMeasure hs hp hp1 hdom,
-    pgf_negativeBinomialMeasure (add_pos hr hs) hp hp1 hdom]
-  exact (Real.rpow_add hbase r s).symm
+  by_cases hp_valid : 0 < p ∧ p ≤ 1
+  · rcases hp_valid with ⟨hp, hp1⟩
+    rcases hr.eq_or_lt with rfl | hr
+    · rw [negativeBinomialMeasure_zero hp hp1, Measure.dirac_zero_conv, zero_add]
+    rcases hs.eq_or_lt with rfl | hs
+    · rw [negativeBinomialMeasure_zero hp hp1, Measure.conv_dirac_zero, add_zero]
+    let _ := isProbabilityMeasure_negativeBinomialMeasure hr.le hp hp1
+    let _ := isProbabilityMeasure_negativeBinomialMeasure hs.le hp hp1
+    let _ := isProbabilityMeasure_negativeBinomialMeasure (add_pos hr hs).le hp hp1
+    apply measure_eq_of_pgf_eqOn
+    intro t ht
+    have ht_abs : |t| < 1 := abs_lt.mpr ht
+    have hdom : |(1 - p) * t| < 1 := by
+      rw [abs_mul, abs_of_nonneg (sub_nonneg.mpr hp1)]
+      calc
+        (1 - p) * |t| ≤ 1 * |t| :=
+          mul_le_mul_of_nonneg_right (by linarith : 1 - p ≤ 1) (abs_nonneg t)
+        _ < 1 := by simpa using ht_abs
+    have hbase : 0 < p / (1 - (1 - p) * t) := by
+      apply div_pos hp
+      exact sub_pos.mpr (lt_of_le_of_lt (le_abs_self _) hdom)
+    rw [pgf_conv _ _ ht_abs.le, pgf_negativeBinomialMeasure hr hp hp1 hdom,
+      pgf_negativeBinomialMeasure hs hp hp1 hdom,
+      pgf_negativeBinomialMeasure (add_pos hr hs) hp hp1 hdom]
+    exact (Real.rpow_add hbase r s).symm
+  · have hzero (a : ℝ) : negativeBinomialMeasure a p = 0 :=
+      negativeBinomialMeasure_eq_zero_of_invalid (fun h => hp_valid h.2)
+    simp only [hzero, Measure.zero_conv]
 
 end Probability
 

--- a/TauCeti/Probability/Distributions/NegativeBinomial.lean
+++ b/TauCeti/Probability/Distributions/NegativeBinomial.lean
@@ -21,8 +21,18 @@ native mass is the Gamma-expression
 
 The definition is totalized explicitly: the positive family is used for `0 < r` and `0 < p ≤ 1`,
 the boundary `r = 0` is a Dirac mass at zero, and every other parameter value gives the zero
-measure.  The file supplies the normalized measure, its native singleton interface, and the exact
-integrability domain and closed form of its probability-generating function.
+measure.  The file supplies the normalized measure, its native singleton and support interfaces,
+the exact integrability domain and closed form of its probability-generating function, and the
+additivity of the shape parameter under convolution.
+
+## Main results
+
+* `negativeBinomialMeasure_singleton` and `negativeBinomialMeasure_real_singleton` compute the
+  native masses;
+* `negativeBinomialMeasure_singleton_ne_zero_iff` characterizes their exact support, including the
+  shape-zero and success-probability-one boundary laws;
+* `pgf_negativeBinomialMeasure` computes the probability-generating function on its exact domain;
+* `negativeBinomialMeasure_conv_negativeBinomialMeasure` proves that convolution adds shapes.
 
 The normalization uses Mathlib's real binomial power series, after identifying its coefficients
 with the Gamma quotient.  The distributional convention follows Johnson, Kemp, and Kotz,
@@ -226,6 +236,54 @@ theorem negativeBinomialMeasure_real_singleton {r p : ℝ} (hr : 0 ≤ r) (hp : 
   rw [measureReal_def, negativeBinomialMeasure_singleton hr hp hp1,
     negativeBinomialWeight_toReal hr hp.le hp1]
 
+/-! ### Support -/
+
+/-- A real negative-binomial weight is positive exactly at zero or in the nondegenerate family.
+
+Thus the shape-zero and success-probability-one laws are supported only at zero, while positive
+shape and success probability strictly below one give positive mass to every natural number. -/
+theorem negativeBinomialWeightReal_pos_iff {r p : ℝ} (hr : 0 ≤ r) (hp : 0 < p)
+    (hp1 : p ≤ 1) (k : ℕ) :
+    0 < negativeBinomialWeightReal r p k ↔ k = 0 ∨ (0 < r ∧ p < 1) := by
+  rcases hr.eq_or_lt with rfl | hr
+  · by_cases hk : k = 0
+    · simp [negativeBinomialWeightReal, hk]
+    · simp [negativeBinomialWeightReal, hk]
+  rw [negativeBinomialWeightReal_eq_gamma hr.ne' k]
+  have hcoeff : 0 < Real.Gamma (k + r) / (k.factorial * Real.Gamma r) := by
+    apply div_pos (Real.Gamma_pos_of_pos (by positivity))
+    exact mul_pos (by positivity) (Real.Gamma_pos_of_pos hr)
+  have hp_rpow : 0 < Real.rpow p r := Real.rpow_pos_of_pos hp r
+  constructor
+  · intro h
+    by_cases hk : k = 0
+    · exact Or.inl hk
+    · refine Or.inr ⟨hr, ?_⟩
+      by_contra hnot
+      have hpeq : p = 1 := le_antisymm hp1 (le_of_not_gt hnot)
+      subst p
+      simp [hk] at h
+  · intro h
+    rcases h with rfl | ⟨_, hp_lt_one⟩
+    · simpa using mul_pos (mul_pos hcoeff hp_rpow) (pow_pos one_pos 0)
+    · exact mul_pos (mul_pos hcoeff hp_rpow) (pow_pos (sub_pos.mpr hp_lt_one) k)
+
+/-- A negative-binomial weight is nonzero exactly at zero or in the nondegenerate family. -/
+@[simp]
+theorem negativeBinomialWeight_ne_zero_iff {r p : ℝ} (hr : 0 ≤ r) (hp : 0 < p)
+    (hp1 : p ≤ 1) (k : ℕ) :
+    negativeBinomialWeight r p k ≠ 0 ↔ k = 0 ∨ (0 < r ∧ p < 1) := by
+  rw [negativeBinomialWeight, ENNReal.ofReal_ne_zero_iff,
+    negativeBinomialWeightReal_pos_iff hr hp hp1]
+
+/-- The singleton mass of a valid negative-binomial law is nonzero exactly at zero or in the
+nondegenerate family. -/
+theorem negativeBinomialMeasure_singleton_ne_zero_iff {r p : ℝ} (hr : 0 ≤ r) (hp : 0 < p)
+    (hp1 : p ≤ 1) (k : ℕ) :
+    negativeBinomialMeasure r p {k} ≠ 0 ↔ k = 0 ∨ (0 < r ∧ p < 1) := by
+  rw [negativeBinomialMeasure_singleton hr hp hp1,
+    negativeBinomialWeight_ne_zero_iff hr hp hp1]
+
 /-- For positive shape and valid success probability, the negative-binomial
 probability-generating-function integrand is integrable exactly inside its disk of convergence.
 Thus it is non-integrable both on and beyond the boundary. -/
@@ -276,6 +334,58 @@ theorem pgf_negativeBinomialMeasure_zero (p t : ℝ) :
       simpa using h
     rw [hz, pgf_def]
     simp
+
+/-! ### Convolution -/
+
+/-- The convolution of two negative-binomial laws with the same success probability is
+negative-binomial, with the shape parameters added. This includes either shape-zero boundary and
+the success-probability-one Dirac family. -/
+@[simp]
+theorem negativeBinomialMeasure_conv_negativeBinomialMeasure {r s p : ℝ}
+    (hr : 0 ≤ r) (hs : 0 ≤ s) (hp : 0 < p) (hp1 : p ≤ 1) :
+    negativeBinomialMeasure r p ∗ negativeBinomialMeasure s p =
+      negativeBinomialMeasure (r + s) p := by
+  rcases hr.eq_or_lt with rfl | hr
+  · rw [negativeBinomialMeasure_zero hp hp1, Measure.dirac_zero_conv, zero_add]
+  rcases hs.eq_or_lt with rfl | hs
+  · rw [negativeBinomialMeasure_zero hp hp1, Measure.conv_dirac_zero, add_zero]
+  let _ := isProbabilityMeasure_negativeBinomialMeasure hr.le hp hp1
+  let _ := isProbabilityMeasure_negativeBinomialMeasure hs.le hp hp1
+  let _ := isProbabilityMeasure_negativeBinomialMeasure (add_pos hr hs).le hp hp1
+  apply measure_eq_of_pgf_eqOn
+  intro t ht
+  have ht_abs : |t| < 1 := abs_lt.mpr ht
+  have hdom : |(1 - p) * t| < 1 := by
+    rw [abs_mul, abs_of_nonneg (sub_nonneg.mpr hp1)]
+    calc
+      (1 - p) * |t| ≤ 1 * |t| :=
+        mul_le_mul_of_nonneg_right (by linarith : 1 - p ≤ 1) (abs_nonneg t)
+      _ < 1 := by simpa using ht_abs
+  have hbase : 0 < p / (1 - (1 - p) * t) := by
+    apply div_pos hp
+    exact sub_pos.mpr (lt_of_le_of_lt (le_abs_self _) hdom)
+  have hpgf_conv :
+      pgf id (negativeBinomialMeasure r p ∗ negativeBinomialMeasure s p) t =
+        pgf id (negativeBinomialMeasure r p) t *
+          pgf id (negativeBinomialMeasure s p) t := by
+    rw [Measure.conv, pgf_map (by fun_prop)]
+    -- `pgf_map` leaves coordinate addition under a lambda, while
+    -- `IndepFun.pgf_add_of_abs_le_one` expects the definitionally equal pointwise sum.
+    change pgf ((fun z : ℕ × ℕ => z.1) + fun z => z.2)
+      ((negativeBinomialMeasure r p).prod (negativeBinomialMeasure s p)) t = _
+    have hindep : IndepFun (fun z : ℕ × ℕ => z.1) (fun z => z.2)
+        ((negativeBinomialMeasure r p).prod (negativeBinomialMeasure s p)) :=
+      indepFun_prod (μ := negativeBinomialMeasure r p)
+        (ν := negativeBinomialMeasure s p) (X := id) (Y := id)
+        measurable_id measurable_id
+    rw [TauCeti.Probability.IndepFun.pgf_add_of_abs_le_one hindep
+      measurable_fst.aemeasurable measurable_snd.aemeasurable ht_abs.le]
+    rw [← pgf_map measurable_fst.aemeasurable, ← pgf_map measurable_snd.aemeasurable]
+    simp
+  rw [hpgf_conv, pgf_negativeBinomialMeasure hr hp hp1 hdom,
+    pgf_negativeBinomialMeasure hs hp hp1 hdom,
+    pgf_negativeBinomialMeasure (add_pos hr hs) hp hp1 hdom]
+  exact (Real.rpow_add hbase r s).symm
 
 end Probability
 

--- a/TauCeti/Probability/Distributions/NegativeBinomial.lean
+++ b/TauCeti/Probability/Distributions/NegativeBinomial.lean
@@ -242,6 +242,7 @@ theorem negativeBinomialMeasure_real_singleton {r p : ℝ} (hr : 0 ≤ r) (hp : 
 
 Thus the shape-zero and success-probability-one laws are supported only at zero, while positive
 shape and success probability strictly below one give positive mass to every natural number. -/
+@[simp]
 theorem negativeBinomialWeightReal_pos_iff {r p : ℝ} (hr : 0 ≤ r) (hp : 0 < p)
     (hp1 : p ≤ 1) (k : ℕ) :
     0 < negativeBinomialWeightReal r p k ↔ k = 0 ∨ (0 < r ∧ p < 1) := by
@@ -367,7 +368,8 @@ theorem negativeBinomialMeasure_conv_negativeBinomialMeasure {r s p : ℝ}
     have hbase : 0 < p / (1 - (1 - p) * t) := by
       apply div_pos hp
       exact sub_pos.mpr (lt_of_le_of_lt (le_abs_self _) hdom)
-    rw [Measure.pgf_conv _ _ ht_abs.le, pgf_negativeBinomialMeasure hr hp hp1 hdom,
+    rw [Measure.pgf_conv_of_abs_le_one _ _ ht_abs.le,
+      pgf_negativeBinomialMeasure hr hp hp1 hdom,
       pgf_negativeBinomialMeasure hs hp hp1 hdom,
       pgf_negativeBinomialMeasure (add_pos hr hs) hp hp1 hdom]
     exact (Real.rpow_add hbase r s).symm

--- a/TauCeti/Probability/GeneratingFunction.lean
+++ b/TauCeti/Probability/GeneratingFunction.lean
@@ -51,6 +51,8 @@ corresponding measure-integral formulas directly.
 * `TauCeti.Probability.IndepFun.pgf_add_of_abs_le_one` and
   `TauCeti.Probability.iIndepFun.pgf_sum_of_abs_le_one` — the corresponding formulas on the
   interval `[-1, 1]`, where integrability is automatic.
+* `TauCeti.Probability.pgf_conv` — convolution of finite measures becomes multiplication on
+  `[-1, 1]`.
 * `TauCeti.Probability.hasSum_pgf` and `TauCeti.Probability.pgf_eq_tsum` — the power-series
   expansion in the singleton masses, valid on `[-1, 1]`.
 * `TauCeti.Probability.hasFPowerSeriesOnBall_pgf` and `TauCeti.Probability.analyticOnNhd_pgf` —
@@ -165,6 +167,15 @@ theorem IndepFun.pgf_add_of_abs_le_one [IsFiniteMeasure μ] {X Y : Ω → ℕ}
     (ht : |t| ≤ 1) : pgf (X + Y) μ t = pgf X μ t * pgf Y μ t :=
   IndepFun.pgf_add hXY t (integrable_pow_of_abs_le_one hX ht)
     (integrable_pow_of_abs_le_one hY ht)
+
+/-- On `[-1, 1]`, the probability-generating function sends convolution of finite measures to
+multiplication. -/
+theorem pgf_conv (μ ν : Measure ℕ) [IsFiniteMeasure μ] [IsFiniteMeasure ν] {t : ℝ}
+    (ht : |t| ≤ 1) : pgf id (μ ∗ ν) t = pgf id μ t * pgf id ν t := by
+  rw [pgf_def, integral_conv (integrable_pow_of_abs_le_one aemeasurable_id ht)]
+  simp_rw [id_eq, pow_add, integral_const_mul]
+  rw [integral_mul_const, ← pgf_def, ← pgf_def]
+  rfl
 
 /-- A probability-generating function turns a finite sum of independent random variables into the
 product of their generating functions whenever every factor integrand is integrable. -/

--- a/TauCeti/Probability/GeneratingFunction.lean
+++ b/TauCeti/Probability/GeneratingFunction.lean
@@ -51,7 +51,7 @@ corresponding measure-integral formulas directly.
 * `TauCeti.Probability.IndepFun.pgf_add_of_abs_le_one` and
   `TauCeti.Probability.iIndepFun.pgf_sum_of_abs_le_one` — the corresponding formulas on the
   interval `[-1, 1]`, where integrability is automatic.
-* `TauCeti.Probability.pgf_conv` — convolution of finite measures becomes multiplication on
+* `Measure.pgf_conv` — convolution of finite measures becomes multiplication on
   `[-1, 1]`.
 * `TauCeti.Probability.hasSum_pgf` and `TauCeti.Probability.pgf_eq_tsum` — the power-series
   expansion in the singleton masses, valid on `[-1, 1]`.
@@ -170,7 +170,8 @@ theorem IndepFun.pgf_add_of_abs_le_one [IsFiniteMeasure μ] {X Y : Ω → ℕ}
 
 /-- On `[-1, 1]`, the probability-generating function sends convolution of finite measures to
 multiplication. -/
-theorem pgf_conv (μ ν : Measure ℕ) [IsFiniteMeasure μ] [IsFiniteMeasure ν] {t : ℝ}
+theorem _root_.MeasureTheory.Measure.pgf_conv (μ ν : Measure ℕ) [IsFiniteMeasure μ]
+    [IsFiniteMeasure ν] {t : ℝ}
     (ht : |t| ≤ 1) : pgf id (μ ∗ ν) t = pgf id μ t * pgf id ν t := by
   rw [pgf_def, integral_conv (integrable_pow_of_abs_le_one aemeasurable_id ht)]
   simp_rw [id_eq, pow_add, integral_const_mul]

--- a/TauCeti/Probability/GeneratingFunction.lean
+++ b/TauCeti/Probability/GeneratingFunction.lean
@@ -51,7 +51,8 @@ corresponding measure-integral formulas directly.
 * `TauCeti.Probability.IndepFun.pgf_add_of_abs_le_one` and
   `TauCeti.Probability.iIndepFun.pgf_sum_of_abs_le_one` — the corresponding formulas on the
   interval `[-1, 1]`, where integrability is automatic.
-* `Measure.pgf_conv` — convolution of finite measures becomes multiplication on
+* `Measure.pgf_conv` and `Measure.pgf_conv_of_abs_le_one` — convolution becomes
+  multiplication under the natural integrability hypotheses, and for finite measures on
   `[-1, 1]`.
 * `TauCeti.Probability.hasSum_pgf` and `TauCeti.Probability.pgf_eq_tsum` — the power-series
   expansion in the singleton masses, valid on `[-1, 1]`.
@@ -168,15 +169,30 @@ theorem IndepFun.pgf_add_of_abs_le_one [IsFiniteMeasure μ] {X Y : Ω → ℕ}
   IndepFun.pgf_add hXY t (integrable_pow_of_abs_le_one hX ht)
     (integrable_pow_of_abs_le_one hY ht)
 
-/-- On `[-1, 1]`, the probability-generating function sends convolution of finite measures to
-multiplication. -/
-theorem _root_.MeasureTheory.Measure.pgf_conv (μ ν : Measure ℕ) [IsFiniteMeasure μ]
-    [IsFiniteMeasure ν] {t : ℝ}
-    (ht : |t| ≤ 1) : pgf id (μ ∗ ν) t = pgf id μ t * pgf id ν t := by
-  rw [pgf_def, integral_conv (integrable_pow_of_abs_le_one aemeasurable_id ht)]
-  simp_rw [id_eq, pow_add, integral_const_mul]
+/-- The probability-generating function sends convolution to multiplication whenever both factor
+integrands are integrable. -/
+theorem _root_.MeasureTheory.Measure.pgf_conv (μ ν : Measure ℕ) [SFinite μ] [SFinite ν]
+    (t : ℝ) (hμ : Integrable (fun k => t ^ k) μ) (hν : Integrable (fun k => t ^ k) ν) :
+    pgf id (μ ∗ ν) t = pgf id μ t * pgf id ν t := by
+  have hconv : Integrable (fun k : ℕ => t ^ k) (μ ∗ ν) := by
+    rw [Measure.conv, integrable_map_measure .of_discrete .of_discrete]
+    convert hμ.mul_prod hν using 1
+    ext z
+    simp [pow_add]
+  rw [pgf_def]
+  simp only [id_eq]
+  rw [integral_conv hconv]
+  simp_rw [pow_add, integral_const_mul]
   rw [integral_mul_const, ← pgf_def, ← pgf_def]
   rfl
+
+/-- On `[-1, 1]`, the probability-generating function sends convolution of finite measures to
+multiplication. -/
+theorem _root_.MeasureTheory.Measure.pgf_conv_of_abs_le_one (μ ν : Measure ℕ)
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν] {t : ℝ} (ht : |t| ≤ 1) :
+    pgf id (μ ∗ ν) t = pgf id μ t * pgf id ν t :=
+  Measure.pgf_conv μ ν t (integrable_pow_of_abs_le_one aemeasurable_id ht)
+    (integrable_pow_of_abs_le_one aemeasurable_id ht)
 
 /-- A probability-generating function turns a finite sum of independent random variables into the
 product of their generating functions whenever every factor integrand is integrable. -/


### PR DESCRIPTION
This PR characterizes the exact native support of the valid negative-binomial law and proves that convolution at a fixed success probability adds the real shape parameters. It advances `TauCetiRoadmap/StandardDistributions/README.md`, Layer 3, “Negative binomial,” specifically the target requiring the native mass and support formulas and `negativeBinomialMeasure r p ∗ negativeBinomialMeasure s p = negativeBinomialMeasure (r + s) p` for nonnegative shapes and `0 < p ≤ 1`.

The support theorem treats the totalized boundaries honestly: shape zero and success probability one are supported only at zero, while positive shape with `p < 1` gives nonzero mass at every natural number. The convolution proof handles the Dirac boundaries separately and, in the nondegenerate case, reuses `IndepFun.pgf_add_of_abs_le_one`, `measure_eq_of_pgf_eqOn`, the existing negative-binomial PGF, and `Real.rpow_add`; no generalized Vandermonde identity is reproved.

This is the most effective current Layer 3 step because the measure/mass and PGF foundations have landed and the result directly supplies the convolution input for Layer 4 item 4’s law of finite sums of i.i.d. geometric variables. After this PR, the negative-binomial family still needs cast moments and transforms, cumulative/CDF formulas, parameter measurability, and the remaining shape-zero analytic boundary formulas; Layer 4’s geometric-sum theorem can then consume this convolution law.

The formulas follow N. L. Johnson, A. W. Kemp, and S. Kotz, *Univariate Discrete Distributions*, 3rd ed., Wiley (2005), Chapter 6. No Mathlib infrastructure is vendored.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"negativebinomialmeasure-conv-negativebinomialmeasure"}-->

🤖 Prepared with Codex
