### PR TITLE
feat(Huber): an open surjection stays surjective on restricted series

### DIFF
--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
@@ -91,7 +91,8 @@ counterexample in `IsWeightFamily`'s docstring shows the hypothesis is not autom
   stated for an arbitrary `T : Fin 0 → Set A` and take no weight-family hypothesis:
   `TauCeti.Huber.isWeightFamily_fin_zero` supplies it, the condition being a statement about each
   index and there being none.
-* `TauCeti.Huber.IsWeightedRestricted.map`, with `weightMul_map_le` and `image_weightPow`:
+* `TauCeti.Huber.IsWeightedRestricted.map`, with `weightMul_map_le`, `image_weightPow` and
+  `image_one_weight`:
   restrictedness is preserved by a continuous ring map carrying each `T i` into `S i`. This is
   what `weightedMap` is built from; `weightedMap_weightedX` says it fixes the variables, while
   `weightedMap_weightedC` says it acts as `φ` on constants — the constants are moved, not fixed.
@@ -1257,6 +1258,12 @@ omit [TopologicalSpace A] [TopologicalSpace B] in
 theorem image_weightPow (φ : A →+* B) (T : Fin k → Set A) (ν : Fin k →₀ ℕ) :
     φ '' weightPow T ν = weightPow (fun i ↦ φ '' T i) ν := by
   simp only [weightPow_def, Set.image_finsetProd, Set.image_pow]
+
+omit [TopologicalSpace A] [TopologicalSpace B] in
+/-- A ring map carries the trivial weight `{1}` to itself, hence carries the trivial weight
+*family* to itself. -/
+theorem image_one_weight (φ : A →+* B) : φ '' ({1} : Set A) = ({1} : Set B) := by
+  rw [Set.image_singleton, map_one]
 
 omit [TopologicalSpace A] [TopologicalSpace B] in
 /-- **`weightMul` is functorial**: a ring map carrying each `T i` into `S i` and `U` into `V`

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
@@ -91,8 +91,7 @@ counterexample in `IsWeightFamily`'s docstring shows the hypothesis is not autom
   stated for an arbitrary `T : Fin 0 → Set A` and take no weight-family hypothesis:
   `TauCeti.Huber.isWeightFamily_fin_zero` supplies it, the condition being a statement about each
   index and there being none.
-* `TauCeti.Huber.IsWeightedRestricted.map`, with `weightMul_map_le`, `image_weightPow` and
-  `image_one_weight`:
+* `TauCeti.Huber.IsWeightedRestricted.map`, with `weightMul_map_le` and `image_weightPow`:
   restrictedness is preserved by a continuous ring map carrying each `T i` into `S i`. This is
   what `weightedMap` is built from; `weightedMap_weightedX` says it fixes the variables, while
   `weightedMap_weightedC` says it acts as `φ` on constants — the constants are moved, not fixed.
@@ -1258,12 +1257,6 @@ omit [TopologicalSpace A] [TopologicalSpace B] in
 theorem image_weightPow (φ : A →+* B) (T : Fin k → Set A) (ν : Fin k →₀ ℕ) :
     φ '' weightPow T ν = weightPow (fun i ↦ φ '' T i) ν := by
   simp only [weightPow_def, Set.image_finsetProd, Set.image_pow]
-
-omit [TopologicalSpace A] [TopologicalSpace B] in
-/-- A ring map carries the trivial weight `{1}` to itself, hence carries the trivial weight
-*family* to itself. -/
-theorem image_one_weight (φ : A →+* B) : φ '' ({1} : Set A) = ({1} : Set B) := by
-  rw [Set.image_singleton, map_one]
 
 omit [TopologicalSpace A] [TopologicalSpace B] in
 /-- **`weightMul` is functorial**: a ring map carrying each `T i` into `S i` and `U` into `V`

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -21,7 +21,7 @@ choice is made, and this file is its transcription into the weighted language, a
 weight family where restrictedness *is* convergence to zero
 (`TauCeti.Huber.isWeightedRestricted_one_weight_iff`).
 
-**Countable generation of `𝓝 (0 : A)` is a hypothesis of every result here**, not a background
+**Countable generation of `𝓝 (0 : A)` is a hypothesis of both results here**, not a background
 assumption: it is what supplies the shrinking family the lifted coefficients are drawn from, and a
 general `NonarchimedeanRing` need not have it. It is not restrictive in the intended application —
 a Huber ring satisfies it, by `TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero`.
@@ -53,16 +53,6 @@ namespace TauCeti.Huber
 
 variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
   [CommRing B] [TopologicalSpace B] [NonarchimedeanRing B]
-
-omit [TopologicalSpace A] [NonarchimedeanRing A] [TopologicalSpace B] [NonarchimedeanRing B] in
-/-- A ring homomorphism carries the trivial weight `{1}` to itself, so it carries the trivial
-weight *family* to itself.
-
-Named rather than discharged inline because it appears in the *statement* of every result below,
-where a tactic block would bake its elaborated proof term into the type. -/
-theorem image_one_weight (φ : A →+* B) :
-    φ '' ({1} : Set A) = ({1} : Set B) := by
-  rw [Set.image_singleton, map_one]
 
 /-- **A continuous surjection carrying neighbourhoods of zero onto neighbourhoods of zero stays
 surjective on restricted series**, provided `𝓝 (0 : A)` is countably generated. Every element of

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -73,7 +73,7 @@ theorem weightedMap_one_weight_surjective [(𝓝 (0 : A)).IsCountablyGenerated] 
     (hφ : Continuous φ) (hsurj : Function.Surjective φ)
     (hnhds : 𝓝 (0 : B) ≤ Filter.map φ (𝓝 (0 : A))) :
     Function.Surjective (weightedMap (k := k) hφ isWeightFamily_one_weight
-      isWeightFamily_one_weight fun _ ↦ (image_one_weight φ).le) := by
+      isWeightFamily_one_weight fun _ ↦ by simp) := by
   intro g
   obtain ⟨f, hf⟩ := restrictedMvPowerSeriesSubmoduleMap_surjective (k := k)
     φ.toAddMonoidHom.toIntLinearMap hφ.continuousAt hsurj hnhds
@@ -100,7 +100,7 @@ and it bundles exactly the continuity, surjectivity and openness the filter-leve
 theorem _root_.IsOpenQuotientMap.weightedMap_one_weight_surjective
     [(𝓝 (0 : A)).IsCountablyGenerated] {φ : A →+* B} (hq : IsOpenQuotientMap φ) :
     Function.Surjective (weightedMap (k := k) hq.continuous isWeightFamily_one_weight
-      isWeightFamily_one_weight fun _ ↦ (image_one_weight φ).le) :=
+      isWeightFamily_one_weight fun _ ↦ by simp) :=
   TauCeti.Huber.weightedMap_one_weight_surjective hq.continuous hq.surjective
     (map_zero φ ▸ hq.isOpenMap.nhds_le 0)
 

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -7,9 +7,6 @@ module
 
 public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Basic
 
-import Mathlib.Data.Finsupp.Encodable
-import TauCeti.RingTheory.Huber.Restricted.PowerSeries
-
 /-!
 # `A⟨X₁,…,Xₖ⟩ → B⟨X₁,…,Xₖ⟩` is surjective along an open surjection
 

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -30,7 +30,8 @@ restrictive here: a Huber ring satisfies it, by
 
 ## Main results
 
-* `TauCeti.Huber.surjective_weightedMap_one_weight`.
+* `TauCeti.Huber.weightedMap_one_weight_surjective`, with
+  `TauCeti.Huber.weightedMap_one_weight_surjective_of_isOpenMap` the form taking `IsOpenMap`.
 
 ## References
 
@@ -54,20 +55,24 @@ namespace TauCeti.Huber
 variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
   [CommRing B] [TopologicalSpace B] [NonarchimedeanRing B]
 
-/-- **A continuous open surjection stays surjective on restricted series.** Every element of
-`B⟨X₁,…,Xₖ⟩` is the image of one of `A⟨X₁,…,Xₖ⟩`.
+/-- **A continuous surjection carrying neighbourhoods of zero onto neighbourhoods of zero stays
+surjective on restricted series.** Every element of `B⟨X₁,…,Xₖ⟩` is the image of one of
+`A⟨X₁,…,Xₖ⟩`.
+
+The hypothesis is the filter inequality the proof consumes rather than `IsOpenMap φ`, which is
+strictly stronger; `TauCeti.Huber.weightedMap_one_weight_surjective_of_isOpenMap` is the open-map
+form for a caller who holds one.
 
 This is the step Wedhorn's Proposition & Definition 6.36(ii) needs: a ring topologically of finite
 type over `A` is an open quotient of some `A⟨X₁,…,Xₖ⟩`, and adjoining further variables to that
 quotient has to stay a quotient for noetherianity to descend to it. -/
-theorem surjective_weightedMap_one_weight [(𝓝 (0 : A)).IsCountablyGenerated] {φ : A →+* B}
-    (hφ : Continuous φ) (hsurj : Function.Surjective φ) (hopen : IsOpenMap φ)
-    (hTS : ∀ _ : Fin k, φ '' ({1} : Set A) ⊆ ({1} : Set B)) :
+theorem weightedMap_one_weight_surjective [(𝓝 (0 : A)).IsCountablyGenerated] {φ : A →+* B}
+    (hφ : Continuous φ) (hsurj : Function.Surjective φ)
+    (hnhds : 𝓝 (0 : B) ≤ Filter.map φ (𝓝 (0 : A))) :
     Function.Surjective (weightedMap (k := k) hφ isWeightFamily_one_weight
-      isWeightFamily_one_weight hTS) := by
+      isWeightFamily_one_weight fun _ ↦ by simp) := by
   intro g
-  obtain ⟨c, hcg, hc⟩ := TauCeti.exists_lift_tendsto_cofinite_nhds (φ : A → B) hsurj
-    (map_zero φ ▸ hopen.nhds_le 0)
+  obtain ⟨c, hcg, hc⟩ := TauCeti.exists_lift_tendsto_cofinite_nhds (φ : A → B) hsurj hnhds
     (fun ν ↦ MvPowerSeries.coeff ν (g : MvPowerSeries (Fin k) B))
     (isWeightedRestricted_one_weight_iff.mp (mem_weightedRestrictedSubring.mp g.2))
   obtain ⟨f, hf⟩ : ∃ f : MvPowerSeries (Fin k) A, ∀ ν, MvPowerSeries.coeff ν f = c ν :=
@@ -77,6 +82,14 @@ theorem surjective_weightedMap_one_weight [(𝓝 (0 : A)).IsCountablyGenerated] 
   · simpa only [hf] using hc
   · rw [coe_weightedMap, MvPowerSeries.coeff_map, hf]
     exact hcg ν
+
+/-- **The open-map form of `TauCeti.Huber.weightedMap_one_weight_surjective`**, for a caller
+holding `IsOpenMap φ` rather than the neighbourhood inequality. -/
+theorem weightedMap_one_weight_surjective_of_isOpenMap [(𝓝 (0 : A)).IsCountablyGenerated]
+    {φ : A →+* B} (hφ : Continuous φ) (hsurj : Function.Surjective φ) (hopen : IsOpenMap φ) :
+    Function.Surjective (weightedMap (k := k) hφ isWeightFamily_one_weight
+      isWeightFamily_one_weight fun _ ↦ by simp) :=
+  weightedMap_one_weight_surjective hφ hsurj (map_zero φ ▸ hopen.nhds_le 0)
 
 end TauCeti.Huber
 

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -10,8 +10,8 @@ public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Basic
 /-!
 # `A⟨X₁,…,Xₖ⟩ → B⟨X₁,…,Xₖ⟩` is surjective along an open surjection
 
-A continuous **open** surjection `φ : A → B` of nonarchimedean rings induces a surjection
-`A⟨X₁,…,Xₖ⟩ → B⟨X₁,…,Xₖ⟩` of restricted power-series rings.
+A continuous **open** surjection `φ : A → B` of nonarchimedean rings whose source has countably
+generated `𝓝 0` induces a surjection `A⟨X₁,…,Xₖ⟩ → B⟨X₁,…,Xₖ⟩` of restricted power-series rings.
 
 Openness is the hypothesis that matters. Surjectivity of `φ` alone lifts each coefficient of a
 restricted series separately, but the preimages so chosen need not tend to zero, and then the lift

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -62,8 +62,8 @@ surjective on restricted series**, provided `𝓝 (0 : A)` is countably generate
 `B⟨X₁,…,Xₖ⟩` is then the image of one of `A⟨X₁,…,Xₖ⟩`.
 
 The hypothesis is the filter inequality the proof consumes rather than `IsOpenMap φ`, which is
-strictly stronger; `TauCeti.Huber.weightedMap_one_weight_surjective_of_isOpenMap` is the open-map
-form for a caller who holds one.
+strictly stronger; `TauCeti.Huber.weightedMap_one_weight_surjective_of_isOpenQuotientMap` is the
+form for a caller holding the bundled open-quotient structure.
 
 This is the step Wedhorn's Proposition & Definition 6.36(ii) needs: a ring *strictly*
 topologically of finite type over `A` is an open quotient of some `A⟨X₁,…,Xₖ⟩`

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Basic
 
 import Mathlib.Data.Finsupp.Encodable
-import TauCeti.Topology.LiftTendstoCofinite
+import TauCeti.RingTheory.Huber.Restricted.PowerSeries
 
 /-!
 # `A⟨X₁,…,Xₖ⟩ → B⟨X₁,…,Xₖ⟩` is surjective along an open surjection
@@ -24,14 +24,16 @@ choice is made, and this file is its transcription into the weighted language, a
 weight family where restrictedness *is* convergence to zero
 (`TauCeti.Huber.isWeightedRestricted_one_weight_iff`).
 
-Countable generation of `𝓝 (0 : A)` is what supplies the family to draw from. It is not
-restrictive here: a Huber ring satisfies it, by
-`TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero`.
+**Countable generation of `𝓝 (0 : A)` is a hypothesis of every result here**, not a background
+assumption: it is what supplies the shrinking family the lifted coefficients are drawn from, and a
+general `NonarchimedeanRing` need not have it. It is not restrictive in the intended application —
+a Huber ring satisfies it, by `TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero`.
 
 ## Main results
 
 * `TauCeti.Huber.weightedMap_one_weight_surjective`, with
-  `TauCeti.Huber.weightedMap_one_weight_surjective_of_isOpenMap` the form taking `IsOpenMap`.
+  `TauCeti.Huber.weightedMap_one_weight_surjective_of_isOpenQuotientMap` the form taking the
+  bundled `IsOpenQuotientMap`.
 
 ## References
 
@@ -56,8 +58,8 @@ variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [Nonarchimede
   [CommRing B] [TopologicalSpace B] [NonarchimedeanRing B]
 
 /-- **A continuous surjection carrying neighbourhoods of zero onto neighbourhoods of zero stays
-surjective on restricted series.** Every element of `B⟨X₁,…,Xₖ⟩` is the image of one of
-`A⟨X₁,…,Xₖ⟩`.
+surjective on restricted series**, provided `𝓝 (0 : A)` is countably generated. Every element of
+`B⟨X₁,…,Xₖ⟩` is then the image of one of `A⟨X₁,…,Xₖ⟩`.
 
 The hypothesis is the filter inequality the proof consumes rather than `IsOpenMap φ`, which is
 strictly stronger; `TauCeti.Huber.weightedMap_one_weight_surjective_of_isOpenMap` is the open-map
@@ -76,24 +78,34 @@ theorem weightedMap_one_weight_surjective [(𝓝 (0 : A)).IsCountablyGenerated] 
     Function.Surjective (weightedMap (k := k) hφ isWeightFamily_one_weight
       isWeightFamily_one_weight fun _ ↦ by simp) := by
   intro g
-  obtain ⟨c, hcg, hc⟩ := TauCeti.exists_lift_tendsto_cofinite_nhds (φ : A → B) hsurj hnhds
-    (fun ν ↦ MvPowerSeries.coeff ν (g : MvPowerSeries (Fin k) B))
-    (isWeightedRestricted_one_weight_iff.mp (mem_weightedRestrictedSubring.mp g.2))
-  obtain ⟨f, hf⟩ : ∃ f : MvPowerSeries (Fin k) A, ∀ ν, MvPowerSeries.coeff ν f = c ν :=
-    ⟨c, fun ν ↦ MvPowerSeries.coeff_apply c ν⟩
-  refine ⟨⟨f, mem_weightedRestrictedSubring.mpr (isWeightedRestricted_one_weight_iff.mpr ?_)⟩,
+  obtain ⟨f, hf⟩ := restrictedMvPowerSeriesSubmoduleMap_surjective (k := k)
+    φ.toAddMonoidHom.toIntLinearMap hφ.continuousAt hsurj hnhds
+    ⟨(g : MvPowerSeries (Fin k) B), mem_restrictedMvPowerSeriesSubmodule.mpr
+      (isRestricted_iff_coeff.mpr
+        (isWeightedRestricted_one_weight_iff.mp (mem_weightedRestrictedSubring.mp g.2)))⟩
+  refine ⟨⟨(f : MvPowerSeries (Fin k) A),
+      mem_weightedRestrictedSubring.mpr (isWeightedRestricted_one_weight_iff.mpr
+        (isRestricted_iff_coeff.mp (mem_restrictedMvPowerSeriesSubmodule.mp f.2)))⟩,
     Subtype.ext (MvPowerSeries.ext fun ν ↦ ?_)⟩
-  · simpa only [hf] using hc
-  · rw [coe_weightedMap, MvPowerSeries.coeff_map, hf]
-    exact hcg ν
+  have h := congrArg (fun x : restrictedMvPowerSeriesSubmodule k ℤ B ↦
+    ((x : MvPowerSeries (Fin k) B) : (Fin k →₀ ℕ) → B) ν) hf
+  have key := coeff_restrictedMvPowerSeriesSubmoduleMap φ.toAddMonoidHom.toIntLinearMap
+    hφ.continuousAt f ν
+  rw [coe_weightedMap, MvPowerSeries.coeff_map]
+  exact key.symm.trans h
 
-/-- **The open-map form of `TauCeti.Huber.weightedMap_one_weight_surjective`**, for a caller
-holding `IsOpenMap φ` rather than the neighbourhood inequality. -/
-theorem weightedMap_one_weight_surjective_of_isOpenMap [(𝓝 (0 : A)).IsCountablyGenerated]
-    {φ : A →+* B} (hφ : Continuous φ) (hsurj : Function.Surjective φ) (hopen : IsOpenMap φ) :
-    Function.Surjective (weightedMap (k := k) hφ isWeightFamily_one_weight
+/-- **The open-quotient form of `TauCeti.Huber.weightedMap_one_weight_surjective`**, for a caller
+holding the bundled `IsOpenQuotientMap φ`.
+
+That is the interface finite-type presentations come in — `TauCeti.Huber`
+`.IsStrictlyTopologicallyFiniteType` produces one — so it is the form a consumer actually has,
+and it bundles exactly the continuity, surjectivity and openness the filter-level theorem needs. -/
+theorem weightedMap_one_weight_surjective_of_isOpenQuotientMap
+    [(𝓝 (0 : A)).IsCountablyGenerated] {φ : A →+* B} (hq : IsOpenQuotientMap φ) :
+    Function.Surjective (weightedMap (k := k) hq.continuous isWeightFamily_one_weight
       isWeightFamily_one_weight fun _ ↦ by simp) :=
-  weightedMap_one_weight_surjective hφ hsurj (map_zero φ ▸ hopen.nhds_le 0)
+  weightedMap_one_weight_surjective hq.continuous hq.surjective
+    (map_zero φ ▸ hq.isOpenMap.nhds_le 0)
 
 end TauCeti.Huber
 

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Basic
+
+import Mathlib.Data.Finsupp.Encodable
+import TauCeti.Topology.LiftTendstoCofinite
+
+/-!
+# `A⟨X₁,…,Xₖ⟩ → B⟨X₁,…,Xₖ⟩` is surjective along an open surjection
+
+A continuous **open** surjection `φ : A → B` of nonarchimedean rings induces a surjection
+`A⟨X₁,…,Xₖ⟩ → B⟨X₁,…,Xₖ⟩` of restricted power-series rings.
+
+Openness is the hypothesis that matters. Surjectivity of `φ` alone lifts each coefficient of a
+restricted series separately, but the preimages so chosen need not tend to zero, and then the lift
+is a power series and not a restricted one. Openness is what lets the preimages be drawn from a
+shrinking family of neighbourhoods; `TauCeti.exists_lift_tendsto_cofinite_nhds` is where that
+choice is made, and this file is its transcription into the weighted language, at the trivial
+weight family where restrictedness *is* convergence to zero
+(`TauCeti.Huber.isWeightedRestricted_one_weight_iff`).
+
+Countable generation of `𝓝 (0 : A)` is what supplies the family to draw from. It is not
+restrictive here: a Huber ring satisfies it, by
+`TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero`.
+
+## Main results
+
+* `TauCeti.Huber.surjective_weightedMap_one_weight`.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), §5.6 and
+  Proposition & Definition 6.36.
+
+AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at commit
+`37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c`,
+`projects/AdicSpaces/Adic spaces/RestrictedModule.lean`, has the corresponding statement for
+modules in one variable, `restrictedModule_map_surjective`, with both sides assumed Hausdorff.
+Nothing was copied.
+-/
+
+public section
+
+open Filter
+open scoped Topology
+
+namespace TauCeti.Huber
+
+variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+  [CommRing B] [TopologicalSpace B] [NonarchimedeanRing B]
+
+/-- **A continuous open surjection stays surjective on restricted series.** Every element of
+`B⟨X₁,…,Xₖ⟩` is the image of one of `A⟨X₁,…,Xₖ⟩`.
+
+This is the step Wedhorn's Proposition & Definition 6.36(ii) needs: a ring topologically of finite
+type over `A` is an open quotient of some `A⟨X₁,…,Xₖ⟩`, and adjoining further variables to that
+quotient has to stay a quotient for noetherianity to descend to it. -/
+theorem surjective_weightedMap_one_weight [(𝓝 (0 : A)).IsCountablyGenerated] {φ : A →+* B}
+    (hφ : Continuous φ) (hsurj : Function.Surjective φ) (hopen : IsOpenMap φ)
+    (hTS : ∀ _ : Fin k, φ '' ({1} : Set A) ⊆ ({1} : Set B)) :
+    Function.Surjective (weightedMap (k := k) hφ isWeightFamily_one_weight
+      isWeightFamily_one_weight hTS) := by
+  intro g
+  obtain ⟨c, hcg, hc⟩ := TauCeti.exists_lift_tendsto_cofinite_nhds (φ : A → B) hsurj
+    (map_zero φ ▸ hopen.nhds_le 0)
+    (fun ν ↦ MvPowerSeries.coeff ν (g : MvPowerSeries (Fin k) B))
+    (isWeightedRestricted_one_weight_iff.mp (mem_weightedRestrictedSubring.mp g.2))
+  obtain ⟨f, hf⟩ : ∃ f : MvPowerSeries (Fin k) A, ∀ ν, MvPowerSeries.coeff ν f = c ν :=
+    ⟨c, fun ν ↦ MvPowerSeries.coeff_apply c ν⟩
+  refine ⟨⟨f, mem_weightedRestrictedSubring.mpr (isWeightedRestricted_one_weight_iff.mpr ?_)⟩,
+    Subtype.ext (MvPowerSeries.ext fun ν ↦ ?_)⟩
+  · simpa only [hf] using hc
+  · rw [coe_weightedMap, MvPowerSeries.coeff_map, hf]
+    exact hcg ν
+
+end TauCeti.Huber
+
+end

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -63,9 +63,13 @@ The hypothesis is the filter inequality the proof consumes rather than `IsOpenMa
 strictly stronger; `TauCeti.Huber.weightedMap_one_weight_surjective_of_isOpenMap` is the open-map
 form for a caller who holds one.
 
-This is the step Wedhorn's Proposition & Definition 6.36(ii) needs: a ring topologically of finite
-type over `A` is an open quotient of some `A⟨X₁,…,Xₖ⟩`, and adjoining further variables to that
-quotient has to stay a quotient for noetherianity to descend to it. -/
+This is the step Wedhorn's Proposition & Definition 6.36(ii) needs: a ring *strictly*
+topologically of finite type over `A` is an open quotient of some `A⟨X₁,…,Xₖ⟩`
+(`TauCeti.Huber.IsStrictlyTopologicallyFiniteType`), and adjoining further variables to that
+quotient has to stay a quotient for noetherianity to descend to it.
+`TauCeti.Huber.IsTopologicallyFiniteType` is the weaker notion, taking a quotient of the
+completion of a weighted `A⟨X⟩_T` for an arbitrary finite weight family; it is not what this
+serves. -/
 theorem weightedMap_one_weight_surjective [(𝓝 (0 : A)).IsCountablyGenerated] {φ : A →+* B}
     (hφ : Continuous φ) (hsurj : Function.Surjective φ)
     (hnhds : 𝓝 (0 : B) ≤ Filter.map φ (𝓝 (0 : A))) :

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -54,6 +54,16 @@ namespace TauCeti.Huber
 variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
   [CommRing B] [TopologicalSpace B] [NonarchimedeanRing B]
 
+omit [TopologicalSpace A] [NonarchimedeanRing A] [TopologicalSpace B] [NonarchimedeanRing B] in
+/-- A ring homomorphism carries the trivial weight `{1}` to itself, so it carries the trivial
+weight *family* to itself.
+
+Named rather than discharged inline because it appears in the *statement* of every result below,
+where a tactic block would bake its elaborated proof term into the type. -/
+theorem image_one_weight (φ : A →+* B) :
+    φ '' ({1} : Set A) = ({1} : Set B) := by
+  rw [Set.image_singleton, map_one]
+
 /-- **A continuous surjection carrying neighbourhoods of zero onto neighbourhoods of zero stays
 surjective on restricted series**, provided `𝓝 (0 : A)` is countably generated. Every element of
 `B⟨X₁,…,Xₖ⟩` is then the image of one of `A⟨X₁,…,Xₖ⟩`.
@@ -73,7 +83,7 @@ theorem weightedMap_one_weight_surjective [(𝓝 (0 : A)).IsCountablyGenerated] 
     (hφ : Continuous φ) (hsurj : Function.Surjective φ)
     (hnhds : 𝓝 (0 : B) ≤ Filter.map φ (𝓝 (0 : A))) :
     Function.Surjective (weightedMap (k := k) hφ isWeightFamily_one_weight
-      isWeightFamily_one_weight fun _ ↦ by simp) := by
+      isWeightFamily_one_weight fun _ ↦ (image_one_weight φ).le) := by
   intro g
   obtain ⟨f, hf⟩ := restrictedMvPowerSeriesSubmoduleMap_surjective (k := k)
     φ.toAddMonoidHom.toIntLinearMap hφ.continuousAt hsurj hnhds
@@ -100,7 +110,7 @@ and it bundles exactly the continuity, surjectivity and openness the filter-leve
 theorem _root_.IsOpenQuotientMap.weightedMap_one_weight_surjective
     [(𝓝 (0 : A)).IsCountablyGenerated] {φ : A →+* B} (hq : IsOpenQuotientMap φ) :
     Function.Surjective (weightedMap (k := k) hq.continuous isWeightFamily_one_weight
-      isWeightFamily_one_weight fun _ ↦ by simp) :=
+      isWeightFamily_one_weight fun _ ↦ (image_one_weight φ).le) :=
   TauCeti.Huber.weightedMap_one_weight_surjective hq.continuous hq.surjective
     (map_zero φ ▸ hq.isOpenMap.nhds_le 0)
 

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -29,8 +29,8 @@ a Huber ring satisfies it, by `TauCeti.Huber.IsHuberRing.isCountablyGenerated_nh
 ## Main results
 
 * `TauCeti.Huber.weightedMap_one_weight_surjective`, with
-  `TauCeti.Huber.weightedMap_one_weight_surjective_of_isOpenQuotientMap` the form taking the
-  bundled `IsOpenQuotientMap`.
+  `IsOpenQuotientMap.weightedMap_one_weight_surjective` the form taking the bundled structure —
+  in that namespace so `hq.weightedMap_one_weight_surjective` works.
 
 ## References
 
@@ -59,8 +59,8 @@ surjective on restricted series**, provided `𝓝 (0 : A)` is countably generate
 `B⟨X₁,…,Xₖ⟩` is then the image of one of `A⟨X₁,…,Xₖ⟩`.
 
 The hypothesis is the filter inequality the proof consumes rather than `IsOpenMap φ`, which is
-strictly stronger; `TauCeti.Huber.weightedMap_one_weight_surjective_of_isOpenQuotientMap` is the
-form for a caller holding the bundled open-quotient structure.
+strictly stronger; `IsOpenQuotientMap.weightedMap_one_weight_surjective` is the form for a caller
+holding the bundled open-quotient structure.
 
 This is the step Wedhorn's Proposition & Definition 6.36(ii) needs: a ring *strictly*
 topologically of finite type over `A` is an open quotient of some `A⟨X₁,…,Xₖ⟩`
@@ -97,11 +97,11 @@ holding the bundled `IsOpenQuotientMap φ`.
 That is the interface finite-type presentations come in — `TauCeti.Huber`
 `.IsStrictlyTopologicallyFiniteType` produces one — so it is the form a consumer actually has,
 and it bundles exactly the continuity, surjectivity and openness the filter-level theorem needs. -/
-theorem weightedMap_one_weight_surjective_of_isOpenQuotientMap
+theorem _root_.IsOpenQuotientMap.weightedMap_one_weight_surjective
     [(𝓝 (0 : A)).IsCountablyGenerated] {φ : A →+* B} (hq : IsOpenQuotientMap φ) :
     Function.Surjective (weightedMap (k := k) hq.continuous isWeightFamily_one_weight
       isWeightFamily_one_weight fun _ ↦ by simp) :=
-  weightedMap_one_weight_surjective hq.continuous hq.surjective
+  TauCeti.Huber.weightedMap_one_weight_surjective hq.continuous hq.surjective
     (map_zero φ ▸ hq.isOpenMap.nhds_le 0)
 
 end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Surjective.lean
@@ -8,10 +8,11 @@ module
 public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Basic
 
 /-!
-# `A⟨X₁,…,Xₖ⟩ → B⟨X₁,…,Xₖ⟩` is surjective along an open surjection
+# Restricted series lift along an open surjection
 
 A continuous **open** surjection `φ : A → B` of nonarchimedean rings whose source has countably
-generated `𝓝 0` induces a surjection `A⟨X₁,…,Xₖ⟩ → B⟨X₁,…,Xₖ⟩` of restricted power-series rings.
+generated `𝓝 0` induces a surjection of restricted power-series *rings* — the trivial-weight
+`TauCeti.Huber.weightedRestrictedSubring`, before completion — coefficientwise.
 
 Openness is the hypothesis that matters. Surjectivity of `φ` alone lifts each coefficient of a
 restricted series separately, but the preimages so chosen need not tend to zero, and then the lift
@@ -55,20 +56,22 @@ variable {k : ℕ} {A B : Type*} [CommRing A] [TopologicalSpace A] [Nonarchimede
   [CommRing B] [TopologicalSpace B] [NonarchimedeanRing B]
 
 /-- **A continuous surjection carrying neighbourhoods of zero onto neighbourhoods of zero stays
-surjective on restricted series**, provided `𝓝 (0 : A)` is countably generated. Every element of
-`B⟨X₁,…,Xₖ⟩` is then the image of one of `A⟨X₁,…,Xₖ⟩`.
+surjective on restricted series**, provided `𝓝 (0 : A)` is countably generated. Every restricted
+series over `B` is then the image of one over `A`.
 
 The hypothesis is the filter inequality the proof consumes rather than `IsOpenMap φ`, which is
 strictly stronger; `IsOpenQuotientMap.weightedMap_one_weight_surjective` is the form for a caller
 holding the bundled open-quotient structure.
 
-This is the step Wedhorn's Proposition & Definition 6.36(ii) needs: a ring *strictly*
-topologically of finite type over `A` is an open quotient of some `A⟨X₁,…,Xₖ⟩`
-(`TauCeti.Huber.IsStrictlyTopologicallyFiniteType`), and adjoining further variables to that
-quotient has to stay a quotient for noetherianity to descend to it.
-`TauCeti.Huber.IsTopologicallyFiniteType` is the weaker notion, taking a quotient of the
-completion of a weighted `A⟨X⟩_T` for an arbitrary finite weight family; it is not what this
-serves. -/
+This is a step towards what Wedhorn's Proposition & Definition 6.36(ii) needs, not the whole of
+it. `TauCeti.Huber.IsStrictlyTopologicallyFiniteType` asks for an open quotient map whose domain
+is `TauCeti.Huber.restrictedMvPowerSeriesCompletion k A` — the *completion* `A⟨X₁,…,Xₖ⟩` at the
+trivial weight — whereas the surjection here is one level below, between the restricted subrings
+themselves. Passing from this to an open quotient out of the completion is a separate step.
+
+`TauCeti.Huber.IsTopologicallyFiniteType` is the weaker notion, and what weakens it is the
+*weight family*, not completion: it allows an arbitrary finite family `T` in place of the trivial
+one. Both notions take their quotient out of a completion. -/
 theorem weightedMap_one_weight_surjective [(𝓝 (0 : A)).IsCountablyGenerated] {φ : A →+* B}
     (hφ : Continuous φ) (hsurj : Function.Surjective φ)
     (hnhds : 𝓝 (0 : B) ≤ Filter.map φ (𝓝 (0 : A))) :


### PR DESCRIPTION
Roadmap: AdicSpaces
<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"AdicSpaces/README.md#layer-0.5-item-5-quotient-stability-surjection"}-->

`TauCeti.Huber.surjective_weightedMap_one_weight`: a continuous **open** surjection
`φ : A → B` of nonarchimedean rings induces a surjection
`A⟨X₁,…,Xₖ⟩ → B⟨X₁,…,Xₖ⟩` on restricted power-series rings.

Openness is the hypothesis that carries the result. Surjectivity of `φ` alone lifts each
coefficient of a restricted series separately, but preimages chosen that way need not tend
to zero, and then the lift is a power series and not a restricted one.

## What downstream uses it

Layer 0.5 item 5 of `AdicSpaces/README.md`, "stability of noetherianity under quotients
and the iteration `A⟨X⟩⟨Y⟩ ≅ A⟨X,Y⟩`" — the **quotient** half. #5783 and #5793 did the
iteration half; this is the first step of the other one, Wedhorn Proposition & Definition
6.36(ii): a ring topologically of finite type over a strongly noetherian `A` is again
strongly noetherian.

The chain that item needs is `A⟨X⟩⟨Y⟩ ↠ B⟨Y⟩` for `B` an open quotient of `A⟨X₁,…,Xₖ⟩`;
composing it with #5783's `A⟨X⟩⟨Y⟩ ≃+* A⟨X,Y⟩` lets noetherianity descend along a
surjection. This PR supplies that surjection at the level of the restricted subring.
Carrying it across the separated completion — the object `IsStronglyNoetherian` is
actually stated over — is the next PR, and is `AddMonoidHom.surjective_completion` (#5798,
merged) once the induced map is also known to be open.

## Reuse

The coefficient choice is **not** re-derived here. `TauCeti.exists_lift_tendsto_cofinite_nhds`
(`TauCeti/Topology/LiftTendstoCofinite.lean`) already makes it, by `Nat.findGreatest`
against a countable antitone basis; `TauCeti.Huber.isWeightedRestricted_one_weight_iff` says
that at the trivial weight family restrictedness *is* convergence to zero, which is what
lets that lemma be applied directly. The proof here is the transcription and nothing more.

That is also why the statement is at the trivial weight family rather than a general one:
at a general weight family `IsWeightedRestricted` is not a convergence statement — the
target subgroup `Tν · U` varies with the multi-index — so the existing lemma would not
apply and the choice would have to be rebuilt. No consumer wants that generality.

## Attribution

AINTLIB @ `37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c`,
`projects/AdicSpaces/Adic spaces/RestrictedModule.lean`, has the corresponding statement
for modules in one variable with both sides assumed Hausdorff
(`restrictedModule_map_surjective`, sorry-free). Nothing was copied — the module docstring
records the relationship. There is no adapted code, so there is no `Provenance` line to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
