### PR TITLE
feat: smooth dependence of an ODE solution on its initial condition

### DIFF
--- a/TauCeti/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/TauCeti/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -10,12 +10,15 @@ public import Mathlib.Analysis.Calculus.BumpFunction.FiniteDimension
 /-!
 # Extending finite-dimensional smooth germs
 
-A finite-order smooth germ on a finite-dimensional real normed space can be represented by a
-globally smooth function of the same order. A smooth bump function performs the extension while
-preserving the original function near the base point.
+A function which is smooth, of finite or infinite order, on a neighbourhood of a point of a
+finite-dimensional real normed space agrees near that point with a globally smooth function of
+the same order. A smooth bump function performs the extension while preserving the original
+function near the base point. Since the bump is compactly supported, so is the representative,
+and a representative of order at least one is moreover globally Lipschitz.
 
-This general calculus lemma is used by the parameter-dependent ODE construction for the Lie-group
-exponential.
+These general calculus lemmas are used by the parameter-dependent ODE construction for the
+Lie-group exponential, and by the construction of a local flow out of the global solution of a
+globally Lipschitz field.
 
 ## References
 
@@ -30,13 +33,13 @@ open scoped ContDiff
 variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   [NormedAddCommGroup F] [NormedSpace ℝ F]
 
-/-- A finite-order smooth germ on a finite-dimensional real normed space has a globally smooth
-representative of the same order. -/
-theorem ContDiffAt.exists_contDiff_eventuallyEq_of_finiteDimensional
-    [FiniteDimensional ℝ E] (n : ℕ) {f : E → F} {x : E}
-    (hf : ContDiffAt ℝ n f x) :
-    ∃ g : E → F, ContDiff ℝ n g ∧ g =ᶠ[nhds x] f := by
-  obtain ⟨s, hs, hfs⟩ := hf.contDiffOn le_rfl (by simp)
+/-- A function which is smooth on a neighbourhood of a point of a finite-dimensional real normed
+space agrees near that point with a compactly supported globally smooth function of the same
+order. -/
+theorem ContDiffOn.exists_contDiff_eventuallyEq_of_finiteDimensional
+    [FiniteDimensional ℝ E] {n : ℕ∞} {f : E → F} {x : E} {s : Set E}
+    (hfs : ContDiffOn ℝ n f s) (hs : s ∈ nhds x) :
+    ∃ g : E → F, ContDiff ℝ n g ∧ HasCompactSupport g ∧ g =ᶠ[nhds x] f := by
   obtain ⟨ε, hε, hεs⟩ := Metric.mem_nhds_iff.mp hs
   let b : ContDiffBump x :=
     ⟨ε / 4, ε / 2, by positivity, by linarith⟩
@@ -60,9 +63,36 @@ theorem ContDiffAt.exists_contDiff_eventuallyEq_of_finiteDimensional
         filter_upwards [hbzero] with z hz
         simp only [g, hz, zero_smul]
       exact contDiffAt_const.congr_of_eventuallyEq hgeq
-  refine ⟨g, hg, ?_⟩
+  refine ⟨g, hg, b.hasCompactSupport.smul_right, ?_⟩
   filter_upwards [b.eventuallyEq_one] with y hy
   have hone : (fun _ : E ↦ (1 : ℝ)) y = 1 := by
     rfl
   have hy' : b y = 1 := hy.trans hone
   simp only [g, hy', one_smul]
+
+/-- A finite-order smooth germ on a finite-dimensional real normed space has a compactly supported
+globally smooth representative of the same order. -/
+theorem ContDiffAt.exists_contDiff_eventuallyEq_of_finiteDimensional
+    [FiniteDimensional ℝ E] (n : ℕ) {f : E → F} {x : E}
+    (hf : ContDiffAt ℝ n f x) :
+    ∃ g : E → F, ContDiff ℝ n g ∧ HasCompactSupport g ∧ g =ᶠ[nhds x] f :=
+  let ⟨s, hs, hfs⟩ := hf.contDiffOn le_rfl (by simp)
+  hfs.exists_contDiff_eventuallyEq_of_finiteDimensional hs
+
+/-- A function which is smooth of order at least one on a neighbourhood of a point of a
+finite-dimensional real normed space agrees near that point with a globally smooth **and globally
+Lipschitz** function of the same order: the compactly supported representative above has a bounded
+derivative. -/
+theorem ContDiffOn.exists_lipschitzWith_contDiff_eventuallyEq_of_finiteDimensional
+    [FiniteDimensional ℝ E] {n : ℕ∞} {f : E → F} {x : E} {s : Set E}
+    (hf : ContDiffOn ℝ (n + 1) f s) (hs : s ∈ nhds x) :
+    ∃ (g : E → F) (K : NNReal), ContDiff ℝ (n + 1) g ∧ LipschitzWith K g ∧ g =ᶠ[nhds x] f := by
+  obtain ⟨g, hg, hgsupp, hgf⟩ := hf.exists_contDiff_eventuallyEq_of_finiteDimensional hs
+  have hone : ((n : WithTop ℕ∞) + 1) ≠ 0 := by simp
+  obtain ⟨C, hC⟩ := (hg.continuous_fderiv hone).bounded_above_of_compact_support
+    (hgsupp.fderiv (𝕜 := ℝ))
+  have hC0 : 0 ≤ C := (norm_nonneg _).trans (hC x)
+  refine ⟨g, C.toNNReal, hg, lipschitzWith_of_nnnorm_fderiv_le (hg.differentiable hone) ?_, hgf⟩
+  intro y
+  rw [← NNReal.coe_le_coe, coe_nnnorm, Real.coe_toNNReal C hC0]
+  exact hC y

--- a/TauCeti/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/TauCeti/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -88,11 +88,5 @@ theorem ContDiffOn.exists_lipschitzWith_contDiff_eventuallyEq_of_finiteDimension
     (hf : ContDiffOn ℝ (n + 1) f s) (hs : s ∈ nhds x) :
     ∃ (g : E → F) (K : NNReal), ContDiff ℝ (n + 1) g ∧ LipschitzWith K g ∧ g =ᶠ[nhds x] f := by
   obtain ⟨g, hg, hgsupp, hgf⟩ := hf.exists_contDiff_eventuallyEq_of_finiteDimensional hs
-  have hone : ((n : WithTop ℕ∞) + 1) ≠ 0 := by simp
-  obtain ⟨C, hC⟩ := (hg.continuous_fderiv hone).bounded_above_of_compact_support
-    (hgsupp.fderiv (𝕜 := ℝ))
-  have hC0 : 0 ≤ C := (norm_nonneg _).trans (hC x)
-  refine ⟨g, C.toNNReal, hg, lipschitzWith_of_nnnorm_fderiv_le (hg.differentiable hone) ?_, hgf⟩
-  intro y
-  rw [← NNReal.coe_le_coe, coe_nnnorm, Real.coe_toNNReal C hC0]
-  exact hC y
+  obtain ⟨C, hC⟩ := hg.lipschitzWith_of_hasCompactSupport hgsupp (by simp)
+  exact ⟨g, C, hg, hC, hgf⟩

--- a/TauCeti/Analysis/ODE/GlobalSolution.lean
+++ b/TauCeti/Analysis/ODE/GlobalSolution.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.ODE.Basic
 public import Mathlib.Analysis.ODE.ExistUnique
+public import Mathlib.Analysis.ODE.Transform
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 public import Mathlib.Topology.ContinuousMap.Bounded.Normed
@@ -41,6 +42,7 @@ Mathlib's `ODE_solution_unique_univ`, and the fixed point depends on the initial
 * `ODE.globalSolution_zero` and `ODE.hasDerivAt_globalSolution`: it is a solution.
 * `ODE.eq_globalSolution`: every global solution with the same initial value is equal to it.
 * `ODE.globalSolution_congr`: it does not depend on the chosen Lipschitz bound.
+* `ODE.globalSolution_add`: the flow law, following the solution for two successive times.
 * `ODE.globalSolution_neg`: reversing time solves the negated field.
 * `ODE.dist_globalSolution_le`: two solutions drift apart at most exponentially.
 * `ODE.continuous_globalSolution`: joint continuity in time and initial condition.
@@ -296,6 +298,15 @@ theorem globalSolution_congr (v : E → E) {K K' : ℝ≥0} (hv : LipschitzWith 
     (hv' : LipschitzWith K' v) (x : E) : globalSolution v hv x = globalSolution v hv' x := by
   have h := eq_globalSolution v hv' (γ := globalSolution v hv x) (hasDerivAt_globalSolution v hv x)
   rwa [globalSolution_zero] at h
+
+/-- **The flow law.** Following the global solution from `x` for the time `t + s` is the same as
+following it from `x` for the time `t` and then, from where it has arrived, for the time `s`: both
+curves solve the equation on the whole line and start at the same point. -/
+theorem globalSolution_add (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v) (x : E) (t s : ℝ) :
+    globalSolution v hv x (t + s) = globalSolution v hv (globalSolution v hv x t) s := by
+  have hγ : IsIntegralCurve (fun r : ℝ ↦ globalSolution v hv x (t + r)) fun _ y ↦ v y := by
+    simpa [Function.comp_def, add_comm] using (isIntegralCurve_globalSolution v hv x).comp_add t
+  simpa using congrFun (eq_globalSolution v hv hγ) s
 
 /-- The Picard fixed point depends on the initial condition `1`-Lipschitzly. -/
 private theorem dist_picardFixedPoint_le {v : E → E} (hvc : Continuous v) {k : ℝ} (hk : 0 < k)

--- a/TauCeti/Analysis/ODE/InitialCondition.lean
+++ b/TauCeti/Analysis/ODE/InitialCondition.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.ODE.GlobalSolution
+public import TauCeti.Analysis.ODE.SmoothParameter
+
+/-!
+# Smooth dependence of an ODE solution on its initial condition
+
+Picard iteration produces a solution of `γ' = v ∘ γ` continuously, indeed Lipschitzly, in the
+initial condition. It says nothing about differentiability: the contraction argument is metric.
+This file upgrades continuity to smoothness of the same order as the field, jointly in the initial
+condition and in time, near time `0`.
+
+The mechanism is a change of variables that turns the initial condition into a *parameter* of a
+new equation, so that `ODE.exists_contDiffAt_picard_solution` applies. Writing a solution through
+`x` as `t ↦ x + u (t / ε)`, the curve `u` solves
+
+`u' s = ε • v (x + u s)`, `u 0 = 0`
+
+on the fixed time interval `[0, 1]`, with `(x, ε)` a parameter and the initial state `0` fixed.
+At `ε = 0` that field vanishes identically, which is exactly the degeneracy hypothesis of the
+parameterized Picard theorem, and the solution at the base parameter is the constant curve `0`.
+Evaluating the resulting smooth family of paths at the endpoint `s = 1` — a continuous linear
+map on the path space — produces `x + u 1`, which Grönwall's uniqueness theorem identifies with
+the value of the global solution at time `ε`. Both the initial condition and the time are
+therefore smooth directions.
+
+## Main results
+
+* `ODE.contDiffAt_globalSolution`: the global solution of a globally Lipschitz `C^(n+1)` field is
+  `C^(n+1)` in time and initial condition near time `0`, for `n` finite or infinite.
+* `ODE.eventually_contDiffAt_globalSolution`: at every small time, the time-`t` map of such a
+  field is `C^(n+1)` in the initial condition.
+* `ODE.exists_contDiffAt_localFlow`: a vector field which is `C^(n+1)` on a neighbourhood of a
+  point has a local flow through the nearby points which is `C^(n+1)` in time and initial
+  condition near that point at time `0`.
+
+The local flow produced here is the model-space input to the smooth flow of a vector field on a
+manifold, and in particular to the flow of the geodesic spray, whose base curves are the
+geodesics of a Riemannian metric.
+
+## References
+
+* J. Dieudonné, *Foundations of Modern Analysis*, Academic Press, 1969, Chapter X.
+-/
+
+public section
+
+open Filter Set Topology
+open scoped ContDiff NNReal
+
+noncomputable section
+
+universe u
+
+namespace ODE
+
+variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- Rescaling a Lipschitz field rescales a Lipschitz constant. -/
+private theorem lipschitzWith_const_smul {K : ℝ≥0} {v : E → E} (hv : LipschitzWith K v) (ε : ℝ) :
+    LipschitzWith (‖ε‖₊ * K) fun z ↦ ε • v z :=
+  LipschitzWith.of_dist_le_mul fun y z ↦ by
+    rw [dist_smul₀, NNReal.coe_mul, coe_nnnorm, mul_assoc]
+    exact mul_le_mul_of_nonneg_left (hv.dist_le_mul y z) (norm_nonneg ε)
+
+/-- **Time rescaling.** A curve solving the field `v` sped up by the factor `ε` on the unit
+interval reaches, at time `1`, the value of the global solution at time `ε`. Only right
+derivatives are required, which is the form in which the parameterized Picard theorem delivers
+its solutions. -/
+private theorem eq_globalSolution_of_smul [CompleteSpace E] (v : E → E) {K : ℝ≥0}
+    (hv : LipschitzWith K v) (x : E) (ε : ℝ) {u : ℝ → E} (hu₀ : u 0 = x)
+    (hu : ContinuousOn u (Icc 0 1))
+    (hu' : ∀ s ∈ Ico (0 : ℝ) 1, HasDerivWithinAt u (ε • v (u s)) (Ici s) s) :
+    u 1 = globalSolution v hv x ε := by
+  have hflow : ∀ s : ℝ, HasDerivAt (fun r : ℝ ↦ globalSolution v hv x (ε * r))
+      (ε • v (globalSolution v hv x (ε * s))) s := fun s ↦ by
+    simpa [Function.comp_def, mul_comm] using
+      (hasDerivAt_globalSolution v hv x (ε * s)).scomp s ((hasDerivAt_id s).const_mul ε)
+  have hdist := dist_le_of_trajectories_ODE (v := fun _ z ↦ ε • v z) (K := ‖ε‖₊ * K)
+    (a := 0) (b := 1) (δ := 0) (f := u) (g := fun r ↦ globalSolution v hv x (ε * r))
+    (fun _ ↦ lipschitzWith_const_smul hv ε) hu hu'
+    (((continuous_globalSolution_apply v hv x).comp
+      (continuous_const.mul continuous_id)).continuousOn)
+    (fun s _ ↦ (hflow s).hasDerivWithinAt)
+    (by simp [hu₀]) 1 (by norm_num)
+  simpa using dist_le_zero.mp (by simpa using hdist)
+
+variable [FiniteDimensional ℝ E]
+
+/-- The finite-order form of `ODE.contDiffAt_globalSolution`, which is where the parameterized
+Picard theorem applies. -/
+private theorem contDiffAt_globalSolution_nat (n : ℕ) (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v)
+    (hvs : ContDiff ℝ (n + 1) v) (a : E) :
+    ContDiffAt ℝ (n + 1) (fun p : E × ℝ ↦ globalSolution v hv p.1 p.2) (a, 0) := by
+  -- The field of the rescaled equation, with the initial condition and the speed as parameters.
+  have hf : ContDiffAt ℝ (n + 1) (fun q : (E × ℝ) × E ↦ q.1.2 • v (q.1.1 + q.2))
+      (((a, (0 : ℝ)), (0 : E))) :=
+    (ContDiff.smul (contDiff_fst.snd) (hvs.comp (contDiff_fst.fst.add contDiff_snd))).contDiffAt
+  have hzero : ∀ᶠ y in nhds (0 : E),
+      (fun q : (E × ℝ) × E ↦ q.1.2 • v (q.1.1 + q.2)) (((a, (0 : ℝ))), y) = 0 :=
+    .of_forall fun y ↦ zero_smul ℝ _
+  obtain ⟨γ, hγ, -, hprop⟩ :=
+    exists_contDiffAt_picard_solution n (fun q : (E × ℝ) × E ↦ q.1.2 • v (q.1.1 + q.2))
+      (a, (0 : ℝ)) (0 : E) hf hzero
+  have hsmooth : ContDiffAt ℝ (n + 1)
+      (fun p : E × ℝ ↦ p.1 + γ p ⟨1, by norm_num⟩) (a, 0) := by
+    have := ((ContinuousMap.evalCLM (R := ℝ) (⟨1, by norm_num⟩ : Icc (0 : ℝ) 1)).contDiff
+      (n := (n + 1 : ℕ))).comp_contDiffAt (a, (0 : ℝ)) hγ
+    exact contDiffAt_fst.add (by simpa [Function.comp_def] using this)
+  refine hsmooth.congr_of_eventuallyEq ?_
+  filter_upwards [hprop] with p hp
+  obtain ⟨hpicard, -, hright⟩ := hp
+  -- The rescaled solution starts at `p.1` and moves with speed `p.2 • v`.
+  have hbase : γ p ⟨0, by norm_num⟩ = 0 := by simpa using hpicard ⟨0, by norm_num⟩
+  have hcont : ContinuousOn (fun s : ℝ ↦ p.1 + γ p (projIcc 0 1 zero_le_one s)) (Icc 0 1) :=
+    Continuous.continuousOn (by fun_prop)
+  have hderiv : ∀ s ∈ Ico (0 : ℝ) 1,
+      HasDerivWithinAt (fun r : ℝ ↦ p.1 + γ p (projIcc 0 1 zero_le_one r))
+        (p.2 • v (p.1 + γ p (projIcc 0 1 zero_le_one s))) (Ici s) s :=
+    fun s hs ↦ (hright s hs).const_add p.1
+  have := eq_globalSolution_of_smul v hv p.1 p.2
+    (u := fun s : ℝ ↦ p.1 + γ p (projIcc 0 1 zero_le_one s))
+    (by simpa [projIcc_left] using congrArg (fun w : E ↦ p.1 + w) hbase) hcont hderiv
+  simpa [projIcc_right] using this.symm
+
+/-- **The global solution of a globally Lipschitz field depends smoothly on time and on its
+initial condition**, near time `0`, at the order of the field. -/
+theorem contDiffAt_globalSolution {n : ℕ∞} (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v)
+    (hvs : ContDiff ℝ (n + 1) v) (a : E) :
+    ContDiffAt ℝ (n + 1) (fun p : E × ℝ ↦ globalSolution v hv p.1 p.2) (a, 0) := by
+  induction n using ENat.recTopCoe with
+  | top =>
+    have htop : ((⊤ : ℕ∞) : WithTop ℕ∞) + 1 = ∞ := by
+      norm_cast
+    rw [htop] at hvs ⊢
+    exact contDiffAt_infty.2 fun m ↦
+      (contDiffAt_globalSolution_nat m v hv (hvs.of_le (by exact_mod_cast le_top)) a).of_le
+        (by exact_mod_cast Nat.le_succ m)
+  | coe m => exact contDiffAt_globalSolution_nat m v hv (by exact_mod_cast hvs) a
+
+/-- **`C^(n+1)` dependence on the initial condition.** For every small time the time-`t` map of a
+globally Lipschitz `C^(n+1)` field is `C^(n+1)` at the base point. The order is finite here
+because smoothness of infinite order at one point does not propagate to a neighbourhood. -/
+theorem eventually_contDiffAt_globalSolution (n : ℕ) (v : E → E) {K : ℝ≥0} (hv : LipschitzWith K v)
+    (hvs : ContDiff ℝ (n + 1) v) (a : E) :
+    ∀ᶠ t in nhds (0 : ℝ), ContDiffAt ℝ (n + 1) (fun x ↦ globalSolution v hv x t) a := by
+  have hev := (contDiffAt_globalSolution (n := (n : ℕ∞)) v hv
+    (by exact_mod_cast hvs) a).eventually (by simp)
+  have hslice := (continuousAt_const.prodMk continuousAt_id).eventually hev
+  filter_upwards [hslice] with t ht
+  exact ht.comp a (contDiffAt_id.prodMk contDiffAt_const)
+
+/-- **The local flow of a smooth vector field.** A field which is `C^(n+1)` on a neighbourhood of
+`a` admits a family of curves, one through each point, which solve the equation near `a` at times
+near `0` and depend on the initial condition and the time in a `C^(n+1)` way. No global hypothesis
+on the field is needed: the equation is only claimed where the curves have not yet left the
+neighbourhood on which the field is smooth. -/
+theorem exists_contDiffAt_localFlow {n : ℕ∞} (v : E → E) {a : E} {s : Set E}
+    (hv : ContDiffOn ℝ (n + 1) v s) (hs : s ∈ nhds a) :
+    ∃ Φ : E → ℝ → E, ContDiffAt ℝ (n + 1) (fun p : E × ℝ ↦ Φ p.1 p.2) (a, 0) ∧
+      (∀ x, Φ x 0 = x) ∧
+      ∀ᶠ p in nhds ((a, 0) : E × ℝ), HasDerivAt (Φ p.1) (v (Φ p.1 p.2)) p.2 := by
+  obtain ⟨g, K, hg, hgK, hgv⟩ :=
+    hv.exists_lipschitzWith_contDiff_eventuallyEq_of_finiteDimensional hs
+  refine ⟨globalSolution g hgK, contDiffAt_globalSolution g hgK hg a,
+    fun x ↦ globalSolution_zero g hgK x, ?_⟩
+  have htends : Tendsto (fun p : E × ℝ ↦ globalSolution g hgK p.1 p.2) (nhds ((a, 0) : E × ℝ))
+      (nhds a) := by
+    have hcont : Continuous fun p : E × ℝ ↦ globalSolution g hgK p.1 p.2 :=
+      (continuous_globalSolution g hgK).comp (continuous_snd.prodMk continuous_fst)
+    have h := hcont.tendsto ((a, 0) : E × ℝ)
+    simp only [globalSolution_zero] at h
+    exact h
+  filter_upwards [htends.eventually hgv] with p hp
+  exact hp ▸ hasDerivAt_globalSolution g hgK p.1 p.2
+
+end ODE
+
+end

--- a/TauCeti/Analysis/ODE/InitialCondition.lean
+++ b/TauCeti/Analysis/ODE/InitialCondition.lean
@@ -38,7 +38,8 @@ therefore smooth directions.
   field is `C^(n+1)` in the initial condition.
 * `ODE.exists_contDiffAt_localFlow`: a vector field which is `C^(n+1)` on a neighbourhood of a
   point has a local flow through the nearby points which is `C^(n+1)` in time and initial
-  condition near that point at time `0`.
+  condition near that point at time `0`, and which obeys the flow law
+  `Φ x (t + u) = Φ (Φ x t) u`.
 
 The local flow produced here is the model-space input to the smooth flow of a vector field on a
 manifold, and in particular to the flow of the geodesic spray, whose base curves are the
@@ -149,20 +150,22 @@ theorem eventually_contDiffAt_globalSolution (n : ℕ) (v : E → E) {K : ℝ≥
   exact ht.comp a (contDiffAt_id.prodMk contDiffAt_const)
 
 /-- **The local flow of a smooth vector field.** A field which is `C^(n+1)` on a neighbourhood of
-`a` admits a family of curves, one through each point, which start at that point, depend on the
-initial condition and the time in a `C^(n+1)` way near `(a, 0)`, and solve the equation for every
-initial condition and time in some neighbourhood of `(a, 0)`. No global hypothesis on the field is
-needed: a bump function cuts the field down to a globally Lipschitz one agreeing with it near
-`a`, and the two fields still agree along the curves at the times where the equation is claimed. -/
+`a` admits a flow `Φ`: a family of curves, one through each point, which start at that point,
+obey the flow law `Φ x (t + u) = Φ (Φ x t) u`, depend on the initial condition and the time in a
+`C^(n+1)` way near `(a, 0)`, and solve the equation for every initial condition and time in some
+neighbourhood of `(a, 0)`. No global hypothesis on the field is needed: a bump function cuts the
+field down to a globally Lipschitz one agreeing with it near `a`, and the two fields still agree
+along the curves at the times where the equation is claimed. The flow law holds for all times
+because `Φ` is the global flow of that cut-off field; only the equation for `v` is local. -/
 theorem exists_contDiffAt_localFlow [FiniteDimensional ℝ E] {n : ℕ∞} (v : E → E) {a : E}
     {s : Set E} (hv : ContDiffOn ℝ (n + 1) v s) (hs : s ∈ nhds a) :
     ∃ Φ : E → ℝ → E, ContDiffAt ℝ (n + 1) (fun p : E × ℝ ↦ Φ p.1 p.2) (a, 0) ∧
-      (∀ x, Φ x 0 = x) ∧
+      (∀ x, Φ x 0 = x) ∧ (∀ x t u, Φ x (t + u) = Φ (Φ x t) u) ∧
       ∀ᶠ p in nhds ((a, 0) : E × ℝ), HasDerivAt (Φ p.1) (v (Φ p.1 p.2)) p.2 := by
   obtain ⟨g, K, hg, hgK, hgv⟩ :=
     hv.exists_lipschitzWith_contDiff_eventuallyEq_of_finiteDimensional hs
   refine ⟨globalSolution g hgK, contDiffAt_globalSolution g hgK hg a,
-    fun x ↦ globalSolution_zero g hgK x, ?_⟩
+    fun x ↦ globalSolution_zero g hgK x, fun x t u ↦ globalSolution_add g hgK x t u, ?_⟩
   have htends : Tendsto (fun p : E × ℝ ↦ globalSolution g hgK p.1 p.2) (nhds ((a, 0) : E × ℝ))
       (nhds a) := by
     have hcont : Continuous fun p : E × ℝ ↦ globalSolution g hgK p.1 p.2 :=

--- a/TauCeti/Analysis/ODE/InitialCondition.lean
+++ b/TauCeti/Analysis/ODE/InitialCondition.lean
@@ -85,6 +85,8 @@ private theorem eq_globalSolution_of_smul [CompleteSpace E] (v : E → E) {K : �
     (by simp [hu₀])
   simpa using heq (right_mem_Icc.2 zero_le_one)
 
+section
+
 variable [CompleteSpace E]
 
 /-- The finite-order form of `ODE.contDiffAt_globalSolution`, which is where the parameterized
@@ -149,6 +151,8 @@ theorem eventually_contDiffAt_globalSolution (n : ℕ) (v : E → E) {K : ℝ≥
   filter_upwards [hslice] with t ht
   exact ht.comp a (contDiffAt_id.prodMk contDiffAt_const)
 
+end
+
 /-- **The local flow of a smooth vector field.** A field which is `C^(n+1)` on a neighbourhood of
 `a` admits a flow `Φ`: a family of curves, one through each point, which start at that point,
 obey the flow law `Φ x (t + u) = Φ (Φ x t) u`, depend on the initial condition and the time in a
@@ -162,6 +166,7 @@ theorem exists_contDiffAt_localFlow [FiniteDimensional ℝ E] {n : ℕ∞} (v : 
     ∃ Φ : E → ℝ → E, ContDiffAt ℝ (n + 1) (fun p : E × ℝ ↦ Φ p.1 p.2) (a, 0) ∧
       (∀ x, Φ x 0 = x) ∧ (∀ x t u, Φ x (t + u) = Φ (Φ x t) u) ∧
       ∀ᶠ p in nhds ((a, 0) : E × ℝ), HasDerivAt (Φ p.1) (v (Φ p.1 p.2)) p.2 := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   obtain ⟨g, K, hg, hgK, hgv⟩ :=
     hv.exists_lipschitzWith_contDiff_eventuallyEq_of_finiteDimensional hs
   refine ⟨globalSolution g hgK, contDiffAt_globalSolution g hgK hg a,

--- a/TauCeti/Analysis/ODE/InitialCondition.lean
+++ b/TauCeti/Analysis/ODE/InitialCondition.lean
@@ -17,8 +17,8 @@ This file upgrades continuity to smoothness of the same order as the field, join
 condition and in time, near time `0`.
 
 The mechanism is a change of variables that turns the initial condition into a *parameter* of a
-new equation, so that `ODE.exists_contDiffAt_picard_solution` applies. Writing a solution through
-`x` as `t ↦ x + u (t / ε)`, the curve `u` solves
+new equation, so that `ODE.exists_contDiffAt_picard_solution_of_contDiff` applies. Writing a
+solution through `x` as `t ↦ x + u (t / ε)`, the curve `u` solves
 
 `u' s = ε • v (x + u s)`, `u 0 = 0`
 
@@ -26,7 +26,7 @@ on the fixed time interval `[0, 1]`, with `(x, ε)` a parameter and the initial 
 At `ε = 0` that field vanishes identically, which is exactly the degeneracy hypothesis of the
 parameterized Picard theorem, and the solution at the base parameter is the constant curve `0`.
 Evaluating the resulting smooth family of paths at the endpoint `s = 1` — a continuous linear
-map on the path space — produces `x + u 1`, which Grönwall's uniqueness theorem identifies with
+map on the path space — produces `x + u 1`, which `ODE_solution_unique` identifies with
 the value of the global solution at time `ε`. Both the initial condition and the time are
 therefore smooth directions.
 
@@ -62,13 +62,6 @@ namespace ODE
 
 variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
-/-- Rescaling a Lipschitz field rescales a Lipschitz constant. -/
-private theorem lipschitzWith_const_smul {K : ℝ≥0} {v : E → E} (hv : LipschitzWith K v) (ε : ℝ) :
-    LipschitzWith (‖ε‖₊ * K) fun z ↦ ε • v z :=
-  LipschitzWith.of_dist_le_mul fun y z ↦ by
-    rw [dist_smul₀, NNReal.coe_mul, coe_nnnorm, mul_assoc]
-    exact mul_le_mul_of_nonneg_left (hv.dist_le_mul y z) (norm_nonneg ε)
-
 /-- **Time rescaling.** A curve solving the field `v` sped up by the factor `ε` on the unit
 interval reaches, at time `1`, the value of the global solution at time `ε`. Only right
 derivatives are required, which is the form in which the parameterized Picard theorem delivers
@@ -82,16 +75,16 @@ private theorem eq_globalSolution_of_smul [CompleteSpace E] (v : E → E) {K : �
       (ε • v (globalSolution v hv x (ε * s))) s := fun s ↦ by
     simpa [Function.comp_def, mul_comm] using
       (hasDerivAt_globalSolution v hv x (ε * s)).scomp s ((hasDerivAt_id s).const_mul ε)
-  have hdist := dist_le_of_trajectories_ODE (v := fun _ z ↦ ε • v z) (K := ‖ε‖₊ * K)
-    (a := 0) (b := 1) (δ := 0) (f := u) (g := fun r ↦ globalSolution v hv x (ε * r))
-    (fun _ ↦ lipschitzWith_const_smul hv ε) hu hu'
+  have heq := ODE_solution_unique (v := fun _ z ↦ ε • v z) (K := ‖ε‖₊ * K)
+    (a := 0) (b := 1) (f := u) (g := fun r ↦ globalSolution v hv x (ε * r))
+    (fun _ ↦ (lipschitzWith_smul ε).comp hv) hu hu'
     (((continuous_globalSolution_apply v hv x).comp
       (continuous_const.mul continuous_id)).continuousOn)
     (fun s _ ↦ (hflow s).hasDerivWithinAt)
-    (by simp [hu₀]) 1 (by norm_num)
-  simpa using dist_le_zero.mp (by simpa using hdist)
+    (by simp [hu₀])
+  simpa using heq (right_mem_Icc.2 zero_le_one)
 
-variable [FiniteDimensional ℝ E]
+variable [CompleteSpace E]
 
 /-- The finite-order form of `ODE.contDiffAt_globalSolution`, which is where the parameterized
 Picard theorem applies. -/
@@ -99,15 +92,14 @@ private theorem contDiffAt_globalSolution_nat (n : ℕ) (v : E → E) {K : ℝ�
     (hvs : ContDiff ℝ (n + 1) v) (a : E) :
     ContDiffAt ℝ (n + 1) (fun p : E × ℝ ↦ globalSolution v hv p.1 p.2) (a, 0) := by
   -- The field of the rescaled equation, with the initial condition and the speed as parameters.
-  have hf : ContDiffAt ℝ (n + 1) (fun q : (E × ℝ) × E ↦ q.1.2 • v (q.1.1 + q.2))
-      (((a, (0 : ℝ)), (0 : E))) :=
-    (ContDiff.smul (contDiff_fst.snd) (hvs.comp (contDiff_fst.fst.add contDiff_snd))).contDiffAt
+  have hf : ContDiff ℝ (n + 1) fun q : (E × ℝ) × E ↦ q.1.2 • v (q.1.1 + q.2) :=
+    ContDiff.smul (contDiff_fst.snd) (hvs.comp (contDiff_fst.fst.add contDiff_snd))
   have hzero : ∀ᶠ y in nhds (0 : E),
       (fun q : (E × ℝ) × E ↦ q.1.2 • v (q.1.1 + q.2)) (((a, (0 : ℝ))), y) = 0 :=
     .of_forall fun y ↦ zero_smul ℝ _
   obtain ⟨γ, hγ, -, hprop⟩ :=
-    exists_contDiffAt_picard_solution n (fun q : (E × ℝ) × E ↦ q.1.2 • v (q.1.1 + q.2))
-      (a, (0 : ℝ)) (0 : E) hf hzero
+    exists_contDiffAt_picard_solution_of_contDiff n
+      (fun q : (E × ℝ) × E ↦ q.1.2 • v (q.1.1 + q.2)) (a, (0 : ℝ)) (0 : E) hf hzero
   have hsmooth : ContDiffAt ℝ (n + 1)
       (fun p : E × ℝ ↦ p.1 + γ p ⟨1, by norm_num⟩) (a, 0) := by
     have := ((ContinuousMap.evalCLM (R := ℝ) (⟨1, by norm_num⟩ : Icc (0 : ℝ) 1)).contDiff
@@ -157,12 +149,13 @@ theorem eventually_contDiffAt_globalSolution (n : ℕ) (v : E → E) {K : ℝ≥
   exact ht.comp a (contDiffAt_id.prodMk contDiffAt_const)
 
 /-- **The local flow of a smooth vector field.** A field which is `C^(n+1)` on a neighbourhood of
-`a` admits a family of curves, one through each point, which solve the equation near `a` at times
-near `0` and depend on the initial condition and the time in a `C^(n+1)` way. No global hypothesis
-on the field is needed: the equation is only claimed where the curves have not yet left the
-neighbourhood on which the field is smooth. -/
-theorem exists_contDiffAt_localFlow {n : ℕ∞} (v : E → E) {a : E} {s : Set E}
-    (hv : ContDiffOn ℝ (n + 1) v s) (hs : s ∈ nhds a) :
+`a` admits a family of curves, one through each point, which start at that point, depend on the
+initial condition and the time in a `C^(n+1)` way near `(a, 0)`, and solve the equation for every
+initial condition and time in some neighbourhood of `(a, 0)`. No global hypothesis on the field is
+needed: a bump function cuts the field down to a globally Lipschitz one agreeing with it near
+`a`, and the two fields still agree along the curves at the times where the equation is claimed. -/
+theorem exists_contDiffAt_localFlow [FiniteDimensional ℝ E] {n : ℕ∞} (v : E → E) {a : E}
+    {s : Set E} (hv : ContDiffOn ℝ (n + 1) v s) (hs : s ∈ nhds a) :
     ∃ Φ : E → ℝ → E, ContDiffAt ℝ (n + 1) (fun p : E × ℝ ↦ Φ p.1 p.2) (a, 0) ∧
       (∀ x, Φ x 0 = x) ∧
       ∀ᶠ p in nhds ((a, 0) : E × ℝ), HasDerivAt (Φ p.1) (v (Φ p.1 p.2)) p.2 := by

--- a/TauCeti/Analysis/ODE/SmoothParameter.lean
+++ b/TauCeti/Analysis/ODE/SmoothParameter.lean
@@ -219,16 +219,21 @@ theorem exists_contDiffAt_picard_solution_of_contDiff
   let R := picardResidual gc x₀
   let basePath : C(Set.Icc (0 : ℝ) 1, F) := ContinuousMap.const _ x₀
   let u : E × C(Set.Icc (0 : ℝ) 1, F) := (p₀, basePath)
+  have hgc : ContDiff ℝ (n + 1) gc := by
+    change ContDiff ℝ (n + 1) f
+    exact hf
   have hR : ContDiffAt ℝ (n + 1) R u :=
-    (contDiff_picardResidual (n + 1) gc hf x₀).contDiffAt
+    (contDiff_picardResidual (n + 1) gc hgc x₀).contDiffAt
   have hzeroBase : f (p₀, x₀) = 0 := hzero.self_of_nhds
-  have hgzero : ∀ᶠ y in nhds x₀, gc (p₀, y) = 0 := hzero
+  have hgzero : ∀ᶠ y in nhds x₀, gc (p₀, y) = 0 := by
+    change ∀ᶠ y in nhds x₀, f (p₀, y) = 0
+    exact hzero
   -- At the constant base solution the path derivative of the residual is the identity, so the
   -- implicit function theorem produces a smooth parameter-to-path germ.
   have hinvertible :
       (fderiv ℝ R u ∘L
         ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)).IsInvertible :=
-    isInvertible_fderiv_picardResidual_comp_inr gc (hf.of_le (by norm_num)) p₀ x₀ hgzero
+    isInvertible_fderiv_picardResidual_comp_inr gc (hgc.of_le (by norm_num)) p₀ x₀ hgzero
   let γ : E → C(Set.Icc (0 : ℝ) 1, F) :=
     hR.implicitFunction (by norm_num) hinvertible
   have hγsmooth : ContDiffAt ℝ (n + 1) γ p₀ :=

--- a/TauCeti/Analysis/ODE/SmoothParameter.lean
+++ b/TauCeti/Analysis/ODE/SmoothParameter.lean
@@ -19,9 +19,11 @@ smooth parameterized autonomous ODE depend smoothly on its parameter.
 
 ## Main results
 
-* `ODE.exists_contDiffAt_picard_solution`: a finite-order smooth family of local solutions of the
-  Picard integral equation, satisfying the ODE at interior times and from the right at the initial
-  endpoint.
+* `ODE.exists_contDiffAt_picard_solution_of_contDiff`: for a globally smooth field on complete
+  spaces, a finite-order smooth family of local solutions of the Picard integral equation,
+  satisfying the ODE at interior times and from the right at the initial endpoint.
+* `ODE.exists_contDiffAt_picard_solution`: the same for a germ of a smooth field, in finite
+  dimension.
 
 ## References
 
@@ -189,11 +191,91 @@ private theorem eventually_dist_parameterizedPath_lt {γ : E → C(K, F)} {p₀ 
   simpa only [hpathBase, Function.comp_apply, id_eq] using
     (Metric.continuousAt_iff'.mp hpath ε hε)
 
+/-- A globally smooth parameterized autonomous vector field which vanishes near the base state at
+the base parameter admits a locally smooth family of solutions through that state. The result is
+stated at every finite order; this is the form needed to assemble smoothness of a germ. Each
+nearby path satisfies the Picard integral equation, the corresponding ODE at every interior time,
+and its right-hand version at the initial endpoint. A field defined and smooth on the whole space
+needs no cutoff, so completeness of the two spaces is the only hypothesis. -/
+theorem exists_contDiffAt_picard_solution_of_contDiff
+    [CompleteSpace E] [CompleteSpace F]
+    (n : ℕ) (f : E × F → F) (p₀ : E) (x₀ : F)
+    (hf : ContDiff ℝ (n + 1) f)
+    (hzero : ∀ᶠ y in nhds x₀, f (p₀, y) = 0) :
+    ∃ γ : E → C(Set.Icc (0 : ℝ) 1, F),
+      ContDiffAt ℝ (n + 1) γ p₀ ∧
+      γ p₀ = ContinuousMap.const _ x₀ ∧
+      ∀ᶠ p in nhds p₀,
+        (∀ t : Set.Icc (0 : ℝ) 1,
+          γ p t = x₀ + ∫ s in (0 : ℝ)..t,
+            f (p, γ p (Set.projIcc 0 1 zero_le_one s))) ∧
+        (∀ t ∈ Set.Ioo (0 : ℝ) 1,
+          HasDerivAt (fun s ↦ γ p (Set.projIcc 0 1 zero_le_one s))
+            (f (p, γ p (Set.projIcc 0 1 zero_le_one t))) t) ∧
+        ∀ t ∈ Set.Ico (0 : ℝ) 1,
+          HasDerivWithinAt (fun s ↦ γ p (Set.projIcc 0 1 zero_le_one s))
+            (f (p, γ p (Set.projIcc 0 1 zero_le_one t))) (Set.Ici t) t := by
+  let gc : C(E × F, F) := ⟨f, hf.continuous⟩
+  let R := picardResidual gc x₀
+  let basePath : C(Set.Icc (0 : ℝ) 1, F) := ContinuousMap.const _ x₀
+  let u : E × C(Set.Icc (0 : ℝ) 1, F) := (p₀, basePath)
+  have hR : ContDiffAt ℝ (n + 1) R u :=
+    (contDiff_picardResidual (n + 1) gc hf x₀).contDiffAt
+  have hzeroBase : f (p₀, x₀) = 0 := hzero.self_of_nhds
+  have hgzero : ∀ᶠ y in nhds x₀, gc (p₀, y) = 0 := hzero
+  -- At the constant base solution the path derivative of the residual is the identity, so the
+  -- implicit function theorem produces a smooth parameter-to-path germ.
+  have hinvertible :
+      (fderiv ℝ R u ∘L
+        ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)).IsInvertible :=
+    isInvertible_fderiv_picardResidual_comp_inr gc (hf.of_le (by norm_num)) p₀ x₀ hgzero
+  let γ : E → C(Set.Icc (0 : ℝ) 1, F) :=
+    hR.implicitFunction (by norm_num) hinvertible
+  have hγsmooth : ContDiffAt ℝ (n + 1) γ p₀ :=
+    hR.contDiffAt_implicitFunction (by norm_num) hinvertible
+  have hγbase : γ p₀ = basePath :=
+    hR.implicitFunction_apply_self (by norm_num) hinvertible
+  have hRbase : R u = 0 := by
+    have hcomp : gc.comp (parameterizedPath u) = 0 := by
+      ext t
+      rw [ContinuousMap.comp_apply, parameterizedPath_apply]
+      simp only [gc, u, basePath, ContinuousMap.const_apply]
+      exact hzeroBase
+    simp only [R, picardResidual_apply, u, basePath, hcomp, map_zero, sub_self]
+  have hγeq : ∀ᶠ p in nhds p₀, R (p, γ p) = 0 := by
+    filter_upwards [hR.eventually_apply_implicitFunction (by norm_num) hinvertible] with p hp
+    rw [hp, hRbase]
+  refine ⟨γ, hγsmooth, by simpa only [basePath] using hγbase, ?_⟩
+  filter_upwards [hγeq] with p hp
+  have hpicard : ∀ t : Set.Icc (0 : ℝ) 1,
+      γ p t = x₀ + ∫ s in (0 : ℝ)..t,
+        gc (p, γ p (Set.projIcc 0 1 zero_le_one s)) :=
+    (picardResidual_eq_zero_iff gc x₀ p (γ p)).mp hp
+  let vproj : ℝ → F := fun s ↦ gc (p, γ p (Set.projIcc 0 1 zero_le_one s))
+  have hvproj : Continuous vproj :=
+    gc.continuous.comp
+      (continuous_const.prodMk ((γ p).continuous.comp continuous_projIcc))
+  refine ⟨hpicard, ?_, ?_⟩
+  · intro t ht
+    exact (hasDerivWithinAt_Icc_of_forall_eq_picard vproj hvproj x₀ (γ p) hpicard
+      ⟨ht.1.le, ht.2.le⟩).hasDerivAt (Icc_mem_nhds ht.1 ht.2)
+  · intro t ht
+    have hIcc := hasDerivWithinAt_Icc_of_forall_eq_picard vproj hvproj x₀ (γ p) hpicard
+      ⟨ht.1, ht.2.le⟩
+    have hsmall := hIcc.mono (Set.Icc_subset_Icc ht.1 le_rfl)
+    apply hsmall.congr_set
+    filter_upwards [Iic_mem_nhds ht.2] with s hs
+    apply propext
+    constructor
+    · exact fun h ↦ h.1
+    · exact fun h ↦ ⟨h, hs⟩
+
 /-- A smooth parameterized autonomous vector field which vanishes at the base parameter admits a
-locally smooth family of solutions through a fixed initial state. The result is stated at every
-finite order; this is the form needed to assemble smoothness of a germ. Each nearby path satisfies
-the Picard integral equation, the corresponding ODE at every interior time, and its right-hand
-version at the initial endpoint. -/
+locally smooth family of solutions through a fixed initial state. Only a germ of the field at the
+base point is needed: a bump function replaces it by a globally smooth representative, to which
+`ODE.exists_contDiffAt_picard_solution_of_contDiff` applies. Each nearby path satisfies the Picard
+integral equation, the corresponding ODE at every interior time, and its right-hand version at the
+initial endpoint. -/
 theorem exists_contDiffAt_picard_solution
     [FiniteDimensional ℝ E] [FiniteDimensional ℝ F]
     (n : ℕ) (f : E × F → F) (p₀ : E) (x₀ : F)
@@ -214,91 +296,36 @@ theorem exists_contDiffAt_picard_solution
             (f (p, γ p (Set.projIcc 0 1 zero_le_one t))) (Set.Ici t) t := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   let _ : CompleteSpace F := FiniteDimensional.complete ℝ F
-  -- Replace the local vector-field germ by a global smooth representative so the Banach-space
-  -- implicit function theorem applies without changing the ODE near the base point.
+  -- Replace the local vector-field germ by a global smooth representative, which does not change
+  -- the ODE near the base point.
   obtain ⟨g, hg, -, hgf⟩ :=
     hf.exists_contDiff_eventuallyEq_of_finiteDimensional (n + 1)
-  let gc : C(E × F, F) := ⟨g, hg.continuous⟩
-  let R := picardResidual gc x₀
-  let basePath : C(Set.Icc (0 : ℝ) 1, F) := ContinuousMap.const _ x₀
-  let u : E × C(Set.Icc (0 : ℝ) 1, F) := (p₀, basePath)
-  have hR : ContDiffAt ℝ (n + 1) R u :=
-    (contDiff_picardResidual (n + 1) gc hg x₀).contDiffAt
-  have hgfBase : g (p₀, x₀) = f (p₀, x₀) :=
-    hgf.self_of_nhds
-  have hzeroBase : f (p₀, x₀) = 0 := hzero.self_of_nhds
-  have hgzero : ∀ᶠ y in nhds x₀, gc (p₀, y) = 0 := by
+  have hgzero : ∀ᶠ y in nhds x₀, g (p₀, y) = 0 := by
     have hpull : ∀ᶠ y in nhds x₀, g (p₀, y) = f (p₀, y) :=
       (continuousAt_const.prodMk continuousAt_id).eventually hgf
     filter_upwards [hpull, hzero] with y hy hyzero
     exact hy.trans hyzero
-  -- At the constant base solution the path derivative of the residual is the identity, so the
-  -- implicit function theorem produces a smooth parameter-to-path germ.
-  have hinvertible :
-      (fderiv ℝ R u ∘L
-        ContinuousLinearMap.inr ℝ E C(Set.Icc (0 : ℝ) 1, F)).IsInvertible :=
-    isInvertible_fderiv_picardResidual_comp_inr gc (hg.of_le (by norm_num)) p₀ x₀ hgzero
-  let γ : E → C(Set.Icc (0 : ℝ) 1, F) :=
-    hR.implicitFunction (by norm_num) hinvertible
-  have hγsmooth : ContDiffAt ℝ (n + 1) γ p₀ :=
-    hR.contDiffAt_implicitFunction (by norm_num) hinvertible
-  have hγbase : γ p₀ = basePath :=
-    hR.implicitFunction_apply_self (by norm_num) hinvertible
-  have hRbase : R u = 0 := by
-    have hcomp : gc.comp (parameterizedPath u) = 0 := by
-      ext t
-      rw [ContinuousMap.comp_apply, parameterizedPath_apply]
-      simp only [gc, u, basePath, ContinuousMap.const_apply]
-      exact hgfBase.trans hzeroBase
-    simp only [R, picardResidual_apply, u, basePath, hcomp, map_zero, sub_self]
-  have hγeq : ∀ᶠ p in nhds p₀, R (p, γ p) = 0 := by
-    filter_upwards [hR.eventually_apply_implicitFunction (by norm_num) hinvertible] with p hp
-    rw [hp, hRbase]
+  obtain ⟨γ, hγsmooth, hγbase, hprop⟩ :=
+    exists_contDiffAt_picard_solution_of_contDiff n g p₀ x₀ hg hgzero
+  refine ⟨γ, hγsmooth, hγbase, ?_⟩
   have hgfSet : {z : E × F | g z = f z} ∈ nhds (p₀, x₀) := hgf
   obtain ⟨ε, hε, hεgf⟩ := Metric.mem_nhds_iff.mp hgfSet
   have hpathsNear := eventually_dist_parameterizedPath_lt (γ := γ)
-    hγsmooth.continuousAt (by simpa only [basePath] using hγbase) hε
-  -- Restrict to parameters whose whole Picard path remains where the cutoff field agrees with
+    hγsmooth.continuousAt hγbase hε
+  -- Restrict to parameters whose whole Picard path remains where the representative agrees with
   -- the original field; then transfer the integral equation and its derivative consequences.
-  refine ⟨γ, hγsmooth, by simpa only [basePath] using hγbase, ?_⟩
-  filter_upwards [hγeq, hpathsNear] with p hp hpnear
-  have hpoint (t : Set.Icc (0 : ℝ) 1) :
-      gc (parameterizedPath (p, γ p) t) = f (p, γ p t) := by
+  filter_upwards [hprop, hpathsNear] with p hp hpnear
+  obtain ⟨hpicard, hderiv, hright⟩ := hp
+  have hpoint (t : Set.Icc (0 : ℝ) 1) : g (p, γ p t) = f (p, γ p t) := by
     apply hεgf
     rw [Metric.mem_ball]
     simpa only [parameterizedPath_apply, ContinuousMap.const_apply] using
       (ContinuousMap.dist_apply_le_dist
         (f := parameterizedPath (p, γ p))
         (g := ContinuousMap.const _ (p₀, x₀)) t).trans_lt hpnear
-  have hpicard : ∀ t : Set.Icc (0 : ℝ) 1,
-      γ p t = x₀ + ∫ s in (0 : ℝ)..t,
-        gc (p, γ p (Set.projIcc 0 1 zero_le_one s)) :=
-    (picardResidual_eq_zero_iff gc x₀ p (γ p)).mp hp
-  let vproj : ℝ → F := fun s ↦ gc (p, γ p (Set.projIcc 0 1 zero_le_one s))
-  have hvproj : Continuous vproj :=
-    gc.continuous.comp
-      (continuous_const.prodMk ((γ p).continuous.comp continuous_projIcc))
   refine ⟨fun t ↦ (hpicard t).trans (congrArg (x₀ + ·) ?_), ?_, ?_⟩
-  · apply intervalIntegral.integral_congr
-    intro s _
-    exact hpoint (Set.projIcc 0 1 zero_le_one s)
-  · intro t ht
-    have hderiv :=
-      (hasDerivWithinAt_Icc_of_forall_eq_picard vproj hvproj x₀ (γ p) hpicard
-        ⟨ht.1.le, ht.2.le⟩).hasDerivAt (Icc_mem_nhds ht.1 ht.2)
-    exact hderiv.congr_deriv (hpoint (Set.projIcc 0 1 zero_le_one t))
-  · intro t ht
-    have hIcc := hasDerivWithinAt_Icc_of_forall_eq_picard vproj hvproj x₀ (γ p) hpicard
-      ⟨ht.1, ht.2.le⟩
-    have hsmall := hIcc.mono (Set.Icc_subset_Icc ht.1 le_rfl)
-    have hderiv : HasDerivWithinAt
-        (fun s ↦ γ p (Set.projIcc 0 1 zero_le_one s)) (vproj t) (Set.Ici t) t := by
-      apply hsmall.congr_set
-      filter_upwards [Iic_mem_nhds ht.2] with s hs
-      apply propext
-      constructor
-      · exact fun h ↦ h.1
-      · exact fun h ↦ ⟨h, hs⟩
-    exact hderiv.congr_deriv (hpoint (Set.projIcc 0 1 zero_le_one t))
+  · exact intervalIntegral.integral_congr fun s _ ↦ hpoint (Set.projIcc 0 1 zero_le_one s)
+  · exact fun t ht ↦ (hderiv t ht).congr_deriv (hpoint (Set.projIcc 0 1 zero_le_one t))
+  · exact fun t ht ↦ (hright t ht).congr_deriv (hpoint (Set.projIcc 0 1 zero_le_one t))
 
 end ODE

--- a/TauCeti/Analysis/ODE/SmoothParameter.lean
+++ b/TauCeti/Analysis/ODE/SmoothParameter.lean
@@ -216,7 +216,7 @@ theorem exists_contDiffAt_picard_solution
   let _ : CompleteSpace F := FiniteDimensional.complete ℝ F
   -- Replace the local vector-field germ by a global smooth representative so the Banach-space
   -- implicit function theorem applies without changing the ODE near the base point.
-  obtain ⟨g, hg, hgf⟩ :=
+  obtain ⟨g, hg, -, hgf⟩ :=
     hf.exists_contDiff_eventuallyEq_of_finiteDimensional (n + 1)
   let gc : C(E × F, F) := ⟨g, hg.continuous⟩
   let R := picardResidual gc x₀

--- a/TauCeti/Analysis/ODE/SmoothParameter.lean
+++ b/TauCeti/Analysis/ODE/SmoothParameter.lean
@@ -220,14 +220,12 @@ theorem exists_contDiffAt_picard_solution_of_contDiff
   let basePath : C(Set.Icc (0 : ℝ) 1, F) := ContinuousMap.const _ x₀
   let u : E × C(Set.Icc (0 : ℝ) 1, F) := (p₀, basePath)
   have hgc : ContDiff ℝ (n + 1) gc := by
-    change ContDiff ℝ (n + 1) f
-    exact hf
+    simpa only [gc, ContinuousMap.coe_mk] using hf
   have hR : ContDiffAt ℝ (n + 1) R u :=
     (contDiff_picardResidual (n + 1) gc hgc x₀).contDiffAt
   have hzeroBase : f (p₀, x₀) = 0 := hzero.self_of_nhds
   have hgzero : ∀ᶠ y in nhds x₀, gc (p₀, y) = 0 := by
-    change ∀ᶠ y in nhds x₀, f (p₀, y) = 0
-    exact hzero
+    simpa only [gc, ContinuousMap.coe_mk] using hzero
   -- At the constant base solution the path derivative of the residual is the identity, so the
   -- implicit function theorem produces a smooth parameter-to-path germ.
   have hinvertible :

--- a/TauCeti/Dynamics/Flow/OfLipschitz.lean
+++ b/TauCeti/Dynamics/Flow/OfLipschitz.lean
@@ -52,10 +52,7 @@ noncomputable def flowOfLipschitz (v : E → E) {K : ℝ≥0} (hv : LipschitzWit
   toFun t x := ODE.globalSolution v hv x t
   cont' := ODE.continuous_globalSolution v hv
   map_add' t₁ t₂ x := by
-    have hγ : ∀ t : ℝ, HasDerivAt (fun t : ℝ ↦ ODE.globalSolution v hv x (t + t₂))
-        (v (ODE.globalSolution v hv x (t + t₂))) t :=
-      (ODE.isIntegralCurve_globalSolution v hv x).comp_add t₂
-    simpa using congrFun (ODE.eq_globalSolution v hv hγ) t₁
+    simpa [add_comm] using ODE.globalSolution_add v hv x t₂ t₁
   map_zero' x := ODE.globalSolution_zero v hv x
 
 @[simp]

--- a/TauCeti/Dynamics/Flow/OfLipschitz.lean
+++ b/TauCeti/Dynamics/Flow/OfLipschitz.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.ODE.Transform
 public import Mathlib.Dynamics.Flow
 public import TauCeti.Analysis.ODE.GlobalSolution
 


### PR DESCRIPTION
This PR proves that the solution of an autonomous ODE depends smoothly on its initial condition, jointly with time, near time `0`, and packages the consequence as a local flow for a vector field that is smooth only near a point. It serves the HopfRinow roadmap's Layer 1 milestone "Smooth dependence and the local geodesic flow", whose README records that the pinned ODE library supplies Picard–Lindelöf, Grönwall and local flows but that "the real gaps for this roadmap are `C^k` dependence on initial data and maximal intervals in the required form", and that smooth dependence "is a target, not a theorem available in the pinned ODE library". Mathlib's `Mathlib/Analysis/ODE/PicardLindelof.lean` gives only Lipschitz dependence on the initial condition (`exists_forall_closedBall_funSpace_dist_le_mul`), and `ODE.continuous_globalSolution` in `TauCeti/Analysis/ODE/GlobalSolution.lean` only joint continuity; the contraction argument behind both is metric and says nothing about derivatives.

`TauCeti/Analysis/ODE/InitialCondition.lean` (185 lines) rescales time to turn the initial condition into a parameter: writing a solution through `x` as `t ↦ x + u (t / ε)`, the curve `u` solves `u' s = ε • v (x + u s)` with `u 0 = 0` on the fixed interval `[0, 1]`, with `(x, ε)` a parameter and the initial state pinned at `0`. At `ε = 0` this field vanishes identically, which is exactly the degeneracy hypothesis of `ODE.exists_contDiffAt_picard_solution`, so that theorem produces a `C^(n+1)` family of paths in the Banach space `C(Icc 0 1, E)`; evaluation at the endpoint `s = 1` is a continuous linear map, and Grönwall's `dist_le_of_trajectories_ODE` identifies the resulting value `x + u 1` with `ODE.globalSolution v hv x ε`. Both the initial condition and the time are therefore smooth directions. The main results are `ODE.contDiffAt_globalSolution` (joint `C^(n+1)` smoothness at `(a, 0)` for a globally Lipschitz `C^(n+1)` field, `n` finite or infinite), `ODE.eventually_contDiffAt_globalSolution` (at every small time, the time-`t` map is `C^(n+1)` in the initial condition), and `ODE.exists_contDiffAt_localFlow` (the same for a field smooth on a neighbourhood of a point, with no global hypothesis, the equation being claimed only where the curves have not left that neighbourhood). The flow produced there is a genuine flow: `TauCeti/Analysis/ODE/GlobalSolution.lean` gains `ODE.globalSolution_add`, the flow law `globalSolution v hv x (t + s) = globalSolution v hv (globalSolution v hv x t) s`, obtained from uniqueness and Mathlib's `IsIntegralCurve.comp_add`, and `ODE.exists_contDiffAt_localFlow` carries `∀ x t u, Φ x (t + u) = Φ (Φ x t) u` as a conjunct.

To cut a merely local field down to a globally Lipschitz one, `TauCeti/Analysis/Calculus/BumpFunction/FiniteDimension.lean` gains 44 lines: its bump extension is restated from a neighbourhood hypothesis so that it also covers infinite order, records that the representative has compact support, and yields `ContDiffOn.exists_lipschitzWith_contDiff_eventuallyEq_of_finiteDimensional`, a globally smooth and globally Lipschitz representative of a germ of order at least one, via the bounded derivative of a compactly supported function. The single existing call site in `TauCeti/Analysis/ODE/SmoothParameter.lean` is updated.

What the milestone still owes after this PR: propagation of the smoothness from a neighbourhood of time `0` to all times, which needs the flow's semigroup law together with a compactness argument along a trajectory, and then the transfer of the local flow to a manifold and its application to the geodesic spray. No sorries, no new axioms.

Roadmap: HopfRinow

<!--tauceti-target:v1 {"focus":"HopfRinow","id":"smooth-dependence-on-initial-data"}-->

🤖 Prepared with Claude Code

