### PR TITLE
feat: preserve explicit cups under inflation

### DIFF
--- a/TauCeti/GroupTheory/GroupAction/FixedPoints.lean
+++ b/TauCeti/GroupTheory/GroupAction/FixedPoints.lean
@@ -339,9 +339,10 @@ variable {G : Type*} [Group G]
   {N : Type*} [AddCommGroup N] [DistribMulAction G N]
   {P : Type*} [AddCommGroup P] [DistribMulAction G P]
 
-/-- An equivariant biadditive pairing restricts to the fixed points of any subgroup. -/
+/-- An `H`-equivariant biadditive pairing restricts to the fixed points of `H`. -/
 def fixedPointsPairing (H : Subgroup G) (μ : M →+ N →+ P)
-    (hequiv : ∀ (g : G) (m : M) (n : N), μ (g • m) (g • n) = g • μ m n) :
+    (hequiv : ∀ (h : H) (m : M) (n : N),
+      μ ((h : G) • m) ((h : G) • n) = (h : G) • μ m n) :
     FixedPoints.addSubgroup H M →+ FixedPoints.addSubgroup H N →+
       FixedPoints.addSubgroup H P where
   toFun m :=
@@ -354,7 +355,7 @@ def fixedPointsPairing (H : Subgroup G) (μ : M →+ N →+ P)
             simpa only [Subgroup.smul_def] using
               (FixedPoints.mem_addSubgroup H N _).1 n.2 h
           simpa only [Subgroup.smul_def, hm, hn] using
-            (hequiv (h : G) (m : M) (n : N)).symm⟩
+            (hequiv h (m : M) (n : N)).symm⟩
       map_zero' := Subtype.ext (map_zero (μ (m : M)))
       map_add' := fun n n' => Subtype.ext (map_add (μ (m : M)) (n : N) (n' : N)) }
   map_zero' := AddMonoidHom.ext fun _ => Subtype.ext <| by simp
@@ -363,7 +364,8 @@ def fixedPointsPairing (H : Subgroup G) (μ : M →+ N →+ P)
 /-- The pairing on fixed points is the original pairing on underlying elements. -/
 @[simp]
 theorem coe_fixedPointsPairing (H : Subgroup G) (μ : M →+ N →+ P)
-    (hequiv : ∀ (g : G) (m : M) (n : N), μ (g • m) (g • n) = g • μ m n)
+    (hequiv : ∀ (h : H) (m : M) (n : N),
+      μ ((h : G) • m) ((h : G) • n) = (h : G) • μ m n)
     (m : FixedPoints.addSubgroup H M) (n : FixedPoints.addSubgroup H N) :
     (fixedPointsPairing H μ hequiv m n : P) = μ (m : M) (n : N) :=
   by simp [fixedPointsPairing]
@@ -373,8 +375,8 @@ theorem coe_fixedPointsPairing (H : Subgroup G) (μ : M →+ N →+ P)
 theorem fixedPointsPairing_quotient_smul (H : Subgroup G) [H.Normal] (μ : M →+ N →+ P)
     (hequiv : ∀ (g : G) (m : M) (n : N), μ (g • m) (g • n) = g • μ m n)
     (q : G ⧸ H) (m : FixedPoints.addSubgroup H M) (n : FixedPoints.addSubgroup H N) :
-    fixedPointsPairing H μ hequiv (q • m) (q • n) =
-      q • fixedPointsPairing H μ hequiv m n := by
+    fixedPointsPairing H μ (fun h => hequiv (h : G)) (q • m) (q • n) =
+      q • fixedPointsPairing H μ (fun h => hequiv (h : G)) m n := by
   induction q using QuotientGroup.induction_on with
   | H g =>
       apply Subtype.ext

--- a/TauCeti/GroupTheory/GroupAction/FixedPoints.lean
+++ b/TauCeti/GroupTheory/GroupAction/FixedPoints.lean
@@ -40,6 +40,8 @@ Nothing here is specific to a topology or to cohomology; the continuous-cohomolo
   fixed points and into the ambient additive monoid, with their functoriality laws.
 * `TauCeti.fixedPointsMap` and `TauCeti.fixedPointsQuotientMap`: functoriality of fixed points in
   the additive monoid, additively and as a quotient-equivariant map.
+* `TauCeti.fixedPointsPairing`: the pairing induced on the fixed points of an equivariant
+  biadditive pairing.
 -/
 
 public section
@@ -329,5 +331,55 @@ theorem fixedPointsMap_comp_fixedPointsInclusion (f : M →+[G] N) (h : K ≤ H)
 end Map
 
 end Functoriality
+
+section Pairing
+
+variable {G : Type*} [Group G]
+  {M : Type*} [AddCommGroup M] [DistribMulAction G M]
+  {N : Type*} [AddCommGroup N] [DistribMulAction G N]
+  {P : Type*} [AddCommGroup P] [DistribMulAction G P]
+
+/-- An equivariant biadditive pairing restricts to the fixed points of any subgroup. -/
+def fixedPointsPairing (H : Subgroup G) (μ : M →+ N →+ P)
+    (hequiv : ∀ (g : G) (m : M) (n : N), μ (g • m) (g • n) = g • μ m n) :
+    FixedPoints.addSubgroup H M →+ FixedPoints.addSubgroup H N →+
+      FixedPoints.addSubgroup H P where
+  toFun m :=
+    { toFun := fun n =>
+        ⟨μ (m : M) (n : N), (FixedPoints.mem_addSubgroup H P _).2 fun h => by
+          have hm : (h : G) • (m : M) = m := by
+            simpa only [Subgroup.smul_def] using
+              (FixedPoints.mem_addSubgroup H M _).1 m.2 h
+          have hn : (h : G) • (n : N) = n := by
+            simpa only [Subgroup.smul_def] using
+              (FixedPoints.mem_addSubgroup H N _).1 n.2 h
+          simpa only [Subgroup.smul_def, hm, hn] using
+            (hequiv (h : G) (m : M) (n : N)).symm⟩
+      map_zero' := Subtype.ext (map_zero (μ (m : M)))
+      map_add' := fun n n' => Subtype.ext (map_add (μ (m : M)) (n : N) (n' : N)) }
+  map_zero' := AddMonoidHom.ext fun _ => Subtype.ext <| by simp
+  map_add' := fun m m' => AddMonoidHom.ext fun n => Subtype.ext <| by simp
+
+/-- The pairing on fixed points is the original pairing on underlying elements. -/
+@[simp]
+theorem coe_fixedPointsPairing (H : Subgroup G) (μ : M →+ N →+ P)
+    (hequiv : ∀ (g : G) (m : M) (n : N), μ (g • m) (g • n) = g • μ m n)
+    (m : FixedPoints.addSubgroup H M) (n : FixedPoints.addSubgroup H N) :
+    (fixedPointsPairing H μ hequiv m n : P) = μ (m : M) (n : N) :=
+  by simp [fixedPointsPairing]
+
+/-- For a normal subgroup, the pairing on fixed points is equivariant for the quotient action. -/
+@[simp]
+theorem fixedPointsPairing_quotient_smul (H : Subgroup G) [H.Normal] (μ : M →+ N →+ P)
+    (hequiv : ∀ (g : G) (m : M) (n : N), μ (g • m) (g • n) = g • μ m n)
+    (q : G ⧸ H) (m : FixedPoints.addSubgroup H M) (n : FixedPoints.addSubgroup H N) :
+    fixedPointsPairing H μ hequiv (q • m) (q • n) =
+      q • fixedPointsPairing H μ hequiv m n := by
+  induction q using QuotientGroup.induction_on with
+  | H g =>
+      apply Subtype.ext
+      simpa using hequiv g (m : M) (n : N)
+
+end Pairing
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/Cup/Inflation.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/Cup/Inflation.lean
@@ -50,6 +50,8 @@ variable (G : Type uG) [Group G]
   (μ : M →+ A →+ P)
   (hequiv : ∀ (g : G) (m : M) (a : A), μ (g • m) (g • a) = g • μ m a)
 
+local notation "μᴺ" => fixedPointsPairing N μ (fun n => hequiv (n : G))
+
 /-- **Inflation preserves the `(0,0)` cup product.** -/
 @[simp]
 theorem explicitInfl0_explicitCup00
@@ -58,7 +60,7 @@ theorem explicitInfl0_explicitCup00
     explicitInfl0 G P N
         (explicitCup00 (G ⧸ N) (FixedPoints.addSubgroup N M)
           (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P)
-          (fixedPointsPairing N μ hequiv)
+          μᴺ
           (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
       explicitCup00 G M A P μ hequiv
         (explicitInfl0 G M N a) (explicitInfl0 G A N b) := by
@@ -83,7 +85,7 @@ variable (G : Type uG) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
   (μ : M →+ A →+ P) (hμ : Continuous fun p : M × A => μ p.1 p.2)
   (hequiv : ∀ (g : G) (m : M) (a : A), μ (g • m) (g • a) = g • μ m a)
 
-local notation "μᴺ" => fixedPointsPairing N μ hequiv
+local notation "μᴺ" => fixedPointsPairing N μ (fun n => hequiv (n : G))
 
 include hμ hequiv
 
@@ -97,7 +99,7 @@ theorem explicitInfl1_explicitCup01
     explicitInfl1 G P N
         (explicitCup01 (G ⧸ N) (FixedPoints.addSubgroup N M)
           (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P) μᴺ
-          (continuous_fixedPointsPairing N μ hequiv hμ)
+          (continuous_fixedPointsPairing N μ (fun n => hequiv (n : G)) hμ)
           (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
       explicitCup01 G M A P μ hμ hequiv
         (explicitInfl0 G M N a) (explicitInfl1 G A N b) := by
@@ -117,7 +119,7 @@ theorem explicitInfl1_explicitCup10
     explicitInfl1 G P N
         (explicitCup10 (G ⧸ N) (FixedPoints.addSubgroup N M)
           (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P) μᴺ
-          (continuous_fixedPointsPairing N μ hequiv hμ)
+          (continuous_fixedPointsPairing N μ (fun n => hequiv (n : G)) hμ)
           (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
       explicitCup10 G M A P μ hμ hequiv
         (explicitInfl1 G M N a) (explicitInfl0 G A N b) := by
@@ -137,7 +139,7 @@ theorem explicitInfl2_explicitCup02
     explicitInfl2 G P N
         (explicitCup02 (G ⧸ N) (FixedPoints.addSubgroup N M)
           (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P) μᴺ
-          (continuous_fixedPointsPairing N μ hequiv hμ)
+          (continuous_fixedPointsPairing N μ (fun n => hequiv (n : G)) hμ)
           (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
       explicitCup02 G M A P μ hμ hequiv
         (explicitInfl0 G M N a) (explicitInfl2 G A N b) := by
@@ -156,7 +158,7 @@ theorem explicitInfl2_explicitCup11
     explicitInfl2 G P N
         (explicitCup11 (G ⧸ N) (FixedPoints.addSubgroup N M)
           (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P) μᴺ
-          (continuous_fixedPointsPairing N μ hequiv hμ)
+          (continuous_fixedPointsPairing N μ (fun n => hequiv (n : G)) hμ)
           (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
       explicitCup11 G M A P μ hμ hequiv
         (explicitInfl1 G M N a) (explicitInfl1 G A N b) := by
@@ -180,7 +182,7 @@ theorem explicitInfl2_explicitCup20
     explicitInfl2 G P N
         (explicitCup20 (G ⧸ N) (FixedPoints.addSubgroup N M)
           (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P) μᴺ
-          (continuous_fixedPointsPairing N μ hequiv hμ)
+          (continuous_fixedPointsPairing N μ (fun n => hequiv (n : G)) hμ)
           (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
       explicitCup20 G M A P μ hμ hequiv
         (explicitInfl2 G M N a) (explicitInfl0 G A N b) := by
@@ -193,25 +195,8 @@ theorem explicitInfl2_explicitCup20
             (((((g : G ⧸ N) * (h : G ⧸ N)) •
               (b : FixedPoints.addSubgroup N A)) : FixedPoints.addSubgroup N A) : A) =
               (g * h) • (b : A) := by
-          calc
-            _ = ((((g : G ⧸ N) • ((h : G ⧸ N) •
-                (b : FixedPoints.addSubgroup N A))) : FixedPoints.addSubgroup N A) : A) :=
-              congrArg Subtype.val (mul_smul (g : G ⧸ N) (h : G ⧸ N)
-                (b : FixedPoints.addSubgroup N A))
-            _ = (((g : G) • ((h : G ⧸ N) •
-                (b : FixedPoints.addSubgroup N A))) : FixedPoints.addSubgroup N A) :=
-              congrArg Subtype.val <| coe_quotient_smul_fixedPoints_addSubgroup (H := N) g _
-            _ = g • ((((h : G ⧸ N) •
-                (b : FixedPoints.addSubgroup N A)) : FixedPoints.addSubgroup N A) : A) :=
-              coe_smul_fixedPoints_addSubgroup g _
-            _ = g • (((h : G) •
-                (b : FixedPoints.addSubgroup N A) : FixedPoints.addSubgroup N A) : A) :=
-              congrArg (fun x : A => g • x) <| congrArg Subtype.val <|
-                coe_quotient_smul_fixedPoints_addSubgroup (H := N) h
-                  (b : FixedPoints.addSubgroup N A)
-            _ = g • (h • (b : A)) := congrArg (fun x : A => g • x)
-              (coe_smul_fixedPoints_addSubgroup h (b : FixedPoints.addSubgroup N A))
-            _ = (g * h) • (b : A) := (mul_smul g h (b : A)).symm
+          simpa only [ContinuousMonoidHom.quotientMk_apply, map_mul,
+            AddSubgroup.coe_subtype] using subtype_quotientMk_smul G A N (g * h) b
         simpa [cocyclesMap2_coe] using congrArg (μ (↑((a : (G ⧸ N) × (G ⧸ N) →
           FixedPoints.addSubgroup N M) ((g : G ⧸ N), (h : G ⧸ N))) : M))
             hsmul

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/Cup/Inflation.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/Cup/Inflation.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Homological.ContCohomology.Cup.Product
+public import TauCeti.RepresentationTheory.Homological.ContCohomology.Inflation
+
+/-!
+# Inflation preserves explicit low-degree cup products
+
+Let `N` be a normal subgroup of `G`. An equivariant pairing `M × A → P` restricts to a pairing
+`Mᴺ × Aᴺ → Pᴺ` on the invariant coefficients over `G ⧸ N`. Inflation preserves each of the six
+explicit cup products:
+
+```text
+inf (a ⌣ b) = inf a ⌣ inf b.
+```
+
+The equality already holds on cocycle representatives: inflation precomposes cochains with the
+quotient map and includes their invariant values into the ambient coefficient modules.
+
+## Main statements
+
+* `TauCeti.ContCohomology.explicitInfl0_explicitCup00`,
+  `explicitInfl1_explicitCup01`, `explicitInfl1_explicitCup10`,
+  `explicitInfl2_explicitCup02`, `explicitInfl2_explicitCup11`, and
+  `explicitInfl2_explicitCup20`: inflation preserves the corresponding explicit cup product.
+
+## Reference
+
+J. Neukirch, A. Schmidt, K. Wingberg, *Cohomology of Number Fields*, 2nd ed., (1.5.3)(iii).
+-/
+
+public section
+
+namespace TauCeti.ContCohomology
+
+universe uG uM uA uP
+
+section DegreeZero
+
+variable (G : Type uG) [Group G]
+  (M : Type uM) [AddCommGroup M] [DistribMulAction G M]
+  (A : Type uA) [AddCommGroup A] [DistribMulAction G A]
+  (P : Type uP) [AddCommGroup P] [DistribMulAction G P]
+  (N : Subgroup G) [N.Normal]
+  (μ : M →+ A →+ P)
+  (hequiv : ∀ (g : G) (m : M) (a : A), μ (g • m) (g • a) = g • μ m a)
+
+/-- **Inflation preserves the `(0,0)` cup product.** -/
+@[simp]
+theorem explicitInfl0_explicitCup00
+    (a : H0 (G ⧸ N) (FixedPoints.addSubgroup N M))
+    (b : H0 (G ⧸ N) (FixedPoints.addSubgroup N A)) :
+    explicitInfl0 G P N
+        (explicitCup00 (G ⧸ N) (FixedPoints.addSubgroup N M)
+          (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P)
+          (fixedPointsPairing N μ hequiv)
+          (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
+      explicitCup00 G M A P μ hequiv
+        (explicitInfl0 G M N a) (explicitInfl0 G A N b) := by
+  apply Subtype.ext
+  simp only [coe_explicitInfl0, coe_explicitCup00, coe_fixedPointsPairing]
+
+end DegreeZero
+
+section PositiveDegree
+
+variable (G : Type uG) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  (M : Type uM) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+    [DistribMulAction G M] [ContinuousSMul G M]
+  (A : Type uA) [AddCommGroup A] [TopologicalSpace A] [IsTopologicalAddGroup A]
+    [DistribMulAction G A] [ContinuousSMul G A]
+  (P : Type uP) [AddCommGroup P] [TopologicalSpace P] [IsTopologicalAddGroup P]
+    [DistribMulAction G P] [ContinuousSMul G P]
+  (N : Subgroup G) [N.Normal]
+  [ContinuousSMul (G ⧸ N) (FixedPoints.addSubgroup N M)]
+  [ContinuousSMul (G ⧸ N) (FixedPoints.addSubgroup N A)]
+  [ContinuousSMul (G ⧸ N) (FixedPoints.addSubgroup N P)]
+  (μ : M →+ A →+ P) (hμ : Continuous fun p : M × A => μ p.1 p.2)
+  (hequiv : ∀ (g : G) (m : M) (a : A), μ (g • m) (g • a) = g • μ m a)
+
+local notation "μᴺ" => fixedPointsPairing N μ hequiv
+
+include hμ hequiv
+
+omit [IsTopologicalAddGroup M] [ContinuousSMul G M]
+    [ContinuousSMul (G ⧸ N) (FixedPoints.addSubgroup N M)] [IsTopologicalGroup G] in
+/-- **Inflation preserves the `(0,1)` cup product.** -/
+@[simp]
+theorem explicitInfl1_explicitCup01
+    (a : H0 (G ⧸ N) (FixedPoints.addSubgroup N M))
+    (b : H1 (G ⧸ N) (FixedPoints.addSubgroup N A)) :
+    explicitInfl1 G P N
+        (explicitCup01 (G ⧸ N) (FixedPoints.addSubgroup N M)
+          (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P) μᴺ
+          (continuous_fixedPointsPairing N μ hequiv hμ)
+          (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
+      explicitCup01 G M A P μ hμ hequiv
+        (explicitInfl0 G M N a) (explicitInfl1 G A N b) := by
+  induction b using QuotientAddGroup.induction_on with
+  | _ b =>
+      rw [explicitCup01_mk, explicitInfl1_mk, explicitInfl1_mk, explicitCup01_mk]
+      exact congrArg (fun z : Z1 G P => (z : H1 G P)) <| Subtype.ext <| funext fun g => by
+        simp [cocyclesMap1_coe]
+
+omit [IsTopologicalAddGroup A] [ContinuousSMul G A]
+    [ContinuousSMul (G ⧸ N) (FixedPoints.addSubgroup N A)] [IsTopologicalGroup G] in
+/-- **Inflation preserves the `(1,0)` cup product.** -/
+@[simp]
+theorem explicitInfl1_explicitCup10
+    (a : H1 (G ⧸ N) (FixedPoints.addSubgroup N M))
+    (b : H0 (G ⧸ N) (FixedPoints.addSubgroup N A)) :
+    explicitInfl1 G P N
+        (explicitCup10 (G ⧸ N) (FixedPoints.addSubgroup N M)
+          (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P) μᴺ
+          (continuous_fixedPointsPairing N μ hequiv hμ)
+          (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
+      explicitCup10 G M A P μ hμ hequiv
+        (explicitInfl1 G M N a) (explicitInfl0 G A N b) := by
+  induction a using QuotientAddGroup.induction_on with
+  | _ a =>
+      rw [explicitCup10_mk, explicitInfl1_mk, explicitInfl1_mk, explicitCup10_mk]
+      exact congrArg (fun z : Z1 G P => (z : H1 G P)) <| Subtype.ext <| funext fun g => by
+        simp [cocyclesMap1_coe]
+
+omit [IsTopologicalAddGroup M] [ContinuousSMul G M]
+    [ContinuousSMul (G ⧸ N) (FixedPoints.addSubgroup N M)] in
+/-- **Inflation preserves the `(0,2)` cup product.** -/
+@[simp]
+theorem explicitInfl2_explicitCup02
+    (a : H0 (G ⧸ N) (FixedPoints.addSubgroup N M))
+    (b : H2 (G ⧸ N) (FixedPoints.addSubgroup N A)) :
+    explicitInfl2 G P N
+        (explicitCup02 (G ⧸ N) (FixedPoints.addSubgroup N M)
+          (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P) μᴺ
+          (continuous_fixedPointsPairing N μ hequiv hμ)
+          (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
+      explicitCup02 G M A P μ hμ hequiv
+        (explicitInfl0 G M N a) (explicitInfl2 G A N b) := by
+  induction b using QuotientAddGroup.induction_on with
+  | _ b =>
+      rw [explicitCup02_mk, explicitInfl2_mk, explicitInfl2_mk, explicitCup02_mk]
+      exact congrArg (fun z : Z2 G P => (z : H2 G P)) <| Subtype.ext <| funext fun q => by
+        obtain ⟨g, h⟩ := q
+        simp [cocyclesMap2_coe]
+
+/-- **Inflation preserves the `(1,1)` cup product.** -/
+@[simp]
+theorem explicitInfl2_explicitCup11
+    (a : H1 (G ⧸ N) (FixedPoints.addSubgroup N M))
+    (b : H1 (G ⧸ N) (FixedPoints.addSubgroup N A)) :
+    explicitInfl2 G P N
+        (explicitCup11 (G ⧸ N) (FixedPoints.addSubgroup N M)
+          (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P) μᴺ
+          (continuous_fixedPointsPairing N μ hequiv hμ)
+          (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
+      explicitCup11 G M A P μ hμ hequiv
+        (explicitInfl1 G M N a) (explicitInfl1 G A N b) := by
+  induction a using QuotientAddGroup.induction_on with
+  | _ a =>
+      induction b using QuotientAddGroup.induction_on with
+      | _ b =>
+          rw [explicitCup11_mk, explicitInfl2_mk, explicitInfl1_mk, explicitInfl1_mk,
+            explicitCup11_mk]
+          exact congrArg (fun z : Z2 G P => (z : H2 G P)) <| Subtype.ext <| funext fun q => by
+            obtain ⟨g, h⟩ := q
+            simp [cocyclesMap1_coe, cocyclesMap2_coe]
+
+omit [IsTopologicalAddGroup A] [ContinuousSMul G A]
+    [ContinuousSMul (G ⧸ N) (FixedPoints.addSubgroup N A)] in
+/-- **Inflation preserves the `(2,0)` cup product.** -/
+@[simp]
+theorem explicitInfl2_explicitCup20
+    (a : H2 (G ⧸ N) (FixedPoints.addSubgroup N M))
+    (b : H0 (G ⧸ N) (FixedPoints.addSubgroup N A)) :
+    explicitInfl2 G P N
+        (explicitCup20 (G ⧸ N) (FixedPoints.addSubgroup N M)
+          (FixedPoints.addSubgroup N A) (FixedPoints.addSubgroup N P) μᴺ
+          (continuous_fixedPointsPairing N μ hequiv hμ)
+          (fixedPointsPairing_quotient_smul N μ hequiv) a b) =
+      explicitCup20 G M A P μ hμ hequiv
+        (explicitInfl2 G M N a) (explicitInfl0 G A N b) := by
+  induction a using QuotientAddGroup.induction_on with
+  | _ a =>
+      rw [explicitCup20_mk, explicitInfl2_mk, explicitInfl2_mk, explicitCup20_mk]
+      exact congrArg (fun z : Z2 G P => (z : H2 G P)) <| Subtype.ext <| funext fun q => by
+        obtain ⟨g, h⟩ := q
+        have hsmul :
+            (((((g : G ⧸ N) * (h : G ⧸ N)) •
+              (b : FixedPoints.addSubgroup N A)) : FixedPoints.addSubgroup N A) : A) =
+              (g * h) • (b : A) := by
+          calc
+            _ = ((((g : G ⧸ N) • ((h : G ⧸ N) •
+                (b : FixedPoints.addSubgroup N A))) : FixedPoints.addSubgroup N A) : A) :=
+              congrArg Subtype.val (mul_smul (g : G ⧸ N) (h : G ⧸ N)
+                (b : FixedPoints.addSubgroup N A))
+            _ = (((g : G) • ((h : G ⧸ N) •
+                (b : FixedPoints.addSubgroup N A))) : FixedPoints.addSubgroup N A) :=
+              congrArg Subtype.val <| coe_quotient_smul_fixedPoints_addSubgroup (H := N) g _
+            _ = g • ((((h : G ⧸ N) •
+                (b : FixedPoints.addSubgroup N A)) : FixedPoints.addSubgroup N A) : A) :=
+              coe_smul_fixedPoints_addSubgroup g _
+            _ = g • (((h : G) •
+                (b : FixedPoints.addSubgroup N A) : FixedPoints.addSubgroup N A) : A) :=
+              congrArg (fun x : A => g • x) <| congrArg Subtype.val <|
+                coe_quotient_smul_fixedPoints_addSubgroup (H := N) h
+                  (b : FixedPoints.addSubgroup N A)
+            _ = g • (h • (b : A)) := congrArg (fun x : A => g • x)
+              (coe_smul_fixedPoints_addSubgroup h (b : FixedPoints.addSubgroup N A))
+            _ = (g * h) • (b : A) := (mul_smul g h (b : A)).symm
+        simpa [cocyclesMap2_coe] using congrArg (μ (↑((a : (G ⧸ N) × (G ⧸ N) →
+          FixedPoints.addSubgroup N M) ((g : G ⧸ N), (h : G ⧸ N))) : M))
+            hsmul
+
+end PositiveDegree
+
+end TauCeti.ContCohomology

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/Inflation.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/Inflation.lean
@@ -25,8 +25,8 @@ at its two nodes.
 
 ## Main definitions
 
-* `TauCeti.ContCohomology.explicitInfl1` and `TauCeti.ContCohomology.explicitInfl2`: inflation on
-  the explicit model in degrees `1` and `2`.
+* `TauCeti.ContCohomology.explicitInfl0`, `explicitInfl1`, and `explicitInfl2`: inflation on the
+  explicit model in degrees `0`, `1`, and `2`.
 
 ## Main statements
 
@@ -111,6 +111,28 @@ theorem subtype_quotientMk_smul (g : G) (m : FixedPoints.addSubgroup N M) :
     coe_quotient_smul_fixedPoints_addSubgroup, coe_smul_fixedPoints_addSubgroup]
 
 end CompatiblePair
+
+section DegreeZero
+
+variable (G : Type u) [Group G]
+  (M : Type v) [AddCommGroup M] [DistribMulAction G M]
+  (N : Subgroup G) [N.Normal]
+
+/-- **Inflation in degree zero**: inclusion of the `G ⧸ N`-invariants of `M ^ N` into the
+`G`-invariants of `M`. -/
+def explicitInfl0 : H0 (G ⧸ N) (FixedPoints.addSubgroup N M) →+ H0 G M :=
+  explicitMap0 (G ⧸ N) (FixedPoints.addSubgroup N M) (QuotientGroup.mk' N)
+    (FixedPoints.addSubgroup N M).subtype fun g m => by
+      simp only [QuotientGroup.mk'_apply, AddSubgroup.coe_subtype,
+        coe_quotient_smul_fixedPoints_addSubgroup, coe_smul_fixedPoints_addSubgroup]
+
+/-- Degree-zero inflation does not change the underlying coefficient. -/
+@[simp]
+theorem coe_explicitInfl0 (m : H0 (G ⧸ N) (FixedPoints.addSubgroup N M)) :
+    (explicitInfl0 G M N m : M) = (m : M) :=
+  coe_explicitMap0 _ _ _ _ _ m
+
+end DegreeZero
 
 section DegreeOne
 

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/Invariants.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/Invariants.lean
@@ -48,6 +48,8 @@ unbundled classes freely.
   `H` of a group with a topology acting continuously on a discrete module, the quotient `G ⧸ H`
   acts continuously on `M ^ H`; no compatibility of the topology of `G` with its group structure
   is used.
+* `TauCeti.continuous_fixedPointsPairing`: a jointly continuous equivariant pairing remains
+  jointly continuous after restriction to invariant coefficients.
 
 ## Roadmap
 
@@ -71,6 +73,32 @@ public section
 open MulAction
 
 namespace TauCeti
+
+section Pairing
+
+variable {G : Type*} [Group G]
+  {M : Type*} [AddCommGroup M] [TopologicalSpace M] [DistribMulAction G M]
+  {N : Type*} [AddCommGroup N] [TopologicalSpace N] [DistribMulAction G N]
+  {P : Type*} [AddCommGroup P] [TopologicalSpace P] [DistribMulAction G P]
+
+/-- Restricting a jointly continuous pairing to invariant coefficients remains jointly
+continuous. -/
+theorem continuous_fixedPointsPairing (H : Subgroup G) (μ : M →+ N →+ P)
+    (hequiv : ∀ (g : G) (m : M) (n : N), μ (g • m) (g • n) = g • μ m n)
+    (hμ : Continuous fun p : M × N => μ p.1 p.2) :
+    Continuous fun p : FixedPoints.addSubgroup H M × FixedPoints.addSubgroup H N =>
+      fixedPointsPairing H μ hequiv p.1 p.2 := by
+  rw [continuous_induced_rng]
+  have hfun :
+      (Subtype.val ∘ fun p : FixedPoints.addSubgroup H M × FixedPoints.addSubgroup H N =>
+        fixedPointsPairing H μ hequiv p.1 p.2) =
+        fun p => μ (p.1 : M) (p.2 : N) := by
+    funext p
+    exact coe_fixedPointsPairing H μ hequiv p.1 p.2
+  rw [hfun]
+  exact hμ.comp (continuous_subtype_val.prodMap continuous_subtype_val)
+
+end Pairing
 
 section FiniteLevel
 

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/Invariants.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/Invariants.lean
@@ -81,10 +81,11 @@ variable {G : Type*} [Group G]
   {N : Type*} [AddCommGroup N] [TopologicalSpace N] [DistribMulAction G N]
   {P : Type*} [AddCommGroup P] [TopologicalSpace P] [DistribMulAction G P]
 
-/-- Restricting a jointly continuous pairing to invariant coefficients remains jointly
-continuous. -/
+/-- Restricting a jointly continuous `H`-equivariant pairing to invariant coefficients remains
+jointly continuous. -/
 theorem continuous_fixedPointsPairing (H : Subgroup G) (μ : M →+ N →+ P)
-    (hequiv : ∀ (g : G) (m : M) (n : N), μ (g • m) (g • n) = g • μ m n)
+    (hequiv : ∀ (h : H) (m : M) (n : N),
+      μ ((h : G) • m) ((h : G) • n) = (h : G) • μ m n)
     (hμ : Continuous fun p : M × N => μ p.1 p.2) :
     Continuous fun p : FixedPoints.addSubgroup H M × FixedPoints.addSubgroup H N =>
       fixedPointsPairing H μ hequiv p.1 p.2 := by


### PR DESCRIPTION
This PR completes the inflation-compatibility target in ProfiniteCohomology `README.md`, Layer 8 “cup products in low degrees,” Compatibilities item 2: prove `inf (a ⌣ b) = inf a ⌣ inf b` in every explicit bidegree with total degree at most two. It advances the Layer 8 milestone by closing all six inflation squares; after this PR, that milestone still needs coefficient-map naturality, the connecting-map identities, and the Bockstein package.

It restricts an equivariant biadditive pairing to fixed-point coefficients, records continuity and quotient equivariance of that pairing, and adds the missing degree-zero inflation map alongside the existing degree-one and degree-two maps. The six class-level theorems are proved on cocycle representatives, including the `(2,0)` translation factor where the quotient action must be identified with the ambient action. The normalization follows Neukirch–Schmidt–Wingberg, *Cohomology of Number Fields*, 2nd ed., (1.5.3)(iii).

Roadmap: ProfiniteCohomology

No Mathlib infrastructure is vendored; the implementation reuses Mathlib's `FixedPoints.addSubgroup`, quotient actions, and Tau Ceti's existing explicit cup and compatible-pair maps.

<!--tauceti-target:v1 {"focus":"ProfiniteCohomology","id":"explicit-cup-inflation"}-->

🤖 Prepared with Codex
