### PR TITLE
feat: the orthogonal quotient of an orthogonal direct sum

### DIFF
--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
@@ -33,6 +33,7 @@ restriction to a subgroup can be degenerate.
 * `TauCeti.FiniteBilinearModule.IsNondegenerate`: bijectivity of the adjoint pairing.
 * `TauCeti.FiniteBilinearModule.Hom`: a pairing-preserving additive homomorphism.
 * `TauCeti.FiniteBilinearModule.Isometry`: a pairing-preserving additive equivalence.
+* `TauCeti.FiniteBilinearModule.Isometry.prod`: the orthogonal direct sum of two isometries.
 * `TauCeti.FiniteBilinearModule.orthogonalComplement`: the orthogonal complement of a subgroup.
 * `TauCeti.FiniteBilinearModule.IsIsotropicElem`: vanishing of the self-pairing on an element.
 * `TauCeti.FiniteBilinearModule.IsIsotropic`: vanishing of the pairing on a subgroup.
@@ -50,13 +51,15 @@ restriction to a subgroup can be degenerate.
   subgroups.
 * `TauCeti.FiniteBilinearModule.Isometry.isLagrangian_map_iff`: an isometry transports Lagrangian
   subgroups.
+* `TauCeti.FiniteBilinearModule.isIsotropic_prod_iff`: isotropy of a product subgroup in an
+  orthogonal direct sum is isotropy of each factor subgroup.
 -/
 
 public section
 
 namespace TauCeti
 
-universe u v w
+universe u v w x
 
 section CharacterModuleDuality
 
@@ -636,6 +639,26 @@ theorem isNondegenerate_prod (B : FiniteBilinearModule) :
       exact h1.symm.trans (heq.trans h2)
     exact Prod.ext (hA hx) (hB hy)
 
+section IsometryProd
+
+variable {A : FiniteBilinearModule.{u}} {B : FiniteBilinearModule.{v}}
+  {C : FiniteBilinearModule.{w}} {D : FiniteBilinearModule.{x}}
+
+/-- **The orthogonal direct sum of two isometries.** -/
+def Isometry.prod (f : Isometry A C) (g : Isometry B D) :
+    Isometry (A.prod B) (C.prod D) where
+  toAddEquiv := f.toAddEquiv.prodCongr g.toAddEquiv
+  map_pairing' z w := by
+    rw [prod_pairing, prod_pairing]
+    exact congrArg₂ (· + ·) (f.map_pairing z.1 w.1) (g.map_pairing z.2 w.2)
+
+/-- An orthogonal direct sum of isometries acts componentwise. -/
+@[simp]
+theorem Isometry.prod_apply (f : Isometry A C) (g : Isometry B D) (z : A.carrier × B.carrier) :
+    f.prod g z = (f z.1, g z.2) := (rfl)
+
+end IsometryProd
+
 /-- The radical is the kernel of the adjoint pairing. -/
 def radical : AddSubgroup A := A.pairing.ker
 
@@ -793,6 +816,24 @@ theorem IsIsotropic.mono {H K : AddSubgroup A} (hK : A.IsIsotropic K) (h : H ≤
 /-- The trivial subgroup is isotropic. -/
 @[simp]
 theorem isIsotropic_bot : A.IsIsotropic ⊥ := by simp [IsIsotropic]
+
+/-- **Isotropy of a product subgroup is componentwise.** -/
+@[simp]
+theorem isIsotropic_prod_iff (B : FiniteBilinearModule) (H : AddSubgroup A) (K : AddSubgroup B) :
+    (A.prod B).IsIsotropic (H.prod K) ↔ A.IsIsotropic H ∧ B.IsIsotropic K := by
+  simp only [isIsotropic_def]
+  constructor
+  · intro h
+    refine ⟨fun x hx y hy ↦ ?_, fun x hx y hy ↦ ?_⟩
+    · have hxy := h (x, 0) (AddSubgroup.mem_prod.mpr ⟨hx, K.zero_mem⟩)
+        (y, 0) (AddSubgroup.mem_prod.mpr ⟨hy, K.zero_mem⟩)
+      rwa [prod_pairing, pairing_zero_left, add_zero] at hxy
+    · have hxy := h (0, x) (AddSubgroup.mem_prod.mpr ⟨H.zero_mem, hx⟩)
+        (0, y) (AddSubgroup.mem_prod.mpr ⟨H.zero_mem, hy⟩)
+      rwa [prod_pairing, pairing_zero_left, zero_add] at hxy
+  · rintro ⟨hH, hK⟩ x hx y hy
+    rw [AddSubgroup.mem_prod] at hx hy
+    rw [prod_pairing, hH x.1 hx.1 y.1 hy.1, hK x.2 hx.2 y.2 hy.2, add_zero]
 
 /-- A Lagrangian is a subgroup equal to its orthogonal complement. -/
 def IsLagrangian (H : AddSubgroup A) : Prop := H = A.orthogonalComplement H

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Prod.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Prod.lean
@@ -18,8 +18,8 @@ against the product subgroup `H × K` is orthogonality of each component against
 (H × K)⊥ = H⊥ × K⊥.
 ```
 
-Isotropy and the Lagrangian condition are componentwise for the same reason, and the orthogonal
-quotient splits:
+The Lagrangian condition is componentwise for the same reason — as is isotropy, proved in
+`TauCeti.LinearAlgebra.FiniteBilinearModule.Basic` — and the orthogonal quotient splits:
 
 ```text
 (H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K).
@@ -27,7 +27,9 @@ quotient splits:
 
 The same statements hold for finite quadratic modules, whose orthogonal quotient is taken along a
 quadratic-isotropic subgroup; there the quadratic values, not only the pairings, add across the
-two factors.
+two factors. The quadratic splitting is the bilinear one: the underlying bilinear module of a
+quadratic orthogonal quotient is the bilinear orthogonal quotient, so only the preservation of
+quadratic values has to be checked.
 
 These are the componentwise laws that the gluing theory of integral lattices needs: the
 discriminant module of an orthogonal direct sum of lattices is the orthogonal direct sum of the
@@ -37,14 +39,10 @@ sum of the two glued overlattices, so its discriminant module must split the sam
 ## Main declarations
 
 * `TauCeti.FiniteBilinearModule.orthogonalComplement_prod`: `(H × K)⊥ = H⊥ × K⊥`.
-* `TauCeti.FiniteBilinearModule.isIsotropic_prod_iff` and
-  `TauCeti.FiniteBilinearModule.isLagrangian_prod_iff`: isotropy and the Lagrangian condition are
-  componentwise.
+* `TauCeti.FiniteBilinearModule.isLagrangian_prod_iff`: the Lagrangian condition is componentwise.
 * `TauCeti.FiniteBilinearModule.orthogonalQuotientProdIsometry`: the isometry
   `(H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K)`.
-* `TauCeti.FiniteBilinearModule.Isometry.prod`: the orthogonal direct sum of two isometries.
-* `TauCeti.FiniteQuadraticModule.isIsotropic_prod_iff`,
-  `TauCeti.FiniteQuadraticModule.isLagrangian_prod_iff` and
+* `TauCeti.FiniteQuadraticModule.isLagrangian_prod_iff` and
   `TauCeti.FiniteQuadraticModule.orthogonalQuotientProdIsometry`: the quadratic counterparts.
   An orthogonal direct sum of quadratic isometries is Mathlib's
   `QuadraticMap.IsometryEquiv.prod`.
@@ -59,7 +57,7 @@ public section
 
 namespace TauCeti
 
-universe u v w x
+universe u v
 
 namespace FiniteBilinearModule
 
@@ -110,31 +108,12 @@ private theorem prod_eq_prod_iff {H H' : AddSubgroup A} {K K' : AddSubgroup B} :
   · rintro ⟨rfl, rfl⟩
     rfl
 
-/-- **Isotropy of a product subgroup is componentwise.** -/
-@[simp]
-theorem isIsotropic_prod_iff (H : AddSubgroup A) (K : AddSubgroup B) :
-    (A.prod B).IsIsotropic (H.prod K) ↔ A.IsIsotropic H ∧ B.IsIsotropic K := by
-  rw [(A.prod B).isIsotropic_iff_le_orthogonalComplement,
-    A.isIsotropic_iff_le_orthogonalComplement, B.isIsotropic_iff_le_orthogonalComplement,
-    A.orthogonalComplement_prod B]
-  constructor
-  · intro h
-    refine ⟨fun x hx ↦ ?_, fun y hy ↦ ?_⟩
-    · exact (AddSubgroup.mem_prod.mp (h (show (x, (0 : B.carrier)) ∈ H.prod K from
-        AddSubgroup.mem_prod.mpr ⟨hx, K.zero_mem⟩))).1
-    · exact (AddSubgroup.mem_prod.mp (h (show ((0 : A.carrier), y) ∈ H.prod K from
-        AddSubgroup.mem_prod.mpr ⟨H.zero_mem, hy⟩))).2
-  · rintro ⟨hH, hK⟩ x hx
-    rw [AddSubgroup.mem_prod] at hx ⊢
-    exact ⟨hH hx.1, hK hx.2⟩
-
 /-- **The Lagrangian condition on a product subgroup is componentwise.** -/
 @[simp]
 theorem isLagrangian_prod_iff (H : AddSubgroup A) (K : AddSubgroup B) :
     (A.prod B).IsLagrangian (H.prod K) ↔ A.IsLagrangian H ∧ B.IsLagrangian K := by
   rw [(A.prod B).isLagrangian_def, A.isLagrangian_def, B.isLagrangian_def,
     A.orthogonalComplement_prod B, A.prod_eq_prod_iff B]
-
 
 /-! ## The orthogonal quotient of an orthogonal direct sum -/
 
@@ -158,11 +137,15 @@ def orthogonalComplementProdSnd (H : AddSubgroup A) (K : AddSubgroup B) :
   map_zero' := rfl
   map_add' _ _ := rfl
 
+/-- Taking the first component of a vector of `(H × K)⊥` and then forgetting that it lies in `H⊥`
+is taking the first component in `A ⊥ B`. -/
 @[simp]
 theorem coe_orthogonalComplementProdFst (H : AddSubgroup A) (K : AddSubgroup B)
     (x : (A.prod B).orthogonalComplement (H.prod K)) :
     (orthogonalComplementProdFst H K x : A) = (x : A.carrier × B.carrier).1 := (rfl)
 
+/-- Taking the second component of a vector of `(H × K)⊥` and then forgetting that it lies in `K⊥`
+is taking the second component in `A ⊥ B`. -/
 @[simp]
 theorem coe_orthogonalComplementProdSnd (H : AddSubgroup A) (K : AddSubgroup B)
     (x : (A.prod B).orthogonalComplement (H.prod K)) :
@@ -192,8 +175,8 @@ private theorem orthogonalQuotientProdMap_orthogonalQuotientMk (H : AddSubgroup 
     orthogonalQuotientProdMap H K ((A.prod B).orthogonalQuotientMk (H.prod K) x) =
       (A.orthogonalQuotientMk H (orthogonalComplementProdFst H K x),
         B.orthogonalQuotientMk K (orthogonalComplementProdSnd H K x)) := by
-  rw [(A.prod B).orthogonalQuotientMk_apply]
-  rfl
+  rw [(A.prod B).orthogonalQuotientMk_apply, orthogonalQuotientProdMap]
+  exact Submodule.liftQ_apply _ _ x
 
 private theorem orthogonalQuotientProdMap_bijective (H : AddSubgroup A) (K : AddSubgroup B) :
     Function.Bijective (orthogonalQuotientProdMap H K) := by
@@ -212,7 +195,11 @@ private theorem orthogonalQuotientProdMap_bijective (H : AddSubgroup A) (K : Add
     refine ⟨(A.prod B).orthogonalQuotientMk (H.prod K)
       ⟨((y : A), (z : B)), (A.mem_orthogonalComplement_prod_iff B H K _).mpr ⟨y.2, z.2⟩⟩, ?_⟩
     rw [orthogonalQuotientProdMap_orthogonalQuotientMk]
-    rfl
+    exact Prod.ext
+      (congrArg (A.orthogonalQuotientMk H)
+        (Subtype.ext (coe_orthogonalComplementProdFst H K _)))
+      (congrArg (B.orthogonalQuotientMk K)
+        (Subtype.ext (coe_orthogonalComplementProdSnd H K _)))
 
 /-- **The orthogonal quotient of an orthogonal direct sum splits.** For subgroups `H ≤ A` and
 `K ≤ B`, the orthogonal quotient of `A ⊥ B` by `H × K` is the orthogonal direct sum of the two
@@ -233,6 +220,8 @@ noncomputable def orthogonalQuotientProdIsometry (H : AddSubgroup A) (K : AddSub
     | mk x =>
       induction r using orthogonalQuotient_induction_on with
       | mk y =>
+        -- `AddEquiv.ofBijective` has no `coe` simp lemma, so name the underlying linear map
+        -- explicitly; the two are the same function by definition.
         change ((A.orthogonalQuotient H).prod (B.orthogonalQuotient K)).pairing
             (orthogonalQuotientProdMap H K _) (orthogonalQuotientProdMap H K _) = _
         rw [orthogonalQuotientProdMap_orthogonalQuotientMk,
@@ -251,45 +240,13 @@ theorem orthogonalQuotientProdIsometry_orthogonalQuotientMk (H : AddSubgroup A)
         B.orthogonalQuotientMk K (orthogonalComplementProdSnd H K x)) :=
   orthogonalQuotientProdMap_orthogonalQuotientMk H K x
 
-/-! ## Orthogonal direct sums of isometries -/
-
-/-- **The orthogonal direct sum of two isometries.** -/
-def Isometry.prod {C : FiniteBilinearModule.{w}} {D : FiniteBilinearModule.{x}}
-    (f : Isometry A C) (g : Isometry B D) :
-    Isometry (A.prod B) (C.prod D) where
-  toAddEquiv := f.toAddEquiv.prodCongr g.toAddEquiv
-  map_pairing' x y := by
-    rw [prod_pairing, prod_pairing]
-    exact congrArg₂ (· + ·) (f.map_pairing x.1 y.1) (g.map_pairing x.2 y.2)
-
-@[simp]
-theorem Isometry.prod_apply {C : FiniteBilinearModule.{w}} {D : FiniteBilinearModule.{x}}
-    (f : Isometry A C) (g : Isometry B D) (z : A.carrier × B.carrier) :
-    f.prod g z = (f z.1, g z.2) := (rfl)
-
 end FiniteBilinearModule
 
 namespace FiniteQuadraticModule
 
 variable (A : FiniteQuadraticModule.{u}) (B : FiniteQuadraticModule.{v})
 
-/-! ## Quadratic isotropy of a product subgroup -/
-
-/-- **Quadratic isotropy of a product subgroup is componentwise.** -/
-@[simp]
-theorem isIsotropic_prod_iff (H : AddSubgroup A) (K : AddSubgroup B) :
-    (A.prod B).IsIsotropic (H.prod K) ↔ A.IsIsotropic H ∧ B.IsIsotropic K := by
-  simp only [isIsotropic_def]
-  constructor
-  · intro h
-    refine ⟨fun x hx ↦ ?_, fun y hy ↦ ?_⟩
-    · have hx' := h (x, 0) (AddSubgroup.mem_prod.mpr ⟨hx, K.zero_mem⟩)
-      rwa [A.prod_quadratic B, B.quadratic.map_zero, add_zero] at hx'
-    · have hy' := h (0, y) (AddSubgroup.mem_prod.mpr ⟨H.zero_mem, hy⟩)
-      rwa [A.prod_quadratic B, A.quadratic.map_zero, zero_add] at hy'
-  · rintro ⟨hH, hK⟩ ⟨x, y⟩ hxy
-    rw [AddSubgroup.mem_prod] at hxy
-    rw [A.prod_quadratic B, hH x hxy.1, hK y hxy.2, add_zero]
+/-! ## The quadratic Lagrangian condition on a product subgroup -/
 
 /-- **The quadratic Lagrangian condition on a product subgroup is componentwise.** -/
 @[simp]
@@ -316,62 +273,34 @@ theorem isLagrangian_prod_iff (H : AddSubgroup A) (K : AddSubgroup B) :
 
 variable {A B}
 
-/-- The map splitting the quadratic orthogonal quotient of `A ⊥ B` by a product subgroup into the
-two quadratic orthogonal quotients, as a `ℤ`-linear map. -/
-private noncomputable def orthogonalQuotientProdMap {H : AddSubgroup A} {K : AddSubgroup B}
+/-- The additive equivalence splitting a quadratic orthogonal quotient of `A ⊥ B` along a product
+subgroup. It *is* the bilinear splitting: the underlying bilinear module of a quadratic orthogonal
+quotient is the bilinear orthogonal quotient, and an orthogonal direct sum of quadratic modules
+has the orthogonal direct sum of the polar pairings, so the two source and target modules agree. -/
+private noncomputable def orthogonalQuotientProdAddEquiv {H : AddSubgroup A} {K : AddSubgroup B}
     (hH : A.IsIsotropic H) (hK : B.IsIsotropic K) :
-    (A.prod B).orthogonalQuotient (H.prod K) ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩) →ₗ[ℤ]
-      (A.orthogonalQuotient H hH).carrier × (B.orthogonalQuotient K hK).carrier :=
-  Submodule.liftQ ((A.prod B).subgroupInOrthogonalComplement (H.prod K)).toIntSubmodule
-    (((A.orthogonalQuotientMk H hH).comp
-        (FiniteBilinearModule.orthogonalComplementProdFst H K)).prod
-      ((B.orthogonalQuotientMk K hK).comp
-        (FiniteBilinearModule.orthogonalComplementProdSnd H K))).toIntLinearMap
-    (by
-      intro x hx
-      have hx0 : x ∈ (A.prod B).subgroupInOrthogonalComplement (H.prod K) := hx
-      have hx' : (x : A.carrier × B.carrier) ∈ H.prod K :=
-        ((A.prod B).mem_subgroupInOrthogonalComplement_iff (H.prod K) x).mp hx0
-      rw [AddSubgroup.mem_prod] at hx'
-      rw [LinearMap.mem_ker]
-      refine Prod.ext ?_ ?_
-      · exact (A.orthogonalQuotientMk_eq_zero_iff H hH _).mpr hx'.1
-      · exact (B.orthogonalQuotientMk_eq_zero_iff K hK _).mpr hx'.2)
+    (A.prod B).orthogonalQuotient (H.prod K) ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩) ≃+
+      (A.orthogonalQuotient H hH).prod (B.orthogonalQuotient K hK) :=
+  (FiniteBilinearModule.orthogonalQuotientProdIsometry (A := A.toFiniteBilinearModule)
+    (B := B.toFiniteBilinearModule) H K).toAddEquiv
 
 @[simp]
-private theorem orthogonalQuotientProdMap_orthogonalQuotientMk {H : AddSubgroup A}
+private theorem orthogonalQuotientProdAddEquiv_orthogonalQuotientMk {H : AddSubgroup A}
     {K : AddSubgroup B} (hH : A.IsIsotropic H) (hK : B.IsIsotropic K)
     (x : (A.prod B).toFiniteBilinearModule.orthogonalComplement (H.prod K)) :
-    orthogonalQuotientProdMap hH hK
+    orthogonalQuotientProdAddEquiv hH hK
         ((A.prod B).orthogonalQuotientMk (H.prod K)
           ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩) x) =
       (A.orthogonalQuotientMk H hH (FiniteBilinearModule.orthogonalComplementProdFst H K x),
         B.orthogonalQuotientMk K hK
           (FiniteBilinearModule.orthogonalComplementProdSnd H K x)) := by
-  rw [(A.prod B).orthogonalQuotientMk_apply]
-  rfl
-
-private theorem orthogonalQuotientProdMap_bijective {H : AddSubgroup A} {K : AddSubgroup B}
-    (hH : A.IsIsotropic H) (hK : B.IsIsotropic K) :
-    Function.Bijective (orthogonalQuotientProdMap hH hK) := by
-  constructor
-  · rw [injective_iff_map_eq_zero]
-    intro z hz
-    induction z using orthogonalQuotient_induction_on with
-    | mk x =>
-      rw [orthogonalQuotientProdMap_orthogonalQuotientMk] at hz
-      rw [(A.prod B).orthogonalQuotientMk_eq_zero_iff, AddSubgroup.mem_prod]
-      exact ⟨(A.orthogonalQuotientMk_eq_zero_iff H hH _).mp (congrArg Prod.fst hz),
-        (B.orthogonalQuotientMk_eq_zero_iff K hK _).mp (congrArg Prod.snd hz)⟩
-  · rintro ⟨p, q⟩
-    obtain ⟨y, rfl⟩ := A.orthogonalQuotientMk_surjective H hH p
-    obtain ⟨z, rfl⟩ := B.orthogonalQuotientMk_surjective K hK q
-    refine ⟨(A.prod B).orthogonalQuotientMk (H.prod K)
-      ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩)
-      ⟨((y : A), (z : B)),
-        (FiniteBilinearModule.mem_orthogonalComplement_prod_iff _ _ H K _).mpr ⟨y.2, z.2⟩⟩, ?_⟩
-    rw [orthogonalQuotientProdMap_orthogonalQuotientMk]
-    rfl
+  rw [(A.prod B).orthogonalQuotientMk_apply, A.orthogonalQuotientMk_apply,
+    B.orthogonalQuotientMk_apply]
+  have h := FiniteBilinearModule.orthogonalQuotientProdIsometry_orthogonalQuotientMk
+    (A := A.toFiniteBilinearModule) (B := B.toFiniteBilinearModule) H K x
+  rwa [FiniteBilinearModule.orthogonalQuotientMk_apply,
+    FiniteBilinearModule.orthogonalQuotientMk_apply,
+    FiniteBilinearModule.orthogonalQuotientMk_apply] at h
 
 /-- **The quadratic orthogonal quotient of an orthogonal direct sum splits.** For
 quadratic-isotropic subgroups `H ≤ A` and `K ≤ B`, the orthogonal quotient of `A ⊥ B` by the
@@ -381,22 +310,20 @@ quotients:
 ```text
 (H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K).
 ```
--/
+
+The underlying additive equivalence is `TauCeti.FiniteBilinearModule`'s splitting of the same
+quotient; only the preservation of quadratic values is new. -/
 noncomputable def orthogonalQuotientProdIsometry {H : AddSubgroup A} {K : AddSubgroup B}
     (hH : A.IsIsotropic H) (hK : B.IsIsotropic K) :
     Isometry
       ((A.prod B).orthogonalQuotient (H.prod K) ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩))
       ((A.orthogonalQuotient H hH).prod (B.orthogonalQuotient K hK)) where
-  toLinearEquiv := (AddEquiv.ofBijective (orthogonalQuotientProdMap hH hK).toAddMonoidHom
-    (orthogonalQuotientProdMap_bijective hH hK)).toIntLinearEquiv
+  toLinearEquiv := (orthogonalQuotientProdAddEquiv hH hK).toIntLinearEquiv
   map_app' q := by
-    change ((A.orthogonalQuotient H hH).prod (B.orthogonalQuotient K hK)).quadratic
-        (orthogonalQuotientProdMap hH hK q) =
-      ((A.prod B).orthogonalQuotient (H.prod K)
-        ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩)).quadratic q
     induction q using orthogonalQuotient_induction_on with
     | mk x =>
-      rw [orthogonalQuotientProdMap_orthogonalQuotientMk,
+      simp only [LinearMap.toFun_eq_coe, LinearEquiv.coe_coe, AddEquiv.coe_toIntLinearEquiv]
+      rw [orthogonalQuotientProdAddEquiv_orthogonalQuotientMk,
         prod_quadratic, A.orthogonalQuotient_quadratic_mk H hH,
         B.orthogonalQuotient_quadratic_mk K hK,
         (A.prod B).orthogonalQuotient_quadratic_mk (H.prod K)
@@ -415,7 +342,7 @@ theorem orthogonalQuotientProdIsometry_orthogonalQuotientMk {H : AddSubgroup A}
       (A.orthogonalQuotientMk H hH (FiniteBilinearModule.orthogonalComplementProdFst H K x),
         B.orthogonalQuotientMk K hK
           (FiniteBilinearModule.orthogonalComplementProdSnd H K x)) :=
-  orthogonalQuotientProdMap_orthogonalQuotientMk hH hK x
+  orthogonalQuotientProdAddEquiv_orthogonalQuotientMk hH hK x
 
 end FiniteQuadraticModule
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Prod.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Prod.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
+public import TauCeti.LinearAlgebra.Quotient.Prod
 
 /-!
 # Orthogonal complements and quotients of an orthogonal direct sum
@@ -93,27 +94,29 @@ theorem orthogonalComplement_prod (H : AddSubgroup A) (K : AddSubgroup B) :
   rw [AddSubgroup.mem_prod]
   exact A.mem_orthogonalComplement_prod_iff B H K x
 
-/-- Two product subgroups of a product group are equal exactly when their factors are. -/
-private theorem prod_eq_prod_iff {H H' : AddSubgroup A} {K K' : AddSubgroup B} :
-    H.prod K = H'.prod K' ↔ H = H' ∧ K = K' := by
-  constructor
-  · intro h
-    refine ⟨AddSubgroup.ext fun x ↦ ?_, AddSubgroup.ext fun y ↦ ?_⟩
-    · have hx : (x, (0 : B.carrier)) ∈ H.prod K ↔ (x, (0 : B.carrier)) ∈ H'.prod K' := by
-        rw [h]
-      simpa only [AddSubgroup.mem_prod, K.zero_mem, K'.zero_mem, and_true] using hx
-    · have hy : ((0 : A.carrier), y) ∈ H.prod K ↔ ((0 : A.carrier), y) ∈ H'.prod K' := by
-        rw [h]
-      simpa only [AddSubgroup.mem_prod, H.zero_mem, H'.zero_mem, true_and] using hy
-  · rintro ⟨rfl, rfl⟩
-    rfl
-
 /-- **The Lagrangian condition on a product subgroup is componentwise.** -/
 @[simp]
 theorem isLagrangian_prod_iff (H : AddSubgroup A) (K : AddSubgroup B) :
     (A.prod B).IsLagrangian (H.prod K) ↔ A.IsLagrangian H ∧ B.IsLagrangian K := by
   rw [(A.prod B).isLagrangian_def, A.isLagrangian_def, B.isLagrangian_def,
-    A.orthogonalComplement_prod B, A.prod_eq_prod_iff B]
+    A.orthogonalComplement_prod B]
+  constructor
+  · intro h
+    refine ⟨AddSubgroup.ext fun x ↦ ?_, AddSubgroup.ext fun y ↦ ?_⟩
+    · have hx : (x, (0 : B.carrier)) ∈ H.prod K ↔
+          (x, (0 : B.carrier)) ∈
+            (A.orthogonalComplement H).prod (B.orthogonalComplement K) := by
+        rw [h]
+      simpa only [AddSubgroup.mem_prod, K.zero_mem,
+        (B.orthogonalComplement K).zero_mem, and_true] using hx
+    · have hy : ((0 : A.carrier), y) ∈ H.prod K ↔
+          ((0 : A.carrier), y) ∈
+            (A.orthogonalComplement H).prod (B.orthogonalComplement K) := by
+        rw [h]
+      simpa only [AddSubgroup.mem_prod, H.zero_mem,
+        (A.orthogonalComplement H).zero_mem, true_and] using hy
+  · intro h
+    exact congrArg₂ AddSubgroup.prod h.1 h.2
 
 /-! ## The orthogonal quotient of an orthogonal direct sum -/
 
@@ -151,55 +154,61 @@ theorem coe_orthogonalComplementProdSnd (H : AddSubgroup A) (K : AddSubgroup B)
     (x : (A.prod B).orthogonalComplement (H.prod K)) :
     (orthogonalComplementProdSnd H K x : B) = (x : A.carrier × B.carrier).2 := (rfl)
 
-/-- The map splitting the orthogonal quotient of `A ⊥ B` by a product subgroup into the two
-orthogonal quotients, as a `ℤ`-linear map. -/
-private noncomputable def orthogonalQuotientProdMap (H : AddSubgroup A) (K : AddSubgroup B) :
-    (A.prod B).orthogonalQuotient (H.prod K) →ₗ[ℤ]
+/-- The identification `(H × K)⊥ ≃ H⊥ × K⊥` underlying the quotient splitting. -/
+private def orthogonalComplementProdEquiv (H : AddSubgroup A) (K : AddSubgroup B) :
+    (A.prod B).orthogonalComplement (H.prod K) ≃ₗ[ℤ]
+      A.orthogonalComplement H × B.orthogonalComplement K where
+  toFun x := (orthogonalComplementProdFst H K x, orthogonalComplementProdSnd H K x)
+  invFun x := ⟨((x.1 : A), (x.2 : B)),
+    (A.mem_orthogonalComplement_prod_iff B H K _).mpr ⟨x.1.2, x.2.2⟩⟩
+  left_inv _ := Subtype.ext rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+/-- Under `(H × K)⊥ ≃ H⊥ × K⊥`, the denominator is the product of the two
+denominators. -/
+private theorem map_addSubgroupOf_orthogonalComplement_prod (H : AddSubgroup A)
+    (K : AddSubgroup B) :
+    ((H.prod K).addSubgroupOf
+        ((A.prod B).orthogonalComplement (H.prod K))).toIntSubmodule.map
+      (orthogonalComplementProdEquiv H K : _ →ₗ[ℤ] _) =
+      (H.addSubgroupOf (A.orthogonalComplement H)).toIntSubmodule.prod
+        (K.addSubgroupOf (B.orthogonalComplement K)).toIntSubmodule := by
+  ext x
+  rw [Submodule.mem_map_equiv, Submodule.mem_prod]
+  change ((orthogonalComplementProdEquiv H K).symm x : A.carrier × B.carrier) ∈ H.prod K ↔
+    (x.1 : A) ∈ H ∧ (x.2 : B) ∈ K
+  rw [AddSubgroup.mem_prod]
+  rfl
+
+/-- The canonical linear equivalence splitting the orthogonal quotient of a product. -/
+private noncomputable def orthogonalQuotientProdLinearEquiv (H : AddSubgroup A)
+    (K : AddSubgroup B) :
+    (A.prod B).orthogonalQuotient (H.prod K) ≃ₗ[ℤ]
       (A.orthogonalQuotient H).carrier × (B.orthogonalQuotient K).carrier :=
-  Submodule.liftQ
-    ((H.prod K).addSubgroupOf ((A.prod B).orthogonalComplement (H.prod K))).toIntSubmodule
-    (((A.orthogonalQuotientMk H).comp (orthogonalComplementProdFst H K)).prod
-      ((B.orthogonalQuotientMk K).comp (orthogonalComplementProdSnd H K))).toIntLinearMap
-    (by
-      intro x hx
-      have hx' : (x : A.carrier × B.carrier) ∈ H.prod K := hx
-      rw [AddSubgroup.mem_prod] at hx'
-      rw [LinearMap.mem_ker]
-      refine Prod.ext ?_ ?_
-      · exact (A.orthogonalQuotientMk_eq_zero_iff H _).mpr hx'.1
-      · exact (B.orthogonalQuotientMk_eq_zero_iff K _).mpr hx'.2)
+  (Submodule.Quotient.equiv _ _ (orthogonalComplementProdEquiv H K)
+      (map_addSubgroupOf_orthogonalComplement_prod H K)).trans
+    (Submodule.quotientProdEquiv
+      (H.addSubgroupOf (A.orthogonalComplement H)).toIntSubmodule
+      (K.addSubgroupOf (B.orthogonalComplement K)).toIntSubmodule)
 
 @[simp]
-private theorem orthogonalQuotientProdMap_orthogonalQuotientMk (H : AddSubgroup A)
-    (K : AddSubgroup B) (x : (A.prod B).orthogonalComplement (H.prod K)) :
-    orthogonalQuotientProdMap H K ((A.prod B).orthogonalQuotientMk (H.prod K) x) =
+private theorem orthogonalQuotientProdLinearEquiv_orthogonalQuotientMk
+    (H : AddSubgroup A) (K : AddSubgroup B)
+    (x : (A.prod B).orthogonalComplement (H.prod K)) :
+    orthogonalQuotientProdLinearEquiv H K
+        ((A.prod B).orthogonalQuotientMk (H.prod K) x) =
       (A.orthogonalQuotientMk H (orthogonalComplementProdFst H K x),
         B.orthogonalQuotientMk K (orthogonalComplementProdSnd H K x)) := by
-  rw [(A.prod B).orthogonalQuotientMk_apply, orthogonalQuotientProdMap]
-  exact Submodule.liftQ_apply _ _ x
-
-private theorem orthogonalQuotientProdMap_bijective (H : AddSubgroup A) (K : AddSubgroup B) :
-    Function.Bijective (orthogonalQuotientProdMap H K) := by
-  constructor
-  · rw [injective_iff_map_eq_zero]
-    intro z hz
-    induction z using orthogonalQuotient_induction_on with
-    | mk x =>
-      rw [orthogonalQuotientProdMap_orthogonalQuotientMk] at hz
-      rw [(A.prod B).orthogonalQuotientMk_eq_zero_iff, AddSubgroup.mem_prod]
-      exact ⟨(A.orthogonalQuotientMk_eq_zero_iff H _).mp (congrArg Prod.fst hz),
-        (B.orthogonalQuotientMk_eq_zero_iff K _).mp (congrArg Prod.snd hz)⟩
-  · rintro ⟨p, q⟩
-    obtain ⟨y, rfl⟩ := A.orthogonalQuotientMk_surjective H p
-    obtain ⟨z, rfl⟩ := B.orthogonalQuotientMk_surjective K q
-    refine ⟨(A.prod B).orthogonalQuotientMk (H.prod K)
-      ⟨((y : A), (z : B)), (A.mem_orthogonalComplement_prod_iff B H K _).mpr ⟨y.2, z.2⟩⟩, ?_⟩
-    rw [orthogonalQuotientProdMap_orthogonalQuotientMk]
-    exact Prod.ext
-      (congrArg (A.orthogonalQuotientMk H)
-        (Subtype.ext (coe_orthogonalComplementProdFst H K _)))
-      (congrArg (B.orthogonalQuotientMk K)
-        (Subtype.ext (coe_orthogonalComplementProdSnd H K _)))
+  rw [(A.prod B).orthogonalQuotientMk_apply]
+  change (Submodule.quotientProdEquiv _ _)
+      ((Submodule.Quotient.equiv _ _ (orthogonalComplementProdEquiv H K)
+        (map_addSubgroupOf_orthogonalComplement_prod H K)) (Submodule.Quotient.mk x)) = _
+  rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply,
+    Submodule.quotientProdEquiv_apply_mk, A.orthogonalQuotientMk_apply,
+    B.orthogonalQuotientMk_apply]
+  rfl
 
 /-- **The orthogonal quotient of an orthogonal direct sum splits.** For subgroups `H ≤ A` and
 `K ≤ B`, the orthogonal quotient of `A ⊥ B` by `H × K` is the orthogonal direct sum of the two
@@ -213,19 +222,16 @@ No isotropy hypothesis is needed, exactly as for the orthogonal quotient itself.
 noncomputable def orthogonalQuotientProdIsometry (H : AddSubgroup A) (K : AddSubgroup B) :
     Isometry ((A.prod B).orthogonalQuotient (H.prod K))
       ((A.orthogonalQuotient H).prod (B.orthogonalQuotient K)) where
-  toAddEquiv := AddEquiv.ofBijective (orthogonalQuotientProdMap H K).toAddMonoidHom
-    (orthogonalQuotientProdMap_bijective H K)
+  toAddEquiv := (orthogonalQuotientProdLinearEquiv H K).toAddEquiv
   map_pairing' q r := by
     induction q using orthogonalQuotient_induction_on with
     | mk x =>
       induction r using orthogonalQuotient_induction_on with
       | mk y =>
-        -- `AddEquiv.ofBijective` has no `coe` simp lemma, so name the underlying linear map
-        -- explicitly; the two are the same function by definition.
         change ((A.orthogonalQuotient H).prod (B.orthogonalQuotient K)).pairing
-            (orthogonalQuotientProdMap H K _) (orthogonalQuotientProdMap H K _) = _
-        rw [orthogonalQuotientProdMap_orthogonalQuotientMk,
-          orthogonalQuotientProdMap_orthogonalQuotientMk, prod_pairing,
+            (orthogonalQuotientProdLinearEquiv H K _) (orthogonalQuotientProdLinearEquiv H K _) = _
+        rw [orthogonalQuotientProdLinearEquiv_orthogonalQuotientMk,
+          orthogonalQuotientProdLinearEquiv_orthogonalQuotientMk, prod_pairing,
           A.orthogonalQuotient_pairing_mk, B.orthogonalQuotient_pairing_mk,
           (A.prod B).orthogonalQuotient_pairing_mk, prod_pairing,
           coe_orthogonalComplementProdFst, coe_orthogonalComplementProdFst,
@@ -238,7 +244,7 @@ theorem orthogonalQuotientProdIsometry_orthogonalQuotientMk (H : AddSubgroup A)
     orthogonalQuotientProdIsometry H K ((A.prod B).orthogonalQuotientMk (H.prod K) x) =
       (A.orthogonalQuotientMk H (orthogonalComplementProdFst H K x),
         B.orthogonalQuotientMk K (orthogonalComplementProdSnd H K x)) :=
-  orthogonalQuotientProdMap_orthogonalQuotientMk H K x
+  orthogonalQuotientProdLinearEquiv_orthogonalQuotientMk H K x
 
 end FiniteBilinearModule
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Prod.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Prod.lean
@@ -1,0 +1,422 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
+
+/-!
+# Orthogonal complements and quotients of an orthogonal direct sum
+
+Let `A` and `B` be finite bilinear modules and let `H ≤ A`, `K ≤ B` be additive subgroups. The
+pairing of the orthogonal direct sum `A ⊥ B` has no cross terms, so orthogonality of a vector
+against the product subgroup `H × K` is orthogonality of each component against its own factor:
+
+```text
+(H × K)⊥ = H⊥ × K⊥.
+```
+
+Isotropy and the Lagrangian condition are componentwise for the same reason, and the orthogonal
+quotient splits:
+
+```text
+(H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K).
+```
+
+The same statements hold for finite quadratic modules, whose orthogonal quotient is taken along a
+quadratic-isotropic subgroup; there the quadratic values, not only the pairings, add across the
+two factors.
+
+These are the componentwise laws that the gluing theory of integral lattices needs: the
+discriminant module of an orthogonal direct sum of lattices is the orthogonal direct sum of the
+discriminant modules, and an overlattice glued along a product subgroup is the orthogonal direct
+sum of the two glued overlattices, so its discriminant module must split the same way.
+
+## Main declarations
+
+* `TauCeti.FiniteBilinearModule.orthogonalComplement_prod`: `(H × K)⊥ = H⊥ × K⊥`.
+* `TauCeti.FiniteBilinearModule.isIsotropic_prod_iff` and
+  `TauCeti.FiniteBilinearModule.isLagrangian_prod_iff`: isotropy and the Lagrangian condition are
+  componentwise.
+* `TauCeti.FiniteBilinearModule.orthogonalQuotientProdIsometry`: the isometry
+  `(H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K)`.
+* `TauCeti.FiniteBilinearModule.Isometry.prod`: the orthogonal direct sum of two isometries.
+* `TauCeti.FiniteQuadraticModule.isIsotropic_prod_iff`,
+  `TauCeti.FiniteQuadraticModule.isLagrangian_prod_iff` and
+  `TauCeti.FiniteQuadraticModule.orthogonalQuotientProdIsometry`: the quadratic counterparts.
+  An orthogonal direct sum of quadratic isometries is Mathlib's
+  `QuadraticMap.IsometryEquiv.prod`.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.4.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w x
+
+namespace FiniteBilinearModule
+
+variable (A : FiniteBilinearModule.{u}) (B : FiniteBilinearModule.{v})
+
+/-! ## Orthogonal complements of a product subgroup -/
+
+/-- A vector of `A ⊥ B` is orthogonal to `H × K` exactly when each of its components is
+orthogonal to the corresponding factor. -/
+theorem mem_orthogonalComplement_prod_iff (H : AddSubgroup A) (K : AddSubgroup B)
+    (x : A.carrier × B.carrier) :
+    x ∈ (A.prod B).orthogonalComplement (H.prod K) ↔
+      x.1 ∈ A.orthogonalComplement H ∧ x.2 ∈ B.orthogonalComplement K := by
+  rw [(A.prod B).mem_orthogonalComplement_iff, A.mem_orthogonalComplement_iff,
+    B.mem_orthogonalComplement_iff]
+  constructor
+  · intro hx
+    refine ⟨fun y hy ↦ ?_, fun z hz ↦ ?_⟩
+    · have h := hx (y, 0) (AddSubgroup.mem_prod.mpr ⟨hy, K.zero_mem⟩)
+      rwa [A.prod_pairing B, B.pairing_zero_right, add_zero] at h
+    · have h := hx (0, z) (AddSubgroup.mem_prod.mpr ⟨H.zero_mem, hz⟩)
+      rwa [A.prod_pairing B, A.pairing_zero_right, zero_add] at h
+  · rintro ⟨hxA, hxB⟩ y hy
+    rw [AddSubgroup.mem_prod] at hy
+    rw [A.prod_pairing B, hxA y.1 hy.1, hxB y.2 hy.2, add_zero]
+
+/-- **The orthogonal complement of a product subgroup is the product of the complements.** -/
+@[simp]
+theorem orthogonalComplement_prod (H : AddSubgroup A) (K : AddSubgroup B) :
+    (A.prod B).orthogonalComplement (H.prod K) =
+      (A.orthogonalComplement H).prod (B.orthogonalComplement K) := by
+  ext x
+  rw [AddSubgroup.mem_prod]
+  exact A.mem_orthogonalComplement_prod_iff B H K x
+
+/-- Two product subgroups of a product group are equal exactly when their factors are. -/
+private theorem prod_eq_prod_iff {H H' : AddSubgroup A} {K K' : AddSubgroup B} :
+    H.prod K = H'.prod K' ↔ H = H' ∧ K = K' := by
+  constructor
+  · intro h
+    refine ⟨AddSubgroup.ext fun x ↦ ?_, AddSubgroup.ext fun y ↦ ?_⟩
+    · have hx : (x, (0 : B.carrier)) ∈ H.prod K ↔ (x, (0 : B.carrier)) ∈ H'.prod K' := by
+        rw [h]
+      simpa only [AddSubgroup.mem_prod, K.zero_mem, K'.zero_mem, and_true] using hx
+    · have hy : ((0 : A.carrier), y) ∈ H.prod K ↔ ((0 : A.carrier), y) ∈ H'.prod K' := by
+        rw [h]
+      simpa only [AddSubgroup.mem_prod, H.zero_mem, H'.zero_mem, true_and] using hy
+  · rintro ⟨rfl, rfl⟩
+    rfl
+
+/-- **Isotropy of a product subgroup is componentwise.** -/
+@[simp]
+theorem isIsotropic_prod_iff (H : AddSubgroup A) (K : AddSubgroup B) :
+    (A.prod B).IsIsotropic (H.prod K) ↔ A.IsIsotropic H ∧ B.IsIsotropic K := by
+  rw [(A.prod B).isIsotropic_iff_le_orthogonalComplement,
+    A.isIsotropic_iff_le_orthogonalComplement, B.isIsotropic_iff_le_orthogonalComplement,
+    A.orthogonalComplement_prod B]
+  constructor
+  · intro h
+    refine ⟨fun x hx ↦ ?_, fun y hy ↦ ?_⟩
+    · exact (AddSubgroup.mem_prod.mp (h (show (x, (0 : B.carrier)) ∈ H.prod K from
+        AddSubgroup.mem_prod.mpr ⟨hx, K.zero_mem⟩))).1
+    · exact (AddSubgroup.mem_prod.mp (h (show ((0 : A.carrier), y) ∈ H.prod K from
+        AddSubgroup.mem_prod.mpr ⟨H.zero_mem, hy⟩))).2
+  · rintro ⟨hH, hK⟩ x hx
+    rw [AddSubgroup.mem_prod] at hx ⊢
+    exact ⟨hH hx.1, hK hx.2⟩
+
+/-- **The Lagrangian condition on a product subgroup is componentwise.** -/
+@[simp]
+theorem isLagrangian_prod_iff (H : AddSubgroup A) (K : AddSubgroup B) :
+    (A.prod B).IsLagrangian (H.prod K) ↔ A.IsLagrangian H ∧ B.IsLagrangian K := by
+  rw [(A.prod B).isLagrangian_def, A.isLagrangian_def, B.isLagrangian_def,
+    A.orthogonalComplement_prod B, A.prod_eq_prod_iff B]
+
+
+/-! ## The orthogonal quotient of an orthogonal direct sum -/
+
+variable {A B}
+
+/-- The first component of a vector of `A ⊥ B` orthogonal to `H × K`, as a vector of `A`
+orthogonal to `H`. -/
+def orthogonalComplementProdFst (H : AddSubgroup A) (K : AddSubgroup B) :
+    (A.prod B).orthogonalComplement (H.prod K) →+ A.orthogonalComplement H where
+  toFun x := ⟨(x : A.carrier × B.carrier).1,
+    ((A.mem_orthogonalComplement_prod_iff B H K x).mp x.2).1⟩
+  map_zero' := rfl
+  map_add' _ _ := rfl
+
+/-- The second component of a vector of `A ⊥ B` orthogonal to `H × K`, as a vector of `B`
+orthogonal to `K`. -/
+def orthogonalComplementProdSnd (H : AddSubgroup A) (K : AddSubgroup B) :
+    (A.prod B).orthogonalComplement (H.prod K) →+ B.orthogonalComplement K where
+  toFun x := ⟨(x : A.carrier × B.carrier).2,
+    ((A.mem_orthogonalComplement_prod_iff B H K x).mp x.2).2⟩
+  map_zero' := rfl
+  map_add' _ _ := rfl
+
+@[simp]
+theorem coe_orthogonalComplementProdFst (H : AddSubgroup A) (K : AddSubgroup B)
+    (x : (A.prod B).orthogonalComplement (H.prod K)) :
+    (orthogonalComplementProdFst H K x : A) = (x : A.carrier × B.carrier).1 := (rfl)
+
+@[simp]
+theorem coe_orthogonalComplementProdSnd (H : AddSubgroup A) (K : AddSubgroup B)
+    (x : (A.prod B).orthogonalComplement (H.prod K)) :
+    (orthogonalComplementProdSnd H K x : B) = (x : A.carrier × B.carrier).2 := (rfl)
+
+/-- The map splitting the orthogonal quotient of `A ⊥ B` by a product subgroup into the two
+orthogonal quotients, as a `ℤ`-linear map. -/
+private noncomputable def orthogonalQuotientProdMap (H : AddSubgroup A) (K : AddSubgroup B) :
+    (A.prod B).orthogonalQuotient (H.prod K) →ₗ[ℤ]
+      (A.orthogonalQuotient H).carrier × (B.orthogonalQuotient K).carrier :=
+  Submodule.liftQ
+    ((H.prod K).addSubgroupOf ((A.prod B).orthogonalComplement (H.prod K))).toIntSubmodule
+    (((A.orthogonalQuotientMk H).comp (orthogonalComplementProdFst H K)).prod
+      ((B.orthogonalQuotientMk K).comp (orthogonalComplementProdSnd H K))).toIntLinearMap
+    (by
+      intro x hx
+      have hx' : (x : A.carrier × B.carrier) ∈ H.prod K := hx
+      rw [AddSubgroup.mem_prod] at hx'
+      rw [LinearMap.mem_ker]
+      refine Prod.ext ?_ ?_
+      · exact (A.orthogonalQuotientMk_eq_zero_iff H _).mpr hx'.1
+      · exact (B.orthogonalQuotientMk_eq_zero_iff K _).mpr hx'.2)
+
+@[simp]
+private theorem orthogonalQuotientProdMap_orthogonalQuotientMk (H : AddSubgroup A)
+    (K : AddSubgroup B) (x : (A.prod B).orthogonalComplement (H.prod K)) :
+    orthogonalQuotientProdMap H K ((A.prod B).orthogonalQuotientMk (H.prod K) x) =
+      (A.orthogonalQuotientMk H (orthogonalComplementProdFst H K x),
+        B.orthogonalQuotientMk K (orthogonalComplementProdSnd H K x)) := by
+  rw [(A.prod B).orthogonalQuotientMk_apply]
+  rfl
+
+private theorem orthogonalQuotientProdMap_bijective (H : AddSubgroup A) (K : AddSubgroup B) :
+    Function.Bijective (orthogonalQuotientProdMap H K) := by
+  constructor
+  · rw [injective_iff_map_eq_zero]
+    intro z hz
+    induction z using orthogonalQuotient_induction_on with
+    | mk x =>
+      rw [orthogonalQuotientProdMap_orthogonalQuotientMk] at hz
+      rw [(A.prod B).orthogonalQuotientMk_eq_zero_iff, AddSubgroup.mem_prod]
+      exact ⟨(A.orthogonalQuotientMk_eq_zero_iff H _).mp (congrArg Prod.fst hz),
+        (B.orthogonalQuotientMk_eq_zero_iff K _).mp (congrArg Prod.snd hz)⟩
+  · rintro ⟨p, q⟩
+    obtain ⟨y, rfl⟩ := A.orthogonalQuotientMk_surjective H p
+    obtain ⟨z, rfl⟩ := B.orthogonalQuotientMk_surjective K q
+    refine ⟨(A.prod B).orthogonalQuotientMk (H.prod K)
+      ⟨((y : A), (z : B)), (A.mem_orthogonalComplement_prod_iff B H K _).mpr ⟨y.2, z.2⟩⟩, ?_⟩
+    rw [orthogonalQuotientProdMap_orthogonalQuotientMk]
+    rfl
+
+/-- **The orthogonal quotient of an orthogonal direct sum splits.** For subgroups `H ≤ A` and
+`K ≤ B`, the orthogonal quotient of `A ⊥ B` by `H × K` is the orthogonal direct sum of the two
+orthogonal quotients:
+
+```text
+(H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K).
+```
+
+No isotropy hypothesis is needed, exactly as for the orthogonal quotient itself. -/
+noncomputable def orthogonalQuotientProdIsometry (H : AddSubgroup A) (K : AddSubgroup B) :
+    Isometry ((A.prod B).orthogonalQuotient (H.prod K))
+      ((A.orthogonalQuotient H).prod (B.orthogonalQuotient K)) where
+  toAddEquiv := AddEquiv.ofBijective (orthogonalQuotientProdMap H K).toAddMonoidHom
+    (orthogonalQuotientProdMap_bijective H K)
+  map_pairing' q r := by
+    induction q using orthogonalQuotient_induction_on with
+    | mk x =>
+      induction r using orthogonalQuotient_induction_on with
+      | mk y =>
+        change ((A.orthogonalQuotient H).prod (B.orthogonalQuotient K)).pairing
+            (orthogonalQuotientProdMap H K _) (orthogonalQuotientProdMap H K _) = _
+        rw [orthogonalQuotientProdMap_orthogonalQuotientMk,
+          orthogonalQuotientProdMap_orthogonalQuotientMk, prod_pairing,
+          A.orthogonalQuotient_pairing_mk, B.orthogonalQuotient_pairing_mk,
+          (A.prod B).orthogonalQuotient_pairing_mk, prod_pairing,
+          coe_orthogonalComplementProdFst, coe_orthogonalComplementProdFst,
+          coe_orthogonalComplementProdSnd, coe_orthogonalComplementProdSnd]
+
+/-- **The splitting of an orthogonal quotient on representatives.** -/
+@[simp]
+theorem orthogonalQuotientProdIsometry_orthogonalQuotientMk (H : AddSubgroup A)
+    (K : AddSubgroup B) (x : (A.prod B).orthogonalComplement (H.prod K)) :
+    orthogonalQuotientProdIsometry H K ((A.prod B).orthogonalQuotientMk (H.prod K) x) =
+      (A.orthogonalQuotientMk H (orthogonalComplementProdFst H K x),
+        B.orthogonalQuotientMk K (orthogonalComplementProdSnd H K x)) :=
+  orthogonalQuotientProdMap_orthogonalQuotientMk H K x
+
+/-! ## Orthogonal direct sums of isometries -/
+
+/-- **The orthogonal direct sum of two isometries.** -/
+def Isometry.prod {C : FiniteBilinearModule.{w}} {D : FiniteBilinearModule.{x}}
+    (f : Isometry A C) (g : Isometry B D) :
+    Isometry (A.prod B) (C.prod D) where
+  toAddEquiv := f.toAddEquiv.prodCongr g.toAddEquiv
+  map_pairing' x y := by
+    rw [prod_pairing, prod_pairing]
+    exact congrArg₂ (· + ·) (f.map_pairing x.1 y.1) (g.map_pairing x.2 y.2)
+
+@[simp]
+theorem Isometry.prod_apply {C : FiniteBilinearModule.{w}} {D : FiniteBilinearModule.{x}}
+    (f : Isometry A C) (g : Isometry B D) (z : A.carrier × B.carrier) :
+    f.prod g z = (f z.1, g z.2) := (rfl)
+
+end FiniteBilinearModule
+
+namespace FiniteQuadraticModule
+
+variable (A : FiniteQuadraticModule.{u}) (B : FiniteQuadraticModule.{v})
+
+/-! ## Quadratic isotropy of a product subgroup -/
+
+/-- **Quadratic isotropy of a product subgroup is componentwise.** -/
+@[simp]
+theorem isIsotropic_prod_iff (H : AddSubgroup A) (K : AddSubgroup B) :
+    (A.prod B).IsIsotropic (H.prod K) ↔ A.IsIsotropic H ∧ B.IsIsotropic K := by
+  simp only [isIsotropic_def]
+  constructor
+  · intro h
+    refine ⟨fun x hx ↦ ?_, fun y hy ↦ ?_⟩
+    · have hx' := h (x, 0) (AddSubgroup.mem_prod.mpr ⟨hx, K.zero_mem⟩)
+      rwa [A.prod_quadratic B, B.quadratic.map_zero, add_zero] at hx'
+    · have hy' := h (0, y) (AddSubgroup.mem_prod.mpr ⟨H.zero_mem, hy⟩)
+      rwa [A.prod_quadratic B, A.quadratic.map_zero, zero_add] at hy'
+  · rintro ⟨hH, hK⟩ ⟨x, y⟩ hxy
+    rw [AddSubgroup.mem_prod] at hxy
+    rw [A.prod_quadratic B, hH x hxy.1, hK y hxy.2, add_zero]
+
+/-- **The quadratic Lagrangian condition on a product subgroup is componentwise.** -/
+@[simp]
+theorem isLagrangian_prod_iff (H : AddSubgroup A) (K : AddSubgroup B) :
+    (A.prod B).IsLagrangian (H.prod K) ↔ A.IsLagrangian H ∧ B.IsLagrangian K := by
+  constructor
+  · intro h
+    have hisotropic := (A.isIsotropic_prod_iff B H K).mp (IsLagrangian.isIsotropic _ h)
+    have hlagrangian := (FiniteBilinearModule.isLagrangian_prod_iff
+      A.toFiniteBilinearModule B.toFiniteBilinearModule H K).mp
+      (IsLagrangian.toFiniteBilinearModule _ h)
+    exact ⟨(A.isLagrangian_def H).mpr ⟨hisotropic.1, hlagrangian.1⟩,
+      (B.isLagrangian_def K).mpr ⟨hisotropic.2, hlagrangian.2⟩⟩
+  · intro h
+    refine ((A.prod B).isLagrangian_def (H.prod K)).mpr
+      ⟨(A.isIsotropic_prod_iff B H K).mpr
+        ⟨IsLagrangian.isIsotropic _ h.1, IsLagrangian.isIsotropic _ h.2⟩, ?_⟩
+    exact (FiniteBilinearModule.isLagrangian_prod_iff
+      A.toFiniteBilinearModule B.toFiniteBilinearModule H K).mpr
+      ⟨IsLagrangian.toFiniteBilinearModule _ h.1,
+        IsLagrangian.toFiniteBilinearModule _ h.2⟩
+
+/-! ## The orthogonal quotient of an orthogonal direct sum -/
+
+variable {A B}
+
+/-- The map splitting the quadratic orthogonal quotient of `A ⊥ B` by a product subgroup into the
+two quadratic orthogonal quotients, as a `ℤ`-linear map. -/
+private noncomputable def orthogonalQuotientProdMap {H : AddSubgroup A} {K : AddSubgroup B}
+    (hH : A.IsIsotropic H) (hK : B.IsIsotropic K) :
+    (A.prod B).orthogonalQuotient (H.prod K) ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩) →ₗ[ℤ]
+      (A.orthogonalQuotient H hH).carrier × (B.orthogonalQuotient K hK).carrier :=
+  Submodule.liftQ ((A.prod B).subgroupInOrthogonalComplement (H.prod K)).toIntSubmodule
+    (((A.orthogonalQuotientMk H hH).comp
+        (FiniteBilinearModule.orthogonalComplementProdFst H K)).prod
+      ((B.orthogonalQuotientMk K hK).comp
+        (FiniteBilinearModule.orthogonalComplementProdSnd H K))).toIntLinearMap
+    (by
+      intro x hx
+      have hx0 : x ∈ (A.prod B).subgroupInOrthogonalComplement (H.prod K) := hx
+      have hx' : (x : A.carrier × B.carrier) ∈ H.prod K :=
+        ((A.prod B).mem_subgroupInOrthogonalComplement_iff (H.prod K) x).mp hx0
+      rw [AddSubgroup.mem_prod] at hx'
+      rw [LinearMap.mem_ker]
+      refine Prod.ext ?_ ?_
+      · exact (A.orthogonalQuotientMk_eq_zero_iff H hH _).mpr hx'.1
+      · exact (B.orthogonalQuotientMk_eq_zero_iff K hK _).mpr hx'.2)
+
+@[simp]
+private theorem orthogonalQuotientProdMap_orthogonalQuotientMk {H : AddSubgroup A}
+    {K : AddSubgroup B} (hH : A.IsIsotropic H) (hK : B.IsIsotropic K)
+    (x : (A.prod B).toFiniteBilinearModule.orthogonalComplement (H.prod K)) :
+    orthogonalQuotientProdMap hH hK
+        ((A.prod B).orthogonalQuotientMk (H.prod K)
+          ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩) x) =
+      (A.orthogonalQuotientMk H hH (FiniteBilinearModule.orthogonalComplementProdFst H K x),
+        B.orthogonalQuotientMk K hK
+          (FiniteBilinearModule.orthogonalComplementProdSnd H K x)) := by
+  rw [(A.prod B).orthogonalQuotientMk_apply]
+  rfl
+
+private theorem orthogonalQuotientProdMap_bijective {H : AddSubgroup A} {K : AddSubgroup B}
+    (hH : A.IsIsotropic H) (hK : B.IsIsotropic K) :
+    Function.Bijective (orthogonalQuotientProdMap hH hK) := by
+  constructor
+  · rw [injective_iff_map_eq_zero]
+    intro z hz
+    induction z using orthogonalQuotient_induction_on with
+    | mk x =>
+      rw [orthogonalQuotientProdMap_orthogonalQuotientMk] at hz
+      rw [(A.prod B).orthogonalQuotientMk_eq_zero_iff, AddSubgroup.mem_prod]
+      exact ⟨(A.orthogonalQuotientMk_eq_zero_iff H hH _).mp (congrArg Prod.fst hz),
+        (B.orthogonalQuotientMk_eq_zero_iff K hK _).mp (congrArg Prod.snd hz)⟩
+  · rintro ⟨p, q⟩
+    obtain ⟨y, rfl⟩ := A.orthogonalQuotientMk_surjective H hH p
+    obtain ⟨z, rfl⟩ := B.orthogonalQuotientMk_surjective K hK q
+    refine ⟨(A.prod B).orthogonalQuotientMk (H.prod K)
+      ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩)
+      ⟨((y : A), (z : B)),
+        (FiniteBilinearModule.mem_orthogonalComplement_prod_iff _ _ H K _).mpr ⟨y.2, z.2⟩⟩, ?_⟩
+    rw [orthogonalQuotientProdMap_orthogonalQuotientMk]
+    rfl
+
+/-- **The quadratic orthogonal quotient of an orthogonal direct sum splits.** For
+quadratic-isotropic subgroups `H ≤ A` and `K ≤ B`, the orthogonal quotient of `A ⊥ B` by the
+quadratic-isotropic subgroup `H × K` is the orthogonal direct sum of the two orthogonal
+quotients:
+
+```text
+(H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K).
+```
+-/
+noncomputable def orthogonalQuotientProdIsometry {H : AddSubgroup A} {K : AddSubgroup B}
+    (hH : A.IsIsotropic H) (hK : B.IsIsotropic K) :
+    Isometry
+      ((A.prod B).orthogonalQuotient (H.prod K) ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩))
+      ((A.orthogonalQuotient H hH).prod (B.orthogonalQuotient K hK)) where
+  toLinearEquiv := (AddEquiv.ofBijective (orthogonalQuotientProdMap hH hK).toAddMonoidHom
+    (orthogonalQuotientProdMap_bijective hH hK)).toIntLinearEquiv
+  map_app' q := by
+    change ((A.orthogonalQuotient H hH).prod (B.orthogonalQuotient K hK)).quadratic
+        (orthogonalQuotientProdMap hH hK q) =
+      ((A.prod B).orthogonalQuotient (H.prod K)
+        ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩)).quadratic q
+    induction q using orthogonalQuotient_induction_on with
+    | mk x =>
+      rw [orthogonalQuotientProdMap_orthogonalQuotientMk,
+        prod_quadratic, A.orthogonalQuotient_quadratic_mk H hH,
+        B.orthogonalQuotient_quadratic_mk K hK,
+        (A.prod B).orthogonalQuotient_quadratic_mk (H.prod K)
+          ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩) x,
+        FiniteBilinearModule.coe_orthogonalComplementProdFst,
+        FiniteBilinearModule.coe_orthogonalComplementProdSnd, prod_quadratic]
+
+/-- **The splitting of a quadratic orthogonal quotient on representatives.** -/
+@[simp]
+theorem orthogonalQuotientProdIsometry_orthogonalQuotientMk {H : AddSubgroup A}
+    {K : AddSubgroup B} (hH : A.IsIsotropic H) (hK : B.IsIsotropic K)
+    (x : (A.prod B).toFiniteBilinearModule.orthogonalComplement (H.prod K)) :
+    orthogonalQuotientProdIsometry hH hK
+        ((A.prod B).orthogonalQuotientMk (H.prod K)
+          ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩) x) =
+      (A.orthogonalQuotientMk H hH (FiniteBilinearModule.orthogonalComplementProdFst H K x),
+        B.orthogonalQuotientMk K hK
+          (FiniteBilinearModule.orthogonalComplementProdSnd H K x)) :=
+  orthogonalQuotientProdMap_orthogonalQuotientMk hH hK x
+
+end FiniteQuadraticModule
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Prod.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Prod.lean
@@ -23,7 +23,8 @@ The Lagrangian condition is componentwise for the same reason — as is isotropy
 `TauCeti.LinearAlgebra.FiniteBilinearModule.Basic` — and the orthogonal quotient splits:
 
 ```text
-(H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K).
+(H × K)⊥ / ((H × K) ∩ (H × K)⊥) ≅
+  (H⊥ / (H ∩ H⊥)) ⊥ (K⊥ / (K ∩ K⊥)).
 ```
 
 The same statements hold for finite quadratic modules, whose orthogonal quotient is taken along a
@@ -42,7 +43,8 @@ sum of the two glued overlattices, so its discriminant module must split the sam
 * `TauCeti.FiniteBilinearModule.orthogonalComplement_prod`: `(H × K)⊥ = H⊥ × K⊥`.
 * `TauCeti.FiniteBilinearModule.isLagrangian_prod_iff`: the Lagrangian condition is componentwise.
 * `TauCeti.FiniteBilinearModule.orthogonalQuotientProdIsometry`: the isometry
-  `(H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K)`.
+  `(H × K)⊥ / ((H × K) ∩ (H × K)⊥) ≅
+    (H⊥ / (H ∩ H⊥)) ⊥ (K⊥ / (K ∩ K⊥))`.
 * `TauCeti.FiniteQuadraticModule.isLagrangian_prod_iff` and
   `TauCeti.FiniteQuadraticModule.orthogonalQuotientProdIsometry`: the quadratic counterparts.
   An orthogonal direct sum of quadratic isometries is Mathlib's
@@ -177,6 +179,8 @@ private theorem map_addSubgroupOf_orthogonalComplement_prod (H : AddSubgroup A)
         (K.addSubgroupOf (B.orthogonalComplement K)).toIntSubmodule := by
   ext x
   rw [Submodule.mem_map_equiv, Submodule.mem_prod]
+  -- The source subgroup is represented inside the complement subtype, so expose the coercion
+  -- applied by the inverse complement equivalence before using `AddSubgroup.mem_prod`.
   change ((orthogonalComplementProdEquiv H K).symm x : A.carrier × B.carrier) ∈ H.prod K ↔
     (x.1 : A) ∈ H ∧ (x.2 : B) ∈ K
   rw [AddSubgroup.mem_prod]
@@ -202,6 +206,8 @@ private theorem orthogonalQuotientProdLinearEquiv_orthogonalQuotientMk
       (A.orthogonalQuotientMk H (orthogonalComplementProdFst H K x),
         B.orthogonalQuotientMk K (orthogonalComplementProdSnd H K x)) := by
   rw [(A.prod B).orthogonalQuotientMk_apply]
+  -- The linear equivalence is a composite of the transported-complement quotient equivalence and
+  -- the quotient-product equivalence; expose that composite to apply their representative lemmas.
   change (Submodule.quotientProdEquiv _ _)
       ((Submodule.Quotient.equiv _ _ (orthogonalComplementProdEquiv H K)
         (map_addSubgroupOf_orthogonalComplement_prod H K)) (Submodule.Quotient.mk x)) = _
@@ -215,7 +221,8 @@ private theorem orthogonalQuotientProdLinearEquiv_orthogonalQuotientMk
 orthogonal quotients:
 
 ```text
-(H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K).
+(H × K)⊥ / ((H × K) ∩ (H × K)⊥) ≅
+  (H⊥ / (H ∩ H⊥)) ⊥ (K⊥ / (K ∩ K⊥)).
 ```
 
 No isotropy hypothesis is needed, exactly as for the orthogonal quotient itself. -/
@@ -228,6 +235,8 @@ noncomputable def orthogonalQuotientProdIsometry (H : AddSubgroup A) (K : AddSub
     | mk x =>
       induction r using orthogonalQuotient_induction_on with
       | mk y =>
+        -- The isometry stores the linear equivalence above as an additive equivalence; expose that
+        -- wrapper equality so its representative theorem rewrites both arguments.
         change ((A.orthogonalQuotient H).prod (B.orthogonalQuotient K)).pairing
             (orthogonalQuotientProdLinearEquiv H K _) (orthogonalQuotientProdLinearEquiv H K _) = _
         rw [orthogonalQuotientProdLinearEquiv_orthogonalQuotientMk,
@@ -287,8 +296,12 @@ private noncomputable def orthogonalQuotientProdAddEquiv {H : AddSubgroup A} {K 
     (hH : A.IsIsotropic H) (hK : B.IsIsotropic K) :
     (A.prod B).orthogonalQuotient (H.prod K) ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩) ≃+
       (A.orthogonalQuotient H hH).prod (B.orthogonalQuotient K hK) :=
-  (FiniteBilinearModule.orthogonalQuotientProdIsometry (A := A.toFiniteBilinearModule)
-    (B := B.toFiniteBilinearModule) H K).toAddEquiv
+  (((A.prod B).orthogonalQuotientUnderlyingEquiv (H.prod K)
+      ((A.isIsotropic_prod_iff B H K).mpr ⟨hH, hK⟩)).trans
+    (FiniteBilinearModule.orthogonalQuotientProdIsometry (A := A.toFiniteBilinearModule)
+      (B := B.toFiniteBilinearModule) H K).toAddEquiv).trans
+    ((A.orthogonalQuotientUnderlyingEquiv H hH).symm.prodCongr
+      (B.orthogonalQuotientUnderlyingEquiv K hK).symm)
 
 @[simp]
 private theorem orthogonalQuotientProdAddEquiv_orthogonalQuotientMk {H : AddSubgroup A}
@@ -300,13 +313,39 @@ private theorem orthogonalQuotientProdAddEquiv_orthogonalQuotientMk {H : AddSubg
       (A.orthogonalQuotientMk H hH (FiniteBilinearModule.orthogonalComplementProdFst H K x),
         B.orthogonalQuotientMk K hK
           (FiniteBilinearModule.orthogonalComplementProdSnd H K x)) := by
-  rw [(A.prod B).orthogonalQuotientMk_apply, A.orthogonalQuotientMk_apply,
-    B.orthogonalQuotientMk_apply]
-  have h := FiniteBilinearModule.orthogonalQuotientProdIsometry_orthogonalQuotientMk
-    (A := A.toFiniteBilinearModule) (B := B.toFiniteBilinearModule) H K x
-  rwa [FiniteBilinearModule.orthogonalQuotientMk_apply,
-    FiniteBilinearModule.orthogonalQuotientMk_apply,
-    FiniteBilinearModule.orthogonalQuotientMk_apply] at h
+  rw [orthogonalQuotientProdAddEquiv, AddEquiv.trans_apply, AddEquiv.trans_apply,
+    (A.prod B).orthogonalQuotientUnderlyingEquiv_orthogonalQuotientMk]
+  let x' : (A.toFiniteBilinearModule.prod B.toFiniteBilinearModule).orthogonalComplement
+      (H.prod K) := by
+    simpa only [A.prod_toFiniteBilinearModule B] using x
+  have hx : (A.prod B).toFiniteBilinearModule.orthogonalQuotientMk (H.prod K) x =
+      (A.toFiniteBilinearModule.prod B.toFiniteBilinearModule).orthogonalQuotientMk
+        (H.prod K) x' := by
+    rfl
+  rw [hx]
+  have hsplit :
+      (FiniteBilinearModule.orthogonalQuotientProdIsometry
+          (A := A.toFiniteBilinearModule) (B := B.toFiniteBilinearModule) H K).toAddEquiv
+          ((A.toFiniteBilinearModule.prod B.toFiniteBilinearModule).orthogonalQuotientMk
+            (H.prod K) x') =
+        (A.toFiniteBilinearModule.orthogonalQuotientMk H
+            (FiniteBilinearModule.orthogonalComplementProdFst H K x'),
+          B.toFiniteBilinearModule.orthogonalQuotientMk K
+            (FiniteBilinearModule.orthogonalComplementProdSnd H K x')) :=
+    FiniteBilinearModule.orthogonalQuotientProdIsometry_orthogonalQuotientMk H K x'
+  rw [hsplit]
+  -- The final transport is the componentwise product of the two inverse underlying-quotient
+  -- equivalences; expose its pointwise action before applying their representative formulas.
+  change
+    ((A.orthogonalQuotientUnderlyingEquiv H hH).symm
+        (A.toFiniteBilinearModule.orthogonalQuotientMk H
+          (FiniteBilinearModule.orthogonalComplementProdFst H K x')),
+      (B.orthogonalQuotientUnderlyingEquiv K hK).symm
+        (B.toFiniteBilinearModule.orthogonalQuotientMk K
+          (FiniteBilinearModule.orthogonalComplementProdSnd H K x'))) = _
+  rw [A.orthogonalQuotientUnderlyingEquiv_symm_orthogonalQuotientMk,
+    B.orthogonalQuotientUnderlyingEquiv_symm_orthogonalQuotientMk]
+  rfl
 
 /-- **The quadratic orthogonal quotient of an orthogonal direct sum splits.** For
 quadratic-isotropic subgroups `H ≤ A` and `K ≤ B`, the orthogonal quotient of `A ⊥ B` by the

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -768,11 +768,8 @@ theorem card_quotientOfLeQuadraticRadical (K : AddSubgroup A)
 /-! ### The induced quadratic form on `H^⊥ / H` -/
 
 /-- The elements of `H` lying in `H^⊥`, viewed as a subgroup of `H^⊥`. When `H ≤ H^⊥`, this
-intersection is a copy of all of `H`.
-
-Exposed for the same reason as `orthogonalQuotient`, which is built on it: so that the carrier of
-the quadratic orthogonal quotient reduces to the carrier of the bilinear one. -/
-@[expose] def subgroupInOrthogonalComplement (H : AddSubgroup A) :
+intersection is a copy of all of `H`. -/
+def subgroupInOrthogonalComplement (H : AddSubgroup A) :
     AddSubgroup (A.toFiniteBilinearModule.orthogonalComplement H) :=
   H.addSubgroupOf (A.toFiniteBilinearModule.orthogonalComplement H)
 
@@ -824,6 +821,13 @@ theorem orthogonalQuotient_toFiniteBilinearModule (H : AddSubgroup A) (hH : A.Is
     (A.orthogonalQuotient H hH).toFiniteBilinearModule =
       A.toFiniteBilinearModule.orthogonalQuotient H := (rfl)
 
+/-- The additive equivalence from a quadratic orthogonal quotient to its underlying bilinear
+orthogonal quotient. -/
+noncomputable def orthogonalQuotientUnderlyingEquiv (A : FiniteQuadraticModule.{u})
+    (H : AddSubgroup A) (hH : A.IsIsotropic H) :
+    A.orthogonalQuotient H hH ≃+ A.toFiniteBilinearModule.orthogonalQuotient H := by
+  rw [A.orthogonalQuotient_toFiniteBilinearModule H hH]
+
 /-- The quotient map from `H^⊥` onto its induced quadratic quotient. -/
 noncomputable def orthogonalQuotientMk (H : AddSubgroup A) (hH : A.IsIsotropic H) :
     A.toFiniteBilinearModule.orthogonalComplement H →+
@@ -842,6 +846,30 @@ theorem orthogonalQuotientMk_apply (H : AddSubgroup A) (hH : A.IsIsotropic H)
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x
+
+/-- The equivalence with the underlying bilinear orthogonal quotient commutes with the quotient
+maps. -/
+@[simp]
+theorem orthogonalQuotientUnderlyingEquiv_orthogonalQuotientMk (H : AddSubgroup A)
+    (hH : A.IsIsotropic H) (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    A.orthogonalQuotientUnderlyingEquiv H hH (A.orthogonalQuotientMk H hH x) =
+      A.toFiniteBilinearModule.orthogonalQuotientMk H x := by
+  unfold orthogonalQuotientUnderlyingEquiv FiniteQuadraticModule.orthogonalQuotientMk
+  unfold subgroupInOrthogonalComplement quotientOfLeQuadraticRadicalMk
+  rw [A.toFiniteBilinearModule.orthogonalQuotientMk_apply]
+  exact Submodule.mkQ_apply _ _
+
+/-- The inverse equivalence from the underlying bilinear orthogonal quotient commutes with the
+quotient maps. -/
+@[simp]
+theorem orthogonalQuotientUnderlyingEquiv_symm_orthogonalQuotientMk (H : AddSubgroup A)
+    (hH : A.IsIsotropic H) (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    (A.orthogonalQuotientUnderlyingEquiv H hH).symm
+        (A.toFiniteBilinearModule.orthogonalQuotientMk H x) =
+      A.orthogonalQuotientMk H hH x := by
+  apply (A.orthogonalQuotientUnderlyingEquiv H hH).injective
+  rw [AddEquiv.apply_symm_apply,
+    A.orthogonalQuotientUnderlyingEquiv_orthogonalQuotientMk]
 
 /-- The quadratic form on `H^⊥ / H` is represented by the original quadratic form. -/
 @[simp]
@@ -953,27 +981,6 @@ theorem isIsotropic_of_map_eq (f : Isometry A B) {H : AddSubgroup A} {K : AddSub
   rw [← h, f.isIsotropic_map_iff]
   exact hH
 
-/-- The additive equivalence from a quadratic orthogonal quotient to its underlying bilinear
-orthogonal quotient. -/
-private noncomputable def orthogonalQuotientUnderlyingEquiv (A : FiniteQuadraticModule.{w})
-    (H : AddSubgroup A) (hH : A.IsIsotropic H) :
-    A.orthogonalQuotient H hH ≃+ A.toFiniteBilinearModule.orthogonalQuotient H := by
-  unfold FiniteQuadraticModule.orthogonalQuotient
-  unfold subgroupInOrthogonalComplement quotientOfLeQuadraticRadical
-  unfold FiniteBilinearModule.orthogonalQuotient
-  exact AddEquiv.refl _
-
-@[simp]
-private theorem orthogonalQuotientUnderlyingEquiv_orthogonalQuotientMk
-    (A : FiniteQuadraticModule.{w}) (H : AddSubgroup A) (hH : A.IsIsotropic H)
-    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
-    orthogonalQuotientUnderlyingEquiv A H hH (A.orthogonalQuotientMk H hH x) =
-      A.toFiniteBilinearModule.orthogonalQuotientMk H x := by
-  unfold orthogonalQuotientUnderlyingEquiv FiniteQuadraticModule.orthogonalQuotientMk
-  unfold subgroupInOrthogonalComplement quotientOfLeQuadraticRadicalMk
-  rw [A.toFiniteBilinearModule.orthogonalQuotientMk_apply]
-  exact Submodule.mkQ_apply _ _
-
 /-- The bilinear transport induced by a quadratic isometry. -/
 private noncomputable def orthogonalQuotientBilinearMapAddEquiv (f : Isometry A B)
     (H : AddSubgroup A) :
@@ -1018,7 +1025,7 @@ private noncomputable def orthogonalQuotientMapAddEquiv (f : Isometry A B)
       B.orthogonalQuotient (H.map f.toAddEquiv) hK := by
   let eA : A.orthogonalQuotient H hH ≃+
       A.toFiniteBilinearModule.orthogonalQuotient H :=
-    orthogonalQuotientUnderlyingEquiv A H hH
+    A.orthogonalQuotientUnderlyingEquiv H hH
   let e : A.toFiniteBilinearModule.orthogonalQuotient H ≃+
       B.toFiniteBilinearModule.orthogonalQuotient (H.map f.toAddEquiv) :=
     orthogonalQuotientBilinearMapAddEquiv f H
@@ -1041,7 +1048,7 @@ private theorem orthogonalQuotientMapAddEquiv_orthogonalQuotientMk (f : Isometry
           A.toFiniteBilinearModule f.toFiniteBilinearModule
           (by rw [f.toFiniteBilinearModule_toAddEquiv]) x.2⟩ := by
   rw [orthogonalQuotientMapAddEquiv, AddEquiv.trans_apply, AddEquiv.trans_apply,
-    orthogonalQuotientUnderlyingEquiv_orthogonalQuotientMk,
+    A.orthogonalQuotientUnderlyingEquiv_orthogonalQuotientMk,
     orthogonalQuotientBilinearMapAddEquiv_orthogonalQuotientMk]
   unfold FiniteQuadraticModule.orthogonalQuotientMk
   unfold subgroupInOrthogonalComplement quotientOfLeQuadraticRadicalMk

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -36,6 +36,8 @@ the polar pairing is therefore `B(x, y)` modulo `ℤ`.
 * `TauCeti.FiniteQuadraticModule.Hom`: a quadratic-map-preserving additive homomorphism.
 * `TauCeti.FiniteQuadraticModule.Isometry`: a quadratic-map isometric equivalence.
 * `TauCeti.FiniteQuadraticModule.IsIsotropic`: quadratic isotropy of an additive subgroup.
+* `TauCeti.FiniteQuadraticModule.isIsotropic_prod_iff`: quadratic isotropy of a product subgroup
+  in an orthogonal direct sum is quadratic isotropy of each factor subgroup.
 * `TauCeti.FiniteQuadraticModule.IsLagrangian`: a quadratic-isotropic subgroup equal to its
   bilinear orthogonal complement.
 * `TauCeti.FiniteQuadraticModule.orthogonalQuotient`: the quadratic module induced on
@@ -529,6 +531,23 @@ theorem IsIsotropic.mono {H K : AddSubgroup A} (hK : A.IsIsotropic K) (h : H ≤
 theorem isIsotropic_bot : A.IsIsotropic ⊥ := by
   simp [IsIsotropic]
 
+/-- **Quadratic isotropy of a product subgroup is componentwise.** -/
+@[simp]
+theorem isIsotropic_prod_iff (B : FiniteQuadraticModule) (H : AddSubgroup A)
+    (K : AddSubgroup B) :
+    (A.prod B).IsIsotropic (H.prod K) ↔ A.IsIsotropic H ∧ B.IsIsotropic K := by
+  simp only [isIsotropic_def]
+  constructor
+  · intro h
+    refine ⟨fun x hx ↦ ?_, fun y hy ↦ ?_⟩
+    · have hx' := h (x, 0) (AddSubgroup.mem_prod.mpr ⟨hx, K.zero_mem⟩)
+      rwa [A.prod_quadratic B, B.quadratic.map_zero, add_zero] at hx'
+    · have hy' := h (0, y) (AddSubgroup.mem_prod.mpr ⟨H.zero_mem, hy⟩)
+      rwa [A.prod_quadratic B, A.quadratic.map_zero, zero_add] at hy'
+  · rintro ⟨hH, hK⟩ ⟨x, y⟩ hxy
+    rw [AddSubgroup.mem_prod] at hxy
+    rw [A.prod_quadratic B, hH x hxy.1, hK y hxy.2, add_zero]
+
 /-- A subgroup is quadratically isotropic exactly when the restricted quadratic map is zero. -/
 theorem isIsotropic_iff_restrict_eq_zero (H : AddSubgroup A) :
     A.IsIsotropic H ↔ (A.restrict H).quadratic = 0 := by
@@ -749,8 +768,11 @@ theorem card_quotientOfLeQuadraticRadical (K : AddSubgroup A)
 /-! ### The induced quadratic form on `H^⊥ / H` -/
 
 /-- The elements of `H` lying in `H^⊥`, viewed as a subgroup of `H^⊥`. When `H ≤ H^⊥`, this
-intersection is a copy of all of `H`. -/
-def subgroupInOrthogonalComplement (H : AddSubgroup A) :
+intersection is a copy of all of `H`.
+
+Exposed for the same reason as `orthogonalQuotient`, which is built on it: so that the carrier of
+the quadratic orthogonal quotient reduces to the carrier of the bilinear one. -/
+@[expose] def subgroupInOrthogonalComplement (H : AddSubgroup A) :
     AddSubgroup (A.toFiniteBilinearModule.orthogonalComplement H) :=
   H.addSubgroupOf (A.toFiniteBilinearModule.orthogonalComplement H)
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -425,20 +425,22 @@ theorem neg_toFiniteBilinearModule :
 theorem isNondegenerate_neg : A.neg.IsNondegenerate ↔ A.IsNondegenerate := by
   exact A.toFiniteBilinearModule.isNondegenerate_neg
 
-/-- The orthogonal product of two finite quadratic modules. -/
-@[expose] def prod (B : FiniteQuadraticModule) : FiniteQuadraticModule where
+/-- The orthogonal product of two finite quadratic modules.
+
+Reducible, exactly as `TauCeti.FiniteBilinearModule.prod` is, so that the carrier of an orthogonal
+product reduces to the product of the carriers and a subgroup of that product is a subgroup of the
+orthogonal product without further coercion. -/
+abbrev prod (B : FiniteQuadraticModule) : FiniteQuadraticModule where
   toFiniteBilinearModule := A.toFiniteBilinearModule.prod B.toFiniteBilinearModule
   quadratic := A.quadratic.prod B.quadratic
   polar_eq_pairing' x y := by
     rw [FiniteBilinearModule.prod_pairing, ← A.polar_eq_pairing, ← B.polar_eq_pairing]
     exact QuadraticMap.polar_prod A.quadratic B.quadratic x y
 
-@[simp]
 theorem prod_quadratic (B : FiniteQuadraticModule) (x : A) (y : B) :
     (A.prod B).quadratic (x, y) = A.quadratic x + B.quadratic y := by
   rfl
 
-@[simp]
 theorem prod_pairing (B : FiniteQuadraticModule) (x y : A.carrier × B.carrier) :
     (A.prod B).toFiniteBilinearModule.pairing x y =
       A.toFiniteBilinearModule.pairing x.1 y.1 +
@@ -560,6 +562,11 @@ polar bilinear pairing. -/
 def IsLagrangian (H : AddSubgroup A) : Prop :=
   A.IsIsotropic H ∧ A.toFiniteBilinearModule.IsLagrangian H
 
+/-- The quadratic Lagrangian condition, unfolded to its two defining properties. -/
+theorem isLagrangian_def (H : AddSubgroup A) :
+    A.IsLagrangian H ↔
+      A.IsIsotropic H ∧ A.toFiniteBilinearModule.IsLagrangian H := Iff.rfl
+
 /-- A quadratic isometry transports quadratic Lagrangian subgroups. -/
 @[simp]
 theorem Isometry.isLagrangian_map_iff {B : FiniteQuadraticModule} (f : Isometry A B)
@@ -647,6 +654,12 @@ noncomputable def quotientOfLeQuadraticRadicalMk (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
     A →+ A.quotientOfLeQuadraticRadical K hK :=
   K.toIntSubmodule.mkQ.toAddMonoidHom
+
+/-- The quotient map sends an element to its quotient class. -/
+theorem quotientOfLeQuadraticRadicalMk_apply (K : AddSubgroup A)
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) (x : A) :
+    A.quotientOfLeQuadraticRadicalMk K hK x = Submodule.Quotient.mk x :=
+  Submodule.mkQ_apply K.toIntSubmodule x
 
 /-- The quotient quadratic map is represented by the original quadratic map. -/
 @[simp]
@@ -797,6 +810,16 @@ noncomputable def orthogonalQuotientMk (H : AddSubgroup A) (hH : A.IsIsotropic H
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)
+
+/-- The orthogonal-quotient map sends an element of `H^⊥` to its quotient class. -/
+theorem orthogonalQuotientMk_apply (H : AddSubgroup A) (hH : A.IsIsotropic H)
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    A.orthogonalQuotientMk H hH x = Submodule.Quotient.mk x := by
+  unfold orthogonalQuotientMk
+  exact quotientOfLeQuadraticRadicalMk_apply
+    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
+    (A.subgroupInOrthogonalComplement H)
+    (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x
 
 /-- The quadratic form on `H^⊥ / H` is represented by the original quadratic form. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Dual.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Dual.lean
@@ -48,6 +48,9 @@ computed componentwise on an orthogonal direct sum.
   intermediate carrier is unimodular exactly when its subgroup is Lagrangian.
 * `TauCeti.IntegralLattice.dual_intermediateCarrierOfDiscriminantSubgroup_eq_self_iff`: the
   overlattice `L_H` is unimodular exactly when `H = H⊥`.
+* `TauCeti.IntegralLattice.IntermediateCarrier.mem_dualCarrier_orthogonalSum_iff`: a vector is a
+  dual vector of an assembled overlattice exactly when both of its components are dual vectors of
+  the two factors.
 
 ## References
 
@@ -334,6 +337,40 @@ theorem dual_orthogonalSumIntermediateCarrier (L : IntegralLattice V) (M : Integ
   · rintro ⟨hp₁, hp₂⟩ q hq
     rw [orthogonalSum_form, orthogonalSumForm_apply]
     exact add_mem (hp₁ q.1 hq.1) (hp₂ q.2 hq.2)
+
+section OrthogonalSum
+
+variable {M : IntegralLattice W} [L.IsNondegenerate] [M.IsNondegenerate]
+variable {P : L.IntermediateCarrier} {Q : M.IntermediateCarrier}
+
+namespace IntermediateCarrier
+
+/-- **Dual vectors of an assembled overlattice are componentwise.** -/
+@[simp]
+theorem mem_dualCarrier_orthogonalSum_iff (hP : IsIntegral P) (hQ : IsIntegral Q) (x : V × W) :
+    x ∈ (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier ↔
+      x.1 ∈ hP.toIntegralLattice.dualCarrier ∧ x.2 ∈ hQ.toIntegralLattice.dualCarrier := by
+  rw [IsIntegral.toIntegralLattice_dualCarrier, IsIntegral.toIntegralLattice_dualCarrier,
+    IsIntegral.toIntegralLattice_dualCarrier, dual_orthogonalSumIntermediateCarrier,
+    mem_orthogonalSumIntermediateCarrier_iff]
+
+/-- The first component of a dual vector of the assembled overlattice is a dual vector of the
+first overlattice. -/
+theorem fst_mem_dualCarrier_orthogonalSum (hP : IsIntegral P) (hQ : IsIntegral Q)
+    (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :
+    (y : V × W).1 ∈ hP.toIntegralLattice.dualCarrier :=
+  ((mem_dualCarrier_orthogonalSum_iff hP hQ (y : V × W)).mp y.2).1
+
+/-- The second component of a dual vector of the assembled overlattice is a dual vector of the
+second overlattice. -/
+theorem snd_mem_dualCarrier_orthogonalSum (hP : IsIntegral P) (hQ : IsIntegral Q)
+    (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :
+    (y : V × W).2 ∈ hQ.toIntegralLattice.dualCarrier :=
+  ((mem_dualCarrier_orthogonalSum_iff hP hQ (y : V × W)).mp y.2).2
+
+end IntermediateCarrier
+
+end OrthogonalSum
 
 end IntegralLattice
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Naturality.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Naturality.lean
@@ -587,6 +587,13 @@ theorem isIntegral_orthogonalSumIntermediateCarrier_iff (P : L.IntermediateCarri
     rw [orthogonalSum_form, orthogonalSumForm_apply]
     exact Submodule.add_mem _ (hP p.1 hp.1 q.1 hq.1) (hQ p.2 hp.2 q.2 hq.2)
 
+/-- The assembled carrier `P ⊕ Q` of two integral intermediate carriers is integral. -/
+theorem IntermediateCarrier.IsIntegral.orthogonalSum {P : L.IntermediateCarrier}
+    {Q : M.IntermediateCarrier} (hP : IntermediateCarrier.IsIntegral P)
+    (hQ : IntermediateCarrier.IsIntegral Q) :
+    IntermediateCarrier.IsIntegral (orthogonalSumIntermediateCarrier L M P Q) :=
+  (isIntegral_orthogonalSumIntermediateCarrier_iff P Q).mpr ⟨hP, hQ⟩
+
 /-- **Evenness of an assembled carrier is componentwise.** -/
 @[simp]
 theorem isEven_orthogonalSumIntermediateCarrier_iff (P : L.IntermediateCarrier)

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/OrthogonalSum.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Prod
-public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Naturality
 public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Bilinear
 
 /-!

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/OrthogonalSum.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Prod
 public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Bilinear
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Quadratic
 
 /-!
 # The comparison `A_(P ⊕ Q) ≅ (H⊥ / H) ⊥ (K⊥ / K)` for an orthogonal direct sum
@@ -29,6 +30,9 @@ under a lattice isometry, proved in
 functoriality package the gluing theory asks of the comparison isometry attached to an integral
 overlattice.
 
+For even lattices and even overlattices, the same construction and representative formula are
+also given for the discriminant quadratic modules.
+
 The two ingredients are the splitting of an orthogonal quotient of finite bilinear modules along
 a product subgroup, from
 `TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Prod`, and the componentwise description
@@ -44,6 +48,8 @@ of the intermediate-carrier correspondence, from
 * `IntermediateCarrier.discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum_mk`: it is
   componentwise, that is, it agrees with the pair of the comparison isometries of `P` and
   of `Q`.
+* `IntermediateCarrier.discriminantQuadraticOrthogonalQuotientIsometryOrthogonalSum` and its
+  `_mk` theorem: the corresponding componentwise comparison of discriminant quadratic modules.
 
 ## References
 
@@ -169,6 +175,90 @@ theorem discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum_mk
       (congrArg Prod.fst (discriminantBilinearIsometryOrthogonalSum_dualClassHom hP hQ y))
   · exact (FiniteBilinearModule.coe_orthogonalComplementProdSnd _ _ _).trans
       (congrArg Prod.snd (discriminantBilinearIsometryOrthogonalSum_dualClassHom hP hQ y))
+
+/-! ## The quadratic comparison for even overlattices -/
+
+/-- **The discriminant quadratic module of an assembled even overlattice as an orthogonal direct
+sum of orthogonal quotients.** This is the even refinement of
+`discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum`. -/
+noncomputable def discriminantQuadraticOrthogonalQuotientIsometryOrthogonalSum
+    (hL : L.IsEven) (hM : M.IsEven) (hP : IsEven P) (hQ : IsEven Q) :
+    FiniteQuadraticModule.Isometry
+      ((hP.isIntegral.orthogonalSum hQ.isIntegral).toIntegralLattice.discriminantQuadraticModule
+        ((isEven_orthogonalSumIntermediateCarrier_iff P Q).mpr
+          ⟨hP, hQ⟩).isEven_toIntegralLattice)
+      (((L.discriminantQuadraticModule hL).orthogonalQuotient
+          (L.discriminantSubgroup P)
+          ((isEven_iff_isIsotropic_discriminantSubgroup hL P).mp hP)).prod
+        ((M.discriminantQuadraticModule hM).orthogonalQuotient
+          (M.discriminantSubgroup Q)
+          ((isEven_iff_isIsotropic_discriminantSubgroup hM Q).mp hQ))) := by
+  let hLM : (L.orthogonalSum M).IsEven :=
+    (L.isEven_orthogonalSum_iff M).mpr ⟨hL, hM⟩
+  let hPQ : IsEven (orthogonalSumIntermediateCarrier L M P Q) :=
+    (isEven_orthogonalSumIntermediateCarrier_iff P Q).mpr ⟨hP, hQ⟩
+  let hSubgroup := (isEven_iff_isIsotropic_discriminantSubgroup hLM
+    (orthogonalSumIntermediateCarrier L M P Q)).mp hPQ
+  have hMap := map_discriminantSubgroup_orthogonalSumIntermediateCarrier P Q
+  rw [← L.discriminantQuadraticIsometryOrthogonalSum_toAddEquiv M hL hM] at hMap
+  exact ((discriminantOrthogonalQuotientIsometry hLM hPQ).trans
+    ((L.discriminantQuadraticIsometryOrthogonalSum M hL hM).orthogonalQuotientEquiv
+      hSubgroup hMap)).trans
+    (FiniteQuadraticModule.orthogonalQuotientProdIsometry
+      ((isEven_iff_isIsotropic_discriminantSubgroup hL P).mp hP)
+      ((isEven_iff_isIsotropic_discriminantSubgroup hM Q).mp hQ))
+
+/-- **The quadratic comparison for an assembled even overlattice is componentwise.** It sends a
+dual-vector class to the pair of its component classes under the two quadratic comparison
+isometries. -/
+theorem discriminantQuadraticOrthogonalQuotientIsometryOrthogonalSum_mk
+    (hL : L.IsEven) (hM : M.IsEven) (hP : IsEven P) (hQ : IsEven Q)
+    (y : (hP.isIntegral.orthogonalSum hQ.isIntegral).toIntegralLattice.dualCarrier) :
+    discriminantQuadraticOrthogonalQuotientIsometryOrthogonalSum hL hM hP hQ
+        (Submodule.Quotient.mk y) =
+      (discriminantOrthogonalQuotientIsometry hL hP
+          (Submodule.Quotient.mk ⟨(y : V × W).1,
+            fst_mem_dualCarrier_orthogonalSum hP.isIntegral hQ.isIntegral y⟩),
+        discriminantOrthogonalQuotientIsometry hM hQ
+          (Submodule.Quotient.mk ⟨(y : V × W).2,
+            snd_mem_dualCarrier_orthogonalSum hP.isIntegral hQ.isIntegral y⟩)) := by
+  rw [discriminantQuadraticOrthogonalQuotientIsometryOrthogonalSum]
+  -- The definition is a composite of three quadratic isometries whose quotient carriers use
+  -- propositionally identified discriminant-group types. Expose the composite application after
+  -- elaboration so that the three public representative formulas can rewrite it.
+  change (FiniteQuadraticModule.orthogonalQuotientProdIsometry _ _)
+    (((L.discriminantQuadraticIsometryOrthogonalSum M hL hM).orthogonalQuotientEquiv _ _)
+      (discriminantOrthogonalQuotientIsometry _ _ (Submodule.Quotient.mk y))) = _
+  rw [discriminantOrthogonalQuotientIsometry_mk]
+  refine (congrArg (FiniteQuadraticModule.orthogonalQuotientProdIsometry _ _)
+    (FiniteQuadraticModule.Isometry.orthogonalQuotientEquiv_orthogonalQuotientMk
+      _ _ _ _)).trans ?_
+  refine (FiniteQuadraticModule.orthogonalQuotientProdIsometry_orthogonalQuotientMk
+    _ _ _).trans ?_
+  have hclass :
+      L.discriminantQuadraticIsometryOrthogonalSum M hL hM
+          ((hP.isIntegral.orthogonalSum hQ.isIntegral).dualClassHom y) =
+        (hP.isIntegral.dualClassHom
+            ⟨(y : V × W).1, fst_mem_dualCarrier_orthogonalSum
+              hP.isIntegral hQ.isIntegral y⟩,
+          hQ.isIntegral.dualClassHom
+            ⟨(y : V × W).2, snd_mem_dualCarrier_orthogonalSum
+              hP.isIntegral hQ.isIntegral y⟩) := by
+    rw [discriminantQuadraticIsometryOrthogonalSum_apply]
+    rw [← discriminantBilinearIsometryOrthogonalSum_apply]
+    exact discriminantBilinearIsometryOrthogonalSum_dualClassHom
+      hP.isIntegral hQ.isIntegral y
+  refine Prod.ext
+    (Eq.trans (congrArg ((L.discriminantQuadraticModule hL).orthogonalQuotientMk
+        (L.discriminantSubgroup P) _) (Subtype.ext ?_))
+      (discriminantOrthogonalQuotientIsometry_mk hL hP _).symm)
+    (Eq.trans (congrArg ((M.discriminantQuadraticModule hM).orthogonalQuotientMk
+        (M.discriminantSubgroup Q) _) (Subtype.ext ?_))
+      (discriminantOrthogonalQuotientIsometry_mk hM hQ _).symm)
+  · exact (FiniteBilinearModule.coe_orthogonalComplementProdFst _ _ _).trans
+      (congrArg Prod.fst hclass)
+  · exact (FiniteBilinearModule.coe_orthogonalComplementProdSnd _ _ _).trans
+      (congrArg Prod.snd hclass)
 
 end IntermediateCarrier
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/OrthogonalSum.lean
@@ -10,7 +10,7 @@ public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Naturality
 public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Bilinear
 
 /-!
-# The comparison `A_M ≅ H⊥ / H` on an orthogonal direct sum
+# The comparison `A_(P ⊕ Q) ≅ (H⊥ / H) ⊥ (K⊥ / K)` for an orthogonal direct sum
 
 Let `L` and `M` be nondegenerate integral lattices in rational spaces `V` and `W`, and let
 `L ≤ P ≤ Lᵛ` and `M ≤ Q ≤ Mᵛ` be integral overlattices with subgroups `H = P / L ≤ A_L` and
@@ -27,19 +27,18 @@ the class of a dual vector `y` of `P ⊕ Q` to the pair of the classes of its tw
 the comparison isometries of `P` and of `Q`. Together with the naturality of that comparison
 under a lattice isometry, proved in
 `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Bilinear`, this is the
-functoriality package the gluing theory asks of `A_M ≅ H⊥ / H`.
+functoriality package the gluing theory asks of the comparison isometry attached to an integral
+overlattice.
 
 The two ingredients are the splitting of an orthogonal quotient of finite bilinear modules along
 a product subgroup, from
 `TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Prod`, and the componentwise description
 of the intermediate-carrier correspondence, from
-`TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Naturality`.
+`TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Naturality` and
+`TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual`.
 
 ## Main declarations
 
-* `TauCeti.IntegralLattice.IntermediateCarrier.mem_dualCarrier_orthogonalSum_iff`: a vector is a
-  dual vector of the assembled overlattice exactly when both components are dual vectors of the
-  factors.
 * `IntermediateCarrier.discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum`: the
   isometry `A_(P ⊕ Q) ≅ (H⊥ / H) ⊥ (K⊥ / K)` obtained from the comparison of `P ⊕ Q` and the
   splitting of the orthogonal quotient.
@@ -65,34 +64,6 @@ variable [L.IsNondegenerate] [M.IsNondegenerate]
 variable {P : L.IntermediateCarrier} {Q : M.IntermediateCarrier}
 
 namespace IntermediateCarrier
-
-omit [L.IsNondegenerate] [M.IsNondegenerate] in
-/-- The assembled carrier `P ⊕ Q` of two integral intermediate carriers is integral. -/
-theorem IsIntegral.orthogonalSum (hP : IsIntegral P) (hQ : IsIntegral Q) :
-    IsIntegral (orthogonalSumIntermediateCarrier L M P Q) :=
-  (isIntegral_orthogonalSumIntermediateCarrier_iff P Q).mpr ⟨hP, hQ⟩
-
-/-- **Dual vectors of an assembled overlattice are componentwise.** -/
-theorem mem_dualCarrier_orthogonalSum_iff (hP : IsIntegral P) (hQ : IsIntegral Q) (x : V × W) :
-    x ∈ (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier ↔
-      x.1 ∈ hP.toIntegralLattice.dualCarrier ∧ x.2 ∈ hQ.toIntegralLattice.dualCarrier := by
-  rw [IsIntegral.toIntegralLattice_dualCarrier, IsIntegral.toIntegralLattice_dualCarrier,
-    IsIntegral.toIntegralLattice_dualCarrier, dual_orthogonalSumIntermediateCarrier,
-    mem_orthogonalSumIntermediateCarrier_iff]
-
-/-- The first component of a dual vector of the assembled overlattice is a dual vector of the
-first overlattice. -/
-theorem fst_mem_dualCarrier_orthogonalSum (hP : IsIntegral P) (hQ : IsIntegral Q)
-    (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :
-    (y : V × W).1 ∈ hP.toIntegralLattice.dualCarrier :=
-  ((mem_dualCarrier_orthogonalSum_iff hP hQ (y : V × W)).mp y.2).1
-
-/-- The second component of a dual vector of the assembled overlattice is a dual vector of the
-second overlattice. -/
-theorem snd_mem_dualCarrier_orthogonalSum (hP : IsIntegral P) (hQ : IsIntegral Q)
-    (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :
-    (y : V × W).2 ∈ hQ.toIntegralLattice.dualCarrier :=
-  ((mem_dualCarrier_orthogonalSum_iff hP hQ (y : V × W)).mp y.2).2
 
 /-- **The orthogonal-sum isometry of discriminant bilinear modules on a dual class.** The
 discriminant class in `A_(L ⊥ M)` of a dual vector of the assembled overlattice is the pair of the
@@ -170,9 +141,10 @@ noncomputable def discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum
       (A := L.discriminantBilinearModule) (B := M.discriminantBilinearModule)
       (L.discriminantSubgroup P) (M.discriminantSubgroup Q))
 
-/-- **The comparison isometry `A_M ≅ H⊥ / H` is componentwise on an orthogonal direct sum.** The
-isometry attached to the assembled overlattice sends the class of a dual vector to the pair of
-the classes of its two components under the comparison isometries of the two factors. -/
+/-- **The comparison isometry `A_(P ⊕ Q) ≅ (H⊥ / H) ⊥ (K⊥ / K)` is componentwise.** The isometry
+attached to the assembled overlattice sends the class of a dual vector to the pair of the classes
+of its two components under the comparison isometries `A_P ≅ H⊥ / H` of `P` and
+`A_Q ≅ K⊥ / K` of `Q`. -/
 theorem discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum_mk
     (hP : IsIntegral P) (hQ : IsIntegral Q)
     (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/OrthogonalSum.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Prod
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Naturality
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Bilinear
+
+/-!
+# The comparison `A_M ≅ H⊥ / H` on an orthogonal direct sum
+
+Let `L` and `M` be nondegenerate integral lattices in rational spaces `V` and `W`, and let
+`L ≤ P ≤ Lᵛ` and `M ≤ Q ≤ Mᵛ` be integral overlattices with subgroups `H = P / L ≤ A_L` and
+`K = Q / M ≤ A_M`. The assembled carrier `P ⊕ Q` is an integral overlattice of `L ⊥ M`, its
+subgroup is `H × K` under the canonical equivalence `A_(L ⊥ M) ≅ A_L ⊥ A_M`, and its discriminant
+bilinear module is therefore computed twice over:
+
+```text
+A_(P ⊕ Q) ≅ (H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K).
+```
+
+This file proves that the resulting comparison is componentwise: the composite isometry sends
+the class of a dual vector `y` of `P ⊕ Q` to the pair of the classes of its two components under
+the comparison isometries of `P` and of `Q`. Together with the naturality of that comparison
+under a lattice isometry, proved in
+`TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient.Bilinear`, this is the
+functoriality package the gluing theory asks of `A_M ≅ H⊥ / H`.
+
+The two ingredients are the splitting of an orthogonal quotient of finite bilinear modules along
+a product subgroup, from
+`TauCeti.LinearAlgebra.FiniteBilinearModule.Orthogonal.Prod`, and the componentwise description
+of the intermediate-carrier correspondence, from
+`TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Naturality`.
+
+## Main declarations
+
+* `TauCeti.IntegralLattice.IntermediateCarrier.mem_dualCarrier_orthogonalSum_iff`: a vector is a
+  dual vector of the assembled overlattice exactly when both components are dual vectors of the
+  factors.
+* `IntermediateCarrier.discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum`: the
+  isometry `A_(P ⊕ Q) ≅ (H⊥ / H) ⊥ (K⊥ / K)` obtained from the comparison of `P ⊕ Q` and the
+  splitting of the orthogonal quotient.
+* `IntermediateCarrier.discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum_mk`: it is
+  componentwise, that is, it agrees with the pair of the comparison isometries of `P` and
+  of `Q`.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.4.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace IntegralLattice
+
+variable {V W : Type*} [AddCommGroup V] [Module ℚ V] [AddCommGroup W] [Module ℚ W]
+variable {L : IntegralLattice V} {M : IntegralLattice W}
+variable [L.IsNondegenerate] [M.IsNondegenerate]
+variable {P : L.IntermediateCarrier} {Q : M.IntermediateCarrier}
+
+namespace IntermediateCarrier
+
+omit [L.IsNondegenerate] [M.IsNondegenerate] in
+/-- The assembled carrier `P ⊕ Q` of two integral intermediate carriers is integral. -/
+theorem IsIntegral.orthogonalSum (hP : IsIntegral P) (hQ : IsIntegral Q) :
+    IsIntegral (orthogonalSumIntermediateCarrier L M P Q) :=
+  (isIntegral_orthogonalSumIntermediateCarrier_iff P Q).mpr ⟨hP, hQ⟩
+
+/-- **Dual vectors of an assembled overlattice are componentwise.** -/
+theorem mem_dualCarrier_orthogonalSum_iff (hP : IsIntegral P) (hQ : IsIntegral Q) (x : V × W) :
+    x ∈ (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier ↔
+      x.1 ∈ hP.toIntegralLattice.dualCarrier ∧ x.2 ∈ hQ.toIntegralLattice.dualCarrier := by
+  rw [IsIntegral.toIntegralLattice_dualCarrier, IsIntegral.toIntegralLattice_dualCarrier,
+    IsIntegral.toIntegralLattice_dualCarrier, dual_orthogonalSumIntermediateCarrier,
+    mem_orthogonalSumIntermediateCarrier_iff]
+
+/-- The first component of a dual vector of the assembled overlattice is a dual vector of the
+first overlattice. -/
+theorem fst_mem_dualCarrier_orthogonalSum (hP : IsIntegral P) (hQ : IsIntegral Q)
+    (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :
+    (y : V × W).1 ∈ hP.toIntegralLattice.dualCarrier :=
+  ((mem_dualCarrier_orthogonalSum_iff hP hQ (y : V × W)).mp y.2).1
+
+/-- The second component of a dual vector of the assembled overlattice is a dual vector of the
+second overlattice. -/
+theorem snd_mem_dualCarrier_orthogonalSum (hP : IsIntegral P) (hQ : IsIntegral Q)
+    (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :
+    (y : V × W).2 ∈ hQ.toIntegralLattice.dualCarrier :=
+  ((mem_dualCarrier_orthogonalSum_iff hP hQ (y : V × W)).mp y.2).2
+
+/-- **The orthogonal-sum isometry of discriminant bilinear modules on a dual class.** The
+discriminant class in `A_(L ⊥ M)` of a dual vector of the assembled overlattice is the pair of the
+discriminant classes of its two components. -/
+theorem discriminantBilinearIsometryOrthogonalSum_dualClassHom (hP : IsIntegral P)
+    (hQ : IsIntegral Q) (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :
+    L.discriminantBilinearIsometryOrthogonalSum M ((hP.orthogonalSum hQ).dualClassHom y) =
+      (hP.dualClassHom ⟨(y : V × W).1, fst_mem_dualCarrier_orthogonalSum hP hQ y⟩,
+        hQ.dualClassHom ⟨(y : V × W).2, snd_mem_dualCarrier_orthogonalSum hP hQ y⟩) := by
+  rw [discriminantBilinearIsometryOrthogonalSum_apply, IsIntegral.dualClassHom_apply,
+    discriminantGroupOrthogonalSumEquiv_mk, orthogonalSumDualCarrierEquiv_apply,
+    IsIntegral.dualClassHom_apply, IsIntegral.dualClassHom_apply]
+
+/-- The transported discriminant class of a dual vector of the assembled overlattice is orthogonal
+to the product subgroup, because each component is orthogonal to its own subgroup. -/
+private theorem dualClassHom_mem_orthogonalComplement_prod (hP : IsIntegral P)
+    (hQ : IsIntegral Q) (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :
+    L.discriminantBilinearIsometryOrthogonalSum M ((hP.orthogonalSum hQ).dualClassHom y) ∈
+      (L.discriminantBilinearModule.prod M.discriminantBilinearModule).orthogonalComplement
+        ((L.discriminantSubgroup P).prod (M.discriminantSubgroup Q)) := by
+  rw [discriminantBilinearIsometryOrthogonalSum_dualClassHom hP hQ y]
+  exact (FiniteBilinearModule.mem_orthogonalComplement_prod_iff L.discriminantBilinearModule
+      M.discriminantBilinearModule (L.discriminantSubgroup P) (M.discriminantSubgroup Q) _).mpr
+    ⟨hP.dualClassHom_mem_orthogonalComplement _, hQ.dualClassHom_mem_orthogonalComplement _⟩
+
+/-- The comparison isometry of the assembled overlattice, transported along the orthogonal-sum
+isometry of discriminant bilinear modules to the orthogonal quotient by the product subgroup. -/
+private noncomputable def discriminantBilinearOrthogonalQuotientProdStep (hP : IsIntegral P)
+    (hQ : IsIntegral Q) :
+    FiniteBilinearModule.Isometry
+      (hP.orthogonalSum hQ).toIntegralLattice.discriminantBilinearModule
+      ((L.discriminantBilinearModule.prod M.discriminantBilinearModule).orthogonalQuotient
+        ((L.discriminantSubgroup P).prod (M.discriminantSubgroup Q))) :=
+  (discriminantBilinearOrthogonalQuotientIsometry (hP.orthogonalSum hQ)).trans
+    ((L.discriminantBilinearIsometryOrthogonalSum M).orthogonalQuotientEquiv
+      (H := (L.orthogonalSum M).discriminantSubgroup
+        (orthogonalSumIntermediateCarrier L M P Q))
+      (K := (L.discriminantSubgroup P).prod (M.discriminantSubgroup Q))
+      (by
+        rw [discriminantBilinearIsometryOrthogonalSum_toAddEquiv]
+        exact map_discriminantSubgroup_orthogonalSumIntermediateCarrier P Q))
+
+/-- The transported comparison isometry sends the class of a dual vector of the assembled
+overlattice to the class of its transported discriminant class. -/
+private theorem discriminantBilinearOrthogonalQuotientProdStep_mk (hP : IsIntegral P)
+    (hQ : IsIntegral Q) (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :
+    discriminantBilinearOrthogonalQuotientProdStep hP hQ (Submodule.Quotient.mk y) =
+      (L.discriminantBilinearModule.prod M.discriminantBilinearModule).orthogonalQuotientMk
+        ((L.discriminantSubgroup P).prod (M.discriminantSubgroup Q))
+        ⟨L.discriminantBilinearIsometryOrthogonalSum M ((hP.orthogonalSum hQ).dualClassHom y),
+          dualClassHom_mem_orthogonalComplement_prod hP hQ y⟩ := by
+  rw [discriminantBilinearOrthogonalQuotientProdStep]
+  refine (FiniteBilinearModule.Isometry.trans_apply _ _ _).trans ?_
+  rw [discriminantBilinearOrthogonalQuotientIsometry_mk]
+  exact FiniteBilinearModule.Isometry.orthogonalQuotientEquiv_orthogonalQuotientMk
+    (L.discriminantBilinearIsometryOrthogonalSum M) _ _
+
+/-- **The discriminant bilinear module of an assembled overlattice as an orthogonal direct sum of
+orthogonal quotients.** For integral overlattices `P` of `L` and `Q` of `M` with subgroups
+`H = P / L` and `K = Q / M`, the comparison isometry of the assembled overlattice, transported
+along `A_(L ⊥ M) ≅ A_L ⊥ A_M` and split along the product subgroup, is an isometry
+
+```text
+A_(P ⊕ Q) ≅ (H⊥ / H) ⊥ (K⊥ / K).
+```
+-/
+noncomputable def discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum
+    (hP : IsIntegral P) (hQ : IsIntegral Q) :
+    FiniteBilinearModule.Isometry
+      (hP.orthogonalSum hQ).toIntegralLattice.discriminantBilinearModule
+      ((L.discriminantBilinearModule.orthogonalQuotient (L.discriminantSubgroup P)).prod
+        (M.discriminantBilinearModule.orthogonalQuotient (M.discriminantSubgroup Q))) :=
+  (discriminantBilinearOrthogonalQuotientProdStep hP hQ).trans
+    (FiniteBilinearModule.orthogonalQuotientProdIsometry
+      (A := L.discriminantBilinearModule) (B := M.discriminantBilinearModule)
+      (L.discriminantSubgroup P) (M.discriminantSubgroup Q))
+
+/-- **The comparison isometry `A_M ≅ H⊥ / H` is componentwise on an orthogonal direct sum.** The
+isometry attached to the assembled overlattice sends the class of a dual vector to the pair of
+the classes of its two components under the comparison isometries of the two factors. -/
+theorem discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum_mk
+    (hP : IsIntegral P) (hQ : IsIntegral Q)
+    (y : (hP.orthogonalSum hQ).toIntegralLattice.dualCarrier) :
+    discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum hP hQ
+        (Submodule.Quotient.mk y) =
+      (discriminantBilinearOrthogonalQuotientIsometry hP
+          (Submodule.Quotient.mk ⟨(y : V × W).1, fst_mem_dualCarrier_orthogonalSum hP hQ y⟩),
+        discriminantBilinearOrthogonalQuotientIsometry hQ
+          (Submodule.Quotient.mk ⟨(y : V × W).2,
+            snd_mem_dualCarrier_orthogonalSum hP hQ y⟩)) := by
+  rw [discriminantBilinearOrthogonalQuotientIsometryOrthogonalSum]
+  refine (FiniteBilinearModule.Isometry.trans_apply _ _ _).trans ?_
+  rw [discriminantBilinearOrthogonalQuotientProdStep_mk]
+  refine (FiniteBilinearModule.orthogonalQuotientProdIsometry_orthogonalQuotientMk _ _ _).trans ?_
+  refine Prod.ext
+    (Eq.trans (congrArg (L.discriminantBilinearModule.orthogonalQuotientMk
+        (L.discriminantSubgroup P)) (Subtype.ext ?_))
+      (discriminantBilinearOrthogonalQuotientIsometry_mk hP _).symm)
+    (Eq.trans (congrArg (M.discriminantBilinearModule.orthogonalQuotientMk
+        (M.discriminantSubgroup Q)) (Subtype.ext ?_))
+      (discriminantBilinearOrthogonalQuotientIsometry_mk hQ _).symm)
+  · exact (FiniteBilinearModule.coe_orthogonalComplementProdFst _ _ _).trans
+      (congrArg Prod.fst (discriminantBilinearIsometryOrthogonalSum_dualClassHom hP hQ y))
+  · exact (FiniteBilinearModule.coe_orthogonalComplementProdSnd _ _ _).trans
+      (congrArg Prod.snd (discriminantBilinearIsometryOrthogonalSum_dualClassHom hP hQ y))
+
+end IntermediateCarrier
+
+end IntegralLattice
+
+end TauCeti


### PR DESCRIPTION
This PR splits the orthogonal complement, isotropy, the Lagrangian condition and the orthogonal quotient of a finite bilinear or quadratic module along a product subgroup, and uses that splitting to prove that the comparison isometry `A_M ≅ H⊥ / H` for an integral overlattice is componentwise over an orthogonal direct sum of lattices. For subgroups `H ≤ A` and `K ≤ B` the pairing of `A ⊥ B` has no cross terms, so `(H × K)⊥ = H⊥ × K⊥`, isotropy and the Lagrangian condition hold exactly when they hold in each factor, and `(H × K)⊥ / (H × K) ≅ (H⊥ / H) ⊥ (K⊥ / K)` both bilinearly and, along a quadratic-isotropic subgroup, quadratically. On the lattice side, for integral overlattices `L ≤ P ≤ Lᵛ` and `M ≤ Q ≤ Mᵛ` the assembled overlattice `P ⊕ Q` of `L ⊥ M` has subgroup `H × K` under `A_(L ⊥ M) ≅ A_L ⊥ A_M`, and the resulting isometry `A_(P ⊕ Q) ≅ (H⊥ / H) ⊥ (K⊥ / K)` is shown to send the class of a dual vector to the pair of the classes of its two components under the comparison isometries of `P` and of `Q`.

This serves the `IntegralLattices` milestone "Layer 4: overlattices and isotropic subgroups", whose last bullet asks to "Prove naturality: a lattice isometry transports intermediate and integral/even overlattices ... and commutes with `A_{L_H} ≅ H^⊥/H`. Prove the componentwise statement for orthogonal direct sums." Naturality under a lattice isometry is already on `main` (TauCeti#5604); the componentwise statement was the missing half, and its module-level input — the behaviour of `H^⊥` and `H^⊥/H` under the orthogonal direct sums that Layer 3 asks the finite bilinear and quadratic module API to carry — did not exist. After this PR the even refinement of the same square, `A_(P ⊕ Q) ≅ (H⊥ / H) ⊥ (K⊥ / K)` as finite *quadratic* modules for even lattices, still has to be assembled from the quadratic splitting proved here together with `discriminantQuadraticIsometryOrthogonalSum`; Layer 2's invariant-factor divisibility chain for a non-positive Gram determinant is the roadmap's only other open item and is already in flight in TauCeti#5684.

Two files are new: `TauCeti/LinearAlgebra/FiniteBilinearModule/Orthogonal/Prod.lean` (349 lines) and `TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient/OrthogonalSum.lean` (178 lines). Four existing files gain declarations, each placed beside the API it belongs to. `FiniteBilinearModule/Basic.lean` gains `Isometry.prod` and `Isometry.prod_apply` next to `prod`, and the bilinear `isIsotropic_prod_iff` next to `isIsotropicElem_prod`. `FiniteBilinearModule/Quadratic.lean` gains the quadratic `isIsotropic_prod_iff` next to `IsIsotropic`; three missing `_apply`/`_def` lemmas — `isLagrangian_def`, `quotientOfLeQuadraticRadicalMk_apply` and `orthogonalQuotientMk_apply` — which are needed because the quotient constructions they unfold are not exposed; and `@[expose]` on `subgroupInOrthogonalComplement`, which is what makes the carrier of a quadratic orthogonal quotient reduce to the carrier of the bilinear one outside that file. There too `FiniteQuadraticModule.prod` becomes an `abbrev`, matching `FiniteBilinearModule.prod`, which is what makes a subgroup of a product of carriers usable as a subgroup of the orthogonal product without a coercion; `prod_quadratic` and `prod_pairing` consequently lose `@[simp]`, since after that change the linter reports them as no longer simp-normal — again matching the bilinear file, where `prod_pairing` is not a simp lemma either. Finally `Overlattice/Naturality.lean` gains `IntermediateCarrier.IsIntegral.orthogonalSum` next to `isIntegral_orthogonalSumIntermediateCarrier_iff`, and `Overlattice/Dual.lean` the three componentwise dual-carrier lemmas next to `dual_orthogonalSumIntermediateCarrier`.

No Mathlib infrastructure was vendored; the quadratic splitting reuses Mathlib's `QuadraticMap.prod`, and an orthogonal direct sum of quadratic isometries is Mathlib's `QuadraticMap.IsometryEquiv.prod` rather than a new wrapper. The quadratic splitting of an orthogonal quotient is likewise not a second construction: it takes its underlying additive equivalence from the bilinear one and only checks that quadratic values are preserved. The mathematics is Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.4, in the half-norm `ℚ/ℤ` convention fixed by the repository, and Ebeling, *Lattices and Codes*, Chapter 1.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"discriminant-orthogonal-quotient-orthogonal-sum"}-->

🤖 Prepared with Claude Code