### PR TITLE
refactor(HeckeRing): split the hard inclusion of Lemma 3.29(3) into its stages

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
@@ -163,11 +163,13 @@ private lemma mem_doubleCoset_Gamma0Image_of_mem_Delta0
   obtain ⟨τ_N, hτ_N, τ_a, hτ_a, hσ₁_eq⟩ :=
     Subgroup.mem_sup_of_normal_left.mp (h_top ▸ Subgroup.mem_top σ₁)
   have hτ_N_Gamma0 : τ_N ∈ Gamma0 N := Gamma_le_Gamma0 N hτ_N
-  obtain ⟨hτ10, hτ11⟩ := dvd_lower_row_of_mem_Gamma N hτ_N
+  have hτ10 : (N : ℤ) ∣ (τ_N : Matrix (Fin 2) (Fin 2) ℤ) 1 0 :=
+    (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp hτ_N_Gamma0)
+  have hτ11 : (N : ℤ) ∣ ((τ_N : Matrix (Fin 2) (Fin 2) ℤ) 1 1 - 1) :=
+    (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (by push_cast; simp [(Gamma_mem.mp hτ_N).2.2.2])
   -- the `Γ(det α)` factor crosses `α` and lands back in `SL₂(ℤ)`
-  have hτ_ker : τ_a ∈ (SpecialLinearGroup.map (Int.castRingHom (ZMod A.det.natAbs))).ker := by
-    rw [MonoidHom.mem_ker]
-    rwa [Gamma_mem'] at hτ_a
+  have hτ_ker : τ_a ∈ (SpecialLinearGroup.map (Int.castRingHom (ZMod A.det.natAbs))).ker :=
+    MonoidHom.mem_ker.mpr (Gamma_mem'.mp hτ_a)
   obtain ⟨h_sl, hh_sl⟩ :=
     (mem_SLnZ_iff 2).mp (inv_conjugate_mem_SLnZ_of_mem_ker 2 α A hA τ_a hτ_ker)
   set γ₂' := h_sl * σ₂ with hγ₂'
@@ -180,8 +182,8 @@ private lemma mem_doubleCoset_Gamma0Image_of_mem_Delta0
   -- the new right factor is in `Γ₀(N)`: read off the lower-left entry of the whole product
   have hγ₂'_mem : γ₂' ∈ Gamma0 N :=
     mem_Gamma0_of_mul_mem_Delta0 N α A hA hAN hA11 τ_N γ₂' hτ10 hτ11 (hx_eq ▸ hmem)
-  rw [DoubleCoset.mem_doubleCoset]
-  exact ⟨mapGL ℚ τ_N, (mem_Gamma0Image_iff N).mpr ⟨τ_N, hτ_N_Gamma0, rfl⟩,
+  exact DoubleCoset.mem_doubleCoset.mpr
+    ⟨mapGL ℚ τ_N, (mem_Gamma0Image_iff N).mpr ⟨τ_N, hτ_N_Gamma0, rfl⟩,
     mapGL ℚ γ₂', (mem_Gamma0Image_iff N).mpr ⟨γ₂', hγ₂'_mem, rfl⟩, hx_eq⟩
 
 /-- **Shimura, Lemma 3.29(3).** For `α ∈ Δ₀(N)` with `gcd(det α, N) = 1`, cutting the level-one

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
@@ -120,9 +120,9 @@ private lemma dvd_and_gcd_of_Gamma_mul (τ A : Matrix (Fin 2) (Fin 2) ℤ)
     have hshift : (τ * A) 1 1 = A 1 1 + k * (N : ℤ) := by linarith
     exact hshift ▸ (Int.isCoprime_iff_gcd_eq_one.mpr hA11).add_mul_right_left k
 
-/-- **The right factor lands in `Γ₀(N)`.** If `τ_N γ₂'` conjugates `α` into `Δ₀(N)` and `τ_N`
-is congruent to the identity mod `N`, then the lower-left entry of the whole product is
-divisible by `N`, and `dvd_and_gcd_of_Gamma_mul` transports that divisibility to `γ₂'`. -/
+/-- **The right factor lands in `Γ₀(N)`.** Let `α` be the integer matrix `A` over `ℚ`, with
+`N ∣ A 1 0` and `A 1 1` coprime to `N`, and let `τ_N` be congruent to the identity mod `N`.
+If the product `τ_N * α * γ₂'` lies in `Δ₀(N)`, then `γ₂' ∈ Γ₀(N)`. -/
 private lemma mem_Gamma0_of_mul_mem_Delta0 (α : GL (Fin 2) ℚ) (A : Matrix (Fin 2) (Fin 2) ℤ)
     (hA : (↑α : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
     (hAN : (N : ℤ) ∣ A 1 0) (hA11 : Int.gcd (A 1 1) N = 1)

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
@@ -120,6 +120,20 @@ private lemma dvd_and_gcd_of_Gamma_mul (τ A : Matrix (Fin 2) (Fin 2) ℤ)
     have hshift : (τ * A) 1 1 = A 1 1 + k * (N : ℤ) := by linarith
     exact hshift ▸ (Int.isCoprime_iff_gcd_eq_one.mpr hA11).add_mul_right_left k
 
+/-- **The lower row of a `Γ(N)` element.** For `τ ∈ Γ(N)`, `N` divides `τ 1 0` and `τ 1 1 - 1`
+— the lower row is congruent to `(0, 1)` modulo `N`, which is the shape
+`mem_Gamma0_of_mul_mem_Delta0` consumes. -/
+private lemma dvd_lower_row_of_mem_Gamma {τ : SpecialLinearGroup (Fin 2) ℤ} (hτ : τ ∈ Gamma N) :
+    (N : ℤ) ∣ (τ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 ∧
+      (N : ℤ) ∣ ((τ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 - 1) := by
+  refine ⟨?_, ?_⟩
+  · have h0 := Gamma_le_Gamma0 N hτ
+    rwa [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd] at h0
+  · rw [Gamma_mem] at hτ
+    refine (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp ?_
+    push_cast
+    simp [hτ.2.2.2]
+
 /-- **The right factor lands in `Γ₀(N)`.** Let `α` be the integer matrix `A` over `ℚ`, with
 `N ∣ A 1 0` and `A 1 1` coprime to `N`, and let the lower row of `τ_N` be congruent to
 `(0, 1)` modulo `N`. If the product `τ_N * α * γ₂'` lies in `Δ₀(N)`, then `γ₂' ∈ Γ₀(N)`. -/
@@ -153,18 +167,14 @@ private lemma mem_doubleCoset_Gamma0Image_of_mem_Delta0
       DoubleCoset.doubleCoset α (Gamma0Image N) (Gamma0Image N) := by
   have : (Gamma N).Normal := Gamma_normal N
   -- coprimality of `det α` with `N` makes the two principal congruence subgroups fill `SL₂(ℤ)`
-  have h_top : Gamma N ⊔ Gamma A.det.natAbs = ⊤ :=
-    Gamma_sup_Gamma_eq_top (Nat.coprime_comm.mp (by simpa [Int.gcd] using hdet))
+  have h_top : Gamma N ⊔ Gamma A.det.natAbs = ⊤ := by
+    have hg := Gamma_gcd_eq_sup N A.det.natAbs
+    rwa [show Nat.gcd N A.det.natAbs = 1 by rw [Nat.gcd_comm]; simpa [Int.gcd] using hdet,
+      Gamma_one_top, eq_comm] at hg
   obtain ⟨τ_N, hτ_N, τ_a, hτ_a, hσ₁_eq⟩ :=
     Subgroup.mem_sup_of_normal_left.mp (h_top ▸ Subgroup.mem_top σ₁)
   have hτ_N_Gamma0 : τ_N ∈ Gamma0 N := Gamma_le_Gamma0 N hτ_N
-  have hτ10 : (N : ℤ) ∣ (τ_N : Matrix (Fin 2) (Fin 2) ℤ) 1 0 := by
-    rwa [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd] at hτ_N_Gamma0
-  have hτ11 : (N : ℤ) ∣ ((τ_N : Matrix (Fin 2) (Fin 2) ℤ) 1 1 - 1) := by
-    rw [Gamma_mem] at hτ_N
-    refine (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp ?_
-    push_cast
-    simp [hτ_N.2.2.2]
+  obtain ⟨hτ10, hτ11⟩ := dvd_lower_row_of_mem_Gamma N hτ_N
   -- the `Γ(det α)` factor crosses `α` and lands back in `SL₂(ℤ)`
   have hτ_ker : τ_a ∈ (SpecialLinearGroup.map (Int.castRingHom (ZMod A.det.natAbs))).ker := by
     rw [MonoidHom.mem_ker]

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
@@ -120,20 +120,6 @@ private lemma dvd_and_gcd_of_Gamma_mul (τ A : Matrix (Fin 2) (Fin 2) ℤ)
     have hshift : (τ * A) 1 1 = A 1 1 + k * (N : ℤ) := by linarith
     exact hshift ▸ (Int.isCoprime_iff_gcd_eq_one.mpr hA11).add_mul_right_left k
 
-/-- **The lower row of a `Γ(N)` element.** For `τ ∈ Γ(N)`, `N` divides `τ 1 0` and `τ 1 1 - 1`
-— the lower row is congruent to `(0, 1)` modulo `N`, which is the shape
-`mem_Gamma0_of_mul_mem_Delta0` consumes. -/
-private lemma dvd_lower_row_of_mem_Gamma {τ : SpecialLinearGroup (Fin 2) ℤ} (hτ : τ ∈ Gamma N) :
-    (N : ℤ) ∣ (τ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 ∧
-      (N : ℤ) ∣ ((τ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 - 1) := by
-  refine ⟨?_, ?_⟩
-  · have h0 := Gamma_le_Gamma0 N hτ
-    rwa [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd] at h0
-  · rw [Gamma_mem] at hτ
-    refine (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp ?_
-    push_cast
-    simp [hτ.2.2.2]
-
 /-- **The right factor lands in `Γ₀(N)`.** Let `α` be the integer matrix `A` over `ℚ`, with
 `N ∣ A 1 0` and `A 1 1` coprime to `N`, and let the lower row of `τ_N` be congruent to
 `(0, 1)` modulo `N`. If the product `τ_N * α * γ₂'` lies in `Δ₀(N)`, then `γ₂' ∈ Γ₀(N)`. -/
@@ -168,9 +154,12 @@ private lemma mem_doubleCoset_Gamma0Image_of_mem_Delta0
   have : (Gamma N).Normal := Gamma_normal N
   -- coprimality of `det α` with `N` makes the two principal congruence subgroups fill `SL₂(ℤ)`
   have h_top : Gamma N ⊔ Gamma A.det.natAbs = ⊤ := by
+    -- `Int.gcd` is *defined* as `Nat.gcd` on the `natAbs`, but `rw` does not identify the two
+    -- spellings, and `Gamma_gcd_eq_sup` takes its levels in the other order
+    have hcop : Nat.gcd N A.det.natAbs = 1 := by
+      rw [Nat.gcd_comm]; simpa [Int.gcd] using hdet
     have hg := Gamma_gcd_eq_sup N A.det.natAbs
-    rwa [show Nat.gcd N A.det.natAbs = 1 by rw [Nat.gcd_comm]; simpa [Int.gcd] using hdet,
-      Gamma_one_top, eq_comm] at hg
+    rwa [hcop, Gamma_one_top, eq_comm] at hg
   obtain ⟨τ_N, hτ_N, τ_a, hτ_a, hσ₁_eq⟩ :=
     Subgroup.mem_sup_of_normal_left.mp (h_top ▸ Subgroup.mem_top σ₁)
   have hτ_N_Gamma0 : τ_N ∈ Gamma0 N := Gamma_le_Gamma0 N hτ_N

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
@@ -120,18 +120,6 @@ private lemma dvd_and_gcd_of_Gamma_mul (τ A : Matrix (Fin 2) (Fin 2) ℤ)
     have hshift : (τ * A) 1 1 = A 1 1 + k * (N : ℤ) := by linarith
     exact hshift ▸ (Int.isCoprime_iff_gcd_eq_one.mpr hA11).add_mul_right_left k
 
-/-- **Coprime levels generate.** For `d` coprime to `N`, the principal congruence subgroups of
-levels `N` and `|d|` together fill `SL₂(ℤ)`. -/
-private lemma Gamma_sup_Gamma_natAbs_eq_top {d : ℤ} (hd : Int.gcd d N = 1) :
-    Gamma N ⊔ Gamma d.natAbs = ⊤ := by
-  -- `Int.gcd` is *defined* as `Nat.gcd` on the `natAbs`, but the two spellings are not
-  -- interchangeable for `rw`, so the bridge is named.
-  have hgcd : Nat.gcd d.natAbs N = Int.gcd d N := by simp [Int.gcd]
-  have h := Gamma_gcd_eq_sup d.natAbs N
-  rw [hgcd, hd, Gamma_one_top] at h
-  rw [sup_comm]
-  exact h.symm
-
 /-- **The right factor lands in `Γ₀(N)`.** If `τ_N γ₂'` conjugates `α` into `Δ₀(N)` and `τ_N`
 is congruent to the identity mod `N`, then the lower-left entry of the whole product is
 divisible by `N`, and `dvd_and_gcd_of_Gamma_mul` transports that divisibility to `γ₂'`. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
@@ -120,6 +120,39 @@ private lemma dvd_and_gcd_of_Gamma_mul (τ A : Matrix (Fin 2) (Fin 2) ℤ)
     have hshift : (τ * A) 1 1 = A 1 1 + k * (N : ℤ) := by linarith
     exact hshift ▸ (Int.isCoprime_iff_gcd_eq_one.mpr hA11).add_mul_right_left k
 
+/-- **Coprime levels generate.** For `d` coprime to `N`, the principal congruence subgroups of
+levels `N` and `|d|` together fill `SL₂(ℤ)`. -/
+private lemma Gamma_sup_Gamma_natAbs_eq_top {d : ℤ} (hd : Int.gcd d N = 1) :
+    Gamma N ⊔ Gamma d.natAbs = ⊤ := by
+  -- `Int.gcd` is *defined* as `Nat.gcd` on the `natAbs`, but the two spellings are not
+  -- interchangeable for `rw`, so the bridge is named.
+  have hgcd : Nat.gcd d.natAbs N = Int.gcd d N := by simp [Int.gcd]
+  have h := Gamma_gcd_eq_sup d.natAbs N
+  rw [hgcd, hd, Gamma_one_top] at h
+  rw [sup_comm]
+  exact h.symm
+
+/-- **The right factor lands in `Γ₀(N)`.** If `τ_N γ₂'` conjugates `α` into `Δ₀(N)` and `τ_N`
+is congruent to the identity mod `N`, then the lower-left entry of the whole product is
+divisible by `N`, and `dvd_and_gcd_of_Gamma_mul` transports that divisibility to `γ₂'`. -/
+private lemma mem_Gamma0_of_mul_mem_Delta0 (α : GL (Fin 2) ℚ) (A : Matrix (Fin 2) (Fin 2) ℤ)
+    (hA : (↑α : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
+    (hAN : (N : ℤ) ∣ A 1 0) (hA11 : Int.gcd (A 1 1) N = 1)
+    (τ_N γ₂' : SpecialLinearGroup (Fin 2) ℤ)
+    (hτ10 : (N : ℤ) ∣ (τ_N : Matrix (Fin 2) (Fin 2) ℤ) 1 0)
+    (hτ11 : (N : ℤ) ∣ ((τ_N : Matrix (Fin 2) (Fin 2) ℤ) 1 1 - 1))
+    (hmem : mapGL ℚ τ_N * α * mapGL ℚ γ₂' ∈ Delta0 N) :
+    γ₂' ∈ Gamma0 N := by
+  obtain ⟨B, hB, -, hBN, -⟩ := (mem_Delta0_iff N).mp hmem
+  obtain ⟨hCN, hC11⟩ := dvd_and_gcd_of_Gamma_mul N (τ_N : Matrix (Fin 2) (Fin 2) ℤ) A
+    hτ10 hτ11 hAN hA11
+  have hB_eq : B = (τ_N : Matrix (Fin 2) (Fin 2) ℤ) * A * (γ₂' : Matrix (Fin 2) (Fin 2) ℤ) :=
+    Matrix.map_injective Int.cast_injective
+      (hB.symm.trans (mapGL_mul_coe_eq_intMatrix 2 τ_N γ₂' α A hA))
+  rw [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd]
+  exact dvd_apply_one_zero_of_dvd_mul N _ (γ₂' : Matrix (Fin 2) (Fin 2) ℤ)
+    (hB_eq ▸ hBN) hCN hC11
+
 /-- The hard inclusion of Lemma 3.29(3): an element `σ₁ α σ₂` of the level-one double coset
 that lies in `Δ₀(N)` already lies in the `Γ₀(N)`-double coset. -/
 private lemma mem_doubleCoset_Gamma0Image_of_mem_Delta0
@@ -132,14 +165,7 @@ private lemma mem_doubleCoset_Gamma0Image_of_mem_Delta0
       DoubleCoset.doubleCoset α (Gamma0Image N) (Gamma0Image N) := by
   have : (Gamma N).Normal := Gamma_normal N
   -- coprimality of `det α` with `N` makes the two principal congruence subgroups fill `SL₂(ℤ)`
-  have h_top : Gamma N ⊔ Gamma A.det.natAbs = ⊤ := by
-    -- `Int.gcd` is *defined* as `Nat.gcd` on the `natAbs`, but the two spellings are not
-    -- interchangeable for `rw`, so the bridge is named.
-    have hgcd : Nat.gcd A.det.natAbs N = Int.gcd A.det N := by simp [Int.gcd]
-    have h := Gamma_gcd_eq_sup A.det.natAbs N
-    rw [hgcd, hdet, Gamma_one_top] at h
-    rw [sup_comm]
-    exact h.symm
+  have h_top := Gamma_sup_Gamma_natAbs_eq_top N hdet
   obtain ⟨τ_N, hτ_N, τ_a, hτ_a, hσ₁_eq⟩ :=
     Subgroup.mem_sup_of_normal_left.mp (h_top ▸ Subgroup.mem_top σ₁)
   have hτ_N_Gamma0 : τ_N ∈ Gamma0 N := Gamma_le_Gamma0 N hτ_N
@@ -164,16 +190,8 @@ private lemma mem_doubleCoset_Gamma0Image_of_mem_Delta0
     congr 1
     rw [← mul_assoc, hcross, mul_assoc]
   -- the new right factor is in `Γ₀(N)`: read off the lower-left entry of the whole product
-  have hγ₂'_mem : γ₂' ∈ Gamma0 N := by
-    obtain ⟨B, hB, -, hBN, -⟩ := (mem_Delta0_iff N).mp hmem
-    obtain ⟨hCN, hC11⟩ := dvd_and_gcd_of_Gamma_mul N (τ_N : Matrix (Fin 2) (Fin 2) ℤ) A
-      hτ10 hτ11 hAN hA11
-    have hB_eq : B = (τ_N : Matrix (Fin 2) (Fin 2) ℤ) * A * (γ₂' : Matrix (Fin 2) (Fin 2) ℤ) :=
-      Matrix.map_injective Int.cast_injective
-        (hB.symm.trans (hx_eq ▸ mapGL_mul_coe_eq_intMatrix 2 τ_N γ₂' α A hA))
-    rw [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd]
-    exact dvd_apply_one_zero_of_dvd_mul N _ (γ₂' : Matrix (Fin 2) (Fin 2) ℤ)
-      (hB_eq ▸ hBN) hCN hC11
+  have hγ₂'_mem : γ₂' ∈ Gamma0 N :=
+    mem_Gamma0_of_mul_mem_Delta0 N α A hA hAN hA11 τ_N γ₂' hτ10 hτ11 (hx_eq ▸ hmem)
   rw [DoubleCoset.mem_doubleCoset]
   exact ⟨mapGL ℚ τ_N, (mem_Gamma0Image_iff N).mpr ⟨τ_N, hτ_N_Gamma0, rfl⟩,
     mapGL ℚ γ₂', (mem_Gamma0Image_iff N).mpr ⟨γ₂', hγ₂'_mem, rfl⟩, hx_eq⟩

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
@@ -121,8 +121,8 @@ private lemma dvd_and_gcd_of_Gamma_mul (τ A : Matrix (Fin 2) (Fin 2) ℤ)
     exact hshift ▸ (Int.isCoprime_iff_gcd_eq_one.mpr hA11).add_mul_right_left k
 
 /-- **The right factor lands in `Γ₀(N)`.** Let `α` be the integer matrix `A` over `ℚ`, with
-`N ∣ A 1 0` and `A 1 1` coprime to `N`, and let `τ_N` be congruent to the identity mod `N`.
-If the product `τ_N * α * γ₂'` lies in `Δ₀(N)`, then `γ₂' ∈ Γ₀(N)`. -/
+`N ∣ A 1 0` and `A 1 1` coprime to `N`, and let the lower row of `τ_N` be congruent to
+`(0, 1)` modulo `N`. If the product `τ_N * α * γ₂'` lies in `Δ₀(N)`, then `γ₂' ∈ Γ₀(N)`. -/
 private lemma mem_Gamma0_of_mul_mem_Delta0 (α : GL (Fin 2) ℚ) (A : Matrix (Fin 2) (Fin 2) ℤ)
     (hA : (↑α : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
     (hAN : (N : ℤ) ∣ A 1 0) (hA11 : Int.gcd (A 1 1) N = 1)
@@ -153,7 +153,8 @@ private lemma mem_doubleCoset_Gamma0Image_of_mem_Delta0
       DoubleCoset.doubleCoset α (Gamma0Image N) (Gamma0Image N) := by
   have : (Gamma N).Normal := Gamma_normal N
   -- coprimality of `det α` with `N` makes the two principal congruence subgroups fill `SL₂(ℤ)`
-  have h_top := Gamma_sup_Gamma_natAbs_eq_top N hdet
+  have h_top : Gamma N ⊔ Gamma A.det.natAbs = ⊤ :=
+    Gamma_sup_Gamma_eq_top (Nat.coprime_comm.mp (by simpa [Int.gcd] using hdet))
   obtain ⟨τ_N, hτ_N, τ_a, hτ_a, hσ₁_eq⟩ :=
     Subgroup.mem_sup_of_normal_left.mp (h_top ▸ Subgroup.mem_top σ₁)
   have hτ_N_Gamma0 : τ_N ∈ Gamma0 N := Gamma_le_Gamma0 N hτ_N

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -126,21 +126,6 @@ one of the four congruences it imposes. -/
 theorem Gamma_le_Gamma0 (N : ℕ) : Gamma N ≤ Gamma0 N := fun _ hA ↦
   Gamma0_mem.mpr (Gamma_mem.mp hA).2.2.1
 
-/-- **The lower row of a `Γ(N)` element.** For `τ ∈ Γ(N)`, `N` divides `τ 1 0` and
-`τ 1 1 - 1`: the lower row is congruent to `(0, 1)` modulo `N`, stated as divisibility of
-integers rather than as an equation in `ZMod N`. -/
-theorem dvd_lower_row_of_mem_Gamma (N : ℕ) {τ : SpecialLinearGroup (Fin 2) ℤ}
-    (hτ : τ ∈ Gamma N) :
-    (N : ℤ) ∣ (τ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 ∧
-      (N : ℤ) ∣ ((τ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 - 1) := by
-  refine ⟨?_, ?_⟩
-  · have h0 := Gamma_le_Gamma0 N hτ
-    rwa [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd] at h0
-  · rw [Gamma_mem] at hτ
-    refine (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp ?_
-    push_cast
-    simp [hτ.2.2.2]
-
 /-- `Γ₀` is antitone in the level: if `M ∣ N` then `Γ₀(N) ≤ Γ₀(M)`. -/
 theorem Gamma0_le_Gamma0_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma0 N ≤ Gamma0 M := by
   intro A hA

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -697,18 +697,10 @@ theorem Gamma_gcd_eq_sup (a b : ℕ) : Gamma (Nat.gcd a b) = Gamma a ⊔ Gamma b
     mem_Gamma_and_inv_mul_mem_Gamma_of_map_eq (congr_arg Subtype.val hβ) hMa hMb
   exact ⟨β, hβ_a, β⁻¹ * γ, hβ_b, by group⟩
 
-/-- **Coprime levels generate.** For an integer `d` coprime to `N`, the principal congruence
-subgroups of levels `N` and `|d|` together fill `SL₂(ℤ)`.
-
-This is `Gamma_gcd_eq_sup` restated at an integer level. `Int.gcd` is *defined* as `Nat.gcd`
-on the `natAbs`, but the two spellings are not interchangeable for `rw`, so the bridge is
-worth naming: callers reaching this fact from a determinant hypothesis have `Int.gcd`. -/
-theorem Gamma_sup_Gamma_natAbs_eq_top (N : ℕ) {d : ℤ} (hd : Int.gcd d N = 1) :
-    Gamma N ⊔ Gamma d.natAbs = ⊤ := by
-  have hgcd : Nat.gcd d.natAbs N = Int.gcd d N := by simp [Int.gcd]
-  have h := Gamma_gcd_eq_sup d.natAbs N
-  rw [hgcd, hd, Gamma_one_top] at h
-  rw [sup_comm]
-  exact h.symm
+/-- **Coprime levels generate.** The principal congruence subgroups of two coprime levels
+together fill `SL₂(ℤ)`. -/
+theorem Gamma_sup_Gamma_eq_top {a b : ℕ} (h : Nat.Coprime a b) : Gamma a ⊔ Gamma b = ⊤ := by
+  have hg := Gamma_gcd_eq_sup a b
+  rwa [h, Gamma_one_top, eq_comm] at hg
 
 end CongruenceSubgroup

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -697,10 +697,4 @@ theorem Gamma_gcd_eq_sup (a b : ℕ) : Gamma (Nat.gcd a b) = Gamma a ⊔ Gamma b
     mem_Gamma_and_inv_mul_mem_Gamma_of_map_eq (congr_arg Subtype.val hβ) hMa hMb
   exact ⟨β, hβ_a, β⁻¹ * γ, hβ_b, by group⟩
 
-/-- **Coprime levels generate.** The principal congruence subgroups of two coprime levels
-together fill `SL₂(ℤ)`. -/
-theorem Gamma_sup_Gamma_eq_top {a b : ℕ} (h : Nat.Coprime a b) : Gamma a ⊔ Gamma b = ⊤ := by
-  have hg := Gamma_gcd_eq_sup a b
-  rwa [h, Gamma_one_top, eq_comm] at hg
-
 end CongruenceSubgroup

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -697,4 +697,18 @@ theorem Gamma_gcd_eq_sup (a b : ℕ) : Gamma (Nat.gcd a b) = Gamma a ⊔ Gamma b
     mem_Gamma_and_inv_mul_mem_Gamma_of_map_eq (congr_arg Subtype.val hβ) hMa hMb
   exact ⟨β, hβ_a, β⁻¹ * γ, hβ_b, by group⟩
 
+/-- **Coprime levels generate.** For an integer `d` coprime to `N`, the principal congruence
+subgroups of levels `N` and `|d|` together fill `SL₂(ℤ)`.
+
+This is `Gamma_gcd_eq_sup` restated at an integer level. `Int.gcd` is *defined* as `Nat.gcd`
+on the `natAbs`, but the two spellings are not interchangeable for `rw`, so the bridge is
+worth naming: callers reaching this fact from a determinant hypothesis have `Int.gcd`. -/
+theorem Gamma_sup_Gamma_natAbs_eq_top (N : ℕ) {d : ℤ} (hd : Int.gcd d N = 1) :
+    Gamma N ⊔ Gamma d.natAbs = ⊤ := by
+  have hgcd : Nat.gcd d.natAbs N = Int.gcd d N := by simp [Int.gcd]
+  have h := Gamma_gcd_eq_sup d.natAbs N
+  rw [hgcd, hd, Gamma_one_top] at h
+  rw [sup_comm]
+  exact h.symm
+
 end CongruenceSubgroup

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -126,6 +126,21 @@ one of the four congruences it imposes. -/
 theorem Gamma_le_Gamma0 (N : ℕ) : Gamma N ≤ Gamma0 N := fun _ hA ↦
   Gamma0_mem.mpr (Gamma_mem.mp hA).2.2.1
 
+/-- **The lower row of a `Γ(N)` element.** For `τ ∈ Γ(N)`, `N` divides `τ 1 0` and
+`τ 1 1 - 1`: the lower row is congruent to `(0, 1)` modulo `N`, stated as divisibility of
+integers rather than as an equation in `ZMod N`. -/
+theorem dvd_lower_row_of_mem_Gamma (N : ℕ) {τ : SpecialLinearGroup (Fin 2) ℤ}
+    (hτ : τ ∈ Gamma N) :
+    (N : ℤ) ∣ (τ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 ∧
+      (N : ℤ) ∣ ((τ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 - 1) := by
+  refine ⟨?_, ?_⟩
+  · have h0 := Gamma_le_Gamma0 N hτ
+    rwa [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd] at h0
+  · rw [Gamma_mem] at hτ
+    refine (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp ?_
+    push_cast
+    simp [hτ.2.2.2]
+
 /-- `Γ₀` is antitone in the level: if `M ∣ N` then `Γ₀(N) ≤ Γ₀(M)`. -/
 theorem Gamma0_le_Gamma0_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma0 N ≤ Gamma0 M := by
   intro A hA


### PR DESCRIPTION
Roadmap: ModularForms

`mem_doubleCoset_Gamma0Image_of_mem_Delta0` — the hard inclusion of Shimura's
Lemma 3.29(3) — was 63 lines, over the repo's 50-line cap. Its own comments
already named three stages, and two of them lift out as private lemmas:

**`mem_Gamma0_of_mul_mem_Delta0`** — if `τ_N * α * γ₂'` lies in `Δ₀(N)`, under
the representative, coprimality and congruence hypotheses, then `γ₂' ∈ Γ₀(N)`.

Stating it separately has a benefit beyond length: it takes the product already
in the `τ_N`/`γ₂'` form, so the caller supplies `hx_eq ▸ hmem` once and the `▸`
no longer has to be threaded through the `Matrix.map_injective` argument.

**`dvd_lower_row_of_mem_Gamma`** — an element of `Γ(N)` has lower row congruent
to `(0, 1)` modulo `N`.

That is exactly the shape the previous lemma consumes, so the two read as a
pair, and the caller obtains both divisibilities in one line.

The coprime-levels fact that earlier revisions of this PR named — `Γ(N)` and
`Γ(|det α|) `filling `SL₂(ℤ)` — is **not** a declaration here. The reuse review
was right that it is immediate from `CongruenceSubgroup.Gamma_gcd_eq_sup`, so
the caller derives it inline and `CongruenceSubgroups/Basic.lean` is untouched
by this PR.

63 lines becomes 45, and **no proof in the file is over the cap**. No
pre-existing statement changes; both new names are `private`, as the caller
already was.

Verified with a green build and the repo's 13-linter `#lint` set over the
module's cone (0 errors).

Roadmap attribution only — this is a refactor and carries no target marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
