### PR TITLE
refactor: drop 25 more unused `set … with` equations

### DIFF
--- a/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
+++ b/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
@@ -122,7 +122,7 @@ theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
   -- (`IsArtinianRing.of_finite` is a theorem, not an instance, so it is supplied by hand).
   -- A right inverse therefore already presents the conjugator as a unit.
   have : IsArtinianRing A := IsArtinianRing.of_finite K A
-  set u : A := (Bimodule.of g).symm (ψ (Bimodule.of f 1)) with hu
+  set u : A := (Bimodule.of g).symm (ψ (Bimodule.of f 1))
   -- Name the two coercions of the constructed unit through the stable `Units` API rather than
   -- relying on `Units.mkOfMulEqOne` reducing definitionally.
   have hUval : ((Units.mkOfMulEqOne u v huv : Aˣ) : A) = u := Units.val_mkOfMulEqOne huv

--- a/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
+++ b/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
@@ -134,7 +134,7 @@ theorem exists_compl_fixedBy_subset_apply_eq {ι β : Type*} [Finite ι] (f g : 
     ∃ σ : Equiv.Perm β,
       (MulAction.fixedBy β σ)ᶜ ⊆ Set.range f ∪ Set.range g ∧ ∀ i, σ (f i) = g i := by
   classical
-  set T : Set β := Set.range f ∪ Set.range g with hT
+  set T : Set β := Set.range f ∪ Set.range g
   have : Fintype ↥T := ((Set.finite_range f).union (Set.finite_range g)).fintype
   have hfT : ∀ i, f i ∈ T := fun i => Or.inl ⟨i, rfl⟩
   have hgT : ∀ i, g i ∈ T := fun i => Or.inr ⟨i, rfl⟩

--- a/TauCeti/Analysis/Contour/PiecewiseC1On.lean
+++ b/TauCeti/Analysis/Contour/PiecewiseC1On.lean
@@ -292,7 +292,7 @@ private theorem piecewise_gluing_induction {p : Finset ℝ} {Q : ℝ → ℝ →
     intro c d hcard hcd hsub
     rcases (p.filter (· ∈ Ioo c d)).eq_empty_or_nonempty with he | hne
     · exact hbase c d hcd hsub (hdisj he)
-    set m := (p.filter (· ∈ Ioo c d)).max' hne with hm_def
+    set m := (p.filter (· ∈ Ioo c d)).max' hne
     obtain ⟨hmp, hm⟩ := Finset.mem_filter.mp ((p.filter (· ∈ Ioo c d)).max'_mem hne)
     have hssub : p.filter (· ∈ Ioo c m) ⊂ p.filter (· ∈ Ioo c d) :=
       (Finset.ssubset_iff_of_subset (Finset.monotone_filter_right _ fun x _ hx =>

--- a/TauCeti/Analysis/Contour/PwC1ImmersionOn.lean
+++ b/TauCeti/Analysis/Contour/PwC1ImmersionOn.lean
@@ -160,7 +160,7 @@ private theorem exists_Icc_right_avoiding {p : Finset ℝ} {t₀ : ℝ}
     (hp : ↑p ⊆ Ioo (min a b) (max a b)) (ht₀ : t₀ ∈ Ico (min a b) (max a b)) :
     ∃ d : ℝ, t₀ < d ∧ Icc t₀ d ⊆ uIcc a b ∧ Disjoint (↑p : Set ℝ) (Ioo t₀ d) := by
   classical
-  set q : Finset ℝ := insert (max a b) (p.filter (t₀ < ·)) with hq_def
+  set q : Finset ℝ := insert (max a b) (p.filter (t₀ < ·))
   have hq_ne : q.Nonempty := ⟨max a b, Finset.mem_insert_self _ _⟩
   refine ⟨q.min' hq_ne, ?_, ?_, ?_⟩
   · rcases Finset.mem_insert.mp (q.min'_mem hq_ne) with hm | hm
@@ -181,7 +181,7 @@ private theorem exists_Icc_left_avoiding {p : Finset ℝ} {t₀ : ℝ}
     (hp : ↑p ⊆ Ioo (min a b) (max a b)) (ht₀ : t₀ ∈ Ioc (min a b) (max a b)) :
     ∃ c : ℝ, c < t₀ ∧ Icc c t₀ ⊆ uIcc a b ∧ Disjoint (↑p : Set ℝ) (Ioo c t₀) := by
   classical
-  set q : Finset ℝ := insert (min a b) (p.filter (· < t₀)) with hq_def
+  set q : Finset ℝ := insert (min a b) (p.filter (· < t₀))
   have hq_ne : q.Nonempty := ⟨min a b, Finset.mem_insert_self _ _⟩
   refine ⟨q.max' hq_ne, ?_, ?_, ?_⟩
   · rcases Finset.mem_insert.mp (q.max'_mem hq_ne) with hm | hm

--- a/TauCeti/Analysis/Contour/Residue/Theorem.lean
+++ b/TauCeti/Analysis/Contour/Residue/Theorem.lean
@@ -301,7 +301,7 @@ theorem classicalResidueTheorem_circle_of_meromorphicOrderAt_neg {f : ℂ → �
     circleIntegral f c R = 2 * (Real.pi : ℂ) * Complex.I * (∑ s ∈ S, residue f s) := by
   -- Pass to the meromorphic normal form `F` of `f`: it is genuinely analytic off `S` (whereas raw
   -- `f` may take isolated "wrong values"), and the circle integral and residues are unchanged.
-  set F := toMeromorphicNFOn f (closedBall c R) with hF_def
+  set F := toMeromorphicNFOn f (closedBall c R)
   have hF_mero : MeromorphicOn F (closedBall c R) :=
     (meromorphicNFOn_toMeromorphicNFOn f _).meromorphicOn
   have hordF : ∀ z ∈ closedBall c R, meromorphicOrderAt F z = meromorphicOrderAt f z :=

--- a/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
@@ -272,7 +272,7 @@ theorem setIntegral_pi_eq_zero_of_forall_inner {h : Lp 𝕜 2 (Measure.pi μ)}
     (hz : ∀ F : ∀ i, Lp 𝕜 2 (μ i), inner 𝕜 (L2piMul F) h = 0)
     (s : ∀ i, Set (α i)) (hs : ∀ i, MeasurableSet (s i)) (hfin : ∀ i, μ i (s i) ≠ ⊤) :
     ∫ x in Set.univ.pi s, h x ∂(Measure.pi μ) = 0 := by
-  set F : ∀ i, Lp 𝕜 2 (μ i) := fun i => indicatorConstLp 2 (hs i) (hfin i) (1 : 𝕜) with hFdef
+  set F : ∀ i, Lp 𝕜 2 (μ i) := fun i => indicatorConstLp 2 (hs i) (hfin i) (1 : 𝕜)
   have hFc : ∀ᵐ x : ∀ i, α i ∂(Measure.pi μ),
       ∀ i, F i (x i) = (s i).indicator (fun _ => (1 : 𝕜)) (x i) := by
     rw [ae_all_iff]

--- a/TauCeti/Analysis/InnerProductSpace/L2/Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Product.lean
@@ -255,8 +255,8 @@ theorem setIntegral_prod_eq_zero_of_forall_inner [SFinite μ] [SFinite ν] {h : 
     {A : Set α} (hA : MeasurableSet A) (hμA : μ A ≠ ⊤)
     {B : Set β} (hB : MeasurableSet B) (hνB : ν B ≠ ⊤) :
     ∫ p in A ×ˢ B, h p ∂(μ.prod ν) = 0 := by
-  set F : Lp 𝕜 2 μ := indicatorConstLp 2 hA hμA (1 : 𝕜) with hFdef
-  set G : Lp 𝕜 2 ν := indicatorConstLp 2 hB hνB (1 : 𝕜) with hGdef
+  set F : Lp 𝕜 2 μ := indicatorConstLp 2 hA hμA (1 : 𝕜)
+  set G : Lp 𝕜 2 ν := indicatorConstLp 2 hB hνB (1 : 𝕜)
   have hFc : ⇑F =ᵐ[μ] A.indicator fun _ => (1 : 𝕜) := indicatorConstLp_coeFn
   have hGc : ⇑G =ᵐ[ν] B.indicator fun _ => (1 : 𝕜) := indicatorConstLp_coeFn
   calc ∫ p in A ×ˢ B, h p ∂(μ.prod ν)

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
@@ -105,7 +105,7 @@ maximum principle with drift. -/
 @[simp] theorem laplacian_exp_inner (α : ℝ) (u x : E) :
     Δ (fun y : E => Real.exp (α * ⟪u, y⟫)) x
       = α ^ 2 * ‖u‖ ^ 2 * Real.exp (α * ⟪u, x⟫) := by
-  set w : E → ℝ := fun y => Real.exp (α * ⟪u, y⟫) with hw
+  set w : E → ℝ := fun y => Real.exp (α * ⟪u, y⟫)
   -- The first derivative of `w`, as a function of the base point.
   have hfw : fderiv ℝ w = fun y => Real.exp (α * ⟪u, y⟫) • (α • innerSL ℝ u) :=
     funext fun y => (hasFDerivAt_exp_inner α u y).fderiv

--- a/TauCeti/Data/Nat/Factorization/PrimePowerProd/DivisorTable.lean
+++ b/TauCeti/Data/Nat/Factorization/PrimePowerProd/DivisorTable.lean
@@ -175,7 +175,7 @@ theorem primePowerProd_mul_eq_sum_divisors_gcd
       Nat.div_one, primePowerProd_one, one_mul,
       ← primePowerProd_mul_of_coprime D hg fun _ _ _ _ _ ↦ Commute.all _ _]
   -- Split both arguments at the least prime `p` of the gcd.
-  set p := g.minFac with hp_def
+  set p := g.minFac
   have hp : p.Prime := Nat.minFac_prime hg1
   have hpm : p ∣ m := (Nat.minFac_dvd g).trans (hg ▸ Nat.gcd_dvd_left m n)
   have hpn : p ∣ n := (Nat.minFac_dvd g).trans (hg ▸ Nat.gcd_dvd_right m n)

--- a/TauCeti/FieldTheory/FunctionField/Different/Divisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Different/Divisor.lean
@@ -96,7 +96,7 @@ a divisor. -/
 theorem finite_setOf_differentExponent_ne_zero (hF : IsFunctionField k F) :
     {P' : Place k' F' | differentExponent k F P' ≠ 0}.Finite := by
   classical
-  set b : Basis (Fin (finrank F F')) F F' := finBasis F F' with hb
+  set b : Basis (Fin (finrank F F')) F F' := finBasis F F'
   set bad : Set (Place k F) :=
     {P | P.ord (Algebra.discr F b) ≠ 0} ∪ ⋃ i, {P | ¬ IsIntegral P.integers (b i)} with hbaddef
   have hbad : bad.Finite :=

--- a/TauCeti/GroupTheory/ExponentTwo.lean
+++ b/TauCeti/GroupTheory/ExponentTwo.lean
@@ -82,7 +82,7 @@ theorem exists_index_eq_two_notMem_of_exponent_dvd_two (hexp : Monoid.exponent G
     simpa using mul_mem (inv_mem hb) hbσ
   · -- Otherwise `H ⊔ ⟨b⟩` is strictly bigger than `H`, hence contains `σ` by maximality.
     refine Or.inl ⟨?_, hb⟩
-    set N : Subgroup G := Subgroup.closure {b} with hN
+    set N : Subgroup G := Subgroup.closure {b}
     have hbN : b ∈ N := Subgroup.subset_closure rfl
     have : N.Normal := ⟨fun n hn g => by
       rw [hcomm g n, mul_assoc, mul_inv_cancel, mul_one]; exact hn⟩

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Basic.lean
@@ -167,7 +167,7 @@ theorem hasCartanType_of_pairing_eq [FaithfulSMul ℤ R] {P : RootPairing ι R M
     · rintro ⟨k, hk⟩
       obtain ⟨i, rfl⟩ := (mem_simpleSupport he).mp (hb ▸ hk)
       exact ⟨i, rfl⟩
-  set q := (Equiv.ofBijective _ hbij).symm with hq
+  set q := (Equiv.ofBijective _ hbij).symm
   refine (hasCartanType_iff b t).mpr ⟨q, fun i j => ?_⟩
   have hval : ∀ x : b.support, (x : ι) = e (q x) := fun x =>
     congrArg Subtype.val (Equiv.apply_symm_apply (Equiv.ofBijective _ hbij) x).symm

--- a/TauCeti/NumberTheory/EffectiveBounds/HermiteCount/Basic.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/HermiteCount/Basic.lean
@@ -175,8 +175,8 @@ theorem ncard_setOf_finiteDimensional_abs_discr_le_le :
         |discr K| ≤ (N : ℤ)}.ncard ≤
       (2 * coeffBoundOfDiscrBdd N + 1) ^ (rankOfDiscrBdd N + 1) * rankOfDiscrBdd N := by
   classical
-  set D := rankOfDiscrBdd N with hD
-  set C := coeffBoundOfDiscrBdd N with hC
+  set D := rankOfDiscrBdd N
+  set C := coeffBoundOfDiscrBdd N
   set S := {K : {F : IntermediateField ℚ A // FiniteDimensional ℚ F} |
       haveI : _root_.NumberField K := @NumberField.mk _ _ inferInstance K.prop
       |discr K| ≤ (N : ℤ)} with hS

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/TwoRank.lean
@@ -81,7 +81,7 @@ theorem narrowTwoRank_le_ncard_ramifiedPrimes_sub_one
     (hsf : Squarefree d) (hd : 1 < d.natAbs) :
     NumberField.NarrowClassGroup.twoRank K ≤ (ramifiedPrimes K).ncard - 1 := by
   classical
-  set s := (NumberField.finite_ramifiedPrimes (K := K)).toFinset with hsdef
+  set s := (NumberField.finite_ramifiedPrimes (K := K)).toFinset
   have hscoe : (s : Set ℕ) = ramifiedPrimes K := Set.Finite.coe_toFinset _
   have hcard : s.card = (ramifiedPrimes K).ncard := by
     rw [← Set.ncard_coe_finset, hscoe]

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -195,8 +195,8 @@ private theorem exists_half_int_coords (hmin : minpoly ℤ θ = X ^ 2 - C d)
   have hfr := finrank_rat_eq_two hmin hgen
   obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
     hfr (gen_notMem_range hmin) θ.isIntegral_coe
-  set a := bs.repr (z : K) 0 with ha
-  set c := bs.repr (z : K) 1 with hc
+  set a := bs.repr (z : K) 0
+  set c := bs.repr (z : K) 1
   have hz : (z : K) = algebraMap ℚ K a + algebraMap ℚ K c * (θ : K) := by
     have hsum := bs.sum_repr (z : K)
     rw [Fin.sum_univ_two, hbs] at hsum

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/BlockCylinder.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/BlockCylinder.lean
@@ -69,7 +69,7 @@ theorem measure_inter_blockCylinder_eq_setLIntegral_of_condExp [StandardBorelSpa
   have hTail : tailProcess X ≤ ‹MeasurableSpace Ω› :=
     tailProcess_le_ambient 0 fun j _ => hX_meas j
   have : IsFiniteMeasure (μ.trim hTail) := isFiniteMeasure_trim hTail
-  set A : Set Ω := directingProbabilityMeasure μ X ⁻¹' S with hA_def
+  set A : Set Ω := directingProbabilityMeasure μ X ⁻¹' S
   have hA_tail : MeasurableSet[tailProcess X] A :=
     measurable_tailProcess_directingProbabilityMeasure hS
   have hA : MeasurableSet A := hTail _ hA_tail

--- a/TauCeti/RepresentationTheory/CharacterTable/Completeness.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Completeness.lean
@@ -138,7 +138,7 @@ orthonormal for the character pairing, so the coefficient of `χᵢ` is the pair
 theorem sum_characterPairing_smul_ofCharacter (f : ClassFunction k G) :
     ∑ i, characterPairing (ofCharacter (ρ i)) f • ofCharacter (ρ i) = f := by
   classical
-  set b := basisOfIrreducibleCharacters ρ hind hcard with hb
+  set b := basisOfIrreducibleCharacters ρ hind hcard
   have hbi : ∀ i, b i = ofCharacter (ρ i) := basisOfIrreducibleCharacters_apply ρ hind hcard
   have hrepr : ∀ j, characterPairing (ofCharacter (ρ j)) f = b.repr f j := by
     intro j

--- a/TauCeti/RingTheory/Semisimple/EndAlgebra.lean
+++ b/TauCeti/RingTheory/Semisimple/EndAlgebra.lean
@@ -148,8 +148,8 @@ theorem finrank_end_mul_finrank_eq_sq :
   rw [← isSimpleModule_iff_isAtom] at hS
   obtain ⟨k, hk, ⟨eM⟩⟩ := exists_algEquiv_matrix_end K S M
   obtain ⟨m, hm, ⟨eR⟩⟩ := exists_algEquiv_matrix_end K S R
-  set s := finrank K S with hs
-  set d := finrank K (Module.End R ↥S) with hd
+  set s := finrank K S
+  set d := finrank K (Module.End R ↥S)
   -- The matrix presentations turn both endomorphism dimensions into `(size)² * d`.
   have hEM : finrank K (Module.End R M) = k ^ 2 * d := by
     rw [(eM.toLinearEquiv).finrank_eq, Module.finrank_matrix, Fintype.card_fin, sq]

--- a/TauCeti/RingTheory/Valuation/CofinalIdeal/Restrict.lean
+++ b/TauCeti/RingTheory/Valuation/CofinalIdeal/Restrict.lean
@@ -466,7 +466,7 @@ theorem restrictToIdeal_ne_zero_of_isAdmissible (v : Valuation A Γ₀) (I : Ide
     (hu0 : v u ≠ 0) (hT : ∀ t ∈ T, v t ≤ v u) :
     v.restrictToIdeal I hfg u ≠ 0 := by
   intro hRu
-  set R := v.restrictToIdeal I hfg with hR
+  set R := v.restrictToIdeal I hfg
   have hsupp : insert u T ⊆ (Valuation.supp R : Set A) := by
     rintro t (rfl | ht)
     · exact hRu

--- a/TauCeti/Topology/Covering/Factorization.lean
+++ b/TauCeti/Topology/Covering/Factorization.lean
@@ -81,7 +81,7 @@ private theorem isEvenlyCovered_of_trivialization (hq : Continuous q) (hg : Cont
         (tq (g (tp.toOpenPartialHomeomorph.symm (q f₀, i)))).2 :=
     fun i _ hv => hVconn.constant (hcont i) hv hf₀V
   set j₀ : J := (tq f₀).2 with hj₀
-  set W : Set F := {f | q f ∈ V ∧ (tq f).2 = j₀} with hWdef
+  set W : Set F := {f | q f ∈ V ∧ (tq f).2 = j₀}
   have hf₀W : f₀ ∈ W := ⟨hf₀V, rfl⟩
   have hWopen : IsOpen W := by
     have hW : W = q ⁻¹' V ∩ (tq.source ∩ (fun f => (tq f).2) ⁻¹' {j₀}) := by


### PR DESCRIPTION
Follow-up to #5730, same class and same scan. `set x := e with h` binds the
defining equation `h : x = e`; in these 25 proofs the abstracted variable is
used throughout but the equation never is — not by name, and not by any tactic
that reads the local context. Dropping the `with` clause leaves the `set` and
every other step unchanged.

**Why this is separable from a dead `have`.** A `with` clause has no proof term,
so unlike #5727 (where a dead `have`'s proof was the only consumer of two of its
theorem's binders) removing it cannot strand a hypothesis. The only way to be
wrong here is if the equation is consumed, which is exactly what the scan tests.

**How each row was screened.**

* The equation name never occurs after the `set`, searching the proof body
  delimited by the enclosing declaration — not a fixed line window.
* No context-searching tactic appears in that body: `omega`, `linarith`,
  `nlinarith`, `simp_all`, `aesop`, `assumption`, `positivity`, `grobner`,
  `lia`, `field`, `congr`/`congrm`/`convert`, `rwa`/`simpa` (both fall back to
  `assumption`), `subst` (which names the variable, not the hypothesis),
  `norm_num`, `field_simp`, `gcongr`, `decide`, `tauto`, and `simp [*]`/`at *`.
* Each edit is applied **by line number** with the line asserted to start with
  `set ` and end with the exact ` with <name>` suffix, after #5730 turned up a
  file containing the same `set … with` line twice where only one was dead.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp