### PR TITLE
feat: localize the different ideal

### DIFF
--- a/TauCeti/RingTheory/DedekindDomain/Different/Basic.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Basic.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.Different
+
+/-!
+# The different ideal
+
+This file supplies general lemmas about trace-dual fractional ideals.
+-/
+
+public section
+
+open Module
+
+open scoped nonZeroDivisors
+
+namespace TauCeti
+
+universe uR uS uK uL
+
+variable {R : Type uR} {S : Type uS} {K : Type uK} {L : Type uL}
+variable [CommRing R] [CommRing S] [Field K] [Field L]
+variable [Algebra R S] [Algebra R K] [Algebra K L] [Algebra R L] [Algebra S L]
+variable [IsScalarTower R K L] [IsScalarTower R S L]
+variable [IsDomain R]
+variable [IsFractionRing R K] [IsFractionRing S L]
+variable [IsIntegrallyClosed R] [IsIntegralClosure S R L]
+variable [FiniteDimensional K L] [Algebra.IsSeparable K L]
+
+namespace FractionalIdeal
+
+/-- Over a domain, the fractional-ideal trace dual of one coerces to the submodule trace dual. -/
+@[simp]
+theorem coe_dual_one_of_isDomain [IsDomain S] :
+    (↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) =
+      Submodule.traceDual R K (1 : Submodule S L) := by
+  ext x
+  change x ∈ FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L) ↔ _
+  have h : (1 : FractionalIdeal S⁰ L) ≠ 0 := one_ne_zero
+  simp [FractionalIdeal.dual, h]
+  rfl
+
+end FractionalIdeal
+
+end TauCeti
+
+end

--- a/TauCeti/RingTheory/DedekindDomain/Different/Basic.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Basic.lean
@@ -10,7 +10,9 @@ public import Mathlib.RingTheory.DedekindDomain.Different
 /-!
 # The different ideal
 
-This file supplies general lemmas about trace-dual fractional ideals.
+This file supplies general lemmas about trace-dual fractional ideals.  The coercion result connects
+the fractional-ideal and submodule trace duals, allowing submodule results such as localization to
+be transferred to fractional ideals.
 -/
 
 public section
@@ -40,9 +42,13 @@ theorem coe_dual_one_of_isDomain [IsDomain S] :
     (↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) =
       Submodule.traceDual R K (1 : Submodule S L) := by
   ext x
+  -- Rewriting through `FractionalIdeal.coe_mk` directly requires Mathlib's transparency override.
+  -- Extensionality reduces the coercion equality to the definitionally equal membership predicates.
   change x ∈ FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L) ↔ _
   have h : (1 : FractionalIdeal S⁰ L) ≠ 0 := one_ne_zero
   simp [FractionalIdeal.dual, h]
+  -- In the nonzero branch, `dual` stores the trace-dual submodule itself; only its proof field is
+  -- discarded by the coercion, so the two remaining membership predicates are definitionally equal.
   rfl
 
 end FractionalIdeal

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -165,11 +165,23 @@ variable [IsDomain S] [IsDomain Sₘ]
 
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 /-- The trace-dual fractional ideal commutes with localization. -/
-theorem extendedHom_dual_one_eq_dual_one
-    (h : S⁰ ≤ Submonoid.comap (algebraMap S Sₘ) Sₘ⁰) :
-    FractionalIdeal.extendedHom' L h
+theorem extendedHom'_dual_one_eq_dual_one :
+    FractionalIdeal.extendedHom' L
+        (nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _
+          (IsLocalization.injective Sₘ
+            (show Algebra.algebraMapSubmonoid S M ≤ S⁰ from
+              map_le_nonZeroDivisors_of_injective _
+                (algebraMap_injective_of_field_isFractionRing R S K L) hM)))
         (FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) =
       FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L) := by
+  let hMS : Algebra.algebraMapSubmonoid S M ≤ S⁰ :=
+    map_le_nonZeroDivisors_of_injective _
+      (algebraMap_injective_of_field_isFractionRing R S K L) hM
+  let h : S⁰ ≤ Submonoid.comap (algebraMap S Sₘ) Sₘ⁰ :=
+    nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _
+      (IsLocalization.injective Sₘ hMS)
+  change FractionalIdeal.extendedHom' L h
+      (FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) = _
   rw [FractionalIdeal.extendedHom'_apply]
   apply FractionalIdeal.coeToSubmodule_injective
   refine (FractionalIdeal.coe_extended_eq_span L h _).trans ?_
@@ -230,9 +242,9 @@ theorem map_differentIdeal_eq_differentIdeal :
     ← FractionalIdeal.extended_coeIdeal_eq_map (K := L) L h,
     ← FractionalIdeal.extendedHom'_apply]
   rw [coeIdeal_differentIdeal R K L S, coeIdeal_differentIdeal Rₘ K L Sₘ, map_inv₀,
-    extendedHom_dual_one_eq_dual_one (R := R) (Rₘ := Rₘ) (S := S)
+    extendedHom'_dual_one_eq_dual_one (R := R) (Rₘ := Rₘ) (S := S)
       (Sₘ := Sₘ)
-      (K := K) (L := L) (M := M) hM h]
+      (K := K) (L := L) (M := M) hM]
 
 end TauCeti
 

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.DedekindDomain.Different
-public import Mathlib.RingTheory.Localization.NormTrace
+public import Mathlib.RingTheory.Localization.Integer
 
 /-!
 # Localization of the different ideal
@@ -46,12 +46,62 @@ variable (hM : M ≤ R⁰)
 
 include M hM
 
+omit [Algebra R Sₘ] [IsScalarTower R S Sₘ] [IsScalarTower R Sₘ L]
+  [IsLocalization (Algebra.algebraMapSubmonoid S M) Sₘ] [IsDomain R] [IsDomain Rₘ]
+  [IsFractionRing R K] [IsFractionRing Rₘ K] hM in
+private theorem exists_smul_mem_traceDual_of_mem_traceDual {x : L}
+    (hx : x ∈ Submodule.traceDual Rₘ K (1 : Submodule Sₘ L)) :
+    ∃ b : M, algebraMap R K b • x ∈ Submodule.traceDual R K (1 : Submodule S L) := by
+  rw [Submodule.mem_traceDual] at hx
+  obtain ⟨s, hs⟩ := Module.Finite.fg_top (R := R) (M := S)
+  choose c hc using fun i : s ↦ hx (algebraMap S L i) (Submodule.mem_one.mpr
+    ⟨algebraMap S Sₘ i, by rw [← IsScalarTower.algebraMap_apply S Sₘ L]⟩)
+  obtain ⟨b, hb⟩ := IsLocalization.exist_integer_multiples_of_finite M c
+  refine ⟨b, ?_⟩
+  rw [Submodule.mem_traceDual]
+  intro a ha
+  rw [Submodule.mem_one] at ha
+  obtain ⟨a, rfl⟩ := ha
+  let f : S →ₗ[R] K := ((Algebra.traceForm K L) (algebraMap R K b • x)).restrictScalars R
+    ∘ₗ (Algebra.linearMap S L).restrictScalars R
+  let N : Submodule R S := Submodule.comap f (1 : Submodule R K)
+  have hsN : (s : Set S) ⊆ N := by
+    intro i hi
+    let j : s := ⟨i, hi⟩
+    obtain ⟨r, hr⟩ := hb j
+    apply Submodule.mem_comap.mpr
+    rw [Submodule.mem_one]
+    refine ⟨r, ?_⟩
+    calc
+      algebraMap R K r = algebraMap Rₘ K (algebraMap R Rₘ r) := by
+        rw [IsScalarTower.algebraMap_apply R Rₘ K]
+      _ = algebraMap Rₘ K ((b : R) • c j) := congrArg (algebraMap Rₘ K) hr
+      _ = algebraMap R K b * algebraMap Rₘ K (c j) := by
+        rw [Algebra.smul_def, map_mul, ← IsScalarTower.algebraMap_apply R Rₘ K]
+      _ = algebraMap R K b * (Algebra.traceForm K L x) (algebraMap S L j) := by
+        rw [hc j]
+      _ = (Algebra.trace K L) (algebraMap R K b • (x * algebraMap S L j)) := by
+        rw [(Algebra.trace K L).map_smul, Algebra.traceForm_apply, Algebra.smul_def]
+        simp only [Algebra.algebraMap_self_apply]
+      _ = (Algebra.trace K L) ((algebraMap R K b • x) * algebraMap S L i) := by
+        congr 1
+        simp only [Algebra.smul_def, j]
+        ring
+      _ = f i := rfl
+  have hN : N = ⊤ := by
+    apply top_unique
+    rw [← hs]
+    exact Submodule.span_le.mpr hsN
+  have haN : a ∈ N := hN.symm ▸ Submodule.mem_top
+  exact Submodule.mem_one.mp (Submodule.mem_comap.mp haN)
+
 omit [IsDomain Rₘ] [IsFractionRing Rₘ K] in
 /-- The trace dual of a finite algebra commutes with localization. -/
-theorem Submodule.span_traceDual_one_eq_traceDual_one :
+theorem span_traceDual_one_eq_traceDual_one :
     Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) =
       Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) := by
   apply le_antisymm
+  -- Extension of scalars sends an integral trace value to its localized image.
   · rw [Submodule.span_le]
     intro x hx
     simp only [SetLike.mem_coe] at hx ⊢
@@ -85,49 +135,10 @@ theorem Submodule.span_traceDual_one_eq_traceDual_one :
       (mem_nonZeroDivisors_iff_ne_zero.mp (hM hm)))
     rw [IsScalarTower.algebraMap_apply R Rₘ K, ← map_mul, IsLocalization.mk'_spec]
     simpa only [IsScalarTower.algebraMap_apply R Rₘ K] using htrace.symm
+  -- Conversely, clear one denominator for trace values on a finite set of algebra generators.
   · intro x hx
-    rw [Submodule.mem_traceDual] at hx
-    obtain ⟨s, hs⟩ := Module.Finite.fg_top (R := R) (M := S)
-    choose c hc using fun i : s ↦ hx (algebraMap S L i) (Submodule.mem_one.mpr
-      ⟨algebraMap S Sₘ i, by rw [← IsScalarTower.algebraMap_apply S Sₘ L]⟩)
-    obtain ⟨b, hb⟩ := IsLocalization.exist_integer_multiples_of_finite M c
-    have hbx : algebraMap R K b • x ∈ Submodule.traceDual R K (1 : Submodule S L) := by
-      rw [Submodule.mem_traceDual]
-      intro a ha
-      rw [Submodule.mem_one] at ha
-      obtain ⟨a, rfl⟩ := ha
-      let f : S →ₗ[R] K := ((Algebra.traceForm K L) (algebraMap R K b • x)).restrictScalars R
-        ∘ₗ (Algebra.linearMap S L).restrictScalars R
-      let N : Submodule R S := Submodule.comap f (1 : Submodule R K)
-      have hsN : (s : Set S) ⊆ N := by
-        intro i hi
-        let j : s := ⟨i, hi⟩
-        obtain ⟨r, hr⟩ := hb j
-        apply Submodule.mem_comap.mpr
-        rw [Submodule.mem_one]
-        refine ⟨r, ?_⟩
-        calc
-          algebraMap R K r = algebraMap Rₘ K (algebraMap R Rₘ r) := by
-            rw [IsScalarTower.algebraMap_apply R Rₘ K]
-          _ = algebraMap Rₘ K ((b : R) • c j) := congrArg (algebraMap Rₘ K) hr
-          _ = algebraMap R K b * algebraMap Rₘ K (c j) := by
-            rw [Algebra.smul_def, map_mul, ← IsScalarTower.algebraMap_apply R Rₘ K]
-          _ = algebraMap R K b * (Algebra.traceForm K L x) (algebraMap S L j) := by
-            rw [hc j]
-          _ = (Algebra.trace K L) (algebraMap R K b • (x * algebraMap S L j)) := by
-            rw [(Algebra.trace K L).map_smul, Algebra.traceForm_apply, Algebra.smul_def]
-            simp only [Algebra.algebraMap_self_apply]
-          _ = (Algebra.trace K L) ((algebraMap R K b • x) * algebraMap S L i) := by
-            congr 1
-            simp only [Algebra.smul_def, j]
-            ring
-          _ = f i := rfl
-      have hN : N = ⊤ := by
-        apply top_unique
-        rw [← hs]
-        exact Submodule.span_le.mpr hsN
-      have haN : a ∈ N := hN.symm ▸ Submodule.mem_top
-      exact Submodule.mem_one.mp (Submodule.mem_comap.mp haN)
+    obtain ⟨b, hbx⟩ := exists_smul_mem_traceDual_of_mem_traceDual
+      (R := R) (Rₘ := Rₘ) (S := S) (Sₘ := Sₘ) (K := K) (L := L) M hx
     let bm : Algebra.algebraMapSubmonoid S M := ⟨algebraMap R S b, ⟨b, b.2, rfl⟩⟩
     have hbx' := Submodule.smul_mem (Submodule.span Sₘ
       (Submodule.traceDual R K (1 : Submodule S L) : Set L)) (IsLocalization.mk' Sₘ 1 bm)
@@ -143,43 +154,56 @@ variable [IsFractionRing S L] [IsFractionRing Sₘ L]
 variable [IsIntegrallyClosed R] [IsIntegrallyClosed Rₘ]
 variable [IsIntegralClosure S R L] [IsIntegralClosure Sₘ Rₘ L]
 variable [FiniteDimensional K L] [Algebra.IsSeparable K L]
-variable [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] [IsTorsionFree S Sₘ]
+variable [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ]
 
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 /-- The trace-dual fractional ideal commutes with localization. -/
-theorem FractionalIdeal.extendedHom_dual_one_eq_dual_one :
-    FractionalIdeal.extendedHom L Sₘ
+theorem extendedHom_dual_one_eq_dual_one
+    (h : S⁰ ≤ Submonoid.comap (algebraMap S Sₘ) Sₘ⁰) :
+    FractionalIdeal.extendedHom' L h
         (FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) =
       FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L) := by
+  rw [FractionalIdeal.extendedHom'_apply]
   apply FractionalIdeal.coeToSubmodule_injective
-  let h : S⁰ ≤ Submonoid.comap (algebraMap S Sₘ) Sₘ⁰ :=
-    nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _
-      (FaithfulSMul.algebraMap_injective S Sₘ)
-  change (↑(FractionalIdeal.extended L h
-      (FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L))) : Submodule Sₘ L) =
-    (↑(FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L)) : Submodule Sₘ L)
-  rw [FractionalIdeal.coe_extended_eq_span, FractionalIdeal.coe_dual_one]
+  refine (FractionalIdeal.coe_extended_eq_span L h _).trans ?_
   have hmap : IsLocalization.map L (algebraMap S Sₘ) h = RingHom.id L := by
     apply IsFractionRing.ringHom_ext (A := S)
     intro s
     rw [IsLocalization.map_eq, RingHom.id_apply, IsScalarTower.algebraMap_apply S Sₘ L]
   rw [hmap]
   simp only [RingHom.id_apply, Set.image_id']
-  change Submodule.span Sₘ
-    ((↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) : Set L) = _
-  rw [FractionalIdeal.coe_dual_one]
-  exact Submodule.span_traceDual_one_eq_traceDual_one M hM
+  have hdual :
+      ((↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) : Set L) =
+        (Submodule.traceDual R K (1 : Submodule S L) : Set L) :=
+    congrArg (fun N : Submodule S L ↦ (N : Set L))
+      (FractionalIdeal.coe_dual_one R K L S)
+  calc
+    Submodule.span Sₘ
+        ((↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) : Set L) =
+        Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) :=
+      congrArg (Submodule.span Sₘ) hdual
+    _ = Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) :=
+      span_traceDual_one_eq_traceDual_one M hM
+    _ = (↑(FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L)) : Submodule Sₘ L) :=
+      (FractionalIdeal.coe_dual_one Rₘ K L Sₘ).symm
 
 include K L in
 /-- The different ideal commutes with localization. -/
-theorem Ideal.map_differentIdeal_eq_differentIdeal :
+theorem map_differentIdeal_eq_differentIdeal :
     (differentIdeal R S).map (algebraMap S Sₘ) = differentIdeal Rₘ Sₘ := by
+  have hMS : Algebra.algebraMapSubmonoid S M ≤ S⁰ :=
+    map_le_nonZeroDivisors_of_injective (algebraMap R S)
+      (FaithfulSMul.algebraMap_injective R S) hM
+  have hSSₘ : Function.Injective (algebraMap S Sₘ) := IsLocalization.injective Sₘ hMS
+  let h : S⁰ ≤ Submonoid.comap (algebraMap S Sₘ) Sₘ⁰ :=
+    nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _ hSSₘ
   rw [← FractionalIdeal.coeIdeal_inj (K := L),
-    ← FractionalIdeal.extendedHom_coeIdeal_eq_map (A := S) (K := L) (L := L) (B := Sₘ)]
+    ← FractionalIdeal.extended_coeIdeal_eq_map (K := L) L h,
+    ← FractionalIdeal.extendedHom'_apply]
   rw [coeIdeal_differentIdeal R K L S, coeIdeal_differentIdeal Rₘ K L Sₘ, map_inv₀,
-    FractionalIdeal.extendedHom_dual_one_eq_dual_one (R := R) (Rₘ := Rₘ) (S := S)
+    extendedHom_dual_one_eq_dual_one (R := R) (Rₘ := Rₘ) (S := S)
       (Sₘ := Sₘ)
-      (K := K) (L := L) M hM]
+      (K := K) (L := L) M hM h]
 
 end TauCeti
 

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -29,7 +29,7 @@ universe uR uRm uS uSm uK uL
 variable {R : Type uR} {Rₘ : Type uRm} {S : Type uS} {Sₘ : Type uSm}
 variable {K : Type uK} {L : Type uL}
 variable [CommRing R] [CommRing Rₘ] [CommRing S] [CommRing Sₘ] [Field K] [Field L]
-variable (M : Submonoid R)
+variable {M : Submonoid R}
 variable [Algebra R Rₘ] [Algebra R S] [Algebra Rₘ Sₘ] [Algebra S Sₘ]
 variable [Algebra R Sₘ] [IsScalarTower R S Sₘ]
 variable [Algebra R K] [Algebra Rₘ K] [IsScalarTower R Rₘ K]
@@ -142,7 +142,7 @@ theorem span_traceDual_one_eq_traceDual_one :
   -- Conversely, clear one denominator for trace values on a finite set of algebra generators.
   · intro x hx
     obtain ⟨b, hbx⟩ := exists_smul_mem_traceDual_of_mem_traceDual
-      (R := R) (Rₘ := Rₘ) (S := S) (Sₘ := Sₘ) (K := K) (L := L) M hx
+      (R := R) (Rₘ := Rₘ) (S := S) (Sₘ := Sₘ) (K := K) (L := L) (M := M) hx
     let bm : Algebra.algebraMapSubmonoid S M := ⟨algebraMap R S b, ⟨b, b.2, rfl⟩⟩
     have hbx' := Submodule.smul_mem (Submodule.span Sₘ
       (Submodule.traceDual R K (1 : Submodule S L) : Set L)) (IsLocalization.mk' Sₘ 1 bm)
@@ -153,12 +153,15 @@ theorem span_traceDual_one_eq_traceDual_one :
       ← mul_assoc, ← map_mul, IsLocalization.mk'_spec]
     simp only [map_one, one_mul]
 
-variable [IsDedekindDomain S] [IsDedekindDomain Sₘ]
 variable [IsFractionRing S L] [IsFractionRing Sₘ L]
 variable [IsIntegrallyClosed R] [IsIntegrallyClosed Rₘ]
 variable [IsIntegralClosure S R L] [IsIntegralClosure Sₘ Rₘ L]
 variable [FiniteDimensional K L] [Algebra.IsSeparable K L]
 variable [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ]
+
+section
+
+variable [IsDomain S] [IsDomain Sₘ]
 
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 /-- The trace-dual fractional ideal commutes with localization. -/
@@ -176,20 +179,33 @@ theorem extendedHom_dual_one_eq_dual_one
     rw [IsLocalization.map_eq, RingHom.id_apply, IsScalarTower.algebraMap_apply S Sₘ L]
   rw [hmap]
   simp only [RingHom.id_apply, Set.image_id']
-  have hdual :
-      ((↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) : Set L) =
-        (Submodule.traceDual R K (1 : Submodule S L) : Set L) :=
-    congrArg (fun N : Submodule S L ↦ (N : Set L))
-      (FractionalIdeal.coe_dual_one R K L S)
+  -- Mathlib's coercion lemma for `dual 1` is Dedekind-scoped, although this definitional
+  -- reduction only needs a domain.
+  have hdualS :
+      (↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) =
+        Submodule.traceDual R K (1 : Submodule S L) := by
+    set_option backward.isDefEq.respectTransparency.types false in
+      rw [FractionalIdeal.dual, dite_eq_right one_ne_zero, FractionalIdeal.coe_mk,
+        FractionalIdeal.coe_one]
+  have hdualSₘ :
+      (↑(FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L)) : Submodule Sₘ L) =
+        Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) := by
+    set_option backward.isDefEq.respectTransparency.types false in
+      rw [FractionalIdeal.dual, dite_eq_right one_ne_zero, FractionalIdeal.coe_mk,
+        FractionalIdeal.coe_one]
   calc
     Submodule.span Sₘ
         ((↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) : Set L) =
         Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) :=
-      congrArg (Submodule.span Sₘ) hdual
+      congrArg (Submodule.span Sₘ) (congrArg (fun N : Submodule S L ↦ (N : Set L)) hdualS)
     _ = Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) :=
-      span_traceDual_one_eq_traceDual_one M hM
+      span_traceDual_one_eq_traceDual_one (M := M) hM
     _ = (↑(FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L)) : Submodule Sₘ L) :=
-      (FractionalIdeal.coe_dual_one Rₘ K L Sₘ).symm
+      hdualSₘ.symm
+
+end
+
+variable [IsDedekindDomain S] [IsDedekindDomain Sₘ]
 
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 include K L in
@@ -216,7 +232,7 @@ theorem map_differentIdeal_eq_differentIdeal :
   rw [coeIdeal_differentIdeal R K L S, coeIdeal_differentIdeal Rₘ K L Sₘ, map_inv₀,
     extendedHom_dual_one_eq_dual_one (R := R) (Rₘ := Rₘ) (S := S)
       (Sₘ := Sₘ)
-      (K := K) (L := L) M hM h]
+      (K := K) (L := L) (M := M) hM h]
 
 end TauCeti
 

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -87,7 +87,11 @@ private theorem exists_smul_mem_traceDual_of_mem_traceDual {x : L}
         congr 1
         simp only [Algebra.smul_def, j]
         ring
-      _ = f i := rfl
+      _ = ((Algebra.traceForm K L) (algebraMap R K b • x)) (algebraMap S L i) := by
+        rw [Algebra.traceForm_apply]
+      _ = f i := by
+        simp only [f, LinearMap.comp_apply, LinearMap.restrictScalars_apply,
+          Algebra.linearMap_apply]
   have hN : N = ⊤ := by
     apply top_unique
     rw [← hs]
@@ -187,10 +191,19 @@ theorem extendedHom_dual_one_eq_dual_one
     _ = (↑(FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L)) : Submodule Sₘ L) :=
       (FractionalIdeal.coe_dual_one Rₘ K L Sₘ).symm
 
+omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 include K L in
 /-- The different ideal commutes with localization. -/
 theorem map_differentIdeal_eq_differentIdeal :
+    let _ : IsTorsionFree R L := .trans_faithfulSMul R K L
+    let _ : IsTorsionFree Rₘ L := .trans_faithfulSMul Rₘ K L
+    let _ : IsTorsionFree R S := IsIntegralClosure.isTorsionFree R L
+    let _ : IsTorsionFree Rₘ Sₘ := IsIntegralClosure.isTorsionFree Rₘ L
     (differentIdeal R S).map (algebraMap S Sₘ) = differentIdeal Rₘ Sₘ := by
+  have : IsTorsionFree R L := .trans_faithfulSMul R K L
+  have : IsTorsionFree Rₘ L := .trans_faithfulSMul Rₘ K L
+  have : IsTorsionFree R S := IsIntegralClosure.isTorsionFree R L
+  have : IsTorsionFree Rₘ Sₘ := IsIntegralClosure.isTorsionFree Rₘ L
   have hMS : Algebra.algebraMapSubmonoid S M ≤ S⁰ :=
     map_le_nonZeroDivisors_of_injective (algebraMap R S)
       (FaithfulSMul.algebraMap_injective R S) hM

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.Different
+public import Mathlib.RingTheory.Localization.NormTrace
+
+/-!
+# Localization of the different ideal
+
+This file proves that trace duals and different ideals commute with localization.  This is the
+localization input needed to read the transitivity theorem for different ideals coefficientwise at
+a tower of discrete valuations.
+-/
+
+public section
+
+open Module
+
+open scoped nonZeroDivisors
+
+namespace TauCeti
+
+universe uR uRm uS uSm uK uL
+
+variable {R : Type uR} {Rₘ : Type uRm} {S : Type uS} {Sₘ : Type uSm}
+variable {K : Type uK} {L : Type uL}
+variable [CommRing R] [CommRing Rₘ] [CommRing S] [CommRing Sₘ] [Field K] [Field L]
+variable (M : Submonoid R)
+variable [Algebra R Rₘ] [Algebra R S] [Algebra Rₘ Sₘ] [Algebra S Sₘ]
+variable [Algebra R Sₘ] [IsScalarTower R S Sₘ]
+variable [Algebra R K] [Algebra Rₘ K] [IsScalarTower R Rₘ K]
+variable [Algebra K L] [Algebra R L] [Algebra Rₘ L] [Algebra S L] [Algebra Sₘ L]
+variable [IsScalarTower R K L] [IsScalarTower Rₘ K L]
+variable [IsScalarTower R S L] [IsScalarTower Rₘ Sₘ L] [IsScalarTower S Sₘ L]
+variable [IsScalarTower R Sₘ L]
+variable [IsLocalization M Rₘ]
+variable [IsLocalization (Algebra.algebraMapSubmonoid S M) Sₘ]
+variable [Module.Finite R S]
+variable [IsDomain R] [IsDomain Rₘ]
+variable [IsFractionRing R K] [IsFractionRing Rₘ K]
+variable (hM : M ≤ R⁰)
+
+include M hM
+
+omit [IsDomain Rₘ] [IsFractionRing Rₘ K] in
+/-- The trace dual of a finite algebra commutes with localization. -/
+theorem Submodule.span_traceDual_one_eq_traceDual_one :
+    Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) =
+      Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) := by
+  apply le_antisymm
+  · rw [Submodule.span_le]
+    intro x hx
+    simp only [SetLike.mem_coe] at hx ⊢
+    rw [Submodule.mem_traceDual] at hx ⊢
+    intro a ha
+    rw [Submodule.mem_one] at ha
+    obtain ⟨a, rfl⟩ := ha
+    obtain ⟨⟨s, _, m, hm, rfl⟩, hsm⟩ := IsLocalization.surj
+      (Algebra.algebraMapSubmonoid S M) a
+    obtain ⟨r, hr⟩ := hx (algebraMap S L s) (Submodule.mem_one.mpr ⟨s, rfl⟩)
+    have hsmL : algebraMap Sₘ L a * algebraMap R L m = algebraMap S L s := by
+      simpa only [map_mul, IsScalarTower.algebraMap_apply R S Sₘ,
+        IsScalarTower.algebraMap_apply R Sₘ L, IsScalarTower.algebraMap_apply S Sₘ L]
+        using congrArg (algebraMap Sₘ L) hsm
+    have htrace : (Algebra.traceForm K L x) (algebraMap Sₘ L a) * algebraMap R K m =
+        algebraMap R K r := by
+      calc
+        _ = algebraMap R K m * (Algebra.trace K L) (x * algebraMap Sₘ L a) := mul_comm _ _
+        _ = (Algebra.trace K L) (algebraMap R K m • (x * algebraMap Sₘ L a)) :=
+          ((Algebra.trace K L).map_smul _ _).symm
+        _ = (Algebra.trace K L) (x * algebraMap S L s) := by
+          congr 1
+          rw [Algebra.smul_def, ← IsScalarTower.algebraMap_apply R K L]
+          calc
+            algebraMap R L m * (x * algebraMap Sₘ L a) =
+                x * (algebraMap Sₘ L a * algebraMap R L m) := by ring
+            _ = x * algebraMap S L s := by rw [hsmL]
+        _ = _ := hr.symm
+    refine ⟨IsLocalization.mk' Rₘ r ⟨m, hm⟩, ?_⟩
+    apply mul_right_cancel₀ (IsFractionRing.to_map_eq_zero_iff.ne.mpr
+      (mem_nonZeroDivisors_iff_ne_zero.mp (hM hm)))
+    rw [IsScalarTower.algebraMap_apply R Rₘ K, ← map_mul, IsLocalization.mk'_spec]
+    simpa only [IsScalarTower.algebraMap_apply R Rₘ K] using htrace.symm
+  · intro x hx
+    rw [Submodule.mem_traceDual] at hx
+    obtain ⟨s, hs⟩ := Module.Finite.fg_top (R := R) (M := S)
+    choose c hc using fun i : s ↦ hx (algebraMap S L i) (Submodule.mem_one.mpr
+      ⟨algebraMap S Sₘ i, by rw [← IsScalarTower.algebraMap_apply S Sₘ L]⟩)
+    obtain ⟨b, hb⟩ := IsLocalization.exist_integer_multiples_of_finite M c
+    have hbx : algebraMap R K b • x ∈ Submodule.traceDual R K (1 : Submodule S L) := by
+      rw [Submodule.mem_traceDual]
+      intro a ha
+      rw [Submodule.mem_one] at ha
+      obtain ⟨a, rfl⟩ := ha
+      let f : S →ₗ[R] K := ((Algebra.traceForm K L) (algebraMap R K b • x)).restrictScalars R
+        ∘ₗ (Algebra.linearMap S L).restrictScalars R
+      let N : Submodule R S := Submodule.comap f (1 : Submodule R K)
+      have hsN : (s : Set S) ⊆ N := by
+        intro i hi
+        let j : s := ⟨i, hi⟩
+        obtain ⟨r, hr⟩ := hb j
+        apply Submodule.mem_comap.mpr
+        rw [Submodule.mem_one]
+        refine ⟨r, ?_⟩
+        calc
+          algebraMap R K r = algebraMap Rₘ K (algebraMap R Rₘ r) := by
+            rw [IsScalarTower.algebraMap_apply R Rₘ K]
+          _ = algebraMap Rₘ K ((b : R) • c j) := congrArg (algebraMap Rₘ K) hr
+          _ = algebraMap R K b * algebraMap Rₘ K (c j) := by
+            rw [Algebra.smul_def, map_mul, ← IsScalarTower.algebraMap_apply R Rₘ K]
+          _ = algebraMap R K b * (Algebra.traceForm K L x) (algebraMap S L j) := by
+            rw [hc j]
+          _ = (Algebra.trace K L) (algebraMap R K b • (x * algebraMap S L j)) := by
+            rw [(Algebra.trace K L).map_smul, Algebra.traceForm_apply, Algebra.smul_def]
+            simp only [Algebra.algebraMap_self_apply]
+          _ = (Algebra.trace K L) ((algebraMap R K b • x) * algebraMap S L i) := by
+            congr 1
+            simp only [Algebra.smul_def, j]
+            ring
+          _ = f i := rfl
+      have hN : N = ⊤ := by
+        apply top_unique
+        rw [← hs]
+        exact Submodule.span_le.mpr hsN
+      have haN : a ∈ N := hN.symm ▸ Submodule.mem_top
+      exact Submodule.mem_one.mp (Submodule.mem_comap.mp haN)
+    let bm : Algebra.algebraMapSubmonoid S M := ⟨algebraMap R S b, ⟨b, b.2, rfl⟩⟩
+    have hbx' := Submodule.smul_mem (Submodule.span Sₘ
+      (Submodule.traceDual R K (1 : Submodule S L) : Set L)) (IsLocalization.mk' Sₘ 1 bm)
+      (Submodule.subset_span hbx)
+    suffices IsLocalization.mk' Sₘ 1 bm • (algebraMap R K b • x) = x by rwa [this] at hbx'
+    rw [Algebra.smul_def, Algebra.smul_def, ← IsScalarTower.algebraMap_apply R K L,
+      IsScalarTower.algebraMap_apply R S L, IsScalarTower.algebraMap_apply S Sₘ L,
+      ← mul_assoc, ← map_mul, IsLocalization.mk'_spec]
+    simp only [map_one, one_mul]
+
+variable [IsDedekindDomain S] [IsDedekindDomain Sₘ]
+variable [IsFractionRing S L] [IsFractionRing Sₘ L]
+variable [IsIntegrallyClosed R] [IsIntegrallyClosed Rₘ]
+variable [IsIntegralClosure S R L] [IsIntegralClosure Sₘ Rₘ L]
+variable [FiniteDimensional K L] [Algebra.IsSeparable K L]
+variable [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] [IsTorsionFree S Sₘ]
+
+omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
+/-- The trace-dual fractional ideal commutes with localization. -/
+theorem FractionalIdeal.extendedHom_dual_one_eq_dual_one :
+    FractionalIdeal.extendedHom L Sₘ
+        (FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) =
+      FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L) := by
+  apply FractionalIdeal.coeToSubmodule_injective
+  let h : S⁰ ≤ Submonoid.comap (algebraMap S Sₘ) Sₘ⁰ :=
+    nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _
+      (FaithfulSMul.algebraMap_injective S Sₘ)
+  change (↑(FractionalIdeal.extended L h
+      (FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L))) : Submodule Sₘ L) =
+    (↑(FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L)) : Submodule Sₘ L)
+  rw [FractionalIdeal.coe_extended_eq_span, FractionalIdeal.coe_dual_one]
+  have hmap : IsLocalization.map L (algebraMap S Sₘ) h = RingHom.id L := by
+    apply IsFractionRing.ringHom_ext (A := S)
+    intro s
+    rw [IsLocalization.map_eq, RingHom.id_apply, IsScalarTower.algebraMap_apply S Sₘ L]
+  rw [hmap]
+  simp only [RingHom.id_apply, Set.image_id']
+  change Submodule.span Sₘ
+    ((↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) : Set L) = _
+  rw [FractionalIdeal.coe_dual_one]
+  exact Submodule.span_traceDual_one_eq_traceDual_one M hM
+
+include K L in
+/-- The different ideal commutes with localization. -/
+theorem Ideal.map_differentIdeal_eq_differentIdeal :
+    (differentIdeal R S).map (algebraMap S Sₘ) = differentIdeal Rₘ Sₘ := by
+  rw [← FractionalIdeal.coeIdeal_inj (K := L),
+    ← FractionalIdeal.extendedHom_coeIdeal_eq_map (A := S) (K := L) (L := L) (B := Sₘ)]
+  rw [coeIdeal_differentIdeal R K L S, coeIdeal_differentIdeal Rₘ K L Sₘ, map_inv₀,
+    FractionalIdeal.extendedHom_dual_one_eq_dual_one (R := R) (Rₘ := Rₘ) (S := S)
+      (Sₘ := Sₘ)
+      (K := K) (L := L) M hM]
+
+end TauCeti
+
+end

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -106,6 +106,7 @@ private theorem exists_smul_mem_traceDual_of_mem_traceDual {x : L}
 
 omit [IsDomain R] [IsDomain Rₘ] [IsFractionRing Rₘ K] in
 /-- The trace dual of a finite algebra commutes with localization. -/
+@[simp]
 theorem span_traceDual_one_eq_traceDual_one :
     Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) =
       Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) := by
@@ -181,6 +182,7 @@ variable [IsDomain S] [IsDomain Sₘ]
 
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 /-- The trace-dual fractional ideal commutes with localization. -/
+@[simp]
 theorem extendedHom'_dual_one_eq_dual_one :
     FractionalIdeal.extendedHom' L
         (nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _
@@ -227,6 +229,7 @@ variable [IsDedekindDomain S] [IsDedekindDomain Sₘ]
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 include K L in
 /-- The different ideal commutes with localization. -/
+@[simp]
 theorem map_differentIdeal_eq_differentIdeal :
     let _ : IsTorsionFree R L := .trans_faithfulSMul R K L
     let _ : IsTorsionFree Rₘ L := .trans_faithfulSMul Rₘ K L

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -14,6 +14,11 @@ public import Mathlib.RingTheory.Localization.Integer
 This file proves that trace duals and different ideals commute with localization.  This is the
 localization input needed to read the transitivity theorem for different ideals coefficientwise at
 a tower of discrete valuations.
+
+## References
+
+- [AlgebraicCurves roadmap, Layer 7](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/AlgebraicCurves/README.md#layer-7-the-different-and-the-hurwitz-genus-formula)
+- H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., Sections III.4–III.5.
 -/
 
 public section
@@ -99,11 +104,12 @@ private theorem exists_smul_mem_traceDual_of_mem_traceDual {x : L}
   have haN : a ∈ N := hN.symm ▸ Submodule.mem_top
   exact Submodule.mem_one.mp (Submodule.mem_comap.mp haN)
 
-omit [IsDomain Rₘ] [IsFractionRing Rₘ K] in
+omit [IsDomain R] [IsDomain Rₘ] [IsFractionRing Rₘ K] in
 /-- The trace dual of a finite algebra commutes with localization. -/
 theorem span_traceDual_one_eq_traceDual_one :
     Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) =
       Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) := by
+  let _ : Nontrivial R := (algebraMap R K).domain_nontrivial
   apply le_antisymm
   -- Extension of scalars sends an integral trace value to its localized image.
   · rw [Submodule.span_le]
@@ -136,7 +142,7 @@ theorem span_traceDual_one_eq_traceDual_one :
         _ = _ := hr.symm
     refine ⟨IsLocalization.mk' Rₘ r ⟨m, hm⟩, ?_⟩
     apply mul_right_cancel₀ (IsFractionRing.to_map_eq_zero_iff.ne.mpr
-      (mem_nonZeroDivisors_iff_ne_zero.mp (hM hm)))
+      (nonZeroDivisors.ne_zero (hM hm)))
     rw [IsScalarTower.algebraMap_apply R Rₘ K, ← map_mul, IsLocalization.mk'_spec]
     simpa only [IsScalarTower.algebraMap_apply R Rₘ K] using htrace.symm
   -- Conversely, clear one denominator for trace values on a finite set of algebra generators.
@@ -159,6 +165,16 @@ variable [IsIntegralClosure S R L] [IsIntegralClosure Sₘ Rₘ L]
 variable [FiniteDimensional K L] [Algebra.IsSeparable K L]
 variable [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ]
 
+omit M [Module.Finite R S] [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] hM in
+private theorem coe_dual_one [IsDomain S] :
+    (↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) =
+      Submodule.traceDual R K (1 : Submodule S L) := by
+  -- Mathlib's public coercion lemma is Dedekind-scoped; unfold once here to expose the
+  -- domain-level definitional equality needed by the more general localization theorem.
+  set_option backward.isDefEq.respectTransparency.types false in
+    rw [FractionalIdeal.dual, dite_eq_right one_ne_zero, FractionalIdeal.coe_mk,
+      FractionalIdeal.coe_one]
+
 section
 
 variable [IsDomain S] [IsDomain Sₘ]
@@ -180,6 +196,8 @@ theorem extendedHom'_dual_one_eq_dual_one :
   let h : S⁰ ≤ Submonoid.comap (algebraMap S Sₘ) Sₘ⁰ :=
     nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _
       (IsLocalization.injective Sₘ hMS)
+  -- `extendedHom'` takes the inclusion proof explicitly, so proof irrelevance identifies the
+  -- canonical proof in the statement with the named proof `h` used throughout this proof.
   change FractionalIdeal.extendedHom' L h
       (FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) = _
   rw [FractionalIdeal.extendedHom'_apply]
@@ -191,29 +209,16 @@ theorem extendedHom'_dual_one_eq_dual_one :
     rw [IsLocalization.map_eq, RingHom.id_apply, IsScalarTower.algebraMap_apply S Sₘ L]
   rw [hmap]
   simp only [RingHom.id_apply, Set.image_id']
-  -- Mathlib's coercion lemma for `dual 1` is Dedekind-scoped, although this definitional
-  -- reduction only needs a domain.
-  have hdualS :
-      (↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) =
-        Submodule.traceDual R K (1 : Submodule S L) := by
-    set_option backward.isDefEq.respectTransparency.types false in
-      rw [FractionalIdeal.dual, dite_eq_right one_ne_zero, FractionalIdeal.coe_mk,
-        FractionalIdeal.coe_one]
-  have hdualSₘ :
-      (↑(FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L)) : Submodule Sₘ L) =
-        Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) := by
-    set_option backward.isDefEq.respectTransparency.types false in
-      rw [FractionalIdeal.dual, dite_eq_right one_ne_zero, FractionalIdeal.coe_mk,
-        FractionalIdeal.coe_one]
   calc
     Submodule.span Sₘ
         ((↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) : Set L) =
         Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) :=
-      congrArg (Submodule.span Sₘ) (congrArg (fun N : Submodule S L ↦ (N : Set L)) hdualS)
+      congrArg (Submodule.span Sₘ)
+        (congrArg (fun N : Submodule S L ↦ (N : Set L)) coe_dual_one)
     _ = Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) :=
       span_traceDual_one_eq_traceDual_one (M := M) hM
     _ = (↑(FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L)) : Submodule Sₘ L) :=
-      hdualSₘ.symm
+      (coe_dual_one (R := Rₘ) (S := Sₘ)).symm
 
 end
 

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -46,14 +46,13 @@ variable [IsLocalization M Rₘ]
 variable [IsLocalization (Algebra.algebraMapSubmonoid S M) Sₘ]
 variable [Module.Finite R S]
 variable [IsDomain R] [IsDomain Rₘ]
-variable [IsFractionRing R K] [IsFractionRing Rₘ K]
-variable (hM : M ≤ R⁰)
+variable [IsFractionRing R K]
 
-include M hM
+include M
 
 omit [Algebra R Sₘ] [IsScalarTower R S Sₘ] [IsScalarTower R Sₘ L]
   [IsLocalization (Algebra.algebraMapSubmonoid S M) Sₘ] [IsDomain R] [IsDomain Rₘ]
-  [IsFractionRing R K] [IsFractionRing Rₘ K] hM in
+  [IsFractionRing R K] in
 private theorem exists_smul_mem_traceDual_of_mem_traceDual {x : L}
     (hx : x ∈ Submodule.traceDual Rₘ K (1 : Submodule Sₘ L)) :
     ∃ b : M, algebraMap R K b • x ∈ Submodule.traceDual R K (1 : Submodule S L) := by
@@ -104,7 +103,7 @@ private theorem exists_smul_mem_traceDual_of_mem_traceDual {x : L}
   have haN : a ∈ N := hN.symm ▸ Submodule.mem_top
   exact Submodule.mem_one.mp (Submodule.mem_comap.mp haN)
 
-omit [IsDomain R] [IsDomain Rₘ] [IsFractionRing R K] [IsFractionRing Rₘ K] hM in
+omit [IsDomain R] [IsDomain Rₘ] [IsFractionRing R K] in
 /-- The trace dual of a finite algebra commutes with localization. -/
 theorem span_traceDual_one_eq_traceDual_one :
     Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) =
@@ -160,24 +159,25 @@ theorem span_traceDual_one_eq_traceDual_one :
       ← mul_assoc, ← map_mul, IsLocalization.mk'_spec]
     simp only [map_one, one_mul]
 
-variable [IsFractionRing S L] [IsFractionRing Sₘ L]
-variable [IsIntegrallyClosed R] [IsIntegrallyClosed Rₘ]
+variable [IsFractionRing S L]
+variable [IsIntegrallyClosed R]
 variable [IsIntegralClosure S R L] [IsIntegralClosure Sₘ Rₘ L]
 variable [FiniteDimensional K L] [Algebra.IsSeparable K L]
 variable [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ]
 
 namespace FractionalIdeal
 
-omit M [Module.Finite R S] [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] hM in
+omit M [Module.Finite R S] [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 /-- Over a domain, the fractional-ideal trace dual of one coerces to the submodule trace dual. -/
+@[simp]
 theorem coe_dual_one_of_isDomain [IsDomain S] :
     (↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) =
       Submodule.traceDual R K (1 : Submodule S L) := by
-  -- Mathlib's public coercion lemma is Dedekind-scoped; unfold once here to expose the
-  -- domain-level definitional equality needed by the more general localization theorem.
-  set_option backward.isDefEq.respectTransparency.types false in
-    rw [FractionalIdeal.dual, dite_eq_right one_ne_zero, FractionalIdeal.coe_mk,
-      FractionalIdeal.coe_one]
+  ext x
+  change x ∈ FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L) ↔ _
+  have h : (1 : FractionalIdeal S⁰ L) ≠ 0 := one_ne_zero
+  simp [FractionalIdeal.dual, h]
+  rfl
 
 end FractionalIdeal
 
@@ -188,17 +188,36 @@ variable [IsDomain S] [IsDomain Sₘ]
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 /-- The trace-dual fractional ideal commutes with localization. -/
 theorem extended_dual_one_eq_dual_one :
+    let hM : M ≤ R⁰ := fun m hm ↦ mem_nonZeroDivisors_iff_ne_zero.mpr fun hm0 ↦
+      (IsLocalization.map_units Rₘ ⟨m, hm⟩).ne_zero (by simp [hm0])
+    let hMS : Algebra.algebraMapSubmonoid S M ≤ S⁰ :=
+      map_le_nonZeroDivisors_of_injective _
+        (algebraMap_injective_of_field_isFractionRing R S K L) hM
+    let _ : IsFractionRing Rₘ K :=
+      IsFractionRing.isFractionRing_of_isDomain_of_isLocalization M Rₘ K
+    let _ : IsIntegrallyClosed Rₘ :=
+      isIntegrallyClosed_of_isLocalization Rₘ M hM
+    let _ : IsFractionRing Sₘ L :=
+      IsFractionRing.isFractionRing_of_isDomain_of_isLocalization
+        (Algebra.algebraMapSubmonoid S M) Sₘ L
     FractionalIdeal.extended L
         (nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _
-          (IsLocalization.injective Sₘ
-            (show Algebra.algebraMapSubmonoid S M ≤ S⁰ from
-              map_le_nonZeroDivisors_of_injective _
-                (algebraMap_injective_of_field_isFractionRing R S K L) hM)))
+          (IsLocalization.injective Sₘ hMS))
         (FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) =
       FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L) := by
+  dsimp only
+  let hM : M ≤ R⁰ := fun m hm ↦ mem_nonZeroDivisors_iff_ne_zero.mpr fun hm0 ↦
+    (IsLocalization.map_units Rₘ ⟨m, hm⟩).ne_zero (by simp [hm0])
   let hMS : Algebra.algebraMapSubmonoid S M ≤ S⁰ :=
     map_le_nonZeroDivisors_of_injective _
       (algebraMap_injective_of_field_isFractionRing R S K L) hM
+  let _ : IsFractionRing Rₘ K :=
+    IsFractionRing.isFractionRing_of_isDomain_of_isLocalization M Rₘ K
+  let _ : IsIntegrallyClosed Rₘ :=
+    isIntegrallyClosed_of_isLocalization Rₘ M hM
+  let _ : IsFractionRing Sₘ L :=
+    IsFractionRing.isFractionRing_of_isDomain_of_isLocalization
+      (Algebra.algebraMapSubmonoid S M) Sₘ L
   let h : S⁰ ≤ Submonoid.comap (algebraMap S Sₘ) Sₘ⁰ :=
     nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _
       (IsLocalization.injective Sₘ hMS)
@@ -228,17 +247,38 @@ theorem extended_dual_one_eq_dual_one :
 
 end
 
-variable [IsDedekindDomain S] [IsDedekindDomain Sₘ]
+variable [IsDedekindDomain S]
 
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 include K L in
 /-- The different ideal commutes with localization. -/
 theorem map_differentIdeal_eq_differentIdeal :
+    let hM : M ≤ R⁰ := fun m hm ↦ mem_nonZeroDivisors_iff_ne_zero.mpr fun hm0 ↦
+      (IsLocalization.map_units Rₘ ⟨m, hm⟩).ne_zero (by simp [hm0])
+    let hMS : Algebra.algebraMapSubmonoid S M ≤ S⁰ :=
+      map_le_nonZeroDivisors_of_injective _
+        (algebraMap_injective_of_field_isFractionRing R S K L) hM
+    let _ : IsFractionRing Rₘ K :=
+      IsFractionRing.isFractionRing_of_isDomain_of_isLocalization M Rₘ K
+    let _ : IsIntegrallyClosed Rₘ :=
+      isIntegrallyClosed_of_isLocalization Rₘ M hM
+    let _ : IsDomain Sₘ := IsLocalization.isDomain_of_le_nonZeroDivisors Sₘ hMS
+    let _ : IsFractionRing Sₘ L :=
+      IsFractionRing.isFractionRing_of_isDomain_of_isLocalization
+        (Algebra.algebraMapSubmonoid S M) Sₘ L
+    let _ : IsDedekindDomain Sₘ := IsLocalization.isDedekindDomain S hMS Sₘ
     let _ : IsTorsionFree R L := .trans_faithfulSMul R K L
     let _ : IsTorsionFree Rₘ L := .trans_faithfulSMul Rₘ K L
     let _ : IsTorsionFree R S := IsIntegralClosure.isTorsionFree R L
     let _ : IsTorsionFree Rₘ Sₘ := IsIntegralClosure.isTorsionFree Rₘ L
     (differentIdeal R S).map (algebraMap S Sₘ) = differentIdeal Rₘ Sₘ := by
+  dsimp only
+  let hM : M ≤ R⁰ := fun m hm ↦ mem_nonZeroDivisors_iff_ne_zero.mpr fun hm0 ↦
+    (IsLocalization.map_units Rₘ ⟨m, hm⟩).ne_zero (by simp [hm0])
+  let _ : IsFractionRing Rₘ K :=
+    IsFractionRing.isFractionRing_of_isDomain_of_isLocalization M Rₘ K
+  let _ : IsIntegrallyClosed Rₘ :=
+    isIntegrallyClosed_of_isLocalization Rₘ M hM
   have : IsTorsionFree R L := .trans_faithfulSMul R K L
   have : IsTorsionFree Rₘ L := .trans_faithfulSMul Rₘ K L
   have : IsTorsionFree R S := IsIntegralClosure.isTorsionFree R L
@@ -246,6 +286,11 @@ theorem map_differentIdeal_eq_differentIdeal :
   have hMS : Algebra.algebraMapSubmonoid S M ≤ S⁰ :=
     map_le_nonZeroDivisors_of_injective (algebraMap R S)
       (FaithfulSMul.algebraMap_injective R S) hM
+  let _ : IsDomain Sₘ := IsLocalization.isDomain_of_le_nonZeroDivisors Sₘ hMS
+  let _ : IsFractionRing Sₘ L :=
+    IsFractionRing.isFractionRing_of_isDomain_of_isLocalization
+      (Algebra.algebraMapSubmonoid S M) Sₘ L
+  let _ : IsDedekindDomain Sₘ := IsLocalization.isDedekindDomain S hMS Sₘ
   have hSSₘ : Function.Injective (algebraMap S Sₘ) := IsLocalization.injective Sₘ hMS
   let h : S⁰ ≤ Submonoid.comap (algebraMap S Sₘ) Sₘ⁰ :=
     nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _ hSSₘ
@@ -256,7 +301,7 @@ theorem map_differentIdeal_eq_differentIdeal :
     FractionalIdeal.extendedHom'_apply,
     extended_dual_one_eq_dual_one (R := R) (Rₘ := Rₘ) (S := S)
       (Sₘ := Sₘ)
-      (K := K) (L := L) (M := M) hM]
+      (K := K) (L := L) (M := M)]
 
 end TauCeti
 

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -45,13 +45,13 @@ variable [IsScalarTower R Sₘ L]
 variable [IsLocalization M Rₘ]
 variable [IsLocalization (Algebra.algebraMapSubmonoid S M) Sₘ]
 variable [Module.Finite R S]
-variable [IsDomain R] [IsDomain Rₘ]
+variable [IsDomain R]
 variable [IsFractionRing R K]
 
 include M
 
 omit [Algebra R Sₘ] [IsScalarTower R S Sₘ] [IsScalarTower R Sₘ L]
-  [IsLocalization (Algebra.algebraMapSubmonoid S M) Sₘ] [IsDomain R] [IsDomain Rₘ]
+  [IsLocalization (Algebra.algebraMapSubmonoid S M) Sₘ] [IsDomain R]
   [IsFractionRing R K] in
 private theorem exists_smul_mem_traceDual_of_mem_traceDual {x : L}
     (hx : x ∈ Submodule.traceDual Rₘ K (1 : Submodule Sₘ L)) :
@@ -103,7 +103,7 @@ private theorem exists_smul_mem_traceDual_of_mem_traceDual {x : L}
   have haN : a ∈ N := hN.symm ▸ Submodule.mem_top
   exact Submodule.mem_one.mp (Submodule.mem_comap.mp haN)
 
-omit [IsDomain R] [IsDomain Rₘ] [IsFractionRing R K] in
+omit [IsDomain R] [IsFractionRing R K] in
 /-- The trace dual of a finite algebra commutes with localization. -/
 theorem span_traceDual_one_eq_traceDual_one :
     Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) =
@@ -172,8 +172,10 @@ variable [IsDomain S]
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 /-- The trace-dual fractional ideal commutes with localization. -/
 theorem extended_dual_one_eq_dual_one :
+    let _ : Nontrivial Rₘ := (algebraMap Rₘ K).domain_nontrivial
     let hM : M ≤ R⁰ := fun m hm ↦ mem_nonZeroDivisors_iff_ne_zero.mpr fun hm0 ↦
       (IsLocalization.map_units Rₘ ⟨m, hm⟩).ne_zero (by simp [hm0])
+    let _ : IsDomain Rₘ := IsLocalization.isDomain_of_le_nonZeroDivisors Rₘ hM
     let hMS : Algebra.algebraMapSubmonoid S M ≤ S⁰ :=
       map_le_nonZeroDivisors_of_injective _
         (algebraMap_injective_of_field_isFractionRing R S K L) hM
@@ -191,8 +193,10 @@ theorem extended_dual_one_eq_dual_one :
         (FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) =
       FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L) := by
   dsimp only
+  let _ : Nontrivial Rₘ := (algebraMap Rₘ K).domain_nontrivial
   let hM : M ≤ R⁰ := fun m hm ↦ mem_nonZeroDivisors_iff_ne_zero.mpr fun hm0 ↦
     (IsLocalization.map_units Rₘ ⟨m, hm⟩).ne_zero (by simp [hm0])
+  let _ : IsDomain Rₘ := IsLocalization.isDomain_of_le_nonZeroDivisors Rₘ hM
   let hMS : Algebra.algebraMapSubmonoid S M ≤ S⁰ :=
     map_le_nonZeroDivisors_of_injective _
       (algebraMap_injective_of_field_isFractionRing R S K L) hM
@@ -239,8 +243,10 @@ omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 include K L in
 /-- The different ideal commutes with localization. -/
 theorem map_differentIdeal_eq_differentIdeal :
+    let _ : Nontrivial Rₘ := (algebraMap Rₘ K).domain_nontrivial
     let hM : M ≤ R⁰ := fun m hm ↦ mem_nonZeroDivisors_iff_ne_zero.mpr fun hm0 ↦
       (IsLocalization.map_units Rₘ ⟨m, hm⟩).ne_zero (by simp [hm0])
+    let _ : IsDomain Rₘ := IsLocalization.isDomain_of_le_nonZeroDivisors Rₘ hM
     let hMS : Algebra.algebraMapSubmonoid S M ≤ S⁰ :=
       map_le_nonZeroDivisors_of_injective _
         (algebraMap_injective_of_field_isFractionRing R S K L) hM
@@ -259,8 +265,10 @@ theorem map_differentIdeal_eq_differentIdeal :
     let _ : IsTorsionFree Rₘ Sₘ := IsIntegralClosure.isTorsionFree Rₘ L
     (differentIdeal R S).map (algebraMap S Sₘ) = differentIdeal Rₘ Sₘ := by
   dsimp only
+  let _ : Nontrivial Rₘ := (algebraMap Rₘ K).domain_nontrivial
   let hM : M ≤ R⁰ := fun m hm ↦ mem_nonZeroDivisors_iff_ne_zero.mpr fun hm0 ↦
     (IsLocalization.map_units Rₘ ⟨m, hm⟩).ne_zero (by simp [hm0])
+  let _ : IsDomain Rₘ := IsLocalization.isDomain_of_le_nonZeroDivisors Rₘ hM
   let _ : IsFractionRing Rₘ K :=
     IsFractionRing.isFractionRing_of_isDomain_of_isLocalization M Rₘ K
   let _ : IsIntegrallyClosed Rₘ :=

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -5,8 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.RingTheory.DedekindDomain.Different
 public import Mathlib.RingTheory.Localization.Integer
+public import TauCeti.RingTheory.DedekindDomain.Different.Basic
 
 /-!
 # Localization of the different ideal
@@ -165,25 +165,9 @@ variable [IsIntegralClosure S R L] [IsIntegralClosure Sₘ Rₘ L]
 variable [FiniteDimensional K L] [Algebra.IsSeparable K L]
 variable [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ]
 
-namespace FractionalIdeal
-
-omit M [Module.Finite R S] [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
-/-- Over a domain, the fractional-ideal trace dual of one coerces to the submodule trace dual. -/
-@[simp]
-theorem coe_dual_one_of_isDomain [IsDomain S] :
-    (↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) =
-      Submodule.traceDual R K (1 : Submodule S L) := by
-  ext x
-  change x ∈ FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L) ↔ _
-  have h : (1 : FractionalIdeal S⁰ L) ≠ 0 := one_ne_zero
-  simp [FractionalIdeal.dual, h]
-  rfl
-
-end FractionalIdeal
-
 section
 
-variable [IsDomain S] [IsDomain Sₘ]
+variable [IsDomain S]
 
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 /-- The trace-dual fractional ideal commutes with localization. -/
@@ -197,6 +181,7 @@ theorem extended_dual_one_eq_dual_one :
       IsFractionRing.isFractionRing_of_isDomain_of_isLocalization M Rₘ K
     let _ : IsIntegrallyClosed Rₘ :=
       isIntegrallyClosed_of_isLocalization Rₘ M hM
+    let _ : IsDomain Sₘ := IsLocalization.isDomain_of_le_nonZeroDivisors Sₘ hMS
     let _ : IsFractionRing Sₘ L :=
       IsFractionRing.isFractionRing_of_isDomain_of_isLocalization
         (Algebra.algebraMapSubmonoid S M) Sₘ L
@@ -215,6 +200,7 @@ theorem extended_dual_one_eq_dual_one :
     IsFractionRing.isFractionRing_of_isDomain_of_isLocalization M Rₘ K
   let _ : IsIntegrallyClosed Rₘ :=
     isIntegrallyClosed_of_isLocalization Rₘ M hM
+  let _ : IsDomain Sₘ := IsLocalization.isDomain_of_le_nonZeroDivisors Sₘ hMS
   let _ : IsFractionRing Sₘ L :=
     IsFractionRing.isFractionRing_of_isDomain_of_isLocalization
       (Algebra.algebraMapSubmonoid S M) Sₘ L

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -106,7 +106,6 @@ private theorem exists_smul_mem_traceDual_of_mem_traceDual {x : L}
 
 omit [IsDomain R] [IsDomain Rₘ] [IsFractionRing Rₘ K] in
 /-- The trace dual of a finite algebra commutes with localization. -/
-@[simp]
 theorem span_traceDual_one_eq_traceDual_one :
     Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) =
       Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) := by
@@ -182,9 +181,8 @@ variable [IsDomain S] [IsDomain Sₘ]
 
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 /-- The trace-dual fractional ideal commutes with localization. -/
-@[simp]
-theorem extendedHom'_dual_one_eq_dual_one :
-    FractionalIdeal.extendedHom' L
+theorem extended_dual_one_eq_dual_one :
+    FractionalIdeal.extended L
         (nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _
           (IsLocalization.injective Sₘ
             (show Algebra.algebraMapSubmonoid S M ≤ S⁰ from
@@ -198,11 +196,10 @@ theorem extendedHom'_dual_one_eq_dual_one :
   let h : S⁰ ≤ Submonoid.comap (algebraMap S Sₘ) Sₘ⁰ :=
     nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _
       (IsLocalization.injective Sₘ hMS)
-  -- `extendedHom'` takes the inclusion proof explicitly, so proof irrelevance identifies the
+  -- `extended` takes the inclusion proof explicitly, so proof irrelevance identifies the
   -- canonical proof in the statement with the named proof `h` used throughout this proof.
-  change FractionalIdeal.extendedHom' L h
+  change FractionalIdeal.extended L h
       (FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) = _
-  rw [FractionalIdeal.extendedHom'_apply]
   apply FractionalIdeal.coeToSubmodule_injective
   refine (FractionalIdeal.coe_extended_eq_span L h _).trans ?_
   have hmap : IsLocalization.map L (algebraMap S Sₘ) h = RingHom.id L := by
@@ -229,7 +226,6 @@ variable [IsDedekindDomain S] [IsDedekindDomain Sₘ]
 omit [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] in
 include K L in
 /-- The different ideal commutes with localization. -/
-@[simp]
 theorem map_differentIdeal_eq_differentIdeal :
     let _ : IsTorsionFree R L := .trans_faithfulSMul R K L
     let _ : IsTorsionFree Rₘ L := .trans_faithfulSMul Rₘ K L
@@ -250,7 +246,8 @@ theorem map_differentIdeal_eq_differentIdeal :
     ← FractionalIdeal.extended_coeIdeal_eq_map (K := L) L h,
     ← FractionalIdeal.extendedHom'_apply]
   rw [coeIdeal_differentIdeal R K L S, coeIdeal_differentIdeal Rₘ K L Sₘ, map_inv₀,
-    extendedHom'_dual_one_eq_dual_one (R := R) (Rₘ := Rₘ) (S := S)
+    FractionalIdeal.extendedHom'_apply,
+    extended_dual_one_eq_dual_one (R := R) (Rₘ := Rₘ) (S := S)
       (Sₘ := Sₘ)
       (K := K) (L := L) (M := M) hM]
 

--- a/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Different/Localization.lean
@@ -17,8 +17,8 @@ a tower of discrete valuations.
 
 ## References
 
-- [AlgebraicCurves roadmap, Layer 7](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/AlgebraicCurves/README.md#layer-7-the-different-and-the-hurwitz-genus-formula)
 - H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., Sections III.4–III.5.
+- A. Yang, [Mathlib's different-ideal formalization](https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/RingTheory/DedekindDomain/Different.lean).
 -/
 
 public section
@@ -104,7 +104,7 @@ private theorem exists_smul_mem_traceDual_of_mem_traceDual {x : L}
   have haN : a ∈ N := hN.symm ▸ Submodule.mem_top
   exact Submodule.mem_one.mp (Submodule.mem_comap.mp haN)
 
-omit [IsDomain R] [IsDomain Rₘ] [IsFractionRing Rₘ K] in
+omit [IsDomain R] [IsDomain Rₘ] [IsFractionRing R K] [IsFractionRing Rₘ K] hM in
 /-- The trace dual of a finite algebra commutes with localization. -/
 theorem span_traceDual_one_eq_traceDual_one :
     Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) =
@@ -141,8 +141,9 @@ theorem span_traceDual_one_eq_traceDual_one :
             _ = x * algebraMap S L s := by rw [hsmL]
         _ = _ := hr.symm
     refine ⟨IsLocalization.mk' Rₘ r ⟨m, hm⟩, ?_⟩
-    apply mul_right_cancel₀ (IsFractionRing.to_map_eq_zero_iff.ne.mpr
-      (nonZeroDivisors.ne_zero (hM hm)))
+    apply mul_right_cancel₀ (b := algebraMap R K m)
+    · rw [IsScalarTower.algebraMap_apply R Rₘ K]
+      exact ((IsLocalization.map_units Rₘ ⟨m, hm⟩).map (algebraMap Rₘ K)).ne_zero
     rw [IsScalarTower.algebraMap_apply R Rₘ K, ← map_mul, IsLocalization.mk'_spec]
     simpa only [IsScalarTower.algebraMap_apply R Rₘ K] using htrace.symm
   -- Conversely, clear one denominator for trace values on a finite set of algebra generators.
@@ -165,8 +166,11 @@ variable [IsIntegralClosure S R L] [IsIntegralClosure Sₘ Rₘ L]
 variable [FiniteDimensional K L] [Algebra.IsSeparable K L]
 variable [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ]
 
+namespace FractionalIdeal
+
 omit M [Module.Finite R S] [IsTorsionFree R S] [IsTorsionFree Rₘ Sₘ] hM in
-private theorem coe_dual_one [IsDomain S] :
+/-- Over a domain, the fractional-ideal trace dual of one coerces to the submodule trace dual. -/
+theorem coe_dual_one_of_isDomain [IsDomain S] :
     (↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) =
       Submodule.traceDual R K (1 : Submodule S L) := by
   -- Mathlib's public coercion lemma is Dedekind-scoped; unfold once here to expose the
@@ -174,6 +178,8 @@ private theorem coe_dual_one [IsDomain S] :
   set_option backward.isDefEq.respectTransparency.types false in
     rw [FractionalIdeal.dual, dite_eq_right one_ne_zero, FractionalIdeal.coe_mk,
       FractionalIdeal.coe_one]
+
+end FractionalIdeal
 
 section
 
@@ -213,11 +219,12 @@ theorem extended_dual_one_eq_dual_one :
         ((↑(FractionalIdeal.dual R K (1 : FractionalIdeal S⁰ L)) : Submodule S L) : Set L) =
         Submodule.span Sₘ (Submodule.traceDual R K (1 : Submodule S L) : Set L) :=
       congrArg (Submodule.span Sₘ)
-        (congrArg (fun N : Submodule S L ↦ (N : Set L)) coe_dual_one)
+        (congrArg (fun N : Submodule S L ↦ (N : Set L))
+          FractionalIdeal.coe_dual_one_of_isDomain)
     _ = Submodule.traceDual Rₘ K (1 : Submodule Sₘ L) :=
-      span_traceDual_one_eq_traceDual_one (M := M) hM
+      span_traceDual_one_eq_traceDual_one (M := M)
     _ = (↑(FractionalIdeal.dual Rₘ K (1 : FractionalIdeal Sₘ⁰ L)) : Submodule Sₘ L) :=
-      (coe_dual_one (R := Rₘ) (S := Sₘ)).symm
+      (FractionalIdeal.coe_dual_one_of_isDomain (R := Rₘ) (S := Sₘ)).symm
 
 end
 


### PR DESCRIPTION
This PR proves that trace duals, trace-dual fractional ideals, and the different ideal commute with localization. It advances the AlgebraicCurves Layer 7 milestone “different exponent transitivity in towers”; the exact roadmap target is “First prove that localization preserves the trace dual / different ideal,” whose result is consumed by the coefficientwise proof of `d(P″ ∣ P) = e(P″ ∣ P′) d(P′ ∣ P) + d(P″ ∣ P′)`.

The proof clears one common denominator for a finite set of algebra generators, then lifts the submodule equality through Mathlib's `FractionalIdeal.extendedHom` and `coeIdeal_differentIdeal` APIs. It reuses Mathlib's trace-dual and different-ideal infrastructure directly; no Mathlib code is vendored.

After this PR, the milestone still needs the global different-ideal transitivity theorem read coefficientwise at a tower of primes and identified with `Place.differentExponent`.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"different-ideal-localization"}-->

🤖 Prepared with Codex
