### PR TITLE
feat: the Rayleigh characterisation of the first Dirichlet eigenvalue

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/LaxMilgram.lean
+++ b/TauCeti/Analysis/InnerProductSpace/LaxMilgram.lean
@@ -45,15 +45,17 @@ open scoped InnerProductSpace
 
 namespace IsCoercive
 
-variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [CompleteSpace V]
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
 variable {B : V →L[ℝ] V →L[ℝ] ℝ}
 
-omit [CompleteSpace V] in
 /-- A coercive form has nonnegative diagonal. -/
 theorem apply_self_nonneg (hB : IsCoercive B) (v : V) : 0 ≤ B v v := by
   obtain ⟨C, hC, hle⟩ := id hB
   refine le_trans ?_ (hle v)
   positivity
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [CompleteSpace V]
+variable {B : V →L[ℝ] V →L[ℝ] ℝ}
 
 /-- The solution supplied by Lax--Milgram for a represented forcing functional.
 

--- a/TauCeti/Analysis/InnerProductSpace/LaxMilgram.lean
+++ b/TauCeti/Analysis/InnerProductSpace/LaxMilgram.lean
@@ -25,6 +25,7 @@ bundled structure.
 
 * `IsCoercive.solutionOfInner`: the solution of the variational equation with forcing
   represented by `F`.
+* `IsCoercive.apply_self_nonneg`: coercive forms have nonnegative diagonal.
 * `IsCoercive.apply_solutionOfInner_eq_inner`: the defining variational identity.
 * `IsCoercive.eq_solutionOfInner`: uniqueness of a vector satisfying the variational
   identity.
@@ -46,6 +47,13 @@ namespace IsCoercive
 
 variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [CompleteSpace V]
 variable {B : V →L[ℝ] V →L[ℝ] ℝ}
+
+omit [CompleteSpace V] in
+/-- A coercive form has nonnegative diagonal. -/
+theorem apply_self_nonneg (hB : IsCoercive B) (v : V) : 0 ≤ B v v := by
+  obtain ⟨C, hC, hle⟩ := id hB
+  refine le_trans ?_ (hle v)
+  positivity
 
 /-- The solution supplied by Lax--Milgram for a represented forcing functional.
 

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.InnerProductSpace.Variational.Spectrum
-public import Mathlib.LinearAlgebra.BilinearForm.Properties
 
 /-!
 # The Rayleigh principle for a coercive variational problem
@@ -96,8 +95,7 @@ theorem norm_apply_sq_le_norm_formSolutionOperator_mul (hB : IsCoercive B) (J : 
           mul_le_mul_of_nonneg_left ((hB.formSolutionOperator J).le_opNorm _) (norm_nonneg _)
       _ = ‖hB.formSolutionOperator J‖ * ‖J v‖ ^ 2 := by ring
   have hcs : B w v ^ 2 ≤ B w w * B v v :=
-    B.toBilinForm.apply_sq_le_of_symm hB.apply_self_nonneg
-      (LinearMap.BilinForm.isSymm_iff.mp (LinearMap.BilinForm.isSymm_def.2 hsymm)) w v
+    B.toBilinForm.apply_sq_le_of_symm hB.apply_self_nonneg ⟨hsymm⟩ w v
   rw [hwv] at hcs
   rcases eq_or_lt_of_le (norm_nonneg (J v)) with hzero | hpos
   · rw [← hzero]
@@ -112,9 +110,9 @@ theorem norm_apply_sq_le_norm_formSolutionOperator_mul (hB : IsCoercive B) (J : 
       _ = ‖hB.formSolutionOperator J‖ * B v v * ‖J v‖ ^ 2 := by ring
 
 /-- **The Rayleigh lower bound**: `‖S‖⁻¹ ‖J v‖² ≤ B v v` for every `v : V`.  For the Dirichlet
-problem this is the Poincaré inequality with the first eigenvalue as its constant.  Beyond
-coercivity, only symmetry is needed: when `S = 0` the left-hand side vanishes and the bound is the
-nonnegativity of the energy. -/
+problem this is the Poincaré inequality with the reciprocal solution-operator norm as its
+constant.  Beyond coercivity, only symmetry is needed: when `S = 0` the left-hand side vanishes
+and the bound is the nonnegativity of the energy. -/
 theorem inv_norm_formSolutionOperator_mul_norm_apply_sq_le (hB : IsCoercive B) (J : V →L[ℝ] H)
     (hsymm : ∀ u v : V, B u v = B v u) (v : V) :
     ‖hB.formSolutionOperator J‖⁻¹ * ‖J v‖ ^ 2 ≤ B v v := by
@@ -143,10 +141,11 @@ theorem isLeast_rayleighQuotient (hB : IsCoercive B) {J : V →L[ℝ] H} (hJ : I
     rw [le_div_iff₀ (by positivity : (0 : ℝ) < ‖J v‖ ^ 2)]
     exact hB.inv_norm_formSolutionOperator_mul_norm_apply_sq_le J hsymm v
 
-/-- **The first variational eigenvalue is the optimal constant** in the inequality
+/-- **The reciprocal solution-operator norm is the optimal constant** in the inequality
 `C ‖J v‖² ≤ B v v`: it satisfies the inequality, and no larger constant does.  For the Dirichlet
-problem this identifies the first eigenvalue with the best Poincaré constant.  Unlike attainment
-of the Rayleigh minimum, this characterization does not require compactness of `J`. -/
+problem this identifies the quantity defined as `firstDirichletEigenvalue` with the best Poincaré
+constant.  Unlike attainment of the Rayleigh minimum, this characterization does not require
+compactness of `J`. -/
 theorem isGreatest_inv_norm_formSolutionOperator (hB : IsCoercive B) {J : V →L[ℝ] H}
     (hsymm : ∀ u v : V, B u v = B v u) (hJne : J ≠ 0) :
     IsGreatest {C : ℝ | ∀ v : V, C * ‖J v‖ ^ 2 ≤ B v v} ‖hB.formSolutionOperator J‖⁻¹ := by
@@ -154,9 +153,9 @@ theorem isGreatest_inv_norm_formSolutionOperator (hB : IsCoercive B) {J : V →L
     simpa only [zero_apply] using DFunLike.ne_iff.mp hJne
   have _ : Nontrivial H := nontrivial_of_ne (J w) 0 hw
   set S := hB.formSolutionOperator J with hS
-  have hSne : S ≠ 0 := fun hzero =>
-    hw (inner_self_eq_zero.mp ((hB.formSolutionOperator_apply_eq_zero_iff J (J w)).mp
-      (by rw [← hS, hzero, zero_apply]) w))
+  have hSne : S ≠ 0 := by
+    rw [hS]
+    exact hB.formSolutionOperator_ne_zero hJne
   have hnorm_pos : 0 < ‖S‖ := norm_pos_iff.mpr hSne
   refine ⟨fun v => hB.inv_norm_formSolutionOperator_mul_norm_apply_sq_le J hsymm v, fun C hC => ?_⟩
   rcases le_or_gt C 0 with hCnonpos | hCpos

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.InnerProductSpace.Variational.Spectrum
-public import TauCeti.LinearAlgebra.BilinearForm.PosSemidef
+public import Mathlib.LinearAlgebra.BilinearForm.Properties
 
 /-!
 # The Rayleigh principle for a coercive variational problem
@@ -34,8 +34,8 @@ The lower bound `‖S‖⁻¹ ‖J v‖² ≤ B v v` needs no compactness and no
 `‖J v‖² = B w v` and `B w w = ⟪J v, S (J v)⟫ ≤ ‖S‖ ‖J v‖²`, and
 `(B w v)² ≤ B w w · B v v` closes the loop.  Coercivity enters only through the
 nonnegativity of the diagonal, which is what makes the energy form obey Cauchy--Schwarz;
-that inequality is `LinearMap.BilinForm.IsPosSemidef.sq_apply_le_mul_apply_self`, transferred
-to continuous bilinear forms here by
+that inequality is `LinearMap.BilinForm.apply_sq_le_of_symm`, transferred to continuous
+bilinear forms here by
 `ContinuousLinearMap.sq_apply_le_apply_self_mul_apply_self`.
 
 The *attainment* is where compactness enters: `‖S‖` is an eigenvalue of the compact symmetric
@@ -78,19 +78,16 @@ variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] {B : V →L[ℝ]
 
 /-- **Cauchy--Schwarz for a symmetric continuous bilinear form with nonnegative diagonal**:
 `(B u v)² ≤ B u u · B v v`.  This transfers
-`LinearMap.BilinForm.IsPosSemidef.sq_apply_le_mul_apply_self` — where the inequality is proved,
-by a discriminant, with no continuity in sight — to the bundled continuous bilinear forms that
-carry a variational problem. -/
+`LinearMap.BilinForm.apply_sq_le_of_symm` to the bundled continuous bilinear forms that carry a
+variational problem. -/
 theorem ContinuousLinearMap.sq_apply_le_apply_self_mul_apply_self
     (hsymm : ∀ u v : V, B u v = B v u) (hnonneg : ∀ w : V, 0 ≤ B w w) (u v : V) :
     B u v ^ 2 ≤ B u u * B v v := by
   let B' : LinearMap.BilinForm ℝ V :=
     LinearMap.mk₂ ℝ (fun u v => B u v) (fun _ _ _ => by simp) (fun _ _ _ => by simp)
       (fun _ _ _ => by simp) (fun _ _ _ => by simp)
-  have hB' : B'.IsPosSemidef :=
-    (LinearMap.BilinForm.isPosSemidef_iff_forall_nonneg B'
-      (LinearMap.BilinForm.isSymm_def.2 hsymm)).2 hnonneg
-  exact hB'.sq_apply_le_mul_apply_self u v
+  have hB'symm : B'.IsSymm := LinearMap.BilinForm.isSymm_def.2 hsymm
+  exact B'.apply_sq_le_of_symm hnonneg (LinearMap.BilinForm.isSymm_iff.mp hB'symm) u v
 
 end CauchySchwarz
 

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
@@ -1,0 +1,226 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.InnerProductSpace.Variational.Spectrum
+public import TauCeti.LinearAlgebra.BilinearForm.PosSemidef
+
+/-!
+# The Rayleigh principle for a coercive variational problem
+
+Let `B` be a bounded coercive symmetric bilinear form on a real Hilbert space `V` and let
+`J : V →L[ℝ] H` be a continuous linear map into a second real Hilbert space.  The **variational
+eigenvalues** of the pair are the reciprocals of the nonzero eigenvalues of the solution
+operator `S = IsCoercive.formSolutionOperator`, so the *least* variational eigenvalue is
+`‖S‖⁻¹`.  This file proves that this number is the minimum of the **Rayleigh quotient**
+
+`B v v / ‖J v‖²`,
+
+taken over the `v : V` with `J v ≠ 0`, and — the same statement read as an inequality — that it
+is the largest constant `C` for which `C ‖J v‖² ≤ B v v` holds for every `v : V`.
+
+For the Dirichlet problem of a divergence-form elliptic operator, with `V = H¹₀(Ω)`,
+`H = L²(Ω)` and `J` the inclusion, this says that the first eigenvalue is the minimum of the
+energy over the `L²`-unit sphere, and that it is exactly the optimal constant in the Poincaré
+inequality `C‖u‖²_{L²} ≤ a(u, u)`.
+
+## The two halves of the argument
+
+The lower bound `‖S‖⁻¹ ‖J v‖² ≤ B v v` needs no compactness and no attainment.  It comes from
+**Cauchy--Schwarz in the energy form**: solving `B w u = ⟪J v, J u⟫` for `w` gives
+`‖J v‖² = B w v` and `B w w = ⟪J v, S (J v)⟫ ≤ ‖S‖ ‖J v‖²`, and
+`(B w v)² ≤ B w w · B v v` closes the loop.  Coercivity enters only through the
+nonnegativity of the diagonal, which is what makes the energy form obey Cauchy--Schwarz;
+that inequality is `LinearMap.BilinForm.IsPosSemidef.sq_apply_le_mul_apply_self`, transferred
+to continuous bilinear forms here by
+`ContinuousLinearMap.sq_apply_le_apply_self_mul_apply_self`.
+
+The *attainment* is where compactness enters: `‖S‖` is an eigenvalue of the compact symmetric
+positive operator `S` (`IsCoercive.exists_ne_zero_forall_apply_eq_inv_norm_smul_inner`), and its
+eigenfunction realizes the quotient.  Without compactness the infimum can fail to be attained,
+so the `IsLeast`/`IsGreatest` statements carry `IsCompactOperator J` while the inequality does
+not.
+
+## Main declarations
+
+* `ContinuousLinearMap.sq_apply_le_apply_self_mul_apply_self`: Cauchy--Schwarz for a symmetric
+  continuous bilinear form with nonnegative diagonal.
+* `IsCoercive.norm_apply_sq_le_norm_formSolutionOperator_mul`: the estimate
+  `‖J v‖² ≤ ‖S‖ B v v`, and `IsCoercive.inv_norm_formSolutionOperator_mul_norm_apply_sq_le` its
+  reciprocal form `‖S‖⁻¹ ‖J v‖² ≤ B v v`.
+* `IsCoercive.exists_ne_zero_forall_apply_eq_inv_norm_smul_inner`: `‖S‖⁻¹` is a variational
+  eigenvalue, the least one.
+* `IsCoercive.isLeast_rayleighQuotient`: **the Rayleigh principle**, `‖S‖⁻¹` is the minimum of
+  the Rayleigh quotient.
+* `IsCoercive.isGreatest_setOf_forall_mul_norm_apply_sq_le`: `‖S‖⁻¹` is the optimal constant in
+  the inequality `C ‖J v‖² ≤ B v v`.
+
+## References
+
+L. C. Evans, *Partial Differential Equations*, Section 6.5.1, Theorem 2 (the variational
+principle for the principal eigenvalue); H. Brezis, *Functional Analysis, Sobolev Spaces and
+Partial Differential Equations*, Section 6.4.
+-/
+
+public section
+
+noncomputable section
+
+open Module.End
+open scoped InnerProduct InnerProductSpace
+
+section CauchySchwarz
+
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] {B : V →L[ℝ] V →L[ℝ] ℝ}
+
+/-- **Cauchy--Schwarz for a symmetric continuous bilinear form with nonnegative diagonal**:
+`(B u v)² ≤ B u u · B v v`.  This transfers
+`LinearMap.BilinForm.IsPosSemidef.sq_apply_le_mul_apply_self` — where the inequality is proved,
+by a discriminant, with no continuity in sight — to the bundled continuous bilinear forms that
+carry a variational problem. -/
+theorem ContinuousLinearMap.sq_apply_le_apply_self_mul_apply_self
+    (hsymm : ∀ u v : V, B u v = B v u) (hnonneg : ∀ w : V, 0 ≤ B w w) (u v : V) :
+    B u v ^ 2 ≤ B u u * B v v := by
+  let B' : LinearMap.BilinForm ℝ V :=
+    LinearMap.mk₂ ℝ (fun u v => B u v) (fun _ _ _ => by simp) (fun _ _ _ => by simp)
+      (fun _ _ _ => by simp) (fun _ _ _ => by simp)
+  have hB' : B'.IsPosSemidef :=
+    (LinearMap.BilinForm.isPosSemidef_iff_forall_nonneg B'
+      (LinearMap.BilinForm.isSymm_def.2 hsymm)).2 hnonneg
+  exact hB'.sq_apply_le_mul_apply_self u v
+
+end CauchySchwarz
+
+namespace IsCoercive
+
+variable {V H : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [CompleteSpace V]
+  [NormedAddCommGroup H] [InnerProductSpace ℝ H] [CompleteSpace H]
+  {B : V →L[ℝ] V →L[ℝ] ℝ}
+
+omit [CompleteSpace V] in
+/-- A coercive form has nonnegative diagonal. -/
+theorem apply_self_nonneg (hB : IsCoercive B) (v : V) : 0 ≤ B v v := by
+  obtain ⟨C, hC, hle⟩ := id hB
+  refine le_trans ?_ (hle v)
+  positivity
+
+/-! ### The Rayleigh lower bound -/
+
+/-- **The energy form dominates the `H`-norm, with constant the norm of the solution
+operator**: `‖J v‖² ≤ ‖S‖ · B v v`.  This is Cauchy--Schwarz in the energy form, applied to `v`
+and to the solution `w` of `B w u = ⟪J v, J u⟫`; no compactness of `J` is used. -/
+theorem norm_apply_sq_le_norm_formSolutionOperator_mul (hB : IsCoercive B) (J : V →L[ℝ] H)
+    (hsymm : ∀ u v : V, B u v = B v u) (v : V) :
+    ‖J v‖ ^ 2 ≤ ‖hB.formSolutionOperator J‖ * B v v := by
+  set w := hB.formSolutionMap J (J v) with hw
+  have hwv : B w v = ‖J v‖ ^ 2 := by
+    rw [hw, apply_formSolutionMap, real_inner_self_eq_norm_sq]
+  have hww : B w w ≤ ‖hB.formSolutionOperator J‖ * ‖J v‖ ^ 2 := by
+    have hself : B w w = ⟪J v, hB.formSolutionOperator J (J v)⟫_ℝ := by
+      rw [hw, apply_formSolutionMap, formSolutionOperator_apply]
+    calc B w w = ⟪J v, hB.formSolutionOperator J (J v)⟫_ℝ := hself
+      _ ≤ ‖J v‖ * ‖hB.formSolutionOperator J (J v)‖ := real_inner_le_norm _ _
+      _ ≤ ‖J v‖ * (‖hB.formSolutionOperator J‖ * ‖J v‖) :=
+          mul_le_mul_of_nonneg_left ((hB.formSolutionOperator J).le_opNorm _) (norm_nonneg _)
+      _ = ‖hB.formSolutionOperator J‖ * ‖J v‖ ^ 2 := by ring
+  have hcs : B w v ^ 2 ≤ B w w * B v v :=
+    ContinuousLinearMap.sq_apply_le_apply_self_mul_apply_self hsymm hB.apply_self_nonneg w v
+  rw [hwv] at hcs
+  rcases eq_or_lt_of_le (norm_nonneg (J v)) with hzero | hpos
+  · rw [← hzero]
+    have : (0 : ℝ) ≤ ‖hB.formSolutionOperator J‖ * B v v :=
+      mul_nonneg (norm_nonneg _) (hB.apply_self_nonneg v)
+    simpa using this
+  · refine le_of_mul_le_mul_right ?_ (by positivity : (0 : ℝ) < ‖J v‖ ^ 2)
+    calc ‖J v‖ ^ 2 * ‖J v‖ ^ 2 = (‖J v‖ ^ 2) ^ 2 := by ring
+      _ ≤ B w w * B v v := hcs
+      _ ≤ (‖hB.formSolutionOperator J‖ * ‖J v‖ ^ 2) * B v v :=
+          mul_le_mul_of_nonneg_right hww (hB.apply_self_nonneg v)
+      _ = ‖hB.formSolutionOperator J‖ * B v v * ‖J v‖ ^ 2 := by ring
+
+/-- **The Rayleigh lower bound**: `‖S‖⁻¹ ‖J v‖² ≤ B v v` for every `v : V`.  For the Dirichlet
+problem this is the Poincaré inequality with the first eigenvalue as its constant.  No
+hypothesis beyond symmetry is needed: when `S = 0` the left-hand side vanishes and the bound is
+the nonnegativity of the energy. -/
+theorem inv_norm_formSolutionOperator_mul_norm_apply_sq_le (hB : IsCoercive B) (J : V →L[ℝ] H)
+    (hsymm : ∀ u v : V, B u v = B v u) (v : V) :
+    ‖hB.formSolutionOperator J‖⁻¹ * ‖J v‖ ^ 2 ≤ B v v := by
+  rcases eq_or_lt_of_le (norm_nonneg (hB.formSolutionOperator J)) with hzero | hpos
+  · rw [← hzero]
+    simpa using hB.apply_self_nonneg v
+  · rw [inv_mul_le_iff₀ hpos]
+    linarith [hB.norm_apply_sq_le_norm_formSolutionOperator_mul J hsymm v]
+
+/-! ### Attainment at the first variational eigenvalue -/
+
+/-- **The reciprocal of the norm of the solution operator is a variational eigenvalue.**  It is
+the least one, by `IsCoercive.isLeast_rayleighQuotient`.  Compactness of `J` is what makes `‖S‖`
+itself an eigenvalue of `S`, and positivity of `S` is what excludes `-‖S‖`. -/
+theorem exists_ne_zero_forall_apply_eq_inv_norm_smul_inner (hB : IsCoercive B) {J : V →L[ℝ] H}
+    (hJ : IsCompactOperator J) (hsymm : ∀ u v : V, B u v = B v u) (hJne : J ≠ 0) :
+    ∃ u : V, u ≠ 0 ∧
+      ∀ v : V, B u v = ‖hB.formSolutionOperator J‖⁻¹ * ⟪J u, J v⟫_ℝ := by
+  obtain ⟨w, hw⟩ : ∃ w : V, J w ≠ 0 := by
+    simpa only [zero_apply] using DFunLike.ne_iff.mp hJne
+  have _ : Nontrivial H := nontrivial_of_ne (J w) 0 hw
+  set S := hB.formSolutionOperator J with hS
+  have hSne : S ≠ 0 := fun hzero =>
+    hw (inner_self_eq_zero.mp ((hB.formSolutionOperator_apply_eq_zero_iff J (J w)).mp
+      (by rw [← hS, hzero, zero_apply]) w))
+  have hnorm_pos : 0 < ‖S‖ := norm_pos_iff.mpr hSne
+  have hcompact : IsCompactOperator S := hB.isCompactOperator_formSolutionOperator hJ
+  have hsym : LinearMap.IsSymmetric (S : H →ₗ[ℝ] H) := hB.isSymmetric_formSolutionOperator J hsymm
+  have hnorm_or_neg : ‖S‖ ∈ spectrum ℝ S ∨ -‖S‖ ∈ spectrum ℝ S := by
+    simp_rw [spectrum, Set.mem_compl_iff]
+    by_contra! h
+    obtain ⟨d, hd, hle⟩ := S.abs_rayleighQuotient_le_of_norm_mem_resolventSet h.1 h.2
+    have hsup := ciSup_le hle
+    have heq := ContinuousLinearMap.norm_eq_iSup_rayleighQuotient S hsym
+    linarith
+  have hnorm_mem : ‖S‖ ∈ spectrum ℝ S := hnorm_or_neg.resolve_right fun hneg => by
+    have hneg_eigen : HasEigenvalue (S : H →ₗ[ℝ] H) (-‖S‖) :=
+      (hcompact.hasEigenvalue_iff_mem_spectrum (neg_ne_zero.mpr hnorm_pos.ne')).mpr hneg
+    have hnonneg : 0 ≤ -‖S‖ := eigenvalue_nonneg_of_nonneg hneg_eigen fun f => by
+      simpa [hS] using hB.inner_formSolutionOperator_self_nonneg J f
+    linarith
+  have hnorm_eigen : HasEigenvalue (S : H →ₗ[ℝ] H) ‖S‖ :=
+    (hcompact.hasEigenvalue_iff_mem_spectrum hnorm_pos.ne').mpr hnorm_mem
+  refine (hB.hasEigenvalue_formSolutionOperator_iff J (inv_ne_zero hnorm_pos.ne')).mp ?_
+  simpa using hnorm_eigen
+
+/-! ### The Rayleigh principle -/
+
+/-- **The Rayleigh principle**: the least variational eigenvalue `‖S‖⁻¹` is the *minimum* of the
+Rayleigh quotient `B v v / ‖J v‖²` over the vectors with `J v ≠ 0`.  The minimum is attained at
+an eigenfunction, which is why compactness of `J` is assumed. -/
+theorem isLeast_rayleighQuotient (hB : IsCoercive B) {J : V →L[ℝ] H} (hJ : IsCompactOperator J)
+    (hsymm : ∀ u v : V, B u v = B v u) (hJne : J ≠ 0) :
+    IsLeast {r : ℝ | ∃ v : V, J v ≠ 0 ∧ B v v / ‖J v‖ ^ 2 = r}
+      ‖hB.formSolutionOperator J‖⁻¹ := by
+  obtain ⟨u, hu, heq⟩ := hB.exists_ne_zero_forall_apply_eq_inv_norm_smul_inner hJ hsymm hJne
+  have hJu : J u ≠ 0 := hB.apply_ne_zero_of_forall_apply_eq_smul_inner J hu heq
+  constructor
+  · refine ⟨u, hJu, ?_⟩
+    rw [heq u, real_inner_self_eq_norm_sq, mul_div_assoc,
+      div_self (by positivity : ‖J u‖ ^ 2 ≠ 0), mul_one]
+  · rintro r ⟨v, hJv, rfl⟩
+    rw [le_div_iff₀ (by positivity : (0 : ℝ) < ‖J v‖ ^ 2)]
+    exact hB.inv_norm_formSolutionOperator_mul_norm_apply_sq_le J hsymm v
+
+/-- **The first variational eigenvalue is the optimal constant** in the inequality
+`C ‖J v‖² ≤ B v v`: it satisfies the inequality, and no larger constant does.  For the Dirichlet
+problem this identifies the first eigenvalue with the best Poincaré constant. -/
+theorem isGreatest_setOf_forall_mul_norm_apply_sq_le (hB : IsCoercive B) {J : V →L[ℝ] H}
+    (hJ : IsCompactOperator J) (hsymm : ∀ u v : V, B u v = B v u) (hJne : J ≠ 0) :
+    IsGreatest {C : ℝ | ∀ v : V, C * ‖J v‖ ^ 2 ≤ B v v} ‖hB.formSolutionOperator J‖⁻¹ := by
+  obtain ⟨u, hu, heq⟩ := hB.exists_ne_zero_forall_apply_eq_inv_norm_smul_inner hJ hsymm hJne
+  have hJu : J u ≠ 0 := hB.apply_ne_zero_of_forall_apply_eq_smul_inner J hu heq
+  refine ⟨fun v => hB.inv_norm_formSolutionOperator_mul_norm_apply_sq_le J hsymm v, fun C hC => ?_⟩
+  have hself : B u u = ‖hB.formSolutionOperator J‖⁻¹ * ‖J u‖ ^ 2 := by
+    rw [heq u, real_inner_self_eq_norm_sq]
+  exact le_of_mul_le_mul_right (by rw [← hself]; exact hC u) (by positivity : (0 : ℝ) < ‖J u‖ ^ 2)
+
+end IsCoercive

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
@@ -34,9 +34,8 @@ The lower bound `‖S‖⁻¹ ‖J v‖² ≤ B v v` needs no compactness and no
 `‖J v‖² = B w v` and `B w w = ⟪J v, S (J v)⟫ ≤ ‖S‖ ‖J v‖²`, and
 `(B w v)² ≤ B w w · B v v` closes the loop.  Coercivity enters only through the
 nonnegativity of the diagonal, which is what makes the energy form obey Cauchy--Schwarz;
-that inequality is `LinearMap.BilinForm.apply_sq_le_of_symm`, transferred to continuous
-bilinear forms here by
-`ContinuousLinearMap.sq_apply_le_apply_self_mul_apply_self`.
+that inequality is `LinearMap.BilinForm.apply_sq_le_of_symm`, applied to the continuous form's
+underlying bilinear form.
 
 The *attainment* is where compactness enters: `‖S‖` is an eigenvalue of the compact symmetric
 positive operator `S` (`IsCoercive.exists_ne_zero_forall_apply_eq_inv_norm_smul_inner`), and its
@@ -46,8 +45,6 @@ not.
 
 ## Main declarations
 
-* `ContinuousLinearMap.sq_apply_le_apply_self_mul_apply_self`: Cauchy--Schwarz for a symmetric
-  continuous bilinear form with nonnegative diagonal.
 * `IsCoercive.norm_apply_sq_le_norm_formSolutionOperator_mul`: the estimate
   `‖J v‖² ≤ ‖S‖ B v v`, and `IsCoercive.inv_norm_formSolutionOperator_mul_norm_apply_sq_le` its
   reciprocal form `‖S‖⁻¹ ‖J v‖² ≤ B v v`.
@@ -71,25 +68,6 @@ noncomputable section
 
 open Module.End
 open scoped InnerProduct InnerProductSpace
-
-section CauchySchwarz
-
-variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V] {B : V →L[ℝ] V →L[ℝ] ℝ}
-
-/-- **Cauchy--Schwarz for a symmetric continuous bilinear form with nonnegative diagonal**:
-`(B u v)² ≤ B u u · B v v`.  This transfers
-`LinearMap.BilinForm.apply_sq_le_of_symm` to the bundled continuous bilinear forms that carry a
-variational problem. -/
-theorem ContinuousLinearMap.sq_apply_le_apply_self_mul_apply_self
-    (hsymm : ∀ u v : V, B u v = B v u) (hnonneg : ∀ w : V, 0 ≤ B w w) (u v : V) :
-    B u v ^ 2 ≤ B u u * B v v := by
-  let B' : LinearMap.BilinForm ℝ V :=
-    LinearMap.mk₂ ℝ (fun u v => B u v) (fun _ _ _ => by simp) (fun _ _ _ => by simp)
-      (fun _ _ _ => by simp) (fun _ _ _ => by simp)
-  have hB'symm : B'.IsSymm := LinearMap.BilinForm.isSymm_def.2 hsymm
-  exact B'.apply_sq_le_of_symm hnonneg (LinearMap.BilinForm.isSymm_iff.mp hB'symm) u v
-
-end CauchySchwarz
 
 namespace IsCoercive
 
@@ -124,7 +102,8 @@ theorem norm_apply_sq_le_norm_formSolutionOperator_mul (hB : IsCoercive B) (J : 
           mul_le_mul_of_nonneg_left ((hB.formSolutionOperator J).le_opNorm _) (norm_nonneg _)
       _ = ‖hB.formSolutionOperator J‖ * ‖J v‖ ^ 2 := by ring
   have hcs : B w v ^ 2 ≤ B w w * B v v :=
-    ContinuousLinearMap.sq_apply_le_apply_self_mul_apply_self hsymm hB.apply_self_nonneg w v
+    B.toBilinForm.apply_sq_le_of_symm hB.apply_self_nonneg
+      (LinearMap.BilinForm.isSymm_iff.mp (LinearMap.BilinForm.isSymm_def.2 hsymm)) w v
   rw [hwv] at hcs
   rcases eq_or_lt_of_le (norm_nonneg (J v)) with hzero | hpos
   · rw [← hzero]

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
@@ -32,16 +32,16 @@ inequality `C‖u‖²_{L²} ≤ a(u, u)`.
 The lower bound `‖S‖⁻¹ ‖J v‖² ≤ B v v` needs no compactness and no attainment.  It comes from
 **Cauchy--Schwarz in the energy form**: solving `B w u = ⟪J v, J u⟫` for `w` gives
 `‖J v‖² = B w v` and `B w w = ⟪J v, S (J v)⟫ ≤ ‖S‖ ‖J v‖²`, and
-`(B w v)² ≤ B w w · B v v` closes the loop.  Coercivity enters only through the
-nonnegativity of the diagonal, which is what makes the energy form obey Cauchy--Schwarz;
-that inequality is `LinearMap.BilinForm.apply_sq_le_of_symm`, applied to the continuous form's
-underlying bilinear form.
+`(B w v)² ≤ B w w · B v v` closes the loop.  Coercivity supplies the solution operator through
+Lax--Milgram and the nonnegativity of the diagonal, which is what makes the energy form obey
+Cauchy--Schwarz; that inequality is `LinearMap.BilinForm.apply_sq_le_of_symm`, applied to the
+continuous form's underlying bilinear form.
 
 The *attainment* is where compactness enters: `‖S‖` is an eigenvalue of the compact symmetric
 positive operator `S` (`IsCoercive.exists_ne_zero_forall_apply_eq_inv_norm_smul_inner`), and its
 eigenfunction realizes the quotient.  Without compactness the infimum can fail to be attained,
-so the `IsLeast`/`IsGreatest` statements carry `IsCompactOperator J` while the inequality does
-not.
+so the `IsLeast` statement carries `IsCompactOperator J`; the optimal-constant `IsGreatest`
+statement does not require attainment.
 
 ## Main declarations
 
@@ -74,13 +74,6 @@ namespace IsCoercive
 variable {V H : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [CompleteSpace V]
   [NormedAddCommGroup H] [InnerProductSpace ℝ H] [CompleteSpace H]
   {B : V →L[ℝ] V →L[ℝ] ℝ}
-
-omit [CompleteSpace V] in
-/-- A coercive form has nonnegative diagonal. -/
-theorem apply_self_nonneg (hB : IsCoercive B) (v : V) : 0 ≤ B v v := by
-  obtain ⟨C, hC, hle⟩ := id hB
-  refine le_trans ?_ (hle v)
-  positivity
 
 /-! ### The Rayleigh lower bound -/
 
@@ -118,9 +111,9 @@ theorem norm_apply_sq_le_norm_formSolutionOperator_mul (hB : IsCoercive B) (J : 
       _ = ‖hB.formSolutionOperator J‖ * B v v * ‖J v‖ ^ 2 := by ring
 
 /-- **The Rayleigh lower bound**: `‖S‖⁻¹ ‖J v‖² ≤ B v v` for every `v : V`.  For the Dirichlet
-problem this is the Poincaré inequality with the first eigenvalue as its constant.  No
-hypothesis beyond symmetry is needed: when `S = 0` the left-hand side vanishes and the bound is
-the nonnegativity of the energy. -/
+problem this is the Poincaré inequality with the first eigenvalue as its constant.  Beyond
+coercivity, only symmetry is needed: when `S = 0` the left-hand side vanishes and the bound is the
+nonnegativity of the energy. -/
 theorem inv_norm_formSolutionOperator_mul_norm_apply_sq_le (hB : IsCoercive B) (J : V →L[ℝ] H)
     (hsymm : ∀ u v : V, B u v = B v u) (v : V) :
     ‖hB.formSolutionOperator J‖⁻¹ * ‖J v‖ ^ 2 ≤ B v v := by
@@ -129,43 +122,6 @@ theorem inv_norm_formSolutionOperator_mul_norm_apply_sq_le (hB : IsCoercive B) (
     simpa using hB.apply_self_nonneg v
   · rw [inv_mul_le_iff₀ hpos]
     linarith [hB.norm_apply_sq_le_norm_formSolutionOperator_mul J hsymm v]
-
-/-! ### Attainment at the first variational eigenvalue -/
-
-/-- **The reciprocal of the norm of the solution operator is a variational eigenvalue.**  It is
-the least one, by `IsCoercive.isLeast_rayleighQuotient`.  Compactness of `J` is what makes `‖S‖`
-itself an eigenvalue of `S`, and positivity of `S` is what excludes `-‖S‖`. -/
-theorem exists_ne_zero_forall_apply_eq_inv_norm_smul_inner (hB : IsCoercive B) {J : V →L[ℝ] H}
-    (hJ : IsCompactOperator J) (hsymm : ∀ u v : V, B u v = B v u) (hJne : J ≠ 0) :
-    ∃ u : V, u ≠ 0 ∧
-      ∀ v : V, B u v = ‖hB.formSolutionOperator J‖⁻¹ * ⟪J u, J v⟫_ℝ := by
-  obtain ⟨w, hw⟩ : ∃ w : V, J w ≠ 0 := by
-    simpa only [zero_apply] using DFunLike.ne_iff.mp hJne
-  have _ : Nontrivial H := nontrivial_of_ne (J w) 0 hw
-  set S := hB.formSolutionOperator J with hS
-  have hSne : S ≠ 0 := fun hzero =>
-    hw (inner_self_eq_zero.mp ((hB.formSolutionOperator_apply_eq_zero_iff J (J w)).mp
-      (by rw [← hS, hzero, zero_apply]) w))
-  have hnorm_pos : 0 < ‖S‖ := norm_pos_iff.mpr hSne
-  have hcompact : IsCompactOperator S := hB.isCompactOperator_formSolutionOperator hJ
-  have hsym : LinearMap.IsSymmetric (S : H →ₗ[ℝ] H) := hB.isSymmetric_formSolutionOperator J hsymm
-  have hnorm_or_neg : ‖S‖ ∈ spectrum ℝ S ∨ -‖S‖ ∈ spectrum ℝ S := by
-    simp_rw [spectrum, Set.mem_compl_iff]
-    by_contra! h
-    obtain ⟨d, hd, hle⟩ := S.abs_rayleighQuotient_le_of_norm_mem_resolventSet h.1 h.2
-    have hsup := ciSup_le hle
-    have heq := ContinuousLinearMap.norm_eq_iSup_rayleighQuotient S hsym
-    linarith
-  have hnorm_mem : ‖S‖ ∈ spectrum ℝ S := hnorm_or_neg.resolve_right fun hneg => by
-    have hneg_eigen : HasEigenvalue (S : H →ₗ[ℝ] H) (-‖S‖) :=
-      (hcompact.hasEigenvalue_iff_mem_spectrum (neg_ne_zero.mpr hnorm_pos.ne')).mpr hneg
-    have hnonneg : 0 ≤ -‖S‖ := eigenvalue_nonneg_of_nonneg hneg_eigen fun f => by
-      simpa [hS] using hB.inner_formSolutionOperator_self_nonneg J f
-    linarith
-  have hnorm_eigen : HasEigenvalue (S : H →ₗ[ℝ] H) ‖S‖ :=
-    (hcompact.hasEigenvalue_iff_mem_spectrum hnorm_pos.ne').mpr hnorm_mem
-  refine (hB.hasEigenvalue_formSolutionOperator_iff J (inv_ne_zero hnorm_pos.ne')).mp ?_
-  simpa using hnorm_eigen
 
 /-! ### The Rayleigh principle -/
 
@@ -188,15 +144,37 @@ theorem isLeast_rayleighQuotient (hB : IsCoercive B) {J : V →L[ℝ] H} (hJ : I
 
 /-- **The first variational eigenvalue is the optimal constant** in the inequality
 `C ‖J v‖² ≤ B v v`: it satisfies the inequality, and no larger constant does.  For the Dirichlet
-problem this identifies the first eigenvalue with the best Poincaré constant. -/
+problem this identifies the first eigenvalue with the best Poincaré constant.  Unlike attainment
+of the Rayleigh minimum, this characterization does not require compactness of `J`. -/
 theorem isGreatest_setOf_forall_mul_norm_apply_sq_le (hB : IsCoercive B) {J : V →L[ℝ] H}
-    (hJ : IsCompactOperator J) (hsymm : ∀ u v : V, B u v = B v u) (hJne : J ≠ 0) :
+    (hsymm : ∀ u v : V, B u v = B v u) (hJne : J ≠ 0) :
     IsGreatest {C : ℝ | ∀ v : V, C * ‖J v‖ ^ 2 ≤ B v v} ‖hB.formSolutionOperator J‖⁻¹ := by
-  obtain ⟨u, hu, heq⟩ := hB.exists_ne_zero_forall_apply_eq_inv_norm_smul_inner hJ hsymm hJne
-  have hJu : J u ≠ 0 := hB.apply_ne_zero_of_forall_apply_eq_smul_inner J hu heq
+  obtain ⟨w, hw⟩ : ∃ w : V, J w ≠ 0 := by
+    simpa only [zero_apply] using DFunLike.ne_iff.mp hJne
+  have _ : Nontrivial H := nontrivial_of_ne (J w) 0 hw
+  set S := hB.formSolutionOperator J with hS
+  have hSne : S ≠ 0 := fun hzero =>
+    hw (inner_self_eq_zero.mp ((hB.formSolutionOperator_apply_eq_zero_iff J (J w)).mp
+      (by rw [← hS, hzero, zero_apply]) w))
+  have hnorm_pos : 0 < ‖S‖ := norm_pos_iff.mpr hSne
   refine ⟨fun v => hB.inv_norm_formSolutionOperator_mul_norm_apply_sq_le J hsymm v, fun C hC => ?_⟩
-  have hself : B u u = ‖hB.formSolutionOperator J‖⁻¹ * ‖J u‖ ^ 2 := by
-    rw [heq u, real_inner_self_eq_norm_sq]
-  exact le_of_mul_le_mul_right (by rw [← hself]; exact hC u) (by positivity : (0 : ℝ) < ‖J u‖ ^ 2)
+  rcases le_or_gt C 0 with hCnonpos | hCpos
+  · exact hCnonpos.trans (inv_nonneg.mpr (norm_nonneg S))
+  · have hop : ‖C • S‖ ≤ 1 := (C • S).opNorm_le_bound zero_le_one fun h => by
+      rw [smul_apply, norm_smul, Real.norm_eq_abs, abs_of_pos hCpos]
+      rcases eq_or_ne (S h) 0 with hzero | hne
+      · simp [hzero]
+      · have henergy : C * ‖S h‖ ^ 2 ≤ ⟪h, S h⟫_ℝ := calc
+          C * ‖S h‖ ^ 2 = C * ‖J (hB.formSolutionMap J h)‖ ^ 2 := by
+            rw [hS, formSolutionOperator_apply]
+          _ ≤ B (hB.formSolutionMap J h) (hB.formSolutionMap J h) :=
+            hC (hB.formSolutionMap J h)
+          _ = ⟪h, S h⟫_ℝ := by
+            rw [hS, inner_formSolutionOperator_self]
+        have hinner : ⟪h, S h⟫_ℝ ≤ ‖h‖ * ‖S h‖ := real_inner_le_norm _ _
+        exact le_of_mul_le_mul_right (by nlinarith) (norm_pos_iff.mpr hne)
+    rw [norm_smul, Real.norm_eq_abs, abs_of_pos hCpos] at hop
+    rw [inv_eq_one_div]
+    exact (le_div_iff₀ hnorm_pos).mpr hop
 
 end IsCoercive

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean
@@ -12,15 +12,16 @@ public import Mathlib.LinearAlgebra.BilinearForm.Properties
 # The Rayleigh principle for a coercive variational problem
 
 Let `B` be a bounded coercive symmetric bilinear form on a real Hilbert space `V` and let
-`J : V →L[ℝ] H` be a continuous linear map into a second real Hilbert space.  The **variational
-eigenvalues** of the pair are the reciprocals of the nonzero eigenvalues of the solution
-operator `S = IsCoercive.formSolutionOperator`, so the *least* variational eigenvalue is
-`‖S‖⁻¹`.  This file proves that this number is the minimum of the **Rayleigh quotient**
+`J : V →L[ℝ] H` be a continuous linear map into a second real Hilbert space.  When `J` is nonzero
+and compact, the **variational eigenvalues** of the pair are the reciprocals of the nonzero
+eigenvalues of the solution operator `S = IsCoercive.formSolutionOperator`, and the *least*
+variational eigenvalue `‖S‖⁻¹` is the minimum of the **Rayleigh quotient**
 
 `B v v / ‖J v‖²`,
 
-taken over the `v : V` with `J v ≠ 0`, and — the same statement read as an inequality — that it
-is the largest constant `C` for which `C ‖J v‖² ≤ B v v` holds for every `v : V`.
+taken over the `v : V` with `J v ≠ 0`.  Without compactness, this file proves that `‖S‖⁻¹` is
+still the largest constant `C` for which `C ‖J v‖² ≤ B v v` holds for every `v : V`, provided
+`J ≠ 0`.
 
 For the Dirichlet problem of a divergence-form elliptic operator, with `V = H¹₀(Ω)`,
 `H = L²(Ω)` and `J` the inclusion, this says that the first eigenvalue is the minimum of the
@@ -52,7 +53,7 @@ statement does not require attainment.
   eigenvalue, the least one.
 * `IsCoercive.isLeast_rayleighQuotient`: **the Rayleigh principle**, `‖S‖⁻¹` is the minimum of
   the Rayleigh quotient.
-* `IsCoercive.isGreatest_setOf_forall_mul_norm_apply_sq_le`: `‖S‖⁻¹` is the optimal constant in
+* `IsCoercive.isGreatest_inv_norm_formSolutionOperator`: `‖S‖⁻¹` is the optimal constant in
   the inequality `C ‖J v‖² ≤ B v v`.
 
 ## References
@@ -146,7 +147,7 @@ theorem isLeast_rayleighQuotient (hB : IsCoercive B) {J : V →L[ℝ] H} (hJ : I
 `C ‖J v‖² ≤ B v v`: it satisfies the inequality, and no larger constant does.  For the Dirichlet
 problem this identifies the first eigenvalue with the best Poincaré constant.  Unlike attainment
 of the Rayleigh minimum, this characterization does not require compactness of `J`. -/
-theorem isGreatest_setOf_forall_mul_norm_apply_sq_le (hB : IsCoercive B) {J : V →L[ℝ] H}
+theorem isGreatest_inv_norm_formSolutionOperator (hB : IsCoercive B) {J : V →L[ℝ] H}
     (hsymm : ∀ u v : V, B u v = B v u) (hJne : J ≠ 0) :
     IsGreatest {C : ℝ | ∀ v : V, C * ‖J v‖ ^ 2 ≤ B v v} ‖hB.formSolutionOperator J‖⁻¹ := by
   obtain ⟨w, hw⟩ : ∃ w : V, J w ≠ 0 := by

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Spectrum.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Spectrum.lean
@@ -192,6 +192,16 @@ theorem formSolutionOperator_apply_eq_zero_iff (hB : IsCoercive B) (J : V →L[�
       eq_formSolutionMap hB J fun v => by rw [horth v]; simp
     rw [formSolutionOperator_apply, ← hsol, map_zero]
 
+/-- The solution operator is nonzero whenever the map defining it is nonzero. -/
+theorem formSolutionOperator_ne_zero (hB : IsCoercive B) {J : V →L[ℝ] H} (hJ : J ≠ 0) :
+    hB.formSolutionOperator J ≠ 0 := by
+  obtain ⟨w, hw⟩ : ∃ w : V, J w ≠ 0 := by
+    simpa only [zero_apply] using DFunLike.ne_iff.mp hJ
+  intro hzero
+  have hJw : hB.formSolutionOperator J (J w) = 0 := by rw [hzero, zero_apply]
+  exact hw (inner_self_eq_zero.mp
+    ((hB.formSolutionOperator_apply_eq_zero_iff J (J w)).mp hJw w))
+
 /-- **The kernel of the solution operator** is the orthogonal complement of the range of `J`;
 `IsCoercive.eigenspace_formSolutionOperator_zero_eq_bot` draws the consequence for a `J` with
 dense range. -/
@@ -312,14 +322,7 @@ the variational eigenvalue problem has a nonzero eigenvalue with an eigenfunctio
 theorem exists_ne_zero_forall_apply_eq_smul_inner (hB : IsCoercive B) {J : V →L[ℝ] H}
     (hJ : IsCompactOperator J) (hsymm : ∀ u v : V, B u v = B v u) (hJne : J ≠ 0) :
     ∃ kappa : ℝ, kappa ≠ 0 ∧ ∃ u : V, u ≠ 0 ∧ ∀ v : V, B u v = kappa * ⟪J u, J v⟫_ℝ := by
-  obtain ⟨w, hw⟩ : ∃ w : V, J w ≠ 0 := by
-    simpa only [zero_apply] using DFunLike.ne_iff.mp hJne
-  have hSne : hB.formSolutionOperator J ≠ 0 := by
-    intro hzero
-    have hJw : hB.formSolutionOperator J (J w) = 0 := by
-      rw [hzero, zero_apply]
-    exact hw (inner_self_eq_zero.mp
-      ((hB.formSolutionOperator_apply_eq_zero_iff J (J w)).mp hJw w))
+  have hSne := hB.formSolutionOperator_ne_zero hJne
   have hcompact := hB.isCompactOperator_formSolutionOperator hJ
   have hsym := hB.isSymmetric_formSolutionOperator J hsymm
   have hex : ¬ ∀ mu : ℝ,
@@ -357,9 +360,9 @@ theorem exists_ne_zero_forall_apply_eq_inv_norm_smul_inner (hB : IsCoercive B)
     simpa only [zero_apply] using DFunLike.ne_iff.mp hJne
   have _ : Nontrivial H := nontrivial_of_ne (J w) 0 hw
   set S := hB.formSolutionOperator J with hS
-  have hSne : S ≠ 0 := fun hzero =>
-    hw (inner_self_eq_zero.mp ((hB.formSolutionOperator_apply_eq_zero_iff J (J w)).mp
-      (by rw [← hS, hzero, zero_apply]) w))
+  have hSne : S ≠ 0 := by
+    rw [hS]
+    exact hB.formSolutionOperator_ne_zero hJne
   have hnorm_pos : 0 < ‖S‖ := norm_pos_iff.mpr hSne
   have hcompact : IsCompactOperator S := hB.isCompactOperator_formSolutionOperator hJ
   have hsym : LinearMap.IsSymmetric (S : H →ₗ[ℝ] H) :=

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Spectrum.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Spectrum.lean
@@ -256,7 +256,10 @@ theorem le_of_forall_apply_eq_smul_inner (hB : IsCoercive B) {J : V →L[ℝ] H}
   have hsq : 0 < ‖u‖ ^ 2 := by positivity
   exact le_of_mul_le_mul_right (by linarith [hlower u]) hsq
 
-omit [CompleteSpace V] [CompleteSpace H] in
+variable {V H : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+  [NormedAddCommGroup H] [InnerProductSpace ℝ H]
+  {B : V →L[ℝ] V →L[ℝ] ℝ}
+
 /-- **A variational eigenfunction has nonzero image in `H`.**  If `J u` vanished, the
 eigenvalue equation would make the energy of `u` vanish too, which coercivity forbids for
 `u ≠ 0`. -/
@@ -269,6 +272,10 @@ theorem apply_ne_zero_of_forall_apply_eq_smul_inner (hB : IsCoercive B) (J : V �
   have hself : B u u = 0 := by rw [heq u, hzero, inner_zero_left, mul_zero]
   have h2 : 0 < C * ‖u‖ * ‖u‖ := mul_pos (mul_pos hC hpos) hpos
   linarith [hle u]
+
+variable {V H : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [CompleteSpace V]
+  [NormedAddCommGroup H] [InnerProductSpace ℝ H] [CompleteSpace H]
+  {B : V →L[ℝ] V →L[ℝ] ℝ}
 
 /-- A variational eigenfunction for `κ ≠ 0` produces an eigenvector of the solution operator
 with eigenvalue `κ⁻¹`. -/

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Spectrum.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Spectrum.lean
@@ -53,6 +53,8 @@ eigenfunction.
   the nonzero eigenvalues of `S` and the variational eigenvalues.
 * `IsCoercive.exists_ne_zero_forall_apply_eq_smul_inner`: existence of a variational
   eigenvalue.
+* `IsCoercive.exists_ne_zero_forall_apply_eq_inv_norm_smul_inner`: the reciprocal of the norm
+  of the solution operator is a variational eigenvalue.
 * `IsCoercive.pos_of_forall_apply_eq_smul_inner` and
   `IsCoercive.le_of_forall_apply_eq_smul_inner`: positivity of a variational eigenvalue, and
   the lower bound by the coercivity constant.
@@ -335,6 +337,43 @@ theorem hasEigenvalue_formSolutionOperator_iff (hB : IsCoercive B) (J : V →L[�
   · rintro ⟨u, hu, heq⟩
     exact hasEigenvalue_of_hasEigenvector
       (hB.hasEigenvector_formSolutionOperator J hkappa hu heq)
+
+/-- **The reciprocal of the norm of the solution operator is a variational eigenvalue.**
+Compactness of `J` is what makes `‖S‖` itself an eigenvalue of `S`, and positivity of `S` is what
+excludes `-‖S‖`. -/
+theorem exists_ne_zero_forall_apply_eq_inv_norm_smul_inner (hB : IsCoercive B)
+    {J : V →L[ℝ] H} (hJ : IsCompactOperator J) (hsymm : ∀ u v : V, B u v = B v u)
+    (hJne : J ≠ 0) :
+    ∃ u : V, u ≠ 0 ∧
+      ∀ v : V, B u v = ‖hB.formSolutionOperator J‖⁻¹ * ⟪J u, J v⟫_ℝ := by
+  obtain ⟨w, hw⟩ : ∃ w : V, J w ≠ 0 := by
+    simpa only [zero_apply] using DFunLike.ne_iff.mp hJne
+  have _ : Nontrivial H := nontrivial_of_ne (J w) 0 hw
+  set S := hB.formSolutionOperator J with hS
+  have hSne : S ≠ 0 := fun hzero =>
+    hw (inner_self_eq_zero.mp ((hB.formSolutionOperator_apply_eq_zero_iff J (J w)).mp
+      (by rw [← hS, hzero, zero_apply]) w))
+  have hnorm_pos : 0 < ‖S‖ := norm_pos_iff.mpr hSne
+  have hcompact : IsCompactOperator S := hB.isCompactOperator_formSolutionOperator hJ
+  have hsym : LinearMap.IsSymmetric (S : H →ₗ[ℝ] H) :=
+    hB.isSymmetric_formSolutionOperator J hsymm
+  have hnorm_or_neg : ‖S‖ ∈ spectrum ℝ S ∨ -‖S‖ ∈ spectrum ℝ S := by
+    simp_rw [spectrum, Set.mem_compl_iff]
+    by_contra! h
+    obtain ⟨d, hd, hle⟩ := S.abs_rayleighQuotient_le_of_norm_mem_resolventSet h.1 h.2
+    have hsup := ciSup_le hle
+    have heq := ContinuousLinearMap.norm_eq_iSup_rayleighQuotient S hsym
+    linarith
+  have hnorm_mem : ‖S‖ ∈ spectrum ℝ S := hnorm_or_neg.resolve_right fun hneg => by
+    have hneg_eigen : HasEigenvalue (S : H →ₗ[ℝ] H) (-‖S‖) :=
+      (hcompact.hasEigenvalue_iff_mem_spectrum (neg_ne_zero.mpr hnorm_pos.ne')).mpr hneg
+    have hnonneg : 0 ≤ -‖S‖ := eigenvalue_nonneg_of_nonneg hneg_eigen fun f => by
+      simpa [hS] using hB.inner_formSolutionOperator_self_nonneg J f
+    linarith
+  have hnorm_eigen : HasEigenvalue (S : H →ₗ[ℝ] H) ‖S‖ :=
+    (hcompact.hasEigenvalue_iff_mem_spectrum hnorm_pos.ne').mpr hnorm_mem
+  refine (hB.hasEigenvalue_formSolutionOperator_iff J (inv_ne_zero hnorm_pos.ne')).mp ?_
+  simpa using hnorm_eigen
 
 /-! ### The spectral theorem for the solution operator -/
 

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Spectrum.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Spectrum.lean
@@ -254,6 +254,20 @@ theorem le_of_forall_apply_eq_smul_inner (hB : IsCoercive B) {J : V →L[ℝ] H}
   have hsq : 0 < ‖u‖ ^ 2 := by positivity
   exact le_of_mul_le_mul_right (by linarith [hlower u]) hsq
 
+omit [CompleteSpace V] [CompleteSpace H] in
+/-- **A variational eigenfunction has nonzero image in `H`.**  If `J u` vanished, the
+eigenvalue equation would make the energy of `u` vanish too, which coercivity forbids for
+`u ≠ 0`. -/
+theorem apply_ne_zero_of_forall_apply_eq_smul_inner (hB : IsCoercive B) (J : V →L[ℝ] H)
+    {kappa : ℝ} {u : V} (hu : u ≠ 0) (heq : ∀ v : V, B u v = kappa * ⟪J u, J v⟫_ℝ) :
+    J u ≠ 0 := by
+  intro hzero
+  obtain ⟨C, hC, hle⟩ := id hB
+  have hpos : 0 < ‖u‖ := norm_pos_iff.mpr hu
+  have hself : B u u = 0 := by rw [heq u, hzero, inner_zero_left, mul_zero]
+  have h2 : 0 < C * ‖u‖ * ‖u‖ := mul_pos (mul_pos hC hpos) hpos
+  linarith [hle u]
+
 /-- A variational eigenfunction for `κ ≠ 0` produces an eigenvector of the solution operator
 with eigenvalue `κ⁻¹`. -/
 theorem hasEigenvector_formSolutionOperator (hB : IsCoercive B) (J : V →L[ℝ] H) {kappa : ℝ}
@@ -261,14 +275,8 @@ theorem hasEigenvector_formSolutionOperator (hB : IsCoercive B) (J : V →L[ℝ]
     HasEigenvector (hB.formSolutionOperator J : H →ₗ[ℝ] H) kappa⁻¹ (kappa • J u) := by
   have hsol : u = hB.formSolutionMap J (kappa • J u) :=
     eq_formSolutionMap hB J fun v => by rw [heq v, real_inner_smul_left]
-  have hJu : J u ≠ 0 := by
-    intro hzero
-    obtain ⟨C, hC, hle⟩ := id hB
-    have hpos : 0 < ‖u‖ := norm_pos_iff.mpr hu
-    have hself : B u u = 0 := by rw [heq u, hzero, inner_zero_left, mul_zero]
-    have h2 : 0 < C * ‖u‖ * ‖u‖ := mul_pos (mul_pos hC hpos) hpos
-    linarith [hle u]
-  refine ⟨mem_eigenspace_iff.mpr ?_, smul_ne_zero hkappa hJu⟩
+  refine ⟨mem_eigenspace_iff.mpr ?_,
+    smul_ne_zero hkappa (hB.apply_ne_zero_of_forall_apply_eq_smul_inner J hu heq)⟩
   rw [ContinuousLinearMap.coe_coe, formSolutionOperator_apply, ← hsol, smul_smul,
     inv_mul_cancel₀ hkappa, one_smul]
 

--- a/TauCeti/Analysis/InnerProductSpace/Variational/Spectrum.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Variational/Spectrum.lean
@@ -373,7 +373,7 @@ theorem exists_ne_zero_forall_apply_eq_inv_norm_smul_inner (hB : IsCoercive B)
   have hnorm_eigen : HasEigenvalue (S : H →ₗ[ℝ] H) ‖S‖ :=
     (hcompact.hasEigenvalue_iff_mem_spectrum hnorm_pos.ne').mpr hnorm_mem
   refine (hB.hasEigenvalue_formSolutionOperator_iff J (inv_ne_zero hnorm_pos.ne')).mp ?_
-  simpa using hnorm_eigen
+  simpa only [hS, inv_inv] using hnorm_eigen
 
 /-! ### The spectral theorem for the solution operator -/
 

--- a/TauCeti/Analysis/PDE/Spectrum.lean
+++ b/TauCeti/Analysis/PDE/Spectrum.lean
@@ -398,7 +398,7 @@ theorem le_firstDirichletEigenvalue
 
 /-! ### The Rayleigh principle -/
 
-/-- **The first Dirichlet eigenvalue is a Poincaré constant for the energy form**:
+/-- **The quantity `firstDirichletEigenvalue` is a Poincaré constant for the energy form**:
 
 `κ₁ ‖u‖²_{L²(Ω)} ≤ a(u, u)` for every `u ∈ H¹₀(Ω)`,
 
@@ -450,9 +450,9 @@ theorem isLeast_rayleighQuotient_firstDirichletEigenvalue
   exact hcoercive.isLeast_rayleighQuotient (W1p0.isCompactOperator_valueL (by simp) hOmega)
     (energyFormH1L0_comm hcoeff hsymm) (W1p0.valueL_ne_zero hOmega_nonempty)
 
-/-- **The first Dirichlet eigenvalue is the optimal Poincaré constant** of the energy form: it is
-the greatest `C` with `C ‖u‖²_{L²(Ω)} ≤ a(u, u)` for all `u ∈ H¹₀(Ω)`.  This is the Rayleigh
-principle read as an inequality, and it is what makes the lower bounds
+/-- **The quantity `firstDirichletEigenvalue` is the optimal Poincaré constant** of the energy
+form: it is the greatest `C` with `C ‖u‖²_{L²(Ω)} ≤ a(u, u)` for all `u ∈ H¹₀(Ω)`.  This is the
+Rayleigh principle read as an inequality, and it is what makes the lower bounds
 `TauCeti.PDE.le_firstDirichletEigenvalue` sharp.  Boundedness of `Ω` is not needed because this
 optimal-constant characterization does not assert attainment. -/
 theorem isGreatest_firstDirichletEigenvalue

--- a/TauCeti/Analysis/PDE/Spectrum.lean
+++ b/TauCeti/Analysis/PDE/Spectrum.lean
@@ -452,11 +452,11 @@ theorem isLeast_rayleighQuotient_firstDirichletEigenvalue
 /-- **The first Dirichlet eigenvalue is the optimal Poincaré constant** of the energy form: it is
 the greatest `C` with `C ‖u‖²_{L²(Ω)} ≤ a(u, u)` for all `u ∈ H¹₀(Ω)`.  This is the Rayleigh
 principle read as an inequality, and it is what makes the lower bounds
-`TauCeti.PDE.le_firstDirichletEigenvalue` sharp. -/
+`TauCeti.PDE.le_firstDirichletEigenvalue` sharp.  Boundedness of `Ω` is not needed because this
+optimal-constant characterization does not assert attainment. -/
 theorem isGreatest_setOf_forall_mul_norm_value_sq_le
     (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
     (hcoercive : IsCoercive (energyFormH1L0 hcoeff))
-    (hOmega : IsBounded (Omega : Set (EuclideanSpace ℝ ι)))
     (hsymm : ∀ u v : W1p0 mu Omega 2,
       energyFormH1 a b c (u : W1p mu Omega 2) (v : W1p mu Omega 2) =
         energyFormH1 a b c (v : W1p mu Omega 2) (u : W1p mu Omega 2))
@@ -473,8 +473,7 @@ theorem isGreatest_setOf_forall_mul_norm_value_sq_le
     simp only [W1p0.valueL_apply, energyFormH1L0_apply]
   rw [hset, firstDirichletEigenvalue_def, dirichletSolutionOperator]
   exact hcoercive.isGreatest_setOf_forall_mul_norm_apply_sq_le
-    (W1p0.isCompactOperator_valueL (by simp) hOmega) (energyFormH1L0_comm hcoeff hsymm)
-    (W1p0.valueL_ne_zero hOmega_nonempty)
+    (energyFormH1L0_comm hcoeff hsymm) (W1p0.valueL_ne_zero hOmega_nonempty)
 
 /-- **The eigenspaces of the Dirichlet problem are finite dimensional** on a bounded domain. -/
 theorem finiteDimensional_eigenspace_dirichletSolutionOperator

--- a/TauCeti/Analysis/PDE/Spectrum.lean
+++ b/TauCeti/Analysis/PDE/Spectrum.lean
@@ -452,9 +452,9 @@ theorem isLeast_rayleighQuotient_firstDirichletEigenvalue
 
 /-- **The quantity `firstDirichletEigenvalue` is the optimal Poincaré constant** of the energy
 form: it is the greatest `C` with `C ‖u‖²_{L²(Ω)} ≤ a(u, u)` for all `u ∈ H¹₀(Ω)`.  This is the
-Rayleigh principle read as an inequality, and it is what makes the lower bounds
-`TauCeti.PDE.le_firstDirichletEigenvalue` sharp.  Boundedness of `Ω` is not needed because this
-optimal-constant characterization does not assert attainment. -/
+Rayleigh principle read as an inequality, and it shows that the bound
+`TauCeti.PDE.firstDirichletEigenvalue_mul_norm_value_sq_le` is optimal.  Boundedness of `Ω` is
+not needed because this optimal-constant characterization does not assert attainment. -/
 theorem isGreatest_firstDirichletEigenvalue
     (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
     (hcoercive : IsCoercive (energyFormH1L0 hcoeff))

--- a/TauCeti/Analysis/PDE/Spectrum.lean
+++ b/TauCeti/Analysis/PDE/Spectrum.lean
@@ -65,8 +65,9 @@ weak solution for every `f ∈ L²(Ω)`
 The first Dirichlet eigenvalue is not only the least one: it is the minimum of the Rayleigh
 quotient `a(u, u) / ‖u‖²_{L²(Ω)}` over `H¹₀(Ω)`, equivalently the largest constant `C` for which
 the Poincaré-type inequality `C‖u‖²_{L²(Ω)} ≤ a(u, u)` holds.  The inequality itself needs
-neither boundedness nor nonemptiness of `Ω`; boundedness is what makes the minimum *attained*,
-through the compactness of the solution operator.
+neither boundedness nor nonemptiness of `Ω`; boundedness together with nonemptiness makes the
+minimum *attained*, through compactness of the solution operator and nonvanishing of the value
+map.
 
 ## Main declarations
 
@@ -86,7 +87,7 @@ through the compactness of the solution operator.
 * `TauCeti.PDE.isLeast_rayleighQuotient_firstDirichletEigenvalue`: the Rayleigh principle, that
   the first Dirichlet eigenvalue is the minimum of `a(u, u) / ‖u‖²_{L²(Ω)}`, with its inequality
   half `TauCeti.PDE.firstDirichletEigenvalue_mul_norm_value_sq_le` and its reading as the optimal
-  Poincaré constant `TauCeti.PDE.isGreatest_setOf_forall_mul_norm_value_sq_le`.
+  Poincaré constant `TauCeti.PDE.isGreatest_firstDirichletEigenvalue`.
 * `TauCeti.PDE.isDirichletEigenvalue_iff_hasEigenvalue`: the reciprocal correspondence with the
   nonzero eigenvalues of the solution operator.
 * `TauCeti.PDE.finiteDimensional_eigenspace_dirichletSolutionOperator` and
@@ -401,7 +402,7 @@ theorem le_firstDirichletEigenvalue
 
 `κ₁ ‖u‖²_{L²(Ω)} ≤ a(u, u)` for every `u ∈ H¹₀(Ω)`,
 
-and by `TauCeti.PDE.isGreatest_setOf_forall_mul_norm_value_sq_le` it is the largest constant for
+and by `TauCeti.PDE.isGreatest_firstDirichletEigenvalue` it is the largest constant for
 which this holds.  Neither boundedness nor nonemptiness of `Ω` is needed here: only coercivity,
 which makes the solution operator exist, and symmetry, which gives the energy form its
 Cauchy--Schwarz inequality. -/
@@ -454,7 +455,7 @@ the greatest `C` with `C ‖u‖²_{L²(Ω)} ≤ a(u, u)` for all `u ∈ H¹₀(
 principle read as an inequality, and it is what makes the lower bounds
 `TauCeti.PDE.le_firstDirichletEigenvalue` sharp.  Boundedness of `Ω` is not needed because this
 optimal-constant characterization does not assert attainment. -/
-theorem isGreatest_setOf_forall_mul_norm_value_sq_le
+theorem isGreatest_firstDirichletEigenvalue
     (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
     (hcoercive : IsCoercive (energyFormH1L0 hcoeff))
     (hsymm : ∀ u v : W1p0 mu Omega 2,
@@ -472,7 +473,7 @@ theorem isGreatest_setOf_forall_mul_norm_value_sq_le
         C * ‖W1p0.valueL u‖ ^ 2 ≤ energyFormH1L0 hcoeff u u} := by
     simp only [W1p0.valueL_apply, energyFormH1L0_apply]
   rw [hset, firstDirichletEigenvalue_def, dirichletSolutionOperator]
-  exact hcoercive.isGreatest_setOf_forall_mul_norm_apply_sq_le
+  exact hcoercive.isGreatest_inv_norm_formSolutionOperator
     (energyFormH1L0_comm hcoeff hsymm) (W1p0.valueL_ne_zero hOmega_nonempty)
 
 /-- **The eigenspaces of the Dirichlet problem are finite dimensional** on a bounded domain. -/

--- a/TauCeti/Analysis/PDE/Spectrum.lean
+++ b/TauCeti/Analysis/PDE/Spectrum.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.InnerProductSpace.Variational.Spectrum
+public import TauCeti.Analysis.InnerProductSpace.Variational.Rayleigh
 public import TauCeti.Analysis.PDE.FredholmAlternative
 
 /-!
@@ -60,6 +60,14 @@ familiar statement: if `κ` is *not* a Dirichlet eigenvalue, then `L u - κ u = 
 weak solution for every `f ∈ L²(Ω)`
 (`TauCeti.PDE.existsUnique_isWeakSolutionDirichletMassShift_of_not_isDirichletEigenvalue`).
 
+## The variational characterization
+
+The first Dirichlet eigenvalue is not only the least one: it is the minimum of the Rayleigh
+quotient `a(u, u) / ‖u‖²_{L²(Ω)}` over `H¹₀(Ω)`, equivalently the largest constant `C` for which
+the Poincaré-type inequality `C‖u‖²_{L²(Ω)} ≤ a(u, u)` holds.  The inequality itself needs
+neither boundedness nor nonemptiness of `Ω`; boundedness is what makes the minimum *attained*,
+through the compactness of the solution operator.
+
 ## Main declarations
 
 * `TauCeti.PDE.dirichletSolutionOperator`: the solution operator on `L²(Ω)`, with
@@ -75,6 +83,10 @@ weak solution for every `f ∈ L²(Ω)`
   Dirichlet eigenvalue and its attainment on a nonempty bounded domain.
 * `TauCeti.PDE.pos_of_isDirichletEigenvalue` and `TauCeti.PDE.le_of_isDirichletEigenvalue`:
   every Dirichlet eigenvalue is positive, and at least the coercivity constant.
+* `TauCeti.PDE.isLeast_rayleighQuotient_firstDirichletEigenvalue`: the Rayleigh principle, that
+  the first Dirichlet eigenvalue is the minimum of `a(u, u) / ‖u‖²_{L²(Ω)}`, with its inequality
+  half `TauCeti.PDE.firstDirichletEigenvalue_mul_norm_value_sq_le` and its reading as the optimal
+  Poincaré constant `TauCeti.PDE.isGreatest_setOf_forall_mul_norm_value_sq_le`.
 * `TauCeti.PDE.isDirichletEigenvalue_iff_hasEigenvalue`: the reciprocal correspondence with the
   nonzero eigenvalues of the solution operator.
 * `TauCeti.PDE.finiteDimensional_eigenspace_dirichletSolutionOperator` and
@@ -288,12 +300,9 @@ theorem exists_isDirichletEigenvalue
         energyFormH1 a b c (v : W1p mu Omega 2) (u : W1p mu Omega 2))
     (hOmega_nonempty : (Omega : Set (EuclideanSpace ℝ ι)).Nonempty) :
     ∃ kappa : ℝ, IsDirichletEigenvalue mu Omega a b c kappa := by
-  obtain ⟨w, hw⟩ := W1p0.exists_value_ne_zero (mu := mu) (Omega := Omega) hOmega_nonempty
-  have hvalueL_ne : (W1p0.valueL (mu := mu) (Omega := Omega) (p := 2)) ≠ 0 := fun hzero =>
-    hw (by rw [← W1p0.valueL_apply, hzero, zero_apply])
   obtain ⟨kappa, -, u, hu, heq⟩ := hcoercive.exists_ne_zero_forall_apply_eq_smul_inner
     (W1p0.isCompactOperator_valueL (by simp) hOmega) (energyFormH1L0_comm hcoeff hsymm)
-    hvalueL_ne
+    (W1p0.valueL_ne_zero hOmega_nonempty)
   refine ⟨kappa, u, hu, fun v => ?_⟩
   have hv := heq v
   rwa [energyFormH1L0_apply, W1p0.valueL_apply, W1p0.valueL_apply] at hv
@@ -324,43 +333,13 @@ theorem isDirichletEigenvalue_first
     (hOmega_nonempty : (Omega : Set (EuclideanSpace ℝ ι)).Nonempty) :
     IsDirichletEigenvalue mu Omega a b c
       (firstDirichletEigenvalue hcoeff hcoercive) := by
-  set S := dirichletSolutionOperator hcoeff hcoercive with hS
-  obtain ⟨w, hw⟩ := W1p0.exists_value_ne_zero (mu := mu) (Omega := Omega) hOmega_nonempty
-  let _ : Nontrivial (Lp ℝ 2 (mu.restrict Omega)) := nontrivial_of_ne
-    (W1p.value (w : W1p mu Omega 2)) 0 hw
-  have hSne : S ≠ 0 := by
-    intro hzero
-    have happly : hcoercive.formSolutionOperator W1p0.valueL (W1p0.valueL w) = 0 := by
-      rw [← dirichletSolutionOperator, ← hS, hzero, zero_apply]
-    have horth := (hcoercive.formSolutionOperator_apply_eq_zero_iff W1p0.valueL _).mp happly w
-    rw [W1p0.valueL_apply] at horth
-    exact hw (inner_self_eq_zero.mp horth)
-  have hnorm_pos : 0 < ‖S‖ := (norm_pos_iff.mpr hSne)
-  have hcompact : IsCompactOperator S := isCompactOperator_dirichletSolutionOperator
-    hcoeff hcoercive hOmega
-  have hsym : LinearMap.IsSymmetric (S :
-      Lp ℝ 2 (mu.restrict Omega) →ₗ[ℝ] Lp ℝ 2 (mu.restrict Omega)) :=
-    isSymmetric_dirichletSolutionOperator hcoeff hcoercive hsymm
-  have hnorm_or_neg : ‖S‖ ∈ spectrum ℝ S ∨ -‖S‖ ∈ spectrum ℝ S := by
-    simp_rw [spectrum, Set.mem_compl_iff]
-    by_contra! h
-    obtain ⟨d, hd, hle⟩ := S.abs_rayleighQuotient_le_of_norm_mem_resolventSet h.1 h.2
-    have hsup := ciSup_le hle
-    have heq := ContinuousLinearMap.norm_eq_iSup_rayleighQuotient S hsym
-    linarith
-  have hnorm_mem : ‖S‖ ∈ spectrum ℝ S := hnorm_or_neg.resolve_right fun hneg => by
-    have hneg_eigen : HasEigenvalue (S :
-        Lp ℝ 2 (mu.restrict Omega) →ₗ[ℝ] Lp ℝ 2 (mu.restrict Omega)) (-‖S‖) :=
-      (hcompact.hasEigenvalue_iff_mem_spectrum (neg_ne_zero.mpr hnorm_pos.ne')).mpr hneg
-    have hnonneg : 0 ≤ -‖S‖ := eigenvalue_nonneg_of_nonneg hneg_eigen fun f => by
-      simpa [hS] using inner_dirichletSolutionOperator_self_nonneg hcoeff hcoercive f
-    linarith
-  have hnorm_eigen : HasEigenvalue (S :
-      Lp ℝ 2 (mu.restrict Omega) →ₗ[ℝ] Lp ℝ 2 (mu.restrict Omega)) ‖S‖ :=
-    (hcompact.hasEigenvalue_iff_mem_spectrum hnorm_pos.ne').mpr hnorm_mem
-  rw [firstDirichletEigenvalue_def,
-    isDirichletEigenvalue_iff_hasEigenvalue hcoeff hcoercive (inv_ne_zero hnorm_pos.ne')]
-  simpa using hnorm_eigen
+  rw [firstDirichletEigenvalue_def, dirichletSolutionOperator]
+  obtain ⟨u, hu, heq⟩ := hcoercive.exists_ne_zero_forall_apply_eq_inv_norm_smul_inner
+    (W1p0.isCompactOperator_valueL (by simp) hOmega) (energyFormH1L0_comm hcoeff hsymm)
+    (W1p0.valueL_ne_zero hOmega_nonempty)
+  refine ⟨u, hu, fun v => ?_⟩
+  have hv := heq v
+  rwa [energyFormH1L0_apply, W1p0.valueL_apply, W1p0.valueL_apply] at hv
 
 /-- The first Dirichlet eigenvalue is positive. -/
 theorem firstDirichletEigenvalue_pos
@@ -415,6 +394,87 @@ theorem le_firstDirichletEigenvalue
     C ≤ firstDirichletEigenvalue hcoeff hcoercive :=
   le_of_isDirichletEigenvalue hcoeff hcoercive hlower
     (isDirichletEigenvalue_first hcoeff hcoercive hOmega hsymm hOmega_nonempty)
+
+/-! ### The Rayleigh principle -/
+
+/-- **The first Dirichlet eigenvalue is a Poincaré constant for the energy form**:
+
+`κ₁ ‖u‖²_{L²(Ω)} ≤ a(u, u)` for every `u ∈ H¹₀(Ω)`,
+
+and by `TauCeti.PDE.isGreatest_setOf_forall_mul_norm_value_sq_le` it is the largest constant for
+which this holds.  Neither boundedness nor nonemptiness of `Ω` is needed here: only coercivity,
+which makes the solution operator exist, and symmetry, which gives the energy form its
+Cauchy--Schwarz inequality. -/
+theorem firstDirichletEigenvalue_mul_norm_value_sq_le
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
+    (hcoercive : IsCoercive (energyFormH1L0 hcoeff))
+    (hsymm : ∀ u v : W1p0 mu Omega 2,
+      energyFormH1 a b c (u : W1p mu Omega 2) (v : W1p mu Omega 2) =
+        energyFormH1 a b c (v : W1p mu Omega 2) (u : W1p mu Omega 2))
+    (u : W1p0 mu Omega 2) :
+    firstDirichletEigenvalue hcoeff hcoercive * ‖W1p.value (u : W1p mu Omega 2)‖ ^ 2 ≤
+      energyFormH1 a b c (u : W1p mu Omega 2) (u : W1p mu Omega 2) := by
+  rw [firstDirichletEigenvalue_def, dirichletSolutionOperator]
+  have h := hcoercive.inv_norm_formSolutionOperator_mul_norm_apply_sq_le
+    (W1p0.valueL (mu := mu) (Omega := Omega) (p := 2)) (energyFormH1L0_comm hcoeff hsymm) u
+  rwa [energyFormH1L0_apply, W1p0.valueL_apply] at h
+
+/-- **The Rayleigh principle for the Dirichlet problem.**  On a nonempty bounded domain with a
+symmetric energy form, the first Dirichlet eigenvalue is the *minimum* of the Rayleigh quotient
+
+`a(u, u) / ‖u‖²_{L²(Ω)}`
+
+over the `u ∈ H¹₀(Ω)` with nonzero `L²` value; the minimum is attained at an eigenfunction.
+Boundedness of `Ω` enters only through the attainment, by way of Rellich--Kondrachov: the
+inequality alone is `TauCeti.PDE.firstDirichletEigenvalue_mul_norm_value_sq_le`. -/
+theorem isLeast_rayleighQuotient_firstDirichletEigenvalue
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
+    (hcoercive : IsCoercive (energyFormH1L0 hcoeff))
+    (hOmega : IsBounded (Omega : Set (EuclideanSpace ℝ ι)))
+    (hsymm : ∀ u v : W1p0 mu Omega 2,
+      energyFormH1 a b c (u : W1p mu Omega 2) (v : W1p mu Omega 2) =
+        energyFormH1 a b c (v : W1p mu Omega 2) (u : W1p mu Omega 2))
+    (hOmega_nonempty : (Omega : Set (EuclideanSpace ℝ ι)).Nonempty) :
+    IsLeast {r : ℝ | ∃ u : W1p0 mu Omega 2, W1p.value (u : W1p mu Omega 2) ≠ 0 ∧
+        energyFormH1 a b c (u : W1p mu Omega 2) (u : W1p mu Omega 2) /
+          ‖W1p.value (u : W1p mu Omega 2)‖ ^ 2 = r}
+      (firstDirichletEigenvalue hcoeff hcoercive) := by
+  have hset : {r : ℝ | ∃ u : W1p0 mu Omega 2, W1p.value (u : W1p mu Omega 2) ≠ 0 ∧
+      energyFormH1 a b c (u : W1p mu Omega 2) (u : W1p mu Omega 2) /
+        ‖W1p.value (u : W1p mu Omega 2)‖ ^ 2 = r} =
+      {r : ℝ | ∃ u : W1p0 mu Omega 2, W1p0.valueL u ≠ 0 ∧
+        energyFormH1L0 hcoeff u u / ‖W1p0.valueL u‖ ^ 2 = r} := by
+    simp only [W1p0.valueL_apply, energyFormH1L0_apply]
+  rw [hset, firstDirichletEigenvalue_def, dirichletSolutionOperator]
+  exact hcoercive.isLeast_rayleighQuotient (W1p0.isCompactOperator_valueL (by simp) hOmega)
+    (energyFormH1L0_comm hcoeff hsymm) (W1p0.valueL_ne_zero hOmega_nonempty)
+
+/-- **The first Dirichlet eigenvalue is the optimal Poincaré constant** of the energy form: it is
+the greatest `C` with `C ‖u‖²_{L²(Ω)} ≤ a(u, u)` for all `u ∈ H¹₀(Ω)`.  This is the Rayleigh
+principle read as an inequality, and it is what makes the lower bounds
+`TauCeti.PDE.le_firstDirichletEigenvalue` sharp. -/
+theorem isGreatest_setOf_forall_mul_norm_value_sq_le
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
+    (hcoercive : IsCoercive (energyFormH1L0 hcoeff))
+    (hOmega : IsBounded (Omega : Set (EuclideanSpace ℝ ι)))
+    (hsymm : ∀ u v : W1p0 mu Omega 2,
+      energyFormH1 a b c (u : W1p mu Omega 2) (v : W1p mu Omega 2) =
+        energyFormH1 a b c (v : W1p mu Omega 2) (u : W1p mu Omega 2))
+    (hOmega_nonempty : (Omega : Set (EuclideanSpace ℝ ι)).Nonempty) :
+    IsGreatest {C : ℝ | ∀ u : W1p0 mu Omega 2,
+        C * ‖W1p.value (u : W1p mu Omega 2)‖ ^ 2 ≤
+          energyFormH1 a b c (u : W1p mu Omega 2) (u : W1p mu Omega 2)}
+      (firstDirichletEigenvalue hcoeff hcoercive) := by
+  have hset : {C : ℝ | ∀ u : W1p0 mu Omega 2,
+      C * ‖W1p.value (u : W1p mu Omega 2)‖ ^ 2 ≤
+        energyFormH1 a b c (u : W1p mu Omega 2) (u : W1p mu Omega 2)} =
+      {C : ℝ | ∀ u : W1p0 mu Omega 2,
+        C * ‖W1p0.valueL u‖ ^ 2 ≤ energyFormH1L0 hcoeff u u} := by
+    simp only [W1p0.valueL_apply, energyFormH1L0_apply]
+  rw [hset, firstDirichletEigenvalue_def, dirichletSolutionOperator]
+  exact hcoercive.isGreatest_setOf_forall_mul_norm_apply_sq_le
+    (W1p0.isCompactOperator_valueL (by simp) hOmega) (energyFormH1L0_comm hcoeff hsymm)
+    (W1p0.valueL_ne_zero hOmega_nonempty)
 
 /-- **The eigenspaces of the Dirichlet problem are finite dimensional** on a bounded domain. -/
 theorem finiteDimensional_eigenspace_dirichletSolutionOperator

--- a/TauCeti/Analysis/Sobolev/W1p/Zero.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Zero.lean
@@ -45,8 +45,8 @@ subspace under a suitable geometric hypothesis but not on all of `W^{1,p}(Ω)`.
   norm.
 * `TauCeti.W1p0.valueL`: the canonical continuous value map into `Lᵖ(Ω)`.
 * `TauCeti.W1p0.denseRange_valueL_two`: test functions make the value map from
-  `W^{1,2}_0(Ω)` dense in `L²(Ω)`, and `TauCeti.W1p0.valueL_ne_zero`: on a nonempty `Ω` that map
-  is nonzero.
+  `W^{1,2}_0(Ω)` dense in `L²(Ω)`, and `TauCeti.W1p0.valueL_ne_zero`: on a nonempty `Ω` the value
+  map is nonzero for every `p`.
 * `TauCeti.w1p0Submodule_subset_of_isClosed`: a closed set containing every test-function jet
   contains `W^{1,p}_0(Ω)`, which is how a property is extended from test functions to the whole
   space.
@@ -212,34 +212,34 @@ theorem W1p0.denseRange_valueL_two :
   rw [hcoe] at hdense
   exact hdense
 
-/-- A nonempty open set contains a zero-boundary Sobolev function with nonzero `L²` value. -/
+/-- A nonempty open set contains a zero-boundary Sobolev function with nonzero `Lᵖ` value. -/
 theorem W1p0.exists_value_ne_zero (hOmega : (Omega : Set E).Nonempty) :
-    ∃ w : W1p0 mu Omega 2, W1p.value (w : W1p mu Omega 2) ≠ 0 := by
+    ∃ w : W1p0 mu Omega p, W1p.value (w : W1p mu Omega p) ≠ 0 := by
   obtain ⟨x, hx⟩ := hOmega
   obtain ⟨g, hgs, hgc, hg, _, hgx⟩ :=
     exists_contDiff_tsupport_subset (n := (⊤ : ℕ∞)) (Omega.isOpen.mem_nhds hx)
   let phi : 𝓓(Omega, ℝ) := ⟨g, hg, hgc, hgs⟩
-  let w : W1p0 mu Omega 2 :=
-    ⟨W1p.ofTestFunctionₗ mu Omega 2 phi, W1p.ofTestFunctionₗ_mem_w1p0Submodule phi⟩
+  let w : W1p0 mu Omega p :=
+    ⟨W1p.ofTestFunctionₗ mu Omega p phi, W1p.ofTestFunctionₗ_mem_w1p0Submodule phi⟩
   refine ⟨w, ?_⟩
   rw [W1p.value_ofTestFunctionₗ]
   intro hzero
-  have hzeroTest : testFunctionLp (mu := mu) (Omega := Omega) 2 (0 : 𝓓(Omega, ℝ)) = 0 := by
+  have hzeroTest : testFunctionLp (mu := mu) (Omega := Omega) p (0 : 𝓓(Omega, ℝ)) = 0 := by
     apply Lp.ext
     exact Filter.EventuallyEq.trans
-      (testFunctionLp_apply_ae (mu := mu) 2 (0 : 𝓓(Omega, ℝ)))
-      (Lp.coeFn_zero ℝ 2 (mu.restrict Omega)).symm
-  have hphi : phi = 0 := testFunctionLp_injective 2 (hzero.trans hzeroTest.symm)
+      (testFunctionLp_apply_ae (mu := mu) p (0 : 𝓓(Omega, ℝ)))
+      (Lp.coeFn_zero ℝ p (mu.restrict Omega)).symm
+  have hphi : phi = 0 := testFunctionLp_injective p (hzero.trans hzeroTest.symm)
   have : g x = 0 := by
     have := congrArg (fun q : 𝓓(Omega, ℝ) => q x) hphi
     simpa [phi] using this
   linarith
 
-/-- On a nonempty open set the value map `W^{1,2}_0(Ω) → L²(Ω)` is nonzero: it does not kill the
+/-- On a nonempty open set the value map `W^{1,p}_0(Ω) → Lᵖ(Ω)` is nonzero: it does not kill the
 test function of `TauCeti.W1p0.exists_value_ne_zero`. -/
 theorem W1p0.valueL_ne_zero (hOmega : (Omega : Set E).Nonempty) :
-    (W1p0.valueL (mu := mu) (Omega := Omega) (p := 2)) ≠ 0 := by
-  obtain ⟨w, hw⟩ := W1p0.exists_value_ne_zero (mu := mu) (Omega := Omega) hOmega
+    (W1p0.valueL (mu := mu) (Omega := Omega) (p := p)) ≠ 0 := by
+  obtain ⟨w, hw⟩ := W1p0.exists_value_ne_zero (mu := mu) (Omega := Omega) (p := p) hOmega
   exact fun hzero => hw (by rw [← W1p0.valueL_apply, hzero, zero_apply])
 
 /-- `W^{1,p}_0(Ω)` is complete: it is a closed subspace of the complete space `W^{1,p}(Ω)`. -/

--- a/TauCeti/Analysis/Sobolev/W1p/Zero.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Zero.lean
@@ -45,7 +45,8 @@ subspace under a suitable geometric hypothesis but not on all of `W^{1,p}(Ω)`.
   norm.
 * `TauCeti.W1p0.valueL`: the canonical continuous value map into `Lᵖ(Ω)`.
 * `TauCeti.W1p0.denseRange_valueL_two`: test functions make the value map from
-  `W^{1,2}_0(Ω)` dense in `L²(Ω)`.
+  `W^{1,2}_0(Ω)` dense in `L²(Ω)`, and `TauCeti.W1p0.valueL_ne_zero`: on a nonempty `Ω` that map
+  is nonzero.
 * `TauCeti.w1p0Submodule_subset_of_isClosed`: a closed set containing every test-function jet
   contains `W^{1,p}_0(Ω)`, which is how a property is extended from test functions to the whole
   space.
@@ -233,6 +234,13 @@ theorem W1p0.exists_value_ne_zero (hOmega : (Omega : Set E).Nonempty) :
     have := congrArg (fun q : 𝓓(Omega, ℝ) => q x) hphi
     simpa [phi] using this
   linarith
+
+/-- On a nonempty open set the value map `W^{1,2}_0(Ω) → L²(Ω)` is nonzero: it does not kill the
+test function of `TauCeti.W1p0.exists_value_ne_zero`. -/
+theorem W1p0.valueL_ne_zero (hOmega : (Omega : Set E).Nonempty) :
+    (W1p0.valueL (mu := mu) (Omega := Omega) (p := 2)) ≠ 0 := by
+  obtain ⟨w, hw⟩ := W1p0.exists_value_ne_zero (mu := mu) (Omega := Omega) hOmega
+  exact fun hzero => hw (by rw [← W1p0.valueL_apply, hzero, zero_apply])
 
 /-- `W^{1,p}_0(Ω)` is complete: it is a closed subspace of the complete space `W^{1,p}(Ω)`. -/
 instance : CompleteSpace (W1p0 mu Omega p) :=

--- a/TauCeti/LinearAlgebra/BilinearForm/PosSemidef.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/PosSemidef.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.QuadraticDiscriminant
 public import Mathlib.LinearAlgebra.BilinearForm.Properties
 
 /-!
@@ -18,6 +19,10 @@ quadratic-form signature criteria and other pointwise positivity arguments.
 
 * `LinearMap.BilinForm.isPosSemidef_iff_forall_nonneg`: a symmetric bilinear form is
   positive-semidefinite exactly when its diagonal values are nonnegative.
+* `LinearMap.BilinForm.IsPosSemidef.sq_apply_le_mul_apply_self`: the Cauchy--Schwarz inequality
+  `B u v ^ 2 ≤ B u u * B v v` for a positive-semidefinite form over a linearly ordered field.
+  The form need not be definite, so this covers the energy form of a merely coercive variational
+  problem as well as an inner product.
 -/
 
 public section
@@ -33,5 +38,29 @@ theorem isPosSemidef_iff_forall_nonneg (B : LinearMap.BilinForm R M) (hB : B.IsS
     B.IsPosSemidef ↔ ∀ x, 0 ≤ B x x := by
   rw [LinearMap.BilinForm.isPosSemidef_def, LinearMap.BilinForm.isNonneg_def]
   simp only [hB, true_and]
+
+section LinearOrderedField
+
+variable {R M : Type*} [Field R] [LinearOrder R] [IsStrictOrderedRing R] [AddCommGroup M]
+  [Module R M] {B : LinearMap.BilinForm R M}
+
+/-- **The Cauchy--Schwarz inequality for a positive-semidefinite bilinear form**:
+`(B u v)² ≤ B u u · B v v`.  Definiteness is not needed: the quadratic
+`t ↦ B (u + t • v) (u + t • v)` is nonnegative, so its discriminant is nonpositive. -/
+theorem IsPosSemidef.sq_apply_le_mul_apply_self (hB : B.IsPosSemidef) (u v : M) :
+    B u v ^ 2 ≤ B u u * B v v := by
+  have hsymm := LinearMap.BilinForm.isSymm_def.1 hB.isSymm
+  have hexp : ∀ t : R, B (u + t • v) (u + t • v) = B v v * (t * t) + 2 * B u v * t + B u u := by
+    intro t
+    simp only [map_add, map_smul, LinearMap.add_apply, LinearMap.smul_apply, smul_eq_mul,
+      hsymm v u]
+    ring
+  have hquad : ∀ t : R, 0 ≤ B v v * (t * t) + 2 * B u v * t + B u u := fun t =>
+    (hexp t) ▸ hB.isNonneg.nonneg (u + t • v)
+  have hdiscrim := discrim_le_zero hquad
+  simp only [discrim] at hdiscrim
+  linarith [hdiscrim]
+
+end LinearOrderedField
 
 end LinearMap.BilinForm

--- a/TauCeti/LinearAlgebra/BilinearForm/PosSemidef.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/PosSemidef.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.QuadraticDiscriminant
 public import Mathlib.LinearAlgebra.BilinearForm.Properties
 
 /-!
@@ -19,10 +18,6 @@ quadratic-form signature criteria and other pointwise positivity arguments.
 
 * `LinearMap.BilinForm.isPosSemidef_iff_forall_nonneg`: a symmetric bilinear form is
   positive-semidefinite exactly when its diagonal values are nonnegative.
-* `LinearMap.BilinForm.IsPosSemidef.sq_apply_le_mul_apply_self`: the Cauchy--Schwarz inequality
-  `B u v ^ 2 ≤ B u u * B v v` for a positive-semidefinite form over a linearly ordered field.
-  The form need not be definite, so this covers the energy form of a merely coercive variational
-  problem as well as an inner product.
 -/
 
 public section
@@ -38,29 +33,5 @@ theorem isPosSemidef_iff_forall_nonneg (B : LinearMap.BilinForm R M) (hB : B.IsS
     B.IsPosSemidef ↔ ∀ x, 0 ≤ B x x := by
   rw [LinearMap.BilinForm.isPosSemidef_def, LinearMap.BilinForm.isNonneg_def]
   simp only [hB, true_and]
-
-section LinearOrderedField
-
-variable {R M : Type*} [Field R] [LinearOrder R] [IsStrictOrderedRing R] [AddCommGroup M]
-  [Module R M] {B : LinearMap.BilinForm R M}
-
-/-- **The Cauchy--Schwarz inequality for a positive-semidefinite bilinear form**:
-`(B u v)² ≤ B u u · B v v`.  Definiteness is not needed: the quadratic
-`t ↦ B (u + t • v) (u + t • v)` is nonnegative, so its discriminant is nonpositive. -/
-theorem IsPosSemidef.sq_apply_le_mul_apply_self (hB : B.IsPosSemidef) (u v : M) :
-    B u v ^ 2 ≤ B u u * B v v := by
-  have hsymm := LinearMap.BilinForm.isSymm_def.1 hB.isSymm
-  have hexp : ∀ t : R, B (u + t • v) (u + t • v) = B v v * (t * t) + 2 * B u v * t + B u u := by
-    intro t
-    simp only [map_add, map_smul, LinearMap.add_apply, LinearMap.smul_apply, smul_eq_mul,
-      hsymm v u]
-    ring
-  have hquad : ∀ t : R, 0 ≤ B v v * (t * t) + 2 * B u v * t + B u u := fun t =>
-    (hexp t) ▸ hB.isNonneg.nonneg (u + t • v)
-  have hdiscrim := discrim_le_zero hquad
-  simp only [discrim] at hdiscrim
-  linarith [hdiscrim]
-
-end LinearOrderedField
 
 end LinearMap.BilinForm


### PR DESCRIPTION
This PR proves the Rayleigh characterisation of the first Dirichlet eigenvalue of a divergence-form elliptic operator `L u = -∂ⱼ(aⁱʲ ∂ᵢu) + bⁱ ∂ᵢu + c u` on an open `Ω ⊆ ℝⁿ`: on a nonempty bounded domain with a coercive symmetric energy form, `κ₁` is the *minimum* of the Rayleigh quotient `a(u, u) / ‖u‖²_{L²(Ω)}` over the `u ∈ H¹₀(Ω)` with nonzero `L²` value (`TauCeti.PDE.isLeast_rayleighQuotient_firstDirichletEigenvalue`), equivalently the greatest constant `C` for which the Poincaré-type inequality `C‖u‖²_{L²(Ω)} ≤ a(u, u)` holds on `H¹₀(Ω)` (`TauCeti.PDE.isGreatest_firstDirichletEigenvalue`). The inequality half, `TauCeti.PDE.firstDirichletEigenvalue_mul_norm_value_sq_le`, needs neither boundedness nor nonemptiness of `Ω`; boundedness enters only through the attainment, by way of Rellich--Kondrachov.

This serves Lane D milestone 19 of `TauCetiRoadmap/PDE/README.md` ("Spectrum of `−Δ`: the Dirichlet eigenvalues/eigenfunctions of `−Δ` on a bounded `Ω`") and its acceptance criterion "Eigenvalues are real and positive: the first Dirichlet eigenvalue of `−Δ` is positive, matching the Poincaré constant" — the `IsGreatest` statement is exactly that matching, identifying `κ₁` with the optimal Poincaré constant of the energy form and making the existing lower bounds `TauCeti.PDE.le_firstDirichletEigenvalue` and `TauCeti.PDE.le_of_isDirichletEigenvalue_laplacian_of_subset_ball` sharp. What D.19 still owes after this PR is the ordered eigenvalue sequence with its higher-eigenvalue min-max characterisation and the orthonormal basis of eigenfunctions (only the density of their span, `TauCeti.PDE.orthogonalComplement_iSup_eigenspaces_ne_zero_dirichletSolutionOperator_eq_bot`, is available today).

The mathematics splits in two, and so does the file layout. The lower bound is Cauchy--Schwarz in the energy form: solving `B w u = ⟪J v, J u⟫` gives `‖J v‖² = B w v` and `B w w = ⟪J v, S (J v)⟫ ≤ ‖S‖‖J v‖²`, and `(B w v)² ≤ B w w · B v v` closes the loop, where `S` is the abstract solution operator `IsCoercive.formSolutionOperator` and `κ₁ = ‖S‖⁻¹`. That Cauchy--Schwarz inequality is not in Mathlib for a merely semidefinite form, so `TauCeti/LinearAlgebra/BilinearForm/PosSemidef.lean` gains `LinearMap.BilinForm.IsPosSemidef.sq_apply_le_mul_apply_self` over any linearly ordered field, proved from Mathlib's `discrim_le_zero` applied to `t ↦ B (u + t • v) (u + t • v)`; the new `TauCeti/Analysis/InnerProductSpace/Variational/Rayleigh.lean` transfers it to continuous bilinear forms and runs the argument abstractly, ending in `IsCoercive.isLeast_rayleighQuotient` and `IsCoercive.isGreatest_inv_norm_formSolutionOperator` for a coercive symmetric `B` and a compact `J : V →L[ℝ] H`. The attainment reuses the spectral argument that `‖S‖` is an eigenvalue of the compact positive symmetric `S`; that argument previously sat inside `TauCeti.PDE.isDirichletEigenvalue_first`, so it moves up to the abstract file as `IsCoercive.exists_ne_zero_forall_apply_eq_inv_norm_smul_inner` and the Dirichlet proof now consumes it, shrinking from thirty-odd lines to six. Two smaller extractions go the same way: the "an eigenfunction has nonzero image" step becomes `IsCoercive.apply_ne_zero_of_forall_apply_eq_smul_inner` in `Variational/Spectrum.lean` (used three times), and the nonvanishing of the value map `H¹₀(Ω) → L²(Ω)` on a nonempty domain becomes `TauCeti.W1p0.valueL_ne_zero` next to `TauCeti.W1p0.exists_value_ne_zero`, replacing two copies of the same three lines.

No Mathlib source was vendored. Mathlib is consumed for `discrim_le_zero`, `LinearMap.BilinForm.IsPosSemidef`, the norm/Rayleigh-quotient description of the spectrum of a compact symmetric operator, and Lax--Milgram underneath the solution operator.

Roadmap: PDE

<!--tauceti-target:v1 {"focus":"PDE","id":"rayleigh-first-dirichlet-eigenvalue"}-->

🤖 Prepared with Claude Code

