### PR TITLE
feat(EllipticCurves): the regulator as the Gram determinant on the free quotient

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/Regulator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/Regulator.lean
@@ -61,9 +61,10 @@ private theorem neronTateGramMatrix_eq_toMatrix₂Aux [W.toAffine.IsElliptic] {�
   simp
 
 /-- A change of basis acts on the Gram matrix of the Néron-Tate pairing by congruence, along the
-integer change-of-basis matrix. -/
-theorem neronTateGramMatrix_basis_change [W.toAffine.IsElliptic] {ι : Type*} [Fintype ι]
-    (b b' : Module.Basis ι ℤ (PointModTorsion W)) :
+integer change-of-basis matrix. The two bases need not share an index type: the change-of-basis
+matrix is then rectangular, and the congruence still typechecks. -/
+theorem neronTateGramMatrix_basis_change [W.toAffine.IsElliptic] {ι ι' : Type*} [Fintype ι]
+    (b : Module.Basis ι ℤ (PointModTorsion W)) (b' : Module.Basis ι' ℤ (PointModTorsion W)) :
     neronTateGramMatrix W b' = ((b.toMatrix b').map Int.cast)ᵀ * neronTateGramMatrix W b *
       ((b.toMatrix b').map Int.cast) := by
   simp only [neronTateGramMatrix_eq_toMatrix₂Aux]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/Regulator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/Regulator.lean
@@ -6,7 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.PointModTorsion
-public import TauCeti.LinearAlgebra.BilinearMap.GramCongruence
+-- The Gram-congruence lemmas are used only inside the proofs below, so the import is private:
+-- nothing in this module's exported statements mentions `toMatrix₂Aux`.
+import TauCeti.LinearAlgebra.BilinearMap.GramCongruence
 
 /-!
 # The regulator of an elliptic curve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/Regulator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/Regulator.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.PointModTorsion
+public import TauCeti.LinearAlgebra.BilinearMap.GramCongruence
+
+/-!
+# The regulator of an elliptic curve
+
+The regulator is the absolute value of the determinant of the Néron-Tate pairing's Gram matrix
+on a basis of the points modulo torsion. It does not depend on the basis chosen: a change of
+basis transforms the Gram matrix by congruence, `G' = Mᵀ G M`, along an integer matrix `M` of
+determinant `±1`.
+
+## Main definitions
+
+* `WeierstrassCurve.Affine.regulator`: the regulator of a curve whose points modulo torsion are
+  finitely generated as a `ℤ`-module.
+
+## Main results
+
+* `WeierstrassCurve.Affine.neronTateGramMatrix_basis_change`: a change of basis acts on the
+  Gram matrix by congruence.
+* `WeierstrassCurve.Affine.abs_det_neronTateGramMatrix_basis_change`: the absolute determinant is
+  independent of the basis, including of its index type.
+* `WeierstrassCurve.Affine.regulator_eq_abs_det_neronTateGramMatrix`: the regulator is computed
+  by any basis whatsoever.
+* `WeierstrassCurve.Affine.regulator_eq_one_of_finrank_eq_zero`: the rank-zero convention.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], VIII.9, where the canonical
+  height and its associated pairing are constructed; the regulator is the determinant of that
+  pairing's Gram matrix on a basis of the free quotient.
+-/
+
+public section
+
+open Height Matrix
+
+namespace WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] {W : Affine F} [AdmissibleAbsValues F] [DecidableEq F]
+
+-- `neronTateGramMatrix` is defined as exactly this `toMatrix₂Aux`, but its body is not exposed
+-- across the module boundary, so the identification is not `rfl` here: it goes through the
+-- public entrywise characterisation `neronTateGramMatrix_apply`.
+private theorem neronTateGramMatrix_eq_toMatrix₂Aux [W.toAffine.IsElliptic] {ι : Type*}
+    (b : Module.Basis ι ℤ (PointModTorsion W)) :
+    neronTateGramMatrix W b =
+      LinearMap.toMatrix₂Aux ℤ (b : ι → PointModTorsion W) (b : ι → PointModTorsion W)
+        (neronTatePairingModTorsion W) := by
+  ext i j
+  simp
+
+/-- A change of basis acts on the Gram matrix of the Néron-Tate pairing by congruence, along the
+integer change-of-basis matrix. -/
+theorem neronTateGramMatrix_basis_change [W.toAffine.IsElliptic] {ι : Type*} [Fintype ι]
+    (b b' : Module.Basis ι ℤ (PointModTorsion W)) :
+    neronTateGramMatrix W b' = ((b.toMatrix b').map Int.cast)ᵀ * neronTateGramMatrix W b *
+      ((b.toMatrix b').map Int.cast) := by
+  simp only [neronTateGramMatrix_eq_toMatrix₂Aux]
+  simpa [algebraMap_int_eq] using
+    (LinearMap.toMatrix₂Aux_mul_map_basis_toMatrix (neronTatePairingModTorsion W) b b b' b').symm
+
+/-- The absolute determinant of the Gram matrix does not depend on the basis, nor on its index
+type. -/
+theorem abs_det_neronTateGramMatrix_basis_change [W.toAffine.IsElliptic] {ι ι' : Type*}
+    [Fintype ι] [DecidableEq ι] [Fintype ι'] [DecidableEq ι']
+    (b : Module.Basis ι ℤ (PointModTorsion W)) (b' : Module.Basis ι' ℤ (PointModTorsion W)) :
+    |(neronTateGramMatrix W b').det| = |(neronTateGramMatrix W b).det| := by
+  simp only [neronTateGramMatrix_eq_toMatrix₂Aux]
+  exact congrArg abs
+    (LinearMap.det_toMatrix₂Aux_eq_det_toMatrix₂Aux (neronTatePairingModTorsion W) b b')
+
+variable (W)
+
+/-- **The regulator** of an elliptic curve whose points modulo torsion are finitely generated as a
+`ℤ`-module: the absolute determinant of the Gram matrix of the Néron-Tate pairing on any basis of
+that quotient. For a curve of rank zero this is the empty determinant, namely `1`. -/
+noncomputable def regulator [W.toAffine.IsElliptic] [Module.Finite ℤ (PointModTorsion W)] : ℝ :=
+  |(neronTateGramMatrix W (Module.finBasis ℤ (PointModTorsion W))).det|
+
+/-- The regulator is computed by any basis of the points modulo torsion. -/
+theorem regulator_eq_abs_det_neronTateGramMatrix [W.toAffine.IsElliptic]
+    [Module.Finite ℤ (PointModTorsion W)] {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (b : Module.Basis ι ℤ (PointModTorsion W)) :
+    regulator W = |(neronTateGramMatrix W b).det| :=
+  abs_det_neronTateGramMatrix_basis_change b _
+
+/-- **The rank-zero convention.** A curve whose points modulo torsion have rank zero has
+regulator `1`, the determinant of the empty matrix. -/
+@[simp]
+theorem regulator_eq_one_of_finrank_eq_zero [W.toAffine.IsElliptic]
+    [Module.Finite ℤ (PointModTorsion W)] (h : Module.finrank ℤ (PointModTorsion W) = 0) :
+    regulator W = 1 := by
+  have : IsEmpty (Fin (Module.finrank ℤ (PointModTorsion W))) := by rw [h]; infer_instance
+  rw [regulator_eq_abs_det_neronTateGramMatrix W (Module.finBasis ℤ (PointModTorsion W)),
+    Matrix.det_isEmpty, abs_one]
+
+/-- The regulator is non-negative. -/
+theorem regulator_nonneg [W.toAffine.IsElliptic] [Module.Finite ℤ (PointModTorsion W)] :
+    0 ≤ regulator W :=
+  abs_nonneg _
+
+end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/Regulator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/Regulator.lean
@@ -15,8 +15,10 @@ import TauCeti.LinearAlgebra.BilinearMap.GramCongruence
 
 The regulator is the absolute value of the determinant of the Néron-Tate pairing's Gram matrix
 on a basis of the points modulo torsion. It does not depend on the basis chosen: a change of
-basis transforms the Gram matrix by congruence, `G' = Mᵀ G M`, along an integer matrix `M` of
-determinant `±1`.
+basis transforms the Gram matrix by congruence, `G' = Mᵀ G M`, along the integer change-of-basis
+matrix `M`. The two bases need not be indexed by the same type, in which case `M` is rectangular
+and has no determinant; the absolute determinant is invariant all the same, because the index
+types of two bases of the same module are equivalent.
 
 ## Main definitions
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/Regulator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/Regulator.lean
@@ -32,6 +32,7 @@ determinant `±1`.
 * `WeierstrassCurve.Affine.regulator_eq_abs_det_neronTateGramMatrix`: the regulator is computed
   by any basis whatsoever.
 * `WeierstrassCurve.Affine.regulator_eq_one_of_finrank_eq_zero`: the rank-zero convention.
+* `WeierstrassCurve.Affine.regulator_nonneg`: the regulator is non-negative.
 
 ## References
 


### PR DESCRIPTION
The regulator of an elliptic curve: the absolute determinant of the Gram matrix of the
Néron–Tate pairing on a basis of the points modulo torsion, together with the basis
independence that makes it well defined and the rank-zero convention `Reg = 1`.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"regulator"}-->

This completes the canonical-height strand of Layer 6. `EllipticCurves/README.md` names the
target: "the **regulator** as the Gram determinant on a basis of the free quotient with basis
independence, and the rank-zero convention `Reg = 1`", and `STATUS.md`'s frontier entry reads
"**The canonical height.** Construct the Néron–Tate height and pairing from the finished
naïve-height theory, including vanishing exactly on torsion, isogeny compatibility and the
regulator." The pairing landed in #5660, its descent to the free quotient and the Gram matrix
in #5678, and the basis-change algebra in #5686; this is the determinant on top of those.

### What is added

* `neronTateGramMatrix_basis_change` — a change of basis acts on the Gram matrix by congruence,
  `G' = Mᵀ * G * M` along the integer change-of-basis matrix `M`.
* `abs_det_neronTateGramMatrix_basis_change` — the absolute determinant is independent of the
  basis, **including of its index type**, which is what the definition below needs.
* `regulator` — the invariant itself. Its hypothesis is `[Module.Finite ℤ (PointModTorsion W)]`,
  on the quotient, rather than `[AddGroup.FG W.Point]` on the points: that is what the
  definition actually consumes, and it is strictly weaker. A caller holding finite generation of
  the points still gets it by `inferInstance` — checked by compiling such a caller.
* `regulator_eq_abs_det_neronTateGramMatrix` — the regulator is computed by *any* basis. This is
  the lemma consumers apply, and it is not a convenience: `regulator` is a `def` in a
  `public section` without `@[expose]`, so its body does not cross the module boundary and a
  consumer cannot unfold it. The same probe that checked the instance above also checked that a
  downstream caller can evaluate the regulator through this lemma alone.
* `regulator_eq_one_of_finrank_eq_zero` — the rank-zero convention, the empty determinant.
* `regulator_nonneg`.

### Both basis-change results are specialisations, not new algebra

Neither congruence lemma is proved here. Both are instances of the general statements #5686 put
in `TauCeti/LinearAlgebra/BilinearMap/GramCongruence.lean`:

* `neronTateGramMatrix_basis_change` is `LinearMap.toMatrix₂Aux_mul_map_basis_toMatrix` with
  `algebraMap ℤ ℝ` normalised to `Int.cast`;
* `abs_det_neronTateGramMatrix_basis_change` is `congrArg abs` applied to
  `LinearMap.det_toMatrix₂Aux_eq_det_toMatrix₂Aux` — the index-type transport along
  `Module.Basis.indexEquiv` and the `Matrix.det_submatrix_equiv_self` permutation discharge both
  live in that merged lemma, not here.

The split happened because a `generality` finding on the first draft of this file observed that
those two lemmas used no elliptic-curve property whatsoever, only that the pairing is `ℤ`-bilinear
with values outside `ℤ`. That is the structural point: the Néron–Tate pairing is a
`LinearMap.BilinMap ℤ (PointModTorsion W) ℝ`, bilinear over `ℤ` but **valued in `ℝ`**, so its
target is not its scalar ring, and mathlib's basis-change congruence for bilinear forms
(`LinearMap.toMatrix₂_mul_basis_toMatrix`) is unavailable — not incidentally but structurally,
since it multiplies matrices that would have to live in different rings. The same wall rules out
`LinearMap.IsSymm` and `BilinForm.toMatrixAux` for this pairing.

What remains here is one private bridge, `neronTateGramMatrix_eq_toMatrix₂Aux`. `neronTateGramMatrix`
is *defined* in #5678 as exactly the `toMatrix₂Aux` in question, but that definition is likewise
unexposed, so the identification is not `rfl` across the module boundary — the compiler says so
explicitly ("definitions were not unfolded because their definition is not exposed"). The bridge
therefore goes through the public entrywise characterisation `neronTateGramMatrix_apply`.

### Why `0 < regulator` is *not* here

The classical statement is that the regulator is positive, and #5678 supplies the pairing's
positive definiteness on the quotient (`neronTatePairingModTorsion_self_eq_zero_iff`). That is
deliberately not enough, and claiming positivity from it would be wrong: positive definiteness
*on the lattice* does not by itself make the Gram determinant nonzero — that needs the form to be
positive definite on the real span `PointModTorsion W ⊗ ℝ`, a strictly stronger fact resting on
the Northcott property rather than on the lattice inequality. So this PR states
`regulator_nonneg`, which is exactly what `|det|` gives for free, and leaves positivity to the
separate development that earns it. Mathlib's
`Matrix.det_gram_ne_zero_iff_linearIndependent` does not close the gap either: like the rest of
`Analysis/InnerProductSpace/GramMatrix.lean` it needs `Inner 𝕜 E` and `[RCLike 𝕜]`.

### Provenance

Original work; no source ported. Recorded absence checks:

* `github.com/MichaelStollBayreuth/EllipticCurves` @ `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`
  — greps `regulator`, `neronTateGramMatrix`, `gram_matrix`, `heightPairing`, `height_pairing`:
  no hits; no canonical height at all. (The chain's intake already records that the Néron–Tate
  strand has no upstream source and is developed from the roadmap.)
* `github.com/CBirkbeck/FLT` — greps `regulator`, `neronTateGramMatrix`, `heightPairing`,
  `neronTate`: no hits.
* Mathlib @ `03616a12cdf1e3f499349f69e80eee82b28745bc` — every `regulator` in mathlib is
  `NumberField.Units.regulator`, the covolume of the unit lattice, a different invariant.
  Mathlib *does* have a Gram-matrix file, `Analysis/InnerProductSpace/GramMatrix.lean`
  (`Matrix.gram`, `submatrix_gram`, `gram_eq_conjTranspose_mul`,
  `det_gram_ne_zero_iff_linearIndependent`), but it is confined to inner-product spaces: `gram`
  needs `Inner 𝕜 E` and every substantive result needs `[RCLike 𝕜]`. `PointModTorsion W` is a
  finitely generated free `ℤ`-module with no `Inner` instance, and `RCLike ℤ` is false, so none
  of that API applies to this pairing.

The rank-zero convention agrees with mathlib's number-field regulator, whose `regulator_eq_det'`
degenerates the same way at unit rank zero.
