### PR TITLE
refactor: drop eight imports another import already provides

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.BaseChange.Basic
-public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Functoriality
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.FiniteType
 public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
 public import TauCeti.Algebra.Bialgebra.MonoidAlgebra.BaseChange

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Reductive.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeType.Semisimple
 public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
-public import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
 public import TauCeti.Algebra.AlgebraicGroup.Torus.SmoothConnected
 
 /-!

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
@@ -11,7 +11,6 @@ public import TauCeti.Algebra.Coalgebra.Comodule.Flag.Induction
 import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Naturality
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.ClosedSubgroup
 import TauCeti.Algebra.AlgebraicGroup.UpperUnitriangular.Unipotent
-import TauCeti.Algebra.Coalgebra.Comodule.PointAction
 import TauCeti.Algebra.Coalgebra.Comodule.Transport
 import TauCeti.CategoryTheory.Comma.Over
 import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Kolchin

--- a/TauCeti/LowDimTopology/Plumbing/OneVertex.lean
+++ b/TauCeti/LowDimTopology/Plumbing/OneVertex.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LowDimTopology.Plumbing.Tower
-import TauCeti.LowDimTopology.Plumbing.Cube.Weight.Recursion
 import TauCeti.LowDimTopology.Plumbing.DiagonalDominance
 import TauCeti.LowDimTopology.Plumbing.TopDegree
 import TauCeti.LowDimTopology.Plumbing.Weight.Polarization

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CoprimeMul.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CoprimeMul.lean
@@ -9,7 +9,6 @@ public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
 
 import Mathlib.LinearAlgebra.Matrix.Integer
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.CongruenceSplit
-import TauCeti.NumberTheory.HeckeRing.Multiplicity.Support
 
 /-!
 # Coprime multiplication in the `GL_n` Hecke ring

--- a/TauCeti/NumberTheory/ModularForms/Norm/Cusps.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Cusps.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Data.ZMod.QuotientGroup
-public import TauCeti.NumberTheory.ModularForms.Norm.Order
 public import TauCeti.NumberTheory.ModularForms.Norm.Trace
 public import TauCeti.NumberTheory.ModularForms.Norm.Valence
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Compositum.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Compositum.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.NumberTheory.Multiquadratic.Galois.Basic
 public import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminant.Field
 public import Mathlib.NumberTheory.NumberField.Discriminant.Different
-import TauCeti.NumberTheory.Multiquadratic.Degree
 import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminant.Independence
 import Mathlib.Algebra.BigOperators.Option
 

--- a/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Dominance.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Combinatorics.Young.Dominance
-public import TauCeti.RepresentationTheory.AsAlgebraHom
 public import TauCeti.RepresentationTheory.Symmetric.PermutationModule.Basic
 public import TauCeti.RepresentationTheory.Symmetric.Symmetrizer
 


### PR DESCRIPTION
Eight imports that another of the same file's imports already provides.

| file | dropped | provided via |
|---|---|---|
| `NumberTheory/ModularForms/Norm/Cusps.lean` | `public import …Norm.Order` | `Norm.Valence → Order.SubgroupOrbits → Norm.Order` |
| `NumberTheory/HeckeRing/GLn/CoprimeMul.lean` | `import …Multiplicity.Support` | `GLn.DiagonalCosets → HeckeRing.One → Multiplication → Multiplicity.Support` |
| `NumberTheory/Multiquadratic/Prime/Discriminant/Compositum.lean` | `import …Multiquadratic.Degree` | `Prime.Discriminant.Independence → Multiquadratic.Degree` |
| `LowDimTopology/Plumbing/OneVertex.lean` | `import …Cube.Weight.Recursion` | `Plumbing.Tower → Grading → Differential → Cube.Generator → Cube.Weight.Recursion` |
| `RepresentationTheory/Symmetric/Dominance.lean` | `public import …AsAlgebraHom` | `Symmetric.Symmetrizer → SubgroupCharSum → AsAlgebraHom` |
| `Algebra/AlgebraicGroup/Torus/Reductive.lean` | `public import …Smooth.GeometricallyReduced` | `Torus.SmoothConnected → Smooth.GeometricallyReduced` |
| `Algebra/AlgebraicGroup/DiagonalizableGroup/BaseChange.lean` | `public import …DiagonalizableGroup.Functoriality` | `DiagonalizableGroup.FiniteType → Functoriality` |
| `Algebra/AlgebraicGroup/Unipotent/Embedding.lean` | `import …Comodule.PointAction` | `Representation.UpperUnitriangular → Faithful.Basic → PointsAction → Comodule.PointAction` |

## Why these are provable, not merely plausible

**Under the module system an import is not transitive.** `import B` gives you B, but B's own plain imports stay private to B; only `public import` re-exports. So "A is already provided by B" holds precisely when B reaches A along a chain of **public** imports. This repo has **6,585 public** and **1,220 plain** TauCeti import edges, and every chain above is public end to end.

That makes the two cases asymmetric, and they were checked separately:

- a **plain** `import A` may be dropped when *any* other direct import publicly reaches A — the file only needs to *see* A;
- a **`public import A`** may be dropped only when another **public** direct import publicly reaches A — the file also *re-exports* A, and a plain import of the cover would not carry that on. All four `public import` rows here have public covers, so the re-export surface is unchanged.

## Why dropping rather than keeping

Being redundant is not on its own a reason to remove an import — a file that directly uses a module arguably should name it, and an index module's import list is its whole content. Neither applies here:

- **none of these files is an index module** — each has its own declarations;
- **none of the eight modules contributes a name the importing file mentions**;
- **none of them registers instances or notation**, so nothing is reached implicitly either. (This last check matters: a sibling candidate was dropped from this PR because the module it would have removed declares exactly one thing — `instance instModuleFiniteCotangentSpace` — which typeclass search consumes without ever naming it.)

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp