### PR TITLE
docs(Huber): document the equivalence, not what simp does with it

### DIFF
--- a/TauCeti/RingTheory/Huber/Completion.lean
+++ b/TauCeti/RingTheory/Huber/Completion.lean
@@ -510,10 +510,7 @@ theorem isPowerBounded_of_isPowerBounded_completion_coe [IsHuberRing A] {a : A}
   exact isBounded_of_isBounded_image_completion_coe ha
 
 /-- **Wedhorn Lemma 7.47(1), at the level of elements: `A⁰` is the preimage of `Â⁰`.** An element of
-`A` is power-bounded exactly when its image in the completion is.
-
-`@[simp]` so that a power-boundedness goal in a completion is reduced to one in `A`, where the
-unconditional facts about the generators of a restricted power-series ring can close it. -/
+`A` is power-bounded exactly when its image in the completion is. -/
 @[simp]
 theorem isPowerBounded_completion_coe_iff [IsHuberRing A] {a : A} :
     IsPowerBounded ((a : Completion A)) ↔ IsPowerBounded a :=


### PR DESCRIPTION
`TauCeti.Huber.isPowerBounded_completion_coe_iff` loses the second paragraph of its docstring:

```text
`@[simp]` so that a power-boundedness goal in a completion is reduced to one in `A`, where the
unconditional facts about the generators of a restricted power-series ring can close it.
```

That describes what `simp` does with the lemma, not what the lemma says. The first sentence — that
this is Wedhorn Lemma 7.47(1) at the level of elements, so `A⁰` is the preimage of `Â⁰` — already
documents the result, and the `@[simp]` attribute is visible directly above the statement.

Roadmap: AdicSpaces

Improving already-merged code needs no roadmap entry; the area named above is the one the work
serves. No `tauceti-target` marker: this authors no target.

## Why it is its own PR

The paragraph came in with #5781 and has been flagged twice since. The `documentation` rubric asked
for its removal on #5783, where it was in scope at the time because that PR still carried the
`@[simp]` attribute itself. #5781 then merged, #5783 was rebased, and the deletion became the only
thing left of `Huber/Completion.lean` in a diff otherwise about the iteration isomorphism — at which
point the `scope` rubric blocked #5783 over it and said, verbatim:

> Revert this hunk or move the documentation change to a separate PR.

This is that separate PR. #5783 has reverted its copy, so the two do not collide.

**Acknowledged overlap:** #5798 also touches `TauCeti/RingTheory/Huber/Completion.lean`, but only
its import line — `Nonarchimedean.Completion` becomes `Nonarchimedean.Completion.Basic` at line 8,
several hundred lines from this docstring. The two hunks do not conflict, and whichever lands first
the other rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
