### PR TITLE
feat(Isogeny): the units of the endomorphism monoid are the degree-one endomorphisms

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Hom.lean
@@ -53,6 +53,8 @@ needs the rational addition formulas rather than anything in this file.
   map included — which is what the value `degree 0 = 0` is chosen for.
 * `TauCeti.Isogeny.Hom.comp_eq_zero_iff`: a composite vanishes exactly when a factor does, so the
   endomorphism monoid has no zero divisors.
+* `TauCeti.Isogeny.Hom.instNontrivial`: the carrier has more than one element, which is what
+  lets Mathlib's theory of nontrivial monoids with zero apply to it.
 
 ## Implementation notes
 
@@ -292,6 +294,12 @@ theorem comp_assoc {W₄ : WeierstrassCurve.Affine F} (h : Hom W₃ W₄) (g : H
 noncomputable def id (W : WeierstrassCurve.Affine F) : Hom W W :=
   ofIsogeny (Isogeny.id W)
 
+/-- The defining equation of `id`. -/
+-- Needed as a lemma rather than left to unfolding: `id`'s body is not exposed across a module
+-- boundary, so `rw [id]` in a downstream file fails with "Invalid rewrite argument".
+theorem id_def (W : WeierstrassCurve.Affine F) :
+    id W = ofIsogeny (Isogeny.id W) := (rfl)
+
 /-- **The identity is a left unit for composition.** -/
 @[simp]
 theorem id_comp (f : Hom W₁ W₂) : (id W₂).comp f = f := by
@@ -335,6 +343,13 @@ theorem mul_def (g f : Hom W₁ W₁) : g * f = g.comp f := (rfl)
 /-- The monoid's unit is the identity endomorphism. -/
 @[simp]
 theorem one_def : (1 : Hom W₁ W₁) = id W₁ := (rfl)
+
+/-- **The carrier has more than one element**: the zero map has degree `0` and the identity
+degree `1`. Supplying this makes Mathlib's generic theory of nontrivial monoids with zero apply,
+`not_isUnit_zero` among it. -/
+instance : Nontrivial (Hom W₁ W₁) :=
+  ⟨⟨0, id W₁, fun h => zero_ne_one (α := ℕ) (by rw [← degree_zero (W₁ := W₁) (W₂ := W₁), h,
+    degree_id])⟩⟩
 
 end Hom
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Units.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Units.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Factorisation
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom
+
+/-!
+# The units of the endomorphism monoid
+
+An endomorphism of `W` is invertible exactly when it has degree one. Degree one means the
+function-field pullback is onto, and the factorisation theorem turns a surjective pullback into
+an isogeny inverting it on both sides; conversely degree is multiplicative and the identity has
+degree one, so a unit's degree divides one.
+
+`Units` is defined for a monoid, so `(Hom W W)ˣ` is determined by the multiplicative structure
+alone: the group described here is the same one the endomorphism ring will have.
+
+## Main results
+
+* `TauCeti.Isogeny.Hom.isUnit_iff_degree_eq_one`: a unit is exactly a degree-one endomorphism.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.4.1.
+-/
+
+public section
+
+namespace TauCeti.Isogeny.Hom
+
+variable {F : Type*} [Field F] {W₁ : WeierstrassCurve.Affine F}
+
+/-- **The units of the endomorphism monoid are exactly the degree-one endomorphisms**, an
+isogeny of degree one being an isomorphism. `Units` depends only on the multiplicative
+structure, so this describes the whole unit group of the endomorphism monoid. -/
+@[simp]
+theorem isUnit_iff_degree_eq_one {f : Hom W₁ W₁} : IsUnit f ↔ f.degree = 1 := by
+  constructor
+  · rintro ⟨u, rfl⟩
+    have h : (u : Hom W₁ W₁).degree * (↑u⁻¹ : Hom W₁ W₁).degree = 1 := by
+      rw [← degree_comp, ← mul_def, u.mul_inv, one_def, degree_id]
+    exact Nat.eq_one_of_mul_eq_one_right h
+  · intro hd
+    obtain ⟨φ, rfl⟩ := f.eq_zero_or_exists_ofIsogeny.resolve_left fun h => by simp [h] at hd
+    rw [degree_ofIsogeny] at hd
+    obtain ⟨χ, h1, h2⟩ := Isogeny.exists_comp_eq_id_and_comp_eq_id_of_degree_eq_one φ hd
+    exact ⟨⟨ofIsogeny φ, ofIsogeny χ,
+      by rw [mul_def, ofIsogeny_comp_ofIsogeny, h2, one_def, id_def],
+      by rw [mul_def, ofIsogeny_comp_ofIsogeny, h1, one_def, id_def]⟩, rfl⟩
+
+/-- **An automorphism has degree one.** -/
+@[simp]
+theorem degree_coe_units (u : (Hom W₁ W₁)ˣ) : (u : Hom W₁ W₁).degree = 1 :=
+  isUnit_iff_degree_eq_one.mp u.isUnit
+
+end TauCeti.Isogeny.Hom
+
+end


### PR DESCRIPTION
**The units of the endomorphism monoid are exactly the degree-one endomorphisms** — API for the
monoid built in #5759, after the carrier in #5752.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"isogeny-hom-units"}-->

### The statement

```lean
theorem isUnit_iff_degree_eq_one {f : Hom W₁ W₁} : IsUnit f ↔ f.degree = 1
@[simp] theorem degree_coe_units (u : (Hom W₁ W₁)ˣ) : (u : Hom W₁ W₁).degree = 1
instance : Nontrivial (Hom W₁ W₁)
```

This characterises the unit group of the `MonoidWithZero` that #5759 builds; it introduces no
type and no new mathematics. `Units` is defined for a `Monoid`, so `(Hom W W)ˣ` is already
determined by the multiplicative structure — the additive structure the hom-group milestone still
needs will make the monoid a ring without changing this group or this theorem. That is why it
lands here rather than waiting: it is API for what exists, not a claim on the ring-based
`Aut (E, O)` target, which needs the addition that is not built yet.

### Why both directions are short

Forward: degree is multiplicative on the whole carrier and the identity has degree one, so
`deg u · deg u⁻¹ = 1` in `ℕ` and both factors are one.

Backward: degree one means the function-field pullback is onto (`Isogeny.degree_eq_one_iff`), and
`Isogeny.exists_comp_eq_id_and_comp_eq_id_of_degree_eq_one` — the merged first consequence of the
factorisation theorem — turns that into an isogeny which is a two-sided inverse. Lifting it
through `ofIsogeny` gives the unit.

So this PR adds no mathematics of its own: it connects the merged factorisation theorem to the
monoid structure. That is the whole content, and it is why it is short.

### The formal zero is not an automorphism — via Mathlib, not a lemma of ours

A first draft stated `¬ IsUnit (0 : Hom W W)` here. Mathlib already proves that for every
nontrivial monoid with zero, so the specialisation was redundant — but its generic theorem did not
apply, because `Nontrivial (Hom W W)` was missing. The instance is what this PR adds instead: `0`
has degree `0` and the identity degree `1`, so the carrier is nontrivial, and with that
`_root_.not_isUnit_zero` applies directly — along with the rest of Mathlib's theory of nontrivial
monoids with zero.

### Placement

A new `Isogeny/Units.lean`, importing `Hom` and `Factorisation`. The units results depend on the
factorisation theorem, which is downstream of the carrier, so putting them in `Hom.lean` — even
behind a private import — would have pointed the foundational module at later theory. `Hom.lean`
keeps only the `Nontrivial` instance, which needs nothing but its own degrees, and gains `id_def`
so the units proof can name the identity rather than unfold it. That is not stylistic: `id`'s
body is not exposed across a module boundary, so `rw [id]` in the downstream file fails with
`Invalid rewrite argument`.

### Provenance

Original, assembled from merged results: `Isogeny.exists_comp_eq_id_and_comp_eq_id_of_degree_eq_one`
and `Isogeny.degree_eq_one_iff`, with the carrier and its monoid from #5752 and #5759. The
mathematics is Silverman, *The Arithmetic of Elliptic Curves*, II.2.4.1.

### Gates

- `lake build`: green for the module and its dependents.
- `#lint in TauCeti`, 15 linters over 422 declarations: 0 errors.
- No `sorry`, no `native_decide`, no `maxHeartbeats`; no line over 100 codepoints.
- Longest proof: 12 lines. `Hom.lean` 356 lines, `Units.lean` 65.

### Builds on #5759

`degree_comp`, `degree_id`, `mul_def`, `one_def` and the `MonoidWithZero` instance come from that
PR, now merged.
