### PR TITLE
feat(NumberField): the Artin symbol is trivial exactly at the completely split primes

### DIFF
--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -41,6 +41,8 @@ conjugation action.
   `Nat.card` form.
 * `TauCeti.ConjClasses.ncard_carrier_mk_of_mem_center`: the class of a central element is a single
   point.
+* `ConjClasses.mk_eq_one_iff`: a class is the identity class exactly when a representative is
+  the identity.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
   the group, with `TauCeti.ConjClasses.card_carrier_cast_ne_zero` the consequence that the size of
   a class is nonzero in any semiring where the group order is.
@@ -295,6 +297,14 @@ theorem map_pow {N : Type*} [Monoid N] (f : M →* N) (C : ConjClasses M) (j : �
   -- the map on representatives, after which `mk_pow` handles both powers and `map_pow` finishes
   -- in `N`.
   rw [mk_pow, map_mk, map_mk, mk_pow, _root_.map_pow]
+
+/-- **A conjugacy class is trivial exactly when a representative is.** Only the identity is
+conjugate to the identity, so `mk a` is the identity class precisely when `a = 1`.
+
+The attribute is deliberately omitted: this is a good `simp` normalisation, but promoting it
+belongs in a change whose subject is this API rather than in a consumer. -/
+theorem mk_eq_one_iff {G : Type*} [Group G] {a : G} : ConjClasses.mk a = 1 ↔ a = 1 := by
+  rw [ConjClasses.one_eq_mk_one, ConjClasses.mk_eq_mk_iff_isConj, isConj_one_left]
 
 /-- **Elements of different orders are not conjugate.** Conjugation is an automorphism, so it
 preserves the order of an element; hence two elements whose orders differ have distinct conjugacy

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -41,8 +41,6 @@ conjugation action.
   `Nat.card` form.
 * `TauCeti.ConjClasses.ncard_carrier_mk_of_mem_center`: the class of a central element is a single
   point.
-* `ConjClasses.mk_eq_one_iff`: a class is the identity class exactly when a representative is
-  the identity.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
   the group, with `TauCeti.ConjClasses.card_carrier_cast_ne_zero` the consequence that the size of
   a class is nonzero in any semiring where the group order is.
@@ -297,14 +295,6 @@ theorem map_pow {N : Type*} [Monoid N] (f : M →* N) (C : ConjClasses M) (j : �
   -- the map on representatives, after which `mk_pow` handles both powers and `map_pow` finishes
   -- in `N`.
   rw [mk_pow, map_mk, map_mk, mk_pow, _root_.map_pow]
-
-/-- **A conjugacy class is trivial exactly when a representative is.** Only the identity is
-conjugate to the identity, so `mk a` is the identity class precisely when `a = 1`.
-
-The attribute is deliberately omitted: this is a good `simp` normalisation, but promoting it
-belongs in a change whose subject is this API rather than in a consumer. -/
-theorem mk_eq_one_iff {G : Type*} [Group G] {a : G} : ConjClasses.mk a = 1 ↔ a = 1 := by
-  rw [ConjClasses.one_eq_mk_one, ConjClasses.mk_eq_mk_iff_isConj, isConj_one_left]
 
 /-- **Elements of different orders are not conjugate.** Conjugation is an automorphism, so it
 preserves the order of an element; hence two elements whose orders differ have distinct conjugacy

--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -7,11 +7,11 @@ module
 
 public import Mathlib.NumberTheory.RamificationInertia.Galois
 public import Mathlib.RingTheory.Frobenius
-public import TauCeti.NumberTheory.NumberField.Frobenius.DecompositionGroup
 public import TauCeti.NumberTheory.NumberField.Frobenius.Restriction
-public import TauCeti.NumberTheory.NumberField.SplitsCompletely
 public import TauCeti.NumberTheory.NumberField.UnramifiedTower
 import TauCeti.Algebra.Group.Conj
+import TauCeti.NumberTheory.NumberField.Frobenius.DecompositionGroup
+import TauCeti.NumberTheory.NumberField.SplitsCompletely
 
 /-!
 # The Artin symbol of an unramified prime
@@ -183,9 +183,8 @@ section SplitsCompletely
 /-!
 ### The trivial Artin symbol
 
-The Artin symbol is the identity class exactly at the primes that split completely. Both
-directions come from the same computation: the symbol is represented by an arithmetic Frobenius
-`σ` at any prime `Q` above `𝔭`, and `orderOf σ` is the inertia degree `f(Q/𝔭)`.
+Two equivalent readings of the identity Artin class at an unramified prime: residue degree one,
+and complete splitting.
 -/
 
 variable {L : Type*} [Field L] [NumberField L] [Algebra K L] [IsGalois K L]
@@ -193,8 +192,7 @@ variable {L : Type*} [Field L] [NumberField L] [Algebra K L] [IsGalois K L]
 /-- **The Artin symbol is trivial exactly at residue degree one.** For a prime `Q` of `𝓞 L` above
 an unramified `𝔭`, the Artin symbol of `𝔭` is the identity class if and only if `f(Q/𝔭) = 1`.
 
-The symbol is `ConjClasses.mk σ` for an arithmetic Frobenius `σ` at `Q`, a class is trivial
-exactly when a representative is (`ConjClasses.mk_eq_one_iff`), and `orderOf σ = f(Q/𝔭)`. -/
+The residue degree is common to all primes above `𝔭`, so the choice of `Q` is immaterial. -/
 theorem artinSymbol_eq_one_iff_inertiaDeg_eq_one (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal]
     (hur : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q)
     (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭] :
@@ -202,15 +200,15 @@ theorem artinSymbol_eq_one_iff_inertiaDeg_eq_one (𝔭 : Ideal (𝓞 K)) [𝔭.I
   have hQ : Q ≠ ⊥ := Ideal.ne_bot_of_liesOver_of_ne_bot (NeZero.ne 𝔭) Q
   have : Algebra.IsUnramifiedAt (𝓞 K) Q := hur Q
   obtain ⟨σ, hσ⟩ := exists_isArithFrobAt K Q hQ
-  rw [artinSymbol_eq_mk_of_isArithFrobAt 𝔭 hur Q σ hσ, ConjClasses.mk_eq_one_iff,
-    ← orderOf_eq_one_iff, orderOf_eq_inertiaDeg_of_isArithFrobAt Q hQ hσ]
+  rw [artinSymbol_eq_mk_of_isArithFrobAt 𝔭 hur Q σ hσ, ConjClasses.one_eq_mk_one,
+    ConjClasses.mk_eq_mk_iff_isConj, isConj_one_left, ← orderOf_eq_one_iff,
+    orderOf_eq_inertiaDeg_of_isArithFrobAt Q hQ hσ]
 
 /-- **The Artin symbol is trivial exactly at the completely split primes.** For `𝔭` unramified in
 `L`, the Artin symbol of `𝔭` is the identity class if and only if `𝔭` splits completely, that is,
 `𝓞 L` has `[L : K]` primes above `𝔭`.
 
-The count criterion reads complete splitting as `e = f = 1`; unramifiedness supplies `e = 1`, so
-what is left is exactly the residue-degree condition. -/
+A caller who knows the prime count therefore knows the symbol, and conversely. -/
 theorem artinSymbol_eq_one_iff_ncard_primesOver_eq_finrank (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal]
     (hur : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q) :
     artinSymbol 𝔭 hur = 1 ↔ (𝔭.primesOver (𝓞 L)).ncard = Module.finrank K L := by

--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -194,7 +194,7 @@ variable {L : Type*} [Field L] [NumberField L] [Algebra K L] [IsGalois K L]
 an unramified `𝔭`, the Artin symbol of `𝔭` is the identity class if and only if `f(Q/𝔭) = 1`.
 
 The symbol is `ConjClasses.mk σ` for an arithmetic Frobenius `σ` at `Q`, a class is trivial
-exactly when its representative is, and `orderOf σ = f(Q/𝔭)`. -/
+exactly when a representative is (`ConjClasses.mk_eq_one_iff`), and `orderOf σ = f(Q/𝔭)`. -/
 theorem artinSymbol_eq_one_iff_inertiaDeg_eq_one (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal]
     (hur : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q)
     (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭] :
@@ -202,9 +202,8 @@ theorem artinSymbol_eq_one_iff_inertiaDeg_eq_one (𝔭 : Ideal (𝓞 K)) [𝔭.I
   have hQ : Q ≠ ⊥ := Ideal.ne_bot_of_liesOver_of_ne_bot (NeZero.ne 𝔭) Q
   have : Algebra.IsUnramifiedAt (𝓞 K) Q := hur Q
   obtain ⟨σ, hσ⟩ := exists_isArithFrobAt K Q hQ
-  rw [artinSymbol_eq_mk_of_isArithFrobAt 𝔭 hur Q σ hσ, ConjClasses.one_eq_mk_one,
-    ConjClasses.mk_eq_mk_iff_isConj, isConj_one_left, ← orderOf_eq_one_iff,
-    orderOf_eq_inertiaDeg_of_isArithFrobAt Q hQ hσ]
+  rw [artinSymbol_eq_mk_of_isArithFrobAt 𝔭 hur Q σ hσ, ConjClasses.mk_eq_one_iff,
+    ← orderOf_eq_one_iff, orderOf_eq_inertiaDeg_of_isArithFrobAt Q hQ hσ]
 
 /-- **The Artin symbol is trivial exactly at the completely split primes.** For `𝔭` unramified in
 `L`, the Artin symbol of `𝔭` is the identity class if and only if `𝔭` splits completely, that is,

--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -7,7 +7,9 @@ module
 
 public import Mathlib.NumberTheory.RamificationInertia.Galois
 public import Mathlib.RingTheory.Frobenius
+public import TauCeti.NumberTheory.NumberField.Frobenius.DecompositionGroup
 public import TauCeti.NumberTheory.NumberField.Frobenius.Restriction
+public import TauCeti.NumberTheory.NumberField.SplitsCompletely
 public import TauCeti.NumberTheory.NumberField.UnramifiedTower
 import TauCeti.Algebra.Group.Conj
 
@@ -25,6 +27,9 @@ Exercise 2.
 The same reference gives functoriality in a normal tower: restriction maps the Artin symbol of
 `L/K` to the Artin symbol of `M/K`. Unramifiedness in the intermediate extension is derived from
 unramifiedness in the top extension, rather than assumed separately.
+
+Finally, the symbol detects complete splitting: it is the identity class exactly when the
+residue degree is one, equivalently when `𝓞 L` has `[L : K]` primes above `𝔭`.
 -/
 
 public section
@@ -172,5 +177,53 @@ theorem artinSymbol_eq_map_autCongr (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal] (e 
   rfl
 
 end IsoOfExtensions
+
+section SplitsCompletely
+
+/-!
+### The trivial Artin symbol
+
+The Artin symbol is the identity class exactly at the primes that split completely. Both
+directions come from the same computation: the symbol is represented by an arithmetic Frobenius
+`σ` at any prime `Q` above `𝔭`, and `orderOf σ` is the inertia degree `f(Q/𝔭)`.
+-/
+
+variable {L : Type*} [Field L] [NumberField L] [Algebra K L] [IsGalois K L]
+
+/-- **The Artin symbol is trivial exactly at residue degree one.** For a prime `Q` of `𝓞 L` above
+an unramified `𝔭`, the Artin symbol of `𝔭` is the identity class if and only if `f(Q/𝔭) = 1`.
+
+The symbol is `ConjClasses.mk σ` for an arithmetic Frobenius `σ` at `Q`, a class is trivial
+exactly when its representative is, and `orderOf σ = f(Q/𝔭)`. -/
+theorem artinSymbol_eq_one_iff_inertiaDeg_eq_one (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal]
+    (hur : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q)
+    (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭] :
+    artinSymbol 𝔭 hur = 1 ↔ Q.inertiaDeg (𝓞 K) = 1 := by
+  have hQ : Q ≠ ⊥ := Ideal.ne_bot_of_liesOver_of_ne_bot (NeZero.ne 𝔭) Q
+  have : Algebra.IsUnramifiedAt (𝓞 K) Q := hur Q
+  obtain ⟨σ, hσ⟩ := exists_isArithFrobAt K Q hQ
+  rw [artinSymbol_eq_mk_of_isArithFrobAt 𝔭 hur Q σ hσ, ConjClasses.one_eq_mk_one,
+    ConjClasses.mk_eq_mk_iff_isConj, isConj_one_left, ← orderOf_eq_one_iff,
+    orderOf_eq_inertiaDeg_of_isArithFrobAt Q hQ hσ]
+
+/-- **The Artin symbol is trivial exactly at the completely split primes.** For `𝔭` unramified in
+`L`, the Artin symbol of `𝔭` is the identity class if and only if `𝔭` splits completely, that is,
+`𝓞 L` has `[L : K]` primes above `𝔭`.
+
+The count criterion reads complete splitting as `e = f = 1`; unramifiedness supplies `e = 1`, so
+what is left is exactly the residue-degree condition. -/
+theorem artinSymbol_eq_one_iff_ncard_primesOver_eq_finrank (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal]
+    (hur : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q) :
+    artinSymbol 𝔭 hur = 1 ↔ (𝔭.primesOver (𝓞 L)).ncard = Module.finrank K L := by
+  obtain ⟨Q, _, _⟩ := (inferInstance : Nonempty (𝔭.primesOver (𝓞 L)))
+  have : Algebra.IsUnramifiedAt (𝓞 K) Q := hur Q
+  rw [artinSymbol_eq_one_iff_inertiaDeg_eq_one 𝔭 hur Q,
+    ncard_primesOver_eq_finrank_iff_of_isGalois K L 𝔭,
+    Ideal.ramificationIdxIn_eq_ramificationIdx 𝔭 Q (L ≃ₐ[K] L),
+    Ideal.inertiaDegIn_eq_inertiaDeg 𝔭 Q (L ≃ₐ[K] L),
+    Ideal.ramificationIdx_eq_one_of_isUnramifiedAt]
+  exact (and_iff_right rfl).symm
+
+end SplitsCompletely
 
 end NumberField


### PR DESCRIPTION
Two `iff`s pinning down when the Artin symbol is trivial. For a finite Galois extension `L / K`
of number fields and a prime `𝔭` of `𝓞 K` unramified in `L`:

```lean
theorem artinSymbol_eq_one_iff_inertiaDeg_eq_one (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal]
    (hur : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q)
    (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭] :
    artinSymbol 𝔭 hur = 1 ↔ Q.inertiaDeg (𝓞 K) = 1

theorem artinSymbol_eq_one_iff_ncard_primesOver_eq_finrank (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal]
    (hur : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q) :
    artinSymbol 𝔭 hur = 1 ↔ (𝔭.primesOver (𝓞 L)).ncard = Module.finrank K L
```

This is the Chebotarev roadmap's Layer 1 item "prove that the class at a split-completely prime
is the identity", strengthened to an `iff` because the route gives both directions at once.

### Why an `iff`, and why two forms

The whole proof is one computation: the symbol is `ConjClasses.mk σ` for an arithmetic Frobenius
`σ` at any prime `Q` above `𝔭`, a conjugacy class is trivial exactly when a representative is,
and `orderOf σ = f(Q/𝔭)`. Every step is an equivalence, so proving only the roadmap's direction
would have meant discarding half the result.

The two forms are not redundant. The residue-degree form takes `Q` as a hypothesis rather than
choosing one, so a caller who already has a prime in hand does not have to produce the count;
the splitting form has no `Q` at all and is the shape "splits completely" is usually stated in.
Each is a one-line consequence of the other in the presence of the Galois fibre lemmas, which is
exactly why both belong here rather than at the call sites.

### Reuse

Nothing is re-derived. The proof is assembled from material already on `main` and in Mathlib:

* `orderOf_eq_inertiaDeg_of_isArithFrobAt` (`NumberField/Frobenius/DecompositionGroup.lean`)
  turns the class condition into the residue degree;
* `ncard_primesOver_eq_finrank_iff_of_isGalois` (`NumberField/SplitsCompletely.lean`) reads
  complete splitting as `e = f = 1`;
* Mathlib's `Ideal.ramificationIdx_eq_one_of_isUnramifiedAt` discharges the `e = 1` conjunct, so
  the count criterion collapses onto the residue-degree condition;
* `Ideal.ramificationIdxIn_eq_ramificationIdx` and `Ideal.inertiaDegIn_eq_inertiaDeg` move
  between the fibre-wide invariants and the chosen `Q`.

The second theorem's proof is the first one plus those four rewrites. Both are under ten lines.

### Placement

In `ArtinSymbol.lean`, the file that defines `artinSymbol`, rather than under
`TauCeti/NumberTheory/Chebotarev/`. These are basic properties of the symbol, stated purely in
its own vocabulary, and every consumer of the symbol wants them — not only the density argument
that motivated them. The file's module docstring is extended in its existing prose style to name
the new results.

`Frobenius.DecompositionGroup` and `SplitsCompletely` are needed only inside the two proofs, so
they are **plain `import`s, not `public import`s** — in the module system a public import
re-exports to every downstream consumer, and neither declaration appears in a statement. The file
already used a plain import for its `TauCeti.Algebra.Group.Conj` dependency for the same reason.

### Mathlib absence

Mathlib has no Artin symbol and no complete-splitting predicate, so this statement cannot be
phrased in its vocabulary at all — a full-name grep for `artinSymbol`/`ArtinSymbol` and for
`splitsCompletely`/`SplitsCompletely`/`totallySplit` over the pinned tree
(`5fcc6656691ed31965746c369f41fa75e567ac9d`) returns nothing, and `IsArithFrobAt` occurs only in
`Mathlib/RingTheory/Frobenius.lean`, which carries no order or splitting criterion. Both
theorems elaborate with no pre-existing lemma applying.

### No `Provenance` line

Nothing here is adapted. The named source, `CBirkbeck/chebotarev-density`, does have adjacent
material, and it is worth saying precisely how it differs rather than leaving the overlap
unexplained. Its `frobeniusClass_fixedField_eq_one` (`CebotarevDensity/CyclotomicNormResidue.lean`)
is the *converse* direction, routed through a fixed field `F = fixedField H` with `H` abelian and
with `Frob ∈ H` as the hypothesis. Its splitting corollary `Chebotarev.density_split_completely`
(`CebotarevDensity/Main.lean`) is stated as a condition on `frobeniusClass K L 𝔭 = ConjClasses.mk 1`
— that is, it *uses the trivial class as the definition* of splitting completely and never
formalises the equivalence with the actual splitting count. The source's blueprint states that
equivalence only as prose. So the `iff` proved here is absent from the source, and this PR
supplies what would make a statement of that shape mean what it says.

### On the scope line

Chebotarev's README lists "an Artin symbol" under *Out of scope*, so it is worth saying why the
attribution below is still `Chebotarev` rather than Number Field Arithmetic. That exclusion is
an **ownership boundary**, in the README's own words: "The first three exclusions are ownership
boundaries, not omissions … A theorem here imports their declarations and never rebuilds them
under a Chebotarev-specific spelling." This PR imports `artinSymbol` and does not rebuild it, so
it stays on the right side of that line. Meanwhile Layer 1 names this exact result — "prove that
the class at a split-completely prime is the identity" — and "splitting-completely and
arithmetic-progression specializations" appear under *In scope*. Chebotarev is the roadmap that
asks for the theorem; Number Field Arithmetic owns the object it is about, which is why the
declarations sit in that roadmap's file.

Roadmap: Chebotarev

<!--tauceti-target:v1 {"focus":"Chebotarev","id":"Chebotarev/README.md:Layer-1"}-->

---

## Review round 1 — four findings implemented, and one contradiction resolved by deletion

The review requested changes on five rubrics. **Three of them were about the same declaration and
two of those contradicted each other:**

* `reuse` — "`ConjClasses.mk_eq_one_iff` is an unnecessary thin wrapper around existing Mathlib
  lemmas and is used only once in this PR. *Fix:* Delete it."
* `api-design` — "…lacks `@[simp]`. *Fix:* Annotate the theorem with `@[simp]`."
* `generality` — "…assumes `[Group G]`, although the statement and every lemma used hold for a
  monoid. *Fix:* Generalize the signature."

One says remove it; the other two say keep it and improve it. **I have taken the `reuse` route and
deleted it**, which makes the other two moot rather than contested: with the declaration gone there
is nothing to annotate or generalise. That is also the substantively right call — the lemma was
three rewrites with a single call site, which is exactly the bar `reuse` applies. Its three steps
are now inlined at the one place they were used.

A consequence worth noting: `TauCeti/Algebra/Group/Conj.lean` is now **byte-identical to `main`**,
so this PR is a one-file diff.

The other two findings are implemented as asked:

* `placement` — the two proof-only dependencies became plain imports (see Placement above).
* `documentation` — the `simp`-attribute paragraph is gone with the declaration, and the section
  header plus both theorem docstrings no longer narrate the proof route. They now state the
  equivalence, its hypotheses, and how a caller reads the condition.

**On the cleanup pass.** The `lean-lsp` MCP server has been unreachable for this whole session,
so `/cleanup`'s phase 6.5 (`/simplify`) and 6.6 (`/buzz`) could not run through their usual
hand-offs. Both were discharged directly instead, and I would rather say how than let the
receipt imply the tooling ran:

* **6.6 (`/buzz`)** is about elaboration cost, which `#count_heartbeats` measures without an LSP.
  The two theorems use **1328** and **1780** heartbeats against the 200000 default — well under
  one percent of budget, so there is nothing to tune and no `maxHeartbeats` override anywhere.
* **6.5 (`/simplify`)** was done by hand, and produced the `ConjClasses.mk_eq_one_iff`
  extraction above.

The rest of the workflow ran normally: clean rebuild of the module closure with no Mathlib
recompilation, every line within 100 characters, the terminal bare `simp` squeezed to
`exact (and_iff_right rfl).symm`, naming and docstrings checked, axioms confirmed to be exactly
`propext`, `Classical.choice` and `Quot.sound`, and the downstream Chebotarev consumers plus
`Algebra.Group.ConjFinite` rebuilt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF
