### PR TITLE
feat(LinearAlgebra): doubling is invertible on the ℤ-endomorphisms of a real vector space

### DIFF
--- a/TauCeti/LinearAlgebra/End/InvertibleTwo.lean
+++ b/TauCeti/LinearAlgebra/End/InvertibleTwo.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.CharP.Invertible
+public import Mathlib.Algebra.Group.Action.Hom
+public import Mathlib.Algebra.Module.LinearMap.End
+public import Mathlib.Basic.Real.Basic
+
+/-!
+# Doubling is invertible on a real vector space
+
+For a real vector space `N`, multiplication by `2` is a bijection, so the doubling map is a unit
+of the endomorphism ring — and it remains one when `N` is regarded only as a `ℤ`-module, where
+`2` itself is not invertible. This file records that as an `Invertible (2 : Module.End ℤ N)`
+instance, together with the rewrite rule identifying its inverse with the real scalar `(2 : ℝ)⁻¹`.
+
+## Main definitions
+
+* `TauCeti.invertibleTwoModuleEndInt`: for any semiring `S` acting on `N` in which `2` is
+  invertible, doubling is invertible on the `ℤ`-endomorphisms of `N`.
+
+## Main results
+
+* `TauCeti.invOf_two_moduleEndInt_apply`: the inverse of doubling is halving by the scalar,
+  for whichever `Invertible (2 : Module.End ℤ N)` instance is in scope.
+* `TauCeti.instInvertibleTwoModuleEndInt`: the instance for `S = ℝ`, so that doubling is
+  invertible on any real vector space viewed as an endomorphism of its underlying `ℤ`-module.
+* `TauCeti.half_moduleEndInt_apply_eq_half_smul`: that inverse acts as the scalar `(2 : ℝ)⁻¹`.
+  This is the `R = ℤ` counterpart of Mathlib's
+  `QuadraticMap.half_moduleEnd_apply_eq_half_smul`, whose `Invertible (2 : R)` hypothesis is
+  unavailable for `R = ℤ`; here the halving scalar comes from the module structure instead of
+  from the ring.
+
+## The consumer this exists for
+
+Mathlib builds the bilinear map associated with a quadratic map by halving the polar form:
+`QuadraticMap.associatedHom` is `⅟(2 : Module.End R N) • QuadraticMap.polarBilin`, with
+`QuadraticMap.associated'` the `ℤ`-linear specialisation. Halving needs
+`Invertible (2 : Module.End R N)`, and Mathlib's docstring for `associatedHom` names exactly the
+case this file supplies:
+
+> Note that this makes the bijection available in more cases than the simpler condition
+> `Invertible (2 : R)`, e.g., when `R = ℤ` and `N = ℝ`.
+
+Mathlib provides no instance reaching it: its only route is
+`[Invertible (2 : R)] → Invertible (2 : Module.End R M)`, which for `R = ℤ` asks for
+`Invertible (2 : ℤ)` and fails. With the instance below, `associated'` and its API —
+`associated_apply`, `associated_isSymm`, `associated_flip`, `associated_eq_self_apply` — become
+usable on `ℤ`-quadratic maps with values in a real vector space.
+
+## Implementation notes
+
+The construction is stated for a general scalar semiring `S` but is a `def` rather than an
+`instance`, because `S` appears nowhere in the conclusion `Invertible (2 : Module.End ℤ N)` and
+so could never be inferred by instance search. Instances are registered by applying it to the
+scalar rings that are wanted; `ℝ` is the one this repository needs.
+
+-/
+
+public section
+
+namespace TauCeti
+
+variable {N : Type*} [AddCommGroup N]
+
+/-- **Doubling is invertible on the `ℤ`-endomorphisms of a module over a semiring in which `2` is
+invertible.** The halving scalar comes from the module structure rather than from `ℤ`. -/
+-- A `def`, not an `instance`: `S` occurs nowhere in the conclusion, so instance search could never
+-- infer it. Instances are registered for the scalar rings that are wanted, `ℝ` below.
+@[instance_reducible]
+noncomputable def invertibleTwoModuleEndInt (S : Type*) [Semiring S] [Module S N]
+    [Invertible (2 : S)] : Invertible (2 : Module.End ℤ N) :=
+  -- Doubling is the image of `2 : S` under `x ↦ x • 1`, which is multiplicative, so
+  -- `Invertible.map` transports invertibility along it; only the numerals need reconciling.
+  (Invertible.map (MonoidHom.smulOneHom (M := S) (N := Module.End ℤ N)) 2).copy 2 <|
+    -- `ofNat_smul_eq_nsmul` is the bridge: the `2 •` that `Module.End`'s numeral produces is an
+    -- `nsmul`, and it has to be matched against the `S`-action before the scalars can cancel.
+    by ext x; simp [← ofNat_smul_eq_nsmul S]
+
+/-- **The inverse of doubling is halving by the scalar**, for whichever
+`Invertible (2 : Module.End ℤ N)` instance is in scope. -/
+-- Instance-independent because an inverse in a monoid is unique: `invOf_eq_right_inv` derives
+-- `⅟` from the equation, so the proof never unfolds `invertibleTwoModuleEndInt` and the
+-- definition needs no `@[expose]`.
+theorem invOf_two_moduleEndInt_apply (S : Type*) [Semiring S] [Module S N] [Invertible (2 : S)]
+    [Invertible (2 : Module.End ℤ N)] (x : N) :
+    ⅟(2 : Module.End ℤ N) x = ⅟(2 : S) • x := by
+  rw [invOf_eq_right_inv (b := ⅟(2 : S) • (1 : Module.End ℤ N))
+    (by ext y; simp [← ofNat_smul_eq_nsmul S, smul_smul])]
+  simp
+
+variable [Module ℝ N]
+
+/-- **Doubling is invertible on a real vector space**, as an endomorphism of its `ℤ`-module
+structure. -/
+-- Named rather than anonymous: Lean's generated name for the anonymous form carries an underscore
+-- (`instInvertibleEndIntOfNat_tauCeti`), which the `defsWithUnderscore` linter rejects.
+noncomputable instance instInvertibleTwoModuleEndInt : Invertible (2 : Module.End ℤ N) :=
+  invertibleTwoModuleEndInt ℝ
+
+/-- The inverse of doubling acts as the real scalar `(2 : ℝ)⁻¹`. -/
+-- Stated with function application rather than `•`, because `simp` normalises a `Module.End`
+-- action to application (`Module.End.smul_def`).
+@[simp]
+theorem half_moduleEndInt_apply_eq_half_smul (x : N) :
+    ⅟(2 : Module.End ℤ N) x = (2 : ℝ)⁻¹ • x := by
+  rw [invOf_two_moduleEndInt_apply ℝ, invOf_eq_inv]
+
+end TauCeti


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"canonical-height"}-->

## Why this exists

Mathlib builds the bilinear map associated with a quadratic map by **halving the polar form**:
`QuadraticMap.associatedHom` is `⅟(2 : Module.End R N) • QuadraticMap.polarBilin`, with
`associated' = associatedHom ℤ`. Halving needs `Invertible (2 : Module.End R N)`, and Mathlib's
own docstring for `associatedHom` names the case this PR supplies
(`Mathlib/LinearAlgebra/QuadraticForm/Basic.lean:659`):

> Note that this makes the bijection available in more cases than the simpler condition
> `Invertible (2 : R)`, e.g., when `R = ℤ` and `N = ℝ`.

But Mathlib provides no instance reaching it. Its only route is
`[Invertible (2 : R)] → Invertible (2 : Module.End R M)` (`Basic.lean:824`), which at `R = ℤ` asks
for `Invertible (2 : ℤ)` and fails. Verified by a compiled probe:

```
example : Invertible (2 : Module.End ℤ ℝ) := by infer_instance
-- failed to synthesize instance of type class Invertible 2
```

So the advertised case is unreachable, and every real-valued `ℤ`-quadratic form is cut off from
`associated'` and its API.

## What it adds

```lean
-- the general construction: a `def`, because `S` is not inferable from the conclusion
@[instance_reducible]
noncomputable def invertibleTwoModuleEndInt {N : Type*} [AddCommGroup N] (S : Type*) [Semiring S]
    [Module S N] [Invertible (2 : S)] : Invertible (2 : Module.End ℤ N)

-- the characteristic rule, at general `S` and for whatever End-instance is in scope
theorem invOf_two_moduleEndInt_apply {N : Type*} [AddCommGroup N] (S : Type*) [Semiring S]
    [Module S N] [Invertible (2 : S)] [Invertible (2 : Module.End ℤ N)] (x : N) :
    ⅟(2 : Module.End ℤ N) x = ⅟(2 : S) • x

-- the specialisation that is registered
noncomputable instance instInvertibleTwoModuleEndInt
    {N : Type*} [AddCommGroup N] [Module ℝ N] : Invertible (2 : Module.End ℤ N)

@[simp] theorem half_moduleEndInt_apply_eq_half_smul {N : Type*} [AddCommGroup N] [Module ℝ N]
    (x : N) : ⅟(2 : Module.End ℤ N) x = (2 : ℝ)⁻¹ • x
```

Four short proofs: the `def` transports `Invertible (2 : S)` along `x ↦ x • 1` with
`Invertible.map`, leaving only the numeral reconciliation `(2 : Module.End ℤ N) = (2 : S) • 1`;
the instance and the `ℝ` rewrite rule are one line each. The lemma name mirrors Mathlib's
`QuadraticMap.half_moduleEnd_apply_eq_half_smul`, of which it is the `R = ℤ` counterpart: there
the halving scalar comes from the ring, here from the module structure.

## Four design points

**General `def`, `ℝ` instance.** The mathematically natural statement is "if `2` is invertible in
`S` and `N` is an `S`-module, then `2` is invertible on the `ℤ`-endomorphisms of `N`" — and `S`
does not appear in the conclusion `Invertible (2 : Module.End ℤ N)`, so instance search could
never infer it. That rules out an *instance* at general `S`, not the construction: the `def`
carries the general statement and each wanted scalar ring gets a one-line instance. `ℝ` is the
one this repository needs.

**`algebraMap` is not available here, and could not be.** The inverse is *not* obtained by
transporting `invertibleTwo` along `algebraMap ℝ (Module.End ℤ N)`, because that algebra
structure does not exist: `Module.End.instAlgebra` requires `[SMul ℝ ℤ]` and
`[IsScalarTower ℝ ℤ N]`, and the requirement is not incidental — `Algebra ℝ (Module.End ℤ N)`
would put the image of `algebraMap` in the centre, i.e. make *every* `ℤ`-linear endomorphism of
`N` an `ℝ`-linear one, which is false (additive endomorphisms of `ℝ` are not all `ℝ`-linear).
The transport therefore goes along `MonoidHom.smulOneHom`, which is multiplicative without being
central, and `Invertible.map` needs no more than that.

**The rewrite rules are proved from uniqueness, not by unfolding.** (This rationale lives in a
`--` comment at the declaration, not in its docstring.) An inverse in a monoid is
unique (`invOf_eq_right_inv`), so exhibiting one determines `⅟` — which means the characteristic
rule can be proved without ever unfolding the construction, and it holds for *whichever*
`Invertible (2 : Module.End ℤ N)` instance is in scope rather than only for the one built here.
The definition therefore stays opaque and needs no `@[expose]`. An earlier draft did unfold it and
needed `@[expose]` to get the `rfl` through the module-system export barrier; the uniqueness proof
removes both.

**The rewrite rule is stated with function application, not `•`.** The `•` form was written first
and `simpNF` rejected it: `Module.End.smul_def` normalises a `Module.End` action to application,
so `⅟2 • x` is not in simp-normal form.

The instance is also **named rather than anonymous**, against the usual default, because Lean's
generated name for the anonymous form (`instInvertibleEndIntOfNat_tauCeti`) carries an underscore
that `defsWithUnderscore` rejects. Mathlib's analogous instance gets away with anonymity because
its generated name happens to be clean. Both forms were compiled and linted before choosing.

## What it unlocks, verified from a downstream module

```lean
import TauCeti.LinearAlgebra.End.InvertibleTwo

noncomputable example : Invertible (2 : Module.End ℤ ℝ) := by infer_instance          -- found

example (Q : QuadraticMap ℤ M ℝ) (x y : M) :                                          -- symmetry
    QuadraticMap.associated' Q x y = QuadraticMap.associated' Q y x :=
  (QuadraticMap.associated_isSymm ℤ Q) x y

example (Q : QuadraticMap ℤ M ℝ) (x : M) :                                            -- diagonal
    QuadraticMap.associated' Q x x = Q x := by
  simpa using QuadraticMap.associated_eq_self_apply ℤ Q x

example (Q : QuadraticMap ℤ M ℝ) : (QuadraticMap.associated' Q).flip =                 -- flipped
    QuadraticMap.associated' Q := QuadraticMap.associated_flip ℤ Q

example (Q : QuadraticMap ℤ M ℝ) (x y : M) :                                    -- applied form
    QuadraticMap.associated' Q x y = (Q (x + y) - Q x - Q y) / 2 := by
  simp only [QuadraticMap.associated_apply, Module.End.smul_def,
    TauCeti.half_moduleEndInt_apply_eq_half_smul, smul_eq_mul]
  ring
```

Note that `LinearMap.IsSymm` does **not** apply to a bilinear map with a non-scalar target, which
is why the symmetry fact above is the pointwise `associated_isSymm` and the `flip` form is
`associated_flip` — Mathlib documents that lemma as "a version of `associated_isSymm` for general
targets (using `flip` because `IsSymm` does not apply here)". All five examples compile against
this branch.

## Placement follows the content, not the motivation

`TauCeti/LinearAlgebra/End/InvertibleTwo.lean`, beside the existing `End/FiniteOrder.lean`,
`End/Prod.lean`, `End/ScalarExtension.lean` and `End/TensorProduct.lean`. The declarations mention
only `Invertible`, `Module.End`, `ℤ` and real scalar multiplication — no quadratic-form API at all
— so this is generic endomorphism infrastructure that happens to have a quadratic-form consumer,
and it is filed as such. The imports are correspondingly narrow: `Mathlib.Algebra.Module.LinearMap.End`
(where `Module.End` is defined), the reals, `Mathlib.Algebra.Group.Action.Hom` for
`MonoidHom.smulOneHom` and `Mathlib.Algebra.CharP.Invertible` for `Invertible (2 : ℝ)`. Together
these cut the module's dependency closure from 1811 build jobs to 811.

This gap arguably belongs upstream in Mathlib, since Mathlib's docstring already promises the case.
If it lands there, this file should be deleted rather than kept as a shim.

## Roadmap position

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 6 names **the Néron–Tate bilinear pairing** among
the canonical-height milestones. That pairing is the halved polar form of the canonical height as a
`ℤ`-quadratic map with real values — i.e. exactly `associated'` at `R = ℤ, N = ℝ`. This PR is the
prerequisite that makes the reuse possible; without it the pairing would have to re-derive
Mathlib's halving, its symmetry and its diagonal by hand. It ships separately because it is
general endomorphism infrastructure, not elliptic-curve mathematics — one topic per PR.

## Reuse

Consumed from Mathlib: `Invertible.map` (transports invertibility along a monoid hom),
`Invertible.copy` (reconciles the numeral), `MonoidHom.smulOneHom` (the action as a monoid hom),
`invertibleTwo`, `Module.End`, `ofNat_smul_eq_nsmul`. Neither inverse law is proved by hand —
both come from `Invertible.map`, leaving one `ext`/`simp` line for the numeral. The instance
supplies data Mathlib asks for, and the rewrite lemma exposes the field it chose.

Absence checked: `grep -rn "Invertible (2 : Module.End" .lake/packages/mathlib/Mathlib/` finds only
the `[Invertible (2 : R)]`-conditioned instance at `Basic.lean:824`; the compiled probe above shows
the `R = ℤ` case unreachable. Over TauCeti `main`, `git grep -n "invOf_two\|InvertibleTwo"` returns
nothing.

## Provenance

Provenance: original work — no source ported. Both sources named in the chain intake were pinned
and swept and neither contains this content: `github.com/MichaelStollBayreuth/EllipticCurves` @
`57f93fa71f16056014f6dab4e8c820fe93dee252` (45 Lean files; zero hits for `Invertible (2`,
`Module.End`, `QuadraticMap`, `associated'`, `polarBilin`, and no height/pairing/regulator
vocabulary — the only `invOf` hits are `PowerSeries.invOfUnit` in formal-group code) and
`github.com/CBirkbeck/FLT` @ `20eda920b763b27e8bd4fc404839deb9a55e15bd` (25 Lean files, zero hits
for all six queries). The content is one construction closing a gap in Mathlib's own advertised
API.

## Gates

- `lake build`: green, 0 errors, 0 warnings under `warningAsError = true`, no Mathlib recompiled
  (811 jobs).
- **`#lint in TauCeti` — the 13-linter environment set**: "All linting checks passed", 0 errors in
  4 declarations. Two earlier forms were rejected by it and fixed before this head: a `•`-form
  rewrite rule (`simpNF`) and an anonymous instance (`defsWithUnderscore`, via Lean's generated
  name).
- `#print axioms`: `[propext, Classical.choice, Quot.sound]`.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; no line over 100 characters.
- **Unicode**: every non-ASCII character in the diff is already in use across TauCeti on `main`,
  checked mechanically against all 402 codepoints main uses.
- Claim at `refs/tauceti-claims/author/EllipticCurves/associated-real`.
