### PR TITLE
refactor(HeckeRing): name the vanishing step of the left Fubini count

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -293,13 +293,14 @@ private lemma multiplicity_mul_multiplicity_eq_sum_indicator [IsHeckeTriple Δ H
 
 open Classical in
 /-- **Only the double coset of the product contributes.** If `E` is not the `H₁`-`H₃` double
-coset of `w`, then no left-coset representative of `E` is congruent to `w` modulo `H₃`, so the
-indicator sum over those representatives vanishes. -/
-private lemma sum_ite_eq_zero_of_ne_mk [IsHeckeTriple Δ H₁ H₃] (g₃ d w : Δ)
-    (E : HeckeCoset Δ H₁ H₃) (hne : E ≠ HeckeCoset.mk H₁ H₃ w) :
+coset of `w`, then no left-coset representative of `E` is congruent to `w` modulo `H₃`. An
+indicator sum over those representatives therefore vanishes whatever else `P` asks of them. -/
+private lemma sum_ite_eq_zero_of_ne_mk (w : Δ) (E : HeckeCoset Δ H₁ H₃)
+    [Fintype (DecompQuotient H₁ H₃ (E.rep : G))]
+    (P : DecompQuotient H₁ H₃ (E.rep : G) → Prop) (hne : E ≠ HeckeCoset.mk H₁ H₃ w) :
     ∑ l : DecompQuotient H₁ H₃ (E.rep : G),
-        (if (((l.out : G) * E.rep)⁻¹ * d ∈ doubleCoset (g₃ : G) H₃ H₄) ∧
-            ((w : G) : G ⧸ H₃) = (((l.out : G) * E.rep : G) : G ⧸ H₃) then 1 else 0) = 0 := by
+        (if P l ∧ ((w : G) : G ⧸ H₃) = (((l.out : G) * E.rep : G) : G ⧸ H₃) then 1 else 0)
+      = 0 := by
   refine Finset.sum_eq_zero fun l _ ↦ ite_eq_right ?_
   rintro ⟨-, hmatch⟩
   have hwE : (w : G) ∈ doubleCoset ((E.rep : Δ) : G) H₁ H₃ :=
@@ -342,7 +343,7 @@ private lemma sum_image_mulMap_multiplicity_left [IsHeckeTriple Δ H₁ H₂]
   have hmk : ((wG : G) : G ⧸ H₃) = (((l₀.out : G) * (E₀.rep : G) : G) : G ⧸ H₃) :=
     (QuotientGroup.eq.mpr hl₀).symm
   rw [Finset.sum_eq_single_of_mem E₀ hE₀mem ?hEne]
-  case hEne => exact fun E _ hne ↦ sum_ite_eq_zero_of_ne_mk g₃ d ⟨wG, hwΔ⟩ E hne
+  case hEne => exact fun E _ hne ↦ sum_ite_eq_zero_of_ne_mk ⟨wG, hwΔ⟩ E _ hne
   rw [Finset.sum_eq_single_of_mem l₀ (Finset.mem_univ _) ?hlne]
   case hlne =>
     intro l _ hlne

--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -305,9 +305,7 @@ private lemma sum_ite_eq_zero_of_ne_mk (w : Δ) (E : HeckeCoset Δ H₁ H₃)
   rintro ⟨-, hmatch⟩
   have hwE : (w : G) ∈ doubleCoset ((E.rep : Δ) : G) H₁ H₃ :=
     mem_doubleCoset_of_quotient_eq l.out.2 hmatch
-  refine hne (HeckeCoset.toSet_injective ?_)
-  rw [HeckeCoset.toSet_eq_doubleCoset_rep, HeckeCoset.toSet_mk]
-  exact (doubleCoset_eq_of_mem hwE).symm
+  exact hne ((HeckeCoset.mk_rep E).symm.trans (HeckeCoset.mk_eq_mk_of_mem hwE).symm)
 
 open Classical in
 /-- The left-handed Fubini step: the left association also counts pairs of representatives

--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -292,6 +292,23 @@ private lemma multiplicity_mul_multiplicity_eq_sum_indicator [IsHeckeTriple Δ H
   · exact (Finset.sum_eq_zero fun p _ ↦ ite_eq_right fun hh ↦ hcond hh.1).symm
 
 open Classical in
+/-- **Only the double coset of the product contributes.** If `E` is not the `H₁`-`H₃` double
+coset of `w`, then no left-coset representative of `E` is congruent to `w` modulo `H₃`, so the
+indicator sum over those representatives vanishes. -/
+private lemma sum_ite_eq_zero_of_ne_mk [IsHeckeTriple Δ H₁ H₃] (g₃ d w : Δ)
+    (E : HeckeCoset Δ H₁ H₃) (hne : E ≠ HeckeCoset.mk H₁ H₃ w) :
+    ∑ l : DecompQuotient H₁ H₃ (E.rep : G),
+        (if (((l.out : G) * E.rep)⁻¹ * d ∈ doubleCoset (g₃ : G) H₃ H₄) ∧
+            ((w : G) : G ⧸ H₃) = (((l.out : G) * E.rep : G) : G ⧸ H₃) then 1 else 0) = 0 := by
+  refine Finset.sum_eq_zero fun l _ ↦ ite_eq_right ?_
+  rintro ⟨-, hmatch⟩
+  have hwE : (w : G) ∈ doubleCoset ((E.rep : Δ) : G) H₁ H₃ :=
+    mem_doubleCoset_of_quotient_eq l.out.2 hmatch
+  refine hne (HeckeCoset.toSet_injective ?_)
+  rw [HeckeCoset.toSet_eq_doubleCoset_rep, HeckeCoset.toSet_mk]
+  exact (doubleCoset_eq_of_mem hwE).symm
+
+open Classical in
 /-- The left-handed Fubini step: the left association also counts pairs of representatives
 whose product moves `d` into `H₃g₃H₄`, using the invariance of the multiplicity across the
 left cosets of a double coset. -/
@@ -325,15 +342,7 @@ private lemma sum_image_mulMap_multiplicity_left [IsHeckeTriple Δ H₁ H₂]
   have hmk : ((wG : G) : G ⧸ H₃) = (((l₀.out : G) * (E₀.rep : G) : G) : G ⧸ H₃) :=
     (QuotientGroup.eq.mpr hl₀).symm
   rw [Finset.sum_eq_single_of_mem E₀ hE₀mem ?hEne]
-  case hEne =>
-    intro E hE hne
-    refine Finset.sum_eq_zero fun l _ ↦ ite_eq_right ?_
-    rintro ⟨-, hmatch⟩
-    have hwE : wG ∈ doubleCoset ((E.rep : Δ) : G) H₁ H₃ :=
-      mem_doubleCoset_of_quotient_eq l.out.2 hmatch
-    refine hne (HeckeCoset.toSet_injective ?_)
-    rw [HeckeCoset.toSet_eq_doubleCoset_rep, hE₀def, HeckeCoset.toSet_mk]
-    exact (doubleCoset_eq_of_mem hwE).symm
+  case hEne => exact fun E _ hne ↦ sum_ite_eq_zero_of_ne_mk g₃ d ⟨wG, hwΔ⟩ E hne
   rw [Finset.sum_eq_single_of_mem l₀ (Finset.mem_univ _) ?hlne]
   case hlne =>
     intro l _ hlne


### PR DESCRIPTION
Roadmap: ModularForms

`sum_image_mulMap_multiplicity_left` was 58 lines, over the repo's 50-line cap.

Most of the excess was a single side goal. The proof rewrites a sum over all
`H₁`-`H₃` double cosets down to the one term at `E₀`, and `Finset.sum_eq_single_of_mem`
leaves behind the obligation that every *other* `E` contributes nothing. Discharging
that in place took nine lines of a `case` block.

But what those nine lines prove is not about the Fubini rearrangement they sit
inside, and not about the pair `p` the enclosing proof has fixed. They say
something about cosets on their own:

> if `E` is not the `H₁`-`H₃` double coset of `w`, then no left-coset
> representative of `E` is congruent to `w` modulo `H₃`, so the indicator sum
> over those representatives vanishes.

That reads better with a name than as an anonymous case, so it is now
`sum_ite_eq_zero_of_ne_mk` and the side goal is discharged by applying it:

```
  case hEne => exact fun E _ hne ↦ sum_ite_eq_zero_of_ne_mk ⟨wG, hwΔ⟩ E _ hne
```

Extracting it also drops the `hE₀def` rewrite the inline version needed to see
past the local abbreviation — the standalone statement quantifies over `w`
directly.

Review then pointed out that the extracted statement had inherited more than it
uses: the indicator's first conjunct is discarded by the very first `rintro`, so
`g₃`, `d` and `H₄` did no work, and `IsHeckeTriple Δ H₁ H₃` was present only to
supply the `Fintype` the sum ranges over. It now takes an arbitrary predicate `P`
on representatives and that `Fintype` directly — same proof, strictly stronger
statement, with the caller instantiating `P` by unification.

58 lines becomes 50, and `Associativity.lean` now has no proof over the cap. No
statement changes anywhere, and the new lemma is `private`, as its only caller
already was.

Verified with a green build of the module and everything importing it, plus the
repo's 13-linter `#lint` set over its cone (0 errors, 136 declarations).

Roadmap attribution only — this is a refactor and carries no target marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
