### PR TITLE
feat: construct the reduced center

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
@@ -31,6 +31,7 @@ ideal, so the represented closed subgroup is canonical.
 ## Main declarations
 
 * `TauCeti.CommHopfAlgCat.centerDefiningIdeal`: the Hopf ideal cutting out the center.
+* `TauCeti.CommHopfAlgCat.centerCoordinateRing`: the coordinate Hopf algebra of the center.
 * `TauCeti.CommHopfAlgCat.centerGroupScheme`: the center as a closed affine group scheme.
 * `TauCeti.CommHopfAlgCat.mem_centerPointsSubgroup_iff`: its points are exactly the universally
   central points.
@@ -314,6 +315,11 @@ uses coefficients in a chosen vector-space basis internally; `centerDefiningIdea
 characterizes it without that choice. -/
 noncomputable def centerDefiningIdeal (H : _root_.CommHopfAlgCat.{v} k) : HopfIdeal k H :=
   centerCoefficientHopfIdeal (k := k) (H := H)
+
+/-- The coordinate Hopf algebra of the center of an affine group. -/
+noncomputable abbrev centerCoordinateRing (H : _root_.CommHopfAlgCat.{v} k) :
+    _root_.CommHopfAlgCat.{v} k :=
+  quotient H (centerDefiningIdeal H)
 
 /-- The underlying ideal of the center is the coefficient ideal of the cocommutativity defect. -/
 private theorem mem_centerDefiningIdeal_iff (H : _root_.CommHopfAlgCat.{v} k) {x : H} :

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
@@ -8,7 +8,6 @@ module
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
-import TauCeti.Algebra.HopfAlgebra.Kernel
 
 /-!
 # The center of an affine group scheme

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
@@ -32,7 +32,7 @@ ideal, so the represented closed subgroup is canonical.
 ## Main declarations
 
 * `TauCeti.CommHopfAlgCat.centerDefiningIdeal`: the Hopf ideal cutting out the center.
-* `TauCeti.CommHopfAlgCat.centerCoordinateRing`: the coordinate Hopf algebra of the center.
+* `TauCeti.CommHopfAlgCat.centerCoordinateHopfAlgebra`: the coordinate Hopf algebra of the center.
 * `TauCeti.CommHopfAlgCat.centerGroupScheme`: the center as a closed affine group scheme.
 * `TauCeti.CommHopfAlgCat.mem_centerPointsSubgroup_iff`: its points are exactly the universally
   central points.
@@ -307,7 +307,7 @@ noncomputable def centerDefiningIdeal (H : _root_.CommHopfAlgCat.{v} k) : HopfId
   centerCoefficientHopfIdeal (k := k) (H := H)
 
 /-- The coordinate Hopf algebra of the center of an affine group. -/
-noncomputable abbrev centerCoordinateRing (H : _root_.CommHopfAlgCat.{v} k) :
+noncomputable abbrev centerCoordinateHopfAlgebra (H : _root_.CommHopfAlgCat.{v} k) :
     _root_.CommHopfAlgCat.{v} k :=
   quotient H (centerDefiningIdeal H)
 

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
@@ -8,6 +8,7 @@ module
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
+import TauCeti.Algebra.HopfAlgebra.Kernel
 
 /-!
 # The center of an affine group scheme
@@ -279,21 +280,10 @@ private theorem centerCoefficientIdeal_comul_mem {x : H}
   have hker : RingHom.ker (Algebra.TensorProduct.map q q).toRingHom =
       HopfIdeal.leftTensorIdeal (R := k) (H := H) I ⊔
         HopfIdeal.rightTensorIdeal (R := k) (H := H) I := by
-    have hqker_eq : RingHom.ker (q : H →+* Q) = I := Ideal.Quotient.mkₐ_ker k I
-    -- `map_ker` uses algebra-hom coercions while the tensor ideals store explicit ring homs.
-    change RingHom.ker (Algebra.TensorProduct.map q q) =
-      Ideal.map Algebra.TensorProduct.includeLeft.toRingHom I ⊔
-        Ideal.map Algebra.TensorProduct.includeRight.toRingHom I
-    calc
-      RingHom.ker (Algebra.TensorProduct.map q q) =
-          Ideal.map Algebra.TensorProduct.includeLeft (RingHom.ker (q : H →+* Q)) ⊔
-            Ideal.map Algebra.TensorProduct.includeRight (RingHom.ker (q : H →+* Q)) :=
-        Algebra.TensorProduct.map_ker (f := q) (g := q)
-          (Ideal.Quotient.mkₐ_surjective k I) (Ideal.Quotient.mkₐ_surjective k I)
-      _ = Ideal.map Algebra.TensorProduct.includeLeft.toRingHom I ⊔
-          Ideal.map Algebra.TensorProduct.includeRight.toRingHom I := by
-        rw [hqker_eq]
-        rfl
+    have hqker : RingHom.ker q = I := Ideal.Quotient.mkₐ_ker k I
+    simpa only [AlgHom.ker_coe, AlgHom.toRingHom_eq_coe, hqker] using
+      AlgHom.tensor_map_ker_eq_left_sup_right q q
+        (Ideal.Quotient.mkₐ_surjective k I) (Ideal.Quotient.mkₐ_surjective k I)
   rw [← hker, RingHom.mem_ker]
   exact hmapzero
 

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
@@ -281,7 +281,7 @@ private theorem centerCoefficientIdeal_comul_mem {x : H}
         HopfIdeal.rightTensorIdeal (R := k) (H := H) I := by
     have hqker : RingHom.ker q = I := Ideal.Quotient.mkₐ_ker k I
     simpa only [AlgHom.ker_coe, AlgHom.toRingHom_eq_coe, hqker] using
-      AlgHom.tensor_map_ker_eq_left_sup_right q q
+      HopfIdeal.ker_tensorProduct_map_eq_leftTensorIdeal_sup_rightTensorIdeal q q
         (Ideal.Quotient.mkₐ_surjective k I) (Ideal.Quotient.mkₐ_surjective k I)
   rw [← hker, RingHom.mem_ker]
   exact hmapzero

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
@@ -113,18 +113,11 @@ theorem isReduced_reducedCenterCoordinateRing :
 /-- The ambient ideal defining the reduced center is the radical of the center ideal. -/
 theorem reducedCenterDefiningIdeal_toIdeal :
     (reducedCenterDefiningIdeal H).toIdeal = (centerDefiningIdeal H).toIdeal.radical := by
-  ext x
-  rw [HopfIdeal.mem_toIdeal, reducedCenterDefiningIdeal,
-    HopfIdeal.mem_comapOfSurjective, HopfIdeal.mem_reduction, Ideal.mem_radical_iff]
-  constructor
-  · rintro ⟨n, hn⟩
-    refine ⟨n, ?_⟩
-    rw [← mkQuotient_eq_zero_iff H (centerDefiningIdeal H), map_pow]
-    exact hn
-  · rintro ⟨n, hn⟩
-    refine ⟨n, ?_⟩
-    rw [← map_pow, mkQuotient_eq_zero_iff H (centerDefiningIdeal H)]
-    exact hn
+  rw [reducedCenterDefiningIdeal, HopfIdeal.comapOfSurjective_toIdeal,
+    HopfIdeal.reduction_toIdeal, nilradical, Ideal.comap_radical]
+  congr 1
+  rw [Ideal.zero_eq_bot, ← RingHom.ker_eq_comap_bot]
+  exact mkQuotient_ker H (centerDefiningIdeal H)
 
 /-- The quotient by the ambient reduced-center ideal is canonically the iterated quotient formed
 by taking the center and then killing its nilradical. -/
@@ -133,6 +126,30 @@ noncomputable def quotientReducedCenterIso :
   quotientIsoOfSurjective (mkQuotient H (centerDefiningIdeal H))
     (mkQuotient_surjective H (centerDefiningIdeal H))
       (HopfIdeal.reduction k (centerCoordinateRing H))
+
+/-- The forward reduced-center quotient isomorphism maps an ambient quotient class to its class
+in the iterated quotient. -/
+@[simp]
+theorem quotientReducedCenterIso_hom_mk (x : H) :
+    (quotientReducedCenterIso H).hom.hom
+        (Ideal.Quotient.mk (reducedCenterDefiningIdeal H).toIdeal x) =
+      Ideal.Quotient.mkₐ k (HopfIdeal.reduction k (centerCoordinateRing H)).toIdeal
+        ((mkQuotient H (centerDefiningIdeal H)).hom x) := by
+  exact quotientIsoOfSurjective_hom_mk (mkQuotient H (centerDefiningIdeal H))
+    (mkQuotient_surjective H (centerDefiningIdeal H))
+      (HopfIdeal.reduction k (centerCoordinateRing H)) x
+
+/-- The forward reduced-center quotient isomorphism commutes with the ambient and iterated
+quotient morphisms. -/
+@[simp]
+theorem mkQuotient_comp_quotientReducedCenterIso_hom :
+    mkQuotient H (reducedCenterDefiningIdeal H) ≫ (quotientReducedCenterIso H).hom =
+      mkQuotient H (centerDefiningIdeal H) ≫
+        mkQuotient (centerCoordinateRing H) (HopfIdeal.reduction k (centerCoordinateRing H)) := by
+  exact mkQuotient_comp_quotientIsoOfSurjective_hom
+    (mkQuotient H (centerDefiningIdeal H))
+      (mkQuotient_surjective H (centerDefiningIdeal H))
+        (HopfIdeal.reduction k (centerCoordinateRing H))
 
 /-- The ambient quotient model of the reduced center has reduced coordinate ring. -/
 theorem isReduced_quotient_reducedCenterDefiningIdeal :

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Center.Basic
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Reduction
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.AlgebraicallyClosed
+import Mathlib.RingTheory.Noetherian.Nilpotent
+
+/-!
+# The reduced center of an affine group
+
+The center of an affine group can be nonreduced, even when the ambient group is smooth. This file
+constructs its reduction in Hopf coordinates. First quotient by the center ideal, then quotient
+that coordinate algebra by its nilradical. Equivalently, the reduced center is cut out in the
+ambient coordinate algebra by the radical of the center ideal.
+
+The only additional input is reducedness of the tensor square of the reduced center coordinate
+algebra. This is the exact commutative-algebra condition needed to make the nilradical a Hopf
+ideal; it is kept explicit by `TauCeti.HopfIdeal.reduction`. The construction records both the
+nested quotient and the single ambient defining ideal, together with their canonical
+identification.
+
+This is the reduced-center input for proving that the center of a semisimple affine group is
+finite. Semisimplicity trivializes the smooth connected identity component of this reduction;
+the finite component-group theorem then makes the reduction finite, after which nilpotence of the
+thickening controls the original center.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.centerCoordinateRing`: the coordinate Hopf algebra of the center.
+* `TauCeti.CommHopfAlgCat.reducedCenterDefiningIdeal`: the ambient ideal cutting out the reduced
+  center.
+* `TauCeti.CommHopfAlgCat.reducedCenterCoordinateRing`: its coordinate Hopf algebra.
+* `TauCeti.CommHopfAlgCat.reducedCenterDefiningIdeal_toIdeal`: the ambient defining ideal is the
+  radical of the center ideal.
+* `TauCeti.CommHopfAlgCat.quotientReducedCenterIso`: the ambient and iterated quotient models
+  agree.
+* `TauCeti.CommHopfAlgCat.smooth_reducedCenterCoordinateRing`: over an algebraically closed
+  field, a finite-type reduced center is smooth.
+* `TauCeti.CommHopfAlgCat.isNilpotent_reducedCenterKernel`: in finite type, the thickening from
+  the reduced center to the full center is nilpotent.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§1.f and 21.10.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §11.4.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u v
+
+variable {k : Type u} [Field k]
+
+/-- The coordinate Hopf algebra of the center of an affine group. -/
+noncomputable abbrev centerCoordinateRing (H : _root_.CommHopfAlgCat.{v} k) :
+    _root_.CommHopfAlgCat.{v} k :=
+  quotient H (centerDefiningIdeal H)
+
+variable (H : _root_.CommHopfAlgCat.{v} k)
+
+variable [IsReduced
+  ((((centerCoordinateRing H : _root_.CommHopfAlgCat.{v} k) : Type v) ⧸
+      nilradical ((centerCoordinateRing H : _root_.CommHopfAlgCat.{v} k) : Type v)) ⊗[k]
+    (((centerCoordinateRing H : _root_.CommHopfAlgCat.{v} k) : Type v) ⧸
+      nilradical ((centerCoordinateRing H : _root_.CommHopfAlgCat.{v} k) : Type v)))]
+
+/-- The Hopf ideal in the ambient coordinate algebra cutting out the reduced center.
+
+It is the inverse image of the nilradical Hopf ideal of the center coordinate algebra. -/
+noncomputable def reducedCenterDefiningIdeal : HopfIdeal k H :=
+  (HopfIdeal.reduction k (centerCoordinateRing H)).comapOfSurjective
+    (mkQuotient H (centerDefiningIdeal H)).hom
+    (mkQuotient_surjective H (centerDefiningIdeal H))
+
+/-- The center ideal is contained in the reduced-center ideal. Contravariantly, the reduced
+center is a closed subgroup of the center. -/
+theorem centerDefiningIdeal_le_reducedCenterDefiningIdeal :
+    centerDefiningIdeal H ≤ reducedCenterDefiningIdeal H := by
+  intro x hx
+  rw [reducedCenterDefiningIdeal, HopfIdeal.mem_comapOfSurjective]
+  have hzero : (mkQuotient H (centerDefiningIdeal H)).hom x = 0 :=
+    (mkQuotient_eq_zero_iff H (centerDefiningIdeal H) x).mpr hx
+  rw [hzero]
+  exact HopfIdeal.mem_toIdeal.mp
+    (HopfIdeal.reduction k (centerCoordinateRing H)).toIdeal.zero_mem
+
+/-- The ideal defining the reduced center is central. -/
+theorem isCentral_reducedCenterDefiningIdeal :
+    (reducedCenterDefiningIdeal H).IsCentral :=
+  (centerDefiningIdeal_le_iff H (reducedCenterDefiningIdeal H)).mp
+    (centerDefiningIdeal_le_reducedCenterDefiningIdeal H)
+
+/-- The coordinate Hopf algebra of the reduced center, formed by quotienting the center by its
+nilradical. -/
+noncomputable abbrev reducedCenterCoordinateRing : _root_.CommHopfAlgCat.{v} k :=
+  quotient (centerCoordinateRing H) (HopfIdeal.reduction k (centerCoordinateRing H))
+
+/-- The reduced-center coordinate algebra is reduced. -/
+theorem isReduced_reducedCenterCoordinateRing :
+    IsReduced (reducedCenterCoordinateRing H) :=
+  HopfIdeal.isReduced_quotient_reduction k (centerCoordinateRing H)
+
+/-- The ambient ideal defining the reduced center is the radical of the center ideal. -/
+theorem reducedCenterDefiningIdeal_toIdeal :
+    (reducedCenterDefiningIdeal H).toIdeal = (centerDefiningIdeal H).toIdeal.radical := by
+  ext x
+  rw [HopfIdeal.mem_toIdeal, reducedCenterDefiningIdeal,
+    HopfIdeal.mem_comapOfSurjective, HopfIdeal.mem_reduction, Ideal.mem_radical_iff]
+  constructor
+  · rintro ⟨n, hn⟩
+    refine ⟨n, ?_⟩
+    rw [← mkQuotient_eq_zero_iff H (centerDefiningIdeal H), map_pow]
+    exact hn
+  · rintro ⟨n, hn⟩
+    refine ⟨n, ?_⟩
+    rw [← map_pow, mkQuotient_eq_zero_iff H (centerDefiningIdeal H)]
+    exact hn
+
+/-- The quotient by the ambient reduced-center ideal is canonically the iterated quotient formed
+by taking the center and then killing its nilradical. -/
+noncomputable def quotientReducedCenterIso :
+    quotient H (reducedCenterDefiningIdeal H) ≅ reducedCenterCoordinateRing H :=
+  quotientIsoOfSurjective (mkQuotient H (centerDefiningIdeal H))
+    (mkQuotient_surjective H (centerDefiningIdeal H))
+      (HopfIdeal.reduction k (centerCoordinateRing H))
+
+/-- The ambient quotient model of the reduced center has reduced coordinate ring. -/
+theorem isReduced_quotient_reducedCenterDefiningIdeal :
+    IsReduced (quotient H (reducedCenterDefiningIdeal H)) := by
+  let _ : IsReduced (reducedCenterCoordinateRing H) :=
+    isReduced_reducedCenterCoordinateRing H
+  exact isReduced_of_injective (quotientReducedCenterIso H).hom.hom.toAlgHom.toRingHom
+    (ConcreteCategory.bijective_of_isIso (quotientReducedCenterIso H).hom).1
+
+/-- For a finite-type affine group, the ideal removed from the center to form its reduction is
+nilpotent. This records that the reduced center and the full center differ by a nilpotent
+thickening. -/
+theorem isNilpotent_reducedCenterKernel [Algebra.FiniteType k H] :
+    IsNilpotent (HopfIdeal.reduction k (centerCoordinateRing H)).toIdeal := by
+  rw [HopfIdeal.reduction_toIdeal]
+  let _ : IsNoetherianRing (centerCoordinateRing H) :=
+    Algebra.FiniteType.isNoetherianRing k (centerCoordinateRing H)
+  exact IsNoetherianRing.isNilpotent_nilradical (centerCoordinateRing H)
+
+section Smooth
+
+variable (G : _root_.CommHopfAlgCat.{u} k)
+variable [IsReduced
+  ((((centerCoordinateRing G : _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
+      nilradical ((centerCoordinateRing G : _root_.CommHopfAlgCat.{u} k) : Type u)) ⊗[k]
+    (((centerCoordinateRing G : _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
+      nilradical ((centerCoordinateRing G : _root_.CommHopfAlgCat.{u} k) : Type u)))]
+
+/-- Over an algebraically closed field, the reduced center of a finite-type affine group is
+smooth. -/
+theorem smooth_reducedCenterCoordinateRing [IsAlgClosed k] [Algebra.FiniteType k G] :
+    Algebra.Smooth k (reducedCenterCoordinateRing G) := by
+  let _ : IsReduced (reducedCenterCoordinateRing G) :=
+    isReduced_reducedCenterCoordinateRing G
+  exact (smoothCommHopfAlgProperty_iff (reducedCenterCoordinateRing G)).mp
+    (smoothCommHopfAlgProperty_of_isAlgClosed_of_isReduced k (reducedCenterCoordinateRing G))
+
+end Smooth
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
@@ -129,6 +129,18 @@ noncomputable def quotientReducedCenterIso :
     (mkQuotient_surjective H (centerDefiningIdeal H))
       (HopfIdeal.reduction k (centerCoordinateRing H))
 
+/-- The canonical reduced-center isomorphism commutes with the ambient and iterated quotient
+morphisms. -/
+@[simp]
+theorem mkQuotient_comp_quotientReducedCenterIso_hom :
+    mkQuotient H (reducedCenterDefiningIdeal H) ≫ (quotientReducedCenterIso H).hom =
+      mkQuotient H (centerDefiningIdeal H) ≫
+        mkQuotient (centerCoordinateRing H) (HopfIdeal.reduction k (centerCoordinateRing H)) := by
+  exact mkQuotient_comp_quotientIsoOfSurjective_hom
+    (mkQuotient H (centerDefiningIdeal H))
+      (mkQuotient_surjective H (centerDefiningIdeal H))
+        (HopfIdeal.reduction k (centerCoordinateRing H))
+
 /-- The ambient quotient model of the reduced center has reduced coordinate ring. -/
 theorem isReduced_quotient_reducedCenterDefiningIdeal :
     IsReduced (quotient H (reducedCenterDefiningIdeal H)) := by
@@ -154,9 +166,9 @@ variable [IsReduced
     (((centerCoordinateRing G : _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
       nilradical ((centerCoordinateRing G : _root_.CommHopfAlgCat.{u} k) : Type u)))]
 
-/-- Over an algebraically closed field, the reduced center of a finite-type affine group is
-smooth. -/
-theorem smooth_reducedCenterCoordinateRing [IsAlgClosed k] [Algebra.FiniteType k G] :
+/-- Over an algebraically closed field, a finite-type reduced center is smooth. -/
+theorem smooth_reducedCenterCoordinateRing [IsAlgClosed k]
+    [Algebra.FiniteType k (reducedCenterCoordinateRing G)] :
     Algebra.Smooth k (reducedCenterCoordinateRing G) := by
   let _ : IsReduced (reducedCenterCoordinateRing G) :=
     isReduced_reducedCenterCoordinateRing G

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
@@ -31,7 +31,6 @@ thickening controls the original center.
 
 ## Main declarations
 
-* `TauCeti.CommHopfAlgCat.centerCoordinateRing`: the coordinate Hopf algebra of the center.
 * `TauCeti.CommHopfAlgCat.reducedCenterDefiningIdeal`: the ambient ideal cutting out the reduced
   center.
 * `TauCeti.CommHopfAlgCat.reducedCenterCoordinateRing`: its coordinate Hopf algebra.
@@ -41,8 +40,8 @@ thickening controls the original center.
   agree.
 * `TauCeti.CommHopfAlgCat.smooth_reducedCenterCoordinateRing`: over an algebraically closed
   field, a finite-type reduced center is smooth.
-* `TauCeti.CommHopfAlgCat.isNilpotent_reducedCenterKernel`: in finite type, the thickening from
-  the reduced center to the full center is nilpotent.
+* `TauCeti.CommHopfAlgCat.isNilpotent_reducedCenterKernel`: over a Noetherian center coordinate
+  ring, the thickening from the reduced center to the full center is nilpotent.
 
 ## References
 
@@ -60,11 +59,6 @@ namespace TauCeti.CommHopfAlgCat
 universe u v
 
 variable {k : Type u} [Field k]
-
-/-- The coordinate Hopf algebra of the center of an affine group. -/
-noncomputable abbrev centerCoordinateRing (H : _root_.CommHopfAlgCat.{v} k) :
-    _root_.CommHopfAlgCat.{v} k :=
-  quotient H (centerDefiningIdeal H)
 
 variable (H : _root_.CommHopfAlgCat.{v} k)
 
@@ -111,6 +105,7 @@ theorem isReduced_reducedCenterCoordinateRing :
   HopfIdeal.isReduced_quotient_reduction k (centerCoordinateRing H)
 
 /-- The ambient ideal defining the reduced center is the radical of the center ideal. -/
+@[simp]
 theorem reducedCenterDefiningIdeal_toIdeal :
     (reducedCenterDefiningIdeal H).toIdeal = (centerDefiningIdeal H).toIdeal.radical := by
   rw [reducedCenterDefiningIdeal, HopfIdeal.comapOfSurjective_toIdeal,
@@ -118,6 +113,13 @@ theorem reducedCenterDefiningIdeal_toIdeal :
   congr 1
   rw [Ideal.zero_eq_bot, ← RingHom.ker_eq_comap_bot]
   exact mkQuotient_ker H (centerDefiningIdeal H)
+
+/-- An element belongs to the reduced-center ideal exactly when it belongs to the radical of the
+center ideal. -/
+@[simp]
+theorem mem_reducedCenterDefiningIdeal {x : H} :
+    x ∈ reducedCenterDefiningIdeal H ↔ x ∈ (centerDefiningIdeal H).toIdeal.radical := by
+  rw [← HopfIdeal.mem_toIdeal, reducedCenterDefiningIdeal_toIdeal]
 
 /-- The quotient by the ambient reduced-center ideal is canonically the iterated quotient formed
 by taking the center and then killing its nilradical. -/
@@ -127,30 +129,6 @@ noncomputable def quotientReducedCenterIso :
     (mkQuotient_surjective H (centerDefiningIdeal H))
       (HopfIdeal.reduction k (centerCoordinateRing H))
 
-/-- The forward reduced-center quotient isomorphism maps an ambient quotient class to its class
-in the iterated quotient. -/
-@[simp]
-theorem quotientReducedCenterIso_hom_mk (x : H) :
-    (quotientReducedCenterIso H).hom.hom
-        (Ideal.Quotient.mk (reducedCenterDefiningIdeal H).toIdeal x) =
-      Ideal.Quotient.mkₐ k (HopfIdeal.reduction k (centerCoordinateRing H)).toIdeal
-        ((mkQuotient H (centerDefiningIdeal H)).hom x) := by
-  exact quotientIsoOfSurjective_hom_mk (mkQuotient H (centerDefiningIdeal H))
-    (mkQuotient_surjective H (centerDefiningIdeal H))
-      (HopfIdeal.reduction k (centerCoordinateRing H)) x
-
-/-- The forward reduced-center quotient isomorphism commutes with the ambient and iterated
-quotient morphisms. -/
-@[simp]
-theorem mkQuotient_comp_quotientReducedCenterIso_hom :
-    mkQuotient H (reducedCenterDefiningIdeal H) ≫ (quotientReducedCenterIso H).hom =
-      mkQuotient H (centerDefiningIdeal H) ≫
-        mkQuotient (centerCoordinateRing H) (HopfIdeal.reduction k (centerCoordinateRing H)) := by
-  exact mkQuotient_comp_quotientIsoOfSurjective_hom
-    (mkQuotient H (centerDefiningIdeal H))
-      (mkQuotient_surjective H (centerDefiningIdeal H))
-        (HopfIdeal.reduction k (centerCoordinateRing H))
-
 /-- The ambient quotient model of the reduced center has reduced coordinate ring. -/
 theorem isReduced_quotient_reducedCenterDefiningIdeal :
     IsReduced (quotient H (reducedCenterDefiningIdeal H)) := by
@@ -159,14 +137,12 @@ theorem isReduced_quotient_reducedCenterDefiningIdeal :
   exact isReduced_of_injective (quotientReducedCenterIso H).hom.hom.toAlgHom.toRingHom
     (ConcreteCategory.bijective_of_isIso (quotientReducedCenterIso H).hom).1
 
-/-- For a finite-type affine group, the ideal removed from the center to form its reduction is
-nilpotent. This records that the reduced center and the full center differ by a nilpotent
-thickening. -/
-theorem isNilpotent_reducedCenterKernel [Algebra.FiniteType k H] :
+/-- If the center coordinate ring is Noetherian, the ideal removed from the center to form its
+reduction is nilpotent. This records that the reduced center and the full center differ by a
+nilpotent thickening. -/
+theorem isNilpotent_reducedCenterKernel [IsNoetherianRing (centerCoordinateRing H)] :
     IsNilpotent (HopfIdeal.reduction k (centerCoordinateRing H)).toIdeal := by
   rw [HopfIdeal.reduction_toIdeal]
-  let _ : IsNoetherianRing (centerCoordinateRing H) :=
-    Algebra.FiniteType.isNoetherianRing k (centerCoordinateRing H)
   exact IsNoetherianRing.isNilpotent_nilradical (centerCoordinateRing H)
 
 section Smooth

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.Center.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Reduction
 public import TauCeti.Algebra.AlgebraicGroup.Smooth.AlgebraicallyClosed
-import Mathlib.RingTheory.Noetherian.Nilpotent
 
 /-!
 # The reduced center of an affine group
@@ -39,8 +38,8 @@ thickening controls the original center.
   agree.
 * `TauCeti.CommHopfAlgCat.smooth_reducedCenterCoordinateHopfAlgebra`: over an algebraically closed
   field, a finite-type reduced center is smooth.
-* `TauCeti.CommHopfAlgCat.isNilpotent_reducedCenterReduction_toIdeal`: over a Noetherian center
-  coordinate ring, the thickening from the reduced center to the full center is nilpotent.
+* `TauCeti.HopfIdeal.isNilpotent_reduction_toIdeal`: over a Noetherian coordinate ring, the
+  thickening discarded by any Hopf-algebra reduction is nilpotent.
 
 ## References
 
@@ -169,23 +168,14 @@ theorem reducedCenterDefiningIdeal_le_of_centerDefiningIdeal_le_of_isReduced_quo
   exact ((Ideal.isRadical_iff_quotient_reduced I.toIdeal).mpr inferInstance).radical_le_iff.mpr
     (HopfIdeal.toIdeal_le_toIdeal.mpr hcenter)
 
-/-- If the center coordinate ring is Noetherian, the ideal removed from the center to form its
-reduction is nilpotent. This records that the reduced center and the full center differ by a
-nilpotent thickening. -/
-theorem isNilpotent_reducedCenterReduction_toIdeal
-    [IsNoetherianRing (centerCoordinateHopfAlgebra H)] :
-    IsNilpotent (HopfIdeal.reduction k (centerCoordinateHopfAlgebra H)).toIdeal := by
-  rw [HopfIdeal.reduction_toIdeal]
-  exact IsNoetherianRing.isNilpotent_nilradical (centerCoordinateHopfAlgebra H)
-
 section Smooth
 
-variable (G : _root_.CommHopfAlgCat.{u} k)
+variable (G : _root_.CommHopfAlgCat.{v} k)
 variable [IsReduced
-  ((((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
-      nilradical ((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{u} k) : Type u)) ⊗[k]
-    (((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
-      nilradical ((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{u} k) : Type u)))]
+  ((((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{v} k) : Type v) ⧸
+      nilradical ((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{v} k) : Type v)) ⊗[k]
+    (((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{v} k) : Type v) ⧸
+      nilradical ((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{v} k) : Type v)))]
 
 /-- Over an algebraically closed field, a finite-type reduced center is smooth. -/
 theorem smooth_reducedCenterCoordinateHopfAlgebra [IsAlgClosed k]

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
@@ -32,12 +32,12 @@ thickening controls the original center.
 
 * `TauCeti.CommHopfAlgCat.reducedCenterDefiningIdeal`: the ambient ideal cutting out the reduced
   center.
-* `TauCeti.CommHopfAlgCat.reducedCenterCoordinateRing`: its coordinate Hopf algebra.
+* `TauCeti.CommHopfAlgCat.reducedCenterCoordinateHopfAlgebra`: its coordinate Hopf algebra.
 * `TauCeti.CommHopfAlgCat.reducedCenterDefiningIdeal_toIdeal`: the ambient defining ideal is the
   radical of the center ideal.
 * `TauCeti.CommHopfAlgCat.quotientReducedCenterIso`: the ambient and iterated quotient models
   agree.
-* `TauCeti.CommHopfAlgCat.smooth_reducedCenterCoordinateRing`: over an algebraically closed
+* `TauCeti.CommHopfAlgCat.smooth_reducedCenterCoordinateHopfAlgebra`: over an algebraically closed
   field, a finite-type reduced center is smooth.
 * `TauCeti.CommHopfAlgCat.isNilpotent_reducedCenterReduction_toIdeal`: over a Noetherian center
   coordinate ring, the thickening from the reduced center to the full center is nilpotent.
@@ -62,16 +62,16 @@ variable {k : Type u} [Field k]
 variable (H : _root_.CommHopfAlgCat.{v} k)
 
 variable [IsReduced
-  ((((centerCoordinateRing H : _root_.CommHopfAlgCat.{v} k) : Type v) ⧸
-      nilradical ((centerCoordinateRing H : _root_.CommHopfAlgCat.{v} k) : Type v)) ⊗[k]
-    (((centerCoordinateRing H : _root_.CommHopfAlgCat.{v} k) : Type v) ⧸
-      nilradical ((centerCoordinateRing H : _root_.CommHopfAlgCat.{v} k) : Type v)))]
+  ((((centerCoordinateHopfAlgebra H : _root_.CommHopfAlgCat.{v} k) : Type v) ⧸
+      nilradical ((centerCoordinateHopfAlgebra H : _root_.CommHopfAlgCat.{v} k) : Type v)) ⊗[k]
+    (((centerCoordinateHopfAlgebra H : _root_.CommHopfAlgCat.{v} k) : Type v) ⧸
+      nilradical ((centerCoordinateHopfAlgebra H : _root_.CommHopfAlgCat.{v} k) : Type v)))]
 
 /-- The Hopf ideal in the ambient coordinate algebra cutting out the reduced center.
 
 It is the inverse image of the nilradical Hopf ideal of the center coordinate algebra. -/
 noncomputable def reducedCenterDefiningIdeal : HopfIdeal k H :=
-  (HopfIdeal.reduction k (centerCoordinateRing H)).comapOfSurjective
+  (HopfIdeal.reduction k (centerCoordinateHopfAlgebra H)).comapOfSurjective
     (mkQuotient H (centerDefiningIdeal H)).hom
     (mkQuotient_surjective H (centerDefiningIdeal H))
 
@@ -85,7 +85,7 @@ theorem centerDefiningIdeal_le_reducedCenterDefiningIdeal :
     (mkQuotient_eq_zero_iff H (centerDefiningIdeal H) x).mpr hx
   rw [hzero]
   exact HopfIdeal.mem_toIdeal.mp
-    (HopfIdeal.reduction k (centerCoordinateRing H)).toIdeal.zero_mem
+    (HopfIdeal.reduction k (centerCoordinateHopfAlgebra H)).toIdeal.zero_mem
 
 /-- The ideal defining the reduced center is central. -/
 theorem isCentral_reducedCenterDefiningIdeal :
@@ -95,27 +95,33 @@ theorem isCentral_reducedCenterDefiningIdeal :
 
 /-- The coordinate Hopf algebra of the reduced center, formed by quotienting the center by its
 nilradical. -/
-noncomputable abbrev reducedCenterCoordinateRing : _root_.CommHopfAlgCat.{v} k :=
-  quotient (centerCoordinateRing H) (HopfIdeal.reduction k (centerCoordinateRing H))
+noncomputable abbrev reducedCenterCoordinateHopfAlgebra : _root_.CommHopfAlgCat.{v} k :=
+  quotient (centerCoordinateHopfAlgebra H) (HopfIdeal.reduction k (centerCoordinateHopfAlgebra H))
 
 /-- The reduced-center coordinate algebra is reduced. -/
-theorem isReduced_reducedCenterCoordinateRing :
-    IsReduced (reducedCenterCoordinateRing H) :=
-  HopfIdeal.isReduced_quotient_reduction k (centerCoordinateRing H)
+theorem isReduced_reducedCenterCoordinateHopfAlgebra :
+    IsReduced (reducedCenterCoordinateHopfAlgebra H) :=
+  HopfIdeal.isReduced_quotient_reduction k (centerCoordinateHopfAlgebra H)
 
 /-- The ambient ideal defining the reduced center is the radical of the center ideal. -/
 @[simp]
 theorem reducedCenterDefiningIdeal_toIdeal :
     (reducedCenterDefiningIdeal H).toIdeal = (centerDefiningIdeal H).toIdeal.radical := by
   have hcomap :
-      Ideal.comap ((mkQuotient H (centerDefiningIdeal H)).hom :
-        H →+* centerCoordinateRing H) ⊥ =
-        (centerDefiningIdeal H).toIdeal := by
-    ext x
-    rw [Ideal.mem_comap, Ideal.mem_bot]
-    exact mkQuotient_eq_zero_iff H (centerDefiningIdeal H) x
+      RingHom.ker ((mkQuotient H (centerDefiningIdeal H)).hom :
+        H →+* centerCoordinateHopfAlgebra H) =
+        (centerDefiningIdeal H).toIdeal :=
+    calc
+      RingHom.ker ((mkQuotient H (centerDefiningIdeal H)).hom :
+          H →+* centerCoordinateHopfAlgebra H) =
+          RingHom.ker (mkQuotient H (centerDefiningIdeal H)).hom.toAlgHom.toRingHom := by
+        ext x
+        rfl
+      _ = (centerDefiningIdeal H).toIdeal :=
+        mkQuotient_ker H (centerDefiningIdeal H)
   rw [reducedCenterDefiningIdeal, HopfIdeal.comapOfSurjective_toIdeal,
-    HopfIdeal.reduction_toIdeal, nilradical, Ideal.comap_radical, Ideal.zero_eq_bot, hcomap]
+    HopfIdeal.reduction_toIdeal, nilradical, Ideal.comap_radical, Ideal.zero_eq_bot,
+    ← RingHom.ker_eq_comap_bot, hcomap]
 
 /-- An element belongs to the reduced-center ideal exactly when it belongs to the radical of the
 center ideal. -/
@@ -127,10 +133,10 @@ theorem mem_reducedCenterDefiningIdeal {x : H} :
 /-- The quotient by the ambient reduced-center ideal is canonically the iterated quotient formed
 by taking the center and then killing its nilradical. -/
 noncomputable def quotientReducedCenterIso :
-    quotient H (reducedCenterDefiningIdeal H) ≅ reducedCenterCoordinateRing H :=
+    quotient H (reducedCenterDefiningIdeal H) ≅ reducedCenterCoordinateHopfAlgebra H :=
   quotientIsoOfSurjective (mkQuotient H (centerDefiningIdeal H))
     (mkQuotient_surjective H (centerDefiningIdeal H))
-      (HopfIdeal.reduction k (centerCoordinateRing H))
+      (HopfIdeal.reduction k (centerCoordinateHopfAlgebra H))
 
 /-- The canonical reduced-center isomorphism commutes with the ambient and iterated quotient
 morphisms. -/
@@ -138,23 +144,25 @@ morphisms. -/
 theorem mkQuotient_comp_quotientReducedCenterIso_hom :
     mkQuotient H (reducedCenterDefiningIdeal H) ≫ (quotientReducedCenterIso H).hom =
       mkQuotient H (centerDefiningIdeal H) ≫
-        mkQuotient (centerCoordinateRing H) (HopfIdeal.reduction k (centerCoordinateRing H)) := by
+        mkQuotient (centerCoordinateHopfAlgebra H)
+          (HopfIdeal.reduction k (centerCoordinateHopfAlgebra H)) := by
   exact mkQuotient_comp_quotientIsoOfSurjective_hom
     (mkQuotient H (centerDefiningIdeal H))
       (mkQuotient_surjective H (centerDefiningIdeal H))
-        (HopfIdeal.reduction k (centerCoordinateRing H))
+        (HopfIdeal.reduction k (centerCoordinateHopfAlgebra H))
 
 /-- The ambient quotient model of the reduced center has reduced coordinate ring. -/
 theorem isReduced_quotient_reducedCenterDefiningIdeal :
     IsReduced (quotient H (reducedCenterDefiningIdeal H)) := by
-  let _ : IsReduced (reducedCenterCoordinateRing H) :=
-    isReduced_reducedCenterCoordinateRing H
+  let _ : IsReduced (reducedCenterCoordinateHopfAlgebra H) :=
+    isReduced_reducedCenterCoordinateHopfAlgebra H
   exact isReduced_of_injective (quotientReducedCenterIso H).hom.hom.toAlgHom.toRingHom
     (ConcreteCategory.bijective_of_isIso (quotientReducedCenterIso H).hom).1
 
 /-- The reduced-center ideal is contained in every central Hopf ideal whose quotient is
 reduced. -/
-theorem reducedCenterDefiningIdeal_le_of_isReduced_quotient (I : HopfIdeal k H)
+theorem reducedCenterDefiningIdeal_le_of_centerDefiningIdeal_le_of_isReduced_quotient
+    (I : HopfIdeal k H)
     (hcenter : centerDefiningIdeal H ≤ I) [IsReduced (quotient H I)] :
     reducedCenterDefiningIdeal H ≤ I := by
   rw [← HopfIdeal.toIdeal_le_toIdeal, reducedCenterDefiningIdeal_toIdeal]
@@ -165,28 +173,29 @@ theorem reducedCenterDefiningIdeal_le_of_isReduced_quotient (I : HopfIdeal k H)
 reduction is nilpotent. This records that the reduced center and the full center differ by a
 nilpotent thickening. -/
 theorem isNilpotent_reducedCenterReduction_toIdeal
-    [IsNoetherianRing (centerCoordinateRing H)] :
-    IsNilpotent (HopfIdeal.reduction k (centerCoordinateRing H)).toIdeal := by
+    [IsNoetherianRing (centerCoordinateHopfAlgebra H)] :
+    IsNilpotent (HopfIdeal.reduction k (centerCoordinateHopfAlgebra H)).toIdeal := by
   rw [HopfIdeal.reduction_toIdeal]
-  exact IsNoetherianRing.isNilpotent_nilradical (centerCoordinateRing H)
+  exact IsNoetherianRing.isNilpotent_nilradical (centerCoordinateHopfAlgebra H)
 
 section Smooth
 
 variable (G : _root_.CommHopfAlgCat.{u} k)
 variable [IsReduced
-  ((((centerCoordinateRing G : _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
-      nilradical ((centerCoordinateRing G : _root_.CommHopfAlgCat.{u} k) : Type u)) ⊗[k]
-    (((centerCoordinateRing G : _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
-      nilradical ((centerCoordinateRing G : _root_.CommHopfAlgCat.{u} k) : Type u)))]
+  ((((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
+      nilradical ((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{u} k) : Type u)) ⊗[k]
+    (((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{u} k) : Type u) ⧸
+      nilradical ((centerCoordinateHopfAlgebra G : _root_.CommHopfAlgCat.{u} k) : Type u)))]
 
 /-- Over an algebraically closed field, a finite-type reduced center is smooth. -/
-theorem smooth_reducedCenterCoordinateRing [IsAlgClosed k]
-    [Algebra.FiniteType k (reducedCenterCoordinateRing G)] :
-    Algebra.Smooth k (reducedCenterCoordinateRing G) := by
-  let _ : IsReduced (reducedCenterCoordinateRing G) :=
-    isReduced_reducedCenterCoordinateRing G
-  exact (smoothCommHopfAlgProperty_iff (reducedCenterCoordinateRing G)).mp
-    (smoothCommHopfAlgProperty_of_isAlgClosed_of_isReduced k (reducedCenterCoordinateRing G))
+theorem smooth_reducedCenterCoordinateHopfAlgebra [IsAlgClosed k]
+    [Algebra.FiniteType k (reducedCenterCoordinateHopfAlgebra G)] :
+    Algebra.Smooth k (reducedCenterCoordinateHopfAlgebra G) := by
+  let _ : IsReduced (reducedCenterCoordinateHopfAlgebra G) :=
+    isReduced_reducedCenterCoordinateHopfAlgebra G
+  exact (smoothCommHopfAlgProperty_iff (reducedCenterCoordinateHopfAlgebra G)).mp
+    (smoothCommHopfAlgProperty_of_isAlgClosed_of_isReduced k
+      (reducedCenterCoordinateHopfAlgebra G))
 
 end Smooth
 

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
@@ -39,8 +39,8 @@ thickening controls the original center.
   agree.
 * `TauCeti.CommHopfAlgCat.smooth_reducedCenterCoordinateRing`: over an algebraically closed
   field, a finite-type reduced center is smooth.
-* `TauCeti.CommHopfAlgCat.isNilpotent_reducedCenterKernel`: over a Noetherian center coordinate
-  ring, the thickening from the reduced center to the full center is nilpotent.
+* `TauCeti.CommHopfAlgCat.isNilpotent_reducedCenterReduction_toIdeal`: over a Noetherian center
+  coordinate ring, the thickening from the reduced center to the full center is nilpotent.
 
 ## References
 
@@ -164,7 +164,8 @@ theorem reducedCenterDefiningIdeal_le_of_isReduced_quotient (I : HopfIdeal k H)
 /-- If the center coordinate ring is Noetherian, the ideal removed from the center to form its
 reduction is nilpotent. This records that the reduced center and the full center differ by a
 nilpotent thickening. -/
-theorem isNilpotent_reducedCenterKernel [IsNoetherianRing (centerCoordinateRing H)] :
+theorem isNilpotent_reducedCenterReduction_toIdeal
+    [IsNoetherianRing (centerCoordinateRing H)] :
     IsNilpotent (HopfIdeal.reduction k (centerCoordinateRing H)).toIdeal := by
   rw [HopfIdeal.reduction_toIdeal]
   exact IsNoetherianRing.isNilpotent_nilradical (centerCoordinateRing H)

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
@@ -18,11 +18,10 @@ constructs its reduction in Hopf coordinates. First quotient by the center ideal
 that coordinate algebra by its nilradical. Equivalently, the reduced center is cut out in the
 ambient coordinate algebra by the radical of the center ideal.
 
-The only additional input is reducedness of the tensor square of the reduced center coordinate
-algebra. This is the exact commutative-algebra condition needed to make the nilradical a Hopf
-ideal; it is kept explicit by `TauCeti.HopfIdeal.reduction`. The construction records both the
-nested quotient and the single ambient defining ideal, together with their canonical
-identification.
+Assuming the tensor square of the reduced center coordinate algebra is reduced, its nilradical
+forms a Hopf ideal; this sufficient commutative-algebra hypothesis is kept explicit by
+`TauCeti.HopfIdeal.reduction`. The construction records both the nested quotient and the single
+ambient defining ideal, together with their canonical identification.
 
 This is the reduced-center input for proving that the center of a semisimple affine group is
 finite. Semisimplicity trivializes the smooth connected identity component of this reduction;
@@ -108,11 +107,15 @@ theorem isReduced_reducedCenterCoordinateRing :
 @[simp]
 theorem reducedCenterDefiningIdeal_toIdeal :
     (reducedCenterDefiningIdeal H).toIdeal = (centerDefiningIdeal H).toIdeal.radical := by
+  have hcomap :
+      Ideal.comap ((mkQuotient H (centerDefiningIdeal H)).hom :
+        H →+* centerCoordinateRing H) ⊥ =
+        (centerDefiningIdeal H).toIdeal := by
+    ext x
+    rw [Ideal.mem_comap, Ideal.mem_bot]
+    exact mkQuotient_eq_zero_iff H (centerDefiningIdeal H) x
   rw [reducedCenterDefiningIdeal, HopfIdeal.comapOfSurjective_toIdeal,
-    HopfIdeal.reduction_toIdeal, nilradical, Ideal.comap_radical]
-  congr 1
-  rw [Ideal.zero_eq_bot, ← RingHom.ker_eq_comap_bot]
-  exact mkQuotient_ker H (centerDefiningIdeal H)
+    HopfIdeal.reduction_toIdeal, nilradical, Ideal.comap_radical, Ideal.zero_eq_bot, hcomap]
 
 /-- An element belongs to the reduced-center ideal exactly when it belongs to the radical of the
 center ideal. -/
@@ -148,6 +151,15 @@ theorem isReduced_quotient_reducedCenterDefiningIdeal :
     isReduced_reducedCenterCoordinateRing H
   exact isReduced_of_injective (quotientReducedCenterIso H).hom.hom.toAlgHom.toRingHom
     (ConcreteCategory.bijective_of_isIso (quotientReducedCenterIso H).hom).1
+
+/-- The reduced-center ideal is contained in every central Hopf ideal whose quotient is
+reduced. -/
+theorem reducedCenterDefiningIdeal_le_of_isReduced_quotient (I : HopfIdeal k H)
+    (hcenter : centerDefiningIdeal H ≤ I) [IsReduced (quotient H I)] :
+    reducedCenterDefiningIdeal H ≤ I := by
+  rw [← HopfIdeal.toIdeal_le_toIdeal, reducedCenterDefiningIdeal_toIdeal]
+  exact ((Ideal.isRadical_iff_quotient_reduced I.toIdeal).mpr inferInstance).radical_le_iff.mpr
+    (HopfIdeal.toIdeal_le_toIdeal.mpr hcenter)
 
 /-- If the center coordinate ring is Noetherian, the ideal removed from the center to form its
 reduction is nilpotent. This records that the reduced center and the full center differ by a

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean
@@ -38,8 +38,6 @@ thickening controls the original center.
   agree.
 * `TauCeti.CommHopfAlgCat.smooth_reducedCenterCoordinateHopfAlgebra`: over an algebraically closed
   field, a finite-type reduced center is smooth.
-* `TauCeti.HopfIdeal.isNilpotent_reduction_toIdeal`: over a Noetherian coordinate ring, the
-  thickening discarded by any Hopf-algebra reduction is nilpotent.
 
 ## References
 
@@ -112,10 +110,11 @@ theorem reducedCenterDefiningIdeal_toIdeal :
         (centerDefiningIdeal H).toIdeal :=
     calc
       RingHom.ker ((mkQuotient H (centerDefiningIdeal H)).hom :
-          H →+* centerCoordinateHopfAlgebra H) =
+        H →+* centerCoordinateHopfAlgebra H) =
           RingHom.ker (mkQuotient H (centerDefiningIdeal H)).hom.toAlgHom.toRingHom := by
         ext x
-        rfl
+        simp only [RingHom.mem_ker, AlgHom.toRingHom_eq_coe, RingHom.coe_coe,
+          BialgHom.coe_toAlgHom]
       _ = (centerDefiningIdeal H).toIdeal :=
         mkQuotient_ker H (centerDefiningIdeal H)
   rw [reducedCenterDefiningIdeal, HopfIdeal.comapOfSurjective_toIdeal,

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
@@ -10,6 +10,7 @@ public import TauCeti.Algebra.AlgebraicGroup.Connected.IdentityComponent
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Basic
 import TauCeti.Algebra.AlgebraicGroup.Connected.Translation
 import TauCeti.AlgebraicGeometry.AugmentationPoint.ConnectedComponent
+import TauCeti.Algebra.HopfAlgebra.Kernel
 import TauCeti.RingTheory.FiniteType.PointSeparation
 public import TauCeti.Topology.NoetherianSpace.ConnectedComponents
 import Mathlib.RingTheory.FiniteStability
@@ -181,17 +182,8 @@ private theorem comul_one_sub_connectedComponentIdempotent_mem
       exact Ideal.Quotient.mkₐ_ker k I
     -- Unfold the local tensor-square map abbreviation before tensor-product exactness rewrites it.
     change RingHom.ker (Algebra.TensorProduct.map q q) = _
-    have hleft :
-        I.map (Algebra.TensorProduct.includeLeft (R := k) (S := k) (A := H) (B := H)) =
-          HopfIdeal.leftTensorIdeal (R := k) (H := H) I := by
-      rw [HopfIdeal.leftTensorIdeal_def, AlgHom.toRingHom_eq_coe]
-      exact AlgHom.coe_ideal_map _ I
-    have hright :
-        I.map (Algebra.TensorProduct.includeRight (R := k) (A := H) (B := H)) =
-          HopfIdeal.rightTensorIdeal (R := k) (H := H) I := by
-      rw [HopfIdeal.rightTensorIdeal_def, AlgHom.toRingHom_eq_coe]
-      exact AlgHom.coe_ideal_map _ I
-    rw [Algebra.TensorProduct.map_ker (f := q) (g := q) hq hq, hqker, hleft, hright]
+    simpa only [AlgHom.ker_coe, AlgHom.toRingHom_eq_coe, hqker] using
+      AlgHom.tensor_map_ker_eq_left_sup_right q q hq hq
   rwa [hker_eq] at hker
 
 /-- The ideal cutting out the augmentation point's connected component is stable under

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
@@ -182,7 +182,7 @@ private theorem comul_one_sub_connectedComponentIdempotent_mem
     -- Unfold the local tensor-square map abbreviation before tensor-product exactness rewrites it.
     change RingHom.ker (Algebra.TensorProduct.map q q) = _
     simpa only [AlgHom.ker_coe, AlgHom.toRingHom_eq_coe, hqker] using
-      AlgHom.tensor_map_ker_eq_left_sup_right q q hq hq
+      HopfIdeal.ker_tensorProduct_map_eq_leftTensorIdeal_sup_rightTensorIdeal q q hq hq
   rwa [hker_eq] at hker
 
 /-- The ideal cutting out the augmentation point's connected component is stable under

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
@@ -10,7 +10,6 @@ public import TauCeti.Algebra.AlgebraicGroup.Connected.IdentityComponent
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Basic
 import TauCeti.Algebra.AlgebraicGroup.Connected.Translation
 import TauCeti.AlgebraicGeometry.AugmentationPoint.ConnectedComponent
-import TauCeti.Algebra.HopfAlgebra.Kernel
 import TauCeti.RingTheory.FiniteType.PointSeparation
 public import TauCeti.Topology.NoetherianSpace.ConnectedComponents
 import Mathlib.RingTheory.FiniteStability

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -30,8 +30,6 @@ the finite-type coordinate-Hopf-algebra category.
 ## Main declarations
 
 * `TauCeti.CommHopfAlgCat.quotient`: the quotient object in `CommHopfAlgCat`.
-* `TauCeti.CommHopfAlgCat.quotientRingEquiv`: its underlying ring is the corresponding ideal
-  quotient.
 * `TauCeti.CommHopfAlgCat.mkQuotient_surjective`: the quotient morphism is surjective.
 * `TauCeti.CommHopfAlgCat.mkQuotient_hom_ext`: morphisms out of a quotient are determined
   after precomposition with the quotient morphism.
@@ -122,12 +120,6 @@ Hopf algebra. -/
 noncomputable abbrev quotient (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
     _root_.CommHopfAlgCat.{v} R :=
   _root_.CommHopfAlgCat.of R (H ⧸ I.toIdeal)
-
-/-- The underlying ring of a commutative Hopf-algebra quotient is the corresponding ideal
-quotient. -/
-def quotientRingEquiv (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
-    ((quotient H I : _root_.CommHopfAlgCat.{v} R) : Type v) ≃+* (H ⧸ I.toIdeal) :=
-  RingEquiv.refl _
 
 /-- The quotient morphism `H ⟶ H ⧸ I` in `CommHopfAlgCat`. -/
 noncomputable abbrev mkQuotient (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -11,6 +11,7 @@ public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
 public import TauCeti.Algebra.Bialgebra.Quotient
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Basic
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Map
+import Mathlib.RingTheory.Ideal.Quotient.Nilpotent
 
 /-!
 # Hopf-ideal quotients of finite-type commutative Hopf algebras
@@ -30,6 +31,8 @@ the finite-type coordinate-Hopf-algebra category.
 ## Main declarations
 
 * `TauCeti.CommHopfAlgCat.quotient`: the quotient object in `CommHopfAlgCat`.
+* `TauCeti.CommHopfAlgCat.isReduced_quotient_iff`: characterizes when its underlying ring is
+  reduced.
 * `TauCeti.CommHopfAlgCat.mkQuotient_surjective`: the quotient morphism is surjective.
 * `TauCeti.CommHopfAlgCat.mkQuotient_hom_ext`: morphisms out of a quotient are determined
   after precomposition with the quotient morphism.
@@ -120,6 +123,12 @@ Hopf algebra. -/
 noncomputable abbrev quotient (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
     _root_.CommHopfAlgCat.{v} R :=
   _root_.CommHopfAlgCat.of R (H ⧸ I.toIdeal)
+
+/-- The underlying ring of a Hopf-ideal quotient is reduced exactly when its defining ideal is
+radical. -/
+theorem isReduced_quotient_iff (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
+    IsReduced (quotient H I) ↔ I.toIdeal.IsRadical :=
+  (Ideal.isRadical_iff_quotient_reduced I.toIdeal).symm
 
 /-- The quotient morphism `H ⟶ H ⧸ I` in `CommHopfAlgCat`. -/
 noncomputable abbrev mkQuotient (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -11,7 +11,6 @@ public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
 public import TauCeti.Algebra.Bialgebra.Quotient
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Basic
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Map
-import Mathlib.RingTheory.Ideal.Quotient.Nilpotent
 
 /-!
 # Hopf-ideal quotients of finite-type commutative Hopf algebras
@@ -31,8 +30,6 @@ the finite-type coordinate-Hopf-algebra category.
 ## Main declarations
 
 * `TauCeti.CommHopfAlgCat.quotient`: the quotient object in `CommHopfAlgCat`.
-* `TauCeti.CommHopfAlgCat.isReduced_quotient_iff`: characterizes when its underlying ring is
-  reduced.
 * `TauCeti.CommHopfAlgCat.mkQuotient_surjective`: the quotient morphism is surjective.
 * `TauCeti.CommHopfAlgCat.mkQuotient_hom_ext`: morphisms out of a quotient are determined
   after precomposition with the quotient morphism.
@@ -123,12 +120,6 @@ Hopf algebra. -/
 noncomputable abbrev quotient (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
     _root_.CommHopfAlgCat.{v} R :=
   _root_.CommHopfAlgCat.of R (H ⧸ I.toIdeal)
-
-/-- The underlying ring of a Hopf-ideal quotient is reduced exactly when its defining ideal is
-radical. -/
-theorem isReduced_quotient_iff (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
-    IsReduced (quotient H I) ↔ I.toIdeal.IsRadical :=
-  (Ideal.isRadical_iff_quotient_reduced I.toIdeal).symm
 
 /-- The quotient morphism `H ⟶ H ⧸ I` in `CommHopfAlgCat`. -/
 noncomputable abbrev mkQuotient (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -30,6 +30,8 @@ the finite-type coordinate-Hopf-algebra category.
 ## Main declarations
 
 * `TauCeti.CommHopfAlgCat.quotient`: the quotient object in `CommHopfAlgCat`.
+* `TauCeti.CommHopfAlgCat.quotientRingEquiv`: its underlying ring is the corresponding ideal
+  quotient.
 * `TauCeti.CommHopfAlgCat.mkQuotient_surjective`: the quotient morphism is surjective.
 * `TauCeti.CommHopfAlgCat.mkQuotient_hom_ext`: morphisms out of a quotient are determined
   after precomposition with the quotient morphism.
@@ -120,6 +122,12 @@ Hopf algebra. -/
 noncomputable abbrev quotient (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
     _root_.CommHopfAlgCat.{v} R :=
   _root_.CommHopfAlgCat.of R (H ⧸ I.toIdeal)
+
+/-- The underlying ring of a commutative Hopf-algebra quotient is the corresponding ideal
+quotient. -/
+def quotientRingEquiv (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :
+    ((quotient H I : _root_.CommHopfAlgCat.{v} R) : Type v) ≃+* (H ⧸ I.toIdeal) :=
+  RingEquiv.refl _
 
 /-- The quotient morphism `H ⟶ H ⧸ I` in `CommHopfAlgCat`. -/
 noncomputable abbrev mkQuotient (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H) :

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean
@@ -45,9 +45,7 @@ theorem isReduced_quotient_reduction
       rw [reduction_toIdeal]
       exact Ideal.radical_isRadical ⊥)
   exact isReduced_of_injective
-    (CommHopfAlgCat.quotientRingEquiv
-      (_root_.CommHopfAlgCat.of R H) (reduction R H)).toRingHom
-    (CommHopfAlgCat.quotientRingEquiv
-      (_root_.CommHopfAlgCat.of R H) (reduction R H)).injective
+    (RingEquiv.refl (H ⧸ (reduction R H).toIdeal)).toRingHom
+    (RingEquiv.refl (H ⧸ (reduction R H).toIdeal)).injective
 
 end TauCeti.HopfIdeal

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean
@@ -5,27 +5,18 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.RingTheory.Ideal.Quotient.Nilpotent
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Reduction
 
 /-!
-# The reduced closed subgroup of an affine group
+# The reduced quotient of an affine group
 
-Let `H` be a commutative Hopf algebra over a reduced commutative ring. Its nilradical is
-automatically stable under the counit and antipode. It is stable under comultiplication provided
-the tensor square of the reduced coordinate algebra is reduced: the image of a nilpotent element
-under comultiplication is nilpotent, hence vanishes in that tensor square. This packages the
-nilradical as a Hopf ideal under precisely that hypothesis.
-
-The tensor-square hypothesis is the algebraic condition needed for reduction to commute with the
-product of the underlying affine scheme. It holds, in particular, for finite-type algebras over a
-perfect field once the standard geometric-reducedness theorem is available. Keeping it explicit
-here separates the Hopf-algebra argument from that commutative-algebra input.
+This file packages the quotient by the generic nilradical Hopf ideal from
+`TauCeti.Algebra.HopfAlgebra.HopfIdeal.Reduction` as a commutative Hopf-algebra object and records
+that its underlying coordinate ring is reduced.
 
 ## Main declarations
 
-* `TauCeti.HopfIdeal.reduction`: the nilradical, packaged as a Hopf ideal.
-* `TauCeti.HopfIdeal.reduction_toIdeal`: its underlying ideal is the nilradical.
 * `TauCeti.HopfIdeal.isReduced_quotient_reduction`: the resulting quotient is reduced.
 
 ## References
@@ -45,86 +36,18 @@ universe u v
 variable (R : Type u) [CommRing R] [IsReduced R]
 variable (H : Type v) [CommRing H] [HopfAlgebra R H]
 
-private theorem nilradical_counit_eq_zero {x : H} (hx : x ∈ nilradical H) :
-    Coalgebra.counit (R := R) x = 0 := by
-  rw [mem_nilradical] at hx
-  exact isNilpotent_iff_eq_zero.mp (hx.map (Bialgebra.counitAlgHom R H))
-
-omit [IsReduced R] in
-private theorem nilradical_antipode_mem {x : H} (hx : x ∈ nilradical H) :
-    HopfAlgebra.antipode R x ∈ nilradical H := by
-  rw [mem_nilradical] at hx ⊢
-  simpa only [HopfAlgebra.antipodeAlgHom_apply] using
-    hx.map (HopfAlgebra.antipodeAlgHom R H)
-
-omit [IsReduced R] in
-private theorem nilradical_comul_mem
-    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))]
-    {x : H} (hx : x ∈ nilradical H) :
-    Coalgebra.comul (R := R) x ∈
-      leftTensorIdeal (R := R) (H := H) (nilradical H) ⊔
-        rightTensorIdeal (R := R) (H := H) (nilradical H) := by
-  let q : H →ₐ[R] H ⧸ nilradical H := Ideal.Quotient.mkₐ R (nilradical H)
-  have hnil : IsNilpotent (Coalgebra.comul (R := R) x) :=
-    (mem_nilradical.mp hx).map (Bialgebra.comulAlgHom R H)
-  have hzero : Algebra.TensorProduct.map q q (Coalgebra.comul (R := R) x) = 0 :=
-    isNilpotent_iff_eq_zero.mp (hnil.map (Algebra.TensorProduct.map q q))
-  have hker : RingHom.ker (Algebra.TensorProduct.map q q).toRingHom =
-      leftTensorIdeal (R := R) (H := H) (nilradical H) ⊔
-        rightTensorIdeal (R := R) (H := H) (nilradical H) := by
-    have hqker : RingHom.ker (q : H →+* H ⧸ nilradical H) = nilradical H :=
-      Ideal.Quotient.mkₐ_ker R (nilradical H)
-    change RingHom.ker (Algebra.TensorProduct.map q q) =
-      Ideal.map Algebra.TensorProduct.includeLeft.toRingHom (nilradical H) ⊔
-        Ideal.map Algebra.TensorProduct.includeRight.toRingHom (nilradical H)
-    calc
-      RingHom.ker (Algebra.TensorProduct.map q q) =
-          Ideal.map Algebra.TensorProduct.includeLeft
-              (RingHom.ker (q : H →+* H ⧸ nilradical H)) ⊔
-            Ideal.map Algebra.TensorProduct.includeRight
-              (RingHom.ker (q : H →+* H ⧸ nilradical H)) :=
-        Algebra.TensorProduct.map_ker (f := q) (g := q)
-          (Ideal.Quotient.mkₐ_surjective R (nilradical H))
-          (Ideal.Quotient.mkₐ_surjective R (nilradical H))
-      _ = Ideal.map Algebra.TensorProduct.includeLeft.toRingHom (nilradical H) ⊔
-          Ideal.map Algebra.TensorProduct.includeRight.toRingHom (nilradical H) := by
-        rw [hqker]
-        rfl
-  rw [← hker, RingHom.mem_ker]
-  exact hzero
-
-/-- The nilradical of a commutative Hopf algebra, as a Hopf ideal.
-
-The tensor square of the reduced coordinate algebra must be reduced. This is exactly what makes
-the comultiplication descend: a nilpotent element maps to a nilpotent element of that tensor
-square and therefore to zero. -/
-noncomputable def reduction
-    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] : HopfIdeal R H :=
-  ofIdeal (nilradical H)
-    (fun {x} hx ↦ nilradical_comul_mem R H (x := x) hx)
-    (fun {x} hx ↦ nilradical_counit_eq_zero R H (x := x) hx)
-    (fun {x} hx ↦ nilradical_antipode_mem R H (x := x) hx)
-
-/-- The underlying ideal of the reduction Hopf ideal is the nilradical. -/
-@[simp]
-theorem reduction_toIdeal
-    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] :
-    (reduction R H).toIdeal = nilradical H := by
-  rw [reduction, toIdeal_carrier, ofIdeal_carrier]
-
-/-- Membership in the reduction Hopf ideal is nilpotence. -/
-@[simp]
-theorem mem_reduction
-    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] {x : H} :
-    x ∈ reduction R H ↔ IsNilpotent x := by
-  rw [← mem_toIdeal, reduction_toIdeal, mem_nilradical]
-
 /-- The quotient by the reduction Hopf ideal has reduced coordinate ring. -/
 theorem isReduced_quotient_reduction
     [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] :
     IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of R H) (reduction R H)) := by
-  change IsReduced (H ⧸ nilradical H)
-  exact (Ideal.isRadical_iff_quotient_reduced (nilradical H)).mp
-    (Ideal.radical_isRadical ⊥)
+  let _ : IsReduced (H ⧸ (reduction R H).toIdeal) :=
+    (Ideal.isRadical_iff_quotient_reduced (reduction R H).toIdeal).mp (by
+      rw [reduction_toIdeal]
+      exact Ideal.radical_isRadical ⊥)
+  exact isReduced_of_injective
+    (CommHopfAlgCat.quotientRingEquiv
+      (_root_.CommHopfAlgCat.of R H) (reduction R H)).toRingHom
+    (CommHopfAlgCat.quotientRingEquiv
+      (_root_.CommHopfAlgCat.of R H) (reduction R H)).injective
 
 end TauCeti.HopfIdeal

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean
@@ -40,12 +40,7 @@ variable (H : Type v) [CommRing H] [HopfAlgebra R H]
 theorem isReduced_quotient_reduction
     [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] :
     IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of R H) (reduction R H)) := by
-  let _ : IsReduced (H ⧸ (reduction R H).toIdeal) :=
-    (Ideal.isRadical_iff_quotient_reduced (reduction R H).toIdeal).mp (by
-      rw [reduction_toIdeal]
-      exact Ideal.radical_isRadical ⊥)
-  exact isReduced_of_injective
-    (RingEquiv.refl (H ⧸ (reduction R H).toIdeal)).toRingHom
-    (RingEquiv.refl (H ⧸ (reduction R H).toIdeal)).injective
+  rw [CommHopfAlgCat.isReduced_quotient_iff, reduction_toIdeal]
+  exact Ideal.radical_isRadical ⊥
 
 end TauCeti.HopfIdeal

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean
@@ -40,7 +40,7 @@ variable (H : Type v) [CommRing H] [HopfAlgebra R H]
 theorem isReduced_quotient_reduction
     [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] :
     IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of R H) (reduction R H)) := by
-  rw [CommHopfAlgCat.isReduced_quotient_iff, reduction_toIdeal]
+  rw [← Ideal.isRadical_iff_quotient_reduced, reduction_toIdeal]
   exact Ideal.radical_isRadical ⊥
 
 end TauCeti.HopfIdeal

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Ideal.Quotient.Nilpotent
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
+
+/-!
+# The reduced closed subgroup of an affine group
+
+Let `H` be a commutative Hopf algebra over a reduced commutative ring. Its nilradical is
+automatically stable under the counit and antipode. It is stable under comultiplication provided
+the tensor square of the reduced coordinate algebra is reduced: the image of a nilpotent element
+under comultiplication is nilpotent, hence vanishes in that tensor square. This packages the
+nilradical as a Hopf ideal under precisely that hypothesis.
+
+The tensor-square hypothesis is the algebraic condition needed for reduction to commute with the
+product of the underlying affine scheme. It holds, in particular, for finite-type algebras over a
+perfect field once the standard geometric-reducedness theorem is available. Keeping it explicit
+here separates the Hopf-algebra argument from that commutative-algebra input.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.reduction`: the nilradical, packaged as a Hopf ideal.
+* `TauCeti.HopfIdeal.reduction_toIdeal`: its underlying ideal is the nilradical.
+* `TauCeti.HopfIdeal.isReduced_quotient_reduction`: the resulting quotient is reduced.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §11.4.
+* J. S. Milne, *Algebraic Groups* (2017), §1.f.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.HopfIdeal
+
+universe u v
+
+variable (R : Type u) [CommRing R] [IsReduced R]
+variable (H : Type v) [CommRing H] [HopfAlgebra R H]
+
+private theorem nilradical_counit_eq_zero {x : H} (hx : x ∈ nilradical H) :
+    Coalgebra.counit (R := R) x = 0 := by
+  rw [mem_nilradical] at hx
+  exact isNilpotent_iff_eq_zero.mp (hx.map (Bialgebra.counitAlgHom R H))
+
+omit [IsReduced R] in
+private theorem nilradical_antipode_mem {x : H} (hx : x ∈ nilradical H) :
+    HopfAlgebra.antipode R x ∈ nilradical H := by
+  rw [mem_nilradical] at hx ⊢
+  simpa only [HopfAlgebra.antipodeAlgHom_apply] using
+    hx.map (HopfAlgebra.antipodeAlgHom R H)
+
+omit [IsReduced R] in
+private theorem nilradical_comul_mem
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))]
+    {x : H} (hx : x ∈ nilradical H) :
+    Coalgebra.comul (R := R) x ∈
+      leftTensorIdeal (R := R) (H := H) (nilradical H) ⊔
+        rightTensorIdeal (R := R) (H := H) (nilradical H) := by
+  let q : H →ₐ[R] H ⧸ nilradical H := Ideal.Quotient.mkₐ R (nilradical H)
+  have hnil : IsNilpotent (Coalgebra.comul (R := R) x) :=
+    (mem_nilradical.mp hx).map (Bialgebra.comulAlgHom R H)
+  have hzero : Algebra.TensorProduct.map q q (Coalgebra.comul (R := R) x) = 0 :=
+    isNilpotent_iff_eq_zero.mp (hnil.map (Algebra.TensorProduct.map q q))
+  have hker : RingHom.ker (Algebra.TensorProduct.map q q).toRingHom =
+      leftTensorIdeal (R := R) (H := H) (nilradical H) ⊔
+        rightTensorIdeal (R := R) (H := H) (nilradical H) := by
+    have hqker : RingHom.ker (q : H →+* H ⧸ nilradical H) = nilradical H :=
+      Ideal.Quotient.mkₐ_ker R (nilradical H)
+    change RingHom.ker (Algebra.TensorProduct.map q q) =
+      Ideal.map Algebra.TensorProduct.includeLeft.toRingHom (nilradical H) ⊔
+        Ideal.map Algebra.TensorProduct.includeRight.toRingHom (nilradical H)
+    calc
+      RingHom.ker (Algebra.TensorProduct.map q q) =
+          Ideal.map Algebra.TensorProduct.includeLeft
+              (RingHom.ker (q : H →+* H ⧸ nilradical H)) ⊔
+            Ideal.map Algebra.TensorProduct.includeRight
+              (RingHom.ker (q : H →+* H ⧸ nilradical H)) :=
+        Algebra.TensorProduct.map_ker (f := q) (g := q)
+          (Ideal.Quotient.mkₐ_surjective R (nilradical H))
+          (Ideal.Quotient.mkₐ_surjective R (nilradical H))
+      _ = Ideal.map Algebra.TensorProduct.includeLeft.toRingHom (nilradical H) ⊔
+          Ideal.map Algebra.TensorProduct.includeRight.toRingHom (nilradical H) := by
+        rw [hqker]
+        rfl
+  rw [← hker, RingHom.mem_ker]
+  exact hzero
+
+/-- The nilradical of a commutative Hopf algebra, as a Hopf ideal.
+
+The tensor square of the reduced coordinate algebra must be reduced. This is exactly what makes
+the comultiplication descend: a nilpotent element maps to a nilpotent element of that tensor
+square and therefore to zero. -/
+noncomputable def reduction
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] : HopfIdeal R H :=
+  ofIdeal (nilradical H)
+    (fun {x} hx ↦ nilradical_comul_mem R H (x := x) hx)
+    (fun {x} hx ↦ nilradical_counit_eq_zero R H (x := x) hx)
+    (fun {x} hx ↦ nilradical_antipode_mem R H (x := x) hx)
+
+/-- The underlying ideal of the reduction Hopf ideal is the nilradical. -/
+@[simp]
+theorem reduction_toIdeal
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] :
+    (reduction R H).toIdeal = nilradical H := by
+  rw [reduction, toIdeal_carrier, ofIdeal_carrier]
+
+/-- Membership in the reduction Hopf ideal is nilpotence. -/
+@[simp]
+theorem mem_reduction
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] {x : H} :
+    x ∈ reduction R H ↔ IsNilpotent x := by
+  rw [← mem_toIdeal, reduction_toIdeal, mem_nilradical]
+
+/-- The quotient by the reduction Hopf ideal has reduced coordinate ring. -/
+theorem isReduced_quotient_reduction
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] :
+    IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of R H) (reduction R H)) := by
+  change IsReduced (H ⧸ nilradical H)
+  exact (Ideal.isRadical_iff_quotient_reduced (nilradical H)).mp
+    (Ideal.radical_isRadical ⊥)
+
+end TauCeti.HopfIdeal

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Basic.lean
@@ -28,6 +28,8 @@ must satisfy exactly these Hopf-ideal closure conditions.
 * `TauCeti.HopfIdeal`: a Hopf ideal in a Hopf algebra over a commutative semiring.
 * `TauCeti.HopfIdeal.leftTensorIdeal` and `TauCeti.HopfIdeal.rightTensorIdeal`: the two
   summands `I ⊗ H` and `H ⊗ I` inside `H ⊗ H`.
+* `AlgHom.tensor_map_ker_eq_left_sup_right`: the tensor product of two surjective algebra maps
+  has the expected kernel in tensor-ideal notation.
 * `⊥ : HopfIdeal R H`: the zero Hopf ideal.
 * `I ⊔ J : HopfIdeal R H`: the sum of two Hopf ideals.
 * `sSup S : HopfIdeal R H` and `⨆ i, I i : HopfIdeal R H`: arbitrary suprema of Hopf ideals,
@@ -633,3 +635,32 @@ end HopfIdeal
 end Bridge
 
 end TauCeti
+
+namespace AlgHom
+
+variable {R : Type u} {H : Type v}
+variable [CommRing R] [Ring H]
+
+/-- The tensor-kernel exactness theorem in the tensor-ideal notation used by `HopfIdeal`. -/
+theorem tensor_map_ker_eq_left_sup_right [Algebra R H]
+    {A B : Type*} [Ring A] [Ring B] [Algebra R A] [Algebra R B]
+    (f : H →ₐ[R] A) (g : H →ₐ[R] B)
+    (hf : Function.Surjective f) (hg : Function.Surjective g) :
+    RingHom.ker (Algebra.TensorProduct.map f g) =
+      TauCeti.HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) ⊔
+        TauCeti.HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker g) := by
+  have hleft :
+      (RingHom.ker f).map
+          (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) =
+        TauCeti.HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) := by
+    rw [TauCeti.HopfIdeal.leftTensorIdeal_def, AlgHom.toRingHom_eq_coe]
+    exact AlgHom.coe_ideal_map _ _
+  have hright :
+      (RingHom.ker g).map
+          (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
+        TauCeti.HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker g) := by
+    rw [TauCeti.HopfIdeal.rightTensorIdeal_def, AlgHom.toRingHom_eq_coe]
+    exact AlgHom.coe_ideal_map _ _
+  rw [Algebra.TensorProduct.map_ker (f := f) (g := g) hf hg, hleft, hright]
+
+end AlgHom

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Basic.lean
@@ -28,8 +28,8 @@ must satisfy exactly these Hopf-ideal closure conditions.
 * `TauCeti.HopfIdeal`: a Hopf ideal in a Hopf algebra over a commutative semiring.
 * `TauCeti.HopfIdeal.leftTensorIdeal` and `TauCeti.HopfIdeal.rightTensorIdeal`: the two
   summands `I ⊗ H` and `H ⊗ I` inside `H ⊗ H`.
-* `AlgHom.tensor_map_ker_eq_left_sup_right`: the tensor product of two surjective algebra maps
-  has the expected kernel in tensor-ideal notation.
+* `TauCeti.HopfIdeal.ker_tensorProduct_map_eq_leftTensorIdeal_sup_rightTensorIdeal`: the
+  tensor product of two surjective algebra maps has the expected kernel in tensor-ideal notation.
 * `⊥ : HopfIdeal R H`: the zero Hopf ideal.
 * `I ⊔ J : HopfIdeal R H`: the sum of two Hopf ideals.
 * `sSup S : HopfIdeal R H` and `⨆ i, I i : HopfIdeal R H`: arbitrary suprema of Hopf ideals,
@@ -634,33 +634,33 @@ end HopfIdeal
 
 end Bridge
 
-end TauCeti
-
-namespace AlgHom
+namespace HopfIdeal
 
 variable {R : Type u} {H : Type v}
 variable [CommRing R] [Ring H]
 
 /-- The tensor-kernel exactness theorem in the tensor-ideal notation used by `HopfIdeal`. -/
-theorem tensor_map_ker_eq_left_sup_right [Algebra R H]
+theorem ker_tensorProduct_map_eq_leftTensorIdeal_sup_rightTensorIdeal [Algebra R H]
     {A B : Type*} [Ring A] [Ring B] [Algebra R A] [Algebra R B]
     (f : H →ₐ[R] A) (g : H →ₐ[R] B)
     (hf : Function.Surjective f) (hg : Function.Surjective g) :
     RingHom.ker (Algebra.TensorProduct.map f g) =
-      TauCeti.HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) ⊔
-        TauCeti.HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker g) := by
+      leftTensorIdeal (R := R) (H := H) (RingHom.ker f) ⊔
+        rightTensorIdeal (R := R) (H := H) (RingHom.ker g) := by
   have hleft :
       (RingHom.ker f).map
           (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) =
-        TauCeti.HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) := by
-    rw [TauCeti.HopfIdeal.leftTensorIdeal_def, AlgHom.toRingHom_eq_coe]
+        leftTensorIdeal (R := R) (H := H) (RingHom.ker f) := by
+    rw [leftTensorIdeal_def, AlgHom.toRingHom_eq_coe]
     exact AlgHom.coe_ideal_map _ _
   have hright :
       (RingHom.ker g).map
           (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
-        TauCeti.HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker g) := by
-    rw [TauCeti.HopfIdeal.rightTensorIdeal_def, AlgHom.toRingHom_eq_coe]
+        rightTensorIdeal (R := R) (H := H) (RingHom.ker g) := by
+    rw [rightTensorIdeal_def, AlgHom.toRingHom_eq_coe]
     exact AlgHom.coe_ideal_map _ _
   rw [Algebra.TensorProduct.map_ker (f := f) (g := g) hf hg, hleft, hright]
 
-end AlgHom
+end HopfIdeal
+
+end TauCeti

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
@@ -74,7 +74,7 @@ private theorem nilradical_comul_mem
     rw [RingHom.mem_ker]
     exact hzero
   rw [AlgHom.toRingHom_eq_coe, RingHom.ker_coe_toRingHom] at hmem
-  rw [tensor_map_ker_eq_left_sup_right q
+  rw [AlgHom.tensor_map_ker_eq_left_sup_right q
     (Ideal.Quotient.mkₐ_surjective R (nilradical H))] at hmem
   rw [← RingHom.ker_coe_toRingHom q, Ideal.Quotient.mkₐ_ker] at hmem
   exact hmem

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Ideal.Quotient.Nilpotent
+public import TauCeti.Algebra.HopfAlgebra.Kernel
+
+/-!
+# Reduction of commutative Hopf algebras
+
+Let `H` be a commutative Hopf algebra over a reduced commutative ring. Its nilradical is
+automatically stable under the counit and antipode. It is stable under comultiplication provided
+the tensor square of the reduced algebra is reduced: the image of a nilpotent element under
+comultiplication is nilpotent, hence vanishes in that tensor square. This packages the nilradical
+as a Hopf ideal under precisely that hypothesis.
+
+The tensor-square hypothesis is the algebraic condition needed for reduction to commute with a
+product. It holds, in particular, for finite-type algebras over a perfect field once the standard
+geometric-reducedness theorem is available. Keeping it explicit here separates the Hopf-algebra
+argument from that commutative-algebra input.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.reduction`: the nilradical, packaged as a Hopf ideal.
+* `TauCeti.HopfIdeal.reduction_toIdeal`: its underlying ideal is the nilradical.
+* `TauCeti.HopfIdeal.mem_reduction`: membership is nilpotence.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §11.4.
+* J. S. Milne, *Algebraic Groups* (2017), §1.f.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.HopfIdeal
+
+universe u v
+
+variable (R : Type u) [CommRing R] [IsReduced R]
+variable (H : Type v) [CommRing H] [HopfAlgebra R H]
+
+private theorem nilradical_counit_eq_zero {x : H} (hx : x ∈ nilradical H) :
+    Coalgebra.counit (R := R) x = 0 := by
+  rw [mem_nilradical] at hx
+  exact isNilpotent_iff_eq_zero.mp (hx.map (Bialgebra.counitAlgHom R H))
+
+omit [IsReduced R] in
+private theorem nilradical_antipode_mem {x : H} (hx : x ∈ nilradical H) :
+    HopfAlgebra.antipode R x ∈ nilradical H := by
+  rw [mem_nilradical] at hx ⊢
+  simpa only [HopfAlgebra.antipodeAlgHom_apply] using
+    hx.map (HopfAlgebra.antipodeAlgHom R H)
+
+omit [IsReduced R] in
+private theorem nilradical_comul_mem
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))]
+    {x : H} (hx : x ∈ nilradical H) :
+    Coalgebra.comul (R := R) x ∈
+      leftTensorIdeal (R := R) (H := H) (nilradical H) ⊔
+        rightTensorIdeal (R := R) (H := H) (nilradical H) := by
+  let q : H →ₐ[R] H ⧸ nilradical H := Ideal.Quotient.mkₐ R (nilradical H)
+  have hnil : IsNilpotent (Coalgebra.comul (R := R) x) :=
+    (mem_nilradical.mp hx).map (Bialgebra.comulAlgHom R H)
+  have hzero : Algebra.TensorProduct.map q q (Coalgebra.comul (R := R) x) = 0 :=
+    isNilpotent_iff_eq_zero.mp (hnil.map (Algebra.TensorProduct.map q q))
+  have hmem : Coalgebra.comul (R := R) x ∈
+      RingHom.ker (Algebra.TensorProduct.map q q).toRingHom := by
+    rw [RingHom.mem_ker]
+    exact hzero
+  rw [AlgHom.toRingHom_eq_coe, RingHom.ker_coe_toRingHom] at hmem
+  rw [tensor_map_ker_eq_left_sup_right q
+    (Ideal.Quotient.mkₐ_surjective R (nilradical H))] at hmem
+  rw [← RingHom.ker_coe_toRingHom q, Ideal.Quotient.mkₐ_ker] at hmem
+  exact hmem
+
+/-- The nilradical of a commutative Hopf algebra, as a Hopf ideal.
+
+The tensor square of the reduced algebra must be reduced. This is exactly what makes the
+comultiplication descend: a nilpotent element maps to a nilpotent element of that tensor square
+and therefore to zero. -/
+noncomputable def reduction
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] : HopfIdeal R H :=
+  ofIdeal (nilradical H)
+    (fun {x} hx ↦ nilradical_comul_mem R H (x := x) hx)
+    (fun {x} hx ↦ nilradical_counit_eq_zero R H (x := x) hx)
+    (fun {x} hx ↦ nilradical_antipode_mem R H (x := x) hx)
+
+/-- The underlying ideal of the reduction Hopf ideal is the nilradical. -/
+@[simp]
+theorem reduction_toIdeal
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] :
+    (reduction R H).toIdeal = nilradical H := by
+  rw [reduction, toIdeal_carrier, ofIdeal_carrier]
+
+/-- Membership in the reduction Hopf ideal is nilpotence. -/
+@[simp]
+theorem mem_reduction
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] {x : H} :
+    x ∈ reduction R H ↔ IsNilpotent x := by
+  rw [← mem_toIdeal, reduction_toIdeal, mem_nilradical]
+
+end TauCeti.HopfIdeal

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
@@ -6,7 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.Ideal.Quotient.Nilpotent
-public import TauCeti.Algebra.HopfAlgebra.Kernel
+public import Mathlib.RingTheory.Noetherian.Nilpotent
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Basic
 
 /-!
 # Reduction of commutative Hopf algebras
@@ -29,6 +30,8 @@ Hopf-algebra argument from that commutative-algebra input.
 * `TauCeti.HopfIdeal.mem_reduction`: membership is nilpotence.
 * `TauCeti.HopfIdeal.reduction_le_of_isReduced_quotient`: its minimality among Hopf ideals with
   reduced quotient.
+* `TauCeti.HopfIdeal.isNilpotent_reduction_toIdeal`: over a Noetherian algebra, the reduction
+  ideal is nilpotent.
 
 ## References
 
@@ -115,5 +118,13 @@ theorem reduction_le_of_isReduced_quotient
   rw [← toIdeal_le_toIdeal, reduction_toIdeal, nilradical]
   exact ((Ideal.isRadical_iff_quotient_reduced I.toIdeal).mpr inferInstance).radical_le_iff.mpr
     bot_le
+
+/-- Over a Noetherian commutative Hopf algebra, the ideal removed to form the reduction is
+nilpotent. -/
+theorem isNilpotent_reduction_toIdeal
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))]
+    [IsNoetherianRing H] : IsNilpotent (reduction R H).toIdeal := by
+  rw [reduction_toIdeal]
+  exact IsNoetherianRing.isNilpotent_nilradical H
 
 end TauCeti.HopfIdeal

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.Ideal.Quotient.Nilpotent
-public import Mathlib.RingTheory.Noetherian.Nilpotent
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Basic
 
 /-!
@@ -30,8 +29,6 @@ Hopf-algebra argument from that commutative-algebra input.
 * `TauCeti.HopfIdeal.mem_reduction`: membership is nilpotence.
 * `TauCeti.HopfIdeal.reduction_le_of_isReduced_quotient`: its minimality among Hopf ideals with
   reduced quotient.
-* `TauCeti.HopfIdeal.isNilpotent_reduction_toIdeal`: over a Noetherian algebra, the reduction
-  ideal is nilpotent.
 
 ## References
 
@@ -118,13 +115,5 @@ theorem reduction_le_of_isReduced_quotient
   rw [← toIdeal_le_toIdeal, reduction_toIdeal, nilradical]
   exact ((Ideal.isRadical_iff_quotient_reduced I.toIdeal).mpr inferInstance).radical_le_iff.mpr
     bot_le
-
-/-- Over a Noetherian commutative Hopf algebra, the ideal removed to form the reduction is
-nilpotent. -/
-theorem isNilpotent_reduction_toIdeal
-    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))]
-    [IsNoetherianRing H] : IsNilpotent (reduction R H).toIdeal := by
-  rw [reduction_toIdeal]
-  exact IsNoetherianRing.isNilpotent_nilradical H
 
 end TauCeti.HopfIdeal

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
@@ -79,7 +79,7 @@ private theorem nilradical_comul_mem
         rightTensorIdeal (R := R) (H := H) (nilradical H) := by
     have hqker : RingHom.ker q = nilradical H := Ideal.Quotient.mkₐ_ker R (nilradical H)
     simpa only [AlgHom.ker_coe, AlgHom.toRingHom_eq_coe, hqker] using
-        AlgHom.tensor_map_ker_eq_left_sup_right q q
+        HopfIdeal.ker_tensorProduct_map_eq_leftTensorIdeal_sup_rightTensorIdeal q q
           (Ideal.Quotient.mkₐ_surjective R (nilradical H))
           (Ideal.Quotient.mkₐ_surjective R (nilradical H))
   rw [← hker, RingHom.mem_ker]

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Reduction.lean
@@ -14,19 +14,21 @@ public import TauCeti.Algebra.HopfAlgebra.Kernel
 Let `H` be a commutative Hopf algebra over a reduced commutative ring. Its nilradical is
 automatically stable under the counit and antipode. It is stable under comultiplication provided
 the tensor square of the reduced algebra is reduced: the image of a nilpotent element under
-comultiplication is nilpotent, hence vanishes in that tensor square. This packages the nilradical
-as a Hopf ideal under precisely that hypothesis.
+comultiplication is nilpotent, hence vanishes in that tensor square. Thus reducedness of this
+tensor square is a sufficient hypothesis for packaging the nilradical as a Hopf ideal.
 
-The tensor-square hypothesis is the algebraic condition needed for reduction to commute with a
-product. It holds, in particular, for finite-type algebras over a perfect field once the standard
-geometric-reducedness theorem is available. Keeping it explicit here separates the Hopf-algebra
-argument from that commutative-algebra input.
+The tensor-square hypothesis ensures that reduction commutes with the product used by the
+comultiplication. It holds, in particular, for finite-type algebras over a perfect field once the
+standard geometric-reducedness theorem is available. Keeping it explicit here separates the
+Hopf-algebra argument from that commutative-algebra input.
 
 ## Main declarations
 
 * `TauCeti.HopfIdeal.reduction`: the nilradical, packaged as a Hopf ideal.
 * `TauCeti.HopfIdeal.reduction_toIdeal`: its underlying ideal is the nilradical.
 * `TauCeti.HopfIdeal.mem_reduction`: membership is nilpotence.
+* `TauCeti.HopfIdeal.reduction_le_of_isReduced_quotient`: its minimality among Hopf ideals with
+  reduced quotient.
 
 ## References
 
@@ -69,21 +71,21 @@ private theorem nilradical_comul_mem
     (mem_nilradical.mp hx).map (Bialgebra.comulAlgHom R H)
   have hzero : Algebra.TensorProduct.map q q (Coalgebra.comul (R := R) x) = 0 :=
     isNilpotent_iff_eq_zero.mp (hnil.map (Algebra.TensorProduct.map q q))
-  have hmem : Coalgebra.comul (R := R) x ∈
-      RingHom.ker (Algebra.TensorProduct.map q q).toRingHom := by
-    rw [RingHom.mem_ker]
-    exact hzero
-  rw [AlgHom.toRingHom_eq_coe, RingHom.ker_coe_toRingHom] at hmem
-  rw [AlgHom.tensor_map_ker_eq_left_sup_right q
-    (Ideal.Quotient.mkₐ_surjective R (nilradical H))] at hmem
-  rw [← RingHom.ker_coe_toRingHom q, Ideal.Quotient.mkₐ_ker] at hmem
-  exact hmem
+  have hker : RingHom.ker (Algebra.TensorProduct.map q q).toRingHom =
+      leftTensorIdeal (R := R) (H := H) (nilradical H) ⊔
+        rightTensorIdeal (R := R) (H := H) (nilradical H) := by
+    have hqker : RingHom.ker q = nilradical H := Ideal.Quotient.mkₐ_ker R (nilradical H)
+    simpa only [AlgHom.ker_coe, AlgHom.toRingHom_eq_coe, hqker] using
+        AlgHom.tensor_map_ker_eq_left_sup_right q q
+          (Ideal.Quotient.mkₐ_surjective R (nilradical H))
+          (Ideal.Quotient.mkₐ_surjective R (nilradical H))
+  rw [← hker, RingHom.mem_ker]
+  exact hzero
 
 /-- The nilradical of a commutative Hopf algebra, as a Hopf ideal.
 
-The tensor square of the reduced algebra must be reduced. This is exactly what makes the
-comultiplication descend: a nilpotent element maps to a nilpotent element of that tensor square
-and therefore to zero. -/
+Assuming the tensor square of the reduced algebra is reduced, the comultiplication descends: a
+nilpotent element maps to a nilpotent element of that tensor square and therefore to zero. -/
 noncomputable def reduction
     [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] : HopfIdeal R H :=
   ofIdeal (nilradical H)
@@ -104,5 +106,14 @@ theorem mem_reduction
     [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))] {x : H} :
     x ∈ reduction R H ↔ IsNilpotent x := by
   rw [← mem_toIdeal, reduction_toIdeal, mem_nilradical]
+
+/-- The reduction is contained in every Hopf ideal whose quotient is reduced. -/
+theorem reduction_le_of_isReduced_quotient
+    [IsReduced ((H ⧸ nilradical H) ⊗[R] (H ⧸ nilradical H))]
+    (I : HopfIdeal R H) [IsReduced (H ⧸ I.toIdeal)] :
+    reduction R H ≤ I := by
+  rw [← toIdeal_le_toIdeal, reduction_toIdeal, nilradical]
+  exact ((Ideal.isRadical_iff_quotient_reduced I.toIdeal).mpr inferInstance).radical_le_iff.mpr
+    bot_le
 
 end TauCeti.HopfIdeal

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -41,7 +41,7 @@ dictionary.
   by the kernel to the codomain.
 * `TauCeti.HopfIdeal.kerOfSurjective_mkBialgHom`: the kernel of the quotient morphism by `I`
   is `I`.
-* `TauCeti.AlgHom.tensor_map_ker_eq_left_sup_right`: the tensor square of a surjective
+* `AlgHom.tensor_map_ker_eq_left_sup_right`: the tensor square of a surjective
   algebra map has the expected kernel in tensor-ideal notation.
 * `TauCeti.HopfIdeal.ker_lTensor_eq_rightTensorIdeal`: tensoring on the left by a flat algebra
   carries the kernel of an algebra map to the corresponding right tensor ideal.
@@ -56,8 +56,6 @@ public section
 
 open scoped TensorProduct
 
-namespace TauCeti
-
 universe u v w x
 
 namespace AlgHom
@@ -70,10 +68,10 @@ theorem tensor_map_ker_eq_left_sup_right [Algebra R H] {A : Type*} [Ring A] [Alg
     (f : H →ₐ[R] A)
     (hf : Function.Surjective f) :
     RingHom.ker (Algebra.TensorProduct.map f f) =
-      HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) ⊔
-        HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker f) := by
+      TauCeti.HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) ⊔
+        TauCeti.HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker f) := by
   rw [Algebra.TensorProduct.map_ker (f := f) (g := f) hf hf,
-    HopfIdeal.leftTensorIdeal_def, HopfIdeal.rightTensorIdeal_def]
+    TauCeti.HopfIdeal.leftTensorIdeal_def, TauCeti.HopfIdeal.rightTensorIdeal_def]
   simp only [AlgHom.toRingHom_eq_coe]
   -- `map_ker` states the two maps via algebra-hom coercions, while `leftTensorIdeal_def`
   -- and `rightTensorIdeal_def` use their `toRingHom`; after the named coercion rewrite
@@ -81,6 +79,8 @@ theorem tensor_map_ker_eq_left_sup_right [Algebra R H] {A : Type*} [Ring A] [Alg
   apply congr_arg₂ (· ⊔ ·) <;> rfl
 
 end AlgHom
+
+namespace TauCeti
 
 namespace HopfIdeal
 

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -41,7 +41,7 @@ dictionary.
   by the kernel to the codomain.
 * `TauCeti.HopfIdeal.kerOfSurjective_mkBialgHom`: the kernel of the quotient morphism by `I`
   is `I`.
-* `TauCeti.HopfIdeal.tensor_map_ker_eq_left_sup_right`: the tensor square of a surjective
+* `TauCeti.AlgHom.tensor_map_ker_eq_left_sup_right`: the tensor square of a surjective
   algebra map has the expected kernel in tensor-ideal notation.
 * `TauCeti.HopfIdeal.ker_lTensor_eq_rightTensorIdeal`: tensoring on the left by a flat algebra
   carries the kernel of an algebra map to the corresponding right tensor ideal.
@@ -60,25 +60,32 @@ namespace TauCeti
 
 universe u v w x
 
-namespace HopfIdeal
+namespace AlgHom
 
-variable {R : Type u} {H : Type v} {K : Type w}
-variable [CommRing R] [Ring H] [Ring K]
+variable {R : Type u} {H : Type v}
+variable [CommRing R] [Ring H]
 
 /-- The tensor-kernel exactness theorem in the tensor-ideal notation used by `HopfIdeal`. -/
 theorem tensor_map_ker_eq_left_sup_right [Algebra R H] {A : Type*} [Ring A] [Algebra R A]
     (f : H →ₐ[R] A)
     (hf : Function.Surjective f) :
     RingHom.ker (Algebra.TensorProduct.map f f) =
-      leftTensorIdeal (R := R) (H := H) (RingHom.ker f) ⊔
-        rightTensorIdeal (R := R) (H := H) (RingHom.ker f) := by
+      HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) ⊔
+        HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker f) := by
   rw [Algebra.TensorProduct.map_ker (f := f) (g := f) hf hf,
-    leftTensorIdeal_def, rightTensorIdeal_def]
+    HopfIdeal.leftTensorIdeal_def, HopfIdeal.rightTensorIdeal_def]
   simp only [AlgHom.toRingHom_eq_coe]
   -- `map_ker` states the two maps via algebra-hom coercions, while `leftTensorIdeal_def`
   -- and `rightTensorIdeal_def` use their `toRingHom`; after the named coercion rewrite
   -- these are the same ideal maps definitionally.
   apply congr_arg₂ (· ⊔ ·) <;> rfl
+
+end AlgHom
+
+namespace HopfIdeal
+
+variable {R : Type u} {H : Type v} {K : Type w}
+variable [CommRing R] [Ring H] [Ring K]
 
 /-- Tensoring on the left by a flat algebra carries the kernel of an algebra map to the
 corresponding right tensor ideal. -/
@@ -196,7 +203,7 @@ def kerOfSurjective (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdea
     have hker' : Coalgebra.comul (R := R) x ∈
         RingHom.ker (Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K)) := by
       simpa using hker
-    rwa [tensor_map_ker_eq_left_sup_right (R := R) (f : H →ₐ[R] K) hf] at hker')
+    rwa [AlgHom.tensor_map_ker_eq_left_sup_right (R := R) (f : H →ₐ[R] K) hf] at hker')
 
 /-- The underlying ideal of the kernel Hopf ideal is the ring-hom kernel. -/
 @[simp]
@@ -267,7 +274,8 @@ private theorem comul_mem_left_sup_right_of_mem_ker (f : H →ₐc[k] K) {x : H}
   have hker : RingHom.ker (Algebra.TensorProduct.map q q).toRingHom =
       leftTensorIdeal (R := k) (H := H) I ⊔ rightTensorIdeal (R := k) (H := H) I := by
     simpa only [q, AlgHom.ker_coe, AlgHom.toRingHom_eq_coe, Ideal.Quotient.mkₐ_ker] using
-      tensor_map_ker_eq_left_sup_right (R := k) q (Ideal.Quotient.mkₐ_surjective k I)
+      AlgHom.tensor_map_ker_eq_left_sup_right (R := k) q
+        (Ideal.Quotient.mkₐ_surjective k I)
   rw [← hker, RingHom.mem_ker]
   exact hqzero
 

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -41,6 +41,8 @@ dictionary.
   by the kernel to the codomain.
 * `TauCeti.HopfIdeal.kerOfSurjective_mkBialgHom`: the kernel of the quotient morphism by `I`
   is `I`.
+* `TauCeti.HopfIdeal.tensor_map_ker_eq_left_sup_right`: the tensor square of a surjective
+  algebra map has the expected kernel in tensor-ideal notation.
 * `TauCeti.HopfIdeal.ker_lTensor_eq_rightTensorIdeal`: tensoring on the left by a flat algebra
   carries the kernel of an algebra map to the corresponding right tensor ideal.
 
@@ -64,7 +66,7 @@ variable {R : Type u} {H : Type v} {K : Type w}
 variable [CommRing R] [Ring H] [Ring K]
 
 /-- The tensor-kernel exactness theorem in the tensor-ideal notation used by `HopfIdeal`. -/
-private theorem tensor_map_ker_eq_left_sup_right [Algebra R H] {A : Type*} [Ring A] [Algebra R A]
+theorem tensor_map_ker_eq_left_sup_right [Algebra R H] {A : Type*} [Ring A] [Algebra R A]
     (f : H →ₐ[R] A)
     (hf : Function.Surjective f) :
     RingHom.ker (Algebra.TensorProduct.map f f) =

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -41,8 +41,8 @@ dictionary.
   by the kernel to the codomain.
 * `TauCeti.HopfIdeal.kerOfSurjective_mkBialgHom`: the kernel of the quotient morphism by `I`
   is `I`.
-* `AlgHom.tensor_map_ker_eq_left_sup_right`: the tensor square of a surjective
-  algebra map has the expected kernel in tensor-ideal notation.
+* `AlgHom.tensor_map_ker_eq_left_sup_right`: the tensor product of two surjective
+  algebra maps has the expected kernel in tensor-ideal notation.
 * `TauCeti.HopfIdeal.ker_lTensor_eq_rightTensorIdeal`: tensoring on the left by a flat algebra
   carries the kernel of an algebra map to the corresponding right tensor ideal.
 
@@ -64,19 +64,26 @@ variable {R : Type u} {H : Type v}
 variable [CommRing R] [Ring H]
 
 /-- The tensor-kernel exactness theorem in the tensor-ideal notation used by `HopfIdeal`. -/
-theorem tensor_map_ker_eq_left_sup_right [Algebra R H] {A : Type*} [Ring A] [Algebra R A]
-    (f : H →ₐ[R] A)
-    (hf : Function.Surjective f) :
-    RingHom.ker (Algebra.TensorProduct.map f f) =
+theorem tensor_map_ker_eq_left_sup_right [Algebra R H]
+    {A B : Type*} [Ring A] [Ring B] [Algebra R A] [Algebra R B]
+    (f : H →ₐ[R] A) (g : H →ₐ[R] B)
+    (hf : Function.Surjective f) (hg : Function.Surjective g) :
+    RingHom.ker (Algebra.TensorProduct.map f g) =
       TauCeti.HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) ⊔
-        TauCeti.HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker f) := by
-  rw [Algebra.TensorProduct.map_ker (f := f) (g := f) hf hf,
-    TauCeti.HopfIdeal.leftTensorIdeal_def, TauCeti.HopfIdeal.rightTensorIdeal_def]
-  simp only [AlgHom.toRingHom_eq_coe]
-  -- `map_ker` states the two maps via algebra-hom coercions, while `leftTensorIdeal_def`
-  -- and `rightTensorIdeal_def` use their `toRingHom`; after the named coercion rewrite
-  -- these are the same ideal maps definitionally.
-  apply congr_arg₂ (· ⊔ ·) <;> rfl
+        TauCeti.HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker g) := by
+  have hleft :
+      (RingHom.ker f).map
+          (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) =
+        TauCeti.HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) := by
+    rw [TauCeti.HopfIdeal.leftTensorIdeal_def, AlgHom.toRingHom_eq_coe]
+    exact AlgHom.coe_ideal_map _ _
+  have hright :
+      (RingHom.ker g).map
+          (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
+        TauCeti.HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker g) := by
+    rw [TauCeti.HopfIdeal.rightTensorIdeal_def, AlgHom.toRingHom_eq_coe]
+    exact AlgHom.coe_ideal_map _ _
+  rw [Algebra.TensorProduct.map_ker (f := f) (g := g) hf hg, hleft, hright]
 
 end AlgHom
 
@@ -203,7 +210,8 @@ def kerOfSurjective (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdea
     have hker' : Coalgebra.comul (R := R) x ∈
         RingHom.ker (Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K)) := by
       simpa using hker
-    rwa [AlgHom.tensor_map_ker_eq_left_sup_right (R := R) (f : H →ₐ[R] K) hf] at hker')
+    rwa [AlgHom.tensor_map_ker_eq_left_sup_right (R := R)
+      (f : H →ₐ[R] K) (f : H →ₐ[R] K) hf hf] at hker')
 
 /-- The underlying ideal of the kernel Hopf ideal is the ring-hom kernel. -/
 @[simp]
@@ -274,8 +282,8 @@ private theorem comul_mem_left_sup_right_of_mem_ker (f : H →ₐc[k] K) {x : H}
   have hker : RingHom.ker (Algebra.TensorProduct.map q q).toRingHom =
       leftTensorIdeal (R := k) (H := H) I ⊔ rightTensorIdeal (R := k) (H := H) I := by
     simpa only [q, AlgHom.ker_coe, AlgHom.toRingHom_eq_coe, Ideal.Quotient.mkₐ_ker] using
-      AlgHom.tensor_map_ker_eq_left_sup_right (R := k) q
-        (Ideal.Quotient.mkₐ_surjective k I)
+      AlgHom.tensor_map_ker_eq_left_sup_right (R := k) q q
+        (Ideal.Quotient.mkₐ_surjective k I) (Ideal.Quotient.mkₐ_surjective k I)
   rw [← hker, RingHom.mem_ker]
   exact hqzero
 

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -178,7 +178,7 @@ def kerOfSurjective (f : H →ₐc[R] K) (hf : Function.Surjective f) : HopfIdea
     have hker' : Coalgebra.comul (R := R) x ∈
         RingHom.ker (Algebra.TensorProduct.map (f : H →ₐ[R] K) (f : H →ₐ[R] K)) := by
       simpa using hker
-    rwa [AlgHom.tensor_map_ker_eq_left_sup_right (R := R)
+    rwa [HopfIdeal.ker_tensorProduct_map_eq_leftTensorIdeal_sup_rightTensorIdeal (R := R)
       (f : H →ₐ[R] K) (f : H →ₐ[R] K) hf hf] at hker')
 
 /-- The underlying ideal of the kernel Hopf ideal is the ring-hom kernel. -/
@@ -250,7 +250,7 @@ private theorem comul_mem_left_sup_right_of_mem_ker (f : H →ₐc[k] K) {x : H}
   have hker : RingHom.ker (Algebra.TensorProduct.map q q).toRingHom =
       leftTensorIdeal (R := k) (H := H) I ⊔ rightTensorIdeal (R := k) (H := H) I := by
     simpa only [q, AlgHom.ker_coe, AlgHom.toRingHom_eq_coe, Ideal.Quotient.mkₐ_ker] using
-      AlgHom.tensor_map_ker_eq_left_sup_right (R := k) q q
+      HopfIdeal.ker_tensorProduct_map_eq_leftTensorIdeal_sup_rightTensorIdeal (R := k) q q
         (Ideal.Quotient.mkₐ_surjective k I) (Ideal.Quotient.mkₐ_surjective k I)
   rw [← hker, RingHom.mem_ker]
   exact hqzero

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.Basis.VectorSpace
-public import Mathlib.LinearAlgebra.TensorProduct.RightExactness
 public import Mathlib.RingTheory.Flat.Equalizer
 public import TauCeti.Algebra.Bialgebra.Quotient
 public import TauCeti.Algebra.HopfAlgebra.Basic
@@ -41,8 +40,6 @@ dictionary.
   by the kernel to the codomain.
 * `TauCeti.HopfIdeal.kerOfSurjective_mkBialgHom`: the kernel of the quotient morphism by `I`
   is `I`.
-* `AlgHom.tensor_map_ker_eq_left_sup_right`: the tensor product of two surjective
-  algebra maps has the expected kernel in tensor-ideal notation.
 * `TauCeti.HopfIdeal.ker_lTensor_eq_rightTensorIdeal`: tensoring on the left by a flat algebra
   carries the kernel of an algebra map to the corresponding right tensor ideal.
 
@@ -57,35 +54,6 @@ public section
 open scoped TensorProduct
 
 universe u v w x
-
-namespace AlgHom
-
-variable {R : Type u} {H : Type v}
-variable [CommRing R] [Ring H]
-
-/-- The tensor-kernel exactness theorem in the tensor-ideal notation used by `HopfIdeal`. -/
-theorem tensor_map_ker_eq_left_sup_right [Algebra R H]
-    {A B : Type*} [Ring A] [Ring B] [Algebra R A] [Algebra R B]
-    (f : H →ₐ[R] A) (g : H →ₐ[R] B)
-    (hf : Function.Surjective f) (hg : Function.Surjective g) :
-    RingHom.ker (Algebra.TensorProduct.map f g) =
-      TauCeti.HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) ⊔
-        TauCeti.HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker g) := by
-  have hleft :
-      (RingHom.ker f).map
-          (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) =
-        TauCeti.HopfIdeal.leftTensorIdeal (R := R) (H := H) (RingHom.ker f) := by
-    rw [TauCeti.HopfIdeal.leftTensorIdeal_def, AlgHom.toRingHom_eq_coe]
-    exact AlgHom.coe_ideal_map _ _
-  have hright :
-      (RingHom.ker g).map
-          (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
-        TauCeti.HopfIdeal.rightTensorIdeal (R := R) (H := H) (RingHom.ker g) := by
-    rw [TauCeti.HopfIdeal.rightTensorIdeal_def, AlgHom.toRingHom_eq_coe]
-    exact AlgHom.coe_ideal_map _ _
-  rw [Algebra.TensorProduct.map_ker (f := f) (g := g) hf hg, hleft, hright]
-
-end AlgHom
 
 namespace TauCeti
 


### PR DESCRIPTION
This PR packages the nilradical of a commutative Hopf algebra over a reduced base as a Hopf ideal under the exact hypothesis that the tensor square of the reduced quotient is reduced. The proof sends nilpotents through the counit, antipode, and comultiplication; in the last case, reducedness of the quotient tensor square turns the mapped nilpotent into zero, and the tensor-product kernel formula identifies the required sum of tensor ideals.

It then constructs the reduced center in both forms needed downstream: as the iterated quotient of the center by its nilradical, and as the single ambient Hopf ideal whose underlying ideal is the radical of `centerDefiningIdeal`. The canonical quotient isomorphism identifies those models. The resulting coordinate algebra is reduced, is smooth in finite type over an algebraically closed field, and the discarded finite-type thickening is nilpotent.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone **“Reductive and semisimple groups”**, specifically the requirement to develop the center `Z(G)` and prove the finite-center input for adjoint forms and central isogenies. This is the next critical-path prerequisite because `semisimpleCommHopfAlgProperty.eq_augmentation_of_isCentral` already trivializes a smooth geometrically connected central subgroup, while `moduleFinite_of_identityComponentHopfIdeal_eq_augmentation` already converts a trivial identity component into finiteness; both need the reduced center constructed here before they can be composed.

After this PR, the finite-center step still needs the commutative-algebra result that a finite-type reduced algebra over the relevant perfect/algebraically closed field has reduced tensor square, geometric connectedness of the reduced center's identity component, and the final finite-module lift across its nilpotent thickening.

The change adds `TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Reduction.lean` (130 lines) and `TauCeti/Algebra/AlgebraicGroup/Center/Reduced.lean` (175 lines). It reuses Mathlib's nilradical, radical quotient, Noetherian nilpotence, and tensor-product kernel results, together with Tau Ceti's Hopf-ideal quotient/comap API and algebraically-closed smoothness criterion; no upstream implementation is duplicated.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"reduced-center-hopf-ideal"}-->

🤖 Prepared with Codex
