### PR TITLE
feat: the complex Specht modules classify the irreducible complex representations of Sₙ

### DIFF
--- a/TauCeti/RepresentationTheory/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/BaseChange.lean
@@ -215,6 +215,18 @@ private def intertwiningMapEquivKerDefect (ρ : _root_.Representation K G V)
   left_inv _ := rfl
   right_inv _ := rfl
 
+/-- **The intertwining defect of a base-changed map is the base change of its defect**,
+componentwise: base change is compatible with composition and subtraction, and the base-changed
+representations act by the base-changed operators. -/
+private theorem intertwiningDefect_baseChange (ρ : _root_.Representation K G V)
+    (σ : _root_.Representation K G W) (f : V →ₗ[K] W) (g : G) :
+    intertwiningDefect (_root_.Representation.baseChange L ρ)
+        (_root_.Representation.baseChange L σ) (f.baseChange L) g
+      = (intertwiningDefect ρ σ f g).baseChange L := by
+  rw [intertwiningDefect_apply, intertwiningDefect_apply, LinearMap.baseChange_sub,
+    LinearMap.baseChange_comp, LinearMap.baseChange_comp, _root_.Representation.baseChange_apply,
+    _root_.Representation.baseChange_apply]
+
 variable [FiniteDimensional K V]
 
 variable (K L V W) in
@@ -240,6 +252,12 @@ private noncomputable def piBaseChangeEquiv (G : Type*) [Fintype G] [DecidableEq
   (TensorProduct.piRight K L L _).trans
     (LinearEquiv.piCongrRight fun _ => homBaseChangeEquiv K L V W)
 
+private theorem piBaseChangeEquiv_tmul {G : Type*} [Fintype G] [DecidableEq G] (a : L)
+    (f : G → (V →ₗ[K] W)) (g : G) :
+    piBaseChangeEquiv K L V W G (a ⊗ₜ[K] f) g = a • (f g).baseChange L := by
+  rw [piBaseChangeEquiv, LinearEquiv.trans_apply, LinearEquiv.piCongrRight_apply,
+    TensorProduct.piRight_apply, TensorProduct.piRightHom_tmul, homBaseChangeEquiv_tmul]
+
 /-- The intertwining defect commutes with scalar extension. -/
 private theorem intertwiningDefect_homBaseChangeEquiv [Fintype G] [DecidableEq G]
     (ρ : _root_.Representation K G V) (σ : _root_.Representation K G W)
@@ -253,30 +271,46 @@ private theorem intertwiningDefect_homBaseChangeEquiv [Fintype G] [DecidableEq G
   | add x y hx hy => simp [hx, hy]
   | tmul a f =>
     funext g
-    simp [intertwiningDefect_apply, homBaseChangeEquiv_tmul, piBaseChangeEquiv,
-      LinearMap.baseChange_sub, LinearMap.baseChange_comp, LinearMap.smul_comp,
-      LinearMap.comp_smul]
-    module
+    -- the defect is linear, so both sides are `a • (intertwiningDefect ρ σ f g)`
+    -- base-changed to `L`
+    rw [homBaseChangeEquiv_tmul, _root_.map_smul, Pi.smul_apply, intertwiningDefect_baseChange,
+      TensorProduct.AlgebraTensorModule.lTensor_tmul, piBaseChangeEquiv_tmul]
 
-/-- **The kernel of the intertwining defect commutes with scalar extension.** `L` is flat over `K`,
-so extending the scalars commutes with taking the kernel of a linear map
-(`LinearMap.tensorKerEquiv`); the identification `TauCeti.homBaseChangeEquiv` of the two ambient
-spaces carries one kernel onto the other, so the two dimensions agree. -/
+/-- **The intertwiner kernels correspond under the identification of the ambient spaces.** Pulling
+the kernel of the base-changed defect back along `TauCeti.homBaseChangeEquiv` gives the kernel of
+the scalar extension of the defect. -/
+private theorem comap_ker_intertwiningDefect_baseChange [Finite G]
+    (ρ : _root_.Representation K G V) (σ : _root_.Representation K G W) :
+    Submodule.comap (homBaseChangeEquiv K L V W : L ⊗[K] (V →ₗ[K] W) →ₗ[L] _)
+        (LinearMap.ker (intertwiningDefect (_root_.Representation.baseChange L ρ)
+          (_root_.Representation.baseChange L σ)))
+      = LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor L L
+          (intertwiningDefect ρ σ)) := by
+  classical
+  let _ := Fintype.ofFinite G
+  ext x
+  simp [LinearMap.mem_ker, intertwiningDefect_homBaseChangeEquiv,
+    (piBaseChangeEquiv K L V W G).map_eq_zero_iff]
+
+/-- **The kernel of a base-changed linear map has the dimension of the original kernel.** `L` is
+flat over `K`, so the kernel of the extended map is the extension of the kernel
+(`LinearMap.tensorKerEquiv`), whose dimension over `L` is that of the kernel over `K`. -/
+private theorem finrank_ker_lTensor {M N : Type*} [AddCommGroup M] [Module K M] [AddCommGroup N]
+    [Module K N] (f : M →ₗ[K] N) :
+    Module.finrank L (LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor L L f))
+      = Module.finrank K (LinearMap.ker f) :=
+  ((LinearMap.tensorKerEquiv L L f).finrank_eq).symm.trans Module.finrank_baseChange
+
+/-- **The kernel of the intertwining defect commutes with scalar extension.** The identification
+`TauCeti.homBaseChangeEquiv` of the two ambient spaces carries one kernel onto the other
+(`TauCeti.comap_ker_intertwiningDefect_baseChange`), and taking a kernel commutes with the
+extension because `L` is flat over `K` (`TauCeti.finrank_ker_lTensor`), so the two dimensions
+agree. -/
 private theorem finrank_ker_intertwiningDefect_baseChange [Finite G]
     (ρ : _root_.Representation K G V) (σ : _root_.Representation K G W) :
     Module.finrank L (LinearMap.ker (intertwiningDefect
         (_root_.Representation.baseChange L ρ) (_root_.Representation.baseChange L σ)))
-      = Module.finrank K (LinearMap.ker (intertwiningDefect ρ σ)) := by
-  classical
-  let _ := Fintype.ofFinite G
-  have hcomap : Submodule.comap (homBaseChangeEquiv K L V W : L ⊗[K] (V →ₗ[K] W) →ₗ[L] _)
-      (LinearMap.ker (intertwiningDefect (_root_.Representation.baseChange L ρ)
-        (_root_.Representation.baseChange L σ)))
-      = LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor L L
-          (intertwiningDefect ρ σ)) := by
-    ext x
-    simp [LinearMap.mem_ker, intertwiningDefect_homBaseChangeEquiv,
-      (piBaseChangeEquiv K L V W G).map_eq_zero_iff]
+      = Module.finrank K (LinearMap.ker (intertwiningDefect ρ σ)) :=
   calc Module.finrank L (LinearMap.ker (intertwiningDefect
         (_root_.Representation.baseChange L ρ) (_root_.Representation.baseChange L σ)))
       -- transport the kernel along the identification of the ambient spaces
@@ -286,11 +320,9 @@ private theorem finrank_ker_intertwiningDefect_baseChange [Finite G]
             (_root_.Representation.baseChange L σ)))) :=
         ((LinearEquiv.ofSubmodule' (homBaseChangeEquiv K L V W) _).finrank_eq).symm
     _ = Module.finrank L (LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor L L
-          (intertwiningDefect ρ σ))) := by rw [hcomap]
-    -- flatness: the kernel of the extended map is the extension of the kernel
-    _ = Module.finrank L (L ⊗[K] LinearMap.ker (intertwiningDefect ρ σ)) :=
-        ((LinearMap.tensorKerEquiv L L (intertwiningDefect ρ σ)).finrank_eq).symm
-    _ = Module.finrank K (LinearMap.ker (intertwiningDefect ρ σ)) := Module.finrank_baseChange
+          (intertwiningDefect ρ σ))) := by
+        rw [comap_ker_intertwiningDefect_baseChange]
+    _ = Module.finrank K (LinearMap.ker (intertwiningDefect ρ σ)) := finrank_ker_lTensor _
 
 /-- **Base change preserves the dimension of an intertwiner space.** An intertwiner is a linear
 map annihilated by the finite family of linear conditions `σ g ∘ₗ f = f ∘ₗ ρ g`, so the intertwiner

--- a/TauCeti/RepresentationTheory/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/BaseChange.lean
@@ -327,11 +327,11 @@ private theorem finrank_ker_intertwiningDefect_baseChange [Finite G]
 /-- **Base change preserves the dimension of an intertwiner space.** An intertwiner is a linear
 map annihilated by the finite family of linear conditions `σ g ∘ₗ f = f ∘ₗ ρ g`, so the intertwiner
 space is the kernel of a single linear map; `L` is flat over `K`, so extending the scalars commutes
-with taking that kernel (`LinearMap.tensorKerEquiv`). So the intertwiner space over `L` is the
-scalar extension of the one over `K`: extending the scalars destroys no intertwiners and adds no
-linearly independent new ones — individual intertwiners over `L` are `L`-combinations of the ones
-already defined over `K` — which is what makes an absolutely irreducible representation stay
-irreducible after extending the scalars. -/
+with taking that kernel (`LinearMap.tensorKerEquiv`), leaving the dimension unchanged. Only the
+dimensions are compared here; the underlying identification of the two intertwiner spaces is not
+exposed. The dimension alone is what makes an absolutely irreducible representation stay
+irreducible after extending the scalars: a one-dimensional endomorphism algebra stays
+one-dimensional. -/
 theorem _root_.Representation.finrank_intertwiningMap_baseChange [Finite G]
     (ρ : _root_.Representation K G V) (σ : _root_.Representation K G W) :
     Module.finrank L (_root_.Representation.IntertwiningMap

--- a/TauCeti/RepresentationTheory/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/BaseChange.lean
@@ -327,9 +327,11 @@ private theorem finrank_ker_intertwiningDefect_baseChange [Finite G]
 /-- **Base change preserves the dimension of an intertwiner space.** An intertwiner is a linear
 map annihilated by the finite family of linear conditions `σ g ∘ₗ f = f ∘ₗ ρ g`, so the intertwiner
 space is the kernel of a single linear map; `L` is flat over `K`, so extending the scalars commutes
-with taking that kernel (`LinearMap.tensorKerEquiv`). So the extension can neither create nor
-destroy intertwiners, which is what makes an absolutely irreducible representation stay irreducible
-after extending the scalars. -/
+with taking that kernel (`LinearMap.tensorKerEquiv`). So the intertwiner space over `L` is the
+scalar extension of the one over `K`: extending the scalars destroys no intertwiners and adds no
+linearly independent new ones — individual intertwiners over `L` are `L`-combinations of the ones
+already defined over `K` — which is what makes an absolutely irreducible representation stay
+irreducible after extending the scalars. -/
 theorem _root_.Representation.finrank_intertwiningMap_baseChange [Finite G]
     (ρ : _root_.Representation K G V) (σ : _root_.Representation K G W) :
     Module.finrank L (_root_.Representation.IntertwiningMap

--- a/TauCeti/RepresentationTheory/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/BaseChange.lean
@@ -200,10 +200,9 @@ private theorem intertwiningDefect_apply (ρ : _root_.Representation K G V)
 private theorem mem_ker_intertwiningDefect {ρ : _root_.Representation K G V}
     {σ : _root_.Representation K G W} {f : V →ₗ[K] W} :
     f ∈ LinearMap.ker (intertwiningDefect ρ σ) ↔ ∀ g, f ∘ₗ ρ g = σ g ∘ₗ f := by
-  have h : f ∈ LinearMap.ker (intertwiningDefect ρ σ) ↔ ∀ g, σ g ∘ₗ f = f ∘ₗ ρ g := by
-    simp [LinearMap.mem_ker, intertwiningDefect, funext_iff, sub_eq_zero,
-      LinearMap.llcomp_apply', LinearMap.lcomp_apply']
-  exact h.trans ⟨fun H g => (H g).symm, fun H g => (H g).symm⟩
+  rw [LinearMap.mem_ker, funext_iff]
+  refine forall_congr' fun g => ?_
+  rw [intertwiningDefect_apply, Pi.zero_apply, sub_eq_zero, eq_comm]
 
 /-- The intertwiner space is the kernel of the intertwining defect. -/
 private def intertwiningMapEquivKerDefect (ρ : _root_.Representation K G V)
@@ -259,6 +258,40 @@ private theorem intertwiningDefect_homBaseChangeEquiv [Fintype G] [DecidableEq G
       LinearMap.comp_smul]
     module
 
+/-- **The kernel of the intertwining defect commutes with scalar extension.** `L` is flat over `K`,
+so extending the scalars commutes with taking the kernel of a linear map
+(`LinearMap.tensorKerEquiv`); the identification `TauCeti.homBaseChangeEquiv` of the two ambient
+spaces carries one kernel onto the other, so the two dimensions agree. -/
+private theorem finrank_ker_intertwiningDefect_baseChange [Finite G]
+    (ρ : _root_.Representation K G V) (σ : _root_.Representation K G W) :
+    Module.finrank L (LinearMap.ker (intertwiningDefect
+        (_root_.Representation.baseChange L ρ) (_root_.Representation.baseChange L σ)))
+      = Module.finrank K (LinearMap.ker (intertwiningDefect ρ σ)) := by
+  classical
+  let _ := Fintype.ofFinite G
+  have hcomap : Submodule.comap (homBaseChangeEquiv K L V W : L ⊗[K] (V →ₗ[K] W) →ₗ[L] _)
+      (LinearMap.ker (intertwiningDefect (_root_.Representation.baseChange L ρ)
+        (_root_.Representation.baseChange L σ)))
+      = LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor L L
+          (intertwiningDefect ρ σ)) := by
+    ext x
+    simp [LinearMap.mem_ker, intertwiningDefect_homBaseChangeEquiv,
+      (piBaseChangeEquiv K L V W G).map_eq_zero_iff]
+  calc Module.finrank L (LinearMap.ker (intertwiningDefect
+        (_root_.Representation.baseChange L ρ) (_root_.Representation.baseChange L σ)))
+      -- transport the kernel along the identification of the ambient spaces
+      = Module.finrank L (Submodule.comap
+          (homBaseChangeEquiv K L V W : L ⊗[K] (V →ₗ[K] W) →ₗ[L] _)
+          (LinearMap.ker (intertwiningDefect (_root_.Representation.baseChange L ρ)
+            (_root_.Representation.baseChange L σ)))) :=
+        ((LinearEquiv.ofSubmodule' (homBaseChangeEquiv K L V W) _).finrank_eq).symm
+    _ = Module.finrank L (LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor L L
+          (intertwiningDefect ρ σ))) := by rw [hcomap]
+    -- flatness: the kernel of the extended map is the extension of the kernel
+    _ = Module.finrank L (L ⊗[K] LinearMap.ker (intertwiningDefect ρ σ)) :=
+        ((LinearMap.tensorKerEquiv L L (intertwiningDefect ρ σ)).finrank_eq).symm
+    _ = Module.finrank K (LinearMap.ker (intertwiningDefect ρ σ)) := Module.finrank_baseChange
+
 /-- **Base change preserves the dimension of an intertwiner space.** An intertwiner is a linear
 map annihilated by the finite family of linear conditions `σ g ∘ₗ f = f ∘ₗ ρ g`, so the intertwiner
 space is the kernel of a single linear map; `L` is flat over `K`, so extending the scalars commutes
@@ -270,27 +303,12 @@ theorem _root_.Representation.finrank_intertwiningMap_baseChange [Finite G]
     Module.finrank L (_root_.Representation.IntertwiningMap
         (_root_.Representation.baseChange L ρ) (_root_.Representation.baseChange L σ))
       = Module.finrank K (_root_.Representation.IntertwiningMap ρ σ) := by
-  classical
-  let _ := Fintype.ofFinite G
-  -- the intertwiners of the base-changed representations are the scalar extension of the
-  -- intertwiners, `L` being flat over `K`
-  have hcomap : Submodule.comap (homBaseChangeEquiv K L V W : L ⊗[K] (V →ₗ[K] W) →ₗ[L] _)
-      (LinearMap.ker (intertwiningDefect (_root_.Representation.baseChange L ρ)
-        (_root_.Representation.baseChange L σ)))
-      = LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor L L
-          (intertwiningDefect ρ σ)) := by
-    ext x
-    simp [LinearMap.mem_ker, intertwiningDefect_homBaseChangeEquiv,
-      (piBaseChangeEquiv K L V W G).map_eq_zero_iff]
-  rw [(intertwiningMapEquivKerDefect ρ σ).finrank_eq,
-    (intertwiningMapEquivKerDefect (_root_.Representation.baseChange L ρ)
+  -- both intertwiner spaces are kernels of the intertwining defect, and those kernels have the
+  -- same dimension because `L` is flat over `K`
+  rw [(intertwiningMapEquivKerDefect (_root_.Representation.baseChange L ρ)
       (_root_.Representation.baseChange L σ)).finrank_eq,
-    ← (LinearEquiv.ofSubmodule' (homBaseChangeEquiv K L V W)
-        (LinearMap.ker (intertwiningDefect (_root_.Representation.baseChange L ρ)
-          (_root_.Representation.baseChange L σ)))).finrank_eq,
-    hcomap,
-    ← (LinearMap.tensorKerEquiv L L (intertwiningDefect ρ σ)).finrank_eq]
-  exact Module.finrank_baseChange
+    (intertwiningMapEquivKerDefect ρ σ).finrank_eq]
+  exact finrank_ker_intertwiningDefect_baseChange ρ σ
 
 end Intertwiner
 

--- a/TauCeti/RepresentationTheory/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/BaseChange.lean
@@ -8,10 +8,13 @@ module
 public import Mathlib.RepresentationTheory.Basic
 public import Mathlib.RepresentationTheory.Character
 public import TauCeti.LinearAlgebra.TensorProduct.Basis
--- Non-public: `charZero_of_injective_algebraMap` transports characteristic zero along the
--- structure map of the extension, and is used only inside the proof of
+-- Non-public: the flat base change of a kernel (`LinearMap.tensorKerEquiv`), the scalar extension
+-- of a space of linear maps (`IsBaseChange.linearMapLeftRight`) and of a finite product
+-- (`TensorProduct.piRight`) are used only inside the proof of
 -- `Representation.finrank_intertwiningMap_baseChange`.
-import Mathlib.Algebra.CharP.Algebra
+import Mathlib.RingTheory.Flat.Equalizer
+import Mathlib.RingTheory.TensorProduct.IsBaseChangeHom
+import Mathlib.LinearAlgebra.TensorProduct.Pi
 
 /-!
 # Base change of representations
@@ -23,12 +26,14 @@ extension yields a nonzero common fixed vector over the base field.
 Two invariants survive the extension unchanged. The **character** is the trace of a linear map, and
 the trace of a base-changed endomorphism is the image of the trace
 (`LinearMap.trace_baseChange`), so the character of `L ⊗[K] V` is the character of `V` read in `L`.
-The **dimension of an intertwiner space** between two finite-dimensional representations of a
-finite group in characteristic zero is a character integral
-(`Representation.card_inv_mul_sum_char_mul_char_eq_finrank`), so it too is unchanged. Applied to a
-representation whose endomorphism algebra is one-dimensional, that equality says the endomorphism
-algebra after the extension is one-dimensional again, which is the mechanism by which an absolutely
-irreducible representation stays irreducible over any extension.
+The **dimension of an intertwiner space** between two representations of a finite monoid, the
+source finite-dimensional, is unchanged as well: an intertwiner is a linear map killed by the
+finite family of conditions `σ g ∘ₗ f = f ∘ₗ ρ g`, so the intertwiner space is the kernel of a
+single linear map, and the extension is flat, so it commutes with that kernel
+(`LinearMap.tensorKerEquiv`). Applied to a representation whose endomorphism algebra is
+one-dimensional, that equality says the endomorphism algebra after the extension is one-dimensional
+again, which is the mechanism by which an absolutely irreducible representation stays irreducible
+over any extension.
 
 ## Main declarations
 
@@ -38,7 +43,7 @@ irreducible representation stays irreducible over any extension.
 * `Representation.character_baseChange`: the character of a base-changed representation is the
   image of the character.
 * `Representation.finrank_intertwiningMap_baseChange`: base change preserves the dimension of an
-  intertwiner space, over a base field of characteristic zero.
+  intertwiner space.
 -/
 
 public section
@@ -161,38 +166,132 @@ theorem _root_.Representation.character_baseChange {G : Type*} [Monoid G]
   simp [_root_.Representation.character, _root_.Representation.baseChange_apply,
     LinearMap.trace_baseChange]
 
-variable {W : Type*} [AddCommGroup W] [Module K W] [FiniteDimensional K W]
+end Character
 
-/-- **Base change preserves the dimension of an intertwiner space.** For finite-dimensional
-representations of a finite group over a field of characteristic zero, the dimension of the space
-of intertwiners is the character integral
-`|G|⁻¹ ∑ g, χ_σ g * χ_ρ g⁻¹` (`Representation.card_inv_mul_sum_char_mul_char_eq_finrank`), and both
-the group order and the two characters are carried to their images by the structure map of the
-extension.  So the extension can neither create nor destroy intertwiners, which is what makes an
-absolutely irreducible representation stay irreducible after extending the scalars. -/
-theorem _root_.Representation.finrank_intertwiningMap_baseChange [CharZero K]
-    {G : Type*} [Group G] [Finite G]
+end TauCeti.Representation
+
+-- The intertwiner argument is staged through private helpers taking explicit `Representation`
+-- arguments. A Mathlib namespace nested under `TauCeti` gives no dot notation on the Mathlib type,
+-- so those helpers sit directly under `TauCeti` rather than under `TauCeti.Representation`.
+namespace TauCeti
+
+section Intertwiner
+
+open TensorProduct
+
+variable {K : Type*} {L : Type*} [Field K] [Field L] [Algebra K L]
+variable {G : Type*} [Monoid G]
+variable {V : Type*} [AddCommGroup V] [Module K V]
+variable {W : Type*} [AddCommGroup W] [Module K W]
+
+/-- The **intertwining defect** of a linear map `f : V →ₗ[K] W`: the family
+`g ↦ σ g ∘ₗ f - f ∘ₗ ρ g`, whose vanishing is exactly the intertwining condition. Writing the
+intertwiner space as the kernel of a single linear map is what makes it visibly compatible with
+base change, `L` being flat over `K`. -/
+private def intertwiningDefect (ρ : _root_.Representation K G V) (σ : _root_.Representation K G W) :
+    (V →ₗ[K] W) →ₗ[K] (G → (V →ₗ[K] W)) :=
+  LinearMap.pi fun g => LinearMap.llcomp K V W W (σ g) - LinearMap.lcomp K W (ρ g)
+
+private theorem intertwiningDefect_apply (ρ : _root_.Representation K G V)
+    (σ : _root_.Representation K G W) (f : V →ₗ[K] W) (g : G) :
+    intertwiningDefect ρ σ f g = σ g ∘ₗ f - f ∘ₗ ρ g :=
+  rfl
+
+private theorem mem_ker_intertwiningDefect {ρ : _root_.Representation K G V}
+    {σ : _root_.Representation K G W} {f : V →ₗ[K] W} :
+    f ∈ LinearMap.ker (intertwiningDefect ρ σ) ↔ ∀ g, f ∘ₗ ρ g = σ g ∘ₗ f := by
+  have h : f ∈ LinearMap.ker (intertwiningDefect ρ σ) ↔ ∀ g, σ g ∘ₗ f = f ∘ₗ ρ g := by
+    simp [LinearMap.mem_ker, intertwiningDefect, funext_iff, sub_eq_zero,
+      LinearMap.llcomp_apply', LinearMap.lcomp_apply']
+  exact h.trans ⟨fun H g => (H g).symm, fun H g => (H g).symm⟩
+
+/-- The intertwiner space is the kernel of the intertwining defect. -/
+private def intertwiningMapEquivKerDefect (ρ : _root_.Representation K G V)
+    (σ : _root_.Representation K G W) :
+    _root_.Representation.IntertwiningMap ρ σ ≃ₗ[K] LinearMap.ker (intertwiningDefect ρ σ) where
+  toFun f := ⟨f.toLinearMap, mem_ker_intertwiningDefect.mpr f.isIntertwining'⟩
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+  invFun f := ⟨f.1, mem_ker_intertwiningDefect.mp f.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+variable [FiniteDimensional K V]
+
+variable (K L V W) in
+/-- Scalar extension of linear maps out of a finite-dimensional space: `L ⊗[K] (V →ₗ[K] W)` is the
+space of `L`-linear maps `L ⊗[K] V →ₗ[L] L ⊗[K] W`. -/
+private noncomputable def homBaseChangeEquiv :
+    L ⊗[K] (V →ₗ[K] W) ≃ₗ[L] ((L ⊗[K] V) →ₗ[L] (L ⊗[K] W)) :=
+  ((TensorProduct.isBaseChange K V L).linearMapLeftRight
+    (TensorProduct.isBaseChange K W L)).equiv
+
+private theorem homBaseChangeEquiv_tmul (a : L) (f : V →ₗ[K] W) :
+    homBaseChangeEquiv K L V W (a ⊗ₜ f) = a • f.baseChange L := by
+  rw [homBaseChangeEquiv, IsBaseChange.equiv_tmul]
+  congr 1
+  ext v
+  exact IsBaseChange.linearMapLeftRightHom_comp_apply (TensorProduct.isBaseChange K V L)
+    ((TensorProduct.mk K L W) 1) f v
+
+variable (K L V W) in
+/-- Scalar extension of a finite family of linear maps, componentwise. -/
+private noncomputable def piBaseChangeEquiv (G : Type*) [Fintype G] [DecidableEq G] :
+    L ⊗[K] (G → (V →ₗ[K] W)) ≃ₗ[L] (G → ((L ⊗[K] V) →ₗ[L] (L ⊗[K] W))) :=
+  (TensorProduct.piRight K L L _).trans
+    (LinearEquiv.piCongrRight fun _ => homBaseChangeEquiv K L V W)
+
+/-- The intertwining defect commutes with scalar extension. -/
+private theorem intertwiningDefect_homBaseChangeEquiv [Fintype G] [DecidableEq G]
+    (ρ : _root_.Representation K G V) (σ : _root_.Representation K G W)
+    (x : L ⊗[K] (V →ₗ[K] W)) :
+    intertwiningDefect (_root_.Representation.baseChange L ρ)
+        (_root_.Representation.baseChange L σ) (homBaseChangeEquiv K L V W x)
+      = piBaseChangeEquiv K L V W G
+          (TensorProduct.AlgebraTensorModule.lTensor L L (intertwiningDefect ρ σ) x) := by
+  induction x with
+  | zero => simp
+  | add x y hx hy => simp [hx, hy]
+  | tmul a f =>
+    funext g
+    simp [intertwiningDefect_apply, homBaseChangeEquiv_tmul, piBaseChangeEquiv,
+      LinearMap.baseChange_sub, LinearMap.baseChange_comp, LinearMap.smul_comp,
+      LinearMap.comp_smul]
+    module
+
+/-- **Base change preserves the dimension of an intertwiner space.** An intertwiner is a linear
+map annihilated by the finite family of linear conditions `σ g ∘ₗ f = f ∘ₗ ρ g`, so the intertwiner
+space is the kernel of a single linear map; `L` is flat over `K`, so extending the scalars commutes
+with taking that kernel (`LinearMap.tensorKerEquiv`). So the extension can neither create nor
+destroy intertwiners, which is what makes an absolutely irreducible representation stay irreducible
+after extending the scalars. -/
+theorem _root_.Representation.finrank_intertwiningMap_baseChange [Finite G]
     (ρ : _root_.Representation K G V) (σ : _root_.Representation K G W) :
     Module.finrank L (_root_.Representation.IntertwiningMap
         (_root_.Representation.baseChange L ρ) (_root_.Representation.baseChange L σ))
       = Module.finrank K (_root_.Representation.IntertwiningMap ρ σ) := by
+  classical
   let _ := Fintype.ofFinite G
-  have : CharZero L := charZero_of_injective_algebraMap (algebraMap K L).injective
-  have _ : Invertible ((Nat.card G : K)) :=
-    invertibleOfNonzero (Nat.cast_ne_zero.mpr Nat.card_pos.ne')
-  have _ : Invertible ((Nat.card G : L)) :=
-    invertibleOfNonzero (Nat.cast_ne_zero.mpr Nat.card_pos.ne')
-  have key : algebraMap K L ((Nat.card G : K)⁻¹ * ∑ g : G, σ.character g * ρ.character g⁻¹)
-      = (Nat.card G : L)⁻¹ * ∑ g : G,
-          (_root_.Representation.baseChange L σ).character g *
-            (_root_.Representation.baseChange L ρ).character g⁻¹ := by
-    simp [_root_.Representation.character_baseChange, map_sum, map_mul, map_inv₀]
-  rw [_root_.Representation.card_inv_mul_sum_char_mul_char_eq_finrank ρ σ,
-    _root_.Representation.card_inv_mul_sum_char_mul_char_eq_finrank
-      (_root_.Representation.baseChange L ρ) (_root_.Representation.baseChange L σ),
-    map_natCast] at key
-  exact_mod_cast key.symm
+  -- the intertwiners of the base-changed representations are the scalar extension of the
+  -- intertwiners, `L` being flat over `K`
+  have hcomap : Submodule.comap (homBaseChangeEquiv K L V W : L ⊗[K] (V →ₗ[K] W) →ₗ[L] _)
+      (LinearMap.ker (intertwiningDefect (_root_.Representation.baseChange L ρ)
+        (_root_.Representation.baseChange L σ)))
+      = LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor L L
+          (intertwiningDefect ρ σ)) := by
+    ext x
+    simp [LinearMap.mem_ker, intertwiningDefect_homBaseChangeEquiv,
+      (piBaseChangeEquiv K L V W G).map_eq_zero_iff]
+  rw [(intertwiningMapEquivKerDefect ρ σ).finrank_eq,
+    (intertwiningMapEquivKerDefect (_root_.Representation.baseChange L ρ)
+      (_root_.Representation.baseChange L σ)).finrank_eq,
+    ← (LinearEquiv.ofSubmodule' (homBaseChangeEquiv K L V W)
+        (LinearMap.ker (intertwiningDefect (_root_.Representation.baseChange L ρ)
+          (_root_.Representation.baseChange L σ)))).finrank_eq,
+    hcomap,
+    ← (LinearMap.tensorKerEquiv L L (intertwiningDefect ρ σ)).finrank_eq]
+  exact Module.finrank_baseChange
 
-end Character
+end Intertwiner
 
-end TauCeti.Representation
+end TauCeti

--- a/TauCeti/RepresentationTheory/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/BaseChange.lean
@@ -25,9 +25,10 @@ the trace of a base-changed endomorphism is the image of the trace
 (`LinearMap.trace_baseChange`), so the character of `L ⊗[K] V` is the character of `V` read in `L`.
 The **dimension of an intertwiner space** between two finite-dimensional representations of a
 finite group in characteristic zero is a character integral
-(`Representation.card_inv_mul_sum_char_mul_char_eq_finrank`), so it too is unchanged: extending the
-scalars neither merges nor splits the constituents, and this is the mechanism by which an
-absolutely irreducible representation stays irreducible over any extension.
+(`Representation.card_inv_mul_sum_char_mul_char_eq_finrank`), so it too is unchanged. Applied to a
+representation whose endomorphism algebra is one-dimensional, that equality says the endomorphism
+algebra after the extension is one-dimensional again, which is the mechanism by which an absolutely
+irreducible representation stays irreducible over any extension.
 
 ## Main declarations
 
@@ -153,6 +154,7 @@ variable {V : Type*} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
 /-- **The character is unchanged by base change**, read through the structure map: the character of
 `L ⊗[K] V` at `g` is the image in `L` of the character of `V` at `g`, because the trace of a
 base-changed endomorphism is the image of its trace. -/
+@[simp]
 theorem _root_.Representation.character_baseChange {G : Type*} [Monoid G]
     (ρ : _root_.Representation K G V) (g : G) :
     (_root_.Representation.baseChange L ρ).character g = algebraMap K L (ρ.character g) := by

--- a/TauCeti/RepresentationTheory/BaseChange.lean
+++ b/TauCeti/RepresentationTheory/BaseChange.lean
@@ -6,7 +6,12 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RepresentationTheory.Basic
+public import Mathlib.RepresentationTheory.Character
 public import TauCeti.LinearAlgebra.TensorProduct.Basis
+-- Non-public: `charZero_of_injective_algebraMap` transports characteristic zero along the
+-- structure map of the extension, and is used only inside the proof of
+-- `Representation.finrank_intertwiningMap_baseChange`.
+import Mathlib.Algebra.CharP.Algebra
 
 /-!
 # Base change of representations
@@ -15,11 +20,24 @@ This file extends a representation's scalars by base-changing each linear endomo
 records the descent step needed for fixed vectors: a nonzero common fixed vector after a field
 extension yields a nonzero common fixed vector over the base field.
 
+Two invariants survive the extension unchanged. The **character** is the trace of a linear map, and
+the trace of a base-changed endomorphism is the image of the trace
+(`LinearMap.trace_baseChange`), so the character of `L ⊗[K] V` is the character of `V` read in `L`.
+The **dimension of an intertwiner space** between two finite-dimensional representations of a
+finite group in characteristic zero is a character integral
+(`Representation.card_inv_mul_sum_char_mul_char_eq_finrank`), so it too is unchanged: extending the
+scalars neither merges nor splits the constituents, and this is the mechanism by which an
+absolutely irreducible representation stays irreducible over any extension.
+
 ## Main declarations
 
 * `Representation.baseChange`: scalar extension of a representation.
 * `Representation.exists_common_fixed_vector_of_baseChange`: descent of a nonzero common
   fixed vector.
+* `Representation.character_baseChange`: the character of a base-changed representation is the
+  image of the character.
+* `Representation.finrank_intertwiningMap_baseChange`: base change preserves the dimension of an
+  intertwiner space, over a base field of characteristic zero.
 -/
 
 public section
@@ -124,5 +142,55 @@ theorem _root_.Representation.exists_common_fixed_vector_of_baseChange
     exact congrArg descend (hfixed g)
 
 end
+
+section Character
+
+open TensorProduct
+
+variable {K : Type*} {L : Type*} [Field K] [Field L] [Algebra K L]
+variable {V : Type*} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
+
+/-- **The character is unchanged by base change**, read through the structure map: the character of
+`L ⊗[K] V` at `g` is the image in `L` of the character of `V` at `g`, because the trace of a
+base-changed endomorphism is the image of its trace. -/
+theorem _root_.Representation.character_baseChange {G : Type*} [Monoid G]
+    (ρ : _root_.Representation K G V) (g : G) :
+    (_root_.Representation.baseChange L ρ).character g = algebraMap K L (ρ.character g) := by
+  simp [_root_.Representation.character, _root_.Representation.baseChange_apply,
+    LinearMap.trace_baseChange]
+
+variable {W : Type*} [AddCommGroup W] [Module K W] [FiniteDimensional K W]
+
+/-- **Base change preserves the dimension of an intertwiner space.** For finite-dimensional
+representations of a finite group over a field of characteristic zero, the dimension of the space
+of intertwiners is the character integral
+`|G|⁻¹ ∑ g, χ_σ g * χ_ρ g⁻¹` (`Representation.card_inv_mul_sum_char_mul_char_eq_finrank`), and both
+the group order and the two characters are carried to their images by the structure map of the
+extension.  So the extension can neither create nor destroy intertwiners, which is what makes an
+absolutely irreducible representation stay irreducible after extending the scalars. -/
+theorem _root_.Representation.finrank_intertwiningMap_baseChange [CharZero K]
+    {G : Type*} [Group G] [Finite G]
+    (ρ : _root_.Representation K G V) (σ : _root_.Representation K G W) :
+    Module.finrank L (_root_.Representation.IntertwiningMap
+        (_root_.Representation.baseChange L ρ) (_root_.Representation.baseChange L σ))
+      = Module.finrank K (_root_.Representation.IntertwiningMap ρ σ) := by
+  let _ := Fintype.ofFinite G
+  have : CharZero L := charZero_of_injective_algebraMap (algebraMap K L).injective
+  have _ : Invertible ((Nat.card G : K)) :=
+    invertibleOfNonzero (Nat.cast_ne_zero.mpr Nat.card_pos.ne')
+  have _ : Invertible ((Nat.card G : L)) :=
+    invertibleOfNonzero (Nat.cast_ne_zero.mpr Nat.card_pos.ne')
+  have key : algebraMap K L ((Nat.card G : K)⁻¹ * ∑ g : G, σ.character g * ρ.character g⁻¹)
+      = (Nat.card G : L)⁻¹ * ∑ g : G,
+          (_root_.Representation.baseChange L σ).character g *
+            (_root_.Representation.baseChange L ρ).character g⁻¹ := by
+    simp [_root_.Representation.character_baseChange, map_sum, map_mul, map_inv₀]
+  rw [_root_.Representation.card_inv_mul_sum_char_mul_char_eq_finrank ρ σ,
+    _root_.Representation.card_inv_mul_sum_char_mul_char_eq_finrank
+      (_root_.Representation.baseChange L ρ) (_root_.Representation.baseChange L σ),
+    map_natCast] at key
+  exact_mod_cast key.symm
+
+end Character
 
 end TauCeti.Representation

--- a/TauCeti/RepresentationTheory/CharacterTable/SimpleModuleCount.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/SimpleModuleCount.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.Basis
+public import TauCeti.RepresentationTheory.Simple.FDRepClasses
 public import TauCeti.RingTheory.Semisimple.CenterDimension
 
 /-!
@@ -30,10 +31,18 @@ modules are shown to exhaust the simple `ℚ[Sₙ]`-modules in
 `TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean`, over `ℚ`, which is not
 algebraically closed.
 
+The two `bijective_of_injective_of_card_conjClasses_le` lemmas package that step once and for all,
+in the module language and in the language of `FDRep k G`, so that a classification only has to
+supply the injection and the count of conjugacy classes.
+
 ## Main results
 
 * `TauCeti.card_simpleSubmoduleClasses_le_card_conjClasses`: over a field with `k[G]` semisimple,
   the isomorphism classes of simple `k[G]`-modules are at most the conjugacy classes of `G`.
+* `TauCeti.SimpleSubmoduleClasses.bijective_of_injective_of_card_conjClasses_le` and
+  `TauCeti.SimpleFDRepClasses.bijective_of_injective_of_card_conjClasses_le`: an injection into the
+  isomorphism classes of simple modules, resp. of simple objects of `FDRep k G`, from a type with
+  at least as many elements as `G` has conjugacy classes, is a bijection.
 
 ## References
 
@@ -62,5 +71,34 @@ theorem card_simpleSubmoduleClasses_le_card_conjClasses :
     Nat.card (SimpleSubmoduleClasses k[G] k[G]) ≤ Nat.card (ConjClasses G) := by
   rw [Nat.card_congr (simpleSubmoduleClassesEquiv k[G] k[G]), ← finrank_center_monoidAlgebra k G]
   exact card_isotypicComponents_le_finrank_center k k[G]
+
+variable {k G}
+
+/-- **Enough pairwise non-isomorphic simple modules are all of them.** An injection into the
+isomorphism classes of simple `k[G]`-modules, from a type with at least as many elements as `G` has
+conjugacy classes, is a bijection: by `TauCeti.card_simpleSubmoduleClasses_le_card_conjClasses`
+there is no room left for a class outside the image. -/
+theorem SimpleSubmoduleClasses.bijective_of_injective_of_card_conjClasses_le {ι : Type*}
+    {f : ι → SimpleSubmoduleClasses k[G] k[G]} (hf : Function.Injective f)
+    (h : Nat.card (ConjClasses G) ≤ Nat.card ι) : Function.Bijective f :=
+  have : Finite (SimpleSubmoduleClasses k[G] k[G]) :=
+    .of_equiv _ (simpleSubmoduleClassesEquiv _ _).symm
+  hf.bijective_of_nat_card_le ((card_simpleSubmoduleClasses_le_card_conjClasses k G).trans h)
+
+/-- **Enough pairwise non-isomorphic simple objects are all of them**, the same count read in
+`FDRep k G`: the isomorphism classes of simple objects inject into the isomorphism classes of the
+`k[G]`-modules they carry (`TauCeti.SimpleFDRepClasses.toSimpleSubmoduleClasses_injective`), so the
+conjugacy classes bound them too. -/
+theorem SimpleFDRepClasses.bijective_of_injective_of_card_conjClasses_le {ι : Type*}
+    {f : ι → SimpleFDRepClasses k G} (hf : Function.Injective f)
+    (h : Nat.card (ConjClasses G) ≤ Nat.card ι) : Function.Bijective f :=
+  have : Finite (SimpleSubmoduleClasses k[G] k[G]) :=
+    .of_equiv _ (simpleSubmoduleClassesEquiv _ _).symm
+  have : Finite (SimpleFDRepClasses k G) :=
+    .of_injective _ SimpleFDRepClasses.toSimpleSubmoduleClasses_injective
+  hf.bijective_of_nat_card_le
+    (((Nat.card_le_card_of_injective _
+      SimpleFDRepClasses.toSimpleSubmoduleClasses_injective).trans
+        (card_simpleSubmoduleClasses_le_card_conjClasses k G)).trans h)
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/RealForm.lean
+++ b/TauCeti/RepresentationTheory/RealForm.lean
@@ -161,9 +161,7 @@ particular it takes real values (`Representation.IsRealForm.conj_char`). -/
 theorem IsRealForm.char_eq [FiniteDimensional ℝ W] (h : IsRealForm ρ σ) (g : G) :
     ρ.character g = (σ.character g : ℂ) := by
   obtain ⟨φ⟩ := isRealForm_iff_nonempty_equiv.mp h
-  rw [← congrFun (char_iso φ) g]
-  simp only [Representation.character, Representation.baseChange_apply,
-    LinearMap.trace_baseChange, Complex.coe_algebraMap]
+  rw [← congrFun (char_iso φ) g, Representation.character_baseChange, Complex.coe_algebraMap]
 
 /-- The character of a representation with a real form is fixed by complex conjugation. -/
 theorem IsRealForm.conj_char [FiniteDimensional ℝ W] (h : IsRealForm ρ σ) (g : G) :

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Completeness.lean
@@ -122,15 +122,8 @@ theorem spechtModuleClass_injective : Function.Injective (spechtModuleClass (n :
 /-- **The Specht modules exhaust the simple `ℚ[Sₙ]`-modules.** They are as many as the conjugacy
 classes of `Sₙ` and pairwise non-isomorphic, and no field admits more isomorphism classes of simple
 modules over the group algebra than the group has conjugacy classes. -/
-theorem spechtModuleClass_bijective : Function.Bijective (spechtModuleClass (n := n)) := by
-  classical
-  have : Finite (SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)]) :=
-    .of_equiv _ (simpleSubmoduleClassesEquiv _ _).symm
-  let _ := Fintype.ofFinite (SimpleSubmoduleClasses ℚ[Equiv.Perm (Fin n)] ℚ[Equiv.Perm (Fin n)])
-  refine (Fintype.bijective_iff_injective_and_card _).mpr ⟨spechtModuleClass_injective, ?_⟩
-  rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card]
-  refine le_antisymm (Nat.card_le_card_of_injective _ spechtModuleClass_injective) ?_
-  exact (card_simpleSubmoduleClasses_le_card_conjClasses ℚ (Equiv.Perm (Fin n))).trans
+theorem spechtModuleClass_bijective : Function.Bijective (spechtModuleClass (n := n)) :=
+  SimpleSubmoduleClasses.bijective_of_injective_of_card_conjClasses_le spechtModuleClass_injective
     (Nat.card_congr (partitionEquivConjClasses n).symm).le
 
 /-- **The classification of the irreducible rational representations of the symmetric group.**

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
@@ -65,6 +65,8 @@ complex characters of `Sₙ` are exactly the `χ^μ`.
 
 * [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 4.
 * B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Section 2.4.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 4, "Absolute irreducibility" and "Distinctness and completeness".
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
@@ -35,7 +35,8 @@ So the complex endomorphism algebra is one-dimensional too, which over `ℂ` is 
 (`FDRep.simple_iff_char_is_norm_one`). The same dimension count with two different partitions is
 `0` on the rational side by Schur's lemma, hence `0` on the complex side, which is distinctness; and
 the partitions of `n` are as many as the conjugacy classes of `Sₙ`, which bounds the number of
-isomorphism classes of simple objects over any field, so distinctness already forces exhaustion.
+isomorphism classes of simple objects over a field whose group algebra is semisimple, as
+`ℂ[Sₙ]` is, so distinctness already forces exhaustion.
 
 Because the character of `S^μ` is integer-valued (`TauCeti.spechtChar`), the complex characters are
 the same integers read in `ℂ`, and the integer-valued character table of `Sₙ`
@@ -66,8 +67,6 @@ irreducible complex characters of `Sₙ` are exactly the `χ^μ`.
 
 * [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 4.
 * B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Section 2.4.
-* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
-  Layer 4, "Absolute irreducibility" and "Distinctness and completeness".
 -/
 
 public section
@@ -212,8 +211,10 @@ theorem spechtModuleℂFDRepClass_def (μ : n.Partition) :
   (rfl)
 
 /-- **The complex Specht modules exhaust the simple objects of `FDRep ℂ Sₙ`.** They are pairwise
-non-isomorphic and as many as the conjugacy classes of `Sₙ`, and no field admits more isomorphism
-classes of simple objects than the group has conjugacy classes. -/
+non-isomorphic and as many as the conjugacy classes of `Sₙ`, and over a field whose group algebra
+is semisimple, as `ℂ[Sₙ]` is, the conjugacy classes bound the isomorphism classes of simple objects
+(`TauCeti.SimpleFDRepClasses.bijective_of_injective_of_card_conjClasses_le`), so there is no room
+for any other. -/
 theorem spechtModuleℂFDRepClass_bijective :
     Function.Bijective (spechtModuleℂFDRepClass (n := n)) := by
   refine SimpleFDRepClasses.bijective_of_injective_of_card_conjClasses_le ?_

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
@@ -11,8 +11,10 @@ public import TauCeti.RepresentationTheory.Symmetric.Specht.Character
 public import TauCeti.RepresentationTheory.Symmetric.Specht.Completeness
 public import Mathlib.RepresentationTheory.FinGroupCharZero
 -- Non-public: `Complex.isAlgClosed` is what puts `ℂ` in the scope of the orthogonality relations,
--- and is used only inside the proofs below; no statement here mentions algebraic closedness.
+-- and `FDRep.nonempty_iso_of_character_eq_of_simple` consumes it; both are used only inside the
+-- proofs below, and no statement here mentions algebraic closedness.
 import Mathlib.Analysis.Complex.Polynomial.Basic
+import TauCeti.RepresentationTheory.CharacterTable.Independence
 
 /-!
 # The complex Specht modules classify the irreducible complex representations of `Sₙ`
@@ -182,21 +184,12 @@ theorem spechtModuleℂ_iso_iff (μ ν : n.Partition) :
     finrank_intertwiningMap_spechtModule_eq_zero (Ne.symm hne)] at h
   simp [hiso] at h
 
-/-- **A complex Specht module is determined by its character.** -/
+/-- **A complex Specht module is determined by its character.** A simple object of `FDRep ℂ Sₙ` is
+determined by its character (`FDRep.nonempty_iso_of_character_eq_of_simple`), and complex Specht
+modules of distinct shapes are non-isomorphic. -/
 theorem spechtModuleℂ_character_injective :
-    Function.Injective fun μ : n.Partition => (spechtModuleℂ μ).character := by
-  intro μ ν h
-  have hchar : (spechtModuleℂ μ).character = (spechtModuleℂ ν).character := h
-  refine (spechtModuleℂ_iso_iff μ ν).mp ?_
-  by_contra hc
-  have hs : ((Nat.card (Equiv.Perm (Fin n)) : ℂ))⁻¹ *
-      ∑ σ : Equiv.Perm (Fin n),
-        (spechtModuleℂ μ).character σ * (spechtModuleℂ μ).character σ⁻¹ = 1 := by
-    simpa [Nonempty.intro (Iso.refl (spechtModuleℂ μ))] using
-      FDRep.char_orthonormal (spechtModuleℂ μ) (spechtModuleℂ μ)
-  have hd := FDRep.char_orthonormal (spechtModuleℂ μ) (spechtModuleℂ ν)
-  rw [← hchar, hs] at hd
-  simp [hc] at hd
+    Function.Injective fun μ : n.Partition => (spechtModuleℂ μ).character := fun _ _ h =>
+  (spechtModuleℂ_iso_iff _ _).mp (FDRep.nonempty_iso_of_character_eq_of_simple _ _ h)
 
 /-! ### The classification -/
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
@@ -38,9 +38,10 @@ the partitions of `n` are as many as the conjugacy classes of `Sₙ`, which boun
 isomorphism classes of simple objects over any field, so distinctness already forces exhaustion.
 
 Because the character of `S^μ` is integer-valued (`TauCeti.spechtChar`), the complex characters are
-the same integers read in `ℂ`, and the character table of `Sₙ` computed over `ℚ`
-(`TauCeti.symmetricCharacterTable`) is therefore also its complex character table: the irreducible
-complex characters of `Sₙ` are exactly the `χ^μ`.
+the same integers read in `ℂ`, and the integer-valued character table of `Sₙ`
+(`TauCeti.symmetricCharacterTable`, a `Matrix (Nat.Partition n) (Nat.Partition n) ℤ`), whose casts
+recover the rational character values, therefore records the complex ones just as well: the
+irreducible complex characters of `Sₙ` are exactly the `χ^μ`.
 
 ## Main definitions
 
@@ -104,8 +105,9 @@ theorem character_spechtModuleℂ (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
   exact Representation.character_baseChange _ σ
 
 /-- **The complex character is the integer character `χ^μ` read in `ℂ`.** Combined with
-`TauCeti.spechtChar_eq_value` this says that the character table of `Sₙ` computed over `ℚ`,
-`TauCeti.symmetricCharacterTable`, is also its complex character table. -/
+`TauCeti.spechtChar_eq_value` this says that the integer-valued character table of `Sₙ`,
+`TauCeti.symmetricCharacterTable`, whose casts recover the rational character values, records the
+complex ones too. -/
 @[simp]
 theorem character_spechtModuleℂ_intCast (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
     (spechtModuleℂ μ).character σ = (spechtChar μ σ : ℂ) := by
@@ -255,8 +257,9 @@ theorem existsUnique_nonempty_iso_spechtModuleℂ (X : FDRep ℂ (Equiv.Perm (Fi
 /-- **The `ℂ`-corollary: the irreducible complex characters of `Sₙ` are exactly the `χ^μ`.** Every
 simple object of `FDRep ℂ Sₙ` has, for exactly one partition `μ` of `n`, the integer character
 `TauCeti.spechtChar` of the Specht module `S^μ` read in `ℂ`. With
-`TauCeti.spechtChar_eq_value` this identifies `TauCeti.symmetricCharacterTable n`, computed over
-`ℚ`, as the complex character table of `Sₙ`. -/
+`TauCeti.spechtChar_eq_value` this identifies the integer-valued
+`TauCeti.symmetricCharacterTable n`, whose casts recover the rational character values, as
+recording the complex character table of `Sₙ` as well. -/
 theorem existsUnique_character_eq_spechtChar (X : FDRep ℂ (Equiv.Perm (Fin n))) [Simple X] :
     ∃! μ : n.Partition, X.character = fun σ => (spechtChar μ σ : ℂ) := by
   obtain ⟨μ, ⟨e⟩, -⟩ := existsUnique_nonempty_iso_spechtModuleℂ X

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
@@ -27,8 +27,8 @@ they classify the rational ones (`TauCeti.partitionEquivSimpleFDRepClasses`).
 Simplicity is where the rational theory could fail and does not, and the reason is **absolute
 irreducibility**: irreducibility over `ℚ` alone says nothing about `ℂ ⊗_ℚ S^μ`, but
 `TauCeti.spechtModuleIntertwiningEndAlgEquiv` says the intertwiner algebra of `S^μ` is `ℚ` itself,
-one-dimensional, and the dimension of an intertwiner space is a character integral
-(`Representation.finrank_intertwiningMap_baseChange`) and so is unchanged by extending the scalars.
+one-dimensional, and the intertwiner space is the kernel of a linear map, so its dimension is
+unchanged by the flat extension `ℚ → ℂ` (`Representation.finrank_intertwiningMap_baseChange`).
 So the complex endomorphism algebra is one-dimensional too, which over `ℂ` is simplicity
 (`FDRep.simple_iff_char_is_norm_one`). The same dimension count with two different partitions is
 `0` on the rational side by Schur's lemma, hence `0` on the complex side, which is distinctness; and
@@ -59,19 +59,10 @@ complex characters of `Sₙ` are exactly the `χ^μ`.
 * `TauCeti.existsUnique_character_eq_spechtChar`: **the ℂ-corollary** — the irreducible complex
   characters of `Sₙ` are exactly the integer characters `χ^μ`, one for each partition of `n`.
 
-## Implementation notes
-
-`TauCeti.spechtModuleℂ` carries `@[expose]` because its body determines the carrier type
-`ℂ ⊗_ℚ S^μ`: without exposure the statement of `TauCeti.spechtModuleℂ_ρ`, and with it every
-base-change lemma routed through that identification, fails to elaborate, the underlying module of
-the `FDRep` object no longer being recognizable as a tensor product.
-
 ## References
 
 * [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 4.
 * B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Section 2.4.
-* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
-  "Absolute irreducibility" and "Distinctness and completeness" (the `ℂ`-corollary).
 -/
 
 public section
@@ -94,19 +85,18 @@ private noncomputable instance : Invertible ((Nat.card (Equiv.Perm (Fin n)) : �
 `TauCeti.spechtModule` to `ℂ`. It is simple (`TauCeti.instSimpleSpechtModuleℂ`), and as `μ` ranges
 over the partitions of `n` these exhaust the simple objects of `FDRep ℂ Sₙ` without repetition
 (`TauCeti.partitionEquivSimpleFDRepClassesℂ`). -/
-@[expose]
 noncomputable def spechtModuleℂ (μ : n.Partition) : FDRep ℂ (Equiv.Perm (Fin n)) :=
   FDRep.of (Representation.baseChange ℂ (spechtModule μ).ρ)
 
-/-- The representation carried by the complex Specht module is the base change of the rational
-one. -/
-theorem spechtModuleℂ_ρ (μ : n.Partition) :
-    (spechtModuleℂ μ).ρ = Representation.baseChange ℂ (spechtModule μ).ρ := (rfl)
+/-- The complex Specht module is the object of `FDRep ℂ Sₙ` carrying the base change of the
+rational Specht representation. -/
+theorem spechtModuleℂ_def (μ : n.Partition) :
+    spechtModuleℂ μ = FDRep.of (Representation.baseChange ℂ (spechtModule μ).ρ) := (rfl)
 
 /-- **The complex character is the rational character read in `ℂ`.** -/
 theorem character_spechtModuleℂ (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
     (spechtModuleℂ μ).character σ = algebraMap ℚ ℂ ((spechtModule μ).character σ) := by
-  rw [FDRep.character, spechtModuleℂ_ρ]
+  rw [spechtModuleℂ_def, FDRep.character, FDRep.of_ρ']
   exact Representation.character_baseChange _ σ
 
 /-- **The complex character is the integer character `χ^μ` read in `ℂ`.** Combined with
@@ -118,8 +108,9 @@ theorem character_spechtModuleℂ_intCast (μ : n.Partition) (σ : Equiv.Perm (F
 
 /-- **Extending the scalars does not change the dimension.** -/
 theorem finrank_spechtModuleℂ (μ : n.Partition) :
-    finrank ℂ (spechtModuleℂ μ) = finrank ℚ (spechtModule μ) :=
-  Module.finrank_baseChange
+    finrank ℂ (spechtModuleℂ μ) = finrank ℚ (spechtModule μ) := by
+  rw [spechtModuleℂ_def]
+  exact Module.finrank_baseChange
 
 /-- **The dimension of an intertwiner space is unchanged by complexification.** This is the whole
 mechanism of the file: the rational intertwiner dimensions, `1` on the diagonal and `0` off it,
@@ -127,7 +118,7 @@ are inherited verbatim by the complex Specht modules. -/
 theorem finrank_intertwiningMap_spechtModuleℂ (μ ν : n.Partition) :
     finrank ℂ (Representation.IntertwiningMap (spechtModuleℂ μ).ρ (spechtModuleℂ ν).ρ)
       = finrank ℚ (Representation.IntertwiningMap (spechtModule μ).ρ (spechtModule ν).ρ) := by
-  rw [spechtModuleℂ_ρ, spechtModuleℂ_ρ]
+  rw [spechtModuleℂ_def, spechtModuleℂ_def, FDRep.of_ρ', FDRep.of_ρ']
   exact Representation.finrank_intertwiningMap_baseChange _ _
 
 /-! ### Simplicity and distinctness -/

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
@@ -104,6 +104,7 @@ theorem character_spechtModuleℂ (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
 /-- **The complex character is the integer character `χ^μ` read in `ℂ`.** Combined with
 `TauCeti.spechtChar_eq_value` this says that the character table of `Sₙ` computed over `ℚ`,
 `TauCeti.symmetricCharacterTable`, is also its complex character table. -/
+@[simp]
 theorem character_spechtModuleℂ_intCast (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
     (spechtModuleℂ μ).character σ = (spechtChar μ σ : ℂ) := by
   rw [character_spechtModuleℂ, ← spechtChar_cast, eq_ratCast, Rat.cast_intCast]
@@ -117,7 +118,7 @@ theorem finrank_spechtModuleℂ (μ : n.Partition) :
 /-- **The dimension of an intertwiner space is unchanged by complexification.** This is the whole
 mechanism of the file: the rational intertwiner dimensions, `1` on the diagonal and `0` off it,
 are inherited verbatim by the complex Specht modules. -/
-theorem finrank_intertwiningMap_spechtModuleℂ (μ ν : n.Partition) :
+private theorem finrank_intertwiningMap_spechtModuleℂ (μ ν : n.Partition) :
     finrank ℂ (Representation.IntertwiningMap (spechtModuleℂ μ).ρ (spechtModuleℂ ν).ρ)
       = finrank ℚ (Representation.IntertwiningMap (spechtModule μ).ρ (spechtModule ν).ρ) := by
   rw [spechtModuleℂ_def, spechtModuleℂ_def, FDRep.of_ρ', FDRep.of_ρ']
@@ -147,7 +148,8 @@ private theorem finrank_intertwiningMap_spechtModule_eq_zero {μ ν : n.Partitio
 /-- **The character inner product of two complex Specht modules is the rational intertwiner
 dimension times `|Sₙ|`.** Unnormalized, because this is the shape both
 `FDRep.simple_iff_char_is_norm_one` and `FDRep.char_orthonormal` consume. -/
-theorem sum_character_spechtModuleℂ (μ ν : n.Partition) :
+private theorem sum_character_spechtModuleℂ_mul_character_spechtModuleℂ_inv_eq_finrank_mul_card
+    (μ ν : n.Partition) :
     ∑ σ : Equiv.Perm (Fin n),
         (spechtModuleℂ μ).character σ * (spechtModuleℂ ν).character σ⁻¹
       = (finrank ℚ (Representation.IntertwiningMap (spechtModule ν).ρ (spechtModule μ).ρ) : ℂ) *
@@ -170,7 +172,8 @@ instance instSimpleSpechtModuleℂ (μ : n.Partition) : Simple (spechtModuleℂ 
       (Representation.IntertwiningMap (spechtModule μ).ρ (spechtModule μ).ρ) = 1 := by
     rw [(spechtModuleIntertwiningEndAlgEquiv μ).toLinearEquiv.finrank_eq]
     exact Module.finrank_self ℚ
-  rw [FDRep.simple_iff_char_is_norm_one, sum_character_spechtModuleℂ, hend]
+  rw [FDRep.simple_iff_char_is_norm_one,
+    sum_character_spechtModuleℂ_mul_character_spechtModuleℂ_inv_eq_finrank_mul_card, hend]
   simp
 
 /-- **Complex Specht modules of distinct shapes are non-isomorphic.** -/
@@ -180,7 +183,7 @@ theorem spechtModuleℂ_iso_iff (μ ν : n.Partition) :
   refine ⟨fun hiso => ?_, by rintro rfl; exact ⟨Iso.refl _⟩⟩
   by_contra hne
   have h := FDRep.char_orthonormal (spechtModuleℂ μ) (spechtModuleℂ ν)
-  rw [sum_character_spechtModuleℂ,
+  rw [sum_character_spechtModuleℂ_mul_character_spechtModuleℂ_inv_eq_finrank_mul_card,
     finrank_intertwiningMap_spechtModule_eq_zero (Ne.symm hne)] at h
   simp [hiso] at h
 
@@ -209,24 +212,12 @@ non-isomorphic and as many as the conjugacy classes of `Sₙ`, and no field admi
 classes of simple objects than the group has conjugacy classes. -/
 theorem spechtModuleℂFDRepClass_bijective :
     Function.Bijective (spechtModuleℂFDRepClass (n := n)) := by
-  classical
-  have hinj : Function.Injective (spechtModuleℂFDRepClass (n := n)) := by
-    intro μ ν h
-    rw [spechtModuleℂFDRepClass_def, spechtModuleℂFDRepClass_def,
-      SimpleFDRepClasses.mk_eq_mk_iff] at h
-    exact (spechtModuleℂ_iso_iff μ ν).mp h
-  have _ : Finite (SimpleSubmoduleClasses ℂ[Equiv.Perm (Fin n)] ℂ[Equiv.Perm (Fin n)]) :=
-    .of_equiv _ (simpleSubmoduleClassesEquiv _ _).symm
-  have _ : Finite (SimpleFDRepClasses ℂ (Equiv.Perm (Fin n))) :=
-    .of_injective _ SimpleFDRepClasses.toSimpleSubmoduleClasses_injective
-  let _ := Fintype.ofFinite (SimpleFDRepClasses ℂ (Equiv.Perm (Fin n)))
-  refine (Fintype.bijective_iff_injective_and_card _).mpr ⟨hinj, ?_⟩
-  rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card]
-  refine le_antisymm (Nat.card_le_card_of_injective _ hinj) ?_
-  refine (Nat.card_le_card_of_injective _
-    SimpleFDRepClasses.toSimpleSubmoduleClasses_injective).trans ?_
-  exact (card_simpleSubmoduleClasses_le_card_conjClasses ℂ (Equiv.Perm (Fin n))).trans
+  refine SimpleFDRepClasses.bijective_of_injective_of_card_conjClasses_le ?_
     (Nat.card_congr (partitionEquivConjClasses n).symm).le
+  intro μ ν h
+  rw [spechtModuleℂFDRepClass_def, spechtModuleℂFDRepClass_def,
+    SimpleFDRepClasses.mk_eq_mk_iff] at h
+  exact (spechtModuleℂ_iso_iff μ ν).mp h
 
 /-- **The classification of the irreducible complex representations of the symmetric group**:
 `μ ↦ ℂ ⊗_ℚ S^μ` is a bijection from the partitions of `n` to the isomorphism classes of simple

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
@@ -1,0 +1,283 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.BaseChange
+public import TauCeti.RepresentationTheory.Symmetric.Specht.AbsoluteIrreducibility
+public import TauCeti.RepresentationTheory.Symmetric.Specht.Character
+public import TauCeti.RepresentationTheory.Symmetric.Specht.Completeness
+public import Mathlib.RepresentationTheory.FinGroupCharZero
+-- Non-public: `Complex.isAlgClosed` is what puts `ℂ` in the scope of the orthogonality relations,
+-- and is used only inside the proofs below; no statement here mentions algebraic closedness.
+import Mathlib.Analysis.Complex.Polynomial.Basic
+
+/-!
+# The complex Specht modules classify the irreducible complex representations of `Sₙ`
+
+The Specht module `S^μ` is defined over `ℚ`, and this file extends its scalars to `ℂ`:
+`TauCeti.spechtModuleℂ μ` is `ℂ ⊗_ℚ S^μ`, an object of `FDRep ℂ Sₙ`. The point of the file is that
+nothing is lost and nothing is gained in the passage — the complex Specht modules are again
+**simple**, again pairwise **non-isomorphic**, and again **all** of the simple objects — so the
+partitions of `n` classify the irreducible complex representations of the symmetric group exactly as
+they classify the rational ones (`TauCeti.partitionEquivSimpleFDRepClasses`).
+
+Simplicity is where the rational theory could fail and does not, and the reason is **absolute
+irreducibility**: irreducibility over `ℚ` alone says nothing about `ℂ ⊗_ℚ S^μ`, but
+`TauCeti.spechtModuleIntertwiningEndAlgEquiv` says the intertwiner algebra of `S^μ` is `ℚ` itself,
+one-dimensional, and the dimension of an intertwiner space is a character integral
+(`Representation.finrank_intertwiningMap_baseChange`) and so is unchanged by extending the scalars.
+So the complex endomorphism algebra is one-dimensional too, which over `ℂ` is simplicity
+(`FDRep.simple_iff_char_is_norm_one`). The same dimension count with two different partitions is
+`0` on the rational side by Schur's lemma, hence `0` on the complex side, which is distinctness; and
+the partitions of `n` are as many as the conjugacy classes of `Sₙ`, which bounds the number of
+isomorphism classes of simple objects over any field, so distinctness already forces exhaustion.
+
+Because the character of `S^μ` is integer-valued (`TauCeti.spechtChar`), the complex characters are
+the same integers read in `ℂ`, and the character table of `Sₙ` computed over `ℚ`
+(`TauCeti.symmetricCharacterTable`) is therefore also its complex character table: the irreducible
+complex characters of `Sₙ` are exactly the `χ^μ`.
+
+## Main definitions
+
+* `TauCeti.spechtModuleℂ`: the complex Specht module `ℂ ⊗_ℚ S^μ`.
+* `TauCeti.spechtModuleℂFDRepClass`: its isomorphism class as a simple object of `FDRep ℂ Sₙ`.
+* `TauCeti.partitionEquivSimpleFDRepClassesℂ`: **the classification**, `μ ↦ ℂ ⊗_ℚ S^μ` as a
+  bijection from `Nat.Partition n` to the isomorphism classes of simple objects of `FDRep ℂ Sₙ`.
+
+## Main results
+
+* `TauCeti.character_spechtModuleℂ` and `TauCeti.character_spechtModuleℂ_intCast`: the complex
+  character is the rational character, equivalently the integer character `χ^μ`, read in `ℂ`.
+* `TauCeti.finrank_spechtModuleℂ`: extending the scalars does not change the dimension.
+* `TauCeti.instSimpleSpechtModuleℂ`: **the complex Specht module is simple.**
+* `TauCeti.spechtModuleℂ_iso_iff`: complex Specht modules of distinct shapes are non-isomorphic.
+* `TauCeti.existsUnique_nonempty_iso_spechtModuleℂ`: every simple object of `FDRep ℂ Sₙ` is a
+  complex Specht module for exactly one partition.
+* `TauCeti.existsUnique_character_eq_spechtChar`: **the ℂ-corollary** — the irreducible complex
+  characters of `Sₙ` are exactly the integer characters `χ^μ`, one for each partition of `n`.
+
+## Implementation notes
+
+`TauCeti.spechtModuleℂ` carries `@[expose]` because its body determines the carrier type
+`ℂ ⊗_ℚ S^μ`: without exposure the statement of `TauCeti.spechtModuleℂ_ρ`, and with it every
+base-change lemma routed through that identification, fails to elaborate, the underlying module of
+the `FDRep` object no longer being recognizable as a tensor product.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 4.
+* B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Section 2.4.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 4, "Absolute irreducibility" and "Distinctness and completeness" (the `ℂ`-corollary), whose
+  `Suggested.lean` pins the object built here as `spechtModuleℂ`.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory Module
+open scoped MonoidAlgebra
+
+variable {n : ℕ}
+
+/-- The order of `Sₙ` is invertible in `ℂ`, which is what puts the complex Specht modules in the
+scope of the character-orthogonality machinery. -/
+private noncomputable instance : Invertible ((Nat.card (Equiv.Perm (Fin n)) : ℂ)) :=
+  invertibleOfNonzero (Nat.cast_ne_zero.mpr Nat.card_pos.ne')
+
+/-! ### The complex Specht module -/
+
+/-- **The complex Specht module** `ℂ ⊗_ℚ S^μ`, the scalar extension of the rational Specht module
+`TauCeti.spechtModule` to `ℂ`. It is simple (`TauCeti.instSimpleSpechtModuleℂ`), and as `μ` ranges
+over the partitions of `n` these exhaust the simple objects of `FDRep ℂ Sₙ` without repetition
+(`TauCeti.partitionEquivSimpleFDRepClassesℂ`). -/
+@[expose]
+noncomputable def spechtModuleℂ (μ : n.Partition) : FDRep ℂ (Equiv.Perm (Fin n)) :=
+  FDRep.of (Representation.baseChange ℂ (spechtModule μ).ρ)
+
+/-- The representation carried by the complex Specht module is the base change of the rational
+one. -/
+theorem spechtModuleℂ_ρ (μ : n.Partition) :
+    (spechtModuleℂ μ).ρ = Representation.baseChange ℂ (spechtModule μ).ρ := (rfl)
+
+/-- **The complex character is the rational character read in `ℂ`.** -/
+theorem character_spechtModuleℂ (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+    (spechtModuleℂ μ).character σ = algebraMap ℚ ℂ ((spechtModule μ).character σ) := by
+  rw [FDRep.character, spechtModuleℂ_ρ]
+  exact Representation.character_baseChange _ σ
+
+/-- **The complex character is the integer character `χ^μ` read in `ℂ`.** Combined with
+`TauCeti.spechtChar_eq_value` this says that the character table of `Sₙ` computed over `ℚ`,
+`TauCeti.symmetricCharacterTable`, is also its complex character table. -/
+theorem character_spechtModuleℂ_intCast (μ : n.Partition) (σ : Equiv.Perm (Fin n)) :
+    (spechtModuleℂ μ).character σ = (spechtChar μ σ : ℂ) := by
+  rw [character_spechtModuleℂ, ← spechtChar_cast, eq_ratCast, Rat.cast_intCast]
+
+/-- **Extending the scalars does not change the dimension.** -/
+theorem finrank_spechtModuleℂ (μ : n.Partition) :
+    finrank ℂ (spechtModuleℂ μ) = finrank ℚ (spechtModule μ) :=
+  Module.finrank_baseChange
+
+/-- **The dimension of an intertwiner space is unchanged by complexification.** This is the whole
+mechanism of the file: the rational intertwiner dimensions, `1` on the diagonal and `0` off it,
+are inherited verbatim by the complex Specht modules. -/
+theorem finrank_intertwiningMap_spechtModuleℂ (μ ν : n.Partition) :
+    finrank ℂ (Representation.IntertwiningMap (spechtModuleℂ μ).ρ (spechtModuleℂ ν).ρ)
+      = finrank ℚ (Representation.IntertwiningMap (spechtModule μ).ρ (spechtModule ν).ρ) := by
+  rw [spechtModuleℂ_ρ, spechtModuleℂ_ρ]
+  exact Representation.finrank_intertwiningMap_baseChange _ _
+
+/-! ### Simplicity and distinctness -/
+
+/-- Specht modules of distinct shapes are inequivalent as rational representations. This is
+`TauCeti.spechtModule_iso_iff` read at the level of `Representation.Equiv`. -/
+private theorem isEmpty_equiv_spechtModule {μ ν : n.Partition} (h : μ ≠ ν) :
+    IsEmpty (Representation.Equiv (spechtModule μ).ρ (spechtModule ν).ρ) := by
+  rw [← not_nonempty_iff]
+  intro hne
+  exact h ((spechtModule_iso_iff μ ν).mp (nonempty_fdRepIso_iff.mpr hne))
+
+/-- Schur's lemma over `ℚ`: there are no nonzero intertwiners between Specht modules of distinct
+shapes. -/
+private theorem finrank_intertwiningMap_spechtModule_eq_zero {μ ν : n.Partition} (h : μ ≠ ν) :
+    finrank ℚ (Representation.IntertwiningMap (spechtModule μ).ρ (spechtModule ν).ρ) = 0 := by
+  have _ : Representation.IsIrreducible (spechtModule μ).ρ := isIrreducible_spechtModule μ
+  have _ : Representation.IsIrreducible (spechtModule ν).ρ := isIrreducible_spechtModule ν
+  have _ := isEmpty_equiv_spechtModule h
+  have : Subsingleton (Representation.IntertwiningMap (spechtModule μ).ρ (spechtModule ν).ρ) :=
+    inferInstance
+  exact Module.finrank_zero_of_subsingleton
+
+/-- **The character inner product of two complex Specht modules is the rational intertwiner
+dimension times `|Sₙ|`.** Unnormalized, because this is the shape both
+`FDRep.simple_iff_char_is_norm_one` and `FDRep.char_orthonormal` consume. -/
+theorem sum_character_spechtModuleℂ (μ ν : n.Partition) :
+    ∑ σ : Equiv.Perm (Fin n),
+        (spechtModuleℂ μ).character σ * (spechtModuleℂ ν).character σ⁻¹
+      = (finrank ℚ (Representation.IntertwiningMap (spechtModule ν).ρ (spechtModule μ).ρ) : ℂ) *
+        (Nat.card (Equiv.Perm (Fin n)) : ℂ) := by
+  have h := Representation.card_inv_mul_sum_char_mul_char_eq_finrank
+    (spechtModuleℂ ν).ρ (spechtModuleℂ μ).ρ
+  rw [finrank_intertwiningMap_spechtModuleℂ] at h
+  have hN : ((Nat.card (Equiv.Perm (Fin n)) : ℂ)) ≠ 0 :=
+    Nat.cast_ne_zero.mpr Nat.card_pos.ne'
+  field_simp at h
+  rw [mul_comm]
+  exact h
+
+/-- **The complex Specht module is simple.** Its endomorphism algebra is one-dimensional, because
+that of the rational Specht module is (`TauCeti.spechtModuleIntertwiningEndAlgEquiv`) and the
+dimension survives complexification; over `ℂ` a one-dimensional endomorphism algebra is
+simplicity. -/
+instance instSimpleSpechtModuleℂ (μ : n.Partition) : Simple (spechtModuleℂ μ) := by
+  have hend : finrank ℚ
+      (Representation.IntertwiningMap (spechtModule μ).ρ (spechtModule μ).ρ) = 1 := by
+    rw [(spechtModuleIntertwiningEndAlgEquiv μ).toLinearEquiv.finrank_eq]
+    exact Module.finrank_self ℚ
+  rw [FDRep.simple_iff_char_is_norm_one, sum_character_spechtModuleℂ, hend]
+  simp
+
+/-- **Complex Specht modules of distinct shapes are non-isomorphic.** -/
+theorem spechtModuleℂ_iso_iff (μ ν : n.Partition) :
+    Nonempty (spechtModuleℂ μ ≅ spechtModuleℂ ν) ↔ μ = ν := by
+  refine ⟨fun hiso => ?_, by rintro rfl; exact ⟨Iso.refl _⟩⟩
+  by_contra hne
+  have h := FDRep.char_orthonormal (spechtModuleℂ μ) (spechtModuleℂ ν)
+  rw [sum_character_spechtModuleℂ,
+    finrank_intertwiningMap_spechtModule_eq_zero (Ne.symm hne)] at h
+  simp [hiso] at h
+
+/-- **A complex Specht module is determined by its character.** -/
+theorem spechtModuleℂ_character_inj {μ ν : n.Partition}
+    (h : (spechtModuleℂ μ).character = (spechtModuleℂ ν).character) : μ = ν := by
+  refine (spechtModuleℂ_iso_iff μ ν).mp ?_
+  by_contra hc
+  have hs : ((Nat.card (Equiv.Perm (Fin n)) : ℂ))⁻¹ *
+      ∑ σ : Equiv.Perm (Fin n),
+        (spechtModuleℂ μ).character σ * (spechtModuleℂ μ).character σ⁻¹ = 1 := by
+    simpa [Nonempty.intro (Iso.refl (spechtModuleℂ μ))] using
+      FDRep.char_orthonormal (spechtModuleℂ μ) (spechtModuleℂ μ)
+  have hd := FDRep.char_orthonormal (spechtModuleℂ μ) (spechtModuleℂ ν)
+  rw [← h, hs] at hd
+  simp [hc] at hd
+
+/-! ### The classification -/
+
+/-- **The isomorphism class of the complex Specht module `ℂ ⊗_ℚ S^μ`** as a simple object of
+`FDRep ℂ Sₙ`. The complex counterpart of `TauCeti.spechtModuleFDRepClass`. -/
+noncomputable def spechtModuleℂFDRepClass (μ : n.Partition) :
+    SimpleFDRepClasses ℂ (Equiv.Perm (Fin n)) :=
+  SimpleFDRepClasses.mk (spechtModuleℂ μ)
+
+@[simp]
+theorem spechtModuleℂFDRepClass_def (μ : n.Partition) :
+    spechtModuleℂFDRepClass μ = SimpleFDRepClasses.mk (spechtModuleℂ μ) :=
+  (rfl)
+
+/-- **The complex Specht modules exhaust the simple objects of `FDRep ℂ Sₙ`.** They are pairwise
+non-isomorphic and as many as the conjugacy classes of `Sₙ`, and no field admits more isomorphism
+classes of simple objects than the group has conjugacy classes. -/
+theorem spechtModuleℂFDRepClass_bijective :
+    Function.Bijective (spechtModuleℂFDRepClass (n := n)) := by
+  classical
+  have hinj : Function.Injective (spechtModuleℂFDRepClass (n := n)) := by
+    intro μ ν h
+    rw [spechtModuleℂFDRepClass_def, spechtModuleℂFDRepClass_def,
+      SimpleFDRepClasses.mk_eq_mk_iff] at h
+    exact (spechtModuleℂ_iso_iff μ ν).mp h
+  have _ : Finite (SimpleSubmoduleClasses ℂ[Equiv.Perm (Fin n)] ℂ[Equiv.Perm (Fin n)]) :=
+    .of_equiv _ (simpleSubmoduleClassesEquiv _ _).symm
+  have _ : Finite (SimpleFDRepClasses ℂ (Equiv.Perm (Fin n))) :=
+    .of_injective _ SimpleFDRepClasses.toSimpleSubmoduleClasses_injective
+  let _ := Fintype.ofFinite (SimpleFDRepClasses ℂ (Equiv.Perm (Fin n)))
+  refine (Fintype.bijective_iff_injective_and_card _).mpr ⟨hinj, ?_⟩
+  rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card]
+  refine le_antisymm (Nat.card_le_card_of_injective _ hinj) ?_
+  refine (Nat.card_le_card_of_injective _
+    SimpleFDRepClasses.toSimpleSubmoduleClasses_injective).trans ?_
+  exact (card_simpleSubmoduleClasses_le_card_conjClasses ℂ (Equiv.Perm (Fin n))).trans
+    (Nat.card_congr (partitionEquivConjClasses n).symm).le
+
+/-- **The classification of the irreducible complex representations of the symmetric group**:
+`μ ↦ ℂ ⊗_ℚ S^μ` is a bijection from the partitions of `n` to the isomorphism classes of simple
+objects of `FDRep ℂ Sₙ`. It is the complex counterpart of
+`TauCeti.partitionEquivSimpleFDRepClasses`, indexed by the same partitions. -/
+noncomputable def partitionEquivSimpleFDRepClassesℂ (n : ℕ) :
+    n.Partition ≃ SimpleFDRepClasses ℂ (Equiv.Perm (Fin n)) :=
+  Equiv.ofBijective _ spechtModuleℂFDRepClass_bijective
+
+@[simp]
+theorem partitionEquivSimpleFDRepClassesℂ_apply (μ : n.Partition) :
+    partitionEquivSimpleFDRepClassesℂ n μ = spechtModuleℂFDRepClass μ :=
+  (rfl)
+
+/-- **Every simple object of `FDRep ℂ Sₙ` is a complex Specht module for exactly one
+partition.** -/
+theorem existsUnique_nonempty_iso_spechtModuleℂ (X : FDRep ℂ (Equiv.Perm (Fin n))) [Simple X] :
+    ∃! μ : n.Partition, Nonempty (X ≅ spechtModuleℂ μ) := by
+  obtain ⟨μ, hμ⟩ := spechtModuleℂFDRepClass_bijective.surjective (SimpleFDRepClasses.mk X)
+  rw [spechtModuleℂFDRepClass_def, SimpleFDRepClasses.mk_eq_mk_iff] at hμ
+  refine ⟨μ, ⟨hμ.some.symm⟩, fun ν hν => ?_⟩
+  exact (spechtModuleℂ_iso_iff ν μ).mp ⟨hν.some.symm.trans hμ.some.symm⟩
+
+/-- **The `ℂ`-corollary: the irreducible complex characters of `Sₙ` are exactly the `χ^μ`.** Every
+simple object of `FDRep ℂ Sₙ` has, for exactly one partition `μ` of `n`, the integer character
+`TauCeti.spechtChar` of the Specht module `S^μ` read in `ℂ`. With
+`TauCeti.spechtChar_eq_value` this identifies `TauCeti.symmetricCharacterTable n`, computed over
+`ℚ`, as the complex character table of `Sₙ`. -/
+theorem existsUnique_character_eq_spechtChar (X : FDRep ℂ (Equiv.Perm (Fin n))) [Simple X] :
+    ∃! μ : n.Partition, X.character = fun σ => (spechtChar μ σ : ℂ) := by
+  obtain ⟨μ, ⟨e⟩, -⟩ := existsUnique_nonempty_iso_spechtModuleℂ X
+  have hμ : X.character = fun σ => (spechtChar μ σ : ℂ) := by
+    rw [FDRep.char_iso e]
+    exact funext (character_spechtModuleℂ_intCast μ)
+  refine ⟨μ, hμ, fun ν hν => ?_⟩
+  refine spechtModuleℂ_character_inj (funext fun σ => ?_)
+  rw [character_spechtModuleℂ_intCast, character_spechtModuleℂ_intCast]
+  exact congrFun (hν.symm.trans hμ) σ
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean
@@ -71,8 +71,7 @@ the `FDRep` object no longer being recognizable as a tensor product.
 * [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 4.
 * B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Section 2.4.
 * [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
-  Layer 4, "Absolute irreducibility" and "Distinctness and completeness" (the `ℂ`-corollary), whose
-  `Suggested.lean` pins the object built here as `spechtModuleℂ`.
+  "Absolute irreducibility" and "Distinctness and completeness" (the `ℂ`-corollary).
 -/
 
 public section
@@ -182,6 +181,7 @@ instance instSimpleSpechtModuleℂ (μ : n.Partition) : Simple (spechtModuleℂ 
   simp
 
 /-- **Complex Specht modules of distinct shapes are non-isomorphic.** -/
+@[simp]
 theorem spechtModuleℂ_iso_iff (μ ν : n.Partition) :
     Nonempty (spechtModuleℂ μ ≅ spechtModuleℂ ν) ↔ μ = ν := by
   refine ⟨fun hiso => ?_, by rintro rfl; exact ⟨Iso.refl _⟩⟩
@@ -192,8 +192,10 @@ theorem spechtModuleℂ_iso_iff (μ ν : n.Partition) :
   simp [hiso] at h
 
 /-- **A complex Specht module is determined by its character.** -/
-theorem spechtModuleℂ_character_inj {μ ν : n.Partition}
-    (h : (spechtModuleℂ μ).character = (spechtModuleℂ ν).character) : μ = ν := by
+theorem spechtModuleℂ_character_injective :
+    Function.Injective fun μ : n.Partition => (spechtModuleℂ μ).character := by
+  intro μ ν h
+  have hchar : (spechtModuleℂ μ).character = (spechtModuleℂ ν).character := h
   refine (spechtModuleℂ_iso_iff μ ν).mp ?_
   by_contra hc
   have hs : ((Nat.card (Equiv.Perm (Fin n)) : ℂ))⁻¹ *
@@ -202,7 +204,7 @@ theorem spechtModuleℂ_character_inj {μ ν : n.Partition}
     simpa [Nonempty.intro (Iso.refl (spechtModuleℂ μ))] using
       FDRep.char_orthonormal (spechtModuleℂ μ) (spechtModuleℂ μ)
   have hd := FDRep.char_orthonormal (spechtModuleℂ μ) (spechtModuleℂ ν)
-  rw [← h, hs] at hd
+  rw [← hchar, hs] at hd
   simp [hc] at hd
 
 /-! ### The classification -/
@@ -255,6 +257,15 @@ theorem partitionEquivSimpleFDRepClassesℂ_apply (μ : n.Partition) :
     partitionEquivSimpleFDRepClassesℂ n μ = spechtModuleℂFDRepClass μ :=
   (rfl)
 
+/-- The partition a complex Specht module's class names is the partition it was built from: the
+`symm` companion of `TauCeti.partitionEquivSimpleFDRepClassesℂ_apply`. -/
+@[simp]
+theorem partitionEquivSimpleFDRepClassesℂ_symm_mk_spechtModuleℂ (μ : n.Partition) :
+    (partitionEquivSimpleFDRepClassesℂ n).symm
+      (SimpleFDRepClasses.mk (spechtModuleℂ μ)) = μ := by
+  rw [← spechtModuleℂFDRepClass_def, ← partitionEquivSimpleFDRepClassesℂ_apply,
+    Equiv.symm_apply_apply]
+
 /-- **Every simple object of `FDRep ℂ Sₙ` is a complex Specht module for exactly one
 partition.** -/
 theorem existsUnique_nonempty_iso_spechtModuleℂ (X : FDRep ℂ (Equiv.Perm (Fin n))) [Simple X] :
@@ -276,8 +287,10 @@ theorem existsUnique_character_eq_spechtChar (X : FDRep ℂ (Equiv.Perm (Fin n))
     rw [FDRep.char_iso e]
     exact funext (character_spechtModuleℂ_intCast μ)
   refine ⟨μ, hμ, fun ν hν => ?_⟩
-  refine spechtModuleℂ_character_inj (funext fun σ => ?_)
-  rw [character_spechtModuleℂ_intCast, character_spechtModuleℂ_intCast]
-  exact congrFun (hν.symm.trans hμ) σ
+  have hchar : (spechtModuleℂ ν).character = (spechtModuleℂ μ).character := by
+    funext σ
+    rw [character_spechtModuleℂ_intCast, character_spechtModuleℂ_intCast]
+    exact congrFun (hν.symm.trans hμ) σ
+  exact spechtModuleℂ_character_injective hchar
 
 end TauCeti


### PR DESCRIPTION
This PR extends the rational Specht modules to `ℂ` and proves that the complexifications classify the irreducible complex representations of the symmetric group. `TauCeti.spechtModuleℂ μ` is `ℂ ⊗_ℚ S^μ` as an object of `FDRep ℂ Sₙ`; it is simple, complex Specht modules of distinct shapes are non-isomorphic, and every simple object of `FDRep ℂ Sₙ` is one of them for exactly one partition of `n`. Because the character of `S^μ` is integer-valued, the complex characters are those same integers read in `ℂ`, so the character table computed over `ℚ` (`TauCeti.symmetricCharacterTable`) is also the complex character table: the irreducible complex characters of `Sₙ` are exactly the `χ^μ`.

The mechanism is a general fact about scalar extension, added to the existing `TauCeti/RepresentationTheory/BaseChange.lean`. An intertwiner is a linear map killed by the finite family of linear conditions `σ g ∘ₗ f = f ∘ₗ ρ g`, so the intertwiner space is the kernel of a single linear map; a field extension is flat, so it commutes with that kernel (Mathlib's `LinearMap.tensorKerEquiv`, together with `IsBaseChange.linearMapLeftRight` for `L ⊗_K Hom_K(V, W) ≃ Hom_L(V_L, W_L)`). So the dimension is unchanged: `Representation.finrank_intertwiningMap_baseChange`, for representations of any finite monoid over any field, only the source being required finite-dimensional. Alongside it sits `Representation.character_baseChange` (the trace of a base-changed endomorphism is the image of the trace). Applied to `S^μ`, whose intertwiner algebra is `ℚ` itself by absolute irreducibility (`TauCeti.spechtModuleIntertwiningEndAlgEquiv`), it gives a one-dimensional complex endomorphism algebra, which over `ℂ` is simplicity; applied to two different shapes it gives `0` by Schur's lemma over `ℚ`, which is distinctness; and the partitions of `n` are as many as the conjugacy classes of `Sₙ`, which bounds the isomorphism classes of simple objects over any field, so distinctness already forces exhaustion. Irreducibility over `ℚ` alone would say nothing here — absolute irreducibility is exactly what the argument consumes, as the roadmap notes.

The target is `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 4, whose "Absolute irreducibility" bullet asks for the statement that "only then does `ℂ ⊗_ℚ S^λ` stay irreducible and stay non-isomorphic across `λ`", and whose "Distinctness and completeness" bullet asks to "State the `ℂ`-corollary: the irreducible complex characters of `Sₙ` are exactly `{χ^λ}_{λ ⊢ n}`". The object built here is the one that roadmap's `Suggested.lean` pins as `spechtModuleℂ`, consumed there by `schurWeylDecomposition` in Layer 8. Layer 4's prerequisites are all on `main`: `TauCeti/RepresentationTheory/Symmetric/Specht/AbsoluteIrreducibility.lean` (the endomorphism algebra), `.../Distinctness.lean` (`spechtModule_iso_iff`), `.../Completeness.lean` (the rational classification and `partitionEquivConjClasses`) and `.../Character.lean` (the integer character `spechtChar`).

New file `TauCeti/RepresentationTheory/Symmetric/Specht/Complex.lean`: `spechtModuleℂ` with its defining equation `spechtModuleℂ_def`, character (over `ℚ` and as an integer cast) and dimension; `instSimpleSpechtModuleℂ`; `spechtModuleℂ_iso_iff` and `spechtModuleℂ_character_injective`; and the classification `spechtModuleℂFDRepClass_bijective`, `partitionEquivSimpleFDRepClassesℂ`, `existsUnique_nonempty_iso_spechtModuleℂ`, `existsUnique_character_eq_spechtChar` (the intertwiner dimension count and the character inner product are private helpers of that file). `TauCeti/RepresentationTheory/BaseChange.lean` gains the two general base-change lemmas above, and `TauCeti/RepresentationTheory/RealForm.lean` now routes `Representation.IsRealForm.char_eq` through `Representation.character_baseChange` rather than re-deriving it.

The last step of both classifications — an injection saturating the conjugacy-class bound is a bijection — is shared, so it is factored into `TauCeti/RepresentationTheory/CharacterTable/SimpleModuleCount.lean` as `SimpleSubmoduleClasses.bijective_of_injective_of_card_conjClasses_le` and its `FDRep k G` counterpart `SimpleFDRepClasses.bijective_of_injective_of_card_conjClasses_le`; the rational `spechtModuleClass_bijective` in `.../Specht/Completeness.lean` now uses the first and the complex `spechtModuleℂFDRepClass_bijective` the second.

No Mathlib infrastructure was vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"complex-specht-module"}-->

🤖 Prepared with Claude Code



