### PR TITLE
refactor(HeckeRing): name the leading term of the T(1,p) power convolution

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -492,6 +492,23 @@ private lemma T_ad_one_p_mul_supp_ne_leading_eval_zero (p : ℕ) (hp : p.Prime) 
   rw [T_elem_ppow_factor p hp.pos i (n - i) hi_le_sub, ← mul_assoc]
   exact T_mul_T_pp_pow_eval_at_one_zero p hp.one_lt i (p ^ (n + 1)) hi_ge (pow_pos hp.pos _) _
 
+/-- The structure constant of `T(1,p) · T(1,pⁿ)` at the leading coset `T(1, p^(n+1))` is `1`.
+This is the companion of `T_ad_one_p_mul_supp_ne_leading_eval_zero`, which gives `0` at every
+other coset in the support. -/
+private lemma T_ad_one_p_mul_leading_eval_one (p : ℕ) (hp : p.Prime) (n : ℕ) :
+    (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+      (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ)))
+      (HeckeCoset.rep (diagCoset (![1, p ^ n] : Fin 2 → ℕ))))
+      (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 1 := by
+  rw [← diagElem_mul_diagElem,
+    show diagElem (![1, p] : Fin 2 → ℕ) = heckeTDiag 1 p from
+      (heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _)).symm,
+    -- `![…]` literals that are only extensionally equal do not unify syntactically, so the
+    -- intended spelling is stated here for the following rewrite to match.
+    show diagElem (![1, p ^ n] : Fin 2 → ℕ) = heckeTDiag 1 (p ^ n) from
+      (heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos n) (one_dvd _)).symm]
+  exact T_ad_one_p_mul_T_ad_one_ppow_eval_leading p hp n
+
 /-- Leading coefficient of `T(1,p)^a`: `(heckeTDiag 1 p)^a` evaluated at the leading coset
 `diagCoset ![1, p^a]` equals 1. -/
 private lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
@@ -502,15 +519,13 @@ private lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
     -- `![1, 1]` and `fun _ ↦ 1` are extensionally but not syntactically equal, so the
     -- conversion is stated and proved pointwise before `diagElem_one` can apply.
     rw [pow_zero, pow_zero, show (![1, 1] : Fin 2 → ℕ) = (fun _ : Fin 2 ↦ 1) from by
-        funext i; fin_cases i <;> rfl, ← diagElem_one]
-    rw [diagElem_def, HeckeCosetModule.single_apply, ite_eq_left rfl]
+        funext i; fin_cases i <;> rfl, ← diagElem_one, diagElem_def,
+      HeckeCosetModule.single_apply, ite_eq_left rfl]
   | succ n ih =>
     rw [pow_succ']
     set g := (heckeTDiag 1 p) ^ n
-    set D_target : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2) :=
-      diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)
-    set D_leading : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2) :=
-      diagCoset (![1, p ^ n] : Fin 2 → ℕ)
+    set D_target := diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)
+    set D_leading := diagCoset (![1, p ^ n] : Fin 2 → ℕ)
     rw [heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _), diagElem_def,
       HeckeCosetModule.mul_def, HeckeCosetModule.single_mul]
     -- Evaluate the convolution at `D_target` in the wrapper's own vocabulary: push the
@@ -519,30 +534,6 @@ private lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
     simp only [HeckeCosetModule.smul_apply, one_mul]
     have h_leading_in_supp : D_leading ∈ g.support :=
       HeckeCosetModule.mem_support_iff.mpr (ih ▸ one_ne_zero)
-    rw [← Finset.sum_erase_add _ _ h_leading_in_supp]
-    have h_erased : ∀ D₂ ∈ g.support.erase D_leading,
-        (g D₂ • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-          (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep D₂)) D_target = 0 := by
-      intro D₂ hD₂
-      rw [Finset.mem_erase] at hD₂
-      -- The `•` here and the one in `smul_apply` print alike but sit on different instance
-      -- paths, so `rw`/`simp` cannot match it. Writing the equation out lets it elaborate
-      -- with the goal's instances, and `smul_apply` then checks against it up to defeq.
-      have hs : (g D₂ • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-            (diagCoset (![1, p] : Fin 2 → ℕ)).rep D₂.rep) D_target =
-          g D₂ * (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-            (diagCoset (![1, p] : Fin 2 → ℕ)).rep D₂.rep) D_target :=
-        HeckeCosetModule.smul_apply _ _ _
-      rw [hs]
-      rw [T_ad_one_p_mul_supp_ne_leading_eval_zero p hp n D₂
-        (HeckeCosetModule.mem_support_iff.mp hD₂.2) hD₂.1, mul_zero]
-    have h_sum_zero :
-        ∑ x ∈ g.support.erase D_leading, (g x •
-          HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-          (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep x)) D_target = 0 :=
-      Finset.sum_eq_zero h_erased
-    -- Goal: ∑ + (g D_leading • m ...) D_target = 1
-    -- Strategy: prove the leading term equals 1, then linarith with h_sum_zero
     have h_leading_eq : (g D_leading •
         HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
           (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep D_leading))
@@ -552,28 +543,22 @@ private lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
           g D_leading * (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
             (diagCoset (![1, p] : Fin 2 → ℕ)).rep D_leading.rep) D_target :=
         HeckeCosetModule.smul_apply _ _ _
-      rw [hs, ih, one_mul, ← diagElem_mul_diagElem]
-      rw [show diagElem (![1, p] : Fin 2 → ℕ) = heckeTDiag 1 p from
-          (heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _)).symm,
-        -- `![…]` literals that are only extensionally equal do not unify syntactically, so the
-        -- intended spelling is stated here for the following rewrite to match.
-        show diagElem (![1, p ^ n] : Fin 2 → ℕ) = heckeTDiag 1 (p ^ n) from
-          (heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos n) (one_dvd _)).symm]
-      exact T_ad_one_p_mul_T_ad_one_ppow_eval_leading p hp n
-    calc ∑ x ∈ g.support.erase D_leading, (g x •
-          HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-            (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep x)) D_target +
-          (g D_leading • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-            (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep D_leading)) D_target
-        = 0 + (g D_leading • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-              (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep D_leading))
-              D_target :=
-          by rw [h_sum_zero]
-      _ = (g D_leading • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-            (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ))) (HeckeCoset.rep D_leading))
-            D_target :=
-          zero_add _
-      _ = 1 := h_leading_eq
+      rw [hs, ih, one_mul]
+      exact T_ad_one_p_mul_leading_eval_one p hp n
+    -- Every other coset in the support contributes nothing, so only the leading term survives.
+    refine (Finset.sum_eq_single_of_mem D_leading h_leading_in_supp ?_).trans h_leading_eq
+    intro D₂ hD₂ hne
+    -- The `•` here and the one in `smul_apply` print alike but sit on different instance
+    -- paths, so `rw`/`simp` cannot match it. Writing the equation out lets it elaborate
+    -- with the goal's instances, and `smul_apply` then checks against it up to defeq.
+    have hs : (g D₂ • HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+          (diagCoset (![1, p] : Fin 2 → ℕ)).rep D₂.rep) D_target =
+        g D₂ * (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+          (diagCoset (![1, p] : Fin 2 → ℕ)).rep D₂.rep) D_target :=
+      HeckeCosetModule.smul_apply _ _ _
+    exact hs.trans (by
+      rw [T_ad_one_p_mul_supp_ne_leading_eval_zero p hp n D₂
+        (HeckeCosetModule.mem_support_iff.mp hD₂) hne, mul_zero])
 
 /-- For `a₁ ≠ a₂`, evaluating `(heckeTDiag 1 p)^a₁` at the coset `T(1, p^{a₂})` gives `0`. -/
 private lemma T_ad_one_p_pow_eval_at_one_ppow_of_ne (p : ℕ) (hp : p.Prime) {a₁ a₂ : ℕ}

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Injective.lean
@@ -414,9 +414,21 @@ private lemma T_elem_p_ppow_eval_at_one_ppow_succ_zero (p : ℕ) (hp : 1 < p) {n
   simp only [Matrix.cons_val_zero] at this
   have := hp; omega
 
-/-- `(T(1,p) · T(1, pⁿ))` evaluated at the leading coset `T(1, p^{n+1})` equals `1`. -/
+/-- **The structure constant of `T(1,p) · T(1, pⁿ)` at the leading coset `T(1, p^(n+1))` is
+`1`.** This is the companion of `T_ad_one_p_mul_supp_ne_leading_eval_zero`, which gives `0` at
+every other coset in the support. -/
 private lemma T_ad_one_p_mul_T_ad_one_ppow_eval_leading (p : ℕ) (hp : p.Prime) (n : ℕ) :
-    (heckeTDiag 1 p * heckeTDiag 1 (p ^ n)) (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 1 := by
+    (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+      (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ)))
+      (HeckeCoset.rep (diagCoset (![1, p ^ n] : Fin 2 → ℕ))))
+      (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 1 := by
+  rw [← diagElem_mul_diagElem,
+    show diagElem (![1, p] : Fin 2 → ℕ) = heckeTDiag 1 p from
+      (heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _)).symm,
+    -- `![…]` literals that are only extensionally equal do not unify syntactically, so the
+    -- intended spelling is stated here for the following rewrite to match.
+    show diagElem (![1, p ^ n] : Fin 2 → ℕ) = heckeTDiag 1 (p ^ n) from
+      (heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos n) (one_dvd _)).symm]
   classical
   rcases eq_or_ne n 0 with hn | hn
   · subst hn
@@ -492,23 +504,6 @@ private lemma T_ad_one_p_mul_supp_ne_leading_eval_zero (p : ℕ) (hp : p.Prime) 
   rw [T_elem_ppow_factor p hp.pos i (n - i) hi_le_sub, ← mul_assoc]
   exact T_mul_T_pp_pow_eval_at_one_zero p hp.one_lt i (p ^ (n + 1)) hi_ge (pow_pos hp.pos _) _
 
-/-- The structure constant of `T(1,p) · T(1,pⁿ)` at the leading coset `T(1, p^(n+1))` is `1`.
-This is the companion of `T_ad_one_p_mul_supp_ne_leading_eval_zero`, which gives `0` at every
-other coset in the support. -/
-private lemma T_ad_one_p_mul_leading_eval_one (p : ℕ) (hp : p.Prime) (n : ℕ) :
-    (HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
-      (HeckeCoset.rep (diagCoset (![1, p] : Fin 2 → ℕ)))
-      (HeckeCoset.rep (diagCoset (![1, p ^ n] : Fin 2 → ℕ))))
-      (diagCoset (![1, p ^ (n + 1)] : Fin 2 → ℕ)) = 1 := by
-  rw [← diagElem_mul_diagElem,
-    show diagElem (![1, p] : Fin 2 → ℕ) = heckeTDiag 1 p from
-      (heckeTDiag_eq_diagElem Nat.one_pos hp.pos (one_dvd _)).symm,
-    -- `![…]` literals that are only extensionally equal do not unify syntactically, so the
-    -- intended spelling is stated here for the following rewrite to match.
-    show diagElem (![1, p ^ n] : Fin 2 → ℕ) = heckeTDiag 1 (p ^ n) from
-      (heckeTDiag_eq_diagElem Nat.one_pos (pow_pos hp.pos n) (one_dvd _)).symm]
-  exact T_ad_one_p_mul_T_ad_one_ppow_eval_leading p hp n
-
 /-- Leading coefficient of `T(1,p)^a`: `(heckeTDiag 1 p)^a` evaluated at the leading coset
 `diagCoset ![1, p^a]` equals 1. -/
 private lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
@@ -544,7 +539,7 @@ private lemma T_ad_one_p_pow_eval_leading (p : ℕ) (hp : p.Prime) (a : ℕ) :
             (diagCoset (![1, p] : Fin 2 → ℕ)).rep D_leading.rep) D_target :=
         HeckeCosetModule.smul_apply _ _ _
       rw [hs, ih, one_mul]
-      exact T_ad_one_p_mul_leading_eval_one p hp n
+      exact T_ad_one_p_mul_T_ad_one_ppow_eval_leading p hp n
     -- Every other coset in the support contributes nothing, so only the leading term survives.
     refine (Finset.sum_eq_single_of_mem D_leading h_leading_in_supp ?_).trans h_leading_eq
     intro D₂ hD₂ hne


### PR DESCRIPTION
Roadmap: ModularForms

`T_ad_one_p_pow_eval_leading` was 82 lines — the longest proof in the file and
well over the repo's 50-line cap. Three things kept it there.

### The split is `Finset.sum_eq_single_of_mem`

The successor step evaluates a convolution at the leading coset, so all it needs
is: the leading term survives, everything else vanishes. Written with
`Finset.sum_erase_add` that took a separate `∀`-quantified vanishing hypothesis,
a separate sum-is-zero hypothesis, and a four-step `calc` whose only work was to
restate the goal in a form `rw` could match:

```
    calc ∑ x ∈ g.support.erase D_leading, (g x • …) D_target + (g D_leading • …) D_target
        = 0 + (g D_leading • …) D_target := by rw [h_sum_zero]
      _ = (g D_leading • …) D_target := zero_add _
      _ = 1 := h_leading_eq
```

`Finset.sum_eq_single_of_mem` gives the split directly, and `Eq.trans` crosses
the mismatch that blocked `rw` — the `•` in the goal and the one in
`HeckeCosetModule.smul_apply` print alike but sit on different instance paths, so
`rw` cannot match them while `exact` unifies up to defeq. That mismatch is why
the `calc` was there in the first place.

### The leading structure constant, stated where it is used

The file already contained this statement's mirror image:
`T_ad_one_p_mul_supp_ne_leading_eval_zero` gives `0` at every *non*-leading coset
of the support, in the `structureConstants` spelling. Its counterpart
`T_ad_one_p_mul_T_ad_one_ppow_eval_leading` gave `1` at the leading one but in
the `heckeTDiag`-product spelling, so the caller had to convert between the two.

That conversion now sits at the head of the counterpart's own proof, and the
counterpart is stated in the `structureConstants` form. The two companions match,
and there is one lemma rather than a lemma plus a wrapper around it.

### Two inferable ascriptions

The `set`s for `D_target` and `D_leading` carried
`: HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)`, which elaboration recovers from
`diagCoset`.

82 lines becomes 50.

### On the source

`T_ad_one_p_pow_eval_leading` itself came from AINTLIB, so I read its
neighbourhood there rather than only grepping for a name. The source inlines the
leading-term step exactly as TauCeti did — same `sum_erase_add` split, same local
`h_leading_eq`, same `calc` — and has no lemma for it. The name this PR adds is
new, not a re-port of one the source already had.

### What this PR does not do

`det_rep_T_gen_zero_pow_mul` in the same file is 51 lines. Different content, its
own PR.

Verified with a green build of the module and everything importing it, plus the
repo's 13-linter `#lint` set over its cone (0 errors, 728 declarations).

Roadmap attribution only — this is a refactor and carries no target marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
