### PR TITLE
feat(ModularForms): descend a cusp form along a q-support condition

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -184,6 +184,23 @@ lemma coe_scaleGL_smul [NeZero d] (τ : ℍ) : ((scaleGL d • τ : ℍ) : ℂ) 
   rw [coe_smul_of_det_pos val_det_scaleGL_pos]
   simp [UpperHalfPlane.num]
 
+/-- Scaling down divides the argument. -/
+@[simp]
+lemma coe_inv_scaleGL_smul [NeZero d] (τ : ℍ) : (((scaleGL d)⁻¹ • τ : ℍ) : ℂ) = τ / d := by
+  have hd : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+  have hs := coe_scaleGL_smul (d := d) ((scaleGL d)⁻¹ • τ)
+  rw [smul_inv_smul] at hs
+  rw [hs, mul_comm, mul_div_assoc, div_self hd, mul_one]
+
+/-- Scaling down commutes with translation, at the cost of dividing the shift by `d`. -/
+lemma inv_scaleGL_smul_vadd [NeZero d] (a : ℝ) (τ : ℍ) :
+    ((scaleGL d)⁻¹ • ((a : ℝ) +ᵥ τ) : ℍ) = (a / (d : ℝ)) +ᵥ ((scaleGL d)⁻¹ • τ) := by
+  apply UpperHalfPlane.ext
+  rw [coe_inv_scaleGL_smul, UpperHalfPlane.coe_vadd, UpperHalfPlane.coe_vadd,
+    coe_inv_scaleGL_smul]
+  push_cast
+  ring
+
 @[simp]
 lemma scaleGL_one : scaleGL 1 = 1 := by
   rw [scaleGL, ← map_one diagGL]

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -193,6 +193,7 @@ lemma coe_inv_scaleGL_smul [NeZero d] (τ : ℍ) : (((scaleGL d)⁻¹ • τ : �
   rw [hs, mul_comm, mul_div_assoc, div_self hd, mul_one]
 
 /-- Scaling down commutes with translation, at the cost of dividing the shift by `d`. -/
+@[simp]
 lemma inv_scaleGL_smul_vadd [NeZero d] (a : ℝ) (τ : ℍ) :
     ((scaleGL d)⁻¹ • ((a : ℝ) +ᵥ τ) : ℍ) = (a / (d : ℝ)) +ᵥ ((scaleGL d)⁻¹ • τ) := by
   apply UpperHalfPlane.ext

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent.lean
@@ -57,55 +57,19 @@ namespace TauCeti
 
 variable {N l : ℕ} [NeZero l] {k : ℤ}
 
-/-- Slashing by `T` translates the argument by one. -/
-private lemma slash_mapGL_T_apply (k : ℤ) (f : ℍ → ℂ) (τ : ℍ) :
-    (f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ)) τ = f ((1 : ℝ) +ᵥ τ) := by
-  have hSL : (f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ)) =
-      f ∣[k] (ModularGroup.T : SL(2, ℤ)) :=
-    (ModularForm.SL_slash (f := f) (k := k) ModularGroup.T).symm
-  rw [hSL, ModularForm.SL_slash_apply, UpperHalfPlane.modular_T_smul]
-  simp [UpperHalfPlane.denom, ModularGroup.coe_T]
-
-/-- Scaling down commutes with translation, at the cost of dividing the shift by `l`. -/
-private lemma inv_scaleGL_smul_vadd_one (τ : ℍ) :
-    ((scaleGL l)⁻¹ • ((1 : ℝ) +ᵥ τ) : ℍ) = ((1 : ℝ) / (l : ℝ)) +ᵥ ((scaleGL l)⁻¹ • τ) := by
-  have hl : (l : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne l)
-  have h : ∀ σ : ℍ, (((scaleGL l)⁻¹ • σ : ℍ) : ℂ) = (σ : ℂ) / (l : ℂ) := fun σ ↦ by
-    have hs := coe_scaleGL_smul (d := l) ((scaleGL l)⁻¹ • σ)
-    rw [smul_inv_smul] at hs
-    rw [hs, mul_comm, mul_div_assoc, div_self hl, mul_one]
-  apply UpperHalfPlane.ext
-  rw [h ((1 : ℝ) +ᵥ τ), UpperHalfPlane.coe_vadd, UpperHalfPlane.coe_vadd, h τ]
-  push_cast
-  ring
-
-/-- Translating by `1 / l` fixes every `q`-power the support condition leaves alive: it scales
-the `n`-th by an `l`-th root of unity to the `n`, trivial exactly when `l ∣ n`. -/
-private lemma smul_qParam_pow_shift_eq {c : ℕ → ℂ} (hc : ∀ n : ℕ, ¬ l ∣ n → c n = 0)
-    (σ : ℍ) (n : ℕ) :
-    c n • Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (l : ℝ)) +ᵥ σ : ℍ) : ℂ) ^ n =
-      c n • Function.Periodic.qParam (1 : ℝ) (σ : ℂ) ^ n := by
-  have hqP : Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (l : ℝ)) +ᵥ σ : ℍ) : ℂ) =
-      Function.Periodic.qParam (1 : ℝ) (σ : ℂ) *
-        Complex.exp (2 * (Real.pi : ℂ) * Complex.I / (l : ℂ)) := by
-    simp only [Function.Periodic.qParam, UpperHalfPlane.coe_vadd, ← Complex.exp_add]
-    congr 1
-    push_cast
-    ring
-  by_cases hln : l ∣ n
-  · obtain ⟨m, rfl⟩ := hln
-    rw [hqP, mul_pow, pow_mul (Complex.exp _) l m,
-      (Complex.isPrimitiveRoot_exp l (NeZero.ne l)).pow_eq_one, one_pow, mul_one]
-  · rw [hc n hln, zero_smul, zero_smul]
-
 /-- The scaled-down form is `T`-invariant, by uniqueness of the `q`-expansion sum. -/
-private lemma slash_T_eq_of_support (g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)
+private lemma slash_T_eq_of_support {F : Type*} [FunLike F ℍ ℂ]
+    [ModularFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (g : F)
     (hg : ∀ n : ℕ, ¬ l ∣ n → (qExpansion 1 g).coeff n = 0) :
     (fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ)) ∣[k]
         (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) =
       fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ) := by
   funext τ
-  rw [slash_mapGL_T_apply, inv_scaleGL_smul_vadd_one]
+  rw [show (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) =
+      ((ModularGroup.T ^ (1 : ℤ) : SL(2, ℤ)) : GL (Fin 2) ℝ) by
+        rw [zpow_one, Matrix.SpecialLinearGroup.coe_GL_eq_mapGL],
+    ← ModularForm.SL_slash, ModularForm.slash_T_zpow_apply]
+  rw [show ((1 : ℤ) : ℝ) = (1 : ℝ) from Int.cast_one, inv_scaleGL_smul_vadd]
   set σ : ℍ := (scaleGL l)⁻¹ • τ
   have h1 := one_mem_strictPeriods_Gamma1_map N
   have : Fact (IsCusp OnePoint.infty ((Gamma1 N).map (mapGL ℝ))) :=
@@ -117,19 +81,35 @@ private lemma slash_T_eq_of_support (g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k
   rw [funext (smul_qParam_pow_shift_eq hg σ)] at Hσ'
   exact ((key σ).unique Hσ').symm
 
-/-- **Descent along a `q`-support condition.** A cusp form of level `Γ₁(N)` whose period-one
+/-- **Descent along a `q`-support condition.** A modular form of level `Γ₁(N)` whose period-one
 `q`-expansion is supported on the multiples of `l` is the renormalised slash by `diag(l, 1)` of a
-function invariant under the weight-`k` slash action of `T`. -/
-theorem exists_slash_T_invariant_of_qExpansionSupportedOnDvd
-    (g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (hg : QExpansionSupportedOnDvd l g) :
+function invariant under the weight-`k` slash action of `T`.
+
+No cusp condition enters: the argument needs only period-one invariance, holomorphy and
+boundedness at infinity, so it is stated for any `ModularFormClass`. -/
+theorem exists_slash_T_invariant_of_isSupportedOnDvd {F : Type*} [FunLike F ℍ ℂ]
+    [ModularFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (g : F)
+    (hg : PowerSeries.IsSupportedOnDvd l (qExpansion 1 g)) :
     ∃ f : ℍ → ℂ, (⇑g : ℍ → ℂ) = (l : ℂ) ^ (1 - k) • (f ∣[k] scaleGL l) ∧
       f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = f := by
   refine ⟨fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ), ?_,
-    slash_T_eq_of_support g (PowerSeries.isSupportedOnDvd_iff.1
-      (qExpansionSupportedOnDvd_iff.1 hg))⟩
+    slash_T_eq_of_support g (PowerSeries.isSupportedOnDvd_iff.1 hg)⟩
   rw [smul_slash_scaleGL_eq]
   funext τ
   rw [inv_smul_smul]
+
+namespace CuspForm
+
+/-- **Descent along a `q`-support condition, for cusp forms.** The specialisation of
+`TauCeti.exists_slash_T_invariant_of_isSupportedOnDvd` at a `CuspForm` and this repository's
+`QExpansionSupportedOnDvd`, which is the shape the Atkin–Lehner old-subspace argument consumes. -/
+theorem exists_slash_T_invariant_of_qExpansionSupportedOnDvd
+    (g : _root_.CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (hg : QExpansionSupportedOnDvd l g) :
+    ∃ f : ℍ → ℂ, (⇑g : ℍ → ℂ) = (l : ℂ) ^ (1 - k) • (f ∣[k] scaleGL l) ∧
+      f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = f :=
+  exists_slash_T_invariant_of_isSupportedOnDvd g (qExpansionSupportedOnDvd_iff.1 hg)
+
+end CuspForm
 
 end TauCeti
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent.lean
@@ -27,9 +27,18 @@ Invariance under `T` is where the support condition is spent: translating by `1 
 the `n`-th `q`-power by a primitive `l`-th root of unity raised to `n`, which is `1` exactly on
 the multiples of `l`, and those are the only indices carrying a nonzero coefficient.
 
+Neither the cusp condition nor the congruence level is used. What the argument needs of the group
+is that `1` be a strict period — the hypothesis making `qExpansion 1` the right expansion and `∞`
+a cusp — so the theorem is stated at an arbitrary `𝒢` carrying that, in the idiom
+`Degeneracy.lean` already uses for its `q`-expansion results, and `Γ₁(N)` enters only in the
+cusp-form specialisation, through `TauCeti.one_mem_strictPeriods_Gamma1_map`.
+
 ## Main results
 
-* `TauCeti.exists_slash_T_invariant_of_qExpansionSupportedOnDvd`: the descent.
+* `TauCeti.exists_slash_T_invariant_of_isSupportedOnDvd`: the descent, at any group with strict
+  period `1`.
+* `CuspForm.exists_slash_T_invariant_of_qExpansionSupportedOnDvd`: its `Γ₁(N)` specialisation to
+  cusp forms, in the shape the Atkin–Lehner old-subspace argument consumes.
 
 ## Provenance
 
@@ -55,11 +64,11 @@ open scoped MatrixGroups ModularForm
 
 namespace TauCeti
 
-variable {N l : ℕ} [NeZero l] {k : ℤ}
+variable {l : ℕ} [NeZero l] {k : ℤ} {𝒢 : Subgroup (GL (Fin 2) ℝ)}
 
 /-- The scaled-down form is `T`-invariant, by uniqueness of the `q`-expansion sum. -/
-private lemma slash_T_eq_of_support {F : Type*} [FunLike F ℍ ℂ]
-    [ModularFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (g : F)
+private lemma slash_T_eq_of_support {F : Type*} [FunLike F ℍ ℂ] [ModularFormClass F 𝒢 k]
+    (h𝒢 : (1 : ℝ) ∈ 𝒢.strictPeriods) (g : F)
     (hg : ∀ n : ℕ, ¬ l ∣ n → (qExpansion 1 g).coeff n = 0) :
     (fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ)) ∣[k]
         (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) =
@@ -71,29 +80,29 @@ private lemma slash_T_eq_of_support {F : Type*} [FunLike F ℍ ℂ]
     ← ModularForm.SL_slash, ModularForm.slash_T_zpow_apply]
   rw [show ((1 : ℤ) : ℝ) = (1 : ℝ) from Int.cast_one, inv_scaleGL_smul_vadd]
   set σ : ℍ := (scaleGL l)⁻¹ • τ
-  have h1 := one_mem_strictPeriods_Gamma1_map N
-  have : Fact (IsCusp OnePoint.infty ((Gamma1 N).map (mapGL ℝ))) :=
-    ⟨((Gamma1 N).map (mapGL ℝ)).isCusp_of_mem_strictPeriods one_pos h1⟩
+  have : Fact (IsCusp OnePoint.infty 𝒢) := ⟨𝒢.isCusp_of_mem_strictPeriods one_pos h𝒢⟩
   have key := UpperHalfPlane.hasSum_qExpansion one_pos
-    (SlashInvariantFormClass.periodic_comp_ofComplex g h1) (ModularFormClass.holo g)
+    (SlashInvariantFormClass.periodic_comp_ofComplex g h𝒢) (ModularFormClass.holo g)
     (ModularFormClass.bdd_at_infty g)
   have Hσ' := key (((1 : ℝ) / (l : ℝ)) +ᵥ σ)
   rw [funext (smul_qParam_pow_shift_eq hg σ)] at Hσ'
   exact ((key σ).unique Hσ').symm
 
-/-- **Descent along a `q`-support condition.** A modular form of level `Γ₁(N)` whose period-one
-`q`-expansion is supported on the multiples of `l` is the renormalised slash by `diag(l, 1)` of a
-function invariant under the weight-`k` slash action of `T`.
+/-- **Descent along a `q`-support condition.** A modular form whose period-one `q`-expansion is
+supported on the multiples of `l` is the renormalised slash by `diag(l, 1)` of a function
+invariant under the weight-`k` slash action of `T`.
 
-No cusp condition enters: the argument needs only period-one invariance, holomorphy and
-boundedness at infinity, so it is stated for any `ModularFormClass`. -/
+Neither a cusp condition nor a congruence level enters. The argument needs only holomorphy,
+boundedness at infinity, and that `1` be a strict period of the group — the hypothesis that makes
+`qExpansion 1` the right expansion and `∞` a cusp — so it is stated for any `ModularFormClass` at
+any such `𝒢`. `TauCeti.one_mem_strictPeriods_Gamma1_map` discharges it at `Γ₁(N)`. -/
 theorem exists_slash_T_invariant_of_isSupportedOnDvd {F : Type*} [FunLike F ℍ ℂ]
-    [ModularFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (g : F)
+    [ModularFormClass F 𝒢 k] (h𝒢 : (1 : ℝ) ∈ 𝒢.strictPeriods) (g : F)
     (hg : PowerSeries.IsSupportedOnDvd l (qExpansion 1 g)) :
     ∃ f : ℍ → ℂ, (⇑g : ℍ → ℂ) = (l : ℂ) ^ (1 - k) • (f ∣[k] scaleGL l) ∧
       f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = f := by
   refine ⟨fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ), ?_,
-    slash_T_eq_of_support g (PowerSeries.isSupportedOnDvd_iff.1 hg)⟩
+    slash_T_eq_of_support h𝒢 g (PowerSeries.isSupportedOnDvd_iff.1 hg)⟩
   rw [smul_slash_scaleGL_eq]
   funext τ
   rw [inv_smul_smul]
@@ -114,7 +123,8 @@ theorem exists_slash_T_invariant_of_qExpansionSupportedOnDvd
     (g : _root_.CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (hg : QExpansionSupportedOnDvd l g) :
     ∃ f : ℍ → ℂ, (⇑g : ℍ → ℂ) = (l : ℂ) ^ (1 - k) • (f ∣[k] scaleGL l) ∧
       f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = f :=
-  exists_slash_T_invariant_of_isSupportedOnDvd g (qExpansionSupportedOnDvd_iff.1 hg)
+  exists_slash_T_invariant_of_isSupportedOnDvd (one_mem_strictPeriods_Gamma1_map N) g
+    (qExpansionSupportedOnDvd_iff.1 hg)
 
 end CuspForm
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent.lean
@@ -98,11 +98,18 @@ theorem exists_slash_T_invariant_of_isSupportedOnDvd {F : Type*} [FunLike F ℍ 
   funext τ
   rw [inv_smul_smul]
 
+end TauCeti
+
 namespace CuspForm
+
+open TauCeti UpperHalfPlane CongruenceSubgroup Matrix.SpecialLinearGroup
+
+variable {N l : ℕ} [NeZero l] {k : ℤ}
 
 /-- **Descent along a `q`-support condition, for cusp forms.** The specialisation of
 `TauCeti.exists_slash_T_invariant_of_isSupportedOnDvd` at a `CuspForm` and this repository's
-`QExpansionSupportedOnDvd`, which is the shape the Atkin–Lehner old-subspace argument consumes. -/
+`QExpansionSupportedOnDvd`, which is the shape the Atkin–Lehner old-subspace argument consumes.
+-/
 theorem exists_slash_T_invariant_of_qExpansionSupportedOnDvd
     (g : _root_.CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (hg : QExpansionSupportedOnDvd l g) :
     ∃ f : ℍ → ℂ, (⇑g : ℍ → ℂ) = (l : ℂ) ^ (1 - k) • (f ∣[k] scaleGL l) ∧
@@ -110,7 +117,5 @@ theorem exists_slash_T_invariant_of_qExpansionSupportedOnDvd
   exists_slash_T_invariant_of_isSupportedOnDvd g (qExpansionSupportedOnDvd_iff.1 hg)
 
 end CuspForm
-
-end TauCeti
 
 end

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, Claude
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.Newforms.QSupport
+
+import Mathlib.RingTheory.RootsOfUnity.Complex
+import TauCeti.NumberTheory.ModularForms.Cusps.Basic
+
+/-!
+# Descent along a `q`-support condition
+
+A cusp form of level `Γ₁(N)` whose period-one `q`-expansion is supported on the multiples of `l`
+is `τ ↦ f (l τ)` for a function `f` invariant under the weight-`k` slash action of `T`.
+
+This is the converse half of the Atkin–Lehner description of the old subspace: `QSupport.lean`
+shows that a level-raise is `q`-supported on multiples of `l`, and this file recovers a
+preimage from that support condition alone. The preimage is only a function — its invariance
+under all of `Γ₁(N/l)` is what the conductor dichotomy goes on to establish — so the statement
+is about `ℍ → ℂ`, and `Degeneracy.smul_slash_scaleGL_eq` is what phrases `τ ↦ f (l τ)` as the
+renormalised slash `l ^ (1 - k) • (f ∣[k] diag(l, 1))` that `levelRaise` uses.
+
+Invariance under `T` is where the support condition is spent: translating by `1 / l` multiplies
+the `n`-th `q`-power by a primitive `l`-th root of unity raised to `n`, which is `1` exactly on
+the multiples of `l`, and those are the only indices carrying a nonzero coefficient.
+
+## Main results
+
+* `TauCeti.exists_slash_T_invariant_of_qExpansionSupportedOnDvd`: the descent.
+
+## Provenance
+
+Adapted from [AINTLIB](https://github.com/CBirkbeck/AINTLIB) (Chris Birkbeck, Apache-2.0) at
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
+`projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Newforms.lean` — the theorem
+`exists_levelRaise_preimage_of_coeff_support_multiples` and its three private helpers. The
+source's `levelRaiseMatrix l` is this repository's `scaleGL l` and its `levelRaiseFun l k f` is
+`l ^ (1 - k) • (f ∣[k] scaleGL l)`, so neither is ported again. The source's `1 < l` and `l ∣ N`
+hypotheses are dropped: neither is used, as the underscores on them record.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.6.
+* [Miyake, *Modular forms*][miyake1989], §4.6.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup ModularForm
+
+open scoped MatrixGroups ModularForm
+
+namespace TauCeti
+
+variable {N l : ℕ} [NeZero l] {k : ℤ}
+
+/-- Slashing by `T` translates the argument by one. -/
+private lemma slash_mapGL_T_apply (k : ℤ) (f : ℍ → ℂ) (τ : ℍ) :
+    (f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ)) τ = f ((1 : ℝ) +ᵥ τ) := by
+  have hSL : (f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ)) =
+      f ∣[k] (ModularGroup.T : SL(2, ℤ)) :=
+    (ModularForm.SL_slash (f := f) (k := k) ModularGroup.T).symm
+  rw [hSL, ModularForm.SL_slash_apply, UpperHalfPlane.modular_T_smul]
+  simp [UpperHalfPlane.denom, ModularGroup.coe_T]
+
+/-- Scaling down commutes with translation, at the cost of dividing the shift by `l`. -/
+private lemma inv_scaleGL_smul_vadd_one (τ : ℍ) :
+    ((scaleGL l)⁻¹ • ((1 : ℝ) +ᵥ τ) : ℍ) = ((1 : ℝ) / (l : ℝ)) +ᵥ ((scaleGL l)⁻¹ • τ) := by
+  have hl : (l : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne l)
+  have h : ∀ σ : ℍ, (((scaleGL l)⁻¹ • σ : ℍ) : ℂ) = (σ : ℂ) / (l : ℂ) := fun σ ↦ by
+    have hs := coe_scaleGL_smul (d := l) ((scaleGL l)⁻¹ • σ)
+    rw [smul_inv_smul] at hs
+    rw [hs, mul_comm, mul_div_assoc, div_self hl, mul_one]
+  apply UpperHalfPlane.ext
+  rw [h ((1 : ℝ) +ᵥ τ), UpperHalfPlane.coe_vadd, UpperHalfPlane.coe_vadd, h τ]
+  push_cast
+  ring
+
+/-- Translating by `1 / l` fixes every `q`-power the support condition leaves alive: it scales
+the `n`-th by an `l`-th root of unity to the `n`, trivial exactly when `l ∣ n`. -/
+private lemma smul_qParam_pow_shift_eq {c : ℕ → ℂ} (hc : ∀ n : ℕ, ¬ l ∣ n → c n = 0)
+    (σ : ℍ) (n : ℕ) :
+    c n • Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (l : ℝ)) +ᵥ σ : ℍ) : ℂ) ^ n =
+      c n • Function.Periodic.qParam (1 : ℝ) (σ : ℂ) ^ n := by
+  have hqP : Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (l : ℝ)) +ᵥ σ : ℍ) : ℂ) =
+      Function.Periodic.qParam (1 : ℝ) (σ : ℂ) *
+        Complex.exp (2 * (Real.pi : ℂ) * Complex.I / (l : ℂ)) := by
+    simp only [Function.Periodic.qParam, UpperHalfPlane.coe_vadd, ← Complex.exp_add]
+    congr 1
+    push_cast
+    ring
+  by_cases hln : l ∣ n
+  · obtain ⟨m, rfl⟩ := hln
+    rw [hqP, mul_pow, pow_mul (Complex.exp _) l m,
+      (Complex.isPrimitiveRoot_exp l (NeZero.ne l)).pow_eq_one, one_pow, mul_one]
+  · rw [hc n hln, zero_smul, zero_smul]
+
+/-- The scaled-down form is `T`-invariant, by uniqueness of the `q`-expansion sum. -/
+private lemma slash_T_eq_of_support (g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)
+    (hg : ∀ n : ℕ, ¬ l ∣ n → (qExpansion 1 g).coeff n = 0) :
+    (fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ)) ∣[k]
+        (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) =
+      fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ) := by
+  funext τ
+  rw [slash_mapGL_T_apply, inv_scaleGL_smul_vadd_one]
+  set σ : ℍ := (scaleGL l)⁻¹ • τ
+  have h1 := one_mem_strictPeriods_Gamma1_map N
+  have : Fact (IsCusp OnePoint.infty ((Gamma1 N).map (mapGL ℝ))) :=
+    ⟨((Gamma1 N).map (mapGL ℝ)).isCusp_of_mem_strictPeriods one_pos h1⟩
+  have key := UpperHalfPlane.hasSum_qExpansion one_pos
+    (SlashInvariantFormClass.periodic_comp_ofComplex g h1) (ModularFormClass.holo g)
+    (ModularFormClass.bdd_at_infty g)
+  have Hσ' := key (((1 : ℝ) / (l : ℝ)) +ᵥ σ)
+  rw [funext (smul_qParam_pow_shift_eq hg σ)] at Hσ'
+  exact ((key σ).unique Hσ').symm
+
+/-- **Descent along a `q`-support condition.** A cusp form of level `Γ₁(N)` whose period-one
+`q`-expansion is supported on the multiples of `l` is the renormalised slash by `diag(l, 1)` of a
+function invariant under the weight-`k` slash action of `T`. -/
+theorem exists_slash_T_invariant_of_qExpansionSupportedOnDvd
+    (g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (hg : QExpansionSupportedOnDvd l g) :
+    ∃ f : ℍ → ℂ, (⇑g : ℍ → ℂ) = (l : ℂ) ^ (1 - k) • (f ∣[k] scaleGL l) ∧
+      f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = f := by
+  refine ⟨fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ), ?_,
+    slash_T_eq_of_support g (PowerSeries.isSupportedOnDvd_iff.1
+      (qExpansionSupportedOnDvd_iff.1 hg))⟩
+  rw [smul_slash_scaleGL_eq]
+  funext τ
+  rw [inv_smul_smul]
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Descent.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Descent.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.NumberTheory.ModularForms.Newforms.QSupport
 
-import Mathlib.RingTheory.RootsOfUnity.Complex
 import TauCeti.NumberTheory.ModularForms.Cusps.Basic
 
 /-!
@@ -27,18 +26,20 @@ Invariance under `T` is where the support condition is spent: translating by `1 
 the `n`-th `q`-power by a primitive `l`-th root of unity raised to `n`, which is `1` exactly on
 the multiples of `l`, and those are the only indices carrying a nonzero coefficient.
 
-Neither the cusp condition nor the congruence level is used. What the argument needs of the group
-is that `1` be a strict period — the hypothesis making `qExpansion 1` the right expansion and `∞`
-a cusp — so the theorem is stated at an arbitrary `𝒢` carrying that, in the idiom
-`Degeneracy.lean` already uses for its `q`-expansion results, and `Γ₁(N)` enters only in the
-cusp-form specialisation, through `TauCeti.one_mem_strictPeriods_Gamma1_map`.
+Neither the cusp condition nor the congruence level is used, and neither is the group. What the
+argument asks of `g` is exactly what `UpperHalfPlane.hasSum_qExpansion` asks: that `g ∘ ofComplex`
+have period `1`, that `g` be holomorphic, and that it be bounded at `i∞`. So the theorem is stated
+for a bare `g : ℍ → ℂ` carrying those three hypotheses, and `Γ₁(N)` enters only in the cusp-form
+specialisation, which supplies them from the form class — period `1` through
+`TauCeti.one_mem_strictPeriods_Gamma1_map`, and boundedness through the `Fact (IsCusp ∞ _)` that
+`ModularFormClass.bdd_at_infty` asks for.
 
 ## Main results
 
-* `TauCeti.exists_slash_T_invariant_of_isSupportedOnDvd`: the descent, at any group with strict
-  period `1`.
-* `CuspForm.exists_slash_T_invariant_of_qExpansionSupportedOnDvd`: its `Γ₁(N)` specialisation to
-  cusp forms, in the shape the Atkin–Lehner old-subspace argument consumes.
+* `TauCeti.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_isSupportedOnDvd`: the descent, for any
+  period-one holomorphic function bounded at `i∞`.
+* `CuspForm.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_qExpansionSupportedOnDvd`: its `Γ₁(N)`
+  specialisation to cusp forms, in the shape the Atkin–Lehner old-subspace argument consumes.
 
 ## Provenance
 
@@ -60,49 +61,48 @@ public section
 
 open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup ModularForm
 
-open scoped MatrixGroups ModularForm
+open scoped Manifold MatrixGroups ModularForm
 
 namespace TauCeti
 
-variable {l : ℕ} [NeZero l] {k : ℤ} {𝒢 : Subgroup (GL (Fin 2) ℝ)}
+variable {l : ℕ} [NeZero l]
 
-/-- The scaled-down form is `T`-invariant, by uniqueness of the `q`-expansion sum. -/
-private lemma slash_T_eq_of_support {F : Type*} [FunLike F ℍ ℂ] [ModularFormClass F 𝒢 k]
-    (h𝒢 : (1 : ℝ) ∈ 𝒢.strictPeriods) (g : F)
+/-- The scaled-down function is `T`-invariant, by uniqueness of the `q`-expansion sum. -/
+private lemma slash_T_eq_of_support (k : ℤ) {g : ℍ → ℂ}
+    (hper : Function.Periodic (g ∘ UpperHalfPlane.ofComplex) 1) (hhol : MDiff g)
+    (hbdd : IsBoundedAtImInfty g)
     (hg : ∀ n : ℕ, ¬ l ∣ n → (qExpansion 1 g).coeff n = 0) :
-    (fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ)) ∣[k]
-        (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) =
-      fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ) := by
+    (fun τ ↦ g ((scaleGL l)⁻¹ • τ)) ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) =
+      fun τ ↦ g ((scaleGL l)⁻¹ • τ) := by
   funext τ
+  -- `slash_T_zpow_apply` is stated at a *power* of `T` inside `SL(2, ℤ)`, while the statement
+  -- above names the generator in `GL (Fin 2) ℝ`; `T = T ^ 1` under `coe_GL_eq_mapGL` is the
+  -- one rewrite that reconciles the two spellings, and no lemma states it at `T` itself.
   rw [show (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) =
       ((ModularGroup.T ^ (1 : ℤ) : SL(2, ℤ)) : GL (Fin 2) ℝ) by
         rw [zpow_one, Matrix.SpecialLinearGroup.coe_GL_eq_mapGL],
-    ← ModularForm.SL_slash, ModularForm.slash_T_zpow_apply]
-  rw [show ((1 : ℤ) : ℝ) = (1 : ℝ) from Int.cast_one, inv_scaleGL_smul_vadd]
+    ← ModularForm.SL_slash, ModularForm.slash_T_zpow_apply, Int.cast_one,
+    inv_scaleGL_smul_vadd]
   set σ : ℍ := (scaleGL l)⁻¹ • τ
-  have : Fact (IsCusp OnePoint.infty 𝒢) := ⟨𝒢.isCusp_of_mem_strictPeriods one_pos h𝒢⟩
-  have key := UpperHalfPlane.hasSum_qExpansion one_pos
-    (SlashInvariantFormClass.periodic_comp_ofComplex g h𝒢) (ModularFormClass.holo g)
-    (ModularFormClass.bdd_at_infty g)
+  have key := UpperHalfPlane.hasSum_qExpansion one_pos hper hhol hbdd
   have Hσ' := key (((1 : ℝ) / (l : ℝ)) +ᵥ σ)
   rw [funext (smul_qParam_pow_shift_eq hg σ)] at Hσ'
   exact ((key σ).unique Hσ').symm
 
-/-- **Descent along a `q`-support condition.** A modular form whose period-one `q`-expansion is
+/-- **Descent along a `q`-support condition.** A function whose period-one `q`-expansion is
 supported on the multiples of `l` is the renormalised slash by `diag(l, 1)` of a function
 invariant under the weight-`k` slash action of `T`.
 
-Neither a cusp condition nor a congruence level enters. The argument needs only holomorphy,
-boundedness at infinity, and that `1` be a strict period of the group — the hypothesis that makes
-`qExpansion 1` the right expansion and `∞` a cusp — so it is stated for any `ModularFormClass` at
-any such `𝒢`. `TauCeti.one_mem_strictPeriods_Gamma1_map` discharges it at `Γ₁(N)`. -/
-theorem exists_slash_T_invariant_of_isSupportedOnDvd {F : Type*} [FunLike F ℍ ℂ]
-    [ModularFormClass F 𝒢 k] (h𝒢 : (1 : ℝ) ∈ 𝒢.strictPeriods) (g : F)
-    (hg : PowerSeries.IsSupportedOnDvd l (qExpansion 1 g)) :
-    ∃ f : ℍ → ℂ, (⇑g : ℍ → ℂ) = (l : ℂ) ^ (1 - k) • (f ∣[k] scaleGL l) ∧
+The hypotheses are exactly the three that `UpperHalfPlane.hasSum_qExpansion` needs — period `1`
+after `ofComplex`, holomorphy, and boundedness at `i∞` — so no group, no slash invariance beyond
+that single period, and no cusp condition enter. -/
+theorem exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_isSupportedOnDvd (k : ℤ) {g : ℍ → ℂ}
+    (hper : Function.Periodic (g ∘ UpperHalfPlane.ofComplex) 1) (hhol : MDiff g)
+    (hbdd : IsBoundedAtImInfty g) (hg : PowerSeries.IsSupportedOnDvd l (qExpansion 1 g)) :
+    ∃ f : ℍ → ℂ, g = (l : ℂ) ^ (1 - k) • (f ∣[k] scaleGL l) ∧
       f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = f := by
-  refine ⟨fun τ ↦ (⇑g : ℍ → ℂ) ((scaleGL l)⁻¹ • τ), ?_,
-    slash_T_eq_of_support h𝒢 g (PowerSeries.isSupportedOnDvd_iff.1 hg)⟩
+  refine ⟨fun τ ↦ g ((scaleGL l)⁻¹ • τ), ?_,
+    slash_T_eq_of_support k hper hhol hbdd (PowerSeries.isSupportedOnDvd_iff.1 hg)⟩
   rw [smul_slash_scaleGL_eq]
   funext τ
   rw [inv_smul_smul]
@@ -116,15 +116,20 @@ open TauCeti UpperHalfPlane CongruenceSubgroup Matrix.SpecialLinearGroup
 variable {N l : ℕ} [NeZero l] {k : ℤ}
 
 /-- **Descent along a `q`-support condition, for cusp forms.** The specialisation of
-`TauCeti.exists_slash_T_invariant_of_isSupportedOnDvd` at a `CuspForm` and this repository's
-`QExpansionSupportedOnDvd`, which is the shape the Atkin–Lehner old-subspace argument consumes.
--/
-theorem exists_slash_T_invariant_of_qExpansionSupportedOnDvd
+`TauCeti.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_isSupportedOnDvd` at a `CuspForm` and this
+repository's `QExpansionSupportedOnDvd`, which is the shape the Atkin–Lehner old-subspace argument
+consumes. The three analytic hypotheses come from the form class, period `1` at `Γ₁(N)` from
+`TauCeti.one_mem_strictPeriods_Gamma1_map`. -/
+theorem exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_qExpansionSupportedOnDvd
     (g : _root_.CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (hg : QExpansionSupportedOnDvd l g) :
     ∃ f : ℍ → ℂ, (⇑g : ℍ → ℂ) = (l : ℂ) ^ (1 - k) • (f ∣[k] scaleGL l) ∧
       f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = f :=
-  exists_slash_T_invariant_of_isSupportedOnDvd (one_mem_strictPeriods_Gamma1_map N) g
-    (qExpansionSupportedOnDvd_iff.1 hg)
+  have h1 := one_mem_strictPeriods_Gamma1_map N
+  have : Fact (IsCusp OnePoint.infty ((Gamma1 N).map (mapGL ℝ))) :=
+    ⟨((Gamma1 N).map (mapGL ℝ)).isCusp_of_mem_strictPeriods one_pos h1⟩
+  exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_isSupportedOnDvd k
+    (SlashInvariantFormClass.periodic_comp_ofComplex g h1) (ModularFormClass.holo g)
+    (ModularFormClass.bdd_at_infty g) (qExpansionSupportedOnDvd_iff.1 hg)
 
 end CuspForm
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/QSupport.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/QSupport.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.ModularForms.Degeneracy
+public import TauCeti.Analysis.Complex.Periodic
 public import Mathlib.NumberTheory.ModularForms.CuspFormSubmodule
 public import TauCeti.NumberTheory.ModularForms.QExpansion.Basic
 
@@ -174,6 +175,31 @@ theorem iSup_range_levelRaise_le_qSupportedOnDvdSubmodule (N : ℕ) :
       LinearMap.range (CuspForm.levelRaiseₗ (k := k) d (Gamma1_map_le_conjAct_scaleGL_of_dvd h)) ≤
         qSupportedOnDvdSubmodule N k d :=
   iSup_le fun M ↦ iSup_le fun h ↦ range_levelRaise_le_qSupportedOnDvdSubmodule M h
+
+omit [NeZero M] in
+/-- **A shift by `1 / d` fixes every `q`-power the support condition leaves alive.** Translating
+the argument by `1 / d` scales the `n`-th `q`-power by a `d`-th root of unity raised to `n`, which
+is trivial exactly on the multiples of `d` — and a coefficient function supported there kills
+every other index. This is what a `q`-support hypothesis is spent on when descending along `V_d`.
+-/
+theorem smul_qParam_pow_shift_eq {c : ℕ → ℂ} (hc : ∀ n : ℕ, ¬ d ∣ n → c n = 0) (σ : ℍ) (n : ℕ) :
+    c n • Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) ^ n =
+      c n • Function.Periodic.qParam (1 : ℝ) (σ : ℂ) ^ n := by
+  have hqP : Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) =
+      Function.Periodic.qParam (1 : ℝ) (σ : ℂ) *
+        Complex.exp (2 * (Real.pi : ℂ) * Complex.I / (d : ℂ)) := by
+    have h := TauCeti.Periodic.qParam_sub (h := (1 : ℝ)) (σ : ℂ) (-(1 / (d : ℂ)))
+    rw [show ((σ : ℂ) - -(1 / (d : ℂ))) = ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) from by
+      rw [UpperHalfPlane.coe_vadd]; push_cast; ring] at h
+    rw [h]
+    congr 1
+    push_cast
+    ring_nf
+  by_cases hdn : d ∣ n
+  · obtain ⟨m, rfl⟩ := hdn
+    rw [hqP, mul_pow, pow_mul (Complex.exp _) d m,
+      (Complex.isPrimitiveRoot_exp d (NeZero.ne d)).pow_eq_one, one_pow, mul_one]
+  · rw [hc n hdn, zero_smul, zero_smul]
 
 end QExpansion
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/QSupport.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/QSupport.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.ModularForms.Degeneracy
-public import TauCeti.Analysis.Complex.Periodic
 public import Mathlib.NumberTheory.ModularForms.CuspFormSubmodule
 public import TauCeti.NumberTheory.ModularForms.QExpansion.Basic
 
@@ -175,38 +174,6 @@ theorem iSup_range_levelRaise_le_qSupportedOnDvdSubmodule (N : ℕ) :
       LinearMap.range (CuspForm.levelRaiseₗ (k := k) d (Gamma1_map_le_conjAct_scaleGL_of_dvd h)) ≤
         qSupportedOnDvdSubmodule N k d :=
   iSup_le fun M ↦ iSup_le fun h ↦ range_levelRaise_le_qSupportedOnDvdSubmodule M h
-
-omit [NeZero M] [NeZero d] in
-/-- The translate `1 / d +ᵥ σ`, read in `ℂ`, is the subtraction `TauCeti.Periodic.qParam_sub`
-expects: that lemma is stated at `z - j`, and the shift here enters as a `+ᵥ` on `ℍ`. Naming the
-coercion bridge keeps the root-of-unity computation below free of casting. -/
-private lemma coe_vadd_one_div_eq_sub (σ : ℍ) :
-    ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) = (σ : ℂ) - -(1 / (d : ℂ)) := by
-  rw [UpperHalfPlane.coe_vadd]
-  push_cast
-  ring
-
-omit [NeZero M] in
-/-- **A shift by `1 / d` fixes every `q`-power the support condition leaves alive.** Translating
-the argument by `1 / d` scales the `n`-th `q`-power by a `d`-th root of unity raised to `n`, which
-is trivial exactly on the multiples of `d` — and a coefficient function supported there kills
-every other index. This is what a `q`-support hypothesis is spent on when descending along `V_d`.
--/
-theorem smul_qParam_pow_shift_eq {c : ℕ → ℂ} (hc : ∀ n : ℕ, ¬ d ∣ n → c n = 0) (σ : ℍ) (n : ℕ) :
-    c n • Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) ^ n =
-      c n • Function.Periodic.qParam (1 : ℝ) (σ : ℂ) ^ n := by
-  have hqP : Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) =
-      Function.Periodic.qParam (1 : ℝ) (σ : ℂ) *
-        Complex.exp (2 * (Real.pi : ℂ) * Complex.I / (d : ℂ)) := by
-    rw [coe_vadd_one_div_eq_sub, TauCeti.Periodic.qParam_sub]
-    congr 1
-    push_cast
-    ring_nf
-  by_cases hdn : d ∣ n
-  · obtain ⟨m, rfl⟩ := hdn
-    rw [hqP, mul_pow, pow_mul (Complex.exp _) d m,
-      (Complex.isPrimitiveRoot_exp d (NeZero.ne d)).pow_eq_one, one_pow, mul_one]
-  · rw [hc n hdn, zero_smul, zero_smul]
 
 end QExpansion
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/QSupport.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/QSupport.lean
@@ -176,6 +176,16 @@ theorem iSup_range_levelRaise_le_qSupportedOnDvdSubmodule (N : ℕ) :
         qSupportedOnDvdSubmodule N k d :=
   iSup_le fun M ↦ iSup_le fun h ↦ range_levelRaise_le_qSupportedOnDvdSubmodule M h
 
+omit [NeZero M] [NeZero d] in
+/-- The translate `1 / d +ᵥ σ`, read in `ℂ`, is the subtraction `TauCeti.Periodic.qParam_sub`
+expects: that lemma is stated at `z - j`, and the shift here enters as a `+ᵥ` on `ℍ`. Naming the
+coercion bridge keeps the root-of-unity computation below free of casting. -/
+private lemma coe_vadd_one_div_eq_sub (σ : ℍ) :
+    ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) = (σ : ℂ) - -(1 / (d : ℂ)) := by
+  rw [UpperHalfPlane.coe_vadd]
+  push_cast
+  ring
+
 omit [NeZero M] in
 /-- **A shift by `1 / d` fixes every `q`-power the support condition leaves alive.** Translating
 the argument by `1 / d` scales the `n`-th `q`-power by a `d`-th root of unity raised to `n`, which
@@ -188,10 +198,7 @@ theorem smul_qParam_pow_shift_eq {c : ℕ → ℂ} (hc : ∀ n : ℕ, ¬ d ∣ n
   have hqP : Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) =
       Function.Periodic.qParam (1 : ℝ) (σ : ℂ) *
         Complex.exp (2 * (Real.pi : ℂ) * Complex.I / (d : ℂ)) := by
-    have h := TauCeti.Periodic.qParam_sub (h := (1 : ℝ)) (σ : ℂ) (-(1 / (d : ℂ)))
-    rw [show ((σ : ℂ) - -(1 / (d : ℂ))) = ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) from by
-      rw [UpperHalfPlane.coe_vadd]; push_cast; ring] at h
-    rw [h]
+    rw [coe_vadd_one_div_eq_sub, TauCeti.Periodic.qParam_sub]
     congr 1
     push_cast
     ring_nf

--- a/TauCeti/NumberTheory/ModularForms/QExpansion/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/Basic.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.ModularForms.QExpansion
+public import TauCeti.Analysis.Complex.Periodic
 
 /-!
 # The `q`-expansion as a linear map, and uniqueness of coefficients for raw functions
@@ -21,10 +22,19 @@ invoke it. The proof is Mathlib's, run through `UpperHalfPlane.hasFPowerSeriesOn
 which *is* stated for `{f : ℍ → ℂ}`, with `qExpansionFormalMultilinearSeries` spelled out
 inline for the same reason.
 
+Alongside those, the effect of a `1 / d` translation on the `q`-powers a support condition
+leaves alive: shifting the argument by `1 / d` scales the `n`-th `q`-power by a `d`-th root of
+unity raised to `n`, so a coefficient function supported on the multiples of `d` does not see the
+shift. That is what a `q`-support hypothesis is spent on when descending along `V_d`, and it is
+stated here rather than at the descent because it mentions only coefficients, divisibility and
+`Function.Periodic.qParam`.
+
 ## Main declarations
 
 * `TauCeti.ModularForm.qExpansionLinearMap`.
 * `TauCeti.UpperHalfPlane.qExpansion_coeff_unique`.
+* `TauCeti.smul_qParam_pow_shift_eq`: a shift by `1 / d` fixes every `q`-power that a
+  `d`-supported coefficient function leaves alive.
 
 ## References
 
@@ -73,6 +83,37 @@ lemma UpperHalfPlane.qExpansion_coeff_unique {f : ℍ → ℂ} {c : ℕ → ℂ}
     simpa [_root_.UpperHalfPlane.qExpansion_coeff, div_eq_mul_inv, mul_comm]
       using hfanalytic.hasFPowerSeriesAt
   simpa using congr_arg (FormalMultilinearSeries.coeff · m) (h1.eq_formalMultilinearSeries h2)
+
+/-- The translate `1 / d +ᵥ σ`, read in `ℂ`, is the subtraction `TauCeti.Periodic.qParam_sub`
+expects: that lemma is stated at `z - j`, and the shift here enters as a `+ᵥ` on `ℍ`. Naming the
+coercion bridge keeps the root-of-unity computation below free of casting. -/
+private lemma coe_vadd_one_div_eq_sub {d : ℕ} (σ : ℍ) :
+    ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) = (σ : ℂ) - -(1 / (d : ℂ)) := by
+  rw [UpperHalfPlane.coe_vadd]
+  push_cast
+  ring
+
+/-- **A shift by `1 / d` fixes every `q`-power the support condition leaves alive.** Translating
+the argument by `1 / d` scales the `n`-th `q`-power by a `d`-th root of unity raised to `n`, which
+is trivial exactly on the multiples of `d` — and a coefficient function supported there kills
+every other index. This is what a `q`-support hypothesis is spent on when descending along `V_d`.
+-/
+theorem smul_qParam_pow_shift_eq {d : ℕ} [NeZero d] {c : ℕ → ℂ}
+    (hc : ∀ n : ℕ, ¬ d ∣ n → c n = 0) (σ : ℍ) (n : ℕ) :
+    c n • Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) ^ n =
+      c n • Function.Periodic.qParam (1 : ℝ) (σ : ℂ) ^ n := by
+  have hqP : Function.Periodic.qParam (1 : ℝ) ((((1 : ℝ) / (d : ℝ)) +ᵥ σ : ℍ) : ℂ) =
+      Function.Periodic.qParam (1 : ℝ) (σ : ℂ) *
+        Complex.exp (2 * (Real.pi : ℂ) * Complex.I / (d : ℂ)) := by
+    rw [coe_vadd_one_div_eq_sub, TauCeti.Periodic.qParam_sub]
+    congr 1
+    push_cast
+    ring_nf
+  by_cases hdn : d ∣ n
+  · obtain ⟨m, rfl⟩ := hdn
+    rw [hqP, mul_pow, pow_mul (Complex.exp _) d m,
+      (Complex.isPrimitiveRoot_exp d (NeZero.ne d)).pow_eq_one, one_pow, mul_one]
+  · rw [hc n hdn, zero_smul, zero_smul]
 
 end TauCeti
 


### PR DESCRIPTION
A function of period `1`, holomorphic and bounded at `i∞`, whose `q`-expansion is supported on the
multiples of `l`, is `τ ↦ f (l τ)` for an `f` invariant under the weight-`k` slash action of `T`:

```lean
theorem exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_isSupportedOnDvd (k : ℤ) {g : ℍ → ℂ}
    (hper : Function.Periodic (g ∘ UpperHalfPlane.ofComplex) 1) (hhol : MDiff g)
    (hbdd : IsBoundedAtImInfty g) (hg : PowerSeries.IsSupportedOnDvd l (qExpansion 1 g)) :
    ∃ f : ℍ → ℂ, g = (l : ℂ) ^ (1 - k) • (f ∣[k] scaleGL l) ∧
      f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = f
```

with the `Γ₁(N)` cusp-form specialisation
`CuspForm.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_qExpansionSupportedOnDvd` supplying the
three analytic hypotheses from the form class.

## What this is for

This is the **converse half** of the Atkin–Lehner description of the old subspace.
`Newforms/QSupport.lean` already has the forward half — a level-raise is `q`-supported on
multiples of `l` (`levelRaise_mem_qSupportedOnDvdSubmodule`). This recovers a preimage from the
support condition alone.

The preimage is only a *function*: its invariance under all of `Γ₁(N/l)` is what the conductor
dichotomy goes on to establish, so the statement is deliberately about `ℍ → ℂ`.
`Degeneracy.smul_slash_scaleGL_eq` — which exists precisely "for a bare function … the situation
of the conductor theorem" — phrases `τ ↦ f (l τ)` as the renormalised slash
`l ^ (1 - k) • (f ∣[k] diag(l, 1))` that `levelRaise` is built from.

Invariance under `T` is where the support hypothesis is spent: translating by `1 / l` multiplies
the `n`-th `q`-power by a primitive `l`-th root of unity raised to `n`, which is `1` exactly on
the multiples of `l` — and by hypothesis those are the only indices carrying a nonzero
coefficient. Uniqueness of the `q`-expansion sum then identifies the two values.

## Hypotheses

No group, no cusp condition, no congruence level. The argument asks of `g` exactly what
`UpperHalfPlane.hasSum_qExpansion` asks: period `1` after `ofComplex`, holomorphy, and
boundedness at `i∞`. The cusp-form specialisation supplies all three from `ModularFormClass`,
taking period `1` at `Γ₁(N)` from `one_mem_strictPeriods_Gamma1_map` and carrying the
`Fact (IsCusp ∞ _)` that `ModularFormClass.bdd_at_infty` requires.

The source states its version with `1 < l` and `l ∣ N`. Neither is used — the underscores on them
in the source record as much — so both are dropped; what remains is `[NeZero l]`.

## Where the pieces sit

Three files: the descent itself in `Newforms/Descent.lean`; two small `scaleGL` facts in
`Degeneracy.lean` (`coe_inv_scaleGL_smul`, and `inv_scaleGL_smul_vadd`, which is `@[simp]`); and
the `q`-parameter shift lemma `smul_qParam_pow_shift_eq` in `QExpansion/Basic.lean`, which is
where it belongs — it mentions only coefficients, divisibility and `Function.Periodic.qParam`, so
it is infrastructure rather than newforms API. `Newforms/QSupport.lean` is unchanged.

## Where it leads

Reading the Layer 5 chain from the top: strong multiplicity one consumes
`coeff_one_ne_zero_of_mem_cuspFormsNew_of_eigen`, which consumes `mainLemma_charSpace_routeB`,
which reaches `qSupportedOnDvd_mem_cuspFormsOld_of_char`, whose two inputs are the conductor
dichotomy — already here as `ConductorDichotomy.lean`, and turned into oldness by
[#5657](https://github.com/TauCetiProject/TauCeti/pull/5657) — and this descent.

Roadmap: ModularForms

New mathematics, so the citation: this supplies a prerequisite that
`TauCetiRoadmap/ModularForms/README.md` § "Layer 5: strong multiplicity one and the eigenform
characterization" needs — the fixed-space `strongMultiplicityOne` bullet. It does **not** author
that target, so it carries no `tauceti-target` marker: the marker is for a PR authoring a target,
and inventing an id for a prerequisite risks colliding with the PR that eventually authors
`strongMultiplicityOne` and having the duplicate sweeper close one of them.

Provenance: [AINTLIB](https://github.com/CBirkbeck/AINTLIB) @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
Apache-2.0, Chris Birkbeck — `projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Newforms.lean`,
the theorem `exists_levelRaise_preimage_of_coeff_support_multiples` and its three private helpers
`levelRaiseMatrix_inv_smul_vadd_one_eq`, `smul_qParam_pow_shift_eq` and
`levelRaisePreimage_slash_T_eq`. The source's `levelRaiseMatrix l` is this repository's
`scaleGL l` and its `levelRaiseFun l k f` is `l ^ (1 - k) • (f ∣[k] scaleGL l)`, so neither is
ported again; the hypothesis is stated with this repository's own `QExpansionSupportedOnDvd`
rather than a bare `∀ n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR

