### PR TITLE
feat: the tame case of Dedekind's different theorem

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Different/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Different/Basic.lean
@@ -172,6 +172,7 @@ theorem algebraMap_mem_integers_of_mem_integralClosure
 /-- **The prime of `𝒪_P` below the centre of `P'` on the local model is the maximal ideal of
 `𝒪_P`**: the residue extension read on the local model is the residue-field extension of the two
 places. -/
+@[simp]
 theorem center_restrict_asIdeal_eq_maximalIdeal :
     ((P'.restrict k F).center (algebraMap_mem_integers_restrict
         (R := ((P'.restrict k F).integers)) k F P'

--- a/TauCeti/FieldTheory/FunctionField/Different/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Different/Basic.lean
@@ -46,6 +46,9 @@ fields, and nothing needs `k` perfect.
 
 ## Main results
 
+* `TauCeti.Place.center_restrict_asIdeal_eq_maximalIdeal`: the prime of `𝒪_P` below the centre of
+  `P'` on the local model is the maximal ideal of `𝒪_P`, so the residue extension the different
+  exponent reads is the residue-field extension of the two places.
 * `TauCeti.Place.pow_dvd_differentIdeal_iff_le_differentExponent`: the characteristic property of
   the different exponent, `𝔓'^n ∣ differentIdeal 𝒪_P 𝒪'_P ↔ n ≤ d(P' ∣ P)`.
 * `TauCeti.Place.ramificationIdx_le_differentExponent_add_one`: **Dedekind's different theorem**
@@ -166,6 +169,18 @@ theorem algebraMap_mem_integers_of_mem_integralClosure
   exact P'.mem_integers_of_isIntegral (R := ((P'.restrict k F).integers))
     (fun a ↦ (mem_integers_restrict_iff k F P' (a : F)).mp a.2) b.2
 
+/-- **The prime of `𝒪_P` below the centre of `P'` on the local model is the maximal ideal of
+`𝒪_P`**: the residue extension read on the local model is the residue-field extension of the two
+places. -/
+theorem center_restrict_asIdeal_eq_maximalIdeal :
+    ((P'.restrict k F).center (algebraMap_mem_integers_restrict
+        (R := ((P'.restrict k F).integers)) k F P'
+        (algebraMap_mem_integers_of_mem_integralClosure k F P'))).asIdeal
+      = IsLocalRing.maximalIdeal ((P'.restrict k F).integers) := by
+  ext f
+  rw [mem_center_asIdeal, mem_maximalIdeal_iff_valuation_lt_one]
+  exact Iff.rfl
+
 variable [Algebra.IsSeparable F F']
 
 /-- **The centre of `P'` on the local model `𝒪'_P`**: the height one prime of the integral closure
@@ -176,6 +191,14 @@ noncomputable def centerIntegralClosure :
 
 theorem centerIntegralClosure_def : centerIntegralClosure k F P' =
     P'.center (algebraMap_mem_integers_of_mem_integralClosure k F P') := (rfl)
+
+/-- The centre of `P'` on the local model lies over the maximal ideal of `𝒪_P`, so the residue
+extension of the local model is read at the residue field of `P`. -/
+instance centerIntegralClosure_liesOver_maximalIdeal :
+    (centerIntegralClosure k F P').asIdeal.LiesOver
+      (IsLocalRing.maximalIdeal ((P'.restrict k F).integers)) := by
+  rw [← center_restrict_asIdeal_eq_maximalIdeal k F P', centerIntegralClosure_def]
+  exact center_liesOver k F P' _
 
 /-- **The different exponent `d(P' ∣ P)`** of a place `P'` of `F' / k'` over the place
 `P = P'.restrict k F` of `F / k` (Stichtenoth, Definition 3.4.3), for `F' / F` finite and

--- a/TauCeti/FieldTheory/FunctionField/Different/Tame.lean
+++ b/TauCeti/FieldTheory/FunctionField/Different/Tame.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.FunctionField.Different.Divisor
+public import TauCeti.RingTheory.DedekindDomain.Different
+
+/-!
+# The different exponent of a tame place
+
+Let `F' / k'` be an extension of the algebraic function field `F / k` with `F' / F` finite and
+separable, and let `P'` be a place of `F' / k'` over `P = P'.restrict k F`.  Dedekind's different
+theorem (Stichtenoth, Theorem 3.5.1) says that `d(P' ∣ P) ≥ e(P' ∣ P) - 1` always, with equality
+exactly when the place is **tame**.  The inequality is
+`TauCeti.Place.ramificationIdx_le_differentExponent_add_one`; this file supplies the equality,
+`e(P' ∣ P) = d(P' ∣ P) + 1`, at a place where the residue extension of the local model is
+separable and the residue characteristic does not divide `e(P' ∣ P)`.
+
+Everything is read on the local model `𝒪_P ⊆ 𝒪'_P` of
+`TauCeti/FieldTheory/FunctionField/Different/Basic.lean`, where the different exponent lives, so
+the two hypotheses are stated for the centre `𝔓` of `P'` on `𝒪'_P` and a maximal ideal `𝔭` of
+`𝒪_P` that `𝔓` lies over — necessarily the maximal ideal of the discrete valuation ring `𝒪_P`,
+whose residue ring is the residue field of `P`.  This is the same ideal-theoretic reading of the
+residue extension that `TauCeti.Place.differentExponent_eq_zero_iff` uses for unramifiedness.  The
+theorem behind it is `TauCeti.not_pow_ramificationIdx_dvd_differentIdeal`.
+
+Tameness is genuinely needed, and so is residue separability: `d = e - 1` fails in the wild case
+(Stichtenoth, Corollary 3.5.5 records `d ≥ e` there), and over an imperfect residue field an
+unramified-looking place with inseparable residue extension already has `d > 0`.
+
+## Main results
+
+* `TauCeti.Place.ramificationIdx_eq_differentExponent_add_one`: **Dedekind's different theorem in
+  the tame case** (Stichtenoth, Theorem 3.5.1(b)), in the subtraction-free form
+  `e(P' ∣ P) = d(P' ∣ P) + 1`.
+* `TauCeti.Divisor.coeff_different_add_one_eq_ramificationIdx`: the same statement read on the
+  different divisor.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Theorem 3.5.1 and Corollary 3.5.5.
+-/
+
+public section
+
+open IsDedekindDomain
+
+namespace TauCeti
+
+universe u u' v v'
+
+variable {k : Type u} {k' : Type u'} {F : Type v} {F' : Type v'}
+variable [Field k] [Field k'] [Field F] [Field F']
+variable [Algebra k F] [Algebra F F'] [Algebra k k'] [Algebra k' F'] [Algebra k F']
+variable [IsScalarTower k k' F'] [IsScalarTower k F F'] [FiniteDimensional F F']
+variable [Algebra.IsSeparable F F']
+
+attribute [local instance 10] Place.algebraIntegersExtension
+  Place.isScalarTowerIntegersExtension
+
+namespace Place
+
+variable (k F) (P' : Place k' F')
+
+/-- **The prime of `𝒪_P` below the centre of `P'` on the local model is the maximal ideal of
+`𝒪_P`**: the residue extension that the different exponent reads is the residue-field extension of
+the two places. -/
+theorem center_restrict_asIdeal_eq_maximalIdeal :
+    ((P'.restrict k F).center (algebraMap_mem_integers_restrict
+        (R := ((P'.restrict k F).integers)) k F P'
+        (algebraMap_mem_integers_of_mem_integralClosure k F P'))).asIdeal
+      = IsLocalRing.maximalIdeal ((P'.restrict k F).integers) := by
+  ext f
+  rw [mem_center_asIdeal, mem_maximalIdeal_iff_valuation_lt_one]
+  exact Iff.rfl
+
+/-- The centre of `P'` on the local model lies over the maximal ideal of `𝒪_P`, so the hypotheses
+of `TauCeti.Place.ramificationIdx_eq_differentExponent_add_one` can always be read at
+`𝔭 = 𝔪_P`. -/
+instance centerIntegralClosure_liesOver_maximalIdeal :
+    (centerIntegralClosure k F P').asIdeal.LiesOver
+      (IsLocalRing.maximalIdeal ((P'.restrict k F).integers)) := by
+  rw [← center_restrict_asIdeal_eq_maximalIdeal k F P', centerIntegralClosure_def]
+  exact center_liesOver k F P' _
+
+/-- **Dedekind's different theorem in the tame case** (Stichtenoth, Theorem 3.5.1(b)): at a place
+`P'` whose local model has separable residue extension and whose ramification index is invertible
+in the residue ring of the prime below, the different exponent is exactly one less than the
+ramification index.  It is stated as `e(P' ∣ P) = d(P' ∣ P) + 1` so that no truncated subtraction
+of natural numbers appears.
+
+The ideal `𝔭` is the maximal ideal of the discrete valuation ring `𝒪_P`; the `LiesOver` hypothesis
+identifies it as the prime of `𝒪_P` below the centre of `P'` on the local model, and
+`𝒪_P ⧸ 𝔭` is then the residue field of `P`.  Both hypotheses are essential: without tameness the
+place is wild and `d(P' ∣ P) ≥ e(P' ∣ P)`, and without residue separability
+`TauCeti.Place.differentExponent_eq_zero_iff` already fails at `e = 1`. -/
+theorem ramificationIdx_eq_differentExponent_add_one
+    (𝔭 : Ideal ((P'.restrict k F).integers)) [𝔭.IsMaximal]
+    [(centerIntegralClosure k F P').asIdeal.LiesOver 𝔭]
+    [Algebra.IsSeparable (((P'.restrict k F).integers) ⧸ 𝔭)
+      (integralClosure ((P'.restrict k F).integers) F' ⧸ (centerIntegralClosure k F P').asIdeal)]
+    (htame : ((ramificationIdx F P' : ℕ) : ((P'.restrict k F).integers) ⧸ 𝔭) ≠ 0) :
+    ramificationIdx F P' = differentExponent k F P' + 1 := by
+  have hS := algebraMap_mem_integers_of_mem_integralClosure k F P'
+  have hpbot : 𝔭 ≠ ⊥ := by
+    rw [IsLocalRing.eq_maximalIdeal ‹𝔭.IsMaximal›]
+    exact IsDiscreteValuationRing.not_a_field _
+  have hmax : (centerIntegralClosure k F P').asIdeal.IsMaximal :=
+    (centerIntegralClosure k F P').isPrime.isMaximal (centerIntegralClosure k F P').ne_bot
+  have hidx : (centerIntegralClosure k F P').asIdeal.ramificationIdx
+      ((P'.restrict k F).integers) = ramificationIdx F P' := by
+    rw [centerIntegralClosure_def]
+    exact (ramificationIdx_eq_ramificationIdx_center
+      (R := ((P'.restrict k F).integers)) k F P' hS).symm
+  have hnot := not_pow_ramificationIdx_dvd_differentIdeal ((P'.restrict k F).integers) hpbot
+    (centerIntegralClosure k F P').asIdeal (by rwa [hidx])
+  rw [hidx] at hnot
+  have hle := ramificationIdx_le_differentExponent_add_one k F P'
+  have hlt : ¬ ramificationIdx F P' ≤ differentExponent k F P' := fun h ↦
+    hnot ((pow_dvd_differentIdeal_iff_le_differentExponent k F P').mpr h)
+  omega
+
+end Place
+
+namespace Divisor
+
+/-- **The different divisor at a tame place** (Stichtenoth, Theorem 3.5.1(b) and Remark 3.4.4):
+the coefficient of a tame place `P'` in `Diff(F'/F)` is `e(P' ∣ P) - 1`, stated without
+subtraction. -/
+theorem coeff_different_add_one_eq_ramificationIdx (hF : IsFunctionField k F) (P' : Place k' F')
+    (𝔭 : Ideal ((P'.restrict k F).integers)) [𝔭.IsMaximal]
+    [(Place.centerIntegralClosure k F P').asIdeal.LiesOver 𝔭]
+    [Algebra.IsSeparable (((P'.restrict k F).integers) ⧸ 𝔭)
+      (integralClosure ((P'.restrict k F).integers) F' ⧸
+        (Place.centerIntegralClosure k F P').asIdeal)]
+    (htame : ((Place.ramificationIdx F P' : ℕ) : ((P'.restrict k F).integers) ⧸ 𝔭) ≠ 0) :
+    (different k' F' hF).coeff P' + 1 = (Place.ramificationIdx F P' : ℤ) := by
+  rw [coeff_different]
+  exact_mod_cast
+    (Place.ramificationIdx_eq_differentExponent_add_one k F P' 𝔭 htame).symm
+
+end Divisor
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/Different/Tame.lean
+++ b/TauCeti/FieldTheory/FunctionField/Different/Tame.lean
@@ -21,11 +21,11 @@ separable and the residue characteristic does not divide `e(P' ∣ P)`.
 
 Everything is read on the local model `𝒪_P ⊆ 𝒪'_P` of
 `TauCeti/FieldTheory/FunctionField/Different/Basic.lean`, where the different exponent lives, so
-the two hypotheses are stated for the centre `𝔓` of `P'` on `𝒪'_P` and a maximal ideal `𝔭` of
-`𝒪_P` that `𝔓` lies over — necessarily the maximal ideal of the discrete valuation ring `𝒪_P`,
-whose residue ring is the residue field of `P`.  This is the same ideal-theoretic reading of the
-residue extension that `TauCeti.Place.differentExponent_eq_zero_iff` uses for unramifiedness.  The
-theorem behind it is `TauCeti.not_pow_ramificationIdx_dvd_differentIdeal`.
+the two hypotheses are stated for the centre `𝔓` of `P'` on `𝒪'_P` over the maximal ideal of the
+discrete valuation ring `𝒪_P`, whose residue ring is the residue field of `P`
+(`TauCeti.Place.center_restrict_asIdeal_eq_maximalIdeal`).  This is the same ideal-theoretic
+reading of the residue extension that `TauCeti.Place.differentExponent_eq_zero_iff` uses for
+unramifiedness.  The theorem behind it is `TauCeti.not_pow_ramificationIdx_dvd_differentIdeal`.
 
 Tameness is genuinely needed, and so is residue separability: `d = e - 1` fails in the wild case
 (Stichtenoth, Corollary 3.5.5 records `d ≥ e` there), and over an imperfect residue field an
@@ -66,49 +66,28 @@ namespace Place
 
 variable (k F) (P' : Place k' F')
 
-/-- **The prime of `𝒪_P` below the centre of `P'` on the local model is the maximal ideal of
-`𝒪_P`**: the residue extension that the different exponent reads is the residue-field extension of
-the two places. -/
-theorem center_restrict_asIdeal_eq_maximalIdeal :
-    ((P'.restrict k F).center (algebraMap_mem_integers_restrict
-        (R := ((P'.restrict k F).integers)) k F P'
-        (algebraMap_mem_integers_of_mem_integralClosure k F P'))).asIdeal
-      = IsLocalRing.maximalIdeal ((P'.restrict k F).integers) := by
-  ext f
-  rw [mem_center_asIdeal, mem_maximalIdeal_iff_valuation_lt_one]
-  exact Iff.rfl
-
-/-- The centre of `P'` on the local model lies over the maximal ideal of `𝒪_P`, so the hypotheses
-of `TauCeti.Place.ramificationIdx_eq_differentExponent_add_one` can always be read at
-`𝔭 = 𝔪_P`. -/
-instance centerIntegralClosure_liesOver_maximalIdeal :
-    (centerIntegralClosure k F P').asIdeal.LiesOver
-      (IsLocalRing.maximalIdeal ((P'.restrict k F).integers)) := by
-  rw [← center_restrict_asIdeal_eq_maximalIdeal k F P', centerIntegralClosure_def]
-  exact center_liesOver k F P' _
-
 /-- **Dedekind's different theorem in the tame case** (Stichtenoth, Theorem 3.5.1(b)): at a place
 `P'` whose local model has separable residue extension and whose ramification index is invertible
-in the residue ring of the prime below, the different exponent is exactly one less than the
-ramification index.  It is stated as `e(P' ∣ P) = d(P' ∣ P) + 1` so that no truncated subtraction
-of natural numbers appears.
+in the residue field of `P`, the different exponent is exactly one less than the ramification
+index.  It is stated as `e(P' ∣ P) = d(P' ∣ P) + 1` so that no truncated subtraction of natural
+numbers appears.
 
-The ideal `𝔭` is the maximal ideal of the discrete valuation ring `𝒪_P`; the `LiesOver` hypothesis
-identifies it as the prime of `𝒪_P` below the centre of `P'` on the local model, and
-`𝒪_P ⧸ 𝔭` is then the residue field of `P`.  Both hypotheses are essential: without tameness the
-place is wild and `d(P' ∣ P) ≥ e(P' ∣ P)`, and without residue separability
+The residue extension is read on the local model, between the residue ring of the maximal ideal of
+the discrete valuation ring `𝒪_P` — which is the residue field of `P`, by
+`TauCeti.Place.center_restrict_asIdeal_eq_maximalIdeal` — and the residue ring of the centre of
+`P'` on `𝒪'_P`.  Both hypotheses are essential: without tameness the place is wild and
+`d(P' ∣ P) ≥ e(P' ∣ P)`, and without residue separability
 `TauCeti.Place.differentExponent_eq_zero_iff` already fails at `e = 1`. -/
 theorem ramificationIdx_eq_differentExponent_add_one
-    (𝔭 : Ideal ((P'.restrict k F).integers)) [𝔭.IsMaximal]
-    [(centerIntegralClosure k F P').asIdeal.LiesOver 𝔭]
-    [Algebra.IsSeparable (((P'.restrict k F).integers) ⧸ 𝔭)
+    [Algebra.IsSeparable
+      (((P'.restrict k F).integers) ⧸ IsLocalRing.maximalIdeal ((P'.restrict k F).integers))
       (integralClosure ((P'.restrict k F).integers) F' ⧸ (centerIntegralClosure k F P').asIdeal)]
-    (htame : ((ramificationIdx F P' : ℕ) : ((P'.restrict k F).integers) ⧸ 𝔭) ≠ 0) :
+    (htame : ((ramificationIdx F P' : ℕ) :
+      ((P'.restrict k F).integers) ⧸ IsLocalRing.maximalIdeal ((P'.restrict k F).integers)) ≠ 0) :
     ramificationIdx F P' = differentExponent k F P' + 1 := by
   have hS := algebraMap_mem_integers_of_mem_integralClosure k F P'
-  have hpbot : 𝔭 ≠ ⊥ := by
-    rw [IsLocalRing.eq_maximalIdeal ‹𝔭.IsMaximal›]
-    exact IsDiscreteValuationRing.not_a_field _
+  have hpbot : IsLocalRing.maximalIdeal ((P'.restrict k F).integers) ≠ ⊥ :=
+    IsDiscreteValuationRing.not_a_field _
   have hmax : (centerIntegralClosure k F P').asIdeal.IsMaximal :=
     (centerIntegralClosure k F P').isPrime.isMaximal (centerIntegralClosure k F P').ne_bot
   have hidx : (centerIntegralClosure k F P').asIdeal.ramificationIdx
@@ -132,16 +111,15 @@ namespace Divisor
 the coefficient of a tame place `P'` in `Diff(F'/F)` is `e(P' ∣ P) - 1`, stated without
 subtraction. -/
 theorem coeff_different_add_one_eq_ramificationIdx (hF : IsFunctionField k F) (P' : Place k' F')
-    (𝔭 : Ideal ((P'.restrict k F).integers)) [𝔭.IsMaximal]
-    [(Place.centerIntegralClosure k F P').asIdeal.LiesOver 𝔭]
-    [Algebra.IsSeparable (((P'.restrict k F).integers) ⧸ 𝔭)
+    [Algebra.IsSeparable
+      (((P'.restrict k F).integers) ⧸ IsLocalRing.maximalIdeal ((P'.restrict k F).integers))
       (integralClosure ((P'.restrict k F).integers) F' ⧸
         (Place.centerIntegralClosure k F P').asIdeal)]
-    (htame : ((Place.ramificationIdx F P' : ℕ) : ((P'.restrict k F).integers) ⧸ 𝔭) ≠ 0) :
+    (htame : ((Place.ramificationIdx F P' : ℕ) :
+      ((P'.restrict k F).integers) ⧸ IsLocalRing.maximalIdeal ((P'.restrict k F).integers)) ≠ 0) :
     (different k' F' hF).coeff P' + 1 = (Place.ramificationIdx F P' : ℤ) := by
   rw [coeff_different]
-  exact_mod_cast
-    (Place.ramificationIdx_eq_differentExponent_add_one k F P' 𝔭 htame).symm
+  exact_mod_cast (Place.ramificationIdx_eq_differentExponent_add_one k F P' htame).symm
 
 end Divisor
 

--- a/TauCeti/LinearAlgebra/Trace/Exact.lean
+++ b/TauCeti/LinearAlgebra/Trace/Exact.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+public import TauCeti.LinearAlgebra.Trace.Prod
+
+/-!
+# The trace of an endomorphism of a short exact sequence
+
+An endomorphism of a short exact sequence `0 → N → M → Q → 0` of vector spaces, `M`
+finite-dimensional, has `trace f = trace fN + trace fQ`.  A linear section of the surjection splits
+the sequence as `M ≃ N × Q`, and in that decomposition the endomorphism is block upper triangular
+because it preserves the image of `N`, so `LinearMap.trace_prodMap_add_inl_comp_snd` computes its
+trace from the two diagonal blocks.
+
+Mathlib has the additivity of the trace over an *internal direct sum*
+(`LinearMap.trace_eq_sum_trace_restrict`), which needs the endomorphism to preserve every summand.
+An endomorphism of a short exact sequence only respects the filtration, not any splitting of it, so
+that result does not apply: the splitting has to be chosen independently of `f`, and the
+off-diagonal block is then killed by `LinearMap.trace_comp_comm'` rather than being zero.  Working
+over a field is what makes such a splitting available.
+
+The typical use is a filtration whose graded pieces are known: iterating the identity along
+`M ⊇ M₁ ⊇ ⋯` expresses `trace f` as the sum of the traces on the successive quotients.  That is how
+`Algebra.trace_quotient_pow` computes the trace of `B ⧸ P ^ n` from the trace of `B ⧸ P`.
+
+## Main results
+
+* `LinearMap.trace_eq_add_of_exact`: the trace of the middle endomorphism of a short exact sequence
+  is the sum of the traces of the outer ones.
+-/
+
+public section
+
+open Module
+
+namespace LinearMap
+
+variable {K M N Q : Type*} [Field K]
+variable [AddCommGroup M] [Module K M] [AddCommGroup N] [Module K N] [AddCommGroup Q] [Module K Q]
+
+/-- **The trace is additive along a short exact sequence.** If `0 → N --i--> M --π--> Q → 0` is
+exact and the endomorphisms `fN`, `f`, `fQ` commute with `i` and `π`, then
+`trace f = trace fN + trace fQ`. -/
+theorem trace_eq_add_of_exact [FiniteDimensional K M] {i : N →ₗ[K] M} {π : M →ₗ[K] Q}
+    (hi : Function.Injective i) (hπ : Function.Surjective π) (hex : Function.Exact i π)
+    {f : M →ₗ[K] M} {fN : N →ₗ[K] N} {fQ : Q →ₗ[K] Q}
+    (hN : f ∘ₗ i = i ∘ₗ fN) (hQ : π ∘ₗ f = fQ ∘ₗ π) :
+    trace K M f = trace K N fN + trace K Q fQ := by
+  have _ : FiniteDimensional K N := FiniteDimensional.of_injective i hi
+  have _ : FiniteDimensional K Q := Module.Finite.of_surjective π hπ
+  -- choose a linear section of `π`
+  obtain ⟨s, hs⟩ := π.exists_rightInverse_of_surjective (range_eq_top.mpr hπ)
+  -- the section splits the sequence: `(n, q) ↦ i n + s q` is an isomorphism `N × Q ≃ M`
+  have hπs (q : Q) : π (s q) = q := congr($hs q)
+  have hπi (n : N) : π (i n) = 0 := hex.apply_apply_eq_zero n
+  have hbij : Function.Bijective (i.coprod s) := by
+    constructor
+    · rintro ⟨n, q⟩ ⟨n', q'⟩ h
+      simp only [coprod_apply] at h
+      have hq : q = q' := by simpa [hπi, hπs] using congrArg π h
+      subst hq
+      exact Prod.ext (hi (by simpa using h)) rfl
+    · intro m
+      obtain ⟨n, hn⟩ := (hex (m - s (π m))).mp (by simp [hπs])
+      exact ⟨(n, π m), by simp [hn]⟩
+  set E : (N × Q) ≃ₗ[K] M := LinearEquiv.ofBijective (i.coprod s) hbij with hE
+  have hEapply (n : N) (q : Q) : E (n, q) = i n + s q := rfl
+  -- `snd` reads off the quotient component through `π`
+  have hsnd : (snd K N Q) ∘ₗ (E.symm : M →ₗ[K] N × Q) = π := by
+    refine ext fun m ↦ ?_
+    have : E (E.symm m) = m := E.apply_symm_apply m
+    conv_rhs => rw [← this]
+    rw [hEapply]
+    simp [hπi, hπs]
+  -- transport `f` to `N × Q`; it is block upper triangular there
+  set F : (N × Q) →ₗ[K] N × Q := E.symm.conj f with hF
+  have hFapply (x : N × Q) : F x = E.symm (f (E x)) := by
+    simp [hF, LinearEquiv.conj_apply]
+  have hsnd₂ (m : M) : (E.symm m).2 = π m := congr($hsnd m)
+  have hinl : F ∘ₗ (inl K N Q) = (inl K N Q) ∘ₗ fN := by
+    refine ext fun n ↦ E.injective ?_
+    have hfi : f (i n) = i (fN n) := congr($hN n)
+    simp only [comp_apply, inl_apply, hFapply, E.apply_symm_apply, hEapply, map_zero, add_zero]
+    exact hfi
+  have hsnd' : (snd K N Q) ∘ₗ F = fQ ∘ₗ (snd K N Q) := by
+    refine ext fun x ↦ ?_
+    have h₃ : π (f (E x)) = fQ (π (E x)) := congr($hQ (E x))
+    simp only [comp_apply, snd_apply, hFapply, hsnd₂, h₃]
+    rw [← hsnd₂ (E x), E.symm_apply_apply]
+  rw [← LinearMap.trace_conj' f E.symm, ← hF,
+    eq_prodMap_add_inl_comp_snd (fA := fN) (fC := fQ) F hinl hsnd',
+    trace_prodMap_add_inl_comp_snd]
+
+end LinearMap

--- a/TauCeti/LinearAlgebra/Trace/Exact.lean
+++ b/TauCeti/LinearAlgebra/Trace/Exact.lean
@@ -16,7 +16,7 @@ finite-dimensional, has `trace f = trace fN + trace fQ`.
 
 The typical use is a filtration whose graded pieces are known: iterating the identity along
 `M ⊇ M₁ ⊇ ⋯` expresses `trace f` as the sum of the traces on the successive quotients.  That is how
-`Algebra.trace_quotient_pow` computes the trace of `B ⧸ P ^ n` from the trace of `B ⧸ P`.
+`Algebra.trace_quotient_pow_mk` computes the trace of `B ⧸ P ^ n` from the trace of `B ⧸ P`.
 
 ## Main results
 
@@ -33,11 +33,13 @@ namespace LinearMap
 variable {K M N Q : Type*} [Field K]
 variable [AddCommGroup M] [Module K M] [AddCommGroup N] [Module K N] [AddCommGroup Q] [Module K Q]
 
+-- Provenance: the argument below is the one carried by the private
+-- `TauCeti.TensorSquare.trace_eq_add_of_exact` of
+-- `TauCeti/RepresentationTheory/Tensor/Square.lean`, generalized here to an arbitrary short exact
+-- sequence and consumed there.
 /-- **The trace is additive along a short exact sequence.** If `0 → N --i--> M --π--> Q → 0` is
 exact and the endomorphisms `fN`, `f`, `fQ` commute with `i` and `π`, then
-`trace f = trace fN + trace fQ`.
-
-This generalizes the former private `TauCeti.TensorSquare.trace_eq_add_of_exact` implementation. -/
+`trace f = trace fN + trace fQ`. -/
 theorem trace_eq_add_of_exact [FiniteDimensional K M] {i : N →ₗ[K] M} {π : M →ₗ[K] Q}
     (hi : Function.Injective i) (hπ : Function.Surjective π) (hex : Function.Exact i π)
     {f : M →ₗ[K] M} {fN : N →ₗ[K] N} {fQ : Q →ₗ[K] Q}

--- a/TauCeti/LinearAlgebra/Trace/Exact.lean
+++ b/TauCeti/LinearAlgebra/Trace/Exact.lean
@@ -17,6 +17,10 @@ the sequence as `M ≃ N × Q`, and in that decomposition the endomorphism is bl
 because it preserves the image of `N`, so `LinearMap.trace_prodMap_add_inl_comp_snd` computes its
 trace from the two diagonal blocks.
 
+The proof generalizes the former private `TauCeti.TensorSquare.trace_eq_add_of_exact`
+implementation in `TauCeti.RepresentationTheory.Tensor.Square`, extracting its split
+exact-sequence argument into reusable linear-algebra API.
+
 Mathlib has the additivity of the trace over an *internal direct sum*
 (`LinearMap.trace_eq_sum_trace_restrict`), which needs the endomorphism to preserve every summand.
 An endomorphism of a short exact sequence only respects the filtration, not any splitting of it, so

--- a/TauCeti/LinearAlgebra/Trace/Exact.lean
+++ b/TauCeti/LinearAlgebra/Trace/Exact.lean
@@ -12,21 +12,7 @@ public import TauCeti.LinearAlgebra.Trace.Prod
 # The trace of an endomorphism of a short exact sequence
 
 An endomorphism of a short exact sequence `0 → N → M → Q → 0` of vector spaces, `M`
-finite-dimensional, has `trace f = trace fN + trace fQ`.  A linear section of the surjection splits
-the sequence as `M ≃ N × Q`, and in that decomposition the endomorphism is block upper triangular
-because it preserves the image of `N`, so `LinearMap.trace_prodMap_add_inl_comp_snd` computes its
-trace from the two diagonal blocks.
-
-The proof generalizes the former private `TauCeti.TensorSquare.trace_eq_add_of_exact`
-implementation in `TauCeti.RepresentationTheory.Tensor.Square`, extracting its split
-exact-sequence argument into reusable linear-algebra API.
-
-Mathlib has the additivity of the trace over an *internal direct sum*
-(`LinearMap.trace_eq_sum_trace_restrict`), which needs the endomorphism to preserve every summand.
-An endomorphism of a short exact sequence only respects the filtration, not any splitting of it, so
-that result does not apply: the splitting has to be chosen independently of `f`, and the
-off-diagonal block is then killed by `LinearMap.trace_comp_comm'` rather than being zero.  Working
-over a field is what makes such a splitting available.
+finite-dimensional, has `trace f = trace fN + trace fQ`.
 
 The typical use is a filtration whose graded pieces are known: iterating the identity along
 `M ⊇ M₁ ⊇ ⋯` expresses `trace f` as the sum of the traces on the successive quotients.  That is how
@@ -49,7 +35,9 @@ variable [AddCommGroup M] [Module K M] [AddCommGroup N] [Module K N] [AddCommGro
 
 /-- **The trace is additive along a short exact sequence.** If `0 → N --i--> M --π--> Q → 0` is
 exact and the endomorphisms `fN`, `f`, `fQ` commute with `i` and `π`, then
-`trace f = trace fN + trace fQ`. -/
+`trace f = trace fN + trace fQ`.
+
+This generalizes the former private `TauCeti.TensorSquare.trace_eq_add_of_exact` implementation. -/
 theorem trace_eq_add_of_exact [FiniteDimensional K M] {i : N →ₗ[K] M} {π : M →ₗ[K] Q}
     (hi : Function.Injective i) (hπ : Function.Surjective π) (hex : Function.Exact i π)
     {f : M →ₗ[K] M} {fN : N →ₗ[K] N} {fQ : Q →ₗ[K] Q}
@@ -59,44 +47,26 @@ theorem trace_eq_add_of_exact [FiniteDimensional K M] {i : N →ₗ[K] M} {π : 
   have _ : FiniteDimensional K Q := Module.Finite.of_surjective π hπ
   -- choose a linear section of `π`
   obtain ⟨s, hs⟩ := π.exists_rightInverse_of_surjective (range_eq_top.mpr hπ)
-  -- the section splits the sequence: `(n, q) ↦ i n + s q` is an isomorphism `N × Q ≃ M`
-  have hπs (q : Q) : π (s q) = q := congr($hs q)
-  have hπi (n : N) : π (i n) = 0 := hex.apply_apply_eq_zero n
-  have hbij : Function.Bijective (i.coprod s) := by
-    constructor
-    · rintro ⟨n, q⟩ ⟨n', q'⟩ h
-      simp only [coprod_apply] at h
-      have hq : q = q' := by simpa [hπi, hπs] using congrArg π h
-      subst hq
-      exact Prod.ext (hi (by simpa using h)) rfl
-    · intro m
-      obtain ⟨n, hn⟩ := (hex (m - s (π m))).mp (by simp [hπs])
-      exact ⟨(n, π m), by simp [hn]⟩
-  set E : (N × Q) ≃ₗ[K] M := LinearEquiv.ofBijective (i.coprod s) hbij with hE
-  have hEapply (n : N) (q : Q) : E (n, q) = i n + s q := rfl
-  -- `snd` reads off the quotient component through `π`
-  have hsnd : (snd K N Q) ∘ₗ (E.symm : M →ₗ[K] N × Q) = π := by
-    refine ext fun m ↦ ?_
-    have : E (E.symm m) = m := E.apply_symm_apply m
-    conv_rhs => rw [← this]
-    rw [hEapply]
-    simp [hπi, hπs]
+  obtain ⟨E, hiE, hπE⟩ := hex.splitSurjectiveEquiv hi ⟨s, hs⟩
+  have hi_apply (n : N) : E.symm (n, 0) = i n := by
+    simpa using congr($hiE n).symm
   -- transport `f` to `N × Q`; it is block upper triangular there
-  set F : (N × Q) →ₗ[K] N × Q := E.symm.conj f with hF
-  have hFapply (x : N × Q) : F x = E.symm (f (E x)) := by
+  set F : (N × Q) →ₗ[K] N × Q := E.conj f with hF
+  have hFapply (x : N × Q) : F x = E (f (E.symm x)) := by
     simp [hF, LinearEquiv.conj_apply]
-  have hsnd₂ (m : M) : (E.symm m).2 = π m := congr($hsnd m)
+  have hsnd (m : M) : (E m).2 = π m := by
+    simpa using congr($hπE m).symm
   have hinl : F ∘ₗ (inl K N Q) = (inl K N Q) ∘ₗ fN := by
-    refine ext fun n ↦ E.injective ?_
+    refine ext fun n ↦ E.symm.injective ?_
     have hfi : f (i n) = i (fN n) := congr($hN n)
-    simp only [comp_apply, inl_apply, hFapply, E.apply_symm_apply, hEapply, map_zero, add_zero]
+    simp only [comp_apply, inl_apply, hFapply, E.symm_apply_apply, hi_apply]
     exact hfi
   have hsnd' : (snd K N Q) ∘ₗ F = fQ ∘ₗ (snd K N Q) := by
     refine ext fun x ↦ ?_
-    have h₃ : π (f (E x)) = fQ (π (E x)) := congr($hQ (E x))
-    simp only [comp_apply, snd_apply, hFapply, hsnd₂, h₃]
-    rw [← hsnd₂ (E x), E.symm_apply_apply]
-  rw [← LinearMap.trace_conj' f E.symm, ← hF,
+    have h₃ : π (f (E.symm x)) = fQ (π (E.symm x)) := congr($hQ (E.symm x))
+    simp only [comp_apply, snd_apply, hFapply, hsnd, h₃]
+    rw [← hsnd (E.symm x), E.apply_symm_apply]
+  rw [← LinearMap.trace_conj' f E, ← hF,
     eq_prodMap_add_inl_comp_snd (fA := fN) (fC := fQ) F hinl hsnd',
     trace_prodMap_add_inl_comp_snd]
 

--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -12,7 +12,7 @@ public import TauCeti.LinearAlgebra.TensorSquare
 public import TauCeti.LinearAlgebra.ExteriorPower
 public import TauCeti.RepresentationTheory.ExteriorPower
 public import TauCeti.RepresentationTheory.SymmetricPower
-public import TauCeti.LinearAlgebra.Trace.Prod
+public import TauCeti.LinearAlgebra.Trace.Exact
 public import TauCeti.LinearAlgebra.Trace.Square
 public import TauCeti.RepresentationTheory.Tensor.Power
 
@@ -51,10 +51,10 @@ the sum and difference identities coincide, so neither character is determined b
 
 ## Implementation notes
 
-Both trace identities go through the same private helper, trace additivity along the exact
-sequence `⋀²M → M ⊗ M → Sym²M`, so its hypothesis on the alternating inclusion is named once
-(`TauCeti.TensorSquare.map_comp_toTensorPower`) and reused for both readings; the matching
-hypothesis on the symmetric quotient is `SymmetricPower.map_mk` read extensionally. The
+Both trace identities read the exact sequence `⋀²M → M ⊗ M → Sym²M` through the same trace
+additivity `LinearMap.trace_eq_add_of_exact`, so its hypothesis on the alternating inclusion is
+named once (`TauCeti.TensorSquare.map_comp_toTensorPower`) and reused for both readings; the
+matching hypothesis on the symmetric quotient is `SymmetricPower.map_mk` read extensionally. The
 linear-algebra steps stay private, as the file's public interface is the character identities.
 
 ## References
@@ -184,58 +184,6 @@ private theorem toTensorPower_injective {R : Type} {M : Type*}
   simp only [exteriorPower.ιMultiDual, exteriorPower.ιMulti_family,
     pairingDual_ιMulti_apply, h]
 
--- Along a splitting `e` identifying `A` with the first summand via `i`, conjugating by `e` sends
--- an endomorphism restricting to `fA` along `i` to one preserving that summand, acting as `fA`.
-private theorem conj_comp_inl_eq_inl_comp {R A B C : Type*} [Semiring R]
-    [AddCommMonoid A] [Module R A] [AddCommMonoid B] [Module R B] [AddCommMonoid C] [Module R C]
-    {i : A →ₗ[R] B} {fA : A →ₗ[R] A} {fB : B →ₗ[R] B} (e : B ≃ₗ[R] A × C)
-    (hi : ∀ x : A, e.symm ((LinearMap.inl R A C) x) = i x) (hfi : fB.comp i = i.comp fA) :
-    (((e : B →ₗ[R] A × C).comp fB).comp (e.symm : (A × C) →ₗ[R] B)).comp (LinearMap.inl R A C)
-      = (LinearMap.inl R A C).comp fA := by
-  have hi' : ∀ x : A, e (i x) = (LinearMap.inl R A C) x := fun x => by
-    rw [← hi x, LinearEquiv.apply_symm_apply]
-  refine LinearMap.ext fun a => ?_
-  simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, hi]
-  rw [← LinearMap.comp_apply, hfi, LinearMap.comp_apply, hi']
-
--- Dually, along a splitting `e` identifying `C` with the second summand via `q`, conjugating by
--- `e` sends an endomorphism covering `fC` along `q` to one covering `fC` on that summand.
-private theorem snd_comp_conj_eq_comp_snd {R A B C : Type*} [Semiring R]
-    [AddCommMonoid A] [Module R A] [AddCommMonoid B] [Module R B] [AddCommMonoid C] [Module R C]
-    {q : B →ₗ[R] C} {fB : B →ₗ[R] B} {fC : C →ₗ[R] C} (e : B ≃ₗ[R] A × C)
-    (hq : ∀ b : B, (LinearMap.snd R A C) (e b) = q b) (hfq : q.comp fB = fC.comp q) :
-    (LinearMap.snd R A C).comp (((e : B →ₗ[R] A × C).comp fB).comp (e.symm : (A × C) →ₗ[R] B))
-      = fC.comp (LinearMap.snd R A C) := by
-  have hq' : ∀ x : A × C, q (e.symm x) = (LinearMap.snd R A C) x := fun x => by
-    rw [← hq (e.symm x), LinearEquiv.apply_symm_apply]
-  refine LinearMap.ext fun x => ?_
-  simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, hq]
-  rw [← LinearMap.comp_apply, hfq, LinearMap.comp_apply, hq']
-
--- Split an exact sequence as vector spaces. In that splitting the middle action is block
--- triangular, so its trace is the sum of the traces on the subspace and the quotient.
-private theorem trace_eq_add_of_exact {K A B C : Type*} [Field K]
-    [AddCommGroup A] [Module K A] [FiniteDimensional K A] [AddCommGroup B] [Module K B]
-    [AddCommGroup C] [Module K C] [FiniteDimensional K C] (i : A →ₗ[K] B) (q : B →ₗ[K] C)
-    (fA : A →ₗ[K] A) (fB : B →ₗ[K] B) (fC : C →ₗ[K] C)
-    (hi : Function.Injective i) (hq : Function.Surjective q)
-    (hexact : LinearMap.range i = LinearMap.ker q)
-    (hfi : fB.comp i = i.comp fA) (hfq : q.comp fB = fC.comp q) :
-    LinearMap.trace K B fB =
-      LinearMap.trace K A fA + LinearMap.trace K C fC := by
-  classical
-  -- Split `B ≃ₗ A × C`, using Mathlib's correspondence between sections of `q` and splittings.
-  obtain ⟨s, hs⟩ := q.exists_rightInverse_of_surjective (LinearMap.range_eq_top.mpr hq)
-  obtain ⟨e, hie, hqe⟩ :=
-    (LinearMap.exact_iff.mpr hexact.symm).splitSurjectiveEquiv hi ⟨s, hs⟩
-  have hia : ∀ x : A, e.symm ((LinearMap.inl K A C) x) = i x := fun x => by rw [hie]; rfl
-  have hsnd : ∀ b : B, (LinearMap.snd K A C) (e b) = q b := fun b => by rw [hqe]; rfl
-  -- In that splitting `fB` becomes block upper triangular, so its trace splits.
-  rw [← LinearMap.trace_conj' fB e, LinearEquiv.conj_apply,
-    LinearMap.eq_prodMap_add_inl_comp_snd _ (conj_comp_inl_eq_inl_comp e hia hfi)
-      (snd_comp_conj_eq_comp_snd e hsnd hfq),
-    LinearMap.trace_prodMap_add_inl_comp_snd]
-
 /-- The alternating inclusion `⋀²M → M ⊗ M` is natural in the endomorphism: it intertwines the
 exterior square with the diagonal action. -/
 private theorem map_comp_toTensorPower {R : Type} {M : Type*}
@@ -318,15 +266,10 @@ private theorem trace_symmetricPower_sub_trace_exteriorPower {R : Type} {M : Typ
       LinearMap.comp_apply]
     exact congrArg (SymmetricPower.map (ι := Fin 2) f)
       (LinearMap.congr_fun mk_comp_swap x)
-  have h := trace_eq_add_of_exact
-    (exteriorPower.toTensorPower R M 2)
-    (SymmetricPower.mk R (Fin 2) M)
-    (-exteriorPower.map 2 f)
-    ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (tensorSwap R M).toLinearMap)
-    (SymmetricPower.map (ι := Fin 2) f)
+  have h := LinearMap.trace_eq_add_of_exact
     toTensorPower_injective
     (LinearMap.range_eq_top.mp (SymmetricPower.range_mk R (Fin 2) M))
-    range_toTensorPower_eq_ker_mk hfi hfq
+    (LinearMap.exact_iff.mpr range_toTensorPower_eq_ker_mk.symm) hfi hfq
   have hneg : LinearMap.trace R (⋀[R]^2 M) (-exteriorPower.map 2 f)
       = -LinearMap.trace R (⋀[R]^2 M) (exteriorPower.map 2 f) :=
     map_neg (LinearMap.trace R (⋀[R]^2 M)) (exteriorPower.map 2 f)
@@ -390,17 +333,14 @@ theorem char_tensorSquare (ρ : Representation R G M) (g : G) : (ρ.character g)
   simp only [Representation.character, tensorPower_apply, symmetricPower_apply,
     exteriorPower_apply]
   -- Trace is additive along the exact sequence `⋀²M → M⊗M → Sym²M`.
-  have h := TauCeti.TensorSquare.trace_eq_add_of_exact
-    (exteriorPower.toTensorPower R M 2)
-    (SymmetricPower.mk R (Fin 2) M)
-    (exteriorPower.map 2 (ρ g))
-    (PiTensorProduct.map fun _ : Fin 2 ↦ ρ g)
-    (SymmetricPower.map (ρ g))
+  have hq : (SymmetricPower.mk R (Fin 2) M) ∘ₗ (PiTensorProduct.map fun _ : Fin 2 ↦ ρ g)
+      = (SymmetricPower.map (ι := Fin 2) (ρ g)) ∘ₗ (SymmetricPower.mk R (Fin 2) M) :=
+    LinearMap.ext fun x ↦ (SymmetricPower.map_mk (ρ g) x).symm
+  have h := LinearMap.trace_eq_add_of_exact
     TauCeti.TensorSquare.toTensorPower_injective
     (LinearMap.range_eq_top.mp (SymmetricPower.range_mk R (Fin 2) M))
-    TauCeti.TensorSquare.range_toTensorPower_eq_ker_mk
-    (TauCeti.TensorSquare.map_comp_toTensorPower (ρ g))
-    (LinearMap.ext fun x ↦ (SymmetricPower.map_mk (ρ g) x).symm)
+    (LinearMap.exact_iff.mpr TauCeti.TensorSquare.range_toTensorPower_eq_ker_mk.symm)
+    (TauCeti.TensorSquare.map_comp_toTensorPower (ρ g)) hq
   simpa only [add_comm] using h
 
 /-- **The difference of the two square characters is the character at the square.** Over any

--- a/TauCeti/RingTheory/DedekindDomain/Different.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different.lean
@@ -23,7 +23,7 @@ The criterion used is Mathlib's `not_dvd_differentIdeal_of_intTrace_not_mem`: to
 `I` with `I * Q = p · B` does not divide `𝔡(B/A)` it is enough to produce `x ∈ Q` whose integral
 trace is a unit mod `p`.  Taking `I = P ^ e` and `Q` the prime-to-`P` part of `p · B`, the Chinese
 remainder theorem turns that into the requirement that the trace form of the `A ⧸ p`-algebra
-`B ⧸ P ^ e` be nonzero, and `Algebra.trace_quotient_pow` evaluates it: the trace of a residue is
+`B ⧸ P ^ e` be nonzero, and `Algebra.trace_quotient_pow_mk` evaluates it: the trace of a residue is
 `e` times its trace in `B ⧸ P`.  Separability of the residue extension makes the latter trace
 nonzero somewhere, and tameness keeps the factor `e` from killing it.  Both hypotheses are needed:
 in the wild case `e` is zero in `A ⧸ p` and the trace of `B ⧸ P ^ e` vanishes identically, and
@@ -91,7 +91,7 @@ theorem not_pow_dvd_differentIdeal_of_isCoprime_of_isSeparable
     simpa [LinearMap.ext_iff] using Algebra.trace_ne_zero (A ⧸ p) (B ⧸ P)
   obtain ⟨z, rfl⟩ := Ideal.Quotient.mk_surjective w
   have hx : Algebra.trace (A ⧸ p) (B ⧸ P ^ e) (Ideal.Quotient.mk _ z) ≠ 0 := by
-    rw [Algebra.trace_quotient_pow hPbot e z, nsmul_eq_mul]
+    rw [Algebra.trace_quotient_pow_mk hPbot e z, nsmul_eq_mul]
     exact mul_ne_zero he hw
   -- the Chinese remainder decomposition of `B ⧸ pB`
   let ee : (B ⧸ Ideal.map (algebraMap A B) p) ≃ₐ[A ⧸ p] ((B ⧸ P ^ e) × B ⧸ Q) :=

--- a/TauCeti/RingTheory/DedekindDomain/Different.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different.lean
@@ -98,11 +98,14 @@ theorem not_pow_dvd_differentIdeal_of_isCoprime_of_isSeparable
     { __ := (Ideal.quotEquivOfEq hmul.symm).trans
         (Ideal.quotientMulEquivQuotientProd (P ^ e) Q hPQ)
       commutes' := Quotient.ind fun _ ↦ rfl }
+  have ee_snd_mk (b : B) :
+      (ee (Ideal.Quotient.mk (Ideal.map (algebraMap A B) p) b)).2 =
+        Ideal.Quotient.mk Q b := by
+    simp [ee]
   obtain ⟨y, hy⟩ := Ideal.Quotient.mk_surjective (ee.symm (Ideal.Quotient.mk _ z, 0))
   refine not_dvd_differentIdeal_of_intTrace_not_mem A (P ^ e) Q hmul y ?_ ?_
-  · have h2 := congr((ee $hy).2)
-    simp at h2
-    simpa [ee, Ideal.Quotient.eq_zero_iff_mem] using h2
+  · rw [← Ideal.Quotient.eq_zero_iff_mem, ← ee_snd_mk]
+    simpa using congrArg (fun x ↦ (ee x).2) hy
   · rw [← Ideal.Quotient.eq_zero_iff_mem, ← Algebra.trace_quotient_eq_of_isDedekindDomain,
       hy, Algebra.trace_eq_of_algEquiv, Algebra.trace_prod_apply]
     simpa using hx

--- a/TauCeti/RingTheory/DedekindDomain/Different.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.Different
+public import TauCeti.RingTheory.Trace.QuotientPow
+
+/-!
+# Dedekind's different theorem in the tame case
+
+Let `B` be a Dedekind domain, module-finite over a Dedekind domain `A` with `Frac B / Frac A`
+separable, let `p` be a maximal ideal of `A` and `P` a maximal ideal of `B` over it with
+ramification index `e = e(P ∣ p)`.  Mathlib's `pow_sub_one_dvd_differentIdeal` gives the universal
+half of Dedekind's different theorem, `P ^ (e - 1) ∣ 𝔡(B/A)`, and leaves the exact value in the
+tame case as an explicit TODO.  This file supplies it: when the residue extension
+`(B ⧸ P) / (A ⧸ p)` is separable and the residue characteristic does not divide `e`, the divisor
+`P ^ e` does *not* divide the different, so the different exponent at `P` is exactly `e - 1`.
+
+The criterion used is Mathlib's `not_dvd_differentIdeal_of_intTrace_not_mem`: to see that an ideal
+`I` with `I * Q = p · B` does not divide `𝔡(B/A)` it is enough to produce `x ∈ Q` whose integral
+trace is a unit mod `p`.  Taking `I = P ^ e` and `Q` the prime-to-`P` part of `p · B`, the Chinese
+remainder theorem turns that into the requirement that the trace form of the `A ⧸ p`-algebra
+`B ⧸ P ^ e` be nonzero, and `Algebra.trace_quotient_pow` evaluates it: the trace of a residue is
+`e` times its trace in `B ⧸ P`.  Separability of the residue extension makes the latter trace
+nonzero somewhere, and tameness keeps the factor `e` from killing it.  Both hypotheses are needed:
+in the wild case `e` is zero in `A ⧸ p` and the trace of `B ⧸ P ^ e` vanishes identically, and
+without residue separability the different is divisible by `P` even when `e = 1`
+(`dvd_differentIdeal_of_not_isSeparable`).
+
+## Main results
+
+* `TauCeti.not_pow_dvd_differentIdeal_of_isCoprime_of_isSeparable`: the criterion in the form that
+  names a complement `Q` of `P ^ e` in `p · B`.
+* `TauCeti.not_pow_ramificationIdx_dvd_differentIdeal`: **Dedekind's different theorem, tame
+  half** — for a tame `P` with separable residue extension, `P ^ e(P ∣ p) ∤ 𝔡(B/A)`.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Theorem 3.5.1(b).
+-/
+
+public section
+
+open Module
+
+attribute [local instance] FractionRing.liftAlgebra FractionRing.isScalarTower_liftAlgebra
+
+namespace TauCeti
+
+variable (A : Type*) {B : Type*} [CommRing A] [CommRing B] [Algebra A B]
+variable [IsDedekindDomain A] [IsDedekindDomain B] [Module.IsTorsionFree A B] [Module.Finite A B]
+
+attribute [local instance] Ideal.Quotient.field
+
+/-- **A tame prime power does not divide the different ideal.** If `p · B = P ^ e * Q` with
+`P ^ e` and `Q` coprime, the residue extension at `P` is separable, and `e` is invertible in the
+residue field `A ⧸ p`, then `P ^ e` does not divide `differentIdeal A B`.
+
+Together with Mathlib's `pow_sub_one_dvd_differentIdeal` this pins the different exponent at `P`
+to `e - 1`.  Tameness enters only through `he`, and it is essential: in the wild case the trace
+form of `B ⧸ P ^ e` over `A ⧸ p` is identically zero. -/
+theorem not_pow_dvd_differentIdeal_of_isCoprime_of_isSeparable
+    [Algebra.IsSeparable (FractionRing A) (FractionRing B)]
+    {p : Ideal A} [p.IsMaximal] (P Q : Ideal B) [P.IsMaximal] [P.LiesOver p] {e : ℕ}
+    [Algebra.IsSeparable (A ⧸ p) (B ⧸ P)]
+    (hPQ : IsCoprime (P ^ e) Q) (hmul : P ^ e * Q = Ideal.map (algebraMap A B) p)
+    (he : (e : A ⧸ p) ≠ 0) :
+    ¬ P ^ e ∣ differentIdeal A B := by
+  have hene : e ≠ 0 := by rintro rfl; simp at he
+  rcases eq_or_ne P ⊥ with rfl | hPbot
+  · intro hdvd
+    rw [← Ideal.zero_eq_bot, zero_pow hene] at hdvd
+    exact differentIdeal_ne_bot ((zero_dvd_iff.mp hdvd).trans Ideal.zero_eq_bot)
+  have hQle : p ≤ Ideal.comap (algebraMap A B) Q := by
+    rw [← Ideal.map_le_iff_le_comap, ← hmul]; exact Ideal.mul_le_right
+  have hPle : p ≤ Ideal.comap (algebraMap A B) (P ^ e) := by
+    rw [← Ideal.map_le_iff_le_comap, ← hmul]; exact Ideal.mul_le_left
+  let instQ : Algebra (A ⧸ p) (B ⧸ Q) := Ideal.Quotient.algebraQuotientOfLEComap hQle
+  have : IsScalarTower A (A ⧸ p) (B ⧸ Q) := .of_algebraMap_eq' rfl
+  let instPe : Algebra (A ⧸ p) (B ⧸ P ^ e) := Ideal.Quotient.algebraQuotientOfLEComap hPle
+  have : IsScalarTower A (A ⧸ p) (B ⧸ P ^ e) := .of_algebraMap_eq' rfl
+  have hfQ : Module.Finite (A ⧸ p) (B ⧸ Q) := Ideal.Quotient.finite_of_module_finite p Q
+  have hfP : Module.Finite (A ⧸ p) (B ⧸ P ^ e) := Ideal.Quotient.finite_of_module_finite p (P ^ e)
+  have hfP1 : Module.Finite (A ⧸ p) (B ⧸ P) := Ideal.Quotient.finite_of_module_finite p P
+  -- a residue with nonzero trace; its lift to `B ⧸ P ^ e` has trace `e` times as large
+  obtain ⟨w, hw⟩ : ∃ w, Algebra.trace (A ⧸ p) (B ⧸ P) w ≠ 0 := by
+    simpa [LinearMap.ext_iff] using Algebra.trace_ne_zero (A ⧸ p) (B ⧸ P)
+  obtain ⟨z, rfl⟩ := Ideal.Quotient.mk_surjective w
+  have hx : Algebra.trace (A ⧸ p) (B ⧸ P ^ e) (Ideal.Quotient.mk _ z) ≠ 0 := by
+    rw [Algebra.trace_quotient_pow hPbot e z, nsmul_eq_mul]
+    exact mul_ne_zero he hw
+  -- the Chinese remainder decomposition of `B ⧸ pB`
+  let ee : (B ⧸ Ideal.map (algebraMap A B) p) ≃ₐ[A ⧸ p] ((B ⧸ P ^ e) × B ⧸ Q) :=
+    { __ := (Ideal.quotEquivOfEq hmul.symm).trans
+        (Ideal.quotientMulEquivQuotientProd (P ^ e) Q hPQ)
+      commutes' := Quotient.ind fun _ ↦ rfl }
+  obtain ⟨y, hy⟩ := Ideal.Quotient.mk_surjective (ee.symm (Ideal.Quotient.mk _ z, 0))
+  refine not_dvd_differentIdeal_of_intTrace_not_mem A (P ^ e) Q hmul y ?_ ?_
+  · have h2 := congr((ee $hy).2)
+    simp at h2
+    simpa [ee, Ideal.Quotient.eq_zero_iff_mem] using h2
+  · rw [← Ideal.Quotient.eq_zero_iff_mem, ← Algebra.trace_quotient_eq_of_isDedekindDomain,
+      hy, Algebra.trace_eq_of_algEquiv, Algebra.trace_prod_apply]
+    simpa using hx
+
+/-- **Dedekind's different theorem, the tame half** (Stichtenoth, Theorem 3.5.1(b)): at a prime
+`P` whose residue extension is separable and whose ramification index is invertible in the residue
+field of `p`, the different ideal is divisible by `P ^ (e - 1)` — Mathlib's
+`pow_sub_one_dvd_differentIdeal` — but not by `P ^ e`.
+
+The complement `Q` of `P ^ e` in `p · B` is produced by `Ideal.eq_prime_pow_mul_coprime`, whose
+exponent is the ramification index by
+`Ideal.IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count`. -/
+theorem not_pow_ramificationIdx_dvd_differentIdeal
+    [Algebra.IsSeparable (FractionRing A) (FractionRing B)]
+    {p : Ideal A} [p.IsMaximal] (hp : p ≠ ⊥) (P : Ideal B) [P.IsMaximal] [P.LiesOver p]
+    [Algebra.IsSeparable (A ⧸ p) (B ⧸ P)]
+    (he : ((P.ramificationIdx A : ℕ) : A ⧸ p) ≠ 0) :
+    ¬ P ^ P.ramificationIdx A ∣ differentIdeal A B := by
+  have hp' : Ideal.map (algebraMap A B) p ≠ ⊥ :=
+    (Ideal.map_eq_bot_iff_of_injective (FaithfulSMul.algebraMap_injective A B)).not.mpr hp
+  obtain ⟨Q, h₁, h₂⟩ := Ideal.eq_prime_pow_mul_coprime hp' P
+  rw [← Ideal.IsDedekindDomain.ramificationIdx_eq_normalizedFactors_count p P hp'] at h₂
+  exact not_pow_dvd_differentIdeal_of_isCoprime_of_isSeparable A P Q
+    (Ideal.isCoprime_iff_sup_eq.mpr h₁).pow_left h₂.symm he
+
+end TauCeti

--- a/TauCeti/RingTheory/DedekindDomain/Different.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different.lean
@@ -14,8 +14,8 @@ public import TauCeti.RingTheory.Trace.QuotientPow
 Let `B` be a Dedekind domain, module-finite over a Dedekind domain `A` with `Frac B / Frac A`
 separable, let `p` be a maximal ideal of `A` and `P` a maximal ideal of `B` over it with
 ramification index `e = e(P ∣ p)`.  Mathlib's `pow_sub_one_dvd_differentIdeal` gives the universal
-half of Dedekind's different theorem, `P ^ (e - 1) ∣ 𝔡(B/A)`, and leaves the exact value in the
-tame case as an explicit TODO.  This file supplies it: when the residue extension
+half of Dedekind's different theorem, `P ^ (e - 1) ∣ 𝔡(B/A)`.  This file supplies the matching
+non-divisibility that pins the exact value in the tame case: when the residue extension
 `(B ⧸ P) / (A ⧸ p)` is separable and the residue characteristic does not divide `e`, the divisor
 `P ^ e` does *not* divide the different, so the different exponent at `P` is exactly `e - 1`.
 
@@ -83,9 +83,9 @@ theorem not_pow_dvd_differentIdeal_of_isCoprime_of_isSeparable
   have : IsScalarTower A (A ⧸ p) (B ⧸ Q) := .of_algebraMap_eq' rfl
   let instPe : Algebra (A ⧸ p) (B ⧸ P ^ e) := Ideal.Quotient.algebraQuotientOfLEComap hPle
   have : IsScalarTower A (A ⧸ p) (B ⧸ P ^ e) := .of_algebraMap_eq' rfl
-  have hfQ : Module.Finite (A ⧸ p) (B ⧸ Q) := Ideal.Quotient.finite_of_module_finite p Q
-  have hfP : Module.Finite (A ⧸ p) (B ⧸ P ^ e) := Ideal.Quotient.finite_of_module_finite p (P ^ e)
-  have hfP1 : Module.Finite (A ⧸ p) (B ⧸ P) := Ideal.Quotient.finite_of_module_finite p P
+  have hfQ : Module.Finite (A ⧸ p) (B ⧸ Q) := .of_restrictScalars_finite A _ _
+  have hfP : Module.Finite (A ⧸ p) (B ⧸ P ^ e) := .of_restrictScalars_finite A _ _
+  have hfP1 : Module.Finite (A ⧸ p) (B ⧸ P) := .of_restrictScalars_finite A _ _
   -- a residue with nonzero trace; its lift to `B ⧸ P ^ e` has trace `e` times as large
   obtain ⟨w, hw⟩ : ∃ w, Algebra.trace (A ⧸ p) (B ⧸ P) w ≠ 0 := by
     simpa [LinearMap.ext_iff] using Algebra.trace_ne_zero (A ⧸ p) (B ⧸ P)

--- a/TauCeti/RingTheory/Trace/QuotientPow.lean
+++ b/TauCeti/RingTheory/Trace/QuotientPow.lean
@@ -35,9 +35,8 @@ identity is `LinearMap.trace_eq_add_of_exact`.
 The formula is what makes the tame case of Dedekind's different theorem work: it produces an
 element of `B ⧸ P ^ e` with nonzero trace as soon as the residue extension is separable and the
 characteristic of `κ` does not divide `e` (see
-`TauCeti.RingTheory.DedekindDomain.Different`).  Mathlib computes the trace of `B ⧸ p · B` over
-`κ` (`Algebra.trace_quotient_eq_of_isDedekindDomain`) but has nothing about the individual
-`P`-primary factors.
+`TauCeti.RingTheory.DedekindDomain.Different`, where it is combined with Mathlib's trace
+computation for `B ⧸ p · B`, `Algebra.trace_quotient_eq_of_isDedekindDomain`).
 
 ## Main results
 
@@ -47,19 +46,6 @@ characteristic of `κ` does not divide `e` (see
 public section
 
 open Module
-
-namespace Ideal.Quotient
-
-/-- A quotient of a module-finite algebra by an ideal is finite over the residue ring of the
-base. -/
-theorem finite_of_module_finite {A B : Type*} [CommRing A] [CommRing B] [Algebra A B]
-    [Module.Finite A B] (p : Ideal A) (I : Ideal B) [Algebra (A ⧸ p) (B ⧸ I)]
-    [IsScalarTower A (A ⧸ p) (B ⧸ I)] : Module.Finite (A ⧸ p) (B ⧸ I) := by
-  have : Module.Finite A (B ⧸ I) :=
-    Module.Finite.of_surjective (Ideal.Quotient.mkₐ A I).toLinearMap Ideal.Quotient.mk_surjective
-  exact Module.Finite.of_restrictScalars_finite A (A ⧸ p) (B ⧸ I)
-
-end Ideal.Quotient
 
 namespace Algebra
 
@@ -88,7 +74,7 @@ theorem trace_quotient_pow [Module.Finite A B] (hP : P ≠ ⊥) (n : ℕ)
         exact Ideal.one_eq_top
       rw [Subsingleton.elim (Ideal.Quotient.mk (P ^ 0) z) 0, map_zero, zero_smul]
   | succ n ih =>
-      have := Ideal.Quotient.finite_of_module_finite p (P ^ (n + 1))
+      have := Module.Finite.of_restrictScalars_finite A (A ⧸ p) (B ⧸ P ^ (n + 1))
       -- the base ideal is carried into `P ^ (n + 1)`, hence into `P ^ n`
       have hcomap : p ≤ Ideal.comap (algebraMap A B) (P ^ (n + 1)) := by
         intro x hx
@@ -100,8 +86,8 @@ theorem trace_quotient_pow [Module.Finite A B] (hP : P ≠ ⊥) (n : ℕ)
         hcomap.trans (Ideal.comap_mono (Ideal.pow_le_pow_right n.le_succ))
       let instA' : Algebra (A ⧸ p) (B ⧸ P ^ n) := Ideal.Quotient.algebraQuotientOfLEComap hcomap'
       let instT' : IsScalarTower A (A ⧸ p) (B ⧸ P ^ n) := IsScalarTower.of_algebraMap_eq' rfl
-      have := Ideal.Quotient.finite_of_module_finite p (P ^ n)
-      have := Ideal.Quotient.finite_of_module_finite p P
+      have := Module.Finite.of_restrictScalars_finite A (A ⧸ p) (B ⧸ P ^ n)
+      have := Module.Finite.of_restrictScalars_finite A (A ⧸ p) (B ⧸ P)
       -- an element generating `P ^ n` modulo `P ^ (n + 1)`
       obtain ⟨a, ha, ha'⟩ := Ideal.exists_mem_pow_notMem_pow_succ P hP
         (Ideal.IsPrime.ne_top inferInstance) n
@@ -141,13 +127,12 @@ theorem trace_quotient_pow [Module.Finite A B] (hP : P ≠ ⊥) (n : ℕ)
           obtain ⟨x, w, hw, rfl⟩ :=
             Ideal.exists_mul_add_mem_pow_succ hP a u ha ha' hu
           refine ⟨Ideal.Quotient.mk P x, ?_⟩
-          rw [hi_apply, Ideal.Quotient.mk_eq_mk_iff_sub_mem,
-            show a * x - (a * x + w) = -w by ring]
+          rw [hi_apply, Ideal.Quotient.mk_eq_mk_iff_sub_mem, sub_add_cancel_left]
           exact neg_mem hw
         · rintro ⟨y, hy⟩
           obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective y
           rw [hi_apply, Ideal.Quotient.mk_eq_mk_iff_sub_mem] at hy
-          rw [show u = a * x - (a * x - u) by ring]
+          rw [← sub_sub_cancel (a * x) u]
           exact sub_mem (Ideal.mul_mem_right x _ ha) (Ideal.pow_le_pow_right n.le_succ hy)
       -- multiplication by `z` is an endomorphism of the whole sequence
       set f : Module.End (A ⧸ p) (B ⧸ P ^ (n + 1)) :=
@@ -156,19 +141,20 @@ theorem trace_quotient_pow [Module.Finite A B] (hP : P ≠ ⊥) (n : ℕ)
         Algebra.lmul (A ⧸ p) _ (Ideal.Quotient.mk _ z) with hfN
       set fQ : Module.End (A ⧸ p) (B ⧸ P ^ n) :=
         Algebra.lmul (A ⧸ p) _ (Ideal.Quotient.mk _ z) with hfQ
+      have hf_apply (y : B ⧸ P ^ (n + 1)) : f y = Ideal.Quotient.mk (P ^ (n + 1)) z * y := rfl
+      have hfN_apply (y : B ⧸ P) : fN y = Ideal.Quotient.mk P z * y := rfl
+      have hfQ_apply (y : B ⧸ P ^ n) : fQ y = Ideal.Quotient.mk (P ^ n) z * y := rfl
       have hN : f ∘ₗ i = i ∘ₗ fN := by
         refine LinearMap.ext fun y ↦ ?_
         obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective y
-        change Ideal.Quotient.mk (P ^ (n + 1)) z * i (Ideal.Quotient.mk P x)
-          = i (Ideal.Quotient.mk P z * Ideal.Quotient.mk P x)
-        rw [hi_apply, ← map_mul, ← map_mul, hi_apply]
+        rw [LinearMap.comp_apply, LinearMap.comp_apply, hf_apply, hfN_apply, hi_apply, ← map_mul,
+          ← map_mul, hi_apply]
         exact congrArg _ (by ring)
       have hQ : pi ∘ₗ f = fQ ∘ₗ pi := by
         refine LinearMap.ext fun y ↦ ?_
         obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective y
-        change pi (Ideal.Quotient.mk (P ^ (n + 1)) z * Ideal.Quotient.mk (P ^ (n + 1)) x)
-          = Ideal.Quotient.mk (P ^ n) z * pi (Ideal.Quotient.mk (P ^ (n + 1)) x)
-        rw [← map_mul, hpi_apply, hpi_apply, map_mul]
+        rw [LinearMap.comp_apply, LinearMap.comp_apply, hf_apply, hfQ_apply, ← map_mul, hpi_apply,
+          hpi_apply, map_mul]
       have e1 : Algebra.trace (A ⧸ p) (B ⧸ P ^ (n + 1)) (Ideal.Quotient.mk _ z)
           = LinearMap.trace (A ⧸ p) _ f := Algebra.trace_apply _ _
       have e2 : Algebra.trace (A ⧸ p) (B ⧸ P) (Ideal.Quotient.mk _ z)

--- a/TauCeti/RingTheory/Trace/QuotientPow.lean
+++ b/TauCeti/RingTheory/Trace/QuotientPow.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
 public import Mathlib.RingTheory.Trace.Basic
 public import TauCeti.LinearAlgebra.Trace.Exact
+import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 
 /-!
 # The trace of a quotient by a power of a prime
@@ -28,7 +29,7 @@ time, through the short exact sequence
 
 where `a` is any element of `P ^ n` not in `P ^ (n + 1)`; injectivity of multiplication by `a` and
 exactness in the middle are the two Dedekind facts
-`Ideal.IsPrime.mem_pow_mul` and `Ideal.span_singleton_sup_pow_succ`, and the trace
+`Ideal.IsPrime.mem_pow_mul` and `Ideal.exists_mul_add_mem_pow_succ`, and the trace
 identity is `LinearMap.trace_eq_add_of_exact`.
 
 The formula is what makes the tame case of Dedekind's different theorem work: it produces an
@@ -40,43 +41,12 @@ characteristic of `κ` does not divide `e` (see
 
 ## Main results
 
-* `Ideal.span_singleton_sup_pow_succ`: in a Dedekind domain, an element of `P ^ n` outside
-  `P ^ (n + 1)` generates `P ^ n` modulo `P ^ (n + 1)`.
 * `Algebra.trace_quotient_pow`: the trace formula `Tr_{B ⧸ P ^ n} = n · Tr_{B ⧸ P}`.
-
-## References
-
-Mathlib already proves the ideal equality `Ideal.span_singleton_sup_pow_succ` below, as the
-`suffices` step inside the proof of `Ideal.exists_mul_add_mem_pow_succ` in
-`Mathlib.RingTheory.Ideal.Norm.AbsNorm`, on the way to the element-wise form of that statement;
-Mathlib credits it to [J. Neukirch, *Algebraic Number Theory*][Neukirch1992], Proposition 6.1.
-The theorem below states that step on its own, with the proof adapted from Mathlib's, because it
-is the ideal-level form — not the element-wise one — that the filtration argument here needs.
 -/
 
 public section
 
 open Module
-
-namespace Ideal
-
-variable {B : Type*} [CommRing B] [IsDedekindDomain B] (P : Ideal B) [P.IsPrime]
-
-/-- In a Dedekind domain, an element of `P ^ n` that is not in `P ^ (n + 1)` generates `P ^ n`
-modulo `P ^ (n + 1)`.
-
-This equality is extracted from the proof of Mathlib's `Ideal.exists_mul_add_mem_pow_succ`
-(`Mathlib.RingTheory.Ideal.Norm.AbsNorm`), where it appears as an internal `suffices` step, and
-the proof below is adapted from that one; Mathlib credits it to
-[J. Neukirch, *Algebraic Number Theory*][Neukirch1992], Proposition 6.1. -/
-theorem span_singleton_sup_pow_succ (hP : P ≠ ⊥) {n : ℕ} {a : B} (ha : a ∈ P ^ n)
-    (ha' : a ∉ P ^ (n + 1)) : Ideal.span {a} ⊔ P ^ (n + 1) = P ^ n := by
-  refine Ideal.eq_prime_pow_of_succ_lt_of_le hP (lt_of_le_of_ne le_sup_right fun h ↦ ha' ?_)
-    (sup_le (Ideal.span_le.mpr (Set.singleton_subset_iff.mpr ha))
-      (Ideal.pow_le_pow_right n.le_succ))
-  exact h ▸ (le_sup_left : Ideal.span {a} ≤ _) (Ideal.mem_span_singleton_self a)
-
-end Ideal
 
 namespace Ideal.Quotient
 
@@ -168,12 +138,11 @@ theorem trace_quotient_pow [Module.Finite A B] (hP : P ≠ ⊥) (n : ℕ)
         rw [hpi_apply, Ideal.Quotient.eq_zero_iff_mem]
         constructor
         · intro hu
-          rw [← Ideal.span_singleton_sup_pow_succ P hP ha ha'] at hu
-          obtain ⟨v, hv, w, hw, rfl⟩ := Submodule.mem_sup.mp hu
-          obtain ⟨x, rfl⟩ := Ideal.mem_span_singleton'.mp hv
+          obtain ⟨x, w, hw, rfl⟩ :=
+            Ideal.exists_mul_add_mem_pow_succ hP a u ha ha' hu
           refine ⟨Ideal.Quotient.mk P x, ?_⟩
           rw [hi_apply, Ideal.Quotient.mk_eq_mk_iff_sub_mem,
-            show a * x - (x * a + w) = -w by ring]
+            show a * x - (a * x + w) = -w by ring]
           exact neg_mem hw
         · rintro ⟨y, hy⟩
           obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective y

--- a/TauCeti/RingTheory/Trace/QuotientPow.lean
+++ b/TauCeti/RingTheory/Trace/QuotientPow.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
+public import Mathlib.RingTheory.Trace.Basic
+public import TauCeti.LinearAlgebra.Trace.Exact
+
+/-!
+# The trace of a quotient by a power of a prime
+
+Let `B` be a Dedekind domain over a commutative ring `A`, let `p` be a maximal ideal of `A` with
+residue field `κ = A ⧸ p`, and let `P` be a maximal ideal of `B` with `p · B ⊆ P ^ n`, so that
+`B ⧸ P ^ n` is a `κ`-algebra.  This file computes the trace of that algebra:
+
+`Tr_{(B ⧸ P ^ n) / κ} (z) = n · Tr_{(B ⧸ P) / κ} (z)`.
+
+The `P`-adic filtration of `B ⧸ P ^ n` has `n` graded pieces, each of them a copy of the residue
+field `B ⧸ P` on which multiplication by `z` acts as multiplication by the residue of `z`; the
+trace of an endomorphism of a filtered vector space is the sum of the traces on the pieces, so the
+`n` copies contribute `n` equal summands.  The induction runs over one step of the filtration at a
+time, through the short exact sequence
+
+`0 → B ⧸ P --· a--> B ⧸ P ^ (n + 1) → B ⧸ P ^ n → 0`,
+
+where `a` is any element of `P ^ n` not in `P ^ (n + 1)`; injectivity of multiplication by `a` and
+exactness in the middle are the two Dedekind facts
+`Ideal.IsPrime.mem_pow_mul` and `Ideal.span_singleton_sup_pow_succ`, and the trace
+identity is `LinearMap.trace_eq_add_of_exact`.
+
+The formula is what makes the tame case of Dedekind's different theorem work: it produces an
+element of `B ⧸ P ^ e` with nonzero trace as soon as the residue extension is separable and the
+characteristic of `κ` does not divide `e` (see
+`TauCeti.RingTheory.DedekindDomain.Different`).  Mathlib computes the trace of `B ⧸ p · B` over
+`κ` (`Algebra.trace_quotient_eq_of_isDedekindDomain`) but has nothing about the individual
+`P`-primary factors.
+
+## Main results
+
+* `Ideal.span_singleton_sup_pow_succ`: in a Dedekind domain, an element of `P ^ n` outside
+  `P ^ (n + 1)` generates `P ^ n` modulo `P ^ (n + 1)`.
+* `Algebra.trace_quotient_pow`: the trace formula `Tr_{B ⧸ P ^ n} = n · Tr_{B ⧸ P}`.
+-/
+
+public section
+
+open Module
+
+namespace Ideal
+
+variable {B : Type*} [CommRing B] [IsDedekindDomain B] (P : Ideal B) [P.IsPrime]
+
+/-- In a Dedekind domain, an element of `P ^ n` that is not in `P ^ (n + 1)` generates `P ^ n`
+modulo `P ^ (n + 1)`. -/
+theorem span_singleton_sup_pow_succ (hP : P ≠ ⊥) {n : ℕ} {a : B} (ha : a ∈ P ^ n)
+    (ha' : a ∉ P ^ (n + 1)) : Ideal.span {a} ⊔ P ^ (n + 1) = P ^ n := by
+  refine Ideal.eq_prime_pow_of_succ_lt_of_le hP (lt_of_le_of_ne le_sup_right fun h ↦ ha' ?_)
+    (sup_le (Ideal.span_le.mpr (Set.singleton_subset_iff.mpr ha))
+      (Ideal.pow_le_pow_right n.le_succ))
+  exact h ▸ (le_sup_left : Ideal.span {a} ≤ _) (Ideal.mem_span_singleton_self a)
+
+end Ideal
+
+namespace Ideal.Quotient
+
+/-- A quotient of a module-finite algebra by an ideal is finite over the residue ring of the
+base. -/
+theorem finite_of_module_finite {A B : Type*} [CommRing A] [CommRing B] [Algebra A B]
+    [Module.Finite A B] (p : Ideal A) (I : Ideal B) [Algebra (A ⧸ p) (B ⧸ I)]
+    [IsScalarTower A (A ⧸ p) (B ⧸ I)] : Module.Finite (A ⧸ p) (B ⧸ I) := by
+  have : Module.Finite A (B ⧸ I) :=
+    Module.Finite.of_surjective (Ideal.Quotient.mkₐ A I).toLinearMap Ideal.Quotient.mk_surjective
+  exact Module.Finite.of_restrictScalars_finite A (A ⧸ p) (B ⧸ I)
+
+end Ideal.Quotient
+
+namespace Algebra
+
+variable {A B : Type*} [CommRing A] [CommRing B] [Algebra A B] [IsDedekindDomain B]
+variable {p : Ideal A} [p.IsMaximal] {P : Ideal B} [P.IsMaximal]
+
+attribute [local instance] Ideal.Quotient.field
+
+/-- **The trace of a quotient by a prime power.** For `P` a maximal ideal of a Dedekind domain `B`
+that is module-finite over `A`, and `p` a maximal ideal of `A` making both `B ⧸ P ^ n` and `B ⧸ P`
+algebras over the residue field `A ⧸ p`, the trace of the residue of `z` in `B ⧸ P ^ n` is `n`
+times its trace in the residue field `B ⧸ P`.
+
+The two `IsScalarTower` hypotheses pin the algebra structures to the ones induced by `A → B`;
+they are what `Ideal.Quotient.algebraQuotientOfLEComap` provides, and they hold for `B ⧸ P ^ n`
+exactly when `p · B ⊆ P ^ n`. -/
+theorem trace_quotient_pow [Module.Finite A B] (hP : P ≠ ⊥) (n : ℕ)
+    [instA : Algebra (A ⧸ p) (B ⧸ P ^ n)] [instT : IsScalarTower A (A ⧸ p) (B ⧸ P ^ n)]
+    [Algebra (A ⧸ p) (B ⧸ P)] [IsScalarTower A (A ⧸ p) (B ⧸ P)] (z : B) :
+    Algebra.trace (A ⧸ p) (B ⧸ P ^ n) (Ideal.Quotient.mk _ z) =
+      n • Algebra.trace (A ⧸ p) (B ⧸ P) (Ideal.Quotient.mk _ z) := by
+  induction n generalizing instA instT with
+  | zero =>
+      have : Subsingleton (B ⧸ P ^ 0) := by
+        rw [Ideal.Quotient.subsingleton_iff, pow_zero]
+        exact Ideal.one_eq_top
+      rw [Subsingleton.elim (Ideal.Quotient.mk (P ^ 0) z) 0, map_zero, zero_smul]
+  | succ n ih =>
+      have := Ideal.Quotient.finite_of_module_finite p (P ^ (n + 1))
+      -- the base ideal is carried into `P ^ (n + 1)`, hence into `P ^ n`
+      have hcomap : p ≤ Ideal.comap (algebraMap A B) (P ^ (n + 1)) := by
+        intro x hx
+        have h0 : algebraMap A (B ⧸ P ^ (n + 1)) x = 0 := by
+          rw [IsScalarTower.algebraMap_apply A (A ⧸ p) (B ⧸ P ^ (n + 1)),
+            Ideal.Quotient.algebraMap_eq, Ideal.Quotient.eq_zero_iff_mem.mpr hx, map_zero]
+        rwa [Ideal.mem_comap, ← Ideal.Quotient.eq_zero_iff_mem]
+      have hcomap' : p ≤ Ideal.comap (algebraMap A B) (P ^ n) :=
+        hcomap.trans (Ideal.comap_mono (Ideal.pow_le_pow_right n.le_succ))
+      let instA' : Algebra (A ⧸ p) (B ⧸ P ^ n) := Ideal.Quotient.algebraQuotientOfLEComap hcomap'
+      let instT' : IsScalarTower A (A ⧸ p) (B ⧸ P ^ n) := IsScalarTower.of_algebraMap_eq' rfl
+      have := Ideal.Quotient.finite_of_module_finite p (P ^ n)
+      have := Ideal.Quotient.finite_of_module_finite p P
+      -- an element generating `P ^ n` modulo `P ^ (n + 1)`
+      obtain ⟨a, ha, ha'⟩ := Ideal.exists_mem_pow_notMem_pow_succ P hP
+        (Ideal.IsPrime.ne_top inferInstance) n
+      -- the two maps of the short exact sequence, `B`-linearly
+      have hmul : P ≤ Submodule.comap (LinearMap.mulLeft B a) (P ^ (n + 1)) := fun x hx ↦ by
+        simpa [pow_succ] using Ideal.mul_mem_mul ha hx
+      have hfac : P ^ (n + 1) ≤ Submodule.comap (LinearMap.id (R := B) (M := B)) (P ^ n) :=
+        Ideal.pow_le_pow_right n.le_succ
+      have hsurj : Function.Surjective (algebraMap A (A ⧸ p)) := Ideal.Quotient.mk_surjective
+      set i : (B ⧸ P) →ₗ[A ⧸ p] (B ⧸ P ^ (n + 1)) :=
+        ((Submodule.mapQ P (P ^ (n + 1)) (LinearMap.mulLeft B a) hmul).restrictScalars
+          A).extendScalarsOfSurjective hsurj with hi_def
+      set pi : (B ⧸ P ^ (n + 1)) →ₗ[A ⧸ p] (B ⧸ P ^ n) :=
+        ((Submodule.mapQ (P ^ (n + 1)) (P ^ n) LinearMap.id hfac).restrictScalars
+          A).extendScalarsOfSurjective hsurj with hpi_def
+      have hi_apply (x : B) : i (Ideal.Quotient.mk P x) = Ideal.Quotient.mk (P ^ (n + 1)) (a * x) :=
+        rfl
+      have hpi_apply (x : B) :
+          pi (Ideal.Quotient.mk (P ^ (n + 1)) x) = Ideal.Quotient.mk (P ^ n) x := rfl
+      -- the sequence `0 → B ⧸ P → B ⧸ P ^ (n + 1) → B ⧸ P ^ n → 0` is exact
+      have hinj : Function.Injective i := by
+        rw [injective_iff_map_eq_zero]
+        intro y hy
+        obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective y
+        rw [hi_apply, Ideal.Quotient.eq_zero_iff_mem] at hy
+        rw [Ideal.Quotient.eq_zero_iff_mem]
+        exact (Ideal.IsPrime.mem_pow_mul P hy).resolve_left ha'
+      have hsur : Function.Surjective pi := fun y ↦ by
+        obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective y
+        exact ⟨Ideal.Quotient.mk _ x, hpi_apply x⟩
+      have hex : Function.Exact i pi := by
+        intro y
+        obtain ⟨u, rfl⟩ := Ideal.Quotient.mk_surjective y
+        rw [hpi_apply, Ideal.Quotient.eq_zero_iff_mem]
+        constructor
+        · intro hu
+          rw [← Ideal.span_singleton_sup_pow_succ P hP ha ha'] at hu
+          obtain ⟨v, hv, w, hw, rfl⟩ := Submodule.mem_sup.mp hu
+          obtain ⟨x, rfl⟩ := Ideal.mem_span_singleton'.mp hv
+          refine ⟨Ideal.Quotient.mk P x, ?_⟩
+          rw [hi_apply, Ideal.Quotient.mk_eq_mk_iff_sub_mem,
+            show a * x - (x * a + w) = -w by ring]
+          exact neg_mem hw
+        · rintro ⟨y, hy⟩
+          obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective y
+          rw [hi_apply, Ideal.Quotient.mk_eq_mk_iff_sub_mem] at hy
+          rw [show u = a * x - (a * x - u) by ring]
+          exact sub_mem (Ideal.mul_mem_right x _ ha) (Ideal.pow_le_pow_right n.le_succ hy)
+      -- multiplication by `z` is an endomorphism of the whole sequence
+      set f : Module.End (A ⧸ p) (B ⧸ P ^ (n + 1)) :=
+        Algebra.lmul (A ⧸ p) _ (Ideal.Quotient.mk _ z) with hf
+      set fN : Module.End (A ⧸ p) (B ⧸ P) :=
+        Algebra.lmul (A ⧸ p) _ (Ideal.Quotient.mk _ z) with hfN
+      set fQ : Module.End (A ⧸ p) (B ⧸ P ^ n) :=
+        Algebra.lmul (A ⧸ p) _ (Ideal.Quotient.mk _ z) with hfQ
+      have hN : f ∘ₗ i = i ∘ₗ fN := by
+        refine LinearMap.ext fun y ↦ ?_
+        obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective y
+        change Ideal.Quotient.mk (P ^ (n + 1)) z * i (Ideal.Quotient.mk P x)
+          = i (Ideal.Quotient.mk P z * Ideal.Quotient.mk P x)
+        rw [hi_apply, ← map_mul, ← map_mul, hi_apply]
+        exact congrArg _ (by ring)
+      have hQ : pi ∘ₗ f = fQ ∘ₗ pi := by
+        refine LinearMap.ext fun y ↦ ?_
+        obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective y
+        change pi (Ideal.Quotient.mk (P ^ (n + 1)) z * Ideal.Quotient.mk (P ^ (n + 1)) x)
+          = Ideal.Quotient.mk (P ^ n) z * pi (Ideal.Quotient.mk (P ^ (n + 1)) x)
+        rw [← map_mul, hpi_apply, hpi_apply, map_mul]
+      have e1 : Algebra.trace (A ⧸ p) (B ⧸ P ^ (n + 1)) (Ideal.Quotient.mk _ z)
+          = LinearMap.trace (A ⧸ p) _ f := Algebra.trace_apply _ _
+      have e2 : Algebra.trace (A ⧸ p) (B ⧸ P) (Ideal.Quotient.mk _ z)
+          = LinearMap.trace (A ⧸ p) _ fN := Algebra.trace_apply _ _
+      have e3 : Algebra.trace (A ⧸ p) (B ⧸ P ^ n) (Ideal.Quotient.mk _ z)
+          = LinearMap.trace (A ⧸ p) _ fQ := Algebra.trace_apply _ _
+      rw [e1, LinearMap.trace_eq_add_of_exact hinj hsur hex hN hQ, ← e2, ← e3, ih,
+        succ_nsmul']
+
+end Algebra

--- a/TauCeti/RingTheory/Trace/QuotientPow.lean
+++ b/TauCeti/RingTheory/Trace/QuotientPow.lean
@@ -40,7 +40,7 @@ computation for `B ⧸ p · B`, `Algebra.trace_quotient_eq_of_isDedekindDomain`)
 
 ## Main results
 
-* `Algebra.trace_quotient_pow`: the trace formula `Tr_{B ⧸ P ^ n} = n · Tr_{B ⧸ P}`.
+* `Algebra.trace_quotient_pow_mk`: the trace formula `Tr_{B ⧸ P ^ n} = n · Tr_{B ⧸ P}`.
 -/
 
 public section
@@ -62,7 +62,7 @@ times its trace in the residue field `B ⧸ P`.
 The two `IsScalarTower` hypotheses pin the algebra structures to the ones induced by `A → B`;
 they are what `Ideal.Quotient.algebraQuotientOfLEComap` provides, and they hold for `B ⧸ P ^ n`
 exactly when `p · B ⊆ P ^ n`. -/
-theorem trace_quotient_pow [Module.Finite A B] (hP : P ≠ ⊥) (n : ℕ)
+theorem trace_quotient_pow_mk [Module.Finite A B] (hP : P ≠ ⊥) (n : ℕ)
     [instA : Algebra (A ⧸ p) (B ⧸ P ^ n)] [instT : IsScalarTower A (A ⧸ p) (B ⧸ P ^ n)]
     [Algebra (A ⧸ p) (B ⧸ P)] [IsScalarTower A (A ⧸ p) (B ⧸ P)] (z : B) :
     Algebra.trace (A ⧸ p) (B ⧸ P ^ n) (Ideal.Quotient.mk _ z) =

--- a/TauCeti/RingTheory/Trace/QuotientPow.lean
+++ b/TauCeti/RingTheory/Trace/QuotientPow.lean
@@ -43,6 +43,15 @@ characteristic of `κ` does not divide `e` (see
 * `Ideal.span_singleton_sup_pow_succ`: in a Dedekind domain, an element of `P ^ n` outside
   `P ^ (n + 1)` generates `P ^ n` modulo `P ^ (n + 1)`.
 * `Algebra.trace_quotient_pow`: the trace formula `Tr_{B ⧸ P ^ n} = n · Tr_{B ⧸ P}`.
+
+## References
+
+Mathlib already proves the ideal equality `Ideal.span_singleton_sup_pow_succ` below, as the
+`suffices` step inside the proof of `Ideal.exists_mul_add_mem_pow_succ` in
+`Mathlib.RingTheory.Ideal.Norm.AbsNorm`, on the way to the element-wise form of that statement;
+Mathlib credits it to [J. Neukirch, *Algebraic Number Theory*][Neukirch1992], Proposition 6.1.
+The theorem below states that step on its own, with the proof adapted from Mathlib's, because it
+is the ideal-level form — not the element-wise one — that the filtration argument here needs.
 -/
 
 public section
@@ -54,7 +63,12 @@ namespace Ideal
 variable {B : Type*} [CommRing B] [IsDedekindDomain B] (P : Ideal B) [P.IsPrime]
 
 /-- In a Dedekind domain, an element of `P ^ n` that is not in `P ^ (n + 1)` generates `P ^ n`
-modulo `P ^ (n + 1)`. -/
+modulo `P ^ (n + 1)`.
+
+This equality is extracted from the proof of Mathlib's `Ideal.exists_mul_add_mem_pow_succ`
+(`Mathlib.RingTheory.Ideal.Norm.AbsNorm`), where it appears as an internal `suffices` step, and
+the proof below is adapted from that one; Mathlib credits it to
+[J. Neukirch, *Algebraic Number Theory*][Neukirch1992], Proposition 6.1. -/
 theorem span_singleton_sup_pow_succ (hP : P ≠ ⊥) {n : ℕ} {a : B} (ha : a ∈ P ^ n)
     (ha' : a ∉ P ^ (n + 1)) : Ideal.span {a} ⊔ P ^ (n + 1) = P ^ n := by
   refine Ideal.eq_prime_pow_of_succ_lt_of_le hP (lt_of_le_of_ne le_sup_right fun h ↦ ha' ?_)

--- a/TauCeti/RingTheory/Trace/QuotientPow.lean
+++ b/TauCeti/RingTheory/Trace/QuotientPow.lean
@@ -104,9 +104,17 @@ theorem trace_quotient_pow [Module.Finite A B] (hP : P ≠ ⊥) (n : ℕ)
         ((Submodule.mapQ (P ^ (n + 1)) (P ^ n) LinearMap.id hfac).restrictScalars
           A).extendScalarsOfSurjective hsurj with hpi_def
       have hi_apply (x : B) : i (Ideal.Quotient.mk P x) = Ideal.Quotient.mk (P ^ (n + 1)) (a * x) :=
-        rfl
+        by
+          rw [hi_def, LinearMap.extendScalarsOfSurjective_apply,
+            LinearMap.restrictScalars_apply]
+          simpa only [← Ideal.Quotient.mk_eq_mk, LinearMap.mulLeft_apply] using
+            Submodule.mapQ_apply P (P ^ (n + 1)) (LinearMap.mulLeft B a) x
       have hpi_apply (x : B) :
-          pi (Ideal.Quotient.mk (P ^ (n + 1)) x) = Ideal.Quotient.mk (P ^ n) x := rfl
+          pi (Ideal.Quotient.mk (P ^ (n + 1)) x) = Ideal.Quotient.mk (P ^ n) x := by
+        rw [hpi_def, LinearMap.extendScalarsOfSurjective_apply,
+          LinearMap.restrictScalars_apply]
+        simpa only [← Ideal.Quotient.mk_eq_mk, LinearMap.id_apply] using
+          Submodule.mapQ_apply (P ^ (n + 1)) (P ^ n) LinearMap.id x
       -- the sequence `0 → B ⧸ P → B ⧸ P ^ (n + 1) → B ⧸ P ^ n → 0` is exact
       have hinj : Function.Injective i := by
         rw [injective_iff_map_eq_zero]


### PR DESCRIPTION
This PR proves the tame case of Dedekind's different theorem: at a place `P'` of `F'/k'` over `P` of `F/k` whose local model has separable residue extension and whose ramification index is invertible in the residue field of `P`, the different exponent is exactly `d(P' | P) = e(P' | P) - 1`. This is the AlgebraicCurves roadmap's Layer 7 bullet "Dedekind's different theorem (Thm. 3.5.1) ... (b) equality ⟺ `char k ∤ e(P′∣P)` (tame) ... the **exact tame value is built here** (it is the pin's own TODO)". Mathlib's `pow_sub_one_dvd_differentIdeal` supplies `P^(e-1) ∣ 𝔡` and `TauCeti.Place.ramificationIdx_le_differentExponent_add_one` already transcribes that half; what was missing everywhere, in Mathlib as well as here, is the matching non-divisibility `P^e ∤ 𝔡`, and that is what this PR establishes.

The missing input is a trace computation. Mathlib's `not_dvd_differentIdeal_of_intTrace_not_mem` reduces `P^e ∤ 𝔡(B/A)` to producing an element of the prime-to-`P` part of `p·B` whose integral trace is a unit mod `p`; through the Chinese remainder decomposition of `B ⧸ p·B` that is the statement that the trace form of the `A ⧸ p`-algebra `B ⧸ P^e` is nonzero. `Algebra.trace_quotient_pow` evaluates it: the `P`-adic filtration of `B ⧸ P^n` has `n` graded pieces, each a copy of `B ⧸ P` on which multiplication by `z` acts through the residue of `z`, so `Tr_{B ⧸ P^n}(z) = n · Tr_{B ⧸ P}(z̄)`. Separability of the residue extension makes the right-hand trace nonzero somewhere and tameness keeps the factor `n = e` from killing it — both hypotheses are essential, since in the wild case the trace of `B ⧸ P^e` vanishes identically and without residue separability `P ∣ 𝔡` already at `e = 1`. The induction over the filtration runs on one short exact sequence at a time, which needs the additivity of the trace along `0 → N → M → Q → 0`; Mathlib has additivity over an internal direct sum (`LinearMap.trace_eq_sum_trace_restrict`), but an endomorphism of a short exact sequence respects only the filtration, so the splitting has to be chosen independently of it and the off-diagonal block killed by `LinearMap.trace_comp_comm'`. The repo's existing `LinearMap.trace_prodMap_add_inl_comp_snd` does the block-triangular bookkeeping.

Four files, 576 lines. `TauCeti/LinearAlgebra/Trace/Exact.lean` proves `LinearMap.trace_eq_add_of_exact`. `TauCeti/RingTheory/Trace/QuotientPow.lean` proves `Ideal.span_singleton_sup_pow_succ` (an element of `P^n` outside `P^(n+1)` generates `P^n` modulo `P^(n+1)`, from Mathlib's `Ideal.eq_prime_pow_of_succ_lt_of_le`) and `Algebra.trace_quotient_pow`. `TauCeti/RingTheory/DedekindDomain/Different.lean` proves `TauCeti.not_pow_dvd_differentIdeal_of_isCoprime_of_isSeparable` and, with the complement produced by `Ideal.eq_prime_pow_mul_coprime`, `TauCeti.not_pow_ramificationIdx_dvd_differentIdeal`. `TauCeti/FieldTheory/FunctionField/Different/Tame.lean` transcribes it to places: `TauCeti.Place.ramificationIdx_eq_differentExponent_add_one` in the subtraction-free form `e(P' | P) = d(P' | P) + 1`, together with `TauCeti.Divisor.coeff_different_add_one_eq_ramificationIdx` for the coefficient of the different divisor of TauCeti#5680. The two hypotheses are read on the local model `𝒪_P ⊆ 𝒪'_P` where the different exponent lives, following the idiom `TauCeti.Place.differentExponent_eq_zero_iff` already uses for unramifiedness; `TauCeti.Place.center_restrict_asIdeal_eq_maximalIdeal` and the accompanying `LiesOver` instance identify the prime below as the maximal ideal of the discrete valuation ring `𝒪_P`, so the hypotheses are always instantiable at the residue field of `P`.

No Mathlib infrastructure was vendored; everything consumes the pinned Mathlib directly.

After this PR, Layer 7 still owes the cotrace of Weil differentials with the divisor identity `(Cotr ω) = Con (ω) + Diff(F′/F)`, which is what Hurwitz falls out of, and which additionally waits on the canonical divisor of a Weil differential (open PR TauCeti#5207); transitivity of the different, `d(P″∣P) = e(P″∣P′)·d(P′∣P) + d(P″∣P′)`, remains blocked on a localization compatibility for the trace dual that Mathlib does not have.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"differentexponent-eq-ramificationidx-sub-one"}-->

🤖 Prepared with Claude Code
