### PR TITLE
feat: the pinned weight torus of the Geck carrier of a Lie-type index

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/GeckCarrier.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/GeckCarrier.lean
@@ -166,10 +166,10 @@ the numbered raising subgroup at Bourbaki node `i` by a weight-torus point `s` r
 parameter by `α_i(s)`, where `α_i` is the simple root of the pinned simply connected root datum of
 the Dynkin type the index names, at the same node.
 
-The character is read in that root datum rather than as a row of the Cartan matrix because the
-whole numbered interface of this roadmap is indexed through
-`TauCeti.ValidLieTypeIndex.dynkinType`, so a consumer meets the simple roots and never the
-matrix. -/
+The character is read in that root datum rather than as a row of the Cartan matrix: the datum is
+the one attached to `TauCeti.ValidLieTypeIndex.dynkinType`, so it carries the Bourbaki node
+numbering that numbers the root subgroups here, and node `i` on either side is the same node. -/
+@[simp]
 theorem geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex (i : Fin d.rank)
     (s : Fin d.rank → d.Closureˣ) (u : Multiplicative d.Closure) :
     d.geckWeightTorus s * d.geckRootSubgroup (.inl i) u * (d.geckWeightTorus s)⁻¹ =
@@ -185,6 +185,7 @@ theorem geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex (i : Fin d.rank)
 
 /-- **The pinning equation of the Geck carrier of an index, at the negative of a named simple
 root.** -/
+@[simp]
 theorem geckWeightTorus_conj_geckRootSubgroup_neg_root_simpleIndex (i : Fin d.rank)
     (s : Fin d.rank → d.Closureˣ) (u : Multiplicative d.Closure) :
     d.geckWeightTorus s * d.geckRootSubgroup (.inr i) u * (d.geckWeightTorus s)⁻¹ =

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/GeckCarrier.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/GeckCarrier.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.GroupTheory.SpecificGroups.CFSG.Frobenius
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.Frobenius
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.RootDatum
 
 /-!
 # The Geck carrier of a Lie-type index
@@ -40,18 +41,28 @@ connected one, that its weight torus is maximal, or that its point group is fini
   the Geck carrier of the underlying Dynkin type over the algebraic closure of the prime field, as
   a subgroup of `GLₙ` and as a type.
 * `TauCeti.ValidLieTypeIndex.geckRootSubgroup`: its Bourbaki-numbered root subgroups.
+* `TauCeti.ValidLieTypeIndex.geckWeightTorus`: the split weight torus of the same carrier, of rank
+  the rank of the index.
 * `TauCeti.ValidLieTypeIndex.geckFrobenius`: its `q`-power Frobenius, for `q` the field order
   recorded by the index.
 
 ## Main results
 
+* `TauCeti.ValidLieTypeIndex.geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex` and its
+  negative-root counterpart: conjugation by a weight-torus point rescales the parameter of the
+  numbered root subgroup at node `i` by the simple root `α_i` of the root datum
+  `TauCeti.DynkinType.simplyConnectedRootDatum` of the Dynkin type the index names, in the same
+  Bourbaki numbering.
 * `TauCeti.ValidLieTypeIndex.coe_geckFrobenius_apply`: the Frobenius raises every matrix entry to
   the `q`-th power.
-* `TauCeti.ValidLieTypeIndex.geckFrobenius_geckRootSubgroup`: it raises the parameter of every
-  numbered root subgroup to the `q`-th power.
+* `TauCeti.ValidLieTypeIndex.geckFrobenius_geckRootSubgroup` and
+  `TauCeti.ValidLieTypeIndex.geckFrobenius_geckWeightTorus`: it raises the parameter of every
+  numbered root subgroup, and every coordinate of a weight-torus point, to the `q`-th power.
 * `TauCeti.ValidLieTypeIndex.mem_fixedSubgroup_geckFrobenius_iff`: its fixed points are the points
   whose matrix entries lie in the field of definition `𝔽_q` of
   `TauCeti.ValidLieTypeIndex.fixedField`.
+* `TauCeti.ValidLieTypeIndex.geckWeightTorus_mem_fixedSubgroup_geckFrobenius`: among those points
+  are the weight-torus points all of whose coordinates lie in `𝔽_q`.
 
 ## References
 
@@ -122,6 +133,71 @@ theorem coe_geckRootSubgroup (i : Fin d.dynkinType.rank ⊕ Fin d.dynkinType.ran
         ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := d.Closure)).symm u) :=
   d.dynkinType.coe_geckRootSubgroupPoints d.dynkinType_valid i d.Closure u
 
+/-! ## The pinned weight torus -/
+
+/-- **The split weight torus of the Geck point group of a valid Lie-type index**, of rank the rank
+of the index: the diagonal points through which the Geck coordinate weights act. Together with
+`TauCeti.ValidLieTypeIndex.geckRootSubgroup` it is the pinned data of the carrier that the
+conjugation equations below are stated against.
+
+As for the point group itself, no maximality statement is attached to it, and it is not claimed to
+be the split maximal torus of a pinned simply connected Chevalley--Demazure group. -/
+def geckWeightTorus : (Fin d.rank → d.Closureˣ) →* GeckGroup d :=
+  d.dynkinType.geckWeightTorusPoints d.dynkinType_valid d.Closure
+
+/-- The weight torus of an index is that of the pinned Geck carrier of the Dynkin type it names.
+This is its unfolding lemma; the definition itself stays sealed. -/
+theorem geckWeightTorus_def : d.geckWeightTorus =
+    d.dynkinType.geckWeightTorusPoints d.dynkinType_valid d.Closure := by
+  rw [geckWeightTorus]
+
+/-- The general linear matrix underlying a weight-torus point is the diagonal matrix of the Geck
+weight characters at that point. -/
+@[simp]
+theorem coe_geckWeightTorus (s : Fin d.rank → d.Closureˣ) :
+    (d.geckWeightTorus s : Matrix.GeneralLinearGroup
+        (Fin (d.dynkinType.geckDim d.dynkinType_valid)) d.Closure) =
+      d.dynkinType.geckTorusMatrix d.dynkinType_valid s := by
+  rw [geckWeightTorus_def]
+  exact d.dynkinType.coe_geckWeightTorusPoints d.dynkinType_valid d.Closure s
+
+/-- **The pinning equation of the Geck carrier of an index, at a named simple root.** Conjugating
+the numbered raising subgroup at Bourbaki node `i` by a weight-torus point `s` rescales its
+parameter by `α_i(s)`, where `α_i` is the simple root of the pinned simply connected root datum of
+the Dynkin type the index names, at the same node.
+
+The character is read in that root datum rather than as a row of the Cartan matrix because the
+whole numbered interface of this roadmap is indexed through
+`TauCeti.ValidLieTypeIndex.dynkinType`, so a consumer meets the simple roots and never the
+matrix. -/
+theorem geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex (i : Fin d.rank)
+    (s : Fin d.rank → d.Closureˣ) (u : Multiplicative d.Closure) :
+    d.geckWeightTorus s * d.geckRootSubgroup (.inl i) u * (d.geckWeightTorus s)⁻¹ =
+      d.geckRootSubgroup (.inl i)
+        (Multiplicative.ofAdd
+          ((torusCharacter s
+              ((d.dynkinType.simplyConnectedRootDatum d.dynkinType_valid).root
+                (d.dynkinType.simpleIndex d.dynkinType_valid i)) : d.Closure) *
+            Multiplicative.toAdd u)) := by
+  rw [geckWeightTorus_def]
+  exact d.dynkinType.geckWeightTorusPoints_conj_geckRootSubgroupPoints_root_simpleIndex
+    d.dynkinType_valid i d.Closure s u
+
+/-- **The pinning equation of the Geck carrier of an index, at the negative of a named simple
+root.** -/
+theorem geckWeightTorus_conj_geckRootSubgroup_neg_root_simpleIndex (i : Fin d.rank)
+    (s : Fin d.rank → d.Closureˣ) (u : Multiplicative d.Closure) :
+    d.geckWeightTorus s * d.geckRootSubgroup (.inr i) u * (d.geckWeightTorus s)⁻¹ =
+      d.geckRootSubgroup (.inr i)
+        (Multiplicative.ofAdd
+          ((torusCharacter s
+              (-(d.dynkinType.simplyConnectedRootDatum d.dynkinType_valid).root
+                (d.dynkinType.simpleIndex d.dynkinType_valid i)) : d.Closure) *
+            Multiplicative.toAdd u)) := by
+  rw [geckWeightTorus_def]
+  exact d.dynkinType.geckWeightTorusPoints_conj_geckRootSubgroupPoints_neg_root_simpleIndex
+    d.dynkinType_valid i d.Closure s u
+
 /-! ## The Frobenius endomorphism -/
 
 /-- **The `q`-power Frobenius endomorphism of the Geck point group**, for `q` the field order
@@ -164,6 +240,26 @@ theorem geckFrobenius_geckRootSubgroup (i : Fin d.dynkinType.rank ⊕ Fin d.dynk
   rw [d.fieldOrder_eq_characteristic_pow]
   exact d.dynkinType.geckFrobenius_geckRootSubgroupPoints d.dynkinType_valid
     d.characteristic d.fieldExponent d.Closure i u
+
+/-- **The Frobenius raises every coordinate of a weight-torus point to the `q`-th power.** -/
+@[simp]
+theorem geckFrobenius_geckWeightTorus (s : Fin d.rank → d.Closureˣ) :
+    d.geckFrobenius (d.geckWeightTorus s) = d.geckWeightTorus (s ^ d.fieldOrder) := by
+  rw [d.fieldOrder_eq_characteristic_pow, geckFrobenius_def, geckWeightTorus_def]
+  exact d.dynkinType.geckFrobenius_geckWeightTorusPoints d.dynkinType_valid
+    d.characteristic d.fieldExponent d.Closure s
+
+/-- **A weight-torus point whose coordinates lie in the field of definition is fixed by the
+Frobenius.** Writing `𝔽_q` for `TauCeti.ValidLieTypeIndex.fixedField`, these are the weight-torus
+points with coordinates in `𝔽_q`; that they exhaust the weight-torus points of the Frobenius-fixed
+group, or that they form a maximal torus of it, is not claimed. -/
+theorem geckWeightTorus_mem_fixedSubgroup_geckFrobenius (s : Fin d.rank → d.Closureˣ)
+    (hs : ∀ k, (s k : d.Closure) ∈ d.fixedField) :
+    d.geckWeightTorus s ∈ fixedSubgroup d.geckFrobenius := by
+  rw [mem_fixedSubgroup, geckFrobenius_geckWeightTorus]
+  refine congrArg _ (funext fun k => Units.ext ?_)
+  rw [Pi.pow_apply, Units.val_pow_eq_pow_val]
+  exact (d.mem_fixedField).1 (hs k)
 
 /-- **A point of the Geck point group is fixed by the Frobenius exactly when all of its matrix
 entries lie in the field of definition.** Writing `𝔽_q` for `TauCeti.ValidLieTypeIndex.fixedField`,

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/GeckCarrier.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/GeckCarrier.lean
@@ -145,8 +145,8 @@ be the split maximal torus of a pinned simply connected Chevalley--Demazure grou
 def geckWeightTorus : (Fin d.rank → d.Closureˣ) →* GeckGroup d :=
   d.dynkinType.geckWeightTorusPoints d.dynkinType_valid d.Closure
 
-/-- The weight torus of an index is that of the pinned Geck carrier of the Dynkin type it names.
-This is its unfolding lemma; the definition itself stays sealed. -/
+/-- The weight torus of an index is the represented weight torus of the pinned Geck carrier of the
+Dynkin type it names, over the algebraic closure of the prime field of the index. -/
 theorem geckWeightTorus_def : d.geckWeightTorus =
     d.dynkinType.geckWeightTorusPoints d.dynkinType_valid d.Closure := by
   rw [geckWeightTorus]

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/OrdinarySteinberg.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/OrdinarySteinberg.lean
@@ -65,6 +65,8 @@ branch whose carrier has not been identified.
 
 * `TauCeti.GraphTwistedIndex.geckGraphAut_geckRootSubgroup`: the graph automorphism renumbers the
   root subgroups by the diagram permutation and leaves their parameters alone.
+* `TauCeti.GraphTwistedIndex.geckGraphAut_geckWeightTorus`: it relabels the coordinates of a
+  weight-torus point by the inverse of that permutation.
 * `TauCeti.GraphTwistedIndex.geckGraphAut_pow_twistOrder`: the twist order of the index annihilates
   the graph automorphism.
 * `TauCeti.GraphTwistedIndex.geckGraphAut_comp_geckFrobenius`: the graph automorphism commutes with
@@ -73,6 +75,10 @@ branch whose carrier has not been identified.
 * `TauCeti.GraphTwistedIndex.geckSteinberg_geckRootSubgroup`: the Steinberg map raises the
   parameter of every numbered root subgroup to the `q`-th power and renumbers it by the diagram
   permutation.
+* `TauCeti.GraphTwistedIndex.geckSteinberg_geckWeightTorus`: it raises every coordinate of a
+  weight-torus point to the `q`-th power and relabels them by the inverse of that permutation.
+* `TauCeti.GraphTwistedIndex.geckWeightTorus_mem_fixedSubgroup_geckSteinberg`: a weight-torus point
+  satisfying the resulting twisted equations `s_{σ⁻¹ k} ^ q = s_k` is fixed by the Steinberg map.
 * `TauCeti.GraphTwistedIndex.geckSteinberg_eq_geckFrobenius_of_diagramPerm_eq_one`: on an untwisted
   family it is the Frobenius.
 * `TauCeti.UnimodularExceptionalIndex.steinberg_eq_geckSteinberg`: it agrees with the Steinberg map
@@ -168,6 +174,18 @@ theorem geckGraphAut_geckRootSubgroup (i : Fin d.1.rank ⊕ Fin d.1.rank)
     ValidLieTypeIndex.coe_geckRootSubgroup]
   exact h
 
+/-- **The graph automorphism relabels the coordinates of a weight-torus point** by the inverse of
+the diagram permutation, leaving the torus itself invariant. This is the torus half of the pinning
+equation that `TauCeti.GraphTwistedIndex.geckGraphAut_geckRootSubgroup` states on root
+subgroups. -/
+@[simp]
+theorem geckGraphAut_geckWeightTorus (s : Fin d.1.rank → d.1.Closureˣ) :
+    d.geckGraphAut (d.1.geckWeightTorus s) =
+      d.1.geckWeightTorus fun k => s (d.diagramPerm⁻¹ k) := by
+  rw [geckGraphAut_def, ValidLieTypeIndex.geckWeightTorus_def]
+  exact d.1.dynkinType.geckGraphAutPoints_geckWeightTorusPoints d.1.dynkinType_valid
+    d.diagramPerm_mem_diagramSymmetry d.1.Closure s
+
 /-- **The twist order recorded by an index annihilates its graph automorphism.** This is `γ ^ 2 = 1`
 for `²Aₙ`, `²Dₙ` and `²E₆`, `γ ^ 3 = 1` for `³D₄`, and the trivial relation on an untwisted family,
 which is the order relation milestone L1 requires of the graph factor. -/
@@ -252,6 +270,28 @@ theorem geckSteinberg_geckRootSubgroup (i : Fin d.1.rank ⊕ Fin d.1.rank)
         (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.fieldOrder)) := by
   rw [geckSteinberg_apply, ValidLieTypeIndex.geckFrobenius_geckRootSubgroup,
     geckGraphAut_geckRootSubgroup]
+
+/-- **The Steinberg map raises every coordinate of a weight-torus point to the `q`-th power and
+relabels them by the inverse of the diagram permutation.** This is the equation the map satisfies
+on the second half of the pinned data, beside
+`TauCeti.GraphTwistedIndex.geckSteinberg_geckRootSubgroup` on the root subgroups. -/
+@[simp]
+theorem geckSteinberg_geckWeightTorus (s : Fin d.1.rank → d.1.Closureˣ) :
+    d.geckSteinberg (d.1.geckWeightTorus s) =
+      d.1.geckWeightTorus fun k => s (d.diagramPerm⁻¹ k) ^ d.1.fieldOrder := by
+  rw [geckSteinberg_apply, ValidLieTypeIndex.geckFrobenius_geckWeightTorus,
+    geckGraphAut_geckWeightTorus]
+  exact congrArg _ (funext fun k => Pi.pow_apply s d.1.fieldOrder _)
+
+/-- **A weight-torus point satisfying the twisted equations of an index is fixed by its Steinberg
+map.** On an untwisted family, where the diagram permutation is the identity, the condition says
+that every coordinate lies in the field of definition `𝔽_q`; on a graph-twisted family it couples
+instead the coordinates that the permutation exchanges. -/
+theorem geckWeightTorus_mem_fixedSubgroup_geckSteinberg (s : Fin d.1.rank → d.1.Closureˣ)
+    (hs : ∀ k, s (d.diagramPerm⁻¹ k) ^ d.1.fieldOrder = s k) :
+    d.1.geckWeightTorus s ∈ fixedSubgroup d.geckSteinberg := by
+  rw [mem_fixedSubgroup, geckSteinberg_geckWeightTorus]
+  exact congrArg _ (funext hs)
 
 /-- **On a family whose diagram permutation is trivial the Steinberg map is the plain Frobenius.**
 Those are the nine untwisted constructors, where the printed family name carries no superscript. -/

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean
@@ -61,9 +61,11 @@ group is finite, perfect, or simple.
   form requires.
 * `TauCeti.UnimodularLieIndex.isClosedImmersion_geckWeightTorus`: consequently the pinned split
   torus is a closed subgroup scheme of the Geck carrier.
-* `TauCeti.UnimodularExceptionalIndex.steinberg_geckRootSubgroup`: the Steinberg map raises the
-  parameter of every numbered root subgroup to the `q`-th power, the shape of the equation
-  milestone L1 asks of the untwisted families, proved on this carrier.
+* `TauCeti.UnimodularExceptionalIndex.steinberg_geckRootSubgroup` and
+  `TauCeti.UnimodularExceptionalIndex.steinberg_geckWeightTorus`: the Steinberg map raises the
+  parameter of every numbered root subgroup, and every coordinate of a weight-torus point, to the
+  `q`-th power, the shape of the equations milestone L1 asks of the untwisted families, proved on
+  this carrier.
 * `TauCeti.UnimodularExceptionalIndex.mem_fixedSubgroup_steinberg_iff`: the fixed points of that
   map are the points of the carrier whose matrix entries lie in the field of definition `𝔽_q`
   recorded by `TauCeti.ValidLieTypeIndex.fixedField`.
@@ -192,6 +194,16 @@ theorem steinberg_geckRootSubgroup (i : Fin d.1.1.dynkinType.rank ⊕ Fin d.1.1.
         (Multiplicative.ofAdd (Multiplicative.toAdd u ^ d.1.1.fieldOrder)) := by
   rw [steinberg_eq_geckFrobenius]
   exact d.1.1.geckFrobenius_geckRootSubgroup i u
+
+/-- **The Steinberg map raises every coordinate of a weight-torus point to the `q`-th power.** It
+is the untwisted case of the equation a Steinberg endomorphism satisfies on the second half of the
+pinned data, the first half being `TauCeti.UnimodularExceptionalIndex.steinberg_geckRootSubgroup`
+on the root subgroups. -/
+@[simp]
+theorem steinberg_geckWeightTorus (s : Fin d.1.1.dynkinType.rank → d.1.1.Closureˣ) :
+    d.steinberg (d.1.1.geckWeightTorus s) = d.1.1.geckWeightTorus (s ^ d.1.1.fieldOrder) := by
+  rw [steinberg_eq_geckFrobenius]
+  exact d.1.1.geckFrobenius_geckWeightTorus s
 
 /-- **A point of the Geck point group is fixed by the Steinberg map exactly when all of its matrix
 entries lie in the field of definition.** Writing `𝔽_q` for

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean
@@ -64,8 +64,8 @@ group is finite, perfect, or simple.
 * `TauCeti.UnimodularExceptionalIndex.steinberg_geckRootSubgroup` and
   `TauCeti.UnimodularExceptionalIndex.steinberg_geckWeightTorus`: the Steinberg map raises the
   parameter of every numbered root subgroup, and every coordinate of a weight-torus point, to the
-  `q`-th power, the shape of the equations milestone L1 asks of the untwisted families, proved on
-  this carrier.
+  `q`-th power, which is how the Steinberg map of an untwisted index acts on both halves of the
+  pinned data of this carrier.
 * `TauCeti.UnimodularExceptionalIndex.mem_fixedSubgroup_steinberg_iff`: the fixed points of that
   map are the points of the carrier whose matrix entries lie in the field of definition `𝔽_q`
   recorded by `TauCeti.ValidLieTypeIndex.fixedField`.

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
@@ -75,6 +75,8 @@ reductivity, maximality of the weight torus, or any finiteness or simplicity sta
   points is the map the carrier automorphism induces.
 * `TauCeti.DynkinType.geckGraphAutPoints_geckRootSubgroupMatrix` and
   `TauCeti.DynkinType.geckGraphAutPoints_geckTorusMatrix`: the two pinning equations on points.
+* `TauCeti.DynkinType.geckGraphAutPoints_geckWeightTorusPoints`: the second of those equations
+  read on the represented weight torus, which is the form a consumer of that homomorphism uses.
 * `TauCeti.DynkinType.geckPointsMap_comp_geckGraphAutPoints`: the automorphism on points is natural
   in the value ring.
 * `TauCeti.DynkinType.geckGraphAutPoints_pow_eq_one` and
@@ -464,6 +466,23 @@ theorem geckGraphAutPoints_geckTorusMatrix (hsigma : sigma ∈ t.diagramSymmetry
   simp only [geckGraphAutMatrix]
   simpa only [TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] using
     hconj.trans (congrArg diagGL (funext hpt))
+
+/-- **The graph automorphism relabels a point of the represented weight torus** by the inverse of
+the diagram symmetry.
+
+This is `TauCeti.DynkinType.geckGraphAutPoints_geckTorusMatrix` stated on
+`TauCeti.DynkinType.geckWeightTorusPoints`, the homomorphism through which the weight torus enters
+the point group, so that both sides are values of that homomorphism. -/
+@[simp]
+theorem geckGraphAutPoints_geckWeightTorusPoints (hsigma : sigma ∈ t.diagramSymmetry)
+    (A : Type v) [CommRing A] (s : Fin t.rank → Aˣ) :
+    t.geckGraphAutPoints ht hsigma A (t.geckWeightTorusPoints ht A s) =
+      t.geckWeightTorusPoints ht A fun k => s (sigma⁻¹ k) := by
+  have htorus (r : Fin t.rank → Aˣ) :
+      (⟨t.geckTorusMatrix ht r, t.geckTorusMatrix_mem_geckPoints ht A r⟩ :
+          t.geckPoints ht A) = t.geckWeightTorusPoints ht A r :=
+    Subtype.ext (t.coe_geckWeightTorusPoints ht A r).symm
+  rw [← htorus s, geckPoints_mk_geckTorusMatrix, geckGraphAutPoints_geckTorusMatrix, htorus]
 
 /-- **The graph automorphism on points is natural in the value ring.** In particular it commutes
 with the Frobenius endomorphism of the points of the carrier. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean
@@ -69,14 +69,13 @@ noncomputable section
 
 variable (t : DynkinType) (ht : t.Valid)
 
-/-! None of the restatements below is a `simp` lemma, at any of the three tiers. Their right-hand
-sides are not `simp`-normal: `TauCeti.DynkinType.root_simpleIndex` rewrites a named simple root
-back to its Bourbaki row of `t.cartanMatrix`, which is also what
-`TauCeti.DynkinType.rootGeneratorWeight_inl` produces from the character on the left. This is the
-policy recorded in `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/KostantForm.lean`
-beside the substitution these restatements perform: both forms are already `simp`-normal, so
-orienting the identification either way would undo an existing rule. They are stated to be used by
-`exact` and `rw`, as `TauCeti/GroupTheory/SpecificGroups/CFSG/GeckCarrier.lean` uses them. -/
+/-! The character by which a torus point rescales the parameter of the raising subgroup at node `i`
+and the simple root `α_i` of `TauCeti.DynkinType.simplyConnectedRootDatum` are the same element of
+the character lattice, both being row `i` of `t.cartanMatrix`, and the lowering subgroup at node
+`i` is rescaled by `-α_i`. The equations below are the conjugation equations of the carrier in that
+named-root reading, in which the pinned root datum rather than the Cartan matrix is the object the
+equation is about, at the three tiers the carrier offers: on parameters, on schemes, and on the
+points of the group scheme. -/
 
 /-! ## The pointwise conjugation equations -/
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean
@@ -69,6 +69,15 @@ noncomputable section
 
 variable (t : DynkinType) (ht : t.Valid)
 
+/-! None of the restatements below is a `simp` lemma, at any of the three tiers. Their right-hand
+sides are not `simp`-normal: `TauCeti.DynkinType.root_simpleIndex` rewrites a named simple root
+back to its Bourbaki row of `t.cartanMatrix`, which is also what
+`TauCeti.DynkinType.rootGeneratorWeight_inl` produces from the character on the left. This is the
+policy recorded in `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/KostantForm.lean`
+beside the substitution these restatements perform: both forms are already `simp`-normal, so
+orienting the identification either way would undo an existing rule. They are stated to be used by
+`exact` and `rw`, as `TauCeti/GroupTheory/SpecificGroups/CFSG/GeckCarrier.lean` uses them. -/
+
 /-! ## The pointwise conjugation equations -/
 
 /-- **The pointwise conjugation equation of the Geck carrier at a named simple root.** A split-torus

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/RootDatum.lean
@@ -40,6 +40,9 @@ of a root datum carried by the group scheme; those are separate Layer 9 targets.
   read as a named simple root.
 * `TauCeti.DynkinType.geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex` and its
   negative-root counterpart: the corresponding equations on scheme-valued points.
+* `TauCeti.DynkinType.geckWeightTorusPoints_conj_geckRootSubgroupPoints_root_simpleIndex` and its
+  negative-root counterpart: the corresponding equations inside the matrix point group, where the
+  represented torus and the represented root subgroups are group homomorphisms.
 
 ## References
 
@@ -142,6 +145,43 @@ theorem geckWeightTorus_conj_geckRootSubgroup_neg_root_simpleIndex (i : Fin t.ra
         (t.geckRootSubgroup ht (.inr i)).hom.hom := by
   rw [← t.rootGeneratorWeight_inr_eq_neg_root_simpleIndex ht i]
   exact t.geckWeightTorus_conj_geckRootSubgroup ht (.inr i) A s u
+
+/-! ## The conjugation equations inside the matrix point group -/
+
+/-- **The pinning equation in the point group of the Geck carrier, at a named simple root.**
+Conjugating the numbered raising subgroup at node `i` by a represented weight-torus point rescales
+its parameter by `α_i(s)`, where `α_i` is the simple root of the pinned simply connected datum with
+the same Bourbaki node number.
+
+This is the form in which a consumer working with the matrix points rather than with the group
+scheme uses the pinning: `TauCeti.DynkinType.geckWeightTorusPoints` and
+`TauCeti.DynkinType.geckRootSubgroupPoints` are group homomorphisms into
+`TauCeti.DynkinType.geckPoints`, so both sides are elements of one group. -/
+theorem geckWeightTorusPoints_conj_geckRootSubgroupPoints_root_simpleIndex (i : Fin t.rank)
+    (A : Type v) [CommRing A] (s : Fin t.rank → Aˣ) (u : Multiplicative A) :
+    t.geckWeightTorusPoints ht A s * t.geckRootSubgroupPoints ht (.inl i) A u *
+        (t.geckWeightTorusPoints ht A s)⁻¹ =
+      t.geckRootSubgroupPoints ht (.inl i) A
+        (Multiplicative.ofAdd
+          ((TauCeti.torusCharacter s
+              ((t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i)) : A) *
+            Multiplicative.toAdd u)) := by
+  rw [← t.rootGeneratorWeight_inl_eq_root_simpleIndex ht i]
+  exact t.geckWeightTorusPoints_conj_geckRootSubgroupPoints ht (.inl i) A s u
+
+/-- **The pinning equation in the point group of the Geck carrier, at the negative of a named
+simple root.** -/
+theorem geckWeightTorusPoints_conj_geckRootSubgroupPoints_neg_root_simpleIndex (i : Fin t.rank)
+    (A : Type v) [CommRing A] (s : Fin t.rank → Aˣ) (u : Multiplicative A) :
+    t.geckWeightTorusPoints ht A s * t.geckRootSubgroupPoints ht (.inr i) A u *
+        (t.geckWeightTorusPoints ht A s)⁻¹ =
+      t.geckRootSubgroupPoints ht (.inr i) A
+        (Multiplicative.ofAdd
+          ((TauCeti.torusCharacter s
+              (-(t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i)) : A) *
+            Multiplicative.toAdd u)) := by
+  rw [← t.rootGeneratorWeight_inr_eq_neg_root_simpleIndex ht i]
+  exact t.geckWeightTorusPoints_conj_geckRootSubgroupPoints ht (.inr i) A s u
 
 end
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/TwistedFrobenius.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/TwistedFrobenius.lean
@@ -85,9 +85,8 @@ reproved.
   Frobenius by the pinned symmetry matrix.
 * `TauCeti.DynkinType.geckTwistedFrobenius_geckRootSubgroupMatrix`: the defining equation on the
   pinned numbered root subgroups.
-* `TauCeti.DynkinType.geckTwistedFrobenius_geckWeightTorusPoints` and
-  `TauCeti.DynkinType.geckTwistedFrobenius_geckTorusMatrix`: the equation on the pinned weight
-  torus, on the represented torus homomorphism and on the matrix that homomorphism produces.
+* `TauCeti.DynkinType.geckTwistedFrobenius_geckTorusMatrix`: the equation on the pinned weight
+  torus.
 * `TauCeti.DynkinType.geckFrobenius_pow` and `TauCeti.DynkinType.geckTwistedFrobenius_pow`: the
   powers of the two endomorphisms, the second separating into `γ ^ m ∘ Frob_(q ^ m)`.
 * `TauCeti.DynkinType.geckTwistedFrobenius_pow_eq_geckFrobenius`: a symmetry of order dividing `m`
@@ -203,18 +202,8 @@ theorem geckTwistedFrobenius_geckRootSubgroupMatrix (i : Fin t.rank ⊕ Fin t.ra
   rw [geckTwistedFrobenius_apply, hroot, geckFrobenius_geckRootSubgroupPoints, ← hroot,
     geckGraphAutPoints_geckRootSubgroupMatrix]
 
-/-- **The twisted Frobenius raises a point of the represented Geck weight torus to its `p ^ k`-th
-power and relabels its coordinates** by the inverse of the diagram symmetry. -/
-@[simp]
-theorem geckTwistedFrobenius_geckWeightTorusPoints (s : Fin t.rank → Aˣ) :
-    t.geckTwistedFrobenius ht hsigma p k A (t.geckWeightTorusPoints ht A s) =
-      t.geckWeightTorusPoints ht A fun j => s (sigma⁻¹ j) ^ p ^ k := by
-  rw [geckTwistedFrobenius_apply, geckFrobenius_geckWeightTorusPoints,
-    geckGraphAutPoints_geckWeightTorusPoints]
-  exact congrArg _ (funext fun j => Pi.pow_apply s (p ^ k) _)
-
-/-- **The twisted Frobenius on the pinned Geck weight torus**, written on the matrix that the
-represented torus produces. -/
+/-- **The twisted Frobenius raises a point of the pinned Geck weight torus to its `p ^ k`-th power
+and relabels its coordinates** by the inverse of the diagram symmetry. -/
 @[simp]
 theorem geckTwistedFrobenius_geckTorusMatrix (s : Fin t.rank → Aˣ) :
     t.geckTwistedFrobenius ht hsigma p k A
@@ -225,10 +214,13 @@ theorem geckTwistedFrobenius_geckTorusMatrix (s : Fin t.rank → Aˣ) :
         t.geckTorusMatrix_mem_geckPoints ht A _⟩ := by
   have htorus (r : Fin t.rank → Aˣ) :
       (⟨t.geckTorusMatrix ht r, t.geckTorusMatrix_mem_geckPoints ht A r⟩ :
-          t.geckPoints ht A) = t.geckWeightTorusPoints ht A r :=
-    Subtype.ext (t.coe_geckWeightTorusPoints ht A r).symm
-  rw [← geckPoints_mk_geckTorusMatrix, htorus, geckTwistedFrobenius_geckWeightTorusPoints,
-    ← htorus]
+          t.geckPoints ht A) = t.geckWeightTorusPoints ht A r := by
+    apply Subtype.ext
+    exact (t.coe_geckWeightTorusPoints ht A r).symm
+  rw [geckTwistedFrobenius_apply, ← geckPoints_mk_geckTorusMatrix]
+  rw [htorus, geckFrobenius_geckWeightTorusPoints, ← htorus, geckPoints_mk_geckTorusMatrix,
+    geckGraphAutPoints_geckTorusMatrix]
+  exact Subtype.ext (congrArg (t.geckTorusMatrix ht) (funext fun j => Pi.pow_apply s (p ^ k) _))
 
 /-! ## The degenerate parameters
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/TwistedFrobenius.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/TwistedFrobenius.lean
@@ -85,8 +85,9 @@ reproved.
   Frobenius by the pinned symmetry matrix.
 * `TauCeti.DynkinType.geckTwistedFrobenius_geckRootSubgroupMatrix`: the defining equation on the
   pinned numbered root subgroups.
-* `TauCeti.DynkinType.geckTwistedFrobenius_geckTorusMatrix`: the equation on the pinned weight
-  torus.
+* `TauCeti.DynkinType.geckTwistedFrobenius_geckWeightTorusPoints` and
+  `TauCeti.DynkinType.geckTwistedFrobenius_geckTorusMatrix`: the equation on the pinned weight
+  torus, on the represented torus homomorphism and on the matrix that homomorphism produces.
 * `TauCeti.DynkinType.geckFrobenius_pow` and `TauCeti.DynkinType.geckTwistedFrobenius_pow`: the
   powers of the two endomorphisms, the second separating into `γ ^ m ∘ Frob_(q ^ m)`.
 * `TauCeti.DynkinType.geckTwistedFrobenius_pow_eq_geckFrobenius`: a symmetry of order dividing `m`
@@ -202,8 +203,18 @@ theorem geckTwistedFrobenius_geckRootSubgroupMatrix (i : Fin t.rank ⊕ Fin t.ra
   rw [geckTwistedFrobenius_apply, hroot, geckFrobenius_geckRootSubgroupPoints, ← hroot,
     geckGraphAutPoints_geckRootSubgroupMatrix]
 
-/-- **The twisted Frobenius raises a point of the pinned Geck weight torus to its `p ^ k`-th power
-and relabels its coordinates** by the inverse of the diagram symmetry. -/
+/-- **The twisted Frobenius raises a point of the represented Geck weight torus to its `p ^ k`-th
+power and relabels its coordinates** by the inverse of the diagram symmetry. -/
+@[simp]
+theorem geckTwistedFrobenius_geckWeightTorusPoints (s : Fin t.rank → Aˣ) :
+    t.geckTwistedFrobenius ht hsigma p k A (t.geckWeightTorusPoints ht A s) =
+      t.geckWeightTorusPoints ht A fun j => s (sigma⁻¹ j) ^ p ^ k := by
+  rw [geckTwistedFrobenius_apply, geckFrobenius_geckWeightTorusPoints,
+    geckGraphAutPoints_geckWeightTorusPoints]
+  exact congrArg _ (funext fun j => Pi.pow_apply s (p ^ k) _)
+
+/-- **The twisted Frobenius on the pinned Geck weight torus**, written on the matrix that the
+represented torus produces. -/
 @[simp]
 theorem geckTwistedFrobenius_geckTorusMatrix (s : Fin t.rank → Aˣ) :
     t.geckTwistedFrobenius ht hsigma p k A
@@ -214,13 +225,10 @@ theorem geckTwistedFrobenius_geckTorusMatrix (s : Fin t.rank → Aˣ) :
         t.geckTorusMatrix_mem_geckPoints ht A _⟩ := by
   have htorus (r : Fin t.rank → Aˣ) :
       (⟨t.geckTorusMatrix ht r, t.geckTorusMatrix_mem_geckPoints ht A r⟩ :
-          t.geckPoints ht A) = t.geckWeightTorusPoints ht A r := by
-    apply Subtype.ext
-    exact (t.coe_geckWeightTorusPoints ht A r).symm
-  rw [geckTwistedFrobenius_apply, ← geckPoints_mk_geckTorusMatrix]
-  rw [htorus, geckFrobenius_geckWeightTorusPoints, ← htorus, geckPoints_mk_geckTorusMatrix,
-    geckGraphAutPoints_geckTorusMatrix]
-  exact Subtype.ext (congrArg (t.geckTorusMatrix ht) (funext fun j => Pi.pow_apply s (p ^ k) _))
+          t.geckPoints ht A) = t.geckWeightTorusPoints ht A r :=
+    Subtype.ext (t.coe_geckWeightTorusPoints ht A r).symm
+  rw [← geckPoints_mk_geckTorusMatrix, htorus, geckTwistedFrobenius_geckWeightTorusPoints,
+    ← htorus]
 
 /-! ## The degenerate parameters
 


### PR DESCRIPTION
This PR gives every valid Lie-type index the split weight torus of its Geck point group, and the
equations that pin it. `TauCeti.ValidLieTypeIndex.geckWeightTorus` is the represented weight torus
of the Geck carrier evaluated over the algebraic closure of the index's prime field, at the rank
the index records; `coe_geckWeightTorus` identifies the matrix it produces;
`geckWeightTorus_conj_geckRootSubgroup_root_simpleIndex` and its negative-root counterpart read the
character by which conjugation by a torus point rescales the parameter of the numbered root
subgroup at Bourbaki node `i` as the simple root `α_i` of
`TauCeti.DynkinType.simplyConnectedRootDatum` at the Dynkin type
`TauCeti.ValidLieTypeIndex.dynkinType` names, in the same numbering. On the maps the carrier
already carries, `geckFrobenius_geckWeightTorus` raises every coordinate to the `q`-th power,
`GraphTwistedIndex.geckGraphAut_geckWeightTorus` relabels the coordinates by the inverse of the
index's diagram permutation, and `GraphTwistedIndex.geckSteinberg_geckWeightTorus` combines the
two; `UnimodularExceptionalIndex.steinberg_geckWeightTorus` is the untwisted case on `E₈(q)`,
`F₄(q)` and `G₂(q)`. Two sufficient conditions for a torus point to survive follow:
`geckWeightTorus_mem_fixedSubgroup_geckFrobenius` for coordinates in the field of definition
`𝔽_q`, and `GraphTwistedIndex.geckWeightTorus_mem_fixedSubgroup_geckSteinberg` for the coupled
equations `s_{σ⁻¹ k} ^ q = s_k` a twisted index imposes.

The milestone is L0, "explicit pinned Chevalley--Demazure groups", of
`TauCetiRoadmap/CFSGStatement/README.md`, whose *Pinnings* input is a pinning `(G, T, B, {X_α})`
and whose stated output includes "root-subgroup maps `x_α` ... and the equations expressing their
compatibility with the pinning"; the torus half of that data was the piece the index-level Geck
interface did not have. `TauCeti/GroupTheory/SpecificGroups/CFSG/GeckCarrier.lean` gave an index
its point group, its numbered root subgroups and its Frobenius, but no torus, so no equation
relating the two, and hence no reading of a numbered root character in the index's own root datum,
was available on this carrier; every other CFSG carrier file carries that reading, as
`TypeDDiagramLieIndex.rootGeneratorWeight_eq_root_simpleIndex` and
`TypeTwistedE6LieIndex.rootGeneratorWeight_eq_root_simpleIndex` do for the type-`D` spin and
doubled minuscule carriers. It also supplies the second half of the milestone L1 equations, which
`TauCeti/GroupTheory/SpecificGroups/CFSG/OrdinarySteinberg.lean` proved on root subgroups only,
for all thirteen ordinary indices at once. After this PR the L0 gap on this carrier is the
identification of it with the pinned simply connected Chevalley--Demazure group scheme, which is a
Layer 9 target of `TauCetiRoadmap/ReductiveGroups/README.md` that the CFSG roadmap consumes rather
than builds, and milestones L0 and L3 still owe carriers or candidate groups for the `²Dₙ`, `³D₄`,
`²E₆` and `E₇` branches and for the four half-Frobenius ones.

Nothing here asserts that the Geck carrier is reductive, that this torus is maximal in it, that it
is the split maximal torus of a pinned simply connected group, or that any group named is finite,
perfect or simple. The `geck` prefix is the same disclaimer the rest of that file carries: Geck's
module is the adjoint module, so its characters span the whole character lattice only on the `E₈`,
`F₄` and `G₂` diagrams, which is recorded in
`TauCeti/GroupTheory/SpecificGroups/CFSG/Unimodular.lean`.

Everything is instantiated from material already in Tau Ceti rather than rebuilt: the pinning
equation is `DynkinType.geckWeightTorusPoints_conj_geckRootSubgroupPoints` and the substitution
`DynkinType.rootGeneratorWeight_inl_eq_root_simpleIndex`, the Frobenius equation is
`DynkinType.geckFrobenius_geckWeightTorusPoints`, and the graph and twisted equations are
`DynkinType.geckGraphAutPoints_geckTorusMatrix` and `DynkinType.geckTwistedFrobenius_apply`. Three
statements the index-level ones consume are added at the Dynkin-type level, each beside the map it
describes and stated for an arbitrary valid type, coefficient ring and diagram symmetry rather than
for an index: `geckWeightTorusPoints_conj_geckRootSubgroupPoints_root_simpleIndex` and its
negative-root counterpart in `GeckLattice/RootDatum.lean`, alongside the pointwise and
scheme-valued forms that file already carries;
`geckGraphAutPoints_geckWeightTorusPoints` in `GeckLattice/GraphAutomorphism.lean`; and
`geckTwistedFrobenius_geckWeightTorusPoints` in `GeckLattice/TwistedFrobenius.lean`. These state on
`geckWeightTorusPoints`, the homomorphism through which the weight torus enters the point group,
what the existing lemmas state on the raw matrix; `geckTwistedFrobenius_geckTorusMatrix` is
reproved from the new form, which removes the conversion its old proof performed twice.

The conventions follow M. Geck, *On the construction of semisimple Lie algebras and Chevalley
groups*, Proc. Amer. Math. Soc. **145** (2017), 3233--3247, for the matrix realization of the
carrier, R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 7.1, and *Finite Groups of Lie Type:
Conjugacy Classes and Complex Characters*, §§1.15 and 1.17, for the pinned root-subgroup and
Steinberg-map conventions, and the Bourbaki numbering of Plates I--IX. No Mathlib or other external
material is vendored.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"validlietypeindex-geckweighttorus"}-->

🤖 Prepared with Claude Code
