### PR TITLE
fix: draw the per-roadmap chart from every merged PR

### DIFF
--- a/scripts/loc_roadmap_graph.py
+++ b/scripts/loc_roadmap_graph.py
@@ -42,12 +42,37 @@ MAINTENANCE_TITLE = re.compile(
 )
 
 
+# `gh pr list` returns at most `--limit` pull requests, newest first, and says nothing when it
+# stops. The limit here was 2000 against 5072 merged pull requests, so the chart was built from
+# the newest 2000 and silently lost every band before them -- a cumulative series whose early
+# history simply was not there. This ceiling exists only so a runaway query cannot page forever;
+# reaching it means the chart would be wrong, so reaching it raises instead.
+MERGED_PR_CEILING = 100_000
+
+
 def fetch_gh(repo: str) -> list[dict]:
     out = subprocess.run(
-        ["gh", "pr", "list", "--repo", repo, "--state", "merged", "--limit", "2000",
+        ["gh", "pr", "list", "--repo", repo, "--state", "merged",
+         "--limit", str(MERGED_PR_CEILING),
          "--json", "number,title,labels,mergedAt,additions,deletions"],
         check=True, text=True, stdout=subprocess.PIPE).stdout
-    return json.loads(out)
+    prs = json.loads(out)
+    check_complete(prs)
+    return prs
+
+
+def check_complete(prs: list[dict]) -> None:
+    """Refuse a truncated result rather than drawing a chart that is quietly missing its start.
+
+    A cumulative chart cannot survive losing its oldest rows: every band is shifted by whatever
+    was dropped, and it looks entirely plausible while being wrong. There is no partial answer
+    worth publishing here, so this raises and the caller keeps the previous SVG.
+    """
+    if len(prs) >= MERGED_PR_CEILING:
+        raise RuntimeError(
+            f"gh returned {len(prs)} merged pull requests, at or above the {MERGED_PR_CEILING} "
+            "ceiling, so the oldest ones were probably dropped and the cumulative series would "
+            "start in the wrong place. Raise MERGED_PR_CEILING.")
 
 
 def roadmap_of(pr: dict) -> str | None:

--- a/scripts/test_loc_roadmap_graph.py
+++ b/scripts/test_loc_roadmap_graph.py
@@ -45,5 +45,29 @@ class RoadmapSeries(unittest.TestCase):
             graph.build_series(prs)
 
 
+class TruncationTest(unittest.TestCase):
+    """A cumulative chart cannot survive losing its oldest rows.
+
+    `gh pr list` returns at most --limit results, newest first, and reports nothing when it
+    stops there. The limit was 2000 while the repository had 5072 merged pull requests, so every
+    band silently began 3000 pull requests too late and the chart looked entirely plausible.
+    """
+
+    def test_a_full_result_is_refused_rather_than_drawn(self):
+        prs = [pr(n, "feat: add theorem", "roadmap/PDE", 1, 0)
+               for n in range(graph.MERGED_PR_CEILING)]
+        with self.assertRaisesRegex(RuntimeError, "ceiling"):
+            graph.check_complete(prs)
+
+    def test_a_short_result_is_accepted(self):
+        self.assertIsNone(graph.check_complete([pr(1, "feat: x", "roadmap/PDE", 1, 0)]))
+
+    def test_the_ceiling_is_well_clear_of_the_project(self):
+        # The point of the ceiling is to stop a runaway query, not to bound the project. If it
+        # ever sits near the real number of merged pull requests, the guard above starts firing
+        # on healthy runs instead of on a bug.
+        self.assertGreaterEqual(graph.MERGED_PR_CEILING, 50_000)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR removes a silent truncation in the per-roadmap lines chart, which was drawing only the newest 2000 of 5072 merged pull requests.

`gh pr list` returns at most `--limit` results, newest first, and says nothing when it stops there. A cumulative series cannot survive losing its oldest rows: every band began three thousand pull requests too late, and the chart looked entirely plausible while being wrong.

Raise the ceiling to a number no real project reaches, and refuse a result that touches it, so the only remaining outcome is a loud one. The chart step already keeps the committed fallback SVG when the query fails, which is the right behaviour here, because there is no partial version of this chart worth publishing.

Costs roughly 30 more requests per Pages run, against about 4400 saved by the snapshot reuse in #5828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)