### PR TITLE
feat: prove the SL2 Borel maximal solvable

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Borel.lean
@@ -263,7 +263,7 @@ private theorem isBorelOverField_definingHopfIdeal :
         (CommAlgCat.of k K)) := hIsolvable
   let _ : Group.IsSolvable P :=
     Group.isSolvable_of_isSolvable_injective (f := e.symm.toMonoidHom) e.symm.injective
-  have hPB : P ≤ GL2Borel K := GL2Borel.le_of_isSolvable K P hBP
+  have hPB : P ≤ GL2Borel K := GL2Borel.le_of_isSolvable_of_infinite K P hBP
   let _ : IsReduced (CommHopfAlgCat.quotient H I) :=
     ((smoothCommHopfAlgProperty_iff_geometricallyReduced k
       (CommHopfAlgCat.quotient H I)).mp hIsmooth).isReduced

--- a/TauCeti/GroupTheory/DoubleCoset/Generation.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Generation.lean
@@ -17,15 +17,15 @@ generate the ambient group. When that group is nonsolvable, every solvable subgr
 
 ## Main statements
 
-* `TauCeti.closure_insert_eq_top_of_notMem_imp_mem_doubleCoset`: a subgroup and a representative
+* `Subgroup.closure_insert_eq_top_of_notMem_imp_mem_doubleCoset`: a subgroup and a representative
   generate the ambient group when their two double cosets cover it.
-* `TauCeti.le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset`: in a nonsolvable
+* `Subgroup.le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset`: in a nonsolvable
   group, that subgroup contains every solvable overgroup.
 -/
 
 public section
 
-namespace TauCeti
+namespace Subgroup
 
 variable {G : Type*} [Group G]
 
@@ -72,4 +72,4 @@ theorem le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
   rw [hPtop]
   exact Subgroup.mem_top g
 
-end TauCeti
+end Subgroup

--- a/TauCeti/GroupTheory/DoubleCoset/Generation.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Generation.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.Solvable
-public import TauCeti.GroupTheory.DoubleCoset.Identity
+public import Mathlib.GroupTheory.DoubleCoset
 
 /-!
 # Generation from two double cosets

--- a/TauCeti/GroupTheory/DoubleCoset/Generation.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Generation.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.Solvable
+public import TauCeti.GroupTheory.DoubleCoset.Identity
+
+/-!
+# Generation from two double cosets
+
+If every element outside a subgroup `B` lies in one double coset `B w B`, then `B` and `w`
+generate the ambient group. When that group is nonsolvable, every solvable subgroup containing
+`B` is therefore equal to `B`.
+
+## Main statements
+
+* `TauCeti.closure_insert_eq_top_of_notMem_imp_mem_doubleCoset`: a subgroup and a representative
+  generate the ambient group when their two double cosets cover it.
+* `TauCeti.le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset`: in a nonsolvable
+  group, that subgroup contains every solvable overgroup.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {G : Type*} [Group G]
+
+/-- If every element outside a subgroup `B` belongs to the double coset `B w B`, then `B` and
+`w` generate the ambient group. -/
+theorem closure_insert_eq_top_of_notMem_imp_mem_doubleCoset (B : Subgroup G) (w : G)
+    (hcell : ∀ {g : G}, g ∉ B →
+      g ∈ DoubleCoset.doubleCoset w (B : Set G) (B : Set G)) :
+    Subgroup.closure (insert w (B : Set G)) = ⊤ := by
+  refine eq_top_iff.mpr fun g _ ↦ ?_
+  by_cases hg : g ∈ B
+  · exact Subgroup.subset_closure (Set.mem_insert_of_mem _ hg)
+  · obtain ⟨x, hx, y, hy, rfl⟩ := DoubleCoset.mem_doubleCoset.mp (hcell hg)
+    exact mul_mem
+      (mul_mem (Subgroup.subset_closure (Set.mem_insert_of_mem _ hx))
+        (Subgroup.subset_closure (Set.mem_insert _ _)))
+      (Subgroup.subset_closure (Set.mem_insert_of_mem _ hy))
+
+/-- Suppose every element outside `B` belongs to `B w B`. If the ambient group is not solvable,
+then every solvable subgroup containing `B` is contained in `B`. -/
+theorem le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
+    (B P : Subgroup G) (w : G) [Group.IsSolvable P] (hG : ¬ Group.IsSolvable G)
+    (hcell : ∀ {g : G}, g ∉ B →
+      g ∈ DoubleCoset.doubleCoset w (B : Set G) (B : Set G))
+    (hBP : B ≤ P) : P ≤ B := by
+  by_contra hPB
+  obtain ⟨g, hgP, hgB⟩ := SetLike.not_le_iff_exists.mp hPB
+  obtain ⟨x, hx, y, hy, hxy⟩ := DoubleCoset.mem_doubleCoset.mp (hcell hgB)
+  have hwP : w ∈ P := by
+    have hxP := hBP hx
+    have hyP := hBP hy
+    have hprod : x⁻¹ * g * y⁻¹ ∈ P := mul_mem (mul_mem (inv_mem hxP) hgP) (inv_mem hyP)
+    convert hprod using 1
+    rw [hxy]
+    simp [mul_assoc]
+  have hclosure : Subgroup.closure (insert w (B : Set G)) ≤ P :=
+    (Subgroup.closure_le P).mpr (Set.insert_subset_iff.mpr ⟨hwP, hBP⟩)
+  rw [closure_insert_eq_top_of_notMem_imp_mem_doubleCoset B w hcell] at hclosure
+  have hPtop : P = ⊤ := top_unique hclosure
+  apply hG
+  apply Group.isSolvable_of_surjective (f := P.subtype)
+  intro g
+  refine ⟨⟨g, ?_⟩, rfl⟩
+  rw [hPtop]
+  exact Subgroup.mem_top g
+
+end TauCeti

--- a/TauCeti/GroupTheory/DoubleCoset/Identity.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Identity.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.DoubleCoset
+public import Mathlib.GroupTheory.Solvable
 
 /-!
 # The identity double coset
@@ -29,6 +30,10 @@ outside `H`.
 * `TauCeti.doubleCosetMk_eq_mk_one_iff`: the double coset of `s` is the identity one exactly when
   `s ∈ H * K`.
 * `TauCeti.doubleCosetMk_eq_mk_one_iff_mem`: for `K = H`, that condition is `s ∈ H`.
+* `TauCeti.closure_insert_eq_top_of_notMem_imp_mem_doubleCoset`: a subgroup and a representative
+  generate the ambient group when their two double cosets cover it.
+* `TauCeti.le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset`: in a nonsolvable
+  group, that subgroup contains every solvable overgroup.
 -/
 
 public section
@@ -73,5 +78,48 @@ theorem doubleCosetMk_eq_mk_one_iff (H K : Subgroup G) (s : G) :
 theorem doubleCosetMk_eq_mk_one_iff_mem (H : Subgroup G) (s : G) :
     DoubleCoset.mk H H s = DoubleCoset.mk H H 1 ↔ s ∈ H := by
   rw [doubleCosetMk_eq_mk_one_iff, coe_mul_coe, SetLike.mem_coe]
+
+/-- If every element outside a subgroup `B` belongs to the double coset `B w B`, then `B` and
+`w` generate the ambient group. -/
+theorem closure_insert_eq_top_of_notMem_imp_mem_doubleCoset (B : Subgroup G) (w : G)
+    (hcell : ∀ {g : G}, g ∉ B →
+      g ∈ DoubleCoset.doubleCoset w (B : Set G) (B : Set G)) :
+    Subgroup.closure (insert w (B : Set G)) = ⊤ := by
+  refine eq_top_iff.mpr fun g _ ↦ ?_
+  by_cases hg : g ∈ B
+  · exact Subgroup.subset_closure (Set.mem_insert_of_mem _ hg)
+  · obtain ⟨x, hx, y, hy, rfl⟩ := DoubleCoset.mem_doubleCoset.mp (hcell hg)
+    exact mul_mem
+      (mul_mem (Subgroup.subset_closure (Set.mem_insert_of_mem _ hx))
+        (Subgroup.subset_closure (Set.mem_insert _ _)))
+      (Subgroup.subset_closure (Set.mem_insert_of_mem _ hy))
+
+/-- Suppose every element outside `B` belongs to `B w B`. If the ambient group is not solvable,
+then every solvable subgroup containing `B` is contained in `B`. -/
+theorem le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
+    (B P : Subgroup G) (w : G) [Group.IsSolvable P] (hG : ¬ Group.IsSolvable G)
+    (hcell : ∀ {g : G}, g ∉ B →
+      g ∈ DoubleCoset.doubleCoset w (B : Set G) (B : Set G))
+    (hBP : B ≤ P) : P ≤ B := by
+  by_contra hPB
+  obtain ⟨g, hgP, hgB⟩ := SetLike.not_le_iff_exists.mp hPB
+  obtain ⟨x, hx, y, hy, hxy⟩ := DoubleCoset.mem_doubleCoset.mp (hcell hgB)
+  have hwP : w ∈ P := by
+    have hxP := hBP hx
+    have hyP := hBP hy
+    have hprod : x⁻¹ * g * y⁻¹ ∈ P := mul_mem (mul_mem (inv_mem hxP) hgP) (inv_mem hyP)
+    convert hprod using 1
+    rw [hxy]
+    simp [mul_assoc]
+  have hclosure : Subgroup.closure (insert w (B : Set G)) ≤ P :=
+    (Subgroup.closure_le P).mpr (Set.insert_subset_iff.mpr ⟨hwP, hBP⟩)
+  rw [closure_insert_eq_top_of_notMem_imp_mem_doubleCoset B w hcell] at hclosure
+  have hPtop : P = ⊤ := top_unique hclosure
+  apply hG
+  apply Group.isSolvable_of_surjective (f := P.subtype)
+  intro g
+  refine ⟨⟨g, ?_⟩, rfl⟩
+  rw [hPtop]
+  exact Subgroup.mem_top g
 
 end TauCeti

--- a/TauCeti/GroupTheory/DoubleCoset/Identity.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Identity.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.DoubleCoset
-public import Mathlib.GroupTheory.Solvable
 
 /-!
 # The identity double coset
@@ -30,10 +29,6 @@ outside `H`.
 * `TauCeti.doubleCosetMk_eq_mk_one_iff`: the double coset of `s` is the identity one exactly when
   `s ∈ H * K`.
 * `TauCeti.doubleCosetMk_eq_mk_one_iff_mem`: for `K = H`, that condition is `s ∈ H`.
-* `TauCeti.closure_insert_eq_top_of_notMem_imp_mem_doubleCoset`: a subgroup and a representative
-  generate the ambient group when their two double cosets cover it.
-* `TauCeti.le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset`: in a nonsolvable
-  group, that subgroup contains every solvable overgroup.
 -/
 
 public section
@@ -78,48 +73,5 @@ theorem doubleCosetMk_eq_mk_one_iff (H K : Subgroup G) (s : G) :
 theorem doubleCosetMk_eq_mk_one_iff_mem (H : Subgroup G) (s : G) :
     DoubleCoset.mk H H s = DoubleCoset.mk H H 1 ↔ s ∈ H := by
   rw [doubleCosetMk_eq_mk_one_iff, coe_mul_coe, SetLike.mem_coe]
-
-/-- If every element outside a subgroup `B` belongs to the double coset `B w B`, then `B` and
-`w` generate the ambient group. -/
-theorem closure_insert_eq_top_of_notMem_imp_mem_doubleCoset (B : Subgroup G) (w : G)
-    (hcell : ∀ {g : G}, g ∉ B →
-      g ∈ DoubleCoset.doubleCoset w (B : Set G) (B : Set G)) :
-    Subgroup.closure (insert w (B : Set G)) = ⊤ := by
-  refine eq_top_iff.mpr fun g _ ↦ ?_
-  by_cases hg : g ∈ B
-  · exact Subgroup.subset_closure (Set.mem_insert_of_mem _ hg)
-  · obtain ⟨x, hx, y, hy, rfl⟩ := DoubleCoset.mem_doubleCoset.mp (hcell hg)
-    exact mul_mem
-      (mul_mem (Subgroup.subset_closure (Set.mem_insert_of_mem _ hx))
-        (Subgroup.subset_closure (Set.mem_insert _ _)))
-      (Subgroup.subset_closure (Set.mem_insert_of_mem _ hy))
-
-/-- Suppose every element outside `B` belongs to `B w B`. If the ambient group is not solvable,
-then every solvable subgroup containing `B` is contained in `B`. -/
-theorem le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
-    (B P : Subgroup G) (w : G) [Group.IsSolvable P] (hG : ¬ Group.IsSolvable G)
-    (hcell : ∀ {g : G}, g ∉ B →
-      g ∈ DoubleCoset.doubleCoset w (B : Set G) (B : Set G))
-    (hBP : B ≤ P) : P ≤ B := by
-  by_contra hPB
-  obtain ⟨g, hgP, hgB⟩ := SetLike.not_le_iff_exists.mp hPB
-  obtain ⟨x, hx, y, hy, hxy⟩ := DoubleCoset.mem_doubleCoset.mp (hcell hgB)
-  have hwP : w ∈ P := by
-    have hxP := hBP hx
-    have hyP := hBP hy
-    have hprod : x⁻¹ * g * y⁻¹ ∈ P := mul_mem (mul_mem (inv_mem hxP) hgP) (inv_mem hyP)
-    convert hprod using 1
-    rw [hxy]
-    simp [mul_assoc]
-  have hclosure : Subgroup.closure (insert w (B : Set G)) ≤ P :=
-    (Subgroup.closure_le P).mpr (Set.insert_subset_iff.mpr ⟨hwP, hBP⟩)
-  rw [closure_insert_eq_top_of_notMem_imp_mem_doubleCoset B w hcell] at hclosure
-  have hPtop : P = ⊤ := top_unique hclosure
-  apply hG
-  apply Group.isSolvable_of_surjective (f := P.subtype)
-  intro g
-  refine ⟨⟨g, ?_⟩, rfl⟩
-  rw [hPtop]
-  exact Subgroup.mem_top g
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
@@ -20,7 +20,7 @@ public import Mathlib.GroupTheory.Solvable
 import TauCeti.GroupTheory.DoubleCoset.Identity
 -- Non-public: perfect groups are nonsolvable, which proves that `GL₂` over an infinite field is
 -- nonsolvable.
-import Mathlib.GroupTheory.IsPerfect
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Borel
 -- Non-public: the order of `GL₂` over a finite field is used only inside the proof of the size of
 -- the big cell.
 import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Card
@@ -110,7 +110,7 @@ public section
 
 namespace TauCeti
 
-open Matrix
+open _root_.Matrix
 
 universe u
 
@@ -345,37 +345,9 @@ namespace Matrix.GeneralLinearGroup
 
 /-- The general linear group `GL₂` over an infinite field is not solvable. -/
 theorem not_isSolvable_fin_two [Infinite F] : ¬ Group.IsSolvable (GL (Fin 2) F) := by
-  let S : Set F := {0} ∪ {1} ∪ {-1}
-  let U := {x : F // x ∈ Sᶜ}
-  let _ : Infinite U := (Set.toFinite S).infinite_compl.to_subtype
-  obtain ⟨a, _, _⟩ := exists_pair_ne U
-  have ha0 : (a : F) ≠ 0 := by
-    intro h
-    apply a.property
-    simp [S, h]
-  have ha1 : (a : F) ^ 2 ≠ 1 := by
-    rw [sq_ne_one_iff]
-    constructor
-    · intro h
-      apply a.property
-      simp [S, h]
-    · intro h
-      apply a.property
-      simp [S, h]
-  let _ : Group.IsPerfect (Matrix.SpecialLinearGroup (Fin 2) F) :=
-    ⟨Matrix.SL2.commutator_eq_top ha0 ha1⟩
-  have h01 : (0 : Fin 2) ≠ 1 := by decide
-  let t : Matrix.SpecialLinearGroup (Fin 2) F :=
-    Matrix.SpecialLinearGroup.transvection h01 1
-  have ht : t ≠ 1 := by
-    intro ht
-    have hentry := congrArg
-      (fun s : Matrix.SpecialLinearGroup (Fin 2) F ↦ (s : Matrix (Fin 2) (Fin 2) F) 0 1) ht
-    simp [t, Matrix.SpecialLinearGroup.transvection_coe, Matrix.single] at hentry
-  let _ : Nontrivial (Matrix.SpecialLinearGroup (Fin 2) F) := ⟨t, 1, ht⟩
   intro hGL
   let _ : Group.IsSolvable (GL (Fin 2) F) := hGL
-  exact Group.IsPerfect.not_isSolvable (Matrix.SpecialLinearGroup (Fin 2) F) <|
+  exact Matrix.SpecialLinearGroup.not_isSolvable_fin_two F <|
     Group.isSolvable_of_isSolvable_injective
       (f := Matrix.SpecialLinearGroup.toGL) Matrix.SpecialLinearGroup.toGL_injective
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
@@ -18,9 +18,9 @@ public import Mathlib.GroupTheory.Solvable
 -- double coset of a subgroup is the subgroup itself — are used only inside the proofs of the
 -- double-coset results below, which are their specializations to the Borel subgroup of `GL₂`.
 import TauCeti.GroupTheory.DoubleCoset.Identity
--- Non-public: perfect groups are nonsolvable, which proves that `GL₂` over an infinite field is
--- nonsolvable.
-import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Borel
+-- Non-public: `SL₂` over an infinite field is nonsolvable, which proves the corresponding result
+-- for `GL₂`.
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Solvable
 -- Non-public: the order of `GL₂` over a finite field is used only inside the proof of the size of
 -- the big cell.
 import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Card

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
@@ -329,15 +329,8 @@ triangular or a product `b₁ w b₂` of two upper-triangular matrices with the 
 the generation axiom of the `(B, N)`-pair of `GL₂`. -/
 theorem closure_insert_gl2WeylElement_eq_top :
     Subgroup.closure (insert (GL2WeylElement F) (GL2Borel F : Set (GL (Fin 2) F))) = ⊤ := by
-  refine eq_top_iff.mpr fun g _ => ?_
-  by_cases hg : g ∈ GL2Borel F
-  · exact Subgroup.subset_closure (Set.mem_insert_of_mem _ hg)
-  · obtain ⟨x, hx, y, hy, rfl⟩ :=
-      DoubleCoset.mem_doubleCoset.mp (mem_doubleCoset_weyl_of_notMem hg)
-    exact mul_mem
-      (mul_mem (Subgroup.subset_closure (Set.mem_insert_of_mem _ hx))
-        (Subgroup.subset_closure (Set.mem_insert _ _)))
-      (Subgroup.subset_closure (Set.mem_insert_of_mem _ hy))
+  exact closure_insert_eq_top_of_notMem_imp_mem_doubleCoset (GL2Borel F) (GL2WeylElement F)
+    mem_doubleCoset_weyl_of_notMem
 
 end GL2Borel
 
@@ -359,28 +352,9 @@ namespace GL2Borel
 subgroup is contained in it. -/
 theorem le_of_isSolvable [Infinite F] (P : Subgroup (GL (Fin 2) F)) [Group.IsSolvable P]
     (hBP : GL2Borel F ≤ P) : P ≤ GL2Borel F := by
-  by_contra hPB
-  obtain ⟨g, hgP, hgB⟩ := SetLike.not_le_iff_exists.mp hPB
-  obtain ⟨x, hx, y, hy, hxy⟩ :=
-    DoubleCoset.mem_doubleCoset.mp (mem_doubleCoset_weyl_of_notMem hgB)
-  have hwP : GL2WeylElement F ∈ P := by
-    have hxP := hBP hx
-    have hyP := hBP hy
-    have hprod : x⁻¹ * g * y⁻¹ ∈ P := mul_mem (mul_mem (inv_mem hxP) hgP) (inv_mem hyP)
-    convert hprod using 1
-    rw [hxy]
-    group
-  have hclosure :
-      Subgroup.closure (insert (GL2WeylElement F) (GL2Borel F : Set (GL (Fin 2) F))) ≤ P :=
-    (Subgroup.closure_le P).mpr (Set.insert_subset_iff.mpr ⟨hwP, hBP⟩)
-  rw [closure_insert_gl2WeylElement_eq_top] at hclosure
-  have hPtop : P = ⊤ := top_unique hclosure
-  apply Matrix.GeneralLinearGroup.not_isSolvable_fin_two F
-  apply Group.isSolvable_of_surjective (f := P.subtype)
-  intro g
-  refine ⟨⟨g, ?_⟩, rfl⟩
-  rw [hPtop]
-  exact Subgroup.mem_top g
+  exact le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
+    (GL2Borel F) P (GL2WeylElement F) (Matrix.GeneralLinearGroup.not_isSolvable_fin_two F)
+    mem_doubleCoset_weyl_of_notMem hBP
 
 end GL2Borel
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
@@ -17,6 +17,9 @@ public import Mathlib.GroupTheory.Solvable
 -- Non-public: the general double-coset identities — when two classes agree, and that the identity
 -- double coset of a subgroup is the subgroup itself — are used only inside the proofs of the
 -- double-coset results below, which are their specializations to the Borel subgroup of `GL₂`.
+import TauCeti.GroupTheory.DoubleCoset.Identity
+-- Non-public: the generic two-cell generation and maximal-solvability arguments are used only to
+-- derive their `GL₂` specializations below.
 import TauCeti.GroupTheory.DoubleCoset.Generation
 -- Non-public: `SL₂` over an infinite field is nonsolvable, which proves the corresponding result
 -- for `GL₂`.

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
@@ -330,15 +330,15 @@ triangular or a product `b₁ w b₂` of two upper-triangular matrices with the 
 the generation axiom of the `(B, N)`-pair of `GL₂`. -/
 theorem closure_insert_gl2WeylElement_eq_top :
     Subgroup.closure (insert (GL2WeylElement F) (GL2Borel F : Set (GL (Fin 2) F))) = ⊤ := by
-  exact closure_insert_eq_top_of_notMem_imp_mem_doubleCoset (GL2Borel F) (GL2WeylElement F)
-    mem_doubleCoset_weyl_of_notMem
+  exact Subgroup.closure_insert_eq_top_of_notMem_imp_mem_doubleCoset
+    (GL2Borel F) (GL2WeylElement F) mem_doubleCoset_weyl_of_notMem
 
 /-- Every solvable subgroup of `GL₂(F)` that contains the upper-triangular subgroup is contained
 in it if `F` has a nonzero element whose square is not one. -/
 theorem le_of_isSolvable (hF : ∃ a : F, a ≠ 0 ∧ a ^ 2 ≠ 1)
     (P : Subgroup (GL (Fin 2) F)) [Group.IsSolvable P]
     (hBP : GL2Borel F ≤ P) : P ≤ GL2Borel F := by
-  exact le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
+  exact Subgroup.le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
     (GL2Borel F) P (GL2WeylElement F) (Matrix.GeneralLinearGroup.not_isSolvable_fin_two F hF)
     mem_doubleCoset_weyl_of_notMem hBP
 
@@ -347,7 +347,7 @@ subgroup is contained in it. -/
 theorem le_of_isSolvable_of_infinite [Infinite F]
     (P : Subgroup (GL (Fin 2) F)) [Group.IsSolvable P]
     (hBP : GL2Borel F ≤ P) : P ≤ GL2Borel F := by
-  exact le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
+  exact Subgroup.le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
     (GL2Borel F) P (GL2WeylElement F)
     (Matrix.GeneralLinearGroup.not_isSolvable_fin_two_of_infinite F)
     mem_doubleCoset_weyl_of_notMem hBP

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
@@ -17,7 +17,7 @@ public import Mathlib.GroupTheory.Solvable
 -- Non-public: the general double-coset identities — when two classes agree, and that the identity
 -- double coset of a subgroup is the subgroup itself — are used only inside the proofs of the
 -- double-coset results below, which are their specializations to the Borel subgroup of `GL₂`.
-import TauCeti.GroupTheory.DoubleCoset.Identity
+import TauCeti.GroupTheory.DoubleCoset.Generation
 -- Non-public: `SL₂` over an infinite field is nonsolvable, which proves the corresponding result
 -- for `GL₂`.
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Solvable
@@ -73,9 +73,10 @@ the Weyl element.
 * `TauCeti.GL2Borel.card_doubleCosetQuotient_eq_two`: `B` has exactly two double cosets in `GL₂`.
 * `TauCeti.GL2Borel.closure_insert_gl2WeylElement_eq_top`: the Borel subgroup and the Weyl element
   generate `GL₂`.
-* `TauCeti.Matrix.GeneralLinearGroup.not_isSolvable_fin_two`: `GL₂` over an infinite field is not
-  solvable, and `TauCeti.GL2Borel.le_of_isSolvable`: every solvable subgroup containing the Borel
-  subgroup equals it.
+* `TauCeti.Matrix.GeneralLinearGroup.not_isSolvable_fin_two`: `GL₂` is not solvable when the
+  field contains a nonzero element whose square is not one, and
+  `TauCeti.GL2Borel.le_of_isSolvable`: every solvable subgroup containing the Borel subgroup
+  equals it under the same hypothesis.
 * `TauCeti.GL2Borel.ncard_doubleCoset_weyl`: the big cell of `GL₂(𝔽_q)` has `q² (q - 1)²`
   elements.
 
@@ -336,11 +337,22 @@ end GL2Borel
 
 namespace Matrix.GeneralLinearGroup
 
-/-- The general linear group `GL₂` over an infinite field is not solvable. -/
-theorem not_isSolvable_fin_two [Infinite F] : ¬ Group.IsSolvable (GL (Fin 2) F) := by
+/-- The general linear group `GL₂(F)` is not solvable if `F` contains a nonzero element whose
+square is not one. -/
+theorem not_isSolvable_fin_two (hF : ∃ a : F, a ≠ 0 ∧ a ^ 2 ≠ 1) :
+    ¬ Group.IsSolvable (GL (Fin 2) F) := by
   intro hGL
   let _ : Group.IsSolvable (GL (Fin 2) F) := hGL
-  exact Matrix.SpecialLinearGroup.not_isSolvable_fin_two F <|
+  exact Matrix.SpecialLinearGroup.not_isSolvable_fin_two F hF <|
+    Group.isSolvable_of_isSolvable_injective
+      (f := Matrix.SpecialLinearGroup.toGL) Matrix.SpecialLinearGroup.toGL_injective
+
+/-- The general linear group `GL₂` over an infinite field is not solvable. -/
+theorem not_isSolvable_fin_two_of_infinite [Infinite F] :
+    ¬ Group.IsSolvable (GL (Fin 2) F) := by
+  intro hGL
+  let _ : Group.IsSolvable (GL (Fin 2) F) := hGL
+  exact Matrix.SpecialLinearGroup.not_isSolvable_fin_two_of_infinite F <|
     Group.isSolvable_of_isSolvable_injective
       (f := Matrix.SpecialLinearGroup.toGL) Matrix.SpecialLinearGroup.toGL_injective
 
@@ -348,12 +360,23 @@ end Matrix.GeneralLinearGroup
 
 namespace GL2Borel
 
-/-- Every solvable subgroup of `GL₂` over an infinite field that contains the upper-triangular
-subgroup is contained in it. -/
-theorem le_of_isSolvable [Infinite F] (P : Subgroup (GL (Fin 2) F)) [Group.IsSolvable P]
+/-- Every solvable subgroup of `GL₂(F)` that contains the upper-triangular subgroup is contained
+in it if `F` has a nonzero element whose square is not one. -/
+theorem le_of_isSolvable (hF : ∃ a : F, a ≠ 0 ∧ a ^ 2 ≠ 1)
+    (P : Subgroup (GL (Fin 2) F)) [Group.IsSolvable P]
     (hBP : GL2Borel F ≤ P) : P ≤ GL2Borel F := by
   exact le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
-    (GL2Borel F) P (GL2WeylElement F) (Matrix.GeneralLinearGroup.not_isSolvable_fin_two F)
+    (GL2Borel F) P (GL2WeylElement F) (Matrix.GeneralLinearGroup.not_isSolvable_fin_two F hF)
+    mem_doubleCoset_weyl_of_notMem hBP
+
+/-- Every solvable subgroup of `GL₂` over an infinite field that contains the upper-triangular
+subgroup is contained in it. -/
+theorem le_of_isSolvable_of_infinite [Infinite F]
+    (P : Subgroup (GL (Fin 2) F)) [Group.IsSolvable P]
+    (hBP : GL2Borel F ≤ P) : P ≤ GL2Borel F := by
+  exact le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
+    (GL2Borel F) P (GL2WeylElement F)
+    (Matrix.GeneralLinearGroup.not_isSolvable_fin_two_of_infinite F)
     mem_doubleCoset_weyl_of_notMem hBP
 
 end GL2Borel

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Bruhat.lean
@@ -21,9 +21,8 @@ import TauCeti.GroupTheory.DoubleCoset.Identity
 -- Non-public: the generic two-cell generation and maximal-solvability arguments are used only to
 -- derive their `GL₂` specializations below.
 import TauCeti.GroupTheory.DoubleCoset.Generation
--- Non-public: `SL₂` over an infinite field is nonsolvable, which proves the corresponding result
--- for `GL₂`.
-import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Solvable
+-- Non-public: nonsolvability of `GL₂` is used only in the maximal-solvability results below.
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Solvable
 -- Non-public: the order of `GL₂` over a finite field is used only inside the proof of the size of
 -- the big cell.
 import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Card
@@ -76,10 +75,8 @@ the Weyl element.
 * `TauCeti.GL2Borel.card_doubleCosetQuotient_eq_two`: `B` has exactly two double cosets in `GL₂`.
 * `TauCeti.GL2Borel.closure_insert_gl2WeylElement_eq_top`: the Borel subgroup and the Weyl element
   generate `GL₂`.
-* `TauCeti.Matrix.GeneralLinearGroup.not_isSolvable_fin_two`: `GL₂` is not solvable when the
-  field contains a nonzero element whose square is not one, and
-  `TauCeti.GL2Borel.le_of_isSolvable`: every solvable subgroup containing the Borel subgroup
-  equals it under the same hypothesis.
+* `TauCeti.GL2Borel.le_of_isSolvable`: every solvable subgroup containing the Borel subgroup
+  equals it when the field contains a nonzero element whose square is not one.
 * `TauCeti.GL2Borel.ncard_doubleCoset_weyl`: the big cell of `GL₂(𝔽_q)` has `q² (q - 1)²`
   elements.
 
@@ -335,33 +332,6 @@ theorem closure_insert_gl2WeylElement_eq_top :
     Subgroup.closure (insert (GL2WeylElement F) (GL2Borel F : Set (GL (Fin 2) F))) = ⊤ := by
   exact closure_insert_eq_top_of_notMem_imp_mem_doubleCoset (GL2Borel F) (GL2WeylElement F)
     mem_doubleCoset_weyl_of_notMem
-
-end GL2Borel
-
-namespace Matrix.GeneralLinearGroup
-
-/-- The general linear group `GL₂(F)` is not solvable if `F` contains a nonzero element whose
-square is not one. -/
-theorem not_isSolvable_fin_two (hF : ∃ a : F, a ≠ 0 ∧ a ^ 2 ≠ 1) :
-    ¬ Group.IsSolvable (GL (Fin 2) F) := by
-  intro hGL
-  let _ : Group.IsSolvable (GL (Fin 2) F) := hGL
-  exact Matrix.SpecialLinearGroup.not_isSolvable_fin_two F hF <|
-    Group.isSolvable_of_isSolvable_injective
-      (f := Matrix.SpecialLinearGroup.toGL) Matrix.SpecialLinearGroup.toGL_injective
-
-/-- The general linear group `GL₂` over an infinite field is not solvable. -/
-theorem not_isSolvable_fin_two_of_infinite [Infinite F] :
-    ¬ Group.IsSolvable (GL (Fin 2) F) := by
-  intro hGL
-  let _ : Group.IsSolvable (GL (Fin 2) F) := hGL
-  exact Matrix.SpecialLinearGroup.not_isSolvable_fin_two_of_infinite F <|
-    Group.isSolvable_of_isSolvable_injective
-      (f := Matrix.SpecialLinearGroup.toGL) Matrix.SpecialLinearGroup.toGL_injective
-
-end Matrix.GeneralLinearGroup
-
-namespace GL2Borel
 
 /-- Every solvable subgroup of `GL₂(F)` that contains the upper-triangular subgroup is contained
 in it if `F` has a nonzero element whose square is not one. -/

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Solvable.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Solvable.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.Solvable
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Solvable
+
+/-!
+# Nonsolvability of `GL₂`
+
+If a field contains an element `a` with `a ≠ 0` and `a² ≠ 1`, then `GL₂` is nonsolvable.
+In particular, this holds over every infinite field.
+
+## Main declarations
+
+* `TauCeti.Matrix.GeneralLinearGroup.not_isSolvable_fin_two`: `GL₂` is not solvable when the
+  field contains an element outside the roots of `X * (X² - 1)`.
+* `TauCeti.Matrix.GeneralLinearGroup.not_isSolvable_fin_two_of_infinite`: the infinite-field
+  specialization.
+-/
+
+public section
+
+open scoped MatrixGroups
+
+namespace TauCeti.Matrix.GeneralLinearGroup
+
+universe u
+
+/-- The general linear group `GL₂(F)` is not solvable if `F` contains a nonzero element whose
+square is not one. -/
+theorem not_isSolvable_fin_two (F : Type u) [Field F]
+    (hF : ∃ a : F, a ≠ 0 ∧ a ^ 2 ≠ 1) : ¬ Group.IsSolvable (GL (Fin 2) F) := by
+  intro hGL
+  let _ : Group.IsSolvable (GL (Fin 2) F) := hGL
+  exact Matrix.SpecialLinearGroup.not_isSolvable_fin_two F hF <|
+    Group.isSolvable_of_isSolvable_injective
+      (f := Matrix.SpecialLinearGroup.toGL) Matrix.SpecialLinearGroup.toGL_injective
+
+/-- The general linear group `GL₂` over an infinite field is not solvable. -/
+theorem not_isSolvable_fin_two_of_infinite (F : Type u) [Field F] [Infinite F] :
+    ¬ Group.IsSolvable (GL (Fin 2) F) := by
+  intro hGL
+  let _ : Group.IsSolvable (GL (Fin 2) F) := hGL
+  exact Matrix.SpecialLinearGroup.not_isSolvable_fin_two_of_infinite F <|
+    Group.isSolvable_of_isSolvable_injective
+      (f := Matrix.SpecialLinearGroup.toGL) Matrix.SpecialLinearGroup.toGL_injective
+
+end TauCeti.Matrix.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
@@ -6,9 +6,11 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.DoubleCoset
+public import Mathlib.GroupTheory.Solvable
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Borel
-public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.UpperTriangular.Solvable
-public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Solvable
+import TauCeti.GroupTheory.DoubleCoset.Identity
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.UpperTriangular.Solvable
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Solvable
 
 /-!
 # The upper-triangular subgroup of `SL₂`
@@ -36,8 +38,8 @@ field.
 
 * J. E. Humphreys, *Linear Algebraic Groups*, §28.3.
 * R. Steinberg, *Lectures on Chevalley Groups*, §3.
-* The proofs of `closure_insert_modularGroup_S_eq_top` and `le_of_isSolvable` adapt the formal
-  templates `GL2Borel.closure_insert_gl2WeylElement_eq_top` and `GL2Borel.le_of_isSolvable`.
+* The proofs of `closure_insert_modularGroup_S_eq_top` and `le_of_isSolvable` use the same generic
+  two-double-coset lemmas as their `GL₂` counterparts.
 -/
 
 public section
@@ -59,6 +61,13 @@ namespace SL2Borel
 section CommRing
 
 variable {R : Type u} [CommRing R]
+
+private theorem coe_modularGroup_S :
+    ((((ModularGroup.S : SL(2, ℤ)) : SL(2, R)) : SL(2, R)) :
+        Matrix (Fin 2) (Fin 2) R) = !![0, -1; 1, 0] := by
+  rw [Matrix.SpecialLinearGroup.coe_matrix_coe, ModularGroup.coe_S]
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp
 
 /-- An element of `SL₂(R)` belongs to the standard Borel exactly when its lower-left entry
 vanishes. -/
@@ -117,14 +126,8 @@ theorem mem_doubleCoset_modularGroup_S_of_notMem {g : SL(2, F)} (hg : g ∉ SL2B
     rw [mem_iff]
     rfl
   refine DoubleCoset.mem_doubleCoset.mpr ⟨x, hx, y, hy, ?_⟩
-  have hS :
-      ((((ModularGroup.S : SL(2, ℤ)) : SL(2, F)) : SL(2, F)) :
-          Matrix (Fin 2) (Fin 2) F) = !![0, -1; 1, 0] := by
-    rw [Matrix.SpecialLinearGroup.coe_matrix_coe, ModularGroup.coe_S]
-    ext i j
-    fin_cases i <;> fin_cases j <;> simp
   apply Subtype.ext
-  rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul, hS]
+  rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul, coe_modularGroup_S]
   dsimp only [x, y]
   rw [Matrix.mul_fin_two, Matrix.mul_fin_two]
   ext i j
@@ -163,13 +166,7 @@ theorem mem_doubleCoset_modularGroup_S_iff {g : SL(2, F)} :
       intro h
       rw [h, zero_mul] at hydet
       exact zero_ne_one hydet
-    have hS :
-        ((((ModularGroup.S : SL(2, ℤ)) : SL(2, F)) : SL(2, F)) :
-            Matrix (Fin 2) (Fin 2) F) = !![0, -1; 1, 0] := by
-      rw [Matrix.SpecialLinearGroup.coe_matrix_coe, ModularGroup.coe_S]
-      ext i j
-      fin_cases i <;> fin_cases j <;> simp
-    rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul, hS]
+    rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul, coe_modularGroup_S]
     simpa only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.of_apply, Matrix.cons_val_one,
       Matrix.cons_val_zero, Matrix.head_cons, neg_mul, one_mul, zero_mul, add_zero, hx10, hy10,
       mul_zero, mul_one, zero_add] using mul_ne_zero hx11 hy00
@@ -181,44 +178,17 @@ theorem closure_insert_modularGroup_S_eq_top :
     Subgroup.closure
         (insert (((ModularGroup.S : SL(2, ℤ)) : SL(2, F)))
           (SL2Borel F : Set SL(2, F))) = ⊤ := by
-  refine eq_top_iff.mpr fun g _ ↦ ?_
-  by_cases hg : g ∈ SL2Borel F
-  · exact Subgroup.subset_closure (Set.mem_insert_of_mem _ hg)
-  · obtain ⟨x, hx, y, hy, rfl⟩ :=
-      DoubleCoset.mem_doubleCoset.mp (mem_doubleCoset_modularGroup_S_of_notMem hg)
-    exact mul_mem
-      (mul_mem (Subgroup.subset_closure (Set.mem_insert_of_mem _ hx))
-        (Subgroup.subset_closure (Set.mem_insert _ _)))
-      (Subgroup.subset_closure (Set.mem_insert_of_mem _ hy))
+  exact closure_insert_eq_top_of_notMem_imp_mem_doubleCoset (SL2Borel F)
+    ((ModularGroup.S : SL(2, ℤ)) : SL(2, F)) mem_doubleCoset_modularGroup_S_of_notMem
 
 /-- Every solvable subgroup of `SL₂` over an infinite field that contains the standard Borel
 is contained in it. -/
 theorem le_of_isSolvable [Infinite F] (P : Subgroup SL(2, F)) [Group.IsSolvable P]
     (hBP : SL2Borel F ≤ P) : P ≤ SL2Borel F := by
-  by_contra hPB
-  obtain ⟨g, hgP, hgB⟩ := SetLike.not_le_iff_exists.mp hPB
-  obtain ⟨x, hx, y, hy, hxy⟩ :=
-    DoubleCoset.mem_doubleCoset.mp (mem_doubleCoset_modularGroup_S_of_notMem hgB)
-  have hwP : ((ModularGroup.S : SL(2, ℤ)) : SL(2, F)) ∈ P := by
-    have hxP := hBP hx
-    have hyP := hBP hy
-    have hprod : x⁻¹ * g * y⁻¹ ∈ P := mul_mem (mul_mem (inv_mem hxP) hgP) (inv_mem hyP)
-    convert hprod using 1
-    rw [hxy]
-    group
-  have hclosure :
-      Subgroup.closure
-          (insert (((ModularGroup.S : SL(2, ℤ)) : SL(2, F)))
-            (SL2Borel F : Set SL(2, F))) ≤ P :=
-    (Subgroup.closure_le P).mpr (Set.insert_subset_iff.mpr ⟨hwP, hBP⟩)
-  rw [closure_insert_modularGroup_S_eq_top] at hclosure
-  have hPtop : P = ⊤ := top_unique hclosure
-  apply Matrix.SpecialLinearGroup.not_isSolvable_fin_two F
-  apply Group.isSolvable_of_surjective (f := P.subtype)
-  intro g
-  refine ⟨⟨g, ?_⟩, rfl⟩
-  rw [hPtop]
-  exact Subgroup.mem_top g
+  exact le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
+    (SL2Borel F) P ((ModularGroup.S : SL(2, ℤ)) : SL(2, F))
+    (Matrix.SpecialLinearGroup.not_isSolvable_fin_two F)
+    mem_doubleCoset_modularGroup_S_of_notMem hBP
 
 end Field
 

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
@@ -1,0 +1,227 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.DoubleCoset
+public import Mathlib.GroupTheory.Solvable
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Borel
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.UpperTriangular.Solvable
+import Mathlib.GroupTheory.IsPerfect
+
+/-!
+# The upper-triangular subgroup of `SL₂`
+
+The standard Borel subgroup of `SL₂(R)` consists of the determinant-one upper-triangular
+matrices. Over a field, its two Bruhat cells are represented by the identity and by
+`ModularGroup.S = !![0, -1; 1, 0]`. Thus the Borel together with `ModularGroup.S` generates
+`SL₂`, and over an infinite field no larger solvable subgroup can contain it.
+
+The maximal-solvability theorem is the abstract-group input for proving that the
+upper-triangular closed subgroup scheme of `SL₂` is a Borel subgroup. The infinitude assumption
+is used only to rule out solvability of `SL₂`; the Bruhat decomposition itself holds over every
+field.
+
+## Main declarations
+
+* `TauCeti.SL2Borel`: the upper-triangular subgroup of `SL₂`.
+* `Matrix.SpecialLinearGroup.not_isSolvable_fin_two`: `SL₂` over an infinite field is not
+  solvable.
+* `TauCeti.SL2Borel.mem_doubleCoset_modularGroup_S_of_notMem`: the big-cell half of the rank-one
+  Bruhat decomposition.
+* `TauCeti.SL2Borel.closure_insert_modularGroup_S_eq_top`: the Borel and the Weyl element generate
+  `SL₂`.
+* `TauCeti.SL2Borel.le_of_isSolvable`: a solvable subgroup containing the Borel is contained in it.
+
+## References
+
+* J. E. Humphreys, *Linear Algebraic Groups*, §28.3.
+* R. Steinberg, *Lectures on Chevalley Groups*, §3.
+- The nonsolvability proof uses Mathlib's `Matrix.SL2.commutator_eq_top`.
+-/
+
+public section
+
+open Matrix
+open scoped MatrixGroups
+
+namespace TauCeti
+
+universe u
+
+/-- The standard upper-triangular subgroup of `SL₂(R)`, obtained by pulling the
+upper-triangular subgroup of `GL₂(R)` back along the canonical inclusion. -/
+abbrev SL2Borel (R : Type u) [CommRing R] : Subgroup SL(2, R) :=
+  (GL2Borel R).comap Matrix.SpecialLinearGroup.toGL
+
+namespace Matrix.SpecialLinearGroup
+
+/-- The special linear group `SL₂` over an infinite field is not solvable. -/
+theorem not_isSolvable_fin_two (F : Type u) [Field F] [Infinite F] :
+    ¬ Group.IsSolvable SL(2, F) := by
+  let S : Set F := {0} ∪ {1} ∪ {-1}
+  let U := {x : F // x ∈ Sᶜ}
+  let _ : Infinite U := (Set.toFinite S).infinite_compl.to_subtype
+  obtain ⟨a, _, _⟩ := exists_pair_ne U
+  have ha0 : (a : F) ≠ 0 := by
+    intro h
+    apply a.property
+    simp [S, h]
+  have ha1 : (a : F) ^ 2 ≠ 1 := by
+    rw [sq_ne_one_iff]
+    constructor
+    · intro h
+      apply a.property
+      simp [S, h]
+    · intro h
+      apply a.property
+      simp [S, h]
+  let _ : Group.IsPerfect SL(2, F) := ⟨Matrix.SL2.commutator_eq_top ha0 ha1⟩
+  have h01 : (0 : Fin 2) ≠ 1 := by decide
+  let t : SL(2, F) := Matrix.SpecialLinearGroup.transvection h01 1
+  have ht : t ≠ 1 := by
+    intro ht
+    have hentry := congrArg
+      (fun s : SL(2, F) ↦ (s : Matrix (Fin 2) (Fin 2) F) 0 1) ht
+    simp [t, Matrix.SpecialLinearGroup.transvection_coe, Matrix.single] at hentry
+  let _ : Nontrivial SL(2, F) := ⟨t, 1, ht⟩
+  exact Group.IsPerfect.not_isSolvable SL(2, F)
+
+end Matrix.SpecialLinearGroup
+
+namespace SL2Borel
+
+section CommRing
+
+variable {R : Type u} [CommRing R]
+
+/-- An element of `SL₂(R)` belongs to the standard Borel exactly when its lower-left entry
+vanishes. -/
+theorem mem_iff {g : SL(2, R)} :
+    g ∈ SL2Borel R ↔ (g : Matrix (Fin 2) (Fin 2) R) 1 0 = 0 := by
+  exact GL2Borel.mem_iff
+
+/-- The canonical inclusion from the `SL₂` Borel to the `GL₂` Borel. -/
+def toGL2Borel : SL2Borel R →* GL2Borel R :=
+  { toFun := fun g ↦ ⟨Matrix.SpecialLinearGroup.toGL g.1, g.2⟩
+    map_one' := Subtype.ext (map_one Matrix.SpecialLinearGroup.toGL)
+    map_mul' := fun g h ↦ Subtype.ext (map_mul Matrix.SpecialLinearGroup.toGL g.1 h.1) }
+
+/-- The inclusion of the `SL₂` Borel into the `GL₂` Borel does not change the underlying
+general linear matrix. -/
+@[simp]
+theorem coe_toGL2Borel (g : SL2Borel R) :
+    (toGL2Borel g : GL (Fin 2) R) = Matrix.SpecialLinearGroup.toGL g.1 :=
+  by
+    rw [toGL2Borel]
+    rfl
+
+/-- The inclusion from the `SL₂` Borel to the `GL₂` Borel is injective. -/
+theorem toGL2Borel_injective : Function.Injective (toGL2Borel (R := R)) := by
+  intro g h hgh
+  apply Subtype.ext
+  apply Matrix.SpecialLinearGroup.toGL_injective
+  exact congrArg Subtype.val hgh
+
+/-- The upper-triangular subgroup of `SL₂(R)` is solvable. -/
+instance instIsSolvable : Group.IsSolvable (SL2Borel R) :=
+  Group.isSolvable_of_isSolvable_injective (toGL2Borel_injective (R := R))
+
+end CommRing
+
+section Field
+
+variable {F : Type u} [Field F]
+
+/-- An element outside the upper-triangular subgroup of `SL₂(F)` lies in the big Bruhat cell
+represented by `ModularGroup.S`. -/
+theorem mem_doubleCoset_modularGroup_S_of_notMem {g : SL(2, F)} (hg : g ∉ SL2Borel F) :
+    g ∈ DoubleCoset.doubleCoset (((ModularGroup.S : SL(2, ℤ)) : SL(2, F)))
+      (SL2Borel F : Set SL(2, F)) (SL2Borel F : Set SL(2, F)) := by
+  have hc : g 1 0 ≠ 0 := by
+    simpa only [mem_iff, not_false_eq_true] using hg
+  let x : SL(2, F) :=
+    ⟨!![1, g 0 0 * (g 1 0)⁻¹; 0, 1], by simp [Matrix.det_fin_two_of]⟩
+  let y : SL(2, F) :=
+    ⟨!![g 1 0, g 1 1; 0, (g 1 0)⁻¹], by simp [Matrix.det_fin_two_of, hc]⟩
+  have hx : x ∈ SL2Borel F := by
+    rw [mem_iff]
+    rfl
+  have hy : y ∈ SL2Borel F := by
+    rw [mem_iff]
+    rfl
+  refine DoubleCoset.mem_doubleCoset.mpr ⟨x, hx, y, hy, ?_⟩
+  have hS :
+      ((((ModularGroup.S : SL(2, ℤ)) : SL(2, F)) : SL(2, F)) :
+          Matrix (Fin 2) (Fin 2) F) = !![0, -1; 1, 0] := by
+    rw [Matrix.SpecialLinearGroup.coe_matrix_coe, ModularGroup.coe_S]
+    ext i j
+    fin_cases i <;> fin_cases j <;> simp
+  apply Subtype.ext
+  rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul, hS]
+  change (g : Matrix (Fin 2) (Fin 2) F) =
+    !![1, g 0 0 * (g 1 0)⁻¹; 0, 1] * !![0, -1; 1, 0] *
+      !![g 1 0, g 1 1; 0, (g 1 0)⁻¹]
+  rw [Matrix.mul_fin_two, Matrix.mul_fin_two]
+  ext i j
+  fin_cases i <;> fin_cases j
+  · simp [hc]
+  · have hdet := g.2
+    rw [Matrix.det_fin_two] at hdet
+    simp
+    field_simp
+    linear_combination -hdet
+  · simp [hc]
+  · simp [hc]
+
+/-- The upper-triangular subgroup and the Weyl element `ModularGroup.S` generate `SL₂(F)`. -/
+theorem closure_insert_modularGroup_S_eq_top :
+    Subgroup.closure
+        (insert (((ModularGroup.S : SL(2, ℤ)) : SL(2, F)))
+          (SL2Borel F : Set SL(2, F))) = ⊤ := by
+  refine eq_top_iff.mpr fun g _ ↦ ?_
+  by_cases hg : g ∈ SL2Borel F
+  · exact Subgroup.subset_closure (Set.mem_insert_of_mem _ hg)
+  · obtain ⟨x, hx, y, hy, rfl⟩ :=
+      DoubleCoset.mem_doubleCoset.mp (mem_doubleCoset_modularGroup_S_of_notMem hg)
+    exact mul_mem
+      (mul_mem (Subgroup.subset_closure (Set.mem_insert_of_mem _ hx))
+        (Subgroup.subset_closure (Set.mem_insert _ _)))
+      (Subgroup.subset_closure (Set.mem_insert_of_mem _ hy))
+
+/-- Every solvable subgroup of `SL₂` over an infinite field that contains the standard Borel
+is contained in it. -/
+theorem le_of_isSolvable [Infinite F] (P : Subgroup SL(2, F)) [Group.IsSolvable P]
+    (hBP : SL2Borel F ≤ P) : P ≤ SL2Borel F := by
+  by_contra hPB
+  obtain ⟨g, hgP, hgB⟩ := SetLike.not_le_iff_exists.mp hPB
+  obtain ⟨x, hx, y, hy, hxy⟩ :=
+    DoubleCoset.mem_doubleCoset.mp (mem_doubleCoset_modularGroup_S_of_notMem hgB)
+  have hwP : ((ModularGroup.S : SL(2, ℤ)) : SL(2, F)) ∈ P := by
+    have hxP := hBP hx
+    have hyP := hBP hy
+    have hprod : x⁻¹ * g * y⁻¹ ∈ P := mul_mem (mul_mem (inv_mem hxP) hgP) (inv_mem hyP)
+    convert hprod using 1
+    rw [hxy]
+    group
+  have hclosure :
+      Subgroup.closure
+          (insert (((ModularGroup.S : SL(2, ℤ)) : SL(2, F)))
+            (SL2Borel F : Set SL(2, F))) ≤ P :=
+    (Subgroup.closure_le P).mpr (Set.insert_subset_iff.mpr ⟨hwP, hBP⟩)
+  rw [closure_insert_modularGroup_S_eq_top] at hclosure
+  have hPtop : P = ⊤ := top_unique hclosure
+  apply Matrix.SpecialLinearGroup.not_isSolvable_fin_two F
+  apply Group.isSolvable_of_surjective (f := P.subtype)
+  intro g
+  refine ⟨⟨g, ?_⟩, rfl⟩
+  rw [hPtop]
+  exact Subgroup.mem_top g
+
+end Field
+
+end SL2Borel
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
@@ -6,10 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.DoubleCoset
-public import Mathlib.GroupTheory.Solvable
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Borel
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.UpperTriangular.Solvable
-import Mathlib.GroupTheory.IsPerfect
+public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Solvable
 
 /-!
 # The upper-triangular subgroup of `SL₂`
@@ -27,10 +26,8 @@ field.
 ## Main declarations
 
 * `TauCeti.SL2Borel`: the upper-triangular subgroup of `SL₂`.
-* `Matrix.SpecialLinearGroup.not_isSolvable_fin_two`: `SL₂` over an infinite field is not
-  solvable.
-* `TauCeti.SL2Borel.mem_doubleCoset_modularGroup_S_of_notMem`: the big-cell half of the rank-one
-  Bruhat decomposition.
+* `TauCeti.SL2Borel.mem_doubleCoset_modularGroup_S_iff`: the big cell of the rank-one Bruhat
+  decomposition is detected by the lower-left entry.
 * `TauCeti.SL2Borel.closure_insert_modularGroup_S_eq_top`: the Borel and the Weyl element generate
   `SL₂`.
 * `TauCeti.SL2Borel.le_of_isSolvable`: a solvable subgroup containing the Borel is contained in it.
@@ -39,7 +36,8 @@ field.
 
 * J. E. Humphreys, *Linear Algebraic Groups*, §28.3.
 * R. Steinberg, *Lectures on Chevalley Groups*, §3.
-- The nonsolvability proof uses Mathlib's `Matrix.SL2.commutator_eq_top`.
+* The proofs of `closure_insert_modularGroup_S_eq_top` and `le_of_isSolvable` adapt the formal
+  templates `GL2Borel.closure_insert_gl2WeylElement_eq_top` and `GL2Borel.le_of_isSolvable`.
 -/
 
 public section
@@ -56,41 +54,6 @@ upper-triangular subgroup of `GL₂(R)` back along the canonical inclusion. -/
 abbrev SL2Borel (R : Type u) [CommRing R] : Subgroup SL(2, R) :=
   (GL2Borel R).comap Matrix.SpecialLinearGroup.toGL
 
-namespace Matrix.SpecialLinearGroup
-
-/-- The special linear group `SL₂` over an infinite field is not solvable. -/
-theorem not_isSolvable_fin_two (F : Type u) [Field F] [Infinite F] :
-    ¬ Group.IsSolvable SL(2, F) := by
-  let S : Set F := {0} ∪ {1} ∪ {-1}
-  let U := {x : F // x ∈ Sᶜ}
-  let _ : Infinite U := (Set.toFinite S).infinite_compl.to_subtype
-  obtain ⟨a, _, _⟩ := exists_pair_ne U
-  have ha0 : (a : F) ≠ 0 := by
-    intro h
-    apply a.property
-    simp [S, h]
-  have ha1 : (a : F) ^ 2 ≠ 1 := by
-    rw [sq_ne_one_iff]
-    constructor
-    · intro h
-      apply a.property
-      simp [S, h]
-    · intro h
-      apply a.property
-      simp [S, h]
-  let _ : Group.IsPerfect SL(2, F) := ⟨Matrix.SL2.commutator_eq_top ha0 ha1⟩
-  have h01 : (0 : Fin 2) ≠ 1 := by decide
-  let t : SL(2, F) := Matrix.SpecialLinearGroup.transvection h01 1
-  have ht : t ≠ 1 := by
-    intro ht
-    have hentry := congrArg
-      (fun s : SL(2, F) ↦ (s : Matrix (Fin 2) (Fin 2) F) 0 1) ht
-    simp [t, Matrix.SpecialLinearGroup.transvection_coe, Matrix.single] at hentry
-  let _ : Nontrivial SL(2, F) := ⟨t, 1, ht⟩
-  exact Group.IsPerfect.not_isSolvable SL(2, F)
-
-end Matrix.SpecialLinearGroup
-
 namespace SL2Borel
 
 section CommRing
@@ -103,11 +66,15 @@ theorem mem_iff {g : SL(2, R)} :
     g ∈ SL2Borel R ↔ (g : Matrix (Fin 2) (Fin 2) R) 1 0 = 0 := by
   exact GL2Borel.mem_iff
 
+/-- The lower-left entry of an element of the standard Borel subgroup vanishes. -/
+@[simp]
+theorem apply_one_zero (g : SL2Borel R) :
+    (g : Matrix (Fin 2) (Fin 2) R) 1 0 = 0 :=
+  mem_iff.mp g.2
+
 /-- The canonical inclusion from the `SL₂` Borel to the `GL₂` Borel. -/
 def toGL2Borel : SL2Borel R →* GL2Borel R :=
-  { toFun := fun g ↦ ⟨Matrix.SpecialLinearGroup.toGL g.1, g.2⟩
-    map_one' := Subtype.ext (map_one Matrix.SpecialLinearGroup.toGL)
-    map_mul' := fun g h ↦ Subtype.ext (map_mul Matrix.SpecialLinearGroup.toGL g.1 h.1) }
+  Matrix.SpecialLinearGroup.toGL.restrict fun _ hg ↦ hg
 
 /-- The inclusion of the `SL₂` Borel into the `GL₂` Borel does not change the underlying
 general linear matrix. -/
@@ -115,15 +82,12 @@ general linear matrix. -/
 theorem coe_toGL2Borel (g : SL2Borel R) :
     (toGL2Borel g : GL (Fin 2) R) = Matrix.SpecialLinearGroup.toGL g.1 :=
   by
-    rw [toGL2Borel]
-    rfl
+    simp only [toGL2Borel, MonoidHom.restrict, MonoidHom.codRestrict_apply,
+      MonoidHom.domRestrict_apply]
 
 /-- The inclusion from the `SL₂` Borel to the `GL₂` Borel is injective. -/
-theorem toGL2Borel_injective : Function.Injective (toGL2Borel (R := R)) := by
-  intro g h hgh
-  apply Subtype.ext
-  apply Matrix.SpecialLinearGroup.toGL_injective
-  exact congrArg Subtype.val hgh
+theorem toGL2Borel_injective : Function.Injective (toGL2Borel (R := R)) :=
+  MonoidHom.restrict_injective _ Matrix.SpecialLinearGroup.toGL_injective
 
 /-- The upper-triangular subgroup of `SL₂(R)` is solvable. -/
 instance instIsSolvable : Group.IsSolvable (SL2Borel R) :=
@@ -161,9 +125,7 @@ theorem mem_doubleCoset_modularGroup_S_of_notMem {g : SL(2, F)} (hg : g ∉ SL2B
     fin_cases i <;> fin_cases j <;> simp
   apply Subtype.ext
   rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul, hS]
-  change (g : Matrix (Fin 2) (Fin 2) F) =
-    !![1, g 0 0 * (g 1 0)⁻¹; 0, 1] * !![0, -1; 1, 0] *
-      !![g 1 0, g 1 1; 0, (g 1 0)⁻¹]
+  dsimp only [x, y]
   rw [Matrix.mul_fin_two, Matrix.mul_fin_two]
   ext i j
   fin_cases i <;> fin_cases j
@@ -175,6 +137,44 @@ theorem mem_doubleCoset_modularGroup_S_of_notMem {g : SL(2, F)} (hg : g ∉ SL2B
     linear_combination -hdet
   · simp [hc]
   · simp [hc]
+
+/-- **The lower-left entry detects the big cell.** An element of `SL₂(F)` lies in the double
+coset of `ModularGroup.S` by the standard Borel exactly when its lower-left entry is nonzero.
+
+Not a `simp` lemma: `TauCeti.mem_doubleCoset_iff_mk_mem_orbit` rewrites double-coset membership
+to orbit membership, so the left-hand side is not simp-normal. -/
+theorem mem_doubleCoset_modularGroup_S_iff {g : SL(2, F)} :
+    g ∈ DoubleCoset.doubleCoset (((ModularGroup.S : SL(2, ℤ)) : SL(2, F)))
+      (SL2Borel F : Set SL(2, F)) (SL2Borel F : Set SL(2, F)) ↔ g 1 0 ≠ 0 := by
+  constructor
+  · intro hg
+    obtain ⟨x, hx, y, hy, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hg
+    have hx10 : x 1 0 = 0 := mem_iff.mp hx
+    have hy10 : y 1 0 = 0 := mem_iff.mp hy
+    have hxdet : x 0 0 * x 1 1 = 1 := by
+      simpa only [Matrix.det_fin_two, hx10, mul_zero, sub_zero] using x.2
+    have hydet : y 0 0 * y 1 1 = 1 := by
+      simpa only [Matrix.det_fin_two, hy10, mul_zero, sub_zero] using y.2
+    have hx11 : x 1 1 ≠ 0 := by
+      intro h
+      rw [h, mul_zero] at hxdet
+      exact zero_ne_one hxdet
+    have hy00 : y 0 0 ≠ 0 := by
+      intro h
+      rw [h, zero_mul] at hydet
+      exact zero_ne_one hydet
+    have hS :
+        ((((ModularGroup.S : SL(2, ℤ)) : SL(2, F)) : SL(2, F)) :
+            Matrix (Fin 2) (Fin 2) F) = !![0, -1; 1, 0] := by
+      rw [Matrix.SpecialLinearGroup.coe_matrix_coe, ModularGroup.coe_S]
+      ext i j
+      fin_cases i <;> fin_cases j <;> simp
+    rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul, hS]
+    simpa only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.of_apply, Matrix.cons_val_one,
+      Matrix.cons_val_zero, Matrix.head_cons, neg_mul, one_mul, zero_mul, add_zero, hx10, hy10,
+      mul_zero, mul_one, zero_add] using mul_ne_zero hx11 hy00
+  · intro hg
+    exact mem_doubleCoset_modularGroup_S_of_notMem (mem_iff.not.mpr hg)
 
 /-- The upper-triangular subgroup and the Weyl element `ModularGroup.S` generate `SL₂(F)`. -/
 theorem closure_insert_modularGroup_S_eq_top :

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.GroupTheory.DoubleCoset
 public import Mathlib.GroupTheory.Solvable
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Borel
-import TauCeti.GroupTheory.DoubleCoset.Identity
+import TauCeti.GroupTheory.DoubleCoset.Generation
 import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.UpperTriangular.Solvable
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Solvable
 
@@ -18,11 +18,12 @@ import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Solvable
 The standard Borel subgroup of `SL₂(R)` consists of the determinant-one upper-triangular
 matrices. Over a field, its two Bruhat cells are represented by the identity and by
 `ModularGroup.S = !![0, -1; 1, 0]`. Thus the Borel together with `ModularGroup.S` generates
-`SL₂`, and over an infinite field no larger solvable subgroup can contain it.
+`SL₂`, and no larger solvable subgroup can contain it whenever the field has a nonzero
+element whose square is not one. In particular, this holds over every infinite field.
 
 The maximal-solvability theorem is the abstract-group input for proving that the
-upper-triangular closed subgroup scheme of `SL₂` is a Borel subgroup. The infinitude assumption
-is used only to rule out solvability of `SL₂`; the Bruhat decomposition itself holds over every
+upper-triangular closed subgroup scheme of `SL₂` is a Borel subgroup. The field hypothesis is
+used only to rule out solvability of `SL₂`; the Bruhat decomposition itself holds over every
 field.
 
 ## Main declarations
@@ -32,7 +33,8 @@ field.
   decomposition is detected by the lower-left entry.
 * `TauCeti.SL2Borel.closure_insert_modularGroup_S_eq_top`: the Borel and the Weyl element generate
   `SL₂`.
-* `TauCeti.SL2Borel.le_of_isSolvable`: a solvable subgroup containing the Borel is contained in it.
+* `TauCeti.SL2Borel.le_of_isSolvable`: a solvable subgroup containing the Borel is contained in it
+  when the field contains a nonzero element whose square is not one.
 
 ## References
 
@@ -181,13 +183,24 @@ theorem closure_insert_modularGroup_S_eq_top :
   exact closure_insert_eq_top_of_notMem_imp_mem_doubleCoset (SL2Borel F)
     ((ModularGroup.S : SL(2, ℤ)) : SL(2, F)) mem_doubleCoset_modularGroup_S_of_notMem
 
-/-- Every solvable subgroup of `SL₂` over an infinite field that contains the standard Borel
-is contained in it. -/
-theorem le_of_isSolvable [Infinite F] (P : Subgroup SL(2, F)) [Group.IsSolvable P]
+/-- Every solvable subgroup of `SL₂(F)` that contains the standard Borel is contained in it if
+`F` has a nonzero element whose square is not one. -/
+theorem le_of_isSolvable (hF : ∃ a : F, a ≠ 0 ∧ a ^ 2 ≠ 1)
+    (P : Subgroup SL(2, F)) [Group.IsSolvable P]
     (hBP : SL2Borel F ≤ P) : P ≤ SL2Borel F := by
   exact le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
     (SL2Borel F) P ((ModularGroup.S : SL(2, ℤ)) : SL(2, F))
-    (Matrix.SpecialLinearGroup.not_isSolvable_fin_two F)
+    (Matrix.SpecialLinearGroup.not_isSolvable_fin_two F hF)
+    mem_doubleCoset_modularGroup_S_of_notMem hBP
+
+/-- Every solvable subgroup of `SL₂` over an infinite field that contains the standard Borel
+is contained in it. -/
+theorem le_of_isSolvable_of_infinite [Infinite F]
+    (P : Subgroup SL(2, F)) [Group.IsSolvable P]
+    (hBP : SL2Borel F ≤ P) : P ≤ SL2Borel F := by
+  exact le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
+    (SL2Borel F) P ((ModularGroup.S : SL(2, ℤ)) : SL(2, F))
+    (Matrix.SpecialLinearGroup.not_isSolvable_fin_two_of_infinite F)
     mem_doubleCoset_modularGroup_S_of_notMem hBP
 
 end Field

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
@@ -40,8 +40,6 @@ field.
 
 * J. E. Humphreys, *Linear Algebraic Groups*, §28.3.
 * R. Steinberg, *Lectures on Chevalley Groups*, §3.
-* The proofs of `closure_insert_modularGroup_S_eq_top` and `le_of_isSolvable` use the same generic
-  two-double-coset lemmas as their `GL₂` counterparts.
 -/
 
 public section
@@ -55,7 +53,7 @@ universe u
 
 /-- The standard upper-triangular subgroup of `SL₂(R)`, obtained by pulling the
 upper-triangular subgroup of `GL₂(R)` back along the canonical inclusion. -/
-abbrev SL2Borel (R : Type u) [CommRing R] : Subgroup SL(2, R) :=
+def SL2Borel (R : Type u) [CommRing R] : Subgroup SL(2, R) :=
   (GL2Borel R).comap Matrix.SpecialLinearGroup.toGL
 
 namespace SL2Borel
@@ -73,9 +71,11 @@ private theorem coe_modularGroup_S :
 
 /-- An element of `SL₂(R)` belongs to the standard Borel exactly when its lower-left entry
 vanishes. -/
+@[simp]
 theorem mem_iff {g : SL(2, R)} :
     g ∈ SL2Borel R ↔ (g : Matrix (Fin 2) (Fin 2) R) 1 0 = 0 := by
-  exact GL2Borel.mem_iff
+  change Matrix.SpecialLinearGroup.toGL g ∈ GL2Borel R ↔ _
+  rw [GL2Borel.mem_iff, Matrix.SpecialLinearGroup.coe_GL_coe_matrix]
 
 /-- The lower-left entry of an element of the standard Borel subgroup vanishes. -/
 @[simp]
@@ -85,7 +85,8 @@ theorem apply_one_zero (g : SL2Borel R) :
 
 /-- The canonical inclusion from the `SL₂` Borel to the `GL₂` Borel. -/
 def toGL2Borel : SL2Borel R →* GL2Borel R :=
-  Matrix.SpecialLinearGroup.toGL.restrict fun _ hg ↦ hg
+  Matrix.SpecialLinearGroup.toGL.restrict fun _ hg ↦ by
+    exact GL2Borel.mem_iff.mpr (mem_iff.mp hg)
 
 /-- The inclusion of the `SL₂` Borel into the `GL₂` Borel does not change the underlying
 general linear matrix. -/

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
@@ -10,6 +10,7 @@ public import Mathlib.GroupTheory.Solvable
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Borel
 import TauCeti.GroupTheory.DoubleCoset.Generation
 import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.UpperTriangular.Solvable
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.ModularGroup
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Solvable
 
 /-!
@@ -62,20 +63,13 @@ section CommRing
 
 variable {R : Type u} [CommRing R]
 
-private theorem coe_modularGroup_S :
-    ((((ModularGroup.S : SL(2, ℤ)) : SL(2, R)) : SL(2, R)) :
-        Matrix (Fin 2) (Fin 2) R) = !![0, -1; 1, 0] := by
-  rw [Matrix.SpecialLinearGroup.coe_matrix_coe, ModularGroup.coe_S]
-  ext i j
-  fin_cases i <;> fin_cases j <;> simp
-
 /-- An element of `SL₂(R)` belongs to the standard Borel exactly when its lower-left entry
 vanishes. -/
 @[simp]
 theorem mem_iff {g : SL(2, R)} :
     g ∈ SL2Borel R ↔ (g : Matrix (Fin 2) (Fin 2) R) 1 0 = 0 := by
-  change Matrix.SpecialLinearGroup.toGL g ∈ GL2Borel R ↔ _
-  rw [GL2Borel.mem_iff, Matrix.SpecialLinearGroup.coe_GL_coe_matrix]
+  rw [SL2Borel, Subgroup.mem_comap, GL2Borel.mem_iff,
+    Matrix.SpecialLinearGroup.coe_GL_coe_matrix]
 
 /-- The lower-left entry of an element of the standard Borel subgroup vanishes. -/
 @[simp]
@@ -130,7 +124,8 @@ theorem mem_doubleCoset_modularGroup_S_of_notMem {g : SL(2, F)} (hg : g ∉ SL2B
     rfl
   refine DoubleCoset.mem_doubleCoset.mpr ⟨x, hx, y, hy, ?_⟩
   apply Subtype.ext
-  rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul, coe_modularGroup_S]
+  rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul,
+    TauCeti.Matrix.SpecialLinearGroup.coe_modularGroup_S]
   dsimp only [x, y]
   rw [Matrix.mul_fin_two, Matrix.mul_fin_two]
   ext i j
@@ -169,7 +164,8 @@ theorem mem_doubleCoset_modularGroup_S_iff {g : SL(2, F)} :
       intro h
       rw [h, zero_mul] at hydet
       exact zero_ne_one hydet
-    rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul, coe_modularGroup_S]
+    rw [Matrix.SpecialLinearGroup.coe_mul, Matrix.SpecialLinearGroup.coe_mul,
+      TauCeti.Matrix.SpecialLinearGroup.coe_modularGroup_S]
     simpa only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.of_apply, Matrix.cons_val_one,
       Matrix.cons_val_zero, Matrix.head_cons, neg_mul, one_mul, zero_mul, add_zero, hx10, hy10,
       mul_zero, mul_one, zero_add] using mul_ne_zero hx11 hy00

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
@@ -204,4 +204,12 @@ end Field
 
 end SL2Borel
 
+/-- The standard Borel of `SL₂(R)` is the pullback of the standard Borel of `GL₂(R)` along the
+canonical inclusion. -/
+theorem SL2Borel_def (R : Type u) [CommRing R] :
+    SL2Borel R = (GL2Borel R).comap Matrix.SpecialLinearGroup.toGL := by
+  ext g
+  rw [SL2Borel.mem_iff, Subgroup.mem_comap, GL2Borel.mem_iff,
+    Matrix.SpecialLinearGroup.coe_GL_coe_matrix]
+
 end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
@@ -177,7 +177,7 @@ theorem closure_insert_modularGroup_S_eq_top :
     Subgroup.closure
         (insert (((ModularGroup.S : SL(2, ℤ)) : SL(2, F)))
           (SL2Borel F : Set SL(2, F))) = ⊤ := by
-  exact closure_insert_eq_top_of_notMem_imp_mem_doubleCoset (SL2Borel F)
+  exact Subgroup.closure_insert_eq_top_of_notMem_imp_mem_doubleCoset (SL2Borel F)
     ((ModularGroup.S : SL(2, ℤ)) : SL(2, F)) mem_doubleCoset_modularGroup_S_of_notMem
 
 /-- Every solvable subgroup of `SL₂(F)` that contains the standard Borel is contained in it if
@@ -185,7 +185,7 @@ theorem closure_insert_modularGroup_S_eq_top :
 theorem le_of_isSolvable (hF : ∃ a : F, a ≠ 0 ∧ a ^ 2 ≠ 1)
     (P : Subgroup SL(2, F)) [Group.IsSolvable P]
     (hBP : SL2Borel F ≤ P) : P ≤ SL2Borel F := by
-  exact le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
+  exact Subgroup.le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
     (SL2Borel F) P ((ModularGroup.S : SL(2, ℤ)) : SL(2, F))
     (Matrix.SpecialLinearGroup.not_isSolvable_fin_two F hF)
     mem_doubleCoset_modularGroup_S_of_notMem hBP
@@ -195,7 +195,7 @@ is contained in it. -/
 theorem le_of_isSolvable_of_infinite [Infinite F]
     (P : Subgroup SL(2, F)) [Group.IsSolvable P]
     (hBP : SL2Borel F ≤ P) : P ≤ SL2Borel F := by
-  exact le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
+  exact Subgroup.le_of_isSolvable_of_not_isSolvable_of_notMem_imp_mem_doubleCoset
     (SL2Borel F) P ((ModularGroup.S : SL(2, ℤ)) : SL(2, F))
     (Matrix.SpecialLinearGroup.not_isSolvable_fin_two_of_infinite F)
     mem_doubleCoset_modularGroup_S_of_notMem hBP

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean
@@ -204,12 +204,4 @@ end Field
 
 end SL2Borel
 
-/-- The standard Borel of `SL₂(R)` is the pullback of the standard Borel of `GL₂(R)` along the
-canonical inclusion. -/
-theorem SL2Borel_def (R : Type u) [CommRing R] :
-    SL2Borel R = (GL2Borel R).comap Matrix.SpecialLinearGroup.toGL := by
-  ext g
-  rw [SL2Borel.mem_iff, Subgroup.mem_comap, GL2Borel.mem_iff,
-    Matrix.SpecialLinearGroup.coe_GL_coe_matrix]
-
 end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/ModularGroup.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/ModularGroup.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+
+/-!
+# The modular-group generator in special linear groups
+
+This module records the matrix of the standard modular-group generator after scalar extension
+from `SL₂(ℤ)` to `SL₂(R)`.
+
+## Main declaration
+
+* `TauCeti.Matrix.SpecialLinearGroup.coe_modularGroup_S`: the scalar extension of
+  `ModularGroup.S` has matrix `!![0, -1; 1, 0]`.
+-/
+
+public section
+
+open Matrix
+open scoped MatrixGroups
+
+namespace TauCeti.Matrix.SpecialLinearGroup
+
+universe u
+
+/-- The scalar extension of `ModularGroup.S` to a commutative ring has its standard matrix. -/
+@[simp]
+theorem coe_modularGroup_S {R : Type u} [CommRing R] :
+    (((ModularGroup.S : SL(2, ℤ)) : SL(2, R)) : Matrix (Fin 2) (Fin 2) R) =
+      !![0, -1; 1, 0] := by
+  rw [Matrix.SpecialLinearGroup.coe_matrix_coe, ModularGroup.coe_S]
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp
+
+end TauCeti.Matrix.SpecialLinearGroup

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/ModularGroup.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/ModularGroup.lean
@@ -29,6 +29,7 @@ namespace TauCeti.Matrix.SpecialLinearGroup
 universe u
 
 /-- The scalar extension of `ModularGroup.S` to a commutative ring has its standard matrix. -/
+@[simp]
 theorem coe_modularGroup_S {R : Type u} [CommRing R] :
     (((ModularGroup.S : SL(2, ℤ)) : SL(2, R)) : Matrix (Fin 2) (Fin 2) R) =
       !![0, -1; 1, 0] := by

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/ModularGroup.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/ModularGroup.lean
@@ -29,7 +29,6 @@ namespace TauCeti.Matrix.SpecialLinearGroup
 universe u
 
 /-- The scalar extension of `ModularGroup.S` to a commutative ring has its standard matrix. -/
-@[simp]
 theorem coe_modularGroup_S {R : Type u} [CommRing R] :
     (((ModularGroup.S : SL(2, ℤ)) : SL(2, R)) : Matrix (Fin 2) (Fin 2) R) =
       !![0, -1; 1, 0] := by

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Solvable.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Solvable.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.Solvable
+public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+import Mathlib.GroupTheory.IsPerfect
+
+/-!
+# Nonsolvability of `SL₂`
+
+Over an infinite field, `SL₂` is nonsolvable. The proof uses Mathlib's computation that its
+commutator subgroup is the whole group.
+
+## Main declaration
+
+* `Matrix.SpecialLinearGroup.not_isSolvable_fin_two`: `SL₂` over an infinite field is not
+  solvable.
+-/
+
+public section
+
+open scoped MatrixGroups
+
+namespace TauCeti.Matrix.SpecialLinearGroup
+
+universe u
+
+/-- The special linear group `SL₂` over an infinite field is not solvable. -/
+theorem not_isSolvable_fin_two (F : Type u) [Field F] [Infinite F] :
+    ¬ Group.IsSolvable SL(2, F) := by
+  let S : Set F := {0} ∪ {1} ∪ {-1}
+  let U := {x : F // x ∈ Sᶜ}
+  let _ : Infinite U := (Set.toFinite S).infinite_compl.to_subtype
+  obtain ⟨a, _, _⟩ := exists_pair_ne U
+  have ha0 : (a : F) ≠ 0 := by
+    intro h
+    apply a.property
+    simp [S, h]
+  have ha1 : (a : F) ^ 2 ≠ 1 := by
+    rw [sq_ne_one_iff]
+    constructor
+    · intro h
+      apply a.property
+      simp [S, h]
+    · intro h
+      apply a.property
+      simp [S, h]
+  let _ : Group.IsPerfect SL(2, F) := ⟨Matrix.SL2.commutator_eq_top ha0 ha1⟩
+  have h01 : (0 : Fin 2) ≠ 1 := by decide
+  let t : SL(2, F) := Matrix.SpecialLinearGroup.transvection h01 1
+  have ht : t ≠ 1 := by
+    intro ht
+    have hentry := congrArg
+      (fun s : SL(2, F) ↦ (s : Matrix (Fin 2) (Fin 2) F) 0 1) ht
+    simp [t, Matrix.SpecialLinearGroup.transvection_coe, Matrix.single] at hentry
+  let _ : Nontrivial SL(2, F) := ⟨t, 1, ht⟩
+  exact Group.IsPerfect.not_isSolvable SL(2, F)
+
+end TauCeti.Matrix.SpecialLinearGroup

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Solvable.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Solvable.lean
@@ -51,23 +51,10 @@ theorem not_isSolvable_fin_two (F : Type u) [Field F]
 theorem not_isSolvable_fin_two_of_infinite (F : Type u) [Field F] [Infinite F] :
     ¬ Group.IsSolvable SL(2, F) := by
   apply not_isSolvable_fin_two F
-  let S : Set F := {0} ∪ {1} ∪ {-1}
-  let U := {x : F // x ∈ Sᶜ}
-  let _ : Infinite U := (Set.toFinite S).infinite_compl.to_subtype
-  obtain ⟨a, _, _⟩ := exists_pair_ne U
-  have ha0 : (a : F) ≠ 0 := by
-    intro h
-    apply a.property
-    simp [S, h]
-  have ha1 : (a : F) ^ 2 ≠ 1 := by
-    rw [sq_ne_one_iff]
-    constructor
-    · intro h
-      apply a.property
-      simp [S, h]
-    · intro h
-      apply a.property
-      simp [S, h]
-  exact ⟨a, ha0, ha1⟩
+  classical
+  obtain ⟨a, ha⟩ := Infinite.exists_notMem_finset ({0, 1, -1} : Finset F)
+  have ha' : a ≠ 0 ∧ a ≠ 1 ∧ a ≠ -1 := by
+    simpa only [Finset.mem_insert, Finset.mem_singleton, not_or] using ha
+  exact ⟨a, ha'.1, sq_ne_one_iff.mpr ha'.2⟩
 
 end TauCeti.Matrix.SpecialLinearGroup

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Solvable.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Solvable.lean
@@ -13,8 +13,7 @@ import Mathlib.GroupTheory.IsPerfect
 # Nonsolvability of `SL₂`
 
 If a field contains an element `a` with `a ≠ 0` and `a² ≠ 1`, then `SL₂` is nonsolvable.
-In particular, this holds over every infinite field. The proof uses Mathlib's computation that
-the commutator subgroup is the whole group.
+In particular, this holds over every infinite field.
 
 ## Main declarations
 

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Solvable.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Solvable.lean
@@ -12,13 +12,16 @@ import Mathlib.GroupTheory.IsPerfect
 /-!
 # Nonsolvability of `SL₂`
 
-Over an infinite field, `SL₂` is nonsolvable. The proof uses Mathlib's computation that its
-commutator subgroup is the whole group.
+If a field contains an element `a` with `a ≠ 0` and `a² ≠ 1`, then `SL₂` is nonsolvable.
+In particular, this holds over every infinite field. The proof uses Mathlib's computation that
+the commutator subgroup is the whole group.
 
-## Main declaration
+## Main declarations
 
-* `Matrix.SpecialLinearGroup.not_isSolvable_fin_two`: `SL₂` over an infinite field is not
-  solvable.
+* `TauCeti.Matrix.SpecialLinearGroup.not_isSolvable_fin_two`: `SL₂` is not solvable when the
+  field contains an element outside the roots of `X * (X² - 1)`.
+* `TauCeti.Matrix.SpecialLinearGroup.not_isSolvable_fin_two_of_infinite`: the infinite-field
+  specialization.
 -/
 
 public section
@@ -29,9 +32,26 @@ namespace TauCeti.Matrix.SpecialLinearGroup
 
 universe u
 
+/-- The special linear group `SL₂(F)` is not solvable if `F` contains a nonzero element whose
+square is not one. -/
+theorem not_isSolvable_fin_two (F : Type u) [Field F]
+    (hF : ∃ a : F, a ≠ 0 ∧ a ^ 2 ≠ 1) : ¬ Group.IsSolvable SL(2, F) := by
+  obtain ⟨a, ha0, ha1⟩ := hF
+  let _ : Group.IsPerfect SL(2, F) := ⟨Matrix.SL2.commutator_eq_top ha0 ha1⟩
+  have h01 : (0 : Fin 2) ≠ 1 := by decide
+  let t : SL(2, F) := Matrix.SpecialLinearGroup.transvection h01 1
+  have ht : t ≠ 1 := by
+    intro ht
+    have hentry := congrArg
+      (fun s : SL(2, F) ↦ (s : Matrix (Fin 2) (Fin 2) F) 0 1) ht
+    simp [t, Matrix.SpecialLinearGroup.transvection_coe, Matrix.single] at hentry
+  let _ : Nontrivial SL(2, F) := ⟨t, 1, ht⟩
+  exact Group.IsPerfect.not_isSolvable SL(2, F)
+
 /-- The special linear group `SL₂` over an infinite field is not solvable. -/
-theorem not_isSolvable_fin_two (F : Type u) [Field F] [Infinite F] :
+theorem not_isSolvable_fin_two_of_infinite (F : Type u) [Field F] [Infinite F] :
     ¬ Group.IsSolvable SL(2, F) := by
+  apply not_isSolvable_fin_two F
   let S : Set F := {0} ∪ {1} ∪ {-1}
   let U := {x : F // x ∈ Sᶜ}
   let _ : Infinite U := (Set.toFinite S).infinite_compl.to_subtype
@@ -49,15 +69,6 @@ theorem not_isSolvable_fin_two (F : Type u) [Field F] [Infinite F] :
     · intro h
       apply a.property
       simp [S, h]
-  let _ : Group.IsPerfect SL(2, F) := ⟨Matrix.SL2.commutator_eq_top ha0 ha1⟩
-  have h01 : (0 : Fin 2) ≠ 1 := by decide
-  let t : SL(2, F) := Matrix.SpecialLinearGroup.transvection h01 1
-  have ht : t ≠ 1 := by
-    intro ht
-    have hentry := congrArg
-      (fun s : SL(2, F) ↦ (s : Matrix (Fin 2) (Fin 2) F) 0 1) ht
-    simp [t, Matrix.SpecialLinearGroup.transvection_coe, Matrix.single] at hentry
-  let _ : Nontrivial SL(2, F) := ⟨t, 1, ht⟩
-  exact Group.IsPerfect.not_isSolvable SL(2, F)
+  exact ⟨a, ha0, ha1⟩
 
 end TauCeti.Matrix.SpecialLinearGroup


### PR DESCRIPTION
This PR proves that the determinant-one upper-triangular subgroup of `SL₂` is maximal among solvable subgroups over every infinite field. It defines `TauCeti.SL2Borel`, gives its matrix membership and solvability API, proves the big-cell factorization `g = x S y` for every non-upper-triangular element, and deduces both generation by the Borel and `ModularGroup.S` and maximal solvability.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 7, “Borel subgroups, maximal tori, and their conjugacy,” and the designated milestone it serves is Layer 9, “Pinnings,” whose datum `(G, T, B, {X_α})` requires a Borel containing the split torus. The declaration-level dependency edge is the type-`A₁` upper-triangular closed subgroup scheme → `HopfIdeal.IsBorel` maximality over the algebraic closure → `SL2Borel.le_of_isSolvable`; the algebraic closure is infinite, exactly matching the theorem’s hypothesis. After this PR, the type-`A₁` pinning step still needs the coordinate-side smoothness and geometric connectedness of the upper-triangular `SL₂` subgroup and the reduced-point-separation argument transporting this abstract maximality to `HopfIdeal.IsBorel`.

This is the most effective current step because Tau Ceti already has the upper-triangular `SL` carrier and the geometric Borel predicate, while its only maximal-solvability theorem was for `GL₂`; the missing determinant-one rank-one theorem is the precise maximality input for the first special-linear Borel example. The existing `Matrix.GeneralLinearGroup.not_isSolvable_fin_two` now reuses the stronger new `SL₂` nonsolvability theorem, removing its duplicated perfectness argument.

The proof reuses Mathlib’s `ModularGroup.S`, `Matrix.SL2.commutator_eq_top`, the special-linear scalar-extension map, and Tau Ceti’s upper-triangular solvability instance. No Mathlib infrastructure is vendored. The Bruhat and Borel argument follows Humphreys, *Linear Algebraic Groups*, §28.3, and Steinberg, *Lectures on Chevalley Groups*, §3, as cited in the module documentation.

The change adds `TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Borel.lean` in 227 lines and simplifies the existing `GeneralLinearGroup/Bruhat.lean` proof by 31 lines.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"sl2-borel-maximal-solvable"}-->

🤖 Prepared with Codex
