### PR TITLE
feat: the continuous characters of the circle are the Fourier monomials

### DIFF
--- a/TauCeti/Analysis/Fourier/AddCircle.lean
+++ b/TauCeti/Analysis/Fourier/AddCircle.lean
@@ -8,30 +8,65 @@ module
 public import Mathlib.Analysis.Fourier.AddCircle
 
 /-!
-# Distinct Fourier monomials
+# The continuous characters of the circle are the Fourier monomials
 
 Mathlib's `fourier n : C(AddCircle T, ℂ)` is developed as a family of `L²` monomials: the lemmas
 about it record how it behaves in the *index* `n` (`fourier_add`, `fourier_neg`) and what it
-contributes to the Fourier basis. Read the other way, as a family of characters of `AddCircle T`
-indexed by `n`, the first thing a representation-theoretic consumer needs is that the family is
-*faithful*: distinct indices give distinct characters, so the corresponding one-dimensional
-representations are pairwise inequivalent.
+contributes to the Fourier basis. Read the other way, as a family of *characters* of the group
+`AddCircle T` indexed by `n`, the two facts a representation-theoretic consumer needs are that the
+family is **faithful** (distinct indices give distinct characters, so the corresponding
+one-dimensional representations are pairwise inequivalent) and that it is **exhaustive** (there are
+no other continuous characters). This file proves both, and packages them as an equivalence
+between `ℤ` and the continuous additive characters of the circle.
 
-That is the single fact recorded here. Multiplicativity in the circle argument needs no lemma of
-its own: it is Mathlib's `AddCircle.toCircle_addChar`, the bundled additive character underlying
-`fourier`.
+Faithfulness is elementary: two monomials already differ at the point `T / 2 / (m - n)`.
+Exhaustiveness is where analysis enters. A continuous character `χ` is in particular a nonzero
+continuous function, so some Fourier coefficient `fourierCoeff χ n` is nonzero — that is Mathlib's
+`fourierBasis`, a Hilbert basis of `L²`, together with the injectivity of the map
+`C(AddCircle T, ℂ) → L²`. Translating that coefficient by `y` and using that both `fourier (-n)`
+and `χ` turn a sum into a product rewrites `fourierCoeff χ n` as
+`fourier (-n) y * χ y * fourierCoeff χ n`, whence `fourier (-n) y * χ y = 1`, and therefore
+`χ y = fourier n y`.
+
+Nothing here assumes that `χ` takes values in the unit circle: on a compact group that is
+automatic, and here it comes out as a corollary, since a continuous character *is* a Fourier
+monomial.
+
+`TauCeti/RepresentationTheory/Compact/Circle.lean` reads this classification for the circle group
+`Multiplicative (AddCircle T)`, where it says that the one-dimensional continuous representations
+of the circle are exactly the Fourier ones.
+
+## Main definitions
+
+* `TauCeti.fourierAddChar`: the `n`-th Fourier monomial as a bundled additive character
+  `AddChar (AddCircle T) ℂ`.
+* `TauCeti.fourierAddCharEquiv`: the resulting equivalence between `ℤ` and the continuous additive
+  characters of `AddCircle T`.
 
 ## Main statements
 
 * `TauCeti.fourier_injective`: `n ↦ fourier n` is injective, so distinct indices give distinct
   characters.
+* `TauCeti.eq_zero_of_forall_fourierCoeff_eq_zero`: a continuous function on the circle all of
+  whose Fourier coefficients vanish is the zero function.
+* `TauCeti.exists_fourierAddChar_eq`: **every continuous additive character of the circle is a
+  Fourier monomial.**
+* `TauCeti.norm_apply_eq_one_of_continuous_addChar`: consequently a continuous additive character
+  of the circle takes values of modulus one.
+
+## References
+
+* [Compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
+  the worked example "The circle `S¹` and Fourier series are Peter-Weyl".
 
 ## Tags
 
-Fourier, additive circle, character
+Fourier, additive circle, character, Pontryagin dual
 -/
 
 public section
+
+open MeasureTheory AddCircle
 
 namespace TauCeti
 
@@ -61,5 +96,125 @@ theorem fourier_injective (hT : T ≠ 0) : Function.Injective (fourier (T := T))
           rw [← Complex.exp_sub, he]
       _ = 1 := by rw [hx, div_self (Complex.exp_ne_zero _)]
   norm_num at hcontra
+
+/-- **Fourier monomials are multiplicative in the circle variable.** Mathlib's `fourier_add`
+records multiplicativity in the *index*; this is the other variable, and it is what makes
+`fourier n` a character of `AddCircle T`. -/
+theorem fourier_apply_add (n : ℤ) (x y : AddCircle T) :
+    fourier n (x + y) = fourier n x * fourier n y := by
+  simp_rw [fourier_apply, smul_add, toCircle_add, Circle.coe_mul]
+
+/-- **The `n`-th Fourier monomial as a bundled additive character of the circle.** -/
+noncomputable def fourierAddChar (n : ℤ) : AddChar (AddCircle T) ℂ where
+  toFun := fourier n
+  map_zero_eq_one' := fourier_eval_zero n
+  map_add_eq_mul' := fourier_apply_add n
+
+@[simp]
+theorem fourierAddChar_apply (n : ℤ) (x : AddCircle T) :
+    fourierAddChar n x = fourier n x := (rfl)
+
+theorem continuous_fourierAddChar (n : ℤ) : Continuous (fourierAddChar (T := T) n) :=
+  (fourier n).continuous
+
+/-- Distinct indices give distinct additive characters: `TauCeti.fourier_injective` again. -/
+theorem fourierAddChar_injective (hT : T ≠ 0) :
+    Function.Injective (fourierAddChar (T := T)) := fun _ _ h =>
+  fourier_injective hT (ContinuousMap.ext fun x => DFunLike.congr_fun h x)
+
+section Classification
+
+variable [Fact (0 < T)]
+
+/-- **A continuous function on the circle with vanishing Fourier coefficients is zero.** The
+Fourier coefficients are the coordinates of the function in Mathlib's Hilbert basis `fourierBasis`
+of `L²`, so they determine its class in `L²`, and a continuous function on the circle is determined
+by that class because normalized Haar measure is positive on nonempty open sets. -/
+theorem eq_zero_of_forall_fourierCoeff_eq_zero (F : C(AddCircle T, ℂ))
+    (h : ∀ n : ℤ, fourierCoeff (⇑F) n = 0) : F = 0 := by
+  have hzero : ∀ n : ℤ,
+      fourierBasis.repr (ContinuousMap.toLp (E := ℂ) 2 haarAddCircle ℂ F) n = 0 := fun n => by
+    rw [fourierBasis_repr, fourierCoeff_toLp, h n]
+  have hsum := fourierBasis.hasSum_repr (ContinuousMap.toLp (E := ℂ) 2 haarAddCircle ℂ F)
+  simp only [hzero, zero_smul] at hsum
+  refine ContinuousMap.toLp_injective (𝕜 := ℂ) (p := 2) haarAddCircle ?_
+  rw [map_zero]
+  exact (hasSum_zero.unique hsum).symm
+
+/-- **Every continuous additive character of the circle is a Fourier monomial.** Together with
+`TauCeti.fourierAddChar_injective` this identifies the continuous characters of `AddCircle T` with
+`ℤ`.
+
+Some Fourier coefficient `c = fourierCoeff χ n` is nonzero, because `χ 0 = 1` makes `χ` a nonzero
+continuous function. Normalized Haar measure is translation invariant, so translating the integral
+defining `c` by `y` leaves it unchanged; expanding both `fourier (-n)` and `χ` on the translated
+sum turns that integral into `(fourier (-n) y * χ y) * c`, so `fourier (-n) y * χ y = 1`. Since
+also `fourier (-n) y * fourier n y = fourier 0 y = 1`, and `fourier (-n) y ≠ 0`, the two values
+agree. -/
+theorem exists_fourierAddChar_eq (χ : AddChar (AddCircle T) ℂ) (hχ : Continuous χ) :
+    ∃ n : ℤ, fourierAddChar n = χ := by
+  have hcoeff : ∀ n : ℤ, fourierCoeff (⇑(⟨χ, hχ⟩ : C(AddCircle T, ℂ))) n
+      = ∫ x : AddCircle T, fourier (-n) x * χ x ∂haarAddCircle := fun _ => rfl
+  have hFne : (⟨χ, hχ⟩ : C(AddCircle T, ℂ)) ≠ 0 := by
+    intro h
+    have hzero := DFunLike.congr_fun h (0 : AddCircle T)
+    simp at hzero
+  obtain ⟨n, hn⟩ : ∃ n : ℤ, ∫ x : AddCircle T, fourier (-n) x * χ x ∂haarAddCircle ≠ 0 := by
+    by_contra hcon
+    refine hFne (eq_zero_of_forall_fourierCoeff_eq_zero ⟨χ, hχ⟩ fun n => ?_)
+    rw [hcoeff n]
+    by_contra hne
+    exact hcon ⟨n, hne⟩
+  refine ⟨n, AddChar.ext _ _ fun y => ?_⟩
+  have hfactor : (∫ x : AddCircle T, fourier (-n) x * χ x ∂haarAddCircle)
+      = (fourier (-n) y * χ y) * ∫ x : AddCircle T, fourier (-n) x * χ x ∂haarAddCircle :=
+    calc (∫ x : AddCircle T, fourier (-n) x * χ x ∂haarAddCircle)
+        = ∫ x : AddCircle T, fourier (-n) (x + y) * χ (x + y) ∂haarAddCircle :=
+          (integral_add_right_eq_self _ y).symm
+      _ = ∫ x : AddCircle T, (fourier (-n) y * χ y) * (fourier (-n) x * χ x) ∂haarAddCircle :=
+          integral_congr_ae (Filter.Eventually.of_forall fun x => by
+            simp only [fourier_apply_add, AddChar.map_add_eq_mul]; ring)
+      _ = (fourier (-n) y * χ y) * ∫ x : AddCircle T, fourier (-n) x * χ x ∂haarAddCircle :=
+          integral_const_mul _ _
+  have hone : fourier (-n) y * χ y = 1 :=
+    mul_right_cancel₀ hn (by rw [one_mul]; exact hfactor.symm)
+  have hprod : fourier (-n) y * fourier n y = 1 := by
+    rw [← fourier_add, neg_add_cancel]
+    exact fourier_zero
+  have hne0 : fourier (-n) y ≠ 0 := by
+    rw [fourier_apply]
+    exact Circle.coe_ne_zero _
+  exact mul_left_cancel₀ hne0 (hprod.trans hone.symm)
+
+/-- The Fourier index of a continuous additive character of the circle is unique. -/
+theorem existsUnique_fourierAddChar_eq (χ : AddChar (AddCircle T) ℂ) (hχ : Continuous χ) :
+    ∃! n : ℤ, fourierAddChar n = χ := by
+  obtain ⟨n, hn⟩ := exists_fourierAddChar_eq χ hχ
+  exact ⟨n, hn, fun m hm =>
+    fourierAddChar_injective (Fact.out (p := (0 < T))).ne' (hm.trans hn.symm)⟩
+
+/-- **A continuous additive character of the circle takes values of modulus one.** No unitarity
+hypothesis is needed anywhere above: continuity alone forces the character to be a Fourier
+monomial, and `fourier n` is valued in the unit circle. -/
+theorem norm_apply_eq_one_of_continuous_addChar (χ : AddChar (AddCircle T) ℂ) (hχ : Continuous χ)
+    (x : AddCircle T) : ‖χ x‖ = 1 := by
+  obtain ⟨n, rfl⟩ := exists_fourierAddChar_eq χ hχ
+  rw [fourierAddChar_apply, fourier_apply]
+  exact Circle.norm_coe _
+
+/-- **The Fourier monomials index the continuous characters of the circle**, that is, the
+Pontryagin dual of `AddCircle T` is `ℤ`. This is the indexing under which the compact-group
+Peter-Weyl basis of `L²(AddCircle T)` becomes Mathlib's `AddCircle.fourierBasis`. -/
+noncomputable def fourierAddCharEquiv :
+    ℤ ≃ {χ : AddChar (AddCircle T) ℂ // Continuous χ} :=
+  Equiv.ofBijective (fun n => ⟨fourierAddChar n, continuous_fourierAddChar n⟩)
+    ⟨fun _ _ h => fourierAddChar_injective (Fact.out (p := (0 < T))).ne' (congrArg Subtype.val h),
+      fun χ => (exists_fourierAddChar_eq χ.1 χ.2).imp fun _ hn => Subtype.ext hn⟩
+
+@[simp]
+theorem fourierAddCharEquiv_apply (n : ℤ) :
+    (fourierAddCharEquiv (T := T) n : AddChar (AddCircle T) ℂ) = fourierAddChar n := (rfl)
+
+end Classification
 
 end TauCeti

--- a/TauCeti/Analysis/Fourier/AddCircle.lean
+++ b/TauCeti/Analysis/Fourier/AddCircle.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Fourier.AddCircle
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleAddChar
+public import Mathlib.Topology.Algebra.PontryaginDual
 
 /-!
 # The continuous characters of the circle are the Fourier monomials
@@ -17,8 +18,8 @@ contributes to the Fourier basis. Read the other way, as a family of *characters
 `AddCircle T` indexed by `n`, the two facts a representation-theoretic consumer needs are that the
 family is **faithful** (distinct indices give distinct characters, so the corresponding
 one-dimensional representations are pairwise inequivalent) and that it is **exhaustive** (there are
-no other continuous characters). This file proves both, and packages them as an equivalence
-between `ℤ` and the continuous additive characters of the circle.
+no other continuous characters). This file proves both, and packages them as an isomorphism of
+groups between `Multiplicative ℤ` and the Pontryagin dual of the circle group.
 
 Faithfulness is elementary: two monomials already differ at the point `T / 2 / (m - n)`.
 Exhaustiveness is where analysis enters. A continuous character `χ` is in particular a nonzero
@@ -34,15 +35,18 @@ automatic, and here it comes out as a corollary, since a continuous character *i
 monomial.
 
 `TauCeti/RepresentationTheory/Compact/Circle.lean` reads this classification for the circle group
-`Multiplicative (AddCircle T)`, where it says that the one-dimensional continuous representations
-of the circle are exactly the Fourier ones.
+`Multiplicative (AddCircle T)`, where it says that the continuous representations of the circle on
+`ℂ` are exactly the Fourier ones.
 
 ## Main definitions
 
 * `TauCeti.fourierAddChar`: the `n`-th Fourier monomial as a bundled additive character
   `AddChar (AddCircle T) ℂ`.
-* `TauCeti.fourierAddCharEquiv`: the resulting equivalence between `ℤ` and the continuous additive
-  characters of `AddCircle T`.
+* `TauCeti.fourierPontryaginDual`: the `n`-th Fourier monomial as an element of the Pontryagin dual
+  `PontryaginDual (Multiplicative (AddCircle T))` of the circle group, i.e. as a continuous
+  homomorphism to the unit circle.
+* `TauCeti.fourierPontryaginDualEquiv`: the resulting isomorphism of groups between
+  `Multiplicative ℤ` and that Pontryagin dual.
 
 ## Main statements
 
@@ -107,6 +111,30 @@ theorem fourierAddChar_apply (n : ℤ) (x : AddCircle T) :
 theorem continuous_fourierAddChar (n : ℤ) : Continuous (fourierAddChar (T := T) n) :=
   (fourier n).continuous
 
+/-- **The `n`-th Fourier monomial as an element of the Pontryagin dual of the circle group.** The
+circle group is `Multiplicative (AddCircle T)`, and this character sends `x` to
+`AddCircle.toCircle (n • x)`, the value of `fourier n` read in the unit circle rather than in `ℂ`;
+`TauCeti.coe_fourierPontryaginDual` identifies its value with `fourier n`. -/
+noncomputable def fourierPontryaginDual (n : ℤ) :
+    PontryaginDual (Multiplicative (AddCircle T)) where
+  toFun x := toCircle (n • Multiplicative.toAdd x)
+  map_one' := by simp
+  map_mul' x y := by rw [toAdd_mul, smul_add, toCircle_add]
+  continuous_toFun := (continuous_toCircle.comp (continuous_zsmul n) :
+    Continuous fun x : AddCircle T => toCircle (n • x))
+
+@[simp]
+theorem coe_fourierPontryaginDual (n : ℤ) (x : Multiplicative (AddCircle T)) :
+    (fourierPontryaginDual n x : ℂ) = fourier n (Multiplicative.toAdd x) := (rfl)
+
+/-- Distinct indices give distinct elements of the Pontryagin dual: `TauCeti.fourier_injective`
+again. -/
+theorem fourierPontryaginDual_injective (hT : T ≠ 0) :
+    Function.Injective (fourierPontryaginDual (T := T)) := fun _ _ h =>
+  fourier_injective hT (ContinuousMap.ext fun x => by
+    simpa using congrArg
+      (fun ψ : PontryaginDual (Multiplicative (AddCircle T)) => (ψ (.ofAdd x) : ℂ)) h)
+
 /-- Distinct indices give distinct additive characters: `TauCeti.fourier_injective` again. -/
 theorem fourierAddChar_injective (hT : T ≠ 0) :
     Function.Injective (fourierAddChar (T := T)) := fun _ _ h =>
@@ -140,7 +168,7 @@ namespace AddChar
 /-- **Every continuous additive character of the circle is a Fourier monomial.** Continuity is the
 only hypothesis: no unitarity is assumed, and none is needed. Together with
 `TauCeti.fourierAddChar_injective` this identifies the continuous characters of `AddCircle T` with
-`ℤ`, which is the content of `TauCeti.fourierAddCharEquiv`. -/
+`ℤ`, which is the content of `TauCeti.fourierPontryaginDualEquiv`. -/
 theorem exists_fourierAddChar_eq (χ : AddChar (AddCircle T) ℂ) (hχ : Continuous χ) :
     ∃ n : ℤ, fourierAddChar n = χ := by
   have hcoeff : ∀ n : ℤ, fourierCoeff (⇑(⟨χ, hχ⟩ : C(AddCircle T, ℂ))) n
@@ -196,18 +224,50 @@ end AddChar
 
 namespace TauCeti
 
-/-- **The Fourier monomials index the continuous characters of the circle**: `n ↦ fourierAddChar n`
-is a bijection from `ℤ` onto the continuous additive characters of `AddCircle T`. This is a
-bijection of types only; it is not equipped here with the group structure of the Pontryagin
-dual. -/
-noncomputable def fourierAddCharEquiv :
-    ℤ ≃ {χ : AddChar (AddCircle T) ℂ // Continuous χ} :=
-  Equiv.ofBijective (fun n => ⟨fourierAddChar n, continuous_fourierAddChar n⟩)
-    ⟨fun _ _ h => fourierAddChar_injective (Fact.out (p := (0 < T))).ne' (congrArg Subtype.val h),
-      fun χ => (AddChar.exists_fourierAddChar_eq χ.1 χ.2).imp fun _ hn => Subtype.ext hn⟩
+/-- **The Fourier monomials are the Pontryagin dual of the circle.** The map
+`n ↦ fourierPontryaginDual n` is an isomorphism of groups from `Multiplicative ℤ` onto
+`PontryaginDual (Multiplicative (AddCircle T))`, the group of continuous characters of the circle
+group: it is a homomorphism because `fourier (m + n) = fourier m * fourier n`, injective by
+`TauCeti.fourierPontryaginDual_injective`, and surjective by `AddChar.exists_fourierAddChar_eq`.
+
+The multiplicative type tags are what make this a statement about groups: the dual multiplies
+characters pointwise, and that multiplication corresponds to addition of Fourier indices. -/
+noncomputable def fourierPontryaginDualEquiv :
+    Multiplicative ℤ ≃* PontryaginDual (Multiplicative (AddCircle T)) :=
+  MulEquiv.ofBijective
+    ({ toFun := fun n => fourierPontryaginDual (Multiplicative.toAdd n)
+       map_one' := PontryaginDual.ext fun _ => Circle.ext (by simp)
+       map_mul' := fun m n => PontryaginDual.ext fun x => Circle.ext <| by
+         -- the dual multiplies characters pointwise by definition, so this `change` only
+         -- spells the right-hand side out; `fourier_add` then closes the goal through `simp`
+         change ((fourierPontryaginDual (Multiplicative.toAdd (m * n)) x : Circle) : ℂ) =
+           (fourierPontryaginDual (Multiplicative.toAdd m) x : ℂ) *
+             (fourierPontryaginDual (Multiplicative.toAdd n) x : ℂ)
+         simp } :
+      Multiplicative ℤ →* PontryaginDual (Multiplicative (AddCircle T)))
+    ⟨fun _ _ h => Multiplicative.toAdd.injective
+        (fourierPontryaginDual_injective (Fact.out (p := (0 < T))).ne' h),
+      fun ψ => by
+        have hcoe : Continuous ((↑) : Circle → ℂ) := continuous_induced_dom
+        have hcont : Continuous fun x : AddCircle T => (ψ (Multiplicative.ofAdd x) : ℂ) :=
+          hcoe.comp (map_continuous ψ)
+        obtain ⟨n, hn⟩ := AddChar.exists_fourierAddChar_eq
+          { toFun := fun x : AddCircle T => (ψ (Multiplicative.ofAdd x) : ℂ)
+            map_zero_eq_one' := by simp
+            map_add_eq_mul' := fun x y => by rw [ofAdd_add, map_mul, Circle.coe_mul] } hcont
+        exact ⟨Multiplicative.ofAdd n, PontryaginDual.ext fun x => Circle.ext (by
+          simpa using DFunLike.congr_fun hn (Multiplicative.toAdd x))⟩⟩
 
 @[simp]
-theorem fourierAddCharEquiv_apply (n : ℤ) :
-    (fourierAddCharEquiv (T := T) n : AddChar (AddCircle T) ℂ) = fourierAddChar n := (rfl)
+theorem fourierPontryaginDualEquiv_apply (n : Multiplicative ℤ) :
+    fourierPontryaginDualEquiv (T := T) n = fourierPontryaginDual (Multiplicative.toAdd n) := (rfl)
+
+/-- The inverse of `TauCeti.fourierPontryaginDualEquiv` returns the Fourier index of a continuous
+character: the monomial at that index is the character one started from. -/
+@[simp]
+theorem fourierPontryaginDualEquiv_symm_apply
+    (ψ : PontryaginDual (Multiplicative (AddCircle T))) :
+    fourierPontryaginDual (Multiplicative.toAdd (fourierPontryaginDualEquiv.symm ψ)) = ψ :=
+  fourierPontryaginDualEquiv.apply_symm_apply ψ
 
 end TauCeti

--- a/TauCeti/Analysis/Fourier/AddCircle.lean
+++ b/TauCeti/Analysis/Fourier/AddCircle.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Fourier.AddCircle
+public import Mathlib.Analysis.SpecialFunctions.Complex.CircleAddChar
 
 /-!
 # The continuous characters of the circle are the Fourier monomials
@@ -47,17 +48,12 @@ of the circle are exactly the Fourier ones.
 
 * `TauCeti.fourier_injective`: `n ↦ fourier n` is injective, so distinct indices give distinct
   characters.
-* `TauCeti.eq_zero_of_forall_fourierCoeff_eq_zero`: a continuous function on the circle all of
-  whose Fourier coefficients vanish is the zero function.
-* `TauCeti.exists_fourierAddChar_eq`: **every continuous additive character of the circle is a
+* `ContinuousMap.eq_zero_of_forall_fourierCoeff_eq_zero`: a continuous function on the circle all
+  of whose Fourier coefficients vanish is the zero function.
+* `AddChar.exists_fourierAddChar_eq`: **every continuous additive character of the circle is a
   Fourier monomial.**
-* `TauCeti.norm_apply_eq_one_of_continuous_addChar`: consequently a continuous additive character
-  of the circle takes values of modulus one.
-
-## References
-
-* [Compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
-  the worked example "The circle `S¹` and Fourier series are Peter-Weyl".
+* `AddChar.norm_apply_eq_one_of_continuous`: consequently a continuous additive character of the
+  circle takes values of modulus one.
 
 ## Tags
 
@@ -68,9 +64,9 @@ public section
 
 open MeasureTheory AddCircle
 
-namespace TauCeti
-
 variable {T : ℝ}
+
+namespace TauCeti
 
 /-- **Distinct indices give distinct Fourier monomials.** At the point `T / 2 / (m - n)` the two
 monomials `fourier m` and `fourier n` differ by `Complex.exp (π * I) = -1`, so they are already
@@ -97,18 +93,12 @@ theorem fourier_injective (hT : T ≠ 0) : Function.Injective (fourier (T := T))
       _ = 1 := by rw [hx, div_self (Complex.exp_ne_zero _)]
   norm_num at hcontra
 
-/-- **Fourier monomials are multiplicative in the circle variable.** Mathlib's `fourier_add`
-records multiplicativity in the *index*; this is the other variable, and it is what makes
-`fourier n` a character of `AddCircle T`. -/
-theorem fourier_apply_add (n : ℤ) (x y : AddCircle T) :
-    fourier n (x + y) = fourier n x * fourier n y := by
-  simp_rw [fourier_apply, smul_add, toCircle_add, Circle.coe_mul]
-
-/-- **The `n`-th Fourier monomial as a bundled additive character of the circle.** -/
-noncomputable def fourierAddChar (n : ℤ) : AddChar (AddCircle T) ℂ where
-  toFun := fourier n
-  map_zero_eq_one' := fourier_eval_zero n
-  map_add_eq_mul' := fourier_apply_add n
+/-- **The `n`-th Fourier monomial as a bundled additive character of the circle.** It is Mathlib's
+`AddCircle.toCircle_addChar` precomposed with multiplication by `n` and postcomposed with the
+inclusion of the unit circle into `ℂ`; `TauCeti.fourierAddChar_apply` identifies its value with
+`fourier n`. -/
+noncomputable def fourierAddChar (n : ℤ) : AddChar (AddCircle T) ℂ :=
+  Circle.coeHom.compAddChar (toCircle_addChar.compAddMonoidHom (zsmulAddGroupHom n))
 
 @[simp]
 theorem fourierAddChar_apply (n : ℤ) (x : AddCircle T) :
@@ -122,9 +112,13 @@ theorem fourierAddChar_injective (hT : T ≠ 0) :
     Function.Injective (fourierAddChar (T := T)) := fun _ _ h =>
   fourier_injective hT (ContinuousMap.ext fun x => DFunLike.congr_fun h x)
 
-section Classification
+end TauCeti
+
+open TauCeti
 
 variable [Fact (0 < T)]
+
+namespace ContinuousMap
 
 /-- **A continuous function on the circle with vanishing Fourier coefficients is zero.** The
 Fourier coefficients are the coordinates of the function in Mathlib's Hilbert basis `fourierBasis`
@@ -140,6 +134,10 @@ theorem eq_zero_of_forall_fourierCoeff_eq_zero (F : C(AddCircle T, ℂ))
   refine ContinuousMap.toLp_injective (𝕜 := ℂ) (p := 2) haarAddCircle ?_
   rw [map_zero]
   exact (hasSum_zero.unique hsum).symm
+
+end ContinuousMap
+
+namespace AddChar
 
 /-- **Every continuous additive character of the circle is a Fourier monomial.** Together with
 `TauCeti.fourierAddChar_injective` this identifies the continuous characters of `AddCircle T` with
@@ -161,7 +159,7 @@ theorem exists_fourierAddChar_eq (χ : AddChar (AddCircle T) ℂ) (hχ : Continu
     simp at hzero
   obtain ⟨n, hn⟩ : ∃ n : ℤ, ∫ x : AddCircle T, fourier (-n) x * χ x ∂haarAddCircle ≠ 0 := by
     by_contra hcon
-    refine hFne (eq_zero_of_forall_fourierCoeff_eq_zero ⟨χ, hχ⟩ fun n => ?_)
+    refine hFne (ContinuousMap.eq_zero_of_forall_fourierCoeff_eq_zero ⟨χ, hχ⟩ fun n => ?_)
     rw [hcoeff n]
     by_contra hne
     exact hcon ⟨n, hne⟩
@@ -173,7 +171,7 @@ theorem exists_fourierAddChar_eq (χ : AddChar (AddCircle T) ℂ) (hχ : Continu
           (integral_add_right_eq_self _ y).symm
       _ = ∫ x : AddCircle T, (fourier (-n) y * χ y) * (fourier (-n) x * χ x) ∂haarAddCircle :=
           integral_congr_ae (Filter.Eventually.of_forall fun x => by
-            simp only [fourier_apply_add, AddChar.map_add_eq_mul]; ring)
+            simp only [← fourierAddChar_apply, AddChar.map_add_eq_mul]; ring)
       _ = (fourier (-n) y * χ y) * ∫ x : AddCircle T, fourier (-n) x * χ x ∂haarAddCircle :=
           integral_const_mul _ _
   have hone : fourier (-n) y * χ y = 1 :=
@@ -196,25 +194,26 @@ theorem existsUnique_fourierAddChar_eq (χ : AddChar (AddCircle T) ℂ) (hχ : C
 /-- **A continuous additive character of the circle takes values of modulus one.** No unitarity
 hypothesis is needed anywhere above: continuity alone forces the character to be a Fourier
 monomial, and `fourier n` is valued in the unit circle. -/
-theorem norm_apply_eq_one_of_continuous_addChar (χ : AddChar (AddCircle T) ℂ) (hχ : Continuous χ)
+theorem norm_apply_eq_one_of_continuous (χ : AddChar (AddCircle T) ℂ) (hχ : Continuous χ)
     (x : AddCircle T) : ‖χ x‖ = 1 := by
   obtain ⟨n, rfl⟩ := exists_fourierAddChar_eq χ hχ
   rw [fourierAddChar_apply, fourier_apply]
   exact Circle.norm_coe _
 
+end AddChar
+
+namespace TauCeti
+
 /-- **The Fourier monomials index the continuous characters of the circle**, that is, the
-Pontryagin dual of `AddCircle T` is `ℤ`. This is the indexing under which the compact-group
-Peter-Weyl basis of `L²(AddCircle T)` becomes Mathlib's `AddCircle.fourierBasis`. -/
+Pontryagin dual of `AddCircle T` is `ℤ`. -/
 noncomputable def fourierAddCharEquiv :
     ℤ ≃ {χ : AddChar (AddCircle T) ℂ // Continuous χ} :=
   Equiv.ofBijective (fun n => ⟨fourierAddChar n, continuous_fourierAddChar n⟩)
     ⟨fun _ _ h => fourierAddChar_injective (Fact.out (p := (0 < T))).ne' (congrArg Subtype.val h),
-      fun χ => (exists_fourierAddChar_eq χ.1 χ.2).imp fun _ hn => Subtype.ext hn⟩
+      fun χ => (AddChar.exists_fourierAddChar_eq χ.1 χ.2).imp fun _ hn => Subtype.ext hn⟩
 
 @[simp]
 theorem fourierAddCharEquiv_apply (n : ℤ) :
     (fourierAddCharEquiv (T := T) n : AddChar (AddCircle T) ℂ) = fourierAddChar n := (rfl)
-
-end Classification
 
 end TauCeti

--- a/TauCeti/Analysis/Fourier/AddCircle.lean
+++ b/TauCeti/Analysis/Fourier/AddCircle.lean
@@ -121,34 +121,26 @@ variable [Fact (0 < T)]
 namespace ContinuousMap
 
 /-- **A continuous function on the circle with vanishing Fourier coefficients is zero.** The
-Fourier coefficients are the coordinates of the function in Mathlib's Hilbert basis `fourierBasis`
-of `L²`, so they determine its class in `L²`, and a continuous function on the circle is determined
-by that class because normalized Haar measure is positive on nonempty open sets. -/
+separation statement for the Fourier coefficients of a continuous function, at the level of
+`C(AddCircle T, ℂ)` rather than of `L²`; it is what makes a nonzero continuous function have a
+nonzero Fourier coefficient. -/
 theorem eq_zero_of_forall_fourierCoeff_eq_zero (F : C(AddCircle T, ℂ))
     (h : ∀ n : ℤ, fourierCoeff (⇑F) n = 0) : F = 0 := by
-  have hzero : ∀ n : ℤ,
-      fourierBasis.repr (ContinuousMap.toLp (E := ℂ) 2 haarAddCircle ℂ F) n = 0 := fun n => by
-    rw [fourierBasis_repr, fourierCoeff_toLp, h n]
-  have hsum := fourierBasis.hasSum_repr (ContinuousMap.toLp (E := ℂ) 2 haarAddCircle ℂ F)
-  simp only [hzero, zero_smul] at hsum
   refine ContinuousMap.toLp_injective (𝕜 := ℂ) (p := 2) haarAddCircle ?_
-  rw [map_zero]
-  exact (hasSum_zero.unique hsum).symm
+  refine fourierBasis.repr.injective ?_
+  rw [map_zero, map_zero]
+  ext n
+  rw [fourierBasis_repr, fourierCoeff_toLp, h n]
+  rfl
 
 end ContinuousMap
 
 namespace AddChar
 
-/-- **Every continuous additive character of the circle is a Fourier monomial.** Together with
+/-- **Every continuous additive character of the circle is a Fourier monomial.** Continuity is the
+only hypothesis: no unitarity is assumed, and none is needed. Together with
 `TauCeti.fourierAddChar_injective` this identifies the continuous characters of `AddCircle T` with
-`ℤ`.
-
-Some Fourier coefficient `c = fourierCoeff χ n` is nonzero, because `χ 0 = 1` makes `χ` a nonzero
-continuous function. Normalized Haar measure is translation invariant, so translating the integral
-defining `c` by `y` leaves it unchanged; expanding both `fourier (-n)` and `χ` on the translated
-sum turns that integral into `(fourier (-n) y * χ y) * c`, so `fourier (-n) y * χ y = 1`. Since
-also `fourier (-n) y * fourier n y = fourier 0 y = 1`, and `fourier (-n) y ≠ 0`, the two values
-agree. -/
+`ℤ`, which is the content of `TauCeti.fourierAddCharEquiv`. -/
 theorem exists_fourierAddChar_eq (χ : AddChar (AddCircle T) ℂ) (hχ : Continuous χ) :
     ∃ n : ℤ, fourierAddChar n = χ := by
   have hcoeff : ∀ n : ℤ, fourierCoeff (⇑(⟨χ, hχ⟩ : C(AddCircle T, ℂ))) n
@@ -204,8 +196,10 @@ end AddChar
 
 namespace TauCeti
 
-/-- **The Fourier monomials index the continuous characters of the circle**, that is, the
-Pontryagin dual of `AddCircle T` is `ℤ`. -/
+/-- **The Fourier monomials index the continuous characters of the circle**: `n ↦ fourierAddChar n`
+is a bijection from `ℤ` onto the continuous additive characters of `AddCircle T`. This is a
+bijection of types only; it is not equipped here with the group structure of the Pontryagin
+dual. -/
 noncomputable def fourierAddCharEquiv :
     ℤ ≃ {χ : AddChar (AddCircle T) ℂ // Continuous χ} :=
   Equiv.ofBijective (fun n => ⟨fourierAddChar n, continuous_fourierAddChar n⟩)

--- a/TauCeti/Analysis/Fourier/AddCircle.lean
+++ b/TauCeti/Analysis/Fourier/AddCircle.lean
@@ -276,7 +276,7 @@ theorem fourierPontryaginDualEquiv_apply (n : Multiplicative ℤ) :
 /-- The inverse of `TauCeti.fourierPontryaginDualEquiv` returns the Fourier index of a continuous
 character: the monomial at that index is the character one started from. -/
 @[simp]
-theorem fourierPontryaginDualEquiv_symm_apply
+theorem fourierPontryaginDualEquiv_apply_symm_apply
     (ψ : PontryaginDual (Multiplicative (AddCircle T))) :
     fourierPontryaginDual (Multiplicative.toAdd (fourierPontryaginDualEquiv.symm ψ)) = ψ :=
   fourierPontryaginDualEquiv.apply_symm_apply ψ

--- a/TauCeti/Analysis/Fourier/AddCircle.lean
+++ b/TauCeti/Analysis/Fourier/AddCircle.lean
@@ -21,6 +21,11 @@ one-dimensional representations are pairwise inequivalent) and that it is **exha
 no other continuous characters). This file proves both, and packages them as an isomorphism of
 groups between `Multiplicative ℤ` and the Pontryagin dual of the circle group.
 
+Both halves need the period to be nondegenerate, and they need it to differing extents.
+Faithfulness holds as soon as `T ≠ 0`, and that hypothesis is carried explicitly. Exhaustiveness
+rests on Mathlib's Fourier analysis on `AddCircle T`, which is set up under `[Fact (0 < T)]`, so
+that instance is assumed for the classification results and for the isomorphism of groups.
+
 Faithfulness is elementary: two monomials already differ at the point `T / 2 / (m - n)`.
 Exhaustiveness is where analysis enters. A continuous character `χ` is in particular a nonzero
 continuous function, so some Fourier coefficient `fourierCoeff χ n` is nonzero — that is Mathlib's
@@ -35,8 +40,8 @@ automatic, and here it comes out as a corollary, since a continuous character *i
 monomial.
 
 `TauCeti/RepresentationTheory/Compact/Circle.lean` reads this classification for the circle group
-`Multiplicative (AddCircle T)`, where it says that the continuous representations of the circle on
-`ℂ` are exactly the Fourier ones.
+`Multiplicative (AddCircle T)` with `[Fact (0 < T)]`, where the group is compact and the statement
+becomes that the continuous representations of the circle on `ℂ` are exactly the Fourier ones.
 
 ## Main definitions
 
@@ -106,10 +111,13 @@ noncomputable def fourierAddChar (n : ℤ) : AddChar (AddCircle T) ℂ :=
 
 @[simp]
 theorem fourierAddChar_apply (n : ℤ) (x : AddCircle T) :
-    fourierAddChar n x = fourier n x := (rfl)
+    fourierAddChar n x = fourier n x := by
+  rw [fourierAddChar, MonoidHom.compAddChar_apply, Function.comp_apply,
+    AddChar.compAddMonoidHom_apply, toCircle_addChar, AddChar.coe_mk, fourier_apply]
+  rfl
 
 theorem continuous_fourierAddChar (n : ℤ) : Continuous (fourierAddChar (T := T) n) :=
-  (fourier n).continuous
+  (fourier n).continuous.congr fun x => (fourierAddChar_apply n x).symm
 
 /-- **The `n`-th Fourier monomial as an element of the Pontryagin dual of the circle group.** The
 circle group is `Multiplicative (AddCircle T)`, and this character sends `x` to
@@ -125,7 +133,9 @@ noncomputable def fourierPontryaginDual (n : ℤ) :
 
 @[simp]
 theorem coe_fourierPontryaginDual (n : ℤ) (x : Multiplicative (AddCircle T)) :
-    (fourierPontryaginDual n x : ℂ) = fourier n (Multiplicative.toAdd x) := (rfl)
+    (fourierPontryaginDual n x : ℂ) = fourier n (Multiplicative.toAdd x) := by
+  rw [fourier_apply]
+  rfl
 
 /-- Distinct indices give distinct elements of the Pontryagin dual: `TauCeti.fourier_injective`
 again. -/
@@ -172,7 +182,8 @@ only hypothesis: no unitarity is assumed, and none is needed. Together with
 theorem exists_fourierAddChar_eq (χ : AddChar (AddCircle T) ℂ) (hχ : Continuous χ) :
     ∃ n : ℤ, fourierAddChar n = χ := by
   have hcoeff : ∀ n : ℤ, fourierCoeff (⇑(⟨χ, hχ⟩ : C(AddCircle T, ℂ))) n
-      = ∫ x : AddCircle T, fourier (-n) x * χ x ∂haarAddCircle := fun _ => rfl
+      = ∫ x : AddCircle T, fourier (-n) x * χ x ∂haarAddCircle := fun _ => by
+    simp only [fourierCoeff, ContinuousMap.coe_mk, smul_eq_mul]
   have hFne : (⟨χ, hχ⟩ : C(AddCircle T, ℂ)) ≠ 0 := by
     intro h
     have hzero := DFunLike.congr_fun h (0 : AddCircle T)

--- a/TauCeti/RepresentationTheory/Compact/Circle.lean
+++ b/TauCeti/RepresentationTheory/Compact/Circle.lean
@@ -9,10 +9,9 @@ public import TauCeti.Analysis.Fourier.AddCircle
 public import TauCeti.MeasureTheory.Group.TypeTags
 public import TauCeti.RepresentationTheory.Compact.Character.Basic
 public import TauCeti.RepresentationTheory.LinearCharacter
-public import Mathlib.Analysis.SpecialFunctions.Complex.CircleAddChar
 
 /-!
-# The circle group: Fourier monomials are its irreducible characters
+# The circle group: Fourier monomials are its continuous representations on `ℂ`
 
 The circle `AddCircle T` is a compact abelian group. This file builds its continuous
 representations on `ℂ` from Mathlib's Fourier monomials, shows that they exhaust the
@@ -32,10 +31,10 @@ Under those identifications:
   orthogonality relation `character_orthonormal_distinct` return the diagonal and off-diagonal
   halves of that same statement.
 
-The list `n ↦ fourierRep T n` is moreover complete among the one-dimensional representations: a
-continuous representation of the circle group on `ℂ` acts by the scalar `π x 1`, which is a
-continuous additive character of `AddCircle T` and therefore a Fourier monomial by
-`AddChar.exists_fourierAddChar_eq`.
+The list `n ↦ fourierRep T n` is moreover complete among the continuous representations carried by
+`ℂ`: such a representation acts by the scalar `π x 1`, which is a continuous additive character of
+`AddCircle T` and therefore a Fourier monomial by `AddChar.exists_fourierAddChar_eq`. Nothing here
+transports that statement to a representation on some other one-dimensional space.
 
 The last two are recorded as anonymous `example`s: they are consistency checks on the general
 theory's normalization, not new API, and naming them would duplicate
@@ -59,8 +58,8 @@ theory's normalization, not new API, and naming them would duplicate
   continuous intertwiner `fourierRep T n → fourierRep T m`, so the Fourier representations are
   pairwise inequivalent.
 * `MonoidHom.exists_fourierChar_eq`, `ContRepresentation.exists_fourierRep_eq`: every continuous
-  linear character, and every one-dimensional continuous representation, of the circle group is a
-  Fourier one.
+  linear character of the circle group, and every continuous representation of it carried by `ℂ`,
+  is a Fourier one.
 * `TauCeti.orthonormal_characterLp_fourierRep`: the characters of the `fourierRep T n` are an
   orthonormal family in `L²` of the circle group for normalized Haar measure; this is
   `AddCircle.orthonormal_fourier` read through the general compact-group packaging.
@@ -83,9 +82,9 @@ which is what lets `inner_characterLp_fourierRep` end in Mathlib's orthonormalit
 
 What is *not* done here is the full Peter-Weyl identification of `peterWeylBasis` with
 `AddCircle.fourierBasis` under the indexing equivalence `Σ π, Fin 1 × Fin 1 ≃ ℤ`. Exhaustion is
-available in dimension one (`ContRepresentation.exists_fourierRep_eq`), but the step from there to
-*every* finite-dimensional irreducible — that an irreducible representation of an abelian group
-over an algebraically closed field is one-dimensional — is not proved here.
+available for representations carried by `ℂ` (`ContRepresentation.exists_fourierRep_eq`), but the
+step from there to *every* finite-dimensional irreducible — that an irreducible representation of
+an abelian group over an algebraically closed field is one-dimensional — is not proved here.
 
 The general compact-group character theory that is specialized here is in
 `TauCeti/RepresentationTheory/Compact/Character/Basic.lean`. The mathematical development follows
@@ -289,12 +288,13 @@ end MonoidHom
 namespace ContRepresentation
 
 include hT in
-/-- **Every one-dimensional continuous representation of the circle group is a Fourier
+/-- **Every continuous representation of the circle group carried by `ℂ` is a Fourier
 representation.** With `TauCeti.contIntertwiningMap_fourierRep_eq_zero_of_ne` this says that
-`n ↦ fourierRep T n` lists the one-dimensional continuous representations of the circle group
-exactly once. Passing from here to *all* finite-dimensional irreducibles needs the separate fact
-that an irreducible representation of an abelian group over an algebraically closed field is
-one-dimensional, which is not proved here. -/
+`n ↦ fourierRep T n` lists the continuous representations of the circle group on `ℂ` exactly once.
+The quantifier is over representations whose carrier is literally `ℂ`; transporting the statement
+along an isomorphism to an arbitrary one-dimensional carrier, and passing from there to *all*
+finite-dimensional irreducibles — which needs that an irreducible representation of an abelian
+group over an algebraically closed field is one-dimensional — are not done here. -/
 theorem exists_fourierRep_eq (π : ContRepresentation ℂ (Multiplicative (AddCircle T)) ℂ)
     (hπ : Continuous π) : ∃ n : ℤ, fourierRep T n = π := by
   have hsmul (x : Multiplicative (AddCircle T)) (z : ℂ) : π x z = z * π x 1 := by

--- a/TauCeti/RepresentationTheory/Compact/Circle.lean
+++ b/TauCeti/RepresentationTheory/Compact/Circle.lean
@@ -14,10 +14,12 @@ public import Mathlib.Analysis.SpecialFunctions.Complex.CircleAddChar
 /-!
 # The circle group: Fourier monomials are its irreducible characters
 
-The circle `AddCircle T` is a compact abelian group, so every irreducible representation of it is
-one-dimensional and its own character. This file builds those representations from Mathlib's
-Fourier monomials and checks that the general compact-group theory, specialized to the circle,
-returns Mathlib's Fourier analysis on the nose.
+The circle `AddCircle T` is a compact abelian group. This file builds its continuous
+representations on `ℂ` from Mathlib's Fourier monomials, shows that they exhaust the
+representations carried by `ℂ`, and checks that the general compact-group theory, specialized to
+the circle, returns Mathlib's Fourier analysis on the nose. That every irreducible representation
+of a compact abelian group is one-dimensional — the theorem that would promote this to a
+classification of *all* irreducibles — is not proved here; see the implementation notes.
 
 Concretely, `fourierRep T n` is the continuous representation of the circle on `ℂ` in which the
 group element `x` acts by multiplication by `fourier n x`. It is one-dimensional, hence

--- a/TauCeti/RepresentationTheory/Compact/Circle.lean
+++ b/TauCeti/RepresentationTheory/Compact/Circle.lean
@@ -59,10 +59,9 @@ theory's normalization, not new API, and naming them would duplicate
 * `MonoidHom.exists_fourierChar_eq`, `ContRepresentation.exists_fourierRep_eq`: every continuous
   linear character, and every one-dimensional continuous representation, of the circle group is a
   Fourier one.
-* `TauCeti.orthonormal_characterLp_fourierRep`: **the character-orthonormality half of the
-  acceptance criterion.** The characters of the `fourierRep T n` are an orthonormal family in `L²`
-  of the circle group for normalized Haar measure; this is `AddCircle.orthonormal_fourier` read
-  through the general compact-group packaging.
+* `TauCeti.orthonormal_characterLp_fourierRep`: the characters of the `fourierRep T n` are an
+  orthonormal family in `L²` of the circle group for normalized Haar measure; this is
+  `AddCircle.orthonormal_fourier` read through the general compact-group packaging.
 
 ## Implementation notes
 
@@ -240,11 +239,10 @@ theorem inner_characterLp_fourierRep (m n : ℤ) :
   simp only [character_fourierRep]
   exact key
 
-/-- **The character-orthonormality half of the acceptance criterion.** The characters of the
-Fourier representations are an orthonormal family in `L²` of the circle group for normalized Haar
-measure: the general compact-group character theory, specialized to the circle, is Mathlib's
-`AddCircle.orthonormal_fourier`. The remaining half, the identification of `peterWeylBasis` with
-`AddCircle.fourierBasis`, is not proved here. -/
+/-- **The characters of the Fourier representations are orthonormal.** They form an orthonormal
+family in `L²` of the circle group for normalized Haar measure: the general compact-group character
+theory, specialized to the circle, is Mathlib's `AddCircle.orthonormal_fourier`. The identification
+of `peterWeylBasis` with `AddCircle.fourierBasis` is not proved here. -/
 theorem orthonormal_characterLp_fourierRep :
     Orthonormal ℂ fun n : ℤ =>
       ContRepresentation.characterLp (fourierRep T n) (continuous_fourierRep T n) :=
@@ -290,15 +288,11 @@ namespace ContRepresentation
 
 include hT in
 /-- **Every one-dimensional continuous representation of the circle group is a Fourier
-representation.** A representation on `ℂ` is multiplication by the scalar `π x 1`, and that scalar
-is a continuous additive character of `AddCircle T`, hence a Fourier monomial by
-`AddChar.exists_fourierAddChar_eq`.
-
-With `TauCeti.contIntertwiningMap_fourierRep_eq_zero_of_ne` this says that `n ↦ fourierRep T n`
-lists the one-dimensional continuous representations of the circle group exactly once. Passing from
-here to *all* finite-dimensional irreducibles needs the separate fact that an irreducible
-representation of an abelian group over an algebraically closed field is one-dimensional, which is
-not proved here. -/
+representation.** With `TauCeti.contIntertwiningMap_fourierRep_eq_zero_of_ne` this says that
+`n ↦ fourierRep T n` lists the one-dimensional continuous representations of the circle group
+exactly once. Passing from here to *all* finite-dimensional irreducibles needs the separate fact
+that an irreducible representation of an abelian group over an algebraically closed field is
+one-dimensional, which is not proved here. -/
 theorem exists_fourierRep_eq (π : ContRepresentation ℂ (Multiplicative (AddCircle T)) ℂ)
     (hπ : Continuous π) : ∃ n : ℤ, fourierRep T n = π := by
   have hsmul (x : Multiplicative (AddCircle T)) (z : ℂ) : π x z = z * π x 1 := by

--- a/TauCeti/RepresentationTheory/Compact/Circle.lean
+++ b/TauCeti/RepresentationTheory/Compact/Circle.lean
@@ -30,6 +30,11 @@ Under those identifications:
   orthogonality relation `character_orthonormal_distinct` return the diagonal and off-diagonal
   halves of that same statement.
 
+The list `n ↦ fourierRep T n` is moreover complete among the one-dimensional representations: a
+continuous representation of the circle group on `ℂ` acts by the scalar `π x 1`, which is a
+continuous additive character of `AddCircle T` and therefore a Fourier monomial by
+`TauCeti.exists_fourierAddChar_eq`.
+
 The last two are recorded as anonymous `example`s: they are consistency checks on the general
 theory's normalization, not new API, and naming them would duplicate
 `TauCeti.inner_characterLp_fourierRep`.
@@ -51,6 +56,9 @@ theory's normalization, not new API, and naming them would duplicate
 * `TauCeti.contIntertwiningMap_fourierRep_eq_zero_of_ne`: for `m ≠ n` there is no nonzero
   continuous intertwiner `fourierRep T n → fourierRep T m`, so the Fourier representations are
   pairwise inequivalent.
+* `TauCeti.exists_fourierChar_eq`, `TauCeti.exists_fourierRep_eq`: every continuous linear
+  character, and every one-dimensional continuous representation, of the circle group is a Fourier
+  one.
 * `TauCeti.orthonormal_characterLp_fourierRep`: **the character-orthonormality half of the
   acceptance criterion.** The characters of the `fourierRep T n` are an orthonormal family in `L²`
   of the circle group for normalized Haar measure; this is `AddCircle.orthonormal_fourier` read
@@ -74,9 +82,10 @@ which is what lets `inner_characterLp_fourierRep` end in Mathlib's orthonormalit
 
 What is *not* done here is the full Peter-Weyl half of the roadmap's circle acceptance criterion —
 identifying `peterWeylBasis` with `AddCircle.fourierBasis` under the indexing equivalence
-`Σ π, Fin 1 × Fin 1 ≃ ℤ`. That needs the exhaustion of the irreducibles of the circle, which is not
-proved here: the statements below say that the `fourierRep T n` are pairwise inequivalent
-irreducibles with orthonormal characters, not that there are no others.
+`Σ π, Fin 1 × Fin 1 ≃ ℤ`. Exhaustion is available in dimension one
+(`TauCeti.exists_fourierRep_eq`), but the step from there to *every* finite-dimensional
+irreducible — that an irreducible representation of an abelian group over an algebraically closed
+field is one-dimensional — is not proved here.
 
 This is the circle bullet of the `## Worked examples (acceptance criteria)` section of the
 [compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
@@ -249,5 +258,47 @@ example {m n : ℤ} (h : m ≠ n) :
       ContRepresentation.characterLp (fourierRep T n) (continuous_fourierRep T n)⟫_ℂ = 0 :=
   ContRepresentation.character_orthonormal_distinct _ _ _ _ (isUnitary_fourierRep T m)
     (contIntertwiningMap_fourierRep_eq_zero_of_ne T hT.out.ne' h)
+
+include hT in
+/-- **Every continuous linear character of the circle group is a Fourier character.** This is
+`TauCeti.exists_fourierAddChar_eq`, the classification of the continuous additive characters of
+`AddCircle T`, read for the `ℂˣ`-valued multiplicative characters that
+`Representation.ofLinearCharacter` consumes. -/
+theorem exists_fourierChar_eq (χ : Multiplicative (AddCircle T) →* ℂˣ)
+    (hχ : Continuous fun x : Multiplicative (AddCircle T) => (χ x : ℂ)) :
+    ∃ n : ℤ, fourierChar T n = χ := by
+  obtain ⟨n, hn⟩ := exists_fourierAddChar_eq (T := T)
+    { toFun := fun x : AddCircle T => (χ (Multiplicative.ofAdd x) : ℂ)
+      map_zero_eq_one' := by simp
+      map_add_eq_mul' := fun x y => by simp [← Units.val_mul] } hχ
+  exact ⟨n, MonoidHom.ext fun x =>
+    Units.ext (by simpa using DFunLike.congr_fun hn (Multiplicative.toAdd x))⟩
+
+include hT in
+/-- **Every one-dimensional continuous representation of the circle group is a Fourier
+representation.** A representation on `ℂ` is multiplication by the scalar `π x 1`, and that scalar
+is a continuous additive character of `AddCircle T`, hence a Fourier monomial by
+`TauCeti.exists_fourierAddChar_eq`.
+
+With `TauCeti.contIntertwiningMap_fourierRep_eq_zero_of_ne` this says that `n ↦ fourierRep T n`
+lists the one-dimensional continuous representations of the circle group exactly once. Passing from
+here to *all* finite-dimensional irreducibles needs the separate fact that an irreducible
+representation of an abelian group over an algebraically closed field is one-dimensional, which is
+not proved here. -/
+theorem exists_fourierRep_eq (π : ContRepresentation ℂ (Multiplicative (AddCircle T)) ℂ)
+    (hπ : Continuous π) : ∃ n : ℤ, fourierRep T n = π := by
+  have hsmul (x : Multiplicative (AddCircle T)) (z : ℂ) : π x z = z * π x 1 := by
+    simpa using (π x).map_smul z (1 : ℂ)
+  obtain ⟨n, hn⟩ := exists_fourierAddChar_eq (T := T)
+    { toFun := fun x : AddCircle T => π (Multiplicative.ofAdd x) 1
+      map_zero_eq_one' := by simp
+      map_add_eq_mul' := fun x y => by
+        rw [show Multiplicative.ofAdd (x + y)
+            = Multiplicative.ofAdd x * Multiplicative.ofAdd y from rfl, map_mul]
+        simpa [mul_comm] using hsmul (Multiplicative.ofAdd x) (π (Multiplicative.ofAdd y) 1) }
+    ((ContinuousLinearMap.apply ℂ ℂ (1 : ℂ)).continuous.comp hπ)
+  refine ⟨n, DFunLike.ext _ _ fun x => ContinuousLinearMap.ext fun z => ?_⟩
+  rw [fourierRep_apply, hsmul x z, mul_comm]
+  exact congrArg (z * ·) (by simpa using DFunLike.congr_fun hn (Multiplicative.toAdd x))
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Compact/Circle.lean
+++ b/TauCeti/RepresentationTheory/Compact/Circle.lean
@@ -33,7 +33,7 @@ Under those identifications:
 The list `n ↦ fourierRep T n` is moreover complete among the one-dimensional representations: a
 continuous representation of the circle group on `ℂ` acts by the scalar `π x 1`, which is a
 continuous additive character of `AddCircle T` and therefore a Fourier monomial by
-`TauCeti.exists_fourierAddChar_eq`.
+`AddChar.exists_fourierAddChar_eq`.
 
 The last two are recorded as anonymous `example`s: they are consistency checks on the general
 theory's normalization, not new API, and naming them would duplicate
@@ -56,9 +56,9 @@ theory's normalization, not new API, and naming them would duplicate
 * `TauCeti.contIntertwiningMap_fourierRep_eq_zero_of_ne`: for `m ≠ n` there is no nonzero
   continuous intertwiner `fourierRep T n → fourierRep T m`, so the Fourier representations are
   pairwise inequivalent.
-* `TauCeti.exists_fourierChar_eq`, `TauCeti.exists_fourierRep_eq`: every continuous linear
-  character, and every one-dimensional continuous representation, of the circle group is a Fourier
-  one.
+* `MonoidHom.exists_fourierChar_eq`, `ContRepresentation.exists_fourierRep_eq`: every continuous
+  linear character, and every one-dimensional continuous representation, of the circle group is a
+  Fourier one.
 * `TauCeti.orthonormal_characterLp_fourierRep`: **the character-orthonormality half of the
   acceptance criterion.** The characters of the `fourierRep T n` are an orthonormal family in `L²`
   of the circle group for normalized Haar measure; this is `AddCircle.orthonormal_fourier` read
@@ -80,16 +80,13 @@ multiplicative side. Because `Multiplicative (AddCircle T)` and `AddCircle T` ar
 with the same topology and σ-algebra, an integral over one is literally an integral over the other,
 which is what lets `inner_characterLp_fourierRep` end in Mathlib's orthonormality statement.
 
-What is *not* done here is the full Peter-Weyl half of the roadmap's circle acceptance criterion —
-identifying `peterWeylBasis` with `AddCircle.fourierBasis` under the indexing equivalence
-`Σ π, Fin 1 × Fin 1 ≃ ℤ`. Exhaustion is available in dimension one
-(`TauCeti.exists_fourierRep_eq`), but the step from there to *every* finite-dimensional
-irreducible — that an irreducible representation of an abelian group over an algebraically closed
-field is one-dimensional — is not proved here.
+What is *not* done here is the full Peter-Weyl identification of `peterWeylBasis` with
+`AddCircle.fourierBasis` under the indexing equivalence `Σ π, Fin 1 × Fin 1 ≃ ℤ`. Exhaustion is
+available in dimension one (`ContRepresentation.exists_fourierRep_eq`), but the step from there to
+*every* finite-dimensional irreducible — that an irreducible representation of an abelian group
+over an algebraically closed field is one-dimensional — is not proved here.
 
-This is the circle bullet of the `## Worked examples (acceptance criteria)` section of the
-[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
-whose Layer 6 character theory is in
+The general compact-group character theory that is specialized here is in
 `TauCeti/RepresentationTheory/Compact/Character/Basic.lean`. The mathematical development follows
 Daniel Bump, *Lie Groups*, second edition, Chapter 2.
 
@@ -116,6 +113,13 @@ noncomputable def fourierChar (n : ℤ) : Multiplicative (AddCircle T) →* ℂ�
 @[simp]
 theorem coe_fourierChar (n : ℤ) (x : Multiplicative (AddCircle T)) :
     (fourierChar T n x : ℂ) = fourier n (Multiplicative.toAdd x) := (rfl)
+
+/-- The Fourier character is continuous as a `ℂ`-valued function: that is the continuity of
+`fourier n`. This is the hypothesis of `MonoidHom.exists_fourierChar_eq`. -/
+theorem continuous_coe_fourierChar (n : ℤ) :
+    Continuous fun x : Multiplicative (AddCircle T) => (fourierChar T n x : ℂ) := by
+  simp only [coe_fourierChar]
+  exact (fourier n).continuous.comp continuous_id
 
 /-- **The `n`-th Fourier character of the circle group**, as a one-dimensional continuous
 representation on `ℂ`: the group element `x` acts by multiplication by `fourier n x`. -/
@@ -259,26 +263,36 @@ example {m n : ℤ} (h : m ≠ n) :
   ContRepresentation.character_orthonormal_distinct _ _ _ _ (isUnitary_fourierRep T m)
     (contIntertwiningMap_fourierRep_eq_zero_of_ne T hT.out.ne' h)
 
+end TauCeti
+
+open TauCeti
+
+variable {T : ℝ} [hT : Fact (0 < T)]
+
+namespace MonoidHom
+
 include hT in
 /-- **Every continuous linear character of the circle group is a Fourier character.** This is
-`TauCeti.exists_fourierAddChar_eq`, the classification of the continuous additive characters of
+`AddChar.exists_fourierAddChar_eq`, the classification of the continuous additive characters of
 `AddCircle T`, read for the `ℂˣ`-valued multiplicative characters that
 `Representation.ofLinearCharacter` consumes. -/
 theorem exists_fourierChar_eq (χ : Multiplicative (AddCircle T) →* ℂˣ)
     (hχ : Continuous fun x : Multiplicative (AddCircle T) => (χ x : ℂ)) :
     ∃ n : ℤ, fourierChar T n = χ := by
-  obtain ⟨n, hn⟩ := exists_fourierAddChar_eq (T := T)
-    { toFun := fun x : AddCircle T => (χ (Multiplicative.ofAdd x) : ℂ)
-      map_zero_eq_one' := by simp
-      map_add_eq_mul' := fun x y => by simp [← Units.val_mul] } hχ
+  obtain ⟨n, hn⟩ :=
+    AddChar.exists_fourierAddChar_eq (AddChar.toMonoidHomEquiv.symm ((Units.coeHom ℂ).comp χ)) hχ
   exact ⟨n, MonoidHom.ext fun x =>
     Units.ext (by simpa using DFunLike.congr_fun hn (Multiplicative.toAdd x))⟩
+
+end MonoidHom
+
+namespace ContRepresentation
 
 include hT in
 /-- **Every one-dimensional continuous representation of the circle group is a Fourier
 representation.** A representation on `ℂ` is multiplication by the scalar `π x 1`, and that scalar
 is a continuous additive character of `AddCircle T`, hence a Fourier monomial by
-`TauCeti.exists_fourierAddChar_eq`.
+`AddChar.exists_fourierAddChar_eq`.
 
 With `TauCeti.contIntertwiningMap_fourierRep_eq_zero_of_ne` this says that `n ↦ fourierRep T n`
 lists the one-dimensional continuous representations of the circle group exactly once. Passing from
@@ -289,16 +303,15 @@ theorem exists_fourierRep_eq (π : ContRepresentation ℂ (Multiplicative (AddCi
     (hπ : Continuous π) : ∃ n : ℤ, fourierRep T n = π := by
   have hsmul (x : Multiplicative (AddCircle T)) (z : ℂ) : π x z = z * π x 1 := by
     simpa using (π x).map_smul z (1 : ℂ)
-  obtain ⟨n, hn⟩ := exists_fourierAddChar_eq (T := T)
+  obtain ⟨n, hn⟩ := AddChar.exists_fourierAddChar_eq (T := T)
     { toFun := fun x : AddCircle T => π (Multiplicative.ofAdd x) 1
       map_zero_eq_one' := by simp
       map_add_eq_mul' := fun x y => by
-        rw [show Multiplicative.ofAdd (x + y)
-            = Multiplicative.ofAdd x * Multiplicative.ofAdd y from rfl, map_mul]
+        rw [ofAdd_add, map_mul]
         simpa [mul_comm] using hsmul (Multiplicative.ofAdd x) (π (Multiplicative.ofAdd y) 1) }
     ((ContinuousLinearMap.apply ℂ ℂ (1 : ℂ)).continuous.comp hπ)
   refine ⟨n, DFunLike.ext _ _ fun x => ContinuousLinearMap.ext fun z => ?_⟩
   rw [fourierRep_apply, hsmul x z, mul_comm]
   exact congrArg (z * ·) (by simpa using DFunLike.congr_fun hn (Multiplicative.toAdd x))
 
-end TauCeti
+end ContRepresentation

--- a/TauCeti/RepresentationTheory/Compact/Circle.lean
+++ b/TauCeti/RepresentationTheory/Compact/Circle.lean
@@ -13,12 +13,14 @@ public import TauCeti.RepresentationTheory.LinearCharacter
 /-!
 # The circle group: Fourier monomials are its continuous representations on `ℂ`
 
-The circle `AddCircle T` is a compact abelian group. This file builds its continuous
-representations on `ℂ` from Mathlib's Fourier monomials, shows that they exhaust the
-representations carried by `ℂ`, and checks that the general compact-group theory, specialized to
-the circle, returns Mathlib's Fourier analysis on the nose. That every irreducible representation
-of a compact abelian group is one-dimensional — the theorem that would promote this to a
-classification of *all* irreducibles — is not proved here; see the implementation notes.
+For a positive period — the standing hypothesis `[Fact (0 < T)]`, which is what Mathlib's
+compactness instance and its Fourier analysis on `AddCircle T` both require — the circle
+`AddCircle T` is a compact abelian group. This file builds its continuous representations on `ℂ`
+from Mathlib's Fourier monomials, shows that they exhaust the representations carried by `ℂ`, and
+checks that the general compact-group theory, specialized to the circle, returns Mathlib's Fourier
+analysis on the nose. That every irreducible representation of a compact abelian group is
+one-dimensional — the theorem that would promote this to a classification of *all* irreducibles —
+is not proved here; see the implementation notes.
 
 Concretely, `fourierRep T n` is the continuous representation of the circle on `ℂ` in which the
 group element `x` acts by multiplication by `fourier n x`. It is one-dimensional, hence
@@ -167,13 +169,13 @@ theorem isIrreducible_fourierRep (n : ℤ) :
 
 /-- **The character of the `n`-th Fourier representation is `fourier n`.** A one-dimensional
 representation is its own character; this is `Representation.char_ofLinearCharacter` read through
-`TauCeti.toRepresentation_fourierRep`.
-
-The equation is stated between continuous maps rather than pointwise because that is the spelling
-`simp` can normalize with: `TauCeti.ContRepresentation.character_apply` is itself `@[simp]`, so a
-pointwise `character (fourierRep T n) _ x = _` is not in simp-normal form and `simpNF` rejects the
-tag on it, whereas the unapplied left-hand side is a subterm of the pointwise one and rewrites it
-too. This is how `TauCeti.SU2.character_symPowerModel` is stated for the same reason. -/
+`TauCeti.toRepresentation_fourierRep`. The equality is one of continuous maps, so it identifies the
+character of `fourierRep T n` with Mathlib's Fourier monomial as an element of
+`C(AddCircle T, ℂ)`, and every fact Mathlib proves about `fourier n` there — its continuity, its
+values, its `L²` norm — transfers to the character. -/
+-- Stated unapplied because `TauCeti.ContRepresentation.character_apply` is itself `@[simp]`, so
+-- `simpNF` rejects the tag on the pointwise form; the unapplied left-hand side is a subterm of the
+-- pointwise one and rewrites it too. `TauCeti.SU2.character_symPowerModel` is stated likewise.
 @[simp]
 theorem character_fourierRep (n : ℤ) :
     ContRepresentation.character (fourierRep T n) (continuous_fourierRep T n) = fourier n :=


### PR DESCRIPTION
This PR proves that the continuous characters of the circle are exactly the Fourier monomials, and reads the classification on the circle group. `AddChar.exists_fourierAddChar_eq` shows that every continuous `AddChar (AddCircle T) ℂ` equals `fourier n` for a (unique, by the existing `TauCeti.fourier_injective`) integer `n`, and `TauCeti.fourierPontryaginDualEquiv` packages the two halves as an isomorphism of groups `Multiplicative ℤ ≃* PontryaginDual (Multiplicative (AddCircle T))` — the Pontryagin dual of the circle, with its pointwise multiplication of characters, rather than a bare bijection of types. Downstream, `MonoidHom.exists_fourierChar_eq` and `ContRepresentation.exists_fourierRep_eq` say that every continuous linear character `Multiplicative (AddCircle T) →* ℂˣ`, and every continuous representation of that group carried by `ℂ`, is `TauCeti.fourierChar T n` respectively `TauCeti.fourierRep T n`.

This advances the worked example "The circle `S¹` and Fourier series are Peter-Weyl" in the `## Worked examples (acceptance criteria)` section of `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`, whose acceptance criterion begins "For `G = AddCircle 1` (abelian, so every irreducible is one-dimensional), the irreducible representations are the characters `fourier n`". `TauCeti/RepresentationTheory/Compact/Circle.lean` already supplied the faithfulness and character-orthonormality halves and recorded the exhaustion of the circle's irreducibles as the missing piece; that is what is supplied here, in dimension one. The remaining step to *every* finite-dimensional irreducible — that an irreducible representation of an abelian group over an algebraically closed field is one-dimensional — is not proved here, and the module docstring of `Circle.lean` has been updated to say exactly that instead of its previous claim that no exhaustion at all was available.

The mathematics is the standard argument and uses no new infrastructure. A continuous character is a nonzero continuous function, so it has a nonzero Fourier coefficient: that is `ContinuousMap.eq_zero_of_forall_fourierCoeff_eq_zero`, which reads Mathlib's Hilbert basis `AddCircle.fourierBasis` together with the injectivity of `ContinuousMap.toLp` for a measure positive on open sets. Translating that coefficient's integral by `y` — normalized Haar measure on the circle is translation invariant — and expanding both `fourier (-n)` and `χ` on the translated sum rewrites the coefficient as `fourier (-n) y * χ y` times itself, so `fourier (-n) y * χ y = 1`, and comparison with `fourier (-n) y * fourier n y = 1` gives `χ y = fourier n y`. No unitarity hypothesis enters; that a continuous character of the circle has values of modulus one falls out afterwards as `AddChar.norm_apply_eq_one_of_continuous`.

No Mathlib source was vendored. `TauCeti.fourierAddChar` is assembled from Mathlib's `AddCircle.toCircle_addChar` by `AddChar.compAddMonoidHom` and `MonoidHom.compAddChar`, so its character laws are Mathlib's; the proofs consume `AddCircle.fourierBasis`, `fourierBasis_repr`, `fourierCoeff_toLp`, `ContinuousMap.toLp_injective`, `MeasureTheory.integral_add_right_eq_self`, `AddChar.toMonoidHomEquiv` and `AddCircle.toCircle_add` directly.

Statements whose first explicit argument is an existing Lean/Mathlib type live in that type's root namespace (`ContinuousMap`, `AddChar`, `MonoidHom`, `ContRepresentation`) so that dot notation works; the `ℤ`-indexed definitions stay under `TauCeti`.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"circle-continuous-characters-are-fourier-monomials"}-->

🤖 Prepared with Claude Code

