### PR TITLE
refactor(HeckeRing): drop an unused `set … with` equation

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -310,7 +310,7 @@ private lemma sum_image_mulMap_multiplicity_left [IsHeckeTriple Δ H₁ H₂]
   refine Finset.sum_congr rfl fun p _ ↦ ?_
   -- Step E: for each pair `p` there is exactly one pair `(E, l)` matching the coset of the
   -- product of the representatives of `p`.
-  set wG : G := (p.1.out : G) * g₁ * ((p.2.out : G) * g₂) with hwG
+  set wG : G := (p.1.out : G) * g₁ * ((p.2.out : G) * g₂)
   have hwΔ : wG ∈ Δ :=
     Δ.mul_mem (Δ.mul_mem (IsHeckeTriple.mem_of_mem_left H₂ p.1.out.2) g₁.2)
       (Δ.mul_mem (IsHeckeTriple.mem_of_mem_left H₃ p.2.out.2) g₂.2)


### PR DESCRIPTION
`set wG : G := (p.1.out : G) * g₁ * ((p.2.out : G) * g₂) with hwG` binds the
defining equation `hwG`. The abstracted variable `wG` is used throughout the
remaining proof — in `hwΔ`, `E₀`, `hdec` and `hmk` — but the equation itself is
never used, by name or by any tactic that reads the local context.

**The same proof keeps its other one.** `set E₀ … with hE₀def` *is* used, and the
scan does not flag it — it distinguishes the two rather than stripping every
`with`.

Last of the class: #5730 (7 rows) and #5733 (25 rows) are merged, and this is
the only `set … with` equation left unconsumed in the tree.

Removing a `with` clause cannot strand a hypothesis — unlike a dead `have`, it
carries no proof term — so the only way to be wrong is if the equation were
consumed, which is exactly what the scan tests.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp