### PR TITLE
feat(EllipticCurve): the degree of multiplication by n is n²

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt/Degree.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.DivisionPolynomialTower
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.MulByInt.MapsInfinity
+
+/-!
+# The degree of multiplication by `n`
+
+**`deg [n] = n²`.** The degree of an isogeny is the degree of `F(W)` over the image of its
+function-field pullback — the pulled-back copy of the *target* function field. For `[n]` the
+target is `F(W)` again, and the pullback carries the affine coordinate `x` to `Φₙ / ΨSqₙ`. That
+image is pinned down by where the coordinate goes, and `DivisionPolynomialTower.lean` computes
+its index as `n²` by way of the intermediate tower `F(Φₙ/ΨSqₙ) ⊆ F(x) ⊆ F(W)`.
+
+## Main results
+
+* `TauCeti.Isogeny.fieldPullback_mulByIntIsogeny_X`: the function-field pullback of `[n]` sends
+  the affine coordinate to `Φₙ / ΨSqₙ`, read in `F(x)` rather than in the coordinate ring.
+* `TauCeti.Isogeny.degree_mulByIntIsogeny`: `deg [n] = n²`, for an `n` whose division polynomial
+  does not vanish at the generic point, and
+  `TauCeti.Isogeny.degree_mulByIntIsogenyOfNeZero` for every `n ≠ 0`, that hypothesis being
+  discharged from nonsingularity.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.6.4(a).
+-/
+
+public section
+
+open Polynomial
+
+open scoped RatFunc
+
+namespace TauCeti.Isogeny
+
+variable {F : Type*} [Field F] (W : WeierstrassCurve F)
+
+/-- **The pullback of `[n]` sends the affine coordinate to `Φₙ / ΨSqₙ`**, with the quotient
+formed in `F(x)` and then carried into `F(W)`. This is `mulByIntX` in the shape the degree
+tower asks for. -/
+@[simp]
+theorem fieldPullback_mulByIntIsogeny_X [W.IsElliptic] {n : ℤ}
+    (hn : psiFunctionField W n ≠ 0) :
+    (mulByIntIsogeny W hn).fieldPullback (algebraMap F[X] W.toAffine.FunctionField X) =
+      algebraMap (RatFunc F) W.toAffine.FunctionField
+        (algebraMap F[X] (RatFunc F) (W.Φ n) / algebraMap F[X] (RatFunc F) (W.ΨSq n)) := by
+  -- Unordered on purpose: the two sides meet in the middle, the pullback side coming down
+  -- through the coordinate ring and the quotient side up out of `F(x)`.
+  simp only [IsScalarTower.algebraMap_apply F[X] W.toAffine.CoordinateRing
+      W.toAffine.FunctionField, fieldPullback_algebraMap, mulByIntIsogeny_pullback,
+    AdjoinRoot.algebraMap_eq, mulByIntPullback_X, mulByIntX_def,
+    phiFunctionField_eq_algebraMap, psiFunctionField_sq,
+    TauCeti.WeierstrassCurve.Affine.CoordinateRing.mk_C_eq_algebraMap,
+    ← IsScalarTower.algebraMap_apply, map_div₀]
+
+/-- **`deg [n] = n²`** (Silverman III.6.4(a)). The pullback of `[n]` sends the affine coordinate
+to `Φₙ / ΨSqₙ`, so its image is the field the tower
+`F(Φₙ/ΨSqₙ) ⊆ F(x) ⊆ F(W)` measures, of index `n²`. -/
+@[simp]
+theorem degree_mulByIntIsogeny [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    (mulByIntIsogeny W hn).degree = n.natAbs ^ 2 := by
+  rw [degree_def]
+  exact W.finrank_fieldRange_of_apply_X_eq_Φ_div_ΨSq (fun _ => W.isUnit_Δ.ne_zero)
+    (mulByIntIsogeny W hn).fieldPullback (fieldPullback_mulByIntIsogeny_X W hn)
+
+/-- **`deg [n] = n²` for every `n ≠ 0`**, the non-vanishing hypothesis discharged from
+nonsingularity as in `mulByIntIsogenyOfNeZero`. -/
+-- Not `@[simp]`: `mulByIntIsogenyOfNeZero` is an `abbrev`, so `simp` sees through it to
+-- `degree_mulByIntIsogeny` and `simpNF` rejects the pair as duplicates. It is stated anyway
+-- because this is the form the roadmap result takes, and a caller holding `n ≠ 0` should not
+-- have to unfold an abbreviation to find it.
+theorem degree_mulByIntIsogenyOfNeZero [W.IsElliptic] {n : ℤ} (hn : n ≠ 0) :
+    (mulByIntIsogenyOfNeZero W hn).degree = n.natAbs ^ 2 :=
+  degree_mulByIntIsogeny W _
+
+end TauCeti.Isogeny
+
+end


### PR DESCRIPTION
**`deg [n] = n²`** — Silverman III.6.4(a), the multiplication-by-`n` half of the degree theory the
Hasse bound needs.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"mulbyint-degree"}-->

### The argument

An isogeny's degree is the degree of `F(W)` over the image of its function-field pullback — the
pulled-back copy of the *target* function field (`TauCeti.Isogeny.degree_def`). For `[n]` the
target is `F(W)` again, and the pullback carries the affine coordinate `x` to `Φₙ / ΨSqₙ`, which
pins the image down. `Affine/FunctionField/DivisionPolynomialTower.lean` computes its index as
`n²` by carrying `[F(x) : F(Φₙ/ΨSqₙ)] = n²` up the intermediate tower
`F(Φₙ/ΨSqₙ) ⊆ F(x) ⊆ F(W)` and dividing the outer degree two back out.

So this file has only to identify the pullback and apply that:

```lean
theorem degree_mulByIntIsogeny [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
    (mulByIntIsogeny W hn).degree = n.natAbs ^ 2 := by
  rw [degree_def]
  exact W.finrank_fieldRange_of_apply_X_eq_Φ_div_ΨSq (fun _ => W.isUnit_Δ.ne_zero)
    (mulByIntIsogeny W hn).fieldPullback (fieldPullback_mulByIntIsogeny_X W hn)
```

### The pullback identification

`mulByIntPullback_X` already says the pullback sends the class of `X` to `mulByIntX W n`, which is
`φₙ / ψₙ²` **in `F(W)`**. The degree tower wants it as a single `algebraMap` out of **`F(x)`**, of
`Φₙ / ΨSqₙ` formed there. Every lemma needed to get between the two already exists —
`phiFunctionField_eq_algebraMap` for the numerator, `psiFunctionField_sq` with
`Affine.CoordinateRing.mk_C_eq_algebraMap` for the denominator, and `AdjoinRoot.algebraMap_eq` to
let `mulByIntPullback_X` meet the scalar tower — so the proof adds no lemma of its own. It is a
single unordered `simp only` rather than a `rw` chain: the two sides meet in the middle, the
pullback coming down through the coordinate ring and the quotient coming up out of `F(x)`, and
neither direction should depend on the order the rewrites happen to be listed in.

`degree_mulByIntIsogenyOfNeZero` states the same thing for every `n ≠ 0`, discharging the
non-vanishing hypothesis from nonsingularity. It is deliberately **not** `@[simp]`:
`mulByIntIsogenyOfNeZero` is an `abbrev`, so `simp` sees straight through it to
`degree_mulByIntIsogeny` and `simpNF` rejects the two as duplicates. The theorem is still worth
naming — it is the form the roadmap result takes, and a caller holding `n ≠ 0` should not have to
unfold an abbreviation to find it.

### Placement

`Isogeny/MulByInt/` already holds `Basic.lean`, `InfinityPlace.lean` and `MapsInfinity.lean`,
where `mulByIntIsogeny` itself is defined. The degree joins them, mirroring how
`Isogeny/Frobenius.lean` states `degree_frobeniusIsogeny` beside the Frobenius isogeny.

### Provenance

Original, assembled from merged results: `mulByIntIsogeny` and `mulByIntPullback_X`
(`Isogeny/MulByInt/`), `degree_def` (`Isogeny/Degree.lean`), and
`finrank_fieldRange_of_apply_X_eq_Φ_div_ΨSq` (`Affine/FunctionField/DivisionPolynomialTower.lean`).
The mathematics is Silverman, *The Arithmetic of Elliptic Curves*, III.6.4(a). The tower's own
provenance, back to the AINTLIB `HasseWeil` project
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `513e83879e2f8cbc626eb9e04d660e92be16ccba`), is
recorded in `Affine/FunctionField/AdjoinTower.lean`.

### Gates

- `lake build`: green for this module and its dependents.
- `#lint in TauCeti`, 15 linters over 515 declarations: 0 errors.
- Axioms: `[propext, Classical.choice, Quot.sound]`.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; no line over 100 codepoints; 74 lines,
  three theorems, longest proof 9 lines.

### Builds on #5738

`finrank_fieldRange_of_apply_X_eq_Φ_div_ΨSq` comes from that PR, now merged; this one adds a
single file and touches nothing else.
