### PR TITLE
refactor(RootString): reuse the filtered-sum lemma for the G₂ vanishing slice

### DIFF
--- a/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
+++ b/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
@@ -228,18 +228,11 @@ private theorem sum_smul_mul_sum_smul_of_chainG2Order {R : Type*} [CommRing R]
     congr 1
     simp only [mul_pow, pow_add, pow_mul]
     ring
-  -- Step 4: the terms of the hypercube outside that part vanish.
-  have hsub : ∑ w ∈ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N with
-        w.1 + w.2.1 + w.2.2.1 + w.2.2.2.1 + 2 * w.2.2.2.2.1 < N ∧
-          w.2.2.2.2.2 + w.2.1 + 2 * w.2.2.1 + 3 * w.2.2.2.1 + 3 * w.2.2.2.2.1 < N, G w =
-      ∑ w ∈ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N, G w := by
-    refine Finset.sum_subset (Finset.filter_subset _ _) ?_
-    rintro ⟨a, b, c, d, e, q⟩ hmem hnot
-    simp only [Finset.mem_product, Finset.mem_range] at hmem
-    simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_range] at hnot
-    have hor : N ≤ a + b + c + d + 2 * e ∨ N ≤ q + b + 2 * c + 3 * d + 3 * e := by omega
-    simp [hG, hzero a b c d e q hor]
-  rw [← hsrc, hbij, hsub, hbox]
+  -- Step 4: off that part the summand vanishes, so the slice already carries the whole sum.
+  rw [← hsrc, hbij, ← hbox]
+  exact Finset.sum_filter_of_ne fun w _ hne => by
+    by_contra h
+    exact hne (by simp [hG, hzero w.1 w.2.1 w.2.2.1 w.2.2.2.1 w.2.2.2.2.1 w.2.2.2.2.2 (by omega)])
 
 /-! ## The Chevalley commutator relation -/
 


### PR DESCRIPTION
`sum_smul_mul_sum_smul_of_chainG2Order` closed its last step with a hand-rolled
`Finset.sum_subset` argument wrapped in a `have hsub` whose statement restated the entire
six-fold filtered sum — three lines of set expression repeated verbatim from the step
above it — followed by five lines of membership bookkeeping to reach the disjunction that
`hzero` wants.

The class-two analogue this proof "follows step for step"
(`sum_smul_mul_sum_smul_of_chainLeTwoOrder` in `RootString/Basic.lean`, whose reindexing
step was named in #4442) already closes the same step with `Finset.sum_filter_of_ne`,
which packages precisely that argument: a summand outside the slice is zero, so the slice
carries the whole sum. This adopts the same idiom in the G₂ analogue, so the two proofs
now agree on their final step as well as on the first three.

Both files already name their reindexing step (`sum_chainLeTwoIndex_diag_flip`,
`sum_chainG2Index_diag_flip` from #4536); this closes the last structural divergence
between them.

No statement changes and no new declarations — the proof body goes from 62 lines to 55.
`Finset.sum_filter_of_ne` is already used in five other places in the repository.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp