### PR TITLE
feat: linearize narrow genus characters

### DIFF
--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient/Basic.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient/Basic.lean
@@ -46,7 +46,8 @@ names around it. The cardinality identity is still expressed through the squarin
 * `TauCeti.elementaryTwoQuotientMk_surjective` and `TauCeti.elementaryTwoQuotientMk_eq_iff`: the
   class map is surjective, and two elements have the same class iff they differ by a square.
 * `TauCeti.elementaryTwoQuotientLiftEquiv` and `TauCeti.elementaryTwoQuotientLinearLiftEquiv`: the
-  universal property for maps out of `G/G²`, inherited from `ModN.liftEquiv`.
+  universal property for maps out of `G/G²`, inherited from `ModN.liftEquiv`, with
+  `TauCeti.elementaryTwoQuotientLinearLiftEquiv_symm_mk` as its computation rule.
 * `TauCeti.elementaryTwoQuotientMap` and `TauCeti.elementaryTwoQuotientCongr`: transport along
   homomorphisms and equivalences of commutative groups.
 * `TauCeti.elementaryTwoQuotientMap_apply_eq_self_of_isSquare_div`,
@@ -143,6 +144,14 @@ additive homomorphisms from `Additive G` whose values are killed by `2`. -/
 protected def elementaryTwoQuotientLinearLiftEquiv [AddCommGroup H] [Module (ZMod 2) H] :
     (ElementaryTwoQuotient G →ₗ[ZMod 2] H) ≃ {φ : Additive G →+ H // ∀ g, 2 • φ g = 0} :=
   ModN.liftEquiv'
+
+/-- The linear map obtained from the universal property of `G/G²` evaluates on the class of `g`
+as the original additive homomorphism evaluates on `Additive.ofMul g`. -/
+@[simp] theorem elementaryTwoQuotientLinearLiftEquiv_symm_mk [AddCommGroup H]
+    [Module (ZMod 2) H] (φ : Additive G →+ H) (hφ : ∀ g, 2 • φ g = 0) (g : G) :
+    (TauCeti.elementaryTwoQuotientLinearLiftEquiv.symm ⟨φ, hφ⟩)
+        (elementaryTwoQuotientMk g) = φ (Additive.ofMul g) := by
+  rfl
 
 /-- The class map to `G / G²` sends a product to the sum of the classes. -/
 @[simp] theorem elementaryTwoQuotientMk_mul (g h : G) :

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/ElementaryTwoQuotient.lean
@@ -31,13 +31,11 @@ The construction follows the genus-character treatment in Cox, *Primes of the Fo
 
 ## Main results
 
-* `genusCharFunNarrowClassGroupHom_eq_prod_singleton`: a subset-indexed narrow genus character is
-  the product of its singleton characters.
 * `genusCharFunElementaryTwoQuotientLinearMap`: the genus character as a linear functional on
   `Cl⁺(K) / Cl⁺(K)²`.
 * `genusCharFunElementaryTwoQuotientFamilyLinearMap`: the linear map collecting all singleton
   genus characters.
-* `genusCharFunElementaryTwoQuotientLinearMap_apply_eq_sum_singleton`: a subset character is the
+* `genusCharFunElementaryTwoQuotientLinearMap_eq_sum_singleton`: a subset character is the
   sum of its singleton linear functionals.
 -/
 
@@ -51,54 +49,6 @@ namespace TauCeti.Multiquadratic
 open NumberField
 
 variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
-
-/-- A genus character indexed by a set `t` of prime discriminants is the product of the
-characters indexed by the singletons in `t`.
-
-Although this is immediate for the arithmetic function `genusCharFun`, the narrow-class-group
-characters are defined using coprime representatives. The statement records that their descent
-preserves the same product decomposition. -/
-theorem genusCharFunNarrowClassGroupHom_eq_prod_singleton
-    {s t : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
-    (heven : ∀ P ∈ s, ∀ P' ∈ s,
-      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
-    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
-    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
-    (hsf : Squarefree d) (hts : t ⊆ s) (A : NumberField.NarrowClassGroup K) :
-    genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf hts A =
-      ∏ P : ↥t, genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
-        (Finset.singleton_subset_iff.mpr (hts P.2)) A := by
-  have hm : (∏ P ∈ t, P) ≠ 0 := by
-    rw [Finset.prod_ne_zero_iff]
-    intro P hP
-    exact (hs P (hts hP)).isFundamentalDiscriminant.ne_zero
-  obtain ⟨I, hIA, hIcop⟩ :=
-    NumberField.NarrowClassGroup.exists_mk0_eq_and_isCoprime_absNorm A hm
-  let It : genusCharFunCoprimeIdealSubmonoid (K := K) t := ⟨I, by
-    simpa only [mem_genusCharFunCoprimeIdealSubmonoid_iff] using hIcop⟩
-  rw [← hIA]
-  -- `It` and `I` carry the same ideal; expose that equality to use the quotient computation rule.
-  rw [← show NumberField.NarrowClassGroup.mk0 It.1 =
-      NumberField.NarrowClassGroup.mk0 I from rfl,
-    genusCharFunNarrowClassGroupHom_mk0]
-  apply Units.ext
-  rw [genusCharFunCoprimeIdealHom_apply, genusCharFun_def, Units.coe_prod]
-  -- Coercing the product of unit-valued characters leaves a product of their integer values.
-  change _ = ∏ P : ↥t,
-    ((genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
-      (Finset.singleton_subset_iff.mpr (hts P.2))
-      (NumberField.NarrowClassGroup.mk0 It.1) : ℤˣ) : ℤ)
-  rw [Finset.prod_subtype t (fun _ => Iff.rfl)]
-  apply Finset.prod_congr rfl
-  intro P _
-  let IP : genusCharFunCoprimeIdealSubmonoid (K := K) {P.1} := ⟨I, by
-    rw [mem_genusCharFunCoprimeIdealSubmonoid_iff]
-    simpa using (IsCoprime.prod_right_iff.mp hIcop) P P.2⟩
-  -- `IP` only equips the same ideal with the weaker singleton coprimality property.
-  rw [show NumberField.NarrowClassGroup.mk0 I =
-      NumberField.NarrowClassGroup.mk0 IP.1 from rfl,
-    genusCharFunNarrowClassGroupHom_mk0, genusCharFunCoprimeIdealHom_apply,
-    genusCharFun_singleton]
 
 /-- The genus character as a `ZMod 2`-linear functional on the maximal elementary-2 quotient
 `Cl⁺(K) / Cl⁺(K)²` of the narrow class group.
@@ -167,21 +117,23 @@ singleton prime discriminant. -/
 
 /-- The linear functional of a subset-indexed genus character is the sum of the singleton
 functionals indexed by that subset. -/
-theorem genusCharFunElementaryTwoQuotientLinearMap_apply_eq_sum_singleton
+theorem genusCharFunElementaryTwoQuotientLinearMap_eq_sum_singleton
     {s t : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
     (heven : ∀ P ∈ s, ∀ P' ∈ s,
       IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
     (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
-    (hsf : Squarefree d) (hts : t ⊆ s)
-    (x : NumberField.NarrowClassGroup.ElementaryTwoQuotient K) :
-    genusCharFunElementaryTwoQuotientLinearMap hs heven hprod hmin hgen hsf hts x =
+    (hsf : Squarefree d) (hts : t ⊆ s) :
+    genusCharFunElementaryTwoQuotientLinearMap hs heven hprod hmin hgen hsf hts =
       ∑ P : ↥t, genusCharFunElementaryTwoQuotientLinearMap
-        hs heven hprod hmin hgen hsf (Finset.singleton_subset_iff.mpr (hts P.2)) x := by
+        hs heven hprod hmin hgen hsf (Finset.singleton_subset_iff.mpr (hts P.2)) := by
+  apply LinearMap.ext
+  intro x
   obtain ⟨A, rfl⟩ := TauCeti.elementaryTwoQuotientMk_surjective
     (G := NumberField.NarrowClassGroup K) x
   apply Additive.toMul.injective
-  simpa using genusCharFunNarrowClassGroupHom_eq_prod_singleton
-    hs heven hprod hmin hgen hsf hts A
+  simpa using DFunLike.congr_fun
+    (genusCharFunNarrowClassGroupHom_eq_prod_singleton
+      hs heven hprod hmin hgen hsf hts) A
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/ElementaryTwoQuotient.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.ZMod.IntUnitsPower
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.GenusCharacter.NarrowClassGroup
+public import TauCeti.NumberTheory.NumberField.NarrowClassGroup.ElementaryTwoQuotient
+
+/-!
+# Genus characters on the elementary-2 quotient of the narrow class group
+
+A genus character on the narrow class group has values in the two-element group `ℤˣ`, so it is
+trivial on squares. It therefore factors canonically through the maximal elementary-2 quotient
+
+```text
+Cl⁺(K) / Cl⁺(K)².
+```
+
+Writing the quotient and the sign group additively makes the factor a `ZMod 2`-linear functional.
+This file also collects the characters indexed by the individual prime discriminants into one
+linear map. A character indexed by a subset is the sum of the corresponding singleton
+coordinates. Thus the arithmetic characters are organized as the linear family used in the
+genus-theoretic computation of the narrow class group's two-rank.
+
+The construction follows the genus-character treatment in Cox, *Primes of the Form `x² + ny²`*,
+§3.B, and Lemmermeyer, *Reciprocity Laws*, §2.2. The quotient factorization uses Mathlib's
+`ModN.liftEquiv'`, exposed through `TauCeti.elementaryTwoQuotientLinearLiftEquiv`.
+
+## Main results
+
+* `genusCharFunNarrowClassGroupHom_eq_prod_singleton`: a subset-indexed narrow genus character is
+  the product of its singleton characters.
+* `genusCharFunElementaryTwoQuotientLinearMap`: the genus character as a linear functional on
+  `Cl⁺(K) / Cl⁺(K)²`.
+* `genusCharFunElementaryTwoQuotientFamilyLinearMap`: the linear map collecting all singleton
+  genus characters.
+* `genusCharFunElementaryTwoQuotientLinearMap_apply_eq_sum_singleton`: a subset character is the
+  sum of its singleton linear functionals.
+-/
+
+public section
+
+open Polynomial
+open scoped NumberField nonZeroDivisors
+
+namespace TauCeti.Multiquadratic
+
+open NumberField
+
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
+
+/-- A genus character indexed by a set `t` of prime discriminants is the product of the
+characters indexed by the singletons in `t`.
+
+Although this is immediate for the arithmetic function `genusCharFun`, the narrow-class-group
+characters are defined using coprime representatives. The statement records that their descent
+preserves the same product decomposition. -/
+theorem genusCharFunNarrowClassGroupHom_eq_prod_singleton
+    {s t : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s,
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (hts : t ⊆ s) (A : NumberField.NarrowClassGroup K) :
+    genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf hts A =
+      ∏ P : ↥t, genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
+        (Finset.singleton_subset_iff.mpr (hts P.2)) A := by
+  have hm : (∏ P ∈ t, P) ≠ 0 := by
+    rw [Finset.prod_ne_zero_iff]
+    intro P hP
+    exact (hs P (hts hP)).isFundamentalDiscriminant.ne_zero
+  obtain ⟨I, hIA, hIcop⟩ :=
+    NumberField.NarrowClassGroup.exists_mk0_eq_and_isCoprime_absNorm A hm
+  let It : genusCharFunCoprimeIdealSubmonoid (K := K) t := ⟨I, by
+    simpa only [mem_genusCharFunCoprimeIdealSubmonoid_iff] using hIcop⟩
+  rw [← hIA]
+  -- `It` and `I` carry the same ideal; expose that equality to use the quotient computation rule.
+  rw [← show NumberField.NarrowClassGroup.mk0 It.1 =
+      NumberField.NarrowClassGroup.mk0 I from rfl,
+    genusCharFunNarrowClassGroupHom_mk0]
+  apply Units.ext
+  rw [genusCharFunCoprimeIdealHom_apply, genusCharFun_def, Units.coe_prod]
+  -- Coercing the product of unit-valued characters leaves a product of their integer values.
+  change _ = ∏ P : ↥t,
+    ((genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
+      (Finset.singleton_subset_iff.mpr (hts P.2))
+      (NumberField.NarrowClassGroup.mk0 It.1) : ℤˣ) : ℤ)
+  rw [Finset.prod_subtype t (fun _ => Iff.rfl)]
+  apply Finset.prod_congr rfl
+  intro P _
+  let IP : genusCharFunCoprimeIdealSubmonoid (K := K) {P.1} := ⟨I, by
+    rw [mem_genusCharFunCoprimeIdealSubmonoid_iff]
+    simpa using (IsCoprime.prod_right_iff.mp hIcop) P P.2⟩
+  -- `IP` only equips the same ideal with the weaker singleton coprimality property.
+  rw [show NumberField.NarrowClassGroup.mk0 I =
+      NumberField.NarrowClassGroup.mk0 IP.1 from rfl,
+    genusCharFunNarrowClassGroupHom_mk0, genusCharFunCoprimeIdealHom_apply,
+    genusCharFun_singleton]
+
+/-- The genus character as a `ZMod 2`-linear functional on the maximal elementary-2 quotient
+`Cl⁺(K) / Cl⁺(K)²` of the narrow class group.
+
+The target is written as `Additive ℤˣ`: multiplication of signs is addition in this two-element
+`ZMod 2`-module. -/
+noncomputable def genusCharFunElementaryTwoQuotientLinearMap
+    {s t : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s,
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (hts : t ⊆ s) :
+    NumberField.NarrowClassGroup.ElementaryTwoQuotient K →ₗ[ZMod 2] Additive ℤˣ :=
+  (TauCeti.elementaryTwoQuotientLinearLiftEquiv
+      (G := NumberField.NarrowClassGroup K) (H := Additive ℤˣ)).symm
+    ⟨(genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf hts).toAdditive,
+      fun C => by
+        apply Additive.toMul.injective
+        simp [two_nsmul, Int.units_mul_self]⟩
+
+/-- Evaluating the factored linear genus character on the class of a narrow ideal class recovers
+the original narrow-class-group character. -/
+@[simp] theorem genusCharFunElementaryTwoQuotientLinearMap_mk
+    {s t : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s,
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (hts : t ⊆ s) (A : NumberField.NarrowClassGroup K) :
+    genusCharFunElementaryTwoQuotientLinearMap hs heven hprod hmin hgen hsf hts
+        (TauCeti.elementaryTwoQuotientMk A) =
+      Additive.ofMul (genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf hts A) := by
+  unfold genusCharFunElementaryTwoQuotientLinearMap
+  rw [TauCeti.elementaryTwoQuotientLinearLiftEquiv_symm_mk]
+  rfl
+
+/-- The linear family of singleton genus characters, with one coordinate for each prime
+discriminant in `s`. -/
+noncomputable def genusCharFunElementaryTwoQuotientFamilyLinearMap
+    {s : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s,
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) :
+    NumberField.NarrowClassGroup.ElementaryTwoQuotient K →ₗ[ZMod 2]
+      ((P : ↥s) → Additive ℤˣ) :=
+  LinearMap.pi fun P => genusCharFunElementaryTwoQuotientLinearMap
+    hs heven hprod hmin hgen hsf (Finset.singleton_subset_iff.mpr P.2)
+
+/-- A coordinate of the family map is the linear genus character indexed by the corresponding
+singleton prime discriminant. -/
+@[simp] theorem genusCharFunElementaryTwoQuotientFamilyLinearMap_apply
+    {s : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s,
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (x : NumberField.NarrowClassGroup.ElementaryTwoQuotient K)
+    (P : ↥s) :
+    genusCharFunElementaryTwoQuotientFamilyLinearMap hs heven hprod hmin hgen hsf x P =
+      genusCharFunElementaryTwoQuotientLinearMap hs heven hprod hmin hgen hsf
+        (Finset.singleton_subset_iff.mpr P.2) x := by
+  rfl
+
+/-- The linear functional of a subset-indexed genus character is the sum of the singleton
+functionals indexed by that subset. -/
+theorem genusCharFunElementaryTwoQuotientLinearMap_apply_eq_sum_singleton
+    {s t : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s,
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (hts : t ⊆ s)
+    (x : NumberField.NarrowClassGroup.ElementaryTwoQuotient K) :
+    genusCharFunElementaryTwoQuotientLinearMap hs heven hprod hmin hgen hsf hts x =
+      ∑ P : ↥t, genusCharFunElementaryTwoQuotientLinearMap
+        hs heven hprod hmin hgen hsf (Finset.singleton_subset_iff.mpr (hts P.2)) x := by
+  obtain ⟨A, rfl⟩ := TauCeti.elementaryTwoQuotientMk_surjective
+    (G := NumberField.NarrowClassGroup K) x
+  apply Additive.toMul.injective
+  simpa using genusCharFunNarrowClassGroupHom_eq_prod_singleton
+    hs heven hprod hmin hgen hsf hts A
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/NarrowClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/NarrowClassGroup.lean
@@ -27,6 +27,8 @@ theorem used here are developed in the preceding Tau Ceti modules.
   the map to the narrow class group.
 * `genusCharFunNarrowClassGroupHom`: the descended genus character on `Cl⁺(K)`.
 * `genusCharFunNarrowClassGroupHom_mk0`: its computation on a coprime integral ideal.
+* `genusCharFunNarrowClassGroupHom_eq_prod_singleton`: a subset-indexed narrow genus character is
+  the product of its singleton characters.
 -/
 
 public section
@@ -180,5 +182,64 @@ noncomputable def genusCharFunNarrowClassGroupHom
     exact (Con.kerLift_mk (f := q) I).symm
   rw [he]
   exact Con.lift_mk' hχ I
+
+/-- A genus character indexed by a set `t` of prime discriminants is the product of the
+characters indexed by the singletons in `t`.
+
+Although this is immediate for the arithmetic function `genusCharFun`, the narrow-class-group
+characters are defined using coprime representatives. The statement records that their descent
+preserves the same product decomposition. -/
+theorem genusCharFunNarrowClassGroupHom_eq_prod_singleton
+    {s t : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s,
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (hts : t ⊆ s) :
+    genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf hts =
+      ∏ P : ↥t, genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
+        (Finset.singleton_subset_iff.mpr (hts P.2)) := by
+  apply MonoidHom.ext
+  intro A
+  have hm : (∏ P ∈ t, P) ≠ 0 := by
+    rw [Finset.prod_ne_zero_iff]
+    intro P hP
+    exact (hs P (hts hP)).isFundamentalDiscriminant.ne_zero
+  obtain ⟨I, hIA, hIcop⟩ :=
+    NumberField.NarrowClassGroup.exists_mk0_eq_and_isCoprime_absNorm A hm
+  let It : genusCharFunCoprimeIdealSubmonoid (K := K) t := ⟨I, by
+    simpa only [mem_genusCharFunCoprimeIdealSubmonoid_iff] using hIcop⟩
+  rw [← hIA]
+  -- `It` and `I` carry the same ideal; expose that equality to use the quotient computation rule.
+  rw [← show NumberField.NarrowClassGroup.mk0 It.1 =
+      NumberField.NarrowClassGroup.mk0 I from rfl,
+    genusCharFunNarrowClassGroupHom_mk0]
+  have h_eval :
+      (∏ P : ↥t, genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
+        (Finset.singleton_subset_iff.mpr (hts P.2)))
+          (NumberField.NarrowClassGroup.mk0 It.1) =
+        ∏ P : ↥t, genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
+          (Finset.singleton_subset_iff.mpr (hts P.2))
+          (NumberField.NarrowClassGroup.mk0 It.1) := by
+    simp
+  rw [h_eval]
+  apply Units.ext
+  rw [genusCharFunCoprimeIdealHom_apply, genusCharFun_def, Units.coe_prod]
+  -- Coercing the product of unit-valued characters leaves a product of their integer values.
+  change _ = ∏ P : ↥t,
+    ((genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
+      (Finset.singleton_subset_iff.mpr (hts P.2))
+      (NumberField.NarrowClassGroup.mk0 It.1) : ℤˣ) : ℤ)
+  rw [Finset.prod_subtype t (fun _ => Iff.rfl)]
+  apply Finset.prod_congr rfl
+  intro P _
+  let IP : genusCharFunCoprimeIdealSubmonoid (K := K) {P.1} := ⟨I, by
+    rw [mem_genusCharFunCoprimeIdealSubmonoid_iff]
+    simpa using (IsCoprime.prod_right_iff.mp hIcop) P P.2⟩
+  -- `IP` only equips the same ideal with the weaker singleton coprimality property.
+  rw [show NumberField.NarrowClassGroup.mk0 I =
+      NumberField.NarrowClassGroup.mk0 IP.1 from rfl,
+    genusCharFunNarrowClassGroupHom_mk0, genusCharFunCoprimeIdealHom_apply,
+    genusCharFun_singleton]
 
 end TauCeti.Multiquadratic


### PR DESCRIPTION
This PR factors every descended narrow genus character canonically through `Cl⁺(K) / Cl⁺(K)²` and collects the singleton characters into a `ZMod 2`-linear family. It proves that the character indexed by any subset of prime discriminants is the product of its singleton characters before descent and the sum of their linear functionals afterward, so the arithmetic family now acts on the exact vector space whose dimension is the narrow class-group 2-rank.

The exact target is `TauCetiRoadmap/Multiquadratic/README.md`, Layer 3, “the genus field and the 2-rank theorem (the summit),” specifically the real quadratic clause requiring the narrow class group and its `t - 1` formula. This is the next dependency identified when `genusCharFunNarrowClassGroupHom` landed in #5620: that PR descended individual characters to `Cl⁺(K)`, while the lower-bound argument needs them as a linear family on `Cl⁺(K) / Cl⁺(K)²`. After this PR, the milestone still needs the family-level independence/surjectivity calculation, the resulting lower bound matching `narrowTwoRank_le_ncard_ramifiedPrimes_sub_one`, and then the relative narrow-genus-field Galois-group identification.

The originally designated `UniversalCovers` roadmap has no viable unclaimed critical-path step: every numbered milestone is implemented on `main`, the final pointed-parametrisation packaging is already in PR #5658, and cube connectedness is claimed by PR #5462. I therefore fell back to this ready Layer 3 dependency instead of adding peripheral universal-cover API after the roadmap’s completion.

The new 184-line module `TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/ElementaryTwoQuotient.lean` defines `genusCharFunElementaryTwoQuotientLinearMap`, its singleton family map, their computation rules, and the subset decomposition theorem. The existing generic quotient module gains the missing `@[simp]` computation rule `elementaryTwoQuotientLinearLiftEquiv_symm_mk`, which is the characteristic API required to consume the factor without unfolding its quotient implementation.

No Mathlib source is vendored. The factorization uses Mathlib’s `ModN.liftEquiv'` and its `ZMod 2`-module structure on `Additive ℤˣ`; the genus-character mathematics follows Cox, *Primes of the Form x² + ny²*, §3.B, and Lemmermeyer, *Reciprocity Laws*, §2.2, as cited in the module documentation.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"genus-character-elementary-two-quotient"}-->

🤖 Prepared with Codex
