### PR TITLE
feat: add augmented differential graded algebras

### DIFF
--- a/TauCeti/Algebra/Homology/DG/Algebra/Augmentation.lean
+++ b/TauCeti/Algebra/Homology/DG/Algebra/Augmentation.lean
@@ -5,7 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.LinearAlgebra.Projection
 public import Mathlib.RingTheory.GradedAlgebra.Homogeneous.Submodule
+public import Mathlib.RingTheory.TwoSidedIdeal.Kernel
 public import TauCeti.Algebra.Homology.DG.Algebra.Hom.Basic
 public import TauCeti.RingTheory.GradedAlgebra.Trivial
 
@@ -25,6 +27,7 @@ augmentation ideal rather than from the unit-containing algebra.
 
 * `TauCeti.DGAlgAugmentation`: a DG algebra morphism from `A` to the trivially graded base ring.
 * `TauCeti.DGAlgAugmentation.augmentationIdeal`: the homogeneous kernel of an augmentation.
+* `TauCeti.DGAlgAugmentation.twoSidedIdeal`: the same kernel as a two-sided ideal of `A`.
 * `TauCeti.DGAlgAugmentation.splitLinearEquiv`: the canonical linear splitting
   `A ≃ R × ker ε`.
 * `TauCeti.IsDGAlgebra.unitHom`: the canonical unit morphism from the trivially graded base.
@@ -84,9 +87,13 @@ variable {h : IsDGAlgebra 𝒜 d} (e : DGAlgAugmentation h)
 
 /-- An augmentation restricts to the identity on the image of the ground ring. -/
 @[simp]
-theorem map_algebraMap (r : R) : e (algebraMap R A r) = r := by
-  change e (algebraMap R A r) = algebraMap R R r
-  exact e.toGradedAlgHom.commutes r
+theorem map_algebraMap (r : R) : e (algebraMap R A r) = r :=
+  (e.toGradedAlgHom.commutes r).trans (Algebra.algebraMap_self_apply r)
+
+/-- An augmentation is surjective, since it restricts to the identity on the image of the ground
+ring. -/
+theorem surjective : Function.Surjective e :=
+  fun r => ⟨algebraMap R A r, e.map_algebraMap r⟩
 
 /-- An augmentation annihilates every differential. -/
 @[simp]
@@ -112,15 +119,32 @@ noncomputable def augmentationIdeal :
 theorem mem_augmentationIdeal {a : A} : a ∈ e.augmentationIdeal ↔ e a = 0 :=
   LinearMap.mem_ker
 
+/-- The augmentation ideal, as a two-sided ideal of `A`.  This is the same kernel as
+`TauCeti.DGAlgAugmentation.augmentationIdeal`, packaged so that the two-sided ideal lattice,
+quotient, and multiplication API applies to it. -/
+def twoSidedIdeal : TwoSidedIdeal A :=
+  TwoSidedIdeal.ker e
+
+/-- Membership in the two-sided augmentation ideal is equivalent to vanishing under the
+augmentation. -/
+@[simp]
+theorem mem_twoSidedIdeal {a : A} : a ∈ e.twoSidedIdeal ↔ e a = 0 :=
+  TwoSidedIdeal.mem_ker e
+
+/-- The two-sided augmentation ideal and its homogeneous submodule view have the same elements. -/
+theorem mem_twoSidedIdeal_iff_mem_augmentationIdeal {a : A} :
+    a ∈ e.twoSidedIdeal ↔ a ∈ e.augmentationIdeal := by
+  rw [mem_twoSidedIdeal, mem_augmentationIdeal]
+
 /-- The augmentation ideal absorbs multiplication on the left. -/
 theorem mul_mem_augmentationIdeal_left (a : A) {x : A} (hx : x ∈ e.augmentationIdeal) :
     a * x ∈ e.augmentationIdeal := by
-  rw [mem_augmentationIdeal, map_mul, (mem_augmentationIdeal e).mp hx, mul_zero]
+  simpa using e.twoSidedIdeal.mul_mem_left a x (by simpa using hx)
 
 /-- The augmentation ideal absorbs multiplication on the right. -/
 theorem mul_mem_augmentationIdeal_right {x : A} (hx : x ∈ e.augmentationIdeal) (a : A) :
     x * a ∈ e.augmentationIdeal := by
-  rw [mem_augmentationIdeal, map_mul, (mem_augmentationIdeal e).mp hx, zero_mul]
+  simpa using e.twoSidedIdeal.mul_mem_right x a (by simpa using hx)
 
 /-- The differential of every element lies in the augmentation ideal. -/
 theorem map_mem_augmentationIdeal (x : A) :
@@ -139,22 +163,12 @@ theorem sub_algebraMap_mem_augmentationIdeal (a : A) :
     a - algebraMap R A (e a) ∈ e.augmentationIdeal := by
   rw [mem_augmentationIdeal, map_sub, e.map_algebraMap, sub_self]
 
-/-- The linear projection from an augmented DG algebra onto its augmentation ideal. -/
-noncomputable def reducedPart : A →ₗ[R] e.augmentationIdeal.toSubmodule where
-  toFun a := ⟨a - algebraMap R A (e a), e.sub_algebraMap_mem_augmentationIdeal a⟩
-  map_add' a b := by
-    apply Subtype.ext
-    change a + b - algebraMap R A (e (a + b)) =
-      (a - algebraMap R A (e a)) + (b - algebraMap R A (e b))
-    rw [map_add, map_add]
-    abel
-  map_smul' r a := by
-    apply Subtype.ext
-    change r • a - (Algebra.linearMap R A) (e (r • a)) =
-      r • (a - (Algebra.linearMap R A) (e a))
-    rw [show e (r • a) = r • e a from
-        e.toGradedAlgHom.toAlgHom.toLinearMap.map_smul r a,
-      (Algebra.linearMap R A).map_smul, smul_sub]
+/-- The linear projection from an augmented DG algebra onto its augmentation ideal, subtracting
+the scalar part of an element. -/
+noncomputable def reducedPart : A →ₗ[R] e.augmentationIdeal.toSubmodule :=
+  LinearMap.codRestrict _
+    (LinearMap.id - (Algebra.linearMap R A).comp e.toGradedAlgHom.toAlgHom.toLinearMap)
+    e.sub_algebraMap_mem_augmentationIdeal
 
 /-- The reduced-part projection subtracts the scalar part of an element. -/
 @[simp]
@@ -163,29 +177,16 @@ theorem coe_reducedPart (a : A) :
 
 /-- The reduced-part projection fixes the augmentation ideal pointwise. -/
 @[simp]
-theorem reducedPart_apply_mem (x : e.augmentationIdeal) :
+theorem reducedPart_coe (x : e.augmentationIdeal) :
     e.reducedPart (x : A) = x := by
   apply Subtype.ext
   rw [coe_reducedPart, (mem_augmentationIdeal e).mp x.property, map_zero, sub_zero]
 
 /-- The canonical splitting of an augmented DG algebra into its scalar and reduced parts. -/
-noncomputable def splitLinearEquiv : A ≃ₗ[R] R × e.augmentationIdeal where
-  toFun a := (e a, e.reducedPart a)
-  invFun x := algebraMap R A x.1 + x.2
-  map_add' a b := Prod.ext (map_add e a b) (map_add e.reducedPart a b)
-  map_smul' r a := Prod.ext (map_smul e r a) (map_smul e.reducedPart r a)
-  left_inv a := by
-    simp only [coe_reducedPart]
-    abel
-  right_inv x := by
-    ext
-    · change e (algebraMap R A x.1 + (x.2 : A)) = x.1
-      rw [map_add, e.map_algebraMap, (mem_augmentationIdeal e).mp x.2.property, add_zero]
-    · rw [coe_reducedPart, map_add, e.map_algebraMap,
-        (mem_augmentationIdeal e).mp x.2.property, add_zero]
-      -- Normalize the inverse lambda before applying the additive cancellation law.
-      change (algebraMap R A x.1 + (x.2 : A)) - algebraMap R A x.1 = x.2
-      exact add_sub_cancel_left _ _
+noncomputable def splitLinearEquiv : A ≃ₗ[R] R × e.augmentationIdeal :=
+  LinearMap.equivProdOfSurjectiveOfIsCompl e.toGradedAlgHom.toAlgHom.toLinearMap e.reducedPart
+    (LinearMap.range_eq_top.2 e.surjective) (LinearMap.range_eq_of_proj e.reducedPart_coe)
+    (LinearMap.isCompl_of_proj e.reducedPart_coe)
 
 /-- The splitting sends an element to its scalar part and its reduced part. -/
 @[simp]
@@ -195,7 +196,12 @@ theorem splitLinearEquiv_apply (a : A) :
 /-- The inverse splitting adds the scalar and reduced parts. -/
 @[simp]
 theorem splitLinearEquiv_symm_apply (x : R × e.augmentationIdeal) :
-    e.splitLinearEquiv.symm x = algebraMap R A x.1 + x.2 := (rfl)
+    e.splitLinearEquiv.symm x = algebraMap R A x.1 + x.2 := by
+  have hx : e (x.2 : A) = 0 := (mem_augmentationIdeal e).mp x.2.property
+  rw [LinearEquiv.symm_apply_eq, splitLinearEquiv_apply]
+  refine Prod.ext ?_ (Subtype.ext ?_)
+  · rw [map_add, e.map_algebraMap, hx, add_zero]
+  · rw [coe_reducedPart, map_add, e.map_algebraMap, hx, add_zero, add_sub_cancel_left]
 
 end DGAlgAugmentation
 

--- a/TauCeti/Algebra/Homology/DG/Algebra/Augmentation.lean
+++ b/TauCeti/Algebra/Homology/DG/Algebra/Augmentation.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.GradedAlgebra.Homogeneous.Submodule
+public import TauCeti.Algebra.Homology.DG.Algebra.Hom.Basic
+public import TauCeti.RingTheory.GradedAlgebra.Trivial
+
+/-!
+# Augmented differential graded algebras
+
+An augmentation of a differential graded algebra `A` over `R` is a morphism of DG algebras from
+`A` to the ground ring, placed in degree zero with zero differential.  Its kernel is the reduced
+augmentation ideal.  It is homogeneous, stable under the differential and multiplication from
+either side, and the unit section splits the underlying module as
+`A ≃ R × ker ε`.
+
+This is the input used by the reduced bar construction: tensor words are formed from the
+augmentation ideal rather than from the unit-containing algebra.
+
+## Main definitions
+
+* `TauCeti.DGAlgAugmentation`: a DG algebra morphism from `A` to the trivially graded base ring.
+* `TauCeti.DGAlgAugmentation.augmentationIdeal`: the homogeneous kernel of an augmentation.
+* `TauCeti.DGAlgAugmentation.splitLinearEquiv`: the canonical linear splitting
+  `A ≃ R × ker ε`.
+* `TauCeti.IsDGAlgebra.unitHom`: the canonical unit morphism from the trivially graded base.
+
+## References
+
+* B. Keller, *Introduction to A-infinity algebras and modules*, Section 3.6.
+-/
+
+public section
+
+namespace TauCeti
+
+universe uR uA
+
+variable {R : Type uR} {A : Type uA} [CommRing R] [Ring A] [Algebra R A]
+  {𝒜 : ℤ → Submodule R A} [GradedAlgebra 𝒜] {d : A →ₗ[R] A}
+
+/-- The ground ring with its trivial grading and zero differential is a differential graded
+algebra. -/
+theorem isDGAlgebra_trivialGrading (R : Type uR) [CommRing R] :
+    IsDGAlgebra (trivialGrading R R) (0 : R →ₗ[R] R) :=
+  isDGAlgebra_zero _
+
+/-- An augmentation of a differential graded algebra over `R` is a DG algebra morphism to `R`,
+where the ground ring is concentrated in degree zero and has zero differential. -/
+abbrev DGAlgAugmentation (h : IsDGAlgebra 𝒜 d) :=
+  DGAlgHom h (isDGAlgebra_trivialGrading R)
+
+namespace IsDGAlgebra
+
+/-- The canonical unit morphism from the trivially graded ground ring into a differential graded
+algebra. -/
+noncomputable def unitHom (h : IsDGAlgebra 𝒜 d) :
+    DGAlgHom (isDGAlgebra_trivialGrading R) h where
+  toGradedAlgHom :=
+    { toAlgHom := Algebra.ofId R A
+      map_mem := by
+        intro p r hr
+        rcases (mem_trivialGrading_iff R R).mp hr with rfl | rfl
+        · -- Normalize the `Algebra.ofId` wrapper to the algebra map used by the grading API.
+          change algebraMap R A r ∈ 𝒜 0
+          rw [Algebra.algebraMap_eq_smul_one]
+          exact (𝒜 0).smul_mem r (SetLike.one_mem_graded 𝒜)
+        · simp }
+  map_d' r := by simpa using h.map_algebraMap r
+
+@[simp]
+theorem unitHom_apply (h : IsDGAlgebra 𝒜 d) (r : R) :
+    h.unitHom r = algebraMap R A r := (rfl)
+
+end IsDGAlgebra
+
+namespace DGAlgAugmentation
+
+variable {h : IsDGAlgebra 𝒜 d} (e : DGAlgAugmentation h)
+
+/-- An augmentation restricts to the identity on the image of the ground ring. -/
+@[simp]
+theorem map_algebraMap (r : R) : e (algebraMap R A r) = r := by
+  change e (algebraMap R A r) = algebraMap R R r
+  exact e.toGradedAlgHom.commutes r
+
+/-- An augmentation annihilates every differential. -/
+@[simp]
+theorem map_d (a : A) : e (d a) = 0 := by
+  simpa using (DGAlgHom.map_d e a).symm
+
+/-- The augmentation ideal, as a homogeneous submodule of the underlying graded module. -/
+noncomputable def augmentationIdeal :
+    HomogeneousSubmodule (trivialGrading R R) 𝒜 where
+  toSubmodule := LinearMap.ker e.toGradedAlgHom.toAlgHom.toLinearMap
+  is_homogeneous' := by
+    intro p a ha
+    rw [LinearMap.mem_ker] at ha ⊢
+    -- Unwrap the kernel's linear map so the graded-homomorphism projection lemma applies.
+    change e a = 0 at ha
+    change e (DirectSum.decompose 𝒜 a p) = 0
+    rw [map_directSumDecompose 𝒜 (trivialGrading R R) e, ha,
+      DirectSum.decompose_zero]
+    rfl
+
+/-- Membership in the augmentation ideal is equivalent to vanishing under the augmentation. -/
+@[simp]
+theorem mem_augmentationIdeal {a : A} : a ∈ e.augmentationIdeal ↔ e a = 0 :=
+  LinearMap.mem_ker
+
+/-- The augmentation ideal absorbs multiplication on the left. -/
+theorem mul_mem_augmentationIdeal_left (a : A) {x : A} (hx : x ∈ e.augmentationIdeal) :
+    a * x ∈ e.augmentationIdeal := by
+  rw [mem_augmentationIdeal, map_mul, (mem_augmentationIdeal e).mp hx, mul_zero]
+
+/-- The augmentation ideal absorbs multiplication on the right. -/
+theorem mul_mem_augmentationIdeal_right {x : A} (hx : x ∈ e.augmentationIdeal) (a : A) :
+    x * a ∈ e.augmentationIdeal := by
+  rw [mem_augmentationIdeal, map_mul, (mem_augmentationIdeal e).mp hx, zero_mul]
+
+/-- The differential of every element lies in the augmentation ideal. -/
+theorem map_mem_augmentationIdeal (x : A) :
+    d x ∈ e.augmentationIdeal := by
+  rw [mem_augmentationIdeal, e.map_d]
+
+/-- The augmentation is a retraction of its canonical unit morphism. -/
+@[simp]
+theorem comp_unitHom :
+    e.comp h.unitHom = DGAlgHom.id (isDGAlgebra_trivialGrading R) := by
+  ext r
+  simp
+
+/-- Removing the scalar part of an element leaves an element of the augmentation ideal. -/
+theorem sub_algebraMap_mem_augmentationIdeal (a : A) :
+    a - algebraMap R A (e a) ∈ e.augmentationIdeal := by
+  rw [mem_augmentationIdeal, map_sub, e.map_algebraMap, sub_self]
+
+/-- The linear projection from an augmented DG algebra onto its augmentation ideal. -/
+noncomputable def reducedPart : A →ₗ[R] e.augmentationIdeal.toSubmodule where
+  toFun a := ⟨a - algebraMap R A (e a), e.sub_algebraMap_mem_augmentationIdeal a⟩
+  map_add' a b := by
+    apply Subtype.ext
+    change a + b - algebraMap R A (e (a + b)) =
+      (a - algebraMap R A (e a)) + (b - algebraMap R A (e b))
+    rw [map_add, map_add]
+    abel
+  map_smul' r a := by
+    apply Subtype.ext
+    change r • a - (Algebra.linearMap R A) (e (r • a)) =
+      r • (a - (Algebra.linearMap R A) (e a))
+    rw [show e (r • a) = r • e a from
+        e.toGradedAlgHom.toAlgHom.toLinearMap.map_smul r a,
+      (Algebra.linearMap R A).map_smul, smul_sub]
+
+/-- The reduced-part projection subtracts the scalar part of an element. -/
+@[simp]
+theorem coe_reducedPart (a : A) :
+    (e.reducedPart a : A) = a - algebraMap R A (e a) := (rfl)
+
+/-- The reduced-part projection fixes the augmentation ideal pointwise. -/
+@[simp]
+theorem reducedPart_apply_mem (x : e.augmentationIdeal) :
+    e.reducedPart (x : A) = x := by
+  apply Subtype.ext
+  rw [coe_reducedPart, (mem_augmentationIdeal e).mp x.property, map_zero, sub_zero]
+
+/-- The canonical splitting of an augmented DG algebra into its scalar and reduced parts. -/
+noncomputable def splitLinearEquiv : A ≃ₗ[R] R × e.augmentationIdeal where
+  toFun a := (e a, e.reducedPart a)
+  invFun x := algebraMap R A x.1 + x.2
+  map_add' a b := Prod.ext (map_add e a b) (map_add e.reducedPart a b)
+  map_smul' r a := Prod.ext (map_smul e r a) (map_smul e.reducedPart r a)
+  left_inv a := by
+    simp only [coe_reducedPart]
+    abel
+  right_inv x := by
+    ext
+    · change e (algebraMap R A x.1 + (x.2 : A)) = x.1
+      rw [map_add, e.map_algebraMap, (mem_augmentationIdeal e).mp x.2.property, add_zero]
+    · rw [coe_reducedPart, map_add, e.map_algebraMap,
+        (mem_augmentationIdeal e).mp x.2.property, add_zero]
+      -- Normalize the inverse lambda before applying the additive cancellation law.
+      change (algebraMap R A x.1 + (x.2 : A)) - algebraMap R A x.1 = x.2
+      exact add_sub_cancel_left _ _
+
+/-- The splitting sends an element to its scalar part and its reduced part. -/
+@[simp]
+theorem splitLinearEquiv_apply (a : A) :
+    e.splitLinearEquiv a = (e a, e.reducedPart a) := (rfl)
+
+/-- The inverse splitting adds the scalar and reduced parts. -/
+@[simp]
+theorem splitLinearEquiv_symm_apply (x : R × e.augmentationIdeal) :
+    e.splitLinearEquiv.symm x = algebraMap R A x.1 + x.2 := (rfl)
+
+end DGAlgAugmentation
+
+end TauCeti

--- a/TauCeti/RingTheory/GradedAlgebra/Trivial.lean
+++ b/TauCeti/RingTheory/GradedAlgebra/Trivial.lean
@@ -84,8 +84,7 @@ noncomputable instance instGradedAlgebraTrivialGrading :
 zero map in every other degree. -/
 @[simp]
 theorem proj_trivialGrading (p : ℤ) (a : A) :
-    GradedRing.proj (trivialGrading R A) p a = if p = 0 then a else 0 := by
-  rw [GradedRing.proj_apply]
+    ((DirectSum.decompose (trivialGrading R A) a) p : A) = if p = 0 then a else 0 := by
   by_cases hp : p = 0
   · subst hp
     rw [ite_eq_left rfl]
@@ -97,7 +96,7 @@ theorem proj_trivialGrading (p : ℤ) (a : A) :
 
 /-- Scalar multiplication by the trivially graded base ring preserves every homogeneous piece of
 an internally graded algebra. -/
-instance instGradedSMulTrivialGrading (𝒜 : ℤ → Submodule R A) [GradedAlgebra 𝒜] :
+instance instGradedSMulTrivialGrading (𝒜 : ℤ → Submodule R A) :
     SetLike.GradedSMul (trivialGrading R R) 𝒜 where
   smul_mem := by
     intro p q r a hr ha

--- a/TauCeti/RingTheory/GradedAlgebra/Trivial.lean
+++ b/TauCeti/RingTheory/GradedAlgebra/Trivial.lean
@@ -18,6 +18,7 @@ It is the canonical target grading for augmentations of integer-graded algebras.
 ## Main definitions
 
 * `TauCeti.trivialGrading`: the internal integer grading with the whole algebra in degree zero.
+* `TauCeti.toTrivialGradingZero`: the algebra viewed as the degree-zero piece of that grading.
 
 ## Main results
 
@@ -32,7 +33,7 @@ open DirectSum
 
 namespace TauCeti
 
-variable (R A : Type*) [CommRing R] [Ring A] [Algebra R A]
+variable (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A]
 
 /-- The trivial integer grading of an `R`-algebra: all elements have degree zero and every other
 homogeneous piece is zero. -/
@@ -57,41 +58,52 @@ theorem mem_trivialGrading_iff {p : ℤ} {a : A} :
   · simp [hp]
   · simp [trivialGrading, hp]
 
-noncomputable instance instGradedAlgebraTrivialGrading :
-    GradedAlgebra (trivialGrading R A) := by
-  letI : SetLike.GradedMonoid (trivialGrading R A) := {
-    one_mem := by simp
-    mul_mem := by
-      intro p q a b ha hb
-      rcases (mem_trivialGrading_iff R A).mp ha with rfl | rfl
-      · rcases (mem_trivialGrading_iff R A).mp hb with rfl | rfl <;> simp
-      · simp }
-  apply DirectSum.IsInternal.gradedAlgebra
-  rw [DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top]
-  constructor
-  · rw [iSupIndep_def]
-    intro p
-    by_cases hp : p = 0
-    · subst hp
-      simp only [trivialGrading_zero, top_disjoint, iSup_eq_bot]
-      exact fun i hi ↦ trivialGrading_eq_bot R A hi
-    · rw [trivialGrading_eq_bot R A hp]
-      exact disjoint_bot_left
-  · apply top_unique
-    exact le_iSup_of_le 0 (by simp)
+/-- Every element of the algebra, viewed as an element of the degree-zero piece of the trivial
+grading. -/
+def toTrivialGradingZero : A →+ trivialGrading R A 0 where
+  toFun a := ⟨a, by simp⟩
+  map_zero' := rfl
+  map_add' _ _ := rfl
+
+@[simp]
+theorem coe_toTrivialGradingZero (a : A) : (toTrivialGradingZero R A a : A) = a := (rfl)
+
+/-- The trivial grading is an internal grading: an element is its own degree-zero component, and
+all higher components vanish. -/
+instance instGradedAlgebraTrivialGrading : GradedAlgebra (trivialGrading R A) where
+  one_mem := by simp
+  mul_mem := by
+    intro p q a b ha hb
+    rcases (mem_trivialGrading_iff R A).mp ha with rfl | rfl
+    · rcases (mem_trivialGrading_iff R A).mp hb with rfl | rfl <;> simp
+    · simp
+  decompose' a := DirectSum.of (fun p ↦ trivialGrading R A p) 0 (toTrivialGradingZero R A a)
+  left_inv a := by simp
+  right_inv x := by
+    induction x using DirectSum.induction_on with
+    | zero => simp
+    | of p y =>
+      rw [DirectSum.coeAddMonoidHom_of]
+      by_cases hp : p = 0
+      · subst hp
+        exact congrArg _ (Subtype.ext rfl)
+      · have hy : y = 0 :=
+          Subtype.ext (((mem_trivialGrading_iff R A).mp y.2).resolve_left hp)
+        rw [hy]
+        simp
+    | add x y hx hy => simp only [map_add, hx, hy]
 
 /-- The homogeneous projection for the trivial grading is the identity in degree zero and the
 zero map in every other degree. -/
 @[simp]
 theorem proj_trivialGrading (p : ℤ) (a : A) :
     ((DirectSum.decompose (trivialGrading R A) a) p : A) = if p = 0 then a else 0 := by
+  have ha : a ∈ trivialGrading R A 0 := by simp
   by_cases hp : p = 0
   · subst hp
     rw [ite_eq_left rfl]
-    exact DirectSum.decompose_of_mem_same (trivialGrading R A)
-      (show a ∈ trivialGrading R A 0 by simp)
-  · rw [DirectSum.decompose_of_mem_ne _
-      (show a ∈ trivialGrading R A 0 by simp) (Ne.symm hp)]
+    exact DirectSum.decompose_of_mem_same (trivialGrading R A) ha
+  · rw [DirectSum.decompose_of_mem_ne _ ha (Ne.symm hp)]
     simp [hp]
 
 /-- Scalar multiplication by the trivially graded base ring preserves every homogeneous piece of

--- a/TauCeti/RingTheory/GradedAlgebra/Trivial.lean
+++ b/TauCeti/RingTheory/GradedAlgebra/Trivial.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.GradedMulAction
+public import Mathlib.RingTheory.GradedAlgebra.Basic
+
+/-!
+# The trivial grading of an algebra
+
+Every algebra has a grading concentrated in degree zero.  This file packages that grading in the
+internal `GradedAlgebra` presentation and records its elementary membership and projection API.
+It is the canonical target grading for augmentations of integer-graded algebras.
+
+## Main definitions
+
+* `TauCeti.trivialGrading`: the internal integer grading with the whole algebra in degree zero.
+
+## Main results
+
+* `TauCeti.instGradedAlgebraTrivialGrading`: the trivial grading is a graded algebra.
+* `TauCeti.proj_trivialGrading`: its degree projection is the identity in degree zero and zero in
+  every other degree.
+-/
+
+public section
+
+open DirectSum
+
+namespace TauCeti
+
+variable (R A : Type*) [CommRing R] [Ring A] [Algebra R A]
+
+/-- The trivial integer grading of an `R`-algebra: all elements have degree zero and every other
+homogeneous piece is zero. -/
+def trivialGrading (p : ℤ) : Submodule R A :=
+  if p = 0 then ⊤ else ⊥
+
+/-- The degree-zero piece of the trivial grading is the whole algebra. -/
+@[simp]
+theorem trivialGrading_zero : trivialGrading R A 0 = ⊤ := by
+  simp [trivialGrading]
+
+/-- Every nonzero-degree piece of the trivial grading is zero. -/
+theorem trivialGrading_eq_bot {p : ℤ} (hp : p ≠ 0) : trivialGrading R A p = ⊥ := by
+  simp [trivialGrading, hp]
+
+/-- An element belongs to degree `p` of the trivial grading exactly when `p = 0` or the element
+itself is zero. -/
+@[simp]
+theorem mem_trivialGrading_iff {p : ℤ} {a : A} :
+    a ∈ trivialGrading R A p ↔ p = 0 ∨ a = 0 := by
+  by_cases hp : p = 0
+  · simp [hp]
+  · simp [trivialGrading, hp]
+
+noncomputable instance instGradedAlgebraTrivialGrading :
+    GradedAlgebra (trivialGrading R A) := by
+  letI : SetLike.GradedMonoid (trivialGrading R A) := {
+    one_mem := by simp
+    mul_mem := by
+      intro p q a b ha hb
+      rcases (mem_trivialGrading_iff R A).mp ha with rfl | rfl
+      · rcases (mem_trivialGrading_iff R A).mp hb with rfl | rfl <;> simp
+      · simp }
+  apply DirectSum.IsInternal.gradedAlgebra
+  rw [DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top]
+  constructor
+  · rw [iSupIndep_def]
+    intro p
+    by_cases hp : p = 0
+    · subst hp
+      simp only [trivialGrading_zero, top_disjoint, iSup_eq_bot]
+      exact fun i hi ↦ trivialGrading_eq_bot R A hi
+    · rw [trivialGrading_eq_bot R A hp]
+      exact disjoint_bot_left
+  · apply top_unique
+    exact le_iSup_of_le 0 (by simp)
+
+/-- The homogeneous projection for the trivial grading is the identity in degree zero and the
+zero map in every other degree. -/
+@[simp]
+theorem proj_trivialGrading (p : ℤ) (a : A) :
+    GradedRing.proj (trivialGrading R A) p a = if p = 0 then a else 0 := by
+  rw [GradedRing.proj_apply]
+  by_cases hp : p = 0
+  · subst hp
+    rw [ite_eq_left rfl]
+    exact DirectSum.decompose_of_mem_same (trivialGrading R A)
+      (show a ∈ trivialGrading R A 0 by simp)
+  · rw [DirectSum.decompose_of_mem_ne _
+      (show a ∈ trivialGrading R A 0 by simp) (Ne.symm hp)]
+    simp [hp]
+
+/-- Scalar multiplication by the trivially graded base ring preserves every homogeneous piece of
+an internally graded algebra. -/
+instance instGradedSMulTrivialGrading (𝒜 : ℤ → Submodule R A) [GradedAlgebra 𝒜] :
+    SetLike.GradedSMul (trivialGrading R R) 𝒜 where
+  smul_mem := by
+    intro p q r a hr ha
+    rcases (mem_trivialGrading_iff R R).mp hr with rfl | rfl
+    · simpa using (𝒜 q).smul_mem r ha
+    · simp
+
+end TauCeti


### PR DESCRIPTION
This PR defines an augmentation of a differential graded algebra as a `DGAlgHom` to the ground ring with its degree-zero grading and zero differential, constructs the reduced augmentation ideal as a homogeneous submodule, proves that it absorbs multiplication and contains every differential, and gives the canonical linear splitting `A ≃ₗ[R] R × ker ε`.

The exact roadmap target is `TauCetiRoadmap/DGAInfinity/README.md`, Layer 1, first bullet, “Define nonunital, unital, and augmented DG algebras on graded `k`-modules,” within the milestone **DG algebras, categories, modules, and bimodules**. After this PR, that milestone still needs the nonunital variant and endomorphism-complex constructor, together with the remaining DG category, module, and bimodule theory.

This is the most effective current step because `IsDGAlgebra` and `DGAlgHom` are already on `main`, while the direct `A∞` coderivation-square endpoint, DG-category definition, and DG opposite are independently in flight. The reduced augmentation ideal and its base-plus-ideal splitting are the explicit inputs consumed by the roadmap’s reduced bar construction `B∞A = Tᶜ(s Ā)`.

The implementation reuses Mathlib’s internal `GradedAlgebra`, `HomogeneousSubmodule`, and graded-homomorphism projection API; no Mathlib or external formalization is vendored. The augmentation convention and reduced bar input follow B. Keller, *Introduction to A-infinity algebras and modules*, Section 3.6, as cited in the module documentation.

The change adds `TauCeti/RingTheory/GradedAlgebra/Trivial.lean` (108 lines) and `TauCeti/Algebra/Homology/DG/Algebra/Augmentation.lean` (202 lines).

Roadmap: DGAInfinity

<!--tauceti-target:v1 {"focus":"DGAInfinity","id":"augmented-dg-algebras"}-->

🤖 Prepared with Codex
