### PR TITLE
refactor(OptimalTransport): drop an unused `AEMeasurable` binding in `replaceMarginal`

### DIFF
--- a/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Replacement.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Replacement.lean
@@ -63,10 +63,6 @@ def replaceMarginal (π : ProbabilityMeasure (∀ j, X j)) (i : ι)
     dsimp only [γ]
     infer_instance
   letI := Classical.decEq ι
-  let hu : AEMeasurable (fun q : (∀ j, X j) × X i × X i ↦
-      Function.update q.1 i q.2.2) γ :=
-    (measurable_update'.comp
-      (measurable_fst.prodMk (measurable_snd.comp measurable_snd))).aemeasurable
   exact (⟨γ.map (fun q ↦ Function.update q.1 i q.2.2),
     inferInstance⟩ : ProbabilityMeasure (∀ j, X j))
 


### PR DESCRIPTION
`replaceMarginal` bound

```lean
let hu : AEMeasurable (fun q : (∀ j, X j) × X i × X i ↦
    Function.update q.1 i q.2.2) γ :=
  (measurable_update'.comp
    (measurable_fst.prodMk (measurable_snd.comp measurable_snd))).aemeasurable
```

and then never referred to `hu`. It is not reaching the following `inferInstance` either:
`AEMeasurable` is a plain definition rather than a class, so instance search has no way to
use a hypothesis of that type. The surrounding block is explicit about the difference — it
writes `letI` for the three bindings it *does* mean as instances (`IsProbabilityMeasure ρ`,
`IsProbabilityMeasure γ`, `Classical.decEq ι`) and a plain `let` for this one.

The `IsProbabilityMeasure (γ.map _)` that `inferInstance` needs is supplied by Mathlib's
unconditional instance

```lean
instance {f : α → β} : IsProbabilityMeasure (map f μ)
```

in `Mathlib/MeasureTheory/Measure/Typeclasses/Probability.lean`. It takes no measurability
hypothesis — the non-measurable branch is discharged inside its own proof — and requires
only the `letI : IsProbabilityMeasure γ` already in scope. (Mathlib's results that *do* take
an `AEMeasurable` argument here, `Measure.isProbabilityMeasure_of_map` and
`Measure.isProbabilityMeasure_map_iff`, are theorems, not instances, and run in the opposite
direction.)

The definition and its statement are unchanged; this only removes the dead binding.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp