### PR TITLE
refactor: drop two `namespace` blocks that declare nothing

### DIFF
--- a/TauCeti/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/TauCeti/Topology/Algebra/ContinuousMonoidHom.lean
@@ -44,8 +44,6 @@ theorem subgroupSubtype_apply (S : Subgroup G) (s : S) : subgroupSubtype S s = (
 
 end ContinuousMonoidHom
 
-namespace Subgroup
-
 /-- The inverse conjugation homomorphism of a normal subgroup, with the subspace topology. -/
 def _root_.Subgroup.inverseConjugationHom [IsTopologicalGroup G] (N : Subgroup G) [N.Normal]
     (g : G) : N →ₜ* N where
@@ -98,8 +96,6 @@ theorem _root_.Subgroup.inverseConjugationHom_mul [IsTopologicalGroup G] (N : Su
         (_root_.Subgroup.inverseConjugationHom N g) := by
   ext n
   simp [_root_.Subgroup.inverseConjugationHom_apply, mul_assoc]
-
-end Subgroup
 
 namespace ContinuousMonoidHom
 

--- a/TauCeti/Topology/Homotopy/Monodromy/BasepointChange.lean
+++ b/TauCeti/Topology/Homotopy/Monodromy/BasepointChange.lean
@@ -39,8 +39,6 @@ namespace TauCeti
 variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X]
   {p : E → X} {x₀ x₁ : X}
 
-namespace IsCoveringMap
-
 /-- **Conjugation law for monodromy along a path.** A class `g` at `x₁` fixes the endpoint
 `hp.monodromy ⟦γ⟧ e₀` of the lift of `γ` exactly when its transport back along `γ` fixes the
 starting point `e₀`. This is the path-level statement behind
@@ -111,7 +109,5 @@ theorem _root_.IsCoveringMap.range_mapOfEq_monodromy_path (hp : IsCoveringMap p)
     FundamentalGroup.mem_basepointChangeSubgroup_iff,
     ← IsCoveringMap.monodromy_eq_self_iff_mem_range hp e₀]
   exact hp.monodromy_eq_self_iff_fundamentalGroupMulEquivOfPath_symm_apply γ e₀ g
-
-end IsCoveringMap
 
 end TauCeti


### PR DESCRIPTION
Both blocks below wrap declarations that **all** escape them with `_root_`, so neither puts a
name into the namespace it opens — the block only makes the file read as though it did. Same
residue #5820 and #5838 removed:

| file | block | declarations |
|---|---|---|
| `Topology/Algebra/ContinuousMonoidHom.lean` | `namespace Subgroup` | 4, all `_root_.Subgroup.…` |
| `Topology/Homotopy/Monodromy/BasepointChange.lean` | `namespace IsCoveringMap` | 2, all `_root_.IsCoveringMap.…` |

Two conditions were checked for each:

- **No `variable` inside**, so no binder scope widens.
- **No reference to one of the block's own declarations by short name** — every internal
  reference is written in full.

That second condition is the one that matters, and it is why this PR is smaller than when it was
first opened. Inside `namespace Foo`, a declaration written `_root_.Foo.bar` is reachable from a
later sibling as plain `bar`; deleting the wrapper then breaks those references with
`unknown identifier bar`. The first revision also removed the wrappers in
`Cohomology/Module/Basic.lean`, `Cohomology/Module/Base.lean` and
`QuadraticForm/SpecialOrthogonal.lean`, and the sandboxed build rejected all three for exactly
that reason. They are correct as they stand and have been restored.

Two further blocks (`Profinite/ProP.lean`, `CharacterTable/Determined.lean`) are also left alone:
each has a `variable` inside *and* a declaration after the block, so removing the wrapper would
newly apply those variables to that declaration.

Eight lines deleted, no other change.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp