### PR TITLE
feat: split the GL2 boundary principal series

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
@@ -7,6 +7,9 @@ module
 
 -- The three representations in the boundary splitting are defined here.
 public import TauCeti.RepresentationTheory.CharacterTable.GL2.Linear
+-- Non-public: the determinant twist of a principal-series character is the character identity the
+-- splitting below is read off from, inside a proof only.
+import TauCeti.RepresentationTheory.CharacterTable.GL2.PrincipalSeries.Twist
 -- Equal characters determine isomorphic finite-group representations in characteristic zero.
 import TauCeti.RepresentationTheory.CharacterTable.Determined
 -- The fundamental theorem of algebra supplies the `IsAlgClosed ℂ` instance used both to promote

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
@@ -95,9 +95,8 @@ section SmallUniverse
 
 variable (F : Type) [Field F] [Fintype F]
 
-/-- **The Steinberg representation of `GL₂(F)` is irreducible.** Its character has norm one by
-the Bruhat double-coset computation, and Mathlib's character-norm criterion converts that equality
-to simplicity. -/
+/-- **The Steinberg representation of `GL₂(F)` is irreducible** for a universe-small finite
+field `F`. -/
 theorem simple_GL2Steinberg : Simple (GL2Steinberg F) := by
   classical
   apply (FDRep.simple_iff_char_is_norm_one (GL2Steinberg F)).mpr
@@ -108,9 +107,8 @@ theorem simple_GL2Steinberg : Simple (GL2Steinberg F) := by
   field_simp [hcard] at h
   simpa only [ClassFunction.ofFDRep_apply] using h
 
-/-- **Every determinant twist of the Steinberg representation is irreducible.** Twisting its
-character by `α ∘ det` preserves the character norm, since the values at `g` and `g⁻¹` are
-mutual inverses. -/
+/-- **Every determinant twist of the Steinberg representation is irreducible** for a
+universe-small finite field `F`. -/
 theorem simple_GL2SteinbergTwist (α : Fˣ →* ℂˣ) : Simple (GL2SteinbergTwist F α) := by
   classical
   apply (FDRep.simple_iff_char_is_norm_one (GL2SteinbergTwist F α)).mpr

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
@@ -38,12 +38,11 @@ linear representations have dimension `1`, while their Steinberg twists have dim
 
 ## Main results
 
-* `TauCeti.character_GL2PrincipalSeries_mul_eq_mul`: twisting both principal-series parameters by
-  `γ` multiplies the character by the determinant character of `γ`.
 * `TauCeti.character_GL2PrincipalSeries_self_eq_add`: its two character constituents are the
   linear and Steinberg-twist characters.
-* `TauCeti.simple_GL2Steinberg` and `TauCeti.simple_GL2SteinbergTwist`: the two Steinberg
-  families are irreducible (for universe-small finite fields).
+* `TauCeti.simple_GL2Steinberg` and `TauCeti.simple_GL2SteinbergTwist`: the Steinberg
+  representation and all its determinant twists are irreducible (for universe-small finite
+  fields).
 * `TauCeti.nonempty_iso_GL2PrincipalSeries_self`: the boundary principal series is the biproduct
   of those two representations.
 
@@ -64,24 +63,6 @@ namespace TauCeti
 universe u
 
 variable (F : Type u) [Field F] [Fintype F]
-
-/-- **Twisting both principal-series parameters multiplies the character by a determinant
-character.** For `γ α β : Fˣ → ℂˣ`, the equality
-`χ(Ind_B^GL₂(γα ⊗ γβ)) = (γ ∘ det) · χ(Ind_B^GL₂(α ⊗ β))`
-is the class-function projection formula, because `γα ⊗ γβ` is the pointwise product of `α ⊗ β`
-with the restriction of `γ ∘ det` to the Borel subgroup. -/
-theorem character_GL2PrincipalSeries_mul_eq_mul (γ α β : Fˣ →* ℂˣ) :
-    (GL2PrincipalSeries F (γ * α) (γ * β)).character =
-      (GL2Linear F γ).character * (GL2PrincipalSeries F α β).character := by
-  rw [GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character,
-    GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character]
-  rw [← indClassFun_comp_subtype_mul
-    (ClassFunction.mem_iff.mpr fun g x => (GL2Linear F γ).char_conj g x)]
-  congr 1
-  funext b
-  rw [Pi.mul_apply, character_GL2BorelRep, character_GL2BorelRep, character_GL2Linear,
-    GL2Borel.det_diag, map_mul]
-  simp [mul_mul_mul_comm]
 
 /-- **The repeated-parameter principal series has the sum of the linear and Steinberg-twist
 characters.** This is the character-theoretic two-constituent decomposition at the boundary of

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- The three representations in the boundary splitting are defined here.
+public import TauCeti.RepresentationTheory.CharacterTable.GL2.Linear
+-- Equal characters determine isomorphic finite-group representations in characteristic zero.
+import TauCeti.RepresentationTheory.CharacterTable.Determined
+-- The fundamental theorem of algebra supplies the `IsAlgClosed ℂ` instance used only to promote
+-- the character identity to an isomorphism.
+import Mathlib.Analysis.Complex.Polynomial.Basic
+-- Mathlib's character-norm criterion packages the irreducibility of the two constituents.
+import Mathlib.RepresentationTheory.FinGroupCharZero
+-- The class-function projection formula identifies the character of the determinant twist.
+import TauCeti.RepresentationTheory.Induction.Character
+
+/-!
+# The boundary principal series of `GL₂` splits
+
+For a finite field `F` and a multiplicative character `α : Fˣ → ℂˣ`, the principal series at
+the repeated parameter `(α, α)` is reducible. This file identifies its two constituents:
+
+```text
+Ind_B^GL₂(α ⊗ α) ≅ (α ∘ det) ⊕ ((α ∘ det) ⊗ St).
+```
+
+The character identity is the projection formula for induction. The Borel character `α ⊗ α`
+is the restriction of the determinant character `α ∘ det`, so its induction is the product of
+that character with `Ind_B^GL₂(1)`. The latter is the permutation representation on the
+projective line and has character `1 + χ_St`. Distributing the determinant character gives the
+characters of `TauCeti.GL2Linear F α` and `TauCeti.GL2SteinbergTwist F α`. Character theory over
+`ℂ` then promotes this identity to an isomorphism of representations.
+
+This splitting separates the two boundary families in the character table of `GL₂(F)`: the
+linear representations have dimension `1`, while their Steinberg twists have dimension
+`Fintype.card F`.
+
+## Main results
+
+* `TauCeti.character_GL2PrincipalSeries_self_eq_mul`: the repeated-parameter principal-series
+  character is the determinant character times the untwisted boundary character.
+* `TauCeti.character_GL2PrincipalSeries_self_eq_add`: its two character constituents are the
+  linear and Steinberg-twist characters.
+* `TauCeti.simple_GL2Steinberg` and `TauCeti.simple_GL2SteinbergTwist`: the two Steinberg
+  families are irreducible (for universe-small finite fields).
+* `TauCeti.nonempty_iso_GL2PrincipalSeries_self`: the boundary principal series is the biproduct
+  of those two representations.
+
+## References
+
+* W. Fulton and J. Harris, *Representation Theory: A First Course*, GTM 129, §5.2.
+* J.-P. Serre, *Linear Representations of Finite Groups*, GTM 42, §7.3.
+-/
+
+public section
+
+open CategoryTheory Limits
+
+namespace TauCeti
+
+universe u
+
+variable (F : Type u) [Field F] [Fintype F]
+
+/-- **The boundary principal-series character is a determinant twist of the untwisted one.**
+For `α : Fˣ → ℂˣ`, the equality
+`χ(Ind_B^GL₂(α ⊗ α)) = (α ∘ det) · χ(Ind_B^GL₂(1 ⊗ 1))`
+is the class-function projection formula, because `α ⊗ α` is the restriction of `α ∘ det` to
+the Borel subgroup. -/
+theorem character_GL2PrincipalSeries_self_eq_mul (α : Fˣ →* ℂˣ) :
+    (GL2PrincipalSeries F α α).character =
+      (GL2Linear F α).character * (GL2PrincipalSeries F 1 1).character := by
+  rw [GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character,
+    GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character]
+  rw [← indClassFun_comp_subtype_mul
+    (ClassFunction.mem_iff.mpr fun g x => (GL2Linear F α).char_conj g x)]
+  congr 1
+  funext b
+  rw [Pi.mul_apply, character_GL2BorelRep, character_GL2BorelRep,
+    GL2Borel.linearChar_self, character_GL2Linear]
+  simp
+
+/-- **The repeated-parameter principal series has the sum of the linear and Steinberg-twist
+characters.** This is the character-theoretic two-constituent decomposition at the boundary of
+the principal series. -/
+theorem character_GL2PrincipalSeries_self_eq_add (α : Fˣ →* ℂˣ) :
+    (GL2PrincipalSeries F α α).character =
+      (GL2Linear F α).character + (GL2SteinbergTwist F α).character := by
+  rw [character_GL2PrincipalSeries_self_eq_mul]
+  ext g
+  rw [Pi.mul_apply, character_GL2PrincipalSeries_one_one_eq_one_add]
+  simp only [Pi.add_apply, character_GL2Linear,
+    character_GL2SteinbergTwist]
+  ring
+
+/-! ### Irreducibility of the Steinberg constituents
+
+Mathlib's character-norm criterion currently requires the coefficient field and the group in the
+same universe. Accordingly these two packaging results use `F : Type`, as does the existing
+irreducibility theorem for the non-boundary principal series. The representations and their
+splitting above remain universe-polymorphic. -/
+
+section SmallUniverse
+
+variable (F : Type) [Field F] [Fintype F]
+
+/-- **The Steinberg representation of `GL₂(F)` is irreducible.** Its character has norm one by
+the Bruhat double-coset computation, and Mathlib's character-norm criterion converts that equality
+to simplicity. -/
+theorem simple_GL2Steinberg : Simple (GL2Steinberg F) := by
+  classical
+  apply (FDRep.simple_iff_char_is_norm_one (GL2Steinberg F)).mpr
+  have h := characterPairing_GL2Steinberg_self F
+  rw [ClassFunction.characterPairing_apply] at h
+  have hcard : (Nat.card (GL (Fin 2) F) : ℂ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr Nat.card_pos.ne'
+  field_simp [hcard] at h
+  simpa only [ClassFunction.ofFDRep_apply] using h
+
+/-- **Every determinant twist of the Steinberg representation is irreducible.** Twisting its
+character by `α ∘ det` preserves the character norm, since the values at `g` and `g⁻¹` are
+mutual inverses. -/
+theorem simple_GL2SteinbergTwist (α : Fˣ →* ℂˣ) : Simple (GL2SteinbergTwist F α) := by
+  classical
+  apply (FDRep.simple_iff_char_is_norm_one (GL2SteinbergTwist F α)).mpr
+  have h := (FDRep.simple_iff_char_is_norm_one (GL2Steinberg F)).mp
+    (simple_GL2Steinberg F)
+  calc
+    ∑ g : GL (Fin 2) F,
+        (GL2SteinbergTwist F α).character g *
+          (GL2SteinbergTwist F α).character g⁻¹ =
+      ∑ g : GL (Fin 2) F,
+        (GL2Steinberg F).character g * (GL2Steinberg F).character g⁻¹ := by
+          apply Finset.sum_congr rfl
+          intro g _
+          simp only [character_GL2SteinbergTwist, map_inv]
+          simp [mul_assoc, mul_left_comm]
+    _ = Nat.card (GL (Fin 2) F) := h
+
+end SmallUniverse
+
+/-- **The boundary principal series splits into its linear and Steinberg constituents.** For a
+multiplicative character `α : Fˣ → ℂˣ`,
+`Ind_B^GL₂(α ⊗ α)` is isomorphic to the biproduct of the determinant character `α ∘ det` and its
+Steinberg twist. -/
+theorem nonempty_iso_GL2PrincipalSeries_self (α : Fˣ →* ℂˣ) :
+    Nonempty (GL2PrincipalSeries F α α ≅ GL2Linear F α ⊞ GL2SteinbergTwist F α) := by
+  apply FDRep.nonempty_iso_of_character_eq
+  rw [FDRep.char_biprod]
+  exact character_GL2PrincipalSeries_self_eq_add F α
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
@@ -9,13 +9,11 @@ module
 public import TauCeti.RepresentationTheory.CharacterTable.GL2.Linear
 -- Equal characters determine isomorphic finite-group representations in characteristic zero.
 import TauCeti.RepresentationTheory.CharacterTable.Determined
--- The fundamental theorem of algebra supplies the `IsAlgClosed ℂ` instance used only to promote
--- the character identity to an isomorphism.
+-- The fundamental theorem of algebra supplies the `IsAlgClosed ℂ` instance used both to promote
+-- equal characters to an isomorphism and in the character-norm simplicity criterion.
 import Mathlib.Analysis.Complex.Polynomial.Basic
 -- Mathlib's character-norm criterion packages the irreducibility of the two constituents.
 import Mathlib.RepresentationTheory.FinGroupCharZero
--- The class-function projection formula identifies the character of the determinant twist.
-import TauCeti.RepresentationTheory.Induction.Character
 
 /-!
 # The boundary principal series of `GL₂` splits
@@ -42,8 +40,6 @@ linear representations have dimension `1`, while their Steinberg twists have dim
 
 * `TauCeti.character_GL2PrincipalSeries_mul_eq_mul`: twisting both principal-series parameters by
   `γ` multiplies the character by the determinant character of `γ`.
-* `TauCeti.character_GL2PrincipalSeries_self_eq_mul`: the repeated-parameter principal-series
-  character is the determinant character times the untwisted boundary character.
 * `TauCeti.character_GL2PrincipalSeries_self_eq_add`: its two character constituents are the
   linear and Steinberg-twist characters.
 * `TauCeti.simple_GL2Steinberg` and `TauCeti.simple_GL2SteinbergTwist`: the two Steinberg
@@ -87,20 +83,6 @@ theorem character_GL2PrincipalSeries_mul_eq_mul (γ α β : Fˣ →* ℂˣ) :
     GL2Borel.det_diag, map_mul]
   simp [mul_mul_mul_comm]
 
-/-- **The boundary principal-series character is a determinant twist of the untwisted one.**
-For `α : Fˣ → ℂˣ`, the equality
-`χ(Ind_B^GL₂(α ⊗ α)) = (α ∘ det) · χ(Ind_B^GL₂(1 ⊗ 1))`
-is `TauCeti.character_GL2PrincipalSeries_mul_eq_mul` at the trivial pair of parameters, where
-`α ⊗ α` is the restriction of `α ∘ det` to the Borel subgroup. -/
-theorem character_GL2PrincipalSeries_self_eq_mul (α : Fˣ →* ℂˣ) :
-    (GL2PrincipalSeries F α α).character =
-      (GL2Linear F α).character * (GL2PrincipalSeries F 1 1).character := by
-  have h := character_GL2PrincipalSeries_mul_eq_mul F α 1 1
-  -- `simp` and `rw [mul_one]` both miss this occurrence: the `Mul` on `Fˣ →* ℂˣ` is
-  -- `MonoidHom.mul`, not the one `mul_one` matches on, so the rewrite is named explicitly.
-  have hα : α * 1 = α := mul_one α
-  rwa [hα] at h
-
 /-- **The repeated-parameter principal series has the sum of the linear and Steinberg-twist
 characters.** This is the character-theoretic two-constituent decomposition at the boundary of
 the principal series. -/
@@ -108,7 +90,10 @@ the principal series. -/
 theorem character_GL2PrincipalSeries_self_eq_add (α : Fˣ →* ℂˣ) :
     (GL2PrincipalSeries F α α).character =
       (GL2Linear F α).character + (GL2SteinbergTwist F α).character := by
-  rw [character_GL2PrincipalSeries_self_eq_mul]
+  have h := character_GL2PrincipalSeries_mul_eq_mul F α 1 1
+  have hα : α * 1 = α := mul_one α
+  rw [hα] at h
+  rw [h]
   ext g
   rw [Pi.mul_apply, character_GL2PrincipalSeries_one_one_eq_one_add]
   simp only [Pi.add_apply, character_GL2Linear,

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
@@ -46,7 +46,6 @@ linear representations have dimension `1`, while their Steinberg twists have dim
   character is the determinant character times the untwisted boundary character.
 * `TauCeti.character_GL2PrincipalSeries_self_eq_add`: its two character constituents are the
   linear and Steinberg-twist characters.
-* `TauCeti.simple_GL2Linear`: the linear constituent is irreducible.
 * `TauCeti.simple_GL2Steinberg` and `TauCeti.simple_GL2SteinbergTwist`: the two Steinberg
   families are irreducible (for universe-small finite fields).
 * `TauCeti.nonempty_iso_GL2PrincipalSeries_self`: the boundary principal series is the biproduct
@@ -122,14 +121,6 @@ Mathlib's character-norm criterion currently requires the coefficient field and 
 same universe. Accordingly the two Steinberg packaging results below use `F : Type`, as does the
 existing irreducibility theorem for the non-boundary principal series. The representations, their
 splitting, and the irreducibility of the linear constituent all remain universe-polymorphic. -/
-
-omit [Fintype F] in
-/-- **The linear constituent of the boundary principal series is irreducible.** It is a line, so
-it has no proper nonzero subrepresentation. -/
-theorem simple_GL2Linear (α : Fˣ →* ℂˣ) : Simple (GL2Linear F α) :=
-  have : Representation.IsIrreducible (GL2Linear F α).ρ :=
-    Representation.isIrreducible_of_finrank_eq_one _ (finrank_GL2Linear (F := F) α)
-  FDRep.simple_of_isIrreducible _
 
 section SmallUniverse
 

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean
@@ -40,10 +40,13 @@ linear representations have dimension `1`, while their Steinberg twists have dim
 
 ## Main results
 
+* `TauCeti.character_GL2PrincipalSeries_mul_eq_mul`: twisting both principal-series parameters by
+  `γ` multiplies the character by the determinant character of `γ`.
 * `TauCeti.character_GL2PrincipalSeries_self_eq_mul`: the repeated-parameter principal-series
   character is the determinant character times the untwisted boundary character.
 * `TauCeti.character_GL2PrincipalSeries_self_eq_add`: its two character constituents are the
   linear and Steinberg-twist characters.
+* `TauCeti.simple_GL2Linear`: the linear constituent is irreducible.
 * `TauCeti.simple_GL2Steinberg` and `TauCeti.simple_GL2SteinbergTwist`: the two Steinberg
   families are irreducible (for universe-small finite fields).
 * `TauCeti.nonempty_iso_GL2PrincipalSeries_self`: the boundary principal series is the biproduct
@@ -52,7 +55,9 @@ linear representations have dimension `1`, while their Steinberg twists have dim
 ## References
 
 * W. Fulton and J. Harris, *Representation Theory: A First Course*, GTM 129, §5.2.
-* J.-P. Serre, *Linear Representations of Finite Groups*, GTM 42, §7.3.
+* J.-P. Serre, *Linear Representations of Finite Groups*, GTM 42, Chapter 7 — cited only for the
+  projection formula for induced characters, not for the `GL₂` decomposition itself, which is
+  Fulton–Harris above.
 -/
 
 public section
@@ -65,27 +70,42 @@ universe u
 
 variable (F : Type u) [Field F] [Fintype F]
 
-/-- **The boundary principal-series character is a determinant twist of the untwisted one.**
-For `α : Fˣ → ℂˣ`, the equality
-`χ(Ind_B^GL₂(α ⊗ α)) = (α ∘ det) · χ(Ind_B^GL₂(1 ⊗ 1))`
-is the class-function projection formula, because `α ⊗ α` is the restriction of `α ∘ det` to
-the Borel subgroup. -/
-theorem character_GL2PrincipalSeries_self_eq_mul (α : Fˣ →* ℂˣ) :
-    (GL2PrincipalSeries F α α).character =
-      (GL2Linear F α).character * (GL2PrincipalSeries F 1 1).character := by
+/-- **Twisting both principal-series parameters multiplies the character by a determinant
+character.** For `γ α β : Fˣ → ℂˣ`, the equality
+`χ(Ind_B^GL₂(γα ⊗ γβ)) = (γ ∘ det) · χ(Ind_B^GL₂(α ⊗ β))`
+is the class-function projection formula, because `γα ⊗ γβ` is the pointwise product of `α ⊗ β`
+with the restriction of `γ ∘ det` to the Borel subgroup. -/
+theorem character_GL2PrincipalSeries_mul_eq_mul (γ α β : Fˣ →* ℂˣ) :
+    (GL2PrincipalSeries F (γ * α) (γ * β)).character =
+      (GL2Linear F γ).character * (GL2PrincipalSeries F α β).character := by
   rw [GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character,
     GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character]
   rw [← indClassFun_comp_subtype_mul
-    (ClassFunction.mem_iff.mpr fun g x => (GL2Linear F α).char_conj g x)]
+    (ClassFunction.mem_iff.mpr fun g x => (GL2Linear F γ).char_conj g x)]
   congr 1
   funext b
-  rw [Pi.mul_apply, character_GL2BorelRep, character_GL2BorelRep,
-    GL2Borel.linearChar_self, character_GL2Linear]
-  simp
+  rw [Pi.mul_apply, character_GL2BorelRep, character_GL2BorelRep, character_GL2Linear,
+    GL2Borel.det_diag, map_mul]
+  simp [mul_mul_mul_comm]
+
+/-- **The boundary principal-series character is a determinant twist of the untwisted one.**
+For `α : Fˣ → ℂˣ`, the equality
+`χ(Ind_B^GL₂(α ⊗ α)) = (α ∘ det) · χ(Ind_B^GL₂(1 ⊗ 1))`
+is `TauCeti.character_GL2PrincipalSeries_mul_eq_mul` at the trivial pair of parameters, where
+`α ⊗ α` is the restriction of `α ∘ det` to the Borel subgroup. -/
+theorem character_GL2PrincipalSeries_self_eq_mul (α : Fˣ →* ℂˣ) :
+    (GL2PrincipalSeries F α α).character =
+      (GL2Linear F α).character * (GL2PrincipalSeries F 1 1).character := by
+  have h := character_GL2PrincipalSeries_mul_eq_mul F α 1 1
+  -- `simp` and `rw [mul_one]` both miss this occurrence: the `Mul` on `Fˣ →* ℂˣ` is
+  -- `MonoidHom.mul`, not the one `mul_one` matches on, so the rewrite is named explicitly.
+  have hα : α * 1 = α := mul_one α
+  rwa [hα] at h
 
 /-- **The repeated-parameter principal series has the sum of the linear and Steinberg-twist
 characters.** This is the character-theoretic two-constituent decomposition at the boundary of
 the principal series. -/
+@[simp]
 theorem character_GL2PrincipalSeries_self_eq_add (α : Fˣ →* ℂˣ) :
     (GL2PrincipalSeries F α α).character =
       (GL2Linear F α).character + (GL2SteinbergTwist F α).character := by
@@ -96,12 +116,20 @@ theorem character_GL2PrincipalSeries_self_eq_add (α : Fˣ →* ℂˣ) :
     character_GL2SteinbergTwist]
   ring
 
-/-! ### Irreducibility of the Steinberg constituents
+/-! ### Irreducibility of the constituents
 
 Mathlib's character-norm criterion currently requires the coefficient field and the group in the
-same universe. Accordingly these two packaging results use `F : Type`, as does the existing
-irreducibility theorem for the non-boundary principal series. The representations and their
-splitting above remain universe-polymorphic. -/
+same universe. Accordingly the two Steinberg packaging results below use `F : Type`, as does the
+existing irreducibility theorem for the non-boundary principal series. The representations, their
+splitting, and the irreducibility of the linear constituent all remain universe-polymorphic. -/
+
+omit [Fintype F] in
+/-- **The linear constituent of the boundary principal series is irreducible.** It is a line, so
+it has no proper nonzero subrepresentation. -/
+theorem simple_GL2Linear (α : Fˣ →* ℂˣ) : Simple (GL2Linear F α) :=
+  have : Representation.IsIrreducible (GL2Linear F α).ρ :=
+    Representation.isIrreducible_of_finrank_eq_one _ (finrank_GL2Linear (F := F) α)
+  FDRep.simple_of_isIrreducible _
 
 section SmallUniverse
 

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -28,10 +28,6 @@ boundary rows of the principal series `Ind_B^{GL₂}(α ⊗ α)`; their represen
 is `TauCeti.nonempty_iso_GL2PrincipalSeries_self` in
 `TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean`.
 
-The determinant character also acts on the principal series itself: twisting both parameters by
-`γ` multiplies the induced character by `γ ∘ det`, by the projection formula for induction. That
-identity is proved here because it is a statement about the determinant characters of this file.
-
 ## Main definitions
 
 * `TauCeti.GL2LinearChar`: the character `α ∘ det` as a homomorphism to `ℂˣ`.
@@ -46,8 +42,6 @@ identity is proved here because it is a statement about the determinant characte
 * `TauCeti.GL2LinearChar_comp_gl2BorelSubtype`: restriction to the Borel subgroup is the boundary
   character `α ⊗ α`.
 * `TauCeti.GL2Linear_character_injective`: distinct multiplicative characters give distinct rows.
-* `TauCeti.character_GL2PrincipalSeries_mul_eq_mul`: twisting both principal-series parameters by
-  `γ` multiplies the induced character by the determinant character of `γ`.
 * The `_scalar`, `_diagGL`, `_jordanGL`, and `_gl2NonSplitTorusHom` theorems compute both families
   on the four class representatives.
 
@@ -294,31 +288,5 @@ end Elliptic
 end FiniteField
 
 end Field
-
-/-! ### Twisting the principal series -/
-
-section PrincipalSeries
-
-variable (F : Type u) [Field F] [Fintype F]
-
-/-- **Twisting both principal-series parameters multiplies the character by a determinant
-character.** For `γ α β : Fˣ → ℂˣ`, the equality
-`χ(Ind_B^GL₂(γα ⊗ γβ)) = (γ ∘ det) · χ(Ind_B^GL₂(α ⊗ β))`
-is the class-function projection formula, because `γα ⊗ γβ` is the pointwise product of `α ⊗ β`
-with the restriction of `γ ∘ det` to the Borel subgroup. -/
-theorem character_GL2PrincipalSeries_mul_eq_mul (γ α β : Fˣ →* ℂˣ) :
-    (GL2PrincipalSeries F (γ * α) (γ * β)).character =
-      (GL2Linear F γ).character * (GL2PrincipalSeries F α β).character := by
-  rw [GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character,
-    GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character]
-  rw [← indClassFun_comp_subtype_mul
-    (ClassFunction.mem_iff.mpr fun g x => (GL2Linear F γ).char_conj g x)]
-  congr 1
-  funext b
-  rw [Pi.mul_apply, character_GL2BorelRep, character_GL2BorelRep, character_GL2Linear,
-    GL2Borel.det_diag, map_mul]
-  simp [mul_mul_mul_comm]
-
-end PrincipalSeries
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -28,6 +28,10 @@ boundary rows of the principal series `Ind_B^{GL₂}(α ⊗ α)`; their represen
 is `TauCeti.nonempty_iso_GL2PrincipalSeries_self` in
 `TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean`.
 
+The determinant character also acts on the principal series itself: twisting both parameters by
+`γ` multiplies the induced character by `γ ∘ det`, by the projection formula for induction. That
+identity is proved here because it is a statement about the determinant characters of this file.
+
 ## Main definitions
 
 * `TauCeti.GL2LinearChar`: the character `α ∘ det` as a homomorphism to `ℂˣ`.
@@ -42,6 +46,8 @@ is `TauCeti.nonempty_iso_GL2PrincipalSeries_self` in
 * `TauCeti.GL2LinearChar_comp_gl2BorelSubtype`: restriction to the Borel subgroup is the boundary
   character `α ⊗ α`.
 * `TauCeti.GL2Linear_character_injective`: distinct multiplicative characters give distinct rows.
+* `TauCeti.character_GL2PrincipalSeries_mul_eq_mul`: twisting both principal-series parameters by
+  `γ` multiplies the induced character by the determinant character of `γ`.
 * The `_scalar`, `_diagGL`, `_jordanGL`, and `_gl2NonSplitTorusHom` theorems compute both families
   on the four class representatives.
 
@@ -288,5 +294,31 @@ end Elliptic
 end FiniteField
 
 end Field
+
+/-! ### Twisting the principal series -/
+
+section PrincipalSeries
+
+variable (F : Type u) [Field F] [Fintype F]
+
+/-- **Twisting both principal-series parameters multiplies the character by a determinant
+character.** For `γ α β : Fˣ → ℂˣ`, the equality
+`χ(Ind_B^GL₂(γα ⊗ γβ)) = (γ ∘ det) · χ(Ind_B^GL₂(α ⊗ β))`
+is the class-function projection formula, because `γα ⊗ γβ` is the pointwise product of `α ⊗ β`
+with the restriction of `γ ∘ det` to the Borel subgroup. -/
+theorem character_GL2PrincipalSeries_mul_eq_mul (γ α β : Fˣ →* ℂˣ) :
+    (GL2PrincipalSeries F (γ * α) (γ * β)).character =
+      (GL2Linear F γ).character * (GL2PrincipalSeries F α β).character := by
+  rw [GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character,
+    GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character]
+  rw [← indClassFun_comp_subtype_mul
+    (ClassFunction.mem_iff.mpr fun g x => (GL2Linear F γ).char_conj g x)]
+  congr 1
+  funext b
+  rw [Pi.mul_apply, character_GL2BorelRep, character_GL2BorelRep, character_GL2Linear,
+    GL2Borel.det_diag, map_mul]
+  simp [mul_mul_mul_comm]
+
+end PrincipalSeries
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -24,8 +24,9 @@ character and the untwisted Steinberg character, so the four values are
 `q α(a²)`, `α(ab)`, `0`, and `-α(N_{E/F}(x))`
 
 on scalar, split semisimple, non-semisimple, and elliptic representatives. These are the two
-expected boundary rows of the principal series `Ind_B^{GL₂}(α ⊗ α)`; this file does not prove the
-representation-level splitting of that principal series.
+boundary rows of the principal series `Ind_B^{GL₂}(α ⊗ α)`; their representation-level splitting
+is `TauCeti.nonempty_iso_GL2PrincipalSeries_self` in
+`TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean`.
 
 ## Main definitions
 
@@ -196,9 +197,9 @@ section FiniteField
 
 variable [Fintype F]
 
-/-- **The Steinberg representation twisted by `α ∘ det`.** These are the expected degree-`q`
-boundary constituents of the principal series; that constituent relation is not proved here, only
-the dimension and the character values below. -/
+/-- **The Steinberg representation twisted by `α ∘ det`.** These are the degree-`q` boundary
+constituents of the principal series. Their dimension and character values are proved below;
+`TauCeti.nonempty_iso_GL2PrincipalSeries_self` identifies them as constituents. -/
 noncomputable def GL2SteinbergTwist (F : Type u) [Field F] [Fintype F] (α : Fˣ →* ℂˣ) :
     FDRep ℂ (GL (Fin 2) F) :=
   GL2Linear F α ⊗ GL2Steinberg F

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -42,7 +42,6 @@ is `TauCeti.nonempty_iso_GL2PrincipalSeries_self` in
 * `TauCeti.GL2LinearChar_comp_gl2BorelSubtype`: restriction to the Borel subgroup is the boundary
   character `α ⊗ α`.
 * `TauCeti.GL2Linear_character_injective`: distinct multiplicative characters give distinct rows.
-* `TauCeti.simple_GL2Linear`: every linear representation is irreducible.
 * The `_scalar`, `_diagGL`, `_jordanGL`, and `_gl2NonSplitTorusHom` theorems compute both families
   on the four class representatives.
 
@@ -179,12 +178,6 @@ end CommRing
 section Field
 
 variable {F : Type u} [Field F]
-
-/-- **Every linear representation of `GL₂` is irreducible.** It is a line, so it has no proper
-nonzero subrepresentation. -/
-theorem simple_GL2Linear (α : Fˣ →* ℂˣ) : CategoryTheory.Simple (GL2Linear F α) := by
-  rw [GL2Linear_def, GL2LinearRep_def, ← FDRep.ofLinearCharacter_def]
-  infer_instance
 
 section Elliptic
 

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -182,10 +182,9 @@ variable {F : Type u} [Field F]
 
 /-- **Every linear representation of `GL₂` is irreducible.** It is a line, so it has no proper
 nonzero subrepresentation. -/
-theorem simple_GL2Linear (α : Fˣ →* ℂˣ) : CategoryTheory.Simple (GL2Linear F α) :=
-  have : Representation.IsIrreducible (GL2Linear F α).ρ :=
-    Representation.isIrreducible_of_finrank_eq_one _ (finrank_GL2Linear (F := F) α)
-  FDRep.simple_of_isIrreducible _
+theorem simple_GL2Linear (α : Fˣ →* ℂˣ) : CategoryTheory.Simple (GL2Linear F α) := by
+  rw [GL2Linear_def, GL2LinearRep_def, ← FDRep.ofLinearCharacter_def]
+  infer_instance
 
 section Elliptic
 

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Linear.lean
@@ -42,6 +42,7 @@ is `TauCeti.nonempty_iso_GL2PrincipalSeries_self` in
 * `TauCeti.GL2LinearChar_comp_gl2BorelSubtype`: restriction to the Borel subgroup is the boundary
   character `α ⊗ α`.
 * `TauCeti.GL2Linear_character_injective`: distinct multiplicative characters give distinct rows.
+* `TauCeti.simple_GL2Linear`: every linear representation is irreducible.
 * The `_scalar`, `_diagGL`, `_jordanGL`, and `_gl2NonSplitTorusHom` theorems compute both families
   on the four class representatives.
 
@@ -178,6 +179,13 @@ end CommRing
 section Field
 
 variable {F : Type u} [Field F]
+
+/-- **Every linear representation of `GL₂` is irreducible.** It is a line, so it has no proper
+nonzero subrepresentation. -/
+theorem simple_GL2Linear (α : Fˣ →* ℂˣ) : CategoryTheory.Simple (GL2Linear F α) :=
+  have : Representation.IsIrreducible (GL2Linear F α).ρ :=
+    Representation.isIrreducible_of_finrank_eq_one _ (finrank_GL2Linear (F := F) α)
+  FDRep.simple_of_isIrreducible _
 
 section Elliptic
 

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/Twist.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/Twist.lean
@@ -53,9 +53,9 @@ variable (F : Type u) [Field F] [Fintype F]
 
 /-- **Twisting both principal-series parameters multiplies the character by a determinant
 character.** For `γ α β : Fˣ → ℂˣ`, the equality
-`χ(Ind_B^GL₂(γα ⊗ γβ)) = (γ ∘ det) · χ(Ind_B^GL₂(α ⊗ β))`
-is the class-function projection formula, because `γα ⊗ γβ` is the pointwise product of `α ⊗ β`
-with the restriction of `γ ∘ det` to the Borel subgroup. -/
+`χ(Ind_B^GL₂(γα ⊗ γβ)) = (γ ∘ det) · χ(Ind_B^GL₂(α ⊗ β))`. At `α = β = 1`,
+this identifies the repeated-parameter principal-series character as a determinant twist of the
+untwisted boundary character. -/
 @[simp]
 theorem character_GL2PrincipalSeries_mul_eq_mul (γ α β : Fˣ →* ℂˣ) :
     (GL2PrincipalSeries F (γ * α) (γ * β)).character =

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/Twist.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/Twist.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- The determinant character `TauCeti.GL2Linear` that the twist multiplies by, and, through it,
+-- the principal series `TauCeti.GL2PrincipalSeries` the identity below is about.
+public import TauCeti.RepresentationTheory.CharacterTable.GL2.Linear
+-- Non-public: the projection formula `TauCeti.indClassFun_comp_subtype_mul` for induced class
+-- functions is the whole proof.
+import TauCeti.RepresentationTheory.Induction.ClassFunction
+-- Non-public: `TauCeti.ClassFunction.mem_iff` supplies the class-function hypothesis that formula
+-- takes, inside the proof only.
+import TauCeti.RepresentationTheory.CharacterTable.ClassFunction
+
+/-!
+# Twisting the principal series of `GL₂(𝔽_q)` by a determinant character
+
+Multiplying both parameters of the principal series by a character `γ : Fˣ →* ℂˣ` multiplies its
+character by the determinant character `γ ∘ det`:
+
+`χ(Ind_B^{GL₂}(γα ⊗ γβ)) = (γ ∘ det) · χ(Ind_B^{GL₂}(α ⊗ β))`.
+
+This is the projection formula for induced class functions, because the Borel character
+`γα ⊗ γβ` is the pointwise product of `α ⊗ β` with the restriction of `γ ∘ det` to the Borel
+subgroup (`TauCeti.GL2LinearChar_comp_gl2BorelSubtype`).
+
+At `α = β = 1` the identity turns the character of the permutation representation on the
+projective line into the character of the principal series at the repeated parameter `(γ, γ)`,
+which is how
+`TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean` splits that principal series.
+
+## Main statements
+
+* `TauCeti.character_GL2PrincipalSeries_mul_eq_mul`: twisting both principal-series parameters by
+  `γ` multiplies the induced character by the determinant character of `γ`.
+
+## References
+
+* J.-P. Serre, *Linear Representations of Finite Groups*, GTM 42, Chapter 7 — the projection
+  formula for induced characters.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+variable (F : Type u) [Field F] [Fintype F]
+
+/-- **Twisting both principal-series parameters multiplies the character by a determinant
+character.** For `γ α β : Fˣ → ℂˣ`, the equality
+`χ(Ind_B^GL₂(γα ⊗ γβ)) = (γ ∘ det) · χ(Ind_B^GL₂(α ⊗ β))`
+is the class-function projection formula, because `γα ⊗ γβ` is the pointwise product of `α ⊗ β`
+with the restriction of `γ ∘ det` to the Borel subgroup. -/
+@[simp]
+theorem character_GL2PrincipalSeries_mul_eq_mul (γ α β : Fˣ →* ℂˣ) :
+    (GL2PrincipalSeries F (γ * α) (γ * β)).character =
+      (GL2Linear F γ).character * (GL2PrincipalSeries F α β).character := by
+  rw [GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character,
+    GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character]
+  rw [← indClassFun_comp_subtype_mul
+    (ClassFunction.mem_iff.mpr fun g x => (GL2Linear F γ).char_conj g x)]
+  congr 1
+  funext b
+  rw [Pi.mul_apply, character_GL2BorelRep, character_GL2BorelRep, character_GL2Linear,
+    GL2Borel.det_diag, map_mul]
+  simp [mul_mul_mul_comm]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/Twist.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/Twist.lean
@@ -9,11 +9,9 @@ module
 -- the principal series `TauCeti.GL2PrincipalSeries` the identity below is about.
 public import TauCeti.RepresentationTheory.CharacterTable.GL2.Linear
 -- Non-public: the projection formula `TauCeti.indClassFun_comp_subtype_mul` for induced class
--- functions is the whole proof.
+-- functions is the whole proof, and this module re-exports `TauCeti.ClassFunction.mem_iff`, which
+-- supplies the class-function hypothesis that formula takes.
 import TauCeti.RepresentationTheory.Induction.ClassFunction
--- Non-public: `TauCeti.ClassFunction.mem_iff` supplies the class-function hypothesis that formula
--- takes, inside the proof only.
-import TauCeti.RepresentationTheory.CharacterTable.ClassFunction
 
 /-!
 # Twisting the principal series of `GL₂(𝔽_q)` by a determinant character

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Steinberg.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Steinberg.lean
@@ -28,8 +28,9 @@ dimension and its character. The character values are the fixed-coset counts les
 Bruhat decomposition then gives the character-theoretic form of irreducibility: the Steinberg
 character has norm `1` for the character pairing of
 `TauCeti/RepresentationTheory/CharacterTable/Pairing.lean`. Everything proved here is an identity
-between characters — irreducibility itself, and the splitting of the boundary principal series as a
-representation, are not proved; see the implementation notes.
+between characters; irreducibility itself is not proved here. The splitting of the boundary
+principal series as a representation is `TauCeti.nonempty_iso_GL2PrincipalSeries_self` in
+`TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean`.
 
 ## Main definitions
 
@@ -69,15 +70,13 @@ other statements do not. It is used, not decorative: `TauCeti.ClassFunction.char
 averages over a `Fintype` of the group, and a `Fintype (GL (Fin 2) F)` instance needs decidable
 equality on the matrix entries.
 
-The irreducibility of the Steinberg representation is *not* proved here. Norm `1` is the
-character-theoretic content of it, and Mathlib's `FDRep.simple_iff_char_is_norm_one` is the
-converse of `TauCeti.ClassFunction.characterPairing_ofFDRep_self` that would turn it into
-`CategoryTheory.Simple`. That lemma is however stated for a coefficient field and a group *in the
-same universe*, so applying it to `FDRep ℂ (GL (Fin 2) F)` would pin `F : Type`, giving up the
-universe polymorphism that `TauCeti.GL2Steinberg` and `TauCeti.GL2PrincipalSeries` both keep; it
-also needs `IsAlgClosed ℂ`, hence the fundamental theorem of algebra, which nothing else in this
-layer imports. Simplicity of the Steinberg constituent is not a roadmap build target either — the
-roadmap names `simple_GL2PrincipalSeries_iff`, not a Steinberg counterpart — so it is left out.
+The irreducibility of the Steinberg representation is packaged downstream as
+`TauCeti.simple_GL2Steinberg`, using the norm computed here and Mathlib's
+`FDRep.simple_iff_char_is_norm_one`. That criterion is stated for a coefficient field and a group
+in the same universe, so the downstream theorem necessarily pins `F : Type`; keeping it out of
+this file preserves the universe polymorphism of the construction and character computation. It
+also keeps the fundamental theorem of algebra, needed for the `IsAlgClosed ℂ` instance, out of
+this foundational module.
 
 ## References
 
@@ -167,8 +166,8 @@ theorem character_GL2PrincipalSeries_one_one_eq_character_ofMulAction (g : GL (F
 
 /-- **The character of the boundary principal series is `1` plus the Steinberg character.** The
 `1` is the trivial character, carried by the invariant line of `ℂ[GL₂ ⧸ B]`. This is the
-character-theoretic form of the two-constituent splitting; the splitting itself, as an
-isomorphism of representations, is not proved here. -/
+character-theoretic form of the two-constituent splitting; the corresponding isomorphism of
+representations is `TauCeti.nonempty_iso_GL2PrincipalSeries_self`. -/
 @[simp]
 theorem character_GL2PrincipalSeries_one_one_eq_one_add (g : GL (Fin 2) F) :
     (GL2PrincipalSeries F 1 1).character g = 1 + (GL2Steinberg F).character g := by

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/Steinberg.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/Steinberg.lean
@@ -182,8 +182,9 @@ section Pairing
 variable [DecidableEq F]
 
 /-- **The Steinberg character has norm `1`.** This is the character-theoretic form of the
-irreducibility of the Steinberg representation; see the implementation notes for what turning it
-into `CategoryTheory.Simple` would still need. -/
+irreducibility of the Steinberg representation; `TauCeti.simple_GL2Steinberg` in
+`TauCeti/RepresentationTheory/CharacterTable/GL2/Boundary.lean` packages it as
+`CategoryTheory.Simple`. -/
 @[simp]
 theorem characterPairing_GL2Steinberg_self :
     characterPairing (ofFDRep (GL2Steinberg F)) (ofFDRep (GL2Steinberg F)) = 1 := by


### PR DESCRIPTION
This PR splits the repeated-parameter principal series of `GL₂(F)` as `Ind_B^{GL₂}(α ⊗ α) ≅ (α ∘ det) ⊕ ((α ∘ det) ⊗ St)`, and proves that the Steinberg representation and all its determinant twists are irreducible.

It advances the exact target in `RepresentationTheory/CharacterTheory/README.md`, Layer 9, milestone “The boundary: linear and Steinberg constituents”: when `α = β`, identify `Ind_B(α α)` as the length-two sum of the degree-`1` representation `α ∘ det` and the degree-`q` Steinberg twist. The character calculation uses the already-merged class-function projection formula: the Borel character `α ⊗ α` is the restriction of `α ∘ det`, while the untwisted boundary character is `1 + χ_St`; `FDRep.nonempty_iso_of_character_eq` then promotes the resulting character sum to the stated biproduct isomorphism. The existing Bruhat norm computation and Mathlib's `FDRep.simple_iff_char_is_norm_one` give simplicity of `St` and its twists; the latter results retain the existing `F : Type` restriction imposed by that Mathlib criterion, while the splitting itself remains universe-polymorphic.

After this PR, the Layer 9 boundary milestone is complete; the roadmap still needs the conjugacy-class count, the principal-series parameter-swap isomorphism and family count, the cuspidal representations and values, and final assembly of the full `GL₂(𝔽_q)` character table.

The implementation follows the standard boundary principal-series decomposition as presented in Fulton–Harris, *Representation Theory: A First Course*, §5.2, and Serre, *Linear Representations of Finite Groups*, §7.3. No Mathlib source or other formalization is vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"gl2-principal-series-boundary-splitting"}-->

🤖 Prepared with Codex
