### PR TITLE
refactor: share the helpers of the generator-uniqueness proof

### DIFF
--- a/TauCeti/Analysis/Semigroups/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Topology.Algebra.Module.Basic
 public import Mathlib.Analysis.Normed.Operator.ContinuousLinearMap
 public import Mathlib.Analysis.Normed.Operator.BanachSteinhaus
+public import Mathlib.LinearAlgebra.AffineSpace.Slope
 
 /-!
 # Strongly continuous semigroups
@@ -15,7 +16,8 @@ public import Mathlib.Analysis.Normed.Operator.BanachSteinhaus
 This file contains the foundational C₀-semigroup structures, the nonnegative-time API
 (`map_zero`, `map_add`, `continuousAt_zero`, and their pointwise/tendsto forms),
 the `realOperator` real-time shim,
-operator-norm local boundedness, and strong continuity within the nonnegative half-line.
+operator-norm local boundedness, strong continuity within the nonnegative half-line, and the
+semigroup-law algebra of rebasing an orbit inside a slope (`slope_apply_realOperator_eq`).
 
 ## References
 Ported and adapted (Apache 2.0) from `mrdouglasny/hille-yosida`; references include
@@ -189,6 +191,23 @@ theorem realOperator_add (S : StronglyContinuousSemigroup X) (s t : ℝ) (hs : 0
     S.realOperator (s + t) = (S.realOperator s).comp (S.realOperator t) := by
   rw [realOperator, realOperator, realOperator, Real.toNNReal_add hs ht]
   exact S.map_add' s.toNNReal t.toNNReal
+
+omit [CompleteSpace X] in
+/-- **Rebasing a semigroup orbit inside a slope.** For any family `F` of operators and nonnegative
+times `0 ≤ s ≤ u`, the slope at `s` of `u ↦ F u (S u x)` splits, by the semigroup law
+`S u x = S (u - s) (S s x)`, into the difference quotient of the orbit of `S s x` rebased at `s`
+and pushed through `F u`, plus the slope of `u ↦ F u (S s x)`.  Used by the generator-uniqueness
+argument with `F u = S' (t - u)` for a second semigroup `S'`. -/
+theorem slope_apply_realOperator_eq (S : StronglyContinuousSemigroup X) (F : ℝ → X →L[ℝ] X)
+    (x : X) {s u : ℝ} (hs : 0 ≤ s) (hu : s ≤ u) :
+    slope (fun v : ℝ => F v (S.realOperator v x)) s u =
+      F u ((u - s)⁻¹ • (S.realOperator (u - s) (S.realOperator s x) - S.realOperator s x)) +
+        slope (fun v : ℝ => F v (S.realOperator s x)) s u := by
+  have hus : 0 ≤ u - s := sub_nonneg.mpr hu
+  have hSu : S.realOperator u x = S.realOperator (u - s) (S.realOperator s x) := by
+    rw [← ContinuousLinearMap.comp_apply, ← S.realOperator_add (u - s) s hus hs, sub_add_cancel]
+  simp only [slope_def_module, hSu, map_smul, map_sub, smul_sub]
+  abel
 
 omit [CompleteSpace X] in
 /-- Submultiplicativity of the real-time operator norm at nonnegative times: the semigroup law

--- a/TauCeti/Analysis/Semigroups/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Basic.lean
@@ -314,11 +314,9 @@ private theorem StronglyContinuousSemigroup.norm_realOperator_apply_le_pow_mul_o
         linarith
       have htd_lt : t - δ < (↑k + 1) * δ := by
         push_cast [Nat.succ_eq_add_one] at ht_ub; linarith
-      have h_sg := S.realOperator_add δ (t - δ) hδ_pos.le htd_nn
-      rw [add_sub_cancel] at h_sg
       calc ‖S.realOperator t x‖
           = ‖S.realOperator δ (S.realOperator (t - δ) x)‖ := by
-            simp only [h_sg, ContinuousLinearMap.comp_apply]
+            rw [← S.realOperator_add_apply δ (t - δ) hδ_pos.le htd_nn, add_sub_cancel]
         _ ≤ ‖S.realOperator δ‖ * ‖S.realOperator (t - δ) x‖ :=
             ContinuousLinearMap.le_opNorm _ _
         _ ≤ L * (L ^ k * B) := by
@@ -422,14 +420,9 @@ private theorem StronglyContinuousSemigroup.strongContWithinAt_left
   refine ⟨δ, hδ_pos, fun t ht_mem ht_dist => ?_⟩
   simp only [Set.mem_Icc] at ht_mem
   have ht₀t_nn : 0 ≤ t₀ - t := by linarith [ht_mem.2]
-  have h_sg_eq : S.realOperator t₀ = (S.realOperator t).comp (S.realOperator (t₀ - t)) := by
-    have := S.realOperator_add t (t₀ - t) ht_mem.1 ht₀t_nn
-    rwa [add_sub_cancel] at this
   have h_diff : S.realOperator t x - S.realOperator t₀ x =
       S.realOperator t (x - S.realOperator (t₀ - t) x) := by
-    conv_rhs => rw [map_sub]
-    congr 1
-    rw [h_sg_eq, ContinuousLinearMap.comp_apply]
+    rw [map_sub, ← S.realOperator_add_apply t (t₀ - t) ht_mem.1 ht₀t_nn, add_sub_cancel]
   rw [dist_eq_norm, h_diff]
   calc ‖S.realOperator t (x - S.realOperator (t₀ - t) x)‖
       ≤ ‖S.realOperator t‖ * ‖x - S.realOperator (t₀ - t) x‖ :=
@@ -475,10 +468,7 @@ private theorem StronglyContinuousSemigroup.strongContWithinAt_right
   filter_upwards [self_mem_nhdsWithin] with t ht
   simp only [Set.mem_Ici] at ht
   have ht_nn : 0 ≤ t - t₀ := by linarith
-  have h_sg := S.realOperator_add t₀ (t - t₀) ht₀ ht_nn
-  have h_add_sub_t0 : t₀ + (t - t₀) = t := by ring
-  rw [h_add_sub_t0] at h_sg
-  rw [h_sg, ContinuousLinearMap.comp_apply]
+  rw [← S.realOperator_add_apply t₀ (t - t₀) ht₀ ht_nn, add_sub_cancel]
 
 /-- Strong continuity at every `t₀ ≥ 0`, not just at 0
 ([EN] Prop. I.5.3, [Linares] Cor. 1).

--- a/TauCeti/Analysis/Semigroups/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Basic.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Topology.Algebra.Module.Basic
 public import Mathlib.Analysis.Normed.Operator.ContinuousLinearMap
 public import Mathlib.Analysis.Normed.Operator.BanachSteinhaus
-public import Mathlib.LinearAlgebra.AffineSpace.Slope
 
 /-!
 # Strongly continuous semigroups
@@ -16,8 +15,7 @@ public import Mathlib.LinearAlgebra.AffineSpace.Slope
 This file contains the foundational C₀-semigroup structures, the nonnegative-time API
 (`map_zero`, `map_add`, `continuousAt_zero`, and their pointwise/tendsto forms),
 the `realOperator` real-time shim,
-operator-norm local boundedness, strong continuity within the nonnegative half-line, and the
-semigroup-law algebra of rebasing an orbit inside a slope (`slope_apply_realOperator_eq`).
+operator-norm local boundedness, and strong continuity within the nonnegative half-line.
 
 ## References
 Ported and adapted (Apache 2.0) from `mrdouglasny/hille-yosida`; references include
@@ -35,7 +33,6 @@ namespace TauCeti.Semigroups
 /-! ## Strongly Continuous Semigroups -/
 
 variable (X : Type*) [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
-
 
 /-- A strongly continuous one-parameter semigroup (C₀-semigroup) on a Banach space.
 
@@ -193,21 +190,10 @@ theorem realOperator_add (S : StronglyContinuousSemigroup X) (s t : ℝ) (hs : 0
   exact S.map_add' s.toNNReal t.toNNReal
 
 omit [CompleteSpace X] in
-/-- **Rebasing a semigroup orbit inside a slope.** For any family `F` of operators and nonnegative
-times `0 ≤ s ≤ u`, the slope at `s` of `u ↦ F u (S u x)` splits, by the semigroup law
-`S u x = S (u - s) (S s x)`, into the difference quotient of the orbit of `S s x` rebased at `s`
-and pushed through `F u`, plus the slope of `u ↦ F u (S s x)`.  Used by the generator-uniqueness
-argument with `F u = S' (t - u)` for a second semigroup `S'`. -/
-theorem slope_apply_realOperator_eq (S : StronglyContinuousSemigroup X) (F : ℝ → X →L[ℝ] X)
-    (x : X) {s u : ℝ} (hs : 0 ≤ s) (hu : s ≤ u) :
-    slope (fun v : ℝ => F v (S.realOperator v x)) s u =
-      F u ((u - s)⁻¹ • (S.realOperator (u - s) (S.realOperator s x) - S.realOperator s x)) +
-        slope (fun v : ℝ => F v (S.realOperator s x)) s u := by
-  have hus : 0 ≤ u - s := sub_nonneg.mpr hu
-  have hSu : S.realOperator u x = S.realOperator (u - s) (S.realOperator s x) := by
-    rw [← ContinuousLinearMap.comp_apply, ← S.realOperator_add (u - s) s hus hs, sub_add_cancel]
-  simp only [slope_def_module, hSu, map_smul, map_sub, smul_sub]
-  abel
+/-- The semigroup law at nonnegative real times, applied to a vector. -/
+theorem realOperator_add_apply (S : StronglyContinuousSemigroup X) (s t : ℝ) (hs : 0 ≤ s)
+    (ht : 0 ≤ t) (x : X) : S.realOperator (s + t) x = S.realOperator s (S.realOperator t x) := by
+  rw [S.realOperator_add s t hs ht, ContinuousLinearMap.comp_apply]
 
 omit [CompleteSpace X] in
 /-- Submultiplicativity of the real-time operator norm at nonnegative times: the semigroup law

--- a/TauCeti/Analysis/Semigroups/Generator/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Basic.lean
@@ -157,6 +157,25 @@ theorem StronglyContinuousSemigroup.generator_tendsto
   exact Classical.choose_spec x.property
 
 omit [CompleteSpace X] in
+/-- The generator difference quotient, rebased at `s`: the defining quotient of `S.generator` at
+`x` (`generator_tendsto`), precomposed with `u ↦ u - s` so that it approaches `s` from the right
+rather than `0`. -/
+theorem StronglyContinuousSemigroup.generator_tendsto_comp_sub_const
+    (S : StronglyContinuousSemigroup X) (x : S.domain) (s : ℝ) :
+    Filter.Tendsto (fun u : ℝ => (u - s)⁻¹ • (S.realOperator (u - s) (x : X) - (x : X)))
+      (nhdsWithin s (Set.Ioi s))
+      (nhds (S.generator ⟨(x : X), by
+        rw [S.generator_domain]
+        exact x.property⟩)) := by
+  have hshift : Filter.Tendsto (fun u : ℝ => u - s) (nhdsWithin s (Set.Ioi s))
+      (nhdsWithin 0 (Set.Ioi 0)) :=
+    tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
+      (((continuous_id.sub continuous_const).tendsto' s 0 (sub_self s)).mono_left
+        nhdsWithin_le_nhds)
+      (eventually_nhdsWithin_of_forall fun u hu => Set.mem_Ioi.mpr (sub_pos.mpr hu))
+  simpa [Function.comp_def, one_div] using (S.generator_tendsto x).comp hshift
+
+omit [CompleteSpace X] in
 /-- Eliminator for the generator: if the difference quotient `(S t x - x)/t` of an
 `x ∈ D(A)` converges to `y`, then `A x = y`. -/
 theorem StronglyContinuousSemigroup.generator_eq_of_tendsto
@@ -340,6 +359,12 @@ theorem StronglyContinuousSemigroup.dense_domain
   · simpa using S.tendsto_average_orbit_zero x
   · filter_upwards [self_mem_nhdsWithin] with t ht
     exact S.domain.smul_mem (1 / t) (S.integral_orbit_mem_domain x ht)
+
+/-- Two continuous linear maps that agree on the (dense) generator domain are equal. -/
+theorem StronglyContinuousSemigroup.eq_of_eqOn_domain (S : StronglyContinuousSemigroup X)
+    {f g : X →L[ℝ] X} (h : ∀ x ∈ S.domain, f x = g x) : f = g :=
+  ContinuousLinearMap.ext_on (R₁ := ℝ) (s := (S.domain : Set X))
+    (by rw [Submodule.span_eq]; exact S.dense_domain) h
 
 end TauCeti.Semigroups
 

--- a/TauCeti/Analysis/Semigroups/Generator/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Basic.lean
@@ -9,6 +9,7 @@ public import TauCeti.Analysis.Semigroups.Basic
 public import Mathlib.LinearAlgebra.LinearPMap
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 public import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.Topology.Algebra.Group.Order
 
 /-!
 # Generators of strongly continuous semigroups
@@ -169,10 +170,7 @@ theorem StronglyContinuousSemigroup.generator_tendsto_comp_sub_const
         exact x.property⟩)) := by
   have hshift : Filter.Tendsto (fun u : ℝ => u - s) (nhdsWithin s (Set.Ioi s))
       (nhdsWithin 0 (Set.Ioi 0)) :=
-    tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
-      (((continuous_id.sub continuous_const).tendsto' s 0 (sub_self s)).mono_left
-        nhdsWithin_le_nhds)
-      (eventually_nhdsWithin_of_forall fun u hu => Set.mem_Ioi.mpr (sub_pos.mpr hu))
+    le_of_eq (by rw [Filter.map_subRight_nhdsGT, sub_self])
   simpa [Function.comp_def, one_div] using (S.generator_tendsto x).comp hshift
 
 omit [CompleteSpace X] in
@@ -272,7 +270,7 @@ private theorem StronglyContinuousSemigroup.local_integral_shift_identity
         exact hu.1
       have h_semigroup_apply :
           S.realOperator h (S.realOperator u x) = S.realOperator (u + h) x := by
-        rw [← ContinuousLinearMap.comp_apply, ← S.realOperator_add h u hh.le hu_nonneg, add_comm]
+        rw [← S.realOperator_add_apply h u hh.le hu_nonneg, add_comm]
       simpa [f] using h_semigroup_apply
   have h_sub :
       (∫ u in h..t + h, f u) - ∫ u in (0 : ℝ)..t, f u =
@@ -361,7 +359,8 @@ theorem StronglyContinuousSemigroup.dense_domain
     exact S.domain.smul_mem (1 / t) (S.integral_orbit_mem_domain x ht)
 
 /-- Two continuous linear maps that agree on the (dense) generator domain are equal. -/
-theorem StronglyContinuousSemigroup.eq_of_eqOn_domain (S : StronglyContinuousSemigroup X)
+theorem StronglyContinuousSemigroup.continuousLinearMap_ext_of_eqOn_domain
+    (S : StronglyContinuousSemigroup X)
     {f g : X →L[ℝ] X} (h : ∀ x ∈ S.domain, f x = g x) : f = g :=
   ContinuousLinearMap.ext_on (R₁ := ℝ) (s := (S.domain : Set X))
     (by rw [Submodule.span_eq]; exact S.dense_domain) h

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -17,6 +17,11 @@ right derivative at every nonnegative time in the equivalent forms `A (S t x)` a
 It also proves that a generator-domain orbit has a derivative within the whole nonnegative
 half-line, hence a two-sided derivative at positive times.
 
+Finally, `StronglyContinuousSemigroup.hasDerivWithinAt_apply_realOperator_of_tendsto`
+differentiates an orbit inside an operator family: the right derivative of `u ↦ F u (S u x)` at
+`s` is the sum of the limit of the rebased orbit difference quotient pushed through `F u` and the
+right derivative of `u ↦ F u (S s x)`.
+
 ## References
 
 The argument follows Engel--Nagel, *One-Parameter Semigroups for Linear Evolution
@@ -96,6 +101,24 @@ theorem mem_domain_iff_differentiableWithinAt_realOperator_zero
 
 /-! ## Right derivatives at nonnegative times -/
 
+/-- **Differentiating an orbit inside an operator family.** At a nonnegative time `s`, if the
+difference quotient of the orbit of `S s x`, rebased at `s` and pushed through `F u`, converges to
+`b`, and `u ↦ F u (S s x)` has right derivative `c` at `s`, then `u ↦ F u (S u x)` has right
+derivative `b + c` at `s`.  With `F ≡ id` and `S s x` in the generator domain this specialises to
+`realOperator_hasDerivWithinAt`; generator uniqueness takes `F u = S' (t - u)` for a second
+semigroup `S'`. -/
+theorem hasDerivWithinAt_apply_realOperator_of_tendsto (S : StronglyContinuousSemigroup X)
+    (F : ℝ → X →L[ℝ] X) (x : X) {s : ℝ} (hs : 0 ≤ s) {b c : X}
+    (hquot : Filter.Tendsto (fun u : ℝ =>
+      F u ((u - s)⁻¹ • (S.realOperator (u - s) (S.realOperator s x) - S.realOperator s x)))
+      (𝓝[>] s) (𝓝 b))
+    (hslope : HasDerivWithinAt (fun v : ℝ => F v (S.realOperator s x)) c (Set.Ici s) s) :
+    HasDerivWithinAt (fun u : ℝ => F u (S.realOperator u x)) (b + c) (Set.Ici s) s := by
+  rw [hasDerivWithinAt_iff_tendsto_slope, Set.Ici_sdiff_left] at hslope ⊢
+  refine (hquot.add hslope).congr' ?_
+  filter_upwards [self_mem_nhdsWithin] with u hu
+  exact (S.slope_apply_realOperator_eq F x hs hu.le).symm
+
 /-- At every nonnegative time, if the evolved vector belongs to the generator domain, then the
 right derivative of the orbit is the generator evaluated on that evolved vector. -/
 theorem realOperator_hasDerivWithinAt (S : StronglyContinuousSemigroup X)
@@ -103,26 +126,11 @@ theorem realOperator_hasDerivWithinAt (S : StronglyContinuousSemigroup X)
     HasDerivWithinAt (fun s : ℝ => S.realOperator s x)
       (S.generator ⟨S.realOperator t x, by rw [S.generator_domain]; exact hxt⟩)
       (Set.Ici t) t := by
-  let y : S.domain := ⟨S.realOperator t x, hxt⟩
-  have htranslate : HasDerivWithinAt (fun s : ℝ => S.realOperator (s - t) (y : X))
-      (S.generator ⟨y, by rw [S.generator_domain]; exact y.property⟩) (Set.Ici t) t := by
-    have hinner : HasDerivWithinAt (fun s : ℝ => s - t) 1 (Set.Ici t) t := by
-      simpa using (hasDerivWithinAt_id t (Set.Ici t)).sub_const t
-    have hmaps : Set.MapsTo (fun s : ℝ => s - t) (Set.Ici t) (Set.Ici 0) := by
-      intro s hs
-      simpa only [Set.mem_Ici, sub_nonneg] using hs
-    have hcomp :=
-      (S.realOperator_hasDerivWithinAt_zero y).scomp_of_eq t hinner hmaps (by ring)
-    exact (hcomp.congr (fun _ _ => rfl) rfl).congr_deriv (one_smul ℝ _)
-  refine htranslate.congr (fun s hs => ?_) ?_
-  · have hst : 0 ≤ s - t := sub_nonneg.mpr hs
-    calc
-      S.realOperator s x = S.realOperator ((s - t) + t) x := by ring_nf
-      _ = S.realOperator (s - t) (S.realOperator t x) := by
-        rw [S.realOperator_add _ _ hst ht]
-        rfl
-      _ = S.realOperator (s - t) y := rfl
-  · simp only [sub_self, S.realOperator_zero_apply, y]
+  have h := S.hasDerivWithinAt_apply_realOperator_of_tendsto (fun _ => ContinuousLinearMap.id ℝ X)
+    x ht (by simpa only [ContinuousLinearMap.id_apply] using
+      S.generator_tendsto_comp_sub_const ⟨S.realOperator t x, hxt⟩ t)
+    (hasDerivWithinAt_const t (Set.Ici t) _)
+  simpa only [ContinuousLinearMap.id_apply, add_zero] using h
 
 /-- At every nonnegative time, the right derivative of the orbit is the semigroup operator
 applied to the generator. -/

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -17,10 +17,12 @@ right derivative at every nonnegative time in the equivalent forms `A (S t x)` a
 It also proves that a generator-domain orbit has a derivative within the whole nonnegative
 half-line, hence a two-sided derivative at positive times.
 
-Finally, `StronglyContinuousSemigroup.hasDerivWithinAt_apply_realOperator_of_tendsto`
-differentiates an orbit inside an operator family: the right derivative of `u ↦ F u (S u x)` at
-`s` is the sum of the limit of the rebased orbit difference quotient pushed through `F u` and the
-right derivative of `u ↦ F u (S s x)`.
+Finally, `StronglyContinuousSemigroup.slope_apply_realOperator_eq` rebases an orbit inside a
+slope by the semigroup law, and
+`StronglyContinuousSemigroup.hasDerivWithinAt_apply_realOperator_of_tendsto` differentiates an
+orbit inside an operator family: the right derivative of `u ↦ F u (S u x)` at `s` is the sum of
+the limit of the rebased orbit difference quotient pushed through `F u` and the right derivative
+of `u ↦ F u (S s x)`.
 
 ## References
 
@@ -100,6 +102,20 @@ theorem mem_domain_iff_differentiableWithinAt_realOperator_zero
     simpa [S.realOperator_zero_apply] using hy'
 
 /-! ## Right derivatives at nonnegative times -/
+
+/-- **Rebasing a semigroup orbit inside a slope.** For any family `F` of operators and nonnegative
+times `0 ≤ s ≤ u`, the slope at `s` of `u ↦ F u (S u x)` splits, by the semigroup law
+`S u x = S (u - s) (S s x)`, into the difference quotient of the orbit of `S s x` rebased at `s`
+and pushed through `F u`, plus the slope of `u ↦ F u (S s x)`. -/
+theorem slope_apply_realOperator_eq (S : StronglyContinuousSemigroup X) (F : ℝ → X →L[ℝ] X)
+    (x : X) {s u : ℝ} (hs : 0 ≤ s) (hu : s ≤ u) :
+    slope (fun v : ℝ => F v (S.realOperator v x)) s u =
+      F u ((u - s)⁻¹ • (S.realOperator (u - s) (S.realOperator s x) - S.realOperator s x)) +
+        slope (fun v : ℝ => F v (S.realOperator s x)) s u := by
+  have hSu : S.realOperator u x = S.realOperator (u - s) (S.realOperator s x) := by
+    rw [← S.realOperator_add_apply (u - s) s (sub_nonneg.mpr hu) hs, sub_add_cancel]
+  simp only [slope_def_module, hSu, map_smul, map_sub, smul_sub]
+  abel
 
 /-- **Differentiating an orbit inside an operator family.** At a nonnegative time `s`, if the
 difference quotient of the orbit of `S s x`, rebased at `s` and pushed through `F u`, converges to

--- a/TauCeti/Analysis/Semigroups/Generator/Uniqueness.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Uniqueness.lean
@@ -37,6 +37,12 @@ operator `A` is `t ↦ exp (t • A)` (`TauCeti/Analysis/Semigroups/BoundedGener
 
 ## Main results
 
+* `hasDerivWithinAt_realOperator_apply_realOperator_zero` (in the
+  `TauCeti.Semigroups.StronglyContinuousSemigroup` namespace): a composite orbit
+  `u ↦ S (f u) (T u x)` has vanishing right derivative when the generator contribution of `T`
+  cancels the derivative of `u ↦ S (f u) (T s x)`.
+* `realOperator_apply_realOperator_eq_of_hasDerivWithinAt_zero` (same namespace): a composite
+  orbit with vanishing right derivative on `[0, t)` has value `S (f 0) x` at `t`.
 * `TauCeti.Semigroups.StronglyContinuousSemigroup.realOperator_eq_of_generator_eq`: two
   semigroups with the same generator agree on the generator domain.
 * `TauCeti.Semigroups.StronglyContinuousSemigroup.eq_of_generator_eq` and
@@ -83,60 +89,28 @@ private theorem hasDerivAt_realOperator_sub {S : StronglyContinuousSemigroup X} 
     exact h.hasDerivAt (Ici_mem_nhds hrpos)
   exact HasDerivAt.comp_const_sub t s hpsi
 
-omit [CompleteSpace X] in
-/-- **The generator difference quotient, based at `s`.** The defining quotient of `T.generator` at
-`y`, reparametrised so that it approaches `s` from the right rather than `0`. -/
-private theorem tendsto_generator_diff_quotient {T : StronglyContinuousSemigroup X} {y a : X}
-    (hy : y ∈ T.generator.domain) (hTa : T.generator ⟨y, hy⟩ = a) (s : ℝ) :
-    Tendsto (fun u : ℝ => (u - s)⁻¹ • (T.realOperator (u - s) y - y)) (𝓝[>] s) (𝓝 a) := by
-  have hyT : y ∈ T.domain := by rwa [T.generator_domain] at hy
-  have hshift : Tendsto (fun u : ℝ => u - s) (𝓝[>] s) (𝓝[>] 0) :=
-    tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
-      ((Continuous.tendsto' (by fun_prop) s 0 (by simp)).mono_left nhdsWithin_le_nhds)
-      (eventually_nhdsWithin_of_forall fun x hx => Set.mem_Ioi.mpr (sub_pos.mpr hx))
-  simpa [Function.comp_def, one_div, hTa] using (T.generator_tendsto ⟨y, hyT⟩).comp hshift
-
-omit [CompleteSpace X] in
-/-- **The slope of the interpolation splits.** Using the semigroup law to rebase `T u x` at `s`,
-the difference quotient of `u ↦ S (t - u) (T u x)` separates into the contribution of the inner
-semigroup `T`, pushed through `S (t - u)`, and that of the outer semigroup `S`. -/
-private theorem slope_interpolate_eq {S T : StronglyContinuousSemigroup X} {t : ℝ} {x : X}
-    {s : ℝ} (hs0 : 0 ≤ s) {u : ℝ} (hu : s ≤ u) :
-    slope (fun u : ℝ => S.realOperator (t - u) (T.realOperator u x)) s u
-      = S.realOperator (t - u)
-          ((u - s)⁻¹ • (T.realOperator (u - s) (T.realOperator s x) - T.realOperator s x))
-        + slope (fun u : ℝ => S.realOperator (t - u) (T.realOperator s x)) s u := by
-  have hus : 0 ≤ u - s := sub_nonneg.mpr hu
-  have hTu : T.realOperator u x = T.realOperator (u - s) (T.realOperator s x) := by
-    rw [← ContinuousLinearMap.comp_apply, ← T.realOperator_add (u - s) s hus hs0, sub_add_cancel]
-  simp only [slope_def_module, hTu, map_smul, map_sub, smul_sub]
-  abel
-
-/-- **The two contributions cancel.** Given the inner difference quotient converging to `a` and the
-outer backwards orbit differentiating to `-S (t - s) a`, the interpolation has vanishing right
-derivative: pushing the first through `S (t - u)` produces `S (t - s) a`, cancelling the second. -/
-private theorem hasDerivWithinAt_interpolate_of_tendsto {S T : StronglyContinuousSemigroup X}
-    {t s : ℝ} {x y a : X} (hrpos : 0 < t - s) (hs0 : 0 ≤ s) (hy : T.realOperator s x = y)
-    (hquot : Tendsto (fun u : ℝ => (u - s)⁻¹ • (T.realOperator (u - s) y - y)) (𝓝[>] s) (𝓝 a))
-    (hrho : HasDerivAt (fun u : ℝ => S.realOperator (t - u) y) (-(S.realOperator (t - s) a)) s) :
-    HasDerivWithinAt (fun u : ℝ => S.realOperator (t - u) (T.realOperator u x)) 0
-      (Set.Ici s) s := by
-  subst hy
-  have htime : Tendsto (fun u : ℝ => t - u) (𝓝[>] s) (𝓝 (t - s)) :=
-    ((continuous_sub_left t).tendsto s).mono_left nhdsWithin_le_nhds
-  have hterm1 : Tendsto (fun u : ℝ => S.realOperator (t - u)
+/-- **The two contributions cancel.** Along a time reparametrisation `f`, right-continuous at `s`
+and nonnegative near `s`, if the rebased generator quotient of `T` at `T s x` converges to `a` and
+`u ↦ S (f u) (T s x)` has right derivative `-(S (f s) a)` at `s`, then the composite orbit
+`u ↦ S (f u) (T u x)` has right derivative `0` at `s`: pushing the quotient through `S (f u)`
+produces `S (f s) a`, cancelling the other derivative. -/
+theorem hasDerivWithinAt_realOperator_apply_realOperator_zero
+    (S T : StronglyContinuousSemigroup X) {f : ℝ → ℝ} {x a : X} {s : ℝ} (hs : 0 ≤ s)
+    (hf : Tendsto f (𝓝[>] s) (𝓝 (f s))) (hf0 : ∀ᶠ u in 𝓝[>] s, 0 ≤ f u)
+    (hquot : Tendsto (fun u : ℝ =>
+      (u - s)⁻¹ • (T.realOperator (u - s) (T.realOperator s x) - T.realOperator s x))
+      (𝓝[>] s) (𝓝 a))
+    (hslope : HasDerivWithinAt (fun u : ℝ => S.realOperator (f u) (T.realOperator s x))
+      (-(S.realOperator (f s) a)) (Set.Ici s) s) :
+    HasDerivWithinAt (fun u : ℝ => S.realOperator (f u) (T.realOperator u x)) 0 (Set.Ici s) s := by
+  have hfs : 0 ≤ f s := ge_of_tendsto hf hf0
+  have hterm1 : Tendsto (fun u : ℝ => S.realOperator (f u)
       ((u - s)⁻¹ • (T.realOperator (u - s) (T.realOperator s x) - T.realOperator s x)))
-      (𝓝[>] s) (𝓝 (S.realOperator (t - s) a)) :=
-    S.tendsto_realOperator_apply htime
-      ((htime.eventually_const_lt hrpos).mono fun _ h => h.le) hrpos.le hquot
-  have hterm2 : Tendsto (slope (fun u : ℝ => S.realOperator (t - u) (T.realOperator s x)) s)
-      (𝓝[>] s) (𝓝 (-(S.realOperator (t - s) a))) :=
-    hrho.tendsto_slope.mono_left (nhdsWithin_mono s fun _ hu => hu.ne')
-  rw [hasDerivWithinAt_iff_tendsto_slope, Set.Ici_sdiff_left]
-  have hsum := hterm1.add hterm2
-  rw [add_neg_cancel] at hsum
-  exact hsum.congr' (by
-    filter_upwards [self_mem_nhdsWithin] with u hu using (slope_interpolate_eq hs0 hu.le).symm)
+      (𝓝[>] s) (𝓝 (S.realOperator (f s) a)) :=
+    S.tendsto_realOperator_apply hf hf0 hfs hquot
+  have h := T.hasDerivWithinAt_apply_realOperator_of_tendsto (fun u => S.realOperator (f u)) x hs
+    hterm1 hslope
+  rwa [add_neg_cancel] at h
 
 /-- The interpolation `u ↦ S (t - u) (T u x)` between the two semigroups has vanishing right
 derivative at every `u ∈ [0, t)`.
@@ -152,7 +126,7 @@ private theorem hasDerivWithinAt_interpolate {S T : StronglyContinuousSemigroup 
   have hdom : S.domain = T.domain := by
     rw [← S.generator_domain, ← T.generator_domain, hgen]
   have hrpos : (0 : ℝ) < t - s := sub_pos.mpr hst
-  set y : X := T.realOperator s x with hy_def
+  set y : X := T.realOperator s x
   have hyT : y ∈ T.domain := T.realOperator_mem_domain hs0 hx
   have hyT' : y ∈ T.generator.domain := by rw [T.generator_domain]; exact hyT
   have hyS' : y ∈ S.generator.domain := by rw [S.generator_domain, hdom]; exact hyT
@@ -164,37 +138,46 @@ private theorem hasDerivWithinAt_interpolate {S T : StronglyContinuousSemigroup 
     hasDerivAt_realOperator_sub hrpos hyS' hSa
   -- The inner factor: the defining difference quotient of the generator of `T` at `y`.
   have hquot : Tendsto (fun u : ℝ => (u - s)⁻¹ • (T.realOperator (u - s) y - y))
-      (𝓝[>] s) (𝓝 a) := tendsto_generator_diff_quotient hyT' rfl s
-  exact hasDerivWithinAt_interpolate_of_tendsto hrpos hs0 hy_def.symm hquot hrho
+      (𝓝[>] s) (𝓝 a) := T.generator_tendsto_comp_sub_const ⟨y, hyT⟩ s
+  have htime : Tendsto (fun u : ℝ => t - u) (𝓝[>] s) (𝓝 (t - s)) :=
+    ((continuous_sub_left t).tendsto s).mono_left nhdsWithin_le_nhds
+  exact S.hasDerivWithinAt_realOperator_apply_realOperator_zero T (f := fun u => t - u) hs0 htime
+    ((htime.eventually_const_lt hrpos).mono fun _ h => h.le) hquot hrho.hasDerivWithinAt
+
+/-- **A composite orbit with vanishing right derivative is constant.** If `u ↦ S (f u) (T u x)` has
+right derivative `0` on `[0, t)`, with `f` continuous and nonnegative on `[0, t]`, then its value
+at `t` is its value at `0`, namely `S (f 0) x`. -/
+theorem realOperator_apply_realOperator_eq_of_hasDerivWithinAt_zero
+    (S T : StronglyContinuousSemigroup X) {f : ℝ → ℝ} {x : X} {t : ℝ} (ht : 0 ≤ t)
+    (hf : ContinuousOn f (Set.Icc 0 t)) (hf0 : ∀ u ∈ Set.Icc (0 : ℝ) t, 0 ≤ f u)
+    (hderiv : ∀ u ∈ Set.Ico (0 : ℝ) t,
+      HasDerivWithinAt (fun v : ℝ => S.realOperator (f v) (T.realOperator v x)) 0
+        (Set.Ici u) u) :
+    S.realOperator (f t) (T.realOperator t x) = S.realOperator (f 0) x := by
+  have hcont : ContinuousOn (fun u : ℝ => S.realOperator (f u) (T.realOperator u x))
+      (Set.Icc 0 t) :=
+    S.continuousOn_realOperator_apply hf hf0
+      ((T.realOperator_continuousOn_Ici x).mono fun u hu => hu.1)
+  have heq := constant_of_has_deriv_right_zero hcont hderiv t (Set.right_mem_Icc.mpr ht)
+  simpa only [T.realOperator_zero_apply] using heq
 
 /-- Two strongly continuous semigroups with the same generator agree on the generator domain,
 at every nonnegative time. -/
 theorem realOperator_eq_of_generator_eq {S T : StronglyContinuousSemigroup X}
     (hgen : S.generator = T.generator) {t : ℝ} (ht : 0 ≤ t) {x : X} (hx : x ∈ T.domain) :
     S.realOperator t x = T.realOperator t x := by
-  have hcont : ContinuousOn (fun u : ℝ => S.realOperator (t - u) (T.realOperator u x))
-      (Set.Icc 0 t) :=
-    S.continuousOn_realOperator_apply (continuous_sub_left t).continuousOn
-      (fun u hu => sub_nonneg.mpr hu.2)
-      ((T.realOperator_continuousOn_Ici x).mono fun u hu => hu.1)
-  have hderiv : ∀ u ∈ Set.Ico (0 : ℝ) t,
-      HasDerivWithinAt (fun u : ℝ => S.realOperator (t - u) (T.realOperator u x)) 0
-        (Set.Ici u) u :=
+  have h := S.realOperator_apply_realOperator_eq_of_hasDerivWithinAt_zero T (f := fun u => t - u)
+    ht (continuous_sub_left t).continuousOn (fun u hu => sub_nonneg.mpr hu.2)
     fun _ hu => hasDerivWithinAt_interpolate hgen hx hu.1 hu.2
-  have heq := constant_of_has_deriv_right_zero hcont hderiv t (Set.right_mem_Icc.mpr ht)
-  simp only [sub_self, sub_zero, S.realOperator_zero_apply, T.realOperator_zero_apply] at heq
-  exact heq.symm
+  simpa only [sub_self, sub_zero, S.realOperator_zero_apply] using h.symm
 
 /-- **The generator determines the semigroup**: two strongly continuous semigroups on a real
 Banach space with the same infinitesimal generator are equal ([EN] Thm. II.1.4). -/
 theorem eq_of_generator_eq {S T : StronglyContinuousSemigroup X}
     (hgen : S.generator = T.generator) : S = T := by
   refine StronglyContinuousSemigroup.ext fun τ => ?_
-  refine ContinuousLinearMap.ext_on (R₁ := ℝ) (s := (T.domain : Set X)) ?_ ?_
-  · rw [Submodule.span_eq]
-    exact T.dense_domain
-  · intro x hx
-    simpa using realOperator_eq_of_generator_eq hgen τ.coe_nonneg hx
+  refine T.eq_of_eqOn_domain fun x hx => ?_
+  simpa using realOperator_eq_of_generator_eq hgen τ.coe_nonneg hx
 
 /-- The infinitesimal generator is injective on strongly continuous semigroups. -/
 theorem generator_injective :

--- a/TauCeti/Analysis/Semigroups/Generator/Uniqueness.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Uniqueness.lean
@@ -37,12 +37,13 @@ operator `A` is `t ↦ exp (t • A)` (`TauCeti/Analysis/Semigroups/BoundedGener
 
 ## Main results
 
-* `hasDerivWithinAt_realOperator_apply_realOperator_zero` (in the
-  `TauCeti.Semigroups.StronglyContinuousSemigroup` namespace): a composite orbit
-  `u ↦ S (f u) (T u x)` has vanishing right derivative when the generator contribution of `T`
-  cancels the derivative of `u ↦ S (f u) (T s x)`.
-* `realOperator_apply_realOperator_eq_of_hasDerivWithinAt_zero` (same namespace): a composite
-  orbit with vanishing right derivative on `[0, t)` has value `S (f 0) x` at `t`.
+* `hasDerivWithinAt_realOperator_apply_realOperator` (in the
+  `TauCeti.Semigroups.StronglyContinuousSemigroup` namespace): the right derivative of a composite
+  orbit `u ↦ S (f u) (T u x)` is the generator contribution of `T`, pushed through `S (f s)`, plus
+  the derivative of `u ↦ S (f u) (T s x)`.
+* `realOperator_apply_eq_of_hasDerivWithinAt_zero` (same namespace): a path
+  `u ↦ S (f u) (g u)` with vanishing right derivative on `[0, t)` has the same value at `t` and at
+  `0`.
 * `TauCeti.Semigroups.StronglyContinuousSemigroup.realOperator_eq_of_generator_eq`: two
   semigroups with the same generator agree on the generator domain.
 * `TauCeti.Semigroups.StronglyContinuousSemigroup.eq_of_generator_eq` and
@@ -89,28 +90,23 @@ private theorem hasDerivAt_realOperator_sub {S : StronglyContinuousSemigroup X} 
     exact h.hasDerivAt (Ici_mem_nhds hrpos)
   exact HasDerivAt.comp_const_sub t s hpsi
 
-/-- **The two contributions cancel.** Along a time reparametrisation `f`, right-continuous at `s`
-and nonnegative near `s`, if the rebased generator quotient of `T` at `T s x` converges to `a` and
-`u ↦ S (f u) (T s x)` has right derivative `-(S (f s) a)` at `s`, then the composite orbit
-`u ↦ S (f u) (T u x)` has right derivative `0` at `s`: pushing the quotient through `S (f u)`
-produces `S (f s) a`, cancelling the other derivative. -/
-theorem hasDerivWithinAt_realOperator_apply_realOperator_zero
-    (S T : StronglyContinuousSemigroup X) {f : ℝ → ℝ} {x a : X} {s : ℝ} (hs : 0 ≤ s)
+/-- **Differentiating a composite orbit.** Along a time reparametrisation `f`, right-continuous at
+`s` and nonnegative near `s`, if the rebased generator quotient of `T` at `T s x` converges to `a`
+and `u ↦ S (f u) (T s x)` has right derivative `c` at `s`, then the composite orbit
+`u ↦ S (f u) (T u x)` has right derivative `S (f s) a + c` at `s`: pushing the quotient through
+`S (f u)` produces `S (f s) a`. -/
+theorem hasDerivWithinAt_realOperator_apply_realOperator
+    (S T : StronglyContinuousSemigroup X) {f : ℝ → ℝ} {x a c : X} {s : ℝ} (hs : 0 ≤ s)
     (hf : Tendsto f (𝓝[>] s) (𝓝 (f s))) (hf0 : ∀ᶠ u in 𝓝[>] s, 0 ≤ f u)
     (hquot : Tendsto (fun u : ℝ =>
       (u - s)⁻¹ • (T.realOperator (u - s) (T.realOperator s x) - T.realOperator s x))
       (𝓝[>] s) (𝓝 a))
-    (hslope : HasDerivWithinAt (fun u : ℝ => S.realOperator (f u) (T.realOperator s x))
-      (-(S.realOperator (f s) a)) (Set.Ici s) s) :
-    HasDerivWithinAt (fun u : ℝ => S.realOperator (f u) (T.realOperator u x)) 0 (Set.Ici s) s := by
-  have hfs : 0 ≤ f s := ge_of_tendsto hf hf0
-  have hterm1 : Tendsto (fun u : ℝ => S.realOperator (f u)
-      ((u - s)⁻¹ • (T.realOperator (u - s) (T.realOperator s x) - T.realOperator s x)))
-      (𝓝[>] s) (𝓝 (S.realOperator (f s) a)) :=
-    S.tendsto_realOperator_apply hf hf0 hfs hquot
-  have h := T.hasDerivWithinAt_apply_realOperator_of_tendsto (fun u => S.realOperator (f u)) x hs
-    hterm1 hslope
-  rwa [add_neg_cancel] at h
+    (hslope : HasDerivWithinAt (fun u : ℝ => S.realOperator (f u) (T.realOperator s x)) c
+      (Set.Ici s) s) :
+    HasDerivWithinAt (fun u : ℝ => S.realOperator (f u) (T.realOperator u x))
+      (S.realOperator (f s) a + c) (Set.Ici s) s :=
+  T.hasDerivWithinAt_apply_realOperator_of_tendsto (fun u => S.realOperator (f u)) x hs
+    (S.tendsto_realOperator_apply hf hf0 (ge_of_tendsto hf hf0) hquot) hslope
 
 /-- The interpolation `u ↦ S (t - u) (T u x)` between the two semigroups has vanishing right
 derivative at every `u ∈ [0, t)`.
@@ -141,42 +137,41 @@ private theorem hasDerivWithinAt_interpolate {S T : StronglyContinuousSemigroup 
       (𝓝[>] s) (𝓝 a) := T.generator_tendsto_comp_sub_const ⟨y, hyT⟩ s
   have htime : Tendsto (fun u : ℝ => t - u) (𝓝[>] s) (𝓝 (t - s)) :=
     ((continuous_sub_left t).tendsto s).mono_left nhdsWithin_le_nhds
-  exact S.hasDerivWithinAt_realOperator_apply_realOperator_zero T (f := fun u => t - u) hs0 htime
-    ((htime.eventually_const_lt hrpos).mono fun _ h => h.le) hquot hrho.hasDerivWithinAt
+  simpa only [add_neg_cancel] using
+    S.hasDerivWithinAt_realOperator_apply_realOperator T (f := fun u => t - u) hs0 htime
+      ((htime.eventually_const_lt hrpos).mono fun _ h => h.le) hquot hrho.hasDerivWithinAt
 
-/-- **A composite orbit with vanishing right derivative is constant.** If `u ↦ S (f u) (T u x)` has
-right derivative `0` on `[0, t)`, with `f` continuous and nonnegative on `[0, t]`, then its value
-at `t` is its value at `0`, namely `S (f 0) x`. -/
-theorem realOperator_apply_realOperator_eq_of_hasDerivWithinAt_zero
-    (S T : StronglyContinuousSemigroup X) {f : ℝ → ℝ} {x : X} {t : ℝ} (ht : 0 ≤ t)
+/-- **A path with vanishing right derivative is constant.** If `u ↦ S (f u) (g u)` has right
+derivative `0` on `[0, t)`, with `f` continuous and nonnegative and `g` continuous on `[0, t]`,
+then its value at `t` is its value at `0`. -/
+theorem realOperator_apply_eq_of_hasDerivWithinAt_zero
+    (S : StronglyContinuousSemigroup X) {f : ℝ → ℝ} {g : ℝ → X} {t : ℝ} (ht : 0 ≤ t)
     (hf : ContinuousOn f (Set.Icc 0 t)) (hf0 : ∀ u ∈ Set.Icc (0 : ℝ) t, 0 ≤ f u)
+    (hg : ContinuousOn g (Set.Icc 0 t))
     (hderiv : ∀ u ∈ Set.Ico (0 : ℝ) t,
-      HasDerivWithinAt (fun v : ℝ => S.realOperator (f v) (T.realOperator v x)) 0
-        (Set.Ici u) u) :
-    S.realOperator (f t) (T.realOperator t x) = S.realOperator (f 0) x := by
-  have hcont : ContinuousOn (fun u : ℝ => S.realOperator (f u) (T.realOperator u x))
-      (Set.Icc 0 t) :=
-    S.continuousOn_realOperator_apply hf hf0
-      ((T.realOperator_continuousOn_Ici x).mono fun u hu => hu.1)
-  have heq := constant_of_has_deriv_right_zero hcont hderiv t (Set.right_mem_Icc.mpr ht)
-  simpa only [T.realOperator_zero_apply] using heq
+      HasDerivWithinAt (fun v : ℝ => S.realOperator (f v) (g v)) 0 (Set.Ici u) u) :
+    S.realOperator (f t) (g t) = S.realOperator (f 0) (g 0) :=
+  constant_of_has_deriv_right_zero (S.continuousOn_realOperator_apply hf hf0 hg) hderiv t
+    (Set.right_mem_Icc.mpr ht)
 
 /-- Two strongly continuous semigroups with the same generator agree on the generator domain,
 at every nonnegative time. -/
 theorem realOperator_eq_of_generator_eq {S T : StronglyContinuousSemigroup X}
     (hgen : S.generator = T.generator) {t : ℝ} (ht : 0 ≤ t) {x : X} (hx : x ∈ T.domain) :
     S.realOperator t x = T.realOperator t x := by
-  have h := S.realOperator_apply_realOperator_eq_of_hasDerivWithinAt_zero T (f := fun u => t - u)
-    ht (continuous_sub_left t).continuousOn (fun u hu => sub_nonneg.mpr hu.2)
+  have h := S.realOperator_apply_eq_of_hasDerivWithinAt_zero (f := fun u => t - u)
+    (g := fun u => T.realOperator u x) ht (continuous_sub_left t).continuousOn
+    (fun u hu => sub_nonneg.mpr hu.2) ((T.realOperator_continuousOn_Ici x).mono fun u hu => hu.1)
     fun _ hu => hasDerivWithinAt_interpolate hgen hx hu.1 hu.2
-  simpa only [sub_self, sub_zero, S.realOperator_zero_apply] using h.symm
+  simpa only [sub_self, sub_zero, S.realOperator_zero_apply, T.realOperator_zero_apply] using
+    h.symm
 
 /-- **The generator determines the semigroup**: two strongly continuous semigroups on a real
 Banach space with the same infinitesimal generator are equal ([EN] Thm. II.1.4). -/
 theorem eq_of_generator_eq {S T : StronglyContinuousSemigroup X}
     (hgen : S.generator = T.generator) : S = T := by
   refine StronglyContinuousSemigroup.ext fun τ => ?_
-  refine T.eq_of_eqOn_domain fun x hx => ?_
+  refine T.continuousLinearMap_ext_of_eqOn_domain fun x hx => ?_
   simpa using realOperator_eq_of_generator_eq hgen τ.coe_nonneg hx
 
 /-- The infinitesimal generator is injective on strongly continuous semigroups. -/

--- a/TauCeti/Analysis/Semigroups/Generator/Uniqueness.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Uniqueness.lean
@@ -42,8 +42,7 @@ operator `A` is `t ↦ exp (t • A)` (`TauCeti/Analysis/Semigroups/BoundedGener
   orbit `u ↦ S (f u) (T u x)` is the generator contribution of `T`, pushed through `S (f s)`, plus
   the derivative of `u ↦ S (f u) (T s x)`.
 * `realOperator_apply_eq_of_hasDerivWithinAt_zero` (same namespace): a path
-  `u ↦ S (f u) (g u)` with vanishing right derivative on `[0, t)` has the same value at `t` and at
-  `0`.
+  `u ↦ S (f u) (g u)` with vanishing right derivative on `[0, t)` is constant on `[0, t]`.
 * `TauCeti.Semigroups.StronglyContinuousSemigroup.realOperator_eq_of_generator_eq`: two
   semigroups with the same generator agree on the generator domain.
 * `TauCeti.Semigroups.StronglyContinuousSemigroup.eq_of_generator_eq` and
@@ -143,16 +142,15 @@ private theorem hasDerivWithinAt_interpolate {S T : StronglyContinuousSemigroup 
 
 /-- **A path with vanishing right derivative is constant.** If `u ↦ S (f u) (g u)` has right
 derivative `0` on `[0, t)`, with `f` continuous and nonnegative and `g` continuous on `[0, t]`,
-then its value at `t` is its value at `0`. -/
+then it is constant on `[0, t]`, with value `S (f 0) (g 0)`. -/
 theorem realOperator_apply_eq_of_hasDerivWithinAt_zero
-    (S : StronglyContinuousSemigroup X) {f : ℝ → ℝ} {g : ℝ → X} {t : ℝ} (ht : 0 ≤ t)
+    (S : StronglyContinuousSemigroup X) {f : ℝ → ℝ} {g : ℝ → X} {t : ℝ}
     (hf : ContinuousOn f (Set.Icc 0 t)) (hf0 : ∀ u ∈ Set.Icc (0 : ℝ) t, 0 ≤ f u)
     (hg : ContinuousOn g (Set.Icc 0 t))
     (hderiv : ∀ u ∈ Set.Ico (0 : ℝ) t,
       HasDerivWithinAt (fun v : ℝ => S.realOperator (f v) (g v)) 0 (Set.Ici u) u) :
-    S.realOperator (f t) (g t) = S.realOperator (f 0) (g 0) :=
-  constant_of_has_deriv_right_zero (S.continuousOn_realOperator_apply hf hf0 hg) hderiv t
-    (Set.right_mem_Icc.mpr ht)
+    ∀ u ∈ Set.Icc (0 : ℝ) t, S.realOperator (f u) (g u) = S.realOperator (f 0) (g 0) :=
+  constant_of_has_deriv_right_zero (S.continuousOn_realOperator_apply hf hf0 hg) hderiv
 
 /-- Two strongly continuous semigroups with the same generator agree on the generator domain,
 at every nonnegative time. -/
@@ -160,9 +158,9 @@ theorem realOperator_eq_of_generator_eq {S T : StronglyContinuousSemigroup X}
     (hgen : S.generator = T.generator) {t : ℝ} (ht : 0 ≤ t) {x : X} (hx : x ∈ T.domain) :
     S.realOperator t x = T.realOperator t x := by
   have h := S.realOperator_apply_eq_of_hasDerivWithinAt_zero (f := fun u => t - u)
-    (g := fun u => T.realOperator u x) ht (continuous_sub_left t).continuousOn
+    (g := fun u => T.realOperator u x) (continuous_sub_left t).continuousOn
     (fun u hu => sub_nonneg.mpr hu.2) ((T.realOperator_continuousOn_Ici x).mono fun u hu => hu.1)
-    fun _ hu => hasDerivWithinAt_interpolate hgen hx hu.1 hu.2
+    (fun _ hu => hasDerivWithinAt_interpolate hgen hx hu.1 hu.2) t (Set.right_mem_Icc.mpr ht)
   simpa only [sub_self, sub_zero, S.realOperator_zero_apply, T.realOperator_zero_apply] using
     h.symm
 

--- a/TauCeti/Analysis/Semigroups/Resolvent/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Basic.lean
@@ -208,10 +208,7 @@ private theorem StronglyContinuousSemigroup.resolvent_shift_identity
         (S.realOperator h) (f t) = Real.exp (lambda * h) • f (t + h) := by
       intro t ht
       simp only [f, ContinuousLinearMap.map_smul]
-      have h_time_add_comm : h + t = t + h := add_comm h t
-      rw [← ContinuousLinearMap.comp_apply,
-          ← S.realOperator_add h t (le_of_lt hh) (le_of_lt (Set.mem_Ioi.mp ht)),
-          h_time_add_comm]
+      rw [← S.realOperator_add_apply h t (le_of_lt hh) (le_of_lt (Set.mem_Ioi.mp ht)), add_comm]
       symm; rw [← mul_smul, ← Real.exp_add]; congr 1; ring_nf
     rw [MeasureTheory.setIntegral_congr_fun measurableSet_Ioi h_eq]
     rw [integral_smul (μ := volume.restrict (Set.Ioi (0 : ℝ)))]


### PR DESCRIPTION
This PR is a prerequisite refactor with no new mathematics: six steps of the generator-uniqueness proof in `Analysis/Semigroups/Generator/Uniqueness.lean` become public API, stated at the level their proofs support, and the uniqueness proof uses the shared declarations.

* `StronglyContinuousSemigroup.generator_tendsto_comp_sub_const` (`Generator/Basic.lean`, directly after its base-`0` sibling `generator_tendsto`, in the same shape): the defining difference quotient of the generator precomposed with `u ↦ u - s`.
* `StronglyContinuousSemigroup.realOperator_add_apply` (`Semigroups/Basic.lean`, after `realOperator_add`): the pointwise semigroup law `S (s + t) x = S s (S t x)` at nonnegative real times; the five places that unfolded `realOperator_add` through `comp_apply` by hand (three in `Semigroups/Basic.lean`, one in `Resolvent/Basic.lean`, one in `Generator/Basic.lean`) now use it.
* `StronglyContinuousSemigroup.slope_apply_realOperator_eq` (`Generator/OrbitDerivative.lean`, directly above its consumer): the slope of `u ↦ F u (S u x)` splits by the semigroup law, for any operator family `F`, at nonnegative times `0 ≤ s ≤ u`.
* `StronglyContinuousSemigroup.hasDerivWithinAt_apply_realOperator_of_tendsto` (`Generator/OrbitDerivative.lean`): the right derivative of `u ↦ F u (S u x)` at a nonnegative time, from the limit of the pushed rebased quotient and the right derivative of `u ↦ F u (S s x)`. The orbit-derivative lemma `realOperator_hasDerivWithinAt`, which re-proved the rebasing by hand, is now its `F ≡ id` instance (with `hasDerivWithinAt_const`).
* `StronglyContinuousSemigroup.hasDerivWithinAt_realOperator_apply_realOperator` (`Generator/Uniqueness.lean`): the sum rule for a composite orbit along a time reparametrisation `f`: if the rebased generator quotient of `T` converges to `a` and `u ↦ S (f u) (T s x)` has right derivative `c`, then `u ↦ S (f u) (T u x)` has right derivative `S (f s) a + c` (the uniqueness proof takes `c = -(S (f s) a)`).
* `StronglyContinuousSemigroup.realOperator_apply_eq_of_hasDerivWithinAt_zero` (`Generator/Uniqueness.lean`): a path `u ↦ S (f u) (g u)` with vanishing right derivative on `[0, t)`, for continuous `g`, is constant on `[0, t]` with value `S (f 0) (g 0)` (the uniqueness proof takes `g u = T u x` and evaluates at `t`).
* `StronglyContinuousSemigroup.continuousLinearMap_ext_of_eqOn_domain` (`Generator/Basic.lean`, after `dense_domain`): continuous linear maps that agree on the generator domain are equal.

Also, `generator_tendsto_comp_sub_const` obtains the translated right-neighbourhood filter from Mathlib's `Filter.map_subRight_nhdsGT` instead of by hand.

Motivation: the uniqueness proof takes `F u = S' (t - u)` for a second semigroup `S'`; the follow-up PR proving that two semigroups whose generators are negatives of one another have mutually inverse operators takes `F u = S' u` and uses all of them with `f u = u` (the inverse hypotheses of `StronglyContinuousSemigroup.toGroupOfInverse` from #5669, on the way to Stone's theorem, `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A, "C₀ groups as a stretch"). Per the one-topic rule the extraction ships on its own first.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"generator-uniqueness-shared-helpers"}-->

🤖 Prepared with Claude Code
