### PR TITLE
feat: prove the type-A weight torus maximal on points

### DIFF
--- a/TauCeti/Algebra/Group/Subgroup/Centralizer.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Centralizer.lean
@@ -23,7 +23,7 @@ which is the form every concrete centralizer computation in a matrix group start
 
 * `TauCeti.mem_centralizer_singleton_iff_commute_val`: a unit lies in the centralizer of a unit `g`
   exactly when the two commute as elements of the monoid.
-* `TauCeti.eq_of_centralizer_eq_self_of_le_of_isMulCommutative`: a self-centralizing subgroup is
+* `Subgroup.eq_of_centralizer_eq_self_of_le_of_isMulCommutative`: a self-centralizing subgroup is
   maximal among commutative subgroups.
 -/
 
@@ -37,6 +37,10 @@ theorem mem_centralizer_singleton_iff_commute_val {M : Type*} [Monoid M] {g h : 
   ⟨fun hh => Commute.units_val_iff.mpr (Subgroup.mem_centralizer_singleton_iff.mp hh).symm,
     fun hh => Subgroup.mem_centralizer_singleton_iff.mpr (Commute.units_val_iff.mp hh).symm⟩
 
+end TauCeti
+
+namespace Subgroup
+
 /-- A self-centralizing subgroup is maximal among commutative subgroups. -/
 theorem eq_of_centralizer_eq_self_of_le_of_isMulCommutative {G : Type*} [Group G]
     {S H : Subgroup G} (hS : Subgroup.centralizer (S : Set G) = S) [IsMulCommutative H]
@@ -49,4 +53,4 @@ theorem eq_of_centralizer_eq_self_of_le_of_isMulCommutative {G : Type*} [Group G
         (Subgroup.centralizer_le (SetLike.coe_subset_coe.mpr hle)))
     hle
 
-end TauCeti
+end Subgroup

--- a/TauCeti/Algebra/Group/Subgroup/Centralizer.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Centralizer.lean
@@ -11,7 +11,7 @@ public import Mathlib.GroupTheory.Subgroup.Centralizer
 public import Mathlib.Algebra.Group.Commute.Units
 
 /-!
-# The centralizer of a single unit
+# Centralizers and maximal commutative subgroups
 
 Centralizers of a group of units are computed on the underlying monoid: a unit centralizes another
 exactly when their values commute. Mathlib has both halves —
@@ -23,6 +23,8 @@ which is the form every concrete centralizer computation in a matrix group start
 
 * `TauCeti.mem_centralizer_singleton_iff_commute_val`: a unit lies in the centralizer of a unit `g`
   exactly when the two commute as elements of the monoid.
+* `TauCeti.eq_of_centralizer_eq_self_of_le_of_isMulCommutative`: a self-centralizing subgroup is
+  maximal among commutative subgroups.
 -/
 
 public section
@@ -34,5 +36,17 @@ theorem mem_centralizer_singleton_iff_commute_val {M : Type*} [Monoid M] {g h : 
     h ∈ Subgroup.centralizer {g} ↔ Commute (g : M) (h : M) :=
   ⟨fun hh => Commute.units_val_iff.mpr (Subgroup.mem_centralizer_singleton_iff.mp hh).symm,
     fun hh => Subgroup.mem_centralizer_singleton_iff.mpr (Commute.units_val_iff.mp hh).symm⟩
+
+/-- A self-centralizing subgroup is maximal among commutative subgroups. -/
+theorem eq_of_centralizer_eq_self_of_le_of_isMulCommutative {G : Type*} [Group G]
+    {S H : Subgroup G} (hS : Subgroup.centralizer (S : Set G) = S) [IsMulCommutative H]
+    (hle : S ≤ H) :
+    H = S :=
+  le_antisymm
+    (by
+      rw [← hS]
+      exact (Subgroup.le_centralizer (H := H)).trans
+        (Subgroup.centralizer_le (SetLike.coe_subset_coe.mpr hle)))
+    hle
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -236,6 +236,23 @@ theorem weight_def (k : Fin (r + 1)) (i : Fin r) :
       (if k = i.castSucc then 1 else 0) - (if k = i.succ then 1 else 0) :=
   by rw [weight]
 
+/-- The weights of the standard representation of `sl_{r+1}` are pairwise distinct. -/
+theorem weight_injective : Function.Injective (weight r) := by
+  intro k l hkl
+  by_contra hne
+  have aux {a b : Fin (r + 1)} (hab : (a : ℕ) < b)
+      (hweight : weight r a = weight r b) : False := by
+    have ha : (a : ℕ) < r := by omega
+    let i : Fin r := ⟨a, ha⟩
+    have hvalue := congrFun hweight i
+    simp only [weight_def, Fin.ext_iff, Fin.val_castSucc, Fin.val_succ] at hvalue
+    dsimp only [i] at hvalue
+    split_ifs at hvalue <;> omega
+  have hval : (k : ℕ) ≠ l := fun h ↦ hne (Fin.ext h)
+  rcases lt_or_gt_of_ne hval with hlt | hgt
+  · exact aux hlt hkl
+  · exact aux hgt hkl.symm
+
 /-- The weights of the standard representation sum to zero. -/
 theorem sum_weight_eq_zero : ∑ k, weight r k = 0 := by
   funext i

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -620,6 +620,19 @@ theorem coe_weightTorusPoints (A : Type v) [CommRing A] (s : Fin r → Aˣ) :
   exact TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralWeightTorusPoints
     _ _ _ _ _ _ _ _ A s
 
+/-- The standard weight-torus parametrization is injective over every commutative ring. -/
+theorem weightTorusPoints_injective (A : Type v) [CommRing A] :
+    Function.Injective (weightTorusPoints r A) := by
+  intro s t hst
+  apply torusCharacterHom_injective (span_range_weight_eq_top r)
+  have hmatrix := congrArg (fun g : points r A ↦ g.1) hst
+  rw [coe_weightTorusPoints, coe_weightTorusPoints,
+    UniversalEnvelopingAlgebra.kostantTorusMatrix_apply,
+    UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] at hmatrix
+  funext i
+  rw [torusCharacterHom_apply, torusCharacterHom_apply]
+  exact congrFun (diagGL_injective hmatrix) i
+
 /-- A matrix is a point of the type `A_r` carrier exactly when the associated convolution point
 kills its toral defining Hopf ideal. -/
 @[simp]

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -236,6 +236,20 @@ theorem weight_def (k : Fin (r + 1)) (i : Fin r) :
       (if k = i.castSucc then 1 else 0) - (if k = i.succ then 1 else 0) :=
   by rw [weight]
 
+/-- A standard-module weight as the difference of its possible adjacent basis characters. -/
+theorem weight_eq_ite_single_sub_ite_single (k : Fin (r + 1)) :
+    weight r k =
+      (if hk : (k : ℕ) < r then Pi.single ⟨k, hk⟩ 1 else 0) -
+        (if hk : 0 < (k : ℕ) then Pi.single ⟨k - 1, by omega⟩ 1 else 0) := by
+  classical
+  funext i
+  simp only [weight_def, Pi.sub_apply]
+  split_ifs
+  all_goals simp only [Pi.single_apply, Pi.zero_apply]
+  all_goals try split_ifs
+  all_goals simp only [Fin.ext_iff, Fin.val_castSucc, Fin.val_succ] at *
+  all_goals omega
+
 /-- The weights of the standard representation of `sl_{r+1}` are pairwise distinct. -/
 theorem weight_injective : Function.Injective (weight r) := by
   intro k l hkl
@@ -619,19 +633,6 @@ theorem coe_weightTorusPoints (A : Type v) [CommRing A] (s : Fin r → Aˣ) :
         (lattice r).toAddSubgroup (latticeBasis r) (weight r) s := by
   exact TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralWeightTorusPoints
     _ _ _ _ _ _ _ _ A s
-
-/-- The standard weight-torus parametrization is injective over every commutative ring. -/
-theorem weightTorusPoints_injective (A : Type v) [CommRing A] :
-    Function.Injective (weightTorusPoints r A) := by
-  intro s t hst
-  apply torusCharacterHom_injective (span_range_weight_eq_top r)
-  have hmatrix := congrArg (fun g : points r A ↦ g.1) hst
-  rw [coe_weightTorusPoints, coe_weightTorusPoints,
-    UniversalEnvelopingAlgebra.kostantTorusMatrix_apply,
-    UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] at hmatrix
-  funext i
-  rw [torusCharacterHom_apply, torusCharacterHom_apply]
-  exact congrFun (diagGL_injective hmatrix) i
 
 /-- A matrix is a point of the type `A_r` carrier exactly when the associated convolution point
 kills its toral defining Hopf ideal. -/

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
@@ -35,18 +35,6 @@ noncomputable section
 
 variable (r : ℕ)
 
-private theorem prod_ite_eq_of_eq {M : Type*} [CommMonoid M] (f : Fin r → M)
-    (e : Fin r → Fin (r + 1)) (he : Function.Injective e) (k : Fin (r + 1)) (c : Fin r)
-    (hkc : k = e c) :
-    (∏ i, if k = e i then f i else 1) = f c := by
-  rw [Finset.prod_eq_single c]
-  · simp only [hkc, ↓reduceIte]
-  · intro j _ hj
-    split_ifs with h
-    · exact (hj (he (hkc.symm.trans h)).symm).elim
-    · rfl
-  · exact fun h ↦ absurd (Finset.mem_univ c) h
-
 /-- The standard weight at coordinate `k` evaluates as the quotient of two adjacent partial
 products. Missing factors at the two ends are interpreted as one. -/
 private theorem torusCharacter_weight (K : Type u) [CommRing K]
@@ -67,8 +55,13 @@ private theorem torusCharacter_weight (K : Type u) [CommRing K]
     split_ifs with hk
     · let c : Fin r := ⟨k, hk⟩
       have hkc : k = c.castSucc := Fin.ext (by simp [c])
-      rw [prod_ite_eq_of_eq r s Fin.castSucc
-        (fun _ _ h ↦ Fin.castSucc_inj.mp h) k c hkc]
+      rw [Fintype.prod_eq_single c]
+      · simp only [hkc, ↓reduceIte]
+        exact congrArg s (Fin.ext rfl)
+      · intro j hj
+        split_ifs with h
+        · exact (hj (Fin.castSucc_inj.mp (hkc.symm.trans h)).symm).elim
+        · rfl
     · have : ∀ i : Fin r, k ≠ i.castSucc := by
         intro i hi
         apply hk
@@ -87,8 +80,13 @@ private theorem torusCharacter_weight (K : Type u) [CommRing K]
     · have hi : (k - 1 : ℕ) < r := by omega
       let c : Fin r := ⟨k - 1, hi⟩
       have hkc : k = c.succ := Fin.ext (by simp [c]; omega)
-      rw [prod_ite_eq_of_eq r (fun i ↦ (s i)⁻¹) Fin.succ
-        (fun _ _ h ↦ Fin.succ_inj.mp h) k c hkc]
+      rw [Fintype.prod_eq_single c]
+      · simp only [hkc, ↓reduceIte]
+        exact congrArg (fun j ↦ (s j)⁻¹) (Fin.ext (by simp))
+      · intro j hj
+        split_ifs with h
+        · exact (hj (Fin.succ_inj.mp (hkc.symm.trans h)).symm).elim
+        · rfl
     · have : ∀ i : Fin r, k ≠ i.succ := by
         intro i hi
         apply hk
@@ -113,8 +111,7 @@ private theorem torusCharacter_partialProd {K : Type u} [CommRing K]
     subst k
     have hi : (⟨(0 : Fin (r + 1)), hkr⟩ : Fin r).succ.castSucc =
         (0 : Fin (r + 1)).succ := Fin.ext rfl
-    rw [mul_one, hi, Fin.partialProd_succ,
-      show (0 : Fin (r + 1)).castSucc = (0 : Fin (r + 2)) by rfl,
+    rw [mul_one, hi, Fin.partialProd_succ, Fin.castSucc_zero,
       Fin.partialProd_zero, one_mul]
   · have hkmax : (k : ℕ) = r := by omega
     have hrpos : 0 < r := by omega
@@ -252,7 +249,7 @@ theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [CommRing K] :
 
 /-- If its weight characters are distinct over a ring without zero divisors, the standard weight
 torus is maximal among commutative subgroups of the type `A_r` carrier. -/
-theorem eq_range_weightTorusPoints_of_le_of_isMulCommutative_of_weightChar_injective
+theorem eq_range_weightTorusPoints_of_weightChar_injective_of_le_of_isMulCommutative
     (K : Type u) [CommRing K] [IsCancelMulZero K]
     (hchar : Function.Injective (weightChar K (κ := Fin r)))
     (H : Subgroup (points r K)) [IsMulCommutative H]
@@ -273,7 +270,7 @@ theorem eq_range_weightTorusPoints_of_le_of_isMulCommutative
     (H : Subgroup (points r K)) [IsMulCommutative H]
     (hle : (weightTorusPoints r K).range ≤ H) :
     H = (weightTorusPoints r K).range :=
-  eq_range_weightTorusPoints_of_le_of_isMulCommutative_of_weightChar_injective r K
+  eq_range_weightTorusPoints_of_weightChar_injective_of_le_of_isMulCommutative r K
     weightChar_injective H hle
 
 end

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
@@ -35,6 +35,17 @@ noncomputable section
 
 variable (r : ℕ)
 
+/-- A product supported at one index selected by an injective coordinate map is that factor. -/
+private theorem prod_zpow_ite_eq {K : Type u} [CommRing K] (s : Fin r → Kˣ)
+    (e : Fin r → Fin (r + 1)) (he : Function.Injective e) (k : Fin (r + 1)) (c : Fin r)
+    (hkc : k = e c) :
+    (∏ i, s i ^ (if k = e i then (1 : ℤ) else 0)) = s c := by
+  rw [Fintype.prod_eq_single c]
+  · simp only [hkc, ↓reduceIte, zpow_one]
+  · intro j hj
+    have hne : k ≠ e j := fun h ↦ hj (he (h.symm.trans hkc))
+    simp [hne]
+
 /-- The standard weight at coordinate `k` evaluates as the quotient of two adjacent partial
 products. Missing factors at the two ends are interpreted as one. -/
 private theorem torusCharacter_weight (K : Type u) [CommRing K]
@@ -46,22 +57,10 @@ private theorem torusCharacter_weight (K : Type u) [CommRing K]
   rw [torusCharacter_def]
   simp only [weight_def, zpow_sub, Finset.prod_mul_distrib]
   congr 1
-  · have hfactor : ∀ i : Fin r,
-        s i ^ (if k = i.castSucc then (1 : ℤ) else 0) =
-          if k = i.castSucc then s i else 1 := by
-      intro i
-      split_ifs <;> simp
-    rw [Finset.prod_congr rfl fun i _ ↦ hfactor i]
-    split_ifs with hk
+  · split_ifs with hk
     · let c : Fin r := ⟨k, hk⟩
       have hkc : k = c.castSucc := Fin.ext (by simp [c])
-      rw [Fintype.prod_eq_single c]
-      · simp only [hkc, ↓reduceIte]
-        exact congrArg s (Fin.ext rfl)
-      · intro j hj
-        split_ifs with h
-        · exact (hj (Fin.castSucc_inj.mp (hkc.symm.trans h)).symm).elim
-        · rfl
+      rw [prod_zpow_ite_eq r s Fin.castSucc (fun _ _ h ↦ Fin.castSucc_inj.mp h) k c hkc]
     · have : ∀ i : Fin r, k ≠ i.castSucc := by
         intro i hi
         apply hk
@@ -70,23 +69,13 @@ private theorem torusCharacter_weight (K : Type u) [CommRing K]
         rw [hv]
         exact i.isLt
       simp [this]
-  · have hfactor : ∀ i : Fin r,
-        (s i ^ (if k = i.succ then (1 : ℤ) else 0))⁻¹ =
-          if k = i.succ then (s i)⁻¹ else 1 := by
-      intro i
-      split_ifs <;> simp
-    rw [Finset.prod_congr rfl fun i _ ↦ hfactor i]
+  · simp_rw [← inv_zpow]
     split_ifs with hk
     · have hi : (k - 1 : ℕ) < r := by omega
       let c : Fin r := ⟨k - 1, hi⟩
       have hkc : k = c.succ := Fin.ext (by simp [c]; omega)
-      rw [Fintype.prod_eq_single c]
-      · simp only [hkc, ↓reduceIte]
-        exact congrArg (fun j ↦ (s j)⁻¹) (Fin.ext (by simp))
-      · intro j hj
-        split_ifs with h
-        · exact (hj (Fin.succ_inj.mp (hkc.symm.trans h)).symm).elim
-        · rfl
+      rw [prod_zpow_ite_eq r (fun i ↦ (s i)⁻¹) Fin.succ
+        (fun _ _ h ↦ Fin.succ_inj.mp h) k c hkc]
     · have : ∀ i : Fin r, k ≠ i.succ := by
         intro i hi
         apply hk
@@ -155,16 +144,15 @@ theorem mem_diagonalPoints_iff {K : Type u} [CommRing K] {g : points r K} :
 point centralizing the weight torus is diagonal. -/
 theorem centralizer_range_weightTorusPoints_of_weightChar_injective
     (K : Type u) [CommRing K] [IsCancelMulZero K]
-    (hchar : Function.Injective (weightChar K (κ := Fin r))) :
+    (hchar : Function.Injective (weightChar K ∘ weight r)) :
     Subgroup.centralizer
         ((weightTorusPoints r K).range : Set (points r K)) = diagonalPoints r K := by
   apply le_antisymm
   · intro g hg
     rw [mem_diagonalPoints_iff]
     intro i j hij
-    have hweight : weight r i ≠ weight r j := fun h ↦ hij (weight_injective r h)
     have hchar_ne : weightChar K (weight r i) ≠ weightChar K (weight r j) :=
-      fun h ↦ hweight (hchar h)
+      fun h ↦ hij (hchar h)
     have hexists : ∃ s, weightChar K (weight r i) s ≠ weightChar K (weight r j) s := by
       by_contra h
       push Not at h
@@ -204,22 +192,12 @@ theorem centralizer_range_weightTorusPoints_of_weightChar_injective
 theorem centralizer_range_weightTorusPoints (K : Type u) [Field K] [Infinite K] :
     Subgroup.centralizer
         ((weightTorusPoints r K).range : Set (points r K)) = diagonalPoints r K :=
-  centralizer_range_weightTorusPoints_of_weightChar_injective r K weightChar_injective
-
-/-- The standard weight-torus parametrization is injective over every commutative ring. -/
-theorem weightTorusPoints_injective (K : Type u) [CommRing K] :
-    Function.Injective (weightTorusPoints r K) := by
-  intro s t hst
-  apply eq_of_span_eq_top_of_torusCharacter_eq (span_range_weight_eq_top r)
-  intro i
-  have hmatrix := congrArg (fun g : points r K ↦ g.1) hst
-  rw [coe_weightTorusPoints, coe_weightTorusPoints,
-    UniversalEnvelopingAlgebra.kostantTorusMatrix_apply,
-    UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] at hmatrix
-  exact congrFun (diagGL_injective hmatrix) i
+  centralizer_range_weightTorusPoints_of_weightChar_injective r K
+    (weightChar_injective.comp (weight_injective r))
 
 /-- **Over a commutative ring, the standard weight torus consists of all diagonal carrier
 points.** Thus every diagonal carrier point admits a standard weight-torus parametrization. -/
+@[simp]
 theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [CommRing K] :
     (weightTorusPoints r K).range = diagonalPoints r K := by
   apply le_antisymm
@@ -251,7 +229,7 @@ theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [CommRing K] :
 torus is maximal among commutative subgroups of the type `A_r` carrier. -/
 theorem eq_range_weightTorusPoints_of_weightChar_injective_of_le_of_isMulCommutative
     (K : Type u) [CommRing K] [IsCancelMulZero K]
-    (hchar : Function.Injective (weightChar K (κ := Fin r)))
+    (hchar : Function.Injective (weightChar K ∘ weight r))
     (H : Subgroup (points r K)) [IsMulCommutative H]
     (hle : (weightTorusPoints r K).range ≤ H) :
     H = (weightTorusPoints r K).range :=
@@ -271,7 +249,7 @@ theorem eq_range_weightTorusPoints_of_le_of_isMulCommutative
     (hle : (weightTorusPoints r K).range ≤ H) :
     H = (weightTorusPoints r K).range :=
   eq_range_weightTorusPoints_of_weightChar_injective_of_le_of_isMulCommutative r K
-    weightChar_injective H hle
+    (weightChar_injective.comp (weight_injective r)) H hle
 
 end
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
@@ -12,21 +12,17 @@ public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.FieldPoints
 
 Over an infinite field, the standard carrier's weight-torus points are precisely the
 determinant-one diagonal matrices and form a maximal commutative subgroup of the carrier points.
-The proof first uses the distinct standard weights to compute the centralizer of the weight torus,
-then identifies its image by an explicit partial-product inverse to the weight parametrization.
+The centralizer calculation and maximality theorem identify the subgroup singled out by the
+standard weights as the distinguished torus used in the type `A` pinning.
 
 ## Main declarations
 
-* `TauCeti.SlStd.weight_injective`: the weights of the standard representation are distinct.
 * `TauCeti.SlStd.centralizer_range_weightTorusPoints`: the centralizer of the weight torus is the
   determinant-one diagonal subgroup.
 * `TauCeti.SlStd.range_weightTorusPoints_eq_diagonalPoints`: the weight torus consists of all
   determinant-one diagonal carrier points.
 * `TauCeti.SlStd.eq_range_weightTorusPoints_of_le_of_isMulCommutative`: the weight torus is maximal
   among commutative subgroups of the carrier points.
-
-This advances the "Pinnings" target in Layer 9 of the ReductiveGroups roadmap. Its consumer is
-milestone L0, "pinned ambient groups", of the CFSGStatement roadmap.
 -/
 
 public section
@@ -38,25 +34,6 @@ universe u
 noncomputable section
 
 variable (r : ℕ)
-
-/-! ## The standard weights -/
-
-/-- The weights of the standard representation of `sl_{r+1}` are pairwise distinct. -/
-theorem weight_injective : Function.Injective (weight r) := by
-  intro k l hkl
-  by_contra hne
-  have aux {a b : Fin (r + 1)} (hab : (a : ℕ) < b)
-      (hweight : weight r a = weight r b) : False := by
-    have ha : (a : ℕ) < r := by omega
-    let i : Fin r := ⟨a, ha⟩
-    have hvalue := congrFun hweight i
-    simp only [weight_def, Fin.ext_iff, Fin.val_castSucc, Fin.val_succ] at hvalue
-    dsimp only [i] at hvalue
-    split_ifs at hvalue <;> omega
-  have hval : (k : ℕ) ≠ l := fun h ↦ hne (Fin.ext h)
-  rcases lt_or_gt_of_ne hval with hlt | hgt
-  · exact aux hlt hkl
-  · exact aux hgt hkl.symm
 
 /-- The standard weight at coordinate `k` evaluates as the quotient of two adjacent partial
 products. Missing factors at the two ends are interpreted as one. -/
@@ -150,9 +127,10 @@ private theorem torusCharacter_partialProducts {K : Type u} [CommRing K]
         (∏ j ∈ Finset.range r,
             if hj : j < r + 1 then t ⟨j, hj⟩ else 1) *
               t ⟨r, Nat.lt_succ_self r⟩ = 1 := by
-      conv_lhs => rhs; rw [← show
+      have hlast :
         (if hj : r < r + 1 then t ⟨r, hj⟩ else 1) =
-          t ⟨r, Nat.lt_succ_self r⟩ by simp]
+          t ⟨r, Nat.lt_succ_self r⟩ := by simp
+      rw [← hlast]
       rw [← Finset.prod_range_succ]
       simpa only [Finset.prod_fin_eq_prod_range] using ht
     rw [one_mul, eq_inv_of_mul_eq_one_left htotal, inv_inv]
@@ -194,11 +172,10 @@ theorem centralizer_range_weightTorusPoints (K : Type u) [Field K] [Infinite K] 
     let d := weightTorusPoints r K s
     have hcomm : Commute d g :=
       Subgroup.mem_centralizer_iff.mp hg d ⟨s, rfl⟩
-    have hmatrix : Commute
-        d.1.1 g.1.1 :=
-      congrArg (fun x : points r K ↦
-        x.1.1) hcomm.eq
-    change Commute (weightTorusPoints r K s).1.1 g.1.1 at hmatrix
+    have hmatrix : Commute d.1.1 g.1.1 :=
+      congrArg (fun x : points r K ↦ x.1.1) hcomm.eq
+    have hd : d = weightTorusPoints r K s := rfl
+    rw [hd] at hmatrix
     rw [coe_weightTorusPoints,
       UniversalEnvelopingAlgebra.kostantTorusMatrix_apply, diagGL_coe] at hmatrix
     apply apply_eq_zero_of_commute_diagonal hmatrix
@@ -222,10 +199,9 @@ theorem centralizer_range_weightTorusPoints (K : Type u) [Field K] [Infinite K] 
     apply Subtype.ext
     exact hcomm.eq
 
-/-- **Over a field, the standard weight torus consists of all determinant-one diagonal carrier
-points.** The partial products of the diagonal entries give an explicit inverse to the weight
-parametrization. -/
-theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [Field K] :
+/-- **Over a commutative ring, the standard weight torus consists of all diagonal carrier
+points.** Thus every diagonal carrier point admits a standard weight-torus parametrization. -/
+theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [CommRing K] :
     (weightTorusPoints r K).range = diagonalPoints r K := by
   apply le_antisymm
   · rintro g ⟨s, rfl⟩
@@ -238,7 +214,7 @@ theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [Field K] :
     obtain ⟨t, ht⟩ := mem_diagonalTorus_iff_exists_diagGL.mp
       (mem_diagonalTorus_iff.mpr hg)
     have hprod : ∏ i, t i = 1 := by
-      have hdet := (mem_points_iff_det_eq_one r g.1).mp g.property
+      have hdet := det_eq_one_of_mem_points r g.property
       have hdet' := congrArg Matrix.GeneralLinearGroup.det ht
       rw [det_diagGL] at hdet'
       exact hdet'.trans hdet

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.FieldPoints
+public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.DeterminantOne
 
 /-!
 # Maximality of the type A weight torus on field-valued points
@@ -35,6 +35,18 @@ noncomputable section
 
 variable (r : ℕ)
 
+private theorem prod_ite_eq_of_eq {M : Type*} [CommMonoid M] (f : Fin r → M)
+    (e : Fin r → Fin (r + 1)) (he : Function.Injective e) (k : Fin (r + 1)) (c : Fin r)
+    (hkc : k = e c) :
+    (∏ i, if k = e i then f i else 1) = f c := by
+  rw [Finset.prod_eq_single c]
+  · simp only [hkc, ↓reduceIte]
+  · intro j _ hj
+    split_ifs with h
+    · exact (hj (he (hkc.symm.trans h)).symm).elim
+    · rfl
+  · exact fun h ↦ absurd (Finset.mem_univ c) h
+
 /-- The standard weight at coordinate `k` evaluates as the quotient of two adjacent partial
 products. Missing factors at the two ends are interpreted as one. -/
 private theorem torusCharacter_weight (K : Type u) [CommRing K]
@@ -55,14 +67,8 @@ private theorem torusCharacter_weight (K : Type u) [CommRing K]
     split_ifs with hk
     · let c : Fin r := ⟨k, hk⟩
       have hkc : k = c.castSucc := Fin.ext (by simp [c])
-      rw [Finset.prod_eq_single c]
-      · simp only [hkc, ↓reduceIte]
-        congr 1
-      · intro j _ hj
-        split_ifs with h
-        · exact (hj (Fin.castSucc_inj.mp (hkc.symm.trans h)).symm).elim
-        · rfl
-      · exact fun h ↦ absurd (Finset.mem_univ c) h
+      rw [prod_ite_eq_of_eq r s Fin.castSucc
+        (fun _ _ h ↦ Fin.castSucc_inj.mp h) k c hkc]
     · have : ∀ i : Fin r, k ≠ i.castSucc := by
         intro i hi
         apply hk
@@ -81,14 +87,8 @@ private theorem torusCharacter_weight (K : Type u) [CommRing K]
     · have hi : (k - 1 : ℕ) < r := by omega
       let c : Fin r := ⟨k - 1, hi⟩
       have hkc : k = c.succ := Fin.ext (by simp [c]; omega)
-      rw [Finset.prod_eq_single c]
-      · simp only [hkc, ↓reduceIte]
-        congr 1
-      · intro j _ hj
-        split_ifs with h
-        · exact (hj (Fin.succ_inj.mp (hkc.symm.trans h)).symm).elim
-        · rfl
-      · exact fun h ↦ absurd (Finset.mem_univ c) h
+      rw [prod_ite_eq_of_eq r (fun i ↦ (s i)⁻¹) Fin.succ
+        (fun _ _ h ↦ Fin.succ_inj.mp h) k c hkc]
     · have : ∀ i : Fin r, k ≠ i.succ := by
         intro i hi
         apply hk
@@ -97,43 +97,44 @@ private theorem torusCharacter_weight (K : Type u) [CommRing K]
         omega
       simp [this]
 
-/-- Partial products invert the standard weight parametrization on determinant-one diagonal
-families. -/
-private def partialProducts {K : Type u} [CommRing K]
-    (t : Fin (r + 1) → Kˣ) (i : Fin r) : Kˣ :=
-  ∏ j ∈ Finset.range (i + 1), if hj : j < r + 1 then t ⟨j, hj⟩ else 1
-
-private theorem torusCharacter_partialProducts {K : Type u} [CommRing K]
+private theorem torusCharacter_partialProd {K : Type u} [CommRing K]
     (t : Fin (r + 1) → Kˣ) (ht : ∏ i, t i = 1) (k : Fin (r + 1)) :
-    torusCharacter (partialProducts r t) (weight r k) = t k := by
+    torusCharacter (fun i : Fin r ↦ Fin.partialProd t i.succ.castSucc) (weight r k) = t k := by
   rw [torusCharacter_weight]
   split_ifs with hkr hk0
-  · rw [partialProducts, partialProducts]
-    have hpred : (k - 1 : ℕ) + 1 = k := by omega
-    rw [hpred, ← div_eq_mul_inv, Finset.prod_range_succ_div_prod]
-    rw [dite_eq_left (by omega)]
+  · let i : Fin r := ⟨k, hkr⟩
+    let j : Fin r := ⟨k - 1, by omega⟩
+    have hi : i.succ.castSucc = k.succ := Fin.ext (by simp [i])
+    have hj : j.succ.castSucc = k.castSucc := Fin.ext (by simp [j]; omega)
+    rw [hi, hj]
+    simpa only [mul_comm] using (Fin.partialProd_right_inv t k)
   · have hkzero : (k : ℕ) = 0 := by omega
     have hkfin : k = 0 := Fin.ext hkzero
     subst k
-    simp [partialProducts]
+    have hi : (⟨(0 : Fin (r + 1)), hkr⟩ : Fin r).succ.castSucc =
+        (0 : Fin (r + 1)).succ := Fin.ext rfl
+    rw [mul_one, hi, Fin.partialProd_succ,
+      show (0 : Fin (r + 1)).castSucc = (0 : Fin (r + 2)) by rfl,
+      Fin.partialProd_zero, one_mul]
   · have hkmax : (k : ℕ) = r := by omega
     have hrpos : 0 < r := by omega
     have hkfin : k = ⟨r, Nat.lt_succ_self r⟩ := Fin.ext hkmax
     subst k
-    rw [partialProducts]
-    have hpred : (r - 1 : ℕ) + 1 = r := by omega
-    rw [hpred]
-    have htotal :
-        (∏ j ∈ Finset.range r,
-            if hj : j < r + 1 then t ⟨j, hj⟩ else 1) *
-              t ⟨r, Nat.lt_succ_self r⟩ = 1 := by
-      have hlast :
-        (if hj : r < r + 1 then t ⟨r, hj⟩ else 1) =
-          t ⟨r, Nat.lt_succ_self r⟩ := by simp
-      rw [← hlast]
-      rw [← Finset.prod_range_succ]
-      simpa only [Finset.prod_fin_eq_prod_range] using ht
-    rw [one_mul, eq_inv_of_mul_eq_one_left htotal, inv_inv]
+    let i : Fin r := ⟨r - 1, by omega⟩
+    let k : Fin (r + 1) := ⟨r, Nat.lt_succ_self r⟩
+    have hi : i.succ.castSucc = k.castSucc := Fin.ext (by simp [i, k]; omega)
+    rw [hi]
+    have hlast : Fin.partialProd t k.succ = 1 := by
+      have hk_last : k.succ = Fin.last (r + 1) := Fin.ext (by simp [k])
+      rw [hk_last]
+      rw [Fin.partialProd, Fin.val_last]
+      have htake : (List.ofFn t).take (r + 1) = List.ofFn t :=
+        (List.take_eq_self_iff _).mpr (by simp)
+      rw [htake, Fin.prod_ofFn]
+      exact ht
+    have hright := Fin.partialProd_right_inv t k
+    rw [hlast, mul_one] at hright
+    simpa only [one_mul, k] using hright
   · have hrzero : r = 0 := by omega
     subst r
     have hkfin : k = 0 := Fin.eq_zero k
@@ -153,8 +154,11 @@ theorem mem_diagonalPoints_iff {K : Type u} [CommRing K] {g : points r K} :
   rw [diagonalPoints, Subgroup.mem_comap, mem_diagonalTorus_iff]
   rfl
 
-/-- Over an infinite field, a carrier point centralizing the weight torus is diagonal. -/
-theorem centralizer_range_weightTorusPoints (K : Type u) [Field K] [Infinite K] :
+/-- If distinct weights define distinct characters over a ring without zero divisors, a carrier
+point centralizing the weight torus is diagonal. -/
+theorem centralizer_range_weightTorusPoints_of_weightChar_injective
+    (K : Type u) [CommRing K] [IsCancelMulZero K]
+    (hchar : Function.Injective (weightChar K (κ := Fin r))) :
     Subgroup.centralizer
         ((weightTorusPoints r K).range : Set (points r K)) = diagonalPoints r K := by
   apply le_antisymm
@@ -162,12 +166,12 @@ theorem centralizer_range_weightTorusPoints (K : Type u) [Field K] [Infinite K] 
     rw [mem_diagonalPoints_iff]
     intro i j hij
     have hweight : weight r i ≠ weight r j := fun h ↦ hij (weight_injective r h)
-    have hchar : weightChar K (weight r i) ≠ weightChar K (weight r j) :=
-      fun h ↦ hweight (weightChar_injective h)
+    have hchar_ne : weightChar K (weight r i) ≠ weightChar K (weight r j) :=
+      fun h ↦ hweight (hchar h)
     have hexists : ∃ s, weightChar K (weight r i) s ≠ weightChar K (weight r j) s := by
       by_contra h
       push Not at h
-      exact hchar (MonoidHom.ext h)
+      exact hchar_ne (MonoidHom.ext h)
     obtain ⟨s, hs⟩ := hexists
     let d := weightTorusPoints r K s
     have hcomm : Commute d g :=
@@ -199,6 +203,24 @@ theorem centralizer_range_weightTorusPoints (K : Type u) [Field K] [Infinite K] 
     apply Subtype.ext
     exact hcomm.eq
 
+/-- Over an infinite field, a carrier point centralizing the weight torus is diagonal. -/
+theorem centralizer_range_weightTorusPoints (K : Type u) [Field K] [Infinite K] :
+    Subgroup.centralizer
+        ((weightTorusPoints r K).range : Set (points r K)) = diagonalPoints r K :=
+  centralizer_range_weightTorusPoints_of_weightChar_injective r K weightChar_injective
+
+/-- The standard weight-torus parametrization is injective over every commutative ring. -/
+theorem weightTorusPoints_injective (K : Type u) [CommRing K] :
+    Function.Injective (weightTorusPoints r K) := by
+  intro s t hst
+  apply eq_of_span_eq_top_of_torusCharacter_eq (span_range_weight_eq_top r)
+  intro i
+  have hmatrix := congrArg (fun g : points r K ↦ g.1) hst
+  rw [coe_weightTorusPoints, coe_weightTorusPoints,
+    UniversalEnvelopingAlgebra.kostantTorusMatrix_apply,
+    UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] at hmatrix
+  exact congrFun (diagGL_injective hmatrix) i
+
 /-- **Over a commutative ring, the standard weight torus consists of all diagonal carrier
 points.** Thus every diagonal carrier point admits a standard weight-torus parametrization. -/
 theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [CommRing K] :
@@ -218,13 +240,31 @@ theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [CommRing K] :
       have hdet' := congrArg Matrix.GeneralLinearGroup.det ht
       rw [det_diagGL] at hdet'
       exact hdet'.trans hdet
-    refine ⟨partialProducts r t, ?_⟩
+    refine ⟨(fun i : Fin r ↦ Fin.partialProd t i.succ.castSucc), ?_⟩
     apply Subtype.ext
     rw [coe_weightTorusPoints,
       UniversalEnvelopingAlgebra.kostantTorusMatrix_apply]
-    have hchars : (fun i ↦ torusCharacter (partialProducts r t) (weight r i)) = t :=
-      funext (torusCharacter_partialProducts r t hprod)
+    have hchars :
+        (fun i ↦ torusCharacter (fun j : Fin r ↦ Fin.partialProd t j.succ.castSucc)
+          (weight r i)) = t :=
+      funext (torusCharacter_partialProd r t hprod)
     rw [hchars, ht]
+
+/-- If its weight characters are distinct over a ring without zero divisors, the standard weight
+torus is maximal among commutative subgroups of the type `A_r` carrier. -/
+theorem eq_range_weightTorusPoints_of_le_of_isMulCommutative_of_weightChar_injective
+    (K : Type u) [CommRing K] [IsCancelMulZero K]
+    (hchar : Function.Injective (weightChar K (κ := Fin r)))
+    (H : Subgroup (points r K)) [IsMulCommutative H]
+    (hle : (weightTorusPoints r K).range ≤ H) :
+    H = (weightTorusPoints r K).range :=
+  le_antisymm
+    (by
+      rw [range_weightTorusPoints_eq_diagonalPoints r K,
+        ← centralizer_range_weightTorusPoints_of_weightChar_injective r K hchar]
+      exact (Subgroup.le_centralizer (H := H)).trans
+        (Subgroup.centralizer_le (SetLike.coe_subset_coe.mpr hle)))
+    hle
 
 /-- **The standard weight torus is maximal among commutative subgroups of the type `A_r`
 carrier over an infinite field.** -/
@@ -233,13 +273,8 @@ theorem eq_range_weightTorusPoints_of_le_of_isMulCommutative
     (H : Subgroup (points r K)) [IsMulCommutative H]
     (hle : (weightTorusPoints r K).range ≤ H) :
     H = (weightTorusPoints r K).range :=
-  le_antisymm
-    (by
-      rw [range_weightTorusPoints_eq_diagonalPoints r K,
-        ← centralizer_range_weightTorusPoints r K]
-      exact (Subgroup.le_centralizer (H := H)).trans
-        (Subgroup.centralizer_le (SetLike.coe_subset_coe.mpr hle)))
-    hle
+  eq_range_weightTorusPoints_of_le_of_isMulCommutative_of_weightChar_injective r K
+    weightChar_injective H hle
 
 end
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
@@ -1,0 +1,270 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.FieldPoints
+
+/-!
+# Maximality of the type A weight torus on field-valued points
+
+Over an infinite field, the standard carrier's weight-torus points are precisely the
+determinant-one diagonal matrices and form a maximal commutative subgroup of the carrier points.
+The proof first uses the distinct standard weights to compute the centralizer of the weight torus,
+then identifies its image by an explicit partial-product inverse to the weight parametrization.
+
+## Main declarations
+
+* `TauCeti.SlStd.weight_injective`: the weights of the standard representation are distinct.
+* `TauCeti.SlStd.centralizer_range_weightTorusPoints`: the centralizer of the weight torus is the
+  determinant-one diagonal subgroup.
+* `TauCeti.SlStd.range_weightTorusPoints_eq_diagonalPoints`: the weight torus consists of all
+  determinant-one diagonal carrier points.
+* `TauCeti.SlStd.eq_range_weightTorusPoints_of_le_of_isMulCommutative`: the weight torus is maximal
+  among commutative subgroups of the carrier points.
+
+This advances the "Pinnings" target in Layer 9 of the ReductiveGroups roadmap. Its consumer is
+milestone L0, "pinned ambient groups", of the CFSGStatement roadmap.
+-/
+
+public section
+
+namespace TauCeti.SlStd
+
+universe u
+
+noncomputable section
+
+variable (r : ℕ)
+
+/-! ## The standard weights -/
+
+/-- The weights of the standard representation of `sl_{r+1}` are pairwise distinct. -/
+theorem weight_injective : Function.Injective (weight r) := by
+  intro k l hkl
+  by_contra hne
+  have aux {a b : Fin (r + 1)} (hab : (a : ℕ) < b)
+      (hweight : weight r a = weight r b) : False := by
+    have ha : (a : ℕ) < r := by omega
+    let i : Fin r := ⟨a, ha⟩
+    have hvalue := congrFun hweight i
+    simp only [weight_def, Fin.ext_iff, Fin.val_castSucc, Fin.val_succ] at hvalue
+    dsimp only [i] at hvalue
+    split_ifs at hvalue <;> omega
+  have hval : (k : ℕ) ≠ l := fun h ↦ hne (Fin.ext h)
+  rcases lt_or_gt_of_ne hval with hlt | hgt
+  · exact aux hlt hkl
+  · exact aux hgt hkl.symm
+
+/-- The standard weight at coordinate `k` evaluates as the quotient of two adjacent partial
+products. Missing factors at the two ends are interpreted as one. -/
+private theorem torusCharacter_weight (K : Type u) [CommRing K]
+    (s : Fin r → Kˣ) (k : Fin (r + 1)) :
+    torusCharacter s (weight r k) =
+      (if hk : (k : ℕ) < r then s ⟨k, hk⟩ else 1) *
+        (if hk : 0 < (k : ℕ) then (s ⟨k - 1, by omega⟩)⁻¹ else 1) := by
+  classical
+  rw [torusCharacter_def]
+  simp only [weight_def, zpow_sub, Finset.prod_mul_distrib]
+  congr 1
+  · have hfactor : ∀ i : Fin r,
+        s i ^ (if k = i.castSucc then (1 : ℤ) else 0) =
+          if k = i.castSucc then s i else 1 := by
+      intro i
+      split_ifs <;> simp
+    rw [Finset.prod_congr rfl fun i _ ↦ hfactor i]
+    split_ifs with hk
+    · let c : Fin r := ⟨k, hk⟩
+      have hkc : k = c.castSucc := Fin.ext (by simp [c])
+      rw [Finset.prod_eq_single c]
+      · simp only [hkc, ↓reduceIte]
+        congr 1
+      · intro j _ hj
+        split_ifs with h
+        · exact (hj (Fin.castSucc_inj.mp (hkc.symm.trans h)).symm).elim
+        · rfl
+      · exact fun h ↦ absurd (Finset.mem_univ c) h
+    · have : ∀ i : Fin r, k ≠ i.castSucc := by
+        intro i hi
+        apply hk
+        have hv := congrArg Fin.val hi
+        rw [Fin.val_castSucc] at hv
+        rw [hv]
+        exact i.isLt
+      simp [this]
+  · have hfactor : ∀ i : Fin r,
+        (s i ^ (if k = i.succ then (1 : ℤ) else 0))⁻¹ =
+          if k = i.succ then (s i)⁻¹ else 1 := by
+      intro i
+      split_ifs <;> simp
+    rw [Finset.prod_congr rfl fun i _ ↦ hfactor i]
+    split_ifs with hk
+    · have hi : (k - 1 : ℕ) < r := by omega
+      let c : Fin r := ⟨k - 1, hi⟩
+      have hkc : k = c.succ := Fin.ext (by simp [c]; omega)
+      rw [Finset.prod_eq_single c]
+      · simp only [hkc, ↓reduceIte]
+        congr 1
+      · intro j _ hj
+        split_ifs with h
+        · exact (hj (Fin.succ_inj.mp (hkc.symm.trans h)).symm).elim
+        · rfl
+      · exact fun h ↦ absurd (Finset.mem_univ c) h
+    · have : ∀ i : Fin r, k ≠ i.succ := by
+        intro i hi
+        apply hk
+        have := congrArg Fin.val hi
+        simp only [Fin.val_succ] at this
+        omega
+      simp [this]
+
+/-- Partial products invert the standard weight parametrization on determinant-one diagonal
+families. -/
+private def partialProducts {K : Type u} [CommRing K]
+    (t : Fin (r + 1) → Kˣ) (i : Fin r) : Kˣ :=
+  ∏ j ∈ Finset.range (i + 1), if hj : j < r + 1 then t ⟨j, hj⟩ else 1
+
+private theorem torusCharacter_partialProducts {K : Type u} [CommRing K]
+    (t : Fin (r + 1) → Kˣ) (ht : ∏ i, t i = 1) (k : Fin (r + 1)) :
+    torusCharacter (partialProducts r t) (weight r k) = t k := by
+  rw [torusCharacter_weight]
+  split_ifs with hkr hk0
+  · rw [partialProducts, partialProducts]
+    have hpred : (k - 1 : ℕ) + 1 = k := by omega
+    rw [hpred, ← div_eq_mul_inv, Finset.prod_range_succ_div_prod]
+    rw [dite_eq_left (by omega)]
+  · have hkzero : (k : ℕ) = 0 := by omega
+    have hkfin : k = 0 := Fin.ext hkzero
+    subst k
+    simp [partialProducts]
+  · have hkmax : (k : ℕ) = r := by omega
+    have hrpos : 0 < r := by omega
+    have hkfin : k = ⟨r, Nat.lt_succ_self r⟩ := Fin.ext hkmax
+    subst k
+    rw [partialProducts]
+    have hpred : (r - 1 : ℕ) + 1 = r := by omega
+    rw [hpred]
+    have htotal :
+        (∏ j ∈ Finset.range r,
+            if hj : j < r + 1 then t ⟨j, hj⟩ else 1) *
+              t ⟨r, Nat.lt_succ_self r⟩ = 1 := by
+      conv_lhs => rhs; rw [← show
+        (if hj : r < r + 1 then t ⟨r, hj⟩ else 1) =
+          t ⟨r, Nat.lt_succ_self r⟩ by simp]
+      rw [← Finset.prod_range_succ]
+      simpa only [Finset.prod_fin_eq_prod_range] using ht
+    rw [one_mul, eq_inv_of_mul_eq_one_left htotal, inv_inv]
+  · have hrzero : r = 0 := by omega
+    subst r
+    have hkfin : k = 0 := Fin.eq_zero k
+    subst k
+    simpa only [Fin.prod_univ_succ, Fin.prod_univ_zero, mul_one] using ht.symm
+
+/-! ## The centralizer on field-valued points -/
+
+/-- The diagonal points of the standard carrier. -/
+def diagonalPoints (K : Type u) [CommRing K] : Subgroup (points r K) :=
+  (diagonalTorus K (r + 1)).comap (points r K).subtype
+
+/-- A carrier point lies in `diagonalPoints` exactly when its ambient matrix is diagonal. -/
+@[simp]
+theorem mem_diagonalPoints_iff {K : Type u} [CommRing K] {g : points r K} :
+    g ∈ diagonalPoints r K ↔ g.1.1.IsDiag := by
+  rw [diagonalPoints, Subgroup.mem_comap, mem_diagonalTorus_iff]
+  rfl
+
+/-- Over an infinite field, a carrier point centralizing the weight torus is diagonal. -/
+theorem centralizer_range_weightTorusPoints (K : Type u) [Field K] [Infinite K] :
+    Subgroup.centralizer
+        ((weightTorusPoints r K).range : Set (points r K)) = diagonalPoints r K := by
+  apply le_antisymm
+  · intro g hg
+    rw [mem_diagonalPoints_iff]
+    intro i j hij
+    have hweight : weight r i ≠ weight r j := fun h ↦ hij (weight_injective r h)
+    have hchar : weightChar K (weight r i) ≠ weightChar K (weight r j) :=
+      fun h ↦ hweight (weightChar_injective h)
+    have hexists : ∃ s, weightChar K (weight r i) s ≠ weightChar K (weight r j) s := by
+      by_contra h
+      push Not at h
+      exact hchar (MonoidHom.ext h)
+    obtain ⟨s, hs⟩ := hexists
+    let d := weightTorusPoints r K s
+    have hcomm : Commute d g :=
+      Subgroup.mem_centralizer_iff.mp hg d ⟨s, rfl⟩
+    have hmatrix : Commute
+        d.1.1 g.1.1 :=
+      congrArg (fun x : points r K ↦
+        x.1.1) hcomm.eq
+    change Commute (weightTorusPoints r K s).1.1 g.1.1 at hmatrix
+    rw [coe_weightTorusPoints,
+      UniversalEnvelopingAlgebra.kostantTorusMatrix_apply, diagGL_coe] at hmatrix
+    apply apply_eq_zero_of_commute_diagonal hmatrix
+    rw [weightChar_apply, weightChar_apply] at hs
+    exact fun h ↦ hs (Units.ext h)
+  · intro g hg
+    rw [Subgroup.mem_centralizer_iff]
+    intro d hd
+    obtain ⟨s, rfl⟩ := hd
+    have hdDiag :
+        (weightTorusPoints r K s : Matrix.GeneralLinearGroup (Fin (r + 1)) K) ∈
+          diagonalTorus K (r + 1) := by
+      rw [mem_diagonalTorus_iff]
+      simp only [coe_weightTorusPoints,
+        UniversalEnvelopingAlgebra.kostantTorusMatrix_apply, diagGL_coe]
+      exact Matrix.isDiag_diagonal _
+    have hcomm : Commute
+        (weightTorusPoints r K s : Matrix.GeneralLinearGroup (Fin (r + 1)) K) g :=
+      Subgroup.mem_centralizer_iff.mp
+        (Subgroup.le_centralizer (diagonalTorus K (r + 1)) hdDiag) g hg |>.symm
+    apply Subtype.ext
+    exact hcomm.eq
+
+/-- **Over a field, the standard weight torus consists of all determinant-one diagonal carrier
+points.** The partial products of the diagonal entries give an explicit inverse to the weight
+parametrization. -/
+theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [Field K] :
+    (weightTorusPoints r K).range = diagonalPoints r K := by
+  apply le_antisymm
+  · rintro g ⟨s, rfl⟩
+    rw [mem_diagonalPoints_iff]
+    simp only [coe_weightTorusPoints,
+      UniversalEnvelopingAlgebra.kostantTorusMatrix_apply, diagGL_coe]
+    exact Matrix.isDiag_diagonal _
+  · intro g hg
+    rw [mem_diagonalPoints_iff] at hg
+    obtain ⟨t, ht⟩ := mem_diagonalTorus_iff_exists_diagGL.mp
+      (mem_diagonalTorus_iff.mpr hg)
+    have hprod : ∏ i, t i = 1 := by
+      have hdet := (mem_points_iff_det_eq_one r g.1).mp g.property
+      have hdet' := congrArg Matrix.GeneralLinearGroup.det ht
+      rw [det_diagGL] at hdet'
+      exact hdet'.trans hdet
+    refine ⟨partialProducts r t, ?_⟩
+    apply Subtype.ext
+    rw [coe_weightTorusPoints,
+      UniversalEnvelopingAlgebra.kostantTorusMatrix_apply]
+    have hchars : (fun i ↦ torusCharacter (partialProducts r t) (weight r i)) = t :=
+      funext (torusCharacter_partialProducts r t hprod)
+    rw [hchars, ht]
+
+/-- **The standard weight torus is maximal among commutative subgroups of the type `A_r`
+carrier over an infinite field.** -/
+theorem eq_range_weightTorusPoints_of_le_of_isMulCommutative
+    (K : Type u) [Field K] [Infinite K]
+    (H : Subgroup (points r K)) [IsMulCommutative H]
+    (hle : (weightTorusPoints r K).range ≤ H) :
+    H = (weightTorusPoints r K).range :=
+  le_antisymm
+    (by
+      rw [range_weightTorusPoints_eq_diagonalPoints r K,
+        ← centralizer_range_weightTorusPoints r K]
+      exact (Subgroup.le_centralizer (H := H)).trans
+        (Subgroup.centralizer_le (SetLike.coe_subset_coe.mpr hle)))
+    hle
+
+end
+
+end TauCeti.SlStd

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
@@ -8,21 +8,26 @@ module
 public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.DeterminantOne
 
 /-!
-# Maximality of the type A weight torus on field-valued points
+# The type A weight torus and its maximality on field-valued points
 
-Over an infinite field, the standard carrier's weight-torus points are precisely the
-determinant-one diagonal matrices and form a maximal commutative subgroup of the carrier points.
-The centralizer calculation and maximality theorem identify the subgroup singled out by the
-standard weights as the distinguished torus used in the type `A` pinning.
+Over any commutative ring, the standard carrier's weight-torus points are precisely the
+determinant-one diagonal matrices. Over an infinite field, their centralizer is exactly that
+diagonal subgroup, so they form a maximal commutative subgroup of the carrier points. The
+centralizer calculation follows the ambient `TauCeti.centralizer_diagonalTorus` computation.
 
 ## Main declarations
 
-* `TauCeti.SlStd.centralizer_range_weightTorusPoints`: the centralizer of the weight torus is the
-  determinant-one diagonal subgroup.
+* `TauCeti.SlStd.centralizer_range_weightTorusPoints_eq_diagonalPoints`: over an infinite field,
+  the centralizer of the weight torus is the determinant-one diagonal subgroup.
 * `TauCeti.SlStd.range_weightTorusPoints_eq_diagonalPoints`: the weight torus consists of all
   determinant-one diagonal carrier points.
 * `TauCeti.SlStd.eq_range_weightTorusPoints_of_le_of_isMulCommutative`: the weight torus is maximal
-  among commutative subgroups of the carrier points.
+  among commutative subgroups of the carrier points over an infinite field.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §7.1.
+* J. E. Humphreys, *Linear Algebraic Groups*, §§15.3 and 16.1.
 -/
 
 public section
@@ -35,99 +40,80 @@ noncomputable section
 
 variable (r : ℕ)
 
-/-- A product supported at one index selected by an injective coordinate map is that factor. -/
-private theorem prod_zpow_ite_eq {K : Type u} [CommRing K] (s : Fin r → Kˣ)
-    (e : Fin r → Fin (r + 1)) (he : Function.Injective e) (k : Fin (r + 1)) (c : Fin r)
-    (hkc : k = e c) :
-    (∏ i, s i ^ (if k = e i then (1 : ℤ) else 0)) = s c := by
-  rw [Fintype.prod_eq_single c]
-  · simp only [hkc, ↓reduceIte, zpow_one]
-  · intro j hj
-    have hne : k ≠ e j := fun h ↦ hj (he (h.symm.trans hkc))
-    simp [hne]
-
-/-- The standard weight at coordinate `k` evaluates as the quotient of two adjacent partial
-products. Missing factors at the two ends are interpreted as one. -/
-private theorem torusCharacter_weight (K : Type u) [CommRing K]
+/-- The character of the standard weight at coordinate `k` is the quotient of the adjacent torus
+parameters. Missing factors at the two ends are interpreted as one. -/
+theorem torusCharacter_weight (K : Type u) [CommRing K]
     (s : Fin r → Kˣ) (k : Fin (r + 1)) :
     torusCharacter s (weight r k) =
       (if hk : (k : ℕ) < r then s ⟨k, hk⟩ else 1) *
         (if hk : 0 < (k : ℕ) then (s ⟨k - 1, by omega⟩)⁻¹ else 1) := by
-  classical
-  rw [torusCharacter_def]
-  simp only [weight_def, zpow_sub, Finset.prod_mul_distrib]
-  congr 1
-  · split_ifs with hk
-    · let c : Fin r := ⟨k, hk⟩
-      have hkc : k = c.castSucc := Fin.ext (by simp [c])
-      rw [prod_zpow_ite_eq r s Fin.castSucc (fun _ _ h ↦ Fin.castSucc_inj.mp h) k c hkc]
-    · have : ∀ i : Fin r, k ≠ i.castSucc := by
-        intro i hi
-        apply hk
-        have hv := congrArg Fin.val hi
-        rw [Fin.val_castSucc] at hv
-        rw [hv]
-        exact i.isLt
-      simp [this]
-  · simp_rw [← inv_zpow]
-    split_ifs with hk
-    · have hi : (k - 1 : ℕ) < r := by omega
-      let c : Fin r := ⟨k - 1, hi⟩
-      have hkc : k = c.succ := Fin.ext (by simp [c]; omega)
-      rw [prod_zpow_ite_eq r (fun i ↦ (s i)⁻¹) Fin.succ
-        (fun _ _ h ↦ Fin.succ_inj.mp h) k c hkc]
-    · have : ∀ i : Fin r, k ≠ i.succ := by
-        intro i hi
-        apply hk
-        have := congrArg Fin.val hi
-        simp only [Fin.val_succ] at this
-        omega
-      simp [this]
+  rw [weight_eq_ite_single_sub_ite_single, torusCharacter_sub]
+  split_ifs <;>
+    simp only [← weightChar_apply, weightChar_single, weightChar_zero, MonoidHom.one_apply,
+      div_eq_mul_inv, inv_one]
 
-private theorem torusCharacter_partialProd {K : Type u} [CommRing K]
+/-- The final partial product is the product of all the entries. -/
+private theorem partialProd_last {M : Type*} [CommMonoid M] {n : ℕ} (f : Fin n → M) :
+    Fin.partialProd f (Fin.last n) = ∏ i, f i := by
+  rw [Fin.partialProd, Fin.val_last]
+  rw [(List.take_eq_self_iff _).mpr (by simp), Fin.prod_ofFn]
+
+/-- On a determinant-one diagonal tuple, the partial products evaluate under the standard weight
+characters to the original tuple. -/
+theorem torusCharacter_partialProd {K : Type u} [CommRing K]
     (t : Fin (r + 1) → Kˣ) (ht : ∏ i, t i = 1) (k : Fin (r + 1)) :
     torusCharacter (fun i : Fin r ↦ Fin.partialProd t i.succ.castSucc) (weight r k) = t k := by
   rw [torusCharacter_weight]
   split_ifs with hkr hk0
-  · let i : Fin r := ⟨k, hkr⟩
+  · -- The interior coordinates are successive quotients of partial products.
+    let i : Fin r := ⟨k, hkr⟩
     let j : Fin r := ⟨k - 1, by omega⟩
-    have hi : i.succ.castSucc = k.succ := Fin.ext (by simp [i])
-    have hj : j.succ.castSucc = k.castSucc := Fin.ext (by simp [j]; omega)
+    have hi : i.succ.castSucc = k.succ := by
+      apply Fin.ext
+      simp only [i, Fin.val_castSucc, Fin.val_succ]
+    have hj : j.succ.castSucc = k.castSucc := by
+      apply Fin.ext
+      simp only [j, Fin.val_castSucc, Fin.val_succ]
+      omega
     rw [hi, hj]
     simpa only [mul_comm] using (Fin.partialProd_right_inv t k)
-  · have hkzero : (k : ℕ) = 0 := by omega
+  · -- At coordinate zero, the missing lower partial product is one.
+    have hkzero : (k : ℕ) = 0 := by omega
     have hkfin : k = 0 := Fin.ext hkzero
     subst k
     have hi : (⟨(0 : Fin (r + 1)), hkr⟩ : Fin r).succ.castSucc =
         (0 : Fin (r + 1)).succ := Fin.ext rfl
     rw [mul_one, hi, Fin.partialProd_succ, Fin.castSucc_zero,
       Fin.partialProd_zero, one_mul]
-  · have hkmax : (k : ℕ) = r := by omega
+  · -- At the final coordinate, the determinant-one hypothesis closes the partial product.
+    have hkmax : (k : ℕ) = r := by omega
     have hrpos : 0 < r := by omega
     have hkfin : k = ⟨r, Nat.lt_succ_self r⟩ := Fin.ext hkmax
     subst k
     let i : Fin r := ⟨r - 1, by omega⟩
     let k : Fin (r + 1) := ⟨r, Nat.lt_succ_self r⟩
-    have hi : i.succ.castSucc = k.castSucc := Fin.ext (by simp [i, k]; omega)
+    have hi : i.succ.castSucc = k.castSucc := by
+      apply Fin.ext
+      simp only [i, k, Fin.val_castSucc, Fin.val_succ]
+      omega
     rw [hi]
     have hlast : Fin.partialProd t k.succ = 1 := by
-      have hk_last : k.succ = Fin.last (r + 1) := Fin.ext (by simp [k])
+      have hk_last : k.succ = Fin.last (r + 1) := by
+        apply Fin.ext
+        simp only [k, Fin.val_succ, Fin.val_last]
       rw [hk_last]
-      rw [Fin.partialProd, Fin.val_last]
-      have htake : (List.ofFn t).take (r + 1) = List.ofFn t :=
-        (List.take_eq_self_iff _).mpr (by simp)
-      rw [htake, Fin.prod_ofFn]
-      exact ht
+      exact (partialProd_last t).trans ht
     have hright := Fin.partialProd_right_inv t k
     rw [hlast, mul_one] at hright
     simpa only [one_mul, k] using hright
-  · have hrzero : r = 0 := by omega
+  · -- In rank zero, the determinant-one hypothesis is the only coordinate equation.
+    have hrzero : r = 0 := by omega
     subst r
     have hkfin : k = 0 := Fin.eq_zero k
     subst k
     simpa only [Fin.prod_univ_succ, Fin.prod_univ_zero, mul_one] using ht.symm
 
-/-! ## The centralizer on field-valued points -/
+/-! ## Diagonal points and the weight-torus range -/
 
 /-- The diagonal points of the standard carrier. -/
 def diagonalPoints (K : Type u) [CommRing K] : Subgroup (points r K) :=
@@ -140,9 +126,30 @@ theorem mem_diagonalPoints_iff {K : Type u} [CommRing K] {g : points r K} :
   rw [diagonalPoints, Subgroup.mem_comap, mem_diagonalTorus_iff]
   rfl
 
-/-- If distinct weights define distinct characters over a ring without zero divisors, a carrier
-point centralizing the weight torus is diagonal. -/
-theorem centralizer_range_weightTorusPoints_of_weightChar_injective
+/-- Every standard weight-torus point is diagonal in the ambient general linear group. -/
+theorem coe_weightTorusPoints_mem_diagonalTorus (K : Type u) [CommRing K] (s : Fin r → Kˣ) :
+    (weightTorusPoints r K s : Matrix.GeneralLinearGroup (Fin (r + 1)) K) ∈
+      diagonalTorus K (r + 1) := by
+  rw [mem_diagonalTorus_iff]
+  simp only [coe_weightTorusPoints,
+    UniversalEnvelopingAlgebra.kostantTorusMatrix_apply, diagGL_coe]
+  exact Matrix.isDiag_diagonal _
+
+/-- The partial products of a determinant-one diagonal tuple give an explicit preimage under the
+standard weight-torus parametrization. -/
+theorem coe_weightTorusPoints_partialProd {K : Type u} [CommRing K]
+    (t : Fin (r + 1) → Kˣ) (ht : ∏ i, t i = 1) :
+    (weightTorusPoints r K (fun i : Fin r ↦ Fin.partialProd t i.succ.castSucc) :
+        Matrix.GeneralLinearGroup (Fin (r + 1)) K) = diagGL t := by
+  rw [coe_weightTorusPoints, UniversalEnvelopingAlgebra.kostantTorusMatrix_apply]
+  congr 1
+  exact funext (torusCharacter_partialProd r t ht)
+
+/-! ## The centralizer and maximality -/
+
+/-- If the standard weight characters are distinct over a ring without zero divisors, the
+centralizer of the weight torus in the carrier points is exactly the diagonal subgroup. -/
+theorem centralizer_range_weightTorusPoints_eq_diagonalPoints_of_weightChar_weight_injective
     (K : Type u) [CommRing K] [IsCancelMulZero K]
     (hchar : Function.Injective (weightChar K ∘ weight r)) :
     Subgroup.centralizer
@@ -153,16 +160,12 @@ theorem centralizer_range_weightTorusPoints_of_weightChar_injective
     intro i j hij
     have hchar_ne : weightChar K (weight r i) ≠ weightChar K (weight r j) :=
       fun h ↦ hij (hchar h)
-    have hexists : ∃ s, weightChar K (weight r i) s ≠ weightChar K (weight r j) s := by
-      by_contra h
-      push Not at h
-      exact hchar_ne (MonoidHom.ext h)
-    obtain ⟨s, hs⟩ := hexists
+    obtain ⟨s, hs⟩ := DFunLike.ne_iff.mp hchar_ne
     let d := weightTorusPoints r K s
     have hcomm : Commute d g :=
       Subgroup.mem_centralizer_iff.mp hg d ⟨s, rfl⟩
     have hmatrix : Commute d.1.1 g.1.1 :=
-      congrArg (fun x : points r K ↦ x.1.1) hcomm.eq
+      (hcomm.map (points r K).subtype).map (Units.coeHom _)
     have hd : d = weightTorusPoints r K s := rfl
     rw [hd] at hmatrix
     rw [coe_weightTorusPoints,
@@ -174,25 +177,20 @@ theorem centralizer_range_weightTorusPoints_of_weightChar_injective
     rw [Subgroup.mem_centralizer_iff]
     intro d hd
     obtain ⟨s, rfl⟩ := hd
-    have hdDiag :
-        (weightTorusPoints r K s : Matrix.GeneralLinearGroup (Fin (r + 1)) K) ∈
-          diagonalTorus K (r + 1) := by
-      rw [mem_diagonalTorus_iff]
-      simp only [coe_weightTorusPoints,
-        UniversalEnvelopingAlgebra.kostantTorusMatrix_apply, diagGL_coe]
-      exact Matrix.isDiag_diagonal _
+    have hdDiag := coe_weightTorusPoints_mem_diagonalTorus r K s
     have hcomm : Commute
         (weightTorusPoints r K s : Matrix.GeneralLinearGroup (Fin (r + 1)) K) g :=
       Subgroup.mem_centralizer_iff.mp
         (Subgroup.le_centralizer (diagonalTorus K (r + 1)) hdDiag) g hg |>.symm
-    apply Subtype.ext
-    exact hcomm.eq
+    exact (Commute.of_map (points r K).subtype_injective hcomm).eq
 
-/-- Over an infinite field, a carrier point centralizing the weight torus is diagonal. -/
-theorem centralizer_range_weightTorusPoints (K : Type u) [Field K] [Infinite K] :
+/-- Over an infinite field, the centralizer of the weight torus in the carrier points is exactly
+the diagonal subgroup. -/
+theorem centralizer_range_weightTorusPoints_eq_diagonalPoints
+    (K : Type u) [Field K] [Infinite K] :
     Subgroup.centralizer
         ((weightTorusPoints r K).range : Set (points r K)) = diagonalPoints r K :=
-  centralizer_range_weightTorusPoints_of_weightChar_injective r K
+  centralizer_range_weightTorusPoints_eq_diagonalPoints_of_weightChar_weight_injective r K
     (weightChar_injective.comp (weight_injective r))
 
 /-- **Over a commutative ring, the standard weight torus consists of all diagonal carrier
@@ -203,9 +201,7 @@ theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [CommRing K] :
   apply le_antisymm
   · rintro g ⟨s, rfl⟩
     rw [mem_diagonalPoints_iff]
-    simp only [coe_weightTorusPoints,
-      UniversalEnvelopingAlgebra.kostantTorusMatrix_apply, diagGL_coe]
-    exact Matrix.isDiag_diagonal _
+    exact mem_diagonalTorus_iff.mp (coe_weightTorusPoints_mem_diagonalTorus r K s)
   · intro g hg
     rw [mem_diagonalPoints_iff] at hg
     obtain ⟨t, ht⟩ := mem_diagonalTorus_iff_exists_diagGL.mp
@@ -217,29 +213,19 @@ theorem range_weightTorusPoints_eq_diagonalPoints (K : Type u) [CommRing K] :
       exact hdet'.trans hdet
     refine ⟨(fun i : Fin r ↦ Fin.partialProd t i.succ.castSucc), ?_⟩
     apply Subtype.ext
-    rw [coe_weightTorusPoints,
-      UniversalEnvelopingAlgebra.kostantTorusMatrix_apply]
-    have hchars :
-        (fun i ↦ torusCharacter (fun j : Fin r ↦ Fin.partialProd t j.succ.castSucc)
-          (weight r i)) = t :=
-      funext (torusCharacter_partialProd r t hprod)
-    rw [hchars, ht]
+    rw [coe_weightTorusPoints_partialProd r t hprod, ht]
 
 /-- If its weight characters are distinct over a ring without zero divisors, the standard weight
 torus is maximal among commutative subgroups of the type `A_r` carrier. -/
-theorem eq_range_weightTorusPoints_of_weightChar_injective_of_le_of_isMulCommutative
+theorem eq_range_weightTorusPoints_of_weightChar_weight_injective_of_le_of_isMulCommutative
     (K : Type u) [CommRing K] [IsCancelMulZero K]
     (hchar : Function.Injective (weightChar K ∘ weight r))
     (H : Subgroup (points r K)) [IsMulCommutative H]
     (hle : (weightTorusPoints r K).range ≤ H) :
     H = (weightTorusPoints r K).range :=
-  le_antisymm
-    (by
-      rw [range_weightTorusPoints_eq_diagonalPoints r K,
-        ← centralizer_range_weightTorusPoints_of_weightChar_injective r K hchar]
-      exact (Subgroup.le_centralizer (H := H)).trans
-        (Subgroup.centralizer_le (SetLike.coe_subset_coe.mpr hle)))
-    hle
+  eq_of_centralizer_eq_self_of_le_of_isMulCommutative
+    ((centralizer_range_weightTorusPoints_eq_diagonalPoints_of_weightChar_weight_injective
+      r K hchar).trans (range_weightTorusPoints_eq_diagonalPoints r K).symm) hle
 
 /-- **The standard weight torus is maximal among commutative subgroups of the type `A_r`
 carrier over an infinite field.** -/
@@ -248,7 +234,7 @@ theorem eq_range_weightTorusPoints_of_le_of_isMulCommutative
     (H : Subgroup (points r K)) [IsMulCommutative H]
     (hle : (weightTorusPoints r K).range ≤ H) :
     H = (weightTorusPoints r K).range :=
-  eq_range_weightTorusPoints_of_weightChar_injective_of_le_of_isMulCommutative r K
+  eq_range_weightTorusPoints_of_weightChar_weight_injective_of_le_of_isMulCommutative r K
     (weightChar_injective.comp (weight_injective r)) H hle
 
 end

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
@@ -14,8 +14,7 @@ import TauCeti.Data.Fin.Basic
 
 Over any commutative ring, the standard carrier's weight-torus points are precisely the
 determinant-one diagonal matrices. Over an infinite field, their centralizer is exactly that
-diagonal subgroup, so they form a maximal commutative subgroup of the carrier points. The
-centralizer calculation follows the ambient `TauCeti.centralizer_diagonalTorus` computation.
+diagonal subgroup, so they form a maximal commutative subgroup of the carrier points.
 
 ## Main declarations
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
@@ -7,6 +7,8 @@ module
 
 public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.DeterminantOne
 
+import TauCeti.Data.Fin.Basic
+
 /-!
 # The type A weight torus and its maximality on field-valued points
 
@@ -51,12 +53,6 @@ theorem torusCharacter_weight (K : Type u) [CommRing K]
   split_ifs <;>
     simp only [← weightChar_apply, weightChar_single, weightChar_zero, MonoidHom.one_apply,
       div_eq_mul_inv, inv_one]
-
-/-- The final partial product is the product of all the entries. -/
-private theorem partialProd_last {M : Type*} [CommMonoid M] {n : ℕ} (f : Fin n → M) :
-    Fin.partialProd f (Fin.last n) = ∏ i, f i := by
-  rw [Fin.partialProd, Fin.val_last]
-  rw [(List.take_eq_self_iff _).mpr (by simp), Fin.prod_ofFn]
 
 /-- On a determinant-one diagonal tuple, the partial products evaluate under the standard weight
 characters to the original tuple. -/

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
@@ -126,10 +126,8 @@ theorem mem_diagonalPoints_iff {K : Type u} [CommRing K] {g : points r K} :
 theorem coe_weightTorusPoints_mem_diagonalTorus (K : Type u) [CommRing K] (s : Fin r → Kˣ) :
     (weightTorusPoints r K s : Matrix.GeneralLinearGroup (Fin (r + 1)) K) ∈
       diagonalTorus K (r + 1) := by
-  rw [mem_diagonalTorus_iff]
-  simp only [coe_weightTorusPoints,
-    UniversalEnvelopingAlgebra.kostantTorusMatrix_apply, diagGL_coe]
-  exact Matrix.isDiag_diagonal _
+  rw [coe_weightTorusPoints, UniversalEnvelopingAlgebra.kostantTorusMatrix_apply]
+  exact mem_diagonalTorus_iff_exists_diagGL.mpr ⟨_, rfl⟩
 
 /-- The partial products of a determinant-one diagonal tuple give an explicit preimage under the
 standard weight-torus parametrization. -/

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/MaximalTorus.lean
@@ -98,7 +98,7 @@ theorem torusCharacter_partialProd {K : Type u} [CommRing K]
         apply Fin.ext
         simp only [k, Fin.val_succ, Fin.val_last]
       rw [hk_last]
-      exact (partialProd_last t).trans ht
+      exact (Fin.partialProd_last t).trans ht
     have hright := Fin.partialProd_right_inv t k
     rw [hlast, mul_one] at hright
     simpa only [one_mul, k] using hright
@@ -219,7 +219,7 @@ theorem eq_range_weightTorusPoints_of_weightChar_weight_injective_of_le_of_isMul
     (H : Subgroup (points r K)) [IsMulCommutative H]
     (hle : (weightTorusPoints r K).range ≤ H) :
     H = (weightTorusPoints r K).range :=
-  eq_of_centralizer_eq_self_of_le_of_isMulCommutative
+  Subgroup.eq_of_centralizer_eq_self_of_le_of_isMulCommutative
     ((centralizer_range_weightTorusPoints_eq_diagonalPoints_of_weightChar_weight_injective
       r K hchar).trans (range_weightTorusPoints_eq_diagonalPoints r K).symm) hle
 

--- a/TauCeti/Data/Fin/Basic.lean
+++ b/TauCeti/Data/Fin/Basic.lean
@@ -14,7 +14,8 @@ import Mathlib.Tactic.FinCases
 # Basic results about finite ordinal types
 
 This file collects elementary facts about finite ordinal types, including the classification of
-permutations of `Fin 2` and indicator sums indexed by `Fin n`.
+permutations of `Fin 2`, indicator sums indexed by `Fin n`, and the final value of a partial
+product.
 
 `Fintype.sum_ite_eq` evaluates a sum whose indicator compares two elements of the index type.
 When the comparison is instead between a natural number and the `Fin.val` of the index — as it is
@@ -25,6 +26,7 @@ range, so the value is a `dite` rather than a plain application.
 
 * `TauCeti.perm_fin_two_eq_one_or_swap`: every permutation of `Fin 2` is the identity or the
   transposition.
+* `TauCeti.partialProd_last`: the final partial product is the product of all the entries.
 * `TauCeti.sum_ite_val_add`: a sum against the indicator of `b = k + j` picks out the summand at
   `b - j`, or vanishes when there is no such index.
 -/
@@ -32,6 +34,12 @@ range, so the value is a `dite` rather than a plain application.
 public section
 
 namespace TauCeti
+
+/-- The final partial product is the product of all the entries. -/
+theorem partialProd_last {M : Type*} [CommMonoid M] {n : ℕ} (f : Fin n → M) :
+    Fin.partialProd f (Fin.last n) = ∏ i, f i := by
+  rw [Fin.partialProd, Fin.val_last]
+  rw [(List.take_eq_self_iff _).mpr (by simp), Fin.prod_ofFn]
 
 /-- A permutation of `Fin 2` is either the identity or the transposition. -/
 theorem perm_fin_two_eq_one_or_swap (e : Equiv.Perm (Fin 2)) :

--- a/TauCeti/Data/Fin/Basic.lean
+++ b/TauCeti/Data/Fin/Basic.lean
@@ -26,20 +26,26 @@ range, so the value is a `dite` rather than a plain application.
 
 * `TauCeti.perm_fin_two_eq_one_or_swap`: every permutation of `Fin 2` is the identity or the
   transposition.
-* `TauCeti.partialProd_last`: the final partial product is the product of all the entries.
+* `Fin.partialProd_last`: the final partial product is the product of all the entries.
+* `Fin.partialSum_last`: the final partial sum is the sum of all the entries.
 * `TauCeti.sum_ite_val_add`: a sum against the indicator of `b = k + j` picks out the summand at
   `b - j`, or vanishes when there is no such index.
 -/
 
 public section
 
-namespace TauCeti
+namespace Fin
 
 /-- The final partial product is the product of all the entries. -/
+@[to_additive /-- The final partial sum is the sum of all the entries. -/]
 theorem partialProd_last {M : Type*} [CommMonoid M] {n : ℕ} (f : Fin n → M) :
     Fin.partialProd f (Fin.last n) = ∏ i, f i := by
   rw [Fin.partialProd, Fin.val_last]
   rw [(List.take_eq_self_iff _).mpr (by simp), Fin.prod_ofFn]
+
+end Fin
+
+namespace TauCeti
 
 /-- A permutation of `Fin 2` is either the identity or the transposition. -/
 theorem perm_fin_two_eq_one_or_swap (e : Equiv.Perm (Fin 2)) :

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Basic.lean
@@ -14,8 +14,8 @@ public import Mathlib.LinearAlgebra.Matrix.Permutation
 public import Mathlib.Algebra.Group.Pi.Units
 -- `Matrix.IsDiag` occurs in the statements below.
 public import Mathlib.LinearAlgebra.Matrix.IsDiag
--- `Subgroup.centralizer` and `Subgroup.center` occur in the statements below.
-public import Mathlib.GroupTheory.Subgroup.Centralizer
+-- `Subgroup.centralizer` and its maximal-commutative-subgroup API occur below.
+public import TauCeti.Algebra.Group.Subgroup.Centralizer
 -- `Nat.card` occurs in the statement of `TauCeti.natCard_diagonalTorus`.
 public import Mathlib.SetTheory.Cardinal.Finite
 -- Non-public: `Nat.card_units`, the number of units of a `GroupWithZero`, is used only inside the
@@ -351,12 +351,8 @@ maximality of the torus among abelian subgroups. -/
 theorem eq_diagonalTorus_of_le_of_isMulCommutative (H : Subgroup (GL (Fin n) k))
     [IsMulCommutative H] (hle : diagonalTorus k n ≤ H) :
     H = diagonalTorus k n :=
-  le_antisymm
-    (by
-      rw [← centralizer_diagonalTorus (k := k) (n := n)]
-      exact (Subgroup.le_centralizer (H := H)).trans
-        (Subgroup.centralizer_le (SetLike.coe_subset_coe.mpr hle)))
-    hle
+  eq_of_centralizer_eq_self_of_le_of_isMulCommutative
+    (centralizer_diagonalTorus (k := k) (n := n)) hle
 
 end IsCancelMulZero
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Basic.lean
@@ -351,7 +351,7 @@ maximality of the torus among abelian subgroups. -/
 theorem eq_diagonalTorus_of_le_of_isMulCommutative (H : Subgroup (GL (Fin n) k))
     [IsMulCommutative H] (hle : diagonalTorus k n ≤ H) :
     H = diagonalTorus k n :=
-  eq_of_centralizer_eq_self_of_le_of_isMulCommutative
+  Subgroup.eq_of_centralizer_eq_self_of_le_of_isMulCommutative
     (centralizer_diagonalTorus (k := k) (n := n)) hle
 
 end IsCancelMulZero

--- a/TauCeti/RepresentationTheory/SU2/Basic.lean
+++ b/TauCeti/RepresentationTheory/SU2/Basic.lean
@@ -9,6 +9,7 @@ public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 public import Mathlib.LinearAlgebra.Matrix.IsDiag
 public import Mathlib.LinearAlgebra.Matrix.Trace
 public import Mathlib.Topology.Algebra.ContinuousMonoidHom
+import TauCeti.Algebra.Group.Subgroup.Centralizer
 import TauCeti.LinearAlgebra.Matrix.AdjugateFinTwo
 public import TauCeti.LinearAlgebra.UnitaryGroup
 public import TauCeti.Topology.Algebra.UnitaryGroup
@@ -349,11 +350,8 @@ theorem centralizer_torus : Subgroup.centralizer (torus : Set SU2) = torus := by
 /-- The maximal torus is a maximal abelian subgroup of `SU(2)`: a commutative subgroup containing
 it is equal to it. -/
 theorem eq_torus_of_isMulCommutative {H : Subgroup SU2} [IsMulCommutative H] (hH : torus ≤ H) :
-    H = torus := by
-  refine le_antisymm (fun g hg => ?_) hH
-  rw [← centralizer_torus, Subgroup.mem_centralizer_iff]
-  intro h hh
-  exact setLike_mul_comm (hH hh) hg
+    H = torus :=
+  Subgroup.eq_of_centralizer_eq_self_of_le_of_isMulCommutative centralizer_torus hH
 
 /-! ### Conjugating a torus element back into the torus -/
 


### PR DESCRIPTION
This PR proves that, over an infinite field, the standard type-A carrier's weight-torus points are exactly its determinant-one diagonal points and form a maximal commutative subgroup. It supplies the field-point maximality step for the "Pinnings" target in Layer 9, "The Chevalley--Demazure construction", of `TauCetiRoadmap/ReductiveGroups/README.md`.

The proof shows that the standard weights are pairwise distinct, uses weight characters to compute the torus centralizer, and constructs an explicit inverse to the weight parametrization from partial products of diagonal entries. This treats every rank, including rank zero, and uses the existing carrier-point identification with `SL_{r+1}`.

Dependency edge: CFSGStatement milestone L0, "pinned ambient groups", consumes the ReductiveGroups Layer 9 pinning `(G,T,B,{x_i})`; this PR establishes maximality of the named type-A torus on algebraically closed-field points (indeed, on all infinite-field points). After this PR, the Hopf-ideal scheme-theoretic maximal-torus statement and the remaining root-datum compatibility are still needed before the type-A Layer 9 pinning and CFSGStatement L0 are complete.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"slstd-weight-torus-maximal"}-->

🤖 Prepared with Codex
