### PR TITLE
fix: stop batching timeline queries; they come back truncated

### DIFF
--- a/scripts/pr_stats_graphs.py
+++ b/scripts/pr_stats_graphs.py
@@ -198,51 +198,27 @@ query($owner:String!, $name:String!, $number:Int!, $cursor:String) {
 """
 
 
-# Aliased pull requests in one query, so a cold walk costs a fiftieth of what it did. GitHub
-# prices a GraphQL request from the connection sizes it asks for, not from how many top-level
-# fields it has, and `pullRequest(number:)` is not a connection -- so fifty of them alongside
-# fifty 100-item timelines still scores one point, exactly what a single pull request cost
-# before. Measured against this repository: 25 and 50 aliases both cost 1, 100 costs 2.
+# DO NOT batch timeline queries by aliasing several `pullRequest` fields into one request.
 #
-# The old comment here said batching loses events. That is true of the OUTER pull-request page
-# query, whose nested timelines cannot be paged per node -- and it stays true; PR_PAGE_QUERY has
-# no timelineItems and a test enforces that. It is not true of aliases, which each carry their
-# own pageInfo and can be followed up individually. Anything reporting hasNextPage falls back to
-# the single-pull-request paginating query below, so depth is never silently truncated.
-TIMELINE_BATCH = 50
-TIMELINE_FIRST = 100
-
-TIMELINE_FRAGMENT = f"""
-fragment PrTimeline on PullRequest {{
-  mergedAt closedAt state isDraft
-  labels(first:30) {{ nodes {{ name }} }}
-  timelineItems(first:{TIMELINE_FIRST}, itemTypes:[LABELED_EVENT]) {{
-    pageInfo {{ hasNextPage }}
-    nodes {{ ... on LabeledEvent {{ createdAt label {{ name }} }} }}
-  }}
-}}
-"""
-
-
-def timeline_batch_query(numbers: list[int]) -> str:
-    """A query aliasing one `pullRequest` field per number.
-
-    The numbers are interpolated into the query text rather than passed as variables, because
-    GraphQL has no way to parameterise a field alias. They are required to be genuine ints
-    first: everything reaching here comes from the pull-request page query, so a non-int means a
-    bug rather than hostile input, but a query built by string-formatting is not the place to
-    find that out later.
-    """
-    for number in numbers:
-        if not isinstance(number, int) or isinstance(number, bool) or number < 0:
-            raise TypeError(f"pull request numbers must be non-negative ints, got {number!r}")
-    fields = "\n    ".join(f"p{number}: pullRequest(number:{number}) {{ ...PrTimeline }}"
-                            for number in numbers)
-    return (f"query($owner:String!, $name:String!) {{\n"
-            f"  repository(owner:$owner, name:$name) {{\n    {fields}\n  }}\n}}\n"
-            f"{TIMELINE_FRAGMENT}")
-
-
+# It is tempting, because GitHub prices a request from the connection sizes it asks for and fifty
+# aliases score the same single point as one. It was tried, and it silently returns INCOMPLETE
+# timelines. Measured against this repository on 2026-09-06: in a 50-alias batch, PR #1556 came
+# back with 2 label events and `hasNextPage: false`, where the paginating single-pull-request
+# query returns 4 -- the missing one being the `ci-failed` that the pull request currently
+# carries. Ten and twenty-five aliases happened to be complete for the same sample, and fifty was
+# not, so the limit depends on the total nodes a query asks for and cannot be pinned to a size.
+#
+# What makes it unusable rather than merely awkward is that `hasNextPage` is computed against the
+# truncated slice, so it reports false. There is no signal in the response to detect the loss
+# from, and `totalCount` counts unfiltered timeline items, so it cannot stand in for one either.
+# Silently dropping label events corrupts every lifecycle number downstream.
+#
+# The consistency guard in fetch_prs caught this within one deploy, which is the only reason it
+# was a failed Pages run rather than quietly wrong statistics. Keep that guard.
+#
+# The saving would have been small in any case. Reuse (see reusable_timelines) already takes a
+# normal run to a few dozen timelines, so batching them into one request saves tens of points out
+# of a run costing hundreds. It is not worth a class of error that has no detector.
 def timeline_from_node(pull: dict) -> dict:
     """The normalized timeline record, from either the batched or the single-PR query."""
     return {
@@ -299,54 +275,30 @@ def fetch_timeline(owner: str, name: str, number: int) -> dict:
 def fetch_timelines(
     owner: str, name: str, numbers: list[int], reusable: dict[int, dict] | None = None,
 ) -> tuple[dict[int, dict], int]:
-    """Current state and label timelines for `numbers`, as cheaply as correctness allows.
+    """Current state and label timelines, one paginating request per pull request.
 
-    Two things keep this proportional to the work rather than to the project. `reusable` maps a
-    number to a timeline recorded while the pull request had its current `updatedAt`, so nothing
-    that has not moved is fetched at all. What remains is fetched in batches of aliased pull
-    requests, which GitHub prices as one point per batch rather than one per pull request.
-
-    Together these took a full walk of this repository from about 4600 points -- against an
-    hourly budget of 5000, which it had already outgrown -- to under a hundred.
+    One request each is the only shape that has been shown to return complete timelines; see the
+    note above the batch query that used to live here. Cost is kept proportional to the work by
+    `reusable`, which maps a number to a timeline recorded while the pull request had its current
+    `updatedAt`, so nothing that has not moved is fetched at all. On a normal three-hourly run
+    that leaves a few dozen pull requests rather than every one the project has ever had.
 
     Returns the timelines and how many pull requests had to be fetched.
     """
     reusable = reusable or {}
     result = {}
-    outstanding = []
-    for number in numbers:
+    fetched = 0
+    for index, number in enumerate(numbers, start=1):
         cached = reusable.get(number)
         if cached is not None:
             result[number] = cached
-        else:
-            outstanding.append(number)
-
-    # Anything whose events did not fit in one batched page. Collected and handled afterwards so
-    # that a deep timeline costs one extra paginating fetch rather than shrinking the batch.
-    deep = []
-    for start in range(0, len(outstanding), TIMELINE_BATCH):
-        chunk = outstanding[start:start + TIMELINE_BATCH]
-        repository = graphql(
-            timeline_batch_query(chunk), owner=owner, name=name)["repository"]
-        for number in chunk:
-            pull = repository.get(f"p{number}")
-            if pull is None:
-                raise RuntimeError(f"GitHub returned no timeline for PR #{number}")
-            if pull["timelineItems"]["pageInfo"]["hasNextPage"]:
-                deep.append(number)
-                continue
-            result[number] = timeline_from_node(pull)
-        done = min(start + TIMELINE_BATCH, len(outstanding))
-        print(f"fetched {done:,} of {len(outstanding):,} PR timelines "
-              f"({len(numbers) - len(outstanding):,} reused)", file=sys.stderr)
-
-    for number in deep:
+            continue
         result[number] = fetch_timeline(owner, name, number)
-    if deep:
-        print(f"paged {len(deep):,} timeline(s) deeper than {TIMELINE_FIRST} events",
-              file=sys.stderr)
-
-    return result, len(outstanding)
+        fetched += 1
+        if fetched % 100 == 0 or index == len(numbers):
+            print(f"fetched {fetched:,} PR timelines "
+                  f"({len(numbers) - fetched:,} reused of {len(numbers):,})", file=sys.stderr)
+    return result, fetched
 
 
 def reusable_timelines(previous: dict | None, prs: list[dict]) -> dict[int, dict]:

--- a/scripts/test_pr_stats_graphs.py
+++ b/scripts/test_pr_stats_graphs.py
@@ -61,7 +61,7 @@ class MetricsTest(unittest.TestCase):
         self.assertIn("pullRequests(first:100", stats.PR_PAGE_QUERY)
         self.assertNotIn("timelineItems", stats.PR_PAGE_QUERY)
 
-    def test_a_timeline_too_deep_for_the_batch_falls_back_to_paging(self):
+    def test_direct_label_timeline_pagination_is_not_truncated(self):
         first_page = {
             "repository": {"pullRequests": {
                 "pageInfo": {"hasNextPage": False, "endCursor": None},
@@ -72,16 +72,6 @@ class MetricsTest(unittest.TestCase):
                     "author": {"login": "alice"}, "labels": {"nodes": []},
                 }],
             }},
-        }
-        # The batch answers for #42 but says there is more, so it must be re-fetched with the
-        # paginating query rather than silently keeping this first page.
-        batch = {
-            "repository": {"p42": {"timelineItems": {
-                "pageInfo": {"hasNextPage": True},
-                "nodes": [{"createdAt": timestamp(2),
-                           "label": {"name": "truncated-and-must-not-be-used"}}],
-            }, "mergedAt": None, "closedAt": None, "state": "OPEN",
-                "isDraft": False, "labels": {"nodes": []}}},
         }
         timeline_page = {
             "repository": {"pullRequest": {"timelineItems": {
@@ -102,7 +92,7 @@ class MetricsTest(unittest.TestCase):
         }
         with patch.object(
             stats, "graphql",
-            side_effect=[first_page, batch, timeline_page, timeline_extra],
+            side_effect=[first_page, timeline_page, timeline_extra],
         ):
             prs = stats.fetch_prs("example/project")
         self.assertEqual(
@@ -125,8 +115,8 @@ class MetricsTest(unittest.TestCase):
             }},
         }
         direct = {
-            "repository": {"p42": {"timelineItems": {
-                "pageInfo": {"hasNextPage": False},
+            "repository": {"pullRequest": {"timelineItems": {
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
                 "nodes": [
                     {"createdAt": timestamp(min(index + 1, 14)),
                      "label": {"name": "awaiting-review"}}
@@ -158,67 +148,53 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(prs[0]["labeled_events"], [])
         self.assertEqual(graphql.call_count, 1)
 
-    # --- batched timeline fetching -----------------------------------------------------------
+    # --- timelines are fetched one at a time, on purpose --------------------------------------
     #
-    # GitHub prices a GraphQL request from the connection sizes it asks for, so fifty aliased
-    # pull requests cost the same one point as a single one. That is the difference between a
-    # full walk of this repository costing ~4600 points against an hourly budget of 5000, and
-    # costing under a hundred. These tests hold the batching to its two obligations: actually
-    # batch, and never silently truncate a timeline that did not fit.
+    # Aliasing several pull requests into one GraphQL request is much cheaper and silently
+    # returns incomplete timelines. Measured on 2026-09-06: in a 50-alias batch PR #1556 came
+    # back with 2 label events and `hasNextPage: false` where the paginating query returns 4,
+    # the missing one being its current `ci-failed`. Smaller batches were complete for that
+    # sample, so the limit follows total requested nodes and cannot be pinned to a size, and
+    # `hasNextPage` is computed against the truncated slice so nothing in the response reveals
+    # the loss. This test exists so the optimisation cannot be reintroduced without meeting it.
 
-    @staticmethod
-    def batch_reply(numbers, events=1, has_next=False):
-        return {"repository": {f"p{n}": {
-            "mergedAt": None, "closedAt": None, "state": "OPEN", "isDraft": False,
-            "labels": {"nodes": []},
-            "timelineItems": {"pageInfo": {"hasNextPage": has_next},
+    def test_each_pull_request_gets_its_own_query(self):
+        numbers = [1, 2, 3]
+        reply = {"repository": {"pullRequest": {
+            "timelineItems": {"pageInfo": {"hasNextPage": False, "endCursor": None},
                               "nodes": [{"createdAt": timestamp(2),
-                                         "label": {"name": "awaiting-review"}}] * events},
-        } for n in numbers}}
-
-    def test_timelines_are_fetched_in_batches_not_one_by_one(self):
-        numbers = list(range(1, 121))
-        replies = [self.batch_reply(numbers[i:i + stats.TIMELINE_BATCH])
-                   for i in range(0, len(numbers), stats.TIMELINE_BATCH)]
-        with patch.object(stats, "graphql", side_effect=replies) as graphql:
+                                         "label": {"name": "awaiting-review"}}]},
+            "mergedAt": None, "closedAt": None, "state": "OPEN", "isDraft": False,
+            "labels": {"nodes": [{"name": "awaiting-review"}]}}}}
+        with patch.object(stats, "graphql", return_value=reply) as graphql:
             result, fetched = stats.fetch_timelines("o", "n", numbers)
-        # 120 pull requests in batches of 50 is three requests, not 120.
         self.assertEqual(graphql.call_count, 3)
-        self.assertEqual(fetched, 120)
-        self.assertEqual(len(result), 120)
+        self.assertEqual(fetched, 3)
+        self.assertEqual(len(result), 3)
+        # Each call names exactly one pull request.
+        for call in graphql.call_args_list:
+            self.assertIn("number", call.kwargs)
 
-    def test_reused_pull_requests_are_left_out_of_the_batches(self):
-        numbers = list(range(1, 61))
-        reusable = {n: {"merged_at": None, "closed_at": None, "state": "OPEN",
-                        "is_draft": False, "labels": [], "labeled_events": []}
-                    for n in numbers[:55]}
-        with patch.object(stats, "graphql",
-                          side_effect=[self.batch_reply(numbers[55:])]) as graphql:
+    def test_the_module_defines_no_alias_batching_helper(self):
+        for name in ("timeline_batch_query", "TIMELINE_BATCH"):
+            self.assertFalse(
+                hasattr(stats, name),
+                f"{name} is back. Aliased batching returns silently truncated timelines with "
+                "hasNextPage false; read the note above fetch_timeline before reinstating it.")
+
+    def test_reused_pull_requests_are_not_fetched(self):
+        numbers = [1, 2, 3]
+        reusable = {1: {"merged_at": None, "closed_at": None, "state": "OPEN",
+                        "is_draft": False, "labels": [], "labeled_events": []}}
+        reply = {"repository": {"pullRequest": {
+            "timelineItems": {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": []},
+            "mergedAt": None, "closedAt": None, "state": "OPEN", "isDraft": False,
+            "labels": {"nodes": []}}}}
+        with patch.object(stats, "graphql", return_value=reply) as graphql:
             result, fetched = stats.fetch_timelines("o", "n", numbers, reusable)
-        # Five left to fetch, so one batch -- not two, and not one per pull request.
-        self.assertEqual(graphql.call_count, 1)
-        self.assertEqual(fetched, 5)
-        self.assertEqual(len(result), 60)
-
-    def test_the_batch_query_aliases_every_number_and_asks_for_full_depth(self):
-        query = stats.timeline_batch_query([7, 9])
-        self.assertIn("p7: pullRequest(number:7)", query)
-        self.assertIn("p9: pullRequest(number:9)", query)
-        self.assertIn(f"timelineItems(first:{stats.TIMELINE_FIRST}", query)
-        # Owner and name stay variables; only the numbers are interpolated.
-        self.assertIn("$owner:String!", query)
-
-    def test_the_batch_query_refuses_anything_but_an_int(self):
-        # The query is built by string formatting, so this is the one place that can check.
-        for bad in ["1", 1.0, True, -1, None]:
-            with self.subTest(value=bad):
-                with self.assertRaises(TypeError):
-                    stats.timeline_batch_query([bad])
-
-    def test_a_missing_alias_is_an_error_not_a_silently_dropped_pr(self):
-        with patch.object(stats, "graphql", return_value={"repository": {"p1": None}}):
-            with self.assertRaisesRegex(RuntimeError, "no timeline for PR #1"):
-                stats.fetch_timelines("o", "n", [1])
+        self.assertEqual(graphql.call_count, 2)
+        self.assertEqual(fetched, 2)
+        self.assertEqual(len(result), 3)
 
     # --- incremental snapshots -------------------------------------------------------------
     #
@@ -261,8 +237,8 @@ class MetricsTest(unittest.TestCase):
         # The snapshot was taken when the PR last changed on day 2; it has changed since.
         previous = self.snapshot_with(
             timestamp(2), [{"created_at": timestamp(2), "label": "awaiting-review"}])
-        direct = {"repository": {"p42": {
-            "timelineItems": {"pageInfo": {"hasNextPage": False},
+        direct = {"repository": {"pullRequest": {
+            "timelineItems": {"pageInfo": {"hasNextPage": False, "endCursor": None},
                               "nodes": [{"createdAt": timestamp(3),
                                          "label": {"name": "awaiting-review"}}]},
             "mergedAt": None, "closedAt": None, "state": "OPEN", "isDraft": False,


### PR DESCRIPTION
This PR reverts the aliased timeline batching from #5832, which silently returns incomplete label timelines.

The first Pages run to use it failed: the consistency guard in `fetch_prs` refused a pull request whose current `ci-failed` label had no matching timeline event, which stopped the statistics step and with it the snapshot and `pipeline-health.json`.

Measured against this repository. In a 50-alias batch, PR #1556 comes back with 2 label events and `hasNextPage: false`, where the paginating single-pull-request query returns 4, the missing one being the `ci-failed` it currently carries. Ten and twenty-five aliases were complete for the same sample and fifty was not, so the limit follows the total nodes a query asks for rather than the number of aliases, and cannot be pinned to a safe batch size. What makes it unusable rather than merely awkward is that `hasNextPage` is computed against the truncated slice, so it reports false; `totalCount` counts unfiltered timeline items, so it cannot serve as a check either. There is no signal in the response to detect the loss from.

The comment this optimisation replaced said batching loses events. It was right, and about aliases too, not only about the outer page query. Restore one paginating request per pull request, and pin the decision with a test, because the failure mode is silent corruption of every lifecycle number rather than an error.

Little is given up. Reuse from #5828 already takes a normal run to a few dozen timelines: run 34021810881 fetched 48 and reused 4512, so batching them saved tens of points out of a run costing hundreds. The incremental scoreboard scan from #5832 is untouched.

Verified against the two pull requests that triggered the failure, #1556 and #4987: both now return complete timelines with every current state label backed by an event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)