### PR TITLE
feat(Isogeny): pointedness is exactly a pole of x at infinity

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/InfinityPlace.lean
@@ -51,6 +51,9 @@ Neither direction uses ellipticity, separability, or the degree of an isogeny.
 * `TauCeti.Isogeny.comap_infinityPlace_apply_algebraMap`: the restricted valuation, evaluated on
   the image of the target coordinate ring, is `v_∞ ∘ φ` — the computation rule the other two are
   stated through.
+* `TauCeti.CoordinatePullback.mapsInfinity_iff_one_lt_infinityPlace`: **pointedness is exactly a
+  pole of `x` at infinity**, the form in which a construction can establish it by one valuation
+  computation.
 * `TauCeti.CoordinatePullback.mapsInfinity_iff_isEquiv_comap_infinityPlace`: **the pointedness
   criterion**, `MapsInfinity σ ↔ σ_*(O₁) = O₂`, for an embedding `σ` of function fields.
 
@@ -237,6 +240,18 @@ theorem mapsInfinity_of_one_lt_infinityPlace (σ : W₂.FunctionField →ₐ[F] 
   refine isIntegral_trans (A := C) _ (IsIntegral.tower_top (R := F[X]) ?_)
   exact (Algebra.IsIntegral.isIntegral (R := F[X]) z).map
     (IsScalarTower.toAlgHom F[X] W₁.CoordinateRing W₁.FunctionField)
+
+/-- **Pointedness is exactly a pole of `x` at infinity.** An embedding of function fields
+restricts to a pointed coordinate pullback precisely when it sends the target's coordinate `x` to
+a function with a pole at the source's point at infinity, so a construction can establish
+pointedness by a single valuation computation. -/
+theorem mapsInfinity_iff_one_lt_infinityPlace (σ : W₂.FunctionField →ₐ[F] W₁.FunctionField) :
+    MapsInfinity (σ.comp (IsScalarTower.toAlgHom F W₂.CoordinateRing W₂.FunctionField)) ↔
+      1 < infinityPlace W₁ (σ (algebraMap F[X] W₂.FunctionField X)) := by
+  refine ⟨fun hσ => ?_, mapsInfinity_of_one_lt_infinityPlace σ⟩
+  rw [IsScalarTower.algebraMap_apply F[X] W₂.CoordinateRing W₂.FunctionField]
+  exact Isogeny.one_lt_infinityPlace_pullback_X ({ pullback := _, mapsInfinity := hσ } :
+    Isogeny W₁ W₂)
 
 /-- **The pointedness criterion.** An embedding `σ : F(W₂) → F(W₁)` restricts to a coordinate
 pullback which maps infinity to infinity exactly when the source's place at infinity restricts


### PR DESCRIPTION
`Isogeny/InfinityPlace.lean` already proves both halves of a pointedness criterion in valuation form, but never states it as one:

* `mapsInfinity_of_one_lt_infinityPlace` — an embedding under which `x` acquires a pole at infinity is pointed;
* `Isogeny.one_lt_infinityPlace_pullback_X` — the pullback of `x` along an isogeny has a pole at infinity.

Together they say `MapsInfinity σ ↔ 1 < v_∞ (σ x₂)`. The necessity direction needs one step to assemble — a pointed `σ` cuts out an isogeny, and the existing lemma applies to that — which is the same manoeuvre `mapsInfinity_iff_isEquiv_comap_infinityPlace` already performs a few lines below.

Why state it: pointedness quantifies over every element of a coordinate ring, and a construction that produces a coordinate pullback should not have to reason about all of them. `mapsInfinity_iff_isIntegralElem_genericX` (#5791) reduced it to one integrality obligation; this reduces it to one **valuation** obligation, which is the form that suits a construction whose output is given by a rational formula rather than by a monic witness — the sum of two pullbacks being the case in view.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:Layer-1:hom-group-and-degree-form"}-->

Provenance: original work — this assembles two already-merged Tau Ceti lemmas in the file that states both. No new mathematics: the sufficiency is used verbatim and the necessity reuses the isogeny-packaging step already present in the adjacent criterion. Sources swept: github.com/CBirkbeck/AINTLIB @ 513e83879e2f8cbc626eb9e04d660e92be16ccba has no pointedness field on its `Isogeny` at all, so no counterpart; Mathlib @ pin 5fcc6656691e has no `Isogeny` in `AlgebraicGeometry/EllipticCurve/` and no place theory for these curves.
