### PR TITLE
feat(HeckeRing): multiplicativity of a linear extension is a basis-level condition

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/LinearExtension.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LinearExtension.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.Associativity
+
+/-!
+# Multiplicativity of a linear extension is a basis-level condition
+
+A `Z`-linear map out of the Hecke ring is determined by its values on the basis elements
+`single Z D 1`, one for each double coset. This file records that the same is true of its
+*multiplicativity*: `F (x * y) = F x * F y` for all `x` and `y` follows from the special case
+where both arguments are basis elements, and likewise for the reversed identity
+`F (x * y) = F y * F x`.
+
+That is not automatic. Multiplicativity is a statement about a pair of arguments, so reducing it
+to basis elements needs the convolution to be biadditive and to commute with the scalars on both
+flanks — the first two facts are `HeckeCosetModule.mul_add` and `HeckeCosetModule.add_mul`, and
+the third comes from `HeckeCosetModule.single_mul_single`, which exhibits
+`single Z D₁ a * single Z D₂ b` as `a • b •` the structure constants and hence as
+`a • b • (single Z D₁ 1 * single Z D₂ 1)`.
+
+## Why the reversed identity is stated too
+
+The Hecke ring acts on modular forms through the slash, which is a *right* action, while
+`Module.End` multiplies by composition. Every extension of a coset action over the Hecke ring is
+therefore an anti-homomorphism rather than a homomorphism — see
+`HeckeRing.GL2.twistedHeckeSlashRingCharLinearMap_mul_single_single`, whose conclusion puts the
+two factors in the opposite order. Both directions are recorded so that neither consumer has to
+route through `MulOpposite`.
+
+## What this does and does not close
+
+`Nebentypus/Composition.lean` already proves the basis-element identity for the twisted
+character-space extension, under hypotheses on the double-coset product, and its own
+documentation calls that "the generator-level input that a multiplicativity proof ... would
+consume; it does not itself close that gap, which concerns arbitrary Hecke-ring elements". This
+file supplies the missing implication in general, so what remains of that gap is entirely the
+double-coset combinatorics: an unconditional basis-element identity, with no ring theory left
+around it.
+
+## Main results
+
+* `HeckeCosetModule.map_mul_of_single_single`: a linear map that is multiplicative on basis
+  elements is multiplicative.
+* `HeckeCosetModule.map_mul_rev_of_single_single`: the same with the factors on the right-hand
+  side in the opposite order, the shape a right action produces.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.1 (the Hecke ring as a free module on the double cosets).
+-/
+
+public section
+
+namespace HeckeCosetModule
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H : Subgroup G} [IsHeckeTriple Δ H H]
+
+section Semiring
+
+variable {Z : Type*} [Semiring Z] {A : Type*} [Semiring A] [Module Z A]
+  [IsScalarTower Z A A] [SMulCommClass Z A A]
+
+/-- The product of two basis elements is the product of the two *unit* basis elements, scaled by
+the two coefficients. This is `single_mul_single` with the structure constants eliminated between
+the general and the unit case, which is the form the reductions below consume. -/
+private lemma single_mul_single_eq_smul_smul (D₁ D₂ : HeckeCoset Δ H H) (a b : Z) :
+    single Z D₁ a * single Z D₂ b = a • b • (single Z D₁ 1 * single Z D₂ 1) := by
+  rw [single_mul_single, single_mul_single, one_smul, one_smul]
+
+/-- **Multiplicativity is a basis-level condition.** A `Z`-linear map out of the Hecke ring that
+is multiplicative on the basis elements `single Z D 1` is multiplicative.
+
+The convolution is biadditive, so both sides are biadditive in `(x, y)` and the identity
+propagates from the basis by `HeckeCosetModule.induction_linear` in each argument; the
+coefficients come out through `single_mul_single` and go back in by linearity of `F`. -/
+theorem map_mul_of_single_single (F : 𝕋 Δ H Z →ₗ[Z] A)
+    (h : ∀ D₁ D₂ : HeckeCoset Δ H H,
+      F (single Z D₁ 1 * single Z D₂ 1) = F (single Z D₁ 1) * F (single Z D₂ 1))
+    (x y : 𝕋 Δ H Z) : F (x * y) = F x * F y := by
+  induction x using HeckeCosetModule.induction_linear with
+  | h0 => simp
+  | hadd x₁ x₂ h₁ h₂ => rw [_root_.add_mul, map_add, map_add, h₁, h₂, _root_.add_mul]
+  | hsingle D₁ a =>
+    induction y using HeckeCosetModule.induction_linear with
+    | h0 => simp
+    | hadd y₁ y₂ h₁ h₂ => rw [_root_.mul_add, map_add, map_add, h₁, h₂, _root_.mul_add]
+    | hsingle D₂ b =>
+      rw [single_mul_single_eq_smul_smul, map_smul, map_smul, h, ← smul_single_one Z D₁ a,
+        ← smul_single_one Z D₂ b, map_smul, map_smul, smul_mul_assoc, mul_smul_comm]
+
+end Semiring
+
+section CommSemiring
+
+variable {Z : Type*} [CommSemiring Z] {A : Type*} [Semiring A] [Module Z A]
+  [IsScalarTower Z A A] [SMulCommClass Z A A]
+
+/-- **Anti-multiplicativity is a basis-level condition.** The reversed counterpart of
+`HeckeCosetModule.map_mul_of_single_single`: a `Z`-linear map out of the Hecke ring that sends a
+product of basis elements to the composite of their images *in the opposite order* does so on all
+of the ring.
+
+This is the direction the slash action produces: it is a right action, `Module.End` multiplies by
+composition, and so the left factor of the Hecke-ring product is the operator applied first.
+
+Unlike the unreversed statement this one needs the coefficients to commute, and not for a
+technical reason: reversing the two factors exchanges their coefficients, so the two sides carry
+`a • b •` and `b • a •` respectively. The same asymmetry is already visible one level down, where
+`HeckeCosetModule.smul_mul` holds on the left flank of the convolution over any coefficient
+semiring and fails on the right flank over a noncommutative one. -/
+theorem map_mul_rev_of_single_single (F : 𝕋 Δ H Z →ₗ[Z] A)
+    (h : ∀ D₁ D₂ : HeckeCoset Δ H H,
+      F (single Z D₁ 1 * single Z D₂ 1) = F (single Z D₂ 1) * F (single Z D₁ 1))
+    (x y : 𝕋 Δ H Z) : F (x * y) = F y * F x := by
+  induction x using HeckeCosetModule.induction_linear with
+  | h0 => simp
+  | hadd x₁ x₂ h₁ h₂ => rw [_root_.add_mul, map_add, map_add, h₁, h₂, _root_.mul_add]
+  | hsingle D₁ a =>
+    induction y using HeckeCosetModule.induction_linear with
+    | h0 => simp
+    | hadd y₁ y₂ h₁ h₂ => rw [_root_.mul_add, map_add, map_add, h₁, h₂, _root_.add_mul]
+    | hsingle D₂ b =>
+      rw [single_mul_single_eq_smul_smul, map_smul, map_smul, h, ← smul_single_one Z D₁ a,
+        ← smul_single_one Z D₂ b, map_smul, map_smul, smul_mul_assoc, mul_smul_comm,
+        smul_smul, smul_smul, mul_comm a b]
+
+end CommSemiring
+
+end HeckeCosetModule
+
+end

--- a/TauCeti/NumberTheory/HeckeRing/LinearExtension.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LinearExtension.lean
@@ -30,13 +30,14 @@ The Hecke ring acts on modular forms through the slash, which is a *right* actio
 alongside the plain one, so a consumer whose basis identity comes out reversed — as
 `HeckeRing.GL2.twistedHeckeSlashRingCharLinearMap_mul_single_single` does — need not route
 through `MulOpposite` itself. The two statements are related exactly that way: the reversed one is
-the plain one applied to `op ∘ F`.
+the plain one applied to `op ∘ F`. Both live in the `LinearMap` namespace, so a consumer writes
+`F.map_mul_of_basis`.
 
 ## Main results
 
-* `HeckeCosetModule.map_mul_of_basis`: a linear map that is multiplicative on basis elements is
+* `LinearMap.map_mul_of_basis`: a linear map that is multiplicative on basis elements is
   multiplicative.
-* `HeckeCosetModule.map_mul_reverse_of_basis`: the same with the factors on the right-hand side in
+* `LinearMap.map_mul_reverse_of_basis`: the same with the factors on the right-hand side in
   the opposite order.
 
 ## References
@@ -60,11 +61,22 @@ private lemma single_mul_single_eq_smul_smul (D₁ D₂ : HeckeCoset Δ H H) (a 
     single Z D₁ a * single Z D₂ b = a • b • (single Z D₁ 1 * single Z D₂ 1) := by
   rw [single_mul_single, single_mul_single, one_smul, one_smul]
 
+end HeckeCosetModule
+
+namespace LinearMap
+
+open scoped HeckeCosetModule
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H : Subgroup G} [IsHeckeTriple Δ H H]
+variable {Z : Type*} [Semiring Z] {A : Type*} [NonUnitalNonAssocSemiring A] [Module Z A]
+  [IsScalarTower Z A A] [SMulCommClass Z A A]
+
 /-- **Multiplicativity is a basis-level condition.** A `Z`-linear map out of the Hecke ring that
-is multiplicative on the basis elements `single Z D 1` is multiplicative. -/
+is multiplicative on the basis elements `HeckeCosetModule.single Z D 1` is multiplicative. -/
 theorem map_mul_of_basis (F : 𝕋 Δ H Z →ₗ[Z] A)
     (h : ∀ D₁ D₂ : HeckeCoset Δ H H,
-      F (single Z D₁ 1 * single Z D₂ 1) = F (single Z D₁ 1) * F (single Z D₂ 1))
+      F (HeckeCosetModule.single Z D₁ 1 * HeckeCosetModule.single Z D₂ 1) =
+        F (HeckeCosetModule.single Z D₁ 1) * F (HeckeCosetModule.single Z D₂ 1))
     (x y : 𝕋 Δ H Z) : F (x * y) = F x * F y := by
   induction x using HeckeCosetModule.induction_linear with
   | h0 => simp
@@ -74,8 +86,9 @@ theorem map_mul_of_basis (F : 𝕋 Δ H Z →ₗ[Z] A)
     | h0 => simp
     | hadd y₁ y₂ h₁ h₂ => rw [_root_.mul_add, map_add, map_add, h₁, h₂, _root_.mul_add]
     | hsingle D₂ b =>
-      rw [single_mul_single_eq_smul_smul, map_smul, map_smul, h, ← smul_single_one Z D₁ a,
-        ← smul_single_one Z D₂ b, map_smul, map_smul, smul_mul_assoc, mul_smul_comm]
+      rw [HeckeCosetModule.single_mul_single_eq_smul_smul, map_smul, map_smul, h,
+        ← HeckeCosetModule.smul_single_one Z D₁ a, ← HeckeCosetModule.smul_single_one Z D₂ b,
+        map_smul, map_smul, smul_mul_assoc, mul_smul_comm]
 
 /-- **Anti-multiplicativity is a basis-level condition.** A `Z`-linear map out of the Hecke ring
 that sends a product of basis elements to the product of their images *in the opposite order* does
@@ -85,12 +98,13 @@ This is the order a right action produces, so it is the shape a slash-derived ex
 in; it is `map_mul_of_basis` for the map `op ∘ F` into `Aᵐᵒᵖ`. -/
 theorem map_mul_reverse_of_basis (F : 𝕋 Δ H Z →ₗ[Z] A)
     (h : ∀ D₁ D₂ : HeckeCoset Δ H H,
-      F (single Z D₁ 1 * single Z D₂ 1) = F (single Z D₂ 1) * F (single Z D₁ 1))
+      F (HeckeCosetModule.single Z D₁ 1 * HeckeCosetModule.single Z D₂ 1) =
+        F (HeckeCosetModule.single Z D₂ 1) * F (HeckeCosetModule.single Z D₁ 1))
     (x y : 𝕋 Δ H Z) : F (x * y) = F y * F x :=
   congrArg MulOpposite.unop <|
     map_mul_of_basis ((MulOpposite.opLinearEquiv Z).toLinearMap.comp F)
       (fun D₁ D₂ ↦ by simpa [MulOpposite.op_mul] using congrArg MulOpposite.op (h D₁ D₂)) x y
 
-end HeckeCosetModule
+end LinearMap
 
 end

--- a/TauCeti/NumberTheory/HeckeRing/LinearExtension.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LinearExtension.lean
@@ -5,49 +5,39 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.NumberTheory.HeckeRing.Associativity
+public import Mathlib.Algebra.Module.LinearMap.Defs
+public import Mathlib.Algebra.Module.Equiv.Opposite
+public import TauCeti.NumberTheory.HeckeRing.Multiplication
 
 /-!
 # Multiplicativity of a linear extension is a basis-level condition
 
 A `Z`-linear map out of the Hecke ring is determined by its values on the basis elements
-`single Z D 1`, one for each double coset. This file records that the same is true of its
-*multiplicativity*: `F (x * y) = F x * F y` for all `x` and `y` follows from the special case
-where both arguments are basis elements, and likewise for the reversed identity
-`F (x * y) = F y * F x`.
+`single Z D 1`, one for each double coset. The same is true of its *multiplicativity*:
+`F (x * y) = F x * F y` for all `x` and `y` follows from the special case where both arguments
+are basis elements, and likewise for the reversed identity `F (x * y) = F y * F x`.
 
 That is not automatic. Multiplicativity is a statement about a pair of arguments, so reducing it
 to basis elements needs the convolution to be biadditive and to commute with the scalars on both
-flanks — the first two facts are `HeckeCosetModule.mul_add` and `HeckeCosetModule.add_mul`, and
-the third comes from `HeckeCosetModule.single_mul_single`, which exhibits
+flanks. `HeckeCosetModule.single_mul_single` supplies the latter, exhibiting
 `single Z D₁ a * single Z D₂ b` as `a • b •` the structure constants and hence as
 `a • b • (single Z D₁ 1 * single Z D₂ 1)`.
 
-## Why the reversed identity is stated too
+## The reversed identity
 
 The Hecke ring acts on modular forms through the slash, which is a *right* action, while
-`Module.End` multiplies by composition. Every extension of a coset action over the Hecke ring is
-therefore an anti-homomorphism rather than a homomorphism — see
-`HeckeRing.GL2.twistedHeckeSlashRingCharLinearMap_mul_single_single`, whose conclusion puts the
-two factors in the opposite order. Both directions are recorded so that neither consumer has to
-route through `MulOpposite`.
-
-## What this does and does not close
-
-`Nebentypus/Composition.lean` already proves the basis-element identity for the twisted
-character-space extension, under hypotheses on the double-coset product, and its own
-documentation calls that "the generator-level input that a multiplicativity proof ... would
-consume; it does not itself close that gap, which concerns arbitrary Hecke-ring elements". This
-file supplies the missing implication in general, so what remains of that gap is entirely the
-double-coset combinatorics: an unconditional basis-element identity, with no ring theory left
-around it.
+`Module.End` multiplies by composition; that is what motivates recording the reversed order
+alongside the plain one, so a consumer whose basis identity comes out reversed — as
+`HeckeRing.GL2.twistedHeckeSlashRingCharLinearMap_mul_single_single` does — need not route
+through `MulOpposite` itself. The two statements are related exactly that way: the reversed one is
+the plain one applied to `op ∘ F`.
 
 ## Main results
 
-* `HeckeCosetModule.map_mul_of_single_single`: a linear map that is multiplicative on basis
-  elements is multiplicative.
-* `HeckeCosetModule.map_mul_rev_of_single_single`: the same with the factors on the right-hand
-  side in the opposite order, the shape a right action produces.
+* `HeckeCosetModule.map_mul_of_basis`: a linear map that is multiplicative on basis elements is
+  multiplicative.
+* `HeckeCosetModule.map_mul_reverse_of_basis`: the same with the factors on the right-hand side in
+  the opposite order.
 
 ## References
 
@@ -60,10 +50,7 @@ public section
 namespace HeckeCosetModule
 
 variable {G : Type*} [Group G] {Δ : Submonoid G} {H : Subgroup G} [IsHeckeTriple Δ H H]
-
-section Semiring
-
-variable {Z : Type*} [Semiring Z] {A : Type*} [Semiring A] [Module Z A]
+variable {Z : Type*} [Semiring Z] {A : Type*} [NonUnitalNonAssocSemiring A] [Module Z A]
   [IsScalarTower Z A A] [SMulCommClass Z A A]
 
 /-- The product of two basis elements is the product of the two *unit* basis elements, scaled by
@@ -74,12 +61,8 @@ private lemma single_mul_single_eq_smul_smul (D₁ D₂ : HeckeCoset Δ H H) (a 
   rw [single_mul_single, single_mul_single, one_smul, one_smul]
 
 /-- **Multiplicativity is a basis-level condition.** A `Z`-linear map out of the Hecke ring that
-is multiplicative on the basis elements `single Z D 1` is multiplicative.
-
-The convolution is biadditive, so both sides are biadditive in `(x, y)` and the identity
-propagates from the basis by `HeckeCosetModule.induction_linear` in each argument; the
-coefficients come out through `single_mul_single` and go back in by linearity of `F`. -/
-theorem map_mul_of_single_single (F : 𝕋 Δ H Z →ₗ[Z] A)
+is multiplicative on the basis elements `single Z D 1` is multiplicative. -/
+theorem map_mul_of_basis (F : 𝕋 Δ H Z →ₗ[Z] A)
     (h : ∀ D₁ D₂ : HeckeCoset Δ H H,
       F (single Z D₁ 1 * single Z D₂ 1) = F (single Z D₁ 1) * F (single Z D₂ 1))
     (x y : 𝕋 Δ H Z) : F (x * y) = F x * F y := by
@@ -94,43 +77,19 @@ theorem map_mul_of_single_single (F : 𝕋 Δ H Z →ₗ[Z] A)
       rw [single_mul_single_eq_smul_smul, map_smul, map_smul, h, ← smul_single_one Z D₁ a,
         ← smul_single_one Z D₂ b, map_smul, map_smul, smul_mul_assoc, mul_smul_comm]
 
-end Semiring
+/-- **Anti-multiplicativity is a basis-level condition.** A `Z`-linear map out of the Hecke ring
+that sends a product of basis elements to the product of their images *in the opposite order* does
+so on all of the ring.
 
-section CommSemiring
-
-variable {Z : Type*} [CommSemiring Z] {A : Type*} [Semiring A] [Module Z A]
-  [IsScalarTower Z A A] [SMulCommClass Z A A]
-
-/-- **Anti-multiplicativity is a basis-level condition.** The reversed counterpart of
-`HeckeCosetModule.map_mul_of_single_single`: a `Z`-linear map out of the Hecke ring that sends a
-product of basis elements to the composite of their images *in the opposite order* does so on all
-of the ring.
-
-This is the direction the slash action produces: it is a right action, `Module.End` multiplies by
-composition, and so the left factor of the Hecke-ring product is the operator applied first.
-
-Unlike the unreversed statement this one needs the coefficients to commute, and not for a
-technical reason: reversing the two factors exchanges their coefficients, so the two sides carry
-`a • b •` and `b • a •` respectively. The same asymmetry is already visible one level down, where
-`HeckeCosetModule.smul_mul` holds on the left flank of the convolution over any coefficient
-semiring and fails on the right flank over a noncommutative one. -/
-theorem map_mul_rev_of_single_single (F : 𝕋 Δ H Z →ₗ[Z] A)
+This is the order a right action produces, so it is the shape a slash-derived extension arrives
+in; it is `map_mul_of_basis` for the map `op ∘ F` into `Aᵐᵒᵖ`. -/
+theorem map_mul_reverse_of_basis (F : 𝕋 Δ H Z →ₗ[Z] A)
     (h : ∀ D₁ D₂ : HeckeCoset Δ H H,
       F (single Z D₁ 1 * single Z D₂ 1) = F (single Z D₂ 1) * F (single Z D₁ 1))
-    (x y : 𝕋 Δ H Z) : F (x * y) = F y * F x := by
-  induction x using HeckeCosetModule.induction_linear with
-  | h0 => simp
-  | hadd x₁ x₂ h₁ h₂ => rw [_root_.add_mul, map_add, map_add, h₁, h₂, _root_.mul_add]
-  | hsingle D₁ a =>
-    induction y using HeckeCosetModule.induction_linear with
-    | h0 => simp
-    | hadd y₁ y₂ h₁ h₂ => rw [_root_.mul_add, map_add, map_add, h₁, h₂, _root_.add_mul]
-    | hsingle D₂ b =>
-      rw [single_mul_single_eq_smul_smul, map_smul, map_smul, h, ← smul_single_one Z D₁ a,
-        ← smul_single_one Z D₂ b, map_smul, map_smul, smul_mul_assoc, mul_smul_comm,
-        smul_smul, smul_smul, mul_comm a b]
-
-end CommSemiring
+    (x y : 𝕋 Δ H Z) : F (x * y) = F y * F x :=
+  congrArg MulOpposite.unop <|
+    map_mul_of_basis ((MulOpposite.opLinearEquiv Z).toLinearMap.comp F)
+      (fun D₁ D₂ ↦ by simpa [MulOpposite.op_mul] using congrArg MulOpposite.op (h D₁ D₂)) x y
 
 end HeckeCosetModule
 

--- a/TauCeti/NumberTheory/HeckeRing/LinearExtension.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LinearExtension.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Module.LinearMap.Defs
 public import Mathlib.Algebra.Module.Equiv.Opposite
 public import TauCeti.NumberTheory.HeckeRing.Multiplication
 
@@ -17,20 +16,13 @@ A `Z`-linear map out of the Hecke ring is determined by its values on the basis 
 `F (x * y) = F x * F y` for all `x` and `y` follows from the special case where both arguments
 are basis elements, and likewise for the reversed identity `F (x * y) = F y * F x`.
 
-That is not automatic. Multiplicativity is a statement about a pair of arguments, so reducing it
-to basis elements needs the convolution to be biadditive and to commute with the scalars on both
-flanks. `HeckeCosetModule.single_mul_single` supplies the latter, exhibiting
-`single Z D₁ a * single Z D₂ b` as `a • b •` the structure constants and hence as
-`a • b • (single Z D₁ 1 * single Z D₂ 1)`.
-
 ## The reversed identity
 
 The Hecke ring acts on modular forms through the slash, which is a *right* action, while
 `Module.End` multiplies by composition; that is what motivates recording the reversed order
 alongside the plain one, so a consumer whose basis identity comes out reversed — as
 `HeckeRing.GL2.twistedHeckeSlashRingCharLinearMap_mul_single_single` does — need not route
-through `MulOpposite` itself. The two statements are related exactly that way: the reversed one is
-the plain one applied to `op ∘ F`. Both live in the `LinearMap` namespace, so a consumer writes
+through `MulOpposite` itself. Both live in the `LinearMap` namespace, so a consumer writes
 `F.map_mul_of_basis`.
 
 ## Main results
@@ -78,6 +70,9 @@ theorem map_mul_of_basis (F : 𝕋 Δ H Z →ₗ[Z] A)
       F (HeckeCosetModule.single Z D₁ 1 * HeckeCosetModule.single Z D₂ 1) =
         F (HeckeCosetModule.single Z D₁ 1) * F (HeckeCosetModule.single Z D₂ 1))
     (x y : 𝕋 Δ H Z) : F (x * y) = F x * F y := by
+  -- Both sides are biadditive in `(x, y)`, so `induction_linear` in each argument reduces to a
+  -- pair of basis elements; there `single_mul_single_eq_smul_smul` releases the two coefficients
+  -- and linearity of `F` puts them back.
   induction x using HeckeCosetModule.induction_linear with
   | h0 => simp
   | hadd x₁ x₂ h₁ h₂ => rw [_root_.add_mul, map_add, map_add, h₁, h₂, _root_.add_mul]
@@ -95,12 +90,14 @@ that sends a product of basis elements to the product of their images *in the op
 so on all of the ring.
 
 This is the order a right action produces, so it is the shape a slash-derived extension arrives
-in; it is `map_mul_of_basis` for the map `op ∘ F` into `Aᵐᵒᵖ`. -/
+in. -/
 theorem map_mul_reverse_of_basis (F : 𝕋 Δ H Z →ₗ[Z] A)
     (h : ∀ D₁ D₂ : HeckeCoset Δ H H,
       F (HeckeCosetModule.single Z D₁ 1 * HeckeCosetModule.single Z D₂ 1) =
         F (HeckeCosetModule.single Z D₂ 1) * F (HeckeCosetModule.single Z D₁ 1))
     (x y : 𝕋 Δ H Z) : F (x * y) = F y * F x :=
+  -- `op` turns the reversed hypothesis into the plain one over `Aᵐᵒᵖ`, so this is
+  -- `map_mul_of_basis` for `op ∘ F`, read back through `unop`.
   congrArg MulOpposite.unop <|
     map_mul_of_basis ((MulOpposite.opLinearEquiv Z).toLinearMap.comp F)
       (fun D₁ D₂ ↦ by simpa [MulOpposite.op_mul] using congrArg MulOpposite.op (h D₁ D₂)) x y


### PR DESCRIPTION
A `Z`-linear map out of the Hecke ring is multiplicative as soon as it is multiplicative on the
basis elements, and likewise for the reversed identity:

```lean
theorem LinearMap.map_mul_of_basis (F : 𝕋 Δ H Z →ₗ[Z] A)
    (h : ∀ D₁ D₂, F (single Z D₁ 1 * single Z D₂ 1) = F (single Z D₁ 1) * F (single Z D₂ 1))
    (x y : 𝕋 Δ H Z) : F (x * y) = F x * F y

theorem LinearMap.map_mul_reverse_of_basis (F : 𝕋 Δ H Z →ₗ[Z] A)
    (h : ∀ D₁ D₂, F (single Z D₁ 1 * single Z D₂ 1) = F (single Z D₂ 1) * F (single Z D₁ 1))
    (x y : 𝕋 Δ H Z) : F (x * y) = F y * F x
```

## What this closes

`HeckeSlash/Nebentypus/Composition.lean` proves the basis-element identity for the twisted
character-space extension, and says of it:

> This is the generator-level input that a multiplicativity proof for
> `twistedHeckeSlashRingLinearMap` would consume; it does not itself close that gap, which
> concerns arbitrary Hecke-ring elements on all of `ℍ → ℂ`.

This PR supplies that implication in general. What is left of the gap is now entirely
double-coset combinatorics — an *unconditional* basis-element identity — with no ring theory
around it. The ModularForms roadmap's `STATUS.md` lists the consequence on its frontier:
"prove that the linear extension of the Γ₀(N) Hecke ring acts multiplicatively on each nebentypus
space".

It applies to the intended consumer with no plumbing; this compiles today, against the
character-space extension, on the hypothesis that remains open:

```lean
example {N : ℕ} [NeZero N] (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
    (h : ∀ D₁ D₂, twistedHeckeSlashRingCharLinearMap k χ (single ℤ D₁ 1 * single ℤ D₂ 1) =
      twistedHeckeSlashRingCharLinearMap k χ (single ℤ D₂ 1) *
        twistedHeckeSlashRingCharLinearMap k χ (single ℤ D₁ 1))
    (x y : 𝕋 (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ℤ) :
    twistedHeckeSlashRingCharLinearMap k χ (x * y) =
      twistedHeckeSlashRingCharLinearMap k χ y * twistedHeckeSlashRingCharLinearMap k χ x :=
  LinearMap.map_mul_reverse_of_basis _ h x y
```

## Why the reduction is not automatic

Multiplicativity is a statement about a *pair* of arguments, so reducing it to the basis needs the
convolution to be biadditive and to release both coefficients. The first is
`HeckeCosetModule.mul_add`/`add_mul`; the second is `HeckeCosetModule.single_mul_single`, which
exhibits `single Z D₁ a * single Z D₂ b` as `a • b •` the structure constants and hence as
`a • b • (single Z D₁ 1 * single Z D₂ 1)`. `HeckeCosetModule.induction_linear` then carries the
identity out of the basis in each argument separately — the same shape `Associativity.lean` uses
for `mul_assoc`.

## Why both directions

The Hecke ring acts on modular forms through the slash, a *right* action, while `Module.End`
multiplies by composition, so a basis identity coming from a slash arrives reversed —
`twistedHeckeSlashRingCharLinearMap_mul_single_single` is stated in exactly that form. Recording
both directions saves the consumer a trip through `MulOpposite`; the reversed theorem *is* the
plain one applied to `op ∘ F`, which is how it is proved, so the second statement costs no second
induction.

The ambient generality is `[NonUnitalNonAssocSemiring A]` with
`[Module Z A] [IsScalarTower Z A A] [SMulCommClass Z A A]` rather than `Algebra Z A`: only
distributivity and a zero are used in the codomain, and the intended instance `Z = ℤ` with
`A = Module.End ℂ V` is then found without an algebra structure being asked for. The coefficients
need not commute in either direction.

Roadmap: ModularForms

New mathematics, so the citation: this supplies a prerequisite for the Layer 2 target of
`TauCetiRoadmap/ModularForms/README.md` — the Hecke-ring action on the nebentypus character
spaces — and does not author it, since the basis-element identity it reduces to is still open.
No `tauceti-target` marker for that reason.

Provenance: none. [AINTLIB](https://github.com/CBirkbeck/AINTLIB) @
`2baa76f742bdb4fb8ee323fabba41203bd390e08` has the linear-induction principle
(`HeckeRIngs/AbstractHeckeRing/Ring.lean`, `induction_linear_𝕋`) and applies it inline for
`mul_comm` and for the degree map, but states no reduction of this kind; this repository's
`HeckeCosetModule.induction_linear` is already the port of that principle. Mathlib's
`NumberTheory/HeckeRing/Defs.lean` carries no convolution product, so nothing of this shape can
exist upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR


