### PR TITLE
feat(MordellWeil): the Néron–Tate pairing on the points modulo torsion

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/CanonicalHeight.lean
@@ -413,6 +413,11 @@ theorem neronTatePairing_eq_zero_of_isOfFinAddOrder_right [W.toAffine.IsElliptic
     {Q : W.Point} (h : IsOfFinAddOrder Q) : neronTatePairing W P Q = 0 := by
   rw [neronTatePairing_comm, neronTatePairing_eq_zero_of_isOfFinAddOrder_left h]
 
+/-- **The pairing is reflexive**, being symmetric. Reflexivity is what permits a symmetric
+bilinear descent to a quotient. -/
+theorem isRefl_neronTatePairing [W.toAffine.IsElliptic] : (neronTatePairing W).IsRefl :=
+  fun P Q h ↦ by rwa [neronTatePairing_comm]
+
 -- `LinearMap.IsSymm` does not apply to a bilinear map whose target is not the scalar ring, which
 -- is why symmetry is stated pointwise above and as `flip` here; Mathlib documents
 -- `QuadraticMap.associated_flip` as the general-target version for exactly this reason.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/PointModTorsion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/PointModTorsion.lean
@@ -13,14 +13,18 @@ public import Mathlib.Algebra.Module.Torsion.Basic
 # The points modulo torsion, and the Néron-Tate pairing on them
 
 The Néron-Tate pairing vanishes as soon as either argument is torsion, so it descends to the
-quotient of the points by their torsion submodule, and the descended pairing is positive
-definite. That quotient is where the regulator is defined.
+quotient of the points by their torsion submodule, unconditionally. Under
+`[Northcott (Point.canonicalHeight (W := W))]` — the hypothesis that makes height zero force
+torsion — the descended pairing is moreover positive definite. That quotient is where the
+regulator is defined.
 
 ## Main definitions
 
-* `WeierstrassCurve.Affine.PointModTorsion`: the points modulo torsion. Its freeness and its
-  rank are Mathlib's, from `Module.free_of_finite_type_torsion_free'` and
-  `finrank_quotient_eq_of_le_torsion`, so neither is restated here.
+* `WeierstrassCurve.Affine.PointModTorsion`: the points modulo torsion. Neither its freeness nor
+  its rank is restated here, both being Mathlib's: under `[AddGroup.FG W.Point]` the quotient is
+  free of finite rank by `Module.free_of_finite_type_torsion_free'`, and its rank is
+  `Module.finrank ℤ W.Point` by `finrank_quotient_eq_of_le_torsion` at `le_rfl`. The definition
+  itself assumes neither, so the name says only what the quotient is.
 * `WeierstrassCurve.Affine.neronTatePairingModTorsion`: the Néron-Tate pairing on that quotient.
 * `WeierstrassCurve.Affine.neronTateGramMatrix`: its matrix in a basis, whose determinant is the
   regulator.
@@ -32,7 +36,8 @@ definite. That quotient is where the regulator is defined.
 * `WeierstrassCurve.Affine.neronTatePairingModTorsion_mk`: the descended pairing agrees with the
   original on representatives.
 * `WeierstrassCurve.Affine.neronTatePairingModTorsion_self_eq_zero_iff`: the descended pairing is
-  positive definite, which is what dividing by the torsion buys.
+  positive definite, given the `Northcott` hypothesis. This is what dividing by the torsion buys;
+  on `W.Point` itself the pairing is only semidefinite.
 * `WeierstrassCurve.Affine.isSymm_neronTateGramMatrix`: the Gram matrix is symmetric. The
   regulator is the determinant of this matrix in a basis of the quotient, and is defined
   separately.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/PointModTorsion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/PointModTorsion.lean
@@ -7,31 +7,26 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.CanonicalHeight
 public import Mathlib.LinearAlgebra.Quotient.Bilinear
--- Public so that a consumer importing this module gets the freeness and rank facts this module
--- states, without having to discover the implementation import itself. It also carries the
--- freeness instances transitively, so `Mathlib.LinearAlgebra.FreeModule.PID` is not imported here.
-public import Mathlib.LinearAlgebra.Dimension.Torsion.Basic
+public import Mathlib.Algebra.Module.Torsion.Basic
 
 /-!
 # The points modulo torsion, and the Néron-Tate pairing on them
 
 The Néron-Tate pairing vanishes as soon as either argument is torsion, so it descends to the
-quotient of the points by their torsion submodule. Under finite generation of the points that
-quotient is free of finite rank, and it is where the regulator is defined; freeness needs the
-hypothesis, so nothing below claims it unconditionally.
+quotient of the points by their torsion submodule, and the descended pairing is positive
+definite. That quotient is where the regulator is defined.
 
 ## Main definitions
 
-* `WeierstrassCurve.Affine.PointModTorsion`: the points modulo torsion. It is free of finite
-  rank once the points are finitely generated, but freeness is not part of the definition, so the
-  name says only what the quotient is.
+* `WeierstrassCurve.Affine.PointModTorsion`: the points modulo torsion. Its freeness and its
+  rank are Mathlib's, from `Module.free_of_finite_type_torsion_free'` and
+  `finrank_quotient_eq_of_le_torsion`, so neither is restated here.
 * `WeierstrassCurve.Affine.neronTatePairingModTorsion`: the Néron-Tate pairing on that quotient.
 * `WeierstrassCurve.Affine.neronTateGramMatrix`: its matrix in a basis, whose determinant is the
   regulator.
 
 ## Main results
 
-* `WeierstrassCurve.Affine.finrank_pointModTorsion`: the quotient has the Mordell-Weil rank.
 * `WeierstrassCurve.Affine.torsion_le_ker_neronTatePairing`: the pairing kills the torsion
   submodule, which is what the descent consumes.
 * `WeierstrassCurve.Affine.neronTatePairingModTorsion_mk`: the descended pairing agrees with the
@@ -54,23 +49,6 @@ variable {F : Type*} [Field F] {W : Affine F} [AdmissibleAbsValues F] [Decidable
 variable (W) in
 /-- **The points modulo torsion**, the Mordell-Weil group with its torsion divided out. -/
 abbrev PointModTorsion := W.Point ⧸ Submodule.torsion ℤ W.Point
-
--- Not a restatement of `finrank_quotient_torsion_eq`. That lemma is stated for the
--- group-theoretic `(AddCommGroup.torsion M).toIntSubmodule`, and the submodule sits in a *type*
--- position here, so it cannot be rewritten to this quotient's `Submodule.torsion ℤ`: `exact` it
--- and unification exhausts the heartbeat limit at `isDefEq`, `▸` exhausts it at `whnf`, `simp
--- only [← Submodule.torsion_int, Submodule.toIntSubmodule_toAddSubgroup]` makes no progress, and
--- `rw` reports that the motive is not type correct. `finrank_quotient_eq_of_le_torsion` is the
--- general form and applies at `le_rfl` because this quotient is already by `Submodule.torsion ℤ`,
--- so this is the only statement of the rank a consumer of this module can actually use.
--- The rank is purely module-theoretic, so the absolute values play no part.
-omit [AdmissibleAbsValues F] in
-variable (W) in
-/-- **The quotient has the Mordell-Weil rank**: dividing by the torsion leaves the `ℤ`-rank
-alone, so a basis of the quotient is indexed by the rank of the points themselves. -/
-theorem finrank_pointModTorsion :
-    Module.finrank ℤ (PointModTorsion W) = Module.finrank ℤ W.Point :=
-  finrank_quotient_eq_of_le_torsion le_rfl
 
 /-- The pairing vanishes on the torsion submodule, which is what the descent consumes. -/
 theorem torsion_le_ker_neronTatePairing [W.toAffine.IsElliptic] :

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/PointModTorsion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/PointModTorsion.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.CanonicalHeight
+public import Mathlib.LinearAlgebra.Quotient.Bilinear
+-- Public so that a consumer importing this module gets the freeness and rank facts this module
+-- states, without having to discover the implementation import itself. It also carries the
+-- freeness instances transitively, so `Mathlib.LinearAlgebra.FreeModule.PID` is not imported here.
+public import Mathlib.LinearAlgebra.Dimension.Torsion.Basic
+
+/-!
+# The points modulo torsion, and the Néron-Tate pairing on them
+
+The Néron-Tate pairing vanishes as soon as either argument is torsion, so it descends to the
+quotient of the points by their torsion submodule. Under finite generation of the points that
+quotient is free of finite rank, and it is where the regulator is defined; freeness needs the
+hypothesis, so nothing below claims it unconditionally.
+
+## Main definitions
+
+* `WeierstrassCurve.Affine.PointModTorsion`: the points modulo torsion. It is free of finite
+  rank once the points are finitely generated, but freeness is not part of the definition, so the
+  name says only what the quotient is.
+* `WeierstrassCurve.Affine.neronTatePairingModTorsion`: the Néron-Tate pairing on that quotient.
+* `WeierstrassCurve.Affine.neronTateGramMatrix`: its matrix in a basis, whose determinant is the
+  regulator.
+
+## Main results
+
+* `WeierstrassCurve.Affine.finrank_pointModTorsion`: the quotient has the Mordell-Weil rank.
+* `WeierstrassCurve.Affine.torsion_le_ker_neronTatePairing`: the pairing kills the torsion
+  submodule, which is what the descent consumes.
+* `WeierstrassCurve.Affine.neronTatePairingModTorsion_mk`: the descended pairing agrees with the
+  original on representatives.
+* `WeierstrassCurve.Affine.neronTatePairingModTorsion_self_eq_zero_iff`: the descended pairing is
+  positive definite, which is what dividing by the torsion buys.
+* `WeierstrassCurve.Affine.isSymm_neronTateGramMatrix`: the Gram matrix is symmetric. The
+  regulator is the determinant of this matrix in a basis of the quotient, and is defined
+  separately.
+-/
+
+public section
+
+open Height
+
+namespace WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] {W : Affine F} [AdmissibleAbsValues F] [DecidableEq F]
+
+variable (W) in
+/-- **The points modulo torsion**, the Mordell-Weil group with its torsion divided out. -/
+abbrev PointModTorsion := W.Point ⧸ Submodule.torsion ℤ W.Point
+
+-- Not a restatement of `finrank_quotient_torsion_eq`. That lemma is stated for the
+-- group-theoretic `(AddCommGroup.torsion M).toIntSubmodule`, and the submodule sits in a *type*
+-- position here, so it cannot be rewritten to this quotient's `Submodule.torsion ℤ`: `exact` it
+-- and unification exhausts the heartbeat limit at `isDefEq`, `▸` exhausts it at `whnf`, `simp
+-- only [← Submodule.torsion_int, Submodule.toIntSubmodule_toAddSubgroup]` makes no progress, and
+-- `rw` reports that the motive is not type correct. `finrank_quotient_eq_of_le_torsion` is the
+-- general form and applies at `le_rfl` because this quotient is already by `Submodule.torsion ℤ`,
+-- so this is the only statement of the rank a consumer of this module can actually use.
+-- The rank is purely module-theoretic, so the absolute values play no part.
+omit [AdmissibleAbsValues F] in
+variable (W) in
+/-- **The quotient has the Mordell-Weil rank**: dividing by the torsion leaves the `ℤ`-rank
+alone, so a basis of the quotient is indexed by the rank of the points themselves. -/
+theorem finrank_pointModTorsion :
+    Module.finrank ℤ (PointModTorsion W) = Module.finrank ℤ W.Point :=
+  finrank_quotient_eq_of_le_torsion le_rfl
+
+/-- The pairing vanishes on the torsion submodule, which is what the descent consumes. -/
+theorem torsion_le_ker_neronTatePairing [W.toAffine.IsElliptic] :
+    Submodule.torsion ℤ W.Point ≤ (neronTatePairing W).ker := by
+  intro P hP
+  refine LinearMap.ext fun Q ↦ neronTatePairing_eq_zero_of_isOfFinAddOrder_left ?_ Q
+  -- `Submodule.torsion_int` identifies the module-theoretic torsion with the group-theoretic one
+  rwa [← AddCommGroup.mem_torsion, ← Submodule.torsion_int]
+
+variable (W) in
+/-- **The Néron-Tate pairing on the points modulo torsion.** -/
+noncomputable def neronTatePairingModTorsion [W.toAffine.IsElliptic] :
+    LinearMap.BilinMap ℤ (PointModTorsion W) ℝ :=
+  LinearMap.IsRefl.liftQ₂ (neronTatePairing W) (Submodule.torsion ℤ W.Point)
+    isRefl_neronTatePairing torsion_le_ker_neronTatePairing
+
+/-- The descended pairing agrees with the pairing on representatives. -/
+@[simp]
+theorem neronTatePairingModTorsion_mk [W.toAffine.IsElliptic] (P Q : W.Point) :
+    neronTatePairingModTorsion W (Submodule.Quotient.mk P) (Submodule.Quotient.mk Q)
+      = neronTatePairing W P Q := by
+  simp [neronTatePairingModTorsion]
+
+/-- **The descended pairing is symmetric.** -/
+theorem neronTatePairingModTorsion_comm [W.toAffine.IsElliptic] (x y : PointModTorsion W) :
+    neronTatePairingModTorsion W x y = neronTatePairingModTorsion W y x := by
+  -- Both arguments are classes of representatives, where symmetry is `neronTatePairing_comm`.
+  induction x using Submodule.Quotient.induction_on with
+  | _ P =>
+    induction y using Submodule.Quotient.induction_on with
+    | _ Q => simpa using neronTatePairing_comm P Q
+
+/-- **The descended pairing is symmetric**, as an equality of bilinear maps. -/
+@[simp]
+theorem neronTatePairingModTorsion_flip [W.toAffine.IsElliptic] :
+    (neronTatePairingModTorsion W).flip = neronTatePairingModTorsion W :=
+  (LinearMap.BilinMap.isSymm_iff_eq_flip.1 neronTatePairingModTorsion_comm).symm
+
+/-! ### Positive definiteness -/
+
+/-- **The descended pairing is non-negative on the diagonal**, the canonical height being so. -/
+theorem neronTatePairingModTorsion_self_nonneg [W.toAffine.IsElliptic] (x : PointModTorsion W) :
+    0 ≤ neronTatePairingModTorsion W x x := by
+  induction x using Submodule.Quotient.induction_on with
+  | _ P =>
+    rw [neronTatePairingModTorsion_mk, neronTatePairing_self]
+    exact P.canonicalHeight_nonneg
+
+/-- **The descended pairing is positive definite**: its diagonal vanishes only at zero. This is
+what dividing by the torsion buys, the canonical height vanishing exactly on the torsion. The
+Northcott hypothesis is the one that makes height zero force torsion, and it is what
+`Point.canonicalHeight_eq_zero_iff_isOfFinAddOrder` consumes. -/
+@[simp]
+theorem neronTatePairingModTorsion_self_eq_zero_iff [W.toAffine.IsElliptic]
+    [Northcott (Point.canonicalHeight (W := W))] (x : PointModTorsion W) :
+    neronTatePairingModTorsion W x x = 0 ↔ x = 0 := by
+  induction x using Submodule.Quotient.induction_on with
+  | _ P =>
+    rw [neronTatePairingModTorsion_mk, neronTatePairing_self,
+      Point.canonicalHeight_eq_zero_iff_isOfFinAddOrder, Submodule.Quotient.mk_eq_zero,
+      ← AddCommGroup.mem_torsion, ← Submodule.torsion_int]
+    exact Iff.rfl
+
+/-! ### The Gram matrix -/
+
+variable (W) in
+/-- **The Gram matrix of the Néron-Tate pairing** in a basis of the quotient. -/
+-- `LinearMap.toMatrix₂Aux` is the general-target combinator: its entries lie in the form's
+-- codomain, so it applies here, where the scalars are `ℤ` and the values real.
+-- `LinearMap.BilinForm.toMatrixAux` would not, a `BilinForm R M` having target `R`. The `Aux`
+-- form takes the indexing family as a plain function, so no finiteness or decidable equality is
+-- needed until a determinant is taken.
+noncomputable def neronTateGramMatrix [W.toAffine.IsElliptic] {ι : Type*}
+    (b : Module.Basis ι ℤ (PointModTorsion W)) : Matrix ι ι ℝ :=
+  LinearMap.toMatrix₂Aux ℤ b b (neronTatePairingModTorsion W)
+
+/-- Each Gram-matrix entry is the descended pairing of the corresponding basis vectors. -/
+@[simp]
+theorem neronTateGramMatrix_apply [W.toAffine.IsElliptic] {ι : Type*}
+    (b : Module.Basis ι ℤ (PointModTorsion W)) (i j : ι) :
+    neronTateGramMatrix W b i j = neronTatePairingModTorsion W (b i) (b j) := by
+  simp [neronTateGramMatrix]
+
+/-- **Reindexing the basis permutes the Gram matrix.** -/
+@[simp]
+theorem neronTateGramMatrix_reindex [W.toAffine.IsElliptic] {ι ι' : Type*}
+    (b : Module.Basis ι ℤ (PointModTorsion W)) (σ : ι ≃ ι') :
+    neronTateGramMatrix W (b.reindex σ) = (neronTateGramMatrix W b).submatrix σ.symm σ.symm := by
+  ext i j
+  simp [neronTateGramMatrix]
+
+/-- **The Gram matrix is symmetric**, the pairing being so. -/
+theorem isSymm_neronTateGramMatrix [W.toAffine.IsElliptic] {ι : Type*}
+    (b : Module.Basis ι ℤ (PointModTorsion W)) : (neronTateGramMatrix W b).IsSymm := by
+  ext i j
+  simpa using neronTatePairingModTorsion_comm (b j) (b i)
+
+end WeierstrassCurve.Affine


### PR DESCRIPTION
Roadmap: EllipticCurves

The Néron–Tate pairing descends to the Mordell–Weil group modulo torsion, together with its
symmetry and its Gram matrix in a basis. That quotient is free of finite rank under finite
generation, and is where the regulator is defined. This is the last prerequisite for it.

## Why it descends, and why that is a citation rather than a construction

`neronTatePairing` vanishes as soon as either argument is torsion (#5660), so it factors through
the quotient by the torsion submodule. Mathlib does the factoring:
`LinearMap.IsRefl.liftQ₂` is the symmetric case of bilinear descent, an `abbrev` so that
`LinearMap.liftQ₂_mk` applies through it and gives the computation rule for free. Nothing here
reimplements a quotient.

The only fitting needed was the torsion vocabulary. The descent wants a `Submodule`, so the
quotient is by `Submodule.torsion ℤ W.Point`; the pairing's vanishing lemmas are stated for
`IsOfFinAddOrder`. `Submodule.torsion_int` bridges them —
`(torsion ℤ G).toAddSubgroup = AddCommGroup.torsion G` — so no new lemma was needed. An earlier
draft was part-way through a `natAbs`-based bridge before that turned up.

## What it adds

```lean
abbrev PointModTorsion (W : Affine F) := W.Point ⧸ Submodule.torsion ℤ W.Point

theorem torsion_le_ker_neronTatePairing [W.toAffine.IsElliptic] :
    Submodule.torsion ℤ W.Point ≤ (neronTatePairing W).ker

noncomputable def neronTatePairingModTorsion [W.toAffine.IsElliptic] :
    LinearMap.BilinMap ℤ (PointModTorsion W) ℝ

@[simp] theorem neronTatePairingModTorsion_mk [W.toAffine.IsElliptic] (P Q : W.Point) :
    neronTatePairingModTorsion W (Submodule.Quotient.mk P) (Submodule.Quotient.mk Q)
      = neronTatePairing W P Q

theorem neronTatePairingModTorsion_comm [W.toAffine.IsElliptic] (x y : PointModTorsion W) :
    neronTatePairingModTorsion W x y = neronTatePairingModTorsion W y x

theorem neronTatePairingModTorsion_self_nonneg [W.toAffine.IsElliptic]
    (x : PointModTorsion W) : 0 ≤ neronTatePairingModTorsion W x x
@[simp] theorem neronTatePairingModTorsion_self_eq_zero_iff [W.toAffine.IsElliptic]
    [Northcott (Point.canonicalHeight (W := W))] (x : PointModTorsion W) :
    neronTatePairingModTorsion W x x = 0 ↔ x = 0

noncomputable def neronTateGramMatrix [W.toAffine.IsElliptic] {ι : Type*}
    (b : Module.Basis ι ℤ (PointModTorsion W)) : Matrix ι ι ℝ

@[simp] theorem neronTateGramMatrix_apply ...
@[simp] theorem neronTateGramMatrix_reindex ...   -- reindexing the basis permutes the matrix
theorem isSymm_neronTateGramMatrix [W.toAffine.IsElliptic] {ι : Type*}
    (b : Module.Basis ι ℤ (PointModTorsion W)) : (neronTateGramMatrix W b).IsSymm
```

## The quotient is free — given finite generation

Not asserted — the instances resolve, from `[AddGroup.FG W.Point]` alone:

```lean
example [AddGroup.FG W.Point] : Module.Finite ℤ (PointModTorsion W) := inferInstance
example [AddGroup.FG W.Point] : Module.Free ℤ (PointModTorsion W) := inferInstance
```

via `Submodule.QuotientTorsion.instIsTorsionFree` and
`Module.free_of_finite_type_torsion_free'`, and the rank likewise:

```lean
example : Module.finrank ℤ (PointModTorsion W) = Module.finrank ℤ W.Point :=
  finrank_quotient_eq_of_le_torsion (R := ℤ) (M' := Submodule.torsion ℤ W.Point) le_rfl
```

`main` supplies the finite-generation hypothesis over a number field through
`fg_point_of_numberField`.

**Neither fact is restated here, and the imports are minimal accordingly.** An earlier revision of
this branch did state the rank, as a one-line specialisation of
`finrank_quotient_eq_of_le_torsion` at `le_rfl`, and publicly imported
`Mathlib.LinearAlgebra.FreeModule.PID` and `Mathlib.LinearAlgebra.Dimension.Torsion.Basic` so that
consumers would inherit the freeness instances. Both are gone: the specialisation is a wrapper
around a Mathlib call that a consumer can make directly, as the snippet above shows, and with the
wrapper gone those imports had no user in this file. What is left is the three imports the
declarations actually need — the canonical height, `Quotient.Bilinear` for the descent, and
`Algebra.Module.Torsion.Basic` for `Submodule.torsion` and `Submodule.torsion_int`. A module that
needs the quotient to be free — the regulator, next in this chain — imports the freeness machinery
where it uses it.

## Two things worth flagging

**Positive definiteness is where dividing by the torsion pays off.** On `W.Point` the pairing is
only semidefinite — every torsion point has canonical height `0` — so the diagonal
characterisation is a statement about the quotient, not about the points. Non-negativity needs nothing beyond
`Point.canonicalHeight_nonneg`; the vanishing criterion additionally consumes
`[Northcott (Point.canonicalHeight (W := W))]`, which is the hypothesis that makes height zero
force torsion, and it is carried on that lemma alone rather than on the module.

**The Gram matrix is `LinearMap.toMatrix₂Aux`, the general-target combinator.** Its entries live
in the form's codomain, so it applies to a pairing with scalars `ℤ` and values in `ℝ`. The `Aux`
form takes the indexing family as a plain function rather than a basis, so nothing here needs
`Fintype` or `DecidableEq` on the index — those belong with the determinant, not with the
entries.
`LinearMap.BilinForm.toMatrixAux` would not — a `BilinForm R M` has target `R` — and an earlier
draft of this PR assembled the matrix by hand with `Matrix.of` on exactly that reasoning. The
reasoning was right about `BilinearForm.lean` and wrong about Mathlib: the general-target version
is in `SesquilinearForm.lean`, which I had not looked in.

**Representatives come through `Submodule.Quotient.induction_on`.** `Submodule.Quotient.mk` is not
reducible — Mathlib says so in a comment at `LinearAlgebra/Quotient/Defs.lean:85` — so the `⟦·⟧`
that the generic `Quotient.inductionOn` produces matches the `@[simp]` `_mk` rule only
*definitionally*, and `simp` will not bridge it. Rather than patch that with a `change` in each
proof, the three proofs over representatives use `Submodule.Quotient.induction_on` (nested, for
the binary symmetry statement), which presents representatives through the canonical
`Submodule.Quotient.mk` interface directly; no proof in the file depends on that definitional
equality.

## Two files, and why

`isRefl_neronTatePairing` — that the pairing is reflexive, which is what the descent consumes —
is a property of `neronTatePairing` itself and has nothing to do with any quotient, so it sits in
`CanonicalHeight.lean` beside `neronTatePairing_comm` and `neronTatePairing_flip` rather than
being buried in a downstream module. That is the second file in the diff.

## Its own file

`MordellWeil/PointModTorsion.lean` rather than more declarations in `CanonicalHeight.lean`. The
descent needs `Mathlib.LinearAlgebra.Quotient.Bilinear`, `Algebra.Module.Torsion.Basic`,
and `LinearAlgebra.Matrix.SesquilinearForm`; adding those to
`CanonicalHeight` would widen the dependency closure of every canonical-height consumer for the
benefit of code none of them use. The directory `MordellWeil/` already exists and already holds
`FinitelyGenerated.lean`, whose `AddGroup.FG W.Point` is what makes this quotient free.

The matrix API is *not* imported directly: `LinearMap.toMatrix₂Aux` arrives through
`CanonicalHeight`, which publicly imports `Mathlib.LinearAlgebra.QuadraticForm.Basic`, which
publicly imports `Mathlib.LinearAlgebra.Matrix.SesquilinearForm`. That is a deliberate Mathlib
re-export rather than an accident of transitivity — `QuadraticForm.Basic` needs the matrix API
for its own discriminant — so a direct import here would only widen what this module re-exports.

## Roadmap position

`TauCetiRoadmap/EllipticCurves/STATUS.md` §Layer 6 records the canonical height and regulator as
absent, and `README.md` names the Néron–Tate pairing as the regulator's input. The regulator is
the determinant of this Gram matrix; what remains after this PR is that determinant together
with its independence of the chosen basis (`det U = ±1`), which is a separate topic and ships
separately.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"free-quotient-pairing"}-->

## Provenance

Provenance: original work — no source ported. Every step is an application of existing API, from
Mathlib (`IsRefl.liftQ₂`, `liftQ₂_mk`, `Submodule.torsion_int`, `QuotientTorsion.instIsTorsionFree`,
`free_of_finite_type_torsion_free'`) or from `main` (`neronTatePairing` and its torsion lemmas).
Three sources swept and absent: `github.com/MichaelStollBayreuth/EllipticCurves` @ `57f93fa71f16`
(45 files), `github.com/CBirkbeck/FLT` @ `20eda920b763` (25 files) and
`github.com/CBirkbeck/AINTLIB` @ `513e83879e2f` (286 files) contain no `neronTate`, no
`canonicalHeight` and no regulator.

## Gates

- `lake build`: green, 0 errors, 0 warnings under `warningAsError = true`, no Mathlib recompiled.
- `#lint` environment linter set: "All linting checks passed".
- `#print axioms`: `[propext, Classical.choice, Quot.sound]`.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; 107 lines, no line over 100 characters.
- **Unicode**: every non-ASCII character checked mechanically against those in use on `main`.
- Claim at `refs/tauceti-claims/author/EllipticCurves/free-quotient-pairing`.
