### PR TITLE
feat: add formations and their finite normal layers

### DIFF
--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -92,6 +92,9 @@ equal.
 * E. Artin and J. Tate, *Class Field Theory*, Chapter XIV.
 * J. Neukirch, *Class Field Theory*, Chapter III.
 * J.-P. Serre, *Local Fields*, Chapter XI.
+* `Suggested.lean` of the TauCeti `ClassFieldTheory` roadmap, the blueprint whose signatures for
+  the two structures below and for the level, layer representation and norm constructions this
+  file follows.
 -/
 
 public noncomputable section
@@ -318,6 +321,12 @@ def groundLevelEquiv : (L.rep F).ρ.invariants ≃ₗ[ℤ] F.level L.ground :=
 theorem groundLevelEquiv_apply_coe (x : (L.rep F).ρ.invariants) :
     ((L.groundLevelEquiv F x : F.level L.ground) : F.toRep.V) = ((x : F.level L.top) :
       F.toRep.V) :=
+  (rfl)
+
+@[simp]
+theorem groundLevelEquiv_symm_apply_coe (y : F.level L.ground) :
+    ((((L.groundLevelEquiv F).symm y : (L.rep F).ρ.invariants) : F.level L.top) : F.toRep.V) =
+      (y : F.toRep.V) :=
   (rfl)
 
 end Coefficients

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -21,9 +21,9 @@ topological formulation: a `Formation` is a smooth discrete topological represen
 
 A **finite normal layer** is a pair of open subgroups `V ≤ U` with `V` normal in `U`. In field
 notation it is the layer `K/F` with `U = G_F` and `V = G_K`. Its Galois group `Γ = U ⧸ V` is
-finite as soon as `G` is compact, its coefficient module is the level `A^V`, and its ground level
-is `A^U`. The three constructions below are what the cohomology of the layer is taken of and
-compared with:
+finite because `V` is open in the compact group `U`, its coefficient module is the level `A^V`,
+and its ground level is `A^U`. The three constructions below are what the cohomology of the layer
+is taken of and compared with:
 
 * `rep`, the coefficient module `A^V` carrying the action of `Γ`. The `U`-action on `A^V` is well
   defined because `V` is normal in `U`, and `V` acts on `A^V` trivially, so the action descends to
@@ -67,9 +67,11 @@ The coefficient module is built as `Representation.ofQuotient` of a
 restriction of `A` along `V ∩ U → U → G`, which is the same submodule of the ambient module but
 not the same term as `A^V`, and every later comparison would have to transport along that equality.
 
-Compactness of `G` is not a field of `Formation`: it is assumed exactly where the finiteness of a
-layer's Galois group is used, so that the constructions above are available for an arbitrary
-topological group.
+The group `G` is profinite — a compact, totally disconnected topological group — and both
+`Formation` and `NormalLayer` carry those hypotheses. They are what makes the family of open
+subgroups the distinguished family of the Artin–Tate definition, with the open subgroups a
+neighbourhood basis of `1`, and what makes the Galois group of every layer finite, so that the
+`degree` of a layer is its genuine index and not the junk value `0` of an infinite quotient.
 
 Both the group and the coefficient module live in `Type`. Mathlib's `tateCohomology` asks for the
 finite group and the coefficient ring `ℤ` in one universe and for the coefficient module in that
@@ -99,12 +101,13 @@ attribute [local instance] TopRep.distribMulAction TopRep.smulCommClass
 
 /-! ### Formations and their levels -/
 
-/-- A **formation**: a smooth discrete continuous integral representation of a topological group.
+/-- A **formation**: a smooth discrete continuous integral representation of a profinite group.
 In the arithmetic applications `G` is the Galois group of a Galois extension and the module is the
 multiplicative group of the top field, read additively. The distinguished family of subgroups of
 the Artin–Tate definition is the family of open subgroups of `G`, which is why the levels below
 are indexed by `OpenSubgroup G`. -/
-structure Formation (G : Type) [Group G] [TopologicalSpace G] where
+structure Formation (G : Type) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+    [CompactSpace G] [TotallyDisconnectedSpace G] where
   /-- the coefficient module of the formation, a topological representation of `G` over `ℤ` -/
   module : TopRep.{0} ℤ G
   /-- the coefficient module is discrete with open point stabilizers, so that every element is
@@ -113,7 +116,8 @@ structure Formation (G : Type) [Group G] [TopologicalSpace G] where
 
 namespace Formation
 
-variable {G : Type} [Group G] [TopologicalSpace G] (F : Formation G)
+variable {G : Type} [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
+  [TotallyDisconnectedSpace G] (F : Formation G)
 
 /-- The coefficient module of a formation as a plain integral representation of `G`, forgetting
 its topology. The levels, the layer representations and all of their cohomology are taken of this
@@ -155,7 +159,8 @@ end Formation
 /-- A **finite normal layer** `V ◁ U` of open subgroups of `G`. In field notation this is the
 finite Galois layer `K/F` inside the extension `G` cuts out, with `U = G_F` the ground subgroup and
 `V = G_K` the top subgroup. -/
-structure NormalLayer (G : Type) [Group G] [TopologicalSpace G] where
+structure NormalLayer (G : Type) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+    [CompactSpace G] [TotallyDisconnectedSpace G] where
   /-- the ground subgroup `U`, cutting out the base field of the layer -/
   ground : OpenSubgroup G
   /-- the top subgroup `V`, cutting out the top field of the layer -/
@@ -167,7 +172,8 @@ structure NormalLayer (G : Type) [Group G] [TopologicalSpace G] where
 
 namespace NormalLayer
 
-variable {G : Type} [Group G] [TopologicalSpace G] (L : NormalLayer G)
+variable {G : Type} [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
+  [TotallyDisconnectedSpace G] (L : NormalLayer G)
 
 /-- The top subgroup `V` of a layer, viewed as a subgroup of the ground subgroup `U`. -/
 abbrev relativeTop : Subgroup L.ground := L.top.toSubgroup.subgroupOf L.ground.toSubgroup
@@ -217,8 +223,6 @@ def galOfOpenNormalEquiv (V : OpenSubgroup G) [V.toSubgroup.Normal] :
     exact ⟨fun ⟨_, ha, h⟩ ↦ h ▸ ha, fun hx ↦ ⟨⟨x, trivial⟩, hx, rfl⟩⟩
 
 section Finite
-
-variable [IsTopologicalGroup G] [CompactSpace G]
 
 /-- The top subgroup is open in the compact ground subgroup, so the Galois group is finite. -/
 instance instFiniteGal : Finite L.Gal :=
@@ -313,7 +317,7 @@ end Coefficients
 
 section Norm
 
-variable [IsTopologicalGroup G] [CompactSpace G] (F : Formation G)
+variable (F : Formation G)
 
 /-- The **norm** `N_{U/V} : A^V → A^U` of a finite normal layer: the sum of the Galois conjugates,
 landing in the ground level through `groundLevelEquiv`. -/

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -92,9 +92,6 @@ equal.
 * E. Artin and J. Tate, *Class Field Theory*, Chapter XIV.
 * J. Neukirch, *Class Field Theory*, Chapter III.
 * J.-P. Serre, *Local Fields*, Chapter XI.
-* `Suggested.lean` of the TauCeti `ClassFieldTheory` roadmap, the blueprint whose signatures for
-  the two structures below and for the level, layer representation and norm constructions this
-  file follows.
 -/
 
 public noncomputable section

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -1,0 +1,394 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Topology.Algebra.OpenSubgroup
+public import TauCeti.RepresentationTheory.Homological.ContCohomology.SmoothDiscrete
+public import TauCeti.RepresentationTheory.Homological.TateCohomology.LowDegree
+
+/-!
+# Formations and their finite normal layers
+
+Artin and Tate describe a *formation* by a group `G`, a distinguished family of finite-index
+subgroups, and a `G`-module `A` each of whose elements is fixed by a sufficiently small member of
+the family. In the arithmetic applications the family is the family of open subgroups of a
+profinite Galois group and `A` is a discrete continuous module, so this file uses the equivalent
+topological formulation: a `Formation` is a smooth discrete topological representation of `G` over
+`ℤ`, and its `U`-**level** `A^U` is the submodule fixed by an open subgroup `U`.
+
+A **finite normal layer** is a pair of open subgroups `V ≤ U` with `V` normal in `U`. In field
+notation it is the layer `K/F` with `U = G_F` and `V = G_K`. Its Galois group `Γ = U ⧸ V` is
+finite as soon as `G` is compact, its coefficient module is the level `A^V`, and its ground level
+is `A^U`. The three constructions below are what the cohomology of the layer is taken of and
+compared with:
+
+* `rep`, the coefficient module `A^V` carrying the action of `Γ`. The `U`-action on `A^V` is well
+  defined because `V` is normal in `U`, and `V` acts on `A^V` trivially, so the action descends to
+  `Γ`.
+* `groundLevelEquiv`, the identification `(A^V)^Γ = A^U` of the invariants of the coefficient
+  module with the ground level. Both are submodules of the ambient module of the formation, and
+  the identification does not move an element.
+* `norm`, `normSubgroup` and `NormQuotient`: the norm `N_{U/V} : A^V → A^U`, its image, and the
+  quotient `A^U / N_{U/V}(A^V)`.
+
+The additive convention is used throughout, as in the abstract theory; a multiplicative group such
+as `Kˣ` enters through an `Additive` adapter.
+
+## Main definitions
+
+* `TauCeti.ClassFieldTheory.Formation`: a profinite group's smooth discrete integral coefficient
+  module.
+* `TauCeti.ClassFieldTheory.Formation.level`: the level `A^U` of an open subgroup.
+* `TauCeti.ClassFieldTheory.NormalLayer`: a finite normal layer `V ◁ U`.
+* `TauCeti.ClassFieldTheory.NormalLayer.Gal`, `degree`: the Galois group `U ⧸ V` and its order.
+* `TauCeti.ClassFieldTheory.NormalLayer.ofOpenNormal`: the layer `V ◁ ⊤` of an open normal
+  subgroup, with `galOfOpenNormalEquiv` identifying its Galois group with `G ⧸ V`.
+* `TauCeti.ClassFieldTheory.NormalLayer.rep`: the coefficient module `A^V` of the layer, as a
+  representation of `U ⧸ V`.
+* `TauCeti.ClassFieldTheory.NormalLayer.norm`, `normSubgroup`, `NormQuotient`: the norm of the
+  layer, its image and the norm quotient.
+
+## Main statements
+
+* `TauCeti.ClassFieldTheory.Formation.exists_mem_level`: every element of the coefficient module
+  is fixed by an open subgroup.
+* `TauCeti.ClassFieldTheory.NormalLayer.groundLevelEquiv`: `(A^V)^{U/V} ≃ A^U`.
+* `TauCeti.ClassFieldTheory.NormalLayer.tateHZeroEquivNormQuotient`: degree-zero Tate cohomology
+  of the layer is the norm quotient.
+
+## Implementation notes
+
+The coefficient module is built as `Representation.ofQuotient` of a
+`Representation.subrepresentation`, so that its underlying module is *definitionally* the level
+`A^V`. Mathlib's packaged `Rep.quotientToInvariants` would instead produce the invariants of the
+restriction of `A` along `V ∩ U → U → G`, which is the same submodule of the ambient module but
+not the same term as `A^V`, and every later comparison would have to transport along that equality.
+
+Compactness of `G` is not a field of `Formation`: it is assumed exactly where the finiteness of a
+layer's Galois group is used, so that the constructions above are available for an arbitrary
+topological group.
+
+Both the group and the coefficient module live in `Type`. Mathlib's `tateCohomology` asks for the
+finite group and the coefficient ring `ℤ` in one universe and for the coefficient module in that
+same universe, and every carrier of the arithmetic instances is a `Type`, so nothing is lost.
+
+The coefficient module is read as a plain `Rep ℤ G` through `Representation.ofDistribMulAction` at
+the action `TauCeti.TopRep.distribMulAction` derives from the operators of the topological
+representation. Passing instead through `ContRepresentation.toRepresentation` would carry the
+`Module ℤ` instance packaged inside `TopRep`, which is not the instance `AddCommGroup.toIntModule`
+that typeclass synthesis produces for an integral module, and the two are not definitionally
+equal.
+
+## References
+
+* E. Artin and J. Tate, *Class Field Theory*, Chapter XIV.
+* J. Neukirch, *Class Field Theory*, Chapter III.
+* J.-P. Serre, *Local Fields*, Chapter XI.
+-/
+
+@[expose] public noncomputable section
+
+open CategoryTheory Representation
+
+namespace TauCeti.ClassFieldTheory
+
+attribute [local instance] TopRep.distribMulAction TopRep.smulCommClass
+
+/-! ### Formations and their levels -/
+
+/-- A **formation**: a smooth discrete continuous integral representation of a topological group.
+In the arithmetic applications `G` is the Galois group of a Galois extension and the module is the
+multiplicative group of the top field, read additively. The distinguished family of subgroups of
+the Artin–Tate definition is the family of open subgroups of `G`, which is why the levels below
+are indexed by `OpenSubgroup G`. -/
+structure Formation (G : Type) [Group G] [TopologicalSpace G] where
+  /-- the coefficient module of the formation, a topological representation of `G` over `ℤ` -/
+  module : TopRep.{0} ℤ G
+  /-- the coefficient module is discrete with open point stabilizers, so that every element is
+  fixed by an open subgroup -/
+  smooth : IsSmoothDiscrete ℤ module
+
+namespace Formation
+
+variable {G : Type} [Group G] [TopologicalSpace G] (F : Formation G)
+
+/-- The coefficient module of a formation as a plain integral representation of `G`, forgetting
+its topology. The levels, the layer representations and all of their cohomology are taken of this
+underlying representation. -/
+abbrev toRep : Rep ℤ G := Rep.of (Representation.ofDistribMulAction ℤ G F.module.V)
+
+theorem toRep_ρ_apply (g : G) (x : F.toRep.V) : F.toRep.ρ g x = F.module.ρ g x :=
+  (rfl)
+
+/-- The **level** `A^U` of an open subgroup `U`, as a submodule of the ambient module of the
+formation. Keeping every level inside one ambient module is what makes the inclusion of a level in
+a smaller subgroup's level, and the norm between two levels, maps of submodules of a fixed
+module. -/
+def level (U : OpenSubgroup G) : Submodule ℤ F.toRep.V :=
+  invariants (F.toRep.ρ.comp U.toSubgroup.subtype)
+
+@[simp]
+theorem mem_level {U : OpenSubgroup G} {x : F.toRep.V} :
+    x ∈ F.level U ↔ ∀ u ∈ U, F.toRep.ρ u x = x :=
+  ⟨fun hx u hu ↦ hx ⟨u, hu⟩, fun hx u ↦ hx u u.2⟩
+
+/-- **Every element of the coefficient module lies in a level.** This is the Artin–Tate condition
+that each element of `A` is fixed by a sufficiently small member of the distinguished family of
+subgroups, and it is exactly what smoothness of the module supplies: the stabilizer of an element
+is open. -/
+theorem exists_mem_level (x : F.toRep.V) : ∃ U : OpenSubgroup G, x ∈ F.level U :=
+  ⟨⟨MulAction.stabilizer G x, F.smooth.stabilizer_isOpen x⟩, F.mem_level.2 fun _ hu ↦ hu⟩
+
+/-- Levels decrease as the subgroup grows: a larger subgroup fixes fewer elements. -/
+theorem level_antitone : Antitone F.level := by
+  intro U U' hUU' x hx
+  rw [mem_level] at hx ⊢
+  exact fun u hu ↦ hx u (hUU' hu)
+
+end Formation
+
+/-! ### Finite normal layers -/
+
+/-- A **finite normal layer** `V ◁ U` of open subgroups of `G`. In field notation this is the
+finite Galois layer `K/F` inside the extension `G` cuts out, with `U = G_F` the ground subgroup and
+`V = G_K` the top subgroup. -/
+structure NormalLayer (G : Type) [Group G] [TopologicalSpace G] where
+  /-- the ground subgroup `U`, cutting out the base field of the layer -/
+  ground : OpenSubgroup G
+  /-- the top subgroup `V`, cutting out the top field of the layer -/
+  top : OpenSubgroup G
+  /-- the layer runs upwards: `V ≤ U` -/
+  top_le_ground : top ≤ ground
+  /-- `V` is normal in `U`, so that the layer is Galois -/
+  normal : (top.toSubgroup.subgroupOf ground.toSubgroup).Normal
+
+namespace NormalLayer
+
+variable {G : Type} [Group G] [TopologicalSpace G] (L : NormalLayer G)
+
+/-- The top subgroup `V` of a layer, viewed as a subgroup of the ground subgroup `U`. -/
+abbrev relativeTop : Subgroup L.ground := L.top.toSubgroup.subgroupOf L.ground.toSubgroup
+
+instance : L.relativeTop.Normal := L.normal
+
+/-- The Galois group `Γ = U ⧸ V` of a finite normal layer. -/
+abbrev Gal : Type := L.ground ⧸ L.relativeTop
+
+/-- The top subgroup of a layer is normal in the ground subgroup, read on elements of `G`. -/
+theorem conj_mem_top {u : G} (hu : u ∈ L.ground) {v : G} (hv : v ∈ L.top) :
+    u * v * u⁻¹ ∈ L.top :=
+  Subgroup.mem_subgroupOf.1
+    (L.normal.conj_mem ⟨v, L.top_le_ground hv⟩ (Subgroup.mem_subgroupOf.2 hv) ⟨u, hu⟩)
+
+/-- The **degree** `[U : V]` of a normal layer, the index of the top subgroup in the ground
+subgroup. -/
+def degree : ℕ := L.relativeTop.index
+
+theorem degree_eq_natCard_gal : L.degree = Nat.card L.Gal :=
+  (rfl)
+
+/-- The layer `V ◁ ⊤` cut out by an open normal subgroup of `G`. These layers are the finite
+Galois extensions of the ground field of a formation on `G`. -/
+def ofOpenNormal (V : OpenSubgroup G) [V.toSubgroup.Normal] : NormalLayer G where
+  ground := ⊤
+  top := V
+  top_le_ground := le_top
+  normal := Subgroup.normal_subgroupOf
+
+@[simp]
+theorem ground_ofOpenNormal (V : OpenSubgroup G) [V.toSubgroup.Normal] :
+    (ofOpenNormal V).ground = ⊤ :=
+  (rfl)
+
+@[simp]
+theorem top_ofOpenNormal (V : OpenSubgroup G) [V.toSubgroup.Normal] :
+    (ofOpenNormal V).top = V :=
+  (rfl)
+
+/-- The Galois group of the layer `V ◁ ⊤` is the finite quotient `G ⧸ V`. -/
+def galOfOpenNormalEquiv (V : OpenSubgroup G) [V.toSubgroup.Normal] :
+    (ofOpenNormal V).Gal ≃* G ⧸ V.toSubgroup :=
+  QuotientGroup.congr _ _ Subgroup.topEquiv <| by
+    ext x
+    simp only [Subgroup.mem_map]
+    exact ⟨fun ⟨_, ha, h⟩ ↦ h ▸ ha, fun hx ↦ ⟨⟨x, trivial⟩, hx, rfl⟩⟩
+
+section Finite
+
+variable [IsTopologicalGroup G] [CompactSpace G]
+
+/-- The top subgroup is open in the compact ground subgroup, so the Galois group is finite. -/
+instance instFiniteGal : Finite L.Gal :=
+  Subgroup.quotient_finite_of_isOpen' L.ground.toSubgroup L.relativeTop L.ground.isOpen
+    (L.ground.toSubgroup.subgroupOf_isOpen L.top.toSubgroup L.top.isOpen)
+
+instance instFintypeGal : Fintype L.Gal := Fintype.ofFinite _
+
+theorem degree_pos : 0 < L.degree :=
+  L.degree_eq_natCard_gal ▸ Nat.card_pos
+
+end Finite
+
+/-! ### The coefficient module of a layer -/
+
+section Coefficients
+
+variable (F : Formation G)
+
+/-- The ground subgroup carries the top level into itself: this is exactly normality of `V` in
+`U`. -/
+theorem level_top_le_comap (u : L.ground) :
+    F.level L.top ≤ (F.level L.top).comap (F.toRep.ρ (u : G)) := by
+  intro x hx
+  rw [Submodule.mem_comap, Formation.mem_level]
+  intro v hv
+  have hconj : (u : G)⁻¹ * v * (u : G) ∈ L.top := by
+    simpa using L.conj_mem_top (L.ground.toSubgroup.inv_mem u.2) hv
+  have hvu : v * (u : G) = (u : G) * ((u : G)⁻¹ * v * (u : G)) := by group
+  calc F.toRep.ρ v (F.toRep.ρ (u : G) x)
+      = F.toRep.ρ (v * (u : G)) x := by rw [map_mul, Module.End.mul_apply]
+    _ = F.toRep.ρ (u : G) (F.toRep.ρ ((u : G)⁻¹ * v * (u : G)) x) := by
+        rw [hvu, map_mul, Module.End.mul_apply]
+    _ = F.toRep.ρ (u : G) x := by rw [(F.mem_level.1 hx) _ hconj]
+
+/-- The action of the ground subgroup `U` on the top level `A^V`. -/
+abbrev groundRep : Representation ℤ L.ground (F.level L.top) :=
+  .subrepresentation (F.toRep.ρ.comp L.ground.toSubgroup.subtype) _ (L.level_top_le_comap F)
+
+@[simp]
+theorem groundRep_apply_coe (u : L.ground) (x : F.level L.top) :
+    ((L.groundRep F u x : F.level L.top) : F.toRep.V) = F.toRep.ρ (u : G) x :=
+  (rfl)
+
+/-- The top subgroup acts trivially on the top level, so the `U`-action descends to `U ⧸ V`. -/
+instance : Representation.IsTrivial ((L.groundRep F).comp L.relativeTop.subtype) where
+  out s := by
+    ext x
+    exact (F.mem_level.1 x.2) _ (Subgroup.mem_subgroupOf.1 s.2)
+
+/-- The **coefficient module of a layer**: the top level `A^V` with the induced action of the
+Galois group `U ⧸ V`. Its underlying module is the level itself, not an isomorphic copy. -/
+abbrev rep : Rep ℤ L.Gal := Rep.of ((L.groundRep F).ofQuotient L.relativeTop)
+
+theorem rep_ρ_mk_apply_coe (u : L.ground) (x : F.level L.top) :
+    (((L.rep F).ρ (u : L.Gal) x : F.level L.top) : F.toRep.V) = F.toRep.ρ (u : G) x :=
+  (rfl)
+
+/-- The ground level sits inside the top level. -/
+theorem level_ground_le_level_top : F.level L.ground ≤ F.level L.top :=
+  F.level_antitone L.top_le_ground
+
+/-- **The invariants of the coefficient module are the ground level:** `(A^V)^{U/V} = A^U`. Both
+sides are read inside the top level `A^V`. -/
+theorem invariants_rep :
+    (L.rep F).ρ.invariants = (F.level L.ground).comap (F.level L.top).subtype := by
+  ext x
+  rw [Representation.mem_invariants, Submodule.mem_comap, Submodule.subtype_apply,
+    Formation.mem_level]
+  constructor
+  · intro hx u hu
+    exact congrArg Subtype.val (hx (QuotientGroup.mk (⟨u, hu⟩ : L.ground)))
+  · intro hx γ
+    induction γ using QuotientGroup.induction_on with
+    | H u => exact Subtype.ext (hx u u.2)
+
+/-- The identification `(A^V)^{U/V} ≃ A^U` of the invariants of the coefficient module with the
+ground level. It moves no element of the ambient module. -/
+def groundLevelEquiv : (L.rep F).ρ.invariants ≃ₗ[ℤ] F.level L.ground :=
+  (LinearEquiv.ofEq _ _ (L.invariants_rep F)).trans
+    (Submodule.comapSubtypeEquivOfLe (L.level_ground_le_level_top F))
+
+@[simp]
+theorem groundLevelEquiv_apply_coe (x : (L.rep F).ρ.invariants) :
+    ((L.groundLevelEquiv F x : F.level L.ground) : F.toRep.V) = ((x : F.level L.top) :
+      F.toRep.V) :=
+  (rfl)
+
+end Coefficients
+
+/-! ### The norm of a layer -/
+
+section Norm
+
+variable [IsTopologicalGroup G] [CompactSpace G] (F : Formation G)
+
+/-- The **norm** `N_{U/V} : A^V → A^U` of a finite normal layer: the sum of the Galois conjugates,
+landing in the ground level through `groundLevelEquiv`. -/
+def norm : F.level L.top →ₗ[ℤ] F.level L.ground :=
+  (L.groundLevelEquiv F).toLinearMap ∘ₗ
+    (L.rep F).ρ.norm.codRestrict (L.rep F).ρ.invariants fun x ↦
+      (Representation.mem_invariants _ _).2 fun g ↦ by
+        rw [← LinearMap.comp_apply, Representation.self_comp_norm]
+
+@[simp]
+theorem norm_apply_coe (x : F.level L.top) :
+    ((L.norm F x : F.level L.ground) : F.toRep.V) =
+      ∑ γ : L.Gal, (((L.rep F).ρ γ x : F.level L.top) : F.toRep.V) := by
+  -- The identification with the ground level does not move the underlying element, so the norm
+  -- of the layer and Mathlib's `Representation.norm` take the same value in the ambient module.
+  have h : ((L.norm F x : F.level L.ground) : F.toRep.V)
+      = (((L.rep F).ρ.norm x : F.level L.top) : F.toRep.V) := rfl
+  rw [h]
+  simp [Representation.norm]
+
+/-- The norm of a layer is the trace of the Galois action on the top level, so on an element of
+the ground level it is multiplication by the degree. -/
+theorem norm_apply_coe_of_mem_level_ground (x : F.level L.top)
+    (hx : (x : F.toRep.V) ∈ F.level L.ground) :
+    ((L.norm F x : F.level L.ground) : F.toRep.V) = L.degree • (x : F.toRep.V) := by
+  have hconst : ∀ γ : L.Gal, (((L.rep F).ρ γ x : F.level L.top) : F.toRep.V) = x := by
+    intro γ
+    induction γ using QuotientGroup.induction_on with
+    | H u => exact (F.mem_level.1 hx) u u.2
+  rw [L.norm_apply_coe F x, Finset.sum_congr rfl fun γ _ ↦ hconst γ,
+    L.degree_eq_natCard_gal]
+  simp [Nat.card_eq_fintype_card]
+
+/-- The **norm subgroup** `N_{U/V}(A^V)` of the ground level. -/
+def normSubgroup : Submodule ℤ (F.level L.ground) :=
+  LinearMap.range (L.norm F)
+
+@[simp]
+theorem mem_normSubgroup {y : F.level L.ground} :
+    y ∈ L.normSubgroup F ↔ ∃ x, L.norm F x = y :=
+  Iff.rfl
+
+/-- The **norm quotient** `A^U / N_{U/V}(A^V)` of a finite normal layer. This is the group that
+Artin reciprocity identifies with the abelianization of the Galois group of the layer. -/
+abbrev NormQuotient : Type := F.level L.ground ⧸ L.normSubgroup F
+
+/-- The image under `groundLevelEquiv` of the norm image inside the invariants is the norm
+subgroup. -/
+theorem map_groundLevelEquiv_submoduleOf :
+    Submodule.map (L.groundLevelEquiv F).toLinearMap
+        ((LinearMap.range (L.rep F).ρ.norm).submoduleOf (L.rep F).ρ.invariants) =
+      L.normSubgroup F := by
+  ext y
+  simp only [Submodule.mem_map, Submodule.submoduleOf, Submodule.mem_comap,
+    LinearMap.mem_range, normSubgroup, LinearEquiv.coe_coe]
+  constructor
+  · rintro ⟨z, ⟨v, hv⟩, rfl⟩
+    refine ⟨v, Subtype.ext ?_⟩
+    -- The congruence is bound first: elaborated against the goal, `congrArg` would unify its
+    -- arguments with the two sides of the goal instead of with the two sides of `hv`.
+    have h := congrArg Subtype.val hv
+    exact h
+  · rintro ⟨v, rfl⟩
+    exact ⟨_, ⟨v, rfl⟩, rfl⟩
+
+/-- **Degree-zero Tate cohomology of a finite normal layer is its norm quotient.** This is the
+low-degree identification that the Artin map of a class formation is read through. -/
+def tateHZeroEquivNormQuotient :
+    tateCohomology (L.rep F) 0 ≅ ModuleCat.of ℤ (L.NormQuotient F) :=
+  TateCohomology.H0IsoNormQuotient (L.rep F) ≪≫
+    (Submodule.Quotient.equiv _ _ (L.groundLevelEquiv F)
+      (L.map_groundLevelEquiv_submoduleOf F)).toModuleIso
+
+end Norm
+
+end NormalLayer
+
+end TauCeti.ClassFieldTheory

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -48,8 +48,11 @@ as `Kˣ` enters through an `Additive` adapter.
   subgroup, with `galOfOpenNormalEquiv` identifying its Galois group with `G ⧸ V`.
 * `TauCeti.ClassFieldTheory.NormalLayer.rep`: the coefficient module `A^V` of the layer, as a
   representation of `U ⧸ V`.
-* `TauCeti.ClassFieldTheory.NormalLayer.norm`, `normSubgroup`, `NormQuotient`: the norm of the
-  layer, its image and the norm quotient.
+* `TauCeti.ClassFieldTheory.NormalLayer.H`, `TateH`, `TrivialTateH`: the ordinary and Tate
+  cohomology carriers of the layer, in the coefficient module `A^V` and in trivial integral
+  coefficients.
+* `TauCeti.ClassFieldTheory.NormalLayer.norm`, `normSubgroup`, `NormQuotient`, `normQuotientMk`:
+  the norm of the layer, its image, the norm quotient and the quotient map onto it.
 
 ## Main statements
 
@@ -91,7 +94,7 @@ equal.
 * J.-P. Serre, *Local Fields*, Chapter XI.
 -/
 
-@[expose] public noncomputable section
+public noncomputable section
 
 open CategoryTheory Representation
 
@@ -222,6 +225,12 @@ def galOfOpenNormalEquiv (V : OpenSubgroup G) [V.toSubgroup.Normal] :
     simp only [Subgroup.mem_map]
     exact ⟨fun ⟨_, ha, h⟩ ↦ h ▸ ha, fun hx ↦ ⟨⟨x, trivial⟩, hx, rfl⟩⟩
 
+@[simp]
+theorem galOfOpenNormalEquiv_mk (V : OpenSubgroup G) [V.toSubgroup.Normal]
+    (u : (ofOpenNormal V).ground) :
+    galOfOpenNormalEquiv V (QuotientGroup.mk u) = QuotientGroup.mk (u : G) :=
+  (rfl)
+
 section Finite
 
 /-- The top subgroup is open in the compact ground subgroup, so the Galois group is finite. -/
@@ -313,6 +322,27 @@ theorem groundLevelEquiv_apply_coe (x : (L.rep F).ρ.invariants) :
 
 end Coefficients
 
+/-! ### The cohomology of a layer -/
+
+section Cohomology
+
+variable (F : Formation G)
+
+/-- **Ordinary group cohomology of a finite normal layer**, `H^n(U/V, A^V)`, on Mathlib's carrier.
+The axioms satisfied by a class formation and the fundamental class of a layer are read here. -/
+abbrev H (n : ℕ) : ModuleCat ℤ := groupCohomology (L.rep F) n
+
+/-- **Tate cohomology of a finite normal layer** in its coefficient module, the Tate group
+`H^r(U/V, A^V)` in every integer degree `r`. -/
+abbrev TateH (r : ℤ) : ModuleCat ℤ := tateCohomology (L.rep F) r
+
+/-- **Tate cohomology of a finite normal layer with trivial integral coefficients**, the Tate
+group `H^r(U/V, ℤ)`. Its degree `-2` is the abelianization of the Galois group of the layer, and
+the Artin map of a class formation is a cup product between this carrier and `TateH`. -/
+abbrev TrivialTateH (r : ℤ) : ModuleCat ℤ := tateCohomology (Rep.trivial ℤ L.Gal ℤ) r
+
+end Cohomology
+
 /-! ### The norm of a layer -/
 
 section Norm
@@ -360,9 +390,21 @@ theorem mem_normSubgroup {y : F.level L.ground} :
     y ∈ L.normSubgroup F ↔ ∃ x, L.norm F x = y :=
   Iff.rfl
 
-/-- The **norm quotient** `A^U / N_{U/V}(A^V)` of a finite normal layer. This is the group that
-Artin reciprocity identifies with the abelianization of the Galois group of the layer. -/
+/-- The **norm quotient** `A^U / N_{U/V}(A^V)` of a finite normal layer. It is the group that the
+Artin map of a *class formation* — a formation whose layers satisfy the axioms on `H¹` and `H²`,
+which a bare `Formation` does not assume — identifies with the abelianization of the Galois group
+of the layer. -/
 abbrev NormQuotient : Type := F.level L.ground ⧸ L.normSubgroup F
+
+/-- The canonical map from the ground level onto the norm quotient. The Artin map of a class
+formation is defined on the ground level by composing with this map. -/
+def normQuotientMk : F.level L.ground →ₗ[ℤ] L.NormQuotient F :=
+  (L.normSubgroup F).mkQ
+
+@[simp]
+theorem normQuotientMk_apply (x : F.level L.ground) :
+    L.normQuotientMk F x = Submodule.Quotient.mk x :=
+  (rfl)
 
 /-- The image under `groundLevelEquiv` of the norm image inside the invariants is the norm
 subgroup. -/
@@ -386,10 +428,21 @@ theorem map_groundLevelEquiv_submoduleOf :
 /-- **Degree-zero Tate cohomology of a finite normal layer is its norm quotient.** This is the
 low-degree identification that the Artin map of a class formation is read through. -/
 def tateHZeroEquivNormQuotient :
-    tateCohomology (L.rep F) 0 ≅ ModuleCat.of ℤ (L.NormQuotient F) :=
+    L.TateH F 0 ≅ ModuleCat.of ℤ (L.NormQuotient F) :=
   TateCohomology.H0IsoNormQuotient (L.rep F) ≪≫
     (Submodule.Quotient.equiv _ _ (L.groundLevelEquiv F)
       (L.map_groundLevelEquiv_submoduleOf F)).toModuleIso
+
+/-- The identification of degree-zero Tate cohomology with the norm quotient sends the class of an
+invariant to the class of the corresponding element of the ground level. -/
+@[simp]
+theorem tateHZeroEquivNormQuotient_hom_H0π (x : (L.rep F).ρ.invariants) :
+    (L.tateHZeroEquivNormQuotient F).hom (TateCohomology.H0π (L.rep F) x) =
+      L.normQuotientMk F (L.groundLevelEquiv F x) := by
+  -- The elementwise form of the low-degree identification is bound as a hypothesis first, so
+  -- that it is normalised to the application form the goal uses before it rewrites.
+  have h := TateCohomology.H0π_comp_H0IsoNormQuotient_hom_apply (L.rep F) x
+  simp [tateHZeroEquivNormQuotient, normQuotientMk, h]
 
 end Norm
 

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -29,8 +29,9 @@ is taken of and compared with:
   defined because `V` is normal in `U`, and `V` acts on `A^V` trivially, so the action descends to
   `Γ`.
 * `groundLevelEquiv`, the identification `(A^V)^Γ = A^U` of the invariants of the coefficient
-  module with the ground level. Both are submodules of the ambient module of the formation, and
-  the identification does not move an element.
+  module with the ground level. Both sides are read inside `A^V` — the invariants of `Γ` and the
+  ground level comapped along `A^V ⊆ A` are the same submodule of `A^V` — so the identification
+  does not move an element of the ambient module.
 * `norm`, `normSubgroup` and `NormQuotient`: the norm `N_{U/V} : A^V → A^U`, its image, and the
   quotient `A^U / N_{U/V}(A^V)`.
 
@@ -109,6 +110,7 @@ In the arithmetic applications `G` is the Galois group of a Galois extension and
 multiplicative group of the top field, read additively. The distinguished family of subgroups of
 the Artin–Tate definition is the family of open subgroups of `G`, which is why the levels below
 are indexed by `OpenSubgroup G`. -/
+@[ext]
 structure Formation (G : Type) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
     [CompactSpace G] [TotallyDisconnectedSpace G] where
   /-- the coefficient module of the formation, a topological representation of `G` over `ℤ` -/
@@ -162,6 +164,7 @@ end Formation
 /-- A **finite normal layer** `V ◁ U` of open subgroups of `G`. In field notation this is the
 finite Galois layer `K/F` inside the extension `G` cuts out, with `U = G_F` the ground subgroup and
 `V = G_K` the top subgroup. -/
+@[ext]
 structure NormalLayer (G : Type) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
     [CompactSpace G] [TotallyDisconnectedSpace G] where
   /-- the ground subgroup `U`, cutting out the base field of the layer -/
@@ -196,29 +199,29 @@ theorem conj_mem_top {u : G} (hu : u ∈ L.ground) {v : G} (hv : v ∈ L.top) :
 subgroup. -/
 def degree : ℕ := L.relativeTop.index
 
+@[simp]
 theorem degree_eq_natCard_gal : L.degree = Nat.card L.Gal :=
   (rfl)
 
 /-- The layer `V ◁ ⊤` cut out by an open normal subgroup of `G`. These layers are the finite
 Galois extensions of the ground field of a formation on `G`. -/
-def ofOpenNormal (V : OpenSubgroup G) [V.toSubgroup.Normal] : NormalLayer G where
+def ofOpenNormal (V : OpenNormalSubgroup G) : NormalLayer G where
   ground := ⊤
-  top := V
+  top := V.toOpenSubgroup
   top_le_ground := le_top
   normal := Subgroup.normal_subgroupOf
 
 @[simp]
-theorem ground_ofOpenNormal (V : OpenSubgroup G) [V.toSubgroup.Normal] :
-    (ofOpenNormal V).ground = ⊤ :=
+theorem ground_ofOpenNormal (V : OpenNormalSubgroup G) : (ofOpenNormal V).ground = ⊤ :=
   (rfl)
 
 @[simp]
-theorem top_ofOpenNormal (V : OpenSubgroup G) [V.toSubgroup.Normal] :
-    (ofOpenNormal V).top = V :=
+theorem top_ofOpenNormal (V : OpenNormalSubgroup G) :
+    (ofOpenNormal V).top = V.toOpenSubgroup :=
   (rfl)
 
 /-- The Galois group of the layer `V ◁ ⊤` is the finite quotient `G ⧸ V`. -/
-def galOfOpenNormalEquiv (V : OpenSubgroup G) [V.toSubgroup.Normal] :
+def galOfOpenNormalEquiv (V : OpenNormalSubgroup G) :
     (ofOpenNormal V).Gal ≃* G ⧸ V.toSubgroup :=
   QuotientGroup.congr _ _ Subgroup.topEquiv <| by
     ext x
@@ -226,8 +229,7 @@ def galOfOpenNormalEquiv (V : OpenSubgroup G) [V.toSubgroup.Normal] :
     exact ⟨fun ⟨_, ha, h⟩ ↦ h ▸ ha, fun hx ↦ ⟨⟨x, trivial⟩, hx, rfl⟩⟩
 
 @[simp]
-theorem galOfOpenNormalEquiv_mk (V : OpenSubgroup G) [V.toSubgroup.Normal]
-    (u : (ofOpenNormal V).ground) :
+theorem galOfOpenNormalEquiv_mk (V : OpenNormalSubgroup G) (u : (ofOpenNormal V).ground) :
     galOfOpenNormalEquiv V (QuotientGroup.mk u) = QuotientGroup.mk (u : G) :=
   (rfl)
 

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -113,8 +113,13 @@ disconnected topological group. In the arithmetic applications `G` is the Galois
 Galois extension and the module is the multiplicative group of the top field, read additively. The
 distinguished family of subgroups of the Artin–Tate definition is the family of open subgroups of
 `G`, which is why the levels below are indexed by `OpenSubgroup G`. -/
-abbrev Formation (G : Type) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
-    [CompactSpace G] [TotallyDisconnectedSpace G] := SmoothDiscreteTopRep.{0, 0, 0} ℤ G
+-- The underlying category of smooth discrete objects makes sense over any topological monoid, so
+-- the three profinite hypotheses are mentioned nowhere in the body; they are named with a leading
+-- underscore, the convention for an argument that is deliberately unused there. They are kept
+-- because the theory below — finiteness of a layer's Galois group and the norm maps built from it
+-- — is stated only for a profinite `G`, so a formation should never be formed over anything else.
+abbrev Formation (G : Type) [Group G] [TopologicalSpace G] [_tg : IsTopologicalGroup G]
+    [_cs : CompactSpace G] [_td : TotallyDisconnectedSpace G] := SmoothDiscreteTopRep.{0, 0, 0} ℤ G
 
 namespace Formation
 

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -15,9 +15,9 @@ public import TauCeti.RepresentationTheory.Homological.TateCohomology.LowDegree
 Artin and Tate describe a *formation* by a group `G`, a distinguished family of finite-index
 subgroups, and a `G`-module `A` each of whose elements is fixed by a sufficiently small member of
 the family. In the arithmetic applications the family is the family of open subgroups of a
-profinite Galois group and `A` is a discrete continuous module, so this file uses the equivalent
-topological formulation: a `Formation` is a smooth discrete topological representation of `G` over
-`ℤ`, and its `U`-**level** `A^U` is the submodule fixed by an open subgroup `U`.
+compact, totally disconnected Galois group and `A` is a discrete continuous module, so this file
+uses the topological formulation: a `Formation` is a smooth discrete topological representation
+of `G` over `ℤ`, and its `U`-**level** `A^U` is the submodule fixed by an open subgroup `U`.
 
 A **finite normal layer** is a pair of open subgroups `V ≤ U` with `V` normal in `U`. In field
 notation it is the layer `K/F` with `U = G_F` and `V = G_K`. Its Galois group `Γ = U ⧸ V` is
@@ -40,8 +40,8 @@ as `Kˣ` enters through an `Additive` adapter.
 
 ## Main definitions
 
-* `TauCeti.ClassFieldTheory.Formation`: a profinite group's smooth discrete integral coefficient
-  module.
+* `TauCeti.ClassFieldTheory.Formation`: a compact, totally disconnected topological group's
+  smooth discrete integral coefficient module.
 * `TauCeti.ClassFieldTheory.Formation.level`: the level `A^U` of an open subgroup.
 * `TauCeti.ClassFieldTheory.NormalLayer`: a finite normal layer `V ◁ U`.
 * `TauCeti.ClassFieldTheory.NormalLayer.Gal`, `degree`: the Galois group `U ⧸ V` and its order.
@@ -71,11 +71,9 @@ The coefficient module is built as `Representation.ofQuotient` of a
 restriction of `A` along `V ∩ U → U → G`, which is the same submodule of the ambient module but
 not the same term as `A^V`, and every later comparison would have to transport along that equality.
 
-The group `G` is profinite — a compact, totally disconnected topological group — and both
-`Formation` and `NormalLayer` carry those hypotheses. They are what makes the family of open
-subgroups the distinguished family of the Artin–Tate definition, with the open subgroups a
-neighbourhood basis of `1`, and what makes the Galois group of every layer finite, so that the
-`degree` of a layer is its genuine index and not the junk value `0` of an infinite quotient.
+Both `Formation` and `NormalLayer` assume that `G` is compact and totally disconnected.
+Compactness makes the Galois group of every layer finite, so that the `degree` of a layer is its
+genuine index and not the junk value `0` of an infinite quotient.
 
 Both the group and the coefficient module live in `Type`. Mathlib's `tateCohomology` asks for the
 finite group and the coefficient ring `ℤ` in one universe and for the coefficient module in that
@@ -109,11 +107,11 @@ attribute [local instance] TopRep.distribMulAction TopRep.smulCommClass
 
 /-! ### Formations and their levels -/
 
-/-- A **formation**: a smooth discrete continuous integral representation of a profinite group.
-In the arithmetic applications `G` is the Galois group of a Galois extension and the module is the
-multiplicative group of the top field, read additively. The distinguished family of subgroups of
-the Artin–Tate definition is the family of open subgroups of `G`, which is why the levels below
-are indexed by `OpenSubgroup G`. -/
+/-- A **formation**: a smooth discrete continuous integral representation of a compact, totally
+disconnected topological group. In the arithmetic applications `G` is the Galois group of a
+Galois extension and the module is the multiplicative group of the top field, read additively. The
+distinguished family of subgroups of the Artin–Tate definition is the family of open subgroups of
+`G`, which is why the levels below are indexed by `OpenSubgroup G`. -/
 @[ext]
 structure Formation (G : Type) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
     [CompactSpace G] [TotallyDisconnectedSpace G] where

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -60,7 +60,7 @@ as `Kˣ` enters through an `Additive` adapter.
 * `TauCeti.ClassFieldTheory.Formation.exists_mem_level`: every element of the coefficient module
   is fixed by an open subgroup.
 * `TauCeti.ClassFieldTheory.NormalLayer.groundLevelEquiv`: `(A^V)^{U/V} ≃ A^U`.
-* `TauCeti.ClassFieldTheory.NormalLayer.tateHZeroIsoNormQuotient`: degree-zero Tate cohomology
+* `TauCeti.ClassFieldTheory.NormalLayer.tateHZeroEquivNormQuotient`: degree-zero Tate cohomology
   of the layer is the norm quotient.
 
 ## Implementation notes
@@ -99,7 +99,8 @@ open CategoryTheory Representation
 
 namespace TauCeti.ClassFieldTheory
 
--- Provenance: the signatures of the two structures below, and of `level`, `rep`, `norm` and the
+-- Provenance: the signatures of the formation type and normal-layer structure below, and of
+-- `level`, `rep`, `norm` and the
 -- cohomology carriers, follow the blueprint `Suggested.lean` of the Tau Ceti `ClassFieldTheory`
 -- roadmap (`TauCetiRoadmap/ClassFieldTheory/README.md` and `Suggested.lean`).
 
@@ -112,19 +113,23 @@ disconnected topological group. In the arithmetic applications `G` is the Galois
 Galois extension and the module is the multiplicative group of the top field, read additively. The
 distinguished family of subgroups of the Artin–Tate definition is the family of open subgroups of
 `G`, which is why the levels below are indexed by `OpenSubgroup G`. -/
-@[ext]
-structure Formation (G : Type) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
-    [CompactSpace G] [TotallyDisconnectedSpace G] where
-  /-- the coefficient module of the formation, a topological representation of `G` over `ℤ` -/
-  module : TopRep.{0} ℤ G
-  /-- the coefficient module is discrete with open point stabilizers, so that every element is
-  fixed by an open subgroup -/
-  smooth : IsSmoothDiscrete ℤ module
+abbrev Formation (G : Type) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+    [CompactSpace G] [TotallyDisconnectedSpace G] := SmoothDiscreteTopRep.{0, 0, 0} ℤ G
 
 namespace Formation
 
 variable {G : Type} [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
   [TotallyDisconnectedSpace G] (F : Formation G)
+
+/-- The coefficient module of a formation, as a topological representation of `G` over `ℤ`. -/
+abbrev module : TopRep.{0} ℤ G := F.obj
+
+/-- The coefficient module is discrete with open point stabilizers. -/
+abbrev smooth : IsSmoothDiscrete ℤ F.module := F.property
+
+@[ext]
+theorem ext {F F' : Formation G} (h : F.module = F'.module) : F = F' :=
+  ObjectProperty.FullSubcategory.ext h
 
 /-- The coefficient module of a formation as a plain integral representation of `G`, forgetting
 its topology. The levels, the layer representations and all of their cohomology are taken of this
@@ -437,22 +442,21 @@ theorem map_groundLevelEquiv_submoduleOf :
 
 /-- **Degree-zero Tate cohomology of a finite normal layer is its norm quotient.** This is the
 low-degree identification that the Artin map of a class formation is read through. -/
-def tateHZeroIsoNormQuotient :
-    L.TateH F 0 ≅ ModuleCat.of ℤ (L.NormQuotient F) :=
-  TateCohomology.H0IsoNormQuotient (L.rep F) ≪≫
+def tateHZeroEquivNormQuotient : L.TateH F 0 ≃+ L.NormQuotient F :=
+  (TateCohomology.H0IsoNormQuotient (L.rep F) ≪≫
     (Submodule.Quotient.equiv _ _ (L.groundLevelEquiv F)
-      (L.map_groundLevelEquiv_submoduleOf F)).toModuleIso
+      (L.map_groundLevelEquiv_submoduleOf F)).toModuleIso).toLinearEquiv.toAddEquiv
 
 /-- The identification of degree-zero Tate cohomology with the norm quotient sends the class of an
 invariant to the class of the corresponding element of the ground level. -/
 @[simp]
-theorem tateHZeroIsoNormQuotient_hom_H0π (x : (L.rep F).ρ.invariants) :
-    (L.tateHZeroIsoNormQuotient F).hom (TateCohomology.H0π (L.rep F) x) =
+theorem tateHZeroEquivNormQuotient_H0π (x : (L.rep F).ρ.invariants) :
+    L.tateHZeroEquivNormQuotient F (TateCohomology.H0π (L.rep F) x) =
       L.normQuotientMk F (L.groundLevelEquiv F x) := by
   -- The elementwise form of the low-degree identification is bound as a hypothesis first, so
   -- that it is normalised to the application form the goal uses before it rewrites.
   have h := TateCohomology.H0π_comp_H0IsoNormQuotient_hom_apply (L.rep F) x
-  simp [tateHZeroIsoNormQuotient, normQuotientMk, h]
+  simp [tateHZeroEquivNormQuotient, normQuotientMk, h]
 
 end Norm
 

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -112,7 +112,9 @@ attribute [local instance] TopRep.distribMulAction TopRep.smulCommClass
 disconnected topological group. In the arithmetic applications `G` is the Galois group of a
 Galois extension and the module is the multiplicative group of the top field, read additively. The
 distinguished family of subgroups of the Artin–Tate definition is the family of open subgroups of
-`G`, which is why the levels below are indexed by `OpenSubgroup G`. -/
+`G`, which is why the levels below are indexed by `OpenSubgroup G`. This is the roadmap's
+domain-specific name for `SmoothDiscreteTopRep`; it is definitionally the same type and introduces
+no second representation bundle. -/
 -- The underlying category of smooth discrete objects makes sense over any topological monoid, so
 -- the three profinite hypotheses are mentioned nowhere in the body; they are named with a leading
 -- underscore, the convention for an argument that is deliberately unused there. They are kept

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -112,9 +112,9 @@ attribute [local instance] TopRep.distribMulAction TopRep.smulCommClass
 disconnected topological group. In the arithmetic applications `G` is the Galois group of a
 Galois extension and the module is the multiplicative group of the top field, read additively. The
 distinguished family of subgroups of the Artin–Tate definition is the family of open subgroups of
-`G`, which is why the levels below are indexed by `OpenSubgroup G`. This is the roadmap's
-domain-specific name for `SmoothDiscreteTopRep`; it is definitionally the same type and introduces
-no second representation bundle. -/
+`G`, which is why the levels below are indexed by `OpenSubgroup G`. A formation is definitionally
+the same type as `SmoothDiscreteTopRep ℤ G`, specialized to integral coefficients and to a
+profinite group; it introduces no second representation bundle. -/
 -- The underlying category of smooth discrete objects makes sense over any topological monoid, so
 -- the three profinite hypotheses are mentioned nowhere in the body; they are named with a leading
 -- underscore, the convention for an argument that is deliberately unused there. They are kept

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -60,7 +60,7 @@ as `Kˣ` enters through an `Additive` adapter.
 * `TauCeti.ClassFieldTheory.Formation.exists_mem_level`: every element of the coefficient module
   is fixed by an open subgroup.
 * `TauCeti.ClassFieldTheory.NormalLayer.groundLevelEquiv`: `(A^V)^{U/V} ≃ A^U`.
-* `TauCeti.ClassFieldTheory.NormalLayer.tateHZeroEquivNormQuotient`: degree-zero Tate cohomology
+* `TauCeti.ClassFieldTheory.NormalLayer.tateHZeroIsoNormQuotient`: degree-zero Tate cohomology
   of the layer is the norm quotient.
 
 ## Implementation notes
@@ -437,7 +437,7 @@ theorem map_groundLevelEquiv_submoduleOf :
 
 /-- **Degree-zero Tate cohomology of a finite normal layer is its norm quotient.** This is the
 low-degree identification that the Artin map of a class formation is read through. -/
-def tateHZeroEquivNormQuotient :
+def tateHZeroIsoNormQuotient :
     L.TateH F 0 ≅ ModuleCat.of ℤ (L.NormQuotient F) :=
   TateCohomology.H0IsoNormQuotient (L.rep F) ≪≫
     (Submodule.Quotient.equiv _ _ (L.groundLevelEquiv F)
@@ -446,13 +446,13 @@ def tateHZeroEquivNormQuotient :
 /-- The identification of degree-zero Tate cohomology with the norm quotient sends the class of an
 invariant to the class of the corresponding element of the ground level. -/
 @[simp]
-theorem tateHZeroEquivNormQuotient_hom_H0π (x : (L.rep F).ρ.invariants) :
-    (L.tateHZeroEquivNormQuotient F).hom (TateCohomology.H0π (L.rep F) x) =
+theorem tateHZeroIsoNormQuotient_hom_H0π (x : (L.rep F).ρ.invariants) :
+    (L.tateHZeroIsoNormQuotient F).hom (TateCohomology.H0π (L.rep F) x) =
       L.normQuotientMk F (L.groundLevelEquiv F x) := by
   -- The elementwise form of the low-degree identification is bound as a hypothesis first, so
   -- that it is normalised to the application form the goal uses before it rewrites.
   have h := TateCohomology.H0π_comp_H0IsoNormQuotient_hom_apply (L.rep F) x
-  simp [tateHZeroEquivNormQuotient, normQuotientMk, h]
+  simp [tateHZeroIsoNormQuotient, normQuotientMk, h]
 
 end Norm
 

--- a/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
+++ b/TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean
@@ -101,6 +101,10 @@ open CategoryTheory Representation
 
 namespace TauCeti.ClassFieldTheory
 
+-- Provenance: the signatures of the two structures below, and of `level`, `rep`, `norm` and the
+-- cohomology carriers, follow the blueprint `Suggested.lean` of the Tau Ceti `ClassFieldTheory`
+-- roadmap (`TauCetiRoadmap/ClassFieldTheory/README.md` and `Suggested.lean`).
+
 attribute [local instance] TopRep.distribMulAction TopRep.smulCommClass
 
 /-! ### Formations and their levels -/


### PR DESCRIPTION
This PR opens the class-field-theory development with the objects everything downstream is stated about: an Artin–Tate **formation** in the topological form the roadmap fixes, its **levels**, and the **finite normal layers** of a formation. It serves Layer 1 of the `ClassFieldTheory` roadmap, "formations and finite normal layers", whose exit criterion asks that `Ĥ^r(U/V, A^V)`, `A^U / N_{U/V}(A^V)` and the layer's Galois group all be represented by named types and canonical maps.

A `Formation` on a topological group `G` is a smooth discrete topological representation over `ℤ`, and `Formation.level U` is the submodule `A^U` fixed by an open subgroup `U`. Keeping every level inside one ambient module is what makes the inclusion of one level into another and the norm between two levels maps of submodules of a fixed module; `Formation.exists_mem_level` records that smoothness is exactly the Artin–Tate condition that each element of `A` is fixed by a sufficiently small member of the distinguished family. A `NormalLayer` is a pair of open subgroups `V ≤ U` with `V` normal in `U`, with `Gal = U ⧸ V` finite when `G` is compact, `degree` its index, and `ofOpenNormal` the layers `V ◁ ⊤` whose Galois group `galOfOpenNormalEquiv` identifies with `G ⧸ V`.

The coefficient module `NormalLayer.rep` is the level `A^V` carrying the action of `U ⧸ V`: the `U`-action on `A^V` is well defined because `V` is normal in `U`, and `V` acts trivially, so it descends. It is built from `Representation.subrepresentation` and `Representation.ofQuotient` rather than from Mathlib's packaged `Rep.quotientToInvariants`, so that the underlying module of `rep` is *definitionally* `A^V`; the packaged functor produces the invariants of the restriction of `A` along `V ∩ U → U → G`, the same submodule of the ambient module but not the same term, and every later comparison would have to transport along that equality. On top of that, `invariants_rep` and `groundLevelEquiv` prove `(A^V)^{U/V} = A^U` — an equality of submodules of `A^V`, so the identification moves no element — and `norm`, `normSubgroup` and `NormQuotient` give `N_{U/V} : A^V → A^U`, its image, and `A^U / N_{U/V}(A^V)`, with the value of the norm computed as the sum of the Galois conjugates and, on a ground-level element, as multiplication by the degree.

The file closes by consuming the Layer-0 work already merged: `tateHZeroEquivNormQuotient` identifies `Ĥ⁰(U/V, A^V)` with the norm quotient, by transporting `TauCeti.TateCohomology.H0IsoNormQuotient` (added in #5639) along `groundLevelEquiv`. This is the degree-`0` half of the pair of low-degree identifications through which the Artin map of a class formation is read; the degree-`-2` half is `TauCeti.TateCohomology.HNegTwoAddEquivAbelianization`, already available at the layer's Galois group and so not restated here.

Both `G` and the coefficient module live in `Type`, because Mathlib's `tateCohomology` asks for the finite group, the coefficient ring `ℤ` and the coefficient module in one universe. `G` is profinite: `IsTopologicalGroup`, `CompactSpace` and `TotallyDisconnectedSpace` are hypotheses of both `Formation` and `NormalLayer`, exactly as the roadmap's `Suggested.lean` fixes them, so the Galois group of every layer is finite and its `degree` is a genuine index. The underlying `Rep ℤ G` is read through `Representation.ofDistribMulAction` at the action `TauCeti.TopRep.distribMulAction` derives from the operators of the topological representation, rather than through `ContRepresentation.toRepresentation`, because the latter carries the `Module ℤ` instance packaged inside `TopRep` and that is not the instance typeclass synthesis produces for an integral module. No Mathlib infrastructure is vendored.

New file: `TauCeti/NumberTheory/ClassFieldTheory/Formation/Basic.lean` (394 lines).

**Layer-0 status.** Every Layer-0 output this PR consumes is already on `main`. The only one it uses at all is `TauCeti.TateCohomology.H0IsoNormQuotient` (`Ĥ⁰(G,M) ≃ M^G / N_G M`, merged in #5639); Mathlib supplies the Tate complex, `tateCohomology`, its functoriality, `δ`, the long exact sequence and `isoGroupCohomology`/`isoGroupHomology`, and `TauCeti/RepresentationTheory/Homological/TateCohomology/` already carries `HNegTwoAddEquivAbelianization`, positive-degree inflation with its comparison (#5809), two-periodicity for cyclic groups and the Herbrand quotient (#5764). No declaration in this PR needs the generic Tate theorem, the Tate cup product, or restriction/corestriction in general degrees.

After this PR, Layer 1 still owes the finite quotient system `subgroupLayer` with `subgroupGalEquiv`, `degree_subgroupLayer` and `subgroupRestriction`; the abelian layers `IsAbelianClassFieldLayer` and the maximal abelian sublayer; and the restriction, corestriction, refinement and conjugation adapters with their tower compatibility. Those adapters are deliberately not in this PR — they are separate topics, and the last of them will consume the Layer-0 res/cor item when it lands — but nothing delivered here anticipates or depends on them.

Roadmap: ClassFieldTheory

<!--tauceti-target:v1 {"focus":"ClassFieldTheory","id":"formation-normal-layer"}-->

🤖 Prepared with Claude Code


