### PR TITLE
refactor(HeckeRing): name the twisted-coset separation in the coprime coset family

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
@@ -277,53 +277,53 @@ lemma exists_mem_Gamma1_natDiagGL_mul_primeRep (hp : p.Prime) (hσ10 : σ 1 0 = 
       (by simpa [mul_comm] using hdvd)
     exact ⟨some ⟨j.val, hjlt⟩, δ, hδ, by rw [primeRep_some]; exact heq⟩
 
-/-- **The `p + 1` right cosets are pairwise distinct for any integral subgroup when `1 < p`.**
-The `p` upper-triangular ones are separated by `op_upperTriRep_smul_injective`; separating the
-twisted one from them is integrality. If
-`G · !![1, b; 0, p] = G · σ · diag(p, 1)`, comparing the top rows gives
+/-- **The twisted coset is none of the upper-triangular ones.** This is where integrality
+enters. If `G · !![1, b; 0, p] = G · σ · diag(p, 1)`, comparing the top rows gives
 `n = p (m b + σ'₀₁)` for some `σ' ∈ G`, so `p ∣ n`, and then `m p − n N = 1` makes `p` a
 divisor of `1`. -/
+private lemma op_primeRep_smul_some_ne_none {G : Subgroup SL(2, ℤ)} (hp : 1 < p)
+    (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ)) (b : Fin p) :
+    MulOpposite.op (primeRep σ p (some b)) • ((G.map (mapGL ℚ)) : Set (GL (Fin 2) ℚ)) ≠
+      MulOpposite.op (primeRep σ p none) • ((G.map (mapGL ℚ)) : Set (GL (Fin 2) ℚ)) := by
+  have hp0 : 0 < p := by omega
+  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 :=
+    mul_sub_mul_eq_one_of_lowerRow hσ10 hσ11
+  intro heq
+  obtain ⟨τ, -, hτeq⟩ := Subgroup.mem_map.mp ((rightCoset_eq_iff _).mp heq)
+  have hmul : (mapGL ℚ τ : GL (Fin 2) ℚ) * upperTriRep p b = primeRep σ p none := by
+    rw [hτeq, ← primeRep_some σ p b, inv_mul_cancel_right]
+  have hmat : (↑(mapGL ℚ τ) : Matrix (Fin 2) (Fin 2) ℚ) * !![1, (b : ℚ); 0, (p : ℚ)] =
+      (↑(primeRep σ p none) : Matrix (Fin 2) (Fin 2) ℚ) := by
+    rw [← coe_upperTriRep, ← Units.val_mul, hmul]
+  rw [coe_mapGL_int_rat_fin_two, coe_primeRep_none hp0, Matrix.mul_fin_two] at hmat
+  have h00 : ((τ 0 0 : ℤ) : ℚ) = ((σ 0 0 : ℤ) : ℚ) * (p : ℚ) := by
+    simpa using congrFun (congrFun hmat 0) 0
+  have h01 : ((τ 0 0 : ℤ) : ℚ) * (b : ℚ) + ((τ 0 1 : ℤ) : ℚ) * (p : ℚ) = ((σ 0 1 : ℤ) : ℚ) := by
+    simpa using congrFun (congrFun hmat 0) 1
+  rw [h00] at h01
+  have hn : (σ 0 1 : ℤ) = (p : ℤ) * (σ 0 0 * (b : ℕ) + τ 0 1) := by
+    have hQ : ((σ 0 1 : ℤ) : ℚ) = (((p : ℤ) * (σ 0 0 * (b : ℕ) + τ 0 1) : ℤ) : ℚ) := by
+      push_cast at h01 ⊢
+      linarith
+    exact_mod_cast hQ
+  have hdvd : (p : ℤ) ∣ 1 :=
+    ⟨σ 0 0 - (σ 0 0 * (b : ℕ) + τ 0 1) * (N : ℤ), by linear_combination -hσdet - (N : ℤ) * hn⟩
+  have hle := Int.le_of_dvd one_pos hdvd
+  have htwo : 2 ≤ (p : ℤ) := by exact_mod_cast hp
+  omega
+
+/-- **The `p + 1` right cosets are pairwise distinct for any integral subgroup when `1 < p`.**
+The `p` upper-triangular ones are separated by `op_upperTriRep_smul_injective`, and
+`op_primeRep_smul_some_ne_none` separates the twisted one from those. -/
 theorem op_primeRep_smul_injective {G : Subgroup SL(2, ℤ)} (hp : 1 < p)
     (hσ10 : σ 1 0 = (N : ℤ))
     (hσ11 : σ 1 1 = (p : ℤ)) :
     Function.Injective fun i : Option (Fin p) ↦
       MulOpposite.op (primeRep σ p i) • ((G.map (mapGL ℚ)) : Set (GL (Fin 2) ℚ)) := by
-  have hp0 : 0 < p := by omega
-  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 :=
-    mul_sub_mul_eq_one_of_lowerRow hσ10 hσ11
-  -- the twisted coset is not one of the upper-triangular ones
-  have hne : ∀ b : Fin p,
-      MulOpposite.op (primeRep σ p (some b)) • ((G.map (mapGL ℚ)) :
-          Set (GL (Fin 2) ℚ)) ≠
-        MulOpposite.op (primeRep σ p none) • ((G.map (mapGL ℚ)) :
-          Set (GL (Fin 2) ℚ)) := by
-    intro b heq
-    obtain ⟨τ, -, hτeq⟩ := Subgroup.mem_map.mp ((rightCoset_eq_iff _).mp heq)
-    have hmul : (mapGL ℚ τ : GL (Fin 2) ℚ) * upperTriRep p b = primeRep σ p none := by
-      rw [hτeq, ← primeRep_some σ p b, inv_mul_cancel_right]
-    have hmat : (↑(mapGL ℚ τ) : Matrix (Fin 2) (Fin 2) ℚ) * !![1, (b : ℚ); 0, (p : ℚ)] =
-        (↑(primeRep σ p none) : Matrix (Fin 2) (Fin 2) ℚ) := by
-      rw [← coe_upperTriRep, ← Units.val_mul, hmul]
-    rw [coe_mapGL_int_rat_fin_two, coe_primeRep_none hp0, Matrix.mul_fin_two] at hmat
-    have h00 : ((τ 0 0 : ℤ) : ℚ) = ((σ 0 0 : ℤ) : ℚ) * (p : ℚ) := by
-      simpa using congrFun (congrFun hmat 0) 0
-    have h01 : ((τ 0 0 : ℤ) : ℚ) * (b : ℚ) + ((τ 0 1 : ℤ) : ℚ) * (p : ℚ) = ((σ 0 1 : ℤ) : ℚ) := by
-      simpa using congrFun (congrFun hmat 0) 1
-    rw [h00] at h01
-    have hn : (σ 0 1 : ℤ) = (p : ℤ) * (σ 0 0 * (b : ℕ) + τ 0 1) := by
-      have hQ : ((σ 0 1 : ℤ) : ℚ) = (((p : ℤ) * (σ 0 0 * (b : ℕ) + τ 0 1) : ℤ) : ℚ) := by
-        push_cast at h01 ⊢
-        linarith
-      exact_mod_cast hQ
-    have hdvd : (p : ℤ) ∣ 1 :=
-      ⟨σ 0 0 - (σ 0 0 * (b : ℕ) + τ 0 1) * (N : ℤ), by linear_combination -hσdet - (N : ℤ) * hn⟩
-    have hle := Int.le_of_dvd one_pos hdvd
-    have htwo : 2 ≤ (p : ℤ) := by exact_mod_cast hp
-    omega
   rintro (_ | b₁) (_ | b₂) h
   · rfl
-  · exact absurd h.symm (hne b₂)
-  · exact absurd h (hne b₁)
+  · exact absurd h.symm (op_primeRep_smul_some_ne_none hp hσ10 hσ11 b₂)
+  · exact absurd h (op_primeRep_smul_some_ne_none hp hσ10 hσ11 b₁)
   · simpa using op_upperTriRep_smul_injective (G := G) (by simpa using h)
 
 /-- **The `Tₚ` double coset at a prime `p ∤ N` is the union of `p + 1` right cosets.**

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
@@ -277,17 +277,17 @@ lemma exists_mem_Gamma1_natDiagGL_mul_primeRep (hp : p.Prime) (hσ10 : σ 1 0 = 
       (by simpa [mul_comm] using hdvd)
     exact ⟨some ⟨j.val, hjlt⟩, δ, hδ, by rw [primeRep_some]; exact heq⟩
 
-/-- **The twisted coset is none of the upper-triangular ones.** This is where integrality
-enters. If `G · !![1, b; 0, p] = G · σ · diag(p, 1)`, comparing the top rows gives
-`n = p (m b + σ'₀₁)` for some `σ' ∈ G`, so `p ∣ n`, and then `m p − n N = 1` makes `p` a
-divisor of `1`. -/
+/-- **The twisted representative lies in none of the upper-triangular cosets.** For `1 < p`
+and `σ` whose lower-right entry is `p`, the right coset of `σ · diag(p, 1)` modulo any
+subgroup `G ≤ SL(2, ℤ)` differs from that of every `!![1, b; 0, p]`. -/
 private lemma op_primeRep_smul_some_ne_none {G : Subgroup SL(2, ℤ)} (hp : 1 < p)
-    (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ)) (b : Fin p) :
+    (hσ11 : σ 1 1 = (p : ℤ)) (b : Fin p) :
     MulOpposite.op (primeRep σ p (some b)) • ((G.map (mapGL ℚ)) : Set (GL (Fin 2) ℚ)) ≠
       MulOpposite.op (primeRep σ p none) • ((G.map (mapGL ℚ)) : Set (GL (Fin 2) ℚ)) := by
   have hp0 : 0 < p := by omega
-  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 :=
-    mul_sub_mul_eq_one_of_lowerRow hσ10 hσ11
+  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * σ 1 0 = 1 := by
+    rw [← hσ11]
+    exact fin_two_mul_sub_mul_eq_one σ
   intro heq
   obtain ⟨τ, -, hτeq⟩ := Subgroup.mem_map.mp ((rightCoset_eq_iff _).mp heq)
   have hmul : (mapGL ℚ τ : GL (Fin 2) ℚ) * upperTriRep p b = primeRep σ p none := by
@@ -307,23 +307,21 @@ private lemma op_primeRep_smul_some_ne_none {G : Subgroup SL(2, ℤ)} (hp : 1 < 
       linarith
     exact_mod_cast hQ
   have hdvd : (p : ℤ) ∣ 1 :=
-    ⟨σ 0 0 - (σ 0 0 * (b : ℕ) + τ 0 1) * (N : ℤ), by linear_combination -hσdet - (N : ℤ) * hn⟩
+    ⟨σ 0 0 - (σ 0 0 * (b : ℕ) + τ 0 1) * σ 1 0, by linear_combination -hσdet - σ 1 0 * hn⟩
   have hle := Int.le_of_dvd one_pos hdvd
   have htwo : 2 ≤ (p : ℤ) := by exact_mod_cast hp
   omega
 
-/-- **The `p + 1` right cosets are pairwise distinct for any integral subgroup when `1 < p`.**
-The `p` upper-triangular ones are separated by `op_upperTriRep_smul_injective`, and
-`op_primeRep_smul_some_ne_none` separates the twisted one from those. -/
+/-- **The `p + 1` right cosets are pairwise distinct**, modulo any subgroup `G ≤ SL(2, ℤ)`,
+whenever `1 < p` and `σ` has lower-right entry `p`. -/
 theorem op_primeRep_smul_injective {G : Subgroup SL(2, ℤ)} (hp : 1 < p)
-    (hσ10 : σ 1 0 = (N : ℤ))
     (hσ11 : σ 1 1 = (p : ℤ)) :
     Function.Injective fun i : Option (Fin p) ↦
       MulOpposite.op (primeRep σ p i) • ((G.map (mapGL ℚ)) : Set (GL (Fin 2) ℚ)) := by
   rintro (_ | b₁) (_ | b₂) h
   · rfl
-  · exact absurd h.symm (op_primeRep_smul_some_ne_none hp hσ10 hσ11 b₂)
-  · exact absurd h (op_primeRep_smul_some_ne_none hp hσ10 hσ11 b₁)
+  · exact absurd h.symm (op_primeRep_smul_some_ne_none hp hσ11 b₂)
+  · exact absurd h (op_primeRep_smul_some_ne_none hp hσ11 b₁)
   · simpa using op_upperTriRep_smul_injective (G := G) (by simpa using h)
 
 /-- **The `Tₚ` double coset at a prime `p ∤ N` is the union of `p + 1` right cosets.**

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
@@ -89,7 +89,7 @@ theorem heckeSlashSum_diagCosetGamma1_of_coprime (hp : p.Prime) (h : Nat.Coprime
       (primeRep (gamma0Twist N p h) p)
       (doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets_of_prime hp
         (gamma0Twist_apply_one_zero h) (gamma0Twist_apply_one_one h))
-      (op_primeRep_smul_injective (G := Gamma1 N) hp.one_lt (gamma0Twist_apply_one_zero h)
+      (op_primeRep_smul_injective (G := Gamma1 N) hp.one_lt
         (gamma0Twist_apply_one_one h)) f,
     Fintype.sum_option, heckeSlashUpperTri_def]
   simp only [primeRep_some, primeRep_none]


### PR DESCRIPTION
`op_primeRep_smul_injective` says the `p + 1` right cosets representing
`Γ₁(N) · diag(1, p) · Γ₁(N)` are pairwise distinct. At 53 lines it was over the
proof-length cap, and almost all of it sat inside one nested `have`.

### What the proof actually is

Two separate facts, unevenly sized:

* the `p` upper-triangular cosets are pairwise distinct — one line, delegated to
  `op_upperTriRep_smul_injective`;
* the twisted representative `σ · diag(p, 1)` is none of them — thirty lines, and
  the only place integrality is used.

The second was an anonymous `hne` in the middle of the first. It is now
`op_primeRep_smul_some_ne_none`, a private lemma with the argument in its
docstring: comparing top rows in `G · !![1, b; 0, p] = G · σ · diag(p, 1)` gives
`n = p (m b + σ'₀₁)`, so `p ∣ n`, and `m p − n N = 1` then makes `p` divide `1`.

What is left of the parent is the four-way case split over
`Option (Fin p) × Option (Fin p)`, each branch one line. The two halves of the
argument are now the same size as each other on the page.

### Numbers

`op_primeRep_smul_injective` 53 → 14 lines; the extracted lemma is 34. Both
under the cap, and the `hp0`/`hσdet` setup moves with the proof that uses it, so
the parent inherits no binders it does not need.

Review round 2 removed one more: `hσ10` was never used for anything but naming
`σ 1 0` as `N`. The determinant relation the argument needs is
`fin_two_mul_sub_mul_eq_one σ` rewritten by `hσ11`, so both this lemma and the
public `op_primeRep_smul_injective` now take only `hp` and `hσ11`, and neither
mentions the level `N` at all. The single caller in `HeckeSlash/Prime.lean` is
updated.

### Not in this PR

`exists_mem_Gamma1_natDiagGL_mul_primeRep_none_of_dvd` in the same file is also
over the cap, at 53 lines. Its natural seam — existence of the left factor in
`Γ₁(N)` — needs the explicit `2 × 2` witness in the extracted statement, which is
a heavier lemma than this one and a separate judgement call. Left for its own PR
rather than bundled here.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR

