### PR TITLE
feat: prove the graphon cut-distance triangle inequality

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean
@@ -6,6 +6,7 @@ Authors: Claude
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.CutMetric.Coupling
+public import TauCeti.Combinatorics.DenseGraphLimits.Graphon.Pullback
 public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
 import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Pullback
 
@@ -51,6 +52,8 @@ overlaid difference, and the cut norm is even and drops along a pushforward
   measure-preserving maps, and `cutDist_le_cutNorm_sub_of_measurePreserving` bounds the cut
   distance by that value; `cutDist_le_cutNorm_sub` is its identity case, and `cutDist_self`
   follows;
+* `cutDist_le_cutDist_comap_right` compares the cut distance with its value against a
+  measure-preserving pullback of the right-hand graphon;
 * `cutNorm_overlayDiff_diagonalCoupling` computes the value the diagonal coupling contributes to
   that infimum: it is exactly the same-carrier cut norm of the difference.
 
@@ -235,6 +238,42 @@ theorem cutDist_le_cutNorm_sub_of_measurePreserving [IsFiniteMeasure μ]
   exact (cutDist_le U W (isCoupling_map_prodMk hf hg)).trans_eq
     (cutNorm_overlayDiff_map_prodMk U W hf.measurable hg.measurable
       ⟨hf.measurable.prodMk hg.measurable, rfl⟩)
+
+/-- **Reading the right-hand graphon along a measure-preserving map does not decrease the cut
+distance:** if `f : Ω₂' → Ω₂` is measure preserving, then
+`cutDist U W ≤ cutDist U (W.comap f hf.measurable μ₂')`.
+
+The two sides are in fact equal; the reverse inequality needs the triangle inequality and is
+`TauCeti.DenseGraphLimits.cutDist_comap_right` in
+`TauCeti.Combinatorics.DenseGraphLimits.CutMetric.Triangle`. -/
+theorem cutDist_le_cutDist_comap_right
+    {Ω₂' : Type*} [MeasurableSpace Ω₂'] {μ₂' : Measure Ω₂'} [IsProbabilityMeasure μ₂']
+    (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) {f : Ω₂' → Ω₂}
+    (hf : MeasurePreserving f μ₂' μ₂) :
+    cutDist U W ≤ cutDist U (W.comap f hf.measurable μ₂') := by
+  refine le_cutDist U (W.comap f hf.measurable μ₂') fun π hπ => ?_
+  let _ := hπ.isProbabilityMeasure
+  have hg : Measurable fun p : Ω₁ × Ω₂' => f p.2 := hf.measurable.comp measurable_snd
+  let ρ : Measure (Ω₁ × Ω₂) := π.map fun p => (p.1, f p.2)
+  have hρ : IsCoupling μ₁ μ₂ ρ :=
+    isCoupling_map_prodMk hπ.measurePreserving_fst (hf.comp hπ.measurePreserving_snd)
+  let _ := hρ.isProbabilityMeasure
+  have hmp : MeasurePreserving (fun p : Ω₁ × Ω₂' => (p.1, f p.2)) π ρ :=
+    ⟨measurable_fst.prodMk hg, rfl⟩
+  have hid : MeasurePreserving (fun p : Ω₁ × Ω₂' => (p.1, p.2)) π π :=
+    ⟨measurable_fst.prodMk measurable_snd, by simp⟩
+  calc
+    cutDist U W ≤ cutNorm ρ (overlayDiff U W ρ) := cutDist_le U W hρ
+    _ = cutNorm π (U.toSymmKernel.comap Prod.fst measurable_fst π -
+          W.toSymmKernel.comap (fun p => f p.2) hg π) :=
+      cutNorm_overlayDiff_map_prodMk U W measurable_fst hg hmp
+    _ = cutNorm π (overlayDiff U (W.comap f hf.measurable μ₂') π) := by
+      rw [cutNorm_overlayDiff_map_prodMk U (W.comap f hf.measurable μ₂') measurable_fst
+        measurable_snd hid, Graphon.toSymmKernel_comap, SymmKernel.comap_comap]
+      -- Both sides now pull `W` back along the same map: `f ∘ Prod.snd` is `fun p => f p.2`.
+      -- Rewriting that spelling is not motive correct, since the measurability proof depends on
+      -- the map, so the two are identified definitionally instead.
+      rfl
 
 variable [IsProbabilityMeasure μ]
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Triangle.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Triangle.lean
@@ -1,0 +1,268 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.CutMetric.Stability
+public import TauCeti.Combinatorics.DenseGraphLimits.StepGraphon.Regularity
+import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Pullback
+import TauCeti.Combinatorics.DenseGraphLimits.Graphon.Pullback
+import TauCeti.MeasureTheory.MeasurableSpace.Finpartition
+import TauCeti.MeasureTheory.OptimalTransport.Gluing
+
+/-!
+# The triangle inequality for graphon cut distance
+
+This file proves the triangle inequality for the coupling-primary cut distance on arbitrary
+probability carriers.  The central finite-middle case glues two couplings over a countable
+intermediate carrier and pulls all three overlaid kernels back to the glued probability space,
+where their pointwise difference telescopes.  Exact invariance of the cut norm under
+measure-preserving pullback then returns the estimate to the original couplings.
+
+For an arbitrary intermediate carrier, Frieze--Kannan weak regularity replaces the middle graphon
+by a finite step graphon.  Its finite set of blocks is the countable middle carrier to which the
+gluing argument applies, and stability of cut distance under cut-norm approximation removes the
+replacement error.  This avoids imposing standard-Borel or atomlessness hypotheses on any of the
+three carriers.
+
+The triangle inequality is the final pseudometric law needed to form the metric quotient of
+graphons at cut distance zero.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.cutDist_triangle_of_countable_middle` proves the triangle inequality
+  when the intermediate carrier is countable with measurable singletons.
+* `TauCeti.DenseGraphLimits.cutDist_triangle` proves it on arbitrary probability carriers.
+
+## References
+
+* S. Janson, *Graphons, cut norm and distance, couplings and rearrangements*, NYJM Monographs 4
+  (2013), Lemma 6.5.
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Section 8.2.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set TauCeti.MeasureTheory
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {Ω₁ Ω₂ Ω₃ : Type*}
+variable [MeasurableSpace Ω₁] [MeasurableSpace Ω₂] [MeasurableSpace Ω₃]
+variable {μ₁ : Measure Ω₁} {μ₂ : Measure Ω₂} {μ₃ : Measure Ω₃}
+variable [IsProbabilityMeasure μ₁] [IsProbabilityMeasure μ₂] [IsProbabilityMeasure μ₃]
+
+/-- Pulling the three overlaid differences to a joint law makes the outer difference telescope.
+
+Here `gamma` has `pi12` as its `(Omega1, Omega2)` marginal and `pi23` as its
+`(Omega2, Omega3)` marginal.  Its outer marginal is therefore a coupling of `mu1` and `mu3`, and
+the cut norm along that coupling is at most the sum of the two input cut norms. -/
+private theorem exists_isCoupling_cutNorm_overlayDiff_le_of_glue
+    (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) (X : Graphon Ω₃ μ₃)
+    {π₁₂ : Measure (Ω₁ × Ω₂)} {π₂₃ : Measure (Ω₂ × Ω₃)}
+    (hπ₁₂ : IsCoupling μ₁ μ₂ π₁₂) (hπ₂₃ : IsCoupling μ₂ μ₃ π₂₃)
+    {γ : Measure (Ω₁ × Ω₂ × Ω₃)}
+    (hleft : γ.map (Prod.map id Prod.fst) = π₁₂) (hright : γ.snd = π₂₃) :
+    ∃ (π₁₃ : Measure (Ω₁ × Ω₃)) (hπ₁₃ : IsCoupling μ₁ μ₃ π₁₃),
+      @cutNorm _ _ π₁₃ hπ₁₃.isFiniteMeasure (overlayDiff U X π₁₃) ≤
+        @cutNorm _ _ π₁₂ hπ₁₂.isFiniteMeasure (overlayDiff U W π₁₂) +
+          @cutNorm _ _ π₂₃ hπ₂₃.isFiniteMeasure (overlayDiff W X π₂₃) := by
+  let _ := hπ₁₂.isProbabilityMeasure
+  let _ := hπ₂₃.isProbabilityMeasure
+  let _ : IsProbabilityMeasure (γ.map (Prod.map id Prod.fst)) :=
+    hleft.symm ▸ hπ₁₂.isProbabilityMeasure
+  let _ : IsProbabilityMeasure γ :=
+    Measure.isProbabilityMeasure_of_map (measurable_id.prodMap measurable_fst).aemeasurable
+  let π₁₃ : Measure (Ω₁ × Ω₃) := γ.map (Prod.map id Prod.snd)
+  have hπ₁₃ : IsCoupling μ₁ μ₃ π₁₃ := isCoupling_iff.2
+    <| ⟨(TauCeti.Measure.fst_map_prodMap_id_snd hleft).trans hπ₁₂.fst_eq,
+      (TauCeti.Measure.snd_map_prodMap_id_snd hright).trans hπ₂₃.snd_eq⟩
+  let _ := hπ₁₃.isProbabilityMeasure
+  have hmp12 : MeasurePreserving (fun p : Ω₁ × Ω₂ × Ω₃ => (p.1, p.2.1)) γ π₁₂ :=
+    ⟨measurable_id.prodMap measurable_fst, hleft⟩
+  have hmp23 : MeasurePreserving Prod.snd γ π₂₃ := ⟨measurable_snd, hright⟩
+  have hmp13 : MeasurePreserving (fun p : Ω₁ × Ω₂ × Ω₃ => (p.1, p.2.2)) γ π₁₃ :=
+    ⟨measurable_id.prodMap measurable_snd, rfl⟩
+  refine ⟨π₁₃, hπ₁₃, ?_⟩
+  calc
+    cutNorm π₁₃ (overlayDiff U X π₁₃) =
+        cutNorm γ ((overlayDiff U X π₁₃).comap (fun p => (p.1, p.2.2))
+          (measurable_id.prodMap measurable_snd) γ) :=
+      (cutNorm_comap hmp13 _).symm
+    _ = cutNorm γ
+        ((overlayDiff U W π₁₂).comap (fun p => (p.1, p.2.1))
+            (measurable_id.prodMap measurable_fst) γ +
+          (overlayDiff W X π₂₃).comap Prod.snd measurable_snd γ) := by
+      congr 1
+      ext p q
+      simp only [overlayDiff_apply, SymmKernel.comap_apply, SymmKernel.coe_add, Pi.add_apply]
+      ring
+    _ ≤ cutNorm γ
+          ((overlayDiff U W π₁₂).comap (fun p => (p.1, p.2.1))
+            (measurable_id.prodMap measurable_fst) γ) +
+        cutNorm γ ((overlayDiff W X π₂₃).comap Prod.snd measurable_snd γ) :=
+      cutNorm_add_le γ _ _
+    _ = cutNorm π₁₂ (overlayDiff U W π₁₂) + cutNorm π₂₃ (overlayDiff W X π₂₃) := by
+      rw [cutNorm_comap hmp12, cutNorm_comap hmp23]
+
+/-- The coupling cut distance satisfies the triangle inequality when the intermediate carrier is
+countable and has measurable singletons.
+
+Two nearly optimal couplings are glued over the middle marginal.  This result is the exact finite
+gluing statement used after replacing an arbitrary middle graphon by a finite step graphon. -/
+theorem cutDist_triangle_of_countable_middle [Countable Ω₂]
+    [MeasurableSingletonClass Ω₂] (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂)
+    (X : Graphon Ω₃ μ₃) : cutDist U X ≤ cutDist U W + cutDist W X := by
+  refine le_of_forall_pos_le_add fun ε hε => ?_
+  obtain ⟨π₁₂, hπ₁₂, hnorm12⟩ :=
+    exists_isCoupling_cutNorm_lt U W (c := cutDist U W + ε / 2)
+      (lt_add_of_pos_right _ (half_pos hε))
+  obtain ⟨π₂₃, hπ₂₃, hnorm23⟩ :=
+    exists_isCoupling_cutNorm_lt W X (c := cutDist W X + ε / 2)
+      (lt_add_of_pos_right _ (half_pos hε))
+  let _ := hπ₂₃.isFiniteMeasure
+  obtain ⟨γ, hleft, hright⟩ :=
+    TauCeti.MeasureTheory.exists_glue_of_countable_middle π₁₂ π₂₃
+      (hπ₁₂.snd_eq.trans hπ₂₃.fst_eq.symm)
+  obtain ⟨π₁₃, hπ₁₃, hnorm13⟩ :=
+    exists_isCoupling_cutNorm_overlayDiff_le_of_glue U W X hπ₁₂ hπ₂₃ hleft hright
+  calc
+    cutDist U X ≤
+        @cutNorm _ _ π₁₃ hπ₁₃.isFiniteMeasure (overlayDiff U X π₁₃) :=
+      cutDist_le U X hπ₁₃
+    _ ≤ @cutNorm _ _ π₁₂ hπ₁₂.isFiniteMeasure (overlayDiff U W π₁₂) +
+        @cutNorm _ _ π₂₃ hπ₂₃.isFiniteMeasure (overlayDiff W X π₂₃) := hnorm13
+    _ ≤ cutDist U W + cutDist W X + ε := by linarith
+
+private theorem cutDist_le_cutDist_comap_right
+    {Ω₂' : Type*} [MeasurableSpace Ω₂'] {μ₂' : Measure Ω₂'} [IsProbabilityMeasure μ₂']
+    (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) {f : Ω₂' → Ω₂}
+    (hf : MeasurePreserving f μ₂' μ₂) :
+    cutDist U W ≤ cutDist U (W.comap f hf.measurable μ₂') := by
+  refine le_cutDist U (W.comap f hf.measurable μ₂') fun π hπ => ?_
+  let _ := hπ.isProbabilityMeasure
+  let ρ : Measure (Ω₁ × Ω₂) := π.map (Prod.map id f)
+  have hρ : IsCoupling μ₁ μ₂ ρ := isCoupling_iff.2
+    ⟨by
+      rw [← hπ.fst_eq]
+      simp only [ρ, Measure.fst, Measure.map_map measurable_fst
+        (measurable_id.prodMap hf.measurable), Prod.map_fst', Function.id_comp],
+    by
+      rw [← hf.map_eq, ← hπ.snd_eq]
+      simp only [ρ, Measure.snd, Measure.map_map measurable_snd
+        (measurable_id.prodMap hf.measurable), Measure.map_map hf.measurable measurable_snd,
+        Prod.map_snd']⟩
+  let _ := hρ.isProbabilityMeasure
+  have hmp : MeasurePreserving (Prod.map id f) π ρ :=
+    ⟨measurable_id.prodMap hf.measurable, rfl⟩
+  calc
+    cutDist U W ≤ cutNorm ρ (overlayDiff U W ρ) := cutDist_le U W hρ
+    _ = cutNorm π ((overlayDiff U W ρ).comap (Prod.map id f)
+          (measurable_id.prodMap hf.measurable) π) := (cutNorm_comap hmp _).symm
+    _ = cutNorm π (overlayDiff U (W.comap f hf.measurable μ₂') π) := by
+      congr 1
+      ext p q
+      simp
+
+private theorem cutDist_comap_right_of_countable
+    [Countable Ω₂] [MeasurableSingletonClass Ω₂]
+    {Ω₂' : Type*} [MeasurableSpace Ω₂'] {μ₂' : Measure Ω₂'} [IsProbabilityMeasure μ₂']
+    (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) {f : Ω₂' → Ω₂}
+    (hf : MeasurePreserving f μ₂' μ₂) :
+    cutDist U (W.comap f hf.measurable μ₂') = cutDist U W := by
+  apply le_antisymm
+  · have hzero : cutDist W (W.comap f hf.measurable μ₂') = 0 := by
+      apply le_antisymm
+      · have h := cutDist_le_cutNorm_sub_of_measurePreserving W
+          (W.comap f hf.measurable μ₂') hf (MeasurePreserving.id μ₂')
+        rw [Graphon.toSymmKernel_comap, SymmKernel.comap_id, sub_self, cutNorm_zero] at h
+        exact h
+      · exact cutDist_nonneg _ _
+    calc
+      cutDist U (W.comap f hf.measurable μ₂') ≤
+          cutDist U W + cutDist W (W.comap f hf.measurable μ₂') :=
+        cutDist_triangle_of_countable_middle U W _
+      _ = cutDist U W := by rw [hzero, add_zero]
+  · exact cutDist_le_cutDist_comap_right U W hf
+
+section StepModel
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+variable {P : Finpartition (Set.univ : Set Ω)} [MeasurableSpace P.parts]
+variable [DiscreteMeasurableSpace P.parts]
+
+/-- A finite step graphon's block matrix, regarded as a graphon on the discrete probability space
+of partition parts. -/
+private def stepGraphonModel
+    (val : P.parts → P.parts → Set.Icc (0 : ℝ) 1) (hsymm : ∀ p q, val p q = val q p) :
+    Graphon P.parts (μ.map P.indexedPartition.index) where
+  toFun p q := val p q
+  symm' p q := congrArg Subtype.val (hsymm p q)
+  meas' := measurable_of_countable _
+  bdd' := ⟨1, fun p q => by
+    rw [abs_of_nonneg (val p q).property.1]
+    exact (val p q).property.2⟩
+  mem01' p q := (val p q).property
+
+@[simp]
+private theorem stepGraphonModel_apply
+    (val : P.parts → P.parts → Set.Icc (0 : ℝ) 1) (hsymm : ∀ p q, val p q = val q p)
+    (p q : P.parts) : stepGraphonModel (μ := μ) val hsymm p q = val p q := rfl
+
+end StepModel
+
+/-- The cut distance satisfies the triangle inequality when the intermediate graphon is constant
+on the rectangles of a measurable finite partition. -/
+private theorem cutDist_triangle_of_constantOn_partition
+    (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) (X : Graphon Ω₃ μ₃)
+    (P : Finpartition (Set.univ : Set Ω₂)) (hP : ∀ p ∈ P.parts, MeasurableSet p)
+    (hconst : ∀ (p q : P.parts) {x y : Ω₂}, x ∈ (p : Set Ω₂) → y ∈ (q : Set Ω₂) →
+      W x y = W (P.indexedPartition.some p) (P.indexedPartition.some q)) :
+    cutDist U X ≤ cutDist U W + cutDist W X := by
+  let _ : MeasurableSpace P.parts := ⊤
+  let ν : Measure P.parts := μ₂.map P.indexedPartition.index
+  let val : P.parts → P.parts → Set.Icc (0 : ℝ) 1 := fun p q =>
+    ⟨W (P.indexedPartition.some p) (P.indexedPartition.some q), W.mem_Icc _ _⟩
+  have hsymm : ∀ p q, val p q = val q p := fun p q => by
+    apply Subtype.ext
+    exact W.symm _ _
+  let A : Graphon P.parts ν := stepGraphonModel (μ := μ₂) val hsymm
+  have hindex : Measurable P.indexedPartition.index :=
+    Finpartition.measurable_indexedPartition_index P hP
+  have hmp : MeasurePreserving P.indexedPartition.index μ₂ ν := ⟨hindex, rfl⟩
+  have hmodel : W = A.comap P.indexedPartition.index hindex μ₂ := by
+    ext x y
+    rw [Graphon.comap_apply, stepGraphonModel_apply]
+    exact hconst _ _ (P.indexedPartition.mem_index x) (P.indexedPartition.mem_index y)
+  rw [hmodel, cutDist_comap_right_of_countable U A hmp, cutDist_comm
+    (A.comap P.indexedPartition.index hindex μ₂) X, cutDist_comap_right_of_countable X A hmp,
+    cutDist_comm X A]
+  exact cutDist_triangle_of_countable_middle U A X
+
+/-- The coupling-primary graphon cut distance satisfies the triangle inequality on arbitrary
+probability carriers. -/
+theorem cutDist_triangle (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) (X : Graphon Ω₃ μ₃) :
+    cutDist U X ≤ cutDist U W + cutDist W X := by
+  refine le_of_forall_pos_le_add fun ε hε => ?_
+  obtain ⟨P, hP, _, happrox⟩ := weak_regularity_frieze_kannan μ₂ W (half_pos hε)
+  let W' := stepGraphonAvg (μ := μ₂) P hP W
+  have htriangle : cutDist U X ≤ cutDist U W' + cutDist W' X := by
+    apply cutDist_triangle_of_constantOn_partition U W' X P hP
+    intro p q x y hx hy
+    rw [show W' = stepGraphonAvg (μ := μ₂) P hP W from rfl,
+      stepGraphonAvg_apply P hP W hx hy,
+      stepGraphonAvg_apply P hP W (P.indexedPartition.some_mem p)
+        (P.indexedPartition.some_mem q)]
+  have htransfer := cutDist_le_add_two_mul_cutNorm_of_le_add U W W' X htriangle
+  dsimp only [W'] at htransfer
+  nlinarith
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Triangle.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Triangle.lean
@@ -7,8 +7,8 @@ module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.CutMetric.Stability
 public import TauCeti.Combinatorics.DenseGraphLimits.StepGraphon.Regularity
+public import TauCeti.Combinatorics.DenseGraphLimits.Graphon.Pullback
 import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Pullback
-import TauCeti.Combinatorics.DenseGraphLimits.Graphon.Pullback
 import TauCeti.MeasureTheory.MeasurableSpace.Finpartition
 import TauCeti.MeasureTheory.OptimalTransport.Gluing
 
@@ -34,6 +34,10 @@ graphons at cut distance zero.
 
 * `TauCeti.DenseGraphLimits.cutDist_triangle_of_countable_middle` proves the triangle inequality
   when the intermediate carrier is countable with measurable singletons.
+* `TauCeti.DenseGraphLimits.cutDist_le_cutDist_comap_right` bounds the cut distance by its value
+  against a measure-preserving pullback of the right-hand graphon.
+* `TauCeti.DenseGraphLimits.cutDist_comap_right_of_countable` upgrades that bound to an equality
+  over a countable carrier with measurable singletons.
 * `TauCeti.DenseGraphLimits.cutDist_triangle` proves it on arbitrary probability carriers.
 
 ## References
@@ -140,7 +144,10 @@ theorem cutDist_triangle_of_countable_middle [Countable Ω₂]
         @cutNorm _ _ π₂₃ hπ₂₃.isFiniteMeasure (overlayDiff W X π₂₃) := hnorm13
     _ ≤ cutDist U W + cutDist W X + ε := by linarith
 
-private theorem cutDist_le_cutDist_comap_right
+/-- Reading the right-hand graphon on a smaller carrier along a measure-preserving map can only
+increase the cut distance: every coupling with the pulled-back graphon pushes forward to a coupling
+with the original one, at the same cut norm. -/
+theorem cutDist_le_cutDist_comap_right
     {Ω₂' : Type*} [MeasurableSpace Ω₂'] {μ₂' : Measure Ω₂'} [IsProbabilityMeasure μ₂']
     (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) {f : Ω₂' → Ω₂}
     (hf : MeasurePreserving f μ₂' μ₂) :
@@ -148,16 +155,8 @@ private theorem cutDist_le_cutDist_comap_right
   refine le_cutDist U (W.comap f hf.measurable μ₂') fun π hπ => ?_
   let _ := hπ.isProbabilityMeasure
   let ρ : Measure (Ω₁ × Ω₂) := π.map (Prod.map id f)
-  have hρ : IsCoupling μ₁ μ₂ ρ := isCoupling_iff.2
-    ⟨by
-      rw [← hπ.fst_eq]
-      simp only [ρ, Measure.fst, Measure.map_map measurable_fst
-        (measurable_id.prodMap hf.measurable), Prod.map_fst', Function.id_comp],
-    by
-      rw [← hf.map_eq, ← hπ.snd_eq]
-      simp only [ρ, Measure.snd, Measure.map_map measurable_snd
-        (measurable_id.prodMap hf.measurable), Measure.map_map hf.measurable measurable_snd,
-        Prod.map_snd']⟩
+  have hρ : IsCoupling μ₁ μ₂ ρ :=
+    isCoupling_map_prodMk hπ.measurePreserving_fst (hf.comp hπ.measurePreserving_snd)
   let _ := hρ.isProbabilityMeasure
   have hmp : MeasurePreserving (Prod.map id f) π ρ :=
     ⟨measurable_id.prodMap hf.measurable, rfl⟩
@@ -170,7 +169,10 @@ private theorem cutDist_le_cutDist_comap_right
       ext p q
       simp
 
-private theorem cutDist_comap_right_of_countable
+/-- Over a countable carrier with measurable singletons, reading the right-hand graphon along a
+measure-preserving map leaves the cut distance unchanged: the pulled-back graphon is at cut distance
+zero from the original, and the countable-middle triangle inequality transfers that. -/
+theorem cutDist_comap_right_of_countable
     [Countable Ω₂] [MeasurableSingletonClass Ω₂]
     {Ω₂' : Type*} [MeasurableSpace Ω₂'] {μ₂' : Measure Ω₂'} [IsProbabilityMeasure μ₂']
     (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) {f : Ω₂' → Ω₂}
@@ -255,8 +257,8 @@ theorem cutDist_triangle (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) (X 
   have htriangle : cutDist U X ≤ cutDist U W' + cutDist W' X := by
     apply cutDist_triangle_of_constantOn_partition U W' X P hP
     intro p q x y hx hy
-    rw [show W' = stepGraphonAvg (μ := μ₂) P hP W from rfl,
-      stepGraphonAvg_apply P hP W hx hy,
+    dsimp only [W']
+    rw [stepGraphonAvg_apply P hP W hx hy,
       stepGraphonAvg_apply P hP W (P.indexedPartition.some_mem p)
         (P.indexedPartition.some_mem q)]
   have htransfer := cutDist_le_add_two_mul_cutNorm_of_le_add U W W' X htriangle

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Triangle.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Triangle.lean
@@ -6,7 +6,6 @@ Authors: Codex
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.CutMetric.Stability
-public import TauCeti.Combinatorics.DenseGraphLimits.Graphon.Pullback
 public import TauCeti.Combinatorics.DenseGraphLimits.StepGraphon.Regularity
 import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Pullback
 import TauCeti.MeasureTheory.MeasurableSpace.Finpartition

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Triangle.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Triangle.lean
@@ -6,8 +6,8 @@ Authors: Codex
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.CutMetric.Stability
-public import TauCeti.Combinatorics.DenseGraphLimits.StepGraphon.Regularity
 public import TauCeti.Combinatorics.DenseGraphLimits.Graphon.Pullback
+public import TauCeti.Combinatorics.DenseGraphLimits.StepGraphon.Regularity
 import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Pullback
 import TauCeti.MeasureTheory.MeasurableSpace.Finpartition
 import TauCeti.MeasureTheory.OptimalTransport.Gluing
@@ -18,7 +18,7 @@ import TauCeti.MeasureTheory.OptimalTransport.Gluing
 This file proves the triangle inequality for the coupling-primary cut distance on arbitrary
 probability carriers.  The central finite-middle case glues two couplings over a countable
 intermediate carrier and pulls all three overlaid kernels back to the glued probability space,
-where their pointwise difference telescopes.  Exact invariance of the cut norm under
+where their difference telescopes.  Exact invariance of the cut norm under
 measure-preserving pullback then returns the estimate to the original couplings.
 
 For an arbitrary intermediate carrier, Frieze--Kannan weak regularity replaces the middle graphon
@@ -32,13 +32,10 @@ graphons at cut distance zero.
 
 ## Main results
 
-* `TauCeti.DenseGraphLimits.cutDist_triangle_of_countable_middle` proves the triangle inequality
-  when the intermediate carrier is countable with measurable singletons.
-* `TauCeti.DenseGraphLimits.cutDist_le_cutDist_comap_right` bounds the cut distance by its value
-  against a measure-preserving pullback of the right-hand graphon.
-* `TauCeti.DenseGraphLimits.cutDist_comap_right_of_countable` upgrades that bound to an equality
-  over a countable carrier with measurable singletons.
-* `TauCeti.DenseGraphLimits.cutDist_triangle` proves it on arbitrary probability carriers.
+* `TauCeti.DenseGraphLimits.cutDist_triangle` proves the triangle inequality on arbitrary
+  probability carriers.
+* `TauCeti.DenseGraphLimits.cutDist_comap_right` states that reading the right-hand graphon along
+  a measure-preserving map leaves the cut distance unchanged.
 
 ## References
 
@@ -90,7 +87,8 @@ private theorem exists_isCoupling_cutNorm_overlayDiff_le_of_glue
   let _ := hπ₁₃.isProbabilityMeasure
   have hmp12 : MeasurePreserving (fun p : Ω₁ × Ω₂ × Ω₃ => (p.1, p.2.1)) γ π₁₂ :=
     ⟨measurable_id.prodMap measurable_fst, hleft⟩
-  have hmp23 : MeasurePreserving Prod.snd γ π₂₃ := ⟨measurable_snd, hright⟩
+  have hmp23 : MeasurePreserving (fun p : Ω₁ × Ω₂ × Ω₃ => (p.2.1, p.2.2)) γ π₂₃ :=
+    ⟨measurable_snd.fst.prodMk measurable_snd.snd, hright⟩
   have hmp13 : MeasurePreserving (fun p : Ω₁ × Ω₂ × Ω₃ => (p.1, p.2.2)) γ π₁₃ :=
     ⟨measurable_id.prodMap measurable_snd, rfl⟩
   refine ⟨π₁₃, hπ₁₃, ?_⟩
@@ -102,15 +100,18 @@ private theorem exists_isCoupling_cutNorm_overlayDiff_le_of_glue
     _ = cutNorm γ
         ((overlayDiff U W π₁₂).comap (fun p => (p.1, p.2.1))
             (measurable_id.prodMap measurable_fst) γ +
-          (overlayDiff W X π₂₃).comap Prod.snd measurable_snd γ) := by
+          (overlayDiff W X π₂₃).comap (fun p => (p.2.1, p.2.2))
+            (measurable_snd.fst.prodMk measurable_snd.snd) γ) := by
       congr 1
-      ext p q
-      simp only [overlayDiff_apply, SymmKernel.comap_apply, SymmKernel.coe_add, Pi.add_apply]
-      ring
+      rw [comap_overlayDiff_prodMk U X π₁₃ measurable_fst measurable_snd.snd γ,
+        comap_overlayDiff_prodMk U W π₁₂ measurable_fst measurable_snd.fst γ,
+        comap_overlayDiff_prodMk W X π₂₃ measurable_snd.fst measurable_snd.snd γ]
+      abel
     _ ≤ cutNorm γ
           ((overlayDiff U W π₁₂).comap (fun p => (p.1, p.2.1))
             (measurable_id.prodMap measurable_fst) γ) +
-        cutNorm γ ((overlayDiff W X π₂₃).comap Prod.snd measurable_snd γ) :=
+        cutNorm γ ((overlayDiff W X π₂₃).comap (fun p => (p.2.1, p.2.2))
+          (measurable_snd.fst.prodMk measurable_snd.snd) γ) :=
       cutNorm_add_le γ _ _
     _ = cutNorm π₁₂ (overlayDiff U W π₁₂) + cutNorm π₂₃ (overlayDiff W X π₂₃) := by
       rw [cutNorm_comap hmp12, cutNorm_comap hmp23]
@@ -118,9 +119,9 @@ private theorem exists_isCoupling_cutNorm_overlayDiff_le_of_glue
 /-- The coupling cut distance satisfies the triangle inequality when the intermediate carrier is
 countable and has measurable singletons.
 
-Two nearly optimal couplings are glued over the middle marginal.  This result is the exact finite
-gluing statement used after replacing an arbitrary middle graphon by a finite step graphon. -/
-theorem cutDist_triangle_of_countable_middle [Countable Ω₂]
+This is the case of `cutDist_triangle` that an arbitrary middle graphon is reduced to, by replacing
+it with a finite step graphon. -/
+private theorem cutDist_triangle_of_countable_middle [Countable Ω₂]
     [MeasurableSingletonClass Ω₂] (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂)
     (X : Graphon Ω₃ μ₃) : cutDist U X ≤ cutDist U W + cutDist W X := by
   refine le_of_forall_pos_le_add fun ε hε => ?_
@@ -143,55 +144,6 @@ theorem cutDist_triangle_of_countable_middle [Countable Ω₂]
     _ ≤ @cutNorm _ _ π₁₂ hπ₁₂.isFiniteMeasure (overlayDiff U W π₁₂) +
         @cutNorm _ _ π₂₃ hπ₂₃.isFiniteMeasure (overlayDiff W X π₂₃) := hnorm13
     _ ≤ cutDist U W + cutDist W X + ε := by linarith
-
-/-- Reading the right-hand graphon on a smaller carrier along a measure-preserving map can only
-increase the cut distance: every coupling with the pulled-back graphon pushes forward to a coupling
-with the original one, at the same cut norm. -/
-theorem cutDist_le_cutDist_comap_right
-    {Ω₂' : Type*} [MeasurableSpace Ω₂'] {μ₂' : Measure Ω₂'} [IsProbabilityMeasure μ₂']
-    (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) {f : Ω₂' → Ω₂}
-    (hf : MeasurePreserving f μ₂' μ₂) :
-    cutDist U W ≤ cutDist U (W.comap f hf.measurable μ₂') := by
-  refine le_cutDist U (W.comap f hf.measurable μ₂') fun π hπ => ?_
-  let _ := hπ.isProbabilityMeasure
-  let ρ : Measure (Ω₁ × Ω₂) := π.map (Prod.map id f)
-  have hρ : IsCoupling μ₁ μ₂ ρ :=
-    isCoupling_map_prodMk hπ.measurePreserving_fst (hf.comp hπ.measurePreserving_snd)
-  let _ := hρ.isProbabilityMeasure
-  have hmp : MeasurePreserving (Prod.map id f) π ρ :=
-    ⟨measurable_id.prodMap hf.measurable, rfl⟩
-  calc
-    cutDist U W ≤ cutNorm ρ (overlayDiff U W ρ) := cutDist_le U W hρ
-    _ = cutNorm π ((overlayDiff U W ρ).comap (Prod.map id f)
-          (measurable_id.prodMap hf.measurable) π) := (cutNorm_comap hmp _).symm
-    _ = cutNorm π (overlayDiff U (W.comap f hf.measurable μ₂') π) := by
-      congr 1
-      ext p q
-      simp
-
-/-- Over a countable carrier with measurable singletons, reading the right-hand graphon along a
-measure-preserving map leaves the cut distance unchanged: the pulled-back graphon is at cut distance
-zero from the original, and the countable-middle triangle inequality transfers that. -/
-theorem cutDist_comap_right_of_countable
-    [Countable Ω₂] [MeasurableSingletonClass Ω₂]
-    {Ω₂' : Type*} [MeasurableSpace Ω₂'] {μ₂' : Measure Ω₂'} [IsProbabilityMeasure μ₂']
-    (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) {f : Ω₂' → Ω₂}
-    (hf : MeasurePreserving f μ₂' μ₂) :
-    cutDist U (W.comap f hf.measurable μ₂') = cutDist U W := by
-  apply le_antisymm
-  · have hzero : cutDist W (W.comap f hf.measurable μ₂') = 0 := by
-      apply le_antisymm
-      · have h := cutDist_le_cutNorm_sub_of_measurePreserving W
-          (W.comap f hf.measurable μ₂') hf (MeasurePreserving.id μ₂')
-        rw [Graphon.toSymmKernel_comap, SymmKernel.comap_id, sub_self, cutNorm_zero] at h
-        exact h
-      · exact cutDist_nonneg _ _
-    calc
-      cutDist U (W.comap f hf.measurable μ₂') ≤
-          cutDist U W + cutDist W (W.comap f hf.measurable μ₂') :=
-        cutDist_triangle_of_countable_middle U W _
-      _ = cutDist U W := by rw [hzero, add_zero]
-  · exact cutDist_le_cutDist_comap_right U W hf
 
 section StepModel
 
@@ -242,10 +194,15 @@ private theorem cutDist_triangle_of_constantOn_partition
     ext x y
     rw [Graphon.comap_apply, stepGraphonModel_apply]
     exact hconst _ _ (P.indexedPartition.mem_index x) (P.indexedPartition.mem_index y)
-  rw [hmodel, cutDist_comap_right_of_countable U A hmp, cutDist_comm
-    (A.comap P.indexedPartition.index hindex μ₂) X, cutDist_comap_right_of_countable X A hmp,
-    cutDist_comm X A]
-  exact cutDist_triangle_of_countable_middle U A X
+  have hUA : cutDist U A ≤ cutDist U W := by
+    rw [hmodel]
+    exact cutDist_le_cutDist_comap_right U A hmp
+  have hAX : cutDist A X ≤ cutDist W X := by
+    rw [cutDist_comm A X, cutDist_comm W X, hmodel]
+    exact cutDist_le_cutDist_comap_right X A hmp
+  calc
+    cutDist U X ≤ cutDist U A + cutDist A X := cutDist_triangle_of_countable_middle U A X
+    _ ≤ cutDist U W + cutDist W X := by linarith
 
 /-- The coupling-primary graphon cut distance satisfies the triangle inequality on arbitrary
 probability carriers. -/
@@ -264,6 +221,27 @@ theorem cutDist_triangle (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) (X 
   have htransfer := cutDist_le_add_two_mul_cutNorm_of_le_add U W W' X htriangle
   dsimp only [W'] at htransfer
   nlinarith
+
+/-- Reading the right-hand graphon along a measure-preserving map `f : Ω₂' → Ω₂` leaves the cut
+distance unchanged: `cutDist U (W.comap f hf.measurable μ₂') = cutDist U W`.
+
+Together with `cutDist_comm` this says that the cut distance only depends on a graphon through its
+measure-preserving pullbacks, on arbitrary probability carriers; the inequality `≥` alone is
+`cutDist_le_cutDist_comap_right`, and needs no triangle inequality. -/
+theorem cutDist_comap_right {Ω₂' : Type*} [MeasurableSpace Ω₂'] {μ₂' : Measure Ω₂'}
+    [IsProbabilityMeasure μ₂'] (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) {f : Ω₂' → Ω₂}
+    (hf : MeasurePreserving f μ₂' μ₂) :
+    cutDist U (W.comap f hf.measurable μ₂') = cutDist U W := by
+  have hzero : cutDist W (W.comap f hf.measurable μ₂') = 0 := by
+    refine le_antisymm ?_ (cutDist_nonneg _ _)
+    have h := cutDist_le_cutNorm_sub_of_measurePreserving W (W.comap f hf.measurable μ₂') hf
+      (MeasurePreserving.id μ₂')
+    rwa [Graphon.toSymmKernel_comap, SymmKernel.comap_id, sub_self, cutNorm_zero] at h
+  refine le_antisymm ?_ (cutDist_le_cutDist_comap_right U W hf)
+  calc
+    cutDist U (W.comap f hf.measurable μ₂') ≤
+        cutDist U W + cutDist W (W.comap f hf.measurable μ₂') := cutDist_triangle U W _
+    _ = cutDist U W := by rw [hzero, add_zero]
 
 end DenseGraphLimits
 

--- a/TauCeti/MeasureTheory/MeasurableSpace/Finpartition.lean
+++ b/TauCeti/MeasureTheory/MeasurableSpace/Finpartition.lean
@@ -7,12 +7,14 @@ module
 
 public import Mathlib.MeasureTheory.MeasurableSpace.Basic
 public import TauCeti.Order.Partition.Finpartition
+import Mathlib.MeasureTheory.MeasurableSpace.Constructions
 
 /-!
 # Measurable finite partitions
 
 This file records elementary ways to construct measurable finite partitions and shows that
-measurability passes from a finer finite partition to a coarser one.
+measurability passes from a finer finite partition to a coarser one.  It also makes the canonical
+map from a point to its finite-partition index measurable.
 -/
 
 public section
@@ -22,6 +24,19 @@ open Set
 namespace Finpartition
 
 variable {Ω : Type*} [MeasurableSpace Ω]
+
+/-- The map sending a point to its part in a measurable finite partition is measurable when the
+finite type of parts carries the discrete measurable space. -/
+theorem measurable_indexedPartition_index (P : Finpartition (Set.univ : Set Ω))
+    (hP : ∀ p ∈ P.parts, MeasurableSet p) :
+    @Measurable Ω P.parts _ ⊤ P.indexedPartition.index := by
+  let _ : MeasurableSpace P.parts := ⊤
+  refine measurable_to_countable' fun p => ?_
+  have hpreimage : P.indexedPartition.index ⁻¹' {p} = (p : Set Ω) := by
+    ext x
+    exact P.indexedPartition.mem_iff_index_eq.symm
+  rw [hpreimage]
+  exact hP p p.property
 
 /-- Every part of a bipartition along a measurable set is measurable. -/
 theorem measurableSet_of_mem_bipartition {s p : Set Ω} (hs : MeasurableSet s)

--- a/TauCeti/MeasureTheory/MeasurableSpace/Finpartition.lean
+++ b/TauCeti/MeasureTheory/MeasurableSpace/Finpartition.lean
@@ -25,12 +25,13 @@ namespace Finpartition
 
 variable {Ω : Type*} [MeasurableSpace Ω]
 
-/-- The map sending a point to its part in a measurable finite partition is measurable when the
-finite type of parts carries the discrete measurable space. -/
+/-- The map sending a point to its part in a measurable finite partition is measurable, for any
+measurable space structure on the finite type of parts — in particular for the discrete one.
+Countability of the parts is what makes an arbitrary structure on them admissible: measurability of
+the fibres already forces measurability of every preimage. -/
 theorem measurable_indexedPartition_index (P : Finpartition (Set.univ : Set Ω))
-    (hP : ∀ p ∈ P.parts, MeasurableSet p) :
-    @Measurable Ω P.parts _ ⊤ P.indexedPartition.index := by
-  let _ : MeasurableSpace P.parts := ⊤
+    [MeasurableSpace P.parts] (hP : ∀ p ∈ P.parts, MeasurableSet p) :
+    Measurable P.indexedPartition.index := by
   refine measurable_to_countable' fun p => ?_
   have hpreimage : P.indexedPartition.index ⁻¹' {p} = (p : Set Ω) := by
     ext x

--- a/TauCeti/Order/Partition/Finpartition.lean
+++ b/TauCeti/Order/Partition/Finpartition.lean
@@ -5,14 +5,16 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Data.Setoid.Partition
 public import Mathlib.Order.Partition.Finpartition
 
 /-!
 # Finite partition helpers
 
 This file contains general-purpose constructions and facts about finite partitions: the partition
-of the top element into an element and its complement, cardinality bounds for common refinements,
-and the behavior of intersections of parts under refinement.
+of the top element into an element and its complement, the associated indexed partition,
+cardinality bounds for common refinements, and the behavior of intersections of parts under
+refinement.
 -/
 
 public section
@@ -52,6 +54,17 @@ theorem card_parts_inf_le_mul {α : Type*} [DistribLattice α] [OrderBot α] [De
     (Finset.card_image_le.trans_eq (Finset.card_product _ _))
 
 variable {Ω : Type*} {u : Set Ω}
+
+/-- The indexed partition associated to a finite partition of `Set.univ`, indexed by its actual
+parts.  Its `index` sends each point to the unique part containing it. -/
+noncomputable def indexedPartition (P : Finpartition (Set.univ : Set Ω)) :
+    IndexedPartition (fun p : P.parts => (p : Set Ω)) :=
+  IndexedPartition.mk' _
+    (fun p q hne => P.disjoint p.property q.property fun h => hne (Subtype.ext h))
+    (fun p => Set.nonempty_iff_ne_empty.mpr (P.ne_bot p.property))
+    (fun x => by
+      obtain ⟨p, ⟨hp, hxp⟩, _⟩ := P.isPartition_parts.2 x
+      exact ⟨⟨p, hp⟩, hxp⟩)
 
 /-- Under refinement, a part of the finer partition is either contained in a given part of the
 coarser one or disjoint from it. -/


### PR DESCRIPTION
This PR proves the `DenseGraphLimits` Layer 1 target `cutDist_triangle`: the coupling-primary graphon cut distance satisfies the triangle inequality on arbitrary probability carriers. It glues near-optimal couplings when the middle carrier is countable, realizes measurable finite-partition step graphons on their discrete block carrier, and uses Frieze–Kannan weak regularity plus the landed cut-distance stability bound to remove the finite-step approximation.

This closes the triangle-inequality step of the Layer 1 core-objects milestone. After this PR, the fixed-carrier `GraphonSpace Ω μ` metric quotient remains to complete the roadmap's pseudometric-to-quotient transition.

The proof directly consumes the roadmap's two required design gates: finite/countable-middle coupling gluing with zero-mass atoms handled by `exists_glue_of_countable_middle`, and stability under step approximation via `cutDist_le_add_two_mul_cutNorm_of_le_add`; `weak_regularity_frieze_kannan` supplies the finite middle model. The argument follows Janson, Lemma 6.5, and is written natively for Tau Ceti's coupling-primary API. No external code or Mathlib infrastructure is vendored; existing Mathlib `IndexedPartition`, measure-map, and probability-measure APIs are reused.

Roadmap: DenseGraphLimits

<!--tauceti-target:v1 {"focus":"DenseGraphLimits","id":"cutdist-triangle"}-->

🤖 Prepared with Codex
