### PR TITLE
refactor(IdealCount): drop unused primality hypotheses

### DIFF
--- a/TauCeti/NumberTheory/EffectiveBounds/IdealCount/Basic.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/IdealCount/Basic.lean
@@ -218,7 +218,7 @@ same coordinate are equal.  Only `P` need be assumed prime and nonzero: the shar
 coordinate places `Q` at `P`'s index in the list of primes over that rational prime,
 which already forces `Q` to lie in it.
 -/
-private theorem prime_eq_of_absNormUnder_eq_of_primeCoord_eq {P Q : Ideal (𝓞 F)}
+private theorem eq_of_absNormUnder_eq_of_primeCoord_eq {P Q : Ideal (𝓞 F)}
     (hP : P.IsPrime) (hP0 : P ≠ ⊥)
     (hr : absNormUnder F P = absNormUnder F Q) (hc : primeCoord F P = primeCoord F Q) : P = Q := by
   have hUeq : Ideal.under ℤ P = Ideal.under ℤ Q := under_eq_of_absNormUnder_eq F hr
@@ -329,7 +329,7 @@ private theorem count_eq_padicValNat {I : Ideal (𝓞 F)} {P : Ideal (𝓞 F)}
     have hQp : Q.IsPrime := isPrime_of_prime (prime_of_normalized_factor Q hQ.1)
     have hQ0 : Q ≠ ⊥ := ne_zero_of_mem_normalizedFactors hQ.1
     have hrb : absNormUnder F Q ≠ absNormUnder F P := fun h =>
-      hQP (prime_eq_of_absNormUnder_eq_of_primeCoord_eq F hQp hQ0 h hQ.2)
+      hQP (eq_of_absNormUnder_eq_of_primeCoord_eq F hQp hQ0 h hQ.2)
     have := hQp
     have : NeZero Q := ⟨hQ0⟩
     have hQbelow : (absNormUnder F Q).Prime := by

--- a/TauCeti/NumberTheory/EffectiveBounds/IdealCount/Basic.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/IdealCount/Basic.lean
@@ -213,18 +213,17 @@ private theorem under_eq_of_absNormUnder_eq {P Q : Ideal (𝓞 F)}
     ← Int.ideal_span_absNorm_eq_self (Ideal.under ℤ Q), hr']
 
 /-
-[foundational] Two nonzero primes over the same rational prime with the same
-coordinate are equal.
+[foundational] A nonzero prime and an ideal over the same rational prime with the
+same coordinate are equal.  Only `P` need be assumed prime and nonzero: the shared
+coordinate places `Q` at `P`'s index in the list of primes over that rational prime,
+which already forces `Q` to lie in it.
 -/
 private theorem prime_eq_of_absNormUnder_eq_of_primeCoord_eq {P Q : Ideal (𝓞 F)}
-    (hP : P.IsPrime) (hP0 : P ≠ ⊥) (hQ : Q.IsPrime) (hQ0 : Q ≠ ⊥)
+    (hP : P.IsPrime) (hP0 : P ≠ ⊥)
     (hr : absNormUnder F P = absNormUnder F Q) (hc : primeCoord F P = primeCoord F Q) : P = Q := by
   have hUeq : Ideal.under ℤ P = Ideal.under ℤ Q := under_eq_of_absNormUnder_eq F hr
   set l := (IsDedekindDomain.primesOverFinset (Ideal.under ℤ P) (𝓞 F)).toList with hl
   have hPl : P ∈ l := Finset.mem_toList.mpr (mem_primesOverFinset_under F hP hP0)
-  have hQl : Q ∈ l := by
-    rw [hl, hUeq]
-    exact Finset.mem_toList.mpr (mem_primesOverFinset_under F hQ hQ0)
   have hidx : l.idxOf P = l.idxOf Q := by
     have hP' : l.idxOf P = primeCoord F P := by rw [primeCoord, hl]
     have hQ' : l.idxOf Q = primeCoord F Q := by rw [primeCoord, hl, hUeq]
@@ -330,7 +329,7 @@ private theorem count_eq_padicValNat {I : Ideal (𝓞 F)} {P : Ideal (𝓞 F)}
     have hQp : Q.IsPrime := isPrime_of_prime (prime_of_normalized_factor Q hQ.1)
     have hQ0 : Q ≠ ⊥ := ne_zero_of_mem_normalizedFactors hQ.1
     have hrb : absNormUnder F Q ≠ absNormUnder F P := fun h =>
-      hQP (prime_eq_of_absNormUnder_eq_of_primeCoord_eq F hQp hQ0 hP hP0 h hQ.2)
+      hQP (prime_eq_of_absNormUnder_eq_of_primeCoord_eq F hQp hQ0 h hQ.2)
     have := hQp
     have : NeZero Q := ⟨hQ0⟩
     have hQbelow : (absNormUnder F Q).Prime := by


### PR DESCRIPTION
`prime_eq_of_absNormUnder_eq_of_primeCoord_eq` assumes both `P` and `Q` are
nonzero primes. Only `P`'s assumptions are used, so this drops `hQ` and `hQ0`.

**Why the weaker statement still holds.** The proof puts `P` and `Q` in `l`, the
list of primes over their common rational prime, and finishes with
`(List.idxOf_inj hPl).mp hidx` — which takes **one** membership. If `Q ∉ l` then
`l.idxOf Q = l.length`, which is strictly greater than `l.idxOf P`; since
`hidx : l.idxOf P = l.idxOf Q`, that is impossible. So the shared coordinate
already forces `Q ∈ l`, and assuming it is a nonzero prime is redundant.

That makes `have hQl : Q ∈ l` dead, and its proof term
`mem_primesOverFinset_under F hQ hQ0` was the only consumer of `hQ` and `hQ0`.

The single call site (`count_eq_padicValNat`) passed `hP`/`hP0` for the two
dropped arguments; both remain used elsewhere in that theorem, including in its
own statement via `primeCoord_lt F hP hP0`, so nothing is stranded there.

Since `Q` is no longer assumed prime, the theorem is renamed
**`prime_eq_of_… → eq_of_absNormUnder_eq_of_primeCoord_eq`**: the conclusion is
just `P = Q`, and the old name advertised an equality of primes the statement no
longer claims. (Applies the round-1 `naming` finding.)

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp