### PR TITLE
feat: add Fisher-Snedecor parameter measurability

### DIFF
--- a/TauCeti/Probability/Distributions/FisherSnedecor/Measurability.lean
+++ b/TauCeti/Probability/Distributions/FisherSnedecor/Measurability.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Distributions.FisherSnedecor.Basic
+import all TauCeti.Probability.Distributions.FisherSnedecor.Basic
+import TauCeti.Analysis.SpecialFunctions.Gamma
+
+/-!
+# Parameter measurability of Fisher's F distribution
+
+This file proves that the Fisher--Snedecor law is a measurable function of its two degrees of
+freedom. Consequently, measurable numerator and denominator parameters can be used to form a
+probability kernel whenever they lie in the positive range.
+
+Joint measurability of the density is exposed alongside the measure-level result, so both the law
+and its density can be composed with measurable parameter maps.
+
+## Main results
+
+* `measurable_uncurry_fisherSnedecorPDF` — joint measurability of the density.
+* `measurable_fisherSnedecorMeasure` — joint parameter measurability of the family of measures.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Real
+
+namespace TauCeti
+
+namespace Probability
+
+/-- The Fisher--Snedecor density is jointly measurable in the numerator and denominator degrees
+of freedom and the sample point. -/
+@[fun_prop]
+theorem measurable_uncurry_fisherSnedecorPDF :
+    Measurable fun q : (ℝ × ℝ) × ℝ => fisherSnedecorPDF q.1.1 q.1.2 q.2 := by
+  unfold fisherSnedecorPDF fisherSnedecorPDFReal
+  refine (Measurable.ite ?_ (by fun_prop) measurable_const).ennreal_ofReal
+  have hzero : Measurable fun _ : (ℝ × ℝ) × ℝ => (0 : ℝ) := measurable_const
+  exact (measurableSet_lt hzero measurable_fst.fst).inter
+    ((measurableSet_lt hzero measurable_fst.snd).inter
+      (measurableSet_lt hzero measurable_snd))
+
+/-- The Fisher--Snedecor family is jointly measurable in its two degrees of freedom.
+
+This theorem includes every invalid parameter pair, where `fisherSnedecorMeasure` is the zero
+measure. -/
+@[fun_prop]
+theorem measurable_fisherSnedecorMeasure :
+    Measurable fun p : ℝ × ℝ => fisherSnedecorMeasure p.1 p.2 := by
+  simpa only [fisherSnedecorMeasure_eq_withDensity] using
+    measurable_withDensity (μ := volume) measurable_uncurry_fisherSnedecorPDF
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR makes the Fisher--Snedecor family jointly measurable in its numerator and denominator degrees of freedom, completing the shared parameter-measurability requirement for that distribution. It adds joint measurability of `fisherSnedecorPDF` in `(m, n, x)` and derives `measurable_fisherSnedecorMeasure` from the existing all-parameter `fisherSnedecorMeasure_eq_withDensity` identity.

The exact roadmap target is `StandardDistributions/README.md`, shared requirement 4, “Parameter measurability,” as applied to the Layer 3 milestone “Fisher's F.” This is the most effective current step because the law, density, cdf, sharp moments, and exact exponential-integrability domain are already on `main`, and merged PR #5729 identifies parameter measurability as the family's sole remaining target. After this PR, the Fisher's F milestone is complete; Layer 3 as a whole still waits only for the negative-binomial cumulative-law target already in flight in #5718 before Layer 4's stated prerequisite is fully discharged.

The proof reuses Tau Ceti's `Real.measurable_Gamma` and Fisher density characterization together with Mathlib's `measurable_withDensity`; no Mathlib infrastructure is vendored. The change adds `TauCeti/Probability/Distributions/FisherSnedecor/Measurability.lean` (62 lines).

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"measurable-fishersnedecormeasure"}-->

🤖 Prepared with Codex
