### PR TITLE
feat(Topology): a ring quotient map presents its target as the quotient by its kernel

### DIFF
--- a/TauCeti/Topology/Algebra/Ring/Ideal.lean
+++ b/TauCeti/Topology/Algebra/Ring/Ideal.lean
@@ -5,14 +5,17 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.RingTheory.Ideal.Quotient.Operations
 public import Mathlib.Topology.Algebra.Ring.Ideal
 public import Mathlib.Topology.Algebra.Group.Quotient
 
 /-!
-# Separation of the quotient of a topological ring by an ideal
+# The quotient of a topological ring by an ideal
 
-The quotient `R ⧸ I` of a topological ring by an ideal is `T1` exactly when `I` is closed, and
-hence `T0`.
+Two things about `R ⧸ I` that its algebraic theory does not record. It is `T1` exactly when `I` is
+closed, and hence `T0`; and when `f : R →+* S` presents `S` as a topological quotient of `R`, the
+first isomorphism theorem `R ⧸ ker f ≃+* S` is a homeomorphism, so `S` carries the quotient
+topology and not merely a coarser one.
 
 Mathlib proves the corresponding statement for the quotient of a topological group by a
 subgroup, as `QuotientGroup.t1Space_iff` and `QuotientGroup.instT1Space`. Those are stated for
@@ -25,8 +28,27 @@ that presentation, which unification does not do on its own: with only `IsClosed
 context, `T1Space (R ⧸ I)` is not synthesized. So the results below are that transport, and
 their proofs delegate to Mathlib rather than reproving anything.
 
-Only separate continuity of addition is needed, matching the hypotheses of the group statements
-these delegate to; no ring topology and no multiplicative continuity is used.
+Only separate continuity of addition is needed for the separation results, matching the hypotheses
+of the group statements they delegate to; no ring topology and no multiplicative continuity is
+used. The first isomorphism theorem below asks for even less: only that `R ⧸ ker f` carries the
+coinduced topology, which it does by construction.
+
+## The topological first isomorphism theorem
+
+Algebraically, `RingHom.quotientKerEquivOfSurjective` identifies `R ⧸ ker f` with `S` for any
+surjective `f`. Topologically that says nothing: `R ⧸ ker f` carries the quotient topology, and a
+continuous surjection can land on a strictly coarser topology than the quotient one, so the
+bijection is continuous but need not be open. What closes the gap is exactly the hypothesis that
+`f` is a *quotient map*, and with it the algebraic isomorphism becomes a homeomorphism.
+
+The point of separating the two is that the quotient-map hypothesis is where the analysis lives.
+Over a Tate ring it is `TauCeti.Huber.IsTateRing.isQuotientMap`, an open mapping theorem, and
+supplying it is real work; everything downstream of it is the formal argument below, which uses
+nothing but injectivity of `RingHom.kerLift` and the universal property of the quotient topology.
+
+Note that closedness of `ker f` comes for free once `S` is `T1`, since a kernel is the preimage of
+a point; it is not a further hypothesis of the theorem but a consequence for its consumers, and
+`Ideal.Quotient.instT1Space` above then hands back the separation of `R ⧸ ker f`.
 
 ## Main results
 
@@ -35,6 +57,10 @@ these delegate to; no ring topology and no multiplicative continuity is used.
   automatically once `I` is known to be closed.
 * `Ideal.Quotient.continuous_lift`: a continuous ring homomorphism annihilating `I` induces a
   *continuous* homomorphism on `R ⧸ I`, with no hypothesis on `I`.
+* `RingHom.continuous_kerLift` and `RingHom.isOpenMap_kerLift`: the map `R ⧸ ker f →+* S` induced
+  by `f` is continuous when `f` is, and open when `f` is a quotient map.
+* `RingHom.quotientKerHomeomorph`: the two together, as a homeomorphism `R ⧸ ker f ≃ₜ S`. Its
+  underlying ring isomorphism is `RingHom.quotientKerEquivOfSurjective`.
 
 ## References
 
@@ -74,3 +100,69 @@ theorem continuous_lift {S : Type*} [Semiring S] [TopologicalSpace S] {f : R →
   continuous_coinduced_dom.mpr hf
 
 end Ideal.Quotient
+
+section FirstIsomorphism
+
+open Topology
+
+variable {R S : Type*} [TopologicalSpace R] [CommRing R] [TopologicalSpace S] [Ring S]
+  {f : R →+* S}
+
+namespace RingHom
+
+/-- **The lift of `f` to `R ⧸ ker f` is continuous.** This is `Ideal.Quotient.continuous_lift`
+for the canonical choice of ideal, spelled for `RingHom.kerLift` so that the first isomorphism
+theorem can be read topologically. -/
+theorem continuous_kerLift (hf : Continuous f) : Continuous (kerLift f) :=
+  Ideal.Quotient.continuous_lift (ker f) hf fun _ ↦ mem_ker.mp
+
+/-- **The lift of a quotient map to `R ⧸ ker f` is open.**
+
+Continuity of `f` alone cannot give this: it makes the lift a continuous bijection onto `S`, and a
+continuous bijection is open only when the topology it lands in is no coarser than the one it
+carries. That `f` is a quotient map is exactly the statement that it is not coarser.
+
+The proof is the set identity `f ⁻¹' (kerLift f '' U) = mk (ker f) ⁻¹' U`, which holds because
+`RingHom.kerLift` is injective, followed by the two halves of the quotient-map hypothesis: the
+right-hand side is open because `U` is, and openness transfers back across `f` because `f`
+coinduces the topology of `S`. -/
+theorem isOpenMap_kerLift (hq : IsQuotientMap (f : R → S)) : IsOpenMap (kerLift f) := by
+  intro U hU
+  rw [← hq.isCoinducing.isOpen_preimage]
+  have himg : ⇑f ⁻¹' (kerLift f '' U) = ⇑(Ideal.Quotient.mk (ker f)) ⁻¹' U := by
+    ext x
+    refine ⟨?_, fun hx ↦ ⟨_, hx, kerLift_mk f x⟩⟩
+    rintro ⟨u, hu, hux⟩
+    have hu' : u = Ideal.Quotient.mk (ker f) x :=
+      kerLift_injective f (hux.trans (kerLift_mk f x).symm)
+    change Ideal.Quotient.mk (ker f) x ∈ U
+    exact hu' ▸ hu
+  rw [himg]
+  exact hU.preimage continuous_coinduced_rng
+
+/-- **The topological first isomorphism theorem for rings.** A ring homomorphism that is a
+quotient map presents its target as the quotient of its source by its kernel, topologically as
+well as algebraically.
+
+The underlying map is `RingHom.kerLift`, so the ring structure is carried by
+`RingHom.quotientKerEquivOfSurjective` applied to `hq.surjective`, and this definition adds the
+topology to it. Mathlib has no type of continuous ring isomorphisms to bundle the two into, so a
+consumer needing both takes the ring isomorphism from there and its two continuities from here. -/
+@[expose]
+noncomputable def quotientKerHomeomorph (hq : IsQuotientMap (f : R → S)) : (R ⧸ ker f) ≃ₜ S :=
+  (quotientKerEquivOfSurjective hq.surjective).toEquiv.toHomeomorphOfContinuousOpen
+    (continuous_kerLift hq.continuous) (isOpenMap_kerLift hq)
+
+@[simp]
+theorem coe_quotientKerHomeomorph (hq : IsQuotientMap (f : R → S)) :
+    ⇑(quotientKerHomeomorph hq) = ⇑(quotientKerEquivOfSurjective hq.surjective) :=
+  rfl
+
+@[simp]
+theorem coe_quotientKerHomeomorph_symm (hq : IsQuotientMap (f : R → S)) :
+    ⇑(quotientKerHomeomorph hq).symm = ⇑(quotientKerEquivOfSurjective hq.surjective).symm :=
+  rfl
+
+end RingHom
+
+end FirstIsomorphism

--- a/TauCeti/Topology/Algebra/Ring/Ideal.lean
+++ b/TauCeti/Topology/Algebra/Ring/Ideal.lean
@@ -41,10 +41,8 @@ continuous surjection can land on a strictly coarser topology than the quotient 
 bijection is continuous but need not be open. What closes the gap is exactly the hypothesis that
 `f` is a *quotient map*, and with it the algebraic isomorphism becomes a homeomorphism.
 
-The quotient-map hypothesis is where the analysis lives. Over a Tate ring it is
-`TauCeti.Huber.IsTateRing.isQuotientMap`, an open mapping theorem, and supplying it is real work;
-everything downstream of it is the formal argument below, which uses nothing but injectivity of
-`RingHom.kerLift` and the universal property of the quotient topology.
+Over a Tate ring the quotient-map hypothesis is `TauCeti.Huber.IsTateRing.isQuotientMap`, an open
+mapping theorem.
 
 Note that closedness of `ker f` comes for free once `S` is `T1`, since a kernel is the preimage of
 a point; it is not a further hypothesis of the theorem but a consequence for its consumers, and
@@ -57,9 +55,8 @@ a point; it is not a further hypothesis of the theorem but a consequence for its
   automatically once `I` is known to be closed.
 * `Ideal.Quotient.continuous_lift`: a continuous ring homomorphism annihilating `I` induces a
   *continuous* homomorphism on `R ⧸ I`, with no hypothesis on `I`.
-* `RingHom.isOpenMap_kerLift`: the map `R ⧸ ker f →+* S` induced by `f` is open when `f` is a
-  quotient map.
-* `RingHom.isHomeomorph_kerLift`: it is a homeomorphism. `IsHomeomorph.homeomorph` bundles that as
+* `RingHom.isHomeomorph_kerLift`: the map `R ⧸ ker f →+* S` induced by `f` is a homeomorphism when
+  `f` is a quotient map. `IsHomeomorph.homeomorph` bundles that as
   `R ⧸ ker f ≃ₜ S`, and the map bundled is the ring homomorphism `RingHom.kerLift`, so the ring
   structure comes along with it and needs no transport of its own.
 
@@ -111,39 +108,26 @@ variable {R S : Type*} [TopologicalSpace R] [CommRing R] [TopologicalSpace S] [S
 
 namespace RingHom
 
-/-- **The lift of a quotient map to `R ⧸ ker f` is open.**
-
-Surjectivity of `f` is not enough on its own: it makes the lift a continuous bijection, and a
-continuous bijection is open only when the topology it lands in is no coarser than the one it
-carries. That `f` is a quotient map is exactly the statement that it is not coarser. -/
-theorem isOpenMap_kerLift (hq : IsQuotientMap (f : R → S)) : IsOpenMap (kerLift f) := by
-  intro U hU
-  -- `f` coinduces the topology of `S`, so it is enough to open the preimage; and that preimage is
-  -- `mk (ker f) ⁻¹' U`, because `RingHom.kerLift` is injective
-  rw [← hq.isCoinducing.isOpen_preimage]
-  have himg : ⇑f ⁻¹' (kerLift f '' U) = ⇑(Ideal.Quotient.mk (ker f)) ⁻¹' U := by
-    ext x
-    refine ⟨?_, fun hx ↦ ⟨_, hx, kerLift_mk f x⟩⟩
-    rintro ⟨u, hu, hux⟩
-    have hu' : u = Ideal.Quotient.mk (ker f) x :=
-      kerLift_injective f (hux.trans (kerLift_mk f x).symm)
-    exact Set.mem_preimage.mpr (hu' ▸ hu)
-  rw [himg]
-  exact hU.preimage continuous_coinduced_rng
-
 /-- **The topological first isomorphism theorem for rings.** A ring homomorphism that is a
 quotient map presents its target as the quotient of its source by its kernel, topologically as
 well as algebraically.
 
+A continuous surjection is not enough on its own. Surjectivity of `f` makes the lift bijective and
+continuity of `f` makes it continuous, but a continuous bijection is open only when the topology it
+lands in is no coarser than the one it carries; that `f` is a quotient map is exactly the statement
+that it is not coarser.
+
 `IsHomeomorph.homeomorph` turns this into `R ⧸ ker f ≃ₜ S`. What it bundles is `RingHom.kerLift`,
 which is a ring homomorphism, so a consumer needing the isomorphism of rings has it already —
 `RingHom.quotientKerEquivOfSurjective` is that same map. -/
-theorem isHomeomorph_kerLift (hq : IsQuotientMap (f : R → S)) : IsHomeomorph (kerLift f) where
-  continuous := Ideal.Quotient.continuous_lift (ker f) hq.continuous fun _ ↦ mem_ker.mp
-  isOpenMap := isOpenMap_kerLift hq
-  bijective := ⟨kerLift_injective f, fun y ↦
-    let ⟨x, hx⟩ := hq.surjective y
-    ⟨Ideal.Quotient.mk (ker f) x, (kerLift_mk f x).trans hx⟩⟩
+theorem isHomeomorph_kerLift (hq : IsQuotientMap (f : R → S)) : IsHomeomorph (kerLift f) := by
+  -- `f` factors as `kerLift f ∘ mk`, and `mk` coinduces, so the quotient-map hypothesis on `f`
+  -- transfers to `kerLift f`; injectivity then upgrades coinducing to open
+  have hcomp : ⇑(kerLift f) ∘ ⇑(Ideal.Quotient.mk (ker f)) = ⇑f := funext (kerLift_mk f)
+  have hmk : IsCoinducing ⇑(Ideal.Quotient.mk (ker f)) := ⟨rfl⟩
+  have hkl : IsQuotientMap ⇑(kerLift f) := .of_comp_of_isCoinducing (hcomp ▸ hq) hmk
+  exact ⟨hkl.continuous, hkl.isCoinducing.isOpenMap_of_injective (kerLift_injective f),
+    kerLift_injective f, hkl.surjective⟩
 
 end RingHom
 

--- a/TauCeti/Topology/Algebra/Ring/Ideal.lean
+++ b/TauCeti/Topology/Algebra/Ring/Ideal.lean
@@ -122,12 +122,11 @@ which is a ring homomorphism, so a consumer needing the isomorphism of rings has
 `RingHom.quotientKerEquivOfSurjective` is that same map. -/
 theorem isHomeomorph_kerLift (hq : IsQuotientMap (f : R → S)) : IsHomeomorph (kerLift f) := by
   -- `f` factors as `kerLift f ∘ mk`, and `mk` coinduces, so the quotient-map hypothesis on `f`
-  -- transfers to `kerLift f`; injectivity then upgrades coinducing to open
+  -- transfers to `kerLift f`; an injective quotient map is a homeomorphism
   have hcomp : ⇑(kerLift f) ∘ ⇑(Ideal.Quotient.mk (ker f)) = ⇑f := funext (kerLift_mk f)
   have hmk : IsCoinducing ⇑(Ideal.Quotient.mk (ker f)) := ⟨rfl⟩
   have hkl : IsQuotientMap ⇑(kerLift f) := .of_comp_of_isCoinducing (hcomp ▸ hq) hmk
-  exact ⟨hkl.continuous, hkl.isCoinducing.isOpenMap_of_injective (kerLift_injective f),
-    kerLift_injective f, hkl.surjective⟩
+  exact isHomeomorph_iff_isQuotientMap_injective.mpr ⟨hkl, kerLift_injective f⟩
 
 end RingHom
 

--- a/TauCeti/Topology/Algebra/Ring/Ideal.lean
+++ b/TauCeti/Topology/Algebra/Ring/Ideal.lean
@@ -41,10 +41,10 @@ continuous surjection can land on a strictly coarser topology than the quotient 
 bijection is continuous but need not be open. What closes the gap is exactly the hypothesis that
 `f` is a *quotient map*, and with it the algebraic isomorphism becomes a homeomorphism.
 
-The point of separating the two is that the quotient-map hypothesis is where the analysis lives.
-Over a Tate ring it is `TauCeti.Huber.IsTateRing.isQuotientMap`, an open mapping theorem, and
-supplying it is real work; everything downstream of it is the formal argument below, which uses
-nothing but injectivity of `RingHom.kerLift` and the universal property of the quotient topology.
+The quotient-map hypothesis is where the analysis lives. Over a Tate ring it is
+`TauCeti.Huber.IsTateRing.isQuotientMap`, an open mapping theorem, and supplying it is real work;
+everything downstream of it is the formal argument below, which uses nothing but injectivity of
+`RingHom.kerLift` and the universal property of the quotient topology.
 
 Note that closedness of `ker f` comes for free once `S` is `T1`, since a kernel is the preimage of
 a point; it is not a further hypothesis of the theorem but a consequence for its consumers, and
@@ -57,10 +57,11 @@ a point; it is not a further hypothesis of the theorem but a consequence for its
   automatically once `I` is known to be closed.
 * `Ideal.Quotient.continuous_lift`: a continuous ring homomorphism annihilating `I` induces a
   *continuous* homomorphism on `R ⧸ I`, with no hypothesis on `I`.
-* `RingHom.continuous_kerLift` and `RingHom.isOpenMap_kerLift`: the map `R ⧸ ker f →+* S` induced
-  by `f` is continuous when `f` is, and open when `f` is a quotient map.
-* `RingHom.quotientKerHomeomorph`: the two together, as a homeomorphism `R ⧸ ker f ≃ₜ S`. Its
-  underlying ring isomorphism is `RingHom.quotientKerEquivOfSurjective`.
+* `RingHom.isOpenMap_kerLift`: the map `R ⧸ ker f →+* S` induced by `f` is open when `f` is a
+  quotient map.
+* `RingHom.isHomeomorph_kerLift`: it is a homeomorphism. `IsHomeomorph.homeomorph` bundles that as
+  `R ⧸ ker f ≃ₜ S`, and the map bundled is the ring homomorphism `RingHom.kerLift`, so the ring
+  structure comes along with it and needs no transport of its own.
 
 ## References
 
@@ -105,29 +106,20 @@ section FirstIsomorphism
 
 open Topology
 
-variable {R S : Type*} [TopologicalSpace R] [CommRing R] [TopologicalSpace S] [Ring S]
+variable {R S : Type*} [TopologicalSpace R] [CommRing R] [TopologicalSpace S] [Semiring S]
   {f : R →+* S}
 
 namespace RingHom
 
-/-- **The lift of `f` to `R ⧸ ker f` is continuous.** This is `Ideal.Quotient.continuous_lift`
-for the canonical choice of ideal, spelled for `RingHom.kerLift` so that the first isomorphism
-theorem can be read topologically. -/
-theorem continuous_kerLift (hf : Continuous f) : Continuous (kerLift f) :=
-  Ideal.Quotient.continuous_lift (ker f) hf fun _ ↦ mem_ker.mp
-
 /-- **The lift of a quotient map to `R ⧸ ker f` is open.**
 
-Continuity of `f` alone cannot give this: it makes the lift a continuous bijection onto `S`, and a
+Surjectivity of `f` is not enough on its own: it makes the lift a continuous bijection, and a
 continuous bijection is open only when the topology it lands in is no coarser than the one it
-carries. That `f` is a quotient map is exactly the statement that it is not coarser.
-
-The proof is the set identity `f ⁻¹' (kerLift f '' U) = mk (ker f) ⁻¹' U`, which holds because
-`RingHom.kerLift` is injective, followed by the two halves of the quotient-map hypothesis: the
-right-hand side is open because `U` is, and openness transfers back across `f` because `f`
-coinduces the topology of `S`. -/
+carries. That `f` is a quotient map is exactly the statement that it is not coarser. -/
 theorem isOpenMap_kerLift (hq : IsQuotientMap (f : R → S)) : IsOpenMap (kerLift f) := by
   intro U hU
+  -- `f` coinduces the topology of `S`, so it is enough to open the preimage; and that preimage is
+  -- `mk (ker f) ⁻¹' U`, because `RingHom.kerLift` is injective
   rw [← hq.isCoinducing.isOpen_preimage]
   have himg : ⇑f ⁻¹' (kerLift f '' U) = ⇑(Ideal.Quotient.mk (ker f)) ⁻¹' U := by
     ext x
@@ -135,8 +127,7 @@ theorem isOpenMap_kerLift (hq : IsQuotientMap (f : R → S)) : IsOpenMap (kerLif
     rintro ⟨u, hu, hux⟩
     have hu' : u = Ideal.Quotient.mk (ker f) x :=
       kerLift_injective f (hux.trans (kerLift_mk f x).symm)
-    change Ideal.Quotient.mk (ker f) x ∈ U
-    exact hu' ▸ hu
+    exact Set.mem_preimage.mpr (hu' ▸ hu)
   rw [himg]
   exact hU.preimage continuous_coinduced_rng
 
@@ -144,24 +135,15 @@ theorem isOpenMap_kerLift (hq : IsQuotientMap (f : R → S)) : IsOpenMap (kerLif
 quotient map presents its target as the quotient of its source by its kernel, topologically as
 well as algebraically.
 
-The underlying map is `RingHom.kerLift`, so the ring structure is carried by
-`RingHom.quotientKerEquivOfSurjective` applied to `hq.surjective`, and this definition adds the
-topology to it. Mathlib has no type of continuous ring isomorphisms to bundle the two into, so a
-consumer needing both takes the ring isomorphism from there and its two continuities from here. -/
-@[expose]
-noncomputable def quotientKerHomeomorph (hq : IsQuotientMap (f : R → S)) : (R ⧸ ker f) ≃ₜ S :=
-  (quotientKerEquivOfSurjective hq.surjective).toEquiv.toHomeomorphOfContinuousOpen
-    (continuous_kerLift hq.continuous) (isOpenMap_kerLift hq)
-
-@[simp]
-theorem coe_quotientKerHomeomorph (hq : IsQuotientMap (f : R → S)) :
-    ⇑(quotientKerHomeomorph hq) = ⇑(quotientKerEquivOfSurjective hq.surjective) :=
-  rfl
-
-@[simp]
-theorem coe_quotientKerHomeomorph_symm (hq : IsQuotientMap (f : R → S)) :
-    ⇑(quotientKerHomeomorph hq).symm = ⇑(quotientKerEquivOfSurjective hq.surjective).symm :=
-  rfl
+`IsHomeomorph.homeomorph` turns this into `R ⧸ ker f ≃ₜ S`. What it bundles is `RingHom.kerLift`,
+which is a ring homomorphism, so a consumer needing the isomorphism of rings has it already —
+`RingHom.quotientKerEquivOfSurjective` is that same map. -/
+theorem isHomeomorph_kerLift (hq : IsQuotientMap (f : R → S)) : IsHomeomorph (kerLift f) where
+  continuous := Ideal.Quotient.continuous_lift (ker f) hq.continuous fun _ ↦ mem_ker.mp
+  isOpenMap := isOpenMap_kerLift hq
+  bijective := ⟨kerLift_injective f, fun y ↦
+    let ⟨x, hx⟩ := hq.surjective y
+    ⟨Ideal.Quotient.mk (ker f) x, (kerLift_mk f x).trans hx⟩⟩
 
 end RingHom
 


### PR DESCRIPTION
Adds the topological first isomorphism theorem for rings: when a ring homomorphism is a topological
quotient map, the algebraic identification `R ⧸ ker f ≃+* S` is a homeomorphism.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-4.1-topological-statements"}-->

## What is added

One theorem in `TauCeti/Topology/Algebra/Ring/Ideal.lean`, beside the `Ideal.Quotient` material
already there, and no new definitions:

* `RingHom.isHomeomorph_kerLift` — the induced `R ⧸ ker f →+* S` is a homeomorphism when `f` is a
  quotient map.

Mathlib has no type of continuous ring isomorphisms, and this deliberately does not invent one.
`IsHomeomorph` is a predicate on the map, so what `IsHomeomorph.homeomorph` bundles is
`RingHom.kerLift` itself — already a ring homomorphism, and the underlying map of Mathlib's
`RingHom.quotientKerEquivOfSurjective`. A consumer needing the topology and the ring structure
together gets both from the one statement, with no coercion lemmas to connect two objects.

Round 1 had a `quotientKerHomeomorph` definition instead, and two rubrics asked for incompatible
things about it: api-design wanted `@[expose]` removed while its two coercion simp lemmas stayed,
reuse wanted those lemmas deleted in favour of the generic
`Equiv.toHomeomorphOfContinuousOpen_apply`, "unfolding `quotientKerHomeomorph` where necessary".
Both cannot hold — without `@[expose]` nothing can see through the definition, and the suggested
`:= (rfl)` proofs are rejected by the module system for exactly that reason. Dropping the
definition removes what they disagreed about, and is the better shape anyway.

## Why the quotient-map hypothesis, and not surjectivity

`R ⧸ ker f` carries the quotient topology. A continuous surjection can land on a strictly coarser
topology than that, so the algebraic bijection is continuous but need not be open — surjectivity
alone gives no homeomorphism. Being a quotient map is exactly the missing statement, and the proof
uses nothing else: `f` factors as `kerLift f ∘ mk`, `mk` coinduces, so
`IsQuotientMap.of_comp_of_isCoinducing` transfers the hypothesis to `kerLift f`, and
`isHomeomorph_iff_isQuotientMap_injective` turns that plus `RingHom.kerLift_injective` into the
conclusion. Every step is a Mathlib lemma; nothing about quotient topologies is re-derived here.

## Which roadmap item uses this

`AdicSpaces/README.md`, Layer 4.1, whose algebraic chain (Remark 8.29, Lemma 8.31, Proposition
8.30, Corollary 8.32, Lemma 8.33) is followed by:

> Prove the additional topological statements separately. The rings and modules in the argument are
> complete, Hausdorff, and metrisable; use Layer 0's open mapping theorem to show that the relevant
> images are closed and that the algebraic quotient topology agrees with the topology on the target.

This is the second of those two, in the ring form that Wedhorn's Example 6.38 presentation needs.
Concretely, Proposition 8.30 goes through presenting `A⟨T ∪ {t}/s⟩` as a quotient of the restricted
series ring `A⟨T/s⟩⟨X⟩` by `(t/s - X)`. Getting a *topological* presentation that way would
otherwise need the ideal to be proved closed and the quotient complete; with this theorem the
surjection itself supplies both, since the kernel of a continuous map into a `T1` ring is closed and
the quotient topology is the target's own.

Note on ordering: the scope rubric has previously read Layer 4.1's "in the following order" as
gating work on steps 3-5. It does not gate this PR — the roadmap puts the topological statements
outside that chain and asks for them *separately*.

The quotient-map hypothesis is dischargeable today. `TauCeti.Huber.IsTateRing.isQuotientMap`
(`TauCeti/RingTheory/Huber/OpenMapping.lean`) is Layer 0's open mapping theorem in the required
form, and it composes directly: for a surjective `f : C →ₐ[A] N` continuous at zero between
complete metrisable topological `A`-algebras over a Tate ring `A`,

```lean
IsHomeomorph.homeomorph _
    (RingHom.isHomeomorph_kerLift (IsTateRing.isQuotientMap f.toLinearMap hf hfc)) :
  (C ⧸ RingHom.ker (f : C →+* N)) ≃ₜ N
```

typechecks with no glue. That composition is not shipped here: it is two lines over a long instance
preamble, and it belongs with the consumer that needs it rather than in a topology file that cannot
import Huber. It is `IsTateRing.isQuotientMap`'s first use.

## Placement

The new material goes in the existing `TauCeti/Topology/Algebra/Ring/Ideal.lean` rather than a new
file: it is about `R ⧸ I` for a topological ring, `Ideal.Quotient.continuous_lift` there is the
unbundled half of `RingHom.continuous_kerLift`, and the file was 78 lines. Its module docstring is
retitled and gains a section for the new topic; the existing hypothesis discussion is scoped to the
separation results it was about.

## Hypotheses

`[TopologicalSpace R] [CommRing R] [TopologicalSpace S] [Semiring S]` and nothing else — no
`IsTopologicalRing`, no separation, no completeness. The `CommRing` is what `R ⧸ I` is stated over
in Mathlib; the target needs only a semiring structure, which is what `RingHom.kerLift` is stated
over. The topology enters only through the quotient topology being coinduced.

## Provenance

None: nothing is adapted. The source sweep (AINTLIB @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
queries `kerLift`, `quotientKerEquiv`, `Homeomorph`, `QuotientMap`, `coinduced`) found the
*additive-group* case written inline inside a declaration that carries a `sorry` in another
conjunct (`BanachOMT.lean`), and `Wedhorn828.lean` using `RingHom.kerLift` for Example 6.38 with no
topological first isomorphism theorem. Neither was used. In Mathlib, the strict-map material
(`Topology.isStrictMap_iff_isHomeomorph_quotientKerEquivRange`,
`LinearMap.isStrictMap_iff_isHomeomorph_quotKerEquivRange`) covers setoid, group and module
quotients; the ring case with `R ⧸ ker f` an `Ideal` quotient is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1



