### PR TITLE
refactor: remove nine unused private declarations, and one they kept alive

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Base.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Base.lean
@@ -321,12 +321,6 @@ private theorem diagonalRootIndexOfNe_snd {n : ℕ} (i j : Fin n) (hij : i ≠ j
     (diagonalRootIndexOfNe i j hij).1.2 = ULift.up j := by
   rfl
 
-private theorem diagonalRootIndexOfNe_eq_diagonalSimpleRootIndex (n : ℕ) (i : Fin n) :
-    diagonalRootIndexOfNe i.castSucc i.succ i.castSucc_lt_succ.ne =
-      diagonalSimpleRootIndex n i := by
-  apply Subtype.ext
-  apply Prod.ext <;> simp
-
 private theorem diagonalRootIndexOfNe_isPos_of_lt (n : ℕ) (i j : Fin (n + 1))
     (hij : i < j) :
     (diagonalRootBase.{u} n).IsPos (diagonalRootIndexOfNe i j hij.ne) := by

--- a/TauCeti/Algebra/Lie/HighestWeight/Irreducible.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Irreducible.lean
@@ -182,18 +182,6 @@ private theorem prodComm_mem_lieSpan_diagonal
   rw [map_lieSpan_diagonal_prodComm] at hmap
   simpa using hmap
 
-omit [CharZero K] [LieAlgebra K L] [IsKilling K L] [FiniteDimensional K L]
-  [LieModule K L M] [LieModule K L N] in
-private theorem diagonalComapInr_eq_diagonalComapInl_swap :
-    diagonalComapInr K L v w = diagonalComapInl K L w v := by
-  ext n
-  rw [mem_diagonalComapInr, mem_diagonalComapInl]
-  constructor
-  · intro hn
-    simpa using prodComm_mem_lieSpan_diagonal hn
-  · intro hn
-    simpa using prodComm_mem_lieSpan_diagonal (M := N) (N := M) hn
-
 omit [CharZero K] [LieAlgebra K L] [IsKilling K L] [FiniteDimensional K L] [LieModule K L M]
   [LieModule K L N] in
 /-- If the diagonal submodule contains both factors whole, it is everything. -/
@@ -237,13 +225,6 @@ private theorem diagonalComapInr_eq_bot [LieModule.IsIrreducible K L M]
   refine (IsSimpleOrder.eq_bot_or_eq_top _).resolve_right fun hr => ?_
   exact lieSpan_diagonal_ne_top hv hw (lieSpan_diagonal_eq_top_of_eq_top
     (diagonalComapInl_eq_top_of_diagonalComapInr_eq_top hv.ne_zero hr) hr)
-
-/-- **The diagonal submodule meets the first factor trivially.** -/
-private theorem diagonalComapInl_eq_bot [LieModule.IsIrreducible K L M]
-    [LieModule.IsIrreducible K L N] (hv : IsHighestWeightVector b lam v)
-    (hw : IsHighestWeightVector b lam w) : diagonalComapInl K L v w = ⊥ := by
-  have h := diagonalComapInr_eq_bot (M := N) (N := M) hw hv
-  rwa [diagonalComapInr_eq_diagonalComapInl_swap] at h
 
 /-! ### The diagonal submodule is the graph of an isomorphism -/
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
@@ -87,13 +87,6 @@ private theorem pullbackSpecBaseChangeIso_inv_snd (H : CommHopfAlgCat.{u} R) :
         (Algebra.TensorProduct.includeLeftRingHom : S →+* S ⊗[R] H)) := by
   simp [pullbackSpecBaseChangeIso]
 
-private theorem hopfSpec_map_left {T : Type u} [CommRing T]
-    {H K : CommHopfAlgCat.{u} T} (f : H ⟶ K) :
-    ((hopfSpec (CommRingCat.of T)).map f.op).hom.hom.left =
-      Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom) := by
-  -- `hopfSpec.map` is built by lifting this `Spec.map`; no separate projection lemma is exposed.
-  rfl
-
 private theorem pullbackSpecIso'_natural {H K : CommHopfAlgCat.{u} R}
     (f : H ⟶ K) :
     (pullbackSpecBaseChangeIso (R := R) (S := S) K).inv ≫

--- a/TauCeti/Analysis/Semigroups/Generation/LimitSemigroup.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/LimitSemigroup.lean
@@ -472,13 +472,6 @@ theorem continuousOn_yosidaLimit (hA : IsMDissipative A) (hdense : Dense (A.doma
   continuousOn_Ici_of_forall_continuousOn_Icc fun _T hT =>
     hA.continuousOn_yosidaLimit_Icc hdense x hT
 
-/-- Strong continuity at time `0` of the Yosida limit, in the nonnegative-time parametrisation
-used by `StronglyContinuousSemigroup`. -/
-private theorem continuousAt_yosidaLimit_zero (hA : IsMDissipative A)
-    (hdense : Dense (A.domain : Set X)) (x : X) :
-    ContinuousAt (fun t : ℝ≥0 => yosidaLimit A t x) 0 :=
-  continuousAt_nnreal_zero_of_continuousOn_Ici (hA.continuousOn_yosidaLimit hdense x)
-
 /-! ## The contraction semigroup -/
 
 /-- **The contraction semigroup produced by the Yosida construction.** For a densely defined

--- a/TauCeti/Combinatorics/DenseGraphLimits/Applications.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Applications.lean
@@ -94,31 +94,6 @@ private theorem integral_graphonDegree_sq_ge (W : Graphon Ω μ) :
   simp only [Pi.pow_apply] at h
   linarith
 
-private theorem integrable_triple_graphon_product (W : Graphon Ω μ) :
-    Integrable (fun p : Ω × Ω × Ω =>
-      W p.1 p.2.1 * (1 - W p.1 p.2.2) * (1 - W p.2.1 p.2.2)) (μ.prod (μ.prod μ)) := by
-  apply (integrable_const (1 : ℝ)).mono
-    (by
-      have hxy : Measurable (fun p : Ω × Ω × Ω => W p.1 p.2.1) :=
-        W.measurable.comp (measurable_fst.prodMk (measurable_fst.comp measurable_snd))
-      have hxz : Measurable (fun p : Ω × Ω × Ω => W p.1 p.2.2) :=
-        W.measurable.comp (measurable_fst.prodMk (measurable_snd.comp measurable_snd))
-      have hyz : Measurable (fun p : Ω × Ω × Ω => W p.2.1 p.2.2) :=
-        W.measurable.comp (measurable_fst.comp measurable_snd |>.prodMk
-          (measurable_snd.comp measurable_snd))
-      exact (hxy.mul ((measurable_const.sub hxz))).mul (measurable_const.sub hyz)
-        |>.aestronglyMeasurable)
-  filter_upwards [] with p
-  have h₁ : 0 ≤ W p.1 p.2.1 := W.nonneg _ _
-  have h₂ : W p.1 p.2.1 ≤ 1 := W.le_one _ _
-  have h₃ : 0 ≤ 1 - W p.1 p.2.2 := sub_nonneg.mpr (W.le_one _ _)
-  have h₄ : 1 - W p.1 p.2.2 ≤ 1 := by linarith [W.nonneg p.1 p.2.2]
-  have h₅ : 0 ≤ 1 - W p.2.1 p.2.2 := sub_nonneg.mpr (W.le_one _ _)
-  have h₆ : 1 - W p.2.1 p.2.2 ≤ 1 := by linarith [W.nonneg p.2.1 p.2.2]
-  rw [Real.norm_eq_abs, abs_of_nonneg (mul_nonneg (mul_nonneg h₁ h₃) h₅), norm_one]
-  exact (mul_le_mul (mul_le_mul h₂ h₄ h₃ (by norm_num)) h₆ h₅ (by norm_num)).trans_eq
-    (by ring)
-
 private theorem integrable_triple_graphon_edge (W : Graphon Ω μ) :
     Integrable (fun p : Ω × Ω × Ω => W p.1 p.2.1) (μ.prod (μ.prod μ)) := by
   have hm : Measurable (fun p : Ω × Ω × Ω => W p.1 p.2.1) :=

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Metric.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Metric.lean
@@ -142,18 +142,6 @@ private lemma HasMetricProductRuleWithinAt.add_left
   ring
 
 omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
-/-- The product rule is additive in its second field. -/
-private lemma HasMetricProductRuleWithinAt.add_right
-    {V W W' : ∀ r, TangentSpace I (γ r)}
-    (hW : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V W)
-    (hW' : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V W')
-    (hcoordW : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ W (γ t)) s t)
-    (hcoordW' : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ W' (γ t)) s t) :
-    HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V
-      (fun r ↦ W r + W' r) :=
-  (hW.symm.add_left hW'.symm hcoordW hcoordW').symm
-
-omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
 /-- The product rule is preserved by multiplying its first field by a differentiable scalar. -/
 private lemma HasMetricProductRuleWithinAt.smul_left
     {V W : ∀ r, TangentSpace I (γ r)} {f : ℝ → ℝ}

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -68,14 +68,6 @@ private theorem two_smul_contractLeft_associated [Invertible (2 : R)]
       rw [hpolar', Algebra.smul_def, ← ι_mul_ι_add_swap]
       noncomm_ring
 
-private theorem contractLeft_associated_eq_zero_of_commute_of_mem_even
-    [Invertible (2 : R)] (Q : QuadraticForm R M) {x : CliffordAlgebra Q}
-    (hx_even : x ∈ even Q) (hx_comm : ∀ v : M, Commute x (ι Q v)) (v : M) :
-    contractLeft (Q.associated v) x = 0 := by
-  apply (isUnit_of_invertible (2 : R)).smul_eq_zero.mp
-  rw [two_smul_contractLeft_associated Q, involute_eq_of_mem_even hx_even,
-    (hx_comm v).eq, sub_self]
-
 section Exterior
 
 private noncomputable def exteriorCoordProj {n : ℕ}

--- a/TauCeti/RepresentationTheory/InvariantForm/RealStructure.lean
+++ b/TauCeti/RepresentationTheory/InvariantForm/RealStructure.lean
@@ -366,14 +366,6 @@ private theorem isSymm_balance {H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ} (hH : H.
 private theorem conj_eq_self_of_nonneg {z : ℂ} (hz : 0 ≤ z) : (starRingEnd ℂ) z = z :=
   Complex.conj_eq_iff_im.mpr (Complex.nonneg_iff.mp hz).2.symm
 
-/-- The balanced form is nonnegative if `H` is: both summands are, the second because conjugation
-fixes a nonnegative complex number. -/
-private theorem isNonneg_balance {H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ} (hH : H.IsNonneg)
-    (K : V →ₛₗ[starRingEnd ℂ] V) : (balance H K).IsNonneg where
-  nonneg x := by
-    rw [balance_apply, conj_eq_self_of_nonneg (hH.nonneg (K x))]
-    exact add_nonneg (hH.nonneg x) (hH.nonneg (K x))
-
 /-- The balanced form is definite off the origin if `H` is: the first summand is already nonzero
 and the second is nonnegative. -/
 private theorem balance_apply_self_ne_zero {H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ} (hH : H.IsNonneg)

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Basis.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Basis.lean
@@ -80,8 +80,6 @@ private noncomputable def volumeLoop (i : V) :
 private noncomputable def volumePath (i : V) : Quiver.TotalPath (DoubledQuiver G) :=
   ⟨vertex G i, vertex G i, volumeLoop G i⟩
 
-private theorem volumePath_fst (i : V) : (volumePath G i).1 = vertex G i := (rfl)
-
 private theorem length_volumeLoop {i j : V} (h : G.Adj i j) : (volumeLoop G i).length = 2 := by
   rw [volumeLoop, dite_eq_left (⟨j, h⟩ : ∃ j, G.Adj i j)]
   exact length_backtrackPath G _


### PR DESCRIPTION
Nine `private` declarations that nothing references, plus a tenth that only they kept alive.

A `private` declaration is invisible outside its own file, so this is checkable one file at a time: each of these occurs exactly once in its file — its own declaration — and is therefore unreachable from anywhere.

| file | declaration |
|---|---|
| `Analysis/Semigroups/Generation/LimitSemigroup.lean` | `continuousAt_yosidaLimit_zero` |
| `AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean` | `hopfSpec_map_left` |
| `RepresentationTheory/Quiver/Zigzag/Basis.lean` | `volumePath_fst` |
| `RepresentationTheory/InvariantForm/RealStructure.lean` | `isNonneg_balance` |
| `Combinatorics/DenseGraphLimits/Applications.lean` | `integrable_triple_graphon_product` |
| `LinearAlgebra/CliffordAlgebra/Basic.lean` | `contractLeft_associated_eq_zero_of_commute_of_mem_even` |
| `Geometry/Manifold/.../AlongCurve/Metric.lean` | `HasMetricProductRuleWithinAt.add_right` |
| `Algebra/AlgebraicGroup/GeneralLinear/Root/Base.lean` | `diagonalRootIndexOfNe_eq_diagonalSimpleRootIndex` |
| `Algebra/Lie/HighestWeight/Irreducible.lean` | `diagonalComapInl_eq_bot` |

**Transitively dead**: `Irreducible.lean`'s `diagonalComapInr_eq_diagonalComapInl_swap` was used only by `diagonalComapInl_eq_bot` (`rwa [diagonalComapInr_eq_diagonalComapInl_swap] at h`). Removing the latter leaves it dead, so it goes in the same PR rather than being left behind as newly-dead code. Re-running the scan on the post-deletion tree reaches a fixpoint here — nothing further becomes unreferenced.

94 deletions, no other change. Where a declaration carried its own `omit … in` modifier — including a two-line one — that modifier goes with it; the following declaration's is untouched.

## How "unreferenced" was established

A scan over all **9,104** `private` declarations. Three ways a declaration is used without its name appearing were excluded first, each found by checking a suspicious result rather than assuming:

- **attribute-registered** (291 skipped): `@[simp]`, `@[ext]`, `@[aesop]` … enter a declaration into a discrimination tree; tactics consume it without naming it.
- **dot notation** (73 skipped): `private theorem IsCosetSelection.exists_lt` is invoked as `hm.exists_lt hhK hh1`, and a `private lemma foo` inside a namespace as `W.foo`. The declared spelling appears nowhere in either case.
- **bare leaf under `open`**: `private def ReducedTensorWords.gradedCoderivSummand` is used bare four times in a file carrying `open ReducedTensorWords`.

## What was deliberately left alone

Some unreferenced `private` declarations are not dead — they exist to be *elaborated*, and deleting them would delete the fact they record:

- `MeasureTheory/Measure/UnitIntervalMap.lean` — three instances under `### Regressions: the atomic cases`, which the file says "fail for any formulation that quietly assumes `μ` has no atoms".
- `Probability/Kernel/Disintegration/Countable.lean` — two under `### Regressions`: uniqueness fails at a null atom, and `IsFiniteMeasure σ` cannot be dropped.
- `NumberTheory/Multiquadratic/SquareClass/Rational.lean` — a worked example, `[ℚ(√(8/9), √(3/4)) : ℚ] = 4`.
- `MeasureTheory/Measure/MapRestrictDensity.lean` — records that the density genuinely takes fractional values.
- `RingTheory/Polynomial/SymmetricPower.lean` — a four-lemma `_apply`/`_symm_apply` family; two members are unused but complete a deliberate symmetric API.
- `Analysis/PDE/EnergyForm/Sobolev.lean` — `jetField_add_ae`. `jetField` is public and **all three** of its linearity laws are private, so deleting the additive one narrows what is available about a public definition rather than removing something inert.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp