### PR TITLE
feat: reduce Lie-Kolchin to the derived subgroup

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
@@ -10,6 +10,8 @@ public import TauCeti.Algebra.AlgebraicGroup.Solvable.Trigonalizable
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
 public import TauCeti.RepresentationTheory.Unipotent.DerivedEigenvector
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.Reduced
+import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Naturality
+import TauCeti.Algebra.Coalgebra.Comodule.Transport
 import TauCeti.Algebra.Coalgebra.Subcomodule.PointSeparation
 
 /-!
@@ -62,16 +64,82 @@ namespace TauCeti
 
 open CategoryTheory WithConv
 
-universe u
+universe u v w
 
 noncomputable section
 
 namespace Comodule
 
-variable {k H M : Type u}
+variable {k : Type u} {H : Type v} {M : Type w}
 variable [Field k] [IsAlgClosed k] [CommRing H] [HopfAlgebra k H]
 variable [Algebra.FiniteType k H] [IsReduced H]
 variable [AddCommGroup M] [Module k M] [Comodule k H M]
+
+private theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived_aux
+    {V : Type u} [AddCommGroup V] [Module k V] [Comodule k H V]
+    [FiniteDimensional k V] [Nontrivial V]
+    (hderived : ∀ g : WithConv
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
+        (CommHopfAlgCat.derivedDefiningIdeal (R := k) H) →ₐ[k] k),
+      HopfAlgebra.IsUnipotentPoint g) :
+    HasNonzeroWeightVector k H V := by
+  let A := _root_.CommHopfAlgCat.of k H
+  let I := CommHopfAlgCat.derivedDefiningIdeal (R := k) H
+  let Q := CommHopfAlgCat.quotient A I
+  let q : H →ₐc[k] Q := (CommHopfAlgCat.mkQuotient A I).hom
+  let G := HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)
+  let N := CommHopfAlgCat.quotientPointsSubgroup A I (CommAlgCat.of k k)
+  let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal A I
+    (CommHopfAlgCat.isNormal_derivedDefiningIdeal A) (CommAlgCat.of k k)
+  let rho : _root_.Representation k G (k ⊗[k] V) :=
+    pointsRepresentation (R := k) (H := H) (A := k) V
+  have hcomm : _root_.commutator G ≤ N :=
+    CommHopfAlgCat.commutator_le_quotientPointsSubgroup_of_le_derivedDefiningIdeal
+      A I le_rfl (CommAlgCat.of k k)
+  have hunipotent (n : N) : IsNilpotent (rho n - 1) := by
+    obtain ⟨g, hg⟩ := n.2
+    have hg' : HopfAlgebra.IsUnipotentPoint (AlgHom.mapDomain q g) :=
+      (hderived g).mapDomain q
+    have hnil :=
+      (HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one
+        (AlgHom.mapDomain q g)).mp hg'
+        (FGComoduleCat.of (R := k) (C := H) V)
+    have hinclude : CommHopfAlgCat.quotientPointsHom A I (CommAlgCat.of k k) g =
+        AlgHom.mapDomain q g := by
+      rw [CommHopfAlgCat.quotientPointsHom_apply, AlgHom.mapDomain_apply]
+    have hn : (n : G) = AlgHom.mapDomain q g := hg.symm.trans hinclude
+    rw [show rho n = endOfPoint V (n : G).ofConv by
+      exact pointsRepresentation_apply V (n : G), hn]
+    exact hnil
+  obtain ⟨χ, w, hw, haction⟩ :=
+    rho.exists_unitHom_jointEigenvector_of_commutator_le_of_isUnipotent N hcomm hunipotent
+  let e := TensorProduct.lid k V
+  let v := e w
+  have hv : v ≠ 0 := e.map_ne_zero_iff.mpr hw
+  have hv' : (1 : k) ⊗ₜ[k] v = w := by
+    exact (TensorProduct.lid_symm_apply (R := k) v).symm.trans (e.symm_apply_apply w)
+  have haction' (g : WithConv (H →ₐ[k] k)) :
+      basePointsRepresentation (R := k) (H := H) V g v = (χ g : k) • v := by
+    rw [basePointsRepresentation_apply, hv']
+    have hg := haction g
+    rw [show rho g = endOfPoint V g.ofConv by exact pointsRepresentation_apply V g] at hg
+    rw [hg, map_smul]
+  let p : Submodule k V := k ∙ v
+  have hact (g : WithConv (H →ₐ[k] k)) {m : V} (hm : m ∈ p) :
+      basePointsRepresentation (R := k) (H := H) V g m ∈ p := by
+    rw [Submodule.mem_span_singleton] at hm
+    obtain ⟨a, rfl⟩ := hm
+    rw [map_smul, haction' g]
+    exact p.smul_mem _ (p.smul_mem _ (Submodule.mem_span_singleton_self v))
+  have hstable : ∀ (g : H →ₐ[k] k) {m : V}, m ∈ p →
+      endOfPoint V g (1 ⊗ₜ[k] m) ∈ p.baseChange k := by
+    intro g m hm
+    rw [endOfPoint_tmul, one_smul,
+      endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation]
+    exact Submodule.tmul_mem_baseChange_of_mem _ (hact (toConv g) hm)
+  exact hasNonzeroWeightVector_of_toSubmodule_eq_span
+    (Subcomodule.ofEndOfPointStable (K := k) p hstable) hv
+    (Subcomodule.ofEndOfPointStable_toSubmodule (K := k) p hstable)
 
 /-- If every point of the derived closed subgroup acts unipotently, then every nonzero
 finite-dimensional representation has a nonzero weight vector.
@@ -87,76 +155,33 @@ theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived
         (CommHopfAlgCat.derivedDefiningIdeal (R := k) H) →ₐ[k] k),
       HopfAlgebra.IsUnipotentPoint g) :
     HasNonzeroWeightVector k H M := by
-  let A := _root_.CommHopfAlgCat.of k H
-  let I := CommHopfAlgCat.derivedDefiningIdeal (R := k) H
-  let Q := CommHopfAlgCat.quotient A I
-  let q : H →ₐc[k] Q := (CommHopfAlgCat.mkQuotient A I).hom
-  let G := HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)
-  let N := CommHopfAlgCat.quotientPointsSubgroup A I (CommAlgCat.of k k)
-  let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal A I
-    (CommHopfAlgCat.isNormal_derivedDefiningIdeal A) (CommAlgCat.of k k)
-  let rho : _root_.Representation k G (k ⊗[k] M) :=
-    pointsRepresentation (R := k) (H := H) (A := k) M
-  have hcomm : _root_.commutator G ≤ N :=
-    CommHopfAlgCat.commutator_le_quotientPointsSubgroup_of_le_derivedDefiningIdeal
-      A I le_rfl (CommAlgCat.of k k)
-  have hunipotent (n : N) : IsNilpotent (rho n - 1) := by
-    obtain ⟨g, hg⟩ := n.2
-    have hg' : HopfAlgebra.IsUnipotentPoint (AlgHom.mapDomain q g) :=
-      (hderived g).mapDomain q
-    have hnil :=
-      (HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one
-        (AlgHom.mapDomain q g)).mp hg'
-        (FGComoduleCat.of (R := k) (C := H) M)
-    have hn : (n : G) = AlgHom.mapDomain q g :=
-      hg.symm.trans <| by rfl
-    change IsNilpotent
-      (pointsRepresentation (R := k) (H := H) (A := k) M n - 1)
-    rw [pointsRepresentation_apply, hn]
-    exact hnil
-  obtain ⟨χ, w, hw, haction⟩ :=
-    rho.exists_unitHom_jointEigenvector_of_commutator_le_of_isUnipotent N hcomm hunipotent
-  let e := TensorProduct.lid k M
-  let v := e w
-  have hv : v ≠ 0 := e.map_ne_zero_iff.mpr hw
-  have hv' : (1 : k) ⊗ₜ[k] v = w := by
-    exact (TensorProduct.lid_symm_apply (R := k) v).symm.trans (e.symm_apply_apply w)
-  have haction' (g : WithConv (H →ₐ[k] k)) :
-      basePointsRepresentation (R := k) (H := H) M g v = (χ g : k) • v := by
-    rw [basePointsRepresentation_apply, hv']
-    have hg := haction g
-    change pointsRepresentation (R := k) (H := H) (A := k) M g w = _ at hg
-    rw [pointsRepresentation_apply] at hg
-    rw [hg, map_smul]
-  let p : Submodule k M := k ∙ v
-  have hact (g : WithConv (H →ₐ[k] k)) {m : M} (hm : m ∈ p) :
-      basePointsRepresentation (R := k) (H := H) M g m ∈ p := by
-    rw [Submodule.mem_span_singleton] at hm
-    obtain ⟨a, rfl⟩ := hm
-    rw [map_smul, haction' g]
-    exact p.smul_mem _ (p.smul_mem _ (Submodule.mem_span_singleton_self v))
-  have hstable : ∀ (g : H →ₐ[k] k) {m : M}, m ∈ p →
-      endOfPoint M g (1 ⊗ₜ[k] m) ∈ p.baseChange k := by
-    intro g m hm
-    rw [endOfPoint_tmul, one_smul,
-      endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation]
-    exact Submodule.tmul_mem_baseChange_of_mem _ (hact (toConv g) hm)
-  exact hasNonzeroWeightVector_of_toSubmodule_eq_span
-    (Subcomodule.ofEndOfPointStable (K := k) p hstable) hv
-    (Subcomodule.ofEndOfPointStable_toSubmodule (K := k) p hstable)
+  let e : M ≃ₗ[k] (Fin (Module.finrank k M) → k) := (Module.finBasis k M).equivFun
+  let _ : Comodule k H (Fin (Module.finrank k M) → k) := Comodule.Transport e
+  let _ : Nontrivial (Fin (Module.finrank k M) → k) := e.symm.toEquiv.nontrivial
+  have hweight : HasNonzeroWeightVector k H (Fin (Module.finrank k M) → k) :=
+    hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived_aux hderived
+  obtain ⟨v, c, hv, hc, hvc⟩ := (hasNonzeroWeightVector_iff (k := k) (C := H)).mp hweight
+  refine (hasNonzeroWeightVector_iff (k := k) (C := H)).mpr
+    ⟨e.symm v, c, e.symm.map_ne_zero_iff.mpr hv, hc, ?_⟩
+  have hmap := (Comodule.transportInvHom (R := k) (C := H) e).map_coact_apply v
+  rw [hvc] at hmap
+  simpa only [Comodule.transportInvHom_apply, Comodule.transportInvHom_toLinearMap,
+    LinearEquiv.coe_coe, TensorProduct.map_tmul, LinearMap.id_apply] using hmap.symm
 
-/-- If the reduced derived closed subgroup is geometrically unipotent, then every nonzero
+/-- If the derived closed subgroup is geometrically unipotent, then every nonzero
 finite-dimensional representation has a nonzero weight vector. -/
 theorem hasNonzeroWeightVector_of_geometricallyUnipotent_derived
     [FiniteDimensional k M] [Nontrivial M]
-    [IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
-      (CommHopfAlgCat.derivedDefiningIdeal (R := k) H))]
     (hderived : geometricallyUnipotentPointsCommHopfAlgProperty k
       (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
         (CommHopfAlgCat.derivedDefiningIdeal (R := k) H))) :
-    HasNonzeroWeightVector k H M :=
-  hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived fun g ↦
-    geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint hderived g
+    HasNonzeroWeightVector k H M := by
+  apply hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived
+  intro g
+  let φ : k →ₐ[k] AlgebraicClosure k := _root_.Algebra.ofId k (AlgebraicClosure k)
+  have hgeom := (geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mp hderived
+  exact (HopfAlgebra.isUnipotentPoint_mapValue_iff_of_injective g φ φ.injective).mp
+    (hgeom (AlgHom.mapValue φ g))
 
 /-- **Lie--Kolchin under unipotence of the derived subgroup.** If every point of the derived
 closed subgroup of a reduced finite-type affine group over an algebraically closed field is
@@ -175,14 +200,12 @@ theorem exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPo
     fun V _ _ _ _ _ ↦
       hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived (M := V) hderived
 
-/-- **Geometric Lie--Kolchin reduction.** If the reduced derived closed subgroup of a reduced
+/-- **Geometric Lie--Kolchin reduction.** If the derived closed subgroup of a reduced
 finite-type affine group over an algebraically closed field is geometrically unipotent, then every
 finite-dimensional representation admits an upper-triangular basis with characters on the
 diagonal. -/
 theorem exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_derived
     [FiniteDimensional k M]
-    [IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
-      (CommHopfAlgCat.derivedDefiningIdeal (R := k) H))]
     (hderived : geometricallyUnipotentPointsCommHopfAlgProperty k
       (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
         (CommHopfAlgCat.derivedDefiningIdeal (R := k) H))) :

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
@@ -1,0 +1,200 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Derived.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Trigonalizable
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+public import TauCeti.RepresentationTheory.Unipotent.DerivedEigenvector
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.Reduced
+import TauCeti.Algebra.Coalgebra.Subcomodule.PointSeparation
+
+/-!
+# Lie--Kolchin reduction to the derived subgroup
+
+Let `H` be the coordinate Hopf algebra of a reduced affine group of finite type over an
+algebraically closed field. This file proves the representation-theoretic reduction at the heart
+of Lie--Kolchin: if the derived closed subgroup has only unipotent points, then every nonzero
+finite-dimensional `H`-comodule has a weight vector, and every finite-dimensional comodule is
+upper triangularizable.
+
+The abstract argument applies to a representation `ρ` and a normal subgroup `N` containing the
+commutator subgroup. Kolchin gives a nonzero vector fixed by `N`. The whole group preserves the
+space of `N`-fixed vectors, and its action there factors through the commutative quotient `G/N`.
+Simultaneous triangularization of commuting operators then gives a common eigenvector. For an
+affine group, take `N` to be the points of the scheme-theoretic derived subgroup. Point
+separation promotes the resulting point-stable eigenline to a one-dimensional subcomodule.
+
+The remaining geometric step in the general Lie--Kolchin theorem is to prove that the derived
+subgroup of a connected solvable affine group is unipotent.
+
+## Main declarations
+
+* `TauCeti.Comodule.hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived`: unipotence of the
+  derived subgroup supplies a weight vector in every nonzero finite-dimensional comodule.
+* `TauCeti.Comodule.hasNonzeroWeightVector_of_geometricallyUnipotent_derived`: the same conclusion
+  phrased using the geometric-unipotence object property.
+* `TauCeti.Comodule.
+    exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPoint_derived`:
+  the resulting Lie--Kolchin upper-triangular basis.
+* `TauCeti.Comodule.
+    exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_derived`:
+  the geometric-unipotence formulation of that basis theorem.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, Theorem 6.3.1.
+* A. Borel, *Linear Algebraic Groups*, Section 10.5.
+
+This advances the "Lie--Kolchin; solvable groups" milestone in Layer 5 of the ReductiveGroups
+roadmap.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+open CategoryTheory WithConv
+
+universe u
+
+noncomputable section
+
+namespace Comodule
+
+variable {k H M : Type u}
+variable [Field k] [IsAlgClosed k] [CommRing H] [HopfAlgebra k H]
+variable [Algebra.FiniteType k H] [IsReduced H]
+variable [AddCommGroup M] [Module k M] [Comodule k H M]
+
+/-- If every point of the derived closed subgroup acts unipotently, then every nonzero
+finite-dimensional representation has a nonzero weight vector.
+
+This is the representation-theoretic reduction in Lie--Kolchin. The hypothesis concerns the
+coordinate algebra `H / derivedDefiningIdeal H` of the scheme-theoretic derived subgroup, not
+merely the abstract commutator subgroup of `H(k)`.
+-/
+theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived
+    [FiniteDimensional k M] [Nontrivial M]
+    (hderived : ∀ g : WithConv
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
+        (CommHopfAlgCat.derivedDefiningIdeal (R := k) H) →ₐ[k] k),
+      HopfAlgebra.IsUnipotentPoint g) :
+    HasNonzeroWeightVector k H M := by
+  let A := _root_.CommHopfAlgCat.of k H
+  let I := CommHopfAlgCat.derivedDefiningIdeal (R := k) H
+  let Q := CommHopfAlgCat.quotient A I
+  let q : H →ₐc[k] Q := (CommHopfAlgCat.mkQuotient A I).hom
+  let G := HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)
+  let N := CommHopfAlgCat.quotientPointsSubgroup A I (CommAlgCat.of k k)
+  let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal A I
+    (CommHopfAlgCat.isNormal_derivedDefiningIdeal A) (CommAlgCat.of k k)
+  let rho : _root_.Representation k G (k ⊗[k] M) :=
+    pointsRepresentation (R := k) (H := H) (A := k) M
+  have hcomm : _root_.commutator G ≤ N :=
+    CommHopfAlgCat.commutator_le_quotientPointsSubgroup_of_le_derivedDefiningIdeal
+      A I le_rfl (CommAlgCat.of k k)
+  have hunipotent (n : N) : IsNilpotent (rho n - 1) := by
+    obtain ⟨g, hg⟩ := n.2
+    have hg' : HopfAlgebra.IsUnipotentPoint (AlgHom.mapDomain q g) :=
+      (hderived g).mapDomain q
+    have hnil :=
+      (HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one
+        (AlgHom.mapDomain q g)).mp hg'
+        (FGComoduleCat.of (R := k) (C := H) M)
+    have hn : (n : G) = AlgHom.mapDomain q g :=
+      hg.symm.trans <| by rfl
+    change IsNilpotent
+      (pointsRepresentation (R := k) (H := H) (A := k) M n - 1)
+    rw [pointsRepresentation_apply, hn]
+    exact hnil
+  obtain ⟨χ, w, hw, haction⟩ :=
+    rho.exists_unitHom_jointEigenvector_of_commutator_le_of_isUnipotent N hcomm hunipotent
+  let e := TensorProduct.lid k M
+  let v := e w
+  have hv : v ≠ 0 := e.map_ne_zero_iff.mpr hw
+  have hv' : (1 : k) ⊗ₜ[k] v = w := by
+    exact (TensorProduct.lid_symm_apply (R := k) v).symm.trans (e.symm_apply_apply w)
+  have haction' (g : WithConv (H →ₐ[k] k)) :
+      basePointsRepresentation (R := k) (H := H) M g v = (χ g : k) • v := by
+    rw [basePointsRepresentation_apply, hv']
+    have hg := haction g
+    change pointsRepresentation (R := k) (H := H) (A := k) M g w = _ at hg
+    rw [pointsRepresentation_apply] at hg
+    rw [hg, map_smul]
+  let p : Submodule k M := k ∙ v
+  have hact (g : WithConv (H →ₐ[k] k)) {m : M} (hm : m ∈ p) :
+      basePointsRepresentation (R := k) (H := H) M g m ∈ p := by
+    rw [Submodule.mem_span_singleton] at hm
+    obtain ⟨a, rfl⟩ := hm
+    rw [map_smul, haction' g]
+    exact p.smul_mem _ (p.smul_mem _ (Submodule.mem_span_singleton_self v))
+  have hstable : ∀ (g : H →ₐ[k] k) {m : M}, m ∈ p →
+      endOfPoint M g (1 ⊗ₜ[k] m) ∈ p.baseChange k := by
+    intro g m hm
+    rw [endOfPoint_tmul, one_smul,
+      endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation]
+    exact Submodule.tmul_mem_baseChange_of_mem _ (hact (toConv g) hm)
+  exact hasNonzeroWeightVector_of_toSubmodule_eq_span
+    (Subcomodule.ofEndOfPointStable (K := k) p hstable) hv
+    (Subcomodule.ofEndOfPointStable_toSubmodule (K := k) p hstable)
+
+/-- If the reduced derived closed subgroup is geometrically unipotent, then every nonzero
+finite-dimensional representation has a nonzero weight vector. -/
+theorem hasNonzeroWeightVector_of_geometricallyUnipotent_derived
+    [FiniteDimensional k M] [Nontrivial M]
+    [IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
+      (CommHopfAlgCat.derivedDefiningIdeal (R := k) H))]
+    (hderived : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
+        (CommHopfAlgCat.derivedDefiningIdeal (R := k) H))) :
+    HasNonzeroWeightVector k H M :=
+  hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived fun g ↦
+    geometricallyUnipotentPointsCommHopfAlgProperty.isUnipotentPoint hderived g
+
+/-- **Lie--Kolchin under unipotence of the derived subgroup.** If every point of the derived
+closed subgroup of a reduced finite-type affine group over an algebraically closed field is
+unipotent, then every finite-dimensional representation admits a basis in which its coefficient
+matrix is upper triangular, with characters on the diagonal. -/
+theorem exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPoint_derived
+    [FiniteDimensional k M]
+    (hderived : ∀ g : WithConv
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
+        (CommHopfAlgCat.derivedDefiningIdeal (R := k) H) →ₐ[k] k),
+      HopfAlgebra.IsUnipotentPoint g) :
+    ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
+      (coefficientMatrix (C := H) b).IsUpperTriangular ∧
+        ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
+  exists_basis_coefficientMatrix_isUpperTriangular_of_weight_vectors
+    fun V _ _ _ _ _ ↦
+      hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived (M := V) hderived
+
+/-- **Geometric Lie--Kolchin reduction.** If the reduced derived closed subgroup of a reduced
+finite-type affine group over an algebraically closed field is geometrically unipotent, then every
+finite-dimensional representation admits an upper-triangular basis with characters on the
+diagonal. -/
+theorem exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_derived
+    [FiniteDimensional k M]
+    [IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
+      (CommHopfAlgCat.derivedDefiningIdeal (R := k) H))]
+    (hderived : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
+        (CommHopfAlgCat.derivedDefiningIdeal (R := k) H))) :
+    ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
+      (coefficientMatrix (C := H) b).IsUpperTriangular ∧
+        ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
+  exists_basis_coefficientMatrix_isUpperTriangular_of_weight_vectors
+    fun V _ _ _ _ _ ↦
+      hasNonzeroWeightVector_of_geometricallyUnipotent_derived (M := V) hderived
+
+end Comodule
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
@@ -198,7 +198,7 @@ theorem hasNonzeroWeightVector_of_geometricallyUnipotent_derived
 
 /-- If a unipotent closed subgroup contains the derived subgroup, then every finite-dimensional
 representation admits an upper-triangular basis with characters on the diagonal. -/
-theorem exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPoint_of_le_derived
+theorem exists_basis_upperTriangular_of_forall_isUnipotentPoint_of_le_derivedDefiningIdeal
     [FiniteDimensional k M]
     (I : HopfIdeal k H) (hID : I ≤ CommHopfAlgCat.derivedDefiningIdeal H)
     (hI : ∀ g : WithConv
@@ -225,13 +225,13 @@ theorem exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPo
     ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
       (coefficientMatrix (C := H) b).IsUpperTriangular ∧
         ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
-  exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPoint_of_le_derived
+  exists_basis_upperTriangular_of_forall_isUnipotentPoint_of_le_derivedDefiningIdeal
     (CommHopfAlgCat.derivedDefiningIdeal H) le_rfl hderived
 
 /-- If a geometrically unipotent closed subgroup contains the derived subgroup, then every
 finite-dimensional representation admits an upper-triangular basis with characters on the
 diagonal. -/
-theorem exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_of_le_derived
+theorem exists_basis_upperTriangular_of_geometricallyUnipotent_of_le_derivedDefiningIdeal
     [FiniteDimensional k M]
     (I : HopfIdeal k H) (hID : I ≤ CommHopfAlgCat.derivedDefiningIdeal H)
     (hI : geometricallyUnipotentPointsCommHopfAlgProperty k
@@ -256,7 +256,7 @@ theorem exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipote
     ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
       (coefficientMatrix (C := H) b).IsUpperTriangular ∧
         ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
-  exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_of_le_derived
+  exists_basis_upperTriangular_of_geometricallyUnipotent_of_le_derivedDefiningIdeal
     (CommHopfAlgCat.derivedDefiningIdeal H) le_rfl hderived
 
 end Comodule

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
@@ -9,10 +9,8 @@ public import TauCeti.Algebra.AlgebraicGroup.Derived.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Solvable.Trigonalizable
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
 public import TauCeti.RepresentationTheory.Unipotent.DerivedEigenvector
-import TauCeti.Algebra.AlgebraicGroup.Unipotent.Reduced
 import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Naturality
 import TauCeti.Algebra.Coalgebra.Comodule.Transport
-import TauCeti.Algebra.Coalgebra.Subcomodule.PointSeparation
 
 /-!
 # Lie--Kolchin reduction to the derived subgroup
@@ -46,14 +44,14 @@ subgroup of a connected solvable affine group is unipotent.
     exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_derived`:
   the geometric-unipotence formulation of that basis theorem.
 
+The corresponding declarations taking `I` and `hID` apply to any closed subgroup containing the
+derived subgroup.
+
 ## References
 
 * J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
 * T. A. Springer, *Linear Algebraic Groups*, Theorem 6.3.1.
 * A. Borel, *Linear Algebraic Groups*, Section 10.5.
-
-This advances the "Lie--Kolchin; solvable groups" milestone in Layer 5 of the ReductiveGroups
-roadmap.
 -/
 
 public section
@@ -75,33 +73,32 @@ variable [Field k] [IsAlgClosed k] [CommRing H] [HopfAlgebra k H]
 variable [Algebra.FiniteType k H] [IsReduced H]
 variable [AddCommGroup M] [Module k M] [Comodule k H M]
 
-private theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived_aux
+private theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_of_le_derivedDefiningIdeal_aux
     {V : Type u} [AddCommGroup V] [Module k V] [Comodule k H V]
     [FiniteDimensional k V] [Nontrivial V]
-    (hderived : ∀ g : WithConv
-      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
-        (CommHopfAlgCat.derivedDefiningIdeal (R := k) H) →ₐ[k] k),
+    (I : HopfIdeal k H) (hID : I ≤ CommHopfAlgCat.derivedDefiningIdeal H)
+    (hI : ∀ g : WithConv
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H) I →ₐ[k] k),
       HopfAlgebra.IsUnipotentPoint g) :
     HasNonzeroWeightVector k H V := by
   let A := _root_.CommHopfAlgCat.of k H
-  let I := CommHopfAlgCat.derivedDefiningIdeal (R := k) H
   let Q := CommHopfAlgCat.quotient A I
   let q : H →ₐc[k] Q := (CommHopfAlgCat.mkQuotient A I).hom
   let G := HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)
   let N := CommHopfAlgCat.quotientPointsSubgroup A I (CommAlgCat.of k k)
   let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal A I
-    (CommHopfAlgCat.isNormal_derivedDefiningIdeal A) (CommAlgCat.of k k)
+    (CommHopfAlgCat.isNormal_of_le_derivedDefiningIdeal A I hID) (CommAlgCat.of k k)
   let rho : _root_.Representation k G (k ⊗[k] V) :=
     pointsRepresentation (R := k) (H := H) (A := k) V
   have hrho (g : G) : rho g = endOfPoint V g.ofConv := by
     simp only [rho, G, pointsRepresentation_apply]
   have hcomm : _root_.commutator G ≤ N :=
     CommHopfAlgCat.commutator_le_quotientPointsSubgroup_of_le_derivedDefiningIdeal
-      A I le_rfl (CommAlgCat.of k k)
+      A I hID (CommAlgCat.of k k)
   have hunipotent (n : N) : IsNilpotent (rho n - 1) := by
     obtain ⟨g, hg⟩ := n.2
     have hg' : HopfAlgebra.IsUnipotentPoint (AlgHom.mapDomain q g) :=
-      (hderived g).mapDomain q
+      (hI g).mapDomain q
     have hnil :=
       (HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one
         (AlgHom.mapDomain q g)).mp hg'
@@ -132,15 +129,29 @@ private theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived_aux
     obtain ⟨a, rfl⟩ := hm
     rw [map_smul, haction' g]
     exact p.smul_mem _ (p.smul_mem _ (Submodule.mem_span_singleton_self v))
-  have hstable : ∀ (g : H →ₐ[k] k) {m : V}, m ∈ p →
-      endOfPoint V g (1 ⊗ₜ[k] m) ∈ p.baseChange k := by
-    intro g m hm
-    rw [endOfPoint_tmul, one_smul,
-      endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation]
-    exact Submodule.tmul_mem_baseChange_of_mem _ (hact (toConv g) hm)
-  exact hasNonzeroWeightVector_of_toSubmodule_eq_span
-    (Subcomodule.ofEndOfPointStable (K := k) p hstable) hv
-    (Subcomodule.ofEndOfPointStable_toSubmodule (K := k) p hstable)
+  exact hasNonzeroWeightVector_of_basePointsRepresentation_stable p v hv rfl hact
+
+/-- If a closed subgroup containing the derived subgroup acts unipotently, then every nonzero
+finite-dimensional representation has a nonzero weight vector. -/
+theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_of_le_derivedDefiningIdeal
+    [FiniteDimensional k M] [Nontrivial M]
+    (I : HopfIdeal k H) (hID : I ≤ CommHopfAlgCat.derivedDefiningIdeal H)
+    (hI : ∀ g : WithConv
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H) I →ₐ[k] k),
+      HopfAlgebra.IsUnipotentPoint g) :
+    HasNonzeroWeightVector k H M := by
+  let e : M ≃ₗ[k] (Fin (Module.finrank k M) → k) := (Module.finBasis k M).equivFun
+  let _ : Comodule k H (Fin (Module.finrank k M) → k) := Comodule.Transport e
+  let _ : Nontrivial (Fin (Module.finrank k M) → k) := e.symm.toEquiv.nontrivial
+  have hweight : HasNonzeroWeightVector k H (Fin (Module.finrank k M) → k) :=
+    hasNonzeroWeightVector_of_forall_isUnipotentPoint_of_le_derivedDefiningIdeal_aux I hID hI
+  obtain ⟨v, c, hv, hc, hvc⟩ := (hasNonzeroWeightVector_iff (k := k) (C := H)).mp hweight
+  refine (hasNonzeroWeightVector_iff (k := k) (C := H)).mpr
+    ⟨e.symm v, c, e.symm.map_ne_zero_iff.mpr hv, hc, ?_⟩
+  have hmap := (Comodule.transportInvHom (R := k) (C := H) e).map_coact_apply v
+  rw [hvc] at hmap
+  simpa only [Comodule.transportInvHom_apply, Comodule.transportInvHom_toLinearMap,
+    LinearEquiv.coe_coe, TensorProduct.map_tmul, LinearMap.id_apply] using hmap.symm
 
 /-- If every point of the derived closed subgroup acts unipotently, then every nonzero
 finite-dimensional representation has a nonzero weight vector.
@@ -155,19 +166,24 @@ theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived
       (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
         (CommHopfAlgCat.derivedDefiningIdeal (R := k) H) →ₐ[k] k),
       HopfAlgebra.IsUnipotentPoint g) :
+    HasNonzeroWeightVector k H M :=
+  hasNonzeroWeightVector_of_forall_isUnipotentPoint_of_le_derivedDefiningIdeal
+    (CommHopfAlgCat.derivedDefiningIdeal H) le_rfl hderived
+
+/-- If a geometrically unipotent closed subgroup contains the derived subgroup, then every nonzero
+finite-dimensional representation has a nonzero weight vector. -/
+theorem hasNonzeroWeightVector_of_geometricallyUnipotent_of_le_derivedDefiningIdeal
+    [FiniteDimensional k M] [Nontrivial M]
+    (I : HopfIdeal k H) (hID : I ≤ CommHopfAlgCat.derivedDefiningIdeal H)
+    (hI : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H) I)) :
     HasNonzeroWeightVector k H M := by
-  let e : M ≃ₗ[k] (Fin (Module.finrank k M) → k) := (Module.finBasis k M).equivFun
-  let _ : Comodule k H (Fin (Module.finrank k M) → k) := Comodule.Transport e
-  let _ : Nontrivial (Fin (Module.finrank k M) → k) := e.symm.toEquiv.nontrivial
-  have hweight : HasNonzeroWeightVector k H (Fin (Module.finrank k M) → k) :=
-    hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived_aux hderived
-  obtain ⟨v, c, hv, hc, hvc⟩ := (hasNonzeroWeightVector_iff (k := k) (C := H)).mp hweight
-  refine (hasNonzeroWeightVector_iff (k := k) (C := H)).mpr
-    ⟨e.symm v, c, e.symm.map_ne_zero_iff.mpr hv, hc, ?_⟩
-  have hmap := (Comodule.transportInvHom (R := k) (C := H) e).map_coact_apply v
-  rw [hvc] at hmap
-  simpa only [Comodule.transportInvHom_apply, Comodule.transportInvHom_toLinearMap,
-    LinearEquiv.coe_coe, TensorProduct.map_tmul, LinearMap.id_apply] using hmap.symm
+  apply hasNonzeroWeightVector_of_forall_isUnipotentPoint_of_le_derivedDefiningIdeal I hID
+  intro g
+  let φ : k →ₐ[k] AlgebraicClosure k := _root_.Algebra.ofId k (AlgebraicClosure k)
+  have hgeom := (geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mp hI
+  exact (HopfAlgebra.isUnipotentPoint_mapValue_iff_of_injective g φ φ.injective).mp
+    (hgeom (AlgHom.mapValue φ g))
 
 /-- If the derived closed subgroup is geometrically unipotent, then every nonzero
 finite-dimensional representation has a nonzero weight vector. -/
@@ -176,13 +192,25 @@ theorem hasNonzeroWeightVector_of_geometricallyUnipotent_derived
     (hderived : geometricallyUnipotentPointsCommHopfAlgProperty k
       (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H)
         (CommHopfAlgCat.derivedDefiningIdeal (R := k) H))) :
-    HasNonzeroWeightVector k H M := by
-  apply hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived
-  intro g
-  let φ : k →ₐ[k] AlgebraicClosure k := _root_.Algebra.ofId k (AlgebraicClosure k)
-  have hgeom := (geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mp hderived
-  exact (HopfAlgebra.isUnipotentPoint_mapValue_iff_of_injective g φ φ.injective).mp
-    (hgeom (AlgHom.mapValue φ g))
+    HasNonzeroWeightVector k H M :=
+  hasNonzeroWeightVector_of_geometricallyUnipotent_of_le_derivedDefiningIdeal
+    (CommHopfAlgCat.derivedDefiningIdeal H) le_rfl hderived
+
+/-- If a unipotent closed subgroup contains the derived subgroup, then every finite-dimensional
+representation admits an upper-triangular basis with characters on the diagonal. -/
+theorem exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPoint_of_le_derived
+    [FiniteDimensional k M]
+    (I : HopfIdeal k H) (hID : I ≤ CommHopfAlgCat.derivedDefiningIdeal H)
+    (hI : ∀ g : WithConv
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H) I →ₐ[k] k),
+      HopfAlgebra.IsUnipotentPoint g) :
+    ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
+      (coefficientMatrix (C := H) b).IsUpperTriangular ∧
+        ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
+  exists_basis_coefficientMatrix_isUpperTriangular_of_weight_vectors
+    fun V _ _ _ _ _ ↦
+      hasNonzeroWeightVector_of_forall_isUnipotentPoint_of_le_derivedDefiningIdeal
+        (M := V) I hID hI
 
 /-- **Lie--Kolchin under unipotence of the derived subgroup.** If every point of the derived
 closed subgroup of a reduced finite-type affine group over an algebraically closed field is
@@ -197,9 +225,24 @@ theorem exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPo
     ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
       (coefficientMatrix (C := H) b).IsUpperTriangular ∧
         ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
+  exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPoint_of_le_derived
+    (CommHopfAlgCat.derivedDefiningIdeal H) le_rfl hderived
+
+/-- If a geometrically unipotent closed subgroup contains the derived subgroup, then every
+finite-dimensional representation admits an upper-triangular basis with characters on the
+diagonal. -/
+theorem exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_of_le_derived
+    [FiniteDimensional k M]
+    (I : HopfIdeal k H) (hID : I ≤ CommHopfAlgCat.derivedDefiningIdeal H)
+    (hI : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k H) I)) :
+    ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
+      (coefficientMatrix (C := H) b).IsUpperTriangular ∧
+        ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
   exists_basis_coefficientMatrix_isUpperTriangular_of_weight_vectors
     fun V _ _ _ _ _ ↦
-      hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived (M := V) hderived
+      hasNonzeroWeightVector_of_geometricallyUnipotent_of_le_derivedDefiningIdeal
+        (M := V) I hID hI
 
 /-- **Geometric Lie--Kolchin reduction.** If the derived closed subgroup of a reduced
 finite-type affine group over an algebraically closed field is geometrically unipotent, then every
@@ -213,9 +256,8 @@ theorem exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipote
     ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
       (coefficientMatrix (C := H) b).IsUpperTriangular ∧
         ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
-  exists_basis_coefficientMatrix_isUpperTriangular_of_weight_vectors
-    fun V _ _ _ _ _ ↦
-      hasNonzeroWeightVector_of_geometricallyUnipotent_derived (M := V) hderived
+  exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_of_le_derived
+    (CommHopfAlgCat.derivedDefiningIdeal H) le_rfl hderived
 
 end Comodule
 

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
@@ -37,11 +37,9 @@ subgroup of a connected solvable affine group is unipotent.
   derived subgroup supplies a weight vector in every nonzero finite-dimensional comodule.
 * `TauCeti.Comodule.hasNonzeroWeightVector_of_geometricallyUnipotent_derived`: the same conclusion
   phrased using the geometric-unipotence object property.
-* `TauCeti.Comodule.
-    exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPoint_derived`:
+* `exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPoint_derived`:
   the resulting Lie--Kolchin upper-triangular basis.
-* `TauCeti.Comodule.
-    exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_derived`:
+* `exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_derived`:
   the geometric-unipotence formulation of that basis theorem.
 
 The corresponding declarations taking `I` and `hID` apply to any closed subgroup containing the

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
@@ -196,7 +196,7 @@ theorem hasNonzeroWeightVector_of_geometricallyUnipotent_derived
 
 /-- If a unipotent closed subgroup contains the derived subgroup, then every finite-dimensional
 representation admits an upper-triangular basis with characters on the diagonal. -/
-theorem exists_basis_upperTriangular_of_forall_isUnipotentPoint_of_le_derivedDefiningIdeal
+theorem exists_basis_coefficientMatrix_isUpperTriangular_of_unipotentPoints_of_le_derived
     [FiniteDimensional k M]
     (I : HopfIdeal k H) (hID : I ≤ CommHopfAlgCat.derivedDefiningIdeal H)
     (hI : ∀ g : WithConv
@@ -223,13 +223,13 @@ theorem exists_basis_coefficientMatrix_isUpperTriangular_of_forall_isUnipotentPo
     ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
       (coefficientMatrix (C := H) b).IsUpperTriangular ∧
         ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
-  exists_basis_upperTriangular_of_forall_isUnipotentPoint_of_le_derivedDefiningIdeal
+  exists_basis_coefficientMatrix_isUpperTriangular_of_unipotentPoints_of_le_derived
     (CommHopfAlgCat.derivedDefiningIdeal H) le_rfl hderived
 
 /-- If a geometrically unipotent closed subgroup contains the derived subgroup, then every
 finite-dimensional representation admits an upper-triangular basis with characters on the
 diagonal. -/
-theorem exists_basis_upperTriangular_of_geometricallyUnipotent_of_le_derivedDefiningIdeal
+theorem exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_of_le_derived
     [FiniteDimensional k M]
     (I : HopfIdeal k H) (hID : I ≤ CommHopfAlgCat.derivedDefiningIdeal H)
     (hI : geometricallyUnipotentPointsCommHopfAlgProperty k
@@ -254,7 +254,7 @@ theorem exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipote
     ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
       (coefficientMatrix (C := H) b).IsUpperTriangular ∧
         ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
-  exists_basis_upperTriangular_of_geometricallyUnipotent_of_le_derivedDefiningIdeal
+  exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_of_le_derived
     (CommHopfAlgCat.derivedDefiningIdeal H) le_rfl hderived
 
 end Comodule

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean
@@ -93,6 +93,8 @@ private theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived_aux
     (CommHopfAlgCat.isNormal_derivedDefiningIdeal A) (CommAlgCat.of k k)
   let rho : _root_.Representation k G (k ⊗[k] V) :=
     pointsRepresentation (R := k) (H := H) (A := k) V
+  have hrho (g : G) : rho g = endOfPoint V g.ofConv := by
+    simp only [rho, G, pointsRepresentation_apply]
   have hcomm : _root_.commutator G ≤ N :=
     CommHopfAlgCat.commutator_le_quotientPointsSubgroup_of_le_derivedDefiningIdeal
       A I le_rfl (CommAlgCat.of k k)
@@ -108,8 +110,7 @@ private theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived_aux
         AlgHom.mapDomain q g := by
       rw [CommHopfAlgCat.quotientPointsHom_apply, AlgHom.mapDomain_apply]
     have hn : (n : G) = AlgHom.mapDomain q g := hg.symm.trans hinclude
-    rw [show rho n = endOfPoint V (n : G).ofConv by
-      exact pointsRepresentation_apply V (n : G), hn]
+    rw [hrho n, hn]
     exact hnil
   obtain ⟨χ, w, hw, haction⟩ :=
     rho.exists_unitHom_jointEigenvector_of_commutator_le_of_isUnipotent N hcomm hunipotent
@@ -122,7 +123,7 @@ private theorem hasNonzeroWeightVector_of_forall_isUnipotentPoint_derived_aux
       basePointsRepresentation (R := k) (H := H) V g v = (χ g : k) • v := by
     rw [basePointsRepresentation_apply, hv']
     have hg := haction g
-    rw [show rho g = endOfPoint V g.ofConv by exact pointsRepresentation_apply V g] at hg
+    rw [hrho g] at hg
     rw [hg, map_smul]
   let p : Submodule k V := k ∙ v
   have hact (g : WithConv (H →ₐ[k] k)) {m : V} (hm : m ∈ p) :

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Trigonalizable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Trigonalizable.lean
@@ -31,6 +31,8 @@ enters, is not proved here.
 
 ## Main declarations
 
+* `TauCeti.Comodule.hasNonzeroWeightVector_of_basePointsRepresentation_stable`: a nonzero vector
+  spanning a point-stable line is a weight vector.
 * `TauCeti.Comodule.hasNonzeroWeightVector_of_pairwise_commute`: commuting point actions produce a
   weight vector.
 * `TauCeti.Comodule.hasNonzeroWeightVector_of_isCocomm`: every nonzero finite-dimensional
@@ -65,6 +67,24 @@ variable {k : Type u} {H : Type v} {M : Type w}
 variable [Field k] [CommRing H] [HopfAlgebra k H]
 variable [AddCommGroup M] [Module k M] [Comodule k H M]
 
+/-- A nonzero vector spanning a submodule preserved by every base-valued point is a weight
+vector. -/
+theorem hasNonzeroWeightVector_of_basePointsRepresentation_stable
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H]
+    (p : Submodule k M) (v : M) (hv : v ≠ 0) (hspan : p = k ∙ v)
+    (hact : ∀ (g : WithConv (H →ₐ[k] k)) {m : M}, m ∈ p →
+      basePointsRepresentation (R := k) (H := H) M g m ∈ p) :
+    HasNonzeroWeightVector k H M := by
+  have hstable : ∀ (g : H →ₐ[k] k) {m : M}, m ∈ p →
+      Comodule.endOfPoint M g ((1 : k) ⊗ₜ[k] m) ∈ p.baseChange k := by
+    intro g m hm
+    rw [endOfPoint_tmul, one_smul,
+      endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation]
+    exact Submodule.tmul_mem_baseChange_of_mem _ (hact (toConv g) hm)
+  exact hasNonzeroWeightVector_of_toSubmodule_eq_span
+    (Subcomodule.ofEndOfPointStable (K := k) p hstable) hv
+    ((Subcomodule.ofEndOfPointStable_toSubmodule (K := k) p hstable).trans hspan)
+
 /-- If the base-valued points of a reduced finite-type commutative Hopf algebra over an
 algebraically closed field act on a nonzero finite-dimensional comodule by pairwise-commuting
 operators, then that comodule has a nonzero weight vector. -/
@@ -86,17 +106,9 @@ theorem hasNonzeroWeightVector_of_pairwise_commute
   have hspan : (k ∙ v) = p :=
     Submodule.eq_of_le_of_finrank_eq ((Submodule.span_singleton_le_iff_mem v p).mpr hvp)
       ((finrank_span_singleton hv).trans hrank.symm)
-  have hstable : ∀ (g : H →ₐ[k] k) {m : M}, m ∈ p →
-      Comodule.endOfPoint M g ((1 : k) ⊗ₜ[k] m) ∈ p.baseChange k := by
-    intro g m hm
-    have haction := endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation
-      (R := k) (H := H) (M := M) (toConv g) m
-    rw [ofConv_toConv] at haction
-    rw [endOfPoint_tmul, one_smul, haction]
-    exact Submodule.tmul_mem_baseChange_of_mem _ (hact (toConv g) m hm ▸ p.smul_mem _ hm)
-  exact hasNonzeroWeightVector_of_toSubmodule_eq_span
-    (Subcomodule.ofEndOfPointStable (K := k) p hstable) hv
-    ((Subcomodule.ofEndOfPointStable_toSubmodule (K := k) p hstable).trans hspan.symm)
+  apply hasNonzeroWeightVector_of_basePointsRepresentation_stable p v hv hspan.symm
+  intro g m hm
+  exact hact g m hm ▸ p.smul_mem _ hm
 
 /-- Every nonzero finite-dimensional representation of a commutative affine group, reduced and of
 finite type over an algebraically closed field, has a nonzero weight vector. -/

--- a/TauCeti/RepresentationTheory/Unipotent/DerivedEigenvector.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/DerivedEigenvector.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Exists
+public import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Kolchin
+import Mathlib.RepresentationTheory.Invariants
+
+/-!
+# Eigenvectors modulo a unipotent normal subgroup
+
+Let `N` be a normal subgroup containing the commutator subgroup of `G`, and let `G` act on a
+nonzero finite-dimensional vector space over an algebraically closed field. If every element of
+`N` acts unipotently, then the representation has a common eigenvector.
+
+Kolchin first supplies a nonzero `N`-fixed vector. The whole group preserves the space of
+`N`-fixed vectors, and its action there factors through the commutative quotient `G/N`.
+Commuting operators over an algebraically closed field have a common eigenvector, whose
+eigenvalues assemble into a unit-valued character of `G`.
+
+## Main declaration
+
+* `Representation.exists_unitHom_jointEigenvector_of_commutator_le_of_isUnipotent`: a normal
+  unipotent subgroup containing every commutator forces a common eigenvector.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, Theorem 6.3.1.
+
+This is the abstract representation-theoretic reduction used in the Lie--Kolchin milestone of
+Layer 5 of the ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w
+
+noncomputable section
+
+variable {K : Type u} {G : Type v} {V : Type w}
+variable [Field K] [IsAlgClosed K] [Group G]
+variable [AddCommGroup V] [Module K V] [FiniteDimensional K V] [Nontrivial V]
+
+/-- A representation has a common eigenvector if some normal subgroup containing the commutator
+subgroup acts unipotently.
+
+Kolchin first produces a nonzero vector fixed by the normal subgroup. Its entire fixed space is
+stable under the ambient group, and the induced action factors through the commutative quotient.
+-/
+theorem _root_.Representation.exists_unitHom_jointEigenvector_of_commutator_le_of_isUnipotent
+    (rho : _root_.Representation K G V) (N : Subgroup G) [N.Normal]
+    (hcomm : _root_.commutator G ≤ N)
+    (hunipotent : ∀ n : N, IsNilpotent (rho n - 1)) :
+    ∃ (χ : G →* Kˣ) (v : V), v ≠ 0 ∧ ∀ g, rho g v = (χ g : K) • v := by
+  let S := Representation.invariants (rho.comp N.subtype)
+  obtain ⟨x, hx, hfixed⟩ :=
+    _root_.Representation.exists_common_fixed_vector_of_isUnipotent
+      (rho.comp N.subtype) hunipotent
+  let xS : S := ⟨x, hfixed⟩
+  let _ : Nontrivial S := ⟨xS, 0, fun h ↦ hx (congrArg Subtype.val h)⟩
+  let rhoQ : _root_.Representation K (G ⧸ N) S := rho.quotientToInvariants N
+  let _ : IsMulCommutative (G ⧸ N) :=
+    Subgroup.Normal.quotient_commutative_iff_commutator_le.mpr hcomm
+  obtain ⟨χ, y, hy, heigen⟩ :=
+    TauCeti.exists_unitHom_jointEigenvector_of_pairwise_commute_of_isAlgClosed
+      rhoQ fun (g h : G ⧸ N) _ ↦ by
+        change rhoQ g * rhoQ h = rhoQ h * rhoQ g
+        rw [← map_mul, mul_comm' g h, map_mul]
+  let χ' : G →* Kˣ := χ.comp (QuotientGroup.mk' N)
+  refine ⟨χ', y, fun h ↦ hy (Subtype.ext h), fun g ↦ ?_⟩
+  exact congrArg Subtype.val (heigen (QuotientGroup.mk' N g))
+
+end
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Unipotent/DerivedEigenvector.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/DerivedEigenvector.lean
@@ -70,8 +70,8 @@ theorem _root_.Representation.exists_unitHom_jointEigenvector_of_commutator_le_o
   obtain ⟨χ, y, hy, heigen⟩ :=
     TauCeti.exists_unitHom_jointEigenvector_of_pairwise_commute_of_isAlgClosed
       rhoQ fun (g h : G ⧸ N) _ ↦ by
-        change rhoQ g * rhoQ h = rhoQ h * rhoQ g
-        rw [← map_mul, mul_comm' g h, map_mul]
+        exact (rhoQ.map_mul g h).symm.trans <|
+          (congrArg rhoQ (mul_comm' g h)).trans (rhoQ.map_mul h g)
   let χ' : G →* Kˣ := χ.comp (QuotientGroup.mk' N)
   refine ⟨χ', y, fun h ↦ hy (Subtype.ext h), fun g ↦ ?_⟩
   exact congrArg Subtype.val (heigen (QuotientGroup.mk' N g))

--- a/TauCeti/RepresentationTheory/Unipotent/DerivedEigenvector.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/DerivedEigenvector.lean
@@ -31,8 +31,7 @@ eigenvalues assemble into a unit-valued character of `G`.
 * J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
 * T. A. Springer, *Linear Algebraic Groups*, Theorem 6.3.1.
 
-This is the abstract representation-theoretic reduction used in the Lie--Kolchin milestone of
-Layer 5 of the ReductiveGroups roadmap.
+This supplies the abstract reduction used in Lie--Kolchin arguments.
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/Unipotent/DerivedEigenvector.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/DerivedEigenvector.lean
@@ -23,8 +23,8 @@ eigenvalues assemble into a unit-valued character of `G`.
 
 ## Main declaration
 
-* `Representation.exists_unitHom_jointEigenvector_of_commutator_le_of_isUnipotent`: a normal
-  unipotent subgroup containing every commutator forces a common eigenvector.
+* `Representation.exists_unitHom_jointEigenvector_of_commutator_le_of_isUnipotent`: a unipotent
+  subgroup containing every commutator forces a common eigenvector.
 
 ## References
 
@@ -46,17 +46,18 @@ variable {K : Type u} {G : Type v} {V : Type w}
 variable [Field K] [IsAlgClosed K] [Group G]
 variable [AddCommGroup V] [Module K V] [FiniteDimensional K V] [Nontrivial V]
 
-/-- A representation has a common eigenvector if some normal subgroup containing the commutator
-subgroup acts unipotently.
+/-- A representation has a common eigenvector if some subgroup containing the commutator subgroup
+acts unipotently. Such a subgroup is automatically normal.
 
 Kolchin first produces a nonzero vector fixed by the normal subgroup. Its entire fixed space is
 stable under the ambient group, and the induced action factors through the commutative quotient.
 -/
 theorem _root_.Representation.exists_unitHom_jointEigenvector_of_commutator_le_of_isUnipotent
-    (rho : _root_.Representation K G V) (N : Subgroup G) [N.Normal]
+    (rho : _root_.Representation K G V) (N : Subgroup G)
     (hcomm : _root_.commutator G ≤ N)
     (hunipotent : ∀ n : N, IsNilpotent (rho n - 1)) :
     ∃ (χ : G →* Kˣ) (v : V), v ≠ 0 ∧ ∀ g, rho g v = (χ g : K) • v := by
+  let _ : N.Normal := Subgroup.Normal.of_commutator_le (G := G) hcomm
   let S := Representation.invariants (rho.comp N.subtype)
   obtain ⟨x, hx, hfixed⟩ :=
     _root_.Representation.exists_common_fixed_vector_of_isUnipotent


### PR DESCRIPTION
This PR proves the Lie--Kolchin reduction from a unipotent derived subgroup: show abstractly that a representation has a common eigenvector when a normal unipotent subgroup contains every commutator, apply this to the scheme-theoretic derived-point subgroup, promote the resulting point-stable eigenline to a subcomodule by point separation, and iterate it to obtain an upper-triangular coefficient matrix with group-like diagonal entries.

The exact roadmap target is Layer 5, “Lie–Kolchin; solvable groups,” in `TauCetiRoadmap/ReductiveGroups/README.md`. This is the next critical-path step because the existing commutative trigonalization theorem explicitly leaves the derived-subgroup induction open, while the existing scheme-theoretic derived subgroup already supplies normality and containment of pointwise commutators. After this PR, the milestone still needs the geometric theorem that the derived subgroup of a connected solvable affine group is unipotent, which will discharge this PR's hypothesis and yield general Lie--Kolchin.

The abstract theorem works for any normal subgroup containing the commutator subgroup and uses Kolchin's common fixed-vector theorem followed by simultaneous eigenvector existence for the commutative quotient action. The affine-group theorem then uses `CommHopfAlgCat.derivedDefiningIdeal`, its pointwise commutator containment, unipotent-point functoriality, and reduced finite-type point separation. Both the direct pointwise hypothesis and the canonical `geometricallyUnipotentPointsCommHopfAlgProperty` formulation are provided. No Mathlib declaration or external implementation is vendored.

The change adds `TauCeti/RepresentationTheory/Unipotent/DerivedEigenvector.lean` (81 lines) and `TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.lean` (200 lines).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"derived-unipotent-lie-kolchin"}-->

🤖 Prepared with Codex
