### PR TITLE
feat: the shift identities of the graded Ext-Euler characteristic

### DIFF
--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Basic.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Basic.lean
@@ -244,6 +244,13 @@ noncomputable def gradedExtDimension {X Y : C}
     {n : ℕ} (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n)) : LaurentPolynomial ℤ :=
   targetShiftGradedDimension k (GradedExt.{w} e X Y n) h
 
+/-- The graded `Ext` dimension is the target-shift graded dimension of the bigraded family, so
+the generic reindexing lemmas for `TauCeti.targetShiftGradedDimension` apply to it. -/
+theorem gradedExtDimension_eq_targetShiftGradedDimension {X Y : C}
+    {n : ℕ} (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n)) :
+    gradedExtDimension k e h = targetShiftGradedDimension k (GradedExt.{w} e X Y n) h :=
+  (rfl)
+
 /-- The coefficient of `q^j` in the graded Ext dimension is
 `dim_k Ext^{n,-j}(X,Y)`. -/
 @[simp]

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
@@ -29,19 +29,25 @@ dimension by `q`; shifting the source instead identifies `Ext^{n,j}(X{1}, Y)` wi
 `Ext^{n,j-1}(X, Y)` and multiplies it by `q⁻¹`.  The source identity uses that `Ext` is invariant
 under the equivalence `e`, so it needs `e` to be `k`-linear and not merely additive: an additive
 isomorphism of `k`-vector spaces need not preserve dimension.  The comparison of `e ^ (j + 1)`
-with the composites `e ^ j ∘ e` and `e ∘ e ^ j` is `TauCeti.equivPowSuccIso` and
-`TauCeti.equivPowSuccRightIso`.
+with the composites `e ^ j ∘ e` and `e ∘ e ^ j` is
+`CategoryTheory.Equivalence.powSuccIso` and `CategoryTheory.Equivalence.powSuccRightIso`.
+
+Every identity below takes a single admissibility witness, for the unshifted pair: the shifted
+witness it needs is the one this file constructs from it.
 
 ## Main definitions
 
 * `TauCeti.gradedExtShiftTargetEquiv`: `Ext^{n,j}(X, Y{1}) ≃ₗ[k] Ext^{n,j+1}(X, Y)`.
+* `TauCeti.gradedExtShiftTargetInverseEquiv`: `Ext^{n,j}(X, Y{-1}) ≃ₗ[k] Ext^{n,j-1}(X, Y)`.
 * `TauCeti.gradedExtShiftSourceEquiv`: `Ext^{n,j}(X{1}, Y) ≃ₗ[k] Ext^{n,j-1}(X, Y)`.
+* `TauCeti.gradedExtShiftSourceInverseEquiv`: `Ext^{n,j}(X{-1}, Y) ≃ₗ[k] Ext^{n,j+1}(X, Y)`.
 
 ## Main results
 
 * `TauCeti.IsGradedEulerAdmissible.shiftTarget` and
   `TauCeti.IsGradedEulerAdmissible.shiftSource`: graded Euler-admissibility is preserved by the
-  grading shift in either variable.
+  grading shift in either variable; `TauCeti.IsGradedEulerAdmissible.shiftTargetInverse` and
+  `TauCeti.IsGradedEulerAdmissible.shiftSourceInverse` are the same for the inverse shift.
 * `TauCeti.gradedExtEuler_shiftTarget`: `χ_q(X, Y{1}) = q · χ_q(X, Y)`.
 * `TauCeti.gradedExtEuler_shiftSource`: `χ_q(X{1}, Y) = q⁻¹ · χ_q(X, Y)`.
 * `TauCeti.gradedExtEuler_shiftTarget_inverse` and
@@ -52,7 +58,6 @@ with the composites `e ^ j ∘ e` and `e ∘ e ^ j` is `TauCeti.equivPowSuccIso`
 * Zsuzsanna Dancso and Anthony Licata, "Koszul algebras and flow lattices", *Journal of
   Combinatorial Theory, Series A* 185 (2022), Sections 1.2 and 2.2, for the q-antilinear/q-linear
   convention of the q-Euler form.
-* `TauCetiRoadmap/GrothendieckEulerForms/README.md`, Layer 6, "q-Euler form".
 -/
 
 public section
@@ -75,40 +80,80 @@ isomorphism of objects. -/
 `Ext^{n,j}(X, Y{1}) ≅ Ext^{n,j+1}(X, Y)`. -/
 noncomputable def gradedExtShiftTargetEquiv (X Y : C) (n : ℕ) (j : ℤ) :
     GradedExt.{w} e X (e.functor.obj Y) n j ≃ₗ[k] GradedExt.{w} e X Y n (j + 1) :=
-  extLinearEquivOfIso k (Iso.refl X) ((equivPowSuccIso e j).app Y).symm n
+  extLinearEquivOfIso k (Iso.refl X) ((e.powSuccIso j).app Y).symm n
+
+/-- Shifting the target by the inverse shift lowers the internal degree by one:
+`Ext^{n,j}(X, Y{-1}) ≅ Ext^{n,j-1}(X, Y)`. -/
+noncomputable def gradedExtShiftTargetInverseEquiv (X Y : C) (n : ℕ) (j : ℤ) :
+    GradedExt.{w} e X (e.inverse.obj Y) n j ≃ₗ[k] GradedExt.{w} e X Y n (j - 1) :=
+  extLinearEquivOfIso k (Iso.refl X) ((e.powPredIso j).app Y) n
 
 variable {k e}
 variable {X Y : C}
+
+/-- Finite Laurent support in one cohomological degree is preserved by shifting the target. -/
+theorem HasFiniteLaurentSupport.gradedExtShiftTarget {n : ℕ}
+    (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n)) :
+    HasFiniteLaurentSupport k (GradedExt.{w} e X (e.functor.obj Y) n) :=
+  (h.reindex_add 1).of_equiv fun j => (gradedExtShiftTargetEquiv k e X Y n j).symm
+
+/-- Finite Laurent support in one cohomological degree is preserved by the inverse shift of the
+target. -/
+theorem HasFiniteLaurentSupport.gradedExtShiftTargetInverse {n : ℕ}
+    (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n)) :
+    HasFiniteLaurentSupport k (GradedExt.{w} e X (e.inverse.obj Y) n) :=
+  (h.reindex_add (-1)).of_equiv fun j => (gradedExtShiftTargetInverseEquiv k e X Y n j).symm
 
 /-- Finite internal support of bigraded `Ext` is preserved by shifting the target. -/
 theorem IsGradedExtInternallyFinite.shiftTarget
     (h : IsGradedExtInternallyFinite.{w} k e X Y) :
     IsGradedExtInternallyFinite.{w} k e X (e.functor.obj Y) :=
-  ⟨fun n => ((h.finiteLaurentSupport n).reindex_add 1).of_equiv fun j =>
-    (gradedExtShiftTargetEquiv k e X Y n j).symm⟩
+  ⟨fun n => (h.finiteLaurentSupport n).gradedExtShiftTarget⟩
+
+/-- Finite internal support of bigraded `Ext` is preserved by the inverse shift of the target. -/
+theorem IsGradedExtInternallyFinite.shiftTargetInverse
+    (h : IsGradedExtInternallyFinite.{w} k e X Y) :
+    IsGradedExtInternallyFinite.{w} k e X (e.inverse.obj Y) :=
+  ⟨fun n => (h.finiteLaurentSupport n).gradedExtShiftTargetInverse⟩
 
 /-- A cohomological vanishing bound is preserved by shifting the target. -/
 theorem IsGradedExtBoundedBy.shiftTarget {N : ℕ} (h : IsGradedExtBoundedBy.{w} e X Y N) :
     IsGradedExtBoundedBy.{w} e X (e.functor.obj Y) N :=
   ⟨fun n hn j => have := h.subsingleton hn (j + 1)
-    (extAddEquivOfIso (Iso.refl X) ((equivPowSuccIso e j).app Y).symm n).toEquiv.subsingleton⟩
+    (extAddEquivOfIso (Iso.refl X) ((e.powSuccIso j).app Y).symm n).toEquiv.subsingleton⟩
+
+/-- A cohomological vanishing bound is preserved by the inverse shift of the target. -/
+theorem IsGradedExtBoundedBy.shiftTargetInverse {N : ℕ} (h : IsGradedExtBoundedBy.{w} e X Y N) :
+    IsGradedExtBoundedBy.{w} e X (e.inverse.obj Y) N :=
+  ⟨fun n hn j => have := h.subsingleton hn (j - 1)
+    (extAddEquivOfIso (Iso.refl X) ((e.powPredIso j).app Y) n).toEquiv.subsingleton⟩
 
 /-- Eventual cohomological vanishing of bigraded `Ext` is preserved by shifting the target. -/
 theorem IsGradedExtBounded.shiftTarget (h : IsGradedExtBounded.{w} e X Y) :
     IsGradedExtBounded.{w} e X (e.functor.obj Y) :=
   ⟨h.exists_bound.choose, h.exists_bound.choose_spec.shiftTarget⟩
 
+/-- Eventual cohomological vanishing of bigraded `Ext` is preserved by the inverse shift of the
+target. -/
+theorem IsGradedExtBounded.shiftTargetInverse (h : IsGradedExtBounded.{w} e X Y) :
+    IsGradedExtBounded.{w} e X (e.inverse.obj Y) :=
+  ⟨h.exists_bound.choose, h.exists_bound.choose_spec.shiftTargetInverse⟩
+
 /-- **Graded Euler-admissibility is preserved by shifting the target.** -/
 theorem IsGradedEulerAdmissible.shiftTarget (h : IsGradedEulerAdmissible.{w} k e X Y) :
     IsGradedEulerAdmissible.{w} k e X (e.functor.obj Y) :=
   ⟨h.internallyFinite.shiftTarget, h.bounded.shiftTarget⟩
 
+/-- **Graded Euler-admissibility is preserved by the inverse shift of the target.** -/
+theorem IsGradedEulerAdmissible.shiftTargetInverse (h : IsGradedEulerAdmissible.{w} k e X Y) :
+    IsGradedEulerAdmissible.{w} k e X (e.inverse.obj Y) :=
+  ⟨h.internallyFinite.shiftTargetInverse, h.bounded.shiftTargetInverse⟩
+
 /-- Shifting the target multiplies the graded `Ext` dimension in one cohomological degree by
 `q`. -/
 theorem gradedExtDimension_shiftTarget {n : ℕ}
-    (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n))
-    (h' : HasFiniteLaurentSupport k (GradedExt.{w} e X (e.functor.obj Y) n)) :
-    gradedExtDimension k e h' = T 1 * gradedExtDimension k e h := by
+    (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n)) :
+    gradedExtDimension k e h.gradedExtShiftTarget = T 1 * gradedExtDimension k e h := by
   ext j
   simp only [T, coeff_gradedExtDimension, AddMonoidAlgebra.coeff_single_mul_apply, one_mul]
   rw [(gradedExtShiftTargetEquiv k e X Y n (-j)).finrank_eq]
@@ -116,32 +161,29 @@ theorem gradedExtDimension_shiftTarget {n : ℕ}
   rw [hj]
 
 /-- Shifting the target multiplies every truncation of the q-Euler sum by `q`. -/
-theorem truncatedGradedExtEuler_shiftTarget (h : IsGradedExtInternallyFinite.{w} k e X Y)
-    (h' : IsGradedExtInternallyFinite.{w} k e X (e.functor.obj Y)) (N : ℕ) :
-    truncatedGradedExtEuler k e h' N = T 1 * truncatedGradedExtEuler k e h N := by
+theorem truncatedGradedExtEuler_shiftTarget (h : IsGradedExtInternallyFinite.{w} k e X Y) (N : ℕ) :
+    truncatedGradedExtEuler k e h.shiftTarget N = T 1 * truncatedGradedExtEuler k e h N := by
   induction N with
   | zero => simp
   | succ N ih =>
       rw [truncatedGradedExtEuler_succ, truncatedGradedExtEuler_succ, ih, mul_add,
-        gradedExtDimension_shiftTarget (h.finiteLaurentSupport N) (h'.finiteLaurentSupport N),
-        mul_smul_comm]
+        gradedExtDimension_shiftTarget (h.finiteLaurentSupport N), mul_smul_comm]
 
 /-- **`χ_q(X, Y{1}) = q · χ_q(X, Y)`**: the q-Euler characteristic is q-linear in its second
 argument. -/
-theorem gradedExtEuler_shiftTarget (h : IsGradedEulerAdmissible.{w} k e X Y)
-    (h' : IsGradedEulerAdmissible.{w} k e X (e.functor.obj Y)) :
-    gradedExtEuler k e h' = T 1 * gradedExtEuler k e h := by
+theorem gradedExtEuler_shiftTarget (h : IsGradedEulerAdmissible.{w} k e X Y) :
+    gradedExtEuler k e h.shiftTarget = T 1 * gradedExtEuler k e h := by
   obtain ⟨N, hN⟩ := h.bounded.exists_bound
-  rw [gradedExtEuler_eq k e h hN, gradedExtEuler_eq k e h' hN.shiftTarget]
-  exact truncatedGradedExtEuler_shiftTarget h.internallyFinite h'.internallyFinite N
+  rw [gradedExtEuler_eq k e h hN, gradedExtEuler_eq k e h.shiftTarget hN.shiftTarget]
+  exact truncatedGradedExtEuler_shiftTarget h.internallyFinite N
 
 /-- **`χ_q(X, Y{-1}) = q⁻¹ · χ_q(X, Y)`**: the inverse shift of the second argument. -/
-theorem gradedExtEuler_shiftTarget_inverse (h : IsGradedEulerAdmissible.{w} k e X Y)
-    (h' : IsGradedEulerAdmissible.{w} k e X (e.inverse.obj Y)) :
-    gradedExtEuler k e h' = T (-1) * gradedExtEuler k e h := by
-  have hcounit : gradedExtEuler k e h = gradedExtEuler k e h'.shiftTarget :=
-    gradedExtEuler_of_iso k h h'.shiftTarget (Iso.refl X) (e.counitIso.app Y).symm
-  rw [hcounit, gradedExtEuler_shiftTarget h' h'.shiftTarget, ← mul_assoc, ← T_add]
+theorem gradedExtEuler_shiftTarget_inverse (h : IsGradedEulerAdmissible.{w} k e X Y) :
+    gradedExtEuler k e h.shiftTargetInverse = T (-1) * gradedExtEuler k e h := by
+  have hcounit : gradedExtEuler k e h = gradedExtEuler k e h.shiftTargetInverse.shiftTarget :=
+    gradedExtEuler_of_iso k h h.shiftTargetInverse.shiftTarget (Iso.refl X)
+      (e.counitIso.app Y).symm
+  rw [hcounit, gradedExtEuler_shiftTarget h.shiftTargetInverse, ← mul_assoc, ← T_add]
   simp
 
 /-! ### Shifting the source
@@ -155,8 +197,8 @@ variable [e.functor.Additive] [e.functor.Linear k]
 /-- The comparison `(Y{j-1}){1} ≅ Y{j}`, which moves a source shift into the internal degree. -/
 private noncomputable def shiftSourceObjIso (Y : C) (j : ℤ) :
     e.functor.obj ((e ^ (j - 1)).functor.obj Y) ≅ (e ^ j).functor.obj Y :=
-  ((equivPowSuccRightIso e (j - 1)).app Y).symm ≪≫
-    (equivPowCongrIso e (by ring : j - 1 + 1 = j)).app Y
+  ((e.powSuccRightIso (j - 1)).app Y).symm ≪≫
+    (e.powCongrIso (by ring : j - 1 + 1 = j)).app Y
 
 /-- Shifting the source of a bigraded `Ext` group lowers its internal degree by one:
 `Ext^{n,j}(X{1}, Y) ≅ Ext^{n,j-1}(X, Y)`. -/
@@ -165,15 +207,40 @@ noncomputable def gradedExtShiftSourceEquiv (X Y : C) (n : ℕ) (j : ℤ) :
   ((extLinearEquivOfEquivalence k e X ((e ^ (j - 1)).functor.obj Y) n).trans
     (extLinearEquivOfIso k (Iso.refl (e.functor.obj X)) (shiftSourceObjIso e Y j) n)).symm
 
+/-- Shifting the source by the inverse shift raises the internal degree by one:
+`Ext^{n,j}(X{-1}, Y) ≅ Ext^{n,j+1}(X, Y)`. -/
+noncomputable def gradedExtShiftSourceInverseEquiv (X Y : C) (n : ℕ) (j : ℤ) :
+    GradedExt.{w} e (e.inverse.obj X) Y n j ≃ₗ[k] GradedExt.{w} e X Y n (j + 1) :=
+  (extLinearEquivOfEquivalence k e (e.inverse.obj X) ((e ^ j).functor.obj Y) n).trans
+    (extLinearEquivOfIso k (e.counitIso.app X) ((e.powSuccRightIso j).app Y).symm n)
+
 variable {k e}
 variable {X Y : C}
+
+/-- Finite Laurent support in one cohomological degree is preserved by shifting the source. -/
+theorem HasFiniteLaurentSupport.gradedExtShiftSource {n : ℕ}
+    (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n)) :
+    HasFiniteLaurentSupport k (GradedExt.{w} e (e.functor.obj X) Y n) :=
+  (h.reindex_add (-1)).of_equiv fun j => (gradedExtShiftSourceEquiv k e X Y n j).symm
+
+/-- Finite Laurent support in one cohomological degree is preserved by the inverse shift of the
+source. -/
+theorem HasFiniteLaurentSupport.gradedExtShiftSourceInverse {n : ℕ}
+    (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n)) :
+    HasFiniteLaurentSupport k (GradedExt.{w} e (e.inverse.obj X) Y n) :=
+  (h.reindex_add 1).of_equiv fun j => (gradedExtShiftSourceInverseEquiv k e X Y n j).symm
 
 /-- Finite internal support of bigraded `Ext` is preserved by shifting the source. -/
 theorem IsGradedExtInternallyFinite.shiftSource
     (h : IsGradedExtInternallyFinite.{w} k e X Y) :
     IsGradedExtInternallyFinite.{w} k e (e.functor.obj X) Y :=
-  ⟨fun n => ((h.finiteLaurentSupport n).reindex_add (-1)).of_equiv fun j =>
-    (gradedExtShiftSourceEquiv k e X Y n j).symm⟩
+  ⟨fun n => (h.finiteLaurentSupport n).gradedExtShiftSource⟩
+
+/-- Finite internal support of bigraded `Ext` is preserved by the inverse shift of the source. -/
+theorem IsGradedExtInternallyFinite.shiftSourceInverse
+    (h : IsGradedExtInternallyFinite.{w} k e X Y) :
+    IsGradedExtInternallyFinite.{w} k e (e.inverse.obj X) Y :=
+  ⟨fun n => (h.finiteLaurentSupport n).gradedExtShiftSourceInverse⟩
 
 omit [Functor.Linear k e.functor] in
 /-- A cohomological vanishing bound is preserved by shifting the source. -/
@@ -185,22 +252,44 @@ theorem IsGradedExtBoundedBy.shiftSource {N : ℕ} (h : IsGradedExtBoundedBy.{w}
         (shiftSourceObjIso e Y j) n)).symm).toEquiv.subsingleton⟩
 
 omit [Functor.Linear k e.functor] in
+/-- A cohomological vanishing bound is preserved by the inverse shift of the source. -/
+theorem IsGradedExtBoundedBy.shiftSourceInverse {N : ℕ} (h : IsGradedExtBoundedBy.{w} e X Y N) :
+    IsGradedExtBoundedBy.{w} e (e.inverse.obj X) Y N :=
+  ⟨fun n hn j =>
+    have := h.subsingleton hn (j + 1)
+    have equiv : GradedExt.{w} e (e.inverse.obj X) Y n j ≃+ GradedExt.{w} e X Y n (j + 1) :=
+      (extAddEquivOfEquivalence e (e.inverse.obj X) ((e ^ j).functor.obj Y) n).trans
+        (extAddEquivOfIso (e.counitIso.app X) ((e.powSuccRightIso j).app Y).symm n)
+    equiv.toEquiv.subsingleton⟩
+
+omit [Functor.Linear k e.functor] in
 /-- Eventual cohomological vanishing of bigraded `Ext` is preserved by shifting the source. -/
 theorem IsGradedExtBounded.shiftSource (h : IsGradedExtBounded.{w} e X Y) :
     IsGradedExtBounded.{w} e (e.functor.obj X) Y :=
   ⟨h.exists_bound.choose, h.exists_bound.choose_spec.shiftSource⟩
+
+omit [Functor.Linear k e.functor] in
+/-- Eventual cohomological vanishing of bigraded `Ext` is preserved by the inverse shift of the
+source. -/
+theorem IsGradedExtBounded.shiftSourceInverse (h : IsGradedExtBounded.{w} e X Y) :
+    IsGradedExtBounded.{w} e (e.inverse.obj X) Y :=
+  ⟨h.exists_bound.choose, h.exists_bound.choose_spec.shiftSourceInverse⟩
 
 /-- **Graded Euler-admissibility is preserved by shifting the source.** -/
 theorem IsGradedEulerAdmissible.shiftSource (h : IsGradedEulerAdmissible.{w} k e X Y) :
     IsGradedEulerAdmissible.{w} k e (e.functor.obj X) Y :=
   ⟨h.internallyFinite.shiftSource, h.bounded.shiftSource⟩
 
+/-- **Graded Euler-admissibility is preserved by the inverse shift of the source.** -/
+theorem IsGradedEulerAdmissible.shiftSourceInverse (h : IsGradedEulerAdmissible.{w} k e X Y) :
+    IsGradedEulerAdmissible.{w} k e (e.inverse.obj X) Y :=
+  ⟨h.internallyFinite.shiftSourceInverse, h.bounded.shiftSourceInverse⟩
+
 /-- Shifting the source multiplies the graded `Ext` dimension in one cohomological degree by
 `q⁻¹`. -/
 theorem gradedExtDimension_shiftSource {n : ℕ}
-    (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n))
-    (h' : HasFiniteLaurentSupport k (GradedExt.{w} e (e.functor.obj X) Y n)) :
-    gradedExtDimension k e h' = T (-1) * gradedExtDimension k e h := by
+    (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n)) :
+    gradedExtDimension k e h.gradedExtShiftSource = T (-1) * gradedExtDimension k e h := by
   ext j
   simp only [T, coeff_gradedExtDimension, AddMonoidAlgebra.coeff_single_mul_apply, one_mul]
   rw [(gradedExtShiftSourceEquiv k e X Y n (-j)).finrank_eq]
@@ -208,32 +297,29 @@ theorem gradedExtDimension_shiftSource {n : ℕ}
   rw [hj]
 
 /-- Shifting the source multiplies every truncation of the q-Euler sum by `q⁻¹`. -/
-theorem truncatedGradedExtEuler_shiftSource (h : IsGradedExtInternallyFinite.{w} k e X Y)
-    (h' : IsGradedExtInternallyFinite.{w} k e (e.functor.obj X) Y) (N : ℕ) :
-    truncatedGradedExtEuler k e h' N = T (-1) * truncatedGradedExtEuler k e h N := by
+theorem truncatedGradedExtEuler_shiftSource (h : IsGradedExtInternallyFinite.{w} k e X Y) (N : ℕ) :
+    truncatedGradedExtEuler k e h.shiftSource N = T (-1) * truncatedGradedExtEuler k e h N := by
   induction N with
   | zero => simp
   | succ N ih =>
       rw [truncatedGradedExtEuler_succ, truncatedGradedExtEuler_succ, ih, mul_add,
-        gradedExtDimension_shiftSource (h.finiteLaurentSupport N) (h'.finiteLaurentSupport N),
-        mul_smul_comm]
+        gradedExtDimension_shiftSource (h.finiteLaurentSupport N), mul_smul_comm]
 
 /-- **`χ_q(X{1}, Y) = q⁻¹ · χ_q(X, Y)`**: the q-Euler characteristic is q-antilinear in its first
 argument. -/
-theorem gradedExtEuler_shiftSource (h : IsGradedEulerAdmissible.{w} k e X Y)
-    (h' : IsGradedEulerAdmissible.{w} k e (e.functor.obj X) Y) :
-    gradedExtEuler k e h' = T (-1) * gradedExtEuler k e h := by
+theorem gradedExtEuler_shiftSource (h : IsGradedEulerAdmissible.{w} k e X Y) :
+    gradedExtEuler k e h.shiftSource = T (-1) * gradedExtEuler k e h := by
   obtain ⟨N, hN⟩ := h.bounded.exists_bound
-  rw [gradedExtEuler_eq k e h hN, gradedExtEuler_eq k e h' hN.shiftSource]
-  exact truncatedGradedExtEuler_shiftSource h.internallyFinite h'.internallyFinite N
+  rw [gradedExtEuler_eq k e h hN, gradedExtEuler_eq k e h.shiftSource hN.shiftSource]
+  exact truncatedGradedExtEuler_shiftSource h.internallyFinite N
 
 /-- **`χ_q(X{-1}, Y) = q · χ_q(X, Y)`**: the inverse shift of the first argument. -/
-theorem gradedExtEuler_shiftSource_inverse (h : IsGradedEulerAdmissible.{w} k e X Y)
-    (h' : IsGradedEulerAdmissible.{w} k e (e.inverse.obj X) Y) :
-    gradedExtEuler k e h' = T 1 * gradedExtEuler k e h := by
-  have hcounit : gradedExtEuler k e h = gradedExtEuler k e h'.shiftSource :=
-    gradedExtEuler_of_iso k h h'.shiftSource (e.counitIso.app X).symm (Iso.refl Y)
-  rw [hcounit, gradedExtEuler_shiftSource h' h'.shiftSource, ← mul_assoc, ← T_add]
+theorem gradedExtEuler_shiftSource_inverse (h : IsGradedEulerAdmissible.{w} k e X Y) :
+    gradedExtEuler k e h.shiftSourceInverse = T 1 * gradedExtEuler k e h := by
+  have hcounit : gradedExtEuler k e h = gradedExtEuler k e h.shiftSourceInverse.shiftSource :=
+    gradedExtEuler_of_iso k h h.shiftSourceInverse.shiftSource (e.counitIso.app X).symm
+      (Iso.refl Y)
+  rw [hcounit, gradedExtEuler_shiftSource h.shiftSourceInverse, ← mul_assoc, ← T_add]
   simp
 
 end TauCeti

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
@@ -37,6 +37,8 @@ witness it needs is the one this file constructs from it.
 
 ## Main definitions
 
+* `TauCeti.shiftSourceObjIso`: the comparison `(Y{j-1}){1} ≅ Y{j}` through which a source shift
+  is moved into the internal degree.
 * `TauCeti.gradedExtShiftTargetEquiv`: `Ext^{n,j}(X, Y{1}) ≃ₗ[k] Ext^{n,j+1}(X, Y)`.
 * `TauCeti.gradedExtShiftTargetInverseEquiv`: `Ext^{n,j}(X, Y{-1}) ≃ₗ[k] Ext^{n,j-1}(X, Y)`.
 * `TauCeti.gradedExtShiftSourceEquiv`: `Ext^{n,j}(X{1}, Y) ≃ₗ[k] Ext^{n,j-1}(X, Y)`.
@@ -87,11 +89,29 @@ noncomputable def gradedExtShiftTargetEquiv (X Y : C) (n : ℕ) (j : ℤ) :
     GradedExt.{w} e X (e.functor.obj Y) n j ≃ₗ[k] GradedExt.{w} e X Y n (j + 1) :=
   extLinearEquivOfIso k (Iso.refl X) ((e.powSuccIso j).app Y).symm n
 
+/-- `TauCeti.gradedExtShiftTargetEquiv` composes with the comparison isomorphism
+`(Y{1}){j} ≅ Y{j+1}`. -/
+@[simp]
+theorem gradedExtShiftTargetEquiv_apply (X Y : C) (n : ℕ) (j : ℤ)
+    (x : GradedExt.{w} e X (e.functor.obj Y) n j) :
+    gradedExtShiftTargetEquiv k e X Y n j x =
+      x.comp (Ext.mk₀ ((e.powSuccIso j).app Y).inv) (add_zero n) := by
+  simp [gradedExtShiftTargetEquiv]
+
 /-- Shifting the target by the inverse shift lowers the internal degree by one:
 `Ext^{n,j}(X, Y{-1}) ≅ Ext^{n,j-1}(X, Y)`. -/
 noncomputable def gradedExtShiftTargetInverseEquiv (X Y : C) (n : ℕ) (j : ℤ) :
     GradedExt.{w} e X (e.inverse.obj Y) n j ≃ₗ[k] GradedExt.{w} e X Y n (j - 1) :=
   extLinearEquivOfIso k (Iso.refl X) ((e.powPredIso j).app Y) n
+
+/-- `TauCeti.gradedExtShiftTargetInverseEquiv` composes with the comparison isomorphism
+`(Y{-1}){j} ≅ Y{j-1}`. -/
+@[simp]
+theorem gradedExtShiftTargetInverseEquiv_apply (X Y : C) (n : ℕ) (j : ℤ)
+    (x : GradedExt.{w} e X (e.inverse.obj Y) n j) :
+    gradedExtShiftTargetInverseEquiv k e X Y n j x =
+      x.comp (Ext.mk₀ ((e.powPredIso j).app Y).hom) (add_zero n) := by
+  simp [gradedExtShiftTargetInverseEquiv]
 
 end CommRing
 
@@ -205,7 +225,7 @@ merely additive.  As for the target, the two reindexing equivalences need only a
 of scalars. -/
 
 /-- The comparison `(Y{j-1}){1} ≅ Y{j}`, which moves a source shift into the internal degree. -/
-private noncomputable def shiftSourceObjIso (Y : C) (j : ℤ) :
+noncomputable def shiftSourceObjIso (Y : C) (j : ℤ) :
     e.functor.obj ((e ^ (j - 1)).functor.obj Y) ≅ (e ^ j).functor.obj Y :=
   ((e.powSuccRightIso (j - 1)).app Y).symm ≪≫
     eqToIso (congrArg (fun i : ℤ => (e ^ i).functor.obj Y) (by ring : j - 1 + 1 = j))
@@ -221,12 +241,34 @@ noncomputable def gradedExtShiftSourceEquiv (X Y : C) (n : ℕ) (j : ℤ) :
   ((extLinearEquivOfEquivalence k e X ((e ^ (j - 1)).functor.obj Y) n).trans
     (extLinearEquivOfIso k (Iso.refl (e.functor.obj X)) (shiftSourceObjIso e Y j) n)).symm
 
+/-- The inverse of `TauCeti.gradedExtShiftSourceEquiv` transports along `e` and then composes with
+the comparison isomorphism `(Y{j-1}){1} ≅ Y{j}`; this is the direction in which the equivalence is
+built. -/
+@[simp]
+theorem gradedExtShiftSourceEquiv_symm_apply (X Y : C) (n : ℕ) (j : ℤ)
+    (x : GradedExt.{w} e X Y n (j - 1)) :
+    (gradedExtShiftSourceEquiv k e X Y n j).symm x =
+      (x.mapExactFunctor e.functor).comp
+        (Ext.mk₀ (shiftSourceObjIso e Y j).hom) (add_zero n) := by
+  simp [gradedExtShiftSourceEquiv]
+
 /-- Shifting the source by the inverse shift raises the internal degree by one:
 `Ext^{n,j}(X{-1}, Y) ≅ Ext^{n,j+1}(X, Y)`. -/
 noncomputable def gradedExtShiftSourceInverseEquiv (X Y : C) (n : ℕ) (j : ℤ) :
     GradedExt.{w} e (e.inverse.obj X) Y n j ≃ₗ[k] GradedExt.{w} e X Y n (j + 1) :=
   (extLinearEquivOfEquivalence k e (e.inverse.obj X) ((e ^ j).functor.obj Y) n).trans
     (extLinearEquivOfIso k (e.counitIso.app X) ((e.powSuccRightIso j).app Y).symm n)
+
+/-- `TauCeti.gradedExtShiftSourceInverseEquiv` transports along `e` and then composes with the
+counit and the comparison isomorphism `(Y{j}){1} ≅ Y{j+1}`. -/
+@[simp]
+theorem gradedExtShiftSourceInverseEquiv_apply (X Y : C) (n : ℕ) (j : ℤ)
+    (x : GradedExt.{w} e (e.inverse.obj X) Y n j) :
+    gradedExtShiftSourceInverseEquiv k e X Y n j x =
+      (Ext.mk₀ (e.counitIso.app X).inv).comp
+        ((x.mapExactFunctor e.functor).comp
+          (Ext.mk₀ ((e.powSuccRightIso j).app Y).inv) (add_zero n)) (zero_add n) := by
+  simp [gradedExtShiftSourceInverseEquiv]
 
 end CommRingSource
 

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
@@ -50,8 +50,8 @@ witness it needs is the one this file constructs from it.
   `TauCeti.IsGradedEulerAdmissible.shiftSourceInverse` are the same for the inverse shift.
 * `TauCeti.gradedExtEuler_shiftTarget`: `χ_q(X, Y{1}) = q · χ_q(X, Y)`.
 * `TauCeti.gradedExtEuler_shiftSource`: `χ_q(X{1}, Y) = q⁻¹ · χ_q(X, Y)`.
-* `TauCeti.gradedExtEuler_shiftTarget_inverse` and
-  `TauCeti.gradedExtEuler_shiftSource_inverse`: the two identities for the inverse shift `{-1}`.
+* `TauCeti.gradedExtEuler_shiftTargetInverse` and
+  `TauCeti.gradedExtEuler_shiftSourceInverse`: the two identities for the inverse shift `{-1}`.
 
 ## References
 
@@ -178,7 +178,7 @@ theorem gradedExtEuler_shiftTarget (h : IsGradedEulerAdmissible.{w} k e X Y) :
   exact truncatedGradedExtEuler_shiftTarget h.internallyFinite N
 
 /-- **`χ_q(X, Y{-1}) = q⁻¹ · χ_q(X, Y)`**: the inverse shift of the second argument. -/
-theorem gradedExtEuler_shiftTarget_inverse (h : IsGradedEulerAdmissible.{w} k e X Y) :
+theorem gradedExtEuler_shiftTargetInverse (h : IsGradedEulerAdmissible.{w} k e X Y) :
     gradedExtEuler k e h.shiftTargetInverse = T (-1) * gradedExtEuler k e h := by
   have hcounit : gradedExtEuler k e h = gradedExtEuler k e h.shiftTargetInverse.shiftTarget :=
     gradedExtEuler_of_iso k h h.shiftTargetInverse.shiftTarget (Iso.refl X)
@@ -247,7 +247,7 @@ omit [Functor.Linear k e.functor] in
 theorem IsGradedExtBoundedBy.shiftSource {N : ℕ} (h : IsGradedExtBoundedBy.{w} e X Y N) :
     IsGradedExtBoundedBy.{w} e (e.functor.obj X) Y N :=
   ⟨fun n hn j => have := h.subsingleton hn (j - 1)
-    (((extAddEquivOfEquivalence e X ((e ^ (j - 1)).functor.obj Y) n).trans
+    (((e.extAddEquiv X ((e ^ (j - 1)).functor.obj Y) n).trans
       (extAddEquivOfIso (Iso.refl (e.functor.obj X))
         (shiftSourceObjIso e Y j) n)).symm).toEquiv.subsingleton⟩
 
@@ -258,7 +258,7 @@ theorem IsGradedExtBoundedBy.shiftSourceInverse {N : ℕ} (h : IsGradedExtBounde
   ⟨fun n hn j =>
     have := h.subsingleton hn (j + 1)
     have equiv : GradedExt.{w} e (e.inverse.obj X) Y n j ≃+ GradedExt.{w} e X Y n (j + 1) :=
-      (extAddEquivOfEquivalence e (e.inverse.obj X) ((e ^ j).functor.obj Y) n).trans
+      (e.extAddEquiv (e.inverse.obj X) ((e ^ j).functor.obj Y) n).trans
         (extAddEquivOfIso (e.counitIso.app X) ((e.powSuccRightIso j).app Y).symm n)
     equiv.toEquiv.subsingleton⟩
 
@@ -314,7 +314,7 @@ theorem gradedExtEuler_shiftSource (h : IsGradedEulerAdmissible.{w} k e X Y) :
   exact truncatedGradedExtEuler_shiftSource h.internallyFinite N
 
 /-- **`χ_q(X{-1}, Y) = q · χ_q(X, Y)`**: the inverse shift of the first argument. -/
-theorem gradedExtEuler_shiftSource_inverse (h : IsGradedEulerAdmissible.{w} k e X Y) :
+theorem gradedExtEuler_shiftSourceInverse (h : IsGradedEulerAdmissible.{w} k e X Y) :
     gradedExtEuler k e h.shiftSourceInverse = T 1 * gradedExtEuler k e h := by
   have hcounit : gradedExtEuler k e h = gradedExtEuler k e h.shiftSourceInverse.shiftSource :=
     gradedExtEuler_of_iso k h h.shiftSourceInverse.shiftSource (e.counitIso.app X).symm

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
@@ -170,7 +170,8 @@ theorem gradedExtDimension_shiftTarget {n : ℕ}
     (gradedExtShiftTargetEquiv k e X Y n j).symm).symm
 
 /-- Shifting the target multiplies every truncation of the q-Euler sum by `q`. -/
-theorem truncatedGradedExtEuler_shiftTarget (h : IsGradedExtInternallyFinite.{w} k e X Y) (N : ℕ) :
+private theorem truncatedGradedExtEuler_shiftTarget
+    (h : IsGradedExtInternallyFinite.{w} k e X Y) (N : ℕ) :
     truncatedGradedExtEuler k e h.shiftTarget N = T 1 * truncatedGradedExtEuler k e h N := by
   induction N with
   | zero => simp
@@ -314,7 +315,8 @@ theorem gradedExtDimension_shiftSource {n : ℕ}
     (gradedExtShiftSourceEquiv k e X Y n j).symm).symm
 
 /-- Shifting the source multiplies every truncation of the q-Euler sum by `q⁻¹`. -/
-theorem truncatedGradedExtEuler_shiftSource (h : IsGradedExtInternallyFinite.{w} k e X Y) (N : ℕ) :
+private theorem truncatedGradedExtEuler_shiftSource
+    (h : IsGradedExtInternallyFinite.{w} k e X Y) (N : ℕ) :
     truncatedGradedExtEuler k e h.shiftSource N = T (-1) * truncatedGradedExtEuler k e h N := by
   induction N with
   | zero => simp

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
@@ -68,13 +68,18 @@ open CategoryTheory CategoryTheory.Abelian LaurentPolynomial
 
 universe w v u t
 
-variable {C : Type u} [Category.{v} C] [Abelian C]
-  (k : Type t) [Field k] [Linear k C] [HasExt.{w} C] (e : C ≌ C)
+variable {C : Type u} [Category.{v} C] [Abelian C] [HasExt.{w} C]
+  (k : Type t) (e : C ≌ C)
 
 /-! ### Shifting the target
 
 Nothing in this section needs the shift to be additive or linear: the reindexing is induced by an
-isomorphism of objects. -/
+isomorphism of objects.  The two reindexing equivalences need only a commutative ring of scalars;
+`k` is a field only from the point where dimensions are taken. -/
+
+section CommRing
+
+variable [CommRing k] [Linear k C]
 
 /-- Shifting the target of a bigraded `Ext` group raises its internal degree by one:
 `Ext^{n,j}(X, Y{1}) ≅ Ext^{n,j+1}(X, Y)`. -/
@@ -88,6 +93,11 @@ noncomputable def gradedExtShiftTargetInverseEquiv (X Y : C) (n : ℕ) (j : ℤ)
     GradedExt.{w} e X (e.inverse.obj Y) n j ≃ₗ[k] GradedExt.{w} e X Y n (j - 1) :=
   extLinearEquivOfIso k (Iso.refl X) ((e.powPredIso j).app Y) n
 
+end CommRing
+
+section Field
+
+variable [Field k] [Linear k C]
 variable {k e}
 variable {X Y : C}
 
@@ -154,11 +164,10 @@ theorem IsGradedEulerAdmissible.shiftTargetInverse (h : IsGradedEulerAdmissible.
 theorem gradedExtDimension_shiftTarget {n : ℕ}
     (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n)) :
     gradedExtDimension k e h.gradedExtShiftTarget = T 1 * gradedExtDimension k e h := by
-  ext j
-  simp only [T, coeff_gradedExtDimension, AddMonoidAlgebra.coeff_single_mul_apply, one_mul]
-  rw [(gradedExtShiftTargetEquiv k e X Y n (-j)).finrank_eq]
-  have hj : -j + 1 = -(-1 + j) := by omega
-  rw [hj]
+  simp only [gradedExtDimension_eq_targetShiftGradedDimension,
+    ← targetShiftGradedDimension_reindex_add h 1]
+  exact (targetShiftGradedDimension_equiv (h.reindex_add 1) fun j =>
+    (gradedExtShiftTargetEquiv k e X Y n j).symm).symm
 
 /-- Shifting the target multiplies every truncation of the q-Euler sum by `q`. -/
 theorem truncatedGradedExtEuler_shiftTarget (h : IsGradedExtInternallyFinite.{w} k e X Y) (N : ℕ) :
@@ -186,19 +195,23 @@ theorem gradedExtEuler_shiftTargetInverse (h : IsGradedEulerAdmissible.{w} k e X
   rw [hcounit, gradedExtEuler_shiftTarget h.shiftTargetInverse, ← mul_assoc, ← T_add]
   simp
 
+end Field
+
 /-! ### Shifting the source
 
 The source identity uses that `Ext` is invariant under `e`, so `e` must be `k`-linear and not
-merely additive. -/
-
-variable (k e)
-variable [e.functor.Additive] [e.functor.Linear k]
+merely additive.  As for the target, the two reindexing equivalences need only a commutative ring
+of scalars. -/
 
 /-- The comparison `(Y{j-1}){1} ≅ Y{j}`, which moves a source shift into the internal degree. -/
 private noncomputable def shiftSourceObjIso (Y : C) (j : ℤ) :
     e.functor.obj ((e ^ (j - 1)).functor.obj Y) ≅ (e ^ j).functor.obj Y :=
   ((e.powSuccRightIso (j - 1)).app Y).symm ≪≫
-    (e.powCongrIso (by ring : j - 1 + 1 = j)).app Y
+    eqToIso (congrArg (fun i : ℤ => (e ^ i).functor.obj Y) (by ring : j - 1 + 1 = j))
+
+section CommRingSource
+
+variable [CommRing k] [Linear k C] [e.functor.Additive] [e.functor.Linear k]
 
 /-- Shifting the source of a bigraded `Ext` group lowers its internal degree by one:
 `Ext^{n,j}(X{1}, Y) ≅ Ext^{n,j-1}(X, Y)`. -/
@@ -214,6 +227,11 @@ noncomputable def gradedExtShiftSourceInverseEquiv (X Y : C) (n : ℕ) (j : ℤ)
   (extLinearEquivOfEquivalence k e (e.inverse.obj X) ((e ^ j).functor.obj Y) n).trans
     (extLinearEquivOfIso k (e.counitIso.app X) ((e.powSuccRightIso j).app Y).symm n)
 
+end CommRingSource
+
+section FieldSource
+
+variable [Field k] [Linear k C] [e.functor.Additive] [e.functor.Linear k]
 variable {k e}
 variable {X Y : C}
 
@@ -290,11 +308,10 @@ theorem IsGradedEulerAdmissible.shiftSourceInverse (h : IsGradedEulerAdmissible.
 theorem gradedExtDimension_shiftSource {n : ℕ}
     (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n)) :
     gradedExtDimension k e h.gradedExtShiftSource = T (-1) * gradedExtDimension k e h := by
-  ext j
-  simp only [T, coeff_gradedExtDimension, AddMonoidAlgebra.coeff_single_mul_apply, one_mul]
-  rw [(gradedExtShiftSourceEquiv k e X Y n (-j)).finrank_eq]
-  have hj : -j - 1 = -(- -1 + j) := by omega
-  rw [hj]
+  simp only [gradedExtDimension_eq_targetShiftGradedDimension,
+    ← targetShiftGradedDimension_reindex_add h (-1)]
+  exact (targetShiftGradedDimension_equiv (h.reindex_add (-1)) fun j =>
+    (gradedExtShiftSourceEquiv k e X Y n j).symm).symm
 
 /-- Shifting the source multiplies every truncation of the q-Euler sum by `q⁻¹`. -/
 theorem truncatedGradedExtEuler_shiftSource (h : IsGradedExtInternallyFinite.{w} k e X Y) (N : ℕ) :
@@ -321,5 +338,7 @@ theorem gradedExtEuler_shiftSourceInverse (h : IsGradedEulerAdmissible.{w} k e X
       (Iso.refl Y)
   rw [hcounit, gradedExtEuler_shiftSource h.shiftSourceInverse, ← mul_assoc, ← T_add]
   simp
+
+end FieldSource
 
 end TauCeti

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean
@@ -1,0 +1,239 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Homology.EulerCharacteristic.ExtEuler.Graded.Basic
+public import TauCeti.Algebra.Homology.Ext.Equivalence
+public import TauCeti.CategoryTheory.Equivalence.Pow
+
+/-!
+# The shift identities of the graded Ext-Euler characteristic
+
+Let `C` be a `k`-linear abelian category with a grading shift `e : C ≌ C`, written `{1}`.  The
+q-Euler characteristic `χ_q(X, Y) = ∑ n,j (-1)^n q⁻ʲ dim_k Ext^n(X, Y{j})` of
+`TauCeti.gradedExtEuler` is q-linear in its second argument and q-antilinear in its first:
+
+```text
+χ_q(X, Y{1}) = q · χ_q(X, Y),        χ_q(X{1}, Y) = q⁻¹ · χ_q(X, Y).
+```
+
+These are the generating identities behind the sesquilinearity of the q-Euler form, and they fix
+the handedness of the internal grading.
+
+Both identities come from a reindexing of the internal degree.  Shifting the target by one
+identifies `Ext^{n,j}(X, Y{1})` with `Ext^{n,j+1}(X, Y)`, which multiplies the target-shift graded
+dimension by `q`; shifting the source instead identifies `Ext^{n,j}(X{1}, Y)` with
+`Ext^{n,j-1}(X, Y)` and multiplies it by `q⁻¹`.  The source identity uses that `Ext` is invariant
+under the equivalence `e`, so it needs `e` to be `k`-linear and not merely additive: an additive
+isomorphism of `k`-vector spaces need not preserve dimension.  The comparison of `e ^ (j + 1)`
+with the composites `e ^ j ∘ e` and `e ∘ e ^ j` is `TauCeti.equivPowSuccIso` and
+`TauCeti.equivPowSuccRightIso`.
+
+## Main definitions
+
+* `TauCeti.gradedExtShiftTargetEquiv`: `Ext^{n,j}(X, Y{1}) ≃ₗ[k] Ext^{n,j+1}(X, Y)`.
+* `TauCeti.gradedExtShiftSourceEquiv`: `Ext^{n,j}(X{1}, Y) ≃ₗ[k] Ext^{n,j-1}(X, Y)`.
+
+## Main results
+
+* `TauCeti.IsGradedEulerAdmissible.shiftTarget` and
+  `TauCeti.IsGradedEulerAdmissible.shiftSource`: graded Euler-admissibility is preserved by the
+  grading shift in either variable.
+* `TauCeti.gradedExtEuler_shiftTarget`: `χ_q(X, Y{1}) = q · χ_q(X, Y)`.
+* `TauCeti.gradedExtEuler_shiftSource`: `χ_q(X{1}, Y) = q⁻¹ · χ_q(X, Y)`.
+* `TauCeti.gradedExtEuler_shiftTarget_inverse` and
+  `TauCeti.gradedExtEuler_shiftSource_inverse`: the two identities for the inverse shift `{-1}`.
+
+## References
+
+* Zsuzsanna Dancso and Anthony Licata, "Koszul algebras and flow lattices", *Journal of
+  Combinatorial Theory, Series A* 185 (2022), Sections 1.2 and 2.2, for the q-antilinear/q-linear
+  convention of the q-Euler form.
+* `TauCetiRoadmap/GrothendieckEulerForms/README.md`, Layer 6, "q-Euler form".
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Abelian LaurentPolynomial
+
+universe w v u t
+
+variable {C : Type u} [Category.{v} C] [Abelian C]
+  (k : Type t) [Field k] [Linear k C] [HasExt.{w} C] (e : C ≌ C)
+
+/-! ### Shifting the target
+
+Nothing in this section needs the shift to be additive or linear: the reindexing is induced by an
+isomorphism of objects. -/
+
+/-- Shifting the target of a bigraded `Ext` group raises its internal degree by one:
+`Ext^{n,j}(X, Y{1}) ≅ Ext^{n,j+1}(X, Y)`. -/
+noncomputable def gradedExtShiftTargetEquiv (X Y : C) (n : ℕ) (j : ℤ) :
+    GradedExt.{w} e X (e.functor.obj Y) n j ≃ₗ[k] GradedExt.{w} e X Y n (j + 1) :=
+  extLinearEquivOfIso k (Iso.refl X) ((equivPowSuccIso e j).app Y).symm n
+
+variable {k e}
+variable {X Y : C}
+
+/-- Finite internal support of bigraded `Ext` is preserved by shifting the target. -/
+theorem IsGradedExtInternallyFinite.shiftTarget
+    (h : IsGradedExtInternallyFinite.{w} k e X Y) :
+    IsGradedExtInternallyFinite.{w} k e X (e.functor.obj Y) :=
+  ⟨fun n => ((h.finiteLaurentSupport n).reindex_add 1).of_equiv fun j =>
+    (gradedExtShiftTargetEquiv k e X Y n j).symm⟩
+
+/-- A cohomological vanishing bound is preserved by shifting the target. -/
+theorem IsGradedExtBoundedBy.shiftTarget {N : ℕ} (h : IsGradedExtBoundedBy.{w} e X Y N) :
+    IsGradedExtBoundedBy.{w} e X (e.functor.obj Y) N :=
+  ⟨fun n hn j => have := h.subsingleton hn (j + 1)
+    (extAddEquivOfIso (Iso.refl X) ((equivPowSuccIso e j).app Y).symm n).toEquiv.subsingleton⟩
+
+/-- Eventual cohomological vanishing of bigraded `Ext` is preserved by shifting the target. -/
+theorem IsGradedExtBounded.shiftTarget (h : IsGradedExtBounded.{w} e X Y) :
+    IsGradedExtBounded.{w} e X (e.functor.obj Y) :=
+  ⟨h.exists_bound.choose, h.exists_bound.choose_spec.shiftTarget⟩
+
+/-- **Graded Euler-admissibility is preserved by shifting the target.** -/
+theorem IsGradedEulerAdmissible.shiftTarget (h : IsGradedEulerAdmissible.{w} k e X Y) :
+    IsGradedEulerAdmissible.{w} k e X (e.functor.obj Y) :=
+  ⟨h.internallyFinite.shiftTarget, h.bounded.shiftTarget⟩
+
+/-- Shifting the target multiplies the graded `Ext` dimension in one cohomological degree by
+`q`. -/
+theorem gradedExtDimension_shiftTarget {n : ℕ}
+    (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n))
+    (h' : HasFiniteLaurentSupport k (GradedExt.{w} e X (e.functor.obj Y) n)) :
+    gradedExtDimension k e h' = T 1 * gradedExtDimension k e h := by
+  ext j
+  simp only [T, coeff_gradedExtDimension, AddMonoidAlgebra.coeff_single_mul_apply, one_mul]
+  rw [(gradedExtShiftTargetEquiv k e X Y n (-j)).finrank_eq]
+  have hj : -j + 1 = -(-1 + j) := by omega
+  rw [hj]
+
+/-- Shifting the target multiplies every truncation of the q-Euler sum by `q`. -/
+theorem truncatedGradedExtEuler_shiftTarget (h : IsGradedExtInternallyFinite.{w} k e X Y)
+    (h' : IsGradedExtInternallyFinite.{w} k e X (e.functor.obj Y)) (N : ℕ) :
+    truncatedGradedExtEuler k e h' N = T 1 * truncatedGradedExtEuler k e h N := by
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      rw [truncatedGradedExtEuler_succ, truncatedGradedExtEuler_succ, ih, mul_add,
+        gradedExtDimension_shiftTarget (h.finiteLaurentSupport N) (h'.finiteLaurentSupport N),
+        mul_smul_comm]
+
+/-- **`χ_q(X, Y{1}) = q · χ_q(X, Y)`**: the q-Euler characteristic is q-linear in its second
+argument. -/
+theorem gradedExtEuler_shiftTarget (h : IsGradedEulerAdmissible.{w} k e X Y)
+    (h' : IsGradedEulerAdmissible.{w} k e X (e.functor.obj Y)) :
+    gradedExtEuler k e h' = T 1 * gradedExtEuler k e h := by
+  obtain ⟨N, hN⟩ := h.bounded.exists_bound
+  rw [gradedExtEuler_eq k e h hN, gradedExtEuler_eq k e h' hN.shiftTarget]
+  exact truncatedGradedExtEuler_shiftTarget h.internallyFinite h'.internallyFinite N
+
+/-- **`χ_q(X, Y{-1}) = q⁻¹ · χ_q(X, Y)`**: the inverse shift of the second argument. -/
+theorem gradedExtEuler_shiftTarget_inverse (h : IsGradedEulerAdmissible.{w} k e X Y)
+    (h' : IsGradedEulerAdmissible.{w} k e X (e.inverse.obj Y)) :
+    gradedExtEuler k e h' = T (-1) * gradedExtEuler k e h := by
+  have hcounit : gradedExtEuler k e h = gradedExtEuler k e h'.shiftTarget :=
+    gradedExtEuler_of_iso k h h'.shiftTarget (Iso.refl X) (e.counitIso.app Y).symm
+  rw [hcounit, gradedExtEuler_shiftTarget h' h'.shiftTarget, ← mul_assoc, ← T_add]
+  simp
+
+/-! ### Shifting the source
+
+The source identity uses that `Ext` is invariant under `e`, so `e` must be `k`-linear and not
+merely additive. -/
+
+variable (k e)
+variable [e.functor.Additive] [e.functor.Linear k]
+
+/-- The comparison `(Y{j-1}){1} ≅ Y{j}`, which moves a source shift into the internal degree. -/
+private noncomputable def shiftSourceObjIso (Y : C) (j : ℤ) :
+    e.functor.obj ((e ^ (j - 1)).functor.obj Y) ≅ (e ^ j).functor.obj Y :=
+  ((equivPowSuccRightIso e (j - 1)).app Y).symm ≪≫
+    (equivPowCongrIso e (by ring : j - 1 + 1 = j)).app Y
+
+/-- Shifting the source of a bigraded `Ext` group lowers its internal degree by one:
+`Ext^{n,j}(X{1}, Y) ≅ Ext^{n,j-1}(X, Y)`. -/
+noncomputable def gradedExtShiftSourceEquiv (X Y : C) (n : ℕ) (j : ℤ) :
+    GradedExt.{w} e (e.functor.obj X) Y n j ≃ₗ[k] GradedExt.{w} e X Y n (j - 1) :=
+  ((extLinearEquivOfEquivalence k e X ((e ^ (j - 1)).functor.obj Y) n).trans
+    (extLinearEquivOfIso k (Iso.refl (e.functor.obj X)) (shiftSourceObjIso e Y j) n)).symm
+
+variable {k e}
+variable {X Y : C}
+
+/-- Finite internal support of bigraded `Ext` is preserved by shifting the source. -/
+theorem IsGradedExtInternallyFinite.shiftSource
+    (h : IsGradedExtInternallyFinite.{w} k e X Y) :
+    IsGradedExtInternallyFinite.{w} k e (e.functor.obj X) Y :=
+  ⟨fun n => ((h.finiteLaurentSupport n).reindex_add (-1)).of_equiv fun j =>
+    (gradedExtShiftSourceEquiv k e X Y n j).symm⟩
+
+omit [Functor.Linear k e.functor] in
+/-- A cohomological vanishing bound is preserved by shifting the source. -/
+theorem IsGradedExtBoundedBy.shiftSource {N : ℕ} (h : IsGradedExtBoundedBy.{w} e X Y N) :
+    IsGradedExtBoundedBy.{w} e (e.functor.obj X) Y N :=
+  ⟨fun n hn j => have := h.subsingleton hn (j - 1)
+    (((extAddEquivOfEquivalence e X ((e ^ (j - 1)).functor.obj Y) n).trans
+      (extAddEquivOfIso (Iso.refl (e.functor.obj X))
+        (shiftSourceObjIso e Y j) n)).symm).toEquiv.subsingleton⟩
+
+omit [Functor.Linear k e.functor] in
+/-- Eventual cohomological vanishing of bigraded `Ext` is preserved by shifting the source. -/
+theorem IsGradedExtBounded.shiftSource (h : IsGradedExtBounded.{w} e X Y) :
+    IsGradedExtBounded.{w} e (e.functor.obj X) Y :=
+  ⟨h.exists_bound.choose, h.exists_bound.choose_spec.shiftSource⟩
+
+/-- **Graded Euler-admissibility is preserved by shifting the source.** -/
+theorem IsGradedEulerAdmissible.shiftSource (h : IsGradedEulerAdmissible.{w} k e X Y) :
+    IsGradedEulerAdmissible.{w} k e (e.functor.obj X) Y :=
+  ⟨h.internallyFinite.shiftSource, h.bounded.shiftSource⟩
+
+/-- Shifting the source multiplies the graded `Ext` dimension in one cohomological degree by
+`q⁻¹`. -/
+theorem gradedExtDimension_shiftSource {n : ℕ}
+    (h : HasFiniteLaurentSupport k (GradedExt.{w} e X Y n))
+    (h' : HasFiniteLaurentSupport k (GradedExt.{w} e (e.functor.obj X) Y n)) :
+    gradedExtDimension k e h' = T (-1) * gradedExtDimension k e h := by
+  ext j
+  simp only [T, coeff_gradedExtDimension, AddMonoidAlgebra.coeff_single_mul_apply, one_mul]
+  rw [(gradedExtShiftSourceEquiv k e X Y n (-j)).finrank_eq]
+  have hj : -j - 1 = -(- -1 + j) := by omega
+  rw [hj]
+
+/-- Shifting the source multiplies every truncation of the q-Euler sum by `q⁻¹`. -/
+theorem truncatedGradedExtEuler_shiftSource (h : IsGradedExtInternallyFinite.{w} k e X Y)
+    (h' : IsGradedExtInternallyFinite.{w} k e (e.functor.obj X) Y) (N : ℕ) :
+    truncatedGradedExtEuler k e h' N = T (-1) * truncatedGradedExtEuler k e h N := by
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      rw [truncatedGradedExtEuler_succ, truncatedGradedExtEuler_succ, ih, mul_add,
+        gradedExtDimension_shiftSource (h.finiteLaurentSupport N) (h'.finiteLaurentSupport N),
+        mul_smul_comm]
+
+/-- **`χ_q(X{1}, Y) = q⁻¹ · χ_q(X, Y)`**: the q-Euler characteristic is q-antilinear in its first
+argument. -/
+theorem gradedExtEuler_shiftSource (h : IsGradedEulerAdmissible.{w} k e X Y)
+    (h' : IsGradedEulerAdmissible.{w} k e (e.functor.obj X) Y) :
+    gradedExtEuler k e h' = T (-1) * gradedExtEuler k e h := by
+  obtain ⟨N, hN⟩ := h.bounded.exists_bound
+  rw [gradedExtEuler_eq k e h hN, gradedExtEuler_eq k e h' hN.shiftSource]
+  exact truncatedGradedExtEuler_shiftSource h.internallyFinite h'.internallyFinite N
+
+/-- **`χ_q(X{-1}, Y) = q · χ_q(X, Y)`**: the inverse shift of the first argument. -/
+theorem gradedExtEuler_shiftSource_inverse (h : IsGradedEulerAdmissible.{w} k e X Y)
+    (h' : IsGradedEulerAdmissible.{w} k e (e.inverse.obj X) Y) :
+    gradedExtEuler k e h' = T 1 * gradedExtEuler k e h := by
+  have hcounit : gradedExtEuler k e h = gradedExtEuler k e h'.shiftSource :=
+    gradedExtEuler_of_iso k h h'.shiftSource (e.counitIso.app X).symm (Iso.refl Y)
+  rw [hcounit, gradedExtEuler_shiftSource h' h'.shiftSource, ← mul_assoc, ← T_add]
+  simp
+
+end TauCeti

--- a/TauCeti/Algebra/Homology/Ext/Equivalence.lean
+++ b/TauCeti/Algebra/Homology/Ext/Equivalence.lean
@@ -19,8 +19,8 @@ inverse equivalence supplies the inverse map, up to the transport along the unit
 
 ## Main definitions
 
-* `TauCeti.extAddEquivOfEquivalence`: `Extⁿ(X, Y) ≃+ Extⁿ(e X, e Y)` for an additive equivalence
-  `e`.
+* `CategoryTheory.Equivalence.extAddEquiv`: `Extⁿ(X, Y) ≃+ Extⁿ(e X, e Y)` for an additive
+  equivalence `e`.
 * `TauCeti.extLinearEquivOfEquivalence`: its `R`-linear refinement for an `R`-linear equivalence
   of `R`-linear abelian categories.  `R`-linearity of `e` is genuinely needed for the linear
   statement: an additive isomorphism of `k`-vector spaces need not preserve dimension.
@@ -74,7 +74,8 @@ private theorem mapExactFunctor_inverse_injective (e : C ≌ D) [e.functor.Addit
 /-- **`Ext` groups are invariant under an additive equivalence.**  The equivalence `e` carries
 `Extⁿ(X, Y)` isomorphically onto `Extⁿ(e X, e Y)`, with the inverse supplied by the inverse
 equivalence and the unit isomorphism. -/
-noncomputable def extAddEquivOfEquivalence (e : C ≌ D) [e.functor.Additive] (X Y : C) (n : ℕ) :
+noncomputable def _root_.CategoryTheory.Equivalence.extAddEquiv
+    (e : C ≌ D) [e.functor.Additive] (X Y : C) (n : ℕ) :
     Ext.{w} X Y n ≃+ Ext.{w} (e.functor.obj X) (e.functor.obj Y) n where
   toFun α := α.mapExactFunctor e.functor
   invFun β := (extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n).symm
@@ -90,18 +91,19 @@ noncomputable def extAddEquivOfEquivalence (e : C ≌ D) [e.functor.Additive] (X
     exact hinj (symm_extAddEquivOfIso_mapExactFunctor e X Y n _)
 
 @[simp]
-theorem extAddEquivOfEquivalence_apply (e : C ≌ D) [e.functor.Additive] {X Y : C} {n : ℕ}
+theorem _root_.CategoryTheory.Equivalence.extAddEquiv_apply
+    (e : C ≌ D) [e.functor.Additive] {X Y : C} {n : ℕ}
     (α : Ext.{w} X Y n) :
-    extAddEquivOfEquivalence e X Y n α = α.mapExactFunctor e.functor :=
+    e.extAddEquiv X Y n α = α.mapExactFunctor e.functor :=
   (rfl)
 
-/-- **The `R`-linear refinement of `TauCeti.extAddEquivOfEquivalence`.**  For an `R`-linear
+/-- **The `R`-linear refinement of `CategoryTheory.Equivalence.extAddEquiv`.**  For an `R`-linear
 equivalence of `R`-linear abelian categories, `Extⁿ(X, Y)` and `Extⁿ(e X, e Y)` are isomorphic as
 `R`-modules. -/
 noncomputable def extLinearEquivOfEquivalence (R : Type t) [Ring R] [Linear R C] [Linear R D]
     (e : C ≌ D) [e.functor.Additive] [e.functor.Linear R] (X Y : C) (n : ℕ) :
     Ext.{w} X Y n ≃ₗ[R] Ext.{w} (e.functor.obj X) (e.functor.obj Y) n where
-  __ := extAddEquivOfEquivalence e X Y n
+  __ := e.extAddEquiv X Y n
   map_smul' r α := by simp
 
 @[simp]

--- a/TauCeti/Algebra/Homology/Ext/Equivalence.lean
+++ b/TauCeti/Algebra/Homology/Ext/Equivalence.lean
@@ -104,4 +104,11 @@ noncomputable def extLinearEquivOfEquivalence (R : Type t) [Ring R] [Linear R C]
   __ := extAddEquivOfEquivalence e X Y n
   map_smul' r α := by simp
 
+@[simp]
+theorem extLinearEquivOfEquivalence_apply (R : Type t) [Ring R] [Linear R C] [Linear R D]
+    (e : C ≌ D) [e.functor.Additive] [e.functor.Linear R] {X Y : C} {n : ℕ}
+    (α : Ext.{w} X Y n) :
+    extLinearEquivOfEquivalence R e X Y n α = α.mapExactFunctor e.functor :=
+  (rfl)
+
 end TauCeti

--- a/TauCeti/Algebra/Homology/Ext/Equivalence.lean
+++ b/TauCeti/Algebra/Homology/Ext/Equivalence.lean
@@ -5,17 +5,18 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Homology.DerivedCategory.Ext.Map
+public import Mathlib.Algebra.Homology.DerivedCategory.Ext.MapAdjunction
 public import TauCeti.Algebra.Homology.Ext.Basic
 
 /-!
 # `Ext` groups are invariant under an additive equivalence
 
-Mathlib's `CategoryTheory.Abelian.Ext.mapExactFunctor` sends `Extⁿ(X, Y)` to
-`Extⁿ(F X, F Y)` for an exact additive functor `F`, and proves it bijective only under a
-projective- or injective-object hypothesis.  For an equivalence no such hypothesis is needed: the
-inverse equivalence supplies the inverse map, up to the transport along the unit isomorphism from
-`TauCeti.extAddEquivOfIso`.
+Mathlib's `CategoryTheory.Adjunction.extEquiv` promotes an adjunction `F ⊣ G` between exact
+functors to an additive equivalence `Extⁿ(F X, Y) ≃+ Extⁿ(X, G Y)`.  For an equivalence `e` this
+specialises, along `CategoryTheory.Equivalence.toAdjunction` and the transport of the target along
+the unit isomorphism from `TauCeti.extAddEquivOfIso`, to the invariance of `Ext` under `e`, which
+Mathlib does not state in this form.  (`CategoryTheory.Abelian.Ext.mapExactFunctor` is shown
+bijective only under a projective- or injective-object hypothesis.)
 
 ## Main definitions
 
@@ -37,65 +38,22 @@ universe w v v' u u' t
 variable {C : Type u} [Category.{v} C] [Abelian C] {D : Type u'} [Category.{v'} D] [Abelian D]
   [HasExt.{w} C] [HasExt.{w} D]
 
-/-- Pushing an `Ext` class forward along an equivalence and pulling it back along the inverse
-equivalence is transport along the unit isomorphism. -/
-private theorem mapExactFunctor_inverse_mapExactFunctor (e : C ≌ D) [e.functor.Additive]
-    {X Y : C} {n : ℕ} (α : Ext.{w} X Y n) :
-    (α.mapExactFunctor e.functor).mapExactFunctor e.inverse =
-      extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n α := by
-  have key := Ext.mapExactFunctor_comp_mk₀_natTransApp α (F := 𝟭 C)
-    (G := e.functor ⋙ e.inverse) e.unitIso.hom
-  rw [Ext.id_mapExactFunctor] at key
-  rw [extAddEquivOfIso_apply, ← Ext.comp_mapExactFunctor]
-  simp only [Iso.app_hom, Iso.app_inv]
-  rw [key, Ext.mk₀_comp_mk₀_assoc]
-  simp
-
-/-- Transporting back along the unit isomorphism inverts the pushforward of an `Ext` class along
-an equivalence. -/
-private theorem symm_extAddEquivOfIso_mapExactFunctor (e : C ≌ D) [e.functor.Additive]
-    (X Y : C) (n : ℕ) (α : Ext.{w} X Y n) :
-    (extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n).symm
-        ((α.mapExactFunctor e.functor).mapExactFunctor e.inverse) = α := by
-  rw [mapExactFunctor_inverse_mapExactFunctor]
-  exact (extAddEquivOfIso _ _ n).symm_apply_apply α
-
-/-- Pushing forward along the inverse of an equivalence is injective on `Ext` groups. -/
-private theorem mapExactFunctor_inverse_injective (e : C ≌ D) [e.functor.Additive]
-    (A B : D) (n : ℕ) :
-    Function.Injective fun β : Ext.{w} A B n => β.mapExactFunctor e.inverse := by
-  have : e.symm.functor.Additive := inferInstanceAs e.inverse.Additive
-  intro β₁ β₂ h
-  have h₁ := symm_extAddEquivOfIso_mapExactFunctor e.symm A B n β₁
-  have h₂ := symm_extAddEquivOfIso_mapExactFunctor e.symm A B n β₂
-  rw [← h₁, ← h₂]
-  exact congrArg _ (congrArg (fun γ => Ext.mapExactFunctor e.symm.inverse γ) h)
-
 /-- **`Ext` groups are invariant under an additive equivalence.**  The equivalence `e` carries
-`Extⁿ(X, Y)` isomorphically onto `Extⁿ(e X, e Y)`, with the inverse supplied by the inverse
-equivalence and the unit isomorphism. -/
+`Extⁿ(X, Y)` isomorphically onto `Extⁿ(e X, e Y)`.  This is `CategoryTheory.Adjunction.extEquiv`
+for the adjunction `e.functor ⊣ e.inverse`, with the target transported along the unit
+isomorphism. -/
 noncomputable def _root_.CategoryTheory.Equivalence.extAddEquiv
     (e : C ≌ D) [e.functor.Additive] (X Y : C) (n : ℕ) :
-    Ext.{w} X Y n ≃+ Ext.{w} (e.functor.obj X) (e.functor.obj Y) n where
-  toFun α := α.mapExactFunctor e.functor
-  invFun β := (extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n).symm
-    (β.mapExactFunctor e.inverse)
-  map_add' α β := by simp
-  left_inv α := symm_extAddEquivOfIso_mapExactFunctor e X Y n α
-  right_inv β := by
-    have hinj : Function.Injective fun γ : Ext.{w} (e.functor.obj X) (e.functor.obj Y) n =>
-        (extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n).symm
-          (γ.mapExactFunctor e.inverse) :=
-      (extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n).symm.injective.comp
-        (mapExactFunctor_inverse_injective e _ _ n)
-    exact hinj (symm_extAddEquivOfIso_mapExactFunctor e X Y n _)
+    Ext.{w} X Y n ≃+ Ext.{w} (e.functor.obj X) (e.functor.obj Y) n :=
+  (extAddEquivOfIso (Iso.refl X) (e.unitIso.app Y) n).trans e.toAdjunction.extEquiv.symm
 
 @[simp]
 theorem _root_.CategoryTheory.Equivalence.extAddEquiv_apply
     (e : C ≌ D) [e.functor.Additive] {X Y : C} {n : ℕ}
     (α : Ext.{w} X Y n) :
-    e.extAddEquiv X Y n α = α.mapExactFunctor e.functor :=
-  (rfl)
+    e.extAddEquiv X Y n α = α.mapExactFunctor e.functor := by
+  simp [Equivalence.extAddEquiv, Adjunction.extEquiv_symm_apply, Ext.mapExactFunctor_comp,
+    Ext.mapExactFunctor_mk₀]
 
 /-- **The `R`-linear refinement of `CategoryTheory.Equivalence.extAddEquiv`.**  For an `R`-linear
 equivalence of `R`-linear abelian categories, `Extⁿ(X, Y)` and `Extⁿ(e X, e Y)` are isomorphic as
@@ -111,6 +69,6 @@ theorem extLinearEquivOfEquivalence_apply (R : Type t) [Ring R] [Linear R C] [Li
     (e : C ≌ D) [e.functor.Additive] [e.functor.Linear R] {X Y : C} {n : ℕ}
     (α : Ext.{w} X Y n) :
     extLinearEquivOfEquivalence R e X Y n α = α.mapExactFunctor e.functor :=
-  (rfl)
+  e.extAddEquiv_apply α
 
 end TauCeti

--- a/TauCeti/Algebra/Homology/Ext/Equivalence.lean
+++ b/TauCeti/Algebra/Homology/Ext/Equivalence.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Homology.DerivedCategory.Ext.Map
+public import TauCeti.Algebra.Homology.Ext.Basic
+
+/-!
+# `Ext` groups are invariant under an additive equivalence
+
+Mathlib's `CategoryTheory.Abelian.Ext.mapExactFunctor` sends `Extⁿ(X, Y)` to
+`Extⁿ(F X, F Y)` for an exact additive functor `F`, and proves it bijective only under a
+projective- or injective-object hypothesis.  For an equivalence no such hypothesis is needed: the
+inverse equivalence supplies the inverse map, up to the transport along the unit isomorphism from
+`TauCeti.extAddEquivOfIso`.
+
+## Main definitions
+
+* `TauCeti.extAddEquivOfEquivalence`: `Extⁿ(X, Y) ≃+ Extⁿ(e X, e Y)` for an additive equivalence
+  `e`.
+* `TauCeti.extLinearEquivOfEquivalence`: its `R`-linear refinement for an `R`-linear equivalence
+  of `R`-linear abelian categories.  `R`-linearity of `e` is genuinely needed for the linear
+  statement: an additive isomorphism of `k`-vector spaces need not preserve dimension.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Abelian CategoryTheory.Limits
+
+universe w v v' u u' t
+
+variable {C : Type u} [Category.{v} C] [Abelian C] {D : Type u'} [Category.{v'} D] [Abelian D]
+  [HasExt.{w} C] [HasExt.{w} D]
+
+/-- Pushing an `Ext` class forward along an equivalence and pulling it back along the inverse
+equivalence is transport along the unit isomorphism. -/
+private theorem mapExactFunctor_inverse_mapExactFunctor (e : C ≌ D) [e.functor.Additive]
+    {X Y : C} {n : ℕ} (α : Ext.{w} X Y n) :
+    (α.mapExactFunctor e.functor).mapExactFunctor e.inverse =
+      extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n α := by
+  have key := Ext.mapExactFunctor_comp_mk₀_natTransApp α (F := 𝟭 C)
+    (G := e.functor ⋙ e.inverse) e.unitIso.hom
+  rw [Ext.id_mapExactFunctor] at key
+  rw [extAddEquivOfIso_apply, ← Ext.comp_mapExactFunctor]
+  simp only [Iso.app_hom, Iso.app_inv]
+  rw [key, Ext.mk₀_comp_mk₀_assoc]
+  simp
+
+/-- Transporting back along the unit isomorphism inverts the pushforward of an `Ext` class along
+an equivalence. -/
+private theorem symm_extAddEquivOfIso_mapExactFunctor (e : C ≌ D) [e.functor.Additive]
+    (X Y : C) (n : ℕ) (α : Ext.{w} X Y n) :
+    (extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n).symm
+        ((α.mapExactFunctor e.functor).mapExactFunctor e.inverse) = α := by
+  rw [mapExactFunctor_inverse_mapExactFunctor]
+  exact (extAddEquivOfIso _ _ n).symm_apply_apply α
+
+/-- Pushing forward along the inverse of an equivalence is injective on `Ext` groups. -/
+private theorem mapExactFunctor_inverse_injective (e : C ≌ D) [e.functor.Additive]
+    (A B : D) (n : ℕ) :
+    Function.Injective fun β : Ext.{w} A B n => β.mapExactFunctor e.inverse := by
+  have : e.symm.functor.Additive := inferInstanceAs e.inverse.Additive
+  intro β₁ β₂ h
+  have h₁ := symm_extAddEquivOfIso_mapExactFunctor e.symm A B n β₁
+  have h₂ := symm_extAddEquivOfIso_mapExactFunctor e.symm A B n β₂
+  rw [← h₁, ← h₂]
+  exact congrArg _ (congrArg (fun γ => Ext.mapExactFunctor e.symm.inverse γ) h)
+
+/-- **`Ext` groups are invariant under an additive equivalence.**  The equivalence `e` carries
+`Extⁿ(X, Y)` isomorphically onto `Extⁿ(e X, e Y)`, with the inverse supplied by the inverse
+equivalence and the unit isomorphism. -/
+noncomputable def extAddEquivOfEquivalence (e : C ≌ D) [e.functor.Additive] (X Y : C) (n : ℕ) :
+    Ext.{w} X Y n ≃+ Ext.{w} (e.functor.obj X) (e.functor.obj Y) n where
+  toFun α := α.mapExactFunctor e.functor
+  invFun β := (extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n).symm
+    (β.mapExactFunctor e.inverse)
+  map_add' α β := by simp
+  left_inv α := symm_extAddEquivOfIso_mapExactFunctor e X Y n α
+  right_inv β := by
+    have hinj : Function.Injective fun γ : Ext.{w} (e.functor.obj X) (e.functor.obj Y) n =>
+        (extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n).symm
+          (γ.mapExactFunctor e.inverse) :=
+      (extAddEquivOfIso (e.unitIso.app X) (e.unitIso.app Y) n).symm.injective.comp
+        (mapExactFunctor_inverse_injective e _ _ n)
+    exact hinj (symm_extAddEquivOfIso_mapExactFunctor e X Y n _)
+
+@[simp]
+theorem extAddEquivOfEquivalence_apply (e : C ≌ D) [e.functor.Additive] {X Y : C} {n : ℕ}
+    (α : Ext.{w} X Y n) :
+    extAddEquivOfEquivalence e X Y n α = α.mapExactFunctor e.functor :=
+  (rfl)
+
+/-- **The `R`-linear refinement of `TauCeti.extAddEquivOfEquivalence`.**  For an `R`-linear
+equivalence of `R`-linear abelian categories, `Extⁿ(X, Y)` and `Extⁿ(e X, e Y)` are isomorphic as
+`R`-modules. -/
+noncomputable def extLinearEquivOfEquivalence (R : Type t) [Ring R] [Linear R C] [Linear R D]
+    (e : C ≌ D) [e.functor.Additive] [e.functor.Linear R] (X Y : C) (n : ℕ) :
+    Ext.{w} X Y n ≃ₗ[R] Ext.{w} (e.functor.obj X) (e.functor.obj Y) n where
+  __ := extAddEquivOfEquivalence e X Y n
+  map_smul' r α := by simp
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Equivalence/Pow.lean
+++ b/TauCeti/CategoryTheory/Equivalence/Pow.lean
@@ -41,11 +41,6 @@ universe v u
 
 variable {C : Type u} [Category.{v} C]
 
-/-- Equal integer exponents give the same power functor. -/
-def _root_.CategoryTheory.Equivalence.powCongrIso (e : C ≌ C) {a b : ℤ} (h : a = b) :
-    (e ^ a).functor ≅ (e ^ b).functor :=
-  eqToIso (by rw [h])
-
 /-- **The successor isomorphism `e ^ (j + 1) ≅ e ⋙ e ^ j`.**  Mathlib's power is built by
 prepending a copy of `e`, so this is the identity except at the two exponents where the recursion
 bottoms out. -/
@@ -63,7 +58,8 @@ def _root_.CategoryTheory.Equivalence.powSuccIso (e : C ≌ C) : ∀ j : ℤ,
 def _root_.CategoryTheory.Equivalence.powPredIso (e : C ≌ C) (j : ℤ) :
     e.inverse ⋙ (e ^ j).functor ≅ (e ^ (j - 1)).functor :=
   Functor.isoWhiskerLeft e.inverse
-      (e.powCongrIso (by ring : j = j - 1 + 1) ≪≫ e.powSuccIso (j - 1)) ≪≫
+      (eqToIso (congrArg (fun i : ℤ => (e ^ i).functor) (by ring : j = j - 1 + 1)) ≪≫
+        e.powSuccIso (j - 1)) ≪≫
     e.invFunIdAssoc _
 
 /-- The inductive step of `CategoryTheory.Equivalence.powAddIso` which raises the first exponent
@@ -72,11 +68,12 @@ private def _root_.CategoryTheory.Equivalence.powAddIsoOfSucc (e : C ≌ C) (b a
     (h : a' = a + 1)
     (ih : (e ^ (a + b)).functor ≅ (e ^ a).functor ⋙ (e ^ b).functor) :
     (e ^ (a' + b)).functor ≅ (e ^ a').functor ⋙ (e ^ b).functor :=
-  e.powCongrIso (by rw [h]; ring : a' + b = a + b + 1) ≪≫
+  eqToIso (congrArg (fun i : ℤ => (e ^ i).functor) (by rw [h]; ring : a' + b = a + b + 1)) ≪≫
     e.powSuccIso (a + b) ≪≫ Functor.isoWhiskerLeft e.functor ih ≪≫
       (Functor.associator _ _ _).symm ≪≫
         Functor.isoWhiskerRight
-          ((e.powSuccIso a).symm ≪≫ e.powCongrIso (by rw [h] : a + 1 = a')) _
+          ((e.powSuccIso a).symm ≪≫
+            eqToIso (congrArg (fun i : ℤ => (e ^ i).functor) (by rw [h] : a + 1 = a'))) _
 
 /-- The inductive step of `CategoryTheory.Equivalence.powAddIso` which lowers the first exponent
 by one. -/
@@ -87,16 +84,19 @@ private def _root_.CategoryTheory.Equivalence.powAddIsoOfPred (e : C ≌ C) (b a
   (e.invFunIdAssoc _).symm ≪≫
     Functor.isoWhiskerLeft e.inverse
         ((e.powSuccIso (a' + b)).symm ≪≫
-          e.powCongrIso (by rw [h]; ring : a' + b + 1 = a + b) ≪≫ ih) ≪≫
+          eqToIso (congrArg (fun i : ℤ => (e ^ i).functor)
+            (by rw [h]; ring : a' + b + 1 = a + b)) ≪≫ ih) ≪≫
       (Functor.associator _ _ _).symm ≪≫
         Functor.isoWhiskerRight
-          (e.powPredIso a ≪≫ e.powCongrIso (by rw [h] : a - 1 = a')) _
+          (e.powPredIso a ≪≫
+            eqToIso (congrArg (fun i : ℤ => (e ^ i).functor) (by rw [h] : a - 1 = a'))) _
 
 /-- Additivity of the integer powers at a nonnegative first exponent. -/
 private def _root_.CategoryTheory.Equivalence.powAddNatIso (e : C ≌ C) (b : ℤ) : ∀ n : ℕ,
     (e ^ ((n : ℤ) + b)).functor ≅ (e ^ (n : ℤ)).functor ⋙ (e ^ b).functor
   | 0 =>
-      e.powCongrIso (by push_cast; ring : ((0 : ℕ) : ℤ) + b = b) ≪≫
+      eqToIso (congrArg (fun i : ℤ => (e ^ i).functor)
+          (by push_cast; ring : ((0 : ℕ) : ℤ) + b = b)) ≪≫
         (Functor.leftUnitor _).symm
   | n + 1 =>
       e.powAddIsoOfSucc b (n : ℤ) (((n + 1 : ℕ) : ℤ)) (by push_cast; ring)
@@ -106,7 +106,8 @@ private def _root_.CategoryTheory.Equivalence.powAddNatIso (e : C ≌ C) (b : �
 private def _root_.CategoryTheory.Equivalence.powSubNatIso (e : C ≌ C) (b : ℤ) : ∀ n : ℕ,
     (e ^ (-(n : ℤ) + b)).functor ≅ (e ^ (-(n : ℤ))).functor ⋙ (e ^ b).functor
   | 0 =>
-      e.powCongrIso (by push_cast; ring : -((0 : ℕ) : ℤ) + b = b) ≪≫
+      eqToIso (congrArg (fun i : ℤ => (e ^ i).functor)
+          (by push_cast; ring : -((0 : ℕ) : ℤ) + b = b)) ≪≫
         (Functor.leftUnitor _).symm
   | n + 1 =>
       e.powAddIsoOfPred b (-(n : ℤ)) (-((n + 1 : ℕ) : ℤ)) (by push_cast; ring)

--- a/TauCeti/CategoryTheory/Equivalence/Pow.lean
+++ b/TauCeti/CategoryTheory/Equivalence/Pow.lean
@@ -42,8 +42,11 @@ universe v u
 variable {C : Type u} [Category.{v} C]
 
 /-- **The successor isomorphism `e ^ (j + 1) ≅ e ⋙ e ^ j`.**  Mathlib's power is built by
-prepending a copy of `e`, so this is the identity except at the two exponents where the recursion
-bottoms out. -/
+prepending a copy of `e`, so at a positive exponent the isomorphism is the identity.  Each of the
+remaining cases inserts exactly what the recursion leaves out there: a right unitor at `j = 0`,
+where `e ^ 0` is the identity functor; the unit isomorphism at `j = -1`, where `e ⋙ e ^ (-1)` is
+`e ⋙ e.inverse`; and at every `j ≤ -2` a composite of a left unitor, the unit isomorphism and an
+associator, which grows a negative power by inserting `e ⋙ e.inverse` in front of it. -/
 def _root_.CategoryTheory.Equivalence.powSuccIso (e : C ≌ C) : ∀ j : ℤ,
     (e ^ (j + 1)).functor ≅ e.functor ⋙ (e ^ j).functor
   | (0 : ℕ) => (Functor.rightUnitor e.functor).symm

--- a/TauCeti/CategoryTheory/Equivalence/Pow.lean
+++ b/TauCeti/CategoryTheory/Equivalence/Pow.lean
@@ -24,32 +24,32 @@ equation, is what downstream constructions use.
 
 ## Main definitions
 
-* `TauCeti.equivPowSuccIso`: `e ^ (j + 1) ≅ e ⋙ e ^ j`, by case analysis on `j`.
-* `TauCeti.equivPowPredIso`: `e⁻¹ ⋙ e ^ j ≅ e ^ (j - 1)`.
-* `TauCeti.equivPowAddIso`: `e ^ (a + b) ≅ e ^ a ⋙ e ^ b`.
-* `TauCeti.equivPowSuccRightIso`: `e ^ (j + 1) ≅ e ^ j ⋙ e`, the opposite-handed successor
-  isomorphism, which the additivity isomorphism supplies but the recursion does not.
+* `CategoryTheory.Equivalence.powSuccIso`: `e ^ (j + 1) ≅ e ⋙ e ^ j`, by case analysis on `j`.
+* `CategoryTheory.Equivalence.powPredIso`: `e⁻¹ ⋙ e ^ j ≅ e ^ (j - 1)`.
+* `CategoryTheory.Equivalence.powAddIso`: `e ^ (a + b) ≅ e ^ a ⋙ e ^ b`.
+* `CategoryTheory.Equivalence.powSuccRightIso`: `e ^ (j + 1) ≅ e ^ j ⋙ e`, the opposite-handed
+  successor isomorphism, which the additivity isomorphism supplies but the recursion does not.
 -/
 
 public section
 
-namespace TauCeti
-
 open CategoryTheory
+
+namespace TauCeti
 
 universe v u
 
 variable {C : Type u} [Category.{v} C]
 
 /-- Equal integer exponents give the same power functor. -/
-def equivPowCongrIso (e : C ≌ C) {a b : ℤ} (h : a = b) :
+def _root_.CategoryTheory.Equivalence.powCongrIso (e : C ≌ C) {a b : ℤ} (h : a = b) :
     (e ^ a).functor ≅ (e ^ b).functor :=
   eqToIso (by rw [h])
 
 /-- **The successor isomorphism `e ^ (j + 1) ≅ e ⋙ e ^ j`.**  Mathlib's power is built by
 prepending a copy of `e`, so this is the identity except at the two exponents where the recursion
 bottoms out. -/
-def equivPowSuccIso (e : C ≌ C) : ∀ j : ℤ,
+def _root_.CategoryTheory.Equivalence.powSuccIso (e : C ≌ C) : ∀ j : ℤ,
     (e ^ (j + 1)).functor ≅ e.functor ⋙ (e ^ j).functor
   | (0 : ℕ) => (Functor.rightUnitor e.functor).symm
   | ((_ + 1 : ℕ) : ℤ) => Iso.refl _
@@ -59,70 +59,68 @@ def equivPowSuccIso (e : C ≌ C) : ∀ j : ℤ,
         Functor.isoWhiskerRight e.unitIso _ ≪≫
           Functor.associator e.functor e.inverse (e.symm.powNat (m + 1)).functor
 
-/-- Composing on the left with the inverse equivalence cancels a leading copy of the functor. -/
-private def leftCancelInverseIso (e : C ≌ C) (G : C ⥤ C) :
-    e.inverse ⋙ e.functor ⋙ G ≅ G :=
-  (Functor.associator _ _ _).symm ≪≫ Functor.isoWhiskerRight e.counitIso G ≪≫
-    Functor.leftUnitor G
-
 /-- **The predecessor isomorphism `e⁻¹ ⋙ e ^ j ≅ e ^ (j - 1)`.** -/
-def equivPowPredIso (e : C ≌ C) (j : ℤ) :
+def _root_.CategoryTheory.Equivalence.powPredIso (e : C ≌ C) (j : ℤ) :
     e.inverse ⋙ (e ^ j).functor ≅ (e ^ (j - 1)).functor :=
   Functor.isoWhiskerLeft e.inverse
-      (equivPowCongrIso e (by ring : j = j - 1 + 1) ≪≫ equivPowSuccIso e (j - 1)) ≪≫
-    leftCancelInverseIso e _
+      (e.powCongrIso (by ring : j = j - 1 + 1) ≪≫ e.powSuccIso (j - 1)) ≪≫
+    e.invFunIdAssoc _
 
-/-- The inductive step of `TauCeti.equivPowAddIso` which raises the first exponent by one. -/
-private def addIsoOfSucc (e : C ≌ C) (b a a' : ℤ) (h : a' = a + 1)
+/-- The inductive step of `CategoryTheory.Equivalence.powAddIso` which raises the first exponent
+by one. -/
+private def _root_.CategoryTheory.Equivalence.powAddIsoOfSucc (e : C ≌ C) (b a a' : ℤ)
+    (h : a' = a + 1)
     (ih : (e ^ (a + b)).functor ≅ (e ^ a).functor ⋙ (e ^ b).functor) :
     (e ^ (a' + b)).functor ≅ (e ^ a').functor ⋙ (e ^ b).functor :=
-  equivPowCongrIso e (by rw [h]; ring : a' + b = a + b + 1) ≪≫
-    equivPowSuccIso e (a + b) ≪≫ Functor.isoWhiskerLeft e.functor ih ≪≫
+  e.powCongrIso (by rw [h]; ring : a' + b = a + b + 1) ≪≫
+    e.powSuccIso (a + b) ≪≫ Functor.isoWhiskerLeft e.functor ih ≪≫
       (Functor.associator _ _ _).symm ≪≫
         Functor.isoWhiskerRight
-          ((equivPowSuccIso e a).symm ≪≫ equivPowCongrIso e (by rw [h] : a + 1 = a')) _
+          ((e.powSuccIso a).symm ≪≫ e.powCongrIso (by rw [h] : a + 1 = a')) _
 
-/-- The inductive step of `TauCeti.equivPowAddIso` which lowers the first exponent by one. -/
-private def addIsoOfPred (e : C ≌ C) (b a a' : ℤ) (h : a' = a - 1)
+/-- The inductive step of `CategoryTheory.Equivalence.powAddIso` which lowers the first exponent
+by one. -/
+private def _root_.CategoryTheory.Equivalence.powAddIsoOfPred (e : C ≌ C) (b a a' : ℤ)
+    (h : a' = a - 1)
     (ih : (e ^ (a + b)).functor ≅ (e ^ a).functor ⋙ (e ^ b).functor) :
     (e ^ (a' + b)).functor ≅ (e ^ a').functor ⋙ (e ^ b).functor :=
-  (leftCancelInverseIso e _).symm ≪≫
+  (e.invFunIdAssoc _).symm ≪≫
     Functor.isoWhiskerLeft e.inverse
-        ((equivPowSuccIso e (a' + b)).symm ≪≫
-          equivPowCongrIso e (by rw [h]; ring : a' + b + 1 = a + b) ≪≫ ih) ≪≫
+        ((e.powSuccIso (a' + b)).symm ≪≫
+          e.powCongrIso (by rw [h]; ring : a' + b + 1 = a + b) ≪≫ ih) ≪≫
       (Functor.associator _ _ _).symm ≪≫
         Functor.isoWhiskerRight
-          (equivPowPredIso e a ≪≫ equivPowCongrIso e (by rw [h] : a - 1 = a')) _
+          (e.powPredIso a ≪≫ e.powCongrIso (by rw [h] : a - 1 = a')) _
 
 /-- Additivity of the integer powers at a nonnegative first exponent. -/
-private def equivPowAddNatIso (e : C ≌ C) (b : ℤ) : ∀ n : ℕ,
+private def _root_.CategoryTheory.Equivalence.powAddNatIso (e : C ≌ C) (b : ℤ) : ∀ n : ℕ,
     (e ^ ((n : ℤ) + b)).functor ≅ (e ^ (n : ℤ)).functor ⋙ (e ^ b).functor
   | 0 =>
-      equivPowCongrIso e (by push_cast; ring : ((0 : ℕ) : ℤ) + b = b) ≪≫
+      e.powCongrIso (by push_cast; ring : ((0 : ℕ) : ℤ) + b = b) ≪≫
         (Functor.leftUnitor _).symm
   | n + 1 =>
-      addIsoOfSucc e b (n : ℤ) (((n + 1 : ℕ) : ℤ)) (by push_cast; ring)
-        (equivPowAddNatIso e b n)
+      e.powAddIsoOfSucc b (n : ℤ) (((n + 1 : ℕ) : ℤ)) (by push_cast; ring)
+        (CategoryTheory.Equivalence.powAddNatIso e b n)
 
 /-- Additivity of the integer powers at a nonpositive first exponent. -/
-private def equivPowSubNatIso (e : C ≌ C) (b : ℤ) : ∀ n : ℕ,
+private def _root_.CategoryTheory.Equivalence.powSubNatIso (e : C ≌ C) (b : ℤ) : ∀ n : ℕ,
     (e ^ (-(n : ℤ) + b)).functor ≅ (e ^ (-(n : ℤ))).functor ⋙ (e ^ b).functor
   | 0 =>
-      equivPowCongrIso e (by push_cast; ring : -((0 : ℕ) : ℤ) + b = b) ≪≫
+      e.powCongrIso (by push_cast; ring : -((0 : ℕ) : ℤ) + b = b) ≪≫
         (Functor.leftUnitor _).symm
   | n + 1 =>
-      addIsoOfPred e b (-(n : ℤ)) (-((n + 1 : ℕ) : ℤ)) (by push_cast; ring)
-        (equivPowSubNatIso e b n)
+      e.powAddIsoOfPred b (-(n : ℤ)) (-((n + 1 : ℕ) : ℤ)) (by push_cast; ring)
+        (CategoryTheory.Equivalence.powSubNatIso e b n)
 
 /-- **Additivity of the integer powers of an autoequivalence**: `e ^ (a + b) ≅ e ^ a ⋙ e ^ b`. -/
-def equivPowAddIso (e : C ≌ C) : ∀ a b : ℤ,
+def _root_.CategoryTheory.Equivalence.powAddIso (e : C ≌ C) : ∀ a b : ℤ,
     (e ^ (a + b)).functor ≅ (e ^ a).functor ⋙ (e ^ b).functor
-  | Int.ofNat n, b => equivPowAddNatIso e b n
-  | Int.negSucc n, b => equivPowSubNatIso e b (n + 1)
+  | Int.ofNat n, b => e.powAddNatIso b n
+  | Int.negSucc n, b => e.powSubNatIso b (n + 1)
 
 /-- **The opposite-handed successor isomorphism `e ^ (j + 1) ≅ e ^ j ⋙ e`.** -/
-def equivPowSuccRightIso (e : C ≌ C) (j : ℤ) :
+def _root_.CategoryTheory.Equivalence.powSuccRightIso (e : C ≌ C) (j : ℤ) :
     (e ^ (j + 1)).functor ≅ (e ^ j).functor ⋙ e.functor :=
-  equivPowAddIso e j 1
+  e.powAddIso j 1
 
 end TauCeti

--- a/TauCeti/CategoryTheory/Equivalence/Pow.lean
+++ b/TauCeti/CategoryTheory/Equivalence/Pow.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.CategoryTheory.EqToHom
+public import Mathlib.CategoryTheory.Equivalence
+public import Mathlib.Tactic.Ring
+
+/-!
+# Additivity of the integer powers of an autoequivalence
+
+Mathlib defines the integer powers `e ^ j` of an autoequivalence `e : C ≌ C` by recursion and
+records `e ^ 0`, `e ^ 1` and `e ^ (-1)`, but leaves the comparison of `e ^ (a + b)` with the
+composite `e ^ a ⋙ e ^ b` as an explicit TODO.  This file supplies that comparison as an
+isomorphism of the underlying functors, together with the successor and predecessor forms which
+consume it.
+
+Only the underlying functors are compared.  `e ^ (a + b)` and `(e ^ a).trans (e ^ b)` are not
+equal as equivalences — the recursion inserts unitors — so the isomorphism below, and not an
+equation, is what downstream constructions use.
+
+## Main definitions
+
+* `TauCeti.equivPowSuccIso`: `e ^ (j + 1) ≅ e ⋙ e ^ j`, by case analysis on `j`.
+* `TauCeti.equivPowPredIso`: `e⁻¹ ⋙ e ^ j ≅ e ^ (j - 1)`.
+* `TauCeti.equivPowAddIso`: `e ^ (a + b) ≅ e ^ a ⋙ e ^ b`.
+* `TauCeti.equivPowSuccRightIso`: `e ^ (j + 1) ≅ e ^ j ⋙ e`, the opposite-handed successor
+  isomorphism, which the additivity isomorphism supplies but the recursion does not.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe v u
+
+variable {C : Type u} [Category.{v} C]
+
+/-- Equal integer exponents give the same power functor. -/
+def equivPowCongrIso (e : C ≌ C) {a b : ℤ} (h : a = b) :
+    (e ^ a).functor ≅ (e ^ b).functor :=
+  eqToIso (by rw [h])
+
+/-- **The successor isomorphism `e ^ (j + 1) ≅ e ⋙ e ^ j`.**  Mathlib's power is built by
+prepending a copy of `e`, so this is the identity except at the two exponents where the recursion
+bottoms out. -/
+def equivPowSuccIso (e : C ≌ C) : ∀ j : ℤ,
+    (e ^ (j + 1)).functor ≅ e.functor ⋙ (e ^ j).functor
+  | (0 : ℕ) => (Functor.rightUnitor e.functor).symm
+  | ((_ + 1 : ℕ) : ℤ) => Iso.refl _
+  | Int.negSucc 0 => e.unitIso
+  | Int.negSucc (m + 1) =>
+      (Functor.leftUnitor (e.symm.powNat (m + 1)).functor).symm ≪≫
+        Functor.isoWhiskerRight e.unitIso _ ≪≫
+          Functor.associator e.functor e.inverse (e.symm.powNat (m + 1)).functor
+
+/-- Composing on the left with the inverse equivalence cancels a leading copy of the functor. -/
+private def leftCancelInverseIso (e : C ≌ C) (G : C ⥤ C) :
+    e.inverse ⋙ e.functor ⋙ G ≅ G :=
+  (Functor.associator _ _ _).symm ≪≫ Functor.isoWhiskerRight e.counitIso G ≪≫
+    Functor.leftUnitor G
+
+/-- **The predecessor isomorphism `e⁻¹ ⋙ e ^ j ≅ e ^ (j - 1)`.** -/
+def equivPowPredIso (e : C ≌ C) (j : ℤ) :
+    e.inverse ⋙ (e ^ j).functor ≅ (e ^ (j - 1)).functor :=
+  Functor.isoWhiskerLeft e.inverse
+      (equivPowCongrIso e (by ring : j = j - 1 + 1) ≪≫ equivPowSuccIso e (j - 1)) ≪≫
+    leftCancelInverseIso e _
+
+/-- The inductive step of `TauCeti.equivPowAddIso` which raises the first exponent by one. -/
+private def addIsoOfSucc (e : C ≌ C) (b a a' : ℤ) (h : a' = a + 1)
+    (ih : (e ^ (a + b)).functor ≅ (e ^ a).functor ⋙ (e ^ b).functor) :
+    (e ^ (a' + b)).functor ≅ (e ^ a').functor ⋙ (e ^ b).functor :=
+  equivPowCongrIso e (by rw [h]; ring : a' + b = a + b + 1) ≪≫
+    equivPowSuccIso e (a + b) ≪≫ Functor.isoWhiskerLeft e.functor ih ≪≫
+      (Functor.associator _ _ _).symm ≪≫
+        Functor.isoWhiskerRight
+          ((equivPowSuccIso e a).symm ≪≫ equivPowCongrIso e (by rw [h] : a + 1 = a')) _
+
+/-- The inductive step of `TauCeti.equivPowAddIso` which lowers the first exponent by one. -/
+private def addIsoOfPred (e : C ≌ C) (b a a' : ℤ) (h : a' = a - 1)
+    (ih : (e ^ (a + b)).functor ≅ (e ^ a).functor ⋙ (e ^ b).functor) :
+    (e ^ (a' + b)).functor ≅ (e ^ a').functor ⋙ (e ^ b).functor :=
+  (leftCancelInverseIso e _).symm ≪≫
+    Functor.isoWhiskerLeft e.inverse
+        ((equivPowSuccIso e (a' + b)).symm ≪≫
+          equivPowCongrIso e (by rw [h]; ring : a' + b + 1 = a + b) ≪≫ ih) ≪≫
+      (Functor.associator _ _ _).symm ≪≫
+        Functor.isoWhiskerRight
+          (equivPowPredIso e a ≪≫ equivPowCongrIso e (by rw [h] : a - 1 = a')) _
+
+/-- Additivity of the integer powers at a nonnegative first exponent. -/
+private def equivPowAddNatIso (e : C ≌ C) (b : ℤ) : ∀ n : ℕ,
+    (e ^ ((n : ℤ) + b)).functor ≅ (e ^ (n : ℤ)).functor ⋙ (e ^ b).functor
+  | 0 =>
+      equivPowCongrIso e (by push_cast; ring : ((0 : ℕ) : ℤ) + b = b) ≪≫
+        (Functor.leftUnitor _).symm
+  | n + 1 =>
+      addIsoOfSucc e b (n : ℤ) (((n + 1 : ℕ) : ℤ)) (by push_cast; ring)
+        (equivPowAddNatIso e b n)
+
+/-- Additivity of the integer powers at a nonpositive first exponent. -/
+private def equivPowSubNatIso (e : C ≌ C) (b : ℤ) : ∀ n : ℕ,
+    (e ^ (-(n : ℤ) + b)).functor ≅ (e ^ (-(n : ℤ))).functor ⋙ (e ^ b).functor
+  | 0 =>
+      equivPowCongrIso e (by push_cast; ring : -((0 : ℕ) : ℤ) + b = b) ≪≫
+        (Functor.leftUnitor _).symm
+  | n + 1 =>
+      addIsoOfPred e b (-(n : ℤ)) (-((n + 1 : ℕ) : ℤ)) (by push_cast; ring)
+        (equivPowSubNatIso e b n)
+
+/-- **Additivity of the integer powers of an autoequivalence**: `e ^ (a + b) ≅ e ^ a ⋙ e ^ b`. -/
+def equivPowAddIso (e : C ≌ C) : ∀ a b : ℤ,
+    (e ^ (a + b)).functor ≅ (e ^ a).functor ⋙ (e ^ b).functor
+  | Int.ofNat n, b => equivPowAddNatIso e b n
+  | Int.negSucc n, b => equivPowSubNatIso e b (n + 1)
+
+/-- **The opposite-handed successor isomorphism `e ^ (j + 1) ≅ e ^ j ⋙ e`.** -/
+def equivPowSuccRightIso (e : C ≌ C) (j : ℤ) :
+    (e ^ (j + 1)).functor ≅ (e ^ j).functor ⋙ e.functor :=
+  equivPowAddIso e j 1
+
+end TauCeti


### PR DESCRIPTION
This PR proves the two generating shift identities of the graded Ext-Euler characteristic:
`χ_q(X, Y{1}) = q · χ_q(X, Y)` and `χ_q(X{1}, Y) = q⁻¹ · χ_q(X, Y)`, together with their
inverse-shift forms and the preservation of graded Euler-admissibility under the grading shift in
either variable. These are the identities named in the Layer 6 milestone bullet "q-Euler form" of
`TauCetiRoadmap/GrothendieckEulerForms/README.md` — "Prove `χ_q(rM,N)=bar(r)χ_q(M,N)` and
`χ_q(M,rN)=rχ_q(M,N)`, including the generating identities for shifts" — and they are exactly the
two equations the roadmap's "A minimal graded check" acceptance example demands
(`χ_q(M{1},M)=q⁻¹χ_q(M,M)` and `χ_q(M,M{1})=qχ_q(M,M)`). They also fix the handedness of the
internal grading, which the landed `TauCeti.gradedExtEuler` records only through its target-shift
convention.

`TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Graded/Shift.lean` supplies the reindexing
isomorphisms `Ext^{n,j}(X, Y{1}) ≃ₗ[k] Ext^{n,j+1}(X, Y)` and
`Ext^{n,j}(X{1}, Y) ≃ₗ[k] Ext^{n,j-1}(X, Y)`, transports the three admissibility predicates of
`TauCeti.IsGradedEulerAdmissible` along the shift, and then reads the identities off the
target-shift graded dimension one cohomological degree at a time. The two conditions of graded
Euler-admissibility stay separate throughout, as the roadmap requires: finite internal support is
moved by a reindexing of the Laurent support, the uniform cohomological bound by a subsingleton
transport. `k`-linearity of the shift is assumed only for the first-variable identity and only
where it is genuinely needed: that proof compares `Ext` groups with different sources, and an
additive isomorphism of `k`-vector spaces need not preserve dimension, so an additive shift would
not suffice.

Two prerequisites did not exist and are supplied here. `TauCeti/CategoryTheory/Equivalence/Pow.lean`
compares `e ^ (a + b)` with `e ^ a ⋙ e ^ b` for an autoequivalence `e : C ≌ C`; Mathlib defines
`Equivalence.pow` and records `e ^ 0`, `e ^ 1` and `e ^ (-1)`, but leaves this comparison as an
explicit TODO in `Mathlib/CategoryTheory/Equivalence.lean`, and `TauCeti.GradedExt` is indexed by
those powers, so no shift statement about it is expressible without them. Only the underlying
functors are compared, since the recursion inserts unitors and the equivalences are not equal.
`TauCeti/Algebra/Homology/Ext/Equivalence.lean` proves that `Ext` is invariant under an additive
equivalence: Mathlib's `Ext.mapExactFunctor` is shown bijective only under a projective- or
injective-object hypothesis (`Functor.mapExt_bijective_of_preservesProjectiveObjects` and its
injective twin), whereas for an equivalence the inverse equivalence supplies the inverse map
directly, through Mathlib's `Ext.comp_mapExactFunctor`, `Ext.id_mapExactFunctor` and
`Ext.mapExactFunctor_comp_mk₀_natTransApp`. No Mathlib source is vendored.

What remains in that milestone bullet after this PR is the Laurent-coefficient packaging: descending
these identities to `TauCeti.LaurentK0` so that `χ_q` becomes a genuine `ℤ[q,q⁻¹]`-sesquilinear map
for `LaurentPolynomial.invert`, which additionally needs a graded exact structure on a shift-stable
extension-closed full subcategory before the preliminary biadditive pairing of
`TauCeti.gradedExtEulerPairing` can be upgraded.

Roadmap: GrothendieckEulerForms

<!--tauceti-target:v1 {"focus":"GrothendieckEulerForms","id":"graded-ext-euler-shift-identities"}-->

🤖 Prepared with Claude Code
