### PR TITLE
feat(Multiquadratic): every product-one sign pattern is a narrow class of ℚ(√d)

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/Independence.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/GenusCharacter/Independence.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.GenusCharacter.SplitPrime
+import TauCeti.NumberTheory.Multiquadratic.Legendre.PrimeDiscriminant.Dirichlet
+
+/-!
+# Independence of the genus characters of a quadratic field
+
+Let `K = ℚ(√d)` with `d` squarefree, and let `D = P₁ ⋯ P_t` be the prime-discriminant
+factorization of its fundamental discriminant. The genus characters `χ_{P_i}` are characters of the
+narrow class group `Cl⁺(K)` (`genusCharFunNarrowClassGroupHom`), and their product over all `i` is
+trivial on every class. This file proves that this is the **only** relation among them: every
+assignment of signs `ε_i = ±1` with `∏ ε_i = 1` is the vector of values `(χ_{P_i}(A))_i` at some
+narrow class `A`. In other words the map `Cl⁺(K) → {±1}^t` they define hits the whole
+product-one hyperplane, which has `2^(t-1)` elements.
+
+This is the lower bound half of the genus-theoretic `2`-rank formula for the narrow class group,
+`rank₂ Cl⁺(K) ≥ t - 1`; the matching upper bound is
+`TauCeti.Multiquadratic.narrowTwoRank_le_ncard_ramifiedPrimes_sub_one`. See D. A. Cox, *Primes of
+the Form x² + ny²*, §3.B and §6.A, and F. Lemmermeyer, *Reciprocity Laws: From Euler to
+Eisenstein*, §2.2.
+
+## Main results
+
+* `TauCeti.Multiquadratic.exists_forall_genusCharFunNarrowClassGroupHom_singleton_eq`: every sign
+  pattern of product `1` on the prime discriminants of `D` is the value vector of the singleton
+  genus characters at some narrow class.
+* `TauCeti.Multiquadratic.exists_forall_genusCharFunNarrowClassGroupHom_subset_eq`: the same class
+  has the prescribed product of signs as the value of every subset-indexed genus character.
+-/
+
+public section
+
+open Polynomial
+open scoped NumberField nonZeroDivisors
+
+namespace TauCeti.Multiquadratic
+
+open NumberField
+
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
+
+/-- **Every sign pattern of product one is attained by a narrow class.** Let `K = ℚ(√d)` with `d`
+squarefree, let `∏ P ∈ s, P = fundamentalDiscriminant d` be the prime-discriminant factorization,
+and let `ε` assign a sign to each `P ∈ s` with `∏ P ∈ s, ε P = 1`. Then some narrow class `A` has
+`χ_P(A) = ε P` for every `P ∈ s`. -/
+theorem exists_forall_genusCharFunNarrowClassGroupHom_singleton_eq
+    {s : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (ε : ℤ → ℤˣ) (hε : ∏ P ∈ s, ε P = 1) :
+    ∃ A : NarrowClassGroup K, ∀ P (hP : P ∈ s),
+      genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf
+        (Finset.singleton_subset_iff.mpr hP) A = ε P := by
+  obtain ⟨q, -, hq, hq2, hqε⟩ :=
+    exists_prime_gt_forall_primeDiscriminantCharFun_eq hs heven ε 0
+  have : Fact q.Prime := ⟨hq⟩
+  have hgc : genusCharFun s (q : ℤ) = 1 := by
+    rw [genusCharFun_def, Finset.prod_congr rfl fun P hP => hqε P hP, ← Units.coe_prod, hε,
+      Units.val_one]
+  obtain ⟨A, hA⟩ :=
+    exists_forall_genusCharFunNarrowClassGroupHom_eq hs heven hprod hmin hgen hsf hq2 hgc
+  refine ⟨A, fun P hP => Units.ext ?_⟩
+  rw [hA P hP, hqε P hP]
+
+/-- **Every sign pattern of product one is attained, on all subset characters at once.** Under the
+hypotheses of `exists_forall_genusCharFunNarrowClassGroupHom_singleton_eq`, some narrow class `A`
+has `χ_t(A) = ∏ P ∈ t, ε P` for every subset `t ⊆ s` simultaneously. -/
+theorem exists_forall_genusCharFunNarrowClassGroupHom_subset_eq
+    {s : Finset ℤ} (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ P' ∈ s, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant P' → P = P')
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (ε : ℤ → ℤˣ) (hε : ∏ P ∈ s, ε P = 1) :
+    ∃ A : NarrowClassGroup K, ∀ t (hts : t ⊆ s),
+      genusCharFunNarrowClassGroupHom hs heven hprod hmin hgen hsf hts A = ∏ P ∈ t, ε P := by
+  obtain ⟨A, hA⟩ :=
+    exists_forall_genusCharFunNarrowClassGroupHom_singleton_eq hs heven hprod hmin hgen hsf ε hε
+  refine ⟨A, fun t hts => ?_⟩
+  rw [genusCharFunNarrowClassGroupHom_eq_prod_singleton hs heven hprod hmin hgen hsf hts,
+    MonoidHom.finsetProd_apply, ← Finset.prod_coe_sort t]
+  exact Finset.prod_congr rfl fun P _ => hA P (hts P.2)
+
+end TauCeti.Multiquadratic


### PR DESCRIPTION
Let `K = ℚ(√d)` with `d` squarefree and let `D = ∏ P ∈ s, P` be the prime-discriminant factorization of its fundamental discriminant. The genus characters `χ_P` are characters of the narrow class group `Cl⁺(K)` (`genusCharFunNarrowClassGroupHom`, in `main`). This PR proves that every assignment of signs `ε_P = ±1` with `∏ ε_P = 1` is attained: some narrow class `A` has `χ_P(A) = ε_P` for all `P ∈ s` (`exists_forall_genusCharFunNarrowClassGroupHom_singleton_eq`), and then `χ_t(A) = ∏_{P ∈ t} ε_P` for every subset `t ⊆ s` (`exists_forall_genusCharFunNarrowClassGroupHom_eq`). The class is that of a degree-one prime ideal above an odd prime `q > |d|` at which each `χ_P` takes the value `ε_P` (`exists_prime_gt_forall_primeDiscriminantCharFun_eq`, #5766); `(d/q) = (D/q) = ∏ ε_P = 1`, so `q` splits (`ncard_primesOver_quadratic_iff`) and a prime above it has absolute norm `q`. Two small Legendre-symbol prerequisites are added in their own canonical files: multiplicativity over finite products (`TauCeti.legendreSym_prod`, new `NumberTheory/LegendreSymbol/Basic.lean`) and `legendreSym q (fundamentalDiscriminant d) = legendreSym q d` at odd `q` (new `Multiquadratic/Legendre/FundamentalDiscriminant.lean`, reusing `legendreSym_mul_sq`).

**Why.** This is the independence of the genus characters — the lower-bound half of the real quadratic `2`-rank formula. The upper bound `narrowTwoRank_le_ncard_ramifiedPrimes_sub_one` is in `main`; the follow-up PR turns this surjectivity onto the product-one hyperplane into `t - 1 ≤ 2-rank Cl⁺(K)` and the equality.

**Roadmap node.** `TauCetiRoadmap/Multiquadratic/README.md`, heading *### Layer 3: the genus field and the 2-rank theorem (the summit)*: "The 2-rank formula `= t − 1` … is a theorem about the *narrow* class group … the `t − 1` count needs the narrow class group" — the real-quadratic lower bound, listed in `STATUS.md` as the first frontier item ("Real narrow 2-rank formula … descend the coprime-ideal genus characters to enough independent characters of `Cl⁺(K)/Cl⁺(K)²`"). Intention: TauCetiRoadmap#332. New file `Quadratic/GenusCharacter/Independence.lean`; the splitting law, the degree-one-prime criterion and Dirichlet's theorem are imported privately (proof-only). No new axioms.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"TauCetiRoadmap/Multiquadratic/README.md#layer-3-narrow-two-rank-lower-bound/genus-character-independence"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WouEDwRYZVr9YqX9VFj8wa
