### PR TITLE
feat: place Kostant Weyl elements in toral carriers

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
@@ -31,6 +31,8 @@ group of the root datum.
 
 * `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint`: the Weyl representative as a point
   of the toral closure.
+* `TauCeti.UniversalEnvelopingAlgebra.map_kostantToralWeylPoint`: the representative is natural
+  in the value ring.
 * `TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralWeylPoint`: its matrix is the integral Weyl
   automorphism in the chosen basis.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_conj_rootSubgroupPoints`: conjugation
@@ -53,7 +55,7 @@ open TensorProduct
 
 namespace TauCeti.UniversalEnvelopingAlgebra
 
-universe u v w
+universe u v v' w
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 attribute [local instance high] Algebra.toModule
@@ -113,6 +115,30 @@ noncomputable def kostantToralWeylPoint (i j : I) (A : Type v) [CommRing A] :
       (Multiplicative.ofAdd (-1 : A)) *
     kostantToralRootSubgroupPoints e h ρ M hM hnil b wt i A
       (Multiplicative.ofAdd (1 : A))
+
+/-- The carrier's Weyl representative is natural in the value ring. Applying a ring homomorphism
+entrywise sends the representative over the source ring to the representative over the target
+ring. -/
+theorem map_kostantToralWeylPoint {A : Type v} {B : Type v'} [CommRing A] [CommRing B]
+    (φ : A →+* B) (i j : I) :
+    GeneralLinear.mapHopfIdealPointsSubgroup n
+        (kostantToralDefiningIdeal e h ρ M hM hnil b wt) φ.toIntAlgHom
+        (MulEquiv.subgroupCongr
+          (kostantToralPointsSubgroup_def e h ρ M hM hnil b wt A)
+          (kostantToralWeylPoint e h ρ M hM hnil b wt i j A)) =
+      MulEquiv.subgroupCongr
+        (kostantToralPointsSubgroup_def e h ρ M hM hnil b wt B)
+        (kostantToralWeylPoint e h ρ M hM hnil b wt i j B) := by
+  apply Subtype.ext
+  have hring : φ.toIntAlgHom.toRingHom = φ := RingHom.ext (RingHom.toIntAlgHom_apply φ)
+  simp only [GeneralLinear.coe_mapHopfIdealPointsSubgroup, kostantToralWeylPoint,
+    MulEquiv.subgroupCongr_apply, Subgroup.coe_mul, map_mul,
+    coe_kostantToralRootSubgroupPoints, hring]
+  rw [map_kostantRootSubgroupMatrix e h ρ M hM i (hnil i) b φ,
+    map_kostantRootSubgroupMatrix e h ρ M hM j (hnil j) b φ,
+    AdditiveGroup.mapValue_gaPointsMulEquiv_symm_apply,
+    AdditiveGroup.mapValue_gaPointsMulEquiv_symm_apply]
+  simp only [toAdd_ofAdd, map_one, map_neg]
 
 /-- In the chosen basis, the carrier's Weyl representative is the matrix of the integral Weyl
 automorphism of the admissible lattice. -/

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
@@ -217,15 +217,14 @@ theorem kostantToralWeylPoint_mem_normalizer_weightTorusPoints
   have hcarrier :
       (kostantToralWeightTorusPoints e h ρ M hM hnil b wt A).range =
         T.subgroupOf K := by
-    ext x
-    simp only [MonoidHom.mem_range, Subgroup.mem_subgroupOf]
-    constructor
-    · rintro ⟨s, rfl⟩
-      refine ⟨s, ?_⟩
-      exact (coe_kostantToralWeightTorusPoints e h ρ M hM hnil b wt A s).symm
-    · rintro ⟨s, hs⟩
-      refine ⟨s, Subtype.ext ?_⟩
-      exact (coe_kostantToralWeightTorusPoints e h ρ M hM hnil b wt A s).trans hs
+    let fK := (kostantTorusMatrix M b wt).codRestrict K fun x ↦ hTK ⟨x, rfl⟩
+    have hf : kostantToralWeightTorusPoints e h ρ M hM hnil b wt A = fK := by
+      apply MonoidHom.ext
+      intro s
+      apply Subtype.ext
+      exact coe_kostantToralWeightTorusPoints e h ρ M hM hnil b wt A s
+    rw [hf]
+    exact (MonoidHom.subgroupOf_range_eq_of_le (kostantTorusMatrix M b wt) hTK).symm
   rw [hcarrier, ← Subgroup.subgroupOf_normalizer_eq hTK]
   rw [Subgroup.mem_subgroupOf]
   rw [coe_kostantToralWeylPoint]

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
@@ -33,12 +33,12 @@ group of the root datum.
   of the toral closure.
 * `TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralWeylPoint`: its matrix is the integral Weyl
   automorphism in the chosen basis.
-* `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_conj_rootSubgroup`: conjugation
+* `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_conj_rootSubgroupPoints`: conjugation
   exchanges the two root subgroups in the `sl₂` pair.
-* `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_conj_weightTorus`: its conjugation
+* `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_conj_weightTorusPoints`: its conjugation
   action on the represented split torus.
-* `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_mem_normalizer_weightTorus`: the Weyl
-  representative belongs to the torus normalizer inside the carrier.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_mem_normalizer_weightTorusPoints`: the
+  Weyl representative belongs to the torus normalizer inside the carrier.
 
 ## References
 
@@ -70,6 +70,15 @@ variable (hnil : ∀ i, IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι �
 variable {n : ℕ} (b : Module.Basis (Fin n) ℤ M)
 variable (wt : Fin n → κ → ℤ)
 
+omit [Module ℚ V] in
+private theorem basisMatrix_eq_of_val_apply_eq {A : Type v} [CommRing A]
+    {x y : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)}
+    (hxy : ∀ z, x.val z = y.val z) :
+    Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom x =
+      Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom y :=
+  congrArg (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom)
+    (Units.ext (LinearMap.ext hxy))
+
 /-! ## The Weyl representative in the carrier -/
 
 /-- The Weyl representative `xᵢ(1) xⱼ(-1) xᵢ(1)` as a point of the Kostant toral closure.
@@ -100,15 +109,12 @@ theorem coe_kostantToralWeylPoint (i j : I) (A : Type v) [CommRing A] :
     ← basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A j
       (Multiplicative.ofAdd (-1)),
     ← map_mul, ← map_mul]
-  congr 1
-  apply Units.ext
-  apply LinearMap.ext
-  intro z
-  rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
-    kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
-    kostantRootSubgroupParam_val_apply, toAdd_ofAdd, toAdd_ofAdd, kostantWeylGL_val]
-  exact LinearMap.congr_fun
-    (kostantWeylPoints_toLinearMap_eq e h ρ M hM (hnil i) (hnil j) (A := A)).symm z
+  exact basisMatrix_eq_of_val_apply_eq (A := A) M b fun z => by
+    rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
+      kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
+      kostantRootSubgroupParam_val_apply, toAdd_ofAdd, toAdd_ofAdd, kostantWeylGL_val]
+    exact LinearMap.congr_fun
+      (kostantWeylPoints_toLinearMap_eq e h ρ M hM (hnil i) (hnil j) (A := A)).symm z
 
 /-! ## Normalization of the represented torus -/
 
@@ -122,7 +128,7 @@ variable (hαneg : ∀ q, ⁅h q, e j⁆ = -((α q : ℚ) • e j))
 include hT in
 /-- Conjugation by the carrier's Weyl representative exchanges the two root subgroups of the
 `sl₂` pair, negating the parameter: `nᵢ xᵢ(u) nᵢ⁻¹ = xⱼ(-u)`. -/
-theorem kostantToralWeylPoint_conj_rootSubgroup (A : Type v) [CommRing A] (u : A) :
+theorem kostantToralWeylPoint_conj_rootSubgroupPoints (A : Type v) [CommRing A] (u : A) :
     kostantToralWeylPoint e h ρ M hM hnil b wt i j A *
         kostantToralRootSubgroupPoints e h ρ M hM hnil b wt i A
           (Multiplicative.ofAdd u) *
@@ -137,29 +143,25 @@ theorem kostantToralWeylPoint_conj_rootSubgroup (A : Type v) [CommRing A] (u : A
       (Multiplicative.ofAdd u),
     ← basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A j
       (Multiplicative.ofAdd (-u))]
-  have hGL :
-      kostantWeylGL e h ρ M hM (hnil i) (hnil j) A *
-          kostantRootSubgroupParam e h ρ M hM i (hnil i) (CommAlgCat.of ℤ A)
-            (Multiplicative.ofAdd u) *
-          (kostantWeylGL e h ρ M hM (hnil i) (hnil j) A)⁻¹ =
-        kostantRootSubgroupParam e h ρ M hM j (hnil j) (CommAlgCat.of ℤ A)
-          (Multiplicative.ofAdd (-u)) := by
-    apply Units.ext
-    apply LinearMap.ext
-    intro z
-    rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
-      kostantWeylGL_val, kostantWeylGL_inv_val,
-      kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
-      toAdd_ofAdd, toAdd_ofAdd]
-    exact LinearMap.congr_fun
-      (kostantWeylPoints_conj_baseChangeExp e h ρ M hM (hnil i) (hnil j) hT u) z
   simpa only [map_mul, map_inv, MulEquiv.toMonoidHom_eq_coe] using
-    congrArg (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom) hGL
+    basisMatrix_eq_of_val_apply_eq (A := A) M b
+      (x := kostantWeylGL e h ρ M hM (hnil i) (hnil j) A *
+        kostantRootSubgroupParam e h ρ M hM i (hnil i) (CommAlgCat.of ℤ A)
+          (Multiplicative.ofAdd u) *
+        (kostantWeylGL e h ρ M hM (hnil i) (hnil j) A)⁻¹)
+      (y := kostantRootSubgroupParam e h ρ M hM j (hnil j) (CommAlgCat.of ℤ A)
+        (Multiplicative.ofAdd (-u))) fun z => by
+      rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
+        kostantWeylGL_val, kostantWeylGL_inv_val,
+        kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
+        toAdd_ofAdd, toAdd_ofAdd]
+      exact LinearMap.congr_fun
+        (kostantWeylPoints_conj_baseChangeExp e h ρ M hM (hnil i) (hnil j) hT u) z
 
 include hT hα hαneg in
 /-- Conjugating a represented weight-torus point by the carrier's Weyl representative reflects
 the torus point by the root `α` and its coroot coordinate `c`. -/
-theorem kostantToralWeylPoint_conj_weightTorus
+theorem kostantToralWeylPoint_conj_weightTorusPoints
     [DecidableEq κ]
     (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V))
     (A : Type v) [CommRing A] (s : κ → Aˣ) :
@@ -182,34 +184,52 @@ theorem kostantToralWeylPoint_conj_weightTorus
 include hT hα hαneg in
 /-- The Weyl representative is in the normalizer of the represented weight torus inside the
 Kostant toral closure. -/
-theorem kostantToralWeylPoint_mem_normalizer_weightTorus
+theorem kostantToralWeylPoint_mem_normalizer_weightTorusPoints
     (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V))
     (A : Type v) [CommRing A] :
     kostantToralWeylPoint e h ρ M hM hnil b wt i j A ∈
       Subgroup.normalizer
         (kostantToralWeightTorusPoints e h ρ M hM hnil b wt A).range := by
   classical
-  apply Subgroup.mem_normalizer_iff_map_conj_eq.mpr
-  have hαc : α c = 2 := rootWeight_apply_coroot_eq_two e h ρ hT (hα c)
-  have hconj := kostantToralWeylPoint_conj_weightTorus
-    e h ρ M hM hnil b wt hT hα hαneg hwt A
-  have hconj' : ∀ s : κ → Aˣ,
-      (MulAut.conj (kostantToralWeylPoint e h ρ M hM hnil b wt i j A))
-          (kostantToralWeightTorusPoints e h ρ M hM hnil b wt A s) =
-        kostantToralWeightTorusPoints e h ρ M hM hnil b wt A
-          (weylReflectTorusPoint α c s) :=
-    hconj
-  ext y
-  simp only [Subgroup.mem_map, MonoidHom.mem_range]
-  constructor
-  · rintro ⟨z, ⟨s, rfl⟩, rfl⟩
-    exact ⟨weylReflectTorusPoint α c s, (hconj' s).symm⟩
-  · rintro ⟨s, rfl⟩
-    refine ⟨kostantToralWeightTorusPoints e h ρ M hM hnil b wt A
-        (weylReflectTorusPoint α c s),
-      ⟨weylReflectTorusPoint α c s, rfl⟩, ?_⟩
-    exact (hconj' (weylReflectTorusPoint α c s)).trans <|
-      congrArg (kostantToralWeightTorusPoints e h ρ M hM hnil b wt A)
-        (weylReflectTorusPoint_weylReflectTorusPoint α hαc s)
+  let K := kostantToralPointsSubgroup e h ρ M hM hnil b wt A
+  let T := (kostantTorusMatrix M b wt :
+    (κ → Aˣ) →* Matrix.GeneralLinearGroup (Fin n) A).range
+  have hTK : T ≤ K := by
+    rintro _ ⟨s, rfl⟩
+    exact kostantTorusMatrix_mem_toralPoints e h ρ M hM hnil b wt A s
+  have hcarrier :
+      (kostantToralWeightTorusPoints e h ρ M hM hnil b wt A).range =
+        T.subgroupOf K := by
+    ext x
+    simp only [MonoidHom.mem_range, Subgroup.mem_subgroupOf]
+    constructor
+    · rintro ⟨s, rfl⟩
+      refine ⟨s, ?_⟩
+      exact (coe_kostantToralWeightTorusPoints e h ρ M hM hnil b wt A s).symm
+    · rintro ⟨s, hs⟩
+      refine ⟨s, Subtype.ext ?_⟩
+      exact (coe_kostantToralWeightTorusPoints e h ρ M hM hnil b wt A s).trans hs
+  rw [hcarrier, ← Subgroup.subgroupOf_normalizer_eq hTK]
+  change (kostantToralWeylPoint e h ρ M hM hnil b wt i j A :
+    Matrix.GeneralLinearGroup (Fin n) A) ∈ Subgroup.normalizer T
+  rw [coe_kostantToralWeylPoint]
+  let f := Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
+  let T' := (kostantTorusPoints M b wt A).range
+  have hTmap : T'.map f = T := by
+    ext x
+    simp only [Subgroup.mem_map]
+    constructor
+    · rintro ⟨_, ⟨s, rfl⟩, rfl⟩
+      refine ⟨s, ?_⟩
+      exact (basisMatrix_kostantTorusPoints M b wt s).symm
+    · rintro ⟨s, rfl⟩
+      exact ⟨kostantTorusPoints M b wt A s, ⟨s, rfl⟩,
+        basisMatrix_kostantTorusPoints M b wt s⟩
+  rw [← hTmap]
+  apply Subgroup.le_normalizer_map f
+  exact Subgroup.mem_map_of_mem f <|
+    Subgroup.mem_normalizer_iff_map_conj_eq.mpr <|
+      map_kostantTorusPoints_range_conj_kostantWeylGL
+        e h ρ M hM (hnil i) (hnil j) hT hα hαneg b wt hwt
 
 end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Points
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Weyl.Torus
+
+/-!
+# Weyl representatives in the Kostant toral closure
+
+The Weyl element attached to an `sl₂` root pair is the product
+
+```text
+nᵢ = xᵢ(1) x₋ᵢ(-1) xᵢ(1).
+```
+
+Each factor is a point of the Kostant toral closure, so this product gives a canonical point of
+the assembled Chevalley carrier over every commutative ring. This file packages that point in the
+carrier, identifies its matrix with the integral Weyl automorphism of the admissible lattice, and
+proves that it normalizes the represented split torus. Its conjugation action is the reflection
+attached to the root and coroot of the `sl₂` pair.
+
+These representatives supply the point-level Weyl group data used to transport simple-root
+subgroups to arbitrary roots and to compare the normalizer of the represented torus with the Weyl
+group of the root datum.
+
+## Main declarations
+
+* `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint`: the Weyl representative as a point
+  of the toral closure.
+* `TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralWeylPoint`: its matrix is the integral Weyl
+  automorphism in the chosen basis.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_conj_rootSubgroup`: conjugation
+  exchanges the two root subgroups in the `sl₂` pair.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_conj_weightTorus`: its conjugation
+  action on the represented split torus.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_mem_normalizer_weightTorus`: the Weyl
+  representative belongs to the torus normalizer inside the carrier.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §§6.4 and 7.2.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27.
+* R. Steinberg, *Lectures on Chevalley Groups*, §3.
+-/
+
+public section
+
+open TensorProduct
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+universe u v w
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+attribute [local instance high] Algebra.toModule
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {I : Type w} {κ : Type} [Fintype κ]
+variable {V : Type} [AddCommGroup V] [Module ℚ V]
+
+variable (e : I → L) (h : κ → L)
+variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+variable (M : AddSubgroup V)
+variable (hM : ∀ u ∈ kostantForm e h, ∀ m ∈ M, ρ u m ∈ M)
+variable (hnil : ∀ i, IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+variable {n : ℕ} (b : Module.Basis (Fin n) ℤ M)
+variable (wt : Fin n → κ → ℤ)
+
+/-! ## The Weyl representative in the carrier -/
+
+/-- The Weyl representative `xᵢ(1) xⱼ(-1) xᵢ(1)` as a point of the Kostant toral closure.
+
+The intended indices `i` and `j` are opposite roots in an `sl₂` pair. The definition itself only
+uses their represented root subgroups; the `sl₂` relations enter when describing conjugation. -/
+noncomputable def kostantToralWeylPoint (i j : I) (A : Type v) [CommRing A] :
+    kostantToralPointsSubgroup e h ρ M hM hnil b wt A :=
+  kostantToralRootSubgroupPoints e h ρ M hM hnil b wt i A
+      (Multiplicative.ofAdd (1 : A)) *
+    kostantToralRootSubgroupPoints e h ρ M hM hnil b wt j A
+      (Multiplicative.ofAdd (-1 : A)) *
+    kostantToralRootSubgroupPoints e h ρ M hM hnil b wt i A
+      (Multiplicative.ofAdd (1 : A))
+
+/-- In the chosen basis, the carrier's Weyl representative is the matrix of the integral Weyl
+automorphism of the admissible lattice. -/
+@[simp]
+theorem coe_kostantToralWeylPoint (i j : I) (A : Type v) [CommRing A] :
+    (kostantToralWeylPoint e h ρ M hM hnil b wt i j A :
+        Matrix.GeneralLinearGroup (Fin n) A) =
+      Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMulEquiv
+        (kostantWeylGL e h ρ M hM (hnil i) (hnil j) A) := by
+  rw [kostantToralWeylPoint]
+  simp only [Subgroup.coe_mul, coe_kostantToralRootSubgroupPoints]
+  rw [← basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A i
+      (Multiplicative.ofAdd 1),
+    ← basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A j
+      (Multiplicative.ofAdd (-1)),
+    ← map_mul, ← map_mul]
+  congr 1
+  apply Units.ext
+  apply LinearMap.ext
+  intro z
+  rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
+    kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
+    kostantRootSubgroupParam_val_apply, toAdd_ofAdd, toAdd_ofAdd, kostantWeylGL_val]
+  exact LinearMap.congr_fun
+    (kostantWeylPoints_toLinearMap_eq e h ρ M hM (hnil i) (hnil j) (A := A)).symm z
+
+/-! ## Normalization of the represented torus -/
+
+variable {i j : I} {c : κ} {α : κ → ℤ}
+variable (hT : IsSl2Triple (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)))
+  (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)))
+  (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+variable (hα : ∀ q, ⁅h q, e i⁆ = (α q : ℚ) • e i)
+variable (hαneg : ∀ q, ⁅h q, e j⁆ = -((α q : ℚ) • e j))
+
+include hT in
+/-- Conjugation by the carrier's Weyl representative exchanges the two root subgroups of the
+`sl₂` pair, negating the parameter: `nᵢ xᵢ(u) nᵢ⁻¹ = xⱼ(-u)`. -/
+theorem kostantToralWeylPoint_conj_rootSubgroup (A : Type v) [CommRing A] (u : A) :
+    kostantToralWeylPoint e h ρ M hM hnil b wt i j A *
+        kostantToralRootSubgroupPoints e h ρ M hM hnil b wt i A
+          (Multiplicative.ofAdd u) *
+        (kostantToralWeylPoint e h ρ M hM hnil b wt i j A)⁻¹ =
+      kostantToralRootSubgroupPoints e h ρ M hM hnil b wt j A
+        (Multiplicative.ofAdd (-u)) := by
+  apply Subtype.ext
+  rw [Subgroup.coe_mul, Subgroup.coe_mul, Subgroup.coe_inv,
+    coe_kostantToralWeylPoint, coe_kostantToralRootSubgroupPoints,
+    coe_kostantToralRootSubgroupPoints,
+    ← basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A i
+      (Multiplicative.ofAdd u),
+    ← basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A j
+      (Multiplicative.ofAdd (-u))]
+  have hGL :
+      kostantWeylGL e h ρ M hM (hnil i) (hnil j) A *
+          kostantRootSubgroupParam e h ρ M hM i (hnil i) (CommAlgCat.of ℤ A)
+            (Multiplicative.ofAdd u) *
+          (kostantWeylGL e h ρ M hM (hnil i) (hnil j) A)⁻¹ =
+        kostantRootSubgroupParam e h ρ M hM j (hnil j) (CommAlgCat.of ℤ A)
+          (Multiplicative.ofAdd (-u)) := by
+    apply Units.ext
+    apply LinearMap.ext
+    intro z
+    rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
+      kostantWeylGL_val, kostantWeylGL_inv_val,
+      kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
+      toAdd_ofAdd, toAdd_ofAdd]
+    exact LinearMap.congr_fun
+      (kostantWeylPoints_conj_baseChangeExp e h ρ M hM (hnil i) (hnil j) hT u) z
+  simpa only [map_mul, map_inv, MulEquiv.toMonoidHom_eq_coe] using
+    congrArg (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom) hGL
+
+include hT hα hαneg in
+/-- Conjugating a represented weight-torus point by the carrier's Weyl representative reflects
+the torus point by the root `α` and its coroot coordinate `c`. -/
+theorem kostantToralWeylPoint_conj_weightTorus
+    [DecidableEq κ]
+    (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V))
+    (A : Type v) [CommRing A] (s : κ → Aˣ) :
+    kostantToralWeylPoint e h ρ M hM hnil b wt i j A *
+        kostantToralWeightTorusPoints e h ρ M hM hnil b wt A s *
+        (kostantToralWeylPoint e h ρ M hM hnil b wt i j A)⁻¹ =
+      kostantToralWeightTorusPoints e h ρ M hM hnil b wt A
+        (weylReflectTorusPoint α c s) := by
+  apply Subtype.ext
+  rw [Subgroup.coe_mul, Subgroup.coe_mul, Subgroup.coe_inv,
+    coe_kostantToralWeylPoint, coe_kostantToralWeightTorusPoints,
+    coe_kostantToralWeightTorusPoints]
+  have hmatrix := congrArg
+    (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom)
+    (kostantWeylGL_conj_kostantTorusPoints e h ρ M hM (hnil i) (hnil j)
+      hT hα hαneg b wt hwt s)
+  simpa only [map_mul, map_inv, MulEquiv.toMonoidHom_eq_coe,
+    basisMatrix_kostantTorusPoints] using hmatrix
+
+include hT hα hαneg in
+/-- The Weyl representative is in the normalizer of the represented weight torus inside the
+Kostant toral closure. -/
+theorem kostantToralWeylPoint_mem_normalizer_weightTorus
+    (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V))
+    (A : Type v) [CommRing A] :
+    kostantToralWeylPoint e h ρ M hM hnil b wt i j A ∈
+      Subgroup.normalizer
+        (kostantToralWeightTorusPoints e h ρ M hM hnil b wt A).range := by
+  classical
+  apply Subgroup.mem_normalizer_iff_map_conj_eq.mpr
+  have hαc : α c = 2 := rootWeight_apply_coroot_eq_two e h ρ hT (hα c)
+  have hconj := kostantToralWeylPoint_conj_weightTorus
+    e h ρ M hM hnil b wt hT hα hαneg hwt A
+  have hconj' : ∀ s : κ → Aˣ,
+      (MulAut.conj (kostantToralWeylPoint e h ρ M hM hnil b wt i j A))
+          (kostantToralWeightTorusPoints e h ρ M hM hnil b wt A s) =
+        kostantToralWeightTorusPoints e h ρ M hM hnil b wt A
+          (weylReflectTorusPoint α c s) :=
+    hconj
+  ext y
+  simp only [Subgroup.mem_map, MonoidHom.mem_range]
+  constructor
+  · rintro ⟨z, ⟨s, rfl⟩, rfl⟩
+    exact ⟨weylReflectTorusPoint α c s, (hconj' s).symm⟩
+  · rintro ⟨s, rfl⟩
+    refine ⟨kostantToralWeightTorusPoints e h ρ M hM hnil b wt A
+        (weylReflectTorusPoint α c s),
+      ⟨weylReflectTorusPoint α c s, rfl⟩, ?_⟩
+    exact (hconj' (weylReflectTorusPoint α c s)).trans <|
+      congrArg (kostantToralWeightTorusPoints e h ρ M hM hnil b wt A)
+        (weylReflectTorusPoint_weylReflectTorusPoint α hαc s)
+
+end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
@@ -71,13 +71,41 @@ variable {n : ℕ} (b : Module.Basis (Fin n) ℤ M)
 variable (wt : Fin n → κ → ℤ)
 
 omit [Module ℚ V] in
-private theorem basisMatrix_eq_of_val_apply_eq {A : Type v} [CommRing A]
+private theorem basisMatrix_eq_of_val_eq {A : Type v} [CommRing A]
     {x y : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)}
-    (hxy : ∀ z, x.val z = y.val z) :
+    (hxy : x.val = y.val) :
     Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom x =
       Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom y :=
   congrArg (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom)
-    (Units.ext (LinearMap.ext hxy))
+    (Units.ext hxy)
+
+omit [Fintype κ] in
+private theorem coe_kostantRootSubgroupParam {A : Type v} [CommRing A] (i : I)
+    (t : Multiplicative A) :
+    (kostantRootSubgroupParam e h ρ M hM i (hnil i) (CommAlgCat.of ℤ A) t :
+        Module.End A (A ⊗[ℤ] M)) =
+      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
+        (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
+        (Multiplicative.toAdd t) :=
+  LinearMap.ext fun z =>
+    kostantRootSubgroupParam_val_apply e h ρ M hM i (hnil i) (CommAlgCat.of ℤ A) t z
+
+omit [Fintype κ] in
+private theorem basisMatrix_kostantWeylProduct (i j : I) (A : Type v) [CommRing A] :
+    Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
+        (kostantRootSubgroupParam e h ρ M hM i (hnil i) (CommAlgCat.of ℤ A)
+            (Multiplicative.ofAdd 1) *
+          kostantRootSubgroupParam e h ρ M hM j (hnil j) (CommAlgCat.of ℤ A)
+            (Multiplicative.ofAdd (-1)) *
+          kostantRootSubgroupParam e h ρ M hM i (hnil i) (CommAlgCat.of ℤ A)
+            (Multiplicative.ofAdd 1)) =
+      Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
+        (kostantWeylGL e h ρ M hM (hnil i) (hnil j) A) := by
+  apply basisMatrix_eq_of_val_eq (A := A) M b
+  rw [Units.val_mul, Units.val_mul, coe_kostantRootSubgroupParam (i := i),
+    coe_kostantRootSubgroupParam (i := j), toAdd_ofAdd, kostantWeylGL_val]
+  exact (kostantWeylPoints_toLinearMap_eq
+    e h ρ M hM (hnil i) (hnil j) (A := A)).symm
 
 /-! ## The Weyl representative in the carrier -/
 
@@ -102,19 +130,12 @@ theorem coe_kostantToralWeylPoint (i j : I) (A : Type v) [CommRing A] :
         Matrix.GeneralLinearGroup (Fin n) A) =
       Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMulEquiv
         (kostantWeylGL e h ρ M hM (hnil i) (hnil j) A) := by
-  rw [kostantToralWeylPoint]
-  simp only [Subgroup.coe_mul, coe_kostantToralRootSubgroupPoints]
-  rw [← basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A i
-      (Multiplicative.ofAdd 1),
-    ← basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A j
-      (Multiplicative.ofAdd (-1)),
-    ← map_mul, ← map_mul]
-  exact basisMatrix_eq_of_val_apply_eq (A := A) M b fun z => by
-    rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
-      kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
-      kostantRootSubgroupParam_val_apply, toAdd_ofAdd, toAdd_ofAdd, kostantWeylGL_val]
-    exact LinearMap.congr_fun
-      (kostantWeylPoints_toLinearMap_eq e h ρ M hM (hnil i) (hnil j) (A := A)).symm z
+  simpa only [kostantToralWeylPoint, Subgroup.coe_mul,
+    coe_kostantToralRootSubgroupPoints, map_mul,
+    basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A i (Multiplicative.ofAdd 1),
+    basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A j (Multiplicative.ofAdd (-1)),
+    MulEquiv.toMonoidHom_eq_coe] using
+    basisMatrix_kostantWeylProduct e h ρ M hM hnil b i j A
 
 /-! ## Normalization of the represented torus -/
 
@@ -124,6 +145,24 @@ variable (hT : IsSl2Triple (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)))
   (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
 variable (hα : ∀ q, ⁅h q, e i⁆ = (α q : ℚ) • e i)
 variable (hαneg : ∀ q, ⁅h q, e j⁆ = -((α q : ℚ) • e j))
+
+omit [Fintype κ] in
+include hT in
+private theorem basisMatrix_kostantWeylConjRoot (A : Type v) [CommRing A] (u : A) :
+    Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
+        (kostantWeylGL e h ρ M hM (hnil i) (hnil j) A *
+          kostantRootSubgroupParam e h ρ M hM i (hnil i) (CommAlgCat.of ℤ A)
+            (Multiplicative.ofAdd u) *
+          (kostantWeylGL e h ρ M hM (hnil i) (hnil j) A)⁻¹) =
+      Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
+        (kostantRootSubgroupParam e h ρ M hM j (hnil j) (CommAlgCat.of ℤ A)
+          (Multiplicative.ofAdd (-u))) := by
+  apply basisMatrix_eq_of_val_eq (A := A) M b
+  rw [Units.val_mul, Units.val_mul, kostantWeylGL_val, kostantWeylGL_inv_val,
+    coe_kostantRootSubgroupParam (i := i), coe_kostantRootSubgroupParam (i := j),
+    toAdd_ofAdd]
+  exact kostantWeylPoints_conj_baseChangeExp
+    e h ρ M hM (hnil i) (hnil j) hT u
 
 include hT in
 /-- Conjugation by the carrier's Weyl representative exchanges the two root subgroups of the
@@ -136,27 +175,12 @@ theorem kostantToralWeylPoint_conj_rootSubgroupPoints (A : Type v) [CommRing A] 
       kostantToralRootSubgroupPoints e h ρ M hM hnil b wt j A
         (Multiplicative.ofAdd (-u)) := by
   apply Subtype.ext
-  rw [Subgroup.coe_mul, Subgroup.coe_mul, Subgroup.coe_inv,
-    coe_kostantToralWeylPoint, coe_kostantToralRootSubgroupPoints,
-    coe_kostantToralRootSubgroupPoints,
-    ← basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A i
-      (Multiplicative.ofAdd u),
-    ← basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A j
-      (Multiplicative.ofAdd (-u))]
-  simpa only [map_mul, map_inv, MulEquiv.toMonoidHom_eq_coe] using
-    basisMatrix_eq_of_val_apply_eq (A := A) M b
-      (x := kostantWeylGL e h ρ M hM (hnil i) (hnil j) A *
-        kostantRootSubgroupParam e h ρ M hM i (hnil i) (CommAlgCat.of ℤ A)
-          (Multiplicative.ofAdd u) *
-        (kostantWeylGL e h ρ M hM (hnil i) (hnil j) A)⁻¹)
-      (y := kostantRootSubgroupParam e h ρ M hM j (hnil j) (CommAlgCat.of ℤ A)
-        (Multiplicative.ofAdd (-u))) fun z => by
-      rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
-        kostantWeylGL_val, kostantWeylGL_inv_val,
-        kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
-        toAdd_ofAdd, toAdd_ofAdd]
-      exact LinearMap.congr_fun
-        (kostantWeylPoints_conj_baseChangeExp e h ρ M hM (hnil i) (hnil j) hT u) z
+  simpa only [Subgroup.coe_mul, Subgroup.coe_inv, coe_kostantToralWeylPoint,
+    coe_kostantToralRootSubgroupPoints, map_mul, map_inv,
+    basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A i (Multiplicative.ofAdd u),
+    basisMatrix_kostantRootSubgroupParam e h ρ M hM hnil b A j (Multiplicative.ofAdd (-u)),
+    MulEquiv.toMonoidHom_eq_coe] using
+    basisMatrix_kostantWeylConjRoot e h ρ M hM hnil b hT A u
 
 include hT hα hαneg in
 /-- Conjugating a represented weight-torus point by the carrier's Weyl representative reflects
@@ -210,8 +234,7 @@ theorem kostantToralWeylPoint_mem_normalizer_weightTorusPoints
       refine ⟨s, Subtype.ext ?_⟩
       exact (coe_kostantToralWeightTorusPoints e h ρ M hM hnil b wt A s).trans hs
   rw [hcarrier, ← Subgroup.subgroupOf_normalizer_eq hTK]
-  change (kostantToralWeylPoint e h ρ M hM hnil b wt i j A :
-    Matrix.GeneralLinearGroup (Fin n) A) ∈ Subgroup.normalizer T
+  rw [Subgroup.mem_subgroupOf]
   rw [coe_kostantToralWeylPoint]
   let f := Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
   let T' := (kostantTorusPoints M b wt A).range

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
@@ -34,7 +34,7 @@ group of the root datum.
 * `TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralWeylPoint`: its matrix is the integral Weyl
   automorphism in the chosen basis.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_conj_rootSubgroupPoints`: conjugation
-  exchanges the two root subgroups in the `sl₂` pair.
+  sends the `i` root subgroup to the `j` root subgroup, negating the parameter.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_conj_weightTorusPoints`: its conjugation
   action on the represented split torus.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantToralWeylPoint_mem_normalizer_weightTorusPoints`: the
@@ -70,15 +70,6 @@ variable (hnil : ∀ i, IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι �
 variable {n : ℕ} (b : Module.Basis (Fin n) ℤ M)
 variable (wt : Fin n → κ → ℤ)
 
-omit [Module ℚ V] in
-private theorem basisMatrix_eq_of_val_eq {A : Type v} [CommRing A]
-    {x y : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)}
-    (hxy : x.val = y.val) :
-    Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom x =
-      Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom y :=
-  congrArg (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom)
-    (Units.ext hxy)
-
 omit [Fintype κ] in
 private theorem coe_kostantRootSubgroupParam {A : Type v} [CommRing A] (i : I)
     (t : Multiplicative A) :
@@ -101,7 +92,8 @@ private theorem basisMatrix_kostantWeylProduct (i j : I) (A : Type v) [CommRing 
             (Multiplicative.ofAdd 1)) =
       Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
         (kostantWeylGL e h ρ M hM (hnil i) (hnil j) A) := by
-  apply basisMatrix_eq_of_val_eq (A := A) M b
+  refine congrArg (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom)
+    (Units.ext ?_)
   rw [Units.val_mul, Units.val_mul, coe_kostantRootSubgroupParam (i := i),
     coe_kostantRootSubgroupParam (i := j), toAdd_ofAdd, kostantWeylGL_val]
   exact (kostantWeylPoints_toLinearMap_eq
@@ -157,7 +149,8 @@ private theorem basisMatrix_kostantWeylConjRoot (A : Type v) [CommRing A] (u : A
       Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
         (kostantRootSubgroupParam e h ρ M hM j (hnil j) (CommAlgCat.of ℤ A)
           (Multiplicative.ofAdd (-u))) := by
-  apply basisMatrix_eq_of_val_eq (A := A) M b
+  refine congrArg (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom)
+    (Units.ext ?_)
   rw [Units.val_mul, Units.val_mul, kostantWeylGL_val, kostantWeylGL_inv_val,
     coe_kostantRootSubgroupParam (i := i), coe_kostantRootSubgroupParam (i := j),
     toAdd_ofAdd]
@@ -165,8 +158,8 @@ private theorem basisMatrix_kostantWeylConjRoot (A : Type v) [CommRing A] (u : A
     e h ρ M hM (hnil i) (hnil j) hT u
 
 include hT in
-/-- Conjugation by the carrier's Weyl representative exchanges the two root subgroups of the
-`sl₂` pair, negating the parameter: `nᵢ xᵢ(u) nᵢ⁻¹ = xⱼ(-u)`. -/
+/-- Conjugation by the carrier's Weyl representative sends the `i` root subgroup to the `j` root
+subgroup, negating the parameter: `nᵢ xᵢ(u) nᵢ⁻¹ = xⱼ(-u)`. -/
 theorem kostantToralWeylPoint_conj_rootSubgroupPoints (A : Type v) [CommRing A] (u : A) :
     kostantToralWeylPoint e h ρ M hM hnil b wt i j A *
         kostantToralRootSubgroupPoints e h ρ M hM hnil b wt i A

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean
@@ -231,15 +231,11 @@ theorem kostantToralWeylPoint_mem_normalizer_weightTorusPoints
   let f := Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom
   let T' := (kostantTorusPoints M b wt A).range
   have hTmap : T'.map f = T := by
-    ext x
-    simp only [Subgroup.mem_map]
-    constructor
-    · rintro ⟨_, ⟨s, rfl⟩, rfl⟩
-      refine ⟨s, ?_⟩
-      exact (basisMatrix_kostantTorusPoints M b wt s).symm
-    · rintro ⟨s, rfl⟩
-      exact ⟨kostantTorusPoints M b wt A s, ⟨s, rfl⟩,
-        basisMatrix_kostantTorusPoints M b wt s⟩
+    rw [MonoidHom.map_range]
+    apply congrArg (fun g : (κ → Aˣ) →* Matrix.GeneralLinearGroup (Fin n) A => g.range)
+    apply MonoidHom.ext
+    intro s
+    exact basisMatrix_kostantTorusPoints M b wt s
   rw [← hTmap]
   apply Subgroup.le_normalizer_map f
   exact Subgroup.mem_map_of_mem f <|


### PR DESCRIPTION
This PR packages each Kostant root-pair Weyl representative `xᵢ(1) xⱼ(-1) xᵢ(1)` as an actual point of the toral Chevalley carrier over every commutative ring, identifies its matrix with the integral Weyl automorphism of the admissible lattice, and proves its conjugation laws on the paired root subgroup and the represented weight torus. It advances the exact `ReductiveGroups/README.md` Layer 9 targets “Pinnings” and “Root subgroup maps” within the milestone “pinned Chevalley–Demazure group schemes over `ℤ`.” After this PR, that milestone still needs to use these representatives to construct all nonsimple root subgroups and identify the carrier torus normalizer quotient with the Weyl group, before completing maximal-torus/Borel packaging and the pinned-group isomorphism theorem.

The construction is honest at carrier level: `kostantToralWeylPoint` is literally the product of the three already represented root points in `kostantToralPointsSubgroup`, with no existence choice and no assumption that the carrier is already reductive. An `sl₂`-triple hypothesis then gives `kostantToralWeylPoint_conj_rootSubgroup`, while the root/coroot weight hypotheses give `kostantToralWeylPoint_conj_weightTorus` and membership in the normalizer of the torus image. All statements retain arbitrary commutative value rings, including characteristics two and three.

This is the most effective current step because the root-subgroup maps, toral carrier, integral Weyl automorphism, and its ambient torus-reflection theorem are all on `main`; what was missing was the bridge proving that the Weyl representative belongs to the assembled carrier itself. CFSGStatement milestone L0, “explicit pinned Chevalley–Demazure groups,” consumes the resulting full root-subgroup and Weyl-normalizer interface when identifying each explicit carrier with the simply connected pinned root datum.

The proof reuses `kostantWeylPoints_toLinearMap_eq`, `kostantWeylPoints_conj_baseChangeExp`, `kostantWeylGL_conj_kostantTorusPoints`, and the existing carrier root/torus point maps. No Mathlib infrastructure is vendored. The mathematical construction follows Carter, *Simple Groups of Lie Type*, §§6.4 and 7.2; Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26–27; and Steinberg, *Lectures on Chevalley Groups*, §3, as cited in the module documentation.

The change adds `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Weyl.lean` in 215 lines.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"kostant-toral-weyl-point"}-->

🤖 Prepared with Codex
