### PR TITLE
refactor(ModularForms): name the FactorsThrough step of the refactoring lemma

### DIFF
--- a/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
+++ b/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
@@ -19,8 +19,6 @@ argument for the conductor theorem consumes, and it is stated for characters val
 
 ## Main results
 
-* `DirichletCharacter.not_factorsThrough_of_not_forall`: a character non-trivial somewhere on
-  the kernel of the reduction does not factor through it.
 * `DirichletCharacter.exists_alt_unit_in_coset_with_char_separation`: character separation within
   a fibre of the reduction map.
 
@@ -38,18 +36,6 @@ consequence of the other, so only this form is ported and the extraction is done
 public section
 
 namespace DirichletCharacter
-
-/-- **A character nontrivial on the kernel does not factor.** A unit homomorphism `χ` that is
-not identically `1` on the kernel of `ZMod.unitsMap : (ZMod N)ˣ →* (ZMod d)ˣ` gives a Dirichlet
-character that does not factor through `d`. This is the hypothesis of
-`exists_alt_unit_in_coset_with_char_separation` in the form callers usually hold it. -/
-theorem not_factorsThrough_of_not_forall {R : Type*} [CommMonoidWithZero R] {N : ℕ} [NeZero N]
-    {d : ℕ} (hd : d ∣ N) {χ : (ZMod N)ˣ →* Rˣ}
-    (hχ : ¬ ∀ u : (ZMod N)ˣ, ZMod.unitsMap hd u = 1 → χ u = 1) :
-    ¬ DirichletCharacter.FactorsThrough (MulChar.ofUnitHom χ) d := by
-  refine fun hfac ↦ hχ fun v hv ↦ ?_
-  simpa using MonoidHom.mem_ker.mp
-    ((factorsThrough_iff_ker_unitsMap hd).mp hfac (MonoidHom.mem_ker.mpr hv))
 
 /-- **Character separation within a coset.** If `χ` does not factor through `d ∣ N`, then every
 unit `u` has a partner `u'` with the same reduction modulo `d` but a different character value —

--- a/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
+++ b/TauCeti/NumberTheory/DirichletCharacter/Basic.lean
@@ -19,6 +19,8 @@ argument for the conductor theorem consumes, and it is stated for characters val
 
 ## Main results
 
+* `DirichletCharacter.not_factorsThrough_of_not_forall`: a character non-trivial somewhere on
+  the kernel of the reduction does not factor through it.
 * `DirichletCharacter.exists_alt_unit_in_coset_with_char_separation`: character separation within
   a fibre of the reduction map.
 
@@ -36,6 +38,18 @@ consequence of the other, so only this form is ported and the extraction is done
 public section
 
 namespace DirichletCharacter
+
+/-- **A character nontrivial on the kernel does not factor.** A unit homomorphism `χ` that is
+not identically `1` on the kernel of `ZMod.unitsMap : (ZMod N)ˣ →* (ZMod d)ˣ` gives a Dirichlet
+character that does not factor through `d`. This is the hypothesis of
+`exists_alt_unit_in_coset_with_char_separation` in the form callers usually hold it. -/
+theorem not_factorsThrough_of_not_forall {R : Type*} [CommMonoidWithZero R] {N : ℕ} [NeZero N]
+    {d : ℕ} (hd : d ∣ N) {χ : (ZMod N)ˣ →* Rˣ}
+    (hχ : ¬ ∀ u : (ZMod N)ˣ, ZMod.unitsMap hd u = 1 → χ u = 1) :
+    ¬ DirichletCharacter.FactorsThrough (MulChar.ofUnitHom χ) d := by
+  refine fun hfac ↦ hχ fun v hv ↦ ?_
+  simpa using MonoidHom.mem_ker.mp
+    ((factorsThrough_iff_ker_unitsMap hd).mp hfac (MonoidHom.mem_ker.mpr hv))
 
 /-- **Character separation within a coset.** If `χ` does not factor through `d ∣ N`, then every
 unit `u` has a partner `u'` with the same reduction modulo `d` but a different character value —

--- a/TauCeti/NumberTheory/ModularForms/ConductorDichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/ConductorDichotomy.lean
@@ -123,6 +123,16 @@ private lemma eq_T_mul_mul_T_of_sub_eq {l Nl i j a a' e e' b b' : ℤ} (hNl : Nl
   · ring
   · linear_combination -hj
 
+omit [NeZero N] in
+/-- **The determinant of a Bézout lift, with its lower-left entry factored.** Writing that entry
+as `l * (N / l)` is the only thing the vanishing argument knows about the lift's upper row, and
+both the chosen unit and its partner are read through this identity. -/
+private lemma gamma0TwistOfUnit_det_eq_one {l : ℕ} (hlN : l ∣ N) (v : (ZMod N)ˣ) :
+    gamma0TwistOfUnit v 0 0 * gamma0TwistOfUnit v 1 1 -
+      gamma0TwistOfUnit v 0 1 * ((l : ℤ) * ((N / l : ℕ) : ℤ)) = 1 := by
+  rw [← gamma0TwistOfUnit_apply_one_zero_eq_mul (l := l) hlN v]
+  exact fin_two_mul_sub_mul_eq_one _
+
 /-- **The refactoring step.** For a character not trivial on the kernel, the `diag(l, 1)`-conjugate
 of the Bézout lift of `u` is a translate — on both sides — of the conjugate of the lift of some
 `u'` on which the character takes a *different* value. Since the function the vanishing argument
@@ -139,23 +149,23 @@ private theorem exists_apply_ne_and_eq_T_zpow_mul_conjScale_mul_T_zpow {l : ℕ}
         (gamma0TwistOfUnit_apply_one_zero_eq_mul hlN _) * ModularGroup.T ^ j := by
   -- `l ≠ 0` is forced by `hlN` and `NeZero N`, so it is derived rather than demanded
   have : NeZero l := NeZero.of_dvd hlN
+  -- nontriviality on the kernel is non-factorisation, in the form the separation lemma takes
+  have hnfac : ¬ DirichletCharacter.FactorsThrough (MulChar.ofUnitHom χ) (N / l) :=
+    fun hfac ↦ hχ fun v hv ↦ by
+      simpa using MonoidHom.mem_ker.mp ((DirichletCharacter.factorsThrough_iff_ker_unitsMap
+        (Nat.div_dvd_of_dvd hlN)).mp hfac (MonoidHom.mem_ker.mpr hv))
   -- the separation is `DirichletCharacter.exists_alt_unit_in_coset_with_char_separation`,
   -- read through `MulChar.ofUnitHom`
   obtain ⟨u', hcoset, hne⟩ :=
     DirichletCharacter.exists_alt_unit_in_coset_with_char_separation
-      (Nat.div_dvd_of_dvd hlN)
-      (DirichletCharacter.not_factorsThrough_of_not_forall (Nat.div_dvd_of_dvd hlN) hχ) u
+      (Nat.div_dvd_of_dvd hlN) hnfac u
   simp only [MulChar.toUnitHom_eq, MulChar.ofUnitHom_eq, Equiv.apply_symm_apply] at hne
   set Nl : ℤ := ((N / l : ℕ) : ℤ) with hNl
   have hNl_ne : Nl ≠ 0 := by
     rw [hNl, Nat.cast_ne_zero]
     exact (Nat.div_pos (Nat.le_of_dvd (Nat.pos_of_neZero N) hlN) (Nat.pos_of_neZero l)).ne'
-  -- the determinant of a lift, read through the factorization `N = l * (N / l)` of its
-  -- lower-left entry: this is the only thing known about the upper row
   have hdet : ∀ v : (ZMod N)ˣ, gamma0TwistOfUnit v 0 0 * gamma0TwistOfUnit v 1 1 -
-      gamma0TwistOfUnit v 0 1 * ((l : ℤ) * Nl) = 1 := fun v => by
-    rw [← gamma0TwistOfUnit_apply_one_zero_eq_mul (l := l) hlN v]
-    exact fin_two_mul_sub_mul_eq_one _
+      gamma0TwistOfUnit v 0 1 * ((l : ℤ) * Nl) = 1 := gamma0TwistOfUnit_det_eq_one hlN
   -- the lower-right entries are the unit values, so the coset congruence is one between them
   have hdvd_e : Nl ∣ gamma0TwistOfUnit u 1 1 - gamma0TwistOfUnit u' 1 1 := by
     rw [gamma0TwistOfUnit_apply_one_one, gamma0TwistOfUnit_apply_one_one]

--- a/TauCeti/NumberTheory/ModularForms/ConductorDichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/ConductorDichotomy.lean
@@ -123,17 +123,6 @@ private lemma eq_T_mul_mul_T_of_sub_eq {l Nl i j a a' e e' b b' : ℤ} (hNl : Nl
   · ring
   · linear_combination -hj
 
-/-- **The hypothesis, as a `FactorsThrough` negation.** `χ` being non-trivial somewhere on the
-kernel of `(ZMod N)ˣ → (ZMod (N / l))ˣ` says exactly that `χ` does not factor through level
-`N / l`, which is the form `DirichletCharacter`'s separation lemmas take. -/
-private lemma not_factorsThrough_of_not_forall {l : ℕ} (hlN : l ∣ N) {χ : (ZMod N)ˣ →* ℂˣ}
-    (hχ : ¬ ∀ u : (ZMod N)ˣ, ZMod.unitsMap (Nat.div_dvd_of_dvd hlN) u = 1 → χ u = 1) :
-    ¬ DirichletCharacter.FactorsThrough (MulChar.ofUnitHom χ) (N / l) := by
-  refine fun hfac ↦ hχ fun v hv ↦ ?_
-  simpa using MonoidHom.mem_ker.mp
-    ((DirichletCharacter.factorsThrough_iff_ker_unitsMap (Nat.div_dvd_of_dvd hlN)).mp hfac
-      (MonoidHom.mem_ker.mpr hv))
-
 /-- **The refactoring step.** For a character not trivial on the kernel, the `diag(l, 1)`-conjugate
 of the Bézout lift of `u` is a translate — on both sides — of the conjugate of the lift of some
 `u'` on which the character takes a *different* value. Since the function the vanishing argument
@@ -154,7 +143,8 @@ private theorem exists_apply_ne_and_eq_T_zpow_mul_conjScale_mul_T_zpow {l : ℕ}
   -- read through `MulChar.ofUnitHom`
   obtain ⟨u', hcoset, hne⟩ :=
     DirichletCharacter.exists_alt_unit_in_coset_with_char_separation
-      (Nat.div_dvd_of_dvd hlN) (not_factorsThrough_of_not_forall hlN hχ) u
+      (Nat.div_dvd_of_dvd hlN)
+      (DirichletCharacter.not_factorsThrough_of_not_forall (Nat.div_dvd_of_dvd hlN) hχ) u
   simp only [MulChar.toUnitHom_eq, MulChar.ofUnitHom_eq, Equiv.apply_symm_apply] at hne
   set Nl : ℤ := ((N / l : ℕ) : ℤ) with hNl
   have hNl_ne : Nl ≠ 0 := by

--- a/TauCeti/NumberTheory/ModularForms/ConductorDichotomy.lean
+++ b/TauCeti/NumberTheory/ModularForms/ConductorDichotomy.lean
@@ -123,6 +123,17 @@ private lemma eq_T_mul_mul_T_of_sub_eq {l Nl i j a a' e e' b b' : ℤ} (hNl : Nl
   · ring
   · linear_combination -hj
 
+/-- **The hypothesis, as a `FactorsThrough` negation.** `χ` being non-trivial somewhere on the
+kernel of `(ZMod N)ˣ → (ZMod (N / l))ˣ` says exactly that `χ` does not factor through level
+`N / l`, which is the form `DirichletCharacter`'s separation lemmas take. -/
+private lemma not_factorsThrough_of_not_forall {l : ℕ} (hlN : l ∣ N) {χ : (ZMod N)ˣ →* ℂˣ}
+    (hχ : ¬ ∀ u : (ZMod N)ˣ, ZMod.unitsMap (Nat.div_dvd_of_dvd hlN) u = 1 → χ u = 1) :
+    ¬ DirichletCharacter.FactorsThrough (MulChar.ofUnitHom χ) (N / l) := by
+  refine fun hfac ↦ hχ fun v hv ↦ ?_
+  simpa using MonoidHom.mem_ker.mp
+    ((DirichletCharacter.factorsThrough_iff_ker_unitsMap (Nat.div_dvd_of_dvd hlN)).mp hfac
+      (MonoidHom.mem_ker.mpr hv))
+
 /-- **The refactoring step.** For a character not trivial on the kernel, the `diag(l, 1)`-conjugate
 of the Bézout lift of `u` is a translate — on both sides — of the conjugate of the lift of some
 `u'` on which the character takes a *different* value. Since the function the vanishing argument
@@ -139,17 +150,11 @@ private theorem exists_apply_ne_and_eq_T_zpow_mul_conjScale_mul_T_zpow {l : ℕ}
         (gamma0TwistOfUnit_apply_one_zero_eq_mul hlN _) * ModularGroup.T ^ j := by
   -- `l ≠ 0` is forced by `hlN` and `NeZero N`, so it is derived rather than demanded
   have : NeZero l := NeZero.of_dvd hlN
-  -- the separation is `DirichletCharacter.exists_alt_unit_in_coset_with_char_separation`, read
-  -- through `MulChar.ofUnitHom`; `hχ` is the negation of `FactorsThrough` by
-  -- `DirichletCharacter.factorsThrough_iff_ker_unitsMap`, exactly as in the dichotomy below
-  have hnfac : ¬ DirichletCharacter.FactorsThrough (MulChar.ofUnitHom χ) (N / l) := by
-    refine fun hfac ↦ hχ fun v hv ↦ ?_
-    simpa using MonoidHom.mem_ker.mp
-      ((DirichletCharacter.factorsThrough_iff_ker_unitsMap (Nat.div_dvd_of_dvd hlN)).mp hfac
-        (MonoidHom.mem_ker.mpr hv))
+  -- the separation is `DirichletCharacter.exists_alt_unit_in_coset_with_char_separation`,
+  -- read through `MulChar.ofUnitHom`
   obtain ⟨u', hcoset, hne⟩ :=
     DirichletCharacter.exists_alt_unit_in_coset_with_char_separation
-      (Nat.div_dvd_of_dvd hlN) hnfac u
+      (Nat.div_dvd_of_dvd hlN) (not_factorsThrough_of_not_forall hlN hχ) u
   simp only [MulChar.toUnitHom_eq, MulChar.ofUnitHom_eq, Equiv.apply_symm_apply] at hne
   set Nl : ℤ := ((N / l : ℕ) : ℤ) with hNl
   have hNl_ne : Nl ≠ 0 := by


### PR DESCRIPTION
Roadmap: ModularForms

`exists_apply_ne_and_eq_T_zpow_mul_conjScale_mul_T_zpow` was 55 lines, over the
repo's 50-line cap. This PR names one step of it so that it fits.

The step is the **determinant identity for a Bézout lift**, with the lower-left
entry written through the factorisation `N = l * (N / l)`:

```
private lemma gamma0TwistOfUnit_det_eq_one {l : ℕ} (hlN : l ∣ N) (v : (ZMod N)ˣ) :
    gamma0TwistOfUnit v 0 0 * gamma0TwistOfUnit v 1 1 -
      gamma0TwistOfUnit v 0 1 * ((l : ℤ) * ((N / l : ℕ) : ℤ)) = 1
```

That factorisation is the only thing the vanishing argument knows about the
lift's upper row, and the proof applies the identity twice — once to the chosen
unit and once to the partner the separation lemma supplies.

55 lines becomes 50, and no proof in the file is over the cap.

### What changed since the first two rounds

The step originally extracted was the conversion from "χ is nontrivial on the
kernel" to `¬ FactorsThrough`. Review moved it out to
`DirichletCharacter/Basic.lean` and generalised it (api-design, placement), and
then `reuse` — reaffirmed on that generalised version — held that it remained a
one-use repackaging of `factorsThrough_iff_ker_unitsMap`. I had committed in the
contest thread to deleting it if the finding stood, so it is gone:
`DirichletCharacter/Basic.lean` is untouched by this PR, back to its state on
`main`, and the conversion is a local `have` at the single place that needs it.

Deleting it returned the proof to 54 lines, so the determinant identity carries
the decomposition instead. It is a better candidate on the rubric's own terms: it
is about `gamma0TwistOfUnit` rather than about Mathlib's character API, it does
not leave this file, and it has two uses rather than one.

### Two Lean details

The conversion is a typed `have` rather than a lambda passed as an argument — in
argument position its coefficient type has nothing to be inferred from and
elaboration gets stuck on the instance.

`omit [NeZero N] in` goes **before** the docstring; between the docstring and the
declaration it is a parse error.

Verified with a green build of the module and everything importing it, plus the
repo's 13-linter `#lint` set over its cone (0 errors, 409 declarations).

Roadmap attribution only — this is a refactor and carries no target marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
