### PR TITLE
feat(AdicSpace): the structure presheaf's index is directed

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -260,7 +260,8 @@ numerator set augmented by its own denominator,
 `R(T₁/s₁) ∩ R(T₂/s₂) = R(U₁U₂ / s₁s₂)`. The augmentation costs nothing
 (`rationalSubset_insert_self`) and is essential — with the bare products the identity fails
 for `T₂ = ∅`. Wedhorn's full Remark 7.30(5) additionally says the right-hand pair is again
-admissible; that lives with the deferred open-ideal layer. This identity is the form Theorem
+admissible; that is `TauCeti.Huber.PairOfDefinition.isOpen_span_insert_mul_insert`, which needs
+the open-ideal criterion and so lives downstream of this file. This identity is the form Theorem
 7.35's own proof consumes. -/
 @[simp]
 theorem rationalSubset_inter (Aplus : Subring A) (T₁ T₂ : Finset A) (s₁ s₂ : A) :

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -146,25 +146,6 @@ section TopologicalRing
 
 variable [IsTopologicalRing A]
 
-open Classical in
-/-- If two numerator ideals are open, then so is the ideal spanned by the product of the
-numerator sets after adjoining their respective denominators. This is the admissibility half of
-the intersection formula for rational subsets. -/
-private theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A)
-    {T₁ T₂ : Finset A} {s₁ s₂ : A}
-    (hT₁ : IsOpen (Ideal.span (T₁ : Set A) : Set A))
-    (hT₂ : IsOpen (Ideal.span (T₂ : Set A) : Set A)) :
-    IsOpen (Ideal.span ((insert s₁ T₁ * insert s₂ T₂ : Finset A) : Set A) : Set A) := by
-  classical
-  rw [P.isOpen_iff_le_radical]
-  have hmul :=
-    (isAdmissible_extendedIdealOfDefinition_of_isOpen_span (s := s₁) P hT₁).mul
-      (isAdmissible_extendedIdealOfDefinition_of_isOpen_span (s := s₂) P hT₂)
-  rw [isAdmissible_iff] at hmul
-  have hs : s₁ * s₂ ∈ insert s₁ T₁ * insert s₂ T₂ :=
-    Finset.mul_mem_mul (Finset.mem_insert_self _ _) (Finset.mem_insert_self _ _)
-  rwa [Set.insert_eq_self.mpr (Finset.mem_coe.mpr hs)] at hmul
-
 /-- **Wedhorn Remark 7.30(5).** Rational subsets with open numerator ideal are closed under
 intersection. The set identity is `rationalSubset_inter`; admissibility is multiplicative in
 `Spv(A,IA)`, and adjoining the product denominator turns it back into openness. -/
@@ -176,7 +157,7 @@ theorem inter_mem_spaRationalFamily_of_pairOfDefinition (P : PairOfDefinition A)
   obtain ⟨T₁, s₁, hT₁, rfl⟩ := hU
   obtain ⟨T₂, s₂, hT₂, rfl⟩ := hV
   refine ⟨insert s₁ T₁ * insert s₂ T₂, s₁ * s₂,
-    isOpen_span_insert_mul_insert P hT₁ hT₂, ?_⟩
+    P.isOpen_span_insert_mul_insert hT₁ hT₂, ?_⟩
   rw [← Set.preimage_inter, rationalSubset_inter]
 
 /-- **Wedhorn Remark 7.30(5).** Over a Huber ring, the rational family is closed under binary

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/StructurePresheaf/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/StructurePresheaf/Basic.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.RationalSubset.Basic
+public import TauCeti.RingTheory.Huber.OpenIdeal
 public import TauCeti.RingTheory.Huber.LocalizationTopology.CompleteSeparated.RefinementCategory
 public import TauCeti.Topology.Category.TopCommRingCat.CompleteSeparated.Limits
 
@@ -34,6 +35,10 @@ functor along the forgetful map, and the value is its limit — which exists bec
 
 ## Main results
 
+* `IsDirected (TauCeti.ValuationSpectrum.PresentationIndex Aplus V) (· ≤ ·)` : the index is
+  directed — two admissible presentations refining `V` have an admissible common refinement. This
+  is the admissibility half of Wedhorn Remark 7.30(5), which `Presentation.commonRefinement`
+  leaves to its consumers because `Presentation` carries no openness field.
 * `TauCeti.ValuationSpectrum.presentationLimit_hom_ext` : two morphisms into the limit agree as
   soon as their projections do.
 * `TauCeti.ValuationSpectrum.presentationLimitMap_comp_π` : restriction is reindexing —
@@ -123,6 +128,30 @@ theorem PresentationIndex.ext {i j : PresentationIndex (P := P) Aplus V} (h : i.
   cases j
   subst h
   rfl
+
+open scoped Classical Pointwise in
+/-- **The index is directed**: two admissible presentations refining `V` are both refined by their
+common refinement, which is again admissible.
+
+Both of the index's own fields have to be re-established, which is what
+`TauCeti.Huber.PairOfDefinition.Presentation.commonRefinement` deliberately does not do — it
+carries no openness field. The containment in `V` is the intersection identity
+`TauCeti.ValuationSpectrum.rationalSubset_inter`, and openness of the numerator span is
+`TauCeti.Huber.PairOfDefinition.isOpen_span_mul`: the common refinement's numerators are a
+pointwise product, and a product of open ideals is open. Together they are the admissibility half
+of Wedhorn Remark 7.30(5). -/
+instance : IsDirected (PresentationIndex (P := P) Aplus V) (· ≤ ·) := by
+  refine ⟨fun i j ↦ ⟨⟨i.pres.commonRefinement j.pres, ?_, ?_⟩,
+    i.pres.le_commonRefinement_left j.pres, i.pres.le_commonRefinement_right j.pres⟩⟩
+  · rw [PairOfDefinition.Presentation.commonRefinement_num, Finset.coe_mul]
+    exact P.isOpen_span_mul (P.isOpen_of_le (Ideal.span_mono (by simp)) i.isOpen_span)
+      (P.isOpen_of_le (Ideal.span_mono (by simp)) j.isOpen_span)
+  · refine le_trans ?_ i.le_open
+    intro v hv
+    rw [mem_spaBasicOpen] at hv ⊢
+    rw [PairOfDefinition.Presentation.commonRefinement_num,
+      PairOfDefinition.Presentation.commonRefinement_den, ← rationalSubset_inter] at hv
+    exact hv.1
 
 /-- Forgetting the containment is a functor to the category of all presentations. -/
 private def presentationIndexInclusion (Aplus : Subring A) (V : Opens ↥(spa Aplus)) :

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/StructurePresheaf/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/StructurePresheaf/Basic.lean
@@ -36,9 +36,9 @@ functor along the forgetful map, and the value is its limit — which exists bec
 ## Main results
 
 * `IsDirected (TauCeti.ValuationSpectrum.PresentationIndex Aplus V) (· ≤ ·)` : the index is
-  directed — two admissible presentations refining `V` have an admissible common refinement. This
-  is the admissibility half of Wedhorn Remark 7.30(5), which `Presentation.commonRefinement`
-  leaves to its consumers because `Presentation` carries no openness field.
+  directed — two admissible presentations refining `V` have an admissible common refinement.
+  `Presentation.commonRefinement` leaves both index fields to its consumers, because
+  `Presentation` carries no openness field.
 * `TauCeti.ValuationSpectrum.presentationLimit_hom_ext` : two morphisms into the limit agree as
   soon as their projections do.
 * `TauCeti.ValuationSpectrum.presentationLimitMap_comp_π` : restriction is reindexing —
@@ -137,15 +137,14 @@ Both of the index's own fields have to be re-established, which is what
 `TauCeti.Huber.PairOfDefinition.Presentation.commonRefinement` deliberately does not do — it
 carries no openness field. The containment in `V` is the intersection identity
 `TauCeti.ValuationSpectrum.rationalSubset_inter`, and openness of the numerator span is
-`TauCeti.Huber.PairOfDefinition.isOpen_span_mul`: the common refinement's numerators are a
-pointwise product, and a product of open ideals is open. Together they are the admissibility half
-of Wedhorn Remark 7.30(5). -/
+`TauCeti.Huber.PairOfDefinition.isOpen_span_insert_mul_insert`, the admissibility half of Wedhorn
+Remark 7.30(5), which `TauCeti.ValuationSpectrum.inter_mem_spaRationalFamily_of_pairOfDefinition`
+also uses. -/
 instance : IsDirected (PresentationIndex (P := P) Aplus V) (· ≤ ·) := by
   refine ⟨fun i j ↦ ⟨⟨i.pres.commonRefinement j.pres, ?_, ?_⟩,
     i.pres.le_commonRefinement_left j.pres, i.pres.le_commonRefinement_right j.pres⟩⟩
-  · rw [PairOfDefinition.Presentation.commonRefinement_num, Finset.coe_mul]
-    exact P.isOpen_span_mul (P.isOpen_of_le (Ideal.span_mono (by simp)) i.isOpen_span)
-      (P.isOpen_of_le (Ideal.span_mono (by simp)) j.isOpen_span)
+  · rw [PairOfDefinition.Presentation.commonRefinement_num]
+    exact P.isOpen_span_insert_mul_insert i.isOpen_span j.isOpen_span
   · refine le_trans ?_ i.le_open
     intro v hv
     rw [mem_spaBasicOpen] at hv ⊢

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/StructurePresheaf/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/StructurePresheaf/Basic.lean
@@ -6,9 +6,10 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.RationalSubset.Basic
-public import TauCeti.RingTheory.Huber.OpenIdeal
 public import TauCeti.RingTheory.Huber.LocalizationTopology.CompleteSeparated.RefinementCategory
 public import TauCeti.Topology.Category.TopCommRingCat.CompleteSeparated.Limits
+
+import TauCeti.RingTheory.Huber.OpenIdeal
 
 /-!
 # The presentation-indexed limit behind the structure presheaf

--- a/TauCeti/RingTheory/Huber/OpenIdeal.lean
+++ b/TauCeti/RingTheory/Huber/OpenIdeal.lean
@@ -26,6 +26,11 @@ work is that an *ideal* of `A` containing the image of `Iⁿ` automatically cont
   it contains a power of `I · A`.
 * `TauCeti.Huber.PairOfDefinition.isOpen_iff_le_radical`: an ideal of `A` is open exactly when its
   radical contains `I · A`.
+* `TauCeti.Huber.PairOfDefinition.isOpen_of_le`: openness passes up to a larger ideal.
+* `TauCeti.Huber.PairOfDefinition.isOpen_mul`: the product of two open ideals is open — the
+  powers of `I · A` witnessing each add.
+* `TauCeti.Huber.PairOfDefinition.isOpen_span_mul`: the span of a pointwise product of sets is
+  open when the two spans are, which is the form an intersection of rational subsets needs.
 * `TauCeti.Huber.IsTateRing.isOpen_iff_eq_top`: an ideal of a Tate ring is open exactly when it is
   the whole ring.
 
@@ -42,9 +47,16 @@ as `fg_extendedIdealOfDefinition` is, by `Ideal.FG.map`. Its
 and hypothesising a finitely generated ideal of definition; the form below instead names the pair
 of definition and routes the whole lemma through `Ideal.map_pow`.
 
+The product lemmas below are independent of it in a stronger sense: AINTLIB's
+`ValuationSpectrum.HasRationalPresentation` (`projects/AdicSpaces/Adic spaces/RationalSubsets.lean`)
+records only that a set *is* some `R(T/s)`, with no openness condition on `T A`, so its
+`HasRationalPresentation.inter` is the set-level identity alone. Its blueprint asserts in prose
+that "the numerator family of the product still generates an open ideal", but that half is not
+formalised there and nothing could be ported.
+
 ## References
 
-* [Wedhorn, *Adic Spaces*][wedhorn_adic], Lemma 6.6.
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Lemma 6.6 and Remark 7.30(5).
 * [AINTLIB](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
   `projects/AdicSpaces/Adic spaces/OpenIdeals.lean` and `HuberRings.lean`.
 -/
@@ -85,6 +97,36 @@ theorem isOpen_iff_le_radical (P : PairOfDefinition A) (a : Ideal A) :
   rw [P.isOpen_iff_exists_pow_le a]
   exact ⟨fun ⟨n, hn⟩ _ hx ↦ ⟨n, hn (Ideal.pow_mem_pow hx n)⟩,
     fun h ↦ Ideal.exists_pow_le_of_le_radical_of_fg h P.fg_extendedIdealOfDefinition⟩
+
+/-- **An ideal above an open ideal is open.** Openness of an ideal is containment of a power of
+`I · A` (`TauCeti.Huber.PairOfDefinition.isOpen_iff_exists_pow_le`), and that containment is
+inherited upwards. -/
+theorem isOpen_of_le (P : PairOfDefinition A) {a b : Ideal A} (hab : a ≤ b)
+    (ha : IsOpen (a : Set A)) : IsOpen (b : Set A) :=
+  (P.isOpen_iff_exists_pow_le b).mpr <|
+    ((P.isOpen_iff_exists_pow_le a).mp ha).imp fun _ hn ↦ hn.trans hab
+
+/-- **The product of two open ideals is open.** If `a` contains `(I · A)ⁿ` and `b` contains
+`(I · A)ᵐ`, then `a * b` contains `(I · A)ⁿ⁺ᵐ`. Note this is a statement about the *product*
+ideal, which is smaller than the intersection: openness survives the smaller of the two. -/
+theorem isOpen_mul (P : PairOfDefinition A) {a b : Ideal A} (ha : IsOpen (a : Set A))
+    (hb : IsOpen (b : Set A)) : IsOpen ((a * b : Ideal A) : Set A) := by
+  obtain ⟨n, hn⟩ := (P.isOpen_iff_exists_pow_le a).mp ha
+  obtain ⟨m, hm⟩ := (P.isOpen_iff_exists_pow_le b).mp hb
+  refine (P.isOpen_iff_exists_pow_le _).mpr ⟨n + m, ?_⟩
+  rw [pow_add]
+  exact Ideal.mul_mono hn hm
+
+open scoped Pointwise in
+/-- **A span over a pointwise product of sets is open** when the two factors' spans are, since
+`Ideal.span_mul_span` identifies it with the product ideal. This is the form Wedhorn's
+Remark 7.30(5) needs: the numerator set of an intersection of rational subsets is a pointwise
+product. -/
+theorem isOpen_span_mul (P : PairOfDefinition A) {S T : Set A}
+    (hS : IsOpen (Ideal.span S : Set A)) (hT : IsOpen (Ideal.span T : Set A)) :
+    IsOpen (Ideal.span (S * T) : Set A) := by
+  rw [← Ideal.span_mul_span]
+  exact P.isOpen_mul hS hT
 
 end PairOfDefinition
 

--- a/TauCeti/RingTheory/Huber/OpenIdeal.lean
+++ b/TauCeti/RingTheory/Huber/OpenIdeal.lean
@@ -26,7 +26,6 @@ work is that an *ideal* of `A` containing the image of `Iⁿ` automatically cont
   it contains a power of `I · A`.
 * `TauCeti.Huber.PairOfDefinition.isOpen_iff_le_radical`: an ideal of `A` is open exactly when its
   radical contains `I · A`.
-* `TauCeti.Huber.PairOfDefinition.isOpen_of_le`: openness passes up to a larger ideal.
 * `TauCeti.Huber.PairOfDefinition.isOpen_mul`: the product of two open ideals is open — the
   powers of `I · A` witnessing each add.
 * `TauCeti.Huber.PairOfDefinition.isOpen_span_mul`: the span of a pointwise product of sets is
@@ -100,14 +99,6 @@ theorem isOpen_iff_le_radical (P : PairOfDefinition A) (a : Ideal A) :
   exact ⟨fun ⟨n, hn⟩ _ hx ↦ ⟨n, hn (Ideal.pow_mem_pow hx n)⟩,
     fun h ↦ Ideal.exists_pow_le_of_le_radical_of_fg h P.fg_extendedIdealOfDefinition⟩
 
-/-- **An ideal above an open ideal is open.** Openness of an ideal is containment of a power of
-`I · A` (`TauCeti.Huber.PairOfDefinition.isOpen_iff_exists_pow_le`), and that containment is
-inherited upwards. -/
-theorem isOpen_of_le (P : PairOfDefinition A) {a b : Ideal A} (hab : a ≤ b)
-    (ha : IsOpen (a : Set A)) : IsOpen (b : Set A) :=
-  (P.isOpen_iff_exists_pow_le b).mpr <|
-    ((P.isOpen_iff_exists_pow_le a).mp ha).imp fun _ hn ↦ hn.trans hab
-
 /-- **The product of two open ideals is open.** If `a` contains `(I · A)ⁿ` and `b` contains
 `(I · A)ᵐ`, then `a * b` contains `(I · A)ⁿ⁺ᵐ`. Note this is a statement about the *product*
 ideal, which is smaller than the intersection: openness survives the smaller of the two. -/
@@ -133,7 +124,8 @@ theorem isOpen_span_mul (P : PairOfDefinition A) {S T : Set A}
 open scoped Classical Pointwise in
 /-- **The numerator set of an intersection of rational subsets spans an open ideal.** Adjoining
 each denominator only enlarges a span, so this is `isOpen_span_mul` after two applications of
-`isOpen_of_le`. It is the admissibility half of Wedhorn Remark 7.30(5): the set identity
+Mathlib's `Ideal.isOpen_of_isOpen_subideal`. It is the admissibility half of Wedhorn
+Remark 7.30(5): the set identity
 `TauCeti.ValuationSpectrum.rationalSubset_inter` presents the intersection with numerators
 `insert s₁ T₁ * insert s₂ T₂`, and a rational subset is one whose numerator ideal is open. -/
 theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A) {T₁ T₂ : Finset A} {s₁ s₂ : A}
@@ -141,8 +133,8 @@ theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A) {T₁ T₂ : Fins
     (hT₂ : IsOpen (Ideal.span (T₂ : Set A) : Set A)) :
     IsOpen (Ideal.span ((insert s₁ T₁ * insert s₂ T₂ : Finset A) : Set A) : Set A) := by
   rw [Finset.coe_mul]
-  exact P.isOpen_span_mul (P.isOpen_of_le (Ideal.span_mono (by simp)) hT₁)
-    (P.isOpen_of_le (Ideal.span_mono (by simp)) hT₂)
+  exact P.isOpen_span_mul (Ideal.isOpen_of_isOpen_subideal (Ideal.span_mono (by simp)) hT₁)
+    (Ideal.isOpen_of_isOpen_subideal (Ideal.span_mono (by simp)) hT₂)
 
 end PairOfDefinition
 

--- a/TauCeti/RingTheory/Huber/OpenIdeal.lean
+++ b/TauCeti/RingTheory/Huber/OpenIdeal.lean
@@ -30,7 +30,9 @@ work is that an *ideal* of `A` containing the image of `Iⁿ` automatically cont
 * `TauCeti.Huber.PairOfDefinition.isOpen_mul`: the product of two open ideals is open — the
   powers of `I · A` witnessing each add.
 * `TauCeti.Huber.PairOfDefinition.isOpen_span_mul`: the span of a pointwise product of sets is
-  open when the two spans are, which is the form an intersection of rational subsets needs.
+  open when the two spans are.
+* `TauCeti.Huber.PairOfDefinition.isOpen_span_insert_mul_insert`: its `Finset` form with the two
+  denominators adjoined — the admissibility half of Wedhorn Remark 7.30(5).
 * `TauCeti.Huber.IsTateRing.isOpen_iff_eq_top`: an ideal of a Tate ring is open exactly when it is
   the whole ring.
 
@@ -127,6 +129,20 @@ theorem isOpen_span_mul (P : PairOfDefinition A) {S T : Set A}
     IsOpen (Ideal.span (S * T) : Set A) := by
   rw [← Ideal.span_mul_span]
   exact P.isOpen_mul hS hT
+
+open scoped Classical Pointwise in
+/-- **The numerator set of an intersection of rational subsets spans an open ideal.** Adjoining
+each denominator only enlarges a span, so this is `isOpen_span_mul` after two applications of
+`isOpen_of_le`. It is the admissibility half of Wedhorn Remark 7.30(5): the set identity
+`TauCeti.ValuationSpectrum.rationalSubset_inter` presents the intersection with numerators
+`insert s₁ T₁ * insert s₂ T₂`, and a rational subset is one whose numerator ideal is open. -/
+theorem isOpen_span_insert_mul_insert (P : PairOfDefinition A) {T₁ T₂ : Finset A} {s₁ s₂ : A}
+    (hT₁ : IsOpen (Ideal.span (T₁ : Set A) : Set A))
+    (hT₂ : IsOpen (Ideal.span (T₂ : Set A) : Set A)) :
+    IsOpen (Ideal.span ((insert s₁ T₁ * insert s₂ T₂ : Finset A) : Set A) : Set A) := by
+  rw [Finset.coe_mul]
+  exact P.isOpen_span_mul (P.isOpen_of_le (Ideal.span_mono (by simp)) hT₁)
+    (P.isOpen_of_le (Ideal.span_mono (by simp)) hT₂)
 
 end PairOfDefinition
 


### PR DESCRIPTION
`StructurePresheaf/Basic.lean` builds `𝒪_X(V)` as a limit over `PresentationIndex Aplus V`, and
that index had no directedness. This supplies it:

```text
instance : IsDirected (PresentationIndex Aplus V) (· ≤ ·)
```

`Presentation.commonRefinement` gives the underlying presentation but neither of the index's two
fields, and says so:

> `Presentation` carries no openness or admissibility field, so nothing here tracks or preserves
> openness of the numerator ideal; a consumer that needs it — the structure presheaf's index —
> must carry and re-establish it itself.

This PR is that consumer re-establishing them: containment in `V` from `rationalSubset_inter`, and
openness of the numerator span from the admissibility half of Remark 7.30(5).

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-3.3-presentation-index-directed"}-->

## What downstream roadmap item needs this

`TauCetiRoadmap/AdicSpaces/README.md`, Layer 3.3, defines the structure presheaf by "the limit
over rational subsets contained in the open", and requires that "the two definitions agree on
rational subsets". Computing that limit over a *rational* subset is what
`presentationLimitPresheaf`'s docstring is waiting on:

> Wedhorn §8.1's `𝒪_X` is this presheaf only once presentation-independence is available.

Directedness of the index is a prerequisite for that computation: it is what makes any two
admissible presentations of a subset comparable inside the index, so that the presentations
refining a chosen one can be shown initial. Layer 4.1's conclusion, `Huber.IsSheafyPair A Aplus`,
is stated over the presheaf that step produces.

## A correction, and a de-duplication

I opened this PR believing the admissibility half of Remark 7.30(5) was unproved, on the strength
of a sentence in `rationalSubset_inter`'s docstring:

> Wedhorn's full Remark 7.30(5) additionally says the right-hand pair is again admissible; that
> lives with the deferred open-ideal layer.

**That sentence is stale.** It is proved, privately, in `RationalSubset/Basis.lean`, by a
different route — through `isAdmissible` and radicals in `Spv(A,IA)` — and feeds
`inter_mem_spaRationalFamily_of_pairOfDefinition`. The sentence is corrected here to point at it.

So rather than add a second proof of one fact, this PR makes the general statement public where
open ideals live and deletes the private copy:

```text
PairOfDefinition.isOpen_mul                    IsOpen a → IsOpen b → IsOpen (a * b)
PairOfDefinition.isOpen_span_mul               the pointwise-product form
PairOfDefinition.isOpen_span_insert_mul_insert the Finset form  ← was private in Basis.lean
```

`inter_mem_spaRationalFamily_of_pairOfDefinition` consumes the new one unchanged, so the net
effect on that file is one deleted proof. The product lemma rests on Lemma 6.6, already here as `isOpen_iff_exists_pow_le`: openness is
containment of a power of `I · A`, and `(I·A)ⁿ ≤ a` with `(I·A)ᵐ ≤ b` gives `(I·A)ⁿ⁺ᵐ ≤ a * b`.
Note this is the *product* ideal, smaller than the intersection, so it is the sharper statement.
Passing openness *upwards* along `≤` needs no pair of definition at all and is Mathlib's
`Ideal.isOpen_of_isOpen_subideal`; an earlier revision of this PR restated it locally, which the
`reuse` rubric caught.

## Overlap with #5712, acknowledged

#5712 ("rational subsets are stable under small perturbations") adds
`exists_forall_mem_idealImage_exists_sum_eq` to `OpenIdeal.lean` at the same insertion point this
PR uses, and extends the same `## Main results` list. Not a duplicate: that lemma sharpens the
open-ideal criterion to produce `T`-combinations whose coefficients are topologically nilpotent,
for a valuation estimate; these prove openness survives a product of ideals. No declaration and no
target marker is shared. The clash is textual and resolves as an ordinary rebase for whichever
lands second.

## Relation to AINTLIB

Nothing adapted. AINTLIB's `ValuationSpectrum.HasRationalPresentation` records only that a set *is*
some `R(T/s)`, with no openness condition, so its `HasRationalPresentation.inter` is the set-level
identity alone; its blueprint asserts the openness half in prose without formalising it. Recorded
in `OpenIdeal.lean`'s Provenance section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
