### PR TITLE
refactor: remove three dead `let` bindings

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
@@ -212,7 +212,6 @@ theorem comul_mem_connectedComponentIdeal_augmentationPoint
   intro hx
   let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
   let I := PrimeSpectrum.connectedComponentIdeal z
-  let e := PrimeSpectrum.connectedComponentIdempotent z
   -- Expose the local component ideal so its principal-generator characterization can rewrite.
   change x ∈ I at hx
   change Coalgebra.comul (R := k) x ∈

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Cocharacter.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeType/Cocharacter.lean
@@ -218,8 +218,6 @@ private theorem geometricCharacterGroupSchemeMap_eq (T : MultiplicativeTypeCommH
             (geometricCharacterFGEquiv T x.toMul) := by
   let hG := DiagonalizableGroup.groupScheme_def (AlgebraicClosure k)
     (geometricCharacterFG T)
-  let hZ := DiagonalizableGroup.groupScheme_def (AlgebraicClosure k)
-    DiagonalizableGroup.multiplicativeCharacterGroup
   rw [DiagonalizableGroup.characterGroupSchemeMap_def,
     DiagonalizableGroup.groupSchemeMap_def]
   simp only [geometricCharacterGroupSchemeMap, geometricFiberGroupSchemeIso,

--- a/TauCeti/Analysis/Contour/Crossing/Decomposition.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Decomposition.lean
@@ -260,7 +260,6 @@ private theorem cauchyPVExistsAt_exciseCrossings_of_ordered_windows
       have hinsideTail := inside_tail_of_ordered_windows W hordered.1 hinside
       have havoidTail := avoid_tail_of_ordered_windows W hW havoid
       have hpvTail := ih htail (by linarith [hW.2.2]) hordered.2 hinsideTail havoidTail
-      let excised := exciseCrossings γ s (W :: windows)
       obtain ⟨heqLeft, heqWindow, heqTail⟩ :=
         eqOn_pieces_exciseCrossings_cons W windows
           (List.pairwise_cons.mpr ⟨hordered.1, hordered.2⟩) hW


### PR DESCRIPTION
Three proofs bind a `let` that nothing afterwards mentions:

| file | binding |
|---|---|
| `Algebra/AlgebraicGroup/Connected/Comultiplication.lean` | `let e := PrimeSpectrum.connectedComponentIdempotent z` — the neighbouring `let I` *is* used; this one is not |
| `Algebra/AlgebraicGroup/MultiplicativeType/Cocharacter.lean` | `let hZ := DiagonalizableGroup.groupScheme_def …` |
| `Analysis/Contour/Crossing/Decomposition.lean` | `let excised := exciseCrossings γ s (W :: windows)` |

Same family as #5727 (dead `have`) and #5730/#5733 (dead `set … with`).

**Three exclusions do the real work here**, and each was found by reading a
proof the scan had flagged:

* a `let` whose type is a **class** supplies instances by search, never by
  name — `let hFin : ∀ i, Module.Finite F … := fun i => inferInstance` in
  `ToClass.lean` is consumed by `Module.Finite.equiv` on the next line;
* a tactic `let` that **mirrors a `let` in the declaration's own statement**
  discharges the goal's binder rather than introducing a fresh one — 37 rows
  in the tree do this, including `standardQuadraticToSoLieEquiv` and
  `normalSemidirectMul`, whose types literally begin `let Q := …` / `let A := …`;
* `let rec` and `let mut` are keywords, not binding names.

**Worth attacking:** whether any of the three is load-bearing for *elaboration*
rather than by reference — a local definition can in principle matter to
unification without being named. I could not rule that out by reading, and the
shared Mathlib cache is currently broken here, so CI is the check.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp