### PR TITLE
feat(CanonicalHeight): the canonical height vanishes exactly on the torsion points

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -53,10 +53,16 @@ with — is half of it. Getting this wrong would scale every later invariant.
   statement it specialises lives in `TauCeti/LinearAlgebra/QuadraticForm/OfParallelogram.lean`.
 * `WeierstrassCurve.Affine.Point.canonicalHeight_nonneg`: it is non-negative, read off the
   defining sequence termwise.
+* `WeierstrassCurve.Affine.Point.canonicalHeight_eq_zero_iff_isOfFinAddOrder`: it vanishes exactly
+  on the torsion points. The two directions are also available separately, because they need
+  different hypotheses: `canonicalHeight_eq_zero_of_isOfFinAddOrder` is quadraticity at a
+  vanishing multiple and needs no finiteness, while `isOfFinAddOrder_of_canonicalHeight_eq_zero`
+  assumes Northcott finiteness for the canonical height itself.
 * `WeierstrassCurve.Affine.Point.abs_canonicalHeight_sub_naiveHeight_le`: the canonical height stays
   within a bounded distance of *half* the naïve one, by a
   constant depending only on the curve. This is what makes the two interchangeable in
-  finiteness arguments — in particular Northcott finiteness transfers to it.
+  finiteness arguments — in particular Northcott finiteness transfers to it, which the `Northcott`
+  instance below makes formal.
 
 ## Implementation notes
 
@@ -270,5 +276,52 @@ theorem Point.canonicalHeight_nsmul [W.toAffine.IsElliptic] (n : ℕ) (P : W.Poi
   rw [← natCast_zsmul, Point.canonicalHeight_zsmul]
   push_cast
   ring
+
+/-- **A torsion point has canonical height zero.** Unlike the converse this needs no Northcott
+hypothesis, so it holds over every field carrying admissible absolute values. -/
+theorem Point.canonicalHeight_eq_zero_of_isOfFinAddOrder [W.toAffine.IsElliptic] {P : W.Point}
+    (h : IsOfFinAddOrder P) : P.canonicalHeight = 0 := by
+  -- Quadraticity at `n = addOrderOf P`, where `n • P = 0` and `n ≠ 0`: `n² * canonicalHeight P`
+  -- vanishes, and `n² ≠ 0`.
+  simpa [h.addOrderOf_pos.ne'] using (Point.canonicalHeight_nsmul (addOrderOf P) P).symm
+
+/-- **Northcott finiteness transfers from the naïve height to the canonical one.** This is what
+lets the results below assume Northcott for the canonical height itself while callers supply only
+the naïve height — or, through `MordellWeil/NaiveHeight.lean`, only the field height. -/
+instance [W.toAffine.IsElliptic] [Northcott (Point.naiveHeight (W := W))] :
+    Northcott (Point.canonicalHeight (W := W)) := by
+  -- `abs_canonicalHeight_sub_naiveHeight_le` gives a `D` for which `canonicalHeight Q ≤ B` forces
+  -- `naiveHeight Q ≤ 2 (B + D)`, so every sublevel set of the former sits inside a finite sublevel
+  -- set of the latter.
+  obtain ⟨D, hD⟩ := Point.abs_canonicalHeight_sub_naiveHeight_le (W := W)
+  refine ⟨fun B ↦ (Northcott.finite_le (h := Point.naiveHeight (W := W)) (2 * (B + D))).subset ?_⟩
+  intro Q hQ
+  simp only [Set.mem_ofPred_eq] at hQ ⊢
+  linarith [(abs_le.1 (hD Q)).1]
+
+/-- **A point of canonical height zero is torsion.** The hypothesis is `Northcott` for the
+canonical height, the class this API takes finiteness from; the instance above supplies it from
+the naïve height and `MordellWeil/NaiveHeight.lean` from the field height, so a caller carrying
+either of those needs nothing extra. -/
+theorem Point.isOfFinAddOrder_of_canonicalHeight_eq_zero [W.toAffine.IsElliptic]
+    [Northcott (Point.canonicalHeight (W := W))] {P : W.Point} (h : P.canonicalHeight = 0) :
+    IsOfFinAddOrder P := by
+  -- Quadraticity sends every multiple to `n² * canonicalHeight P = 0`, so they all lie in the
+  -- sublevel set `{Q | canonicalHeight Q ≤ 0}`, which Northcott makes finite.
+  refine finite_multiples.1 ?_
+  refine (Northcott.finite_le (h := Point.canonicalHeight (W := W)) 0).subset ?_
+  rintro Q ⟨n, rfl⟩
+  simp [h]
+
+/-- **The canonical height vanishes exactly on the torsion points**, identifying the kernel of
+the canonical height with the torsion subgroup. This is one input to positive definiteness on the
+free part, and so to the regulator; the others — polarising it, and finite generation of `W.Point`
+— are elsewhere, and neither is supplied here. -/
+@[simp]
+theorem Point.canonicalHeight_eq_zero_iff_isOfFinAddOrder [W.toAffine.IsElliptic]
+    [Northcott (Point.canonicalHeight (W := W))] (P : W.Point) :
+    P.canonicalHeight = 0 ↔ IsOfFinAddOrder P :=
+  ⟨Point.isOfFinAddOrder_of_canonicalHeight_eq_zero,
+    Point.canonicalHeight_eq_zero_of_isOfFinAddOrder⟩
 
 end WeierstrassCurve.Affine


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"canonical-height"}-->

## The target

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 6 lists the canonical-height milestones in order:

> construction of `ĥ` with bounded difference from the naïve height, quadraticity,
> nonnegativity, **`ĥ(P) = 0 ↔ P` torsion**, the Néron–Tate bilinear pairing, …

The first three have landed (#5600, #5612, #5619). This is the fourth, and it is the first that
needs all three at once: the bounded difference supplies the bound, quadraticity supplies the
multiples, and nonnegativity is what makes "vanishes" the whole story rather than one inequality
of two.

## What it adds

```lean
theorem Point.canonicalHeight_eq_zero_of_isOfFinAddOrder [W.toAffine.IsElliptic] {P : W.Point}
    (h : IsOfFinAddOrder P) : P.canonicalHeight = 0

theorem Point.isOfFinAddOrder_of_canonicalHeight_eq_zero [W.toAffine.IsElliptic]
    [Northcott (Point.naiveHeight (W := W))] {P : W.Point} (h : P.canonicalHeight = 0) :
    IsOfFinAddOrder P

@[simp]
theorem Point.canonicalHeight_eq_zero_iff_isOfFinAddOrder [W.toAffine.IsElliptic]
    [Northcott (Point.naiveHeight (W := W))] (P : W.Point) :
    P.canonicalHeight = 0 ↔ IsOfFinAddOrder P
```

## The two directions are stated separately, because their hypotheses differ

This is the API decision in this PR, and it is not stylistic.

**`ĥ(P) = 0` from torsion needs no finiteness.** With `n = addOrderOf P`, quadraticity
(`canonicalHeight_nsmul`) reads `0 = ĥ(0) = n² · ĥ(P)`, and `n² ≠ 0` in `ℝ`. So that direction
holds over *every* field carrying admissible absolute values — no Northcott property, no number
field. Folding it into the `↔` would silently strengthen it, and a consumer with a torsion point
over a field with no Northcott instance could not use it at all.

**The converse is where Northcott enters**, and it is the only place it does: all the multiples
`n • P` satisfy `|ĥ(n • P) − h(n • P)/2| ≤ D` for the single constant `D` of
`abs_canonicalHeight_sub_naiveHeight_le`, and `ĥ(n • P) = n² · ĥ(P) = 0`, so `h(n • P) ≤ 2 D` for
every `n`. `Northcott.finite_le` makes that set finite and `finite_multiples` converts finitely
many multiples into finite order.

## The Northcott hypothesis is on the canonical height itself

The converse and the iff assume `Northcott (Point.canonicalHeight (W := W))` — finiteness of the
sublevel sets of `ĥ`, which is exactly what the argument consumes — rather than Northcott for the
naïve height or, as the neighbouring `MordellWeil/` declarations carry, for the field height
`logHeight₁`. That is the weakest of the three, and it makes the proof shorter: every multiple of
a height-zero point lands in `{Q | ĥ Q ≤ 0}`, so the bounded-difference lemma is not needed at all
in the converse.

To keep it free for callers, this PR also adds the transfer that the module docstring already
promised about `abs_canonicalHeight_sub_naiveHeight_le` ("Northcott finiteness transfers to it"):

```lean
instance [W.toAffine.IsElliptic] [Northcott (Point.naiveHeight (W := W))] :
    Northcott (Point.canonicalHeight (W := W))
```

`ĥ Q ≤ B` forces `h Q ≤ 2 (B + D)` for the single constant `D`, so each sublevel set of `ĥ` sits
inside a finite sublevel set of `h`. Composed with the existing instance in
`MordellWeil/NaiveHeight.lean`, the chain runs `Northcott logHeight₁ → Northcott h → Northcott ĥ`,
with no reverse instance and so no loop.

Verified rather than assumed: callers holding only `[Northcott (logHeight₁ (K := F))]`, and
callers holding only `[Northcott (Point.naiveHeight (W := W))]`, both still apply all three
theorems, and the `@[simp]` rule still fires under the field-level instance alone — each checked
by compiling an `example`.

One consequence worth naming: the converse no longer calls `finite_naiveHeight_le`, a one-line
TauCeti wrapper around `Northcott.finite_le` stated at the field level. That wrapper already had
no call sites on `main`; this PR neither changes that nor touches it.

## `@[simp]` on the iff

`ĥ P = 0` normalises to `IsOfFinAddOrder P`, not the reverse: the equation mentions a definition
and has no API, while the predicate is where the API lives (`addOrderOf_pos`, `finite_multiples`,
the torsion subgroup). Mathlib tags the same shape the same way — `orderOf_eq_zero_iff` and its
`to_additive` twin are `@[simp]`.

It does **not** strand the sharper, already-`@[simp]` `canonicalHeight_zero`, and that was checked
rather than hoped: `canonicalHeight_zero` carries no `[Northcott …]`, so the general rule cannot
fire everywhere the special case applies, `simpNF` reports no conflict, and
`(0 : W.Point).canonicalHeight = 0` is still closed by `simp` both with and without a Northcott
instance in scope.

## Reuse

From Mathlib: `addOrderOf`, `IsOfFinAddOrder.addOrderOf_pos`, `finite_multiples`,
`Northcott.finite_le`, `le_of_abs_le`. `finite_multiples` is the `to_additive` image of
`finite_powers` (`Mathlib/GroupTheory/OrderOfElement.lean:649`), so it is text nowhere in Mathlib
and was found by elaboration rather than grep.

From this development, all already reviewed: `canonicalHeight_nsmul` (#5612),
`abs_canonicalHeight_sub_naiveHeight_le` and `canonicalHeight_zero` (#5600). No new machinery, and
no new import.

Absence checked before writing: `canonicalHeight` does not occur anywhere in the pinned Mathlib,
so there is nothing there to reuse or duplicate; over TauCeti `main`, `git grep -n
'canonicalHeight_eq_zero\|isOfFinAddOrder_of_canonicalHeight'` returns nothing.

## Placement

`EllipticCurve/CanonicalHeight.lean`, after the quadraticity lemmas the proofs consume. The file's
module docstring already promised that "Northcott finiteness for `h` transfers to the canonical
height through this" about `abs_canonicalHeight_sub_naiveHeight_le`; this is that transfer being
used. The Main-results list gains one entry recording why the two directions exist separately.

## Provenance

**Original work.** The chain's intake records that the Néron–Tate height has no source: it is the
one Layer 6 item with nothing to port. `MichaelStollBayreuth/EllipticCurves` has the naïve height
and its approximate parallelogram law, both already on `main`, and no canonical height.

## Gates

- `lake build`: green, 0 errors, 0 warnings under `warningAsError = true`, no Mathlib recompiled.
- **`#lint in TauCeti` — the 13-linter environment set**: "All linting checks passed", 0 errors in
  44 declarations.
- `#print axioms` on all three: `[propext, Classical.choice, Quot.sound]`.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; no line over 100 characters; longest new
  proof 7 lines (the transfer instance); every new declaration far under the elaboration budget.
- One file touched.
- Claim at `refs/tauceti-claims/author/EllipticCurves/canonical-height-torsion`.
