### PR TITLE
fix: publish pipeline health again, and notice when a cron only fails

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -84,6 +84,14 @@ jobs:
       # This is what `advance-docgen-ref` follows; there is deliberately no output for whether a
       # rebuild was *planned*, because that says nothing about what ended up being published.
       docs-source-sha: ${{ steps.fold.outputs.docs-source-sha }}
+      # Which of the generated data assets could not be regenerated this run. The steps that
+      # produce them are deliberately non-fatal -- a GitHub hiccup should cost a stale chart, not
+      # the whole site deploy -- but "non-fatal" turned into "invisible": the PR statistics step
+      # failed on every run from 2026-09-04, so the snapshot it dumps was never written, so
+      # pipeline-health.json was skipped every time and never existed at all, and the run stayed
+      # green throughout. The report-data-freshness job below turns this back into a red run,
+      # AFTER the deploy, so both properties hold at once.
+      data-failures: ${{ steps.data-failures.outputs.assets }}
     defaults:
       run:
         working-directory: web
@@ -151,6 +159,25 @@ jobs:
             --out web/static_files/participation.svg \
           || echo "::warning::participation graph generation failed; keeping the committed fallback SVG"
 
+      # Walking every pull request's label timeline costs one GraphQL request each, against a
+      # budget of 5000 an hour. At ~4600 open-or-recently-closed pull requests that no longer
+      # fits -- which is how this step started failing outright -- and the project adds about
+      # ninety a day, so it cannot be made to fit again by trimming. The snapshot is therefore
+      # carried between runs: a pull request whose `updatedAt` has not moved keeps its recorded
+      # timeline, and only what actually changed in the last three hours is fetched.
+      #
+      # A restore miss is not a failure. The generator falls back to the full walk and waits out
+      # a depleted budget rather than giving up, so a cold start (first run, or an evicted entry)
+      # still completes; it just costs an hour of waiting instead of three minutes.
+      - name: Restore the previous pull-request snapshot
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/pr-snapshot.json
+          # Always a miss, so the save below always writes a fresh entry; the prefix is what
+          # actually restores the newest previous snapshot.
+          key: pr-snapshot-${{ github.run_id }}
+          restore-keys: pr-snapshot-
+
       # PR history and current queue state come from GitHub rather than git. The generator
       # paginates both the PR connection and each label timeline, and bounds contributor
       # rendering so growth in participation cannot make the deployed SVG unmanageably large.
@@ -159,11 +186,40 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Reads the restored snapshot and overwrites it with the new one. The generator loads
+          # it fully before writing anything, so naming one path for both is safe.
           python3 scripts/pr_stats_graphs.py \
             --repo "${{ github.repository }}" \
             --out-dir web/static_files \
+            --since-data "$RUNNER_TEMP/pr-snapshot.json" \
             --dump-data "$RUNNER_TEMP/pr-snapshot.json" \
-          || echo "::warning::PR statistics generation failed; keeping the committed fallback assets"
+          || {
+            echo "::warning::PR statistics generation failed; keeping the committed fallback assets"
+            echo "pull-request statistics" >> "$RUNNER_TEMP/data-failures"
+          }
+
+      # Gated on the file existing, because actions/cache/save errors on a missing path and this
+      # step must never be the thing that fails the job it exists to make cheaper.
+      - name: Check whether a snapshot is present to save
+        id: snapshot
+        if: always()
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ -s "$RUNNER_TEMP/pr-snapshot.json" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Save the pull-request snapshot for the next run
+        # Saved even when the step above failed: an older or partial snapshot still spares the
+        # next run most of the walk, and the alternative is that one bad run condemns every later
+        # one to a cold start.
+        if: always() && steps.snapshot.outputs.present == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/pr-snapshot.json
+          key: pr-snapshot-${{ github.run_id }}
 
       # Pipeline health reuses the snapshot the charts just fetched rather than
       # walking every PR timeline a second time: that walk is thousands of
@@ -173,14 +229,38 @@ jobs:
       - name: Derive pipeline health from the same snapshot
         working-directory: ${{ github.workspace }}
         run: |
-          if [ -f "$RUNNER_TEMP/pr-snapshot.json" ]; then
+          if [ -s "$RUNNER_TEMP/pr-snapshot.json" ]; then
             python3 scripts/pipeline_health.py \
               --data "$RUNNER_TEMP/pr-snapshot.json" \
               --out web/static_files/pipeline-health.json \
               --json > /dev/null \
-            || echo "::warning::pipeline health generation failed"
+            || {
+              echo "::warning::pipeline health generation failed"
+              echo "pipeline health" >> "$RUNNER_TEMP/data-failures"
+            }
           else
             echo "::warning::no PR snapshot; skipping pipeline health"
+            echo "pipeline health (no snapshot)" >> "$RUNNER_TEMP/data-failures"
+          fi
+          # The published file is what every reader of "where is the queue stuck" fetches, so a
+          # run that does not write one has not done its job even if the site deploys.
+          if [ ! -s web/static_files/pipeline-health.json ]; then
+            echo "::warning::pipeline-health.json was not written"
+          fi
+
+      - name: Collect which data assets could not be regenerated
+        id: data-failures
+        if: always()
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ -s "$RUNNER_TEMP/data-failures" ]; then
+            {
+              echo "assets<<EOF"
+              paste -sd ', ' "$RUNNER_TEMP/data-failures"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "assets=" >> "$GITHUB_OUTPUT"
           fi
 
       # Pinned leanprover/elan release, verified by SHA-256, rather than whatever the installer
@@ -450,6 +530,26 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  # Fail the run when a generated data asset could not be regenerated, without having stopped the
+  # deploy. The two are genuinely different questions and were previously collapsed into one: the
+  # steps that build the charts and pipeline-health.json swallow their failures on purpose, so
+  # that a GitHub hiccup costs a stale chart rather than a whole missed site publish. What was
+  # missing is the other half. A warning annotation notifies nobody, so the PR-statistics step
+  # failed on every run for two days, pipeline-health.json was never published at all, and every
+  # run was green. Running after `deploy` keeps the site publishing while making the run red, and
+  # a red scheduled run is what stuck_alerts.py's failing-scheduler detector watches for.
+  report-data-freshness:
+    needs: [build-site, deploy]
+    if: always() && needs.build-site.outputs.data-failures != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report the assets serving stale data
+        env:
+          ASSETS: ${{ needs.build-site.outputs.data-failures }}
+        run: |
+          echo "::error title=Stale site data::the site deployed, but these could not be regenerated and are now serving whatever was published last: ${ASSETS}"
+          exit 1
 
   # Point `docgen` at the commit whose documentation is now live.
   #

--- a/scripts/pipeline_health.py
+++ b/scripts/pipeline_health.py
@@ -50,7 +50,9 @@ from pr_lifecycle import (  # noqa: E402
     iso_z,
     parse_dt,
 )
-from pr_stats_graphs import atomic_write, fetch_snapshot, percentile  # noqa: E402
+from pr_stats_graphs import (  # noqa: E402
+    atomic_write, fetch_snapshot, load_previous, percentile,
+)
 
 OWNED_BY_PROJECT = [s for s in STAGE_ORDER if s not in STATE_AUTHOR_ACTION]
 
@@ -382,6 +384,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo", default="TauCetiProject/TauCeti")
     parser.add_argument("--data", type=Path, help="replay a normalized offline snapshot")
     parser.add_argument("--dump-data", type=Path, help="write the fetched snapshot")
+    parser.add_argument("--since-data", type=Path,
+                        help="an earlier snapshot; pull requests untouched since it was "
+                             "written keep their recorded timeline rather than being "
+                             "walked again. Walking every timeline costs one request per "
+                             "pull request and no longer fits in an hour's API budget.")
     parser.add_argument("--out", type=Path, help="write the JSON result here")
     parser.add_argument("--window", type=float, default=24.0, help="recent window, hours")
     parser.add_argument("--baseline", type=float, default=14 * 24.0, help="baseline, hours")
@@ -390,7 +397,8 @@ def main(argv: list[str] | None = None) -> int:
                         help="analyse as at this instant (default: the snapshot's fetched_at)")
     args = parser.parse_args(argv)
 
-    snapshot = json.loads(args.data.read_text()) if args.data else fetch_snapshot(args.repo)
+    snapshot = (json.loads(args.data.read_text()) if args.data
+                else fetch_snapshot(args.repo, load_previous(args.since_data, args.repo)))
     if args.dump_data:
         args.dump_data.write_text(json.dumps(snapshot, indent=1))
 

--- a/scripts/pr_stats_graphs.py
+++ b/scripts/pr_stats_graphs.py
@@ -100,10 +100,38 @@ def atomic_write(path: Path, content: str) -> None:
         raise
 
 
+# A depleted budget is not a transient failure: retrying in one, two and four seconds cannot
+# refill it, so the original three quick attempts turned an hour-long wait into an immediate
+# error. The budget refills on a fixed schedule, so the only useful response is to wait for it.
+RATE_LIMITED = re.compile(r"rate limit|secondary rate|was submitted too quickly", re.I)
+# One GraphQL window is an hour, plus a margin for clock skew between here and GitHub. Capped so
+# that a misread reset time, or a limit that is not actually going to refill, fails the job
+# instead of holding a runner indefinitely.
+MAX_RATE_LIMIT_WAIT = 75 * 60
+
+
+def rate_limit_reset_wait() -> float | None:
+    """Seconds until the GraphQL budget refills, or None if that cannot be established."""
+    probe = subprocess.run(
+        ["gh", "api", "rate_limit", "--jq", ".resources.graphql.reset"],
+        text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    if probe.returncode != 0:
+        return None
+    try:
+        reset = datetime.fromtimestamp(int(probe.stdout.strip()), tz=timezone.utc)
+    except ValueError:
+        return None
+    # A small margin past the reset, so a request does not land on the boundary and fail again.
+    return max(0.0, (reset - datetime.now(timezone.utc)).total_seconds()) + 5
+
+
 def run_gh(arguments: list[str], attempts: int = 3) -> str:
-    """Run gh with short retries for transient GitHub/API failures."""
+    """Run gh, with short retries for transient failures and a long one for a depleted budget."""
     last_error = None
-    for attempt in range(attempts):
+    waited = 0.0
+    attempt = 0
+    while attempt < attempts:
         result = subprocess.run(
             ["gh", *arguments], text=True, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -111,7 +139,22 @@ def run_gh(arguments: list[str], attempts: int = 3) -> str:
         if result.returncode == 0:
             return result.stdout
         last_error = result.stderr.strip() or f"gh exited {result.returncode}"
-        if attempt + 1 < attempts:
+        if RATE_LIMITED.search(last_error):
+            wait = rate_limit_reset_wait()
+            if wait is None or waited + wait > MAX_RATE_LIMIT_WAIT:
+                raise RuntimeError(
+                    f"GitHub rate limit exhausted and not waitable: {last_error}. "
+                    f"Already waited {waited / 60:.0f} min of a {MAX_RATE_LIMIT_WAIT / 60:.0f} "
+                    "min budget. Pass a recent snapshot with --since-data so that unchanged "
+                    "pull requests do not have to be walked again.")
+            print(f"rate limit reached; waiting {wait / 60:.1f} min for the budget to refill",
+                  file=sys.stderr)
+            time.sleep(wait)
+            waited += wait
+            # Waiting is not one of the three attempts: the request never really ran.
+            continue
+        attempt += 1
+        if attempt < attempts:
             time.sleep(2 ** attempt)
     raise RuntimeError(f"GitHub query failed after {attempts} attempts: {last_error}")
 
@@ -130,7 +173,7 @@ query($owner:String!, $name:String!, $cursor:String) {
                  orderBy:{field:CREATED_AT, direction:ASC}) {
       pageInfo { hasNextPage endCursor }
       nodes {
-        number createdAt mergedAt closedAt state isDraft
+        number createdAt updatedAt mergedAt closedAt state isDraft
         author { login }
         labels(first:30) { nodes { name } }
       }
@@ -200,18 +243,76 @@ def fetch_timeline(owner: str, name: str, number: int) -> dict:
         cursor = timeline["pageInfo"]["endCursor"]
 
 
-def fetch_timelines(owner: str, name: str, numbers: list[int]) -> dict[int, dict]:
-    """Fetch current state and timelines independently; batching loses events."""
+def fetch_timelines(
+    owner: str, name: str, numbers: list[int], reusable: dict[int, dict] | None = None,
+) -> tuple[dict[int, dict], int]:
+    """Fetch current state and timelines independently; batching loses events.
+
+    One GraphQL request per pull request, which is the dominant cost of this script and the
+    reason it needs `reusable`: a repository with more open-plus-recently-closed pull requests
+    than the hourly GraphQL budget cannot be walked from scratch at all. `reusable` maps a
+    number to a timeline recorded when the pull request last had a given `updatedAt`; the caller
+    only puts an entry there when that `updatedAt` still holds, so a hit is exact rather than a
+    heuristic. Returns the timelines and how many had to be fetched.
+    """
+    reusable = reusable or {}
     result = {}
+    fetched = 0
     for index, number in enumerate(numbers, start=1):
+        cached = reusable.get(number)
+        if cached is not None:
+            result[number] = cached
+            continue
         result[number] = fetch_timeline(owner, name, number)
-        if index % 100 == 0 or index == len(numbers):
-            print(f"fetched {index:,}/{len(numbers):,} PR timelines", file=sys.stderr)
-    return result
+        fetched += 1
+        if fetched % 100 == 0 or index == len(numbers):
+            print(f"fetched {fetched:,} PR timelines "
+                  f"({len(numbers) - fetched:,} reused of {len(numbers):,})", file=sys.stderr)
+    return result, fetched
 
 
-def fetch_prs(repo: str) -> list[dict]:
-    """Fetch every PR and its authoritative, directly queried label timeline."""
+def reusable_timelines(previous: dict | None, prs: list[dict]) -> dict[int, dict]:
+    """Timelines from an earlier snapshot that the current `updatedAt` proves are still current.
+
+    A pull request's `updatedAt` moves when it is labelled, so an unchanged one is a sound
+    certificate that its label timeline is unchanged too. Anything the previous snapshot does
+    not carry a matching `updated_at` and a recorded timeline for is simply refetched, so a
+    snapshot written before this field existed, a truncated one, or none at all all degrade to
+    the original full walk rather than to wrong data.
+    """
+    if not previous:
+        return {}
+    recorded = {}
+    for entry in previous.get("prs") or []:
+        if entry.get("updated_at") and "labeled_events" in entry:
+            recorded[entry.get("number")] = entry
+    reusable = {}
+    for pr in prs:
+        entry = recorded.get(pr["number"])
+        if entry is None or entry["updated_at"] != pr["updated_at"]:
+            continue
+        # Shaped like a fetch_timeline result, because that is what the caller substitutes it
+        # for. Only the event list comes from the previous snapshot: the state fields are taken
+        # from this run's page query, which was read later than the cached copy and so is the
+        # fresher of the two. They must agree anyway -- an unchanged `updatedAt` says so -- but
+        # preferring the newer read keeps a reused pull request no staler than a fetched one.
+        reusable[pr["number"]] = {
+            "merged_at": pr["merged_at"],
+            "closed_at": pr["closed_at"],
+            "state": pr["state"],
+            "is_draft": pr["is_draft"],
+            "labels": pr["labels"],
+            "labeled_events": entry.get("labeled_events") or [],
+        }
+    return reusable
+
+
+def fetch_prs(repo: str, previous: dict | None = None) -> list[dict]:
+    """Fetch every PR and its authoritative, directly queried label timeline.
+
+    `previous` is an earlier snapshot from this same repository, used only to skip refetching
+    the timeline of a pull request that has not been touched since. See `reusable_timelines`.
+    """
     owner, name = split_repo(repo)
     cursor = None
     prs = []
@@ -223,6 +324,7 @@ def fetch_prs(repo: str) -> list[dict]:
             prs.append({
                 "number": raw["number"],
                 "created_at": raw["createdAt"],
+                "updated_at": raw["updatedAt"],
                 "merged_at": raw["mergedAt"],
                 "closed_at": raw["closedAt"],
                 "state": raw["state"],
@@ -238,7 +340,8 @@ def fetch_prs(repo: str) -> list[dict]:
         pr["number"] for pr in prs
         if pr["closed_at"] is None or parse_dt(pr["closed_at"]) >= LIFECYCLE_EPOCH
     ]
-    timelines = fetch_timelines(owner, name, timeline_numbers)
+    timelines, _ = fetch_timelines(
+        owner, name, timeline_numbers, reusable_timelines(previous, prs))
     for pr in prs:
         if pr["number"] not in timelines:
             continue
@@ -338,8 +441,37 @@ def fetch_scoreboards(
     return scoreboards, rejected
 
 
-def fetch_snapshot(repo: str) -> dict:
-    prs = fetch_prs(repo)
+def load_previous(path: Path | None, repo: str) -> dict | None:
+    """An earlier snapshot to reuse timelines from, or None if there is nothing usable.
+
+    Every failure here is non-fatal and reported, because this file is only ever an
+    optimisation: no snapshot, an unreadable one, or one from another repository all mean the
+    same thing -- walk everything, as before. Silence would be the wrong choice in the other
+    direction though. A cache that has quietly stopped being restored looks exactly like a
+    healthy run until the budget runs out, which is the failure this whole path exists to
+    prevent, so a miss says so on stderr.
+    """
+    if path is None:
+        return None
+    try:
+        previous = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"no previous snapshot at {path}; walking every timeline", file=sys.stderr)
+        return None
+    except (OSError, ValueError) as error:
+        print(f"ignoring unreadable snapshot {path}: {error}", file=sys.stderr)
+        return None
+    if previous.get("repo") != repo:
+        print(f"ignoring snapshot for {previous.get('repo')!r}, expected {repo!r}",
+              file=sys.stderr)
+        return None
+    print(f"reusing timelines from the snapshot taken at {previous.get('fetched_at')}",
+          file=sys.stderr)
+    return previous
+
+
+def fetch_snapshot(repo: str, previous: dict | None = None) -> dict:
+    prs = fetch_prs(repo, previous)
     trusted_logins = {
         pr["author"] for pr in prs
         if pr.get("merged_at") and pr.get("author") != "unknown"
@@ -889,6 +1021,11 @@ def main() -> int:
     parser.add_argument("--out-dir", required=True, type=Path)
     parser.add_argument("--data", type=Path, help="normalized offline snapshot")
     parser.add_argument("--dump-data", type=Path, help="write fetched normalized snapshot")
+    parser.add_argument("--since-data", type=Path,
+                        help="an earlier snapshot; pull requests untouched since it was written "
+                             "keep their recorded timeline instead of being walked again. "
+                             "A missing or unreadable file is ignored, so a cold start still "
+                             "works -- it is a cost optimisation, never a source of truth.")
     parser.add_argument("--as-of", help="override snapshot time (ISO 8601)")
     parser.add_argument("--contributor-limit", type=int, default=24)
     parser.add_argument("--history-days", type=int, default=90)
@@ -900,7 +1037,7 @@ def main() -> int:
     if args.data:
         data = json.loads(args.data.read_text(encoding="utf-8"))
     else:
-        data = fetch_snapshot(args.repo)
+        data = fetch_snapshot(args.repo, load_previous(args.since_data, args.repo))
         if args.dump_data:
             atomic_write(args.dump_data, json.dumps(data, indent=2) + "\n")
     as_of = parse_dt(args.as_of) if args.as_of else None

--- a/scripts/pr_status/stuck_alerts.py
+++ b/scripts/pr_status/stuck_alerts.py
@@ -32,6 +32,12 @@ Detectors (each names the infra failure it implies):
   5. dead-scheduler  A scheduled workflow is missing, disabled, or its last
                      SCHEDULED run is older than its cadence + slack. GitHub
                      disabled the cron (60-day inactivity), or it errors at dispatch.
+  5b. failing-scheduler
+                     A scheduled workflow whose cron fires on time and whose last
+                     few runs all FAILED. dead-scheduler reads only when runs
+                     started, never how they ended, so on its own it cannot tell a
+                     healthy job from one that has been red for days -- which is
+                     exactly how pages.yml served a stale site unnoticed.
   6. main-red        The newest conclusive CI run on main is red, with no newer
                      successful run. The "main is always green" invariant is broken.
   7. stale-fkb       An open first-known-bad issue (label `dependency-incompatibility`)
@@ -102,6 +108,7 @@ import, so send/find target this topic.
 
 import base64
 import datetime
+import itertools
 import json
 import os
 import re
@@ -148,6 +155,12 @@ SCHEDULERS = {
     # routinely delays a scheduled run well past its cadence.
     "merge-conflicts.yml":   ("merge-conflict labels",     2),
 }
+# How many consecutive failed scheduled runs make a workflow "failing" rather than
+# flaky, and how many recent runs to read to decide. Two is one full cadence of
+# breakage for every workflow in the table above, and enough that a lone network
+# blip never posts.
+FAILING_SCHEDULER_RUNS = 2
+SCHEDULER_RUN_WINDOW = 10
 # A PR carrying any of these labels is intentionally parked; never "stranded".
 HOLD_LABELS = {"keep", "hold", "wip", "human", "do-not-close", "blocked"}
 # The downstream-reports first-known-bad tracking issue carries this label
@@ -618,6 +631,68 @@ def _sched_alert(wf, name, problem, fix):
     }
 
 
+def detect_failing_schedulers():
+    """A cron that fires on time and fails every time.
+
+    dead-scheduler above proves only that runs are STARTING. It reads a run's created_at and
+    never its conclusion, so a workflow that fires punctually and fails punctually looks
+    perfectly healthy to it. That gap is not hypothetical: pages.yml failed on all ten of its
+    scheduled runs between 2026-09-05 and 2026-09-06 while the site served content from the last
+    success, and nothing said a word, because a red scheduled run notifies nobody and the one
+    watchdog that looks at pages.yml was satisfied that it had run.
+
+    Consecutive failures, rather than the newest one, are what is alerted: these jobs are long
+    and touch the network, so a single red run is noise. Requiring the whole recent streak to be
+    red keeps the topic worth reading, and any real breakage produces that streak within one
+    cadence anyway.
+    """
+    out = []
+    for wf, (name, _max_hours) in SCHEDULERS.items():
+        try:
+            out.extend(_check_scheduler_health(wf, name))
+        except Exception as exc:
+            # As in detect_dead_schedulers: one workflow's transient error must not mark every
+            # other scheduler unknown for the run.
+            zp.log(f"scheduler health check for {wf} failed (non-fatal): {exc}")
+    return out
+
+
+def _check_scheduler_health(wf, name):
+    runs = gh_stream(
+        f"/repos/{REPO}/actions/workflows/{wf}/runs?event=schedule"
+        f"&per_page={SCHEDULER_RUN_WINDOW}",
+        jq='.workflow_runs[] | {status: (.status // ""), conclusion: (.conclusion // ""), '
+           'created_at: (.created_at // ""), url: (.html_url // "")}',
+        paginate=False)
+    # Queued, in-progress and cancelled runs are evidence of nothing: they are skipped rather
+    # than breaking the streak, so a run cancelled by a concurrency policy cannot mask a streak
+    # of genuine failures behind it.
+    conclusive = [r for r in runs
+                  if r.get("status") == "completed"
+                  and r.get("conclusion") in CONCLUSIVE_CI]
+    streak = list(itertools.takewhile(
+        lambda r: r.get("conclusion") in RED_CONCLUSIONS, conclusive))
+    if len(streak) < FAILING_SCHEDULER_RUNS:
+        return []
+    # Only report a streak we have actually seen the end of. A window entirely of failures may
+    # be a longer streak, which is still worth alerting -- but say so honestly.
+    bounded = "" if len(streak) < len(conclusive) else " (at least; the whole window is red)"
+    oldest = streak[-1].get("created_at") or ""
+    since = f"{hours_since(oldest):.0f}h" if oldest else "an unknown period"
+    return [{
+        "key": f"failing-scheduler/{wf}",
+        "title": f"Scheduler failing — {name}",
+        "body": (
+            f"`{wf}`'s last {len(streak)} scheduled runs all failed{bounded}, over the past "
+            f"{since}. The cron is firing, so dead-scheduler cannot see this: whatever the job "
+            f"publishes has been stale since the last success.\n\n"
+            f"Newest failure: {streak[0].get('url') or 'see the Actions tab'}\n\n"
+            f"**Fix:** read that run's log and repair the job. If the failure is expected for "
+            f"now, disable the schedule rather than leaving it red, so this topic keeps meaning "
+            f"something."),
+    }]
+
+
 def detect_main_red():
     tip = gh_scalar(f"/repos/{REPO}/commits/main", jq='.sha // ""')
     if not tip:
@@ -693,6 +768,7 @@ DETECTORS = [
     ("diverged-head", detect_diverged_head),
     ("review-stuck", detect_review_stuck),
     ("dead-scheduler", detect_dead_schedulers),
+    ("failing-scheduler", detect_failing_schedulers),
     ("main-red", detect_main_red),
     ("stale-fkb", detect_stale_fkb),
 ]

--- a/scripts/pr_status/test_stuck_alerts.py
+++ b/scripts/pr_status/test_stuck_alerts.py
@@ -7,6 +7,7 @@ recurrence visibility. Pure logic only -- GitHub and Zulip are faked, so no netw
 or `gh` is needed. Run: python3 scripts/pr_status/test_stuck_alerts.py
 """
 
+import datetime
 import os
 import unittest
 
@@ -456,6 +457,74 @@ class DivergedHeadTest(unittest.TestCase):
         # A deleted head repo/branch is a different problem; do not cry wolf on an API miss.
         _install(self, self._routes(""))
         self.assertEqual(sa.detect_diverged_head(), [])
+
+class FailingSchedulerTest(unittest.TestCase):
+    """A cron that fires punctually and fails punctually must not read as healthy.
+
+    dead-scheduler reads only a run's created_at, so it cannot distinguish a working job from a
+    broken one. pages.yml failed every scheduled run for a day while that detector stayed quiet
+    and the site served stale content; these tests pin the gap shut.
+    """
+
+    @staticmethod
+    def sched_run(conclusion, status="completed", hours=1):
+        when = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=hours)
+        return {"status": status, "conclusion": conclusion,
+                "created_at": when.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "url": "https://github.com/x/y/actions/runs/1"}
+
+    def check(self, runs):
+        self.addCleanup(setattr, sa, "gh_stream", sa.gh_stream)
+        sa.gh_stream = lambda *a, **k: runs
+        return sa._check_scheduler_health("pages.yml", "pages / doc-gen publish")
+
+    def test_a_streak_of_failures_alerts(self):
+        alerts = self.check([self.sched_run("failure", hours=1), self.sched_run("failure", hours=4)])
+        self.assertEqual(len(alerts), 1)
+        self.assertEqual(alerts[0]["key"], "failing-scheduler/pages.yml")
+        self.assertIn("pages.yml", alerts[0]["body"])
+
+    def test_one_failure_is_not_an_emergency(self):
+        # These jobs are long and touch the network; a lone red run is noise, and this topic
+        # stops being read the moment it carries noise.
+        self.assertEqual(
+            self.check([self.sched_run("failure", hours=1), self.sched_run("success", hours=4)]), [])
+
+    def test_a_recent_success_clears_the_streak(self):
+        self.assertEqual(
+            self.check([self.sched_run("success", hours=1), self.sched_run("failure", hours=4),
+                        self.sched_run("failure", hours=7)]), [])
+
+    def test_in_progress_and_cancelled_runs_do_not_hide_a_streak(self):
+        # A queued run at the head, and a cancelled one between two failures, are evidence of
+        # nothing. Treating either as a break would let a concurrency policy mask real breakage.
+        alerts = self.check([
+            self.sched_run(None, status="in_progress", hours=0),
+            self.sched_run("failure", hours=1),
+            self.sched_run("cancelled", hours=4),
+            self.sched_run("failure", hours=7),
+        ])
+        self.assertEqual(len(alerts), 1)
+
+    def test_an_entirely_red_window_says_it_is_a_lower_bound(self):
+        alerts = self.check([self.sched_run("failure", hours=h) for h in (1, 4, 7)])
+        self.assertIn("at least", alerts[0]["body"])
+
+    def test_timed_out_counts_as_failure(self):
+        alerts = self.check([self.sched_run("timed_out", hours=1), self.sched_run("failure", hours=4)])
+        self.assertEqual(len(alerts), 1)
+
+    def test_no_runs_at_all_is_dead_schedulers_business(self):
+        # An absent cron is a different alert with a different fix; do not double-report it.
+        self.assertEqual(self.check([]), [])
+
+    def test_the_detector_is_registered_under_its_own_prefix(self):
+        # The prefix is what "fail closed" keys off: a detector raising must mark only its own
+        # alerts unknown, so its keys and its registered prefix have to agree.
+        prefixes = dict(sa.DETECTORS)
+        self.assertIn("failing-scheduler", prefixes)
+        self.assertEqual(sa.key_prefix("failing-scheduler/pages.yml"), "failing-scheduler")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_pr_stats_graphs.py
+++ b/scripts/test_pr_stats_graphs.py
@@ -11,6 +11,7 @@ import unittest
 import xml.etree.ElementTree as ET
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import chart_style
@@ -43,6 +44,7 @@ def pr(number, created_day, *, state="CLOSED", merged_day=None, author="alice",
     return {
         "number": number,
         "created_at": timestamp(created_day),
+        "updated_at": timestamp(merged_day or 14, 12),
         "merged_at": timestamp(merged_day, 12) if merged_day else None,
         "closed_at": timestamp(merged_day, 12) if merged_day else None,
         "state": state,
@@ -63,7 +65,8 @@ class MetricsTest(unittest.TestCase):
             "repository": {"pullRequests": {
                 "pageInfo": {"hasNextPage": False, "endCursor": None},
                 "nodes": [{
-                    "number": 42, "createdAt": timestamp(1), "mergedAt": None,
+                    "number": 42, "createdAt": timestamp(1), "updatedAt": timestamp(3),
+                    "mergedAt": None,
                     "closedAt": None, "state": "OPEN", "isDraft": False,
                     "author": {"login": "alice"}, "labels": {"nodes": []},
                 }],
@@ -101,7 +104,8 @@ class MetricsTest(unittest.TestCase):
             "repository": {"pullRequests": {
                 "pageInfo": {"hasNextPage": False, "endCursor": None},
                 "nodes": [{
-                    "number": 42, "createdAt": timestamp(1), "mergedAt": None,
+                    "number": 42, "createdAt": timestamp(1), "updatedAt": timestamp(3),
+                    "mergedAt": None,
                     "closedAt": timestamp(14), "state": "CLOSED", "isDraft": False,
                     "author": {"login": "alice"},
                     "labels": {"nodes": [{"name": "roadmap/PDE"}]},
@@ -130,7 +134,8 @@ class MetricsTest(unittest.TestCase):
             "repository": {"pullRequests": {
                 "pageInfo": {"hasNextPage": False, "endCursor": None},
                 "nodes": [{
-                    "number": 42, "createdAt": timestamp(1), "mergedAt": timestamp(2),
+                    "number": 42, "createdAt": timestamp(1), "updatedAt": timestamp(2),
+                    "mergedAt": timestamp(2),
                     "closedAt": timestamp(2), "state": "MERGED", "isDraft": False,
                     "author": {"login": "alice"}, "labels": {"nodes": []},
                 }],
@@ -140,6 +145,120 @@ class MetricsTest(unittest.TestCase):
             prs = stats.fetch_prs("example/project")
         self.assertEqual(prs[0]["labeled_events"], [])
         self.assertEqual(graphql.call_count, 1)
+
+    # --- incremental snapshots -------------------------------------------------------------
+    #
+    # One GraphQL request per pull request, against an hourly budget of 5000 points, is a wall
+    # this repository walked into: by September 2026 a full pass needed about 4600 requests and
+    # the charts ahead of it in the Pages job spent the rest, so the snapshot stopped being
+    # written at all and the published pipeline-health.json simply never appeared. Reuse is what
+    # keeps a run proportional to what changed rather than to how big the project has become, so
+    # these tests pin down both that it happens and that it cannot serve stale events.
+
+    OPEN_PAGE = {
+        "repository": {"pullRequests": {
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+            "nodes": [{
+                "number": 42, "createdAt": timestamp(1), "updatedAt": timestamp(3),
+                "mergedAt": None, "closedAt": None, "state": "OPEN", "isDraft": False,
+                "author": {"login": "alice"},
+                "labels": {"nodes": [{"name": "awaiting-review"}]},
+            }],
+        }},
+    }
+
+    def snapshot_with(self, updated_at, events):
+        return {"repo": "example/project", "fetched_at": timestamp(3), "prs": [{
+            "number": 42, "updated_at": updated_at, "merged_at": None, "closed_at": None,
+            "state": "OPEN", "is_draft": False, "labels": ["awaiting-review"],
+            "labeled_events": events,
+        }]}
+
+    def test_unchanged_pr_reuses_its_recorded_timeline(self):
+        events = [{"created_at": timestamp(2), "label": "awaiting-review"}]
+        previous = self.snapshot_with(timestamp(3), events)
+        with patch.object(stats, "graphql", side_effect=[self.OPEN_PAGE]) as graphql:
+            prs = stats.fetch_prs("example/project", previous)
+        # One call: the page query. The timeline query never ran.
+        self.assertEqual(graphql.call_count, 1)
+        self.assertEqual(prs[0]["labeled_events"], events)
+
+    def test_touched_pr_is_refetched(self):
+        # The snapshot was taken when the PR last changed on day 2; it has changed since.
+        previous = self.snapshot_with(
+            timestamp(2), [{"created_at": timestamp(2), "label": "awaiting-review"}])
+        direct = {"repository": {"pullRequest": {
+            "timelineItems": {"pageInfo": {"hasNextPage": False, "endCursor": None},
+                              "nodes": [{"createdAt": timestamp(3),
+                                         "label": {"name": "awaiting-review"}}]},
+            "mergedAt": None, "closedAt": None, "state": "OPEN", "isDraft": False,
+            "labels": {"nodes": [{"name": "awaiting-review"}]}}}}
+        with patch.object(stats, "graphql", side_effect=[self.OPEN_PAGE, direct]) as graphql:
+            prs = stats.fetch_prs("example/project", previous)
+        self.assertEqual(graphql.call_count, 2)
+        self.assertEqual(prs[0]["labeled_events"],
+                         [{"created_at": timestamp(3), "label": "awaiting-review"}])
+
+    def test_reuse_keeps_the_current_labels_not_the_recorded_ones(self):
+        # A reused entry supplies only the event list. Its state fields come from this run's
+        # page query, which was read later. Here the recorded copy disagrees, and must lose.
+        previous = self.snapshot_with(
+            timestamp(3), [{"created_at": timestamp(2), "label": "awaiting-review"}])
+        previous["prs"][0]["labels"] = ["ready-to-merge"]
+        previous["prs"][0]["state"] = "MERGED"
+        with patch.object(stats, "graphql", side_effect=[self.OPEN_PAGE]):
+            prs = stats.fetch_prs("example/project", previous)
+        self.assertEqual(prs[0]["labels"], ["awaiting-review"])
+        self.assertEqual(prs[0]["state"], "OPEN")
+
+    def test_snapshot_without_update_times_is_not_reused(self):
+        # A snapshot written before updated_at was recorded carries no certificate that its
+        # events are current, so it must fall back to a full walk rather than be trusted.
+        previous = self.snapshot_with(timestamp(3), [])
+        del previous["prs"][0]["updated_at"]
+        self.assertEqual(stats.reusable_timelines(previous, [
+            {"number": 42, "updated_at": timestamp(3), "merged_at": None, "closed_at": None,
+             "state": "OPEN", "is_draft": False, "labels": []}]), {})
+
+    def test_snapshot_from_another_repository_is_ignored(self):
+        previous = self.snapshot_with(timestamp(3), [])
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "snapshot.json"
+            path.write_text(json.dumps(previous))
+            self.assertIsNone(stats.load_previous(path, "someone/else"))
+            self.assertIsNotNone(stats.load_previous(path, "example/project"))
+
+    def test_a_missing_or_corrupt_snapshot_is_not_fatal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            missing = Path(directory) / "absent.json"
+            self.assertIsNone(stats.load_previous(missing, "example/project"))
+            corrupt = Path(directory) / "corrupt.json"
+            corrupt.write_text("{not json")
+            self.assertIsNone(stats.load_previous(corrupt, "example/project"))
+
+    def test_run_gh_waits_for_the_budget_instead_of_failing(self):
+        # Three retries one, two and four seconds apart cannot refill an hourly budget, so the
+        # original behaviour turned "wait a while" into "this run produces nothing".
+        results = [
+            SimpleNamespace(returncode=1, stdout="",
+                            stderr="gh: API rate limit already exceeded for site ID installation."),
+            SimpleNamespace(returncode=0, stdout="done", stderr=""),
+        ]
+        with patch.object(stats.subprocess, "run", side_effect=results) as run:
+            with patch.object(stats, "rate_limit_reset_wait", return_value=42.0):
+                with patch.object(stats.time, "sleep") as sleep:
+                    self.assertEqual(stats.run_gh(["api", "graphql"]), "done")
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(42.0)
+
+    def test_run_gh_gives_up_when_the_budget_will_not_refill(self):
+        limited = SimpleNamespace(
+            returncode=1, stdout="", stderr="gh: API rate limit already exceeded")
+        with patch.object(stats.subprocess, "run", return_value=limited):
+            with patch.object(stats, "rate_limit_reset_wait", return_value=None):
+                with self.assertRaises(RuntimeError) as caught:
+                    stats.run_gh(["api", "graphql"])
+        self.assertIn("--since-data", str(caught.exception))
 
     def test_review_cycles_use_label_transitions_and_reach_seven(self):
         prs = [


### PR DESCRIPTION
This PR makes `pipeline-health.json` publishable within the API budget, and makes a scheduled workflow that fires but fails impossible to miss.

The file has never existed. It is derived from the snapshot the pull-request charts dump, and that step walks every open-or-recently-closed pull request's label timeline at one GraphQL request each. At roughly 4600 requests against a budget of 5000 an hour it stopped fitting, so the snapshot was never written, so the health step skipped every run. Both steps end in `|| echo ::warning::`, so the run stayed green while the file returned 404 and the charts served committed fallbacks.

Carry the snapshot between runs: a pull request whose `updatedAt` has not moved keeps its recorded timeline, so a run costs what changed in the last three hours rather than what the project has accumulated. Reuse is certificated by `updatedAt` rather than guessed, and a snapshot that predates the field, or comes from another repository, or will not parse, all fall back to the full walk rather than to wrong data. Measured against `TauCetiReview`, a second pass reuses every timeline and drops from 18.1s to 2.0s with identical output. A restore miss still walks everything, now waiting out a depleted budget instead of failing, so a cold start completes.

Regenerating data stays non-fatal, because a GitHub hiccup should cost a stale chart rather than a missed deploy, but a job after `deploy` now turns any stale asset into a red run. And `stuck_alerts.py` gains a `failing-scheduler` detector: `dead-scheduler` reads only when runs started, never how they ended, which is why `pages.yml` failing ten scheduled runs in a row raised nothing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)