### PR TITLE
feat: add supernatural index of profinite subgroups

### DIFF
--- a/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
@@ -50,6 +50,24 @@ namespace TauCeti
 variable {G : Type*} [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
   [TotallyDisconnectedSpace G]
 
+omit [TotallyDisconnectedSpace G] in
+/-- Taking the topological closure of a subgroup does not change its image in a finite
+continuous quotient. -/
+@[simp]
+theorem _root_.Subgroup.map_topologicalClosure_quotient_eq (H : Subgroup G)
+    (N : OpenNormalSubgroup G) :
+    H.topologicalClosure.map (QuotientGroup.mk' N.toSubgroup) =
+      H.map (QuotientGroup.mk' N.toSubgroup) := by
+  apply le_antisymm
+  · rw [Subgroup.map_le_iff_le_comap]
+    apply H.topologicalClosure_minimal
+      (Subgroup.le_comap_map (QuotientGroup.mk' N.toSubgroup) H)
+    exact
+      (Set.toFinite
+        (H.map (QuotientGroup.mk' N.toSubgroup) : Set (G ⧸ N.toSubgroup))).isClosed.preimage
+          (QuotientGroup.continuous_mk (N := N.toSubgroup))
+  · exact Subgroup.map_mono H.le_topologicalClosure
+
 /-- A closed subgroup of a profinite group is the infimum of the subgroups `N ⊔ U`, over the
 open normal subgroups `U` of `G`: the open normal subgroups are cofinal among the open
 subgroups containing `N`. This is the saturation statement behind the clopen-image argument

--- a/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Basic.lean
@@ -50,9 +50,9 @@ namespace TauCeti
 variable {G : Type*} [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
   [TotallyDisconnectedSpace G]
 
-omit [TotallyDisconnectedSpace G] in
-/-- Taking the topological closure of a subgroup does not change its image in a finite
-continuous quotient. -/
+omit [CompactSpace G] [TotallyDisconnectedSpace G] in
+/-- Taking the topological closure of a subgroup does not change its image in the quotient by
+an open normal subgroup: that quotient is discrete, so the image is already closed. -/
 @[simp]
 theorem _root_.Subgroup.map_topologicalClosure_quotient_eq (H : Subgroup G)
     (N : OpenNormalSubgroup G) :
@@ -62,10 +62,9 @@ theorem _root_.Subgroup.map_topologicalClosure_quotient_eq (H : Subgroup G)
   · rw [Subgroup.map_le_iff_le_comap]
     apply H.topologicalClosure_minimal
       (Subgroup.le_comap_map (QuotientGroup.mk' N.toSubgroup) H)
-    exact
-      (Set.toFinite
-        (H.map (QuotientGroup.mk' N.toSubgroup) : Set (G ⧸ N.toSubgroup))).isClosed.preimage
-          (QuotientGroup.continuous_mk (N := N.toSubgroup))
+    exact (isClosed_discrete
+      (H.map (QuotientGroup.mk' N.toSubgroup) : Set (G ⧸ N.toSubgroup))).preimage
+        (QuotientGroup.continuous_mk (N := N.toSubgroup))
   · exact Subgroup.map_mono H.le_topologicalClosure
 
 /-- A closed subgroup of a profinite group is the infimum of the subgroups `N ⊔ U`, over the

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -35,6 +35,9 @@ description as the least common multiple of the indices of open overgroups.
 * `Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top`: the index is one exactly
   for dense subgroups.
 * `Subgroup.profiniteIndex_eq_one_iff`: the closed-subgroup specialization.
+* `Subgroup.profiniteIndex_eq_bot_iff_topologicalClosure_eq_top` and
+  `Subgroup.profiniteIndex_eq_bot_iff`: the simp-normal forms of the two previous results,
+  since the supernatural unit is the bottom element.
 
 ## References
 
@@ -263,6 +266,14 @@ theorem _root_.Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top (H :
   · intro hclosure
     rw [← Subgroup.profiniteIndex_topologicalClosure H, hclosure, Subgroup.profiniteIndex_top]
 
+/-- Simp-normal form of `profiniteIndex_eq_one_iff_topologicalClosure_eq_top`: the supernatural
+unit is the bottom element, so `simp` states index one as `profiniteIndex H = ⊥`. -/
+@[simp]
+theorem _root_.Subgroup.profiniteIndex_eq_bot_iff_topologicalClosure_eq_top (H : Subgroup G) :
+    Subgroup.profiniteIndex H = ⊥ ↔ H.topologicalClosure = ⊤ := by
+  rw [← Supernatural.one_eq_bot,
+    Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top]
+
 /-- A closed subgroup of a profinite group has supernatural index one exactly when it is the
 whole group. -/
 theorem _root_.Subgroup.profiniteIndex_eq_one_iff (H : Subgroup G) (hH : IsClosed (H : Set G)) :
@@ -272,6 +283,16 @@ theorem _root_.Subgroup.profiniteIndex_eq_one_iff (H : Subgroup G) (hH : IsClose
     rw [Subgroup.topologicalClosure_coe, hH.closure_eq]
   rw [Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top,
     hclosure]
+
+/-- Simp-normal form of `profiniteIndex_eq_one_iff`, stating index one for a closed subgroup as
+`profiniteIndex H = ⊥`. Its priority is above
+`profiniteIndex_eq_bot_iff_topologicalClosure_eq_top`, so that a closed subgroup simplifies to
+`H = ⊤` rather than to a statement about its closure. -/
+@[simp high]
+theorem _root_.Subgroup.profiniteIndex_eq_bot_iff (H : Subgroup G)
+    (hH : IsClosed (H : Set G)) :
+    Subgroup.profiniteIndex H = ⊥ ↔ H = ⊤ := by
+  rw [← Supernatural.one_eq_bot, Subgroup.profiniteIndex_eq_one_iff H hH]
 
 end Subgroup
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -163,6 +163,7 @@ theorem profiniteIndex_apply_eq_iSup_openSubgroup [TotallyDisconnectedSpace G]
 
 /-- For an open subgroup, the supernatural index is the prime factorization of its ordinary
 index. -/
+@[simp]
 theorem profiniteIndex_openSubgroup [TotallyDisconnectedSpace G] (U : OpenSubgroup G) :
     profiniteIndex U.toSubgroup =
       Supernatural.ofNat
@@ -180,7 +181,6 @@ theorem profiniteIndex_openSubgroup [TotallyDisconnectedSpace G] (U : OpenSubgro
 
 /-- Primewise, the profinite index of an open subgroup is the valuation of its ordinary
 index. -/
-@[simp]
 theorem profiniteIndex_openSubgroup_apply [TotallyDisconnectedSpace G]
     (U : OpenSubgroup G) (ℓ : Nat.Primes) :
     profiniteIndex U.toSubgroup ℓ = (padicValNat ℓ U.toSubgroup.index : ℕ∞) := by

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.GroupTheory.Index
 public import TauCeti.NumberTheory.Supernatural
 public import TauCeti.Topology.Algebra.Group.Profinite.Basic
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -68,17 +68,17 @@ theorem _root_.Subgroup.profiniteIndex_apply (H : Subgroup G) (ℓ : Nat.Primes)
       (padicValNat ℓ ((H.map (QuotientGroup.mk' N.toSubgroup)).index) : ℕ∞) :=
   by rw [Subgroup.profiniteIndex, Supernatural.ofFun_apply]
 
-end Subgroup
-
 /-- The whole group has supernatural index one. -/
 @[simp]
-theorem profiniteIndex_top : Subgroup.profiniteIndex (⊤ : Subgroup G) = 1 := by
+theorem _root_.Subgroup.profiniteIndex_top : Subgroup.profiniteIndex (⊤ : Subgroup G) = 1 := by
   have hmap : ∀ N : OpenNormalSubgroup G,
       (⊤ : Subgroup G).map (QuotientGroup.mk' N.toSubgroup) = ⊤ := fun N ↦
     Subgroup.map_top_of_surjective _ (QuotientGroup.mk'_surjective N.toSubgroup)
   ext ℓ
   simp_rw [Subgroup.profiniteIndex_apply, hmap]
   simp
+
+end Subgroup
 
 section Profinite
 
@@ -217,20 +217,6 @@ theorem _root_.OpenSubgroup.profiniteIndex_apply [TotallyDisconnectedSpace G]
 
 end OpenSubgroup
 
-private theorem map_topologicalClosure_quotient_eq (H : Subgroup G)
-    (N : OpenNormalSubgroup G) :
-    H.topologicalClosure.map (QuotientGroup.mk' N.toSubgroup) =
-      H.map (QuotientGroup.mk' N.toSubgroup) := by
-  apply le_antisymm
-  · rw [Subgroup.map_le_iff_le_comap]
-    apply H.topologicalClosure_minimal
-      (Subgroup.le_comap_map (QuotientGroup.mk' N.toSubgroup) H)
-    exact
-      (Set.toFinite
-        (H.map (QuotientGroup.mk' N.toSubgroup) : Set (G ⧸ N.toSubgroup))).isClosed.preimage
-          (QuotientGroup.continuous_mk (N := N.toSubgroup))
-  · exact Subgroup.map_mono H.le_topologicalClosure
-
 namespace Subgroup
 
 /-- Taking the topological closure of a subgroup does not change its supernatural index. -/
@@ -238,7 +224,7 @@ namespace Subgroup
 theorem _root_.Subgroup.profiniteIndex_topologicalClosure (H : Subgroup G) :
     Subgroup.profiniteIndex H.topologicalClosure = Subgroup.profiniteIndex H := by
   ext ℓ
-  simp_rw [Subgroup.profiniteIndex_apply, map_topologicalClosure_quotient_eq]
+  simp_rw [Subgroup.profiniteIndex_apply, Subgroup.map_topologicalClosure_quotient_eq]
 
 variable [TotallyDisconnectedSpace G]
 
@@ -273,7 +259,7 @@ theorem _root_.Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top (H :
           Subgroup.comap_top]
       _ ≤ H.topologicalClosure ⊔ N.toSubgroup := sup_le_sup_right H.le_topologicalClosure _
   · intro hclosure
-    rw [← Subgroup.profiniteIndex_topologicalClosure H, hclosure, profiniteIndex_top]
+    rw [← Subgroup.profiniteIndex_topologicalClosure H, hclosure, Subgroup.profiniteIndex_top]
 
 /-- A closed subgroup of a profinite group has supernatural index one exactly when it is the
 whole group. -/

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -24,16 +24,16 @@ description as the least common multiple of the indices of open overgroups.
 
 ## Main results
 
-* `TauCeti.Subgroup.profiniteIndex`: the supernatural index of a subgroup of a profinite group.
-* `TauCeti.Subgroup.profiniteIndex_anti`: subgroup inclusion reverses supernatural indices.
-* `TauCeti.Subgroup.profiniteIndex_eq_iSup_openSubgroup`: the description as the least common
+* `Subgroup.profiniteIndex`: the supernatural index of a subgroup of a profinite group.
+* `Subgroup.profiniteIndex_anti`: subgroup inclusion reverses supernatural indices.
+* `Subgroup.profiniteIndex_eq_iSup_openSubgroup`: the description as the least common
   multiple of the indices of open overgroups.
-* `TauCeti.OpenSubgroup.profiniteIndex`: agreement with the ordinary index for an open subgroup.
-* `TauCeti.Subgroup.profiniteIndex_topologicalClosure`: taking topological closure does not change
+* `OpenSubgroup.profiniteIndex`: agreement with the ordinary index for an open subgroup.
+* `Subgroup.profiniteIndex_topologicalClosure`: taking topological closure does not change
   the index.
-* `TauCeti.Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top`: the index is one exactly
+* `Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top`: the index is one exactly
   for dense subgroups.
-* `TauCeti.Subgroup.profiniteIndex_eq_one_iff`: the closed-subgroup specialization.
+* `Subgroup.profiniteIndex_eq_one_iff`: the closed-subgroup specialization.
 
 ## References
 
@@ -56,17 +56,17 @@ namespace Subgroup
 
 The definition makes sense for an arbitrary subgroup; closedness is required only by results
 that regard the subgroup itself as profinite. -/
-noncomputable def profiniteIndex (H : Subgroup G) : Supernatural :=
+noncomputable def _root_.Subgroup.profiniteIndex (H : Subgroup G) : Supernatural :=
   Supernatural.ofFun fun ℓ ↦ ⨆ N : OpenNormalSubgroup G,
     (padicValNat ℓ ((H.map (QuotientGroup.mk' N.toSubgroup)).index) : ℕ∞)
 
 /-- The exponent of a profinite index at a prime is the supremum of the valuations of the
 indices in the finite continuous quotients. -/
 @[simp]
-theorem profiniteIndex_apply (H : Subgroup G) (ℓ : Nat.Primes) :
-    profiniteIndex H ℓ = ⨆ N : OpenNormalSubgroup G,
+theorem _root_.Subgroup.profiniteIndex_apply (H : Subgroup G) (ℓ : Nat.Primes) :
+    Subgroup.profiniteIndex H ℓ = ⨆ N : OpenNormalSubgroup G,
       (padicValNat ℓ ((H.map (QuotientGroup.mk' N.toSubgroup)).index) : ℕ∞) :=
-  by rw [profiniteIndex, Supernatural.ofFun_apply]
+  by rw [Subgroup.profiniteIndex, Supernatural.ofFun_apply]
 
 end Subgroup
 
@@ -88,13 +88,13 @@ namespace Subgroup
 
 /-- The supernatural index is equivalently the supremum of the ordinary positive indices of
 the images in finite continuous quotients. -/
-theorem profiniteIndex_eq_iSup_ofNat (H : Subgroup G) :
-    profiniteIndex H = ⨆ N : OpenNormalSubgroup G,
+theorem _root_.Subgroup.profiniteIndex_eq_iSup_ofNat (H : Subgroup G) :
+    Subgroup.profiniteIndex H = ⨆ N : OpenNormalSubgroup G,
       Supernatural.ofNat
         ⟨(H.map (QuotientGroup.mk' N.toSubgroup)).index,
           Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ := by
   ext ℓ
-  rw [profiniteIndex_apply, Supernatural.iSup_apply]
+  rw [Subgroup.profiniteIndex_apply, Supernatural.iSup_apply]
   congr 1
   funext N
   exact
@@ -103,9 +103,9 @@ theorem profiniteIndex_eq_iSup_ofNat (H : Subgroup G) :
         Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ ℓ).symm
 
 /-- Inclusion of subgroups reverses their supernatural indices. -/
-theorem profiniteIndex_anti {H K : Subgroup G} (h : H ≤ K) :
-    profiniteIndex K ≤ profiniteIndex H := by
-  rw [profiniteIndex_eq_iSup_ofNat, profiniteIndex_eq_iSup_ofNat]
+theorem _root_.Subgroup.profiniteIndex_anti {H K : Subgroup G} (h : H ≤ K) :
+    Subgroup.profiniteIndex K ≤ Subgroup.profiniteIndex H := by
+  rw [Subgroup.profiniteIndex_eq_iSup_ofNat, Subgroup.profiniteIndex_eq_iSup_ofNat]
   refine iSup_le fun N ↦ ?_
   refine (Supernatural.ofNat_le_ofNat_iff.mpr ?_).trans
     (le_iSup (fun N : OpenNormalSubgroup G ↦
@@ -119,12 +119,13 @@ ordinary indices of the open subgroups containing `H`.
 
 Although the usual statement assumes that `H` is closed, the formula holds for every subgroup:
 an open subgroup contains `H` exactly when it contains its closure. -/
-theorem profiniteIndex_eq_iSup_openSubgroup [TotallyDisconnectedSpace G] (H : Subgroup G) :
-    profiniteIndex H = ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
+theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup [TotallyDisconnectedSpace G]
+    (H : Subgroup G) :
+    Subgroup.profiniteIndex H = ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
       Supernatural.ofNat
         (⟨U.1.toSubgroup.index,
           Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) := by
-  rw [profiniteIndex_eq_iSup_ofNat]
+  rw [Subgroup.profiniteIndex_eq_iSup_ofNat]
   have index_image_eq (N : OpenNormalSubgroup G) :
       (H.map (QuotientGroup.mk' N.toSubgroup)).index =
         (H ⊔ N.toSubgroup).index := by
@@ -172,11 +173,11 @@ theorem profiniteIndex_eq_iSup_openSubgroup [TotallyDisconnectedSpace G] (H : Su
     exact PNat.dvd_iff.mpr hdvd
 
 /-- Primewise form of `profiniteIndex_eq_iSup_openSubgroup`. -/
-theorem profiniteIndex_apply_eq_iSup_openSubgroup [TotallyDisconnectedSpace G]
+theorem _root_.Subgroup.profiniteIndex_apply_eq_iSup_openSubgroup [TotallyDisconnectedSpace G]
     (H : Subgroup G) (ℓ : Nat.Primes) :
-    profiniteIndex H ℓ = ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
+    Subgroup.profiniteIndex H ℓ = ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
       (padicValNat ℓ U.1.toSubgroup.index : ℕ∞) := by
-  rw [profiniteIndex_eq_iSup_openSubgroup, Supernatural.iSup_apply]
+  rw [Subgroup.profiniteIndex_eq_iSup_openSubgroup, Supernatural.iSup_apply]
   congr 1
   funext U
   exact Supernatural.ofNat_apply _ _
@@ -188,7 +189,7 @@ namespace OpenSubgroup
 /-- For an open subgroup, the supernatural index is the prime factorization of its ordinary
 index. -/
 @[simp]
-theorem profiniteIndex [TotallyDisconnectedSpace G] (U : OpenSubgroup G) :
+theorem _root_.OpenSubgroup.profiniteIndex [TotallyDisconnectedSpace G] (U : OpenSubgroup G) :
     Subgroup.profiniteIndex U.toSubgroup =
       Supernatural.ofNat
         (⟨U.toSubgroup.index,
@@ -205,11 +206,11 @@ theorem profiniteIndex [TotallyDisconnectedSpace G] (U : OpenSubgroup G) :
 
 /-- Primewise, the profinite index of an open subgroup is the valuation of its ordinary
 index. -/
-theorem profiniteIndex_apply [TotallyDisconnectedSpace G]
+theorem _root_.OpenSubgroup.profiniteIndex_apply [TotallyDisconnectedSpace G]
     (U : OpenSubgroup G) (ℓ : Nat.Primes) :
     Subgroup.profiniteIndex U.toSubgroup ℓ =
       (padicValNat ℓ U.toSubgroup.index : ℕ∞) := by
-  rw [profiniteIndex]
+  rw [OpenSubgroup.profiniteIndex]
   exact Supernatural.ofNat_apply
     (⟨U.toSubgroup.index,
       Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) ℓ
@@ -234,16 +235,16 @@ namespace Subgroup
 
 /-- Taking the topological closure of a subgroup does not change its supernatural index. -/
 @[simp]
-theorem profiniteIndex_topologicalClosure (H : Subgroup G) :
-    profiniteIndex H.topologicalClosure = profiniteIndex H := by
+theorem _root_.Subgroup.profiniteIndex_topologicalClosure (H : Subgroup G) :
+    Subgroup.profiniteIndex H.topologicalClosure = Subgroup.profiniteIndex H := by
   ext ℓ
-  simp_rw [profiniteIndex_apply, map_topologicalClosure_quotient_eq]
+  simp_rw [Subgroup.profiniteIndex_apply, map_topologicalClosure_quotient_eq]
 
 variable [TotallyDisconnectedSpace G]
 
 /-- A subgroup of a profinite group has supernatural index one exactly when it is dense. -/
-theorem profiniteIndex_eq_one_iff_topologicalClosure_eq_top (H : Subgroup G) :
-    profiniteIndex H = 1 ↔ H.topologicalClosure = ⊤ := by
+theorem _root_.Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top (H : Subgroup G) :
+    Subgroup.profiniteIndex H = 1 ↔ H.topologicalClosure = ⊤ := by
   constructor
   · intro hindex
     have himage : ∀ N : OpenNormalSubgroup G,
@@ -253,8 +254,8 @@ theorem profiniteIndex_eq_one_iff_topologicalClosure_eq_top (H : Subgroup G) :
       let n : ℕ+ :=
         ⟨(H.map (QuotientGroup.mk' N.toSubgroup)).index,
           Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩
-      have hle : Supernatural.ofNat n ≤ profiniteIndex H := by
-        rw [profiniteIndex_eq_iSup_ofNat]
+      have hle : Supernatural.ofNat n ≤ Subgroup.profiniteIndex H := by
+        rw [Subgroup.profiniteIndex_eq_iSup_ofNat]
         exact le_iSup (fun U : OpenNormalSubgroup G ↦
           Supernatural.ofNat
             ⟨(H.map (QuotientGroup.mk' U.toSubgroup)).index,
@@ -272,16 +273,16 @@ theorem profiniteIndex_eq_one_iff_topologicalClosure_eq_top (H : Subgroup G) :
           Subgroup.comap_top]
       _ ≤ H.topologicalClosure ⊔ N.toSubgroup := sup_le_sup_right H.le_topologicalClosure _
   · intro hclosure
-    rw [← profiniteIndex_topologicalClosure H, hclosure, profiniteIndex_top]
+    rw [← Subgroup.profiniteIndex_topologicalClosure H, hclosure, profiniteIndex_top]
 
 /-- A closed subgroup of a profinite group has supernatural index one exactly when it is the
 whole group. -/
-theorem profiniteIndex_eq_one_iff (H : Subgroup G) (hH : IsClosed (H : Set G)) :
-    profiniteIndex H = 1 ↔ H = ⊤ := by
+theorem _root_.Subgroup.profiniteIndex_eq_one_iff (H : Subgroup G) (hH : IsClosed (H : Set G)) :
+    Subgroup.profiniteIndex H = 1 ↔ H = ⊤ := by
   have hclosure : H.topologicalClosure = H := by
     apply SetLike.coe_injective
     rw [Subgroup.topologicalClosure_coe, hH.closure_eq]
-  rw [profiniteIndex_eq_one_iff_topologicalClosure_eq_top,
+  rw [Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top,
     hclosure]
 
 end Subgroup

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -24,14 +24,16 @@ description as the least common multiple of the indices of open overgroups.
 
 ## Main results
 
-* `profiniteIndex`: the supernatural index of a subgroup of a profinite group.
-* `profiniteIndex_eq_iSup_openSubgroup`: the description as the least common multiple of the
-  indices of open overgroups.
-* `profiniteIndex_openSubgroup`: agreement with the ordinary index for an open subgroup.
-* `profiniteIndex_topologicalClosure`: taking topological closure does not change the index.
-* `profiniteIndex_eq_one_iff_topologicalClosure_eq_top`: the index is one exactly for dense
-  subgroups.
-* `profiniteIndex_eq_one_iff`: the closed-subgroup specialization.
+* `TauCeti.Subgroup.profiniteIndex`: the supernatural index of a subgroup of a profinite group.
+* `TauCeti.Subgroup.profiniteIndex_anti`: subgroup inclusion reverses supernatural indices.
+* `TauCeti.Subgroup.profiniteIndex_eq_iSup_openSubgroup`: the description as the least common
+  multiple of the indices of open overgroups.
+* `TauCeti.OpenSubgroup.profiniteIndex`: agreement with the ordinary index for an open subgroup.
+* `TauCeti.Subgroup.profiniteIndex_topologicalClosure`: taking topological closure does not change
+  the index.
+* `TauCeti.Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top`: the index is one exactly
+  for dense subgroups.
+* `TauCeti.Subgroup.profiniteIndex_eq_one_iff`: the closed-subgroup specialization.
 
 ## References
 
@@ -45,6 +47,8 @@ namespace TauCeti
 open scoped ENat
 
 variable {G : Type*} [Group G] [TopologicalSpace G]
+
+namespace Subgroup
 
 /-- The **index of a subgroup of a profinite group**, as a supernatural number. At a prime
 `ℓ`, it is the supremum over open normal subgroups `N` of the `ℓ`-adic valuations of
@@ -64,19 +68,23 @@ theorem profiniteIndex_apply (H : Subgroup G) (ℓ : Nat.Primes) :
       (padicValNat ℓ ((H.map (QuotientGroup.mk' N.toSubgroup)).index) : ℕ∞) :=
   by rw [profiniteIndex, Supernatural.ofFun_apply]
 
+end Subgroup
+
 /-- The whole group has supernatural index one. -/
 @[simp]
-theorem profiniteIndex_top : profiniteIndex (⊤ : Subgroup G) = 1 := by
+theorem profiniteIndex_top : Subgroup.profiniteIndex (⊤ : Subgroup G) = 1 := by
   have hmap : ∀ N : OpenNormalSubgroup G,
       (⊤ : Subgroup G).map (QuotientGroup.mk' N.toSubgroup) = ⊤ := fun N ↦
     Subgroup.map_top_of_surjective _ (QuotientGroup.mk'_surjective N.toSubgroup)
   ext ℓ
-  simp_rw [profiniteIndex_apply, hmap]
+  simp_rw [Subgroup.profiniteIndex_apply, hmap]
   simp
 
 section Profinite
 
 variable [IsTopologicalGroup G] [CompactSpace G]
+
+namespace Subgroup
 
 /-- The supernatural index is equivalently the supremum of the ordinary positive indices of
 the images in finite continuous quotients. -/
@@ -93,6 +101,18 @@ theorem profiniteIndex_eq_iSup_ofNat (H : Subgroup G) :
     (Supernatural.ofNat_apply
       ⟨(H.map (QuotientGroup.mk' N.toSubgroup)).index,
         Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ ℓ).symm
+
+/-- Inclusion of subgroups reverses their supernatural indices. -/
+theorem profiniteIndex_anti {H K : Subgroup G} (h : H ≤ K) :
+    profiniteIndex K ≤ profiniteIndex H := by
+  rw [profiniteIndex_eq_iSup_ofNat, profiniteIndex_eq_iSup_ofNat]
+  refine iSup_le fun N ↦ ?_
+  refine (Supernatural.ofNat_le_ofNat_iff.mpr ?_).trans
+    (le_iSup (fun N : OpenNormalSubgroup G ↦
+      Supernatural.ofNat
+        ⟨(H.map (QuotientGroup.mk' N.toSubgroup)).index,
+          Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩) N)
+  exact PNat.dvd_iff.mpr (Subgroup.index_dvd_of_le (Subgroup.map_mono h))
 
 /-- The profinite index is the least common multiple, in the supernatural lattice, of the
 ordinary indices of the open subgroups containing `H`.
@@ -161,15 +181,19 @@ theorem profiniteIndex_apply_eq_iSup_openSubgroup [TotallyDisconnectedSpace G]
   funext U
   exact Supernatural.ofNat_apply _ _
 
+end Subgroup
+
+namespace OpenSubgroup
+
 /-- For an open subgroup, the supernatural index is the prime factorization of its ordinary
 index. -/
 @[simp]
-theorem profiniteIndex_openSubgroup [TotallyDisconnectedSpace G] (U : OpenSubgroup G) :
-    profiniteIndex U.toSubgroup =
+theorem profiniteIndex [TotallyDisconnectedSpace G] (U : OpenSubgroup G) :
+    Subgroup.profiniteIndex U.toSubgroup =
       Supernatural.ofNat
         (⟨U.toSubgroup.index,
           Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) := by
-  rw [profiniteIndex_eq_iSup_openSubgroup]
+  rw [Subgroup.profiniteIndex_eq_iSup_openSubgroup]
   apply le_antisymm
   · refine iSup_le fun V ↦ ?_
     exact Supernatural.ofNat_le_ofNat_iff.mpr <|
@@ -181,13 +205,16 @@ theorem profiniteIndex_openSubgroup [TotallyDisconnectedSpace G] (U : OpenSubgro
 
 /-- Primewise, the profinite index of an open subgroup is the valuation of its ordinary
 index. -/
-theorem profiniteIndex_openSubgroup_apply [TotallyDisconnectedSpace G]
+theorem profiniteIndex_apply [TotallyDisconnectedSpace G]
     (U : OpenSubgroup G) (ℓ : Nat.Primes) :
-    profiniteIndex U.toSubgroup ℓ = (padicValNat ℓ U.toSubgroup.index : ℕ∞) := by
-  rw [profiniteIndex_openSubgroup]
+    Subgroup.profiniteIndex U.toSubgroup ℓ =
+      (padicValNat ℓ U.toSubgroup.index : ℕ∞) := by
+  rw [profiniteIndex]
   exact Supernatural.ofNat_apply
     (⟨U.toSubgroup.index,
       Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) ℓ
+
+end OpenSubgroup
 
 private theorem map_topologicalClosure_quotient_eq (H : Subgroup G)
     (N : OpenNormalSubgroup G) :
@@ -202,6 +229,8 @@ private theorem map_topologicalClosure_quotient_eq (H : Subgroup G)
         (H.map (QuotientGroup.mk' N.toSubgroup) : Set (G ⧸ N.toSubgroup))).isClosed.preimage
           (QuotientGroup.continuous_mk (N := N.toSubgroup))
   · exact Subgroup.map_mono H.le_topologicalClosure
+
+namespace Subgroup
 
 /-- Taking the topological closure of a subgroup does not change its supernatural index. -/
 @[simp]
@@ -254,6 +283,8 @@ theorem profiniteIndex_eq_one_iff (H : Subgroup G) (hH : IsClosed (H : Set G)) :
     rw [Subgroup.topologicalClosure_coe, hH.closure_eq]
   rw [profiniteIndex_eq_one_iff_topologicalClosure_eq_top,
     hclosure]
+
+end Subgroup
 
 end Profinite
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -1,0 +1,260 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.Index
+public import TauCeti.NumberTheory.Supernatural
+public import TauCeti.Topology.Algebra.Group.Profinite.Basic
+
+/-!
+# Indices of subgroups of profinite groups
+
+The index of a subgroup of a profinite group is a supernatural number. Its exponent at a
+prime `ℓ` is the supremum of the `ℓ`-adic valuations of the indices of the subgroup's images
+in all finite continuous quotients.
+
+The definition applies to an arbitrary subgroup. It only sees the subgroup's topological
+closure, as every finite continuous quotient has discrete topology. In particular, its index
+is one exactly when the subgroup is dense; for closed subgroups, this says exactly that the
+subgroup is the whole group. These closure comparisons are the starting point for the usual
+description as the least common multiple of the indices of open overgroups.
+
+## Main results
+
+* `profiniteIndex`: the supernatural index of a subgroup of a profinite group.
+* `profiniteIndex_eq_iSup_openSubgroup`: the description as the least common multiple of the
+  indices of open overgroups.
+* `profiniteIndex_openSubgroup`: agreement with the ordinary index for an open subgroup.
+* `profiniteIndex_topologicalClosure`: taking topological closure does not change the index.
+* `profiniteIndex_eq_one_iff_topologicalClosure_eq_top`: the index is one exactly for dense
+  subgroups.
+* `profiniteIndex_eq_one_iff`: the closed-subgroup specialization.
+
+## References
+
+* L. Ribes and P. Zalesskii, *Profinite Groups*, Section 2.3.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped ENat
+
+variable {G : Type*} [Group G] [TopologicalSpace G]
+
+/-- The **index of a subgroup of a profinite group**, as a supernatural number. At a prime
+`ℓ`, it is the supremum over open normal subgroups `N` of the `ℓ`-adic valuations of
+`[G/N : HN/N]`.
+
+The definition makes sense for an arbitrary subgroup; closedness is required only by results
+that regard the subgroup itself as profinite. -/
+noncomputable def profiniteIndex (H : Subgroup G) : Supernatural :=
+  Supernatural.ofFun fun ℓ ↦ ⨆ N : OpenNormalSubgroup G,
+    (padicValNat ℓ ((H.map (QuotientGroup.mk' N.toSubgroup)).index) : ℕ∞)
+
+/-- The exponent of a profinite index at a prime is the supremum of the valuations of the
+indices in the finite continuous quotients. -/
+@[simp]
+theorem profiniteIndex_apply (H : Subgroup G) (ℓ : Nat.Primes) :
+    profiniteIndex H ℓ = ⨆ N : OpenNormalSubgroup G,
+      (padicValNat ℓ ((H.map (QuotientGroup.mk' N.toSubgroup)).index) : ℕ∞) :=
+  by rw [profiniteIndex, Supernatural.ofFun_apply]
+
+/-- The whole group has supernatural index one. -/
+@[simp]
+theorem profiniteIndex_top : profiniteIndex (⊤ : Subgroup G) = 1 := by
+  have hmap : ∀ N : OpenNormalSubgroup G,
+      (⊤ : Subgroup G).map (QuotientGroup.mk' N.toSubgroup) = ⊤ := fun N ↦
+    Subgroup.map_top_of_surjective _ (QuotientGroup.mk'_surjective N.toSubgroup)
+  ext ℓ
+  simp_rw [profiniteIndex_apply, hmap]
+  simp
+
+section Profinite
+
+variable [IsTopologicalGroup G] [CompactSpace G]
+
+/-- The supernatural index is equivalently the supremum of the ordinary positive indices of
+the images in finite continuous quotients. -/
+theorem profiniteIndex_eq_iSup_ofNat (H : Subgroup G) :
+    profiniteIndex H = ⨆ N : OpenNormalSubgroup G,
+      Supernatural.ofNat
+        ⟨(H.map (QuotientGroup.mk' N.toSubgroup)).index,
+          Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ := by
+  ext ℓ
+  rw [profiniteIndex_apply, Supernatural.iSup_apply]
+  congr 1
+  funext N
+  exact
+    (Supernatural.ofNat_apply
+      ⟨(H.map (QuotientGroup.mk' N.toSubgroup)).index,
+        Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ ℓ).symm
+
+/-- The profinite index is the least common multiple, in the supernatural lattice, of the
+ordinary indices of the open subgroups containing `H`.
+
+Although the usual statement assumes that `H` is closed, the formula holds for every subgroup:
+an open subgroup contains `H` exactly when it contains its closure. -/
+theorem profiniteIndex_eq_iSup_openSubgroup [TotallyDisconnectedSpace G] (H : Subgroup G) :
+    profiniteIndex H = ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
+      Supernatural.ofNat
+        (⟨U.1.toSubgroup.index,
+          Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) := by
+  rw [profiniteIndex_eq_iSup_ofNat]
+  have index_image_eq (N : OpenNormalSubgroup G) :
+      (H.map (QuotientGroup.mk' N.toSubgroup)).index =
+        (H ⊔ N.toSubgroup).index := by
+    rw [H.index_map, QuotientGroup.ker_mk',
+      (QuotientGroup.mk' N.toSubgroup).range_eq_top_of_surjective
+        (QuotientGroup.mk'_surjective N.toSubgroup), Subgroup.index_top, mul_one]
+  apply le_antisymm
+  · refine iSup_le fun N ↦ ?_
+    let V : OpenSubgroup G :=
+      { toSubgroup := H ⊔ N.toSubgroup
+        isOpen' := Subgroup.isOpen_of_openSubgroup _ le_sup_right }
+    let V' : {U : OpenSubgroup G // H ≤ U.toSubgroup} := ⟨V, le_sup_left⟩
+    have hVpos : 0 < V.toSubgroup.index := by
+      rw [← index_image_eq N]
+      exact Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite
+    calc
+      Supernatural.ofNat
+          (⟨(H.map (QuotientGroup.mk' N.toSubgroup)).index,
+            Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) =
+          Supernatural.ofNat
+            (⟨V.toSubgroup.index,
+              hVpos⟩ : ℕ+) := by
+        apply congrArg Supernatural.ofNat
+        exact Subtype.ext (index_image_eq N)
+      _ ≤ ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
+          Supernatural.ofNat
+            (⟨U.1.toSubgroup.index,
+              Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) := by
+        simpa only [V'] using le_iSup (fun U : {U : OpenSubgroup G // H ≤ U.toSubgroup} ↦
+          Supernatural.ofNat
+            (⟨U.1.toSubgroup.index,
+              Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+)) V'
+  · refine iSup_le fun U ↦ ?_
+    obtain ⟨N, hN⟩ :=
+      ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one U.1.isOpen U.1.one_mem'
+    have hdvd : U.1.toSubgroup.index ∣
+        (H.map (QuotientGroup.mk' N.toSubgroup)).index := by
+      rw [index_image_eq N]
+      exact Subgroup.index_dvd_of_le (sup_le U.2 fun _ hx ↦ hN hx)
+    refine le_trans ?_ (le_iSup (fun N : OpenNormalSubgroup G ↦
+      Supernatural.ofNat
+        (⟨(H.map (QuotientGroup.mk' N.toSubgroup)).index,
+          Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+)) N)
+    apply Supernatural.ofNat_le_ofNat_iff.mpr
+    exact PNat.dvd_iff.mpr hdvd
+
+/-- Primewise form of `profiniteIndex_eq_iSup_openSubgroup`. -/
+theorem profiniteIndex_apply_eq_iSup_openSubgroup [TotallyDisconnectedSpace G]
+    (H : Subgroup G) (ℓ : Nat.Primes) :
+    profiniteIndex H ℓ = ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
+      (padicValNat ℓ U.1.toSubgroup.index : ℕ∞) := by
+  rw [profiniteIndex_eq_iSup_openSubgroup, Supernatural.iSup_apply]
+  congr 1
+  funext U
+  exact Supernatural.ofNat_apply _ _
+
+/-- For an open subgroup, the supernatural index is the prime factorization of its ordinary
+index. -/
+theorem profiniteIndex_openSubgroup [TotallyDisconnectedSpace G] (U : OpenSubgroup G) :
+    profiniteIndex U.toSubgroup =
+      Supernatural.ofNat
+        (⟨U.toSubgroup.index,
+          Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) := by
+  rw [profiniteIndex_eq_iSup_openSubgroup]
+  apply le_antisymm
+  · refine iSup_le fun V ↦ ?_
+    exact Supernatural.ofNat_le_ofNat_iff.mpr <|
+      PNat.dvd_iff.mpr (Subgroup.index_dvd_of_le V.2)
+  · exact le_iSup (fun V : {V : OpenSubgroup G // U.toSubgroup ≤ V.toSubgroup} ↦
+      Supernatural.ofNat
+        (⟨V.1.toSubgroup.index,
+          Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+)) ⟨U, le_rfl⟩
+
+/-- Primewise, the profinite index of an open subgroup is the valuation of its ordinary
+index. -/
+@[simp]
+theorem profiniteIndex_openSubgroup_apply [TotallyDisconnectedSpace G]
+    (U : OpenSubgroup G) (ℓ : Nat.Primes) :
+    profiniteIndex U.toSubgroup ℓ = (padicValNat ℓ U.toSubgroup.index : ℕ∞) := by
+  rw [profiniteIndex_openSubgroup]
+  exact Supernatural.ofNat_apply
+    (⟨U.toSubgroup.index,
+      Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) ℓ
+
+private theorem map_topologicalClosure_quotient_eq (H : Subgroup G)
+    (N : OpenNormalSubgroup G) :
+    H.topologicalClosure.map (QuotientGroup.mk' N.toSubgroup) =
+      H.map (QuotientGroup.mk' N.toSubgroup) := by
+  apply le_antisymm
+  · rw [Subgroup.map_le_iff_le_comap]
+    apply H.topologicalClosure_minimal
+      (Subgroup.le_comap_map (QuotientGroup.mk' N.toSubgroup) H)
+    exact
+      (Set.toFinite
+        (H.map (QuotientGroup.mk' N.toSubgroup) : Set (G ⧸ N.toSubgroup))).isClosed.preimage
+          (QuotientGroup.continuous_mk (N := N.toSubgroup))
+  · exact Subgroup.map_mono H.le_topologicalClosure
+
+/-- Taking the topological closure of a subgroup does not change its supernatural index. -/
+@[simp]
+theorem profiniteIndex_topologicalClosure (H : Subgroup G) :
+    profiniteIndex H.topologicalClosure = profiniteIndex H := by
+  ext ℓ
+  simp_rw [profiniteIndex_apply, map_topologicalClosure_quotient_eq]
+
+variable [TotallyDisconnectedSpace G]
+
+/-- A subgroup of a profinite group has supernatural index one exactly when it is dense. -/
+theorem profiniteIndex_eq_one_iff_topologicalClosure_eq_top (H : Subgroup G) :
+    profiniteIndex H = 1 ↔ H.topologicalClosure = ⊤ := by
+  constructor
+  · intro hindex
+    have himage : ∀ N : OpenNormalSubgroup G,
+        H.map (QuotientGroup.mk' N.toSubgroup) = ⊤ := by
+      intro N
+      rw [← Subgroup.index_eq_one]
+      let n : ℕ+ :=
+        ⟨(H.map (QuotientGroup.mk' N.toSubgroup)).index,
+          Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩
+      have hle : Supernatural.ofNat n ≤ profiniteIndex H := by
+        rw [profiniteIndex_eq_iSup_ofNat]
+        exact le_iSup (fun U : OpenNormalSubgroup G ↦
+          Supernatural.ofNat
+            ⟨(H.map (QuotientGroup.mk' U.toSubgroup)).index,
+              Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩) N
+      rw [hindex, ← Supernatural.ofNat_one, Supernatural.ofNat_le_ofNat_iff] at hle
+      exact congrArg Subtype.val ((PNat.dvd_one_iff n).mp hle)
+    rw [Subgroup.eq_iInf_sup_openNormalSubgroup H.topologicalClosure
+      H.isClosed_topologicalClosure]
+    apply iInf_eq_top.mpr
+    intro N
+    apply top_unique
+    calc
+      ⊤ = H ⊔ N.toSubgroup := by
+        rw [sup_comm, ← QuotientGroup.comap_map_mk' N.toSubgroup H, himage N,
+          Subgroup.comap_top]
+      _ ≤ H.topologicalClosure ⊔ N.toSubgroup := sup_le_sup_right H.le_topologicalClosure _
+  · intro hclosure
+    rw [← profiniteIndex_topologicalClosure H, hclosure, profiniteIndex_top]
+
+/-- A closed subgroup of a profinite group has supernatural index one exactly when it is the
+whole group. -/
+theorem profiniteIndex_eq_one_iff (H : Subgroup G) (hH : IsClosed (H : Set G)) :
+    profiniteIndex H = 1 ↔ H = ⊤ := by
+  have hclosure : H.topologicalClosure = H := by
+    apply SetLike.coe_injective
+    rw [Subgroup.topologicalClosure_coe, hH.closure_eq]
+  rw [profiniteIndex_eq_one_iff_topologicalClosure_eq_top,
+    hclosure]
+
+end Profinite
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -28,7 +28,8 @@ description as the least common multiple of the indices of open overgroups.
 * `Subgroup.profiniteIndex_anti`: subgroup inclusion reverses supernatural indices.
 * `Subgroup.profiniteIndex_eq_iSup_openSubgroup`: the description as the least common
   multiple of the indices of open overgroups.
-* `OpenSubgroup.profiniteIndex`: agreement with the ordinary index for an open subgroup.
+* `OpenSubgroup.profiniteIndex_eq_ofNat_index`: agreement with the ordinary index for an
+  open subgroup.
 * `Subgroup.profiniteIndex_topologicalClosure`: taking topological closure does not change
   the index.
 * `Subgroup.profiniteIndex_eq_one_iff_topologicalClosure_eq_top`: the index is one exactly
@@ -119,8 +120,7 @@ ordinary indices of the open subgroups containing `H`.
 
 Although the usual statement assumes that `H` is closed, the formula holds for every subgroup:
 an open subgroup contains `H` exactly when it contains its closure. -/
-theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup [TotallyDisconnectedSpace G]
-    (H : Subgroup G) :
+theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup (H : Subgroup G) :
     Subgroup.profiniteIndex H = ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
       Supernatural.ofNat
         (⟨U.1.toSubgroup.index,
@@ -160,7 +160,8 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup [TotallyDisconnected
               Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+)) V'
   · refine iSup_le fun U ↦ ?_
     obtain ⟨N, hN⟩ :=
-      ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one U.1.isOpen U.1.one_mem'
+      IsTopologicalGroup.exist_openNormalSubgroup_sub_clopen_nhds_of_one U.1.isClopen
+        U.1.one_mem'
     have hdvd : U.1.toSubgroup.index ∣
         (H.map (QuotientGroup.mk' N.toSubgroup)).index := by
       rw [index_image_eq N]
@@ -173,8 +174,8 @@ theorem _root_.Subgroup.profiniteIndex_eq_iSup_openSubgroup [TotallyDisconnected
     exact PNat.dvd_iff.mpr hdvd
 
 /-- Primewise form of `profiniteIndex_eq_iSup_openSubgroup`. -/
-theorem _root_.Subgroup.profiniteIndex_apply_eq_iSup_openSubgroup [TotallyDisconnectedSpace G]
-    (H : Subgroup G) (ℓ : Nat.Primes) :
+theorem _root_.Subgroup.profiniteIndex_apply_eq_iSup_openSubgroup (H : Subgroup G)
+    (ℓ : Nat.Primes) :
     Subgroup.profiniteIndex H ℓ = ⨆ U : {U : OpenSubgroup G // H ≤ U.toSubgroup},
       (padicValNat ℓ U.1.toSubgroup.index : ℕ∞) := by
   rw [Subgroup.profiniteIndex_eq_iSup_openSubgroup, Supernatural.iSup_apply]
@@ -189,7 +190,7 @@ namespace OpenSubgroup
 /-- For an open subgroup, the supernatural index is the prime factorization of its ordinary
 index. -/
 @[simp]
-theorem _root_.OpenSubgroup.profiniteIndex [TotallyDisconnectedSpace G] (U : OpenSubgroup G) :
+theorem _root_.OpenSubgroup.profiniteIndex_eq_ofNat_index (U : OpenSubgroup G) :
     Subgroup.profiniteIndex U.toSubgroup =
       Supernatural.ofNat
         (⟨U.toSubgroup.index,
@@ -206,11 +207,11 @@ theorem _root_.OpenSubgroup.profiniteIndex [TotallyDisconnectedSpace G] (U : Ope
 
 /-- Primewise, the profinite index of an open subgroup is the valuation of its ordinary
 index. -/
-theorem _root_.OpenSubgroup.profiniteIndex_apply [TotallyDisconnectedSpace G]
-    (U : OpenSubgroup G) (ℓ : Nat.Primes) :
+theorem _root_.OpenSubgroup.profiniteIndex_apply_eq_padicValNat (U : OpenSubgroup G)
+    (ℓ : Nat.Primes) :
     Subgroup.profiniteIndex U.toSubgroup ℓ =
       (padicValNat ℓ U.toSubgroup.index : ℕ∞) := by
-  rw [OpenSubgroup.profiniteIndex]
+  rw [OpenSubgroup.profiniteIndex_eq_ofNat_index]
   exact Supernatural.ofNat_apply
     (⟨U.toSubgroup.index,
       Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) ℓ
@@ -219,6 +220,7 @@ end OpenSubgroup
 
 namespace Subgroup
 
+omit [CompactSpace G] in
 /-- Taking the topological closure of a subgroup does not change its supernatural index. -/
 @[simp]
 theorem _root_.Subgroup.profiniteIndex_topologicalClosure (H : Subgroup G) :


### PR DESCRIPTION
This PR defines the supernatural index `profiniteIndex H` of a subgroup of a profinite group and proves the comparison results that characterize it. It advances `TauCetiRoadmap/ProfiniteProPGroups/README.md`, Layer 1, milestone “The index of a closed subgroup”: the exponent at `ℓ` is the supremum of the `ℓ`-adic valuations of `[G/N : HN/N]`, and `profiniteIndex_eq_iSup_openSubgroup` identifies the resulting supernatural number with the least common multiple of the ordinary indices `[G : U]` over open overgroups `H ≤ U`.

This is the most effective unclaimed critical-path step alongside open PR #5621’s supernatural order: index is the other Layer 1 carrier needed by Lagrange and the supernatural formulation of pro-`p` Sylow subgroups. The lcm theorem is stated in the stronger natural form for arbitrary `H`, since every open overgroup is closed and therefore contains `H` exactly when it contains its topological closure; the requested closed-subgroup form follows immediately. The module also proves `profiniteIndex H = profiniteIndex H.topologicalClosure`, index one exactly when `H` is dense, the closed specialization `profiniteIndex H = 1 ↔ H = ⊤`, and agreement with `Subgroup.index` for open subgroups.

After this PR, Layer 1 still needs the remaining “Index API” results (topological-isomorphism invariance, tower multiplicativity, and the continuous-surjection image formula), Lagrange, and the pro-`p`/natural-index characterizations; the separate order PR still needs its worked `ℤ_p` and `ℤ̂` computations.

The definition and lcm description follow Ribes and Zalesskii, *Profinite Groups*, §2.3, cited in the module documentation. The proof reuses Mathlib’s `Subgroup.index_map`, `Subgroup.index_dvd_of_le`, and `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one`, together with Tau Ceti’s `Supernatural` API and `Subgroup.eq_iInf_sup_openNormalSubgroup`; no Mathlib infrastructure or external formalization is vendored.

The new file is `TauCeti/Topology/Algebra/Group/Profinite/Index.lean` (260 lines).

Roadmap: ProfiniteProPGroups

<!--tauceti-target:v1 {"focus":"ProfiniteProPGroups","id":"profinite-index"}-->

🤖 Prepared with Codex
