### PR TITLE
refactor(HeckeRing): name the two base cases of the prime-power recurrence

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean
@@ -142,20 +142,20 @@ private lemma heckeT_prime_pow_recurrence_step (k : ℕ) (hk_pos : 0 < k)
   linear_combination (norm := module) -h5
 
 include hp in
-/-- The prime-power recurrence at `k = 1`: `T(p²) = T(p)² − p · T(p,p)`. The base case is
-separate because the telescoping identity behind the general step degenerates here — the
-coefficient of `T(p,p)` arrives as `p + 1` rather than `p`, the extra unit cancelling against
-`T(p⁰) = 1`. -/
-private lemma heckeT_prime_pow_recurrence_base_one :
+/-- The prime-power recurrence at `k = 1`: `T(p²) = T(p)² − p · T(p,p)`. -/
+private lemma heckeT_prime_pow_recurrence_one :
     heckeT ⟨p ^ (1 + 1), pow_pos hp.pos (1 + 1)⟩ =
       heckeT ⟨p, hp.pos⟩ * heckeT ⟨p ^ 1, pow_pos hp.pos 1⟩ -
         (p : ℤ) • (heckeTScalar p * heckeT ⟨p ^ (1 - 1), pow_pos hp.pos (1 - 1)⟩) := by
   have h5 := heckeT_prime_mul_heckeTDiag_one_prime_pow p hp 1
   rw [heckeTDiag_p_prime_pow_eq p 1 (by omega)] at h5
   have h2 := heckeTDiag_one_prime_pow_eq p hp (1 + 1) (by omega)
+  -- `heckeTDiag_one_prime_pow_eq` spells the exponent `(k + 1) - 2`, while `h5` and the goal
+  -- carry it as `k - 1`. Equal, but not syntactically so: normalising either side to the
+  -- numeral instead leaves the `rw [h2] at h5` below with no matching pattern.
   conv at h2 => rhs; rw [show (1 + 1) - 2 = 1 - 1 by omega]
   rw [h2] at h5
-  simp only [show (1 : ℕ) - 1 = 0 from rfl, ite_true] at h5 ⊢
+  simp only [Nat.sub_self, ite_true] at h5 ⊢
   rw [heckeT_prime_pow_zero p hp, pow_zero, heckeTDiag_one_one, mul_one] at h5
   rw [heckeT_prime_pow_zero p hp, mul_one, heckeT_prime_pow_one p hp]
   rw [heckeTDiag_one_prime_pow_one, heckeT_prime p hp] at h5
@@ -164,22 +164,25 @@ private lemma heckeT_prime_pow_recurrence_base_one :
   linear_combination (norm := module) -h5
 
 include hp in
-/-- The prime-power recurrence at `k = 2`: `T(p³) = T(p) · T(p²) − p · T(p,p) · T(p)`. Still
-separate from the general step, because the telescoped difference bottoms out at `T(p⁰)` and
-the scalar operator has to be commuted past `T(1,p)` by hand. -/
-private lemma heckeT_prime_pow_recurrence_base_two :
+/-- The prime-power recurrence at `k = 2`: `T(p³) = T(p) · T(p²) − p · T(p,p) · T(p)`. -/
+private lemma heckeT_prime_pow_recurrence_two :
     heckeT ⟨p ^ (2 + 1), pow_pos hp.pos (2 + 1)⟩ =
       heckeT ⟨p, hp.pos⟩ * heckeT ⟨p ^ 2, pow_pos hp.pos 2⟩ -
         (p : ℤ) • (heckeTScalar p * heckeT ⟨p ^ (2 - 1), pow_pos hp.pos (2 - 1)⟩) := by
   have h5 := heckeT_prime_mul_heckeTDiag_one_prime_pow p hp 2
   rw [heckeTDiag_p_prime_pow_eq p 2 (by omega)] at h5
   have h2 := heckeTDiag_one_prime_pow_eq p hp (2 + 1) (by omega)
+  -- as at `k = 1`: the exponent must be respelled the way `h5` writes it, since normalising
+  -- to the numeral leaves the `rw [h2] at h5` below with no matching pattern.
   conv at h2 => rhs; rw [show (2 + 1) - 2 = 2 - 1 by omega]
   rw [h2] at h5
+  -- the multiplicity carries an `if k = 1` guard that has to be discharged before the
+  -- exponent can be reduced; the numeral simprocs (`Nat.reduceSub`, `reduceIte`) do both at
+  -- once and over-reduce, leaving the closing `linear_combination` shapes `ring` cannot match
   simp only [show (2 : ℕ) ≠ 1 by omega, ite_false, show (2 : ℕ) - 1 = 1 by omega] at h5 ⊢
   rw [heckeTDiag_one_prime_pow_eq p hp 2 (by omega)] at h5
   rw [mul_sub] at h5
-  simp only [show 2 - 2 = 0 from rfl] at h5 ⊢
+  simp only [Nat.sub_self] at h5 ⊢
   rw [heckeT_prime_pow_zero p hp, mul_one, heckeTDiag_one_prime_pow_one, heckeT_prime p hp] at h5
   rw [heckeT_prime_pow_one p hp] at h5 ⊢
   rw [heckeT_prime p hp] at h5 ⊢
@@ -202,9 +205,9 @@ theorem heckeT_prime_pow_recurrence : ∀ k : ℕ, 0 < k →
   rcases k with _ | k
   · omega
   rcases k with _ | k
-  · exact heckeT_prime_pow_recurrence_base_one p hp
+  · exact heckeT_prime_pow_recurrence_one p hp
   rcases k with _ | k
-  · exact heckeT_prime_pow_recurrence_base_two p hp
+  · exact heckeT_prime_pow_recurrence_two p hp
   · exact heckeT_prime_pow_recurrence_step p hp (k + 1) (by omega) ih
 
 section Centrality

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean
@@ -142,6 +142,52 @@ private lemma heckeT_prime_pow_recurrence_step (k : ℕ) (hk_pos : 0 < k)
   linear_combination (norm := module) -h5
 
 include hp in
+/-- The prime-power recurrence at `k = 1`: `T(p²) = T(p)² − p · T(p,p)`. The base case is
+separate because the telescoping identity behind the general step degenerates here — the
+coefficient of `T(p,p)` arrives as `p + 1` rather than `p`, the extra unit cancelling against
+`T(p⁰) = 1`. -/
+private lemma heckeT_prime_pow_recurrence_base_one :
+    heckeT ⟨p ^ (1 + 1), pow_pos hp.pos (1 + 1)⟩ =
+      heckeT ⟨p, hp.pos⟩ * heckeT ⟨p ^ 1, pow_pos hp.pos 1⟩ -
+        (p : ℤ) • (heckeTScalar p * heckeT ⟨p ^ (1 - 1), pow_pos hp.pos (1 - 1)⟩) := by
+  have h5 := heckeT_prime_mul_heckeTDiag_one_prime_pow p hp 1
+  rw [heckeTDiag_p_prime_pow_eq p 1 (by omega)] at h5
+  have h2 := heckeTDiag_one_prime_pow_eq p hp (1 + 1) (by omega)
+  conv at h2 => rhs; rw [show (1 + 1) - 2 = 1 - 1 by omega]
+  rw [h2] at h5
+  simp only [show (1 : ℕ) - 1 = 0 from rfl, ite_true] at h5 ⊢
+  rw [heckeT_prime_pow_zero p hp, pow_zero, heckeTDiag_one_one, mul_one] at h5
+  rw [heckeT_prime_pow_zero p hp, mul_one, heckeT_prime_pow_one p hp]
+  rw [heckeTDiag_one_prime_pow_one, heckeT_prime p hp] at h5
+  rw [heckeT_prime p hp]
+  rw [add_smul, one_smul] at h5
+  linear_combination (norm := module) -h5
+
+include hp in
+/-- The prime-power recurrence at `k = 2`: `T(p³) = T(p) · T(p²) − p · T(p,p) · T(p)`. Still
+separate from the general step, because the telescoped difference bottoms out at `T(p⁰)` and
+the scalar operator has to be commuted past `T(1,p)` by hand. -/
+private lemma heckeT_prime_pow_recurrence_base_two :
+    heckeT ⟨p ^ (2 + 1), pow_pos hp.pos (2 + 1)⟩ =
+      heckeT ⟨p, hp.pos⟩ * heckeT ⟨p ^ 2, pow_pos hp.pos 2⟩ -
+        (p : ℤ) • (heckeTScalar p * heckeT ⟨p ^ (2 - 1), pow_pos hp.pos (2 - 1)⟩) := by
+  have h5 := heckeT_prime_mul_heckeTDiag_one_prime_pow p hp 2
+  rw [heckeTDiag_p_prime_pow_eq p 2 (by omega)] at h5
+  have h2 := heckeTDiag_one_prime_pow_eq p hp (2 + 1) (by omega)
+  conv at h2 => rhs; rw [show (2 + 1) - 2 = 2 - 1 by omega]
+  rw [h2] at h5
+  simp only [show (2 : ℕ) ≠ 1 by omega, ite_false, show (2 : ℕ) - 1 = 1 by omega] at h5 ⊢
+  rw [heckeTDiag_one_prime_pow_eq p hp 2 (by omega)] at h5
+  rw [mul_sub] at h5
+  simp only [show 2 - 2 = 0 from rfl] at h5 ⊢
+  rw [heckeT_prime_pow_zero p hp, mul_one, heckeTDiag_one_prime_pow_one, heckeT_prime p hp] at h5
+  rw [heckeT_prime_pow_one p hp] at h5 ⊢
+  rw [heckeT_prime p hp] at h5 ⊢
+  rw [HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
+    (transposeAntiInvolution_onHeckeCoset_eq_self 2) (heckeTDiag 1 p) (heckeTScalar p)] at h5
+  linear_combination (norm := module) -h5
+
+include hp in
 /-- **Shimura, Theorem 3.24(4)** — the prime-power recurrence:
 `T(p^(k+1)) = T(p) · T(pᵏ) − p · T(p,p) · T(p^(k−1))` for `k ≥ 1`, which determines every
 `T(pᵏ)` from `T(p)` and the scalar operator. -/
@@ -153,33 +199,12 @@ theorem heckeT_prime_pow_recurrence : ∀ k : ℕ, 0 < k →
   induction k using Nat.strongRecOn with
   | _ k ih =>
   intro hk
-  have h5 := heckeT_prime_mul_heckeTDiag_one_prime_pow p hp k
-  rw [heckeTDiag_p_prime_pow_eq p k hk] at h5
-  have h2 := heckeTDiag_one_prime_pow_eq p hp (k + 1) (by omega)
-  conv at h2 => rhs; rw [show (k + 1) - 2 = k - 1 by omega]
-  rw [h2] at h5
   rcases k with _ | k
   · omega
   rcases k with _ | k
-  · simp only [show (1 : ℕ) - 1 = 0 from rfl, ite_true] at h5 ⊢
-    rw [heckeT_prime_pow_zero p hp, pow_zero, heckeTDiag_one_one, mul_one] at h5
-    rw [heckeT_prime_pow_zero p hp, mul_one, heckeT_prime_pow_one p hp]
-    rw [heckeTDiag_one_prime_pow_one, heckeT_prime p hp] at h5
-    rw [heckeT_prime p hp]
-    -- split the `k = 1` coefficient `p + 1` into `p` and the unit
-    rw [add_smul, one_smul] at h5
-    linear_combination (norm := module) -h5
+  · exact heckeT_prime_pow_recurrence_base_one p hp
   rcases k with _ | k
-  · simp only [show (2 : ℕ) ≠ 1 by omega, ite_false, show (2 : ℕ) - 1 = 1 by omega] at h5 ⊢
-    rw [heckeTDiag_one_prime_pow_eq p hp 2 (by omega)] at h5
-    rw [mul_sub] at h5
-    simp only [show 2 - 2 = 0 from rfl] at h5 ⊢
-    rw [heckeT_prime_pow_zero p hp, mul_one, heckeTDiag_one_prime_pow_one, heckeT_prime p hp] at h5
-    rw [heckeT_prime_pow_one p hp] at h5 ⊢
-    rw [heckeT_prime p hp] at h5 ⊢
-    rw [HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
-      (transposeAntiInvolution_onHeckeCoset_eq_self 2) (heckeTDiag 1 p) (heckeTScalar p)] at h5
-    linear_combination (norm := module) -h5
+  · exact heckeT_prime_pow_recurrence_base_two p hp
   · exact heckeT_prime_pow_recurrence_step p hp (k + 1) (by omega) ih
 
 section Centrality


### PR DESCRIPTION
`heckeT_prime_pow_recurrence` — Shimura's Theorem 3.24(4) — was 52 lines, over the
proof-length cap. It is a strong induction, and the file had already named its
general case:

```
heckeT_prime_pow_recurrence_step (k : ℕ) (hk_pos : 0 < k) (ih : …) : …
```

The two base cases had not been named. They sat inline at about ten lines apiece,
reached through a shared `h5`/`h2` preamble that existed only to serve them — the
general case was never given it, because `_step` derives its own.

### What the base cases are

They are separate for a mathematical reason, not a bookkeeping one. The
telescoping identity behind the general step degenerates at small `k`:

* at `k = 1` the coefficient of `T(p,p)` arrives as `p + 1` rather than `p`, and
  the extra unit has to cancel against `T(p⁰) = 1`;
* at `k = 2` the telescoped difference bottoms out at `T(p⁰)`, and the scalar
  operator has to be commuted past `T(1,p)` by hand.

They are now `heckeT_prime_pow_recurrence_base_one` and `_base_two`, each
deriving its own preamble exactly as `_step` does, so the three cases of the
induction are three lemmas of the same shape. Each takes only `p` and `hp`; the
preamble leaves the theorem entirely, because nothing else used it.

### What is left

`omega` at `k = 0`, then one `exact` per case. 52 lines to 31, and
`GL2/Recurrence.lean` is clear of the cap.

### Provenance

Nothing to adapt here. AINTLIB *defines* `heckeT_ppow` by this recurrence —
`heckeT_ppow_succ_succ` is documented there as "the prime-power recurrence
(definitional)", following Diamond–Shurman (5.10) — so it has no base cases to
prove. This repository proves the recurrence from the multiplication table
instead, which is exactly where the two degenerate cases come from.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
