### PR TITLE
feat: add positive cyclic Tate periodicity

### DIFF
--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Periodic.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Periodic.lean
@@ -35,10 +35,12 @@ construction is copied.
 
 ## Main definitions
 
-* `TauCeti.TateCohomology.positiveEvenIso`: the common explicit model for positive even degrees.
-* `TauCeti.TateCohomology.positiveOddIso`: the common explicit model for positive odd degrees.
-* `TauCeti.TateCohomology.positivePeriodicIso`: the two-periodicity isomorphism between positive
-  degrees of the same parity.
+* `TauCeti.Rep.FiniteCyclicGroup.positiveEvenIso`: the common explicit model for positive even
+  degrees.
+* `TauCeti.Rep.FiniteCyclicGroup.positiveOddIso`: the common explicit model for positive odd
+  degrees.
+* `TauCeti.Rep.FiniteCyclicGroup.positivePeriodicIso`: the two-periodicity isomorphism between
+  positive degrees of the same parity.
 
 ## References
 
@@ -52,9 +54,9 @@ universe u
 
 open CategoryTheory
 
-namespace TauCeti.TateCohomology
+namespace TauCeti.Rep.FiniteCyclicGroup
 
-variable {R G : Type u} [CommRing R] [CommGroup G] [Fintype G]
+variable {R G : Type u} [CommRing R] [Group G] [Fintype G]
 
 /-- In a positive even degree, Tate cohomology of a finite cyclic group is the homology of
 `M --N--> M --(g - 1)--> M` for a chosen generator `g`.
@@ -63,9 +65,15 @@ The isomorphism is the composite of Mathlib's Tate-to-ordinary-cohomology compar
 calculation from the standard periodic resolution. -/
 def positiveEvenIso (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
     (n : ℕ) [NeZero n] (hn : Even n) :
-    tateCohomology M n ≅ (Rep.FiniteCyclicGroup.normHomCompSub M g).homology := by
+    let _ : IsCyclic G := isCyclic_iff_exists_zpowers_eq_top.mpr
+      ⟨g, (Subgroup.zpowers g).eq_top_iff'.mpr hg⟩
+    let _ : CommGroup G := IsCyclic.commGroup
+    tateCohomology M n ≅ (_root_.Rep.FiniteCyclicGroup.normHomCompSub M g).homology := by
+  letI : IsCyclic G := isCyclic_iff_exists_zpowers_eq_top.mpr
+    ⟨g, (Subgroup.zpowers g).eq_top_iff'.mpr hg⟩
+  letI : CommGroup G := IsCyclic.commGroup
   exact (_root_.TateCohomology.isoGroupCohomology n).app M ≪≫
-    Rep.FiniteCyclicGroup.groupCohomologyIsoEven M g hg n hn
+    _root_.Rep.FiniteCyclicGroup.groupCohomologyIsoEven M g hg n hn
 
 /-- In a positive odd degree, Tate cohomology of a finite cyclic group is the homology of
 `M --(g - 1)--> M --N--> M` for a chosen generator `g`.
@@ -74,10 +82,16 @@ The isomorphism is the composite of Mathlib's Tate-to-ordinary-cohomology compar
 calculation from the standard periodic resolution. -/
 def positiveOddIso (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
     (n : ℕ) (hn : Odd n) :
-    tateCohomology M n ≅ (Rep.FiniteCyclicGroup.subCompNormHom M g).homology := by
+    let _ : IsCyclic G := isCyclic_iff_exists_zpowers_eq_top.mpr
+      ⟨g, (Subgroup.zpowers g).eq_top_iff'.mpr hg⟩
+    let _ : CommGroup G := IsCyclic.commGroup
+    tateCohomology M n ≅ (_root_.Rep.FiniteCyclicGroup.subCompNormHom M g).homology := by
+  letI : IsCyclic G := isCyclic_iff_exists_zpowers_eq_top.mpr
+    ⟨g, (Subgroup.zpowers g).eq_top_iff'.mpr hg⟩
+  letI : CommGroup G := IsCyclic.commGroup
   haveI : NeZero n := ⟨hn.pos.ne'⟩
   exact (_root_.TateCohomology.isoGroupCohomology n).app M ≪≫
-    Rep.FiniteCyclicGroup.groupCohomologyIsoOdd M g hg n hn
+    _root_.Rep.FiniteCyclicGroup.groupCohomologyIsoOdd M g hg n hn
 
 /-- **Positive-degree two-periodicity for Tate cohomology of a finite cyclic group.** Positive
 Tate degrees congruent modulo two are isomorphic. The construction compares both degrees with the
@@ -132,4 +146,4 @@ theorem natCard_tateCohomology_eq_of_pos_of_modEq
     Nat.card (tateCohomology M m) = Nat.card (tateCohomology M n) :=
   Nat.card_congr (positivePeriodicIso M g hg m n hmn).toLinearEquiv.toEquiv
 
-end TauCeti.TateCohomology
+end TauCeti.Rep.FiniteCyclicGroup

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Periodic.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Periodic.lean
@@ -28,10 +28,9 @@ periodicity. The degree-zero and negative-degree comparisons are separate low-de
 
 The corresponding all-degree construction is `Rep.periodicTateCohomology` in
 `ClassFieldTheory/Cohomology/FiniteCyclic/UpDown.lean` from `kbuzzard/ClassFieldTheory`, commit
-`ccc3323c6750abca25b49b35106f54eb3a398509`. The implementation here is new: in positive degrees
-the pinned Mathlib already provides the periodic-resolution calculations
-`Rep.FiniteCyclicGroup.groupCohomologyIsoEven` and `groupCohomologyIsoOdd`, so no dimension-shift
-construction is copied.
+`ccc3323c6750abca25b49b35106f54eb3a398509`. Its positive-degree specialization has the same
+mathematical content as the periodicity below, expressed through the periodic-resolution
+calculations `Rep.FiniteCyclicGroup.groupCohomologyIsoEven` and `groupCohomologyIsoOdd`.
 
 ## Main definitions
 
@@ -93,11 +92,11 @@ def positiveOddIso (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
   exact (_root_.TateCohomology.isoGroupCohomology n).app M ≪≫
     _root_.Rep.FiniteCyclicGroup.groupCohomologyIsoOdd M g hg n hn
 
-/-- **Positive-degree two-periodicity for Tate cohomology of a finite cyclic group.** Positive
-Tate degrees congruent modulo two are isomorphic. The construction compares both degrees with the
-same homology object of the standard periodic resolution, using the even model or the odd model
-according to their common parity. -/
-def positivePeriodicIso (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
+/-- The generator-dependent comparison underlying positive-degree two-periodicity. It compares
+both degrees with the same homology object of the standard periodic resolution, using the even
+model or the odd model according to their common parity. -/
+def positivePeriodicIsoOfGenerator (M : Rep R G) (g : G)
+    (hg : ∀ x, x ∈ Subgroup.zpowers g)
     (m n : ℕ) [NeZero m] [NeZero n] (hmn : m ≡ n [MOD 2]) :
     tateCohomology M m ≅ tateCohomology M n := by
   by_cases hm : Even m
@@ -116,34 +115,46 @@ def positivePeriodicIso (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpower
     exact (positiveOddIso M g hg m (Nat.not_even_iff_odd.mp hm)).trans
       (positiveOddIso M g hg n hn).symm
 
-/-- In even degrees, `positivePeriodicIso` is the unique comparison obtained by identifying both
-Tate groups with the even homology object of the periodic resolution. -/
+/-- **Positive-degree two-periodicity for Tate cohomology of a finite cyclic group.** Positive
+Tate degrees congruent modulo two are isomorphic. -/
+def positivePeriodicIso (M : Rep R G) [IsCyclic G]
+    (m n : ℕ) [NeZero m] [NeZero n] (hmn : m ≡ n [MOD 2]) :
+    tateCohomology M m ≅ tateCohomology M n := by
+  let hgen := isCyclic_iff_exists_zpowers_eq_top.mp (inferInstance : IsCyclic G)
+  let g := hgen.choose
+  exact positivePeriodicIsoOfGenerator M g
+    (fun x ↦ hgen.choose_spec.ge (Subgroup.mem_top x)) m n hmn
+
+/-- In even degrees, `positivePeriodicIsoOfGenerator` is the unique comparison obtained by
+identifying both Tate groups with the even homology object of the periodic resolution. -/
 @[simp, reassoc]
-theorem positivePeriodicIso_hom_comp_positiveEvenIso_hom
+theorem positivePeriodicIsoOfGenerator_hom_comp_positiveEvenIso_hom
     (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
     (m n : ℕ) [NeZero m] [NeZero n] (hmn : m ≡ n [MOD 2])
     (hm : Even m) (hn : Even n) :
-    (positivePeriodicIso M g hg m n hmn).hom ≫ (positiveEvenIso M g hg n hn).hom =
+    (positivePeriodicIsoOfGenerator M g hg m n hmn).hom ≫
+        (positiveEvenIso M g hg n hn).hom =
       (positiveEvenIso M g hg m hm).hom := by
-  simp [positivePeriodicIso, hm]
+  simp [positivePeriodicIsoOfGenerator, hm]
 
-/-- In odd degrees, `positivePeriodicIso` is the unique comparison obtained by identifying both
-Tate groups with the odd homology object of the periodic resolution. -/
+/-- In odd degrees, `positivePeriodicIsoOfGenerator` is the unique comparison obtained by
+identifying both Tate groups with the odd homology object of the periodic resolution. -/
 @[simp, reassoc]
-theorem positivePeriodicIso_hom_comp_positiveOddIso_hom
+theorem positivePeriodicIsoOfGenerator_hom_comp_positiveOddIso_hom
     (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
     (m n : ℕ) [NeZero m] [NeZero n] (hmn : m ≡ n [MOD 2])
     (hm : Odd m) (hn : Odd n) :
-    (positivePeriodicIso M g hg m n hmn).hom ≫ (positiveOddIso M g hg n hn).hom =
+    (positivePeriodicIsoOfGenerator M g hg m n hmn).hom ≫
+        (positiveOddIso M g hg n hn).hom =
       (positiveOddIso M g hg m hm).hom := by
-  simp [positivePeriodicIso, Nat.not_even_iff_odd.mpr hm]
+  simp [positivePeriodicIsoOfGenerator, Nat.not_even_iff_odd.mpr hm]
 
 /-- Positive Tate cohomology groups in degrees congruent modulo two have the same cardinality.
 This is the form used in Herbrand-quotient computations. -/
 theorem natCard_tateCohomology_eq_of_pos_of_modEq
-    (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
+    (M : Rep R G) [IsCyclic G]
     (m n : ℕ) [NeZero m] [NeZero n] (hmn : m ≡ n [MOD 2]) :
     Nat.card (tateCohomology M m) = Nat.card (tateCohomology M n) :=
-  Nat.card_congr (positivePeriodicIso M g hg m n hmn).toLinearEquiv.toEquiv
+  Nat.card_congr (positivePeriodicIso M m n hmn).toLinearEquiv.toEquiv
 
 end Rep.FiniteCyclicGroup

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Periodic.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Periodic.lean
@@ -35,11 +35,11 @@ construction is copied.
 
 ## Main definitions
 
-* `TauCeti.Rep.FiniteCyclicGroup.positiveEvenIso`: the common explicit model for positive even
+* `Rep.FiniteCyclicGroup.positiveEvenIso`: the common explicit model for positive even
   degrees.
-* `TauCeti.Rep.FiniteCyclicGroup.positiveOddIso`: the common explicit model for positive odd
+* `Rep.FiniteCyclicGroup.positiveOddIso`: the common explicit model for positive odd
   degrees.
-* `TauCeti.Rep.FiniteCyclicGroup.positivePeriodicIso`: the two-periodicity isomorphism between
+* `Rep.FiniteCyclicGroup.positivePeriodicIso`: the two-periodicity isomorphism between
   positive degrees of the same parity.
 
 ## References
@@ -54,7 +54,7 @@ universe u
 
 open CategoryTheory
 
-namespace TauCeti.Rep.FiniteCyclicGroup
+namespace Rep.FiniteCyclicGroup
 
 variable {R G : Type u} [CommRing R] [Group G] [Fintype G]
 
@@ -146,4 +146,4 @@ theorem natCard_tateCohomology_eq_of_pos_of_modEq
     Nat.card (tateCohomology M m) = Nat.card (tateCohomology M n) :=
   Nat.card_congr (positivePeriodicIso M g hg m n hmn).toLinearEquiv.toEquiv
 
-end TauCeti.Rep.FiniteCyclicGroup
+end Rep.FiniteCyclicGroup

--- a/TauCeti/RepresentationTheory/Homological/TateCohomology/Periodic.lean
+++ b/TauCeti/RepresentationTheory/Homological/TateCohomology/Periodic.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RepresentationTheory.Homological.GroupCohomology.FiniteCyclic
+public import Mathlib.RepresentationTheory.Homological.TateCohomology.Basic
+
+/-!
+# Positive Tate cohomology of finite cyclic groups
+
+For a finite cyclic group, the standard periodic resolution alternates the norm map with
+`g - 1`, where `g` is a chosen generator. Consequently all positive Tate cohomology groups of a
+fixed parity are isomorphic: even degrees are the homology of
+
+`M --N--> M --(g - 1)--> M`,
+
+and odd degrees are the homology of the same two maps in the opposite order.
+
+Mathlib already constructs this periodic resolution and identifies its homology with ordinary
+group cohomology. It also identifies positive Tate cohomology with ordinary group cohomology.
+This file composes those two canonical comparisons and records the resulting positive-degree
+periodicity. The degree-zero and negative-degree comparisons are separate low-degree questions.
+
+## Provenance
+
+The corresponding all-degree construction is `Rep.periodicTateCohomology` in
+`ClassFieldTheory/Cohomology/FiniteCyclic/UpDown.lean` from `kbuzzard/ClassFieldTheory`, commit
+`ccc3323c6750abca25b49b35106f54eb3a398509`. The implementation here is new: in positive degrees
+the pinned Mathlib already provides the periodic-resolution calculations
+`Rep.FiniteCyclicGroup.groupCohomologyIsoEven` and `groupCohomologyIsoOdd`, so no dimension-shift
+construction is copied.
+
+## Main definitions
+
+* `TauCeti.TateCohomology.positiveEvenIso`: the common explicit model for positive even degrees.
+* `TauCeti.TateCohomology.positiveOddIso`: the common explicit model for positive odd degrees.
+* `TauCeti.TateCohomology.positivePeriodicIso`: the two-periodicity isomorphism between positive
+  degrees of the same parity.
+
+## References
+
+* K. S. Brown, *Cohomology of Groups*, Chapter VI, §2.
+* J.-P. Serre, *Local Fields*, Chapter VIII, §4.
+-/
+
+public noncomputable section
+
+universe u
+
+open CategoryTheory
+
+namespace TauCeti.TateCohomology
+
+variable {R G : Type u} [CommRing R] [CommGroup G] [Fintype G]
+
+/-- In a positive even degree, Tate cohomology of a finite cyclic group is the homology of
+`M --N--> M --(g - 1)--> M` for a chosen generator `g`.
+
+The isomorphism is the composite of Mathlib's Tate-to-ordinary-cohomology comparison and its
+calculation from the standard periodic resolution. -/
+def positiveEvenIso (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
+    (n : ℕ) [NeZero n] (hn : Even n) :
+    tateCohomology M n ≅ (Rep.FiniteCyclicGroup.normHomCompSub M g).homology := by
+  exact (_root_.TateCohomology.isoGroupCohomology n).app M ≪≫
+    Rep.FiniteCyclicGroup.groupCohomologyIsoEven M g hg n hn
+
+/-- In a positive odd degree, Tate cohomology of a finite cyclic group is the homology of
+`M --(g - 1)--> M --N--> M` for a chosen generator `g`.
+
+The isomorphism is the composite of Mathlib's Tate-to-ordinary-cohomology comparison and its
+calculation from the standard periodic resolution. -/
+def positiveOddIso (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
+    (n : ℕ) (hn : Odd n) :
+    tateCohomology M n ≅ (Rep.FiniteCyclicGroup.subCompNormHom M g).homology := by
+  haveI : NeZero n := ⟨hn.pos.ne'⟩
+  exact (_root_.TateCohomology.isoGroupCohomology n).app M ≪≫
+    Rep.FiniteCyclicGroup.groupCohomologyIsoOdd M g hg n hn
+
+/-- **Positive-degree two-periodicity for Tate cohomology of a finite cyclic group.** Positive
+Tate degrees congruent modulo two are isomorphic. The construction compares both degrees with the
+same homology object of the standard periodic resolution, using the even model or the odd model
+according to their common parity. -/
+def positivePeriodicIso (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
+    (m n : ℕ) [NeZero m] [NeZero n] (hmn : m ≡ n [MOD 2]) :
+    tateCohomology M m ≅ tateCohomology M n := by
+  by_cases hm : Even m
+  · have hn : Even n := by
+      have hmn' : m % 2 = n % 2 := hmn
+      rw [Nat.even_iff]
+      rw [Nat.even_iff] at hm
+      exact hmn'.symm.trans hm
+    exact (positiveEvenIso M g hg m hm).trans (positiveEvenIso M g hg n hn).symm
+  · have hn : Odd n := by
+      have hm' : Odd m := Nat.not_even_iff_odd.mp hm
+      have hmn' : m % 2 = n % 2 := hmn
+      rw [Nat.odd_iff]
+      rw [Nat.odd_iff] at hm'
+      exact hmn'.symm.trans hm'
+    exact (positiveOddIso M g hg m (Nat.not_even_iff_odd.mp hm)).trans
+      (positiveOddIso M g hg n hn).symm
+
+/-- In even degrees, `positivePeriodicIso` is the unique comparison obtained by identifying both
+Tate groups with the even homology object of the periodic resolution. -/
+@[simp, reassoc]
+theorem positivePeriodicIso_hom_comp_positiveEvenIso_hom
+    (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
+    (m n : ℕ) [NeZero m] [NeZero n] (hmn : m ≡ n [MOD 2])
+    (hm : Even m) (hn : Even n) :
+    (positivePeriodicIso M g hg m n hmn).hom ≫ (positiveEvenIso M g hg n hn).hom =
+      (positiveEvenIso M g hg m hm).hom := by
+  simp [positivePeriodicIso, hm]
+
+/-- In odd degrees, `positivePeriodicIso` is the unique comparison obtained by identifying both
+Tate groups with the odd homology object of the periodic resolution. -/
+@[simp, reassoc]
+theorem positivePeriodicIso_hom_comp_positiveOddIso_hom
+    (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
+    (m n : ℕ) [NeZero m] [NeZero n] (hmn : m ≡ n [MOD 2])
+    (hm : Odd m) (hn : Odd n) :
+    (positivePeriodicIso M g hg m n hmn).hom ≫ (positiveOddIso M g hg n hn).hom =
+      (positiveOddIso M g hg m hm).hom := by
+  simp [positivePeriodicIso, Nat.not_even_iff_odd.mpr hm]
+
+/-- Positive Tate cohomology groups in degrees congruent modulo two have the same cardinality.
+This is the form used in Herbrand-quotient computations. -/
+theorem natCard_tateCohomology_eq_of_pos_of_modEq
+    (M : Rep R G) (g : G) (hg : ∀ x, x ∈ Subgroup.zpowers g)
+    (m n : ℕ) [NeZero m] [NeZero n] (hmn : m ≡ n [MOD 2]) :
+    Nat.card (tateCohomology M m) = Nat.card (tateCohomology M n) :=
+  Nat.card_congr (positivePeriodicIso M g hg m n hmn).toLinearEquiv.toEquiv
+
+end TauCeti.TateCohomology


### PR DESCRIPTION
This PR adds positive-degree two-periodicity for Tate cohomology of a finite cyclic group by identifying every positive even degree with the homology of `M --N--> M --(g - 1)--> M` and every positive odd degree with the reverse short complex. It exposes the two parity models, the same-parity isomorphism, its commuting characterization in each parity, and the resulting equality of cardinalities.

This advances the exact target in `TauCetiRoadmap/ClassFieldTheory/README.md`, Layer 0, “audit and complete the cohomology suppliers,” bullet “two-periodicity for cyclic groups and the Herbrand quotient.” It supplies the positive-degree part directly from the pinned Mathlib periodic cyclic resolution. After this PR, that Layer 0 target still needs the degree-zero and negative-degree comparisons joined to this positive range, followed by the Herbrand-quotient laws; Layer 0 separately still needs restriction/corestriction, inflation, all-degree cup products, and the generic Tate theorem.

Consumer roadmap: Multiquadratic

The dependency edge is explicit: Multiquadratic Layer 3’s summit isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` requires the global Artin reciprocity map; ClassFieldTheory constructs that map from its global class formation, whose axioms use the cyclic Herbrand-quotient calculations supplied by this Layer 0 periodicity target.

The implementation reuses Mathlib’s `TateCohomology.isoGroupCohomology`, `Rep.FiniteCyclicGroup.groupCohomologyIsoEven`, and `Rep.FiniteCyclicGroup.groupCohomologyIsoOdd`; no Mathlib infrastructure is vendored. The corresponding stronger all-degree construction is `Rep.periodicTateCohomology` in `ClassFieldTheory/Cohomology/FiniteCyclic/UpDown.lean` from `kbuzzard/ClassFieldTheory` at commit `ccc3323c6750abca25b49b35106f54eb3a398509`; this PR credits it while using a new proof specialized to infrastructure already present in pinned Mathlib.

The change adds `TauCeti/RepresentationTheory/Homological/TateCohomology/Periodic.lean` (135 lines).

Roadmap: ClassFieldTheory

<!--tauceti-target:v1 {"focus":"ClassFieldTheory","id":"positive-tate-periodicity-cyclic"}-->

🤖 Prepared with Codex
