### PR TITLE
feat: close type-B spin root subgroups

### DIFF
--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/Basic.lean
@@ -223,7 +223,28 @@ noncomputable def rootSubgroup (k : Fin (n + 1) ⊕ Fin (n + 1)) :
     (TauCeti.typeBSimpleRootGeneratorFamily (K := ℚ))
     (TauCeti.typeBSimpleCorootGenerator (K := ℚ)) (rep n) (lattice n).toAddSubgroup
     (rep_kostantForm_mem_lattice n) (isNilpotent_rep_rootGenerator n)
-    (latticeBasis n) (basisWeight n) k
+    (latticeBasis n) (basisWeight n) k ≫
+  eqToHom (by rfl : kostantToralGroupScheme
+    (TauCeti.typeBSimpleRootGeneratorFamily (K := ℚ))
+    (TauCeti.typeBSimpleCorootGenerator (K := ℚ)) (rep n) (lattice n).toAddSubgroup
+    (rep_kostantForm_mem_lattice n) (isNilpotent_rep_rootGenerator n)
+    (latticeBasis n) (basisWeight n) = groupScheme n)
+
+/-- The numbered root subgroup is the generic Kostant root subgroup factored through the toral
+closure at the type-`Bₙ₊₁` spin data. -/
+theorem rootSubgroup_def (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    rootSubgroup n k =
+      kostantRootSubgroupToToral
+        (TauCeti.typeBSimpleRootGeneratorFamily (K := ℚ))
+        (TauCeti.typeBSimpleCorootGenerator (K := ℚ)) (rep n) (lattice n).toAddSubgroup
+        (rep_kostantForm_mem_lattice n) (isNilpotent_rep_rootGenerator n)
+        (latticeBasis n) (basisWeight n) k ≫
+      eqToHom (by rfl : kostantToralGroupScheme
+        (TauCeti.typeBSimpleRootGeneratorFamily (K := ℚ))
+        (TauCeti.typeBSimpleCorootGenerator (K := ℚ)) (rep n) (lattice n).toAddSubgroup
+        (rep_kostantForm_mem_lattice n) (isNilpotent_rep_rootGenerator n)
+        (latticeBasis n) (basisWeight n) = groupScheme n) := by
+  rw [rootSubgroup]
 
 /-- Including a root subgroup into the ambient general linear group gives its exponential. -/
 @[simp]

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/ClosedRootSubgroup.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/ClosedRootSubgroup.lean
@@ -19,12 +19,12 @@ The spin representation makes the required unit matrix coefficient explicit. At 
 node, the raising and lowering operators move an exterior singleton between two adjacent
 coordinates. At the terminal short node, they create or annihilate the final coordinate, with the
 distinguished remainder vector acting by exterior parity. The generic Kostant root-subgroup
-criterion then makes the coordinate map surjective.
+criterion then makes the coordinate-ring homomorphism surjective.
 
 ## Main declarations
 
 * `TauCeti.TypeBSpinCarrier.rootSubgroupCoordinateMap_surjective`: every numbered root-subgroup
-  coordinate map is surjective.
+  coordinate-ring homomorphism is surjective.
 * `TauCeti.TypeBSpinCarrier.isClosedImmersion_rootSubgroup`: every numbered root subgroup is a
   closed immersion.
 * `TauCeti.TypeBSpinCarrier.rootSubgroupClosedSubgroup`: the corresponding closed subgroup scheme.
@@ -37,7 +37,7 @@ criterion then makes the coordinate map surjective.
 * J. E. Humphreys, *Linear Algebraic Groups*, Section 26.
 * R. W. Carter, *Simple Groups of Lie Type*, Sections 4.4 and 7.1.
 * `TauCeti.Algebra.Lie.Orthogonal.TypeD.SpinCarrier.ClosedRootSubgroup`, for the corresponding
-  type-`D` proof organization.
+  type-`D` closed-root-subgroup construction.
 -/
 
 public section
@@ -126,7 +126,8 @@ private theorem rep_rootGenerator_sq_apply_latticeBasis
 
 /-! ## Closed root-subgroup morphisms -/
 
-/-- The coordinate morphism of every numbered type-`Bₙ₊₁` spin root subgroup is surjective. -/
+/-- The coordinate-ring homomorphism of every numbered type-`Bₙ₊₁` spin root subgroup is
+surjective. -/
 theorem rootSubgroupCoordinateMap_surjective
     (k : Fin (n + 1) ⊕ Fin (n + 1)) :
     Function.Surjective

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/ClosedRootSubgroup.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/ClosedRootSubgroup.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.Orthogonal.TypeB.SpinCarrier.Basic
+public import
+  TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.RootInToral
+
+/-!
+# Closed root subgroups of the type-B spin carrier
+
+For every Bourbaki node of type `Bₙ₊₁`, the raising and lowering root-subgroup maps into
+`TauCeti.TypeBSpinCarrier.groupScheme n` are closed copies of the additive group scheme.
+
+The spin representation makes the required unit matrix coefficient explicit. At a nonterminal
+node, the raising and lowering operators move an exterior singleton between two adjacent
+coordinates. At the terminal short node, they create or annihilate the final coordinate, with the
+distinguished remainder vector acting by exterior parity. The generic Kostant root-subgroup
+criterion then makes the coordinate map surjective.
+
+## Main declarations
+
+* `TauCeti.TypeBSpinCarrier.rootSubgroupCoordinateMap_surjective`: every numbered root-subgroup
+  coordinate map is surjective.
+* `TauCeti.TypeBSpinCarrier.isClosedImmersion_rootSubgroup`: every numbered root subgroup is a
+  closed immersion.
+* `TauCeti.TypeBSpinCarrier.rootSubgroupClosedSubgroup`: the corresponding closed subgroup scheme.
+* `TauCeti.TypeBSpinCarrier.rootSubgroupClosedSubgroupIso`: its canonical isomorphism with the
+  additive group scheme.
+
+## References
+
+* C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
+* J. E. Humphreys, *Linear Algebraic Groups*, Section 26.
+* R. W. Carter, *Simple Groups of Lie Type*, Sections 4.4 and 7.1.
+* `TauCeti.Algebra.Lie.Orthogonal.TypeD.SpinCarrier.ClosedRootSubgroup`, for the corresponding
+  type-`D` proof organization.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory CliffordAlgebra
+
+namespace TauCeti.TypeBSpinCarrier
+
+noncomputable section
+
+variable (n : ℕ)
+
+/-! ## Unit-coefficient exterior-basis steps -/
+
+private noncomputable def basisIndex (s : Finset (Fin (n + 1))) : Fin (dimension n) :=
+  Fintype.equivFin (Finset (Fin (n + 1))) s
+
+@[simp]
+private theorem signSet_basisIndex (s : Finset (Fin (n + 1))) :
+    signSet n (basisIndex n s) = s := by
+  simp [basisIndex, signSet]
+
+private def rootSourceSet :
+    Fin (n + 1) ⊕ Fin (n + 1) → Finset (Fin (n + 1))
+  | .inl i => Fin.lastCases ∅ (fun j => {j.succ}) i
+  | .inr i => Fin.lastCases {Fin.last n} (fun j => {j.castSucc}) i
+
+private def rootTargetSet :
+    Fin (n + 1) ⊕ Fin (n + 1) → Finset (Fin (n + 1))
+  | .inl i => Fin.lastCases {Fin.last n} (fun j => {j.castSucc}) i
+  | .inr i => Fin.lastCases ∅ (fun j => {j.succ}) i
+
+private theorem rep_rootGenerator_latticeBasis
+    (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    rep n (_root_.UniversalEnvelopingAlgebra.ι ℚ
+        (TauCeti.typeBSimpleRootGeneratorFamily k))
+        ((latticeBasis n (basisIndex n (rootSourceSet n k)) : lattice n) :
+          ExteriorAlgebra ℚ (polarization n).W) =
+      (1 : ℤ) •
+        ((latticeBasis n (basisIndex n (rootTargetSet n k)) : lattice n) :
+          ExteriorAlgebra ℚ (polarization n).W) := by
+  cases k with
+  | inl i =>
+      refine Fin.lastCases ?_ (fun j => ?_) i
+      · simpa only [coe_latticeBasis, signSet_basisIndex, rootSourceSet,
+          rootTargetSet, Fin.lastCases_last, one_zsmul] using
+          (polarization n).typeBSpinRep_simpleRootGenerator_last_exteriorBasis_empty
+            (polarizationBasis n) (remainderOne n)
+            (TauCeti.splitOddForm_remainderOne ℚ (n + 1))
+            (TauCeti.splitOddPolarization_lineCoordinate_remainderOne ℚ (n + 1))
+      · simpa only [coe_latticeBasis, signSet_basisIndex, rootSourceSet,
+          rootTargetSet, Fin.lastCases_castSucc, one_zsmul] using
+          (polarization n).typeBSpinRep_simpleRootGenerator_castSucc_exteriorBasis_singleton
+            (polarizationBasis n) (remainderOne n)
+            (TauCeti.splitOddForm_remainderOne ℚ (n + 1)) j
+  | inr i =>
+      refine Fin.lastCases ?_ (fun j => ?_) i
+      · simpa only [coe_latticeBasis, signSet_basisIndex, rootSourceSet,
+          rootTargetSet, Fin.lastCases_last, one_zsmul] using
+          (polarization n).typeBSpinRep_simpleNegativeRootGenerator_last_exteriorBasis_singleton
+            (polarizationBasis n) (remainderOne n)
+            (TauCeti.splitOddForm_remainderOne ℚ (n + 1))
+            (TauCeti.splitOddPolarization_lineCoordinate_remainderOne ℚ (n + 1))
+      · simpa only [coe_latticeBasis, signSet_basisIndex, rootSourceSet,
+          rootTargetSet, Fin.lastCases_castSucc, one_zsmul] using
+          (polarization n).typeBSpinRep_simpleNegativeRootGenerator_castSucc_exteriorBasis_singleton
+            (polarizationBasis n) (remainderOne n)
+            (TauCeti.splitOddForm_remainderOne ℚ (n + 1)) j
+
+private theorem rep_rootGenerator_sq_apply_latticeBasis
+    (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    rep n (_root_.UniversalEnvelopingAlgebra.ι ℚ
+        (TauCeti.typeBSimpleRootGeneratorFamily k))
+      (rep n (_root_.UniversalEnvelopingAlgebra.ι ℚ
+          (TauCeti.typeBSimpleRootGeneratorFamily k))
+        ((latticeBasis n (basisIndex n (rootSourceSet n k)) : lattice n) :
+          ExteriorAlgebra ℚ (polarization n).W)) = 0 := by
+  have h := congrArg
+    (fun f : Module.End ℚ (ExteriorAlgebra ℚ (polarization n).W) =>
+      f ((latticeBasis n (basisIndex n (rootSourceSet n k)) : lattice n) :
+        ExteriorAlgebra ℚ (polarization n).W))
+    ((polarization n).typeBSpinRep_simpleRootGenerator_sq
+      (polarizationBasis n) (remainderOne n)
+      (TauCeti.splitOddForm_remainderOne ℚ (n + 1)) k)
+  simpa only [rep, pow_two, Module.End.mul_apply, LinearMap.zero_apply] using h
+
+/-! ## Closed root-subgroup morphisms -/
+
+/-- The coordinate morphism of every numbered type-`Bₙ₊₁` spin root subgroup is surjective. -/
+theorem rootSubgroupCoordinateMap_surjective
+    (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    Function.Surjective
+      (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap
+        (TauCeti.typeBSimpleRootGeneratorFamily (K := ℚ))
+        (TauCeti.typeBSimpleCorootGenerator (K := ℚ)) (rep n) (lattice n).toAddSubgroup
+        (rep_kostantForm_mem_lattice n) (isNilpotent_rep_rootGenerator n)
+        (latticeBasis n) (basisWeight n) k).hom :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap_surjective
+    (TauCeti.typeBSimpleRootGeneratorFamily (K := ℚ))
+    (TauCeti.typeBSimpleCorootGenerator (K := ℚ)) (rep n) (lattice n).toAddSubgroup
+    (rep_kostantForm_mem_lattice n) k (isNilpotent_rep_rootGenerator n)
+    (latticeBasis n) (basisWeight n) isUnit_one
+    (rep_rootGenerator_latticeBasis n k)
+    (rep_rootGenerator_sq_apply_latticeBasis n k)
+
+/-- Every numbered root-subgroup map into the type-`Bₙ₊₁` spin carrier is a closed immersion. -/
+instance isClosedImmersion_rootSubgroup (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    IsClosedImmersion (rootSubgroup n k).hom.hom.left := by
+  have hroot :=
+    TauCeti.UniversalEnvelopingAlgebra.isClosedImmersion_kostantRootSubgroupToToral
+    (TauCeti.typeBSimpleRootGeneratorFamily (K := ℚ))
+    (TauCeti.typeBSimpleCorootGenerator (K := ℚ)) (rep n) (lattice n).toAddSubgroup
+    (rep_kostantForm_mem_lattice n) k (isNilpotent_rep_rootGenerator n)
+    (latticeBasis n) (basisWeight n) isUnit_one
+    (rep_rootGenerator_latticeBasis n k)
+    (rep_rootGenerator_sq_apply_latticeBasis n k)
+  rw [← closedSubgroupMorphismProperty_iff
+    (Spec (CommRingCat.of ℤ)) (rootSubgroup n k), rootSubgroup_def,
+    (closedSubgroupMorphismProperty (Spec (CommRingCat.of ℤ))).cancel_right_of_respectsIso]
+  exact (closedSubgroupMorphismProperty_iff _ _).2 hroot
+
+/-- Every numbered root-subgroup map into the type-`Bₙ₊₁` spin carrier is a monomorphism. -/
+theorem mono_rootSubgroup (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    Mono (rootSubgroup n k) :=
+  mono_of_isClosedImmersion_underlying (rootSubgroup n k)
+
+/-- A numbered type-`Bₙ₊₁` spin root subgroup, bundled as a closed subgroup scheme. -/
+noncomputable def rootSubgroupClosedSubgroup
+    (k : Fin (n + 1) ⊕ Fin (n + 1)) : ClosedSubgroupScheme (groupScheme n) :=
+  ClosedSubgroupScheme.mk (rootSubgroup n k)
+
+/-- The bundled closed root subgroup is represented by the numbered root-subgroup morphism. -/
+@[simp]
+theorem coe_rootSubgroupClosedSubgroup
+    (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    (rootSubgroupClosedSubgroup n k).1 =
+      letI := mono_rootSubgroup n k
+      Subobject.mk (rootSubgroup n k) := by
+  exact ClosedSubgroupScheme.coe_mk _
+
+/-- The bundled numbered root subgroup is canonically isomorphic to the additive group scheme. -/
+noncomputable def rootSubgroupClosedSubgroupIso
+    (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    ((rootSubgroupClosedSubgroup n k).1 :
+      Grp (Over (Spec (CommRingCat.of ℤ)))) ≅ AdditiveGroup.groupScheme ℤ :=
+  ClosedSubgroupScheme.mkIso (rootSubgroup n k)
+
+/-- The canonical parametrization followed by inclusion is the numbered root-subgroup map. -/
+@[simp]
+theorem rootSubgroupClosedSubgroupIso_inv_comp_arrow
+    (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    (rootSubgroupClosedSubgroupIso n k).inv ≫
+        (rootSubgroupClosedSubgroup n k).1.arrow =
+      rootSubgroup n k :=
+  ClosedSubgroupScheme.mkIso_inv_comp_arrow (rootSubgroup n k)
+
+end
+
+end TauCeti.TypeBSpinCarrier

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Split/Odd.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Split/Odd.lean
@@ -298,6 +298,13 @@ theorem coe_splitOddRemainderOne (K : Type u) [CommRing K] (n : ℕ) :
     (splitOddRemainderOne K n : SplitOddSpace K n) = ((0, 0), 1) := by
   rw [splitOddRemainderOne]
 
+/-- The distinguished remainder vector has scalar coordinate one. -/
+@[simp]
+theorem splitOddPolarization_lineCoordinate_remainderOne
+    (K : Type u) [CommRing K] (n : ℕ) :
+    (splitOddPolarization K n).lineCoordinate (splitOddRemainderOne K n) = 1 := by
+  rfl
+
 /-- The distinguished remainder vector has quadratic norm one. -/
 theorem splitOddForm_remainderOne (K : Type u) [CommRing K] (n : ℕ) :
     splitOddForm K n (splitOddRemainderOne K n : SplitOddSpace K n) = 1 := by

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeB/KostantLattice.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeB/KostantLattice.lean
@@ -116,6 +116,79 @@ theorem typeBSpinRep_simpleRootGenerator_sq (k : Fin (n + 1) ⊕ Fin (n + 1)) :
       rw [typeBSimpleRootGeneratorFamily_inr, ← pow_two,
         P.typeBQuadraticEquiv_typeBSimpleNegativeRootGenerator_mul_self b z hz i, map_zero]
 
+/-- A nonterminal positive simple-root operator moves the next exterior singleton one coordinate
+to the left. -/
+theorem typeBSpinRep_simpleRootGenerator_castSucc_exteriorBasis_singleton (j : Fin n) :
+    P.typeBSpinRep b z hz
+        (_root_.UniversalEnvelopingAlgebra.ι K
+          (typeBSimpleRootGeneratorFamily (.inl j.castSucc)))
+        (b.ExteriorAlgebra {j.succ}) =
+      b.ExteriorAlgebra {j.castSucc} := by
+  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
+    typeBSimpleRootGeneratorFamily_inl, typeBSimpleRootGenerator_castSucc,
+    P.typeBQuadraticEquiv_typeBLongRootGenerator b z hz,
+    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_basis_dualVector b
+      (ne_of_lt j.castSucc_lt_succ)), map_mul, Module.End.mul_apply,
+    spinAction_ι_wedge, spinAction_ι_contract, P.pairingEquiv_dualVector,
+    TauCeti.ExteriorAlgebra.basis_singleton, CliffordAlgebra.contractLeft_ι]
+  simp [TauCeti.ExteriorAlgebra.basis_singleton]
+
+/-- A nonterminal negative simple-root operator moves an exterior singleton one coordinate to the
+right. -/
+theorem typeBSpinRep_simpleNegativeRootGenerator_castSucc_exteriorBasis_singleton (j : Fin n) :
+    P.typeBSpinRep b z hz
+        (_root_.UniversalEnvelopingAlgebra.ι K
+          (typeBSimpleRootGeneratorFamily (.inr j.castSucc)))
+        (b.ExteriorAlgebra {j.castSucc}) =
+      b.ExteriorAlgebra {j.succ} := by
+  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
+    typeBSimpleRootGeneratorFamily_inr, typeBSimpleNegativeRootGenerator_castSucc,
+    P.typeBQuadraticEquiv_typeBLongRootGenerator b z hz,
+    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_basis_dualVector b
+      (ne_of_gt j.castSucc_lt_succ)), map_mul, Module.End.mul_apply,
+    spinAction_ι_wedge, spinAction_ι_contract, P.pairingEquiv_dualVector,
+    TauCeti.ExteriorAlgebra.basis_singleton, CliffordAlgebra.contractLeft_ι]
+  simp [TauCeti.ExteriorAlgebra.basis_singleton]
+
+/-- The terminal positive short-root operator creates the final exterior coordinate from the
+vacuum when the distinguished remainder vector has coordinate one. -/
+theorem typeBSpinRep_simpleRootGenerator_last_exteriorBasis_empty
+    (hcoord : P.lineCoordinate z = 1) :
+    P.typeBSpinRep b z hz
+        (_root_.UniversalEnvelopingAlgebra.ι K
+          (typeBSimpleRootGeneratorFamily (.inl (Fin.last n))))
+        (b.ExteriorAlgebra ∅) =
+      b.ExteriorAlgebra {Fin.last n} := by
+  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
+    typeBSimpleRootGeneratorFamily_inl, typeBSimpleRootGenerator_last,
+    P.typeBQuadraticEquiv_typeBShortRootGenerator b z hz,
+    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_W_line _ z), map_mul,
+    Module.End.mul_apply, spinAction_ι_wedge, spinAction_ι_lineOperator, hcoord,
+    TauCeti.ExteriorAlgebra.involute_basis]
+  have hEmpty : b.ExteriorAlgebra (∅ : Finset (Fin (n + 1))) = 1 := by
+    rw [ExteriorAlgebra.basis_apply]
+    simp
+  simp only [Finset.card_empty, pow_zero, one_smul]
+  rw [hEmpty, mul_one, TauCeti.ExteriorAlgebra.basis_singleton]
+
+/-- The terminal negative short-root operator annihilates the final exterior coordinate to the
+vacuum when the distinguished remainder vector has coordinate one. -/
+theorem typeBSpinRep_simpleNegativeRootGenerator_last_exteriorBasis_singleton
+    (hcoord : P.lineCoordinate z = 1) :
+    P.typeBSpinRep b z hz
+        (_root_.UniversalEnvelopingAlgebra.ι K
+          (typeBSimpleRootGeneratorFamily (.inr (Fin.last n))))
+        (b.ExteriorAlgebra {Fin.last n}) =
+      b.ExteriorAlgebra ∅ := by
+  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
+    typeBSimpleRootGeneratorFamily_inr, typeBSimpleNegativeRootGenerator_last,
+    P.typeBQuadraticEquiv_typeBShortNegativeRootGenerator b z hz,
+    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_line_W' z _), map_mul,
+    Module.End.mul_apply, spinAction_ι_contract, P.pairingEquiv_dualVector,
+    TauCeti.ExteriorAlgebra.basis_singleton, CliffordAlgebra.contractLeft_ι,
+    spinAction_ι_lineOperator, hcoord]
+  simp [ExteriorAlgebra.basis_apply]
+
 /-! ## The weights of the simple coroots -/
 
 /-- The integral eigenvalue of a numbered simple coroot on an exterior-basis vector. -/

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeB/KostantLattice.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeB/KostantLattice.lean
@@ -116,6 +116,41 @@ theorem typeBSpinRep_simpleRootGenerator_sq (k : Fin (n + 1) ⊕ Fin (n + 1)) :
       rw [typeBSimpleRootGeneratorFamily_inr, ← pow_two,
         P.typeBQuadraticEquiv_typeBSimpleNegativeRootGenerator_mul_self b z hz i, map_zero]
 
+private theorem typeBSpinRep_longRootGenerator_apply (i j : Fin (n + 1)) (hij : i ≠ j)
+    (x : ExteriorAlgebra K P.W) :
+    P.typeBSpinRep b z hz
+        (_root_.UniversalEnvelopingAlgebra.ι K (typeBLongRootGenerator i j hij)) x =
+      ExteriorAlgebra.ι K (b i) *
+        CliffordAlgebra.contractLeft (b.coord j) x := by
+  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
+    P.typeBQuadraticEquiv_typeBLongRootGenerator b z hz,
+    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_basis_dualVector b hij), map_mul,
+    Module.End.mul_apply, spinAction_ι_wedge, spinAction_ι_contract,
+    P.pairingEquiv_dualVector]
+
+private theorem typeBSpinRep_shortRootGenerator_apply (i : Fin (n + 1))
+    (x : ExteriorAlgebra K P.W) :
+    P.typeBSpinRep b z hz
+        (_root_.UniversalEnvelopingAlgebra.ι K (typeBShortRootGenerator i)) x =
+      ExteriorAlgebra.ι K (b i) *
+        (P.lineCoordinate z • CliffordAlgebra.involute x) := by
+  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
+    P.typeBQuadraticEquiv_typeBShortRootGenerator b z hz,
+    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_W_line _ z), map_mul,
+    Module.End.mul_apply, spinAction_ι_wedge, spinAction_ι_lineOperator]
+
+private theorem typeBSpinRep_shortNegativeRootGenerator_apply (i : Fin (n + 1))
+    (x : ExteriorAlgebra K P.W) :
+    P.typeBSpinRep b z hz
+        (_root_.UniversalEnvelopingAlgebra.ι K (typeBShortNegativeRootGenerator i)) x =
+      P.lineCoordinate z • CliffordAlgebra.involute
+        (CliffordAlgebra.contractLeft (b.coord i) x) := by
+  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
+    P.typeBQuadraticEquiv_typeBShortNegativeRootGenerator b z hz,
+    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_line_W' z _), map_mul,
+    Module.End.mul_apply, spinAction_ι_contract, P.pairingEquiv_dualVector,
+    spinAction_ι_lineOperator]
+
 /-- A nonterminal positive simple-root operator moves the next exterior singleton one coordinate
 to the left. -/
 theorem typeBSpinRep_simpleRootGenerator_castSucc_exteriorBasis_singleton (j : Fin n) :
@@ -124,12 +159,8 @@ theorem typeBSpinRep_simpleRootGenerator_castSucc_exteriorBasis_singleton (j : F
           (typeBSimpleRootGeneratorFamily (.inl j.castSucc)))
         (b.ExteriorAlgebra {j.succ}) =
       b.ExteriorAlgebra {j.castSucc} := by
-  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
-    typeBSimpleRootGeneratorFamily_inl, typeBSimpleRootGenerator_castSucc,
-    P.typeBQuadraticEquiv_typeBLongRootGenerator b z hz,
-    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_basis_dualVector b
-      (ne_of_lt j.castSucc_lt_succ)), map_mul, Module.End.mul_apply,
-    spinAction_ι_wedge, spinAction_ι_contract, P.pairingEquiv_dualVector,
+  rw [typeBSimpleRootGeneratorFamily_inl, typeBSimpleRootGenerator_castSucc,
+    P.typeBSpinRep_longRootGenerator_apply b z hz,
     TauCeti.ExteriorAlgebra.basis_singleton, CliffordAlgebra.contractLeft_ι]
   simp [TauCeti.ExteriorAlgebra.basis_singleton]
 
@@ -141,12 +172,8 @@ theorem typeBSpinRep_simpleNegativeRootGenerator_castSucc_exteriorBasis_singleto
           (typeBSimpleRootGeneratorFamily (.inr j.castSucc)))
         (b.ExteriorAlgebra {j.castSucc}) =
       b.ExteriorAlgebra {j.succ} := by
-  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
-    typeBSimpleRootGeneratorFamily_inr, typeBSimpleNegativeRootGenerator_castSucc,
-    P.typeBQuadraticEquiv_typeBLongRootGenerator b z hz,
-    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_basis_dualVector b
-      (ne_of_gt j.castSucc_lt_succ)), map_mul, Module.End.mul_apply,
-    spinAction_ι_wedge, spinAction_ι_contract, P.pairingEquiv_dualVector,
+  rw [typeBSimpleRootGeneratorFamily_inr, typeBSimpleNegativeRootGenerator_castSucc,
+    P.typeBSpinRep_longRootGenerator_apply b z hz,
     TauCeti.ExteriorAlgebra.basis_singleton, CliffordAlgebra.contractLeft_ι]
   simp [TauCeti.ExteriorAlgebra.basis_singleton]
 
@@ -159,11 +186,8 @@ theorem typeBSpinRep_simpleRootGenerator_last_exteriorBasis_empty
           (typeBSimpleRootGeneratorFamily (.inl (Fin.last n))))
         (b.ExteriorAlgebra ∅) =
       b.ExteriorAlgebra {Fin.last n} := by
-  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
-    typeBSimpleRootGeneratorFamily_inl, typeBSimpleRootGenerator_last,
-    P.typeBQuadraticEquiv_typeBShortRootGenerator b z hz,
-    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_W_line _ z), map_mul,
-    Module.End.mul_apply, spinAction_ι_wedge, spinAction_ι_lineOperator, hcoord,
+  rw [typeBSimpleRootGeneratorFamily_inl, typeBSimpleRootGenerator_last,
+    P.typeBSpinRep_shortRootGenerator_apply b z hz, hcoord,
     TauCeti.ExteriorAlgebra.involute_basis]
   have hEmpty : b.ExteriorAlgebra (∅ : Finset (Fin (n + 1))) = 1 := by
     rw [ExteriorAlgebra.basis_apply]
@@ -180,13 +204,10 @@ theorem typeBSpinRep_simpleNegativeRootGenerator_last_exteriorBasis_singleton
           (typeBSimpleRootGeneratorFamily (.inr (Fin.last n))))
         (b.ExteriorAlgebra {Fin.last n}) =
       b.ExteriorAlgebra ∅ := by
-  rw [_root_.UniversalEnvelopingAlgebra.ι_apply, P.typeBSpinRep_ι b z hz,
-    typeBSimpleRootGeneratorFamily_inr, typeBSimpleNegativeRootGenerator_last,
-    P.typeBQuadraticEquiv_typeBShortNegativeRootGenerator b z hz,
-    bivector_eq_ι_mul_ι_of_isOrtho Q (P.isOrtho_line_W' z _), map_mul,
-    Module.End.mul_apply, spinAction_ι_contract, P.pairingEquiv_dualVector,
+  rw [typeBSimpleRootGeneratorFamily_inr, typeBSimpleNegativeRootGenerator_last,
+    P.typeBSpinRep_shortNegativeRootGenerator_apply b z hz,
     TauCeti.ExteriorAlgebra.basis_singleton, CliffordAlgebra.contractLeft_ι,
-    spinAction_ι_lineOperator, hcoord]
+    hcoord]
   simp [ExteriorAlgebra.basis_apply]
 
 /-! ## The weights of the simple coroots -/


### PR DESCRIPTION
This PR proves that every numbered positive and negative simple-root map of the full-weight type-`Bₙ₊₁` spin carrier is a closed immersion, bundles its image as a closed subgroup scheme, and identifies that subgroup canonically with `𝔾ₐ`. This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, targets “Pinnings” and “Root subgroup maps,” by supplying the closed-copy-of-`𝔾ₐ` part of the root-subgroup interface for the explicit type-`B` carrier consumed by the `Bₙ(q)` family of finite groups of Lie type.

The proof exhibits a unit coefficient in the spin exterior basis for every numbered generator. Nonterminal raising and lowering operators move a singleton between adjacent coordinates; the terminal short-root operators create or annihilate the final coordinate, using the distinguished odd remainder vector’s scalar coordinate one. The existing generic Kostant criterion then makes each coordinate-ring map surjective and hence each scheme morphism a closed immersion.

The new 199-line module `TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/ClosedRootSubgroup.lean` contains the scheme-level result. The directly consumed representation API adds the four simple-root exterior-basis computations, the scalar-coordinate normalization, and a characteristic equation for the carrier’s root-subgroup definition. No Mathlib infrastructure is vendored. The declaration order and scheme-level proof organization adapt `TauCeti.Algebra.Lie.Orthogonal.TypeD.SpinCarrier.ClosedRootSubgroup`; the module also cites Chevalley, Humphreys, and Carter for the spin and root-subgroup mathematics.

After this PR, the Layer 9 type-`B` path still needs the all-root Kostant comparison and commutator interface, a Borel, reductivity, maximal-torus and simply-connected identifications, and final attachment to the valid `Bₙ(q)` indices; base change and Frobenius are already in flight separately.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-b-spin-closed-root-subgroups"}-->

🤖 Prepared with Codex
