### PR TITLE
feat: identify the SL center quotient with PSL

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Projective.lean
@@ -1,0 +1,346 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Projective
+public import TauCeti.Algebra.AlgebraicGroup.Center.Quotient
+public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Center.Basic
+
+/-!
+# The projective special linear point functor
+
+For positive `n`, the represented center of `SLₙ` maps isomorphically onto the ordinary center
+of its group of points. Consequently, its pointwise center quotient is Mathlib's projective
+special linear group `PSL(Fin n, A)` over every commutative value algebra `A`. This file proves
+that identification and packages it naturally in `A`.
+
+Over an algebraically closed field, Mathlib's canonical inclusion from `PSLₙ` to `PGLₙ` is
+bijective. Composing it with the pointwise quotient identification gives the expected
+`SLₙ / Z(SLₙ) ≅ PGLₙ` on field-valued points.
+
+These are identifications of pointwise quotients before fppf sheafification. They do not assert
+that the pointwise quotient is already an fppf sheaf, or construct a representing Hopf algebra.
+
+## Main declarations
+
+* `TauCeti.SpecialLinear.centerPointwiseQuotientIsoPSL`: the objectwise group isomorphism.
+* `TauCeti.SpecialLinear.pslPointsFunctor`: projective special linear groups under extension of
+  scalars.
+* `TauCeti.SpecialLinear.centerPointwiseQuotientNatIsoPSL`: the natural pointwise identification.
+* `TauCeti.SpecialLinear.centerPointwiseQuotientIsoPGLOfAlgClosed`: the resulting identification
+  with `PGLₙ` over an algebraically closed field.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Examples 5.49 and 21.4.
+
+This advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap: the
+central quotient relating the simply connected form `SLₙ` and the adjoint form `PGLₙ`.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+namespace SpecialLinear
+
+universe u v w
+
+variable (n : ℕ)
+
+section ProjectiveMap
+
+variable {R : Type v} [CommRing R] {S : Type w} [CommRing S]
+
+/-- Entrywise application of a ring homomorphism carries the center of a special linear group
+into the center of the target special linear group. -/
+theorem map_center_le_comap_center (f : R →+* S) :
+    Subgroup.center (Matrix.SpecialLinearGroup (Fin n) R) ≤
+      (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) S)).comap
+        (Matrix.SpecialLinearGroup.map f) := by
+  intro g hg
+  rw [Subgroup.mem_comap, Matrix.SpecialLinearGroup.mem_center_iff]
+  rw [Matrix.SpecialLinearGroup.mem_center_iff] at hg
+  obtain ⟨r, hr, hrg⟩ := hg
+  refine ⟨f r, ?_, ?_⟩
+  · rw [← map_pow, hr, map_one]
+  · rw [Matrix.SpecialLinearGroup.map_apply_coe, ← hrg]
+    ext i j
+    by_cases hij : i = j <;>
+      simp [RingHom.mapMatrix_apply, Matrix.scalar_apply, hij]
+
+/-- Extension of scalars on projective special linear groups. -/
+noncomputable def projectiveMap (f : R →+* S) :
+    Matrix.ProjectiveSpecialLinearGroup (Fin n) R →*
+      Matrix.ProjectiveSpecialLinearGroup (Fin n) S :=
+  QuotientGroup.map
+    (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) R))
+    (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) S))
+    (Matrix.SpecialLinearGroup.map f) (map_center_le_comap_center n f)
+
+/-- Extension of scalars on projective special linear groups is computed on representatives by
+entrywise application of the ring homomorphism. -/
+@[simp]
+theorem projectiveMap_mk (f : R →+* S) (g : Matrix.SpecialLinearGroup (Fin n) R) :
+    projectiveMap n f (QuotientGroup.mk g) =
+      QuotientGroup.mk (Matrix.SpecialLinearGroup.map f g) := by
+  exact QuotientGroup.map_mk _ _ _ _ g
+
+/-- Extension of scalars by the identity is the identity on projective special linear groups. -/
+@[simp]
+theorem projectiveMap_id :
+    projectiveMap n (RingHom.id R) = MonoidHom.id _ := by
+  apply MonoidHom.ext
+  intro x
+  induction x using QuotientGroup.induction_on with
+  | H g =>
+      rw [projectiveMap_mk]
+      congr 1
+
+/-- Successive extensions of scalars compose on projective special linear groups. -/
+@[simp]
+theorem projectiveMap_comp {T : Type u} [CommRing T] (f : R →+* S) (g : S →+* T) :
+    (projectiveMap n g).comp (projectiveMap n f) = projectiveMap n (g.comp f) := by
+  apply MonoidHom.ext
+  intro x
+  induction x using QuotientGroup.induction_on with
+  | H x =>
+      rw [MonoidHom.comp_apply, projectiveMap_mk, projectiveMap_mk, projectiveMap_mk]
+      congr 1
+
+end ProjectiveMap
+
+variable {k : Type u} [Field k]
+
+/-- Under the standard equivalence between `SLₙ`-points and determinant-one matrices, the
+represented center maps onto the ordinary group-theoretic center. -/
+theorem map_centerPointsSubgroup_pointsMulEquiv_eq_center (hn : 0 < n)
+    (A : CommAlgCat.{u} k) :
+    (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A).map
+        (pointsMulEquiv (R := k) (A := A) n) =
+      Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) := by
+  apply le_antisymm
+  · rintro _ ⟨q, hq, rfl⟩
+    apply MulEquivClass.apply_mem_center
+    apply HopfAlgebra.center_le_center
+    rw [← CommHopfAlgCat.centerPointsSubgroup_eq_center]
+    exact hq
+  · intro g hg
+    let c : Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) := ⟨g, hg⟩
+    let ζ : rootsOfUnity n A :=
+      Matrix.SpecialLinearGroup.centerMulEquivRootsOfUnityFin n hn A c
+    let f := (RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n).symm ζ
+    refine ⟨rootsOfUnityScalarPoints n f,
+      rootsOfUnityScalarPoints_mem_centerPointsSubgroup n f, ?_⟩
+    change pointsMulEquiv (R := k) (A := A) n (rootsOfUnityScalarPoints n f) = g
+    rw [pointsMulEquiv_rootsOfUnityScalarPoints n f, MulEquiv.apply_symm_apply]
+    apply Subtype.ext
+    rw [coe_rootsOfUnityScalarSL,
+      ← Matrix.SpecialLinearGroup.coe_centerMulEquivRootsOfUnityFin_symm_apply n hn A ζ]
+    simpa only [ζ, c] using congrArg
+      (fun x : Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) =>
+        ((x : Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A))
+      ((Matrix.SpecialLinearGroup.centerMulEquivRootsOfUnityFin n hn A).symm_apply_apply c)
+
+/-- The pointwise quotient of `SLₙ` by its represented center is the projective special linear
+group over the same value algebra. -/
+noncomputable def centerPointwiseQuotientIsoPSL (hn : 0 < n) (A : CommAlgCat.{u} k) :
+    CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) A ≅
+      GrpCat.of (Matrix.ProjectiveSpecialLinearGroup (Fin n) A) := by
+  let _ : Group (CommHopfAlgCat.centerPointwiseQuotient
+      (coordinateHopfAlgebra k n) A) :=
+    (CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) A).str
+  let _ : (CommHopfAlgCat.centerPointsSubgroup
+      (coordinateHopfAlgebra k n) A).Normal :=
+    CommHopfAlgCat.quotientPointsSubgroup_normal
+      (coordinateHopfAlgebra k n)
+      (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+      (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A
+  exact (QuotientGroup.congr
+    (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A)
+    (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A))
+    (pointsMulEquiv (R := k) (A := A) n)
+    (map_centerPointsSubgroup_pointsMulEquiv_eq_center n hn A)).toGrpIso
+
+/-- The quotient equivalence sends the class of an `SLₙ`-point to the class of its associated
+determinant-one matrix. -/
+@[simp]
+theorem centerPointwiseQuotientIsoPSL_hom_mk (hn : 0 < n) (A : CommAlgCat.{u} k)
+    (q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) :
+    (centerPointwiseQuotientIsoPSL n hn A).hom
+        (↑q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+          CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) =
+      QuotientGroup.mk (pointsMulEquiv (R := k) (A := A) n q) := by
+  let _ : (CommHopfAlgCat.centerPointsSubgroup
+      (coordinateHopfAlgebra k n) A).Normal :=
+    CommHopfAlgCat.quotientPointsSubgroup_normal
+      (coordinateHopfAlgebra k n)
+      (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+      (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A
+  exact QuotientGroup.congr_mk'
+    (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A)
+    (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A))
+    (pointsMulEquiv (R := k) (A := A) n)
+    (map_centerPointsSubgroup_pointsMulEquiv_eq_center n hn A) q
+
+/-- The inverse quotient equivalence sends the class of a determinant-one matrix to the class of
+its associated `SLₙ`-point. -/
+@[simp]
+theorem centerPointwiseQuotientIsoPSL_inv_mk (hn : 0 < n) (A : CommAlgCat.{u} k)
+    (g : Matrix.SpecialLinearGroup (Fin n) A) :
+    (centerPointwiseQuotientIsoPSL n hn A).inv (QuotientGroup.mk g) =
+      (↑((pointsMulEquiv (R := k) (A := A) n).symm g) :
+        HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+          CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) := by
+  have h := centerPointwiseQuotientIsoPSL_hom_mk n hn A
+    ((pointsMulEquiv (R := k) (A := A) n).symm g)
+  rw [MulEquiv.apply_symm_apply] at h
+  rw [← h, Iso.hom_inv_id_apply]
+
+/-- The presheaf `A ↦ PSL(Fin n, A)`, with maps induced by entrywise extension of scalars. -/
+noncomputable def pslPointsFunctor {R : Type u} [CommRing R] :
+    CommAlgCat.{w} R ⥤ GrpCat.{w} where
+  obj A := GrpCat.of (Matrix.ProjectiveSpecialLinearGroup (Fin n) A)
+  map φ := GrpCat.ofHom (projectiveMap n φ.hom.toRingHom)
+  map_id A := by
+    apply GrpCat.hom_ext
+    exact projectiveMap_id n
+  map_comp φ ψ := by
+    apply GrpCat.hom_ext
+    exact (projectiveMap_comp n φ.hom.toRingHom ψ.hom.toRingHom).symm
+
+/-- The objects of `pslPointsFunctor` are Mathlib's projective special linear groups. -/
+@[simp]
+theorem pslPointsFunctor_obj {R : Type u} [CommRing R] (A : CommAlgCat.{w} R) :
+    (pslPointsFunctor n).obj A =
+      GrpCat.of (Matrix.ProjectiveSpecialLinearGroup (Fin n) A) :=
+  by unfold pslPointsFunctor; rfl
+
+/-- The maps of `pslPointsFunctor` are induced by entrywise extension of scalars. -/
+@[simp]
+theorem pslPointsFunctor_map {R : Type u} [CommRing R]
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+    (pslPointsFunctor n).map φ =
+      eqToHom (pslPointsFunctor_obj n A) ≫
+        GrpCat.ofHom (projectiveMap n φ.hom.toRingHom) ≫
+          eqToHom (pslPointsFunctor_obj n B).symm :=
+  by unfold pslPointsFunctor; rfl
+
+/-- The quotient equivalence commutes with extension of scalars in the value algebra. -/
+theorem centerPointwiseQuotientIsoPSL_hom_naturality (hn : 0 < n)
+    {A B : CommAlgCat.{u} k} (φ : A ⟶ B) :
+    CommHopfAlgCat.mapPointwiseQuotient
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ ≫
+      (centerPointwiseQuotientIsoPSL n hn B).hom =
+    (centerPointwiseQuotientIsoPSL n hn A).hom ≫
+      GrpCat.ofHom (projectiveMap n φ.hom.toRingHom) := by
+  let _ : Group (CommHopfAlgCat.centerPointwiseQuotient
+      (coordinateHopfAlgebra k n) A) :=
+    (CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) A).str
+  let _ : Group (CommHopfAlgCat.centerPointwiseQuotient
+      (coordinateHopfAlgebra k n) B) :=
+    (CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) B).str
+  apply GrpCat.hom_ext
+  apply MonoidHom.ext
+  intro x
+  obtain ⟨q, rfl⟩ := CommHopfAlgCat.centerPointwiseQuotientMk_surjective
+    (coordinateHopfAlgebra k n) A x
+  simp only [GrpCat.hom_comp, MonoidHom.comp_apply, ConcreteCategory.hom_ofHom]
+  rw [CommHopfAlgCat.mapPointwiseQuotient_centerPointwiseQuotientMk]
+  rw [CommHopfAlgCat.centerPointwiseQuotientMk_apply,
+    CommHopfAlgCat.centerPointwiseQuotientMk_apply]
+  change
+    (centerPointwiseQuotientIsoPSL n hn B).hom
+        (↑(HopfAlgebra.mapPoints (H := coordinateHopfAlgebra k n) φ q) :
+          HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) B ⧸
+            CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) B) =
+      projectiveMap n φ.hom.toRingHom
+        ((centerPointwiseQuotientIsoPSL n hn A).hom
+          (↑q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+            CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A))
+  rw [centerPointwiseQuotientIsoPSL_hom_mk,
+    centerPointwiseQuotientIsoPSL_hom_mk, projectiveMap_mk,
+    HopfAlgebra.mapPoints_apply]
+  exact congrArg QuotientGroup.mk
+    (SpecialLinear.pointsMulEquiv_mapValue (R := k) (A := A) (B := B) n φ.hom q)
+
+/-- The pointwise center quotient of `SLₙ` is naturally isomorphic to the presheaf with values
+Mathlib's projective special linear groups. -/
+noncomputable def centerPointwiseQuotientNatIsoPSL (hn : 0 < n) :
+    CommHopfAlgCat.pointwiseQuotientFunctor
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) ≅
+      pslPointsFunctor n :=
+  NatIso.ofComponents
+    (fun A =>
+      eqToIso (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) ≪≫
+      centerPointwiseQuotientIsoPSL n hn A ≪≫
+      eqToIso (pslPointsFunctor_obj n A).symm) (by
+      intro A B φ
+      have hprojective :
+          eqToHom (pslPointsFunctor_obj n A).symm ≫
+              (pslPointsFunctor n).map φ =
+            GrpCat.ofHom (projectiveMap n φ.hom.toRingHom) ≫
+              eqToHom (pslPointsFunctor_obj n B).symm := by
+        rw [pslPointsFunctor_map]
+        simp
+      simpa only [Iso.trans_hom, eqToIso.hom,
+        CommHopfAlgCat.pointwiseQuotientFunctor_map, Category.assoc,
+        eqToHom_trans_assoc, eqToHom_refl, Category.id_comp, Category.comp_id,
+        hprojective] using
+        congrArg (fun z =>
+          eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+            (coordinateHopfAlgebra k n)
+            (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+            (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) ≫
+              z ≫ eqToHom (pslPointsFunctor_obj n B).symm)
+          (centerPointwiseQuotientIsoPSL_hom_naturality n hn φ))
+
+/-- Over an algebraically closed field, the pointwise center quotient of `SLₙ` is `PGLₙ`.
+This uses Mathlib's canonical isomorphism between projective general and special linear groups. -/
+noncomputable def centerPointwiseQuotientIsoPGLOfAlgClosed (hn : 0 < n)
+    (F : Type u) [Field F] [IsAlgClosed F] [Algebra k F] :
+    CommHopfAlgCat.centerPointwiseQuotient
+        (coordinateHopfAlgebra k n) (CommAlgCat.of k F) ≅
+      GrpCat.of (Matrix.ProjGenLinGroup (Fin n) F) := by
+  letI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  exact centerPointwiseQuotientIsoPSL n hn (CommAlgCat.of k F) ≪≫
+    (Matrix.ProjectiveSpecialLinearGroup.isoPSLOfAlgClosedOfNonempty
+      (n := Fin n) (F := F)).symm.toGrpIso
+
+/-- The algebraically closed-field identification sends an `SLₙ`-point to the projective class
+of its underlying invertible matrix. -/
+@[simp]
+theorem centerPointwiseQuotientIsoPGLOfAlgClosed_hom_mk (hn : 0 < n)
+    (F : Type u) [Field F] [IsAlgClosed F] [Algebra k F]
+    (q : HopfAlgebra.points (R := k)
+      (H := coordinateHopfAlgebra k n) (CommAlgCat.of k F)) :
+    (centerPointwiseQuotientIsoPGLOfAlgClosed n hn F).hom
+        (↑q : HopfAlgebra.points (R := k)
+            (H := coordinateHopfAlgebra k n) (CommAlgCat.of k F) ⧸
+          CommHopfAlgCat.centerPointsSubgroup
+            (coordinateHopfAlgebra k n) (CommAlgCat.of k F)) =
+      Matrix.ProjGenLinGroup.mk
+        (Matrix.SpecialLinearGroup.toGL
+          (pointsMulEquiv (R := k) (A := F) n q)) := by
+  let _ : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  unfold centerPointwiseQuotientIsoPGLOfAlgClosed
+  change Matrix.ProjectiveSpecialLinearGroup.toPGL
+      ((centerPointwiseQuotientIsoPSL n hn (CommAlgCat.of k F)).hom (↑q)) = _
+  rw [centerPointwiseQuotientIsoPSL_hom_mk]
+  rfl
+
+end SpecialLinear
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Projective.lean
@@ -36,6 +36,8 @@ that the pointwise quotient is already an fppf sheaf, or construct a representin
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), Examples 5.49 and 21.4.
+* The quotient equivalence, point functor, naturality proof, and natural isomorphism adapt the
+  corresponding constructions in `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Projective`.
 
 This advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap: the
 central quotient relating the simply connected form `SLₙ` and the adjoint form `PGLₙ`.
@@ -95,23 +97,15 @@ theorem projectiveMap_mk (f : R →+* S) (g : Matrix.SpecialLinearGroup (Fin n) 
 @[simp]
 theorem projectiveMap_id :
     projectiveMap n (RingHom.id R) = MonoidHom.id _ := by
-  apply MonoidHom.ext
-  intro x
-  induction x using QuotientGroup.induction_on with
-  | H g =>
-      rw [projectiveMap_mk]
-      congr 1
+  rw [projectiveMap]
+  exact QuotientGroup.map_id _ _
 
 /-- Successive extensions of scalars compose on projective special linear groups. -/
 @[simp]
 theorem projectiveMap_comp {T : Type u} [CommRing T] (f : R →+* S) (g : S →+* T) :
     (projectiveMap n g).comp (projectiveMap n f) = projectiveMap n (g.comp f) := by
-  apply MonoidHom.ext
-  intro x
-  induction x using QuotientGroup.induction_on with
-  | H x =>
-      rw [MonoidHom.comp_apply, projectiveMap_mk, projectiveMap_mk, projectiveMap_mk]
-      congr 1
+  rw [projectiveMap, projectiveMap, projectiveMap]
+  exact QuotientGroup.map_comp_map _ _ _ _ _ _ _ _
 
 end ProjectiveMap
 
@@ -135,9 +129,15 @@ theorem map_centerPointsSubgroup_pointsMulEquiv_eq_center (hn : 0 < n)
     let ζ : rootsOfUnity n A :=
       Matrix.SpecialLinearGroup.centerMulEquivRootsOfUnityFin n hn A c
     let f := (RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n).symm ζ
-    refine ⟨rootsOfUnityScalarPoints n f,
-      rootsOfUnityScalarPoints_mem_centerPointsSubgroup n f, ?_⟩
-    change pointsMulEquiv (R := k) (A := A) n (rootsOfUnityScalarPoints n f) = g
+    let q := rootsOfUnityScalarCenterMulEquiv (S := k) n hn A f
+    refine ⟨q.1, ?_, ?_⟩
+    · rw [CommHopfAlgCat.centerPointsSubgroup_eq_center]
+      exact q.2
+    change pointsMulEquiv (R := k) (A := A) n q.1 = g
+    rw [show q.1 = (rootsOfUnityScalarCenterHom n A f).1 by
+        rw [rootsOfUnityScalarCenterMulEquiv_apply,
+          coe_rootsOfUnityScalarCenterHom_apply],
+      coe_rootsOfUnityScalarCenterHom_apply]
     rw [pointsMulEquiv_rootsOfUnityScalarPoints n f, MulEquiv.apply_symm_apply]
     apply Subtype.ext
     rw [coe_rootsOfUnityScalarSL,

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Projective.lean
@@ -5,9 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Projective
 public import TauCeti.Algebra.AlgebraicGroup.Center.Quotient
 public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Center.Basic
+public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Projective
 
 /-!
 # The projective special linear point functor
@@ -38,9 +38,6 @@ that the pointwise quotient is already an fppf sheaf, or construct a representin
 * J. S. Milne, *Algebraic Groups* (2017), Examples 5.49 and 21.4.
 * The quotient equivalence, point functor, naturality proof, and natural isomorphism adapt the
   corresponding constructions in `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Projective`.
-
-This advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap: the
-central quotient relating the simply connected form `SLₙ` and the adjoint form `PGLₙ`.
 -/
 
 public section
@@ -51,63 +48,9 @@ namespace TauCeti
 
 namespace SpecialLinear
 
-universe u v w
+universe u w
 
 variable (n : ℕ)
-
-section ProjectiveMap
-
-variable {R : Type v} [CommRing R] {S : Type w} [CommRing S]
-
-/-- Entrywise application of a ring homomorphism carries the center of a special linear group
-into the center of the target special linear group. -/
-theorem map_center_le_comap_center (f : R →+* S) :
-    Subgroup.center (Matrix.SpecialLinearGroup (Fin n) R) ≤
-      (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) S)).comap
-        (Matrix.SpecialLinearGroup.map f) := by
-  intro g hg
-  rw [Subgroup.mem_comap, Matrix.SpecialLinearGroup.mem_center_iff]
-  rw [Matrix.SpecialLinearGroup.mem_center_iff] at hg
-  obtain ⟨r, hr, hrg⟩ := hg
-  refine ⟨f r, ?_, ?_⟩
-  · rw [← map_pow, hr, map_one]
-  · rw [Matrix.SpecialLinearGroup.map_apply_coe, ← hrg]
-    ext i j
-    by_cases hij : i = j <;>
-      simp [RingHom.mapMatrix_apply, Matrix.scalar_apply, hij]
-
-/-- Extension of scalars on projective special linear groups. -/
-noncomputable def projectiveMap (f : R →+* S) :
-    Matrix.ProjectiveSpecialLinearGroup (Fin n) R →*
-      Matrix.ProjectiveSpecialLinearGroup (Fin n) S :=
-  QuotientGroup.map
-    (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) R))
-    (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) S))
-    (Matrix.SpecialLinearGroup.map f) (map_center_le_comap_center n f)
-
-/-- Extension of scalars on projective special linear groups is computed on representatives by
-entrywise application of the ring homomorphism. -/
-@[simp]
-theorem projectiveMap_mk (f : R →+* S) (g : Matrix.SpecialLinearGroup (Fin n) R) :
-    projectiveMap n f (QuotientGroup.mk g) =
-      QuotientGroup.mk (Matrix.SpecialLinearGroup.map f g) := by
-  exact QuotientGroup.map_mk _ _ _ _ g
-
-/-- Extension of scalars by the identity is the identity on projective special linear groups. -/
-@[simp]
-theorem projectiveMap_id :
-    projectiveMap n (RingHom.id R) = MonoidHom.id _ := by
-  rw [projectiveMap]
-  exact QuotientGroup.map_id _ _
-
-/-- Successive extensions of scalars compose on projective special linear groups. -/
-@[simp]
-theorem projectiveMap_comp {T : Type u} [CommRing T] (f : R →+* S) (g : S →+* T) :
-    (projectiveMap n g).comp (projectiveMap n f) = projectiveMap n (g.comp f) := by
-  rw [projectiveMap, projectiveMap, projectiveMap]
-  exact QuotientGroup.map_comp_map _ _ _ _ _ _ _ _
-
-end ProjectiveMap
 
 variable {k : Type u} [Field k]
 
@@ -129,16 +72,16 @@ theorem map_centerPointsSubgroup_pointsMulEquiv_eq_center (hn : 0 < n)
     let ζ : rootsOfUnity n A :=
       Matrix.SpecialLinearGroup.centerMulEquivRootsOfUnityFin n hn A c
     let f := (RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n).symm ζ
-    let q := rootsOfUnityScalarCenterMulEquiv (S := k) n hn A f
-    refine ⟨q.1, ?_, ?_⟩
+    refine ⟨(rootsOfUnityScalarCenterMulEquiv (S := k) n hn A f).1, ?_, ?_⟩
     · rw [CommHopfAlgCat.centerPointsSubgroup_eq_center]
-      exact q.2
-    change pointsMulEquiv (R := k) (A := A) n q.1 = g
-    rw [show q.1 = (rootsOfUnityScalarCenterHom n A f).1 by
-        rw [rootsOfUnityScalarCenterMulEquiv_apply,
-          coe_rootsOfUnityScalarCenterHom_apply],
-      coe_rootsOfUnityScalarCenterHom_apply]
-    rw [pointsMulEquiv_rootsOfUnityScalarPoints n f, MulEquiv.apply_symm_apply]
+      exact (rootsOfUnityScalarCenterMulEquiv (S := k) n hn A f).2
+    -- The two established roots-of-unity equivalences identify the represented center and the
+    -- matrix center. The subgroup-map witness uses the coerced equivalence, so expose its
+    -- application before applying their public evaluation lemmas.
+    change pointsMulEquiv (R := k) (A := A) n
+      (rootsOfUnityScalarCenterMulEquiv (S := k) n hn A f).1 = g
+    rw [rootsOfUnityScalarCenterMulEquiv_apply,
+      pointsMulEquiv_rootsOfUnityScalarPoints, MulEquiv.apply_symm_apply]
     apply Subtype.ext
     rw [coe_rootsOfUnityScalarSL,
       ← Matrix.SpecialLinearGroup.coe_centerMulEquivRootsOfUnityFin_symm_apply n hn A ζ]
@@ -256,6 +199,7 @@ theorem centerPointwiseQuotientIsoPSL_hom_naturality (hn : 0 < n)
   rw [CommHopfAlgCat.mapPointwiseQuotient_centerPointwiseQuotientMk]
   rw [CommHopfAlgCat.centerPointwiseQuotientMk_apply,
     CommHopfAlgCat.centerPointwiseQuotientMk_apply]
+  -- Normalize both projection applications to the quotient coercions used by the public API.
   change
     (centerPointwiseQuotientIsoPSL n hn B).hom
         (↑(HopfAlgebra.mapPoints (H := coordinateHopfAlgebra k n) φ q) :
@@ -307,6 +251,77 @@ noncomputable def centerPointwiseQuotientNatIsoPSL (hn : 0 < n) :
               z ≫ eqToHom (pslPointsFunctor_obj n B).symm)
           (centerPointwiseQuotientIsoPSL_hom_naturality n hn φ))
 
+/-- After transport to the concrete quotient groups, the hom component of the natural
+identification is the objectwise quotient isomorphism. -/
+@[simp]
+theorem centerPointwiseQuotientNatIsoPSL_hom_app (hn : 0 < n)
+    (A : CommAlgCat.{u} k) :
+    eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm ≫
+      (centerPointwiseQuotientNatIsoPSL n hn).hom.app A ≫
+        eqToHom (pslPointsFunctor_obj n A) =
+      (centerPointwiseQuotientIsoPSL n hn A).hom := by
+  unfold centerPointwiseQuotientNatIsoPSL
+  simp
+
+/-- After transport to the concrete quotient groups, the inverse component of the natural
+identification is the inverse objectwise quotient isomorphism. -/
+@[simp]
+theorem centerPointwiseQuotientNatIsoPSL_inv_app (hn : 0 < n)
+    (A : CommAlgCat.{u} k) :
+    eqToHom (pslPointsFunctor_obj n A).symm ≫
+        (centerPointwiseQuotientNatIsoPSL n hn).inv.app A ≫
+      eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) =
+    (centerPointwiseQuotientIsoPSL n hn A).inv := by
+  unfold centerPointwiseQuotientNatIsoPSL
+  simp
+
+/-- After transport to the concrete quotient groups, the hom component of the natural
+identification sends a quotient class to the class of its associated determinant-one matrix. -/
+@[simp]
+theorem centerPointwiseQuotientNatIsoPSL_hom_app_mk (hn : 0 < n)
+    (A : CommAlgCat.{u} k)
+    (q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) :
+    eqToHom (pslPointsFunctor_obj n A)
+        ((centerPointwiseQuotientNatIsoPSL n hn).hom.app A
+          (eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+              (coordinateHopfAlgebra k n)
+              (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+              (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm
+            (↑q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+              CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A))) =
+      QuotientGroup.mk (pointsMulEquiv (R := k) (A := A) n q) := by
+  have h := congrArg
+    (fun f ↦ f (↑q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+      CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A))
+    (centerPointwiseQuotientNatIsoPSL_hom_app n hn A)
+  simp only [GrpCat.hom_comp, MonoidHom.comp_apply] at h
+  rw [h, centerPointwiseQuotientIsoPSL_hom_mk]
+
+/-- After transport to the concrete quotient groups, the inverse component of the natural
+identification sends the class of a determinant-one matrix to its associated quotient class. -/
+@[simp]
+theorem centerPointwiseQuotientNatIsoPSL_inv_app_mk (hn : 0 < n)
+    (A : CommAlgCat.{u} k) (g : Matrix.SpecialLinearGroup (Fin n) A) :
+    eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A)
+      ((centerPointwiseQuotientNatIsoPSL n hn).inv.app A
+        (eqToHom (pslPointsFunctor_obj n A).symm (QuotientGroup.mk g))) =
+      (↑((pointsMulEquiv (R := k) (A := A) n).symm g) :
+        HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+          CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) := by
+  have h := congrArg (fun f ↦ f (QuotientGroup.mk g))
+    (centerPointwiseQuotientNatIsoPSL_inv_app n hn A)
+  simp only [GrpCat.hom_comp, MonoidHom.comp_apply] at h
+  rw [h, centerPointwiseQuotientIsoPSL_inv_mk]
+
 /-- Over an algebraically closed field, the pointwise center quotient of `SLₙ` is `PGLₙ`.
 This uses Mathlib's canonical isomorphism between projective general and special linear groups. -/
 noncomputable def centerPointwiseQuotientIsoPGLOfAlgClosed (hn : 0 < n)
@@ -336,10 +351,30 @@ theorem centerPointwiseQuotientIsoPGLOfAlgClosed_hom_mk (hn : 0 < n)
           (pointsMulEquiv (R := k) (A := F) n q)) := by
   let _ : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
   unfold centerPointwiseQuotientIsoPGLOfAlgClosed
+  -- The composite categorical isomorphism computes through Mathlib's underlying PSL-to-PGL map.
   change Matrix.ProjectiveSpecialLinearGroup.toPGL
       ((centerPointwiseQuotientIsoPSL n hn (CommAlgCat.of k F)).hom (↑q)) = _
-  rw [centerPointwiseQuotientIsoPSL_hom_mk]
-  rfl
+  rw [centerPointwiseQuotientIsoPSL_hom_mk,
+    Matrix.ProjectiveSpecialLinearGroup.toPGL_mk]
+
+/-- The inverse algebraically closed-field identification sends the projective class of a
+determinant-one matrix to the quotient class of its associated `SLₙ`-point. -/
+@[simp]
+theorem centerPointwiseQuotientIsoPGLOfAlgClosed_inv_mk_toGL (hn : 0 < n)
+    (F : Type u) [Field F] [IsAlgClosed F] [Algebra k F]
+    (g : Matrix.SpecialLinearGroup (Fin n) F) :
+    (centerPointwiseQuotientIsoPGLOfAlgClosed n hn F).inv
+        (Matrix.ProjGenLinGroup.mk (Matrix.SpecialLinearGroup.toGL g)) =
+      (↑((pointsMulEquiv (R := k) (A := F) n).symm g) :
+        HopfAlgebra.points (R := k)
+            (H := coordinateHopfAlgebra k n) (CommAlgCat.of k F) ⧸
+          CommHopfAlgCat.centerPointsSubgroup
+            (coordinateHopfAlgebra k n) (CommAlgCat.of k F)) := by
+  have h := centerPointwiseQuotientIsoPGLOfAlgClosed_hom_mk n hn F
+    ((pointsMulEquiv (R := k) (A := F) n).symm g)
+  rw [MulEquiv.apply_symm_apply] at h
+  rw [← h]
+  exact GrpCat.inv_hom_apply _ _
 
 end SpecialLinear
 

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Projective.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Projective.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Projective
+public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
+
+/-!
+# Extension of scalars for projective special linear groups
+
+This file defines the map on projective special linear groups induced by a ring homomorphism
+and proves its identity, composition, and representative formulas.
+
+## Main declarations
+
+* `TauCeti.SpecialLinear.projectiveMap`: extension of scalars on projective special linear
+  groups.
+* `TauCeti.SpecialLinear.projectiveMap_mk`: the action on quotient representatives.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace SpecialLinear
+
+universe u v w
+
+variable (n : ℕ)
+variable {R : Type v} [CommRing R] {S : Type w} [CommRing S]
+
+/-- Entrywise application of a ring homomorphism carries the center of a special linear group
+into the center of the target special linear group. -/
+theorem map_center_le_comap_center (f : R →+* S) :
+    Subgroup.center (Matrix.SpecialLinearGroup (Fin n) R) ≤
+      (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) S)).comap
+        (Matrix.SpecialLinearGroup.map f) := by
+  intro g hg
+  rw [Subgroup.mem_comap, Matrix.SpecialLinearGroup.mem_center_iff]
+  rw [Matrix.SpecialLinearGroup.mem_center_iff] at hg
+  obtain ⟨r, hr, hrg⟩ := hg
+  refine ⟨f r, ?_, ?_⟩
+  · rw [← map_pow, hr, map_one]
+  · rw [Matrix.SpecialLinearGroup.map_apply_coe, ← hrg]
+    ext i j
+    by_cases hij : i = j <;>
+      simp [RingHom.mapMatrix_apply, Matrix.scalar_apply, hij]
+
+/-- Extension of scalars on projective special linear groups. -/
+noncomputable def projectiveMap (f : R →+* S) :
+    Matrix.ProjectiveSpecialLinearGroup (Fin n) R →*
+      Matrix.ProjectiveSpecialLinearGroup (Fin n) S :=
+  QuotientGroup.map
+    (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) R))
+    (Subgroup.center (Matrix.SpecialLinearGroup (Fin n) S))
+    (Matrix.SpecialLinearGroup.map f) (map_center_le_comap_center n f)
+
+/-- Extension of scalars on projective special linear groups is computed on representatives by
+entrywise application of the ring homomorphism. -/
+@[simp]
+theorem projectiveMap_mk (f : R →+* S) (g : Matrix.SpecialLinearGroup (Fin n) R) :
+    projectiveMap n f (QuotientGroup.mk g) =
+      QuotientGroup.mk (Matrix.SpecialLinearGroup.map f g) := by
+  exact QuotientGroup.map_mk _ _ _ _ g
+
+/-- Extension of scalars by the identity is the identity on projective special linear groups. -/
+@[simp]
+theorem projectiveMap_id :
+    projectiveMap n (RingHom.id R) = MonoidHom.id _ := by
+  rw [projectiveMap]
+  exact QuotientGroup.map_id _ _
+
+/-- Successive extensions of scalars compose on projective special linear groups. -/
+@[simp]
+theorem projectiveMap_comp {T : Type u} [CommRing T] (f : R →+* S) (g : S →+* T) :
+    (projectiveMap n g).comp (projectiveMap n f) = projectiveMap n (g.comp f) := by
+  rw [projectiveMap, projectiveMap, projectiveMap]
+  exact QuotientGroup.map_comp_map _ _ _ _ _ _ _ _
+
+end SpecialLinear
+
+end TauCeti


### PR DESCRIPTION
This PR identifies the represented-center quotient of `SLₙ` on every commutative value algebra with Mathlib's `PSL(Fin n, A)`, packages that identification as a natural isomorphism, and composes it with the canonical `PSLₙ ≅ PGLₙ` comparison over algebraically closed fields.

It advances the exact `ReductiveGroups/README.md` Layer 6 milestone "Reductive / semisimple" targets "center and derived subgroup, central isogenies, simply-connected and adjoint forms" and the worked examples `SLₙ` and `PGLₙ`. After this PR, it remains to represent the fppf-sheaf quotient by `PGLₙ` and prove the resulting adjoint-form properties.

The implementation reuses Mathlib's projective special/general linear groups, quotient-group transport, and algebraically closed-field `PGLₙ ≅ PSLₙ` theorem; it vendors no Mathlib infrastructure.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-linear-center-quotient-psl"}-->

🤖 Prepared with Codex
