### PR TITLE
refactor(HeckeRing): name the unpacking step in the GL2 support-subset proof

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -303,25 +303,21 @@ end DegreeCount
 
 section SupportSubset
 
-include hp in
-/-- The support of `T(1,p) · T(1,pᵏ)` is contained in `{T(1,p^(k+1)), T(p,pᵏ)}`. -/
-private lemma mulSupport_pp_subset (k : ℕ)
-    (A : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+/-- Unpacking a support coset of `T(1,p) · T(1,pᵏ)`. If `T(a)` occurs in the product then some
+pair of coset representatives multiplies into the double coset of `natDiagGL 2 a`; naming the
+`SL₂(ℤ)` lift of each of the four `SL₂` factors turns that membership into an explicit
+equation. -/
+private lemma mulSupport_pp_exists_prod_eq (k : ℕ) (a : Fin 2 → ℕ)
     (hA : multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
       (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
-      (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)) ((A.rep : GL (Fin 2) ℚ)) ≠ 0) :
-    A = diagCoset ![1, p ^ (k + 1)] ∨ A = diagCoset ![p, p ^ k] := by
-  classical
-  -- Stage 1: positivity of the two input diagonals, and a diagonal representative `a` for `A`.
-  have h1p_pos : ∀ i : Fin 2, 0 < (![1, p] : Fin 2 → ℕ) i := fun i ↦ by
-    fin_cases i <;> simp [hp.pos]
-  have h1pk_pos : ∀ i : Fin 2, 0 < (![1, p ^ k] : Fin 2 → ℕ) i := fun i ↦ by
-    fin_cases i <;> simp [pow_pos hp.pos k]
-  obtain ⟨a, ha_pos, hdiv, hA_eq⟩ := exists_diagonal_representative A
-  -- Stage 2: `A` occurs in the product, so some pair `q` of coset representatives multiplies
-  -- into the double coset of `natDiagGL 2 a`; unpack that into an explicit `La · D · Ra`.
+      (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
+      (((diagCoset a).rep : GL (Fin 2) ℚ)) ≠ 0) :
+    ∃ SL_i₀ SL_j₀ SL_La SL_Ra : SpecialLinearGroup (Fin 2) ℤ,
+      mapGL ℚ SL_i₀ * ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) *
+        (mapGL ℚ SL_j₀ * ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)) =
+        mapGL ℚ SL_La * natDiagGL 2 a * mapGL ℚ SL_Ra := by
   have hmem := (HeckeCoset.mem_image_mulMap_iff (diagCoset ![1, p]).rep
-    (diagCoset ![1, p ^ k]).rep A).mpr hA
+    (diagCoset ![1, p ^ k]).rep (diagCoset a)).mpr hA
   simp only [Finset.mem_image, Finset.mem_univ, true_and] at hmem
   obtain ⟨q, hq⟩ := hmem
   have h_prod_mem : ((q.1.out : GL (Fin 2) ℚ) * ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) *
@@ -333,47 +329,59 @@ private lemma mulSupport_pp_subset (k : ℕ)
           (diagCoset ![1, p]).rep (diagCoset ![1, p ^ k]).rep q).toSet := by
       rw [HeckeCoset.mulMap_eq_mk, HeckeCoset.toSet_mk]
       exact mem_doubleCoset_self _ _ _
-    rwa [hq, hA_eq, diagCoset_toSet] at hself
+    rwa [hq, diagCoset_toSet] at hself
   rw [mem_doubleCoset] at h_prod_mem
   obtain ⟨La, hLa, Ra, hRa, h_prod_eq⟩ := h_prod_mem
-  -- Stage 3: every `SLnZ 2` element appearing above is `mapGL ℚ` of an honest integral `SL₂`
-  -- matrix; name those lifts, and likewise for the two input cosets' own decompositions.
   obtain ⟨SL_La, hSL_La⟩ := (mem_SLnZ_iff 2).mp hLa
   obtain ⟨SL_Ra, hSL_Ra⟩ := (mem_SLnZ_iff 2).mp hRa
   obtain ⟨SL_i₀, hSL_i₀⟩ := (mem_SLnZ_iff 2).mp q.1.out.2
   obtain ⟨SL_j₀, hSL_j₀⟩ := (mem_SLnZ_iff 2).mp q.2.out.2
+  refine ⟨SL_i₀, SL_j₀, SL_La, SL_Ra, ?_⟩
+  rw [hSL_i₀, hSL_j₀, hSL_La, hSL_Ra]
+  exact h_prod_eq
+
+include hp in
+/-- The support of `T(1,p) · T(1,pᵏ)` is contained in `{T(1,p^(k+1)), T(p,pᵏ)}`. -/
+private lemma mulSupport_pp_subset (k : ℕ)
+    (A : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+    (hA : multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+      (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+      (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)) ((A.rep : GL (Fin 2) ℚ)) ≠ 0) :
+    A = diagCoset ![1, p ^ (k + 1)] ∨ A = diagCoset ![p, p ^ k] := by
+  -- Stage 1: positivity of the two input diagonals, and a diagonal representative `a` for `A`.
+  have h1p_pos : ∀ i : Fin 2, 0 < (![1, p] : Fin 2 → ℕ) i := fun i ↦ by
+    fin_cases i <;> simp [hp.pos]
+  have h1pk_pos : ∀ i : Fin 2, 0 < (![1, p ^ k] : Fin 2 → ℕ) i := fun i ↦ by
+    fin_cases i <;> simp [pow_pos hp.pos k]
+  obtain ⟨a, ha_pos, hdiv, rfl⟩ := exists_diagonal_representative A
+  -- Stage 2: `T(a)` occurs in the product, so the two coset representatives multiply into the
+  -- double coset of `natDiagGL 2 a`, with every factor lifted to an integral `SL₂` matrix.
+  obtain ⟨SL_i₀, SL_j₀, SL_La, SL_Ra, h_prod_eq⟩ := mulSupport_pp_exists_prod_eq p k a hA
+  -- Stage 3: the two input cosets' own decompositions, lifted the same way.
   obtain ⟨L₁, hL₁, R₁, hR₁, hD1⟩ := exists_rep_diagCoset_eq_mul_natDiagGL_mul (![1, p])
   obtain ⟨SL_L₁, hSL_L₁⟩ := (mem_SLnZ_iff 2).mp hL₁
   obtain ⟨SL_R₁, hSL_R₁⟩ := (mem_SLnZ_iff 2).mp hR₁
   obtain ⟨L₂, hL₂, R₂, hR₂, hD2⟩ := exists_rep_diagCoset_eq_mul_natDiagGL_mul (![1, p ^ k])
   obtain ⟨SL_L₂, hSL_L₂⟩ := (mem_SLnZ_iff 2).mp hL₂
   obtain ⟨SL_R₂, hSL_R₂⟩ := (mem_SLnZ_iff 2).mp hR₂
-  have h_prod_eq' : (q.1.out : GL (Fin 2) ℚ) *
-      ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) *
-      ((q.2.out : GL (Fin 2) ℚ) * ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)) =
-      mapGL ℚ SL_La * natDiagGL 2 a * mapGL ℚ SL_Ra := by
-    rw [hSL_La, hSL_Ra]
-    exact h_prod_eq
   -- Stage 4: determinants. Both sides of the product have determinant `p^(k+1)`, which pins
   -- `a 0 * a 1`; the two coset representatives' determinants come from `diagCoset_rep_det`, and
   -- the two `SL₂` factors' from `det_eq_one_of_mem_SLnZ`.
-  have h_det := diag_entries_mul_eq_pow_succ p k a ha_pos (q.1.out : GL (Fin 2) ℚ)
-    ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) (q.2.out : GL (Fin 2) ℚ)
+  have h_det := diag_entries_mul_eq_pow_succ p k a ha_pos (mapGL ℚ SL_i₀)
+    ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) (mapGL ℚ SL_j₀)
     ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)
-    (det_eq_one_of_mem_SLnZ 2 q.1.out.2)
+    (det_eq_one_of_mem_SLnZ 2 ((mem_SLnZ_iff 2).mpr ⟨SL_i₀, rfl⟩))
     (by rw [diagCoset_rep_det _ h1p_pos]; simp [Fin.prod_univ_two])
-    (det_eq_one_of_mem_SLnZ 2 q.2.out.2)
+    (det_eq_one_of_mem_SLnZ 2 ((mem_SLnZ_iff 2).mpr ⟨SL_j₀, rfl⟩))
     (by rw [diagCoset_rep_det _ h1pk_pos]; simp [Fin.prod_univ_two])
-    SL_La SL_Ra h_prod_eq'
+    SL_La SL_Ra h_prod_eq
   -- Stage 5: the first invariant factor divides `p`, because conjugating the middle matrix
   -- keeps it integral. With `a 0 * a 1 = p^(k+1)` that leaves only the two claimed cosets.
   have h_dvd := mulSupport_pp_dvd_p p hp k a ha_pos hdiv
     ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)
-    (q.1.out : GL (Fin 2) ℚ) (q.2.out : GL (Fin 2) ℚ)
+    (mapGL ℚ SL_i₀) (mapGL ℚ SL_j₀)
     SL_L₁ SL_R₁ SL_L₂ SL_R₂ SL_La SL_Ra SL_i₀ SL_j₀
-    (by rw [hD1, hSL_L₁, hSL_R₁]) (by rw [hD2, hSL_L₂, hSL_R₂])
-    hSL_i₀.symm hSL_j₀.symm h_prod_eq'
-  rw [hA_eq]
+    (by rw [hD1, hSL_L₁, hSL_R₁]) (by rw [hD2, hSL_L₂, hSL_R₂]) rfl rfl h_prod_eq
   exact mulSupport_pp_case_split p hp k a h_det h_dvd
 
 include hp in

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -201,21 +201,17 @@ private lemma mulSupport_pp_dvd_p_aux (p : ℕ) (hp : p.Prime)
 /-- Divisibility constraint: if a `T(1,p) · T(1,pᵏ)`-shaped product lies in the double
 coset of `diag a`, the first invariant `a 0` divides `p`. -/
 private lemma mulSupport_pp_dvd_p (p : ℕ) (hp : p.Prime) (k : ℕ) (a : Fin 2 → ℕ)
-    (ha_pos : ∀ i, 0 < a i) (hdiv : IsDvdChain a) (D1c D2c i₀_gl j₀_gl : GL (Fin 2) ℚ)
+    (ha_pos : ∀ i, 0 < a i) (hdiv : IsDvdChain a) (D1c D2c : GL (Fin 2) ℚ)
     (SL_L₁ SL_R₁ SL_L₂ SL_R₂ SL_La SL_Ra SL_i₀ SL_j₀ : SpecialLinearGroup (Fin 2) ℤ)
     (hD1_eq : D1c = mapGL ℚ SL_L₁ * natDiagGL 2 (![1, p]) * mapGL ℚ SL_R₁)
     (hD2_eq : D2c = mapGL ℚ SL_L₂ * natDiagGL 2 (![1, p ^ k]) * mapGL ℚ SL_R₂)
-    (hi₀ : i₀_gl = mapGL ℚ SL_i₀) (hj₀ : j₀_gl = mapGL ℚ SL_j₀)
-    (h_prod_eq_a : i₀_gl * D1c * (j₀_gl * D2c) =
+    (h_prod_eq_a : mapGL ℚ SL_i₀ * D1c * (mapGL ℚ SL_j₀ * D2c) =
       mapGL ℚ SL_La * natDiagGL 2 a * mapGL ℚ SL_Ra) : a 0 ∣ p := by
   apply mulSupport_pp_dvd_p_aux p hp (SL_R₁ * SL_j₀ * SL_L₂) (SL_La⁻¹ * SL_i₀ * SL_L₁)
     (SL_R₂ * SL_Ra⁻¹) a ha_pos hdiv k
-  have hprod : mapGL ℚ SL_i₀ * (mapGL ℚ SL_L₁ * natDiagGL 2 (![1, p]) * mapGL ℚ SL_R₁) *
-      (mapGL ℚ SL_j₀ * (mapGL ℚ SL_L₂ * natDiagGL 2 (![1, p ^ k]) * mapGL ℚ SL_R₂)) =
-      mapGL ℚ SL_La * natDiagGL 2 a * mapGL ℚ SL_Ra := by
-    rwa [← hi₀, ← hj₀, ← hD1_eq, ← hD2_eq]
+  rw [hD1_eq, hD2_eq] at h_prod_eq_a
   have hiso := congr_arg (· * (mapGL ℚ SL_Ra)⁻¹)
-    (congr_arg ((mapGL ℚ SL_La)⁻¹ * ·) hprod)
+    (congr_arg ((mapGL ℚ SL_La)⁻¹ * ·) h_prod_eq_a)
   simp only [mul_assoc, inv_mul_cancel_left] at hiso
   simp only [map_mul, map_inv]
   convert hiso using 1
@@ -366,22 +362,21 @@ private lemma mulSupport_pp_subset (k : ℕ)
   obtain ⟨SL_R₂, hSL_R₂⟩ := (mem_SLnZ_iff 2).mp hR₂
   -- Stage 4: determinants. Both sides of the product have determinant `p^(k+1)`, which pins
   -- `a 0 * a 1`; the two coset representatives' determinants come from `diagCoset_rep_det`, and
-  -- the two `SL₂` factors' from `det_eq_one_of_mem_SLnZ`.
+  -- the two `SL₂` factors' from `SpecialLinearGroup.det_mapGL`.
   have h_det := diag_entries_mul_eq_pow_succ p k a ha_pos (mapGL ℚ SL_i₀)
     ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) (mapGL ℚ SL_j₀)
     ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)
-    (det_eq_one_of_mem_SLnZ 2 ((mem_SLnZ_iff 2).mpr ⟨SL_i₀, rfl⟩))
+    (congrArg Units.val (SpecialLinearGroup.det_mapGL (S := ℚ) SL_i₀))
     (by rw [diagCoset_rep_det _ h1p_pos]; simp [Fin.prod_univ_two])
-    (det_eq_one_of_mem_SLnZ 2 ((mem_SLnZ_iff 2).mpr ⟨SL_j₀, rfl⟩))
+    (congrArg Units.val (SpecialLinearGroup.det_mapGL (S := ℚ) SL_j₀))
     (by rw [diagCoset_rep_det _ h1pk_pos]; simp [Fin.prod_univ_two])
     SL_La SL_Ra h_prod_eq
   -- Stage 5: the first invariant factor divides `p`, because conjugating the middle matrix
   -- keeps it integral. With `a 0 * a 1 = p^(k+1)` that leaves only the two claimed cosets.
   have h_dvd := mulSupport_pp_dvd_p p hp k a ha_pos hdiv
     ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)
-    (mapGL ℚ SL_i₀) (mapGL ℚ SL_j₀)
     SL_L₁ SL_R₁ SL_L₂ SL_R₂ SL_La SL_Ra SL_i₀ SL_j₀
-    (by rw [hD1, hSL_L₁, hSL_R₁]) (by rw [hD2, hSL_L₂, hSL_R₂]) rfl rfl h_prod_eq
+    (by rw [hD1, hSL_L₁, hSL_R₁]) (by rw [hD2, hSL_L₂, hSL_R₂]) h_prod_eq
   exact mulSupport_pp_case_split p hp k a h_det h_dvd
 
 include hp in


### PR DESCRIPTION
`mulSupport_pp_subset` ran to **74 lines** — the only declaration in
`GL2/MultiplicationTable.lean` over the 50-line cap.

Its first two stages did one self-contained job: turn the hypothesis "`T(a)` occurs in
`T(1,p) · T(1,pᵏ)`" into an explicit equation between products of integral matrices. This
PR gives that step a name.

### What changed

* New `private lemma mulSupport_pp_exists_prod_eq` (33L): from the non-vanishing
  multiplicity it produces the four `SL₂(ℤ)` matrices witnessing
  `mapGL ℚ SL_i₀ * T(1,p).rep * (mapGL ℚ SL_j₀ * T(1,pᵏ).rep) = mapGL ℚ SL_La * diag a * mapGL ℚ SL_Ra`.

  Returning the *lifts* rather than the raw `SLnZ 2` members is what makes this pay:
  the caller previously took the coset representatives, re-derived their lifts through
  `mem_SLnZ_iff`, and then restated the product equation in lifted form. All of that is
  now internal, and the two `hi₀`/`hj₀` arguments it fed onward become `rfl`.

* `mulSupport_pp_subset` **74L → 45L**, and the file has **no over-cap declaration left**.
  Destructuring `exists_diagonal_representative` with `rfl` also removes the closing
  `rw [hA_eq]`.

* Neither proof turns out to need `classical` — I removed it from each and confirmed both
  still build. It was dead weight before this PR too.

No statement changes: `mulSupport_pp_subset` keeps its signature, and every downstream
user is untouched.

### Why this shape

The file had already chosen this seam and stopped partway: stages 4 and 5 are the named
`diag_entries_mul_eq_pow_succ`, `mulSupport_pp_dvd_p` and `mulSupport_pp_case_split`,
while stages 1–3 sat inline. The new lemma joins the existing `mulSupport_pp_*` family.

### Verification

* `lake build TauCeti.NumberTheory.HeckeRing.GL2.MultiplicationTable` — clean.
* `#lint` with the 13-linter set (`checkType defsWithUnderscore deprecatedNoSince
  impossibleInstance nonClassInstance simpComm simpNF structureInType
  subsetDotNotationLinter synTaut tacticDocs unusedArguments unusedHavesSuffices`) over
  the import cone: **0 errors in 636 declarations**.
* No line over 100 characters; no trailing whitespace.

Roadmap: ModularForms

Provenance: refactor of already-merged TauCeti code; no new mathematics, so no target
marker. Swept github.com/CBirkbeck/AINTLIB @ 2baa76f742bdb4fb8ee323fabba41203bd390e08
(Apache-2.0) for a counterpart: `mem_mulSupport_of_product_mem`
(`AbstractHeckeRing/Multiplication.lean`) is the converse direction, and the Γ₀ analogue
`mulSupport_Gamma0_pp_subset` (`GLn/CongruenceHecke/Surjectivity.lean`) names only a
coarser split that keeps this unpacking inline. Nothing was transcribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
