### PR TITLE
feat: eliminate normal unipotent E7 subgroups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
@@ -8,9 +8,6 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.SmoothConnected
 public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
-import TauCeti.Algebra.AlgebraicGroup.Reductive.LinearlyReductive
-import TauCeti.Algebra.AlgebraicGroup.Representation.ClosedSubgroup
-import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
 
 /-!
@@ -93,6 +90,8 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
       (FiniteTypeCommHopfAlgCat.quotient H J) :=
     (smoothUnipotentCommHopfAlgProperty k).prop_of_iso qIso'.symm hU
   let _ : IsReduced H := by
+    -- `H` packages this coordinate algebra with its finite-type proof, so its carrier is
+    -- definitionally the coordinate algebra on which smoothness supplies reducedness.
     change IsReduced (coordinateHopfAlgebra k n)
     exact isReduced_of_smooth_of_field k _
   let _ : Comodule k (coordinateHopfAlgebra k n) (Fin n → k) := standardComodule k n

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
@@ -11,6 +11,7 @@ public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
 import TauCeti.Algebra.AlgebraicGroup.Reductive.LinearlyReductive
 import TauCeti.Algebra.AlgebraicGroup.Representation.ClosedSubgroup
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
 
 /-!
 # The general linear group is reductive
@@ -81,34 +82,29 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
   let qIso : CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J ≅
       CommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n).obj I :=
     CommHopfAlgCat.quotientIsoOfIso e I
-  have hU' := (smoothUnipotentCommHopfAlgProperty_iff k
-    (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I)).mp hU
-  let _ : Algebra.Smooth k
-      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
-    (smoothCommHopfAlgProperty_iff _).mp <|
-      (smoothCommHopfAlgProperty k).prop_of_iso qIso.symm
-        ((smoothCommHopfAlgProperty_iff _).mpr hU'.1)
-  have hJunipotent : geometricallyUnipotentPointsCommHopfAlgProperty k
-      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
-    (geometricallyUnipotentPointsCommHopfAlgProperty k).prop_of_iso qIso.symm
-      ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU'.2)
-  let _ : IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
-    isReduced_of_smooth_of_field k _
+  let H : FiniteTypeCommHopfAlgCat k :=
+    ⟨coordinateHopfAlgebra k n, by
+      rw [← finiteTypeCoordinateHopfAlgebra_obj]
+      exact (finiteTypeCoordinateHopfAlgebra k n).property⟩
+  let qIso' : FiniteTypeCommHopfAlgCat.quotient H J ≅
+      FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I :=
+    ObjectProperty.isoMk _ qIso
+  have hUJ : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H J) :=
+    (smoothUnipotentCommHopfAlgProperty k).prop_of_iso qIso'.symm hU
+  let _ : IsReduced H := by
+    change IsReduced (coordinateHopfAlgebra k n)
+    exact isReduced_of_smooth_of_field k _
   let _ : Comodule k (coordinateHopfAlgebra k n) (Fin n → k) := standardComodule k n
-  have hu :=
-    geometricallyUnipotentPointsCommHopfAlgProperty.forall_isUnipotentPoint hJunipotent
   have hcr : Comodule.IsCompletelyReducible k (coordinateHopfAlgebra k n) (Fin n → k) := by
     cases n with
     | zero => exact Comodule.isCompletelyReducible_of_subsingleton
     | succ n =>
         let _ : NeZero n.succ := ⟨Nat.succ_ne_zero n⟩
         exact Comodule.isCompletelyReducible_of_isSimpleOrder
-  have htrivial :=
-    mkQuotient_coact_eq_tmul_one_of_isNormal_of_forall_isUnipotentPoint_of_isCompletelyReducible
-      hJnormal hu hcr
   have hJ : J = HopfIdeal.augmentation k (coordinateHopfAlgebra k n) :=
-    Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one J
-      (isFaithful_standardComodule k n) htrivial
+    HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful k H (Fin n → k)
+      hcr (isFaithful_standardComodule k n) J hJnormal hUJ
   rw [← HopfIdeal.comapOfSurjective_eq_comapOfSurjective_iff f hf.2,
     HopfIdeal.comapOfSurjective_augmentation]
   exact hJ

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -588,12 +588,6 @@ noncomputable abbrev quotient (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfI
     FiniteTypeCommHopfAlgCat.{u, v} R :=
   ⟨CommHopfAlgCat.quotient H.obj I, inferInstanceAs (Algebra.FiniteType R (H ⧸ I.toIdeal))⟩
 
-/-- The underlying commutative Hopf algebra of a finite-type quotient is the quotient of the
-underlying commutative Hopf algebra. -/
-theorem quotient_obj (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
-    (quotient H I).obj = CommHopfAlgCat.quotient H.obj I :=
-  rfl
-
 /-- Quotienting a finite-type commutative Hopf algebra by the zero Hopf ideal gives an
 isomorphic finite-type commutative Hopf algebra. -/
 noncomputable def quotientBotIso (H : FiniteTypeCommHopfAlgCat.{u, v} R) :

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -588,6 +588,12 @@ noncomputable abbrev quotient (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfI
     FiniteTypeCommHopfAlgCat.{u, v} R :=
   ⟨CommHopfAlgCat.quotient H.obj I, inferInstanceAs (Algebra.FiniteType R (H ⧸ I.toIdeal))⟩
 
+/-- The underlying commutative Hopf algebra of a finite-type quotient is the quotient of the
+underlying commutative Hopf algebra. -/
+theorem quotient_obj (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
+    (quotient H I).obj = CommHopfAlgCat.quotient H.obj I :=
+  rfl
+
 /-- Quotienting a finite-type commutative Hopf algebra by the zero Hopf ideal gives an
 isomorphic finite-type commutative Hopf algebra. -/
 noncomputable def quotientBotIso (H : FiniteTypeCommHopfAlgCat.{u, v} R) :

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
@@ -7,12 +7,9 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.StandardComodule
 public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
-import TauCeti.Algebra.AlgebraicGroup.Reductive.LinearlyReductive
-import TauCeti.Algebra.AlgebraicGroup.Representation.ClosedSubgroup
 import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Connected
 import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Smooth
-import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
 import TauCeti.RingTheory.Smooth.GeometricallyReduced
 
@@ -102,6 +99,8 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
       (FiniteTypeCommHopfAlgCat.quotient H J) :=
     (smoothUnipotentCommHopfAlgProperty k).prop_of_iso qIso'.symm hU
   let _ : IsReduced H := by
+    -- `H` packages this coordinate algebra with its finite-type proof, so its carrier is
+    -- definitionally the coordinate algebra on which smoothness supplies reducedness.
     change IsReduced (coordinateHopfAlgebra k n)
     exact isReduced_of_smooth_of_field k _
   let _ : Comodule k (coordinateHopfAlgebra k n) (Fin n → k) := standardComodule k n

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
@@ -13,6 +13,7 @@ import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Connected
 import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Smooth
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
 import TauCeti.RingTheory.Smooth.GeometricallyReduced
 
 /-!
@@ -90,35 +91,29 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
   let qIso : CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J ≅
       CommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n).obj I :=
     CommHopfAlgCat.quotientIsoOfIso e I
-  have hU' := (smoothUnipotentCommHopfAlgProperty_iff k
-    (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I)).mp hU
-  let _ : Algebra.Smooth k
-      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
-    (smoothCommHopfAlgProperty_iff _).mp <|
-      (smoothCommHopfAlgProperty k).prop_of_iso qIso.symm
-        ((smoothCommHopfAlgProperty_iff _).mpr hU'.1)
-  have hJunipotent : geometricallyUnipotentPointsCommHopfAlgProperty k
-      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
-    (geometricallyUnipotentPointsCommHopfAlgProperty k).prop_of_iso qIso.symm
-      ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU'.2)
-  let _ : IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
-    isReduced_of_smooth_of_field k _
-  let _ : IsReduced (coordinateHopfAlgebra k n) := isReduced_of_smooth_of_field k _
+  let H : FiniteTypeCommHopfAlgCat k :=
+    ⟨coordinateHopfAlgebra k n, by
+      rw [← finiteTypeCoordinateHopfAlgebra_obj]
+      exact (finiteTypeCoordinateHopfAlgebra k n).property⟩
+  let qIso' : FiniteTypeCommHopfAlgCat.quotient H J ≅
+      FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I :=
+    ObjectProperty.isoMk _ qIso
+  have hUJ : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H J) :=
+    (smoothUnipotentCommHopfAlgProperty k).prop_of_iso qIso'.symm hU
+  let _ : IsReduced H := by
+    change IsReduced (coordinateHopfAlgebra k n)
+    exact isReduced_of_smooth_of_field k _
   let _ : Comodule k (coordinateHopfAlgebra k n) (Fin n → k) := standardComodule k n
-  have hu :=
-    geometricallyUnipotentPointsCommHopfAlgProperty.forall_isUnipotentPoint hJunipotent
   have hcr : Comodule.IsCompletelyReducible k (coordinateHopfAlgebra k n) (Fin n → k) := by
     cases n with
     | zero => exact Comodule.isCompletelyReducible_of_subsingleton
     | succ n =>
         let _ : NeZero n.succ := ⟨Nat.succ_ne_zero n⟩
         exact Comodule.isCompletelyReducible_of_isSimpleOrder
-  have htrivial :=
-    mkQuotient_coact_eq_tmul_one_of_isNormal_of_forall_isUnipotentPoint_of_isCompletelyReducible
-      hJnormal hu hcr
   have hJ : J = HopfIdeal.augmentation k (coordinateHopfAlgebra k n) :=
-    Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one J
-      (isFaithful_standardComodule k n) htrivial
+    HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful k H (Fin n → k)
+      hcr (isFaithful_standardComodule k n) J hJnormal hUJ
   rw [← HopfIdeal.comapOfSurjective_eq_comapOfSurjective_iff f hf.2,
     HopfIdeal.comapOfSurjective_augmentation]
   exact hJ

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Faithful.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Faithful.lean
@@ -33,6 +33,8 @@ nor connectedness of `H` itself is needed; reducedness of `H` is.
 
 ## Main results
 
+* `TauCeti.HopfIdeal.eq_augmentation_of_isNormal_of_forall_isUnipotentPoint_of_isFaithful`:
+  a normal subgroup with reduced quotient and only unipotent points is trivial.
 * `TauCeti.HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful`: a normal
   smooth unipotent closed subgroup of such an `H` is trivial.
 * `TauCeti.FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_augmentation_of_isFaithful`:
@@ -63,6 +65,24 @@ variable (M : Type u) [AddCommGroup M] [Module k M] [Comodule k H M] [FiniteDime
 
 namespace HopfIdeal
 
+/-- **A normal closed subgroup is trivial when its quotient is reduced, all of its points are
+unipotent, and the ambient affine group has a faithful completely reducible representation.**
+
+The conclusion is stated contravariantly: the subgroup's defining Hopf ideal is the augmentation
+ideal. -/
+theorem eq_augmentation_of_isNormal_of_forall_isUnipotentPoint_of_isFaithful
+    (hcr : Comodule.IsCompletelyReducible k H M)
+    (hM : Comodule.IsFaithful (k := k) (H := H) (V := M))
+    (I : HopfIdeal k H) (hI : I.IsNormal)
+    [IsReduced (CommHopfAlgCat.quotient H.obj I)]
+    (hu : ∀ g : WithConv (CommHopfAlgCat.quotient H.obj I →ₐ[k] k),
+      HopfAlgebra.IsUnipotentPoint g) :
+    I = HopfIdeal.augmentation k H := by
+  have htrivial :=
+    mkQuotient_coact_eq_tmul_one_of_isNormal_of_forall_isUnipotentPoint_of_isCompletelyReducible
+      (M := M) hI hu hcr
+  exact Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one I hM htrivial
+
 /-- **A normal smooth unipotent closed subgroup is trivial as soon as the ambient reduced
 finite-type affine group has a faithful completely reducible finite-dimensional
 representation.**
@@ -78,28 +98,18 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful
     I = HopfIdeal.augmentation k H := by
   have hU' := (smoothUnipotentCommHopfAlgProperty_iff k
     (FiniteTypeCommHopfAlgCat.quotient H I)).mp hU
-  -- The normal-invariants theorem is stated for the unbundled quotient `CommHopfAlgCat.quotient`,
-  -- while the smooth-unipotent property is an object property of the bundled finite-type quotient.
-  -- The two objects agree by `FiniteTypeCommHopfAlgCat.quotient_obj`; transport the smoothness and
-  -- the unipotence of the points along that identification rather than leaving it implicit.
-  let e : CommHopfAlgCat.quotient H.obj I ≅ (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
-    eqToIso (FiniteTypeCommHopfAlgCat.quotient_obj H I).symm
   have hgeom : geometricallyUnipotentPointsCommHopfAlgProperty k
       (CommHopfAlgCat.quotient H.obj I) :=
-    (geometricallyUnipotentPointsCommHopfAlgProperty k).prop_of_iso e.symm
-      ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU'.2)
+    (geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU'.2
   let _ : Algebra.Smooth k (CommHopfAlgCat.quotient H.obj I) :=
     (smoothCommHopfAlgProperty_iff _).mp <|
-      (smoothCommHopfAlgProperty k).prop_of_iso e.symm
-        ((smoothCommHopfAlgProperty_iff _).mpr hU'.1)
+      (smoothCommHopfAlgProperty_iff _).mpr hU'.1
   let _ : IsReduced (CommHopfAlgCat.quotient H.obj I) := isReduced_of_smooth_of_field k _
   have hu : ∀ g : WithConv (CommHopfAlgCat.quotient H.obj I →ₐ[k] k),
       HopfAlgebra.IsUnipotentPoint g :=
     geometricallyUnipotentPointsCommHopfAlgProperty.forall_isUnipotentPoint hgeom
-  have htrivial :=
-    mkQuotient_coact_eq_tmul_one_of_isNormal_of_forall_isUnipotentPoint_of_isCompletelyReducible
-      (M := M) hI hu hcr
-  exact Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one I hM htrivial
+  exact eq_augmentation_of_isNormal_of_forall_isUnipotentPoint_of_isFaithful
+    k H M hcr hM I hI hu
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Faithful.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Faithful.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.ClosedSubgroup
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Construction
+public import TauCeti.Algebra.Coalgebra.Comodule.LinearlyReductive
+import TauCeti.Algebra.AlgebraicGroup.Reductive.LinearlyReductive
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
+import TauCeti.RingTheory.Smooth.GeometricallyReduced
+
+/-!
+# Normal unipotent subgroups seen through a faithful representation
+
+Let `H` be a reduced finite-type commutative Hopf algebra over an algebraically closed field `k`
+and let `M` be a finite-dimensional `H`-comodule which is completely reducible and faithful. Then
+every normal Hopf ideal of `H` whose quotient is smooth unipotent is the augmentation ideal:
+contravariantly, every normal smooth unipotent closed subgroup of the represented affine group is
+trivial. Consequently the unipotent radical of `H` is trivial.
+
+Smoothness of the quotient makes the subgroup coordinate ring reduced, and geometric unipotence
+says that all of its points act unipotently. Normality makes the fixed vectors of the subgroup an
+ambient subcomodule, so the normal-invariants theorem together with Kolchin's fixed-vector theorem
+forces the subgroup to act trivially on `M`, and faithfulness then identifies its defining ideal
+with the augmentation ideal.
+
+Only the existence of one faithful completely reducible finite-dimensional representation is used,
+so the same statement serves `GLₙ`, `SLₙ` and the explicit Chevalley carriers. Neither smoothness
+nor connectedness of `H` itself is needed; reducedness of `H` is.
+
+## Main results
+
+* `TauCeti.HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful`: a normal
+  smooth unipotent closed subgroup of such an `H` is trivial.
+* `TauCeti.FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_augmentation_of_isFaithful`:
+  the unipotent radical of such an `H` is trivial.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§4.a, 5 and 19.b.
+* J. E. Humphreys, *Linear Algebraic Groups*, §§19 and 26.
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2 and II.2.
+* The argument is the one already formalized for `SLₙ` in
+  `TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean`.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+variable (k : Type u) [Field k] [IsAlgClosed k]
+variable (H : FiniteTypeCommHopfAlgCat.{u, u} k) [IsReduced H]
+variable (M : Type u) [AddCommGroup M] [Module k M] [Comodule k H M] [FiniteDimensional k M]
+
+namespace HopfIdeal
+
+/-- **A normal smooth unipotent closed subgroup is trivial as soon as the ambient reduced
+finite-type affine group has a faithful completely reducible finite-dimensional
+representation.**
+
+The conclusion is stated contravariantly: the subgroup's defining Hopf ideal is the augmentation
+ideal. Neither smoothness nor connectedness of the ambient group is needed. -/
+theorem eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful
+    (hcr : Comodule.IsCompletelyReducible k H M)
+    (hM : Comodule.IsFaithful (k := k) (H := H) (V := M))
+    (I : HopfIdeal k H) (hI : I.IsNormal)
+    (hU : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I)) :
+    I = HopfIdeal.augmentation k H := by
+  have hU' := (smoothUnipotentCommHopfAlgProperty_iff k
+    (FiniteTypeCommHopfAlgCat.quotient H I)).mp hU
+  -- The normal-invariants theorem is stated for the unbundled quotient `CommHopfAlgCat.quotient`,
+  -- while the smooth-unipotent property is an object property of the bundled finite-type quotient.
+  -- The two objects agree by `FiniteTypeCommHopfAlgCat.quotient_obj`; transport the smoothness and
+  -- the unipotence of the points along that identification rather than leaving it implicit.
+  let e : CommHopfAlgCat.quotient H.obj I ≅ (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
+    eqToIso (FiniteTypeCommHopfAlgCat.quotient_obj H I).symm
+  have hgeom : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (CommHopfAlgCat.quotient H.obj I) :=
+    (geometricallyUnipotentPointsCommHopfAlgProperty k).prop_of_iso e.symm
+      ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU'.2)
+  let _ : Algebra.Smooth k (CommHopfAlgCat.quotient H.obj I) :=
+    (smoothCommHopfAlgProperty_iff _).mp <|
+      (smoothCommHopfAlgProperty k).prop_of_iso e.symm
+        ((smoothCommHopfAlgProperty_iff _).mpr hU'.1)
+  let _ : IsReduced (CommHopfAlgCat.quotient H.obj I) := isReduced_of_smooth_of_field k _
+  have hu : ∀ g : WithConv (CommHopfAlgCat.quotient H.obj I →ₐ[k] k),
+      HopfAlgebra.IsUnipotentPoint g :=
+    geometricallyUnipotentPointsCommHopfAlgProperty.forall_isUnipotentPoint hgeom
+  have htrivial :=
+    mkQuotient_coact_eq_tmul_one_of_isNormal_of_forall_isUnipotentPoint_of_isCompletelyReducible
+      (M := M) hI hu hcr
+  exact Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one I hM htrivial
+
+end HopfIdeal
+
+namespace FiniteTypeCommHopfAlgCat
+
+/-- **The unipotent radical is trivial as soon as the reduced finite-type affine group has a
+faithful completely reducible finite-dimensional representation.** -/
+theorem unipotentRadicalDefiningIdeal_eq_augmentation_of_isFaithful
+    (hcr : Comodule.IsCompletelyReducible k H M)
+    (hM : Comodule.IsFaithful (k := k) (H := H) (V := M)) :
+    unipotentRadicalDefiningIdeal H = HopfIdeal.augmentation k H := by
+  rw [unipotentRadicalDefiningIdeal_eq_augmentation_iff]
+  intro I hI
+  exact HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful k H M hcr hM I
+    hI.isNormal hI.smoothUnipotent
+
+end FiniteTypeCommHopfAlgCat
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
@@ -110,6 +110,15 @@ theorem coordinateMap_surjective : Function.Surjective (coordinateMap A).hom := 
   exact CommHopfAlgCat.mkQuotient_surjective
     (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A)
 
+/-- The kernel of the specialized carrier coordinate morphism is the transported defining ideal:
+the morphism presents the carrier as the closed subgroup of `GL₅₆` that ideal cuts out. -/
+theorem coordinateMap_ker :
+    RingHom.ker (coordinateMap A).hom.toAlgHom.toRingHom =
+      (baseChangeDefiningIdeal A).toIdeal := by
+  unfold coordinateMap
+  exact CommHopfAlgCat.mkQuotient_ker
+    (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A)
+
 section Points
 
 variable {B : Type w} [CommRing B] [Algebra A B]

--- a/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
@@ -92,13 +92,13 @@ noncomputable def baseChangeDefiningIdeal :
 
 /-- The coordinate Hopf algebra of the full-weight type-`E₇` minuscule carrier after base
 change to `A`. -/
-noncomputable abbrev coordinateHopfAlgebra :=
+public noncomputable abbrev coordinateHopfAlgebra :=
   CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra A 56)
     (baseChangeDefiningIdeal A)
 
 /-- The quotient coordinate morphism `O(GL₅₆) ⟶ O(carrier)`, representing the closed immersion
 of the specialized minuscule carrier into `GL₅₆`. -/
-noncomputable abbrev coordinateMap :
+public noncomputable abbrev coordinateMap :
     GeneralLinear.coordinateHopfAlgebra A 56 ⟶ coordinateHopfAlgebra A :=
   CommHopfAlgCat.mkQuotient _ _
 

--- a/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
@@ -33,6 +33,8 @@ reductive, that its torus is maximal, or that its root datum has been identified
   `O(GL₅₆/A)`.
 * `TauCeti.E7Minuscule.coordinateHopfAlgebra` and `TauCeti.E7Minuscule.coordinateMap`: the
   specialized carrier coordinate algebra and its ambient quotient map.
+* `TauCeti.E7Minuscule.finiteTypeCoordinateHopfAlgebra`: the same coordinate algebra bundled
+  with its finite-type property.
 * `TauCeti.E7Minuscule.baseChangeCoordinateIso`: its quotient is the scalar extension of the
   integral carrier coordinate Hopf algebra.
 * `TauCeti.E7Minuscule.rootSubgroupToBaseChangeCoordinateMap`: the transported numbered root
@@ -101,6 +103,34 @@ of the specialized minuscule carrier into `GL₅₆`. -/
 public noncomputable abbrev coordinateMap :
     GeneralLinear.coordinateHopfAlgebra A 56 ⟶ coordinateHopfAlgebra A :=
   CommHopfAlgCat.mkQuotient _ _
+
+/-- The specialized carrier coordinate morphism sends an ambient coordinate to its quotient
+class. -/
+theorem coordinateMap_apply (x : GeneralLinear.coordinateHopfAlgebra A 56) :
+    (coordinateMap A).hom x =
+      Ideal.Quotient.mkₐ A (baseChangeDefiningIdeal A).toIdeal x :=
+  CommHopfAlgCat.mkQuotient_apply
+    (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A) x
+
+/-- The kernel of the specialized carrier coordinate morphism is the transported defining
+ideal. -/
+theorem coordinateMap_ker :
+    RingHom.ker (coordinateMap A).hom.toAlgHom.toRingHom =
+      (baseChangeDefiningIdeal A).toIdeal :=
+  CommHopfAlgCat.mkQuotient_ker
+    (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A)
+
+/-- The specialized type-`E₇` minuscule carrier as a finite-type commutative Hopf algebra. -/
+public noncomputable abbrev finiteTypeCoordinateHopfAlgebra :
+    FiniteTypeCommHopfAlgCat.{v, v} A :=
+  FiniteTypeCommHopfAlgCat.of A (coordinateHopfAlgebra A)
+
+/-- The finite-type package has the specialized carrier coordinate Hopf algebra as its underlying
+object. -/
+@[simp]
+theorem finiteTypeCoordinateHopfAlgebra_obj :
+    (finiteTypeCoordinateHopfAlgebra A).obj = coordinateHopfAlgebra A :=
+  (rfl)
 
 /-- Membership in the transported defining ideal is membership of the corresponding element in
 the base change of the named integral defining ideal. -/

--- a/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
@@ -100,25 +100,68 @@ public noncomputable abbrev coordinateHopfAlgebra :=
 
 /-- The quotient coordinate morphism `O(GL₅₆) ⟶ O(carrier)`, representing the closed immersion
 of the specialized minuscule carrier into `GL₅₆`. -/
-public noncomputable abbrev coordinateMap :
+public noncomputable def coordinateMap :
     GeneralLinear.coordinateHopfAlgebra A 56 ⟶ coordinateHopfAlgebra A :=
   CommHopfAlgCat.mkQuotient _ _
+
+/-- The specialized carrier coordinate morphism is the canonical quotient morphism by the
+transported defining ideal. -/
+theorem coordinateMap_def :
+    coordinateMap A =
+      CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra A 56)
+        (baseChangeDefiningIdeal A) := by
+  unfold coordinateMap
+  rfl
 
 /-- The specialized carrier coordinate morphism sends an ambient coordinate to its quotient
 class. -/
 theorem coordinateMap_apply (x : GeneralLinear.coordinateHopfAlgebra A 56) :
     (coordinateMap A).hom x =
       Ideal.Quotient.mkₐ A (baseChangeDefiningIdeal A).toIdeal x :=
-  CommHopfAlgCat.mkQuotient_apply
-    (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A) x
+  by
+    rw [coordinateMap_def]
+    exact CommHopfAlgCat.mkQuotient_apply
+      (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A) x
 
 /-- The kernel of the specialized carrier coordinate morphism is the transported defining
 ideal. -/
 theorem coordinateMap_ker :
     RingHom.ker (coordinateMap A).hom.toAlgHom.toRingHom =
       (baseChangeDefiningIdeal A).toIdeal :=
-  CommHopfAlgCat.mkQuotient_ker
+  by
+    rw [coordinateMap_def]
+    exact CommHopfAlgCat.mkQuotient_ker
+      (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A)
+
+/-- The specialized carrier coordinate morphism is surjective. -/
+theorem coordinateMap_surjective : Function.Surjective (coordinateMap A).hom := by
+  rw [coordinateMap_def]
+  exact CommHopfAlgCat.mkQuotient_surjective
     (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A)
+
+/-- A coordinate morphism which kills the transported defining ideal factors through the
+specialized carrier coordinate morphism. -/
+@[simp]
+theorem coordinateMap_comp_liftQuotient
+    {K : _root_.CommHopfAlgCat.{v} A}
+    (f : GeneralLinear.coordinateHopfAlgebra A 56 ⟶ K)
+    (hf : (baseChangeDefiningIdeal A).toIdeal ≤
+      RingHom.ker f.hom.toAlgHom.toRingHom) :
+    coordinateMap A ≫ CommHopfAlgCat.liftQuotient (baseChangeDefiningIdeal A) f hf = f := by
+  rw [coordinateMap_def]
+  exact CommHopfAlgCat.mkQuotient_comp_liftQuotient (baseChangeDefiningIdeal A) f hf
+
+/-- The factorization of a coordinate morphism through the specialized carrier coordinate
+morphism is unique. -/
+theorem coordinateMap_liftQuotient_unique
+    {K : _root_.CommHopfAlgCat.{v} A}
+    (f : GeneralLinear.coordinateHopfAlgebra A 56 ⟶ K)
+    (hf : (baseChangeDefiningIdeal A).toIdeal ≤
+      RingHom.ker f.hom.toAlgHom.toRingHom)
+    (g : coordinateHopfAlgebra A ⟶ K) (hg : coordinateMap A ≫ g = f) :
+    g = CommHopfAlgCat.liftQuotient (baseChangeDefiningIdeal A) f hf := by
+  rw [coordinateMap_def] at hg
+  exact CommHopfAlgCat.liftQuotient_unique (baseChangeDefiningIdeal A) f hf g hg
 
 /-- The specialized type-`E₇` minuscule carrier as a finite-type commutative Hopf algebra. -/
 public noncomputable abbrev finiteTypeCoordinateHopfAlgebra :

--- a/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/BaseChange.lean
@@ -72,7 +72,7 @@ open scoped Matrix TensorProduct
 
 namespace TauCeti.E7Minuscule
 
-universe v
+universe v w
 
 noncomputable section
 
@@ -104,64 +104,28 @@ public noncomputable def coordinateMap :
     GeneralLinear.coordinateHopfAlgebra A 56 ⟶ coordinateHopfAlgebra A :=
   CommHopfAlgCat.mkQuotient _ _
 
-/-- The specialized carrier coordinate morphism is the canonical quotient morphism by the
-transported defining ideal. -/
-theorem coordinateMap_def :
-    coordinateMap A =
-      CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra A 56)
-        (baseChangeDefiningIdeal A) := by
-  unfold coordinateMap
-  rfl
-
-/-- The specialized carrier coordinate morphism sends an ambient coordinate to its quotient
-class. -/
-theorem coordinateMap_apply (x : GeneralLinear.coordinateHopfAlgebra A 56) :
-    (coordinateMap A).hom x =
-      Ideal.Quotient.mkₐ A (baseChangeDefiningIdeal A).toIdeal x :=
-  by
-    rw [coordinateMap_def]
-    exact CommHopfAlgCat.mkQuotient_apply
-      (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A) x
-
-/-- The kernel of the specialized carrier coordinate morphism is the transported defining
-ideal. -/
-theorem coordinateMap_ker :
-    RingHom.ker (coordinateMap A).hom.toAlgHom.toRingHom =
-      (baseChangeDefiningIdeal A).toIdeal :=
-  by
-    rw [coordinateMap_def]
-    exact CommHopfAlgCat.mkQuotient_ker
-      (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A)
-
 /-- The specialized carrier coordinate morphism is surjective. -/
 theorem coordinateMap_surjective : Function.Surjective (coordinateMap A).hom := by
-  rw [coordinateMap_def]
+  unfold coordinateMap
   exact CommHopfAlgCat.mkQuotient_surjective
     (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A)
 
-/-- A coordinate morphism which kills the transported defining ideal factors through the
-specialized carrier coordinate morphism. -/
-@[simp]
-theorem coordinateMap_comp_liftQuotient
-    {K : _root_.CommHopfAlgCat.{v} A}
-    (f : GeneralLinear.coordinateHopfAlgebra A 56 ⟶ K)
-    (hf : (baseChangeDefiningIdeal A).toIdeal ≤
-      RingHom.ker f.hom.toAlgHom.toRingHom) :
-    coordinateMap A ≫ CommHopfAlgCat.liftQuotient (baseChangeDefiningIdeal A) f hf = f := by
-  rw [coordinateMap_def]
-  exact CommHopfAlgCat.mkQuotient_comp_liftQuotient (baseChangeDefiningIdeal A) f hf
+section Points
 
-/-- The factorization of a coordinate morphism through the specialized carrier coordinate
-morphism is unique. -/
-theorem coordinateMap_liftQuotient_unique
-    {K : _root_.CommHopfAlgCat.{v} A}
-    (f : GeneralLinear.coordinateHopfAlgebra A 56 ⟶ K)
-    (hf : (baseChangeDefiningIdeal A).toIdeal ≤
-      RingHom.ker f.hom.toAlgHom.toRingHom)
-    (g : coordinateHopfAlgebra A ⟶ K) (hg : coordinateMap A ≫ g = f) :
-    g = CommHopfAlgCat.liftQuotient (baseChangeDefiningIdeal A) f hf := by
-  rw [coordinateMap_def] at hg
-  exact CommHopfAlgCat.liftQuotient_unique (baseChangeDefiningIdeal A) f hf g hg
+variable {B : Type w} [CommRing B] [Algebra A B]
+
+/-- Mapping a carrier point along the coordinate morphism gives the corresponding quotient
+point of the ambient general linear group. -/
+theorem mapPointsFunctor_coordinateMap_app
+    (g : HopfAlgebra.points (R := A) (H := coordinateHopfAlgebra A) (CommAlgCat.of A B)) :
+    (CommHopfAlgCat.mapPointsFunctor (coordinateMap A)).app (CommAlgCat.of A B) g =
+      CommHopfAlgCat.quotientPointsHom
+        (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A)
+        (CommAlgCat.of A B) g := by
+  apply WithConv.ext
+  rfl
+
+end Points
 
 /-- The specialized type-`E₇` minuscule carrier as a finite-type commutative Hopf algebra. -/
 public noncomputable abbrev finiteTypeCoordinateHopfAlgebra :
@@ -374,13 +338,14 @@ noncomputable def weightTorusToBaseChangeCoordinateMap :
     rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
     e7MinusculeWeight A
 
-/-- The factored weight-torus map recovers its ambient transported coordinate map. -/
+/-- The factored weight-torus map composed with the carrier coordinate morphism recovers its
+ambient transported coordinate map. -/
 @[simp]
-theorem mkQuotient_comp_weightTorusToBaseChangeCoordinateMap :
-    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra A 56)
-          (baseChangeDefiningIdeal A) ≫
+theorem coordinateMap_comp_weightTorusToBaseChangeCoordinateMap :
+    coordinateMap A ≫
         weightTorusToBaseChangeCoordinateMap A =
       GeneralLinear.weightTorusBaseChangeCoordinateMap ℤ A e7MinusculeWeight := by
+  unfold coordinateMap
   unfold baseChangeDefiningIdeal weightTorusToBaseChangeCoordinateMap
   exact mkQuotient_comp_kostantWeightTorusToralBaseChangePresentationCoordinateMap
     (TauCeti.serreRootGenerator (CartanMatrix.E 7))

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -115,7 +115,7 @@ theorem piScalarRight_comp_endOfPoint
         (CommHopfAlgCat.quotientPointsHom
           (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
           (CommAlgCat.of R A) g).ofConv := by
-    rw [coordinateMap_def, CommHopfAlgCat.quotientPointsHom_apply]
+    exact congrArg WithConv.ofConv (mapPointsFunctor_coordinateMap_app R g)
   rw [hpoint]
   exact GeneralLinear.piScalarRight_comp_endOfPoint R 56 _
 
@@ -138,7 +138,7 @@ theorem mulVec_mem
         CommHopfAlgCat.quotientPointsHom
           (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
           (CommAlgCat.of R R) g := by
-    rw [AlgHom.mapDomain_apply, coordinateMap_def, CommHopfAlgCat.quotientPointsHom_apply]
+    exact mapPointsFunctor_coordinateMap_app R g
   rw [hpoint] at h
   exact h
 
@@ -210,8 +210,7 @@ private theorem weightTorusToBaseChangeCoordinateMap_coordinate (i a : Fin 56) :
             (GeneralLinear.coordinateRingMap k 56 (MvPolynomial.X (i, a))))) =
       if i = a then MonoidAlgebra.single (minusculeCharacter a) (1 : k) else 0 := by
   rw [← _root_.BialgHom.comp_apply, ← _root_.CommHopfAlgCat.hom_comp]
-  rw [coordinateMap_def]
-  rw [mkQuotient_comp_weightTorusToBaseChangeCoordinateMap]
+  rw [coordinateMap_comp_weightTorusToBaseChangeCoordinateMap]
   rw [GeneralLinear.hom_weightTorusBaseChangeCoordinateMap,
     GeneralLinear.weightTorusCoordinateBialgHom_X]
   split_ifs with h

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -75,11 +75,9 @@ theorem standardComodule_coact :
     Comodule.corestrictCoact
         (R := R) (C := GeneralLinear.coordinateHopfAlgebra R 56)
         (D := coordinateHopfAlgebra R) (M := Fin 56 → R)
-        (Bialgebra.Quotient.mkBialgHom (R := R)
-          (baseChangeDefiningIdeal R).toIdeal).toCoalgHom =
+        (coordinateMap R).hom.toCoalgHom =
       TensorProduct.map LinearMap.id
-          (Bialgebra.Quotient.mkBialgHom (R := R)
-            (baseChangeDefiningIdeal R).toIdeal).toLinearMap ∘ₗ
+          (coordinateMap R).hom.toCoalgHom.toLinearMap ∘ₗ
         GeneralLinear.standardCoact R 56 := by
   apply LinearMap.ext
   intro v
@@ -90,7 +88,7 @@ theorem standardComodule_coact :
 theorem isFaithful_standardComodule :
     Comodule.IsFaithful (k := R) (H := coordinateHopfAlgebra R) (V := Fin 56 → R) := by
   exact Comodule.isFaithful_corestrict_of_surjective (coordinateMap R).hom
-    (CommHopfAlgCat.mkQuotient_surjective _ _)
+    (coordinateMap_surjective R)
     (GeneralLinear.isFaithful_standardComodule R 56)
 
 section PointAction
@@ -117,7 +115,7 @@ theorem piScalarRight_comp_endOfPoint
         (CommHopfAlgCat.quotientPointsHom
           (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
           (CommAlgCat.of R A) g).ofConv := by
-    rw [CommHopfAlgCat.quotientPointsHom_apply]
+    rw [coordinateMap_def, CommHopfAlgCat.quotientPointsHom_apply]
   rw [hpoint]
   exact GeneralLinear.piScalarRight_comp_endOfPoint R 56 _
 
@@ -140,7 +138,7 @@ theorem mulVec_mem
         CommHopfAlgCat.quotientPointsHom
           (GeneralLinear.coordinateHopfAlgebra R 56) (baseChangeDefiningIdeal R)
           (CommAlgCat.of R R) g := by
-    rw [AlgHom.mapDomain_apply, CommHopfAlgCat.quotientPointsHom_apply]
+    rw [AlgHom.mapDomain_apply, coordinateMap_def, CommHopfAlgCat.quotientPointsHom_apply]
   rw [hpoint] at h
   exact h
 
@@ -212,6 +210,7 @@ private theorem weightTorusToBaseChangeCoordinateMap_coordinate (i a : Fin 56) :
             (GeneralLinear.coordinateRingMap k 56 (MvPolynomial.X (i, a))))) =
       if i = a then MonoidAlgebra.single (minusculeCharacter a) (1 : k) else 0 := by
   rw [← _root_.BialgHom.comp_apply, ← _root_.CommHopfAlgCat.hom_comp]
+  rw [coordinateMap_def]
   rw [mkQuotient_comp_weightTorusToBaseChangeCoordinateMap]
   rw [GeneralLinear.hom_weightTorusBaseChangeCoordinateMap,
     GeneralLinear.weightTorusCoordinateBialgHom_X]
@@ -236,7 +235,6 @@ private theorem torusCorestrict_eq_ofWeights :
   rw [Comodule.corestrict_coact_apply
     (weightTorusToBaseChangeCoordinateMap k).hom.toCoalgHom]
   rw [Comodule.corestrict_coact]
-  simp only [coordinateMap, CategoryTheory.ConcreteCategory.hom_ofHom]
   rw [standardComodule_coact, LinearMap.comp_apply,
     GeneralLinear.standardCoact_apply_basisFun, map_sum]
   simp only [TensorProduct.map_tmul, LinearMap.id_coe, id_eq]
@@ -246,13 +244,10 @@ private theorem torusCorestrict_eq_ofWeights :
     (_root_.BialgHom.toAlgHom_toLinearMap
       (weightTorusToBaseChangeCoordinateMap k).hom).symm
   have hcoordinateLinear :
-      (Bialgebra.Quotient.mkBialgHom (R := k)
-          (baseChangeDefiningIdeal k).toIdeal).toLinearMap =
-        (Bialgebra.Quotient.mkBialgHom (R := k)
-          (baseChangeDefiningIdeal k).toIdeal).toAlgHom.toLinearMap :=
+      (coordinateMap k).hom.toCoalgHom.toLinearMap =
+        (coordinateMap k).hom.toAlgHom.toLinearMap :=
     (_root_.BialgHom.toAlgHom_toLinearMap
-      (Bialgebra.Quotient.mkBialgHom (R := k)
-        (baseChangeDefiningIdeal k).toIdeal)).symm
+      (coordinateMap k).hom).symm
   rw [hweightLinear, hcoordinateLinear]
   simp only [map_sum, TensorProduct.map_tmul, LinearMap.id_coe, id_eq,
     AlgHom.toLinearMap_apply]

--- a/TauCeti/Algebra/Lie/E7/Minuscule/UnipotentRadical.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/UnipotentRadical.lean
@@ -39,6 +39,8 @@ the carrier is reductive.
 
 ## References
 
+* The proof of the normal-unipotent obstruction is adapted from
+  `TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean`.
 * J. E. Humphreys, *Linear Algebraic Groups*, §§19 and 26.
 * J. C. Jantzen, *Representations of Algebraic Groups*, I.2 and II.2.
 -/
@@ -99,10 +101,8 @@ theorem unipotentRadicalDefiningIdeal_eq_augmentation
     FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
         (finiteTypeCoordinateHopfAlgebra k) =
       HopfIdeal.augmentation k (coordinateHopfAlgebra k) := by
-  let I := FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
-    (finiteTypeCoordinateHopfAlgebra k)
-  have hI := FiniteTypeCommHopfAlgCat.isUnipotentRadicalCandidate_unipotentRadicalDefiningIdeal
-    (finiteTypeCoordinateHopfAlgebra k)
+  rw [FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_augmentation_iff]
+  intro I hI
   exact eq_augmentation_of_isNormal_of_smoothUnipotent k I hI.isNormal hI.smoothUnipotent
 
 end

--- a/TauCeti/Algebra/Lie/E7/Minuscule/UnipotentRadical.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/UnipotentRadical.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E7.Minuscule.StandardComodule
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Construction
+import TauCeti.Algebra.AlgebraicGroup.Reductive.LinearlyReductive
+import TauCeti.Algebra.AlgebraicGroup.Representation.ClosedSubgroup
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
+import TauCeti.RingTheory.Smooth.GeometricallyReduced
+
+/-!
+# The unipotent radical obstruction for the type-E7 minuscule carrier
+
+Let `H` be the coordinate Hopf algebra of the specialized full-weight type-`E₇` minuscule
+carrier. Over an algebraically closed field, if `H` is reduced, then every normal smooth
+unipotent closed subgroup of the carrier is trivial. Consequently its unipotent radical is
+trivial.
+
+The mathematical input is the carrier's standard 56-dimensional comodule. It is simple, hence
+completely reducible, and faithful. Normality makes the fixed vectors of a smooth unipotent
+closed subgroup into an ambient subcomodule. Kolchin's fixed-vector theorem then forces the
+subgroup to act trivially, and faithfulness identifies its defining ideal with the augmentation
+ideal.
+
+Reducedness is stated explicitly. No smoothness or connectedness of the carrier is asserted here,
+so the result is the normal-unipotent obstruction needed for reductivity rather than a proof that
+the carrier is reductive.
+
+## Main declarations
+
+* `TauCeti.E7Minuscule.eq_augmentation_of_isNormal_of_smoothUnipotent`: every normal smooth
+  unipotent closed subgroup of a reduced specialized carrier is trivial.
+* `TauCeti.E7Minuscule.unipotentRadicalDefiningIdeal_eq_augmentation`: the unipotent radical of
+  a reduced specialized carrier is trivial.
+
+## References
+
+* J. E. Humphreys, *Linear Algebraic Groups*, §§19 and 26.
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2 and II.2.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.E7Minuscule
+
+universe u
+
+noncomputable section
+
+open HopfIdeal
+
+variable (k : Type u) [Field k] [IsAlgClosed k]
+
+/-- The specialized type-`E₇` minuscule carrier as a finite-type commutative Hopf algebra. -/
+public noncomputable abbrev finiteTypeCoordinateHopfAlgebra :
+    FiniteTypeCommHopfAlgCat.{u, u} k :=
+  FiniteTypeCommHopfAlgCat.of k (coordinateHopfAlgebra k)
+
+attribute [local instance] standardComodule
+
+/-- **Every normal smooth unipotent closed subgroup of a reduced specialized type-`E₇`
+minuscule carrier is trivial.**
+
+The conclusion is stated contravariantly: the subgroup's defining Hopf ideal is the augmentation
+ideal of the carrier's coordinate algebra. -/
+theorem eq_augmentation_of_isNormal_of_smoothUnipotent
+    [IsReduced (coordinateHopfAlgebra k)]
+    (I : HopfIdeal k (coordinateHopfAlgebra k)) (hI : I.IsNormal)
+    (hU : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k) I)) :
+    I = HopfIdeal.augmentation k (coordinateHopfAlgebra k) := by
+  have hU' := (smoothUnipotentCommHopfAlgProperty_iff k
+    (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k) I)).mp hU
+  let _ : Algebra.Smooth k
+      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k) I) := hU'.1
+  let _ : IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k) I) :=
+    isReduced_of_smooth_of_field k _
+  have hu : ∀ g : WithConv
+      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k) I →ₐ[k] k),
+      HopfAlgebra.IsUnipotentPoint g :=
+    geometricallyUnipotentPointsCommHopfAlgProperty.forall_isUnipotentPoint
+      ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU'.2)
+  have htrivial :=
+    mkQuotient_coact_eq_tmul_one_of_isNormal_of_forall_isUnipotentPoint_of_isCompletelyReducible
+      (M := Fin 56 → k) hI hu Comodule.isCompletelyReducible_of_isSimpleOrder
+  exact Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one I
+    (isFaithful_standardComodule k) htrivial
+
+/-- **The unipotent radical of a reduced specialized type-`E₇` minuscule carrier over an
+algebraically closed field is trivial.** -/
+theorem unipotentRadicalDefiningIdeal_eq_augmentation
+    [IsReduced (coordinateHopfAlgebra k)] :
+    FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+        (finiteTypeCoordinateHopfAlgebra k) =
+      HopfIdeal.augmentation k (coordinateHopfAlgebra k) := by
+  let I := FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+    (finiteTypeCoordinateHopfAlgebra k)
+  have hI := FiniteTypeCommHopfAlgCat.isUnipotentRadicalCandidate_unipotentRadicalDefiningIdeal
+    (finiteTypeCoordinateHopfAlgebra k)
+  exact eq_augmentation_of_isNormal_of_smoothUnipotent k I hI.isNormal hI.smoothUnipotent
+
+end
+
+end TauCeti.E7Minuscule

--- a/TauCeti/Algebra/Lie/E7/Minuscule/UnipotentRadical.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/UnipotentRadical.lean
@@ -6,11 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.E7.Minuscule.StandardComodule
-public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Construction
-import TauCeti.Algebra.AlgebraicGroup.Reductive.LinearlyReductive
-import TauCeti.Algebra.AlgebraicGroup.Representation.ClosedSubgroup
-import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
-import TauCeti.RingTheory.Smooth.GeometricallyReduced
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
 
 /-!
 # The unipotent radical obstruction for the type-E7 minuscule carrier
@@ -21,10 +17,11 @@ unipotent closed subgroup of the carrier is trivial. Consequently its unipotent 
 trivial.
 
 The mathematical input is the carrier's standard 56-dimensional comodule. It is simple, hence
-completely reducible, and faithful. Normality makes the fixed vectors of a smooth unipotent
-closed subgroup into an ambient subcomodule. Kolchin's fixed-vector theorem then forces the
-subgroup to act trivially, and faithfulness identifies its defining ideal with the augmentation
-ideal.
+completely reducible, and faithful. The generic normal-unipotent elimination theorem
+`TauCeti.HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful` then applies
+verbatim: normality makes the fixed vectors of a smooth unipotent closed subgroup an ambient
+subcomodule, Kolchin's fixed-vector theorem forces the subgroup to act trivially, and
+faithfulness identifies its defining ideal with the augmentation ideal.
 
 Reducedness is stated explicitly. No smoothness or connectedness of the carrier is asserted here,
 so the result is the normal-unipotent obstruction needed for reductivity rather than a proof that
@@ -39,8 +36,6 @@ the carrier is reductive.
 
 ## References
 
-* The proof of the normal-unipotent obstruction is adapted from
-  `TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean`.
 * J. E. Humphreys, *Linear Algebraic Groups*, §§19 and 26.
 * J. C. Jantzen, *Representations of Algebraic Groups*, I.2 and II.2.
 -/
@@ -55,14 +50,7 @@ universe u
 
 noncomputable section
 
-open HopfIdeal
-
 variable (k : Type u) [Field k] [IsAlgClosed k]
-
-/-- The specialized type-`E₇` minuscule carrier as a finite-type commutative Hopf algebra. -/
-public noncomputable abbrev finiteTypeCoordinateHopfAlgebra :
-    FiniteTypeCommHopfAlgCat.{u, u} k :=
-  FiniteTypeCommHopfAlgCat.of k (coordinateHopfAlgebra k)
 
 attribute [local instance] standardComodule
 
@@ -76,23 +64,10 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
     (I : HopfIdeal k (coordinateHopfAlgebra k)) (hI : I.IsNormal)
     (hU : smoothUnipotentCommHopfAlgProperty k
       (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k) I)) :
-    I = HopfIdeal.augmentation k (coordinateHopfAlgebra k) := by
-  have hU' := (smoothUnipotentCommHopfAlgProperty_iff k
-    (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k) I)).mp hU
-  let _ : Algebra.Smooth k
-      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k) I) := hU'.1
-  let _ : IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k) I) :=
-    isReduced_of_smooth_of_field k _
-  have hu : ∀ g : WithConv
-      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k) I →ₐ[k] k),
-      HopfAlgebra.IsUnipotentPoint g :=
-    geometricallyUnipotentPointsCommHopfAlgProperty.forall_isUnipotentPoint
-      ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU'.2)
-  have htrivial :=
-    mkQuotient_coact_eq_tmul_one_of_isNormal_of_forall_isUnipotentPoint_of_isCompletelyReducible
-      (M := Fin 56 → k) hI hu Comodule.isCompletelyReducible_of_isSimpleOrder
-  exact Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one I
-    (isFaithful_standardComodule k) htrivial
+    I = HopfIdeal.augmentation k (coordinateHopfAlgebra k) :=
+  HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful k
+    (finiteTypeCoordinateHopfAlgebra k) (Fin 56 → k)
+    Comodule.isCompletelyReducible_of_isSimpleOrder (isFaithful_standardComodule k) I hI hU
 
 /-- **The unipotent radical of a reduced specialized type-`E₇` minuscule carrier over an
 algebraically closed field is trivial.** -/
@@ -100,10 +75,10 @@ theorem unipotentRadicalDefiningIdeal_eq_augmentation
     [IsReduced (coordinateHopfAlgebra k)] :
     FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
         (finiteTypeCoordinateHopfAlgebra k) =
-      HopfIdeal.augmentation k (coordinateHopfAlgebra k) := by
-  rw [FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_augmentation_iff]
-  intro I hI
-  exact eq_augmentation_of_isNormal_of_smoothUnipotent k I hI.isNormal hI.smoothUnipotent
+      HopfIdeal.augmentation k (coordinateHopfAlgebra k) :=
+  FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_augmentation_of_isFaithful k
+    (finiteTypeCoordinateHopfAlgebra k) (Fin 56 → k)
+    Comodule.isCompletelyReducible_of_isSimpleOrder (isFaithful_standardComodule k)
 
 end
 


### PR DESCRIPTION
This PR uses the faithful simple 56-dimensional standard comodule to prove that every normal smooth unipotent closed subgroup of a reduced specialized type-`E₇` minuscule carrier over an algebraically closed field is trivial, and identifies the carrier's unipotent-radical defining ideal with its augmentation ideal. It keeps reducedness explicit: the result supplies the normal-unipotent obstruction needed for reductivity without claiming the still-unproved smoothness or connectedness of the carrier.

The exact roadmap target is ReductiveGroups Layer 9, “The Chevalley–Demazure construction,” whose explicit carrier must be a split reductive group scheme before it can support the requested pinning and pinned-group isomorphism theorem. The designated milestone is Layer 9, “pinned Chevalley–Demazure group schemes over `ℤ`.” This is the most effective current step because PR #5560 has just supplied the carrier's faithful simple standard comodule, so the existing normal-invariants and Kolchin machinery now eliminates its unipotent radical directly rather than adding another carrier-level interface.

Milestone L0, “pinned ambient groups,” of the CFSGStatement roadmap consumes the eventual pinned simply connected `E₇` group through `ValidLieTypeIndex.AmbientGroup`; the dependency edge is CFSGStatement L0 ← ReductiveGroups Layer 9's explicit pinned `E₇` carrier ← trivial geometric unipotent radical, supplied here after reducedness. After this PR, the `E₇` Layer 9 path still needs reducedness/smoothness and geometric connectedness of the carrier, then maximal-torus and Borel packaging, all-root generation, and the final pinned simply connected identification.

Review round 2 asked for the argument to be exposed generically, so the normal-unipotent pipeline now lives in `TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Faithful.lean` as `HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful` and `FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_augmentation_of_isFaithful`, parameterized by a reduced finite-type Hopf algebra with a faithful completely reducible finite-dimensional comodule. It reuses `HopfIdeal.mkQuotient_coact_eq_tmul_one_of_isNormal_of_forall_isUnipotentPoint_of_isCompletelyReducible` and `Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one`; both E7 theorems are one-line applications of it, supplying the newly landed `E7Minuscule.instIsSimpleOrderSubcomodule` and `isFaithful_standardComodule`. It follows the normal-unipotent argument documented in Humphreys, *Linear Algebraic Groups*, §§19 and 26, and Jantzen, *Representations of Algebraic Groups*, I.2 and II.2, with those sources recorded in the module. No Mathlib infrastructure is vendored.

The change adds the generic module above and `TauCeti/Algebra/Lie/E7/Minuscule/UnipotentRadical.lean`; marks the already-documented `coordinateHopfAlgebra` and `coordinateMap` abbreviations public in `BaseChange.lean` so the downstream theorem can expose its canonical carrier type; adds `coordinateMap_apply`, `coordinateMap_ker` and the carrier's `finiteTypeCoordinateHopfAlgebra` (over an arbitrary commutative base ring) there; and adds the missing `FiniteTypeCommHopfAlgCat.quotient_obj` conversion lemma next to `FiniteTypeCommHopfAlgCat.quotient`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e7-minuscule-normal-unipotent-trivial"}-->

🤖 Prepared with Codex

