### PR TITLE
feat: glue inverse semigroups into a C₀ group

### DIFF
--- a/TauCeti/Analysis/Semigroups/Group/InverseSemigroups.lean
+++ b/TauCeti/Analysis/Semigroups/Group/InverseSemigroups.lean
@@ -1,0 +1,281 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Semigroups.Group.Basic
+
+/-!
+# Gluing inverse semigroups into a strongly continuous group
+
+Two strongly continuous semigroups form the positive and negative halves of a strongly continuous
+group when their operators at equal times are mutual inverses. This file constructs the group by
+using the first semigroup at nonnegative times and the second one at nonpositive times.
+
+The construction isolates the gluing step used in generation results for two-sided groups. In
+particular, a Stone-type construction can generate contraction semigroups for an operator and its
+negative separately, prove that their operators are inverse, and then apply
+`StronglyContinuousSemigroup.toGroupOfInverse`.
+
+## Main declarations
+
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.comp_comm_of_inverse`: operators from the two
+  semigroups commute, even at different times.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.toGroupOfInverse`: glue two mutually inverse
+  C₀-semigroups into a C₀-group.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.toGroupOfInverse_toSemigroup`: the positive half
+  of the glued group is the first semigroup.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.toGroupOfInverse_reflect_toSemigroup`: the
+  positive half of the reflected group is the second semigroup.
+
+## References
+
+* K.-J. Engel and R. Nagel, *One-Parameter Semigroups for Linear Evolution Equations*,
+  Section II.3.11.
+-/
+
+public section
+
+noncomputable section
+
+open scoped NNReal Topology
+
+namespace TauCeti.Semigroups
+
+namespace StronglyContinuousSemigroup
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
+
+variable (S T : StronglyContinuousSemigroup X)
+
+omit [CompleteSpace X] in
+/-- The operators of mutually inverse semigroups commute, also when their time parameters differ.
+This is the cancellation step needed for the mixed-sign cases in the group law. -/
+theorem comp_comm_of_inverse
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X)
+    (s t : ℝ≥0) : (S s).comp (T t) = (T t).comp (S s) := by
+  ext x
+  apply (Function.LeftInverse.injective (g := S s) fun y => by
+    have h := congrArg (fun A : X →L[ℝ] X => A y) (hST s)
+    simpa using h)
+  calc
+    T s (S s (T t x)) = T t x := by
+      have h := congrArg (fun A : X →L[ℝ] X => A (T t x)) (hTS s)
+      simpa using h
+    _ = T t (T s (S s x)) := by
+      have h := congrArg (fun A : X →L[ℝ] X => A x) (hTS s)
+      simpa using congrArg (T t) h.symm
+    _ = T s (T t (S s x)) := by
+      rw [← T.map_add_apply, ← T.map_add_apply, add_comm]
+
+/-- Evaluation of the piecewise operator family used to glue two semigroups. -/
+private def inverseGluingFun (t : ℝ) : X →L[ℝ] X :=
+  if 0 ≤ t then S.realOperator t else T.realOperator (-t)
+
+omit [CompleteSpace X] in
+private theorem inverseGluingFun_of_nonneg {t : ℝ} (ht : 0 ≤ t) :
+    inverseGluingFun S T t = S.realOperator t := by
+  simp [inverseGluingFun, ht]
+
+omit [CompleteSpace X] in
+private theorem inverseGluingFun_of_nonpos {t : ℝ} (ht : t ≤ 0) :
+    inverseGluingFun S T t = T.realOperator (-t) := by
+  rcases ht.eq_or_lt with rfl | ht
+  · simp [inverseGluingFun]
+  · simp [inverseGluingFun, not_le.mpr ht]
+
+omit [CompleteSpace X] in
+private theorem inverseGluingFun_map_add
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X)
+    (s t : ℝ) :
+    inverseGluingFun S T (s + t) =
+      (inverseGluingFun S T s).comp (inverseGluingFun S T t) := by
+  -- For equal signs this is one of the original semigroup laws. For mixed signs, split
+  -- according to the sign of the sum, factor the longer-time operator, and cancel the inverse
+  -- pair. The two mixed orders differ only by cross-commutation.
+  by_cases hs : 0 ≤ s
+  · by_cases ht : 0 ≤ t
+    · rw [inverseGluingFun_of_nonneg S T hs,
+          inverseGluingFun_of_nonneg S T ht,
+          inverseGluingFun_of_nonneg S T (add_nonneg hs ht)]
+      exact S.realOperator_add s t hs ht
+    · have ht' : t ≤ 0 := le_of_lt (not_le.mp ht)
+      by_cases hst : 0 ≤ s + t
+      · rw [inverseGluingFun_of_nonneg S T hs,
+            inverseGluingFun_of_nonpos S T ht',
+            inverseGluingFun_of_nonneg S T hst]
+        ext x
+        have hneg : 0 ≤ -t := neg_nonneg.mpr ht'
+        have hmap : S.realOperator s =
+            (S.realOperator (s + t)).comp (S.realOperator (-t)) := by
+          have h := S.realOperator_add (s + t) (-t) hst hneg
+          rw [show s + t + -t = s by ring] at h
+          exact h
+        rw [hmap, ContinuousLinearMap.comp_apply, ContinuousLinearMap.comp_apply]
+        have hinv : (S.realOperator (-t)).comp (T.realOperator (-t)) =
+            ContinuousLinearMap.id ℝ X := by
+          simpa only [S.realOperator_def, T.realOperator_def,
+            Real.toNNReal_of_nonneg hneg] using hST (-t).toNNReal
+        have hinvApply := congrArg (fun A : X →L[ℝ] X => A x) hinv
+        rw [ContinuousLinearMap.comp_apply] at hinvApply
+        simpa using (congrArg (S.realOperator (s + t)) hinvApply).symm
+      · have hst' : s + t ≤ 0 := le_of_lt (not_le.mp hst)
+        rw [inverseGluingFun_of_nonneg S T hs,
+          inverseGluingFun_of_nonpos S T ht',
+          inverseGluingFun_of_nonpos S T hst']
+        ext x
+        have hnegSum : 0 ≤ -(s + t) := neg_nonneg.mpr hst'
+        have hmap : T.realOperator (-t) =
+            (T.realOperator (-(s + t))).comp (T.realOperator s) := by
+          have h := T.realOperator_add (-(s + t)) s hnegSum hs
+          rw [show -(s + t) + s = -t by ring] at h
+          exact h
+        rw [hmap, ContinuousLinearMap.comp_apply, ContinuousLinearMap.comp_apply]
+        have hcomm : (S.realOperator s).comp (T.realOperator (-(s + t))) =
+            (T.realOperator (-(s + t))).comp (S.realOperator s) := by
+          simpa only [S.realOperator_def, T.realOperator_def, Real.toNNReal_of_nonneg hs,
+            Real.toNNReal_of_nonneg hnegSum] using
+            S.comp_comm_of_inverse T hST hTS s.toNNReal (-(s + t)).toNNReal
+        have hcommApply := congrArg
+          (fun A : X →L[ℝ] X => A (T.realOperator s x)) hcomm
+        rw [ContinuousLinearMap.comp_apply, ContinuousLinearMap.comp_apply] at hcommApply
+        rw [hcommApply]
+        have hinv : (S.realOperator s).comp (T.realOperator s) =
+            ContinuousLinearMap.id ℝ X := by
+          simpa only [S.realOperator_def, T.realOperator_def,
+            Real.toNNReal_of_nonneg hs] using hST s.toNNReal
+        have hinvApply := congrArg (fun A : X →L[ℝ] X => A x) hinv
+        rw [ContinuousLinearMap.comp_apply] at hinvApply
+        simpa using (congrArg (T.realOperator (-(s + t))) hinvApply).symm
+  · have hs' : s ≤ 0 := le_of_lt (not_le.mp hs)
+    by_cases ht : 0 ≤ t
+    · by_cases hst : 0 ≤ s + t
+      · rw [inverseGluingFun_of_nonpos S T hs',
+          inverseGluingFun_of_nonneg S T ht,
+          inverseGluingFun_of_nonneg S T hst]
+        ext x
+        have hsneg : 0 ≤ -s := neg_nonneg.mpr hs'
+        have hmap : S.realOperator t =
+            (S.realOperator (s + t)).comp (S.realOperator (-s)) := by
+          have h := S.realOperator_add (s + t) (-s) hst hsneg
+          rw [show s + t + -s = t by ring] at h
+          exact h
+        have hcomm : (S.realOperator t).comp (T.realOperator (-s)) =
+            (T.realOperator (-s)).comp (S.realOperator t) := by
+          simpa only [S.realOperator_def, T.realOperator_def,
+            Real.toNNReal_of_nonneg ht, Real.toNNReal_of_nonneg hsneg] using
+            S.comp_comm_of_inverse T hST hTS t.toNNReal (-s).toNNReal
+        rw [← hcomm, hmap, ContinuousLinearMap.comp_apply,
+          ContinuousLinearMap.comp_apply]
+        have hinv : (S.realOperator (-s)).comp (T.realOperator (-s)) =
+            ContinuousLinearMap.id ℝ X := by
+          simpa only [S.realOperator_def, T.realOperator_def,
+            Real.toNNReal_of_nonneg hsneg] using hST (-s).toNNReal
+        have hinvApply := congrArg (fun A : X →L[ℝ] X => A x) hinv
+        rw [ContinuousLinearMap.comp_apply] at hinvApply
+        simpa using (congrArg (S.realOperator (s + t)) hinvApply).symm
+      · have hst' : s + t ≤ 0 := le_of_lt (not_le.mp hst)
+        rw [inverseGluingFun_of_nonpos S T hs',
+          inverseGluingFun_of_nonneg S T ht,
+          inverseGluingFun_of_nonpos S T hst']
+        ext x
+        have hnegSum : 0 ≤ -(s + t) := neg_nonneg.mpr hst'
+        have hsneg : 0 ≤ -s := neg_nonneg.mpr hs'
+        have hmap : T.realOperator (-s) =
+            (T.realOperator (-(s + t))).comp (T.realOperator t) := by
+          have h := T.realOperator_add (-(s + t)) t hnegSum ht
+          rw [show -(s + t) + t = -s by ring] at h
+          exact h
+        rw [hmap, ContinuousLinearMap.comp_apply, ContinuousLinearMap.comp_apply]
+        have hinv : (T.realOperator t).comp (S.realOperator t) =
+            ContinuousLinearMap.id ℝ X := by
+          simpa only [S.realOperator_def, T.realOperator_def,
+            Real.toNNReal_of_nonneg ht] using hTS t.toNNReal
+        have hinvApply := congrArg (fun A : X →L[ℝ] X => A x) hinv
+        rw [ContinuousLinearMap.comp_apply] at hinvApply
+        simpa using (congrArg (T.realOperator (-(s + t))) hinvApply).symm
+    · have ht' : t ≤ 0 := le_of_lt (not_le.mp ht)
+      have hst : s + t ≤ 0 := add_nonpos hs' ht'
+      rw [inverseGluingFun_of_nonpos S T hs',
+        inverseGluingFun_of_nonpos S T ht',
+        inverseGluingFun_of_nonpos S T hst]
+      have hsneg : 0 ≤ -s := neg_nonneg.mpr hs'
+      have htneg : 0 ≤ -t := neg_nonneg.mpr ht'
+      have hsum : -(s + t) = -s + -t := by ring
+      rw [hsum, T.realOperator_add (-s) (-t) hsneg htneg]
+
+private theorem continuous_inverseGluingFun_apply (x : X) :
+    Continuous fun t : ℝ => inverseGluingFun S T t x := by
+  have h := continuous_if_le (f := fun _ : ℝ => (0 : ℝ)) (g := id)
+    (f' := fun t : ℝ => S.realOperator t x)
+    (g' := fun t : ℝ => T.realOperator (-t) x)
+    continuous_const continuous_id (S.realOperator_continuousOn_Ici x)
+    ((T.realOperator_continuousOn_Ici x).comp continuous_neg.continuousOn fun t ht => by
+      simpa only [Set.mem_Ici] using neg_nonneg.mpr ht)
+    (fun t ht => by simp only [id_eq] at ht; subst t; simp)
+  simpa only [inverseGluingFun, id_eq, DFunLike.ite_apply] using h
+
+/-- Glue two strongly continuous semigroups whose equal-time operators are mutual inverses into a
+strongly continuous group. The first semigroup supplies nonnegative times and the second supplies
+negative times, with time reflected at zero. -/
+def toGroupOfInverse
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X) :
+    StronglyContinuousGroup X where
+  toFun := inverseGluingFun S T
+  map_zero' := by simp [inverseGluingFun]
+  map_add' := inverseGluingFun_map_add S T hST hTS
+  continuousAt_zero' x := (continuous_inverseGluingFun_apply S T x).continuousAt
+
+/-- At nonnegative time, the group obtained by gluing inverse semigroups is the first semigroup. -/
+@[simp]
+theorem toGroupOfInverse_apply_of_nonneg
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X)
+    {t : ℝ} (ht : 0 ≤ t) :
+    S.toGroupOfInverse T hST hTS t = S.realOperator t :=
+  inverseGluingFun_of_nonneg S T ht
+
+/-- At nonpositive time, the group obtained by gluing inverse semigroups is the second semigroup
+at the reflected time. -/
+@[simp]
+theorem toGroupOfInverse_apply_of_nonpos
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X)
+    {t : ℝ} (ht : t ≤ 0) :
+    S.toGroupOfInverse T hST hTS t = T.realOperator (-t) :=
+  inverseGluingFun_of_nonpos S T ht
+
+/-- The forward semigroup of the group obtained by gluing inverse semigroups is the first
+semigroup. -/
+@[simp]
+theorem toGroupOfInverse_toSemigroup
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X) :
+    (S.toGroupOfInverse T hST hTS).toSemigroup = S := by
+  ext t
+  rw [StronglyContinuousGroup.toSemigroup_apply,
+    toGroupOfInverse_apply_of_nonneg S T hST hTS t.coe_nonneg,
+    S.realOperator_coe]
+
+/-- The forward semigroup of the reflected group obtained by gluing inverse semigroups is the
+second semigroup. -/
+@[simp]
+theorem toGroupOfInverse_reflect_toSemigroup
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X) :
+    (S.toGroupOfInverse T hST hTS).reflect.toSemigroup = T := by
+  ext t
+  rw [StronglyContinuousGroup.toSemigroup_apply, StronglyContinuousGroup.reflect_apply,
+    toGroupOfInverse_apply_of_nonpos S T hST hTS (neg_nonpos.mpr t.coe_nonneg), neg_neg,
+    T.realOperator_coe]
+
+end StronglyContinuousSemigroup
+
+end TauCeti.Semigroups
+
+end

--- a/TauCeti/Analysis/Semigroups/Group/InverseSemigroups.lean
+++ b/TauCeti/Analysis/Semigroups/Group/InverseSemigroups.lean
@@ -116,7 +116,7 @@ private theorem realOperator_comp_realOperator_of_le
     (S.realOperator a).comp (T.realOperator b) = S.realOperator (a - b) := by
   have hsplit : S.realOperator a = (S.realOperator (a - b)).comp (S.realOperator b) := by
     have h := S.realOperator_add (a - b) b (sub_nonneg.mpr hab) hb
-    rwa [show a - b + b = a by ring] at h
+    rwa [sub_add_cancel] at h
   ext x
   rw [ContinuousLinearMap.comp_apply, hsplit, ContinuousLinearMap.comp_apply,
     realOperator_apply_realOperator_of_inverse S T hST b]
@@ -131,7 +131,7 @@ private theorem realOperator_comp_realOperator_of_ge
     (S.realOperator a).comp (T.realOperator b) = T.realOperator (b - a) := by
   have hsplit : T.realOperator b = (T.realOperator (b - a)).comp (T.realOperator a) := by
     have h := T.realOperator_add (b - a) a (sub_nonneg.mpr hab) ha
-    rwa [show b - a + a = b by ring] at h
+    rwa [sub_add_cancel] at h
   ext x
   rw [ContinuousLinearMap.comp_apply, hsplit, ContinuousLinearMap.comp_apply,
     ← ContinuousLinearMap.comp_apply,
@@ -160,28 +160,27 @@ private theorem inverseGluingFun_map_add
       by_cases hst : 0 ≤ s + t
       · rw [inverseGluingFun_of_nonneg S T hst,
           realOperator_comp_realOperator_of_le S T hST (neg_nonneg.mpr ht') (by linarith),
-          show s - -t = s + t by ring]
+          sub_neg_eq_add]
       · have hst' : s + t ≤ 0 := le_of_lt (not_le.mp hst)
+        have htime : -t - s = -(s + t) := by ring
         rw [inverseGluingFun_of_nonpos S T hst',
-          realOperator_comp_realOperator_of_ge S T hST hTS hs (by linarith),
-          show -t - s = -(s + t) by ring]
+          realOperator_comp_realOperator_of_ge S T hST hTS hs (by linarith), htime]
   · have hs' : s ≤ 0 := le_of_lt (not_le.mp hs)
     by_cases ht : 0 ≤ t
     · rw [inverseGluingFun_of_nonpos S T hs', inverseGluingFun_of_nonneg S T ht,
         ← realOperator_comp_comm_of_inverse S T hST hTS t (-s)]
       by_cases hst : 0 ≤ s + t
-      · rw [inverseGluingFun_of_nonneg S T hst,
-          realOperator_comp_realOperator_of_le S T hST (neg_nonneg.mpr hs') (by linarith),
-          show t - -s = s + t by ring]
+      · have htime : t - -s = s + t := by ring
+        rw [inverseGluingFun_of_nonneg S T hst,
+          realOperator_comp_realOperator_of_le S T hST (neg_nonneg.mpr hs') (by linarith), htime]
       · have hst' : s + t ≤ 0 := le_of_lt (not_le.mp hst)
+        have htime : -s - t = -(s + t) := by ring
         rw [inverseGluingFun_of_nonpos S T hst',
-          realOperator_comp_realOperator_of_ge S T hST hTS ht (by linarith),
-          show -s - t = -(s + t) by ring]
+          realOperator_comp_realOperator_of_ge S T hST hTS ht (by linarith), htime]
     · have ht' : t ≤ 0 := le_of_lt (not_le.mp ht)
       rw [inverseGluingFun_of_nonpos S T hs',
         inverseGluingFun_of_nonpos S T ht',
-        inverseGluingFun_of_nonpos S T (add_nonpos hs' ht'),
-        show -(s + t) = -s + -t by ring,
+        inverseGluingFun_of_nonpos S T (add_nonpos hs' ht'), neg_add,
         T.realOperator_add (-s) (-t) (neg_nonneg.mpr hs') (neg_nonneg.mpr ht')]
 
 omit [CompleteSpace X] in
@@ -297,23 +296,25 @@ reflected forward semigroup is `T` is the group glued from `S` and `T`. Together
 `toGroupOfInverse_toSemigroup` and `toGroupOfInverse_reflect_toSemigroup`, this identifies the
 gluing construction as the two-sided inverse of splitting a C₀-group into its two halves, so a
 group can be recognized as a glued group without repeating a sign split. -/
-theorem eq_toGroupOfInverse (S T : StronglyContinuousSemigroup X)
-    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
-    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X)
+theorem eq_toGroupOfInverse {S T : StronglyContinuousSemigroup X}
     (hS : U.toSemigroup = S) (hT : U.reflect.toSemigroup = T) :
-    U = S.toGroupOfInverse T hST hTS := by
+    U = S.toGroupOfInverse T (hS ▸ hT ▸ U.toSemigroup_comp_reflect_toSemigroup)
+      (hS ▸ hT ▸ U.reflect_toSemigroup_comp_toSemigroup) := by
+  subst hS
+  subst hT
   ext t
   rcases le_or_gt 0 t with ht | ht
-  · rw [StronglyContinuousSemigroup.toGroupOfInverse_apply_of_nonneg S T hST hTS ht, ← hS,
+  · rw [StronglyContinuousSemigroup.toGroupOfInverse_apply_of_nonneg _ _ _ _ ht,
       U.toSemigroup_realOperator_of_nonneg ht]
-  · rw [StronglyContinuousSemigroup.toGroupOfInverse_apply_of_nonpos S T hST hTS ht.le, ← hT,
+  · rw [StronglyContinuousSemigroup.toGroupOfInverse_apply_of_nonpos _ _ _ _ ht.le,
       U.reflect_toSemigroup_realOperator_of_nonneg (neg_nonneg.mpr ht.le), neg_neg]
 
 /-- Gluing the two halves of a C₀-group recovers the group. -/
+@[simp]
 theorem toGroupOfInverse_toSemigroup_reflect_toSemigroup :
     U.toSemigroup.toGroupOfInverse U.reflect.toSemigroup U.toSemigroup_comp_reflect_toSemigroup
       U.reflect_toSemigroup_comp_toSemigroup = U :=
-  (U.eq_toGroupOfInverse _ _ _ _ rfl rfl).symm
+  (U.eq_toGroupOfInverse rfl rfl).symm
 
 end StronglyContinuousGroup
 

--- a/TauCeti/Analysis/Semigroups/Group/InverseSemigroups.lean
+++ b/TauCeti/Analysis/Semigroups/Group/InverseSemigroups.lean
@@ -29,6 +29,8 @@ negative separately, prove that their operators are inverse, and then apply
   of the glued group is the first semigroup.
 * `TauCeti.Semigroups.StronglyContinuousSemigroup.toGroupOfInverse_reflect_toSemigroup`: the
   positive half of the reflected group is the second semigroup.
+* `TauCeti.Semigroups.StronglyContinuousGroup.eq_toGroupOfInverse`: conversely, a C₀-group is the
+  group glued from its own two halves, so gluing is inverse to splitting.
 
 ## References
 
@@ -88,15 +90,65 @@ private theorem inverseGluingFun_of_nonpos {t : ℝ} (ht : t ≤ 0) :
   · simp [inverseGluingFun, not_le.mpr ht]
 
 omit [CompleteSpace X] in
+/-- The real-time, pointwise form of the inverse hypothesis. Negative times are covered too, both
+operators then being the identity. -/
+private theorem realOperator_apply_realOperator_of_inverse
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X) (a : ℝ) (x : X) :
+    S.realOperator a (T.realOperator a x) = x := by
+  have h := congrArg (fun A : X →L[ℝ] X => A x) (hST a.toNNReal)
+  simpa [S.realOperator_def, T.realOperator_def] using h
+
+omit [CompleteSpace X] in
+/-- The real-time form of `comp_comm_of_inverse`. -/
+private theorem realOperator_comp_comm_of_inverse
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X) (a b : ℝ) :
+    (S.realOperator a).comp (T.realOperator b) = (T.realOperator b).comp (S.realOperator a) := by
+  rw [S.realOperator_def, T.realOperator_def]
+  exact S.comp_comm_of_inverse T hST hTS a.toNNReal b.toNNReal
+
+omit [CompleteSpace X] in
+/-- Mixed-sign cancellation when the forward time is the longer one: the backward operator eats
+part of the forward one and leaves the forward operator at the difference. -/
+private theorem realOperator_comp_realOperator_of_le
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    {a b : ℝ} (hb : 0 ≤ b) (hab : b ≤ a) :
+    (S.realOperator a).comp (T.realOperator b) = S.realOperator (a - b) := by
+  have hsplit : S.realOperator a = (S.realOperator (a - b)).comp (S.realOperator b) := by
+    have h := S.realOperator_add (a - b) b (sub_nonneg.mpr hab) hb
+    rwa [show a - b + b = a by ring] at h
+  ext x
+  rw [ContinuousLinearMap.comp_apply, hsplit, ContinuousLinearMap.comp_apply,
+    realOperator_apply_realOperator_of_inverse S T hST b]
+
+omit [CompleteSpace X] in
+/-- Mixed-sign cancellation when the backward time is the longer one: the forward operator is
+absorbed and leaves the backward operator at the difference. -/
+private theorem realOperator_comp_realOperator_of_ge
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X)
+    {a b : ℝ} (ha : 0 ≤ a) (hab : a ≤ b) :
+    (S.realOperator a).comp (T.realOperator b) = T.realOperator (b - a) := by
+  have hsplit : T.realOperator b = (T.realOperator (b - a)).comp (T.realOperator a) := by
+    have h := T.realOperator_add (b - a) a (sub_nonneg.mpr hab) ha
+    rwa [show b - a + a = b by ring] at h
+  ext x
+  rw [ContinuousLinearMap.comp_apply, hsplit, ContinuousLinearMap.comp_apply,
+    ← ContinuousLinearMap.comp_apply,
+    realOperator_comp_comm_of_inverse S T hST hTS a (b - a),
+    ContinuousLinearMap.comp_apply,
+    realOperator_apply_realOperator_of_inverse S T hST a]
+
+omit [CompleteSpace X] in
 private theorem inverseGluingFun_map_add
     (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
     (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X)
     (s t : ℝ) :
     inverseGluingFun S T (s + t) =
       (inverseGluingFun S T s).comp (inverseGluingFun S T t) := by
-  -- For equal signs this is one of the original semigroup laws. For mixed signs, split
-  -- according to the sign of the sum, factor the longer-time operator, and cancel the inverse
-  -- pair. The two mixed orders differ only by cross-commutation.
+  -- For equal signs this is one of the original semigroup laws. For mixed signs, put the two
+  -- operators in the order `S ∘ T` and cancel the shorter time against the longer one; which of
+  -- the two survives is decided by the sign of the sum.
   by_cases hs : 0 ≤ s
   · by_cases ht : 0 ≤ t
     · rw [inverseGluingFun_of_nonneg S T hs,
@@ -104,109 +156,33 @@ private theorem inverseGluingFun_map_add
           inverseGluingFun_of_nonneg S T (add_nonneg hs ht)]
       exact S.realOperator_add s t hs ht
     · have ht' : t ≤ 0 := le_of_lt (not_le.mp ht)
+      rw [inverseGluingFun_of_nonneg S T hs, inverseGluingFun_of_nonpos S T ht']
       by_cases hst : 0 ≤ s + t
-      · rw [inverseGluingFun_of_nonneg S T hs,
-            inverseGluingFun_of_nonpos S T ht',
-            inverseGluingFun_of_nonneg S T hst]
-        ext x
-        have hneg : 0 ≤ -t := neg_nonneg.mpr ht'
-        have hmap : S.realOperator s =
-            (S.realOperator (s + t)).comp (S.realOperator (-t)) := by
-          have h := S.realOperator_add (s + t) (-t) hst hneg
-          rw [show s + t + -t = s by ring] at h
-          exact h
-        rw [hmap, ContinuousLinearMap.comp_apply, ContinuousLinearMap.comp_apply]
-        have hinv : (S.realOperator (-t)).comp (T.realOperator (-t)) =
-            ContinuousLinearMap.id ℝ X := by
-          simpa only [S.realOperator_def, T.realOperator_def,
-            Real.toNNReal_of_nonneg hneg] using hST (-t).toNNReal
-        have hinvApply := congrArg (fun A : X →L[ℝ] X => A x) hinv
-        rw [ContinuousLinearMap.comp_apply] at hinvApply
-        simpa using (congrArg (S.realOperator (s + t)) hinvApply).symm
+      · rw [inverseGluingFun_of_nonneg S T hst,
+          realOperator_comp_realOperator_of_le S T hST (neg_nonneg.mpr ht') (by linarith),
+          show s - -t = s + t by ring]
       · have hst' : s + t ≤ 0 := le_of_lt (not_le.mp hst)
-        rw [inverseGluingFun_of_nonneg S T hs,
-          inverseGluingFun_of_nonpos S T ht',
-          inverseGluingFun_of_nonpos S T hst']
-        ext x
-        have hnegSum : 0 ≤ -(s + t) := neg_nonneg.mpr hst'
-        have hmap : T.realOperator (-t) =
-            (T.realOperator (-(s + t))).comp (T.realOperator s) := by
-          have h := T.realOperator_add (-(s + t)) s hnegSum hs
-          rw [show -(s + t) + s = -t by ring] at h
-          exact h
-        rw [hmap, ContinuousLinearMap.comp_apply, ContinuousLinearMap.comp_apply]
-        have hcomm : (S.realOperator s).comp (T.realOperator (-(s + t))) =
-            (T.realOperator (-(s + t))).comp (S.realOperator s) := by
-          simpa only [S.realOperator_def, T.realOperator_def, Real.toNNReal_of_nonneg hs,
-            Real.toNNReal_of_nonneg hnegSum] using
-            S.comp_comm_of_inverse T hST hTS s.toNNReal (-(s + t)).toNNReal
-        have hcommApply := congrArg
-          (fun A : X →L[ℝ] X => A (T.realOperator s x)) hcomm
-        rw [ContinuousLinearMap.comp_apply, ContinuousLinearMap.comp_apply] at hcommApply
-        rw [hcommApply]
-        have hinv : (S.realOperator s).comp (T.realOperator s) =
-            ContinuousLinearMap.id ℝ X := by
-          simpa only [S.realOperator_def, T.realOperator_def,
-            Real.toNNReal_of_nonneg hs] using hST s.toNNReal
-        have hinvApply := congrArg (fun A : X →L[ℝ] X => A x) hinv
-        rw [ContinuousLinearMap.comp_apply] at hinvApply
-        simpa using (congrArg (T.realOperator (-(s + t))) hinvApply).symm
+        rw [inverseGluingFun_of_nonpos S T hst',
+          realOperator_comp_realOperator_of_ge S T hST hTS hs (by linarith),
+          show -t - s = -(s + t) by ring]
   · have hs' : s ≤ 0 := le_of_lt (not_le.mp hs)
     by_cases ht : 0 ≤ t
-    · by_cases hst : 0 ≤ s + t
-      · rw [inverseGluingFun_of_nonpos S T hs',
-          inverseGluingFun_of_nonneg S T ht,
-          inverseGluingFun_of_nonneg S T hst]
-        ext x
-        have hsneg : 0 ≤ -s := neg_nonneg.mpr hs'
-        have hmap : S.realOperator t =
-            (S.realOperator (s + t)).comp (S.realOperator (-s)) := by
-          have h := S.realOperator_add (s + t) (-s) hst hsneg
-          rw [show s + t + -s = t by ring] at h
-          exact h
-        have hcomm : (S.realOperator t).comp (T.realOperator (-s)) =
-            (T.realOperator (-s)).comp (S.realOperator t) := by
-          simpa only [S.realOperator_def, T.realOperator_def,
-            Real.toNNReal_of_nonneg ht, Real.toNNReal_of_nonneg hsneg] using
-            S.comp_comm_of_inverse T hST hTS t.toNNReal (-s).toNNReal
-        rw [← hcomm, hmap, ContinuousLinearMap.comp_apply,
-          ContinuousLinearMap.comp_apply]
-        have hinv : (S.realOperator (-s)).comp (T.realOperator (-s)) =
-            ContinuousLinearMap.id ℝ X := by
-          simpa only [S.realOperator_def, T.realOperator_def,
-            Real.toNNReal_of_nonneg hsneg] using hST (-s).toNNReal
-        have hinvApply := congrArg (fun A : X →L[ℝ] X => A x) hinv
-        rw [ContinuousLinearMap.comp_apply] at hinvApply
-        simpa using (congrArg (S.realOperator (s + t)) hinvApply).symm
+    · rw [inverseGluingFun_of_nonpos S T hs', inverseGluingFun_of_nonneg S T ht,
+        ← realOperator_comp_comm_of_inverse S T hST hTS t (-s)]
+      by_cases hst : 0 ≤ s + t
+      · rw [inverseGluingFun_of_nonneg S T hst,
+          realOperator_comp_realOperator_of_le S T hST (neg_nonneg.mpr hs') (by linarith),
+          show t - -s = s + t by ring]
       · have hst' : s + t ≤ 0 := le_of_lt (not_le.mp hst)
-        rw [inverseGluingFun_of_nonpos S T hs',
-          inverseGluingFun_of_nonneg S T ht,
-          inverseGluingFun_of_nonpos S T hst']
-        ext x
-        have hnegSum : 0 ≤ -(s + t) := neg_nonneg.mpr hst'
-        have hsneg : 0 ≤ -s := neg_nonneg.mpr hs'
-        have hmap : T.realOperator (-s) =
-            (T.realOperator (-(s + t))).comp (T.realOperator t) := by
-          have h := T.realOperator_add (-(s + t)) t hnegSum ht
-          rw [show -(s + t) + t = -s by ring] at h
-          exact h
-        rw [hmap, ContinuousLinearMap.comp_apply, ContinuousLinearMap.comp_apply]
-        have hinv : (T.realOperator t).comp (S.realOperator t) =
-            ContinuousLinearMap.id ℝ X := by
-          simpa only [S.realOperator_def, T.realOperator_def,
-            Real.toNNReal_of_nonneg ht] using hTS t.toNNReal
-        have hinvApply := congrArg (fun A : X →L[ℝ] X => A x) hinv
-        rw [ContinuousLinearMap.comp_apply] at hinvApply
-        simpa using (congrArg (T.realOperator (-(s + t))) hinvApply).symm
+        rw [inverseGluingFun_of_nonpos S T hst',
+          realOperator_comp_realOperator_of_ge S T hST hTS ht (by linarith),
+          show -s - t = -(s + t) by ring]
     · have ht' : t ≤ 0 := le_of_lt (not_le.mp ht)
-      have hst : s + t ≤ 0 := add_nonpos hs' ht'
       rw [inverseGluingFun_of_nonpos S T hs',
         inverseGluingFun_of_nonpos S T ht',
-        inverseGluingFun_of_nonpos S T hst]
-      have hsneg : 0 ≤ -s := neg_nonneg.mpr hs'
-      have htneg : 0 ≤ -t := neg_nonneg.mpr ht'
-      have hsum : -(s + t) = -s + -t := by ring
-      rw [hsum, T.realOperator_add (-s) (-t) hsneg htneg]
+        inverseGluingFun_of_nonpos S T (add_nonpos hs' ht'),
+        show -(s + t) = -s + -t by ring,
+        T.realOperator_add (-s) (-t) (neg_nonneg.mpr hs') (neg_nonneg.mpr ht')]
 
 omit [CompleteSpace X] in
 private theorem continuousAt_inverseGluingFun_apply (x : X) :
@@ -293,6 +269,53 @@ theorem toGroupOfInverse_reflect_toSemigroup
     T.realOperator_coe]
 
 end StronglyContinuousSemigroup
+
+namespace StronglyContinuousGroup
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+
+variable (U : StronglyContinuousGroup X)
+
+/-- The forward semigroup of a C₀-group and the forward semigroup of its reflection satisfy the
+first inverse hypothesis of
+`TauCeti.Semigroups.StronglyContinuousSemigroup.toGroupOfInverse`. -/
+theorem toSemigroup_comp_reflect_toSemigroup (t : ℝ≥0) :
+    (U.toSemigroup t).comp (U.reflect.toSemigroup t) = ContinuousLinearMap.id ℝ X := by
+  ext x
+  simp
+
+/-- The forward semigroup of a C₀-group and the forward semigroup of its reflection satisfy the
+second inverse hypothesis of
+`TauCeti.Semigroups.StronglyContinuousSemigroup.toGroupOfInverse`. -/
+theorem reflect_toSemigroup_comp_toSemigroup (t : ℝ≥0) :
+    (U.reflect.toSemigroup t).comp (U.toSemigroup t) = ContinuousLinearMap.id ℝ X := by
+  ext x
+  simp
+
+/-- **Gluing is inverse to splitting.** A C₀-group whose forward semigroup is `S` and whose
+reflected forward semigroup is `T` is the group glued from `S` and `T`. Together with
+`toGroupOfInverse_toSemigroup` and `toGroupOfInverse_reflect_toSemigroup`, this identifies the
+gluing construction as the two-sided inverse of splitting a C₀-group into its two halves, so a
+group can be recognized as a glued group without repeating a sign split. -/
+theorem eq_toGroupOfInverse (S T : StronglyContinuousSemigroup X)
+    (hST : ∀ t, (S t).comp (T t) = ContinuousLinearMap.id ℝ X)
+    (hTS : ∀ t, (T t).comp (S t) = ContinuousLinearMap.id ℝ X)
+    (hS : U.toSemigroup = S) (hT : U.reflect.toSemigroup = T) :
+    U = S.toGroupOfInverse T hST hTS := by
+  ext t
+  rcases le_or_gt 0 t with ht | ht
+  · rw [StronglyContinuousSemigroup.toGroupOfInverse_apply_of_nonneg S T hST hTS ht, ← hS,
+      U.toSemigroup_realOperator_of_nonneg ht]
+  · rw [StronglyContinuousSemigroup.toGroupOfInverse_apply_of_nonpos S T hST hTS ht.le, ← hT,
+      U.reflect_toSemigroup_realOperator_of_nonneg (neg_nonneg.mpr ht.le), neg_neg]
+
+/-- Gluing the two halves of a C₀-group recovers the group. -/
+theorem toGroupOfInverse_toSemigroup_reflect_toSemigroup :
+    U.toSemigroup.toGroupOfInverse U.reflect.toSemigroup U.toSemigroup_comp_reflect_toSemigroup
+      U.reflect_toSemigroup_comp_toSemigroup = U :=
+  (U.eq_toGroupOfInverse _ _ _ _ rfl rfl).symm
+
+end StronglyContinuousGroup
 
 end TauCeti.Semigroups
 

--- a/TauCeti/Analysis/Semigroups/Group/InverseSemigroups.lean
+++ b/TauCeti/Analysis/Semigroups/Group/InverseSemigroups.lean
@@ -208,17 +208,31 @@ private theorem inverseGluingFun_map_add
       have hsum : -(s + t) = -s + -t := by ring
       rw [hsum, T.realOperator_add (-s) (-t) hsneg htneg]
 
-private theorem continuous_inverseGluingFun_apply (x : X) :
-    Continuous fun t : ℝ => inverseGluingFun S T t x := by
-  have h := continuous_if_le (f := fun _ : ℝ => (0 : ℝ)) (g := id)
-    (f' := fun t : ℝ => S.realOperator t x)
-    (g' := fun t : ℝ => T.realOperator (-t) x)
-    continuous_const continuous_id (S.realOperator_continuousOn_Ici x)
-    ((T.realOperator_continuousOn_Ici x).comp continuous_neg.continuousOn fun t ht => by
-      simpa only [Set.mem_Ici] using neg_nonneg.mpr ht)
-    (fun t ht => by simp only [id_eq] at ht; subst t; simp)
-  simpa only [inverseGluingFun, id_eq, DFunLike.ite_apply] using h
+omit [CompleteSpace X] in
+private theorem continuousAt_inverseGluingFun_apply (x : X) :
+    ContinuousAt (fun t : ℝ => inverseGluingFun S T t x) 0 := by
+  rw [continuousAt_iff_continuous_left_right]
+  constructor
+  · have hneg : ContinuousWithinAt (fun t : ℝ => -t) (Set.Iic 0) 0 :=
+      continuousAt_neg.continuousWithinAt
+    have hT := ContinuousWithinAt.comp_of_eq (f := fun t : ℝ => -t)
+      (g := fun t : ℝ => T.realOperator t x) (s := Set.Iic 0) (t := Set.Ici 0)
+      (x := 0) (y := 0) (T.realOperator_continuousWithinAt_zero x) hneg
+      (fun t ht => by
+        simp only [Set.mem_Iic] at ht
+        simpa only [Set.mem_Ici] using neg_nonneg.mpr ht)
+      neg_zero
+    apply hT.congr
+    · intro t ht
+      rw [inverseGluingFun_of_nonpos S T ht]
+      rfl
+    · simp [inverseGluingFun]
+  · apply (S.realOperator_continuousWithinAt_zero x).congr
+    · intro t ht
+      rw [inverseGluingFun_of_nonneg S T ht]
+    · simp [inverseGluingFun]
 
+omit [CompleteSpace X] in
 /-- Glue two strongly continuous semigroups whose equal-time operators are mutual inverses into a
 strongly continuous group. The first semigroup supplies nonnegative times and the second supplies
 negative times, with time reflected at zero. -/
@@ -229,8 +243,9 @@ def toGroupOfInverse
   toFun := inverseGluingFun S T
   map_zero' := by simp [inverseGluingFun]
   map_add' := inverseGluingFun_map_add S T hST hTS
-  continuousAt_zero' x := (continuous_inverseGluingFun_apply S T x).continuousAt
+  continuousAt_zero' x := continuousAt_inverseGluingFun_apply S T x
 
+omit [CompleteSpace X] in
 /-- At nonnegative time, the group obtained by gluing inverse semigroups is the first semigroup. -/
 @[simp]
 theorem toGroupOfInverse_apply_of_nonneg
@@ -240,6 +255,7 @@ theorem toGroupOfInverse_apply_of_nonneg
     S.toGroupOfInverse T hST hTS t = S.realOperator t :=
   inverseGluingFun_of_nonneg S T ht
 
+omit [CompleteSpace X] in
 /-- At nonpositive time, the group obtained by gluing inverse semigroups is the second semigroup
 at the reflected time. -/
 @[simp]
@@ -250,6 +266,7 @@ theorem toGroupOfInverse_apply_of_nonpos
     S.toGroupOfInverse T hST hTS t = T.realOperator (-t) :=
   inverseGluingFun_of_nonpos S T ht
 
+omit [CompleteSpace X] in
 /-- The forward semigroup of the group obtained by gluing inverse semigroups is the first
 semigroup. -/
 @[simp]
@@ -262,6 +279,7 @@ theorem toGroupOfInverse_toSemigroup
     toGroupOfInverse_apply_of_nonneg S T hST hTS t.coe_nonneg,
     S.realOperator_coe]
 
+omit [CompleteSpace X] in
 /-- The forward semigroup of the reflected group obtained by gluing inverse semigroups is the
 second semigroup. -/
 @[simp]


### PR DESCRIPTION
This PR adds the canonical gluing construction that turns two strongly continuous semigroups whose equal-time operators are mutual inverses into a strongly continuous group, using the first semigroup on nonnegative times and the reflected second semigroup on negative times.

The exact target is `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A, “C₀ groups as a stretch,” specifically the Stone-theorem milestone constructing the two-sided unitary group generated by an unbounded self-adjoint operator. This is the most effective current step because Lumer–Phillips can generate the forward and backward contraction semigroups separately, while the existing group API only restricts a group to those halves and did not reconstruct one from them. After this PR, the Stone milestone still needs to prove maximal dissipativity for the real restrictions of `iA` and `-iA`, identify the resulting semigroups as mutual inverses, prove complex linearity and unitarity of the glued group, and identify its complex generator with `iA`.

Add `TauCeti/Analysis/Semigroups/Group/InverseSemigroups.lean` (281 lines). The public API proves cross-commutation of operators from the inverse semigroups, evaluates the glued group on both half-lines, and identifies its forward semigroup and its reflected forward semigroup exactly with the two inputs. The piecewise operator family and its sign-case proof of the group law remain private implementation details.

The construction reuses Mathlib’s `continuous_if_le` to glue the two strongly continuous orbit maps at zero and Tau Ceti’s existing real-time semigroup and C₀-group APIs; no Mathlib infrastructure or external formalization is vendored. The mathematical organization follows Engel and Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Section II.3.11, as cited in the module documentation.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"inverse-semigroups-strongly-continuous-group"}-->

🤖 Prepared with Codex
