### PR TITLE
feat: subgroups parametrise the pointed connected covers bijectively

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean
@@ -9,6 +9,7 @@ public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Existence
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.RecoveredSubgroup
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Regular
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Unpointed
+import TauCeti.Topology.IsLocalHomeomorph
 
 /-!
 # Subgroups parametrise the pointed connected covers bijectively
@@ -73,17 +74,18 @@ variable {X : Type*} [TopologicalSpace X] [PathConnectedSpace X] [LocallyPathCon
   [SemilocallySimplyConnectedSpace X] (x₀ : X)
 
 /-- **A pointed connected cover is the quotient of the universal cover by the subgroup it
-recovers.** If a covering map `p` with path-connected, locally path-connected total space and a
-lift `e₀` of `x₀` recover `H ≤ π₁(X, x₀)`, then `E` is homeomorphic to `UniversalCover x₀ / H`
-over `X`, by a homeomorphism carrying `e₀` to the distinguished point.
+recovers.** If a covering map `p` with path-connected total space and a lift `e₀` of `x₀` recover
+`H ≤ π₁(X, x₀)`, then `E` is homeomorphic to `UniversalCover x₀ / H` over `X`, by a
+homeomorphism carrying `e₀` to the distinguished point.
 
 This is the surjectivity of the subgroup parametrisation. -/
 theorem exists_homeomorph_subgroupQuotient_of_range_eq {E : Type*} [TopologicalSpace E]
-    [PathConnectedSpace E] [LocallyPathConnectedSpace E] {p : E → X} (hp : IsCoveringMap p)
+    [PathConnectedSpace E] {p : E → X} (hp : IsCoveringMap p)
     {e₀ : E} (hpe : p e₀ = x₀) (H : Subgroup (FundamentalGroup X x₀))
     (hH : (mapOfEq ⟨p, hp.continuous⟩ hpe).range = H) :
     ∃ h : E ≃ₜ SubgroupQuotient x₀ H, h e₀ = SubgroupQuotient.basepoint x₀ H ∧
       subgroupQuotientProj x₀ H ∘ h = p := by
+  have := hp.isLocalHomeomorph.locallyPathConnectedSpace
   have := locallyPathConnectedSpace_subgroupQuotient x₀ H
   exact TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_of_range_eq hp
     (isCoveringMap_subgroupQuotientProj x₀ H) hpe (subgroupQuotientProj_basepoint x₀ H)
@@ -93,10 +95,11 @@ theorem exists_homeomorph_subgroupQuotient_of_range_eq {E : Type*} [TopologicalS
 `π₁(X, x₀)`.** The subgroups of `π₁(X, x₀)` therefore parametrise the pointed connected covers
 of `(X, x₀)` bijectively, up to isomorphism over `X` respecting the chosen lifts. -/
 theorem existsUnique_subgroup_homeomorph_subgroupQuotient {E : Type*} [TopologicalSpace E]
-    [PathConnectedSpace E] [LocallyPathConnectedSpace E] {p : E → X} (hp : IsCoveringMap p)
+    [PathConnectedSpace E] {p : E → X} (hp : IsCoveringMap p)
     {e₀ : E} (hpe : p e₀ = x₀) :
     ∃! H : Subgroup (FundamentalGroup X x₀), ∃ h : E ≃ₜ SubgroupQuotient x₀ H,
       h e₀ = SubgroupQuotient.basepoint x₀ H ∧ subgroupQuotientProj x₀ H ∘ h = p := by
+  have := hp.isLocalHomeomorph.locallyPathConnectedSpace
   refine ⟨(mapOfEq ⟨p, hp.continuous⟩ hpe).range,
     exists_homeomorph_subgroupQuotient_of_range_eq x₀ hp hpe _ rfl, fun H hH => ?_⟩
   have := locallyPathConnectedSpace_subgroupQuotient x₀ H
@@ -135,6 +138,7 @@ theorem exists_homeomorph_subgroupQuotient_comp_eq_iff_exists_eq_map_conj
   simp only [range_mapOfEq_subgroupQuotientProj]
 
 /-- **The cover attached to `H` is a regular cover exactly when `H` is normal.** -/
+@[simp]
 theorem isRegular_subgroupQuotientProj_iff_normal (H : Subgroup (FundamentalGroup X x₀)) :
     Deck.IsRegular (subgroupQuotientProj x₀ H) ↔ H.Normal := by
   have := locallyPathConnectedSpace_subgroupQuotient x₀ H

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-import TauCeti.Algebra.GroupAction.OrbitRelQuotient
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Existence
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.RecoveredSubgroup
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Regular
@@ -37,16 +36,7 @@ Galois correspondence between subgroups of `π₁(X, x₀)` and connected covers
 regular-cover criterion is read off in the same way: the cover attached to `H` is regular
 exactly when `H` is normal.
 
-The two extreme subgroups are pinned as well. The quotient of the universal cover by the trivial
-subgroup is the universal cover itself, and the quotient by the whole fundamental group is `X`,
-because the orbits of the fundamental-group action on the universal cover are exactly the fibres
-of the endpoint projection. Both are recorded as homeomorphisms whose underlying maps are the
-canonical ones rather than as bare existence statements, since the correspondence attaches the
-universal cover to `⊥` and the trivial cover to `⊤` only through these specific maps.
-
-Nothing here is a new covering-space argument: every step is bookkeeping on top of the pointed
-and unpointed comparison theorems and the recovered subgroup of `subgroupQuotientProj`. The
-standing hypotheses are those of the whole construction — `X` path-connected, locally
+The standing hypotheses are those of the whole construction — `X` path-connected, locally
 path-connected and semilocally simply connected — because the universal cover is what the
 subgroup quotients are built from.
 
@@ -63,9 +53,6 @@ subgroup quotients are built from.
   are isomorphic as *unpointed* covers exactly when the subgroups are conjugate.
 * `TauCeti.UniversalCover.isRegular_subgroupQuotientProj_iff_normal`: the cover attached to `H`
   is regular exactly when `H` is normal.
-* `TauCeti.UniversalCover.subgroupQuotientBotHomeomorph`: the cover attached to `⊥` is the
-  universal cover.
-* `TauCeti.UniversalCover.subgroupQuotientTopHomeomorph`: the cover attached to `⊤` is `X`.
 
 ## References
 
@@ -73,7 +60,7 @@ The mathematics is Hatcher, *Algebraic Topology*, Theorem 1.38 and the classific
 that follows it. The construction consumed here is the based-path universal cover adapted from
 Kim Morrison's [mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292),
 and the lifting criterion underlying the comparison theorems is Junyan Xu's, in
-`Mathlib/Topology/Homotopy/Lifting.lean`. No Mathlib proof is vendored here.
+`Mathlib/Topology/Homotopy/Lifting.lean`.
 -/
 
 public section
@@ -156,47 +143,5 @@ theorem isRegular_subgroupQuotientProj_iff_normal (H : Subgroup (FundamentalGrou
     ⟨SubgroupQuotient.basepoint x₀ H,
       Set.mem_singleton_iff.mpr (subgroupQuotientProj_basepoint x₀ H)⟩) ?_
   rw [range_mapOfEq_subgroupQuotientProj]
-
-/-! ### The two ends of the correspondence -/
-
-omit [PathConnectedSpace X] in
-/-- **The cover attached to the trivial subgroup is the universal cover.** The underlying map is
-the quotient map `subgroupQuotientMap x₀ ⊥`, so the identification is one over `X`. -/
-noncomputable def subgroupQuotientBotHomeomorph :
-    UniversalCover x₀ ≃ₜ SubgroupQuotient x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) :=
-  Equiv.toHomeomorphOfContinuousOpen
-    (Equiv.ofBijective (subgroupQuotientMap x₀ ⊥) (by
-      have h : subgroupQuotientMap x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) =
-          ⇑(TauCeti.MulAction.orbitRelQuotientBotEquiv
-            (G := FundamentalGroup X x₀) (X := UniversalCover x₀)).symm := by
-        funext e
-        simp
-      rw [h]
-      exact (TauCeti.MulAction.orbitRelQuotientBotEquiv
-        (G := FundamentalGroup X x₀) (X := UniversalCover x₀)).symm.bijective))
-    (isQuotientCoveringMap_subgroupQuotientMap x₀ ⊥).isCoveringMap.continuous
-    (isQuotientCoveringMap_subgroupQuotientMap x₀ ⊥).isCoveringMap.isLocalHomeomorph.isOpenMap
-
-omit [PathConnectedSpace X] in
-@[simp]
-theorem coe_subgroupQuotientBotHomeomorph :
-    ⇑(subgroupQuotientBotHomeomorph x₀) =
-      subgroupQuotientMap x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) :=
-  (rfl)
-
-/-- **The cover attached to the whole fundamental group is `X` itself.** The comparison is the
-descended endpoint projection, so the cover attached to `⊤` is the trivial one-sheeted cover. -/
-noncomputable def subgroupQuotientTopHomeomorph :
-    SubgroupQuotient x₀ (⊤ : Subgroup (FundamentalGroup X x₀)) ≃ₜ X :=
-  (Equiv.ofBijective (subgroupQuotientProj x₀ ⊤) ⟨subgroupQuotientProj_top_injective x₀,
-    subgroupQuotientProj_surjective x₀ ⊤⟩).toHomeomorphOfContinuousOpen
-      (continuous_subgroupQuotientProj x₀ ⊤)
-      (isCoveringMap_subgroupQuotientProj x₀ ⊤).isLocalHomeomorph.isOpenMap
-
-@[simp]
-theorem coe_subgroupQuotientTopHomeomorph :
-    ⇑(subgroupQuotientTopHomeomorph x₀) =
-      subgroupQuotientProj x₀ (⊤ : Subgroup (FundamentalGroup X x₀)) :=
-  (rfl)
 
 end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.GroupAction.OrbitRelQuotient
+import TauCeti.Algebra.GroupAction.OrbitRelQuotient
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Existence
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.RecoveredSubgroup
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Regular
@@ -59,7 +59,7 @@ subgroup quotients are built from.
   of `π₁(X, x₀)` parametrise pointed connected covers bijectively.
 * `TauCeti.UniversalCover.exists_homeomorph_subgroupQuotient_comp_eq_iff_eq`: two subgroup
   quotients are isomorphic as *pointed* covers exactly when the subgroups are equal.
-* `TauCeti.UniversalCover.exists_homeomorph_subgroupQuotient_comp_eq_iff_exists_map_conj`: they
+* `TauCeti.UniversalCover.exists_homeomorph_subgroupQuotient_comp_eq_iff_exists_eq_map_conj`: they
   are isomorphic as *unpointed* covers exactly when the subgroups are conjugate.
 * `TauCeti.UniversalCover.isRegular_subgroupQuotientProj_iff_normal`: the cover attached to `H`
   is regular exactly when `H` is normal.
@@ -90,9 +90,7 @@ recovers.** If a covering map `p` with path-connected, locally path-connected to
 lift `e₀` of `x₀` recover `H ≤ π₁(X, x₀)`, then `E` is homeomorphic to `UniversalCover x₀ / H`
 over `X`, by a homeomorphism carrying `e₀` to the distinguished point.
 
-This is the surjectivity of the subgroup parametrisation; the comparison theorem
-`TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_of_range_eq` supplies the homeomorphism once
-the cover attached to `H` is known to recover `H`. -/
+This is the surjectivity of the subgroup parametrisation. -/
 theorem exists_homeomorph_subgroupQuotient_of_range_eq {E : Type*} [TopologicalSpace E]
     [PathConnectedSpace E] [LocallyPathConnectedSpace E] {p : E → X} (hp : IsCoveringMap p)
     {e₀ : E} (hpe : p e₀ = x₀) (H : Subgroup (FundamentalGroup X x₀))
@@ -106,11 +104,7 @@ theorem exists_homeomorph_subgroupQuotient_of_range_eq {E : Type*} [TopologicalS
 
 /-- **Every pointed connected cover of `(X, x₀)` is realised by exactly one subgroup of
 `π₁(X, x₀)`.** The subgroups of `π₁(X, x₀)` therefore parametrise the pointed connected covers
-of `(X, x₀)` bijectively, up to isomorphism over `X` respecting the chosen lifts.
-
-Existence is `exists_homeomorph_subgroupQuotient_of_range_eq` at the recovered subgroup;
-uniqueness is the pointed comparison theorem, which forces any realising subgroup to be the
-recovered one. -/
+of `(X, x₀)` bijectively, up to isomorphism over `X` respecting the chosen lifts. -/
 theorem existsUnique_subgroup_homeomorph_subgroupQuotient {E : Type*} [TopologicalSpace E]
     [PathConnectedSpace E] [LocallyPathConnectedSpace E] {p : E → X} (hp : IsCoveringMap p)
     {e₀ : E} (hpe : p e₀ = x₀) :
@@ -141,7 +135,7 @@ theorem exists_homeomorph_subgroupQuotient_comp_eq_iff_eq
 subgroups are conjugate.** Forgetting the distinguished points therefore turns the subgroup
 parametrisation into a bijection between conjugacy classes of subgroups of `π₁(X, x₀)` and
 isomorphism classes of connected covers of `X`. -/
-theorem exists_homeomorph_subgroupQuotient_comp_eq_iff_exists_map_conj
+theorem exists_homeomorph_subgroupQuotient_comp_eq_iff_exists_eq_map_conj
     (H K : Subgroup (FundamentalGroup X x₀)) :
     (∃ h : SubgroupQuotient x₀ H ≃ₜ SubgroupQuotient x₀ K,
         subgroupQuotientProj x₀ K ∘ h = subgroupQuotientProj x₀ H) ↔
@@ -153,9 +147,7 @@ theorem exists_homeomorph_subgroupQuotient_comp_eq_iff_exists_map_conj
     (subgroupQuotientProj_basepoint x₀ H) (subgroupQuotientProj_basepoint x₀ K)]
   simp only [range_mapOfEq_subgroupQuotientProj]
 
-/-- **The cover attached to `H` is a regular cover exactly when `H` is normal.** This is the
-regular-cover criterion `TauCeti.IsCoveringMap.isRegular_iff_normal_range` read at the
-distinguished point of the cover attached to `H`, where the recovered subgroup is `H`. -/
+/-- **The cover attached to `H` is a regular cover exactly when `H` is normal.** -/
 theorem isRegular_subgroupQuotientProj_iff_normal (H : Subgroup (FundamentalGroup X x₀)) :
     Deck.IsRegular (subgroupQuotientProj x₀ H) ↔ H.Normal := by
   have := locallyPathConnectedSpace_subgroupQuotient x₀ H
@@ -167,10 +159,9 @@ theorem isRegular_subgroupQuotientProj_iff_normal (H : Subgroup (FundamentalGrou
 
 /-! ### The two ends of the correspondence -/
 
-/-- **The cover attached to the trivial subgroup is the universal cover.** The comparison is the
-quotient map itself, which `subgroupQuotientProj_comp_subgroupQuotientMap` already records as a
-map over `X`; the underlying bijection is the generic bottom-orbit quotient equivalence
-`TauCeti.MulAction.orbitRelQuotientBotEquiv`. -/
+omit [PathConnectedSpace X] in
+/-- **The cover attached to the trivial subgroup is the universal cover.** The underlying map is
+the quotient map `subgroupQuotientMap x₀ ⊥`, so the identification is one over `X`. -/
 noncomputable def subgroupQuotientBotHomeomorph :
     UniversalCover x₀ ≃ₜ SubgroupQuotient x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) :=
   Equiv.toHomeomorphOfContinuousOpen
@@ -192,21 +183,6 @@ theorem coe_subgroupQuotientBotHomeomorph :
     ⇑(subgroupQuotientBotHomeomorph x₀) =
       subgroupQuotientMap x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) :=
   (rfl)
-
-omit [PathConnectedSpace X] [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X] in
-/-- The descended endpoint projection is injective on the orbit quotient by the whole fundamental
-group, because the orbits of that action are exactly the fibres of the endpoint projection. -/
-theorem subgroupQuotientProj_top_injective :
-    Function.Injective (subgroupQuotientProj x₀ (⊤ : Subgroup (FundamentalGroup X x₀))) := by
-  intro a b hab
-  induction a using Quotient.inductionOn' with
-  | h e₁ =>
-    induction b using Quotient.inductionOn' with
-    | h e₂ =>
-      rw [subgroupQuotientProj_mk, subgroupQuotientProj_mk] at hab
-      obtain ⟨g, hg⟩ := proj_eq_iff_mem_orbit.mp hab
-      rw [← subgroupQuotientMap_apply x₀ ⊤ e₁, ← subgroupQuotientMap_apply x₀ ⊤ e₂]
-      exact (subgroupQuotientMap_eq_iff x₀ ⊤).mpr ⟨⟨g, Subgroup.mem_top g⟩, hg⟩
 
 /-- **The cover attached to the whole fundamental group is `X` itself.** The comparison is the
 descended endpoint projection, so the cover attached to `⊤` is the trivial one-sheeted cover. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean
@@ -1,0 +1,228 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Existence
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.RecoveredSubgroup
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Regular
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Unpointed
+
+/-!
+# Subgroups parametrise the pointed connected covers bijectively
+
+Two halves of the correspondence between subgroups of `π₁(X, x₀)` and pointed connected covers
+of `(X, x₀)` are already available. The comparison theorem
+`TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_iff_range_eq` says a pointed connected cover is
+determined by the subgroup it recovers, and `TauCeti.UniversalCover.subgroupQuotientProj`
+together with `TauCeti.UniversalCover.range_mapOfEq_subgroupQuotientProj` builds, for every
+subgroup `H`, a pointed cover recovering `H`. What neither states is that *every* pointed
+connected cover arises this way.
+
+This file supplies that statement and reads the correspondence off it:
+
+* a pointed connected cover of `(X, x₀)` is isomorphic over `X`, by a homeomorphism matching the
+  chosen lift with the distinguished point, to `UniversalCover x₀ / H` for the subgroup `H` it
+  recovers, and `H` is the *only* subgroup with that property;
+* the covers attached to `H` and to `K` are isomorphic as pointed covers exactly when `H = K`,
+  and as unpointed covers exactly when `H` and `K` are conjugate.
+
+Together with the order statement
+`TauCeti.UniversalCover.exists_isCoveringMap_subgroupQuotientProj_comp_eq_iff_le`, which says
+the cover attached to `H` covers the cover attached to `K` precisely when `H ≤ K`, this is the
+Galois correspondence between subgroups of `π₁(X, x₀)` and connected covers of `X`. The
+regular-cover criterion is read off in the same way: the cover attached to `H` is regular
+exactly when `H` is normal.
+
+The two extreme subgroups are pinned as well. The quotient of the universal cover by the trivial
+subgroup is the universal cover itself, and the quotient by the whole fundamental group is `X`,
+because the orbits of the fundamental-group action on the universal cover are exactly the fibres
+of the endpoint projection. Both are recorded as homeomorphisms whose underlying maps are the
+canonical ones rather than as bare existence statements, since the correspondence attaches the
+universal cover to `⊥` and the trivial cover to `⊤` only through these specific maps.
+
+Nothing here is a new covering-space argument: every step is bookkeeping on top of the pointed
+and unpointed comparison theorems and the recovered subgroup of `subgroupQuotientProj`. The
+standing hypotheses are those of the whole construction — `X` path-connected, locally
+path-connected and semilocally simply connected — because the universal cover is what the
+subgroup quotients are built from.
+
+## Main declarations
+
+* `TauCeti.UniversalCover.exists_homeomorph_subgroupQuotient_of_range_eq`: **a pointed connected
+  cover is the quotient of the universal cover by the subgroup it recovers.**
+* `TauCeti.UniversalCover.existsUnique_subgroup_homeomorph_subgroupQuotient`: **the recovering
+  subgroup is the unique parameter that realises a given pointed connected cover**, so subgroups
+  of `π₁(X, x₀)` parametrise pointed connected covers bijectively.
+* `TauCeti.UniversalCover.exists_homeomorph_subgroupQuotient_comp_eq_iff_eq`: two subgroup
+  quotients are isomorphic as *pointed* covers exactly when the subgroups are equal.
+* `TauCeti.UniversalCover.exists_homeomorph_subgroupQuotient_comp_eq_iff_exists_map_conj`: they
+  are isomorphic as *unpointed* covers exactly when the subgroups are conjugate.
+* `TauCeti.UniversalCover.isRegular_subgroupQuotientProj_iff_normal`: the cover attached to `H`
+  is regular exactly when `H` is normal.
+* `TauCeti.UniversalCover.subgroupQuotientBotHomeomorph`: the cover attached to `⊥` is the
+  universal cover.
+* `TauCeti.UniversalCover.subgroupQuotientTopHomeomorph`: the cover attached to `⊤` is `X`.
+
+## References
+
+The mathematics is Hatcher, *Algebraic Topology*, Theorem 1.38 and the classification corollary
+that follows it. The construction consumed here is the based-path universal cover adapted from
+Kim Morrison's [mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292),
+and the lifting criterion underlying the comparison theorems is Junyan Xu's, in
+`Mathlib/Topology/Homotopy/Lifting.lean`. No Mathlib proof is vendored here.
+-/
+
+public section
+
+namespace TauCeti.UniversalCover
+
+open _root_.FundamentalGroup
+
+variable {X : Type*} [TopologicalSpace X] [PathConnectedSpace X] [LocallyPathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X] (x₀ : X)
+
+/-- **A pointed connected cover is the quotient of the universal cover by the subgroup it
+recovers.** If a covering map `p` with path-connected, locally path-connected total space and a
+lift `e₀` of `x₀` recover `H ≤ π₁(X, x₀)`, then `E` is homeomorphic to `UniversalCover x₀ / H`
+over `X`, by a homeomorphism carrying `e₀` to the distinguished point.
+
+This is the surjectivity of the subgroup parametrisation; the comparison theorem
+`TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_of_range_eq` supplies the homeomorphism once
+the cover attached to `H` is known to recover `H`. -/
+theorem exists_homeomorph_subgroupQuotient_of_range_eq {E : Type*} [TopologicalSpace E]
+    [PathConnectedSpace E] [LocallyPathConnectedSpace E] {p : E → X} (hp : IsCoveringMap p)
+    {e₀ : E} (hpe : p e₀ = x₀) (H : Subgroup (FundamentalGroup X x₀))
+    (hH : (mapOfEq ⟨p, hp.continuous⟩ hpe).range = H) :
+    ∃ h : E ≃ₜ SubgroupQuotient x₀ H, h e₀ = SubgroupQuotient.basepoint x₀ H ∧
+      subgroupQuotientProj x₀ H ∘ h = p := by
+  have := locallyPathConnectedSpace_subgroupQuotient x₀ H
+  exact TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_of_range_eq hp
+    (isCoveringMap_subgroupQuotientProj x₀ H) hpe (subgroupQuotientProj_basepoint x₀ H)
+    (hH.trans (range_mapOfEq_subgroupQuotientProj x₀ H).symm)
+
+/-- **Every pointed connected cover of `(X, x₀)` is realised by exactly one subgroup of
+`π₁(X, x₀)`.** The subgroups of `π₁(X, x₀)` therefore parametrise the pointed connected covers
+of `(X, x₀)` bijectively, up to isomorphism over `X` respecting the chosen lifts.
+
+Existence is `exists_homeomorph_subgroupQuotient_of_range_eq` at the recovered subgroup;
+uniqueness is the pointed comparison theorem, which forces any realising subgroup to be the
+recovered one. -/
+theorem existsUnique_subgroup_homeomorph_subgroupQuotient {E : Type*} [TopologicalSpace E]
+    [PathConnectedSpace E] [LocallyPathConnectedSpace E] {p : E → X} (hp : IsCoveringMap p)
+    {e₀ : E} (hpe : p e₀ = x₀) :
+    ∃! H : Subgroup (FundamentalGroup X x₀), ∃ h : E ≃ₜ SubgroupQuotient x₀ H,
+      h e₀ = SubgroupQuotient.basepoint x₀ H ∧ subgroupQuotientProj x₀ H ∘ h = p := by
+  refine ⟨(mapOfEq ⟨p, hp.continuous⟩ hpe).range,
+    exists_homeomorph_subgroupQuotient_of_range_eq x₀ hp hpe _ rfl, fun H hH => ?_⟩
+  have := locallyPathConnectedSpace_subgroupQuotient x₀ H
+  rw [← range_mapOfEq_subgroupQuotientProj x₀ H]
+  exact ((TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_iff_range_eq hp
+    (isCoveringMap_subgroupQuotientProj x₀ H) hpe (subgroupQuotientProj_basepoint x₀ H)).mp hH).symm
+
+/-- **The covers attached to two subgroups are isomorphic as pointed covers exactly when the
+subgroups are equal.** This is the injectivity of the subgroup parametrisation. -/
+theorem exists_homeomorph_subgroupQuotient_comp_eq_iff_eq
+    (H K : Subgroup (FundamentalGroup X x₀)) :
+    (∃ h : SubgroupQuotient x₀ H ≃ₜ SubgroupQuotient x₀ K,
+        h (SubgroupQuotient.basepoint x₀ H) = SubgroupQuotient.basepoint x₀ K ∧
+          subgroupQuotientProj x₀ K ∘ h = subgroupQuotientProj x₀ H) ↔ H = K := by
+  have := locallyPathConnectedSpace_subgroupQuotient x₀ H
+  have := locallyPathConnectedSpace_subgroupQuotient x₀ K
+  rw [TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_iff_range_eq
+    (isCoveringMap_subgroupQuotientProj x₀ H) (isCoveringMap_subgroupQuotientProj x₀ K)
+    (subgroupQuotientProj_basepoint x₀ H) (subgroupQuotientProj_basepoint x₀ K),
+    range_mapOfEq_subgroupQuotientProj, range_mapOfEq_subgroupQuotientProj]
+
+/-- **The covers attached to two subgroups are isomorphic as unpointed covers exactly when the
+subgroups are conjugate.** Forgetting the distinguished points therefore turns the subgroup
+parametrisation into a bijection between conjugacy classes of subgroups of `π₁(X, x₀)` and
+isomorphism classes of connected covers of `X`. -/
+theorem exists_homeomorph_subgroupQuotient_comp_eq_iff_exists_map_conj
+    (H K : Subgroup (FundamentalGroup X x₀)) :
+    (∃ h : SubgroupQuotient x₀ H ≃ₜ SubgroupQuotient x₀ K,
+        subgroupQuotientProj x₀ K ∘ h = subgroupQuotientProj x₀ H) ↔
+      ∃ γ : FundamentalGroup X x₀, K = H.map (MulAut.conj γ).toMonoidHom := by
+  have := locallyPathConnectedSpace_subgroupQuotient x₀ H
+  have := locallyPathConnectedSpace_subgroupQuotient x₀ K
+  rw [TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_iff_exists_range_eq_map_conj
+    (isCoveringMap_subgroupQuotientProj x₀ H) (isCoveringMap_subgroupQuotientProj x₀ K)
+    (subgroupQuotientProj_basepoint x₀ H) (subgroupQuotientProj_basepoint x₀ K)]
+  simp only [range_mapOfEq_subgroupQuotientProj]
+
+/-- **The cover attached to `H` is a regular cover exactly when `H` is normal.** This is the
+regular-cover criterion `TauCeti.IsCoveringMap.isRegular_iff_normal_range` read at the
+distinguished point of the cover attached to `H`, where the recovered subgroup is `H`. -/
+theorem isRegular_subgroupQuotientProj_iff_normal (H : Subgroup (FundamentalGroup X x₀)) :
+    Deck.IsRegular (subgroupQuotientProj x₀ H) ↔ H.Normal := by
+  have := locallyPathConnectedSpace_subgroupQuotient x₀ H
+  refine Iff.trans (TauCeti.IsCoveringMap.isRegular_iff_normal_range
+    (isCoveringMap_subgroupQuotientProj x₀ H)
+    ⟨SubgroupQuotient.basepoint x₀ H,
+      Set.mem_singleton_iff.mpr (subgroupQuotientProj_basepoint x₀ H)⟩) ?_
+  rw [range_mapOfEq_subgroupQuotientProj]
+
+/-! ### The two ends of the correspondence -/
+
+omit [PathConnectedSpace X] [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X] in
+/-- The quotient map to the orbit quotient by the trivial subgroup is injective, since the
+orbits of the trivial subgroup are singletons. -/
+theorem subgroupQuotientMap_bot_injective :
+    Function.Injective (subgroupQuotientMap x₀ (⊥ : Subgroup (FundamentalGroup X x₀))) := by
+  intro e₁ e₂ h
+  obtain ⟨g, hg⟩ := (subgroupQuotientMap_eq_iff x₀ ⊥).mp h
+  rw [← hg, Subsingleton.elim g 1]
+  exact one_smul _ e₂
+
+/-- **The cover attached to the trivial subgroup is the universal cover.** The comparison is the
+quotient map itself, which `subgroupQuotientProj_comp_subgroupQuotientMap` already records as a
+map over `X`. -/
+noncomputable def subgroupQuotientBotHomeomorph :
+    UniversalCover x₀ ≃ₜ SubgroupQuotient x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) :=
+  (Equiv.ofBijective (subgroupQuotientMap x₀ ⊥)
+    ⟨subgroupQuotientMap_bot_injective x₀,
+      subgroupQuotientMap_surjective x₀ ⊥⟩).toHomeomorphOfContinuousOpen
+      (isQuotientCoveringMap_subgroupQuotientMap x₀ ⊥).isCoveringMap.continuous
+      (isQuotientCoveringMap_subgroupQuotientMap x₀
+        ⊥).isCoveringMap.isLocalHomeomorph.isOpenMap
+
+omit [PathConnectedSpace X] in
+@[simp]
+theorem coe_subgroupQuotientBotHomeomorph :
+    ⇑(subgroupQuotientBotHomeomorph x₀) =
+      subgroupQuotientMap x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) :=
+  (rfl)
+
+omit [PathConnectedSpace X] [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X] in
+/-- The descended endpoint projection is injective on the orbit quotient by the whole fundamental
+group, because the orbits of that action are exactly the fibres of the endpoint projection. -/
+theorem subgroupQuotientProj_top_injective :
+    Function.Injective (subgroupQuotientProj x₀ (⊤ : Subgroup (FundamentalGroup X x₀))) := by
+  intro a b hab
+  induction a using Quotient.inductionOn' with
+  | h e₁ =>
+    induction b using Quotient.inductionOn' with
+    | h e₂ =>
+      rw [subgroupQuotientProj_mk, subgroupQuotientProj_mk] at hab
+      obtain ⟨g, hg⟩ := proj_eq_iff_mem_orbit.mp hab
+      rw [← subgroupQuotientMap_apply x₀ ⊤ e₁, ← subgroupQuotientMap_apply x₀ ⊤ e₂]
+      exact (subgroupQuotientMap_eq_iff x₀ ⊤).mpr ⟨⟨g, Subgroup.mem_top g⟩, hg⟩
+
+/-- **The cover attached to the whole fundamental group is `X` itself.** The comparison is the
+descended endpoint projection, so the cover attached to `⊤` is the trivial one-sheeted cover. -/
+noncomputable def subgroupQuotientTopHomeomorph :
+    SubgroupQuotient x₀ (⊤ : Subgroup (FundamentalGroup X x₀)) ≃ₜ X :=
+  (Equiv.ofBijective (subgroupQuotientProj x₀ ⊤) ⟨subgroupQuotientProj_top_injective x₀,
+    subgroupQuotientProj_surjective x₀ ⊤⟩).toHomeomorphOfContinuousOpen
+      (continuous_subgroupQuotientProj x₀ ⊤)
+      (isCoveringMap_subgroupQuotientProj x₀ ⊤).isLocalHomeomorph.isOpenMap
+
+@[simp]
+theorem coe_subgroupQuotientTopHomeomorph :
+    ⇑(subgroupQuotientTopHomeomorph x₀) =
+      subgroupQuotientProj x₀ (⊤ : Subgroup (FundamentalGroup X x₀)) :=
+  (rfl)
+
+end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.GroupAction.OrbitRelQuotient
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Existence
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.RecoveredSubgroup
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Regular
@@ -166,27 +167,24 @@ theorem isRegular_subgroupQuotientProj_iff_normal (H : Subgroup (FundamentalGrou
 
 /-! ### The two ends of the correspondence -/
 
-omit [PathConnectedSpace X] [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X] in
-/-- The quotient map to the orbit quotient by the trivial subgroup is injective, since the
-orbits of the trivial subgroup are singletons. -/
-theorem subgroupQuotientMap_bot_injective :
-    Function.Injective (subgroupQuotientMap x₀ (⊥ : Subgroup (FundamentalGroup X x₀))) := by
-  intro e₁ e₂ h
-  obtain ⟨g, hg⟩ := (subgroupQuotientMap_eq_iff x₀ ⊥).mp h
-  rw [← hg, Subsingleton.elim g 1]
-  exact one_smul _ e₂
-
 /-- **The cover attached to the trivial subgroup is the universal cover.** The comparison is the
 quotient map itself, which `subgroupQuotientProj_comp_subgroupQuotientMap` already records as a
-map over `X`. -/
+map over `X`; the underlying bijection is the generic bottom-orbit quotient equivalence
+`TauCeti.MulAction.orbitRelQuotientBotEquiv`. -/
 noncomputable def subgroupQuotientBotHomeomorph :
     UniversalCover x₀ ≃ₜ SubgroupQuotient x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) :=
-  (Equiv.ofBijective (subgroupQuotientMap x₀ ⊥)
-    ⟨subgroupQuotientMap_bot_injective x₀,
-      subgroupQuotientMap_surjective x₀ ⊥⟩).toHomeomorphOfContinuousOpen
-      (isQuotientCoveringMap_subgroupQuotientMap x₀ ⊥).isCoveringMap.continuous
-      (isQuotientCoveringMap_subgroupQuotientMap x₀
-        ⊥).isCoveringMap.isLocalHomeomorph.isOpenMap
+  Equiv.toHomeomorphOfContinuousOpen
+    (Equiv.ofBijective (subgroupQuotientMap x₀ ⊥) (by
+      have h : subgroupQuotientMap x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) =
+          ⇑(TauCeti.MulAction.orbitRelQuotientBotEquiv
+            (G := FundamentalGroup X x₀) (X := UniversalCover x₀)).symm := by
+        funext e
+        simp
+      rw [h]
+      exact (TauCeti.MulAction.orbitRelQuotientBotEquiv
+        (G := FundamentalGroup X x₀) (X := UniversalCover x₀)).symm.bijective))
+    (isQuotientCoveringMap_subgroupQuotientMap x₀ ⊥).isCoveringMap.continuous
+    (isQuotientCoveringMap_subgroupQuotientMap x₀ ⊥).isCoveringMap.isLocalHomeomorph.isOpenMap
 
 omit [PathConnectedSpace X] in
 @[simp]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Existence.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Existence.lean
@@ -39,6 +39,8 @@ itself a quotient covering map for any group.
   `H ≤ π₁(X, x₀)` is a covering space of `X`.
 * `TauCeti.UniversalCover.subgroupCover`: the same cover, bundled as a connected covering space.
 * `TauCeti.UniversalCover.subgroupCoverBasepointFiber`: its distinguished fibre point.
+* `TauCeti.UniversalCover.subgroupQuotientTopHomeomorph`: the cover associated to the whole
+  fundamental group is `X` itself.
 
 ## References
 
@@ -182,5 +184,22 @@ theorem subgroupCoverFiberEquivSubgroupQuotient_apply_basepoint
     subgroupCoverFiberEquivSubgroupQuotient x₀ H (subgroupCoverBasepointFiber x₀ H) =
       SubgroupQuotient.basepointFiber x₀ H :=
   Equiv.apply_symm_apply _ _
+
+/-- **The cover associated to the whole fundamental group is `X` itself.** The comparison is the
+descended endpoint projection, so this cover is the trivial one-sheeted cover. -/
+def subgroupQuotientTopHomeomorph [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] (x₀ : X) :
+    SubgroupQuotient x₀ (⊤ : Subgroup (FundamentalGroup X x₀)) ≃ₜ X :=
+  (Equiv.ofBijective (subgroupQuotientProj x₀ ⊤) ⟨subgroupQuotientProj_top_injective x₀,
+    subgroupQuotientProj_surjective x₀ ⊤⟩).toHomeomorphOfContinuousOpen
+      (continuous_subgroupQuotientProj x₀ ⊤)
+      (isCoveringMap_subgroupQuotientProj x₀ ⊤).isLocalHomeomorph.isOpenMap
+
+@[simp]
+theorem coe_subgroupQuotientTopHomeomorph [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] (x₀ : X) :
+    ⇑(subgroupQuotientTopHomeomorph x₀) =
+      subgroupQuotientProj x₀ (⊤ : Subgroup (FundamentalGroup X x₀)) :=
+  (rfl)
 
 end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
@@ -184,4 +184,18 @@ theorem subgroupQuotientProj_surjective [PathConnectedSpace X]
   unfold subgroupQuotientProj
   exact Quotient.lift_surjective proj _ (proj_surjective (x₀ := x₀))
 
+/-- The descended endpoint projection is injective on the orbit quotient by the whole fundamental
+group, because the orbits of that action are exactly the fibres of the endpoint projection. -/
+theorem subgroupQuotientProj_top_injective :
+    Function.Injective (subgroupQuotientProj x₀ (⊤ : Subgroup (FundamentalGroup X x₀))) := by
+  intro a b hab
+  induction a using Quotient.inductionOn' with
+  | h e₁ =>
+    induction b using Quotient.inductionOn' with
+    | h e₂ =>
+      rw [subgroupQuotientProj_mk, subgroupQuotientProj_mk] at hab
+      obtain ⟨g, hg⟩ := proj_eq_iff_mem_orbit.mp hab
+      rw [← subgroupQuotientMap_apply x₀ ⊤ e₁, ← subgroupQuotientMap_apply x₀ ⊤ e₂]
+      exact (subgroupQuotientMap_eq_iff x₀ ⊤).mpr ⟨⟨g, Subgroup.mem_top g⟩, hg⟩
+
 end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+import TauCeti.Algebra.GroupAction.OrbitRelQuotient
 public import TauCeti.AlgebraicTopology.UniversalCover.Action
 
 /-!
@@ -32,6 +33,8 @@ file will prove that the descended map is a covering map.
   subgroup quotient.
 * `TauCeti.UniversalCover.SubgroupQuotient.basepointFiber`: the distinguished point, bundled in
   the fibre over the basepoint.
+* `TauCeti.UniversalCover.subgroupQuotientBotHomeomorph`: the quotient by the trivial subgroup is
+  the universal cover itself.
 
 ## References
 
@@ -197,5 +200,31 @@ theorem subgroupQuotientProj_top_injective :
       obtain ⟨g, hg⟩ := proj_eq_iff_mem_orbit.mp hab
       rw [← subgroupQuotientMap_apply x₀ ⊤ e₁, ← subgroupQuotientMap_apply x₀ ⊤ e₂]
       exact (subgroupQuotientMap_eq_iff x₀ ⊤).mpr ⟨⟨g, Subgroup.mem_top g⟩, hg⟩
+
+/-- **The quotient of the universal cover by the trivial subgroup is the universal cover.** The
+underlying map is the quotient map `subgroupQuotientMap x₀ ⊥`, so the identification is one over
+`X`. -/
+def subgroupQuotientBotHomeomorph [LocallyPathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] :
+    UniversalCover x₀ ≃ₜ SubgroupQuotient x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) :=
+  Equiv.toHomeomorphOfContinuousOpen
+    (Equiv.ofBijective (subgroupQuotientMap x₀ ⊥) (by
+      have h : subgroupQuotientMap x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) =
+          ⇑(TauCeti.MulAction.orbitRelQuotientBotEquiv
+            (G := FundamentalGroup X x₀) (X := UniversalCover x₀)).symm := by
+        funext e
+        simp
+      rw [h]
+      exact (TauCeti.MulAction.orbitRelQuotientBotEquiv
+        (G := FundamentalGroup X x₀) (X := UniversalCover x₀)).symm.bijective))
+    (isQuotientCoveringMap_subgroupQuotientMap x₀ ⊥).isCoveringMap.continuous
+    (isQuotientCoveringMap_subgroupQuotientMap x₀ ⊥).isCoveringMap.isLocalHomeomorph.isOpenMap
+
+@[simp]
+theorem coe_subgroupQuotientBotHomeomorph [LocallyPathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] :
+    ⇑(subgroupQuotientBotHomeomorph x₀) =
+      subgroupQuotientMap x₀ (⊥ : Subgroup (FundamentalGroup X x₀)) :=
+  (rfl)
 
 end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
@@ -26,6 +26,7 @@ file will prove that the descended map is a covering map.
   fundamental group.
 * `TauCeti.UniversalCover.SubgroupQuotient.basepoint`: the class of the constant based path.
 * `TauCeti.UniversalCover.subgroupQuotientMap`: the quotient map.
+* `TauCeti.UniversalCover.subgroupQuotientMap_surjective`: the quotient map is surjective.
 * `TauCeti.UniversalCover.isQuotientCoveringMap_subgroupQuotientMap`: the quotient map is a
   quotient covering map, and hence a covering map.
 * `TauCeti.UniversalCover.subgroupQuotientProj`: the endpoint projection descended to the
@@ -89,6 +90,13 @@ theorem subgroupQuotientMap_eq_iff (H : Subgroup (FundamentalGroup X x₀))
       e₁ ∈ MulAction.orbit H e₂ := by
   rw [subgroupQuotientMap_apply, subgroupQuotientMap_apply, Quotient.eq'',
     MulAction.orbitRel_apply]
+
+/-- Every point of the subgroup quotient is the class of a point of the universal cover. -/
+theorem subgroupQuotientMap_surjective (H : Subgroup (FundamentalGroup X x₀)) :
+    Function.Surjective (subgroupQuotientMap x₀ H) := by
+  intro a
+  induction a using Quotient.inductionOn' with
+  | h e => exact ⟨e, subgroupQuotientMap_apply x₀ H e⟩
 
 /-- The fundamental-group action is locally disjoint without a global connectedness assumption. -/
 private theorem fundamentalGroup_disjoint [LocallyPathConnectedSpace X]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
@@ -26,7 +26,6 @@ file will prove that the descended map is a covering map.
   fundamental group.
 * `TauCeti.UniversalCover.SubgroupQuotient.basepoint`: the class of the constant based path.
 * `TauCeti.UniversalCover.subgroupQuotientMap`: the quotient map.
-* `TauCeti.UniversalCover.subgroupQuotientMap_surjective`: the quotient map is surjective.
 * `TauCeti.UniversalCover.isQuotientCoveringMap_subgroupQuotientMap`: the quotient map is a
   quotient covering map, and hence a covering map.
 * `TauCeti.UniversalCover.subgroupQuotientProj`: the endpoint projection descended to the
@@ -90,13 +89,6 @@ theorem subgroupQuotientMap_eq_iff (H : Subgroup (FundamentalGroup X x₀))
       e₁ ∈ MulAction.orbit H e₂ := by
   rw [subgroupQuotientMap_apply, subgroupQuotientMap_apply, Quotient.eq'',
     MulAction.orbitRel_apply]
-
-/-- Every point of the subgroup quotient is the class of a point of the universal cover. -/
-theorem subgroupQuotientMap_surjective (H : Subgroup (FundamentalGroup X x₀)) :
-    Function.Surjective (subgroupQuotientMap x₀ H) := by
-  intro a
-  induction a using Quotient.inductionOn' with
-  | h e => exact ⟨e, subgroupQuotientMap_apply x₀ H e⟩
 
 /-- The fundamental-group action is locally disjoint without a global connectedness assumption. -/
 private theorem fundamentalGroup_disjoint [LocallyPathConnectedSpace X]


### PR DESCRIPTION
This PR proves that every pointed connected cover of `(X, x₀)` is the quotient of the universal cover by the subgroup it recovers, and that the recovering subgroup is the unique parameter that realises it. Two halves of the correspondence were already in the repository: `TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_iff_range_eq` says a pointed connected cover is determined by the subgroup it recovers, and `TauCeti.UniversalCover.range_mapOfEq_subgroupQuotientProj` says the cover `UniversalCover x₀ / H` recovers `H`; what was missing is that *every* pointed connected cover arises this way, so the parametrisation is onto and hence bijective. With that in hand the file reads off the comparison statements for the covers attached to two subgroups — isomorphic as pointed covers exactly when the subgroups are equal, as unpointed covers exactly when the subgroups are conjugate, and regular exactly when the subgroup is normal — and pins the two extreme values, the cover attached to `⊥` being the universal cover and the cover attached to `⊤` being `X` itself.

The milestone served is Stage 2, item 8 of `TauCetiRoadmap/UniversalCovers/README.md`, whose first bullet asks for the correspondence between pointed connected covers of `(X, x₀)` and subgroups of `π₁(X, x₀)`; its existence half (item 7) and its injectivity half were merged separately, and the order-preserving half landed in #5571 as `exists_isCoveringMap_subgroupQuotientProj_comp_eq_iff_le`. After this PR the numbered items of the roadmap are discharged, and what remains of item 8 is only a packaging question — there is no type of pointed covers in the library, so the bijection is stated as surjectivity plus a uniqueness clause rather than as a single `OrderIso`.

New file `TauCeti/AlgebraicTopology/UniversalCover/Classification/Bijection.lean` (228 lines), with `subgroupQuotientMap_surjective` added to `Classification/SubgroupQuotient.lean`, next to the existing surjectivity of the descended projection. Main declarations: `exists_homeomorph_subgroupQuotient_of_range_eq`, `existsUnique_subgroup_homeomorph_subgroupQuotient`, `exists_homeomorph_subgroupQuotient_comp_eq_iff_eq`, `exists_homeomorph_subgroupQuotient_comp_eq_iff_exists_map_conj`, `isRegular_subgroupQuotientProj_iff_normal`, `subgroupQuotientBotHomeomorph` and `subgroupQuotientTopHomeomorph`. No Mathlib infrastructure is vendored: the based-path universal cover consumed here was adapted in earlier PRs from Kim Morrison's mathlib4#38292, and the lifting criterion underlying the comparison theorems is Junyan Xu's, in `Mathlib/Topology/Homotopy/Lifting.lean`. The mathematics is Hatcher, *Algebraic Topology*, Theorem 1.38 and the classification corollary that follows it.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"exists-homeomorph-subgroupquotientproj-comp-eq"}-->

🤖 Prepared with Claude Code
