### PR TITLE
refactor(Gaussian): rename the directional mgf to the roadmap's name

### DIFF
--- a/TauCeti/Probability/Distributions/Gaussian/Transforms.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Transforms.lean
@@ -26,7 +26,7 @@ the variance as the covariance-matrix quadratic form.
   variance.
 * `TauCeti.integrableExpSet_inner_multivariateGaussian` gives the exact domain for a directional
   functional of a multivariate Gaussian.
-* `TauCeti.mgf_inner_toEuclideanLin_multivariateGaussian` gives the corresponding closed formula.
+* `TauCeti.mgf_inner_multivariateGaussian` gives the corresponding closed formula.
 
 ## References
 
@@ -95,7 +95,7 @@ theorem integrableExpSet_inner_multivariateGaussian (m θ : EuclideanSpace ℝ �
 
 The exponent consists of the directional mean and one half of the covariance quadratic form,
 scaled respectively by `t` and `t²`. -/
-theorem mgf_inner_toEuclideanLin_multivariateGaussian (m θ : EuclideanSpace ℝ ι)
+theorem mgf_inner_multivariateGaussian (m θ : EuclideanSpace ℝ ι)
     {S : Matrix ι ι ℝ} (hS : S.PosSemidef) (t : ℝ) :
     mgf (fun x ↦ ⟪θ, x⟫) (multivariateGaussian m S) t =
       Real.exp (t * ⟪θ, m⟫ + t ^ 2 / 2 * ⟪θ, S.toEuclideanLin θ⟫) := by


### PR DESCRIPTION
This PR renames the directional Gaussian mgf in `TauCeti/Probability/Distributions/Gaussian/Transforms.lean` from `mgf_inner_toEuclideanLin_multivariateGaussian` to `mgf_inner_multivariateGaussian`. The roadmap's `Suggested.lean` for `TauCetiRoadmap/StandardDistributions` uses `mgf_inner_multivariateGaussian` for the mgf of the linear statistic `x ↦ ⟪θ, x⟫`, and reserves `mgf_inner_toEuclideanLin_multivariateGaussian` for the quadratic statistic `x ↦ ⟪x, Θ.toEuclideanLin x⟫`, the theorem listed among Layer 5's key declarations. The current name describes the right-hand side of the formula rather than the statistic, and it blocks the roadmap-pinned name for the quadratic-form theorem, which a follow-up PR adds.

No statement changes; the theorem has no other uses in the repository.

Roadmap: StandardDistributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
