### PR TITLE
feat: tensor products of differential graded algebras

### DIFF
--- a/TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean
+++ b/TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean
@@ -70,6 +70,7 @@ noncomputable def dgTensorDifferential (dA : A →ₗ[R] A) (dB : B →ₗ[R] B)
 variable {𝒜 ℬ} {dA : A →ₗ[R] A} {dB : B →ₗ[R] B}
 
 /-- The differential of a tensor product, evaluated on a pure tensor. -/
+@[simp]
 theorem dgTensorDifferential_tmul (a : A) (b : B) :
     dgTensorDifferential 𝒜 ℬ dA dB (a ᵍ⊗ₜ[R] b) =
       dA a ᵍ⊗ₜ[R] b + (InternalGrading.ofDecomposition 𝒜).koszulTwist 1 a ᵍ⊗ₜ[R] dB b := by
@@ -122,8 +123,9 @@ private theorem dgTensorDifferential_leibniz_tmul (hA : IsDGAlgebra 𝒜 dA) (hB
   have hq : ((q.negOnePow : ℤ) : R) * ((q.negOnePow : ℤ) : R) = 1 := by
     rw [← Int.cast_mul, ← Units.val_mul, ← Int.negOnePow_add, Int.negOnePow_even _ ⟨q, rfl⟩]
     norm_num
-  simp only [show (q + 1) * p' = q * p' + p' by ring, show q * (p' + 1) = q * p' + q by ring,
-    Int.negOnePow_add, Units.val_mul, Int.cast_mul]
+  have h_left_degree : (q + 1) * p' = q * p' + p' := by ring
+  have h_right_degree : q * (p' + 1) = q * p' + q := by ring
+  simp only [h_left_degree, h_right_degree, Int.negOnePow_add, Units.val_mul, Int.cast_mul]
   match_scalars
   · ring
   · linear_combination (-(((q * p').negOnePow : ℤ) : R) * ((p.negOnePow : ℤ) : R)) * hq
@@ -163,10 +165,10 @@ theorem isDGAlgebra_gradedTensorGrading (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlg
       (gradedTensorGrading 𝒜 ℬ (n + 1))) (fun p a ha b hb ↦ ?_) hx
     rw [Submodule.mem_comap, dgTensorDifferential_tmul_of_mem' ha]
     refine Submodule.add_mem _ ?_ (Submodule.smul_mem _ _ ?_)
-    · rw [show n + 1 = p + 1 + (n - p) by ring]
-      exact tmul_mem_gradedTensorGrading 𝒜 ℬ (hA.map_mem ha) hb
-    · rw [show n + 1 = p + (n - p + 1) by ring]
-      exact tmul_mem_gradedTensorGrading 𝒜 ℬ ha (hB.map_mem hb)
+    · have h_degree : p + 1 + (n - p) = n + 1 := by ring
+      simpa only [h_degree] using tmul_mem_gradedTensorGrading 𝒜 ℬ (hA.map_mem ha) hb
+    · have h_degree : p + (n - p + 1) = n + 1 := by ring
+      simpa only [h_degree] using tmul_mem_gradedTensorGrading 𝒜 ℬ ha (hB.map_mem hb)
   sq_zero x := by
     have key : (dgTensorDifferential 𝒜 ℬ dA dB ∘ₗ dgTensorDifferential 𝒜 ℬ dA dB :
         (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ)) = 0 := by
@@ -188,8 +190,8 @@ theorem isDGAlgebra_gradedTensorGrading (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlg
       simp only [LinearMap.mem_ker, LinearMap.sub_apply, LinearMap.comp_apply,
         LinearMap.add_apply, LinearMap.smul_apply, LinearMap.flip_apply,
         ← GradedTensorProduct.mul_def, sub_eq_zero]
-      rw [show m = p + (m - p) by ring]
-      exact dgTensorDifferential_leibniz_tmul_left hA hB ha hb y
+      have h_degree : p + (m - p) = m := by ring
+      simpa only [h_degree] using dgTensorDifferential_leibniz_tmul_left hA hB ha hb y
     simp only [LinearMap.mem_ker, LinearMap.sub_apply, LinearMap.comp_apply,
       LinearMap.add_apply, LinearMap.smul_apply, LinearMap.flip_apply,
       ← GradedTensorProduct.mul_def, sub_eq_zero] at key
@@ -207,6 +209,8 @@ noncomputable def dgTensorIncludeLeft (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgeb
 @[simp]
 theorem dgTensorIncludeLeft_apply (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra ℬ dB) (a : A) :
     dgTensorIncludeLeft hA hB a = a ᵍ⊗ₜ[R] (1 : B) := by
+  -- The `DGAlgHom` coercion is definitionally its stored `GradedAlgHom`; `change` exposes that
+  -- projection so the graded inclusion's public application lemma applies.
   change gradedTensorIncludeLeft 𝒜 ℬ a = _
   exact gradedTensorIncludeLeft_apply 𝒜 ℬ a
 
@@ -223,6 +227,8 @@ noncomputable def dgTensorIncludeRight (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlge
 @[simp]
 theorem dgTensorIncludeRight_apply (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra ℬ dB) (b : B) :
     dgTensorIncludeRight hA hB b = (1 : A) ᵍ⊗ₜ[R] b := by
+  -- The `DGAlgHom` coercion is definitionally its stored `GradedAlgHom`; `change` exposes that
+  -- projection so the graded inclusion's public application lemma applies.
   change gradedTensorIncludeRight 𝒜 ℬ b = _
   exact gradedTensorIncludeRight_apply 𝒜 ℬ b
 

--- a/TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean
+++ b/TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean
@@ -27,6 +27,8 @@ has degree one the second summand carries the twist `a ↦ (-1) ^ |a| a` on the 
 * `TauCeti.dgTensorDifferential`: the differential of the tensor product.
 * `TauCeti.dgTensorIncludeLeft` and `TauCeti.dgTensorIncludeRight`: the inclusions of the two
   factors, as morphisms of differential graded algebras.
+* `TauCeti.dgTensorLift`: the morphism of differential graded algebras out of the tensor product
+  induced by two morphisms whose images satisfy the Koszul commutation rule.
 
 ## Main results
 
@@ -34,6 +36,8 @@ has degree one the second summand carries the twist `a ↦ (-1) ^ |a| a` on the 
   algebras is a differential graded algebra for the total-degree grading.
 * `TauCeti.dgTensorDifferential_tmul_of_mem`: the sign rule on pure tensors with a homogeneous
   left factor.
+* `TauCeti.dgTensorAlgHom_ext`: morphisms of differential graded algebras out of the tensor product
+  are determined by their restrictions to the two factors.
 
 Only the left factor of a pure tensor has to be homogeneous for the sign rule, and only the left
 factor of a product has to be homogeneous for the Leibniz rule, exactly as in the one-factor
@@ -51,7 +55,7 @@ open scoped DirectSum TensorProduct
 
 namespace TauCeti
 
-universe uR uA uB
+universe uR uA uB uC
 
 variable {R : Type uR} {A : Type uA} {B : Type uB}
   [CommRing R] [Ring A] [Ring B] [Algebra R A] [Algebra R B]
@@ -231,5 +235,55 @@ theorem dgTensorIncludeRight_apply (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra 
   -- projection so the graded inclusion's public application lemma applies.
   change gradedTensorIncludeRight 𝒜 ℬ b = _
   exact gradedTensorIncludeRight_apply 𝒜 ℬ b
+
+section Lift
+
+variable {C : Type uC} [Ring C] [Algebra R C] {𝒞 : ℤ → Submodule R C} [GradedAlgebra 𝒞]
+  {dC : C →ₗ[R] C} {hA : IsDGAlgebra 𝒜 dA} {hB : IsDGAlgebra ℬ dB} {hC : IsDGAlgebra 𝒞 dC}
+
+/-- The morphism of differential graded algebras out of a tensor product induced by two morphisms
+of differential graded algebras whose images satisfy the Koszul commutation rule. -/
+noncomputable def dgTensorLift (f : DGAlgHom hA hC) (g : DGAlgHom hB hC)
+    (h : ∀ ⦃i j⦄ (a : 𝒜 i) (b : ℬ j),
+      f a * g b = (-1 : ℤˣ) ^ (j * i) • (g b * f a)) :
+    DGAlgHom (isDGAlgebra_gradedTensorGrading hA hB) hC where
+  toGradedAlgHom := gradedTensorLift 𝒜 ℬ 𝒞 f.toGradedAlgHom g.toGradedAlgHom h
+  map_d' x := by
+    have key : (dC ∘ₗ (gradedTensorLift 𝒜 ℬ 𝒞 f.toGradedAlgHom g.toGradedAlgHom
+          h).toAlgHom.toLinearMap : (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] C) =
+        (gradedTensorLift 𝒜 ℬ 𝒞 f.toGradedAlgHom g.toGradedAlgHom h).toAlgHom.toLinearMap ∘ₗ
+          dgTensorDifferential 𝒜 ℬ dA dB := by
+      refine linearMap_ext_of_tmul 𝒜 ℬ fun p q a ha b _ ↦ ?_
+      have hfa : (f a : C) ∈ 𝒞 p := f.toGradedAlgHom.map_mem ha
+      simp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply, GradedAlgHom.coe_toAlgHom,
+        DGAlgHom.coe_toGradedAlgHom, gradedTensorLift_tmul,
+        dgTensorDifferential_tmul_of_mem' ha, map_add, map_smul]
+      rw [hC.leibniz hfa (g b), f.map_d, g.map_d, negOnePow_smul_eq (R := R)]
+    exact LinearMap.congr_fun key x
+
+/-- The lift of two morphisms of differential graded algebras sends a pure tensor to the product of
+their values. -/
+@[simp]
+theorem dgTensorLift_tmul (f : DGAlgHom hA hC) (g : DGAlgHom hB hC)
+    (h : ∀ ⦃i j⦄ (a : 𝒜 i) (b : ℬ j),
+      f a * g b = (-1 : ℤˣ) ^ (j * i) • (g b * f a)) (a : A) (b : B) :
+    dgTensorLift f g h (a ᵍ⊗ₜ[R] b) = f a * g b :=
+  gradedTensorLift_tmul 𝒜 ℬ 𝒞 f.toGradedAlgHom g.toGradedAlgHom h a b
+
+/-- Two morphisms of differential graded algebras out of a tensor product agree if their
+compositions with the left and right factor inclusions agree. -/
+@[ext]
+theorem dgTensorAlgHom_ext ⦃f g : DGAlgHom (isDGAlgebra_gradedTensorGrading hA hB) hC⦄
+    (ha : f.comp (dgTensorIncludeLeft hA hB) = g.comp (dgTensorIncludeLeft hA hB))
+    (hb : f.comp (dgTensorIncludeRight hA hB) = g.comp (dgTensorIncludeRight hA hB)) :
+    f = g := by
+  refine DGAlgHom.toGradedAlgHom_injective (gradedTensorAlgHom_ext 𝒜 ℬ 𝒞
+    (GradedAlgHom.ext fun x ↦ ?_) (GradedAlgHom.ext fun x ↦ ?_))
+  · simpa only [GradedAlgHom.comp_apply, DGAlgHom.coe_toGradedAlgHom, DGAlgHom.comp_apply,
+      gradedTensorIncludeLeft_apply, dgTensorIncludeLeft_apply] using DFunLike.congr_fun ha x
+  · simpa only [GradedAlgHom.comp_apply, DGAlgHom.coe_toGradedAlgHom, DGAlgHom.comp_apply,
+      gradedTensorIncludeRight_apply, dgTensorIncludeRight_apply] using DFunLike.congr_fun hb x
+
+end Lift
 
 end TauCeti

--- a/TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean
+++ b/TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean
@@ -82,7 +82,7 @@ theorem dgTensorDifferential_tmul_of_mem {p : ℤ} {a : A} (ha : a ∈ 𝒜 p) (
       dA a ᵍ⊗ₜ[R] b + p.negOnePow • (a ᵍ⊗ₜ[R] dB b : 𝒜 ᵍ⊗[R] ℬ) := by
   rw [dgTensorDifferential_tmul,
     (InternalGrading.ofDecomposition 𝒜).koszulTwist_apply_of_mem
-      (InternalGrading.mem_ofDecomposition_piece.2 ha) 1]
+      (by simpa only [InternalGrading.ofDecomposition_piece] using ha) 1]
   congr 1
   rw [gradedTensor_smul_tmul, Units.smul_def, ← Int.cast_smul_eq_zsmul R, one_mul]
 
@@ -204,6 +204,12 @@ noncomputable def dgTensorIncludeLeft (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgeb
     simp only [gradedTensorIncludeLeft_apply]
     rw [dgTensorDifferential_tmul, hB.map_one_eq_zero, gradedTensor_tmul_zero, add_zero]
 
+@[simp]
+theorem dgTensorIncludeLeft_apply (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra ℬ dB) (a : A) :
+    dgTensorIncludeLeft hA hB a = a ᵍ⊗ₜ[R] (1 : B) := by
+  change gradedTensorIncludeLeft 𝒜 ℬ a = _
+  exact gradedTensorIncludeLeft_apply 𝒜 ℬ a
+
 /-- The inclusion `b ↦ 1 ᵍ⊗ₜ b` of the right factor, as a morphism of differential graded
 algebras. -/
 noncomputable def dgTensorIncludeRight (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra ℬ dB) :
@@ -213,5 +219,11 @@ noncomputable def dgTensorIncludeRight (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlge
     simp only [gradedTensorIncludeRight_apply]
     rw [dgTensorDifferential_tmul_of_mem (SetLike.one_mem_graded 𝒜), hA.map_one_eq_zero,
       gradedTensor_zero_tmul, zero_add, Int.negOnePow_zero, one_smul]
+
+@[simp]
+theorem dgTensorIncludeRight_apply (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra ℬ dB) (b : B) :
+    dgTensorIncludeRight hA hB b = (1 : A) ᵍ⊗ₜ[R] b := by
+  change gradedTensorIncludeRight 𝒜 ℬ b = _
+  exact gradedTensorIncludeRight_apply 𝒜 ℬ b
 
 end TauCeti

--- a/TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean
+++ b/TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean
@@ -9,6 +9,7 @@ public import TauCeti.Algebra.Homology.DG.Algebra.Hom.Basic
 public import TauCeti.RingTheory.GradedAlgebra.TensorProduct
 
 import Mathlib.Tactic.LinearCombination
+import TauCeti.Algebra.Ring.NegOnePow
 
 /-!
 # Tensor products of differential graded algebras
@@ -89,20 +90,16 @@ theorem dgTensorDifferential_tmul_of_mem {p : ℤ} {a : A} (ha : a ∈ 𝒜 p) (
     (InternalGrading.ofDecomposition 𝒜).koszulTwist_apply_of_mem
       (by simpa only [InternalGrading.ofDecomposition_piece] using ha) 1]
   congr 1
-  rw [gradedTensor_smul_tmul, Units.smul_def, ← Int.cast_smul_eq_zsmul R, one_mul]
-
-/-- A sign `(-1) ^ k`, acting through the units of `ℤ`, acts as the image of `(-1) ^ k` in the
-ground ring. -/
-private theorem negOnePow_smul_eq (k : ℤ) {M : Type*} [AddCommGroup M] [Module R M] (x : M) :
-    k.negOnePow • x = (((k.negOnePow : ℤ) : R)) • x := by
-  rw [Units.smul_def, ← Int.cast_smul_eq_zsmul R]
+  rw [gradedTensor_smul_tmul, negOnePow_smul_eq_negOnePowCast_smul (R := R),
+    negOnePowCast_eq_intCast, one_mul]
 
 /-- The sign rule for the differential of a tensor product, with the sign written as a scalar of
 the ground ring. -/
 private theorem dgTensorDifferential_tmul_of_mem' {p : ℤ} {a : A} (ha : a ∈ 𝒜 p) (b : B) :
     dgTensorDifferential 𝒜 ℬ dA dB (a ᵍ⊗ₜ[R] b) =
       dA a ᵍ⊗ₜ[R] b + (((p.negOnePow : ℤ) : R)) • (a ᵍ⊗ₜ[R] dB b : 𝒜 ᵍ⊗[R] ℬ) := by
-  rw [dgTensorDifferential_tmul_of_mem ha, negOnePow_smul_eq (R := R)]
+  rw [dgTensorDifferential_tmul_of_mem ha,
+    negOnePow_smul_eq_negOnePowCast_smul (R := R), negOnePowCast_eq_intCast]
 
 /-- The Leibniz rule of the tensor product, on two pure tensors of homogeneous elements. -/
 private theorem dgTensorDifferential_leibniz_tmul (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra ℬ dB)
@@ -113,7 +110,8 @@ private theorem dgTensorDifferential_leibniz_tmul (hA : IsDGAlgebra 𝒜 dA) (hB
         (((p + q).negOnePow : ℤ) : R) •
           ((a ᵍ⊗ₜ[R] b) * dgTensorDifferential 𝒜 ℬ dA dB (a' ᵍ⊗ₜ[R] b')) := by
   rw [GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ a ⟨b, hb⟩ ⟨a', ha'⟩ b',
-    ← Int.negOnePow_def, negOnePow_smul_eq (R := R), map_smul,
+    ← Int.negOnePow_def, negOnePow_smul_eq_negOnePowCast_smul (R := R),
+    negOnePowCast_eq_intCast, map_smul,
     dgTensorDifferential_tmul_of_mem' (SetLike.mul_mem_graded ha ha'),
     hA.leibniz ha a', hB.leibniz hb b']
   rw [dgTensorDifferential_tmul_of_mem' ha, dgTensorDifferential_tmul_of_mem' ha']
@@ -122,8 +120,9 @@ private theorem dgTensorDifferential_leibniz_tmul (hA : IsDGAlgebra 𝒜 dA) (hB
     GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ a ⟨dB b, hB.map_mem hb⟩ ⟨a', ha'⟩ b',
     GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ a ⟨b, hb⟩ ⟨dA a', hA.map_mem ha'⟩ b',
     GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ a ⟨b, hb⟩ ⟨a', ha'⟩ (dB b')]
-  simp only [← Int.negOnePow_def, negOnePow_smul_eq (R := R), gradedTensor_add_tmul,
-    gradedTensor_tmul_add, gradedTensor_smul_tmul, gradedTensor_tmul_smul, smul_add, smul_smul]
+  simp only [← Int.negOnePow_def, negOnePow_smul_eq_negOnePowCast_smul (R := R),
+    negOnePowCast_eq_intCast, gradedTensor_add_tmul, gradedTensor_tmul_add,
+    gradedTensor_smul_tmul, gradedTensor_tmul_smul, smul_add, smul_smul]
   have hq : ((q.negOnePow : ℤ) : R) * ((q.negOnePow : ℤ) : R) = 1 := by
     rw [← Int.cast_mul, ← Units.val_mul, ← Int.negOnePow_add, Int.negOnePow_even _ ⟨q, rfl⟩]
     norm_num
@@ -151,7 +150,7 @@ private theorem dgTensorDifferential_leibniz_tmul_left (hA : IsDGAlgebra 𝒜 dA
         (((p + q).negOnePow : ℤ) : R) •
           (GradedTensorProduct.mulHom 𝒜 ℬ (a ᵍ⊗ₜ[R] b) ∘ₗ
             dgTensorDifferential 𝒜 ℬ dA dB) := by
-    refine linearMap_ext_of_tmul 𝒜 ℬ fun p' q' a' ha' b' _ ↦ ?_
+    refine gradedTensor_linearMap_ext 𝒜 ℬ fun p' q' a' ha' b' _ ↦ ?_
     simp only [LinearMap.comp_apply, LinearMap.add_apply, LinearMap.smul_apply,
       ← GradedTensorProduct.mul_def]
     exact dgTensorDifferential_leibniz_tmul hA hB ha hb ha' b'
@@ -176,7 +175,7 @@ theorem isDGAlgebra_gradedTensorGrading (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlg
   sq_zero x := by
     have key : (dgTensorDifferential 𝒜 ℬ dA dB ∘ₗ dgTensorDifferential 𝒜 ℬ dA dB :
         (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ)) = 0 := by
-      refine linearMap_ext_of_tmul 𝒜 ℬ fun p q a ha b hb ↦ ?_
+      refine gradedTensor_linearMap_ext 𝒜 ℬ fun p q a ha b hb ↦ ?_
       rw [LinearMap.comp_apply, dgTensorDifferential_tmul_of_mem' ha, map_add, map_smul,
         dgTensorDifferential_tmul_of_mem' (hA.map_mem ha),
         dgTensorDifferential_tmul_of_mem' ha, hA.sq_zero, hB.sq_zero, Int.negOnePow_succ]
@@ -199,7 +198,7 @@ theorem isDGAlgebra_gradedTensorGrading (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlg
     simp only [LinearMap.mem_ker, LinearMap.sub_apply, LinearMap.comp_apply,
       LinearMap.add_apply, LinearMap.smul_apply, LinearMap.flip_apply,
       ← GradedTensorProduct.mul_def, sub_eq_zero] at key
-    rw [key, negOnePow_smul_eq (R := R)]
+    rw [key, negOnePow_smul_eq_negOnePowCast_smul (R := R), negOnePowCast_eq_intCast]
 
 /-- The inclusion `a ↦ a ᵍ⊗ₜ 1` of the left factor, as a morphism of differential graded
 algebras. -/
@@ -253,12 +252,13 @@ noncomputable def dgTensorLift (f : DGAlgHom hA hC) (g : DGAlgHom hB hC)
           h).toAlgHom.toLinearMap : (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] C) =
         (gradedTensorLift 𝒜 ℬ 𝒞 f.toGradedAlgHom g.toGradedAlgHom h).toAlgHom.toLinearMap ∘ₗ
           dgTensorDifferential 𝒜 ℬ dA dB := by
-      refine linearMap_ext_of_tmul 𝒜 ℬ fun p q a ha b _ ↦ ?_
+      refine gradedTensor_linearMap_ext 𝒜 ℬ fun p q a ha b _ ↦ ?_
       have hfa : (f a : C) ∈ 𝒞 p := f.toGradedAlgHom.map_mem ha
       simp only [LinearMap.comp_apply, AlgHom.toLinearMap_apply, GradedAlgHom.coe_toAlgHom,
         DGAlgHom.coe_toGradedAlgHom, gradedTensorLift_tmul,
         dgTensorDifferential_tmul_of_mem' ha, map_add, map_smul]
-      rw [hC.leibniz hfa (g b), f.map_d, g.map_d, negOnePow_smul_eq (R := R)]
+      rw [hC.leibniz hfa (g b), f.map_d, g.map_d,
+        negOnePow_smul_eq_negOnePowCast_smul (R := R), negOnePowCast_eq_intCast]
     exact LinearMap.congr_fun key x
 
 /-- The lift of two morphisms of differential graded algebras sends a pure tensor to the product of

--- a/TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean
+++ b/TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Homology.DG.Algebra.Hom.Basic
+public import TauCeti.RingTheory.GradedAlgebra.TensorProduct
+
+import Mathlib.Tactic.LinearCombination
+
+/-!
+# Tensor products of differential graded algebras
+
+The tensor product of two differential graded algebras `(A, d_A)` and `(B, d_B)` is Mathlib's
+Koszul-signed graded tensor product `𝒜 ᵍ⊗[R] ℬ`, graded by total degree, with the differential
+
+`d (a ᵍ⊗ₜ b) = d_A a ᵍ⊗ₜ b + (-1) ^ |a| • (a ᵍ⊗ₜ d_B b)`.
+
+The sign is the one forced by the Koszul rule `(f ⊗ g) (x ⊗ y) = (-1) ^ (|g| |x|) f x ⊗ g y` for
+tensor products of homogeneous maps: the differential is `d_A ⊗ 1` plus `1 ⊗ d_B`, and since `d_B`
+has degree one the second summand carries the twist `a ↦ (-1) ^ |a| a` on the left factor.
+
+## Main definitions
+
+* `TauCeti.dgTensorDifferential`: the differential of the tensor product.
+* `TauCeti.dgTensorIncludeLeft` and `TauCeti.dgTensorIncludeRight`: the inclusions of the two
+  factors, as morphisms of differential graded algebras.
+
+## Main results
+
+* `TauCeti.isDGAlgebra_gradedTensorGrading`: the graded tensor product of two differential graded
+  algebras is a differential graded algebra for the total-degree grading.
+* `TauCeti.dgTensorDifferential_tmul_of_mem`: the sign rule on pure tensors with a homogeneous
+  left factor.
+
+Only the left factor of a pure tensor has to be homogeneous for the sign rule, and only the left
+factor of a product has to be homogeneous for the Leibniz rule, exactly as in the one-factor
+Leibniz axiom `TauCeti.IsDGAlgebra.leibniz`.
+
+## References
+
+* B. Keller, *Introduction to A-infinity algebras and modules*, Section 3.1.
+* N. Bourbaki, *Algebra I*, Chapter III, §4.7, example (2).
+-/
+
+public section
+
+open scoped DirectSum TensorProduct
+
+namespace TauCeti
+
+universe uR uA uB
+
+variable {R : Type uR} {A : Type uA} {B : Type uB}
+  [CommRing R] [Ring A] [Ring B] [Algebra R A] [Algebra R B]
+
+variable (𝒜 : ℤ → Submodule R A) (ℬ : ℤ → Submodule R B) [GradedAlgebra 𝒜] [GradedAlgebra ℬ]
+
+/-- The differential of the tensor product of two differential graded algebras: the sum of
+`d_A ⊗ 1` and of `d_B` preceded, on the left factor, by the Koszul twist `a ↦ (-1) ^ |a| a`. -/
+noncomputable def dgTensorDifferential (dA : A →ₗ[R] A) (dB : B →ₗ[R] B) :
+    (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) :=
+  (GradedTensorProduct.of R 𝒜 ℬ).toLinearMap ∘ₗ
+    (TensorProduct.map dA LinearMap.id +
+      TensorProduct.map ((InternalGrading.ofDecomposition 𝒜).koszulTwist 1) dB) ∘ₗ
+    (GradedTensorProduct.of R 𝒜 ℬ).symm.toLinearMap
+
+variable {𝒜 ℬ} {dA : A →ₗ[R] A} {dB : B →ₗ[R] B}
+
+/-- The differential of a tensor product, evaluated on a pure tensor. -/
+theorem dgTensorDifferential_tmul (a : A) (b : B) :
+    dgTensorDifferential 𝒜 ℬ dA dB (a ᵍ⊗ₜ[R] b) =
+      dA a ᵍ⊗ₜ[R] b + (InternalGrading.ofDecomposition 𝒜).koszulTwist 1 a ᵍ⊗ₜ[R] dB b := by
+  simp [dgTensorDifferential, GradedTensorProduct.tmul]
+
+/-- The sign rule for the differential of a tensor product on a pure tensor with homogeneous left
+factor: `d (a ᵍ⊗ₜ b) = d_A a ᵍ⊗ₜ b + (-1) ^ |a| • (a ᵍ⊗ₜ d_B b)`. -/
+theorem dgTensorDifferential_tmul_of_mem {p : ℤ} {a : A} (ha : a ∈ 𝒜 p) (b : B) :
+    dgTensorDifferential 𝒜 ℬ dA dB (a ᵍ⊗ₜ[R] b) =
+      dA a ᵍ⊗ₜ[R] b + p.negOnePow • (a ᵍ⊗ₜ[R] dB b : 𝒜 ᵍ⊗[R] ℬ) := by
+  rw [dgTensorDifferential_tmul,
+    (InternalGrading.ofDecomposition 𝒜).koszulTwist_apply_of_mem
+      (InternalGrading.mem_ofDecomposition_piece.2 ha) 1]
+  congr 1
+  rw [gradedTensor_smul_tmul, Units.smul_def, ← Int.cast_smul_eq_zsmul R, one_mul]
+
+/-- A sign `(-1) ^ k`, acting through the units of `ℤ`, acts as the image of `(-1) ^ k` in the
+ground ring. -/
+private theorem negOnePow_smul_eq (k : ℤ) {M : Type*} [AddCommGroup M] [Module R M] (x : M) :
+    k.negOnePow • x = (((k.negOnePow : ℤ) : R)) • x := by
+  rw [Units.smul_def, ← Int.cast_smul_eq_zsmul R]
+
+/-- The sign rule for the differential of a tensor product, with the sign written as a scalar of
+the ground ring. -/
+private theorem dgTensorDifferential_tmul_of_mem' {p : ℤ} {a : A} (ha : a ∈ 𝒜 p) (b : B) :
+    dgTensorDifferential 𝒜 ℬ dA dB (a ᵍ⊗ₜ[R] b) =
+      dA a ᵍ⊗ₜ[R] b + (((p.negOnePow : ℤ) : R)) • (a ᵍ⊗ₜ[R] dB b : 𝒜 ᵍ⊗[R] ℬ) := by
+  rw [dgTensorDifferential_tmul_of_mem ha, negOnePow_smul_eq (R := R)]
+
+/-- The Leibniz rule of the tensor product, on two pure tensors of homogeneous elements. -/
+private theorem dgTensorDifferential_leibniz_tmul (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra ℬ dB)
+    {p q p' : ℤ} {a a' : A} {b : B}
+    (ha : a ∈ 𝒜 p) (hb : b ∈ ℬ q) (ha' : a' ∈ 𝒜 p') (b' : B) :
+    dgTensorDifferential 𝒜 ℬ dA dB ((a ᵍ⊗ₜ[R] b) * (a' ᵍ⊗ₜ[R] b') : 𝒜 ᵍ⊗[R] ℬ) =
+      dgTensorDifferential 𝒜 ℬ dA dB (a ᵍ⊗ₜ[R] b) * (a' ᵍ⊗ₜ[R] b') +
+        (((p + q).negOnePow : ℤ) : R) •
+          ((a ᵍ⊗ₜ[R] b) * dgTensorDifferential 𝒜 ℬ dA dB (a' ᵍ⊗ₜ[R] b')) := by
+  rw [GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ a ⟨b, hb⟩ ⟨a', ha'⟩ b',
+    ← Int.negOnePow_def, negOnePow_smul_eq (R := R), map_smul,
+    dgTensorDifferential_tmul_of_mem' (SetLike.mul_mem_graded ha ha'),
+    hA.leibniz ha a', hB.leibniz hb b']
+  rw [dgTensorDifferential_tmul_of_mem' ha, dgTensorDifferential_tmul_of_mem' ha']
+  simp only [add_mul, mul_add, smul_mul_assoc, mul_smul_comm]
+  rw [GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ (dA a) ⟨b, hb⟩ ⟨a', ha'⟩ b',
+    GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ a ⟨dB b, hB.map_mem hb⟩ ⟨a', ha'⟩ b',
+    GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ a ⟨b, hb⟩ ⟨dA a', hA.map_mem ha'⟩ b',
+    GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ a ⟨b, hb⟩ ⟨a', ha'⟩ (dB b')]
+  simp only [← Int.negOnePow_def, negOnePow_smul_eq (R := R), gradedTensor_add_tmul,
+    gradedTensor_tmul_add, gradedTensor_smul_tmul, gradedTensor_tmul_smul, smul_add, smul_smul]
+  have hq : ((q.negOnePow : ℤ) : R) * ((q.negOnePow : ℤ) : R) = 1 := by
+    rw [← Int.cast_mul, ← Units.val_mul, ← Int.negOnePow_add, Int.negOnePow_even _ ⟨q, rfl⟩]
+    norm_num
+  simp only [show (q + 1) * p' = q * p' + p' by ring, show q * (p' + 1) = q * p' + q by ring,
+    Int.negOnePow_add, Units.val_mul, Int.cast_mul]
+  match_scalars
+  · ring
+  · linear_combination (-(((q * p').negOnePow : ℤ) : R) * ((p.negOnePow : ℤ) : R)) * hq
+  · ring
+  · ring
+
+/-- The Leibniz rule of the tensor product, for a homogeneous pure tensor on the left and an
+arbitrary element on the right. -/
+private theorem dgTensorDifferential_leibniz_tmul_left (hA : IsDGAlgebra 𝒜 dA)
+    (hB : IsDGAlgebra ℬ dB) {p q : ℤ} {a : A} {b : B} (ha : a ∈ 𝒜 p) (hb : b ∈ ℬ q)
+    (y : 𝒜 ᵍ⊗[R] ℬ) :
+    dgTensorDifferential 𝒜 ℬ dA dB ((a ᵍ⊗ₜ[R] b) * y) =
+      dgTensorDifferential 𝒜 ℬ dA dB (a ᵍ⊗ₜ[R] b) * y +
+        (((p + q).negOnePow : ℤ) : R) •
+          ((a ᵍ⊗ₜ[R] b) * dgTensorDifferential 𝒜 ℬ dA dB y) := by
+  have key : (dgTensorDifferential 𝒜 ℬ dA dB ∘ₗ
+        GradedTensorProduct.mulHom 𝒜 ℬ (a ᵍ⊗ₜ[R] b) : (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ)) =
+      GradedTensorProduct.mulHom 𝒜 ℬ (dgTensorDifferential 𝒜 ℬ dA dB (a ᵍ⊗ₜ[R] b)) +
+        (((p + q).negOnePow : ℤ) : R) •
+          (GradedTensorProduct.mulHom 𝒜 ℬ (a ᵍ⊗ₜ[R] b) ∘ₗ
+            dgTensorDifferential 𝒜 ℬ dA dB) := by
+    refine linearMap_ext_of_tmul 𝒜 ℬ fun p' q' a' ha' b' _ ↦ ?_
+    simp only [LinearMap.comp_apply, LinearMap.add_apply, LinearMap.smul_apply,
+      ← GradedTensorProduct.mul_def]
+    exact dgTensorDifferential_leibniz_tmul hA hB ha hb ha' b'
+  simpa only [LinearMap.comp_apply, LinearMap.add_apply, LinearMap.smul_apply,
+    ← GradedTensorProduct.mul_def] using LinearMap.congr_fun key y
+
+/-- The tensor product of two differential graded algebras is a differential graded algebra: the
+total-degree grading of `𝒜 ᵍ⊗[R] ℬ` and the differential
+`d (a ᵍ⊗ₜ b) = d_A a ᵍ⊗ₜ b + (-1) ^ |a| • (a ᵍ⊗ₜ d_B b)` satisfy the degree, square-zero, and
+graded Leibniz axioms. -/
+theorem isDGAlgebra_gradedTensorGrading (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra ℬ dB) :
+    IsDGAlgebra (gradedTensorGrading 𝒜 ℬ) (dgTensorDifferential 𝒜 ℬ dA dB) where
+  map_mem {n x} hx := by
+    refine gradedTensorGrading_le 𝒜 ℬ (C := Submodule.comap (dgTensorDifferential 𝒜 ℬ dA dB)
+      (gradedTensorGrading 𝒜 ℬ (n + 1))) (fun p a ha b hb ↦ ?_) hx
+    rw [Submodule.mem_comap, dgTensorDifferential_tmul_of_mem' ha]
+    refine Submodule.add_mem _ ?_ (Submodule.smul_mem _ _ ?_)
+    · rw [show n + 1 = p + 1 + (n - p) by ring]
+      exact tmul_mem_gradedTensorGrading 𝒜 ℬ (hA.map_mem ha) hb
+    · rw [show n + 1 = p + (n - p + 1) by ring]
+      exact tmul_mem_gradedTensorGrading 𝒜 ℬ ha (hB.map_mem hb)
+  sq_zero x := by
+    have key : (dgTensorDifferential 𝒜 ℬ dA dB ∘ₗ dgTensorDifferential 𝒜 ℬ dA dB :
+        (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ)) = 0 := by
+      refine linearMap_ext_of_tmul 𝒜 ℬ fun p q a ha b hb ↦ ?_
+      rw [LinearMap.comp_apply, dgTensorDifferential_tmul_of_mem' ha, map_add, map_smul,
+        dgTensorDifferential_tmul_of_mem' (hA.map_mem ha),
+        dgTensorDifferential_tmul_of_mem' ha, hA.sq_zero, hB.sq_zero, Int.negOnePow_succ]
+      simp only [gradedTensor_zero_tmul, gradedTensor_tmul_zero, Units.val_neg, Int.cast_neg,
+        LinearMap.zero_apply, smul_zero, neg_smul]
+      module
+    exact LinearMap.congr_fun key x
+  leibniz {m x} hx y := by
+    have key : x ∈ LinearMap.ker
+        (dgTensorDifferential 𝒜 ℬ dA dB ∘ₗ (GradedTensorProduct.mulHom 𝒜 ℬ).flip y -
+          (((GradedTensorProduct.mulHom 𝒜 ℬ).flip y ∘ₗ dgTensorDifferential 𝒜 ℬ dA dB) +
+            (((m.negOnePow : ℤ) : R)) • ((GradedTensorProduct.mulHom 𝒜 ℬ).flip
+              (dgTensorDifferential 𝒜 ℬ dA dB y)))) := by
+      refine gradedTensorGrading_le 𝒜 ℬ (fun p a ha b hb ↦ ?_) hx
+      simp only [LinearMap.mem_ker, LinearMap.sub_apply, LinearMap.comp_apply,
+        LinearMap.add_apply, LinearMap.smul_apply, LinearMap.flip_apply,
+        ← GradedTensorProduct.mul_def, sub_eq_zero]
+      rw [show m = p + (m - p) by ring]
+      exact dgTensorDifferential_leibniz_tmul_left hA hB ha hb y
+    simp only [LinearMap.mem_ker, LinearMap.sub_apply, LinearMap.comp_apply,
+      LinearMap.add_apply, LinearMap.smul_apply, LinearMap.flip_apply,
+      ← GradedTensorProduct.mul_def, sub_eq_zero] at key
+    rw [key, negOnePow_smul_eq (R := R)]
+
+/-- The inclusion `a ↦ a ᵍ⊗ₜ 1` of the left factor, as a morphism of differential graded
+algebras. -/
+noncomputable def dgTensorIncludeLeft (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra ℬ dB) :
+    DGAlgHom hA (isDGAlgebra_gradedTensorGrading hA hB) where
+  toGradedAlgHom := gradedTensorIncludeLeft 𝒜 ℬ
+  map_d' a := by
+    simp only [gradedTensorIncludeLeft_apply]
+    rw [dgTensorDifferential_tmul, hB.map_one_eq_zero, gradedTensor_tmul_zero, add_zero]
+
+/-- The inclusion `b ↦ 1 ᵍ⊗ₜ b` of the right factor, as a morphism of differential graded
+algebras. -/
+noncomputable def dgTensorIncludeRight (hA : IsDGAlgebra 𝒜 dA) (hB : IsDGAlgebra ℬ dB) :
+    DGAlgHom hB (isDGAlgebra_gradedTensorGrading hA hB) where
+  toGradedAlgHom := gradedTensorIncludeRight 𝒜 ℬ
+  map_d' b := by
+    simp only [gradedTensorIncludeRight_apply]
+    rw [dgTensorDifferential_tmul_of_mem (SetLike.one_mem_graded 𝒜), hA.map_one_eq_zero,
+      gradedTensor_zero_tmul, zero_add, Int.negOnePow_zero, one_smul]
+
+end TauCeti

--- a/TauCeti/Algebra/Module/GradedModule/Internal.lean
+++ b/TauCeti/Algebra/Module/GradedModule/Internal.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.DirectSum.Decomposition
 public import Mathlib.Algebra.Ring.NegOnePow
 public import Mathlib.RingTheory.Finiteness.Basic
+public import TauCeti.LinearAlgebra.Graded.LinearMap
 import TauCeti.Algebra.DirectSum.Internal
 
 /-!
@@ -32,6 +33,7 @@ the letterwise tuple operation that applies it on a half-open index interval.
 * `InternalGrading`: an internal `ℤ`-grading of a module.
 * `InternalGrading.ofDecomposition`: the internal grading carried by a family of submodules with a
   `DirectSum.Decomposition`, as graded algebras store it.
+* `InternalGrading.map`: transport an internal grading across a linear equivalence.
 * `InternalGrading.koszulTwist`: the operator scaling degree-`e` elements by `(-1)^(q * e)`.
 * `InternalGrading.twistedTuple`: a tuple with a consecutive block of letters Koszul-twisted.
 
@@ -95,6 +97,133 @@ noncomputable def ofDecomposition (ℳ : ℤ → Submodule R M) [DirectSum.Decom
 @[simp]
 theorem ofDecomposition_piece (ℳ : ℤ → Submodule R M) [DirectSum.Decomposition ℳ] :
     (ofDecomposition ℳ).piece = ℳ := (rfl)
+
+section Map
+
+variable {N : Type w} [AddCommMonoid N] [Module R N]
+
+private noncomputable def mapPiecesEquiv (G : InternalGrading R M) (e : M ≃ₗ[R] N) :
+    (⨁ p : ℤ, G.piece p) ≃ₗ[R] (⨁ p : ℤ, (G.piece p).map e.toLinearMap) :=
+  DirectSum.congrLinearEquiv fun p ↦
+    Submodule.equivMapOfInjective e.toLinearMap e.injective (G.piece p)
+
+private theorem mapPiecesEquiv_lof (G : InternalGrading R M) (e : M ≃ₗ[R] N)
+    (p : ℤ) (x : G.piece p) :
+    mapPiecesEquiv G e (DirectSum.lof R ℤ (fun i ↦ G.piece i) p x) =
+      DirectSum.lof R ℤ (fun i ↦ (G.piece i).map e.toLinearMap) p
+        ((Submodule.equivMapOfInjective e.toLinearMap e.injective (G.piece p)).toLinearMap x) := by
+  -- Expose the bundled linear map so the direct-sum application lemma can rewrite it.
+  change (mapPiecesEquiv G e).toLinearMap
+    (DirectSum.lof R ℤ (fun i ↦ G.piece i) p x) = _
+  rw [mapPiecesEquiv, DirectSum.congrLinearEquiv_toLinearMap, DirectSum.lmap_lof]
+
+private theorem coeLinearMap_comp_mapPiecesEquiv (G : InternalGrading R M)
+    (e : M ≃ₗ[R] N) :
+    (DirectSum.coeLinearMap fun p : ℤ ↦ (G.piece p).map e.toLinearMap) ∘ₗ
+        (mapPiecesEquiv G e).toLinearMap =
+      e.toLinearMap ∘ₗ DirectSum.coeLinearMap G.piece := by
+  apply DirectSum.linearMap_ext R
+  intro p
+  apply LinearMap.ext
+  intro x
+  simp only [LinearMap.comp_apply]
+  calc
+    (DirectSum.coeLinearMap fun p : ℤ ↦ (G.piece p).map e.toLinearMap)
+        ((mapPiecesEquiv G e).toLinearMap
+          (DirectSum.lof R ℤ (fun i ↦ G.piece i) p x)) =
+        (DirectSum.coeLinearMap fun p : ℤ ↦ (G.piece p).map e.toLinearMap)
+          (DirectSum.lof R ℤ (fun i ↦ (G.piece i).map e.toLinearMap) p
+            ((Submodule.equivMapOfInjective e.toLinearMap e.injective
+              (G.piece p)).toLinearMap x)) :=
+      congrArg _ (mapPiecesEquiv_lof G e p x)
+    _ = e x := by
+      rw [DirectSum.coeLinearMap_lof]
+      exact Submodule.coe_equivMapOfInjective_apply e.toLinearMap e.injective (G.piece p) x
+    _ = e.toLinearMap (DirectSum.coeLinearMap G.piece
+        (DirectSum.lof R ℤ (fun i ↦ G.piece i) p x)) := by
+      rw [DirectSum.coeLinearMap_lof]
+      rfl
+
+/-- Transport an internal grading across a linear equivalence. The degree-`p` piece of the target
+is the image of the degree-`p` piece of the source. -/
+noncomputable def map (G : InternalGrading R M) (e : M ≃ₗ[R] N) : InternalGrading R N where
+  piece p := (G.piece p).map e.toLinearMap
+  isInternal := by
+    -- Expose `coeLinearMap` rather than its definitionally equal additive coercion so it can be
+    -- composed with `mapPiecesEquiv` below.
+    change Function.Bijective
+      (DirectSum.coeLinearMap fun p : ℤ ↦ (G.piece p).map e.toLinearMap)
+    let E := mapPiecesEquiv G e
+    have hcomp : Function.Bijective
+        ((DirectSum.coeLinearMap fun p : ℤ ↦ (G.piece p).map e.toLinearMap) ∘ₗ E.toLinearMap) := by
+      rw [coeLinearMap_comp_mapPiecesEquiv]
+      exact e.bijective.comp G.isInternal
+    constructor
+    · intro x y hxy
+      obtain ⟨x', rfl⟩ := E.surjective x
+      obtain ⟨y', rfl⟩ := E.surjective y
+      exact congrArg E (hcomp.injective (by
+        simpa only [LinearMap.comp_apply, LinearEquiv.coe_toLinearMap] using hxy))
+    · intro y
+      obtain ⟨x, hx⟩ := hcomp.surjective y
+      exact ⟨E x, by
+        simpa only [LinearMap.comp_apply, LinearEquiv.coe_toLinearMap] using hx⟩
+
+/-- The degree-`p` piece of a transported grading is the image of the original piece. -/
+@[simp]
+theorem map_piece (G : InternalGrading R M) (e : M ≃ₗ[R] N) (p : ℤ) :
+    (G.map e).piece p = (G.piece p).map e.toLinearMap :=
+  (rfl)
+
+/-- Membership in a transported piece can be checked after applying the inverse equivalence.
+
+This is not a `simp` lemma: `map_piece` already rewrites the left-hand side to a `Submodule.map`,
+on which the `simp` set fires `Submodule.mem_map_equiv` to reach the same right-hand side. -/
+theorem mem_map_piece_iff (G : InternalGrading R M) (e : M ≃ₗ[R] N) (p : ℤ) (y : N) :
+    y ∈ (G.map e).piece p ↔ e.symm y ∈ G.piece p := by
+  exact Submodule.mem_map_equiv (p := G.piece p) (e := e)
+
+/-- A linear equivalence maps a homogeneous element into the transported piece of the same
+degree. This is the special case of `mem_map_piece_iff` that `simp` already reaches. -/
+theorem apply_mem_map_piece_iff (G : InternalGrading R M) (e : M ≃ₗ[R] N) (p : ℤ) (x : M) :
+    e x ∈ (G.map e).piece p ↔ x ∈ G.piece p := by
+  simp
+
+/-- The equivalence used to transport a grading is homogeneous of degree zero. -/
+theorem isHomogeneous_map (G : InternalGrading R M) (e : M ≃ₗ[R] N) :
+    TauCeti.LinearMap.IsHomogeneous e.toLinearMap G.piece (G.map e).piece 0 := by
+  rw [TauCeti.LinearMap.isHomogeneous_def]
+  intro p x hx
+  simpa using hx
+
+/-- The inverse of an equivalence used to transport a grading is homogeneous of degree zero. -/
+theorem isHomogeneous_map_symm (G : InternalGrading R M) (e : M ≃ₗ[R] N) :
+    TauCeti.LinearMap.IsHomogeneous e.symm.toLinearMap (G.map e).piece G.piece 0 := by
+  rw [TauCeti.LinearMap.isHomogeneous_def]
+  intro p y hy
+  simpa using hy
+
+/-- Transport along the identity equivalence leaves an internal grading unchanged. -/
+@[simp]
+theorem map_refl (G : InternalGrading R M) : G.map (LinearEquiv.refl R M) = G := by
+  apply InternalGrading.ext
+  intro p
+  apply Submodule.ext
+  intro x
+  simp
+
+/-- Successive transport agrees with transport along the composite equivalence. -/
+@[simp]
+theorem map_trans {P : Type*} [AddCommMonoid P] [Module R P]
+    (G : InternalGrading R M) (e : M ≃ₗ[R] N) (f : N ≃ₗ[R] P) :
+    (G.map e).map f = G.map (e.trans f) := by
+  apply InternalGrading.ext
+  intro p
+  apply Submodule.ext
+  intro x
+  simp
+
+end Map
 
 /-- An additive map that vanishes on every homogeneous piece except degree `i` sees only the
 degree-`i` component of each argument. -/

--- a/TauCeti/Algebra/Module/GradedModule/Internal.lean
+++ b/TauCeti/Algebra/Module/GradedModule/Internal.lean
@@ -96,10 +96,6 @@ noncomputable def ofDecomposition (ℳ : ℤ → Submodule R M) [DirectSum.Decom
 theorem ofDecomposition_piece (ℳ : ℤ → Submodule R M) [DirectSum.Decomposition ℳ] :
     (ofDecomposition ℳ).piece = ℳ := (rfl)
 
-theorem mem_ofDecomposition_piece {ℳ : ℤ → Submodule R M} [DirectSum.Decomposition ℳ] {p : ℤ}
-    {x : M} : x ∈ (ofDecomposition ℳ).piece p ↔ x ∈ ℳ p := by
-  rw [ofDecomposition_piece]
-
 /-- An additive map that vanishes on every homogeneous piece except degree `i` sees only the
 degree-`i` component of each argument. -/
 theorem map_eq_map_decompose {N : Type w} [AddCommMonoid N] (G : InternalGrading R M)

--- a/TauCeti/Algebra/Module/GradedModule/Internal.lean
+++ b/TauCeti/Algebra/Module/GradedModule/Internal.lean
@@ -30,6 +30,8 @@ the letterwise tuple operation that applies it on a half-open index interval.
 ## Main definitions
 
 * `InternalGrading`: an internal `ℤ`-grading of a module.
+* `InternalGrading.ofDecomposition`: the internal grading carried by a family of submodules with a
+  `DirectSum.Decomposition`, as graded algebras store it.
 * `InternalGrading.koszulTwist`: the operator scaling degree-`e` elements by `(-1)^(q * e)`.
 * `InternalGrading.twistedTuple`: a tuple with a consecutive block of letters Koszul-twisted.
 
@@ -82,6 +84,21 @@ theorem ext : ∀ {G H : InternalGrading R M}, (∀ p, G.piece p = H.piece p) �
 /-- The decomposition attached to an internal grading. -/
 noncomputable instance (G : InternalGrading R M) : DirectSum.Decomposition G.piece :=
   G.isInternal.chooseDecomposition
+
+/-- The internal grading carried by a family of submodules with a `DirectSum.Decomposition`.  This
+is the bridge from Mathlib's decomposition typeclass, under which graded algebras are stated, to
+the bundled internal grading of this file. -/
+noncomputable def ofDecomposition (ℳ : ℤ → Submodule R M) [DirectSum.Decomposition ℳ] :
+    InternalGrading R M :=
+  ⟨ℳ, DirectSum.Decomposition.isInternal ℳ⟩
+
+@[simp]
+theorem ofDecomposition_piece (ℳ : ℤ → Submodule R M) [DirectSum.Decomposition ℳ] :
+    (ofDecomposition ℳ).piece = ℳ := (rfl)
+
+theorem mem_ofDecomposition_piece {ℳ : ℤ → Submodule R M} [DirectSum.Decomposition ℳ] {p : ℤ}
+    {x : M} : x ∈ (ofDecomposition ℳ).piece p ↔ x ∈ ℳ p := by
+  rw [ofDecomposition_piece]
 
 /-- An additive map that vanishes on every homogeneous piece except degree `i` sees only the
 degree-`i` component of each argument. -/

--- a/TauCeti/Algebra/Module/GradedModule/Opposite.lean
+++ b/TauCeti/Algebra/Module/GradedModule/Opposite.lean
@@ -8,23 +8,20 @@ module
 public import Mathlib.Algebra.Module.Equiv.Opposite
 public import Mathlib.RingTheory.GradedAlgebra.Basic
 public import TauCeti.Algebra.Module.GradedModule.Internal
-public import TauCeti.LinearAlgebra.Graded.LinearMap
 
 /-!
 # Opposites of internally graded modules
 
-This file transports an internal grading across a linear equivalence and applies that construction
-to the multiplicative opposite. The degree of an element is unchanged by `MulOpposite.op`, and an
-internal graded algebra therefore induces an internal graded algebra on its opposite. The order of
-homogeneous factors reverses, but their total degree is unchanged because the grading group is
-`ℤ`.
+This file applies transport of an internal grading across a linear equivalence to the multiplicative
+opposite. The degree of an element is unchanged by `MulOpposite.op`, and an internal graded algebra
+therefore induces an internal graded algebra on its opposite. The order of homogeneous factors
+reverses, but their total degree is unchanged because the grading group is `ℤ`.
 
 The Koszul twist commutes with passage to the opposite. This is the compatibility needed to form
 opposite DG and `A∞` objects without changing their sign convention.
 
 ## Main definitions
 
-* `InternalGrading.map`: transport an internal grading across a linear equivalence.
 * `InternalGrading.opposite`: the induced grading on the multiplicative opposite.
 
 ## Main results
@@ -44,137 +41,9 @@ open scoped DirectSum
 
 namespace TauCeti
 
-universe u v w
+universe u v
 
 namespace InternalGrading
-
-section Map
-
-variable {R : Type u} {M : Type v} {N : Type w}
-  [Semiring R] [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module R N]
-
-private noncomputable def mapPiecesEquiv (G : InternalGrading R M) (e : M ≃ₗ[R] N) :
-    (⨁ p : ℤ, G.piece p) ≃ₗ[R] (⨁ p : ℤ, (G.piece p).map e.toLinearMap) :=
-  DirectSum.congrLinearEquiv fun p ↦
-    Submodule.equivMapOfInjective e.toLinearMap e.injective (G.piece p)
-
-private theorem mapPiecesEquiv_lof (G : InternalGrading R M) (e : M ≃ₗ[R] N)
-    (p : ℤ) (x : G.piece p) :
-    mapPiecesEquiv G e (DirectSum.lof R ℤ (fun i ↦ G.piece i) p x) =
-      DirectSum.lof R ℤ (fun i ↦ (G.piece i).map e.toLinearMap) p
-        ((Submodule.equivMapOfInjective e.toLinearMap e.injective (G.piece p)).toLinearMap x) := by
-  -- Expose the bundled linear map so the direct-sum application lemma can rewrite it.
-  change (mapPiecesEquiv G e).toLinearMap
-    (DirectSum.lof R ℤ (fun i ↦ G.piece i) p x) = _
-  rw [mapPiecesEquiv, DirectSum.congrLinearEquiv_toLinearMap, DirectSum.lmap_lof]
-
-private theorem coeLinearMap_comp_mapPiecesEquiv (G : InternalGrading R M)
-    (e : M ≃ₗ[R] N) :
-    (DirectSum.coeLinearMap fun p : ℤ ↦ (G.piece p).map e.toLinearMap) ∘ₗ
-        (mapPiecesEquiv G e).toLinearMap =
-      e.toLinearMap ∘ₗ DirectSum.coeLinearMap G.piece := by
-  apply DirectSum.linearMap_ext R
-  intro p
-  apply LinearMap.ext
-  intro x
-  simp only [LinearMap.comp_apply]
-  calc
-    (DirectSum.coeLinearMap fun p : ℤ ↦ (G.piece p).map e.toLinearMap)
-        ((mapPiecesEquiv G e).toLinearMap
-          (DirectSum.lof R ℤ (fun i ↦ G.piece i) p x)) =
-        (DirectSum.coeLinearMap fun p : ℤ ↦ (G.piece p).map e.toLinearMap)
-          (DirectSum.lof R ℤ (fun i ↦ (G.piece i).map e.toLinearMap) p
-            ((Submodule.equivMapOfInjective e.toLinearMap e.injective
-              (G.piece p)).toLinearMap x)) :=
-      congrArg _ (mapPiecesEquiv_lof G e p x)
-    _ = e x := by
-      rw [DirectSum.coeLinearMap_lof]
-      exact Submodule.coe_equivMapOfInjective_apply e.toLinearMap e.injective (G.piece p) x
-    _ = e.toLinearMap (DirectSum.coeLinearMap G.piece
-        (DirectSum.lof R ℤ (fun i ↦ G.piece i) p x)) := by
-      rw [DirectSum.coeLinearMap_lof]
-      rfl
-
-/-- Transport an internal grading across a linear equivalence. The degree-`p` piece of the target
-is the image of the degree-`p` piece of the source. -/
-noncomputable def map (G : InternalGrading R M) (e : M ≃ₗ[R] N) : InternalGrading R N where
-  piece p := (G.piece p).map e.toLinearMap
-  isInternal := by
-    -- Expose `coeLinearMap` rather than its definitionally equal additive coercion so it can be
-    -- composed with `mapPiecesEquiv` below.
-    change Function.Bijective
-      (DirectSum.coeLinearMap fun p : ℤ ↦ (G.piece p).map e.toLinearMap)
-    let E := mapPiecesEquiv G e
-    have hcomp : Function.Bijective
-        ((DirectSum.coeLinearMap fun p : ℤ ↦ (G.piece p).map e.toLinearMap) ∘ₗ E.toLinearMap) := by
-      rw [coeLinearMap_comp_mapPiecesEquiv]
-      exact e.bijective.comp G.isInternal
-    constructor
-    · intro x y hxy
-      obtain ⟨x', rfl⟩ := E.surjective x
-      obtain ⟨y', rfl⟩ := E.surjective y
-      exact congrArg E (hcomp.injective (by
-        simpa only [LinearMap.comp_apply, LinearEquiv.coe_toLinearMap] using hxy))
-    · intro y
-      obtain ⟨x, hx⟩ := hcomp.surjective y
-      exact ⟨E x, by
-        simpa only [LinearMap.comp_apply, LinearEquiv.coe_toLinearMap] using hx⟩
-
-/-- The degree-`p` piece of a transported grading is the image of the original piece. -/
-@[simp]
-theorem map_piece (G : InternalGrading R M) (e : M ≃ₗ[R] N) (p : ℤ) :
-    (G.map e).piece p = (G.piece p).map e.toLinearMap :=
-  (rfl)
-
-/-- Membership in a transported piece can be checked after applying the inverse equivalence.
-
-This is not a `simp` lemma: `map_piece` already rewrites the left-hand side to a `Submodule.map`,
-on which the `simp` set fires `Submodule.mem_map_equiv` to reach the same right-hand side. -/
-theorem mem_map_piece_iff (G : InternalGrading R M) (e : M ≃ₗ[R] N) (p : ℤ) (y : N) :
-    y ∈ (G.map e).piece p ↔ e.symm y ∈ G.piece p := by
-  exact Submodule.mem_map_equiv (p := G.piece p) (e := e)
-
-/-- A linear equivalence maps a homogeneous element into the transported piece of the same
-degree. This is the special case of `mem_map_piece_iff` that `simp` already reaches. -/
-theorem apply_mem_map_piece_iff (G : InternalGrading R M) (e : M ≃ₗ[R] N) (p : ℤ) (x : M) :
-    e x ∈ (G.map e).piece p ↔ x ∈ G.piece p := by
-  simp
-
-/-- The equivalence used to transport a grading is homogeneous of degree zero. -/
-theorem isHomogeneous_map (G : InternalGrading R M) (e : M ≃ₗ[R] N) :
-    TauCeti.LinearMap.IsHomogeneous e.toLinearMap G.piece (G.map e).piece 0 := by
-  rw [TauCeti.LinearMap.isHomogeneous_def]
-  intro p x hx
-  simpa using hx
-
-/-- The inverse of an equivalence used to transport a grading is homogeneous of degree zero. -/
-theorem isHomogeneous_map_symm (G : InternalGrading R M) (e : M ≃ₗ[R] N) :
-    TauCeti.LinearMap.IsHomogeneous e.symm.toLinearMap (G.map e).piece G.piece 0 := by
-  rw [TauCeti.LinearMap.isHomogeneous_def]
-  intro p y hy
-  simpa using hy
-
-/-- Transport along the identity equivalence leaves an internal grading unchanged. -/
-@[simp]
-theorem map_refl (G : InternalGrading R M) : G.map (LinearEquiv.refl R M) = G := by
-  apply InternalGrading.ext
-  intro p
-  apply Submodule.ext
-  intro x
-  simp
-
-/-- Successive transport agrees with transport along the composite equivalence. -/
-@[simp]
-theorem map_trans {P : Type*} [AddCommMonoid P] [Module R P]
-    (G : InternalGrading R M) (e : M ≃ₗ[R] N) (f : N ≃ₗ[R] P) :
-    (G.map e).map f = G.map (e.trans f) := by
-  apply InternalGrading.ext
-  intro p
-  apply Submodule.ext
-  intro x
-  simp
-
-end Map
 
 section Opposite
 
@@ -189,7 +58,7 @@ noncomputable def opposite (G : InternalGrading R M) : InternalGrading R Mᵐᵒ
 @[simp]
 theorem opposite_piece (G : InternalGrading R M) (p : ℤ) :
     G.opposite.piece p = (G.piece p).map (opLinearEquiv R).toLinearMap :=
-  (rfl)
+  G.map_piece (opLinearEquiv R) p
 
 /-- An opposite element belongs to degree `p` exactly when the original element does. This is the
 special case of `mem_opposite_piece_iff` that `simp` already reaches. -/

--- a/TauCeti/Algebra/Ring/NegOnePow.lean
+++ b/TauCeti/Algebra/Ring/NegOnePow.lean
@@ -17,6 +17,11 @@ This file provides the cast to a ground ring of Mathlib's unit-valued sign chara
 ## Main definitions
 
 * `TauCeti.negOnePowCast`: the scalar `(-1) ^ e` in a ground ring.
+
+## Main results
+
+* `TauCeti.negOnePow_smul_eq_negOnePowCast_smul`: the unit-valued sign and its ground-ring cast
+  induce the same scalar action on a module.
 -/
 
 public section
@@ -60,6 +65,17 @@ theorem negOnePowCast_even {e : ℤ} (he : Even e) : negOnePowCast R e = 1 := by
 
 theorem negOnePowCast_odd {e : ℤ} (he : Odd e) : negOnePowCast R e = -1 := by
   simp [negOnePowCast, Int.negOnePow_odd _ he]
+
+section
+
+variable {A : Type uA} [AddCommGroup A] [Module R A]
+
+/-- A sign `(-1) ^ e`, acting through the units of `ℤ`, acts as its cast to the ground ring. -/
+theorem negOnePow_smul_eq_negOnePowCast_smul (e : ℤ) (a : A) :
+    e.negOnePow • a = negOnePowCast R e • a := by
+  rw [negOnePowCast, Units.smul_def, ← Int.cast_smul_eq_zsmul R]
+
+end
 
 variable {A : Type uA} [AddCommMonoid A] [Module R A]
 

--- a/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
+++ b/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
@@ -26,6 +26,8 @@ compatible with: the total-degree grading of the underlying tensor product of gr
 
 * `TauCeti.gradedTensorGrading`: the total-degree grading of `𝒜 ᵍ⊗[R] ℬ`, whose degree-`n` piece
   is the sum of the images of `𝒜 p ⊗ ℬ (n - p)`.
+* `TauCeti.gradedTensorLift`: the graded universal-property map induced by two graded algebra maps
+  whose images satisfy the Koszul commutation rule.
 * `TauCeti.gradedTensorIncludeLeft` and `TauCeti.gradedTensorIncludeRight`: the inclusions
   `a ↦ a ᵍ⊗ₜ 1` and `b ↦ 1 ᵍ⊗ₜ b` of the two factors, as homomorphisms of graded algebras.
 
@@ -56,7 +58,7 @@ open scoped DirectSum TensorProduct
 
 namespace TauCeti
 
-universe uR uA uB
+universe uR uA uB uC
 
 variable {R : Type uR} {A : Type uA} {B : Type uB}
   [CommRing R] [Ring A] [Ring B] [Algebra R A] [Algebra R B]
@@ -140,6 +142,59 @@ algebra for the total-degree grading. -/
 noncomputable instance instGradedAlgebraGradedTensorGrading :
     GradedAlgebra (gradedTensorGrading 𝒜 ℬ) :=
   (isInternal_gradedTensorGrading 𝒜 ℬ).gradedAlgebra
+
+section Lift
+
+variable {C : Type uC} [Ring C] [Algebra R C]
+  (𝒞 : ℤ → Submodule R C) [GradedAlgebra 𝒞]
+
+private theorem gradedTensorLift_map_mem (F : (𝒜 ᵍ⊗[R] ℬ) →ₐ[R] C)
+    (f : 𝒜 →ₐᵍ[R] 𝒞) (g : ℬ →ₐᵍ[R] 𝒞) (hF : ∀ a b, F (a ᵍ⊗ₜ[R] b) = f a * g b)
+    {n : ℤ} {x : 𝒜 ᵍ⊗[R] ℬ} (hx : x ∈ gradedTensorGrading 𝒜 ℬ n) : F x ∈ 𝒞 n := by
+  refine gradedTensorGrading_le 𝒜 ℬ (C := Submodule.comap
+    F.toLinearMap (𝒞 n)) (fun p a ha b hb ↦ ?_) hx
+  rw [Submodule.mem_comap, AlgHom.toLinearMap_apply, hF]
+  have hfg := SetLike.mul_mem_graded (f.map_mem ha) (g.map_mem hb)
+  -- `mul_mem_graded` uses the stored graded ring maps; expose the definitionally equal
+  -- `GradedAlgHom` coercions before normalizing the degree.
+  change f a * g b ∈ 𝒞 (p + (n - p)) at hfg
+  simpa only [add_sub_cancel] using hfg
+
+/-- The graded algebra map out of a graded tensor product induced by two graded algebra maps whose
+images satisfy the Koszul commutation rule. -/
+@[expose] noncomputable def gradedTensorLift (f : 𝒜 →ₐᵍ[R] 𝒞) (g : ℬ →ₐᵍ[R] 𝒞)
+    (h : ∀ ⦃i j⦄ (a : 𝒜 i) (b : ℬ j),
+      f a * g b = (-1 : ℤˣ) ^ (j * i) • (g b * f a)) :
+    gradedTensorGrading 𝒜 ℬ →ₐᵍ[R] 𝒞 := by
+  have h' : ∀ ⦃i j⦄ (a : 𝒜 i) (b : ℬ j),
+      f.toAlgHom a * g.toAlgHom b = (-1 : ℤˣ) ^ (j * i) •
+        (g.toAlgHom b * f.toAlgHom a) := by
+    intro i j a b
+    -- Mathlib's lift accepts the stored `AlgHom`s, whose applications are definitionally the
+    -- applications of the graded maps in the supplied commutation hypothesis.
+    change f a * g b = (-1 : ℤˣ) ^ (j * i) • (g b * f a)
+    exact h a b
+  let F : (𝒜 ᵍ⊗[R] ℬ) →ₐ[R] C :=
+    GradedTensorProduct.lift 𝒜 ℬ f.toAlgHom g.toAlgHom h'
+  exact { F with
+    map_mem := by
+      apply gradedTensorLift_map_mem 𝒜 ℬ 𝒞
+        (F := F) (f := f) (g := g)
+      intro a b
+      -- The local `F` is Mathlib's underlying lift; expose its stored factor maps to use its
+      -- pure-tensor computation theorem.
+      change F (a ᵍ⊗ₜ[R] b) = f.toAlgHom a * g.toAlgHom b
+      exact GradedTensorProduct.lift_tmul 𝒜 ℬ f.toAlgHom g.toAlgHom h' a b }
+
+/-- The graded tensor lift sends a pure tensor to the product of the two factor maps. -/
+@[simp]
+theorem gradedTensorLift_tmul (f : 𝒜 →ₐᵍ[R] 𝒞) (g : ℬ →ₐᵍ[R] 𝒞)
+    (h : ∀ ⦃i j⦄ (a : 𝒜 i) (b : ℬ j),
+      f a * g b = (-1 : ℤˣ) ^ (j * i) • (g b * f a)) (a : A) (b : B) :
+    gradedTensorLift 𝒜 ℬ 𝒞 f g h (a ᵍ⊗ₜ[R] b) = f a * g b :=
+  rfl
+
+end Lift
 
 /-- A pure tensor of the graded tensor product is additive in its left factor. -/
 @[simp]

--- a/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
+++ b/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
@@ -36,11 +36,11 @@ compatible with: the total-degree grading of the underlying tensor product of gr
 * `TauCeti.instGradedAlgebraGradedTensorGrading`: the graded tensor product of two internally
   `ℤ`-graded algebras is an internally `ℤ`-graded algebra.
 * `TauCeti.gradedTensorGrading_le`: a submodule containing every homogeneous pure tensor of total
-  degree `n` contains the whole degree-`n` piece; `TauCeti.eq_top_of_tmul_mem` and
-  `TauCeti.linearMap_ext_of_tmul` are the corresponding statements for the whole graded tensor
-  product and for maps out of it.  These three are the tools with which a statement about the
-  graded tensor product is reduced to pure tensors of homogeneous elements, which is where the
-  Koszul sign is available.
+  degree `n` contains the whole degree-`n` piece; `TauCeti.gradedTensor_eq_top_of_tmul_mem` and
+  `TauCeti.gradedTensor_linearMap_ext` are the corresponding statements for the whole graded
+  tensor product and for maps out of it.  These three are the tools with which a statement about
+  the graded tensor product is reduced to pure tensors of homogeneous elements, which is where
+  the Koszul sign is available.
 * `TauCeti.gradedTensorAlgHom_ext`: graded algebra maps out of the tensor product are determined by
   their restrictions to the two factors.
 
@@ -98,7 +98,7 @@ theorem gradedTensorGrading_le {n : ℤ} {C : Submodule R (𝒜 ᵍ⊗[R] ℬ)}
   exact iSup_le fun p ↦ Submodule.map₂_le.2 fun a ha b hb ↦ h p a ha b hb
 
 /-- A submodule containing every homogeneous pure tensor is the whole graded tensor product. -/
-theorem eq_top_of_tmul_mem {C : Submodule R (𝒜 ᵍ⊗[R] ℬ)}
+theorem gradedTensor_eq_top_of_tmul_mem {C : Submodule R (𝒜 ᵍ⊗[R] ℬ)}
     (h : ∀ p q : ℤ, ∀ a ∈ 𝒜 p, ∀ b ∈ ℬ q, a ᵍ⊗ₜ[R] b ∈ C) :
     C = ⊤ := by
   refine top_le_iff.1 ?_
@@ -235,13 +235,13 @@ theorem gradedTensor_tmul_zero (a : A) : a ᵍ⊗ₜ[R] (0 : B) = (0 : 𝒜 ᵍ�
 
 /-- Two linear maps out of the graded tensor product agree as soon as they agree on the pure
 tensors of homogeneous elements. -/
-theorem linearMap_ext_of_tmul {M : Type*} [AddCommGroup M] [Module R M]
+theorem gradedTensor_linearMap_ext {M : Type*} [AddCommGroup M] [Module R M]
     {f g : (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] M}
     (h : ∀ p q : ℤ, ∀ a ∈ 𝒜 p, ∀ b ∈ ℬ q, f (a ᵍ⊗ₜ[R] b) = g (a ᵍ⊗ₜ[R] b)) :
     f = g := by
   refine LinearMap.ext fun x ↦ sub_eq_zero.1 ?_
   have hx : x ∈ (⊤ : Submodule R (𝒜 ᵍ⊗[R] ℬ)) := trivial
-  rw [← eq_top_of_tmul_mem 𝒜 ℬ (C := LinearMap.ker (f - g))
+  rw [← gradedTensor_eq_top_of_tmul_mem 𝒜 ℬ (C := LinearMap.ker (f - g))
     fun p q a ha b hb ↦ by simp [h p q a ha b hb]] at hx
   simpa using hx
 

--- a/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
+++ b/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.LinearAlgebra.TensorProduct.Graded.Internal
 public import Mathlib.RingTheory.GradedAlgebra.AlgHom
-public import TauCeti.Algebra.Module.GradedModule.Opposite
 public import TauCeti.Algebra.Module.GradedModule.TensorProduct
 
 /-!

--- a/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
+++ b/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
@@ -42,6 +42,8 @@ compatible with: the total-degree grading of the underlying tensor product of gr
   product and for maps out of it.  These three are the tools with which a statement about the
   graded tensor product is reduced to pure tensors of homogeneous elements, which is where the
   Koszul sign is available.
+* `TauCeti.gradedTensorAlgHom_ext`: graded algebra maps out of the tensor product are determined by
+  their restrictions to the two factors.
 
 The grading of the underlying module is `TauCeti.InternalGrading.tensorProduct` and the Koszul
 multiplication is Mathlib's `GradedTensorProduct`; only their compatibility is proved here.
@@ -162,7 +164,7 @@ private theorem gradedTensorLift_map_mem (F : (𝒜 ᵍ⊗[R] ℬ) →ₐ[R] C)
 
 /-- The graded algebra map out of a graded tensor product induced by two graded algebra maps whose
 images satisfy the Koszul commutation rule. -/
-@[expose] noncomputable def gradedTensorLift (f : 𝒜 →ₐᵍ[R] 𝒞) (g : ℬ →ₐᵍ[R] 𝒞)
+noncomputable def gradedTensorLift (f : 𝒜 →ₐᵍ[R] 𝒞) (g : ℬ →ₐᵍ[R] 𝒞)
     (h : ∀ ⦃i j⦄ (a : 𝒜 i) (b : ℬ j),
       f a * g b = (-1 : ℤˣ) ^ (j * i) • (g b * f a)) :
     gradedTensorGrading 𝒜 ℬ →ₐᵍ[R] 𝒞 := by
@@ -191,8 +193,10 @@ images satisfy the Koszul commutation rule. -/
 theorem gradedTensorLift_tmul (f : 𝒜 →ₐᵍ[R] 𝒞) (g : ℬ →ₐᵍ[R] 𝒞)
     (h : ∀ ⦃i j⦄ (a : 𝒜 i) (b : ℬ j),
       f a * g b = (-1 : ℤˣ) ^ (j * i) • (g b * f a)) (a : A) (b : B) :
-    gradedTensorLift 𝒜 ℬ 𝒞 f g h (a ᵍ⊗ₜ[R] b) = f a * g b :=
-  rfl
+    gradedTensorLift 𝒜 ℬ 𝒞 f g h (a ᵍ⊗ₜ[R] b) = f a * g b := by
+  apply GradedTensorProduct.lift_tmul 𝒜 ℬ f.toAlgHom g.toAlgHom
+  intro i j a b
+  simpa only [GradedAlgHom.coe_toAlgHom] using h a b
 
 end Lift
 
@@ -269,5 +273,21 @@ noncomputable def gradedTensorIncludeRight : ℬ →ₐᵍ[R] gradedTensorGradin
 @[simp]
 theorem gradedTensorIncludeRight_apply (b : B) :
     gradedTensorIncludeRight 𝒜 ℬ b = (1 : A) ᵍ⊗ₜ[R] b := (rfl)
+
+/-- Two graded algebra morphisms from the graded tensor product agree if their compositions with
+the left and right factor inclusions agree. -/
+@[ext]
+theorem gradedTensorAlgHom_ext {C : Type uC} [Ring C] [Algebra R C]
+    (𝒞 : ℤ → Submodule R C) [GradedAlgebra 𝒞]
+    ⦃f g : gradedTensorGrading 𝒜 ℬ →ₐᵍ[R] 𝒞⦄
+    (ha : f.comp (gradedTensorIncludeLeft 𝒜 ℬ) = g.comp (gradedTensorIncludeLeft 𝒜 ℬ))
+    (hb : f.comp (gradedTensorIncludeRight 𝒜 ℬ) = g.comp (gradedTensorIncludeRight 𝒜 ℬ)) :
+    f = g := by
+  apply GradedAlgHom.coe_toAlgHom_injective
+  apply GradedTensorProduct.algHom_ext
+  · simpa only [GradedAlgHom.comp_toAlgHom, gradedTensorIncludeLeft] using
+      congrArg GradedAlgHom.toAlgHom ha
+  · simpa only [GradedAlgHom.comp_toAlgHom, gradedTensorIncludeRight] using
+      congrArg GradedAlgHom.toAlgHom hb
 
 end TauCeti

--- a/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
+++ b/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
@@ -66,29 +66,20 @@ variable (𝒜 : ℤ → Submodule R A) (ℬ : ℤ → Submodule R B) [GradedAlg
 /-- The total-degree grading of the graded tensor product `𝒜 ᵍ⊗[R] ℬ`: the degree-`n` piece is the
 sum of the images of `𝒜 p ⊗ ℬ (n - p)`. -/
 noncomputable def gradedTensorGrading (n : ℤ) : Submodule R (𝒜 ᵍ⊗[R] ℬ) :=
-  Submodule.map (GradedTensorProduct.of R 𝒜 ℬ).toLinearMap
-    (⨆ p : ℤ, Submodule.map₂ (TensorProduct.mk R A B) (𝒜 p) (ℬ (n - p)))
-
-/-- The total-degree grading of `𝒜 ᵍ⊗[R] ℬ` is the tensor-product grading of the underlying graded
-modules, moved across the type synonym. -/
-theorem gradedTensorGrading_eq :
-    gradedTensorGrading 𝒜 ℬ =
-      (((InternalGrading.ofDecomposition 𝒜).tensorProduct
-        (InternalGrading.ofDecomposition ℬ)).map (GradedTensorProduct.of R 𝒜 ℬ)).piece := by
-  funext n
-  rw [InternalGrading.map_piece, gradedTensorGrading,
-    InternalGrading.tensorProduct_piece_eq_iSup, InternalGrading.ofDecomposition_piece,
-    InternalGrading.ofDecomposition_piece]
+  (((InternalGrading.ofDecomposition 𝒜).tensorProduct
+    (InternalGrading.ofDecomposition ℬ)).map (GradedTensorProduct.of R 𝒜 ℬ)).piece n
 
 /-- The homogeneous pieces of the graded tensor product form an internal direct sum. -/
 theorem isInternal_gradedTensorGrading :
-    DirectSum.IsInternal (gradedTensorGrading 𝒜 ℬ) := by
-  rw [gradedTensorGrading_eq]
-  exact InternalGrading.isInternal _
+    DirectSum.IsInternal (gradedTensorGrading 𝒜 ℬ) :=
+  InternalGrading.isInternal _
 
 /-- A pure tensor of homogeneous elements is homogeneous, of the sum of their degrees. -/
 theorem tmul_mem_gradedTensorGrading {p q : ℤ} {a : A} {b : B} (ha : a ∈ 𝒜 p) (hb : b ∈ ℬ q) :
     a ᵍ⊗ₜ[R] b ∈ gradedTensorGrading 𝒜 ℬ (p + q) := by
+  rw [gradedTensorGrading, InternalGrading.map_piece,
+    InternalGrading.tensorProduct_piece_eq_iSup, InternalGrading.ofDecomposition_piece,
+    InternalGrading.ofDecomposition_piece]
   refine Submodule.mem_map_of_mem (Submodule.mem_iSup_of_mem p ?_)
   simpa only [add_sub_cancel_left, TensorProduct.mk_apply] using
     Submodule.apply_mem_map₂ (TensorProduct.mk R A B) ha hb
@@ -98,7 +89,9 @@ degree-`n` piece of the graded tensor product. -/
 theorem gradedTensorGrading_le {n : ℤ} {C : Submodule R (𝒜 ᵍ⊗[R] ℬ)}
     (h : ∀ p : ℤ, ∀ a ∈ 𝒜 p, ∀ b ∈ ℬ (n - p), a ᵍ⊗ₜ[R] b ∈ C) :
     gradedTensorGrading 𝒜 ℬ n ≤ C := by
-  rw [gradedTensorGrading, Submodule.map_le_iff_le_comap]
+  rw [gradedTensorGrading, InternalGrading.map_piece,
+    InternalGrading.tensorProduct_piece_eq_iSup, InternalGrading.ofDecomposition_piece,
+    InternalGrading.ofDecomposition_piece, Submodule.map_le_iff_le_comap]
   exact iSup_le fun p ↦ Submodule.map₂_le.2 fun a ha b hb ↦ h p a ha b hb
 
 /-- A submodule containing every homogeneous pure tensor is the whole graded tensor product. -/
@@ -120,25 +113,27 @@ private theorem tmul_mul_mem_gradedTensorGrading {p q n : ℤ} {a : A} {b : B} {
     GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ a ⟨b, hb⟩ ⟨a', ha'⟩ b']
   rw [Units.smul_def]
   refine zsmul_mem ?_ _
-  rw [show p + q + n = p + r + (q + (n - r)) by ring]
-  exact tmul_mem_gradedTensorGrading 𝒜 ℬ (SetLike.mul_mem_graded ha ha')
-    (SetLike.mul_mem_graded hb hb')
+  convert tmul_mem_gradedTensorGrading 𝒜 ℬ (SetLike.mul_mem_graded ha ha')
+    (SetLike.mul_mem_graded hb hb') using 1
+  all_goals ring_nf
 
 /-- The Koszul multiplication of the graded tensor product adds degrees. -/
 instance instGradedMonoidGradedTensorGrading :
     SetLike.GradedMonoid (gradedTensorGrading 𝒜 ℬ) where
   one_mem := by
     have h : (1 : 𝒜 ᵍ⊗[R] ℬ) = (1 : A) ᵍ⊗ₜ[R] (1 : B) := rfl
-    rw [h, show (0 : ℤ) = 0 + 0 by ring]
-    exact tmul_mem_gradedTensorGrading 𝒜 ℬ (SetLike.one_mem_graded 𝒜) (SetLike.one_mem_graded ℬ)
+    rw [h]
+    convert tmul_mem_gradedTensorGrading 𝒜 ℬ (SetLike.one_mem_graded 𝒜)
+      (SetLike.one_mem_graded ℬ) using 1
+    all_goals ring_nf
   mul_mem := by
     intro m n x y hx hy
     refine gradedTensorGrading_le 𝒜 ℬ (C := Submodule.comap
       ((GradedTensorProduct.mulHom 𝒜 ℬ).flip y) (gradedTensorGrading 𝒜 ℬ (m + n)))
       (fun p a ha b hb ↦ ?_) hx
-    rw [Submodule.mem_comap, LinearMap.flip_apply, ← GradedTensorProduct.mul_def,
-      show m + n = p + (m - p) + n by ring]
-    exact tmul_mul_mem_gradedTensorGrading 𝒜 ℬ ha hb hy
+    rw [Submodule.mem_comap, LinearMap.flip_apply, ← GradedTensorProduct.mul_def]
+    convert tmul_mul_mem_gradedTensorGrading 𝒜 ℬ ha hb hy using 1
+    all_goals ring_nf
 
 /-- The graded tensor product of two internally `ℤ`-graded algebras is an internally `ℤ`-graded
 algebra for the total-degree grading. -/
@@ -147,21 +142,25 @@ noncomputable instance instGradedAlgebraGradedTensorGrading :
   (isInternal_gradedTensorGrading 𝒜 ℬ).gradedAlgebra
 
 /-- A pure tensor of the graded tensor product is additive in its left factor. -/
+@[simp]
 theorem gradedTensor_add_tmul (a₁ a₂ : A) (b : B) :
     (a₁ + a₂) ᵍ⊗ₜ[R] b = (a₁ ᵍ⊗ₜ[R] b : 𝒜 ᵍ⊗[R] ℬ) + a₂ ᵍ⊗ₜ[R] b := by
   simp [GradedTensorProduct.tmul, TensorProduct.add_tmul]
 
 /-- A pure tensor of the graded tensor product is additive in its right factor. -/
+@[simp]
 theorem gradedTensor_tmul_add (a : A) (b₁ b₂ : B) :
     a ᵍ⊗ₜ[R] (b₁ + b₂) = (a ᵍ⊗ₜ[R] b₁ : 𝒜 ᵍ⊗[R] ℬ) + a ᵍ⊗ₜ[R] b₂ := by
   simp [GradedTensorProduct.tmul, TensorProduct.tmul_add]
 
 /-- Scalars pass from the left factor of a pure tensor to the tensor. -/
+@[simp]
 theorem gradedTensor_smul_tmul (r : R) (a : A) (b : B) :
     (r • a) ᵍ⊗ₜ[R] b = r • (a ᵍ⊗ₜ[R] b : 𝒜 ᵍ⊗[R] ℬ) := by
   simp only [GradedTensorProduct.tmul, ← map_smul, TensorProduct.smul_tmul']
 
 /-- Scalars pass from the right factor of a pure tensor to the tensor. -/
+@[simp]
 theorem gradedTensor_tmul_smul (r : R) (a : A) (b : B) :
     a ᵍ⊗ₜ[R] (r • b) = r • (a ᵍ⊗ₜ[R] b : 𝒜 ᵍ⊗[R] ℬ) := by
   simp only [GradedTensorProduct.tmul, ← map_smul, TensorProduct.tmul_smul]
@@ -193,8 +192,9 @@ noncomputable def gradedTensorIncludeLeft : 𝒜 →ₐᵍ[R] gradedTensorGradin
   { GradedTensorProduct.includeLeft 𝒜 ℬ with
     map_mem := fun {i x} hx ↦ by
       have h : x ᵍ⊗ₜ[R] (1 : B) ∈ gradedTensorGrading 𝒜 ℬ i := by
-        rw [show i = i + 0 by ring]
-        exact tmul_mem_gradedTensorGrading 𝒜 ℬ hx (SetLike.one_mem_graded ℬ)
+        convert tmul_mem_gradedTensorGrading 𝒜 ℬ hx
+          (SetLike.one_mem_graded ℬ) using 1
+        all_goals ring_nf
       exact h }
 
 @[simp]
@@ -206,8 +206,9 @@ noncomputable def gradedTensorIncludeRight : ℬ →ₐᵍ[R] gradedTensorGradin
   { GradedTensorProduct.includeRight 𝒜 ℬ with
     map_mem := fun {i x} hx ↦ by
       have h : (1 : A) ᵍ⊗ₜ[R] x ∈ gradedTensorGrading 𝒜 ℬ i := by
-        rw [show i = 0 + i by ring]
-        exact tmul_mem_gradedTensorGrading 𝒜 ℬ (SetLike.one_mem_graded 𝒜) hx
+        convert tmul_mem_gradedTensorGrading 𝒜 ℬ
+          (SetLike.one_mem_graded 𝒜) hx using 1
+        all_goals ring_nf
       exact h }
 
 @[simp]

--- a/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
+++ b/TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.TensorProduct.Graded.Internal
+public import Mathlib.RingTheory.GradedAlgebra.AlgHom
+public import TauCeti.Algebra.Module.GradedModule.Opposite
+public import TauCeti.Algebra.Module.GradedModule.TensorProduct
+
+/-!
+# The graded tensor product of two internally `ℤ`-graded algebras is graded
+
+Mathlib's `GradedTensorProduct R 𝒜 ℬ`, written `𝒜 ᵍ⊗[R] ℬ`, is the tensor product `A ⊗[R] B`
+with the Koszul-signed multiplication
+
+`(a ᵍ⊗ₜ b) * (a' ᵍ⊗ₜ b') = (-1) ^ (|b| * |a'|) • (a * a') ᵍ⊗ₜ (b * b')`.
+
+Mathlib stops at the ring and algebra structures.  This file supplies the grading they are
+compatible with: the total-degree grading of the underlying tensor product of graded modules turns
+`𝒜 ᵍ⊗[R] ℬ` into an internally `ℤ`-graded algebra.
+
+## Main definitions
+
+* `TauCeti.gradedTensorGrading`: the total-degree grading of `𝒜 ᵍ⊗[R] ℬ`, whose degree-`n` piece
+  is the sum of the images of `𝒜 p ⊗ ℬ (n - p)`.
+* `TauCeti.gradedTensorIncludeLeft` and `TauCeti.gradedTensorIncludeRight`: the inclusions
+  `a ↦ a ᵍ⊗ₜ 1` and `b ↦ 1 ᵍ⊗ₜ b` of the two factors, as homomorphisms of graded algebras.
+
+## Main results
+
+* `TauCeti.tmul_mem_gradedTensorGrading`: degrees add on pure tensors.
+* `TauCeti.instGradedAlgebraGradedTensorGrading`: the graded tensor product of two internally
+  `ℤ`-graded algebras is an internally `ℤ`-graded algebra.
+* `TauCeti.gradedTensorGrading_le`: a submodule containing every homogeneous pure tensor of total
+  degree `n` contains the whole degree-`n` piece; `TauCeti.eq_top_of_tmul_mem` and
+  `TauCeti.linearMap_ext_of_tmul` are the corresponding statements for the whole graded tensor
+  product and for maps out of it.  These three are the tools with which a statement about the
+  graded tensor product is reduced to pure tensors of homogeneous elements, which is where the
+  Koszul sign is available.
+
+The grading of the underlying module is `TauCeti.InternalGrading.tensorProduct` and the Koszul
+multiplication is Mathlib's `GradedTensorProduct`; only their compatibility is proved here.
+
+## References
+
+* N. Bourbaki, *Algebra I*, Chapter III, §4.7, example (2).
+* B. Keller, *Introduction to A-infinity algebras and modules*, Section 3.1.
+-/
+
+public section
+
+open scoped DirectSum TensorProduct
+
+namespace TauCeti
+
+universe uR uA uB
+
+variable {R : Type uR} {A : Type uA} {B : Type uB}
+  [CommRing R] [Ring A] [Ring B] [Algebra R A] [Algebra R B]
+
+variable (𝒜 : ℤ → Submodule R A) (ℬ : ℤ → Submodule R B) [GradedAlgebra 𝒜] [GradedAlgebra ℬ]
+
+/-- The total-degree grading of the graded tensor product `𝒜 ᵍ⊗[R] ℬ`: the degree-`n` piece is the
+sum of the images of `𝒜 p ⊗ ℬ (n - p)`. -/
+noncomputable def gradedTensorGrading (n : ℤ) : Submodule R (𝒜 ᵍ⊗[R] ℬ) :=
+  Submodule.map (GradedTensorProduct.of R 𝒜 ℬ).toLinearMap
+    (⨆ p : ℤ, Submodule.map₂ (TensorProduct.mk R A B) (𝒜 p) (ℬ (n - p)))
+
+/-- The total-degree grading of `𝒜 ᵍ⊗[R] ℬ` is the tensor-product grading of the underlying graded
+modules, moved across the type synonym. -/
+theorem gradedTensorGrading_eq :
+    gradedTensorGrading 𝒜 ℬ =
+      (((InternalGrading.ofDecomposition 𝒜).tensorProduct
+        (InternalGrading.ofDecomposition ℬ)).map (GradedTensorProduct.of R 𝒜 ℬ)).piece := by
+  funext n
+  rw [InternalGrading.map_piece, gradedTensorGrading,
+    InternalGrading.tensorProduct_piece_eq_iSup, InternalGrading.ofDecomposition_piece,
+    InternalGrading.ofDecomposition_piece]
+
+/-- The homogeneous pieces of the graded tensor product form an internal direct sum. -/
+theorem isInternal_gradedTensorGrading :
+    DirectSum.IsInternal (gradedTensorGrading 𝒜 ℬ) := by
+  rw [gradedTensorGrading_eq]
+  exact InternalGrading.isInternal _
+
+/-- A pure tensor of homogeneous elements is homogeneous, of the sum of their degrees. -/
+theorem tmul_mem_gradedTensorGrading {p q : ℤ} {a : A} {b : B} (ha : a ∈ 𝒜 p) (hb : b ∈ ℬ q) :
+    a ᵍ⊗ₜ[R] b ∈ gradedTensorGrading 𝒜 ℬ (p + q) := by
+  refine Submodule.mem_map_of_mem (Submodule.mem_iSup_of_mem p ?_)
+  simpa only [add_sub_cancel_left, TensorProduct.mk_apply] using
+    Submodule.apply_mem_map₂ (TensorProduct.mk R A B) ha hb
+
+/-- A submodule containing every homogeneous pure tensor of total degree `n` contains the whole
+degree-`n` piece of the graded tensor product. -/
+theorem gradedTensorGrading_le {n : ℤ} {C : Submodule R (𝒜 ᵍ⊗[R] ℬ)}
+    (h : ∀ p : ℤ, ∀ a ∈ 𝒜 p, ∀ b ∈ ℬ (n - p), a ᵍ⊗ₜ[R] b ∈ C) :
+    gradedTensorGrading 𝒜 ℬ n ≤ C := by
+  rw [gradedTensorGrading, Submodule.map_le_iff_le_comap]
+  exact iSup_le fun p ↦ Submodule.map₂_le.2 fun a ha b hb ↦ h p a ha b hb
+
+/-- A submodule containing every homogeneous pure tensor is the whole graded tensor product. -/
+theorem eq_top_of_tmul_mem {C : Submodule R (𝒜 ᵍ⊗[R] ℬ)}
+    (h : ∀ p q : ℤ, ∀ a ∈ 𝒜 p, ∀ b ∈ ℬ q, a ᵍ⊗ₜ[R] b ∈ C) :
+    C = ⊤ := by
+  refine top_le_iff.1 ?_
+  rw [← (isInternal_gradedTensorGrading 𝒜 ℬ).submodule_iSup_eq_top]
+  exact iSup_le fun n ↦ gradedTensorGrading_le 𝒜 ℬ fun p a ha b hb ↦ h p (n - p) a ha b hb
+
+/-- Multiplying a homogeneous pure tensor into a homogeneous element adds degrees. -/
+private theorem tmul_mul_mem_gradedTensorGrading {p q n : ℤ} {a : A} {b : B} {y : 𝒜 ᵍ⊗[R] ℬ}
+    (ha : a ∈ 𝒜 p) (hb : b ∈ ℬ q) (hy : y ∈ gradedTensorGrading 𝒜 ℬ n) :
+    (a ᵍ⊗ₜ[R] b) * y ∈ gradedTensorGrading 𝒜 ℬ (p + q + n) := by
+  refine gradedTensorGrading_le 𝒜 ℬ (C := Submodule.comap
+    (GradedTensorProduct.mulHom 𝒜 ℬ (a ᵍ⊗ₜ[R] b)) (gradedTensorGrading 𝒜 ℬ (p + q + n)))
+    (fun r a' ha' b' hb' ↦ ?_) hy
+  rw [Submodule.mem_comap, ← GradedTensorProduct.mul_def,
+    GradedTensorProduct.tmul_coe_mul_coe_tmul 𝒜 ℬ a ⟨b, hb⟩ ⟨a', ha'⟩ b']
+  rw [Units.smul_def]
+  refine zsmul_mem ?_ _
+  rw [show p + q + n = p + r + (q + (n - r)) by ring]
+  exact tmul_mem_gradedTensorGrading 𝒜 ℬ (SetLike.mul_mem_graded ha ha')
+    (SetLike.mul_mem_graded hb hb')
+
+/-- The Koszul multiplication of the graded tensor product adds degrees. -/
+instance instGradedMonoidGradedTensorGrading :
+    SetLike.GradedMonoid (gradedTensorGrading 𝒜 ℬ) where
+  one_mem := by
+    have h : (1 : 𝒜 ᵍ⊗[R] ℬ) = (1 : A) ᵍ⊗ₜ[R] (1 : B) := rfl
+    rw [h, show (0 : ℤ) = 0 + 0 by ring]
+    exact tmul_mem_gradedTensorGrading 𝒜 ℬ (SetLike.one_mem_graded 𝒜) (SetLike.one_mem_graded ℬ)
+  mul_mem := by
+    intro m n x y hx hy
+    refine gradedTensorGrading_le 𝒜 ℬ (C := Submodule.comap
+      ((GradedTensorProduct.mulHom 𝒜 ℬ).flip y) (gradedTensorGrading 𝒜 ℬ (m + n)))
+      (fun p a ha b hb ↦ ?_) hx
+    rw [Submodule.mem_comap, LinearMap.flip_apply, ← GradedTensorProduct.mul_def,
+      show m + n = p + (m - p) + n by ring]
+    exact tmul_mul_mem_gradedTensorGrading 𝒜 ℬ ha hb hy
+
+/-- The graded tensor product of two internally `ℤ`-graded algebras is an internally `ℤ`-graded
+algebra for the total-degree grading. -/
+noncomputable instance instGradedAlgebraGradedTensorGrading :
+    GradedAlgebra (gradedTensorGrading 𝒜 ℬ) :=
+  (isInternal_gradedTensorGrading 𝒜 ℬ).gradedAlgebra
+
+/-- A pure tensor of the graded tensor product is additive in its left factor. -/
+theorem gradedTensor_add_tmul (a₁ a₂ : A) (b : B) :
+    (a₁ + a₂) ᵍ⊗ₜ[R] b = (a₁ ᵍ⊗ₜ[R] b : 𝒜 ᵍ⊗[R] ℬ) + a₂ ᵍ⊗ₜ[R] b := by
+  simp [GradedTensorProduct.tmul, TensorProduct.add_tmul]
+
+/-- A pure tensor of the graded tensor product is additive in its right factor. -/
+theorem gradedTensor_tmul_add (a : A) (b₁ b₂ : B) :
+    a ᵍ⊗ₜ[R] (b₁ + b₂) = (a ᵍ⊗ₜ[R] b₁ : 𝒜 ᵍ⊗[R] ℬ) + a ᵍ⊗ₜ[R] b₂ := by
+  simp [GradedTensorProduct.tmul, TensorProduct.tmul_add]
+
+/-- Scalars pass from the left factor of a pure tensor to the tensor. -/
+theorem gradedTensor_smul_tmul (r : R) (a : A) (b : B) :
+    (r • a) ᵍ⊗ₜ[R] b = r • (a ᵍ⊗ₜ[R] b : 𝒜 ᵍ⊗[R] ℬ) := by
+  simp only [GradedTensorProduct.tmul, ← map_smul, TensorProduct.smul_tmul']
+
+/-- Scalars pass from the right factor of a pure tensor to the tensor. -/
+theorem gradedTensor_tmul_smul (r : R) (a : A) (b : B) :
+    a ᵍ⊗ₜ[R] (r • b) = r • (a ᵍ⊗ₜ[R] b : 𝒜 ᵍ⊗[R] ℬ) := by
+  simp only [GradedTensorProduct.tmul, ← map_smul, TensorProduct.tmul_smul]
+
+/-- A pure tensor of the graded tensor product vanishes when its left factor does. -/
+@[simp]
+theorem gradedTensor_zero_tmul (b : B) : (0 : A) ᵍ⊗ₜ[R] b = (0 : 𝒜 ᵍ⊗[R] ℬ) := by
+  simp [GradedTensorProduct.tmul]
+
+/-- A pure tensor of the graded tensor product vanishes when its right factor does. -/
+@[simp]
+theorem gradedTensor_tmul_zero (a : A) : a ᵍ⊗ₜ[R] (0 : B) = (0 : 𝒜 ᵍ⊗[R] ℬ) := by
+  simp [GradedTensorProduct.tmul]
+
+/-- Two linear maps out of the graded tensor product agree as soon as they agree on the pure
+tensors of homogeneous elements. -/
+theorem linearMap_ext_of_tmul {M : Type*} [AddCommGroup M] [Module R M]
+    {f g : (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] M}
+    (h : ∀ p q : ℤ, ∀ a ∈ 𝒜 p, ∀ b ∈ ℬ q, f (a ᵍ⊗ₜ[R] b) = g (a ᵍ⊗ₜ[R] b)) :
+    f = g := by
+  refine LinearMap.ext fun x ↦ sub_eq_zero.1 ?_
+  have hx : x ∈ (⊤ : Submodule R (𝒜 ᵍ⊗[R] ℬ)) := trivial
+  rw [← eq_top_of_tmul_mem 𝒜 ℬ (C := LinearMap.ker (f - g))
+    fun p q a ha b hb ↦ by simp [h p q a ha b hb]] at hx
+  simpa using hx
+
+/-- The inclusion `a ↦ a ᵍ⊗ₜ 1` of the left factor, as a homomorphism of graded algebras. -/
+noncomputable def gradedTensorIncludeLeft : 𝒜 →ₐᵍ[R] gradedTensorGrading 𝒜 ℬ :=
+  { GradedTensorProduct.includeLeft 𝒜 ℬ with
+    map_mem := fun {i x} hx ↦ by
+      have h : x ᵍ⊗ₜ[R] (1 : B) ∈ gradedTensorGrading 𝒜 ℬ i := by
+        rw [show i = i + 0 by ring]
+        exact tmul_mem_gradedTensorGrading 𝒜 ℬ hx (SetLike.one_mem_graded ℬ)
+      exact h }
+
+@[simp]
+theorem gradedTensorIncludeLeft_apply (a : A) :
+    gradedTensorIncludeLeft 𝒜 ℬ a = a ᵍ⊗ₜ[R] (1 : B) := (rfl)
+
+/-- The inclusion `b ↦ 1 ᵍ⊗ₜ b` of the right factor, as a homomorphism of graded algebras. -/
+noncomputable def gradedTensorIncludeRight : ℬ →ₐᵍ[R] gradedTensorGrading 𝒜 ℬ :=
+  { GradedTensorProduct.includeRight 𝒜 ℬ with
+    map_mem := fun {i x} hx ↦ by
+      have h : (1 : A) ᵍ⊗ₜ[R] x ∈ gradedTensorGrading 𝒜 ℬ i := by
+        rw [show i = 0 + i by ring]
+        exact tmul_mem_gradedTensorGrading 𝒜 ℬ (SetLike.one_mem_graded 𝒜) hx
+      exact h }
+
+@[simp]
+theorem gradedTensorIncludeRight_apply (b : B) :
+    gradedTensorIncludeRight 𝒜 ℬ b = (1 : A) ᵍ⊗ₜ[R] b := (rfl)
+
+end TauCeti


### PR DESCRIPTION
This PR constructs the tensor product of two differential graded algebras. It grades Mathlib's Koszul-signed graded tensor product `𝒜 ᵍ⊗[R] ℬ` by total degree, proves that grading is an internal grading compatible with the multiplication `(a ᵍ⊗ₜ b) * (a' ᵍ⊗ₜ b') = (-1)^(|b||a'|) • (a a') ᵍ⊗ₜ (b b')`, equips it with the differential `d (a ᵍ⊗ₜ b) = d_A a ᵍ⊗ₜ b + (-1)^|a| • (a ᵍ⊗ₜ d_B b)`, and proves the three `TauCeti.IsDGAlgebra` axioms for it: the differential raises degree by one, squares to zero, and satisfies the graded Leibniz rule. The two inclusions `a ↦ a ᵍ⊗ₜ 1` and `b ↦ 1 ᵍ⊗ₜ b` are supplied as morphisms of graded algebras and as `TauCeti.DGAlgHom`s.

The exact roadmap target is `TauCetiRoadmap/DGAInfinity/README.md`, Layer 1, item "DG algebras, categories, modules, and bimodules", first bullet: "Define nonunital, unital, and augmented DG algebras on graded `k`-modules; DG algebra morphisms; **opposites and tensor products**; ... Prove all unit, Leibniz, opposite, and **tensor sign formulas on homogeneous elements**." The designated milestone is that Layer 1 bullet, whose zero-differential constructor, cycles/boundaries/cohomology algebra (PR #4654) and morphisms (PR #5613) have landed; the tensor product is the next unbuilt item on it, and it is what the standing convention "an `(A,B)`-bimodule ... is compared with a right module over `Aᵒᵖ ⊗ B`" and the Hochschild layer's `A ⊗ Aᵒᵖ` consume. After this PR that bullet still owes the sign-twisted graded opposite, the augmented and nonunital variants, and the endomorphism-complex constructor.

The Layer-0 dependency it needs — the total-degree grading of a tensor product of internally graded modules — is already on `main` as `TauCeti.InternalGrading.tensorProduct`, so no roadmap switch was required. What was missing is the compatibility of that grading with the Koszul multiplication: Mathlib builds the ring and algebra structures on `GradedTensorProduct` but records "Show that the tensor product of graded algebras is itself a graded algebra" as an open task in `Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean`. `TauCeti.instGradedAlgebraGradedTensorGrading` settles that task in the integer-graded case, and the reduction lemmas `gradedTensorGrading_le`, `eq_top_of_tmul_mem` and `linearMap_ext_of_tmul` are what let every later statement be checked on pure tensors of homogeneous elements, which is the only place a Koszul sign is available.

Two files are added: `TauCeti/RingTheory/GradedAlgebra/TensorProduct.lean` (217 lines, the grading, its `GradedAlgebra` instance, the reduction lemmas, the pure-tensor linearity lemmas and the two graded inclusions) and `TauCeti/Algebra/Homology/DG/Algebra/TensorProduct.lean` (217 lines, the differential and the differential graded structure). `TauCeti/Algebra/Module/GradedModule/Internal.lean` gains `InternalGrading.ofDecomposition`, the bridge from Mathlib's `DirectSum.Decomposition` — under which graded algebras are stated — to this repository's bundled internal grading; it is placed there rather than in the new files because it is pure `InternalGrading` API.

The Leibniz sign is proved, not assumed: the arity-two audit `d(x y) = d x · y + (-1)^{|x|} x · d y` is verified term by term on homogeneous pure tensors, where the four monomials carry the signs `(-1)^{|b||a'|}`, `(-1)^{|b||a'|+|a|}`, `(-1)^{|b||a'|+|a|+|a'|}` and `(-1)^{|b||a'|+|a|+|a'|+|b|}`, and it then extends by the three reduction lemmas above. As in the one-factor axiom `TauCeti.IsDGAlgebra.leibniz`, only the left factor has to be homogeneous.

No Mathlib infrastructure or external formalization is vendored: the Koszul multiplication, its `tmul_coe_mul_coe_tmul` sign lemma and the two inclusions are Mathlib's `GradedTensorProduct`, the underlying module grading and the Koszul twist operator are Tau Ceti's `TauCeti.InternalGrading`, and the differential graded axioms are Tau Ceti's `TauCeti.IsDGAlgebra`. The sign convention follows B. Keller, *Introduction to A-infinity algebras and modules*, Section 3.1, and N. Bourbaki, *Algebra I*, Chapter III, §4.7, example (2), as cited in the module documentation.

Roadmap: DGAInfinity

<!--tauceti-target:v1 {"focus":"DGAInfinity","id":"tensor-product-of-dg-algebras"}-->

🤖 Prepared with Claude Code
