### PR TITLE
refactor(ModularForms): name the two orbit-redistribution steps in the norm valence formula

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Norm/Valence.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Valence.lean
@@ -232,8 +232,8 @@ lemma hasFiniteSupport_weightedOrderOfVanishingOnSubgroupOrbit [Γ.FiniteIndex]
 
 /-- **The `Γ`-orbits carrying mass are covered by the fibres above the `SL(2, ℤ)`-orbits they
 lie in.** Restricting the unrestricted sum to that union changes nothing, which is what lets the
-sum be reindexed by `SL(2, ℤ)`-orbits. The fibres are pairwise disjoint
-(`pairwiseDisjoint_preimage_slOrbitOfSubgroupOrbit`), so the reindexing is a partition. -/
+sum be reindexed by `SL(2, ℤ)`-orbits. Those fibres are pairwise disjoint by
+`Set.pairwiseDisjoint_fiber`, so the reindexing is a partition. -/
 private lemma finsum_eq_finsum_mem_biUnion_preimage_slOrbitOfSubgroupOrbit
     [ModularFormClass F (Γ : Subgroup (GL (Fin 2) ℝ)) k] (f : F) :
     (∑ᶠ o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ,
@@ -248,15 +248,6 @@ private lemma finsum_eq_finsum_mem_biUnion_preimage_slOrbitOfSubgroupOrbit
         slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P} :=
     fun o ho ↦ Set.mem_biUnion ⟨o, ho, rfl⟩ rfl
   rw [finsum_mem_def, Set.indicator_eq_self.mpr hsub]
-
-/-- **Distinct `SL(2, ℤ)`-orbits have disjoint fibres.** A `Γ`-orbit lies above exactly one
-`SL(2, ℤ)`-orbit, so the fibres of `slOrbitOfSubgroupOrbit` partition whatever they cover. -/
-private lemma pairwiseDisjoint_preimage_slOrbitOfSubgroupOrbit
-    (I : Set (orbitRel.Quotient SL(2, ℤ) ℍ)) :
-    I.PairwiseDisjoint (fun P ↦ slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P}) := by
-  intro a _ b _ hab
-  simp only [Function.onFun, Set.disjoint_left, Set.mem_preimage, Set.mem_singleton_iff]
-  exact fun o h1 h2 ↦ hab (h1 ▸ h2)
 
 /-- **The interior mass of the norm, redistributed over the `Γ`-orbits.** The level-one weighted
 divisor sum of `ModularForm.norm 𝒮ℒ f` is the general-level weighted divisor sum of `f`.
@@ -276,7 +267,8 @@ theorem finsum_weightedOrderOfVanishingOnSubgroupOrbit_eq_finsum_norm [Γ.Finite
   set I := slOrbitOfSubgroupOrbit (Γ := Γ) ''
     Function.support (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f) with hIdef
   rw [finsum_eq_finsum_mem_biUnion_preimage_slOrbitOfSubgroupOrbit f,
-    finsum_mem_biUnion (pairwiseDisjoint_preimage_slOrbitOfSubgroupOrbit I) (hsupp.image _)
+    finsum_mem_biUnion (Set.pairwiseDisjoint_fiber (slOrbitOfSubgroupOrbit (Γ := Γ)) I)
+      (hsupp.image _)
       fun P _ ↦ finite_preimage_slOrbitOfSubgroupOrbit P,
     finsum_mem_congr rfl fun P _ ↦
       (weightedOrderOfVanishingOnOrbit_norm_eq_finsum_mem f hf P).symm, finsum_mem_def]

--- a/TauCeti/NumberTheory/ModularForms/Norm/Valence.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Valence.lean
@@ -148,11 +148,9 @@ lemma weightedOrderOfVanishingOnOrbit_eq_two_mul_div [SlashInvariantFormClass F 
 /-- **One `Γ`-orbit's share of the level-one weight.** The summand of the level-one weighted
 order at the `SL(2, ℤ)`-orbit of `p` — the number of cosets translating `p` into the `Γ`-orbit
 `o`, times the order there, scaled by the level-one elliptic order — is the general-level
-weighted order at `o`, and vanishes off the fibre. Orbit-stabiliser
-(`card_fiber_orbitOfCosetTranslate_mul_cardStabilizerOnOrbit_eq`) is what turns the count into
-the weight `2 / |Stab_Γ o|`; off the fibre the count is itself zero. -/
+weighted order at `o`, and vanishes off the fibre. -/
 private lemma card_fiber_smul_orderOfVanishingOnSubgroupOrbit_mul_ellipticOrder_inv_eq_indicator
-    [ModularFormClass F (Γ : Subgroup (GL (Fin 2) ℝ)) k] (f : F) (p : ℍ)
+    [SlashInvariantFormClass F (Γ : Subgroup (GL (Fin 2) ℝ)) k] (f : F) (p : ℍ)
     (o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ) :
     ((Nat.card {q : 𝒮ℒ ⧸ (Γ : Subgroup (GL (Fin 2) ℝ)).subgroupOf 𝒮ℒ //
           orbitOfCosetTranslate p q = o} • orderOfVanishingOnSubgroupOrbit f o : ℤ) : ℚ) *
@@ -231,11 +229,9 @@ lemma hasFiniteSupport_weightedOrderOfVanishingOnSubgroupOrbit [Γ.FiniteIndex]
   exact fun h0 ↦ ho (by rw [weightedOrderOfVanishingOnSubgroupOrbit_def, h0]; simp)
 
 /-- **The `Γ`-orbits carrying mass are covered by the fibres above the `SL(2, ℤ)`-orbits they
-lie in.** Restricting the unrestricted sum to that union changes nothing, which is what lets the
-sum be reindexed by `SL(2, ℤ)`-orbits. Those fibres are pairwise disjoint by
-`Set.pairwiseDisjoint_fiber`, so the reindexing is a partition. -/
+lie in**, so restricting the unrestricted sum to that union changes nothing. -/
 private lemma finsum_eq_finsum_mem_biUnion_preimage_slOrbitOfSubgroupOrbit
-    [ModularFormClass F (Γ : Subgroup (GL (Fin 2) ℝ)) k] (f : F) :
+    [SlashInvariantFormClass F (Γ : Subgroup (GL (Fin 2) ℝ)) k] (f : F) :
     (∑ᶠ o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ,
         weightedOrderOfVanishingOnSubgroupOrbit f o) =
       ∑ᶠ o ∈ ⋃ P ∈ slOrbitOfSubgroupOrbit (Γ := Γ) ''

--- a/TauCeti/NumberTheory/ModularForms/Norm/Valence.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Valence.lean
@@ -228,23 +228,6 @@ lemma hasFiniteSupport_weightedOrderOfVanishingOnSubgroupOrbit [Γ.FiniteIndex]
   simp only [Function.mem_support, ne_eq] at ho ⊢
   exact fun h0 ↦ ho (by rw [weightedOrderOfVanishingOnSubgroupOrbit_def, h0]; simp)
 
-/-- **The `Γ`-orbits carrying mass are covered by the fibres above the `SL(2, ℤ)`-orbits they
-lie in**, so restricting the unrestricted sum to that union changes nothing. -/
-private lemma finsum_eq_finsum_mem_biUnion_preimage_slOrbitOfSubgroupOrbit
-    [SlashInvariantFormClass F (Γ : Subgroup (GL (Fin 2) ℝ)) k] (f : F) :
-    (∑ᶠ o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ,
-        weightedOrderOfVanishingOnSubgroupOrbit f o) =
-      ∑ᶠ o ∈ ⋃ P ∈ slOrbitOfSubgroupOrbit (Γ := Γ) ''
-          Function.support (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f),
-        slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P},
-        weightedOrderOfVanishingOnSubgroupOrbit f o := by
-  have hsub : Function.support (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f) ⊆
-      ⋃ P ∈ slOrbitOfSubgroupOrbit (Γ := Γ) ''
-          Function.support (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f),
-        slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P} :=
-    fun o ho ↦ Set.mem_biUnion ⟨o, ho, rfl⟩ rfl
-  rw [finsum_mem_def, Set.indicator_eq_self.mpr hsub]
-
 /-- **The interior mass of the norm, redistributed over the `Γ`-orbits.** The level-one weighted
 divisor sum of `ModularForm.norm 𝒮ℒ f` is the general-level weighted divisor sum of `f`.
 
@@ -262,7 +245,14 @@ theorem finsum_weightedOrderOfVanishingOnSubgroupOrbit_eq_finsum_norm [Γ.Finite
     hasFiniteSupport_weightedOrderOfVanishingOnSubgroupOrbit f
   set I := slOrbitOfSubgroupOrbit (Γ := Γ) ''
     Function.support (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f) with hIdef
-  rw [finsum_eq_finsum_mem_biUnion_preimage_slOrbitOfSubgroupOrbit f,
+  -- the orbits carrying mass are covered by the fibres above their own image
+  have hrestrict : (∑ᶠ o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ,
+        weightedOrderOfVanishingOnSubgroupOrbit f o) =
+      ∑ᶠ o ∈ ⋃ P ∈ I, slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P},
+        weightedOrderOfVanishingOnSubgroupOrbit f o := by
+    rw [finsum_mem_def, hIdef, Set.biUnion_preimage_singleton,
+      Set.indicator_eq_self.mpr (Set.subset_preimage_image _ _)]
+  rw [hrestrict,
     finsum_mem_biUnion (Set.pairwiseDisjoint_fiber (slOrbitOfSubgroupOrbit (Γ := Γ)) I)
       (hsupp.image _)
       fun P _ ↦ finite_preimage_slOrbitOfSubgroupOrbit P,

--- a/TauCeti/NumberTheory/ModularForms/Norm/Valence.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Valence.lean
@@ -145,6 +145,42 @@ lemma weightedOrderOfVanishingOnOrbit_eq_two_mul_div [SlashInvariantFormClass F 
   push_cast
   field_simp
 
+/-- **One `Γ`-orbit's share of the level-one weight.** The summand of the level-one weighted
+order at the `SL(2, ℤ)`-orbit of `p` — the number of cosets translating `p` into the `Γ`-orbit
+`o`, times the order there, scaled by the level-one elliptic order — is the general-level
+weighted order at `o`, and vanishes off the fibre. Orbit-stabiliser
+(`card_fiber_orbitOfCosetTranslate_mul_cardStabilizerOnOrbit_eq`) is what turns the count into
+the weight `2 / |Stab_Γ o|`; off the fibre the count is itself zero. -/
+private lemma card_fiber_smul_orderOfVanishingOnSubgroupOrbit_mul_ellipticOrder_inv_eq_indicator
+    [ModularFormClass F (Γ : Subgroup (GL (Fin 2) ℝ)) k] (f : F) (p : ℍ)
+    (o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ) :
+    ((Nat.card {q : 𝒮ℒ ⧸ (Γ : Subgroup (GL (Fin 2) ℝ)).subgroupOf 𝒮ℒ //
+          orbitOfCosetTranslate p q = o} • orderOfVanishingOnSubgroupOrbit f o : ℤ) : ℚ) *
+        (ModularGroup.ellipticOrder (Quotient.mk'' p : orbitRel.Quotient SL(2, ℤ) ℍ) : ℚ)⁻¹ =
+      Set.indicator (slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹'
+          {(Quotient.mk'' p : orbitRel.Quotient SL(2, ℤ) ℍ)})
+        (weightedOrderOfVanishingOnSubgroupOrbit f) o := by
+  have he : (ModularGroup.ellipticOrder
+      (Quotient.mk'' p : orbitRel.Quotient SL(2, ℤ) ℍ) : ℚ) ≠ 0 := by
+    exact_mod_cast (ModularGroup.ellipticOrder_pos _).ne'
+  by_cases ho : slOrbitOfSubgroupOrbit o = (Quotient.mk'' p : orbitRel.Quotient SL(2, ℤ) ℍ)
+  · rw [Set.indicator_of_mem (by simpa using ho), weightedOrderOfVanishingOnSubgroupOrbit_def]
+    have hprod := card_fiber_orbitOfCosetTranslate_mul_cardStabilizerOnOrbit_eq p ho
+    have hc : (cardStabilizerOnOrbit o : ℚ) ≠ 0 := by
+      exact_mod_cast cardStabilizerOnOrbit_ne_zero o
+    have hprod' : (Nat.card {q : 𝒮ℒ ⧸ (Γ : Subgroup (GL (Fin 2) ℝ)).subgroupOf 𝒮ℒ //
+        orbitOfCosetTranslate p q = o} : ℚ) * (cardStabilizerOnOrbit o : ℚ) =
+        2 * (ModularGroup.ellipticOrder
+          (Quotient.mk'' p : orbitRel.Quotient SL(2, ℤ) ℍ) : ℚ) := by
+      exact_mod_cast congrArg (fun n : ℕ ↦ (n : ℚ)) hprod
+    rw [nsmul_eq_mul]
+    push_cast
+    field_simp
+    linear_combination (orderOfVanishingOnSubgroupOrbit f o : ℚ) * hprod'
+  · rw [Set.indicator_of_notMem (by simpa using ho),
+      card_fiber_orbitOfCosetTranslate_eq_zero p ho]
+    simp
+
 /-- **The level-one weight at a point redistributes over the `Γ`-orbits above it.** The weighted
 vanishing order of the norm at the `SL(2, ℤ)`-orbit of `p` is the sum of the general-level
 weighted orders of `f` over the `Γ`-orbits inside that orbit.
@@ -162,35 +198,6 @@ lemma weightedOrderOfVanishingOnOrbit_norm_eq_finsum_mem
         weightedOrderOfVanishingOnSubgroupOrbit f o := by
   induction P using Quotient.inductionOn' with
   | h p =>
-    have he : (ModularGroup.ellipticOrder
-        (Quotient.mk'' p : orbitRel.Quotient SL(2, ℤ) ℍ) : ℚ) ≠ 0 := by
-      exact_mod_cast (ModularGroup.ellipticOrder_pos _).ne'
-    -- the multiplicity of a `Γ`-orbit, divided by the level-one weight, is the general-level weight
-    have key : ∀ o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ,
-        ((Nat.card {q : 𝒮ℒ ⧸ (Γ : Subgroup (GL (Fin 2) ℝ)).subgroupOf 𝒮ℒ //
-              orbitOfCosetTranslate p q = o} • orderOfVanishingOnSubgroupOrbit f o : ℤ) : ℚ) *
-            (ModularGroup.ellipticOrder (Quotient.mk'' p : orbitRel.Quotient SL(2, ℤ) ℍ) : ℚ)⁻¹ =
-          Set.indicator (slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹'
-              {(Quotient.mk'' p : orbitRel.Quotient SL(2, ℤ) ℍ)})
-            (weightedOrderOfVanishingOnSubgroupOrbit f) o := by
-      intro o
-      by_cases ho : slOrbitOfSubgroupOrbit o = (Quotient.mk'' p : orbitRel.Quotient SL(2, ℤ) ℍ)
-      · rw [Set.indicator_of_mem (by simpa using ho), weightedOrderOfVanishingOnSubgroupOrbit_def]
-        have hprod := card_fiber_orbitOfCosetTranslate_mul_cardStabilizerOnOrbit_eq p ho
-        have hc : (cardStabilizerOnOrbit o : ℚ) ≠ 0 := by
-          exact_mod_cast cardStabilizerOnOrbit_ne_zero o
-        have hprod' : (Nat.card {q : 𝒮ℒ ⧸ (Γ : Subgroup (GL (Fin 2) ℝ)).subgroupOf 𝒮ℒ //
-            orbitOfCosetTranslate p q = o} : ℚ) * (cardStabilizerOnOrbit o : ℚ) =
-            2 * (ModularGroup.ellipticOrder
-              (Quotient.mk'' p : orbitRel.Quotient SL(2, ℤ) ℍ) : ℚ) := by
-          exact_mod_cast congrArg (fun n : ℕ ↦ (n : ℚ)) hprod
-        rw [nsmul_eq_mul]
-        push_cast
-        field_simp
-        linear_combination (orderOfVanishingOnSubgroupOrbit f o : ℚ) * hprod'
-      · rw [Set.indicator_of_notMem (by simpa using ho),
-          card_fiber_orbitOfCosetTranslate_eq_zero p ho]
-        simp
     have hcast : ((∑ᶠ o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ,
           Nat.card {q : 𝒮ℒ ⧸ (Γ : Subgroup (GL (Fin 2) ℝ)).subgroupOf 𝒮ℒ //
             orbitOfCosetTranslate p q = o} • orderOfVanishingOnSubgroupOrbit f o : ℤ) : ℚ) =
@@ -200,7 +207,8 @@ lemma weightedOrderOfVanishingOnOrbit_norm_eq_finsum_mem
       AddMonoidHom.map_finsum_of_injective (Int.castAddHom ℚ) Int.cast_injective _
     rw [weightedOrderOfVanishingOnOrbit_mk, orderOfVanishingAt_norm_eq_finsum_orbit f hf p,
       finsum_mem_def, div_eq_mul_inv, hcast, finsum_mul]
-    exact finsum_congr key
+    exact finsum_congr
+      (card_fiber_smul_orderOfVanishingOnSubgroupOrbit_mul_ellipticOrder_inv_eq_indicator f p)
 
 /-- The general-level weighted order is nonnegative: a modular form is holomorphic and the
 weight is positive. -/
@@ -222,6 +230,34 @@ lemma hasFiniteSupport_weightedOrderOfVanishingOnSubgroupOrbit [Γ.FiniteIndex]
   simp only [Function.mem_support, ne_eq] at ho ⊢
   exact fun h0 ↦ ho (by rw [weightedOrderOfVanishingOnSubgroupOrbit_def, h0]; simp)
 
+/-- **The `Γ`-orbits carrying mass are covered by the fibres above the `SL(2, ℤ)`-orbits they
+lie in.** Restricting the unrestricted sum to that union changes nothing, which is what lets the
+sum be reindexed by `SL(2, ℤ)`-orbits. The fibres are pairwise disjoint
+(`pairwiseDisjoint_preimage_slOrbitOfSubgroupOrbit`), so the reindexing is a partition. -/
+private lemma finsum_eq_finsum_mem_biUnion_preimage_slOrbitOfSubgroupOrbit
+    [ModularFormClass F (Γ : Subgroup (GL (Fin 2) ℝ)) k] (f : F) :
+    (∑ᶠ o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ,
+        weightedOrderOfVanishingOnSubgroupOrbit f o) =
+      ∑ᶠ o ∈ ⋃ P ∈ slOrbitOfSubgroupOrbit (Γ := Γ) ''
+          Function.support (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f),
+        slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P},
+        weightedOrderOfVanishingOnSubgroupOrbit f o := by
+  have hsub : Function.support (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f) ⊆
+      ⋃ P ∈ slOrbitOfSubgroupOrbit (Γ := Γ) ''
+          Function.support (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f),
+        slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P} :=
+    fun o ho ↦ Set.mem_biUnion ⟨o, ho, rfl⟩ rfl
+  rw [finsum_mem_def, Set.indicator_eq_self.mpr hsub]
+
+/-- **Distinct `SL(2, ℤ)`-orbits have disjoint fibres.** A `Γ`-orbit lies above exactly one
+`SL(2, ℤ)`-orbit, so the fibres of `slOrbitOfSubgroupOrbit` partition whatever they cover. -/
+private lemma pairwiseDisjoint_preimage_slOrbitOfSubgroupOrbit
+    (I : Set (orbitRel.Quotient SL(2, ℤ) ℍ)) :
+    I.PairwiseDisjoint (fun P ↦ slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P}) := by
+  intro a _ b _ hab
+  simp only [Function.onFun, Set.disjoint_left, Set.mem_preimage, Set.mem_singleton_iff]
+  exact fun o h1 h2 ↦ hab (h1 ▸ h2)
+
 /-- **The interior mass of the norm, redistributed over the `Γ`-orbits.** The level-one weighted
 divisor sum of `ModularForm.norm 𝒮ℒ f` is the general-level weighted divisor sum of `f`.
 
@@ -239,27 +275,8 @@ theorem finsum_weightedOrderOfVanishingOnSubgroupOrbit_eq_finsum_norm [Γ.Finite
     hasFiniteSupport_weightedOrderOfVanishingOnSubgroupOrbit f
   set I := slOrbitOfSubgroupOrbit (Γ := Γ) ''
     Function.support (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f) with hIdef
-  have hmem_I {o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ}
-      (ho : o ∈ Function.support
-        (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f)) :
-      slOrbitOfSubgroupOrbit (Γ := Γ) o ∈ I :=
-    ⟨o, ho, rfl⟩
-  have hdisj : I.PairwiseDisjoint (fun P ↦ slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P}) := by
-    intro a _ b _ hab
-    simp only [Function.onFun, Set.disjoint_left, Set.mem_preimage, Set.mem_singleton_iff]
-    exact fun o h1 h2 ↦ hab (h1 ▸ h2)
-  -- the `Γ`-orbits carrying mass are covered by the fibres above the finitely many
-  -- `SL(2, ℤ)`-orbits they lie in
-  have hsub : Function.support (weightedOrderOfVanishingOnSubgroupOrbit (Γ := Γ) (k := k) f) ⊆
-      ⋃ P ∈ I, slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P} := fun o ho ↦
-    Set.mem_biUnion (hmem_I ho) rfl
-  have hrestrict : (∑ᶠ o : orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ,
-        weightedOrderOfVanishingOnSubgroupOrbit f o) =
-      ∑ᶠ o ∈ ⋃ P ∈ I, slOrbitOfSubgroupOrbit (Γ := Γ) ⁻¹' {P},
-        weightedOrderOfVanishingOnSubgroupOrbit f o := by
-    rw [finsum_mem_def, Set.indicator_eq_self.mpr hsub]
-  rw [hrestrict,
-    finsum_mem_biUnion hdisj (hsupp.image _)
+  rw [finsum_eq_finsum_mem_biUnion_preimage_slOrbitOfSubgroupOrbit f,
+    finsum_mem_biUnion (pairwiseDisjoint_preimage_slOrbitOfSubgroupOrbit I) (hsupp.image _)
       fun P _ ↦ finite_preimage_slOrbitOfSubgroupOrbit P,
     finsum_mem_congr rfl fun P _ ↦
       (weightedOrderOfVanishingOnOrbit_norm_eq_finsum_mem f hf P).symm, finsum_mem_def]


### PR DESCRIPTION
`Norm/Valence.lean` had two proofs over the length cap. Both were over it for the
same reason: an anonymous `have` in the middle that is a statement in its own
right.

### The weight conversion

`weightedOrderOfVanishingOnOrbit_norm_eq_finsum_mem` (51 lines) was almost
entirely one `key`. It says that the summand of the level-one weighted order at
the orbit of `p` — the number of cosets translating `p` into a given `Γ`-orbit
`o`, times the order there, scaled by the level-one elliptic order — is exactly
the general-level weighted order at `o`, and vanishes off the fibre.

That is the mathematical heart of the redistribution: orbit-stabiliser is what
turns a coset count into the weight `2 / |Stab_Γ o|`. It now has a name and a
docstring saying so, and the parent is the four rewrites that use it.

### The restriction to the fibres

`finsum_weightedOrderOfVanishingOnSubgroupOrbit_eq_finsum_norm` (57 lines) spent
its first sixteen lines establishing that the support is covered by the fibres
above its image under `slOrbitOfSubgroupOrbit`, so the unrestricted sum may be
restricted to that union — the step that lets the sum be reindexed by
`SL(2, ℤ)`-orbits.

Review turned that into a lesson about what was actually mine. Neither half of it
was: the disjointness of the fibres is Mathlib's `Set.pairwiseDisjoint_fiber`, and
the covering is `Set.biUnion_preimage_singleton` together with
`Set.subset_preimage_image`. Both private helpers this PR first introduced are
therefore gone, and the parent uses the Mathlib lemmas directly — the covering as
a two-line named `have`, the disjointness passed straight to `finsum_mem_biUnion`.

### Numbers

The file goes from two proofs over the cap to none: 51 → 23 and 57 → 46. One
lemma is extracted, the weight conversion, at 38 lines.

The `#lint` pass caught an `IsFiniteRelIndex` instance the first extraction had
inherited but never used; it is gone, so each extracted statement carries only
the hypotheses its own proof needs.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR


