### PR TITLE
feat: define enriched DG categories and their Z0 category

### DIFF
--- a/TauCeti/CategoryTheory/DG/Basic.lean
+++ b/TauCeti/CategoryTheory/DG/Basic.lean
@@ -52,7 +52,7 @@ open CategoryTheory
 
 namespace TauCeti
 
-universe uR uC
+universe uR uC uD
 
 /-- A differential graded category over `R` is a category enriched in cochain complexes of
 `R`-modules. -/
@@ -61,7 +61,7 @@ abbrev DGCategory (R : Type uR) [CommRing R] (C : Type uC) :=
 
 /-- A differential graded functor is a functor enriched in cochain complexes of modules. -/
 abbrev DGFunctor (R : Type uR) [CommRing R] (C : Type uC) [DGCategory R C]
-    (D : Type uC) [DGCategory R D] :=
+    (D : Type uD) [DGCategory R D] :=
   EnrichedFunctor (CochainComplex (ModuleCat.{uR} R) ℤ) C D
 
 namespace DGCategory
@@ -84,7 +84,7 @@ end DGCategory
 namespace DGFunctor
 
 variable {R : Type uR} [CommRing R]
-  {C D : Type uC} [DGCategory R C] [DGCategory R D]
+  {C : Type uC} {D : Type uD} [DGCategory R C] [DGCategory R D]
 
 /-- A DG functor acts on the categories of closed degree-zero morphisms. -/
 noncomputable abbrev zerothCycles (F : DGFunctor R C D) :

--- a/TauCeti/CategoryTheory/DG/Basic.lean
+++ b/TauCeti/CategoryTheory/DG/Basic.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anthony M. Licata
+-/
+module
+
+public import Mathlib.CategoryTheory.Enriched.Opposite
+public import TauCeti.Algebra.Homology.Monoidal.Braiding
+
+/-!
+# Differential graded categories
+
+A differential graded category over a commutative ring `R` is a category enriched in cochain
+complexes of `R`-modules.  This file gives that specialization of Mathlib's enriched-category API
+a name and exposes its first ordinary shadow: the category `Z⁰(C)` whose morphisms are closed
+degree-zero elements of the enriched Hom complexes.
+
+Mathlib constructs the underlying category of an enrichment by applying coyoneda at the monoidal
+unit.  For cochain complexes, a map from the unit complex is precisely a closed degree-zero
+element, so `DGCategory.ZerothCycles C` is the requested `Z⁰` category without a second explicit
+category structure.  Enriched functors induce functors on zeroth cycles, and Mathlib's braided
+opposite supplies the expected comparison `Z⁰(Cᵒᵖ) ≌ Z⁰(C)ᵒᵖ`.
+
+The enrichment uses `TauCeti.koszulSymmetricCategory`; hence its opposite composition carries the
+Koszul braiding fixed by the `DGAInfinity` roadmap.
+
+## Main definitions
+
+* `TauCeti.DGCategory`: categories enriched in cochain complexes of modules.
+* `TauCeti.DGFunctor`: enriched functors between differential graded categories.
+* `TauCeti.DGCategory.ZerothCycles`: the category of closed degree-zero morphisms.
+* `TauCeti.DGFunctor.zerothCycles`: the induced functor on closed degree-zero morphisms.
+* `TauCeti.DGCategory.zerothCyclesOppositeEquivalence`: compatibility of `Z⁰` with opposites.
+
+This advances `TauCetiRoadmap/DGAInfinity/README.md`, Layer 1, item "DG algebras, categories,
+modules, and bimodules", specifically the enriched definition of DG categories, DG functors, the
+`Z⁰` category, and the first opposite compatibility.  The explicit homogeneous-element comparison,
+the underlying graded category, `H⁰`, tensor products, and quasi-equivalences remain separate.
+
+## References
+
+* B. Keller, *Deriving DG categories*, Section 2.
+* A. M. Licata, `CategorifiedLeech.Categorification.DGCategory` and
+  `CategorifiedLeech.Categorification.DGHomotopyCategory`, for the source-side explicit-Hom model
+  which motivated this enriched formulation.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe uR uC
+
+/-- A differential graded category over `R` is a category enriched in cochain complexes of
+`R`-modules. -/
+abbrev DGCategory (R : Type uR) [CommRing R] (C : Type uC) :=
+  EnrichedCategory (CochainComplex (ModuleCat.{uR} R) ℤ) C
+
+/-- A differential graded functor is a functor enriched in cochain complexes of modules. -/
+abbrev DGFunctor (R : Type uR) [CommRing R] (C : Type uC) [DGCategory R C]
+    (D : Type uC) [DGCategory R D] :=
+  EnrichedFunctor (CochainComplex (ModuleCat.{uR} R) ℤ) C D
+
+namespace DGCategory
+
+variable (R : Type uR) [CommRing R] (C : Type uC) [DGCategory R C]
+
+/-- The category `Z⁰(C)` of a differential graded category.  Its objects are those of `C`, and a
+morphism is a map from the monoidal unit to the enriched Hom complex, equivalently a closed
+degree-zero element. -/
+abbrev ZerothCycles :=
+  ForgetEnrichment (CochainComplex (ModuleCat.{uR} R) ℤ) C
+
+/-- Taking closed degree-zero morphisms commutes with passing to the DG opposite. -/
+noncomputable def zerothCyclesOppositeEquivalence :
+    ZerothCycles R Cᵒᵖ ≌ (ZerothCycles R C)ᵒᵖ :=
+  forgetEnrichmentOppositeEquivalence (CochainComplex (ModuleCat.{uR} R) ℤ) C
+
+end DGCategory
+
+namespace DGFunctor
+
+variable {R : Type uR} [CommRing R]
+  {C D : Type uC} [DGCategory R C] [DGCategory R D]
+
+/-- A DG functor acts on the categories of closed degree-zero morphisms. -/
+noncomputable abbrev zerothCycles (F : DGFunctor R C D) :
+    DGCategory.ZerothCycles R C ⥤ DGCategory.ZerothCycles R D :=
+  F.forget
+
+@[simp]
+theorem zerothCycles_obj (F : DGFunctor R C D) (X : C) : F.zerothCycles.obj X = F.obj X :=
+  rfl
+
+
+end DGFunctor
+
+end TauCeti

--- a/TauCeti/CategoryTheory/DG/Basic.lean
+++ b/TauCeti/CategoryTheory/DG/Basic.lean
@@ -23,7 +23,7 @@ category structure.  Enriched functors induce functors on zeroth cycles, and Mat
 opposite supplies the expected comparison `Z⁰(Cᵒᵖ) ≌ Z⁰(C)ᵒᵖ`.
 
 The enrichment uses `TauCeti.koszulSymmetricCategory`; hence its opposite composition carries the
-Koszul braiding fixed by the `DGAInfinity` roadmap.
+Koszul braiding.
 
 ## Main definitions
 
@@ -32,11 +32,8 @@ Koszul braiding fixed by the `DGAInfinity` roadmap.
 * `TauCeti.DGCategory.ZerothCycles`: the category of closed degree-zero morphisms.
 * `TauCeti.DGFunctor.zerothCycles`: the induced functor on closed degree-zero morphisms.
 * `TauCeti.DGCategory.zerothCyclesOppositeEquivalence`: compatibility of `Z⁰` with opposites.
-
-This advances `TauCetiRoadmap/DGAInfinity/README.md`, Layer 1, item "DG algebras, categories,
-modules, and bimodules", specifically the enriched definition of DG categories, DG functors, the
-`Z⁰` category, and the first opposite compatibility.  The explicit homogeneous-element comparison,
-the underlying graded category, `H⁰`, tensor products, and quasi-equivalences remain separate.
+* `CategoryTheory.EnrichedFunctor.forget_map`: the inherited normalization formula for the action
+  of `DGFunctor.zerothCycles` on a closed degree-zero morphism.
 
 ## References
 
@@ -90,11 +87,6 @@ variable {R : Type uR} [CommRing R]
 noncomputable abbrev zerothCycles (F : DGFunctor R C D) :
     DGCategory.ZerothCycles R C ⥤ DGCategory.ZerothCycles R D :=
   F.forget
-
-@[simp]
-theorem zerothCycles_obj (F : DGFunctor R C D) (X : C) : F.zerothCycles.obj X = F.obj X :=
-  rfl
-
 
 end DGFunctor
 


### PR DESCRIPTION
This PR starts the DG-category portion of the DGAInfinity roadmap using the representation the roadmap requires: enrichment in `CochainComplex (ModuleCat R) ℤ`. It names that specialization as `TauCeti.DGCategory`, names enriched functors as `TauCeti.DGFunctor`, and exposes the first ordinary shadow `DGCategory.ZerothCycles R C`.

The key API choice is to reuse Mathlib's `ForgetEnrichment` rather than define a parallel category of closed maps. Its morphisms are maps from the monoidal unit to an enriched Hom complex; for cochain complexes these are precisely closed degree-zero elements. Consequently Mathlib already supplies the category laws, and `DGFunctor.zerothCycles` is the existing enriched-functor forgetful construction; its morphism normalization is `EnrichedFunctor.forget_map`. The PR also records the canonical equivalence `Z⁰(Cᵒᵖ) ≌ Z⁰(C)ᵒᵖ`; the DG opposite uses Tau Ceti's landed Koszul braiding through Mathlib's braided enriched opposite.

This advances Layer 1, second bullet, covering the enriched definition of DG categories, DG functors, the `Z⁰` category, and its first opposite compatibility. The underlying graded category, explicit homogeneous-element comparison, `H⁰`, tensor products, full subcategories, DG natural transformations, and quasi-equivalences remain.

The organization is adapted from the explicit mapping-complex and closed-category models in `CategorifiedLeech.Categorification.DGCategory` and `CategorifiedLeech.Categorification.DGHomotopyCategory`. Those source files are credited in the module documentation; their parallel hand-written category laws are replaced here by Tau Ceti and Mathlib's existing enriched infrastructure.

Validation: `lake build TauCeti.CategoryTheory.DG.Basic`, full `lake build` (10,498 jobs), and `lake exe axioms` (100,083 declarations; only the repository allowlist).

Roadmap: DGAInfinity

<!--tauceti-target:v1 {"focus":"DGAInfinity","id":"dg-category-enrichment-z0"}-->

🤖 Prepared with Codex

