### PR TITLE
refactor(ModularForms): split the twisted-invariance proof into its steps

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
@@ -259,9 +259,11 @@ twisted operators live on the character space where the unweighted `heckeSlashSu
 
 The proof is Shimura's Proposition 3.37 with the character carried through. Right multiplication by
 `γ` permutes the right cosets — the permutation is `MulAction.toPerm` at `γ⁻¹`, exactly as in
-`HeckeSlash/Invariance.lean` — and the one new step, that a right factor of `γ` multiplies a
-summand's weight by `χ (d_γ)⁻¹`, is `nebentypusWeight_smul_slash_slash_eq_char_smul`; that
-eigenvalue then comes back out of the sum and is what the conclusion asserts. -/
+`HeckeSlash/Invariance.lean` — and the one new step is that a right factor of `γ` multiplies a
+summand's weight by `χ (d_γ)⁻¹`, which is
+`nebentypusWeight_eq_char_mul_delta0NebentypusChar`. Combining that with the reindexing gives the
+per-summand identity `nebentypusWeight_smul_slash_slash_eq_char_smul`, and the eigenvalue then
+comes back out of the sum and is what the conclusion asserts. -/
 theorem twistedHeckeSlashSum_mem_functionCharSpace (f : ℍ → ℂ)
     (hf : f ∈ functionCharSpace k χ) :
     twistedHeckeSlashSum k χ D f ∈ functionCharSpace k χ := by

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
@@ -130,10 +130,13 @@ lemma mul_inv_mem_Delta0 {h : GL (Fin 2) ℚ} (hh : h ∈ (Gamma0 N).map (mapGL 
     rw [Subgroup.mem_toSubmonoid, Gamma0Image_def]
     exact inv_mem hh))
 
-/-- The unnormalised representative `δ (γ⁻¹ τᵥ)⁻¹` of the class `γ⁻¹ • v` is the chosen
-representative `τᵥ` with `γ` attached on the right. Both spellings are needed below — the first
-because it is what `mul_inv_mem_Delta0` and the weight lemma are stated at, the second because the
-slash has to be split as `(f ∣ τᵥ) ∣ γ`. -/
+/-- The image of `γ ∈ Γ₀(N)` in the rational copy of `Γ₀(N)` that the Hecke triple acts through. -/
+private lemma mapGL_mem_map_Gamma0 (γ : ↥(Gamma0 N)) :
+    (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) ∈ (Gamma0 N).map (mapGL ℚ) :=
+  Subgroup.mem_map.mpr ⟨_, γ.2, rfl⟩
+
+/-- The chosen representative `τᵥ` with `γ` attached on the right is the unnormalised
+representative `δ (γ⁻¹ τᵥ)⁻¹` of the class `γ⁻¹ • v`. -/
 private lemma rightCosetRep_mul_eq_mul_inv (γ : ↥(Gamma0 N))
     (v : DecompQuotient ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
       (D.out : GL (Fin 2) ℚ)⁻¹) :
@@ -143,28 +146,29 @@ private lemma rightCosetRep_mul_eq_mul_inv (γ : ↥(Gamma0 N))
   rw [rightCosetRep_def]
   group
 
-/-- **A right factor from `Γ₀(N)` scales the weight by `χ (d_γ)⁻¹.** By
+/-- **A right factor from `Γ₀(N)` scales the weight by `χ (d_γ)⁻¹`.** By
 `rightCosetRep_mul_eq_mul_inv` the unnormalised representative of `γ⁻¹ • v` is `τᵥ γ`, so its
 weight is `Wᵥ` divided by `χ (d_γ)`: `delta0NebentypusChar` is multiplicative, and
 `delta0NebentypusChar_mapGL` inverts the nebentypus on `Γ₀(N)`.
 
-Stated in the direction the reindexing consumes it, with `Wᵥ` alone on the left, so that it can be
-rewritten under the slash. This is `delta0Nebentypus_left_weight` of the source. -/
+This is `delta0Nebentypus_left_weight` of the source. -/
 private lemma nebentypusWeight_eq_char_mul_delta0NebentypusChar (γ : ↥(Gamma0 N))
     (v : DecompQuotient ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
-      (D.out : GL (Fin 2) ℚ)⁻¹)
-    (hh : ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ)) ∈
-      (Gamma0 N).map (mapGL ℚ)) :
+      (D.out : GL (Fin 2) ℚ)⁻¹) :
     (nebentypusWeight χ D v : ℂ) = (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) *
       (delta0NebentypusChar N χ ⟨(D.out : GL (Fin 2) ℚ) *
         ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹,
-        mul_inv_mem_Delta0 D hh⟩ : ℂ) := by
-  rw [show (⟨(D.out : GL (Fin 2) ℚ) *
-          ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹,
-        mul_inv_mem_Delta0 D hh⟩ : Delta0 N) =
-      ⟨rightCosetRep D v, rightCosetRep_mem_Delta0 D v⟩ * ⟨_, mapGL_mem_Delta0 N γ⟩ from
-      Subtype.ext (rightCosetRep_mul_eq_mul_inv D γ v).symm,
-    map_mul, Units.val_mul, delta0NebentypusChar_mapGL, Units.val_inv_eq_inv_val,
+        mul_inv_mem_Delta0 D (mul_mem (inv_mem (mapGL_mem_map_Gamma0 γ)) v.out.2)⟩ : ℂ) := by
+  -- `delta0NebentypusChar` is a `MonoidHom` on the subtype `Δ₀(N)`, so reaching `map_mul` needs
+  -- the factorisation as an equality of *subtype* elements, not of matrices: the two sides carry
+  -- different membership proofs, which `rw` on the carrier alone cannot reconcile. `Subtype.ext`
+  -- discharges the proof field and leaves exactly `rightCosetRep_mul_eq_mul_inv`.
+  have hfactor : (⟨(D.out : GL (Fin 2) ℚ) *
+        ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹,
+      mul_inv_mem_Delta0 D (mul_mem (inv_mem (mapGL_mem_map_Gamma0 γ)) v.out.2)⟩ : Delta0 N) =
+      ⟨rightCosetRep D v, rightCosetRep_mem_Delta0 D v⟩ * ⟨_, mapGL_mem_Delta0 N γ⟩ :=
+    Subtype.ext (rightCosetRep_mul_eq_mul_inv D γ v).symm
+  rw [hfactor, map_mul, Units.val_mul, delta0NebentypusChar_mapGL, Units.val_inv_eq_inv_val,
     nebentypusWeight_def]
   field_simp
 
@@ -214,32 +218,30 @@ lemma delta0NebentypusChar_smul_slash_eq_nebentypusWeight_smul_slash (f : ℍ �
 
 /-- **Slashing a weighted summand by `γ` gives `χ (d_γ)` times the summand at `γ⁻¹ • v`.** The
 per-summand step of `twistedHeckeSlashSum_mem_functionCharSpace`, and
-`twisted_weighted_slash_tRep_gen_of_mem` of the source: the slash splits off `γ` on the right,
-`nebentypusWeight_eq_char_mul_delta0NebentypusChar` pulls `χ (d_γ)` out of the weight, and what
-is left is the unnormalised representative that
-`delta0NebentypusChar_smul_slash_eq_nebentypusWeight_smul_slash` identifies with the `γ⁻¹ • v`-th
-summand.
-
-`hmem` is `γ` in the rational copy of `Γ₀(N)`; it is a hypothesis rather than a local `have`
-because it names the group element doing the acting, so it occurs in the statement. -/
+`twisted_weighted_slash_tRep_gen_of_mem` of the source. -/
 private lemma nebentypusWeight_smul_slash_slash_eq_char_smul (f : ℍ → ℂ)
     (hf : f ∈ functionCharSpace k χ) (γ : ↥(Gamma0 N))
-    (hmem : (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) ∈ (Gamma0 N).map (mapGL ℚ))
     (v : DecompQuotient ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
       (D.out : GL (Fin 2) ℚ)⁻¹) :
     ((nebentypusWeight χ D v : ℂ) • (f ∣[k] rightCosetRep D v)) ∣[k]
         (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) =
       (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) •
-        ((nebentypusWeight χ D ((⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ • v) : ℂ) •
-          (f ∣[k] rightCosetRep D ((⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ • v))) := by
+        ((nebentypusWeight χ D ((⟨_, mapGL_mem_map_Gamma0 γ⟩ :
+            ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ • v) : ℂ) •
+          (f ∣[k] rightCosetRep D ((⟨_, mapGL_mem_map_Gamma0 γ⟩ :
+            ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ • v))) := by
   have hh : ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ)) ∈
-      (Gamma0 N).map (mapGL ℚ) := mul_mem (inv_mem hmem) v.out.2
+      (Gamma0 N).map (mapGL ℚ) := mul_mem (inv_mem (mapGL_mem_map_Gamma0 γ)) v.out.2
+  -- pull `γ` out of the slash on the right, rewrite the product of representatives as the
+  -- unnormalised representative of `γ⁻¹ • v`, then take `χ (d_γ)` out of the weight
   rw [ModularForm.rat_smul_slash_of_det_pos k
       (posDetInt_le_glpos 2 (Delta0_le_posDetInt N (mapGL_mem_Delta0 N γ))) _ _,
     ← SlashAction.slash_mul, rightCosetRep_mul_eq_mul_inv D γ v,
-    nebentypusWeight_eq_char_mul_delta0NebentypusChar χ D γ v hh, mul_smul]
+    nebentypusWeight_eq_char_mul_delta0NebentypusChar χ D γ v, mul_smul]
+  -- what remains is that the unnormalised representative has the same weighted slash as `τ`
   exact congrArg _ (delta0NebentypusChar_smul_slash_eq_nebentypusWeight_smul_slash k χ D f hf hh
-    (MulAction.Quotient.mk_smul_out _ (⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ v))
+    (MulAction.Quotient.mk_smul_out _ (⟨_, mapGL_mem_map_Gamma0 γ⟩ :
+      ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ v))
 
 variable [NeZero N]
 
@@ -267,16 +269,15 @@ theorem twistedHeckeSlashSum_mem_functionCharSpace (f : ℍ → ℂ)
   -- `intro` on its own.
   rw [mem_functionCharSpace_iff]
   intro γ
-  -- `γ` is needed in two spellings: integral, to carry the character, and in the rational copy of
-  -- `Γ₀(N)` the Hecke triple is built from, which is what acts on the coset index.
-  have hmem : (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) ∈ (Gamma0 N).map (mapGL ℚ) :=
-    Subgroup.mem_map.mpr ⟨_, γ.2, rfl⟩
   rw [← ModularForm.rat_slash_mapGL, twistedHeckeSlashSum_def, SlashAction.sum_slash,
     Finset.smul_sum]
-  exact Fintype.sum_equiv (MulAction.toPerm (⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹) _ _
+  -- right multiplication by `γ` permutes the right cosets; the permutation is `γ⁻¹` acting on
+  -- the index, and the per-summand identity then matches the two sums term by term
+  exact Fintype.sum_equiv
+    (MulAction.toPerm (⟨_, mapGL_mem_map_Gamma0 γ⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹) _ _
     fun v ↦ by
       simpa only [MulAction.toPerm_apply] using
-        nebentypusWeight_smul_slash_slash_eq_char_smul k χ D f hf γ hmem v
+        nebentypusWeight_smul_slash_slash_eq_char_smul k χ D f hf γ v
 
 /-- **The twisted slash sum as an endomorphism of the character space.** `twistedHeckeSlashSumEnd`
 is an endomorphism of *all* of `ℍ → ℂ`, and its own docstring records that this is the wrong

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
@@ -130,11 +130,6 @@ lemma mul_inv_mem_Delta0 {h : GL (Fin 2) ℚ} (hh : h ∈ (Gamma0 N).map (mapGL 
     rw [Subgroup.mem_toSubmonoid, Gamma0Image_def]
     exact inv_mem hh))
 
-/-- The image of `γ ∈ Γ₀(N)` in the rational copy of `Γ₀(N)` that the Hecke triple acts through. -/
-private lemma mapGL_mem_map_Gamma0 (γ : ↥(Gamma0 N)) :
-    (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) ∈ (Gamma0 N).map (mapGL ℚ) :=
-  Subgroup.mem_map.mpr ⟨_, γ.2, rfl⟩
-
 /-- The chosen representative `τᵥ` with `γ` attached on the right is the unnormalised
 representative `δ (γ⁻¹ τᵥ)⁻¹` of the class `γ⁻¹ • v`. -/
 private lemma rightCosetRep_mul_eq_mul_inv (γ : ↥(Gamma0 N))
@@ -158,14 +153,18 @@ private lemma nebentypusWeight_eq_char_mul_delta0NebentypusChar (γ : ↥(Gamma0
     (nebentypusWeight χ D v : ℂ) = (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) *
       (delta0NebentypusChar N χ ⟨(D.out : GL (Fin 2) ℚ) *
         ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹,
-        mul_inv_mem_Delta0 D (mul_mem (inv_mem (mapGL_mem_map_Gamma0 γ)) v.out.2)⟩ : ℂ) := by
+        mul_inv_mem_Delta0 D
+          (mul_mem (inv_mem (Subgroup.apply_coe_mem_map (mapGL ℚ) (Gamma0 N) γ)) v.out.2)⟩ :
+        ℂ) := by
   -- `delta0NebentypusChar` is a `MonoidHom` on the subtype `Δ₀(N)`, so reaching `map_mul` needs
   -- the factorisation as an equality of *subtype* elements, not of matrices: the two sides carry
   -- different membership proofs, which `rw` on the carrier alone cannot reconcile. `Subtype.ext`
   -- discharges the proof field and leaves exactly `rightCosetRep_mul_eq_mul_inv`.
   have hfactor : (⟨(D.out : GL (Fin 2) ℚ) *
         ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹,
-      mul_inv_mem_Delta0 D (mul_mem (inv_mem (mapGL_mem_map_Gamma0 γ)) v.out.2)⟩ : Delta0 N) =
+      mul_inv_mem_Delta0 D
+        (mul_mem (inv_mem (Subgroup.apply_coe_mem_map (mapGL ℚ) (Gamma0 N) γ)) v.out.2)⟩ :
+      Delta0 N) =
       ⟨rightCosetRep D v, rightCosetRep_mem_Delta0 D v⟩ * ⟨_, mapGL_mem_Delta0 N γ⟩ :=
     Subtype.ext (rightCosetRep_mul_eq_mul_inv D γ v).symm
   rw [hfactor, map_mul, Units.val_mul, delta0NebentypusChar_mapGL, Units.val_inv_eq_inv_val,
@@ -226,12 +225,13 @@ private lemma nebentypusWeight_smul_slash_slash_eq_char_smul (f : ℍ → ℂ)
     ((nebentypusWeight χ D v : ℂ) • (f ∣[k] rightCosetRep D v)) ∣[k]
         (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) =
       (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) •
-        ((nebentypusWeight χ D ((⟨_, mapGL_mem_map_Gamma0 γ⟩ :
+        ((nebentypusWeight χ D ((⟨_, Subgroup.apply_coe_mem_map (mapGL ℚ) (Gamma0 N) γ⟩ :
             ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ • v) : ℂ) •
-          (f ∣[k] rightCosetRep D ((⟨_, mapGL_mem_map_Gamma0 γ⟩ :
+          (f ∣[k] rightCosetRep D ((⟨_, Subgroup.apply_coe_mem_map (mapGL ℚ) (Gamma0 N) γ⟩ :
             ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ • v))) := by
   have hh : ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ)) ∈
-      (Gamma0 N).map (mapGL ℚ) := mul_mem (inv_mem (mapGL_mem_map_Gamma0 γ)) v.out.2
+      (Gamma0 N).map (mapGL ℚ) :=
+    mul_mem (inv_mem (Subgroup.apply_coe_mem_map (mapGL ℚ) (Gamma0 N) γ)) v.out.2
   -- pull `γ` out of the slash on the right, rewrite the product of representatives as the
   -- unnormalised representative of `γ⁻¹ • v`, then take `χ (d_γ)` out of the weight
   rw [ModularForm.rat_smul_slash_of_det_pos k
@@ -240,7 +240,7 @@ private lemma nebentypusWeight_smul_slash_slash_eq_char_smul (f : ℍ → ℂ)
     nebentypusWeight_eq_char_mul_delta0NebentypusChar χ D γ v, mul_smul]
   -- what remains is that the unnormalised representative has the same weighted slash as `τ`
   exact congrArg _ (delta0NebentypusChar_smul_slash_eq_nebentypusWeight_smul_slash k χ D f hf hh
-    (MulAction.Quotient.mk_smul_out _ (⟨_, mapGL_mem_map_Gamma0 γ⟩ :
+    (MulAction.Quotient.mk_smul_out _ (⟨_, Subgroup.apply_coe_mem_map (mapGL ℚ) (Gamma0 N) γ⟩ :
       ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ v))
 
 variable [NeZero N]
@@ -274,7 +274,8 @@ theorem twistedHeckeSlashSum_mem_functionCharSpace (f : ℍ → ℂ)
   -- right multiplication by `γ` permutes the right cosets; the permutation is `γ⁻¹` acting on
   -- the index, and the per-summand identity then matches the two sums term by term
   exact Fintype.sum_equiv
-    (MulAction.toPerm (⟨_, mapGL_mem_map_Gamma0 γ⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹) _ _
+    (MulAction.toPerm (⟨_, Subgroup.apply_coe_mem_map (mapGL ℚ) (Gamma0 N) γ⟩ :
+      ↥((Gamma0 N).map (mapGL ℚ)))⁻¹) _ _
     fun v ↦ by
       simpa only [MulAction.toPerm_apply] using
         nebentypusWeight_smul_slash_slash_eq_char_smul k χ D f hf γ v

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
@@ -53,7 +53,9 @@ Adapted from the AINTLIB `LeanModularForms` project
 <https://github.com/CBirkbeck/AINTLIB> @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`), whose
 `twistedHeckeSlashGen_preserves_invariant` (line 457) is the theorem below, with
 `twisted_weighted_slash_tRep_gen_of_mem` (line 319) and `delta0Nebentypus_left_weight` (line 391)
-its per-summand and weight-transformation steps.
+its per-summand and weight-transformation steps — which are, respectively, the private
+`nebentypusWeight_smul_slash_slash_eq_char_smul` and
+`nebentypusWeight_eq_char_mul_delta0NebentypusChar` here.
 
 Only the statements are taken. The source reaches them through some 210 lines of
 adjugate-and-correction plumbing — `gamma0Correction`, `gamma0_adjugate_decomp_eq`,
@@ -128,6 +130,44 @@ lemma mul_inv_mem_Delta0 {h : GL (Fin 2) ℚ} (hh : h ∈ (Gamma0 N).map (mapGL 
     rw [Subgroup.mem_toSubmonoid, Gamma0Image_def]
     exact inv_mem hh))
 
+/-- The unnormalised representative `δ (γ⁻¹ τᵥ)⁻¹` of the class `γ⁻¹ • v` is the chosen
+representative `τᵥ` with `γ` attached on the right. Both spellings are needed below — the first
+because it is what `mul_inv_mem_Delta0` and the weight lemma are stated at, the second because the
+slash has to be split as `(f ∣ τᵥ) ∣ γ`. -/
+private lemma rightCosetRep_mul_eq_mul_inv (γ : ↥(Gamma0 N))
+    (v : DecompQuotient ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
+      (D.out : GL (Fin 2) ℚ)⁻¹) :
+    rightCosetRep D v * (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) =
+      (D.out : GL (Fin 2) ℚ) *
+        ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹ := by
+  rw [rightCosetRep_def]
+  group
+
+/-- **A right factor from `Γ₀(N)` scales the weight by `χ (d_γ)⁻¹.** By
+`rightCosetRep_mul_eq_mul_inv` the unnormalised representative of `γ⁻¹ • v` is `τᵥ γ`, so its
+weight is `Wᵥ` divided by `χ (d_γ)`: `delta0NebentypusChar` is multiplicative, and
+`delta0NebentypusChar_mapGL` inverts the nebentypus on `Γ₀(N)`.
+
+Stated in the direction the reindexing consumes it, with `Wᵥ` alone on the left, so that it can be
+rewritten under the slash. This is `delta0Nebentypus_left_weight` of the source. -/
+private lemma nebentypusWeight_eq_char_mul_delta0NebentypusChar (γ : ↥(Gamma0 N))
+    (v : DecompQuotient ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
+      (D.out : GL (Fin 2) ℚ)⁻¹)
+    (hh : ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ)) ∈
+      (Gamma0 N).map (mapGL ℚ)) :
+    (nebentypusWeight χ D v : ℂ) = (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) *
+      (delta0NebentypusChar N χ ⟨(D.out : GL (Fin 2) ℚ) *
+        ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹,
+        mul_inv_mem_Delta0 D hh⟩ : ℂ) := by
+  rw [show (⟨(D.out : GL (Fin 2) ℚ) *
+          ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹,
+        mul_inv_mem_Delta0 D hh⟩ : Delta0 N) =
+      ⟨rightCosetRep D v, rightCosetRep_mem_Delta0 D v⟩ * ⟨_, mapGL_mem_Delta0 N γ⟩ from
+      Subtype.ext (rightCosetRep_mul_eq_mul_inv D γ v).symm,
+    map_mul, Units.val_mul, delta0NebentypusChar_mapGL, Units.val_inv_eq_inv_val,
+    nebentypusWeight_def]
+  field_simp
+
 /-- **An unnormalised representative carries the same weighted slash as the chosen one.** If `h` in
 `Γ₀(N)` has class `w`, then the weighted slash at `δ h⁻¹` is the `w`-th summand of
 `twistedHeckeSlashSum`.
@@ -172,6 +212,35 @@ lemma delta0NebentypusChar_smul_slash_eq_nebentypusWeight_smul_slash (f : ℍ �
     show (mapGL ℚ ((⟨σ, hσ⟩ : ↥(Gamma0 N)) : SL(2, ℤ)) : GL (Fin 2) ℚ) = mapGL ℚ σ from rfl, hσX]
   group
 
+/-- **Slashing a weighted summand by `γ` gives `χ (d_γ)` times the summand at `γ⁻¹ • v`.** The
+per-summand step of `twistedHeckeSlashSum_mem_functionCharSpace`, and
+`twisted_weighted_slash_tRep_gen_of_mem` of the source: the slash splits off `γ` on the right,
+`nebentypusWeight_eq_char_mul_delta0NebentypusChar` pulls `χ (d_γ)` out of the weight, and what
+is left is the unnormalised representative that
+`delta0NebentypusChar_smul_slash_eq_nebentypusWeight_smul_slash` identifies with the `γ⁻¹ • v`-th
+summand.
+
+`hmem` is `γ` in the rational copy of `Γ₀(N)`; it is a hypothesis rather than a local `have`
+because it names the group element doing the acting, so it occurs in the statement. -/
+private lemma nebentypusWeight_smul_slash_slash_eq_char_smul (f : ℍ → ℂ)
+    (hf : f ∈ functionCharSpace k χ) (γ : ↥(Gamma0 N))
+    (hmem : (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) ∈ (Gamma0 N).map (mapGL ℚ))
+    (v : DecompQuotient ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
+      (D.out : GL (Fin 2) ℚ)⁻¹) :
+    ((nebentypusWeight χ D v : ℂ) • (f ∣[k] rightCosetRep D v)) ∣[k]
+        (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) =
+      (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) •
+        ((nebentypusWeight χ D ((⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ • v) : ℂ) •
+          (f ∣[k] rightCosetRep D ((⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ • v))) := by
+  have hh : ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ)) ∈
+      (Gamma0 N).map (mapGL ℚ) := mul_mem (inv_mem hmem) v.out.2
+  rw [ModularForm.rat_smul_slash_of_det_pos k
+      (posDetInt_le_glpos 2 (Delta0_le_posDetInt N (mapGL_mem_Delta0 N γ))) _ _,
+    ← SlashAction.slash_mul, rightCosetRep_mul_eq_mul_inv D γ v,
+    nebentypusWeight_eq_char_mul_delta0NebentypusChar χ D γ v hh, mul_smul]
+  exact congrArg _ (delta0NebentypusChar_smul_slash_eq_nebentypusWeight_smul_slash k χ D f hf hh
+    (MulAction.Quotient.mk_smul_out _ (⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ v))
+
 variable [NeZero N]
 
 /-- The enumeration `∑` needs, chosen exactly as in `HeckeSlash/Nebentypus/Basic.lean` so that the
@@ -188,9 +257,9 @@ twisted operators live on the character space where the unweighted `heckeSlashSu
 
 The proof is Shimura's Proposition 3.37 with the character carried through. Right multiplication by
 `γ` permutes the right cosets — the permutation is `MulAction.toPerm` at `γ⁻¹`, exactly as in
-`HeckeSlash/Invariance.lean` — and the one new step is that a right factor of `γ` multiplies a
-summand's weight by `χ (d_γ)⁻¹`, so that eigenvalue comes back out of the sum and is what the
-conclusion asserts. -/
+`HeckeSlash/Invariance.lean` — and the one new step, that a right factor of `γ` multiplies a
+summand's weight by `χ (d_γ)⁻¹`, is `nebentypusWeight_smul_slash_slash_eq_char_smul`; that
+eigenvalue then comes back out of the sum and is what the conclusion asserts. -/
 theorem twistedHeckeSlashSum_mem_functionCharSpace (f : ℍ → ℂ)
     (hf : f ∈ functionCharSpace k χ) :
     twistedHeckeSlashSum k χ D f ∈ functionCharSpace k χ := by
@@ -202,45 +271,12 @@ theorem twistedHeckeSlashSum_mem_functionCharSpace (f : ℍ → ℂ)
   -- `Γ₀(N)` the Hecke triple is built from, which is what acts on the coset index.
   have hmem : (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) ∈ (Gamma0 N).map (mapGL ℚ) :=
     Subgroup.mem_map.mpr ⟨_, γ.2, rfl⟩
-  have hgΔ : (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) ∈ Delta0 N := mapGL_mem_Delta0 N γ
-  -- Slashing the `v`-th weighted summand by `γ` gives `χ (d_γ)` times the summand at `γ⁻¹ • v`.
-  have hperm (v : DecompQuotient ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
-      (D.out : GL (Fin 2) ℚ)⁻¹) :
-      ((nebentypusWeight χ D v : ℂ) • (f ∣[k] rightCosetRep D v)) ∣[k]
-          (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) =
-        (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) •
-          ((nebentypusWeight χ D ((⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ • v) : ℂ) •
-            (f ∣[k] rightCosetRep D ((⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ • v))) := by
-    have hh : ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ)) ∈
-        (Gamma0 N).map (mapGL ℚ) := mul_mem (inv_mem hmem) v.out.2
-    -- `aᵥ γ = δ τᵥ⁻¹ γ = δ (γ⁻¹ τᵥ)⁻¹`: an unnormalised representative of the class `γ⁻¹ • v`.
-    have hx : rightCosetRep D v * (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) =
-        (D.out : GL (Fin 2) ℚ) *
-          ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹ := by
-      rw [rightCosetRep_def]
-      group
-    -- Its weight is `Wᵥ · χ (d_γ)⁻¹`, because the twisting character is multiplicative on `Δ₀(N)`
-    -- and inverts the nebentypus on `Γ₀(N)`.
-    have hw : (nebentypusWeight χ D v : ℂ) = (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) *
-        (delta0NebentypusChar N χ ⟨(D.out : GL (Fin 2) ℚ) *
-          ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹,
-          mul_inv_mem_Delta0 D hh⟩ : ℂ) := by
-      rw [show (⟨(D.out : GL (Fin 2) ℚ) *
-              ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹,
-            mul_inv_mem_Delta0 D hh⟩ : Delta0 N) =
-          ⟨rightCosetRep D v, rightCosetRep_mem_Delta0 D v⟩ * ⟨_, hgΔ⟩ from Subtype.ext hx.symm,
-        map_mul, Units.val_mul, delta0NebentypusChar_mapGL, Units.val_inv_eq_inv_val,
-        nebentypusWeight_def]
-      field_simp
-    rw [ModularForm.rat_smul_slash_of_det_pos k
-        (posDetInt_le_glpos 2 (Delta0_le_posDetInt N hgΔ)) _ _,
-      ← SlashAction.slash_mul, hx, hw, mul_smul]
-    exact congrArg _ (delta0NebentypusChar_smul_slash_eq_nebentypusWeight_smul_slash k χ D f hf hh
-      (MulAction.Quotient.mk_smul_out _ (⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹ v))
   rw [← ModularForm.rat_slash_mapGL, twistedHeckeSlashSum_def, SlashAction.sum_slash,
     Finset.smul_sum]
   exact Fintype.sum_equiv (MulAction.toPerm (⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹) _ _
-    fun v ↦ by simpa only [MulAction.toPerm_apply] using hperm v
+    fun v ↦ by
+      simpa only [MulAction.toPerm_apply] using
+        nebentypusWeight_smul_slash_slash_eq_char_smul k χ D f hf γ hmem v
 
 /-- **The twisted slash sum as an endomorphism of the character space.** `twistedHeckeSlashSumEnd`
 is an endomorphism of *all* of `ℍ → ℂ`, and its own docstring records that this is the wrong

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
@@ -130,14 +130,13 @@ lemma mul_inv_mem_Delta0 {h : GL (Fin 2) ℚ} (hh : h ∈ (Gamma0 N).map (mapGL 
     rw [Subgroup.mem_toSubmonoid, Gamma0Image_def]
     exact inv_mem hh))
 
-/-- The chosen representative `τᵥ` with `γ` attached on the right is the unnormalised
-representative `δ (γ⁻¹ τᵥ)⁻¹` of the class `γ⁻¹ • v`. -/
-private lemma rightCosetRep_mul_eq_mul_inv (γ : ↥(Gamma0 N))
+/-- The chosen representative `τᵥ` with any `g` attached on the right is `δ (g⁻¹ τᵥ)⁻¹`. Pure
+group algebra: no hypothesis on `g` is used, and at `g ∈ Γ₀(N)` the right-hand side is the
+unnormalised representative of the class `g⁻¹ • v`. -/
+private lemma rightCosetRep_mul_eq_mul_inv (g : GL (Fin 2) ℚ)
     (v : DecompQuotient ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
       (D.out : GL (Fin 2) ℚ)⁻¹) :
-    rightCosetRep D v * (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) =
-      (D.out : GL (Fin 2) ℚ) *
-        ((mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹ := by
+    rightCosetRep D v * g = (D.out : GL (Fin 2) ℚ) * (g⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹ := by
   rw [rightCosetRep_def]
   group
 
@@ -166,7 +165,7 @@ private lemma nebentypusWeight_eq_char_mul_delta0NebentypusChar (γ : ↥(Gamma0
         (mul_mem (inv_mem (Subgroup.apply_coe_mem_map (mapGL ℚ) (Gamma0 N) γ)) v.out.2)⟩ :
       Delta0 N) =
       ⟨rightCosetRep D v, rightCosetRep_mem_Delta0 D v⟩ * ⟨_, mapGL_mem_Delta0 N γ⟩ :=
-    Subtype.ext (rightCosetRep_mul_eq_mul_inv D γ v).symm
+    Subtype.ext (rightCosetRep_mul_eq_mul_inv D (mapGL ℚ (γ : SL(2, ℤ))) v).symm
   rw [hfactor, map_mul, Units.val_mul, delta0NebentypusChar_mapGL, Units.val_inv_eq_inv_val,
     nebentypusWeight_def]
   field_simp
@@ -236,7 +235,7 @@ private lemma nebentypusWeight_smul_slash_slash_eq_char_smul (f : ℍ → ℂ)
   -- unnormalised representative of `γ⁻¹ • v`, then take `χ (d_γ)` out of the weight
   rw [ModularForm.rat_smul_slash_of_det_pos k
       (posDetInt_le_glpos 2 (Delta0_le_posDetInt N (mapGL_mem_Delta0 N γ))) _ _,
-    ← SlashAction.slash_mul, rightCosetRep_mul_eq_mul_inv D γ v,
+    ← SlashAction.slash_mul, rightCosetRep_mul_eq_mul_inv D (mapGL ℚ (γ : SL(2, ℤ))) v,
     nebentypusWeight_eq_char_mul_delta0NebentypusChar χ D γ v, mul_smul]
   -- what remains is that the unnormalised representative has the same weighted slash as `τ`
   exact congrArg _ (delta0NebentypusChar_smul_slash_eq_nebentypusWeight_smul_slash k χ D f hf hh
@@ -257,13 +256,10 @@ the weighting, which `HeckeSlash/Nebentypus/Basic.lean` and `HeckeSlash/Nebentyp
 state and defer: `twistedHeckeSlashSum k χ D` maps `functionCharSpace k χ` into itself, so the
 twisted operators live on the character space where the unweighted `heckeSlashSum` does not.
 
-The proof is Shimura's Proposition 3.37 with the character carried through. Right multiplication by
-`γ` permutes the right cosets — the permutation is `MulAction.toPerm` at `γ⁻¹`, exactly as in
-`HeckeSlash/Invariance.lean` — and the one new step is that a right factor of `γ` multiplies a
-summand's weight by `χ (d_γ)⁻¹`, which is
-`nebentypusWeight_eq_char_mul_delta0NebentypusChar`. Combining that with the reindexing gives the
-per-summand identity `nebentypusWeight_smul_slash_slash_eq_char_smul`, and the eigenvalue then
-comes back out of the sum and is what the conclusion asserts. -/
+This is Shimura's Proposition 3.37 with the character carried through. Right multiplication by `γ`
+permutes the right cosets, exactly as in `HeckeSlash/Invariance.lean`; what the weighting adds is
+that a right factor of `γ` multiplies a summand's weight by `χ (d_γ)⁻¹`. That eigenvalue is common
+to every summand, so it comes back out of the sum, and it is what the conclusion asserts. -/
 theorem twistedHeckeSlashSum_mem_functionCharSpace (f : ℍ → ℂ)
     (hf : f ∈ functionCharSpace k χ) :
     twistedHeckeSlashSum k χ D f ∈ functionCharSpace k χ := by


### PR DESCRIPTION
Roadmap: ModularForms

`twistedHeckeSlashSum_mem_functionCharSpace` in
`HeckeSlash/Nebentypus/Invariance.lean` was a 56-line proof — over the repo's
50-line cap — and essentially all of it was a single `have hperm` carrying three
nested `have`s. This splits it, changing no statement and adding no public name.

The split is not invented. The module's own Provenance section already records
that the source keeps these steps as separate declarations, so the port had
collapsed a structure the docstring was still describing:

| new (all `private`) | source counterpart |
|---|---|
| `rightCosetRep_mul_eq_mul_inv` | — (was `hx`; needed by both steps below) |
| `nebentypusWeight_eq_char_mul_delta0NebentypusChar` | `delta0Nebentypus_left_weight` |
| `nebentypusWeight_smul_slash_slash_eq_char_smul` | `twisted_weighted_slash_tRep_gen_of_mem` |

All three sit above `variable [NeZero N]`, which none of them uses — the
`unusedSectionVars` linter is what settles their placement, not taste. The
Provenance paragraph is updated to name the correspondence now that it holds
declaration-for-declaration.

Longest proof in the file drops from 56 lines to 21.

`private` throughout: each step mentions `nebentypusWeight`, `D`, `f` and `hf`,
so none is reusable outside this argument, and the `Main results` list is
unchanged. Verified with the repo's own `scripts/lint-env.sh` as well as a
green build.

Provenance: github.com/CBirkbeck/AINTLIB @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
Apache-2.0, `LeanModularForms/HeckeRIngs/GL2/Unified/TwistedHeckeRing.lean` —
already the file's recorded source; this PR transcribes no new material from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
