### PR TITLE
feat: Burnside's pᵃqᵇ theorem

### DIFF
--- a/TauCeti/LinearAlgebra/End/FiniteOrder.lean
+++ b/TauCeti/LinearAlgebra/End/FiniteOrder.lean
@@ -60,6 +60,10 @@ All the results are stated of `Module.End`, so they sit in the `End` namespace u
   `j`-th power.
 * `TauCeti.End.conj_trace_eq_trace_pow_sub_one`: over `ℂ`, the conjugate of the trace of an
   endomorphism of finite order `n` is the trace of its inverse `f ^ (n - 1)`.
+* `TauCeti.End.exists_eq_smul_of_norm_trace_eq_finrank`: over `ℂ`, an endomorphism of finite order
+  whose trace has absolute value the dimension **is a scalar**, the scalar being a root of unity.
+  The trace is the sum of `finrank ℂ V` many roots of unity, so that absolute value is the largest
+  it can take, and it is attained only when the eigenvalues all coincide.
 * `TauCeti.End.trace_eq_finrank_iff`: over `ℂ`, an endomorphism of finite order has trace equal to
   the dimension **exactly when it is the identity**. The trace is the sum of `finrank ℂ V` many
   roots of unity, each of real part at most `1`, so the value `finrank ℂ V` is attained only when
@@ -208,77 +212,131 @@ theorem conj_trace_eq_trace_pow_sub_one {f : End ℂ V} {n : ℕ} (hn : n ≠ 0)
     exact inv_eq_of_mul_eq_one_right
       (by rw [← pow_succ', Nat.sub_add_cancel (Nat.one_le_iff_ne_zero.2 hn), hμ])
 
-/-- A root of unity whose real part is `1` is `1`: it has norm `1`, so its real part already
-exhausts that norm and its imaginary part vanishes. -/
-private theorem eq_one_of_pow_eq_one_of_re_eq_one {μ : ℂ} {n : ℕ} (hn : n ≠ 0) (hμ : μ ^ n = 1)
-    (hre : μ.re = 1) : μ = 1 := by
-  have hnorm : ‖μ‖ = 1 := Complex.norm_eq_one_of_pow_eq_one hμ hn
+/-- A complex number of norm `1` whose real part is `1` is `1`: the real part already exhausts the
+norm, so the imaginary part vanishes. -/
+private theorem eq_one_of_norm_eq_one_of_re_eq_one {μ : ℂ} (hnorm : ‖μ‖ = 1) (hre : μ.re = 1) :
+    μ = 1 := by
   have him : μ.im = 0 := Complex.abs_re_eq_norm.mp (by rw [hre, hnorm, abs_one])
   exact Complex.ext (by simpa using hre) (by simpa using him)
 
-/-- **An endomorphism of finite order with trace the dimension is the identity.** The eigenvalues
-of `f` are `n`-th roots of unity, so each has real part at most `1`; the trace is the sum of the
-eigenvalues weighted by the dimensions of the eigenspaces, and those dimensions add up to
-`finrank ℂ V`. Comparing real parts, the value `finrank ℂ V` is attained only when every eigenvalue
-has real part `1`, hence is `1`, and `f` is diagonalizable, so it is the identity there.
+/-- **An endomorphism of finite order whose trace has the largest possible absolute value is a
+scalar.** The eigenvalues of `f` are `n`-th roots of unity and the trace is their sum, weighted by
+the dimensions of the eigenspaces, which add up to `finrank ℂ V`. A sum of `finrank ℂ V` many unit
+vectors of `ℂ` has absolute value `finrank ℂ V` only when they all point the same way, so every
+eigenvalue equals the common phase `μ`; `f` is diagonalizable, so it is `μ` times the identity.
 
-The restriction to `ℂ` is one of proof and of API, not of substance. The statement is true over any
-field of characteristic zero, the eigenvalues generating a cyclotomic subfield of the algebraic
-closure that embeds into `ℂ`; what the argument below uses is the comparison `Re μ ≤ ‖μ‖`, which
-such an embedding is exactly what it takes to have. That descent is not carried out here, and `ℂ`
-is where the consumers of this file work. -/
-theorem eq_one_of_trace_eq_finrank {f : End ℂ V} {n : ℕ} (hn : n ≠ 0) (hf : f ^ n = 1)
-    (h : LinearMap.trace ℂ V f = (finrank ℂ V : ℂ)) : f = 1 := by
+The bound itself, `‖tr f‖ ≤ finrank ℂ V`, is the triangle inequality;
+`TauCeti.End.eq_one_of_trace_eq_finrank` is the case `μ = 1`, where the trace attains the bound at
+the positive real value `finrank ℂ V`. -/
+theorem exists_eq_smul_of_norm_trace_eq_finrank {f : End ℂ V} {n : ℕ} (hn : n ≠ 0) (hf : f ^ n = 1)
+    (h : ‖LinearMap.trace ℂ V f‖ = (finrank ℂ V : ℝ)) : ∃ μ : ℂ, μ ^ n = 1 ∧ f = μ • 1 := by
   classical
   have hn' : (n : ℂ) ≠ 0 := Nat.cast_ne_zero.2 hn
-  set E := (End.finite_hasEigenvalue f).toFinset
-  -- the dimensions of the eigenspaces add up to the dimension: the case `m = 0` of the trace
-  -- formula, where `f ^ 0 = 1` has trace `finrank ℂ V`
+  rcases Nat.eq_zero_or_pos (finrank ℂ V) with hV | hV
+  · have : Subsingleton V := Module.finrank_zero_iff.1 hV
+    exact ⟨1, one_pow n, LinearMap.ext fun _ => Subsingleton.elim _ _⟩
+  set E := (End.finite_hasEigenvalue f).toFinset with hE
   have hdim : ∑ μ ∈ E, (finrank ℂ (f.eigenspace μ) : ℂ) = (finrank ℂ V : ℂ) := by
     simpa using (trace_pow_eq_sum_eigenvalue_pow hn' hf 0).symm
-  -- the trace is the weighted sum of the eigenvalues: the case `m = 1`
-  have htrace : ∑ μ ∈ E, (finrank ℂ (f.eigenspace μ) : ℂ) * μ = (finrank ℂ V : ℂ) := by
-    simpa using (trace_pow_eq_sum_eigenvalue_pow hn' hf 1).symm.trans h
-  -- so the eigenvalues, weighted by dimension, differ from `1` by nothing
-  have hcomplex : ∑ μ ∈ E, (finrank ℂ (f.eigenspace μ) : ℂ) * (1 - μ) = 0 := by
-    simp only [mul_sub, mul_one, Finset.sum_sub_distrib, hdim, htrace, sub_self]
-  have hreal : ∑ μ ∈ E, (finrank ℂ (f.eigenspace μ) : ℝ) * (1 - μ.re) = 0 := by
-    have := congrArg Complex.re hcomplex
+  have htrace : ∑ μ ∈ E, (finrank ℂ (f.eigenspace μ) : ℂ) * μ = LinearMap.trace ℂ V f := by
+    simpa using (trace_pow_eq_sum_eigenvalue_pow hn' hf 1).symm
+  have hNne : (finrank ℂ V : ℂ) ≠ 0 := Nat.cast_ne_zero.2 hV.ne'
+  -- the common phase of the eigenvalues
+  set μ₀ : ℂ := LinearMap.trace ℂ V f / (finrank ℂ V : ℂ) with hμ₀def
+  have htμ₀ : LinearMap.trace ℂ V f = μ₀ * (finrank ℂ V : ℂ) := by
+    rw [hμ₀def, div_mul_cancel₀ _ hNne]
+  have hnormμ₀ : ‖μ₀‖ = 1 := by
+    rw [hμ₀def, norm_div, h, Complex.norm_natCast]
+    exact div_self (Nat.cast_ne_zero.2 hV.ne')
+  have hμ₀ne : μ₀ ≠ 0 := by
+    intro h0
+    rw [h0, norm_zero] at hnormμ₀
+    exact zero_ne_one hnormμ₀
+  have hconj : (starRingEnd ℂ) μ₀ * μ₀ = 1 := by
+    rw [← Complex.inv_eq_conj hnormμ₀]
+    exact inv_mul_cancel₀ hμ₀ne
+  -- rotating the trace back by that phase recovers the dimension exactly
+  have hkey : ∑ μ ∈ E, (finrank ℂ (f.eigenspace μ) : ℂ) * ((starRingEnd ℂ) μ₀ * μ)
+      = (finrank ℂ V : ℂ) := by
+    calc ∑ μ ∈ E, (finrank ℂ (f.eigenspace μ) : ℂ) * ((starRingEnd ℂ) μ₀ * μ)
+        = (starRingEnd ℂ) μ₀ * ∑ μ ∈ E, (finrank ℂ (f.eigenspace μ) : ℂ) * μ := by
+          rw [Finset.mul_sum]
+          exact Finset.sum_congr rfl fun _ _ => by ring
+      _ = (starRingEnd ℂ) μ₀ * (μ₀ * (finrank ℂ V : ℂ)) := by rw [htrace, htμ₀]
+      _ = (finrank ℂ V : ℂ) := by rw [← mul_assoc, hconj, one_mul]
+  have hzero : ∑ μ ∈ E, (finrank ℂ (f.eigenspace μ) : ℂ) * (1 - (starRingEnd ℂ) μ₀ * μ) = 0 := by
+    simp only [mul_sub, mul_one, Finset.sum_sub_distrib, hdim, hkey, sub_self]
+  have hreal : ∑ μ ∈ E, (finrank ℂ (f.eigenspace μ) : ℝ) * (1 - ((starRingEnd ℂ) μ₀ * μ).re)
+      = 0 := by
+    have := congrArg Complex.re hzero
     simpa [Complex.re_sum, Complex.mul_re] using this
-  -- every summand is nonnegative, an eigenvalue having real part at most its norm, which is `1`
-  have hnonneg : ∀ μ ∈ E, 0 ≤ (finrank ℂ (f.eigenspace μ) : ℝ) * (1 - μ.re) := by
+  have hnormE : ∀ μ ∈ E, ‖(starRingEnd ℂ) μ₀ * μ‖ = 1 := by
     intro μ hμ
     have hpow : μ ^ n = 1 :=
       pow_eq_one_of_hasEigenvalue hf ((End.finite_hasEigenvalue f).mem_toFinset.1 hμ)
-    have : μ.re ≤ 1 := (Complex.re_le_norm μ).trans_eq (Complex.norm_eq_one_of_pow_eq_one hpow hn)
+    rw [norm_mul, Complex.norm_conj, hnormμ₀, Complex.norm_eq_one_of_pow_eq_one hpow hn, one_mul]
+  -- every summand is nonnegative, a rotated eigenvalue having real part at most its norm `1`
+  have hnonneg : ∀ μ ∈ E,
+      0 ≤ (finrank ℂ (f.eigenspace μ) : ℝ) * (1 - ((starRingEnd ℂ) μ₀ * μ).re) := by
+    intro μ hμ
+    have := (Complex.re_le_norm ((starRingEnd ℂ) μ₀ * μ)).trans_eq (hnormE μ hμ)
     exact mul_nonneg (Nat.cast_nonneg _) (by linarith)
-  -- hence each vanishes, and the dimension factor does not
-  have hone : ∀ μ ∈ E, μ = 1 := by
+  have hall : ∀ μ ∈ E, μ = μ₀ := by
     intro μ hμ
     have hev : f.HasEigenvalue μ := (End.finite_hasEigenvalue f).mem_toFinset.1 hμ
-    have hzero := (Finset.sum_eq_zero_iff_of_nonneg hnonneg).1 hreal μ hμ
+    have hz := (Finset.sum_eq_zero_iff_of_nonneg hnonneg).1 hreal μ hμ
     have hdpos : (finrank ℂ (f.eigenspace μ) : ℝ) ≠ 0 := by
       have : f.eigenspace μ ≠ ⊥ := hev
       simpa [Submodule.finrank_eq_zero] using this
-    refine eq_one_of_pow_eq_one_of_re_eq_one hn
-      (pow_eq_one_of_hasEigenvalue hf hev) ?_
-    have := mul_eq_zero.1 hzero
-    rcases this with h' | h'
-    · exact absurd h' hdpos
-    · linarith
-  -- `f - 1` is semisimple with every eigenvalue `0`, hence zero
-  have hss : (f - 1 : End ℂ V).IsSemisimple := by
-    simpa using (End.isSemisimple_sub_algebraMap_iff (μ := (1 : ℂ))).2
-      (isSemisimple_of_pow_eq_one hn' hf)
+    have hre : ((starRingEnd ℂ) μ₀ * μ).re = 1 := by
+      rcases mul_eq_zero.1 hz with h' | h'
+      · exact absurd h' hdpos
+      · linarith
+    have h1 : (starRingEnd ℂ) μ₀ * μ = 1 :=
+      eq_one_of_norm_eq_one_of_re_eq_one (hnormE μ hμ) hre
+    calc μ = ((starRingEnd ℂ) μ₀ * μ₀) * μ := by rw [hconj, one_mul]
+      _ = μ₀ * ((starRingEnd ℂ) μ₀ * μ) := by ring
+      _ = μ₀ := by rw [h1, mul_one]
+  have hEne : E.Nonempty := by
+    rcases Finset.eq_empty_or_nonempty E with hEmp | hne
+    · rw [hEmp, Finset.sum_empty] at hdim
+      exact absurd hdim.symm hNne
+    · exact hne
+  obtain ⟨ν, hν⟩ := hEne
+  have hμ₀E : μ₀ ∈ E := by rw [← hall ν hν]; exact hν
+  refine ⟨μ₀,
+    pow_eq_one_of_hasEigenvalue hf ((End.finite_hasEigenvalue f).mem_toFinset.1 hμ₀E), ?_⟩
+  -- `f - μ₀` is semisimple with every eigenvalue `0`, hence zero
+  have hss : (f - μ₀ • (1 : End ℂ V)).IsSemisimple := by
+    rw [← Algebra.algebraMap_eq_smul_one]
+    exact (End.isSemisimple_sub_algebraMap_iff (μ := μ₀)).2 (isSemisimple_of_pow_eq_one hn' hf)
   refine sub_eq_zero.1 (hss.eq_zero_iff_forall_eigenvalue.2 fun μ hμ => ?_)
   -- `End.hasEigenvalue_sub_iff` shifts the eigenvalues of `f - c • LinearMap.id` by `c`, so the
-  -- subtracted identity has to be written as that scalar action before it applies
-  have hid : (f - 1 : End ℂ V) = f - (1 : ℂ) • LinearMap.id := by
-    rw [one_smul, End.one_eq_id]
-  have hev : f.HasEigenvalue (μ + 1) := by
-    rw [hid, End.hasEigenvalue_sub_iff] at hμ
-    exact hμ
-  linear_combination hone (μ + 1) ((End.finite_hasEigenvalue f).mem_toFinset.2 hev)
+  -- subtracted scalar has to be written as that scalar action before it applies
+  have hid : (f - μ₀ • (1 : End ℂ V)) = f - μ₀ • LinearMap.id := by rw [End.one_eq_id]
+  rw [hid, End.hasEigenvalue_sub_iff] at hμ
+  have := hall (μ + μ₀) ((End.finite_hasEigenvalue f).mem_toFinset.2 hμ)
+  linear_combination this
+
+/-- **An endomorphism of finite order with trace the dimension is the identity.** The trace
+attains the largest absolute value it can, so `f` is a scalar
+(`TauCeti.End.exists_eq_smul_of_norm_trace_eq_finrank`), and the scalar is `1` because the trace of
+`μ • 1` is `μ` times the dimension.
+
+The restriction to `ℂ` is one of proof and of API, not of substance. The statement is true over any
+field of characteristic zero, the eigenvalues generating a cyclotomic subfield of the algebraic
+closure that embeds into `ℂ`; what the argument uses is the comparison `Re μ ≤ ‖μ‖`, which such an
+embedding is exactly what it takes to have. That descent is not carried out here, and `ℂ` is where
+the consumers of this file work. -/
+theorem eq_one_of_trace_eq_finrank {f : End ℂ V} {n : ℕ} (hn : n ≠ 0) (hf : f ^ n = 1)
+    (h : LinearMap.trace ℂ V f = (finrank ℂ V : ℂ)) : f = 1 := by
+  obtain ⟨μ, -, rfl⟩ :=
+    exists_eq_smul_of_norm_trace_eq_finrank hn hf (by rw [h, Complex.norm_natCast])
+  rcases Nat.eq_zero_or_pos (finrank ℂ V) with hV | hV
+  · have : Subsingleton V := Module.finrank_zero_iff.1 hV
+    exact LinearMap.ext fun _ => Subsingleton.elim _ _
+  · rw [map_smul, LinearMap.trace_one, smul_eq_mul] at h
+    rw [mul_right_cancel₀ (Nat.cast_ne_zero.2 hV.ne') (h.trans (one_mul _).symm), one_smul]
 
 /-- **An endomorphism of finite order has trace the dimension exactly when it is the identity.**
 The forward direction is `TauCeti.End.eq_one_of_trace_eq_finrank`; the converse is

--- a/TauCeti/LinearAlgebra/End/FiniteOrder.lean
+++ b/TauCeti/LinearAlgebra/End/FiniteOrder.lean
@@ -212,13 +212,6 @@ theorem conj_trace_eq_trace_pow_sub_one {f : End ℂ V} {n : ℕ} (hn : n ≠ 0)
     exact inv_eq_of_mul_eq_one_right
       (by rw [← pow_succ', Nat.sub_add_cancel (Nat.one_le_iff_ne_zero.2 hn), hμ])
 
-/-- A complex number of norm `1` whose real part is `1` is `1`: the real part already exhausts the
-norm, so the imaginary part vanishes. -/
-private theorem eq_one_of_norm_eq_one_of_re_eq_one {μ : ℂ} (hnorm : ‖μ‖ = 1) (hre : μ.re = 1) :
-    μ = 1 := by
-  have him : μ.im = 0 := Complex.abs_re_eq_norm.mp (by rw [hre, hnorm, abs_one])
-  exact Complex.ext (by simpa using hre) (by simpa using him)
-
 /-- **An endomorphism of finite order whose trace has the largest possible absolute value is a
 scalar.** The eigenvalues of `f` are `n`-th roots of unity and the trace is their sum, weighted by
 the dimensions of the eigenspaces, which add up to `finrank ℂ V`. A sum of `finrank ℂ V` many unit
@@ -292,8 +285,11 @@ theorem exists_eq_smul_of_norm_trace_eq_finrank {f : End ℂ V} {n : ℕ} (hn : 
       rcases mul_eq_zero.1 hz with h' | h'
       · exact absurd h' hdpos
       · linarith
+    -- a real part of `1` already exhausts the norm `1`, so the imaginary part vanishes
+    have him : ((starRingEnd ℂ) μ₀ * μ).im = 0 :=
+      Complex.abs_re_eq_norm.mp (by rw [hre, hnormE μ hμ, abs_one])
     have h1 : (starRingEnd ℂ) μ₀ * μ = 1 :=
-      eq_one_of_norm_eq_one_of_re_eq_one (hnormE μ hμ) hre
+      Complex.ext (by simpa using hre) (by simpa using him)
     calc μ = ((starRingEnd ℂ) μ₀ * μ₀) * μ := by rw [hconj, one_mul]
       _ = μ₀ * ((starRingEnd ℂ) μ₀ * μ) := by ring
       _ = μ₀ := by rw [h1, mul_one]

--- a/TauCeti/LinearAlgebra/End/FiniteOrder.lean
+++ b/TauCeti/LinearAlgebra/End/FiniteOrder.lean
@@ -42,7 +42,9 @@ conjugation is such a `σ`, with `j = n - 1`, since it sends a root of unity `μ
 `μ⁻¹ = μ ^ (n - 1)`; that instance is the source of `conj (χ g) = χ g⁻¹` for characters of complex
 representations.
 
-All the results are stated of `Module.End`, so they sit in the `End` namespace under `open Module`.
+All the results are stated of `Module.End`, so they sit in the `End` namespace under
+`open Module`; the one whose consumers use it under its Mathlib receiver type,
+`Module.End.exists_eq_smul_of_norm_trace_eq_finrank`, is in that type's own namespace.
 
 ## Main results
 
@@ -60,7 +62,7 @@ All the results are stated of `Module.End`, so they sit in the `End` namespace u
   `j`-th power.
 * `TauCeti.End.conj_trace_eq_trace_pow_sub_one`: over `ℂ`, the conjugate of the trace of an
   endomorphism of finite order `n` is the trace of its inverse `f ^ (n - 1)`.
-* `TauCeti.End.exists_eq_smul_of_norm_trace_eq_finrank`: over `ℂ`, an endomorphism of finite order
+* `Module.End.exists_eq_smul_of_norm_trace_eq_finrank`: over `ℂ`, an endomorphism of finite order
   whose trace has absolute value the dimension **is a scalar**, the scalar being a root of unity.
   The trace is the sum of `finrank ℂ V` many roots of unity, so that absolute value is the largest
   it can take, and it is attained only when the eigenvalues all coincide.
@@ -221,7 +223,8 @@ eigenvalue equals the common phase `μ`; `f` is diagonalizable, so it is `μ` ti
 The bound itself, `‖tr f‖ ≤ finrank ℂ V`, is the triangle inequality;
 `TauCeti.End.eq_one_of_trace_eq_finrank` is the case `μ = 1`, where the trace attains the bound at
 the positive real value `finrank ℂ V`. -/
-theorem exists_eq_smul_of_norm_trace_eq_finrank {f : End ℂ V} {n : ℕ} (hn : n ≠ 0) (hf : f ^ n = 1)
+theorem _root_.Module.End.exists_eq_smul_of_norm_trace_eq_finrank {f : End ℂ V} {n : ℕ}
+    (hn : n ≠ 0) (hf : f ^ n = 1)
     (h : ‖LinearMap.trace ℂ V f‖ = (finrank ℂ V : ℝ)) : ∃ μ : ℂ, μ ^ n = 1 ∧ f = μ • 1 := by
   classical
   have hn' : (n : ℂ) ≠ 0 := Nat.cast_ne_zero.2 hn
@@ -316,7 +319,7 @@ theorem exists_eq_smul_of_norm_trace_eq_finrank {f : End ℂ V} {n : ℕ} (hn : 
 
 /-- **An endomorphism of finite order with trace the dimension is the identity.** The trace
 attains the largest absolute value it can, so `f` is a scalar
-(`TauCeti.End.exists_eq_smul_of_norm_trace_eq_finrank`), and the scalar is `1` because the trace of
+(`Module.End.exists_eq_smul_of_norm_trace_eq_finrank`), and the scalar is `1` because the trace of
 `μ • 1` is `μ` times the dimension.
 
 The restriction to `ℂ` is one of proof and of API, not of substance. The statement is true over any
@@ -327,7 +330,7 @@ the consumers of this file work. -/
 theorem eq_one_of_trace_eq_finrank {f : End ℂ V} {n : ℕ} (hn : n ≠ 0) (hf : f ^ n = 1)
     (h : LinearMap.trace ℂ V f = (finrank ℂ V : ℂ)) : f = 1 := by
   obtain ⟨μ, -, rfl⟩ :=
-    exists_eq_smul_of_norm_trace_eq_finrank hn hf (by rw [h, Complex.norm_natCast])
+    Module.End.exists_eq_smul_of_norm_trace_eq_finrank hn hf (by rw [h, Complex.norm_natCast])
   rcases Nat.eq_zero_or_pos (finrank ℂ V) with hV | hV
   · have : Subsingleton V := Module.finrank_zero_iff.1 hV
     exact LinearMap.ext fun _ => Subsingleton.elim _ _

--- a/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.RepresentationTheory.CharacterTable.CentralCharacter
 public import TauCeti.RepresentationTheory.CharacterTable.Values
-public import Mathlib.Algebra.GCDMonoid.IntegrallyClosed
+public import TauCeti.RingTheory.IntegralClosure.Rat
 
 /-!
 # The degree of an irreducible character divides the group order
@@ -55,24 +55,6 @@ namespace TauCeti
 
 open Module (finrank)
 open scoped MonoidAlgebra
-
-/-- A rational algebraic integer is an integer, in the form used below: if `n · z = m` for natural
-numbers `m` and `n` with `n ≠ 0`, and `z` is integral over `ℤ` in a field of characteristic zero,
-then `n` divides `m`. -/
-private theorem dvd_of_isIntegral_of_natCast_mul_eq {k : Type*} [Field k] [CharZero k] {m n : ℕ}
-    {z : k} (hz : IsIntegral ℤ z) (h : (n : k) * z = m) (hn : n ≠ 0) : n ∣ m := by
-  have hnk : (n : k) ≠ 0 := Nat.cast_ne_zero.mpr hn
-  have hz' : algebraMap ℚ k ((m : ℚ) / (n : ℚ)) = z := by
-    rw [map_div₀, map_natCast, map_natCast, eq_comm, eq_div_iff hnk, mul_comm]
-    exact h
-  have hq : IsIntegral ℤ ((m : ℚ) / (n : ℚ)) :=
-    isIntegral_algebraMap_iff.mp (hz' ▸ hz)
-  obtain ⟨y, hy⟩ := IsIntegrallyClosed.algebraMap_eq_of_integral hq
-  have hyq : (y : ℚ) * (n : ℚ) = (m : ℚ) := by
-    rw [← eq_intCast (algebraMap ℤ ℚ) y, hy, div_mul_cancel₀]
-    exact Nat.cast_ne_zero.mpr hn
-  refine Int.natCast_dvd_natCast.mp ⟨y, ?_⟩
-  exact_mod_cast (by linarith : (m : ℚ) = (n : ℚ) * (y : ℚ))
 
 namespace Representation
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Solvable.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Solvable.lean
@@ -7,10 +7,10 @@ module
 
 public import TauCeti.Algebra.Group.Conj
 public import Mathlib.GroupTheory.Solvable
-public import Mathlib.GroupTheory.Sylow
 import TauCeti.RepresentationTheory.CharacterTable.Table
 import TauCeti.RepresentationTheory.CharacterTable.Vanishing
 import Mathlib.GroupTheory.Nilpotent
+import Mathlib.GroupTheory.Sylow
 
 /-!
 # Burnside's `pᵃqᵇ` theorem
@@ -71,31 +71,6 @@ open Module
 
 universe u
 
-section Integrality
-
-/-- **No algebraic integer is the negative reciprocal of a prime.** A rational algebraic integer is
-an integer, because `ℤ` is integrally closed in `ℚ`, and `-1/p` is not one. -/
-private theorem not_isIntegral_of_mul_eq_neg_one {p : ℕ} (hp : 1 < p) {z : ℂ}
-    (hz : (p : ℂ) * z = -1) : ¬ IsIntegral ℤ z := by
-  intro hint
-  have hp0 : (p : ℂ) ≠ 0 := Nat.cast_ne_zero.2 (by omega)
-  have hzval : z = ((-1 / p : ℚ) : ℂ) := by
-    have hcast : ((-1 / p : ℚ) : ℂ) = -1 / (p : ℂ) := by push_cast; ring
-    rw [hcast, eq_div_iff hp0]
-    linear_combination hz
-  rw [hzval, show (((-1 / p : ℚ)) : ℂ) = algebraMap ℚ ℂ (-1 / p : ℚ) from
-    (eq_ratCast (algebraMap ℚ ℂ) _).symm, isIntegral_algebraMap_iff] at hint
-  obtain ⟨m, hm⟩ := IsIntegrallyClosed.isIntegral_iff.1 hint
-  have hmq : (m : ℚ) * p = -1 := by
-    have hm' : (m : ℚ) = -1 / p := by simpa using hm
-    rw [hm', div_mul_cancel₀ _ (Nat.cast_ne_zero.2 (by omega : p ≠ 0))]
-  have hmz : m * (p : ℤ) = -1 := by exact_mod_cast hmq
-  have hdvd : (p : ℤ) ∣ 1 := ⟨-m, by linear_combination hmz⟩
-  have := Int.le_of_dvd one_pos hdvd
-  omega
-
-end Integrality
-
 section ClassSize
 
 variable {G : Type u} [Group G] [Finite G]
@@ -142,7 +117,9 @@ private theorem exists_ne_of_not_dvd_characterDegree [Invertible (Nat.card G : �
     rw [← character_irreducibleRepresentation ℂ i]
     exact Representation.isIntegral_char _ (isOfFinOrder_of_finite g).orderOf_pos.ne'
       (pow_orderOf_eq_one g)
-  exact not_isIntegral_of_mul_eq_neg_one hp.one_lt (by linear_combination hone) hzint
+  -- `p · (-z) = 1` with `-z` an algebraic integer makes `p` divide `1`
+  exact hp.ne_one (Nat.dvd_one.1 (dvd_of_isIntegral_of_natCast_mul_eq (m := 1) hzint.neg
+    (by push_cast; linear_combination -hone) hp.pos.ne'))
 
 /-- **A conjugacy class of prime-power size larger than one forces a proper normal subgroup.** If
 some element of a finite group has a conjugacy class of size `p ^ k` with `p` prime and `k ≠ 0`,
@@ -202,8 +179,7 @@ theorem not_isSimpleGroup_of_card_carrier_eq_prime_pow {g : G} {p k : ℕ} (hp :
       rw [← character_irreducibleRepresentation ℂ i]
       simp [Representation.character, hone]
     have horth := card_inv_mul_sum_characterTable_mul_conj (G := G) i i₀
-    rw [show (if i = i₀ then (1 : ℂ) else 0) = 0 from ite_eq_right fun h => absurd h hne]
-      at horth
+    simp only [hne, ite_false] at horth
     have hval : ∀ g' : G, characterTable ℂ G i (ConjClasses.mk g') *
         (starRingEnd ℂ) (characterTable ℂ G i₀ (ConjClasses.mk g'))
           = (characterDegree ℂ i : ℂ) := by

--- a/TauCeti/RepresentationTheory/CharacterTable/Solvable.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Solvable.lean
@@ -1,0 +1,318 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Group.Conj
+public import Mathlib.GroupTheory.Solvable
+public import Mathlib.GroupTheory.Sylow
+import TauCeti.RepresentationTheory.CharacterTable.Table
+import TauCeti.RepresentationTheory.CharacterTable.Vanishing
+import Mathlib.GroupTheory.Nilpotent
+
+/-!
+# Burnside's `pᵃqᵇ` theorem
+
+A finite group whose order has at most two prime divisors is solvable. The proof is the classical
+character-theoretic one, and it runs through the statement that a **conjugacy class of prime-power
+size larger than one forces a proper nontrivial normal subgroup**
+(`TauCeti.not_isSimpleGroup_of_card_carrier_eq_prime_pow`), which is where all the representation
+theory is spent.
+
+## The class-size step
+
+Let `g` have a conjugacy class of size `p ^ k` with `k ≠ 0`, and suppose `G` were simple. Column
+orthogonality at the classes of `g` and of `1` reads `∑_χ χ(1) χ(g) = 0`, the sum being over the
+irreducible characters. The trivial character contributes `1`. If every other irreducible character
+either vanished at `g` or had degree divisible by `p`, the remaining terms would add up to `p` times
+an algebraic integer, making `-1/p` an algebraic integer; it is rational and not an integer, so some
+irreducible character `χ ≠ 1` has `χ(g) ≠ 0` and degree prime to `p`.
+
+Its degree is then coprime to the class size, so Burnside's vanishing theorem
+(`TauCeti.Representation.char_eq_zero_or_norm_char_eq_finrank`) applies and gives `‖χ(g)‖ = χ(1)`.
+That is the equality case of the bound on a character value, so the affording representation sends
+`g` to a scalar (`TauCeti.Representation.exists_apply_eq_smul_of_norm_char_eq_finrank`). Its kernel
+is normal, hence trivial or everything: if it is everything the character is constant and row
+orthogonality against the trivial character makes its degree `0`, which is absurd; and if it is
+trivial the representation is faithful, so `g` commutes with everything and its class is a single
+point, contradicting `k ≠ 0`.
+
+## The induction
+
+`TauCeti.isSolvable_of_card_eq_prime_pow_mul_prime_pow` follows by induction on the order. A group
+with a proper nontrivial normal subgroup is solvable as soon as that subgroup and the quotient are,
+and both are smaller. A simple group with no `q`-torsion is a `p`-group, hence nilpotent. Otherwise
+the centre of a Sylow `q`-subgroup `Q` supplies a nontrivial `g` whose centralizer contains `Q`, so
+its class has size dividing the index of `Q`, a power of `p`. A class of size one puts `g` in the
+centre, which simplicity then makes all of `G`, and a larger one contradicts the class-size step.
+
+## Main results
+
+* `TauCeti.not_isSimpleGroup_of_card_carrier_eq_prime_pow`: **a conjugacy class of prime-power size
+  larger than one forces a proper nontrivial normal subgroup.**
+* `TauCeti.isSolvable_of_card_eq_prime_pow_mul_prime_pow`: **Burnside's `pᵃqᵇ` theorem**, that a
+  finite group of order `pᵃqᵇ` is solvable, with
+  `TauCeti.isSolvable_of_card_dvd_prime_pow_mul_prime_pow` the divisibility form that the induction
+  runs in.
+
+## References
+
+* W. Burnside, *Theory of Groups of Finite Order*, 2nd ed. (1911).
+* I. M. Isaacs, *Character Theory of Finite Groups* (1976), Theorem 3.8 and its corollaries.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module
+
+universe u
+
+section Integrality
+
+/-- **No algebraic integer is the negative reciprocal of a prime.** A rational algebraic integer is
+an integer, because `ℤ` is integrally closed in `ℚ`, and `-1/p` is not one. -/
+private theorem not_isIntegral_of_mul_eq_neg_one {p : ℕ} (hp : 1 < p) {z : ℂ}
+    (hz : (p : ℂ) * z = -1) : ¬ IsIntegral ℤ z := by
+  intro hint
+  have hp0 : (p : ℂ) ≠ 0 := Nat.cast_ne_zero.2 (by omega)
+  have hzval : z = ((-1 / p : ℚ) : ℂ) := by
+    have hcast : ((-1 / p : ℚ) : ℂ) = -1 / (p : ℂ) := by push_cast; ring
+    rw [hcast, eq_div_iff hp0]
+    linear_combination hz
+  rw [hzval, show (((-1 / p : ℚ)) : ℂ) = algebraMap ℚ ℂ (-1 / p : ℚ) from
+    (eq_ratCast (algebraMap ℚ ℂ) _).symm, isIntegral_algebraMap_iff] at hint
+  obtain ⟨m, hm⟩ := IsIntegrallyClosed.isIntegral_iff.1 hint
+  have hmq : (m : ℚ) * p = -1 := by
+    have hm' : (m : ℚ) = -1 / p := by simpa using hm
+    rw [hm', div_mul_cancel₀ _ (Nat.cast_ne_zero.2 (by omega : p ≠ 0))]
+  have hmz : m * (p : ℤ) = -1 := by exact_mod_cast hmq
+  have hdvd : (p : ℤ) ∣ 1 := ⟨-m, by linear_combination hmz⟩
+  have := Int.le_of_dvd one_pos hdvd
+  omega
+
+end Integrality
+
+section ClassSize
+
+variable {G : Type u} [Group G] [Finite G]
+
+/-- **Column orthogonality supplies a nontrivial irreducible character that neither vanishes at
+`g` nor has degree divisible by `p`.** Summing the column at `g` against the column at `1` gives
+`0`, and the trivial character `i₀` contributes `1`; were every other contribution `0` or a
+multiple of `p`, the identity would exhibit `-1/p` as an algebraic integer. -/
+private theorem exists_ne_of_not_dvd_characterDegree [Invertible (Nat.card G : ℂ)]
+    {g : G} (hg1 : g ≠ 1) {p : ℕ} (hp : p.Prime)
+    {i₀ : Fin (Nat.card (ConjClasses G))} (hi₀ : irreducibleCharacter ℂ i₀ = fun _ : G => (1 : ℂ)) :
+    ∃ i, i ≠ i₀ ∧ irreducibleCharacter ℂ i g ≠ 0 ∧ ¬ p ∣ characterDegree ℂ i := by
+  classical
+  let : Fintype G := Fintype.ofFinite G
+  have hd₀ : characterDegree ℂ i₀ = 1 := by
+    have h1 : ((characterDegree ℂ i₀ : ℕ) : ℂ) = 1 := by
+      rw [← irreducibleCharacter_one (k := ℂ) i₀, hi₀]
+    exact_mod_cast h1
+  have hsum : ∑ i, irreducibleCharacter ℂ i g * (characterDegree ℂ i : ℂ) = 0 := by
+    simpa [hg1] using sum_characterTable_mul_characterTable_inv (k := ℂ) (G := G) g 1
+  by_contra hcon
+  push Not at hcon
+  set z : ℂ := ∑ i ∈ Finset.univ.erase i₀,
+    irreducibleCharacter ℂ i g * ((characterDegree ℂ i / p : ℕ) : ℂ) with hzdef
+  have hpz : (p : ℂ) * z = ∑ i ∈ Finset.univ.erase i₀,
+      irreducibleCharacter ℂ i g * (characterDegree ℂ i : ℂ) := by
+    rw [hzdef, Finset.mul_sum]
+    refine Finset.sum_congr rfl fun i hi => ?_
+    rcases eq_or_ne (irreducibleCharacter ℂ i g) 0 with h0 | h0
+    · rw [h0]; ring
+    · have hdvd := hcon i (Finset.mem_erase.1 hi).1 h0
+      have hcancel : (p : ℂ) * ((characterDegree ℂ i / p : ℕ) : ℂ)
+          = (characterDegree ℂ i : ℂ) := by
+        rw [← Nat.cast_mul, Nat.mul_div_cancel' hdvd]
+      linear_combination irreducibleCharacter ℂ i g * hcancel
+  have hsplit := (Finset.add_sum_erase Finset.univ
+    (fun i => irreducibleCharacter ℂ i g * (characterDegree ℂ i : ℂ))
+    (Finset.mem_univ i₀)).trans hsum
+  rw [hi₀, hd₀] at hsplit
+  have hone : (1 : ℂ) + (p : ℂ) * z = 0 := by rw [hpz]; simpa using hsplit
+  have hzint : IsIntegral ℤ z := by
+    rw [hzdef]
+    refine IsIntegral.sum _ fun i _ => IsIntegral.mul ?_ (isIntegral_natCast _)
+    rw [← character_irreducibleRepresentation ℂ i]
+    exact Representation.isIntegral_char _ (isOfFinOrder_of_finite g).orderOf_pos.ne'
+      (pow_orderOf_eq_one g)
+  exact not_isIntegral_of_mul_eq_neg_one hp.one_lt (by linear_combination hone) hzint
+
+/-- **A conjugacy class of prime-power size larger than one forces a proper normal subgroup.** If
+some element of a finite group has a conjugacy class of size `p ^ k` with `p` prime and `k ≠ 0`,
+then the group is not simple.
+
+This is the character-theoretic heart of Burnside's `pᵃqᵇ` theorem: it is what a Sylow argument is
+fed into. -/
+theorem not_isSimpleGroup_of_card_carrier_eq_prime_pow {g : G} {p k : ℕ} (hp : p.Prime)
+    (hk : k ≠ 0) (hcard : Nat.card (ConjClasses.mk g).carrier = p ^ k) : ¬ IsSimpleGroup G := by
+  classical
+  intro hsimple
+  let : Fintype G := Fintype.ofFinite G
+  have hcardC : ((Nat.card G : ℕ) : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr Nat.card_pos.ne'
+  let : Invertible ((Nat.card G : ℕ) : ℂ) := invertibleOfNonzero hcardC
+  have hpk : p ^ k ≠ 1 := (Nat.one_lt_pow hk hp.one_lt).ne'
+  have hgcenter : g ∉ Subgroup.center G := fun hg =>
+    hpk (by rw [← hcard, Nat.card_coe_set_eq, ConjClasses.ncard_carrier_mk_of_mem_center hg])
+  have hg1 : g ≠ 1 := fun h => hgcenter (by rw [h]; exact Subgroup.one_mem _)
+  -- the trivial character, and its index in the enumeration of the irreducible characters
+  obtain ⟨i₀, hi₀⟩ : ∃ i, irreducibleCharacter ℂ i = fun _ : G => (1 : ℂ) := by
+    have hchar : (Representation.trivial ℂ G ℂ).character = fun _ : G => (1 : ℂ) := by
+      funext x
+      have hx : (Representation.trivial ℂ G ℂ) x = LinearMap.id := LinearMap.ext fun v => by simp
+      simp [Representation.character, hx]
+    have hmem : (fun _ : G => (1 : ℂ)) ∈ irreducibleCharacters ℂ G := by
+      rw [← hchar]
+      exact character_mem_irreducibleCharacters (Representation.trivial ℂ G ℂ)
+    exact exists_irreducibleCharacter_eq ℂ hmem
+  -- some nontrivial irreducible character survives at `g` with degree prime to `p`
+  obtain ⟨i, hne, hchi, hpdvd⟩ := exists_ne_of_not_dvd_characterDegree hg1 hp hi₀
+  -- its degree is coprime to the class size, so Burnside's vanishing theorem applies
+  have hcop : (Nat.card (ConjClasses.mk g).carrier).Coprime
+      (finrank ℂ (Fin (characterDegree ℂ i) → ℂ)) := by
+    rw [hcard]
+    simpa using Nat.Coprime.pow_left k ((Nat.Prime.coprime_iff_not_dvd hp).2 hpdvd)
+  have hdich := Representation.char_eq_zero_or_norm_char_eq_finrank
+    (irreducibleRepresentation ℂ i) hcop
+  rw [character_irreducibleRepresentation] at hdich
+  rcases hdich with h0 | hnorm
+  · exact hchi h0
+  obtain ⟨μ, -, hμ⟩ := Representation.exists_apply_eq_smul_of_norm_char_eq_finrank
+    (irreducibleRepresentation ℂ i) (isOfFinOrder_of_finite g).orderOf_pos.ne'
+    (pow_orderOf_eq_one g) (by rw [character_irreducibleRepresentation]; exact hnorm)
+  rcases hsimple.eq_bot_or_eq_top_of_normal
+    (MonoidHom.ker (irreducibleRepresentation ℂ i)) inferInstance with hker | hker
+  · -- the representation is faithful, so a scalar value makes `g` central
+    have hinj : Function.Injective (irreducibleRepresentation ℂ i) :=
+      (MonoidHom.ker_eq_bot_iff _).1 hker
+    refine hgcenter (Subgroup.mem_center_iff.2 fun h => hinj ?_)
+    rw [map_mul, map_mul, hμ, mul_smul_comm, smul_mul_assoc, mul_one, one_mul]
+  · -- the representation is trivial, so its character is constant, and row orthogonality
+    -- against the trivial character makes its degree zero
+    have htriv : ∀ h : G, irreducibleCharacter ℂ i h = (characterDegree ℂ i : ℂ) := by
+      intro h
+      have hone : (irreducibleRepresentation ℂ i) h = 1 :=
+        MonoidHom.mem_ker.mp (by rw [hker]; exact Subgroup.mem_top h)
+      rw [← character_irreducibleRepresentation ℂ i]
+      simp [Representation.character, hone]
+    have horth := card_inv_mul_sum_characterTable_mul_conj (G := G) i i₀
+    rw [show (if i = i₀ then (1 : ℂ) else 0) = 0 from ite_eq_right fun h => absurd h hne]
+      at horth
+    have hval : ∀ g' : G, characterTable ℂ G i (ConjClasses.mk g') *
+        (starRingEnd ℂ) (characterTable ℂ G i₀ (ConjClasses.mk g'))
+          = (characterDegree ℂ i : ℂ) := by
+      intro g'
+      rw [characterTable_apply, characterTable_apply, htriv, hi₀]
+      simp
+    simp only [hval, Finset.sum_const, Finset.card_univ, nsmul_eq_mul] at horth
+    have hcardG : ((Fintype.card G : ℕ) : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr Fintype.card_ne_zero
+    have hinv : ((Nat.card G : ℕ) : ℂ)⁻¹ ≠ 0 :=
+      inv_ne_zero (Nat.cast_ne_zero.mpr Nat.card_pos.ne')
+    have hzero : (characterDegree ℂ i : ℂ) = 0 :=
+      (mul_eq_zero.1 ((mul_eq_zero.1 horth).resolve_left hinv)).resolve_left hcardG
+    exact absurd hzero (by exact_mod_cast (characterDegree_pos (k := ℂ) i).ne')
+
+end ClassSize
+
+section Burnside
+
+/-- The induction behind Burnside's `pᵃqᵇ` theorem, on the order of the group. -/
+private theorem isSolvable_aux {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (a b : ℕ) (n : ℕ) :
+    ∀ (G : Type u) [Group G] [Finite G], Nat.card G = n → Nat.card G ∣ p ^ a * q ^ b →
+      Group.IsSolvable G := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro G _ _ hn hdvd
+    have : Fact p.Prime := ⟨hp⟩
+    have : Fact q.Prime := ⟨hq⟩
+    rcases subsingleton_or_nontrivial G with hsub | hnt
+    · exact inferInstance
+    by_cases hN : ∃ N : Subgroup G, N.Normal ∧ N ≠ ⊥ ∧ N ≠ ⊤
+    · -- split along a proper nontrivial normal subgroup
+      obtain ⟨N, hnorm, hbot, htop⟩ := hN
+      have := hnorm
+      have : Nontrivial N := (Subgroup.nontrivial_iff_ne_bot N).2 hbot
+      have hmul : Nat.card N * N.index = Nat.card G := N.card_mul_index
+      have hidx : 2 ≤ N.index := by
+        have h1 : N.index ≠ 1 := fun hi => htop (Subgroup.index_eq_one.1 hi)
+        have h0 : 0 < N.index := by rw [Subgroup.index_eq_card]; exact Nat.card_pos
+        omega
+      have hsub : 2 ≤ Nat.card N := Finite.one_lt_card
+      refine (Group.isSolvable_iff_subgroup_quotient N).2 ⟨ih (Nat.card N) ?_ N rfl ?_,
+        ih (Nat.card (G ⧸ N)) ?_ (G ⧸ N) rfl ?_⟩
+      · subst hn; nlinarith
+      · exact (Subgroup.card_subgroup_dvd_card N).trans hdvd
+      · rw [← Subgroup.index_eq_card]; subst hn; nlinarith
+      · exact (Subgroup.card_quotient_dvd_card N).trans hdvd
+    · -- no such subgroup: the group is simple
+      push Not at hN
+      have hsimple : IsSimpleGroup G :=
+        { eq_bot_or_eq_top_of_normal := fun N hnorm =>
+            (em (N = ⊥)).imp id fun h => hN N hnorm h }
+      by_cases hqdvd : q ∣ Nat.card G
+      · -- a Sylow `q`-subgroup is nontrivial, and the centre of it supplies the element
+        obtain ⟨Q⟩ : Nonempty (Sylow q G) := inferInstance
+        have hQbot : (Q : Subgroup G) ≠ ⊥ := fun h =>
+          Q.not_dvd_index (by rw [h, Subgroup.index_bot]; exact hqdvd)
+        have : Nontrivial (Q : Subgroup G) := (Subgroup.nontrivial_iff_ne_bot _).2 hQbot
+        have : Nontrivial (Subgroup.center (Q : Subgroup G)) := Q.isPGroup'.center_nontrivial
+        obtain ⟨z, hz1⟩ := exists_ne (1 : Subgroup.center ((Q : Subgroup G)))
+        set g : G := ((z : (Q : Subgroup G)) : G) with hgdef
+        have hgne : g ≠ 1 := fun h => hz1 (Subtype.ext (Subtype.ext h))
+        have hle : (Q : Subgroup G) ≤ Subgroup.centralizer {g} := by
+          intro y hy
+          rw [Subgroup.mem_centralizer_iff]
+          rintro m rfl
+          simpa [hgdef] using
+            (congrArg Subtype.val (Subgroup.mem_center_iff.1 z.2 ⟨y, hy⟩)).symm
+        have hQidx : (Q : Subgroup G).index ∣ p ^ a := by
+          have hcop : ((Q : Subgroup G).index).Coprime (q ^ b) :=
+            Nat.Coprime.pow_right b ((hq.coprime_iff_not_dvd.2 Q.not_dvd_index).symm)
+          exact hcop.dvd_of_dvd_mul_right ((Subgroup.index_dvd_card _).trans hdvd)
+        obtain ⟨k, -, hk⟩ :=
+          (Nat.dvd_prime_pow hp).1 ((Subgroup.index_dvd_of_le hle).trans hQidx)
+        have hclass : Nat.card (ConjClasses.mk g).carrier = p ^ k := by
+          rw [ConjClasses.card_carrier_mk, hk]
+        rcases Nat.eq_zero_or_pos k with rfl | hkpos
+        · -- the class is a point, so `g` is central and simplicity makes `G` abelian
+          have htop : Subgroup.centralizer {g} = ⊤ := Subgroup.index_eq_one.1 (by
+            rw [← ConjClasses.card_carrier_mk, hclass, pow_zero])
+          have hgc : g ∈ Subgroup.center G :=
+            Subgroup.centralizer_eq_top_iff_subset.1 htop (Set.mem_singleton g)
+          have hcenter : Subgroup.center G = ⊤ := by
+            rcases hsimple.eq_bot_or_eq_top_of_normal (Subgroup.center G) inferInstance with h | h
+            · exact absurd (by rw [h] at hgc; simpa using hgc) hgne
+            · exact h
+          exact Group.isSolvable_of_comm fun x y => by
+            have hy : y ∈ Subgroup.center G := by rw [hcenter]; exact Subgroup.mem_top y
+            exact Subgroup.mem_center_iff.1 hy x
+        · exact absurd hsimple
+            (not_isSimpleGroup_of_card_carrier_eq_prime_pow hp hkpos.ne' hclass)
+      · -- no `q`-torsion: the group is a `p`-group, hence nilpotent
+        have hcop : (Nat.card G).Coprime (q ^ b) :=
+          Nat.Coprime.pow_right b ((hq.coprime_iff_not_dvd.2 hqdvd).symm)
+        have hpg := IsPGroup.of_card_dvd_pow (p := p) (hcop.dvd_of_dvd_mul_right hdvd)
+        have := hpg.isNilpotent
+        exact inferInstance
+
+/-- **Burnside's `pᵃqᵇ` theorem**, in the form the induction runs in: a finite group whose order
+divides a product of two prime powers is solvable. -/
+theorem isSolvable_of_card_dvd_prime_pow_mul_prime_pow {G : Type u} [Group G] [Finite G] {p q : ℕ}
+    (hp : p.Prime) (hq : q.Prime) {a b : ℕ} (h : Nat.card G ∣ p ^ a * q ^ b) : Group.IsSolvable G :=
+  isSolvable_aux hp hq a b (Nat.card G) G rfl h
+
+/-- **Burnside's `pᵃqᵇ` theorem**: a finite group of order `pᵃqᵇ`, for primes `p` and `q`, is
+solvable. -/
+theorem isSolvable_of_card_eq_prime_pow_mul_prime_pow {G : Type u} [Group G] [Finite G] {p q : ℕ}
+    (hp : p.Prime) (hq : q.Prime) {a b : ℕ} (h : Nat.card G = p ^ a * q ^ b) : Group.IsSolvable G :=
+  isSolvable_of_card_dvd_prime_pow_mul_prime_pow hp hq (by rw [h])
+
+end Burnside
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Solvable.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Solvable.lean
@@ -31,7 +31,7 @@ an algebraic integer, making `-1/p` an algebraic integer; it is rational and not
 irreducible character `χ ≠ 1` has `χ(g) ≠ 0` and degree prime to `p`.
 
 Its degree is then coprime to the class size, so Burnside's vanishing theorem
-(`TauCeti.Representation.char_eq_zero_or_norm_char_eq_finrank`) applies and gives `‖χ(g)‖ = χ(1)`.
+(`Representation.char_eq_zero_or_norm_char_eq_finrank`) applies and gives `‖χ(g)‖ = χ(1)`.
 That is the equality case of the bound on a character value, so the affording representation sends
 `g` to a scalar (`Representation.exists_apply_eq_smul_of_norm_char_eq_finrank`). Its kernel
 is normal, hence trivial or everything: if it is everything the character is constant and row

--- a/TauCeti/RepresentationTheory/CharacterTable/Solvable.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Solvable.lean
@@ -33,7 +33,7 @@ irreducible character `χ ≠ 1` has `χ(g) ≠ 0` and degree prime to `p`.
 Its degree is then coprime to the class size, so Burnside's vanishing theorem
 (`TauCeti.Representation.char_eq_zero_or_norm_char_eq_finrank`) applies and gives `‖χ(g)‖ = χ(1)`.
 That is the equality case of the bound on a character value, so the affording representation sends
-`g` to a scalar (`TauCeti.Representation.exists_apply_eq_smul_of_norm_char_eq_finrank`). Its kernel
+`g` to a scalar (`Representation.exists_apply_eq_smul_of_norm_char_eq_finrank`). Its kernel
 is normal, hence trivial or everything: if it is everything the character is constant and row
 orthogonality against the trivial character makes its degree `0`, which is absurd; and if it is
 trivial the representation is faithful, so `g` commutes with everything and its class is a single

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -208,7 +208,7 @@ theorem _root_.Representation.exists_apply_eq_smul_of_norm_char_eq_finrank
     (ρ : Representation ℂ G V) {g : G} {n : ℕ}
     (hn : n ≠ 0) (hg : g ^ n = 1) (h : ‖ρ.character g‖ = (finrank ℂ V : ℝ)) :
     ∃ μ : ℂ, μ ^ n = 1 ∧ ρ g = μ • 1 :=
-  End.exists_eq_smul_of_norm_trace_eq_finrank hn (by rw [← map_pow, hg, map_one]) h
+  Module.End.exists_eq_smul_of_norm_trace_eq_finrank hn (by rw [← map_pow, hg, map_one]) h
 
 end Complex
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -56,6 +56,8 @@ representation of a group, from the eigenvalues alone, with no invariant inner p
 * `TauCeti.FDRep.char_mem_adjoin_of_isPrimitiveRoot`: over `ℂ` they lie in `ℤ[ζ_e]`, for `ζ_e`
   a primitive root of unity of order the exponent of the group.
 * `TauCeti.FDRep.norm_char_le_finrank`: over `ℂ`, `‖χ(g)‖ ≤ χ(1)`.
+* `TauCeti.Representation.exists_apply_eq_smul_of_norm_char_eq_finrank`: the equality case of that
+  bound, `‖χ(g)‖ = χ(1)`, which forces `ρ g` to be a root of unity times the identity.
 * `TauCeti.FDRep.conj_char`: over `ℂ`, **inversion conjugates character values**,
   `conj (χ g) = χ g⁻¹`. This is what makes the character pairing agree with the Hermitian inner
   product on complex class functions.
@@ -195,6 +197,16 @@ theorem norm_char_le_finrank (ρ : Representation ℂ G V) {g : G} {n : ℕ} (hn
   calc ‖ρ.character g‖ = ‖s.sum‖ := by rw [hsum]
     _ ≤ (s.map (fun μ => ‖μ‖)).sum := norm_multiset_sum_le s
     _ = finrank ℂ V := by rw [hmap]; simp [hcard]
+
+/-- **The equality case of the bound on a character value.** If the absolute value of
+`ρ.character g` attains the degree `finrank ℂ V`, then `ρ g` is a scalar, the scalar being an
+`n`-th root of unity: the character value is a sum of `finrank ℂ V` many roots of unity, so it can
+have that absolute value only if they all coincide, and then `ρ g` is diagonalizable with a single
+eigenvalue. The bound itself is `TauCeti.Representation.norm_char_le_finrank`. -/
+theorem exists_apply_eq_smul_of_norm_char_eq_finrank (ρ : Representation ℂ G V) {g : G} {n : ℕ}
+    (hn : n ≠ 0) (hg : g ^ n = 1) (h : ‖ρ.character g‖ = (finrank ℂ V : ℝ)) :
+    ∃ μ : ℂ, μ ^ n = 1 ∧ ρ g = μ • 1 :=
+  End.exists_eq_smul_of_norm_trace_eq_finrank hn (by rw [← map_pow, hg, map_one]) h
 
 end Complex
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -56,8 +56,9 @@ representation of a group, from the eigenvalues alone, with no invariant inner p
 * `TauCeti.FDRep.char_mem_adjoin_of_isPrimitiveRoot`: over `ℂ` they lie in `ℤ[ζ_e]`, for `ζ_e`
   a primitive root of unity of order the exponent of the group.
 * `TauCeti.FDRep.norm_char_le_finrank`: over `ℂ`, `‖χ(g)‖ ≤ χ(1)`.
-* `Representation.exists_apply_eq_smul_of_norm_char_eq_finrank`: the equality case of that
-  bound, `‖χ(g)‖ = χ(1)`, which forces `ρ g` to be a root of unity times the identity.
+* `Representation.exists_apply_eq_smul_of_norm_char_eq_finrank` and its bundled form
+  `FDRep.exists_apply_eq_smul_of_norm_char_eq_finrank`: the equality case of that bound,
+  `‖χ(g)‖ = χ(1)`, which forces `ρ g` to be a root of unity times the identity.
 * `TauCeti.FDRep.conj_char`: over `ℂ`, **inversion conjugates character values**,
   `conj (χ g) = χ g⁻¹`. This is what makes the character pairing agree with the Hermitian inner
   product on complex class functions.
@@ -318,6 +319,15 @@ theorem char_mem_adjoin_of_isPrimitiveRoot (V : FDRep ℂ G) {ζ : ℂ}
 theorem norm_char_le_finrank (V : FDRep ℂ G) (g : G) : ‖V.character g‖ ≤ finrank ℂ V :=
   Representation.norm_char_le_finrank V.ρ (isOfFinOrder_of_finite g).orderOf_pos.ne'
     (pow_orderOf_eq_one g)
+
+/-- **The equality case of the bound on a character value**, for a finite group: if `‖χ(g)‖`
+attains the degree, then `V.ρ g` is a scalar, the scalar being a root of unity of order dividing
+that of `g`. The bound itself is `TauCeti.FDRep.norm_char_le_finrank`. -/
+theorem _root_.FDRep.exists_apply_eq_smul_of_norm_char_eq_finrank (V : FDRep ℂ G) {g : G}
+    (h : ‖V.character g‖ = (finrank ℂ V : ℝ)) :
+    ∃ μ : ℂ, μ ^ orderOf g = 1 ∧ V.ρ g = μ • 1 :=
+  Representation.exists_apply_eq_smul_of_norm_char_eq_finrank V.ρ
+    (isOfFinOrder_of_finite g).orderOf_pos.ne' (pow_orderOf_eq_one g) h
 
 /-- **Over `ℂ`, inversion conjugates the character values of a finite group**, so that a complex
 character is a "unitary" class function: `conj (χ g) = χ g⁻¹`. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/Values.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Values.lean
@@ -56,7 +56,7 @@ representation of a group, from the eigenvalues alone, with no invariant inner p
 * `TauCeti.FDRep.char_mem_adjoin_of_isPrimitiveRoot`: over `ℂ` they lie in `ℤ[ζ_e]`, for `ζ_e`
   a primitive root of unity of order the exponent of the group.
 * `TauCeti.FDRep.norm_char_le_finrank`: over `ℂ`, `‖χ(g)‖ ≤ χ(1)`.
-* `TauCeti.Representation.exists_apply_eq_smul_of_norm_char_eq_finrank`: the equality case of that
+* `Representation.exists_apply_eq_smul_of_norm_char_eq_finrank`: the equality case of that
   bound, `‖χ(g)‖ = χ(1)`, which forces `ρ g` to be a root of unity times the identity.
 * `TauCeti.FDRep.conj_char`: over `ℂ`, **inversion conjugates character values**,
   `conj (χ g) = χ g⁻¹`. This is what makes the character pairing agree with the Hermitian inner
@@ -203,7 +203,8 @@ theorem norm_char_le_finrank (ρ : Representation ℂ G V) {g : G} {n : ℕ} (hn
 `n`-th root of unity: the character value is a sum of `finrank ℂ V` many roots of unity, so it can
 have that absolute value only if they all coincide, and then `ρ g` is diagonalizable with a single
 eigenvalue. The bound itself is `TauCeti.Representation.norm_char_le_finrank`. -/
-theorem exists_apply_eq_smul_of_norm_char_eq_finrank (ρ : Representation ℂ G V) {g : G} {n : ℕ}
+theorem _root_.Representation.exists_apply_eq_smul_of_norm_char_eq_finrank
+    (ρ : Representation ℂ G V) {g : G} {n : ℕ}
     (hn : n ≠ 0) (hg : g ^ n = 1) (h : ‖ρ.character g‖ = (finrank ℂ V : ℝ)) :
     ∃ μ : ℂ, μ ^ n = 1 ∧ ρ g = μ • 1 :=
   End.exists_eq_smul_of_norm_trace_eq_finrank hn (by rw [← map_pow, hg, map_one]) h

--- a/TauCeti/RingTheory/IntegralClosure/Rat.lean
+++ b/TauCeti/RingTheory/IntegralClosure/Rat.lean
@@ -21,12 +21,6 @@ integrality descending along `algebraMap ℚ k`.
 
 * `TauCeti.dvd_of_isIntegral_of_natCast_mul_eq`: if `(n : k) * z = m` with `z` integral over `ℤ`
   in a field of characteristic zero and `n ≠ 0`, then `n ∣ m`.
-
-## Provenance
-
-Extracted from `TauCeti/RepresentationTheory/CharacterTable/Degree.lean`, where it was a private
-step of the proof that the degree of an irreducible character divides the group order. Burnside's
-`pᵃqᵇ` theorem is the second consumer, using it to rule out `-1/p` being an algebraic integer.
 -/
 
 public section

--- a/TauCeti/RingTheory/IntegralClosure/Rat.lean
+++ b/TauCeti/RingTheory/IntegralClosure/Rat.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Algebra.Rat
+public import Mathlib.Algebra.GCDMonoid.IntegrallyClosed
+
+/-!
+# Rational algebraic integers
+
+`ℤ` is integrally closed in `ℚ`, so an algebraic integer that happens to be rational is an
+integer. This file records the numerical reading of that fact: an identity `n · z = m` between an
+algebraic integer `z` and two natural numbers is a divisibility `n ∣ m`. It holds over an
+arbitrary field of characteristic zero, `z = m / n` being the image of a rational number there and
+integrality descending along `algebraMap ℚ k`.
+
+## Main results
+
+* `TauCeti.dvd_of_isIntegral_of_natCast_mul_eq`: if `(n : k) * z = m` with `z` integral over `ℤ`
+  in a field of characteristic zero and `n ≠ 0`, then `n ∣ m`.
+
+## Provenance
+
+Extracted from `TauCeti/RepresentationTheory/CharacterTable/Degree.lean`, where it was a private
+step of the proof that the degree of an irreducible character divides the group order. Burnside's
+`pᵃqᵇ` theorem is the second consumer, using it to rule out `-1/p` being an algebraic integer.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- **A rational algebraic integer is an integer**, read as a divisibility: if `n · z = m` for
+natural numbers `m` and `n` with `n ≠ 0`, and `z` is integral over `ℤ` in a field of characteristic
+zero, then `n` divides `m`. -/
+theorem dvd_of_isIntegral_of_natCast_mul_eq {k : Type*} [Field k] [CharZero k] {m n : ℕ}
+    {z : k} (hz : IsIntegral ℤ z) (h : (n : k) * z = m) (hn : n ≠ 0) : n ∣ m := by
+  have hnk : (n : k) ≠ 0 := Nat.cast_ne_zero.mpr hn
+  have hz' : algebraMap ℚ k ((m : ℚ) / (n : ℚ)) = z := by
+    rw [map_div₀, map_natCast, map_natCast, eq_comm, eq_div_iff hnk, mul_comm]
+    exact h
+  have hq : IsIntegral ℤ ((m : ℚ) / (n : ℚ)) :=
+    isIntegral_algebraMap_iff.mp (hz' ▸ hz)
+  obtain ⟨y, hy⟩ := IsIntegrallyClosed.algebraMap_eq_of_integral hq
+  have hyq : (y : ℚ) * (n : ℚ) = (m : ℚ) := by
+    rw [← eq_intCast (algebraMap ℤ ℚ) y, hy, div_mul_cancel₀]
+    exact Nat.cast_ne_zero.mpr hn
+  refine Int.natCast_dvd_natCast.mp ⟨y, ?_⟩
+  exact_mod_cast (by linarith : (m : ℚ) = (n : ℚ) * (y : ℚ))
+
+end TauCeti


### PR DESCRIPTION
This PR proves **Burnside's `pᵃqᵇ` theorem**: a finite group of order `p ^ a * q ^ b`, for primes `p` and `q`, is solvable. The proof is the classical character-theoretic one, and its substance is the intermediate statement that a conjugacy class of prime-power size larger than one forces a proper nontrivial normal subgroup, which is where the character theory is spent; the passage from there to solvability is a Sylow argument and an induction on the order.

The milestone is the Layer 4 target of `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`, "Application, off the critical path - Brauer and Burnside", whose second half reads "**Burnside's `pᵃqᵇ` theorem**: a group of order `pᵃqᵇ` is solvable, via central-character integrality and the vanishing theorem", with the signature `isSolvable_of_card_eq_prime_pow_mul_prime_pow` pinned in that roadmap's `Suggested.lean`. Its stated prerequisites are already on `main`: central-character integrality (`Representation.isIntegral_centralCharacter_classSumCenter`), the character table with both orthogonality relations, and Burnside's vanishing theorem `Representation.char_eq_zero_or_norm_char_eq_finrank`, which until now had no consumer in the repository. What remains of that roadmap bullet after this PR is its other half, the cyclotomic splitting-field statement of Brauer.

Four pieces are added, each in the file its statement belongs to.

`TauCeti/RingTheory/IntegralClosure/Rat.lean` is new and carries `dvd_of_isIntegral_of_natCast_mul_eq`, the numerical reading of "a rational algebraic integer is an integer": an identity `n · z = m` between an algebraic integer of a field of characteristic zero and two natural numbers is the divisibility `n ∣ m`. It was a private step of `TauCeti/RepresentationTheory/CharacterTable/Degree.lean`, which now imports it; Burnside's argument is the second consumer, using it to rule out `-1/p` being an algebraic integer.

`TauCeti/LinearAlgebra/End/FiniteOrder.lean` gains `End.exists_eq_smul_of_norm_trace_eq_finrank`: over `ℂ`, an endomorphism of finite order whose trace has absolute value the dimension is a root of unity times the identity. The eigenvalues are roots of unity summing, with multiplicity, to the trace, so the absolute value `finrank ℂ V` is attained only when they all share one phase, and a diagonalizable endomorphism with a single eigenvalue is a scalar. The existing `End.eq_one_of_trace_eq_finrank` is exactly the case where the trace attains that bound at the positive real value `finrank ℂ V`, so it is re-derived from the new statement rather than kept as a parallel eigenvalue argument.

`TauCeti/RepresentationTheory/CharacterTable/Values.lean` gains `Representation.exists_apply_eq_smul_of_norm_char_eq_finrank`, the equality case of the bound `norm_char_le_finrank` proved a few lines above it: when `‖χ(g)‖` attains the degree, `ρ g` is a scalar.

`TauCeti/RepresentationTheory/CharacterTable/Solvable.lean` is new and carries the theorem. Column orthogonality at the classes of `g` and of `1` gives `∑_χ χ(1) χ(g) = 0`, in which the trivial character contributes `1`; if every other irreducible character either vanished at `g` or had degree divisible by `p`, that identity would exhibit `-1/p` as an algebraic integer. So some nontrivial irreducible character has `χ(g) ≠ 0` and degree prime to `p`, hence coprime to the class size, and the vanishing theorem forces `‖χ(g)‖ = χ(1)`. The affording representation therefore sends `g` to a scalar; its kernel is normal, so under simplicity it is trivial or everything, and either alternative fails — a faithful representation makes `g` central, contradicting a class of size larger than one, while a trivial one makes the character constant, and row orthogonality against the trivial character then makes its degree zero. The induction is on the order: a group with a proper nontrivial normal subgroup is solvable as soon as that subgroup and the quotient are; a simple group with no `q`-torsion is a `p`-group, hence nilpotent; and otherwise the centre of a Sylow `q`-subgroup supplies a nontrivial element whose centralizer contains that subgroup, so its class has size a power of `p`, which is either one, making the group abelian by simplicity, or larger, contradicting the class-size step.

Roadmap: CharacterTheory

<!--tauceti-target:v1 {"focus":"CharacterTheory","id":"issolvable-of-card-eq-prime-pow-mul-prime-pow"}-->

🤖 Prepared with Claude Code

