### PR TITLE
feat(ModularForms): a cusp form with a periodic level-`l` descent is old

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.ConductorDichotomy
+public import TauCeti.NumberTheory.ModularForms.Newforms.Basic
+
+/-!
+# A form with a periodic level-`l` descent is old
+
+`ConductorDichotomy.lean` proves Miyake's Theorem 4.6.4: if `l ∣ N`, if `f : ℍ → ℂ` is invariant
+under the weight-`k` slash action of `T`, and if the level-raise `l ^ (1 - k) • (f ∣[k] diag(l, 1))`
+is a cusp form lying in the nebentypus space `S_k(N, χ)`, then *either* `χ` factors through `N / l`
+and `f` is itself a cusp form of level `Γ₁(N / l)`, *or* `f` is identically zero.
+
+Both horns say the same thing about the level-`N` form: it is old. On the first horn it is the
+level-raise `V_l F` of a genuine cusp form of the proper divisor level `N / l`, and on the second
+it is `0`. This file draws that conclusion, which is the step the Atkin–Lehner main lemma takes
+after the dichotomy.
+
+## Why `l ≠ 1` is the only arithmetic hypothesis
+
+`TauCeti.cuspFormsOld` is spanned by the level-raises from **proper** divisor levels, so what the
+argument needs from `l` is exactly that `N / l` is a proper divisor of `N` — that is, `l ≠ 1`,
+which with `[NeZero l]` is `1 < l`. Nothing here asks `l` to be prime, and the descent itself is
+supplied by the caller, so no hypothesis about the `q`-expansion of `f` appears.
+
+## Main results
+
+* `TauCeti.mem_cuspFormsOld_of_slash_T_eq`: a cusp form of level `Γ₁(N)` with a nebentypus,
+  whose level-`l` descent is invariant under the weight-`k` slash action of `T`, is old.
+
+## Provenance
+
+Adapted from [AINTLIB](https://github.com/CBirkbeck/AINTLIB) (Chris Birkbeck, Apache-2.0) at
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
+`projects/LeanModularForms/LeanModularForms/Eigenforms/AtkinLehner.lean` — the case split of
+`qSupportedOnDvd_mem_cuspFormsOld_of_char` (lines 169-192) together with its private helpers
+`cuspForm_coe_eq_of_cast` and `isOldformGenerator_of_funeq`. Those two helpers are not ported:
+they exist to move a `d * (N / d) = N` cast through `DFunLike.coe` and to repackage the result as
+the source's `IsOldformGenerator`, and this repository's `TauCeti.cuspFormsOld` is indexed by the
+divisibility `d * M ∣ N` rather than by an equation, so no cast arises and the introduction rule
+`TauCeti.mem_cuspFormsOld_of_coe_eq_smul_slash_scaleGL` applies directly. The source's remaining
+input, its `q`-expansion support hypothesis, is deliberately absent here: what the argument
+consumes is the descent, and this statement takes it as a hypothesis.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005],
+  Section 5.6.
+* Miyake, *Modular forms*, Section 4.6 (Theorem 4.6.4 is the dichotomy consumed here).
+-/
+
+public section
+
+open Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup
+
+open scoped MatrixGroups ModularForm
+
+namespace TauCeti
+
+variable {N : ℕ} [NeZero N] {k : ℤ}
+
+/-- **A cusp form with a `T`-periodic level-`l` descent is old.** If `f ∈ S_k(N, χ)` is the
+level-raise `l ^ (1 - k) • (φ ∣[k] diag(l, 1))` of a function `φ : ℍ → ℂ` invariant under the
+weight-`k` slash action of `T`, and `l` is a divisor of `N` other than `1`, then `f` lies in the
+old subspace `S_k(Γ₁(N))ᵒˡᵈ`.
+
+This is the level-lowering dichotomy `TauCeti.exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero`
+read for its common conclusion: on the descent horn `φ` is a cusp form of level `Γ₁(N / l)` and
+`f` is its level-raise, and on the vanishing horn `φ = 0` forces `f = 0`. Both are old. -/
+theorem mem_cuspFormsOld_of_slash_T_eq {l : ℕ} [NeZero l] (hl : l ≠ 1) (hlN : l ∣ N)
+    (χ : DirichletCharacter ℂ N) (φ : ℍ → ℂ) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hfχ : f ∈ cuspFormCharSpace k χ.toUnitHom)
+    (hf : ⇑f = (l : ℂ) ^ (1 - k) • (φ ∣[k] scaleGL l))
+    (hT : φ ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = φ) :
+    f ∈ cuspFormsOld N k := by
+  have hl0 : l ≠ 0 := NeZero.ne l
+  have hdvd : l * (N / l) ∣ N := (Nat.mul_div_cancel' hlN).dvd
+  have hM : N / l ≠ N := Nat.ne_of_lt (Nat.div_lt_self (NeZero.pos N) (by omega))
+  rcases exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero hlN k χ φ f hfχ hf hT with
+    ⟨_, F, _, hF⟩ | hφ
+  · exact mem_cuspFormsOld_of_coe_eq_smul_slash_scaleGL hdvd hM (by rw [hf, hF])
+  · have hf0 : f = 0 := DFunLike.coe_injective <| by
+      rw [hf, hφ, SlashAction.zero_slash, smul_zero, FunLike.coe_zero]
+    exact hf0 ▸ (cuspFormsOld N k).zero_mem
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
@@ -11,41 +11,34 @@ public import TauCeti.NumberTheory.ModularForms.Newforms.Basic
 /-!
 # A form with a periodic level-`l` descent is old
 
-`ConductorDichotomy.lean` proves Miyake's Theorem 4.6.4: if `l ∣ N`, if `f : ℍ → ℂ` is invariant
-under the weight-`k` slash action of `T`, and if the level-raise `l ^ (1 - k) • (f ∣[k] diag(l, 1))`
-is a cusp form lying in the nebentypus space `S_k(N, χ)`, then *either* `χ` factors through `N / l`
-and `f` is itself a cusp form of level `Γ₁(N / l)`, *or* `f` is identically zero.
+Let `l` be a divisor of `N` other than `1`, and let `φ : ℍ → ℂ` be invariant under the weight-`k`
+slash action of `T`. If the level-raise `l ^ (1 - k) • (φ ∣[k] diag(l, 1))` is a cusp form `f` of
+level `Γ₁(N)` lying in the nebentypus space `S_k(N, χ)`, then `f` is old.
 
-Both horns say the same thing about the level-`N` form: it is old. On the first horn it is the
-level-raise `V_l F` of a genuine cusp form of the proper divisor level `N / l`, and on the second
-it is `0`. This file draws that conclusion, which is the step the Atkin–Lehner main lemma takes
-after the dichotomy.
+`ConductorDichotomy.lean` proves Miyake's Theorem 4.6.4 under exactly those hypotheses: *either*
+`χ` factors through `N / l` and `φ` is itself a cusp form of level `Γ₁(N / l)`, *or* `φ` is
+identically zero. Both horns say the same thing about `f`. On the first it is the level-raise
+`V_l F` of a genuine cusp form of the proper divisor level `N / l`; on the second it is `0`; and
+`TauCeti.cuspFormsOld` contains both.
 
 ## Why `l ≠ 1` is the only arithmetic hypothesis
 
 `TauCeti.cuspFormsOld` is spanned by the level-raises from **proper** divisor levels, so what the
-argument needs from `l` is exactly that `N / l` is a proper divisor of `N` — that is, `l ≠ 1`,
-which with `[NeZero l]` is `1 < l`. Nothing here asks `l` to be prime, and the descent itself is
-supplied by the caller, so no hypothesis about the `q`-expansion of `f` appears.
+argument needs of `l` is exactly that `N / l` be a proper divisor of `N` — that is, `l ≠ 1`, which
+together with `l ∣ N` and `N ≠ 0` gives `N / l < N`. Nothing here asks `l` to be prime, and the
+descent `φ` is supplied by the caller, so no hypothesis on the `q`-expansion of `f` appears.
 
 ## Main results
 
-* `TauCeti.mem_cuspFormsOld_of_slash_T_eq`: a cusp form of level `Γ₁(N)` with a nebentypus,
-  whose level-`l` descent is invariant under the weight-`k` slash action of `T`, is old.
+* `TauCeti.mem_cuspFormsOld_of_slash_T_eq`: a cusp form of level `Γ₁(N)` with a nebentypus, whose
+  level-`l` descent is invariant under the weight-`k` slash action of `T`, is old.
 
 ## Provenance
 
 Adapted from [AINTLIB](https://github.com/CBirkbeck/AINTLIB) (Chris Birkbeck, Apache-2.0) at
 commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
 `projects/LeanModularForms/LeanModularForms/Eigenforms/AtkinLehner.lean` — the case split of
-`qSupportedOnDvd_mem_cuspFormsOld_of_char` (lines 169-192) together with its private helpers
-`cuspForm_coe_eq_of_cast` and `isOldformGenerator_of_funeq`. Those two helpers are not ported:
-they exist to move a `d * (N / d) = N` cast through `DFunLike.coe` and to repackage the result as
-the source's `IsOldformGenerator`, and this repository's `TauCeti.cuspFormsOld` is indexed by the
-divisibility `d * M ∣ N` rather than by an equation, so no cast arises and the introduction rule
-`TauCeti.mem_cuspFormsOld_of_coe_eq_smul_slash_scaleGL` applies directly. The source's remaining
-input, its `q`-expansion support hypothesis, is deliberately absent here: what the argument
-consumes is the descent, and this statement takes it as a hypothesis.
+`qSupportedOnDvd_mem_cuspFormsOld_of_char` (lines 169-192).
 
 ## References
 
@@ -72,18 +65,24 @@ old subspace `S_k(Γ₁(N))ᵒˡᵈ`.
 This is the level-lowering dichotomy `TauCeti.exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero`
 read for its common conclusion: on the descent horn `φ` is a cusp form of level `Γ₁(N / l)` and
 `f` is its level-raise, and on the vanishing horn `φ = 0` forces `f = 0`. Both are old. -/
-theorem mem_cuspFormsOld_of_slash_T_eq {l : ℕ} [NeZero l] (hl : l ≠ 1) (hlN : l ∣ N)
+theorem mem_cuspFormsOld_of_slash_T_eq {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
     (χ : DirichletCharacter ℂ N) (φ : ℍ → ℂ) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
     (hfχ : f ∈ cuspFormCharSpace k χ.toUnitHom)
-    (hf : ⇑f = (l : ℂ) ^ (1 - k) • (φ ∣[k] scaleGL l))
+    (hf : haveI : NeZero l := NeZero.of_dvd hlN
+      ⇑f = (l : ℂ) ^ (1 - k) • (φ ∣[k] scaleGL l))
     (hT : φ ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = φ) :
     f ∈ cuspFormsOld N k := by
-  have hl0 : l ≠ 0 := NeZero.ne l
+  have : NeZero l := NeZero.of_dvd hlN
   have hdvd : l * (N / l) ∣ N := (Nat.mul_div_cancel' hlN).dvd
-  have hM : N / l ≠ N := Nat.ne_of_lt (Nat.div_lt_self (NeZero.pos N) (by omega))
+  have hM : N / l ≠ N :=
+    Nat.ne_of_lt (Nat.div_lt_self (NeZero.pos N) (by have := NeZero.ne l; omega))
   rcases exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero hlN k χ φ f hfχ hf hT with
     ⟨_, F, _, hF⟩ | hφ
-  · exact mem_cuspFormsOld_of_coe_eq_smul_slash_scaleGL hdvd hM (by rw [hf, hF])
+  · -- `f` and the level-raise of `F` have the same underlying function, and coercion is injective
+    have hcoe : ⇑f = ⇑(CuspForm.levelRaise l (Gamma1_map_le_conjAct_scaleGL_of_dvd hdvd) F) := by
+      rw [CuspForm.coe_levelRaise, hF, hf]
+    rw [DFunLike.coe_injective hcoe]
+    exact levelRaise_mem_cuspFormsOld hdvd hM k F
   · have hf0 : f = 0 := DFunLike.coe_injective <| by
       rw [hf, hφ, SlashAction.zero_slash, smul_zero, FunLike.coe_zero]
     exact hf0 ▸ (cuspFormsOld N k).zero_mem

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
@@ -48,8 +48,6 @@ subspace is still missing.
 
 * `TauCeti.levelRaise_mem_cuspFormsOld` and `TauCeti.cuspFormsOld_le`: the introduction and
   elimination rules for the old subspace.
-* `TauCeti.mem_cuspFormsOld_of_coe_eq_smul_slash_scaleGL`: the introduction rule stated on the
-  underlying function, for callers holding the level-raise as an equation on `ℍ`.
 * `TauCeti.levelRaise_mem_cuspFormsOldMultiples` and `TauCeti.cuspFormsOldMultiples_le`: the
   introduction and elimination rules for the refined old subspace.
 * `TauCeti.cuspFormsOldMultiples_le_cuspFormsOld` and
@@ -119,25 +117,6 @@ theorem levelRaise_mem_cuspFormsOld [NeZero N] (h : d * M ∣ N) (hM : M ≠ N)
   let _ := NeZero.of_dvd (dvd_of_mul_right_dvd h)
   Submodule.mem_iSup_of_mem M (Submodule.mem_iSup_of_mem d
     (Submodule.mem_iSup_of_mem ⟨h, hM⟩ ⟨f, CuspForm.levelRaiseₗ_apply d _ f⟩))
-
-/-- **The introduction rule read off the underlying function.** A cusp form of level `N` whose
-underlying function is `d ^ (1 - k) • (g ∣[k] diag(d, 1))` for a cusp form `g` of a proper divisor
-level `M` is old.
-
-This is `levelRaise_mem_cuspFormsOld` with the level-raise recognised through
-`TauCeti.CuspForm.coe_levelRaise` rather than named. A caller that obtained the identity as an
-equation of functions on `ℍ` — the level-lowering dichotomy
-`TauCeti.exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero` is the example — has no
-`TauCeti.CuspForm.levelRaise` term to point at, and coercion is injective, so producing one is
-exactly this lemma. -/
-theorem mem_cuspFormsOld_of_coe_eq_smul_slash_scaleGL [NeZero N] [NeZero d] (h : d * M ∣ N)
-    (hM : M ≠ N) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
-    {g : CuspForm ((Gamma1 M).map (mapGL ℝ)) k}
-    (hfg : ⇑f = (d : ℂ) ^ (1 - k) • ((⇑g : ℍ → ℂ) ∣[k] scaleGL d)) :
-    f ∈ cuspFormsOld N k := by
-  rw [DFunLike.coe_injective (hfg.trans
-    (CuspForm.coe_levelRaise (Gamma1_map_le_conjAct_scaleGL_of_dvd h) g).symm)]
-  exact levelRaise_mem_cuspFormsOld h hM k g
 
 /-- **Elimination rule for the old subspace**: a subspace containing every level-raise from a
 proper divisor level contains the whole old subspace. -/

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
@@ -48,6 +48,8 @@ subspace is still missing.
 
 * `TauCeti.levelRaise_mem_cuspFormsOld` and `TauCeti.cuspFormsOld_le`: the introduction and
   elimination rules for the old subspace.
+* `TauCeti.mem_cuspFormsOld_of_coe_eq_smul_slash_scaleGL`: the introduction rule stated on the
+  underlying function, for callers holding the level-raise as an equation on `ℍ`.
 * `TauCeti.levelRaise_mem_cuspFormsOldMultiples` and `TauCeti.cuspFormsOldMultiples_le`: the
   introduction and elimination rules for the refined old subspace.
 * `TauCeti.cuspFormsOldMultiples_le_cuspFormsOld` and
@@ -117,6 +119,25 @@ theorem levelRaise_mem_cuspFormsOld [NeZero N] (h : d * M ∣ N) (hM : M ≠ N)
   let _ := NeZero.of_dvd (dvd_of_mul_right_dvd h)
   Submodule.mem_iSup_of_mem M (Submodule.mem_iSup_of_mem d
     (Submodule.mem_iSup_of_mem ⟨h, hM⟩ ⟨f, CuspForm.levelRaiseₗ_apply d _ f⟩))
+
+/-- **The introduction rule read off the underlying function.** A cusp form of level `N` whose
+underlying function is `d ^ (1 - k) • (g ∣[k] diag(d, 1))` for a cusp form `g` of a proper divisor
+level `M` is old.
+
+This is `levelRaise_mem_cuspFormsOld` with the level-raise recognised through
+`TauCeti.CuspForm.coe_levelRaise` rather than named. A caller that obtained the identity as an
+equation of functions on `ℍ` — the level-lowering dichotomy
+`TauCeti.exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero` is the example — has no
+`TauCeti.CuspForm.levelRaise` term to point at, and coercion is injective, so producing one is
+exactly this lemma. -/
+theorem mem_cuspFormsOld_of_coe_eq_smul_slash_scaleGL [NeZero N] [NeZero d] (h : d * M ∣ N)
+    (hM : M ≠ N) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
+    {g : CuspForm ((Gamma1 M).map (mapGL ℝ)) k}
+    (hfg : ⇑f = (d : ℂ) ^ (1 - k) • ((⇑g : ℍ → ℂ) ∣[k] scaleGL d)) :
+    f ∈ cuspFormsOld N k := by
+  rw [DFunLike.coe_injective (hfg.trans
+    (CuspForm.coe_levelRaise (Gamma1_map_le_conjAct_scaleGL_of_dvd h) g).symm)]
+  exact levelRaise_mem_cuspFormsOld h hM k g
 
 /-- **Elimination rule for the old subspace**: a subspace containing every level-raise from a
 proper divisor level contains the whole old subspace. -/


### PR DESCRIPTION
A cusp form of level `Γ₁(N)` with a nebentypus, whose level-`l` descent is invariant under the
weight-`k` slash action of `T`, is old:

```lean
theorem mem_cuspFormsOld_of_slash_T_eq {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
    (χ : DirichletCharacter ℂ N) (φ : ℍ → ℂ) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
    (hfχ : f ∈ cuspFormCharSpace k χ.toUnitHom)
    (hf : haveI : NeZero l := NeZero.of_dvd hlN
      ⇑f = (l : ℂ) ^ (1 - k) • (φ ∣[k] scaleGL l))
    (hT : φ ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = φ) :
    f ∈ cuspFormsOld N k
```

## What this is for

`ConductorDichotomy.lean` already has Miyake's Theorem 4.6.4
(`exists_cuspForm_mem_cuspFormCharSpace_or_eq_zero`): under exactly these hypotheses, *either*
`χ` factors through `N / l` and `φ` is itself a cusp form of level `Γ₁(N / l)`, *or* `φ = 0`.

The two horns look different but agree on the one thing the Atkin–Lehner argument wants: on the
first, `f` is the level-raise `V_l F` of a genuine cusp form of the proper divisor level `N / l`;
on the second, `f = 0`. Both are in `cuspFormsOld N k`. This PR draws that conclusion, which is
the step the main lemma takes immediately after the dichotomy.

The roadmap's ModularForms `STATUS.md` names it on the frontier — *"turn the coefficient filters
and level-lowering dichotomy into the statement that a cusp form supported away from indices
coprime to the level is old"*. This is the level-lowering half. The coefficient-filter half, which
manufactures the `T`-periodic `φ` out of a `q`-expansion support condition, is
[#5646](https://github.com/TauCetiProject/TauCeti/pull/5646); the two compose into the main lemma
in a later PR, and neither depends on the other here.

## Hypotheses

`l ≠ 1` is the only arithmetic condition: `cuspFormsOld` is spanned by level-raises from
**proper** divisor levels, so all the argument asks is that `N / l` be a proper divisor. No
primality is used, and no `q`-expansion hypothesis appears — the descent is supplied by the
caller.

`NeZero l` is *not* a hypothesis: it follows from `l ∣ N` and the ambient `[NeZero N]`. Because
`scaleGL l` occurs in a hypothesis rather than only in the conclusion, the instance is introduced
by a `haveI` inside that binder, the idiom `levelRaise_mem_cuspFormsOldMultiples` already uses for
its own `NeZero M`.

## Not ported from the source

The source's two private helpers `cuspForm_coe_eq_of_cast` and `isOldformGenerator_of_funeq` are
deliberately absent. They exist to move a `d * (N / d) = N` cast through `DFunLike.coe` and to
repackage the result as the source's `IsOldformGenerator`; this repository indexes `cuspFormsOld`
by the divisibility `d * M ∣ N` rather than by an equation, so no cast arises and
`levelRaise_mem_cuspFormsOld` applies after a single `DFunLike.coe_injective`. The source's
`q`-expansion support hypothesis is likewise absent: what its proof consumes is the descent, and
that is what this takes.

Roadmap: ModularForms

New mathematics, so the citation: this supplies a prerequisite that
`TauCetiRoadmap/ModularForms/README.md` § "Layer 5: strong multiplicity one and the eigenform
characterization" needs, via the Atkin–Lehner old-subspace description its `strongMultiplicityOne`
bullet rests on. It does **not** author that target — the main lemma still needs #5646's half — so
it carries no `tauceti-target` marker, an id invented for a prerequisite risking a collision with
the PR that eventually authors the target.

Provenance: [AINTLIB](https://github.com/CBirkbeck/AINTLIB) @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
Apache-2.0, Chris Birkbeck — `projects/LeanModularForms/LeanModularForms/Eigenforms/AtkinLehner.lean`,
the case split of `qSupportedOnDvd_mem_cuspFormsOld_of_char` (lines 169–192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
