### PR TITLE
refactor(ModularForms): name the two excision half-width facts at rho + 1

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -216,6 +216,14 @@ noncomputable def fdBoundaryArcExcisionHalfWidth (ε : ℝ) : ℝ := 12 / Real.p
 @[simp] lemma fdBoundaryArcExcisionHalfWidth_def (ε : ℝ) :
     fdBoundaryArcExcisionHalfWidth ε = 12 / Real.pi * Real.arcsin (ε / 2) := (rfl)
 
+/-- The half-width is exactly the angle `arcsin (ε / 2)` once scaled by the corner's angular
+unit `π / 12`. This is the shape in which the half-width enters both the sine identity below
+and the excised integral at `ρ + 1`. -/
+lemma fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve (ε : ℝ) :
+    fdBoundaryArcExcisionHalfWidth ε * (Real.pi / 12) = Real.arcsin (ε / 2) := by
+  rw [fdBoundaryArcExcisionHalfWidth_def]
+  field_simp
+
 /-- **The chord-matched excision half-width does what it is for.** For an excision radius `ε`
 below the corner chord `2·sin(π/12)`, the half-width lies strictly between `0` and `1` and
 reproduces `ε` as its own chord: `2·sin(δ·π/12) = ε`.
@@ -237,9 +245,8 @@ lemma fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq {ε : ℝ
   refine ⟨by positivity, ?_, ?_⟩
   · rw [div_mul_eq_mul_div, div_lt_one hπ]
     linarith
-  · have hδπ : 12 / Real.pi * Real.arcsin (ε / 2) * (Real.pi / 12) = Real.arcsin (ε / 2) := by
-      field_simp
-    rw [hδπ, Real.sin_arcsin (by linarith) (by linarith)]
+  · rw [← fdBoundaryArcExcisionHalfWidth_def, fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve,
+      Real.sin_arcsin (by linarith) (by linarith)]
     ring
 
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -224,25 +224,6 @@ lemma fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve (ε : ℝ) :
   rw [fdBoundaryArcExcisionHalfWidth_def]
   field_simp
 
-/-- **The vertical excision half-width.** On a vertical leg of length `H - √3/2` the excision
-parameter `ε` becomes a parameter half-width by dividing by that length. The three facts the
-excision argument needs are that it is positive, at most `1`, and undoes the division; only
-`ε ≤ H - √3/2` is required, the leg's positivity following from that together with `0 < ε`.
-The companion on the arc is
-`fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq`. -/
-lemma verticalExcisionHalfWidth_pos_and_le_one_and_mul_eq {ε : ℝ} (hε : 0 < ε)
-    (hεH : ε ≤ H - Real.sqrt 3 / 2) :
-    0 < ε / (H - Real.sqrt 3 / 2) ∧ ε / (H - Real.sqrt 3 / 2) ≤ 1 ∧
-      ε / (H - Real.sqrt 3 / 2) * (H - Real.sqrt 3 / 2) = ε := by
-  have hHpos : (0 : ℝ) < H - Real.sqrt 3 / 2 := hε.trans_le hεH
-  exact ⟨div_pos hε hHpos, (div_le_one hHpos).2 hεH, div_mul_cancel₀ ε hHpos.ne'⟩
-
-/-- **The chord-matched excision half-width does what it is for.** For an excision radius `ε`
-below the corner chord `2·sin(π/12)`, the half-width lies strictly between `0` and `1` and
-reproduces `ε` as its own chord: `2·sin(δ·π/12) = ε`.
-
-This is the trigonometric content shared by the excision constructions at `i`, at `ρ` and at
-`ρ + 1`; it needs no upper bound on `ε` beyond the chord bound. -/
 lemma fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq {ε : ℝ} (hε : 0 < ε)
     (hε₃ : ε < 2 * Real.sin (Real.pi / 12)) :
     0 < fdBoundaryArcExcisionHalfWidth ε ∧ fdBoundaryArcExcisionHalfWidth ε < 1 ∧

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -217,13 +217,24 @@ noncomputable def fdBoundaryArcExcisionHalfWidth (ε : ℝ) : ℝ := 12 / Real.p
     fdBoundaryArcExcisionHalfWidth ε = 12 / Real.pi * Real.arcsin (ε / 2) := (rfl)
 
 /-- The half-width is exactly the angle `arcsin (ε / 2)` once scaled by the corner's angular
-unit `π / 12`. This is the shape in which the half-width enters both the sine identity below
-and the excised integral at `ρ + 1`. -/
+unit `π / 12`. This is the shape in which the half-width enters the sine identity below, the
+excised arc away from the corners, and the excised integrals at `ρ` and `ρ + 1`.
+
+AINTLIB gives the same fact its own name at the corner `i`, where the angular unit is
+`5π / 12`: `half_angle_arcsinDelta` in `LeanModularForms/ForMathlib/CrossingAtI.lean`
+(github.com/CBirkbeck/AINTLIB, Apache-2.0). No code is transcribed; the statement here is
+against this repository's own `fdBoundaryArcExcisionHalfWidth`. -/
 lemma fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve (ε : ℝ) :
     fdBoundaryArcExcisionHalfWidth ε * (Real.pi / 12) = Real.arcsin (ε / 2) := by
   rw [fdBoundaryArcExcisionHalfWidth_def]
   field_simp
 
+/-- **The chord-matched excision half-width does what it is for.** For an excision radius `ε`
+below the corner chord `2·sin(π/12)`, the half-width lies strictly between `0` and `1` and
+reproduces `ε` as its own chord: `2·sin(δ·π/12) = ε`.
+
+This is the trigonometric content shared by the excision constructions at `i`, at `ρ` and at
+`ρ + 1`; it needs no upper bound on `ε` beyond the chord bound. -/
 lemma fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq {ε : ℝ} (hε : 0 < ε)
     (hε₃ : ε < 2 * Real.sin (Real.pi / 12)) :
     0 < fdBoundaryArcExcisionHalfWidth ε ∧ fdBoundaryArcExcisionHalfWidth ε < 1 ∧

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -222,8 +222,7 @@ excised arc away from the corners, and the excised integrals at `ρ` and `ρ + 1
 
 AINTLIB gives the same fact its own name at the corner `i`, where the angular unit is
 `5π / 12`: `half_angle_arcsinDelta` in `LeanModularForms/ForMathlib/CrossingAtI.lean`
-(github.com/CBirkbeck/AINTLIB, Apache-2.0). No code is transcribed; the statement here is
-against this repository's own `fdBoundaryArcExcisionHalfWidth`. -/
+(github.com/CBirkbeck/AINTLIB, Apache-2.0). -/
 lemma fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve (ε : ℝ) :
     fdBoundaryArcExcisionHalfWidth ε * (Real.pi / 12) = Real.arcsin (ε / 2) := by
   rw [fdBoundaryArcExcisionHalfWidth_def]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -224,6 +224,19 @@ lemma fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve (ε : ℝ) :
   rw [fdBoundaryArcExcisionHalfWidth_def]
   field_simp
 
+/-- **The vertical excision half-width.** On a vertical leg of length `H - √3/2` the excision
+parameter `ε` becomes a parameter half-width by dividing by that length. The three facts the
+excision argument needs are that it is positive, at most `1`, and undoes the division; only
+`ε ≤ H - √3/2` is required, the leg's positivity following from that together with `0 < ε`.
+The companion on the arc is
+`fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq`. -/
+lemma verticalExcisionHalfWidth_pos_and_le_one_and_mul_eq {ε : ℝ} (hε : 0 < ε)
+    (hεH : ε ≤ H - Real.sqrt 3 / 2) :
+    0 < ε / (H - Real.sqrt 3 / 2) ∧ ε / (H - Real.sqrt 3 / 2) ≤ 1 ∧
+      ε / (H - Real.sqrt 3 / 2) * (H - Real.sqrt 3 / 2) = ε := by
+  have hHpos : (0 : ℝ) < H - Real.sqrt 3 / 2 := hε.trans_le hεH
+  exact ⟨div_pos hε hHpos, (div_le_one hHpos).2 hεH, div_mul_cancel₀ ε hHpos.ne'⟩
+
 /-- **The chord-matched excision half-width does what it is for.** For an excision radius `ε`
 below the corner chord `2·sin(π/12)`, the half-width lies strictly between `0` and `1` and
 reproduces `ε` as its own chord: `2·sin(δ·π/12) = ε`.

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
@@ -422,7 +422,7 @@ private lemma truncated_integral_spec_arc (hH : 1 < H) (hnorm : ‖w‖ = 1)
   rw [hval, ← hw, log_sub_log_arc ⟨ht₀.1.le, ht₀.2.le⟩ hδ0 (by linarith [ht₀.1])
     (by linarith [ht₀.2]),
     show δ * (Real.pi / 6) = 2 * Real.arcsin (ε / 2) by
-      rw [hδ_def, fdBoundaryArcExcisionHalfWidth_def]; field_simp; ring]
+      rw [← fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve ε, hδ_def]; ring]
   push_cast
   ring
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
@@ -418,11 +418,13 @@ private lemma truncated_integral_spec_arc (hH : 1 < H) (hnorm : ‖w‖ = 1)
       exact norm_sub_arc_le_of_near ⟨by linarith [hs.1, ht₀.1], by linarith [hs.2, ht₀.2]⟩
         ⟨ht₀.1.le, ht₀.2.le⟩ (by linarith [ht₀.1, ht₀.2])
         (abs_le.mpr ⟨by linarith [hs.1], by linarith [hs.2]⟩))
+  -- the arc spans twice the corner's angular unit, so the half-width scales by `π / 6`
+  have hδ6 : δ * (Real.pi / 6) = 2 * Real.arcsin (ε / 2) := by
+    rw [← fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve ε, hδ_def]
+    ring
   refine ⟨hint, ?_⟩
   rw [hval, ← hw, log_sub_log_arc ⟨ht₀.1.le, ht₀.2.le⟩ hδ0 (by linarith [ht₀.1])
-    (by linarith [ht₀.2]),
-    show δ * (Real.pi / 6) = 2 * Real.arcsin (ε / 2) by
-      rw [← fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve ε, hδ_def]; ring]
+    (by linarith [ht₀.2]), hδ6]
   push_cast
   ring
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -342,18 +342,6 @@ private lemma norm_le_of_near_rho_add_one {δL δR : ℝ} (hH : Real.sqrt 3 / 2 
     exact norm_fdBoundary_sub_rho_add_one_arc_le H ⟨h1.le, by linarith [ht.2]⟩
       (by linarith) (by linarith [ht.2])
 
-/-- **The vertical excision half-width.** On the left leg the excision parameter `ε` is
-converted into a parameter half-width by dividing by the leg's length `H - √3/2`; the three
-facts the excision argument needs are that it is positive, at most `1`, and undoes the
-division. The companion on the arc is
-`fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq`. -/
-private lemma verticalExcisionHalfWidth_pos_and_le_one_and_mul_eq (hε : 0 < ε)
-    (hεH : ε < H - Real.sqrt 3 / 2) :
-    0 < ε / (H - Real.sqrt 3 / 2) ∧ ε / (H - Real.sqrt 3 / 2) ≤ 1 ∧
-      ε / (H - Real.sqrt 3 / 2) * (H - Real.sqrt 3 / 2) = ε := by
-  have hHpos : (0 : ℝ) < H - Real.sqrt 3 / 2 := hε.trans hεH
-  exact ⟨div_pos hε hHpos, (div_le_one hHpos).2 hεH.le, div_mul_cancel₀ ε hHpos.ne'⟩
-
 /-- **The excision collapse at `ρ + 1`**: for small `ε`, the `ε`-excised index integrand
 of the boundary contour about `ρ + 1` is interval integrable, and its integral is
 exactly `-πi/3 - arcsin(ε/2)·i`. -/
@@ -371,7 +359,7 @@ private lemma truncated_integral_spec_rho_add_one (hH : Real.sqrt 3 / 2 < H) (h�
   obtain ⟨hδR_pos, hδR_lt, h2sin⟩ :=
     fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq hε hε₃
   set δR := fdBoundaryArcExcisionHalfWidth ε with hδR_def
-  obtain ⟨hδL_pos, hδL_le, hlin⟩ := verticalExcisionHalfWidth_pos_and_le_one_and_mul_eq hε hεH
+  obtain ⟨hδL_pos, hδL_le, hlin⟩ := verticalExcisionHalfWidth_pos_and_le_one_and_mul_eq hε hεH.le
   set δL := ε / (H - Real.sqrt 3 / 2) with hδL_def
   obtain ⟨hi_left, hi_right, hval⟩ :=
     ftc_logDeriv_telescope_rho_add_one H hH hδL_pos hδL_le hδR_pos hδR_lt

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -342,6 +342,18 @@ private lemma norm_le_of_near_rho_add_one {δL δR : ℝ} (hH : Real.sqrt 3 / 2 
     exact norm_fdBoundary_sub_rho_add_one_arc_le H ⟨h1.le, by linarith [ht.2]⟩
       (by linarith) (by linarith [ht.2])
 
+/-- **The vertical excision half-width.** On the left leg the excision parameter `ε` is
+converted into a parameter half-width by dividing by the leg's length `H - √3/2`; the three
+facts the excision argument needs are that it is positive, at most `1`, and undoes the
+division. The companion on the arc is
+`fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq`. -/
+private lemma verticalExcisionHalfWidth_pos_and_le_one_and_mul_eq (hε : 0 < ε)
+    (hεH : ε < H - Real.sqrt 3 / 2) :
+    0 < ε / (H - Real.sqrt 3 / 2) ∧ ε / (H - Real.sqrt 3 / 2) ≤ 1 ∧
+      ε / (H - Real.sqrt 3 / 2) * (H - Real.sqrt 3 / 2) = ε := by
+  have hHpos : (0 : ℝ) < H - Real.sqrt 3 / 2 := hε.trans hεH
+  exact ⟨div_pos hε hHpos, (div_le_one hHpos).2 hεH.le, div_mul_cancel₀ ε hHpos.ne'⟩
+
 /-- **The excision collapse at `ρ + 1`**: for small `ε`, the `ε`-excised index integrand
 of the boundary contour about `ρ + 1` is interval integrable, and its integral is
 exactly `-πi/3 - arcsin(ε/2)·i`. -/
@@ -359,11 +371,8 @@ private lemma truncated_integral_spec_rho_add_one (hH : Real.sqrt 3 / 2 < H) (h�
   obtain ⟨hδR_pos, hδR_lt, h2sin⟩ :=
     fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq hε hε₃
   set δR := fdBoundaryArcExcisionHalfWidth ε with hδR_def
-  have hHpos : (0 : ℝ) < H - Real.sqrt 3 / 2 := by linarith
+  obtain ⟨hδL_pos, hδL_le, hlin⟩ := verticalExcisionHalfWidth_pos_and_le_one_and_mul_eq hε hεH
   set δL := ε / (H - Real.sqrt 3 / 2) with hδL_def
-  have hδL_pos : 0 < δL := div_pos hε hHpos
-  have hδL_le : δL ≤ 1 := (div_le_one hHpos).2 hεH.le
-  have hlin : δL * (H - Real.sqrt 3 / 2) = ε := div_mul_cancel₀ ε hHpos.ne'
   obtain ⟨hi_left, hi_right, hval⟩ :=
     ftc_logDeriv_telescope_rho_add_one H hH hδL_pos hδL_le hδR_pos hδR_lt
   have hae_left := Contour.ae_logDeriv_sub_eq_truncated (γ := fdBoundary H)
@@ -382,9 +391,6 @@ private lemma truncated_integral_spec_rho_add_one (hH : Real.sqrt 3 / 2 < H) (h�
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩
-  have hδ12 : δR * (Real.pi / 12) = Real.arcsin (ε / 2) := by
-    simp only [hδR_def, fdBoundaryArcExcisionHalfWidth_def]
-    field_simp
   rw [← intervalIntegral.integral_add_adjacent_intervals (hi02.trans himid) hi25,
     ← intervalIntegral.integral_add_adjacent_intervals hi02 himid,
     hmid0, add_zero,
@@ -392,7 +398,7 @@ private lemma truncated_integral_spec_rho_add_one (hH : Real.sqrt 3 / 2 < H) (h�
     ← intervalIntegral.integral_congr_ae hae_right,
     hval, log_fdBoundary_one_sub_sub_rho_add_one hH hδL_pos hδL_le,
     log_fdBoundary_one_add_sub_rho_add_one H hδR_pos (hδR_lt.le.trans one_le_two), hlin,
-    h2sin, hδ12]
+    h2sin, hδR_def, fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve]
   push_cast
   ring
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -359,8 +359,10 @@ private lemma truncated_integral_spec_rho_add_one (hH : Real.sqrt 3 / 2 < H) (h�
   obtain ⟨hδR_pos, hδR_lt, h2sin⟩ :=
     fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq hε hε₃
   set δR := fdBoundaryArcExcisionHalfWidth ε with hδR_def
-  obtain ⟨hδL_pos, hδL_le, hlin⟩ := verticalExcisionHalfWidth_pos_and_le_one_and_mul_eq hε hεH.le
   set δL := ε / (H - Real.sqrt 3 / 2) with hδL_def
+  have hδL_pos : 0 < δL := div_pos hε (hε.trans hεH)
+  have hδL_le : δL ≤ 1 := (div_le_one (hε.trans hεH)).2 hεH.le
+  have hlin : δL * (H - Real.sqrt 3 / 2) = ε := div_mul_cancel₀ ε (hε.trans hεH).ne'
   obtain ⟨hi_left, hi_right, hval⟩ :=
     ftc_logDeriv_telescope_rho_add_one H hH hδL_pos hδL_le hδR_pos hδR_lt
   have hae_left := Contour.ae_logDeriv_sub_eq_truncated (γ := fdBoundary H)

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -340,9 +340,10 @@ private lemma truncated_integral_spec_rho (hH : Real.sqrt 3 / 2 < H) (hε : 0 < 
   obtain ⟨hδL_pos, hδL_lt, h2sin⟩ :=
     fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq hε hε₃
   set δL := fdBoundaryArcExcisionHalfWidth ε with hδL_def
-  obtain ⟨hδR_pos, hδR_le, hlin⟩ :=
-    verticalExcisionHalfWidth_pos_and_le_one_and_mul_eq hε hεH.le
   set δR := ε / (H - Real.sqrt 3 / 2) with hδR_def
+  have hδR_pos : 0 < δR := div_pos hε (hε.trans hεH)
+  have hδR_le : δR ≤ 1 := (div_le_one (hε.trans hεH)).2 hεH.le
+  have hlin : δR * (H - Real.sqrt 3 / 2) = ε := div_mul_cancel₀ ε (hε.trans hεH).ne'
   obtain ⟨hi_left, hi_right, hval⟩ :=
     ftc_logDeriv_telescope_rho H hH hδL_pos hδL_lt hδR_pos hδR_le
   have hae_left := Contour.ae_logDeriv_sub_eq_truncated (γ := fdBoundary H)

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -340,11 +340,9 @@ private lemma truncated_integral_spec_rho (hH : Real.sqrt 3 / 2 < H) (hε : 0 < 
   obtain ⟨hδL_pos, hδL_lt, h2sin⟩ :=
     fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq hε hε₃
   set δL := fdBoundaryArcExcisionHalfWidth ε with hδL_def
-  have hHpos : (0 : ℝ) < H - Real.sqrt 3 / 2 := by linarith
+  obtain ⟨hδR_pos, hδR_le, hlin⟩ :=
+    verticalExcisionHalfWidth_pos_and_le_one_and_mul_eq hε hεH.le
   set δR := ε / (H - Real.sqrt 3 / 2) with hδR_def
-  have hδR_pos : 0 < δR := div_pos hε hHpos
-  have hδR_le : δR ≤ 1 := (div_le_one hHpos).2 hεH.le
-  have hlin : δR * (H - Real.sqrt 3 / 2) = ε := div_mul_cancel₀ ε hHpos.ne'
   obtain ⟨hi_left, hi_right, hval⟩ :=
     ftc_logDeriv_telescope_rho H hH hδL_pos hδL_lt hδR_pos hδR_le
   have hae_left := Contour.ae_logDeriv_sub_eq_truncated (γ := fdBoundary H)
@@ -362,16 +360,14 @@ private lemma truncated_integral_spec_rho (hH : Real.sqrt 3 / 2 < H) (hε : 0 < 
   have hi02 := hi_left.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_left)
   have hi25 := hi_right.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae_right)
   refine ⟨(hi02.trans himid).trans hi25, ?_⟩
-  have hδ12 : δL * (Real.pi / 12) = Real.arcsin (ε / 2) := by
-    simp only [hδL_def, fdBoundaryArcExcisionHalfWidth_def]
-    field_simp
   rw [← intervalIntegral.integral_add_adjacent_intervals (hi02.trans himid) hi25,
     ← intervalIntegral.integral_add_adjacent_intervals hi02 himid,
     hmid0, add_zero,
     ← intervalIntegral.integral_congr_ae hae_left,
     ← intervalIntegral.integral_congr_ae hae_right,
     hval, log_fdBoundary_three_sub_sub_rho H hδL_pos (hδL_lt.le.trans one_le_two),
-    log_fdBoundary_three_add_sub_rho hH hδR_pos hδR_le, h2sin, hlin, hδ12]
+    log_fdBoundary_three_add_sub_rho hH hδR_pos hδR_le, h2sin, hlin, hδL_def,
+    fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve]
   push_cast
   ring
 


### PR DESCRIPTION
`truncated_integral_spec_rho_add_one` was 54 lines, over the cap. Two of the
things it opened with were facts rather than steps in its argument.

### The vertical leg: nothing of mine survived, and that is the right answer

The first version of this PR bundled the vertical leg's three facts —
positivity, the bound by `1`, and undoing the division — into one lemma, on the
argument that the arc already has such a companion.

Review disagreed on both counts and was right. `reuse` pointed out that the
conclusion mentions only the raw quotient `ε / (H - √3/2)`, so the bundle
republished `div_pos`, `div_le_one` and `div_mul_cancel₀` under a new name;
`naming` pointed out that the name promised a `verticalExcisionHalfWidth`
operation that does not exist. Defining that operation would have made the name
honest, but it would also have invented API to justify a wrapper. The lemma is
gone and both consumers use the Mathlib lemmas directly.

The leg's positivity is written `hε.trans hεH` inline rather than named: at three
uses it costs no more than a `have`, and it is what keeps
`truncated_integral_spec_rho_add_one` at 50 lines instead of 51.

### The other fact was being proved twice

That `fdBoundaryArcExcisionHalfWidth ε * (π/12)` is `arcsin (ε/2)` was an
anonymous `have` inside
`fdBoundaryArcExcisionHalfWidth_pos_and_lt_one_and_two_mul_sin_eq` in
`Winding/Basic.lean`, and again as `hδ12` here. Neither could see the other.

It is now `fdBoundaryArcExcisionHalfWidth_mul_pi_div_twelve`, stated beside the
definition it is about, and both places use it.

This is also how the source organises it. AINTLIB's `ForMathlib/CrossingAtI.lean`
has the corresponding corner at `i` — `arcsinDelta ε = 12/(5π) · arcsin (ε/2)` —
and gives that fact its own name, `half_angle_arcsinDelta`, with the same
one-line proof. The lemma added here is its sibling at `ρ + 1`, against this
repository's own half-width definition; no code is transcribed.

### Numbers

54 → 50 at `ρ + 1`, and 46 at `ρ`. `Winding/Basic.lean`, `Rho/Value.lean` and
`Rho/AddOne/Value.lean` are all clear of the cap, and the PR adds exactly one
declaration: the scaling lemma that replaced three copies of its own proof.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR

