### PR TITLE
refactor(Profinite): drop four `namespace` blocks that declare nothing

### DIFF
--- a/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Index.lean
@@ -51,8 +51,6 @@ open scoped ENat
 
 variable {G : Type*} [Group G] [TopologicalSpace G]
 
-namespace Subgroup
-
 /-- The **index of a subgroup of a profinite group**, as a supernatural number. At a prime
 `ℓ`, it is the supremum over open normal subgroups `N` of the `ℓ`-adic valuations of
 `[G/N : HN/N]`.
@@ -81,13 +79,9 @@ theorem _root_.Subgroup.profiniteIndex_top : Subgroup.profiniteIndex (⊤ : Subg
   simp_rw [Subgroup.profiniteIndex_apply, hmap]
   simp
 
-end Subgroup
-
 section Profinite
 
 variable [IsTopologicalGroup G] [CompactSpace G]
-
-namespace Subgroup
 
 /-- The supernatural index is equivalently the supremum of the ordinary positive indices of
 the images in finite continuous quotients. -/
@@ -185,10 +179,6 @@ theorem _root_.Subgroup.profiniteIndex_apply_eq_iSup_openSubgroup (H : Subgroup 
   funext U
   exact Supernatural.ofNat_apply _ _
 
-end Subgroup
-
-namespace OpenSubgroup
-
 /-- For an open subgroup, the supernatural index is the prime factorization of its ordinary
 index. -/
 @[simp]
@@ -217,10 +207,6 @@ theorem _root_.OpenSubgroup.profiniteIndex_apply_eq_padicValNat (U : OpenSubgrou
   exact Supernatural.ofNat_apply
     (⟨U.toSubgroup.index,
       Nat.zero_lt_of_ne_zero Subgroup.index_ne_zero_of_finite⟩ : ℕ+) ℓ
-
-end OpenSubgroup
-
-namespace Subgroup
 
 omit [CompactSpace G] in
 /-- Taking the topological closure of a subgroup does not change its supernatural index. -/
@@ -292,8 +278,6 @@ theorem _root_.Subgroup.profiniteIndex_eq_bot_iff (H : Subgroup G)
     (hH : IsClosed (H : Set G)) :
     Subgroup.profiniteIndex H = ⊥ ↔ H = ⊤ := by
   rw [← Supernatural.one_eq_bot, Subgroup.profiniteIndex_eq_one_iff H hH]
-
-end Subgroup
 
 end Profinite
 


### PR DESCRIPTION
`Profinite/Index.lean` declares 14 things, and **all 14** are written `_root_.Subgroup.…`
or `_root_.OpenSubgroup.…`. That placement is right — each takes a `Subgroup G` or
`OpenSubgroup G` as its first explicit argument, so it is dot-notation material on the
Mathlib type.

The file nevertheless wraps them in four blocks that every declaration inside escapes:

| lines | block |
|---|---|
| 54–84 | `namespace Subgroup` |
| 90–188 | `namespace Subgroup` |
| 190–221 | `namespace OpenSubgroup` |
| 223–296 | `namespace Subgroup` |

Nothing is placed in `TauCeti.Profinite.Subgroup` or `TauCeti.Profinite.OpenSubgroup`; the
wrappers only make the file read as though something were — the reading the `naming` rubric
objected to on #5579.

This is the same residue #5820 removed from the two `UnitaryGroup` files, left behind for the
same reason: the change that moved these declarations to `_root_` did not remove the blocks
around them.

**Resolution is unchanged.** References inside are already written in full, and nothing in the
repository names `TauCeti.Profinite.Subgroup`, `TauCeti.Profinite.OpenSubgroup`, or
`Subgroup.Subgroup`. The enclosing `namespace TauCeti` and `section Profinite` are untouched,
and `variable [TotallyDisconnectedSpace G]` is unaffected: its scope now ends at
`end Profinite` instead of `end Subgroup`, with no declaration in between.

Sixteen lines deleted, no other change.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp