### PR TITLE
feat(CanonicalHeight): the Néron–Tate pairing

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.NaiveHeight
+public import Mathlib.LinearAlgebra.QuadraticForm.Basic
+public import TauCeti.LinearAlgebra.End.InvertibleTwo
 import TauCeti.LinearAlgebra.QuadraticForm.OfParallelogram
 
 /-!
@@ -30,6 +32,10 @@ with — is half of it. Getting this wrong would scale every later invariant.
 ## Main definitions
 
 * `WeierstrassCurve.Affine.Point.canonicalHeight`: the limit above.
+* `WeierstrassCurve.Affine.canonicalHeightQuadratic`: the canonical height as a `ℤ`-quadratic map
+  with real values, which is the form Mathlib's polarisation API consumes.
+* `WeierstrassCurve.Affine.neronTatePairing`: the **Néron–Tate pairing**, the bilinear form
+  associated with that quadratic map.
 
 ## Main results
 
@@ -63,6 +69,17 @@ with — is half of it. Getting this wrong would scale every later invariant.
   constant depending only on the curve. This is what makes the two interchangeable in
   finiteness arguments — in particular Northcott finiteness transfers to it, which the `Northcott`
   instance below makes formal.
+* `WeierstrassCurve.Affine.neronTatePairing_apply`: the pairing is the polarisation — its value
+  at `P, Q` is half of `canonicalHeight (P + Q) - canonicalHeight P - canonicalHeight Q`.
+* `WeierstrassCurve.Affine.neronTatePairing_self`: it recovers the canonical height on the
+  diagonal, so the pairing and the height determine each other.
+* `WeierstrassCurve.Affine.neronTatePairing_eq_zero_of_isOfFinAddOrder_left` and
+  `WeierstrassCurve.Affine.neronTatePairing_eq_zero_of_isOfFinAddOrder_right`: it vanishes as soon
+  as either argument is torsion, which is what lets it descend to the free quotient
+  `W.Point ⧸ torsion` where the regulator is defined.
+* `WeierstrassCurve.Affine.neronTatePairing_comm` and
+  `WeierstrassCurve.Affine.neronTatePairing_flip`: it is symmetric, pointwise and as an equality
+  of bilinear maps.
 
 ## Implementation notes
 
@@ -323,5 +340,86 @@ theorem Point.canonicalHeight_eq_zero_iff_isOfFinAddOrder [W.toAffine.IsElliptic
     P.canonicalHeight = 0 ↔ IsOfFinAddOrder P :=
   ⟨Point.isOfFinAddOrder_of_canonicalHeight_eq_zero,
     Point.canonicalHeight_eq_zero_of_isOfFinAddOrder⟩
+
+variable (W) in
+/-- **The canonical height as a `ℤ`-quadratic map** with values in `ℝ`, which is what makes
+Mathlib's polarisation API available to it. -/
+noncomputable def canonicalHeightQuadratic [W.toAffine.IsElliptic] : QuadraticMap ℤ W.Point ℝ :=
+  TauCeti.QuadraticMap.ofParallelogram (smul_right_injective ℝ two_ne_zero)
+    canonicalHeight_parallelogram_nsmul
+
+-- Proved by applying `ofParallelogram_apply` rather than by unfolding the definition: since
+-- `canonicalHeight_parallelogram_nsmul` is `private`, the elaborator hoists it into an auxiliary
+-- constant that `simp [canonicalHeightQuadratic]` cannot see through.
+/-- The quadratic map is the canonical height. -/
+@[simp]
+theorem canonicalHeightQuadratic_apply [W.toAffine.IsElliptic] (P : W.Point) :
+    canonicalHeightQuadratic W P = P.canonicalHeight :=
+  TauCeti.QuadraticMap.ofParallelogram_apply _ _ P
+
+/-- The quadratic map is the canonical height, as functions. -/
+-- `QuadraticMap.polar` takes the function rather than its values, so this is the form that
+-- rewrites `polar ⇑(canonicalHeightQuadratic W)` into `polar Point.canonicalHeight`; the same
+-- reason `TauCeti.QuadraticMap.coe_ofParallelogram` is stated unapplied.
+@[simp]
+theorem coe_canonicalHeightQuadratic [W.toAffine.IsElliptic] :
+    (canonicalHeightQuadratic W : W.Point → ℝ) = fun P ↦ P.canonicalHeight :=
+  TauCeti.QuadraticMap.coe_ofParallelogram _ _
+
+variable (W) in
+-- `QuadraticMap.associated'` is available here because `TauCeti.instInvertibleTwoModuleEndInt`
+-- supplies the `Invertible (2 : Module.End ℤ ℝ)` that the halving needs.
+/-- **The Néron–Tate pairing** `⟨P, Q⟩`, the bilinear form associated with the canonical height.
+It is Mathlib's `QuadraticMap.associated'`, the halved polar form. -/
+noncomputable def neronTatePairing [W.toAffine.IsElliptic] : LinearMap.BilinMap ℤ W.Point ℝ :=
+  QuadraticMap.associated' (canonicalHeightQuadratic W)
+
+-- Deliberately **not** `@[simp]`, for the reason recorded on
+-- `Point.naiveHeight_eq_logHeight`: tagging a defining equation makes the pairing disappear on
+-- sight, which puts the sharper `neronTatePairing_self` out of simp-normal form. With `@[simp]`
+-- here the `simpNF` linter fails on `neronTatePairing_self`, reporting that its left-hand side
+-- simplifies to `((P + P).canonicalHeight - P.canonicalHeight - P.canonicalHeight) / 2`.
+/-- **The Néron–Tate pairing is the polarisation of the canonical height**: its value at `P, Q`
+is half of `canonicalHeight (P + Q) - canonicalHeight P - canonicalHeight Q`. -/
+theorem neronTatePairing_apply [W.toAffine.IsElliptic] (P Q : W.Point) : neronTatePairing W P Q =
+    ((P + Q).canonicalHeight - P.canonicalHeight - Q.canonicalHeight) / 2 := by
+  simp [neronTatePairing, QuadraticMap.associated_apply, inv_mul_eq_div]
+
+/-- **The pairing recovers the canonical height on the diagonal.** -/
+@[simp]
+theorem neronTatePairing_self [W.toAffine.IsElliptic] (P : W.Point) :
+    neronTatePairing W P P = P.canonicalHeight :=
+  (QuadraticMap.associated_eq_self_apply ℤ (canonicalHeightQuadratic W) P).trans
+    (canonicalHeightQuadratic_apply P)
+
+/-- **The pairing kills torsion in its first argument.** Together with symmetry this is what lets
+the pairing descend to the free quotient `W.Point ⧸ torsion`, where the regulator lives. -/
+@[simp]
+theorem neronTatePairing_eq_zero_of_isOfFinAddOrder_left [W.toAffine.IsElliptic] {P : W.Point}
+    (h : IsOfFinAddOrder P) (Q : W.Point) : neronTatePairing W P Q = 0 := by
+  -- `P ↦ ⟨P, Q⟩` is additive, so it preserves finite order, and `ℝ` is torsion-free.
+  -- (Taken through `flip` rather than on `neronTatePairing W` itself, because the space of
+  -- linear maps carries no `IsAddTorsionFree` instance.)
+  simpa using ((((neronTatePairing W).flip Q).toAddMonoidHom.isOfFinAddOrder h).eq_zero')
+
+/-- **The pairing is symmetric**: `⟨P, Q⟩ = ⟨Q, P⟩`. -/
+theorem neronTatePairing_comm [W.toAffine.IsElliptic] (P Q : W.Point) :
+    neronTatePairing W P Q = neronTatePairing W Q P :=
+  QuadraticMap.associated_isSymm ℤ (canonicalHeightQuadratic W) P Q
+
+/-- **The pairing kills torsion in its second argument.** -/
+@[simp]
+theorem neronTatePairing_eq_zero_of_isOfFinAddOrder_right [W.toAffine.IsElliptic] (P : W.Point)
+    {Q : W.Point} (h : IsOfFinAddOrder Q) : neronTatePairing W P Q = 0 := by
+  rw [neronTatePairing_comm, neronTatePairing_eq_zero_of_isOfFinAddOrder_left h]
+
+-- `LinearMap.IsSymm` does not apply to a bilinear map whose target is not the scalar ring, which
+-- is why symmetry is stated pointwise above and as `flip` here; Mathlib documents
+-- `QuadraticMap.associated_flip` as the general-target version for exactly this reason.
+/-- **The pairing is symmetric**, as an equality of bilinear maps. -/
+@[simp]
+theorem neronTatePairing_flip [W.toAffine.IsElliptic] :
+    (neronTatePairing W).flip = neronTatePairing W :=
+  QuadraticMap.associated_flip ℤ (canonicalHeightQuadratic W)
 
 end WeierstrassCurve.Affine


### PR DESCRIPTION
Roadmap: EllipticCurves

The **Néron–Tate pairing** on `W.Point`, as the bilinear form Mathlib associates with a quadratic
map — not as a fresh construction.

## Why it is a citation rather than a construction

The canonical height already satisfies the parallelogram law *exactly* on `main`
(`Point.canonicalHeight_parallelogram_law`), and `TauCeti.QuadraticMap.ofParallelogram` already
turns such a function into a `QuadraticMap ℤ W.Point ℝ`. Mathlib then supplies the polarisation of
a quadratic map, `QuadraticMap.associated'`, together with its symmetry and diagonal value. So the
pairing is one application of existing API in each direction, and the only thing that was missing
was the halving: `associated'` needs `Invertible (2 : Module.End ℤ W.Point)`, which is what the
prerequisite PR supplies.

Concretely, of the ten declarations here, six are proved by Mathlib citations alone:

| declaration | proof |
|---|---|
| `neronTatePairing_self` | `QuadraticMap.associated_eq_self_apply` |
| `neronTatePairing_comm` | `QuadraticMap.associated_isSymm` |
| `neronTatePairing_flip` | `QuadraticMap.associated_flip` |
| `coe_canonicalHeightQuadratic` | `TauCeti.QuadraticMap.coe_ofParallelogram` |

## What it adds

```lean
noncomputable def canonicalHeightQuadratic [W.toAffine.IsElliptic] : QuadraticMap ℤ W.Point ℝ

@[simp] theorem canonicalHeightQuadratic_apply [W.toAffine.IsElliptic] (P : W.Point) :
    canonicalHeightQuadratic W P = P.canonicalHeight

-- the unapplied form, which is what `QuadraticMap.polar` consumes
@[simp] theorem coe_canonicalHeightQuadratic [W.toAffine.IsElliptic] :
    (canonicalHeightQuadratic W : W.Point → ℝ) = fun P ↦ P.canonicalHeight

noncomputable def neronTatePairing [W.toAffine.IsElliptic] : LinearMap.BilinMap ℤ W.Point ℝ :=
  QuadraticMap.associated' (canonicalHeightQuadratic W)

theorem neronTatePairing_apply [W.toAffine.IsElliptic] (P Q : W.Point) :
    neronTatePairing W P Q =
      ((P + Q).canonicalHeight - P.canonicalHeight - Q.canonicalHeight) / 2

@[simp] theorem neronTatePairing_self [W.toAffine.IsElliptic] (P : W.Point) :
    neronTatePairing W P P = P.canonicalHeight

theorem neronTatePairing_comm [W.toAffine.IsElliptic] (P Q : W.Point) :
    neronTatePairing W P Q = neronTatePairing W Q P

@[simp] theorem neronTatePairing_flip [W.toAffine.IsElliptic] :
    (neronTatePairing W).flip = neronTatePairing W

-- what lets the pairing descend to the free quotient
@[simp] theorem neronTatePairing_eq_zero_of_isOfFinAddOrder_left [W.toAffine.IsElliptic]
    {P : W.Point} (h : IsOfFinAddOrder P) (Q : W.Point) : neronTatePairing W P Q = 0

@[simp] theorem neronTatePairing_eq_zero_of_isOfFinAddOrder_right [W.toAffine.IsElliptic]
    (P : W.Point) {Q : W.Point} (h : IsOfFinAddOrder Q) : neronTatePairing W P Q = 0
```

The torsion-vanishing pair is two Mathlib citations: `P ↦ ⟨P, Q⟩` is additive, so
`AddMonoidHom.isOfFinAddOrder` carries finite order across it, and `IsOfFinAddOrder.eq_zero'`
kills a finite-order element of a torsion-free group. It is taken through
`(neronTatePairing W).flip Q` rather than through `neronTatePairing W` itself, because the target
must be where the `IsAddTorsionFree` instance lives: `ℝ` has one, the space
`W.Point →ₗ[ℤ] ℝ` does not, and asking for it fails with
`failed to synthesize instance of type class IsAddTorsionFree (W.Point →ₗ[ℤ] ℝ)`. No height
estimate and no Northcott hypothesis is involved — the same reason
`canonicalHeight_eq_zero_of_isOfFinAddOrder` needs none.

## Three things worth flagging

**`neronTatePairing_apply` is deliberately not `@[simp]`, and this was measured rather than
assumed.** It is the defining equation, so tagging it makes the pairing disappear on sight and
strands the sharper `neronTatePairing_self`. Adding `@[simp]` and running the `#lint` environment
set fails on exactly that:

```
error: @WeierstrassCurve.Affine.neronTatePairing_self Left-hand side simplifies from
  (W.neronTatePairing P) P
to
  ((P + P).canonicalHeight - P.canonicalHeight - P.canonicalHeight) / 2
using
  simp only [*, @WeierstrassCurve.Affine.neronTatePairing_apply]
```

So the two tags are mutually exclusive, and `⟨P, P⟩ = canonicalHeight P` is the better normal form
than a three-term difference of heights. This is the same trade-off already recorded on
`Divisor.eval_eq_finsuppProd` and `Point.naiveHeight_eq_logHeight`, and the reason is now in a
comment at the declaration.

The other way round the choice would be legal — tag `_apply` and untag `_self` — and it is worse:
it would make `simp` turn `⟨P, P⟩` into a three-term difference of heights and then leave it
there, when the whole content of `neronTatePairing_self` is that this collapses back to
`canonicalHeight P`. Every consumer wanting the value at a pair can name `neronTatePairing_apply`
explicitly; nobody wants the diagonal expanded.

**Symmetry is stated twice, and that is not redundancy.** `LinearMap.IsSymm` does not typecheck
for a bilinear map whose target is not the scalar ring, so it is unavailable for
`BilinMap ℤ W.Point ℝ`. Mathlib hit the same wall and says so at `associated_flip`: "a version of
`QuadraticMap.associated_isSymm` for general targets (using `flip` because `IsSymm` does not apply
here)". The pointwise form is what rewrites under a pair of arguments; the `flip` form is what a
consumer transports. Both are one-line citations.

**`canonicalHeightQuadratic_apply` is proved by applying `ofParallelogram_apply`, not by
unfolding.** `canonicalHeight_parallelogram_nsmul` is `private`, so the elaborator hoists it into
an auxiliary constant that `simp [canonicalHeightQuadratic]` cannot see through. Consumers should
use the `@[simp]` lemma rather than unfolding the definition; the reason is recorded in a comment
at the declaration.

## The prerequisite is imported publicly, and that was measured

`TauCeti.LinearAlgebra.End.InvertibleTwo` is a **`public import`**. A private import compiles this
module perfectly well — the instance is visible to its own proof bodies — but silently breaks the
declaration's whole purpose for anyone downstream, because `canonicalHeightQuadratic` is public
while the `Invertible` instance would not be. A consumer module doing

```lean
public import TauCeti.AlgebraicGeometry.EllipticCurve.CanonicalHeight
noncomputable example [W.toAffine.IsElliptic] : LinearMap.BilinMap ℤ W.Point ℝ :=
  QuadraticMap.associated' (canonicalHeightQuadratic W)
```

fails with `failed to synthesize instance of type class Invertible 2` under the private import and
compiles under the public one. Both halves were built.

`OfParallelogram`, by contrast, stays a **private** import: none of its own declarations
(`ofParallelogram`, `coe_ofParallelogram`, `ofParallelogram_apply`) occurs in an exported
signature — they are used only in definition and proof bodies. What *does* occur there is
Mathlib's `QuadraticMap`, which an earlier draft reached by re-exporting `OfParallelogram`
wholesale; that exposed general parallelogram-law infrastructure to every canonical-height
consumer. `public import Mathlib.LinearAlgebra.QuadraticForm.Basic` supplies the type directly
instead, and both the `associated'` consumer above and a consumer taking the pairing down to the
free quotient were rebuilt to confirm the narrower surface is sufficient.

## The prerequisite it needed

`QuadraticMap.associated'` needs `Invertible (2 : Module.End ℤ ℝ)`, which Mathlib has no instance
reaching — its only route asks for `Invertible (2 : ℤ)`. That instance landed separately in #5647
(*doubling is invertible on the ℤ-endomorphisms of a real vector space*) as general endomorphism
infrastructure rather than elliptic-curve mathematics, one topic per PR. It is on `main`, so this
branch sits directly on `main` and depends on nothing unmerged.

## Roadmap position

`TauCetiRoadmap/EllipticCurves/README.md` §Layer 6 names the **Néron–Tate bilinear pairing** among
the canonical-height milestones, as the input to the regulator. This is that declaration. The
regulator itself is the next step: descend the pairing to `W.Point ⧸ torsion`, which is free of
finite rank, and take the Gram determinant in a basis.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"neron-tate-pairing"}-->

## Provenance

Provenance: original work — no source ported. Both sources named in the chain intake were pinned
and swept for this content and neither has it:
`github.com/MichaelStollBayreuth/EllipticCurves` @ `57f93fa71f16056014f6dab4e8c820fe93dee252`
(45 Lean files; zero hits for `neronTate`, `canonicalHeight`, `regulator`, `heightPairing`,
`QuadraticMap`, `polarBilin`) and `github.com/CBirkbeck/FLT` @
`20eda920b763b27e8bd4fc404839deb9a55e15bd` (25 Lean files, zero hits for the same queries).

Every mathematical step is an
application of existing API, from `main` (`canonicalHeight_parallelogram_law`,
`ofParallelogram`) or from Mathlib (`associated'` and its three lemmas). The normalisation
convention — the canonical height attached to the divisor `(O)`, so half the height of the
`x`-coordinate — is the one already fixed on `main` and documented there; it is what makes
`neronTatePairing_self` come out as `canonicalHeight` with no stray factor.

## Gates

- `lake build`: green, 0 errors, 0 warnings under `warningAsError = true`, no Mathlib recompiled.
- `#lint` environment linter set: "All linting checks passed".
- `#print axioms` on all ten: `[propext, Classical.choice, Quot.sound]`.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; no line over 100 characters.
- **Unicode**: checked mechanically against every codepoint in use on `main`. This caught eight
  occurrences of `U+0125` that I had introduced in docstrings before commit — the same character
  that failed CI on #5636 — and they were removed.
- Claim at `refs/tauceti-claims/author/EllipticCurves/neron-tate-pairing`.
