### PR TITLE
feat(ModularForms): the Atkin-Lehner step at one divisor

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
@@ -35,8 +35,7 @@ descent `φ` is supplied by the caller, so no hypothesis on the `q`-expansion of
   level-`l` descent is invariant under the weight-`k` slash action of `T`, is old.
 * `TauCeti.mem_cuspFormsOld_of_qExpansionSupportedOnDvd`: **the Atkin–Lehner step at one
   divisor** — the same conclusion from the `q`-expansion support condition alone, the descent
-  being supplied by `Newforms/Descent.lean`. This is not yet the roadmap's Atkin–Lehner Main
-  Lemma; see below.
+  being supplied by `Newforms/Descent.lean`.
 
 ## Provenance
 
@@ -100,11 +99,14 @@ a `T`-invariant `φ : ℍ → ℂ` with `f = l ^ (1 - k) • (φ ∣[k] diag(l, 
 `mem_cuspFormsOld_of_slash_T_eq` reads the level-lowering dichotomy off that. Nothing else about
 the `q`-expansion is used, and `l` need not be prime.
 
-⚠ This is one divisor and one character, and so is **not** the roadmap's Atkin–Lehner Main Lemma
-(Diamond–Shurman Theorem 5.7.1), which concludes oldness from `aₙ(f) = 0` at *every* `n` coprime
-to `N`. That hypothesis does not name a divisor: passing from it to this one is the sum over the
-primes dividing `N`, which is a separate argument and is not done here. What this supplies is the
-per-divisor, per-character input that argument consumes. -/
+⚠ The hypothesis is support on the multiples of **one** divisor `l`, for a form in **one**
+character space. Diamond–Shurman Theorem 5.7.1 assumes instead that `aₙ(f) = 0` at every `n`
+coprime to `N`, a condition naming no divisor. The two are not interchangeable, and the
+implication runs one way: since `l ∣ N` and `l ≠ 1`, every `n` coprime to `N` is in particular
+not divisible by `l`, so `QExpansionSupportedOnDvd l` is the stronger hypothesis — it kills
+every index off the multiples of `l`, not merely those prime to `N`. (The two coincide exactly
+when `l` and `N` have the same prime factors.) Getting from Diamond–Shurman's hypothesis to this
+one therefore means splitting `f` across the primes dividing `N`. -/
 theorem mem_cuspFormsOld_of_qExpansionSupportedOnDvd {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
     (χ : DirichletCharacter ℂ N) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
     (hfχ : f ∈ cuspFormCharSpace k χ.toUnitHom)

--- a/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
@@ -33,9 +33,10 @@ descent `φ` is supplied by the caller, so no hypothesis on the `q`-expansion of
 
 * `TauCeti.mem_cuspFormsOld_of_slash_T_eq`: a cusp form of level `Γ₁(N)` with a nebentypus, whose
   level-`l` descent is invariant under the weight-`k` slash action of `T`, is old.
-* `TauCeti.mem_cuspFormsOld_of_qExpansionSupportedOnDvd`: **the main lemma** — the same
-  conclusion from the `q`-expansion support condition alone, the descent being supplied by
-  `Newforms/Descent.lean`.
+* `TauCeti.mem_cuspFormsOld_of_qExpansionSupportedOnDvd`: **the Atkin–Lehner step at one
+  divisor** — the same conclusion from the `q`-expansion support condition alone, the descent
+  being supplied by `Newforms/Descent.lean`. This is not yet the roadmap's Atkin–Lehner Main
+  Lemma; see below.
 
 ## Provenance
 
@@ -91,13 +92,19 @@ theorem mem_cuspFormsOld_of_slash_T_eq {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
       rw [hf, hφ, SlashAction.zero_slash, smul_zero, FunLike.coe_zero]
     exact hf0 ▸ (cuspFormsOld N k).zero_mem
 
-/-- **The Atkin–Lehner main lemma.** A cusp form of level `Γ₁(N)` with a nebentypus, whose
-period-one `q`-expansion is supported on the multiples of a divisor `l ≠ 1` of `N`, is old.
+/-- **The Atkin–Lehner step at one divisor.** A cusp form of level `Γ₁(N)` with a nebentypus,
+whose period-one `q`-expansion is supported on the multiples of a divisor `l ≠ 1` of `N`, is old.
 
 The support condition is spent entirely on manufacturing the descent: `Descent.lean` turns it into
 a `T`-invariant `φ : ℍ → ℂ` with `f = l ^ (1 - k) • (φ ∣[k] diag(l, 1))`, and
 `mem_cuspFormsOld_of_slash_T_eq` reads the level-lowering dichotomy off that. Nothing else about
-the `q`-expansion is used, and `l` need not be prime. -/
+the `q`-expansion is used, and `l` need not be prime.
+
+⚠ This is one divisor and one character, and so is **not** the roadmap's Atkin–Lehner Main Lemma
+(Diamond–Shurman Theorem 5.7.1), which concludes oldness from `aₙ(f) = 0` at *every* `n` coprime
+to `N`. That hypothesis does not name a divisor: passing from it to this one is the sum over the
+primes dividing `N`, which is a separate argument and is not done here. What this supplies is the
+per-divisor, per-character input that argument consumes. -/
 theorem mem_cuspFormsOld_of_qExpansionSupportedOnDvd {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
     (χ : DirichletCharacter ℂ N) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
     (hfχ : f ∈ cuspFormCharSpace k χ.toUnitHom)

--- a/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.NumberTheory.ModularForms.ConductorDichotomy
 public import TauCeti.NumberTheory.ModularForms.Newforms.Basic
+public import TauCeti.NumberTheory.ModularForms.Newforms.Descent
 
 /-!
 # A form with a periodic level-`l` descent is old
@@ -32,6 +33,9 @@ descent `φ` is supplied by the caller, so no hypothesis on the `q`-expansion of
 
 * `TauCeti.mem_cuspFormsOld_of_slash_T_eq`: a cusp form of level `Γ₁(N)` with a nebentypus, whose
   level-`l` descent is invariant under the weight-`k` slash action of `T`, is old.
+* `TauCeti.mem_cuspFormsOld_of_qExpansionSupportedOnDvd`: **the main lemma** — the same
+  conclusion from the `q`-expansion support condition alone, the descent being supplied by
+  `Newforms/Descent.lean`.
 
 ## Provenance
 
@@ -86,6 +90,24 @@ theorem mem_cuspFormsOld_of_slash_T_eq {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
   · have hf0 : f = 0 := DFunLike.coe_injective <| by
       rw [hf, hφ, SlashAction.zero_slash, smul_zero, FunLike.coe_zero]
     exact hf0 ▸ (cuspFormsOld N k).zero_mem
+
+/-- **The Atkin–Lehner main lemma.** A cusp form of level `Γ₁(N)` with a nebentypus, whose
+period-one `q`-expansion is supported on the multiples of a divisor `l ≠ 1` of `N`, is old.
+
+The support condition is spent entirely on manufacturing the descent: `Descent.lean` turns it into
+a `T`-invariant `φ : ℍ → ℂ` with `f = l ^ (1 - k) • (φ ∣[k] diag(l, 1))`, and
+`mem_cuspFormsOld_of_slash_T_eq` reads the level-lowering dichotomy off that. Nothing else about
+the `q`-expansion is used, and `l` need not be prime. -/
+theorem mem_cuspFormsOld_of_qExpansionSupportedOnDvd {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
+    (χ : DirichletCharacter ℂ N) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hfχ : f ∈ cuspFormCharSpace k χ.toUnitHom)
+    (hf : haveI : NeZero l := NeZero.of_dvd hlN
+      QExpansionSupportedOnDvd l f) :
+    f ∈ cuspFormsOld N k := by
+  have : NeZero l := NeZero.of_dvd hlN
+  obtain ⟨φ, hφ, hT⟩ :=
+    CuspForm.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_qExpansionSupportedOnDvd f hf
+  exact mem_cuspFormsOld_of_slash_T_eq hl hlN χ φ hfχ hφ hT
 
 end TauCeti
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
@@ -26,8 +26,12 @@ identically zero. Both horns say the same thing about `f`. On the first it is th
 
 `TauCeti.cuspFormsOld` is spanned by the level-raises from **proper** divisor levels, so what the
 argument needs of `l` is exactly that `N / l` be a proper divisor of `N` — that is, `l ≠ 1`, which
-together with `l ∣ N` and `N ≠ 0` gives `N / l < N`. Nothing here asks `l` to be prime, and the
-descent `φ` is supplied by the caller, so no hypothesis on the `q`-expansion of `f` appears.
+together with `l ∣ N` and `N ≠ 0` gives `N / l < N`. Neither result asks `l` to be prime.
+
+The two entry points differ in where the descent comes from.
+`mem_cuspFormsOld_of_slash_T_eq` takes `φ` from the caller, so no hypothesis on the
+`q`-expansion of `f` appears in it at all; `mem_cuspFormsOld_of_qExpansionSupportedOnDvd`
+instead assumes `QExpansionSupportedOnDvd l f` and obtains `φ` from it.
 
 ## Main results
 
@@ -94,10 +98,7 @@ theorem mem_cuspFormsOld_of_slash_T_eq {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
 /-- **The Atkin–Lehner step at one divisor.** A cusp form of level `Γ₁(N)` with a nebentypus,
 whose period-one `q`-expansion is supported on the multiples of a divisor `l ≠ 1` of `N`, is old.
 
-The support condition is spent entirely on manufacturing the descent: `Descent.lean` turns it into
-a `T`-invariant `φ : ℍ → ℂ` with `f = l ^ (1 - k) • (φ ∣[k] diag(l, 1))`, and
-`mem_cuspFormsOld_of_slash_T_eq` reads the level-lowering dichotomy off that. Nothing else about
-the `q`-expansion is used, and `l` need not be prime.
+The support condition is the only thing asked of the `q`-expansion, and `l` need not be prime.
 
 ⚠ The hypothesis is support on the multiples of **one** divisor `l`, for a form in **one**
 character space. Diamond–Shurman Theorem 5.7.1 assumes instead that `aₙ(f) = 0` at every `n`
@@ -114,6 +115,9 @@ theorem mem_cuspFormsOld_of_qExpansionSupportedOnDvd {l : ℕ} (hl : l ≠ 1) (h
     (hf : haveI : NeZero l := NeZero.of_dvd hlN
       QExpansionSupportedOnDvd l f) :
     f ∈ cuspFormsOld N k := by
+  -- The support condition is spent entirely on manufacturing the descent: `Descent.lean` turns
+  -- it into a `T`-invariant `φ` with `f = l ^ (1 - k) • (φ ∣[k] diag(l, 1))`, and
+  -- `mem_cuspFormsOld_of_slash_T_eq` reads the level-lowering dichotomy off that.
   have : NeZero l := NeZero.of_dvd hlN
   obtain ⟨φ, hφ, hT⟩ :=
     CuspForm.exists_eq_smul_slash_scaleGL_and_slash_T_eq_of_qExpansionSupportedOnDvd f hf

--- a/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/AtkinLehner.lean
@@ -104,9 +104,10 @@ character space. Diamond–Shurman Theorem 5.7.1 assumes instead that `aₙ(f) =
 coprime to `N`, a condition naming no divisor. The two are not interchangeable, and the
 implication runs one way: since `l ∣ N` and `l ≠ 1`, every `n` coprime to `N` is in particular
 not divisible by `l`, so `QExpansionSupportedOnDvd l` is the stronger hypothesis — it kills
-every index off the multiples of `l`, not merely those prime to `N`. (The two coincide exactly
-when `l` and `N` have the same prime factors.) Getting from Diamond–Shurman's hypothesis to this
-one therefore means splitting `f` across the primes dividing `N`. -/
+every index off the multiples of `l`, not merely those prime to `N`. The two agree only in the
+degenerate case where `l` is prime and `N` is a power of `l`: if they agree then every prime `q`
+dividing `N` satisfies `l ∣ q`, forcing `q = l`. Getting from Diamond–Shurman's hypothesis to
+this one therefore means splitting `f` across the primes dividing `N`. -/
 theorem mem_cuspFormsOld_of_qExpansionSupportedOnDvd {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
     (χ : DirichletCharacter ℂ N) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
     (hfχ : f ∈ cuspFormCharSpace k χ.toUnitHom)


### PR DESCRIPTION
A cusp form of level `Γ₁(N)` with a nebentypus, whose period-one `q`-expansion is supported on the
multiples of a divisor `l ≠ 1` of `N`, is old:

```lean
theorem mem_cuspFormsOld_of_qExpansionSupportedOnDvd {l : ℕ} (hl : l ≠ 1) (hlN : l ∣ N)
    (χ : DirichletCharacter ℂ N) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
    (hfχ : f ∈ cuspFormCharSpace k χ.toUnitHom)
    (hf : haveI : NeZero l := NeZero.of_dvd hlN
      QExpansionSupportedOnDvd l f) :
    f ∈ cuspFormsOld N k
```

## What this is

The **Atkin–Lehner step at one divisor**: the per-divisor, per-character input to the roadmap's
Atkin–Lehner Main Lemma, which `STATUS.md` names on its frontier as *"turn the coefficient
filters and level-lowering dichotomy into the statement that a cusp form supported away from
indices coprime to the level is old."*

⚠ It is **not** that Main Lemma (Diamond–Shurman Theorem 5.7.1) and no longer claims to be. The
frontier statement hypothesises `aₙ(f) = 0` at *every* `n` coprime to `N` — a condition naming no
divisor; this theorem hypothesises support on the multiples of one fixed `l ∣ N`, inside one
character space. Getting from the former to the latter is the sum over the primes dividing `N`,
a separate argument that is not in this PR. (Corrected after the `api-design` review, which
caught the overclaim in the docstrings; both the code and this description now say the narrower
thing.)

Both halves are already on `main`, so the proof is their composition and nothing else:

- [#5646](https://github.com/TauCetiProject/TauCeti/pull/5646) spends the support condition to
  manufacture a descent — a `T`-invariant `φ : ℍ → ℂ` with
  `⇑f = l ^ (1 - k) • (φ ∣[k] diag(l, 1))`.
- [#5657](https://github.com/TauCetiProject/TauCeti/pull/5657) reads Miyake's level-lowering
  dichotomy off such a descent: either `φ` is a cusp form of level `Γ₁(N / l)` and `f` is its
  level-raise, or `φ = 0` and `f = 0`, and `cuspFormsOld` contains both.

Four lines, and they sit in `Newforms/AtkinLehner.lean` beside the second half, which is the file
named for this lemma.

## Hypotheses

`l ≠ 1` is the only arithmetic condition — `cuspFormsOld` is spanned by level-raises from
**proper** divisor levels, so all the argument asks is that `N / l` be a proper divisor. `l` need
not be prime. `NeZero l` is not a hypothesis: it follows from `l ∣ N` and the ambient `[NeZero N]`,
and is introduced by a `haveI` inside the one binder that needs it, as
`mem_cuspFormsOld_of_slash_T_eq` does.

## Where it leads

This is what the Layer 5 chain reaches down to. Reading from the top: strong multiplicity one
consumes `coeff_one_ne_zero_of_mem_cuspFormsNew_of_eigen`, which consumes
`mainLemma_charSpace_routeB`, which consumes exactly this.

Roadmap: ModularForms

New mathematics, so the citation: this supplies a prerequisite that
`TauCetiRoadmap/ModularForms/README.md` § "Layer 5: strong multiplicity one and the eigenform
characterization" needs, via the Atkin–Lehner old-subspace description its `strongMultiplicityOne`
bullet rests on. It does **not** author that target, so it carries no `tauceti-target` marker.

Provenance: [AINTLIB](https://github.com/CBirkbeck/AINTLIB) @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
Apache-2.0, Chris Birkbeck — `projects/LeanModularForms/LeanModularForms/Eigenforms/AtkinLehner.lean`,
the theorem `qSupportedOnDvd_mem_cuspFormsOld_of_char` (lines 169–192). Its two inputs were adapted
in #5646 and #5657; nothing further is ported here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR

