### PR TITLE
refactor: remove four dead `have` bindings

### DIFF
--- a/TauCeti/CategoryTheory/Exact/Split.lean
+++ b/TauCeti/CategoryTheory/Exact/Split.lean
@@ -233,7 +233,6 @@ theorem split_isDeflation_comp {X Y Z : C} {p : X ⟶ Y} {q : Y ⟶ Z}
   obtain ⟨t₂⟩ := (split_conflation_iff _).mp hS₂
   have hi₁r : i₁ ≫ t₁.r = 𝟙 K₁ := t₁.f_r
   have hsp : t₁.s ≫ p = 𝟙 Y := t₁.s_g
-  have hsr : t₁.s ≫ t₁.r = 0 := t₁.s_r
   have hid₁ : t₁.r ≫ i₁ + p ≫ t₁.s = 𝟙 X := t₁.id
   have hi₂r : i₂ ≫ t₂.r = 𝟙 K₂ := t₂.f_r
   have hsq : t₂.s ≫ q = 𝟙 Z := t₂.s_g

--- a/TauCeti/Data/Nat/Factorization/PrimePowerProd/DivisorTable.lean
+++ b/TauCeti/Data/Nat/Factorization/PrimePowerProd/DivisorTable.lean
@@ -175,7 +175,6 @@ theorem primePowerProd_mul_eq_sum_divisors_gcd
       Nat.div_one, primePowerProd_one, one_mul,
       ← primePowerProd_mul_of_coprime D hg fun _ _ _ _ _ ↦ Commute.all _ _]
   -- Split both arguments at the least prime `p` of the gcd.
-  have hg0 : g ≠ 0 := fun h ↦ hm (Nat.eq_zero_of_gcd_eq_zero_left (hg.trans h))
   set p := g.minFac with hp_def
   have hp : p.Prime := Nat.minFac_prime hg1
   have hpm : p ∣ m := (Nat.minFac_dvd g).trans (hg ▸ Nat.gcd_dvd_left m n)

--- a/TauCeti/LinearAlgebra/Matrix/ProjectiveSpecialLinearGroup.lean
+++ b/TauCeti/LinearAlgebra/Matrix/ProjectiveSpecialLinearGroup.lean
@@ -154,7 +154,6 @@ def glPosToSL2R : GL(2, ℝ)⁺ →* SL(2, ℝ) where
   map_mul' g h := by
     apply Subtype.ext
     have hg_pos : 0 < ((g : GL (Fin 2) ℝ).det.val : ℝ) := g.property
-    have hh_pos : 0 < ((h : GL (Fin 2) ℝ).det.val : ℝ) := h.property
     have h_det : ((g * h : GL(2, ℝ)⁺) : GL (Fin 2) ℝ).det.val =
         (g : GL (Fin 2) ℝ).det.val * (h : GL (Fin 2) ℝ).det.val := by
       simp [Units.val_mul]

--- a/TauCeti/Probability/Distributions/InverseGamma.lean
+++ b/TauCeti/Probability/Distributions/InverseGamma.lean
@@ -474,8 +474,6 @@ theorem cdf_inverseGammaMeasure_eq (ha : 0 < a) (hr : 0 < r) (x : ℝ) :
         · exact (inv_nonpos.mpr hy).trans hxpos.le
         · have hypos : 0 < y := (inv_pos.mpr hxpos).trans_le hy
           exact (inv_le_comm₀ hypos hxpos).mpr hy
-    have hsubset : Ici x⁻¹ ⊆ Ioi (0 : ℝ) := fun y hy ↦
-      (inv_pos.mpr hxpos).trans_le hy
     have hdisj : Disjoint (Iic (0 : ℝ)) (Ici x⁻¹) := Set.disjoint_left.2 fun y hy0 hy ↦
       (not_lt_of_ge hy0) ((inv_pos.mpr hxpos).trans_le hy)
     have hzero : gammaMeasure a r (Iic 0) = 0 := by


### PR DESCRIPTION
Four proofs bind a `have` that nothing afterwards consumes — not by name, and
not by a context-searching tactic. Removing them changes no statement and
leaves every remaining step untouched.

| file | binding | what the proof actually uses |
|---|---|---|
| `CategoryTheory/Exact/Split.lean` | `hsr : t₁.s ≫ t₁.r = 0` | binds all four split identities, uses `hi₁r`, `hsp`, `hid₁` |
| `Data/Nat/.../DivisorTable.lean` | `hg0 : g ≠ 0` | proceeds entirely through `p = g.minFac` |
| `LinearAlgebra/Matrix/ProjectiveSpecialLinearGroup.lean` | `hh_pos` | `Real.sqrt_mul` needs the fact for `g` only |
| `Probability/Distributions/InverseGamma.lean` | `hsubset` | finishes via `hdisj`, `hzero`, `hsets` |

In `DivisorTable.lean` the comment above the removed line describes the
`set p := g.minFac` step, which it now heads directly.

Found by a scan for named `have`s never referenced again. The check that makes
it sound is suppressing every binding a tactic could consume *by search* rather
than by name — `omega`, `linarith`, `simp_all`, `aesop`, `assumption`,
`grobner`, `lia`, `field`, `congr`/`convert`, `rwa`/`simpa` (both fall back to
`assumption`), and `subst w` (which names the variable, not the hypothesis) —
together with every class-typed `have`, since a local hypothesis whose type is
a class is found by instance search and never named. Each was then read
individually against its proof.

A fifth candidate in `NumberTheory/.../IdealCount/Basic.lean` was dropped from
this PR: the `have` there is genuinely dead, but its proof term was the sole
consumer of two of the theorem's own binders, so removing it strands them.
That one needs the binders removed alongside it, which is a statement change
and belongs in its own PR.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp