### PR TITLE
feat: extract a transposition by an odd power

### DIFF
--- a/TauCeti/GroupTheory/Perm/CyclePower.lean
+++ b/TauCeti/GroupTheory/Perm/CyclePower.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.GroupTheory.Perm.Cycle.Type
 
 /-!
-# Powers and cycle decompositions of permutations
+# Powers of a cycle
 
 A cycle `f` of a finite type has order the number `n = f.support.card` of points it moves
 (`Equiv.Perm.IsCycle.orderOf`), and every power `f ^ k` again moves either all of those points or
@@ -24,23 +24,15 @@ order of a power (`orderOf_pow`) and decides when a power of a cycle is again a 
 all the cycles of `f ^ k` have the *same* length, which holds because `(f ^ m) x = x` is
 equivalent to `orderOf f ∣ m` independently of the point `x` of the support.
 
-The final results apply this power calculus to a general permutation with one 2-cycle and only
-odd-length remaining cycles. The product of the odd lengths kills every remaining cycle while
-preserving the 2-cycle, so it is an explicit odd exponent whose power is a transposition.
-
 ## Main results
 
 * `Equiv.Perm.IsCycle.pow_apply_eq_self_iff`: `(f ^ n) x = x` holds for one point moved by the
   cycle exactly when it holds for all of them, namely exactly when `orderOf f ∣ n`.
 * `Equiv.Perm.IsCycle.cycleType_pow_of_not_dvd`: for `n ∤ k`, the cycle type of `f ^ k` is
   `gcd n k` copies of `n / gcd n k`.
-* `Equiv.Perm.isSwap_pow_prod_erase_two_cycleType_and_odd`: if a permutation has exactly one
-  2-cycle and all its other cycles have odd length, an explicit odd power is a transposition.
-* `Equiv.Perm.exists_odd_isSwap_pow`: the corresponding existential form.
 
-The cycle-specific declarations are stated in the `Equiv.Perm.IsCycle` namespace, giving dot
-notation from `hf : f.IsCycle`. The recognition declarations are in `Equiv.Perm`, giving dot
-notation from the permutation itself.
+The declarations are stated in the `Equiv.Perm.IsCycle` namespace, giving dot notation from
+`hf : f.IsCycle`, as upstream candidates.
 
 ## References
 
@@ -123,61 +115,5 @@ theorem _root_.Equiv.Perm.IsCycle.cycleType_pow_of_not_dvd (hf : f.IsCycle) {k :
     refine Nat.eq_of_mul_eq_mul_right hpos ?_
     rw [hsum, Nat.mul_div_cancel' hd]
   rw [hrep, hcard]
-
-/-- If a permutation has exactly one cycle of length two and every other cycle has odd length,
-then raising it to the product of those other cycle lengths gives a transposition.
-
-The exponent is itself odd. This is the cycle-theoretic step used to turn a factorization pattern
-with one quadratic factor and only odd-degree remaining factors into a transposition in a Galois
-group. -/
-theorem _root_.Equiv.Perm.isSwap_pow_prod_erase_two_cycleType_and_odd {σ : Perm α}
-    (htwo : σ.cycleType.count 2 = 1)
-    (hodd : ∀ n ∈ σ.cycleType, n ≠ 2 → Odd n) :
-    (σ ^ (σ.cycleType.erase 2).prod).IsSwap ∧ Odd (σ.cycleType.erase 2).prod := by
-  have hmem : 2 ∈ σ.cycleType := Multiset.count_pos.mp (by omega)
-  obtain ⟨c, τ, hσ, hdisj, hc, hcard⟩ := mem_cycleType_iff.mp hmem
-  have hcSwap : c.IsSwap := card_support_eq_two.mp hcard
-  have hcycleType : σ.cycleType = {2} + τ.cycleType := by
-    rw [hσ, hdisj.cycleType_mul, hc.cycleType, hcard]
-  have herase : σ.cycleType.erase 2 = τ.cycleType := by
-    rw [hcycleType]
-    simp
-  have htwoτ : 2 ∉ τ.cycleType := by
-    rw [← Multiset.count_eq_zero]
-    have : 1 + τ.cycleType.count 2 = 1 := by
-      simpa [hcycleType] using htwo
-    omega
-  have hoddτ : ∀ n ∈ τ.cycleType, Odd n := by
-    intro n hn
-    have hnσ : n ∈ σ.cycleType := by
-      rw [hcycleType, Multiset.mem_add]
-      exact Or.inr hn
-    exact (hodd n hnσ) (fun hn2 ↦ htwoτ (hn2 ▸ hn))
-  have odd_prod : ∀ s : Multiset ℕ, (∀ n ∈ s, Odd n) → Odd s.prod := by
-    intro s hs
-    induction s using Multiset.induction_on with
-    | empty => simp
-    | @cons n s ih =>
-        rw [Multiset.prod_cons]
-        exact (hs n (by simp)).mul (ih fun m hm ↦ hs m (by simp [hm]))
-  have hkodd : Odd τ.cycleType.prod := odd_prod τ.cycleType hoddτ
-  have hτpow : τ ^ τ.cycleType.prod = 1 := by
-    rw [← orderOf_dvd_iff_pow_eq_one, ← lcm_cycleType]
-    exact Multiset.lcm_dvd.mpr fun _ hn ↦ Multiset.dvd_prod hn
-  have hcpow : c ^ τ.cycleType.prod = c := by
-    have hmod : τ.cycleType.prod ≡ 1 [MOD orderOf c] := by
-      rw [hcSwap.orderOf, Nat.ModEq, Nat.odd_iff.mp hkodd]
-    exact ((pow_eq_pow_iff_modEq).mpr hmod).trans (pow_one c)
-  rw [herase, hσ, hdisj.commute.mul_pow, hcpow, hτpow, mul_one]
-  exact ⟨hcSwap, hkodd⟩
-
-/-- A permutation with exactly one 2-cycle and all remaining cycle lengths odd has an odd power
-that is a transposition. -/
-theorem _root_.Equiv.Perm.exists_odd_isSwap_pow {σ : Perm α}
-    (htwo : σ.cycleType.count 2 = 1)
-    (hodd : ∀ n ∈ σ.cycleType, n ≠ 2 → Odd n) :
-    ∃ k, Odd k ∧ (σ ^ k).IsSwap := by
-  have h := σ.isSwap_pow_prod_erase_two_cycleType_and_odd htwo hodd
-  exact ⟨(σ.cycleType.erase 2).prod, h.2, h.1⟩
 
 end TauCeti

--- a/TauCeti/GroupTheory/Perm/CyclePower.lean
+++ b/TauCeti/GroupTheory/Perm/CyclePower.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.GroupTheory.Perm.Cycle.Type
 
 /-!
-# Powers of a cycle
+# Powers and cycle decompositions of permutations
 
 A cycle `f` of a finite type has order the number `n = f.support.card` of points it moves
 (`Equiv.Perm.IsCycle.orderOf`), and every power `f ^ k` again moves either all of those points or
@@ -24,15 +24,23 @@ order of a power (`orderOf_pow`) and decides when a power of a cycle is again a 
 all the cycles of `f ^ k` have the *same* length, which holds because `(f ^ m) x = x` is
 equivalent to `orderOf f ∣ m` independently of the point `x` of the support.
 
+The final results apply this power calculus to a general permutation with one 2-cycle and only
+odd-length remaining cycles. The product of the odd lengths kills every remaining cycle while
+preserving the 2-cycle, so it is an explicit odd exponent whose power is a transposition.
+
 ## Main results
 
 * `Equiv.Perm.IsCycle.pow_apply_eq_self_iff`: `(f ^ n) x = x` holds for one point moved by the
   cycle exactly when it holds for all of them, namely exactly when `orderOf f ∣ n`.
 * `Equiv.Perm.IsCycle.cycleType_pow_of_not_dvd`: for `n ∤ k`, the cycle type of `f ^ k` is
   `gcd n k` copies of `n / gcd n k`.
+* `Equiv.Perm.isSwap_pow_prod_erase_two_cycleType_and_odd`: if a permutation has exactly one
+  2-cycle and all its other cycles have odd length, an explicit odd power is a transposition.
+* `Equiv.Perm.exists_odd_isSwap_pow`: the corresponding existential form.
 
-The declarations are stated in the `Equiv.Perm.IsCycle` namespace, giving dot notation from
-`hf : f.IsCycle`, as upstream candidates.
+The cycle-specific declarations are stated in the `Equiv.Perm.IsCycle` namespace, giving dot
+notation from `hf : f.IsCycle`. The recognition declarations are in `Equiv.Perm`, giving dot
+notation from the permutation itself.
 
 ## References
 
@@ -115,5 +123,61 @@ theorem _root_.Equiv.Perm.IsCycle.cycleType_pow_of_not_dvd (hf : f.IsCycle) {k :
     refine Nat.eq_of_mul_eq_mul_right hpos ?_
     rw [hsum, Nat.mul_div_cancel' hd]
   rw [hrep, hcard]
+
+/-- If a permutation has exactly one cycle of length two and every other cycle has odd length,
+then raising it to the product of those other cycle lengths gives a transposition.
+
+The exponent is itself odd. This is the cycle-theoretic step used to turn a factorization pattern
+with one quadratic factor and only odd-degree remaining factors into a transposition in a Galois
+group. -/
+theorem _root_.Equiv.Perm.isSwap_pow_prod_erase_two_cycleType_and_odd {σ : Perm α}
+    (htwo : σ.cycleType.count 2 = 1)
+    (hodd : ∀ n ∈ σ.cycleType, n ≠ 2 → Odd n) :
+    (σ ^ (σ.cycleType.erase 2).prod).IsSwap ∧ Odd (σ.cycleType.erase 2).prod := by
+  have hmem : 2 ∈ σ.cycleType := Multiset.count_pos.mp (by omega)
+  obtain ⟨c, τ, hσ, hdisj, hc, hcard⟩ := mem_cycleType_iff.mp hmem
+  have hcSwap : c.IsSwap := card_support_eq_two.mp hcard
+  have hcycleType : σ.cycleType = {2} + τ.cycleType := by
+    rw [hσ, hdisj.cycleType_mul, hc.cycleType, hcard]
+  have herase : σ.cycleType.erase 2 = τ.cycleType := by
+    rw [hcycleType]
+    simp
+  have htwoτ : 2 ∉ τ.cycleType := by
+    rw [← Multiset.count_eq_zero]
+    have : 1 + τ.cycleType.count 2 = 1 := by
+      simpa [hcycleType] using htwo
+    omega
+  have hoddτ : ∀ n ∈ τ.cycleType, Odd n := by
+    intro n hn
+    have hnσ : n ∈ σ.cycleType := by
+      rw [hcycleType, Multiset.mem_add]
+      exact Or.inr hn
+    exact (hodd n hnσ) (fun hn2 ↦ htwoτ (hn2 ▸ hn))
+  have odd_prod : ∀ s : Multiset ℕ, (∀ n ∈ s, Odd n) → Odd s.prod := by
+    intro s hs
+    induction s using Multiset.induction_on with
+    | empty => simp
+    | @cons n s ih =>
+        rw [Multiset.prod_cons]
+        exact (hs n (by simp)).mul (ih fun m hm ↦ hs m (by simp [hm]))
+  have hkodd : Odd τ.cycleType.prod := odd_prod τ.cycleType hoddτ
+  have hτpow : τ ^ τ.cycleType.prod = 1 := by
+    rw [← orderOf_dvd_iff_pow_eq_one, ← lcm_cycleType]
+    exact Multiset.lcm_dvd.mpr fun _ hn ↦ Multiset.dvd_prod hn
+  have hcpow : c ^ τ.cycleType.prod = c := by
+    have hmod : τ.cycleType.prod ≡ 1 [MOD orderOf c] := by
+      rw [hcSwap.orderOf, Nat.ModEq, Nat.odd_iff.mp hkodd]
+    exact ((pow_eq_pow_iff_modEq).mpr hmod).trans (pow_one c)
+  rw [herase, hσ, hdisj.commute.mul_pow, hcpow, hτpow, mul_one]
+  exact ⟨hcSwap, hkodd⟩
+
+/-- A permutation with exactly one 2-cycle and all remaining cycle lengths odd has an odd power
+that is a transposition. -/
+theorem _root_.Equiv.Perm.exists_odd_isSwap_pow {σ : Perm α}
+    (htwo : σ.cycleType.count 2 = 1)
+    (hodd : ∀ n ∈ σ.cycleType, n ≠ 2 → Odd n) :
+    ∃ k, Odd k ∧ (σ ^ k).IsSwap := by
+  have h := σ.isSwap_pow_prod_erase_two_cycleType_and_odd htwo hodd
+  exact ⟨(σ.cycleType.erase 2).prod, h.2, h.1⟩
 
 end TauCeti

--- a/TauCeti/GroupTheory/Perm/Recognition.lean
+++ b/TauCeti/GroupTheory/Perm/Recognition.lean
@@ -12,13 +12,13 @@ public import Mathlib.GroupTheory.Perm.Cycle.Type
 /-!
 # Recognizing cycles and transpositions in a permutation group
 
-This file supplies recognition steps for
-`TauCetiRoadmap/PolynomialGaloisGroups/README.md`. A transitive subgroup of a finite symmetric
-group whose degree is prime contains a full cycle: the proof combines orbit--stabilizer with
-Cauchy's theorem and the permutation-group criterion that an element of prime order in prime
-degree is a cycle. A permutation with exactly one 2-cycle and only odd-length remaining cycles
-has an explicit odd power that is a transposition: the product of the odd lengths kills every
-remaining cycle while preserving the 2-cycle.
+This file supplies permutation-group recognition steps used to recognize full symmetric groups
+from cycle data. A transitive subgroup of a finite symmetric group whose degree is prime contains
+a full cycle: the proof combines orbit--stabilizer with Cauchy's theorem and the permutation-group
+criterion that an element of prime order in prime degree is a cycle. A permutation with exactly
+one 2-cycle and only odd-length remaining cycles has an explicit odd power that is a
+transposition: the product of the odd lengths kills every remaining cycle while preserving the
+2-cycle.
 
 ## Main results
 

--- a/TauCeti/GroupTheory/Perm/Recognition.lean
+++ b/TauCeti/GroupTheory/Perm/Recognition.lean
@@ -10,13 +10,23 @@ public import Mathlib.GroupTheory.GroupAction.Transitive
 public import Mathlib.GroupTheory.Perm.Cycle.Type
 
 /-!
-# Recognition of a full cycle in prime degree
+# Recognizing cycles and transpositions in a permutation group
 
-This file supplies the first prime-degree recognition step for
-`TauCetiRoadmap/PolynomialGaloisGroups/README.md`: a transitive subgroup of a finite symmetric
-group whose degree is prime contains a full cycle. The proof combines orbit--stabilizer with
+This file supplies recognition steps for
+`TauCetiRoadmap/PolynomialGaloisGroups/README.md`. A transitive subgroup of a finite symmetric
+group whose degree is prime contains a full cycle: the proof combines orbit--stabilizer with
 Cauchy's theorem and the permutation-group criterion that an element of prime order in prime
-degree is a cycle.
+degree is a cycle. A permutation with exactly one 2-cycle and only odd-length remaining cycles
+has an explicit odd power that is a transposition: the product of the odd lengths kills every
+remaining cycle while preserving the 2-cycle.
+
+## Main results
+
+* `TauCeti.exists_isCycle_mem_of_isPretransitive_of_prime_card`: a transitive permutation group
+  of prime degree contains a full cycle.
+* `Equiv.Perm.isSwap_pow_prod_erase_two_cycleType_and_odd`: if a permutation has exactly one
+  2-cycle and all its other cycles have odd length, an explicit odd power is a transposition.
+* `Equiv.Perm.exists_odd_isSwap_pow`: the corresponding existential form.
 -/
 
 public section
@@ -55,5 +65,55 @@ theorem exists_isCycle_mem_of_isPretransitive_of_prime_card
   have hsupport : (g : Equiv.Perm α).support = Finset.univ :=
     Finset.eq_univ_of_card (g : Equiv.Perm α).support (hcycle.orderOf.symm.trans horder)
   exact ⟨g, g.property, hcycle, hsupport⟩
+
+/-- If a permutation has exactly one cycle of length two and every other cycle has odd length,
+then raising it to the product of those other cycle lengths gives a transposition.
+
+The exponent is itself odd. This is the cycle-theoretic step used to turn a factorization pattern
+with one quadratic factor and only odd-degree remaining factors into a transposition in a Galois
+group. -/
+theorem _root_.Equiv.Perm.isSwap_pow_prod_erase_two_cycleType_and_odd {σ : Equiv.Perm α}
+    (htwo : σ.cycleType.count 2 = 1)
+    (hodd : ∀ n ∈ σ.cycleType, n ≠ 2 → Odd n) :
+    (σ ^ (σ.cycleType.erase 2).prod).IsSwap ∧ Odd (σ.cycleType.erase 2).prod := by
+  have hmem : 2 ∈ σ.cycleType := Multiset.count_pos.mp (by omega)
+  obtain ⟨c, τ, hσ, hdisj, hc, hcard⟩ := Equiv.Perm.mem_cycleType_iff.mp hmem
+  have hcSwap : c.IsSwap := Equiv.Perm.card_support_eq_two.mp hcard
+  have hcycleType : σ.cycleType = {2} + τ.cycleType := by
+    rw [hσ, hdisj.cycleType_mul, hc.cycleType, hcard]
+  have herase : σ.cycleType.erase 2 = τ.cycleType := by
+    rw [hcycleType]
+    simp
+  have htwoτ : 2 ∉ τ.cycleType := by
+    rw [← Multiset.count_eq_zero]
+    have : 1 + τ.cycleType.count 2 = 1 := by
+      simpa [hcycleType] using htwo
+    omega
+  have hoddτ : ∀ n ∈ τ.cycleType, Odd n := by
+    intro n hn
+    have hnσ : n ∈ σ.cycleType := by
+      rw [hcycleType, Multiset.mem_add]
+      exact Or.inr hn
+    exact (hodd n hnσ) (fun hn2 ↦ htwoτ (hn2 ▸ hn))
+  have hkodd : Odd τ.cycleType.prod :=
+    Multiset.prod_induction Odd τ.cycleType (fun _ _ ha hb ↦ ha.mul hb) (by simp) hoddτ
+  have hτpow : τ ^ τ.cycleType.prod = 1 := by
+    rw [← orderOf_dvd_iff_pow_eq_one, ← Equiv.Perm.lcm_cycleType]
+    exact Multiset.lcm_dvd.mpr fun _ hn ↦ Multiset.dvd_prod hn
+  have hcpow : c ^ τ.cycleType.prod = c := by
+    have hmod : τ.cycleType.prod ≡ 1 [MOD orderOf c] := by
+      rw [hcSwap.orderOf, Nat.ModEq, Nat.odd_iff.mp hkodd]
+    exact ((pow_eq_pow_iff_modEq).mpr hmod).trans (pow_one c)
+  rw [herase, hσ, hdisj.commute.mul_pow, hcpow, hτpow, mul_one]
+  exact ⟨hcSwap, hkodd⟩
+
+/-- A permutation with exactly one 2-cycle and all remaining cycle lengths odd has an odd power
+that is a transposition. -/
+theorem _root_.Equiv.Perm.exists_odd_isSwap_pow {σ : Equiv.Perm α}
+    (htwo : σ.cycleType.count 2 = 1)
+    (hodd : ∀ n ∈ σ.cycleType, n ≠ 2 → Odd n) :
+    ∃ k, Odd k ∧ (σ ^ k).IsSwap := by
+  have h := σ.isSwap_pow_prod_erase_two_cycleType_and_odd htwo hodd
+  exact ⟨(σ.cycleType.erase 2).prod, h.2, h.1⟩
 
 end TauCeti

--- a/TauCeti/GroupTheory/Perm/Recognition.lean
+++ b/TauCeti/GroupTheory/Perm/Recognition.lean
@@ -27,6 +27,12 @@ transposition: the product of the odd lengths kills every remaining cycle while 
 * `Equiv.Perm.isSwap_pow_prod_erase_two_cycleType_and_odd`: if a permutation has exactly one
   2-cycle and all its other cycles have odd length, an explicit odd power is a transposition.
 * `Equiv.Perm.exists_odd_isSwap_pow`: the corresponding existential form.
+
+## References
+
+* `TauCetiRoadmap/PolynomialGaloisGroups/README.md`, which specifies both recognition steps: the
+  full cycle in a transitive group of prime degree, and the odd power of a permutation with a
+  unique 2-cycle and otherwise odd cycle lengths that is a transposition.
 -/
 
 public section

--- a/TauCeti/GroupTheory/Perm/Recognition.lean
+++ b/TauCeti/GroupTheory/Perm/Recognition.lean
@@ -12,13 +12,17 @@ public import Mathlib.GroupTheory.Perm.Cycle.Type
 /-!
 # Recognizing cycles and transpositions in a permutation group
 
-This file supplies permutation-group recognition steps used to recognize full symmetric groups
-from cycle data. A transitive subgroup of a finite symmetric group whose degree is prime contains
-a full cycle: the proof combines orbit--stabilizer with Cauchy's theorem and the permutation-group
-criterion that an element of prime order in prime degree is a cycle. A permutation with exactly
-one 2-cycle and only odd-length remaining cycles has an explicit odd power that is a
-transposition: the product of the odd lengths kills every remaining cycle while preserving the
-2-cycle.
+This file supplies recognition steps that read off structure of a permutation group from cycle
+data. A transitive subgroup of a finite symmetric group whose degree is prime contains a full
+cycle. A permutation with exactly one 2-cycle and all its other cycles of odd length has an odd
+power that is a transposition, and the exponent is given explicitly as the product of those odd
+lengths.
+
+Both feed the recognition of a full symmetric group, which needs a primitive group containing a
+transposition: a transitive group of prime degree is primitive, and a transposition is what the
+second result produces. In the Galois-theoretic application the cycle pattern of the element fed
+to the second result is the degree pattern of a factorization of a polynomial modulo a prime, read
+through the Frobenius element.
 
 ## Main results
 
@@ -27,12 +31,6 @@ transposition: the product of the odd lengths kills every remaining cycle while 
 * `Equiv.Perm.isSwap_pow_prod_erase_two_cycleType_and_odd`: if a permutation has exactly one
   2-cycle and all its other cycles have odd length, an explicit odd power is a transposition.
 * `Equiv.Perm.exists_odd_isSwap_pow`: the corresponding existential form.
-
-## References
-
-* `TauCetiRoadmap/PolynomialGaloisGroups/README.md`, which specifies both recognition steps: the
-  full cycle in a transitive group of prime degree, and the odd power of a permutation with a
-  unique 2-cycle and otherwise odd cycle lengths that is a transposition.
 -/
 
 public section


### PR DESCRIPTION
This PR proves the remaining odd-power recognition step in `PolynomialGaloisGroups/README.md`, Layer 1: a permutation with exactly one 2-cycle and only odd-length remaining cycles has an odd power that is a transposition. It gives the explicit exponent `(σ.cycleType.erase 2).prod` and the existential form `Equiv.Perm.exists_odd_isSwap_pow`.

The designated milestone is Layer 1, “The recognition theorems.” This is the most effective current step because Layer 9’s three-prime realization of `Sₙ` consumes it directly to turn the modulo-5 factorization pattern (one quadratic factor and all other factor degrees odd) into a transposition, after which Mathlib’s primitive-with-transposition theorem gives the full symmetric group. After this PR, Layer 1 still needs block-stabilizer and wreath-product infrastructure, the imprimitivity criterion, and the Jordan p-cycle theorem; the other primitive-transposition and 3-cycle recognition implications are already supplied by pinned Mathlib.

The explicit theorem extracts the unique 2-cycle from Mathlib’s cycle decomposition. The product of the other cycle lengths is odd, kills every remaining cycle through `Equiv.Perm.lcm_cycleType`, and preserves the transposition because its order is two. The proof reuses `Equiv.Perm.mem_cycleType_iff`, `Disjoint.cycleType_mul`, `Multiset.lcm_dvd`, and `pow_eq_pow_iff_modEq`; no Mathlib source is vendored.

It extends `TauCeti/GroupTheory/Perm/CyclePower.lean` by 67 lines, in the existing canonical home for power/cycle-type calculations.

Roadmap: PolynomialGaloisGroups

<!--tauceti-target:v1 {"focus":"PolynomialGaloisGroups","id":"odd-power-transposition"}-->

🤖 Prepared with Codex
