### PR TITLE
feat(Isogeny): negation as an isogeny, and the Neg structure on the hom carrier

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
@@ -192,6 +192,13 @@ theorem degree_comp (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂) :
   rw [φ.degree_eq_finrank hφ, ψ.degree_eq_finrank hψ, (ψ.comp φ).degree_eq_finrank hc]
   exact (Module.finrank_mul_finrank W₃.FunctionField W₂.FunctionField W₁.FunctionField).symm
 
+/-- **Both factors of an identity composite have degree one.** Degree is multiplicative and the
+identity has degree one, and `1` factors in `ℕ` only as `1 * 1`. -/
+theorem degree_eq_one_of_comp_eq_id {ψ : Isogeny W₂ W₁} {φ : Isogeny W₁ W₂}
+    (h : ψ.comp φ = id W₁) : ψ.degree = 1 ∧ φ.degree = 1 := by
+  have hmul : ψ.degree * φ.degree = 1 := by rw [← degree_comp, h, degree_id]
+  exact ⟨Nat.eq_one_of_mul_eq_one_right hmul, Nat.eq_one_of_mul_eq_one_left hmul⟩
+
 end Isogeny
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Neg.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Neg.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.CoordinateRing
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Hom
+
+/-!
+# Negation
+
+The involution `(x, y) ↦ (x, -y - a₁x - a₃)` of a Weierstrass curve is negation for the group
+law. Its pullback on functions is `CoordinateRing.conj`, the conjugation of the coordinate ring
+over `F[X]`, so negation is an isogeny of `W` with itself, an involution, and of degree one.
+
+Postcomposing with it negates on the hom carrier, which is the `Neg` structure the carrier's
+additive group is built from.
+
+## Main definitions
+
+* `TauCeti.Isogeny.negPullback`: the coordinate pullback `x ↦ conj x`.
+* `TauCeti.Isogeny.negIsogeny`: the same map packaged as an `Isogeny W W`.
+* `TauCeti.Isogeny.Hom.instNeg`: negation on `Hom W₁ W₂`, by postcomposition.
+
+## Main results
+
+* `TauCeti.Isogeny.negIsogeny_comp_negIsogeny`: negation is an involution.
+* `TauCeti.Isogeny.degree_negIsogeny`: negation has degree one, so it is an automorphism of `W`
+  fixing the point at infinity.
+* `TauCeti.Isogeny.Hom.neg_comp` and `TauCeti.Isogeny.Hom.degree_neg`: negation passes through
+  composition, and preserves degrees, on the carrier.
+
+The `MapsInfinity` condition says each `x` of the coordinate ring is integral over the pulled-back
+copy. Conjugation is an *equivalence*, so every function is the pullback of its own conjugate — the
+algebraic form of "negation fixes the point at infinity".
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.2.
+-/
+
+-- Design provenance: the negation formula is Silverman III.2; the isogeny packaging follows
+-- `TauCetiRoadmap/EllipticCurves/README.md` §Layer 1, whose hom-group target names the
+-- `AddCommGroup` as its content. Negation is that instance's `Neg`.
+
+public section
+
+open TauCeti.WeierstrassCurve.Affine.CoordinateRing
+
+namespace TauCeti
+
+variable {F : Type*} [Field F] (W : WeierstrassCurve.Affine F)
+
+namespace Isogeny
+
+/-- The negation coordinate pullback: an element of the coordinate ring is sent to its
+conjugate over `F[X]`, viewed in the function field. -/
+noncomputable def negPullback : CoordinatePullback W W :=
+  (IsScalarTower.toAlgHom F W.CoordinateRing W.FunctionField).comp
+    ((conj W).toAlgHom.restrictScalars F)
+
+/-- The negation pullback is conjugation. -/
+@[simp]
+theorem negPullback_apply (x : W.CoordinateRing) :
+    negPullback W x = algebraMap W.CoordinateRing W.FunctionField (conj W x) :=
+  (rfl)
+
+/-- **Negation maps the point at infinity to itself.** -/
+theorem mapsInfinity_negPullback : (negPullback W).MapsInfinity :=
+  -- Conjugation is an involution, so every function is already a pullback — of its own conjugate.
+  -- That is the first-power case of the general criterion.
+  CoordinatePullback.mapsInfinity_of_pow (negPullback W) Nat.one_pos fun z =>
+    ⟨conj W z, by rw [negPullback_apply, conj_conj, pow_one]⟩
+
+/-- **Negation, as an isogeny** `W ⟶ W`. -/
+noncomputable def negIsogeny : Isogeny W W where
+  pullback := negPullback W
+  mapsInfinity := mapsInfinity_negPullback W
+
+/-- The negation isogeny's pullback is conjugation. -/
+@[simp]
+theorem negIsogeny_pullback : (negIsogeny W).pullback = negPullback W := (rfl)
+
+/-- **Negation is an involution.** -/
+@[simp]
+theorem negIsogeny_comp_negIsogeny : (negIsogeny W).comp (negIsogeny W) = id W := by
+  refine Isogeny.ext (AlgHom.ext fun x => ?_)
+  -- Both conjugations act on the numerator, and `conj` squares to the identity.
+  simp [comp_pullback, fieldPullback_algebraMap, id_pullback]
+
+/-- **Negation has degree one**, so it is an automorphism of `W` fixing the point at infinity. -/
+@[simp]
+theorem degree_negIsogeny : (negIsogeny W).degree = 1 :=
+  (degree_eq_one_of_comp_eq_id (negIsogeny_comp_negIsogeny W)).1
+
+namespace Hom
+
+variable {W₁ W₂ W₃ : WeierstrassCurve.Affine F}
+
+/-- **Negation on the hom carrier**, by postcomposition with the negation isogeny. This is the
+`Neg` structure of the carrier's additive group; the addition is not built here. -/
+noncomputable instance : Neg (Hom W₁ W₂) :=
+  ⟨fun f => (ofIsogeny (negIsogeny W₂)).comp f⟩
+
+-- Deliberately not `@[simp]`: unfolding `-f` to a composition would make `-` vanish from every
+-- normalised goal, and the lemmas below about `-` could then never fire.
+/-- The equation lemma for negation: the definition's body is not exposed across the module
+boundary, so this is how downstream modules compute with it. -/
+theorem neg_def (f : Hom W₁ W₂) : -f = (ofIsogeny (negIsogeny W₂)).comp f := (rfl)
+
+/-- **The zero map is its own negative.** -/
+@[simp]
+theorem neg_zero : -(0 : Hom W₁ W₂) = 0 := by
+  rw [neg_def, comp_zero]
+
+/-- **Negating a nonzero element** postcomposes the underlying isogeny. -/
+@[simp]
+theorem neg_ofIsogeny (φ : Isogeny W₁ W₂) :
+    -(ofIsogeny φ) = ofIsogeny ((negIsogeny W₂).comp φ) := by
+  rw [neg_def, ofIsogeny_comp_ofIsogeny]
+
+/-- **Negation on the carrier is an involution**, because it is on the curve. -/
+noncomputable instance : InvolutiveNeg (Hom W₁ W₂) where
+  neg_neg f := by
+    rcases f.eq_zero_or_exists_ofIsogeny with rfl | ⟨φ, rfl⟩
+    · rw [neg_zero, neg_zero]
+    · rw [neg_ofIsogeny, neg_ofIsogeny, ← Isogeny.comp_assoc, negIsogeny_comp_negIsogeny,
+        Isogeny.id_comp]
+
+/-- **Negation passes through composition on the left.** -/
+@[simp]
+theorem neg_comp (g : Hom W₂ W₃) (f : Hom W₁ W₂) : (-g).comp f = -(g.comp f) := by
+  rw [neg_def, neg_def, comp_assoc]
+
+/-- **Negation preserves degrees**, negation itself having degree one. -/
+@[simp]
+theorem degree_neg (f : Hom W₁ W₂) : (-f).degree = f.degree := by
+  rw [neg_def, degree_comp, degree_ofIsogeny, degree_negIsogeny, one_mul]
+
+end Hom
+
+end Isogeny
+
+end TauCeti
+
+end


### PR DESCRIPTION
Negation of a Weierstrass curve, packaged as an isogeny, and the `Neg` structure it induces on the hom carrier.

`CoordinateRing.conj` — conjugation of the coordinate ring over `F[X]`, already in the repo as "the coordinate-ring form of Mathlib's `WeierstrassCurve.Affine.negY`" — is the pullback of the negation involution `(x, y) ↦ (x, -y - a₁x - a₃)`. Because conjugation is an *equivalence*, every function is the pullback of its own conjugate, so `MapsInfinity` is the degree-one case of integrality and negation is an `Isogeny W W`. It is an involution; degree being multiplicative and the identity having degree one, its degree is forced to be one, so negation is an automorphism of `W` fixing the point at infinity.

Postcomposing with it is negation on `Hom W₁ W₂`: `Neg` and `InvolutiveNeg` instances, `neg_comp : (-g).comp f = -(g.comp f)`, `degree_neg : (-f).degree = f.degree`, and the computation rules at `0` and at `ofIsogeny`.

`Isogeny/Degree.lean` gains one general lemma the degree computation goes through: `degree_eq_one_of_comp_eq_id`, that both factors of an identity composite have degree one.

This advances `TauCetiRoadmap/EllipticCurves/README.md` §Layer 1, target **"The hom-group and the degree form"**, whose stated "real content is the `AddCommGroup` instance". Negation is that instance's `Neg`; the remaining content — "the pointwise sum of isogenies is an isogeny or zero" — is not built here.

`neg_def` is deliberately not `@[simp]`: unfolding `-f` to a composition would erase `-` from every normalised goal, and the lemmas about `-` could then never fire. The `simpNF` linter confirms both directions.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"isogeny-neg"}-->

Provenance: original work. Sources swept, none containing isogeny-level negation: github.com/MichaelStollBayreuth/EllipticCurves @ 57f93fa71f16 (point-level `negY` in `VariableChange.lean` only — no isogenies, coordinate ring or function field); github.com/CBirkbeck/FLT @ 20eda920b763 (no isogeny material). Mathlib @ pin 5fcc6656691e has no `Isogeny` in `AlgebraicGeometry/EllipticCurve/` and no `CoordinateRing.conj` (compiled probe: unknown constant).
