### PR TITLE
refactor(Huber): drop an unused `set … with` equation

### DIFF
--- a/TauCeti/RingTheory/Huber/OpenIdeal.lean
+++ b/TauCeti/RingTheory/Huber/OpenIdeal.lean
@@ -180,7 +180,7 @@ theorem exists_forall_mem_idealImage_exists_sum_eq (P : PairOfDefinition A) (T :
       (((P.isOpen_idealImage 1).preimage (continuous_const_mul (d z t))).mem_nhds h0)
     exact ⟨N, fun x hx ↦ hN hx⟩
   choose N hN using habs
-  set K : ℕ := G.sup fun z ↦ T.sup (N z) with hK
+  set K : ℕ := G.sup fun z ↦ T.sup (N z)
   refine ⟨m + K, fun a ha ↦ ?_⟩
   obtain ⟨y, hy, rfl⟩ := (P.mem_idealImage (m + K)).mp ha
   have hy' : y ∈ Ideal.span (G : Set P.ringOfDefinition) * P.idealOfDefinition ^ K := by


### PR DESCRIPTION
`set K : ℕ := G.sup fun z ↦ T.sup (N z) with hK` binds the defining equation
`hK`. The abstracted `K` is used throughout the remaining proof — `m + K`,
`P.idealOfDefinition ^ K`, `P.idealImage K` — but the equation itself is never
used, by name or by any tactic that reads the local context.

One line. Removing a `with` clause cannot strand a hypothesis (unlike a dead
`have`, it carries no proof term), so the only way to be wrong is if the equation
were consumed — which is exactly what the scan tests.

Same class as #5730 (7 rows), #5733 (25) and #5756 (1), all merged. That class
was exhausted; this row arrived with `OpenIdeal.lean`'s most recent change.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp