### PR TITLE
feat(ModularForms): the multiplicity-weighted composite of two slash sums

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -72,9 +72,16 @@ identifying the right-coset collision count with the multiplicity, and
 `DoubleCoset.card_pairs_mem_rightCoset_congr`, which supplies the uniformity: each right coset
 of a fixed `D` is met by the same number of pairs.
 
-⚠ The ring homomorphism `𝕋 → Module.End` is still not built here. The weighted composite is its
-analytic half; what remains is to match the sum above against the convolution product of
-`HeckeCosetModule`, whose structure constants are the same multiplicities.
+⚠ The ring homomorphism `𝕋 → Module.End` is still not built here, and the remaining gap is
+wider than a change of notation. `HeckeCosetModule.structureConstants` weights `D` by
+`DoubleCoset.multiplicity Γ₁ Γ₂ Γ₃ δ₁ δ₂ δ₃`, whereas the sum below weights it by
+`DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ δ₂⁻¹ δ₁⁻¹ δ₃⁻¹` — the factors exchanged and all three
+arguments inverted, which is what the right-coset indexing of a slash sum forces. **These are
+not equal**, and no symmetry of `multiplicity` identifies them: the two counts run over
+`Γ ⧸ (Γ ∩ gΓ'g⁻¹)` and `Γ ⧸ (Γ ∩ g⁻¹Γ'g)`, the two degrees of a double coset, and those
+differ in general. Closing the gap needs an anti-involution rather than a rewriting of
+coefficients; `HeckeRing/GLn/TransposeAntiInvolution.lean` supplies one at level `SLₙ(ℤ)`, and
+it is what makes the Hecke ring commutative there (Shimura's Proposition 3.8).
 
 ## Main results
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -100,8 +100,8 @@ it is what makes the Hecke ring commutative there (Shimura's Proposition 3.8).
   double coset. The map is an *anti*-homomorphism there, since `Module.End` composes.
 * `HeckeRing.GL2.pairCoset`: the double coset `Γ₁ (aᵥ b_w) Γ₃` that a pair of right-coset
   representatives lands in — the map the double sum is fibred over.
-* `HeckeRing.GL2.card_pairs_pairCoset_eq_multiplicity`: each right coset of a double coset `D`
-  is met by `m(D₁, D₂; D)` of the pairs, whichever right coset of `D` is chosen.
+* `HeckeRing.GL2.card_pairs_pairCoset_rightCoset_eq_multiplicity`: each right coset of a double
+  coset `D` is met by `m(D₁, D₂; D)` of the pairs, whichever right coset of `D` is chosen.
 * `HeckeRing.GL2.heckeSlashSum_heckeSlashSum_eq_sum_nsmul`: **the multiplicity-weighted
   composite**, `(f ∣[Γ₁ δ₁ Γ₂]ₖ) ∣[Γ₂ δ₂ Γ₃]ₖ = ∑_D m(D₁, D₂; D) • (f ∣[Γ₁ δ₃ Γ₃]ₖ)`, for a
   `Γ₁`-invariant `f`.
@@ -114,6 +114,21 @@ it is what makes the Hecke ring commutative there (Shimura's Proposition 3.8).
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
   §3.4: (3.4.1) defines `f ∣[Γ₁ α Γ₂]ₖ`, and the displayed computation preceding Proposition 3.37
   is the composite below.
+
+## Provenance
+
+`heckeSlashSum_heckeSlashSum_eq_sum_nsmul` and its fibre argument follow the corresponding
+result in the AINTLIB `LeanModularForms` project (Chris Birkbeck, Apache-2.0),
+<https://github.com/CBirkbeck/AINTLIB> @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
+`LeanModularForms/HeckeRIngs/GL2/HeckeActionGeneral.lean`: `heckeSlash_gen_comp_sum_eq` and
+`heckeSlash_gen_fiber_sum`. That version is stated for a single `HeckePair P` (so
+`Γ₁ = Γ₂ = Γ₃`), indexed by *left* cosets through the adjugate anti-involution its
+`HeckePairAction` supplies, and weighted by `Finsupp.sum` over Hecke-ring structure constants.
+The version here is at a general Hecke triple, right-coset indexed as `heckeSlashSum` is, needs
+no anti-involution or determinant hypothesis, and takes its coefficient from
+`DoubleCoset.multiplicity`. No code is transcribed; the shared proof shape —
+`Fintype.sum_prod_type'`, then `Finset.sum_fiberwise_of_maps_to` along the coset-of-the-product
+map, then a per-fibre collapse — is the source's, and is cited here rather than claimed.
 -/
 
 public section
@@ -237,7 +252,7 @@ of `Δ`.** Each factor lies in the double coset of an element of `Δ`, hence in 
 
 Membership in `Δ` is the point of the definition: it is what lets the product name an element of
 `HeckeCoset Δ Γ₁ Γ₃`, which is how the double sum below is partitioned. -/
-noncomputable def pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
+private noncomputable def pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
     DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) : Δ :=
   ⟨rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2, mul_mem
     (IsHeckeTriple.mem_of_mem_doubleCoset (D₁.out).2 (rightCosetRep_mem_doubleCoset D₁ p.1))
@@ -245,7 +260,7 @@ noncomputable def pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2)
 
 /-- Defining equation for `pairRep`. Since `pairRep` is not `@[expose]`, this is how a module
 downstream of this one reads the product off the pair. -/
-@[simp] lemma coe_pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
+private lemma coe_pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
     DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) :
     (pairRep D₁ D₂ p : GL (Fin 2) ℚ) = rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 := (rfl)
 
@@ -256,7 +271,7 @@ noncomputable def pairCoset (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 
   HeckeCoset.mk Γ₁ Γ₃ (pairRep D₁ D₂ p)
 
 /-- Defining equation for `pairCoset`, which is not `@[expose]` either. -/
-lemma pairCoset_def (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
+private lemma pairCoset_def (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
     DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) :
     pairCoset D₁ D₂ p = HeckeCoset.mk Γ₁ Γ₃ (pairRep D₁ D₂ p) := (rfl)
 
@@ -264,41 +279,45 @@ variable {D₁ D₂}
 variable {D : HeckeCoset Δ Γ₁ Γ₃} {p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
   DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹}
 
+/-- **`pairCoset` is characterised by membership**: a pair lies in the fibre over `D` exactly
+when the product of its two representatives lies in the double coset of `D`. -/
+@[simp] lemma pairCoset_eq_iff : pairCoset D₁ D₂ p = D ↔
+    rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 ∈
+      doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃ := by
+  constructor
+  · intro h
+    have hD := HeckeCoset.eq_iff.mp
+      ((pairCoset_def D₁ D₂ p).symm.trans (h.trans (HeckeCoset.mk_rep D).symm))
+    rw [HeckeCoset.rep_def, coe_pairRep] at hD
+    exact hD ▸ mem_doubleCoset_self Γ₁ Γ₃ _
+  · intro h
+    rw [pairCoset_def, ← HeckeCoset.mk_rep D]
+    refine HeckeCoset.eq_iff.mpr ?_
+    rw [HeckeCoset.rep_def, coe_pairRep]
+    exact doubleCoset_eq_of_mem h
+
 /-- The product of a pair lies in the double coset `pairCoset` assigns to it. -/
 lemma mem_doubleCoset_of_pairCoset_eq (h : pairCoset D₁ D₂ p = D) :
     rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 ∈
-      doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃ := by
-  have hD := HeckeCoset.eq_iff.mp
-    ((pairCoset_def D₁ D₂ p).symm.trans (h.trans (HeckeCoset.mk_rep D).symm))
-  rw [HeckeCoset.rep_def, coe_pairRep] at hD
-  exact hD ▸ mem_doubleCoset_self Γ₁ Γ₃ _
+      doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃ :=
+  pairCoset_eq_iff.mp h
 
-/-- Conversely, a pair whose product lies in one right coset `Γ₁ x` of a double coset is in the
-fibre of `pairCoset` over that double coset: a right coset is contained in the double coset it
+/-- A pair whose product lies in one right coset `Γ₁ x` of a double coset is in the fibre of
+`pairCoset` over that double coset: a right coset is contained in the double coset it
 generates, and `x` generates `D`. -/
-lemma pairCoset_eq_of_mem_rightCoset {x : GL (Fin 2) ℚ}
+private lemma pairCoset_eq_of_mem_rightCoset {x : GL (Fin 2) ℚ}
     (hx : x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃)
     (hp : rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 ∈
       MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))) :
     pairCoset D₁ D₂ p = D := by
-  have hmem : rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 ∈
-      doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃ :=
-    doubleCoset_eq_of_mem hx ▸ mem_doubleCoset.mpr
-      ⟨_, (mem_rightCoset_iff x).mp hp, 1, one_mem _, by group⟩
-  rw [pairCoset_def, ← HeckeCoset.mk_rep D]
-  refine HeckeCoset.eq_iff.mpr ?_
-  rw [HeckeCoset.rep_def, coe_pairRep]
-  exact doubleCoset_eq_of_mem hmem
+  refine pairCoset_eq_iff.mpr ?_
+  rw [← doubleCoset_eq_of_mem hx]
+  exact mem_doubleCoset.mpr ⟨_, (mem_rightCoset_iff x).mp hp, 1, one_mem _, by group⟩
 
-/-- **Every right coset of a double coset `D` is met by the same number of pairs**, namely
-Shimura's multiplicity `m(D₁, D₂; D)`.
-
-Two facts combine. The pairs that meet the right coset `Γ₁ x` are automatically in the fibre of
-`pairCoset` over `D` (`pairCoset_eq_of_mem_rightCoset`), so restricting to that fibre changes
-nothing; and the resulting count is independent of which right coset of `D` is chosen
-(`DoubleCoset.card_pairs_mem_rightCoset_congr`) and equal to the multiplicity
-(`DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity`). -/
-lemma card_pairs_pairCoset_eq_multiplicity {x : GL (Fin 2) ℚ}
+/-- **Each right coset of a double coset `D` is met by Shimura's multiplicity `m(D₁, D₂; D)`
+many pairs**, whichever `x ∈ D` names that right coset: among the pairs lying over `D`, the
+number whose product spans the right coset `Γ₁ x` does not depend on `x`. -/
+lemma card_pairs_pairCoset_rightCoset_eq_multiplicity {x : GL (Fin 2) ℚ}
     (hx : x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃) :
     Nat.card {i : {q // pairCoset D₁ D₂ q = D} //
         MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
@@ -330,15 +349,16 @@ met by the products `aᵥ b_w`, of Shimura's multiplicity times the slash sum of
 
 `(f ∣[Γ₁ δ₁ Γ₂]ₖ) ∣[Γ₂ δ₂ Γ₃]ₖ = ∑_D m(D₁, D₂; D) • (f ∣[Γ₁ δ₃ Γ₃]ₖ)`.
 
-`heckeSlashSum_heckeSlashSum_eq_heckeSlashSum` is the special case of one double coset met once
-by each pair; this is the statement the ring homomorphism from the abstract Hecke ring needs.
+`heckeSlashSum_heckeSlashSum_eq_heckeSlashSum` is the special case where the products meet a
+single double coset and meet each of its right cosets exactly once.
 
-The proof partitions the double sum of `heckeSlashSum_heckeSlashSum` along `pairCoset`. Each
-fibre is a family of representatives lying in a single double coset
-(`mem_doubleCoset_of_pairCoset_eq`) which meets every right coset of it the same number of times
-(`card_pairs_pairCoset_eq_multiplicity`), and that is exactly what
-`sum_slash_eq_nsmul_heckeSlashSum` asks for. No finiteness beyond that of the two index types is
-needed: the double cosets met are the image of a finite type. -/
+This is a composition formula for the slash action, not yet the Hecke-ring homomorphism. Its
+coefficient is `DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ δ₂⁻¹ δ₁⁻¹ δ₃⁻¹`, with the factors exchanged
+and all three arguments inverted relative to `HeckeCosetModule.structureConstants`; as the
+module docstring records, the two are not equal, and comparing them needs an anti-involution.
+
+No finiteness beyond that of the two index types is assumed: the double cosets met are the
+image of a finite type under `pairCoset`. -/
 theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul [IsHeckeTriple Δ Γ₁ Γ₃] (f : ℍ → ℂ)
     (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
     heckeSlashSum k D₂ (heckeSlashSum k D₁ f) =
@@ -353,7 +373,7 @@ theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul [IsHeckeTriple Δ Γ₁ Γ₃] 
     (Finset.univ.filter fun q ↦ pairCoset D₁ D₂ q = D) (fun q ↦ by simp)
     fun q ↦ f ∣[k] (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2)]
   exact sum_slash_eq_nsmul_heckeSlashSum k D _ _ (fun i ↦ mem_doubleCoset_of_pairCoset_eq i.2)
-    (fun _ hx ↦ card_pairs_pairCoset_eq_multiplicity hx) f hf
+    (fun _ hx ↦ card_pairs_pairCoset_rightCoset_eq_multiplicity hx) f hf
 
 end Assembly
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -100,6 +100,8 @@ it is what makes the Hecke ring commutative there (Shimura's Proposition 3.8).
   double coset. The map is an *anti*-homomorphism there, since `Module.End` composes.
 * `HeckeRing.GL2.pairCoset`: the double coset `Γ₁ (aᵥ b_w) Γ₃` that a pair of right-coset
   representatives lands in — the map the double sum is fibred over.
+* `HeckeRing.GL2.pairCoset_eq_iff`: a pair lies in the fibre over `D` exactly when the product
+  of its two representatives lies in `D`'s double coset.
 * `HeckeRing.GL2.card_pairs_pairCoset_rightCoset_eq_multiplicity`: each right coset of a double
   coset `D` is met by `m(D₁, D₂; D)` of the pairs, whichever right coset of `D` is chosen.
 * `HeckeRing.GL2.heckeSlashSum_heckeSlashSum_eq_sum_nsmul`: **the multiplicity-weighted
@@ -258,8 +260,8 @@ private noncomputable def pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL
     (IsHeckeTriple.mem_of_mem_doubleCoset (D₁.out).2 (rightCosetRep_mem_doubleCoset D₁ p.1))
     (IsHeckeTriple.mem_of_mem_doubleCoset (D₂.out).2 (rightCosetRep_mem_doubleCoset D₂ p.2))⟩
 
-/-- Defining equation for `pairRep`. Since `pairRep` is not `@[expose]`, this is how a module
-downstream of this one reads the product off the pair. -/
+/-- Defining equation for `pairRep`, used to read the product off a pair inside the proofs
+below. -/
 private lemma coe_pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
     DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) :
     (pairRep D₁ D₂ p : GL (Fin 2) ℚ) = rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 := (rfl)
@@ -270,7 +272,8 @@ noncomputable def pairCoset (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 
     DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) : HeckeCoset Δ Γ₁ Γ₃ :=
   HeckeCoset.mk Γ₁ Γ₃ (pairRep D₁ D₂ p)
 
-/-- Defining equation for `pairCoset`, which is not `@[expose]` either. -/
+/-- Defining equation for `pairCoset`, used inside the proofs below;
+`pairCoset_eq_iff` is the characterisation a caller wants. -/
 private lemma pairCoset_def (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
     DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) :
     pairCoset D₁ D₂ p = HeckeCoset.mk Γ₁ Γ₃ (pairRep D₁ D₂ p) := (rfl)
@@ -295,12 +298,6 @@ when the product of its two representatives lies in the double coset of `D`. -/
     refine HeckeCoset.eq_iff.mpr ?_
     rw [HeckeCoset.rep_def, coe_pairRep]
     exact doubleCoset_eq_of_mem h
-
-/-- The product of a pair lies in the double coset `pairCoset` assigns to it. -/
-lemma mem_doubleCoset_of_pairCoset_eq (h : pairCoset D₁ D₂ p = D) :
-    rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 ∈
-      doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃ :=
-  pairCoset_eq_iff.mp h
 
 /-- A pair whose product lies in one right coset `Γ₁ x` of a double coset is in the fibre of
 `pairCoset` over that double coset: a right coset is contained in the double coset it
@@ -359,8 +356,9 @@ module docstring records, the two are not equal, and comparing them needs an ant
 
 No finiteness beyond that of the two index types is assumed: the double cosets met are the
 image of a finite type under `pairCoset`. -/
-theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul [IsHeckeTriple Δ Γ₁ Γ₃] (f : ℍ → ℂ)
-    (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
+theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul
+    [∀ D : HeckeCoset Δ Γ₁ Γ₃, Finite (DecompQuotient Γ₃ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
+    (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
     heckeSlashSum k D₂ (heckeSlashSum k D₁ f) =
       ∑ D ∈ Finset.univ.image (pairCoset D₁ D₂),
         DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
@@ -372,7 +370,7 @@ theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul [IsHeckeTriple Δ Γ₁ Γ₃] 
   rw [Finset.sum_subtype (p := fun q ↦ pairCoset D₁ D₂ q = D)
     (Finset.univ.filter fun q ↦ pairCoset D₁ D₂ q = D) (fun q ↦ by simp)
     fun q ↦ f ∣[k] (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2)]
-  exact sum_slash_eq_nsmul_heckeSlashSum k D _ _ (fun i ↦ mem_doubleCoset_of_pairCoset_eq i.2)
+  exact sum_slash_eq_nsmul_heckeSlashSum k D _ _ (fun i ↦ pairCoset_eq_iff.mp i.2)
     (fun _ hx ↦ card_pairs_pairCoset_rightCoset_eq_multiplicity hx) f hf
 
 end Assembly

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -354,8 +354,11 @@ coefficient is `DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ δ₂⁻¹ δ₁⁻¹
 and all three arguments inverted relative to `HeckeCosetModule.structureConstants`; as the
 module docstring records, the two are not equal, and comparing them needs an anti-involution.
 
-No finiteness beyond that of the two index types is assumed: the double cosets met are the
-image of a finite type under `pairCoset`. -/
+The double cosets met are the image of a finite type under `pairCoset`, so no *index set* has
+to be assumed finite beyond the two input decomposition quotients. The right-hand side does
+need each output coset's own decomposition quotient to be finite, since `heckeSlashSum k D f`
+is a sum over it; that is the hypothesis this theorem takes, and `IsHeckeTriple Δ Γ₁ Γ₃`
+supplies it. -/
 theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul
     [∀ D : HeckeCoset Δ Γ₁ Γ₃, Finite (DecompQuotient Γ₃ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
     (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.NumberTheory.HeckeRing.Multiplicity.Handedness
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.CuspRing
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Ring
 
@@ -61,14 +62,19 @@ are identified here: `heckeSlashGamma1RingModularFormLinearMap_mul_single_single
 cusp-form companion apply both criteria at once, so the ring product of two basis elements maps
 to the composite of their operators.
 
-⚠ The general multiplicity-weighted statement — the composite as `∑_D m(D₁, D₂; D) · T_D`, and
-with it the ring homomorphism `𝕋 → Module.End` — is still **not** proved here, but its two
-counting ingredients now are. `DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity`
-reconciles the handedness, identifying the right-coset collision count with the multiplicity,
-and `DoubleCoset.card_pairs_mem_rightCoset_congr` supplies the uniformity: each right coset of
-a fixed `D` is met by the same number of pairs. What is still missing is the assembly —
-partitioning the pairs `(v, w)` according to the double coset their product lies in, for which
-the product set must be known to meet only finitely many double cosets.
+The general multiplicity-weighted statement — the composite as `∑_D m(D₁, D₂; D) · T_D` — is
+`heckeSlashSum_heckeSlashSum_eq_sum_nsmul`, in the last section below. It partitions the pairs
+`(v, w)` by the double coset their product lies in, which is what `pairCoset` names; the double
+cosets met are the image of the finite type of pairs under that map, so no finiteness beyond
+that of the two index types is needed. Its two counting ingredients are
+`DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity`, which reconciles the handedness by
+identifying the right-coset collision count with the multiplicity, and
+`DoubleCoset.card_pairs_mem_rightCoset_congr`, which supplies the uniformity: each right coset
+of a fixed `D` is met by the same number of pairs.
+
+⚠ The ring homomorphism `𝕋 → Module.End` is still not built here. The weighted composite is its
+analytic half; what remains is to match the sum above against the convolution product of
+`HeckeCosetModule`, whose structure constants are the same multiplicities.
 
 ## Main results
 
@@ -85,6 +91,13 @@ the product set must be known to meet only finitely many double cosets.
   `HeckeRing.GL2.heckeSlashGamma1CuspRingLinearMap_mul_single_single`: the ring-level reading of
   those two — the Hecke ring acts multiplicatively on basis elements whose product is a single
   double coset. The map is an *anti*-homomorphism there, since `Module.End` composes.
+* `HeckeRing.GL2.pairCoset`: the double coset `Γ₁ (aᵥ b_w) Γ₃` that a pair of right-coset
+  representatives lands in — the map the double sum is fibred over.
+* `HeckeRing.GL2.card_pairs_pairCoset_eq_multiplicity`: each right coset of a double coset `D`
+  is met by `m(D₁, D₂; D)` of the pairs, whichever right coset of `D` is chosen.
+* `HeckeRing.GL2.heckeSlashSum_heckeSlashSum_eq_sum_nsmul`: **the multiplicity-weighted
+  composite**, `(f ∣[Γ₁ δ₁ Γ₂]ₖ) ∣[Γ₂ δ₂ Γ₃]ₖ = ∑_D m(D₁, D₂; D) • (f ∣[Γ₁ δ₃ Γ₃]ₖ)`, for a
+  `Γ₁`-invariant `f`.
 * `HeckeRing.GL2.heckeSlashGamma1ModularFormEnd_mul_of_doubleCoset_eq_mul` and
   `HeckeRing.GL2.heckeSlashGamma1CuspFormEnd_mul_of_doubleCoset_eq_mul`: the same criterion for
   the Hecke operators of level `Γ₁(N)`, as an equation between endomorphisms.
@@ -205,6 +218,137 @@ theorem heckeSlashSum_heckeSlashSum_eq_heckeSlashSum
     Fintype.sum_prod_type]
 
 end Free
+
+section Assembly
+
+variable [IsHeckeTriple Δ Γ₁ Γ₂] [IsHeckeTriple Δ Γ₂ Γ₃]
+  (D₁ : HeckeCoset Δ Γ₁ Γ₂) (D₂ : HeckeCoset Δ Γ₂ Γ₃)
+
+/-- **The product `aᵥ b_w` of a right-coset representative of `D₁` and one of `D₂`, as an element
+of `Δ`.** Each factor lies in the double coset of an element of `Δ`, hence in `Δ` itself by
+`IsHeckeTriple.mem_of_mem_doubleCoset`, and a submonoid is closed under multiplication.
+
+Membership in `Δ` is the point of the definition: it is what lets the product name an element of
+`HeckeCoset Δ Γ₁ Γ₃`, which is how the double sum below is partitioned. -/
+noncomputable def pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
+    DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) : Δ :=
+  ⟨rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2, mul_mem
+    (IsHeckeTriple.mem_of_mem_doubleCoset (D₁.out).2 (rightCosetRep_mem_doubleCoset D₁ p.1))
+    (IsHeckeTriple.mem_of_mem_doubleCoset (D₂.out).2 (rightCosetRep_mem_doubleCoset D₂ p.2))⟩
+
+/-- Defining equation for `pairRep`. Since `pairRep` is not `@[expose]`, this is how a module
+downstream of this one reads the product off the pair. -/
+@[simp] lemma coe_pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
+    DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) :
+    (pairRep D₁ D₂ p : GL (Fin 2) ℚ) = rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 := (rfl)
+
+/-- **The double coset `Γ₁ (aᵥ b_w) Γ₃` a pair of representatives lands in.** This is the map the
+double sum of `heckeSlashSum_heckeSlashSum` is fibred over. -/
+noncomputable def pairCoset (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
+    DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) : HeckeCoset Δ Γ₁ Γ₃ :=
+  HeckeCoset.mk Γ₁ Γ₃ (pairRep D₁ D₂ p)
+
+/-- Defining equation for `pairCoset`, which is not `@[expose]` either. -/
+lemma pairCoset_def (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
+    DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) :
+    pairCoset D₁ D₂ p = HeckeCoset.mk Γ₁ Γ₃ (pairRep D₁ D₂ p) := (rfl)
+
+variable {D₁ D₂}
+variable {D : HeckeCoset Δ Γ₁ Γ₃} {p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
+  DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹}
+
+/-- The product of a pair lies in the double coset `pairCoset` assigns to it. -/
+lemma mem_doubleCoset_of_pairCoset_eq (h : pairCoset D₁ D₂ p = D) :
+    rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 ∈
+      doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃ := by
+  have hD := HeckeCoset.eq_iff.mp
+    ((pairCoset_def D₁ D₂ p).symm.trans (h.trans (HeckeCoset.mk_rep D).symm))
+  rw [HeckeCoset.rep_def, coe_pairRep] at hD
+  exact hD ▸ mem_doubleCoset_self Γ₁ Γ₃ _
+
+/-- Conversely, a pair whose product lies in one right coset `Γ₁ x` of a double coset is in the
+fibre of `pairCoset` over that double coset: a right coset is contained in the double coset it
+generates, and `x` generates `D`. -/
+lemma pairCoset_eq_of_mem_rightCoset {x : GL (Fin 2) ℚ}
+    (hx : x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃)
+    (hp : rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 ∈
+      MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))) :
+    pairCoset D₁ D₂ p = D := by
+  have hmem : rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 ∈
+      doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃ :=
+    doubleCoset_eq_of_mem hx ▸ mem_doubleCoset.mpr
+      ⟨_, (mem_rightCoset_iff x).mp hp, 1, one_mem _, by group⟩
+  rw [pairCoset_def, ← HeckeCoset.mk_rep D]
+  refine HeckeCoset.eq_iff.mpr ?_
+  rw [HeckeCoset.rep_def, coe_pairRep]
+  exact doubleCoset_eq_of_mem hmem
+
+/-- **Every right coset of a double coset `D` is met by the same number of pairs**, namely
+Shimura's multiplicity `m(D₁, D₂; D)`.
+
+Two facts combine. The pairs that meet the right coset `Γ₁ x` are automatically in the fibre of
+`pairCoset` over `D` (`pairCoset_eq_of_mem_rightCoset`), so restricting to that fibre changes
+nothing; and the resulting count is independent of which right coset of `D` is chosen
+(`DoubleCoset.card_pairs_mem_rightCoset_congr`) and equal to the multiplicity
+(`DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity`). -/
+lemma card_pairs_pairCoset_eq_multiplicity {x : GL (Fin 2) ℚ}
+    (hx : x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) (Γ₁ : Set (GL (Fin 2) ℚ)) Γ₃) :
+    Nat.card {i : {q // pairCoset D₁ D₂ q = D} //
+        MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
+            (Γ₁ : Set (GL (Fin 2) ℚ)) = MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))} =
+      DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
+        (D.out : GL (Fin 2) ℚ)⁻¹ := by
+  have hiff (y : GL (Fin 2) ℚ) :
+      (MulOpposite.op y • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+          MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))) ↔
+        y ∈ MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+    rw [rightCoset_eq_iff, mem_rightCoset_iff]
+    exact ⟨fun h ↦ by simpa using inv_mem h, fun h ↦ by simpa using inv_mem h⟩
+  rw [Nat.card_congr (Equiv.subtypeSubtypeEquivSubtype (p := fun q ↦ pairCoset D₁ D₂ q = D)
+      (q := fun q ↦ MulOpposite.op (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2) •
+        (Γ₁ : Set (GL (Fin 2) ℚ)) = MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)))
+      fun {q} hq ↦ pairCoset_eq_of_mem_rightCoset hx ((hiff _).mp hq)),
+    ← card_pairs_mem_rightCoset_eq_multiplicity Γ₁ Γ₂ Γ₃ (D₁.out : GL (Fin 2) ℚ)
+      (D₂.out : GL (Fin 2) ℚ) (D.out : GL (Fin 2) ℚ)]
+  simp only [hiff, rightCosetRep_def, Set.coe_ofPred]
+  exact card_pairs_mem_rightCoset_congr Γ₁ Γ₂ Γ₃ (D₁.out : GL (Fin 2) ℚ)
+    (D₂.out : GL (Fin 2) ℚ) hx
+
+variable (D₁ D₂)
+
+/-- **The multiplicity-weighted composite**, and with it the general form of the composition law.
+For a `Γ₁`-invariant `f`, the composite of the two slash sums is the sum, over the double cosets
+met by the products `aᵥ b_w`, of Shimura's multiplicity times the slash sum of that coset:
+
+`(f ∣[Γ₁ δ₁ Γ₂]ₖ) ∣[Γ₂ δ₂ Γ₃]ₖ = ∑_D m(D₁, D₂; D) • (f ∣[Γ₁ δ₃ Γ₃]ₖ)`.
+
+`heckeSlashSum_heckeSlashSum_eq_heckeSlashSum` is the special case of one double coset met once
+by each pair; this is the statement the ring homomorphism from the abstract Hecke ring needs.
+
+The proof partitions the double sum of `heckeSlashSum_heckeSlashSum` along `pairCoset`. Each
+fibre is a family of representatives lying in a single double coset
+(`mem_doubleCoset_of_pairCoset_eq`) which meets every right coset of it the same number of times
+(`card_pairs_pairCoset_eq_multiplicity`), and that is exactly what
+`sum_slash_eq_nsmul_heckeSlashSum` asks for. No finiteness beyond that of the two index types is
+needed: the double cosets met are the image of a finite type. -/
+theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul [IsHeckeTriple Δ Γ₁ Γ₃]
+    [DecidableEq (HeckeCoset Δ Γ₁ Γ₃)] (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
+    heckeSlashSum k D₂ (heckeSlashSum k D₁ f) =
+      ∑ D ∈ Finset.univ.image (pairCoset D₁ D₂),
+        DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
+          (D.out : GL (Fin 2) ℚ)⁻¹ • heckeSlashSum k D f := by
+  classical
+  rw [heckeSlashSum_heckeSlashSum, ← Fintype.sum_prod_type',
+    ← Finset.sum_fiberwise_of_maps_to (g := pairCoset D₁ D₂)
+      (fun p _ ↦ Finset.mem_image_of_mem _ (Finset.mem_univ p))]
+  refine Finset.sum_congr rfl fun D _ ↦ ?_
+  rw [Finset.sum_subtype (p := fun q ↦ pairCoset D₁ D₂ q = D)
+    (Finset.univ.filter fun q ↦ pairCoset D₁ D₂ q = D) (fun q ↦ by simp)
+    fun q ↦ f ∣[k] (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2)]
+  exact sum_slash_eq_nsmul_heckeSlashSum k D _ _ (fun i ↦ mem_doubleCoset_of_pairCoset_eq i.2)
+    (fun _ hx ↦ card_pairs_pairCoset_eq_multiplicity hx) f hf
+
+end Assembly
 
 section Gamma1
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -323,6 +323,7 @@ lemma card_pairs_pairCoset_eq_multiplicity {x : GL (Fin 2) ℚ}
 
 variable (D₁ D₂)
 
+open Classical in
 /-- **The multiplicity-weighted composite**, and with it the general form of the composition law.
 For a `Γ₁`-invariant `f`, the composite of the two slash sums is the sum, over the double cosets
 met by the products `aᵥ b_w`, of Shimura's multiplicity times the slash sum of that coset:
@@ -338,13 +339,12 @@ fibre is a family of representatives lying in a single double coset
 (`card_pairs_pairCoset_eq_multiplicity`), and that is exactly what
 `sum_slash_eq_nsmul_heckeSlashSum` asks for. No finiteness beyond that of the two index types is
 needed: the double cosets met are the image of a finite type. -/
-theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul [IsHeckeTriple Δ Γ₁ Γ₃]
-    [DecidableEq (HeckeCoset Δ Γ₁ Γ₃)] (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
+theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul [IsHeckeTriple Δ Γ₁ Γ₃] (f : ℍ → ℂ)
+    (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
     heckeSlashSum k D₂ (heckeSlashSum k D₁ f) =
       ∑ D ∈ Finset.univ.image (pairCoset D₁ D₂),
         DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
           (D.out : GL (Fin 2) ℚ)⁻¹ • heckeSlashSum k D f := by
-  classical
   rw [heckeSlashSum_heckeSlashSum, ← Fintype.sum_prod_type',
     ← Finset.sum_fiberwise_of_maps_to (g := pairCoset D₁ D₂)
       (fun p _ ↦ Finset.mem_image_of_mem _ (Finset.mem_univ p))]

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -128,9 +128,7 @@ result in the AINTLIB `LeanModularForms` project (Chris Birkbeck, Apache-2.0),
 `HeckePairAction` supplies, and weighted by `Finsupp.sum` over Hecke-ring structure constants.
 The version here is at a general Hecke triple, right-coset indexed as `heckeSlashSum` is, needs
 no anti-involution or determinant hypothesis, and takes its coefficient from
-`DoubleCoset.multiplicity`. No code is transcribed; the shared proof shape —
-`Fintype.sum_prod_type'`, then `Finset.sum_fiberwise_of_maps_to` along the coset-of-the-product
-map, then a per-fibre collapse — is the source's, and is cited here rather than claimed.
+`DoubleCoset.multiplicity`.
 -/
 
 public section
@@ -260,8 +258,8 @@ private noncomputable def pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL
     (IsHeckeTriple.mem_of_mem_doubleCoset (D₁.out).2 (rightCosetRep_mem_doubleCoset D₁ p.1))
     (IsHeckeTriple.mem_of_mem_doubleCoset (D₂.out).2 (rightCosetRep_mem_doubleCoset D₂ p.2))⟩
 
-/-- Defining equation for `pairRep`, used to read the product off a pair inside the proofs
-below. -/
+/-- The underlying matrix of `pairRep` is the product of the two right-coset
+representatives. -/
 private lemma coe_pairRep (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
     DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) :
     (pairRep D₁ D₂ p : GL (Fin 2) ℚ) = rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2 := (rfl)
@@ -272,8 +270,8 @@ noncomputable def pairCoset (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 
     DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) : HeckeCoset Δ Γ₁ Γ₃ :=
   HeckeCoset.mk Γ₁ Γ₃ (pairRep D₁ D₂ p)
 
-/-- Defining equation for `pairCoset`, used inside the proofs below;
-`pairCoset_eq_iff` is the characterisation a caller wants. -/
+/-- `pairCoset` is the double coset of `pairRep`; `pairCoset_eq_iff` characterises it by
+membership. -/
 private lemma pairCoset_def (p : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
     DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹) :
     pairCoset D₁ D₂ p = HeckeCoset.mk Γ₁ Γ₃ (pairRep D₁ D₂ p) := (rfl)
@@ -354,18 +352,21 @@ coefficient is `DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ δ₂⁻¹ δ₁⁻¹
 and all three arguments inverted relative to `HeckeCosetModule.structureConstants`; as the
 module docstring records, the two are not equal, and comparing them needs an anti-involution.
 
-The double cosets met are the image of a finite type under `pairCoset`, so no *index set* has
-to be assumed finite beyond the two input decomposition quotients. The right-hand side does
-need each output coset's own decomposition quotient to be finite, since `heckeSlashSum k D f`
-is a sum over it; that is the hypothesis this theorem takes, and `IsHeckeTriple Δ Γ₁ Γ₃`
-supplies it. -/
+No finiteness is assumed beyond the two input Hecke triples. The double cosets met are the
+image of a finite type under `pairCoset`, and the finiteness of each output coset's own
+decomposition quotient — which `heckeSlashSum k D f` sums over — comes from the composite
+triple `IsHeckeTriple Δ Γ₁ Γ₃`, which `IsHeckeTriple.trans` derives from the two given ones. -/
 theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul
-    [∀ D : HeckeCoset Δ Γ₁ Γ₃, Finite (DecompQuotient Γ₃ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
     (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
+    letI : IsHeckeTriple Δ Γ₁ Γ₃ := IsHeckeTriple.trans (H₂ := Γ₂)
     heckeSlashSum k D₂ (heckeSlashSum k D₁ f) =
       ∑ D ∈ Finset.univ.image (pairCoset D₁ D₂),
         DoubleCoset.multiplicity Γ₃ Γ₂ Γ₁ (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
           (D.out : GL (Fin 2) ℚ)⁻¹ • heckeSlashSum k D f := by
+  -- the same composite triple the statement derives; `IsHeckeTriple.trans` cannot be an
+  -- instance, since `Γ₂` does not occur in `IsHeckeTriple Δ Γ₁ Γ₃`, so it is named at both
+  -- points rather than found by synthesis
+  let _ : IsHeckeTriple Δ Γ₁ Γ₃ := IsHeckeTriple.trans (H₂ := Γ₂)
   rw [heckeSlashSum_heckeSlashSum, ← Fintype.sum_prod_type',
     ← Finset.sum_fiberwise_of_maps_to (g := pairCoset D₁ D₂)
       (fun p _ ↦ Finset.mem_image_of_mem _ (Finset.mem_univ p))]


### PR DESCRIPTION
`HeckeSlash/Composition.lean` computes the composite of two slash sums as a double sum over
the products `aᵥ b_w` of right-coset representatives, and its docstring named what was left:

> What is still missing is the assembly — partitioning the pairs `(v, w)` according to the
> double coset their product lies in […]

This is that assembly. For a `Γ₁`-invariant `f`,

```
(f ∣[Γ₁ δ₁ Γ₂]ₖ) ∣[Γ₂ δ₂ Γ₃]ₖ = ∑_D m(D₁, D₂; D) • (f ∣[Γ₁ δ₃ Γ₃]ₖ)
```

— `heckeSlashSum_heckeSlashSum_eq_sum_nsmul`, summed over the double cosets `D` the products
meet, weighted by Shimura's multiplicity. The existing
`heckeSlashSum_heckeSlashSum_eq_heckeSlashSum` is the special case of one coset met once by
each pair.

Supporting it: `pairRep` (the product `aᵥ b_w` as an element of `Δ` — that membership is what
lets it name a `HeckeCoset`), `pairCoset` (the map the double sum is fibred over), and
`card_pairs_pairCoset_eq_multiplicity`, which says each right coset of a given `D` is met by
exactly `m(D₁, D₂; D)` of the pairs. Both counting inputs already existed in
`HeckeRing/Multiplicity/Handedness.lean`: `card_pairs_mem_rightCoset_eq_multiplicity`
identifies the right-coset collision count with the multiplicity, and
`card_pairs_mem_rightCoset_congr` says the count is the same for every right coset of a fixed
double coset. What is new is the partition and the observation that restricting the count to
one fibre changes nothing, since a pair meeting a right coset of `D` is already in the fibre
over `D`.

The docstring's stated precondition turned out not to be needed: no finiteness beyond that of
the two index types is assumed, because the double cosets met are the image of the finite type
of pairs under `pairCoset`. The module docstring is updated accordingly.

The ⚠ note now also records, correctly, what still separates this from the ring homomorphism.
`HeckeCosetModule.structureConstants` weights `D` by `multiplicity Γ₁ Γ₂ Γ₃ δ₁ δ₂ δ₃`; this sum
weights it by `multiplicity Γ₃ Γ₂ Γ₁ δ₂⁻¹ δ₁⁻¹ δ₃⁻¹`. Those are **not** the same number and no
symmetry of `multiplicity` identifies them — the counts run over `Γ ⧸ (Γ ∩ gΓ'g⁻¹)` and
`Γ ⧸ (Γ ∩ g⁻¹Γ'g)`, the two degrees of a double coset, which differ in general. Closing that gap
needs an anti-involution (`HeckeRing/GLn/TransposeAntiInvolution.lean` has one at level
`SLₙ(ℤ)`), not a change of notation. An earlier draft of this note claimed the two were the same
multiplicities; that was wrong and the second commit fixes it.

Roadmap: ModularForms

New mathematics, so the citation: this supplies the analytic half of the Layer 2 target of
`TauCetiRoadmap/ModularForms/README.md` — the Hecke-ring action on the nebentypus character
spaces, `heckeRingHomCharSpace` in its Layer 2(b) sketch — and does not author it, since the
ring homomorphism itself still has to be matched against `HeckeCosetModule`'s convolution. No
`tauceti-target` marker for that reason.

Provenance: [AINTLIB](https://github.com/CBirkbeck/AINTLIB) @
`2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache 2.0,
`LeanModularForms/HeckeRIngs/GL2/HeckeActionGeneral.lean` — `heckeSlash_gen_comp_sum_eq` and
`heckeSlash_gen_fiber_sum`. That is the same theorem for a single `HeckePair P` (so
`Γ₁ = Γ₂ = Γ₃ = P.H`), stated over `Finsupp.sum` of the Hecke-ring structure constants `m`,
and indexed by the *left*-coset `decompQuot` through the adjugate anti-involution its
`HeckePairAction` supplies. The version here is at a general `IsHeckeTriple Δ Γ₁ Γ₂` /
`Γ₂ Γ₃` / `Γ₁ Γ₃`, right-coset indexed as this repository's `heckeSlashSum` is, needs no
anti-involution and no determinant hypothesis, and takes its coefficient from
`DoubleCoset.multiplicity` rather than from a Hecke-ring product. No code is transcribed, but
the proof follows the same three moves — `Fintype.sum_prod_type'`, then
`Finset.sum_fiberwise_of_maps_to` along the coset-of-the-product map, then a per-fibre collapse
— and that shape is the source's, so it is cited rather than claimed.

Mathlib has no slash sum, so nothing of this shape exists upstream; the `Finset` and `Equiv`
primitives it is built from (`sum_fiberwise_of_maps_to`, `sum_subtype`, `sum_prod_type'`,
`subtypeSubtypeEquivSubtype`) are used as they stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
