### PR TITLE
refactor: drop two `namespace Matrix` blocks that declare nothing

### DIFF
--- a/TauCeti/Analysis/Matrix/UnitaryGroup.lean
+++ b/TauCeti/Analysis/Matrix/UnitaryGroup.lean
@@ -27,8 +27,6 @@ public section
 
 namespace TauCeti
 
-namespace Matrix
-
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- `U(n) = Circle · SU(n)`: every complex unitary matrix becomes special unitary after
@@ -63,7 +61,5 @@ theorem _root_.Matrix.exists_circle_smul_mem_specialUnitaryGroup (U : Matrix.uni
     push_cast
     field_simp
     ring
-
-end Matrix
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/UnitaryGroup.lean
+++ b/TauCeti/LinearAlgebra/UnitaryGroup.lean
@@ -26,8 +26,6 @@ public section
 
 namespace TauCeti
 
-namespace Matrix
-
 variable {n : Type*} [Fintype n] [DecidableEq n] {α : Type*} [CommRing α] [StarRing α]
 
 /-- The conjugate transpose of a special unitary matrix is its adjugate: it is the inverse, and
@@ -42,7 +40,5 @@ theorem _root_.Matrix.specialUnitaryGroup.star_eq_adjugate (g : Matrix.specialUn
         rw [Matrix.adjugate_mul, hmem.2, one_smul, Matrix.one_mul]
     _ = (g : Matrix n n α).adjugate := by
         rw [Matrix.mul_assoc, hmul, Matrix.mul_one]
-
-end Matrix
 
 end TauCeti


### PR DESCRIPTION
#5776 moved the two unitary-group lemmas into the root `Matrix` namespace with
`theorem _root_.Matrix.…`, which was the right fix — but it left the enclosing
`namespace Matrix` … `end Matrix` blocks in place.

Each block now wraps a single declaration that explicitly escapes it, so neither file puts
anything into `TauCeti.Matrix`:

- `TauCeti/Analysis/Matrix/UnitaryGroup.lean` — one declaration,
  `_root_.Matrix.exists_circle_smul_mem_specialUnitaryGroup`
- `TauCeti/LinearAlgebra/UnitaryGroup.lean` — one declaration,
  `_root_.Matrix.specialUnitaryGroup.star_eq_adjugate`

The wrapper only makes the files look as though they declare into `TauCeti.Matrix`, which is
exactly the reading the `naming` rubric objected to on #5579.

Resolution is unchanged: every reference inside both blocks is already written `Matrix.…` in
full (`Matrix.unitaryGroup`, `Matrix.mem_specialUnitaryGroup_iff`, `Matrix.adjugate_mul`, …),
so those names fell through the empty `TauCeti.Matrix` to the root before and reach it
directly now.

`TauCeti.Matrix` itself stays — other files genuinely declare into it, e.g.
`TauCeti.Matrix.SpecialLinearGroup.coe_GL_eq_mapGL` and
`TauCeti.Matrix.GeneralLinearGroup.polynomialFunctions`. This removes only the two wrappers
that contribute nothing to it.

Eight lines deleted, no other change.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp