### PR TITLE
feat: at a pole of x, the coordinates have poles in ratio two to three

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Unique.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Unique.lean
@@ -13,6 +13,9 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.Infin
 -- them that `open WeierstrassCurve.Affine` inside `namespace TauCeti` would then resolve the open
 -- ambiguously and silently lose `_root_.WeierstrassCurve.Affine`.
 import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.CoordinateRing
+-- Proof-only: the generic point's equation, and the general two-to-three pole ratio it feeds.
+import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.GenericPoint
+import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.ValuationIntegrality
 import Mathlib.NumberTheory.RatFunc.Ostrowski
 
 /-!
@@ -234,52 +237,22 @@ variable [v.IsTrivialOn F]
 
 include hx
 
-/-- The Weierstrass equation, valued: the left-hand product has value `(v x) ^ 3`. -/
-private theorem val_mul_val_add :
-    v (algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W Y)) *
-        v (algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W Y)
-          + algebraMap F[X] W.FunctionField (Polynomial.C W.a₁ * Polynomial.X + Polynomial.C W.a₃))
-      = v (algebraMap F[X] W.FunctionField Polynomial.X) ^ 3 := by
-  have hP : (Polynomial.X ^ 3 + Polynomial.C W.a₂ * Polynomial.X ^ 2
-      + Polynomial.C W.a₄ * Polynomial.X + Polynomial.C W.a₆ : F[X]).natDegree = 3 := by
-    compute_degree!
-  rw [← map_mul, mk_Y_mul_add_eq, val_algebraMap_eq_pow_natDegree v hx (p := _) (by
-    intro h; rw [h, Polynomial.natDegree_zero] at hP; omega), hP]
-
-/-- The linear coefficient `a₁X + a₃` has value at most `v x`. -/
-private theorem val_add_le :
-    v (algebraMap F[X] W.FunctionField (Polynomial.C W.a₁ * Polynomial.X + Polynomial.C W.a₃))
-      ≤ v (algebraMap F[X] W.FunctionField Polynomial.X) := by
-  have : (Polynomial.C W.a₁ * Polynomial.X + Polynomial.C W.a₃ : F[X]).natDegree ≤ 1 := by
-    compute_degree
-  simpa using val_algebraMap_le_pow v hx this
-
-/-- **`y` has a higher pole than `x`.** If `v y ≤ v x` then the left-hand side of the Weierstrass
-equation has value at most `(v x) ^ 2`, while its right-hand side has value `(v x) ^ 3`. -/
+/-- **`y` has a higher pole than `x`.** -/
 theorem val_X_lt_val_mk_Y :
     v (algebraMap F[X] W.FunctionField Polynomial.X)
       < v (algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W Y)) := by
-  by_contra hle
-  rw [not_lt] at hle
-  have h1 := (v.map_add (algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W Y))
-    (algebraMap F[X] W.FunctionField
-      (Polynomial.C W.a₁ * Polynomial.X + Polynomial.C W.a₃))).trans
-    (max_le hle (val_add_le v hx))
-  have h2 := val_mul_val_add v hx
-  have h3 : v (algebraMap F[X] W.FunctionField Polynomial.X) ^ 3
-      ≤ v (algebraMap F[X] W.FunctionField Polynomial.X) ^ 2 := by
-    rw [← h2, sq]
-    exact mul_le_mul' hle h1
-  exact absurd h3 (not_le.mpr (pow_lt_pow_right₀ hx (by norm_num)))
+  have h := valuation_x_lt_valuation_y (W := (W⁄W.FunctionField).toAffine) v
+    (equation_genericX_genericY W) (by rwa [genericX_eq_algebraMap])
+  rwa [genericX_eq_algebraMap, genericY_def] at h
 
 /-- **The pole orders of `x` and `y` are in the ratio `2 : 3`**: `(v y) ^ 2 = (v x) ^ 3`. Once
 `v x < v y` is known, the second factor of the Weierstrass equation has value `v y`. -/
 theorem val_mk_Y_sq :
     v (algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W Y)) ^ 2
       = v (algebraMap F[X] W.FunctionField Polynomial.X) ^ 3 := by
-  rw [sq, ← val_mul_val_add v hx]
-  congr 1
-  exact (v.map_add_eq_of_lt_left ((val_add_le v hx).trans_lt (val_X_lt_val_mk_Y v hx))).symm
+  have h := valuation_y_sq_eq_valuation_x_cube (W := (W⁄W.FunctionField).toAffine) v
+    (equation_genericX_genericY W) (by rwa [genericX_eq_algebraMap])
+  rwa [genericX_eq_algebraMap, genericY_def] at h
 
 omit [v.IsTrivialOn F] in
 /-- `v x` is a unit of the value group, being larger than `1`. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/ValuationIntegrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/ValuationIntegrality.lean
@@ -41,6 +41,8 @@ the `IsDedekindDomain.HeightOneSpectrum.valuation` of a varying prime, which can
 
 * `WeierstrassCurve.Affine.valuation_a₁_le_one` and its `a₂`, `a₃`, `a₄`, `a₆` companions: the
   coefficients of a curve with an integral model are integral, over any value group.
+* `WeierstrassCurve.Affine.valuation_y_sq_eq_valuation_x_cube`: at a pole of `x`, the two
+  coordinates have poles in ratio two to three, over any value group.
 * `WeierstrassCurve.Affine.valuation_x_le_one_and_valuation_y_le_one_of_valuation_x_lt_exp_two`:
   an affine point whose `x`-coordinate has a pole of order less than two has both coordinates
   integral.
@@ -201,6 +203,23 @@ private lemma valuation_lhs_le {x y : F} {C : Γ₀} (hxC : v x ≤ C) (hyC : v 
     calc v W.a₃ * v y ≤ 1 * C := mul_le_mul' (valuation_a₃_le_one v) hyC
       _ = C := one_mul C
       _ ≤ C ^ 2 := le_self_pow h1C (by lia)
+
+/-- **A pole of `x` forces one of `y`, of three halves the order.** On a point of the curve whose
+`x`-coordinate is not integral, `v(y)² = v(x)³`: writing the valuations additively, `x` has a pole
+of order `2e` and `y` one of order `3e`. Neither coordinate can dominate the other by any other
+ratio, because the two sides of the Weierstrass equation must agree. -/
+theorem valuation_y_sq_eq_valuation_x_cube {x y : F} (hxy : W.Equation x y) (hx : 1 < v x) :
+    v y ^ 2 = v x ^ 3 := by
+  -- `y` strictly dominates: otherwise `v x` bounds both coordinates, so the left-hand side is at
+  -- most `v x ^ 2` while the right-hand side is exactly `v x ^ 3`.
+  have hlt : v x < v y := by
+    by_contra hle
+    rw [not_lt] at hle
+    have hbound := valuation_lhs_le (W := W) v le_rfl hle hx.le
+    rw [valuation_lhs_eq_rhs v hxy, valuation_rhs_eq (W := W) v hx] at hbound
+    exact absurd hbound (not_le.2 (pow_lt_pow_right₀ hx (by lia)))
+  rw [← valuation_lhs_eq (W := W) v hlt (hx.trans hlt), valuation_lhs_eq_rhs v hxy,
+    valuation_rhs_eq (W := W) v hx]
 
 end Integral
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/ValuationIntegrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/ValuationIntegrality.lean
@@ -41,6 +41,8 @@ the `IsDedekindDomain.HeightOneSpectrum.valuation` of a varying prime, which can
 
 * `WeierstrassCurve.Affine.valuation_a₁_le_one` and its `a₂`, `a₃`, `a₄`, `a₆` companions: the
   coefficients of a curve with an integral model are integral, over any value group.
+* `WeierstrassCurve.Affine.valuation_x_lt_valuation_y`: at a pole of `x`, the `y`-coordinate
+  strictly dominates.
 * `WeierstrassCurve.Affine.valuation_y_sq_eq_valuation_x_cube`: at a pole of `x`, the two
   coordinates have poles in ratio two to three, over any value group.
 * `WeierstrassCurve.Affine.valuation_x_le_one_and_valuation_y_le_one_of_valuation_x_lt_exp_two`:
@@ -126,6 +128,30 @@ needs `Γ₀ = ℤᵐ⁰`.
 `Field F` cannot be weakened here: `Valuation.valuationSubring` is defined only for a field
 (`Mathlib/RingTheory/Valuation/ValuationSubring.lean:33`). -/
 
+section TrivialBase
+
+variable {K Γ₀ : Type*} [Field K] [LinearOrderedCommGroupWithZero Γ₀] [Algebra F K]
+  (v : Valuation K Γ₀) [v.IsTrivialOn F]
+
+/-- **A curve over a trivially valued base has an integral model.** Every coefficient of `W⁄K` is
+the image of one of `W`'s, and a valuation trivial on `F` puts all of those in its valuation
+subring. -/
+instance isIntegral_baseChange (W : _root_.WeierstrassCurve F) :
+    _root_.WeierstrassCurve.IsIntegral v.valuationSubring (W⁄K) where
+  integral :=
+    ⟨{ a₁ := ⟨algebraMap F K W.a₁,
+         Valuation.IsTrivialOn.valuation_algebraMap_le_one (A := F) v W.a₁⟩
+       a₂ := ⟨algebraMap F K W.a₂,
+         Valuation.IsTrivialOn.valuation_algebraMap_le_one (A := F) v W.a₂⟩
+       a₃ := ⟨algebraMap F K W.a₃,
+         Valuation.IsTrivialOn.valuation_algebraMap_le_one (A := F) v W.a₃⟩
+       a₄ := ⟨algebraMap F K W.a₄,
+         Valuation.IsTrivialOn.valuation_algebraMap_le_one (A := F) v W.a₄⟩
+       a₆ := ⟨algebraMap F K W.a₆,
+         Valuation.IsTrivialOn.valuation_algebraMap_le_one (A := F) v W.a₆⟩ }, rfl⟩
+
+end TrivialBase
+
 section Coefficients
 
 variable {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀] (v : Valuation F Γ₀) {W : Affine F}
@@ -204,20 +230,24 @@ private lemma valuation_lhs_le {x y : F} {C : Γ₀} (hxC : v x ≤ C) (hyC : v 
       _ = C := one_mul C
       _ ≤ C ^ 2 := le_self_pow h1C (by lia)
 
+/-- **At a pole of `x`, the `y`-coordinate strictly dominates.** -/
+theorem valuation_x_lt_valuation_y {x y : F} (hxy : W.Equation x y) (hx : 1 < v x) :
+    v x < v y := by
+  by_contra hle
+  rw [not_lt] at hle
+  -- `v x` then bounds both coordinates, so the left-hand side is at most `v x ^ 2` while the
+  -- right-hand side is exactly `v x ^ 3`.
+  have hbound := valuation_lhs_le (W := W) v le_rfl hle hx.le
+  rw [valuation_lhs_eq_rhs v hxy, valuation_rhs_eq (W := W) v hx] at hbound
+  exact absurd hbound (not_le.2 (pow_lt_pow_right₀ hx (by lia)))
+
 /-- **A pole of `x` forces one of `y`, of three halves the order.** On a point of the curve whose
 `x`-coordinate is not integral, `v(y)² = v(x)³`: writing the valuations additively, `x` has a pole
 of order `2e` and `y` one of order `3e`. Neither coordinate can dominate the other by any other
 ratio, because the two sides of the Weierstrass equation must agree. -/
 theorem valuation_y_sq_eq_valuation_x_cube {x y : F} (hxy : W.Equation x y) (hx : 1 < v x) :
     v y ^ 2 = v x ^ 3 := by
-  -- `y` strictly dominates: otherwise `v x` bounds both coordinates, so the left-hand side is at
-  -- most `v x ^ 2` while the right-hand side is exactly `v x ^ 3`.
-  have hlt : v x < v y := by
-    by_contra hle
-    rw [not_lt] at hle
-    have hbound := valuation_lhs_le (W := W) v le_rfl hle hx.le
-    rw [valuation_lhs_eq_rhs v hxy, valuation_rhs_eq (W := W) v hx] at hbound
-    exact absurd hbound (not_le.2 (pow_lt_pow_right₀ hx (by lia)))
+  have hlt := valuation_x_lt_valuation_y v hxy hx
   rw [← valuation_lhs_eq (W := W) v hlt (hx.trans hlt), valuation_lhs_eq_rhs v hxy,
     valuation_rhs_eq (W := W) v hx]
 


### PR DESCRIPTION
`ValuationIntegrality.lean` proves the coordinate dichotomy for an affine point over a valued field, and its module docstring states the reason in passing:

> at a pole `v(y)² = v(x)³`, and `exp 3` is not a square, which rules out the one intermediate value

That equality is never stated. The three estimates it needs are all in the file already, as private lemmas: the two sides of the Weierstrass equation have equal valuation; at `1 < v(x)` the right-hand side is exactly `v(x)³`; and when `v(y)` dominates, the left-hand side is exactly `v(y)²`. What was missing is the step that rules out the other ordering — if `v(y) ≤ v(x)` then `v(x)` bounds both coordinates, so the left-hand side is at most `v(x)²` while the right-hand side is `v(x)³`, and `1 < v(x)` makes that impossible.

So `valuation_y_sq_eq_valuation_x_cube` is the conclusion the file was already reasoning through, now available to consumers. Written additively: a pole of order `2e` in `x` forces one of order `3e` in `y`, and no other ratio is possible.

It is stated in the general `Γ₀` section, not the discrete one, because nothing in the argument looks at the value group — the file is already organised along exactly that split, and only the parity argument that rules out `v(x) = exp 1` needs `Γ₀ = ℤᵐ⁰`.

The immediate consumer in view is the place at infinity of a function field: pointedness of a coordinate pullback is a pole of `x` there (#5801), and the pole *orders* of the pulled-back coordinates are what a valuation computation on the sum of two pullbacks has to work with.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md:Layer-1:hom-group-and-degree-form"}-->

Provenance: original work — this states a conclusion of already-merged Tau Ceti code, assembled from three private lemmas in the same file (`valuation_lhs_eq_rhs`, `valuation_rhs_eq`, `valuation_lhs_eq`) plus the file's own `valuation_lhs_le` for the excluded ordering. No new estimate is proved. Sources swept: github.com/CBirkbeck/AINTLIB @ 513e83879e2f8cbc626eb9e04d660e92be16ccba has valuation work in `Valuation.lean` and `OrdAtInftyBridge.lean` but none of it states this ratio for a general valued field; Mathlib @ pin 5fcc6656691e has the Weierstrass API but no valuation estimates on it.
