### PR TITLE
feat: add the hypergeometric binomial limit

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Choose.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Choose.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Choose
+import Mathlib.RingTheory.Polynomial.Pochhammer
+
+/-!
+# Limits of binomial coefficients along proportional sequences
+
+For fixed `k`, the leading term of `a.choose k` is `a ^ k / k!`. This file records the
+corresponding limit when `a` and the normalizing denominator vary together: if `a i / b i`
+converges to `x` and `b i⁻¹` converges to zero, then
+
+```text
+  (a i).choose k / (b i) ^ k → x ^ k / k!.
+```
+
+The statement includes boundary limits such as `x = 0`; no divergence hypothesis on `a` is
+needed. It is useful for finite-population limits, where one of a population and its complement
+may stay bounded.
+
+## Main result
+
+* `TauCeti.tendsto_choose_div_pow_of_tendsto_div` — the normalized fixed-order binomial
+  coefficient along an asymptotically proportional sequence.
+-/
+
+public section
+
+open Filter Polynomial Topology
+
+namespace TauCeti
+
+/-- A fixed-order binomial coefficient has its expected leading-term limit along any sequence
+whose ratio to a common denominator converges.
+
+The separate hypothesis that the inverse denominator tends to zero makes the statement applicable
+to denominators other than the natural index. -/
+theorem tendsto_choose_div_pow_of_tendsto_div {α : Type*} {l : Filter α} {a : α → ℕ}
+    {b : α → ℝ} {x : ℝ}
+    (hab : Tendsto (fun i ↦ (a i : ℝ) / b i) l (nhds x))
+    (hb : Tendsto (fun i ↦ (b i)⁻¹) l (nhds 0)) (k : ℕ) :
+    Tendsto (fun i ↦ ((a i).choose k : ℝ) / (b i) ^ k) l
+      (nhds (x ^ k / (k.factorial : ℝ))) := by
+  have hfactor (j : ℕ) :
+      Tendsto (fun i ↦ (a i : ℝ) / b i - (j : ℝ) / b i) l (nhds x) := by
+    have hj : Tendsto (fun i ↦ (j : ℝ) / b i) l (nhds 0) := by
+      simpa only [div_eq_mul_inv, mul_zero] using
+        (tendsto_const_nhds.mul hb :
+          Tendsto (fun i ↦ (j : ℝ) * (b i)⁻¹) l (nhds ((j : ℝ) * 0)))
+    simpa only [sub_zero] using hab.sub hj
+  have hprod :
+      Tendsto (fun i ↦ ∏ j ∈ Finset.range k,
+        ((a i : ℝ) / b i - (j : ℝ) / b i)) l (nhds (x ^ k)) := by
+    simpa using tendsto_finsetProd (Finset.range k) fun j _ ↦ hfactor j
+  refine Tendsto.congr' (Eventually.of_forall fun i ↦ ?_) (hprod.div_const (k.factorial : ℝ))
+  symm
+  dsimp only
+  rw [Nat.cast_choose_eq_descPochhammer_div, descPochhammer_eval_eq_prod_range]
+  simp_rw [← sub_div]
+  rw [Finset.prod_div_distrib, Finset.prod_const, Finset.card_range]
+  ring
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Hypergeometric/Limit.lean
+++ b/TauCeti/Probability/Distributions/Hypergeometric/Limit.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Distributions.Hypergeometric.Basic
+public import Mathlib.Probability.Distributions.Binomial
+import TauCeti.Analysis.SpecialFunctions.Choose
+
+/-!
+# The binomial limit of hypergeometric probabilities
+
+Fix a sample size `n`. Suppose a population of size `N` contains `K N` marked elements and the
+marked proportion `K N / N` converges to `p`. Then, for every fixed `k`, the probability that a
+sample without replacement contains `k` marked elements converges to the corresponding binomial
+probability for `n` independent trials with success probability `p`.
+
+The result includes the boundary proportions `p = 0` and `p = 1`. Its proof normalizes the three
+binomial coefficients in the hypergeometric mass formula by powers of `N`; this avoids requiring
+either `K N` or `N - K N` to tend to infinity at the boundary.
+
+## Main result
+
+* `TauCeti.Probability.tendsto_hypergeometricMeasure_real_singleton` — pointwise convergence of
+  hypergeometric masses to binomial masses.
+
+## References
+
+* N. L. Johnson, A. W. Kemp, S. Kotz, *Univariate Discrete Distributions*, 3rd ed., Wiley,
+  2005, Chapter 6.
+-/
+
+public section
+
+noncomputable section
+
+open Filter MeasureTheory ProbabilityTheory Topology
+
+namespace TauCeti
+
+namespace Probability
+
+/-- If the marked proportion in a growing finite population tends to `p`, then each fixed
+hypergeometric mass tends to the corresponding binomial mass. -/
+theorem tendsto_hypergeometricMeasure_real_singleton (p : unitInterval) (K : ℕ → ℕ)
+    (hK : ∀ N, K N ≤ N)
+    (hKp : Tendsto (fun N ↦ (K N : ℝ) / N) atTop (nhds (p : ℝ))) (n k : ℕ) :
+    Tendsto (fun N ↦ (hypergeometricMeasure N (K N) n).real {k}) atTop
+      (nhds ((binomial n p).real {k})) := by
+  by_cases hkn : k ≤ n
+  · -- Normalize the marked, unmarked, and total population coefficients separately.
+    have hinv : Tendsto (fun N : ℕ ↦ ((N : ℝ))⁻¹) atTop (nhds 0) :=
+      tendsto_inv_atTop_nhds_zero_nat
+    have hcomplement :
+        Tendsto (fun N ↦ ((N - K N : ℕ) : ℝ) / N) atTop
+          (nhds (1 - (p : ℝ))) := by
+      refine Tendsto.congr' ?_ (tendsto_const_nhds.sub hKp)
+      filter_upwards [eventually_ge_atTop 1] with N hN
+      rw [Nat.cast_sub (hK N), sub_div, div_self]
+      exact_mod_cast (show N ≠ 0 by omega)
+    have htotal : Tendsto (fun N : ℕ ↦ (N : ℝ) / N) atTop (nhds 1) := by
+      refine Tendsto.congr' ?_ tendsto_const_nhds
+      filter_upwards [eventually_ge_atTop 1] with N hN
+      rw [div_self]
+      exact_mod_cast (show N ≠ 0 by omega)
+    have hmarked := tendsto_choose_div_pow_of_tendsto_div
+      (a := K) (b := fun N : ℕ ↦ (N : ℝ)) hKp hinv k
+    have hunmarked :=
+      tendsto_choose_div_pow_of_tendsto_div (a := fun N ↦ N - K N)
+        (b := fun N : ℕ ↦ (N : ℝ)) hcomplement hinv (n - k)
+    have hpopulation := tendsto_choose_div_pow_of_tendsto_div
+      (a := id) (b := fun N : ℕ ↦ (N : ℝ)) htotal hinv n
+    -- Combine the three limits before identifying the normalized ratio with the mass.
+    have hnormalized := (hmarked.mul hunmarked).div hpopulation (by positivity)
+    rw [binomial_real_singleton]
+    have hfactorial :
+        (n.choose k : ℝ) * (k.factorial : ℝ) * ((n - k).factorial : ℝ) =
+          (n.factorial : ℝ) := by
+      exact_mod_cast Nat.choose_mul_factorial_mul_factorial hkn
+    have hlimit :
+        (p : ℝ) ^ k / (k.factorial : ℝ) *
+              ((1 - (p : ℝ)) ^ (n - k) / ((n - k).factorial : ℝ)) /
+            (1 ^ n / (n.factorial : ℝ)) =
+          (n.choose k : ℝ) * (p : ℝ) ^ k * (1 - (p : ℝ)) ^ (n - k) := by
+      field_simp
+      rw [← hfactorial]
+      ring
+    rw [hlimit] at hnormalized
+    refine Tendsto.congr' ?_ hnormalized
+    filter_upwards [eventually_ge_atTop (max n 1)] with N hN
+    have hnN : n ≤ N := le_trans (le_max_left n 1) hN
+    have hNpos : 0 < N := lt_of_lt_of_le (by omega) hN
+    rw [hypergeometricMeasure_real_singleton (hK N) hnN k, ite_eq_left hkn]
+    have hNne : (N : ℝ) ≠ 0 := by exact_mod_cast hNpos.ne'
+    have hchooseN : (N.choose n : ℝ) ≠ 0 := by
+      exact_mod_cast Nat.choose_ne_zero hnN
+    simp only [Pi.div_apply, id_eq]
+    field_simp
+    have hpow : (N : ℝ) ^ k * (N : ℝ) ^ (n - k) = (N : ℝ) ^ n := by
+      rw [← pow_add, Nat.add_sub_of_le hkn]
+    calc
+      _ = (K N).choose k * (N - K N).choose (n - k) *
+          ((N : ℝ) ^ k * (N : ℝ) ^ (n - k)) := by rw [hpow]
+      _ = _ := by ring
+  · -- Outside the common support, both the hypergeometric and binomial masses vanish.
+    rw [binomial_real_singleton, Nat.choose_eq_zero_of_lt (lt_of_not_ge hkn)]
+    simp only [Nat.cast_zero, zero_mul]
+    refine Tendsto.congr' ?_ tendsto_const_nhds
+    filter_upwards [eventually_ge_atTop n] with N hnN
+    rw [hypergeometricMeasure_real_singleton (hK N) hnN k, ite_eq_right hkn]
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Hypergeometric/Limit.lean
+++ b/TauCeti/Probability/Distributions/Hypergeometric/Limit.lean
@@ -17,9 +17,8 @@ marked proportion `K N / N` converges to `p`. Then, for every fixed `k`, the pro
 sample without replacement contains `k` marked elements converges to the corresponding binomial
 probability for `n` independent trials with success probability `p`.
 
-The result includes the boundary proportions `p = 0` and `p = 1`. Its proof normalizes the three
-binomial coefficients in the hypergeometric mass formula by powers of `N`; this avoids requiring
-either `K N` or `N - K N` to tend to infinity at the boundary.
+The result includes the boundary proportions `p = 0` and `p = 1`. At these boundary values, no
+divergence assumption is needed for either the marked or unmarked population.
 
 ## Main result
 
@@ -45,7 +44,7 @@ namespace Probability
 /-- If the marked proportion in a growing finite population tends to `p`, then each fixed
 hypergeometric mass tends to the corresponding binomial mass. -/
 theorem tendsto_hypergeometricMeasure_real_singleton (p : unitInterval) (K : ℕ → ℕ)
-    (hK : ∀ N, K N ≤ N)
+    (hK : ∀ᶠ N in atTop, K N ≤ N)
     (hKp : Tendsto (fun N ↦ (K N : ℝ) / N) atTop (nhds (p : ℝ))) (n k : ℕ) :
     Tendsto (fun N ↦ (hypergeometricMeasure N (K N) n).real {k}) atTop
       (nhds ((binomial n p).real {k})) := by
@@ -57,14 +56,16 @@ theorem tendsto_hypergeometricMeasure_real_singleton (p : unitInterval) (K : ℕ
         Tendsto (fun N ↦ ((N - K N : ℕ) : ℝ) / N) atTop
           (nhds (1 - (p : ℝ))) := by
       refine Tendsto.congr' ?_ (tendsto_const_nhds.sub hKp)
-      filter_upwards [eventually_ge_atTop 1] with N hN
-      rw [Nat.cast_sub (hK N), sub_div, div_self]
-      exact_mod_cast (show N ≠ 0 by omega)
+      filter_upwards [eventually_ge_atTop 1, hK] with N hN hKN
+      have hN0 : N ≠ 0 := by omega
+      have hN0' : (N : ℝ) ≠ 0 := by exact_mod_cast hN0
+      rw [Nat.cast_sub hKN, sub_div, div_self hN0']
     have htotal : Tendsto (fun N : ℕ ↦ (N : ℝ) / N) atTop (nhds 1) := by
       refine Tendsto.congr' ?_ tendsto_const_nhds
       filter_upwards [eventually_ge_atTop 1] with N hN
-      rw [div_self]
-      exact_mod_cast (show N ≠ 0 by omega)
+      have hN0 : N ≠ 0 := by omega
+      have hN0' : (N : ℝ) ≠ 0 := by exact_mod_cast hN0
+      rw [div_self hN0']
     have hmarked := tendsto_choose_div_pow_of_tendsto_div
       (a := K) (b := fun N : ℕ ↦ (N : ℝ)) hKp hinv k
     have hunmarked :=
@@ -89,10 +90,10 @@ theorem tendsto_hypergeometricMeasure_real_singleton (p : unitInterval) (K : ℕ
       ring
     rw [hlimit] at hnormalized
     refine Tendsto.congr' ?_ hnormalized
-    filter_upwards [eventually_ge_atTop (max n 1)] with N hN
+    filter_upwards [eventually_ge_atTop (max n 1), hK] with N hN hKN
     have hnN : n ≤ N := le_trans (le_max_left n 1) hN
     have hNpos : 0 < N := lt_of_lt_of_le (by omega) hN
-    rw [hypergeometricMeasure_real_singleton (hK N) hnN k, ite_eq_left hkn]
+    rw [hypergeometricMeasure_real_singleton hKN hnN k, ite_eq_left hkn]
     have hNne : (N : ℝ) ≠ 0 := by exact_mod_cast hNpos.ne'
     have hchooseN : (N.choose n : ℝ) ≠ 0 := by
       exact_mod_cast Nat.choose_ne_zero hnN
@@ -108,8 +109,8 @@ theorem tendsto_hypergeometricMeasure_real_singleton (p : unitInterval) (K : ℕ
     rw [binomial_real_singleton, Nat.choose_eq_zero_of_lt (lt_of_not_ge hkn)]
     simp only [Nat.cast_zero, zero_mul]
     refine Tendsto.congr' ?_ tendsto_const_nhds
-    filter_upwards [eventually_ge_atTop n] with N hnN
-    rw [hypergeometricMeasure_real_singleton (hK N) hnN k, ite_eq_right hkn]
+    filter_upwards [eventually_ge_atTop n, hK] with N hnN hKN
+    rw [hypergeometricMeasure_real_singleton hKN hnN k, ite_eq_right hkn]
 
 end Probability
 


### PR DESCRIPTION
This PR proves the fixed-`k` binomial limit for hypergeometric singleton masses, including the boundary proportions `p = 0` and `p = 1`.

It advances the exact `StandardDistributions/README.md` Layer 3 Hypergeometric target: for `K N / N → p`, prove pointwise convergence of `hypergeometricMeasure N (K N) n` masses to the corresponding `binomial n p` masses. This completes the Layer 3 Hypergeometric milestone. After this PR, Layer 3 still needs the remaining Fisher–Snedecor moment, tail, and measurability results and the remaining negative-binomial cast-transform, cumulative-mass, boundary, and measurability results.

Add a general fixed-order normalized-binomial-coefficient limit in `TauCeti.Analysis.SpecialFunctions.Choose`, then apply it to the marked population, its complement, and the whole population. The probability theorem is stated using `Measure.real`, which is definitionally the roadmap's `ENNReal.toReal` formulation.

No Mathlib infrastructure is vendored. The proofs reuse Mathlib's `Nat.cast_choose_eq_descPochhammer_div`, `descPochhammer_eval_eq_prod_range`, `tendsto_finsetProd`, `tendsto_inv_atTop_nhds_zero_nat`, and `binomial_real_singleton`; the probabilistic limit is the standard hypergeometric-to-binomial limit described in Johnson, Kemp, and Kotz, *Univariate Discrete Distributions*, 3rd ed., Chapter 6.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"hypergeometric-binomial-limit"}-->

🤖 Prepared with Codex
