### PR TITLE
refactor: put two Matrix lemmas in the root `Matrix` namespace

### DIFF
--- a/TauCeti/Analysis/Matrix/UnitaryGroup.lean
+++ b/TauCeti/Analysis/Matrix/UnitaryGroup.lean
@@ -19,7 +19,7 @@ unitary group. Rescaling by a scalar of modulus one keeps a matrix unitary, so n
 
 ## Main results
 
-* `TauCeti.Matrix.exists_circle_smul_mem_specialUnitaryGroup`: every complex unitary matrix becomes
+* `Matrix.exists_circle_smul_mem_specialUnitaryGroup`: every complex unitary matrix becomes
   special unitary after multiplication by a suitable scalar of modulus one.
 -/
 
@@ -34,7 +34,7 @@ variable {n : Type*} [Fintype n] [DecidableEq n]
 /-- `U(n) = Circle · SU(n)`: every complex unitary matrix becomes special unitary after
 multiplication by a suitable scalar of modulus one. The scalar is a `card n`-th root of the inverse
 of the determinant, which has modulus one; the root is taken through `Circle.exp`. -/
-theorem exists_circle_smul_mem_specialUnitaryGroup (U : Matrix.unitaryGroup n ℂ) :
+theorem _root_.Matrix.exists_circle_smul_mem_specialUnitaryGroup (U : Matrix.unitaryGroup n ℂ) :
     ∃ c : Circle, ((c : ℂ) • (U : Matrix n n ℂ)) ∈ Matrix.specialUnitaryGroup n ℂ := by
   have hcc : ∀ z : Circle, (z : ℂ) ∈ unitary ℂ := fun z =>
     Unitary.mem_iff_star_mul_self.mpr <| by

--- a/TauCeti/LinearAlgebra/UnitaryGroup.lean
+++ b/TauCeti/LinearAlgebra/UnitaryGroup.lean
@@ -18,7 +18,7 @@ is what makes the small special unitary groups computable by hand.
 
 ## Main results
 
-* `TauCeti.Matrix.specialUnitaryGroup.star_eq_adjugate`: the conjugate transpose of a special
+* `Matrix.specialUnitaryGroup.star_eq_adjugate`: the conjugate transpose of a special
   unitary matrix is its adjugate.
 -/
 
@@ -32,7 +32,7 @@ variable {n : Type*} [Fintype n] [DecidableEq n] {α : Type*} [CommRing α] [Sta
 
 /-- The conjugate transpose of a special unitary matrix is its adjugate: it is the inverse, and
 for determinant one the inverse is the adjugate. -/
-theorem specialUnitaryGroup.star_eq_adjugate (g : Matrix.specialUnitaryGroup n α) :
+theorem _root_.Matrix.specialUnitaryGroup.star_eq_adjugate (g : Matrix.specialUnitaryGroup n α) :
     star (g : Matrix n n α) = (g : Matrix n n α).adjugate := by
   have hmem := Matrix.mem_specialUnitaryGroup_iff.mp g.2
   have hmul : (g : Matrix n n α) * star (g : Matrix n n α) = 1 :=

--- a/TauCeti/RepresentationTheory/SU2/TorusConjugacy.lean
+++ b/TauCeti/RepresentationTheory/SU2/TorusConjugacy.lean
@@ -25,12 +25,12 @@ Hermitian part of `G` to be a scalar,
 
 `G + G* = (tr G) • 1`   (`TauCeti.SU2.coe_add_star`),
 
-because `G* = G⁻¹` is the adjugate of `G` (`TauCeti.Matrix.specialUnitaryGroup.star_eq_adjugate`)
+because `G* = G⁻¹` is the adjugate of `G` (`Matrix.specialUnitaryGroup.star_eq_adjugate`)
 and a `2 × 2` matrix and its adjugate add up to the trace. So `G` differs from the Hermitian
 matrix `H = i (G - G*)` by a scalar matrix, and any unitary that diagonalises `H` diagonalises
 `G`. The eigenvector unitary supplied by the spectral theorem need not have determinant one, but
 it can be rescaled by a scalar of modulus one until it does
-(`TauCeti.Matrix.exists_circle_smul_mem_specialUnitaryGroup`), and rescaling by a scalar does not
+(`Matrix.exists_circle_smul_mem_specialUnitaryGroup`), and rescaling by a scalar does not
 change the conjugation it induces.
 
 ## Main results


### PR DESCRIPTION
Two lemmas about Mathlib's `Matrix.unitaryGroup` / `Matrix.specialUnitaryGroup`
are declared inside `namespace TauCeti` → `namespace Matrix`, so their full names
are `TauCeti.Matrix.exists_circle_smul_mem_specialUnitaryGroup` and
`TauCeti.Matrix.specialUnitaryGroup.star_eq_adjugate` — names that *read* as
`Matrix.…` while being something else.

Declared `_root_.Matrix.…` instead. This is precisely the fix the `naming` rubric
asked for on #5579 (*"dot-notation material on an existing Mathlib type belongs
in that type's namespace"*), and it is the pattern the `Subgroup` blocks in
`Topology/Algebra/Group/Profinite/Index.lean` and
`Algebra/Group/NormalizerQuotient/*` already use.

**Call sites are unchanged.** Both are already written `Matrix.…` at their uses
(`SU2/TorusConjugacy.lean`, `SU2/Basic.lean`): inside `namespace TauCeti` that
previously resolved to `TauCeti.Matrix.…` and now resolves to the root name.
The three module docstrings that advertised `TauCeti.Matrix.…` are corrected to
match.

Six lines across three files.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp