### PR TITLE
refactor(LinearAlgebra): lift the Smith-normal-form algebra out of AtkinLehner

### DIFF
--- a/TauCeti/Data/Int/Fin2Tuple.lean
+++ b/TauCeti/Data/Int/Fin2Tuple.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.EuclideanDomain.Int
+public import Mathlib.Data.Int.GCD
+
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Fintype.Fin
+import Mathlib.Tactic.FinCases
+
+/-!
+# Two-entry integer tuples
+
+Arithmetic of `Fin 2 → ℤ`. Nothing here involves matrices; the results are stated for tuples
+so that callers holding a diagonal, a pair of invariant factors, or any other two integers can
+use them without dragging in linear algebra.
+
+## Main results
+
+* `Int.eq_of_dvd_of_dvd_of_mul_eq_mul`: two tuples with positive, mutually dividing first
+  entries and equal products are equal.
+-/
+
+namespace Int
+
+public section
+
+/-- **Two `Fin 2 → ℤ` tuples with positive, mutually dividing first entries and equal products
+are equal.** The first entries agree by antisymmetry of divisibility among positives, and the
+second is then pinned by cancelling the first out of the product.
+
+Only the *first* entries are assumed positive; the second may be negative or zero. -/
+theorem eq_of_dvd_of_dvd_of_mul_eq_mul {a b : Fin 2 → ℤ}
+    (ha0_pos : 0 < a 0) (hb0_pos : 0 < b 0) (hab : a 0 ∣ b 0) (hba : b 0 ∣ a 0)
+    (hprod : a 0 * a 1 = b 0 * b 1) : a = b := by
+  have h0 : a 0 = b 0 :=
+    le_antisymm (Int.le_of_dvd hb0_pos hab) (Int.le_of_dvd ha0_pos hba)
+  have h1 : a 1 = b 1 :=
+    mul_left_cancel₀ (ne_of_gt ha0_pos) (by rw [hprod, h0])
+  funext i
+  fin_cases i <;> assumption
+
+end
+
+end Int

--- a/TauCeti/Data/Int/Fin2Tuple.lean
+++ b/TauCeti/Data/Int/Fin2Tuple.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Algebra.EuclideanDomain.Int
 
-import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Fintype.Fin
 import Mathlib.Tactic.FinCases
 

--- a/TauCeti/Data/Int/Fin2Tuple.lean
+++ b/TauCeti/Data/Int/Fin2Tuple.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.EuclideanDomain.Int
-public import Mathlib.Data.Int.GCD
 
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Fintype.Fin

--- a/TauCeti/Data/Int/Fin2Tuple.lean
+++ b/TauCeti/Data/Int/Fin2Tuple.lean
@@ -23,6 +23,15 @@ use them without dragging in linear algebra.
 
 * `Int.eq_of_dvd_of_dvd_of_mul_eq_mul`: two tuples with positive, mutually dividing first
   entries and equal products are equal.
+
+## Provenance
+
+Adapted from [AINTLIB](https://github.com/CBirkbeck/AINTLIB) (Chris Birkbeck), Apache-2.0, at
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, from
+`LeanModularForms/HeckeRIngs/GLn/CongruenceHecke/AtkinLehner.lean`. The source's
+`snf_mutual_dvd_eq` draws the same conclusion from Smith-normal-form data and routes through
+`smith_normal_form_unique`; `Int.eq_of_dvd_of_dvd_of_mul_eq_mul` keeps none of those matrix
+hypotheses and does not use it.
 -/
 
 namespace Int

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Equivalence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Equivalence.lean
@@ -7,8 +7,6 @@ module
 
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
-import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
-
 /-!
 # Two-sided invertible equivalence of matrices
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Equivalence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Equivalence.lean
@@ -16,10 +16,11 @@ semiring.
 
 ## Main results
 
-* `Matrix.inv_mul_mul_inv_of_mul_mul_eq`: inverting a two-sided invertible transformation.
+* `Matrix.GeneralLinearGroup.inv_mul_mul_inv_of_mul_mul_eq`: inverting a two-sided
+  invertible transformation.
 -/
 
-namespace Matrix
+namespace Matrix.GeneralLinearGroup
 
 variable {ι κ : Type*} [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
 
@@ -43,4 +44,4 @@ theorem inv_mul_mul_inv_of_mul_mul_eq {S : Type*} [Semiring S]
 
 end
 
-end Matrix
+end Matrix.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Equivalence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Equivalence.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+
+/-!
+# Two-sided invertible equivalence of matrices
+
+Matrices related by `L * A * R` with `L` and `R` invertible. Rows and columns are transformed
+independently, so the two index types are separate, and nothing here needs more than a
+semiring.
+
+## Main results
+
+* `Matrix.inv_mul_mul_inv_of_mul_mul_eq`: inverting a two-sided invertible transformation.
+-/
+
+namespace Matrix
+
+variable {ι κ : Type*} [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
+
+public section
+
+/-- **Inverting a two-sided invertible transformation.** The rows and columns are transformed
+independently, so they need not share an index type. -/
+theorem inv_mul_mul_inv_of_mul_mul_eq {S : Type*} [Semiring S]
+    {A B : Matrix ι κ S} (L : GeneralLinearGroup ι S) (R : GeneralLinearGroup κ S)
+    (h : (L : Matrix ι ι S) * A * (R : Matrix κ κ S) = B) :
+    (↑L⁻¹ : Matrix ι ι S) * B * (↑R⁻¹ : Matrix κ κ S) = A := by
+  -- with the rows and columns indexed separately, the two cancellations are named rather
+  -- than left to `simp`, which no longer matches them across the differing index types
+  have hL : (↑L⁻¹ : Matrix ι ι S) * (L : Matrix ι ι S) = 1 := by
+    rw [← Units.val_mul, inv_mul_cancel, Units.val_one]
+  have hR : (R : Matrix κ κ S) * (↑R⁻¹ : Matrix κ κ S) = 1 := by
+    rw [← Units.val_mul, mul_inv_cancel, Units.val_one]
+  rw [← h]
+  simp only [Matrix.mul_assoc, hR, Matrix.mul_one]
+  rw [← Matrix.mul_assoc, hL, Matrix.one_mul]
+
+end
+
+end Matrix

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -11,7 +11,6 @@ import Mathlib.Algebra.EuclideanDomain.Int
 -- `dvd_mul_mul_apply` and `dvd_diag_of_dvd_entries`, used only inside proofs below.
 import TauCeti.LinearAlgebra.Matrix.Divisibility
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Equivalence
-import TauCeti.Data.Int.Fin2Tuple
 import Mathlib.Data.Int.GCD
 import Mathlib.Basic.Sign.Basic
 import Mathlib.LinearAlgebra.Determinant

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -840,7 +840,7 @@ theorem smith_normal_form_unique {c d : Fin n → ℤ} (hc_pos : ∀ i, 0 ≤ c 
       (R : Matrix (Fin n) (Fin n) ℤ) = Matrix.diagonal d) : c = d := by
   have h' : (↑L⁻¹ : Matrix (Fin n) (Fin n) ℤ) * Matrix.diagonal d *
       (↑R⁻¹ : Matrix (Fin n) (Fin n) ℤ) = Matrix.diagonal c :=
-    inv_mul_mul_inv_of_mul_mul_eq L R h
+    L.inv_mul_mul_inv_of_mul_mul_eq R h
   have key : ∀ k (hk : k ≤ n),
       ∏ j : Fin k, c ⟨j.val, by omega⟩ = ∏ j : Fin k, d ⟨j.val, by omega⟩ := fun k hk ↦
     Int.dvd_antisymm
@@ -898,7 +898,7 @@ theorem invariant_factor_zero_dvd_entries {S : Type*} [CommSemiring S] [NeZero n
     (L R : GeneralLinearGroup (Fin n) S)
     (h : (L : Matrix (Fin n) (Fin n) S) * A * (R : Matrix (Fin n) (Fin n) S) =
       Matrix.diagonal d) (i j : Fin n) : d 0 ∣ A i j := by
-  rw [← inv_mul_mul_inv_of_mul_mul_eq L R h]
+  rw [← L.inv_mul_mul_inv_of_mul_mul_eq R h]
   refine dvd_mul_mul_apply (fun p q ↦ ?_) _ _ i j
   rcases eq_or_ne p q with rfl | hpq
   · simpa using hd0 p

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -10,7 +10,7 @@ public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 import Mathlib.Algebra.EuclideanDomain.Int
 -- `dvd_mul_mul_apply` and `dvd_diag_of_dvd_entries`, used only inside proofs below.
 import TauCeti.LinearAlgebra.Matrix.Divisibility
-import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Equivalence
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Equivalence
 import Mathlib.Data.Int.GCD
 import Mathlib.Basic.Sign.Basic
 import Mathlib.LinearAlgebra.Determinant

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -885,13 +885,7 @@ commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
 divisibility directions privately at `Fin 2` as `snf_first_dvd_entry₂` and
 `dvd_snf_first_of_dvd_entries`, proved by entrywise cofactor algebra; the proofs here are a
 re-derivation at general `n`, where inverting the unimodular factors removes the need for that
-algebra. The source's third lemma `snf_mutual_dvd_eq` is adapted here as
-`Int.eq_of_dvd_of_dvd_of_mul_eq_mul`, which does *not* go through
-`Matrix.smith_normal_form_unique`. The statement here keeps none of the source's matrix
-hypotheses: it is arithmetic on two `Fin 2 → ℤ` tuples, concluding `dA = dB` from positivity
-of the two first entries, their mutual divisibility, and equality of the two products.
-Callers obtain that product equality from `Matrix.prod_eq_det_of_mul_mul_eq_diagonal` together
-with an equality of determinants. -/
+algebra. -/
 
 /-- **The first entry of a chained diagonal form divides every entry.** If
 `L * A * R = diagonal d` with `L`, `R` unimodular and `d 0` dividing every `d k`, then `d 0`

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -11,6 +11,7 @@ import Mathlib.Algebra.EuclideanDomain.Int
 -- `dvd_mul_mul_apply` and `dvd_diag_of_dvd_entries`, used only inside proofs below.
 import TauCeti.LinearAlgebra.Matrix.Divisibility
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Equivalence
+import TauCeti.Data.Int.Fin2Tuple
 import Mathlib.Data.Int.GCD
 import Mathlib.Basic.Sign.Basic
 import Mathlib.LinearAlgebra.Determinant
@@ -885,7 +886,7 @@ divisibility directions privately at `Fin 2` as `snf_first_dvd_entry₂` and
 `dvd_snf_first_of_dvd_entries`, proved by entrywise cofactor algebra; the proofs here are a
 re-derivation at general `n`, where inverting the unimodular factors removes the need for that
 algebra. The source's third lemma `snf_mutual_dvd_eq` is adapted here as
-`Matrix.eq_of_dvd_of_dvd_of_mul_eq_mul`, which does *not* go through
+`Int.eq_of_dvd_of_dvd_of_mul_eq_mul`, which does *not* go through
 `Matrix.smith_normal_form_unique`. The statement here keeps none of the source's matrix
 hypotheses: it is arithmetic on two `Fin 2 → ℤ` tuples, concluding `dA = dB` from positivity
 of the two first entries, their mutual divisibility, and equality of the two products.
@@ -943,22 +944,5 @@ theorem invariant_factor_zero_eq_gcd [NeZero n] (A : Matrix (Fin n) (Fin n) ℤ)
     d 0 = Finset.univ.gcd fun p : Fin n × Fin n ↦ A p.1 p.2 :=
   Int.eq_of_associated_of_nonneg (associated_invariant_factor_zero_gcd A d hd0 L R h) hnonneg
     (Int.nonneg_of_normalize_eq_self Finset.normalize_gcd)
-
-/-- **Two positive `Fin 2` diagonals with mutually dividing first entries and equal products
-are equal.** The first entries agree by antisymmetry, and the second is then pinned by the
-product.
-
-This is the arithmetic behind "equal determinants and mutually dividing first invariant factors
-determine a `2 × 2` diagonal form". No matrix hypothesis appears: callers obtain `hprod` from
-`Matrix.prod_eq_det_of_mul_mul_eq_diagonal` and an equality of determinants. -/
-theorem eq_of_dvd_of_dvd_of_mul_eq_mul {dA dB : Fin 2 → ℤ}
-    (hdA0_pos : 0 < dA 0) (hdB0_pos : 0 < dB 0) (hAB : dA 0 ∣ dB 0) (hBA : dB 0 ∣ dA 0)
-    (hprod : dA 0 * dA 1 = dB 0 * dB 1) : dA = dB := by
-  have hd0 : dA 0 = dB 0 :=
-    le_antisymm (Int.le_of_dvd hdB0_pos hAB) (Int.le_of_dvd hdA0_pos hBA)
-  have hd1 : dA 1 = dB 1 :=
-    mul_left_cancel₀ (ne_of_gt hdA0_pos) (by rw [hprod, hd0])
-  funext i
-  fin_cases i <;> assumption
 
 end Matrix

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -892,10 +892,12 @@ commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
 divisibility directions privately at `Fin 2` as `snf_first_dvd_entry₂` and
 `dvd_snf_first_of_dvd_entries`, proved by entrywise cofactor algebra; the proofs here are a
 re-derivation at general `n`, where inverting the unimodular factors removes the need for that
-algebra. The source's third lemma `snf_mutual_dvd_eq` is **not** ported here: its conclusion follows
-from `Matrix.dvd_diag_of_dvd_entries` applied in both directions together with a determinant
-cancellation — it does *not* go through `Matrix.smith_normal_form_unique` — and it belongs
-with the Atkin–Lehner material that consumes it rather than here. -/
+algebra. The source's third lemma `snf_mutual_dvd_eq` is adapted here as
+`Matrix.diagonal_eq_of_dvd_of_det_eq`. It does *not* go through
+`Matrix.smith_normal_form_unique`: its conclusion follows from `Matrix.dvd_diag_of_dvd_entries`
+applied in both directions together with a determinant cancellation. The statement here is
+weaker in its hypotheses than the source's — it assumes only that the two transforms are
+diagonal, not that they are Smith normal forms, since no divisibility chain is used. -/
 
 /-- **The first entry of a chained diagonal form divides every entry.** If
 `L * A * R = diagonal d` with `L`, `R` unimodular and `d 0` dividing every `d k`, then `d 0`
@@ -949,26 +951,31 @@ theorem invariant_factor_zero_eq_gcd [NeZero n] (A : Matrix (Fin n) (Fin n) ℤ)
   Int.eq_of_associated_of_nonneg (associated_invariant_factor_zero_gcd A d hd0 L R h) hnonneg
     (Int.nonneg_of_normalize_eq_self Finset.normalize_gcd)
 
-/-- **The product of the invariant factors is the determinant.** Both `SLₙ(ℤ)` factors have
-determinant `1`, so taking determinants through a Smith normal form leaves the diagonal. -/
-theorem prod_eq_det_of_smithNormalForm {A : Matrix (Fin n) (Fin n) ℤ}
-    {L R : SpecialLinearGroup (Fin n) ℤ} {d : Fin n → ℤ}
-    (h : (L : Matrix (Fin n) (Fin n) ℤ) * A * (R : Matrix (Fin n) (Fin n) ℤ) =
+/-- **The product of a diagonalisation's diagonal entries is the determinant.** Both `SLₙ`
+factors have determinant `1`, so taking determinants through `L * A * R = diagonal d` leaves
+the product of the diagonal.
+
+No divisibility chain is assumed, so `d` need not be the invariant factors. -/
+theorem prod_eq_det_of_mul_mul_eq_diagonal {S : Type*} [CommRing S]
+    {A : Matrix (Fin n) (Fin n) S} {L R : SpecialLinearGroup (Fin n) S} {d : Fin n → S}
+    (h : (L : Matrix (Fin n) (Fin n) S) * A * (R : Matrix (Fin n) (Fin n) S) =
       Matrix.diagonal d) :
     ∏ i, d i = A.det := by
   have hdet := congrArg Matrix.det h
   simp only [Matrix.det_mul, L.2, R.2, one_mul, mul_one, Matrix.det_diagonal] at hdet
   exact hdet.symm
 
-/-- **For `2 × 2` matrices, mutually dividing first invariant factors and equal determinants
-force equal Smith normal forms.** The first factors agree by antisymmetry, and the second is
-then pinned by the determinant.
+/-- **For `2 × 2` matrices, mutually dividing first diagonal entries and equal determinants
+force equal diagonal forms.** The first entries agree by antisymmetry, and the second is then
+pinned by the determinant.
 
-Stated at `Fin 2` because that is where two invariant factors and a determinant determine the
-diagonal; at larger `n` the intermediate factors are not fixed by these hypotheses. -/
+Only diagonalisations are assumed, not Smith normal forms: no divisibility chain along `dA` or
+`dB` is used. Stated at `Fin 2` because that is where two diagonal entries and a determinant
+determine the diagonal; at larger `n` the intermediate entries are not fixed by these
+hypotheses. -/
 theorem diagonal_eq_of_dvd_of_det_eq {A B : Matrix (Fin 2) (Fin 2) ℤ}
     {LA RA LB RB : SpecialLinearGroup (Fin 2) ℤ} {dA dB : Fin 2 → ℤ}
-    (hdA_pos : ∀ i, 0 < dA i) (hdB_pos : ∀ i, 0 < dB i)
+    (hdA0_pos : 0 < dA 0) (hdB0_pos : 0 < dB 0)
     (hA : (LA : Matrix (Fin 2) (Fin 2) ℤ) * A * (RA : Matrix (Fin 2) (Fin 2) ℤ) =
       Matrix.diagonal dA)
     (hB : (LB : Matrix (Fin 2) (Fin 2) ℤ) * B * (RB : Matrix (Fin 2) (Fin 2) ℤ) =
@@ -976,47 +983,33 @@ theorem diagonal_eq_of_dvd_of_det_eq {A B : Matrix (Fin 2) (Fin 2) ℤ}
     (hAB : dA 0 ∣ dB 0) (hBA : dB 0 ∣ dA 0) (hdet : A.det = B.det) :
     Matrix.diagonal dA = (Matrix.diagonal dB : Matrix (Fin 2) (Fin 2) ℤ) := by
   have hd0 : dA 0 = dB 0 :=
-    le_antisymm (Int.le_of_dvd (hdB_pos 0) hAB) (Int.le_of_dvd (hdA_pos 0) hBA)
+    le_antisymm (Int.le_of_dvd hdB0_pos hAB) (Int.le_of_dvd hdA0_pos hBA)
   have hprodA : dA 0 * dA 1 = A.det := by
-    simpa [Fin.prod_univ_two] using prod_eq_det_of_smithNormalForm hA
+    simpa [Fin.prod_univ_two] using prod_eq_det_of_mul_mul_eq_diagonal hA
   have hprodB : dB 0 * dB 1 = B.det := by
-    simpa [Fin.prod_univ_two] using prod_eq_det_of_smithNormalForm hB
+    simpa [Fin.prod_univ_two] using prod_eq_det_of_mul_mul_eq_diagonal hB
   have hd1 : dA 1 = dB 1 :=
-    mul_left_cancel₀ (ne_of_gt (hdA_pos 0)) (by rw [hprodA, hd0, hprodB, hdet])
+    mul_left_cancel₀ (ne_of_gt hdA0_pos) (by rw [hprodA, hd0, hprodB, hdet])
   congr 1
   funext i
   fin_cases i <;> assumption
 
-/-- **Two matrices with the same Smith normal form are `SLₙ(ℤ)`-equivalent.** Given
-diagonalisations of `A` and `B` whose diagonals agree, the composites `L_B⁻¹ L_A` and
-`R_A R_B⁻¹` carry `A` to `B`.
+/-- **Matrices sharing an `SLₙ`-transform are `SLₙ`-equivalent.** If `L_A A R_A = L_B B R_B`
+then `L_B⁻¹ L_A` and `R_A R_B⁻¹` carry `A` to `B`.
 
-The hypothesis is equality of the diagonal *matrices* rather than of the invariant-factor
-tuples, which is what `smith_normal_form_unique` and the divisibility arguments produce. -/
-theorem exists_SL_mul_mul_eq_of_diagonal_eq {A B : Matrix (Fin n) (Fin n) ℤ}
-    {LA RA LB RB : SpecialLinearGroup (Fin n) ℤ} {dA dB : Fin n → ℤ}
-    (hA : (LA : Matrix (Fin n) (Fin n) ℤ) * A * (RA : Matrix (Fin n) (Fin n) ℤ) =
-      Matrix.diagonal dA)
-    (hB : (LB : Matrix (Fin n) (Fin n) ℤ) * B * (RB : Matrix (Fin n) (Fin n) ℤ) =
-      Matrix.diagonal dB)
-    (hd : Matrix.diagonal dA = (Matrix.diagonal dB : Matrix (Fin n) (Fin n) ℤ)) :
-    ∃ P Q : SpecialLinearGroup (Fin n) ℤ,
-      (P : Matrix (Fin n) (Fin n) ℤ) * A * (Q : Matrix (Fin n) (Fin n) ℤ) = B := by
+Pure group algebra: nothing is assumed about the common value, which need not be diagonal.
+Callers holding two diagonalisations with equal diagonals compose them into this single
+hypothesis. -/
+theorem exists_SL_mul_mul_eq_of_mul_mul_eq {S : Type*} [CommRing S]
+    {A B : Matrix (Fin n) (Fin n) S} {LA RA LB RB : SpecialLinearGroup (Fin n) S}
+    (h : (LA : Matrix (Fin n) (Fin n) S) * A * (RA : Matrix (Fin n) (Fin n) S) =
+      (LB : Matrix (Fin n) (Fin n) S) * B * (RB : Matrix (Fin n) (Fin n) S)) :
+    ∃ P Q : SpecialLinearGroup (Fin n) S,
+      (P : Matrix (Fin n) (Fin n) S) * A * (Q : Matrix (Fin n) (Fin n) S) = B := by
   refine ⟨LB⁻¹ * LA, RA * RB⁻¹, ?_⟩
-  have hLB : (LB⁻¹).val * LB.val = (1 : Matrix (Fin n) (Fin n) ℤ) := by
-    rw [← SpecialLinearGroup.coe_mul, inv_mul_cancel]
-    rfl
-  have hRB : RB.val * (RB⁻¹).val = (1 : Matrix (Fin n) (Fin n) ℤ) := by
-    rw [← SpecialLinearGroup.coe_mul, mul_inv_cancel]
-    rfl
-  calc ((LB⁻¹ * LA : SpecialLinearGroup (Fin n) ℤ) : Matrix (Fin n) (Fin n) ℤ) * A *
-        ((RA * RB⁻¹ : SpecialLinearGroup (Fin n) ℤ) : Matrix (Fin n) (Fin n) ℤ)
-      = (LB⁻¹).val * (LA.val * A * RA.val) * (RB⁻¹).val := by
-        simp only [SpecialLinearGroup.coe_mul, Matrix.mul_assoc]
-    _ = (LB⁻¹).val * Matrix.diagonal dB * (RB⁻¹).val := by rw [hA, hd]
-    _ = (LB⁻¹).val * (LB.val * B * RB.val) * (RB⁻¹).val := by rw [hB]
-    _ = B := by
-        simp only [Matrix.mul_assoc]
-        rw [hRB, Matrix.mul_one, ← Matrix.mul_assoc (LB⁻¹).val, hLB, Matrix.one_mul]
+  -- `simp` normalises the `SLₙ` inverse to `adjugate`; `inv_def` with `det = 1` takes the
+  -- `GLₙ` inverse the same way, so the two sides meet.
+  simpa [SpecialLinearGroup.coe_mul, Matrix.mul_assoc, Matrix.inv_def] using
+    inv_mul_mul_inv_of_mul_mul_eq LB.toGL RB.toGL h.symm
 
 end Matrix

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -885,11 +885,12 @@ divisibility directions privately at `Fin 2` as `snf_first_dvd_entry₂` and
 `dvd_snf_first_of_dvd_entries`, proved by entrywise cofactor algebra; the proofs here are a
 re-derivation at general `n`, where inverting the unimodular factors removes the need for that
 algebra. The source's third lemma `snf_mutual_dvd_eq` is adapted here as
-`Matrix.diagonal_eq_of_dvd_of_det_eq`. It does *not* go through
-`Matrix.smith_normal_form_unique`: its conclusion follows from `Matrix.dvd_diag_of_dvd_entries`
-applied in both directions together with a determinant cancellation. The statement here is
-weaker in its hypotheses than the source's — it assumes only that the two transforms are
-diagonal, not that they are Smith normal forms, since no divisibility chain is used. -/
+`Matrix.eq_of_dvd_of_dvd_of_mul_eq_mul`, which does *not* go through
+`Matrix.smith_normal_form_unique`. The statement here keeps none of the source's matrix
+hypotheses: it is arithmetic on two `Fin 2 → ℤ` tuples, concluding `dA = dB` from positivity
+of the two first entries, their mutual divisibility, and equality of the two products.
+Callers obtain that product equality from `Matrix.prod_eq_det_of_mul_mul_eq_diagonal` together
+with an equality of determinants. -/
 
 /-- **The first entry of a chained diagonal form divides every entry.** If
 `L * A * R = diagonal d` with `L`, `R` unimodular and `d 0` dividing every `d k`, then `d 0`

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -949,4 +949,74 @@ theorem invariant_factor_zero_eq_gcd [NeZero n] (A : Matrix (Fin n) (Fin n) ℤ)
   Int.eq_of_associated_of_nonneg (associated_invariant_factor_zero_gcd A d hd0 L R h) hnonneg
     (Int.nonneg_of_normalize_eq_self Finset.normalize_gcd)
 
+/-- **The product of the invariant factors is the determinant.** Both `SLₙ(ℤ)` factors have
+determinant `1`, so taking determinants through a Smith normal form leaves the diagonal. -/
+theorem prod_eq_det_of_smithNormalForm {A : Matrix (Fin n) (Fin n) ℤ}
+    {L R : SpecialLinearGroup (Fin n) ℤ} {d : Fin n → ℤ}
+    (h : (L : Matrix (Fin n) (Fin n) ℤ) * A * (R : Matrix (Fin n) (Fin n) ℤ) =
+      Matrix.diagonal d) :
+    ∏ i, d i = A.det := by
+  have hdet := congrArg Matrix.det h
+  simp only [Matrix.det_mul, L.2, R.2, one_mul, mul_one, Matrix.det_diagonal] at hdet
+  exact hdet.symm
+
+/-- **For `2 × 2` matrices, mutually dividing first invariant factors and equal determinants
+force equal Smith normal forms.** The first factors agree by antisymmetry, and the second is
+then pinned by the determinant.
+
+Stated at `Fin 2` because that is where two invariant factors and a determinant determine the
+diagonal; at larger `n` the intermediate factors are not fixed by these hypotheses. -/
+theorem diagonal_eq_of_dvd_of_det_eq {A B : Matrix (Fin 2) (Fin 2) ℤ}
+    {LA RA LB RB : SpecialLinearGroup (Fin 2) ℤ} {dA dB : Fin 2 → ℤ}
+    (hdA_pos : ∀ i, 0 < dA i) (hdB_pos : ∀ i, 0 < dB i)
+    (hA : (LA : Matrix (Fin 2) (Fin 2) ℤ) * A * (RA : Matrix (Fin 2) (Fin 2) ℤ) =
+      Matrix.diagonal dA)
+    (hB : (LB : Matrix (Fin 2) (Fin 2) ℤ) * B * (RB : Matrix (Fin 2) (Fin 2) ℤ) =
+      Matrix.diagonal dB)
+    (hAB : dA 0 ∣ dB 0) (hBA : dB 0 ∣ dA 0) (hdet : A.det = B.det) :
+    Matrix.diagonal dA = (Matrix.diagonal dB : Matrix (Fin 2) (Fin 2) ℤ) := by
+  have hd0 : dA 0 = dB 0 :=
+    le_antisymm (Int.le_of_dvd (hdB_pos 0) hAB) (Int.le_of_dvd (hdA_pos 0) hBA)
+  have hprodA : dA 0 * dA 1 = A.det := by
+    simpa [Fin.prod_univ_two] using prod_eq_det_of_smithNormalForm hA
+  have hprodB : dB 0 * dB 1 = B.det := by
+    simpa [Fin.prod_univ_two] using prod_eq_det_of_smithNormalForm hB
+  have hd1 : dA 1 = dB 1 :=
+    mul_left_cancel₀ (ne_of_gt (hdA_pos 0)) (by rw [hprodA, hd0, hprodB, hdet])
+  congr 1
+  funext i
+  fin_cases i <;> assumption
+
+/-- **Two matrices with the same Smith normal form are `SLₙ(ℤ)`-equivalent.** Given
+diagonalisations of `A` and `B` whose diagonals agree, the composites `L_B⁻¹ L_A` and
+`R_A R_B⁻¹` carry `A` to `B`.
+
+The hypothesis is equality of the diagonal *matrices* rather than of the invariant-factor
+tuples, which is what `smith_normal_form_unique` and the divisibility arguments produce. -/
+theorem exists_SL_mul_mul_eq_of_diagonal_eq {A B : Matrix (Fin n) (Fin n) ℤ}
+    {LA RA LB RB : SpecialLinearGroup (Fin n) ℤ} {dA dB : Fin n → ℤ}
+    (hA : (LA : Matrix (Fin n) (Fin n) ℤ) * A * (RA : Matrix (Fin n) (Fin n) ℤ) =
+      Matrix.diagonal dA)
+    (hB : (LB : Matrix (Fin n) (Fin n) ℤ) * B * (RB : Matrix (Fin n) (Fin n) ℤ) =
+      Matrix.diagonal dB)
+    (hd : Matrix.diagonal dA = (Matrix.diagonal dB : Matrix (Fin n) (Fin n) ℤ)) :
+    ∃ P Q : SpecialLinearGroup (Fin n) ℤ,
+      (P : Matrix (Fin n) (Fin n) ℤ) * A * (Q : Matrix (Fin n) (Fin n) ℤ) = B := by
+  refine ⟨LB⁻¹ * LA, RA * RB⁻¹, ?_⟩
+  have hLB : (LB⁻¹).val * LB.val = (1 : Matrix (Fin n) (Fin n) ℤ) := by
+    rw [← SpecialLinearGroup.coe_mul, inv_mul_cancel]
+    rfl
+  have hRB : RB.val * (RB⁻¹).val = (1 : Matrix (Fin n) (Fin n) ℤ) := by
+    rw [← SpecialLinearGroup.coe_mul, mul_inv_cancel]
+    rfl
+  calc ((LB⁻¹ * LA : SpecialLinearGroup (Fin n) ℤ) : Matrix (Fin n) (Fin n) ℤ) * A *
+        ((RA * RB⁻¹ : SpecialLinearGroup (Fin n) ℤ) : Matrix (Fin n) (Fin n) ℤ)
+      = (LB⁻¹).val * (LA.val * A * RA.val) * (RB⁻¹).val := by
+        simp only [SpecialLinearGroup.coe_mul, Matrix.mul_assoc]
+    _ = (LB⁻¹).val * Matrix.diagonal dB * (RB⁻¹).val := by rw [hA, hd]
+    _ = (LB⁻¹).val * (LB.val * B * RB.val) * (RB⁻¹).val := by rw [hB]
+    _ = B := by
+        simp only [Matrix.mul_assoc]
+        rw [hRB, Matrix.mul_one, ← Matrix.mul_assoc (LB⁻¹).val, hLB, Matrix.one_mul]
+
 end Matrix

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -10,6 +10,7 @@ public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 import Mathlib.Algebra.EuclideanDomain.Int
 -- `dvd_mul_mul_apply` and `dvd_diag_of_dvd_entries`, used only inside proofs below.
 import TauCeti.LinearAlgebra.Matrix.Divisibility
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Equivalence
 import Mathlib.Data.Int.GCD
 import Mathlib.Basic.Sign.Basic
 import Mathlib.LinearAlgebra.Determinant
@@ -827,15 +828,6 @@ private lemma prod_take_dvd_of_mul_diagonal_mul_eq {c d : Fin n → ℤ}
       simp only [Matrix.submatrix_apply, hgeq])
     simp [this]
 
-/-- Inverting a two-sided unimodular transformation. Used both by the uniqueness proof and by
-the content characterisation below, which otherwise repeat the same three lines. -/
-private lemma inv_mul_mul_inv_of_mul_mul_eq {S : Type*} [Semiring S]
-    {A B : Matrix (Fin n) (Fin n) S} (L R : GeneralLinearGroup (Fin n) S)
-    (h : (L : Matrix (Fin n) (Fin n) S) * A * (R : Matrix (Fin n) (Fin n) S) = B) :
-    (↑L⁻¹ : Matrix (Fin n) (Fin n) S) * B * (↑R⁻¹ : Matrix (Fin n) (Fin n) S) = A := by
-  rw [← h]
-  simp [Matrix.mul_assoc]
-
 /-- **Uniqueness of the Smith normal form**: two nonnegative diagonals with divisibility
 chains in the same `GL_n(ℤ)`-equivalence class are equal — including singular forms, whose
 chains vanish from the first zero on.  Together with
@@ -951,65 +943,21 @@ theorem invariant_factor_zero_eq_gcd [NeZero n] (A : Matrix (Fin n) (Fin n) ℤ)
   Int.eq_of_associated_of_nonneg (associated_invariant_factor_zero_gcd A d hd0 L R h) hnonneg
     (Int.nonneg_of_normalize_eq_self Finset.normalize_gcd)
 
-/-- **The product of a diagonalisation's diagonal entries is the determinant.** Both `SLₙ`
-factors have determinant `1`, so taking determinants through `L * A * R = diagonal d` leaves
-the product of the diagonal.
+/-- **Two positive `Fin 2` diagonals with mutually dividing first entries and equal products
+are equal.** The first entries agree by antisymmetry, and the second is then pinned by the
+product.
 
-No divisibility chain is assumed, so `d` need not be the invariant factors. -/
-theorem prod_eq_det_of_mul_mul_eq_diagonal {S : Type*} [CommRing S]
-    {A : Matrix (Fin n) (Fin n) S} {L R : SpecialLinearGroup (Fin n) S} {d : Fin n → S}
-    (h : (L : Matrix (Fin n) (Fin n) S) * A * (R : Matrix (Fin n) (Fin n) S) =
-      Matrix.diagonal d) :
-    ∏ i, d i = A.det := by
-  have hdet := congrArg Matrix.det h
-  simp only [Matrix.det_mul, L.2, R.2, one_mul, mul_one, Matrix.det_diagonal] at hdet
-  exact hdet.symm
-
-/-- **For `2 × 2` matrices, mutually dividing first diagonal entries and equal determinants
-force equal diagonal forms.** The first entries agree by antisymmetry, and the second is then
-pinned by the determinant.
-
-Only diagonalisations are assumed, not Smith normal forms: no divisibility chain along `dA` or
-`dB` is used. Stated at `Fin 2` because that is where two diagonal entries and a determinant
-determine the diagonal; at larger `n` the intermediate entries are not fixed by these
-hypotheses. -/
-theorem diagonal_eq_of_dvd_of_det_eq {A B : Matrix (Fin 2) (Fin 2) ℤ}
-    {LA RA LB RB : SpecialLinearGroup (Fin 2) ℤ} {dA dB : Fin 2 → ℤ}
-    (hdA0_pos : 0 < dA 0) (hdB0_pos : 0 < dB 0)
-    (hA : (LA : Matrix (Fin 2) (Fin 2) ℤ) * A * (RA : Matrix (Fin 2) (Fin 2) ℤ) =
-      Matrix.diagonal dA)
-    (hB : (LB : Matrix (Fin 2) (Fin 2) ℤ) * B * (RB : Matrix (Fin 2) (Fin 2) ℤ) =
-      Matrix.diagonal dB)
-    (hAB : dA 0 ∣ dB 0) (hBA : dB 0 ∣ dA 0) (hdet : A.det = B.det) :
-    Matrix.diagonal dA = (Matrix.diagonal dB : Matrix (Fin 2) (Fin 2) ℤ) := by
+This is the arithmetic behind "equal determinants and mutually dividing first invariant factors
+determine a `2 × 2` diagonal form". No matrix hypothesis appears: callers obtain `hprod` from
+`Matrix.prod_eq_det_of_mul_mul_eq_diagonal` and an equality of determinants. -/
+theorem eq_of_dvd_of_dvd_of_mul_eq_mul {dA dB : Fin 2 → ℤ}
+    (hdA0_pos : 0 < dA 0) (hdB0_pos : 0 < dB 0) (hAB : dA 0 ∣ dB 0) (hBA : dB 0 ∣ dA 0)
+    (hprod : dA 0 * dA 1 = dB 0 * dB 1) : dA = dB := by
   have hd0 : dA 0 = dB 0 :=
     le_antisymm (Int.le_of_dvd hdB0_pos hAB) (Int.le_of_dvd hdA0_pos hBA)
-  have hprodA : dA 0 * dA 1 = A.det := by
-    simpa [Fin.prod_univ_two] using prod_eq_det_of_mul_mul_eq_diagonal hA
-  have hprodB : dB 0 * dB 1 = B.det := by
-    simpa [Fin.prod_univ_two] using prod_eq_det_of_mul_mul_eq_diagonal hB
   have hd1 : dA 1 = dB 1 :=
-    mul_left_cancel₀ (ne_of_gt hdA0_pos) (by rw [hprodA, hd0, hprodB, hdet])
-  congr 1
+    mul_left_cancel₀ (ne_of_gt hdA0_pos) (by rw [hprod, hd0])
   funext i
   fin_cases i <;> assumption
-
-/-- **Matrices sharing an `SLₙ`-transform are `SLₙ`-equivalent.** If `L_A A R_A = L_B B R_B`
-then `L_B⁻¹ L_A` and `R_A R_B⁻¹` carry `A` to `B`.
-
-Pure group algebra: nothing is assumed about the common value, which need not be diagonal.
-Callers holding two diagonalisations with equal diagonals compose them into this single
-hypothesis. -/
-theorem exists_SL_mul_mul_eq_of_mul_mul_eq {S : Type*} [CommRing S]
-    {A B : Matrix (Fin n) (Fin n) S} {LA RA LB RB : SpecialLinearGroup (Fin n) S}
-    (h : (LA : Matrix (Fin n) (Fin n) S) * A * (RA : Matrix (Fin n) (Fin n) S) =
-      (LB : Matrix (Fin n) (Fin n) S) * B * (RB : Matrix (Fin n) (Fin n) S)) :
-    ∃ P Q : SpecialLinearGroup (Fin n) S,
-      (P : Matrix (Fin n) (Fin n) S) * A * (Q : Matrix (Fin n) (Fin n) S) = B := by
-  refine ⟨LB⁻¹ * LA, RA * RB⁻¹, ?_⟩
-  -- `simp` normalises the `SLₙ` inverse to `adjugate`; `inv_def` with `det = 1` takes the
-  -- `GLₙ` inverse the same way, so the two sides meet.
-  simpa [SpecialLinearGroup.coe_mul, Matrix.mul_assoc, Matrix.inv_def] using
-    inv_mul_mul_inv_of_mul_mul_eq LB.toGL RB.toGL h.symm
 
 end Matrix

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean
@@ -20,8 +20,6 @@ rather than inside it, and hold over an arbitrary finite index type.
 ## Main results
 
 * `Matrix.inv_mul_mul_inv_of_mul_mul_eq`: inverting a two-sided unimodular transformation.
-* `Matrix.inv_coe_eq_coe_inv`: the `SL` inverse agrees with the matrix inverse of the
-  coercion.
 * `Matrix.prod_eq_det_of_mul_mul_eq_diagonal`: the product of a diagonalisation's diagonal
   entries is the determinant.
 * `Matrix.exists_SL_mul_mul_eq_of_mul_mul_eq`: two matrices carried to a common value by
@@ -50,15 +48,6 @@ theorem inv_mul_mul_inv_of_mul_mul_eq {S : Type*} [Semiring S]
   simp only [Matrix.mul_assoc, hR, Matrix.mul_one]
   rw [← Matrix.mul_assoc, hL, Matrix.one_mul]
 
-/-- **The `SL` inverse agrees with the matrix inverse of the coercion.** Determinant `1` makes
-the coercion of `M⁻¹` a right inverse of the coercion of `M`, which pins the matrix inverse
-without unfolding how either inverse is represented. -/
-theorem inv_coe_eq_coe_inv {n : Type*} [Fintype n] [DecidableEq n] {S : Type*} [CommRing S]
-    (M : SpecialLinearGroup n S) :
-    ((M : Matrix n n S))⁻¹ = ((M⁻¹ : SpecialLinearGroup n S) : Matrix n n S) :=
-  Matrix.inv_eq_right_inv (by
-    rw [← SpecialLinearGroup.coe_mul, mul_inv_cancel, SpecialLinearGroup.coe_one])
-
 /-- **The product of a diagonalisation's diagonal entries is the determinant.** Both `SL`
 factors have determinant `1`, so taking determinants through `L * A * R = diagonal d` leaves
 the product of the diagonal.
@@ -85,7 +74,10 @@ theorem exists_SL_mul_mul_eq_of_mul_mul_eq {S : Type*} [CommRing S]
     ∃ (P : SpecialLinearGroup ι S) (Q : SpecialLinearGroup κ S),
       (P : Matrix ι ι S) * A * (Q : Matrix κ κ S) = B := by
   refine ⟨LB⁻¹ * LA, RA * RB⁻¹, ?_⟩
-  simpa [SpecialLinearGroup.coe_mul, Matrix.mul_assoc, inv_coe_eq_coe_inv] using
+  -- `toGL` is a monoid hom, so `map_inv` moves the inverse to the `SL` side and
+  -- `coe_GL_coe_matrix` drops back to matrices; both inverses then normalise the same way
+  simpa [SpecialLinearGroup.coe_mul, Matrix.mul_assoc, ← map_inv,
+    SpecialLinearGroup.coe_GL_coe_matrix] using
     inv_mul_mul_inv_of_mul_mul_eq LB.toGL RB.toGL h.symm
 
 end

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean
@@ -5,21 +5,21 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
 
-import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Equivalence
 
 /-!
 # Two-sided unimodular equivalence of matrices
 
-Matrices related by `L * A * R` with `L` and `R` unimodular. Nothing here assumes a Smith
-normal form or a divisibility chain along a diagonal, so these facts sit below that theory
-rather than inside it, and hold over an arbitrary finite index type.
+Matrices related by `L * A * R` with `L` and `R` in `SL`. Nothing here assumes a Smith normal
+form or a divisibility chain along a diagonal, so these facts sit below that theory rather
+than inside it, and hold over an arbitrary finite index type. The corresponding statement for
+merely invertible factors is `Matrix.inv_mul_mul_inv_of_mul_mul_eq`, in
+`TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Equivalence`.
 
 ## Main results
 
-* `Matrix.inv_mul_mul_inv_of_mul_mul_eq`: inverting a two-sided unimodular transformation.
 * `Matrix.prod_eq_det_of_mul_mul_eq_diagonal`: the product of a diagonalisation's diagonal
   entries is the determinant.
 * `Matrix.exists_SL_mul_mul_eq_of_mul_mul_eq`: two matrices carried to a common value by
@@ -31,22 +31,6 @@ namespace Matrix
 variable {ι κ : Type*} [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
 
 public section
-
-/-- **Inverting a two-sided unimodular transformation.** The rows and columns are transformed
-independently, so they need not share an index type. -/
-theorem inv_mul_mul_inv_of_mul_mul_eq {S : Type*} [Semiring S]
-    {A B : Matrix ι κ S} (L : GeneralLinearGroup ι S) (R : GeneralLinearGroup κ S)
-    (h : (L : Matrix ι ι S) * A * (R : Matrix κ κ S) = B) :
-    (↑L⁻¹ : Matrix ι ι S) * B * (↑R⁻¹ : Matrix κ κ S) = A := by
-  -- with the rows and columns indexed separately, the two cancellations are named rather
-  -- than left to `simp`, which no longer matches them across the differing index types
-  have hL : (↑L⁻¹ : Matrix ι ι S) * (L : Matrix ι ι S) = 1 := by
-    rw [← Units.val_mul, inv_mul_cancel, Units.val_one]
-  have hR : (R : Matrix κ κ S) * (↑R⁻¹ : Matrix κ κ S) = 1 := by
-    rw [← Units.val_mul, mul_inv_cancel, Units.val_one]
-  rw [← h]
-  simp only [Matrix.mul_assoc, hR, Matrix.mul_one]
-  rw [← Matrix.mul_assoc, hL, Matrix.one_mul]
 
 /-- **The product of a diagonalisation's diagonal entries is the determinant.** Both `SL`
 factors have determinant `1`, so taking determinants through `L * A * R = diagonal d` leaves

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean
@@ -15,7 +15,7 @@ import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Equivalence
 Matrices related by `L * A * R` with `L` and `R` in `SL`. Nothing here assumes a Smith normal
 form or a divisibility chain along a diagonal, so these facts sit below that theory rather
 than inside it, and hold over an arbitrary finite index type. The corresponding statement for
-merely invertible factors is `Matrix.inv_mul_mul_inv_of_mul_mul_eq`, in
+merely invertible factors is `Matrix.GeneralLinearGroup.inv_mul_mul_inv_of_mul_mul_eq`, in
 `TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Equivalence`.
 
 ## Main results
@@ -62,7 +62,7 @@ theorem exists_SL_mul_mul_eq_of_mul_mul_eq {S : Type*} [CommRing S]
   -- `coe_GL_coe_matrix` drops back to matrices; both inverses then normalise the same way
   simpa [SpecialLinearGroup.coe_mul, Matrix.mul_assoc, ← map_inv,
     SpecialLinearGroup.coe_GL_coe_matrix] using
-    inv_mul_mul_inv_of_mul_mul_eq LB.toGL RB.toGL h.symm
+    LB.toGL.inv_mul_mul_inv_of_mul_mul_eq RB.toGL h.symm
 
 end
 

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean
@@ -20,6 +20,8 @@ rather than inside it, and hold over an arbitrary finite index type.
 ## Main results
 
 * `Matrix.inv_mul_mul_inv_of_mul_mul_eq`: inverting a two-sided unimodular transformation.
+* `Matrix.inv_coe_eq_coe_inv`: the `SL` inverse agrees with the matrix inverse of the
+  coercion.
 * `Matrix.prod_eq_det_of_mul_mul_eq_diagonal`: the product of a diagonalisation's diagonal
   entries is the determinant.
 * `Matrix.exists_SL_mul_mul_eq_of_mul_mul_eq`: two matrices carried to a common value by
@@ -28,17 +30,34 @@ rather than inside it, and hold over an arbitrary finite index type.
 
 namespace Matrix
 
-variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+variable {ι κ : Type*} [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
 
 public section
 
-/-- **Inverting a two-sided unimodular transformation.** -/
+/-- **Inverting a two-sided unimodular transformation.** The rows and columns are transformed
+independently, so they need not share an index type. -/
 theorem inv_mul_mul_inv_of_mul_mul_eq {S : Type*} [Semiring S]
-    {A B : Matrix ι ι S} (L R : GeneralLinearGroup ι S)
-    (h : (L : Matrix ι ι S) * A * (R : Matrix ι ι S) = B) :
-    (↑L⁻¹ : Matrix ι ι S) * B * (↑R⁻¹ : Matrix ι ι S) = A := by
+    {A B : Matrix ι κ S} (L : GeneralLinearGroup ι S) (R : GeneralLinearGroup κ S)
+    (h : (L : Matrix ι ι S) * A * (R : Matrix κ κ S) = B) :
+    (↑L⁻¹ : Matrix ι ι S) * B * (↑R⁻¹ : Matrix κ κ S) = A := by
+  -- with the rows and columns indexed separately, the two cancellations are named rather
+  -- than left to `simp`, which no longer matches them across the differing index types
+  have hL : (↑L⁻¹ : Matrix ι ι S) * (L : Matrix ι ι S) = 1 := by
+    rw [← Units.val_mul, inv_mul_cancel, Units.val_one]
+  have hR : (R : Matrix κ κ S) * (↑R⁻¹ : Matrix κ κ S) = 1 := by
+    rw [← Units.val_mul, mul_inv_cancel, Units.val_one]
   rw [← h]
-  simp [Matrix.mul_assoc]
+  simp only [Matrix.mul_assoc, hR, Matrix.mul_one]
+  rw [← Matrix.mul_assoc, hL, Matrix.one_mul]
+
+/-- **The `SL` inverse agrees with the matrix inverse of the coercion.** Determinant `1` makes
+the coercion of `M⁻¹` a right inverse of the coercion of `M`, which pins the matrix inverse
+without unfolding how either inverse is represented. -/
+theorem inv_coe_eq_coe_inv {n : Type*} [Fintype n] [DecidableEq n] {S : Type*} [CommRing S]
+    (M : SpecialLinearGroup n S) :
+    ((M : Matrix n n S))⁻¹ = ((M⁻¹ : SpecialLinearGroup n S) : Matrix n n S) :=
+  Matrix.inv_eq_right_inv (by
+    rw [← SpecialLinearGroup.coe_mul, mul_inv_cancel, SpecialLinearGroup.coe_one])
 
 /-- **The product of a diagonalisation's diagonal entries is the determinant.** Both `SL`
 factors have determinant `1`, so taking determinants through `L * A * R = diagonal d` leaves
@@ -60,15 +79,13 @@ Pure group algebra: nothing is assumed about the common value, which need not be
 Callers holding two diagonalisations with equal diagonals compose them into this single
 hypothesis. -/
 theorem exists_SL_mul_mul_eq_of_mul_mul_eq {S : Type*} [CommRing S]
-    {A B : Matrix ι ι S} {LA RA LB RB : SpecialLinearGroup ι S}
-    (h : (LA : Matrix ι ι S) * A * (RA : Matrix ι ι S) =
-      (LB : Matrix ι ι S) * B * (RB : Matrix ι ι S)) :
-    ∃ P Q : SpecialLinearGroup ι S,
-      (P : Matrix ι ι S) * A * (Q : Matrix ι ι S) = B := by
+    {A B : Matrix ι κ S} {LA LB : SpecialLinearGroup ι S} {RA RB : SpecialLinearGroup κ S}
+    (h : (LA : Matrix ι ι S) * A * (RA : Matrix κ κ S) =
+      (LB : Matrix ι ι S) * B * (RB : Matrix κ κ S)) :
+    ∃ (P : SpecialLinearGroup ι S) (Q : SpecialLinearGroup κ S),
+      (P : Matrix ι ι S) * A * (Q : Matrix κ κ S) = B := by
   refine ⟨LB⁻¹ * LA, RA * RB⁻¹, ?_⟩
-  -- `simp` normalises the `SL` inverse to `adjugate`; `inv_def` with `det = 1` takes the
-  -- `GL` inverse the same way, so the two sides meet.
-  simpa [SpecialLinearGroup.coe_mul, Matrix.mul_assoc, Matrix.inv_def] using
+  simpa [SpecialLinearGroup.coe_mul, Matrix.mul_assoc, inv_coe_eq_coe_inv] using
     inv_mul_mul_inv_of_mul_mul_eq LB.toGL RB.toGL h.symm
 
 end

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+
+/-!
+# Two-sided unimodular equivalence of matrices
+
+Matrices related by `L * A * R` with `L` and `R` unimodular. Nothing here assumes a Smith
+normal form or a divisibility chain along a diagonal, so these facts sit below that theory
+rather than inside it, and hold over an arbitrary finite index type.
+
+## Main results
+
+* `Matrix.inv_mul_mul_inv_of_mul_mul_eq`: inverting a two-sided unimodular transformation.
+* `Matrix.prod_eq_det_of_mul_mul_eq_diagonal`: the product of a diagonalisation's diagonal
+  entries is the determinant.
+* `Matrix.exists_SL_mul_mul_eq_of_mul_mul_eq`: two matrices carried to a common value by
+  `SL`-transformations are themselves `SL`-equivalent.
+-/
+
+namespace Matrix
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+public section
+
+/-- **Inverting a two-sided unimodular transformation.** -/
+theorem inv_mul_mul_inv_of_mul_mul_eq {S : Type*} [Semiring S]
+    {A B : Matrix ι ι S} (L R : GeneralLinearGroup ι S)
+    (h : (L : Matrix ι ι S) * A * (R : Matrix ι ι S) = B) :
+    (↑L⁻¹ : Matrix ι ι S) * B * (↑R⁻¹ : Matrix ι ι S) = A := by
+  rw [← h]
+  simp [Matrix.mul_assoc]
+
+/-- **The product of a diagonalisation's diagonal entries is the determinant.** Both `SL`
+factors have determinant `1`, so taking determinants through `L * A * R = diagonal d` leaves
+the product of the diagonal.
+
+No divisibility chain is assumed, so `d` need not be the invariant factors. -/
+theorem prod_eq_det_of_mul_mul_eq_diagonal {S : Type*} [CommRing S]
+    {A : Matrix ι ι S} {L R : SpecialLinearGroup ι S} {d : ι → S}
+    (h : (L : Matrix ι ι S) * A * (R : Matrix ι ι S) = Matrix.diagonal d) :
+    ∏ i, d i = A.det := by
+  have hdet := congrArg Matrix.det h
+  simp only [Matrix.det_mul, L.2, R.2, one_mul, mul_one, Matrix.det_diagonal] at hdet
+  exact hdet.symm
+
+/-- **Matrices sharing an `SL`-transform are `SL`-equivalent.** If `L_A A R_A = L_B B R_B`
+then `L_B⁻¹ L_A` and `R_A R_B⁻¹` carry `A` to `B`.
+
+Pure group algebra: nothing is assumed about the common value, which need not be diagonal.
+Callers holding two diagonalisations with equal diagonals compose them into this single
+hypothesis. -/
+theorem exists_SL_mul_mul_eq_of_mul_mul_eq {S : Type*} [CommRing S]
+    {A B : Matrix ι ι S} {LA RA LB RB : SpecialLinearGroup ι S}
+    (h : (LA : Matrix ι ι S) * A * (RA : Matrix ι ι S) =
+      (LB : Matrix ι ι S) * B * (RB : Matrix ι ι S)) :
+    ∃ P Q : SpecialLinearGroup ι S,
+      (P : Matrix ι ι S) * A * (Q : Matrix ι ι S) = B := by
+  refine ⟨LB⁻¹ * LA, RA * RB⁻¹, ?_⟩
+  -- `simp` normalises the `SL` inverse to `adjugate`; `inv_def` with `det = 1` takes the
+  -- `GL` inverse the same way, so the two sides meet.
+  simpa [SpecialLinearGroup.coe_mul, Matrix.mul_assoc, Matrix.inv_def] using
+    inv_mul_mul_inv_of_mul_mul_eq LB.toGL RB.toGL h.symm
+
+end
+
+end Matrix

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -16,6 +16,7 @@ import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Coset
 import TauCeti.LinearAlgebra.Matrix.Divisibility
 import TauCeti.LinearAlgebra.Matrix.SmithNormalForm
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Equivalence
+import TauCeti.Data.Int.Fin2Tuple
 import Mathlib.Data.ZMod.Units
 
 /-!
@@ -382,7 +383,7 @@ private lemma exists_sl2_mul_mul_eq_atkinLehnerEntries
     simpa [Fin.prod_univ_two] using Matrix.prod_eq_det_of_mul_mul_eq_diagonal hA_snf
   have hprodB : dB 0 * dB 1 = B.det := by
     simpa [Fin.prod_univ_two] using Matrix.prod_eq_det_of_mul_mul_eq_diagonal hB_snf
-  have hd : dA = dB := Matrix.eq_of_dvd_of_dvd_of_mul_eq_mul (hdA_pos 0) (hdB_pos 0)
+  have hd : dA = dB := Int.eq_of_dvd_of_dvd_of_mul_eq_mul (hdA_pos 0) (hdB_pos 0)
     hdA0_dvd_dB0 hdB0_dvd_dA0 (by rw [hprodA, hprodB, hB_det])
   -- the two diagonal forms coincide, so `A` and `B` share an `SL₂(ℤ)`-transform
   exact Matrix.exists_SL_mul_mul_eq_of_mul_mul_eq

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -376,11 +376,10 @@ private lemma exists_sl2_mul_mul_eq_atkinLehnerEntries
     Matrix.dvd_diag_of_dvd_entries B (dA 0) dB LB RB hB_snf hdA_B 0
   have hdB0_dvd_dA0 : dB 0 ∣ dA 0 :=
     Matrix.dvd_diag_of_dvd_entries A (dB 0) dA LA RA hA_snf hdB_A 0
-  have hdiag := Matrix.diagonal_eq_of_dvd_of_det_eq hdA_pos hdB_pos hA_snf hB_snf
-    (Matrix.dvd_diag_of_dvd_entries B (dA 0) dB LB RB hB_snf hdA_B 0)
-    (Matrix.dvd_diag_of_dvd_entries A (dB 0) dA LA RA hA_snf hdB_A 0) hB_det.symm
-  -- equal Smith normal forms make the two matrices `SL₂(ℤ)`-equivalent
-  exact Matrix.exists_SL_mul_mul_eq_of_diagonal_eq hA_snf hB_snf hdiag
+  have hdiag := Matrix.diagonal_eq_of_dvd_of_det_eq (hdA_pos 0) (hdB_pos 0) hA_snf hB_snf
+    hdA0_dvd_dB0 hdB0_dvd_dA0 hB_det.symm
+  -- the two diagonal forms coincide, so `A` and `B` share an `SL₂(ℤ)`-transform
+  exact Matrix.exists_SL_mul_mul_eq_of_mul_mul_eq (hA_snf.trans (hdiag.trans hB_snf.symm))
 
 /-- An integer that is a unit mod `N` is coprime to `N`. -/
 private lemma int_gcd_natCast_eq_one_of_isUnit {a : ℤ} (h : IsUnit (a : ZMod N)) :

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -376,43 +376,11 @@ private lemma exists_sl2_mul_mul_eq_atkinLehnerEntries
     Matrix.dvd_diag_of_dvd_entries B (dA 0) dB LB RB hB_snf hdA_B 0
   have hdB0_dvd_dA0 : dB 0 ∣ dA 0 :=
     Matrix.dvd_diag_of_dvd_entries A (dB 0) dA LA RA hA_snf hdB_A 0
-  have hd0 : dA 0 = dB 0 := le_antisymm
-    (Int.le_of_dvd (hdB_pos 0) hdA0_dvd_dB0)
-    (Int.le_of_dvd (hdA_pos 0) hdB0_dvd_dA0)
-  have hprodA : dA 0 * dA 1 = A.det := by
-    have h := congrArg Matrix.det hA_snf
-    simp only [Matrix.det_mul, LA.2, RA.2, one_mul, mul_one, Matrix.det_diagonal,
-      Fin.prod_univ_two] at h
-    exact h.symm
-  have hprodB : dB 0 * dB 1 = B.det := by
-    have h := congrArg Matrix.det hB_snf
-    simp only [Matrix.det_mul, LB.2, RB.2, one_mul, mul_one, Matrix.det_diagonal,
-      Fin.prod_univ_two] at h
-    exact h.symm
-  have hd1 : dA 1 = dB 1 := mul_left_cancel₀ (ne_of_gt (hdA_pos 0)) (by
-    rw [hprodA, hd0, hprodB, hB_det])
-  have hdiag : Matrix.diagonal dA = Matrix.diagonal dB := by
-    congr 1
-    funext i
-    fin_cases i <;> assumption
-  refine ⟨LB⁻¹ * LA, RA * RB⁻¹, ?_⟩
-  have hLB : (LB⁻¹).val * LB.val = (1 : Matrix (Fin 2) (Fin 2) ℤ) := by
-    rw [← SpecialLinearGroup.coe_mul, inv_mul_cancel]
-    rfl
-  have hRB : RB.val * (RB⁻¹).val = (1 : Matrix (Fin 2) (Fin 2) ℤ) := by
-    rw [← SpecialLinearGroup.coe_mul, mul_inv_cancel]
-    rfl
-  calc
-    ((LB⁻¹ * LA : SpecialLinearGroup (Fin 2) ℤ) : Matrix (Fin 2) (Fin 2) ℤ) * A *
-        ((RA * RB⁻¹ : SpecialLinearGroup (Fin 2) ℤ) : Matrix (Fin 2) (Fin 2) ℤ) =
-        (LB⁻¹).val * (LA.val * A * RA.val) * (RB⁻¹).val := by
-          simp only [SpecialLinearGroup.coe_mul, Matrix.mul_assoc]
-    _ = (LB⁻¹).val * Matrix.diagonal dB * (RB⁻¹).val := by rw [hA_snf, hdiag]
-    _ = (LB⁻¹).val * (LB.val * B * RB.val) * (RB⁻¹).val := by rw [hB_snf]
-    _ = B := by
-      simp only [Matrix.mul_assoc]
-      rw [hRB, Matrix.mul_one, ← Matrix.mul_assoc (LB⁻¹).val, hLB, Matrix.one_mul]
-    _ = atkinLehnerEntries N A c := hB
+  have hdiag := Matrix.diagonal_eq_of_dvd_of_det_eq hdA_pos hdB_pos hA_snf hB_snf
+    (Matrix.dvd_diag_of_dvd_entries B (dA 0) dB LB RB hB_snf hdA_B 0)
+    (Matrix.dvd_diag_of_dvd_entries A (dB 0) dA LA RA hA_snf hdB_A 0) hB_det.symm
+  -- equal Smith normal forms make the two matrices `SL₂(ℤ)`-equivalent
+  exact Matrix.exists_SL_mul_mul_eq_of_diagonal_eq hA_snf hB_snf hdiag
 
 /-- An integer that is a unit mod `N` is coprime to `N`. -/
 private lemma int_gcd_natCast_eq_one_of_isUnit {a : ℤ} (h : IsUnit (a : ZMod N)) :

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -15,6 +15,7 @@ import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.CosetMap
 import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Coset
 import TauCeti.LinearAlgebra.Matrix.Divisibility
 import TauCeti.LinearAlgebra.Matrix.SmithNormalForm
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Equivalence
 import Mathlib.Data.ZMod.Units
 
 /-!
@@ -376,10 +377,16 @@ private lemma exists_sl2_mul_mul_eq_atkinLehnerEntries
     Matrix.dvd_diag_of_dvd_entries B (dA 0) dB LB RB hB_snf hdA_B 0
   have hdB0_dvd_dA0 : dB 0 ∣ dA 0 :=
     Matrix.dvd_diag_of_dvd_entries A (dB 0) dA LA RA hA_snf hdB_A 0
-  have hdiag := Matrix.diagonal_eq_of_dvd_of_det_eq (hdA_pos 0) (hdB_pos 0) hA_snf hB_snf
-    hdA0_dvd_dB0 hdB0_dvd_dA0 hB_det.symm
+  -- the determinants agree, so the two diagonals have equal products
+  have hprodA : dA 0 * dA 1 = A.det := by
+    simpa [Fin.prod_univ_two] using Matrix.prod_eq_det_of_mul_mul_eq_diagonal hA_snf
+  have hprodB : dB 0 * dB 1 = B.det := by
+    simpa [Fin.prod_univ_two] using Matrix.prod_eq_det_of_mul_mul_eq_diagonal hB_snf
+  have hd : dA = dB := Matrix.eq_of_dvd_of_dvd_of_mul_eq_mul (hdA_pos 0) (hdB_pos 0)
+    hdA0_dvd_dB0 hdB0_dvd_dA0 (by rw [hprodA, hprodB, hB_det])
   -- the two diagonal forms coincide, so `A` and `B` share an `SL₂(ℤ)`-transform
-  exact Matrix.exists_SL_mul_mul_eq_of_mul_mul_eq (hA_snf.trans (hdiag.trans hB_snf.symm))
+  exact Matrix.exists_SL_mul_mul_eq_of_mul_mul_eq
+    (hA_snf.trans (by rw [hd]; exact hB_snf.symm))
 
 /-- An integer that is a unit mod `N` is coprime to `N`. -/
 private lemma int_gcd_natCast_eq_one_of_isUnit {a : ℤ} (h : IsUnit (a : ZMod N)) :


### PR DESCRIPTION
Roadmap: ModularForms

`exists_sl2_mul_mul_eq_atkinLehnerEntries` was 75 lines, over the repo's 50-line
cap. More to the point, roughly two thirds of it **had no Atkin–Lehner content
at all**: it was linear algebra written in place. The closing `calc` mentioned
`atkinLehnerEntries` only on its final line.

Pulling that algebra out showed how little of it belongs to Smith normal forms.
None of the extracted statements assumes a divisibility chain, and two of them
mention neither `ℤ` nor diagonals. So they land in two new neutral modules
rather than in `SmithNormalForm.lean`.

**Two new modules**, over arbitrary row and column index types `{ι κ}`. They split
by what each lemma actually assumes of its two factors:

`LinearAlgebra/Matrix/GeneralLinearGroup/Equivalence.lean` — invertible over a
semiring, no determinants:

| lemma | statement |
|---|---|
| `Matrix.GeneralLinearGroup.inv_mul_mul_inv_of_mul_mul_eq` | inverting a two-sided `GL` transformation of an `ι × κ` matrix |

Its namespace is `Matrix.GeneralLinearGroup` rather than `Matrix` because its
first explicit argument is a `GeneralLinearGroup`, so all three uses read
`L.inv_mul_mul_inv_of_mul_mul_eq R h`.

`LinearAlgebra/Matrix/SpecialLinearGroup/Equivalence.lean` — genuinely `SL`:

| lemma | statement |
|---|---|
| `Matrix.prod_eq_det_of_mul_mul_eq_diagonal` | `L * A * R = diagonal d` makes `∏ d` the determinant (square, so `ι = κ`) |
| `Matrix.exists_SL_mul_mul_eq_of_mul_mul_eq` | `L_A A R_A = L_B B R_B` makes `A` and `B` `SL`-equivalent |

The inversion helper was `private` in `SmithNormalForm.lean`; it becomes public,
because the uniqueness and content proofs there still use it — and it is the only
thing they use, which is why it lives in the `GL` module and `SmithNormalForm.lean`
imports that one rather than the `SL` one.

**`Data/Int/Fin2Tuple.lean`** (new) takes the one genuinely `Fin 2 → ℤ` fact,
now stated as the arithmetic it proves rather than wrapped in matrices:

```
theorem Int.eq_of_dvd_of_dvd_of_mul_eq_mul {a b : Fin 2 → ℤ}
    (ha0_pos : 0 < a 0) (hb0_pos : 0 < b 0) (hab : a 0 ∣ b 0) (hba : b 0 ∣ a 0)
    (hprod : a 0 * a 1 = b 0 * b 1) : a = b
```

Its predecessor took two matrices, four `SL` transformations and two
diagonalisations, all of which existed only to reach `hprod`. Nothing in the
statement is about matrices or Smith normal forms, so neither is its module: it
carries its own AINTLIB provenance and imports no linear algebra. The
Atkin–Lehner caller now derives the matrix-level statement itself, getting
`hprod` from `prod_eq_det_of_mul_mul_eq_diagonal` and the determinant equality
it already had.

What stays in `AtkinLehner.lean` is what that file is for: the symmetry `hswap`,
giving that `d₀` divides the entries of the bar exactly when it divides those of
the matrix. 75 lines becomes 48.

`TauCeti.lean` is deliberately empty and the lakefile's `globs = ["TauCeti.*"]`
is authoritative, so the three new modules need no root entry and no lakefile
change.

### What this PR does not do

`AtkinLehner.lean` still has three proofs over the guideline (64, 59 and 51
lines), all about `atkinLehnerAntiInvolution_bar_mem_doubleCoset`, and
`smith_normal_form_unique` is 65. Those are different content and belong in
their own PRs.

Verified with a green build of the four changed modules and everything importing
them, plus the repo's 13-linter `#lint` set over their cone (0 errors, 542
declarations).

Roadmap attribution only — this is a refactor and carries no target marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
