### PR TITLE
feat: construct geometric Borel subgroups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
@@ -74,8 +74,8 @@ smooth, geometrically connected, geometrically solvable closed subgroup.
 Over an algebraically closed field, a Borel subgroup is a maximal such candidate. Over a general
 field, `IsBorel` instead requires maximality after base change to an algebraic closure. Keeping the
 non-maximal condition named is useful for constructing Borels by a maximal-dimension argument and
-for asking that a Borel contain a prescribed geometrically connected, geometrically solvable
-subgroup. -/
+for asking that a Borel contain a prescribed smooth, geometrically connected, geometrically
+solvable subgroup. -/
 def IsBorelCandidate (k : Type u) [Field k]
     (H : FiniteTypeCommHopfAlgCat.{u, v} k) (I : HopfIdeal k H) : Prop :=
   borelQuotientProperty k (FiniteTypeCommHopfAlgCat.quotient H I)
@@ -264,6 +264,8 @@ theorem comapOfIso (hI : IsBorel k L.obj I) (e : H ≅ L) :
       (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
         (ConcreteCategory.bijective_of_isIso e.hom).2) := by
   refine ⟨inferInstance, ?_⟩
+  -- After supplying algebraic closedness, `IsBorel` is definitionally the minimal quotient
+  -- property below; the private predicate has no separate propositional transport lemma.
   change Minimal
     (fun J : HopfIdeal (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj ↦

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
@@ -28,6 +28,8 @@ maximality only among subgroups defined over the ground field is not the Borel c
 
 ## Main declarations
 
+* `TauCeti.HopfIdeal.IsBorelCandidate`: a smooth, geometrically connected, geometrically
+  solvable closed subgroup, before imposing maximality.
 * `TauCeti.HopfIdeal.IsBorel`: the Borel-subgroup predicate in Hopf coordinates.
 * `TauCeti.HopfIdeal.IsBorel.comapOfIso_iff`: Borel status is invariant under an ambient
   Hopf-algebra isomorphism.
@@ -64,6 +66,65 @@ private instance (k : Type u) [Field k] :
   unfold borelQuotientProperty
   infer_instance
 
+/-- A Hopf ideal is a **Borel candidate** when its quotient coordinate algebra represents a
+smooth, geometrically connected, geometrically solvable closed subgroup.
+
+A Borel subgroup is a maximal such candidate. Keeping the non-maximal condition named is useful
+for constructing Borels by a maximal-dimension argument and for asking that a Borel contain a
+prescribed connected solvable subgroup. -/
+def IsBorelCandidate (k : Type u) [Field k]
+    (H : FiniteTypeCommHopfAlgCat.{u, v} k) (I : HopfIdeal k H) : Prop :=
+  borelQuotientProperty k (FiniteTypeCommHopfAlgCat.quotient H I)
+
+/-- The three geometric conditions defining a Borel candidate. -/
+@[simp]
+theorem isBorelCandidate_iff (k : Type u) [Field k]
+    (H : FiniteTypeCommHopfAlgCat.{u, v} k) (I : HopfIdeal k H) :
+    IsBorelCandidate k H I ↔
+      smoothCommHopfAlgProperty k
+          (FiniteTypeCommHopfAlgCat.quotient H I).obj ∧
+        geometricallyConnectedCommHopfAlgProperty k
+          (FiniteTypeCommHopfAlgCat.quotient H I).obj ∧
+        geometricallySolvablePointsCommHopfAlgProperty k
+          (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
+  Iff.rfl
+
+namespace IsBorelCandidate
+
+variable {k : Type u} [Field k]
+variable {H : FiniteTypeCommHopfAlgCat.{u, v} k} {I : HopfIdeal k H}
+
+/-- Construct a Borel candidate from smoothness, geometric connectedness, and geometric
+solvability. -/
+theorem mk
+    (h_smooth : smoothCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj)
+    (h_connected : geometricallyConnectedCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj)
+    (h_solvable : geometricallySolvablePointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj) :
+    IsBorelCandidate k H I :=
+  ⟨h_smooth, h_connected, h_solvable⟩
+
+/-- A Borel candidate is smooth. -/
+theorem smooth (hI : IsBorelCandidate k H I) :
+    smoothCommHopfAlgProperty k (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
+  hI.1
+
+/-- A Borel candidate is geometrically connected. -/
+theorem geometricallyConnected (hI : IsBorelCandidate k H I) :
+    geometricallyConnectedCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
+  hI.2.1
+
+/-- A Borel candidate has a solvable group of geometric points. -/
+theorem geometricallySolvable (hI : IsBorelCandidate k H I) :
+    geometricallySolvablePointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
+  hI.2.2
+
+end IsBorelCandidate
+
 /-- A Hopf ideal defines a Borel subgroup when, after base change to an algebraic closure, its
 quotient coordinate algebra is smooth, geometrically connected, and geometrically solvable, and
 no strictly larger closed subgroup has all three properties.
@@ -76,8 +137,7 @@ def IsBorel (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{v} k)
   let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K)
     ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
   let I' := CommHopfAlgCat.baseChangeHopfIdeal (K := K) I
-  Minimal (fun J : HopfIdeal K H'.obj ↦
-    borelQuotientProperty K (FiniteTypeCommHopfAlgCat.quotient H' J)) I'
+  Minimal (IsBorelCandidate K H') I'
 
 /-- The Hopf-ideal criterion for a Borel subgroup: after algebraic-closure base change, its
 quotient is smooth, geometrically connected, and geometrically solvable, and it is maximal among
@@ -110,6 +170,7 @@ theorem isBorel_iff (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{v} k)
               (FiniteTypeCommHopfAlgCat.quotient
                 H' J).obj →
             J ≤ I' → I' ≤ J := by
+  rw [IsBorel]
   constructor
   · rintro ⟨⟨hsmooth, hconnected, hsolvable⟩, hmax⟩
     exact ⟨hsmooth, hconnected, hsolvable,

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.lean
@@ -30,6 +30,8 @@ maximality only among subgroups defined over the ground field is not the Borel c
 
 * `TauCeti.HopfIdeal.IsBorelCandidate`: a smooth, geometrically connected, geometrically
   solvable closed subgroup, before imposing maximality.
+* `TauCeti.HopfIdeal.IsBorelOverAlgClosed`: the Borel-subgroup predicate over an algebraically
+  closed field.
 * `TauCeti.HopfIdeal.IsBorel`: the Borel-subgroup predicate in Hopf coordinates.
 * `TauCeti.HopfIdeal.IsBorel.comapOfIso_iff`: Borel status is invariant under an ambient
   Hopf-algebra isomorphism.
@@ -69,9 +71,11 @@ private instance (k : Type u) [Field k] :
 /-- A Hopf ideal is a **Borel candidate** when its quotient coordinate algebra represents a
 smooth, geometrically connected, geometrically solvable closed subgroup.
 
-A Borel subgroup is a maximal such candidate. Keeping the non-maximal condition named is useful
-for constructing Borels by a maximal-dimension argument and for asking that a Borel contain a
-prescribed connected solvable subgroup. -/
+Over an algebraically closed field, a Borel subgroup is a maximal such candidate. Over a general
+field, `IsBorel` instead requires maximality after base change to an algebraic closure. Keeping the
+non-maximal condition named is useful for constructing Borels by a maximal-dimension argument and
+for asking that a Borel contain a prescribed geometrically connected, geometrically solvable
+subgroup. -/
 def IsBorelCandidate (k : Type u) [Field k]
     (H : FiniteTypeCommHopfAlgCat.{u, v} k) (I : HopfIdeal k H) : Prop :=
   borelQuotientProperty k (FiniteTypeCommHopfAlgCat.quotient H I)
@@ -125,6 +129,22 @@ theorem geometricallySolvable (hI : IsBorelCandidate k H I) :
 
 end IsBorelCandidate
 
+/-- Over an algebraically closed field, a Hopf ideal defines a Borel subgroup when it is minimal
+among Borel candidates. In the contravariant Hopf-ideal order, this means that the represented
+closed subgroup is maximal among smooth, geometrically connected, geometrically solvable closed
+subgroups. -/
+def IsBorelOverAlgClosed (k : Type u) [Field k]
+    (H : FiniteTypeCommHopfAlgCat.{u, v} k) (I : HopfIdeal k H) : Prop :=
+  IsAlgClosed k ∧ Minimal (IsBorelCandidate k H) I
+
+/-- The algebraically-closed-field Borel condition asserts algebraic closedness and minimality
+among Borel candidates. -/
+@[simp]
+theorem isBorelOverAlgClosed_iff (k : Type u) [Field k]
+    (H : FiniteTypeCommHopfAlgCat.{u, v} k) (I : HopfIdeal k H) :
+    IsBorelOverAlgClosed k H I ↔ IsAlgClosed k ∧ Minimal (IsBorelCandidate k H) I :=
+  Iff.rfl
+
 /-- A Hopf ideal defines a Borel subgroup when, after base change to an algebraic closure, its
 quotient coordinate algebra is smooth, geometrically connected, and geometrically solvable, and
 no strictly larger closed subgroup has all three properties.
@@ -137,7 +157,19 @@ def IsBorel (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{v} k)
   let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K)
     ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
   let I' := CommHopfAlgCat.baseChangeHopfIdeal (K := K) I
-  Minimal (IsBorelCandidate K H') I'
+  IsBorelOverAlgClosed K H' I'
+
+/-- The general-field Borel predicate is the algebraically-closed-field Borel predicate after
+base change to an algebraic closure. -/
+theorem isBorel_iff_isBorelOverAlgClosed_baseChange
+    (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{v} k)
+    [Algebra.FiniteType k H] (I : HopfIdeal k H) :
+    let K := AlgebraicClosure k
+    let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K)
+      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
+    let I' := CommHopfAlgCat.baseChangeHopfIdeal (K := K) I
+    IsBorel k H I ↔ IsBorelOverAlgClosed K H' I' :=
+  Iff.rfl
 
 /-- The Hopf-ideal criterion for a Borel subgroup: after algebraic-closure base change, its
 quotient is smooth, geometrically connected, and geometrically solvable, and it is maximal among
@@ -172,13 +204,13 @@ theorem isBorel_iff (k : Type u) [Field k] (H : _root_.CommHopfAlgCat.{v} k)
             J ≤ I' → I' ≤ J := by
   rw [IsBorel]
   constructor
-  · rintro ⟨⟨hsmooth, hconnected, hsolvable⟩, hmax⟩
+  · rintro ⟨_, ⟨⟨hsmooth, hconnected, hsolvable⟩, hmax⟩⟩
     exact ⟨hsmooth, hconnected, hsolvable,
       fun J hJsmooth hJconnected hJsolvable hJI ↦
         hmax ⟨hJsmooth, hJconnected, hJsolvable⟩ hJI⟩
   · rintro ⟨hsmooth, hconnected, hsolvable, hmax⟩
-    exact ⟨⟨hsmooth, hconnected, hsolvable⟩,
-      fun J hJ hJI ↦ hmax J hJ.1 hJ.2.1 hJ.2.2 hJI⟩
+    exact ⟨inferInstance, ⟨⟨hsmooth, hconnected, hsolvable⟩,
+      fun J hJ hJI ↦ hmax J hJ.1 hJ.2.1 hJ.2.2 hJI⟩⟩
 
 private theorem minimal_borelQuotientProperty_comapOfIso
     {k : Type u} [Field k]
@@ -231,8 +263,7 @@ theorem comapOfIso (hI : IsBorel k L.obj I) (e : H ≅ L) :
     IsBorel k H.obj
       (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
         (ConcreteCategory.bijective_of_isIso e.hom).2) := by
-  -- `IsBorel` is definitionally this minimal quotient property; no private `Iff.rfl`
-  -- wrapper is retained solely to unfold and refold it for transport.
+  refine ⟨inferInstance, ?_⟩
   change Minimal
     (fun J : HopfIdeal (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj ↦
@@ -242,7 +273,7 @@ theorem comapOfIso (hI : IsBorel k L.obj I) (e : H ≅ L) :
     (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k)
       (I.comapOfSurjective (FiniteTypeCommHopfAlgCat.toBialgHom e.hom)
         (ConcreteCategory.bijective_of_isIso e.hom).2))
-  exact minimal_borelQuotientProperty_comapOfIso hI e
+  exact minimal_borelQuotientProperty_comapOfIso hI.2 e
 
 /-- Borel status is invariant under pulling the defining ideal back across an ambient
 Hopf-algebra isomorphism. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Existence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Existence.lean
@@ -92,7 +92,7 @@ theorem exists_minimal_isBorelCandidate_le
   exact hJmin ⟨hK, hKJ.trans hJI⟩ hKJ
 
 /-- **Every finite-type affine group over a field has a maximal smooth geometrically connected
-solvable closed subgroup.**
+geometrically solvable closed subgroup.**
 
 Over an algebraically closed field this is a Borel subgroup. Over a general field it is only
 maximal among candidates defined over that field; `exists_geometricBorel` below applies the result

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Existence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Existence.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Borel.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Torus.SmoothConnected
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Smooth.Dimension
+
+/-!
+# Existence of Borel subgroups
+
+A Borel subgroup of an affine algebraic group over an algebraically closed field is a maximal
+smooth connected solvable closed subgroup. This file proves existence by maximizing Lie dimension.
+More precisely, every smooth geometrically connected solvable closed subgroup is contained in a
+maximal one. Applying this on the geometric fibre of a group over an arbitrary field constructs a
+Borel subgroup there.
+
+The identity subgroup makes the family of candidates nonempty. For the relative statement, a
+candidate containing a prescribed one is again a nonempty family. Lie dimensions of closed
+subgroups are bounded by the ambient Lie dimension, and equality of Lie dimensions detects
+equality for an inclusion of smooth connected closed subgroups. This is exactly the general
+maximal-dimension argument in `HopfIdeal.exists_minimal_of_smooth_of_connected`.
+
+The resulting Borel lives over the algebraic closure. It need not descend to the original field:
+the existence of a Borel defined over a non-algebraically-closed field is an additional condition
+on the group. No conjugacy statement is proved here.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.exists_minimal_isBorelCandidate_le`: every Borel candidate is contained in
+  a maximal Borel candidate.
+* `TauCeti.HopfIdeal.exists_minimal_isBorelCandidate`: every finite-type affine group over a
+  field has a maximal Borel candidate.
+* `TauCeti.HopfIdeal.exists_geometricBorel`: the geometric fibre of every finite-type affine
+  group has a Borel subgroup.
+* `TauCeti.HopfIdeal.exists_minimal_isBorelCandidate_le_of_torus`: every torus is contained in a
+  maximal Borel candidate.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 17.6 and §17.a.
+* A. Borel, *Linear Algebraic Groups*, 2nd ed. (1991), §11.1.
+* T. A. Springer, *Linear Algebraic Groups*, §6.2.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal
+
+variable {k : Type u} [Field k]
+
+/-- A solvable-radical candidate is in particular a Borel candidate after forgetting normality. -/
+theorem IsSolvableRadicalCandidate.isBorelCandidate
+    {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k H}
+    (hI : IsSolvableRadicalCandidate H I) : IsBorelCandidate k H I :=
+  IsBorelCandidate.mk
+    ((smoothCommHopfAlgProperty_iff _).mpr hI.smooth)
+    hI.geometricallyConnected hI.geometricallySolvable
+
+/-- The identity subgroup is a Borel candidate. -/
+theorem isBorelCandidate_augmentation (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    IsBorelCandidate k H (augmentation k H) :=
+  (isSolvableRadicalCandidate_augmentation H).isBorelCandidate
+
+/-- **Every smooth connected solvable closed subgroup is contained in a maximal one.**
+
+In Hopf-ideal order the inequality `J ≤ I` says that the closed subgroup cut out by `J` contains
+the one cut out by `I`. Thus the returned minimal Borel candidate is a maximal smooth connected
+solvable subgroup containing the prescribed candidate. -/
+theorem exists_minimal_isBorelCandidate_le
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) {I : HopfIdeal k H}
+    (hI : IsBorelCandidate k H I) :
+    ∃ J : HopfIdeal k H, J ≤ I ∧ Minimal (IsBorelCandidate k H) J := by
+  obtain ⟨J, ⟨⟨hJ, hJI⟩, hJmin⟩⟩ :=
+    exists_minimal_of_smooth_of_connected
+      (fun J : HopfIdeal k H ↦ IsBorelCandidate k H J ∧ J ≤ I)
+      (fun hJ ↦ hJ.1.smooth)
+      (fun hJ ↦ geometricallyConnectedCommHopfAlgProperty.connectedSpace k _
+        hJ.1.geometricallyConnected)
+      ⟨I, hI, le_rfl⟩
+  refine ⟨J, hJI, hJ, fun K hK hKJ ↦ ?_⟩
+  exact hJmin ⟨hK, hKJ.trans hJI⟩ hKJ
+
+/-- **Every finite-type affine group over a field has a maximal smooth geometrically connected
+solvable closed subgroup.**
+
+Over an algebraically closed field this is a Borel subgroup. Over a general field it is only
+maximal among candidates defined over that field; `exists_geometricBorel` below applies the result
+after extension to an algebraic closure. -/
+theorem exists_minimal_isBorelCandidate
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    ∃ I : HopfIdeal k H, Minimal (IsBorelCandidate k H) I := by
+  obtain ⟨I, _, hI⟩ := exists_minimal_isBorelCandidate_le H
+    (isBorelCandidate_augmentation H)
+  exact ⟨I, hI⟩
+
+/-- **The geometric fibre of every finite-type affine group has a Borel subgroup.**
+
+The conclusion is stated directly on the base-changed coordinate Hopf algebra. Since the base
+field there is algebraically closed, a minimal Borel candidate is precisely a maximal smooth
+connected solvable closed subgroup. -/
+theorem exists_geometricBorel (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    let K := AlgebraicClosure k
+    let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K) H
+    ∃ I : HopfIdeal K H', Minimal (IsBorelCandidate K H') I := by
+  exact exists_minimal_isBorelCandidate
+    (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+
+/-- Every torus closed subgroup is a Borel candidate. -/
+theorem IsBorelCandidate.of_torus
+    {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k H}
+    (hI : torusCommHopfAlgProperty k (FiniteTypeCommHopfAlgCat.quotient H I)) :
+    IsBorelCandidate k H I := by
+  let _ : Coalgebra.IsCocomm k (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
+    hI.isCocomm k (FiniteTypeCommHopfAlgCat.quotient H I)
+  exact IsBorelCandidate.mk hI.smooth hI.geometricallyConnected
+    (geometricallySolvablePointsCommHopfAlgProperty_of_isCocomm k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj)
+
+/-- **Every torus is contained in a maximal smooth connected solvable closed subgroup.**
+
+Over an algebraically closed field the subgroup produced is a Borel containing the torus. This is
+the containment form used when choosing a Borel compatible with a prescribed maximal torus. -/
+theorem exists_minimal_isBorelCandidate_le_of_torus
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) {I : HopfIdeal k H}
+    (hI : torusCommHopfAlgProperty k (FiniteTypeCommHopfAlgCat.quotient H I)) :
+    ∃ J : HopfIdeal k H, J ≤ I ∧ Minimal (IsBorelCandidate k H) J :=
+  exists_minimal_isBorelCandidate_le H (IsBorelCandidate.of_torus hI)
+
+end HopfIdeal
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Existence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Existence.lean
@@ -14,10 +14,10 @@ import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Smooth.Dimension
 # Existence of Borel subgroups
 
 A Borel subgroup of an affine algebraic group over an algebraically closed field is a maximal
-smooth connected solvable closed subgroup. This file proves existence by maximizing Lie dimension.
-More precisely, every smooth geometrically connected solvable closed subgroup is contained in a
-maximal one. Applying this on the geometric fibre of a group over an arbitrary field constructs a
-Borel subgroup there.
+smooth, geometrically connected, geometrically solvable closed subgroup. This file proves existence
+by maximizing Lie dimension. More precisely, every Borel candidate is contained in a maximal one.
+Applying this on the geometric fibre of a group over an arbitrary field constructs a Borel subgroup
+there.
 
 The identity subgroup makes the family of candidates nonempty. For the relative statement, a
 candidate containing a prescribed one is again a nonempty family. Lie dimensions of closed
@@ -37,8 +37,7 @@ on the group. No conjugacy statement is proved here.
   field has a maximal Borel candidate.
 * `TauCeti.HopfIdeal.exists_geometricBorel`: the geometric fibre of every finite-type affine
   group has a Borel subgroup.
-* `TauCeti.HopfIdeal.exists_minimal_isBorelCandidate_le_of_torus`: every torus is contained in a
-  maximal Borel candidate.
+* `TauCeti.HopfIdeal.IsBorelCandidate.of_torus`: every torus is a Borel candidate.
 
 ## References
 
@@ -72,11 +71,12 @@ theorem isBorelCandidate_augmentation (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     IsBorelCandidate k H (augmentation k H) :=
   (isSolvableRadicalCandidate_augmentation H).isBorelCandidate
 
-/-- **Every smooth connected solvable closed subgroup is contained in a maximal one.**
+/-- **Every smooth, geometrically connected, geometrically solvable closed subgroup is contained
+in a maximal one.**
 
 In Hopf-ideal order the inequality `J ≤ I` says that the closed subgroup cut out by `J` contains
-the one cut out by `I`. Thus the returned minimal Borel candidate is a maximal smooth connected
-solvable subgroup containing the prescribed candidate. -/
+the one cut out by `I`. Thus the returned minimal Borel candidate is a maximal smooth,
+geometrically connected, geometrically solvable subgroup containing the prescribed candidate. -/
 theorem exists_minimal_isBorelCandidate_le
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) {I : HopfIdeal k H}
     (hI : IsBorelCandidate k H I) :
@@ -107,14 +107,15 @@ theorem exists_minimal_isBorelCandidate
 /-- **The geometric fibre of every finite-type affine group has a Borel subgroup.**
 
 The conclusion is stated directly on the base-changed coordinate Hopf algebra. Since the base
-field there is algebraically closed, a minimal Borel candidate is precisely a maximal smooth
-connected solvable closed subgroup. -/
+field there is algebraically closed, `IsBorelOverAlgClosed` is precisely minimality among smooth,
+geometrically connected, geometrically solvable closed subgroups. -/
 theorem exists_geometricBorel (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     let K := AlgebraicClosure k
     let H' := FiniteTypeCommHopfAlgCat.baseChange (K := K) H
-    ∃ I : HopfIdeal K H', Minimal (IsBorelCandidate K H') I := by
-  exact exists_minimal_isBorelCandidate
+    ∃ I : HopfIdeal K H', IsBorelOverAlgClosed K H' I := by
+  obtain ⟨I, hI⟩ := exists_minimal_isBorelCandidate
     (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+  exact ⟨I, (isBorelOverAlgClosed_iff _ _ _).mpr ⟨inferInstance, hI⟩⟩
 
 /-- Every torus closed subgroup is a Borel candidate. -/
 theorem IsBorelCandidate.of_torus
@@ -126,16 +127,6 @@ theorem IsBorelCandidate.of_torus
   exact IsBorelCandidate.mk hI.smooth hI.geometricallyConnected
     (geometricallySolvablePointsCommHopfAlgProperty_of_isCocomm k
       (FiniteTypeCommHopfAlgCat.quotient H I).obj)
-
-/-- **Every torus is contained in a maximal smooth connected solvable closed subgroup.**
-
-Over an algebraically closed field the subgroup produced is a Borel containing the torus. This is
-the containment form used when choosing a Borel compatible with a prescribed maximal torus. -/
-theorem exists_minimal_isBorelCandidate_le_of_torus
-    (H : FiniteTypeCommHopfAlgCat.{u, u} k) {I : HopfIdeal k H}
-    (hI : torusCommHopfAlgProperty k (FiniteTypeCommHopfAlgCat.quotient H I)) :
-    ∃ J : HopfIdeal k H, J ≤ I ∧ Minimal (IsBorelCandidate k H) J :=
-  exists_minimal_isBorelCandidate_le H (IsBorelCandidate.of_torus hI)
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Existence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Existence.lean
@@ -37,7 +37,7 @@ on the group. No conjugacy statement is proved here.
   field has a maximal Borel candidate.
 * `TauCeti.HopfIdeal.exists_geometricBorel`: the geometric fibre of every finite-type affine
   group has a Borel subgroup.
-* `TauCeti.HopfIdeal.IsBorelCandidate.of_torus`: every torus is a Borel candidate.
+* `TauCeti.HopfIdeal.torusCommHopfAlgProperty.isBorelCandidate`: every torus is a Borel candidate.
 
 ## References
 
@@ -118,7 +118,7 @@ theorem exists_geometricBorel (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
   exact ⟨I, (isBorelOverAlgClosed_iff _ _ _).mpr ⟨inferInstance, hI⟩⟩
 
 /-- Every torus closed subgroup is a Borel candidate. -/
-theorem IsBorelCandidate.of_torus
+theorem torusCommHopfAlgProperty.isBorelCandidate
     {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k H}
     (hI : torusCommHopfAlgProperty k (FiniteTypeCommHopfAlgCat.quotient H I)) :
     IsBorelCandidate k H I := by


### PR DESCRIPTION
This PR constructs maximal smooth geometrically connected solvable closed subgroups in Hopf coordinates: name the non-maximal condition `HopfIdeal.IsBorelCandidate`, prove every candidate is contained in a maximal one, and apply the result after base change to an algebraic closure to obtain a geometric Borel subgroup. It also proves that every torus is a candidate and hence is contained in such a maximal subgroup.

The exact roadmap target is `ReductiveGroups/README.md`, Layer 7, “Borel subgroups, maximal tori, and their conjugacy,” and the designated milestone is Layer 7, “structure theory.” This is the most effective current step because merged PR #5719 supplied existence of maximal tori and the general Lie-dimension maximality theorem, so the same dimension argument now closes Borel existence and produces a Borel compatible with a prescribed torus instead of adding another concrete example. After this PR, the milestone still needs conjugacy of Borel subgroups and maximal tori, parabolic and Levi theory, and extraction of roots and Weyl groups for arbitrary reductive groups.

The construction is honest about fields: over an arbitrary field it returns a maximal candidate defined over that field, while `HopfIdeal.exists_geometricBorel` applies the theorem to the algebraic-closure fibre; no descent of a Borel to the original field is claimed. The relative theorem `exists_minimal_isBorelCandidate_le` gives the containment statement needed by later choices; composing it with `torusCommHopfAlgProperty.isBorelCandidate` supplies the torus specialization without a duplicate wrapper.

The proof reuses Tau Ceti’s `HopfIdeal.exists_minimal_of_smooth_of_connected`, the identity solvable-radical candidate, and the existing smoothness, connectedness, cocommutativity, and pointwise solvability APIs for tori. No Mathlib infrastructure is vendored. The mathematical construction follows Milne, *Algebraic Groups*, Theorem 17.6 and §17.a; Borel, *Linear Algebraic Groups*, §11.1; and Springer, *Linear Algebraic Groups*, §6.2, as cited in the new module.

The change adds `TauCeti/Algebra/AlgebraicGroup/Borel/Existence.lean` (144 lines) and refines `Borel/Basic.lean` by 63 net lines so the candidate predicate and its characteristic API are public and the existing geometric `IsBorel` definition consumes them.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geometric-borel-existence"}-->

🤖 Prepared with Codex
