### PR TITLE
refactor: drop seven unused `set … with` equations

### DIFF
--- a/TauCeti/Algebra/Group/PowMonoidHom.lean
+++ b/TauCeti/Algebra/Group/PowMonoidHom.lean
@@ -83,7 +83,7 @@ private theorem index_powMonoidHom_range_le_of_closure_eq_top {G : Type*} [CommG
     {S : Finset G} {n : ℕ} (hn : n ≠ 0) (hS : Subgroup.closure (S : Set G) = ⊤) :
     (powMonoidHom n : G →* G).range.index ≤ n ^ S.card := by
   classical
-  set H := (powMonoidHom n : G →* G).range with hH
+  set H := (powMonoidHom n : G →* G).range
   have : Group.FG G := Group.fg_iff'.mpr ⟨S.card, S, rfl, hS⟩
   have : Group.FG (G ⧸ H) := Group.fg_of_surjective (QuotientGroup.mk'_surjective H)
   have hpow : ∀ q : G ⧸ H, q ^ n = 1 := fun q =>

--- a/TauCeti/Algebra/Lie/Presentation/Basic.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Basic.lean
@@ -83,7 +83,7 @@ variable (R : Type*) [CommRing R] (X : Type*)
 /-- The generators of a free Lie algebra generate it as a Lie subalgebra. -/
 theorem lieSpan_range_of_eq_top :
     LieSubalgebra.lieSpan R (FreeLieAlgebra R X) (Set.range (FreeLieAlgebra.of R)) = ⊤ := by
-  set K := LieSubalgebra.lieSpan R (FreeLieAlgebra R X) (Set.range (FreeLieAlgebra.of R)) with hK
+  set K := LieSubalgebra.lieSpan R (FreeLieAlgebra R X) (Set.range (FreeLieAlgebra.of R))
   have hmem (x : X) : FreeLieAlgebra.of R x ∈ K :=
     LieSubalgebra.subset_lieSpan (Set.mem_range_self x)
   set g : FreeLieAlgebra R X →ₗ⁅R⁆ K := FreeLieAlgebra.lift R fun x => ⟨_, hmem x⟩ with hg

--- a/TauCeti/Algebra/Polynomial/Card/BoundedCoeff.lean
+++ b/TauCeti/Algebra/Polynomial/Card/BoundedCoeff.lean
@@ -72,7 +72,7 @@ at most `#U ^ (d + 1)`: such a polynomial is determined by the `d + 1` coefficie
 theorem ncard_natDegree_le_coeff_mem_le (d : ℕ) (U : Finset R) :
     {f : R[X] | f.natDegree ≤ d ∧ ∀ i, f.coeff i ∈ U}.ncard ≤ U.card ^ (d + 1) := by
   classical
-  set S : Set R[X] := {f | f.natDegree ≤ d ∧ ∀ i, f.coeff i ∈ U} with hS
+  set S : Set R[X] := {f | f.natDegree ≤ d ∧ ∀ i, f.coeff i ∈ U}
   -- The coefficient map sends `S` into the finite product `Fin (d + 1) → U`.
   set T : Finset (Fin (d + 1) → R) := Fintype.piFinset (fun _ => U) with hT
   have hcard : (T : Set (Fin (d + 1) → R)).ncard = U.card ^ (d + 1) := by

--- a/TauCeti/Analysis/Contour/Argument/Principle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Principle.lean
@@ -174,7 +174,7 @@ private theorem circleIntegral_logDeriv_toMeromorphicNFOn {f : ℂ → ℂ} {c :
     (hf : MeromorphicOn f (Metric.closedBall c R)) :
     circleIntegral (logDeriv f) c R
       = circleIntegral (logDeriv (toMeromorphicNFOn f (Metric.closedBall c R))) c R := by
-  set F := toMeromorphicNFOn f (Metric.closedBall c R) with hF_def
+  set F := toMeromorphicNFOn f (Metric.closedBall c R)
   refine circleIntegral.circleIntegral_congr_codiscreteWithin ?_ hR.ne'
   have hspU : Metric.sphere c |R| ⊆ Metric.closedBall c R := by
     rw [abs_of_pos hR]; exact Metric.sphere_subset_closedBall

--- a/TauCeti/Analysis/Sobolev/WeakDeriv.lean
+++ b/TauCeti/Analysis/Sobolev/WeakDeriv.lean
@@ -628,7 +628,7 @@ The directional statement `TauCeti.HasWeakLineDerivOn.ae_eq` is applied along th
 vectors of a basis of `E`, and the resulting almost-everywhere statements are intersected. -/
 theorem HasWeakFDerivOn.ae_eq {U₁ U₂ : E → E →L[ℝ] F} (h₁ : HasWeakFDerivOn μ Ω u U₁)
     (h₂ : HasWeakFDerivOn μ Ω u U₂) : U₁ =ᵐ[μ.restrict Ω] U₂ := by
-  set b := Module.finBasis ℝ E with hb
+  set b := Module.finBasis ℝ E
   have hcoord : ∀ i, (fun x => U₁ x (b i)) =ᵐ[μ.restrict Ω] fun x => U₂ x (b i) :=
     fun i => (h₁ (b i)).ae_eq (h₂ (b i))
   filter_upwards [Filter.eventually_all.2 hcoord] with x hx

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean
@@ -186,7 +186,7 @@ private theorem checkerboardCarrier_le_intSpan :
 /-- The checkerboard carrier is finitely generated: it is a submodule of the finitely generated
 module `ℤⁿ` over the Noetherian ring `ℤ`. -/
 private theorem checkerboardCarrier_fg : (checkerboardCarrier n).FG := by
-  set M := Submodule.span ℤ (Set.range (Pi.basisFun ℚ (Fin n))) with hM
+  set M := Submodule.span ℤ (Set.range (Pi.basisFun ℚ (Fin n)))
   have : IsNoetherian ℤ M := isNoetherian_span_of_finite ℤ (Set.finite_range _)
   have hfg : ((checkerboardCarrier n).comap M.subtype).FG := IsNoetherian.noetherian _
   have hmap : ((checkerboardCarrier n).comap M.subtype).map M.subtype = checkerboardCarrier n := by

--- a/TauCeti/RingTheory/Huber/RingOfDefinition.lean
+++ b/TauCeti/RingTheory/Huber/RingOfDefinition.lean
@@ -438,7 +438,7 @@ theorem isTopologicallyNilpotent_iff_exists_mem_idealOfDefinition {a : A} :
     obtain ⟨P, hmem⟩ := isPowerBounded_iff_exists_mem_ringOfDefinition.mp
       (IsPowerBounded.of_isTopologicallyNilpotent ha)
     -- `y` is the element itself, viewed in the ring of definition it was just placed in
-    set y : P.ringOfDefinition := ⟨a, hmem⟩ with hy
+    set y : P.ringOfDefinition := ⟨a, hmem⟩
     have hnil : IsTopologicallyNilpotent y := isTopologicallyNilpotent_mk hmem ha
     -- enlarging by `y` puts it in the ideal of definition, leaving the ring of definition alone
     exact ⟨P.enlargeIdeal hnil, hmem, P.mem_enlargeIdeal_idealOfDefinition hnil hmem⟩


### PR DESCRIPTION
`set x := e with h` binds the defining equation `h : x = e`. In these seven
proofs the abstracted variable is used throughout but the equation never is —
not by name, and not by a tactic that reads the context. The `with` clause is
dead; dropping it leaves the `set` and every other step unchanged.

| file | binding |
|---|---|
| `Analysis/Sobolev/WeakDeriv.lean` | `set b := Module.finBasis ℝ E with hb` |
| `LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean` | `set M := … with hM` |
| `Analysis/Contour/Argument/Principle.lean` | `set F := … with hF_def` |
| `Algebra/Lie/Presentation/Basic.lean` | `set K := … with hK` |
| `RingTheory/Huber/RingOfDefinition.lean` | `set y : P.ringOfDefinition := … with hy` |
| `Algebra/Polynomial/Card/BoundedCoeff.lean` | `set S : Set R[X] := … with hS` |
| `Algebra/Group/PowMonoidHom.lean` | `set H := … with hH` |

Two checks worth naming, because both are places this could have gone wrong:

* **`BoundedCoeff.lean` keeps its other equation.** The same proof binds
  `set T … with hT`, and `hT` *is* used by `rw [← hcard]`/`rw [Set.ncard_coe_finset, hT, …]`,
  so it stays. The scan distinguishes them rather than stripping every `with`.
* **`Principle.lean` has the identical `set F := toMeromorphicNFOn f (Metric.closedBall c R) with hF_def`
  line twice**, at 177 and 256. Only the first equation is dead; the edit is by
  line, and line 256 is untouched.

Each of the seven was read against its proof. The suppression list is the one
described in #5727: any binding a tactic could consume by search rather than by
name (`omega`, `linarith`, `simp_all`, `aesop`, `assumption`, `grobner`, `lia`,
`field`, `congr`/`convert`, `rwa`/`simpa`, `subst`) disqualifies the row.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp