### PR TITLE
feat: close the base-changed E7 pinning generators

### DIFF
--- a/TauCeti/Algebra/Lie/E7/Minuscule/ClosedGenerators.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/ClosedGenerators.lean
@@ -16,15 +16,9 @@ and a rank-seven weight torus. This file proves that their transported coordinat
 surjective after base change from `ℤ` to an arbitrary commutative ring. Contravariantly, the
 transported root subgroups and weight torus are closed immersions into the specialized carrier.
 
-The proof uses the explicit unit-coefficient root steps and spanning minuscule weights already
-established for the integral carrier. Surjectivity is preserved by scalar extension, and the
-canonical coordinate identifications on the carrier, additive group, and split torus are
-isomorphisms. The resulting morphisms are therefore the scheme-theoretic base changes of the
-integral pinning generators, not newly chosen subgroups in each fibre.
-
-This supplies the closed-generator part of the base-changed pinning interface required by
-Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`. It does not assert that the carrier is
-smooth, reductive, or geometrically connected, nor that its weight torus is maximal.
+The resulting morphisms are the scheme-theoretic base changes of the integral pinning generators,
+not newly chosen subgroups in each fibre. No assertion is made that the carrier is smooth,
+reductive, or geometrically connected, nor that its weight torus is maximal.
 
 ## Main declarations
 
@@ -175,59 +169,21 @@ noncomputable def baseChangeRootSubgroup (k : Fin 7 ⊕ Fin 7) :
     (AlgebraicGeometry.hopfSpec (CommRingCat.of A)).map
       (rootSubgroupToBaseChangeCoordinateMap A k).op
 
-/-- The transported root-subgroup morphism is the spectrum map of its transported coordinate
-map, after the canonical presentation of the additive group. -/
-theorem baseChangeRootSubgroup_def (k : Fin 7 ⊕ Fin 7) :
-    baseChangeRootSubgroup A k =
-      eqToHom (AdditiveGroup.groupScheme_def A) ≫
-        (AlgebraicGeometry.hopfSpec (CommRingCat.of A)).map
-          (rootSubgroupToBaseChangeCoordinateMap A k).op := by
-  rw [baseChangeRootSubgroup]
-
 /-- Every transported numbered simple root subgroup is a closed immersion into the specialized
 type-`E₇` minuscule carrier. -/
 instance isClosedImmersion_baseChangeRootSubgroup (k : Fin 7 ⊕ Fin 7) :
     IsClosedImmersion (baseChangeRootSubgroup A k).hom.hom.left := by
-  rw [baseChangeRootSubgroup_def]
+  rw [baseChangeRootSubgroup]
   exact (CommHopfAlgCat.isClosedImmersion_eqToHom_comp_hopfSpec_map_iff
     (AdditiveGroup.groupScheme_def A)
     (rootSubgroupToBaseChangeCoordinateMap A k)).2
       (rootSubgroupToBaseChangeCoordinateMap_surjective A k)
-
-/-- Every transported numbered simple root-subgroup morphism is a monomorphism. -/
-theorem mono_baseChangeRootSubgroup (k : Fin 7 ⊕ Fin 7) :
-    Mono (baseChangeRootSubgroup A k) :=
-  mono_of_isClosedImmersion_underlying (baseChangeRootSubgroup A k)
 
 /-- A transported numbered simple root subgroup as a closed subgroup scheme of the specialized
 type-`E₇` minuscule carrier. -/
 noncomputable def baseChangeRootSubgroupClosedSubgroup (k : Fin 7 ⊕ Fin 7) :
     ClosedSubgroupScheme (baseChangeGroupScheme A) :=
   ClosedSubgroupScheme.mk (baseChangeRootSubgroup A k)
-
-/-- The bundled transported root subgroup is represented by the named base-change morphism. -/
-@[simp]
-theorem coe_baseChangeRootSubgroupClosedSubgroup (k : Fin 7 ⊕ Fin 7) :
-    (baseChangeRootSubgroupClosedSubgroup A k).1 =
-      letI := mono_baseChangeRootSubgroup A k
-      Subobject.mk (baseChangeRootSubgroup A k) := by
-  exact ClosedSubgroupScheme.coe_mk _
-
-/-- The bundled transported root subgroup is canonically isomorphic to the additive group
-scheme over `A`. -/
-noncomputable def baseChangeRootSubgroupClosedSubgroupIso (k : Fin 7 ⊕ Fin 7) :
-    ((baseChangeRootSubgroupClosedSubgroup A k).1 :
-      Grp (Over (Spec (CommRingCat.of A)))) ≅ AdditiveGroup.groupScheme A :=
-  ClosedSubgroupScheme.mkIso (baseChangeRootSubgroup A k)
-
-/-- The canonical parametrization of the bundled transported root subgroup followed by its
-inclusion is the named base-change root-subgroup morphism. -/
-@[simp]
-theorem baseChangeRootSubgroupClosedSubgroupIso_inv_comp_arrow (k : Fin 7 ⊕ Fin 7) :
-    (baseChangeRootSubgroupClosedSubgroupIso A k).inv ≫
-        (baseChangeRootSubgroupClosedSubgroup A k).1.arrow =
-      baseChangeRootSubgroup A k :=
-  ClosedSubgroupScheme.mkIso_inv_comp_arrow (baseChangeRootSubgroup A k)
 
 /-- The transported rank-seven weight torus of the specialized type-`E₇` minuscule carrier. -/
 noncomputable def baseChangeWeightTorus :

--- a/TauCeti/Algebra/Lie/E7/Minuscule/ClosedGenerators.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/ClosedGenerators.lean
@@ -68,17 +68,35 @@ private theorem rootSubgroupIntegralCoordinateMap_surjective (k : Fin 7 ⊕ Fin 
       (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
       rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
       e7MinusculeWeight k]
-    intro y
-    obtain ⟨q, hq⟩ := rootSubgroupCoordinateMap_surjective k y
-    obtain ⟨x, hx⟩ := CommHopfAlgCat.mkQuotient_surjective _ _ q
-    refine ⟨x, ?_⟩
-    simpa only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply, hx] using hq
-  rw [← mkQuotient_comp_rootSubgroupIntegralCoordinateMap] at hrepresented
+    exact (rootSubgroupCoordinateMap_surjective k).comp
+      (CommHopfAlgCat.mkQuotient_surjective _ _)
+  apply Function.Surjective.of_comp
+    (g := (CommHopfAlgCat.mkQuotient
+      (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal).hom)
+  have hcomp : Function.Surjective
+      (CommHopfAlgCat.mkQuotient
+          (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal ≫
+        rootSubgroupIntegralCoordinateMap k).hom := by
+    rw [mkQuotient_comp_rootSubgroupIntegralCoordinateMap]
+    exact hrepresented
+  simpa only [_root_.CommHopfAlgCat.hom_comp, BialgHom.coe_comp] using hcomp
+
+/-- Composing a surjective integral coordinate map with the canonical source and target
+identifications preserves surjectivity after base change. -/
+private theorem baseChangeCoordinateMap_surjective
+    {H L : _root_.CommHopfAlgCat.{0} ℤ}
+    {H' L' : _root_.CommHopfAlgCat.{u} A}
+    (eH : H' ≅ CommHopfAlgCat.baseChange (K := A) H)
+    (eL : CommHopfAlgCat.baseChange (K := A) L ≅ L')
+    (f : H ⟶ L) (hf : Function.Surjective f.hom) :
+    Function.Surjective
+      (eH.hom ≫ CommHopfAlgCat.baseChangeMap (K := A) f ≫ eL.hom).hom := by
   intro y
-  obtain ⟨x, hx⟩ := hrepresented y
-  refine ⟨(CommHopfAlgCat.mkQuotient
-    (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal).hom x, ?_⟩
-  simpa only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply] using hx
+  obtain ⟨x, rfl⟩ := (ConcreteCategory.bijective_of_isIso eL.hom).2 y
+  obtain ⟨z, rfl⟩ := CommHopfAlgCat.baseChangeMap_surjective (K := A) f hf x
+  obtain ⟨w, rfl⟩ := (ConcreteCategory.bijective_of_isIso eH.hom).2 z
+  refine ⟨w, ?_⟩
+  simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply]
 
 /-- **Every transported numbered type-`E₇` root-subgroup coordinate map is surjective.**
 Thus the simple-root copy of `𝔾ₐ` remains scheme-theoretically closed after arbitrary base
@@ -87,32 +105,26 @@ theorem rootSubgroupToBaseChangeCoordinateMap_surjective (k : Fin 7 ⊕ Fin 7) :
     Function.Surjective (rootSubgroupToBaseChangeCoordinateMap A k).hom := by
   rw [← baseChangeCoordinateIso_hom_comp_rootSubgroupBaseChangeMap A k]
   let e := AdditiveGroup.coordinateHopfAlgebraBaseChangeIso ℤ A
-  have he : Function.Surjective e.hom.hom :=
-    (ConcreteCategory.bijective_of_isIso e.hom).2
-  have hbase := CommHopfAlgCat.baseChangeMap_surjective
-    (K := A) (rootSubgroupIntegralCoordinateMap k)
-    (rootSubgroupIntegralCoordinateMap_surjective k)
-  have hcarrier : Function.Surjective (baseChangeCoordinateIso A).hom.hom :=
-    (ConcreteCategory.bijective_of_isIso (baseChangeCoordinateIso A).hom).2
-  intro y
-  obtain ⟨x, rfl⟩ := he y
-  obtain ⟨z, rfl⟩ := hbase x
-  obtain ⟨w, rfl⟩ := hcarrier z
-  refine ⟨w, ?_⟩
-  simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply]
-  rfl
+  exact baseChangeCoordinateMap_surjective A
+    (H := CommHopfAlgCat.quotient
+      (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal)
+    (L := AdditiveGroup.coordinateHopfAlgebra ℤ)
+    (H' := CommHopfAlgCat.quotient
+      (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A))
+    (L' := AdditiveGroup.coordinateHopfAlgebra A)
+    (baseChangeCoordinateIso A) e (rootSubgroupIntegralCoordinateMap k)
+      (rootSubgroupIntegralCoordinateMap_surjective k)
 
 /-- The named integral weight-torus coordinate map is surjective. -/
 private theorem weightTorusIntegralCoordinateMap_surjective :
     Function.Surjective weightTorusIntegralCoordinateMap.hom := by
+  apply Function.Surjective.of_comp
+    (g := (CommHopfAlgCat.mkQuotient
+      (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal).hom)
   have h := GeneralLinear.weightTorusCoordinateMap_surjective (R := ℤ) e7MinusculeWeight
     span_range_e7MinusculeWeight_eq_top
   rw [← mkQuotient_comp_weightTorusIntegralCoordinateMap] at h
-  intro y
-  obtain ⟨x, hx⟩ := h y
-  refine ⟨(CommHopfAlgCat.mkQuotient
-    (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal).hom x, ?_⟩
-  simpa only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply] using hx
+  simpa only [_root_.CommHopfAlgCat.hom_comp, BialgHom.coe_comp] using h
 
 /-- **The transported rank-seven weight-torus coordinate map is surjective.** Thus the weight
 torus remains a closed split torus in every specialized carrier. -/
@@ -127,20 +139,17 @@ theorem weightTorusToBaseChangeCoordinateMap_surjective :
     _root_.CommHopfAlgCat.isoMk
       (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv ℤ A
         (G := SplitTorus.characterGroup (Fin 7)))
-  have he : Function.Surjective e.hom.hom :=
-    (ConcreteCategory.bijective_of_isIso e.hom).2
-  have hbase := CommHopfAlgCat.baseChangeMap_surjective
-    (K := A) weightTorusIntegralCoordinateMap
-    weightTorusIntegralCoordinateMap_surjective
-  have hcarrier : Function.Surjective (baseChangeCoordinateIso A).hom.hom :=
-    (ConcreteCategory.bijective_of_isIso (baseChangeCoordinateIso A).hom).2
-  intro y
-  obtain ⟨x, rfl⟩ := he y
-  obtain ⟨z, rfl⟩ := hbase x
-  obtain ⟨w, rfl⟩ := hcarrier z
-  refine ⟨w, ?_⟩
-  simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply]
-  rfl
+  exact baseChangeCoordinateMap_surjective A
+    (H := CommHopfAlgCat.quotient
+      (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal)
+    (L := (DiagonalizableGroup.coordinateRing ℤ
+      (SplitTorus.characterGroup (Fin 7))).obj)
+    (H' := CommHopfAlgCat.quotient
+      (GeneralLinear.coordinateHopfAlgebra A 56) (baseChangeDefiningIdeal A))
+    (L' := (DiagonalizableGroup.coordinateRing A
+      (SplitTorus.characterGroup (Fin 7))).obj)
+    (baseChangeCoordinateIso A) e weightTorusIntegralCoordinateMap
+      weightTorusIntegralCoordinateMap_surjective
 
 /-! ## Scheme-theoretic closed generators
 
@@ -184,6 +193,30 @@ type-`E₇` minuscule carrier. -/
 noncomputable def baseChangeRootSubgroupClosedSubgroup (k : Fin 7 ⊕ Fin 7) :
     ClosedSubgroupScheme (baseChangeGroupScheme A) :=
   ClosedSubgroupScheme.mk (baseChangeRootSubgroup A k)
+
+/-- The bundled closed root subgroup is represented by the transported root-subgroup morphism. -/
+@[simp]
+theorem coe_baseChangeRootSubgroupClosedSubgroup (k : Fin 7 ⊕ Fin 7) :
+    (baseChangeRootSubgroupClosedSubgroup A k).1 =
+      letI := mono_of_isClosedImmersion_underlying (baseChangeRootSubgroup A k)
+      Subobject.mk (baseChangeRootSubgroup A k) :=
+  ClosedSubgroupScheme.coe_mk _
+
+/-- The bundled transported root subgroup is canonically isomorphic to the additive group
+scheme. -/
+noncomputable def baseChangeRootSubgroupClosedSubgroupIso (k : Fin 7 ⊕ Fin 7) :
+    ((baseChangeRootSubgroupClosedSubgroup A k).1 :
+      Grp (Over (Spec (CommRingCat.of A)))) ≅ AdditiveGroup.groupScheme A :=
+  ClosedSubgroupScheme.mkIso (baseChangeRootSubgroup A k)
+
+/-- The canonical parametrization of the bundled closed subgroup followed by its inclusion is
+the transported root-subgroup map. -/
+@[simp]
+theorem baseChangeRootSubgroupClosedSubgroupIso_inv_comp_arrow (k : Fin 7 ⊕ Fin 7) :
+    (baseChangeRootSubgroupClosedSubgroupIso A k).inv ≫
+        (baseChangeRootSubgroupClosedSubgroup A k).1.arrow =
+      baseChangeRootSubgroup A k :=
+  ClosedSubgroupScheme.mkIso_inv_comp_arrow (baseChangeRootSubgroup A k)
 
 /-- The transported rank-seven weight torus of the specialized type-`E₇` minuscule carrier. -/
 noncomputable def baseChangeWeightTorus :

--- a/TauCeti/Algebra/Lie/E7/Minuscule/ClosedGenerators.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/ClosedGenerators.lean
@@ -1,0 +1,251 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.E7.Minuscule.BaseChange
+public import TauCeti.AlgebraicGeometry.GroupScheme.ClosedSubgroup
+
+/-!
+# Closed generators of the type-E7 minuscule carrier after base change
+
+The integral type-`E₇` minuscule carrier comes with fourteen numbered simple-root subgroups
+and a rank-seven weight torus. This file proves that their transported coordinate maps remain
+surjective after base change from `ℤ` to an arbitrary commutative ring. Contravariantly, the
+transported root subgroups and weight torus are closed immersions into the specialized carrier.
+
+The proof uses the explicit unit-coefficient root steps and spanning minuscule weights already
+established for the integral carrier. Surjectivity is preserved by scalar extension, and the
+canonical coordinate identifications on the carrier, additive group, and split torus are
+isomorphisms. The resulting morphisms are therefore the scheme-theoretic base changes of the
+integral pinning generators, not newly chosen subgroups in each fibre.
+
+This supplies the closed-generator part of the base-changed pinning interface required by
+Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`. It does not assert that the carrier is
+smooth, reductive, or geometrically connected, nor that its weight torus is maximal.
+
+## Main declarations
+
+* `TauCeti.E7Minuscule.rootSubgroupToBaseChangeCoordinateMap_surjective`: every transported
+  numbered root-subgroup coordinate map is surjective.
+* `TauCeti.E7Minuscule.weightTorusToBaseChangeCoordinateMap_surjective`: the transported
+  weight-torus coordinate map is surjective.
+* `TauCeti.E7Minuscule.baseChangeRootSubgroup` and
+  `TauCeti.E7Minuscule.baseChangeWeightTorus`: the corresponding morphisms into the specialized
+  carrier.
+* `TauCeti.E7Minuscule.baseChangeRootSubgroupClosedSubgroup`: each numbered root subgroup as a
+  bundled closed subgroup scheme.
+
+## References
+
+* J. E. Humphreys, *Linear Algebraic Groups*, §26.
+* R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 7.1.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.2.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory
+open TauCeti.DynkinType
+
+namespace TauCeti.E7Minuscule
+
+universe u
+
+noncomputable section
+
+variable (A : Type u) [CommRing A]
+
+/-! ## Surjectivity of the transported coordinate maps -/
+
+/-- The named integral root-subgroup coordinate map is surjective. -/
+private theorem rootSubgroupIntegralCoordinateMap_surjective (k : Fin 7 ⊕ Fin 7) :
+    Function.Surjective (rootSubgroupIntegralCoordinateMap k).hom := by
+  have hrepresented : Function.Surjective
+      (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap
+        (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+        (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+        rep_kostantForm_mem_lattice k (isNilpotent_rep_serreRootGenerator k)
+        latticeBasis).hom := by
+    rw [← TauCeti.UniversalEnvelopingAlgebra.mkQuotient_comp_kostantRootSubgroupToralCoordinateMap
+      (TauCeti.serreRootGenerator (CartanMatrix.E 7))
+      (TauCeti.serreH ℚ (CartanMatrix.E 7)) rep lattice.toAddSubgroup
+      rep_kostantForm_mem_lattice isNilpotent_rep_serreRootGenerator latticeBasis
+      e7MinusculeWeight k]
+    intro y
+    obtain ⟨q, hq⟩ := rootSubgroupCoordinateMap_surjective k y
+    obtain ⟨x, hx⟩ := CommHopfAlgCat.mkQuotient_surjective _ _ q
+    refine ⟨x, ?_⟩
+    simpa only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply, hx] using hq
+  rw [← mkQuotient_comp_rootSubgroupIntegralCoordinateMap] at hrepresented
+  intro y
+  obtain ⟨x, hx⟩ := hrepresented y
+  refine ⟨(CommHopfAlgCat.mkQuotient
+    (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal).hom x, ?_⟩
+  simpa only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply] using hx
+
+/-- **Every transported numbered type-`E₇` root-subgroup coordinate map is surjective.**
+Thus the simple-root copy of `𝔾ₐ` remains scheme-theoretically closed after arbitrary base
+change from `ℤ`. -/
+theorem rootSubgroupToBaseChangeCoordinateMap_surjective (k : Fin 7 ⊕ Fin 7) :
+    Function.Surjective (rootSubgroupToBaseChangeCoordinateMap A k).hom := by
+  rw [← baseChangeCoordinateIso_hom_comp_rootSubgroupBaseChangeMap A k]
+  let e := AdditiveGroup.coordinateHopfAlgebraBaseChangeIso ℤ A
+  have he : Function.Surjective e.hom.hom :=
+    (ConcreteCategory.bijective_of_isIso e.hom).2
+  have hbase := CommHopfAlgCat.baseChangeMap_surjective
+    (K := A) (rootSubgroupIntegralCoordinateMap k)
+    (rootSubgroupIntegralCoordinateMap_surjective k)
+  have hcarrier : Function.Surjective (baseChangeCoordinateIso A).hom.hom :=
+    (ConcreteCategory.bijective_of_isIso (baseChangeCoordinateIso A).hom).2
+  intro y
+  obtain ⟨x, rfl⟩ := he y
+  obtain ⟨z, rfl⟩ := hbase x
+  obtain ⟨w, rfl⟩ := hcarrier z
+  refine ⟨w, ?_⟩
+  simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply]
+  rfl
+
+/-- The named integral weight-torus coordinate map is surjective. -/
+private theorem weightTorusIntegralCoordinateMap_surjective :
+    Function.Surjective weightTorusIntegralCoordinateMap.hom := by
+  have h := GeneralLinear.weightTorusCoordinateMap_surjective (R := ℤ) e7MinusculeWeight
+    span_range_e7MinusculeWeight_eq_top
+  rw [← mkQuotient_comp_weightTorusIntegralCoordinateMap] at h
+  intro y
+  obtain ⟨x, hx⟩ := h y
+  refine ⟨(CommHopfAlgCat.mkQuotient
+    (GeneralLinear.coordinateHopfAlgebra ℤ 56) definingIdeal).hom x, ?_⟩
+  simpa only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply] using hx
+
+/-- **The transported rank-seven weight-torus coordinate map is surjective.** Thus the weight
+torus remains a closed split torus in every specialized carrier. -/
+theorem weightTorusToBaseChangeCoordinateMap_surjective :
+    Function.Surjective (weightTorusToBaseChangeCoordinateMap A).hom := by
+  rw [← baseChangeCoordinateIso_hom_comp_weightTorusBaseChangeMap A]
+  let e : CommHopfAlgCat.baseChange (K := A)
+      ((DiagonalizableGroup.coordinateRing ℤ
+        (SplitTorus.characterGroup (Fin 7))).obj) ≅
+        (DiagonalizableGroup.coordinateRing A
+          (SplitTorus.characterGroup (Fin 7))).obj :=
+    _root_.CommHopfAlgCat.isoMk
+      (TauCeti.MonoidAlgebra.scalarTensorBialgEquiv ℤ A
+        (G := SplitTorus.characterGroup (Fin 7)))
+  have he : Function.Surjective e.hom.hom :=
+    (ConcreteCategory.bijective_of_isIso e.hom).2
+  have hbase := CommHopfAlgCat.baseChangeMap_surjective
+    (K := A) weightTorusIntegralCoordinateMap
+    weightTorusIntegralCoordinateMap_surjective
+  have hcarrier : Function.Surjective (baseChangeCoordinateIso A).hom.hom :=
+    (ConcreteCategory.bijective_of_isIso (baseChangeCoordinateIso A).hom).2
+  intro y
+  obtain ⟨x, rfl⟩ := he y
+  obtain ⟨z, rfl⟩ := hbase x
+  obtain ⟨w, rfl⟩ := hcarrier z
+  refine ⟨w, ?_⟩
+  simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply]
+  rfl
+
+/-! ## Scheme-theoretic closed generators
+
+The current `hopfSpec` bridge requires the base ring and all coordinate rings to inhabit the
+same universe. The concrete pinning uses the finite index types `Fin 7` and `Fin 56`, so its
+scheme-level packaging is correspondingly stated in the base universe. -/
+
+end
+
+
+noncomputable section
+
+variable (A : Type) [CommRing A]
+
+/-- The type-`E₇` minuscule carrier specialized to the commutative ring `A`, in its transported
+quotient presentation inside `GL₅₆/A`. -/
+noncomputable abbrev baseChangeGroupScheme : Grp (Over (Spec (CommRingCat.of A))) :=
+  CommHopfAlgCat.quotientSpec (GeneralLinear.coordinateHopfAlgebra A 56)
+    (baseChangeDefiningIdeal A)
+
+/-- A transported positive or negative numbered simple root subgroup of the specialized
+type-`E₇` minuscule carrier. -/
+noncomputable def baseChangeRootSubgroup (k : Fin 7 ⊕ Fin 7) :
+    AdditiveGroup.groupScheme A ⟶ baseChangeGroupScheme A :=
+  eqToHom (AdditiveGroup.groupScheme_def A) ≫
+    (AlgebraicGeometry.hopfSpec (CommRingCat.of A)).map
+      (rootSubgroupToBaseChangeCoordinateMap A k).op
+
+/-- The transported root-subgroup morphism is the spectrum map of its transported coordinate
+map, after the canonical presentation of the additive group. -/
+theorem baseChangeRootSubgroup_def (k : Fin 7 ⊕ Fin 7) :
+    baseChangeRootSubgroup A k =
+      eqToHom (AdditiveGroup.groupScheme_def A) ≫
+        (AlgebraicGeometry.hopfSpec (CommRingCat.of A)).map
+          (rootSubgroupToBaseChangeCoordinateMap A k).op := by
+  rw [baseChangeRootSubgroup]
+
+/-- Every transported numbered simple root subgroup is a closed immersion into the specialized
+type-`E₇` minuscule carrier. -/
+instance isClosedImmersion_baseChangeRootSubgroup (k : Fin 7 ⊕ Fin 7) :
+    IsClosedImmersion (baseChangeRootSubgroup A k).hom.hom.left := by
+  rw [baseChangeRootSubgroup_def]
+  exact (CommHopfAlgCat.isClosedImmersion_eqToHom_comp_hopfSpec_map_iff
+    (AdditiveGroup.groupScheme_def A)
+    (rootSubgroupToBaseChangeCoordinateMap A k)).2
+      (rootSubgroupToBaseChangeCoordinateMap_surjective A k)
+
+/-- Every transported numbered simple root-subgroup morphism is a monomorphism. -/
+theorem mono_baseChangeRootSubgroup (k : Fin 7 ⊕ Fin 7) :
+    Mono (baseChangeRootSubgroup A k) :=
+  mono_of_isClosedImmersion_underlying (baseChangeRootSubgroup A k)
+
+/-- A transported numbered simple root subgroup as a closed subgroup scheme of the specialized
+type-`E₇` minuscule carrier. -/
+noncomputable def baseChangeRootSubgroupClosedSubgroup (k : Fin 7 ⊕ Fin 7) :
+    ClosedSubgroupScheme (baseChangeGroupScheme A) :=
+  ClosedSubgroupScheme.mk (baseChangeRootSubgroup A k)
+
+/-- The bundled transported root subgroup is represented by the named base-change morphism. -/
+@[simp]
+theorem coe_baseChangeRootSubgroupClosedSubgroup (k : Fin 7 ⊕ Fin 7) :
+    (baseChangeRootSubgroupClosedSubgroup A k).1 =
+      letI := mono_baseChangeRootSubgroup A k
+      Subobject.mk (baseChangeRootSubgroup A k) := by
+  exact ClosedSubgroupScheme.coe_mk _
+
+/-- The bundled transported root subgroup is canonically isomorphic to the additive group
+scheme over `A`. -/
+noncomputable def baseChangeRootSubgroupClosedSubgroupIso (k : Fin 7 ⊕ Fin 7) :
+    ((baseChangeRootSubgroupClosedSubgroup A k).1 :
+      Grp (Over (Spec (CommRingCat.of A)))) ≅ AdditiveGroup.groupScheme A :=
+  ClosedSubgroupScheme.mkIso (baseChangeRootSubgroup A k)
+
+/-- The canonical parametrization of the bundled transported root subgroup followed by its
+inclusion is the named base-change root-subgroup morphism. -/
+@[simp]
+theorem baseChangeRootSubgroupClosedSubgroupIso_inv_comp_arrow (k : Fin 7 ⊕ Fin 7) :
+    (baseChangeRootSubgroupClosedSubgroupIso A k).inv ≫
+        (baseChangeRootSubgroupClosedSubgroup A k).1.arrow =
+      baseChangeRootSubgroup A k :=
+  ClosedSubgroupScheme.mkIso_inv_comp_arrow (baseChangeRootSubgroup A k)
+
+/-- The transported rank-seven weight torus of the specialized type-`E₇` minuscule carrier. -/
+noncomputable def baseChangeWeightTorus :
+    SplitTorus.groupScheme A (Fin 7) ⟶ baseChangeGroupScheme A :=
+  eqToHom (DiagonalizableGroup.groupScheme_def A
+      (SplitTorus.characterGroup (Fin 7))) ≫
+    (AlgebraicGeometry.hopfSpec (CommRingCat.of A)).map
+      (weightTorusToBaseChangeCoordinateMap A).op
+
+/-- The transported weight-torus morphism is a closed immersion into the specialized carrier. -/
+instance isClosedImmersion_baseChangeWeightTorus :
+    IsClosedImmersion (baseChangeWeightTorus A).hom.hom.left := by
+  rw [baseChangeWeightTorus]
+  exact (CommHopfAlgCat.isClosedImmersion_eqToHom_comp_hopfSpec_map_iff
+    (DiagonalizableGroup.groupScheme_def A (SplitTorus.characterGroup (Fin 7)))
+    (weightTorusToBaseChangeCoordinateMap A)).2
+      (weightTorusToBaseChangeCoordinateMap_surjective A)
+
+end
+
+end TauCeti.E7Minuscule


### PR DESCRIPTION
This PR proves that the fourteen numbered simple-root coordinate maps and the rank-seven weight-torus coordinate map of the base-changed type-`E₇` minuscule carrier are surjective over every commutative ring. Package the specialized carrier and its transported root maps as group-scheme morphisms, prove each root map and the weight torus is a closed immersion, and bundle every numbered root subgroup as a closed subgroup canonically isomorphic to `𝔾ₐ`.

The exact roadmap targets are ReductiveGroups Layer 9, “Base change along `ℤ → k` for any commutative ring `k`, and the compatibility of the pinning with it,” together with “Pinnings” and “Root subgroup maps.” This supplies the closed-generator part of the base-changed pinning interface for the explicit `E₇` carrier consumed by CFSGStatement milestone L0, “pinned ambient groups.”

The proof transports the already-established integral surjectivity through Tau Ceti’s scalar-extension right-exactness and the canonical coordinate Hopf-algebra isomorphisms for the carrier, additive group, and diagonalizable group; no Mathlib implementation is vendored.

Milestone: Layer 9, “pinned Chevalley–Demazure group schemes over `ℤ`.” After this PR, the `E₇` path still needs smoothness and geometric connectedness, a Borel and maximal-torus theorem, all-root generation and commutator data, reductivity, and final identification with the pinned simply connected root datum.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"e7-minuscule-base-change-closed-generators"}-->

🤖 Prepared with Codex
