### PR TITLE
feat: prove the zigzag algebra is self-injective

### DIFF
--- a/TauCeti/Algebra/DualNumber/Trace.lean
+++ b/TauCeti/Algebra/DualNumber/Trace.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.DualNumber
+public import Mathlib.LinearAlgebra.PerfectPairing.Basic
+
+/-!
+# The Frobenius trace pairing on the dual numbers
+
+This file equips the dual numbers over a field with the perfect associative bilinear form obtained
+by taking the infinitesimal coefficient of a product.
+
+## Main results
+
+* `TauCeti.dualNumberTracePairing`: the Frobenius trace pairing on the dual numbers.
+* `TauCeti.dualNumberTracePairing_isPerfPair`: the trace pairing is perfect.
+* `TauCeti.dualNumberTracePairing_mul_assoc`: the trace pairing is associative.
+-/
+
+public section
+
+namespace TauCeti
+
+universe w
+
+variable (k : Type w) [Field k]
+
+/-- The Frobenius pairing on the dual numbers, obtained by taking the infinitesimal coefficient
+of a product. -/
+noncomputable def dualNumberTracePairing : LinearMap.BilinForm k (DualNumber k) :=
+  LinearMap.mk₂ k (fun x y => x.fst * y.snd + x.snd * y.fst)
+    (fun x y z => by simp only [TrivSqZeroExt.fst_add, TrivSqZeroExt.snd_add]; ring)
+    (fun c x y => by
+      simp only [TrivSqZeroExt.fst_smul, TrivSqZeroExt.snd_smul, smul_eq_mul]
+      ring)
+    (fun x y z => by simp only [TrivSqZeroExt.fst_add, TrivSqZeroExt.snd_add]; ring)
+    (fun c x y => by
+      simp only [TrivSqZeroExt.fst_smul, TrivSqZeroExt.snd_smul, smul_eq_mul]
+      ring)
+
+/-- Evaluation of the dual-number Frobenius pairing in scalar and infinitesimal coordinates. -/
+@[simp]
+theorem dualNumberTracePairing_apply (x y : DualNumber k) :
+    dualNumberTracePairing k x y = x.fst * y.snd + x.snd * y.fst := by
+  simp [dualNumberTracePairing]
+
+/-- The Frobenius trace pairing on the dual numbers is perfect. -/
+instance dualNumberTracePairing_isPerfPair : (dualNumberTracePairing k).IsPerfPair := by
+  have hbij : Function.Bijective (dualNumberTracePairing k) := by
+    constructor
+    · intro x y h
+      apply TrivSqZeroExt.ext
+      · have he := LinearMap.congr_fun h DualNumber.eps
+        simpa using he
+      · have h1 := LinearMap.congr_fun h 1
+        simpa using h1
+    · intro f
+      let d : DualNumber k := ⟨f DualNumber.eps, f 1⟩
+      refine ⟨d, ?_⟩
+      apply LinearMap.ext
+      intro y
+      calc
+        dualNumberTracePairing k d y =
+            y.snd * f DualNumber.eps + y.fst * f 1 := by
+          rw [dualNumberTracePairing_apply]
+          dsimp only [d, TrivSqZeroExt.fst_mk, TrivSqZeroExt.snd_mk]
+          ring
+        _ = f (y.snd • DualNumber.eps + y.fst • (1 : DualNumber k)) := by
+          rw [map_add, map_smul, map_smul]
+          ring
+        _ = f y := by
+          congr 1
+          apply TrivSqZeroExt.ext <;> simp
+  refine ⟨hbij, ?_⟩
+  have hflip : (dualNumberTracePairing k).flip = dualNumberTracePairing k := by
+    ext x y
+    simp only [LinearMap.flip_apply, dualNumberTracePairing_apply]
+    ring
+  simpa only [hflip] using hbij
+
+/-- The Frobenius trace pairing on the dual numbers is associative with multiplication. -/
+theorem dualNumberTracePairing_mul_assoc (x y z : DualNumber k) :
+    dualNumberTracePairing k (x * y) z = dualNumberTracePairing k x (y * z) := by
+  simp only [dualNumberTracePairing_apply, DualNumber.snd_mul, TrivSqZeroExt.fst_mul]
+  ring
+
+end TauCeti

--- a/TauCeti/Algebra/DualNumber/Trace.lean
+++ b/TauCeti/Algebra/DualNumber/Trace.lean
@@ -6,18 +6,21 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.DualNumber
+public import Mathlib.Algebra.Algebra.Bilinear
+public import Mathlib.LinearAlgebra.BilinearForm.Properties
 public import Mathlib.LinearAlgebra.PerfectPairing.Basic
 
 /-!
 # The Frobenius trace pairing on the dual numbers
 
-This file equips the dual numbers over a field with the perfect associative bilinear form obtained
-by taking the infinitesimal coefficient of a product.
+This file equips the dual numbers over a commutative semiring with the perfect symmetric
+associative bilinear form obtained by taking the infinitesimal coefficient of a product.
 
 ## Main results
 
 * `TauCeti.dualNumberTracePairing`: the Frobenius trace pairing on the dual numbers.
 * `TauCeti.dualNumberTracePairing_isPerfPair`: the trace pairing is perfect.
+* `TauCeti.dualNumberTracePairing_isSymm`: the trace pairing is symmetric.
 * `TauCeti.dualNumberTracePairing_mul_assoc`: the trace pairing is associative.
 -/
 
@@ -27,26 +30,30 @@ namespace TauCeti
 
 universe w
 
-variable (k : Type w) [Field k]
+variable (k : Type w) [CommSemiring k]
+
+-- The coordinatewise module structure used by `DualNumber` is compatible with multiplication,
+-- but Mathlib does not provide this scalar-tower instance for `TrivSqZeroExt`.
+local instance dualNumberIsScalarTower :
+    IsScalarTower k (DualNumber k) (DualNumber k) where
+  smul_assoc r x y := by
+    ext <;> simp [mul_add, mul_assoc, mul_comm, mul_left_comm, add_comm]
 
 /-- The Frobenius pairing on the dual numbers, obtained by taking the infinitesimal coefficient
 of a product. -/
 noncomputable def dualNumberTracePairing : LinearMap.BilinForm k (DualNumber k) :=
-  LinearMap.mk₂ k (fun x y => x.fst * y.snd + x.snd * y.fst)
-    (fun x y z => by simp only [TrivSqZeroExt.fst_add, TrivSqZeroExt.snd_add]; ring)
-    (fun c x y => by
-      simp only [TrivSqZeroExt.fst_smul, TrivSqZeroExt.snd_smul, smul_eq_mul]
-      ring)
-    (fun x y z => by simp only [TrivSqZeroExt.fst_add, TrivSqZeroExt.snd_add]; ring)
-    (fun c x y => by
-      simp only [TrivSqZeroExt.fst_smul, TrivSqZeroExt.snd_smul, smul_eq_mul]
-      ring)
+  (LinearMap.mul k (DualNumber k)).compr₂ (TrivSqZeroExt.sndHom k k)
 
 /-- Evaluation of the dual-number Frobenius pairing in scalar and infinitesimal coordinates. -/
 @[simp]
 theorem dualNumberTracePairing_apply (x y : DualNumber k) :
     dualNumberTracePairing k x y = x.fst * y.snd + x.snd * y.fst := by
-  simp [dualNumberTracePairing]
+  rw [dualNumberTracePairing, LinearMap.compr₂_apply, LinearMap.mul_apply',
+    TrivSqZeroExt.sndHom_apply, DualNumber.snd_mul]
+
+/-- The Frobenius trace pairing on the dual numbers is symmetric. -/
+theorem dualNumberTracePairing_isSymm : (dualNumberTracePairing k).IsSymm :=
+  ⟨fun x y => by simp only [dualNumberTracePairing_apply]; ring⟩
 
 /-- The Frobenius trace pairing on the dual numbers is perfect. -/
 instance dualNumberTracePairing_isPerfPair : (dualNumberTracePairing k).IsPerfPair := by
@@ -76,16 +83,25 @@ instance dualNumberTracePairing_isPerfPair : (dualNumberTracePairing k).IsPerfPa
           congr 1
           apply TrivSqZeroExt.ext <;> simp
   refine ⟨hbij, ?_⟩
-  have hflip : (dualNumberTracePairing k).flip = dualNumberTracePairing k := by
-    ext x y
-    simp only [LinearMap.flip_apply, dualNumberTracePairing_apply]
-    ring
-  simpa only [hflip] using hbij
+  constructor
+  · intro x y h
+    apply hbij.injective
+    apply LinearMap.ext
+    intro z
+    rw [(dualNumberTracePairing_isSymm k).eq x z,
+      (dualNumberTracePairing_isSymm k).eq y z]
+    simpa only [LinearMap.flip_apply] using LinearMap.congr_fun h z
+  · intro f
+    obtain ⟨x, hx⟩ := hbij.surjective f
+    refine ⟨x, LinearMap.ext fun z => ?_⟩
+    simp only [LinearMap.flip_apply]
+    rw [(dualNumberTracePairing_isSymm k).eq z x]
+    exact LinearMap.congr_fun hx z
 
 /-- The Frobenius trace pairing on the dual numbers is associative with multiplication. -/
 theorem dualNumberTracePairing_mul_assoc (x y z : DualNumber k) :
     dualNumberTracePairing k (x * y) z = dualNumberTracePairing k x (y * z) := by
-  simp only [dualNumberTracePairing_apply, DualNumber.snd_mul, TrivSqZeroExt.fst_mul]
-  ring
+  rw [dualNumberTracePairing, LinearMap.compr₂_apply, LinearMap.compr₂_apply,
+    LinearMap.mul_apply', LinearMap.mul_apply', mul_assoc]
 
 end TauCeti

--- a/TauCeti/Algebra/Module/Injective/SelfInjective.lean
+++ b/TauCeti/Algebra/Module/Injective/SelfInjective.lean
@@ -41,8 +41,8 @@ on the ring.
 
 ## Main results
 
-* `LinearMap.IsPerfPair.moduleBaer_self` and `LinearMap.IsPerfPair.moduleInjective_self`: an
-  algebra over a field carrying an associative perfect bilinear form is self-injective.
+* `Function.Bijective.moduleBaer_self` and `Function.Bijective.moduleInjective_self`: an algebra
+  over a field carrying an associative bilinear form whose flip is bijective is self-injective.
 * `Module.Baer.of_leftInverse`: a retract of a Baer module is Baer.
 * `Module.Baer.of_isIdempotentElem`: over a self-injective ring, a left ideal consisting of the
   elements fixed by right multiplication by an idempotent is Baer.
@@ -102,13 +102,13 @@ section Frobenius
 variable {k : Type w} [Field k] {A : Type u} [Ring A] [Algebra k A]
   {B : A →ₗ[k] A →ₗ[k] k}
 
-/-- **An algebra over a field carrying an associative perfect bilinear form is self-injective**, in
-Baer's form: every linear map from a left ideal to the regular module extends to the algebra. -/
-theorem _root_.LinearMap.IsPerfPair.moduleBaer_self (hB : B.IsPerfPair)
+/-- **An algebra over a field carrying an associative bilinear form whose flip is bijective is
+self-injective**, in Baer's form: every linear map from a left ideal to the regular module extends
+to the algebra. -/
+theorem _root_.Function.Bijective.moduleBaer_self (hB : Function.Bijective B.flip)
     (hassoc : ∀ x y z : A, B (x * y) z = B x (y * z)) : Module.Baer A A := by
   -- The form is multiplication followed by the trace `B 1`.
   have hone : ∀ x y : A, B x y = B 1 (x * y) := fun x y => by rw [← hassoc, one_mul]
-  have hbij := LinearMap.IsPerfPair.bijective_right B (self := hB)
   intro I f
   -- The trace turns `f` into a `k`-linear functional on `I`, which extends to all of `A`.
   obtain ⟨ψ, hψ⟩ : ∃ ψ : A →ₗ[k] k, ∀ (x : A) (hx : x ∈ I), ψ x = B 1 (f ⟨x, hx⟩) := by
@@ -119,13 +119,13 @@ theorem _root_.LinearMap.IsPerfPair.moduleBaer_self (hB : B.IsPerfPair)
     obtain ⟨ψ, hψ⟩ := LinearMap.exists_extend
       ((B 1).comp ((f.restrictScalars k).comp e))
     exact ⟨ψ, fun x hx => congr($hψ ⟨x, hx⟩)⟩
-  -- Perfectness writes that functional as the pairing against a fixed element `a`.
-  obtain ⟨a, ha⟩ := hbij.surjective ψ
+  -- Bijectivity of the flip writes that functional as the pairing against a fixed element `a`.
+  obtain ⟨a, ha⟩ := hB.surjective ψ
   have hax : ∀ x : A, B x a = ψ x := fun x => congr($ha x)
   refine ⟨LinearMap.mulRight A a, fun x hx => ?_⟩
   rw [LinearMap.mulRight_apply]
   -- The two candidates pair identically against every element, since `f` is `A`-linear.
-  refine hbij.injective (LinearMap.ext fun y => ?_)
+  refine hB.injective (LinearMap.ext fun y => ?_)
   have hyx : y * x ∈ I := I.mul_mem_left y hx
   have hf : f ⟨y * x, hyx⟩ = y * f ⟨x, hx⟩ := by
     calc
@@ -136,9 +136,9 @@ theorem _root_.LinearMap.IsPerfPair.moduleBaer_self (hB : B.IsPerfPair)
   simp only [LinearMap.flip_apply]
   rw [← hassoc, hax, hψ _ hyx, hf, ← hone]
 
-/-- **An algebra over a field carrying an associative perfect bilinear form is self-injective**:
-its regular left module is an injective module. -/
-theorem _root_.LinearMap.IsPerfPair.moduleInjective_self (hB : B.IsPerfPair)
+/-- **An algebra over a field carrying an associative bilinear form whose flip is bijective is
+self-injective**: its regular left module is an injective module. -/
+theorem _root_.Function.Bijective.moduleInjective_self (hB : Function.Bijective B.flip)
     (hassoc : ∀ x y z : A, B (x * y) z = B x (y * z)) : Module.Injective A A :=
   Module.Baer.injective (hB.moduleBaer_self hassoc)
 

--- a/TauCeti/Algebra/Module/Injective/SelfInjective.lean
+++ b/TauCeti/Algebra/Module/Injective/SelfInjective.lean
@@ -112,28 +112,28 @@ theorem _root_.LinearMap.IsPerfPair.moduleBaer_self (hB : B.IsPerfPair)
   intro I f
   -- The trace turns `f` into a `k`-linear functional on `I`, which extends to all of `A`.
   obtain ⟨ψ, hψ⟩ : ∃ ψ : A →ₗ[k] k, ∀ (x : A) (hx : x ∈ I), ψ x = B 1 (f ⟨x, hx⟩) := by
+    let e : I.restrictScalars k →ₗ[k] I :=
+      { toFun := fun x => ⟨x, x.2⟩
+        map_add' := fun _ _ => Subtype.ext rfl
+        map_smul' := fun _ _ => Subtype.ext rfl }
     obtain ⟨ψ, hψ⟩ := LinearMap.exists_extend
-      ({ toFun := fun x : I.restrictScalars k => B 1 (f ⟨x.1, x.2⟩)
-         map_add' := fun x y => by
-           rw [show (⟨(x + y).1, (x + y).2⟩ : I) = ⟨x.1, x.2⟩ + ⟨y.1, y.2⟩ from rfl, map_add,
-             map_add]
-         map_smul' := fun c x => by
-           rw [show (⟨(c • x).1, (c • x).2⟩ : I) = c • (⟨x.1, x.2⟩ : I) from rfl,
-             f.map_smul_of_tower, map_smul, RingHom.id_apply] } : I.restrictScalars k →ₗ[k] k)
+      ((B 1).comp ((f.restrictScalars k).comp e))
     exact ⟨ψ, fun x hx => congr($hψ ⟨x, hx⟩)⟩
   -- Perfectness writes that functional as the pairing against a fixed element `a`.
   obtain ⟨a, ha⟩ := hbij.surjective ψ
   have hax : ∀ x : A, B x a = ψ x := fun x => congr($ha x)
-  refine ⟨{ toFun := fun x => x * a
-            map_add' := fun x y => add_mul x y a
-            map_smul' := fun c x => by simp [mul_assoc] }, fun x hx => ?_⟩
-  change x * a = f ⟨x, hx⟩
+  refine ⟨LinearMap.mulRight A a, fun x hx => ?_⟩
+  rw [LinearMap.mulRight_apply]
   -- The two candidates pair identically against every element, since `f` is `A`-linear.
   refine hbij.injective (LinearMap.ext fun y => ?_)
   have hyx : y * x ∈ I := I.mul_mem_left y hx
   have hf : f ⟨y * x, hyx⟩ = y * f ⟨x, hx⟩ := by
-    rw [show (⟨y * x, hyx⟩ : I) = y • (⟨x, hx⟩ : I) from rfl, map_smul, smul_eq_mul]
-  change B y (x * a) = B y (f ⟨x, hx⟩)
+    calc
+      f ⟨y * x, hyx⟩ = f (y • (⟨x, hx⟩ : I)) := by
+        exact congrArg f (Subtype.ext (smul_eq_mul y x).symm)
+      _ = y • f ⟨x, hx⟩ := map_smul f y ⟨x, hx⟩
+      _ = y * f ⟨x, hx⟩ := smul_eq_mul y _
+  simp only [LinearMap.flip_apply]
   rw [← hassoc, hax, hψ _ hyx, hf, ← hone]
 
 /-- **An algebra over a field carrying an associative perfect bilinear form is self-injective**:

--- a/TauCeti/Algebra/Module/Injective/SelfInjective.lean
+++ b/TauCeti/Algebra/Module/Injective/SelfInjective.lean
@@ -22,15 +22,6 @@ already forces `B x y = B 1 (x * y)`, so the form is multiplication followed by 
 functional `B 1`, the Frobenius trace; perfectness is nondegeneracy in the strong form which also
 makes every functional on `A` of the shape `B · a`.
 
-The proof is Baer's criterion. Given a left ideal `I` and an `A`-linear `f : I →ₗ[A] A`, the trace
-turns `f` into a `k`-linear functional on `I`, which extends to a functional `ψ` on `A` because `I`
-is a subspace of a vector space; perfectness writes `ψ` as `B · a` for some `a : A`, and right
-multiplication by `a` is the required extension of `f`. Indeed `x * a` and `f x` pair identically
-against every `y : A`, because associativity moves `y` inside `f`: `B y (x * a) = B (y * x) a` is
-`ψ` at `y * x ∈ I`, which is `B 1 (f (y * x)) = B 1 (y * f x) = B y (f x)`. Only bijectivity of
-`B.flip` is used, that is, nondegeneracy in the second variable together with surjectivity onto the
-dual.
-
 Two general facts about Baer modules are proved along the way and stated in Mathlib's `Module.Baer`
 namespace, which has neither. A retract of a Baer module is Baer (`Module.Baer.of_leftInverse`),
 and consequently the left ideal cut out by an idempotent is Baer over a self-injective ring
@@ -66,8 +57,9 @@ section Retract
 variable {R : Type u} [Ring R] {Q : Type v} [AddCommGroup Q] [Module R Q]
   {M : Type w} [AddCommGroup M] [Module R M]
 
-/-- **A retract of a Baer module is Baer.** A map out of an ideal is pushed into `Q`, extended
-there, and pulled back along the retraction. -/
+/-- **Baer modules are closed under retracts.** If `M` admits a split inclusion into a Baer module
+`Q`, then `M` is Baer. In particular, this criterion applies to projective summands of a
+self-injective regular module. -/
 theorem _root_.Module.Baer.of_leftInverse (hQ : Module.Baer R Q) (s : M →ₗ[R] Q) (r : Q →ₗ[R] M)
     (hrs : ∀ m, r (s m) = m) : Module.Baer R M := fun I g => by
   obtain ⟨g', hg'⟩ := hQ I (s ∘ₗ g)

--- a/TauCeti/Algebra/Module/Injective/SelfInjective.lean
+++ b/TauCeti/Algebra/Module/Injective/SelfInjective.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Module.Injective
+public import Mathlib.LinearAlgebra.Basis.VectorSpace
+public import Mathlib.LinearAlgebra.PerfectPairing.Basic
+
+/-!
+# Self-injective algebras
+
+A ring is **self-injective** when its regular left module is injective, `Module.Injective A A`.
+This file proves the criterion producing the examples which come from a Frobenius structure: an
+algebra over a field carrying an associative perfect bilinear form is self-injective.
+
+The form is a `k`-bilinear `B : A →ₗ[k] A →ₗ[k] k` which is *associative*,
+`B (x * y) z = B x (y * z)`, and *perfect* in the sense of `LinearMap.IsPerfPair`. Associativity
+already forces `B x y = B 1 (x * y)`, so the form is multiplication followed by the linear
+functional `B 1`, the Frobenius trace; perfectness is nondegeneracy in the strong form which also
+makes every functional on `A` of the shape `B · a`.
+
+The proof is Baer's criterion. Given a left ideal `I` and an `A`-linear `f : I →ₗ[A] A`, the trace
+turns `f` into a `k`-linear functional on `I`, which extends to a functional `ψ` on `A` because `I`
+is a subspace of a vector space; perfectness writes `ψ` as `B · a` for some `a : A`, and right
+multiplication by `a` is the required extension of `f`. Indeed `x * a` and `f x` pair identically
+against every `y : A`, because associativity moves `y` inside `f`: `B y (x * a) = B (y * x) a` is
+`ψ` at `y * x ∈ I`, which is `B 1 (f (y * x)) = B 1 (y * f x) = B y (f x)`. Only bijectivity of
+`B.flip` is used, that is, nondegeneracy in the second variable together with surjectivity onto the
+dual.
+
+Two general facts about Baer modules are proved along the way and stated in Mathlib's `Module.Baer`
+namespace, which has neither. A retract of a Baer module is Baer (`Module.Baer.of_leftInverse`),
+and consequently the left ideal cut out by an idempotent is Baer over a self-injective ring
+(`Module.Baer.of_isIdempotentElem`): over a self-injective ring the principal projective modules
+are injective. Everything is stated for `Module.Baer` rather than `Module.Injective` because the
+two convert freely in one direction only, `Module.Baer.of_injective` costing a smallness hypothesis
+on the ring.
+
+## Main results
+
+* `LinearMap.IsPerfPair.moduleBaer_self` and `LinearMap.IsPerfPair.moduleInjective_self`: an
+  algebra over a field carrying an associative perfect bilinear form is self-injective.
+* `Module.Baer.of_leftInverse`: a retract of a Baer module is Baer.
+* `Module.Baer.of_isIdempotentElem`: over a self-injective ring, a left ideal consisting of the
+  elements fixed by right multiplication by an idempotent is Baer.
+
+## References
+
+See Curtis--Reiner, *Methods of representation theory* I, Section 9, and Lam, *Lectures on modules
+and rings*, Sections 3 and 16, for Frobenius algebras and self-injectivity.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w
+
+/-! ### Retracts and idempotent corners of a Baer module -/
+
+section Retract
+
+variable {R : Type u} [Ring R] {Q : Type v} [AddCommGroup Q] [Module R Q]
+  {M : Type w} [AddCommGroup M] [Module R M]
+
+/-- **A retract of a Baer module is Baer.** A map out of an ideal is pushed into `Q`, extended
+there, and pulled back along the retraction. -/
+theorem _root_.Module.Baer.of_leftInverse (hQ : Module.Baer R Q) (s : M →ₗ[R] Q) (r : Q →ₗ[R] M)
+    (hrs : ∀ m, r (s m) = m) : Module.Baer R M := fun I g => by
+  obtain ⟨g', hg'⟩ := hQ I (s ∘ₗ g)
+  exact ⟨r ∘ₗ g', fun x hx => by rw [LinearMap.comp_apply, hg' x hx, LinearMap.comp_apply, hrs]⟩
+
+end Retract
+
+section Idempotent
+
+variable {A : Type u} [Ring A]
+
+/-- **Over a self-injective ring the principal projective modules are injective**, in Baer's form:
+if the regular module is Baer then so is a left ideal `p` consisting of the elements fixed by right
+multiplication by an idempotent `e`, such a `p` being a retract of the regular module by right
+multiplication by `e`. For `p = Ideal.span {e}` the hypothesis `hp` is
+`TauCeti.mem_span_singleton_iff_mul_eq_self`. -/
+theorem _root_.Module.Baer.of_isIdempotentElem (hA : Module.Baer A A) {e : A}
+    (he : IsIdempotentElem e) {p : Ideal A} (hp : ∀ x : A, x ∈ p ↔ x * e = x) :
+    Module.Baer A p :=
+  hA.of_leftInverse p.subtype
+    { toFun := fun x => ⟨x * e, (hp _).2 (by rw [mul_assoc, he.eq])⟩
+      map_add' := fun x y => Subtype.ext (add_mul x y e)
+      map_smul' := fun a x => Subtype.ext (by simp [mul_assoc]) }
+    fun m => Subtype.ext ((hp m).1 m.2)
+
+end Idempotent
+
+/-! ### Self-injectivity from an associative perfect form -/
+
+section Frobenius
+
+variable {k : Type w} [Field k] {A : Type u} [Ring A] [Algebra k A]
+  {B : A →ₗ[k] A →ₗ[k] k}
+
+/-- **An algebra over a field carrying an associative perfect bilinear form is self-injective**, in
+Baer's form: every linear map from a left ideal to the regular module extends to the algebra. -/
+theorem _root_.LinearMap.IsPerfPair.moduleBaer_self (hB : B.IsPerfPair)
+    (hassoc : ∀ x y z : A, B (x * y) z = B x (y * z)) : Module.Baer A A := by
+  -- The form is multiplication followed by the trace `B 1`.
+  have hone : ∀ x y : A, B x y = B 1 (x * y) := fun x y => by rw [← hassoc, one_mul]
+  have hbij := LinearMap.IsPerfPair.bijective_right B (self := hB)
+  intro I f
+  -- The trace turns `f` into a `k`-linear functional on `I`, which extends to all of `A`.
+  obtain ⟨ψ, hψ⟩ : ∃ ψ : A →ₗ[k] k, ∀ (x : A) (hx : x ∈ I), ψ x = B 1 (f ⟨x, hx⟩) := by
+    obtain ⟨ψ, hψ⟩ := LinearMap.exists_extend
+      ({ toFun := fun x : I.restrictScalars k => B 1 (f ⟨x.1, x.2⟩)
+         map_add' := fun x y => by
+           rw [show (⟨(x + y).1, (x + y).2⟩ : I) = ⟨x.1, x.2⟩ + ⟨y.1, y.2⟩ from rfl, map_add,
+             map_add]
+         map_smul' := fun c x => by
+           rw [show (⟨(c • x).1, (c • x).2⟩ : I) = c • (⟨x.1, x.2⟩ : I) from rfl,
+             f.map_smul_of_tower, map_smul, RingHom.id_apply] } : I.restrictScalars k →ₗ[k] k)
+    exact ⟨ψ, fun x hx => congr($hψ ⟨x, hx⟩)⟩
+  -- Perfectness writes that functional as the pairing against a fixed element `a`.
+  obtain ⟨a, ha⟩ := hbij.surjective ψ
+  have hax : ∀ x : A, B x a = ψ x := fun x => congr($ha x)
+  refine ⟨{ toFun := fun x => x * a
+            map_add' := fun x y => add_mul x y a
+            map_smul' := fun c x => by simp [mul_assoc] }, fun x hx => ?_⟩
+  change x * a = f ⟨x, hx⟩
+  -- The two candidates pair identically against every element, since `f` is `A`-linear.
+  refine hbij.injective (LinearMap.ext fun y => ?_)
+  have hyx : y * x ∈ I := I.mul_mem_left y hx
+  have hf : f ⟨y * x, hyx⟩ = y * f ⟨x, hx⟩ := by
+    rw [show (⟨y * x, hyx⟩ : I) = y • (⟨x, hx⟩ : I) from rfl, map_smul, smul_eq_mul]
+  change B y (x * a) = B y (f ⟨x, hx⟩)
+  rw [← hassoc, hax, hψ _ hyx, hf, ← hone]
+
+/-- **An algebra over a field carrying an associative perfect bilinear form is self-injective**:
+its regular left module is an injective module. -/
+theorem _root_.LinearMap.IsPerfPair.moduleInjective_self (hB : B.IsPerfPair)
+    (hassoc : ∀ x y z : A, B (x * y) z = B x (y * z)) : Module.Injective A A :=
+  Module.Baer.injective (hB.moduleBaer_self hassoc)
+
+end Frobenius
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Module.Injective.SelfInjective
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Projective
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Trace
+
+/-!
+# The zigzag algebra is self-injective
+
+The zigzag algebra of a finite simple graph without isolated vertices is a symmetric Frobenius
+algebra: `TauCeti.zigzagTracePairing` is a symmetric associative bilinear form, and it is perfect
+because its Gram matrix in the vertex, arrow and volume basis is the permutation matrix of the
+involution exchanging an idempotent with a volume class and a dart with its reverse. This file
+draws the module-theoretic consequence over a field: the algebra is **self-injective**, its regular
+left module being an injective module.
+
+The argument is the general criterion `LinearMap.IsPerfPair.moduleBaer_self`: the trace turns a map
+out of a left ideal into a linear functional, which extends to the whole algebra as a vector space
+and is then written as pairing against a fixed element, giving the extension Baer's criterion asks
+for. Nothing about the graph enters beyond the Frobenius pairing already constructed.
+
+Because the vertex projective `Z e_i` is a retract of the regular module, it inherits injectivity:
+over a zigzag algebra the vertex projectives are also the indecomposable injectives. Their
+projectivity is `TauCeti.zigzagProjective_projective`, and their indecomposability is
+`TauCeti.isIndecomposableModule_zigzagProjective`.
+
+## Main results
+
+* `TauCeti.moduleInjective_nonisolatedZigzagQuotient`: the zigzag algebra of a finite simple graph
+  without isolated vertices is self-injective.
+* `TauCeti.moduleInjective_zigzagProjective`: each vertex projective `Z e_i` is an injective
+  module.
+
+## References
+
+See Huerfano--Khovanov, *A category for the adjoint representation*, Section 3, and
+Ehrig--Tubbenhauer, *Algebraic properties of zigzag algebras*, Section 2.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u w
+
+variable (k : Type w) [Field k] {V : Type u} (G : SimpleGraph V) [Finite V]
+  (hns : ∀ i : V, ∃ j, G.Adj i j)
+
+include hns
+
+/-- **The zigzag algebra is self-injective**, in Baer's form: every linear map from a left ideal to
+the regular module is right multiplication by an element of the algebra. -/
+theorem moduleBaer_nonisolatedZigzagQuotient :
+    Module.Baer (nonisolatedZigzagQuotient k G) (nonisolatedZigzagQuotient k G) :=
+  (zigzagTracePairing_isPerfPair k G hns).moduleBaer_self (zigzagTracePairing_mul_assoc k G hns)
+
+/-- **The zigzag algebra of a finite simple graph without isolated vertices is self-injective**: its
+regular left module is an injective module. This is the module-theoretic content of the symmetric
+Frobenius structure carried by the trace pairing. -/
+theorem moduleInjective_nonisolatedZigzagQuotient :
+    Module.Injective (nonisolatedZigzagQuotient k G) (nonisolatedZigzagQuotient k G) :=
+  Module.Baer.injective (moduleBaer_nonisolatedZigzagQuotient k G hns)
+
+/-- **The vertex projectives of a zigzag algebra are injective modules.** The left ideal `Z e_i` is
+a retract of the regular module, which is injective. -/
+theorem moduleInjective_zigzagProjective (i : V) :
+    Module.Injective (nonisolatedZigzagQuotient k G) (zigzagProjective k G i) :=
+  Module.Baer.injective
+    ((moduleBaer_nonisolatedZigzagQuotient k G hns).of_isIdempotentElem
+      (zigzagMk_vertexIdempotent_mul_self k G i) fun _ => mem_zigzagProjective_iff k G)
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
@@ -36,6 +36,9 @@ projectivity is `TauCeti.zigzagProjective_projective`, and their indecomposabili
 
 * `TauCeti.zigzagAlgebraPairing`: the symmetric perfect associative pairing on the public zigzag
   algebra.
+* `TauCeti.zigzagAlgebraPairing_single_nontrivial` and
+  `TauCeti.zigzagAlgebraPairing_single_subsingleton`: on the factor of one connected component that
+  pairing is `TauCeti.zigzagTracePairing` respectively `TauCeti.dualNumberTracePairing`.
 * `TauCeti.moduleBaer_zigzagAlgebra` and `TauCeti.moduleInjective_zigzagAlgebra`: the public
   componentwise zigzag algebra of every finite simple graph is self-injective.
 * `TauCeti.moduleInjective_nonisolatedZigzagQuotient`: the relation-quotient presentation for a
@@ -87,6 +90,28 @@ private instance zigzagComponentPairing_isPerfPair (C : G.ConnectedComponent) :
   classical
   unfold zigzagComponentPairing
   split <;> infer_instance
+
+private theorem zigzagComponentPairing_apply_nontrivial (C : G.ConnectedComponent)
+    [Nontrivial C] (hns : ∀ i : C, ∃ j, C.toSimpleGraph.Adj i j)
+    (x y : zigzagComponentAlgebra k G C) :
+    zigzagComponentPairing k G C x y =
+      zigzagTracePairing k C.toSimpleGraph hns
+        (zigzagComponentAlgebraEquivNonisolated k G C x)
+        (zigzagComponentAlgebraEquivNonisolated k G C y) := by
+  classical
+  have hC : Nontrivial C := inferInstance
+  simp only [zigzagComponentPairing, hC]
+  rfl
+
+private theorem zigzagComponentPairing_apply_subsingleton (C : G.ConnectedComponent)
+    [Subsingleton C] (x y : zigzagComponentAlgebra k G C) :
+    zigzagComponentPairing k G C x y =
+      dualNumberTracePairing k (zigzagComponentAlgebraEquivULiftDualNumber k G C x).down
+        (zigzagComponentAlgebraEquivULiftDualNumber k G C y).down := by
+  classical
+  have hC : ¬ Nontrivial C := fun h => (not_subsingleton_iff_nontrivial.mpr h) inferInstance
+  simp only [zigzagComponentPairing, hC]
+  rfl
 
 private theorem zigzagComponentPairing_mul_assoc (C : G.ConnectedComponent)
     (x y z : zigzagComponentAlgebra k G C) :
@@ -223,6 +248,35 @@ theorem zigzagAlgebraPairing_apply (x y : zigzagAlgebra k G) :
   intro C _
   rw [zigzagAlgebraPairing_single_left, zigzagComponentProjection_zigzagAlgebraMk]
   simp
+
+open Classical in
+/-- On a nontrivial component the direct-sum pairing restricted to the embedded factor is the
+zigzag trace pairing of that component, transported along
+`TauCeti.zigzagComponentAlgebraEquivNonisolated`. -/
+theorem zigzagAlgebraPairing_single_nontrivial (C : G.ConnectedComponent) [Nontrivial C]
+    (hns : ∀ i : C, ∃ j, C.toSimpleGraph.Adj i j) (x y : zigzagComponentAlgebra k G C) :
+    zigzagAlgebraPairing k G (zigzagAlgebraMk k G (Pi.single C x))
+        (zigzagAlgebraMk k G (Pi.single C y)) =
+      zigzagTracePairing k C.toSimpleGraph hns
+        (zigzagComponentAlgebraEquivNonisolated k G C x)
+        (zigzagComponentAlgebraEquivNonisolated k G C y) := by
+  classical
+  rw [zigzagAlgebraPairing_single_left, zigzagComponentProjection_zigzagAlgebraMk,
+    Pi.single_eq_same, zigzagComponentPairing_apply_nontrivial k G C hns]
+
+open Classical in
+/-- On a singleton component the direct-sum pairing restricted to the embedded factor is the
+dual-number trace pairing, transported along
+`TauCeti.zigzagComponentAlgebraEquivULiftDualNumber`. -/
+theorem zigzagAlgebraPairing_single_subsingleton (C : G.ConnectedComponent) [Subsingleton C]
+    (x y : zigzagComponentAlgebra k G C) :
+    zigzagAlgebraPairing k G (zigzagAlgebraMk k G (Pi.single C x))
+        (zigzagAlgebraMk k G (Pi.single C y)) =
+      dualNumberTracePairing k (zigzagComponentAlgebraEquivULiftDualNumber k G C x).down
+        (zigzagComponentAlgebraEquivULiftDualNumber k G C y).down := by
+  classical
+  rw [zigzagAlgebraPairing_single_left, zigzagComponentProjection_zigzagAlgebraMk,
+    Pi.single_eq_same, zigzagComponentPairing_apply_subsingleton k G C]
 
 /-- The direct-sum Frobenius pairing on the public zigzag algebra is perfect. -/
 instance zigzagAlgebraPairing_isPerfPair : (zigzagAlgebraPairing k G).IsPerfPair := by

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
@@ -22,7 +22,7 @@ pairing given by the infinitesimal coefficient of a product. Summing these pairi
 connected components proves the result for `TauCeti.zigzagAlgebra`, including disconnected graphs
 and isolated vertices.
 
-The argument is the general criterion `LinearMap.IsPerfPair.moduleBaer_self`: the trace turns a map
+The argument is the general criterion `Function.Bijective.moduleBaer_self`: the trace turns a map
 out of a left ideal into a linear functional, which extends to the whole algebra as a vector space
 and is then written as pairing against a fixed element, giving the extension Baer's criterion asks
 for.
@@ -34,6 +34,8 @@ projectivity is `TauCeti.zigzagProjective_projective`, and their indecomposabili
 
 ## Main results
 
+* `TauCeti.zigzagAlgebraPairing`: the symmetric perfect associative pairing on the public zigzag
+  algebra.
 * `TauCeti.moduleBaer_zigzagAlgebra` and `TauCeti.moduleInjective_zigzagAlgebra`: the public
   componentwise zigzag algebra of every finite simple graph is self-injective.
 * `TauCeti.moduleInjective_nonisolatedZigzagQuotient`: the relation-quotient presentation for a
@@ -116,8 +118,32 @@ private theorem zigzagComponentPairing_mul_assoc (C : G.ConnectedComponent)
       show e (y * z) = e y * e z from e.map_mul y z]
     exact dualNumberTracePairing_mul_assoc k _ _ _
 
+private theorem zigzagComponentPairing_isSymm (C : G.ConnectedComponent) :
+    (zigzagComponentPairing k G C).IsSymm := by
+  classical
+  constructor
+  intro x y
+  by_cases hC : Nontrivial C
+  · let _ : Nontrivial C := hC
+    let hns : ∀ i : C, ∃ j, C.toSimpleGraph.Adj i j := fun i =>
+      exists_adj_iff_not_isIsolated.mpr
+        (C.connected_toSimpleGraph.preconnected.not_isIsolated i)
+    let e := zigzagComponentAlgebraEquivNonisolated k G C
+    simp only [zigzagComponentPairing, hC]
+    -- Selecting this dependent branch leaves evaluation of the transported pairing definitional.
+    change zigzagTracePairing k C.toSimpleGraph hns (e x) (e y) =
+      zigzagTracePairing k C.toSimpleGraph hns (e y) (e x)
+    exact (zigzagTracePairing_isSymm k C.toSimpleGraph hns).eq _ _
+  · let _ : Subsingleton C := not_nontrivial_iff_subsingleton.mp hC
+    let e := (zigzagComponentAlgebraEquivULiftDualNumber k G C).trans
+      (ULift.algEquiv (R := k) (A := DualNumber k))
+    simp only [zigzagComponentPairing, hC]
+    -- The singleton branch likewise reduces the transported pairing only by definitional equality.
+    change dualNumberTracePairing k (e x) (e y) = dualNumberTracePairing k (e y) (e x)
+    exact (dualNumberTracePairing_isSymm k).eq _ _
+
 /-- The direct-sum Frobenius pairing on the public componentwise zigzag algebra. -/
-private noncomputable def zigzagAlgebraPairing :
+noncomputable def zigzagAlgebraPairing :
     LinearMap.BilinForm k (zigzagAlgebra k G) := by
   classical
   exact
@@ -138,7 +164,7 @@ private noncomputable def zigzagAlgebraPairing :
         simp only [LinearMap.smul_apply]
         rw [Finset.smul_sum] }
 
-private theorem zigzagAlgebraPairing_apply (x y : zigzagAlgebra k G) :
+private theorem zigzagAlgebraPairing_apply_components (x y : zigzagAlgebra k G) :
     zigzagAlgebraPairing k G x y = ∑ C, zigzagComponentPairing k G C
       (zigzagComponentProjection k G C x) (zigzagComponentProjection k G C y) := by
   classical
@@ -152,7 +178,7 @@ private theorem zigzagAlgebraPairing_single_right (x : zigzagAlgebra k G)
     zigzagAlgebraPairing k G x (zigzagAlgebraMk k G (Pi.single C z)) =
       zigzagComponentPairing k G C (zigzagComponentProjection k G C x) z := by
   classical
-  rw [zigzagAlgebraPairing_apply]
+  rw [zigzagAlgebraPairing_apply_components]
   simp_rw [zigzagComponentProjection_zigzagAlgebraMk]
   simpa only [LinearMap.lsum_apply, LinearMap.sum_apply, LinearMap.comp_apply,
     LinearMap.proj_apply] using
@@ -166,7 +192,7 @@ private theorem zigzagAlgebraPairing_single_left (x : zigzagAlgebra k G)
     zigzagAlgebraPairing k G (zigzagAlgebraMk k G (Pi.single C z)) x =
       zigzagComponentPairing k G C z (zigzagComponentProjection k G C x) := by
   classical
-  rw [zigzagAlgebraPairing_apply]
+  rw [zigzagAlgebraPairing_apply_components]
   simp_rw [zigzagComponentProjection_zigzagAlgebraMk]
   have hsum := LinearMap.lsum_piSingle k (fun D : G.ConnectedComponent =>
     zigzagComponentAlgebra k G D) k
@@ -182,7 +208,21 @@ private theorem zigzagAlgebraPairing_single_left (x : zigzagAlgebra k G)
       zigzagComponentPairing k G C z (zigzagComponentProjection k G C x) at hsum
   exact hsum
 
-private instance zigzagAlgebraPairing_isPerfPair : (zigzagAlgebraPairing k G).IsPerfPair := by
+open Classical in
+/-- The direct-sum pairing is the sum of its restrictions to the embedded component factors. -/
+theorem zigzagAlgebraPairing_apply (x y : zigzagAlgebra k G) :
+    zigzagAlgebraPairing k G x y = ∑ C, zigzagAlgebraPairing k G
+      (zigzagAlgebraMk k G (Pi.single C (zigzagComponentProjection k G C x)))
+      (zigzagAlgebraMk k G (Pi.single C (zigzagComponentProjection k G C y))) := by
+  classical
+  rw [zigzagAlgebraPairing_apply_components]
+  apply Finset.sum_congr rfl
+  intro C _
+  rw [zigzagAlgebraPairing_single_left, zigzagComponentProjection_zigzagAlgebraMk]
+  simp
+
+/-- The direct-sum Frobenius pairing on the public zigzag algebra is perfect. -/
+instance zigzagAlgebraPairing_isPerfPair : (zigzagAlgebraPairing k G).IsPerfPair := by
   classical
   apply LinearMap.IsPerfPair.of_injective
   · intro x y h
@@ -207,18 +247,27 @@ private instance zigzagAlgebraPairing_isPerfPair : (zigzagAlgebraPairing k G).Is
     rw [zigzagAlgebraPairing_single_left, zigzagAlgebraPairing_single_left] at hz
     exact hz
 
-private theorem zigzagAlgebraPairing_mul_assoc (x y z : zigzagAlgebra k G) :
+/-- The direct-sum Frobenius pairing on the public zigzag algebra is associative with
+multiplication. -/
+theorem zigzagAlgebraPairing_mul_assoc (x y z : zigzagAlgebra k G) :
     zigzagAlgebraPairing k G (x * y) z = zigzagAlgebraPairing k G x (y * z) := by
   classical
-  rw [zigzagAlgebraPairing_apply, zigzagAlgebraPairing_apply]
+  rw [zigzagAlgebraPairing_apply_components, zigzagAlgebraPairing_apply_components]
   simp_rw [map_mul]
   exact Finset.sum_congr rfl fun C _ => zigzagComponentPairing_mul_assoc k G C _ _ _
+
+/-- The direct-sum Frobenius pairing on the public zigzag algebra is symmetric. -/
+theorem zigzagAlgebraPairing_isSymm : (zigzagAlgebraPairing k G).IsSymm :=
+  ⟨fun x y => by
+    rw [zigzagAlgebraPairing_apply_components, zigzagAlgebraPairing_apply_components]
+    exact Finset.sum_congr rfl fun C _ => (zigzagComponentPairing_isSymm k G C).eq _ _⟩
 
 /-- **The public zigzag algebra of every finite simple graph satisfies Baer's criterion.**
 Singleton components contribute dual-number factors, while every nontrivial component uses its
 zigzag trace pairing; the sum of these component pairings is perfect and associative. -/
 theorem moduleBaer_zigzagAlgebra : Module.Baer (zigzagAlgebra k G) (zigzagAlgebra k G) :=
-  (zigzagAlgebraPairing_isPerfPair k G).moduleBaer_self (zigzagAlgebraPairing_mul_assoc k G)
+  (LinearMap.IsPerfPair.bijective_right (zigzagAlgebraPairing k G)).moduleBaer_self
+    (zigzagAlgebraPairing_mul_assoc k G)
 
 /-- **The public zigzag algebra of every finite simple graph is self-injective.** -/
 theorem moduleInjective_zigzagAlgebra :
@@ -235,7 +284,8 @@ include hns
 the regular module is right multiplication by an element of the algebra. -/
 theorem moduleBaer_nonisolatedZigzagQuotient :
     Module.Baer (nonisolatedZigzagQuotient k G) (nonisolatedZigzagQuotient k G) :=
-  (zigzagTracePairing_isPerfPair k G hns).moduleBaer_self (zigzagTracePairing_mul_assoc k G hns)
+  (LinearMap.IsPerfPair.bijective_right (zigzagTracePairing k G hns)).moduleBaer_self
+    (zigzagTracePairing_mul_assoc k G hns)
 
 /-- **The zigzag algebra of a finite simple graph without isolated vertices is self-injective**: its
 regular left module is an injective module. This is the module-theoretic content of the symmetric

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
@@ -253,15 +253,17 @@ open Classical in
 zigzag trace pairing of that component, transported along
 `TauCeti.zigzagComponentAlgebraEquivNonisolated`. -/
 theorem zigzagAlgebraPairing_single_nontrivial (C : G.ConnectedComponent) [Nontrivial C]
-    (hns : ∀ i : C, ∃ j, C.toSimpleGraph.Adj i j) (x y : zigzagComponentAlgebra k G C) :
+    (x y : zigzagComponentAlgebra k G C) :
     zigzagAlgebraPairing k G (zigzagAlgebraMk k G (Pi.single C x))
         (zigzagAlgebraMk k G (Pi.single C y)) =
-      zigzagTracePairing k C.toSimpleGraph hns
+      zigzagTracePairing k C.toSimpleGraph (fun i =>
+        exists_adj_iff_not_isIsolated.mpr
+          (C.connected_toSimpleGraph.preconnected.not_isIsolated i))
         (zigzagComponentAlgebraEquivNonisolated k G C x)
         (zigzagComponentAlgebraEquivNonisolated k G C y) := by
   classical
   rw [zigzagAlgebraPairing_single_left, zigzagComponentProjection_zigzagAlgebraMk,
-    Pi.single_eq_same, zigzagComponentPairing_apply_nontrivial k G C hns]
+    Pi.single_eq_same, zigzagComponentPairing_apply_nontrivial k G C]
 
 open Classical in
 /-- On a singleton component the direct-sum pairing restricted to the embedded factor is the

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Module.Injective.SelfInjective
+public import TauCeti.Algebra.DualNumber.Trace
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Dimension
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Projective
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Trace
@@ -33,8 +34,8 @@ projectivity is `TauCeti.zigzagProjective_projective`, and their indecomposabili
 
 ## Main results
 
-* `TauCeti.moduleInjective_zigzagAlgebra`: the public componentwise zigzag algebra of every finite
-  simple graph is self-injective.
+* `TauCeti.moduleBaer_zigzagAlgebra` and `TauCeti.moduleInjective_zigzagAlgebra`: the public
+  componentwise zigzag algebra of every finite simple graph is self-injective.
 * `TauCeti.moduleInjective_nonisolatedZigzagQuotient`: the relation-quotient presentation for a
   graph without isolated vertices is self-injective.
 * `TauCeti.moduleInjective_zigzagProjective`: each vertex projective `Z e_i` is an injective
@@ -56,69 +57,11 @@ open SimpleGraph
 
 variable (k : Type w) [Field k] {V : Type u} (G : SimpleGraph V) [Finite V]
 
+/-- The finite indexing type used internally for componentwise pairings. -/
+noncomputable local instance zigzagConnectedComponentFintype : Fintype G.ConnectedComponent :=
+  Fintype.ofFinite _
+
 /-! ### The componentwise public algebra -/
-
-/-- The Frobenius pairing on the dual numbers, obtained by taking the infinitesimal coefficient
-of a product. -/
-private noncomputable def dualNumberTracePairing : LinearMap.BilinForm k (DualNumber k) :=
-  { toFun := fun x =>
-      { toFun := fun y => x.fst * y.snd + x.snd * y.fst
-        map_add' := fun y z => by
-          change x.fst * (y.snd + z.snd) + x.snd * (y.fst + z.fst) =
-            (x.fst * y.snd + x.snd * y.fst) + (x.fst * z.snd + x.snd * z.fst)
-          ring
-        map_smul' := fun c y => by
-          change x.fst * (c * y.snd) + x.snd * (c * y.fst) =
-            c * (x.fst * y.snd + x.snd * y.fst)
-          ring }
-    map_add' := fun x y => by
-      apply LinearMap.ext
-      intro z
-      change (x.fst + y.fst) * z.snd + (x.snd + y.snd) * z.fst =
-        (x.fst * z.snd + x.snd * z.fst) + (y.fst * z.snd + y.snd * z.fst)
-      ring
-    map_smul' := fun c x => by
-      apply LinearMap.ext
-      intro y
-      change (c * x.fst) * y.snd + (c * x.snd) * y.fst =
-        c * (x.fst * y.snd + x.snd * y.fst)
-      ring }
-
-private instance dualNumberTracePairing_isPerfPair : (dualNumberTracePairing k).IsPerfPair := by
-  have hbij : Function.Bijective (dualNumberTracePairing k) := by
-    constructor
-    · intro x y h
-      apply TrivSqZeroExt.ext
-      · have he := LinearMap.congr_fun h DualNumber.eps
-        simpa [dualNumberTracePairing] using he
-      · have h1 := LinearMap.congr_fun h 1
-        simpa [dualNumberTracePairing] using h1
-    · intro f
-      refine ⟨⟨f DualNumber.eps, f 1⟩, ?_⟩
-      apply LinearMap.ext
-      intro y
-      calc
-        dualNumberTracePairing k ⟨f DualNumber.eps, f 1⟩ y =
-            y.snd * f DualNumber.eps + y.fst * f 1 := by
-          change f DualNumber.eps * y.snd + f 1 * y.fst = _
-          ring
-        _ = f (y.snd • DualNumber.eps + y.fst • (1 : DualNumber k)) := by
-          rw [map_add, map_smul, map_smul]
-          ring
-        _ = f y := by
-          congr 1
-          apply TrivSqZeroExt.ext <;> simp
-  refine ⟨hbij, ?_⟩
-  have hflip : (dualNumberTracePairing k).flip = dualNumberTracePairing k := by
-    apply LinearMap.ext
-    intro x
-    apply LinearMap.ext
-    intro y
-    change y.fst * x.snd + y.snd * x.fst = x.fst * y.snd + x.snd * y.fst
-    ring
-  change Function.Bijective ⇑((dualNumberTracePairing k).flip)
-  rw [hflip]
-  exact hbij
 
 /-- The perfect Frobenius pairing on one component of the public zigzag algebra. -/
 private noncomputable def zigzagComponentPairing (C : G.ConnectedComponent) :
@@ -154,6 +97,8 @@ private theorem zigzagComponentPairing_mul_assoc (C : G.ConnectedComponent)
         (C.connected_toSimpleGraph.preconnected.not_isIsolated i)
     let e := zigzagComponentAlgebraEquivNonisolated k G C
     simp only [zigzagComponentPairing, hC]
+    -- Evaluating the transported pairing is definitionally `compl₁₂_apply`; unfolding the
+    -- preceding `by_cases` does not expose that equation to `simp` in this dependent family.
     change zigzagTracePairing k C.toSimpleGraph hns (e (x * y)) (e z) =
       zigzagTracePairing k C.toSimpleGraph hns (e x) (e (y * z))
     rw [show e (x * y) = e x * e y from e.map_mul x y,
@@ -163,20 +108,18 @@ private theorem zigzagComponentPairing_mul_assoc (C : G.ConnectedComponent)
     let e := (zigzagComponentAlgebraEquivULiftDualNumber k G C).trans
       (ULift.algEquiv (R := k) (A := DualNumber k))
     simp only [zigzagComponentPairing, hC]
+    -- As above, this records the definitional evaluation of the transported pairing after the
+    -- singleton branch of the dependent `by_cases` has been selected.
     change dualNumberTracePairing k (e (x * y)) (e z) =
       dualNumberTracePairing k (e x) (e (y * z))
     rw [show e (x * y) = e x * e y from e.map_mul x y,
       show e (y * z) = e y * e z from e.map_mul y z]
-    change (e x * e y).fst * (e z).snd + (e x * e y).snd * (e z).fst =
-      (e x).fst * (e y * e z).snd + (e x).snd * (e y * e z).fst
-    simp only [DualNumber.snd_mul, TrivSqZeroExt.fst_mul]
-    ring
+    exact dualNumberTracePairing_mul_assoc k _ _ _
 
 /-- The direct-sum Frobenius pairing on the public componentwise zigzag algebra. -/
 private noncomputable def zigzagAlgebraPairing :
     LinearMap.BilinForm k (zigzagAlgebra k G) := by
   classical
-  let _ := Fintype.ofFinite G.ConnectedComponent
   exact
     { toFun := fun x =>
         ∑ C, (zigzagComponentPairing k G C (zigzagComponentProjection k G C x)).comp
@@ -195,18 +138,21 @@ private noncomputable def zigzagAlgebraPairing :
         simp only [LinearMap.smul_apply]
         rw [Finset.smul_sum] }
 
+private theorem zigzagAlgebraPairing_apply (x y : zigzagAlgebra k G) :
+    zigzagAlgebraPairing k G x y = ∑ C, zigzagComponentPairing k G C
+      (zigzagComponentProjection k G C x) (zigzagComponentProjection k G C y) := by
+  classical
+  rw [zigzagAlgebraPairing]
+  simp only [LinearMap.coe_mk, AddHom.coe_mk, LinearMap.sum_apply, LinearMap.comp_apply,
+    AlgHom.toLinearMap_apply]
+
 open Classical in
 private theorem zigzagAlgebraPairing_single_right (x : zigzagAlgebra k G)
     (C : G.ConnectedComponent) (z : zigzagComponentAlgebra k G C) :
     zigzagAlgebraPairing k G x (zigzagAlgebraMk k G (Pi.single C z)) =
       zigzagComponentPairing k G C (zigzagComponentProjection k G C x) z := by
   classical
-  let _ := Fintype.ofFinite G.ConnectedComponent
-  rw [zigzagAlgebraPairing]
-  simp only [LinearMap.coe_mk, AddHom.coe_mk]
-  simp only [LinearMap.sum_apply, LinearMap.comp_apply]
-  change (∑ D, zigzagComponentPairing k G D (zigzagComponentProjection k G D x)
-    (zigzagComponentProjection k G D (zigzagAlgebraMk k G (Pi.single C z)))) = _
+  rw [zigzagAlgebraPairing_apply]
   simp_rw [zigzagComponentProjection_zigzagAlgebraMk]
   simpa only [LinearMap.lsum_apply, LinearMap.sum_apply, LinearMap.comp_apply,
     LinearMap.proj_apply] using
@@ -220,13 +166,7 @@ private theorem zigzagAlgebraPairing_single_left (x : zigzagAlgebra k G)
     zigzagAlgebraPairing k G (zigzagAlgebraMk k G (Pi.single C z)) x =
       zigzagComponentPairing k G C z (zigzagComponentProjection k G C x) := by
   classical
-  let _ := Fintype.ofFinite G.ConnectedComponent
-  rw [zigzagAlgebraPairing]
-  simp only [LinearMap.coe_mk, AddHom.coe_mk]
-  simp only [LinearMap.sum_apply, LinearMap.comp_apply]
-  change (∑ D, zigzagComponentPairing k G D
-    (zigzagComponentProjection k G D (zigzagAlgebraMk k G (Pi.single C z)))
-    (zigzagComponentProjection k G D x)) = _
+  rw [zigzagAlgebraPairing_apply]
   simp_rw [zigzagComponentProjection_zigzagAlgebraMk]
   have hsum := LinearMap.lsum_piSingle k (fun D : G.ConnectedComponent =>
     zigzagComponentAlgebra k G D) k
@@ -234,6 +174,8 @@ private theorem zigzagAlgebraPairing_single_left (x : zigzagAlgebra k G)
       (zigzagComponentProjection k G D x)) C z
   rw [LinearMap.lsum_apply] at hsum
   simp only [LinearMap.sum_apply, LinearMap.comp_apply, LinearMap.proj_apply] at hsum
+  -- The dependent component type is intentionally opaque, so `flip_apply` cannot transport the
+  -- heterogeneous `Pi.single` sum by simplification; this conversion states that common type.
   change (∑ D, zigzagComponentPairing k G D
     ((Pi.single C z : ∀ E, zigzagComponentAlgebra k G E) D)
     (zigzagComponentProjection k G D x)) =
@@ -242,7 +184,6 @@ private theorem zigzagAlgebraPairing_single_left (x : zigzagAlgebra k G)
 
 private instance zigzagAlgebraPairing_isPerfPair : (zigzagAlgebraPairing k G).IsPerfPair := by
   classical
-  let _ := Fintype.ofFinite G.ConnectedComponent
   apply LinearMap.IsPerfPair.of_injective
   · intro x y h
     apply zigzagAlgebra.ext
@@ -266,24 +207,23 @@ private instance zigzagAlgebraPairing_isPerfPair : (zigzagAlgebraPairing k G).Is
     rw [zigzagAlgebraPairing_single_left, zigzagAlgebraPairing_single_left] at hz
     exact hz
 
-/-- **The public zigzag algebra of every finite simple graph is self-injective.** Singleton
-components contribute dual-number factors, while every nontrivial component uses its zigzag trace
-pairing; the sum of these component pairings is perfect and associative. -/
-theorem moduleInjective_zigzagAlgebra :
-    Module.Injective (zigzagAlgebra k G) (zigzagAlgebra k G) := by
+private theorem zigzagAlgebraPairing_mul_assoc (x y z : zigzagAlgebra k G) :
+    zigzagAlgebraPairing k G (x * y) z = zigzagAlgebraPairing k G x (y * z) := by
   classical
-  let _ := Fintype.ofFinite G.ConnectedComponent
-  apply (zigzagAlgebraPairing_isPerfPair k G).moduleInjective_self
-  intro x y z
-  rw [zigzagAlgebraPairing]
-  simp only [LinearMap.coe_mk, AddHom.coe_mk]
-  simp only [LinearMap.sum_apply, LinearMap.comp_apply]
-  change (∑ C, zigzagComponentPairing k G C
-    (zigzagComponentProjection k G C (x * y)) (zigzagComponentProjection k G C z)) =
-    ∑ C, zigzagComponentPairing k G C (zigzagComponentProjection k G C x)
-      (zigzagComponentProjection k G C (y * z))
+  rw [zigzagAlgebraPairing_apply, zigzagAlgebraPairing_apply]
   simp_rw [map_mul]
   exact Finset.sum_congr rfl fun C _ => zigzagComponentPairing_mul_assoc k G C _ _ _
+
+/-- **The public zigzag algebra of every finite simple graph satisfies Baer's criterion.**
+Singleton components contribute dual-number factors, while every nontrivial component uses its
+zigzag trace pairing; the sum of these component pairings is perfect and associative. -/
+theorem moduleBaer_zigzagAlgebra : Module.Baer (zigzagAlgebra k G) (zigzagAlgebra k G) :=
+  (zigzagAlgebraPairing_isPerfPair k G).moduleBaer_self (zigzagAlgebraPairing_mul_assoc k G)
+
+/-- **The public zigzag algebra of every finite simple graph is self-injective.** -/
+theorem moduleInjective_zigzagAlgebra :
+    Module.Injective (zigzagAlgebra k G) (zigzagAlgebra k G) :=
+  Module.Baer.injective (moduleBaer_zigzagAlgebra k G)
 
 /-! ### The nonisolated relation quotient and its vertex projectives -/
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
@@ -6,23 +6,25 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Module.Injective.SelfInjective
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Dimension
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Projective
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Trace
 
 /-!
 # The zigzag algebra is self-injective
 
-The zigzag algebra of a finite simple graph without isolated vertices is a symmetric Frobenius
-algebra: `TauCeti.zigzagTracePairing` is a symmetric associative bilinear form, and it is perfect
-because its Gram matrix in the vertex, arrow and volume basis is the permutation matrix of the
-involution exchanging an idempotent with a volume class and a dart with its reverse. This file
-draws the module-theoretic consequence over a field: the algebra is **self-injective**, its regular
-left module being an injective module.
+The public zigzag algebra of every finite simple graph is a symmetric Frobenius algebra, and hence
+is **self-injective**. On a nontrivial connected component, `TauCeti.zigzagTracePairing` is the
+perfect associative pairing whose Gram matrix exchanges an idempotent with a volume class and a
+dart with its reverse. A singleton component instead carries the dual numbers, with perfect
+pairing given by the infinitesimal coefficient of a product. Summing these pairings over the
+connected components proves the result for `TauCeti.zigzagAlgebra`, including disconnected graphs
+and isolated vertices.
 
 The argument is the general criterion `LinearMap.IsPerfPair.moduleBaer_self`: the trace turns a map
 out of a left ideal into a linear functional, which extends to the whole algebra as a vector space
 and is then written as pairing against a fixed element, giving the extension Baer's criterion asks
-for. Nothing about the graph enters beyond the Frobenius pairing already constructed.
+for.
 
 Because the vertex projective `Z e_i` is a retract of the regular module, it inherits injectivity:
 over a zigzag algebra the vertex projectives are also the indecomposable injectives. Their
@@ -31,8 +33,10 @@ projectivity is `TauCeti.zigzagProjective_projective`, and their indecomposabili
 
 ## Main results
 
-* `TauCeti.moduleInjective_nonisolatedZigzagQuotient`: the zigzag algebra of a finite simple graph
-  without isolated vertices is self-injective.
+* `TauCeti.moduleInjective_zigzagAlgebra`: the public componentwise zigzag algebra of every finite
+  simple graph is self-injective.
+* `TauCeti.moduleInjective_nonisolatedZigzagQuotient`: the relation-quotient presentation for a
+  graph without isolated vertices is self-injective.
 * `TauCeti.moduleInjective_zigzagProjective`: each vertex projective `Z e_i` is an injective
   module.
 
@@ -48,8 +52,242 @@ namespace TauCeti
 
 universe u w
 
+open SimpleGraph
+
 variable (k : Type w) [Field k] {V : Type u} (G : SimpleGraph V) [Finite V]
-  (hns : ∀ i : V, ∃ j, G.Adj i j)
+
+/-! ### The componentwise public algebra -/
+
+/-- The Frobenius pairing on the dual numbers, obtained by taking the infinitesimal coefficient
+of a product. -/
+private noncomputable def dualNumberTracePairing : LinearMap.BilinForm k (DualNumber k) :=
+  { toFun := fun x =>
+      { toFun := fun y => x.fst * y.snd + x.snd * y.fst
+        map_add' := fun y z => by
+          change x.fst * (y.snd + z.snd) + x.snd * (y.fst + z.fst) =
+            (x.fst * y.snd + x.snd * y.fst) + (x.fst * z.snd + x.snd * z.fst)
+          ring
+        map_smul' := fun c y => by
+          change x.fst * (c * y.snd) + x.snd * (c * y.fst) =
+            c * (x.fst * y.snd + x.snd * y.fst)
+          ring }
+    map_add' := fun x y => by
+      apply LinearMap.ext
+      intro z
+      change (x.fst + y.fst) * z.snd + (x.snd + y.snd) * z.fst =
+        (x.fst * z.snd + x.snd * z.fst) + (y.fst * z.snd + y.snd * z.fst)
+      ring
+    map_smul' := fun c x => by
+      apply LinearMap.ext
+      intro y
+      change (c * x.fst) * y.snd + (c * x.snd) * y.fst =
+        c * (x.fst * y.snd + x.snd * y.fst)
+      ring }
+
+private instance dualNumberTracePairing_isPerfPair : (dualNumberTracePairing k).IsPerfPair := by
+  have hbij : Function.Bijective (dualNumberTracePairing k) := by
+    constructor
+    · intro x y h
+      apply TrivSqZeroExt.ext
+      · have he := LinearMap.congr_fun h DualNumber.eps
+        simpa [dualNumberTracePairing] using he
+      · have h1 := LinearMap.congr_fun h 1
+        simpa [dualNumberTracePairing] using h1
+    · intro f
+      refine ⟨⟨f DualNumber.eps, f 1⟩, ?_⟩
+      apply LinearMap.ext
+      intro y
+      calc
+        dualNumberTracePairing k ⟨f DualNumber.eps, f 1⟩ y =
+            y.snd * f DualNumber.eps + y.fst * f 1 := by
+          change f DualNumber.eps * y.snd + f 1 * y.fst = _
+          ring
+        _ = f (y.snd • DualNumber.eps + y.fst • (1 : DualNumber k)) := by
+          rw [map_add, map_smul, map_smul]
+          ring
+        _ = f y := by
+          congr 1
+          apply TrivSqZeroExt.ext <;> simp
+  refine ⟨hbij, ?_⟩
+  have hflip : (dualNumberTracePairing k).flip = dualNumberTracePairing k := by
+    apply LinearMap.ext
+    intro x
+    apply LinearMap.ext
+    intro y
+    change y.fst * x.snd + y.snd * x.fst = x.fst * y.snd + x.snd * y.fst
+    ring
+  change Function.Bijective ⇑((dualNumberTracePairing k).flip)
+  rw [hflip]
+  exact hbij
+
+/-- The perfect Frobenius pairing on one component of the public zigzag algebra. -/
+private noncomputable def zigzagComponentPairing (C : G.ConnectedComponent) :
+    LinearMap.BilinForm k (zigzagComponentAlgebra k G C) := by
+  classical
+  by_cases hC : Nontrivial C
+  · let _ : Nontrivial C := hC
+    let hns : ∀ i : C, ∃ j, C.toSimpleGraph.Adj i j := fun i =>
+      exists_adj_iff_not_isIsolated.mpr
+        (C.connected_toSimpleGraph.preconnected.not_isIsolated i)
+    exact (zigzagTracePairing k C.toSimpleGraph hns).compl₁₂
+      (zigzagComponentAlgebraEquivNonisolated k G C).toLinearEquiv
+      (zigzagComponentAlgebraEquivNonisolated k G C).toLinearEquiv
+  · let _ : Subsingleton C := not_nontrivial_iff_subsingleton.mp hC
+    let e := (zigzagComponentAlgebraEquivULiftDualNumber k G C).trans
+      (ULift.algEquiv (R := k) (A := DualNumber k))
+    exact (dualNumberTracePairing k).compl₁₂ e.toLinearEquiv e.toLinearEquiv
+
+private instance zigzagComponentPairing_isPerfPair (C : G.ConnectedComponent) :
+    (zigzagComponentPairing k G C).IsPerfPair := by
+  classical
+  unfold zigzagComponentPairing
+  split <;> infer_instance
+
+private theorem zigzagComponentPairing_mul_assoc (C : G.ConnectedComponent)
+    (x y z : zigzagComponentAlgebra k G C) :
+    zigzagComponentPairing k G C (x * y) z = zigzagComponentPairing k G C x (y * z) := by
+  classical
+  by_cases hC : Nontrivial C
+  · let _ : Nontrivial C := hC
+    let hns : ∀ i : C, ∃ j, C.toSimpleGraph.Adj i j := fun i =>
+      exists_adj_iff_not_isIsolated.mpr
+        (C.connected_toSimpleGraph.preconnected.not_isIsolated i)
+    let e := zigzagComponentAlgebraEquivNonisolated k G C
+    simp only [zigzagComponentPairing, hC]
+    change zigzagTracePairing k C.toSimpleGraph hns (e (x * y)) (e z) =
+      zigzagTracePairing k C.toSimpleGraph hns (e x) (e (y * z))
+    rw [show e (x * y) = e x * e y from e.map_mul x y,
+      show e (y * z) = e y * e z from e.map_mul y z]
+    exact zigzagTracePairing_mul_assoc k C.toSimpleGraph hns _ _ _
+  · let _ : Subsingleton C := not_nontrivial_iff_subsingleton.mp hC
+    let e := (zigzagComponentAlgebraEquivULiftDualNumber k G C).trans
+      (ULift.algEquiv (R := k) (A := DualNumber k))
+    simp only [zigzagComponentPairing, hC]
+    change dualNumberTracePairing k (e (x * y)) (e z) =
+      dualNumberTracePairing k (e x) (e (y * z))
+    rw [show e (x * y) = e x * e y from e.map_mul x y,
+      show e (y * z) = e y * e z from e.map_mul y z]
+    change (e x * e y).fst * (e z).snd + (e x * e y).snd * (e z).fst =
+      (e x).fst * (e y * e z).snd + (e x).snd * (e y * e z).fst
+    simp only [DualNumber.snd_mul, TrivSqZeroExt.fst_mul]
+    ring
+
+/-- The direct-sum Frobenius pairing on the public componentwise zigzag algebra. -/
+private noncomputable def zigzagAlgebraPairing :
+    LinearMap.BilinForm k (zigzagAlgebra k G) := by
+  classical
+  let _ := Fintype.ofFinite G.ConnectedComponent
+  exact
+    { toFun := fun x =>
+        ∑ C, (zigzagComponentPairing k G C (zigzagComponentProjection k G C x)).comp
+          (zigzagComponentProjection k G C).toLinearMap
+      map_add' := fun x y => by
+        apply LinearMap.ext
+        intro z
+        simp only [LinearMap.sum_apply, LinearMap.comp_apply, LinearMap.add_apply]
+        simp only [map_add]
+        exact Finset.sum_add_distrib
+      map_smul' := fun c x => by
+        apply LinearMap.ext
+        intro z
+        simp only [LinearMap.sum_apply, LinearMap.comp_apply, LinearMap.smul_apply]
+        simp only [map_smul, RingHom.id_apply]
+        simp only [LinearMap.smul_apply]
+        rw [Finset.smul_sum] }
+
+open Classical in
+private theorem zigzagAlgebraPairing_single_right (x : zigzagAlgebra k G)
+    (C : G.ConnectedComponent) (z : zigzagComponentAlgebra k G C) :
+    zigzagAlgebraPairing k G x (zigzagAlgebraMk k G (Pi.single C z)) =
+      zigzagComponentPairing k G C (zigzagComponentProjection k G C x) z := by
+  classical
+  let _ := Fintype.ofFinite G.ConnectedComponent
+  rw [zigzagAlgebraPairing]
+  simp only [LinearMap.coe_mk, AddHom.coe_mk]
+  simp only [LinearMap.sum_apply, LinearMap.comp_apply]
+  change (∑ D, zigzagComponentPairing k G D (zigzagComponentProjection k G D x)
+    (zigzagComponentProjection k G D (zigzagAlgebraMk k G (Pi.single C z)))) = _
+  simp_rw [zigzagComponentProjection_zigzagAlgebraMk]
+  simpa only [LinearMap.lsum_apply, LinearMap.sum_apply, LinearMap.comp_apply,
+    LinearMap.proj_apply] using
+      LinearMap.lsum_piSingle k (fun D : G.ConnectedComponent =>
+        zigzagComponentAlgebra k G D) k
+        (fun D => zigzagComponentPairing k G D (zigzagComponentProjection k G D x)) C z
+
+open Classical in
+private theorem zigzagAlgebraPairing_single_left (x : zigzagAlgebra k G)
+    (C : G.ConnectedComponent) (z : zigzagComponentAlgebra k G C) :
+    zigzagAlgebraPairing k G (zigzagAlgebraMk k G (Pi.single C z)) x =
+      zigzagComponentPairing k G C z (zigzagComponentProjection k G C x) := by
+  classical
+  let _ := Fintype.ofFinite G.ConnectedComponent
+  rw [zigzagAlgebraPairing]
+  simp only [LinearMap.coe_mk, AddHom.coe_mk]
+  simp only [LinearMap.sum_apply, LinearMap.comp_apply]
+  change (∑ D, zigzagComponentPairing k G D
+    (zigzagComponentProjection k G D (zigzagAlgebraMk k G (Pi.single C z)))
+    (zigzagComponentProjection k G D x)) = _
+  simp_rw [zigzagComponentProjection_zigzagAlgebraMk]
+  have hsum := LinearMap.lsum_piSingle k (fun D : G.ConnectedComponent =>
+    zigzagComponentAlgebra k G D) k
+    (fun D => (zigzagComponentPairing k G D).flip
+      (zigzagComponentProjection k G D x)) C z
+  rw [LinearMap.lsum_apply] at hsum
+  simp only [LinearMap.sum_apply, LinearMap.comp_apply, LinearMap.proj_apply] at hsum
+  change (∑ D, zigzagComponentPairing k G D
+    ((Pi.single C z : ∀ E, zigzagComponentAlgebra k G E) D)
+    (zigzagComponentProjection k G D x)) =
+      zigzagComponentPairing k G C z (zigzagComponentProjection k G C x) at hsum
+  exact hsum
+
+private instance zigzagAlgebraPairing_isPerfPair : (zigzagAlgebraPairing k G).IsPerfPair := by
+  classical
+  let _ := Fintype.ofFinite G.ConnectedComponent
+  apply LinearMap.IsPerfPair.of_injective
+  · intro x y h
+    apply zigzagAlgebra.ext
+    intro C
+    apply (LinearMap.IsPerfPair.bijective_left (zigzagComponentPairing k G C)).injective
+    apply LinearMap.ext
+    intro z
+    have hz := LinearMap.congr_fun h
+      (zigzagAlgebraMk k G (Pi.single C z))
+    rw [zigzagAlgebraPairing_single_right, zigzagAlgebraPairing_single_right] at hz
+    exact hz
+  · intro x y h
+    apply zigzagAlgebra.ext
+    intro C
+    apply (LinearMap.IsPerfPair.bijective_right (zigzagComponentPairing k G C)).injective
+    apply LinearMap.ext
+    intro z
+    have hz := LinearMap.congr_fun h
+      (zigzagAlgebraMk k G (Pi.single C z))
+    simp only [LinearMap.flip_apply] at hz
+    rw [zigzagAlgebraPairing_single_left, zigzagAlgebraPairing_single_left] at hz
+    exact hz
+
+/-- **The public zigzag algebra of every finite simple graph is self-injective.** Singleton
+components contribute dual-number factors, while every nontrivial component uses its zigzag trace
+pairing; the sum of these component pairings is perfect and associative. -/
+theorem moduleInjective_zigzagAlgebra :
+    Module.Injective (zigzagAlgebra k G) (zigzagAlgebra k G) := by
+  classical
+  let _ := Fintype.ofFinite G.ConnectedComponent
+  apply (zigzagAlgebraPairing_isPerfPair k G).moduleInjective_self
+  intro x y z
+  rw [zigzagAlgebraPairing]
+  simp only [LinearMap.coe_mk, AddHom.coe_mk]
+  simp only [LinearMap.sum_apply, LinearMap.comp_apply]
+  change (∑ C, zigzagComponentPairing k G C
+    (zigzagComponentProjection k G C (x * y)) (zigzagComponentProjection k G C z)) =
+    ∑ C, zigzagComponentPairing k G C (zigzagComponentProjection k G C x)
+      (zigzagComponentProjection k G C (y * z))
+  simp_rw [map_mul]
+  exact Finset.sum_congr rfl fun C _ => zigzagComponentPairing_mul_assoc k G C _ _ _
+
+/-! ### The nonisolated relation quotient and its vertex projectives -/
+
+variable (hns : ∀ i : V, ∃ j, G.Adj i j)
 
 include hns
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
@@ -22,13 +22,12 @@ pairing given by the infinitesimal coefficient of a product. Summing these pairi
 connected components proves the result for `TauCeti.zigzagAlgebra`, including disconnected graphs
 and isolated vertices.
 
-The argument is the general criterion `Function.Bijective.moduleBaer_self`: the trace turns a map
-out of a left ideal into a linear functional, which extends to the whole algebra as a vector space
-and is then written as pairing against a fixed element, giving the extension Baer's criterion asks
-for.
+The general criterion `Function.Bijective.moduleBaer_self` applied to the componentwise perfect
+associative pairing gives self-injectivity of the public zigzag algebra, and also recovers the
+relation-quotient result for graphs without isolated vertices.
 
 Because the vertex projective `Z e_i` is a retract of the regular module, it inherits injectivity:
-over a zigzag algebra the vertex projectives are also the indecomposable injectives. Their
+over a zigzag algebra the vertex projectives are indecomposable injective modules. Their
 projectivity is `TauCeti.zigzagProjective_projective`, and their indecomposability is
 `TauCeti.isIndecomposableModule_zigzagProjective`.
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean
@@ -103,6 +103,8 @@ private theorem zigzagComponentPairing_mul_assoc (C : G.ConnectedComponent)
     -- preceding `by_cases` does not expose that equation to `simp` in this dependent family.
     change zigzagTracePairing k C.toSimpleGraph hns (e (x * y)) (e z) =
       zigzagTracePairing k C.toSimpleGraph hns (e x) (e (y * z))
+    -- `e.map_mul` is stated through `e.toMulEquiv`, whereas this goal contains the `AlgEquiv`
+    -- function coercion, so `rw [e.map_mul x y]` cannot find the syntactically different term.
     rw [show e (x * y) = e x * e y from e.map_mul x y,
       show e (y * z) = e y * e z from e.map_mul y z]
     exact zigzagTracePairing_mul_assoc k C.toSimpleGraph hns _ _ _
@@ -114,6 +116,7 @@ private theorem zigzagComponentPairing_mul_assoc (C : G.ConnectedComponent)
     -- singleton branch of the dependent `by_cases` has been selected.
     change dualNumberTracePairing k (e (x * y)) (e z) =
       dualNumberTracePairing k (e x) (e (y * z))
+    -- The typed equalities bridge the same `e.toMulEquiv` versus `AlgEquiv` coercion mismatch.
     rw [show e (x * y) = e x * e y from e.map_mul x y,
       show e (y * z) = e y * e z from e.map_mul y z]
     exact dualNumberTracePairing_mul_assoc k _ _ _


### PR DESCRIPTION
This PR proves that the zigzag algebra of a finite simple graph without isolated vertices is self-injective, and that its vertex projectives are injective modules. This is the last unmet clause of the trace milestone in Layer 2 of `TauCetiRoadmap/ZigzagPreprojective/README.md`, which asks for the trace `tr(x_i) = 1`, the symmetry and nondegeneracy of `(x, y) ↦ tr(xy)`, and then to "package the resulting symmetric Frobenius and self-injective algebra structures". The symmetric, associative and perfect pairing `TauCeti.zigzagTracePairing` already exists; what was missing, and what `TauCeti/RepresentationTheory/Quiver/Zigzag/Trace.lean` explicitly records as absent, is self-injectivity.

The engine is a general criterion in `TauCeti/Algebra/Module/Injective/SelfInjective.lean`: an algebra `A` over a field `k` carrying a `k`-bilinear form `B` which is associative, `B (x * y) z = B x (y * z)`, and perfect in the sense of Mathlib's `LinearMap.IsPerfPair`, satisfies Baer's criterion for its own regular left module, hence is self-injective (`LinearMap.IsPerfPair.moduleBaer_self` and `LinearMap.IsPerfPair.moduleInjective_self`). Given a left ideal `I` and an `A`-linear `f : I →ₗ[A] A`, the trace `B 1` turns `f` into a `k`-linear functional on `I`, which extends to a functional `ψ` on `A` because `I` is a subspace of a vector space; perfectness writes `ψ` as `B · a`, and right multiplication by `a` is the extension Baer asks for, since `x * a` and `f x` pair identically against every `y` once associativity moves `y` inside `f`. No finiteness of `A` is used. Two general facts about Baer modules are proved on the way and stated in Mathlib's `Module.Baer` namespace, which has neither: a retract of a Baer module is Baer (`Module.Baer.of_leftInverse`), and hence over a self-injective ring so is a left ideal cut out by an idempotent (`Module.Baer.of_isIdempotentElem`), which is what makes the vertex projective `Z e_i` injective.

Nothing was vendored from Mathlib; the criterion consumes `Module.Baer.injective`, `LinearMap.exists_extend` and `LinearMap.IsPerfPair` unchanged, and Mathlib has no notion of a Frobenius algebra or a self-injective ring to reuse.

New files: `TauCeti/Algebra/Module/Injective/SelfInjective.lean` (147 lines) and `TauCeti/RepresentationTheory/Quiver/Zigzag/SelfInjective.lean` (77 lines).

After this PR the Layer 2 trace clause still owes the Frobenius packaging in its bimodule form — the isomorphism of the algebra with its `k`-dual as a left module, which needs a module structure on `Module.Dual k Z` that Mathlib does not carry as an instance — and the componentwise statements for the public `TauCeti.zigzagAlgebra`, whose singleton components are dual numbers rather than relation quotients.

Roadmap: ZigzagPreprojective

<!--tauceti-target:v1 {"focus":"ZigzagPreprojective","id":"zigzag-algebra-self-injective"}-->

🤖 Prepared with Claude Code
