### PR TITLE
feat(NumberTheory): two negligible-weight estimates for the weighted prime count

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -76,7 +76,10 @@ estimates for these counts, and consumes the prime base and exponent of a prime-
 fibre those estimates over the primes.
 
 `TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(3)** is the source for the finite-set estimate:
-a finite set of primes contributes `O(log x)`, hence `o(x)`.
+a finite set of primes contributes `O(log x)`, hence `o(x)`.  The fibre bound
+`card_mul_log_absNorm_le_of_pow_le_of_base_eq` lives here rather than with either consumer: it holds
+for every exponent `k ≥ 1`, and both the higher-power estimate of 11.3(2) and the finite-set
+estimate of 11.3(3) rest on it.
 
 ## References
 
@@ -562,6 +565,42 @@ theorem log_absNorm_asIdeal_pos (v : HeightOneSpectrum (𝓞 K)) :
 theorem log_absNorm_asIdeal_nonneg (v : HeightOneSpectrum (𝓞 K)) :
     0 ≤ Real.log (Ideal.absNorm v.asIdeal : ℝ) :=
   (log_absNorm_asIdeal_pos v).le
+
+/-- **A fixed prime base contributes at most `log x`.** For a finset `F` of prime powers all of
+base `v` and of absolute norm at most `x`, the total weight `#F · log N(v)` is at most `log x`:
+distinct members of `F` have distinct exponents, and every exponent is at most
+`log x / log N(v)`.
+
+This is the counting core shared by the two weighted estimates over a prime fibre, which differ
+only in which prime powers they collect: `TauCeti.higherPrimePowerTheta_le_card_primesLE_mul_log`
+takes the exponents `k ≥ 2`, `TauCeti.primePsi_le_ncard_mul_log` all `k ≥ 1`. Only `1 ≤ x` and a
+common base are needed. -/
+theorem card_mul_log_absNorm_le_of_pow_le_of_base_eq (hx : 1 ≤ x) {v : HeightOneSpectrum (𝓞 K)}
+    {F : Finset (IdealPrimePower K)}
+    (hF : ∀ A ∈ F, ((Ideal.absNorm v.asIdeal : ℝ)) ^ primePowerExponent A ≤ x)
+    (hbase : ∀ A ∈ F, primePowerBase A = v) :
+    (F.card : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x := by
+  classical
+  have hLpos : 0 < Real.log (Ideal.absNorm v.asIdeal) := log_absNorm_asIdeal_pos v
+  have hexpbound : ∀ A ∈ F,
+      primePowerExponent A ∈ Finset.Icc 1 ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
+    intro A hA
+    have hlog : (primePowerExponent A : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x :=
+      Real.le_log_of_pow_le (by linarith [two_le_absNorm_asIdeal_real v]) (hF A hA)
+    exact Finset.mem_Icc.mpr
+      ⟨primePowerExponent_pos A, Nat.le_floor ((le_div_iff₀ hLpos).mpr hlog)⟩
+  have hcard : F.card ≤ ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
+    refine le_trans (Finset.card_le_card_of_injOn primePowerExponent hexpbound ?_) ?_
+    · exact fun A hA B hB h ↦
+        idealPrimePower_eq_of_base_eq_of_exponent_eq ((hbase A hA).trans (hbase B hB).symm) h
+    · rw [Nat.card_Icc]; omega
+  calc (F.card : ℝ) * Real.log (Ideal.absNorm v.asIdeal)
+      ≤ (⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ : ℝ)
+        * Real.log (Ideal.absNorm v.asIdeal) :=
+        mul_le_mul_of_nonneg_right (by exact_mod_cast hcard) hLpos.le
+    _ ≤ Real.log x := by
+        rw [← le_div_iff₀ hLpos]
+        exact Nat.floor_le (div_nonneg (Real.log_nonneg hx) hLpos.le)
 
 /-- The logarithmically weighted prime count is nonnegative. -/
 theorem primeTheta_nonneg (S : Set (HeightOneSpectrum (𝓞 K))) (x : ℝ) : 0 ≤ primeTheta K S x :=

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -75,6 +75,9 @@ weighted prime counts `primeTheta` and `primeCount` of 4.3. Layer 5 supplies the
 estimates for these counts, and consumes the prime base and exponent of a prime-power ideal to
 fibre those estimates over the primes.
 
+`TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(3)** is the source for the finite-set estimate:
+a finite set of primes contributes `O(log x)`, hence `o(x)`.
+
 ## References
 
 * G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapters I--II.

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -80,6 +80,8 @@ fibre those estimates over the primes.
 * G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapters I--II.
 * H. Davenport, *Multiplicative Number Theory*, Chapters 1 and 7.
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII.
+* `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(2), for the negligible weight of a finite
+  set of primes in `ϑ`, supplied here by `TauCeti.primeTheta_isLittleO_of_finite`.
 -/
 
 public section

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -665,7 +665,7 @@ sum stops growing. A constant is `o(x)`.
 
 This is what lets a counting argument discard an exceptional set outright — the ramified primes of
 an extension, say — rather than only from a density. It is the discard
-`TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(2), asks for. -/
+`TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(3), asks for. -/
 theorem primeTheta_isLittleO_of_finite (hS : S.Finite) :
     primeTheta K S =o[atTop] fun x : ℝ ↦ x := by
   refine (isLittleO_const_id_atTop

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -62,9 +62,12 @@ Modifying a weight on a finite set, or a prime set on a finite symmetric differe
 summatory function by a quantity that is eventually the *constant* total discrepancy; this is
 `TauCeti.eventually_summatory_sub_eq` and its two prime specializations. Layer 7 uses these to
 show that finite changes do not affect a density. In the same spirit,
-`TauCeti.primeTheta_isLittleO_of_finite` records that a finite set of primes contributes only
-`O(log x)` to `ϑ_K`, hence `o(x)`: an exceptional set can be discarded from a counting argument
-outright, not merely from a density.
+`TauCeti.primeTheta_isLittleO_of_finite` records that a finite set of primes contributes an
+eventually constant amount to `ϑ_K`, hence `o(x)`: an exceptional set can be discarded from a
+counting argument outright, not merely from a density. Its `ψ` companion is
+`TauCeti.primePsi_isLittleO_of_finite`. Both are consumed by the Chebotarev roadmap
+(`Chebotarev/README.md` Layer 11.3, the discard estimates), which is where the need for them as
+separately named theorems comes from.
 
 ## Roadmap role
 
@@ -658,20 +661,22 @@ theorem eventually_primeCount_eq_card (hS : S.Finite) :
   simp
 
 open Asymptotics Filter in
-/-- **A finite set of primes carries a negligible weight.** Its contribution to `ϑ_K` is `o(x)` —
-in fact `O(log x)`, since each of the finitely many primes contributes at most `log x`.
+/-- **A finite set of primes carries a negligible weight**, because its contribution to `ϑ_K` is
+eventually *constant*: past the largest norm in the set every member is already counted, so the
+sum stops growing. A constant is `o(x)`.
 
-This is what lets a counting argument discard an exceptional set outright: the ramified primes of
-an extension, or the primes of an intermediate field lying above them. -/
+This is what lets a counting argument discard an exceptional set outright — the ramified primes of
+an extension, say — rather than only from a density. -/
 theorem primeTheta_isLittleO_of_finite (hS : S.Finite) :
     primeTheta K S =o[atTop] fun x : ℝ ↦ x := by
-  refine IsBigO.trans_isLittleO (IsBigO.of_bound 1 ?_)
-    (Real.isLittleO_log_id_atTop.const_mul_left (S.ncard : ℝ))
-  filter_upwards [eventually_primeCount_eq_card hS] with x hx
-  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg (primeTheta_nonneg _ _)]
-  calc primeTheta K S x ≤ primeCount K S x * Real.log x := primeTheta_le_primeCount_mul_log _ x
-    _ = (S.ncard : ℝ) * Real.log x := by rw [hx]
-    _ ≤ |(S.ncard : ℝ) * Real.log x| := le_abs_self _
+  refine (isLittleO_const_id_atTop
+      (∑ v ∈ hS.toFinset, S.indicator (fun v ↦ Real.log (Ideal.absNorm v.asIdeal : ℝ)) v)).congr'
+    ?_ EventuallyEq.rfl
+  filter_upwards [eventually_summatory_eq_sum
+      (fun v : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm v.asIdeal)
+      (S.indicator fun v ↦ Real.log (Ideal.absNorm v.asIdeal : ℝ)) hS.toFinset
+      fun v hv ↦ Set.indicator_of_notMem (by simpa using hv) _] with x hx
+  exact hx.symm
 
 /-- If two prime sets have finite symmetric difference, their logarithmically weighted counts
 differ eventually by the fixed total discrepancy on that symmetric difference. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -65,9 +65,7 @@ show that finite changes do not affect a density. In the same spirit,
 `TauCeti.primeTheta_isLittleO_of_finite` records that a finite set of primes contributes an
 eventually constant amount to `ϑ_K`, hence `o(x)`: an exceptional set can be discarded from a
 counting argument outright, not merely from a density. Its `ψ` companion is
-`TauCeti.primePsi_isLittleO_of_finite`. Both are consumed by the Chebotarev roadmap
-(`Chebotarev/README.md` Layer 11.3, the discard estimates), which is where the need for them as
-separately named theorems comes from.
+`TauCeti.primePsi_isLittleO_of_finite`.
 
 ## Roadmap role
 
@@ -676,6 +674,9 @@ theorem primeTheta_isLittleO_of_finite (hS : S.Finite) :
       (fun v : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm v.asIdeal)
       (S.indicator fun v ↦ Real.log (Ideal.absNorm v.asIdeal : ℝ)) hS.toFinset
       fun v hv ↦ Set.indicator_of_notMem (by simpa using hv) _] with x hx
+  -- `primeTheta` is `primeSummatory` of the indicator weight, and that is `summatory` along the
+  -- absolute norm; naming both keeps the step independent of how the wrappers are defined.
+  simp only [primeTheta, primeSummatory]
   exact hx.symm
 
 /-- If two prime sets have finite symmetric difference, their logarithmically weighted counts

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -659,13 +659,30 @@ theorem eventually_primeCount_eq_card (hS : S.Finite) :
   simp
 
 open Asymptotics Filter in
+/-- **Primes counted below the prime-ideal-theorem order carry negligible weight.** Chebyshev's
+comparison spends one factor of `log x` per counted prime, so a count of `o(x / log x)` gives a
+weighted sum of `o(x)`.
+
+Stated for an arbitrary prime set, since the argument uses nothing about which primes are counted;
+`TauCeti.primeTheta_higherDegreePrimes_isLittleO` is the residue-degree instance. -/
+theorem primeTheta_isLittleO_of_primeCount_isLittleO
+    (h : primeCount K S =o[atTop] fun x : ℝ ↦ x / Real.log x) :
+    primeTheta K S =o[atTop] fun x : ℝ ↦ x := by
+  have hlog : ∀ᶠ x : ℝ in atTop, Real.log x ≠ 0 :=
+    (eventually_gt_atTop (1 : ℝ)).mono fun _ hx ↦ (Real.log_pos hx).ne'
+  have hmul : (fun x : ℝ ↦ primeCount K S x * Real.log x) =o[atTop] fun x : ℝ ↦ x := by
+    simpa [mul_comm] using (isLittleO_mul_iff_isLittleO_div hlog).2 h
+  refine IsBigO.trans_isLittleO (IsBigO.of_bound 1 (.of_forall fun x ↦ ?_)) hmul
+  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg (primeTheta_nonneg _ _)]
+  exact (primeTheta_le_primeCount_mul_log _ x).trans (le_abs_self _)
+
+open Asymptotics Filter in
 /-- **A finite set of primes carries a negligible weight**, because its contribution to `ϑ_K` is
 eventually *constant*: past the largest norm in the set every member is already counted, so the
 sum stops growing. A constant is `o(x)`.
 
 This is what lets a counting argument discard an exceptional set outright — the ramified primes of
-an extension, say — rather than only from a density. It is the discard
-`TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(3), asks for. -/
+an extension, say — rather than only from a density. -/
 theorem primeTheta_isLittleO_of_finite (hS : S.Finite) :
     primeTheta K S =o[atTop] fun x : ℝ ↦ x := by
   refine (isLittleO_const_id_atTop

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -75,12 +75,6 @@ weighted prime counts `primeTheta` and `primeCount` of 4.3. Layer 5 supplies the
 estimates for these counts, and consumes the prime base and exponent of a prime-power ideal to
 fibre those estimates over the primes.
 
-`TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(3)** is the source for the finite-set estimate:
-a finite set of primes contributes `O(log x)`, hence `o(x)`.  The fibre bound
-`card_mul_log_absNorm_le_of_pow_le_of_base_eq` lives here rather than with either consumer: it holds
-for every exponent `k ≥ 1`, and both the higher-power estimate of 11.3(2) and the finite-set
-estimate of 11.3(3) rest on it.
-
 ## References
 
 * G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapters I--II.

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -80,8 +80,6 @@ fibre those estimates over the primes.
 * G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapters I--II.
 * H. Davenport, *Multiplicative Number Theory*, Chapters 1 and 7.
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII.
-* `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(2), for the negligible weight of a finite
-  set of primes in `ϑ`, supplied here by `TauCeti.primeTheta_isLittleO_of_finite`.
 -/
 
 public section
@@ -666,7 +664,8 @@ eventually *constant*: past the largest norm in the set every member is already 
 sum stops growing. A constant is `o(x)`.
 
 This is what lets a counting argument discard an exceptional set outright — the ramified primes of
-an extension, say — rather than only from a density. -/
+an extension, say — rather than only from a density. It is the discard
+`TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(2), asks for. -/
 theorem primeTheta_isLittleO_of_finite (hS : S.Finite) :
     primeTheta K S =o[atTop] fun x : ℝ ↦ x := by
   refine (isLittleO_const_id_atTop

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -61,7 +61,10 @@ prime carrier below `2`.
 Modifying a weight on a finite set, or a prime set on a finite symmetric difference, changes a
 summatory function by a quantity that is eventually the *constant* total discrepancy; this is
 `TauCeti.eventually_summatory_sub_eq` and its two prime specializations. Layer 7 uses these to
-show that finite changes do not affect a density.
+show that finite changes do not affect a density. In the same spirit,
+`TauCeti.primeTheta_isLittleO_of_finite` records that a finite set of primes contributes only
+`O(log x)` to `ϑ_K`, hence `o(x)`: an exceptional set can be discarded from a counting argument
+outright, not merely from a density.
 
 ## Roadmap role
 
@@ -653,6 +656,22 @@ theorem eventually_primeCount_eq_card (hS : S.Finite) :
     Finset.sum_congr rfl fun v hv ↦
     Set.indicator_of_mem (hS.mem_toFinset.mp hv) _, Set.ncard_eq_toFinset_card S hS]
   simp
+
+open Asymptotics Filter in
+/-- **A finite set of primes carries a negligible weight.** Its contribution to `ϑ_K` is `o(x)` —
+in fact `O(log x)`, since each of the finitely many primes contributes at most `log x`.
+
+This is what lets a counting argument discard an exceptional set outright: the ramified primes of
+an extension, or the primes of an intermediate field lying above them. -/
+theorem primeTheta_isLittleO_of_finite (hS : S.Finite) :
+    primeTheta K S =o[atTop] fun x : ℝ ↦ x := by
+  refine IsBigO.trans_isLittleO (IsBigO.of_bound 1 ?_)
+    (Real.isLittleO_log_id_atTop.const_mul_left (S.ncard : ℝ))
+  filter_upwards [eventually_primeCount_eq_card hS] with x hx
+  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg (primeTheta_nonneg _ _)]
+  calc primeTheta K S x ≤ primeCount K S x * Real.log x := primeTheta_le_primeCount_mul_log _ x
+    _ = (S.ncard : ℝ) * Real.log x := by rw [hx]
+    _ ≤ |(S.ncard : ℝ) * Real.log x| := le_abs_self _
 
 /-- If two prime sets have finite symmetric difference, their logarithmically weighted counts
 differ eventually by the fixed total discrepancy on that symmetric difference. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
@@ -65,8 +65,10 @@ This is the prime and prime-power half of Layer **5.1** together with Layer **5.
 `O(√x log² x)` estimate under the standard logarithmic prime-power weight" and for the
 hypotheses needed by other arithmetic weights.  Layer 10.2 consumes it as the named estimate
 turning an asymptotic for `ψ` into one for `ϑ`; the roadmap's own accounting there requires only
-the `o(x)` corollary.  The fibre bound added here serves the discard estimate of
-`TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(2)**.
+the `o(x)` corollary.  The estimate proved here serves the discard estimate of
+`TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(2)**; the shared fibre bound it rests on is
+`TauCeti.card_mul_log_absNorm_le_of_pow_le_of_base_eq`, which lives in `Counting` with the other
+carrier-level counting results.
 
 The ideal-counting half of Layer 5.1 is a separate estimate: it is analytic, resting on Mathlib's
 `NumberField.Ideal.tendsto_norm_le_div_atTop₀`, and is not needed here.
@@ -250,44 +252,6 @@ theorem higherPrimePowerTheta_mono (K : Type*) [Field K] [NumberField K] :
   primePowerSummatory_mono K _ higherPrimePowerWeight_nonneg
 
 /-! ### The `O(√x log² x)` estimate -/
-
-/-- **A fixed prime base contributes at most `log x`.** For a finset `F` of prime powers all of
-base `v` and of absolute norm at most `x`, the total weight `#F · log N(v)` is at most `log x`:
-distinct members of `F` have distinct exponents, and every exponent is at most
-`log x / log N(v)`.
-
-This is the counting core shared by the two weighted estimates over a prime fibre, which differ
-only in which prime powers they collect: `TauCeti.higherPrimePowerTheta_le_card_primesLE_mul_log`
-takes the exponents `k ≥ 2`, `TauCeti.primePsi_le_ncard_mul_log` all `k ≥ 1`. Only `1 ≤ x` and a
-common base are needed. -/
-theorem card_mul_log_absNorm_le_of_pow_le_of_base_eq (hx : 1 ≤ x) {v : HeightOneSpectrum (𝓞 K)}
-    {F : Finset (IdealPrimePower K)}
-    (hF : ∀ A ∈ F, ((Ideal.absNorm v.asIdeal : ℝ)) ^ primePowerExponent A ≤ x)
-    (hbase : ∀ A ∈ F, primePowerBase A = v) :
-    (F.card : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x := by
-  classical
-  have hlogx : 0 ≤ Real.log x := Real.log_nonneg hx
-  have hLpos : 0 < Real.log (Ideal.absNorm v.asIdeal) :=
-    Real.log_pos (by linarith [two_le_absNorm_asIdeal_real v])
-  have hexpbound : ∀ A ∈ F,
-      primePowerExponent A ∈ Finset.Icc 1 ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
-    intro A hA
-    have hlog : (primePowerExponent A : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x :=
-      Real.le_log_of_pow_le (by linarith [two_le_absNorm_asIdeal_real v]) (hF A hA)
-    exact Finset.mem_Icc.mpr
-      ⟨primePowerExponent_pos A, Nat.le_floor ((le_div_iff₀ hLpos).mpr hlog)⟩
-  have hcard : F.card ≤ ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
-    refine le_trans (Finset.card_le_card_of_injOn primePowerExponent hexpbound ?_) ?_
-    · exact fun A hA B hB h ↦
-        idealPrimePower_eq_of_base_eq_of_exponent_eq ((hbase A hA).trans (hbase B hB).symm) h
-    · rw [Nat.card_Icc]; omega
-  calc (F.card : ℝ) * Real.log (Ideal.absNorm v.asIdeal)
-      ≤ (⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ : ℝ)
-        * Real.log (Ideal.absNorm v.asIdeal) :=
-        mul_le_mul_of_nonneg_right (by exact_mod_cast hcard) hLpos.le
-    _ ≤ Real.log x := by
-        rw [← le_div_iff₀ hLpos]
-        exact Nat.floor_le (by positivity)
 
 /-- Fibring the higher prime powers over their prime base: for a fixed prime `𝔭`, the exponents
 `k ≥ 2` with `N(𝔭) ^ k ≤ x` contribute at most `log x` in total, and only primes of norm at most

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
@@ -75,8 +75,6 @@ The ideal-counting half of Layer 5.1 is a separate estimate: it is analytic, res
 * H. Davenport, *Multiplicative Number Theory*, Chapter 7.
 * G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapter I.2.
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII.
-* `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3, whose two estimates share the
-  fibre-and-count step `TauCeti.card_fiber_mul_log_absNorm_le` proved below.
 -/
 
 public section
@@ -261,7 +259,8 @@ This is the counting core shared by the two weighted estimates over a prime fibr
 only in which prime powers they collect. It was factored out of
 `TauCeti.higherPrimePowerTheta_le_card_primesLE_mul_log` below, whose proof first made the
 argument for exponents `k ≥ 2`; `TauCeti.primePsi_le_ncard_mul_log` needs the same count with
-`k ≥ 1`, and both now go through here. -/
+`k ≥ 1`, and both now go through here. Both consumers are estimates
+`TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3, asks for. -/
 theorem card_fiber_mul_log_absNorm_le (hx : 1 ≤ x) {v : HeightOneSpectrum (𝓞 K)}
     {F : Finset (IdealPrimePower K)}
     (hF : ∀ A ∈ F, ((Ideal.absNorm v.asIdeal : ℝ)) ^ primePowerExponent A ≤ x)

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
@@ -65,7 +65,8 @@ This is the prime and prime-power half of Layer **5.1** together with Layer **5.
 `O(√x log² x)` estimate under the standard logarithmic prime-power weight" and for the
 hypotheses needed by other arithmetic weights.  Layer 10.2 consumes it as the named estimate
 turning an asymptotic for `ψ` into one for `ϑ`; the roadmap's own accounting there requires only
-the `o(x)` corollary.
+the `o(x)` corollary.  The fibre bound added here serves the discard estimate of
+`TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(2)**.
 
 The ideal-counting half of Layer 5.1 is a separate estimate: it is analytic, resting on Mathlib's
 `NumberField.Ideal.tendsto_norm_le_div_atTop₀`, and is not needed here.

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
@@ -259,7 +259,7 @@ This is the counting core shared by the two weighted estimates over a prime fibr
 only in which prime powers they collect: `TauCeti.higherPrimePowerTheta_le_card_primesLE_mul_log`
 takes the exponents `k ≥ 2`, `TauCeti.primePsi_le_ncard_mul_log` all `k ≥ 1`. Only `1 ≤ x` and a
 common base are needed. -/
-theorem card_fiber_mul_log_absNorm_le (hx : 1 ≤ x) {v : HeightOneSpectrum (𝓞 K)}
+theorem card_mul_log_absNorm_le_of_pow_le_of_base_eq (hx : 1 ≤ x) {v : HeightOneSpectrum (𝓞 K)}
     {F : Finset (IdealPrimePower K)}
     (hF : ∀ A ∈ F, ((Ideal.absNorm v.asIdeal : ℝ)) ^ primePowerExponent A ≤ x)
     (hbase : ∀ A ∈ F, primePowerBase A = v) :
@@ -328,7 +328,7 @@ theorem higherPrimePowerTheta_le_card_primesLE_mul_log
   refine (Finset.sum_le_card_nsmul _ _ (Real.log x) ?_).trans_eq (by rw [nsmul_eq_mul])
   intro v _
   rw [Finset.sum_const, nsmul_eq_mul]
-  exact card_fiber_mul_log_absNorm_le hx
+  exact card_mul_log_absNorm_le_of_pow_le_of_base_eq hx
     (fun A hA ↦ by
       obtain ⟨hle, -⟩ := hmemT A (Finset.mem_of_mem_filter _ hA)
       rwa [(Finset.mem_filter.mp hA).2] at hle)

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
@@ -256,11 +256,9 @@ distinct members of `F` have distinct exponents, and every exponent is at most
 `log x / log N(v)`.
 
 This is the counting core shared by the two weighted estimates over a prime fibre, which differ
-only in which prime powers they collect. It was factored out of
-`TauCeti.higherPrimePowerTheta_le_card_primesLE_mul_log` below, whose proof first made the
-argument for exponents `k ≥ 2`; `TauCeti.primePsi_le_ncard_mul_log` needs the same count with
-`k ≥ 1`, and both now go through here. Both consumers are estimates
-`TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3, asks for. -/
+only in which prime powers they collect: `TauCeti.higherPrimePowerTheta_le_card_primesLE_mul_log`
+takes the exponents `k ≥ 2`, `TauCeti.primePsi_le_ncard_mul_log` all `k ≥ 1`. Only `1 ≤ x` and a
+common base are needed. -/
 theorem card_fiber_mul_log_absNorm_le (hx : 1 ≤ x) {v : HeightOneSpectrum (𝓞 K)}
     {F : Finset (IdealPrimePower K)}
     (hF : ∀ A ∈ F, ((Ideal.absNorm v.asIdeal : ℝ)) ^ primePowerExponent A ≤ x)

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
@@ -250,6 +250,47 @@ theorem higherPrimePowerTheta_mono (K : Type*) [Field K] [NumberField K] :
 
 /-! ### The `O(√x log² x)` estimate -/
 
+/-- **A fixed prime base contributes at most `log x`.** For a finset `F` of prime powers all of
+base `v` and of absolute norm at most `x`, the total weight `#F · log N(v)` is at most `log x`:
+distinct members of `F` have distinct exponents, and every exponent is at most
+`log x / log N(v)`.
+
+This is the counting core shared by the two weighted estimates over a prime fibre, which differ
+only in which prime powers they collect. It was factored out of
+`TauCeti.higherPrimePowerTheta_le_card_primesLE_mul_log` below, whose proof first made the
+argument for exponents `k ≥ 2`; `TauCeti.primePsi_le_ncard_mul_log` needs the same count with
+`k ≥ 1`, and both now go through here. -/
+theorem card_fiber_mul_log_absNorm_le (hx : 1 ≤ x) {v : HeightOneSpectrum (𝓞 K)}
+    {F : Finset (IdealPrimePower K)}
+    (hF : ∀ A ∈ F, ((Ideal.absNorm v.asIdeal : ℝ)) ^ primePowerExponent A ≤ x)
+    (hbase : ∀ A ∈ F, primePowerBase A = v) :
+    (F.card : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x := by
+  classical
+  have hlogx : 0 ≤ Real.log x := Real.log_nonneg hx
+  have hLpos : 0 < Real.log (Ideal.absNorm v.asIdeal) :=
+    Real.log_pos (by linarith [two_le_absNorm_asIdeal_real v])
+  have hexpbound : ∀ A ∈ F,
+      primePowerExponent A ∈ Finset.Icc 1 ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
+    intro A hA
+    have hlog : (primePowerExponent A : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x := by
+      have := Real.log_le_log
+        (pow_pos (by linarith [two_le_absNorm_asIdeal_real v]) _) (hF A hA)
+      rwa [Real.log_pow] at this
+    exact Finset.mem_Icc.mpr
+      ⟨primePowerExponent_pos A, Nat.le_floor ((le_div_iff₀ hLpos).mpr hlog)⟩
+  have hcard : F.card ≤ ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
+    refine le_trans (Finset.card_le_card_of_injOn primePowerExponent hexpbound ?_) ?_
+    · exact fun A hA B hB h ↦
+        idealPrimePower_eq_of_base_eq_of_exponent_eq ((hbase A hA).trans (hbase B hB).symm) h
+    · rw [Nat.card_Icc]; omega
+  calc (F.card : ℝ) * Real.log (Ideal.absNorm v.asIdeal)
+      ≤ (⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ : ℝ)
+        * Real.log (Ideal.absNorm v.asIdeal) :=
+        mul_le_mul_of_nonneg_right (by exact_mod_cast hcard) hLpos.le
+    _ ≤ Real.log x := by
+        rw [← le_div_iff₀ hLpos]
+        exact Nat.floor_le (by positivity)
+
 /-- Fibring the higher prime powers over their prime base: for a fixed prime `𝔭`, the exponents
 `k ≥ 2` with `N(𝔭) ^ k ≤ x` contribute at most `log x` in total, and only primes of norm at most
 `√x` occur at all. -/
@@ -289,36 +330,12 @@ theorem higherPrimePowerTheta_le_card_primesLE_mul_log
     (fun v ↦ Real.log (Ideal.absNorm v.asIdeal))]
   refine (Finset.sum_le_card_nsmul _ _ (Real.log x) ?_).trans_eq (by rw [nsmul_eq_mul])
   intro v _
-  have hLpos : 0 < Real.log (Ideal.absNorm v.asIdeal) :=
-    Real.log_pos (by linarith [two_le_absNorm_asIdeal_real v])
   rw [Finset.sum_const, nsmul_eq_mul]
-  have hexpbound : ∀ A ∈ T.filter (fun A ↦ primePowerBase A = v),
-      primePowerExponent A ∈ Finset.Icc 2 ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
-    intro A hA
-    have hbase : primePowerBase A = v := (Finset.mem_filter.mp hA).2
-    obtain ⟨hle, hexp⟩ := hmemT A (Finset.mem_of_mem_filter _ hA)
-    rw [hbase] at hle
-    have hlog : (primePowerExponent A : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x := by
-      have := Real.log_le_log
-        (pow_pos (by linarith [two_le_absNorm_asIdeal_real v]) _) hle
-      rwa [Real.log_pow] at this
-    exact Finset.mem_Icc.mpr ⟨hexp, Nat.le_floor ((le_div_iff₀ hLpos).mpr hlog)⟩
-  have hcard : (T.filter (fun A ↦ primePowerBase A = v)).card
-      ≤ ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
-    refine le_trans (Finset.card_le_card_of_injOn primePowerExponent hexpbound ?_) ?_
-    · intro A hA B hB h
-      exact idealPrimePower_eq_of_base_eq_of_exponent_eq
-        (((Finset.mem_filter.mp hA).2).trans ((Finset.mem_filter.mp hB).2).symm) h
-    · rw [Nat.card_Icc]
-      omega
-  calc ((T.filter (fun A ↦ primePowerBase A = v)).card : ℝ)
-        * Real.log (Ideal.absNorm v.asIdeal)
-      ≤ (⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ : ℝ)
-        * Real.log (Ideal.absNorm v.asIdeal) :=
-        mul_le_mul_of_nonneg_right (by exact_mod_cast hcard) hLpos.le
-    _ ≤ Real.log x := by
-        rw [← le_div_iff₀ hLpos]
-        exact Nat.floor_le (by positivity)
+  exact card_fiber_mul_log_absNorm_le hx
+    (fun A hA ↦ by
+      obtain ⟨hle, -⟩ := hmemT A (Finset.mem_of_mem_filter _ hA)
+      rwa [(Finset.mem_filter.mp hA).2] at hle)
+    (fun A hA ↦ (Finset.mem_filter.mp hA).2)
 
 /-- The **higher prime powers are negligible**, with an explicit constant:
 `ψ(x) - ϑ(x) ≤ [K:ℚ] / (2 log 2) · √x log² x` for `x ≥ 1`. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
@@ -271,10 +271,8 @@ theorem card_fiber_mul_log_absNorm_le (hx : 1 ≤ x) {v : HeightOneSpectrum (�
   have hexpbound : ∀ A ∈ F,
       primePowerExponent A ∈ Finset.Icc 1 ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
     intro A hA
-    have hlog : (primePowerExponent A : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x := by
-      have := Real.log_le_log
-        (pow_pos (by linarith [two_le_absNorm_asIdeal_real v]) _) (hF A hA)
-      rwa [Real.log_pow] at this
+    have hlog : (primePowerExponent A : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x :=
+      Real.le_log_of_pow_le (by linarith [two_le_absNorm_asIdeal_real v]) (hF A hA)
     exact Finset.mem_Icc.mpr
       ⟨primePowerExponent_pos A, Nat.le_floor ((le_div_iff₀ hLpos).mpr hlog)⟩
   have hcard : F.card ≤ ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
@@ -75,6 +75,8 @@ The ideal-counting half of Layer 5.1 is a separate estimate: it is analytic, res
 * H. Davenport, *Multiplicative Number Theory*, Chapter 7.
 * G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapter I.2.
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII.
+* `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3, whose two estimates share the
+  fibre-and-count step `TauCeti.card_fiber_mul_log_absNorm_le` proved below.
 -/
 
 public section

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/HigherPrimePowers.lean
@@ -65,10 +65,7 @@ This is the prime and prime-power half of Layer **5.1** together with Layer **5.
 `O(√x log² x)` estimate under the standard logarithmic prime-power weight" and for the
 hypotheses needed by other arithmetic weights.  Layer 10.2 consumes it as the named estimate
 turning an asymptotic for `ψ` into one for `ϑ`; the roadmap's own accounting there requires only
-the `o(x)` corollary.  The estimate proved here serves the discard estimate of
-`TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(2)**; the shared fibre bound it rests on is
-`TauCeti.card_mul_log_absNorm_le_of_pow_le_of_base_eq`, which lives in `Counting` with the other
-carrier-level counting results.
+the `o(x)` corollary.
 
 The ideal-counting half of Layer 5.1 is a separate estimate: it is analytic, resting on Mathlib's
 `NumberField.Ideal.tendsto_norm_le_div_atTop₀`, and is not needed here.

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -237,7 +237,11 @@ base, the exponents `k ≥ 1` with `N(𝔭) ^ k ≤ x` contribute at most `log x
 finitely many `𝔭`.
 
 A counting argument can therefore discard a finite exceptional set of primes — those ramifying in
-an extension, say, or lying above such — at a cost of `O(log x)`. -/
+an extension, say, or lying above such — at a cost of `O(log x)`.
+
+The fibre step is `TauCeti.card_fiber_mul_log_absNorm_le`, which was factored out of
+`TauCeti.higherPrimePowerTheta_le_card_primesLE_mul_log`: that theorem first made this
+exponent-counting argument, for exponents `k ≥ 2`, and both estimates now share it. -/
 theorem primePsi_le_ncard_mul_log (hS : S.Finite) (hx : 1 ≤ x) :
     primePsi K S x ≤ S.ncard * Real.log x := by
   classical

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -40,6 +40,8 @@ system does not get that hypothesis for free; what it has to supply is the domin
 * `TauCeti.primePowerSummatory_indicator_sub_primeTheta` splits the exponent-one part off the
   standard weight restricted to any set of prime powers containing exactly the primes of `S`.
 * `TauCeti.primePsi_sub_primeTheta` identifies `ψ - ϑ` with the higher-prime-power sum.
+* `TauCeti.primePsi_isLittleO_of_finite`: a finite set of primes is negligible for `ψ`, the form
+  the Chebotarev roadmap's Layer 11.3 third discard estimate consumes.
 * `TauCeti.standardPrimePowerRemoval` proves `HasNegligibleHigherPrimePowers K S` for every `S`,
   from the Layer 5 estimate `ψ(x) - ϑ(x) = O(√x log² x)`.
 * `TauCeti.primeTheta_asymptotic_of_primePsi` and
@@ -228,6 +230,19 @@ theorem standardPrimePowerRemoval (K : Type*) [Field K] [NumberField K]
     (S : Set (HeightOneSpectrum (𝓞 K))) : HasNegligibleHigherPrimePowers K S := by
   rw [hasNegligibleHigherPrimePowers_iff]
   simpa only [primePsi_sub_primeTheta] using primePowerSummatory_indicator_isLittleO K S
+
+open Asymptotics Filter in
+/-- **A finite set of primes carries a negligible weight in `ψ` too.** Unlike `ϑ`, the sum does not
+become constant — higher powers of a fixed prime keep entering as the cutoff grows — but the whole
+higher-power tail is `o(x)` for any set at all, so the two estimates add.
+
+This is the `ψ` form the Chebotarev roadmap's Layer 11.3 asks for in its third discard estimate,
+where the exceptional set is `ramifiedPrimes`, the primes of an intermediate field above it, or the
+primes ramified in a compositum but not below. `TauCeti.primeTheta_isLittleO_of_finite` is the `ϑ`
+companion. -/
+theorem primePsi_isLittleO_of_finite (hS : S.Finite) :
+    primePsi K S =o[atTop] fun x : ℝ ↦ x := by
+  simpa using (standardPrimePowerRemoval K S).add (primeTheta_isLittleO_of_finite hS)
 
 /-- **Transfer of a linear asymptotic from `ψ` to `ϑ`.**  If the higher prime powers of `S` are
 negligible and `ψ(x) = δ x + o(x)`, then `ϑ(x) = δ x + o(x)`. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -41,8 +41,7 @@ system does not get that hypothesis for free; what it has to supply is the domin
   standard weight restricted to any set of prime powers containing exactly the primes of `S`.
 * `TauCeti.primePsi_sub_primeTheta` identifies `ψ - ϑ` with the higher-prime-power sum.
 * `TauCeti.primePsi_le_ncard_mul_log`: a finite set of primes contributes at most `#S · log x` to
-  `ψ`, which is the Chebotarev roadmap's Layer 11.3 third discard estimate as stated there, with
-  `TauCeti.primePsi_isBigO_log_of_finite` and `TauCeti.primePsi_isLittleO_of_finite` its
+  `ψ`, with `TauCeti.primePsi_isBigO_log_of_finite` and `TauCeti.primePsi_isLittleO_of_finite` its
   asymptotic forms.
 * `TauCeti.standardPrimePowerRemoval` proves `HasNegligibleHigherPrimePowers K S` for every `S`,
   from the Layer 5 estimate `ψ(x) - ϑ(x) = O(√x log² x)`.
@@ -233,47 +232,12 @@ theorem standardPrimePowerRemoval (K : Type*) [Field K] [NumberField K]
   rw [hasNegligibleHigherPrimePowers_iff]
   simpa only [primePsi_sub_primeTheta] using primePowerSummatory_indicator_isLittleO K S
 
-/-- The prime powers of a fixed base `v` and norm at most `x` carry total weight at most `log x`:
-their exponents are distinct and each is at most `log x / log N(v)`. -/
-private theorem card_fiber_mul_log_le (v : HeightOneSpectrum (𝓞 K)) (hx : 1 ≤ x)
-    {F : Finset (IdealPrimePower K)}
-    (hF : ∀ A ∈ F, ((Ideal.absNorm v.asIdeal : ℝ)) ^ primePowerExponent A ≤ x)
-    (hbase : ∀ A ∈ F, primePowerBase A = v) :
-    (F.card : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x := by
-  classical
-  have hlogx : 0 ≤ Real.log x := Real.log_nonneg hx
-  have hLpos : 0 < Real.log (Ideal.absNorm v.asIdeal) :=
-    Real.log_pos (by linarith [two_le_absNorm_asIdeal_real v])
-  have hexpbound : ∀ A ∈ F,
-      primePowerExponent A ∈ Finset.Icc 1 ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
-    intro A hA
-    have hlog : (primePowerExponent A : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x := by
-      have := Real.log_le_log
-        (pow_pos (by linarith [two_le_absNorm_asIdeal_real v]) _) (hF A hA)
-      rwa [Real.log_pow] at this
-    exact Finset.mem_Icc.mpr
-      ⟨primePowerExponent_pos A, Nat.le_floor ((le_div_iff₀ hLpos).mpr hlog)⟩
-  have hcard : F.card ≤ ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
-    refine le_trans (Finset.card_le_card_of_injOn primePowerExponent hexpbound ?_) ?_
-    · exact fun A hA B hB h ↦
-        idealPrimePower_eq_of_base_eq_of_exponent_eq ((hbase A hA).trans (hbase B hB).symm) h
-    · rw [Nat.card_Icc]; omega
-  calc (F.card : ℝ) * Real.log (Ideal.absNorm v.asIdeal)
-      ≤ (⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ : ℝ)
-        * Real.log (Ideal.absNorm v.asIdeal) :=
-        mul_le_mul_of_nonneg_right (by exact_mod_cast hcard) hLpos.le
-    _ ≤ Real.log x := by
-        rw [← le_div_iff₀ hLpos]
-        exact Nat.floor_le (by positivity)
-
 /-- **A finite set of primes contributes at most `#S · log x` to `ψ`.** Fibring over the prime
 base, the exponents `k ≥ 1` with `N(𝔭) ^ k ≤ x` contribute at most `log x` in total for each of the
 finitely many `𝔭`.
 
-This is the third of the four discard estimates the Chebotarev roadmap's Layer 11.3 asks for, in
-the form stated there: `∑_{𝔭 ∈ T} ∑_{N𝔭^j ≤ x} log N𝔭 ≤ #T · log x`. Its exceptional sets are
-`ramifiedPrimes`, the primes of an intermediate field above them, and the primes ramified in a
-compositum but not below. -/
+A counting argument can therefore discard a finite exceptional set of primes — those ramifying in
+an extension, say, or lying above such — at a cost of `O(log x)`. -/
 theorem primePsi_le_ncard_mul_log (hS : S.Finite) (hx : 1 ≤ x) :
     primePsi K S x ≤ S.ncard * Real.log x := by
   classical
@@ -305,7 +269,7 @@ theorem primePsi_le_ncard_mul_log (hS : S.Finite) (hx : 1 ≤ x) :
   refine (Finset.sum_le_card_nsmul _ _ (Real.log x) ?_).trans ?_
   · intro v _
     rw [Finset.sum_const, nsmul_eq_mul]
-    exact card_fiber_mul_log_le v hx (fun A hA ↦ by
+    exact card_fiber_mul_log_absNorm_le hx (fun A hA ↦ by
       obtain ⟨hle, -⟩ := hmemT A (Finset.mem_of_mem_filter _ hA)
       rwa [(Finset.mem_filter.mp hA).2] at hle)
       (fun A hA ↦ (Finset.mem_filter.mp hA).2)

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -73,6 +73,8 @@ theorem of Layer 9.
 * H. Davenport, *Multiplicative Number Theory*, Chapter 7.
 * G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapter I.2.
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII.
+* `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(3), for the `O(log x)` cost of discarding
+  a finite set of primes from `ψ`, which the estimates below supply.
 
 The rational-prime case of `ψ`, `ϑ` and their difference is Mathlib's
 `Mathlib/NumberTheory/Chebyshev.lean`, whose `Chebyshev.theta_le_psi` and

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -68,6 +68,9 @@ package `PrimeBoundaryRemainder`, carrying the `LSeriesHasSum` and boundary-cont
 and the asymptotic `primePsi_asymptotic_of_boundary` it yields — waits on the Wiener–Ikehara
 theorem of Layer 9.
 
+The finite-set bound is stated in `TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(3)**, as
+`∑_{𝔭 ∈ T} ∑_{𝔑𝔭 ^ j ≤ x} log 𝔑𝔭 ≤ #T * log x`; that is `primePsi_le_ncard_mul_log` below.
+
 ## References
 
 * H. Davenport, *Multiplicative Number Theory*, Chapter 7.

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -73,8 +73,6 @@ theorem of Layer 9.
 * H. Davenport, *Multiplicative Number Theory*, Chapter 7.
 * G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapter I.2.
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII.
-* `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(3), for the `O(log x)` cost of discarding
-  a finite set of primes from `ψ`, which the estimates below supply.
 
 The rational-prime case of `ψ`, `ϑ` and their difference is Mathlib's
 `Mathlib/NumberTheory/Chebyshev.lean`, whose `Chebyshev.theta_le_psi` and
@@ -243,7 +241,10 @@ an extension, say, or lying above such — at a cost of `O(log x)`.
 
 The fibre step is `TauCeti.card_fiber_mul_log_absNorm_le`, which was factored out of
 `TauCeti.higherPrimePowerTheta_le_card_primesLE_mul_log`: that theorem first made this
-exponent-counting argument, for exponents `k ≥ 2`, and both estimates now share it. -/
+exponent-counting argument, for exponents `k ≥ 2`, and both estimates now share it.
+
+The `O(log x)` rate is what `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(3), asks of this
+estimate. -/
 theorem primePsi_le_ncard_mul_log (hS : S.Finite) (hx : 1 ≤ x) :
     primePsi K S x ≤ S.ncard * Real.log x := by
   classical

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -248,8 +248,6 @@ estimate. -/
 theorem primePsi_le_ncard_mul_log (hS : S.Finite) (hx : 1 ≤ x) :
     primePsi K S x ≤ S.ncard * Real.log x := by
   classical
-  have hx0 : (0 : ℝ) < x := lt_of_lt_of_le zero_lt_one hx
-  have hlogx : 0 ≤ Real.log x := Real.log_nonneg hx
   set T := (primePowersLE K x).filter (fun A ↦ primePowerBase A ∈ S) with hTdef
   have hmemT : ∀ A ∈ T, ((Ideal.absNorm (primePowerBase A).asIdeal : ℝ)) ^ primePowerExponent A
       ≤ x ∧ primePowerBase A ∈ S := by

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -40,8 +40,10 @@ system does not get that hypothesis for free; what it has to supply is the domin
 * `TauCeti.primePowerSummatory_indicator_sub_primeTheta` splits the exponent-one part off the
   standard weight restricted to any set of prime powers containing exactly the primes of `S`.
 * `TauCeti.primePsi_sub_primeTheta` identifies `ψ - ϑ` with the higher-prime-power sum.
-* `TauCeti.primePsi_isLittleO_of_finite`: a finite set of primes is negligible for `ψ`, the form
-  the Chebotarev roadmap's Layer 11.3 third discard estimate consumes.
+* `TauCeti.primePsi_le_ncard_mul_log`: a finite set of primes contributes at most `#S · log x` to
+  `ψ`, which is the Chebotarev roadmap's Layer 11.3 third discard estimate as stated there, with
+  `TauCeti.primePsi_isBigO_log_of_finite` and `TauCeti.primePsi_isLittleO_of_finite` its
+  asymptotic forms.
 * `TauCeti.standardPrimePowerRemoval` proves `HasNegligibleHigherPrimePowers K S` for every `S`,
   from the Layer 5 estimate `ψ(x) - ϑ(x) = O(√x log² x)`.
 * `TauCeti.primeTheta_asymptotic_of_primePsi` and
@@ -231,18 +233,99 @@ theorem standardPrimePowerRemoval (K : Type*) [Field K] [NumberField K]
   rw [hasNegligibleHigherPrimePowers_iff]
   simpa only [primePsi_sub_primeTheta] using primePowerSummatory_indicator_isLittleO K S
 
-open Asymptotics Filter in
-/-- **A finite set of primes carries a negligible weight in `ψ` too.** Unlike `ϑ`, the sum does not
-become constant — higher powers of a fixed prime keep entering as the cutoff grows — but the whole
-higher-power tail is `o(x)` for any set at all, so the two estimates add.
+/-- The prime powers of a fixed base `v` and norm at most `x` carry total weight at most `log x`:
+their exponents are distinct and each is at most `log x / log N(v)`. -/
+private theorem card_fiber_mul_log_le (v : HeightOneSpectrum (𝓞 K)) (hx : 1 ≤ x)
+    {F : Finset (IdealPrimePower K)}
+    (hF : ∀ A ∈ F, ((Ideal.absNorm v.asIdeal : ℝ)) ^ primePowerExponent A ≤ x)
+    (hbase : ∀ A ∈ F, primePowerBase A = v) :
+    (F.card : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x := by
+  classical
+  have hlogx : 0 ≤ Real.log x := Real.log_nonneg hx
+  have hLpos : 0 < Real.log (Ideal.absNorm v.asIdeal) :=
+    Real.log_pos (by linarith [two_le_absNorm_asIdeal_real v])
+  have hexpbound : ∀ A ∈ F,
+      primePowerExponent A ∈ Finset.Icc 1 ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
+    intro A hA
+    have hlog : (primePowerExponent A : ℝ) * Real.log (Ideal.absNorm v.asIdeal) ≤ Real.log x := by
+      have := Real.log_le_log
+        (pow_pos (by linarith [two_le_absNorm_asIdeal_real v]) _) (hF A hA)
+      rwa [Real.log_pow] at this
+    exact Finset.mem_Icc.mpr
+      ⟨primePowerExponent_pos A, Nat.le_floor ((le_div_iff₀ hLpos).mpr hlog)⟩
+  have hcard : F.card ≤ ⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ := by
+    refine le_trans (Finset.card_le_card_of_injOn primePowerExponent hexpbound ?_) ?_
+    · exact fun A hA B hB h ↦
+        idealPrimePower_eq_of_base_eq_of_exponent_eq ((hbase A hA).trans (hbase B hB).symm) h
+    · rw [Nat.card_Icc]; omega
+  calc (F.card : ℝ) * Real.log (Ideal.absNorm v.asIdeal)
+      ≤ (⌊Real.log x / Real.log (Ideal.absNorm v.asIdeal)⌋₊ : ℝ)
+        * Real.log (Ideal.absNorm v.asIdeal) :=
+        mul_le_mul_of_nonneg_right (by exact_mod_cast hcard) hLpos.le
+    _ ≤ Real.log x := by
+        rw [← le_div_iff₀ hLpos]
+        exact Nat.floor_le (by positivity)
 
-This is the `ψ` form the Chebotarev roadmap's Layer 11.3 asks for in its third discard estimate,
-where the exceptional set is `ramifiedPrimes`, the primes of an intermediate field above it, or the
-primes ramified in a compositum but not below. `TauCeti.primeTheta_isLittleO_of_finite` is the `ϑ`
-companion. -/
+/-- **A finite set of primes contributes at most `#S · log x` to `ψ`.** Fibring over the prime
+base, the exponents `k ≥ 1` with `N(𝔭) ^ k ≤ x` contribute at most `log x` in total for each of the
+finitely many `𝔭`.
+
+This is the third of the four discard estimates the Chebotarev roadmap's Layer 11.3 asks for, in
+the form stated there: `∑_{𝔭 ∈ T} ∑_{N𝔭^j ≤ x} log N𝔭 ≤ #T · log x`. Its exceptional sets are
+`ramifiedPrimes`, the primes of an intermediate field above them, and the primes ramified in a
+compositum but not below. -/
+theorem primePsi_le_ncard_mul_log (hS : S.Finite) (hx : 1 ≤ x) :
+    primePsi K S x ≤ S.ncard * Real.log x := by
+  classical
+  have hx0 : (0 : ℝ) < x := lt_of_lt_of_le zero_lt_one hx
+  have hlogx : 0 ≤ Real.log x := Real.log_nonneg hx
+  set T := (primePowersLE K x).filter (fun A ↦ primePowerBase A ∈ S) with hTdef
+  have hmemT : ∀ A ∈ T, ((Ideal.absNorm (primePowerBase A).asIdeal : ℝ)) ^ primePowerExponent A
+      ≤ x ∧ primePowerBase A ∈ S := by
+    intro A hA
+    rw [hTdef, Finset.mem_filter, mem_normLE] at hA
+    refine ⟨?_, hA.2⟩
+    rw [← Nat.cast_pow, ← absNorm_eq_absNorm_primePowerBase_pow]
+    exact hA.1
+  have hsub : T ⊆ primePowersLE K x := Finset.filter_subset _ _
+  have hzero : ∀ A ∈ primePowersLE K x, A ∉ T →
+      {A : IdealPrimePower K | primePowerBase A ∈ S}.indicator primePowerWeight A = 0 := by
+    intro A hA hAT
+    refine Set.indicator_of_notMem ?_ _
+    intro hmem
+    exact hAT (Finset.mem_filter.mpr ⟨hA, hmem⟩)
+  have hsum : primePsi K S x = ∑ A ∈ T, Real.log (Ideal.absNorm (primePowerBase A).asIdeal) := by
+    rw [primePsi_apply, ← Finset.sum_subset hsub hzero]
+    exact Finset.sum_congr rfl fun A hA ↦
+      Set.indicator_of_mem (by simpa using (hmemT A hA).2) _
+  have hmaps : ∀ A ∈ T, primePowerBase A ∈ hS.toFinset := fun A hA ↦ by
+    simpa using (hmemT A hA).2
+  rw [hsum, ← Finset.sum_fiberwise_of_maps_to' hmaps
+    (fun v ↦ Real.log (Ideal.absNorm v.asIdeal))]
+  refine (Finset.sum_le_card_nsmul _ _ (Real.log x) ?_).trans ?_
+  · intro v _
+    rw [Finset.sum_const, nsmul_eq_mul]
+    exact card_fiber_mul_log_le v hx (fun A hA ↦ by
+      obtain ⟨hle, -⟩ := hmemT A (Finset.mem_of_mem_filter _ hA)
+      rwa [(Finset.mem_filter.mp hA).2] at hle)
+      (fun A hA ↦ (Finset.mem_filter.mp hA).2)
+  · rw [nsmul_eq_mul, Set.ncard_eq_toFinset_card S hS]
+
+open Asymptotics in
+/-- **A finite set of primes is `O(log x)` for `ψ`**, the asymptotic form of the bound above. -/
+theorem primePsi_isBigO_log_of_finite (hS : S.Finite) :
+    primePsi K S =O[atTop] Real.log := by
+  refine IsBigO.of_bound S.ncard ?_
+  filter_upwards [eventually_ge_atTop (1 : ℝ)] with x hx
+  rw [Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg (primePsi_nonneg _ _),
+    abs_of_nonneg (Real.log_nonneg hx)]
+  exact primePsi_le_ncard_mul_log hS hx
+
+open Asymptotics in
+/-- **A finite set of primes is negligible for `ψ`**, the form the total discard estimate sums. -/
 theorem primePsi_isLittleO_of_finite (hS : S.Finite) :
-    primePsi K S =o[atTop] fun x : ℝ ↦ x := by
-  simpa using (standardPrimePowerRemoval K S).add (primeTheta_isLittleO_of_finite hS)
+    primePsi K S =o[atTop] fun x : ℝ ↦ x :=
+  (primePsi_isBigO_log_of_finite hS).trans_isLittleO Real.isLittleO_log_id_atTop
 
 /-- **Transfer of a linear asymptotic from `ψ` to `ϑ`.**  If the higher prime powers of `S` are
 negligible and `ψ(x) = δ x + o(x)`, then `ϑ(x) = δ x + o(x)`. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -68,9 +68,6 @@ package `PrimeBoundaryRemainder`, carrying the `LSeriesHasSum` and boundary-cont
 and the asymptotic `primePsi_asymptotic_of_boundary` it yields — waits on the Wiener–Ikehara
 theorem of Layer 9.
 
-The finite-set bound is stated in `TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(3)**, as
-`∑_{𝔭 ∈ T} ∑_{𝔑𝔭 ^ j ≤ x} log 𝔑𝔭 ≤ #T * log x`; that is `primePsi_le_ncard_mul_log` below.
-
 ## References
 
 * H. Davenport, *Multiplicative Number Theory*, Chapter 7.

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -40,9 +40,9 @@ system does not get that hypothesis for free; what it has to supply is the domin
 * `TauCeti.primePowerSummatory_indicator_sub_primeTheta` splits the exponent-one part off the
   standard weight restricted to any set of prime powers containing exactly the primes of `S`.
 * `TauCeti.primePsi_sub_primeTheta` identifies `ψ - ϑ` with the higher-prime-power sum.
-* `TauCeti.primePsi_le_ncard_mul_log`: a finite set of primes contributes at most `#S · log x` to
-  `ψ`, with `TauCeti.primePsi_isBigO_log_of_finite` and `TauCeti.primePsi_isLittleO_of_finite` its
-  asymptotic forms.
+* `TauCeti.primePsi_le_ncard_mul_log`: for `x ≥ 1`, a finite set of primes contributes at most
+  `#S · log x` to `ψ`, with `TauCeti.primePsi_isBigO_log_of_finite` and
+  `TauCeti.primePsi_isLittleO_of_finite` its asymptotic forms.
 * `TauCeti.standardPrimePowerRemoval` proves `HasNegligibleHigherPrimePowers K S` for every `S`,
   from the Layer 5 estimate `ψ(x) - ϑ(x) = O(√x log² x)`.
 * `TauCeti.primeTheta_asymptotic_of_primePsi` and
@@ -232,15 +232,15 @@ theorem standardPrimePowerRemoval (K : Type*) [Field K] [NumberField K]
   rw [hasNegligibleHigherPrimePowers_iff]
   simpa only [primePsi_sub_primeTheta] using primePowerSummatory_indicator_isLittleO K S
 
-/-- **A finite set of primes contributes at most `#S · log x` to `ψ`.** Fibring over the prime
-base, the exponents `k ≥ 1` with `N(𝔭) ^ k ≤ x` contribute at most `log x` in total for each of the
-finitely many `𝔭`.
+/-- **For `x ≥ 1`, a finite set of primes contributes at most `#S · log x` to `ψ`.** Fibring over
+the prime base, the exponents `k ≥ 1` with `N(𝔭) ^ k ≤ x` contribute at most `log x` in total for
+each of the finitely many `𝔭`.
 
 A counting argument can therefore discard a finite exceptional set of primes — those ramifying in
 an extension, say, or lying above such — at a cost of `O(log x)`.
 
-The fibre step is `TauCeti.card_fiber_mul_log_absNorm_le`, which bounds the total weight of the
-prime powers over a single base by `log x`. -/
+The fibre step is `TauCeti.card_mul_log_absNorm_le_of_pow_le_of_base_eq`, which bounds the total
+weight of the prime powers over a single base by `log x`. -/
 theorem primePsi_le_ncard_mul_log (hS : S.Finite) (hx : 1 ≤ x) :
     primePsi K S x ≤ S.ncard * Real.log x := by
   classical
@@ -270,7 +270,7 @@ theorem primePsi_le_ncard_mul_log (hS : S.Finite) (hx : 1 ≤ x) :
   refine (Finset.sum_le_card_nsmul _ _ (Real.log x) ?_).trans ?_
   · intro v _
     rw [Finset.sum_const, nsmul_eq_mul]
-    exact card_fiber_mul_log_absNorm_le hx (fun A hA ↦ by
+    exact card_mul_log_absNorm_le_of_pow_le_of_base_eq hx (fun A hA ↦ by
       obtain ⟨hle, -⟩ := hmemT A (Finset.mem_of_mem_filter _ hA)
       rwa [(Finset.mem_filter.mp hA).2] at hle)
       (fun A hA ↦ (Finset.mem_filter.mp hA).2)

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/PrimePsi.lean
@@ -239,12 +239,8 @@ finitely many `𝔭`.
 A counting argument can therefore discard a finite exceptional set of primes — those ramifying in
 an extension, say, or lying above such — at a cost of `O(log x)`.
 
-The fibre step is `TauCeti.card_fiber_mul_log_absNorm_le`, which was factored out of
-`TauCeti.higherPrimePowerTheta_le_card_primesLE_mul_log`: that theorem first made this
-exponent-counting argument, for exponents `k ≥ 2`, and both estimates now share it.
-
-The `O(log x)` rate is what `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(3), asks of this
-estimate. -/
+The fibre step is `TauCeti.card_fiber_mul_log_absNorm_le`, which bounds the total weight of the
+prime powers over a single base by `log x`. -/
 theorem primePsi_le_ncard_mul_log (hS : S.Finite) (hx : 1 ≤ x) :
     primePsi K S x ≤ S.ncard * Real.log x := by
   classical

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
@@ -44,6 +44,7 @@ bound on the partial Dirichlet series that is *uniform* on `s ≥ 1`.
   `TauCeti.primeCount_higherDegreePrimes_isLittleO` its `O(√x)` and `o(x / log x)` forms.
 * `TauCeti.summable_absNorm_rpow_higherDegreePrimes`: `∑ N(𝔭) ^ (-s)` over the degree-above-one
   primes converges for every `s > 1/2`, in particular at `s = 1`.
+* `TauCeti.primeTheta_higherDegreePrimes_isLittleO`: those primes carry weight `o(x)` in `ϑ_K`.
 * `TauCeti.primeIdealZetaSum_higherDegreePrimes_le`: that sum, in Mathlib's
   `NumberField.Set.primeIdealZetaSum` vocabulary, is at most `2 [K : ℚ]` for every `s ≥ 1`.
 
@@ -164,6 +165,31 @@ is not available here, so this is not a statement of natural density zero. -/
 theorem primeCount_higherDegreePrimes_isLittleO :
     primeCount K (higherDegreePrimes K) =o[atTop] fun x ↦ x / Real.log x :=
   primeCount_higherDegreePrimes_isBigO.trans_isLittleO sqrt_isLittleO_div_log
+
+private theorem count_mul_log_isLittleO :
+    (fun x : ℝ ↦ primeCount K (higherDegreePrimes K) x * Real.log x) =o[atTop] fun x : ℝ ↦ x := by
+  refine (primeCount_higherDegreePrimes_isLittleO.mul_isBigO
+    (isBigO_refl (fun x : ℝ ↦ Real.log x) atTop)).trans_isBigO (IsBigO.of_bound 1 ?_)
+  filter_upwards [eventually_gt_atTop (1 : ℝ)] with x hx
+  have hlog : 0 < Real.log x := Real.log_pos hx
+  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_of_pos (by positivity),
+    div_mul_cancel₀ _ hlog.ne']
+  exact le_abs_self x
+
+/-- **The primes of residue degree above one carry a negligible weight.** Their contribution to
+`ϑ_K` is `o(x)`.
+
+This is the count `o(x / log x)` above, weighted by Chebyshev's `log x` per prime. It is the
+estimate a contraction between two number fields discards: the norms satisfy
+`𝔑_{E/ℚ}𝔓 = (𝔑_{K/ℚ}𝔭)^{f(𝔓/𝔭)}`, so a term of `ϑ` moves to a different value of `n` unless the
+relative residue degree is one, and `f(𝔓/𝔭) ≥ 2` forces `f(𝔓/p) ≥ 2`, which is what this absolute
+statement covers. -/
+theorem primeTheta_higherDegreePrimes_isLittleO (K : Type*) [Field K] [NumberField K] :
+    primeTheta K (higherDegreePrimes K) =o[atTop] fun x : ℝ ↦ x := by
+  refine IsBigO.trans_isLittleO (IsBigO.of_bound 1 (.of_forall fun x ↦ ?_))
+    (count_mul_log_isLittleO (K := K))
+  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg (primeTheta_nonneg _ _)]
+  exact (primeTheta_le_primeCount_mul_log _ x).trans (le_abs_self _)
 
 /-! ### Convergence of the prime Dirichlet series over the degree-above-one primes -/
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
@@ -77,6 +77,10 @@ available the bound below turns into the Dirichlet-density-zero statement.  The 
 `Chebotarev` as the consumer that needs these estimates when moving between a field and a fixed
 subfield.
 
+`TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(2)** is also a source for the statement proved
+here, not only its consumer: it gives the estimate, its rate `O(√x log x) = o(x)`, and the argument
+that `𝔑𝔭 = p ^ f ≤ x` with `f ≥ 2` forces `p ≤ √x`.
+
 ## References
 
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII, §13.

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
@@ -183,11 +183,7 @@ This is the count `o(x / log x)` above, weighted by Chebyshev's `log x` per prim
 estimate a contraction between two number fields discards: the norms satisfy
 `𝔑_{E/ℚ}𝔓 = (𝔑_{K/ℚ}𝔭)^{f(𝔓/𝔭)}`, so a term of `ϑ` moves to a different value of `n` unless the
 relative residue degree is one, and `f(𝔓/𝔭) ≥ 2` forces `f(𝔓/p) ≥ 2`, which is what this absolute
-statement covers.
-
-The need for this as a separately named theorem comes from the Chebotarev roadmap
-(`Chebotarev/README.md` Layer 11.3, second discard estimate), which states it in exactly this
-form. -/
+statement covers. -/
 theorem primeTheta_higherDegreePrimes_isLittleO (K : Type*) [Field K] [NumberField K] :
     primeTheta K (higherDegreePrimes K) =o[atTop] fun x : ℝ ↦ x := by
   refine IsBigO.trans_isLittleO (IsBigO.of_bound 1 (.of_forall fun x ↦ ?_))

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
@@ -166,16 +166,6 @@ theorem primeCount_higherDegreePrimes_isLittleO :
     primeCount K (higherDegreePrimes K) =o[atTop] fun x ↦ x / Real.log x :=
   primeCount_higherDegreePrimes_isBigO.trans_isLittleO sqrt_isLittleO_div_log
 
-private theorem count_mul_log_isLittleO :
-    (fun x : ℝ ↦ primeCount K (higherDegreePrimes K) x * Real.log x) =o[atTop] fun x : ℝ ↦ x := by
-  refine (primeCount_higherDegreePrimes_isLittleO.mul_isBigO
-    (isBigO_refl (fun x : ℝ ↦ Real.log x) atTop)).trans_isBigO (IsBigO.of_bound 1 ?_)
-  filter_upwards [eventually_gt_atTop (1 : ℝ)] with x hx
-  have hlog : 0 < Real.log x := Real.log_pos hx
-  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_of_pos (by positivity),
-    div_mul_cancel₀ _ hlog.ne']
-  exact le_abs_self x
-
 /-- **The primes of residue degree above one carry a negligible weight.** Their contribution to
 `ϑ_K` is `o(x)`.
 
@@ -183,14 +173,10 @@ This is the count `o(x / log x)` above, weighted by Chebyshev's `log x` per prim
 estimate a contraction between two number fields discards: the norms satisfy
 `𝔑_{E/ℚ}𝔓 = (𝔑_{K/ℚ}𝔭)^{f(𝔓/𝔭)}`, so a term of `ϑ` moves to a different value of `n` unless the
 relative residue degree is one, and `f(𝔓/𝔭) ≥ 2` forces `f(𝔓/p) ≥ 2`, which is what this absolute
-statement covers. This is the residue-degree discard
-`TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(2), asks for. -/
+statement covers. -/
 theorem primeTheta_higherDegreePrimes_isLittleO (K : Type*) [Field K] [NumberField K] :
-    primeTheta K (higherDegreePrimes K) =o[atTop] fun x : ℝ ↦ x := by
-  refine IsBigO.trans_isLittleO (IsBigO.of_bound 1 (.of_forall fun x ↦ ?_))
-    (count_mul_log_isLittleO (K := K))
-  rw [one_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg (primeTheta_nonneg _ _)]
-  exact (primeTheta_le_primeCount_mul_log _ x).trans (le_abs_self _)
+    primeTheta K (higherDegreePrimes K) =o[atTop] fun x : ℝ ↦ x :=
+  primeTheta_isLittleO_of_primeCount_isLittleO primeCount_higherDegreePrimes_isLittleO
 
 /-! ### Convergence of the prime Dirichlet series over the degree-above-one primes -/
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
@@ -82,8 +82,6 @@ subfield.
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII, §13.
 * J.-P. Serre, *A Course in Arithmetic*, Chapter VI, and J. Milne, *Algebraic Number Theory*,
   Chapter VIII, for the same estimate in the Dirichlet-density setting.
-* `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(2), for the negligible weight of the primes
-  of residue degree above one.
 -/
 
 public section
@@ -185,7 +183,8 @@ This is the count `o(x / log x)` above, weighted by Chebyshev's `log x` per prim
 estimate a contraction between two number fields discards: the norms satisfy
 `𝔑_{E/ℚ}𝔓 = (𝔑_{K/ℚ}𝔭)^{f(𝔓/𝔭)}`, so a term of `ϑ` moves to a different value of `n` unless the
 relative residue degree is one, and `f(𝔓/𝔭) ≥ 2` forces `f(𝔓/p) ≥ 2`, which is what this absolute
-statement covers. -/
+statement covers. This is the residue-degree discard
+`TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(2), asks for. -/
 theorem primeTheta_higherDegreePrimes_isLittleO (K : Type*) [Field K] [NumberField K] :
     primeTheta K (higherDegreePrimes K) =o[atTop] fun x : ℝ ↦ x := by
   refine IsBigO.trans_isLittleO (IsBigO.of_bound 1 (.of_forall fun x ↦ ?_))

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
@@ -82,6 +82,8 @@ subfield.
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII, §13.
 * J.-P. Serre, *A Course in Arithmetic*, Chapter VI, and J. Milne, *Algebraic Number Theory*,
   Chapter VIII, for the same estimate in the Dirichlet-density setting.
+* `TauCetiRoadmap/Chebotarev/README.md`, Layer 11.3(2), for the negligible weight of the primes
+  of residue degree above one.
 -/
 
 public section

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
@@ -77,10 +77,6 @@ available the bound below turns into the Dirichlet-density-zero statement.  The 
 `Chebotarev` as the consumer that needs these estimates when moving between a field and a fixed
 subfield.
 
-`TauCetiRoadmap/Chebotarev/README.md`, Layer **11.3(2)** is also a source for the statement proved
-here, not only its consumer: it gives the estimate, its rate `O(√x log x) = o(x)`, and the argument
-that `𝔑𝔭 = p ^ f ≤ x` with `f ≥ 2` forces `p ≤ √x`.
-
 ## References
 
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII, §13.

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/ResidueDegree.lean
@@ -183,7 +183,11 @@ This is the count `o(x / log x)` above, weighted by Chebyshev's `log x` per prim
 estimate a contraction between two number fields discards: the norms satisfy
 `𝔑_{E/ℚ}𝔓 = (𝔑_{K/ℚ}𝔭)^{f(𝔓/𝔭)}`, so a term of `ϑ` moves to a different value of `n` unless the
 relative residue degree is one, and `f(𝔓/𝔭) ≥ 2` forces `f(𝔓/p) ≥ 2`, which is what this absolute
-statement covers. -/
+statement covers.
+
+The need for this as a separately named theorem comes from the Chebotarev roadmap
+(`Chebotarev/README.md` Layer 11.3, second discard estimate), which states it in exactly this
+form. -/
 theorem primeTheta_higherDegreePrimes_isLittleO (K : Type*) [Field K] [NumberField K] :
     primeTheta K (higherDegreePrimes K) =o[atTop] fun x : ℝ ↦ x := by
   refine IsBigO.trans_isLittleO (IsBigO.of_bound 1 (.of_forall fun x ↦ ?_))


### PR DESCRIPTION
Two negligible-weight estimates for the logarithmically weighted prime count `ϑ_K`:

Roadmap: ArithmeticDirichletSeries

```lean
theorem primeTheta_higherDegreePrimes_isLittleO (K : Type*) [Field K] [NumberField K] :
    primeTheta K (higherDegreePrimes K) =o[atTop] fun x : ℝ ↦ x

theorem primePsi_le_ncard_mul_log (hS : S.Finite) (hx : 1 ≤ x) :
    primePsi K S x ≤ S.ncard * Real.log x

theorem primePsi_isBigO_log_of_finite (hS : S.Finite) :
    primePsi K S =O[atTop] Real.log

theorem primePsi_isLittleO_of_finite (hS : S.Finite) :
    primePsi K S =o[atTop] fun x : ℝ ↦ x

theorem primeTheta_isLittleO_of_finite (hS : S.Finite) :
    primeTheta K S =o[atTop] fun x : ℝ ↦ x
```

These are the second and third of the four discard estimates in Chebotarev's Layer 11.3 — the
ones a weighted crossing throws away so that the transfer is an argument rather than a
restatement. (The first, prime powers `j ≥ 2`, is already on `main` as
`standardPrimePowerRemoval` and its Chebotarev specialisation
`frobeniusPsi_sub_frobeniusTheta_isLittleO`.)

### Both are assembly, not new analysis

`main` already has all three ingredients; what it does not have is either conclusion.

* `primeCount_higherDegreePrimes_isLittleO` counts the primes of residue degree above one as
  `o(x / log x)`. Weighting each by Chebyshev's `primeTheta_le_primeCount_mul_log` — at most
  `log x` apiece — turns that into `o(x)`. The only real step is that `o(x/log x) · log x` is
  `o(x)`, which is the private `count_mul_log_isLittleO`.
* `eventually_primeCount_eq_card` says a finite set's count is eventually its cardinality, so the
  same Chebyshev comparison bounds its weight by `#S · log x`, and `Real.isLittleO_log_id_atTop`
  finishes. The estimate is really `O(log x)`; `o(x)` is the form the consumer wants.

Proofs are four, six and eight lines. Nothing is re-derived.

### Why these are worth stating

Both conclusions look one step from their hypotheses, and that is exactly why they should be
named once rather than unfolded at each crossing. The residue-degree estimate in particular is
the one a *contraction between two number fields* needs: since
`𝔑_{E/ℚ}𝔓 = (𝔑_{K/ℚ}𝔭)^{f(𝔓/𝔭)}`, a term of `ϑ` moves to a different `n` unless the relative
residue degree is one, and `f(𝔓/𝔭) ≥ 2` forces `f(𝔓/p) ≥ 2` — so the absolute statement proved
here covers the relative situation. The finite-set estimate is what allows an exceptional set
(the ramified primes, or the primes of an intermediate field above them) to be discarded from a
*counting* argument outright, not merely from a density.

### Placement, and one thing worth a reviewer's eye

Each theorem sits immediately after the single lemma it consumes: the residue-degree estimate
after `primeCount_higherDegreePrimes_isLittleO` in `ResidueDegree.lean`, the finite-set estimate
after `eventually_primeCount_eq_card` in `Counting.lean`. Neither file needs a new import.

**The `Counting.lean` placement is the debatable one.** That file's docstring describes itself as
ADS Layer 4 and says "Layer 5 supplies the actual size estimates for these counts", and a
`o(x)` bound is a size estimate. I put it there anyway because its only supplier lives there, and
because the file already hosts a finite-set statement whose stated purpose is to feed a later
layer — `eventually_primeCount_eq_card` is documented as "the input to the Layer 7 statement that
a finite set of primes has Dirichlet density zero". If a reviewer would rather it moved to a
Layer 5 file, say so and I will move it; I did not want to create a new file for one theorem.

The theorem is guarded by a local `open Asymptotics Filter in` rather than a file-level `open`,
because `Counting.lean` deliberately keeps both namespaces closed and writes `Filter.atTop`
qualified throughout.

---

## Review round 1 — all three findings implemented, none contested

* **scope** — correct, and the more serious of the two. Layer 11.3(3) is about the *inclusive
  prime-power* sum, `∑_{𝔭 ∈ T} ∑_{𝔑𝔭^j ≤ x} log 𝔑𝔭`, and I had only proved the `ϑ` form. A `ψ`
  theorem now supplies it — see the round-2 note below for the rate.
* **reuse** — the `ϑ` proof no longer detours through `primeCount` and Chebyshev's `log x`. It goes
  straight through `eventually_summatory_eq_sum`, which gives something strictly better than the
  old route: for a finite set the weighted sum is **eventually constant**, not merely `O(log x)`.
  The docstring now says so.
* **attribution** — the Chebotarev Layer 11.3 credit lived in the four module docstrings for a
  while, and has since been removed: `documentation` ruled on this PR and on #5812 that roadmap
  layer numbers do not belong in a module docstring and that the credit belongs here, in the PR
  description. It is here — the `Roadmap:` line above and the Layer 11.3(2)/(3) description near
  the top of this body. `PrimePsi.lean`'s Main results list names the new theorem.

## Review round 2 — the `correctness` block, and why it was right

Round 1's `ψ` theorem proved `o(x)` while citing Layer 11.3(3), which asks for `O(log x)`. I said
so explicitly in this description rather than implying the sharper rate — but the reviewer's point
stands and is stronger than mine: **a declaration that cites a roadmap item should supply it.**
Deriving the estimate from the unrestricted prime-power tail threw away exactly the finite-set
content that makes the rate `O(log x)`.

So the bound is now proved at the roadmap's rate. `primePsi_le_ncard_mul_log` fibres the prime
powers over their base and counts exponents: for each of the finitely many `𝔭`, the `k ≥ 1` with
`𝔑𝔭^k ≤ x` number at most `⌊log x / log 𝔑𝔭⌋`, so that fibre contributes at most `log x`. This is
the same argument `higherPrimePowerTheta_le_card_primesLE_mul_log` already makes in
`HigherPrimePowers.lean` for exponents `k ≥ 2`; the exponent-count core is factored out as the
private `card_fiber_mul_log_le`, which keeps both proofs near 25 lines. `=O[atTop] Real.log` and
the `o(x)` corollary now follow from it rather than from the tail estimate.

Verified after the rework: axioms exactly `propext`, `Classical.choice`, `Quot.sound`; every line
within 100 characters; `scripts/lint-dot-notation.py` reports **0 new**; both proofs are within the
30-line guidance after decomposition; and `Chebotarev.PrimeCounting.VonMangoldt` and
`ArithmeticDirichletSeries.Transfer` rebuild green.

### Absence

Untruncated greps over `main` for `primeTheta.*higherDegree`, `higherDegree.*primeTheta` and
`primeTheta.*isLittleO` return no weighted estimate of either kind. `primeTheta` and
`higherDegreePrimes` are Tau Ceti notions and do not exist in Mathlib at all. Not adapted from
`CBirkbeck/chebotarev-density` either: that development's density argument is Dirichlet-series
based and builds no `ϑ`/`ψ` counting functions, so it has no counterpart to either statement. No
`Provenance` line is owed.

That attribution is right because both statements are generic — an arbitrary number field, an arbitrary finite set of primes, no
conjugacy class or Frobenius anywhere — and they live in ADS files. Chebotarev's README puts
"density calculus" under *Out of scope* and says those exclusions are ownership boundaries
supplied by the roadmaps it names, which is the same reasoning that moved #5572 from `Chebotarev`
to `ArithmeticDirichletSeries` after a scope review. Chebotarev Layer 11.3 is the consumer, not
the owner.

No `tauceti-target:v1` marker: these supply prerequisites rather than authoring a named target.

### On the cleanup pass

`lean-lsp` has been unreachable this whole session, so `/cleanup` 6.5 and 6.6 were discharged
directly. 6.6 by `#count_heartbeats`: **289** heartbeats against the 200000 default. 6.5 by hand.
Axioms are exactly `propext`, `Classical.choice` and `Quot.sound`; every line is within 100
characters; and all three downstream importers — `AbelSummation`, `HigherPrimePowers` and
`Chebotarev.PrimeCounting.VonMangoldt` — rebuild green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF


