### PR TITLE
feat: raise the base field in a Frobenius tower

### DIFF
--- a/TauCeti/NumberTheory/NumberField/Frobenius/DecompositionGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius/DecompositionGroup.lean
@@ -41,6 +41,8 @@ prime `τ • Q` gives the other.
 
 * `Ideal.isUnramifiedAt_iff_inertia_eq_bot`: unramifiedness at `Q` is triviality of the
   inertia subgroup of `Q` in `Gal(L/K)`.
+* `Ideal.eq_of_smul_sub_smul_mem_of_isUnramifiedAt`: an element of the decomposition group of an
+  unramified prime is determined by its action on the residue field.
 * `Ideal.stabilizerHom_eq_frobeniusAlgEquivOfAlgebraic`: a Frobenius element at `Q` acts on
   the residue field `𝓞 L ⧸ Q` as the residue Frobenius.
 * `Ideal.orderOf_eq_inertiaDeg_of_isArithFrobAt`: a Frobenius element at an unramified `Q`
@@ -104,6 +106,27 @@ theorem stabilizerHom_injective_of_isUnramifiedAt (Q : Ideal (𝓞 L)) [Q.IsPrim
   have hσ' : (σ : L ≃ₐ[K] L) ∈ Q.inertia (L ≃ₐ[K] L) := Ideal.coe_mem_inertia.mpr hσ
   rw [(isUnramifiedAt_iff_inertia_eq_bot Q).mp ‹_›, Subgroup.mem_bot] at hσ'
   exact Subgroup.mem_bot.mpr (Subtype.ext hσ')
+
+/-- **An element of the decomposition group is determined by its residue action.** At a prime `Q`
+unramified over `𝓞 K`, two elements of `Gal(L/K)` that stabilize `Q` and satisfy
+`σ x ≡ τ x (mod Q)` for every `x : 𝓞 L` are equal.
+
+This is `Ideal.stabilizerHom_injective_of_isUnramifiedAt` in the form a caller comparing two
+automorphisms meets it: the hypothesis is a congruence on `𝓞 L`, not an equality of automorphisms
+of the residue field. Unlike `NumberField.isArithFrobAt_eq_of_isUnramifiedAt` it does not assume
+that either element is a Frobenius, so it also compares elements whose common residue action is a
+power of the residue Frobenius. -/
+theorem eq_of_smul_sub_smul_mem_of_isUnramifiedAt (Q : Ideal (𝓞 L)) [Q.IsPrime]
+    [Algebra.IsUnramifiedAt (𝓞 K) Q] {σ τ : L ≃ₐ[K] L}
+    (hσ : σ ∈ MulAction.stabilizer (L ≃ₐ[K] L) Q)
+    (hτ : τ ∈ MulAction.stabilizer (L ≃ₐ[K] L) Q)
+    (h : ∀ x : 𝓞 L, σ • x - τ • x ∈ Q) : σ = τ := by
+  have key : Ideal.Quotient.stabilizerHom Q (Q.under (𝓞 K)) (L ≃ₐ[K] L) ⟨σ, hσ⟩ =
+      Ideal.Quotient.stabilizerHom Q (Q.under (𝓞 K)) (L ≃ₐ[K] L) ⟨τ, hτ⟩ := by
+    ext x
+    obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective x
+    simpa [MulAction.subgroup_smul_def, Ideal.Quotient.eq] using h x
+  exact congrArg Subtype.val (stabilizerHom_injective_of_isUnramifiedAt Q key)
 
 /-- **The decomposition group of an unramified prime is the residue Galois group.** Mathlib's
 `Ideal.Quotient.stabilizerHom` is always surjective for an invariant extension, and at an

--- a/TauCeti/NumberTheory/NumberField/Frobenius/DecompositionGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius/DecompositionGroup.lean
@@ -41,8 +41,6 @@ prime `τ • Q` gives the other.
 
 * `Ideal.isUnramifiedAt_iff_inertia_eq_bot`: unramifiedness at `Q` is triviality of the
   inertia subgroup of `Q` in `Gal(L/K)`.
-* `Ideal.eq_of_smul_sub_smul_mem_of_isUnramifiedAt`: an element of the decomposition group of an
-  unramified prime is determined by its action on the residue field.
 * `Ideal.stabilizerHom_eq_frobeniusAlgEquivOfAlgebraic`: a Frobenius element at `Q` acts on
   the residue field `𝓞 L ⧸ Q` as the residue Frobenius.
 * `Ideal.orderOf_eq_inertiaDeg_of_isArithFrobAt`: a Frobenius element at an unramified `Q`
@@ -106,27 +104,6 @@ theorem stabilizerHom_injective_of_isUnramifiedAt (Q : Ideal (𝓞 L)) [Q.IsPrim
   have hσ' : (σ : L ≃ₐ[K] L) ∈ Q.inertia (L ≃ₐ[K] L) := Ideal.coe_mem_inertia.mpr hσ
   rw [(isUnramifiedAt_iff_inertia_eq_bot Q).mp ‹_›, Subgroup.mem_bot] at hσ'
   exact Subgroup.mem_bot.mpr (Subtype.ext hσ')
-
-/-- **An element of the decomposition group is determined by its residue action.** At a prime `Q`
-unramified over `𝓞 K`, two elements of `Gal(L/K)` that stabilize `Q` and satisfy
-`σ x ≡ τ x (mod Q)` for every `x : 𝓞 L` are equal.
-
-This is `Ideal.stabilizerHom_injective_of_isUnramifiedAt` in the form a caller comparing two
-automorphisms meets it: the hypothesis is a congruence on `𝓞 L`, not an equality of automorphisms
-of the residue field. Unlike `NumberField.isArithFrobAt_eq_of_isUnramifiedAt` it does not assume
-that either element is a Frobenius, so it also compares elements whose common residue action is a
-power of the residue Frobenius. -/
-theorem eq_of_smul_sub_smul_mem_of_isUnramifiedAt (Q : Ideal (𝓞 L)) [Q.IsPrime]
-    [Algebra.IsUnramifiedAt (𝓞 K) Q] {σ τ : L ≃ₐ[K] L}
-    (hσ : σ ∈ MulAction.stabilizer (L ≃ₐ[K] L) Q)
-    (hτ : τ ∈ MulAction.stabilizer (L ≃ₐ[K] L) Q)
-    (h : ∀ x : 𝓞 L, σ • x - τ • x ∈ Q) : σ = τ := by
-  have key : Ideal.Quotient.stabilizerHom Q (Q.under (𝓞 K)) (L ≃ₐ[K] L) ⟨σ, hσ⟩ =
-      Ideal.Quotient.stabilizerHom Q (Q.under (𝓞 K)) (L ≃ₐ[K] L) ⟨τ, hτ⟩ := by
-    ext x
-    obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective x
-    simpa [MulAction.subgroup_smul_def, Ideal.Quotient.eq] using h x
-  exact congrArg Subtype.val (stabilizerHom_injective_of_isUnramifiedAt Q key)
 
 /-- **The decomposition group of an unramified prime is the residue Galois group.** Mathlib's
 `Ideal.Quotient.stabilizerHom` is always surjective for an invariant extension, and at an

--- a/TauCeti/NumberTheory/NumberField/Frobenius/Tower.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius/Tower.lean
@@ -16,7 +16,7 @@ unramified over `𝓞 K`, and write `𝔓 = Q ∩ 𝓞 M` and `𝔭 = Q ∩ 𝓞
 `τ ∈ Gal(L/M)` at `Q` acts by `x ↦ x ^ 𝔑𝔓`. Since `𝔑𝔓 = 𝔑𝔭 ^ f(𝔓/𝔭)`, the two are related by
 
 ```text
-τ = σ ^ f(𝔓/𝔭).
+AlgEquiv.restrictScalars K τ = σ ^ f(𝔓/𝔭).
 ```
 
 The exponent is a **power**, the residue degree of the intermediate prime over the base, and never
@@ -37,25 +37,25 @@ the restriction of no element of `Gal(L/M)` at all.
 Unramifiedness of `Q` over `𝓞 K` is likewise essential. At a ramified prime a Frobenius lift is
 determined only modulo inertia, so there is no equality of automorphisms to prove; the statement
 would have to be made in the quotient by the inertia subgroup, or about a coset. Here
-unramifiedness enters through `Ideal.eq_of_smul_sub_smul_mem_of_isUnramifiedAt`: the decomposition
+unramifiedness enters through `Ideal.stabilizerHom_injective_of_isUnramifiedAt`: the decomposition
 group of `Q` embeds into the automorphism group of the residue extension, so an element of
-`Gal(L/K)` stabilizing `Q` is pinned down by its residue action, and both `σ ^ f(𝔓/𝔭)` and the
-restriction of `τ` act by `x ↦ x ^ 𝔑𝔓`.
+`Gal(L/K)` stabilizing `Q` is pinned down by its residue action, and both `σ ^ f(𝔓/𝔭)` and
+`AlgEquiv.restrictScalars K τ` act by `x ↦ x ^ 𝔑𝔓`.
 
 ## Main results
 
 * `NumberField.restrictScalars_eq_pow_inertiaDeg`: an arithmetic Frobenius of `Gal(L/M)` at `Q`
-  is the `f(𝔓/𝔭)`-th power of an arithmetic Frobenius of `Gal(L/K)` at `Q`.
+  restricts to the `f(𝔓/𝔭)`-th power of an arithmetic Frobenius of `Gal(L/K)` at `Q`.
 * `NumberField.isArithFrobAt_iff_restrictScalars_eq_pow_inertiaDeg`: that power characterizes the
-  relative Frobenius among the elements of `Gal(L/M)`.
+  relative Frobenius among the elements of `Gal(L/M)` after restriction to `Gal(L/K)`.
 * `NumberField.restrictScalars_arithFrobAt_eq_pow_inertiaDeg`: the same formula for Mathlib's
   coherently chosen `arithFrobAt`, which is what the Artin symbol is built from.
 * `NumberField.exists_isArithFrobAt_pow_inertiaDeg`: the existence form of the tower formula,
   stated for prime ideals `𝔓` and `𝔭` presented by their defining equations.
 * `NumberField.pow_inertiaDeg_apply_algebraMap`: the `f(𝔓/𝔭)`-th power of `σ` fixes `M`
   pointwise.
-* `NumberField.restrictScalars_eq_of_inertiaDeg_eq_one`: at residue degree one the relative
-  Frobenius is `σ` itself, with no power.
+* `NumberField.restrictScalars_eq_of_inertiaDeg_eq_one`: at residue degree one the restriction
+  of the relative Frobenius is `σ` itself, with no power.
 
 ## References
 
@@ -75,9 +75,10 @@ variable {K L : Type*} [Field K] [NumberField K] [Field L] [NumberField L] [Alge
   [IsScalarTower K M L] {Q : Ideal (𝓞 L)} [Q.IsPrime]
 
 /-- **Raising the base field raises the Frobenius to the residue degree.** For number fields
-`K ⊆ M ⊆ L` with `L / K` and `L / M` Galois and `Q` a prime of `𝓞 L` unramified over `𝓞 K`, an
-arithmetic Frobenius `τ ∈ Gal(L/M)` at `Q` is the `f(𝔓/𝔭)`-th power of an arithmetic Frobenius
-`σ ∈ Gal(L/K)` at `Q`, where `𝔓 = Q ∩ 𝓞 M` and `𝔭 = Q ∩ 𝓞 K`.
+`K ⊆ M ⊆ L` with `L / K` and `L / M` Galois and `Q` a prime of `𝓞 L` unramified over `𝓞 K`, the
+restriction to `Gal(L/K)` of an arithmetic Frobenius `τ ∈ Gal(L/M)` at `Q` is the
+`f(𝔓/𝔭)`-th power of an arithmetic Frobenius `σ ∈ Gal(L/K)` at `Q`, where
+`𝔓 = Q ∩ 𝓞 M` and `𝔭 = Q ∩ 𝓞 K`.
 
 The exponent is the residue degree of `𝔓` over `𝓞 K`, and it is a power: the residue field of `𝔓`
 has `𝔑𝔭 ^ f(𝔓/𝔭)` elements, so the two Frobenius elements have residue actions `x ↦ x ^ 𝔑𝔭` and
@@ -97,27 +98,45 @@ theorem restrictScalars_eq_pow_inertiaDeg [Algebra.IsUnramifiedAt (𝓞 K) Q]
     have := Ideal.cardQuot_pow_inertiaDeg (R := 𝓞 K) (S := 𝓞 M)
       (Q.under (𝓞 K)) (Q.under (𝓞 M))
     simpa [Submodule.cardQuot_apply] using this.symm
-  refine Ideal.eq_of_smul_sub_smul_mem_of_isUnramifiedAt Q
-    (τ := σ ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K)) hτ.mem_stabilizer
-    (pow_mem hσ.mem_stabilizer _) fun x ↦ ?_
-  have hres : Ideal.Quotient.mk Q (τ • x) =
-      Ideal.Quotient.mk Q x ^ Nat.card (𝓞 M ⧸ Q.under (𝓞 M)) := hτ.mk_apply x
-  rw [← Ideal.Quotient.eq, hσ.mk_pow_smul _ x]
-  change Ideal.Quotient.mk Q (τ • x) = _
-  rw [hres, hcard]
+  have hrestrict (x : 𝓞 L) : (AlgEquiv.restrictScalars K τ) • x = τ • x := by
+    -- No public lemma states this for the induced actions on `𝓞 L`; it is definitional because
+    -- `AlgEquiv.restrictScalars` preserves the underlying ring equivalence.
+    rfl
+  have hrestrictQ : (AlgEquiv.restrictScalars K τ) • Q = τ • Q := by
+    rw [Ideal.pointwise_smul_def, Ideal.pointwise_smul_def]
+    apply congrArg fun f ↦ Q.map f
+    ext x
+    exact congrArg (algebraMap (𝓞 L) L) (hrestrict x)
+  have hcong (x : 𝓞 L) :
+      (AlgEquiv.restrictScalars K τ) • x -
+        (σ ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K)) • x ∈ Q := by
+    have hres : Ideal.Quotient.mk Q (τ • x) =
+        Ideal.Quotient.mk Q x ^ Nat.card (𝓞 M ⧸ Q.under (𝓞 M)) := hτ.mk_apply x
+    rw [← Ideal.Quotient.eq, hrestrict, hσ.mk_pow_smul, hres, hcard]
+  have key : Ideal.Quotient.stabilizerHom Q (Q.under (𝓞 K)) (L ≃ₐ[K] L)
+      ⟨AlgEquiv.restrictScalars K τ, by
+        rw [MulAction.mem_stabilizer_iff, hrestrictQ]
+        exact MulAction.mem_stabilizer_iff.mp hτ.mem_stabilizer⟩ =
+      Ideal.Quotient.stabilizerHom Q (Q.under (𝓞 K)) (L ≃ₐ[K] L)
+        ⟨σ ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K), pow_mem hσ.mem_stabilizer _⟩ := by
+    ext x
+    obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective x
+    simpa [MulAction.subgroup_smul_def, Ideal.Quotient.eq] using hcong x
+  exact congrArg Subtype.val (Ideal.stabilizerHom_injective_of_isUnramifiedAt Q key)
 
-/-- **The relative Frobenius is exactly that power.** An element of `Gal(L/M)` is an arithmetic
-Frobenius at `Q` precisely when it is the `f(𝔓/𝔭)`-th power of a fixed arithmetic Frobenius
-`σ ∈ Gal(L/K)` at `Q`.
+/-- **The relative Frobenius restricts to exactly that power.** An element of `Gal(L/M)` is an
+arithmetic Frobenius at `Q` precisely when its restriction to `Gal(L/K)` is the
+`f(𝔓/𝔭)`-th power of a fixed arithmetic Frobenius `σ ∈ Gal(L/K)` at `Q`.
 
 The converse direction is uniqueness rather than a second computation: a Frobenius of `Gal(L/M)`
 at `Q` exists, is carried to `σ ^ f(𝔓/𝔭)` by `restrictScalars_eq_pow_inertiaDeg`, and
 `AlgEquiv.restrictScalars` is injective. -/
-theorem isArithFrobAt_iff_restrictScalars_eq_pow_inertiaDeg [IsGalois M L]
+theorem isArithFrobAt_iff_restrictScalars_eq_pow_inertiaDeg
     [Algebra.IsUnramifiedAt (𝓞 K) Q]
     {σ : L ≃ₐ[K] L} (hσ : IsArithFrobAt (𝓞 K) σ Q) (τ : L ≃ₐ[M] L) :
     IsArithFrobAt (𝓞 M) τ Q ↔
       AlgEquiv.restrictScalars K τ = σ ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K) := by
+  have : IsGalois M L := IsGalois.tower_top_of_isGalois K M L
   refine ⟨restrictScalars_eq_pow_inertiaDeg hσ, fun h ↦ ?_⟩
   obtain ⟨τ₀, hτ₀⟩ := exists_isArithFrobAt M Q hσ.ne_bot
   have : τ = τ₀ := AlgEquiv.restrictScalars_injective K
@@ -145,7 +164,9 @@ image in `Gal(L/K)` of an arithmetic Frobenius at `Q` in `Gal(L/M)`.
 
 The unramifiedness hypothesis is phrased for all primes above `𝔭`, matching the argument that
 `NumberField.artinSymbol` takes; only its value at `Q` is used. -/
-theorem exists_isArithFrobAt_pow_inertiaDeg [IsGalois M L] (Q : Ideal (𝓞 L)) [Q.IsPrime]
+theorem exists_isArithFrobAt_pow_inertiaDeg (M : Type*) [Field M] [NumberField M]
+    [Algebra K M] [Algebra M L] [IsScalarTower K M L] [IsGalois M L]
+    (Q : Ideal (𝓞 L)) [Q.IsPrime]
     (𝔓 : Ideal (𝓞 M)) (𝔭 : Ideal (𝓞 K))
     (hQM : Q.under (𝓞 M) = 𝔓) (hQK : Q.under (𝓞 K) = 𝔭)
     (hur : ∀ (Q' : Ideal (𝓞 L)) [Q'.IsPrime] [Q'.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q')
@@ -161,19 +182,21 @@ theorem exists_isArithFrobAt_pow_inertiaDeg [IsGalois M L] (Q : Ideal (𝓞 L)) 
 /-- **The power of the Frobenius fixes the intermediate field.** Even though `M / K` need not be
 normal, and `σ` therefore need not preserve `M`, its `f(𝔓/𝔭)`-th power fixes `M` pointwise: it is
 the image of an element of `Gal(L/M)`. -/
-theorem pow_inertiaDeg_apply_algebraMap [IsGalois M L] [Algebra.IsUnramifiedAt (𝓞 K) Q]
+theorem pow_inertiaDeg_apply_algebraMap [Algebra.IsUnramifiedAt (𝓞 K) Q]
     {σ : L ≃ₐ[K] L} (hσ : IsArithFrobAt (𝓞 K) σ Q) (y : M) :
     (σ ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K)) (algebraMap M L y) = algebraMap M L y := by
+  have : IsGalois M L := IsGalois.tower_top_of_isGalois K M L
   obtain ⟨τ, hτ⟩ := exists_isArithFrobAt M Q hσ.ne_bot
   rw [← restrictScalars_eq_pow_inertiaDeg hσ hτ]
   exact τ.commutes y
 
-/-- **At residue degree one the Frobenius does not move.** If `𝔓 = Q ∩ 𝓞 M` has residue degree one
-over `𝓞 K`, then an arithmetic Frobenius of `Gal(L/M)` at `Q` is the arithmetic Frobenius of
-`Gal(L/K)` at `Q` itself, on the nose.
+/-- **At residue degree one the restricted Frobenius does not move.** If `𝔓 = Q ∩ 𝓞 M` has
+residue degree one over `𝓞 K`, then the restriction to `Gal(L/K)` of an arithmetic Frobenius of
+`Gal(L/M)` at `Q` is the arithmetic Frobenius of `Gal(L/K)` at `Q` itself.
 
 This is the case a fixed-field fibre count runs through: it contracts the primes of `M` whose
-residue degree over `K` is one, exactly so that the relative Frobenius is the absolute one. -/
+residue degree over `K` is one, exactly so that the restriction of the relative Frobenius is the
+absolute one. -/
 theorem restrictScalars_eq_of_inertiaDeg_eq_one [Algebra.IsUnramifiedAt (𝓞 K) Q]
     {σ : L ≃ₐ[K] L} (hσ : IsArithFrobAt (𝓞 K) σ Q)
     {τ : L ≃ₐ[M] L} (hτ : IsArithFrobAt (𝓞 M) τ Q)

--- a/TauCeti/NumberTheory/NumberField/Frobenius/Tower.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius/Tower.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.NumberField.Frobenius.DecompositionGroup
+
+/-!
+# Raising the base field: the tower formula for arithmetic Frobenius elements
+
+Let `K ⊆ M ⊆ L` be number fields with `L / K` and `L / M` Galois, let `Q` be a prime of `𝓞 L`
+unramified over `𝓞 K`, and write `𝔓 = Q ∩ 𝓞 M` and `𝔭 = Q ∩ 𝓞 K`. An arithmetic Frobenius
+`σ ∈ Gal(L/K)` at `Q` acts on the residue field by `x ↦ x ^ 𝔑𝔭`, while an arithmetic Frobenius
+`τ ∈ Gal(L/M)` at `Q` acts by `x ↦ x ^ 𝔑𝔓`. Since `𝔑𝔓 = 𝔑𝔭 ^ f(𝔓/𝔭)`, the two are related by
+
+```text
+τ = σ ^ f(𝔓/𝔭).
+```
+
+The exponent is a **power**, the residue degree of the intermediate prime over the base, and never
+an inverse. In particular `σ ^ f(𝔓/𝔭)` fixes `M` pointwise even though `M / K` need not be normal
+and `σ` itself need not preserve `M`.
+
+This is the second of the two tower laws for Frobenius elements. The first, restriction along a
+normal subextension, takes no power at all and is
+`IsArithFrobAt.restrictNormal` in `TauCeti.NumberTheory.NumberField.Frobenius.Restriction`.
+
+## The two hypotheses that are not decoration
+
+The statement is *relative to one prime `Q` of `L`*. Replacing `σ` by an arbitrary conjugate — an
+arbitrary representative of the Artin class of `𝔭` — makes it false when `M / K` is not normal: a
+conjugate need not stabilize `Q`, so its `f`-th power need not fix `M` pointwise, and it is then
+the restriction of no element of `Gal(L/M)` at all.
+
+Unramifiedness of `Q` over `𝓞 K` is likewise essential. At a ramified prime a Frobenius lift is
+determined only modulo inertia, so there is no equality of automorphisms to prove; the statement
+would have to be made in the quotient by the inertia subgroup, or about a coset. Here
+unramifiedness enters through `Ideal.eq_of_smul_sub_smul_mem_of_isUnramifiedAt`: the decomposition
+group of `Q` embeds into the automorphism group of the residue extension, so an element of
+`Gal(L/K)` stabilizing `Q` is pinned down by its residue action, and both `σ ^ f(𝔓/𝔭)` and the
+restriction of `τ` act by `x ↦ x ^ 𝔑𝔓`.
+
+## Main results
+
+* `NumberField.restrictScalars_eq_pow_inertiaDeg`: an arithmetic Frobenius of `Gal(L/M)` at `Q`
+  is the `f(𝔓/𝔭)`-th power of an arithmetic Frobenius of `Gal(L/K)` at `Q`.
+* `NumberField.isArithFrobAt_iff_restrictScalars_eq_pow_inertiaDeg`: that power characterizes the
+  relative Frobenius among the elements of `Gal(L/M)`.
+* `NumberField.restrictScalars_arithFrobAt_eq_pow_inertiaDeg`: the same formula for Mathlib's
+  coherently chosen `arithFrobAt`, which is what the Artin symbol is built from.
+* `NumberField.exists_isArithFrobAt_pow_inertiaDeg`: the existence form of the tower formula,
+  stated for prime ideals `𝔓` and `𝔭` presented by their defining equations.
+* `NumberField.pow_inertiaDeg_apply_algebraMap`: the `f(𝔓/𝔭)`-th power of `σ` fixes `M`
+  pointwise.
+* `NumberField.restrictScalars_eq_of_inertiaDeg_eq_one`: at residue degree one the relative
+  Frobenius is `σ` itself, with no power.
+
+## References
+
+* [J. Neukirch, *Algebraic Number Theory*][Neukirch1992], Chapter I, §9.
+-/
+
+public section
+
+open Ideal
+
+open scoped NumberField Pointwise
+
+namespace NumberField
+
+variable {K L : Type*} [Field K] [NumberField K] [Field L] [NumberField L] [Algebra K L]
+  [IsGalois K L] {M : Type*} [Field M] [NumberField M] [Algebra K M] [Algebra M L]
+  [IsScalarTower K M L] {Q : Ideal (𝓞 L)} [Q.IsPrime]
+
+/-- **Raising the base field raises the Frobenius to the residue degree.** For number fields
+`K ⊆ M ⊆ L` with `L / K` and `L / M` Galois and `Q` a prime of `𝓞 L` unramified over `𝓞 K`, an
+arithmetic Frobenius `τ ∈ Gal(L/M)` at `Q` is the `f(𝔓/𝔭)`-th power of an arithmetic Frobenius
+`σ ∈ Gal(L/K)` at `Q`, where `𝔓 = Q ∩ 𝓞 M` and `𝔭 = Q ∩ 𝓞 K`.
+
+The exponent is the residue degree of `𝔓` over `𝓞 K`, and it is a power: the residue field of `𝔓`
+has `𝔑𝔭 ^ f(𝔓/𝔭)` elements, so the two Frobenius elements have residue actions `x ↦ x ^ 𝔑𝔭` and
+`x ↦ x ^ 𝔑𝔭 ^ f(𝔓/𝔭)`. Both sides are read inside `Gal(L/K)`, where `τ` is placed by
+`AlgEquiv.restrictScalars`. -/
+theorem restrictScalars_eq_pow_inertiaDeg [Algebra.IsUnramifiedAt (𝓞 K) Q]
+    {σ : L ≃ₐ[K] L} (hσ : IsArithFrobAt (𝓞 K) σ Q)
+    {τ : L ≃ₐ[M] L} (hτ : IsArithFrobAt (𝓞 M) τ Q) :
+    AlgEquiv.restrictScalars K τ = σ ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K) := by
+  have _ : Q.IsMaximal := Ring.DimensionLEOne.maximalOfPrime hσ.ne_bot inferInstance
+  have _ : (Q.under (𝓞 M)).IsMaximal := isMaximal_comap_of_isIntegral_of_isMaximal Q
+  have _ : (Q.under (𝓞 K)).IsMaximal := isMaximal_comap_of_isIntegral_of_isMaximal Q
+  have _ : (Q.under (𝓞 M)).LiesOver (Q.under (𝓞 K)) := ⟨by rw [Ideal.under_under]⟩
+  -- The residue field of `𝔓` has `𝔑𝔭 ^ f(𝔓/𝔭)` elements.
+  have hcard : Nat.card (𝓞 M ⧸ Q.under (𝓞 M)) =
+      Nat.card (𝓞 K ⧸ Q.under (𝓞 K)) ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K) := by
+    have := Ideal.cardQuot_pow_inertiaDeg (R := 𝓞 K) (S := 𝓞 M)
+      (Q.under (𝓞 K)) (Q.under (𝓞 M))
+    simpa [Submodule.cardQuot_apply] using this.symm
+  refine Ideal.eq_of_smul_sub_smul_mem_of_isUnramifiedAt Q
+    (τ := σ ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K)) hτ.mem_stabilizer
+    (pow_mem hσ.mem_stabilizer _) fun x ↦ ?_
+  have hres : Ideal.Quotient.mk Q (τ • x) =
+      Ideal.Quotient.mk Q x ^ Nat.card (𝓞 M ⧸ Q.under (𝓞 M)) := hτ.mk_apply x
+  rw [← Ideal.Quotient.eq, hσ.mk_pow_smul _ x]
+  change Ideal.Quotient.mk Q (τ • x) = _
+  rw [hres, hcard]
+
+/-- **The relative Frobenius is exactly that power.** An element of `Gal(L/M)` is an arithmetic
+Frobenius at `Q` precisely when it is the `f(𝔓/𝔭)`-th power of a fixed arithmetic Frobenius
+`σ ∈ Gal(L/K)` at `Q`.
+
+The converse direction is uniqueness rather than a second computation: a Frobenius of `Gal(L/M)`
+at `Q` exists, is carried to `σ ^ f(𝔓/𝔭)` by `restrictScalars_eq_pow_inertiaDeg`, and
+`AlgEquiv.restrictScalars` is injective. -/
+theorem isArithFrobAt_iff_restrictScalars_eq_pow_inertiaDeg [IsGalois M L]
+    [Algebra.IsUnramifiedAt (𝓞 K) Q]
+    {σ : L ≃ₐ[K] L} (hσ : IsArithFrobAt (𝓞 K) σ Q) (τ : L ≃ₐ[M] L) :
+    IsArithFrobAt (𝓞 M) τ Q ↔
+      AlgEquiv.restrictScalars K τ = σ ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K) := by
+  refine ⟨restrictScalars_eq_pow_inertiaDeg hσ, fun h ↦ ?_⟩
+  obtain ⟨τ₀, hτ₀⟩ := exists_isArithFrobAt M Q hσ.ne_bot
+  have : τ = τ₀ := AlgEquiv.restrictScalars_injective K
+    (h.trans (restrictScalars_eq_pow_inertiaDeg hσ hτ₀).symm)
+  exact this ▸ hτ₀
+
+/-- **The tower formula for Mathlib's chosen Frobenius.** Mathlib's `arithFrobAt` picks a
+Frobenius coherently across the fibre above a prime of the base; at an unramified `Q` the choices
+over `𝓞 K` and over `𝓞 M` are related by the tower formula, because at such a `Q` there is
+nothing left to choose.
+
+This is the form the Artin symbol is built from, `NumberField.artinSymbol` being the conjugacy
+class of `arithFrobAt (𝓞 K) (L ≃ₐ[K] L)` at a prime above `𝔭`. -/
+theorem restrictScalars_arithFrobAt_eq_pow_inertiaDeg [IsGalois M L] (Q : Ideal (𝓞 L))
+    [Q.IsPrime] [Finite (𝓞 L ⧸ Q)] [Algebra.IsUnramifiedAt (𝓞 K) Q] :
+    AlgEquiv.restrictScalars K (arithFrobAt (𝓞 M) (L ≃ₐ[M] L) Q) =
+      arithFrobAt (𝓞 K) (L ≃ₐ[K] L) Q ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K) :=
+  restrictScalars_eq_pow_inertiaDeg (IsArithFrobAt.arithFrobAt (𝓞 K) (L ≃ₐ[K] L) Q)
+    (IsArithFrobAt.arithFrobAt (𝓞 M) (L ≃ₐ[M] L) Q)
+
+/-- **The tower formula, in the form the Artin symbol consumes.** For number fields `K ⊆ M ⊆ L`
+with `L / K` and `L / M` Galois, a prime `Q` of `𝓞 L` with `𝔓 = Q ∩ 𝓞 M` and `𝔭 = Q ∩ 𝓞 K`, and
+`𝔭` unramified in `L`, every arithmetic Frobenius `σ ∈ Gal(L/K)` at `Q` has `σ ^ f(𝔓/𝔭)` as the
+image in `Gal(L/K)` of an arithmetic Frobenius at `Q` in `Gal(L/M)`.
+
+The unramifiedness hypothesis is phrased for all primes above `𝔭`, matching the argument that
+`NumberField.artinSymbol` takes; only its value at `Q` is used. -/
+theorem exists_isArithFrobAt_pow_inertiaDeg [IsGalois M L] (Q : Ideal (𝓞 L)) [Q.IsPrime]
+    (𝔓 : Ideal (𝓞 M)) (𝔭 : Ideal (𝓞 K))
+    (hQM : Q.under (𝓞 M) = 𝔓) (hQK : Q.under (𝓞 K) = 𝔭)
+    (hur : ∀ (Q' : Ideal (𝓞 L)) [Q'.IsPrime] [Q'.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q')
+    (σ : L ≃ₐ[K] L) (hσ : IsArithFrobAt (𝓞 K) σ Q) :
+    ∃ τ : L ≃ₐ[M] L, IsArithFrobAt (𝓞 M) τ Q ∧
+      AlgEquiv.restrictScalars K τ = σ ^ 𝔓.inertiaDeg (𝓞 K) := by
+  subst hQM
+  subst hQK
+  have _ : Algebra.IsUnramifiedAt (𝓞 K) Q := hur Q
+  obtain ⟨τ, hτ⟩ := exists_isArithFrobAt M Q hσ.ne_bot
+  exact ⟨τ, hτ, restrictScalars_eq_pow_inertiaDeg hσ hτ⟩
+
+/-- **The power of the Frobenius fixes the intermediate field.** Even though `M / K` need not be
+normal, and `σ` therefore need not preserve `M`, its `f(𝔓/𝔭)`-th power fixes `M` pointwise: it is
+the image of an element of `Gal(L/M)`. -/
+theorem pow_inertiaDeg_apply_algebraMap [IsGalois M L] [Algebra.IsUnramifiedAt (𝓞 K) Q]
+    {σ : L ≃ₐ[K] L} (hσ : IsArithFrobAt (𝓞 K) σ Q) (y : M) :
+    (σ ^ (Q.under (𝓞 M)).inertiaDeg (𝓞 K)) (algebraMap M L y) = algebraMap M L y := by
+  obtain ⟨τ, hτ⟩ := exists_isArithFrobAt M Q hσ.ne_bot
+  rw [← restrictScalars_eq_pow_inertiaDeg hσ hτ]
+  exact τ.commutes y
+
+/-- **At residue degree one the Frobenius does not move.** If `𝔓 = Q ∩ 𝓞 M` has residue degree one
+over `𝓞 K`, then an arithmetic Frobenius of `Gal(L/M)` at `Q` is the arithmetic Frobenius of
+`Gal(L/K)` at `Q` itself, on the nose.
+
+This is the case a fixed-field fibre count runs through: it contracts the primes of `M` whose
+residue degree over `K` is one, exactly so that the relative Frobenius is the absolute one. -/
+theorem restrictScalars_eq_of_inertiaDeg_eq_one [Algebra.IsUnramifiedAt (𝓞 K) Q]
+    {σ : L ≃ₐ[K] L} (hσ : IsArithFrobAt (𝓞 K) σ Q)
+    {τ : L ≃ₐ[M] L} (hτ : IsArithFrobAt (𝓞 M) τ Q)
+    (hf : (Q.under (𝓞 M)).inertiaDeg (𝓞 K) = 1) :
+    AlgEquiv.restrictScalars K τ = σ := by
+  rw [restrictScalars_eq_pow_inertiaDeg hσ hτ, hf, pow_one]
+
+end NumberField

--- a/TauCeti/RingTheory/Frobenius.lean
+++ b/TauCeti/RingTheory/Frobenius.lean
@@ -10,9 +10,14 @@ public import Mathlib.RingTheory.Frobenius
 /-!
 # Frobenius elements for a group acting on a ring extension
 
-This file supplements Mathlib's `IsArithFrobAt` API with two facts about a group acting on a
-commutative ring extension `S/R`. Both are stated at ring level, so they are available
+This file supplements Mathlib's `IsArithFrobAt` API with facts about a monoid or group acting on
+a commutative ring extension `S/R`. All of them are stated at ring level, so they are available
 independently of any number-field or Legendre-symbol specialization.
+
+Two are properties of a single Frobenius element. The defining congruence has `#(R ⧸ Q ∩ R)` as
+its exponent, so it makes that residue ring finite and therefore forces `Q ≠ ⊥` over an infinite
+base. Iterating it `n` times replaces the exponent by its `n`-th power, which is what a Frobenius
+over an intermediate ring of residue degree `n` is required to satisfy.
 
 For an ideal `p` of `R`, an element `σ` of the acting group cuts out the set of primes of `S` above
 `p` that admit `σ` as an arithmetic Frobenius. These sets need not be disjoint: at a ramified prime
@@ -27,6 +32,10 @@ each of them, which again carries hypotheses of its own, such as those of
 
 * `IsArithFrobAt.eq_of_isUnramifiedAt` — a Frobenius element is unique for a faithful action at an
   unramified prime of a Noetherian ring whose prime complement consists of non-zero-divisors.
+* `IsArithFrobAt.ne_bot` — a prime carrying a Frobenius element over an infinite base ring is
+  nonzero.
+* `IsArithFrobAt.mk_pow_smul` — the `n`-th power of a Frobenius element acts on the residue ring
+  by the `q ^ n`-th power map.
 * `Ideal.nonempty_frobenius_fiber_equiv_of_isConj` — conjugate elements have equipotent fibers
   above a fixed ideal of the base, as a bijection between them.
 * `Ideal.frobenius_fiber_card_eq_of_isConj` — the `Nat.card` form of that equipotence.
@@ -80,6 +89,38 @@ theorem _root_.IsArithFrobAt.eq_of_isUnramifiedAt
     {σ τ : G} (hσ : _root_.IsArithFrobAt R σ Q) (hτ : _root_.IsArithFrobAt R τ Q) : σ = τ := by
   apply MulSemiringAction.toAlgHom_injective R S
   exact AlgHom.IsArithFrobAt.eq_of_isUnramifiedAt hσ hτ hQ
+
+/-- **A prime carrying an arithmetic Frobenius over an infinite base is nonzero.** The defining
+congruence has the cardinality of `R ⧸ Q ∩ R` as its exponent, so it forces that residue ring to
+be finite; over an infinite `R` this rules out `Q = ⊥`. -/
+theorem _root_.IsArithFrobAt.ne_bot {R S G : Type*} [CommRing R] [CommRing S] [Algebra R S]
+    [FaithfulSMul R S] [Infinite R] [Monoid G] [MulSemiringAction G S] [SMulCommClass G R S]
+    {Q : Ideal S} {σ : G} (H : _root_.IsArithFrobAt R σ Q) : Q ≠ ⊥ := by
+  rintro rfl
+  have hfin : Finite (R ⧸ Ideal.under R (⊥ : Ideal S)) := H.finite_quotient
+  rw [Ideal.under_bot] at hfin
+  have : Finite R := Finite.of_equiv _ (RingEquiv.quotientBot R).toEquiv
+  exact not_finite R
+
+/-- **Powers of an arithmetic Frobenius raise the exponent.** If `σ` is an arithmetic Frobenius at
+`Q`, then `σ ^ n` acts on the residue ring `S ⧸ Q` as the `q ^ n`-th power map, where
+`q = #(R ⧸ Q ∩ R)`.
+
+This is the congruence a tower formula rests on: over an intermediate ring whose prime below `Q`
+has residue ring of cardinality `q ^ n`, the `n`-th power of a Frobenius over the base satisfies
+the defining congruence of a Frobenius over that intermediate ring. -/
+theorem _root_.IsArithFrobAt.mk_pow_smul {R S G : Type*} [CommRing R] [CommRing S] [Algebra R S]
+    [Monoid G] [MulSemiringAction G S] [SMulCommClass G R S] {Q : Ideal S} {σ : G}
+    (H : _root_.IsArithFrobAt R σ Q) (n : ℕ) (x : S) :
+    Ideal.Quotient.mk Q ((σ ^ n) • x) =
+      Ideal.Quotient.mk Q x ^ Nat.card (R ⧸ Q.under R) ^ n := by
+  induction n generalizing x with
+  | zero => simp
+  | succ n ih =>
+    have hstep : Ideal.Quotient.mk Q (σ • x) =
+        Ideal.Quotient.mk Q x ^ Nat.card (R ⧸ Q.under R) := H.mk_apply x
+    rw [pow_succ, mul_smul, ih (σ • x), hstep, ← pow_mul]
+    ring
 
 variable {R S G : Type*} [CommRing R] [CommRing S] [Algebra R S] [Group G]
   [MulSemiringAction G S] [SMulCommClass G R S]


### PR DESCRIPTION
This PR proves the tower formula for arithmetic Frobenius elements, `exists_isArithFrobAt_pow_inertiaDeg`, the second of the two named functoriality theorems that Number Field Arithmetic's Layer 2.4 owes. For number fields `K ⊆ M ⊆ L` with `L/K` and `L/M` Galois and a prime `Q` of `𝓞 L` unramified over `𝓞 K`, an arithmetic Frobenius `τ ∈ Gal(L/M)` at `Q` is the `f(𝔓/𝔭)`-th power of an arithmetic Frobenius `σ ∈ Gal(L/K)` at `Q`, where `𝔓 = Q ∩ 𝓞 M` and `𝔭 = Q ∩ 𝓞 K`. The exponent is a power, the residue degree of the intermediate prime over the base, and never an inverse. Layer 2.4's other two names are already on `main` — `IsArithFrobAt.restrictNormal` (#5557) and `artinSymbol_map_restrictNormalHom` — so with this the layer's functoriality half is complete; what Number Field Arithmetic still owes after it is Layer 2.5, the ideal-theoretic Artin map `artinHomAway` and its carrier `idealsAway`.

<!--tauceti-target:v1 {"focus":"NumberFieldArithmetic","id":"exists-isarithfrobat-pow-inertiadeg"}-->

Roadmap: NumberFieldArithmetic

Consumer roadmap: Chebotarev

The dependency edge is explicit in both directions. Chebotarev's README lists `exists_isArithFrobAt_pow_inertiaDeg` in its "Number Field Arithmetic" dependency table with the contract "at one prime `Q` over `𝔓` over `𝔭`, an arithmetic Frobenius `σ` at `Q/𝔭` has `σ ^ f(𝔓/𝔭)` as the restriction of an arithmetic Frobenius at `Q/𝔓`", pins it in its conventions table as the "raising the base field" law, and consumes it by name in Layer 8.1, whose Layer 8.2 fibre count is the consumer milestone: "for `𝔭` unramified in `L` and `Q` above `𝔭` with `𝔓 = Q ∩ 𝓞 E`, the residue degree `f(𝔓/𝔭)` is the least `n ≥ 1` with `Frob_{L/K}(Q)^n ∈ ⟨σ⟩`. In particular `f(𝔓/𝔭) = 1` holds exactly when `Frob_{L/K}(Q) ∈ ⟨σ⟩`, and then 8.1 gives `Frob_{L/E}(𝔓) = Frob_{L/K}(Q)` on the nose." That last sentence is `NumberField.restrictScalars_eq_of_inertiaDeg_eq_one` below. From the supplier's side, Number Field Arithmetic's README ends its Layer 2.4 with "Both carry Lean names because the Chebotarev roadmap consumes them ... Their signatures are contracts", and `exists_isArithFrobAt_pow_inertiaDeg`'s signature here is the one its `Suggested.lean` pins, argument for argument.

The mathematics is short once the right uniqueness statement is available. Both `σ ^ f(𝔓/𝔭)` and the image of `τ` in `Gal(L/K)` stabilize `Q`, and both act on the residue field `𝓞 L ⧸ Q` by `x ↦ x ^ 𝔑𝔓`: for the second that is the defining congruence of `τ`, and for the first it is the defining congruence of `σ` iterated `f(𝔓/𝔭)` times, since `𝔑𝔓 = 𝔑𝔭 ^ f(𝔓/𝔭)`. At an unramified prime the decomposition group embeds into the automorphism group of the residue extension, so that pins the two elements to each other. In particular `σ ^ f(𝔓/𝔭)` fixes `M` pointwise, which is recorded separately as `pow_inertiaDeg_apply_algebraMap`; `M/K` is not assumed normal anywhere, and `σ` itself need not preserve `M`.

Both hypotheses the roadmap flags as load-bearing are respected. The theorem is stated relative to one prime `Q` of `L`, not for an arbitrary representative of the Artin class of `𝔭`: a conjugate representative need not stabilize `Q`, so its `f`-th power need not fix `M` pointwise and would be the restriction of no element of `Gal(L/M)` at all. And unramifiedness is not decoration — it is exactly what makes the residue action faithful, so it is where the proof spends it, not a hypothesis carried along unused. The module docstring records both, since a reader who weakens either gets a false statement rather than a harder one.

Three supporting facts are named rather than inlined, each in the file whose subject it is. `IsArithFrobAt.mk_pow_smul` and `IsArithFrobAt.ne_bot` go into `TauCeti/RingTheory/Frobenius.lean`, the file of ring-level supplements to Mathlib's `IsArithFrobAt`: the first says the `n`-th power of a Frobenius acts on the residue ring by the `q ^ n`-th power map, which is the whole arithmetic content of the tower formula and is stated for a monoid acting on any commutative ring extension; the second observes that the defining congruence makes `R ⧸ Q ∩ R` finite, so over an infinite base `Q ≠ ⊥` comes for free and no caller has to supply it. `Ideal.eq_of_smul_sub_smul_mem_of_isUnramifiedAt` goes into `Frobenius/DecompositionGroup.lean`, next to the injectivity of `Ideal.Quotient.stabilizerHom` it repackages; it differs from `NumberField.isArithFrobAt_eq_of_isUnramifiedAt` in not assuming either element is a Frobenius, which is precisely what comparing `σ ^ f` with `τ` needs.

The new file is `TauCeti/NumberTheory/NumberField/Frobenius/Tower.lean` (185 lines), beside `Frobenius/Restriction.lean`, which holds the other tower law; the two are the shrinking-the-top-field and raising-the-base-field halves of one subject and their docstrings cross-reference. Besides the pinned existence statement it carries the underlying equation for an arbitrary pair `σ`, `τ` (`restrictScalars_eq_pow_inertiaDeg`), the characterization of the relative Frobenius as exactly that power (`isArithFrobAt_iff_restrictScalars_eq_pow_inertiaDeg`, whose converse is uniqueness plus injectivity of `AlgEquiv.restrictScalars`, not a second computation), the specialization to Mathlib's coherently chosen `arithFrobAt` that the Artin symbol is built from, and the residue-degree-one corollary quoted above. No declaration is renamed, moved or deleted, and no existing proof changes.

Nothing here duplicates Mathlib. Untruncated greps over the pinned Mathlib for `pow_inertiaDeg` return only the norm identities `absNorm_pow_inertiaDeg`, `natAbs_pow_inertiaDeg` and `cardQuot_pow_inertiaDeg`, none of which mentions a Frobenius element; `restrictScalars` never occurs near `inertiaDeg`; and `mk_pow_smul` and an `IsArithFrobAt` `ne_bot` do not exist. Mathlib's `Ideal.cardQuot_pow_inertiaDeg` is what supplies `𝔑𝔓 = 𝔑𝔭 ^ f(𝔓/𝔭)`, and Mathlib's `AlgEquiv.restrictScalars_injective`, `Ideal.under_under` and `Ideal.under_bot` are used as they stand. No external source is adapted and no Mathlib infrastructure is vendored, so no `Provenance` line is owed.

🤖 Prepared with Claude Code
