### PR TITLE
feat: compose twisted slash sums with multiplicity

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
@@ -13,10 +13,10 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Independen
 # The composite of two nebentypus-twisted slash sums
 
 `HeckeSlash/Composition.lean` computes the composite of two *unweighted* slash sums. This file is
-the weighted counterpart. It first treats a product supported on one double coset, then proves the
-general multiplicity-weighted formula by partitioning all products according to the double coset
-they meet. The statements are bundled both for functions and as endomorphisms of the character
-space.
+the weighted counterpart. It first proves the general multiplicity-weighted formula, by
+partitioning all products according to the double coset they meet, and then specialises to a
+product supported on a single double coset. The statements are bundled both for functions and as
+endomorphisms of the character space.
 
 ⚠ The multiplicity in the general formula is
 `m(D₂⁻¹, D₁⁻¹; D⁻¹)`, because the slash sum uses right cosets whereas the Hecke-ring structure

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
@@ -12,27 +12,19 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Independen
 /-!
 # The composite of two nebentypus-twisted slash sums
 
-`HeckeSlash/Composition.lean` computes the composite of two *unweighted* slash sums, first over the
-representatives they are defined with and then over free families, and collapses it onto a single
-double coset. This file is the weighted counterpart of that development, up to and including the
-operator statement: for a single pair of double cosets whose product set is a third, the twisted
-operators of `D₁` and `D₂` compose to the operator of `D₃` on the character space. It then reads
-that operator statement at the ring level, on basis elements, through the extension of
-`Nebentypus/CharRing.lean`.
+`HeckeSlash/Composition.lean` computes the composite of two *unweighted* slash sums. This file is
+the weighted counterpart. It first treats a product supported on one double coset, then proves the
+general multiplicity-weighted formula by partitioning all products according to the double coset
+they meet. The statements are bundled both for functions and as endomorphisms of the character
+space.
 
-⚠ That is a *generator-level* statement, and it is **not** the multiplicativity
-`HeckeSlash/Nebentypus/Ring.lean` records as missing. That gap is about
-`twistedHeckeSlashRingLinearMap : 𝕋 … →ₗ[ℤ] Module.End ℂ (ℍ → ℂ)`, over arbitrary elements of the
-Hecke ring and on all of `ℍ → ℂ`; this file proves only the single-double-coset case, only on
-`functionCharSpace k χ`, and only under the per-triple hypotheses `hD₃` and `hinj₃`. That map is
-untouched here and remains merely `ℤ`-linear. As in the untwisted file, the general
-multiplicity-weighted composite `∑_D m(D₁, D₂; D) · T_D` — and with it the ring homomorphism
-`𝕋 → Module.End` — is not proved here. Its two counting ingredients are now available:
-`DoubleCoset.card_pairs_mem_rightCoset_eq_multiplicity` is the left/right handedness
-reconciliation that `DoubleCoset.multiplicity` requires, and
-`DoubleCoset.card_pairs_mem_rightCoset_congr` the count that each right coset of a fixed `D` is
-hit by the same number of pairs. What is missing is the assembly, together with the twisted
-weights it has to carry.
+⚠ The multiplicity in the general formula is
+`m(D₂⁻¹, D₁⁻¹; D⁻¹)`, because the slash sum uses right cosets whereas the Hecke-ring structure
+constants use left cosets. Consequently the formula is not by itself a ring homomorphism from the
+existing Hecke ring: identifying this right-coset coefficient with the relevant structure
+constant is a further step. Nor can the unrestricted `twistedHeckeSlashRingLinearMap` on all of
+`ℍ → ℂ` be multiplicative, since the composition identity requires the input to lie in
+`functionCharSpace k χ`.
 
 ## Why the weights multiply, and why that is the whole point
 
@@ -71,6 +63,10 @@ This file introduces no definitions; the extension it reads the composition theo
   representatives on the right, the weights riding along unchanged.
 * `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum`: the composite of two twisted sums, as
   a double sum over products of representatives weighted by the character of the product.
+* `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_nsmul`: the general composite,
+  grouped by output double coset and weighted by Shimura's multiplicity.
+* `HeckeRing.GL2.twistedHeckeSlashSumCharEnd_mul_eq_sum_nsmul`: the same formula bundled on the
+  character space.
 * `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_of_rightCosets`: the same
   composite over *any* families of representatives of the right cosets.
 * `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum`: the collapse
@@ -117,11 +113,17 @@ multiplies by composition, so `D₁` acts first — exactly as the untwisted
 `heckeSlashGamma1ModularFormEnd_mul_of_doubleCoset_eq_mul` does, and the hypothesis has nothing
 left to do.
 
+The multiplicity-weighted theorem corresponds to AINTLIB's
+`twistedHeckeSlashGen_comp_eq_m_sum` in the same file. Its proof is not transcribed: AINTLIB
+builds a separate left-coset fibre and correction-map apparatus, while the proof here combines
+the existing right-coset `pairCoset` count from `HeckeSlash/Composition.lean` with the uniformly
+repeating weighted-family theorem from `Nebentypus/Independence.lean`.
+
 ⚠ Not adapted, so that the source line numbers are not read as a wider claim:
 `twisted_weighted_slash_product_eq` (`:494`) is a per-pair step that carries a summand into a third
 double coset under an assumed twisted invariance of `f`; the route here goes through
-representative-independence instead. The source's fibre block (`:629`, `:661`, `:710`) is not
-adapted either — that bookkeeping is already on main, untwisted and more general, in
+representative-independence instead. The source's correction-map fibre block (`:629`, `:661`,
+`:710`) is not adapted either — its bookkeeping is already available untwisted and more generally in
 `HeckeSlash/Composition.lean` with the `HeckeRing/Multiplicity` module.
 
 ## References
@@ -197,6 +199,63 @@ theorem twistedHeckeSlashSum_twistedHeckeSlashSum (f : ℍ → ℂ) :
     map_mul, Units.val_mul, mul_comm]
 
 end Composite
+
+section Assembly
+
+variable
+  (D₁ D₂ : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)))
+
+open Classical in
+/-- **The multiplicity-weighted composite of two twisted slash sums.** On a `χ`-eigenfunction,
+the composite is the sum over the double cosets met by products of representatives, with each
+twisted slash sum scaled by the common number of times its right cosets occur:
+
+`T_{D₂}(T_{D₁} f) = ∑_D m(D₂⁻¹, D₁⁻¹; D⁻¹) • T_D f`.
+
+The reversed and inverted arguments are forced by the right-coset convention of the slash sum:
+inversion turns its collision count into the left-coset count defining
+`DoubleCoset.multiplicity`. This is the weighted counterpart of
+`heckeSlashSum_heckeSlashSum_eq_sum_nsmul`; the character weight is constant on each right coset
+only after it is paired with the slash, by `smul_slash_eq_of_rightCoset_eq`. -/
+theorem twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_nsmul
+    (f : ℍ → ℂ) (hf : f ∈ functionCharSpace k χ) :
+    twistedHeckeSlashSum k χ D₂ (twistedHeckeSlashSum k χ D₁ f) =
+      ∑ D ∈ Finset.univ.image (pairCoset D₁ D₂),
+        DoubleCoset.multiplicity ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
+          ((Gamma0 N).map (mapGL ℚ)) (D₂.out : GL (Fin 2) ℚ)⁻¹
+          (D₁.out : GL (Fin 2) ℚ)⁻¹ (D.out : GL (Fin 2) ℚ)⁻¹ •
+            twistedHeckeSlashSum k χ D f := by
+  rw [twistedHeckeSlashSum_twistedHeckeSlashSum, ← Fintype.sum_prod_type',
+    ← Finset.sum_fiberwise_of_maps_to (g := pairCoset D₁ D₂)
+      (fun p _ ↦ Finset.mem_image_of_mem _ (Finset.mem_univ p))]
+  refine Finset.sum_congr rfl fun D _ ↦ ?_
+  rw [Finset.sum_subtype (p := fun q ↦ pairCoset D₁ D₂ q = D)
+    (Finset.univ.filter fun q ↦ pairCoset D₁ D₂ q = D) (fun q ↦ by simp)
+    fun q ↦ (delta0NebentypusChar N χ
+      ⟨rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2,
+        mul_mem (rightCosetRep_mem_Delta0 D₁ q.1) (rightCosetRep_mem_Delta0 D₂ q.2)⟩ : ℂ) •
+          (f ∣[k] (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2))]
+  exact sum_nebentypus_smul_slash_eq_nsmul_twistedHeckeSlashSum k χ D _ _
+    (fun i ↦ pairCoset_eq_iff.mp i.2)
+    (fun _ hx ↦ card_pairs_pairCoset_rightCoset_eq_multiplicity hx) f hf
+
+open Classical in
+/-- **The multiplicity-weighted composition law on the character space.** This is
+`twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_nsmul` bundled as an equality of endomorphisms
+of `functionCharSpace k χ`. The order on the left records that `D₁` acts first. -/
+theorem twistedHeckeSlashSumCharEnd_mul_eq_sum_nsmul :
+    twistedHeckeSlashSumCharEnd k χ D₂ * twistedHeckeSlashSumCharEnd k χ D₁ =
+      ∑ D ∈ Finset.univ.image (pairCoset D₁ D₂),
+        DoubleCoset.multiplicity ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
+          ((Gamma0 N).map (mapGL ℚ)) (D₂.out : GL (Fin 2) ℚ)⁻¹
+          (D₁.out : GL (Fin 2) ℚ)⁻¹ (D.out : GL (Fin 2) ℚ)⁻¹ •
+            twistedHeckeSlashSumCharEnd k χ D := by
+  ext f x
+  have h := congrFun
+    (twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_nsmul k χ D₁ D₂ f f.2) x
+  simpa [Module.End.mul_apply] using h
+
+end Assembly
 
 section Free
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
@@ -114,10 +114,7 @@ multiplies by composition, so `D₁` acts first — exactly as the untwisted
 left to do.
 
 The multiplicity-weighted theorem corresponds to AINTLIB's
-`twistedHeckeSlashGen_comp_eq_m_sum` in the same file. Its proof is not transcribed: AINTLIB
-builds a separate left-coset fibre and correction-map apparatus, while the proof here combines
-the existing right-coset `pairCoset` count from `HeckeSlash/Composition.lean` with the uniformly
-repeating weighted-family theorem from `Nebentypus/Independence.lean`.
+`twistedHeckeSlashGen_comp_eq_m_sum` in the same file.
 
 ⚠ Not adapted, so that the source line numbers are not read as a wider claim:
 `twisted_weighted_slash_product_eq` (`:494`) is a per-pair step that carries a summand into a third

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
@@ -43,9 +43,7 @@ The uniformly repeating-family theorem corresponds to the role of
 `twisted_filtered_sum_collapse_of_qOf` in AINTLIB's
 `LeanModularForms/HeckeRIngs/GL2/Unified/TwistedHeckeRing.lean` (Chris Birkbeck, Apache-2.0,
 <https://github.com/CBirkbeck/AINTLIB> at commit
-`2baa76f742bdb4fb8ee323fabba41203bd390e08`). No code is transcribed: the statement and proof are
-the weighted analogue of this repository's `sum_slash_eq_nsmul_heckeSlashSum`, using
-`smul_slash_eq_of_rightCoset_eq` for the one per-fibre substitution.
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`).
 
 ## References
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
@@ -34,6 +34,18 @@ untwisted file's comparison of two enumerations unchanged.
   depends only on the right coset `Γ₀(N) x`.
 * `HeckeRing.GL2.twistedHeckeSlashSum_eq_sum_of_rightCosets`: `twistedHeckeSlashSum k χ D f` is
   the weighted sum over any family of representatives of the right cosets.
+* `HeckeRing.GL2.sum_nebentypus_smul_slash_eq_nsmul_twistedHeckeSlashSum`: if a family names
+  every right coset exactly `m` times, its weighted sum is `m` times the twisted slash sum.
+
+## Provenance
+
+The uniformly repeating-family theorem corresponds to the role of
+`twisted_filtered_sum_collapse_of_qOf` in AINTLIB's
+`LeanModularForms/HeckeRIngs/GL2/Unified/TwistedHeckeRing.lean` (Chris Birkbeck, Apache-2.0,
+<https://github.com/CBirkbeck/AINTLIB> at commit
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`). No code is transcribed: the statement and proof are
+the weighted analogue of this repository's `sum_slash_eq_nsmul_heckeSlashSum`, using
+`smul_slash_eq_of_rightCoset_eq` for the one per-fibre substitution.
 
 ## References
 
@@ -128,6 +140,58 @@ theorem twistedHeckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι]
   rw [nebentypusWeight_def]
   exact (smul_slash_eq_of_rightCoset_eq k χ f hf (mem_Delta0_of_cover D hcover i)
     (rightCosetRep_mem_Delta0 D (φ i)) (hφ i)).symm
+
+/-- **A uniformly repeating family gives a multiple of the twisted slash sum.** Let `(aᵢ)` be a
+family of elements in the double coset of `D`. If every right coset `Γ₀(N) x` inside `D` is named
+by exactly `m` members of the family, then
+
+`∑ᵢ χ'(aᵢ) • (f ∣[k] aᵢ) = m • twistedHeckeSlashSum k χ D f`
+
+for every `χ`-eigenfunction `f`, where `χ'` is `delta0NebentypusChar N χ`.
+
+This is the twisted counterpart of `sum_slash_eq_nsmul_heckeSlashSum`. Covering is not a
+hypothesis: if some right coset is missed, the common multiplicity is zero, and the conclusion
+still holds. The membership hypothesis puts each `aᵢ` in `Δ₀(N)` automatically, since the whole
+double coset lies there. -/
+theorem sum_nebentypus_smul_slash_eq_nsmul_twistedHeckeSlashSum
+    {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ) (m : ℕ)
+    (hmem : ∀ i, a i ∈ doubleCoset (D.out : GL (Fin 2) ℚ)
+      ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)))
+    (hcard : ∀ x ∈ doubleCoset (D.out : GL (Fin 2) ℚ)
+      ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)),
+      Nat.card {i // MulOpposite.op (a i) •
+          (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op x •
+          (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ))} = m)
+    (f : ℍ → ℂ) (hf : f ∈ functionCharSpace k χ) :
+    ∑ i, (delta0NebentypusChar N χ
+        ⟨a i, IsHeckeTriple.mem_of_mem_doubleCoset D.out.2 (hmem i)⟩ : ℂ) • (f ∣[k] a i) =
+      m • twistedHeckeSlashSum k χ D f := by
+  classical
+  let _ : Fintype (DecompQuotient ((Gamma0 N).map (mapGL ℚ))
+      ((Gamma0 N).map (mapGL ℚ)) (D.out : GL (Fin 2) ℚ)⁻¹) := Fintype.ofFinite _
+  choose g hg using fun i ↦ exists_rightCosetRep_smul_eq D (hmem i)
+  rw [twistedHeckeSlashSum_def, Finset.smul_sum,
+    ← Finset.sum_fiberwise_of_maps_to (fun i _ ↦ Finset.mem_univ (g i))
+      fun i ↦ (delta0NebentypusChar N χ
+        ⟨a i, IsHeckeTriple.mem_of_mem_doubleCoset D.out.2 (hmem i)⟩ : ℂ) • (f ∣[k] a i)]
+  refine Finset.sum_congr rfl fun v _ ↦ ?_
+  rw [Finset.sum_congr rfl fun i hi ↦ ?_, Finset.sum_const]
+  · have hfib : (Finset.univ.filter fun i ↦ g i = v) =
+        Finset.univ.filter fun i ↦ MulOpposite.op (a i) •
+          (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
+            MulOpposite.op (rightCosetRep D v) •
+              (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
+                Set (GL (Fin 2) ℚ)) :=
+      Finset.filter_congr fun i _ ↦
+        ⟨fun h ↦ h ▸ hg i, fun h ↦ op_rightCosetRep_smul_injective D ((hg i).symm.trans h)⟩
+    have hm := hcard _ (rightCosetRep_mem_doubleCoset D v)
+    rw [Nat.card_eq_fintype_card, Fintype.card_subtype] at hm
+    rw [hfib, hm]
+  · rw [nebentypusWeight_def]
+    exact (smul_slash_eq_of_rightCoset_eq k χ f hf
+      (IsHeckeTriple.mem_of_mem_doubleCoset D.out.2 (hmem i))
+      (rightCosetRep_mem_Delta0 D v) ((Finset.mem_filter.mp hi).2 ▸ hg i)).symm
 
 end HeckeRing.GL2
 


### PR DESCRIPTION
This PR proves the multiplicity-weighted composition law for nebentypus-twisted slash sums on `functionCharSpace k χ`. It first identifies a weighted family that meets every right coset `m` times with `m • twistedHeckeSlashSum`, then partitions products of representatives by `pairCoset` to obtain the full sum with Shimura multiplicities, both pointwise and as character-space endomorphisms.

This advances the ModularForms roadmap's Layer 2(b) milestone, “The action on forms”: the ring homomorphism from the abstract Hecke ring to endomorphisms of the character space needs precisely this multiplicity-weighted composition calculation. After this PR, reconciling the reversed/inverted right-coset coefficient with the existing Hecke-ring structure constants and promoting the resulting linear extension to the promised ring homomorphism remain.

This is the most effective current step toward that milestone because the requisite untwisted pair-coset count, nebentypus representative independence, and character-space endomorphisms have all landed, while no open PR supplies their weighted assembly.

The result reuses Tau Ceti's existing `pairCoset` partition and `DoubleCoset.multiplicity` count; a search of the pinned Mathlib sources found no twisted analogue. Its mathematical source counterpart is Chris Birkbeck's `twistedHeckeSlashGen_comp_eq_m_sum` in AINTLIB's `LeanModularForms/HeckeRIngs/GL2/Unified/TwistedHeckeRing.lean` (Apache-2.0, commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`). No source code or Mathlib infrastructure is vendored; the proof is recast through Tau Ceti's right-coset abstractions.

The change modifies `Nebentypus/Independence.lean` and `Nebentypus/Composition.lean` with 146 insertions and 23 removals.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"twisted-hecke-slash-multiplicity-weighted-composite"}-->

🤖 Prepared with Codex
