### PR TITLE
feat(AdicSpace): the residue field of a point of the valuation spectrum

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
@@ -60,10 +60,6 @@ variable {A : Type*} [CommRing A]
 /-- The **residue ring** `A ⧸ supp v` of a point of the valuation spectrum. -/
 abbrev residueRing (v : Spv A) := A ⧸ v.supp
 
-/-- The residue ring is a domain, because the support of a point is a prime ideal. -/
-instance (v : Spv A) : IsDomain (residueRing v) :=
-  Ideal.Quotient.isDomain v.supp
-
 /-- The valuation induced on the residue ring `A ⧸ supp v`. The canonical valuation of `v` has
 `supp v` in its kernel — that is `TauCeti.ValuationSpectrum.supp_eq_valuation_supp` — so it
 descends to the quotient. -/

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
@@ -29,7 +29,9 @@ is evaluated at `v` by its image in the residue field, and the condition cutting
 
 * `TauCeti.ValuationSpectrum.residueRing`: the quotient `A ⧸ supp v`, a domain.
 * `TauCeti.ValuationSpectrum.quotientValuation`: the valuation of `v` pushed to `A ⧸ supp v`.
-* `TauCeti.ValuationSpectrum.residueFieldValuation`: its extension to `Frac (A ⧸ supp v)`.
+* `TauCeti.ValuationSpectrum.residueField`: the residue field `κ(v) = Frac (A ⧸ supp v)`.
+* `TauCeti.ValuationSpectrum.residueFieldValuation`: the extension of the quotient valuation to
+  `κ(v)`.
 
 ## Main results
 
@@ -43,8 +45,8 @@ is evaluated at `v` by its image in the residue field, and the condition cutting
   `residueFieldValuation v (IsLocalization.mk' _ x s) = quotientValuation v x /
   quotientValuation v s`. With the previous lemma this computes the residue-field valuation on
   every element,
-  since every element of a fraction field is a fraction, and neither needs the definition
-  unfolded. It is not a `simp` lemma; its docstring says why.
+  since every element of a fraction field is a fraction, and neither needs the
+  definition unfolded.
 
 ## References
 
@@ -86,14 +88,17 @@ theorem quotientValuation_ne_zero (v : Spv A) {s : residueRing v} (hs : s ≠ 0)
       Ideal.map_quotient_self]
   simpa only [Ne, ← Valuation.mem_supp_iff, hsupp, Ideal.mem_bot] using hs
 
+/-- The **residue field** `κ(v) = Frac (A ⧸ supp v)` of a point of the valuation spectrum. The
+support is prime, so the residue ring is a domain and this is its fraction field. -/
+abbrev residueField (v : Spv A) := FractionRing (residueRing v)
+
 /-- The **residue-field valuation** of a point: the quotient valuation extended along
-`A ⧸ supp v → Frac (A ⧸ supp v)`. Its value group is the one `v` carries on `A`. -/
+`A ⧸ supp v → κ(v)`. Its value group is `ValuativeRel.ValueGroupWithZero`, the one `v.valuation`
+already takes values in. -/
 noncomputable def residueFieldValuation (v : Spv A) :
-    Valuation (FractionRing (residueRing v))
-      (@ValuativeRel.ValueGroupWithZero A _ v.toValuativeRel) :=
+    Valuation (residueField v) (@ValuativeRel.ValueGroupWithZero A _ v.toValuativeRel) :=
   (quotientValuation v).extendToLocalization
-    (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs))
-    (FractionRing (residueRing v))
+    (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs)) (residueField v)
 
 /-- **The residue-ring valuation restricts to the valuation of `v`** along `A → A ⧸ supp v`: the
 descent changes nothing on elements of `A`. This is the characteristic property of
@@ -110,36 +115,29 @@ theorem quotientValuation_comap_quotientMk (v : Spv A) :
 `TauCeti.ValuationSpectrum.residueFieldValuation`. -/
 @[simp]
 theorem residueFieldValuation_algebraMap (v : Spv A) (x : residueRing v) :
-    residueFieldValuation v (algebraMap (residueRing v) (FractionRing (residueRing v)) x)
+    residueFieldValuation v (algebraMap (residueRing v) (residueField v) x)
       = quotientValuation v x := by
   simpa only [residueFieldValuation] using
     Valuation.extendToLocalization_apply_map_apply (quotientValuation v)
       (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs))
-      (FractionRing (residueRing v)) x
+      (residueField v) x
 
 /-- **The residue-field valuation on a fraction**:
 `residueFieldValuation v (IsLocalization.mk' _ x s)` is
 `quotientValuation v x / quotientValuation v s`. The two sides live at different stages — the
-argument is a fraction of the residue *field*, the values are of the *quotient-ring*
-valuation. Together with
-`TauCeti.ValuationSpectrum.residueFieldValuation_algebraMap` this computes the valuation of every
-element of `Frac (A ⧸ supp v)`, since every element is such a fraction — and neither needs
-`TauCeti.ValuationSpectrum.residueFieldValuation` unfolded.
+argument is a fraction of the residue field, the values are of the quotient-ring valuation.
 
-Deliberately **not** `@[simp]`, and the right-hand side is a quotient rather than
-`quotientValuation v x * (quotientValuation v s)⁻¹`: `simp` already carries the left-hand side to
-this exact form through `IsFractionRing.mk'_eq_div`, `map_div₀` and the `algebraMap` equation
-above, so the `simp` attribute fails `simpNF` on a left-hand side that is not in normal form.
-The lemma earns its place as the named, directly citable form of that chain. -/
+With `TauCeti.ValuationSpectrum.residueFieldValuation_algebraMap` this computes the valuation of
+every element of `κ(v)`, since every element of a fraction field is such a fraction. -/
 theorem residueFieldValuation_mk' (v : Spv A) (x : residueRing v)
     (s : (nonZeroDivisors (residueRing v))) :
-    residueFieldValuation v (IsLocalization.mk' (FractionRing (residueRing v)) x s)
+    residueFieldValuation v (IsLocalization.mk' (residueField v) x s)
       = quotientValuation v x / quotientValuation v s := by
   rw [div_eq_mul_inv]
   simpa only [residueFieldValuation] using
     Valuation.extendToLocalization_mk' (quotientValuation v)
       (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs))
-      (FractionRing (residueRing v)) x s
+      (residueField v) x s
 
 end ValuationSpectrum
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AdicSpace.ValuationSpectrum
+public import Mathlib.RingTheory.Localization.FractionRing
+
+/-!
+# The residue field of a point of the valuation spectrum
+
+**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), §2.4.**
+
+A point `v : Spv A` carries a valuation on `A`, but not one on a field. This file makes it one.
+The support of `v` is prime, so `A ⧸ supp v` is a domain; the valuation kills the support by
+construction, so it descends there; and on the quotient it has trivial support, which is exactly
+the hypothesis needed to extend it along `A ⧸ supp v → Frac (A ⧸ supp v)`. The result is the
+**residue field** of `v`, carrying a valuation with the value group `v` already had.
+
+This is the factorisation the structure presheaf is read through: a section is evaluated at `v` by
+its image in the residue field, and the condition `v(f) ≤ 1` cutting out `𝒪_X⁺` is imposed there.
+
+## Main definitions
+
+* `TauCeti.ValuationSpectrum.residueRing`: the quotient `A ⧸ supp v`, a domain.
+* `TauCeti.ValuationSpectrum.quotientValuation`: the valuation of `v` pushed to `A ⧸ supp v`.
+* `TauCeti.ValuationSpectrum.residueFieldValuation`: its extension to `Frac (A ⧸ supp v)`.
+
+## Main results
+
+* `TauCeti.ValuationSpectrum.quotientValuation_ne_zero`: on the residue ring the valuation has
+  trivial support. Passing to the quotient is what arranges this, and it is what
+  `Valuation.extendToLocalization` requires.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), §2.4.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace ValuationSpectrum
+
+variable {A : Type*} [CommRing A]
+
+/-- The **residue ring** `A ⧸ supp v` of a point of the valuation spectrum. -/
+abbrev residueRing (v : Spv A) := A ⧸ v.supp
+
+/-- The residue ring is a domain, because the support of a point is a prime ideal. -/
+instance (v : Spv A) : IsDomain (residueRing v) :=
+  Ideal.Quotient.isDomain v.supp
+
+/-- The valuation induced on the residue ring `A ⧸ supp v`. The canonical valuation of `v` has
+`supp v` in its kernel — that is `TauCeti.ValuationSpectrum.supp_eq_valuation_supp` — so it
+descends to the quotient. -/
+noncomputable def quotientValuation (v : Spv A) :
+    Valuation (residueRing v) (@ValuativeRel.ValueGroupWithZero A _ v.toValuativeRel) :=
+  v.valuation.onQuot (le_of_eq v.supp_eq_valuation_supp)
+
+/-- **On the residue ring the valuation has trivial support**: a nonzero class has nonzero
+valuation. This is what passing to `A ⧸ supp v` buys, and it is the hypothesis
+`Valuation.extendToLocalization` needs in order to reach the fraction field. -/
+theorem quotientValuation_ne_zero (v : Spv A) {s : residueRing v} (hs : s ≠ 0) :
+    quotientValuation v s ≠ 0 := by
+  rwa [Ne, ← Valuation.mem_supp_iff, quotientValuation, Valuation.supp_quot,
+    ← v.supp_eq_valuation_supp, Ideal.map_quotient_self, Ideal.mem_bot]
+
+/-- The **residue-field valuation** of a point: the quotient valuation extended along
+`A ⧸ supp v → Frac (A ⧸ supp v)`. Its value group is the one `v` carries on `A`. -/
+noncomputable def residueFieldValuation (v : Spv A) :
+    Valuation (FractionRing (residueRing v))
+      (@ValuativeRel.ValueGroupWithZero A _ v.toValuativeRel) :=
+  (quotientValuation v).extendToLocalization
+    (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs))
+    (FractionRing (residueRing v))
+
+end ValuationSpectrum
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
@@ -13,14 +13,17 @@ public import Mathlib.RingTheory.Localization.FractionRing
 
 **Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), §2.4.**
 
-A point `v : Spv A` carries a valuation on `A`, but not one on a field. This file makes it one.
-The support of `v` is prime, so `A ⧸ supp v` is a domain; the valuation kills the support by
-construction, so it descends there; and on the quotient it has trivial support, which is exactly
-the hypothesis needed to extend it along `A ⧸ supp v → Frac (A ⧸ supp v)`. The result is the
-**residue field** of `v`, carrying a valuation with the value group `v` already had.
+A point `v : Spv A` determines a valuation `v.valuation` on `A`, but not one on a field. This file
+makes it one. The support of `v` is prime, so `A ⧸ supp v` is a domain; `v.valuation` kills the
+support by construction, so it descends there as `quotientValuation v`; and on the quotient it has
+trivial support, which is exactly the hypothesis needed to extend it along
+`A ⧸ supp v → Frac (A ⧸ supp v)`. The result, `residueFieldValuation v`, is a valuation on the
+**residue field** of `v`, valued in the same `ValuativeRel.ValueGroupWithZero` as `v.valuation`.
 
-This is the factorisation the structure presheaf is read through: a section is evaluated at `v` by
-its image in the residue field, and the condition `v(f) ≤ 1` cutting out `𝒪_X⁺` is imposed there.
+Note that `v` itself is not a function: `Spv A` is a structure, and each of the three valuations
+here has to be named. This is the factorisation the structure presheaf is read through — a section
+is evaluated at `v` by its image in the residue field, and the condition cutting out `𝒪_X⁺` is
+`residueFieldValuation v` of that image being `≤ 1`.
 
 ## Main definitions
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
@@ -6,7 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.AlgebraicGeometry.AdicSpace.ValuationSpectrum
-public import Mathlib.RingTheory.Localization.FractionRing
+public import Mathlib.RingTheory.LocalRing.ResidueField.Ideal
 
 /-!
 # The residue field of a point of the valuation spectrum
@@ -17,8 +17,9 @@ A point `v : Spv A` determines a valuation `v.valuation` on `A`, but not one on 
 makes it one. The support of `v` is prime, so `A ⧸ supp v` is a domain; `v.valuation` kills the
 support by construction, so it descends there as `quotientValuation v`; and on the quotient it has
 trivial support, which is exactly the hypothesis needed to extend it along
-`A ⧸ supp v → Frac (A ⧸ supp v)`. The result, `residueFieldValuation v`, is a valuation on the
-**residue field** of `v`, valued in the same `ValuativeRel.ValueGroupWithZero` as `v.valuation`.
+`A ⧸ supp v → κ(v)`, where `κ(v)` is Mathlib's `Ideal.ResidueField` of the prime ideal `supp v`.
+The result, `residueFieldValuation v`, is a valuation on that **residue field**, valued in the same
+`ValuativeRel.ValueGroupWithZero` as `v.valuation`.
 
 Note that `v` itself is not a function: `Spv A` is a structure, and each of the three valuations
 here has to be named. This is the factorisation the structure presheaf is read through — a section
@@ -29,9 +30,10 @@ is evaluated at `v` by its image in the residue field, and the condition cutting
 
 * `TauCeti.ValuationSpectrum.residueRing`: the quotient `A ⧸ supp v`, a domain.
 * `TauCeti.ValuationSpectrum.quotientValuation`: the valuation of `v` pushed to `A ⧸ supp v`.
-* `TauCeti.ValuationSpectrum.residueField`: the residue field `κ(v) = Frac (A ⧸ supp v)`.
 * `TauCeti.ValuationSpectrum.residueFieldValuation`: the extension of the quotient valuation to
-  `κ(v)`.
+  `κ(v) = (supp v).ResidueField`. The residue field itself is Mathlib's, not a new type: the
+  support is prime, and `Ideal.ResidueField` is the canonical `κ` of a prime ideal, with the
+  `IsFractionRing (A ⧸ supp v) (supp v).ResidueField` instance this extension needs.
 
 ## Main results
 
@@ -88,17 +90,13 @@ theorem quotientValuation_ne_zero (v : Spv A) {s : residueRing v} (hs : s ≠ 0)
       Ideal.map_quotient_self]
   simpa only [Ne, ← Valuation.mem_supp_iff, hsupp, Ideal.mem_bot] using hs
 
-/-- The **residue field** `κ(v) = Frac (A ⧸ supp v)` of a point of the valuation spectrum. The
-support is prime, so the residue ring is a domain and this is its fraction field. -/
-abbrev residueField (v : Spv A) := FractionRing (residueRing v)
-
 /-- The **residue-field valuation** of a point: the quotient valuation extended along
 `A ⧸ supp v → κ(v)`. Its value group is `ValuativeRel.ValueGroupWithZero`, the one `v.valuation`
 already takes values in. -/
 noncomputable def residueFieldValuation (v : Spv A) :
-    Valuation (residueField v) (@ValuativeRel.ValueGroupWithZero A _ v.toValuativeRel) :=
+    Valuation (v.supp.ResidueField) (@ValuativeRel.ValueGroupWithZero A _ v.toValuativeRel) :=
   (quotientValuation v).extendToLocalization
-    (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs)) (residueField v)
+    (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs)) (v.supp.ResidueField)
 
 /-- **The residue-ring valuation restricts to the valuation of `v`** along `A → A ⧸ supp v`: the
 descent changes nothing on elements of `A`. This is the characteristic property of
@@ -115,12 +113,12 @@ theorem quotientValuation_comap_quotientMk (v : Spv A) :
 `TauCeti.ValuationSpectrum.residueFieldValuation`. -/
 @[simp]
 theorem residueFieldValuation_algebraMap (v : Spv A) (x : residueRing v) :
-    residueFieldValuation v (algebraMap (residueRing v) (residueField v) x)
+    residueFieldValuation v (algebraMap (residueRing v) (v.supp.ResidueField) x)
       = quotientValuation v x := by
   simpa only [residueFieldValuation] using
     Valuation.extendToLocalization_apply_map_apply (quotientValuation v)
       (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs))
-      (residueField v) x
+      (v.supp.ResidueField) x
 
 /-- **The residue-field valuation on a fraction**:
 `residueFieldValuation v (IsLocalization.mk' _ x s)` is
@@ -131,13 +129,13 @@ With `TauCeti.ValuationSpectrum.residueFieldValuation_algebraMap` this computes 
 every element of `κ(v)`, since every element of a fraction field is such a fraction. -/
 theorem residueFieldValuation_mk' (v : Spv A) (x : residueRing v)
     (s : (nonZeroDivisors (residueRing v))) :
-    residueFieldValuation v (IsLocalization.mk' (residueField v) x s)
+    residueFieldValuation v (IsLocalization.mk' (v.supp.ResidueField) x s)
       = quotientValuation v x / quotientValuation v s := by
   rw [div_eq_mul_inv]
   simpa only [residueFieldValuation] using
     Valuation.extendToLocalization_mk' (quotientValuation v)
       (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs))
-      (residueField v) x s
+      (v.supp.ResidueField) x s
 
 end ValuationSpectrum
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
@@ -36,8 +36,10 @@ its image in the residue field, and the condition `v(f) ≤ 1` cutting out `𝒪
 * `TauCeti.ValuationSpectrum.quotientValuation_comap_quotientMk` and
   `TauCeti.ValuationSpectrum.residueFieldValuation_algebraMap`: the two characteristic equations,
   saying each valuation restricts to the previous one along the canonical map.
-* `TauCeti.ValuationSpectrum.residueFieldValuation_mk'`: the value of a fraction, `v (x/s) =
-  v x / v s`. With the previous lemma this computes the residue-field valuation on every element,
+* `TauCeti.ValuationSpectrum.residueFieldValuation_mk'`: the value of a fraction,
+  `residueFieldValuation v (IsLocalization.mk' _ x s) = quotientValuation v x /
+  quotientValuation v s`. With the previous lemma this computes the residue-field valuation on
+  every element,
   since every element of a fraction field is a fraction, and neither needs the definition
   unfolded. It is not a `simp` lemma; its docstring says why.
 
@@ -112,7 +114,11 @@ theorem residueFieldValuation_algebraMap (v : Spv A) (x : residueRing v) :
       (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs))
       (FractionRing (residueRing v)) x
 
-/-- **The residue-field valuation on a fraction**: `x/s` has value `v x / v s`. Together with
+/-- **The residue-field valuation on a fraction**:
+`residueFieldValuation v (IsLocalization.mk' _ x s)` is
+`quotientValuation v x / quotientValuation v s`. The two sides live at different stages — the
+argument is a fraction of the residue *field*, the values are of the *quotient-ring*
+valuation. Together with
 `TauCeti.ValuationSpectrum.residueFieldValuation_algebraMap` this computes the valuation of every
 element of `Frac (A ⧸ supp v)`, since every element is such a fraction — and neither needs
 `TauCeti.ValuationSpectrum.residueFieldValuation` unfolded.

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
@@ -36,6 +36,10 @@ its image in the residue field, and the condition `v(f) ≤ 1` cutting out `𝒪
 * `TauCeti.ValuationSpectrum.quotientValuation_comap_quotientMk` and
   `TauCeti.ValuationSpectrum.residueFieldValuation_algebraMap`: the two characteristic equations,
   saying each valuation restricts to the previous one along the canonical map.
+* `TauCeti.ValuationSpectrum.residueFieldValuation_mk'`: the value of a fraction, `v (x/s) =
+  v x / v s`. With the previous lemma this computes the residue-field valuation on every element,
+  since every element of a fraction field is a fraction, and neither needs the definition
+  unfolded. It is not a `simp` lemma; its docstring says why.
 
 ## References
 
@@ -72,8 +76,10 @@ valuation. This is what passing to `A ⧸ supp v` buys, and it is the hypothesis
 `Valuation.extendToLocalization` needs in order to reach the fraction field. -/
 theorem quotientValuation_ne_zero (v : Spv A) {s : residueRing v} (hs : s ≠ 0) :
     quotientValuation v s ≠ 0 := by
-  rwa [Ne, ← Valuation.mem_supp_iff, quotientValuation, Valuation.supp_quot,
-    ← v.supp_eq_valuation_supp, Ideal.map_quotient_self, Ideal.mem_bot]
+  have hsupp : (quotientValuation v).supp = ⊥ := by
+    rw [quotientValuation, Valuation.supp_quot, ← v.supp_eq_valuation_supp,
+      Ideal.map_quotient_self]
+  simpa only [Ne, ← Valuation.mem_supp_iff, hsupp, Ideal.mem_bot] using hs
 
 /-- The **residue-field valuation** of a point: the quotient valuation extended along
 `A ⧸ supp v → Frac (A ⧸ supp v)`. Its value group is the one `v` carries on `A`. -/
@@ -90,8 +96,9 @@ descent changes nothing on elements of `A`. This is the characteristic property 
 `Valuation.onQuot`. -/
 @[simp]
 theorem quotientValuation_comap_quotientMk (v : Spv A) :
-    (quotientValuation v).comap (Ideal.Quotient.mk v.supp) = v.valuation :=
-  v.valuation.onQuot_comap_eq _
+    (quotientValuation v).comap (Ideal.Quotient.mk v.supp) = v.valuation := by
+  simpa only [quotientValuation] using
+    v.valuation.onQuot_comap_eq (le_of_eq v.supp_eq_valuation_supp)
 
 /-- **The residue-field valuation restricts to the residue-ring valuation** along
 `A ⧸ supp v → Frac (A ⧸ supp v)`. This is the characteristic property of
@@ -99,8 +106,31 @@ theorem quotientValuation_comap_quotientMk (v : Spv A) :
 @[simp]
 theorem residueFieldValuation_algebraMap (v : Spv A) (x : residueRing v) :
     residueFieldValuation v (algebraMap (residueRing v) (FractionRing (residueRing v)) x)
-      = quotientValuation v x :=
-  Valuation.extendToLocalization_apply_map_apply _ _ _ _
+      = quotientValuation v x := by
+  simpa only [residueFieldValuation] using
+    Valuation.extendToLocalization_apply_map_apply (quotientValuation v)
+      (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs))
+      (FractionRing (residueRing v)) x
+
+/-- **The residue-field valuation on a fraction**: `x/s` has value `v x / v s`. Together with
+`TauCeti.ValuationSpectrum.residueFieldValuation_algebraMap` this computes the valuation of every
+element of `Frac (A ⧸ supp v)`, since every element is such a fraction — and neither needs
+`TauCeti.ValuationSpectrum.residueFieldValuation` unfolded.
+
+Deliberately **not** `@[simp]`, and the right-hand side is a quotient rather than
+`quotientValuation v x * (quotientValuation v s)⁻¹`: `simp` already carries the left-hand side to
+this exact form through `IsFractionRing.mk'_eq_div`, `map_div₀` and the `algebraMap` equation
+above, so the `simp` attribute fails `simpNF` on a left-hand side that is not in normal form.
+The lemma earns its place as the named, directly citable form of that chain. -/
+theorem residueFieldValuation_mk' (v : Spv A) (x : residueRing v)
+    (s : (nonZeroDivisors (residueRing v))) :
+    residueFieldValuation v (IsLocalization.mk' (FractionRing (residueRing v)) x s)
+      = quotientValuation v x / quotientValuation v s := by
+  rw [div_eq_mul_inv]
+  simpa only [residueFieldValuation] using
+    Valuation.extendToLocalization_mk' (quotientValuation v)
+      (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs))
+      (FractionRing (residueRing v)) x s
 
 end ValuationSpectrum
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean
@@ -33,10 +33,20 @@ its image in the residue field, and the condition `v(f) ≤ 1` cutting out `𝒪
 * `TauCeti.ValuationSpectrum.quotientValuation_ne_zero`: on the residue ring the valuation has
   trivial support. Passing to the quotient is what arranges this, and it is what
   `Valuation.extendToLocalization` requires.
+* `TauCeti.ValuationSpectrum.quotientValuation_comap_quotientMk` and
+  `TauCeti.ValuationSpectrum.residueFieldValuation_algebraMap`: the two characteristic equations,
+  saying each valuation restricts to the previous one along the canonical map.
 
 ## References
 
 * [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), §2.4.
+
+## Provenance
+
+Adapted from `github.com/CBirkbeck/AINTLIB` @ `37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c`,
+Apache-2.0, file `projects/AdicSpaces/Adic spaces/CompletedResidueField.lean`: the declarations
+`residueRing`, `quotientValuation`, `quotientValuation_ne_zero` and `residueFieldValuation`,
+restated against TauCeti's own `Spv` API.
 -/
 
 public section
@@ -77,6 +87,24 @@ noncomputable def residueFieldValuation (v : Spv A) :
   (quotientValuation v).extendToLocalization
     (fun _ hs ↦ quotientValuation_ne_zero v (nonZeroDivisors.ne_zero hs))
     (FractionRing (residueRing v))
+
+/-- **The residue-ring valuation restricts to the valuation of `v`** along `A → A ⧸ supp v`: the
+descent changes nothing on elements of `A`. This is the characteristic property of
+`TauCeti.ValuationSpectrum.quotientValuation`, and the way to compute with it without unfolding
+`Valuation.onQuot`. -/
+@[simp]
+theorem quotientValuation_comap_quotientMk (v : Spv A) :
+    (quotientValuation v).comap (Ideal.Quotient.mk v.supp) = v.valuation :=
+  v.valuation.onQuot_comap_eq _
+
+/-- **The residue-field valuation restricts to the residue-ring valuation** along
+`A ⧸ supp v → Frac (A ⧸ supp v)`. This is the characteristic property of
+`TauCeti.ValuationSpectrum.residueFieldValuation`. -/
+@[simp]
+theorem residueFieldValuation_algebraMap (v : Spv A) (x : residueRing v) :
+    residueFieldValuation v (algebraMap (residueRing v) (FractionRing (residueRing v)) x)
+      = quotientValuation v x :=
+  Valuation.extendToLocalization_apply_map_apply _ _ _ _
 
 end ValuationSpectrum
 


### PR DESCRIPTION
A point `v : Spv A` carries a valuation on `A`, but not one on a field. This makes it one, which
is the form Layer 3.3 evaluates sections of the structure presheaf in.

```text
residueRing v            = A ⧸ supp v          -- a domain, since supp v is prime
quotientValuation v      : Valuation (residueRing v) Γ(v)
quotientValuation_ne_zero                       -- trivial support on the quotient
residueFieldValuation v  : Valuation (Frac (residueRing v)) Γ(v)
```

One new file, `TauCeti/AlgebraicGeometry/AdicSpace/ResidueField.lean`, 84 lines.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-3.3-residue-field-valuation"}-->

Provenance: github.com/CBirkbeck/AINTLIB @ 37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c, Apache-2.0,
adapted from `projects/AdicSpaces/Adic spaces/CompletedResidueField.lean` (a sorry-free file):
`residueRing`, `quotientValuation`, `quotientValuation_ne_zero`, `residueFieldValuation`. The
completed residue field of that file is not included here — it needs `Spa` and a `PlusSubring`,
where this needs only `Spv`.

## What this is, and where it sits

A **§2.4 construction**: the residue field of a point of the valuation spectrum, built from
`v.supp` and `v.valuation` alone. Its only imports are `AdicSpace.ValuationSpectrum` and Mathlib's
`FractionRing`, so it depends on Layer 1 and nothing later — in particular not on Layer 3.1's
rational-domain homeomorphism or rational agreement.

It carries a Layer 3.3 marker because Layer 3.3 is what **consumes** it, not because it does Layer
3.3's own work. Under the roadmap gate this is the "supplies a prerequisite that a specific target
needs" clause.

## What downstream roadmap item needs this

`TauCetiRoadmap/AdicSpaces/README.md`, Layer 3.3 (the structure presheaf), verbatim:

> Prove that every stalk is a local ring, that the support of the point valuation is its maximal
> ideal, and that the valuation therefore factors through the residue field.

This is the factorisation in that last clause. Layer 3.3 defines `𝒪_X⁺(U) = {f ∈ 𝒪_X(U) :
v_x(f_x) ≤ 1 for every x ∈ U}`, and `v_x(f_x) ≤ 1` is a statement about the *residue field* of
`x` — so the condition cannot be written down before this valuation exists. The two stalk clauses
are separate later work; `presentationLimitPresheaf` (already on main) is the presheaf they
concern.

`STATUS.md` records the gap: Layer 3 has "the candidate presheaf" but "not the rational-domain
homeomorphism, rational agreement, stalk valuations or pre-adic spaces".

## What it reuses rather than rebuilds

Three things, each of which the first draft was about to duplicate:

* `ValuationSpectrum.valuation`, the canonical valuation of a point, and
  `ValuationSpectrum.supp_eq_valuation_supp` — both already on main. The draft defined its own
  `canonicalValuation` and hand-rolled the support bridge.
* **`Valuation.supp_quot`** (mathlib, `RingTheory/Valuation/Quotient.lean`) — the support of a
  descended valuation is the image of the original support. With it, trivial support on the
  quotient is a rewrite chain rather than an argument chasing a representative through
  `Ideal.Quotient.mk_surjective`. The earlier proof also concealed a definitional unfolding of
  `Valuation.onQuotVal`; every step is now a named lemma.

Mathlib's `Valuation.supp_quot_supp` states exactly "the descended valuation has trivial support"
and still cannot be used: it is stated with `le_rfl`, i.e. over `A ⧸ supp v.valuation`, whereas
`quotientValuation` descends along `A ⧸ supp v`. The two ideals are propositionally equal but the
quotient *types* differ, so `le_rfl` does not typecheck — checked by probe, not by eye.

## Why `≠ 0` and not `supp = ⊥`

`Valuation.extendToLocalization` takes `hS : S ≤ v.supp.primeCompl`, so the pointwise form is what
the call site consumes. The equational form would be a second declaration with no consumer.

