### PR TITLE
feat(Huber): make `A⟨X₁,…,Xₖ⟩` a nonarchimedean ring, so the construction iterates

### DIFF
--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Basic
+public import Mathlib.Topology.Algebra.Nonarchimedean.Completion
 public import Mathlib.Topology.Algebra.UniformRing
 
 /-!
@@ -18,10 +19,16 @@ at the trivial weight family `Tᵢ = {1}` (Wedhorn *Adic Spaces*, arXiv:1910.059
 completion of `A` itself.
 
 Being a completion, `A⟨X₁,…,Xₖ⟩` is a complete Hausdorff topological `A`-algebra with all of
-that structure found by instance search, so this module fixes the notation and records what
-instance search does not supply: continuity of the structure map, and — at `k = 0`, where the
-construction degenerates to the separated completion of `A` — the identification of `A⟨⟩` with
-`Â` together with its topological API.
+that structure found by instance search. It is also again **nonarchimedean**, since the completion
+of a nonarchimedean group is one, so it is itself a legal coefficient ring for the construction:
+the iterated algebra `A⟨X₁,…,Xₖ⟩⟨Y₁,…,Y_m⟩` is well-formed, and `A⟨X₁,…,Xₖ⟩` is a legal target of
+the universal property in `TauCeti.RingTheory.Huber.WeightedEval.Completion`, whose targets must
+be complete, Hausdorff and nonarchimedean. That instance is Mathlib's, and is available here only
+because this module imports it.
+
+This module fixes the notation and records what instance search does not supply: continuity of the
+structure map, and — at `k = 0`, where the construction degenerates to the separated completion of
+`A` — the identification of `A⟨⟩` with `Â` together with its topological API.
 
 The predicate that every `A⟨X₁,…,Xₖ⟩` is noetherian is
 `TauCeti.Huber.IsStronglyNoetherian`, in `TauCeti.RingTheory.Huber.StronglyNoetherian`; the


### PR DESCRIPTION
`A⟨X₁,…,Xₖ⟩` is a `UniformSpace.Completion`, and Mathlib proves that the completion of a
nonarchimedean group is nonarchimedean. That instance lives in
`Mathlib.Topology.Algebra.Nonarchimedean.Completion`, which
`TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean` did not import, so

```lean
example : NonarchimedeanRing (restrictedMvPowerSeriesCompletion k A) := by infer_instance
-- failed to synthesize instance of type class
--   NonarchimedeanRing (restrictedMvPowerSeriesCompletion k A)
```

One `public import`, and the docstring paragraph that claimed otherwise.

Roadmap: AdicSpaces

## What downstream roadmap item needs this

`TauCetiRoadmap/AdicSpaces/README.md`, Layer 0.5, numbered item 5, verbatim:

> 5. Stability of noetherianity under quotients and the iteration
>    `A⟨X⟩⟨Y⟩ ≅ A⟨X,Y⟩`.

That iteration cannot be *stated* without this instance. `restrictedMvPowerSeriesCompletion`
requires `[NonarchimedeanRing A]` of its coefficient ring, so before this change

```lean
restrictedMvPowerSeriesCompletion m (restrictedMvPowerSeriesCompletion k A)
```

did not elaborate. It does now, and is itself nonarchimedean, so the construction iterates to any
depth.

The same instance is what makes `A⟨X₁,…,Xₖ⟩` a legal **target** of its own universal property.
`existsUnique_continuous_ringHom_completion_weightedRestrictedSubring_of_isWeightedVarPowerBounded`
in `TauCeti.RingTheory.Huber.WeightedEval.Completion` — Wedhorn's Proposition 5.50, carried across
the completion — asks its target to be complete, Hausdorff **and nonarchimedean**. The first two
were available; the third was not. Both directions of the iteration isomorphism are built by
applying that universal property with `A⟨X⟩⟨Y⟩` and `A⟨X,Y⟩` as targets, so neither could be
written down.

Layer 0.5 item 5 is in turn the deepest unbuilt prerequisite of the preservation result —
rational localisations of a strongly noetherian ring are again strongly noetherian — that
Wedhorn takes as the standing hypothesis of his §8.2, and that #5753's chain theorem currently
carries as an explicit family hypothesis rather than deriving.

## Why it is only an import

Nothing is restated. Mathlib's two instances

* `NonarchimedeanAddGroup (Completion G)` and
* `NonarchimedeanRing (Completion R)`

(`Mathlib/Topology/Algebra/Nonarchimedean/Completion.lean`, Mitchell Lee, 2024) are exactly the
facts wanted, and they apply to `A⟨X₁,…,Xₖ⟩` with no side conditions beyond the ones the object
already carries. TauCeti already reaches them from
`TauCeti/Topology/Algebra/Nonarchimedean/Completion.lean`; the weighted-series branch of the tree
simply did not.

No declaration is added, renamed or removed, and nothing downstream changes meaning — the diff is
strictly an enlargement of what instance search can find. Verified with `lake build` over the
module's dependents and `lake exe runLinter`.

## The docstring correction

The module said

> Being a completion, `A⟨X₁,…,Xₖ⟩` is a complete Hausdorff topological `A`-algebra with all of
> that structure found by instance search

which was the claim this bug falsified. It now names the nonarchimedean instance as Mathlib's,
says that it is available only because the module imports it, and says what it is for.

## What is not claimed

The iteration isomorphism `A⟨X⟩⟨Y⟩ ≅ A⟨X,Y⟩` is not here — only the fact that both sides are
well-formed. That isomorphism is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
