### PR TITLE
feat: identify special torus squares with Frobenius

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Frobenius.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Frobenius.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Scheme.Points
+public import TauCeti.Algebra.AlgebraicGroup.Frobenius.Points
+
+/-!
+# Frobenius on diagonalizable groups
+
+Let `A` be a commutative ring of exponential characteristic `p`. For any finitely generated
+commutative group `G`, applying the `n`-fold Frobenius of `A` to an `A`-valued point of the
+diagonalizable group `D(G)` agrees, under the coordinate-algebra comparison, with the existing
+Frobenius endomorphism on convolution points.
+
+## Main result
+
+* `TauCeti.DiagonalizableGroup.groupSchemePointsMulEquiv_mapValue_iterateFrobenius`: the
+  scheme-point and convolution-point descriptions of iterated Frobenius agree.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Sections 12 and 13.
+-/
+
+public section
+
+open CategoryTheory
+open AlgebraicGeometry
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.DiagonalizableGroup
+
+variable {A : Type} [CommRing A]
+variable (p n : ℕ) [ExpChar A p]
+
+/-- Under the coordinate-algebra comparison for a diagonalizable group, applying the iterated
+Frobenius of the value ring is the existing Frobenius endomorphism on convolution points. -/
+theorem groupSchemePointsMulEquiv_mapValue_iterateFrobenius (G : FGCommGrpCat)
+    (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (groupScheme ℤ G).X) :
+    groupSchemePointsMulEquiv (R := ℤ) (A := A) G
+        ((Spec.map (CommRingCat.ofHom (iterateFrobenius A p n).toIntAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of ℤ)) ≫ q) =
+      Bialgebra.iterateFrobeniusPoints p n
+        (groupSchemePointsMulEquiv (R := ℤ) (A := A) G q) := by
+  rw [groupSchemePointsMulEquiv_mapValue,
+    Bialgebra.iterateFrobeniusPoints_apply, AlgHom.mapValue_apply]
+
+end TauCeti.DiagonalizableGroup

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Frobenius.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Frobenius.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Frobenius.Points
+public import TauCeti.Algebra.AlgebraicGroup.SplitTorus.LinearMap
+
+/-!
+# Frobenius on split tori
+
+Let `A` be a commutative ring of exponential characteristic `p`. On the `A`-valued points of an
+integral split torus, post-composition with the `n`-fold Frobenius of `A` agrees with the
+group-scheme power endomorphism of exponent `p ^ n`. Thus the coordinate-free Frobenius on
+convolution points, the functorial action on scheme-valued points, and coordinatewise powering
+all describe the same endomorphism.
+
+This comparison is the bridge needed to read the square of a special isogeny on a split maximal
+torus as Frobenius rather than merely as an abstract power map.
+
+## Main results
+
+* `TauCeti.SplitTorus.groupSchemePointsMulEquiv_mapValue_iterateFrobenius`: under the
+  coordinate-algebra comparison, functoriality along Frobenius is the existing convolution-point
+  Frobenius.
+* `TauCeti.SplitTorus.mapValue_iterateFrobenius_eq_comp_powEnd`: on scheme-valued points, the
+  `n`-fold Frobenius is composition with the power endomorphism of exponent `p ^ n`.
+* `TauCeti.SplitTorus.mapValue_iterateFrobenius_eq_self_iff`: a point is fixed by the iterated
+  Frobenius exactly when each torus coordinate is fixed by the corresponding power map.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Sections 12 and 13.
+* R. Steinberg, *Endomorphisms of linear algebraic groups*, Memoirs AMS 80 (1968), Section 11.
+-/
+
+public section
+
+open CategoryTheory
+open AlgebraicGeometry
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.SplitTorus
+
+variable {A sigma : Type} [CommRing A] [Finite sigma]
+variable (p n : ℕ) [ExpChar A p]
+
+/-- Under the coordinate-algebra comparison for an integral split torus, applying the iterated
+Frobenius of the value ring is the existing Frobenius endomorphism on convolution points. -/
+theorem groupSchemePointsMulEquiv_mapValue_iterateFrobenius
+    (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (groupScheme ℤ sigma).X) :
+    DiagonalizableGroup.groupSchemePointsMulEquiv
+        (R := ℤ) (A := A) (characterGroup sigma)
+        ((Spec.map (CommRingCat.ofHom (iterateFrobenius A p n).toIntAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of ℤ)) ≫ q) =
+      Bialgebra.iterateFrobeniusPoints p n
+        (DiagonalizableGroup.groupSchemePointsMulEquiv
+          (R := ℤ) (A := A) (characterGroup sigma) q) := by
+  rw [DiagonalizableGroup.groupSchemePointsMulEquiv_mapValue,
+    Bialgebra.iterateFrobeniusPoints_apply, AlgHom.mapValue_apply]
+
+/-- **The iterated Frobenius on the points of an integral split torus is its power
+endomorphism.** Precomposing an `A`-valued point by the `n`-fold Frobenius of `A` agrees with
+postcomposing it by the split-torus power map of exponent `p ^ n`. -/
+theorem mapValue_iterateFrobenius_eq_comp_powEnd
+    (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (groupScheme ℤ sigma).X) :
+    (Spec.map (CommRingCat.ofHom (iterateFrobenius A p n).toIntAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of ℤ)) ≫ q =
+      q ≫ (powEnd ℤ sigma ((p ^ n : ℕ) : ℤ)).hom.hom := by
+  refine (schemePointsMulEquiv (R := ℤ) (A := A) (sigma := sigma)).injective ?_
+  funext i
+  apply Units.ext
+  rw [schemePointsMulEquiv_mapValue, schemePointsMulEquiv_powEnd]
+  change iterateFrobenius A p n
+      (schemePointsMulEquiv (R := ℤ) (A := A) q i : A) =
+    ((schemePointsMulEquiv (R := ℤ) (A := A) q i) ^ ((p ^ n : ℕ) : ℤ) : Aˣ)
+  rw [iterateFrobenius_def]
+  exact congrArg (fun x : Aˣ => (x : A))
+    (zpow_natCast (schemePointsMulEquiv (R := ℤ) (A := A) q i) (p ^ n)).symm
+
+/-- The ordinary Frobenius on the points of an integral split torus is its power endomorphism
+of exponent `p`. -/
+theorem mapValue_frobenius_eq_comp_powEnd
+    (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (groupScheme ℤ sigma).X) :
+    (Spec.map (CommRingCat.ofHom (frobenius A p).toIntAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of ℤ)) ≫ q =
+      q ≫ (powEnd ℤ sigma (p : ℤ)).hom.hom := by
+  rw [← iterateFrobenius_one]
+  simpa using mapValue_iterateFrobenius_eq_comp_powEnd p 1 q
+
+/-- An `A`-valued point of an integral split torus is fixed by the `n`-fold Frobenius exactly
+when each of its coordinates is fixed by the power map of exponent `p ^ n`. -/
+theorem mapValue_iterateFrobenius_eq_self_iff
+    (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (groupScheme ℤ sigma).X) :
+    (Spec.map (CommRingCat.ofHom (iterateFrobenius A p n).toIntAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of ℤ)) ≫ q = q ↔
+      ∀ i, schemePointsMulEquiv (R := ℤ) (A := A) q i ^ ((p ^ n : ℕ) : ℤ) =
+        schemePointsMulEquiv (R := ℤ) (A := A) q i := by
+  rw [mapValue_iterateFrobenius_eq_comp_powEnd]
+  constructor
+  · intro h i
+    have hi := congrArg (fun r => schemePointsMulEquiv (R := ℤ) (A := A) r i) h
+    simpa using hi
+  · intro h
+    refine (schemePointsMulEquiv (R := ℤ) (A := A) (sigma := sigma)).injective ?_
+    funext i
+    rw [schemePointsMulEquiv_powEnd]
+    exact h i
+
+end TauCeti.SplitTorus

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Frobenius.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Frobenius.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Frobenius.Points
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Frobenius
 public import TauCeti.Algebra.AlgebraicGroup.SplitTorus.LinearMap
 
 /-!
@@ -22,7 +22,7 @@ torus as Frobenius rather than merely as an abstract power map.
 
 ## Main results
 
-* `TauCeti.SplitTorus.groupSchemePointsMulEquiv_mapValue_iterateFrobenius`: under the
+* `TauCeti.DiagonalizableGroup.groupSchemePointsMulEquiv_mapValue_iterateFrobenius`: under the
   coordinate-algebra comparison, functoriality along Frobenius is the existing convolution-point
   Frobenius.
 * `TauCeti.SplitTorus.mapValue_iterateFrobenius_eq_comp_powEnd`: on scheme-valued points, the
@@ -47,21 +47,6 @@ namespace TauCeti.SplitTorus
 variable {A sigma : Type} [CommRing A] [Finite sigma]
 variable (p n : ℕ) [ExpChar A p]
 
-/-- Under the coordinate-algebra comparison for an integral split torus, applying the iterated
-Frobenius of the value ring is the existing Frobenius endomorphism on convolution points. -/
-theorem groupSchemePointsMulEquiv_mapValue_iterateFrobenius
-    (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
-      (groupScheme ℤ sigma).X) :
-    DiagonalizableGroup.groupSchemePointsMulEquiv
-        (R := ℤ) (A := A) (characterGroup sigma)
-        ((Spec.map (CommRingCat.ofHom (iterateFrobenius A p n).toIntAlgHom.toRingHom)).asOver
-          (Spec (CommRingCat.of ℤ)) ≫ q) =
-      Bialgebra.iterateFrobeniusPoints p n
-        (DiagonalizableGroup.groupSchemePointsMulEquiv
-          (R := ℤ) (A := A) (characterGroup sigma) q) := by
-  rw [DiagonalizableGroup.groupSchemePointsMulEquiv_mapValue,
-    Bialgebra.iterateFrobeniusPoints_apply, AlgHom.mapValue_apply]
-
 /-- **The iterated Frobenius on the points of an integral split torus is its power
 endomorphism.** Precomposing an `A`-valued point by the `n`-fold Frobenius of `A` agrees with
 postcomposing it by the split-torus power map of exponent `p ^ n`. -/
@@ -75,12 +60,16 @@ theorem mapValue_iterateFrobenius_eq_comp_powEnd
   funext i
   apply Units.ext
   rw [schemePointsMulEquiv_mapValue, schemePointsMulEquiv_powEnd]
-  change iterateFrobenius A p n
-      (schemePointsMulEquiv (R := ℤ) (A := A) q i : A) =
-    ((schemePointsMulEquiv (R := ℤ) (A := A) q i) ^ ((p ^ n : ℕ) : ℤ) : Aˣ)
-  rw [iterateFrobenius_def]
-  exact congrArg (fun x : Aˣ => (x : A))
-    (zpow_natCast (schemePointsMulEquiv (R := ℤ) (A := A) q i) (p ^ n)).symm
+  simp only [Units.coe_map]
+  calc
+    _ = (iterateFrobenius A p n).toIntAlgHom
+        (schemePointsMulEquiv (R := ℤ) (A := A) q i : A) :=
+      congrFun (AlgHom.coe_toRingHom (iterateFrobenius A p n).toIntAlgHom)
+        (schemePointsMulEquiv (R := ℤ) (A := A) q i : A)
+    _ = (schemePointsMulEquiv (R := ℤ) (A := A) q i : A) ^ p ^ n := by
+      rw [RingHom.toIntAlgHom_apply, iterateFrobenius_def]
+    _ = _ := congrArg (fun x : Aˣ => (x : A))
+      (zpow_natCast (schemePointsMulEquiv (R := ℤ) (A := A) q i) (p ^ n)).symm
 
 /-- The ordinary Frobenius on the points of an integral split torus is its power endomorphism
 of exponent `p`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/RootDatum/SpecialIsogeny.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/RootDatum/SpecialIsogeny.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.SplitTorus.LinearMap
+public import TauCeti.Algebra.AlgebraicGroup.SplitTorus.Frobenius
 public import TauCeti.LinearAlgebra.RootSystem.Isogeny.Special
 
 /-!
@@ -31,6 +31,8 @@ isogenies of pinned reductive groups.
   `TauCeti.DynkinType.g2SpecialTorusEnd_comp_self`, and
   `TauCeti.DynkinType.f4SpecialTorusEnd_comp_self`: the special torus maps square to the
   characteristic power maps.
+* `TauCeti.DynkinType.mapValue_frobenius_two_eq_comp_b2SpecialTorusEnd_sq` and its `G₂` and
+  `F₄` counterparts: on points in the defining characteristic, these squares are Frobenius.
 
 ## References
 
@@ -139,6 +141,44 @@ theorem f4SpecialTorusEnd_comp_self :
   congr 1
   have h := congrArg RootPairingIsogeny.weightMap f4SpecialIsogeny_mul_self
   simpa [RootPairingIsogeny.mul_def] using h
+
+/-! ### Frobenius square relations on points -/
+
+/-- **On points in characteristic two, the square of the `B₂` special torus endomorphism is
+Frobenius.** -/
+theorem mapValue_frobenius_two_eq_comp_b2SpecialTorusEnd_sq
+    {A : Type} [CommRing A] [ExpChar A 2]
+    (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (SplitTorus.groupScheme ℤ (Fin 2)).X) :
+    (Spec.map (CommRingCat.ofHom (frobenius A 2).toIntAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of ℤ)) ≫ q =
+      q ≫ ((b2SpecialTorusEnd ℤ ≫ b2SpecialTorusEnd ℤ).hom.hom) := by
+  rw [b2SpecialTorusEnd_comp_self]
+  exact SplitTorus.mapValue_frobenius_eq_comp_powEnd 2 q
+
+/-- **On points in characteristic three, the square of the `G₂` special torus endomorphism is
+Frobenius.** -/
+theorem mapValue_frobenius_three_eq_comp_g2SpecialTorusEnd_sq
+    {A : Type} [CommRing A] [ExpChar A 3]
+    (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (SplitTorus.groupScheme ℤ (Fin 2)).X) :
+    (Spec.map (CommRingCat.ofHom (frobenius A 3).toIntAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of ℤ)) ≫ q =
+      q ≫ ((g2SpecialTorusEnd ℤ ≫ g2SpecialTorusEnd ℤ).hom.hom) := by
+  rw [g2SpecialTorusEnd_comp_self]
+  exact SplitTorus.mapValue_frobenius_eq_comp_powEnd 3 q
+
+/-- **On points in characteristic two, the square of the `F₄` special torus endomorphism is
+Frobenius.** -/
+theorem mapValue_frobenius_two_eq_comp_f4SpecialTorusEnd_sq
+    {A : Type} [CommRing A] [ExpChar A 2]
+    (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (SplitTorus.groupScheme ℤ (Fin 4)).X) :
+    (Spec.map (CommRingCat.ofHom (frobenius A 2).toIntAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of ℤ)) ≫ q =
+      q ≫ ((f4SpecialTorusEnd ℤ ≫ f4SpecialTorusEnd ℤ).hom.hom) := by
+  rw [f4SpecialTorusEnd_comp_self]
+  exact SplitTorus.mapValue_frobenius_eq_comp_powEnd 2 q
 
 end DynkinType
 

--- a/TauCeti/Algebra/AlgebraicGroup/SplitTorus/RootDatum/SpecialIsogeny.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SplitTorus/RootDatum/SpecialIsogeny.lean
@@ -31,8 +31,8 @@ isogenies of pinned reductive groups.
   `TauCeti.DynkinType.g2SpecialTorusEnd_comp_self`, and
   `TauCeti.DynkinType.f4SpecialTorusEnd_comp_self`: the special torus maps square to the
   characteristic power maps.
-* `TauCeti.DynkinType.mapValue_frobenius_two_eq_comp_b2SpecialTorusEnd_sq` and its `G₂` and
-  `F₄` counterparts: on points in the defining characteristic, these squares are Frobenius.
+* `TauCeti.DynkinType.mapValue_frobenius_two_eq_comp_b2SpecialTorusEnd_comp_self` and its `G₂`
+  and `F₄` counterparts: on points in the defining characteristic, these squares are Frobenius.
 
 ## References
 
@@ -146,7 +146,7 @@ theorem f4SpecialTorusEnd_comp_self :
 
 /-- **On points in characteristic two, the square of the `B₂` special torus endomorphism is
 Frobenius.** -/
-theorem mapValue_frobenius_two_eq_comp_b2SpecialTorusEnd_sq
+theorem mapValue_frobenius_two_eq_comp_b2SpecialTorusEnd_comp_self
     {A : Type} [CommRing A] [ExpChar A 2]
     (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
       (SplitTorus.groupScheme ℤ (Fin 2)).X) :
@@ -158,7 +158,7 @@ theorem mapValue_frobenius_two_eq_comp_b2SpecialTorusEnd_sq
 
 /-- **On points in characteristic three, the square of the `G₂` special torus endomorphism is
 Frobenius.** -/
-theorem mapValue_frobenius_three_eq_comp_g2SpecialTorusEnd_sq
+theorem mapValue_frobenius_three_eq_comp_g2SpecialTorusEnd_comp_self
     {A : Type} [CommRing A] [ExpChar A 3]
     (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
       (SplitTorus.groupScheme ℤ (Fin 2)).X) :
@@ -170,7 +170,7 @@ theorem mapValue_frobenius_three_eq_comp_g2SpecialTorusEnd_sq
 
 /-- **On points in characteristic two, the square of the `F₄` special torus endomorphism is
 Frobenius.** -/
-theorem mapValue_frobenius_two_eq_comp_f4SpecialTorusEnd_sq
+theorem mapValue_frobenius_two_eq_comp_f4SpecialTorusEnd_comp_self
     {A : Type} [CommRing A] [ExpChar A 2]
     (q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
       (SplitTorus.groupScheme ℤ (Fin 4)).X) :


### PR DESCRIPTION
This PR identifies functorial Frobenius on integral split-torus points with the corresponding group-scheme power endomorphism, and then upgrades the existing B₂, G₂, and F₄ special torus square formulas to the defining-characteristic identities `τ² = Frob_p` on points.

It advances the ReductiveGroups Layer 9 milestone “Special isogenies in characteristics two and three,” specifically the target requiring the exceptional isogeny `τ` to satisfy `τ² = Frob_p`, and it also supplies the split-torus case of the Layer 9 target “Points over an algebraically closed field” where a field endomorphism induces an endomorphism of points. This is the most direct next step after #5736: that PR proved the special torus maps square to abstract power maps, while this PR proves those power maps are exactly Frobenius on scheme-valued points.

The new generic API compares scheme-valued Frobenius with the existing convolution-point Frobenius, proves the iterated and ordinary Frobenius power-map formulas, and characterizes Frobenius-fixed torus points coordinatewise. The type-specific corollaries then reuse the established B₂/G₂/F₄ square relations. No Mathlib infrastructure is vendored; the proofs reuse Mathlib's `frobenius` and `iterateFrobenius` together with Tau Ceti's `Bialgebra.iterateFrobeniusPoints`, split-torus point equivalence, and `powEnd`.

After this PR, the Layer 9 special-isogeny milestone still requires extending these torus maps to the full pinned B₂/G₂/F₄ group schemes and proving the prescribed action on long and short root subgroups.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-isogeny-torus-frobenius"}-->

🤖 Prepared with Codex
