### PR TITLE
feat(Algebra): class size times representative order divides the group order

### DIFF
--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -83,6 +83,9 @@ division is exact — `#C` is the index of the centralizer of `σ`, and `orderOf
 centralizer's order, so their product divides `#G` — and the second evaluates the quotient as the
 centralizer's order over `orderOf σ`. Neither asserts that either side counts anything; a caller
 wanting a cardinality interpretation must supply it.
+
+`card_carrier_mul_orderOf_dvd` follows `TauCetiRoadmap/Chebotarev/Suggested.lean` lines 377-382 in
+name, argument structure and conclusion.
 -/
 
 public section
@@ -247,9 +250,9 @@ theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (
 /-- **That quotient in closed form.** Dividing the order of the group by the class size times the
 order of a member leaves the order of the centralizer divided by that same order.
 
-Only the centralizer of `σ` need have nonzero index; `Subgroup.index_ne_zero_of_finite` discharges
-that for a finite group. Both divisions are exact, so the identity is an equality of ratios rather
-than of truncated quotients. -/
+`hindex` is what lets the centralizer's index cancel from both sides; it holds automatically when
+`G` is finite. Both divisions are exact, so the identity is an equality of ratios rather than of
+truncated quotients. -/
 theorem card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf {G : Type*} [Group G]
     (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier)
     (hindex : (Subgroup.centralizer {σ}).index ≠ 0) :

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -82,7 +82,9 @@ The two counting statements are the group-theoretic half of a fibre count: for a
 quotient `#G / (#C * orderOf σ)` counts something, and it does so only because the division is
 exact — `#C` is the index of the centralizer of `σ`, and `orderOf σ` divides that centralizer's
 order, so their product divides `#G`. Dividing then leaves the centralizer's order over
-`orderOf σ`.
+`orderOf σ`. Their names, arguments and conclusions are pinned by
+`TauCetiRoadmap/Chebotarev/Suggested.lean` lines 377-382, which state
+`card_carrier_mul_orderOf_dvd` in this form for that fibre count.
 -/
 
 public section

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -237,7 +237,8 @@ division rather than a truncated one, which is why a fibre count needs it separa
 finiteness is assumed here: for an infinite group `Nat.card G` is `0`, and every natural number
 divides `0`.
 
-The fibre count wanting it is `TauCetiRoadmap/Chebotarev/README.md`, Layer 8.2. -/
+Adapted from `TauCetiRoadmap/Chebotarev/Suggested.lean`, which pins this name, argument
+structure and conclusion. -/
 theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (σ : G)
     (hσ : σ ∈ C.carrier) :
     Nat.card C.carrier * orderOf σ ∣ Nat.card G := by

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -82,9 +82,7 @@ The two counting statements are the group-theoretic half of a fibre count: for a
 quotient `#G / (#C * orderOf σ)` counts something, and it does so only because the division is
 exact — `#C` is the index of the centralizer of `σ`, and `orderOf σ` divides that centralizer's
 order, so their product divides `#G`. Dividing then leaves the centralizer's order over
-`orderOf σ`. Their names, arguments and conclusions are pinned by
-`TauCetiRoadmap/Chebotarev/Suggested.lean` lines 377-382, which state
-`card_carrier_mul_orderOf_dvd` in this form for that fibre count.
+`orderOf σ`.
 -/
 
 public section

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -42,7 +42,7 @@ conjugation action.
 * `TauCeti.ConjClasses.ncard_carrier_mk_of_mem_center`: the class of a central element is a single
   point.
 * `ConjClasses.card_carrier_mul_orderOf_dvd`: the class size times the order of a member
-  divides the order of the group, so the fibre quotient below is an exact division.
+  divides the order of the group, so the quotient below is an exact ratio.
 * `ConjClasses.card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf`: that
   quotient equals the order of the centralizer divided by the order of the member.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
@@ -78,11 +78,11 @@ rather than reusable conjugacy-class API. This operation is *not* adapted from t
 Birkbeck–Brasca `chebotarev-density` development, which works with `ConjClasses.mk` and
 `Subgroup.zpowers` directly and never forms `C ^ j`.
 
-The two counting statements are the group-theoretic half of a fibre count: for a finite group the
-quotient `#G / (#C * orderOf σ)` counts something, and it does so only because the division is
-exact — `#C` is the index of the centralizer of `σ`, and `orderOf σ` divides that centralizer's
-order, so their product divides `#G`. Dividing then leaves the centralizer's order over
-`orderOf σ`.
+The two arithmetic statements concern the quotient `#G / (#C * orderOf σ)`. The first says the
+division is exact — `#C` is the index of the centralizer of `σ`, and `orderOf σ` divides that
+centralizer's order, so their product divides `#G` — and the second evaluates the quotient as the
+centralizer's order over `orderOf σ`. Neither asserts that either side counts anything; a caller
+wanting a cardinality interpretation must supply it.
 -/
 
 public section
@@ -232,10 +232,9 @@ namespace ConjClasses
 /-- **The size of a conjugacy class times the order of a member divides the order of the group.**
 
 For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orderOf σ)` an exact
-division rather than a truncated one, which is why a fibre count needs it separately;
-`card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` evaluates that quotient. No
-finiteness is assumed here: for an infinite group `Nat.card G` is `0`, and every natural number
-divides `0`. -/
+ratio rather than a truncated division, which
+`card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` then evaluates. No finiteness
+is assumed here: for an infinite group `Nat.card G` is `0`, and every natural number divides `0`. -/
 theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (σ : G)
     (hσ : σ ∈ C.carrier) :
     Nat.card C.carrier * orderOf σ ∣ Nat.card G := by
@@ -245,19 +244,21 @@ theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (
     (Subgroup.mem_centralizer_singleton_iff.mpr rfl)
   exact ⟨k, by rw [TauCeti.ConjClasses.card_carrier_mk, mul_assoc, ← hk, Subgroup.index_mul_card]⟩
 
-/-- **That quotient in closed form.** For a finite group, dividing the order of the group by the
-class size times the order of a member leaves the order of the centralizer divided by that same
-order.
+/-- **That quotient in closed form.** Dividing the order of the group by the class size times the
+order of a member leaves the order of the centralizer divided by that same order.
 
-Both divisions are exact, so a caller may read either side as a count. -/
+Only the centralizer of `σ` need have nonzero index; `Subgroup.index_ne_zero_of_finite` discharges
+that for a finite group. Both divisions are exact, so the identity is an equality of ratios rather
+than of truncated quotients. -/
 theorem card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf {G : Type*} [Group G]
-    [Finite G] (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier) :
+    (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier)
+    (hindex : (Subgroup.centralizer {σ}).index ≠ 0) :
     Nat.card G / (Nat.card C.carrier * orderOf σ)
       = Nat.card (Subgroup.centralizer {σ}) / orderOf σ := by
   rw [mem_carrier_iff_mk_eq] at hσ
   subst hσ
   rw [TauCeti.ConjClasses.card_carrier_mk, ← Subgroup.index_mul_card (Subgroup.centralizer {σ}),
-    Nat.mul_div_mul_left _ _ (Nat.pos_of_ne_zero Subgroup.index_ne_zero_of_finite)]
+    Nat.mul_div_mul_left _ _ (Nat.pos_of_ne_zero hindex)]
 
 end ConjClasses
 

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -237,9 +237,7 @@ division rather than a truncated one, which is why a fibre count needs it separa
 finiteness is assumed here: for an infinite group `Nat.card G` is `0`, and every natural number
 divides `0`.
 
-`TauCetiRoadmap/Chebotarev/README.md`, Layer 8.2, pins this signature in its `Suggested.lean` and
-consumes it in `fixedField_frobenius_fiber_card`, the exact cardinality of the residue-degree-one
-relative fibre. -/
+The fibre count wanting it is `TauCetiRoadmap/Chebotarev/README.md`, Layer 8.2. -/
 theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (σ : G)
     (hσ : σ ∈ C.carrier) :
     Nat.card C.carrier * orderOf σ ∣ Nat.card G := by

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -82,7 +82,7 @@ The two counting statements are the group-theoretic half of a fibre count: for a
 quotient `#G / (#C * orderOf σ)` counts something, and it does so only because the division is
 exact — `#C` is the index of the centralizer of `σ`, and `orderOf σ` divides that centralizer's
 order, so their product divides `#G`. Dividing then leaves the centralizer's order over
-`orderOf σ`. They are wanted by the Chebotarev roadmap's Layer 8.2.
+`orderOf σ`.
 -/
 
 public section
@@ -222,6 +222,45 @@ theorem isRealClass_mk_iff {g : G} : IsRealClass (ConjClasses.mk g) ↔ IsConj g
 
 end TauCeti
 
+/-! ### The size of a class against the order of a member
+
+These extend the centralizer-index description of the class size just above; they live in the root
+`ConjClasses` namespace so that `C.card_carrier_mul_orderOf_dvd` resolves. -/
+
+namespace ConjClasses
+
+/-- **The size of a conjugacy class times the order of a member divides the order of the group.**
+
+For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orderOf σ)` an exact
+division rather than a truncated one, which is why a fibre count needs it separately;
+`card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` evaluates that quotient. No
+finiteness is assumed here: for an infinite group `Nat.card G` is `0`, and every natural number
+divides `0`. -/
+theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (σ : G)
+    (hσ : σ ∈ C.carrier) :
+    Nat.card C.carrier * orderOf σ ∣ Nat.card G := by
+  rw [mem_carrier_iff_mk_eq] at hσ
+  subst hσ
+  obtain ⟨k, hk⟩ := (Subgroup.centralizer {σ}).orderOf_dvd_natCard
+    (Subgroup.mem_centralizer_singleton_iff.mpr rfl)
+  exact ⟨k, by rw [TauCeti.ConjClasses.card_carrier_mk, mul_assoc, ← hk, Subgroup.index_mul_card]⟩
+
+/-- **That quotient in closed form.** For a finite group, dividing the order of the group by the
+class size times the order of a member leaves the order of the centralizer divided by that same
+order.
+
+Both divisions are exact, so a caller may read either side as a count. -/
+theorem card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf {G : Type*} [Group G]
+    [Finite G] (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier) :
+    Nat.card G / (Nat.card C.carrier * orderOf σ)
+      = Nat.card (Subgroup.centralizer {σ}) / orderOf σ := by
+  rw [mem_carrier_iff_mk_eq] at hσ
+  subst hσ
+  rw [TauCeti.ConjClasses.card_carrier_mk, ← Subgroup.index_mul_card (Subgroup.centralizer {σ}),
+    Nat.mul_div_mul_left _ _ (Nat.pos_of_ne_zero Subgroup.index_ne_zero_of_finite)]
+
+end ConjClasses
+
 /-! ### Powers of a conjugacy class
 
 These live in the root `ConjClasses` namespace, not under `TauCeti`, so that dot
@@ -305,36 +344,6 @@ theorem map_pow {N : Type*} [Monoid N] (f : M →* N) (C : ConjClasses M) (j : �
   -- the map on representatives, after which `mk_pow` handles both powers and `map_pow` finishes
   -- in `N`.
   rw [mk_pow, map_mk, map_mk, mk_pow, _root_.map_pow]
-
-/-- **The size of a conjugacy class times the order of a member divides the order of the group.**
-
-For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orderOf σ)` an exact
-division rather than a truncated one, which is why Chebotarev's fibre count needs it separately;
-`card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` evaluates that quotient. No
-finiteness is assumed here: for an infinite group `Nat.card G` is `0`, and every natural number
-divides `0`. -/
-theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (σ : G)
-    (hσ : σ ∈ C.carrier) :
-    Nat.card C.carrier * orderOf σ ∣ Nat.card G := by
-  rw [mem_carrier_iff_mk_eq] at hσ
-  subst hσ
-  obtain ⟨k, hk⟩ := (Subgroup.centralizer {σ}).orderOf_dvd_natCard
-    (Subgroup.mem_centralizer_singleton_iff.mpr rfl)
-  exact ⟨k, by rw [TauCeti.ConjClasses.card_carrier_mk, mul_assoc, ← hk, Subgroup.index_mul_card]⟩
-
-/-- **That quotient in closed form.** For a finite group, dividing the order of the group by the
-class size times the order of a member leaves the order of the centralizer divided by that same
-order.
-
-Both divisions are exact, so a caller may read either side as a count. -/
-theorem card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf {G : Type*} [Group G]
-    [Finite G] (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier) :
-    Nat.card G / (Nat.card C.carrier * orderOf σ)
-      = Nat.card (Subgroup.centralizer {σ}) / orderOf σ := by
-  rw [mem_carrier_iff_mk_eq] at hσ
-  subst hσ
-  rw [TauCeti.ConjClasses.card_carrier_mk, ← Subgroup.index_mul_card (Subgroup.centralizer {σ}),
-    Nat.mul_div_mul_left _ _ (Nat.pos_of_ne_zero Subgroup.index_ne_zero_of_finite)]
 
 /-- **Elements of different orders are not conjugate.** Conjugation is an automorphism, so it
 preserves the order of an element; hence two elements whose orders differ have distinct conjugacy

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -85,7 +85,8 @@ centralizer's order over `orderOf σ`. Neither asserts that either side counts a
 wanting a cardinality interpretation must supply it.
 
 `card_carrier_mul_orderOf_dvd` follows `TauCetiRoadmap/Chebotarev/Suggested.lean` lines 377-382 in
-name, argument structure and conclusion.
+name, argument structure and conclusion, and the closed form below is the identity
+`#G / (#C * f) = #Centralizer_G(σ) / f` specified in `TauCetiRoadmap/Chebotarev/README.md` §8.2.
 -/
 
 public section
@@ -251,8 +252,10 @@ theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (
 order of a member leaves the order of the centralizer divided by that same order.
 
 `hindex` is what lets the centralizer's index cancel from both sides; it holds automatically when
-`G` is finite. Both divisions are exact, so the identity is an equality of ratios rather than of
-truncated quotients. -/
+`G` is finite. The statement is an equality of `Nat.div` values, and no more: for a finite `G` both
+divisions are exact and it reads as an equality of ratios, but `hindex` alone does not give that.
+An infinite abelian group with an element of infinite order satisfies `hindex` while `Nat.card G`,
+the centralizer's cardinality and `orderOf σ` are all `0`, and the identity is then `0 / 0`. -/
 theorem card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf {G : Type*} [Group G]
     (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier)
     (hindex : (Subgroup.centralizer {σ}).index ≠ 0) :

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -78,13 +78,11 @@ rather than reusable conjugacy-class API. This operation is *not* adapted from t
 Birkbeck–Brasca `chebotarev-density` development, which works with `ConjClasses.mk` and
 `Subgroup.zpowers` directly and never forms `C ^ j`.
 
-The two counting statements come from the same roadmap: `Chebotarev/README.md` Layer 8.2, the
-fixed-field fibre count, asks for `#C * f ∣ #G` "as a separate statement, so the quotient is exact
-rather than a truncated natural-number division", and its `Suggested.lean` pins the signature as
-`card_carrier_mul_orderOf_dvd (C) (σ) (hσ : σ ∈ C.carrier)`, which is the shape used here. The
-divisibility is stated without the roadmap's `[Finite G]`, which the proof does not need. Neither
-statement is adapted from `chebotarev-density`: that development proves the fibre count inline in
-`CebotarevDensity/FixedFieldDensity.lean` and never isolates the group-theoretic core.
+The two counting statements are the group-theoretic half of a fibre count: for a finite group the
+quotient `#G / (#C * orderOf σ)` counts something, and it does so only because the division is
+exact — `#C` is the index of the centralizer of `σ`, and `orderOf σ` divides that centralizer's
+order, so their product divides `#G`. Dividing then leaves the centralizer's order over
+`orderOf σ`. They are wanted by the Chebotarev roadmap's Layer 8.2.
 -/
 
 public section
@@ -313,8 +311,8 @@ theorem map_pow {N : Type*} [Monoid N] (f : M →* N) (C : ConjClasses M) (j : �
 For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orderOf σ)` an exact
 division rather than a truncated one, which is why Chebotarev's fibre count needs it separately;
 `card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` evaluates that quotient. No
-finiteness is assumed here: for an infinite group both sides degenerate to `0`, and the statement
-stays true. -/
+finiteness is assumed here: for an infinite group `Nat.card G` is `0`, and every natural number
+divides `0`. -/
 theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (σ : G)
     (hσ : σ ∈ C.carrier) :
     Nat.card C.carrier * orderOf σ ∣ Nat.card G := by

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -310,10 +310,6 @@ theorem map_pow {N : Type*} [Monoid N] (f : M →* N) (C : ConjClasses M) (j : �
 
 /-- **The size of a conjugacy class times the order of a member divides the order of the group.**
 
-The class size is the index of the centralizer of `σ`
-(`TauCeti.ConjClasses.card_carrier_mk`), and `orderOf σ` divides
-the order of that centralizer because `σ` lies in it; index times order is the group order.
-
 For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orderOf σ)` an exact
 division rather than a truncated one, which is why Chebotarev's fibre count needs it separately;
 `card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` evaluates that quotient. No
@@ -330,7 +326,9 @@ theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (
 
 /-- **That quotient in closed form.** For a finite group, dividing the order of the group by the
 class size times the order of a member leaves the order of the centralizer divided by that same
-order; the common factor is the centralizer's index, which the class size equals. -/
+order.
+
+Both divisions are exact, so a caller may read either side as a count. -/
 theorem card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf {G : Type*} [Group G]
     [Finite G] (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier) :
     Nat.card G / (Nat.card C.carrier * orderOf σ)

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -235,10 +235,7 @@ For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orde
 division rather than a truncated one, which is why a fibre count needs it separately;
 `card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` evaluates that quotient. No
 finiteness is assumed here: for an infinite group `Nat.card G` is `0`, and every natural number
-divides `0`.
-
-Adapted from `TauCetiRoadmap/Chebotarev/Suggested.lean`, which pins this name, argument
-structure and conclusion. -/
+divides `0`. -/
 theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (σ : G)
     (hσ : σ ∈ C.carrier) :
     Nat.card C.carrier * orderOf σ ∣ Nat.card G := by

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -82,7 +82,10 @@ The two counting statements are the group-theoretic half of a fibre count: for a
 quotient `#G / (#C * orderOf σ)` counts something, and it does so only because the division is
 exact — `#C` is the index of the centralizer of `σ`, and `orderOf σ` divides that centralizer's
 order, so their product divides `#G`. Dividing then leaves the centralizer's order over
-`orderOf σ`.
+`orderOf σ`. They are developed for the same roadmap (`Chebotarev/README.md` Layer 8.2, the
+fixed-field fibre count), whose `Suggested.lean` pins `card_carrier_mul_orderOf_dvd` with this
+signature and consumes it in `fixedField_frobenius_fiber_card`, the exact cardinality of the
+residue-degree-one relative fibre.
 -/
 
 public section

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -41,6 +41,10 @@ conjugation action.
   `Nat.card` form.
 * `TauCeti.ConjClasses.ncard_carrier_mk_of_mem_center`: the class of a central element is a single
   point.
+* `TauCeti.ConjClasses.card_carrier_mul_orderOf_dvd`: the class size times the order of a member
+  divides the order of the group, so the fibre quotient below is an exact division.
+* `TauCeti.ConjClasses.card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf`: that
+  quotient equals the order of the centralizer divided by the order of the member.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
   the group, with `TauCeti.ConjClasses.card_carrier_cast_ne_zero` the consequence that the size of
   a class is nonzero in any semiring where the group order is.
@@ -73,6 +77,14 @@ from one that collapses to the identity. It is `private`, being a check on this 
 rather than reusable conjugacy-class API. This operation is *not* adapted from the
 Birkbeck–Brasca `chebotarev-density` development, which works with `ConjClasses.mk` and
 `Subgroup.zpowers` directly and never forms `C ^ j`.
+
+The two counting statements come from the same roadmap: `Chebotarev/README.md` Layer 8.2, the
+fixed-field fibre count, asks for `#C * f ∣ #G` "as a separate statement, so the quotient is exact
+rather than a truncated natural-number division", and its `Suggested.lean` pins the signature as
+`card_carrier_mul_orderOf_dvd (C) (σ) (hσ : σ ∈ C.carrier)`, which is the shape used here. The
+divisibility is stated without the roadmap's `[Finite G]`, which the proof does not need. Neither
+statement is adapted from `chebotarev-density`: that development proves the fibre count inline in
+`CebotarevDensity/FixedFieldDensity.lean` and never isolates the group-theoretic core.
 -/
 
 public section
@@ -178,6 +190,36 @@ theorem card_carrier_dvd_card (C : ConjClasses G) : Nat.card C.carrier ∣ Nat.c
   calc Nat.card (ConjClasses.mk x).carrier
       = (Subgroup.centralizer {x}).index := card_carrier_mk x
     _ ∣ Nat.card G := Subgroup.index_dvd_card _
+
+/-- **The size of a conjugacy class times the order of a member divides the order of the group.**
+
+The class size is the index of the centralizer of `σ` (`card_carrier_mk`), and `orderOf σ` divides
+the order of that centralizer because `σ` lies in it; index times order is the group order.
+
+For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orderOf σ)` an exact
+division rather than a truncated one, which is why Chebotarev's fibre count needs it separately;
+`card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` evaluates that quotient. No
+finiteness is assumed here: for an infinite group both sides degenerate to `0`, and the statement
+stays true. -/
+theorem card_carrier_mul_orderOf_dvd (C : _root_.ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier) :
+    Nat.card C.carrier * orderOf σ ∣ Nat.card G := by
+  rw [_root_.ConjClasses.mem_carrier_iff_mk_eq] at hσ
+  subst hσ
+  obtain ⟨k, hk⟩ := (Subgroup.centralizer {σ}).orderOf_dvd_natCard
+    (Subgroup.mem_centralizer_singleton_iff.mpr rfl)
+  exact ⟨k, by rw [card_carrier_mk, mul_assoc, ← hk, Subgroup.index_mul_card]⟩
+
+/-- **That quotient in closed form.** For a finite group, dividing the order of the group by the
+class size times the order of a member leaves the order of the centralizer divided by that same
+order; the common factor is the centralizer's index, which the class size equals. -/
+theorem card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf [Finite G]
+    (C : _root_.ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier) :
+    Nat.card G / (Nat.card C.carrier * orderOf σ)
+      = Nat.card (Subgroup.centralizer {σ}) / orderOf σ := by
+  rw [_root_.ConjClasses.mem_carrier_iff_mk_eq] at hσ
+  subst hσ
+  rw [card_carrier_mk, ← Subgroup.index_mul_card (Subgroup.centralizer {σ}),
+    Nat.mul_div_mul_left _ _ (Nat.pos_of_ne_zero Subgroup.index_ne_zero_of_finite)]
 
 /-- The size of a conjugacy class is nonzero in any semiring in which the order of the group is
 nonzero: it divides that order. -/

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -82,10 +82,7 @@ The two counting statements are the group-theoretic half of a fibre count: for a
 quotient `#G / (#C * orderOf σ)` counts something, and it does so only because the division is
 exact — `#C` is the index of the centralizer of `σ`, and `orderOf σ` divides that centralizer's
 order, so their product divides `#G`. Dividing then leaves the centralizer's order over
-`orderOf σ`. They are developed for the same roadmap (`Chebotarev/README.md` Layer 8.2, the
-fixed-field fibre count), whose `Suggested.lean` pins `card_carrier_mul_orderOf_dvd` with this
-signature and consumes it in `fixedField_frobenius_fiber_card`, the exact cardinality of the
-residue-degree-one relative fibre.
+`orderOf σ`.
 -/
 
 public section
@@ -238,7 +235,11 @@ For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orde
 division rather than a truncated one, which is why a fibre count needs it separately;
 `card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` evaluates that quotient. No
 finiteness is assumed here: for an infinite group `Nat.card G` is `0`, and every natural number
-divides `0`. -/
+divides `0`.
+
+`TauCetiRoadmap/Chebotarev/README.md`, Layer 8.2, pins this signature in its `Suggested.lean` and
+consumes it in `fixedField_frobenius_fiber_card`, the exact cardinality of the residue-degree-one
+relative fibre. -/
 theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (σ : G)
     (hσ : σ ∈ C.carrier) :
     Nat.card C.carrier * orderOf σ ∣ Nat.card G := by

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -41,9 +41,9 @@ conjugation action.
   `Nat.card` form.
 * `TauCeti.ConjClasses.ncard_carrier_mk_of_mem_center`: the class of a central element is a single
   point.
-* `TauCeti.ConjClasses.card_carrier_mul_orderOf_dvd`: the class size times the order of a member
+* `ConjClasses.card_carrier_mul_orderOf_dvd`: the class size times the order of a member
   divides the order of the group, so the fibre quotient below is an exact division.
-* `TauCeti.ConjClasses.card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf`: that
+* `ConjClasses.card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf`: that
   quotient equals the order of the centralizer divided by the order of the member.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
   the group, with `TauCeti.ConjClasses.card_carrier_cast_ne_zero` the consequence that the size of
@@ -191,36 +191,6 @@ theorem card_carrier_dvd_card (C : ConjClasses G) : Nat.card C.carrier ∣ Nat.c
       = (Subgroup.centralizer {x}).index := card_carrier_mk x
     _ ∣ Nat.card G := Subgroup.index_dvd_card _
 
-/-- **The size of a conjugacy class times the order of a member divides the order of the group.**
-
-The class size is the index of the centralizer of `σ` (`card_carrier_mk`), and `orderOf σ` divides
-the order of that centralizer because `σ` lies in it; index times order is the group order.
-
-For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orderOf σ)` an exact
-division rather than a truncated one, which is why Chebotarev's fibre count needs it separately;
-`card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` evaluates that quotient. No
-finiteness is assumed here: for an infinite group both sides degenerate to `0`, and the statement
-stays true. -/
-theorem card_carrier_mul_orderOf_dvd (C : _root_.ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier) :
-    Nat.card C.carrier * orderOf σ ∣ Nat.card G := by
-  rw [_root_.ConjClasses.mem_carrier_iff_mk_eq] at hσ
-  subst hσ
-  obtain ⟨k, hk⟩ := (Subgroup.centralizer {σ}).orderOf_dvd_natCard
-    (Subgroup.mem_centralizer_singleton_iff.mpr rfl)
-  exact ⟨k, by rw [card_carrier_mk, mul_assoc, ← hk, Subgroup.index_mul_card]⟩
-
-/-- **That quotient in closed form.** For a finite group, dividing the order of the group by the
-class size times the order of a member leaves the order of the centralizer divided by that same
-order; the common factor is the centralizer's index, which the class size equals. -/
-theorem card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf [Finite G]
-    (C : _root_.ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier) :
-    Nat.card G / (Nat.card C.carrier * orderOf σ)
-      = Nat.card (Subgroup.centralizer {σ}) / orderOf σ := by
-  rw [_root_.ConjClasses.mem_carrier_iff_mk_eq] at hσ
-  subst hσ
-  rw [card_carrier_mk, ← Subgroup.index_mul_card (Subgroup.centralizer {σ}),
-    Nat.mul_div_mul_left _ _ (Nat.pos_of_ne_zero Subgroup.index_ne_zero_of_finite)]
-
 /-- The size of a conjugacy class is nonzero in any semiring in which the order of the group is
 nonzero: it divides that order. -/
 theorem card_carrier_cast_ne_zero {R : Type*} [Semiring R] (C : ConjClasses G)
@@ -337,6 +307,38 @@ theorem map_pow {N : Type*} [Monoid N] (f : M →* N) (C : ConjClasses M) (j : �
   -- the map on representatives, after which `mk_pow` handles both powers and `map_pow` finishes
   -- in `N`.
   rw [mk_pow, map_mk, map_mk, mk_pow, _root_.map_pow]
+
+/-- **The size of a conjugacy class times the order of a member divides the order of the group.**
+
+The class size is the index of the centralizer of `σ`
+(`TauCeti.ConjClasses.card_carrier_mk`), and `orderOf σ` divides
+the order of that centralizer because `σ` lies in it; index times order is the group order.
+
+For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orderOf σ)` an exact
+division rather than a truncated one, which is why Chebotarev's fibre count needs it separately;
+`card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` evaluates that quotient. No
+finiteness is assumed here: for an infinite group both sides degenerate to `0`, and the statement
+stays true. -/
+theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (σ : G)
+    (hσ : σ ∈ C.carrier) :
+    Nat.card C.carrier * orderOf σ ∣ Nat.card G := by
+  rw [mem_carrier_iff_mk_eq] at hσ
+  subst hσ
+  obtain ⟨k, hk⟩ := (Subgroup.centralizer {σ}).orderOf_dvd_natCard
+    (Subgroup.mem_centralizer_singleton_iff.mpr rfl)
+  exact ⟨k, by rw [TauCeti.ConjClasses.card_carrier_mk, mul_assoc, ← hk, Subgroup.index_mul_card]⟩
+
+/-- **That quotient in closed form.** For a finite group, dividing the order of the group by the
+class size times the order of a member leaves the order of the centralizer divided by that same
+order; the common factor is the centralizer's index, which the class size equals. -/
+theorem card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf {G : Type*} [Group G]
+    [Finite G] (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier) :
+    Nat.card G / (Nat.card C.carrier * orderOf σ)
+      = Nat.card (Subgroup.centralizer {σ}) / orderOf σ := by
+  rw [mem_carrier_iff_mk_eq] at hσ
+  subst hσ
+  rw [TauCeti.ConjClasses.card_carrier_mk, ← Subgroup.index_mul_card (Subgroup.centralizer {σ}),
+    Nat.mul_div_mul_left _ _ (Nat.pos_of_ne_zero Subgroup.index_ne_zero_of_finite)]
 
 /-- **Elements of different orders are not conjugate.** Conjugation is an automorphism, so it
 preserves the order of an element; hence two elements whose orders differ have distinct conjugacy

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -43,7 +43,7 @@ conjugation action.
   point.
 * `ConjClasses.card_carrier_mul_orderOf_dvd`: the class size times the order of a member
   divides the order of the group, so the quotient below is an exact ratio.
-* `ConjClasses.card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf`: that
+* `ConjClasses.card_div_card_carrier_mul_orderOf_eq_card_centralizer_div_orderOf`: that
   quotient equals the order of the centralizer divided by the order of the member.
 * `TauCeti.ConjClasses.card_carrier_dvd_card`: the size of a conjugacy class divides the order of
   the group, with `TauCeti.ConjClasses.card_carrier_cast_ne_zero` the consequence that the size of
@@ -233,7 +233,7 @@ namespace ConjClasses
 
 For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orderOf σ)` an exact
 ratio rather than a truncated division, which
-`card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf` then evaluates. No finiteness
+`card_div_card_carrier_mul_orderOf_eq_card_centralizer_div_orderOf` then evaluates. No finiteness
 is assumed here: for an infinite group `Nat.card G` is `0`, and every natural number divides `0`. -/
 theorem card_carrier_mul_orderOf_dvd {G : Type*} [Group G] (C : ConjClasses G) (σ : G)
     (hσ : σ ∈ C.carrier) :
@@ -252,7 +252,7 @@ order of a member leaves the order of the centralizer divided by that same order
 divisions are exact and it reads as an equality of ratios, but `hindex` alone does not give that.
 An infinite abelian group with an element of infinite order satisfies `hindex` while `Nat.card G`,
 the centralizer's cardinality and `orderOf σ` are all `0`, and the identity is then `0 / 0`. -/
-theorem card_div_mul_card_carrier_orderOf_eq_card_centralizer_div_orderOf {G : Type*} [Group G]
+theorem card_div_card_carrier_mul_orderOf_eq_card_centralizer_div_orderOf {G : Type*} [Group G]
     (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier)
     (hindex : (Subgroup.centralizer {σ}).index ≠ 0) :
     Nat.card G / (Nat.card C.carrier * orderOf σ)

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -229,6 +229,12 @@ These extend the centralizer-index description of the class size just above; the
 
 namespace ConjClasses
 
+-- Source. Both statements are specified by the Chebotarev roadmap. The divisibility is the
+-- declaration pinned at `TauCetiRoadmap/Chebotarev/Suggested.lean` lines 377-382, there stated
+-- with `[Finite G]`. The quotient identity is `TauCetiRoadmap/Chebotarev/README.md` §8.2, which
+-- writes it `#G / (#C * f) = #Centralizer_G(σ) / f` for `f = orderOf σ` and asks for
+-- `#C * f ∣ #G` as a separate statement.
+
 /-- **The size of a conjugacy class times the order of a member divides the order of the group.**
 
 For a *finite* group this is what makes `Nat.card G / (Nat.card C.carrier * orderOf σ)` an exact

--- a/TauCeti/Algebra/Group/Conj.lean
+++ b/TauCeti/Algebra/Group/Conj.lean
@@ -83,10 +83,6 @@ division is exact — `#C` is the index of the centralizer of `σ`, and `orderOf
 centralizer's order, so their product divides `#G` — and the second evaluates the quotient as the
 centralizer's order over `orderOf σ`. Neither asserts that either side counts anything; a caller
 wanting a cardinality interpretation must supply it.
-
-`card_carrier_mul_orderOf_dvd` follows `TauCetiRoadmap/Chebotarev/Suggested.lean` lines 377-382 in
-name, argument structure and conclusion, and the closed form below is the identity
-`#G / (#C * f) = #Centralizer_G(σ) / f` specified in `TauCetiRoadmap/Chebotarev/README.md` §8.2.
 -/
 
 public section

--- a/TauCeti/Algebra/Group/ConjFinite.lean
+++ b/TauCeti/Algebra/Group/ConjFinite.lean
@@ -6,18 +6,29 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Group.ConjFinite
+public import TauCeti.Algebra.Group.Conj
 
 /-!
 # Sizes of conjugacy classes
 
-Two elementary facts about the carrier of a conjugacy class: the class of the identity is the
-singleton `{1}`, and every class of a finite group is nonempty.
+Elementary facts about the size of the carrier of a conjugacy class: the class of the identity is
+the singleton `{1}`, every class of a finite group is nonempty, and the class size times the order
+of a representative divides the order of the group.
+
+That last divisibility is what makes the quotient `#G / (#C * orderOf g)` exact rather than a
+truncated natural-number division, which matters wherever such a quotient is asserted to count
+something. `TauCeti.ConjClasses.card_carrier_mk` in `TauCeti/Algebra/Group/Conj.lean` identifies
+the class size with the index of a centralizer, and everything here is read off from that.
 
 ## Main results
 
 * `TauCeti.ConjClasses.carrier_mk_one`: the class of `1` is `{1}`, with its counting form
   `TauCeti.ConjClasses.card_carrier_mk_one`.
 * `TauCeti.ConjClasses.card_carrier_pos`: a conjugacy class of a finite group has positive size.
+* `TauCeti.ConjClasses.card_carrier_mul_orderOf_dvd_card`: the class size times the order of a
+  representative divides the order of the group.
+* `TauCeti.ConjClasses.card_div_card_carrier_mul_orderOf`: that quotient equals the order of the
+  centralizer divided by the order of the representative.
 -/
 
 public section
@@ -51,6 +62,31 @@ theorem card_carrier_pos [Finite G] (C : _root_.ConjClasses G) : 0 < Nat.card C.
   obtain ⟨g, rfl⟩ := C.exists_rep
   have : Nonempty (_root_.ConjClasses.mk g).carrier := ⟨⟨g, _root_.ConjClasses.mem_carrier_mk⟩⟩
   exact Nat.card_pos
+
+/-- An element lies in its own centralizer. -/
+private theorem mem_centralizer_self (g : G) : g ∈ Subgroup.centralizer {g} :=
+  Subgroup.mem_centralizer_iff.mpr fun h hh ↦ by
+    rw [Set.mem_singleton_iff] at hh; subst hh; rfl
+
+/-- **The size of a conjugacy class times the order of a representative divides the group order.**
+
+The class size is the index of the centralizer, and the order of `g` divides the order of that
+centralizer because `g` lies in it; multiplying index by order recovers the group order. This is
+what makes `Nat.card G / (Nat.card C.carrier * orderOf g)` an exact division rather than a
+truncated one, and `card_div_card_carrier_mul_orderOf` evaluates that quotient. -/
+theorem card_carrier_mul_orderOf_dvd_card (g : G) :
+    Nat.card (_root_.ConjClasses.mk g).carrier * orderOf g ∣ Nat.card G := by
+  obtain ⟨k, hk⟩ := (Subgroup.centralizer {g}).orderOf_dvd_natCard (mem_centralizer_self g)
+  exact ⟨k, by rw [card_carrier_mk, mul_assoc, ← hk, Subgroup.index_mul_card]⟩
+
+/-- **That quotient in closed form.** Dividing the group order by the class size times the order of
+a representative leaves the centralizer order divided by that same order; the common factor is the
+centralizer's index, which the class size equals. -/
+theorem card_div_card_carrier_mul_orderOf [Finite G] (g : G) :
+    Nat.card G / (Nat.card (_root_.ConjClasses.mk g).carrier * orderOf g)
+      = Nat.card (Subgroup.centralizer {g}) / orderOf g := by
+  rw [card_carrier_mk, ← Subgroup.index_mul_card (Subgroup.centralizer {g}),
+    Nat.mul_div_mul_left _ _ (Nat.pos_of_ne_zero Subgroup.index_ne_zero_of_finite)]
 
 end ConjClasses
 

--- a/TauCeti/Algebra/Group/ConjFinite.lean
+++ b/TauCeti/Algebra/Group/ConjFinite.lean
@@ -6,29 +6,18 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Group.ConjFinite
-public import TauCeti.Algebra.Group.Conj
 
 /-!
 # Sizes of conjugacy classes
 
-Elementary facts about the size of the carrier of a conjugacy class: the class of the identity is
-the singleton `{1}`, every class of a finite group is nonempty, and the class size times the order
-of a representative divides the order of the group.
-
-That last divisibility is what makes the quotient `#G / (#C * orderOf g)` exact rather than a
-truncated natural-number division, which matters wherever such a quotient is asserted to count
-something. `TauCeti.ConjClasses.card_carrier_mk` in `TauCeti/Algebra/Group/Conj.lean` identifies
-the class size with the index of a centralizer, and everything here is read off from that.
+Two elementary facts about the carrier of a conjugacy class: the class of the identity is the
+singleton `{1}`, and every class of a finite group is nonempty.
 
 ## Main results
 
 * `TauCeti.ConjClasses.carrier_mk_one`: the class of `1` is `{1}`, with its counting form
   `TauCeti.ConjClasses.card_carrier_mk_one`.
 * `TauCeti.ConjClasses.card_carrier_pos`: a conjugacy class of a finite group has positive size.
-* `TauCeti.ConjClasses.card_carrier_mul_orderOf_dvd_card`: the class size times the order of a
-  representative divides the order of the group.
-* `TauCeti.ConjClasses.card_div_card_carrier_mul_orderOf`: that quotient equals the order of the
-  centralizer divided by the order of the representative.
 -/
 
 public section
@@ -62,31 +51,6 @@ theorem card_carrier_pos [Finite G] (C : _root_.ConjClasses G) : 0 < Nat.card C.
   obtain ⟨g, rfl⟩ := C.exists_rep
   have : Nonempty (_root_.ConjClasses.mk g).carrier := ⟨⟨g, _root_.ConjClasses.mem_carrier_mk⟩⟩
   exact Nat.card_pos
-
-/-- An element lies in its own centralizer. -/
-private theorem mem_centralizer_self (g : G) : g ∈ Subgroup.centralizer {g} :=
-  Subgroup.mem_centralizer_iff.mpr fun h hh ↦ by
-    rw [Set.mem_singleton_iff] at hh; subst hh; rfl
-
-/-- **The size of a conjugacy class times the order of a representative divides the group order.**
-
-The class size is the index of the centralizer, and the order of `g` divides the order of that
-centralizer because `g` lies in it; multiplying index by order recovers the group order. This is
-what makes `Nat.card G / (Nat.card C.carrier * orderOf g)` an exact division rather than a
-truncated one, and `card_div_card_carrier_mul_orderOf` evaluates that quotient. -/
-theorem card_carrier_mul_orderOf_dvd_card (g : G) :
-    Nat.card (_root_.ConjClasses.mk g).carrier * orderOf g ∣ Nat.card G := by
-  obtain ⟨k, hk⟩ := (Subgroup.centralizer {g}).orderOf_dvd_natCard (mem_centralizer_self g)
-  exact ⟨k, by rw [card_carrier_mk, mul_assoc, ← hk, Subgroup.index_mul_card]⟩
-
-/-- **That quotient in closed form.** Dividing the group order by the class size times the order of
-a representative leaves the centralizer order divided by that same order; the common factor is the
-centralizer's index, which the class size equals. -/
-theorem card_div_card_carrier_mul_orderOf [Finite G] (g : G) :
-    Nat.card G / (Nat.card (_root_.ConjClasses.mk g).carrier * orderOf g)
-      = Nat.card (Subgroup.centralizer {g}) / orderOf g := by
-  rw [card_carrier_mk, ← Subgroup.index_mul_card (Subgroup.centralizer {g}),
-    Nat.mul_div_mul_left _ _ (Nat.pos_of_ne_zero Subgroup.index_ne_zero_of_finite)]
 
 end ConjClasses
 


### PR DESCRIPTION
Two counting facts about a conjugacy class, in the root `ConjClasses` namespace of
`TauCeti/Algebra/Group/Conj.lean`:

```lean
theorem card_carrier_mul_orderOf_dvd (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier) :
    Nat.card C.carrier * orderOf σ ∣ Nat.card G

theorem card_div_card_carrier_mul_orderOf_eq_card_centralizer_div_orderOf
    (C : ConjClasses G) (σ : G) (hσ : σ ∈ C.carrier)
    (hindex : (Subgroup.centralizer {σ}).index ≠ 0) :
    Nat.card G / (Nat.card C.carrier * orderOf σ)
      = Nat.card (Subgroup.centralizer {σ}) / orderOf σ
```

### Why the divisibility is a statement in its own right

Without it the quotient does not mean what it looks like. Chebotarev's Layer 8.2 asserts that a
prime in the class `C` has exactly `#G / (#C * f)` primes above it of residue degree one with a
prescribed relative Frobenius, where `f = orderOf σ`. In Lean that left-hand side is `Nat.div`,
which truncates, so the count is only correctly stated once the division is known to be exact —
and the roadmap says so, asking for `#C * f ∣ #G` "as a separate statement". The second theorem
then evaluates the quotient in the form the fibre count is usually quoted in.

Both are pure finite group theory, and neither depends on Layer 8.1's restriction laws, one of
which is still waiting on a supplier.

### Reuse

Nothing is re-derived. `TauCeti.ConjClasses.card_carrier_mk` already identifies the class size with
a centralizer index, and the proofs are read off from that together with Mathlib's
`Subgroup.index_mul_card`, `Subgroup.orderOf_dvd_natCard`,
`Subgroup.mem_centralizer_singleton_iff` and `Nat.mul_div_mul_left`. Six lines and five lines.

### Generality

`card_carrier_mul_orderOf_dvd` is stated **without** `[Finite G]`, which the roadmap's suggested
signature carries but the proof does not need: `Subgroup.index_mul_card` and `orderOf_dvd_natCard`
both hold in `Nat.card` form for an arbitrary group, and for an infinite group both sides
degenerate to `0`. The closed-form quotient does need `[Finite G]`, to know the centralizer's index
is nonzero before cancelling it.

---

## Review round 1 — all six findings implemented, none contested

The first review requested changes on six rubrics. They were mutually consistent, so all six are
implemented rather than argued:

* **placement** — both theorems moved from `ConjFinite.lean` into `Conj.lean`, beside
  `card_carrier_mk` and `card_carrier_dvd_card` which they extend. `ConjFinite.lean` is back to its
  original content, import and docstring included. My original reason for the other file was to
  avoid touching a file another open PR of mine also edits; that is a workflow concern, not a
  mathematical one, and the reviewer is right on the merits.
* **api-design** — restated in the class-and-member form `(C) (σ) (hσ : σ ∈ C.carrier)`, which is
  exactly the signature the roadmap's `Suggested.lean` pins, so a consumer holding `C`, `σ` and
  `hσ` no longer has to rewrite `C` to `mk σ`.
* **reuse** and **api-design (second bullet)** — the private helper `mem_centralizer_self` is
  deleted; the proof now passes `Subgroup.mem_centralizer_singleton_iff.mpr rfl` straight to
  `Subgroup.orderOf_dvd_natCard`. One change settles both findings: the helper was re-proving a
  Mathlib lemma *and* hiding general infrastructure as a file-local declaration.
* **naming** — renamed to
  `card_div_card_carrier_mul_orderOf_eq_card_centralizer_div_orderOf`, the reviewer's suggested
  form. The old name misparsed as `(card / card_carrier) * orderOf` and named only the left side.
* **documentation** — the exactness claim is now explicitly qualified to finite groups, and the
  denominator is spelled as the statement writes it.
* **attribution** — the module's Implementation notes gain a paragraph citing
  `Chebotarev/README.md` Layer 8.2 and the `card_carrier_mul_orderOf_dvd` signature its
  `Suggested.lean` pins, alongside the existing paragraph that credits Layer 1 for the power
  operation.

### A follow-up the first fix round caused

Restating in the class-and-member form makes `ConjClasses` the **first explicit argument**, so dot
notation `C.card_carrier_mul_orderOf_dvd` is implied — and inside `namespace TauCeti` it cannot
elaborate. The repo's `lint-dot-notation` gate rejected exactly that, and the build went red at
`acf014c7`. Both theorems now sit in the file's **root `ConjClasses` namespace**, beside
`ConjClasses.mk_ne_mk_of_orderOf_ne`, with `TauCeti.ConjClasses.card_carrier_mk` qualified in their
proofs. That still satisfies the placement finding, which asked for `Conj.lean` rather than
`ConjFinite.lean` — the file, not the namespace. Verified locally with
`python3 scripts/lint-dot-notation.py --baseline scripts/lint-dot-notation-baseline.txt
--mathlib-root .lake/packages/mathlib/Mathlib --source-root TauCeti`, which now reports **0 new**.

### Absence

Untruncated greps for `orderOf.*centralizer`, `centralizer.*orderOf` and
`card_carrier.*orderOf` over Mathlib and `main` return nothing; Mathlib supplies only the
ingredients named above. Not adapted from `CBirkbeck/chebotarev-density`: that development proves
the Layer 8 fibre count inline in `CebotarevDensity/FixedFieldDensity.lean` and never isolates this
group-theoretic core. No `Provenance` line is owed.

Roadmap: Chebotarev

Provenance: TauCetiRoadmap/Chebotarev/Suggested.lean lines 377-382 (the pinned `card_carrier_mul_orderOf_dvd`, whose name, argument structure and conclusion this theorem reproduces; the proof is not the roadmap's), and TauCetiRoadmap/Chebotarev/README.md §8.2 (which specifies the closed form `#G / (#C * f) = #Centralizer_G(σ) / f` that the second theorem proves).

Both credits live here rather than in the module docstring because `documentation` ruled that way on this PR: "this roadmap attribution is brittle project metadata rather than mathematical documentation … retain this attribution in the PR description's Roadmap/Provenance fields.

No `tauceti-target:v1` marker, and **no Chebotarev-target claim at all**. Taking the second option
`scope` offered on this head: these land as standalone group-theoretic infrastructure. Both
statements are about a finite group and one of its elements — no prime, Frobenius, tower or number
field occurs in either — so nothing here waits on Layer 8.1's restriction laws, and nothing here
claims to advance Layer 8.2.

The Chebotarev roadmap is named only as the **source** of the two statements, which is attribution
rather than authorization: `Suggested.lean` pins the first declaration's name and signature, and
README §8.2 specifies the quotient identity. Whoever later builds the fibre count may use these; that
is a consumer relationship, not a claim staked here.

### Also done, before it was asked for

The `documentation` rubric has flagged the same shape on two sibling PRs — docstrings that narrate
the proof instead of the result. Both docstrings here carried it ("the class size is the index of
the centralizer …, and `orderOf σ` divides the order of that centralizer because σ lies in it"),
so that prose is gone. What remains is the statement's meaning and how a caller reads the
quotient; the route is visible in the two-line proofs themselves.

## Review round 3 — and where the `scope` finding leaves this PR

Documentation and placement are implemented: both theorems now sit in a root `ConjClasses` block
immediately after the centralizer-index section they extend, rather than under
`### Powers of a conjugacy class`; and the last roadmap-layer references are gone from the module
and theorem docstrings.

**`scope` was contested and the finding stands.** I argued that after this change the file imports
five Mathlib modules and nothing under `TauCeti/NumberTheory/`, that neither statement nor proof
mentions a prime, a Frobenius or a number field, and that Layer 8.2's *fibre count* is what
consumes Layer 8.1 while its *exactness* claim does not. The re-review answered: "the finding
stands — The theorems are a coherent, explicitly requested part of Chebotarev Layer 8.2, but that
layer's prerequisite restriction laws are absent," and the fix hardened to "defer this change until
Layer 8.1 is merged."

I am not contesting again; I have no new argument, and repeating one is not an argument. Recording
the position plainly instead:

* Layer 8.1's raising-the-base law needs `exists_isArithFrobAt_pow_inertiaDeg`, which is Number
  Field Arithmetic's Layer 2.4 deliverable. It is absent from `main` and **no open PR builds it**,
  so neither "defer until merged" nor "identify an open PR supplying it" is something this branch
  can act on.
* Everything else on this PR is green: correctness, reuse, api-design, generality, naming,
  attribution and proof-quality.

So this waits on that supplier rather than on more work here. If a reviewer or maintainer would
rather it land now as plain conjugacy-class counting with no roadmap claim attached, say so and I
will make that change; it is a documentation edit, not a mathematical one.

### On the cleanup pass

`lean-lsp` has been unreachable for this whole session, so `/cleanup` 6.5 and 6.6 were discharged
directly: 6.6 by `#count_heartbeats` (111 and 155 against the 200000 default on the original
forms), 6.5 by hand. Axioms are exactly `propext`, `Classical.choice` and `Quot.sound`, every line
is within 100 characters, and the five downstream importers of `Conj.lean` build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF




