### PR TITLE
feat(Huber): the map into the Laurent quotient of a numerator enlargement

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
@@ -6,28 +6,40 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.RingTheory.Huber.LocalizationTopology.Restriction
+public import TauCeti.RingTheory.Huber.StronglyNoetherian
 public import TauCeti.RingTheory.Huber.WeightedEval.Quotient
 
+import TauCeti.RingTheory.Huber.ClosedSubmodule
+import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.PairOfDefinition
+import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.PowerBounded
+
 /-!
-# The Laurent quotient of a numerator enlargement, and its evaluation
+# The Laurent quotient of a numerator enlargement, and the maps between it and `A⟨T'/s⟩`
 
 Let `(T', s)` refine `(T, s)` by enlarging the numerators, and let `t ∈ T'`. Adjoining a variable
 `X` to `A⟨T/s⟩` and imposing the relation `X = t/s` gives `A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)`. This file
-constructs the canonical evaluation out of it, and shows it is the only continuous ring
-homomorphism of its kind:
+constructs the two canonical continuous ring homomorphisms between that quotient and `A⟨T'/s⟩`,
+each the only one of its kind:
 
 ```text
-A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)  →  A⟨T'/s⟩
+A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)  →  A⟨T'/s⟩          constants ↦ restriction,  X ↦ t/s
+A⟨T'/s⟩  →  A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)          compatibly with the structure maps from `A`
 ```
 
-sending constants to the restriction map and `X` to `t/s`. Nothing here needs `T'` to have a
-particular shape, which is what keeps `DecidableEq A` out of the statements.
+The first needs nothing of the shape of `T'`, which is what keeps `DecidableEq A` out of the
+statements. The second needs the numerators of `T'` to be exhausted by those of `T` together with
+`t`, since the fractions `u/s` for `u ∈ T'` must land in the power-bounded elements of the
+quotient; that is the hypothesis `hsplit`, again a splitting rather than `T' = insert t T`. It
+needs one hypothesis more, to make its target a legitimate one for the universal property of
+`A⟨T'/s⟩`: the relation ideal must be **closed**, which is what separates the quotient. A
+topologically nilpotent `s` over a strongly noetherian `A⟨T/s⟩` gives that, and the
+`..._of_isStronglyNoetherian` forms below take those two in its place.
 
-**What is not claimed.** This constructs a map in one direction; it does not identify the two
-rings. For `T' = insert t T` — the case Wedhorn's Remark 7.55 chains, one numerator at a time —
-Remark 7.55 does present `A⟨T'/s⟩` as exactly this quotient, and Proposition 8.30 consumes that
-identification; proving it is separate work. For a general enlargement no identification is even
-expected, since `T'` may adjoin numerators other than `t`.
+**What is not claimed.** The two maps are constructed; that they are mutually inverse is not
+proved here. For `T' = insert t T` — the case Wedhorn's Remark 7.55 chains, one numerator at a
+time — Remark 7.55 does present `A⟨T'/s⟩` as exactly this quotient, and Proposition 8.30 consumes
+that identification. For a general enlargement no identification is even expected, since `T'` may
+adjoin numerators other than `t`; `hsplit` is what rules that out.
 
 The restriction map itself, and the fact that it carries `t/s` to `t/s`, live one file earlier in
 `TauCeti.RingTheory.Huber.LocalizationTopology.Restriction`: they need only the
@@ -44,7 +56,21 @@ restriction/localisation theory, not the weighted-evaluation machinery imported 
 * `TauCeti.Huber.PairOfDefinition.laurentRelationIdeal_quotientMk_weightedC`: in the quotient,
   the constant `t/s` and the variable `X` agree. This is the relation the ideal imposes.
 * `TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_laurentQuotient_restriction`:
-  the map above, with its uniqueness.
+  the map out of the quotient, with its uniqueness; and
+  `TauCeti.Huber.PairOfDefinition.laurentQuotientRestrictionRingHom`, that map named, with
+  `TauCeti.Huber.PairOfDefinition.continuous_laurentQuotientRestrictionRingHom`, its two
+  evaluation lemmas and `TauCeti.Huber.PairOfDefinition.eq_laurentQuotientRestrictionRingHom`
+  as its interface.
+* `TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_completion_laurentQuotient`:
+  the map into it, with its uniqueness, for a closed relation ideal; the
+  `..._of_isStronglyNoetherian` variant takes the hypotheses in the form they are met in.
+* `TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom`: that map, named, with
+  `TauCeti.Huber.PairOfDefinition.continuous_laurentQuotientRingHom`,
+  `TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom_comp_toCompletionLoc` and
+  `TauCeti.Huber.PairOfDefinition.eq_laurentQuotientRingHom` as its interface.
+* `TauCeti.Huber.PairOfDefinition.isClosed_laurentRelationIdeal`: the relation ideal is closed
+  when `A⟨T/s⟩` is Tate and `A⟨T/s⟩⟨X⟩` is noetherian; the `..._of_isStronglyNoetherian` variant
+  takes a topologically nilpotent denominator over a strongly noetherian base instead.
 
 ## References
 
@@ -57,6 +83,8 @@ public section
 namespace TauCeti.Huber
 
 open TauCeti.Localization
+
+open scoped Uniformity
 
 namespace PairOfDefinition
 
@@ -108,6 +136,94 @@ theorem laurentRelationIdeal_quotientMk_weightedC :
   have _ := isHuberRing_locUniformSpace P T s S hden
   rw [← sub_eq_zero, ← map_sub, Ideal.Quotient.eq_zero_iff_mem, laurentRelationIdeal_def]
   exact Ideal.subset_span rfl
+
+/-- **The Laurent relation ideal is closed** when `A⟨T/s⟩` is Tate and `A⟨T/s⟩⟨X⟩` is
+noetherian: in a complete metrisable noetherian Tate ring every submodule is closed. Closedness
+is what the quotient needs to be separated, and hence a legitimate target for the universal
+property of a completion. -/
+theorem isClosed_laurentRelationIdeal
+    (hTate : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsTateRing (UniformSpace.Completion S))
+    (hnoeth : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsNoetherianRing (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight)) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight)) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  -- the types of `hTate` and `hnoeth` are `let`s, so they are instances only once re-elaborated
+  have _ := hTate
+  have _ := hnoeth
+  have _ : (𝓤 (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S)))
+        isWeightFamily_one_weight)).IsCountablyGenerated :=
+    IsUniformAddGroup.uniformity_countably_generated
+  exact isClosed_of_isNoetherian _
+
+/-- **The Laurent relation ideal is closed**, for a topologically nilpotent denominator over a
+strongly noetherian base. A topologically nilpotent `s` makes `A⟨T/s⟩` a Tate ring, and the
+`k = 1` component of strong noetherianity makes `A⟨T/s⟩⟨X⟩` noetherian. -/
+theorem isClosed_laurentRelationIdeal_of_isStronglyNoetherian
+    (hnil : IsTopologicallyNilpotent s)
+    (hSN : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsStronglyNoetherian (UniformSpace.Completion S)) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight)) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  have _ := hSN
+  exact isClosed_laurentRelationIdeal P T s t S hden
+    (isTateRing_completion_locTopology_of_isTopologicallyNilpotent P T s S hden hnil)
+    (isNoetherianRing_of_ringEquiv _
+      (restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)))
+
+-- Each fraction `u/s` allowed by the splitting is power-bounded in the Laurent quotient: an old
+-- numerator is already power-bounded in `A⟨T/s⟩`, and the new one `t` is the class of the
+-- variable, which is power-bounded because the weight is `{1}`.
+private theorem isPowerBounded_quotientMk_weightedC_fraction :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    ∀ (hs : IsUnit (toCompletionLoc P T s S hden s)) {u : A}, u ∈ T ∨ u = t →
+      IsPowerBounded (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+        (weightedC _ isWeightFamily_one_weight
+          (toCompletionLoc P T s S hden u * ↑hs.unit⁻¹))) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  rintro hs u (h | h)
+  · exact (isPowerBounded_weightedC (k := 1) isWeightFamily_one_weight
+      (isPowerBounded_toCompletionLoc_mul_unit_inv P T s S hden (mul_one s).symm hs
+        (by simpa using h))).map_of_isOpenMap continuous_quotient_mk'.continuousAt
+      (QuotientRing.isOpenMap_coe _)
+  · rw [h, toCompletionLoc_mul_unit_inv_eq_divBy P T s S hden t hs,
+      laurentRelationIdeal_quotientMk_weightedC P T s t S hden]
+    exact (isPowerBounded_weightedX (k := 1) isWeightFamily_one_weight
+      rfl).map_of_isOpenMap continuous_quotient_mk'.continuousAt
+      (QuotientRing.isOpenMap_coe _)
 
 section OneStep
 
@@ -177,6 +293,339 @@ theorem existsUnique_continuous_ringHom_laurentQuotient_restriction (ht : t ∈ 
     exact restrictionRingHomOfSubset_coe_divBy P T s S hden T' S' hden' hTT' t
   exact existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring
     isWeightFamily_one_weight hφ hb h𝔞
+
+/-- **The map out of the Laurent quotient**, `A⟨T/s⟩⟨X⟩ ⧸ (t/s - X) → A⟨T'/s⟩`.
+
+Its defining properties are
+`TauCeti.Huber.PairOfDefinition.continuous_laurentQuotientRestrictionRingHom`,
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRestrictionRingHom_quotientMk_weightedC` and
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRestrictionRingHom_quotientMk_weightedX`, and
+`TauCeti.Huber.PairOfDefinition.eq_laurentQuotientRestrictionRingHom` says they determine it.
+This is the companion of `TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom`, in the other
+direction. -/
+noncomputable def laurentQuotientRestrictionRingHom (ht : t ∈ T') :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden) →+* UniformSpace.Completion S' :=
+  (existsUnique_continuous_ringHom_laurentQuotient_restriction P T s t S hden T' S' hden'
+    hTT' ht).choose
+
+/-- The map out of the Laurent quotient is continuous. -/
+theorem continuous_laurentQuotientRestrictionRingHom (ht : t ∈ T') :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    Continuous (laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht) :=
+  (existsUnique_continuous_ringHom_laurentQuotient_restriction P T s t S hden T' S' hden'
+    hTT' ht).choose_spec.1.1
+
+/-- **On constants the map out of the Laurent quotient is the restriction map.** -/
+@[simp]
+theorem laurentQuotientRestrictionRingHom_quotientMk_weightedC (ht : t ∈ T')
+    (a : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      UniformSpace.Completion S) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht
+        (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+          (weightedC _ isWeightFamily_one_weight a))
+      = restrictionRingHomOfSubset P T s S hden T' S' hden' hTT' a :=
+  (existsUnique_continuous_ringHom_laurentQuotient_restriction P T s t S hden T' S' hden'
+    hTT' ht).choose_spec.1.2.1 a
+
+/-- **The variable goes to the fraction `t/s`.** -/
+@[simp]
+theorem laurentQuotientRestrictionRingHom_quotientMk_weightedX (ht : t ∈ T') (i : Fin 1) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht
+        (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+          (weightedX _ isWeightFamily_one_weight i))
+      = ((divBy t s : S') : UniformSpace.Completion S') :=
+  (existsUnique_continuous_ringHom_laurentQuotient_restriction P T s t S hden T' S' hden'
+    hTT' ht).choose_spec.1.2.2 i
+
+/-- **The three properties determine the map out of the Laurent quotient.** -/
+theorem eq_laurentQuotientRestrictionRingHom (ht : t ∈ T') :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    ∀ ψ : (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden) →+* UniformSpace.Completion S',
+      Continuous ψ →
+      (∀ a, ψ (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+          (weightedC _ isWeightFamily_one_weight a))
+        = restrictionRingHomOfSubset P T s S hden T' S' hden' hTT' a) →
+      (∀ i, ψ (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+          (weightedX _ isWeightFamily_one_weight i))
+        = ((divBy t s : S') : UniformSpace.Completion S')) →
+      ψ = laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
+  have _ := isHuberRing_locUniformSpace P T' s S' hden'
+  exact fun ψ hc hC hX ↦
+    (existsUnique_continuous_ringHom_laurentQuotient_restriction P T s t S hden T' S' hden'
+      hTT' ht).choose_spec.2 ψ ⟨hc, hC, hX⟩
+
+/-- **The forward map of the Laurent presentation.** If every numerator of `T'` either already
+lies in `T` or is the new one `t`, there is exactly one continuous ring homomorphism
+
+```text
+A⟨T'/s⟩  →  A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)
+```
+
+compatible with the two structure maps from `A`.
+
+Paired with
+`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_laurentQuotient_restriction`
+this gives the two maps of Wedhorn's Remark 7.55, which Proposition 8.30 uses to reduce flatness
+of a general restriction map to the elementary one. Only the maps are constructed; that they are
+mutually inverse is separate work.
+
+The hypothesis beyond the splitting is what makes the target legitimate for
+`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_completion_locTopology`: a closed
+relation ideal separates the quotient, and the quotient of a complete group by a closed subgroup
+is complete. `TauCeti.Huber.PairOfDefinition.isClosed_laurentRelationIdeal` supplies closedness
+when `A⟨T/s⟩` is Tate and `A⟨T/s⟩⟨X⟩` is noetherian. -/
+theorem existsUnique_continuous_ringHom_completion_laurentQuotient
+    (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    ∃! g : UniformSpace.Completion S' →+* (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+          laurentRelationIdeal P T s t S hden),
+      Continuous g ∧ g.comp (toCompletionLoc P T' s S' hden') =
+        ((Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)).comp
+          (weightedC _ isWeightFamily_one_weight)).comp (toCompletionLoc P T s S hden) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
+  have _ := isHuberRing_locUniformSpace P T' s S' hden'
+  -- the target is a complete Hausdorff Huber ring, which is what the universal property asks
+  have _ := IsHuberRing.quotient (laurentRelationIdeal P T s t S hden)
+  have _ : T1Space (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    (Ideal.Quotient.t1Space_iff _).mpr hcl
+  let _ : UniformSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    IsTopologicalAddGroup.rightUniformSpace _
+  have _ : IsUniformAddGroup (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    isUniformAddGroup_of_addCommGroup
+  have _ : CompleteSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    QuotientAddGroup.completeSpace_right _ (laurentRelationIdeal P T s t S hden).toAddSubgroup
+  set ψ := (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)).comp
+    (weightedC _ isWeightFamily_one_weight) with hψ
+  have hsC : IsUnit (toCompletionLoc P T s S hden s) :=
+    isUnit_toCompletionLoc_of_dvd P T s S hden dvd_rfl
+  have hcont : Continuous (ψ.comp (toCompletionLoc P T s S hden)) := by
+    rw [hψ]
+    exact continuous_quotient_mk'.comp ((continuous_weightedC isWeightFamily_one_weight).comp
+      (continuous_toCompletionLoc P T s S hden))
+  refine existsUnique_continuous_ringHom_completion_locTopology P T' s S' hden'
+    hcont.continuousAt (hsC.map ψ) fun u hu ↦ ?_
+  rw [RingHom.comp_apply, IsUnit.unit_inv_map ψ hsC, ← map_mul]
+  exact isPowerBounded_quotientMk_weightedC_fraction P T s t S hden hsC (hsplit u hu)
+
+/-- **The forward map for a topologically nilpotent denominator over a strongly noetherian base.**
+The hypotheses of
+`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_completion_laurentQuotient` in the
+form in which they are met in practice: `hnil` and `hSN` give the closedness of the relation ideal
+through `TauCeti.Huber.PairOfDefinition.isClosed_laurentRelationIdeal`. -/
+theorem existsUnique_continuous_ringHom_completion_laurentQuotient_of_isStronglyNoetherian
+    (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t) (hnil : IsTopologicallyNilpotent s)
+    (hSN : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsStronglyNoetherian (UniformSpace.Completion S)) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    ∃! g : UniformSpace.Completion S' →+* (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden),
+      Continuous g ∧ g.comp (toCompletionLoc P T' s S' hden') =
+        ((Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)).comp
+        (weightedC _ isWeightFamily_one_weight)).comp (toCompletionLoc P T s S hden) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
+  have _ := isHuberRing_locUniformSpace P T' s S' hden'
+  exact existsUnique_continuous_ringHom_completion_laurentQuotient P T s t S hden T' S' hden'
+    hsplit (isClosed_laurentRelationIdeal_of_isStronglyNoetherian P T s t S hden hnil hSN)
+
+/-- **The map into the Laurent quotient**, `A⟨T'/s⟩ → A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)`.
+
+Its two defining properties are
+`TauCeti.Huber.PairOfDefinition.continuous_laurentQuotientRingHom` and
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom_comp_toCompletionLoc`, and
+`TauCeti.Huber.PairOfDefinition.eq_laurentQuotientRingHom` says they determine it. Those three are
+the interface to use. -/
+noncomputable def laurentQuotientRingHom (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight)))
+    :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    UniformSpace.Completion S' →+* (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden) :=
+  (existsUnique_continuous_ringHom_completion_laurentQuotient P T s t S hden T' S' hden'
+    hsplit hcl).choose
+
+/-- The map into the Laurent quotient is continuous. -/
+theorem continuous_laurentQuotientRingHom (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight)))
+    :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    Continuous (laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl) :=
+  (existsUnique_continuous_ringHom_completion_laurentQuotient P T s t S hden T' S' hden'
+    hsplit hcl).choose_spec.1.1
+
+/-- **The map into the Laurent quotient is compatible with the structure maps from `A`.** This is
+the equation that characterises it. -/
+@[simp]
+theorem laurentQuotientRingHom_comp_toCompletionLoc (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight)))
+    :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    (laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl).comp
+        (toCompletionLoc P T' s S' hden') =
+      ((Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)).comp
+        (weightedC _ isWeightFamily_one_weight)).comp (toCompletionLoc P T s S hden) :=
+  (existsUnique_continuous_ringHom_completion_laurentQuotient P T s t S hden T' S' hden'
+    hsplit hcl).choose_spec.1.2
+
+/-- **The two properties determine the map into the Laurent quotient.** -/
+theorem eq_laurentQuotientRingHom (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight)))
+    :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    ∀ g : UniformSpace.Completion S' →+* (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden),
+      Continuous g → g.comp (toCompletionLoc P T' s S' hden') =
+          ((Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)).comp
+        (weightedC _ isWeightFamily_one_weight)).comp (toCompletionLoc P T s S hden) →
+        g = laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
+  have _ := isHuberRing_locUniformSpace P T' s S' hden'
+  exact fun g hgc hge ↦
+    (existsUnique_continuous_ringHom_completion_laurentQuotient P T s t S hden T' S' hden'
+      hsplit hcl).choose_spec.2 g ⟨hgc, hge⟩
 
 end OneStep
 


### PR DESCRIPTION
Wedhorn's Remark 7.55 presents `A⟨T'/s⟩` as `A⟨T/s⟩⟨X⟩ ⧸ (t/s − X)` when `T'` enlarges the
numerators by one element `t`. #5634 built the map out of that quotient. This PR builds the map
into it, so both maps of the presentation are on main:

```text
A⟨T/s⟩⟨X⟩ ⧸ (t/s − X)  →  A⟨T'/s⟩          #5634
A⟨T'/s⟩  →  A⟨T/s⟩⟨X⟩ ⧸ (t/s − X)          this PR
```

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-4.1-proposition-8.30-one-step-laurent-bridge"}-->

## What downstream roadmap item needs this

`TauCetiRoadmap/AdicSpaces/README.md`, Layer 4.1, numbered step 3, verbatim:

> 3. Proposition 8.30: prove that restriction maps between rational localisations are flat. Use
>    Remark 7.55 for the required chain of rational subsets.

Proposition 8.30 reduces flatness of a general restriction map to the elementary one-numerator
step, and it does so through the identification of `A⟨T'/s⟩` with the Laurent quotient. That
identification needs maps in both directions; only one existed. Steps 1–2 are on main, so this
does not run ahead of the roadmap's mandated ordering.

## The statement

```text
existsUnique_continuous_ringHom_completion_laurentQuotient
    (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t) (hcl : IsClosed (laurentRelationIdeal …)) :
  ∃! g : A⟨T'/s⟩ →+* A⟨T/s⟩⟨X⟩ ⧸ (t/s − X),
    Continuous g ∧ g.comp (toCompletionLoc …) = mk ∘ weightedC ∘ toCompletionLoc …

existsUnique_continuous_ringHom_completion_laurentQuotient_of_isStronglyNoetherian
    (hsplit …) (hnil : IsTopologicallyNilpotent s) (hSN : IsStronglyNoetherian A⟨T/s⟩) : …
```

Following the generality findings, closedness of the relation ideal — the one thing the
construction actually needs of the target — is the hypothesis, and `hnil`/`hSN` discharge it in a
corollary. Round 2 pushed the same split one level down: `isClosed_laurentRelationIdeal` now
assumes a noetherian Tate base, with `isClosed_laurentRelationIdeal_of_isStronglyNoetherian`
taking `hnil`/`hSN` in its place. Both are public — the closedness of the relation ideal is worth
having on its own.

Following the api-design finding, the map is also exposed by name, with the same three-lemma
interface `restrictionRingHom` has:

```text
laurentQuotientRingHom, continuous_laurentQuotientRingHom,
laurentQuotientRingHom_comp_toCompletionLoc  (@[simp]),  eq_laurentQuotientRingHom
```

The consumer that motivates it is real and immediate: proving the two Laurent maps mutually
inverse otherwise unpacks an `∃!` witness twice.

`hsplit` — every numerator of `T'` is an old one or is `t` — replaces `T' = insert t T`, for the
reason #5634 gives for its own hypotheses: it keeps `DecidableEq A` out of the statement. It is
also exactly what the mathematics needs, since the fractions `u/s` for `u ∈ T'` are what must be
power-bounded downstairs.

## Why the two extra hypotheses

The forward direction is the harder one, and not for its formula: the work is showing the
*target* is a legitimate one for the universal property of `A⟨T'/s⟩`
(`existsUnique_continuous_ringHom_completion_locTopology`), which asks for a complete, separated,
non-archimedean ring. `A⟨T/s⟩⟨X⟩ ⧸ (t/s − X)` is one, but only via:

* `hnil` makes `A⟨T/s⟩` a Tate ring
  (`isTateRing_completion_locTopology_of_isTopologicallyNilpotent`);
* `hSN` makes `A⟨T/s⟩⟨X⟩` noetherian, through
  `restrictedMvPowerSeriesCompletionEquiv 1` — the one-variable restricted series over `A⟨T/s⟩`
  *are* the completion appearing in the definition of strong noetherianity;
* a noetherian complete metrisable Tate ring has every submodule closed
  (`isClosed_of_isNoetherian`, #5610), so the relation ideal is closed;
* hence the quotient is `T1` (`Ideal.Quotient.t1Space_iff`) and, being a complete group modulo a
  closed subgroup, complete (`QuotientAddGroup.completeSpace_right`).

The countable generation that `isClosed_of_isNoetherian` needs comes from the Huber structure:
`IsHuberRing.isCountablyGenerated_nhds_zero` gives a countably generated `𝓝 0` — the powers of an
ideal of definition — and `IsUniformAddGroup.uniformity_countably_generated` carries that to `𝓤`.
That is the route `Huber/DenseSubmodule.lean:79` already takes.

## What is added

One public theorem and three private steps, each one fact:

| declaration | says |
|---|---|
| `isPowerBounded_quotientMk_laurentRelationIdeal` | power-boundedness passes to the quotient |
| `isClosed_laurentRelationIdeal` | the relation ideal is closed |
| `isPowerBounded_quotientMk_weightedC_fraction` | each allowed `u/s` is power-bounded downstairs |
| `existsUnique_continuous_ringHom_completion_laurentQuotient` | the map, with its uniqueness |

The third is where `hsplit` is used: an old numerator is power-bounded already in `A⟨T/s⟩`, and
`t/s` is the class of the variable `X`, power-bounded because the weight is `{1}`.

The module docstring is rewritten: it said "this constructs a map in one direction; it does not
identify the two rings", which is no longer what the file does.

## What is not claimed

That the two maps are mutually inverse. That is the identification itself, and it is separate
work; the docstring says so. For a general enlargement no identification is expected at all,
since `T'` may adjoin numerators other than `t` — `hsplit` is what rules that out.

## Checks

Imports were minimised by removal test: six were needed while writing, four survive
(`Complete` and `Topology.Algebra.Ring.Ideal` are reached transitively). `lake exe runLinter`
clean. The proof of the main theorem is 22 lines.

Nothing was adapted, so there is no `Provenance` line. The AINTLIB development at
`37bbdaeb9ad9` has no such construction: every file citing Remark 7.55 alongside a quotient is
sorried, and the one that is not — `projects/AdicSpaces/Adic spaces/FlatnessResults.lean:47` —
records that "the identification of presheaf values with Tate algebra quotients A⟨X⟩/(f-X) …
from TICKET-2B" is still outstanding there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1

## Round 2

Three findings, all implemented.

* **api-design** — `ClosedSubmodule` and `WeightedRestrictedSeries.PowerBounded` appear only in
  proofs and private helpers, so they are `import`, not `public import`. The exported interface is
  now only what the exported *types* mention.
* **generality** — `isClosed_laurentRelationIdeal` used strong noetherianity for its `k = 1`
  component alone; it now takes `IsTateRing` and `IsNoetherianRing (A⟨T/s⟩⟨X⟩)` directly.
* **documentation** — the module and theorem docstrings still described `hnil`/`hSN` as the
  general hypotheses after round 1 moved them into a corollary. Corrected to name closedness.

The branch is also rebased onto the `Laurent/` subdirectory this file moved into with #5688; git
resolved the modify-versus-rename on its own.

## Round 3

One finding: `WeightedRestrictedSeries.PairOfDefinition` was still a `public import` although no
exported declaration's type mentions it. Demoted, and the dependent `Laurent/Flat.lean` rebuilt to
check the re-export was not load-bearing.

That is the third proof-only dependency demoted, after `ClosedSubmodule` and
`WeightedRestrictedSeries.PowerBounded` in round 2 — I fixed the two that were named rather than
re-checking them all. For the record, the three that remain public are each named by an exported
type:

| import | exported type that needs it |
|---|---|
| `LocalizationTopology.Restriction` | `toCompletionLoc`, `restrictionRingHomOfSubset` |
| `StronglyNoetherian` | `IsStronglyNoetherian`, in the corollaries' hypotheses |
| `WeightedEval.Quotient` | `weightedRestrictedSubring`, `weightedC` |

## Round 4

api-design, on the asymmetry this PR created: the *inward* map now has a named interface while
the *outward* map (#5634, merged) was still only an `∃!`, so "downstream inverse proofs must still
unpack this witness". Correct, and it is the same consumer that motivated the inward interface.

Added `laurentQuotientRestrictionRingHom` with continuity, `[simp]` evaluation on constants and on
the variable, and uniqueness — the same four-declaration shape as the inward map and as
`restrictionRingHom`. The two maps of the presentation now have matching interfaces, which is what
the identification proof wants.

## Round 5

api-design green. One reuse finding: the private helper `isPowerBounded_quotientMk_laurentRelationIdeal`
only restated `IsPowerBounded.map_of_isOpenMap`. Deleted, and the generic lemma used directly at
both call sites — one declaration fewer, net −16 lines.

## Round 6

Nine green. One documentation finding, and a fair one: three places described
`isClosed_laurentRelationIdeal` as holding "over a noetherian Tate base", but its two hypotheses
are about two different rings — `A⟨T/s⟩` is Tate, `A⟨T/s⟩⟨X⟩` is noetherian. All three now say so.
