### PR TITLE
refactor(HeckeRing): name the degree balance behind the T(p) multiplication table

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -471,6 +471,35 @@ private lemma multiplicity_one_prime_pow_succ_pos (k : ℕ) :
   group
 
 include hp in
+/-- The degree balance for `T(1,p) · T(1,pᵏ)` over `ℤ`: the multiplicity-weighted degrees of the
+two output cosets `T(1, p^(k+1))` and `T(p, pᵏ)` sum to the product `(p + 1) · p^(k-1)(p + 1)` of
+the input degrees. -/
+private lemma multiplicity_degree_sum_prime_pow (k : ℕ) (hk : 0 < k) :
+    (multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+        (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+        (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
+        (((diagCoset ![1, p ^ (k + 1)]).rep : GL (Fin 2) ℚ)) : ℤ) *
+        ((p : ℤ) ^ k * ((p : ℤ) + 1)) +
+      (multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+        (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+        (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
+        (((diagCoset ![p, p ^ k]).rep : GL (Fin 2) ℚ)) : ℤ) *
+        ((diagCoset (![p, p ^ k] : Fin 2 → ℕ)).degree : ℤ) =
+      ((p : ℤ) + 1) * ((p : ℤ) ^ (k - 1) * ((p : ℤ) + 1)) := by
+  have h_deg := multiplicity_degree_sum_eq (diagCoset ![1, p]) (diagCoset ![1, p ^ k])
+    (diagCoset ![1, p ^ (k + 1)]) (diagCoset ![p, p ^ k])
+    (diagCoset_one_prime_pow_succ_ne p hp k hk) (multiplicity_eq_zero_of_ne_diagCoset p hp k)
+  -- All three degrees are the `i = 0` case of `degree_diagCoset_prime_pow`; `simpa` absorbs
+  -- the `p ^ 0 = 1` and `0 + j = j` normalisations.
+  rw [show (diagCoset (![1, p] : Fin 2 → ℕ)).degree = p + 1 by
+      simpa using degree_diagCoset_prime_pow p hp 0 1 one_pos,
+    show (diagCoset (![1, p ^ k] : Fin 2 → ℕ)).degree = p ^ (k - 1) * (p + 1) by
+      simpa using degree_diagCoset_prime_pow p hp 0 k hk,
+    show (diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ)).degree = p ^ k * (p + 1) by
+      simpa using degree_diagCoset_prime_pow p hp 0 (k + 1) (by omega)] at h_deg
+  exact_mod_cast h_deg
+
+include hp in
 /-- The multiplicities in `T(1,p) · T(1,pᵏ)`: the coset `T(1, p^(k+1))` appears once, and
 `T(p, pᵏ)` appears `p + 1` times for `k = 1` and `p` times for `k ≥ 2`. -/
 private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
@@ -492,19 +521,8 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
     (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
     (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
     (((diagCoset ![p, p ^ k]).rep : GL (Fin 2) ℚ)) with hm2_def
-  have h_ne := diagCoset_one_prime_pow_succ_ne p hp k hk
-  have h_deg := multiplicity_degree_sum_eq (diagCoset ![1, p]) (diagCoset ![1, p ^ k])
-    (diagCoset ![1, p ^ (k + 1)]) (diagCoset ![p, p ^ k]) h_ne
-    (multiplicity_eq_zero_of_ne_diagCoset p hp k)
+  have h_deg := multiplicity_degree_sum_prime_pow p hp k hk
   rw [← hm1_def, ← hm2_def] at h_deg
-  -- All three degrees are the `i = 0` case of `degree_diagCoset_prime_pow`; `simpa` absorbs
-  -- the `p ^ 0 = 1` and `0 + j = j` normalisations.
-  rw [show (diagCoset (![1, p] : Fin 2 → ℕ)).degree = p ^ 0 * (p + 1) by
-      simpa using degree_diagCoset_prime_pow p hp 0 1 one_pos,
-    show (diagCoset (![1, p ^ k] : Fin 2 → ℕ)).degree = p ^ (k - 1) * (p + 1) by
-      simpa using degree_diagCoset_prime_pow p hp 0 k hk,
-    show (diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ)).degree = p ^ k * (p + 1) by
-      simpa using degree_diagCoset_prime_pow p hp 0 (k + 1) (by omega)] at h_deg
   have hm1_pos : 0 < m1 := multiplicity_one_prime_pow_succ_pos p hp k
   have hp2 : (2 : ℤ) ≤ (p : ℤ) := by exact_mod_cast hp.two_le
   by_cases hk1 : k = 1
@@ -512,14 +530,8 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
     -- `![p, p ^ 1]` is the constant vector, so the generic `degree_diagCoset_const` applies.
     rw [show (![p, p ^ 1] : Fin 2 → ℕ) = fun _ ↦ p from by funext i; fin_cases i <;> simp,
       degree_diagCoset_const 2 p] at h_deg
-    have h_degZ : (m1 : ℤ) * ((p : ℤ) ^ 1 * ((p : ℤ) + 1)) + (m2 : ℤ) * 1 =
-        ((p : ℤ) + 1) * ((p : ℤ) + 1) := by
-      have := h_deg
-      push_cast at this ⊢
-      norm_num at this ⊢
-      linarith
     obtain ⟨h1, h2⟩ := m1_eq_one_and_m2_eq_of_eq_one (p : ℤ) (m1 : ℤ) (m2 : ℤ) hp2
-      (by exact_mod_cast hm1_pos) (by positivity) h_degZ
+      (by exact_mod_cast hm1_pos) (by positivity) (by push_cast at h_deg; linarith)
     simp only [ite_true]
     exact ⟨by exact_mod_cast h1, by exact_mod_cast h2⟩
   · have hk2 : 2 ≤ k := by omega
@@ -528,15 +540,8 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
         have h := degree_diagCoset_prime_pow p hp 1 (k - 1) (by omega)
         rw [show 1 + (k - 1) = k by omega, pow_one] at h
         rw [h, show k - 1 - 1 = k - 2 by omega]] at h_deg
-    have h_degZ : (m1 : ℤ) * ((p : ℤ) ^ k * ((p : ℤ) + 1)) +
-        (m2 : ℤ) * ((p : ℤ) ^ (k - 2) * ((p : ℤ) + 1)) =
-        ((p : ℤ) + 1) * ((p : ℤ) ^ (k - 1) * ((p : ℤ) + 1)) := by
-      have := h_deg
-      zify at this
-      ring_nf at this ⊢
-      linarith
     obtain ⟨h1, h2⟩ := m1_eq_one_and_m2_eq_of_two_le (p : ℤ) (m1 : ℤ) (m2 : ℤ) k hk2 hp2
-      (by exact_mod_cast hm1_pos) (by positivity) h_degZ
+      (by exact_mod_cast hm1_pos) (by positivity) (by push_cast at h_deg; linarith)
     simp only [hk1, ite_false]
     exact ⟨by exact_mod_cast h1, by exact_mod_cast h2⟩
 


### PR DESCRIPTION
Roadmap: ModularForms

`multiplicity_values` was 70 lines, well over the repo's 50-line cap.

Its first 23 lines did one thing: derive a degree identity from
`multiplicity_degree_sum_eq` and evaluate the three degrees that do not depend
on the `k = 1` / `k ≥ 2` split. That is now
`multiplicity_degree_sum_prime_pow`:

```
private lemma multiplicity_degree_sum_prime_pow (k : ℕ) (hk : 0 < k) :
    (multiplicity … (diagCoset ![1, p]).rep (diagCoset ![1, p ^ k]).rep
        (diagCoset ![1, p ^ (k + 1)]) : ℤ) * ((p : ℤ) ^ k * ((p : ℤ) + 1)) +
      (multiplicity … (diagCoset ![p, p ^ k]) : ℤ) *
        ((diagCoset (![p, p ^ k] : Fin 2 → ℕ)).degree : ℤ) =
      ((p : ℤ) + 1) * ((p : ℤ) ^ (k - 1) * ((p : ℤ) + 1))
```

The fourth degree, `T(p, pᵏ)`, stays symbolic: it is the one the case split is
*about* — `1` when `k = 1`, since `![p, p]` is a scalar coset, and
`p^(k-2)(p+1)` when `k ≥ 2`.

**Stating it over `ℤ` rather than `ℕ` is what makes it pay.** The two branches
each ended with a bespoke `h_degZ` block casting the `ℕ` identity up before
handing it to `m1_eq_one_and_m2_eq_of_eq_one` / `_of_two_le`. With the shared
step already in `ℤ`, each branch rewrites the one remaining degree and applies
its arithmetic core directly, and both cast blocks go.

70 lines becomes 46.

### What this PR does not do

`mulSupport_pp_subset` in the same file is 74 lines. That is different content —
the support bound rather than the multiplicities — and belongs in its own PR.

Verified with a green build of the module and everything importing it, plus the
repo's 13-linter `#lint` set over its cone (0 errors, 634 declarations).

Roadmap attribution only — this is a refactor and carries no target marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
