### PR TITLE
feat: identify low-degree Tate cohomology

### DIFF
--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
@@ -115,7 +115,7 @@ elementary tensor `⟦g⟧ ⊗ₜ a`. -/
 @[simp]
 theorem HNegTwoAddEquivTensorOfIsTrivial_single (g : G) (a : A) :
     HNegTwoAddEquivTensorOfIsTrivial A
-      (((TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app A).inv
+      ((TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).inv.app A
         (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a)))) =
       Additive.ofMul (Abelianization.of g) ⊗ₜ[ℤ] a := by
   let e : tateCohomology A (-2) ≅ groupHomology.H1 A :=
@@ -132,7 +132,7 @@ homology class. -/
 theorem HNegTwoAddEquivTensorOfIsTrivial_symm_tmul (g : G) (a : A) :
     (HNegTwoAddEquivTensorOfIsTrivial A).symm
         (Additive.ofMul (Abelianization.of g) ⊗ₜ[ℤ] a) =
-      ((TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app A).inv
+      (TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).inv.app A
         (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a))) := by
   apply (HNegTwoAddEquivTensorOfIsTrivial A).injective
   rw [AddEquiv.apply_symm_apply, HNegTwoAddEquivTensorOfIsTrivial_single]
@@ -151,8 +151,8 @@ of `g` in the additive abelianization. -/
 @[simp]
 theorem HNegTwoAddEquivAbelianization_single_one (g : G) :
     HNegTwoAddEquivAbelianization
-      (((TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app
-        (Rep.trivial ℤ G ℤ)).inv
+      ((TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).inv.app
+        (Rep.trivial ℤ G ℤ)
         (H1π (Rep.trivial ℤ G ℤ)
           ((cycles₁IsoOfIsTrivial (Rep.trivial ℤ G ℤ)).inv (Finsupp.single g 1)))) =
       Additive.ofMul (Abelianization.of g) := by
@@ -165,8 +165,8 @@ class represented by `(g, 1)`. -/
 @[simp]
 theorem HNegTwoAddEquivAbelianization_symm_of (g : G) :
     HNegTwoAddEquivAbelianization.symm (Additive.ofMul (Abelianization.of g)) =
-      ((TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app
-        (Rep.trivial ℤ G ℤ)).inv
+      (TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).inv.app
+        (Rep.trivial ℤ G ℤ)
         (H1π (Rep.trivial ℤ G ℤ)
           ((cycles₁IsoOfIsTrivial (Rep.trivial ℤ G ℤ)).inv (Finsupp.single g 1))) := by
   apply HNegTwoAddEquivAbelianization.injective

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
@@ -104,6 +104,14 @@ theorem H0π_comp_H0IsoNormQuotient_hom (M : Rep R G) :
       ModuleCat.ofHom (Submodule.mkQ ((range M.ρ.norm).submoduleOf M.ρ.invariants)) := by
   simp [H0π]
 
+/-- Composing the quotient map by the norm image with the inverse of the low-degree
+identification is the map from invariant representatives to degree-zero Tate cohomology. -/
+@[reassoc (attr := simp), elementwise (attr := simp)]
+theorem mkQ_comp_H0IsoNormQuotient_inv (M : Rep R G) :
+    ModuleCat.ofHom (Submodule.mkQ ((range M.ρ.norm).submoduleOf M.ρ.invariants)) ≫
+      (H0IsoNormQuotient M).inv = H0π M :=
+  (Iso.comp_inv_eq _).2 (H0π_comp_H0IsoNormQuotient_hom M).symm
+
 /-- An invariant represents the zero degree-zero Tate cohomology class exactly when it lies in
 the image of the norm. -/
 @[simp]
@@ -126,7 +134,10 @@ theorem H0_induction_on {M : Rep R G} {C : tateCohomology M 0 → Prop} (x : tat
     (h : ∀ y : M.ρ.invariants, C (H0π M y)) : C x := by
   obtain ⟨y, hy⟩ := Submodule.mkQ_surjective ((range M.ρ.norm).submoduleOf M.ρ.invariants)
     ((H0IsoNormQuotient M).hom x)
-  simpa [H0π, hy] using h y
+  have hx : H0π M y = x := by
+    rw [← mkQ_comp_H0IsoNormQuotient_inv_apply, ← Submodule.mkQ_apply, hy,
+      Iso.hom_inv_id_apply]
+  exact hx ▸ h y
 
 variable (A : Rep R G) [A.IsTrivial]
 

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
@@ -92,6 +92,11 @@ def H0π (M : Rep R G) : ModuleCat.of R M.ρ.invariants ⟶ tateCohomology M 0 :
   ModuleCat.ofHom (Submodule.mkQ ((range M.ρ.norm).submoduleOf M.ρ.invariants)) ≫
     (H0IsoNormQuotient M).inv
 
+instance (M : Rep R G) : Epi (H0π M) :=
+  have : Epi (ModuleCat.ofHom (Submodule.mkQ ((range M.ρ.norm).submoduleOf M.ρ.invariants))) :=
+    (ModuleCat.epi_iff_surjective _).2 (Submodule.mkQ_surjective _)
+  inferInstanceAs <| Epi (_ ≫ _)
+
 /-- Passing an invariant representative to degree-zero Tate cohomology and then applying the
 low-degree identification is the quotient map by the norm image. -/
 @[reassoc (attr := simp), elementwise (attr := simp)]
@@ -99,6 +104,15 @@ theorem H0π_comp_H0IsoNormQuotient_hom (M : Rep R G) :
     H0π M ≫ (H0IsoNormQuotient M).hom =
       ModuleCat.ofHom (Submodule.mkQ ((range M.ρ.norm).submoduleOf M.ρ.invariants)) := by
   simp [H0π]
+
+/-- Every degree-zero Tate cohomology class is represented by an invariant, so a property of all
+classes follows from the property of the classes of invariants. -/
+@[elab_as_elim]
+theorem H0_induction_on {M : Rep R G} {C : tateCohomology M 0 → Prop} (x : tateCohomology M 0)
+    (h : ∀ y : M.ρ.invariants, C (H0π M y)) : C x := by
+  obtain ⟨y, hy⟩ := Submodule.mkQ_surjective ((range M.ρ.norm).submoduleOf M.ρ.invariants)
+    ((H0IsoNormQuotient M).hom x)
+  simpa [H0π, hy] using h y
 
 variable (A : Rep R G) [A.IsTrivial]
 

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
@@ -13,9 +13,9 @@ public import Mathlib.RepresentationTheory.Homological.TateCohomology.Basic
 
 This file gives the two low-degree descriptions used by the Nakayama map. For a representation
 `M` of a finite group, degree zero is the quotient of the invariant submodule by the image of the
-norm. For a trivial integral representation `A`, the comparison with first group homology
-identifies degree `-2` with `Gᵃᵇ ⊗[ℤ] A`, and hence, for `A = ℤ`, with the additive form of the
-abelianization.
+norm. For a trivial representation `A`, the comparison with first group homology identifies degree
+`-2` with `Gᵃᵇ ⊗[ℤ] A`, and hence, for the trivial integral representation, with the additive form
+of the abelianization.
 
 The degree-zero construction is adapted from
 `ClassFieldTheory/Cohomology/TateCohomology.lean` in `kbuzzard/ClassFieldTheory`, commit
@@ -26,9 +26,8 @@ right unitor.
 ## Main definitions
 
 * `TauCeti.TateCohomology.H0IsoNormQuotient`: `Ĥ⁰(G, M) ≅ Mᴳ / N_G M`.
-* `TauCeti.TateCohomology.HNegTwoIsoH1`: `Ĥ⁻²(G, M) ≅ H₁(G, M)`.
 * `TauCeti.TateCohomology.HNegTwoAddEquivTensorOfIsTrivial`:
-  `Ĥ⁻²(G, A) ≃+ Gᵃᵇ ⊗[ℤ] A` for a trivial `A : Rep ℤ G`.
+  `Ĥ⁻²(G, A) ≃+ Gᵃᵇ ⊗[ℤ] A` for a trivial representation `A`.
 * `TauCeti.TateCohomology.HNegTwoAddEquivAbelianization`:
   `Ĥ⁻²(G, ℤ) ≃+ Additive (Gᵃᵇ)`.
 
@@ -88,33 +87,57 @@ def H0IsoNormQuotient (M : Rep R G) :
     · rintro ⟨y, rfl⟩
       exact ⟨⟨M.norm.hom y, norm_comp_d_eq_zero_apply _ y⟩, ⟨_, rfl⟩, rfl⟩
 
-/-- In degree `-2`, Tate cohomology agrees with first group homology. This is the degree-`-2`
-component of Mathlib's comparison `TateCohomology.isoGroupHomology`, named so that composites with
-it, and the lemmas identifying their values, can be stated at the type `groupHomology.H1 M`. -/
-def HNegTwoIsoH1 (M : Rep R G) : tateCohomology M (-2) ≅ groupHomology.H1 M :=
-  (TateCohomology.isoGroupHomology (-2) 1 (by omega)).app M
+/-- The map from invariant representatives to degree-zero Tate cohomology. -/
+def H0π (M : Rep R G) : ModuleCat.of R M.ρ.invariants ⟶ tateCohomology M 0 :=
+  ModuleCat.ofHom (Submodule.mkQ ((range M.ρ.norm).submoduleOf M.ρ.invariants)) ≫
+    (H0IsoNormQuotient M).inv
 
-variable {G : Type} [Group G] [Fintype G] (A : Rep ℤ G) [A.IsTrivial]
+/-- Passing an invariant representative to degree-zero Tate cohomology and then applying the
+low-degree identification is the quotient map by the norm image. -/
+@[reassoc (attr := simp), elementwise (attr := simp)]
+theorem H0π_comp_H0IsoNormQuotient_hom (M : Rep R G) :
+    H0π M ≫ (H0IsoNormQuotient M).hom =
+      ModuleCat.ofHom (Submodule.mkQ ((range M.ρ.norm).submoduleOf M.ρ.invariants)) := by
+  simp [H0π]
 
-/-- For a trivial representation `A` over `ℤ`, degree-`-2` Tate cohomology is the tensor product of
-the additive abelianization of the group with `A`. -/
+variable (A : Rep R G) [A.IsTrivial]
+
+/-- For a trivial representation `A`, degree-`-2` Tate cohomology is the tensor product of the
+additive abelianization of the group with `A`. -/
 def HNegTwoAddEquivTensorOfIsTrivial :
     tateCohomology A (-2) ≃+ (Additive <| Abelianization G) ⊗[ℤ] A :=
-  (HNegTwoIsoH1 A).toLinearEquiv.toAddEquiv.trans (H1AddEquivOfIsTrivial A)
+  let e : tateCohomology A (-2) ≅ groupHomology.H1 A :=
+    (TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app A
+  e.toLinearEquiv.toAddEquiv.trans (H1AddEquivOfIsTrivial A)
 
 /-- The degree-`-2` identification sends the homology class represented by `(g, a)` to the
 elementary tensor `⟦g⟧ ⊗ₜ a`. -/
 @[simp]
-theorem HNegTwoAddEquivTensorOfIsTrivial_apply_HNegTwoIsoH1_inv (g : G) (a : A) :
+theorem HNegTwoAddEquivTensorOfIsTrivial_single (g : G) (a : A) :
     HNegTwoAddEquivTensorOfIsTrivial A
-      ((HNegTwoIsoH1 A).inv (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a)))) =
+      (((TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app A).inv
+        (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a)))) =
       Additive.ofMul (Abelianization.of g) ⊗ₜ[ℤ] a := by
-  have hx : (HNegTwoIsoH1 A).toLinearEquiv.toAddEquiv
-      ((HNegTwoIsoH1 A).inv (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a)))) =
-      H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a)) :=
-    (HNegTwoIsoH1 A).inv_hom_id_apply _
-  simp only [HNegTwoAddEquivTensorOfIsTrivial, AddEquiv.trans_apply]
-  rw [hx, H1AddEquivOfIsTrivial_single]
+  let e : tateCohomology A (-2) ≅ groupHomology.H1 A :=
+    (TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app A
+  change HNegTwoAddEquivTensorOfIsTrivial A
+    (e.inv (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a)))) = _
+  change (H1AddEquivOfIsTrivial A)
+    (e.hom (e.inv (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a))))) = _
+  rw [e.inv_hom_id_apply, H1AddEquivOfIsTrivial_single]
+
+/-- The inverse degree-`-2` identification sends an elementary tensor to the corresponding Tate
+homology class. -/
+@[simp]
+theorem HNegTwoAddEquivTensorOfIsTrivial_symm_tmul (g : G) (a : A) :
+    (HNegTwoAddEquivTensorOfIsTrivial A).symm
+        (Additive.ofMul (Abelianization.of g) ⊗ₜ[ℤ] a) =
+      ((TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app A).inv
+        (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a))) := by
+  apply (HNegTwoAddEquivTensorOfIsTrivial A).injective
+  rw [AddEquiv.apply_symm_apply, HNegTwoAddEquivTensorOfIsTrivial_single]
+
+variable {G : Type} [Group G] [Fintype G]
 
 /-- The degree-`-2` Tate cohomology of the trivial integral representation is the additive
 abelianization of the group. -/
@@ -126,14 +149,27 @@ def HNegTwoAddEquivAbelianization :
 /-- The degree-`-2` identification sends the homology class represented by `(g, 1)` to the class
 of `g` in the additive abelianization. -/
 @[simp]
-theorem HNegTwoAddEquivAbelianization_apply_HNegTwoIsoH1_inv (g : G) :
+theorem HNegTwoAddEquivAbelianization_single_one (g : G) :
     HNegTwoAddEquivAbelianization
-      ((HNegTwoIsoH1 (Rep.trivial ℤ G ℤ)).inv
+      (((TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app
+        (Rep.trivial ℤ G ℤ)).inv
         (H1π (Rep.trivial ℤ G ℤ)
           ((cycles₁IsoOfIsTrivial (Rep.trivial ℤ G ℤ)).inv (Finsupp.single g 1)))) =
       Additive.ofMul (Abelianization.of g) := by
   simp only [HNegTwoAddEquivAbelianization, AddEquiv.trans_apply]
-  rw [HNegTwoAddEquivTensorOfIsTrivial_apply_HNegTwoIsoH1_inv]
+  rw [HNegTwoAddEquivTensorOfIsTrivial_single]
   simp
+
+/-- The inverse integral degree-`-2` identification sends the class of `g` to the Tate homology
+class represented by `(g, 1)`. -/
+@[simp]
+theorem HNegTwoAddEquivAbelianization_symm_of (g : G) :
+    HNegTwoAddEquivAbelianization.symm (Additive.ofMul (Abelianization.of g)) =
+      ((TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app
+        (Rep.trivial ℤ G ℤ)).inv
+        (H1π (Rep.trivial ℤ G ℤ)
+          ((cycles₁IsoOfIsTrivial (Rep.trivial ℤ G ℤ)).inv (Finsupp.single g 1))) := by
+  apply HNegTwoAddEquivAbelianization.injective
+  rw [AddEquiv.apply_symm_apply, HNegTwoAddEquivAbelianization_single_one]
 
 end TauCeti.TateCohomology

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
@@ -5,7 +5,6 @@ Authors: Codex
 -/
 module
 
-public import Mathlib.RepresentationTheory.Homological.GroupHomology.LowDegree
 public import Mathlib.RepresentationTheory.Homological.TateCohomology.Basic
 
 /-!
@@ -149,8 +148,13 @@ theorem HNegTwoAddEquivTensorOfIsTrivial_single (g : G) (a : A) :
       Additive.ofMul (Abelianization.of g) ⊗ₜ[ℤ] a := by
   let e : tateCohomology A (-2) ≅ groupHomology.H1 A :=
     (TateCohomology.isoGroupHomology (-2) 1 (Eq.refl (-2))).app A
+  -- The natural isomorphism lands in `groupHomology.functor R G 1`, whereas the low-degree API
+  -- uses the definitionally equal alias `groupHomology.H1`; an explicit rewrite cannot cross
+  -- that boundary at implicit transparency.
   change HNegTwoAddEquivTensorOfIsTrivial A
     (e.inv (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a)))) = _
+  -- Unfolding the composite similarly exposes the functor value rather than `H1`, so record the
+  -- definitionally equal, well-typed low-degree form before applying the isomorphism law.
   change (H1AddEquivOfIsTrivial A)
     (e.hom (e.inv (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a))))) = _
   rw [e.inv_hom_id_apply, H1AddEquivOfIsTrivial_single]

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
@@ -105,6 +105,21 @@ theorem H0π_comp_H0IsoNormQuotient_hom (M : Rep R G) :
       ModuleCat.ofHom (Submodule.mkQ ((range M.ρ.norm).submoduleOf M.ρ.invariants)) := by
   simp [H0π]
 
+/-- An invariant represents the zero degree-zero Tate cohomology class exactly when it lies in
+the image of the norm. -/
+@[simp]
+theorem H0π_eq_zero_iff {M : Rep R G} (y : M.ρ.invariants) :
+    H0π M y = 0 ↔ y ∈ (range M.ρ.norm).submoduleOf M.ρ.invariants := by
+  rw [← Submodule.Quotient.mk_eq_zero, ← H0π_comp_H0IsoNormQuotient_hom_apply]
+  exact ((H0IsoNormQuotient M).toLinearEquiv.map_eq_zero_iff).symm
+
+/-- Two invariants represent the same degree-zero Tate cohomology class exactly when their
+difference lies in the image of the norm. -/
+@[simp]
+theorem H0π_eq_iff {M : Rep R G} (y z : M.ρ.invariants) :
+    H0π M y = H0π M z ↔ y - z ∈ (range M.ρ.norm).submoduleOf M.ρ.invariants := by
+  rw [← sub_eq_zero, ← map_sub, H0π_eq_zero_iff]
+
 /-- Every degree-zero Tate cohomology class is represented by an invariant, so a property of all
 classes follows from the property of the classes of invariants. -/
 @[elab_as_elim]

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
@@ -13,8 +13,9 @@ public import Mathlib.RepresentationTheory.Homological.TateCohomology.Basic
 
 This file gives the two low-degree descriptions used by the Nakayama map. For a representation
 `M` of a finite group, degree zero is the quotient of the invariant submodule by the image of the
-norm. For the trivial integral representation, the comparison with first group homology
-identifies degree `-2` with the additive form of the abelianization.
+norm. For a trivial integral representation `A`, the comparison with first group homology
+identifies degree `-2` with `Gᵃᵇ ⊗[ℤ] A`, and hence, for `A = ℤ`, with the additive form of the
+abelianization.
 
 The degree-zero construction is adapted from
 `ClassFieldTheory/Cohomology/TateCohomology.lean` in `kbuzzard/ClassFieldTheory`, commit
@@ -24,8 +25,11 @@ right unitor.
 
 ## Main definitions
 
-* `TauCeti.TateCohomology.tateHZeroEquivNormQuotient`: `Ĥ⁰(G, M) ≅ Mᴳ / N_G M`.
-* `TauCeti.TateCohomology.tateHMinusTwoEquivAbelianization`:
+* `TauCeti.TateCohomology.H0IsoNormQuotient`: `Ĥ⁰(G, M) ≅ Mᴳ / N_G M`.
+* `TauCeti.TateCohomology.HNegTwoIsoH1`: `Ĥ⁻²(G, M) ≅ H₁(G, M)`.
+* `TauCeti.TateCohomology.HNegTwoAddEquivTensorOfIsTrivial`:
+  `Ĥ⁻²(G, A) ≃+ Gᵃᵇ ⊗[ℤ] A` for a trivial `A : Rep ℤ G`.
+* `TauCeti.TateCohomology.HNegTwoAddEquivAbelianization`:
   `Ĥ⁻²(G, ℤ) ≃+ Additive (Gᵃᵇ)`.
 
 ## References
@@ -34,11 +38,12 @@ right unitor.
 * K. S. Brown, *Cohomology of Groups*, Chapter VI, §5.
 -/
 
-@[expose] public noncomputable section
+public noncomputable section
 
 universe u
 
 open CategoryTheory Limits groupCohomology groupHomology LinearMap Rep
+open scoped TensorProduct
 
 namespace TauCeti.TateCohomology
 
@@ -49,13 +54,11 @@ namespace Zero
 variable (M : Rep R G)
 
 /-- The concrete short complex whose homology is degree-zero Tate cohomology. -/
-@[simps]
-def shortComplex : ShortComplex (ModuleCat R) :=
+private def shortComplex : ShortComplex (ModuleCat R) :=
   .mk M.norm.toModuleCatHom (d₀₁ M) (norm_comp_d_eq_zero M)
 
 /-- The degree-zero part of the Tate complex is the norm-to-coboundary short complex. -/
-@[simps!]
-def isoShortComplex : (tateComplex M).sc 0 ≅ shortComplex M := by
+private def isoShortComplex : (tateComplex M).sc 0 ≅ shortComplex M := by
   have hnorm :
       (chainsIso₀ M).hom ≫ M.norm.toModuleCatHom = M.tateNorm ≫ (cochainsIso₀ M).hom := by
     simp only [Rep.tateNorm, Category.assoc, Iso.inv_hom_id, Category.comp_id]
@@ -67,7 +70,7 @@ end Zero
 
 /-- Degree-zero Tate cohomology is the quotient of the invariant submodule by the image of the
 norm. -/
-def tateHZeroEquivNormQuotient (M : Rep R G) :
+def H0IsoNormQuotient (M : Rep R G) :
     tateCohomology M 0 ≅
       ModuleCat.of R (M.ρ.invariants ⧸ (range M.ρ.norm).submoduleOf M.ρ.invariants) := calc
   tateCohomology M 0
@@ -85,41 +88,52 @@ def tateHZeroEquivNormQuotient (M : Rep R G) :
     · rintro ⟨y, rfl⟩
       exact ⟨⟨M.norm.hom y, norm_comp_d_eq_zero_apply _ y⟩, ⟨_, rfl⟩, rfl⟩
 
-variable {G : Type} [Group G] [Fintype G]
+/-- In degree `-2`, Tate cohomology agrees with first group homology. This is the degree-`-2`
+component of Mathlib's comparison `TateCohomology.isoGroupHomology`, named so that composites with
+it, and the lemmas identifying their values, can be stated at the type `groupHomology.H1 M`. -/
+def HNegTwoIsoH1 (M : Rep R G) : tateCohomology M (-2) ≅ groupHomology.H1 M :=
+  (TateCohomology.isoGroupHomology (-2) 1 (by omega)).app M
 
-/-- In degree `-2`, Mathlib's comparison between Tate cohomology and group homology specializes to
-an isomorphism with first group homology. -/
-def negTwoIsoGroupHomology :
-    tateCohomology (Rep.trivial ℤ G ℤ) (-2) ≅
-      groupHomology (Rep.trivial ℤ G ℤ) 1 :=
-  (TateCohomology.isoGroupHomology (-2) 1 (by omega)).app (Rep.trivial ℤ G ℤ)
+variable {G : Type} [Group G] [Fintype G] (A : Rep ℤ G) [A.IsTrivial]
+
+/-- For a trivial representation `A` over `ℤ`, degree-`-2` Tate cohomology is the tensor product of
+the additive abelianization of the group with `A`. -/
+def HNegTwoAddEquivTensorOfIsTrivial :
+    tateCohomology A (-2) ≃+ (Additive <| Abelianization G) ⊗[ℤ] A :=
+  (HNegTwoIsoH1 A).toLinearEquiv.toAddEquiv.trans (H1AddEquivOfIsTrivial A)
+
+/-- The degree-`-2` identification sends the homology class represented by `(g, a)` to the
+elementary tensor `⟦g⟧ ⊗ₜ a`. -/
+@[simp]
+theorem HNegTwoAddEquivTensorOfIsTrivial_apply_HNegTwoIsoH1_inv (g : G) (a : A) :
+    HNegTwoAddEquivTensorOfIsTrivial A
+      ((HNegTwoIsoH1 A).inv (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a)))) =
+      Additive.ofMul (Abelianization.of g) ⊗ₜ[ℤ] a := by
+  have hx : (HNegTwoIsoH1 A).toLinearEquiv.toAddEquiv
+      ((HNegTwoIsoH1 A).inv (H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a)))) =
+      H1π A ((cycles₁IsoOfIsTrivial A).inv (Finsupp.single g a)) :=
+    (HNegTwoIsoH1 A).inv_hom_id_apply _
+  simp only [HNegTwoAddEquivTensorOfIsTrivial, AddEquiv.trans_apply]
+  rw [hx, H1AddEquivOfIsTrivial_single]
 
 /-- The degree-`-2` Tate cohomology of the trivial integral representation is the additive
 abelianization of the group. -/
-def tateHMinusTwoEquivAbelianization :
+def HNegTwoAddEquivAbelianization :
     tateCohomology (Rep.trivial ℤ G ℤ) (-2) ≃+ Additive (Abelianization G) :=
-  ((negTwoIsoGroupHomology (G := G)).toLinearEquiv.toAddEquiv.trans
-    (groupHomology.H1AddEquivOfIsTrivial (Rep.trivial ℤ G ℤ))).trans
+  (HNegTwoAddEquivTensorOfIsTrivial (Rep.trivial ℤ G ℤ)).trans
     (TensorProduct.rid ℤ (Additive (Abelianization G))).toAddEquiv
 
 /-- The degree-`-2` identification sends the homology class represented by `(g, 1)` to the class
 of `g` in the additive abelianization. -/
 @[simp]
-theorem tateHMinusTwoEquivAbelianization_apply_negTwoIsoGroupHomology_inv (g : G) :
-    tateHMinusTwoEquivAbelianization
-      ((negTwoIsoGroupHomology (G := G)).inv
-        (groupHomology.H1π (Rep.trivial ℤ G ℤ)
-          ((groupHomology.cycles₁IsoOfIsTrivial (Rep.trivial ℤ G ℤ)).inv
-            (Finsupp.single g 1)))) =
+theorem HNegTwoAddEquivAbelianization_apply_HNegTwoIsoH1_inv (g : G) :
+    HNegTwoAddEquivAbelianization
+      ((HNegTwoIsoH1 (Rep.trivial ℤ G ℤ)).inv
+        (H1π (Rep.trivial ℤ G ℤ)
+          ((cycles₁IsoOfIsTrivial (Rep.trivial ℤ G ℤ)).inv (Finsupp.single g 1)))) =
       Additive.ofMul (Abelianization.of g) := by
-  let x := groupHomology.H1π (Rep.trivial ℤ G ℤ)
-    ((groupHomology.cycles₁IsoOfIsTrivial (Rep.trivial ℤ G ℤ)).inv (Finsupp.single g 1))
-  have hx : (negTwoIsoGroupHomology (G := G)).toLinearEquiv.toAddEquiv
-      ((negTwoIsoGroupHomology (G := G)).inv x) = x :=
-    (negTwoIsoGroupHomology (G := G)).inv_hom_id_apply x
-  simp only [tateHMinusTwoEquivAbelianization, AddEquiv.trans_apply]
-  rw [hx]
-  rw [groupHomology.H1AddEquivOfIsTrivial_single]
+  simp only [HNegTwoAddEquivAbelianization, AddEquiv.trans_apply]
+  rw [HNegTwoAddEquivTensorOfIsTrivial_apply_HNegTwoIsoH1_inv]
   simp
 
 end TauCeti.TateCohomology

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/LowDegree.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.RepresentationTheory.Homological.GroupHomology.LowDegree
+public import Mathlib.RepresentationTheory.Homological.TateCohomology.Basic
+
+/-!
+# Low-degree Tate cohomology
+
+This file gives the two low-degree descriptions used by the Nakayama map. For a representation
+`M` of a finite group, degree zero is the quotient of the invariant submodule by the image of the
+norm. For the trivial integral representation, the comparison with first group homology
+identifies degree `-2` with the additive form of the abelianization.
+
+The degree-zero construction is adapted from
+`ClassFieldTheory/Cohomology/TateCohomology.lean` in `kbuzzard/ClassFieldTheory`, commit
+`ccc3323c6750abca25b49b35106f54eb3a398509`. The degree-`-2` identification combines Mathlib's
+comparison with group homology, `groupHomology.H1AddEquivOfIsTrivial`, and the tensor-product
+right unitor.
+
+## Main definitions
+
+* `TauCeti.TateCohomology.tateHZeroEquivNormQuotient`: `Ĥ⁰(G, M) ≅ Mᴳ / N_G M`.
+* `TauCeti.TateCohomology.tateHMinusTwoEquivAbelianization`:
+  `Ĥ⁻²(G, ℤ) ≃+ Additive (Gᵃᵇ)`.
+
+## References
+
+* E. Artin and J. Tate, *Class Field Theory*, Chapter XIV, §4.
+* K. S. Brown, *Cohomology of Groups*, Chapter VI, §5.
+-/
+
+@[expose] public noncomputable section
+
+universe u
+
+open CategoryTheory Limits groupCohomology groupHomology LinearMap Rep
+
+namespace TauCeti.TateCohomology
+
+variable {R G : Type u} [CommRing R] [Group G] [Fintype G]
+
+namespace Zero
+
+variable (M : Rep R G)
+
+/-- The concrete short complex whose homology is degree-zero Tate cohomology. -/
+@[simps]
+def shortComplex : ShortComplex (ModuleCat R) :=
+  .mk M.norm.toModuleCatHom (d₀₁ M) (norm_comp_d_eq_zero M)
+
+/-- The degree-zero part of the Tate complex is the norm-to-coboundary short complex. -/
+@[simps!]
+def isoShortComplex : (tateComplex M).sc 0 ≅ shortComplex M := by
+  have hnorm :
+      (chainsIso₀ M).hom ≫ M.norm.toModuleCatHom = M.tateNorm ≫ (cochainsIso₀ M).hom := by
+    simp only [Rep.tateNorm, Category.assoc, Iso.inv_hom_id, Category.comp_id]
+  exact (tateComplex M).isoSc' (-1) 0 1 (by simp) (by simp) ≪≫
+    ShortComplex.isoMk (by exact chainsIso₀ M) (cochainsIso₀ M) (cochainsIso₁ M)
+      hnorm (comp_d₀₁_eq M)
+
+end Zero
+
+/-- Degree-zero Tate cohomology is the quotient of the invariant submodule by the image of the
+norm. -/
+def tateHZeroEquivNormQuotient (M : Rep R G) :
+    tateCohomology M 0 ≅
+      ModuleCat.of R (M.ρ.invariants ⧸ (range M.ρ.norm).submoduleOf M.ρ.invariants) := calc
+  tateCohomology M 0
+      ≅ (Zero.shortComplex M).homology :=
+    ShortComplex.homologyMapIso (Zero.isoShortComplex M)
+  _ ≅ ModuleCat.of R (LinearMap.ker (d₀₁ M).hom ⧸ _) :=
+    ShortComplex.moduleCatHomologyIso _
+  _ ≅ ModuleCat.of R
+      (M.ρ.invariants ⧸ (range M.ρ.norm).submoduleOf M.ρ.invariants) := by
+    refine (Submodule.Quotient.equiv _ _
+      (LinearEquiv.ofEq _ _ (d₀₁_ker_eq_invariants M)) ?_).toModuleIso
+    refine Submodule.ext fun ⟨x, hx⟩ ↦ ⟨?_, ?_⟩
+    · rintro ⟨_, ⟨y, rfl⟩, hy⟩
+      exact ⟨y, congr(Subtype.val $hy)⟩
+    · rintro ⟨y, rfl⟩
+      exact ⟨⟨M.norm.hom y, norm_comp_d_eq_zero_apply _ y⟩, ⟨_, rfl⟩, rfl⟩
+
+variable {G : Type} [Group G] [Fintype G]
+
+/-- In degree `-2`, Mathlib's comparison between Tate cohomology and group homology specializes to
+an isomorphism with first group homology. -/
+def negTwoIsoGroupHomology :
+    tateCohomology (Rep.trivial ℤ G ℤ) (-2) ≅
+      groupHomology (Rep.trivial ℤ G ℤ) 1 :=
+  (TateCohomology.isoGroupHomology (-2) 1 (by omega)).app (Rep.trivial ℤ G ℤ)
+
+/-- The degree-`-2` Tate cohomology of the trivial integral representation is the additive
+abelianization of the group. -/
+def tateHMinusTwoEquivAbelianization :
+    tateCohomology (Rep.trivial ℤ G ℤ) (-2) ≃+ Additive (Abelianization G) :=
+  ((negTwoIsoGroupHomology (G := G)).toLinearEquiv.toAddEquiv.trans
+    (groupHomology.H1AddEquivOfIsTrivial (Rep.trivial ℤ G ℤ))).trans
+    (TensorProduct.rid ℤ (Additive (Abelianization G))).toAddEquiv
+
+/-- The degree-`-2` identification sends the homology class represented by `(g, 1)` to the class
+of `g` in the additive abelianization. -/
+@[simp]
+theorem tateHMinusTwoEquivAbelianization_apply_negTwoIsoGroupHomology_inv (g : G) :
+    tateHMinusTwoEquivAbelianization
+      ((negTwoIsoGroupHomology (G := G)).inv
+        (groupHomology.H1π (Rep.trivial ℤ G ℤ)
+          ((groupHomology.cycles₁IsoOfIsTrivial (Rep.trivial ℤ G ℤ)).inv
+            (Finsupp.single g 1)))) =
+      Additive.ofMul (Abelianization.of g) := by
+  let x := groupHomology.H1π (Rep.trivial ℤ G ℤ)
+    ((groupHomology.cycles₁IsoOfIsTrivial (Rep.trivial ℤ G ℤ)).inv (Finsupp.single g 1))
+  have hx : (negTwoIsoGroupHomology (G := G)).toLinearEquiv.toAddEquiv
+      ((negTwoIsoGroupHomology (G := G)).inv x) = x :=
+    (negTwoIsoGroupHomology (G := G)).inv_hom_id_apply x
+  simp only [tateHMinusTwoEquivAbelianization, AddEquiv.trans_apply]
+  rw [hx]
+  rw [groupHomology.H1AddEquivOfIsTrivial_single]
+  simp
+
+end TauCeti.TateCohomology


### PR DESCRIPTION
This PR identifies the two low-degree Tate groups used by the Nakayama map: degree zero as invariants modulo the norm image, and degree `-2` for the trivial integral representation as the additive abelianization. It places both results in the generic Tate-cohomology supplier and fixes the normalization of the latter with a generator calculation.

It advances `TauCetiRoadmap/ClassFieldTheory/README.md`, Layer 0, “audit and complete the cohomology suppliers,” specifically the missing `Ĥ⁻²(G, ℤ) ≃ Gᵃᵇ` and `Ĥ⁰(G, M) ≃ Mᴳ/N_GM` targets consumed by Layer 4's Nakayama map. After this PR, Layer 0 still needs restriction/corestriction, positive-degree inflation, all-degree cup products, cyclic periodicity and Herbrand quotients, and the generic Tate theorem before its exit criterion is met.

The degree-zero construction formally adapts `ClassFieldTheory/Cohomology/TateCohomology.lean` from `kbuzzard/ClassFieldTheory` at commit `ccc3323c6750abca25b49b35106f54eb3a398509`. The degree-`-2` equivalence composes Mathlib's Tate-to-homology comparison, `groupHomology.H1AddEquivOfIsTrivial`, and the tensor-product right unitor. No Mathlib infrastructure is vendored.

Roadmap: ClassFieldTheory

<!--tauceti-target:v1 {"focus":"ClassFieldTheory","id":"tate-low-degree-identifications"}-->

🤖 Prepared with Codex
