### PR TITLE
feat(Huber): the Laurent quotient is A⟨T'/s⟩ (Wedhorn's Remark 7.55)

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
@@ -904,8 +904,8 @@ theorem laurentQuotientRingEquiv_coe (ht : t ∈ T') (hsplit : ∀ u ∈ T', u �
         (weightedRestrictedSubring
       (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
         laurentRelationIdeal P T s t S hden) →+* UniformSpace.Completion S')
-      = laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht :=
-  RingHom.ext fun _ ↦ by simp only [laurentQuotientRingEquiv]; rfl
+      = laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht := by
+  simp only [laurentQuotientRingEquiv, RingEquiv.coe_ringHom_ofRingHom]
 /-- The pointwise form of `TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv_coe`. -/
 @[simp]
 theorem laurentQuotientRingEquiv_apply (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
@@ -953,8 +953,9 @@ theorem laurentQuotientRingEquiv_symm_coe (ht : t ∈ T') (hsplit : ∀ u ∈ T'
         UniformSpace.Completion S' →+* (weightedRestrictedSubring
       (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
         laurentRelationIdeal P T s t S hden))
-      = laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl :=
-  RingHom.ext fun _ ↦ by simp only [laurentQuotientRingEquiv]; rfl
+      = laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl := by
+  simp only [laurentQuotientRingEquiv, RingEquiv.ofRingHom_symm,
+    RingEquiv.coe_ringHom_ofRingHom]
 /-- The pointwise form of
 `TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv_symm_coe`. -/
 @[simp]

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
@@ -277,7 +277,8 @@ universal property
 `TauCeti.Huber.existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring` of the
 quotient. In the special case `T' = insert t T`, Wedhorn's Remark 7.55 chains such refinements and
 Proposition 8.30 reduces flatness of a general restriction map along that chain to the elementary
-one; that reduction needs the identification of the two rings, which is not proved here. -/
+one; the identification that reduction needs is
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv`, below. -/
 theorem existsUnique_continuous_ringHom_laurentQuotient_restriction (ht : t ∈ T') :
     letI := locUniformSpace P T s S hden
     letI := isUniformAddGroup_locUniformSpace P T s S hden
@@ -436,6 +437,42 @@ theorem eq_laurentQuotientRestrictionRingHom (ht : t ∈ T') :
     (existsUnique_continuous_ringHom_laurentQuotient_restriction P T s t S hden T' S' hden'
       hTT' ht).choose_spec.2 ψ ⟨hc, hC, hX⟩
 
+-- A ring homomorphism out of `A⟨T'/s⟩` that agrees with one out of `A⟨T/s⟩` after the structure
+-- maps from `A` sends the fraction `t/s` to the fraction `t/s`. Both `s`-inverses are inverses of
+-- the image of `s`, and inverses in a monoid are unique, so the two fractions correspond.
+private theorem map_divBy_of_comp_toCompletionLoc_eq {B : Type*} [CommRing B] :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    ∀ (g : UniformSpace.Completion S' →+* B) (φ : UniformSpace.Completion S →+* B),
+      g.comp (toCompletionLoc P T' s S' hden') = φ.comp (toCompletionLoc P T s S hden) →
+      g ((divBy t s : S') : UniformSpace.Completion S')
+        = φ ((divBy t s : S) : UniformSpace.Completion S) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
+  intro g φ hge
+  have hu : IsUnit (toCompletionLoc P T s S hden s) :=
+    isUnit_toCompletionLoc_of_dvd P T s S hden dvd_rfl
+  have hu' : IsUnit (toCompletionLoc P T' s S' hden' s) :=
+    isUnit_toCompletionLoc_of_dvd P T' s S' hden' dvd_rfl
+  have hgs : g (toCompletionLoc P T' s S' hden' s) = φ (toCompletionLoc P T s S hden s) :=
+    congrArg (fun k : A →+* B ↦ k s) hge
+  have hgt : g (toCompletionLoc P T' s S' hden' t) = φ (toCompletionLoc P T s S hden t) :=
+    congrArg (fun k : A →+* B ↦ k t) hge
+  -- the two inverses of `s` correspond, being inverses of the same element of `B`
+  have hginv : g ↑hu'.unit⁻¹ = ↑(hu.map φ).unit⁻¹ := by
+    refine (Units.inv_eq_of_mul_eq_one_left ?_).symm
+    rw [(hu.map φ).unit_spec, ← hgs, ← map_mul, hu'.val_inv_mul, map_one]
+  rw [← toCompletionLoc_mul_unit_inv_eq_divBy P T' s S' hden' t hu', map_mul, hginv, hgt,
+    IsUnit.unit_inv_map φ hu, ← map_mul, toCompletionLoc_mul_unit_inv_eq_divBy P T s S hden t hu]
+
 -- The fraction `t/s` downstairs goes to the class of the variable. This is where the Laurent
 -- relation is used, and it needs nothing of the target beyond the ring structure: expand both
 -- fractions, move the inverse across with `IsUnit.unit_inv_map`, and read off the relation.
@@ -465,24 +502,7 @@ private theorem apply_divBy_eq_quotientMk_weightedX :
   have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
   have _ := isHuberRing_locUniformSpace P T' s S' hden'
   intro g hge
-  have hu : IsUnit (toCompletionLoc P T s S hden s) :=
-    isUnit_toCompletionLoc_of_dvd P T s S hden dvd_rfl
-  have hu' : IsUnit (toCompletionLoc P T' s S' hden' s) :=
-    isUnit_toCompletionLoc_of_dvd P T' s S' hden' dvd_rfl
-  have hgs : g (toCompletionLoc P T' s S' hden' s)
-      = laurentStructureHom P T s t S hden (toCompletionLoc P T s S hden s) :=
-    congrArg (fun k : A →+* _ ↦ k s) hge
-  have hgt : g (toCompletionLoc P T' s S' hden' t)
-      = laurentStructureHom P T s t S hden (toCompletionLoc P T s S hden t) :=
-    congrArg (fun k : A →+* _ ↦ k t) hge
-  -- the two inverses of `s` correspond, being inverses of the same element
-  have hginv : g ↑hu'.unit⁻¹ = ↑(hu.map (laurentStructureHom P T s t S hden)).unit⁻¹ := by
-    refine (Units.inv_eq_of_mul_eq_one_left ?_).symm
-    rw [(hu.map (laurentStructureHom P T s t S hden)).unit_spec, ← hgs, ← map_mul,
-      hu'.val_inv_mul, map_one]
-  rw [← toCompletionLoc_mul_unit_inv_eq_divBy P T' s S' hden' t hu', map_mul, hginv, hgt,
-    IsUnit.unit_inv_map (laurentStructureHom P T s t S hden) hu, ← map_mul,
-    toCompletionLoc_mul_unit_inv_eq_divBy P T s S hden t hu]
+  rw [map_divBy_of_comp_toCompletionLoc_eq P T s t S hden T' S' hden' g _ hge]
   exact laurentRelationIdeal_quotientMk_weightedC P T s t S hden
 
 -- Agreement on the image of `A` propagates to all of `A⟨T/s⟩`: two continuous ring homomorphisms
@@ -519,12 +539,13 @@ private theorem comp_restrictionRingHomOfSubset_eq (hcl : letI := locUniformSpac
   have _ : T1Space (_ ⧸ laurentRelationIdeal P T s t S hden) :=
     (Ideal.Quotient.t1Space_iff _).mpr hcl
   intro g hgc hge
-  refine completion_locTopology_ringHom_ext_of_continuous P T s S hden _ _
-    (hgc.comp (continuous_restrictionRingHomOfSubset P T s S hden T' S' hden' hTT'))
-    (continuous_quotient_mk'.comp (continuous_weightedC isWeightFamily_one_weight)) ?_
-  rw [RingHom.comp_assoc,
-    restrictionRingHomOfSubset_comp_toCompletionLoc P T s S hden T' S' hden' hTT']
-  exact hge
+  exact (eq_comp_of_comp_toCompletionLoc_eq P T s S hden (toCompletionLoc P T' s S' hden')
+    ((laurentStructureHom P T s t S hden).comp (toCompletionLoc P T s S hden))
+    (restrictionRingHomOfSubset P T s S hden T' S' hden' hTT')
+    (continuous_restrictionRingHomOfSubset P T s S hden T' S' hden' hTT')
+    (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S hden T' S' hden' hTT') g hgc hge
+    (laurentStructureHom P T s t S hden)
+    (continuous_quotient_mk'.comp (continuous_weightedC isWeightFamily_one_weight)) rfl).symm
 
 /-- **The forward map of the Laurent presentation.** If every numerator of `T'` either already
 lies in `T` or is the new one `t`, there is exactly one continuous ring homomorphism
@@ -538,8 +559,9 @@ compatible with the two structure maps from `A`.
 Paired with
 `TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_laurentQuotient_restriction`
 this gives the two maps of Wedhorn's Remark 7.55, which Proposition 8.30 uses to reduce flatness
-of a general restriction map to the elementary one. Only the maps are constructed; that they are
-mutually inverse is separate work.
+of a general restriction map to the elementary one. They are mutually inverse — see
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv` and the two composite identities it is
+built from.
 
 The hypothesis beyond the splitting is what makes the target legitimate for
 `TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_completion_locTopology`: a closed
@@ -750,10 +772,9 @@ theorem eq_laurentQuotientRingHom (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
 
 end OneStep
 
-/-- **The two maps of Remark 7.55 compose to the identity of `A⟨T'/s⟩`.** Both sides are
-continuous ring homomorphisms out of a completion agreeing after the structure map from `A`, so
-`TauCeti.Huber.PairOfDefinition.completion_locTopology_ringHom_ext_of_continuous` identifies
-them. -/
+/-- **The two maps of Remark 7.55 compose to the identity of `A⟨T'/s⟩`**: going into the Laurent
+quotient and back out again is the identity of the enlarged rational localisation. -/
+@[simp]
 theorem laurentQuotientRestrictionRingHom_comp_laurentQuotientRingHom (ht : t ∈ T')
     (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
     (hcl : letI := locUniformSpace P T s S hden
@@ -786,15 +807,14 @@ theorem laurentQuotientRestrictionRingHom_comp_laurentQuotientRingHom (ht : t �
     laurentQuotientRestrictionRingHom_quotientMk_weightedC P T s t S hden T' S' hden' hTT' ht
   have hgc := continuous_laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl
   have hge := laurentQuotientRingHom_comp_toCompletionLoc P T s t S hden T' S' hden' hsplit hcl
-  refine completion_locTopology_ringHom_ext_of_continuous P T' s S' hden' _ _
-    (hψc.comp hgc) continuous_id ?_
+  refine eq_id_of_comp_toCompletionLoc_eq_self P T' s S' hden' _ (hψc.comp hgc) ?_
   rw [RingHom.comp_assoc, hge]
   exact RingHom.ext fun a ↦ (hψC _).trans <| DFunLike.congr_fun
     (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S hden T' S' hden' hTT') a
 
-/-- **The two maps of Remark 7.55 compose to the identity of the Laurent quotient.** A
-homomorphism out of a quotient is determined by its composite with the quotient map, and a
-continuous one out of `A⟨T/s⟩⟨X⟩` by its values on the constants and the variable. -/
+/-- **The two maps of Remark 7.55 compose to the identity of the Laurent quotient**: going out of
+`A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)` and back in again is its identity. -/
+@[simp]
 theorem laurentQuotientRingHom_comp_laurentQuotientRestrictionRingHom (ht : t ∈ T')
     (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
     (hcl : letI := locUniformSpace P T s S hden
@@ -894,6 +914,8 @@ noncomputable def laurentQuotientRingEquiv (ht : t ∈ T') (hsplit : ∀ u ∈ T
     (laurentQuotientRingHom_comp_laurentQuotientRestrictionRingHom P T s t S hden T' S' hden'
       hTT' ht hsplit hcl)
 
+/-- The identification coerces to
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRestrictionRingHom`, the map out of the quotient. -/
 @[simp]
 theorem laurentQuotientRingEquiv_apply (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
     (hcl : letI := locUniformSpace P T s S hden
@@ -911,9 +933,11 @@ theorem laurentQuotientRingEquiv_apply (ht : t ∈ T') (hsplit : ∀ u ∈ T', u
     letI := isTopologicalRing_locUniformSpace P T' s S' hden'
     letI := isHuberRing_locUniformSpace P T' s S' hden'
     ∀ x, laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl x
-      = laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht x :=
-  fun _ ↦ rfl
+      = laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht x := fun _ ↦ by
+  simp only [laurentQuotientRingEquiv, RingEquiv.ofRingHom_apply]
 
+/-- The inverse of the identification coerces to
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom`, the map into the quotient. -/
 @[simp]
 theorem laurentQuotientRingEquiv_symm_apply (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
     (hcl : letI := locUniformSpace P T s S hden
@@ -931,8 +955,8 @@ theorem laurentQuotientRingEquiv_symm_apply (ht : t ∈ T') (hsplit : ∀ u ∈ 
     letI := isTopologicalRing_locUniformSpace P T' s S' hden'
     letI := isHuberRing_locUniformSpace P T' s S' hden'
     ∀ x, (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).symm x
-      = laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl x :=
-  fun _ ↦ rfl
+      = laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl x := fun _ ↦ by
+  simp only [laurentQuotientRingEquiv, RingEquiv.ofRingHom_symm_apply]
 
 /-- The identification is continuous. -/
 theorem continuous_laurentQuotientRingEquiv (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
@@ -950,8 +974,9 @@ theorem continuous_laurentQuotientRingEquiv (ht : t ∈ T') (hsplit : ∀ u ∈ 
     letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
     letI := isTopologicalRing_locUniformSpace P T' s S' hden'
     letI := isHuberRing_locUniformSpace P T' s S' hden'
-    Continuous (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl) :=
-  continuous_laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht
+    Continuous (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl) := by
+  simpa only [funext (laurentQuotientRingEquiv_apply P T s t S hden T' S' hden' hTT' ht hsplit hcl)]
+    using continuous_laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht
 
 /-- The inverse of the identification is continuous, so it is a homeomorphism. -/
 theorem continuous_laurentQuotientRingEquiv_symm (ht : t ∈ T')
@@ -970,8 +995,10 @@ theorem continuous_laurentQuotientRingEquiv_symm (ht : t ∈ T')
     letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
     letI := isTopologicalRing_locUniformSpace P T' s S' hden'
     letI := isHuberRing_locUniformSpace P T' s S' hden'
-    Continuous (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).symm :=
-  continuous_laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl
+    Continuous (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).symm := by
+  simpa only
+    [funext (laurentQuotientRingEquiv_symm_apply P T s t S hden T' S' hden' hTT' ht hsplit hcl)]
+    using continuous_laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl
 
 end OneStep
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
@@ -35,11 +35,13 @@ needs one hypothesis more, to make its target a legitimate one for the universal
 topologically nilpotent `s` over a strongly noetherian `A⟨T/s⟩` gives that, and the
 `..._of_isStronglyNoetherian` forms below take those two in its place.
 
-**What is not claimed.** The two maps are constructed; that they are mutually inverse is not
-proved here. For `T' = insert t T` — the case Wedhorn's Remark 7.55 chains, one numerator at a
-time — Remark 7.55 does present `A⟨T'/s⟩` as exactly this quotient, and Proposition 8.30 consumes
-that identification. For a general enlargement no identification is even expected, since `T'` may
-adjoin numerators other than `t`; `hsplit` is what rules that out.
+**The two maps are mutually inverse**, under the same `hsplit` that the second one needs, and so
+the quotient *is* `A⟨T'/s⟩`: this is Wedhorn's Remark 7.55, proved here as
+`TauCeti.Huber.PairOfDefinition.exists_ringEquiv_laurentQuotient`. Each composite is pinned by
+the uniqueness half of one of the two universal properties, so no computation with elements is
+needed. For a general enlargement no identification is expected, since `T'` may adjoin numerators
+other than `t`; `hsplit` is what rules that out. Proposition 8.30 consumes the identification to
+reduce flatness of an arbitrary restriction map to the elementary one-numerator case.
 
 The restriction map itself, and the fact that it carries `t/s` to `t/s`, live one file earlier in
 `TauCeti.RingTheory.Huber.LocalizationTopology.Restriction`: they need only the
@@ -68,6 +70,9 @@ restriction/localisation theory, not the weighted-evaluation machinery imported 
   `TauCeti.Huber.PairOfDefinition.continuous_laurentQuotientRingHom`,
   `TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom_comp_toCompletionLoc` and
   `TauCeti.Huber.PairOfDefinition.eq_laurentQuotientRingHom` as its interface.
+* `TauCeti.Huber.PairOfDefinition.exists_ringEquiv_laurentQuotient`: **Wedhorn's Remark 7.55** —
+  the two maps are mutually inverse, so `A⟨T/s⟩⟨X⟩ ⧸ (t/s - X) ≃+* A⟨T'/s⟩`, continuously in both
+  directions and compatibly with the two structure maps from `A`.
 * `TauCeti.Huber.PairOfDefinition.isClosed_laurentRelationIdeal`: the relation ideal is closed
   when `A⟨T/s⟩` is Tate and `A⟨T/s⟩⟨X⟩` is noetherian; the `..._of_isStronglyNoetherian` variant
   takes a topologically nilpotent denominator over a strongly noetherian base instead.
@@ -224,6 +229,139 @@ private theorem isPowerBounded_quotientMk_weightedC_fraction :
     exact (isPowerBounded_weightedX (k := 1) isWeightFamily_one_weight
       rfl).map_of_isOpenMap continuous_quotient_mk'.continuousAt
       (QuotientRing.isOpenMap_coe _)
+
+section OneStep
+
+variable (T' : Finset A) (S' : Type*) [CommRing S'] [Algebra A S'] [IsLocalization.Away s S']
+  (hden' : HasDenominatorPower P T' s S') (hTT' : ∀ u ∈ T, u ∈ T')
+
+-- The abbreviation the two maps of this section are compared through: the structure map of the
+-- Laurent quotient, `a ↦ [a]` on constants.
+private noncomputable abbrev laurentStructureHom :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    UniformSpace.Completion S →+* (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden) :=
+  letI := locUniformSpace P T s S hden
+  letI := isUniformAddGroup_locUniformSpace P T s S hden
+  letI := isTopologicalRing_locUniformSpace P T s S hden
+  letI := isHuberRing_locUniformSpace P T s S hden
+  (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)).comp
+    (weightedC _ isWeightFamily_one_weight)
+
+-- Evaluating at the structure map and the class of the variable kills the Laurent relation: the
+-- two generators of `(t/s - X)` have the same image, so the ideal they span lies in the kernel.
+private theorem laurentRelationIdeal_le_ker_weightedEvalHom
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := IsHuberRing.quotient (laurentRelationIdeal P T s t S hden)
+    letI : T1Space (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+      (Ideal.Quotient.t1Space_iff _).mpr hcl
+    letI : UniformSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+      IsTopologicalAddGroup.rightUniformSpace _
+    letI : IsUniformAddGroup (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+      isUniformAddGroup_of_addCommGroup
+    letI : CompleteSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+      QuotientAddGroup.completeSpace_right _ (laurentRelationIdeal P T s t S hden).toAddSubgroup
+    ∀ (hφ : ContinuousAt (laurentStructureHom P T s t S hden) 0)
+      (hb : IsWeightBounded (laurentStructureHom P T s t S hden)
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S)))
+        (fun i ↦ Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+          (weightedX _ isWeightFamily_one_weight i))),
+      laurentRelationIdeal P T s t S hden
+        ≤ RingHom.ker (weightedEvalHom isWeightFamily_one_weight hφ hb) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  have _ := IsHuberRing.quotient (laurentRelationIdeal P T s t S hden)
+  have _ : T1Space (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    (Ideal.Quotient.t1Space_iff _).mpr hcl
+  let _ : UniformSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    IsTopologicalAddGroup.rightUniformSpace _
+  have _ : IsUniformAddGroup (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    isUniformAddGroup_of_addCommGroup
+  have _ : CompleteSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    QuotientAddGroup.completeSpace_right _ (laurentRelationIdeal P T s t S hden).toAddSubgroup
+  intro hφ hb
+  -- the evaluation identifies the two generators
+  have hrel : weightedEvalHom isWeightFamily_one_weight hφ hb
+      (weightedC _ isWeightFamily_one_weight ((divBy t s : S) : UniformSpace.Completion S))
+      = weightedEvalHom isWeightFamily_one_weight hφ hb
+        (weightedX _ isWeightFamily_one_weight 0) := by
+    rw [weightedEvalHom_weightedC, weightedEvalHom_weightedX]
+    exact laurentRelationIdeal_quotientMk_weightedC P T s t S hden
+  -- the ideal cannot be rewritten in the goal: the target's own type mentions it
+  intro x hx
+  rw [laurentRelationIdeal_def, Ideal.mem_span_singleton] at hx
+  obtain ⟨c, rfl⟩ := hx
+  rw [RingHom.mem_ker, map_mul, map_sub, hrel, sub_self, zero_mul]
+
+-- A continuous endomorphism of the Laurent quotient fixing the constants and the variable is the
+-- identity: both it and the identity solve the quotient's universal property for the same data.
+private theorem ringHom_eq_id_of_laurentQuotient (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    ∀ h : (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden) →+* (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden), Continuous h →
+      (∀ a, h (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+            (weightedC _ isWeightFamily_one_weight a))
+          = Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+            (weightedC _ isWeightFamily_one_weight a)) →
+      (∀ i, h (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+            (weightedX _ isWeightFamily_one_weight i))
+          = Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+            (weightedX _ isWeightFamily_one_weight i)) →
+      h = RingHom.id _ := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  have _ := IsHuberRing.quotient (laurentRelationIdeal P T s t S hden)
+  have _ : T1Space (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    (Ideal.Quotient.t1Space_iff _).mpr hcl
+  let _ : UniformSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    IsTopologicalAddGroup.rightUniformSpace _
+  have _ : IsUniformAddGroup (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    isUniformAddGroup_of_addCommGroup
+  have _ : CompleteSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    QuotientAddGroup.completeSpace_right _ (laurentRelationIdeal P T s t S hden).toAddSubgroup
+  intro h hc hC hX
+  have hφ : ContinuousAt (laurentStructureHom P T s t S hden) 0 :=
+    (continuous_quotient_mk'.comp (continuous_weightedC isWeightFamily_one_weight)).continuousAt
+  have hb : IsWeightBounded (laurentStructureHom P T s t S hden)
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S)))
+      (fun i ↦ Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+        (weightedX _ isWeightFamily_one_weight i)) :=
+    (isWeightBounded_one_weight_iff_forall_isPowerBounded _ _).2 fun _ ↦
+      (isPowerBounded_weightedX (k := 1) isWeightFamily_one_weight rfl).map_of_isOpenMap
+        continuous_quotient_mk'.continuousAt (QuotientRing.isOpenMap_coe _)
+  have h𝔞 := laurentRelationIdeal_le_ker_weightedEvalHom P T s t S hden hcl hφ hb
+  obtain ⟨_w, _hw, huniq⟩ := existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring
+    isWeightFamily_one_weight hφ hb h𝔞
+  exact (huniq h ⟨hc, hC, hX⟩).trans
+    (huniq (RingHom.id _) ⟨continuous_id, fun _ ↦ rfl, fun _ ↦ rfl⟩).symm
 
 section OneStep
 
@@ -404,6 +542,96 @@ theorem eq_laurentQuotientRestrictionRingHom (ht : t ∈ T') :
   exact fun ψ hc hC hX ↦
     (existsUnique_continuous_ringHom_laurentQuotient_restriction P T s t S hden T' S' hden'
       hTT' ht).choose_spec.2 ψ ⟨hc, hC, hX⟩
+
+-- The fraction `t/s` downstairs goes to the class of the variable. This is where the Laurent
+-- relation is used, and it needs nothing of the target beyond the ring structure: expand both
+-- fractions, move the inverse across with `IsUnit.unit_inv_map`, and read off the relation.
+private theorem apply_divBy_eq_quotientMk_weightedX :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    ∀ g : UniformSpace.Completion S' →+* (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+          laurentRelationIdeal P T s t S hden),
+      g.comp (toCompletionLoc P T' s S' hden')
+          = (laurentStructureHom P T s t S hden).comp (toCompletionLoc P T s S hden) →
+        g ((divBy t s : S') : UniformSpace.Completion S')
+          = Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+            (weightedX _ isWeightFamily_one_weight 0) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
+  have _ := isHuberRing_locUniformSpace P T' s S' hden'
+  intro g hge
+  have hu : IsUnit (toCompletionLoc P T s S hden s) :=
+    isUnit_toCompletionLoc_of_dvd P T s S hden dvd_rfl
+  have hu' : IsUnit (toCompletionLoc P T' s S' hden' s) :=
+    isUnit_toCompletionLoc_of_dvd P T' s S' hden' dvd_rfl
+  have hgs : g (toCompletionLoc P T' s S' hden' s)
+      = laurentStructureHom P T s t S hden (toCompletionLoc P T s S hden s) :=
+    congrArg (fun k : A →+* _ ↦ k s) hge
+  have hgt : g (toCompletionLoc P T' s S' hden' t)
+      = laurentStructureHom P T s t S hden (toCompletionLoc P T s S hden t) :=
+    congrArg (fun k : A →+* _ ↦ k t) hge
+  -- the two inverses of `s` correspond, being inverses of the same element
+  have hginv : g ↑hu'.unit⁻¹ = ↑(hu.map (laurentStructureHom P T s t S hden)).unit⁻¹ := by
+    refine (Units.inv_eq_of_mul_eq_one_left ?_).symm
+    rw [(hu.map (laurentStructureHom P T s t S hden)).unit_spec, ← hgs, ← map_mul,
+      hu'.val_inv_mul, map_one]
+  rw [← toCompletionLoc_mul_unit_inv_eq_divBy P T' s S' hden' t hu', map_mul, hginv, hgt,
+    IsUnit.unit_inv_map (laurentStructureHom P T s t S hden) hu, ← map_mul,
+    toCompletionLoc_mul_unit_inv_eq_divBy P T s S hden t hu]
+  exact laurentRelationIdeal_quotientMk_weightedC P T s t S hden
+
+-- Agreement on the image of `A` propagates to all of `A⟨T/s⟩`: two continuous ring homomorphisms
+-- out of a completion that agree after the structure map are equal.
+private theorem comp_restrictionRingHomOfSubset_eq (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    ∀ g : UniformSpace.Completion S' →+* (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+          laurentRelationIdeal P T s t S hden), Continuous g →
+      g.comp (toCompletionLoc P T' s S' hden')
+          = (laurentStructureHom P T s t S hden).comp (toCompletionLoc P T s S hden) →
+        g.comp (restrictionRingHomOfSubset P T s S hden T' S' hden' hTT')
+          = laurentStructureHom P T s t S hden := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
+  have _ := isHuberRing_locUniformSpace P T' s S' hden'
+  have _ : T1Space (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    (Ideal.Quotient.t1Space_iff _).mpr hcl
+  intro g hgc hge
+  refine completion_locTopology_ringHom_ext_of_continuous P T s S hden _ _
+    (hgc.comp (continuous_restrictionRingHomOfSubset P T s S hden T' S' hden' hTT'))
+    (continuous_quotient_mk'.comp (continuous_weightedC isWeightFamily_one_weight)) ?_
+  rw [RingHom.comp_assoc,
+    restrictionRingHomOfSubset_comp_toCompletionLoc P T s S hden T' S' hden' hTT']
+  exact hge
 
 /-- **The forward map of the Laurent presentation.** If every numerator of `T'` either already
 lies in `T` or is the new one `t`, there is exactly one continuous ring homomorphism
@@ -626,6 +854,75 @@ theorem eq_laurentQuotientRingHom (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
   exact fun g hgc hge ↦
     (existsUnique_continuous_ringHom_completion_laurentQuotient P T s t S hden T' S' hden'
       hsplit hcl).choose_spec.2 g ⟨hgc, hge⟩
+
+end OneStep
+
+/-- **Wedhorn's Remark 7.55**: when the numerators of `T'` are those of `T` together with `t`, the
+Laurent quotient *is* `A⟨T'/s⟩`. There is a ring isomorphism
+
+```text
+A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)  ≃  A⟨T'/s⟩
+```
+
+continuous in both directions and restricting to the restriction map on constants — and so
+carrying the class of `X` to `t/s`.
+
+This is the identification Proposition 8.30 consumes: it turns a statement about the Laurent
+quotient, such as its flatness over `A⟨T/s⟩`, into the same statement about `A⟨T'/s⟩`. The two
+maps are `TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom` and the map of
+`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_laurentQuotient_restriction`. -/
+theorem exists_ringEquiv_laurentQuotient (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    ∃ e : (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+          laurentRelationIdeal P T s t S hden) ≃+* UniformSpace.Completion S',
+      Continuous e ∧ Continuous e.symm ∧
+      ∀ a, e (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
+          (weightedC _ isWeightFamily_one_weight a))
+        = restrictionRingHomOfSubset P T s S hden T' S' hden' hTT' a := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
+  have _ := isHuberRing_locUniformSpace P T' s S' hden'
+  have hψc := continuous_laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht
+  have hψC :=
+    laurentQuotientRestrictionRingHom_quotientMk_weightedC P T s t S hden T' S' hden' hTT' ht
+  have hψX :=
+    laurentQuotientRestrictionRingHom_quotientMk_weightedX P T s t S hden T' S' hden' hTT' ht
+  set ψ := laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht
+  set g := laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl
+  have hgc := continuous_laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl
+  have hge := laurentQuotientRingHom_comp_toCompletionLoc P T s t S hden T' S' hden' hsplit hcl
+  refine ⟨RingEquiv.ofRingHom ψ g ?_ ?_, hψc, hgc, hψC⟩
+  -- `ψ.comp g = id`, since both composites fix the structure map of `A⟨T'/s⟩`
+  · refine completion_locTopology_ringHom_ext_of_continuous P T' s S' hden' _ _
+      (hψc.comp hgc) continuous_id ?_
+    rw [RingHom.comp_assoc, hge]
+    exact RingHom.ext fun a ↦ (hψC _).trans <| DFunLike.congr_fun
+      (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S hden T' S' hden' hTT') a
+  -- `g.comp ψ = id`, since both fix the constants and the variable
+  · exact ringHom_eq_id_of_laurentQuotient P T s t S hden hcl _ (hgc.comp hψc)
+      (fun a ↦ (congrArg g (hψC a)).trans <| DFunLike.congr_fun
+        (comp_restrictionRingHomOfSubset_eq P T s t S hden T' S' hden' hTT' hcl _ hgc hge) a)
+      (fun i ↦ by rw [Subsingleton.elim i 0, RingHom.comp_apply, hψX,
+        apply_divBy_eq_quotientMk_weightedX P T s t S hden T' S' hden' _ hge])
 
 end OneStep
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
@@ -36,12 +36,11 @@ topologically nilpotent `s` over a strongly noetherian `A⟨T/s⟩` gives that, 
 `..._of_isStronglyNoetherian` forms below take those two in its place.
 
 **The two maps are mutually inverse**, under the same `hsplit` that the second one needs, and so
-the quotient *is* `A⟨T'/s⟩`: this is Wedhorn's Remark 7.55, proved here as
-`TauCeti.Huber.PairOfDefinition.exists_ringEquiv_laurentQuotient`. Each composite is pinned by
-the uniqueness half of one of the two universal properties, so no computation with elements is
-needed. For a general enlargement no identification is expected, since `T'` may adjoin numerators
-other than `t`; `hsplit` is what rules that out. Proposition 8.30 consumes the identification to
-reduce flatness of an arbitrary restriction map to the elementary one-numerator case.
+the quotient *is* `A⟨T'/s⟩`: this is Wedhorn's Remark 7.55, and
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv` is the resulting isomorphism. For a
+general enlargement no identification is expected, since `T'` may adjoin numerators other than
+`t`; `hsplit` is what rules that out. Proposition 8.30 consumes the identification to reduce
+flatness of an arbitrary restriction map to the elementary one-numerator case.
 
 The restriction map itself, and the fact that it carries `t/s` to `t/s`, live one file earlier in
 `TauCeti.RingTheory.Huber.LocalizationTopology.Restriction`: they need only the
@@ -70,9 +69,14 @@ restriction/localisation theory, not the weighted-evaluation machinery imported 
   `TauCeti.Huber.PairOfDefinition.continuous_laurentQuotientRingHom`,
   `TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom_comp_toCompletionLoc` and
   `TauCeti.Huber.PairOfDefinition.eq_laurentQuotientRingHom` as its interface.
-* `TauCeti.Huber.PairOfDefinition.exists_ringEquiv_laurentQuotient`: **Wedhorn's Remark 7.55** —
-  the two maps are mutually inverse, so `A⟨T/s⟩⟨X⟩ ⧸ (t/s - X) ≃+* A⟨T'/s⟩`, continuously in both
-  directions and compatibly with the two structure maps from `A`.
+* `TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv`: **Wedhorn's Remark 7.55** — the two
+  maps are mutually inverse, so `A⟨T/s⟩⟨X⟩ ⧸ (t/s - X) ≃+* A⟨T'/s⟩`, with
+  `TauCeti.Huber.PairOfDefinition.continuous_laurentQuotientRingEquiv`, its `symm` form and two
+  coercion `@[simp]` lemmas as its interface. The two composite identities it is built from,
+  `TauCeti.Huber.PairOfDefinition.laurentQuotientRestrictionRingHom_comp_laurentQuotientRingHom`
+  and
+  `TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom_comp_laurentQuotientRestrictionRingHom`,
+  are available separately.
 * `TauCeti.Huber.PairOfDefinition.isClosed_laurentRelationIdeal`: the relation ideal is closed
   when `A⟨T/s⟩` is Tate and `A⟨T/s⟩⟨X⟩` is noetherian; the `..._of_isStronglyNoetherian` variant
   takes a topologically nilpotent denominator over a strongly noetherian base instead.
@@ -251,117 +255,6 @@ private noncomputable abbrev laurentStructureHom :
   letI := isHuberRing_locUniformSpace P T s S hden
   (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)).comp
     (weightedC _ isWeightFamily_one_weight)
-
--- Evaluating at the structure map and the class of the variable kills the Laurent relation: the
--- two generators of `(t/s - X)` have the same image, so the ideal they span lies in the kernel.
-private theorem laurentRelationIdeal_le_ker_weightedEvalHom
-    (hcl : letI := locUniformSpace P T s S hden
-      letI := isUniformAddGroup_locUniformSpace P T s S hden
-      letI := isTopologicalRing_locUniformSpace P T s S hden
-      letI := isHuberRing_locUniformSpace P T s S hden
-      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
-        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    letI := isHuberRing_locUniformSpace P T s S hden
-    letI := IsHuberRing.quotient (laurentRelationIdeal P T s t S hden)
-    letI : T1Space (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-      (Ideal.Quotient.t1Space_iff _).mpr hcl
-    letI : UniformSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-      IsTopologicalAddGroup.rightUniformSpace _
-    letI : IsUniformAddGroup (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-      isUniformAddGroup_of_addCommGroup
-    letI : CompleteSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-      QuotientAddGroup.completeSpace_right _ (laurentRelationIdeal P T s t S hden).toAddSubgroup
-    ∀ (hφ : ContinuousAt (laurentStructureHom P T s t S hden) 0)
-      (hb : IsWeightBounded (laurentStructureHom P T s t S hden)
-        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S)))
-        (fun i ↦ Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
-          (weightedX _ isWeightFamily_one_weight i))),
-      laurentRelationIdeal P T s t S hden
-        ≤ RingHom.ker (weightedEvalHom isWeightFamily_one_weight hφ hb) := by
-  let _ := locUniformSpace P T s S hden
-  have _ := isUniformAddGroup_locUniformSpace P T s S hden
-  have _ := isTopologicalRing_locUniformSpace P T s S hden
-  have _ := isHuberRing_locUniformSpace P T s S hden
-  have _ := IsHuberRing.quotient (laurentRelationIdeal P T s t S hden)
-  have _ : T1Space (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-    (Ideal.Quotient.t1Space_iff _).mpr hcl
-  let _ : UniformSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-    IsTopologicalAddGroup.rightUniformSpace _
-  have _ : IsUniformAddGroup (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-    isUniformAddGroup_of_addCommGroup
-  have _ : CompleteSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-    QuotientAddGroup.completeSpace_right _ (laurentRelationIdeal P T s t S hden).toAddSubgroup
-  intro hφ hb
-  -- the evaluation identifies the two generators
-  have hrel : weightedEvalHom isWeightFamily_one_weight hφ hb
-      (weightedC _ isWeightFamily_one_weight ((divBy t s : S) : UniformSpace.Completion S))
-      = weightedEvalHom isWeightFamily_one_weight hφ hb
-        (weightedX _ isWeightFamily_one_weight 0) := by
-    rw [weightedEvalHom_weightedC, weightedEvalHom_weightedX]
-    exact laurentRelationIdeal_quotientMk_weightedC P T s t S hden
-  -- the ideal cannot be rewritten in the goal: the target's own type mentions it
-  intro x hx
-  rw [laurentRelationIdeal_def, Ideal.mem_span_singleton] at hx
-  obtain ⟨c, rfl⟩ := hx
-  rw [RingHom.mem_ker, map_mul, map_sub, hrel, sub_self, zero_mul]
-
--- A continuous endomorphism of the Laurent quotient fixing the constants and the variable is the
--- identity: both it and the identity solve the quotient's universal property for the same data.
-private theorem ringHom_eq_id_of_laurentQuotient (hcl : letI := locUniformSpace P T s S hden
-      letI := isUniformAddGroup_locUniformSpace P T s S hden
-      letI := isTopologicalRing_locUniformSpace P T s S hden
-      letI := isHuberRing_locUniformSpace P T s S hden
-      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
-        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    letI := isHuberRing_locUniformSpace P T s S hden
-    ∀ h : (weightedRestrictedSubring
-      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
-        laurentRelationIdeal P T s t S hden) →+* (weightedRestrictedSubring
-      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
-        laurentRelationIdeal P T s t S hden), Continuous h →
-      (∀ a, h (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
-            (weightedC _ isWeightFamily_one_weight a))
-          = Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
-            (weightedC _ isWeightFamily_one_weight a)) →
-      (∀ i, h (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
-            (weightedX _ isWeightFamily_one_weight i))
-          = Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
-            (weightedX _ isWeightFamily_one_weight i)) →
-      h = RingHom.id _ := by
-  let _ := locUniformSpace P T s S hden
-  have _ := isUniformAddGroup_locUniformSpace P T s S hden
-  have _ := isTopologicalRing_locUniformSpace P T s S hden
-  have _ := isHuberRing_locUniformSpace P T s S hden
-  have _ := IsHuberRing.quotient (laurentRelationIdeal P T s t S hden)
-  have _ : T1Space (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-    (Ideal.Quotient.t1Space_iff _).mpr hcl
-  let _ : UniformSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-    IsTopologicalAddGroup.rightUniformSpace _
-  have _ : IsUniformAddGroup (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-    isUniformAddGroup_of_addCommGroup
-  have _ : CompleteSpace (_ ⧸ laurentRelationIdeal P T s t S hden) :=
-    QuotientAddGroup.completeSpace_right _ (laurentRelationIdeal P T s t S hden).toAddSubgroup
-  intro h hc hC hX
-  have hφ : ContinuousAt (laurentStructureHom P T s t S hden) 0 :=
-    (continuous_quotient_mk'.comp (continuous_weightedC isWeightFamily_one_weight)).continuousAt
-  have hb : IsWeightBounded (laurentStructureHom P T s t S hden)
-      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S)))
-      (fun i ↦ Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
-        (weightedX _ isWeightFamily_one_weight i)) :=
-    (isWeightBounded_one_weight_iff_forall_isPowerBounded _ _).2 fun _ ↦
-      (isPowerBounded_weightedX (k := 1) isWeightFamily_one_weight rfl).map_of_isOpenMap
-        continuous_quotient_mk'.continuousAt (QuotientRing.isOpenMap_coe _)
-  have h𝔞 := laurentRelationIdeal_le_ker_weightedEvalHom P T s t S hden hcl hφ hb
-  obtain ⟨_w, _hw, huniq⟩ := existsUnique_continuous_ringHom_quotient_weightedRestrictedSubring
-    isWeightFamily_one_weight hφ hb h𝔞
-  exact (huniq h ⟨hc, hC, hX⟩).trans
-    (huniq (RingHom.id _) ⟨continuous_id, fun _ ↦ rfl, fun _ ↦ rfl⟩).symm
 
 section OneStep
 
@@ -857,21 +750,12 @@ theorem eq_laurentQuotientRingHom (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
 
 end OneStep
 
-/-- **Wedhorn's Remark 7.55**: when the numerators of `T'` are those of `T` together with `t`, the
-Laurent quotient *is* `A⟨T'/s⟩`. There is a ring isomorphism
-
-```text
-A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)  ≃  A⟨T'/s⟩
-```
-
-continuous in both directions and restricting to the restriction map on constants — and so
-carrying the class of `X` to `t/s`.
-
-This is the identification Proposition 8.30 consumes: it turns a statement about the Laurent
-quotient, such as its flatness over `A⟨T/s⟩`, into the same statement about `A⟨T'/s⟩`. The two
-maps are `TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom` and the map of
-`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_laurentQuotient_restriction`. -/
-theorem exists_ringEquiv_laurentQuotient (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+/-- **The two maps of Remark 7.55 compose to the identity of `A⟨T'/s⟩`.** Both sides are
+continuous ring homomorphisms out of a completion agreeing after the structure map from `A`, so
+`TauCeti.Huber.PairOfDefinition.completion_locTopology_ringHom_ext_of_continuous` identifies
+them. -/
+theorem laurentQuotientRestrictionRingHom_comp_laurentQuotientRingHom (ht : t ∈ T')
+    (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
     (hcl : letI := locUniformSpace P T s S hden
       letI := isUniformAddGroup_locUniformSpace P T s S hden
       letI := isTopologicalRing_locUniformSpace P T s S hden
@@ -886,13 +770,9 @@ theorem exists_ringEquiv_laurentQuotient (ht : t ∈ T') (hsplit : ∀ u ∈ T',
     letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
     letI := isTopologicalRing_locUniformSpace P T' s S' hden'
     letI := isHuberRing_locUniformSpace P T' s S' hden'
-    ∃ e : (weightedRestrictedSubring
-        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
-          laurentRelationIdeal P T s t S hden) ≃+* UniformSpace.Completion S',
-      Continuous e ∧ Continuous e.symm ∧
-      ∀ a, e (Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)
-          (weightedC _ isWeightFamily_one_weight a))
-        = restrictionRingHomOfSubset P T s S hden T' S' hden' hTT' a := by
+    (laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht).comp
+        (laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl)
+      = RingHom.id (UniformSpace.Completion S') := by
   let _ := locUniformSpace P T s S hden
   have _ := isUniformAddGroup_locUniformSpace P T s S hden
   have _ := isTopologicalRing_locUniformSpace P T s S hden
@@ -904,25 +784,194 @@ theorem exists_ringEquiv_laurentQuotient (ht : t ∈ T') (hsplit : ∀ u ∈ T',
   have hψc := continuous_laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht
   have hψC :=
     laurentQuotientRestrictionRingHom_quotientMk_weightedC P T s t S hden T' S' hden' hTT' ht
+  have hgc := continuous_laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl
+  have hge := laurentQuotientRingHom_comp_toCompletionLoc P T s t S hden T' S' hden' hsplit hcl
+  refine completion_locTopology_ringHom_ext_of_continuous P T' s S' hden' _ _
+    (hψc.comp hgc) continuous_id ?_
+  rw [RingHom.comp_assoc, hge]
+  exact RingHom.ext fun a ↦ (hψC _).trans <| DFunLike.congr_fun
+    (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S hden T' S' hden' hTT') a
+
+/-- **The two maps of Remark 7.55 compose to the identity of the Laurent quotient.** A
+homomorphism out of a quotient is determined by its composite with the quotient map, and a
+continuous one out of `A⟨T/s⟩⟨X⟩` by its values on the constants and the variable. -/
+theorem laurentQuotientRingHom_comp_laurentQuotientRestrictionRingHom (ht : t ∈ T')
+    (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    (laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl).comp
+        (laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht)
+      = RingHom.id (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
+  have _ := isHuberRing_locUniformSpace P T' s S' hden'
+  have _ := IsHuberRing.quotient (laurentRelationIdeal P T s t S hden)
+  have _ : T1Space (_ ⧸ laurentRelationIdeal P T s t S hden) :=
+    (Ideal.Quotient.t1Space_iff _).mpr hcl
+  have hψc := continuous_laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht
+  have hψC :=
+    laurentQuotientRestrictionRingHom_quotientMk_weightedC P T s t S hden T' S' hden' hTT' ht
   have hψX :=
     laurentQuotientRestrictionRingHom_quotientMk_weightedX P T s t S hden T' S' hden' hTT' ht
-  set ψ := laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht
   set g := laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl
   have hgc := continuous_laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl
   have hge := laurentQuotientRingHom_comp_toCompletionLoc P T s t S hden T' S' hden' hsplit hcl
-  refine ⟨RingEquiv.ofRingHom ψ g ?_ ?_, hψc, hgc, hψC⟩
-  -- `ψ.comp g = id`, since both composites fix the structure map of `A⟨T'/s⟩`
-  · refine completion_locTopology_ringHom_ext_of_continuous P T' s S' hden' _ _
-      (hψc.comp hgc) continuous_id ?_
-    rw [RingHom.comp_assoc, hge]
-    exact RingHom.ext fun a ↦ (hψC _).trans <| DFunLike.congr_fun
-      (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S hden T' S' hden' hTT') a
-  -- `g.comp ψ = id`, since both fix the constants and the variable
-  · exact ringHom_eq_id_of_laurentQuotient P T s t S hden hcl _ (hgc.comp hψc)
-      (fun a ↦ (congrArg g (hψC a)).trans <| DFunLike.congr_fun
-        (comp_restrictionRingHomOfSubset_eq P T s t S hden T' S' hden' hTT' hcl _ hgc hge) a)
-      (fun i ↦ by rw [Subsingleton.elim i 0, RingHom.comp_apply, hψX,
-        apply_divBy_eq_quotientMk_weightedX P T s t S hden T' S' hden' _ hge])
+  refine Ideal.Quotient.ringHom_ext <|
+    weightedRestrictedSubring_ringHom_ext_of_continuous isWeightFamily_one_weight
+      ((hgc.comp hψc).comp continuous_quot_mk) continuous_quot_mk ?_ ?_
+  · intro a
+    exact (congrArg g (hψC a)).trans <| DFunLike.congr_fun
+      (comp_restrictionRingHomOfSubset_eq P T s t S hden T' S' hden' hTT' hcl _ hgc hge) a
+  · intro i
+    rw [Subsingleton.elim i 0]
+    exact (congrArg g (hψX 0)).trans
+      (apply_divBy_eq_quotientMk_weightedX P T s t S hden T' S' hden' _ hge)
+
+/-- **Wedhorn's Remark 7.55**: when the numerators of `T'` are those of `T` together with `t`, the
+Laurent quotient *is* `A⟨T'/s⟩`,
+
+```text
+A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)  ≃  A⟨T'/s⟩
+```
+
+the two maps already constructed being mutually inverse. This is the identification Proposition
+8.30 consumes: it turns a statement about the Laurent quotient, such as its flatness over
+`A⟨T/s⟩`, into the same statement about `A⟨T'/s⟩`.
+
+Use `TauCeti.Huber.PairOfDefinition.continuous_laurentQuotientRingEquiv` and its `symm` form for
+continuity, and the `@[simp]` lemmas below to compute: the equivalence is
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRestrictionRingHom` and its inverse is
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom`. -/
+noncomputable def laurentQuotientRingEquiv (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden) ≃+* UniformSpace.Completion S' :=
+  letI := locUniformSpace P T s S hden
+  letI := isUniformAddGroup_locUniformSpace P T s S hden
+  letI := isTopologicalRing_locUniformSpace P T s S hden
+  letI := isHuberRing_locUniformSpace P T s S hden
+  letI := locUniformSpace P T' s S' hden'
+  letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+  letI := isHuberRing_locUniformSpace P T' s S' hden'
+  RingEquiv.ofRingHom (laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht)
+    (laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl)
+    (laurentQuotientRestrictionRingHom_comp_laurentQuotientRingHom P T s t S hden T' S' hden'
+      hTT' ht hsplit hcl)
+    (laurentQuotientRingHom_comp_laurentQuotientRestrictionRingHom P T s t S hden T' S' hden'
+      hTT' ht hsplit hcl)
+
+@[simp]
+theorem laurentQuotientRingEquiv_apply (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    ∀ x, laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl x
+      = laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht x :=
+  fun _ ↦ rfl
+
+@[simp]
+theorem laurentQuotientRingEquiv_symm_apply (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    ∀ x, (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).symm x
+      = laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl x :=
+  fun _ ↦ rfl
+
+/-- The identification is continuous. -/
+theorem continuous_laurentQuotientRingEquiv (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    Continuous (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl) :=
+  continuous_laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht
+
+/-- The inverse of the identification is continuous, so it is a homeomorphism. -/
+theorem continuous_laurentQuotientRingEquiv_symm (ht : t ∈ T')
+    (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    Continuous (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).symm :=
+  continuous_laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl
 
 end OneStep
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean
@@ -437,42 +437,6 @@ theorem eq_laurentQuotientRestrictionRingHom (ht : t ∈ T') :
     (existsUnique_continuous_ringHom_laurentQuotient_restriction P T s t S hden T' S' hden'
       hTT' ht).choose_spec.2 ψ ⟨hc, hC, hX⟩
 
--- A ring homomorphism out of `A⟨T'/s⟩` that agrees with one out of `A⟨T/s⟩` after the structure
--- maps from `A` sends the fraction `t/s` to the fraction `t/s`. Both `s`-inverses are inverses of
--- the image of `s`, and inverses in a monoid are unique, so the two fractions correspond.
-private theorem map_divBy_of_comp_toCompletionLoc_eq {B : Type*} [CommRing B] :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    letI := locUniformSpace P T' s S' hden'
-    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
-    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
-    ∀ (g : UniformSpace.Completion S' →+* B) (φ : UniformSpace.Completion S →+* B),
-      g.comp (toCompletionLoc P T' s S' hden') = φ.comp (toCompletionLoc P T s S hden) →
-      g ((divBy t s : S') : UniformSpace.Completion S')
-        = φ ((divBy t s : S) : UniformSpace.Completion S) := by
-  let _ := locUniformSpace P T s S hden
-  have _ := isUniformAddGroup_locUniformSpace P T s S hden
-  have _ := isTopologicalRing_locUniformSpace P T s S hden
-  let _ := locUniformSpace P T' s S' hden'
-  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
-  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
-  intro g φ hge
-  have hu : IsUnit (toCompletionLoc P T s S hden s) :=
-    isUnit_toCompletionLoc_of_dvd P T s S hden dvd_rfl
-  have hu' : IsUnit (toCompletionLoc P T' s S' hden' s) :=
-    isUnit_toCompletionLoc_of_dvd P T' s S' hden' dvd_rfl
-  have hgs : g (toCompletionLoc P T' s S' hden' s) = φ (toCompletionLoc P T s S hden s) :=
-    congrArg (fun k : A →+* B ↦ k s) hge
-  have hgt : g (toCompletionLoc P T' s S' hden' t) = φ (toCompletionLoc P T s S hden t) :=
-    congrArg (fun k : A →+* B ↦ k t) hge
-  -- the two inverses of `s` correspond, being inverses of the same element of `B`
-  have hginv : g ↑hu'.unit⁻¹ = ↑(hu.map φ).unit⁻¹ := by
-    refine (Units.inv_eq_of_mul_eq_one_left ?_).symm
-    rw [(hu.map φ).unit_spec, ← hgs, ← map_mul, hu'.val_inv_mul, map_one]
-  rw [← toCompletionLoc_mul_unit_inv_eq_divBy P T' s S' hden' t hu', map_mul, hginv, hgt,
-    IsUnit.unit_inv_map φ hu, ← map_mul, toCompletionLoc_mul_unit_inv_eq_divBy P T s S hden t hu]
-
 -- The fraction `t/s` downstairs goes to the class of the variable. This is where the Laurent
 -- relation is used, and it needs nothing of the target beyond the ring structure: expand both
 -- fractions, move the inverse across with `IsUnit.unit_inv_map`, and read off the relation.
@@ -502,7 +466,7 @@ private theorem apply_divBy_eq_quotientMk_weightedX :
   have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
   have _ := isHuberRing_locUniformSpace P T' s S' hden'
   intro g hge
-  rw [map_divBy_of_comp_toCompletionLoc_eq P T s t S hden T' S' hden' g _ hge]
+  rw [map_divBy_of_comp_toCompletionLoc_eq P T s S hden T' S' hden' t g _ hge]
   exact laurentRelationIdeal_quotientMk_weightedC P T s t S hden
 
 -- Agreement on the image of `A` propagates to all of `A⟨T/s⟩`: two continuous ring homomorphisms
@@ -914,8 +878,35 @@ noncomputable def laurentQuotientRingEquiv (ht : t ∈ T') (hsplit : ∀ u ∈ T
     (laurentQuotientRingHom_comp_laurentQuotientRestrictionRingHom P T s t S hden T' S' hden'
       hTT' ht hsplit hcl)
 
-/-- The identification coerces to
-`TauCeti.Huber.PairOfDefinition.laurentQuotientRestrictionRingHom`, the map out of the quotient. -/
+/-- **The identification is `laurentQuotientRestrictionRingHom`**, as a ring homomorphism: it
+packages that map together with the inverse supplied by
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom`, rather than introducing a new one. -/
+@[simp]
+theorem laurentQuotientRingEquiv_coe (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    ((laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl :
+        (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden) ≃+* UniformSpace.Completion S') :
+        (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden) →+* UniformSpace.Completion S')
+      = laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht :=
+  RingHom.ext fun _ ↦ by simp only [laurentQuotientRingEquiv]; rfl
+/-- The pointwise form of `TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv_coe`. -/
 @[simp]
 theorem laurentQuotientRingEquiv_apply (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
     (hcl : letI := locUniformSpace P T s S hden
@@ -933,11 +924,39 @@ theorem laurentQuotientRingEquiv_apply (ht : t ∈ T') (hsplit : ∀ u ∈ T', u
     letI := isTopologicalRing_locUniformSpace P T' s S' hden'
     letI := isHuberRing_locUniformSpace P T' s S' hden'
     ∀ x, laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl x
-      = laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht x := fun _ ↦ by
-  simp only [laurentQuotientRingEquiv, RingEquiv.ofRingHom_apply]
+      = laurentQuotientRestrictionRingHom P T s t S hden T' S' hden' hTT' ht x :=
+  fun x ↦ DFunLike.congr_fun
+    (laurentQuotientRingEquiv_coe P T s t S hden T' S' hden' hTT' ht hsplit hcl) x
 
-/-- The inverse of the identification coerces to
-`TauCeti.Huber.PairOfDefinition.laurentQuotientRingHom`, the map into the quotient. -/
+
+/-- **The inverse of the identification is `laurentQuotientRingHom`**, as a ring homomorphism. -/
+@[simp]
+theorem laurentQuotientRingEquiv_symm_coe (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight))) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := isHuberRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    (((laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).symm :
+        UniformSpace.Completion S' ≃+* (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden)) :
+        UniformSpace.Completion S' →+* (weightedRestrictedSubring
+      (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight ⧸
+        laurentRelationIdeal P T s t S hden))
+      = laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl :=
+  RingHom.ext fun _ ↦ by simp only [laurentQuotientRingEquiv]; rfl
+/-- The pointwise form of
+`TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv_symm_coe`. -/
 @[simp]
 theorem laurentQuotientRingEquiv_symm_apply (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
     (hcl : letI := locUniformSpace P T s S hden
@@ -955,8 +974,10 @@ theorem laurentQuotientRingEquiv_symm_apply (ht : t ∈ T') (hsplit : ∀ u ∈ 
     letI := isTopologicalRing_locUniformSpace P T' s S' hden'
     letI := isHuberRing_locUniformSpace P T' s S' hden'
     ∀ x, (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).symm x
-      = laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl x := fun _ ↦ by
-  simp only [laurentQuotientRingEquiv, RingEquiv.ofRingHom_symm_apply]
+      = laurentQuotientRingHom P T s t S hden T' S' hden' hsplit hcl x :=
+  fun x ↦ DFunLike.congr_fun
+    (laurentQuotientRingEquiv_symm_coe P T s t S hden T' S' hden' hTT' ht hsplit hcl) x
+
 
 /-- The identification is continuous. -/
 theorem continuous_laurentQuotientRingEquiv (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
@@ -509,6 +509,46 @@ theorem restrictionRingHomOfSubset_comp_restrictionRingHomOfSubset (T'' : Finset
   · rw [RingHom.comp_assoc, restrictionRingHomOfSubset_comp_toCompletionLoc,
       restrictionRingHomOfSubset_comp_toCompletionLoc]
 
+/-- **A homomorphism that agrees with another after the structure maps sends `t/s` to `t/s`.**
+Given `g` out of `A⟨T'/s⟩` and `φ` out of `A⟨T/s⟩` into a common ring, agreeing after the two
+structure maps from `A`, the distinguished fractions correspond. Both `s`-inverses are inverses of
+the same element of the target, and inverses in a monoid are unique.
+
+This is the transport that identifies the fraction `t/s` across a numerator enlargement, and it
+needs nothing of the target beyond its ring structure. -/
+theorem map_divBy_of_comp_toCompletionLoc_eq (t : A) {B : Type*} [CommRing B] :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    ∀ (g : UniformSpace.Completion S' →+* B) (φ : UniformSpace.Completion S →+* B),
+      g.comp (toCompletionLoc P T' s S' hden') = φ.comp (toCompletionLoc P T s S hden) →
+      g ((divBy t s : S') : UniformSpace.Completion S')
+        = φ ((divBy t s : S) : UniformSpace.Completion S) := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T' s S' hden'
+  intro g φ hge
+  have hu : IsUnit (toCompletionLoc P T s S hden s) :=
+    isUnit_toCompletionLoc_of_dvd P T s S hden dvd_rfl
+  have hu' : IsUnit (toCompletionLoc P T' s S' hden' s) :=
+    isUnit_toCompletionLoc_of_dvd P T' s S' hden' dvd_rfl
+  have hgs : g (toCompletionLoc P T' s S' hden' s) = φ (toCompletionLoc P T s S hden s) :=
+    congrArg (fun k : A →+* B ↦ k s) hge
+  have hgt : g (toCompletionLoc P T' s S' hden' t) = φ (toCompletionLoc P T s S hden t) :=
+    congrArg (fun k : A →+* B ↦ k t) hge
+  -- the two inverses of `s` correspond, being inverses of the same element of `B`
+  have hginv : g ↑hu'.unit⁻¹ = ↑(hu.map φ).unit⁻¹ := by
+    refine (Units.inv_eq_of_mul_eq_one_left ?_).symm
+    rw [(hu.map φ).unit_spec, ← hgs, ← map_mul, hu'.val_inv_mul, map_one]
+  rw [← toCompletionLoc_mul_unit_inv_eq_divBy P T' s S' hden' t hu', map_mul, hginv, hgt,
+    IsUnit.unit_inv_map φ hu, ← map_mul, toCompletionLoc_mul_unit_inv_eq_divBy P T s S hden t hu]
+
 end Subset
 
 end PairOfDefinition

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
@@ -516,7 +516,7 @@ the same element of the target, and inverses in a monoid are unique.
 
 This is the transport that identifies the fraction `t/s` across a numerator enlargement, and it
 needs nothing of the target beyond its ring structure. -/
-theorem map_divBy_of_comp_toCompletionLoc_eq (t : A) {B : Type*} [CommRing B] :
+theorem map_divBy_of_comp_toCompletionLoc_eq (t : A) {B : Type*} [Semiring B] :
     letI := locUniformSpace P T s S hden
     letI := isUniformAddGroup_locUniformSpace P T s S hden
     letI := isTopologicalRing_locUniformSpace P T s S hden


### PR DESCRIPTION
Wedhorn's Remark 7.55 says the Laurent quotient *is* `A⟨T'/s⟩`. Both maps between them are now on
main — #5634 gave the one out of the quotient and #5685 named it `laurentQuotientRestrictionRingHom`
alongside `laurentQuotientRingHom`, the map in. This proves the two mutually inverse, so the
identification is available as a ring isomorphism:

```text
laurentQuotientRingEquiv (ht : t ∈ T') (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t) (hcl) :
  A⟨T/s⟩⟨X⟩ ⧸ (t/s − X)  ≃+*  A⟨T'/s⟩
```

with `continuous_laurentQuotientRingEquiv`, its `symm` form, and `@[simp]` coercion lemmas
identifying the equivalence with `laurentQuotientRestrictionRingHom` and its inverse with
`laurentQuotientRingHom`. The two composite identities it is assembled from,
`laurentQuotientRestrictionRingHom_comp_laurentQuotientRingHom` and
`laurentQuotientRingHom_comp_laurentQuotientRestrictionRingHom`, are public in their own right.

One file, `TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Presentation.lean`, where both
maps already live.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-4.1-remark-7.55-identification"}-->

## What downstream roadmap item needs this

`TauCetiRoadmap/AdicSpaces/README.md`, Layer 4.1, numbered step 3, verbatim:

> 3. Proposition 8.30: prove that restriction maps between rational localisations are flat. Use
>    Remark 7.55 for the required chain of rational subsets.

The chain's steps are enlargements by one numerator, and Proposition 8.30 transports a statement
about the Laurent quotient — its flatness over `A⟨T/s⟩`, which is on main as
`flat_quotient_laurentRelationIdeal` — to the same statement about `A⟨T'/s⟩`. That transport is
this isomorphism. The marker id names Remark 7.55 rather than Proposition 8.30, because the
flatness half of step 3 is a separate PR and two open PRs under one marker are what the duplicate
sweeper closes.

## How the two composites are pinned

Each by the uniqueness half of one universal property, and neither needs a new idea:

* `ψ ∘ g = id` on `A⟨T'/s⟩` — both sides are continuous ring homomorphisms agreeing after
  `toCompletionLoc`, so `completion_locTopology_ringHom_ext_of_continuous` applies.
* `g ∘ ψ = id` on the quotient — `Ideal.Quotient.ringHom_ext` reduces to the composites with the
  quotient map, and `weightedRestrictedSubring_ringHom_ext_of_continuous` compares those on the
  constants and the variable. The variable clause is the only computation: expand `t/s` on both
  sides, move the inverse across with `IsUnit.unit_inv_map`, and read off
  `laurentRelationIdeal_quotientMk_weightedC`.

A private abbreviation and two private lemmas carry that content: `laurentStructureHom` for the
structure map the two are compared through, then `apply_divBy_eq_quotientMk_weightedX` and
`comp_restrictionRingHomOfSubset_eq`.

The module docstring changes with them. It said "the two maps are constructed; that they are
mutually inverse is not proved here", which this PR makes false.

## What is not claimed

Nothing about rational *subsets*. This is an isomorphism of presentations, at the ring level; the
statement that the two presentations present the same rational subset is Spa-level work and is not
here.
