### PR TITLE
refactor: name the monodromy conjugation law behind basepoint change

### DIFF
--- a/TauCeti/Topology/Homotopy/Monodromy/BasepointChange.lean
+++ b/TauCeti/Topology/Homotopy/Monodromy/BasepointChange.lean
@@ -41,6 +41,56 @@ variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X]
 
 namespace IsCoveringMap
 
+/-- **Conjugation law for monodromy along a path.** A class `g` at `x₁` fixes the endpoint
+`hp.monodromy ⟦γ⟧ e₀` of the lift of `γ` exactly when its transport back along `γ` fixes the
+starting point `e₀`. This is the path-level statement behind
+`IsCoveringMap.range_mapOfEq_monodromy_path`: transporting the recovered subgroup along `γ`
+amounts to conjugating the classes that the monodromy action fixes. -/
+theorem _root_.IsCoveringMap.monodromy_eq_self_iff_fundamentalGroupMulEquivOfPath_symm_apply
+    (hp : IsCoveringMap p) (γ : Path x₀ x₁) (e₀ : p ⁻¹' {x₀})
+    (g : _root_.FundamentalGroup X x₁) :
+    hp.monodromy g (hp.monodromy ⟦γ⟧ e₀) = hp.monodromy ⟦γ⟧ e₀ ↔
+      hp.monodromy
+        ((_root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ).symm g) e₀ = e₀ := by
+  let γq : Path.Homotopic.Quotient x₀ x₁ := Path.Homotopic.Quotient.mk γ
+  let f := _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ
+  -- Expose the local names so that the path-lifting composition laws apply directly.
+  change hp.monodromy g (hp.monodromy γq e₀) = hp.monodromy γq e₀ ↔
+    hp.monodromy (f.symm g) e₀ = e₀
+  have htrans :
+      hp.monodromy (Path.Homotopic.Quotient.trans γq g) e₀ =
+        hp.monodromy g (hp.monodromy γq e₀) :=
+    hp.monodromy_trans_apply γq g e₀
+  have hf :
+      f.symm g = Path.Homotopic.Quotient.trans γq
+        (Path.Homotopic.Quotient.trans g γq.symm) := by
+    simpa only [f, γq] using
+      _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath_symm_apply γ g
+  rw [← htrans]
+  rw [hf]
+  have hback : hp.monodromy γq.symm (hp.monodromy γq e₀) = e₀ := by
+    rw [← hp.monodromy_trans_apply]
+    rw [Path.Homotopic.Quotient.trans_symm, hp.monodromy_refl]
+    rfl
+  have hforward {z : p ⁻¹' {x₁}} :
+      hp.monodromy γq (hp.monodromy γq.symm z) = z := by
+    rw [← hp.monodromy_trans_apply]
+    rw [Path.Homotopic.Quotient.symm_trans, hp.monodromy_refl]
+    rfl
+  have hcomp :
+      hp.monodromy (Path.Homotopic.Quotient.trans γq
+        (Path.Homotopic.Quotient.trans g γq.symm)) e₀ =
+        hp.monodromy γq.symm (hp.monodromy (Path.Homotopic.Quotient.trans γq g) e₀) := by
+    rw [← Path.Homotopic.Quotient.trans_assoc]
+    exact hp.monodromy_trans_apply _ _ _
+  rw [hcomp]
+  constructor
+  · intro h
+    rw [h, hback]
+  · intro h
+    have := congrArg (hp.monodromy γq) h
+    simpa only [hforward]
+
 /-- The subgroup recovered at the endpoint of a lifted path is the basepoint transport of the
 subgroup recovered at its starting point. -/
 theorem _root_.IsCoveringMap.range_mapOfEq_monodromy_path (hp : IsCoveringMap p) (γ : Path x₀ x₁)
@@ -51,45 +101,6 @@ theorem _root_.IsCoveringMap.range_mapOfEq_monodromy_path (hp : IsCoveringMap p)
         (FundamentalGroup.mapOfEq ⟨p, hp.continuous⟩ e₀.2).range := by
   let γq : Path.Homotopic.Quotient x₀ x₁ := Path.Homotopic.Quotient.mk γ
   let e₁ : p ⁻¹' {x₁} := hp.monodromy γq e₀
-  let f := _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath γ
-  have hmon (g : _root_.FundamentalGroup X x₁) :
-      hp.monodromy g e₁ = e₁ ↔ hp.monodromy (f.symm g) e₀ = e₀ := by
-    -- Expose the local names so that the path-lifting composition laws apply directly.
-    change hp.monodromy g (hp.monodromy γq e₀) = hp.monodromy γq e₀ ↔
-      hp.monodromy (f.symm g) e₀ = e₀
-    have htrans :
-        hp.monodromy (Path.Homotopic.Quotient.trans γq g) e₀ =
-          hp.monodromy g (hp.monodromy γq e₀) :=
-      hp.monodromy_trans_apply γq g e₀
-    have hf :
-        f.symm g = Path.Homotopic.Quotient.trans γq
-          (Path.Homotopic.Quotient.trans g γq.symm) := by
-      simpa only [f, γq] using
-        _root_.FundamentalGroup.fundamentalGroupMulEquivOfPath_symm_apply γ g
-    rw [← htrans]
-    rw [hf]
-    have hback : hp.monodromy γq.symm (hp.monodromy γq e₀) = e₀ := by
-      rw [← hp.monodromy_trans_apply]
-      rw [Path.Homotopic.Quotient.trans_symm, hp.monodromy_refl]
-      rfl
-    have hforward {z : p ⁻¹' {x₁}} :
-        hp.monodromy γq (hp.monodromy γq.symm z) = z := by
-      rw [← hp.monodromy_trans_apply]
-      rw [Path.Homotopic.Quotient.symm_trans, hp.monodromy_refl]
-      rfl
-    have hcomp :
-        hp.monodromy (Path.Homotopic.Quotient.trans γq
-          (Path.Homotopic.Quotient.trans g γq.symm)) e₀ =
-          hp.monodromy γq.symm (hp.monodromy (Path.Homotopic.Quotient.trans γq g) e₀) := by
-      rw [← Path.Homotopic.Quotient.trans_assoc]
-      exact hp.monodromy_trans_apply _ _ _
-    rw [hcomp]
-    constructor
-    · intro h
-      rw [h, hback]
-    · intro h
-      have := congrArg (hp.monodromy γq) h
-      simpa only [hforward]
   ext g
   -- The range criterion is stated with the subtype's endpoint proof, while `e₁` is the
   -- locally named monodromy endpoint; this change aligns those definitionally equal terms.
@@ -99,7 +110,7 @@ theorem _root_.IsCoveringMap.range_mapOfEq_monodromy_path (hp : IsCoveringMap p)
   rw [← IsCoveringMap.monodromy_eq_self_iff_mem_range hp e₁ g,
     FundamentalGroup.mem_basepointChangeSubgroup_iff,
     ← IsCoveringMap.monodromy_eq_self_iff_mem_range hp e₀]
-  exact hmon g
+  exact hp.monodromy_eq_self_iff_fundamentalGroupMulEquivOfPath_symm_apply γ e₀ g
 
 end IsCoveringMap
 


### PR DESCRIPTION
`IsCoveringMap.range_mapOfEq_monodromy_path` spends **38 of its 51 lines** inside one `have hmon`. That block's statement is self-contained:

> a class `g` at `x₁` fixes the lifted endpoint `hp.monodromy ⟦γ⟧ e₀` **iff** its transport back along `γ` fixes the starting point `e₀`.

That is the path-level conjugation law for monodromy. The rest of the theorem is the short deduction of the subgroup statement from it: rewrite both sides through `monodromy_eq_self_iff_mem_range`, then apply the law.

## What changes

| | before | after |
|---|---|---|
| `range_mapOfEq_monodromy_path` | body **51**, largest block **38** | body **12** |
| `monodromy_eq_self_iff_fundamentalGroupMulEquivOfPath_symm_apply` | — | body **38**, largest block **6** |

Measured with the block profiler: the original is one `prime` row at 51/38; afterwards the consumer no longer registers at a 30-line threshold and the extracted law profiles as `assembly` (largest block 6) — a flat sequence of steps, with no dominant sub-argument left in either proof.

## Why the interface is clean

The block closed over three `let`s — `γq = ⟦γ⟧`, `e₁ = hp.monodromy γq e₀`, and the basepoint-change isomorphism. **All three are definable from `hp`, `γ` and `e₀`**, so the law takes only those plus `g`: four explicit binders, and no part of the consumer's preamble is threaded through. The two `let`s the consumer still needs are re-stated there in two lines.

## Naming and visibility

The law is stated publicly, beside `IsCoveringMap.monodromy_eq_self_iff_mem_range`, whose naming shape it follows: `monodromy_eq_self_iff_…` for a fixed-point criterion, with the differing part naming the operation on the right-hand side — here `(fundamentalGroupMulEquivOfPath γ).symm` applied to `g`. The fixed-point criterion is the reusable form; the subgroup statement is its consequence.

Roadmap: UniversalCovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp