### PR TITLE
doc: separate type-C API documentation from roadmap process

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -5,18 +5,31 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius
 public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.RootDatum
-public import TauCeti.GroupTheory.SpecificGroups.CFSG.Closure
+public import TauCeti.GroupTheory.FixedPointCandidate
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Frobenius
 
 /-!
-# The standard symplectic carrier of a validated type-`C` index
+# The untwisted family `Cₙ(q)` on the standard symplectic carrier
 
 The type-`C` branch of the classification list is built on the type-`C` diagram of rank `n`, and
 Tau Ceti's explicit full-weight Chevalley carrier for that diagram is `TauCeti.SpStd.groupScheme`,
 the Kostant toral closure of the standard representation of `sp_(2n)` inside `GL_(2n)` over `ℤ`.
-This file attaches that carrier to a validated type-`C` index: the group of algebraic-closure-valued
-points of the carrier at the index's rank, its Bourbaki-numbered simple root subgroups, and the
-reading of their root characters in the type-`C` root datum the index names.
+This file attaches that carrier to a validated type-`C` index and runs the classification recipe on
+it: the group of algebraic-closure-valued points of the carrier at the index's rank, its
+Bourbaki-numbered simple root subgroups, the reading of their root characters in the type-`C` root
+datum the index names, the Steinberg endomorphism of the family, and the candidate group
+
+```text
+H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d]).
+```
+
+The Steinberg map is the `q`-power Frobenius outright, `q` being the field order the index records.
+That is what an untwisted family asks for, and `TauCeti.TypeCLieIndex.diagramPerm_eq_one` is the
+check that the diagram permutation this index carries is indeed trivial: the type-`C` diagram has
+no symmetry to twist by, its last node carrying a root of a different length from the others, so
+`Cₙ(q)` is the only classification-list family on it.
 
 The carrier is indexed by `n` in the spelling `C (n + 1)`, so a validated index of rank `r` uses
 the carrier at `TauCeti.TypeCLieIndex.carrierRank`, which is `r - 1`. That subtraction is harmless
@@ -47,15 +60,26 @@ the symplectic group scheme or the pinned simply connected Chevalley--Demazure g
   Bourbaki-numbered node, with
   `TauCeti.TypeCLieIndex.rootGeneratorWeight_carrierNode_eq_root_simpleIndex` identifying the
   character of that subgroup with the corresponding simple root of the type-`C` root datum.
+* `TauCeti.TypeCLieIndex.steinberg`: the Steinberg endomorphism of the family, with
+  `TauCeti.TypeCLieIndex.coe_steinberg_apply` its entrywise description,
+  `TauCeti.TypeCLieIndex.steinberg_simpleRootSubgroup` its pinned equation
+  `Frob_q (x_i(u)) = x_i(u ^ q)`, and
+  `TauCeti.TypeCLieIndex.mem_fixedSubgroup_steinberg_iff` describing the points it fixes as those
+  whose matrix entries lie in the field of definition `𝔽_q`.
+* `TauCeti.TypeCLieIndex.Group`: the candidate group of `Cₙ(q)`, the derived subgroup of those
+  fixed points modulo its centre.
 
 ## References
 
 * R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 11.3.
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17, for
+  the Steinberg endomorphism and its fixed points.
 * N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate III, for the numbering of the
   type-`C` diagram that the root subgroups below are indexed by.
 * The signatures realized here follow the human-authored formal skeleton
-  `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group and the numbered simple root
-  subgroup, both taken on a validated-index subtype.
+  `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group, the numbered simple root
+  subgroup, the Steinberg map with its pinned equation, and the fixed-point candidate, all taken on
+  a validated-index subtype.
 
 ## Roadmap
 
@@ -66,11 +90,15 @@ and the standard symplectic carrier is not offered as a substitute for that pinn
 pinned group scheme, its pinning, and any identification of a carrier with it are Layer 9 targets of
 `TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap consumes rather than builds; none
 of them is proved of `TauCeti.SpStd.groupScheme` here or in the files this one imports. What this
-file supplies is the material that identification will be made against on the `C` branch: the
-branch's explicit carrier, its numbered simple root subgroups, and their root characters read as the
-simple roots of the type-`C` root datum. The milestone L1 Steinberg map of the untwisted family
-`Cₙ(q)` and the milestone L3 quotient built from it are *not* stated here; they wait on L0's pinned
-carrier for this branch.
+file supplies is the branch's explicit carrier, its numbered root characters read in the type-`C`
+root datum, the equation `Frob_q (x_i(u)) = x_i(u ^ q)` that milestone L1 asks of an ordinary
+Frobenius, and the milestone L3 recipe run on it, each in the shape those milestones state it; they
+transfer to the L0 carrier along that Layer 9 identification, and not before. The counterparts on
+the branches already assembled are
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeD.lean`,
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
+`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
 -/
 
 public section
@@ -165,6 +193,86 @@ theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (i j : Fin d.1.rank)
   rw [SpStd.rootGeneratorWeight_inl]
   simp only [DynkinType.root_simpleIndex]
   rw [d.dynkinType_cartanMatrix_apply, d.cartanMatrix_C_carrierNode]
+
+/-! ## The Steinberg endomorphism -/
+
+/-- **The Steinberg endomorphism of a validated type-`C` index**: the `q`-power Frobenius of the
+ambient group, `q` being the field order the index records. The family is untwisted, so no diagram
+automorphism and no half-Frobenius enters; `TauCeti.TypeCLieIndex.diagramPerm_eq_one` is the check
+that its diagram permutation is trivial. -/
+def steinberg : d.AmbientGroup →* d.AmbientGroup :=
+  SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure
+
+/-- The Steinberg map of a type-`C` index is the carrier's Frobenius at the exponent the index
+records. This is its unfolding lemma; the definition itself stays sealed.
+
+It is deliberately not a `simp` lemma: `steinberg_simpleRootSubgroup` and `coe_steinberg_apply` are
+the normal forms the pinned equations of this file are stated against, and unfolding to
+`TauCeti.SpStd.frobenius` would keep them from firing. -/
+theorem steinberg_def :
+    d.steinberg = SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure :=
+  (rfl)
+
+/-- The Steinberg map acts on the ambient group by raising every matrix entry to the `q`-th
+power. -/
+@[simp]
+theorem coe_steinberg_apply (g : d.AmbientGroup)
+    (r c : Fin (d.carrierRank + 1 + (d.carrierRank + 1))) :
+    ((d.steinberg g :
+        Matrix.GeneralLinearGroup (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
+        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
+          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c =
+      ((g :
+        Matrix.GeneralLinearGroup (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
+        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
+          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c ^ d.1.fieldOrder := by
+  rw [steinberg_def, d.1.fieldOrder_eq_characteristic_pow]
+  exact SpStd.coe_frobenius_apply _ _ _ _ g r c
+
+/-- **The Steinberg map fixes the Bourbaki numbering of a simple-root subgroup and raises its
+parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation
+milestone L1 asks of the untwisted families. -/
+@[simp]
+theorem steinberg_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.Closure) :
+    d.steinberg (d.simpleRootSubgroup i u) =
+      d.simpleRootSubgroup i
+        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.fieldOrder)) := by
+  rw [steinberg_def, simpleRootSubgroup_def, SpStd.frobenius_rootSubgroupPoints,
+    d.1.fieldOrder_eq_characteristic_pow]
+
+/-- **A point of the ambient group is fixed by the Steinberg map exactly when all of its matrix
+entries lie in the field of definition.** Writing `𝔽_q` for `TauCeti.ValidLieTypeIndex.fixedField`,
+the copy of the field of `q` elements inside the algebraic closure, the group `H_d` that the
+milestone L3 recipe is run on below is therefore the group of points of the standard symplectic
+carrier whose entries lie in `𝔽_q`.
+
+As for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`, this is not a `simp` lemma:
+`TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites its
+left-hand side to `d.steinberg g = g` through `MonoidHom.mem_eqLocus`, and the `simpNF` linter
+rejects the annotation. -/
+theorem mem_fixedSubgroup_steinberg_iff (g : d.AmbientGroup) :
+    g ∈ fixedSubgroup d.steinberg ↔
+      ∀ r c, ((g :
+          Matrix.GeneralLinearGroup (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
+        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
+          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c ∈ d.1.fixedField := by
+  rw [mem_fixedSubgroup, steinberg_def, SpStd.frobenius_eq_self_iff]
+  simp only [mem_frobeniusFixedSubring, ValidLieTypeIndex.mem_fixedField,
+    d.1.fieldOrder_eq_characteristic_pow]
+
+/-! ## The classification candidate -/
+
+/-- **The candidate simple group of the untwisted family `Cₙ(q)`**: the derived subgroup of the
+fixed points of its Steinberg map, modulo the centre of that derived subgroup.
+
+This is the milestone L3 recipe on the `C` branch, run on the standard symplectic carrier. Nothing
+below asserts that it is finite, perfect, or simple, nor that the carrier is the one milestone L0
+asks for. -/
+abbrev Group : Type := FixedPointCandidate d.steinberg
+
+/-- Milestone L3 asks every valid branch to carry a group instance; the quotient construction
+supplies it. -/
+example : _root_.Group d.Group := inferInstance
 
 end
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -87,9 +87,7 @@ The same construction on the other branches already built is in
 * N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate III, for the numbering of the
   type-`C` diagram that the root subgroups below are indexed by.
 * The signatures realized here follow the human-authored formal skeleton
-  `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group, the numbered simple root
-  subgroup, the Steinberg map with its pinned equation, and the fixed-point candidate, all taken on
-  a validated-index subtype.
+  `TauCetiRoadmap/CFSGStatement/Suggested.lean`.
 -/
 
 public section
@@ -197,11 +195,12 @@ identification of that group with this carrier, which is not proved here. -/
 def steinberg : d.AmbientGroup →* d.AmbientGroup :=
   SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure
 
--- Deliberately not a `simp` lemma: `steinberg_simpleRootSubgroup` and `coe_steinberg_apply` are
--- the normal forms the pinned equations of this file are stated against, and unfolding to
--- `TauCeti.SpStd.frobenius` would keep them from firing.
-/-- The Steinberg map of a type-`C` index is the carrier's Frobenius at the exponent the index
-records. This is its unfolding lemma; the definition itself stays sealed. -/
+-- The unfolding lemma of a sealed definition, and deliberately not a `simp` lemma:
+-- `steinberg_simpleRootSubgroup` and `coe_steinberg_apply` are the normal forms the pinned
+-- equations of this file are stated against, and unfolding to `TauCeti.SpStd.frobenius` would keep
+-- them from firing.
+/-- The Steinberg map of a type-`C` index is the Frobenius of the standard symplectic carrier at
+the characteristic and field exponent that the index records. -/
 theorem steinberg_def :
     d.steinberg = SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure :=
   (rfl)

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -16,10 +16,10 @@ public import TauCeti.GroupTheory.SpecificGroups.CFSG.Frobenius
 The type-`C` branch of the classification list is built on the type-`C` diagram of rank `n`, and
 Tau Ceti's explicit full-weight Chevalley carrier for that diagram is `TauCeti.SpStd.groupScheme`,
 the Kostant toral closure of the standard representation of `sp_(2n)` inside `GL_(2n)` over `ℤ`.
-This file attaches that carrier to a validated type-`C` index and runs the classification recipe on
-it: the group of algebraic-closure-valued points of the carrier at the index's rank, its
-Bourbaki-numbered simple root subgroups, the reading of their root characters in the type-`C` root
-datum the index names, the Steinberg endomorphism of the family, and the milestone L3 quotient
+This file attaches that carrier to a validated type-`C` index: the group of
+algebraic-closure-valued points of the carrier at the index's rank, its Bourbaki-numbered simple
+root subgroups, the reading of their root characters in the type-`C` root datum the index names,
+the Steinberg endomorphism of the family, and the derived-central quotient of its fixed points
 
 ```text
 H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d]).
@@ -50,7 +50,17 @@ acquires the swap of the two Bourbaki nodes.
 
 Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
 the symplectic group scheme or the pinned simply connected Chevalley--Demazure group scheme of type
-`Cₙ`, or that any group below is finite, perfect, or simple.
+`Cₙ`, or that any group below is finite, perfect, or simple. In particular
+`TauCeti.TypeCLieIndex.Group` is not asserted to be the finite simple group `Cₙ(q)`: reading it as
+that group needs an identification of the standard symplectic carrier with the pinned simply
+connected group of the same diagram, and no such identification is proved here or in the files this
+one imports.
+
+The same construction on the other branches already built is in
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeD.lean`,
+`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
+`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
 
 ## Main declarations
 
@@ -66,9 +76,8 @@ the symplectic group scheme or the pinned simply connected Chevalley--Demazure g
   `Frob_q (x_i(u)) = x_i(u ^ q)`, and
   `TauCeti.TypeCLieIndex.mem_fixedSubgroup_steinberg_iff` describing the points it fixes as those
   whose matrix entries lie in the field of definition `𝔽_q`.
-* `TauCeti.TypeCLieIndex.Group`: the milestone L3 quotient of the untwisted family `Cₙ(q)`, the
-  derived subgroup of those fixed points modulo its centre, formed on the standard symplectic
-  carrier rather than on the pinned group milestone L0 asks for.
+* `TauCeti.TypeCLieIndex.Group`: the derived subgroup of those fixed points modulo its centre,
+  formed on the standard symplectic carrier.
 
 ## References
 
@@ -81,25 +90,6 @@ the symplectic group scheme or the pinned simply connected Chevalley--Demazure g
   `TauCetiRoadmap/CFSGStatement/Suggested.lean`: the ambient group, the numbered simple root
   subgroup, the Steinberg map with its pinned equation, and the fixed-point candidate, all taken on
   a validated-index subtype.
-
-## Roadmap
-
-Milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md` asks for the points of the *pinned* simply
-connected Chevalley--Demazure group scheme of `TauCeti.DynkinType.simplyConnectedRootDatum` at the
-diagram the index names, with its root subgroups. **This file does not close L0 on the `C` branch,
-and the standard symplectic carrier is not offered as a substitute for that pinned group.** The
-pinned group scheme, its pinning, and any identification of a carrier with it are Layer 9 targets of
-`TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap consumes rather than builds; none
-of them is proved of `TauCeti.SpStd.groupScheme` here or in the files this one imports. What this
-file supplies is the branch's explicit carrier, its numbered root characters read in the type-`C`
-root datum, the equation `Frob_q (x_i(u)) = x_i(u ^ q)` that milestone L1 asks of an ordinary
-Frobenius, and the milestone L3 recipe run on it, each in the shape those milestones state it; they
-transfer to the L0 carrier along that Layer 9 identification, and not before. The counterparts on
-the branches already assembled are
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeD.lean`,
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
-`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
 -/
 
 public section
@@ -158,8 +148,8 @@ theorem cartanMatrix_C_carrierNode (i j : Fin d.1.rank) :
 /-- **The ambient group this file attaches to a validated type-`C` index**: the points of the
 explicit full-weight standard symplectic Chevalley carrier at the index's rank, over the algebraic
 closure of its prime field. No finiteness, reductivity, pinning or maximality statement is attached
-to it, and it is not claimed to be the pinned type-`Cₙ` group scheme's points that milestone L0 asks
-for, that identification being the Layer 9 target described in the module docstring. -/
+to it, and it is not claimed to be the points of the pinned simply connected group scheme of type
+`Cₙ`, no identification of the two carriers being proved. -/
 abbrev AmbientGroup : Type := SpStd.points d.carrierRank d.1.Closure
 
 /-- The positive simple-root subgroup at the Bourbaki-numbered node `i` of the type-`C` diagram. It
@@ -202,17 +192,16 @@ ambient group, `q` being the field order the index records. The family is untwis
 automorphism and no half-Frobenius enters; `TauCeti.TypeCLieIndex.diagramPerm_eq_one` is the check
 that its diagram permutation is trivial.
 
-It is the Steinberg map of `Cₙ(q)` on the pinned carrier milestone L0 asks for only along the
-Layer 9 identification of the two carriers described in the module docstring, and not before. -/
+It is the Steinberg map of `Cₙ(q)` on the pinned simply connected group of type `Cₙ` only along an
+identification of that group with this carrier, which is not proved here. -/
 def steinberg : d.AmbientGroup →* d.AmbientGroup :=
   SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure
 
+-- Deliberately not a `simp` lemma: `steinberg_simpleRootSubgroup` and `coe_steinberg_apply` are
+-- the normal forms the pinned equations of this file are stated against, and unfolding to
+-- `TauCeti.SpStd.frobenius` would keep them from firing.
 /-- The Steinberg map of a type-`C` index is the carrier's Frobenius at the exponent the index
-records. This is its unfolding lemma; the definition itself stays sealed.
-
-It is deliberately not a `simp` lemma: `steinberg_simpleRootSubgroup` and `coe_steinberg_apply` are
-the normal forms the pinned equations of this file are stated against, and unfolding to
-`TauCeti.SpStd.frobenius` would keep them from firing. -/
+records. This is its unfolding lemma; the definition itself stays sealed. -/
 theorem steinberg_def :
     d.steinberg = SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure :=
   (rfl)
@@ -234,8 +223,8 @@ theorem coe_steinberg_apply (g : d.AmbientGroup)
   exact SpStd.coe_frobenius_apply _ _ _ _ g r c
 
 /-- **The Steinberg map fixes the Bourbaki numbering of a simple-root subgroup and raises its
-parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the equation
-milestone L1 asks of the untwisted families. -/
+parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the pinned
+equation of the Steinberg map of an untwisted family. -/
 @[simp]
 theorem steinberg_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.Closure) :
     d.steinberg (d.simpleRootSubgroup i u) =
@@ -244,16 +233,15 @@ theorem steinberg_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.
   rw [steinberg_def, simpleRootSubgroup_def, SpStd.frobenius_rootSubgroupPoints,
     d.1.fieldOrder_eq_characteristic_pow]
 
+-- As for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`, this is not a `simp`
+-- lemma: `TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites
+-- its left-hand side to `d.steinberg g = g` through `MonoidHom.mem_eqLocus`, and the `simpNF`
+-- linter rejects the annotation.
 /-- **A point of the ambient group is fixed by the Steinberg map exactly when all of its matrix
 entries lie in the field of definition.** Writing `𝔽_q` for `TauCeti.ValidLieTypeIndex.fixedField`,
-the copy of the field of `q` elements inside the algebraic closure, the group `H_d` that the
-milestone L3 recipe is run on below is therefore the group of points of the standard symplectic
-carrier whose entries lie in `𝔽_q`.
-
-As for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`, this is not a `simp` lemma:
-`TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites its
-left-hand side to `d.steinberg g = g` through `MonoidHom.mem_eqLocus`, and the `simpNF` linter
-rejects the annotation. -/
+the copy of the field of `q` elements inside the algebraic closure, the group `H_d` whose
+derived-central quotient is formed below is therefore the group of points of the standard symplectic
+carrier whose entries lie in `𝔽_q`. -/
 theorem mem_fixedSubgroup_steinberg_iff (g : d.AmbientGroup) :
     g ∈ fixedSubgroup d.steinberg ↔
       ∀ r c, ((g :
@@ -264,20 +252,18 @@ theorem mem_fixedSubgroup_steinberg_iff (g : d.AmbientGroup) :
   simp only [mem_frobeniusFixedSubring, ValidLieTypeIndex.mem_fixedField,
     d.1.fieldOrder_eq_characteristic_pow]
 
-/-! ## The milestone L3 quotient -/
+/-! ## The derived-central quotient of the fixed points -/
 
-/-- **The milestone L3 quotient on the standard symplectic carrier**: the derived subgroup of the
+/-- **The derived-central quotient on the standard symplectic carrier**: the derived subgroup of the
 fixed points of the Steinberg map above, modulo the centre of that derived subgroup.
 
-This is the shape milestone L3 asks of the untwisted family `Cₙ(q)`, formed on the standard
-symplectic carrier rather than on the pinned simply connected Chevalley--Demazure group scheme that
-milestone L0 asks for. It becomes the candidate simple group of that family along the Layer 9
-identification of the two carriers described in the module docstring, and not before; it is not
-offered as that candidate here. Nothing below asserts that it is finite, perfect, or simple. -/
+This is the shape the untwisted family `Cₙ(q)` is cut out in, formed here on the standard symplectic
+carrier rather than on the pinned simply connected Chevalley--Demazure group scheme of type `Cₙ`. It
+reads as the candidate simple group of that family only along an identification of those two
+carriers, which is not proved here. Nothing below asserts that it is finite, perfect, or simple. -/
 abbrev Group : Type := FixedPointCandidate d.steinberg
 
-/-- Milestone L3 asks every valid branch to carry a group instance; the quotient construction
-supplies it. -/
+/-- The quotient carries a group instance, supplied by the quotient construction. -/
 example : _root_.Group d.Group := inferInstance
 
 end

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -19,7 +19,7 @@ the Kostant toral closure of the standard representation of `sp_(2n)` inside `GL
 This file attaches that carrier to a validated type-`C` index and runs the classification recipe on
 it: the group of algebraic-closure-valued points of the carrier at the index's rank, its
 Bourbaki-numbered simple root subgroups, the reading of their root characters in the type-`C` root
-datum the index names, the Steinberg endomorphism of the family, and the candidate group
+datum the index names, the Steinberg endomorphism of the family, and the milestone L3 quotient
 
 ```text
 H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d]).
@@ -50,7 +50,7 @@ acquires the swap of the two Bourbaki nodes.
 
 Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
 the symplectic group scheme or the pinned simply connected Chevalley--Demazure group scheme of type
-`Cₙ`, or that its point group is finite.
+`Cₙ`, or that any group below is finite, perfect, or simple.
 
 ## Main declarations
 
@@ -66,8 +66,9 @@ the symplectic group scheme or the pinned simply connected Chevalley--Demazure g
   `Frob_q (x_i(u)) = x_i(u ^ q)`, and
   `TauCeti.TypeCLieIndex.mem_fixedSubgroup_steinberg_iff` describing the points it fixes as those
   whose matrix entries lie in the field of definition `𝔽_q`.
-* `TauCeti.TypeCLieIndex.Group`: the candidate group of `Cₙ(q)`, the derived subgroup of those
-  fixed points modulo its centre.
+* `TauCeti.TypeCLieIndex.Group`: the milestone L3 quotient of the untwisted family `Cₙ(q)`, the
+  derived subgroup of those fixed points modulo its centre, formed on the standard symplectic
+  carrier rather than on the pinned group milestone L0 asks for.
 
 ## References
 
@@ -199,7 +200,10 @@ theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (i j : Fin d.1.rank)
 /-- **The Steinberg endomorphism of a validated type-`C` index**: the `q`-power Frobenius of the
 ambient group, `q` being the field order the index records. The family is untwisted, so no diagram
 automorphism and no half-Frobenius enters; `TauCeti.TypeCLieIndex.diagramPerm_eq_one` is the check
-that its diagram permutation is trivial. -/
+that its diagram permutation is trivial.
+
+It is the Steinberg map of `Cₙ(q)` on the pinned carrier milestone L0 asks for only along the
+Layer 9 identification of the two carriers described in the module docstring, and not before. -/
 def steinberg : d.AmbientGroup →* d.AmbientGroup :=
   SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure
 
@@ -260,14 +264,16 @@ theorem mem_fixedSubgroup_steinberg_iff (g : d.AmbientGroup) :
   simp only [mem_frobeniusFixedSubring, ValidLieTypeIndex.mem_fixedField,
     d.1.fieldOrder_eq_characteristic_pow]
 
-/-! ## The classification candidate -/
+/-! ## The milestone L3 quotient -/
 
-/-- **The candidate simple group of the untwisted family `Cₙ(q)`**: the derived subgroup of the
-fixed points of its Steinberg map, modulo the centre of that derived subgroup.
+/-- **The milestone L3 quotient on the standard symplectic carrier**: the derived subgroup of the
+fixed points of the Steinberg map above, modulo the centre of that derived subgroup.
 
-This is the milestone L3 recipe on the `C` branch, run on the standard symplectic carrier. Nothing
-below asserts that it is finite, perfect, or simple, nor that the carrier is the one milestone L0
-asks for. -/
+This is the shape milestone L3 asks of the untwisted family `Cₙ(q)`, formed on the standard
+symplectic carrier rather than on the pinned simply connected Chevalley--Demazure group scheme that
+milestone L0 asks for. It becomes the candidate simple group of that family along the Layer 9
+identification of the two carriers described in the module docstring, and not before; it is not
+offered as that candidate here. Nothing below asserts that it is finite, perfect, or simple. -/
 abbrev Group : Type := FixedPointCandidate d.steinberg
 
 /-- Milestone L3 asks every valid branch to carry a group instance; the quotient construction

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -5,31 +5,18 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Frobenius
 public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.RootDatum
-public import TauCeti.GroupTheory.FixedPointCandidate
-public import TauCeti.GroupTheory.SpecificGroups.CFSG.Frobenius
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Closure
 
 /-!
-# The untwisted family `Cₙ(q)` on the standard symplectic carrier
+# The standard symplectic carrier of a validated type-`C` index
 
 The type-`C` branch of the classification list is built on the type-`C` diagram of rank `n`, and
 Tau Ceti's explicit full-weight Chevalley carrier for that diagram is `TauCeti.SpStd.groupScheme`,
 the Kostant toral closure of the standard representation of `sp_(2n)` inside `GL_(2n)` over `ℤ`.
-This file attaches that carrier to a validated type-`C` index: the group of
-algebraic-closure-valued points of the carrier at the index's rank, its Bourbaki-numbered simple
-root subgroups, the reading of their root characters in the type-`C` root datum the index names,
-the Steinberg endomorphism of the family, and the derived-central quotient of its fixed points
-
-```text
-H_d = fixedSubgroup d.steinberg,        d.Group = [H_d, H_d] / Z([H_d, H_d]).
-```
-
-The Steinberg map is the `q`-power Frobenius outright, `q` being the field order the index records.
-That is what an untwisted family asks for, and `TauCeti.TypeCLieIndex.diagramPerm_eq_one` is the
-check that the diagram permutation this index carries is indeed trivial: the type-`C` diagram has
-no symmetry to twist by, its last node carrying a root of a different length from the others, so
-`Cₙ(q)` is the only classification-list family on it.
+This file attaches that carrier to a validated type-`C` index: the group of algebraic-closure-valued
+points of the carrier at the index's rank, its Bourbaki-numbered simple root subgroups, and the
+reading of their root characters in the type-`C` root datum the index names.
 
 The carrier is indexed by `n` in the spelling `C (n + 1)`, so a validated index of rank `r` uses
 the carrier at `TauCeti.TypeCLieIndex.carrierRank`, which is `r - 1`. That subtraction is harmless
@@ -50,17 +37,7 @@ acquires the swap of the two Bourbaki nodes.
 
 Nothing here asserts that the carrier is reductive, that its weight torus is maximal, that it is
 the symplectic group scheme or the pinned simply connected Chevalley--Demazure group scheme of type
-`Cₙ`, or that any group below is finite, perfect, or simple. In particular
-`TauCeti.TypeCLieIndex.Group` is not asserted to be the finite simple group `Cₙ(q)`: reading it as
-that group needs an identification of the standard symplectic carrier with the pinned simply
-connected group of the same diagram, and no such identification is proved here or in the files this
-one imports.
-
-The same construction on the other branches already built is in
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeA.lean`,
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeD.lean`,
-`TauCeti/GroupTheory/SpecificGroups/CFSG/TypeE6.lean` and
-`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.
+`Cₙ`, or that its point group is finite.
 
 ## Main declarations
 
@@ -70,20 +47,10 @@ The same construction on the other branches already built is in
   Bourbaki-numbered node, with
   `TauCeti.TypeCLieIndex.rootGeneratorWeight_carrierNode_eq_root_simpleIndex` identifying the
   character of that subgroup with the corresponding simple root of the type-`C` root datum.
-* `TauCeti.TypeCLieIndex.steinberg`: the Steinberg endomorphism of the family, with
-  `TauCeti.TypeCLieIndex.coe_steinberg_apply` its entrywise description,
-  `TauCeti.TypeCLieIndex.steinberg_simpleRootSubgroup` its pinned equation
-  `Frob_q (x_i(u)) = x_i(u ^ q)`, and
-  `TauCeti.TypeCLieIndex.mem_fixedSubgroup_steinberg_iff` describing the points it fixes as those
-  whose matrix entries lie in the field of definition `𝔽_q`.
-* `TauCeti.TypeCLieIndex.Group`: the derived subgroup of those fixed points modulo its centre,
-  formed on the standard symplectic carrier.
 
 ## References
 
 * R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 11.3.
-* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17, for
-  the Steinberg endomorphism and its fixed points.
 * N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate III, for the numbering of the
   type-`C` diagram that the root subgroups below are indexed by.
 -/
@@ -184,88 +151,6 @@ theorem rootGeneratorWeight_carrierNode_eq_root_simpleIndex (i j : Fin d.1.rank)
   rw [SpStd.rootGeneratorWeight_inl]
   simp only [DynkinType.root_simpleIndex]
   rw [d.dynkinType_cartanMatrix_apply, d.cartanMatrix_C_carrierNode]
-
-/-! ## The Steinberg endomorphism -/
-
-/-- **The Steinberg endomorphism of a validated type-`C` index**: the `q`-power Frobenius of the
-ambient group, `q` being the field order the index records. The family is untwisted, so no diagram
-automorphism and no half-Frobenius enters; `TauCeti.TypeCLieIndex.diagramPerm_eq_one` is the check
-that its diagram permutation is trivial.
-
-It is the Steinberg map of `Cₙ(q)` on the pinned simply connected group of type `Cₙ` only along an
-identification of that group with this carrier, which is not proved here. -/
-def steinberg : d.AmbientGroup →* d.AmbientGroup :=
-  SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure
-
--- The unfolding lemma of a sealed definition, and deliberately not a `simp` lemma:
--- `steinberg_simpleRootSubgroup` and `coe_steinberg_apply` are the normal forms the pinned
--- equations of this file are stated against, and unfolding to `TauCeti.SpStd.frobenius` would keep
--- them from firing.
-/-- The Steinberg map of a type-`C` index is the Frobenius of the standard symplectic carrier at
-the characteristic and field exponent that the index records. -/
-theorem steinberg_def :
-    d.steinberg = SpStd.frobenius d.carrierRank d.1.characteristic d.1.fieldExponent d.1.Closure :=
-  (rfl)
-
-/-- The Steinberg map acts on the ambient group by raising every matrix entry to the `q`-th
-power. -/
-@[simp]
-theorem coe_steinberg_apply (g : d.AmbientGroup)
-    (r c : Fin (d.carrierRank + 1 + (d.carrierRank + 1))) :
-    ((d.steinberg g :
-        Matrix.GeneralLinearGroup (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
-        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
-          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c =
-      ((g :
-        Matrix.GeneralLinearGroup (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
-        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
-          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c ^ d.1.fieldOrder := by
-  rw [steinberg_def, d.1.fieldOrder_eq_characteristic_pow]
-  exact SpStd.coe_frobenius_apply _ _ _ _ g r c
-
-/-- **The Steinberg map fixes the Bourbaki numbering of a simple-root subgroup and raises its
-parameter to the `q`-th power**, that is, `Frob_q (x_i(u)) = x_i(u ^ q)`. This is the pinned
-equation of the Steinberg map of an untwisted family. -/
-@[simp]
-theorem steinberg_simpleRootSubgroup (i : Fin d.1.rank) (u : Multiplicative d.1.Closure) :
-    d.steinberg (d.simpleRootSubgroup i u) =
-      d.simpleRootSubgroup i
-        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.fieldOrder)) := by
-  rw [steinberg_def, simpleRootSubgroup_def, SpStd.frobenius_rootSubgroupPoints,
-    d.1.fieldOrder_eq_characteristic_pow]
-
--- As for `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`, this is not a `simp`
--- lemma: `TauCeti.fixedSubgroup` is `MonoidHom.eqLocus` against the identity, so `simp` rewrites
--- its left-hand side to `d.steinberg g = g` through `MonoidHom.mem_eqLocus`, and the `simpNF`
--- linter rejects the annotation.
-/-- **A point of the ambient group is fixed by the Steinberg map exactly when all of its matrix
-entries lie in the field of definition.** Writing `𝔽_q` for `TauCeti.ValidLieTypeIndex.fixedField`,
-the copy of the field of `q` elements inside the algebraic closure, the group `H_d` whose
-derived-central quotient is formed below is therefore the group of points of the standard symplectic
-carrier whose entries lie in `𝔽_q`. -/
-theorem mem_fixedSubgroup_steinberg_iff (g : d.AmbientGroup) :
-    g ∈ fixedSubgroup d.steinberg ↔
-      ∀ r c, ((g :
-          Matrix.GeneralLinearGroup (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) :
-        Matrix (Fin (d.carrierRank + 1 + (d.carrierRank + 1)))
-          (Fin (d.carrierRank + 1 + (d.carrierRank + 1))) d.1.Closure) r c ∈ d.1.fixedField := by
-  rw [mem_fixedSubgroup, steinberg_def, SpStd.frobenius_eq_self_iff]
-  simp only [mem_frobeniusFixedSubring, ValidLieTypeIndex.mem_fixedField,
-    d.1.fieldOrder_eq_characteristic_pow]
-
-/-! ## The derived-central quotient of the fixed points -/
-
-/-- **The derived-central quotient on the standard symplectic carrier**: the derived subgroup of the
-fixed points of the Steinberg map above, modulo the centre of that derived subgroup.
-
-This is the shape the untwisted family `Cₙ(q)` is cut out in, formed here on the standard symplectic
-carrier rather than on the pinned simply connected Chevalley--Demazure group scheme of type `Cₙ`. It
-reads as the candidate simple group of that family only along an identification of those two
-carriers, which is not proved here. Nothing below asserts that it is finite, perfect, or simple. -/
-abbrev Group : Type := FixedPointCandidate d.steinberg
-
-/-- The quotient carries a group instance, supplied by the quotient construction. -/
-example : _root_.Group d.Group := inferInstance
 
 end
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -86,9 +86,10 @@ The same construction on the other branches already built is in
   the Steinberg endomorphism and its fixed points.
 * N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate III, for the numbering of the
   type-`C` diagram that the root subgroups below are indexed by.
-* The signatures realized here follow the human-authored formal skeleton
-  `TauCetiRoadmap/CFSGStatement/Suggested.lean`.
 -/
+
+-- The signatures realized here follow the human-authored formal skeleton
+-- `TauCetiRoadmap/CFSGStatement/Suggested.lean`.
 
 public section
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/TypeC.lean
@@ -156,9 +156,10 @@ def simpleRootSubgroup (i : Fin d.1.rank) :
     Multiplicative d.1.Closure →* d.AmbientGroup :=
   SpStd.rootSubgroupPoints d.carrierRank (.inl (d.carrierNode i)) d.1.Closure
 
+-- The equation through which the upstream root-subgroup API reaches `simpleRootSubgroup`, whose
+-- definition itself stays sealed.
 /-- The simple-root subgroup is the carrier's numbered raising subgroup at the corresponding
-carrier node. This is the equation through which the upstream root-subgroup API reaches
-`simpleRootSubgroup`, whose definition itself stays sealed. -/
+carrier node. -/
 theorem simpleRootSubgroup_def (i : Fin d.1.rank) :
     d.simpleRootSubgroup i =
       SpStd.rootSubgroupPoints d.carrierRank (.inl (d.carrierNode i)) d.1.Closure :=


### PR DESCRIPTION
This PR keeps the Type C module documentation focused on the existing standard symplectic carrier API. It moves the roadmap-skeleton attribution out of the module docstring into an ordinary source comment, and moves the API-mechanics rationale for `simpleRootSubgroup_def` into an ordinary comment so the declaration docstring states only the mathematical equality.

The previously proposed L1 Steinberg map and L3 fixed-point quotient are removed. `TauCetiRoadmap/CFSGStatement/README.md` explicitly makes L1 depend on L0 and L0 depend on ReductiveGroups Layer 9, which does not yet exist for type C; those declarations therefore wait for that prerequisite.

Roadmap: CFSGStatement