### PR TITLE
feat: add nebentypus Hecke ring actions

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -298,14 +298,10 @@ operation used to transport left-coset multiplicities arising from right slash a
 noncomputable def atkinLehnerAutomorphism : GL (Fin 2) ℚ ≃* GL (Fin 2) ℚ :=
   (MulEquiv.inv' (GL (Fin 2) ℚ)).trans (atkinLehnerEquiv N).symm
 
-/-- The ambient automorphism is the Atkin–Lehner bar applied after inversion.
-
-Deliberately not a `simp` lemma: the simp-normal form of this automorphism is the abstract
-one given by `atkinLehnerAutomorphism_involutive` and `atkinLehnerAutomorphism_symm`. Simp
-rewrites innermost first, so with this lemma in the default set the inner application in
-`f (f x)` unfolds to the matrix conjugation before the involutivity lemma can fire, and
-`simpNF` rejects the pair. Use `rw [atkinLehnerAutomorphism_apply]` where the entries are
-what is wanted. -/
+/-- The ambient automorphism is the Atkin–Lehner bar applied after inversion. -/
+-- This is deliberately not a simp lemma: simp rewrites inner applications first, preventing
+-- `atkinLehnerAutomorphism_involutive` from normalizing nested applications. Use `rw` when the
+-- matrix entries are wanted.
 lemma atkinLehnerAutomorphism_apply (x : GL (Fin 2) ℚ) :
     atkinLehnerAutomorphism N x = natDiagGL 2 ![1, N] *
       (transposeGLEquiv 2 x⁻¹).unop * (natDiagGL 2 ![1, N])⁻¹ :=

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -304,27 +304,33 @@ noncomputable def atkinLehnerAutomorphism : GL (Fin 2) ℚ ≃* GL (Fin 2) ℚ :
       (transposeGLEquiv 2 x⁻¹).unop * (natDiagGL 2 ![1, N])⁻¹ :=
   (rfl)
 
+/-- Coercing the ambient automorphism to a monoid hom does not change its value. -/
+private lemma atkinLehnerAutomorphism_toMonoidHom_apply (x : GL (Fin 2) ℚ) :
+    (atkinLehnerAutomorphism N : GL (Fin 2) ℚ →* GL (Fin 2) ℚ) x =
+      atkinLehnerAutomorphism N x :=
+  (rfl)
+
 /-- The ambient Atkin–Lehner automorphism is involutive. -/
-lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
+@[simp] lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
     atkinLehnerAutomorphism N (atkinLehnerAutomorphism N x) = x := by
-  change (atkinLehnerHom N ((atkinLehnerHom N x⁻¹).unop)⁻¹).unop = x
+  rw [atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop,
+    atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop]
   rw [map_inv, MulOpposite.unop_inv, atkinLehnerHom_involutive, inv_inv]
 
 /-- The ambient Atkin–Lehner automorphism preserves the image of `Γ₀(N)`. -/
-theorem atkinLehnerAutomorphism_map_Gamma0 [NeZero N] :
+@[simp] theorem atkinLehnerAutomorphism_map_Gamma0 [NeZero N] :
     ((Gamma0 N).map (mapGL ℚ)).map (atkinLehnerAutomorphism N :
         GL (Fin 2) ℚ →* GL (Fin 2) ℚ) = (Gamma0 N).map (mapGL ℚ) := by
   ext x
   constructor
   · rintro ⟨y, hy, rfl⟩
-    change atkinLehnerAutomorphism N y ∈ (Gamma0 N).map (mapGL ℚ)
-    change (atkinLehnerHom N y⁻¹).unop ∈ (Gamma0 N).map (mapGL ℚ)
+    rw [atkinLehnerAutomorphism_toMonoidHom_apply, atkinLehnerAutomorphism_apply,
+      ← atkinLehnerHom_unop]
     rw [← Gamma0Image_def] at hy ⊢
     exact atkinLehnerHom_mem_Gamma0Image N y⁻¹ (inv_mem hy)
   · intro hx
     refine ⟨atkinLehnerAutomorphism N x, ?_, atkinLehnerAutomorphism_involutive N x⟩
-    change atkinLehnerAutomorphism N x ∈ (Gamma0 N).map (mapGL ℚ)
-    change (atkinLehnerHom N x⁻¹).unop ∈ (Gamma0 N).map (mapGL ℚ)
+    rw [atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop]
     rw [← Gamma0Image_def] at hx ⊢
     exact atkinLehnerHom_mem_Gamma0Image N x⁻¹ (inv_mem hx)
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -311,7 +311,7 @@ private lemma atkinLehnerAutomorphism_toMonoidHom_apply (x : GL (Fin 2) ℚ) :
   (rfl)
 
 /-- The ambient Atkin–Lehner automorphism is involutive. -/
-@[simp] lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
+lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
     atkinLehnerAutomorphism N (atkinLehnerAutomorphism N x) = x := by
   rw [atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop,
     atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop]

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -65,6 +65,7 @@ commutative semiring.
 ## Main definitions
 
 * `HeckeRing.GL2.atkinLehnerAntiInvolution`: the anti-involution of the `Γ₀(N)` Hecke pair.
+* `HeckeRing.GL2.atkinLehnerAutomorphism`: the automorphism `g ↦ ι(g⁻¹)` of the ambient group.
 * `HeckeRing.GL2.commSemiringHeckeRingGamma0`: for nonzero level `N`, the resulting
   commutative-semiring structure on the Hecke ring `R(Γ₀(N), Δ₀(N))`.
 
@@ -169,6 +170,16 @@ private lemma atkinLehnerHom_involutive (g : GL (Fin 2) ℚ) :
     rw [map_inv, MulOpposite.unop_inv, transposeGLEquiv_natDiagGL 2 ![1, N]]
   rw [h_tr, transposeGLEquiv_transposeGLEquiv, transposeGLEquiv_natDiagGL 2 ![1, N], h_inv]
   group
+
+/-- The ambient Atkin–Lehner anti-involution as an equivalence with the opposite group. -/
+private noncomputable def atkinLehnerEquiv : GL (Fin 2) ℚ ≃* (GL (Fin 2) ℚ)ᵐᵒᵖ where
+  toFun := atkinLehnerHom N
+  invFun g := (atkinLehnerHom N g.unop).unop
+  left_inv := atkinLehnerHom_involutive N
+  right_inv g := by
+    apply MulOpposite.unop_injective
+    exact atkinLehnerHom_involutive N g.unop
+  map_mul' := map_mul (atkinLehnerHom N)
 
 /-- The entries of `ι(g)`: `(a, b; N c, e) ↦ (a, c; N b, e)`, as an integral matrix. Gives the
 value lemma, the determinant lemma and the two membership proofs one spelling instead of four
@@ -280,12 +291,55 @@ noncomputable def atkinLehnerAntiInvolution [NeZero N] :
       exact atkinLehnerHom_mem_Gamma0Image N g hg)
     (atkinLehnerHom_mem_Delta0 N)
 
+/-- The automorphism of the ambient group sending `g` to the Atkin–Lehner bar of `g⁻¹`.
+
+Composing two order reversals makes this multiplicative. It is the form of the Atkin–Lehner
+operation used to transport left-coset multiplicities arising from right slash actions. -/
+noncomputable def atkinLehnerAutomorphism : GL (Fin 2) ℚ ≃* GL (Fin 2) ℚ :=
+  (MulEquiv.inv' (GL (Fin 2) ℚ)).trans (atkinLehnerEquiv N).symm
+
+/-- The ambient automorphism is the Atkin–Lehner bar applied after inversion. -/
+@[simp] lemma atkinLehnerAutomorphism_apply (x : GL (Fin 2) ℚ) :
+    atkinLehnerAutomorphism N x = natDiagGL 2 ![1, N] *
+      (transposeGLEquiv 2 x⁻¹).unop * (natDiagGL 2 ![1, N])⁻¹ :=
+  (rfl)
+
+/-- The ambient Atkin–Lehner automorphism is involutive. -/
+lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
+    atkinLehnerAutomorphism N (atkinLehnerAutomorphism N x) = x := by
+  change (atkinLehnerHom N ((atkinLehnerHom N x⁻¹).unop)⁻¹).unop = x
+  rw [map_inv, MulOpposite.unop_inv, atkinLehnerHom_involutive, inv_inv]
+
+/-- The ambient Atkin–Lehner automorphism preserves the image of `Γ₀(N)`. -/
+theorem atkinLehnerAutomorphism_map_Gamma0 [NeZero N] :
+    ((Gamma0 N).map (mapGL ℚ)).map (atkinLehnerAutomorphism N :
+        GL (Fin 2) ℚ →* GL (Fin 2) ℚ) = (Gamma0 N).map (mapGL ℚ) := by
+  ext x
+  constructor
+  · rintro ⟨y, hy, rfl⟩
+    change atkinLehnerAutomorphism N y ∈ (Gamma0 N).map (mapGL ℚ)
+    change (atkinLehnerHom N y⁻¹).unop ∈ (Gamma0 N).map (mapGL ℚ)
+    rw [← Gamma0Image_def] at hy ⊢
+    exact atkinLehnerHom_mem_Gamma0Image N y⁻¹ (inv_mem hy)
+  · intro hx
+    refine ⟨atkinLehnerAutomorphism N x, ?_, atkinLehnerAutomorphism_involutive N x⟩
+    change atkinLehnerAutomorphism N x ∈ (Gamma0 N).map (mapGL ℚ)
+    change (atkinLehnerHom N x⁻¹).unop ∈ (Gamma0 N).map (mapGL ℚ)
+    rw [← Gamma0Image_def] at hx ⊢
+    exact atkinLehnerHom_mem_Gamma0Image N x⁻¹ (inv_mem hx)
+
 /-- The anti-involution acts by conjugating the transpose by `w`, unfolding the sealed
 definition. -/
 @[simp] lemma atkinLehnerAntiInvolution_bar [NeZero N] {x : GL (Fin 2) ℚ} (hx : x ∈ Delta0 N) :
     (atkinLehnerAntiInvolution N).bar x hx =
       natDiagGL 2 ![1, N] * (transposeGLEquiv 2 x).unop * (natDiagGL 2 ![1, N])⁻¹ :=
   HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx
+
+/-- On an inverse from `Δ₀(N)`, the ambient automorphism is the restricted Atkin–Lehner bar. -/
+lemma atkinLehnerAutomorphism_inv_apply [NeZero N] {x : GL (Fin 2) ℚ}
+    (hx : x ∈ Delta0 N) :
+    atkinLehnerAutomorphism N x⁻¹ = (atkinLehnerAntiInvolution N).bar x hx := by
+  rw [atkinLehnerAutomorphism_apply, inv_inv, atkinLehnerAntiInvolution_bar]
 
 /-- **The entrywise action**, on the bundle: `(a, b; N c, e) ↦ (a, c; N b, e)`. This is the
 form a consumer of `Δ₀(N)` elements needs; without it the entries can only be recovered by

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -299,7 +299,7 @@ noncomputable def atkinLehnerAutomorphism : GL (Fin 2) ℚ ≃* GL (Fin 2) ℚ :
   (MulEquiv.inv' (GL (Fin 2) ℚ)).trans (atkinLehnerEquiv N).symm
 
 /-- The ambient automorphism is the Atkin–Lehner bar applied after inversion. -/
-lemma atkinLehnerAutomorphism_apply (x : GL (Fin 2) ℚ) :
+@[simp] lemma atkinLehnerAutomorphism_apply (x : GL (Fin 2) ℚ) :
     atkinLehnerAutomorphism N x = natDiagGL 2 ![1, N] *
       (transposeGLEquiv 2 x⁻¹).unop * (natDiagGL 2 ![1, N])⁻¹ :=
   (rfl)
@@ -311,20 +311,11 @@ private lemma atkinLehnerAutomorphism_toMonoidHom_apply (x : GL (Fin 2) ℚ) :
   (rfl)
 
 /-- The ambient Atkin–Lehner automorphism is involutive. -/
-@[simp] lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
+lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
     atkinLehnerAutomorphism N (atkinLehnerAutomorphism N x) = x := by
   rw [atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop,
     atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop]
   rw [map_inv, MulOpposite.unop_inv, atkinLehnerHom_involutive, inv_inv]
-
-/-- The ambient Atkin–Lehner automorphism is its own inverse. -/
-@[simp] theorem atkinLehnerAutomorphism_symm :
-    (atkinLehnerAutomorphism N).symm = atkinLehnerAutomorphism N := by
-  apply MulEquiv.ext
-  intro x
-  apply (atkinLehnerAutomorphism N).injective
-  rw [(atkinLehnerAutomorphism N).apply_symm_apply,
-    atkinLehnerAutomorphism_involutive]
 
 /-- The ambient Atkin–Lehner automorphism preserves the image of `Γ₀(N)`. -/
 @[simp] theorem atkinLehnerAutomorphism_map_Gamma0 [NeZero N] :

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -299,7 +299,7 @@ noncomputable def atkinLehnerAutomorphism : GL (Fin 2) ℚ ≃* GL (Fin 2) ℚ :
   (MulEquiv.inv' (GL (Fin 2) ℚ)).trans (atkinLehnerEquiv N).symm
 
 /-- The ambient automorphism is the Atkin–Lehner bar applied after inversion. -/
-@[simp] lemma atkinLehnerAutomorphism_apply (x : GL (Fin 2) ℚ) :
+lemma atkinLehnerAutomorphism_apply (x : GL (Fin 2) ℚ) :
     atkinLehnerAutomorphism N x = natDiagGL 2 ![1, N] *
       (transposeGLEquiv 2 x⁻¹).unop * (natDiagGL 2 ![1, N])⁻¹ :=
   (rfl)
@@ -311,11 +311,20 @@ private lemma atkinLehnerAutomorphism_toMonoidHom_apply (x : GL (Fin 2) ℚ) :
   (rfl)
 
 /-- The ambient Atkin–Lehner automorphism is involutive. -/
-lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
+@[simp] lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
     atkinLehnerAutomorphism N (atkinLehnerAutomorphism N x) = x := by
   rw [atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop,
     atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop]
   rw [map_inv, MulOpposite.unop_inv, atkinLehnerHom_involutive, inv_inv]
+
+/-- The ambient Atkin–Lehner automorphism is its own inverse. -/
+@[simp] theorem atkinLehnerAutomorphism_symm :
+    (atkinLehnerAutomorphism N).symm = atkinLehnerAutomorphism N := by
+  apply MulEquiv.ext
+  intro x
+  apply (atkinLehnerAutomorphism N).injective
+  rw [(atkinLehnerAutomorphism N).apply_symm_apply,
+    atkinLehnerAutomorphism_involutive]
 
 /-- The ambient Atkin–Lehner automorphism preserves the image of `Γ₀(N)`. -/
 @[simp] theorem atkinLehnerAutomorphism_map_Gamma0 [NeZero N] :

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -298,8 +298,15 @@ operation used to transport left-coset multiplicities arising from right slash a
 noncomputable def atkinLehnerAutomorphism : GL (Fin 2) ℚ ≃* GL (Fin 2) ℚ :=
   (MulEquiv.inv' (GL (Fin 2) ℚ)).trans (atkinLehnerEquiv N).symm
 
-/-- The ambient automorphism is the Atkin–Lehner bar applied after inversion. -/
-@[simp] lemma atkinLehnerAutomorphism_apply (x : GL (Fin 2) ℚ) :
+/-- The ambient automorphism is the Atkin–Lehner bar applied after inversion.
+
+Deliberately not a `simp` lemma: the simp-normal form of this automorphism is the abstract
+one given by `atkinLehnerAutomorphism_involutive` and `atkinLehnerAutomorphism_symm`. Simp
+rewrites innermost first, so with this lemma in the default set the inner application in
+`f (f x)` unfolds to the matrix conjugation before the involutivity lemma can fire, and
+`simpNF` rejects the pair. Use `rw [atkinLehnerAutomorphism_apply]` where the entries are
+what is wanted. -/
+lemma atkinLehnerAutomorphism_apply (x : GL (Fin 2) ℚ) :
     atkinLehnerAutomorphism N x = natDiagGL 2 ![1, N] *
       (transposeGLEquiv 2 x⁻¹).unop * (natDiagGL 2 ![1, N])⁻¹ :=
   (rfl)
@@ -311,11 +318,17 @@ private lemma atkinLehnerAutomorphism_toMonoidHom_apply (x : GL (Fin 2) ℚ) :
   (rfl)
 
 /-- The ambient Atkin–Lehner automorphism is involutive. -/
-lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
+@[simp] lemma atkinLehnerAutomorphism_involutive (x : GL (Fin 2) ℚ) :
     atkinLehnerAutomorphism N (atkinLehnerAutomorphism N x) = x := by
   rw [atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop,
     atkinLehnerAutomorphism_apply, ← atkinLehnerHom_unop]
   rw [map_inv, MulOpposite.unop_inv, atkinLehnerHom_involutive, inv_inv]
+
+/-- The ambient Atkin–Lehner automorphism is its own inverse. -/
+@[simp] theorem atkinLehnerAutomorphism_symm :
+    (atkinLehnerAutomorphism N).symm = atkinLehnerAutomorphism N :=
+  MulEquiv.ext fun x ↦ (atkinLehnerAutomorphism N).injective <| by
+    rw [(atkinLehnerAutomorphism N).apply_symm_apply, atkinLehnerAutomorphism_involutive]
 
 /-- The ambient Atkin–Lehner automorphism preserves the image of `Γ₀(N)`. -/
 @[simp] theorem atkinLehnerAutomorphism_map_Gamma0 [NeZero N] :

--- a/TauCeti/NumberTheory/HeckeRing/Multiplicity/Equiv.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplicity/Equiv.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.Associativity
+
+/-!
+# Transporting Hecke multiplicities along group equivalences
+
+The double-coset multiplicity is unchanged when the ambient group, its three subgroups, and
+the three elements are transported along a group equivalence. This is the naturality needed
+when a concrete Hecke action presents the structure constants after applying an automorphism of
+the ambient group.
+
+## Main results
+
+* `DoubleCoset.multiplicity_map_equiv`: transport of Shimura's multiplicity along a group
+  equivalence.
+* `DoubleCoset.multiplicity_doubleCoset_congr_second`: invariance in the second input.
+* `DoubleCoset.multiplicity_doubleCoset_congr_first_of_comm`: invariance in the first input when
+  the multiplicity is symmetric.
+-/
+
+public section
+
+open Subgroup
+
+namespace DoubleCoset
+
+variable {G K : Type*} [Group G] [Group K]
+
+/-- Membership in a double coset is preserved by a group equivalence. -/
+lemma mem_doubleCoset_map_equiv_iff (e : G ≃* K) (H₁ H₂ : Subgroup G) (g x : G) :
+    (e : G →* K) x ∈ doubleCoset ((e : G →* K) g) (H₁.map (e : G →* K))
+        (H₂.map (e : G →* K)) ↔
+      x ∈ doubleCoset g H₁ H₂ := by
+  constructor
+  · intro hx
+    obtain ⟨a, ha, b, hb, hab⟩ := mem_doubleCoset.mp hx
+    obtain ⟨a', ha', rfl⟩ := ha
+    obtain ⟨b', hb', rfl⟩ := hb
+    refine mem_doubleCoset.mpr ⟨a', ha', b', hb', e.injective ?_⟩
+    rw [map_mul, map_mul]
+    exact hab
+  · intro hx
+    obtain ⟨a, ha, b, hb, rfl⟩ := mem_doubleCoset.mp hx
+    exact mem_doubleCoset.mpr ⟨(e : G →* K) a, ⟨a, ha, rfl⟩,
+      (e : G →* K) b, ⟨b, hb, rfl⟩, by simp only [map_mul]⟩
+
+/-- A group equivalence carries the decomposition quotient of `g` to that of its image. -/
+noncomputable def decompQuotientEquivMap (e : G ≃* K) (H₁ H₂ : Subgroup G) (g : G) :
+    DecompQuotient H₁ H₂ g ≃
+      DecompQuotient (H₁.map (e : G →* K)) (H₂.map (e : G →* K)) ((e : G →* K) g) := by
+  apply Quotient.congr (e.subgroupMap H₁).toEquiv
+  intro x y
+  simp only [QuotientGroup.leftRel_apply, Subgroup.mem_subgroupOf,
+    Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv,
+    ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv, Subgroup.coe_inv,
+    Subgroup.coe_mul]
+  change (g⁻¹ * ((x : G)⁻¹ * y) * g ∈ H₂) ↔
+    (((e : G →* K) g)⁻¹ * (((e : G →* K) (x : G))⁻¹ * (e : G →* K) (y : G)) *
+      (e : G →* K) g ∈ H₂.map (e : G →* K))
+  convert
+    (Subgroup.mem_map_iff_mem (f := (e : G →* K)) (K := H₂) e.injective
+      (x := g⁻¹ * ((x : G)⁻¹ * y) * g)).symm using 1
+  simp only [map_inv, map_mul]
+
+/-- The image of a decomposition class represented by `x` is represented by `e x`. -/
+lemma decompQuotientEquivMap_mk (e : G ≃* K) (H₁ H₂ : Subgroup G) (g : G) (x : H₁) :
+    decompQuotientEquivMap e H₁ H₂ g (QuotientGroup.mk x) =
+      QuotientGroup.mk (e.subgroupMap H₁ x) :=
+  (rfl)
+
+/-- The chosen representative after transport differs from the transported representative by
+an element of the stabilizer. -/
+lemma decompQuotientEquivMap_out (e : G ≃* K) (H₁ H₂ : Subgroup G) (g : G)
+    (i : DecompQuotient H₁ H₂ g) :
+    ((e : G →* K) g)⁻¹ * (((decompQuotientEquivMap e H₁ H₂ g i).out : K)⁻¹ *
+      (e : G →* K) (i.out : G)) * (e : G →* K) g ∈ H₂.map (e : G →* K) := by
+  have hmk :
+      ((decompQuotientEquivMap e H₁ H₂ g i).out :
+          DecompQuotient (H₁.map (e : G →* K)) (H₂.map (e : G →* K)) ((e : G →* K) g)) =
+        (e.subgroupMap H₁ i.out :
+          DecompQuotient (H₁.map (e : G →* K)) (H₂.map (e : G →* K)) ((e : G →* K) g)) := by
+    calc
+      _ = decompQuotientEquivMap e H₁ H₂ g i := QuotientGroup.out_eq' _
+      _ = decompQuotientEquivMap e H₁ H₂ g (i.out : DecompQuotient H₁ H₂ g) :=
+        congrArg (decompQuotientEquivMap e H₁ H₂ g) (QuotientGroup.out_eq' i).symm
+      _ = _ := decompQuotientEquivMap_mk e H₁ H₂ g i.out
+  exact conj_mem_of_mk_eq ((e : G →* K) g) hmk
+
+/-- Shimura's multiplicity is unchanged when all of its data are transported along a group
+equivalence. -/
+theorem multiplicity_map_equiv (e : G ≃* K) (H₁ H₂ H₃ : Subgroup G) (g h d : G)
+    [Finite (DecompQuotient H₁ H₂ g)] [Finite (DecompQuotient H₂ H₃ h)] :
+    multiplicity (H₁.map (e : G →* K)) (H₂.map (e : G →* K)) (H₃.map (e : G →* K))
+        (e g) (e h) (e d) =
+      multiplicity H₁ H₂ H₃ g h d := by
+  change multiplicity (H₁.map (e : G →* K)) (H₂.map (e : G →* K))
+      (H₃.map (e : G →* K)) ((e : G →* K) g) ((e : G →* K) h)
+        ((e : G →* K) d) = multiplicity H₁ H₂ H₃ g h d
+  let eg := decompQuotientEquivMap e H₁ H₂ g
+  let eh := decompQuotientEquivMap e H₂ H₃ h
+  let : Finite (DecompQuotient (H₁.map (e : G →* K)) (H₂.map (e : G →* K))
+      ((e : G →* K) g)) := Finite.of_equiv _ eg
+  let : Finite (DecompQuotient (H₂.map (e : G →* K)) (H₃.map (e : G →* K))
+      ((e : G →* K) h)) := Finite.of_equiv _ eh
+  rw [multiplicity_eq_card_filter, multiplicity_eq_card_filter]
+  symm
+  refine Nat.card_congr (Equiv.subtypeEquiv eg fun i ↦ ?_)
+  simp only [Set.mem_ofPred_eq]
+  symm
+  have hn := decompQuotientEquivMap_out e H₁ H₂ g i
+  rw [show
+    (((eg i).out : K) * (e : G →* K) g)⁻¹ * (e : G →* K) d =
+      ((e : G →* K) g)⁻¹ * (((eg i).out : K)⁻¹ * (e : G →* K) (i.out : G)) *
+        (e : G →* K) g * (e : G →* K) (((i.out : G) * g)⁻¹ * d) by
+      simp only [map_mul, map_inv, mul_inv_rev]
+      simp only [mul_assoc, mul_inv_cancel_left],
+    mul_mem_doubleCoset_iff hn,
+    mem_doubleCoset_map_equiv_iff]
+
+/-- Shimura's multiplicity depends on its second input only through its double coset. -/
+theorem multiplicity_doubleCoset_congr_second {Δ : Submonoid G} (H₁ H₂ H₃ : Subgroup G)
+    [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] (g : Δ) {h h' : Δ} (d : G)
+    (hh : (h' : G) ∈ doubleCoset (h : G) H₂ H₃) :
+    multiplicity H₁ H₂ H₃ (g : G) (h' : G) d =
+      multiplicity H₁ H₂ H₃ (g : G) (h : G) d := by
+  rw [multiplicity_eq_card_filter, multiplicity_eq_card_filter,
+    doubleCoset_eq_of_mem hh]
+
+/-- If the multiplicity is symmetric in its two inputs, it depends on its first input only
+through its double coset as well. -/
+theorem multiplicity_doubleCoset_congr_first_of_comm {Δ : Submonoid G} (H : Subgroup G)
+    [IsHeckeTriple Δ H H]
+    (hcomm : ∀ a b d : Δ, multiplicity H H H (a : G) (b : G) (d : G) =
+      multiplicity H H H (b : G) (a : G) (d : G))
+    {g g' : Δ} (h d : Δ) (hg : (g' : G) ∈ doubleCoset (g : G) H H) :
+    multiplicity H H H (g' : G) (h : G) (d : G) =
+      multiplicity H H H (g : G) (h : G) (d : G) := by
+  calc
+    _ = multiplicity H H H (h : G) (g' : G) (d : G) := hcomm g' h d
+    _ = multiplicity H H H (h : G) (g : G) (d : G) :=
+      multiplicity_doubleCoset_congr_second H H H h d hg
+    _ = _ := (hcomm g h d).symm
+
+end DoubleCoset
+
+end

--- a/TauCeti/NumberTheory/HeckeRing/Multiplicity/Equiv.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplicity/Equiv.lean
@@ -7,6 +7,8 @@ module
 
 public import TauCeti.NumberTheory.HeckeRing.Associativity
 
+import TauCeti.NumberTheory.HeckeRing.StabConjugation
+
 /-!
 # Transporting Hecke multiplicities along group equivalences
 
@@ -60,6 +62,8 @@ noncomputable def decompQuotientEquivMap (e : G ≃* K) (H₁ H₂ : Subgroup G)
     Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv,
     ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv, Subgroup.coe_inv,
     Subgroup.coe_mul]
+  -- `Quotient.congr` exposes the source relation first and the transported relation second;
+  -- this ascription only names those two reducible relations so that `mem_map_iff_mem` applies.
   change (g⁻¹ * ((x : G)⁻¹ * y) * g ∈ H₂) ↔
     (((e : G →* K) g)⁻¹ * (((e : G →* K) (x : G))⁻¹ * (e : G →* K) (y : G)) *
       (e : G →* K) g ∈ H₂.map (e : G →* K))
@@ -93,57 +97,117 @@ lemma decompQuotientEquivMap_out (e : G ≃* K) (H₁ H₂ : Subgroup G) (g : G)
   exact conj_mem_of_mk_eq ((e : G →* K) g) hmk
 
 /-- Shimura's multiplicity is unchanged when all of its data are transported along a group
-equivalence. -/
-theorem multiplicity_map_equiv (e : G ≃* K) (H₁ H₂ H₃ : Subgroup G) (g h d : G)
-    [Finite (DecompQuotient H₁ H₂ g)] [Finite (DecompQuotient H₂ H₃ h)] :
+equivalence, without any finiteness hypothesis. -/
+theorem multiplicity_map_equiv (e : G ≃* K) (H₁ H₂ H₃ : Subgroup G) (g h d : G) :
     multiplicity (H₁.map (e : G →* K)) (H₂.map (e : G →* K)) (H₃.map (e : G →* K))
         (e g) (e h) (e d) =
       multiplicity H₁ H₂ H₃ g h d := by
-  change multiplicity (H₁.map (e : G →* K)) (H₂.map (e : G →* K))
-      (H₃.map (e : G →* K)) ((e : G →* K) g) ((e : G →* K) h)
-        ((e : G →* K) d) = multiplicity H₁ H₂ H₃ g h d
   let eg := decompQuotientEquivMap e H₁ H₂ g
   let eh := decompQuotientEquivMap e H₂ H₃ h
-  let : Finite (DecompQuotient (H₁.map (e : G →* K)) (H₂.map (e : G →* K))
-      ((e : G →* K) g)) := Finite.of_equiv _ eg
-  let : Finite (DecompQuotient (H₂.map (e : G →* K)) (H₃.map (e : G →* K))
-      ((e : G →* K) h)) := Finite.of_equiv _ eh
-  rw [multiplicity_eq_card_filter, multiplicity_eq_card_filter]
+  let c : DecompQuotient H₁ H₂ g → H₂.map (e : G →* K) := fun i ↦
+    ⟨((e : G →* K) g)⁻¹ * (((eg i).out : K)⁻¹ * (e : G →* K) (i.out : G)) *
+      (e : G →* K) g,
+      decompQuotientEquivMap_out e H₁ H₂ g i⟩
+  -- Transporting the first representative introduces the middle-subgroup correction `c i`.
+  -- Shearing the transported second quotient by it matches the full defining fibres directly.
+  let epairs := Equiv.prodShear eg fun i ↦ eh.trans (MulAction.toPerm (c i))
+  rw [multiplicity_def, multiplicity_def]
   symm
-  refine Nat.card_congr (Equiv.subtypeEquiv eg fun i ↦ ?_)
+  refine Nat.card_congr (Equiv.subtypeEquiv epairs fun p ↦ ?_)
+  obtain ⟨i, j⟩ := p
   simp only [Set.mem_ofPred_eq]
-  symm
-  have hn := decompQuotientEquivMap_out e H₁ H₂ g i
-  rw [show
-    (((eg i).out : K) * (e : G →* K) g)⁻¹ * (e : G →* K) d =
-      ((e : G →* K) g)⁻¹ * (((eg i).out : K)⁻¹ * (e : G →* K) (i.out : G)) *
-        (e : G →* K) g * (e : G →* K) (((i.out : G) * g)⁻¹ * d) by
-      simp only [map_mul, map_inv, mul_inv_rev]
-      simp only [mul_assoc, mul_inv_cancel_left],
-    mul_mem_doubleCoset_iff hn,
-    mem_doubleCoset_map_equiv_iff]
+  let q := c i • eh j
+  have hq : (QuotientGroup.mk q.out : DecompQuotient (H₂.map (e : G →* K))
+      (H₃.map (e : G →* K)) (e h)) =
+      QuotientGroup.mk (c i * (eh j).out) := by
+    calc
+      _ = q := QuotientGroup.out_eq' q
+      _ = c i • eh j := rfl
+      _ = c i • QuotientGroup.mk (eh j).out :=
+        congrArg (c i • ·) (QuotientGroup.out_eq' (eh j)).symm
+      _ = _ := by
+        rw [MulAction.Quotient.smul_mk, smul_eq_mul]
+        rfl
+  have hqmem := conj_mem_of_mk_eq ((e : G →* K) h) hq
+  have hjmem := decompQuotientEquivMap_out e H₂ H₃ h j
+  have hprod :
+      (((eg i).out : K) * (e : G →* K) g * ((q.out : K) * (e : G →* K) h) :
+          K ⧸ (H₃.map (e : G →* K))) =
+        ((e : G →* K) ((i.out : G) * g * ((j.out : G) * h)) :
+          K ⧸ (H₃.map (e : G →* K))) := by
+    rw [QuotientGroup.eq]
+    have hm := (H₃.map (e : G →* K)).mul_mem hqmem hjmem
+    dsimp only [q, c, eh, Subtype.coe_mk] at hm ⊢
+    simp only [Subgroup.coe_mul, map_mul, mul_inv_rev] at hm ⊢
+    simpa only [mul_assoc, mul_inv_cancel_left] using hm
+  -- Unfold only the pair equivalence so its second component is the named quotient `q` above.
+  dsimp only [epairs, Equiv.prodShear_apply, Equiv.trans_apply, MulAction.toPerm_apply]
+  change
+    (((i.out : G) * g * ((j.out : G) * h) : G ⧸ H₃) = (d : G ⧸ H₃)) ↔
+      ((((eg i).out : K) * (e : G →* K) g * ((q.out : K) * (e : G →* K) h) :
+          K ⧸ (H₃.map (e : G →* K))) =
+        ((e : G →* K) d : K ⧸ (H₃.map (e : G →* K))))
+  rw [hprod, QuotientGroup.eq, QuotientGroup.eq]
+  convert
+    (Subgroup.mem_map_iff_mem (f := (e : G →* K)) (K := H₃) e.injective
+      (x := ((i.out : G) * g * ((j.out : G) * h))⁻¹ * d)).symm using 1
+  all_goals simp only [map_inv, map_mul]
 
-/-- Shimura's multiplicity depends on its second input only through its double coset. -/
-theorem multiplicity_doubleCoset_congr_second {Δ : Submonoid G} (H₁ H₂ H₃ : Subgroup G)
-    [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] (g : Δ) {h h' : Δ} (d : G)
-    (hh : (h' : G) ∈ doubleCoset (h : G) H₂ H₃) :
-    multiplicity H₁ H₂ H₃ (g : G) (h' : G) d =
-      multiplicity H₁ H₂ H₃ (g : G) (h : G) d := by
-  rw [multiplicity_eq_card_filter, multiplicity_eq_card_filter,
-    doubleCoset_eq_of_mem hh]
+/-- Shimura's multiplicity depends on its second input only through its double coset, without
+any finiteness or Hecke-triple hypothesis. -/
+theorem multiplicity_doubleCoset_congr_second (H₁ H₂ H₃ : Subgroup G)
+    (g : G) {h h' : G} (d : G) (hh : h' ∈ doubleCoset h H₂ H₃) :
+    multiplicity H₁ H₂ H₃ g h' d = multiplicity H₁ H₂ H₃ g h d := by
+  obtain ⟨a, ha, b, hb, rfl⟩ := mem_doubleCoset.mp hh
+  let aN : Subgroup.normalizer (H₂ : Set G) := ⟨a, Subgroup.le_normalizer ha⟩
+  let eh := decompQuotientEquivMulLeftRight H₂ H₃ h aN (Subgroup.le_normalizer hb)
+  let epairs := Equiv.prodCongr (Equiv.refl (DecompQuotient H₁ H₂ g))
+    (eh.trans (MulAction.toPerm (⟨a, ha⟩ : H₂)))
+  rw [multiplicity_def, multiplicity_def]
+  refine Nat.card_congr (Equiv.subtypeEquiv epairs fun p ↦ ?_)
+  obtain ⟨i, j⟩ := p
+  simp only [Set.mem_ofPred_eq]
+  let q := (⟨a, ha⟩ : H₂) • eh j
+  have hq : (QuotientGroup.mk q.out : DecompQuotient H₂ H₃ h) =
+      QuotientGroup.mk (j.out * (⟨a, ha⟩ : H₂)) := by
+    calc
+      _ = q := QuotientGroup.out_eq' q
+      _ = (⟨a, ha⟩ : H₂) • eh j := rfl
+      _ = (⟨a, ha⟩ : H₂) • eh (QuotientGroup.mk j.out) :=
+        congrArg (fun x ↦ (⟨a, ha⟩ : H₂) • eh x) (QuotientGroup.out_eq' j).symm
+      _ = (⟨a, ha⟩ : H₂) • QuotientGroup.mk
+          ((H₂.normalizerMonoidHom aN).symm j.out) := by
+        rw [decompQuotientEquivMulLeftRight_mk]
+      _ = _ := by
+        rw [MulAction.Quotient.smul_mk, smul_eq_mul]
+        apply congrArg QuotientGroup.mk
+        ext
+        dsimp only [aN]
+        simp [Subgroup.normalizerMonoidHom, HSMul.hSMul, mul_assoc]
+  have hqmem := conj_mem_of_mk_eq h hq
+  have hprod :
+      ((i.out : G) * g * ((j.out : G) * (a * h * b)) : G ⧸ H₃) =
+        ((i.out : G) * g * ((q.out : G) * h) : G ⧸ H₃) := by
+    rw [QuotientGroup.eq]
+    have hm := H₃.mul_mem (H₃.inv_mem hb) (H₃.inv_mem hqmem)
+    simpa [mul_inv_rev, mul_assoc] using hm
+  -- As above, expose only the product equivalence and name its transported component `q`.
+  dsimp only [epairs, Equiv.prodCongr_apply, Equiv.refl_apply, Equiv.trans_apply,
+    MulAction.toPerm_apply]
+  change
+    (((i.out : G) * g * ((j.out : G) * (a * h * b)) : G ⧸ H₃) = (d : G ⧸ H₃)) ↔
+      (((i.out : G) * g * ((q.out : G) * h) : G ⧸ H₃) = (d : G ⧸ H₃))
+  rw [hprod]
 
 /-- If the multiplicity is symmetric in its two inputs, it depends on its first input only
 through its double coset as well. -/
-theorem multiplicity_doubleCoset_congr_first_of_comm {Δ : Submonoid G} (H : Subgroup G)
-    [IsHeckeTriple Δ H H]
-    (hcomm : ∀ a b d : Δ, multiplicity H H H (a : G) (b : G) (d : G) =
-      multiplicity H H H (b : G) (a : G) (d : G))
-    {g g' : Δ} (h d : Δ) (hg : (g' : G) ∈ doubleCoset (g : G) H H) :
-    multiplicity H H H (g' : G) (h : G) (d : G) =
-      multiplicity H H H (g : G) (h : G) (d : G) := by
+theorem multiplicity_doubleCoset_congr_first_of_comm (H : Subgroup G)
+    (hcomm : ∀ a b d : G, multiplicity H H H a b d = multiplicity H H H b a d)
+    {g g' : G} (h d : G) (hg : g' ∈ doubleCoset g H H) :
+    multiplicity H H H g' h d = multiplicity H H H g h d := by
   calc
-    _ = multiplicity H H H (h : G) (g' : G) (d : G) := hcomm g' h d
-    _ = multiplicity H H H (h : G) (g : G) (d : G) :=
+    _ = multiplicity H H H h g' d := hcomm g' h d
+    _ = multiplicity H H H h g d :=
       multiplicity_doubleCoset_congr_second H H H h d hg
     _ = _ := (hcomm g h d).symm
 

--- a/TauCeti/NumberTheory/HeckeRing/Multiplicity/Equiv.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplicity/Equiv.lean
@@ -36,8 +36,7 @@ variable {G K : Type*} [Group G] [Group K]
 
 /-- Membership in a double coset is preserved by a group equivalence. -/
 @[simp] lemma mem_doubleCoset_map_equiv_iff (e : G ≃* K) (H₁ H₂ : Subgroup G) (g x : G) :
-    (e : G →* K) x ∈ doubleCoset ((e : G →* K) g) (H₁.map (e : G →* K))
-        (H₂.map (e : G →* K)) ↔
+    e x ∈ doubleCoset (e g) (e '' (H₁ : Set G)) (e '' (H₂ : Set G)) ↔
       x ∈ doubleCoset g H₁ H₂ := by
   constructor
   · intro hx
@@ -49,13 +48,13 @@ variable {G K : Type*} [Group G] [Group K]
     exact hab
   · intro hx
     obtain ⟨a, ha, b, hb, rfl⟩ := mem_doubleCoset.mp hx
-    exact mem_doubleCoset.mpr ⟨(e : G →* K) a, ⟨a, ha, rfl⟩,
-      (e : G →* K) b, ⟨b, hb, rfl⟩, by simp only [map_mul]⟩
+    exact mem_doubleCoset.mpr ⟨e a, ⟨a, ha, rfl⟩,
+      e b, ⟨b, hb, rfl⟩, by simp only [map_mul]⟩
 
 /-- A group equivalence carries the decomposition quotient of `g` to that of its image. -/
 noncomputable def decompQuotientEquivMap (e : G ≃* K) (H₁ H₂ : Subgroup G) (g : G) :
     DecompQuotient H₁ H₂ g ≃
-      DecompQuotient (H₁.map (e : G →* K)) (H₂.map (e : G →* K)) ((e : G →* K) g) := by
+      DecompQuotient (H₁.map (e : G →* K)) (H₂.map (e : G →* K)) (e g) := by
   apply Quotient.congr (e.subgroupMap H₁).toEquiv
   intro x y
   simp only [QuotientGroup.leftRel_apply, Subgroup.mem_subgroupOf,
@@ -127,7 +126,6 @@ equivalence, without any finiteness hypothesis. -/
         congrArg (c i • ·) (QuotientGroup.out_eq' (eh j)).symm
       _ = _ := by
         rw [MulAction.Quotient.smul_mk, smul_eq_mul]
-        rfl
   have hqmem := conj_mem_of_mk_eq ((e : G →* K) h) hq
   have hjmem := decompQuotientEquivMap_out e H₂ H₃ h j
   have hprod :

--- a/TauCeti/NumberTheory/HeckeRing/Multiplicity/Equiv.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplicity/Equiv.lean
@@ -35,7 +35,7 @@ namespace DoubleCoset
 variable {G K : Type*} [Group G] [Group K]
 
 /-- Membership in a double coset is preserved by a group equivalence. -/
-lemma mem_doubleCoset_map_equiv_iff (e : G ≃* K) (H₁ H₂ : Subgroup G) (g x : G) :
+@[simp] lemma mem_doubleCoset_map_equiv_iff (e : G ≃* K) (H₁ H₂ : Subgroup G) (g x : G) :
     (e : G →* K) x ∈ doubleCoset ((e : G →* K) g) (H₁.map (e : G →* K))
         (H₂.map (e : G →* K)) ↔
       x ∈ doubleCoset g H₁ H₂ := by
@@ -73,7 +73,7 @@ noncomputable def decompQuotientEquivMap (e : G ≃* K) (H₁ H₂ : Subgroup G)
   simp only [map_inv, map_mul]
 
 /-- The image of a decomposition class represented by `x` is represented by `e x`. -/
-lemma decompQuotientEquivMap_mk (e : G ≃* K) (H₁ H₂ : Subgroup G) (g : G) (x : H₁) :
+@[simp] lemma decompQuotientEquivMap_mk (e : G ≃* K) (H₁ H₂ : Subgroup G) (g : G) (x : H₁) :
     decompQuotientEquivMap e H₁ H₂ g (QuotientGroup.mk x) =
       QuotientGroup.mk (e.subgroupMap H₁ x) :=
   (rfl)
@@ -98,7 +98,7 @@ lemma decompQuotientEquivMap_out (e : G ≃* K) (H₁ H₂ : Subgroup G) (g : G)
 
 /-- Shimura's multiplicity is unchanged when all of its data are transported along a group
 equivalence, without any finiteness hypothesis. -/
-theorem multiplicity_map_equiv (e : G ≃* K) (H₁ H₂ H₃ : Subgroup G) (g h d : G) :
+@[simp] theorem multiplicity_map_equiv (e : G ≃* K) (H₁ H₂ H₃ : Subgroup G) (g h d : G) :
     multiplicity (H₁.map (e : G →* K)) (H₂.map (e : G →* K)) (H₃.map (e : G →* K))
         (e g) (e h) (e d) =
       multiplicity H₁ H₂ H₃ g h d := by

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
@@ -104,8 +104,15 @@ theorem multiplicity_inv_reverse_eq (D₁ D₂ D : Coset₀(N)) :
         (b₂ : GL (Fin 2) ℚ) (b₁ : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
       multiplicity_doubleCoset_congr _ _ hb
     _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        (b₁ : GL (Fin 2) ℚ) (b₂ : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
+      hcomm b₂ b₁ D.rep
+    _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        (b₁ : GL (Fin 2) ℚ) (D₂.rep : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
+      multiplicity_doubleCoset_congr_second (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        b₁ D.rep hb₂
+    _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
         (D₂.rep : GL (Fin 2) ℚ) (b₁ : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
-      multiplicity_doubleCoset_congr_first_of_comm (Γ₀Q(N)) hcomm b₁ D.rep hb₂
+      (hcomm D₂.rep b₁ D.rep).symm
     _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
         (D₂.rep : GL (Fin 2) ℚ) (D₁.rep : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
       multiplicity_doubleCoset_congr_second (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
@@ -244,6 +251,9 @@ lemma coe_twistedHeckeSlashModularFormCharLinearMap
       rw [twistedHeckeSlashModularFormCharLinearMap_single,
         twistedHeckeSlashRingCharLinearMap_single]
       ext τ
+      -- Scalar multiplication is bundled independently on `Module.End`, the character
+      -- submodule, `ModularForm`, and functions. After evaluating at `τ`, `change` only exposes
+      -- those coercions; the two named `coe_...` lemmas then supply the substantive equality.
       change c • (⇑((twistedHeckeSlashModularFormCharEnd k χ D f :
         ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) : ℍ → ℂ) τ =
           c • (twistedHeckeSlashSumCharEnd k χ D
@@ -334,6 +344,8 @@ lemma coe_twistedHeckeSlashCuspFormCharLinearMap
       rw [twistedHeckeSlashCuspFormCharLinearMap_single,
         twistedHeckeSlashRingCharLinearMap_single]
       ext τ
+      -- As in the modular-form proof, this exposes only the four bundled scalar/coercion
+      -- layers after evaluation; the explicit coercion lemmas prove the mathematical step.
       change c • (⇑((twistedHeckeSlashCuspFormCharEnd k χ D f :
         CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) : ℍ → ℂ) τ =
           c • (twistedHeckeSlashSumCharEnd k χ D

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
@@ -1,0 +1,404 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.AtkinLehner
+public import TauCeti.NumberTheory.HeckeRing.LinearExtension
+public import TauCeti.NumberTheory.HeckeRing.Multiplicity.Equiv
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Composition
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.ModularForm
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.One
+
+/-!
+# The Hecke-ring action on nebentypus spaces
+
+The twisted slash operators give a right action, so composing the operators attached to `D₁`
+and `D₂` naturally produces the right-coset collision coefficient
+`m(D₂⁻¹, D₁⁻¹; D⁻¹)`. The multiplication of the Hecke ring instead uses
+`m(D₁, D₂; D)`. This file reconciles the two conventions using the Atkin–Lehner
+anti-involution of `Γ₀(N)`: composing it with inversion is an ambient automorphism preserving
+`Γ₀(N)`, and the Atkin–Lehner bar fixes every `Γ₀(N)` double coset.
+
+The resulting basis identity extends by linearity to an anti-homomorphism. Since the `Γ₀(N)`
+Hecke ring is commutative, this is a ring homomorphism. The construction is given first on the
+function character space on which composition was proved, and then on the bundled modular-form
+and cusp-form character spaces.
+
+## Main definitions
+
+* `HeckeRing.GL2.heckeRingHomFunctionCharSpace`: the Hecke-ring action on twisted-invariant
+  functions.
+* `HeckeRing.GL2.heckeRingHomCharSpace`: the action on modular forms of nebentypus `χ`.
+* `HeckeRing.GL2.heckeRingHomCuspCharSpace`: its restriction to cusp forms.
+
+## Provenance
+
+The final ring-homomorphism packaging is adapted from AINTLIB's
+`LeanModularForms/HeckeRIngs/GL2/Unified/NebentypusHeckeRingHom.lean`, declaration
+`heckeRingHomCharSpace` (Chris Birkbeck, Apache-2.0), at commit
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`. The convention bridge is new: AINTLIB proves its
+composition formula directly with the Hecke-ring structure constants, while this repository's
+right-coset composition theorem first exposes the reversed, inverted multiplicity.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
+  HeckeRing.GLn
+open scoped MatrixGroups ModularForm HeckeCosetModule Pointwise
+
+namespace HeckeRing.GL2
+
+variable {N : ℕ} (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) [NeZero N]
+
+attribute [local instance] Fintype.ofFinite
+
+local notation "Γ₀Q(" N ")" => Subgroup.map (mapGL ℚ) (Gamma0 N)
+local notation "Coset₀(" N ")" => HeckeCoset (Delta0 N) (Γ₀Q(N)) (Γ₀Q(N))
+
+/-- The reversed, inverted multiplicity from a right slash action is the ordinary `Γ₀(N)`
+Hecke-ring structure constant. -/
+theorem multiplicity_inv_reverse_eq (D₁ D₂ D : Coset₀(N)) :
+    multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
+          (D.out : GL (Fin 2) ℚ)⁻¹ =
+      multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        (D₁.rep : GL (Fin 2) ℚ) (D₂.rep : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) := by
+  let ι := atkinLehnerAntiInvolution N
+  let b₁ : Delta0 N := ⟨ι.bar D₁.out D₁.out.2, ι.bar_mem_Δ _ D₁.out.2⟩
+  let b₂ : Delta0 N := ⟨ι.bar D₂.out D₂.out.2, ι.bar_mem_Δ _ D₂.out.2⟩
+  let b : Delta0 N := ⟨ι.bar D.out D.out.2, ι.bar_mem_Δ _ D.out.2⟩
+  have hmap := multiplicity_map_equiv (atkinLehnerAutomorphism N)
+    (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N)) (D₂.out : GL (Fin 2) ℚ)⁻¹
+      (D₁.out : GL (Fin 2) ℚ)⁻¹ (D.out : GL (Fin 2) ℚ)⁻¹
+  have hfix := atkinLehnerAntiInvolution_onHeckeCoset_eq_self N
+  have hcomm (a c d : Delta0 N) :
+      multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+          (a : GL (Fin 2) ℚ) (c : GL (Fin 2) ℚ) (d : GL (Fin 2) ℚ) =
+        multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+          (c : GL (Fin 2) ℚ) (a : GL (Fin 2) ℚ) (d : GL (Fin 2) ℚ) :=
+    ι.multiplicity_comm hfix a c d
+  have hb₁ : (b₁ : GL (Fin 2) ℚ) ∈
+      doubleCoset (D₁.rep : GL (Fin 2) ℚ) (Γ₀Q(N)) (Γ₀Q(N)) := by
+    rw [HeckeCoset.rep_def]
+    exact atkinLehnerAntiInvolution_bar_mem_doubleCoset N D₁.out D₁.out.2
+  have hb₂ : (b₂ : GL (Fin 2) ℚ) ∈
+      doubleCoset (D₂.rep : GL (Fin 2) ℚ) (Γ₀Q(N)) (Γ₀Q(N)) := by
+    rw [HeckeCoset.rep_def]
+    exact atkinLehnerAntiInvolution_bar_mem_doubleCoset N D₂.out D₂.out.2
+  have hb : (b : GL (Fin 2) ℚ) ∈
+      doubleCoset (D.rep : GL (Fin 2) ℚ) (Γ₀Q(N)) (Γ₀Q(N)) := by
+    rw [HeckeCoset.rep_def]
+    exact atkinLehnerAntiInvolution_bar_mem_doubleCoset N D.out D.out.2
+  rw [atkinLehnerAutomorphism_map_Gamma0] at hmap
+  rw [atkinLehnerAutomorphism_inv_apply N D₂.out.2,
+    atkinLehnerAutomorphism_inv_apply N D₁.out.2,
+    atkinLehnerAutomorphism_inv_apply N D.out.2] at hmap
+  calc
+    _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        (b₂ : GL (Fin 2) ℚ) (b₁ : GL (Fin 2) ℚ) (b : GL (Fin 2) ℚ) := hmap.symm
+    _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        (b₂ : GL (Fin 2) ℚ) (b₁ : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
+      multiplicity_doubleCoset_congr _ _ hb
+    _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        (D₂.rep : GL (Fin 2) ℚ) (b₁ : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
+      multiplicity_doubleCoset_congr_first_of_comm (Γ₀Q(N)) hcomm b₁ D.rep hb₂
+    _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        (D₂.rep : GL (Fin 2) ℚ) (D₁.rep : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
+      multiplicity_doubleCoset_congr_second (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        D₂.rep D.rep hb₁
+    _ = _ := hcomm D₂.rep D₁.rep D.rep
+
+open Classical in
+/-- The double cosets met by pairs of right-coset representatives are exactly the support of
+the Hecke-ring structure constants. -/
+private lemma image_pairCoset_eq_support_structureConstants (D₁ D₂ : Coset₀(N)) :
+    Finset.univ.image (pairCoset D₁ D₂) =
+      (HeckeCosetModule.structureConstants ℤ (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        D₁.rep D₂.rep).support := by
+  ext D
+  simp only [Finset.mem_image, Finset.mem_univ, true_and,
+    HeckeCosetModule.mem_support_iff, HeckeCosetModule.structureConstants_apply,
+    Nat.cast_ne_zero]
+  constructor
+  · rintro ⟨p, hp⟩
+    have hx := pairCoset_eq_iff.mp hp
+    have hcard := card_pairs_pairCoset_rightCoset_eq_multiplicity (D₁ := D₁) (D₂ := D₂) hx
+    have : Nonempty {i : {q // pairCoset D₁ D₂ q = D} //
+        MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
+            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ)) =
+          MulOpposite.op (rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2) •
+            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ))} :=
+      ⟨⟨⟨p, hp⟩, rfl⟩⟩
+    have hne : multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
+          (D.out : GL (Fin 2) ℚ)⁻¹ ≠ 0 := by
+      rw [← hcard]
+      exact (Nat.card_pos (α := {i : {q // pairCoset D₁ D₂ q = D} //
+        MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
+            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ)) =
+          MulOpposite.op (rightCosetRep D₁ p.1 * rightCosetRep D₂ p.2) •
+            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ))})).ne'
+    rwa [multiplicity_inv_reverse_eq D₁ D₂ D] at hne
+  · intro hne
+    have hne' : multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
+        (D₂.out : GL (Fin 2) ℚ)⁻¹ (D₁.out : GL (Fin 2) ℚ)⁻¹
+          (D.out : GL (Fin 2) ℚ)⁻¹ ≠ 0 := by
+      rwa [multiplicity_inv_reverse_eq D₁ D₂ D]
+    have hcard := card_pairs_pairCoset_rightCoset_eq_multiplicity (D₁ := D₁) (D₂ := D₂)
+      (mem_doubleCoset_self (Γ₀Q(N)) (Γ₀Q(N)) (D.out : GL (Fin 2) ℚ))
+    have hcardne : Nat.card {i : {q // pairCoset D₁ D₂ q = D} //
+        MulOpposite.op (rightCosetRep D₁ i.1.1 * rightCosetRep D₂ i.1.2) •
+            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ)) =
+          MulOpposite.op (D.out : GL (Fin 2) ℚ) •
+            ((Γ₀Q(N)) : Set (GL (Fin 2) ℚ))} ≠ 0 := by
+      rwa [hcard]
+    obtain ⟨i⟩ := (Nat.card_ne_zero.mp hcardne).1
+    exact ⟨i.1.1, i.1.2⟩
+
+/-- The linear extension of the twisted slash action is anti-multiplicative on Hecke-ring basis
+elements. -/
+private theorem twistedHeckeSlashRingCharLinearMap_map_mul_reverse_single
+    (D₁ D₂ : Coset₀(N)) :
+    twistedHeckeSlashRingCharLinearMap k χ
+        (HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1) =
+      twistedHeckeSlashRingCharLinearMap k χ (HeckeCosetModule.single ℤ D₂ 1) *
+        twistedHeckeSlashRingCharLinearMap k χ (HeckeCosetModule.single ℤ D₁ 1) := by
+  rw [HeckeCosetModule.single_mul_single]
+  rw [map_smul, map_smul, one_smul, one_smul]
+  rw [
+    twistedHeckeSlashRingCharLinearMap_single, twistedHeckeSlashRingCharLinearMap_single,
+    one_smul, one_smul, twistedHeckeSlashSumCharEnd_mul_eq_sum_nsmul]
+  rw [twistedHeckeSlashRingCharLinearMap_apply]
+  rw [HeckeCosetModule.sum_def, ← image_pairCoset_eq_support_structureConstants D₁ D₂]
+  refine Finset.sum_congr rfl fun D _ ↦ ?_
+  rw [HeckeCosetModule.structureConstants_apply, ← multiplicity_inv_reverse_eq D₁ D₂ D]
+  exact Nat.cast_smul_eq_nsmul ℤ _ _
+
+/-- The linear extension of the twisted slash action is anti-multiplicative. This is the order
+forced by a right action and multiplication by composition in `Module.End`. -/
+theorem twistedHeckeSlashRingCharLinearMap_map_mul_reverse
+    (S T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) :
+    twistedHeckeSlashRingCharLinearMap k χ (S * T) =
+      twistedHeckeSlashRingCharLinearMap k χ T *
+        twistedHeckeSlashRingCharLinearMap k χ S :=
+  LinearMap.map_mul_reverse_of_basis (twistedHeckeSlashRingCharLinearMap k χ)
+    (twistedHeckeSlashRingCharLinearMap_map_mul_reverse_single k χ) S T
+
+/-- The linear extension is multiplicative. Anti-multiplicativity becomes multiplicativity
+because the `Γ₀(N)` Hecke ring is commutative. -/
+theorem twistedHeckeSlashRingCharLinearMap_map_mul
+    (S T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) :
+    twistedHeckeSlashRingCharLinearMap k χ (S * T) =
+      twistedHeckeSlashRingCharLinearMap k χ S *
+        twistedHeckeSlashRingCharLinearMap k χ T := by
+  rw [HeckeCosetModule.mul_comm_of_antiInvolution ℤ (atkinLehnerAntiInvolution N)
+    (atkinLehnerAntiInvolution_onHeckeCoset_eq_self N) S T]
+  exact twistedHeckeSlashRingCharLinearMap_map_mul_reverse k χ T S
+
+/-- The integral `Γ₀(N)` Hecke ring acts on the space of `χ`-invariant functions. -/
+noncomputable def heckeRingHomFunctionCharSpace :
+    𝕋 (Delta0 N) (Γ₀Q(N)) ℤ →+* Module.End ℂ (functionCharSpace k χ) where
+  toFun := twistedHeckeSlashRingCharLinearMap k χ
+  map_zero' := (twistedHeckeSlashRingCharLinearMap k χ).map_zero
+  map_one' := twistedHeckeSlashRingCharLinearMap_one k χ
+  map_add' := (twistedHeckeSlashRingCharLinearMap k χ).map_add
+  map_mul' := twistedHeckeSlashRingCharLinearMap_map_mul k χ
+
+/-- The function-space Hecke action has the original linear extension as its underlying map. -/
+@[simp] lemma heckeRingHomFunctionCharSpace_apply (T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) :
+    heckeRingHomFunctionCharSpace k χ T = twistedHeckeSlashRingCharLinearMap k χ T :=
+  (rfl)
+
+/-- The `ℤ`-linear extension of the twisted operators on modular forms of nebentypus `χ`. -/
+noncomputable def twistedHeckeSlashModularFormCharLinearMap :
+    𝕋 (Delta0 N) (Γ₀Q(N)) ℤ →ₗ[ℤ] Module.End ℂ (modFormCharSpace k χ) :=
+  Finsupp.linearCombination ℤ fun D ↦ twistedHeckeSlashModularFormCharEnd k χ D
+
+/-- The modular-form linear extension on a basis element. -/
+@[simp] lemma twistedHeckeSlashModularFormCharLinearMap_single (D : Coset₀(N)) (c : ℤ) :
+    twistedHeckeSlashModularFormCharLinearMap k χ (HeckeCosetModule.single ℤ D c) =
+      c • twistedHeckeSlashModularFormCharEnd k χ D :=
+  (Finsupp.linearCombination_apply (R := ℤ)
+    (v := fun D ↦ twistedHeckeSlashModularFormCharEnd k χ D) _).trans
+    (HeckeCosetModule.sum_single_index ℤ (zero_smul _ _))
+
+/-- On underlying functions, the modular-form extension is the function-space extension. -/
+lemma coe_twistedHeckeSlashModularFormCharLinearMap
+    (T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) (f : modFormCharSpace k χ) :
+    ⇑((twistedHeckeSlashModularFormCharLinearMap k χ T f :
+        ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) =
+      (twistedHeckeSlashRingCharLinearMap k χ T
+        ⟨⇑(f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k),
+          (coe_mem_functionCharSpace_iff k χ _).mpr f.2⟩ : functionCharSpace k χ) := by
+  induction T using HeckeCosetModule.induction_linear with
+  | h0 => simp
+  | hadd S T hS hT =>
+      rw [map_add, map_add]
+      simpa only [LinearMap.add_apply, Submodule.coe_add, FunLike.coe_add, Pi.add_apply] using
+        congrArg₂ (· + ·) hS hT
+  | hsingle D c =>
+      rw [twistedHeckeSlashModularFormCharLinearMap_single,
+        twistedHeckeSlashRingCharLinearMap_single]
+      ext τ
+      change c • (⇑((twistedHeckeSlashModularFormCharEnd k χ D f :
+        ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) : ℍ → ℂ) τ =
+          c • (twistedHeckeSlashSumCharEnd k χ D
+            ⟨⇑(f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k),
+              (coe_mem_functionCharSpace_iff k χ _).mpr f.2⟩ : ℍ → ℂ) τ
+      rw [coe_twistedHeckeSlashModularFormCharEnd, coe_twistedHeckeSlashSumCharEnd]
+
+/-- The modular-form extension sends one to the identity endomorphism. -/
+@[simp] theorem twistedHeckeSlashModularFormCharLinearMap_one :
+    twistedHeckeSlashModularFormCharLinearMap k χ 1 = 1 := by
+  refine LinearMap.ext fun f ↦ Subtype.ext (ModularForm.ext fun τ ↦ ?_)
+  have h := congrFun (coe_twistedHeckeSlashModularFormCharLinearMap k χ 1 f) τ
+  simpa using h
+
+/-- The modular-form extension is multiplicative. -/
+theorem twistedHeckeSlashModularFormCharLinearMap_map_mul
+    (S T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) :
+    twistedHeckeSlashModularFormCharLinearMap k χ (S * T) =
+      twistedHeckeSlashModularFormCharLinearMap k χ S *
+        twistedHeckeSlashModularFormCharLinearMap k χ T := by
+  refine LinearMap.ext fun f ↦ Subtype.ext (ModularForm.ext fun τ ↦ ?_)
+  let f₀ : functionCharSpace k χ :=
+    ⟨⇑(f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k),
+      (coe_mem_functionCharSpace_iff k χ _).mpr f.2⟩
+  let Tf := twistedHeckeSlashModularFormCharLinearMap k χ T f
+  let Tf₀ : functionCharSpace k χ :=
+    ⟨⇑(Tf : ModularForm ((Gamma1 N).map (mapGL ℝ)) k),
+      (coe_mem_functionCharSpace_iff k χ _).mpr Tf.2⟩
+  have hT : Tf₀ = twistedHeckeSlashRingCharLinearMap k χ T f₀ :=
+    Subtype.ext (coe_twistedHeckeSlashModularFormCharLinearMap k χ T f)
+  calc
+    _ = (twistedHeckeSlashRingCharLinearMap k χ (S * T) f₀ : ℍ → ℂ) τ :=
+      congrFun (coe_twistedHeckeSlashModularFormCharLinearMap k χ (S * T) f) τ
+    _ = ((twistedHeckeSlashRingCharLinearMap k χ S *
+        twistedHeckeSlashRingCharLinearMap k χ T) f₀ : ℍ → ℂ) τ := by
+      rw [twistedHeckeSlashRingCharLinearMap_map_mul]
+    _ = (twistedHeckeSlashRingCharLinearMap k χ S Tf₀ : ℍ → ℂ) τ := by
+      rw [hT]
+      rfl
+    _ = _ := (congrFun
+      (coe_twistedHeckeSlashModularFormCharLinearMap k χ S Tf) τ).symm
+
+/-- The integral `Γ₀(N)` Hecke ring acts on modular forms of weight `k` and nebentypus `χ`. -/
+noncomputable def heckeRingHomCharSpace :
+    𝕋 (Delta0 N) (Γ₀Q(N)) ℤ →+* Module.End ℂ (modFormCharSpace k χ) where
+  toFun := twistedHeckeSlashModularFormCharLinearMap k χ
+  map_zero' := (twistedHeckeSlashModularFormCharLinearMap k χ).map_zero
+  map_one' := twistedHeckeSlashModularFormCharLinearMap_one k χ
+  map_add' := (twistedHeckeSlashModularFormCharLinearMap k χ).map_add
+  map_mul' := twistedHeckeSlashModularFormCharLinearMap_map_mul k χ
+
+/-- The modular-form Hecke action evaluates through its underlying linear extension. -/
+@[simp] lemma heckeRingHomCharSpace_apply (T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) :
+    heckeRingHomCharSpace k χ T = twistedHeckeSlashModularFormCharLinearMap k χ T :=
+  (rfl)
+
+/-- The `ℤ`-linear extension of the twisted operators on cusp forms of nebentypus `χ`. -/
+noncomputable def twistedHeckeSlashCuspFormCharLinearMap :
+    𝕋 (Delta0 N) (Γ₀Q(N)) ℤ →ₗ[ℤ] Module.End ℂ (cuspFormCharSpace k χ) :=
+  Finsupp.linearCombination ℤ fun D ↦ twistedHeckeSlashCuspFormCharEnd k χ D
+
+/-- The cusp-form linear extension on a basis element. -/
+@[simp] lemma twistedHeckeSlashCuspFormCharLinearMap_single (D : Coset₀(N)) (c : ℤ) :
+    twistedHeckeSlashCuspFormCharLinearMap k χ (HeckeCosetModule.single ℤ D c) =
+      c • twistedHeckeSlashCuspFormCharEnd k χ D :=
+  (Finsupp.linearCombination_apply (R := ℤ)
+    (v := fun D ↦ twistedHeckeSlashCuspFormCharEnd k χ D) _).trans
+    (HeckeCosetModule.sum_single_index ℤ (zero_smul _ _))
+
+/-- On underlying functions, the cusp-form extension is the function-space extension. -/
+lemma coe_twistedHeckeSlashCuspFormCharLinearMap
+    (T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) (f : cuspFormCharSpace k χ) :
+    ⇑((twistedHeckeSlashCuspFormCharLinearMap k χ T f :
+        CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) =
+      (twistedHeckeSlashRingCharLinearMap k χ T
+        ⟨⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k),
+          (coe_mem_functionCharSpace_iff k χ
+            ((f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+              ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).mpr
+            ((coe_mem_modFormCharSpace_iff k χ _).mpr f.2)⟩ : functionCharSpace k χ) := by
+  induction T using HeckeCosetModule.induction_linear with
+  | h0 => simp
+  | hadd S T hS hT =>
+      rw [map_add, map_add]
+      simpa only [LinearMap.add_apply, Submodule.coe_add, FunLike.coe_add, Pi.add_apply] using
+        congrArg₂ (· + ·) hS hT
+  | hsingle D c =>
+      rw [twistedHeckeSlashCuspFormCharLinearMap_single,
+        twistedHeckeSlashRingCharLinearMap_single]
+      ext τ
+      change c • (⇑((twistedHeckeSlashCuspFormCharEnd k χ D f :
+        CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) : ℍ → ℂ) τ =
+          c • (twistedHeckeSlashSumCharEnd k χ D
+            ⟨⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k),
+              (coe_mem_functionCharSpace_iff k χ
+                ((f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+                  ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).mpr
+                ((coe_mem_modFormCharSpace_iff k χ _).mpr f.2)⟩ : ℍ → ℂ) τ
+      rw [coe_twistedHeckeSlashCuspFormCharEnd, coe_twistedHeckeSlashSumCharEnd]
+
+/-- The cusp-form extension sends one to the identity endomorphism. -/
+@[simp] theorem twistedHeckeSlashCuspFormCharLinearMap_one :
+    twistedHeckeSlashCuspFormCharLinearMap k χ 1 = 1 := by
+  refine LinearMap.ext fun f ↦ Subtype.ext (CuspForm.ext fun τ ↦ ?_)
+  have h := congrFun (coe_twistedHeckeSlashCuspFormCharLinearMap k χ 1 f) τ
+  simpa using h
+
+/-- The cusp-form extension is multiplicative. -/
+theorem twistedHeckeSlashCuspFormCharLinearMap_map_mul
+    (S T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) :
+    twistedHeckeSlashCuspFormCharLinearMap k χ (S * T) =
+      twistedHeckeSlashCuspFormCharLinearMap k χ S *
+        twistedHeckeSlashCuspFormCharLinearMap k χ T := by
+  refine LinearMap.ext fun f ↦ Subtype.ext (CuspForm.ext fun τ ↦ ?_)
+  let f₀ : functionCharSpace k χ :=
+    ⟨⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k),
+      (coe_mem_functionCharSpace_iff k χ
+        ((f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+          ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).mpr
+        ((coe_mem_modFormCharSpace_iff k χ _).mpr f.2)⟩
+  let Tf := twistedHeckeSlashCuspFormCharLinearMap k χ T f
+  let Tf₀ : functionCharSpace k χ :=
+    ⟨⇑(Tf : CuspForm ((Gamma1 N).map (mapGL ℝ)) k),
+      (coe_mem_functionCharSpace_iff k χ
+        ((Tf : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+          ModularForm ((Gamma1 N).map (mapGL ℝ)) k)).mpr
+        ((coe_mem_modFormCharSpace_iff k χ _).mpr Tf.2)⟩
+  have hT : Tf₀ = twistedHeckeSlashRingCharLinearMap k χ T f₀ :=
+    Subtype.ext (coe_twistedHeckeSlashCuspFormCharLinearMap k χ T f)
+  calc
+    _ = (twistedHeckeSlashRingCharLinearMap k χ (S * T) f₀ : ℍ → ℂ) τ :=
+      congrFun (coe_twistedHeckeSlashCuspFormCharLinearMap k χ (S * T) f) τ
+    _ = ((twistedHeckeSlashRingCharLinearMap k χ S *
+        twistedHeckeSlashRingCharLinearMap k χ T) f₀ : ℍ → ℂ) τ := by
+      rw [twistedHeckeSlashRingCharLinearMap_map_mul]
+    _ = (twistedHeckeSlashRingCharLinearMap k χ S Tf₀ : ℍ → ℂ) τ := by
+      rw [hT]
+      rfl
+    _ = _ := (congrFun
+      (coe_twistedHeckeSlashCuspFormCharLinearMap k χ S Tf) τ).symm
+
+/-- The integral `Γ₀(N)` Hecke ring acts on cusp forms of weight `k` and nebentypus `χ`. -/
+noncomputable def heckeRingHomCuspCharSpace :
+    𝕋 (Delta0 N) (Γ₀Q(N)) ℤ →+* Module.End ℂ (cuspFormCharSpace k χ) where
+  toFun := twistedHeckeSlashCuspFormCharLinearMap k χ
+  map_zero' := (twistedHeckeSlashCuspFormCharLinearMap k χ).map_zero
+  map_one' := twistedHeckeSlashCuspFormCharLinearMap_one k χ
+  map_add' := (twistedHeckeSlashCuspFormCharLinearMap k χ).map_add
+  map_mul' := twistedHeckeSlashCuspFormCharLinearMap_map_mul k χ
+
+/-- The cusp-form Hecke action evaluates through its underlying linear extension. -/
+@[simp] lemma heckeRingHomCuspCharSpace_apply (T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) :
+    heckeRingHomCuspCharSpace k χ T = twistedHeckeSlashCuspFormCharLinearMap k χ T :=
+  (rfl)
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
@@ -234,7 +234,7 @@ noncomputable def twistedHeckeSlashModularFormCharLinearMap :
     (HeckeCosetModule.sum_single_index ℤ (zero_smul _ _))
 
 /-- On underlying functions, the modular-form extension is the function-space extension. -/
-lemma coe_twistedHeckeSlashModularFormCharLinearMap
+@[simp] lemma coe_twistedHeckeSlashModularFormCharLinearMap
     (T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) (f : modFormCharSpace k χ) :
     ⇑((twistedHeckeSlashModularFormCharLinearMap k χ T f :
         ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) =
@@ -266,7 +266,7 @@ lemma coe_twistedHeckeSlashModularFormCharLinearMap
     twistedHeckeSlashModularFormCharLinearMap k χ 1 = 1 := by
   refine LinearMap.ext fun f ↦ Subtype.ext (ModularForm.ext fun τ ↦ ?_)
   have h := congrFun (coe_twistedHeckeSlashModularFormCharLinearMap k χ 1 f) τ
-  simpa using h
+  simpa only [twistedHeckeSlashRingCharLinearMap_one, Module.End.one_apply] using h
 
 /-- The modular-form extension is multiplicative. -/
 theorem twistedHeckeSlashModularFormCharLinearMap_map_mul
@@ -291,8 +291,7 @@ theorem twistedHeckeSlashModularFormCharLinearMap_map_mul
         twistedHeckeSlashRingCharLinearMap k χ T) f₀ : ℍ → ℂ) τ := by
       rw [twistedHeckeSlashRingCharLinearMap_map_mul]
     _ = (twistedHeckeSlashRingCharLinearMap k χ S Tf₀ : ℍ → ℂ) τ := by
-      rw [hT]
-      rfl
+      rw [hT, Module.End.mul_apply]
     _ = _ := (congrFun
       (coe_twistedHeckeSlashModularFormCharLinearMap k χ S Tf) τ).symm
 
@@ -324,7 +323,7 @@ noncomputable def twistedHeckeSlashCuspFormCharLinearMap :
     (HeckeCosetModule.sum_single_index ℤ (zero_smul _ _))
 
 /-- On underlying functions, the cusp-form extension is the function-space extension. -/
-lemma coe_twistedHeckeSlashCuspFormCharLinearMap
+@[simp] lemma coe_twistedHeckeSlashCuspFormCharLinearMap
     (T : 𝕋 (Delta0 N) (Γ₀Q(N)) ℤ) (f : cuspFormCharSpace k χ) :
     ⇑((twistedHeckeSlashCuspFormCharLinearMap k χ T f :
         CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) =
@@ -361,7 +360,7 @@ lemma coe_twistedHeckeSlashCuspFormCharLinearMap
     twistedHeckeSlashCuspFormCharLinearMap k χ 1 = 1 := by
   refine LinearMap.ext fun f ↦ Subtype.ext (CuspForm.ext fun τ ↦ ?_)
   have h := congrFun (coe_twistedHeckeSlashCuspFormCharLinearMap k χ 1 f) τ
-  simpa using h
+  simpa only [twistedHeckeSlashRingCharLinearMap_one, Module.End.one_apply] using h
 
 /-- The cusp-form extension is multiplicative. -/
 theorem twistedHeckeSlashCuspFormCharLinearMap_map_mul
@@ -392,8 +391,7 @@ theorem twistedHeckeSlashCuspFormCharLinearMap_map_mul
         twistedHeckeSlashRingCharLinearMap k χ T) f₀ : ℍ → ℂ) τ := by
       rw [twistedHeckeSlashRingCharLinearMap_map_mul]
     _ = (twistedHeckeSlashRingCharLinearMap k χ S Tf₀ : ℍ → ℂ) τ := by
-      rw [hT]
-      rfl
+      rw [hT, Module.End.mul_apply]
     _ = _ := (congrFun
       (coe_twistedHeckeSlashCuspFormCharLinearMap k χ S Tf) τ).symm
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/CharRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/CharRing.lean
@@ -36,6 +36,7 @@ a general principle.
 
 ## Main results
 
+* `HeckeRing.GL2.twistedHeckeSlashRingCharLinearMap_apply`: evaluation as a finite sum.
 * `HeckeRing.GL2.twistedHeckeSlashRingCharLinearMap_single`: the value on a basis element is the
   scaled twisted operator of that double coset. With `map_zero`/`map_add` this determines the map.
 
@@ -80,6 +81,14 @@ why `Finsupp.linearCombination` applies at this type. -/
 noncomputable def twistedHeckeSlashRingCharLinearMap :
     𝕋 (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ℤ →ₗ[ℤ] Module.End ℂ (functionCharSpace k χ) :=
   Finsupp.linearCombination ℤ fun D ↦ twistedHeckeSlashSumCharEnd k χ D
+
+/-- Evaluation of the linear extension as a finite sum over the double cosets in its support. -/
+lemma twistedHeckeSlashRingCharLinearMap_apply
+    (T : 𝕋 (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ℤ) :
+    twistedHeckeSlashRingCharLinearMap k χ T =
+      T.sum fun D c ↦ c • twistedHeckeSlashSumCharEnd k χ D :=
+  Finsupp.linearCombination_apply (R := ℤ)
+    (v := fun D ↦ twistedHeckeSlashSumCharEnd k χ D) T
 
 /-- The value on a basis element is the scaled twisted operator of that double coset. -/
 @[simp] lemma twistedHeckeSlashRingCharLinearMap_single


### PR DESCRIPTION
This PR promotes the twisted Γ₀(N) slash action from its existing ℤ-linear extension to ring homomorphisms on the function, modular-form, and cusp-form nebentypus spaces.

It proves the missing convention bridge honestly: transport Shimura multiplicities along group equivalences, compose inversion with the Atkin–Lehner anti-involution, use fixed Γ₀(N) double cosets to identify m(D₂⁻¹,D₁⁻¹;D⁻¹) with m(D₁,D₂;D), and identify the right-representative image with the support of the Hecke structure constants. Extend the resulting basis anti-multiplicativity to all Hecke-ring elements, then use Γ₀(N) Hecke-ring commutativity to obtain multiplicativity. Transfer that action to bundled modular and cusp forms through their underlying functions.

This advances ModularForms README Layer 2(b), “The action on forms,” specifically its heckeRingHomCharSpace target and the requirement that the action preserve both nebentypus and cuspidality. After this PR, Layer 2(b) still needs the classical Tₙ q-expansion recurrences, the abstract-double-coset normalization lemma, the Uₚ = Tₚ packaging, and the diamond/scalar compatibility statements.

The ring-homomorphism packaging is adapted from AINTLIB NebentypusHeckeRingHom.lean at commit 2baa76f742bdb4fb8ee323fabba41203bd390e08; the right-coset convention bridge is new to this implementation.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke-ring-hom-char-space"}-->

🤖 Prepared with Codex