### PR TITLE
feat: the discriminant test for the alternating group

### DIFF
--- a/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
@@ -77,6 +77,7 @@ open scoped Classical in
 /-- **The transformation law for the square root of the discriminant.** An automorphism `ϕ` of a
 splitting extension `E` over `F` multiplies the product of the root differences by the sign of the
 permutation that `ϕ` induces on the roots of `f`. -/
+@[simp]
 theorem _root_.AlgEquiv.map_discrSqrt (ϕ : E ≃ₐ[F] E) (e : Fin f.natDegree ≃ f.rootSet E) :
     ϕ (discrSqrt e) =
       Equiv.Perm.sign (Gal.galActionHom f E (Gal.restrict f E ϕ)) • discrSqrt e := by

--- a/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
@@ -31,8 +31,9 @@ when `discr f` is a square in `F`. This is the **discriminant test** for contain
 alternating group.
 
 The characteristic hypothesis `ringChar F ≠ 2` is not decoration. In characteristic `2` one has
-`-1 = 1`, so the sign never moves `δ`, the discriminant of a separable monic polynomial is
-*always* a square, and the test decides nothing; this is recorded as
+`-1 = 1`, so the sign never moves `δ`; inseparable monic polynomials have zero discriminant.
+Thus the discriminant of every monic polynomial is *always* a square, and the test decides
+nothing; this is recorded as
 `Polynomial.Monic.isSquare_discr_of_char_two`.
 
 ## Main definitions
@@ -50,8 +51,8 @@ The characteristic hypothesis `ringChar F ≠ 2` is not decoration. In character
   `discrSqrt e` comes from `F`.
 * `Polynomial.Monic.isSquare_discr_iff_range_le_alternatingGroup`: **the discriminant test**,
   valid away from characteristic `2`.
-* `Polynomial.Monic.isSquare_discr_of_char_two`: in characteristic `2` the discriminant of a monic
-  separable polynomial is always a square, so the test is vacuous there.
+* `Polynomial.Monic.isSquare_discr_of_char_two`: in characteristic `2` the discriminant of every
+  monic polynomial is a square, so the test is vacuous there.
 
 ## References
 
@@ -148,32 +149,35 @@ theorem _root_.Polynomial.Monic.isSquare_discr_iff_range_le_alternatingGroup
     ⟨(Fintype.equivFinOfCardEq (card_rootSet_eq_natDegree hsep Fact.out)).symm⟩
   exact (hf.isSquare_discr_iff_mem_range hsep e).trans (hf.discrSqrt_mem_range_iff hsep hchar e)
 
-/-- In characteristic `2` the discriminant of a monic separable polynomial is always a square,
-whatever its Galois group: the sign of a permutation acts trivially because `-1 = 1`, so the
-product of the root differences is fixed by the whole Galois group and therefore lies in the base
-field.
+/-- In characteristic `2` the discriminant of every monic polynomial is a square. For a separable
+polynomial, the sign of a permutation acts trivially because `-1 = 1`, so the product of the root
+differences is fixed by the whole Galois group and therefore lies in the base field. For an
+inseparable polynomial, the discriminant is zero.
 
 This is why the discriminant test carries the hypothesis `ringChar F ≠ 2`. The invariant that
 replaces the discriminant in characteristic `2` is Berlekamp's. -/
-theorem _root_.Polynomial.Monic.isSquare_discr_of_char_two (hf : f.Monic) (hsep : f.Separable)
+theorem _root_.Polynomial.Monic.isSquare_discr_of_char_two (hf : f.Monic)
     (hchar : ringChar F = 2) : IsSquare f.discr := by
   classical
-  let E := f.SplittingField
-  let _ : IsGalois F E := IsGalois.of_separable_splitting_field hsep
-  let _ : Fact ((f.map (algebraMap F E)).Splits) := ⟨IsSplittingField.splits E f⟩
-  have hF : (2 : F) = 0 := by
-    exact_mod_cast (ringChar.spec F 2).mpr (by rw [hchar])
-  have h2 : (2 : E) = 0 := by rw [← map_ofNat (algebraMap F E) 2, hF, map_zero]
-  obtain ⟨e⟩ : Nonempty (Fin f.natDegree ≃ f.rootSet E) :=
-    ⟨(Fintype.equivFinOfCardEq (card_rootSet_eq_natDegree hsep Fact.out)).symm⟩
-  rw [hf.isSquare_discr_iff_mem_range hsep e, IsGalois.mem_range_algebraMap_iff_fixed]
-  intro ϕ
-  rw [AlgEquiv.map_discrSqrt]
-  rcases Int.units_eq_one_or (Equiv.Perm.sign (Gal.galActionHom f E (Gal.restrict f E ϕ)))
-    with h1 | h1 <;> rw [h1]
-  · rw [one_smul]
-  · simp only [Units.smul_def, Units.val_neg, Units.val_one, neg_smul, one_smul]
-    linear_combination -h2 * discrSqrt e
+  by_cases hsep : f.Separable
+  · let E := f.SplittingField
+    let _ : IsGalois F E := IsGalois.of_separable_splitting_field hsep
+    let _ : Fact ((f.map (algebraMap F E)).Splits) := ⟨IsSplittingField.splits E f⟩
+    have hF : (2 : F) = 0 := by
+      exact_mod_cast (ringChar.spec F 2).mpr (by rw [hchar])
+    have h2 : (2 : E) = 0 := by rw [← map_ofNat (algebraMap F E) 2, hF, map_zero]
+    obtain ⟨e⟩ : Nonempty (Fin f.natDegree ≃ f.rootSet E) :=
+      ⟨(Fintype.equivFinOfCardEq (card_rootSet_eq_natDegree hsep Fact.out)).symm⟩
+    rw [hf.isSquare_discr_iff_mem_range hsep e, IsGalois.mem_range_algebraMap_iff_fixed]
+    intro ϕ
+    rw [AlgEquiv.map_discrSqrt]
+    rcases Int.units_eq_one_or (Equiv.Perm.sign (Gal.galActionHom f E (Gal.restrict f E ϕ)))
+      with h1 | h1 <;> rw [h1]
+    · rw [one_smul]
+    · simp only [Units.smul_def, Units.val_neg, Units.val_one, neg_smul, one_smul]
+      linear_combination -h2 * discrSqrt e
+  · have hdiscr : f.discr = 0 := not_ne_iff.mp fun hne ↦ hsep (hf.discr_ne_zero_iff.mp hne)
+    simp [hdiscr]
 
 end Galois
 

--- a/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
@@ -5,9 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.FieldTheory.Galois.Basic
 public import Mathlib.FieldTheory.PolynomialGaloisGroup
-public import Mathlib.GroupTheory.Perm.Fin
 public import Mathlib.GroupTheory.SpecificGroups.Alternating
 public import TauCeti.RingTheory.Polynomial.Resultant.Discriminant
 
@@ -34,7 +32,7 @@ alternating group.
 The characteristic hypothesis `ringChar F ≠ 2` is not decoration. In characteristic `2` one has
 `-1 = 1`, so the sign never moves `δ`, the discriminant of a separable monic polynomial is
 *always* a square, and the test decides nothing; this is recorded as
-`TauCeti.isSquare_discr_of_char_two`.
+`Polynomial.Monic.isSquare_discr_of_char_two`.
 
 ## Main definitions
 
@@ -43,15 +41,15 @@ The characteristic hypothesis `ringChar F ≠ 2` is not decoration. In character
 
 ## Main results
 
-* `TauCeti.discrSqrt_sq`: `discrSqrt e ^ 2` is the image of `Polynomial.discr f` in `E`.
+* `Polynomial.Monic.discrSqrt_sq`: `discrSqrt e ^ 2` is the image of `Polynomial.discr f` in `E`.
 * `TauCeti.discrSqrt_trans`: renumbering the roots by `π` multiplies `discrSqrt` by `sign π`.
-* `TauCeti.map_discrSqrt`: an automorphism of `E` over `F` multiplies `discrSqrt e` by the sign of
+* `AlgEquiv.map_discrSqrt`: an automorphism of `E` over `F` multiplies `discrSqrt e` by the sign of
   the permutation of the roots that it induces.
-* `TauCeti.isSquare_discr_iff_mem_range`: `discr f` is a square in `F` exactly when `discrSqrt e`
-  comes from `F`.
-* `TauCeti.isSquare_discr_iff_range_le_alternatingGroup`: **the discriminant test**, valid away
-  from characteristic `2`.
-* `TauCeti.isSquare_discr_of_char_two`: in characteristic `2` the discriminant of a monic
+* `Polynomial.Monic.isSquare_discr_iff_mem_range`: `discr f` is a square in `F` exactly when
+  `discrSqrt e` comes from `F`.
+* `Polynomial.Monic.isSquare_discr_iff_range_le_alternatingGroup`: **the discriminant test**,
+  valid away from characteristic `2`.
+* `Polynomial.Monic.isSquare_discr_of_char_two`: in characteristic `2` the discriminant of a monic
   separable polynomial is always a square, so the test is vacuous there.
 
 ## References
@@ -78,7 +76,7 @@ variable [DecidableEq E] [Fact ((f.map (algebraMap F E)).Splits)]
 /-- **The transformation law for the square root of the discriminant.** An automorphism `ϕ` of a
 splitting extension `E` over `F` multiplies the product of the root differences by the sign of the
 permutation that `ϕ` induces on the roots of `f`. -/
-theorem map_discrSqrt (ϕ : E ≃ₐ[F] E) (e : Fin f.natDegree ≃ f.rootSet E) :
+theorem _root_.AlgEquiv.map_discrSqrt (ϕ : E ≃ₐ[F] E) (e : Fin f.natDegree ≃ f.rootSet E) :
     ϕ (discrSqrt e) =
       Equiv.Perm.sign (Gal.galActionHom f E (Gal.restrict f E ϕ)) • discrSqrt e := by
   -- Transport the induced permutation of the root set to a permutation of `Fin f.natDegree`
@@ -93,18 +91,19 @@ theorem map_discrSqrt (ϕ : E ≃ₐ[F] E) (e : Fin f.natDegree ≃ f.rootSet E)
     exact congrArg Subtype.val h
   have himage : ϕ (discrSqrt e)
       = ∏ i, ∏ j ∈ Finset.Ioi i, ((e (ρ i) : E) - (e (ρ j) : E)) := by
-    simp only [TauCeti.discrSqrt, map_prod]
+    simp only [discrSqrt_def, map_prod]
     refine Finset.prod_congr rfl fun i _ ↦ ?_
     exact Finset.prod_congr rfl fun j _ ↦ by rw [map_sub, key, key]
   have hrenumber : discrSqrt (ρ.trans e)
       = ∏ i, ∏ j ∈ Finset.Ioi i, ((e (ρ i) : E) - (e (ρ j) : E)) := by
-    simp only [TauCeti.discrSqrt, Equiv.trans_apply]
+    simp only [discrSqrt_def, Equiv.trans_apply]
   rw [himage, ← hrenumber, discrSqrt_trans, ← Equiv.Perm.sign_permCongr e ρ, hcongr]
 
 /-- Away from characteristic `2`, the product of the root differences comes from the base field
 exactly when the Galois image consists of even permutations of the roots. -/
-theorem discrSqrt_mem_range_iff [FiniteDimensional F E] [IsGalois F E] (hf : f.Monic)
-    (hsep : f.Separable) (hchar : ringChar F ≠ 2) (e : Fin f.natDegree ≃ f.rootSet E) :
+theorem _root_.Polynomial.Monic.discrSqrt_mem_range_iff [FiniteDimensional F E] [IsGalois F E]
+    (hf : f.Monic) (hsep : f.Separable) (hchar : ringChar F ≠ 2)
+    (e : Fin f.natDegree ≃ f.rootSet E) :
     discrSqrt e ∈ Set.range (algebraMap F E) ↔
       (Gal.galActionHom f E).range ≤ alternatingGroup (f.rootSet E) := by
   have h2 : (2 : E) ≠ 0 := by
@@ -116,32 +115,33 @@ theorem discrSqrt_mem_range_iff [FiniteDimensional F E] [IsGalois F E] (hf : f.M
     obtain ⟨ϕ, rfl⟩ := Gal.restrict_surjective f E σ
     rw [Equiv.Perm.mem_alternatingGroup]
     have hϕ := hfix ϕ
-    rw [map_discrSqrt] at hϕ
+    rw [AlgEquiv.map_discrSqrt] at hϕ
     rcases Int.units_eq_one_or (Equiv.Perm.sign (Gal.galActionHom f E (Gal.restrict f E ϕ)))
       with h1 | h1
     · exact h1
     -- An odd permutation would negate a nonzero element and fix it, forcing `2 = 0` in `E`.
     rw [h1] at hϕ
-    refine absurd ?_ (discrSqrt_ne_zero hf hsep e)
+    refine absurd ?_ (hf.discrSqrt_ne_zero hsep e)
     have hdouble : (2 : E) * discrSqrt e = 0 := by
       simp only [Units.smul_def, Units.val_neg, Units.val_one, neg_smul, one_smul] at hϕ
       linear_combination -hϕ
     exact (mul_eq_zero.mp hdouble).resolve_left h2
   · intro hle ϕ
-    rw [map_discrSqrt, Equiv.Perm.mem_alternatingGroup.mp (hle ⟨_, rfl⟩), one_smul]
+    rw [AlgEquiv.map_discrSqrt, Equiv.Perm.mem_alternatingGroup.mp (hle ⟨_, rfl⟩), one_smul]
 
 /-- **The discriminant test.** For a monic separable polynomial over a field of characteristic
 other than `2`, the discriminant is a square in the base field exactly when the Galois group acts
 on the roots by even permutations.
 
 The characteristic hypothesis cannot be dropped: see
-`TauCeti.isSquare_discr_of_char_two`. -/
-theorem isSquare_discr_iff_range_le_alternatingGroup [FiniteDimensional F E] [IsGalois F E]
-    (hf : f.Monic) (hsep : f.Separable) (hchar : ringChar F ≠ 2) :
+`Polynomial.Monic.isSquare_discr_of_char_two`. -/
+theorem _root_.Polynomial.Monic.isSquare_discr_iff_range_le_alternatingGroup
+    [FiniteDimensional F E] [IsGalois F E] (hf : f.Monic) (hsep : f.Separable)
+    (hchar : ringChar F ≠ 2) :
     IsSquare f.discr ↔ (Gal.galActionHom f E).range ≤ alternatingGroup (f.rootSet E) := by
   obtain ⟨e⟩ : Nonempty (Fin f.natDegree ≃ f.rootSet E) :=
     ⟨(Fintype.equivFinOfCardEq (card_rootSet_eq_natDegree hsep Fact.out)).symm⟩
-  exact (isSquare_discr_iff_mem_range hf hsep e).trans (discrSqrt_mem_range_iff hf hsep hchar e)
+  exact (hf.isSquare_discr_iff_mem_range hsep e).trans (hf.discrSqrt_mem_range_iff hsep hchar e)
 
 /-- In characteristic `2` the discriminant of a monic separable polynomial is always a square,
 whatever its Galois group: the sign of a permutation acts trivially because `-1 = 1`, so the
@@ -150,7 +150,7 @@ field.
 
 This is why the discriminant test carries the hypothesis `ringChar F ≠ 2`. The invariant that
 replaces the discriminant in characteristic `2` is Berlekamp's. -/
-theorem isSquare_discr_of_char_two (hf : f.Monic) (hsep : f.Separable)
+theorem _root_.Polynomial.Monic.isSquare_discr_of_char_two (hf : f.Monic) (hsep : f.Separable)
     (hchar : ringChar F = 2) : IsSquare f.discr := by
   classical
   let E := f.SplittingField
@@ -161,9 +161,9 @@ theorem isSquare_discr_of_char_two (hf : f.Monic) (hsep : f.Separable)
   have h2 : (2 : E) = 0 := by rw [← map_ofNat (algebraMap F E) 2, hF, map_zero]
   obtain ⟨e⟩ : Nonempty (Fin f.natDegree ≃ f.rootSet E) :=
     ⟨(Fintype.equivFinOfCardEq (card_rootSet_eq_natDegree hsep Fact.out)).symm⟩
-  rw [isSquare_discr_iff_mem_range hf hsep e, IsGalois.mem_range_algebraMap_iff_fixed]
+  rw [hf.isSquare_discr_iff_mem_range hsep e, IsGalois.mem_range_algebraMap_iff_fixed]
   intro ϕ
-  rw [map_discrSqrt]
+  rw [AlgEquiv.map_discrSqrt]
   rcases Int.units_eq_one_or (Equiv.Perm.sign (Gal.galActionHom f E (Gal.restrict f E ϕ)))
     with h1 | h1 <;> rw [h1]
   · rw [one_smul]

--- a/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
@@ -1,0 +1,263 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.Galois.Basic
+public import Mathlib.FieldTheory.PolynomialGaloisGroup
+public import Mathlib.GroupTheory.Perm.Fin
+public import Mathlib.GroupTheory.SpecificGroups.Alternating
+public import TauCeti.RingTheory.Polynomial.Resultant.Discriminant
+
+/-!
+# The square root of the discriminant, and the test for the alternating group
+
+Let `f` be a monic separable polynomial over a field `F`, and let `E` be an extension in which
+`f` splits. Numbering the roots of `f` in `E` by an equivalence `e : Fin f.natDegree ≃ f.rootSet E`
+turns the product of the root differences
+
+`δ = ∏_{i < j} (rᵢ - rⱼ)`
+
+into an element of `E`. Its square is the image of `Polynomial.discr f`, so `δ` is a square root
+of the discriminant; it is only *a* square root, because a different numbering changes `δ` by the
+sign of the permutation relating the two numberings.
+
+That sign is the whole point. A field automorphism of `E` over `F` permutes the roots, hence
+multiplies `δ` by the sign of the permutation it induces. Consequently `δ` lies in `F` exactly
+when the Galois image consists of even permutations, and — since `δ² = discr f` — that happens
+exactly when `discr f` is a square in `F`. This is the **discriminant test** for containment in
+the alternating group.
+
+The characteristic hypothesis `ringChar F ≠ 2` is not decoration. In characteristic `2` one has
+`-1 = 1`, so the sign never moves `δ`, the discriminant of a separable monic polynomial is
+*always* a square, and the test decides nothing; this is recorded as
+`TauCeti.isSquare_discr_of_ringChar_eq_two`.
+
+## Main definitions
+
+* `TauCeti.discrSqrt`: the product of the differences of the roots of `f` in `E`, taken over the
+  pairs `i < j` of a numbering of the root set.
+
+## Main results
+
+* `TauCeti.discrSqrt_sq`: `discrSqrt e ^ 2` is the image of `Polynomial.discr f` in `E`.
+* `TauCeti.discrSqrt_trans`: renumbering the roots by `π` multiplies `discrSqrt` by `sign π`.
+* `TauCeti.map_discrSqrt`: an automorphism of `E` over `F` multiplies `discrSqrt e` by the sign of
+  the permutation of the roots that it induces.
+* `TauCeti.isSquare_discr_iff_mem_range`: `discr f` is a square in `F` exactly when `discrSqrt e`
+  comes from `F`.
+* `TauCeti.isSquare_discr_iff_range_le_alternatingGroup`: **the discriminant test**, valid away
+  from characteristic `2`.
+* `TauCeti.isSquare_discr_of_ringChar_eq_two`: in characteristic `2` the discriminant of a monic
+  separable polynomial is always a square, so the test is vacuous there.
+
+## References
+
+* [H. Cohen, *A Course in Computational Algebraic Number Theory*][cohen1993], §6.3.
+-/
+
+public section
+
+open Polynomial
+
+namespace TauCeti
+
+universe u v
+
+variable {F : Type u} [Field F] {E : Type v} [Field E] [Algebra F E] {f : F[X]}
+
+/-! ## Numbering the roots -/
+
+-- Membership in the root set is membership in the root multiset of the mapped polynomial.
+private theorem mem_roots_map_iff {a : E} :
+    a ∈ (f.map (algebraMap F E)).roots ↔ a ∈ f.rootSet E :=
+  Polynomial.mem_aroots'.trans Polynomial.mem_rootSet'.symm
+
+/-- A numbering of the root set of a separable polynomial enumerates the whole root multiset:
+separability makes the roots simple, so the multiset is the image of the numbering. This is the
+hypothesis that the root-product formula for the discriminant takes. -/
+theorem roots_map_eq_map_numbering (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
+    (f.map (algebraMap F E)).roots = Multiset.map (fun i ↦ ((e i : E))) Finset.univ.val := by
+  refine (Multiset.Nodup.ext (nodup_roots hsep.map) ?_).mpr ?_
+  · exact Finset.univ.nodup.map fun i j h ↦ e.injective (Subtype.ext h)
+  · intro a
+    simp only [Multiset.mem_map, Finset.mem_val, Finset.mem_univ, true_and]
+    exact ⟨fun ha ↦ ⟨e.symm ⟨a, mem_roots_map_iff.mp ha⟩, by simp⟩,
+      fun ⟨i, hi⟩ ↦ hi ▸ mem_roots_map_iff.mpr (e i).2⟩
+
+/-! ## The square root of the discriminant -/
+
+/-- The product `∏_{i < j} (rᵢ - rⱼ)` of the differences of the roots of `f` in `E`, taken along a
+numbering `e` of the root set.
+
+For monic separable `f` this is a square root of the discriminant, by `TauCeti.discrSqrt_sq`. It
+is only *a* square root: `TauCeti.discrSqrt_trans` shows that changing the numbering by an odd
+permutation changes the sign. The root set carries no order, so the numbering is an explicit
+argument and is never fixed globally. -/
+def discrSqrt (e : Fin f.natDegree ≃ f.rootSet E) : E :=
+  ∏ i, ∏ j ∈ Finset.Ioi i, ((e i : E) - (e j : E))
+
+/-- The defining equation of `TauCeti.discrSqrt`. -/
+theorem discrSqrt_def (e : Fin f.natDegree ≃ f.rootSet E) :
+    discrSqrt e = ∏ i, ∏ j ∈ Finset.Ioi i, ((e i : E) - (e j : E)) := (rfl)
+
+/-- The defining property: the square of the product of the root differences is the discriminant.
+-/
+theorem discrSqrt_sq (hf : f.Monic) (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
+    discrSqrt e ^ 2 = algebraMap F E f.discr := by
+  rw [hf.discr_eq_prod_roots_sub_sq (roots_map_eq_map_numbering hsep e), discrSqrt_def,
+    ← Finset.prod_pow]
+  exact Finset.prod_congr rfl fun i _ ↦ (Finset.prod_pow _ _ _).symm
+
+/-- A separable monic polynomial has nonzero discriminant, so the product of its root differences
+is nonzero. -/
+theorem discrSqrt_ne_zero (hf : f.Monic) (hsep : f.Separable)
+    (e : Fin f.natDegree ≃ f.rootSet E) : discrSqrt e ≠ 0 := by
+  intro h
+  have h0 : algebraMap F E f.discr = 0 := by rw [← discrSqrt_sq hf hsep e, h, zero_pow two_ne_zero]
+  exact (hf.discr_ne_zero_iff.mpr hsep)
+    ((map_eq_zero_iff _ (algebraMap F E).injective).mp h0)
+
+/-- Renumbering the roots by a permutation `π` multiplies the product of the root differences by
+the sign of `π`. This is the alternating behaviour that makes the discriminant test work. -/
+theorem discrSqrt_trans (e : Fin f.natDegree ≃ f.rootSet E) (π : Equiv.Perm (Fin f.natDegree)) :
+    discrSqrt (π.trans e) = Equiv.Perm.sign π • discrSqrt e := by
+  have h := π.prod_Ioi_comp_eq_sign_mul_prod
+    (f := fun i j ↦ ((e i : E) - (e j : E))) fun i j ↦ (neg_sub _ _).symm
+  simp only [discrSqrt_def, Equiv.trans_apply, h, Units.smul_def, zsmul_eq_mul]
+
+/-- The discriminant is a square in the base field exactly when the product of the root
+differences already comes from the base field. No Galois hypothesis is involved: this is the
+elementary half of the discriminant test, and it is the reading of `TauCeti.discrSqrt_sq` in both
+directions. -/
+theorem isSquare_discr_iff_mem_range (hf : f.Monic) (hsep : f.Separable)
+    (e : Fin f.natDegree ≃ f.rootSet E) :
+    IsSquare f.discr ↔ discrSqrt e ∈ Set.range (algebraMap F E) := by
+  constructor
+  · rintro ⟨c, hc⟩
+    have hsq : discrSqrt e * discrSqrt e = algebraMap F E c * algebraMap F E c := by
+      rw [← map_mul, ← hc, ← sq, discrSqrt_sq hf hsep]
+    rcases mul_self_eq_mul_self_iff.mp hsq with h | h
+    · exact ⟨c, h.symm⟩
+    · exact ⟨-c, by rw [map_neg, ← h]⟩
+  · rintro ⟨c, hc⟩
+    refine ⟨c, (algebraMap F E).injective ?_⟩
+    rw [map_mul, hc, ← sq, discrSqrt_sq hf hsep]
+
+/-! ## The discriminant test -/
+
+section Galois
+
+variable [DecidableEq E] [Fact ((f.map (algebraMap F E)).Splits)]
+
+/-- **The transformation law for the square root of the discriminant.** An automorphism `ϕ` of a
+splitting extension `E` over `F` multiplies the product of the root differences by the sign of the
+permutation that `ϕ` induces on the roots of `f`. -/
+theorem map_discrSqrt (ϕ : E ≃ₐ[F] E) (e : Fin f.natDegree ≃ f.rootSet E) :
+    ϕ (discrSqrt e) =
+      Equiv.Perm.sign (Gal.galActionHom f E (Gal.restrict f E ϕ)) • discrSqrt e := by
+  -- Transport the induced permutation of the root set to a permutation of `Fin f.natDegree`
+  -- along the numbering; the sign is unchanged, and `TauCeti.discrSqrt_trans` applies.
+  obtain ⟨ρ, hcongr⟩ : ∃ ρ : Equiv.Perm (Fin f.natDegree),
+      e.permCongr ρ = Gal.galActionHom f E (Gal.restrict f E ϕ) :=
+    ⟨e.permCongr.symm _, Equiv.apply_symm_apply _ _⟩
+  have key : ∀ i, ϕ ((e i : E)) = ((e (ρ i) : E)) := fun i ↦ by
+    have h : Gal.galActionHom f E (Gal.restrict f E ϕ) (e i) = e (ρ i) := by
+      rw [← hcongr]; simp
+    rw [← Gal.restrict_smul ϕ (e i)]
+    exact congrArg Subtype.val h
+  have himage : ϕ (discrSqrt e)
+      = ∏ i, ∏ j ∈ Finset.Ioi i, ((e (ρ i) : E) - (e (ρ j) : E)) := by
+    rw [discrSqrt_def, map_prod]
+    refine Finset.prod_congr rfl fun i _ ↦ ?_
+    rw [map_prod]
+    exact Finset.prod_congr rfl fun j _ ↦ by rw [map_sub, key, key]
+  have hrenumber : discrSqrt (ρ.trans e)
+      = ∏ i, ∏ j ∈ Finset.Ioi i, ((e (ρ i) : E) - (e (ρ j) : E)) := by
+    rw [discrSqrt_def]
+    simp only [Equiv.trans_apply]
+  rw [himage, ← hrenumber, discrSqrt_trans, ← Equiv.Perm.sign_permCongr e ρ, hcongr]
+
+/-- Away from characteristic `2`, the product of the root differences comes from the base field
+exactly when the Galois image consists of even permutations of the roots. -/
+theorem discrSqrt_mem_range_iff [FiniteDimensional F E] [IsGalois F E] (hf : f.Monic)
+    (hsep : f.Separable) (hchar : ringChar F ≠ 2) (e : Fin f.natDegree ≃ f.rootSet E) :
+    discrSqrt e ∈ Set.range (algebraMap F E) ↔
+      (Gal.galActionHom f E).range ≤ alternatingGroup (f.rootSet E) := by
+  have h2 : (2 : E) ≠ 0 := by
+    rw [← map_ofNat (algebraMap F E) 2]
+    exact (map_ne_zero_iff _ (algebraMap F E).injective).mpr (Ring.two_ne_zero hchar)
+  rw [IsGalois.mem_range_algebraMap_iff_fixed]
+  constructor
+  · rintro hfix g ⟨σ, rfl⟩
+    obtain ⟨ϕ, rfl⟩ := Gal.restrict_surjective f E σ
+    rw [Equiv.Perm.mem_alternatingGroup]
+    have hϕ := hfix ϕ
+    rw [map_discrSqrt] at hϕ
+    rcases Int.units_eq_one_or (Equiv.Perm.sign (Gal.galActionHom f E (Gal.restrict f E ϕ)))
+      with h1 | h1
+    · exact h1
+    -- An odd permutation would negate a nonzero element and fix it, forcing `2 = 0` in `E`.
+    rw [h1] at hϕ
+    refine absurd ?_ (discrSqrt_ne_zero hf hsep e)
+    have hdouble : (2 : E) * discrSqrt e = 0 := by
+      simp only [Units.smul_def, Units.val_neg, Units.val_one, neg_smul, one_smul] at hϕ
+      linear_combination -hϕ
+    exact (mul_eq_zero.mp hdouble).resolve_left h2
+  · intro hle ϕ
+    rw [map_discrSqrt, Equiv.Perm.mem_alternatingGroup.mp (hle ⟨_, rfl⟩), one_smul]
+
+/-- **The discriminant test.** For a monic separable polynomial over a field of characteristic
+other than `2`, the discriminant is a square in the base field exactly when the Galois group acts
+on the roots by even permutations.
+
+The characteristic hypothesis cannot be dropped: see
+`TauCeti.isSquare_discr_of_ringChar_eq_two`. -/
+theorem isSquare_discr_iff_range_le_alternatingGroup [FiniteDimensional F E] [IsGalois F E]
+    (hf : f.Monic) (hsep : f.Separable) (hchar : ringChar F ≠ 2) :
+    IsSquare f.discr ↔ (Gal.galActionHom f E).range ≤ alternatingGroup (f.rootSet E) := by
+  obtain ⟨e⟩ : Nonempty (Fin f.natDegree ≃ f.rootSet E) :=
+    ⟨(Fintype.equivFinOfCardEq (card_rootSet_eq_natDegree hsep Fact.out)).symm⟩
+  exact (isSquare_discr_iff_mem_range hf hsep e).trans (discrSqrt_mem_range_iff hf hsep hchar e)
+
+/-- The discriminant test, read on the elements of the Galois group: away from characteristic `2`
+the discriminant is a square exactly when every element of the Galois group acts on the roots by
+an even permutation. -/
+theorem isSquare_discr_iff_forall_sign_eq_one [FiniteDimensional F E] [IsGalois F E]
+    (hf : f.Monic) (hsep : f.Separable) (hchar : ringChar F ≠ 2) :
+    IsSquare f.discr ↔ ∀ σ : f.Gal, Equiv.Perm.sign (Gal.galActionHom f E σ) = 1 := by
+  rw [isSquare_discr_iff_range_le_alternatingGroup (E := E) hf hsep hchar]
+  refine ⟨fun h σ ↦ Equiv.Perm.mem_alternatingGroup.mp (h ⟨σ, rfl⟩), fun h g hg ↦ ?_⟩
+  obtain ⟨σ, rfl⟩ := hg
+  exact Equiv.Perm.mem_alternatingGroup.mpr (h σ)
+
+omit [DecidableEq E] in
+/-- In characteristic `2` the discriminant of a monic separable polynomial is always a square,
+whatever its Galois group: the sign of a permutation acts trivially because `-1 = 1`, so the
+product of the root differences is fixed by the whole Galois group and therefore lies in the base
+field.
+
+This is why the discriminant test carries the hypothesis `ringChar F ≠ 2`. The invariant that
+replaces the discriminant in characteristic `2` is Berlekamp's. -/
+theorem isSquare_discr_of_ringChar_eq_two [FiniteDimensional F E] [IsGalois F E] (hf : f.Monic)
+    (hsep : f.Separable) (hchar : ringChar F = 2) : IsSquare f.discr := by
+  classical
+  have hF : (2 : F) = 0 := by
+    exact_mod_cast (ringChar.spec F 2).mpr (by rw [hchar])
+  have h2 : (2 : E) = 0 := by rw [← map_ofNat (algebraMap F E) 2, hF, map_zero]
+  obtain ⟨e⟩ : Nonempty (Fin f.natDegree ≃ f.rootSet E) :=
+    ⟨(Fintype.equivFinOfCardEq (card_rootSet_eq_natDegree hsep Fact.out)).symm⟩
+  rw [isSquare_discr_iff_mem_range hf hsep e, IsGalois.mem_range_algebraMap_iff_fixed]
+  intro ϕ
+  rw [map_discrSqrt]
+  rcases Int.units_eq_one_or (Equiv.Perm.sign (Gal.galActionHom f E (Gal.restrict f E ϕ)))
+    with h1 | h1 <;> rw [h1]
+  · rw [one_smul]
+  · simp only [Units.smul_def, Units.val_neg, Units.val_one, neg_smul, one_smul]
+    linear_combination -h2 * discrSqrt e
+
+end Galois
+
+end TauCeti

--- a/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
@@ -71,8 +71,9 @@ variable {F : Type u} [Field F] {E : Type v} [Field E] [Algebra F E] {f : F[X]}
 
 section Galois
 
-variable [DecidableEq E] [Fact ((f.map (algebraMap F E)).Splits)]
+variable [Fact ((f.map (algebraMap F E)).Splits)]
 
+open scoped Classical in
 /-- **The transformation law for the square root of the discriminant.** An automorphism `ϕ` of a
 splitting extension `E` over `F` multiplies the product of the root differences by the sign of the
 permutation that `ϕ` induces on the roots of `f`. -/
@@ -99,6 +100,7 @@ theorem _root_.AlgEquiv.map_discrSqrt (ϕ : E ≃ₐ[F] E) (e : Fin f.natDegree 
     simp only [discrSqrt_def, Equiv.trans_apply]
   rw [himage, ← hrenumber, discrSqrt_trans, ← Equiv.Perm.sign_permCongr e ρ, hcongr]
 
+open scoped Classical in
 /-- Away from characteristic `2`, the product of the root differences comes from the base field
 exactly when the Galois image consists of even permutations of the roots. -/
 theorem _root_.Polynomial.Monic.discrSqrt_mem_range_iff [FiniteDimensional F E] [IsGalois F E]
@@ -129,6 +131,7 @@ theorem _root_.Polynomial.Monic.discrSqrt_mem_range_iff [FiniteDimensional F E] 
   · intro hle ϕ
     rw [AlgEquiv.map_discrSqrt, Equiv.Perm.mem_alternatingGroup.mp (hle ⟨_, rfl⟩), one_smul]
 
+open scoped Classical in
 /-- **The discriminant test.** For a monic separable polynomial over a field of characteristic
 other than `2`, the discriminant is a square in the base field exactly when the Galois group acts
 on the roots by even permutations.

--- a/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
@@ -24,16 +24,17 @@ into an element of `E`. Its square is the image of `Polynomial.discr f`, so `δ`
 of the discriminant; it is only *a* square root, because a different numbering changes `δ` by the
 sign of the permutation relating the two numberings.
 
-That sign is the whole point. A field automorphism of `E` over `F` permutes the roots, hence
-multiplies `δ` by the sign of the permutation it induces. Consequently `δ` lies in `F` exactly
-when the Galois image consists of even permutations, and — since `δ² = discr f` — that happens
-exactly when `discr f` is a square in `F`. This is the **discriminant test** for containment in
-the alternating group.
+That sign is the whole point. In a finite-dimensional Galois splitting extension, a field
+automorphism of `E` over `F` permutes the roots, hence multiplies `δ` by the sign of the
+permutation it induces. When `ringChar F ≠ 2`, consequently `δ` lies in `F` exactly when the
+Galois image consists of even permutations, and — since `δ² = discr f` — that happens exactly
+when `discr f` is a square in `F`. This is the **discriminant test** for containment in the
+alternating group.
 
 The characteristic hypothesis `ringChar F ≠ 2` is not decoration. In characteristic `2` one has
 `-1 = 1`, so the sign never moves `δ`, the discriminant of a separable monic polynomial is
 *always* a square, and the test decides nothing; this is recorded as
-`TauCeti.isSquare_discr_of_ringChar_eq_two`.
+`TauCeti.isSquare_discr_of_char_two`.
 
 ## Main definitions
 
@@ -50,7 +51,7 @@ The characteristic hypothesis `ringChar F ≠ 2` is not decoration. In character
   comes from `F`.
 * `TauCeti.isSquare_discr_iff_range_le_alternatingGroup`: **the discriminant test**, valid away
   from characteristic `2`.
-* `TauCeti.isSquare_discr_of_ringChar_eq_two`: in characteristic `2` the discriminant of a monic
+* `TauCeti.isSquare_discr_of_char_two`: in characteristic `2` the discriminant of a monic
   separable polynomial is always a square, so the test is vacuous there.
 
 ## References
@@ -67,84 +68,6 @@ namespace TauCeti
 universe u v
 
 variable {F : Type u} [Field F] {E : Type v} [Field E] [Algebra F E] {f : F[X]}
-
-/-! ## Numbering the roots -/
-
--- Membership in the root set is membership in the root multiset of the mapped polynomial.
-private theorem mem_roots_map_iff {a : E} :
-    a ∈ (f.map (algebraMap F E)).roots ↔ a ∈ f.rootSet E :=
-  Polynomial.mem_aroots'.trans Polynomial.mem_rootSet'.symm
-
-/-- A numbering of the root set of a separable polynomial enumerates the whole root multiset:
-separability makes the roots simple, so the multiset is the image of the numbering. This is the
-hypothesis that the root-product formula for the discriminant takes. -/
-theorem roots_map_eq_map_numbering (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
-    (f.map (algebraMap F E)).roots = Multiset.map (fun i ↦ ((e i : E))) Finset.univ.val := by
-  refine (Multiset.Nodup.ext (nodup_roots hsep.map) ?_).mpr ?_
-  · exact Finset.univ.nodup.map fun i j h ↦ e.injective (Subtype.ext h)
-  · intro a
-    simp only [Multiset.mem_map, Finset.mem_val, Finset.mem_univ, true_and]
-    exact ⟨fun ha ↦ ⟨e.symm ⟨a, mem_roots_map_iff.mp ha⟩, by simp⟩,
-      fun ⟨i, hi⟩ ↦ hi ▸ mem_roots_map_iff.mpr (e i).2⟩
-
-/-! ## The square root of the discriminant -/
-
-/-- The product `∏_{i < j} (rᵢ - rⱼ)` of the differences of the roots of `f` in `E`, taken along a
-numbering `e` of the root set.
-
-For monic separable `f` this is a square root of the discriminant, by `TauCeti.discrSqrt_sq`. It
-is only *a* square root: `TauCeti.discrSqrt_trans` shows that changing the numbering by an odd
-permutation changes the sign. The root set carries no order, so the numbering is an explicit
-argument and is never fixed globally. -/
-def discrSqrt (e : Fin f.natDegree ≃ f.rootSet E) : E :=
-  ∏ i, ∏ j ∈ Finset.Ioi i, ((e i : E) - (e j : E))
-
-/-- The defining equation of `TauCeti.discrSqrt`. -/
-theorem discrSqrt_def (e : Fin f.natDegree ≃ f.rootSet E) :
-    discrSqrt e = ∏ i, ∏ j ∈ Finset.Ioi i, ((e i : E) - (e j : E)) := (rfl)
-
-/-- The defining property: the square of the product of the root differences is the discriminant.
--/
-theorem discrSqrt_sq (hf : f.Monic) (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
-    discrSqrt e ^ 2 = algebraMap F E f.discr := by
-  rw [hf.discr_eq_prod_roots_sub_sq (roots_map_eq_map_numbering hsep e), discrSqrt_def,
-    ← Finset.prod_pow]
-  exact Finset.prod_congr rfl fun i _ ↦ (Finset.prod_pow _ _ _).symm
-
-/-- A separable monic polynomial has nonzero discriminant, so the product of its root differences
-is nonzero. -/
-theorem discrSqrt_ne_zero (hf : f.Monic) (hsep : f.Separable)
-    (e : Fin f.natDegree ≃ f.rootSet E) : discrSqrt e ≠ 0 := by
-  intro h
-  have h0 : algebraMap F E f.discr = 0 := by rw [← discrSqrt_sq hf hsep e, h, zero_pow two_ne_zero]
-  exact (hf.discr_ne_zero_iff.mpr hsep)
-    ((map_eq_zero_iff _ (algebraMap F E).injective).mp h0)
-
-/-- Renumbering the roots by a permutation `π` multiplies the product of the root differences by
-the sign of `π`. This is the alternating behaviour that makes the discriminant test work. -/
-theorem discrSqrt_trans (e : Fin f.natDegree ≃ f.rootSet E) (π : Equiv.Perm (Fin f.natDegree)) :
-    discrSqrt (π.trans e) = Equiv.Perm.sign π • discrSqrt e := by
-  have h := π.prod_Ioi_comp_eq_sign_mul_prod
-    (f := fun i j ↦ ((e i : E) - (e j : E))) fun i j ↦ (neg_sub _ _).symm
-  simp only [discrSqrt_def, Equiv.trans_apply, h, Units.smul_def, zsmul_eq_mul]
-
-/-- The discriminant is a square in the base field exactly when the product of the root
-differences already comes from the base field. No Galois hypothesis is involved: this is the
-elementary half of the discriminant test, and it is the reading of `TauCeti.discrSqrt_sq` in both
-directions. -/
-theorem isSquare_discr_iff_mem_range (hf : f.Monic) (hsep : f.Separable)
-    (e : Fin f.natDegree ≃ f.rootSet E) :
-    IsSquare f.discr ↔ discrSqrt e ∈ Set.range (algebraMap F E) := by
-  constructor
-  · rintro ⟨c, hc⟩
-    have hsq : discrSqrt e * discrSqrt e = algebraMap F E c * algebraMap F E c := by
-      rw [← map_mul, ← hc, ← sq, discrSqrt_sq hf hsep]
-    rcases mul_self_eq_mul_self_iff.mp hsq with h | h
-    · exact ⟨c, h.symm⟩
-    · exact ⟨-c, by rw [map_neg, ← h]⟩
-  · rintro ⟨c, hc⟩
-    refine ⟨c, (algebraMap F E).injective ?_⟩
-    rw [map_mul, hc, ← sq, discrSqrt_sq hf hsep]
 
 /-! ## The discriminant test -/
 
@@ -170,14 +93,12 @@ theorem map_discrSqrt (ϕ : E ≃ₐ[F] E) (e : Fin f.natDegree ≃ f.rootSet E)
     exact congrArg Subtype.val h
   have himage : ϕ (discrSqrt e)
       = ∏ i, ∏ j ∈ Finset.Ioi i, ((e (ρ i) : E) - (e (ρ j) : E)) := by
-    rw [discrSqrt_def, map_prod]
+    simp only [TauCeti.discrSqrt, map_prod]
     refine Finset.prod_congr rfl fun i _ ↦ ?_
-    rw [map_prod]
     exact Finset.prod_congr rfl fun j _ ↦ by rw [map_sub, key, key]
   have hrenumber : discrSqrt (ρ.trans e)
       = ∏ i, ∏ j ∈ Finset.Ioi i, ((e (ρ i) : E) - (e (ρ j) : E)) := by
-    rw [discrSqrt_def]
-    simp only [Equiv.trans_apply]
+    simp only [TauCeti.discrSqrt, Equiv.trans_apply]
   rw [himage, ← hrenumber, discrSqrt_trans, ← Equiv.Perm.sign_permCongr e ρ, hcongr]
 
 /-- Away from characteristic `2`, the product of the root differences comes from the base field
@@ -214,7 +135,7 @@ other than `2`, the discriminant is a square in the base field exactly when the 
 on the roots by even permutations.
 
 The characteristic hypothesis cannot be dropped: see
-`TauCeti.isSquare_discr_of_ringChar_eq_two`. -/
+`TauCeti.isSquare_discr_of_char_two`. -/
 theorem isSquare_discr_iff_range_le_alternatingGroup [FiniteDimensional F E] [IsGalois F E]
     (hf : f.Monic) (hsep : f.Separable) (hchar : ringChar F ≠ 2) :
     IsSquare f.discr ↔ (Gal.galActionHom f E).range ≤ alternatingGroup (f.rootSet E) := by
@@ -222,18 +143,6 @@ theorem isSquare_discr_iff_range_le_alternatingGroup [FiniteDimensional F E] [Is
     ⟨(Fintype.equivFinOfCardEq (card_rootSet_eq_natDegree hsep Fact.out)).symm⟩
   exact (isSquare_discr_iff_mem_range hf hsep e).trans (discrSqrt_mem_range_iff hf hsep hchar e)
 
-/-- The discriminant test, read on the elements of the Galois group: away from characteristic `2`
-the discriminant is a square exactly when every element of the Galois group acts on the roots by
-an even permutation. -/
-theorem isSquare_discr_iff_forall_sign_eq_one [FiniteDimensional F E] [IsGalois F E]
-    (hf : f.Monic) (hsep : f.Separable) (hchar : ringChar F ≠ 2) :
-    IsSquare f.discr ↔ ∀ σ : f.Gal, Equiv.Perm.sign (Gal.galActionHom f E σ) = 1 := by
-  rw [isSquare_discr_iff_range_le_alternatingGroup (E := E) hf hsep hchar]
-  refine ⟨fun h σ ↦ Equiv.Perm.mem_alternatingGroup.mp (h ⟨σ, rfl⟩), fun h g hg ↦ ?_⟩
-  obtain ⟨σ, rfl⟩ := hg
-  exact Equiv.Perm.mem_alternatingGroup.mpr (h σ)
-
-omit [DecidableEq E] in
 /-- In characteristic `2` the discriminant of a monic separable polynomial is always a square,
 whatever its Galois group: the sign of a permutation acts trivially because `-1 = 1`, so the
 product of the root differences is fixed by the whole Galois group and therefore lies in the base
@@ -241,9 +150,12 @@ field.
 
 This is why the discriminant test carries the hypothesis `ringChar F ≠ 2`. The invariant that
 replaces the discriminant in characteristic `2` is Berlekamp's. -/
-theorem isSquare_discr_of_ringChar_eq_two [FiniteDimensional F E] [IsGalois F E] (hf : f.Monic)
-    (hsep : f.Separable) (hchar : ringChar F = 2) : IsSquare f.discr := by
+theorem isSquare_discr_of_char_two (hf : f.Monic) (hsep : f.Separable)
+    (hchar : ringChar F = 2) : IsSquare f.discr := by
   classical
+  let E := f.SplittingField
+  let _ : IsGalois F E := IsGalois.of_separable_splitting_field hsep
+  let _ : Fact ((f.map (algebraMap F E)).Splits) := ⟨IsSplittingField.splits E f⟩
   have hF : (2 : F) = 0 := by
     exact_mod_cast (ringChar.spec F 2).mpr (by rw [hchar])
   have h2 : (2 : E) = 0 := by rw [← map_ofNat (algebraMap F E) 2, hF, map_zero]

--- a/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/Discriminant.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.FieldTheory.Galois.Infinite
 public import Mathlib.FieldTheory.PolynomialGaloisGroup
 public import Mathlib.GroupTheory.SpecificGroups.Alternating
 public import TauCeti.RingTheory.Polynomial.Resultant.Discriminant
@@ -22,7 +23,7 @@ into an element of `E`. Its square is the image of `Polynomial.discr f`, so `δ`
 of the discriminant; it is only *a* square root, because a different numbering changes `δ` by the
 sign of the permutation relating the two numberings.
 
-That sign is the whole point. In a finite-dimensional Galois splitting extension, a field
+That sign is the whole point. In a Galois splitting extension, a field
 automorphism of `E` over `F` permutes the roots, hence multiplies `δ` by the sign of the
 permutation it induces. When `ringChar F ≠ 2`, consequently `δ` lies in `F` exactly when the
 Galois image consists of even permutations, and — since `δ² = discr f` — that happens exactly
@@ -104,7 +105,7 @@ theorem _root_.AlgEquiv.map_discrSqrt (ϕ : E ≃ₐ[F] E) (e : Fin f.natDegree 
 open scoped Classical in
 /-- Away from characteristic `2`, the product of the root differences comes from the base field
 exactly when the Galois image consists of even permutations of the roots. -/
-theorem _root_.Polynomial.Monic.discrSqrt_mem_range_iff [FiniteDimensional F E] [IsGalois F E]
+theorem _root_.Polynomial.Monic.discrSqrt_mem_range_iff [IsGalois F E]
     (hf : f.Monic) (hsep : f.Separable) (hchar : ringChar F ≠ 2)
     (e : Fin f.natDegree ≃ f.rootSet E) :
     discrSqrt e ∈ Set.range (algebraMap F E) ↔
@@ -112,7 +113,7 @@ theorem _root_.Polynomial.Monic.discrSqrt_mem_range_iff [FiniteDimensional F E] 
   have h2 : (2 : E) ≠ 0 := by
     rw [← map_ofNat (algebraMap F E) 2]
     exact (map_ne_zero_iff _ (algebraMap F E).injective).mpr (Ring.two_ne_zero hchar)
-  rw [IsGalois.mem_range_algebraMap_iff_fixed]
+  rw [InfiniteGalois.mem_range_algebraMap_iff_fixed]
   constructor
   · rintro hfix g ⟨σ, rfl⟩
     obtain ⟨ϕ, rfl⟩ := Gal.restrict_surjective f E σ
@@ -140,7 +141,7 @@ on the roots by even permutations.
 The characteristic hypothesis cannot be dropped: see
 `Polynomial.Monic.isSquare_discr_of_char_two`. -/
 theorem _root_.Polynomial.Monic.isSquare_discr_iff_range_le_alternatingGroup
-    [FiniteDimensional F E] [IsGalois F E] (hf : f.Monic) (hsep : f.Separable)
+    [IsGalois F E] (hf : f.Monic) (hsep : f.Separable)
     (hchar : ringChar F ≠ 2) :
     IsSquare f.discr ↔ (Gal.galActionHom f E).range ≤ alternatingGroup (f.rootSet E) := by
   obtain ⟨e⟩ : Nonempty (Fin f.natDegree ≃ f.rootSet E) :=

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -398,7 +398,7 @@ variable {F : Type*} [CommRing F] {E : Type*} [CommRing E] [IsDomain E] [Algebra
 /-- A numbering of the root set of a separable polynomial enumerates the whole root multiset:
 separability makes the roots simple, so the multiset is the image of the numbering. This is the
 hypothesis that the root-product formula for the discriminant takes. -/
-theorem _root_.Polynomial.Separable.roots_map_eq_map_numbering (hsep : f.Separable)
+private theorem _root_.Polynomial.Separable.roots_map_eq_map_numbering (hsep : f.Separable)
     (e : Fin f.natDegree ≃ f.rootSet E) :
     (f.map (algebraMap F E)).roots = Multiset.map (fun i ↦ ((e i : E))) univ.val := by
   have hmem : ∀ {a : E}, a ∈ (f.map (algebraMap F E)).roots ↔ a ∈ f.rootSet E := fun {_} ↦

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -10,6 +10,7 @@ import Mathlib.Algebra.MvPolynomial.Basic
 public import Mathlib.Algebra.Order.BigOperators.Group.LocallyFinite
 import Mathlib.Data.Nat.Choose.Vandermonde
 public import Mathlib.FieldTheory.Separable
+public import Mathlib.GroupTheory.Perm.Fin
 public import Mathlib.RingTheory.Discriminant
 public import Mathlib.RingTheory.Localization.FractionRing
 public import Mathlib.RingTheory.Polynomial.Resultant.Basic
@@ -39,6 +40,8 @@ separable.
   roots and multiplies `δ` by the sign of that permutation.
 * `Polynomial.Monic.discr_eq_prod_roots_sub_sq`: the same formula for a monic polynomial,
   written against a numbering `r : Fin f.natDegree → L` of its root multiset over an extension.
+* `TauCeti.discrSqrt`, `TauCeti.discrSqrt_sq`: the product of the differences of a numbering of
+  the distinct roots of a separable polynomial, and the fact that its square is the discriminant.
 * `Polynomial.Monic.prod_roots_eval_derivative`: the product of the derivative over the root
   multiset, which is the discriminant up to the same sign. This is the shape in which the
   discriminant of a minimal polynomial is a norm.
@@ -383,6 +386,76 @@ theorem _root_.Polynomial.Monic.discr_eq_prod_roots_sub_sq {L : Type*} [CommRing
     simp
   exact hf.discr_eq_prod_roots_sub_sq_of_splits (splits_iff_card_roots.mpr hcard) hr
 
+/-! ### The square root of the discriminant -/
+
+section DiscrSqrt
+
+variable {F : Type*} [Field F] {E : Type*} [Field E] [Algebra F E] {f : F[X]}
+
+/-- Membership in the roots of a polynomial mapped to an extension field is membership in its
+root set over that extension. -/
+theorem mem_roots_map_iff_mem_rootSet {a : E} :
+    a ∈ (f.map (algebraMap F E)).roots ↔ a ∈ f.rootSet E :=
+  Polynomial.mem_aroots'.trans Polynomial.mem_rootSet'.symm
+
+/-- A numbering of the root set of a separable polynomial enumerates the whole root multiset:
+separability makes the roots simple, so the multiset is the image of the numbering. This is the
+hypothesis that the root-product formula for the discriminant takes. -/
+theorem roots_map_eq_map_numbering (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
+    (f.map (algebraMap F E)).roots = Multiset.map (fun i ↦ ((e i : E))) univ.val := by
+  refine (Multiset.Nodup.ext (nodup_roots hsep.map) ?_).mpr ?_
+  · exact univ.nodup.map fun i j h ↦ e.injective (Subtype.ext h)
+  · intro a
+    simp only [Multiset.mem_map, Finset.mem_val, mem_univ, true_and]
+    exact ⟨fun ha ↦ ⟨e.symm ⟨a, mem_roots_map_iff_mem_rootSet.mp ha⟩, by simp⟩,
+      fun ⟨i, hi⟩ ↦ hi ▸ mem_roots_map_iff_mem_rootSet.mpr (e i).2⟩
+
+/-- The product `∏_{i < j} (rᵢ - rⱼ)` of the differences of the roots of `f` in `E`, taken along a
+numbering `e` of the root set.
+
+For monic separable `f` this is a square root of the discriminant, by `TauCeti.discrSqrt_sq`. It
+is only *a* square root: `TauCeti.discrSqrt_trans` shows that changing the numbering by an odd
+permutation changes the sign. The root set carries no order, so the numbering is an explicit
+argument and is never fixed globally. -/
+@[expose] def discrSqrt (e : Fin f.natDegree ≃ f.rootSet E) : E :=
+  ∏ i, ∏ j ∈ Ioi i, ((e i : E) - (e j : E))
+
+/-- The defining property: the square of the product of the root differences is the discriminant.
+-/
+theorem discrSqrt_sq (hf : f.Monic) (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
+    discrSqrt e ^ 2 = algebraMap F E f.discr := by
+  rw [hf.discr_eq_prod_roots_sub_sq (roots_map_eq_map_numbering hsep e), discrSqrt,
+    ← Finset.prod_pow]
+  exact Finset.prod_congr rfl fun i _ ↦ (Finset.prod_pow _ _ _).symm
+
+/-- Renumbering the roots by a permutation `π` multiplies the product of the root differences by
+the sign of `π`. This is the alternating behaviour that makes the discriminant test work. -/
+theorem discrSqrt_trans (e : Fin f.natDegree ≃ f.rootSet E) (π : Equiv.Perm (Fin f.natDegree)) :
+    discrSqrt (π.trans e) = Equiv.Perm.sign π • discrSqrt e := by
+  have h := π.prod_Ioi_comp_eq_sign_mul_prod
+    (f := fun i j ↦ ((e i : E) - (e j : E))) fun i j ↦ (neg_sub _ _).symm
+  simp only [discrSqrt, Equiv.trans_apply, h, Units.smul_def, zsmul_eq_mul]
+
+/-- The discriminant is a square in the base field exactly when the product of the root
+differences already comes from the base field. No Galois hypothesis is involved: this is the
+elementary half of the discriminant test, and it is the reading of `TauCeti.discrSqrt_sq` in both
+directions. -/
+theorem isSquare_discr_iff_mem_range (hf : f.Monic) (hsep : f.Separable)
+    (e : Fin f.natDegree ≃ f.rootSet E) :
+    IsSquare f.discr ↔ discrSqrt e ∈ Set.range (algebraMap F E) := by
+  constructor
+  · rintro ⟨c, hc⟩
+    have hsq : discrSqrt e * discrSqrt e = algebraMap F E c * algebraMap F E c := by
+      rw [← map_mul, ← hc, ← sq, discrSqrt_sq hf hsep]
+    rcases mul_self_eq_mul_self_iff.mp hsq with h | h
+    · exact ⟨c, h.symm⟩
+    · exact ⟨-c, by rw [map_neg, ← h]⟩
+  · rintro ⟨c, hc⟩
+    refine ⟨c, (algebraMap F E).injective ?_⟩
+    rw [map_mul, hc, ← sq, discrSqrt_sq hf hsep]
+
+end DiscrSqrt
+
 /-! ### Separability -/
 
 /-- A monic polynomial is separable exactly when its discriminant is a unit. This is the
@@ -407,6 +480,16 @@ monic polynomial over `ℤ` with nonzero discriminant that is not separable. -/
 theorem _root_.Polynomial.Monic.discr_ne_zero_iff {K : Type*} [Field K] {f : K[X]}
     (hf : f.Monic) : f.discr ≠ 0 ↔ f.Separable := by
   rw [← hf.isUnit_discr_iff, isUnit_iff_ne_zero]
+
+/-- A separable monic polynomial has nonzero discriminant, so the product of its root differences
+is nonzero. -/
+theorem discrSqrt_ne_zero {F E : Type*} [Field F] [Field E] [Algebra F E] {f : F[X]}
+    (hf : f.Monic) (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
+    discrSqrt e ≠ 0 := by
+  intro h
+  have h0 : algebraMap F E f.discr = 0 := by rw [← discrSqrt_sq hf hsep e, h, zero_pow two_ne_zero]
+  exact (hf.discr_ne_zero_iff.mpr hsep)
+    ((map_eq_zero_iff _ (algebraMap F E).injective).mp h0)
 
 /-- Over a domain, the discriminant of a monic polynomial is nonzero exactly when the polynomial
 becomes separable over the fraction field: over a domain the separability criterion is the one

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -406,8 +406,7 @@ the numbering is an explicit argument and is never fixed globally. -/
 def discrSqrt (e : Fin f.natDegree ≃ f.rootSet E) : E :=
   ∏ i, ∏ j ∈ Ioi i, ((e i : E) - (e j : E))
 
-/-- The product formula that defines the square root of the discriminant. This is the only way the
-body of `TauCeti.discrSqrt` is read outside its own module. -/
+/-- The unfolding equation for the square root of the discriminant. -/
 theorem discrSqrt_def (e : Fin f.natDegree ≃ f.rootSet E) :
     discrSqrt e = ∏ i, ∏ j ∈ Ioi i, ((e i : E) - (e j : E)) := (rfl)
 

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -484,15 +484,14 @@ theorem _root_.Polynomial.Monic.discr_ne_zero_iff {K : Type*} [Field K] {f : K[X
 
 /-- A separable monic polynomial has nonzero discriminant, so the product of its root differences
 is nonzero. -/
-theorem _root_.Polynomial.Monic.discrSqrt_ne_zero {F E : Type*} [Field F] [CommRing E] [IsDomain E]
+theorem _root_.Polynomial.Monic.discrSqrt_ne_zero {F E : Type*} [CommRing F] [CommRing E]
+    [IsDomain E]
     [Algebra F E] {f : F[X]} (hf : f.Monic) (hsep : f.Separable)
     (e : Fin f.natDegree ≃ f.rootSet E) :
     discrSqrt e ≠ 0 := by
   intro h
-  have h0 : algebraMap F E f.discr = 0 := by
-    rw [← hf.discrSqrt_sq hsep e, h, zero_pow two_ne_zero]
-  exact (hf.discr_ne_zero_iff.mpr hsep)
-    ((map_eq_zero_iff _ (algebraMap F E).injective).mp h0)
+  apply ((hf.isUnit_discr_iff.mpr hsep).map (algebraMap F E)).ne_zero
+  rw [← hf.discrSqrt_sq hsep e, h, zero_pow two_ne_zero]
 
 /-- Over a domain, the discriminant of a monic polynomial is nonzero exactly when the polynomial
 becomes separable over the fraction field: over a domain the separability criterion is the one

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -40,8 +40,9 @@ separable.
   roots and multiplies `δ` by the sign of that permutation.
 * `Polynomial.Monic.discr_eq_prod_roots_sub_sq`: the same formula for a monic polynomial,
   written against a numbering `r : Fin f.natDegree → L` of its root multiset over an extension.
-* `TauCeti.discrSqrt`, `TauCeti.discrSqrt_sq`: the product of the differences of a numbering of
-  the distinct roots of a separable polynomial, and the fact that its square is the discriminant.
+* `TauCeti.discrSqrt`, `Polynomial.Monic.discrSqrt_sq`: the product of the differences of a
+  numbering of the distinct roots of a separable polynomial, and the fact that its square is the
+  discriminant.
 * `Polynomial.Monic.prod_roots_eval_derivative`: the product of the derivative over the root
   multiset, which is the discriminant up to the same sign. This is the shape in which the
   discriminant of a minimal polynomial is a norm.
@@ -390,41 +391,45 @@ theorem _root_.Polynomial.Monic.discr_eq_prod_roots_sub_sq {L : Type*} [CommRing
 
 section DiscrSqrt
 
-variable {F : Type*} [Field F] {E : Type*} [Field E] [Algebra F E] {f : F[X]}
+section Domain
 
-/-- Membership in the roots of a polynomial mapped to an extension field is membership in its
-root set over that extension. -/
-theorem mem_roots_map_iff_mem_rootSet {a : E} :
-    a ∈ (f.map (algebraMap F E)).roots ↔ a ∈ f.rootSet E :=
-  Polynomial.mem_aroots'.trans Polynomial.mem_rootSet'.symm
+variable {F : Type*} [CommRing F] {E : Type*} [CommRing E] [IsDomain E] [Algebra F E] {f : F[X]}
 
 /-- A numbering of the root set of a separable polynomial enumerates the whole root multiset:
 separability makes the roots simple, so the multiset is the image of the numbering. This is the
 hypothesis that the root-product formula for the discriminant takes. -/
-theorem roots_map_eq_map_numbering (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
+theorem _root_.Polynomial.Separable.roots_map_eq_map_numbering (hsep : f.Separable)
+    (e : Fin f.natDegree ≃ f.rootSet E) :
     (f.map (algebraMap F E)).roots = Multiset.map (fun i ↦ ((e i : E))) univ.val := by
+  have hmem : ∀ {a : E}, a ∈ (f.map (algebraMap F E)).roots ↔ a ∈ f.rootSet E := fun {_} ↦
+    Polynomial.mem_aroots'.trans Polynomial.mem_rootSet'.symm
   refine (Multiset.Nodup.ext (nodup_roots hsep.map) ?_).mpr ?_
   · exact univ.nodup.map fun i j h ↦ e.injective (Subtype.ext h)
   · intro a
     simp only [Multiset.mem_map, Finset.mem_val, mem_univ, true_and]
-    exact ⟨fun ha ↦ ⟨e.symm ⟨a, mem_roots_map_iff_mem_rootSet.mp ha⟩, by simp⟩,
-      fun ⟨i, hi⟩ ↦ hi ▸ mem_roots_map_iff_mem_rootSet.mpr (e i).2⟩
+    exact ⟨fun ha ↦ ⟨e.symm ⟨a, hmem.mp ha⟩, by simp⟩, fun ⟨i, hi⟩ ↦ hi ▸ hmem.mpr (e i).2⟩
 
 /-- The product `∏_{i < j} (rᵢ - rⱼ)` of the differences of the roots of `f` in `E`, taken along a
 numbering `e` of the root set.
 
-For monic separable `f` this is a square root of the discriminant, by `TauCeti.discrSqrt_sq`. It
-is only *a* square root: `TauCeti.discrSqrt_trans` shows that changing the numbering by an odd
-permutation changes the sign. The root set carries no order, so the numbering is an explicit
-argument and is never fixed globally. -/
-@[expose] def discrSqrt (e : Fin f.natDegree ≃ f.rootSet E) : E :=
+For monic separable `f` this is a square root of the discriminant, by
+`Polynomial.Monic.discrSqrt_sq`. It is only *a* square root: `TauCeti.discrSqrt_trans` shows that
+changing the numbering by an odd permutation changes the sign. The root set carries no order, so
+the numbering is an explicit argument and is never fixed globally. -/
+def discrSqrt (e : Fin f.natDegree ≃ f.rootSet E) : E :=
   ∏ i, ∏ j ∈ Ioi i, ((e i : E) - (e j : E))
+
+/-- The product formula that defines the square root of the discriminant. This is the only way the
+body of `TauCeti.discrSqrt` is read outside its own module. -/
+theorem discrSqrt_def (e : Fin f.natDegree ≃ f.rootSet E) :
+    discrSqrt e = ∏ i, ∏ j ∈ Ioi i, ((e i : E) - (e j : E)) := (rfl)
 
 /-- The defining property: the square of the product of the root differences is the discriminant.
 -/
-theorem discrSqrt_sq (hf : f.Monic) (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
+theorem _root_.Polynomial.Monic.discrSqrt_sq (hf : f.Monic) (hsep : f.Separable)
+    (e : Fin f.natDegree ≃ f.rootSet E) :
     discrSqrt e ^ 2 = algebraMap F E f.discr := by
-  rw [hf.discr_eq_prod_roots_sub_sq (roots_map_eq_map_numbering hsep e), discrSqrt,
+  rw [hf.discr_eq_prod_roots_sub_sq (hsep.roots_map_eq_map_numbering e), discrSqrt_def,
     ← Finset.prod_pow]
   exact Finset.prod_congr rfl fun i _ ↦ (Finset.prod_pow _ _ _).symm
 
@@ -434,25 +439,33 @@ theorem discrSqrt_trans (e : Fin f.natDegree ≃ f.rootSet E) (π : Equiv.Perm (
     discrSqrt (π.trans e) = Equiv.Perm.sign π • discrSqrt e := by
   have h := π.prod_Ioi_comp_eq_sign_mul_prod
     (f := fun i j ↦ ((e i : E) - (e j : E))) fun i j ↦ (neg_sub _ _).symm
-  simp only [discrSqrt, Equiv.trans_apply, h, Units.smul_def, zsmul_eq_mul]
+  simp only [discrSqrt_def, Equiv.trans_apply, h, Units.smul_def, zsmul_eq_mul]
+
+end Domain
+
+section Field
+
+variable {F : Type*} [Field F] {E : Type*} [Field E] [Algebra F E] {f : F[X]}
 
 /-- The discriminant is a square in the base field exactly when the product of the root
 differences already comes from the base field. No Galois hypothesis is involved: this is the
-elementary half of the discriminant test, and it is the reading of `TauCeti.discrSqrt_sq` in both
-directions. -/
-theorem isSquare_discr_iff_mem_range (hf : f.Monic) (hsep : f.Separable)
+elementary half of the discriminant test, and it is the reading of
+`Polynomial.Monic.discrSqrt_sq` in both directions. -/
+theorem _root_.Polynomial.Monic.isSquare_discr_iff_mem_range (hf : f.Monic) (hsep : f.Separable)
     (e : Fin f.natDegree ≃ f.rootSet E) :
     IsSquare f.discr ↔ discrSqrt e ∈ Set.range (algebraMap F E) := by
   constructor
   · rintro ⟨c, hc⟩
     have hsq : discrSqrt e * discrSqrt e = algebraMap F E c * algebraMap F E c := by
-      rw [← map_mul, ← hc, ← sq, discrSqrt_sq hf hsep]
+      rw [← map_mul, ← hc, ← sq, hf.discrSqrt_sq hsep]
     rcases mul_self_eq_mul_self_iff.mp hsq with h | h
     · exact ⟨c, h.symm⟩
     · exact ⟨-c, by rw [map_neg, ← h]⟩
   · rintro ⟨c, hc⟩
     refine ⟨c, (algebraMap F E).injective ?_⟩
-    rw [map_mul, hc, ← sq, discrSqrt_sq hf hsep]
+    rw [map_mul, hc, ← sq, hf.discrSqrt_sq hsep]
+
+end Field
 
 end DiscrSqrt
 
@@ -483,11 +496,12 @@ theorem _root_.Polynomial.Monic.discr_ne_zero_iff {K : Type*} [Field K] {f : K[X
 
 /-- A separable monic polynomial has nonzero discriminant, so the product of its root differences
 is nonzero. -/
-theorem discrSqrt_ne_zero {F E : Type*} [Field F] [Field E] [Algebra F E] {f : F[X]}
-    (hf : f.Monic) (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
+theorem _root_.Polynomial.Monic.discrSqrt_ne_zero {F E : Type*} [Field F] [Field E] [Algebra F E]
+    {f : F[X]} (hf : f.Monic) (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
     discrSqrt e ≠ 0 := by
   intro h
-  have h0 : algebraMap F E f.discr = 0 := by rw [← discrSqrt_sq hf hsep e, h, zero_pow two_ne_zero]
+  have h0 : algebraMap F E f.discr = 0 := by
+    rw [← hf.discrSqrt_sq hsep e, h, zero_pow two_ne_zero]
   exact (hf.discr_ne_zero_iff.mpr hsep)
     ((map_eq_zero_iff _ (algebraMap F E).injective).mp h0)
 

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -432,7 +432,7 @@ end Domain
 
 section Field
 
-variable {F : Type*} [Field F] {E : Type*} [Field E] [Algebra F E] {f : F[X]}
+variable {F : Type*} [Field F] {E : Type*} [CommRing E] [IsDomain E] [Algebra F E] {f : F[X]}
 
 /-- The discriminant is a square in the base field exactly when the product of the root
 differences already comes from the base field. No Galois hypothesis is involved: this is the
@@ -483,8 +483,9 @@ theorem _root_.Polynomial.Monic.discr_ne_zero_iff {K : Type*} [Field K] {f : K[X
 
 /-- A separable monic polynomial has nonzero discriminant, so the product of its root differences
 is nonzero. -/
-theorem _root_.Polynomial.Monic.discrSqrt_ne_zero {F E : Type*} [Field F] [Field E] [Algebra F E]
-    {f : F[X]} (hf : f.Monic) (hsep : f.Separable) (e : Fin f.natDegree ≃ f.rootSet E) :
+theorem _root_.Polynomial.Monic.discrSqrt_ne_zero {F E : Type*} [Field F] [CommRing E] [IsDomain E]
+    [Algebra F E] {f : F[X]} (hf : f.Monic) (hsep : f.Separable)
+    (e : Fin f.natDegree ≃ f.rootSet E) :
     discrSqrt e ≠ 0 := by
   intro h
   have h0 : algebraMap F E f.discr = 0 := by

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -15,6 +15,7 @@ public import Mathlib.RingTheory.Discriminant
 public import Mathlib.RingTheory.Localization.FractionRing
 public import Mathlib.RingTheory.Polynomial.Resultant.Basic
 import TauCeti.RingTheory.Polynomial.Resultant.Basic
+import TauCeti.RingTheory.Polynomial.Roots
 
 /-!
 # The discriminant of a polynomial as a product over pairs of roots
@@ -394,20 +395,6 @@ section DiscrSqrt
 section Domain
 
 variable {F : Type*} [CommRing F] {E : Type*} [CommRing E] [IsDomain E] [Algebra F E] {f : F[X]}
-
-/-- A numbering of the root set of a separable polynomial enumerates the whole root multiset:
-separability makes the roots simple, so the multiset is the image of the numbering. This is the
-hypothesis that the root-product formula for the discriminant takes. -/
-private theorem _root_.Polynomial.Separable.roots_map_eq_map_numbering (hsep : f.Separable)
-    (e : Fin f.natDegree ≃ f.rootSet E) :
-    (f.map (algebraMap F E)).roots = Multiset.map (fun i ↦ ((e i : E))) univ.val := by
-  have hmem : ∀ {a : E}, a ∈ (f.map (algebraMap F E)).roots ↔ a ∈ f.rootSet E := fun {_} ↦
-    Polynomial.mem_aroots'.trans Polynomial.mem_rootSet'.symm
-  refine (Multiset.Nodup.ext (nodup_roots hsep.map) ?_).mpr ?_
-  · exact univ.nodup.map fun i j h ↦ e.injective (Subtype.ext h)
-  · intro a
-    simp only [Multiset.mem_map, Finset.mem_val, mem_univ, true_and]
-    exact ⟨fun ha ↦ ⟨e.symm ⟨a, hmem.mp ha⟩, by simp⟩, fun ⟨i, hi⟩ ↦ hi ▸ hmem.mpr (e i).2⟩
 
 /-- The product `∏_{i < j} (rᵢ - rⱼ)` of the differences of the roots of `f` in `E`, taken along a
 numbering `e` of the root set.

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -413,6 +413,7 @@ theorem discrSqrt_def (e : Fin f.natDegree ≃ f.rootSet E) :
 
 /-- The defining property: the square of the product of the root differences is the discriminant.
 -/
+@[simp]
 theorem _root_.Polynomial.Monic.discrSqrt_sq (hf : f.Monic) (hsep : f.Separable)
     (e : Fin f.natDegree ≃ f.rootSet E) :
     discrSqrt e ^ 2 = algebraMap F E f.discr := by
@@ -422,6 +423,7 @@ theorem _root_.Polynomial.Monic.discrSqrt_sq (hf : f.Monic) (hsep : f.Separable)
 
 /-- Renumbering the roots by a permutation `π` multiplies the product of the root differences by
 the sign of `π`. This is the alternating behaviour that makes the discriminant test work. -/
+@[simp]
 theorem discrSqrt_trans (e : Fin f.natDegree ≃ f.rootSet E) (π : Equiv.Perm (Fin f.natDegree)) :
     discrSqrt (π.trans e) = Equiv.Perm.sign π • discrSqrt e := by
   have h := π.prod_Ioi_comp_eq_sign_mul_prod

--- a/TauCeti/RingTheory/Polynomial/Roots.lean
+++ b/TauCeti/RingTheory/Polynomial/Roots.lean
@@ -17,10 +17,8 @@ This file relates an explicit numbering of a polynomial's root set to its multis
 * `Polynomial.Separable.roots_map_eq_map_numbering`: for a separable polynomial, a numbering of
   its root set enumerates its full root multiset after base change.
 
-## Roadmap
-
-This is the root-numbering prerequisite for the square root of the discriminant in
-`TauCetiRoadmap/PolynomialGaloisGroups/README.md`, Layer 3.
+The numbering lemma lets root-product formulas be expressed as finite products indexed by
+`Fin f.natDegree`, without choosing a global order on the root set.
 -/
 
 public section

--- a/TauCeti/RingTheory/Polynomial/Roots.lean
+++ b/TauCeti/RingTheory/Polynomial/Roots.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.Separable
+
+/-!
+# Numbering the roots of a polynomial
+
+This file relates an explicit numbering of a polynomial's root set to its multiset of roots.
+
+## Main results
+
+* `Polynomial.Separable.roots_map_eq_map_numbering`: for a separable polynomial, a numbering of
+  its root set enumerates its full root multiset after base change.
+
+## Roadmap
+
+This is the root-numbering prerequisite for the square root of the discriminant in
+`TauCetiRoadmap/PolynomialGaloisGroups/README.md`, Layer 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset Polynomial
+
+variable {F : Type*} [CommRing F] {E : Type*} [CommRing E] [IsDomain E] [Algebra F E] {f : F[X]}
+
+/-- A numbering of the root set of a separable polynomial enumerates the whole root multiset:
+separability makes the roots simple, so the multiset is the image of the numbering. -/
+theorem _root_.Polynomial.Separable.roots_map_eq_map_numbering (hsep : f.Separable)
+    (e : Fin f.natDegree ≃ f.rootSet E) :
+    (f.map (algebraMap F E)).roots = Multiset.map (fun i ↦ ((e i : E))) univ.val := by
+  have hmem : ∀ {a : E}, a ∈ (f.map (algebraMap F E)).roots ↔ a ∈ f.rootSet E := fun {_} ↦
+    Polynomial.mem_aroots'.trans Polynomial.mem_rootSet'.symm
+  refine (Multiset.Nodup.ext (nodup_roots hsep.map) ?_).mpr ?_
+  · exact univ.nodup.map fun i j h ↦ e.injective (Subtype.ext h)
+  · intro a
+    simp only [Multiset.mem_map, Finset.mem_val, mem_univ, true_and]
+    exact ⟨fun ha ↦ ⟨e.symm ⟨a, hmem.mp ha⟩, by simp⟩, fun ⟨i, hi⟩ ↦ hi ▸ hmem.mpr (e i).2⟩
+
+end TauCeti


### PR DESCRIPTION
This PR proves the transformation law for the square root of the discriminant and the discriminant test that follows from it. For a monic separable `f` over a field `F` and a numbering `e : Fin f.natDegree ≃ f.rootSet E` of its roots in a splitting extension, `TauCeti.discrSqrt e` is the product `∏_{i < j} (rᵢ - rⱼ)`; `TauCeti.discrSqrt_sq` identifies its square with the image of `Polynomial.discr f`, `TauCeti.discrSqrt_trans` records that a renumbering multiplies it by the sign of the permutation, and `TauCeti.map_discrSqrt` is the law the roadmap asks for, `σ δ = sign (galActionHom σ) • δ` for an automorphism `σ` of the splitting extension. The test itself is `TauCeti.isSquare_discr_iff_range_le_alternatingGroup`: for monic separable `f` with `ringChar F ≠ 2`, `IsSquare f.discr` holds exactly when `(Polynomial.Gal.galActionHom f E).range ≤ alternatingGroup (f.rootSet E)`.

The exact roadmap target is `PolynomialGaloisGroups/README.md`, Layer 3 ("the discriminant and the alternating group"), second bullet, "The square root of the discriminant", which states `δ = ∏_{i<j} (rᵢ − rⱼ)`, the transformation law, and the test in these words. That bullet's *Needs:* line asks for the root-product formula of the first bullet, which landed in TauCeti#5434 as `Polynomial.Monic.discr_eq_prod_roots_sub_sq`, and this PR consumes it directly; the numbering of the root set is the degree bookkeeping of Layer 0, landed in TauCeti#5195. The bullet's "*False generalization*" is discharged as a theorem rather than a remark: `TauCeti.isSquare_discr_of_char_two` proves that in characteristic 2 the discriminant of *every* monic separable polynomial is a square, because `-1 = 1` makes the sign act trivially on `δ`, so the test reports "square" always and decides nothing. That is the sharp form of why `ringChar F ≠ 2` cannot be dropped, and it needs no auxiliary polynomial.

This is the most effective current step because everything else left in Layer 3 reads the test. The discriminant quadratic extension of the third bullet is defined as the splitting field of `X² − C f.discr` and is characterised by whether `f.discr` is a square, and is compared with the fixed field of the even part of the Galois image; the worked instances of the fourth bullet are statements about the image lying in the alternating group; and Layer 4's quartic decision table separates `C₄` from `D₄` over that same extension. After this PR, Layer 3 still owes the discriminant quadratic extension with its API and the worked instances (`x³ − 3x − 1` with discriminant `81`, `x³ − 2` with discriminant `−108`), together with the remaining consequences of the first bullet — the `discr (f * g)` product formula with its `resultant f g` cross term.

Adds `TauCeti/FieldTheory/GaloisGroups/Discriminant.lean` (263 lines), joining `Degree.lean` and `Orbits.lean` in the directory the roadmap's "Suggested home" section names for the Galois-theoretic half.

The proof reuses Mathlib throughout and vendors nothing. The alternating behaviour of the product of root differences is Mathlib's `Equiv.Perm.prod_Ioi_comp_eq_sign_mul_prod`, which is stated for exactly an antisymmetric `f i j` and is what makes `TauCeti.discrSqrt_trans` a three-line proof; the induced permutation of the root set is transported to `Fin f.natDegree` along the numbering with `Equiv.permCongr`, whose sign is unchanged by `Equiv.Perm.sign_permCongr`; the passage from "fixed by every automorphism" to "lies in the base field" is `IsGalois.mem_range_algebraMap_iff_fixed`; and the surjectivity of `Polynomial.Gal.restrict` onto `Polynomial.Gal` over a normal extension is Mathlib's `Polynomial.Gal.restrict_surjective`. The mathematical reference, recorded in the module docstring, is Cohen, *A Course in Computational Algebraic Number Theory*, §6.3.

Roadmap: PolynomialGaloisGroups

<!--tauceti-target:v1 {"focus":"PolynomialGaloisGroups","id":"discriminant-test-alternating-group"}-->

🤖 Prepared with Claude Code
