### PR TITLE
refactor: drop 26 redundant TauCeti imports

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.Equivalence
 public import TauCeti.Algebra.AlgebraicGroup.Representation.Tannaka.JordanDecomposition
 public import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Basic
-import TauCeti.LinearAlgebra.GeneralLinearGroup.Intertwining
 
 /-!
 # Jordan decomposition of algebraic-group points

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Commuting.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Commuting.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Representation.JordanDecomposition.Basic
 public import TauCeti.LinearAlgebra.JordanChevalley.Commuting
-import TauCeti.LinearAlgebra.GeneralLinearGroup.Intertwining
 
 /-!
 # Jordan decomposition of commuting algebraic-group points

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
@@ -9,7 +9,6 @@ public import Mathlib.RingTheory.HopfAlgebra.TensorProduct
 public import TauCeti.Algebra.AlgebraicGroup.Product
 public import TauCeti.Algebra.AlgebraicGroup.Representation.ScalarExtension
 public import TauCeti.LinearAlgebra.JordanChevalley.Functoriality
-import TauCeti.LinearAlgebra.GeneralLinearGroup.Intertwining
 
 /-!
 # Semisimple points of a Hopf algebra

--- a/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
+++ b/TauCeti/Algebra/Lie/E7/Minuscule/StandardComodule.lean
@@ -9,7 +9,6 @@ public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule
 public import TauCeti.Algebra.Lie.E7.Minuscule.BaseChange
 import TauCeti.Algebra.Coalgebra.Comodule.GroupLike
 import TauCeti.Algebra.Coalgebra.Subcomodule.Corestrict
-import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.BaseChange
 import TauCeti.Algebra.Lie.E7.Minuscule.PointsFunctor
 
 /-!

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/SpecialLinear.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/SpecialLinear.lean
@@ -6,7 +6,6 @@ Authors: Codex
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Separation
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Smooth
 public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.BaseChange

--- a/TauCeti/Algebra/Lie/Weights/StructureConstant/Opposite.lean
+++ b/TauCeti/Algebra/Lie/Weights/StructureConstant/Opposite.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.Weights.Root.String
 public import TauCeti.Algebra.Lie.Weights.StructureConstant.Symmetry
 
 /-!

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Comap.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Comap.lean
@@ -6,7 +6,6 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.RationalSubset.Basic
-public import TauCeti.RingTheory.Valuation.ValuativeRel.Basic
 
 /-!
 # Pullbacks and quotient embeddings of sub-unit valuation loci

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
@@ -11,7 +11,6 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Inverse
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.WExpansion
 public import TauCeti.RingTheory.MvPowerSeries.Evaluation
 public import TauCeti.RingTheory.MvPowerSeries.Substitution
-public import TauCeti.Topology.Algebra.Nonarchimedean.AdicTopology
 public import TauCeti.Topology.Algebra.Nonarchimedean.GeometricSeries
 
 /-!

--- a/TauCeti/Analysis/Complex/Conformal/Rouche.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Rouche.lean
@@ -9,8 +9,6 @@ public import Mathlib.Analysis.Analytic.Order
 public import Mathlib.Analysis.Meromorphic.Divisor
 public import TauCeti.Analysis.Complex.ZeroCount
 public import TauCeti.Analysis.Contour.Argument.Cycle
-public import TauCeti.Analysis.Contour.Argument.Divisor
-import TauCeti.Analysis.Contour.LogDerivFTC
 import Mathlib.Analysis.Calculus.LogDeriv
 import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
 import Mathlib.MeasureTheory.Integral.CircleIntegral

--- a/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
+++ b/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
@@ -14,7 +14,6 @@ import TauCeti.Analysis.Contour.Crossing.Finiteness
 import TauCeti.Analysis.Contour.Crossing.PVAggregation
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.PerWindow.HigherOrder
-import TauCeti.Analysis.Contour.PiecewiseC1On
 
 /-!
 # The principal value of a higher-order polar term along an immersed curve

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -15,7 +15,6 @@ import TauCeti.Analysis.Contour.Crossing.Finiteness
 import TauCeti.Analysis.Contour.Crossing.PVAggregation
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.PerWindow.CPV
-import TauCeti.Analysis.Contour.PiecewiseC1On
 
 /-!
 # Existence of the Cauchy-kernel principal value along an immersed curve

--- a/TauCeti/Analysis/Semigroups/Generation/LimitSemigroup.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/LimitSemigroup.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Semigroups.Generation.Yosida.Basic
-import TauCeti.Analysis.Normed.Operator.Basic
 import TauCeti.Analysis.Normed.Operator.Exponential
 import Mathlib.Topology.UniformSpace.UniformApproximation
 

--- a/TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean
@@ -7,9 +7,7 @@ module
 
 public import TauCeti.Analysis.Normed.Operator.Dense
 public import TauCeti.Analysis.Normed.Operator.Resolvent.DomainPow
-public import TauCeti.Analysis.Semigroups.Generator.Invariance
 public import TauCeti.Analysis.Semigroups.Resolvent.Identity
-import TauCeti.Analysis.Normed.Operator.Basic
 
 /-!
 # The iterated generator domains of a strongly continuous semigroup are dense

--- a/TauCeti/FieldTheory/FunctionField/Divisor/DisjointSupport.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/DisjointSupport.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.FieldTheory.FunctionField.Divisor.Principal
-public import TauCeti.FieldTheory.FunctionField.Place.Approximation
 
 /-!
 # Moving a divisor within its class to avoid finitely many places

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/Uniqueness.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/Uniqueness.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.FieldTheory.FunctionField.RiemannRoch.DegreeZero
 public import TauCeti.FieldTheory.FunctionField.RiemannRoch.RatFunc
 
 /-!

--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Geometry.Lie.Adjoint.Basic
-public import TauCeti.Geometry.Lie.Interior
 public import TauCeti.Geometry.Lie.Tangent.LieEquiv
 
 /-!

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/Reindex.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Star/Reindex.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.RootSystem.Classification
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Star.Classification
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Star.Components
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.TypeA

--- a/TauCeti/NumberTheory/EffectiveBounds/UnitSquares/Basic.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/UnitSquares/Basic.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.NumberField.Units.DirichletTheorem
-public import TauCeti.Algebra.Group.PowMonoidHom
 public import TauCeti.Algebra.Group.ElementaryTwoQuotient.Basic
 public import Mathlib.NumberTheory.NumberField.Basic
 

--- a/TauCeti/Probability/DeFinetti/Barycenter.lean
+++ b/TauCeti/Probability/DeFinetti/Barycenter.lean
@@ -7,7 +7,6 @@ module
 
 -- Public: the barycenter is a `Measure.bind` against the measurable countable-power kernel, and
 -- its values are exchangeable path laws.
-public import TauCeti.MeasureTheory.Measure.ProductKernel
 public import TauCeti.Probability.Exchangeability.PathSpace.Law.Basic
 -- Public: `ExchangeableLaw.existsUnique_mixingLaw` is the path-law form of `deFinetti_mixture`.
 public import TauCeti.Probability.DeFinetti.Representation

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic
 public import TauCeti.Probability.Exchangeability.FiniteMarginals
-public import TauCeti.MeasureTheory.Measure.ProductKernel
 -- Public: `iIndepFun` appears in the hypothesis of the degeneracy theorem.
 public import Mathlib.Probability.Independence.Basic
 -- Non-public: the mixture representation and its uniqueness are used only inside the

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Basic.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Data.ZMod.ValMinAbs
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.CentralCharacterCount
 
 /-!

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/QuaternionEight.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/QuaternionEight.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Data.ZMod.ValMinAbs
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.CentralCharacterCount
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.Quaternion
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Quaternion

--- a/TauCeti/RepresentationTheory/Quiver/AdmissibleIdeal.lean
+++ b/TauCeti/RepresentationTheory/Quiver/AdmissibleIdeal.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Combinatorics.Quiver.BoundedPaths
 public import TauCeti.RepresentationTheory.Quiver.Radical
 public import Mathlib.RingTheory.Ideal.Quotient.Operations
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Descent.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Descent.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.QuadraticForm.PosDef
 public import TauCeti.RepresentationTheory.Quiver.Reflection.Coxeter
 
 /-!


### PR DESCRIPTION
Each removed line imports a module that **another direct import of the same file
already provides along a public-import chain**. The file still sees the module
afterwards, so removal is build-safe by construction — the risk here is a rubric
judgement, not CI.

Same class as #5663 (8 rows, merged). This is the result of narrowing the whole
population rather than the rows that happened to appear in a delta.

**How 433 redundant edges became 26.** Every row had to clear all four:

| filter | dropped |
|---|---|
| the covered module registers instances, notation or attributes | **353** |
| one of its declaration names appears in the importing file | **46** |
| the file's own prose names the module (a docstring mention is not a use, but it is not nothing) | **4** |
| the file has no declarations of its own — a re-export module, a different question | **4** |
| **remaining** | **26** |

`import` vs `public import` is treated asymmetrically, as the module system
requires: a plain `import A` counts as covered when any direct import publicly
reaches `A`, but a `public import A` only when a **public** one does.

**Worth attacking:** whether an explicit import is worth keeping as documentation
even when redundant. #5663 settled that for eight rows the same way; the third
filter above is where I draw the line, and it is the one I would question first.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp