### PR TITLE
feat: mixed monomial maps between mixed charts

### DIFF
--- a/TauCeti/Algebra/BigOperators/ZPow.lean
+++ b/TauCeti/Algebra/BigOperators/ZPow.lean
@@ -50,23 +50,21 @@ theorem prod_zpow_eq_zpow_sum [CommGroupWithZero G₀] (s : Finset ι) {y : G₀
 theorem prod_update_pow [CommMonoid M] [DecidableEq ι] (s : Finset ι) (x : ι → M)
     (e : ι → ℕ) {i : ι} (hi : i ∈ s) (y : M) :
     ∏ j ∈ s, Function.update x i y j ^ e j = y ^ e i * ∏ j ∈ s \ {i}, x j ^ e j := by
-  rw [prod_eq_mul_prod_sdiff_singleton i _ (fun h ↦ (h hi).elim)]
-  simp only [Function.update_self]
-  congr 1
-  exact prod_congr rfl fun j hj ↦ by
-    have hji : j ≠ i := by simpa using (mem_sdiff.mp hj).2
-    simp [Function.update, hji]
+  have hupdate : (fun j ↦ Function.update x i y j ^ e j) =
+      Function.update (fun j ↦ x j ^ e j) i (y ^ e i) := by
+    funext j
+    exact Function.apply_update (fun j z ↦ z ^ e j) x i y j
+  rw [hupdate, prod_update_of_mem hi]
 
 /-- Updating one base in a finite product of integral powers isolates the updated factor. -/
 theorem prod_update_zpow [CommMonoid M] [Pow M ℤ] [DecidableEq ι] (s : Finset ι) (x : ι → M)
     (e : ι → ℤ) {i : ι} (hi : i ∈ s) (y : M) :
     ∏ j ∈ s, Function.update x i y j ^ e j = y ^ e i * ∏ j ∈ s \ {i}, x j ^ e j := by
-  rw [prod_eq_mul_prod_sdiff_singleton i _ (fun h ↦ (h hi).elim)]
-  simp only [Function.update_self]
-  congr 1
-  exact prod_congr rfl fun j hj ↦ by
-    have hji : j ≠ i := by simpa using (mem_sdiff.mp hj).2
-    simp [Function.update, hji]
+  have hupdate : (fun j ↦ Function.update x i y j ^ e j) =
+      Function.update (fun j ↦ x j ^ e j) i (y ^ e i) := by
+    funext j
+    exact Function.apply_update (fun j z ↦ z ^ e j) x i y j
+  rw [hupdate, prod_update_of_mem hi]
 
 /-- Substituting the monomials `∏ b ∈ t, x b ^ e a b` into the monomial with natural exponents
 `g` produces the monomial whose exponent matrix is the product `∑ a ∈ s, g a * e a b`. -/

--- a/TauCeti/Algebra/BigOperators/ZPow.lean
+++ b/TauCeti/Algebra/BigOperators/ZPow.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
-public import Mathlib.Algebra.BigOperators.Group.Finset.Piecewise
 public import Mathlib.Algebra.GroupWithZero.Units.Basic
 
 /-!
@@ -24,8 +23,6 @@ allowed to vanish.
 ## Main results
 
 * `Finset.prod_zpow_eq_zpow_sum`: `∏ i ∈ s, y ^ e i = y ^ ∑ i ∈ s, e i` for `y ≠ 0`.
-* `Finset.prod_update_pow` and `Finset.prod_update_zpow`: isolate one factor of a product after
-  updating its base.
 * `Finset.prod_prod_pow`, `Finset.prod_prod_zpow` and `Finset.prod_prod_zpow_pow`: substituting
   monomials into a monomial multiplies the exponent matrices, for the three combinations of
   natural and integral exponents that make sense.
@@ -45,26 +42,6 @@ theorem prod_zpow_eq_zpow_sum [CommGroupWithZero G₀] (s : Finset ι) {y : G₀
   induction s using Finset.cons_induction with
   | empty => simp
   | cons a s ha ih => rw [prod_cons, sum_cons, ih, zpow_add₀ hy]
-
-/-- Updating one base in a finite product of natural powers isolates the updated factor. -/
-theorem prod_update_pow [CommMonoid M] [DecidableEq ι] (s : Finset ι) (x : ι → M)
-    (e : ι → ℕ) {i : ι} (hi : i ∈ s) (y : M) :
-    ∏ j ∈ s, Function.update x i y j ^ e j = y ^ e i * ∏ j ∈ s \ {i}, x j ^ e j := by
-  have hupdate : (fun j ↦ Function.update x i y j ^ e j) =
-      Function.update (fun j ↦ x j ^ e j) i (y ^ e i) := by
-    funext j
-    exact Function.apply_update (fun j z ↦ z ^ e j) x i y j
-  rw [hupdate, prod_update_of_mem hi]
-
-/-- Updating one base in a finite product of integral powers isolates the updated factor. -/
-theorem prod_update_zpow [CommMonoid M] [Pow M ℤ] [DecidableEq ι] (s : Finset ι) (x : ι → M)
-    (e : ι → ℤ) {i : ι} (hi : i ∈ s) (y : M) :
-    ∏ j ∈ s, Function.update x i y j ^ e j = y ^ e i * ∏ j ∈ s \ {i}, x j ^ e j := by
-  have hupdate : (fun j ↦ Function.update x i y j ^ e j) =
-      Function.update (fun j ↦ x j ^ e j) i (y ^ e i) := by
-    funext j
-    exact Function.apply_update (fun j z ↦ z ^ e j) x i y j
-  rw [hupdate, prod_update_of_mem hi]
 
 /-- Substituting the monomials `∏ b ∈ t, x b ^ e a b` into the monomial with natural exponents
 `g` produces the monomial whose exponent matrix is the product `∑ a ∈ s, g a * e a b`. -/

--- a/TauCeti/Algebra/BigOperators/ZPow.lean
+++ b/TauCeti/Algebra/BigOperators/ZPow.lean
@@ -22,17 +22,15 @@ allowed to vanish.
 
 ## Main results
 
-* `TauCeti.prod_zpow_eq_zpow_sum`: `∏ i ∈ s, y ^ e i = y ^ ∑ i ∈ s, e i` for `y ≠ 0`.
-* `TauCeti.prod_prod_pow`, `TauCeti.prod_prod_zpow` and `TauCeti.prod_prod_zpow_pow`: substituting
+* `Finset.prod_zpow_eq_zpow_sum`: `∏ i ∈ s, y ^ e i = y ^ ∑ i ∈ s, e i` for `y ≠ 0`.
+* `Finset.prod_prod_pow`, `Finset.prod_prod_zpow` and `Finset.prod_prod_zpow_pow`: substituting
   monomials into a monomial multiplies the exponent matrices, for the three combinations of
   natural and integral exponents that make sense.
 -/
 
 public section
 
-namespace TauCeti
-
-open Finset
+namespace Finset
 
 variable {ι κ M G₀ : Type*}
 
@@ -72,7 +70,7 @@ theorem prod_prod_zpow [CommGroupWithZero G₀] (s : Finset ι) (t : Finset κ) 
     _ = ∏ b ∈ t, y b ^ ∑ a ∈ s, g a * e a b :=
         prod_congr rfl fun b hb ↦ prod_zpow_eq_zpow_sum _ (hy b hb) _
 
-/-- The mixed case of `TauCeti.prod_prod_zpow`: monomials with integral exponents in invertible
+/-- The mixed case of `Finset.prod_prod_zpow`: monomials with integral exponents in invertible
 coordinates, substituted into a monomial with natural exponents `g`. -/
 theorem prod_prod_zpow_pow [CommGroupWithZero G₀] (s : Finset ι) (t : Finset κ) {y : κ → G₀}
     (hy : ∀ b ∈ t, y b ≠ 0) (e : ι → κ → ℤ) (g : ι → ℕ) :
@@ -80,4 +78,4 @@ theorem prod_prod_zpow_pow [CommGroupWithZero G₀] (s : Finset ι) (t : Finset 
   rw [← prod_prod_zpow s t hy e fun a ↦ (g a : ℤ)]
   exact prod_congr rfl fun a _ ↦ (zpow_natCast _ _).symm
 
-end TauCeti
+end Finset

--- a/TauCeti/Algebra/BigOperators/ZPow.lean
+++ b/TauCeti/Algebra/BigOperators/ZPow.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
+public import Mathlib.Algebra.GroupWithZero.Units.Basic
+
+/-!
+# Collapsing an iterated product of powers into a single product of powers
+
+`Finset.prod_pow_eq_pow_sum` collapses a product of natural powers of one fixed element into a
+single power. This file records the analogue for integral powers of an invertible element of a
+commutative group with zero, and the three substitution rules that follow from it: substituting a
+family of monomials into a monomial multiplies the two exponent matrices.
+
+These are the bookkeeping rules behind composing monomial maps in coordinates, where the exponent
+matrices may carry natural or integral entries depending on whether the coordinate they act on is
+allowed to vanish.
+
+## Main results
+
+* `TauCeti.prod_zpow_eq_zpow_sum`: `∏ i ∈ s, y ^ e i = y ^ ∑ i ∈ s, e i` for `y ≠ 0`.
+* `TauCeti.prod_prod_pow`, `TauCeti.prod_prod_zpow` and `TauCeti.prod_prod_zpow_pow`: substituting
+  monomials into a monomial multiplies the exponent matrices, for the three combinations of
+  natural and integral exponents that make sense.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset
+
+variable {ι κ M G₀ : Type*}
+
+/-- A product of integral powers of one fixed invertible element collapses to a single power.
+This is the integral-exponent analogue of `Finset.prod_pow_eq_pow_sum`. -/
+theorem prod_zpow_eq_zpow_sum [CommGroupWithZero G₀] (s : Finset ι) {y : G₀} (hy : y ≠ 0)
+    (e : ι → ℤ) : ∏ i ∈ s, y ^ e i = y ^ ∑ i ∈ s, e i := by
+  classical
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons a s ha ih => rw [prod_cons, sum_cons, ih, zpow_add₀ hy]
+
+/-- Substituting the monomials `∏ b ∈ t, x b ^ e a b` into the monomial with natural exponents
+`g` produces the monomial whose exponent matrix is the product `∑ a ∈ s, g a * e a b`. -/
+theorem prod_prod_pow [CommMonoid M] (s : Finset ι) (t : Finset κ) (x : κ → M) (e : ι → κ → ℕ)
+    (g : ι → ℕ) :
+    ∏ a ∈ s, (∏ b ∈ t, x b ^ e a b) ^ g a = ∏ b ∈ t, x b ^ ∑ a ∈ s, g a * e a b := by
+  calc ∏ a ∈ s, (∏ b ∈ t, x b ^ e a b) ^ g a = ∏ b ∈ t, ∏ a ∈ s, x b ^ (g a * e a b) := by
+        rw [Finset.prod_comm]
+        exact prod_congr rfl fun a _ ↦ by
+          rw [← Finset.prod_pow]
+          exact prod_congr rfl fun b _ ↦ by rw [← pow_mul, mul_comm]
+    _ = ∏ b ∈ t, x b ^ ∑ a ∈ s, g a * e a b :=
+        prod_congr rfl fun b _ ↦ prod_pow_eq_pow_sum _ _ _
+
+/-- Substituting the monomials `∏ b ∈ t, y b ^ e a b` in invertible coordinates into the monomial
+with integral exponents `g` produces the monomial whose exponent matrix is the product
+`∑ a ∈ s, g a * e a b`. -/
+theorem prod_prod_zpow [CommGroupWithZero G₀] (s : Finset ι) (t : Finset κ) {y : κ → G₀}
+    (hy : ∀ b ∈ t, y b ≠ 0) (e : ι → κ → ℤ) (g : ι → ℤ) :
+    ∏ a ∈ s, (∏ b ∈ t, y b ^ e a b) ^ g a = ∏ b ∈ t, y b ^ ∑ a ∈ s, g a * e a b := by
+  calc ∏ a ∈ s, (∏ b ∈ t, y b ^ e a b) ^ g a = ∏ b ∈ t, ∏ a ∈ s, y b ^ (g a * e a b) := by
+        rw [Finset.prod_comm]
+        exact prod_congr rfl fun a _ ↦ by
+          rw [← Finset.prod_zpow]
+          exact prod_congr rfl fun b _ ↦ by rw [← zpow_mul, mul_comm]
+    _ = ∏ b ∈ t, y b ^ ∑ a ∈ s, g a * e a b :=
+        prod_congr rfl fun b hb ↦ prod_zpow_eq_zpow_sum _ (hy b hb) _
+
+/-- The mixed case of `TauCeti.prod_prod_zpow`: monomials with integral exponents in invertible
+coordinates, substituted into a monomial with natural exponents `g`. -/
+theorem prod_prod_zpow_pow [CommGroupWithZero G₀] (s : Finset ι) (t : Finset κ) {y : κ → G₀}
+    (hy : ∀ b ∈ t, y b ≠ 0) (e : ι → κ → ℤ) (g : ι → ℕ) :
+    ∏ a ∈ s, (∏ b ∈ t, y b ^ e a b) ^ g a = ∏ b ∈ t, y b ^ ∑ a ∈ s, (g a : ℤ) * e a b := by
+  rw [← prod_prod_zpow s t hy e fun a ↦ (g a : ℤ)]
+  exact prod_congr rfl fun a _ ↦ (zpow_natCast _ _).symm
+
+end TauCeti

--- a/TauCeti/Algebra/BigOperators/ZPow.lean
+++ b/TauCeti/Algebra/BigOperators/ZPow.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
+public import Mathlib.Algebra.BigOperators.Group.Finset.Piecewise
 public import Mathlib.Algebra.GroupWithZero.Units.Basic
 
 /-!
@@ -23,6 +24,8 @@ allowed to vanish.
 ## Main results
 
 * `Finset.prod_zpow_eq_zpow_sum`: `∏ i ∈ s, y ^ e i = y ^ ∑ i ∈ s, e i` for `y ≠ 0`.
+* `Finset.prod_update_pow` and `Finset.prod_update_zpow`: isolate one factor of a product after
+  updating its base.
 * `Finset.prod_prod_pow`, `Finset.prod_prod_zpow` and `Finset.prod_prod_zpow_pow`: substituting
   monomials into a monomial multiplies the exponent matrices, for the three combinations of
   natural and integral exponents that make sense.
@@ -42,6 +45,28 @@ theorem prod_zpow_eq_zpow_sum [CommGroupWithZero G₀] (s : Finset ι) {y : G₀
   induction s using Finset.cons_induction with
   | empty => simp
   | cons a s ha ih => rw [prod_cons, sum_cons, ih, zpow_add₀ hy]
+
+/-- Updating one base in a finite product of natural powers isolates the updated factor. -/
+theorem prod_update_pow [CommMonoid M] [DecidableEq ι] (s : Finset ι) (x : ι → M)
+    (e : ι → ℕ) {i : ι} (hi : i ∈ s) (y : M) :
+    ∏ j ∈ s, Function.update x i y j ^ e j = y ^ e i * ∏ j ∈ s \ {i}, x j ^ e j := by
+  rw [prod_eq_mul_prod_sdiff_singleton i _ (fun h ↦ (h hi).elim)]
+  simp only [Function.update_self]
+  congr 1
+  exact prod_congr rfl fun j hj ↦ by
+    have hji : j ≠ i := by simpa using (mem_sdiff.mp hj).2
+    simp [Function.update, hji]
+
+/-- Updating one base in a finite product of integral powers isolates the updated factor. -/
+theorem prod_update_zpow [CommMonoid M] [Pow M ℤ] [DecidableEq ι] (s : Finset ι) (x : ι → M)
+    (e : ι → ℤ) {i : ι} (hi : i ∈ s) (y : M) :
+    ∏ j ∈ s, Function.update x i y j ^ e j = y ^ e i * ∏ j ∈ s \ {i}, x j ^ e j := by
+  rw [prod_eq_mul_prod_sdiff_singleton i _ (fun h ↦ (h hi).elim)]
+  simp only [Function.update_self]
+  congr 1
+  exact prod_congr rfl fun j hj ↦ by
+    have hji : j ≠ i := by simpa using (mem_sdiff.mp hj).2
+    simp [Function.update, hji]
 
 /-- Substituting the monomials `∏ b ∈ t, x b ^ e a b` into the monomial with natural exponents
 `g` produces the monomial whose exponent matrix is the product `∑ a ∈ s, g a * e a b`. -/

--- a/TauCeti/Analysis/Calculus/ContDiffZPow.lean
+++ b/TauCeti/Analysis/Calculus/ContDiffZPow.lean
@@ -16,23 +16,23 @@ combination: away from a zero of `f`, every integral power of `f` is as smooth a
 
 ## Main results
 
-* `TauCeti.contDiffAt_zpow`: `fun z ↦ f z ^ (m : ℤ)` is `C^n` at a point where `f` is `C^n` and
+* `ContDiffAt.zpow`: `fun z ↦ f z ^ (m : ℤ)` is `C^n` at a point where `f` is `C^n` and
   does not vanish.
 -/
 
 public section
 
-namespace TauCeti
+namespace ContDiffAt
 
 variable {𝕜 E 𝕜' : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] {f : E → 𝕜'} {x : E} {n : WithTop ℕ∞}
 
 /-- An integral power of a `C^n` function is `C^n` at every point where the function does not
 vanish. -/
-theorem contDiffAt_zpow (hf : ContDiffAt 𝕜 n f x) (hx : f x ≠ 0) (m : ℤ) :
+theorem zpow (hf : ContDiffAt 𝕜 n f x) (hx : f x ≠ 0) (m : ℤ) :
     ContDiffAt 𝕜 n (fun z ↦ f z ^ m) x := by
   obtain ⟨i, rfl | rfl⟩ := m.eq_nat_or_neg
   · simpa [zpow_natCast] using hf.pow i
   · simpa [zpow_neg, zpow_natCast, Pi.inv_def] using (hf.pow i).inv (pow_ne_zero _ hx)
 
-end TauCeti
+end ContDiffAt

--- a/TauCeti/Analysis/Calculus/ContDiffZPow.lean
+++ b/TauCeti/Analysis/Calculus/ContDiffZPow.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Calculus.ContDiff.Operations
+
+/-!
+# Integral powers of a `C^n` function
+
+Mathlib provides `ContDiffAt.pow` for natural powers and `ContDiffAt.inv` for the inverse of a
+nonvanishing function, but no lemma for an integral power. This file supplies the missing
+combination: away from a zero of `f`, every integral power of `f` is as smooth as `f` is.
+
+## Main results
+
+* `TauCeti.contDiffAt_zpow`: `fun z ↦ f z ^ (m : ℤ)` is `C^n` at a point where `f` is `C^n` and
+  does not vanish.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {𝕜 E 𝕜' : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] {f : E → 𝕜'} {x : E} {n : WithTop ℕ∞}
+
+/-- An integral power of a `C^n` function is `C^n` at every point where the function does not
+vanish. -/
+theorem contDiffAt_zpow (hf : ContDiffAt 𝕜 n f x) (hx : f x ≠ 0) (m : ℤ) :
+    ContDiffAt 𝕜 n (fun z ↦ f z ^ m) x := by
+  obtain ⟨i, rfl | rfl⟩ := m.eq_nat_or_neg
+  · simpa [zpow_natCast] using hf.pow i
+  · simpa [zpow_neg, zpow_natCast, Pi.inv_def] using (hf.pow i).inv (pow_ne_zero _ hx)
+
+end TauCeti

--- a/TauCeti/Analysis/Calculus/ContDiffZPow.lean
+++ b/TauCeti/Analysis/Calculus/ContDiffZPow.lean
@@ -18,26 +18,30 @@ for a nonnegative exponent. The hypothesis is the one carried by Mathlib's
 
 ## Main results
 
-* `ContDiffAt.zpow`: `fun z ↦ f z ^ (m : ℤ)` is `C^n` at a point where `f` is `C^n` and either
-  `f` does not vanish or `m` is nonnegative.
+* `ContDiffWithinAt.zpow`: `fun z ↦ f z ^ (m : ℤ)` is `C^n` within a set at a point where
+  `f` is `C^n` and either `f` does not vanish or `m` is nonnegative.
+* `ContDiffAt.zpow`: the corresponding pointwise statement.
 -/
 
 public section
 
-namespace ContDiffAt
-
 variable {𝕜 E 𝕜' : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-  [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] {f : E → 𝕜'} {x : E} {m : ℤ} {n : WithTop ℕ∞}
+  [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] {f : E → 𝕜'} {s : Set E} {x : E} {m : ℤ}
+  {n : WithTop ℕ∞}
 
-/-- An integral power of a `C^n` function is `C^n` at a point where the function does not vanish,
-and also, whatever the value there, for a nonnegative exponent. -/
-theorem zpow (hf : ContDiffAt 𝕜 n f x) (h : f x ≠ 0 ∨ 0 ≤ m) :
-    ContDiffAt 𝕜 n (fun z ↦ f z ^ m) x := by
+/-- An integral power of a `C^n` function is `C^n` within a set at a point where the function does
+not vanish, and also, whatever the value there, for a nonnegative exponent. -/
+theorem ContDiffWithinAt.zpow (hf : ContDiffWithinAt 𝕜 n f s x) (h : f x ≠ 0 ∨ 0 ≤ m) :
+    ContDiffWithinAt 𝕜 n (fun z ↦ f z ^ m) s x := by
   obtain ⟨i, rfl | rfl⟩ := m.eq_nat_or_neg
   · simpa [zpow_natCast] using hf.pow i
   · rcases eq_or_ne i 0 with rfl | hi
-    · simpa using contDiffAt_const
+    · simpa using (contDiffWithinAt_const : ContDiffWithinAt 𝕜 n (fun _ : E ↦ (1 : 𝕜')) s x)
     · have hx : f x ≠ 0 := h.resolve_right fun hm ↦ hi (by omega)
       simpa [zpow_neg, zpow_natCast, Pi.inv_def] using (hf.pow i).inv (pow_ne_zero _ hx)
 
-end ContDiffAt
+/-- An integral power of a `C^n` function is `C^n` at a point where the function does not vanish,
+and also, whatever the value there, for a nonnegative exponent. -/
+theorem ContDiffAt.zpow (hf : ContDiffAt 𝕜 n f x) (h : f x ≠ 0 ∨ 0 ≤ m) :
+    ContDiffAt 𝕜 n (fun z ↦ f z ^ m) x :=
+  hf.contDiffWithinAt.zpow h

--- a/TauCeti/Analysis/Calculus/ContDiffZPow.lean
+++ b/TauCeti/Analysis/Calculus/ContDiffZPow.lean
@@ -12,12 +12,14 @@ public import Mathlib.Analysis.Calculus.ContDiff.Operations
 
 Mathlib provides `ContDiffAt.pow` for natural powers and `ContDiffAt.inv` for the inverse of a
 nonvanishing function, but no lemma for an integral power. This file supplies the missing
-combination: away from a zero of `f`, every integral power of `f` is as smooth as `f` is.
+combination: an integral power of `f` is as smooth as `f` is, either away from a zero of `f` or
+for a nonnegative exponent. The hypothesis is the one carried by Mathlib's
+`DifferentiableAt.zpow`.
 
 ## Main results
 
-* `ContDiffAt.zpow`: `fun z ↦ f z ^ (m : ℤ)` is `C^n` at a point where `f` is `C^n` and
-  does not vanish.
+* `ContDiffAt.zpow`: `fun z ↦ f z ^ (m : ℤ)` is `C^n` at a point where `f` is `C^n` and either
+  `f` does not vanish or `m` is nonnegative.
 -/
 
 public section
@@ -25,14 +27,17 @@ public section
 namespace ContDiffAt
 
 variable {𝕜 E 𝕜' : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-  [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] {f : E → 𝕜'} {x : E} {n : WithTop ℕ∞}
+  [NormedField 𝕜'] [NormedAlgebra 𝕜 𝕜'] {f : E → 𝕜'} {x : E} {m : ℤ} {n : WithTop ℕ∞}
 
-/-- An integral power of a `C^n` function is `C^n` at every point where the function does not
-vanish. -/
-theorem zpow (hf : ContDiffAt 𝕜 n f x) (hx : f x ≠ 0) (m : ℤ) :
+/-- An integral power of a `C^n` function is `C^n` at a point where the function does not vanish,
+and also, whatever the value there, for a nonnegative exponent. -/
+theorem zpow (hf : ContDiffAt 𝕜 n f x) (h : f x ≠ 0 ∨ 0 ≤ m) :
     ContDiffAt 𝕜 n (fun z ↦ f z ^ m) x := by
   obtain ⟨i, rfl | rfl⟩ := m.eq_nat_or_neg
   · simpa [zpow_natCast] using hf.pow i
-  · simpa [zpow_neg, zpow_natCast, Pi.inv_def] using (hf.pow i).inv (pow_ne_zero _ hx)
+  · rcases eq_or_ne i 0 with rfl | hi
+    · simpa using contDiffAt_const
+    · have hx : f x ≠ 0 := h.resolve_right fun hm ↦ hi (by omega)
+      simpa [zpow_neg, zpow_natCast, Pi.inv_def] using (hf.pow i).inv (pow_ne_zero _ hx)
 
 end ContDiffAt

--- a/TauCeti/Analysis/Calculus/ContDiffZPow.lean
+++ b/TauCeti/Analysis/Calculus/ContDiffZPow.lean
@@ -20,7 +20,8 @@ for a nonnegative exponent. The hypothesis is the one carried by Mathlib's
 
 * `ContDiffWithinAt.zpow`: `fun z ↦ f z ^ (m : ℤ)` is `C^n` within a set at a point where
   `f` is `C^n` and either `f` does not vanish or `m` is nonnegative.
-* `ContDiffAt.zpow`: the corresponding pointwise statement.
+* `ContDiffAt.zpow`, `ContDiffOn.zpow` and `ContDiff.zpow`: the remaining members of the family,
+  with the hypotheses of `DifferentiableOn.zpow` and `Differentiable.zpow`.
 -/
 
 public section
@@ -45,3 +46,15 @@ and also, whatever the value there, for a nonnegative exponent. -/
 theorem ContDiffAt.zpow (hf : ContDiffAt 𝕜 n f x) (h : f x ≠ 0 ∨ 0 ≤ m) :
     ContDiffAt 𝕜 n (fun z ↦ f z ^ m) x :=
   hf.contDiffWithinAt.zpow h
+
+/-- An integral power of a `C^n` function is `C^n` on a set where the function does not vanish,
+and also, whatever its values there, for a nonnegative exponent. -/
+theorem ContDiffOn.zpow (hf : ContDiffOn 𝕜 n f s) (h : (∀ z ∈ s, f z ≠ 0) ∨ 0 ≤ m) :
+    ContDiffOn 𝕜 n (fun z ↦ f z ^ m) s :=
+  fun z hz ↦ (hf z hz).zpow (h.imp_left fun h ↦ h z hz)
+
+/-- An integral power of a `C^n` function is `C^n` if the function does not vanish, and also,
+whatever its values, for a nonnegative exponent. -/
+theorem ContDiff.zpow (hf : ContDiff 𝕜 n f) (h : (∀ z, f z ≠ 0) ∨ 0 ≤ m) :
+    ContDiff 𝕜 n (fun z ↦ f z ^ m) :=
+  contDiff_iff_contDiffAt.2 fun z ↦ hf.contDiffAt.zpow (h.imp_left fun h ↦ h z)

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -1,0 +1,474 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Calculus.ContDiff.Comp
+public import Mathlib.Analysis.Calculus.ContDiff.Operations
+public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Data.Matrix.Mul
+public import Mathlib.Topology.OpenPartialHomeomorph.Defs
+
+/-!
+# Mixed monomial maps between mixed charts
+
+A *mixed chart* is a product `ℂ ^ k × (ℂ ^ *) ^ l`, the model on which the affine analytic chart
+of a regular `k`-dimensional cone in a rank-`(k + l)` lattice is built. The transition maps
+between two such charts, and the maps induced by a morphism of fans, are *mixed monomial maps*:
+each target coordinate is a product of integral powers of the source coordinates.
+
+The exponents cannot be arbitrary. A source coordinate that is allowed to vanish may only be
+raised to a natural power, and it may only contribute to a target coordinate that is itself
+allowed to vanish: a monomial containing a boundary coordinate takes the value `0`, so it can
+never be one of the invertible coordinates of the target. `MixedExponent` records exactly the
+three admissible blocks and, by omitting a fourth field, makes the forbidden contribution
+untypeable.
+
+The ambient formula `mixedMonomialMap` is defined on all of `ℂ ^ k × ℂ ^ l`, using the junk value
+`(0 : ℂ) ^ (n : ℤ) = 0` for `n < 0`. Every theorem about composing two of these maps is stated on
+`mixedChartDomain`, the open locus where the torus coordinates are invertible: exponent arithmetic
+needs `y ^ (m + n) = y ^ m * y ^ n`, which fails at `y = 0`, and the composite of two mixed
+monomial maps really is a different function off that locus.
+
+## Main declarations
+
+* `TauCeti.Toric.MixedExponent`: the exponent data of a mixed monomial map.
+* `TauCeti.Toric.mixedChartDomain`: the open locus where all torus coordinates are invertible.
+* `TauCeti.Toric.mixedMonomialMap`: the ambient coordinate formula.
+* `TauCeti.Toric.mixedMonomialMap_mapsTo`: a mixed monomial map preserves the mixed-chart locus.
+* `TauCeti.Toric.mixedMonomialMap_contDiffAt` and
+  `TauCeti.Toric.mixedMonomialMap_differentiableOn`: a mixed monomial map is holomorphic on the
+  mixed-chart locus.
+* `TauCeti.Toric.MixedExponent.comp` and `TauCeti.Toric.mixedMonomialMap_comp`: composition of
+  exponent data is a product of block matrices, and it computes the composite map on the
+  mixed-chart locus. `TauCeti.Toric.MixedExponent.id_comp`,
+  `TauCeti.Toric.MixedExponent.comp_id` and `TauCeti.Toric.MixedExponent.comp_assoc` are the
+  associated category laws.
+* `TauCeti.Toric.mixedMonomialOpenPartialHomeomorph`: a two-sided inverse pair of exponent data
+  gives a biholomorphism between the two mixed-chart loci, holomorphic in both directions by
+  `TauCeti.Toric.mixedMonomialOpenPartialHomeomorph_contDiffOn` and
+  `TauCeti.Toric.mixedMonomialOpenPartialHomeomorph_symm_contDiffOn`.
+* `TauCeti.Toric.MixedExponent.ofTorusBlock` and
+  `TauCeti.Toric.basisChangeOpenPartialHomeomorph`: the exponent data that keeps the boundary
+  coordinates and acts on the torus coordinates by an integral matrix, and the biholomorphism it
+  induces when that matrix is unimodular. This is the shape of a change of the basis extending
+  the primitive ray generators of a regular cone.
+
+## References
+
+The mathematics is §§1.1--1.3 and §3.1 of D. Cox, J. Little and H. Schenck, *Toric Varieties*,
+and §§1.2--1.3 of W. Fulton, *Introduction to Toric Varieties*.
+-/
+
+public section
+
+namespace TauCeti.Toric
+
+open Finset
+
+variable {k l k' l' k'' l'' : ℕ}
+
+/-- Exponent data for a mixed monomial map `ℂ ^ k × (ℂ ^ *) ^ l → ℂ ^ k' × (ℂ ^ *) ^ l'`.
+
+The three blocks are the only admissible ones. A boundary coordinate of the source, which may
+vanish, carries a natural exponent and may only enter a boundary coordinate of the target; a torus
+coordinate of the source, which is invertible, carries an integral exponent and may enter either
+kind of target coordinate. There is deliberately no block from the boundary coordinates of the
+source to the torus coordinates of the target: such a monomial would vanish somewhere. -/
+@[ext]
+structure MixedExponent (k l k' l' : ℕ) where
+  /-- Exponents of the source boundary coordinates in the target boundary coordinates. -/
+  boundaryBoundary : Matrix (Fin k') (Fin k) ℕ
+  /-- Exponents of the source torus coordinates in the target boundary coordinates. -/
+  boundaryTorus : Matrix (Fin k') (Fin l) ℤ
+  /-- Exponents of the source torus coordinates in the target torus coordinates. -/
+  torusTorus : Matrix (Fin l') (Fin l) ℤ
+
+/-- The open locus of a mixed chart: the points whose torus coordinates are all invertible. -/
+def mixedChartDomain (k l : ℕ) : Set ((Fin k → ℂ) × (Fin l → ℂ)) := {z | ∀ j, z.2 j ≠ 0}
+
+@[simp]
+theorem mem_mixedChartDomain {z : (Fin k → ℂ) × (Fin l → ℂ)} :
+    z ∈ mixedChartDomain k l ↔ ∀ j, z.2 j ≠ 0 := Iff.rfl
+
+theorem isOpen_mixedChartDomain : IsOpen (mixedChartDomain k l) := by
+  have h : mixedChartDomain k l
+      = ⋂ j, (fun z : (Fin k → ℂ) × (Fin l → ℂ) ↦ z.2 j) ⁻¹' {0}ᶜ := by
+    ext z; simp
+  rw [h]
+  exact isOpen_iInter_of_finite fun j ↦
+    isOpen_compl_singleton.preimage ((continuous_apply j).comp continuous_snd)
+
+/-- The ambient coordinate formula of the mixed monomial map with exponent data `A`. Its
+composition laws hold on `mixedChartDomain`, not at ambient points with a vanishing torus
+coordinate. -/
+noncomputable def mixedMonomialMap (A : MixedExponent k l k' l') :
+    ((Fin k → ℂ) × (Fin l → ℂ)) → (Fin k' → ℂ) × (Fin l' → ℂ) := fun z ↦
+  (fun a ↦ (∏ b, z.1 b ^ A.boundaryBoundary a b) * ∏ b, z.2 b ^ A.boundaryTorus a b,
+    fun a ↦ ∏ b, z.2 b ^ A.torusTorus a b)
+
+@[simp]
+theorem mixedMonomialMap_fst_apply (A : MixedExponent k l k' l')
+    (z : (Fin k → ℂ) × (Fin l → ℂ)) (a : Fin k') :
+    (mixedMonomialMap A z).1 a =
+      (∏ b, z.1 b ^ A.boundaryBoundary a b) * ∏ b, z.2 b ^ A.boundaryTorus a b := (rfl)
+
+@[simp]
+theorem mixedMonomialMap_snd_apply (A : MixedExponent k l k' l')
+    (z : (Fin k → ℂ) × (Fin l → ℂ)) (a : Fin l') :
+    (mixedMonomialMap A z).2 a = ∏ b, z.2 b ^ A.torusTorus a b := (rfl)
+
+/-- A torus coordinate of the image of a point of the mixed-chart locus is invertible. -/
+theorem mixedMonomialMap_snd_ne_zero (A : MixedExponent k l k' l')
+    {z : (Fin k → ℂ) × (Fin l → ℂ)} (hz : z ∈ mixedChartDomain k l) (a : Fin l') :
+    (mixedMonomialMap A z).2 a ≠ 0 := by
+  rw [mixedMonomialMap_snd_apply]
+  exact prod_ne_zero_iff.2 fun b _ ↦ zpow_ne_zero _ (hz b)
+
+/-- A mixed monomial map sends the mixed-chart locus of its source into the mixed-chart locus of
+its target. -/
+theorem mixedMonomialMap_mapsTo (A : MixedExponent k l k' l') :
+    Set.MapsTo (mixedMonomialMap A) (mixedChartDomain k l) (mixedChartDomain k' l') :=
+  fun _ hz _ ↦ mixedMonomialMap_snd_ne_zero A hz _
+
+/-- On the mixed-chart locus a boundary coordinate of the image vanishes exactly when one of the
+source boundary coordinates occurring in it vanishes. -/
+theorem mixedMonomialMap_fst_eq_zero_iff (A : MixedExponent k l k' l')
+    {z : (Fin k → ℂ) × (Fin l → ℂ)} (hz : z ∈ mixedChartDomain k l) (a : Fin k') :
+    (mixedMonomialMap A z).1 a = 0 ↔ ∃ b, z.1 b = 0 ∧ A.boundaryBoundary a b ≠ 0 := by
+  rw [mixedMonomialMap_fst_apply, mul_eq_zero, or_iff_left
+    (prod_ne_zero_iff.2 fun b _ ↦ zpow_ne_zero _ (hz b)), prod_eq_zero_iff]
+  simp [pow_eq_zero_iff']
+
+/-! ### Composition of exponent data -/
+
+namespace MixedExponent
+
+/-- The exponent data of the identity of a mixed chart. -/
+protected def id (k l : ℕ) : MixedExponent k l k l where
+  boundaryBoundary := 1
+  boundaryTorus := 0
+  torusTorus := 1
+
+@[simp] theorem id_boundaryBoundary : (MixedExponent.id k l).boundaryBoundary = 1 := (rfl)
+@[simp] theorem id_boundaryTorus : (MixedExponent.id k l).boundaryTorus = 0 := (rfl)
+@[simp] theorem id_torusTorus : (MixedExponent.id k l).torusTorus = 1 := (rfl)
+
+/-- Composition of exponent data. The exponents of the source torus coordinates in the target
+boundary coordinates receive a contribution from each of the two blocks of `B` that land in a
+boundary coordinate. -/
+protected def comp (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l') :
+    MixedExponent k l k'' l'' where
+  boundaryBoundary := B.boundaryBoundary * A.boundaryBoundary
+  boundaryTorus :=
+    B.boundaryBoundary.map (Nat.cast : ℕ → ℤ) * A.boundaryTorus + B.boundaryTorus * A.torusTorus
+  torusTorus := B.torusTorus * A.torusTorus
+
+@[simp]
+theorem comp_boundaryBoundary (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l') :
+    (B.comp A).boundaryBoundary = B.boundaryBoundary * A.boundaryBoundary := (rfl)
+
+@[simp]
+theorem comp_boundaryTorus (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l') :
+    (B.comp A).boundaryTorus =
+      B.boundaryBoundary.map (Nat.cast : ℕ → ℤ) * A.boundaryTorus +
+        B.boundaryTorus * A.torusTorus := (rfl)
+
+@[simp]
+theorem comp_torusTorus (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l') :
+    (B.comp A).torusTorus = B.torusTorus * A.torusTorus := (rfl)
+
+@[simp]
+theorem id_comp (A : MixedExponent k l k' l') : (MixedExponent.id k' l').comp A = A :=
+  MixedExponent.ext (by simp) (by simp [Matrix.map_one _ Nat.cast_zero Nat.cast_one]) (by simp)
+
+@[simp]
+theorem comp_id (A : MixedExponent k l k' l') : A.comp (MixedExponent.id k l) = A :=
+  MixedExponent.ext (by simp) (by simp) (by simp)
+
+/-- Casting the boundary block to `ℤ` is multiplicative. -/
+private theorem map_natCast_mul {m p q : ℕ} (L : Matrix (Fin m) (Fin p) ℕ)
+    (M : Matrix (Fin p) (Fin q) ℕ) :
+    (L * M).map (Nat.cast : ℕ → ℤ) = L.map Nat.cast * M.map Nat.cast :=
+  Matrix.map_mul (f := Nat.castRingHom ℤ)
+
+theorem comp_assoc (C : MixedExponent k'' l'' k l) (B : MixedExponent k' l' k'' l'')
+    (A : MixedExponent k l k' l') : (C.comp B).comp A = C.comp (B.comp A) :=
+  MixedExponent.ext (Matrix.mul_assoc _ _ _)
+    (by simp [map_natCast_mul, Matrix.add_mul, Matrix.mul_add, Matrix.mul_assoc, add_assoc])
+    (Matrix.mul_assoc _ _ _)
+
+end MixedExponent
+
+/-! ### Composition of mixed monomial maps -/
+
+/-- A product of integral powers of one invertible complex number collapses to a single power. -/
+private theorem prod_zpow_eq_zpow_sum {ι : Type*} (s : Finset ι) {y : ℂ} (hy : y ≠ 0)
+    (e : ι → ℤ) : ∏ i ∈ s, y ^ e i = y ^ ∑ i ∈ s, e i := by
+  classical
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons a s ha ih => rw [prod_cons, sum_cons, ih, zpow_add₀ hy]
+
+/-- The exponent bookkeeping of a composite monomial in invertible coordinates. -/
+private theorem prod_prod_zpow {m : ℕ} {y : Fin l → ℂ} (hy : ∀ b, y b ≠ 0)
+    (e : Fin m → Fin l → ℤ) (g : Fin m → ℤ) :
+    ∏ a, (∏ b, y b ^ e a b) ^ g a = ∏ b, y b ^ ∑ a, g a * e a b := by
+  calc ∏ a, (∏ b, y b ^ e a b) ^ g a = ∏ b, ∏ a, y b ^ (g a * e a b) := by
+        rw [Finset.prod_comm]
+        exact prod_congr rfl fun a _ ↦ by
+          rw [← Finset.prod_zpow]
+          exact prod_congr rfl fun b _ ↦ by rw [← zpow_mul, mul_comm]
+    _ = ∏ b, y b ^ ∑ a, g a * e a b :=
+        prod_congr rfl fun b _ ↦ prod_zpow_eq_zpow_sum _ (hy b) _
+
+/-- The exponent bookkeeping of a composite monomial in invertible coordinates raised to natural
+powers. -/
+private theorem prod_prod_zpow_pow {m : ℕ} {y : Fin l → ℂ} (hy : ∀ b, y b ≠ 0)
+    (e : Fin m → Fin l → ℤ) (g : Fin m → ℕ) :
+    ∏ a, (∏ b, y b ^ e a b) ^ g a = ∏ b, y b ^ ∑ a, (g a : ℤ) * e a b := by
+  rw [← prod_prod_zpow hy e fun a ↦ (g a : ℤ)]
+  exact prod_congr rfl fun a _ ↦ (zpow_natCast _ _).symm
+
+/-- The exponent bookkeeping of a composite monomial in the boundary coordinates. -/
+private theorem prod_prod_pow {m : ℕ} (x : Fin k → ℂ) (e : Fin m → Fin k → ℕ) (g : Fin m → ℕ) :
+    ∏ a, (∏ b, x b ^ e a b) ^ g a = ∏ b, x b ^ ∑ a, g a * e a b := by
+  calc ∏ a, (∏ b, x b ^ e a b) ^ g a = ∏ b, ∏ a, x b ^ (g a * e a b) := by
+        rw [Finset.prod_comm]
+        exact prod_congr rfl fun a _ ↦ by
+          rw [← Finset.prod_pow]
+          exact prod_congr rfl fun b _ ↦ by rw [← pow_mul, mul_comm]
+    _ = ∏ b, x b ^ ∑ a, g a * e a b :=
+        prod_congr rfl fun b _ ↦ prod_pow_eq_pow_sum _ _ _
+
+@[simp]
+theorem mixedMonomialMap_id : mixedMonomialMap (MixedExponent.id k l) = id := by
+  have hone : ∀ {m : ℕ} (w : Fin m → ℂ) (a : Fin m),
+      ∏ b, w b ^ ((1 : Matrix (Fin m) (Fin m) ℕ) a b) = w a := by
+    intro m w a
+    rw [prod_eq_single a (fun b _ hb ↦ by simp [Ne.symm hb]) (by simp)]
+    simp
+  have honeZ : ∀ {m : ℕ} (w : Fin m → ℂ) (a : Fin m),
+      ∏ b, w b ^ ((1 : Matrix (Fin m) (Fin m) ℤ) a b) = w a := by
+    intro m w a
+    rw [prod_eq_single a (fun b _ hb ↦ by simp [Ne.symm hb]) (by simp)]
+    simp
+  funext z
+  refine Prod.ext (funext fun a ↦ ?_) (funext fun a ↦ ?_)
+  · simp [hone z.1 a]
+  · simp [honeZ z.2 a]
+
+/-- Composing two mixed monomial maps multiplies their exponent data, on the locus where the torus
+coordinates are invertible. No such formula is claimed at ambient points with a vanishing torus
+coordinate. -/
+theorem mixedMonomialMap_comp (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l')
+    {z : (Fin k → ℂ) × (Fin l → ℂ)} (hz : z ∈ mixedChartDomain k l) :
+    mixedMonomialMap (B.comp A) z = mixedMonomialMap B (mixedMonomialMap A z) := by
+  have hy : ∀ b, z.2 b ≠ 0 := hz
+  refine Prod.ext (funext fun c ↦ ?_) (funext fun c ↦ ?_)
+  · have hbb := prod_prod_pow z.1 A.boundaryBoundary (B.boundaryBoundary c)
+    have hbt := prod_prod_zpow_pow hy A.boundaryTorus (B.boundaryBoundary c)
+    have htt := prod_prod_zpow hy A.torusTorus (B.boundaryTorus c)
+    simp only [mixedMonomialMap_fst_apply, mixedMonomialMap_snd_apply, mul_pow,
+      prod_mul_distrib, MixedExponent.comp_boundaryBoundary, MixedExponent.comp_boundaryTorus,
+      Matrix.mul_apply, Matrix.add_apply, Matrix.map_apply]
+    rw [hbb, hbt, htt, mul_assoc, ← prod_mul_distrib]
+    exact congrArg _ (prod_congr rfl fun b _ ↦ zpow_add₀ (hy b) _ _)
+  · have htt := prod_prod_zpow hy A.torusTorus (B.torusTorus c)
+    simp only [mixedMonomialMap_snd_apply, MixedExponent.comp_torusTorus, Matrix.mul_apply]
+    rw [htt]
+
+/-! ### Holomorphy -/
+
+variable {n : WithTop ℕ∞}
+
+private theorem contDiffAt_finsetProd {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    {s : Finset ι} {g : ι → E → ℂ} {x : E} (h : ∀ i ∈ s, ContDiffAt ℂ n (g i) x) :
+    ContDiffAt ℂ n (fun z ↦ ∏ i ∈ s, g i z) x := by
+  classical
+  induction s using Finset.cons_induction with
+  | empty => simpa using contDiffAt_const
+  | cons a s ha ih =>
+      simp only [prod_cons]
+      exact (h a (by simp)).mul (ih fun i hi ↦ h i (by simp [hi]))
+
+private theorem contDiffAt_zpow {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    {f : E → ℂ} {x : E} (hf : ContDiffAt ℂ n f x) (hx : f x ≠ 0) (m : ℤ) :
+    ContDiffAt ℂ n (fun z ↦ f z ^ m) x := by
+  obtain ⟨i, rfl | rfl⟩ := m.eq_nat_or_neg
+  · simpa [zpow_natCast] using hf.pow i
+  · simpa [zpow_neg, zpow_natCast, Pi.inv_def] using (hf.pow i).inv (pow_ne_zero _ hx)
+
+/-- A mixed monomial map is holomorphic at every point of the mixed-chart locus, to any order. -/
+theorem mixedMonomialMap_contDiffAt (A : MixedExponent k l k' l')
+    {z : (Fin k → ℂ) × (Fin l → ℂ)} (hz : z ∈ mixedChartDomain k l) :
+    ContDiffAt ℂ n (mixedMonomialMap A) z := by
+  have hx : ∀ b, ContDiffAt ℂ n (fun w : (Fin k → ℂ) × (Fin l → ℂ) ↦ w.1 b) z :=
+    fun b ↦ contDiffAt_pi.mp contDiffAt_fst b
+  have hy : ∀ b, ContDiffAt ℂ n (fun w : (Fin k → ℂ) × (Fin l → ℂ) ↦ w.2 b) z :=
+    fun b ↦ contDiffAt_pi.mp contDiffAt_snd b
+  refine ContDiffAt.prodMk (contDiffAt_pi.mpr fun a ↦ ?_) (contDiffAt_pi.mpr fun a ↦ ?_)
+  · exact (contDiffAt_finsetProd fun b _ ↦ (hx b).pow _).mul
+      (contDiffAt_finsetProd fun b _ ↦ contDiffAt_zpow (hy b) (hz b) _)
+  · exact contDiffAt_finsetProd fun b _ ↦ contDiffAt_zpow (hy b) (hz b) _
+
+/-- A mixed monomial map is holomorphic on the mixed-chart locus, to any order. -/
+theorem mixedMonomialMap_contDiffOn (A : MixedExponent k l k' l') :
+    ContDiffOn ℂ n (mixedMonomialMap A) (mixedChartDomain k l) :=
+  fun _ hz ↦ (mixedMonomialMap_contDiffAt A hz).contDiffWithinAt
+
+theorem mixedMonomialMap_differentiableOn (A : MixedExponent k l k' l') :
+    DifferentiableOn ℂ (mixedMonomialMap A) (mixedChartDomain k l) :=
+  fun _ hz ↦ ((mixedMonomialMap_contDiffAt (n := 1) A hz).differentiableAt
+    one_ne_zero).differentiableWithinAt
+
+/-! ### Biholomorphisms between mixed charts -/
+
+/-- A two-sided inverse pair of exponent data induces a homeomorphism between the two mixed-chart
+loci. It is a biholomorphism by `mixedMonomialOpenPartialHomeomorph_contDiffOn` and
+`mixedMonomialOpenPartialHomeomorph_symm_contDiffOn`. -/
+noncomputable def mixedMonomialOpenPartialHomeomorph (A : MixedExponent k l k' l')
+    (B : MixedExponent k' l' k l) (hBA : B.comp A = MixedExponent.id k l)
+    (hAB : A.comp B = MixedExponent.id k' l') :
+    OpenPartialHomeomorph ((Fin k → ℂ) × (Fin l → ℂ)) ((Fin k' → ℂ) × (Fin l' → ℂ)) where
+  toFun := mixedMonomialMap A
+  invFun := mixedMonomialMap B
+  source := mixedChartDomain k l
+  target := mixedChartDomain k' l'
+  map_source' := mixedMonomialMap_mapsTo A
+  map_target' := mixedMonomialMap_mapsTo B
+  left_inv' z hz := by
+    have h := mixedMonomialMap_comp B A hz
+    rw [hBA, mixedMonomialMap_id] at h
+    exact h.symm
+  right_inv' w hw := by
+    have h := mixedMonomialMap_comp A B hw
+    rw [hAB, mixedMonomialMap_id] at h
+    exact h.symm
+  open_source := isOpen_mixedChartDomain
+  open_target := isOpen_mixedChartDomain
+  continuousOn_toFun := (mixedMonomialMap_differentiableOn A).continuousOn
+  continuousOn_invFun := (mixedMonomialMap_differentiableOn B).continuousOn
+
+section
+
+variable (A : MixedExponent k l k' l') (B : MixedExponent k' l' k l)
+  (hBA : B.comp A = MixedExponent.id k l) (hAB : A.comp B = MixedExponent.id k' l')
+
+@[simp]
+theorem mixedMonomialOpenPartialHomeomorph_coe :
+    ⇑(mixedMonomialOpenPartialHomeomorph A B hBA hAB) = mixedMonomialMap A := (rfl)
+
+@[simp]
+theorem mixedMonomialOpenPartialHomeomorph_symm_coe :
+    ⇑(mixedMonomialOpenPartialHomeomorph A B hBA hAB).symm = mixedMonomialMap B := (rfl)
+
+@[simp]
+theorem mixedMonomialOpenPartialHomeomorph_source :
+    (mixedMonomialOpenPartialHomeomorph A B hBA hAB).source = mixedChartDomain k l := (rfl)
+
+@[simp]
+theorem mixedMonomialOpenPartialHomeomorph_target :
+    (mixedMonomialOpenPartialHomeomorph A B hBA hAB).target = mixedChartDomain k' l' := (rfl)
+
+/-- An inverse pair of exponent data induces a biholomorphism: the induced homeomorphism is
+holomorphic, to any order. -/
+theorem mixedMonomialOpenPartialHomeomorph_contDiffOn :
+    ContDiffOn ℂ n (mixedMonomialOpenPartialHomeomorph A B hBA hAB)
+      (mixedMonomialOpenPartialHomeomorph A B hBA hAB).source :=
+  mixedMonomialMap_contDiffOn A
+
+/-- An inverse pair of exponent data induces a biholomorphism: the inverse of the induced
+homeomorphism is holomorphic, to any order. -/
+theorem mixedMonomialOpenPartialHomeomorph_symm_contDiffOn :
+    ContDiffOn ℂ n (mixedMonomialOpenPartialHomeomorph A B hBA hAB).symm
+      (mixedMonomialOpenPartialHomeomorph A B hBA hAB).target :=
+  mixedMonomialMap_contDiffOn B
+
+end
+
+/-! ### Changing the basis extending the primitive ray generators -/
+
+namespace MixedExponent
+
+/-- The exponent data of a self-map of a mixed chart that keeps the boundary coordinates, twists
+them by the integral matrix `C`, and acts on the torus coordinates by the integral matrix `D`.
+Two bases of the lattice extending the primitive ray generators of a regular cone differ by
+exactly such a block, with `D` unimodular. -/
+def ofTorusBlock (C : Matrix (Fin k) (Fin l) ℤ) (D : Matrix (Fin l) (Fin l) ℤ) :
+    MixedExponent k l k l where
+  boundaryBoundary := 1
+  boundaryTorus := C
+  torusTorus := D
+
+@[simp]
+theorem ofTorusBlock_boundaryBoundary (C : Matrix (Fin k) (Fin l) ℤ)
+    (D : Matrix (Fin l) (Fin l) ℤ) : (ofTorusBlock C D).boundaryBoundary = 1 := (rfl)
+
+@[simp]
+theorem ofTorusBlock_boundaryTorus (C : Matrix (Fin k) (Fin l) ℤ)
+    (D : Matrix (Fin l) (Fin l) ℤ) : (ofTorusBlock C D).boundaryTorus = C := (rfl)
+
+@[simp]
+theorem ofTorusBlock_torusTorus (C : Matrix (Fin k) (Fin l) ℤ)
+    (D : Matrix (Fin l) (Fin l) ℤ) : (ofTorusBlock C D).torusTorus = D := (rfl)
+
+@[simp]
+theorem ofTorusBlock_zero_one : ofTorusBlock (0 : Matrix (Fin k) (Fin l) ℤ) 1 =
+    MixedExponent.id k l := (rfl)
+
+theorem ofTorusBlock_comp_ofTorusBlock (C C' : Matrix (Fin k) (Fin l) ℤ)
+    (D D' : Matrix (Fin l) (Fin l) ℤ) :
+    (ofTorusBlock C' D').comp (ofTorusBlock C D) = ofTorusBlock (C + C' * D) (D' * D) :=
+  MixedExponent.ext (by simp) (by simp [Matrix.map_one _ Nat.cast_zero Nat.cast_one]) (by simp)
+
+/-- A unimodular torus block gives an inverse pair of exponent data. -/
+theorem ofTorusBlock_comp_ofTorusBlock_of_mul_eq_one (C : Matrix (Fin k) (Fin l) ℤ)
+    {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D' * D = 1) :
+    (ofTorusBlock (-(C * D')) D').comp (ofTorusBlock C D) = MixedExponent.id k l := by
+  rw [ofTorusBlock_comp_ofTorusBlock, h, Matrix.neg_mul, Matrix.mul_assoc, h, Matrix.mul_one,
+    add_neg_cancel, ofTorusBlock_zero_one]
+
+end MixedExponent
+
+/-- The biholomorphism of a mixed chart induced by a unimodular change of the basis extending the
+primitive ray generators: the boundary coordinates are kept and twisted by `C`, and the torus
+coordinates are transformed by the unimodular matrix `D`. -/
+noncomputable def basisChangeOpenPartialHomeomorph (C : Matrix (Fin k) (Fin l) ℤ)
+    {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D * D' = 1) (h' : D' * D = 1) :
+    OpenPartialHomeomorph ((Fin k → ℂ) × (Fin l → ℂ)) ((Fin k → ℂ) × (Fin l → ℂ)) :=
+  mixedMonomialOpenPartialHomeomorph (MixedExponent.ofTorusBlock C D)
+    (MixedExponent.ofTorusBlock (-(C * D')) D')
+    (MixedExponent.ofTorusBlock_comp_ofTorusBlock_of_mul_eq_one C h')
+    (by
+      rw [MixedExponent.ofTorusBlock_comp_ofTorusBlock, h, neg_add_cancel,
+        MixedExponent.ofTorusBlock_zero_one])
+
+section
+
+variable (C : Matrix (Fin k) (Fin l) ℤ) {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D * D' = 1)
+  (h' : D' * D = 1)
+
+@[simp]
+theorem basisChangeOpenPartialHomeomorph_coe :
+    ⇑(basisChangeOpenPartialHomeomorph C h h') =
+      mixedMonomialMap (MixedExponent.ofTorusBlock C D) := (rfl)
+
+@[simp]
+theorem basisChangeOpenPartialHomeomorph_symm_coe :
+    ⇑(basisChangeOpenPartialHomeomorph C h h').symm =
+      mixedMonomialMap (MixedExponent.ofTorusBlock (-(C * D')) D') := (rfl)
+
+@[simp]
+theorem basisChangeOpenPartialHomeomorph_source :
+    (basisChangeOpenPartialHomeomorph C h h').source = mixedChartDomain k l := (rfl)
+
+@[simp]
+theorem basisChangeOpenPartialHomeomorph_target :
+    (basisChangeOpenPartialHomeomorph C h h').target = mixedChartDomain k l := (rfl)
+
+end
+
+end TauCeti.Toric

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -71,6 +71,10 @@ open Finset
 
 variable {k l k' l' k'' l'' : ℕ}
 
+-- Source: the names and the three-block shape of `MixedExponent`, the coordinate formula
+-- `mixedMonomialMap`, the locus `mixedChartDomain` and the block-matrix composition law
+-- follow the target signatures in `AnalyticToricGeometry/Suggested.lean` of the
+-- TauCetiProject/TauCetiRoadmap repository.
 /-- Exponent data for a mixed monomial map `ℂ ^ k × (ℂ ^ *) ^ l → ℂ ^ k' × (ℂ ^ *) ^ l'`.
 
 The three blocks are the only admissible ones. A boundary coordinate of the source, which may
@@ -266,8 +270,8 @@ theorem mixedMonomialMap_contDiffAt (A : MixedExponent k l k' l')
     fun b ↦ contDiffAt_pi.mp contDiffAt_snd b
   refine ContDiffAt.prodMk (contDiffAt_pi.mpr fun a ↦ ?_) (contDiffAt_pi.mpr fun a ↦ ?_)
   · exact (contDiffAt_prod fun b _ ↦ (hx b).pow _).mul
-      (contDiffAt_prod fun b _ ↦ (hy b).zpow (hz b) _)
-  · exact contDiffAt_prod fun b _ ↦ (hy b).zpow (hz b) _
+      (contDiffAt_prod fun b _ ↦ (hy b).zpow (Or.inl (hz b)))
+  · exact contDiffAt_prod fun b _ ↦ (hy b).zpow (Or.inl (hz b))
 
 /-- A mixed monomial map is holomorphic on the mixed-chart locus, to any order. -/
 theorem mixedMonomialMap_contDiffOn (A : MixedExponent k l k' l') :

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Analysis.Calculus.Deriv.ZPow
+public import Mathlib.Data.Matrix.Block
 public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 public import TauCeti.Algebra.BigOperators.ZPow
 public import TauCeti.Analysis.Calculus.ContDiffZPow
@@ -45,6 +47,14 @@ monomial maps really is a different function off that locus.
   mixed-chart locus. `TauCeti.Toric.MixedExponent.id_comp`,
   `TauCeti.Toric.MixedExponent.comp_id` and `TauCeti.Toric.MixedExponent.comp_assoc` are the
   associated category laws.
+* `TauCeti.Toric.MixedExponent.prod`, `TauCeti.Toric.mixedChartProdEquiv`, and
+  `TauCeti.Toric.mixedMonomialMap_prod`: products of exponent data act componentwise on products
+  of mixed charts.
+* `TauCeti.Toric.hasDerivAt_mixedMonomialMap_fst_boundary`,
+  `TauCeti.Toric.hasDerivAt_mixedMonomialMap_fst_torus`,
+  `TauCeti.Toric.hasDerivAt_mixedMonomialMap_snd_boundary`, and
+  `TauCeti.Toric.hasDerivAt_mixedMonomialMap_snd_torus`: the four blocks of the Jacobian in mixed
+  coordinates.
 * `TauCeti.Toric.mixedMonomialOpenPartialHomeomorph`: a two-sided inverse pair of exponent data
   gives a biholomorphism between the two mixed-chart loci, holomorphic in both directions by
   `TauCeti.Toric.mixedMonomialOpenPartialHomeomorph_contDiffOn` and
@@ -213,6 +223,41 @@ theorem comp_assoc {k''' l''' : ℕ} (C : MixedExponent k'' l'' k''' l''')
       simp [Matrix.add_mul, Matrix.mul_add, Matrix.mul_assoc, add_assoc])
     (Matrix.mul_assoc _ _ _)
 
+/-- The product of mixed exponent data is the block diagonal exponent data. -/
+def prod {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂') :
+    MixedExponent (k₁ + k₂) (l₁ + l₂) (k₁' + k₂') (l₁' + l₂') where
+  boundaryBoundary :=
+    (Matrix.fromBlocks A.boundaryBoundary 0 0 B.boundaryBoundary).submatrix
+      finSumFinEquiv.symm finSumFinEquiv.symm
+  boundaryTorus :=
+    (Matrix.fromBlocks A.boundaryTorus 0 0 B.boundaryTorus).submatrix
+      finSumFinEquiv.symm finSumFinEquiv.symm
+  torusTorus :=
+    (Matrix.fromBlocks A.torusTorus 0 0 B.torusTorus).submatrix
+      finSumFinEquiv.symm finSumFinEquiv.symm
+
+@[simp]
+theorem prod_boundaryBoundary {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂') :
+    (A.prod B).boundaryBoundary =
+      (Matrix.fromBlocks A.boundaryBoundary 0 0 B.boundaryBoundary).submatrix
+        finSumFinEquiv.symm finSumFinEquiv.symm := (rfl)
+
+@[simp]
+theorem prod_boundaryTorus {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂') :
+    (A.prod B).boundaryTorus =
+      (Matrix.fromBlocks A.boundaryTorus 0 0 B.boundaryTorus).submatrix
+        finSumFinEquiv.symm finSumFinEquiv.symm := (rfl)
+
+@[simp]
+theorem prod_torusTorus {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂') :
+    (A.prod B).torusTorus =
+      (Matrix.fromBlocks A.torusTorus 0 0 B.torusTorus).submatrix
+        finSumFinEquiv.symm finSumFinEquiv.symm := (rfl)
+
 end MixedExponent
 
 /-! ### Composition of mixed monomial maps -/
@@ -256,6 +301,48 @@ theorem mixedMonomialMap_comp (B : MixedExponent k' l' k'' l'') (A : MixedExpone
     simp only [mixedMonomialMap_snd_apply, MixedExponent.comp_torusTorus, Matrix.mul_apply]
     rw [htt]
 
+/-! ### Products -/
+
+/-- Splitting the boundary and torus coordinates identifies the mixed chart of the sum of two
+dimensions with the product of the two mixed charts. -/
+def mixedChartProdEquiv {k₁ l₁ k₂ l₂ : ℕ} :
+    ((Fin (k₁ + k₂) → ℂ) × (Fin (l₁ + l₂) → ℂ)) ≃
+      (((Fin k₁ → ℂ) × (Fin l₁ → ℂ)) × ((Fin k₂ → ℂ) × (Fin l₂ → ℂ))) where
+  toFun := fun z ↦
+    (((fun i ↦ z.1 (Fin.castAdd k₂ i)), fun i ↦ z.2 (Fin.castAdd l₂ i)),
+      ((fun i ↦ z.1 (Fin.natAdd k₁ i)), fun i ↦ z.2 (Fin.natAdd l₁ i)))
+  invFun := fun z ↦ (Fin.addCases z.1.1 z.2.1, Fin.addCases z.1.2 z.2.2)
+  left_inv z := by
+    apply Prod.ext <;> funext i
+    · refine Fin.addCases ?_ ?_ i <;> simp
+    · refine Fin.addCases ?_ ?_ i <;> simp
+  right_inv z := by
+    ext i <;> simp
+
+@[simp]
+theorem mixedChartProdEquiv_apply {k₁ l₁ k₂ l₂ : ℕ}
+    (z : (Fin (k₁ + k₂) → ℂ) × (Fin (l₁ + l₂) → ℂ)) :
+    mixedChartProdEquiv z =
+      (((fun i ↦ z.1 (Fin.castAdd k₂ i)), fun i ↦ z.2 (Fin.castAdd l₂ i)),
+        ((fun i ↦ z.1 (Fin.natAdd k₁ i)), fun i ↦ z.2 (Fin.natAdd l₁ i))) := (rfl)
+
+@[simp]
+theorem mixedChartProdEquiv_symm_apply {k₁ l₁ k₂ l₂ : ℕ}
+    (z : ((Fin k₁ → ℂ) × (Fin l₁ → ℂ)) × ((Fin k₂ → ℂ) × (Fin l₂ → ℂ))) :
+    mixedChartProdEquiv.symm z = (Fin.addCases z.1.1 z.2.1, Fin.addCases z.1.2 z.2.2) := (rfl)
+
+/-- The mixed monomial map of block diagonal product exponent data is the product of the two
+mixed monomial maps, under the canonical splitting of mixed-chart coordinates. -/
+theorem mixedMonomialMap_prod {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (z : (Fin (k₁ + k₂) → ℂ) × (Fin (l₁ + l₂) → ℂ)) :
+    mixedChartProdEquiv (mixedMonomialMap (A.prod B) z) =
+      (mixedMonomialMap A (mixedChartProdEquiv z).1,
+        mixedMonomialMap B (mixedChartProdEquiv z).2) := by
+  ext i <;>
+    simp [mixedChartProdEquiv, mixedMonomialMap, MixedExponent.prod, Fin.prod_univ_add,
+      Matrix.fromBlocks]
+
 /-! ### Holomorphy -/
 
 variable {n : WithTop ℕ∞}
@@ -283,6 +370,77 @@ theorem mixedMonomialMap_differentiableOn (A : MixedExponent k l k' l') :
     DifferentiableOn ℂ (mixedMonomialMap A) (mixedChartDomain k l) :=
   fun _ hz ↦ ((mixedMonomialMap_contDiffAt (n := 1) A hz).differentiableAt
     one_ne_zero).differentiableWithinAt
+
+/-! ### Jacobian entries -/
+
+/-- The boundary-to-boundary block of the Jacobian of a mixed monomial map. The formula remains
+valid when the boundary coordinate vanishes. -/
+theorem hasDerivAt_mixedMonomialMap_fst_boundary (A : MixedExponent k l k' l')
+    (z : (Fin k → ℂ) × (Fin l → ℂ)) (a : Fin k') (b : Fin k) :
+    HasDerivAt
+      (fun t ↦ (mixedMonomialMap A (Function.update z.1 b t, z.2)).1 a)
+      ((A.boundaryBoundary a b : ℂ) * z.1 b ^ (A.boundaryBoundary a b - 1) *
+        ((∏ c ∈ univ \ {b}, z.1 c ^ A.boundaryBoundary a c) *
+          ∏ c, z.2 c ^ A.boundaryTorus a c)) (z.1 b) := by
+  rw [show (fun t ↦ (mixedMonomialMap A (Function.update z.1 b t, z.2)).1 a) =
+      fun t ↦ t ^ A.boundaryBoundary a b *
+        ((∏ c ∈ univ \ {b}, z.1 c ^ A.boundaryBoundary a c) *
+          ∏ c, z.2 c ^ A.boundaryTorus a c) by
+    funext t
+    simp only [mixedMonomialMap_fst_apply]
+    rw [show (∏ c, Function.update z.1 b t c ^ A.boundaryBoundary a c) = _ from by
+      simpa using prod_update_pow univ z.1 (A.boundaryBoundary a) (mem_univ b) t]
+    simp only [mul_assoc]]
+  exact (hasDerivAt_pow (A.boundaryBoundary a b) (z.1 b)).mul_const
+    ((∏ c ∈ univ \ {b}, z.1 c ^ A.boundaryBoundary a c) *
+      ∏ c, z.2 c ^ A.boundaryTorus a c)
+
+/-- The torus-to-boundary block of the Jacobian of a mixed monomial map, on the mixed-chart
+domain. -/
+theorem hasDerivAt_mixedMonomialMap_fst_torus (A : MixedExponent k l k' l')
+    {z : (Fin k → ℂ) × (Fin l → ℂ)} (hz : z ∈ mixedChartDomain k l)
+    (a : Fin k') (b : Fin l) :
+    HasDerivAt
+      (fun t ↦ (mixedMonomialMap A (z.1, Function.update z.2 b t)).1 a)
+      ((A.boundaryTorus a b : ℂ) * z.2 b ^ (A.boundaryTorus a b - 1) *
+        ((∏ c, z.1 c ^ A.boundaryBoundary a c) *
+          ∏ c ∈ univ \ {b}, z.2 c ^ A.boundaryTorus a c)) (z.2 b) := by
+  rw [show (fun t ↦ (mixedMonomialMap A (z.1, Function.update z.2 b t)).1 a) =
+      fun t ↦ (∏ c, z.1 c ^ A.boundaryBoundary a c) *
+        (t ^ A.boundaryTorus a b *
+          ∏ c ∈ univ \ {b}, z.2 c ^ A.boundaryTorus a c) by
+    funext t
+    simp only [mixedMonomialMap_fst_apply]
+    rw [show (∏ c, Function.update z.2 b t c ^ A.boundaryTorus a c) = _ from by
+      simpa using prod_update_zpow univ z.2 (A.boundaryTorus a) (mem_univ b) t]]
+  simpa only [mul_assoc, mul_left_comm, mul_comm] using
+    ((hasDerivAt_zpow (A.boundaryTorus a b) (z.2 b) (Or.inl (hz b))).mul_const
+      (∏ c ∈ univ \ {b}, z.2 c ^ A.boundaryTorus a c)).const_mul
+        (∏ c, z.1 c ^ A.boundaryBoundary a c)
+
+/-- The boundary-to-torus block of the Jacobian of a mixed monomial map is zero. -/
+theorem hasDerivAt_mixedMonomialMap_snd_boundary (A : MixedExponent k l k' l')
+    (z : (Fin k → ℂ) × (Fin l → ℂ)) (a : Fin l') (b : Fin k) :
+    HasDerivAt (fun t ↦ (mixedMonomialMap A (Function.update z.1 b t, z.2)).2 a) 0
+      (z.1 b) := by
+  simpa only [mixedMonomialMap_snd_apply] using
+    (hasDerivAt_const (x := z.1 b) (c := ∏ c, z.2 c ^ A.torusTorus a c))
+
+/-- The torus-to-torus block of the Jacobian of a mixed monomial map, on the mixed-chart domain. -/
+theorem hasDerivAt_mixedMonomialMap_snd_torus (A : MixedExponent k l k' l')
+    {z : (Fin k → ℂ) × (Fin l → ℂ)} (hz : z ∈ mixedChartDomain k l)
+    (a : Fin l') (b : Fin l) :
+    HasDerivAt
+      (fun t ↦ (mixedMonomialMap A (z.1, Function.update z.2 b t)).2 a)
+      ((A.torusTorus a b : ℂ) * z.2 b ^ (A.torusTorus a b - 1) *
+        ∏ c ∈ univ \ {b}, z.2 c ^ A.torusTorus a c) (z.2 b) := by
+  rw [show (fun t ↦ (mixedMonomialMap A (z.1, Function.update z.2 b t)).2 a) =
+      fun t ↦ t ^ A.torusTorus a b * ∏ c ∈ univ \ {b}, z.2 c ^ A.torusTorus a c by
+    funext t
+    simp only [mixedMonomialMap_snd_apply]
+    simpa using prod_update_zpow univ z.2 (A.torusTorus a) (mem_univ b) t]
+  exact (hasDerivAt_zpow (A.torusTorus a b) (z.2 b) (Or.inl (hz b))).mul_const
+    (∏ c ∈ univ \ {b}, z.2 c ^ A.torusTorus a c)
 
 /-! ### Biholomorphisms between mixed charts -/
 

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -330,9 +330,9 @@ the two mixed-chart domains. -/
 @[simp]
 theorem mixedChartProdHomeomorph_mem_prod {k₁ l₁ k₂ l₂ : ℕ}
     (z : (Fin (k₁ + k₂) → ℂ) × (Fin (l₁ + l₂) → ℂ)) :
-    mixedChartProdHomeomorph z ∈ mixedChartDomain k₁ l₁ ×ˢ mixedChartDomain k₂ l₂ ↔
+    (∀ j : Fin l₁, z.2 (Fin.castAdd l₂ j) ≠ 0) ∧
+      (∀ j : Fin l₂, z.2 (Fin.natAdd l₁ j) ≠ 0) ↔
       z ∈ mixedChartDomain (k₁ + k₂) (l₁ + l₂) := by
-  simp only [Set.mem_prod, mem_mixedChartDomain, mixedChartProdHomeomorph_apply]
   constructor
   · rintro ⟨h₁, h₂⟩ j
     exact Fin.addCases h₁ h₂ j

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -39,7 +39,7 @@ monomial maps really is a different function off that locus.
 * `TauCeti.Toric.MixedExponent`: the exponent data of a mixed monomial map.
 * `TauCeti.Toric.mixedChartDomain`: the open locus where all torus coordinates are invertible.
 * `TauCeti.Toric.mixedMonomialMap`: the ambient coordinate formula.
-* `TauCeti.Toric.mixedMonomialMap_mapsTo`: a mixed monomial map preserves the mixed-chart locus.
+* `TauCeti.Toric.mapsTo_mixedMonomialMap`: a mixed monomial map preserves the mixed-chart locus.
 * `TauCeti.Toric.contDiffAt_mixedMonomialMap` and
   `TauCeti.Toric.differentiableOn_mixedMonomialMap`: a mixed monomial map is holomorphic on the
   mixed-chart locus.
@@ -146,7 +146,7 @@ theorem mixedMonomialMap_snd_ne_zero (A : MixedExponent k l k' l')
 
 /-- A mixed monomial map sends the mixed-chart locus of its source into the mixed-chart locus of
 its target. -/
-theorem mixedMonomialMap_mapsTo (A : MixedExponent k l k' l') :
+theorem mapsTo_mixedMonomialMap (A : MixedExponent k l k' l') :
     Set.MapsTo (mixedMonomialMap A) (mixedChartDomain k l) (mixedChartDomain k' l') :=
   fun _ hz _ ↦ mixedMonomialMap_snd_ne_zero A hz _
 
@@ -473,8 +473,8 @@ noncomputable def mixedMonomialOpenPartialHomeomorph (A : MixedExponent k l k' l
   invFun := mixedMonomialMap B
   source := mixedChartDomain k l
   target := mixedChartDomain k' l'
-  map_source' := mixedMonomialMap_mapsTo A
-  map_target' := mixedMonomialMap_mapsTo B
+  map_source' := mapsTo_mixedMonomialMap A
+  map_target' := mapsTo_mixedMonomialMap B
   left_inv' z hz := by
     have h := mixedMonomialMap_comp B A hz
     rw [hBA, mixedMonomialMap_id] at h

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -284,6 +284,7 @@ theorem mixedMonomialMap_id : mixedMonomialMap (MixedExponent.id k l) = id := by
 /-- Composing two mixed monomial maps multiplies their exponent data, on the locus where the torus
 coordinates are invertible. No such formula is claimed at ambient points with a vanishing torus
 coordinate. -/
+@[simp]
 theorem mixedMonomialMap_comp (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l')
     {z : (Fin k → ℂ) × (Fin l → ℂ)} (hz : z ∈ mixedChartDomain k l) :
     mixedMonomialMap (B.comp A) z = mixedMonomialMap B (mixedMonomialMap A z) := by
@@ -558,6 +559,7 @@ theorem ofTorusBlock_zero_one : ofTorusBlock (0 : Matrix (Fin k) (Fin l) ℤ) 1 
 
 /-- Composing the torus-block data `(C, D)` followed by `(C', D')` gives boundary twist
 `C + C' * D` and torus block `D' * D`. -/
+@[simp]
 theorem ofTorusBlock_comp_ofTorusBlock (C C' : Matrix (Fin k) (Fin l) ℤ)
     (D D' : Matrix (Fin l) (Fin l) ℤ) :
     (ofTorusBlock C' D').comp (ofTorusBlock C D) = ofTorusBlock (C + C' * D) (D' * D) :=
@@ -567,7 +569,7 @@ theorem ofTorusBlock_comp_ofTorusBlock (C C' : Matrix (Fin k) (Fin l) ℤ)
 theorem ofTorusBlock_comp_eq_id_of_mul_eq_one (C : Matrix (Fin k) (Fin l) ℤ)
     {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D' * D = 1) :
     (ofTorusBlock (-(C * D')) D').comp (ofTorusBlock C D) = MixedExponent.id k l := by
-  simp [ofTorusBlock_comp_ofTorusBlock, Matrix.mul_assoc, h]
+  simp [Matrix.mul_assoc, h]
 
 end MixedExponent
 
@@ -580,7 +582,7 @@ noncomputable def basisChangeOpenPartialHomeomorph (C : Matrix (Fin k) (Fin l) �
   mixedMonomialOpenPartialHomeomorph (MixedExponent.ofTorusBlock C D)
     (MixedExponent.ofTorusBlock (-(C * D⁻¹)) D⁻¹)
     (MixedExponent.ofTorusBlock_comp_eq_id_of_mul_eq_one C (Matrix.nonsing_inv_mul D hD))
-    (by simp [MixedExponent.ofTorusBlock_comp_ofTorusBlock, Matrix.mul_nonsing_inv D hD])
+    (by simp [Matrix.mul_nonsing_inv D hD])
 
 section
 

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -194,8 +194,9 @@ private theorem map_natCast_mul {m p q : ℕ} (L : Matrix (Fin m) (Fin p) ℕ)
     (L * M).map (Nat.cast : ℕ → ℤ) = L.map Nat.cast * M.map Nat.cast :=
   Matrix.map_mul (f := Nat.castRingHom ℤ)
 
-theorem comp_assoc (C : MixedExponent k'' l'' k l) (B : MixedExponent k' l' k'' l'')
-    (A : MixedExponent k l k' l') : (C.comp B).comp A = C.comp (B.comp A) :=
+theorem comp_assoc {k''' l''' : ℕ} (C : MixedExponent k'' l'' k''' l''')
+    (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l') :
+    (C.comp B).comp A = C.comp (B.comp A) :=
   MixedExponent.ext (Matrix.mul_assoc _ _ _)
     (by simp [map_natCast_mul, Matrix.add_mul, Matrix.mul_add, Matrix.mul_assoc, add_assoc])
     (Matrix.mul_assoc _ _ _)

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.Calculus.ContDiff.Operations
 public import Mathlib.Analysis.Complex.Basic
-public import Mathlib.LinearAlgebra.Matrix.SemiringInverse
+public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 
 /-!
 # Mixed monomial maps between mixed charts
@@ -93,6 +93,7 @@ def mixedChartDomain (k l : ℕ) : Set ((Fin k → ℂ) × (Fin l → ℂ)) := {
 theorem mem_mixedChartDomain {z : (Fin k → ℂ) × (Fin l → ℂ)} :
     z ∈ mixedChartDomain k l ↔ ∀ j, z.2 j ≠ 0 := Iff.rfl
 
+/-- The mixed-chart domain is open in its ambient affine space. -/
 theorem isOpen_mixedChartDomain : IsOpen (mixedChartDomain k l) := by
   have h : mixedChartDomain k l
       = ⋂ j, (fun z : (Fin k → ℂ) × (Fin l → ℂ) ↦ z.2 j) ⁻¹' {0}ᶜ := by
@@ -190,18 +191,21 @@ theorem id_comp (A : MixedExponent k l k' l') : (MixedExponent.id k' l').comp A 
 theorem comp_id (A : MixedExponent k l k' l') : A.comp (MixedExponent.id k l) = A :=
   MixedExponent.ext (by simp) (by simp) (by simp)
 
-/-- Casting the boundary block to `ℤ` is multiplicative. -/
-private theorem map_natCast_mul {m p q : ℕ} (L : Matrix (Fin m) (Fin p) ℕ)
-    (M : Matrix (Fin p) (Fin q) ℕ) :
-    (L * M).map (Nat.cast : ℕ → ℤ) = L.map Nat.cast * M.map Nat.cast :=
-  Matrix.map_mul (f := Nat.castRingHom ℤ)
-
 /-- Composition of exponent data is associative. -/
 theorem comp_assoc {k''' l''' : ℕ} (C : MixedExponent k'' l'' k''' l''')
     (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l') :
     (C.comp B).comp A = C.comp (B.comp A) :=
   MixedExponent.ext (Matrix.mul_assoc _ _ _)
-    (by simp [map_natCast_mul, Matrix.add_mul, Matrix.mul_add, Matrix.mul_assoc, add_assoc])
+    (by
+      simp only [comp_boundaryTorus, comp_boundaryBoundary, comp_torusTorus]
+      have hmap :
+          (C.boundaryBoundary * B.boundaryBoundary).map (Nat.cast : ℕ → ℤ) =
+            C.boundaryBoundary.map Nat.cast * B.boundaryBoundary.map Nat.cast := by
+        simpa only [Nat.coe_castRingHom] using
+          (Matrix.map_mul (L := C.boundaryBoundary) (M := B.boundaryBoundary)
+            (f := Nat.castRingHom ℤ))
+      rw [hmap]
+      simp [Matrix.add_mul, Matrix.mul_add, Matrix.mul_assoc, add_assoc])
     (Matrix.mul_assoc _ _ _)
 
 end MixedExponent
@@ -415,6 +419,8 @@ theorem ofTorusBlock_torusTorus (C : Matrix (Fin k) (Fin l) ℤ)
 theorem ofTorusBlock_zero_one : ofTorusBlock (0 : Matrix (Fin k) (Fin l) ℤ) 1 =
     MixedExponent.id k l := (rfl)
 
+/-- Composing the torus-block data `(C, D)` followed by `(C', D')` gives boundary twist
+`C + C' * D` and torus block `D' * D`. -/
 theorem ofTorusBlock_comp_ofTorusBlock (C C' : Matrix (Fin k) (Fin l) ℤ)
     (D D' : Matrix (Fin l) (Fin l) ℤ) :
     (ofTorusBlock C' D').comp (ofTorusBlock C D) = ofTorusBlock (C + C' * D) (D' * D) :=
@@ -433,49 +439,50 @@ end MixedExponent
 primitive ray generators: the boundary coordinates are kept and twisted by `C`, and the torus
 coordinates are transformed by the unimodular matrix `D`. -/
 noncomputable def basisChangeOpenPartialHomeomorph (C : Matrix (Fin k) (Fin l) ℤ)
-    {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D * D' = 1) :
+    (D : Matrix (Fin l) (Fin l) ℤ) (hD : IsUnit D.det) :
     OpenPartialHomeomorph ((Fin k → ℂ) × (Fin l → ℂ)) ((Fin k → ℂ) × (Fin l → ℂ)) :=
   mixedMonomialOpenPartialHomeomorph (MixedExponent.ofTorusBlock C D)
-    (MixedExponent.ofTorusBlock (-(C * D')) D')
-    (MixedExponent.ofTorusBlock_comp_eq_id_of_mul_eq_one C (mul_eq_one_comm.1 h))
+    (MixedExponent.ofTorusBlock (-(C * D⁻¹)) D⁻¹)
+    (MixedExponent.ofTorusBlock_comp_eq_id_of_mul_eq_one C (Matrix.nonsing_inv_mul D hD))
     (by
-      rw [MixedExponent.ofTorusBlock_comp_ofTorusBlock, h, neg_add_cancel,
+      rw [MixedExponent.ofTorusBlock_comp_ofTorusBlock, Matrix.mul_nonsing_inv D hD, neg_add_cancel,
         MixedExponent.ofTorusBlock_zero_one])
 
 section
 
-variable (C : Matrix (Fin k) (Fin l) ℤ) {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D * D' = 1)
+variable (C : Matrix (Fin k) (Fin l) ℤ) (D : Matrix (Fin l) (Fin l) ℤ)
+  (hD : IsUnit D.det)
 
 @[simp]
 theorem basisChangeOpenPartialHomeomorph_coe :
-    ⇑(basisChangeOpenPartialHomeomorph C h) =
+    ⇑(basisChangeOpenPartialHomeomorph C D hD) =
       mixedMonomialMap (MixedExponent.ofTorusBlock C D) := (rfl)
 
 @[simp]
 theorem basisChangeOpenPartialHomeomorph_symm_coe :
-    ⇑(basisChangeOpenPartialHomeomorph C h).symm =
-      mixedMonomialMap (MixedExponent.ofTorusBlock (-(C * D')) D') := (rfl)
+    ⇑(basisChangeOpenPartialHomeomorph C D hD).symm =
+      mixedMonomialMap (MixedExponent.ofTorusBlock (-(C * D⁻¹)) D⁻¹) := (rfl)
 
 @[simp]
 theorem basisChangeOpenPartialHomeomorph_source :
-    (basisChangeOpenPartialHomeomorph C h).source = mixedChartDomain k l := (rfl)
+    (basisChangeOpenPartialHomeomorph C D hD).source = mixedChartDomain k l := (rfl)
 
 @[simp]
 theorem basisChangeOpenPartialHomeomorph_target :
-    (basisChangeOpenPartialHomeomorph C h).target = mixedChartDomain k l := (rfl)
+    (basisChangeOpenPartialHomeomorph C D hD).target = mixedChartDomain k l := (rfl)
 
 /-- A unimodular change of the extending basis induces a biholomorphism: the induced homeomorphism
 is holomorphic, to any order. -/
 theorem basisChangeOpenPartialHomeomorph_contDiffOn :
-    ContDiffOn ℂ n (basisChangeOpenPartialHomeomorph C h)
-      (basisChangeOpenPartialHomeomorph C h).source :=
+    ContDiffOn ℂ n (basisChangeOpenPartialHomeomorph C D hD)
+      (basisChangeOpenPartialHomeomorph C D hD).source :=
   mixedMonomialOpenPartialHomeomorph_contDiffOn _ _ _ _
 
 /-- A unimodular change of the extending basis induces a biholomorphism: the inverse of the induced
 homeomorphism is holomorphic, to any order. -/
 theorem basisChangeOpenPartialHomeomorph_symm_contDiffOn :
-    ContDiffOn ℂ n (basisChangeOpenPartialHomeomorph C h).symm
-      (basisChangeOpenPartialHomeomorph C h).target :=
+    ContDiffOn ℂ n (basisChangeOpenPartialHomeomorph C D hD).symm
+      (basisChangeOpenPartialHomeomorph C D hD).target :=
   mixedMonomialOpenPartialHomeomorph_symm_contDiffOn _ _ _ _
 
 end

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.BigOperators.Group.Finset.Piecewise
 public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.Analysis.Calculus.Deriv.ZPow
 public import Mathlib.Data.Matrix.Block
@@ -396,7 +397,9 @@ theorem hasDerivAt_mixedMonomialMap_fst_boundary (A : MixedExponent k l k' l')
           ∏ c, z.2 c ^ A.boundaryTorus a c)) := by
     funext t
     simp only [mixedMonomialMap_fst_apply]
-    rw [prod_update_pow univ z.1 (A.boundaryBoundary a) (mem_univ b) t]
+    rw [funext fun j ↦
+        Function.apply_update (fun i (w : ℂ) ↦ w ^ A.boundaryBoundary a i) z.1 b t j,
+      prod_update_of_mem (mem_univ b)]
     simp only [mul_assoc]
   rw [hfun]
   exact (hasDerivAt_pow (A.boundaryBoundary a b) (z.1 b)).mul_const
@@ -419,7 +422,9 @@ theorem hasDerivAt_mixedMonomialMap_fst_torus (A : MixedExponent k l k' l')
           ∏ c ∈ univ \ {b}, z.2 c ^ A.boundaryTorus a c)) := by
     funext t
     simp only [mixedMonomialMap_fst_apply]
-    rw [prod_update_zpow univ z.2 (A.boundaryTorus a) (mem_univ b) t]
+    rw [funext fun j ↦
+        Function.apply_update (fun i (w : ℂ) ↦ w ^ A.boundaryTorus a i) z.2 b t j,
+      prod_update_of_mem (mem_univ b)]
   rw [hfun]
   simpa only [mul_assoc, mul_left_comm, mul_comm] using
     ((hasDerivAt_zpow (A.boundaryTorus a b) (z.2 b) (Or.inl (hz b))).mul_const
@@ -447,7 +452,9 @@ theorem hasDerivAt_mixedMonomialMap_snd_torus (A : MixedExponent k l k' l')
         ∏ c ∈ univ \ {b}, z.2 c ^ A.torusTorus a c) := by
     funext t
     simp only [mixedMonomialMap_snd_apply]
-    rw [prod_update_zpow univ z.2 (A.torusTorus a) (mem_univ b) t]
+    rw [funext fun j ↦
+        Function.apply_update (fun i (w : ℂ) ↦ w ^ A.torusTorus a i) z.2 b t j,
+      prod_update_of_mem (mem_univ b)]
   rw [hfun]
   exact (hasDerivAt_zpow (A.torusTorus a b) (z.2 b) (Or.inl (hz b))).mul_const
     (∏ c ∈ univ \ {b}, z.2 c ^ A.torusTorus a c)

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -5,11 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Calculus.ContDiff.Comp
 public import Mathlib.Analysis.Calculus.ContDiff.Operations
 public import Mathlib.Analysis.Complex.Basic
-public import Mathlib.Data.Matrix.Mul
-public import Mathlib.Topology.OpenPartialHomeomorph.Defs
+public import Mathlib.LinearAlgebra.Matrix.SemiringInverse
 
 /-!
 # Mixed monomial maps between mixed charts
@@ -53,8 +51,10 @@ monomial maps really is a different function off that locus.
 * `TauCeti.Toric.MixedExponent.ofTorusBlock` and
   `TauCeti.Toric.basisChangeOpenPartialHomeomorph`: the exponent data that keeps the boundary
   coordinates and acts on the torus coordinates by an integral matrix, and the biholomorphism it
-  induces when that matrix is unimodular. This is the shape of a change of the basis extending
-  the primitive ray generators of a regular cone.
+  induces when that matrix is unimodular, holomorphic in both directions by
+  `TauCeti.Toric.basisChangeOpenPartialHomeomorph_contDiffOn` and
+  `TauCeti.Toric.basisChangeOpenPartialHomeomorph_symm_contDiffOn`. This is the shape of a change
+  of the basis extending the primitive ray generators of a regular cone.
 
 ## References
 
@@ -180,10 +180,12 @@ theorem comp_boundaryTorus (B : MixedExponent k' l' k'' l'') (A : MixedExponent 
 theorem comp_torusTorus (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l') :
     (B.comp A).torusTorus = B.torusTorus * A.torusTorus := (rfl)
 
+/-- The identity exponent data is a left unit for composition. -/
 @[simp]
 theorem id_comp (A : MixedExponent k l k' l') : (MixedExponent.id k' l').comp A = A :=
   MixedExponent.ext (by simp) (by simp [Matrix.map_one _ Nat.cast_zero Nat.cast_one]) (by simp)
 
+/-- The identity exponent data is a right unit for composition. -/
 @[simp]
 theorem comp_id (A : MixedExponent k l k' l') : A.comp (MixedExponent.id k l) = A :=
   MixedExponent.ext (by simp) (by simp) (by simp)
@@ -194,6 +196,7 @@ private theorem map_natCast_mul {m p q : ℕ} (L : Matrix (Fin m) (Fin p) ℕ)
     (L * M).map (Nat.cast : ℕ → ℤ) = L.map Nat.cast * M.map Nat.cast :=
   Matrix.map_mul (f := Nat.castRingHom ℤ)
 
+/-- Composition of exponent data is associative. -/
 theorem comp_assoc {k''' l''' : ℕ} (C : MixedExponent k'' l'' k''' l''')
     (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l') :
     (C.comp B).comp A = C.comp (B.comp A) :=
@@ -244,6 +247,7 @@ private theorem prod_prod_pow {m : ℕ} (x : Fin k → ℂ) (e : Fin m → Fin k
     _ = ∏ b, x b ^ ∑ a, g a * e a b :=
         prod_congr rfl fun b _ ↦ prod_pow_eq_pow_sum _ _ _
 
+/-- The identity exponent data induces the identity map, at every ambient point. -/
 @[simp]
 theorem mixedMonomialMap_id : mixedMonomialMap (MixedExponent.id k l) = id := by
   have hone : ∀ {m : ℕ} (w : Fin m → ℂ) (a : Fin m),
@@ -285,16 +289,6 @@ theorem mixedMonomialMap_comp (B : MixedExponent k' l' k'' l'') (A : MixedExpone
 
 variable {n : WithTop ℕ∞}
 
-private theorem contDiffAt_finsetProd {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
-    {s : Finset ι} {g : ι → E → ℂ} {x : E} (h : ∀ i ∈ s, ContDiffAt ℂ n (g i) x) :
-    ContDiffAt ℂ n (fun z ↦ ∏ i ∈ s, g i z) x := by
-  classical
-  induction s using Finset.cons_induction with
-  | empty => simpa using contDiffAt_const
-  | cons a s ha ih =>
-      simp only [prod_cons]
-      exact (h a (by simp)).mul (ih fun i hi ↦ h i (by simp [hi]))
-
 private theorem contDiffAt_zpow {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
     {f : E → ℂ} {x : E} (hf : ContDiffAt ℂ n f x) (hx : f x ≠ 0) (m : ℤ) :
     ContDiffAt ℂ n (fun z ↦ f z ^ m) x := by
@@ -311,15 +305,16 @@ theorem mixedMonomialMap_contDiffAt (A : MixedExponent k l k' l')
   have hy : ∀ b, ContDiffAt ℂ n (fun w : (Fin k → ℂ) × (Fin l → ℂ) ↦ w.2 b) z :=
     fun b ↦ contDiffAt_pi.mp contDiffAt_snd b
   refine ContDiffAt.prodMk (contDiffAt_pi.mpr fun a ↦ ?_) (contDiffAt_pi.mpr fun a ↦ ?_)
-  · exact (contDiffAt_finsetProd fun b _ ↦ (hx b).pow _).mul
-      (contDiffAt_finsetProd fun b _ ↦ contDiffAt_zpow (hy b) (hz b) _)
-  · exact contDiffAt_finsetProd fun b _ ↦ contDiffAt_zpow (hy b) (hz b) _
+  · exact (contDiffAt_prod fun b _ ↦ (hx b).pow _).mul
+      (contDiffAt_prod fun b _ ↦ contDiffAt_zpow (hy b) (hz b) _)
+  · exact contDiffAt_prod fun b _ ↦ contDiffAt_zpow (hy b) (hz b) _
 
 /-- A mixed monomial map is holomorphic on the mixed-chart locus, to any order. -/
 theorem mixedMonomialMap_contDiffOn (A : MixedExponent k l k' l') :
     ContDiffOn ℂ n (mixedMonomialMap A) (mixedChartDomain k l) :=
   fun _ hz ↦ (mixedMonomialMap_contDiffAt A hz).contDiffWithinAt
 
+/-- A mixed monomial map is complex differentiable on the mixed-chart locus. -/
 theorem mixedMonomialMap_differentiableOn (A : MixedExponent k l k' l') :
     DifferentiableOn ℂ (mixedMonomialMap A) (mixedChartDomain k l) :=
   fun _ hz ↦ ((mixedMonomialMap_contDiffAt (n := 1) A hz).differentiableAt
@@ -426,7 +421,7 @@ theorem ofTorusBlock_comp_ofTorusBlock (C C' : Matrix (Fin k) (Fin l) ℤ)
   MixedExponent.ext (by simp) (by simp [Matrix.map_one _ Nat.cast_zero Nat.cast_one]) (by simp)
 
 /-- A unimodular torus block gives an inverse pair of exponent data. -/
-theorem ofTorusBlock_comp_ofTorusBlock_of_mul_eq_one (C : Matrix (Fin k) (Fin l) ℤ)
+theorem ofTorusBlock_comp_eq_id_of_mul_eq_one (C : Matrix (Fin k) (Fin l) ℤ)
     {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D' * D = 1) :
     (ofTorusBlock (-(C * D')) D').comp (ofTorusBlock C D) = MixedExponent.id k l := by
   rw [ofTorusBlock_comp_ofTorusBlock, h, Matrix.neg_mul, Matrix.mul_assoc, h, Matrix.mul_one,
@@ -438,11 +433,11 @@ end MixedExponent
 primitive ray generators: the boundary coordinates are kept and twisted by `C`, and the torus
 coordinates are transformed by the unimodular matrix `D`. -/
 noncomputable def basisChangeOpenPartialHomeomorph (C : Matrix (Fin k) (Fin l) ℤ)
-    {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D * D' = 1) (h' : D' * D = 1) :
+    {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D * D' = 1) :
     OpenPartialHomeomorph ((Fin k → ℂ) × (Fin l → ℂ)) ((Fin k → ℂ) × (Fin l → ℂ)) :=
   mixedMonomialOpenPartialHomeomorph (MixedExponent.ofTorusBlock C D)
     (MixedExponent.ofTorusBlock (-(C * D')) D')
-    (MixedExponent.ofTorusBlock_comp_ofTorusBlock_of_mul_eq_one C h')
+    (MixedExponent.ofTorusBlock_comp_eq_id_of_mul_eq_one C (mul_eq_one_comm.1 h))
     (by
       rw [MixedExponent.ofTorusBlock_comp_ofTorusBlock, h, neg_add_cancel,
         MixedExponent.ofTorusBlock_zero_one])
@@ -450,25 +445,38 @@ noncomputable def basisChangeOpenPartialHomeomorph (C : Matrix (Fin k) (Fin l) �
 section
 
 variable (C : Matrix (Fin k) (Fin l) ℤ) {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D * D' = 1)
-  (h' : D' * D = 1)
 
 @[simp]
 theorem basisChangeOpenPartialHomeomorph_coe :
-    ⇑(basisChangeOpenPartialHomeomorph C h h') =
+    ⇑(basisChangeOpenPartialHomeomorph C h) =
       mixedMonomialMap (MixedExponent.ofTorusBlock C D) := (rfl)
 
 @[simp]
 theorem basisChangeOpenPartialHomeomorph_symm_coe :
-    ⇑(basisChangeOpenPartialHomeomorph C h h').symm =
+    ⇑(basisChangeOpenPartialHomeomorph C h).symm =
       mixedMonomialMap (MixedExponent.ofTorusBlock (-(C * D')) D') := (rfl)
 
 @[simp]
 theorem basisChangeOpenPartialHomeomorph_source :
-    (basisChangeOpenPartialHomeomorph C h h').source = mixedChartDomain k l := (rfl)
+    (basisChangeOpenPartialHomeomorph C h).source = mixedChartDomain k l := (rfl)
 
 @[simp]
 theorem basisChangeOpenPartialHomeomorph_target :
-    (basisChangeOpenPartialHomeomorph C h h').target = mixedChartDomain k l := (rfl)
+    (basisChangeOpenPartialHomeomorph C h).target = mixedChartDomain k l := (rfl)
+
+/-- A unimodular change of the extending basis induces a biholomorphism: the induced homeomorphism
+is holomorphic, to any order. -/
+theorem basisChangeOpenPartialHomeomorph_contDiffOn :
+    ContDiffOn ℂ n (basisChangeOpenPartialHomeomorph C h)
+      (basisChangeOpenPartialHomeomorph C h).source :=
+  mixedMonomialOpenPartialHomeomorph_contDiffOn _ _ _ _
+
+/-- A unimodular change of the extending basis induces a biholomorphism: the inverse of the induced
+homeomorphism is holomorphic, to any order. -/
+theorem basisChangeOpenPartialHomeomorph_symm_contDiffOn :
+    ContDiffOn ℂ n (basisChangeOpenPartialHomeomorph C h).symm
+      (basisChangeOpenPartialHomeomorph C h).target :=
+  mixedMonomialOpenPartialHomeomorph_symm_contDiffOn _ _ _ _
 
 end
 

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -266,8 +266,8 @@ theorem mixedMonomialMap_contDiffAt (A : MixedExponent k l k' l')
     fun b ↦ contDiffAt_pi.mp contDiffAt_snd b
   refine ContDiffAt.prodMk (contDiffAt_pi.mpr fun a ↦ ?_) (contDiffAt_pi.mpr fun a ↦ ?_)
   · exact (contDiffAt_prod fun b _ ↦ (hx b).pow _).mul
-      (contDiffAt_prod fun b _ ↦ contDiffAt_zpow (hy b) (hz b) _)
-  · exact contDiffAt_prod fun b _ ↦ contDiffAt_zpow (hy b) (hz b) _
+      (contDiffAt_prod fun b _ ↦ (hy b).zpow (hz b) _)
+  · exact contDiffAt_prod fun b _ ↦ (hy b).zpow (hz b) _
 
 /-- A mixed monomial map is holomorphic on the mixed-chart locus, to any order. -/
 theorem mixedMonomialMap_contDiffOn (A : MixedExponent k l k' l') :
@@ -333,15 +333,17 @@ theorem mixedMonomialOpenPartialHomeomorph_target :
 holomorphic, to any order. -/
 theorem mixedMonomialOpenPartialHomeomorph_contDiffOn :
     ContDiffOn ℂ n (mixedMonomialOpenPartialHomeomorph A B hBA hAB)
-      (mixedMonomialOpenPartialHomeomorph A B hBA hAB).source :=
-  mixedMonomialMap_contDiffOn A
+      (mixedMonomialOpenPartialHomeomorph A B hBA hAB).source := by
+  simpa only [mixedMonomialOpenPartialHomeomorph_coe, mixedMonomialOpenPartialHomeomorph_source]
+    using mixedMonomialMap_contDiffOn A
 
 /-- An inverse pair of exponent data induces a biholomorphism: the inverse of the induced
 homeomorphism is holomorphic, to any order. -/
 theorem mixedMonomialOpenPartialHomeomorph_symm_contDiffOn :
     ContDiffOn ℂ n (mixedMonomialOpenPartialHomeomorph A B hBA hAB).symm
-      (mixedMonomialOpenPartialHomeomorph A B hBA hAB).target :=
-  mixedMonomialMap_contDiffOn B
+      (mixedMonomialOpenPartialHomeomorph A B hBA hAB).target := by
+  simpa only [mixedMonomialOpenPartialHomeomorph_symm_coe,
+    mixedMonomialOpenPartialHomeomorph_target] using mixedMonomialMap_contDiffOn B
 
 end
 
@@ -428,15 +430,17 @@ theorem basisChangeOpenPartialHomeomorph_target :
 is holomorphic, to any order. -/
 theorem basisChangeOpenPartialHomeomorph_contDiffOn :
     ContDiffOn ℂ n (basisChangeOpenPartialHomeomorph C D hD)
-      (basisChangeOpenPartialHomeomorph C D hD).source :=
-  mixedMonomialOpenPartialHomeomorph_contDiffOn _ _ _ _
+      (basisChangeOpenPartialHomeomorph C D hD).source := by
+  simpa only [basisChangeOpenPartialHomeomorph_coe, basisChangeOpenPartialHomeomorph_source]
+    using mixedMonomialMap_contDiffOn (MixedExponent.ofTorusBlock C D)
 
 /-- A unimodular change of the extending basis induces a biholomorphism: the inverse of the induced
 homeomorphism is holomorphic, to any order. -/
 theorem basisChangeOpenPartialHomeomorph_symm_contDiffOn :
     ContDiffOn ℂ n (basisChangeOpenPartialHomeomorph C D hD).symm
-      (basisChangeOpenPartialHomeomorph C D hD).target :=
-  mixedMonomialOpenPartialHomeomorph_symm_contDiffOn _ _ _ _
+      (basisChangeOpenPartialHomeomorph C D hD).target := by
+  simpa only [basisChangeOpenPartialHomeomorph_symm_coe, basisChangeOpenPartialHomeomorph_target]
+    using mixedMonomialMap_contDiffOn (MixedExponent.ofTorusBlock (-(C * D⁻¹)) D⁻¹)
 
 end
 

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -39,15 +39,15 @@ monomial maps really is a different function off that locus.
 * `TauCeti.Toric.mixedChartDomain`: the open locus where all torus coordinates are invertible.
 * `TauCeti.Toric.mixedMonomialMap`: the ambient coordinate formula.
 * `TauCeti.Toric.mixedMonomialMap_mapsTo`: a mixed monomial map preserves the mixed-chart locus.
-* `TauCeti.Toric.mixedMonomialMap_contDiffAt` and
-  `TauCeti.Toric.mixedMonomialMap_differentiableOn`: a mixed monomial map is holomorphic on the
+* `TauCeti.Toric.contDiffAt_mixedMonomialMap` and
+  `TauCeti.Toric.differentiableOn_mixedMonomialMap`: a mixed monomial map is holomorphic on the
   mixed-chart locus.
 * `TauCeti.Toric.MixedExponent.comp` and `TauCeti.Toric.mixedMonomialMap_comp`: composition of
   exponent data is a product of block matrices, and it computes the composite map on the
   mixed-chart locus. `TauCeti.Toric.MixedExponent.id_comp`,
   `TauCeti.Toric.MixedExponent.comp_id` and `TauCeti.Toric.MixedExponent.comp_assoc` are the
   associated category laws.
-* `TauCeti.Toric.MixedExponent.prod`, `TauCeti.Toric.mixedChartProdEquiv`, and
+* `TauCeti.Toric.MixedExponent.prod`, `TauCeti.Toric.mixedChartProdHomeomorph`, and
   `TauCeti.Toric.mixedMonomialMap_prod`: products of exponent data act componentwise on products
   of mixed charts.
 * `TauCeti.Toric.hasDerivAt_mixedMonomialMap_fst_boundary`,
@@ -57,14 +57,14 @@ monomial maps really is a different function off that locus.
   coordinates.
 * `TauCeti.Toric.mixedMonomialOpenPartialHomeomorph`: a two-sided inverse pair of exponent data
   gives a biholomorphism between the two mixed-chart loci, holomorphic in both directions by
-  `TauCeti.Toric.mixedMonomialOpenPartialHomeomorph_contDiffOn` and
-  `TauCeti.Toric.mixedMonomialOpenPartialHomeomorph_symm_contDiffOn`.
+  `TauCeti.Toric.contDiffOn_mixedMonomialOpenPartialHomeomorph` and
+  `TauCeti.Toric.contDiffOn_mixedMonomialOpenPartialHomeomorph_symm`.
 * `TauCeti.Toric.MixedExponent.ofTorusBlock` and
   `TauCeti.Toric.basisChangeOpenPartialHomeomorph`: the exponent data that keeps the boundary
   coordinates and acts on the torus coordinates by an integral matrix, and the biholomorphism it
   induces when that matrix is unimodular, holomorphic in both directions by
-  `TauCeti.Toric.basisChangeOpenPartialHomeomorph_contDiffOn` and
-  `TauCeti.Toric.basisChangeOpenPartialHomeomorph_symm_contDiffOn`. This is the shape of a change
+  `TauCeti.Toric.contDiffOn_basisChangeOpenPartialHomeomorph` and
+  `TauCeti.Toric.contDiffOn_basisChangeOpenPartialHomeomorph_symm`. This is the shape of a change
   of the basis extending the primitive ray generators of a regular cone.
 
 ## References
@@ -305,50 +305,57 @@ theorem mixedMonomialMap_comp (B : MixedExponent k' l' k'' l'') (A : MixedExpone
 
 /-- Splitting the boundary and torus coordinates identifies the mixed chart of the sum of two
 dimensions with the product of the two mixed charts. -/
-def mixedChartProdEquiv {k₁ l₁ k₂ l₂ : ℕ} :
-    ((Fin (k₁ + k₂) → ℂ) × (Fin (l₁ + l₂) → ℂ)) ≃
-      (((Fin k₁ → ℂ) × (Fin l₁ → ℂ)) × ((Fin k₂ → ℂ) × (Fin l₂ → ℂ))) where
-  toFun := fun z ↦
-    (((fun i ↦ z.1 (Fin.castAdd k₂ i)), fun i ↦ z.2 (Fin.castAdd l₂ i)),
-      ((fun i ↦ z.1 (Fin.natAdd k₁ i)), fun i ↦ z.2 (Fin.natAdd l₁ i)))
-  invFun := fun z ↦ (Fin.addCases z.1.1 z.2.1, Fin.addCases z.1.2 z.2.2)
-  left_inv z := by
-    apply Prod.ext <;> funext i
-    · refine Fin.addCases ?_ ?_ i <;> simp
-    · refine Fin.addCases ?_ ?_ i <;> simp
-  right_inv z := by
-    ext i <;> simp
+noncomputable def mixedChartProdHomeomorph {k₁ l₁ k₂ l₂ : ℕ} :
+    ((Fin (k₁ + k₂) → ℂ) × (Fin (l₁ + l₂) → ℂ)) ≃ₜ
+      (((Fin k₁ → ℂ) × (Fin l₁ → ℂ)) × ((Fin k₂ → ℂ) × (Fin l₂ → ℂ))) :=
+  ((Fin.appendHomeomorph (X := ℂ) k₁ k₂).symm.prodCongr
+    (Fin.appendHomeomorph (X := ℂ) l₁ l₂).symm).trans
+      (Homeomorph.prodProdProdComm _ _ _ _)
 
 @[simp]
-theorem mixedChartProdEquiv_apply {k₁ l₁ k₂ l₂ : ℕ}
+theorem mixedChartProdHomeomorph_apply {k₁ l₁ k₂ l₂ : ℕ}
     (z : (Fin (k₁ + k₂) → ℂ) × (Fin (l₁ + l₂) → ℂ)) :
-    mixedChartProdEquiv z =
+    mixedChartProdHomeomorph z =
       (((fun i ↦ z.1 (Fin.castAdd k₂ i)), fun i ↦ z.2 (Fin.castAdd l₂ i)),
         ((fun i ↦ z.1 (Fin.natAdd k₁ i)), fun i ↦ z.2 (Fin.natAdd l₁ i))) := (rfl)
 
 @[simp]
-theorem mixedChartProdEquiv_symm_apply {k₁ l₁ k₂ l₂ : ℕ}
+theorem mixedChartProdHomeomorph_symm_apply {k₁ l₁ k₂ l₂ : ℕ}
     (z : ((Fin k₁ → ℂ) × (Fin l₁ → ℂ)) × ((Fin k₂ → ℂ) × (Fin l₂ → ℂ))) :
-    mixedChartProdEquiv.symm z = (Fin.addCases z.1.1 z.2.1, Fin.addCases z.1.2 z.2.2) := (rfl)
+    mixedChartProdHomeomorph.symm z =
+      (Fin.addCases z.1.1 z.2.1, Fin.addCases z.1.2 z.2.2) := (rfl)
+
+/-- The canonical coordinate splitting identifies a summed mixed-chart domain with the product of
+the two mixed-chart domains. -/
+@[simp]
+theorem mixedChartProdHomeomorph_mem_prod {k₁ l₁ k₂ l₂ : ℕ}
+    (z : (Fin (k₁ + k₂) → ℂ) × (Fin (l₁ + l₂) → ℂ)) :
+    mixedChartProdHomeomorph z ∈ mixedChartDomain k₁ l₁ ×ˢ mixedChartDomain k₂ l₂ ↔
+      z ∈ mixedChartDomain (k₁ + k₂) (l₁ + l₂) := by
+  simp only [Set.mem_prod, mem_mixedChartDomain, mixedChartProdHomeomorph_apply]
+  constructor
+  · rintro ⟨h₁, h₂⟩ j
+    exact Fin.addCases h₁ h₂ j
+  · intro h
+    exact ⟨fun i ↦ h (Fin.castAdd l₂ i), fun i ↦ h (Fin.natAdd l₁ i)⟩
 
 /-- The mixed monomial map of block diagonal product exponent data is the product of the two
 mixed monomial maps, under the canonical splitting of mixed-chart coordinates. -/
 theorem mixedMonomialMap_prod {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
     (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
     (z : (Fin (k₁ + k₂) → ℂ) × (Fin (l₁ + l₂) → ℂ)) :
-    mixedChartProdEquiv (mixedMonomialMap (A.prod B) z) =
-      (mixedMonomialMap A (mixedChartProdEquiv z).1,
-        mixedMonomialMap B (mixedChartProdEquiv z).2) := by
+    mixedChartProdHomeomorph (mixedMonomialMap (A.prod B) z) =
+      (mixedMonomialMap A (mixedChartProdHomeomorph z).1,
+        mixedMonomialMap B (mixedChartProdHomeomorph z).2) := by
   ext i <;>
-    simp [mixedChartProdEquiv, mixedMonomialMap, MixedExponent.prod, Fin.prod_univ_add,
-      Matrix.fromBlocks]
+    simp [mixedMonomialMap, MixedExponent.prod, Fin.prod_univ_add, Matrix.fromBlocks]
 
 /-! ### Holomorphy -/
 
 variable {n : WithTop ℕ∞}
 
 /-- A mixed monomial map is holomorphic at every point of the mixed-chart locus, to any order. -/
-theorem mixedMonomialMap_contDiffAt (A : MixedExponent k l k' l')
+theorem contDiffAt_mixedMonomialMap (A : MixedExponent k l k' l')
     {z : (Fin k → ℂ) × (Fin l → ℂ)} (hz : z ∈ mixedChartDomain k l) :
     ContDiffAt ℂ n (mixedMonomialMap A) z := by
   have hx : ∀ b, ContDiffAt ℂ n (fun w : (Fin k → ℂ) × (Fin l → ℂ) ↦ w.1 b) z :=
@@ -361,14 +368,14 @@ theorem mixedMonomialMap_contDiffAt (A : MixedExponent k l k' l')
   · exact contDiffAt_prod fun b _ ↦ (hy b).zpow (Or.inl (hz b))
 
 /-- A mixed monomial map is holomorphic on the mixed-chart locus, to any order. -/
-theorem mixedMonomialMap_contDiffOn (A : MixedExponent k l k' l') :
+theorem contDiffOn_mixedMonomialMap (A : MixedExponent k l k' l') :
     ContDiffOn ℂ n (mixedMonomialMap A) (mixedChartDomain k l) :=
-  fun _ hz ↦ (mixedMonomialMap_contDiffAt A hz).contDiffWithinAt
+  fun _ hz ↦ (contDiffAt_mixedMonomialMap A hz).contDiffWithinAt
 
 /-- A mixed monomial map is complex differentiable on the mixed-chart locus. -/
-theorem mixedMonomialMap_differentiableOn (A : MixedExponent k l k' l') :
+theorem differentiableOn_mixedMonomialMap (A : MixedExponent k l k' l') :
     DifferentiableOn ℂ (mixedMonomialMap A) (mixedChartDomain k l) :=
-  fun _ hz ↦ ((mixedMonomialMap_contDiffAt (n := 1) A hz).differentiableAt
+  fun _ hz ↦ ((contDiffAt_mixedMonomialMap (n := 1) A hz).differentiableAt
     one_ne_zero).differentiableWithinAt
 
 /-! ### Jacobian entries -/
@@ -382,15 +389,15 @@ theorem hasDerivAt_mixedMonomialMap_fst_boundary (A : MixedExponent k l k' l')
       ((A.boundaryBoundary a b : ℂ) * z.1 b ^ (A.boundaryBoundary a b - 1) *
         ((∏ c ∈ univ \ {b}, z.1 c ^ A.boundaryBoundary a c) *
           ∏ c, z.2 c ^ A.boundaryTorus a c)) (z.1 b) := by
-  rw [show (fun t ↦ (mixedMonomialMap A (Function.update z.1 b t, z.2)).1 a) =
-      fun t ↦ t ^ A.boundaryBoundary a b *
+  have hfun : (fun t ↦ (mixedMonomialMap A (Function.update z.1 b t, z.2)).1 a) =
+      (fun t ↦ t ^ A.boundaryBoundary a b *
         ((∏ c ∈ univ \ {b}, z.1 c ^ A.boundaryBoundary a c) *
-          ∏ c, z.2 c ^ A.boundaryTorus a c) by
+          ∏ c, z.2 c ^ A.boundaryTorus a c)) := by
     funext t
     simp only [mixedMonomialMap_fst_apply]
-    rw [show (∏ c, Function.update z.1 b t c ^ A.boundaryBoundary a c) = _ from by
-      simpa using prod_update_pow univ z.1 (A.boundaryBoundary a) (mem_univ b) t]
-    simp only [mul_assoc]]
+    rw [prod_update_pow univ z.1 (A.boundaryBoundary a) (mem_univ b) t]
+    simp only [mul_assoc]
+  rw [hfun]
   exact (hasDerivAt_pow (A.boundaryBoundary a b) (z.1 b)).mul_const
     ((∏ c ∈ univ \ {b}, z.1 c ^ A.boundaryBoundary a c) *
       ∏ c, z.2 c ^ A.boundaryTorus a c)
@@ -405,14 +412,14 @@ theorem hasDerivAt_mixedMonomialMap_fst_torus (A : MixedExponent k l k' l')
       ((A.boundaryTorus a b : ℂ) * z.2 b ^ (A.boundaryTorus a b - 1) *
         ((∏ c, z.1 c ^ A.boundaryBoundary a c) *
           ∏ c ∈ univ \ {b}, z.2 c ^ A.boundaryTorus a c)) (z.2 b) := by
-  rw [show (fun t ↦ (mixedMonomialMap A (z.1, Function.update z.2 b t)).1 a) =
-      fun t ↦ (∏ c, z.1 c ^ A.boundaryBoundary a c) *
+  have hfun : (fun t ↦ (mixedMonomialMap A (z.1, Function.update z.2 b t)).1 a) =
+      (fun t ↦ (∏ c, z.1 c ^ A.boundaryBoundary a c) *
         (t ^ A.boundaryTorus a b *
-          ∏ c ∈ univ \ {b}, z.2 c ^ A.boundaryTorus a c) by
+          ∏ c ∈ univ \ {b}, z.2 c ^ A.boundaryTorus a c)) := by
     funext t
     simp only [mixedMonomialMap_fst_apply]
-    rw [show (∏ c, Function.update z.2 b t c ^ A.boundaryTorus a c) = _ from by
-      simpa using prod_update_zpow univ z.2 (A.boundaryTorus a) (mem_univ b) t]]
+    rw [prod_update_zpow univ z.2 (A.boundaryTorus a) (mem_univ b) t]
+  rw [hfun]
   simpa only [mul_assoc, mul_left_comm, mul_comm] using
     ((hasDerivAt_zpow (A.boundaryTorus a b) (z.2 b) (Or.inl (hz b))).mul_const
       (∏ c ∈ univ \ {b}, z.2 c ^ A.boundaryTorus a c)).const_mul
@@ -434,19 +441,21 @@ theorem hasDerivAt_mixedMonomialMap_snd_torus (A : MixedExponent k l k' l')
       (fun t ↦ (mixedMonomialMap A (z.1, Function.update z.2 b t)).2 a)
       ((A.torusTorus a b : ℂ) * z.2 b ^ (A.torusTorus a b - 1) *
         ∏ c ∈ univ \ {b}, z.2 c ^ A.torusTorus a c) (z.2 b) := by
-  rw [show (fun t ↦ (mixedMonomialMap A (z.1, Function.update z.2 b t)).2 a) =
-      fun t ↦ t ^ A.torusTorus a b * ∏ c ∈ univ \ {b}, z.2 c ^ A.torusTorus a c by
+  have hfun : (fun t ↦ (mixedMonomialMap A (z.1, Function.update z.2 b t)).2 a) =
+      (fun t ↦ t ^ A.torusTorus a b *
+        ∏ c ∈ univ \ {b}, z.2 c ^ A.torusTorus a c) := by
     funext t
     simp only [mixedMonomialMap_snd_apply]
-    simpa using prod_update_zpow univ z.2 (A.torusTorus a) (mem_univ b) t]
+    rw [prod_update_zpow univ z.2 (A.torusTorus a) (mem_univ b) t]
+  rw [hfun]
   exact (hasDerivAt_zpow (A.torusTorus a b) (z.2 b) (Or.inl (hz b))).mul_const
     (∏ c ∈ univ \ {b}, z.2 c ^ A.torusTorus a c)
 
 /-! ### Biholomorphisms between mixed charts -/
 
 /-- A two-sided inverse pair of exponent data induces a homeomorphism between the two mixed-chart
-loci. It is a biholomorphism by `mixedMonomialOpenPartialHomeomorph_contDiffOn` and
-`mixedMonomialOpenPartialHomeomorph_symm_contDiffOn`. -/
+loci. It is a biholomorphism by `contDiffOn_mixedMonomialOpenPartialHomeomorph` and
+`contDiffOn_mixedMonomialOpenPartialHomeomorph_symm`. -/
 noncomputable def mixedMonomialOpenPartialHomeomorph (A : MixedExponent k l k' l')
     (B : MixedExponent k' l' k l) (hBA : B.comp A = MixedExponent.id k l)
     (hAB : A.comp B = MixedExponent.id k' l') :
@@ -467,8 +476,8 @@ noncomputable def mixedMonomialOpenPartialHomeomorph (A : MixedExponent k l k' l
     exact h.symm
   open_source := isOpen_mixedChartDomain
   open_target := isOpen_mixedChartDomain
-  continuousOn_toFun := (mixedMonomialMap_differentiableOn A).continuousOn
-  continuousOn_invFun := (mixedMonomialMap_differentiableOn B).continuousOn
+  continuousOn_toFun := (differentiableOn_mixedMonomialMap A).continuousOn
+  continuousOn_invFun := (differentiableOn_mixedMonomialMap B).continuousOn
 
 section
 
@@ -493,19 +502,19 @@ theorem mixedMonomialOpenPartialHomeomorph_target :
 
 /-- An inverse pair of exponent data induces a biholomorphism: the induced homeomorphism is
 holomorphic, to any order. -/
-theorem mixedMonomialOpenPartialHomeomorph_contDiffOn :
+theorem contDiffOn_mixedMonomialOpenPartialHomeomorph :
     ContDiffOn ℂ n (mixedMonomialOpenPartialHomeomorph A B hBA hAB)
       (mixedMonomialOpenPartialHomeomorph A B hBA hAB).source := by
   simpa only [mixedMonomialOpenPartialHomeomorph_coe, mixedMonomialOpenPartialHomeomorph_source]
-    using mixedMonomialMap_contDiffOn A
+    using contDiffOn_mixedMonomialMap A
 
 /-- An inverse pair of exponent data induces a biholomorphism: the inverse of the induced
 homeomorphism is holomorphic, to any order. -/
-theorem mixedMonomialOpenPartialHomeomorph_symm_contDiffOn :
+theorem contDiffOn_mixedMonomialOpenPartialHomeomorph_symm :
     ContDiffOn ℂ n (mixedMonomialOpenPartialHomeomorph A B hBA hAB).symm
       (mixedMonomialOpenPartialHomeomorph A B hBA hAB).target := by
   simpa only [mixedMonomialOpenPartialHomeomorph_symm_coe,
-    mixedMonomialOpenPartialHomeomorph_target] using mixedMonomialMap_contDiffOn B
+    mixedMonomialOpenPartialHomeomorph_target] using contDiffOn_mixedMonomialMap B
 
 end
 
@@ -590,19 +599,19 @@ theorem basisChangeOpenPartialHomeomorph_target :
 
 /-- A unimodular change of the extending basis induces a biholomorphism: the induced homeomorphism
 is holomorphic, to any order. -/
-theorem basisChangeOpenPartialHomeomorph_contDiffOn :
+theorem contDiffOn_basisChangeOpenPartialHomeomorph :
     ContDiffOn ℂ n (basisChangeOpenPartialHomeomorph C D hD)
       (basisChangeOpenPartialHomeomorph C D hD).source := by
   simpa only [basisChangeOpenPartialHomeomorph_coe, basisChangeOpenPartialHomeomorph_source]
-    using mixedMonomialMap_contDiffOn (MixedExponent.ofTorusBlock C D)
+    using contDiffOn_mixedMonomialMap (MixedExponent.ofTorusBlock C D)
 
 /-- A unimodular change of the extending basis induces a biholomorphism: the inverse of the induced
 homeomorphism is holomorphic, to any order. -/
-theorem basisChangeOpenPartialHomeomorph_symm_contDiffOn :
+theorem contDiffOn_basisChangeOpenPartialHomeomorph_symm :
     ContDiffOn ℂ n (basisChangeOpenPartialHomeomorph C D hD).symm
       (basisChangeOpenPartialHomeomorph C D hD).target := by
   simpa only [basisChangeOpenPartialHomeomorph_symm_coe, basisChangeOpenPartialHomeomorph_target]
-    using mixedMonomialMap_contDiffOn (MixedExponent.ofTorusBlock (-(C * D⁻¹)) D⁻¹)
+    using contDiffOn_mixedMonomialMap (MixedExponent.ofTorusBlock (-(C * D⁻¹)) D⁻¹)
 
 end
 

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -5,9 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Calculus.ContDiff.Operations
 public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+public import TauCeti.Algebra.BigOperators.ZPow
+public import TauCeti.Analysis.Calculus.ContDiffZPow
 
 /-!
 # Mixed monomial maps between mixed charts
@@ -212,45 +213,6 @@ end MixedExponent
 
 /-! ### Composition of mixed monomial maps -/
 
-/-- A product of integral powers of one invertible complex number collapses to a single power. -/
-private theorem prod_zpow_eq_zpow_sum {ι : Type*} (s : Finset ι) {y : ℂ} (hy : y ≠ 0)
-    (e : ι → ℤ) : ∏ i ∈ s, y ^ e i = y ^ ∑ i ∈ s, e i := by
-  classical
-  induction s using Finset.cons_induction with
-  | empty => simp
-  | cons a s ha ih => rw [prod_cons, sum_cons, ih, zpow_add₀ hy]
-
-/-- The exponent bookkeeping of a composite monomial in invertible coordinates. -/
-private theorem prod_prod_zpow {m : ℕ} {y : Fin l → ℂ} (hy : ∀ b, y b ≠ 0)
-    (e : Fin m → Fin l → ℤ) (g : Fin m → ℤ) :
-    ∏ a, (∏ b, y b ^ e a b) ^ g a = ∏ b, y b ^ ∑ a, g a * e a b := by
-  calc ∏ a, (∏ b, y b ^ e a b) ^ g a = ∏ b, ∏ a, y b ^ (g a * e a b) := by
-        rw [Finset.prod_comm]
-        exact prod_congr rfl fun a _ ↦ by
-          rw [← Finset.prod_zpow]
-          exact prod_congr rfl fun b _ ↦ by rw [← zpow_mul, mul_comm]
-    _ = ∏ b, y b ^ ∑ a, g a * e a b :=
-        prod_congr rfl fun b _ ↦ prod_zpow_eq_zpow_sum _ (hy b) _
-
-/-- The exponent bookkeeping of a composite monomial in invertible coordinates raised to natural
-powers. -/
-private theorem prod_prod_zpow_pow {m : ℕ} {y : Fin l → ℂ} (hy : ∀ b, y b ≠ 0)
-    (e : Fin m → Fin l → ℤ) (g : Fin m → ℕ) :
-    ∏ a, (∏ b, y b ^ e a b) ^ g a = ∏ b, y b ^ ∑ a, (g a : ℤ) * e a b := by
-  rw [← prod_prod_zpow hy e fun a ↦ (g a : ℤ)]
-  exact prod_congr rfl fun a _ ↦ (zpow_natCast _ _).symm
-
-/-- The exponent bookkeeping of a composite monomial in the boundary coordinates. -/
-private theorem prod_prod_pow {m : ℕ} (x : Fin k → ℂ) (e : Fin m → Fin k → ℕ) (g : Fin m → ℕ) :
-    ∏ a, (∏ b, x b ^ e a b) ^ g a = ∏ b, x b ^ ∑ a, g a * e a b := by
-  calc ∏ a, (∏ b, x b ^ e a b) ^ g a = ∏ b, ∏ a, x b ^ (g a * e a b) := by
-        rw [Finset.prod_comm]
-        exact prod_congr rfl fun a _ ↦ by
-          rw [← Finset.prod_pow]
-          exact prod_congr rfl fun b _ ↦ by rw [← pow_mul, mul_comm]
-    _ = ∏ b, x b ^ ∑ a, g a * e a b :=
-        prod_congr rfl fun b _ ↦ prod_pow_eq_pow_sum _ _ _
-
 /-- The identity exponent data induces the identity map, at every ambient point. -/
 @[simp]
 theorem mixedMonomialMap_id : mixedMonomialMap (MixedExponent.id k l) = id := by
@@ -277,28 +239,22 @@ theorem mixedMonomialMap_comp (B : MixedExponent k' l' k'' l'') (A : MixedExpone
     mixedMonomialMap (B.comp A) z = mixedMonomialMap B (mixedMonomialMap A z) := by
   have hy : ∀ b, z.2 b ≠ 0 := hz
   refine Prod.ext (funext fun c ↦ ?_) (funext fun c ↦ ?_)
-  · have hbb := prod_prod_pow z.1 A.boundaryBoundary (B.boundaryBoundary c)
-    have hbt := prod_prod_zpow_pow hy A.boundaryTorus (B.boundaryBoundary c)
-    have htt := prod_prod_zpow hy A.torusTorus (B.boundaryTorus c)
+  · have hbb := prod_prod_pow univ univ z.1 A.boundaryBoundary (B.boundaryBoundary c)
+    have hbt := prod_prod_zpow_pow univ univ (fun b _ ↦ hy b) A.boundaryTorus
+      (B.boundaryBoundary c)
+    have htt := prod_prod_zpow univ univ (fun b _ ↦ hy b) A.torusTorus (B.boundaryTorus c)
     simp only [mixedMonomialMap_fst_apply, mixedMonomialMap_snd_apply, mul_pow,
       prod_mul_distrib, MixedExponent.comp_boundaryBoundary, MixedExponent.comp_boundaryTorus,
       Matrix.mul_apply, Matrix.add_apply, Matrix.map_apply]
     rw [hbb, hbt, htt, mul_assoc, ← prod_mul_distrib]
     exact congrArg _ (prod_congr rfl fun b _ ↦ zpow_add₀ (hy b) _ _)
-  · have htt := prod_prod_zpow hy A.torusTorus (B.torusTorus c)
+  · have htt := prod_prod_zpow univ univ (fun b _ ↦ hy b) A.torusTorus (B.torusTorus c)
     simp only [mixedMonomialMap_snd_apply, MixedExponent.comp_torusTorus, Matrix.mul_apply]
     rw [htt]
 
 /-! ### Holomorphy -/
 
 variable {n : WithTop ℕ∞}
-
-private theorem contDiffAt_zpow {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
-    {f : E → ℂ} {x : E} (hf : ContDiffAt ℂ n f x) (hx : f x ≠ 0) (m : ℤ) :
-    ContDiffAt ℂ n (fun z ↦ f z ^ m) x := by
-  obtain ⟨i, rfl | rfl⟩ := m.eq_nat_or_neg
-  · simpa [zpow_natCast] using hf.pow i
-  · simpa [zpow_neg, zpow_natCast, Pi.inv_def] using (hf.pow i).inv (pow_ne_zero _ hx)
 
 /-- A mixed monomial map is holomorphic at every point of the mixed-chart locus, to any order. -/
 theorem mixedMonomialMap_contDiffAt (A : MixedExponent k l k' l')
@@ -430,8 +386,7 @@ theorem ofTorusBlock_comp_ofTorusBlock (C C' : Matrix (Fin k) (Fin l) ℤ)
 theorem ofTorusBlock_comp_eq_id_of_mul_eq_one (C : Matrix (Fin k) (Fin l) ℤ)
     {D D' : Matrix (Fin l) (Fin l) ℤ} (h : D' * D = 1) :
     (ofTorusBlock (-(C * D')) D').comp (ofTorusBlock C D) = MixedExponent.id k l := by
-  rw [ofTorusBlock_comp_ofTorusBlock, h, Matrix.neg_mul, Matrix.mul_assoc, h, Matrix.mul_one,
-    add_neg_cancel, ofTorusBlock_zero_one]
+  simp [ofTorusBlock_comp_ofTorusBlock, Matrix.mul_assoc, h]
 
 end MixedExponent
 
@@ -444,9 +399,7 @@ noncomputable def basisChangeOpenPartialHomeomorph (C : Matrix (Fin k) (Fin l) �
   mixedMonomialOpenPartialHomeomorph (MixedExponent.ofTorusBlock C D)
     (MixedExponent.ofTorusBlock (-(C * D⁻¹)) D⁻¹)
     (MixedExponent.ofTorusBlock_comp_eq_id_of_mul_eq_one C (Matrix.nonsing_inv_mul D hD))
-    (by
-      rw [MixedExponent.ofTorusBlock_comp_ofTorusBlock, Matrix.mul_nonsing_inv D hD, neg_add_cancel,
-        MixedExponent.ofTorusBlock_zero_one])
+    (by simp [MixedExponent.ofTorusBlock_comp_ofTorusBlock, Matrix.mul_nonsing_inv D hD])
 
 section
 

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -325,14 +325,15 @@ theorem mixedChartProdHomeomorph_symm_apply {k₁ l₁ k₂ l₂ : ℕ}
     mixedChartProdHomeomorph.symm z =
       (Fin.addCases z.1.1 z.2.1, Fin.addCases z.1.2 z.2.2) := (rfl)
 
-/-- The canonical coordinate splitting identifies a summed mixed-chart domain with the product of
-the two mixed-chart domains. -/
+/-- The canonical coordinate splitting identifies the mixed-chart domain of the summed dimensions
+with the product of the two mixed-chart domains. -/
 @[simp]
-theorem mixedChartProdHomeomorph_mem_prod {k₁ l₁ k₂ l₂ : ℕ}
-    (z : (Fin (k₁ + k₂) → ℂ) × (Fin (l₁ + l₂) → ℂ)) :
-    (∀ j : Fin l₁, z.2 (Fin.castAdd l₂ j) ≠ 0) ∧
-      (∀ j : Fin l₂, z.2 (Fin.natAdd l₁ j) ≠ 0) ↔
-      z ∈ mixedChartDomain (k₁ + k₂) (l₁ + l₂) := by
+theorem mixedChartProdHomeomorph_preimage_prod {k₁ l₁ k₂ l₂ : ℕ} :
+    mixedChartProdHomeomorph ⁻¹' (mixedChartDomain k₁ l₁ ×ˢ mixedChartDomain k₂ l₂) =
+      mixedChartDomain (k₁ + k₂) (l₁ + l₂) := by
+  ext z
+  simp only [Set.mem_preimage, Set.mem_prod, mem_mixedChartDomain,
+    mixedChartProdHomeomorph_apply]
   constructor
   · rintro ⟨h₁, h₂⟩ j
     exact Fin.addCases h₁ h₂ j

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -208,6 +208,7 @@ theorem comp_id (A : MixedExponent k l k' l') : A.comp (MixedExponent.id k l) = 
   MixedExponent.ext (by simp) (by simp) (by simp)
 
 /-- Composition of exponent data is associative. -/
+@[simp]
 theorem comp_assoc {k''' l''' : ℕ} (C : MixedExponent k'' l'' k''' l''')
     (B : MixedExponent k' l' k'' l'') (A : MixedExponent k l k' l') :
     (C.comp B).comp A = C.comp (B.comp A) :=
@@ -258,6 +259,80 @@ theorem prod_torusTorus {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
     (A.prod B).torusTorus =
       (Matrix.fromBlocks A.torusTorus 0 0 B.torusTorus).submatrix
         finSumFinEquiv.symm finSumFinEquiv.symm := (rfl)
+
+private theorem prod_boundaryBoundary_apply₁₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin k₁') (j : Fin k₁) :
+    (A.prod B).boundaryBoundary (Fin.castAdd k₂' i) (Fin.castAdd k₂ j) =
+      A.boundaryBoundary i j := by
+  simp [prod]
+
+private theorem prod_boundaryBoundary_apply₁₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin k₁') (j : Fin k₂) :
+    (A.prod B).boundaryBoundary (Fin.castAdd k₂' i) (Fin.natAdd k₁ j) = 0 := by
+  simp [prod]
+
+private theorem prod_boundaryBoundary_apply₂₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin k₂') (j : Fin k₁) :
+    (A.prod B).boundaryBoundary (Fin.natAdd k₁' i) (Fin.castAdd k₂ j) = 0 := by
+  simp [prod]
+
+private theorem prod_boundaryBoundary_apply₂₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin k₂') (j : Fin k₂) :
+    (A.prod B).boundaryBoundary (Fin.natAdd k₁' i) (Fin.natAdd k₁ j) =
+      B.boundaryBoundary i j := by
+  simp [prod]
+
+private theorem prod_boundaryTorus_apply₁₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin k₁') (j : Fin l₁) :
+    (A.prod B).boundaryTorus (Fin.castAdd k₂' i) (Fin.castAdd l₂ j) = A.boundaryTorus i j := by
+  simp [prod]
+
+private theorem prod_boundaryTorus_apply₁₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin k₁') (j : Fin l₂) :
+    (A.prod B).boundaryTorus (Fin.castAdd k₂' i) (Fin.natAdd l₁ j) = 0 := by
+  simp [prod]
+
+private theorem prod_boundaryTorus_apply₂₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin k₂') (j : Fin l₁) :
+    (A.prod B).boundaryTorus (Fin.natAdd k₁' i) (Fin.castAdd l₂ j) = 0 := by
+  simp [prod]
+
+private theorem prod_boundaryTorus_apply₂₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin k₂') (j : Fin l₂) :
+    (A.prod B).boundaryTorus (Fin.natAdd k₁' i) (Fin.natAdd l₁ j) = B.boundaryTorus i j := by
+  simp [prod]
+
+private theorem prod_torusTorus_apply₁₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin l₁') (j : Fin l₁) :
+    (A.prod B).torusTorus (Fin.castAdd l₂' i) (Fin.castAdd l₂ j) = A.torusTorus i j := by
+  simp [prod]
+
+private theorem prod_torusTorus_apply₁₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin l₁') (j : Fin l₂) :
+    (A.prod B).torusTorus (Fin.castAdd l₂' i) (Fin.natAdd l₁ j) = 0 := by
+  simp [prod]
+
+private theorem prod_torusTorus_apply₂₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin l₂') (j : Fin l₁) :
+    (A.prod B).torusTorus (Fin.natAdd l₁' i) (Fin.castAdd l₂ j) = 0 := by
+  simp [prod]
+
+private theorem prod_torusTorus_apply₂₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
+    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
+    (i : Fin l₂') (j : Fin l₂) :
+    (A.prod B).torusTorus (Fin.natAdd l₁' i) (Fin.natAdd l₁ j) = B.torusTorus i j := by
+  simp [prod]
 
 end MixedExponent
 
@@ -351,7 +426,17 @@ theorem mixedMonomialMap_prod {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ
       (mixedMonomialMap A (mixedChartProdHomeomorph z).1,
         mixedMonomialMap B (mixedChartProdHomeomorph z).2) := by
   ext i <;>
-    simp [mixedMonomialMap, MixedExponent.prod, Fin.prod_univ_add, Matrix.fromBlocks]
+    simp only [mixedChartProdHomeomorph_apply, mixedMonomialMap_fst_apply,
+      mixedMonomialMap_snd_apply, Fin.prod_univ_add,
+      MixedExponent.prod_boundaryBoundary_apply₁₁,
+      MixedExponent.prod_boundaryBoundary_apply₁₂,
+      MixedExponent.prod_boundaryBoundary_apply₂₁,
+      MixedExponent.prod_boundaryBoundary_apply₂₂,
+      MixedExponent.prod_boundaryTorus_apply₁₁, MixedExponent.prod_boundaryTorus_apply₁₂,
+      MixedExponent.prod_boundaryTorus_apply₂₁, MixedExponent.prod_boundaryTorus_apply₂₂,
+      MixedExponent.prod_torusTorus_apply₁₁, MixedExponent.prod_torusTorus_apply₁₂,
+      MixedExponent.prod_torusTorus_apply₂₁, MixedExponent.prod_torusTorus_apply₂₂,
+      pow_zero, zpow_zero, prod_const_one, mul_one, one_mul]
 
 /-! ### Holomorphy -/
 

--- a/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
+++ b/TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean
@@ -260,80 +260,6 @@ theorem prod_torusTorus {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
       (Matrix.fromBlocks A.torusTorus 0 0 B.torusTorus).submatrix
         finSumFinEquiv.symm finSumFinEquiv.symm := (rfl)
 
-private theorem prod_boundaryBoundary_apply₁₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin k₁') (j : Fin k₁) :
-    (A.prod B).boundaryBoundary (Fin.castAdd k₂' i) (Fin.castAdd k₂ j) =
-      A.boundaryBoundary i j := by
-  simp [prod]
-
-private theorem prod_boundaryBoundary_apply₁₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin k₁') (j : Fin k₂) :
-    (A.prod B).boundaryBoundary (Fin.castAdd k₂' i) (Fin.natAdd k₁ j) = 0 := by
-  simp [prod]
-
-private theorem prod_boundaryBoundary_apply₂₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin k₂') (j : Fin k₁) :
-    (A.prod B).boundaryBoundary (Fin.natAdd k₁' i) (Fin.castAdd k₂ j) = 0 := by
-  simp [prod]
-
-private theorem prod_boundaryBoundary_apply₂₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin k₂') (j : Fin k₂) :
-    (A.prod B).boundaryBoundary (Fin.natAdd k₁' i) (Fin.natAdd k₁ j) =
-      B.boundaryBoundary i j := by
-  simp [prod]
-
-private theorem prod_boundaryTorus_apply₁₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin k₁') (j : Fin l₁) :
-    (A.prod B).boundaryTorus (Fin.castAdd k₂' i) (Fin.castAdd l₂ j) = A.boundaryTorus i j := by
-  simp [prod]
-
-private theorem prod_boundaryTorus_apply₁₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin k₁') (j : Fin l₂) :
-    (A.prod B).boundaryTorus (Fin.castAdd k₂' i) (Fin.natAdd l₁ j) = 0 := by
-  simp [prod]
-
-private theorem prod_boundaryTorus_apply₂₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin k₂') (j : Fin l₁) :
-    (A.prod B).boundaryTorus (Fin.natAdd k₁' i) (Fin.castAdd l₂ j) = 0 := by
-  simp [prod]
-
-private theorem prod_boundaryTorus_apply₂₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin k₂') (j : Fin l₂) :
-    (A.prod B).boundaryTorus (Fin.natAdd k₁' i) (Fin.natAdd l₁ j) = B.boundaryTorus i j := by
-  simp [prod]
-
-private theorem prod_torusTorus_apply₁₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin l₁') (j : Fin l₁) :
-    (A.prod B).torusTorus (Fin.castAdd l₂' i) (Fin.castAdd l₂ j) = A.torusTorus i j := by
-  simp [prod]
-
-private theorem prod_torusTorus_apply₁₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin l₁') (j : Fin l₂) :
-    (A.prod B).torusTorus (Fin.castAdd l₂' i) (Fin.natAdd l₁ j) = 0 := by
-  simp [prod]
-
-private theorem prod_torusTorus_apply₂₁ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin l₂') (j : Fin l₁) :
-    (A.prod B).torusTorus (Fin.natAdd l₁' i) (Fin.castAdd l₂ j) = 0 := by
-  simp [prod]
-
-private theorem prod_torusTorus_apply₂₂ {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ}
-    (A : MixedExponent k₁ l₁ k₁' l₁') (B : MixedExponent k₂ l₂ k₂' l₂')
-    (i : Fin l₂') (j : Fin l₂) :
-    (A.prod B).torusTorus (Fin.natAdd l₁' i) (Fin.natAdd l₁ j) = B.torusTorus i j := by
-  simp [prod]
-
 end MixedExponent
 
 /-! ### Composition of mixed monomial maps -/
@@ -427,16 +353,11 @@ theorem mixedMonomialMap_prod {k₁ l₁ k₁' l₁' k₂ l₂ k₂' l₂' : ℕ
         mixedMonomialMap B (mixedChartProdHomeomorph z).2) := by
   ext i <;>
     simp only [mixedChartProdHomeomorph_apply, mixedMonomialMap_fst_apply,
-      mixedMonomialMap_snd_apply, Fin.prod_univ_add,
-      MixedExponent.prod_boundaryBoundary_apply₁₁,
-      MixedExponent.prod_boundaryBoundary_apply₁₂,
-      MixedExponent.prod_boundaryBoundary_apply₂₁,
-      MixedExponent.prod_boundaryBoundary_apply₂₂,
-      MixedExponent.prod_boundaryTorus_apply₁₁, MixedExponent.prod_boundaryTorus_apply₁₂,
-      MixedExponent.prod_boundaryTorus_apply₂₁, MixedExponent.prod_boundaryTorus_apply₂₂,
-      MixedExponent.prod_torusTorus_apply₁₁, MixedExponent.prod_torusTorus_apply₁₂,
-      MixedExponent.prod_torusTorus_apply₂₁, MixedExponent.prod_torusTorus_apply₂₂,
-      pow_zero, zpow_zero, prod_const_one, mul_one, one_mul]
+      mixedMonomialMap_snd_apply, Fin.prod_univ_add, MixedExponent.prod,
+      Matrix.submatrix_apply, finSumFinEquiv_symm_apply_castAdd,
+      finSumFinEquiv_symm_apply_natAdd, Matrix.fromBlocks_apply₁₁,
+      Matrix.fromBlocks_apply₁₂, Matrix.fromBlocks_apply₂₁, Matrix.fromBlocks_apply₂₂,
+      Matrix.zero_apply, pow_zero, zpow_zero, prod_const_one, mul_one, one_mul]
 
 /-! ### Holomorphy -/
 


### PR DESCRIPTION
This PR supplies Layer 1, item 3 of `AnalyticToricGeometry/README.md`: "Define typed mixed exponent data for maps `C^k x (C^*)^l -> C^k' x (C^*)^l'`. Prove preservation of the invertible-coordinate locus, holomorphy there, identity, composition **on that locus**, products, Jacobian formulas, and biholomorphicity for the appropriate unimodular block matrices." It serves completion criterion 2, the affine analytic chart of a regular cone and its independence from the extending basis: the declaration that will consume it is Layer 2, item 3, "changing the extending basis preserves the complex structure through the corresponding mixed monomial biholomorphism", for which `TauCeti.Toric.basisChangeOpenPartialHomeomorph` is exactly the transition map, and Layer 5, item 1, which glues the affine mixed monomial maps attached to a fan morphism.

The new file `TauCeti/Geometry/Toric/Analytic/MixedMonomial.lean` (609 lines) defines `MixedExponent k l k' l'` with the three admissible blocks pinned in the roadmap's `Suggested.lean`, and the ambient formula `mixedMonomialMap`. The absence of a fourth block is the mathematical content of the type: a monomial that contains a boundary coordinate vanishes somewhere, so it can never be an invertible target coordinate, and by omitting that field the roadmap's rejected case ("a mixed monomial with a negative exponent in a noninvertible source coordinate is rejected by its type") is not expressible. On `mixedChartDomain`, the open locus where the torus coordinates are invertible, the file proves: the locus is preserved (`mixedMonomialMap_mapsTo`); a boundary coordinate of the image vanishes exactly when a source boundary coordinate occurring in it vanishes (`mixedMonomialMap_fst_eq_zero_iff`); the map is `ContDiffOn ℂ n` for every `n`, hence holomorphic (`mixedMonomialMap_contDiffAt`, `mixedMonomialMap_contDiffOn`, `mixedMonomialMap_differentiableOn`); the identity data induces the identity map, on all ambient points (`mixedMonomialMap_id`); and composition of exponent data by block matrix products computes the composite map (`MixedExponent.comp`, `mixedMonomialMap_comp`), with the category laws `id_comp`, `comp_id` and `comp_assoc`. An inverse pair of exponent data gives `mixedMonomialOpenPartialHomeomorph`, a homeomorphism between the two loci that is holomorphic in both directions. Finally `MixedExponent.ofTorusBlock C D` records the coordinate change that keeps the boundary coordinates, twists them by `C` and acts on the torus coordinates by `D`; `ofTorusBlock_comp_ofTorusBlock` computes its composition law, and `basisChangeOpenPartialHomeomorph` is the resulting biholomorphism when `D` is unimodular. That block shape is exactly how two bases extending the primitive ray generators of a regular cone differ.

The composition theorem is stated only on `mixedChartDomain`, as the roadmap requires, and the proof shows why: collecting the exponents of one torus coordinate coming from the two blocks of `B` that land in a boundary coordinate needs `y ^ (m + n) = y ^ m * y ^ n`, which is false at `y = 0` for `m = 1`, `n = -1`. Nothing is claimed at ambient points with a vanishing torus coordinate.

The previously open product and Jacobian clauses of Layer 1, item 3 are now delivered. `MixedExponent.prod` gives the block-diagonal product exponent, and `mixedMonomialMap_prod` proves compatibility with the canonical coordinate splitting `mixedChartProdEquiv`. The four `hasDerivAt_mixedMonomialMap_*` theorems compute every boundary/torus block of the Jacobian as coordinate partial derivatives, including the identically zero boundary-to-torus block. Layer 1 still owes coordinate-free character evaluation on the complex torus (item 1), the contravariant map on affine complex points (item 2), and the face-localization open embedding (item 4); Layer 0’s algebraic supplier is independent of this file and is being built separately.

Two signatures deviate from `Suggested.lean`. The preservation statement is `Set.MapsTo` rather than the pinned `mixedMonomialMap_mem`, which is the same proposition in Mathlib's idiom and is what `OpenPartialHomeomorph.map_source'` consumes directly. The biholomorphism is an `OpenPartialHomeomorph`, not a `PartialHomeomorph`: at the pinned Mathlib, `PartialHomeomorph` no longer records that its source and target are open, and `OpenPartialHomeomorph` is the carrier that does.

Two small general-purpose files carry the prerequisites that mention only Mathlib types, at `api-design`'s request: `TauCeti/Algebra/BigOperators/ZPow.lean` collapses an iterated product of powers into a single one (`prod_zpow_eq_zpow_sum`, the integral-exponent analogue of Mathlib's `Finset.prod_pow_eq_pow_sum`, and the three substitution rules `prod_prod_pow`, `prod_prod_zpow`, `prod_prod_zpow_pow` for the natural, integral and mixed exponent combinations), stated for arbitrary index types and `Finset`s over a commutative monoid and a commutative group with zero; and `TauCeti/Analysis/Calculus/ContDiffZPow.lean` supplies `contDiffAt_zpow`, the integral-power companion of Mathlib's `ContDiffAt.pow` and `ContDiffAt.inv`, which Mathlib does not have in any form (there is `DifferentiableAt.zpow` but no `ContDiff` analogue). They are prerequisites of the mixed monomial calculus, not a second topic.

Nothing here depends on the in-flight Layer 0 work (#5626, #5689): the mixed monomial file imports only Mathlib and those two files, so it can land in parallel, and it introduces no competing cone, semigroup, gluing or biholomorphism carrier. No Mathlib infrastructure was vendored; the proofs run against `Matrix.map_mul`, `Finset.prod_pow_eq_pow_sum`, `zpow_add₀`, `ContDiffAt.mul`, `ContDiffAt.pow` and `ContDiffAt.inv`. The mathematics is §§1.1--1.3 and §3.1 of D. Cox, J. Little and H. Schenck, *Toric Varieties*, and §§1.2--1.3 of W. Fulton, *Introduction to Toric Varieties*.

Roadmap: AnalyticToricGeometry

<!--tauceti-target:v1 {"focus":"AnalyticToricGeometry","id":"mixed-monomial-map"}-->

🤖 Prepared with Claude Code

