### PR TITLE
feat(ModularForms): a repeating family sums to a multiple of the slash sum

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
@@ -121,7 +121,7 @@ public section
 
 open Matrix UpperHalfPlane DoubleCoset HeckeRing.GLn
 
-open scoped MatrixGroups ModularForm
+open scoped MatrixGroups ModularForm Pointwise
 
 namespace HeckeRing.GL2
 
@@ -148,6 +148,40 @@ noncomputable def rightCosetRep (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin
 downstream module rewrites with this instead of unfolding the body. -/
 lemma rightCosetRep_def (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :
     rightCosetRep D v = (D.out : GL (Fin 2) ℚ) * ((v.out : GL (Fin 2) ℚ))⁻¹ := (rfl)
+
+/-- **Shimura's decomposition of the double coset**, in the `rightCosetRep` spelling:
+`Γ₁ δ Γ₂ = ⋃ᵥ Γ₁ (δ τᵥ⁻¹)`. Since `rightCosetRep` is not `@[expose]`, this is how a downstream
+module reads `DoubleCoset.doubleCoset_eq_iUnion_rightCosets` at the representatives the slash sum
+is defined with. -/
+lemma doubleCoset_eq_iUnion_rightCosetRep :
+    doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
+      ⋃ v, MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+  simpa only [rightCosetRep_def] using
+    doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
+
+/-- **The pieces of that decomposition are pairwise distinct**, in the same spelling:
+`DoubleCoset.op_mul_out_inv_smul_injective` read at `rightCosetRep`. -/
+lemma op_rightCosetRep_smul_injective :
+    Function.Injective fun v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹ ↦
+      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+  simpa only [rightCosetRep_def] using op_mul_out_inv_smul_injective Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
+
+/-- Each representative lies in the double coset, being a member of its own piece. -/
+lemma rightCosetRep_mem_doubleCoset (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :
+    rightCosetRep D v ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ := by
+  rw [doubleCoset_eq_iUnion_rightCosetRep D]
+  exact Set.mem_iUnion_of_mem v (mem_own_rightCoset Γ₁.toSubmonoid _)
+
+/-- Every member of the double coset shares its right coset with a chosen representative: it
+lies in one of the pieces, and two right cosets of `Γ₁` that meet are equal. -/
+lemma exists_rightCosetRep_smul_eq {x : GL (Fin 2) ℚ}
+    (hx : x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂) :
+    ∃ v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹,
+      MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+  rw [doubleCoset_eq_iUnion_rightCosetRep D] at hx
+  obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hx
+  exact ⟨v, (rightCoset_eq_iff Γ₁).mpr (by simpa using inv_mem ((mem_rightCoset_iff _).mp hv))⟩
 
 /-- Each representative lies in `posDetInt 2` when `δ` does and `Γ₂` does. Only `Γ₂` and the
 chosen `δ` are constrained: nothing is asked of `Γ₁`, and nothing of `Δ` beyond containing `δ`.

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -66,9 +66,11 @@ with it the ring homomorphism `𝕋 → Module.End` — is still **not** proved 
 counting ingredients now are. `DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity`
 reconciles the handedness, identifying the right-coset collision count with the multiplicity,
 and `DoubleCoset.card_pairs_mem_rightCoset_congr` supplies the uniformity: each right coset of
-a fixed `D` is met by the same number of pairs. What is still missing is the assembly —
-partitioning the pairs `(v, w)` according to the double coset their product lies in, for which
-the product set must be known to meet only finitely many double cosets.
+a fixed `D` is met by the same number of pairs, and `sum_slash_eq_nsmul_heckeSlashSum`
+(`HeckeSlash/Independence.lean`) turns that uniform count into the weighted operator, one double
+coset at a time. What is still missing is the assembly — partitioning the pairs `(v, w)`
+according to the double coset their product lies in, for which the product set must be known to
+meet only finitely many double cosets.
 
 ## Main results
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -66,11 +66,9 @@ with it the ring homomorphism `𝕋 → Module.End` — is still **not** proved 
 counting ingredients now are. `DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity`
 reconciles the handedness, identifying the right-coset collision count with the multiplicity,
 and `DoubleCoset.card_pairs_mem_rightCoset_congr` supplies the uniformity: each right coset of
-a fixed `D` is met by the same number of pairs, and `sum_slash_eq_nsmul_heckeSlashSum`
-(`HeckeSlash/Independence.lean`) turns that uniform count into the weighted operator, one double
-coset at a time. What is still missing is the assembly — partitioning the pairs `(v, w)`
-according to the double coset their product lies in, for which the product set must be known to
-meet only finitely many double cosets.
+a fixed `D` is met by the same number of pairs. What is still missing is the assembly —
+partitioning the pairs `(v, w)` according to the double coset their product lies in, for which
+the product set must be known to meet only finitely many double cosets.
 
 ## Main results
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
@@ -47,18 +47,13 @@ and the products `aᵢ bⱼ` landing in one double coset name each of its right 
 fixed number of times — Shimura's multiplicity, by
 `DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity` and
 `DoubleCoset.card_pairs_mem_rightCoset_congr`. So the last statement below trades injectivity for
-that uniform repetition count and concludes a multiple of the slash sum. It is the step the
-multiplicity-weighted composite `∑_D m(D₁, D₂; D) · T_D` — and with it the ring homomorphism from
-the abstract Hecke ring — has been missing.
+that uniform repetition count and concludes a multiple of the slash sum, which is the form each
+double coset contributes to the multiplicity-weighted composite `∑_D m(D₁, D₂; D) · T_D`.
 
 ## Main results
 
 * `HeckeRing.GL2.slash_eq_of_rightCoset_eq`: slashing a `Γ₁`-invariant function by `x` depends
   only on the right coset `Γ₁ x`.
-* `HeckeRing.GL2.rightCosetRep_mem_doubleCoset` and
-  `HeckeRing.GL2.exists_rightCosetRep_smul_eq`: the two membership facts Shimura's decomposition
-  yields — each chosen representative lies in the double coset, and every member of the double
-  coset shares its right coset with one of them.
 * `HeckeRing.GL2.heckeSlashSum_eq_sum_of_rightCosets`: **the choice-free description of the
   slash sum.** For `Γ₁`-invariant `f`, `heckeSlashSum k D f = ∑ᵢ f ∣[k] aᵢ` for any family
   `(aᵢ)` whose right cosets `Γ₁ aᵢ` are distinct and cover the double coset.
@@ -105,30 +100,6 @@ lemma slash_eq_of_rightCoset_eq {f : ℍ → ℂ} (hf : ∀ γ ∈ Γ₁, f ∣[
     _ = f ∣[k] (y * x⁻¹ * x) := (SlashAction.slash_mul k (y * x⁻¹) x f).symm
     _ = f ∣[k] y := by rw [inv_mul_cancel_right]
 
-/-- **Each chosen representative lies in the double coset**, being a member of its own piece. -/
-lemma rightCosetRep_mem_doubleCoset (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :
-    rightCosetRep D v ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ := by
-  rw [show doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
-      ⋃ w, MulOpposite.op (rightCosetRep D w) • (Γ₁ : Set (GL (Fin 2) ℚ)) by
-    simpa only [rightCosetRep_def] using
-      doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)]
-  exact Set.mem_iUnion_of_mem v (mem_own_rightCoset Γ₁.toSubmonoid _)
-
-/-- **Every member of the double coset shares its right coset with a chosen representative.**
-It lies in one of the pieces, and two right cosets of `Γ₁` that meet are equal. -/
-lemma exists_rightCosetRep_smul_eq {x : GL (Fin 2) ℚ}
-    (hx : x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂) :
-    ∃ v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹,
-      MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) =
-        MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
-  rw [show doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
-      ⋃ v, MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) by
-    simpa only [rightCosetRep_def] using
-      doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)] at hx
-  obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hx
-  exact ⟨v, (rightCoset_eq_iff Γ₁).mpr (by simpa using inv_mem ((mem_rightCoset_iff _).mp hv))⟩
-
-
 variable [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
 
 omit [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)] in
@@ -169,12 +140,9 @@ theorem exists_bijective_rightCosetRep_smul_eq {ι : Type*} (a : ι → GL (Fin 
   have hcoset : ∀ i j, φ i = φ j → MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
       MulOpposite.op (a j) • (Γ₁ : Set (GL (Fin 2) ℚ)) := fun i j hij ↦ by
     rw [hφ i, hφ j, hij]
-  have hinj' : Function.Injective fun v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹ ↦
-      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
-    simpa only [rightCosetRep_def] using op_mul_out_inv_smul_injective Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
   refine ⟨φ, ⟨fun i j hij ↦ hinj (hcoset i j hij), fun v ↦ ?_⟩, hφ⟩
   obtain ⟨i, hi⟩ := key' v
-  exact ⟨i, (hinj' (hi.trans (hφ i))).symm⟩
+  exact ⟨i, (op_rightCosetRep_smul_injective D (hi.trans (hφ i))).symm⟩
 
 /-- **The slash sum of a `Γ₁`-invariant function is the sum over any decomposition of the double
 coset into right cosets.** If the right cosets `Γ₁ aᵢ` are pairwise distinct and cover
@@ -223,16 +191,15 @@ coset of the double coset be named by exactly `m` members of the family: then th
 family is `m • heckeSlashSum k D f`.
 
 Covering is not a hypothesis. A right coset named by no member forces `m = 0`, and then both
-sides vanish; for `m ≠ 0` the family does cover, so nothing is lost by leaving it out — and the
-caller below is spared having to prove it.
+sides vanish; for `m ≠ 0` the family does cover, so nothing is lost by leaving it out and a user
+holding only a set of products need not prove it.
 
 This is the shape the composite of two slash sums arrives in. Grouping the products `aᵢ bⱼ` of
 `heckeSlashSum_heckeSlashSum_eq_sum_of_rightCosets` by the double coset they lie in, the group
 belonging to one double coset meets each of that coset's right cosets the same number of times
 (`DoubleCoset.card_pairs_mem_rightCoset_congr`), and that common count is Shimura's multiplicity
-(`DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity`) — so each group contributes a
-multiplicity-weighted slash sum, which is the missing step towards the ring homomorphism from the
-abstract Hecke ring. -/
+(`DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity`) — so each group contributes
+`m(D₁, D₂; D) • heckeSlashSum k D f`. -/
 theorem sum_slash_eq_nsmul_heckeSlashSum {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ) (m : ℕ)
     (hmem : ∀ i, a i ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂)
     (hcard : ∀ x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂,
@@ -243,9 +210,6 @@ theorem sum_slash_eq_nsmul_heckeSlashSum {ι : Type*} [Fintype ι] (a : ι → G
   classical
   let _ : Fintype (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) := Fintype.ofFinite _
   choose g hg using fun i ↦ exists_rightCosetRep_smul_eq D (hmem i)
-  have hinj : Function.Injective fun v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹ ↦
-      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
-    simpa only [rightCosetRep_def] using op_mul_out_inv_smul_injective Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
   rw [heckeSlashSum_def, Finset.smul_sum,
     ← Finset.sum_fiberwise_of_maps_to (fun i _ ↦ Finset.mem_univ (g i)) fun i ↦ f ∣[k] a i]
   refine Finset.sum_congr rfl fun v _ ↦ ?_
@@ -259,7 +223,7 @@ theorem sum_slash_eq_nsmul_heckeSlashSum {ι : Type*} [Fintype ι] (a : ι → G
       Finset.univ.filter fun i ↦ MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
         MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) :=
     Finset.filter_congr fun i _ ↦
-      ⟨fun h ↦ h ▸ hg i, fun h ↦ hinj ((hg i).symm.trans h)⟩
+      ⟨fun h ↦ h ▸ hg i, fun h ↦ op_rightCosetRep_smul_injective D ((hg i).symm.trans h)⟩
   have hm := hcard _ (rightCosetRep_mem_doubleCoset D v)
   rw [Nat.card_eq_fintype_card, Fintype.card_subtype] at hm
   rw [hfib, hm]

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
@@ -55,11 +55,10 @@ the abstract Hecke ring — has been missing.
 
 * `HeckeRing.GL2.slash_eq_of_rightCoset_eq`: slashing a `Γ₁`-invariant function by `x` depends
   only on the right coset `Γ₁ x`.
-* `HeckeRing.GL2.doubleCoset_eq_iUnion_rightCosetRep` and
-  `HeckeRing.GL2.op_rightCosetRep_smul_injective`: Shimura's decomposition and its distinctness,
-  in the `rightCosetRep` spelling the sum is written with, with
-  `HeckeRing.GL2.rightCosetRep_mem_doubleCoset` and
-  `HeckeRing.GL2.exists_rightCosetRep_smul_eq` the two membership facts they yield.
+* `HeckeRing.GL2.rightCosetRep_mem_doubleCoset` and
+  `HeckeRing.GL2.exists_rightCosetRep_smul_eq`: the two membership facts Shimura's decomposition
+  yields — each chosen representative lies in the double coset, and every member of the double
+  coset shares its right coset with one of them.
 * `HeckeRing.GL2.heckeSlashSum_eq_sum_of_rightCosets`: **the choice-free description of the
   slash sum.** For `Γ₁`-invariant `f`, `heckeSlashSum k D f = ∑ᵢ f ∣[k] aᵢ` for any family
   `(aᵢ)` whose right cosets `Γ₁ aᵢ` are distinct and cover the double coset.
@@ -106,26 +105,13 @@ lemma slash_eq_of_rightCoset_eq {f : ℍ → ℂ} (hf : ∀ γ ∈ Γ₁, f ∣[
     _ = f ∣[k] (y * x⁻¹ * x) := (SlashAction.slash_mul k (y * x⁻¹) x f).symm
     _ = f ∣[k] y := by rw [inv_mul_cancel_right]
 
-/-- **Shimura's decomposition of the double coset**, written with the representatives
-`heckeSlashSum` is defined with: `Γ₁ δ Γ₂ = ⋃ᵥ Γ₁ (δ τᵥ⁻¹)`. This is
-`DoubleCoset.doubleCoset_eq_iUnion_rightCosets` in the `rightCosetRep` spelling. -/
-lemma doubleCoset_eq_iUnion_rightCosetRep :
-    doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
-      ⋃ v, MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
-  simpa only [rightCosetRep_def] using
-    doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
-
-/-- **The pieces of that decomposition are pairwise distinct.** This is
-`DoubleCoset.op_mul_out_inv_smul_injective` in the `rightCosetRep` spelling. -/
-lemma op_rightCosetRep_smul_injective :
-    Function.Injective fun v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹ ↦
-      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
-  simpa only [rightCosetRep_def] using op_mul_out_inv_smul_injective Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
-
 /-- **Each chosen representative lies in the double coset**, being a member of its own piece. -/
 lemma rightCosetRep_mem_doubleCoset (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :
     rightCosetRep D v ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ := by
-  rw [doubleCoset_eq_iUnion_rightCosetRep D]
+  rw [show doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
+      ⋃ w, MulOpposite.op (rightCosetRep D w) • (Γ₁ : Set (GL (Fin 2) ℚ)) by
+    simpa only [rightCosetRep_def] using
+      doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)]
   exact Set.mem_iUnion_of_mem v (mem_own_rightCoset Γ₁.toSubmonoid _)
 
 /-- **Every member of the double coset shares its right coset with a chosen representative.**
@@ -135,7 +121,10 @@ lemma exists_rightCosetRep_smul_eq {x : GL (Fin 2) ℚ}
     ∃ v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹,
       MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) =
         MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
-  rw [doubleCoset_eq_iUnion_rightCosetRep D] at hx
+  rw [show doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
+      ⋃ v, MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) by
+    simpa only [rightCosetRep_def] using
+      doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)] at hx
   obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hx
   exact ⟨v, (rightCoset_eq_iff Γ₁).mpr (by simpa using inv_mem ((mem_rightCoset_iff _).mp hv))⟩
 
@@ -180,9 +169,12 @@ theorem exists_bijective_rightCosetRep_smul_eq {ι : Type*} (a : ι → GL (Fin 
   have hcoset : ∀ i j, φ i = φ j → MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
       MulOpposite.op (a j) • (Γ₁ : Set (GL (Fin 2) ℚ)) := fun i j hij ↦ by
     rw [hφ i, hφ j, hij]
+  have hinj' : Function.Injective fun v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹ ↦
+      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+    simpa only [rightCosetRep_def] using op_mul_out_inv_smul_injective Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
   refine ⟨φ, ⟨fun i j hij ↦ hinj (hcoset i j hij), fun v ↦ ?_⟩, hφ⟩
   obtain ⟨i, hi⟩ := key' v
-  exact ⟨i, (op_rightCosetRep_smul_injective D (hi.trans (hφ i))).symm⟩
+  exact ⟨i, (hinj' (hi.trans (hφ i))).symm⟩
 
 /-- **The slash sum of a `Γ₁`-invariant function is the sum over any decomposition of the double
 coset into right cosets.** If the right cosets `Γ₁ aᵢ` are pairwise distinct and cover
@@ -251,6 +243,9 @@ theorem sum_slash_eq_nsmul_heckeSlashSum {ι : Type*} [Fintype ι] (a : ι → G
   classical
   let _ : Fintype (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) := Fintype.ofFinite _
   choose g hg using fun i ↦ exists_rightCosetRep_smul_eq D (hmem i)
+  have hinj : Function.Injective fun v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹ ↦
+      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+    simpa only [rightCosetRep_def] using op_mul_out_inv_smul_injective Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
   rw [heckeSlashSum_def, Finset.smul_sum,
     ← Finset.sum_fiberwise_of_maps_to (fun i _ ↦ Finset.mem_univ (g i)) fun i ↦ f ∣[k] a i]
   refine Finset.sum_congr rfl fun v _ ↦ ?_
@@ -264,7 +259,7 @@ theorem sum_slash_eq_nsmul_heckeSlashSum {ι : Type*} [Fintype ι] (a : ι → G
       Finset.univ.filter fun i ↦ MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
         MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) :=
     Finset.filter_congr fun i _ ↦
-      ⟨fun h ↦ h ▸ hg i, fun h ↦ op_rightCosetRep_smul_injective D ((hg i).symm.trans h)⟩
+      ⟨fun h ↦ h ▸ hg i, fun h ↦ hinj ((hg i).symm.trans h)⟩
   have hm := hcard _ (rightCosetRep_mem_doubleCoset D v)
   rw [Nat.card_eq_fintype_card, Fintype.card_subtype] at hm
   rw [hfib, hm]

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
@@ -38,15 +38,36 @@ depends on no choice, since `DoubleCoset.doubleCoset_eq_of_mem` gives the same s
 `δ` in it, and `heckeSlashSum_eq_sum_of_mem_doubleCoset` is the resulting statement that any
 such `δ` may be used to form the sum.
 
+## Repetition, and where it comes from
+
+`heckeSlashSum_eq_sum_of_rightCosets` asks its family to name each right coset exactly once. The
+composite of two slash sums does not: `heckeSlashSum_heckeSlashSum_eq_sum_of_rightCosets`
+(`HeckeSlash/Composition.lean`) presents that composite as a sum over *pairs* of representatives,
+and the products `aᵢ bⱼ` landing in one double coset name each of its right cosets not once but a
+fixed number of times — Shimura's multiplicity, by
+`DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity` and
+`DoubleCoset.card_pairs_mem_rightCoset_congr`. So the last statement below trades injectivity for
+that uniform repetition count and concludes a multiple of the slash sum. It is the step the
+multiplicity-weighted composite `∑_D m(D₁, D₂; D) · T_D` — and with it the ring homomorphism from
+the abstract Hecke ring — has been missing.
+
 ## Main results
 
 * `HeckeRing.GL2.slash_eq_of_rightCoset_eq`: slashing a `Γ₁`-invariant function by `x` depends
   only on the right coset `Γ₁ x`.
+* `HeckeRing.GL2.doubleCoset_eq_iUnion_rightCosetRep` and
+  `HeckeRing.GL2.op_rightCosetRep_smul_injective`: Shimura's decomposition and its distinctness,
+  in the `rightCosetRep` spelling the sum is written with, with
+  `HeckeRing.GL2.rightCosetRep_mem_doubleCoset` and
+  `HeckeRing.GL2.exists_rightCosetRep_smul_eq` the two membership facts they yield.
 * `HeckeRing.GL2.heckeSlashSum_eq_sum_of_rightCosets`: **the choice-free description of the
   slash sum.** For `Γ₁`-invariant `f`, `heckeSlashSum k D f = ∑ᵢ f ∣[k] aᵢ` for any family
   `(aᵢ)` whose right cosets `Γ₁ aᵢ` are distinct and cover the double coset.
 * `HeckeRing.GL2.heckeSlashSum_eq_sum_of_mem_doubleCoset`: the special case that fixes the
   choice of double-coset representative only: any `δ ∈ Γ₁ D.out Γ₂` gives the same sum.
+* `HeckeRing.GL2.sum_slash_eq_nsmul_heckeSlashSum`: **the weighted collapse.** A family naming
+  each right coset of the double coset exactly `m` times — repetitions allowed, covering not
+  assumed — sums to `m • heckeSlashSum k D f`.
 * `HeckeRing.GL2.heckeSlashSum_coe_eq_sum_of_rightCosets`: the same description for a form of
   level `G.map (mapGL ℝ)`, whose slash-invariance discharges the hypothesis `hf`. It is what
   `HeckeSlash/ModularForm.lean` reads off the two exported endomorphisms with, in
@@ -85,6 +106,40 @@ lemma slash_eq_of_rightCoset_eq {f : ℍ → ℂ} (hf : ∀ γ ∈ Γ₁, f ∣[
     _ = f ∣[k] (y * x⁻¹ * x) := (SlashAction.slash_mul k (y * x⁻¹) x f).symm
     _ = f ∣[k] y := by rw [inv_mul_cancel_right]
 
+/-- **Shimura's decomposition of the double coset**, written with the representatives
+`heckeSlashSum` is defined with: `Γ₁ δ Γ₂ = ⋃ᵥ Γ₁ (δ τᵥ⁻¹)`. This is
+`DoubleCoset.doubleCoset_eq_iUnion_rightCosets` in the `rightCosetRep` spelling. -/
+lemma doubleCoset_eq_iUnion_rightCosetRep :
+    doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
+      ⋃ v, MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+  simpa only [rightCosetRep_def] using
+    doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
+
+/-- **The pieces of that decomposition are pairwise distinct.** This is
+`DoubleCoset.op_mul_out_inv_smul_injective` in the `rightCosetRep` spelling. -/
+lemma op_rightCosetRep_smul_injective :
+    Function.Injective fun v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹ ↦
+      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+  simpa only [rightCosetRep_def] using op_mul_out_inv_smul_injective Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
+
+/-- **Each chosen representative lies in the double coset**, being a member of its own piece. -/
+lemma rightCosetRep_mem_doubleCoset (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :
+    rightCosetRep D v ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ := by
+  rw [doubleCoset_eq_iUnion_rightCosetRep D]
+  exact Set.mem_iUnion_of_mem v (mem_own_rightCoset Γ₁.toSubmonoid _)
+
+/-- **Every member of the double coset shares its right coset with a chosen representative.**
+It lies in one of the pieces, and two right cosets of `Γ₁` that meet are equal. -/
+lemma exists_rightCosetRep_smul_eq {x : GL (Fin 2) ℚ}
+    (hx : x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂) :
+    ∃ v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹,
+      MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+  rw [doubleCoset_eq_iUnion_rightCosetRep D] at hx
+  obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hx
+  exact ⟨v, (rightCoset_eq_iff Γ₁).mpr (by simpa using inv_mem ((mem_rightCoset_iff _).mp hv))⟩
+
+
 variable [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
 
 omit [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)] in
@@ -106,54 +161,28 @@ theorem exists_bijective_rightCosetRep_smul_eq {ι : Type*} (a : ι → GL (Fin 
       ∀ i, MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
         MulOpposite.op (rightCosetRep D (φ i)) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
   classical
-  -- Shimura's decomposition, written with the representatives `heckeSlashSum` uses.
-  have hcover' : doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
-      ⋃ v, MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
-    simpa only [rightCosetRep_def] using
-      doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
-  have hinj' : Function.Injective fun v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹ ↦
-      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
-    simpa only [rightCosetRep_def] using
-      op_mul_out_inv_smul_injective Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
   -- Mathlib's own lemma; stated for a submonoid, so `Γ₁` is passed through `toSubmonoid`.
   have hself : ∀ x : GL (Fin 2) ℚ, x ∈ MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) := fun x ↦
     mem_own_rightCoset Γ₁.toSubmonoid x
-  -- Two right cosets of `Γ₁` that meet are equal, so each family's cosets occur in the other.
-  have hmatch : ∀ x y : GL (Fin 2) ℚ, x ∈ MulOpposite.op y • (Γ₁ : Set (GL (Fin 2) ℚ)) →
-      MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) =
-        MulOpposite.op y • (Γ₁ : Set (GL (Fin 2) ℚ)) := fun x y hxy ↦
-    (rightCoset_eq_iff Γ₁).mpr (by simpa using inv_mem ((mem_rightCoset_iff y).mp hxy))
-  have key : ∀ i, ∃ v, MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
-      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
-    intro i
-    have hmem : a i ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ := by
-      rw [hcover]; exact Set.mem_iUnion_of_mem i (hself (a i))
-    rw [hcover'] at hmem
-    obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hmem
-    exact ⟨v, hmatch _ _ hv⟩
+  -- Each family's cosets occur in the other: every `aᵢ` lies in the double coset, and every
+  -- chosen representative lies in some `Γ₁ aᵢ`, two right cosets that meet being equal.
+  choose φ hφ using fun i ↦ exists_rightCosetRep_smul_eq D
+    (hcover ▸ Set.mem_iUnion_of_mem i (hself (a i)))
   have key' : ∀ v, ∃ i, MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
       MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
     intro v
-    have hmem : rightCosetRep D v ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ := by
-      rw [hcover']; exact Set.mem_iUnion_of_mem v (hself (rightCosetRep D v))
+    have hmem := rightCosetRep_mem_doubleCoset D v
     rw [hcover] at hmem
     obtain ⟨i, hi⟩ := Set.mem_iUnion.mp hmem
-    exact ⟨i, hmatch _ _ hi⟩
-  -- The two enumerations are matched by `φ`, and matched cosets have equal slashes.
-  obtain ⟨φ, hφ⟩ : ∃ φ : ι → DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹, ∀ i,
-      MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
-        MulOpposite.op (rightCosetRep D (φ i)) • (Γ₁ : Set (GL (Fin 2) ℚ)) :=
-    ⟨fun i ↦ (key i).choose, fun i ↦ (key i).choose_spec⟩
+    exact ⟨i, (rightCoset_eq_iff Γ₁).mpr (by simpa using inv_mem ((mem_rightCoset_iff _).mp hi))⟩
   -- Indices with the same image under `φ` name the same coset of the family `(aᵢ)`, which `hinj`
   -- then identifies; stated separately so that `hinj` is applied to this equality itself.
   have hcoset : ∀ i j, φ i = φ j → MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
       MulOpposite.op (a j) • (Γ₁ : Set (GL (Fin 2) ℚ)) := fun i j hij ↦ by
     rw [hφ i, hφ j, hij]
-  have hbij : Function.Bijective φ := by
-    refine ⟨fun i j hij ↦ hinj (hcoset i j hij), fun v ↦ ?_⟩
-    obtain ⟨i, hi⟩ := key' v
-    exact ⟨i, (hinj' (hi.trans (hφ i))).symm⟩
-  exact ⟨φ, hbij, hφ⟩
+  refine ⟨φ, ⟨fun i j hij ↦ hinj (hcoset i j hij), fun v ↦ ?_⟩, hφ⟩
+  obtain ⟨i, hi⟩ := key' v
+  exact ⟨i, (op_rightCosetRep_smul_injective D (hi.trans (hφ i))).symm⟩
 
 /-- **The slash sum of a `Γ₁`-invariant function is the sum over any decomposition of the double
 coset into right cosets.** If the right cosets `Γ₁ aᵢ` are pairwise distinct and cover
@@ -195,6 +224,50 @@ theorem heckeSlashSum_eq_sum_of_mem_doubleCoset {δ : GL (Fin 2) ℚ}
     (op_mul_out_inv_smul_injective Γ₁ Γ₂ δ) f hf
   rw [← doubleCoset_eq_of_mem hδ]
   exact doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ δ
+
+/-- **A family naming each right coset the same number of times sums to a multiple of the slash
+sum.** In place of the injectivity of `heckeSlashSum_eq_sum_of_rightCosets`, ask that every right
+coset of the double coset be named by exactly `m` members of the family: then the sum over the
+family is `m • heckeSlashSum k D f`.
+
+Covering is not a hypothesis. A right coset named by no member forces `m = 0`, and then both
+sides vanish; for `m ≠ 0` the family does cover, so nothing is lost by leaving it out — and the
+caller below is spared having to prove it.
+
+This is the shape the composite of two slash sums arrives in. Grouping the products `aᵢ bⱼ` of
+`heckeSlashSum_heckeSlashSum_eq_sum_of_rightCosets` by the double coset they lie in, the group
+belonging to one double coset meets each of that coset's right cosets the same number of times
+(`DoubleCoset.card_pairs_mem_rightCoset_congr`), and that common count is Shimura's multiplicity
+(`DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity`) — so each group contributes a
+multiplicity-weighted slash sum, which is the missing step towards the ring homomorphism from the
+abstract Hecke ring. -/
+theorem sum_slash_eq_nsmul_heckeSlashSum {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ) (m : ℕ)
+    (hmem : ∀ i, a i ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂)
+    (hcard : ∀ x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂,
+      Nat.card {i // MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))} = m)
+    (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
+    ∑ i, f ∣[k] a i = m • heckeSlashSum k D f := by
+  classical
+  let _ : Fintype (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) := Fintype.ofFinite _
+  choose g hg using fun i ↦ exists_rightCosetRep_smul_eq D (hmem i)
+  rw [heckeSlashSum_def, Finset.smul_sum,
+    ← Finset.sum_fiberwise_of_maps_to (fun i _ ↦ Finset.mem_univ (g i)) fun i ↦ f ∣[k] a i]
+  refine Finset.sum_congr rfl fun v _ ↦ ?_
+  -- On the fibre of `v` every term is the slash by `v`'s representative, so the fibre
+  -- contributes its cardinality times that one value.
+  rw [Finset.sum_congr rfl fun i hi ↦
+      slash_eq_of_rightCoset_eq k hf ((Finset.mem_filter.mp hi).2 ▸ hg i), Finset.sum_const]
+  -- That cardinality is `m`: the fibre of `v` is the set of indices naming `v`'s right coset,
+  -- since `g i` and `v` name the same coset exactly when they are equal.
+  have hfib : (Finset.univ.filter fun i ↦ g i = v) =
+      Finset.univ.filter fun i ↦ MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) :=
+    Finset.filter_congr fun i _ ↦
+      ⟨fun h ↦ h ▸ hg i, fun h ↦ op_rightCosetRep_smul_injective D ((hg i).symm.trans h)⟩
+  have hm := hcard _ (rightCosetRep_mem_doubleCoset D v)
+  rw [Nat.card_eq_fintype_card, Fintype.card_subtype] at hm
+  rw [hfib, hm]
 
 section Form
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
@@ -62,6 +62,8 @@ double coset contributes to the multiplicity-weighted composite `∑_D m(D₁, D
 * `HeckeRing.GL2.sum_slash_eq_nsmul_heckeSlashSum`: **the weighted collapse.** A family naming
   each right coset of the double coset exactly `m` times — repetitions allowed, covering not
   assumed — sums to `m • heckeSlashSum k D f`.
+* `HeckeRing.GL2.sum_slash_coe_eq_nsmul_heckeSlashSum`: the weighted collapse for a form,
+  whose slash-invariance discharges `hf`.
 * `HeckeRing.GL2.heckeSlashSum_coe_eq_sum_of_rightCosets`: the same description for a form of
   level `G.map (mapGL ℝ)`, whose slash-invariance discharges the hypothesis `hf`. It is what
   `HeckeSlash/ModularForm.lean` reads off the two exported endomorphisms with, in
@@ -251,6 +253,25 @@ theorem heckeSlashSum_coe_eq_sum_of_rightCosets {ι : Type*} [Fintype ι] (a : �
       MulOpposite.op (a i) • (G.map (mapGL ℚ) : Set (GL (Fin 2) ℚ)))
     (f : F) : heckeSlashSum k D ⇑f = ∑ i, ⇑f ∣[k] a i :=
   heckeSlashSum_eq_sum_of_rightCosets k D a hcover hinj ⇑f fun _ hγ ↦
+    ModularForm.slash_eq_of_mem_map_mapGL
+      (fun γ' hγ' ↦ SlashInvariantFormClass.slash_action_eq f γ' hγ') hγ
+
+/-- **The weighted collapse for a form of level `G.map (mapGL ℝ)`.** This is
+`sum_slash_eq_nsmul_heckeSlashSum` with the hypothesis `hf` discharged, exactly as
+`heckeSlashSum_coe_eq_sum_of_rightCosets` discharges it for the unweighted statement: a form of
+that level is slash-invariant under `G.map (mapGL ℚ)` by `ModularForm.slash_eq_of_mem_map_mapGL`.
+
+`F` is any type of slash-invariant forms, so this covers `SlashInvariantForm`, `ModularForm` and
+`CuspForm` at once, and a consumer working on a character space need not rebuild the invariance
+bridge. -/
+theorem sum_slash_coe_eq_nsmul_heckeSlashSum {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ)
+    (m : ℕ)
+    (hmem : ∀ i, a i ∈ doubleCoset (D.out : GL (Fin 2) ℚ) (G.map (mapGL ℚ)) (G.map (mapGL ℚ)))
+    (hcard : ∀ x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) (G.map (mapGL ℚ)) (G.map (mapGL ℚ)),
+      Nat.card {i // MulOpposite.op (a i) • (G.map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op x • (G.map (mapGL ℚ) : Set (GL (Fin 2) ℚ))} = m)
+    (f : F) : ∑ i, ⇑f ∣[k] a i = m • heckeSlashSum k D ⇑f :=
+  sum_slash_eq_nsmul_heckeSlashSum k D a m hmem hcard ⇑f fun _ hγ ↦
     ModularForm.slash_eq_of_mem_map_mapGL
       (fun γ' hγ' ↦ SlashInvariantFormClass.slash_action_eq f γ' hγ') hγ
 


### PR DESCRIPTION
`heckeSlashSum_eq_sum_of_rightCosets` evaluates the slash sum on a family naming each right coset
of the double coset exactly once. The composite of two slash sums does not arrive in that shape:
`heckeSlashSum_heckeSlashSum_eq_sum_of_rightCosets` presents it as a sum over *pairs* of
representatives, and the products landing in one double coset name each of its right cosets a
fixed number of times, not once. This states the sum in that shape.

```lean
theorem sum_slash_eq_nsmul_heckeSlashSum {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ) (m : ℕ)
    (hmem : ∀ i, a i ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂)
    (hcard : ∀ x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂,
      Nat.card {i // MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
        MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))} = m)
    (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
    ∑ i, f ∣[k] a i = m • heckeSlashSum k D f
```

Covering is deliberately not a hypothesis. A right coset named by no member of the family forces
`m = 0`, and then both sides vanish; for `m ≠ 0` the family does cover. So nothing is lost by
leaving it out, and the caller — which will hold a set of *products*, not a decomposition — is
spared having to prove it.

## What this closes

`HeckeSlash/Composition.lean` says of the multiplicity-weighted composite:

> The general multiplicity-weighted statement — the composite as `∑_D m(D₁, D₂; D) · T_D`, and
> with it the ring homomorphism `𝕋 → Module.End` — is still **not** proved here, but its two
> counting ingredients now are. […] What is still missing is the assembly — partitioning the
> pairs `(v, w)` according to the double coset their product lies in […]

This is the per-fibre half of that assembly. Once the pairs are partitioned, each part is a
family of exactly the shape above, and its repetition count is Shimura's multiplicity by the two
counting ingredients already on main (`DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity`
and `DoubleCoset.card_pairs_mem_rightCoset_congr`) — so each part contributes
`m(D₁, D₂; D) • T_D`. The note above is updated to record it as the third ingredient; the
partition itself remains open, and is what a follow-up will do.

With `LinearMap.map_mul_of_basis` (#5659, merged) that partition is then the whole remaining
distance to the ModularForms frontier item *"prove that the linear extension of the Γ₀(N) Hecke
ring acts multiplicatively on each nebentypus space"*: the linear extension is multiplicative as
soon as it is multiplicative on basis elements, and `single D₁ 1 * single D₂ 1` is by definition
the multiplicity-weighted `structureConstants`.

## Also: four named lemmas, and a shorter proof

The file was doing its coset bookkeeping inline, in the middle of
`exists_bijective_rightCosetRep_smul_eq`. The facts it needed are the same ones the new theorem
needs, so they are named rather than repeated:

* `doubleCoset_eq_iUnion_rightCosetRep` and `op_rightCosetRep_smul_injective` — Shimura's
  decomposition and its distinctness, in the `rightCosetRep` spelling `heckeSlashSum` is written
  with, rather than the `δ * v.out⁻¹` spelling `DoubleCoset` states them in;
* `rightCosetRep_mem_doubleCoset` and `exists_rightCosetRep_smul_eq` — the two membership facts
  they yield.

`exists_bijective_rightCosetRep_smul_eq`'s proof drops from 49 lines to 23 as a result, and the
`hcover'`/`hinj'`/`hself`/`hmatch` block it opened with is gone.

Roadmap: ModularForms

New mathematics, so the citation: this supplies a prerequisite for the Layer 2 target of
`TauCetiRoadmap/ModularForms/README.md` — the Hecke-ring action on the nebentypus character
spaces, `heckeRingHomCharSpace` in its Layer 2(b) sketch — and does not author it, since the
partition it reduces to is still open. No `tauceti-target` marker for that reason.

Provenance: none. [AINTLIB](https://github.com/CBirkbeck/AINTLIB) @
`2baa76f742bdb4fb8ee323fabba41203bd390e08` does carry an assembly of this kind, but only as a
chain of `private` lemmas specific to `Gamma0_pair N`, twisted by the nebentypus, and indexed by
the *left*-coset `decompQuot` (`twistedHeckeSlashGen_fiber_sum` and its neighbours,
`LeanModularForms/HeckeRIngs/GL2/Unified/TwistedHeckeRing.lean:601-801`); the statement here is
untwisted, at a general Hecke triple, and right-coset indexed as this repository's `heckeSlashSum`
is, so no code is transcribed. Mathlib has no slash sum, so nothing of this shape can exist
upstream; the `Finset` primitives it is built from (`sum_fiberwise_of_maps_to`, `sum_const`,
`filter_congr`) are used as they stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
