### PR TITLE
feat: mgf and exact domain of a Gaussian quadratic form

### DIFF
--- a/TauCeti/Analysis/Matrix/EuclideanLin.lean
+++ b/TauCeti/Analysis/Matrix/EuclideanLin.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.Adjoint
+
+/-!
+# Quadratic forms of matrices on Euclidean space
+
+Pulling the quadratic form `x ↦ ⟪x, B x⟫` of a square matrix `B` back along the linear map of a
+rectangular matrix `A` gives the quadratic form of the congruent matrix `Aᴴ * B * A`. This is
+the change-of-variables identity behind every computation of a quadratic statistic after a linear
+transformation of the underlying vector.
+
+## Main results
+
+* `Matrix.inner_toEuclideanLin_toEuclideanLin` — the quadratic form of `B` at `A x` is the
+  quadratic form of `Aᴴ * B * A` at `x`.
+-/
+
+public section
+
+open scoped InnerProductSpace
+
+namespace Matrix
+
+variable {𝕜 : Type*} [RCLike 𝕜] {ι κ : Type*} [Fintype ι] [DecidableEq ι] [Fintype κ]
+  [DecidableEq κ]
+
+/-- Pulling the quadratic form of `B` back along the linear map of `A` gives the quadratic form
+of the congruent matrix `Aᴴ * B * A`. -/
+theorem inner_toEuclideanLin_toEuclideanLin (A : Matrix κ ι 𝕜) (B : Matrix κ κ 𝕜)
+    (x : EuclideanSpace 𝕜 ι) :
+    ⟪A.toEuclideanLin x, B.toEuclideanLin (A.toEuclideanLin x)⟫_𝕜 =
+      ⟪x, (Aᴴ * B * A).toEuclideanLin x⟫_𝕜 := by
+  rw [← LinearMap.adjoint_inner_right, ← toEuclideanLin_conjTranspose_eq_adjoint]
+  simp only [toEuclideanLin, toLpLin_mul_same, LinearMap.comp_apply]
+
+end Matrix

--- a/TauCeti/Analysis/Matrix/Spectrum.lean
+++ b/TauCeti/Analysis/Matrix/Spectrum.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Matrix.PosDef
+public import Mathlib.Analysis.Matrix.Spectrum
+
+/-!
+# Eigen-coordinates of a real symmetric matrix
+
+Let `B` be a real symmetric matrix with orthonormal eigenvector basis `hB.eigenvectorBasis` and
+eigenvalues `hB.eigenvalues`. This file reads three quantities off the eigen-coordinates: the
+quadratic form `x ↦ ⟪x, B x⟫`, which becomes a weighted sum of squares, and the positivity and
+the determinant of the pencil `1 - c • B`, which become conditions on the numbers
+`1 - c * hB.eigenvalues j`.
+
+These are the spectral facts behind the moment-generating function of a Gaussian quadratic form,
+whose exponential-integrability domain is a positive-definiteness condition on such a pencil and
+whose value is a power of its determinant.
+
+## Main results
+
+* `Matrix.IsHermitian.inner_toEuclideanLin_sum_smul_eigenvectorBasis` — the quadratic form of
+  `B` at `∑ j, c j • b j` is `∑ j, hB.eigenvalues j * c j ^ 2`;
+* `Matrix.IsHermitian.posDef_one_sub_smul_iff` — `1 - c • B` is positive definite exactly when
+  `c * hB.eigenvalues j < 1` for every `j`;
+* `Matrix.IsHermitian.det_one_sub_smul` — the determinant of `1 - c • B` is
+  `∏ j, (1 - c * hB.eigenvalues j)`.
+-/
+
+public section
+
+noncomputable section
+
+open Unitary
+open scoped RealInnerProductSpace
+
+namespace Matrix.IsHermitian
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι] {B : Matrix ι ι ℝ} (hB : B.IsHermitian)
+include hB
+
+/-- In the eigen-coordinates of a real symmetric matrix, its quadratic form is the sum of the
+squares of the coordinates weighted by the eigenvalues. -/
+theorem inner_toEuclideanLin_sum_smul_eigenvectorBasis (c : ι → ℝ) :
+    ⟪∑ j, c j • hB.eigenvectorBasis j,
+      B.toEuclideanLin (∑ j, c j • hB.eigenvectorBasis j)⟫ =
+      ∑ j, hB.eigenvalues j * c j ^ 2 := by
+  have hb (j : ι) : B.toEuclideanLin (hB.eigenvectorBasis j) =
+      hB.eigenvalues j • hB.eigenvectorBasis j := by
+    simp [toLpLin_apply, hB.mulVec_eigenvectorBasis]
+  rw [map_sum]
+  simp_rw [map_smul, hb, smul_smul]
+  rw [hB.eigenvectorBasis.orthonormal.inner_sum]
+  exact Finset.sum_congr rfl fun j _ ↦ by rw [conj_trivial]; ring
+
+/-- The pencil `1 - c • B` is conjugate, by the eigenvector unitary of `B`, to the diagonal matrix
+with entries `1 - c * hB.eigenvalues j`. -/
+theorem one_sub_smul_eq_conjStarAlgAut (c : ℝ) :
+    1 - c • B =
+      conjStarAlgAut ℝ _ hB.eigenvectorUnitary (diagonal fun j => 1 - c * hB.eigenvalues j) := by
+  have h : (diagonal fun j => 1 - c * hB.eigenvalues j) =
+      1 - c • diagonal (RCLike.ofReal ∘ hB.eigenvalues) := by
+    simp [← diagonal_one, ← diagonal_sub, ← diagonal_smul, Pi.smul_def]
+  rw [h, map_sub, map_one, map_smul, ← hB.spectral_theorem]
+
+open scoped ComplexOrder in
+/-- The pencil `1 - c • B` is positive definite exactly when `c * hB.eigenvalues j < 1` for every
+eigenvalue. -/
+theorem posDef_one_sub_smul_iff (c : ℝ) :
+    (1 - c • B).PosDef ↔ ∀ j, c * hB.eigenvalues j < 1 := by
+  rw [hB.one_sub_smul_eq_conjStarAlgAut c, conjStarAlgAut_apply,
+    IsUnit.posDef_star_right_conjugate_iff isUnit_coe, posDef_diagonal_iff]
+  simp [sub_pos]
+
+/-- The determinant of the pencil `1 - c • B` is the product of `1 - c * hB.eigenvalues j` over
+the eigenvalues. -/
+theorem det_one_sub_smul (c : ℝ) :
+    (1 - c • B).det = ∏ j, (1 - c * hB.eigenvalues j) := by
+  rw [hB.one_sub_smul_eq_conjStarAlgAut c, conjStarAlgAut_apply, det_mul, det_mul,
+    mul_right_comm, ← det_mul, mul_star_self_of_mem hB.eigenvectorUnitary.2, det_one,
+    one_mul, det_diagonal]
+
+end Matrix.IsHermitian

--- a/TauCeti/Analysis/Matrix/Spectrum.lean
+++ b/TauCeti/Analysis/Matrix/Spectrum.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Matrix.PosDef
-public import Mathlib.Analysis.Matrix.Spectrum
 
 /-!
 # Eigen-coordinates of a real symmetric matrix

--- a/TauCeti/Analysis/Matrix/Spectrum.lean
+++ b/TauCeti/Analysis/Matrix/Spectrum.lean
@@ -13,8 +13,9 @@ public import Mathlib.Analysis.Matrix.PosDef
 Let `B` be a Hermitian matrix over an `RCLike` field with orthonormal eigenvector basis
 `hB.eigenvectorBasis` and real eigenvalues `hB.eigenvalues`. This file reads three quantities
 off the eigen-coordinates: the quadratic form `x ↦ ⟪x, B x⟫`, which becomes a weighted sum of
-squared moduli, and the positivity and the determinant of the real pencil `1 - c • B`, which
-become conditions on the real numbers `1 - c * hB.eigenvalues j`.
+squared moduli, and the diagonalization and the determinant of the pencil `1 - c • B`, which are
+read off the scalars `1 - c * hB.eigenvalues j`. The pencil is diagonal in the eigenbasis for
+any scalar `c`; only its positive definiteness asks for a real one.
 
 These are the spectral facts behind the moment-generating function of a Gaussian quadratic form,
 whose exponential-integrability domain is a positive-definiteness condition on such a pencil and
@@ -26,8 +27,9 @@ whose value is a power of its determinant.
   `B` at `∑ j, c j • b j` is `∑ j, hB.eigenvalues j * ‖c j‖ ^ 2`;
 * `Matrix.IsHermitian.posDef_one_sub_smul_iff` — `1 - c • B` is positive definite exactly when
   `c * hB.eigenvalues j < 1` for every `j`;
-* `Matrix.IsHermitian.det_one_sub_smul` — the determinant of `1 - c • B` is
-  `∏ j, (1 - c * hB.eigenvalues j)`.
+* `Matrix.IsHermitian.one_sub_smul_eq_conjStarAlgAut_diagonal` and
+  `Matrix.IsHermitian.det_one_sub_smul` — `1 - c • B` is conjugate to a diagonal matrix, and its
+  determinant is `∏ j, (1 - c * hB.eigenvalues j)`.
 -/
 
 public section
@@ -62,28 +64,31 @@ theorem inner_toEuclideanLin_sum_smul_eigenvectorBasis (c : ι → 𝕜) :
 
 /-- The pencil `1 - c • B` is conjugate, by the eigenvector unitary of `B`, to the diagonal matrix
 with entries `1 - c * hB.eigenvalues j`. -/
-theorem one_sub_smul_eq_conjStarAlgAut_diagonal (c : ℝ) :
+theorem one_sub_smul_eq_conjStarAlgAut_diagonal (c : 𝕜) :
     1 - c • B =
       conjStarAlgAut 𝕜 _ hB.eigenvectorUnitary
-        (diagonal fun j => ((1 - c * hB.eigenvalues j : ℝ) : 𝕜)) := by
-  have h : (diagonal fun j => ((1 - c * hB.eigenvalues j : ℝ) : 𝕜)) =
-      1 - (c : 𝕜) • diagonal (RCLike.ofReal ∘ hB.eigenvalues) := by
+        (diagonal fun j => 1 - c * (hB.eigenvalues j : 𝕜)) := by
+  have h : (diagonal fun j => 1 - c * (hB.eigenvalues j : 𝕜)) =
+      1 - c • diagonal (RCLike.ofReal ∘ hB.eigenvalues) := by
     simp [← diagonal_one, ← diagonal_sub, ← diagonal_smul, Pi.smul_def]
-  rw [RCLike.real_smul_eq_coe_smul (K := 𝕜), h, map_sub, map_one, map_smul, ← hB.spectral_theorem]
+  rw [h, map_sub, map_one, map_smul, ← hB.spectral_theorem]
 
 open scoped ComplexOrder in
 /-- The pencil `1 - c • B` is positive definite exactly when `c * hB.eigenvalues j < 1` for every
 eigenvalue. -/
 theorem posDef_one_sub_smul_iff (c : ℝ) :
     (1 - c • B).PosDef ↔ ∀ j, c * hB.eigenvalues j < 1 := by
-  rw [hB.one_sub_smul_eq_conjStarAlgAut_diagonal c, conjStarAlgAut_apply,
+  have hentry (j : ι) : 1 - (c : 𝕜) * (hB.eigenvalues j : 𝕜) =
+      ((1 - c * hB.eigenvalues j : ℝ) : 𝕜) := by push_cast; ring
+  rw [RCLike.real_smul_eq_coe_smul (K := 𝕜),
+    hB.one_sub_smul_eq_conjStarAlgAut_diagonal (c : 𝕜), conjStarAlgAut_apply,
     IsUnit.posDef_star_right_conjugate_iff isUnit_coe, posDef_diagonal_iff]
-  simp only [RCLike.ofReal_pos, sub_pos]
+  simp only [hentry, RCLike.ofReal_pos, sub_pos]
 
 /-- The determinant of the pencil `1 - c • B` is the product of `1 - c * hB.eigenvalues j` over
 the eigenvalues. -/
-theorem det_one_sub_smul (c : ℝ) :
-    (1 - c • B).det = ∏ j, ((1 - c * hB.eigenvalues j : ℝ) : 𝕜) := by
+theorem det_one_sub_smul (c : 𝕜) :
+    (1 - c • B).det = ∏ j, (1 - c * (hB.eigenvalues j : 𝕜)) := by
   rw [hB.one_sub_smul_eq_conjStarAlgAut_diagonal c, conjStarAlgAut_apply, det_mul, det_mul,
     mul_right_comm, ← det_mul, mul_star_self_of_mem hB.eigenvectorUnitary.2, det_one,
     one_mul, det_diagonal]

--- a/TauCeti/Analysis/Matrix/Spectrum.lean
+++ b/TauCeti/Analysis/Matrix/Spectrum.lean
@@ -8,13 +8,13 @@ module
 public import Mathlib.Analysis.Matrix.PosDef
 
 /-!
-# Eigen-coordinates of a real symmetric matrix
+# Eigen-coordinates of a Hermitian matrix
 
-Let `B` be a real symmetric matrix with orthonormal eigenvector basis `hB.eigenvectorBasis` and
-eigenvalues `hB.eigenvalues`. This file reads three quantities off the eigen-coordinates: the
-quadratic form `x ↦ ⟪x, B x⟫`, which becomes a weighted sum of squares, and the positivity and
-the determinant of the pencil `1 - c • B`, which become conditions on the numbers
-`1 - c * hB.eigenvalues j`.
+Let `B` be a Hermitian matrix over an `RCLike` field with orthonormal eigenvector basis
+`hB.eigenvectorBasis` and real eigenvalues `hB.eigenvalues`. This file reads three quantities
+off the eigen-coordinates: the quadratic form `x ↦ ⟪x, B x⟫`, which becomes a weighted sum of
+squared moduli, and the positivity and the determinant of the real pencil `1 - c • B`, which
+become conditions on the real numbers `1 - c * hB.eigenvalues j`.
 
 These are the spectral facts behind the moment-generating function of a Gaussian quadratic form,
 whose exponential-integrability domain is a positive-definiteness condition on such a pencil and
@@ -23,7 +23,7 @@ whose value is a power of its determinant.
 ## Main results
 
 * `Matrix.IsHermitian.inner_toEuclideanLin_sum_smul_eigenvectorBasis` — the quadratic form of
-  `B` at `∑ j, c j • b j` is `∑ j, hB.eigenvalues j * c j ^ 2`;
+  `B` at `∑ j, c j • b j` is `∑ j, hB.eigenvalues j * ‖c j‖ ^ 2`;
 * `Matrix.IsHermitian.posDef_one_sub_smul_iff` — `1 - c • B` is positive definite exactly when
   `c * hB.eigenvalues j < 1` for every `j`;
 * `Matrix.IsHermitian.det_one_sub_smul` — the determinant of `1 - c • B` is
@@ -35,51 +35,56 @@ public section
 noncomputable section
 
 open Unitary
-open scoped RealInnerProductSpace
+open scoped InnerProductSpace
 
 namespace Matrix.IsHermitian
 
-variable {ι : Type*} [Fintype ι] [DecidableEq ι] {B : Matrix ι ι ℝ} (hB : B.IsHermitian)
+variable {𝕜 : Type*} [RCLike 𝕜] {ι : Type*} [Fintype ι] [DecidableEq ι] {B : Matrix ι ι 𝕜}
+  (hB : B.IsHermitian)
 include hB
 
-/-- In the eigen-coordinates of a real symmetric matrix, its quadratic form is the sum of the
-squares of the coordinates weighted by the eigenvalues. -/
-theorem inner_toEuclideanLin_sum_smul_eigenvectorBasis (c : ι → ℝ) :
+/-- In the eigen-coordinates of a Hermitian matrix, its quadratic form is the sum of the squared
+moduli of the coordinates weighted by the eigenvalues. -/
+theorem inner_toEuclideanLin_sum_smul_eigenvectorBasis (c : ι → 𝕜) :
     ⟪∑ j, c j • hB.eigenvectorBasis j,
-      B.toEuclideanLin (∑ j, c j • hB.eigenvectorBasis j)⟫ =
-      ∑ j, hB.eigenvalues j * c j ^ 2 := by
+      B.toEuclideanLin (∑ j, c j • hB.eigenvectorBasis j)⟫_𝕜 =
+      ∑ j, (hB.eigenvalues j : 𝕜) * (‖c j‖ : 𝕜) ^ 2 := by
   have hb (j : ι) : B.toEuclideanLin (hB.eigenvectorBasis j) =
-      hB.eigenvalues j • hB.eigenvectorBasis j := by
+      (hB.eigenvalues j : 𝕜) • hB.eigenvectorBasis j := by
+    rw [← RCLike.real_smul_eq_coe_smul (K := 𝕜)]
     simp [toLpLin_apply, hB.mulVec_eigenvectorBasis]
   rw [map_sum]
   simp_rw [map_smul, hb, smul_smul]
   rw [hB.eigenvectorBasis.orthonormal.inner_sum]
-  exact Finset.sum_congr rfl fun j _ ↦ by rw [conj_trivial]; ring
+  refine Finset.sum_congr rfl fun j _ ↦ ?_
+  rw [← mul_assoc, RCLike.conj_mul]
+  ring
 
 /-- The pencil `1 - c • B` is conjugate, by the eigenvector unitary of `B`, to the diagonal matrix
 with entries `1 - c * hB.eigenvalues j`. -/
-theorem one_sub_smul_eq_conjStarAlgAut (c : ℝ) :
+theorem one_sub_smul_eq_conjStarAlgAut_diagonal (c : ℝ) :
     1 - c • B =
-      conjStarAlgAut ℝ _ hB.eigenvectorUnitary (diagonal fun j => 1 - c * hB.eigenvalues j) := by
-  have h : (diagonal fun j => 1 - c * hB.eigenvalues j) =
-      1 - c • diagonal (RCLike.ofReal ∘ hB.eigenvalues) := by
+      conjStarAlgAut 𝕜 _ hB.eigenvectorUnitary
+        (diagonal fun j => ((1 - c * hB.eigenvalues j : ℝ) : 𝕜)) := by
+  have h : (diagonal fun j => ((1 - c * hB.eigenvalues j : ℝ) : 𝕜)) =
+      1 - (c : 𝕜) • diagonal (RCLike.ofReal ∘ hB.eigenvalues) := by
     simp [← diagonal_one, ← diagonal_sub, ← diagonal_smul, Pi.smul_def]
-  rw [h, map_sub, map_one, map_smul, ← hB.spectral_theorem]
+  rw [RCLike.real_smul_eq_coe_smul (K := 𝕜), h, map_sub, map_one, map_smul, ← hB.spectral_theorem]
 
 open scoped ComplexOrder in
 /-- The pencil `1 - c • B` is positive definite exactly when `c * hB.eigenvalues j < 1` for every
 eigenvalue. -/
 theorem posDef_one_sub_smul_iff (c : ℝ) :
     (1 - c • B).PosDef ↔ ∀ j, c * hB.eigenvalues j < 1 := by
-  rw [hB.one_sub_smul_eq_conjStarAlgAut c, conjStarAlgAut_apply,
+  rw [hB.one_sub_smul_eq_conjStarAlgAut_diagonal c, conjStarAlgAut_apply,
     IsUnit.posDef_star_right_conjugate_iff isUnit_coe, posDef_diagonal_iff]
-  simp [sub_pos]
+  simp only [RCLike.ofReal_pos, sub_pos]
 
 /-- The determinant of the pencil `1 - c • B` is the product of `1 - c * hB.eigenvalues j` over
 the eigenvalues. -/
 theorem det_one_sub_smul (c : ℝ) :
-    (1 - c • B).det = ∏ j, (1 - c * hB.eigenvalues j) := by
-  rw [hB.one_sub_smul_eq_conjStarAlgAut c, conjStarAlgAut_apply, det_mul, det_mul,
+    (1 - c • B).det = ∏ j, ((1 - c * hB.eigenvalues j : ℝ) : 𝕜) := by
+  rw [hB.one_sub_smul_eq_conjStarAlgAut_diagonal c, conjStarAlgAut_apply, det_mul, det_mul,
     mul_right_comm, ← det_mul, mul_star_self_of_mem hB.eigenvectorUnitary.2, det_one,
     one_mul, det_diagonal]
 

--- a/TauCeti/Analysis/Matrix/Sqrt.lean
+++ b/TauCeti/Analysis/Matrix/Sqrt.lean
@@ -11,11 +11,14 @@ public import Mathlib.LinearAlgebra.Matrix.SchurComplement
 /-!
 # Sandwiches by the square root of a positive-semidefinite matrix
 
-The continuous-functional-calculus square root `CFC.sqrt S` of a matrix `S` is positive
-semidefinite (`CFC.sqrt_nonneg`), hence Hermitian. Sandwiching a Hermitian matrix `Θ` between two
-copies of it gives the Hermitian matrix `CFC.sqrt S * Θ * CFC.sqrt S`. Its pencils
-`1 - c • (CFC.sqrt S * Θ * CFC.sqrt S)` have the same determinant as those of `Θ * S`, by
-Sylvester's determinant identity and `CFC.sqrt S * CFC.sqrt S = S`.
+Pulling the quadratic form `x ↦ ⟪x, B x⟫` of a matrix `B` back along the linear map of a matrix
+`A` gives the quadratic form of the sandwich `Aᴴ * B * A`. This file records that identity and
+specialises it to sandwiches by the continuous-functional-calculus square root `CFC.sqrt S` of a
+matrix `S`, which is positive semidefinite (`CFC.sqrt_nonneg`), hence Hermitian. Sandwiching a
+Hermitian matrix `Θ` between two copies of it gives the Hermitian matrix
+`CFC.sqrt S * Θ * CFC.sqrt S`, whose pencils `1 - c • (CFC.sqrt S * Θ * CFC.sqrt S)` have the
+same determinant as those of `Θ * S`, by Sylvester's determinant identity and
+`CFC.sqrt S * CFC.sqrt S = S`.
 
 The sandwich is the matrix whose eigenvalues govern the exponential moments of a Gaussian
 quadratic form, and the determinant identity is what turns its spectral formula into a formula
@@ -23,7 +26,10 @@ in the original parameters.
 
 ## Main results
 
-* `Matrix.isHermitian_sqrt_mul_mul_sqrt` — the sandwich of a Hermitian matrix is Hermitian;
+* `Matrix.inner_toEuclideanLin_toEuclideanLin` — the quadratic form of `B` at `A x` is the
+  quadratic form of `Aᴴ * B * A` at `x`;
+* `Matrix.isHermitian_sqrt_mul_mul_sqrt` — the sandwich of a Hermitian matrix by a square root
+  is Hermitian;
 * `Matrix.det_one_sub_smul_sqrt_mul_mul_sqrt` — the pencil determinants agree.
 -/
 
@@ -31,11 +37,20 @@ public section
 
 noncomputable section
 
-open scoped ComplexOrder MatrixOrder Matrix.Norms.L2Operator
+open scoped ComplexOrder InnerProductSpace MatrixOrder Matrix.Norms.L2Operator
 
 namespace Matrix
 
 variable {𝕜 : Type*} [RCLike 𝕜] {ι : Type*} [Fintype ι]
+
+/-- Pulling the quadratic form of `B` back along the linear map of `A` gives the quadratic form
+of the sandwich `Aᴴ * B * A`. -/
+theorem inner_toEuclideanLin_toEuclideanLin [DecidableEq ι] (A B : Matrix ι ι 𝕜)
+    (x : EuclideanSpace 𝕜 ι) :
+    ⟪A.toEuclideanLin x, B.toEuclideanLin (A.toEuclideanLin x)⟫_𝕜 =
+      ⟪x, (Aᴴ * B * A).toEuclideanLin x⟫_𝕜 := by
+  rw [← LinearMap.adjoint_inner_right, ← toEuclideanLin_conjTranspose_eq_adjoint]
+  simp only [toEuclideanLin, toLpLin_mul_same, LinearMap.comp_apply]
 
 open scoped Classical in
 /-- Sandwiching a Hermitian matrix between two copies of a square root gives a Hermitian

--- a/TauCeti/Analysis/Matrix/Sqrt.lean
+++ b/TauCeti/Analysis/Matrix/Sqrt.lean
@@ -11,9 +11,9 @@ public import Mathlib.LinearAlgebra.Matrix.SchurComplement
 /-!
 # Sandwiches by the square root of a positive-semidefinite matrix
 
-For a positive-semidefinite matrix `S`, the continuous-functional-calculus square root
-`CFC.sqrt S` is again positive semidefinite, hence Hermitian. Sandwiching a Hermitian matrix `Θ`
-between two copies of it gives the Hermitian matrix `CFC.sqrt S * Θ * CFC.sqrt S`. Its pencils
+The continuous-functional-calculus square root `CFC.sqrt S` of a matrix `S` is positive
+semidefinite (`CFC.sqrt_nonneg`), hence Hermitian. Sandwiching a Hermitian matrix `Θ` between two
+copies of it gives the Hermitian matrix `CFC.sqrt S * Θ * CFC.sqrt S`. Its pencils
 `1 - c • (CFC.sqrt S * Θ * CFC.sqrt S)` have the same determinant as those of `Θ * S`, by
 Sylvester's determinant identity and `CFC.sqrt S * CFC.sqrt S = S`.
 
@@ -23,8 +23,6 @@ in the original parameters.
 
 ## Main results
 
-* `Matrix.posSemidef_sqrt` and `Matrix.isHermitian_sqrt` — the square root is positive
-  semidefinite and Hermitian, for every matrix;
 * `Matrix.isHermitian_sqrt_mul_mul_sqrt` — the sandwich of a Hermitian matrix is Hermitian;
 * `Matrix.det_one_sub_smul_sqrt_mul_mul_sqrt` — the pencil determinants agree.
 -/
@@ -40,22 +38,12 @@ namespace Matrix
 variable {𝕜 : Type*} [RCLike 𝕜] {ι : Type*} [Fintype ι]
 
 open scoped Classical in
-/-- The square root of any matrix is positive semidefinite. For a matrix that is not positive
-semidefinite the square root is `0`. -/
-theorem posSemidef_sqrt (S : Matrix ι ι 𝕜) : (CFC.sqrt S).PosSemidef :=
-  nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg S)
-
-open scoped Classical in
-/-- The square root of any matrix is Hermitian. -/
-theorem isHermitian_sqrt (S : Matrix ι ι 𝕜) : (CFC.sqrt S).IsHermitian :=
-  (posSemidef_sqrt S).1
-
-open scoped Classical in
 /-- Sandwiching a Hermitian matrix between two copies of a square root gives a Hermitian
 matrix. -/
 theorem isHermitian_sqrt_mul_mul_sqrt (S : Matrix ι ι 𝕜) {Θ : Matrix ι ι 𝕜}
     (hΘ : Θ.IsHermitian) : (CFC.sqrt S * Θ * CFC.sqrt S).IsHermitian := by
-  simpa only [(isHermitian_sqrt S).eq] using isHermitian_conjTranspose_mul_mul (CFC.sqrt S) hΘ
+  simpa only [(Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1.eq] using
+    isHermitian_conjTranspose_mul_mul (CFC.sqrt S) hΘ
 
 /-- For positive-semidefinite `S`, the pencils of the sandwich `CFC.sqrt S * Θ * CFC.sqrt S` and
 of the product `Θ * S` have the same determinant. -/
@@ -63,7 +51,7 @@ theorem det_one_sub_smul_sqrt_mul_mul_sqrt [DecidableEq ι] {S : Matrix ι ι �
     (hS : S.PosSemidef) (Θ : Matrix ι ι 𝕜) (c : 𝕜) :
     (1 - c • (CFC.sqrt S * Θ * CFC.sqrt S)).det = (1 - c • (Θ * S)).det := by
   have hsq : CFC.sqrt S * CFC.sqrt S = S :=
-    CFC.sqrt_mul_sqrt_self S (nonneg_iff_posSemidef.mpr hS)
+    CFC.sqrt_mul_sqrt_self S hS.nonneg
   rw [← Matrix.smul_mul, det_one_sub_mul_comm, Matrix.mul_smul, ← Matrix.mul_assoc, hsq,
     ← Matrix.smul_mul, det_one_sub_mul_comm, Matrix.mul_smul]
 

--- a/TauCeti/Analysis/Matrix/Sqrt.lean
+++ b/TauCeti/Analysis/Matrix/Sqrt.lean
@@ -30,7 +30,7 @@ in the original parameters.
   quadratic form of `Aᴴ * B * A` at `x`;
 * `Matrix.isHermitian_sqrt_mul_mul_sqrt` — the sandwich of a Hermitian matrix by a square root
   is Hermitian;
-* `Matrix.det_one_sub_smul_sqrt_mul_mul_sqrt` — the pencil determinants agree.
+* `Matrix.PosSemidef.det_one_sub_smul_sqrt_mul_mul_sqrt` — the pencil determinants agree.
 -/
 
 public section
@@ -62,7 +62,7 @@ theorem isHermitian_sqrt_mul_mul_sqrt (S : Matrix ι ι 𝕜) {Θ : Matrix ι ι
 
 /-- For positive-semidefinite `S`, the pencils of the sandwich `CFC.sqrt S * Θ * CFC.sqrt S` and
 of the product `Θ * S` have the same determinant. -/
-theorem det_one_sub_smul_sqrt_mul_mul_sqrt [DecidableEq ι] {S : Matrix ι ι 𝕜}
+theorem PosSemidef.det_one_sub_smul_sqrt_mul_mul_sqrt [DecidableEq ι] {S : Matrix ι ι 𝕜}
     (hS : S.PosSemidef) (Θ : Matrix ι ι 𝕜) (c : 𝕜) :
     (1 - c • (CFC.sqrt S * Θ * CFC.sqrt S)).det = (1 - c • (Θ * S)).det := by
   have hsq : CFC.sqrt S * CFC.sqrt S = S :=

--- a/TauCeti/Analysis/Matrix/Sqrt.lean
+++ b/TauCeti/Analysis/Matrix/Sqrt.lean
@@ -45,8 +45,8 @@ variable {𝕜 : Type*} [RCLike 𝕜] {ι : Type*} [Fintype ι]
 
 /-- Pulling the quadratic form of `B` back along the linear map of `A` gives the quadratic form
 of the sandwich `Aᴴ * B * A`. -/
-theorem inner_toEuclideanLin_toEuclideanLin [DecidableEq ι] (A B : Matrix ι ι 𝕜)
-    (x : EuclideanSpace 𝕜 ι) :
+theorem inner_toEuclideanLin_toEuclideanLin [DecidableEq ι] {κ : Type*} [Fintype κ]
+    [DecidableEq κ] (A : Matrix κ ι 𝕜) (B : Matrix κ κ 𝕜) (x : EuclideanSpace 𝕜 ι) :
     ⟪A.toEuclideanLin x, B.toEuclideanLin (A.toEuclideanLin x)⟫_𝕜 =
       ⟪x, (Aᴴ * B * A).toEuclideanLin x⟫_𝕜 := by
   rw [← LinearMap.adjoint_inner_right, ← toEuclideanLin_conjTranspose_eq_adjoint]

--- a/TauCeti/Analysis/Matrix/Sqrt.lean
+++ b/TauCeti/Analysis/Matrix/Sqrt.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Matrix.Order
+public import Mathlib.LinearAlgebra.Matrix.SchurComplement
+
+/-!
+# Sandwiches by the square root of a positive-semidefinite matrix
+
+For a positive-semidefinite matrix `S`, the continuous-functional-calculus square root
+`CFC.sqrt S` is again positive semidefinite, hence Hermitian. Sandwiching a Hermitian matrix `Θ`
+between two copies of it gives the Hermitian matrix `CFC.sqrt S * Θ * CFC.sqrt S`. Its pencils
+`1 - c • (CFC.sqrt S * Θ * CFC.sqrt S)` have the same determinant as those of `Θ * S`, by
+Sylvester's determinant identity and `CFC.sqrt S * CFC.sqrt S = S`.
+
+The sandwich is the matrix whose eigenvalues govern the exponential moments of a Gaussian
+quadratic form, and the determinant identity is what turns its spectral formula into a formula
+in the original parameters.
+
+## Main results
+
+* `Matrix.posSemidef_sqrt` and `Matrix.isHermitian_sqrt` — the square root is positive
+  semidefinite and Hermitian, for every matrix;
+* `Matrix.isHermitian_sqrt_mul_mul_sqrt` — the sandwich of a Hermitian matrix is Hermitian;
+* `Matrix.det_one_sub_smul_sqrt_mul_mul_sqrt` — the pencil determinants agree.
+-/
+
+public section
+
+noncomputable section
+
+open scoped ComplexOrder MatrixOrder Matrix.Norms.L2Operator
+
+namespace Matrix
+
+variable {𝕜 : Type*} [RCLike 𝕜] {ι : Type*} [Fintype ι]
+
+open scoped Classical in
+/-- The square root of any matrix is positive semidefinite. For a matrix that is not positive
+semidefinite the square root is `0`. -/
+theorem posSemidef_sqrt (S : Matrix ι ι 𝕜) : (CFC.sqrt S).PosSemidef :=
+  nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg S)
+
+open scoped Classical in
+/-- The square root of any matrix is Hermitian. -/
+theorem isHermitian_sqrt (S : Matrix ι ι 𝕜) : (CFC.sqrt S).IsHermitian :=
+  (posSemidef_sqrt S).1
+
+open scoped Classical in
+/-- Sandwiching a Hermitian matrix between two copies of a square root gives a Hermitian
+matrix. -/
+theorem isHermitian_sqrt_mul_mul_sqrt (S : Matrix ι ι 𝕜) {Θ : Matrix ι ι 𝕜}
+    (hΘ : Θ.IsHermitian) : (CFC.sqrt S * Θ * CFC.sqrt S).IsHermitian := by
+  simpa only [(isHermitian_sqrt S).eq] using isHermitian_conjTranspose_mul_mul (CFC.sqrt S) hΘ
+
+/-- For positive-semidefinite `S`, the pencils of the sandwich `CFC.sqrt S * Θ * CFC.sqrt S` and
+of the product `Θ * S` have the same determinant. -/
+theorem det_one_sub_smul_sqrt_mul_mul_sqrt [DecidableEq ι] {S : Matrix ι ι 𝕜}
+    (hS : S.PosSemidef) (Θ : Matrix ι ι 𝕜) (c : 𝕜) :
+    (1 - c • (CFC.sqrt S * Θ * CFC.sqrt S)).det = (1 - c • (Θ * S)).det := by
+  have hsq : CFC.sqrt S * CFC.sqrt S = S :=
+    CFC.sqrt_mul_sqrt_self S (nonneg_iff_posSemidef.mpr hS)
+  rw [← Matrix.smul_mul, det_one_sub_mul_comm, Matrix.mul_smul, ← Matrix.mul_assoc, hsq,
+    ← Matrix.smul_mul, det_one_sub_mul_comm, Matrix.mul_smul]
+
+end Matrix

--- a/TauCeti/Analysis/Matrix/Sqrt.lean
+++ b/TauCeti/Analysis/Matrix/Sqrt.lean
@@ -7,18 +7,17 @@ module
 
 public import Mathlib.Analysis.Matrix.Order
 public import Mathlib.LinearAlgebra.Matrix.SchurComplement
+public import TauCeti.Analysis.Matrix.EuclideanLin
 
 /-!
 # Sandwiches by the square root of a positive-semidefinite matrix
 
-Pulling the quadratic form `x ↦ ⟪x, B x⟫` of a matrix `B` back along the linear map of a matrix
-`A` gives the quadratic form of the sandwich `Aᴴ * B * A`. This file records that identity and
-specialises it to sandwiches by the continuous-functional-calculus square root `CFC.sqrt S` of a
-matrix `S`, which is positive semidefinite (`CFC.sqrt_nonneg`), hence Hermitian. Sandwiching a
-Hermitian matrix `Θ` between two copies of it gives the Hermitian matrix
-`CFC.sqrt S * Θ * CFC.sqrt S`, whose pencils `1 - c • (CFC.sqrt S * Θ * CFC.sqrt S)` have the
-same determinant as those of `Θ * S`, by Sylvester's determinant identity and
-`CFC.sqrt S * CFC.sqrt S = S`.
+The continuous-functional-calculus square root `CFC.sqrt S` of a matrix `S` is positive
+semidefinite (`CFC.sqrt_nonneg`), hence Hermitian. Sandwiching a Hermitian matrix `Θ` between
+two copies of it gives the Hermitian matrix `CFC.sqrt S * Θ * CFC.sqrt S`, whose quadratic form
+is the pullback of the quadratic form of `Θ` along `CFC.sqrt S`. For positive-semidefinite `S`,
+its pencils `1 - c • (CFC.sqrt S * Θ * CFC.sqrt S)` have the same determinant as those of
+`Θ * S`, by Sylvester's determinant identity and `CFC.sqrt S * CFC.sqrt S = S`.
 
 The sandwich is the matrix whose eigenvalues govern the exponential moments of a Gaussian
 quadratic form, and the determinant identity is what turns its spectral formula into a formula
@@ -26,11 +25,12 @@ in the original parameters.
 
 ## Main results
 
-* `Matrix.inner_toEuclideanLin_toEuclideanLin` — the quadratic form of `B` at `A x` is the
-  quadratic form of `Aᴴ * B * A` at `x`;
 * `Matrix.isHermitian_sqrt_mul_mul_sqrt` — the sandwich of a Hermitian matrix by a square root
   is Hermitian;
-* `Matrix.PosSemidef.det_one_sub_smul_sqrt_mul_mul_sqrt` — the pencil determinants agree.
+* `Matrix.inner_toEuclideanCLM_sqrt_toEuclideanLin` — the quadratic form of `Θ` at
+  `CFC.sqrt S x` is the quadratic form of the sandwich at `x`;
+* `Matrix.PosSemidef.det_one_sub_smul_sqrt_mul_mul_sqrt_eq_det_one_sub_smul_mul` — for
+  positive-semidefinite `S`, the pencil determinants of the sandwich and of `Θ * S` agree.
 -/
 
 public section
@@ -43,15 +43,6 @@ namespace Matrix
 
 variable {𝕜 : Type*} [RCLike 𝕜] {ι : Type*} [Fintype ι]
 
-/-- Pulling the quadratic form of `B` back along the linear map of `A` gives the quadratic form
-of the sandwich `Aᴴ * B * A`. -/
-theorem inner_toEuclideanLin_toEuclideanLin [DecidableEq ι] {κ : Type*} [Fintype κ]
-    [DecidableEq κ] (A : Matrix κ ι 𝕜) (B : Matrix κ κ 𝕜) (x : EuclideanSpace 𝕜 ι) :
-    ⟪A.toEuclideanLin x, B.toEuclideanLin (A.toEuclideanLin x)⟫_𝕜 =
-      ⟪x, (Aᴴ * B * A).toEuclideanLin x⟫_𝕜 := by
-  rw [← LinearMap.adjoint_inner_right, ← toEuclideanLin_conjTranspose_eq_adjoint]
-  simp only [toEuclideanLin, toLpLin_mul_same, LinearMap.comp_apply]
-
 open scoped Classical in
 /-- Sandwiching a Hermitian matrix between two copies of a square root gives a Hermitian
 matrix. -/
@@ -60,10 +51,20 @@ theorem isHermitian_sqrt_mul_mul_sqrt (S : Matrix ι ι 𝕜) {Θ : Matrix ι ι
   simpa only [(Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1.eq] using
     isHermitian_conjTranspose_mul_mul (CFC.sqrt S) hΘ
 
+/-- The quadratic form of `Θ` at `CFC.sqrt S x` is the quadratic form of the sandwich
+`CFC.sqrt S * Θ * CFC.sqrt S` at `x`. -/
+theorem inner_toEuclideanCLM_sqrt_toEuclideanLin [DecidableEq ι] (S Θ : Matrix ι ι 𝕜)
+    (x : EuclideanSpace 𝕜 ι) :
+    ⟪toEuclideanCLM (𝕜 := 𝕜) (CFC.sqrt S) x,
+        Θ.toEuclideanLin (toEuclideanCLM (𝕜 := 𝕜) (CFC.sqrt S) x)⟫_𝕜 =
+      ⟪x, (CFC.sqrt S * Θ * CFC.sqrt S).toEuclideanLin x⟫_𝕜 := by
+  simp only [← ContinuousLinearMap.coe_coe, coe_toEuclideanCLM_eq_toEuclideanLin,
+    inner_toEuclideanLin_toEuclideanLin, (Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1.eq]
+
 /-- For positive-semidefinite `S`, the pencils of the sandwich `CFC.sqrt S * Θ * CFC.sqrt S` and
 of the product `Θ * S` have the same determinant. -/
-theorem PosSemidef.det_one_sub_smul_sqrt_mul_mul_sqrt [DecidableEq ι] {S : Matrix ι ι 𝕜}
-    (hS : S.PosSemidef) (Θ : Matrix ι ι 𝕜) (c : 𝕜) :
+theorem PosSemidef.det_one_sub_smul_sqrt_mul_mul_sqrt_eq_det_one_sub_smul_mul [DecidableEq ι]
+    {S : Matrix ι ι 𝕜} (hS : S.PosSemidef) (Θ : Matrix ι ι 𝕜) (c : 𝕜) :
     (1 - c • (CFC.sqrt S * Θ * CFC.sqrt S)).det = (1 - c • (Θ * S)).det := by
   have hsq : CFC.sqrt S * CFC.sqrt S = S :=
     CFC.sqrt_mul_sqrt_self S hS.nonneg

--- a/TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Probability.Distributions.ChiSquared
 public import TauCeti.Probability.Distributions.Gaussian.Cdf
+public import TauCeti.Probability.Moments.Pi
 
 /-!
 # Squares of standard Gaussian variables
@@ -17,6 +18,11 @@ the sum of the squares of a finite independent standard Gaussian family has the 
 whose degrees of freedom are the cardinality of the family. The empty family is included: both
 the empty sum and `chiSquaredMeasure 0` are the point mass at zero.
 
+It also computes the exponential-integrability domain and the moment-generating function of a
+weighted square `w * x ^ 2` of a standard Gaussian variable, and of a weighted sum of squares
+`∑ j, w j * c j ^ 2` of finitely many independent ones, which is the form a Gaussian quadratic
+statistic takes in eigen-coordinates.
+
 These laws identify Gaussian quadratic statistics with chi-squared distributions. In particular,
 they provide the scalar foundation for distributional results about Gaussian norms and Gaussian
 Gram matrices.
@@ -26,7 +32,14 @@ Gram matrices.
 * `TauCeti.Probability.gaussianReal_map_sq` — the square of the standard Gaussian measure is
   `chiSquaredMeasure 1`;
 * `TauCeti.Probability.iIndepFun.hasLaw_sum_sq_gaussian` — a finite sum of independent squared
-  standard Gaussian variables has the corresponding chi-squared law.
+  standard Gaussian variables has the corresponding chi-squared law;
+* `TauCeti.Probability.mem_integrableExpSet_mul_sq_gaussianReal_iff` and
+  `TauCeti.Probability.mgf_mul_sq_gaussianReal` — the exponential moments of `w * x ^ 2` are
+  finite exactly when `2 * t * w < 1`, where the moment-generating function is
+  `(1 - 2 * t * w) ^ (-1 / 2)`;
+* `TauCeti.Probability.mem_integrableExpSet_sum_mul_sq_pi_gaussianReal_iff` and
+  `TauCeti.Probability.mgf_sum_mul_sq_pi_gaussianReal` — the same for a weighted sum of squares of
+  independent standard Gaussian coordinates, with the product of the one-dimensional values.
 
 ## References
 
@@ -93,6 +106,63 @@ theorem gaussianReal_map_sq :
     rw [Real.erf_eq_regularizedGamma_half_sq herf]
     rw [div_pow, Real.sq_sqrt hx', Real.sq_sqrt (by positivity : (0 : ℝ) ≤ 2)]
     ring
+
+section scalar
+
+variable {w t : ℝ}
+
+/-- The exponential moment of order `t` of `w * x ^ 2` under the standard Gaussian is finite
+exactly when `2 * t * w < 1`. -/
+@[simp]
+theorem mem_integrableExpSet_mul_sq_gaussianReal_iff (w t : ℝ) :
+    t ∈ integrableExpSet (fun x ↦ w * x ^ 2) (gaussianReal 0 1) ↔ 2 * t * w < 1 := by
+  have key : t ∈ integrableExpSet (fun x ↦ w * x ^ 2) (gaussianReal 0 1) ↔
+      t * w ∈ integrableExpSet id (chiSquaredMeasure 1) := by
+    simp only [integrableExpSet, Set.mem_ofPred_eq, id_eq]
+    rw [← gaussianReal_map_sq, integrable_map_measure (by fun_prop) (by fun_prop),
+      Function.comp_def]
+    simp only [mul_assoc]
+  rw [key, integrableExpSet_id_chiSquaredMeasure zero_lt_one, Set.mem_Iio]
+  constructor <;> intro h <;> linarith
+
+/-- The moment-generating function of `w * x ^ 2` under the standard Gaussian is
+`(1 - 2 * t * w) ^ (-1 / 2)` on its domain `2 * t * w < 1`. -/
+@[simp]
+theorem mgf_mul_sq_gaussianReal (ht : 2 * t * w < 1) :
+    mgf (fun x ↦ w * x ^ 2) (gaussianReal 0 1) t = (1 - 2 * t * w) ^ (-1 / 2 : ℝ) := by
+  rw [mgf_const_mul, ← mgf_id_map (X := fun x : ℝ ↦ x ^ 2) (by fun_prop), gaussianReal_map_sq,
+    mgf_id_chiSquaredMeasure zero_le_one (by linarith), mul_comm w t, ← mul_assoc]
+  norm_num
+
+end scalar
+
+section pi
+
+variable {ι : Type*} [Fintype ι] {w : ι → ℝ} {t : ℝ}
+
+/-- The exponential moment of order `t` of the weighted sum of squares `∑ j, w j * c j ^ 2` of
+independent standard Gaussian coordinates is finite exactly when `2 * t * w j < 1` for every
+`j`. -/
+@[simp]
+theorem mem_integrableExpSet_sum_mul_sq_pi_gaussianReal_iff (w : ι → ℝ) (t : ℝ) :
+    t ∈ integrableExpSet (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
+        (Measure.pi fun _ : ι ↦ gaussianReal 0 1) ↔
+      ∀ j, 2 * t * w j < 1 := by
+  rw [integrableExpSet_sum_pi fun j (u : ℝ) ↦ w j * u ^ 2, Set.mem_iInter]
+  simp only [mem_integrableExpSet_mul_sq_gaussianReal_iff]
+
+/-- The moment-generating function of the weighted sum of squares `∑ j, w j * c j ^ 2` of
+independent standard Gaussian coordinates is `∏ j, (1 - 2 * t * w j) ^ (-1 / 2)` on its
+domain. -/
+@[simp]
+theorem mgf_sum_mul_sq_pi_gaussianReal (ht : ∀ j, 2 * t * w j < 1) :
+    mgf (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
+        (Measure.pi fun _ : ι ↦ gaussianReal 0 1) t =
+      ∏ j, (1 - 2 * t * w j) ^ (-1 / 2 : ℝ) := by
+  rw [mgf_sum_pi fun j (u : ℝ) ↦ w j * u ^ 2]
+  exact Finset.prod_congr rfl fun j _ ↦ mgf_mul_sq_gaussianReal (ht j)
+
+end pi
 
 variable {Omega iota : Type*} [MeasurableSpace Omega] [Fintype iota] {P : Measure Omega}
   {X : iota → Omega → ℝ}

--- a/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
@@ -13,12 +13,15 @@ public import TauCeti.Probability.Moments.Covariance
 
 This file identifies the generic covariance matrix from
 `TauCeti.Probability.Moments.Covariance` with the covariance parameter of Mathlib's multivariate
-Gaussian.
+Gaussian, and records the centred multivariate Gaussian as the image of the standard Gaussian
+under the square root of its covariance matrix.
 
 ## Main results
 
 * `TauCeti.covMatrix_multivariateGaussian` recovers the covariance parameter of a multivariate
   Gaussian law.
+* `TauCeti.multivariateGaussian_zero_eq_map_sqrt` writes the centred law as an image of the
+  standard Gaussian.
 
 ## References
 
@@ -31,11 +34,11 @@ public section
 noncomputable section
 
 open ProbabilityTheory
+open scoped MatrixOrder Matrix.Norms.L2Operator
 
 namespace TauCeti
 
 variable {ι : Type*}
-
 
 /-- The covariance matrix of a positive-semidefinite multivariate Gaussian is its covariance
 parameter. -/
@@ -46,5 +49,13 @@ theorem covMatrix_multivariateGaussian [Fintype ι] [DecidableEq ι] (m : Euclid
   classical
   ext i j
   simpa only [covMatrix_apply] using covariance_eval_multivariateGaussian hS i j
+
+/-- A centred multivariate Gaussian law is the image of the standard Gaussian under the square
+root of its covariance matrix. -/
+theorem multivariateGaussian_zero_eq_map_sqrt [Fintype ι] [DecidableEq ι] (S : Matrix ι ι ℝ) :
+    multivariateGaussian 0 S =
+      (stdGaussian (EuclideanSpace ℝ ι)).map
+        (Matrix.toEuclideanCLM (𝕜 := ℝ) (CFC.sqrt S)) := by
+  simp [multivariateGaussian]
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
@@ -20,8 +20,8 @@ under the square root of its covariance matrix.
 
 * `TauCeti.covMatrix_multivariateGaussian` recovers the covariance parameter of a multivariate
   Gaussian law.
-* `TauCeti.multivariateGaussian_zero_eq_map_sqrt` writes the centred law as an image of the
-  standard Gaussian.
+* `TauCeti.multivariateGaussian_zero_eq_map_stdGaussian_sqrt` writes the centred law as an image
+  of the standard Gaussian.
 
 ## References
 
@@ -52,7 +52,8 @@ theorem covMatrix_multivariateGaussian [Fintype ι] [DecidableEq ι] (m : Euclid
 
 /-- A centred multivariate Gaussian law is the image of the standard Gaussian under the square
 root of its covariance matrix. -/
-theorem multivariateGaussian_zero_eq_map_sqrt [Fintype ι] [DecidableEq ι] (S : Matrix ι ι ℝ) :
+theorem multivariateGaussian_zero_eq_map_stdGaussian_sqrt [Fintype ι] [DecidableEq ι]
+    (S : Matrix ι ι ℝ) :
     multivariateGaussian 0 S =
       (stdGaussian (EuclideanSpace ℝ ι)).map
         (Matrix.toEuclideanCLM (𝕜 := ℝ) (CFC.sqrt S)) := by

--- a/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
@@ -14,7 +14,7 @@ public import TauCeti.Probability.Moments.Covariance
 This file identifies the generic covariance matrix from
 `TauCeti.Probability.Moments.Covariance` with the covariance parameter of Mathlib's multivariate
 Gaussian, and records the centred multivariate Gaussian as the image of the standard Gaussian
-under the square root of its covariance matrix.
+under the square root of its matrix parameter.
 
 ## Main results
 
@@ -26,7 +26,7 @@ under the square root of its covariance matrix.
 ## References
 
 * Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 1,
-  **Covariance matrices**.
+  **Covariance matrices**, and Layer 5, item 3, **Gaussian quadratic forms**.
 -/
 
 public section
@@ -51,7 +51,7 @@ theorem covMatrix_multivariateGaussian [Fintype ι] [DecidableEq ι] (m : Euclid
   simpa only [covMatrix_apply] using covariance_eval_multivariateGaussian hS i j
 
 /-- A centred multivariate Gaussian law is the image of the standard Gaussian under the square
-root of its covariance matrix. -/
+root of its matrix parameter. No hypothesis on that parameter is needed. -/
 theorem multivariateGaussian_zero_eq_map_stdGaussian_sqrt [Fintype ι] [DecidableEq ι]
     (S : Matrix ι ι ℝ) :
     multivariateGaussian 0 S =

--- a/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
@@ -26,7 +26,7 @@ under the square root of its matrix parameter.
 ## References
 
 * Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 1,
-  **Covariance matrices**, and Layer 5, item 3, **Gaussian quadratic forms**.
+  **Covariance matrices**.
 -/
 
 public section

--- a/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
@@ -5,57 +5,51 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Probability.Distributions.Gaussian.Multivariate
 public import TauCeti.Analysis.Matrix.Spectrum
 public import TauCeti.Analysis.Matrix.Sqrt
 public import TauCeti.Probability.Distributions.Gaussian.ChiSquared
+public import TauCeti.Probability.Distributions.Gaussian.Multivariate
 
 /-!
 # Moment-generating functions of Gaussian quadratic forms
 
-Let `S` be a positive-semidefinite covariance matrix and `Θ` a real symmetric matrix. This file
-determines exactly when the quadratic statistic `x ↦ ⟪x, Θ x⟫` of a centred multivariate
-Gaussian vector has finite exponential moments of order `t`, and computes its moment-generating
-function there:
+Let `S` be a covariance matrix and `Θ` a real symmetric matrix. This file determines exactly
+when the quadratic statistic `x ↦ ⟪x, Θ x⟫` of a centred multivariate Gaussian vector has finite
+exponential moments of order `t`, and computes its moment-generating function there:
 
-* the integrand is integrable exactly when `1 - (2 * t) • (√S * Θ * √S)` is positive
-  definite, where `√S = CFC.sqrt S`; and
-* on that domain the moment-generating function is `det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`.
+* the integrand is integrable exactly when the pencil `1 - (2 * t) • (√S * Θ * √S)` is positive
+  definite, where `√S = CFC.sqrt S`, with no hypothesis on `S`; and
+* on that domain the moment-generating function is
+  `det (1 - (2 * t) • (√S * Θ * √S)) ^ (-1 / 2)`, which for positive-semidefinite `S` is
+  `det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`.
 
-**The proof.** The law `multivariateGaussian 0 S` is the image of the standard Gaussian under
-`√S`, which turns the statistic into the quadratic form of the symmetric sandwich
-`√S * Θ * √S`. Rotating the standard Gaussian into the eigenbasis of that sandwich, with
-eigenvalues `λ j`, turns the quadratic form into `∑ j, λ j * c j ^ 2` for independent standard
-Gaussian coordinates `c j`. Each summand is a multiple of a chi-squared variable with one degree
-of freedom, whose moment-generating function is `(1 - 2 * s) ^ (-1 / 2)` exactly for
-`s < 1 / 2`, and Fubini's theorem on the product measure multiplies the factors. The domain
-condition `∀ j, 2 * t * λ j < 1` is
-positive definiteness of the pencil `1 - (2 * t) • (√S * Θ * √S)`, and the product of the
-factors is a power of its determinant, which Sylvester's identity identifies with
-`det (1 - (2 * t) • (Θ * S))`.
-
-The one-dimensional building blocks are stated separately, first for a single standard Gaussian
-coordinate and then for a finite product of them.
+The same results are stated for the standard Gaussian vector, in terms of the eigenvalues of the
+symmetric matrix, and for one and for finitely many independent standard Gaussian coordinates,
+where the quadratic form is a weighted sum of squares.
 
 ## Main results
 
 * `TauCeti.mem_integrableExpSet_inner_toEuclideanLin_multivariateGaussian_iff` — the exact
   exponential-integrability domain of a Gaussian quadratic form;
-* `TauCeti.mgf_inner_toEuclideanLin_multivariateGaussian` — its moment-generating function on
-  that domain;
-* `TauCeti.cgf_inner_toEuclideanLin_multivariateGaussian` — the cumulant-generating function, the
-  real logarithm of the same value;
+* `TauCeti.mgf_inner_toEuclideanLin_multivariateGaussian_sqrt` and
+  `TauCeti.mgf_inner_toEuclideanLin_multivariateGaussian` — its moment-generating function on
+  that domain, in terms of the sandwich `√S * Θ * √S` and, for positive-semidefinite `S`, of
+  `Θ * S`;
+* `TauCeti.cgf_inner_toEuclideanLin_multivariateGaussian_sqrt` and
+  `TauCeti.cgf_inner_toEuclideanLin_multivariateGaussian` — the cumulant-generating function, the
+  real logarithm of the same values;
 * `TauCeti.mem_integrableExpSet_inner_toEuclideanLin_stdGaussian_iff` and
   `TauCeti.mgf_inner_toEuclideanLin_stdGaussian` — the same results for the standard Gaussian,
-  in terms of the eigenvalues of the symmetric matrix.
+  in terms of the eigenvalues of the symmetric matrix;
+* `TauCeti.mgf_sum_mul_sq_pi_gaussianReal_eq_prod` — the moment-generating function of a
+  weighted sum of squares of independent standard Gaussian coordinates factors over the
+  coordinates, for every `t`.
 
 ## References
 
 * R. J. Muirhead, *Aspects of Multivariate Statistical Theory*, Wiley (1982), Theorem 1.2.6
   (the multivariate Gaussian) and Theorem 3.2.3 (the Wishart moment-generating function, which
   is the product of these).
-* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 3,
-  **Gaussian quadratic forms**.
 -/
 
 public section
@@ -93,7 +87,7 @@ theorem mgf_mul_sq_gaussianReal (ht : 2 * t * w < 1) :
   rw [mgf_const_mul, ← mgf_id_map (X := fun x : ℝ ↦ x ^ 2) (by fun_prop),
     Probability.gaussianReal_map_sq,
     Probability.mgf_id_chiSquaredMeasure zero_le_one (by linarith),
-    show 2 * (w * t) = 2 * t * w by ring]
+    mul_comm w t, ← mul_assoc]
   norm_num
 
 end scalar
@@ -108,7 +102,7 @@ variable {ι : Type*} [Fintype ι] {w : ι → ℝ} {t : ℝ}
 coordinates, so Fubini's theorem turns its integral into a product of one-dimensional
 moment-generating functions. No integrability hypothesis is needed: off the common domain both
 sides are zero. -/
-private lemma mgf_sum_mul_sq_pi_gaussianReal_eq_prod (w : ι → ℝ) (t : ℝ) :
+theorem mgf_sum_mul_sq_pi_gaussianReal_eq_prod (w : ι → ℝ) (t : ℝ) :
     mgf (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
         (Measure.pi fun _ : ι ↦ gaussianReal 0 1) t =
       ∏ j, mgf (fun u : ℝ ↦ w j * u ^ 2) (gaussianReal 0 1) t := by
@@ -189,38 +183,6 @@ section multivariateGaussian
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] {S Θ : Matrix ι ι ℝ} {t : ℝ}
 
-/-- A centred multivariate Gaussian law is the image of the standard Gaussian under the square
-root of its covariance matrix. -/
-theorem multivariateGaussian_zero_eq_map_sqrt (S : Matrix ι ι ℝ) :
-    multivariateGaussian 0 S =
-      (stdGaussian (EuclideanSpace ℝ ι)).map
-        (Matrix.toEuclideanCLM (𝕜 := ℝ) (CFC.sqrt S)) := by
-  simp [multivariateGaussian]
-
-open Matrix in
-/-- Over the reals the quadratic form of a matrix is the dot product against the matrix-vector
-product. -/
-private lemma inner_toEuclideanLin_eq_dotProduct (A : Matrix ι ι ℝ)
-    (x : EuclideanSpace ℝ ι) : ⟪x, A.toEuclideanLin x⟫ = x ⬝ᵥ A *ᵥ x :=
-  Matrix.inner_toEuclideanCLM A x x
-
-open Matrix in
-/-- Pulling the quadratic form of `Θ` back along a symmetric matrix `R` gives the quadratic form
-of the symmetric sandwich `R * Θ * R`. -/
-private lemma inner_toEuclideanLin_toEuclideanCLM {R : Matrix ι ι ℝ} (hR : R.IsHermitian)
-    (Θ : Matrix ι ι ℝ) (y : EuclideanSpace ℝ ι) :
-    ⟪Matrix.toEuclideanCLM (𝕜 := ℝ) R y,
-        Θ.toEuclideanLin (Matrix.toEuclideanCLM (𝕜 := ℝ) R y)⟫ =
-      ⟪y, (R * Θ * R).toEuclideanLin y⟫ := by
-  have hRT : Rᵀ = R := by
-    rw [← Matrix.conjTranspose_eq_transpose_of_trivial]
-    exact hR
-  have hswap (u v : ι → ℝ) : (R *ᵥ v) ⬝ᵥ u = v ⬝ᵥ R *ᵥ u := by
-    rw [Matrix.dotProduct_mulVec, ← Matrix.mulVec_transpose, hRT]
-  rw [inner_toEuclideanLin_eq_dotProduct, inner_toEuclideanLin_eq_dotProduct,
-    Matrix.ofLp_toEuclideanCLM, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
-  exact hswap _ _
-
 /-- The exponential moment of order `t` of the quadratic form `x ↦ ⟪x, Θ x⟫` of a real
 symmetric matrix `Θ` under the centred multivariate Gaussian with covariance `S` is finite
 exactly when the pencil `1 - (2 * t) • (√S * Θ * √S)` is positive definite.
@@ -240,27 +202,49 @@ theorem mem_integrableExpSet_inner_toEuclideanLin_multivariateGaussian_iff (S : 
   simp only [integrableExpSet, Set.mem_ofPred_eq]
   rw [integrable_map_measure (by fun_prop) (Measurable.aemeasurable (by fun_prop)),
     Function.comp_def]
-  simp only [inner_toEuclideanLin_toEuclideanCLM (Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1]
+  simp only [← ContinuousLinearMap.coe_coe, Matrix.coe_toEuclideanCLM_eq_toEuclideanLin,
+    Matrix.inner_toEuclideanLin_toEuclideanLin, (Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1.eq]
 
 /-- On its exponential-integrability domain, the moment-generating function of the quadratic
 form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
-with covariance `S` is `det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`. -/
-theorem mgf_inner_toEuclideanLin_multivariateGaussian (hS : S.PosSemidef) (hΘ : Θ.IsHermitian)
-    (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
+with covariance `S` is `det (1 - (2 * t) • (√S * Θ * √S)) ^ (-1 / 2)`, for every `S`. -/
+theorem mgf_inner_toEuclideanLin_multivariateGaussian_sqrt (S : Matrix ι ι ℝ)
+    (hΘ : Θ.IsHermitian) (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
     mgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =
-      (1 - (2 * t) • (Θ * S)).det ^ (-1 / 2 : ℝ) := by
+      (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).det ^ (-1 / 2 : ℝ) := by
   have hB := Matrix.isHermitian_sqrt_mul_mul_sqrt S hΘ
   have ht' : ∀ j, 2 * t * hB.eigenvalues j < 1 := (hB.posDef_one_sub_smul_iff (2 * t)).1 ht
   rw [multivariateGaussian_zero_eq_map_sqrt,
     mgf_map (Measurable.aemeasurable (by fun_prop)) (by fun_prop), Function.comp_def]
-  simp only [inner_toEuclideanLin_toEuclideanCLM (Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1]
+  simp only [← ContinuousLinearMap.coe_coe, Matrix.coe_toEuclideanCLM_eq_toEuclideanLin,
+    Matrix.inner_toEuclideanLin_toEuclideanLin, (Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1.eq]
   rw [mgf_inner_toEuclideanLin_stdGaussian hB ht',
-    Real.finsetProd_rpow _ _ (fun j _ ↦ by linarith [ht' j]) _,
-    ← hB.det_one_sub_smul (2 * t), Matrix.det_one_sub_smul_sqrt_mul_mul_sqrt hS Θ (2 * t)]
+    Real.finsetProd_rpow _ _ (fun j _ ↦ by linarith [ht' j]) _, ← hB.det_one_sub_smul (2 * t)]
 
 /-- On its exponential-integrability domain, the cumulant-generating function of the quadratic
 form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
-with covariance `S` is the real logarithm of `det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`. -/
+with covariance `S` is the real logarithm of `det (1 - (2 * t) • (√S * Θ * √S)) ^ (-1 / 2)`,
+for every `S`. -/
+theorem cgf_inner_toEuclideanLin_multivariateGaussian_sqrt (S : Matrix ι ι ℝ)
+    (hΘ : Θ.IsHermitian) (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
+    cgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =
+      Real.log ((1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).det ^ (-1 / 2 : ℝ)) := by
+  rw [cgf, mgf_inner_toEuclideanLin_multivariateGaussian_sqrt S hΘ ht]
+
+/-- On its exponential-integrability domain, the moment-generating function of the quadratic
+form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
+with positive-semidefinite covariance `S` is `det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`. -/
+theorem mgf_inner_toEuclideanLin_multivariateGaussian (hS : S.PosSemidef) (hΘ : Θ.IsHermitian)
+    (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
+    mgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =
+      (1 - (2 * t) • (Θ * S)).det ^ (-1 / 2 : ℝ) := by
+  rw [mgf_inner_toEuclideanLin_multivariateGaussian_sqrt S hΘ ht,
+    Matrix.det_one_sub_smul_sqrt_mul_mul_sqrt hS Θ (2 * t)]
+
+/-- On its exponential-integrability domain, the cumulant-generating function of the quadratic
+form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
+with positive-semidefinite covariance `S` is the real logarithm of
+`det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`. -/
 theorem cgf_inner_toEuclideanLin_multivariateGaussian (hS : S.PosSemidef)
     (hΘ : Θ.IsHermitian) (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
     cgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =

--- a/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
@@ -240,7 +240,7 @@ theorem mem_integrableExpSet_inner_toEuclideanLin_multivariateGaussian_iff (S : 
   simp only [integrableExpSet, Set.mem_ofPred_eq]
   rw [integrable_map_measure (by fun_prop) (Measurable.aemeasurable (by fun_prop)),
     Function.comp_def]
-  simp only [inner_toEuclideanLin_toEuclideanCLM (Matrix.isHermitian_sqrt S)]
+  simp only [inner_toEuclideanLin_toEuclideanCLM (Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1]
 
 /-- On its exponential-integrability domain, the moment-generating function of the quadratic
 form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
@@ -253,7 +253,7 @@ theorem mgf_inner_toEuclideanLin_multivariateGaussian (hS : S.PosSemidef) (hΘ :
   have ht' : ∀ j, 2 * t * hB.eigenvalues j < 1 := (hB.posDef_one_sub_smul_iff (2 * t)).1 ht
   rw [multivariateGaussian_zero_eq_map_sqrt,
     mgf_map (Measurable.aemeasurable (by fun_prop)) (by fun_prop), Function.comp_def]
-  simp only [inner_toEuclideanLin_toEuclideanCLM (Matrix.isHermitian_sqrt S)]
+  simp only [inner_toEuclideanLin_toEuclideanCLM (Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1]
   rw [mgf_inner_toEuclideanLin_stdGaussian hB ht',
     Real.finsetProd_rpow _ _ (fun j _ ↦ by linarith [ht' j]) _,
     ← hB.det_one_sub_smul (2 * t), Matrix.det_one_sub_smul_sqrt_mul_mul_sqrt hS Θ (2 * t)]

--- a/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
@@ -1,0 +1,272 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.Distributions.Gaussian.Multivariate
+public import TauCeti.Analysis.Matrix.Spectrum
+public import TauCeti.Analysis.Matrix.Sqrt
+public import TauCeti.Probability.Distributions.Gaussian.ChiSquared
+
+/-!
+# Moment-generating functions of Gaussian quadratic forms
+
+Let `S` be a positive-semidefinite covariance matrix and `Θ` a real symmetric matrix. This file
+determines exactly when the quadratic statistic `x ↦ ⟪x, Θ x⟫` of a centred multivariate
+Gaussian vector has finite exponential moments of order `t`, and computes its moment-generating
+function there:
+
+* the integrand is integrable exactly when `1 - (2 * t) • (√S * Θ * √S)` is positive
+  definite, where `√S = CFC.sqrt S`; and
+* on that domain the moment-generating function is `det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`.
+
+**The proof.** The law `multivariateGaussian 0 S` is the image of the standard Gaussian under
+`√S`, which turns the statistic into the quadratic form of the symmetric sandwich
+`√S * Θ * √S`. Rotating the standard Gaussian into the eigenbasis of that sandwich, with
+eigenvalues `λ j`, turns the quadratic form into `∑ j, λ j * c j ^ 2` for independent standard
+Gaussian coordinates `c j`. Each summand is a multiple of a chi-squared variable with one degree
+of freedom, whose moment-generating function is `(1 - 2 * s) ^ (-1 / 2)` exactly for
+`s < 1 / 2`, and Fubini's theorem on the product measure multiplies the factors. The domain
+condition `∀ j, 2 * t * λ j < 1` is
+positive definiteness of the pencil `1 - (2 * t) • (√S * Θ * √S)`, and the product of the
+factors is a power of its determinant, which Sylvester's identity identifies with
+`det (1 - (2 * t) • (Θ * S))`.
+
+The one-dimensional building blocks are stated separately, first for a single standard Gaussian
+coordinate and then for a finite product of them.
+
+## Main results
+
+* `TauCeti.mem_integrableExpSet_inner_toEuclideanLin_multivariateGaussian_iff` — the exact
+  exponential-integrability domain of a Gaussian quadratic form;
+* `TauCeti.mgf_inner_toEuclideanLin_multivariateGaussian` — its moment-generating function on
+  that domain;
+* `TauCeti.cgf_inner_toEuclideanLin_multivariateGaussian` — the cumulant-generating function, the
+  real logarithm of the same value;
+* `TauCeti.mem_integrableExpSet_inner_toEuclideanLin_stdGaussian_iff` and
+  `TauCeti.mgf_inner_toEuclideanLin_stdGaussian` — the same results for the standard Gaussian,
+  in terms of the eigenvalues of the symmetric matrix.
+
+## References
+
+* R. J. Muirhead, *Aspects of Multivariate Statistical Theory*, Wiley (1982), Theorem 1.2.6
+  (the multivariate Gaussian) and Theorem 3.2.3 (the Wishart moment-generating function, which
+  is the product of these).
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 3,
+  **Gaussian quadratic forms**.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+open scoped RealInnerProductSpace MatrixOrder Matrix.Norms.L2Operator
+
+namespace TauCeti
+
+/-! ### One standard Gaussian coordinate -/
+
+section scalar
+
+variable {w t : ℝ}
+
+/-- The exponential moment of order `t` of `w * x ^ 2` under the standard Gaussian is finite
+exactly when `2 * t * w < 1`. -/
+theorem mem_integrableExpSet_mul_sq_gaussianReal_iff (w t : ℝ) :
+    t ∈ integrableExpSet (fun x ↦ w * x ^ 2) (gaussianReal 0 1) ↔ 2 * t * w < 1 := by
+  have key : t ∈ integrableExpSet (fun x ↦ w * x ^ 2) (gaussianReal 0 1) ↔
+      t * w ∈ integrableExpSet id (Probability.chiSquaredMeasure 1) := by
+    simp only [integrableExpSet, Set.mem_ofPred_eq, id_eq]
+    rw [← Probability.gaussianReal_map_sq,
+      integrable_map_measure (by fun_prop) (by fun_prop), Function.comp_def]
+    simp only [mul_assoc]
+  rw [key, Probability.integrableExpSet_id_chiSquaredMeasure zero_lt_one, Set.mem_Iio]
+  constructor <;> intro h <;> linarith
+
+/-- The moment-generating function of `w * x ^ 2` under the standard Gaussian is
+`(1 - 2 * t * w) ^ (-1 / 2)` on its domain `2 * t * w < 1`. -/
+theorem mgf_mul_sq_gaussianReal (ht : 2 * t * w < 1) :
+    mgf (fun x ↦ w * x ^ 2) (gaussianReal 0 1) t = (1 - 2 * t * w) ^ (-1 / 2 : ℝ) := by
+  rw [mgf_const_mul, ← mgf_id_map (X := fun x : ℝ ↦ x ^ 2) (by fun_prop),
+    Probability.gaussianReal_map_sq,
+    Probability.mgf_id_chiSquaredMeasure zero_le_one (by linarith),
+    show 2 * (w * t) = 2 * t * w by ring]
+  norm_num
+
+end scalar
+
+/-! ### Independent standard Gaussian coordinates -/
+
+section pi
+
+variable {ι : Type*} [Fintype ι] {w : ι → ℝ} {t : ℝ}
+
+/-- Under a product measure the exponential of a weighted sum of squares factors over the
+coordinates, so Fubini's theorem turns its integral into a product of one-dimensional
+moment-generating functions. No integrability hypothesis is needed: off the common domain both
+sides are zero. -/
+private lemma mgf_sum_mul_sq_pi_gaussianReal_eq_prod (w : ι → ℝ) (t : ℝ) :
+    mgf (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
+        (Measure.pi fun _ : ι ↦ gaussianReal 0 1) t =
+      ∏ j, mgf (fun u : ℝ ↦ w j * u ^ 2) (gaussianReal 0 1) t := by
+  simp only [mgf, Finset.mul_sum, Real.exp_sum]
+  exact integral_fintype_prod_eq_prod fun j (u : ℝ) ↦ Real.exp (t * (w j * u ^ 2))
+
+/-- The exponential moment of order `t` of the weighted sum of squares `∑ j, w j * c j ^ 2` of
+independent standard Gaussian coordinates is finite exactly when `2 * t * w j < 1` for every
+`j`. -/
+theorem mem_integrableExpSet_sum_mul_sq_pi_gaussianReal_iff (w : ι → ℝ) (t : ℝ) :
+    t ∈ integrableExpSet (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
+        (Measure.pi fun _ : ι ↦ gaussianReal 0 1) ↔
+      ∀ j, 2 * t * w j < 1 := by
+  have hpos (j : ι) :
+      0 < mgf (fun u : ℝ ↦ w j * u ^ 2) (gaussianReal 0 1) t ↔ 2 * t * w j < 1 := by
+    rw [mgf_pos_iff]
+    exact mem_integrableExpSet_mul_sq_gaussianReal_iff (w j) t
+  have hmem : t ∈ integrableExpSet (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
+      (Measure.pi fun _ : ι ↦ gaussianReal 0 1) ↔
+      0 < ∏ j, mgf (fun u : ℝ ↦ w j * u ^ 2) (gaussianReal 0 1) t := by
+    rw [← mgf_sum_mul_sq_pi_gaussianReal_eq_prod]
+    exact mgf_pos_iff.symm
+  rw [hmem]
+  refine ⟨fun h j ↦ (hpos j).1 (mgf_nonneg.lt_of_ne' fun hj ↦ ?_),
+    fun h ↦ Finset.prod_pos fun j _ ↦ (hpos j).2 (h j)⟩
+  exact absurd (Finset.prod_eq_zero (Finset.mem_univ j) hj) h.ne'
+
+/-- The moment-generating function of the weighted sum of squares `∑ j, w j * c j ^ 2` of
+independent standard Gaussian coordinates is `∏ j, (1 - 2 * t * w j) ^ (-1 / 2)` on its
+domain. -/
+theorem mgf_sum_mul_sq_pi_gaussianReal (ht : ∀ j, 2 * t * w j < 1) :
+    mgf (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
+        (Measure.pi fun _ : ι ↦ gaussianReal 0 1) t =
+      ∏ j, (1 - 2 * t * w j) ^ (-1 / 2 : ℝ) := by
+  rw [mgf_sum_mul_sq_pi_gaussianReal_eq_prod]
+  exact Finset.prod_congr rfl fun j _ ↦ mgf_mul_sq_gaussianReal (ht j)
+
+end pi
+
+/-! ### The standard Gaussian vector -/
+
+section stdGaussian
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι] {B : Matrix ι ι ℝ} (hB : B.IsHermitian)
+  {t : ℝ}
+include hB
+
+/-- The exponential moment of order `t` of the quadratic form of a real symmetric matrix `B`
+under the standard Gaussian vector is finite exactly when `2 * t * λ < 1` for every eigenvalue
+`λ` of `B`. -/
+theorem mem_integrableExpSet_inner_toEuclideanLin_stdGaussian_iff (t : ℝ) :
+    t ∈ integrableExpSet (fun x ↦ ⟪x, B.toEuclideanLin x⟫)
+        (stdGaussian (EuclideanSpace ℝ ι)) ↔
+      ∀ j, 2 * t * hB.eigenvalues j < 1 := by
+  rw [← mem_integrableExpSet_sum_mul_sq_pi_gaussianReal_iff hB.eigenvalues t]
+  simp only [integrableExpSet, Set.mem_ofPred_eq]
+  rw [stdGaussian_eq_map_pi_orthonormalBasis hB.eigenvectorBasis,
+    integrable_map_measure (by fun_prop) (Measurable.aemeasurable (by fun_prop)),
+    Function.comp_def]
+  simp only [hB.inner_toEuclideanLin_sum_smul_eigenvectorBasis]
+
+/-- The moment-generating function of the quadratic form of a real symmetric matrix `B` under
+the standard Gaussian vector is `∏ j, (1 - 2 * t * λ j) ^ (-1 / 2)` over the eigenvalues `λ j`
+of `B`, on its domain. -/
+theorem mgf_inner_toEuclideanLin_stdGaussian (ht : ∀ j, 2 * t * hB.eigenvalues j < 1) :
+    mgf (fun x ↦ ⟪x, B.toEuclideanLin x⟫) (stdGaussian (EuclideanSpace ℝ ι)) t =
+      ∏ j, (1 - 2 * t * hB.eigenvalues j) ^ (-1 / 2 : ℝ) := by
+  rw [← mgf_sum_mul_sq_pi_gaussianReal ht,
+    stdGaussian_eq_map_pi_orthonormalBasis hB.eigenvectorBasis,
+    mgf_map (Measurable.aemeasurable (by fun_prop)) (by fun_prop), Function.comp_def]
+  simp only [hB.inner_toEuclideanLin_sum_smul_eigenvectorBasis]
+
+end stdGaussian
+
+/-! ### The centred multivariate Gaussian vector -/
+
+section multivariateGaussian
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι] {S Θ : Matrix ι ι ℝ} {t : ℝ}
+
+/-- A centred multivariate Gaussian law is the image of the standard Gaussian under the square
+root of its covariance matrix. -/
+theorem multivariateGaussian_zero_eq_map_sqrt (S : Matrix ι ι ℝ) :
+    multivariateGaussian 0 S =
+      (stdGaussian (EuclideanSpace ℝ ι)).map
+        (Matrix.toEuclideanCLM (𝕜 := ℝ) (CFC.sqrt S)) := by
+  simp [multivariateGaussian]
+
+open Matrix in
+/-- Over the reals the quadratic form of a matrix is the dot product against the matrix-vector
+product. -/
+private lemma inner_toEuclideanLin_eq_dotProduct (A : Matrix ι ι ℝ)
+    (x : EuclideanSpace ℝ ι) : ⟪x, A.toEuclideanLin x⟫ = x ⬝ᵥ A *ᵥ x :=
+  Matrix.inner_toEuclideanCLM A x x
+
+open Matrix in
+/-- Pulling the quadratic form of `Θ` back along a symmetric matrix `R` gives the quadratic form
+of the symmetric sandwich `R * Θ * R`. -/
+private lemma inner_toEuclideanLin_toEuclideanCLM {R : Matrix ι ι ℝ} (hR : R.IsHermitian)
+    (Θ : Matrix ι ι ℝ) (y : EuclideanSpace ℝ ι) :
+    ⟪Matrix.toEuclideanCLM (𝕜 := ℝ) R y,
+        Θ.toEuclideanLin (Matrix.toEuclideanCLM (𝕜 := ℝ) R y)⟫ =
+      ⟪y, (R * Θ * R).toEuclideanLin y⟫ := by
+  have hRT : Rᵀ = R := by
+    rw [← Matrix.conjTranspose_eq_transpose_of_trivial]
+    exact hR
+  have hswap (u v : ι → ℝ) : (R *ᵥ v) ⬝ᵥ u = v ⬝ᵥ R *ᵥ u := by
+    rw [Matrix.dotProduct_mulVec, ← Matrix.mulVec_transpose, hRT]
+  rw [inner_toEuclideanLin_eq_dotProduct, inner_toEuclideanLin_eq_dotProduct,
+    Matrix.ofLp_toEuclideanCLM, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
+  exact hswap _ _
+
+/-- The exponential moment of order `t` of the quadratic form `x ↦ ⟪x, Θ x⟫` of a real
+symmetric matrix `Θ` under the centred multivariate Gaussian with covariance `S` is finite
+exactly when the pencil `1 - (2 * t) • (√S * Θ * √S)` is positive definite.
+
+No hypothesis on `S` is needed: for a covariance matrix that is not positive semidefinite,
+Mathlib's `CFC.sqrt S` is zero, the pencil is the identity, and the law is the Dirac measure
+at the origin. -/
+theorem mem_integrableExpSet_inner_toEuclideanLin_multivariateGaussian_iff (S : Matrix ι ι ℝ)
+    (hΘ : Θ.IsHermitian) (t : ℝ) :
+    t ∈ integrableExpSet (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫)
+        (multivariateGaussian 0 S) ↔
+      (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef := by
+  have hB := Matrix.isHermitian_sqrt_mul_mul_sqrt S hΘ
+  rw [hB.posDef_one_sub_smul_iff,
+    ← mem_integrableExpSet_inner_toEuclideanLin_stdGaussian_iff hB t,
+    multivariateGaussian_zero_eq_map_sqrt]
+  simp only [integrableExpSet, Set.mem_ofPred_eq]
+  rw [integrable_map_measure (by fun_prop) (Measurable.aemeasurable (by fun_prop)),
+    Function.comp_def]
+  simp only [inner_toEuclideanLin_toEuclideanCLM (Matrix.isHermitian_sqrt S)]
+
+/-- On its exponential-integrability domain, the moment-generating function of the quadratic
+form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
+with covariance `S` is `det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`. -/
+theorem mgf_inner_toEuclideanLin_multivariateGaussian (hS : S.PosSemidef) (hΘ : Θ.IsHermitian)
+    (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
+    mgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =
+      (1 - (2 * t) • (Θ * S)).det ^ (-1 / 2 : ℝ) := by
+  have hB := Matrix.isHermitian_sqrt_mul_mul_sqrt S hΘ
+  have ht' : ∀ j, 2 * t * hB.eigenvalues j < 1 := (hB.posDef_one_sub_smul_iff (2 * t)).1 ht
+  rw [multivariateGaussian_zero_eq_map_sqrt,
+    mgf_map (Measurable.aemeasurable (by fun_prop)) (by fun_prop), Function.comp_def]
+  simp only [inner_toEuclideanLin_toEuclideanCLM (Matrix.isHermitian_sqrt S)]
+  rw [mgf_inner_toEuclideanLin_stdGaussian hB ht',
+    Real.finsetProd_rpow _ _ (fun j _ ↦ by linarith [ht' j]) _,
+    ← hB.det_one_sub_smul (2 * t), Matrix.det_one_sub_smul_sqrt_mul_mul_sqrt hS Θ (2 * t)]
+
+/-- On its exponential-integrability domain, the cumulant-generating function of the quadratic
+form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
+with covariance `S` is the real logarithm of `det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`. -/
+theorem cgf_inner_toEuclideanLin_multivariateGaussian (hS : S.PosSemidef)
+    (hΘ : Θ.IsHermitian) (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
+    cgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =
+      Real.log ((1 - (2 * t) • (Θ * S)).det ^ (-1 / 2 : ℝ)) := by
+  rw [cgf, mgf_inner_toEuclideanLin_multivariateGaussian hS hΘ ht]
+
+end multivariateGaussian
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
@@ -239,7 +239,7 @@ theorem mgf_inner_toEuclideanLin_multivariateGaussian (hS : S.PosSemidef) (hΘ :
     mgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =
       (1 - (2 * t) • (Θ * S)).det ^ (-1 / 2 : ℝ) := by
   rw [mgf_inner_toEuclideanLin_multivariateGaussian_sqrt S hΘ ht,
-    Matrix.det_one_sub_smul_sqrt_mul_mul_sqrt hS Θ (2 * t)]
+    hS.det_one_sub_smul_sqrt_mul_mul_sqrt Θ (2 * t)]
 
 /-- On its exponential-integrability domain, the cumulant-generating function of the quadratic
 form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian

--- a/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
@@ -24,8 +24,9 @@ exponential moments of order `t`, and computes its moment-generating function th
   `det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`.
 
 The same results are stated for the standard Gaussian vector, in terms of the eigenvalues of the
-symmetric matrix, and for one and for finitely many independent standard Gaussian coordinates,
-where the quadratic form is a weighted sum of squares.
+symmetric matrix. The one-dimensional building blocks, the exponential moments of a weighted sum
+of squares of independent standard Gaussian coordinates, live in
+`TauCeti.Probability.Distributions.Gaussian.ChiSquared`.
 
 ## Main results
 
@@ -36,14 +37,11 @@ where the quadratic form is a weighted sum of squares.
   that domain, in terms of the sandwich `√S * Θ * √S` and, for positive-semidefinite `S`, of
   `Θ * S`;
 * `TauCeti.cgf_inner_toEuclideanLin_multivariateGaussian_sqrt` and
-  `TauCeti.cgf_inner_toEuclideanLin_multivariateGaussian` — the cumulant-generating function, the
-  real logarithm of the same values;
+  `TauCeti.cgf_inner_toEuclideanLin_multivariateGaussian` — the cumulant-generating function,
+  `-1 / 2` times the real logarithm of the same determinants;
 * `TauCeti.mem_integrableExpSet_inner_toEuclideanLin_stdGaussian_iff` and
   `TauCeti.mgf_inner_toEuclideanLin_stdGaussian` — the same results for the standard Gaussian,
-  in terms of the eigenvalues of the symmetric matrix;
-* `TauCeti.mgf_sum_mul_sq_pi_gaussianReal_eq_prod` — the moment-generating function of a
-  weighted sum of squares of independent standard Gaussian coordinates factors over the
-  coordinates, for every `t`.
+  in terms of the eigenvalues of the symmetric matrix.
 
 ## References
 
@@ -61,87 +59,6 @@ open scoped RealInnerProductSpace MatrixOrder Matrix.Norms.L2Operator
 
 namespace TauCeti
 
-/-! ### One standard Gaussian coordinate -/
-
-section scalar
-
-variable {w t : ℝ}
-
-/-- The exponential moment of order `t` of `w * x ^ 2` under the standard Gaussian is finite
-exactly when `2 * t * w < 1`. -/
-theorem mem_integrableExpSet_mul_sq_gaussianReal_iff (w t : ℝ) :
-    t ∈ integrableExpSet (fun x ↦ w * x ^ 2) (gaussianReal 0 1) ↔ 2 * t * w < 1 := by
-  have key : t ∈ integrableExpSet (fun x ↦ w * x ^ 2) (gaussianReal 0 1) ↔
-      t * w ∈ integrableExpSet id (Probability.chiSquaredMeasure 1) := by
-    simp only [integrableExpSet, Set.mem_ofPred_eq, id_eq]
-    rw [← Probability.gaussianReal_map_sq,
-      integrable_map_measure (by fun_prop) (by fun_prop), Function.comp_def]
-    simp only [mul_assoc]
-  rw [key, Probability.integrableExpSet_id_chiSquaredMeasure zero_lt_one, Set.mem_Iio]
-  constructor <;> intro h <;> linarith
-
-/-- The moment-generating function of `w * x ^ 2` under the standard Gaussian is
-`(1 - 2 * t * w) ^ (-1 / 2)` on its domain `2 * t * w < 1`. -/
-theorem mgf_mul_sq_gaussianReal (ht : 2 * t * w < 1) :
-    mgf (fun x ↦ w * x ^ 2) (gaussianReal 0 1) t = (1 - 2 * t * w) ^ (-1 / 2 : ℝ) := by
-  rw [mgf_const_mul, ← mgf_id_map (X := fun x : ℝ ↦ x ^ 2) (by fun_prop),
-    Probability.gaussianReal_map_sq,
-    Probability.mgf_id_chiSquaredMeasure zero_le_one (by linarith),
-    mul_comm w t, ← mul_assoc]
-  norm_num
-
-end scalar
-
-/-! ### Independent standard Gaussian coordinates -/
-
-section pi
-
-variable {ι : Type*} [Fintype ι] {w : ι → ℝ} {t : ℝ}
-
-/-- Under a product measure the exponential of a weighted sum of squares factors over the
-coordinates, so Fubini's theorem turns its integral into a product of one-dimensional
-moment-generating functions. No integrability hypothesis is needed: off the common domain both
-sides are zero. -/
-theorem mgf_sum_mul_sq_pi_gaussianReal_eq_prod (w : ι → ℝ) (t : ℝ) :
-    mgf (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
-        (Measure.pi fun _ : ι ↦ gaussianReal 0 1) t =
-      ∏ j, mgf (fun u : ℝ ↦ w j * u ^ 2) (gaussianReal 0 1) t := by
-  simp only [mgf, Finset.mul_sum, Real.exp_sum]
-  exact integral_fintype_prod_eq_prod fun j (u : ℝ) ↦ Real.exp (t * (w j * u ^ 2))
-
-/-- The exponential moment of order `t` of the weighted sum of squares `∑ j, w j * c j ^ 2` of
-independent standard Gaussian coordinates is finite exactly when `2 * t * w j < 1` for every
-`j`. -/
-theorem mem_integrableExpSet_sum_mul_sq_pi_gaussianReal_iff (w : ι → ℝ) (t : ℝ) :
-    t ∈ integrableExpSet (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
-        (Measure.pi fun _ : ι ↦ gaussianReal 0 1) ↔
-      ∀ j, 2 * t * w j < 1 := by
-  have hpos (j : ι) :
-      0 < mgf (fun u : ℝ ↦ w j * u ^ 2) (gaussianReal 0 1) t ↔ 2 * t * w j < 1 := by
-    rw [mgf_pos_iff]
-    exact mem_integrableExpSet_mul_sq_gaussianReal_iff (w j) t
-  have hmem : t ∈ integrableExpSet (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
-      (Measure.pi fun _ : ι ↦ gaussianReal 0 1) ↔
-      0 < ∏ j, mgf (fun u : ℝ ↦ w j * u ^ 2) (gaussianReal 0 1) t := by
-    rw [← mgf_sum_mul_sq_pi_gaussianReal_eq_prod]
-    exact mgf_pos_iff.symm
-  rw [hmem]
-  refine ⟨fun h j ↦ (hpos j).1 (mgf_nonneg.lt_of_ne' fun hj ↦ ?_),
-    fun h ↦ Finset.prod_pos fun j _ ↦ (hpos j).2 (h j)⟩
-  exact absurd (Finset.prod_eq_zero (Finset.mem_univ j) hj) h.ne'
-
-/-- The moment-generating function of the weighted sum of squares `∑ j, w j * c j ^ 2` of
-independent standard Gaussian coordinates is `∏ j, (1 - 2 * t * w j) ^ (-1 / 2)` on its
-domain. -/
-theorem mgf_sum_mul_sq_pi_gaussianReal (ht : ∀ j, 2 * t * w j < 1) :
-    mgf (fun c : ι → ℝ ↦ ∑ j, w j * c j ^ 2)
-        (Measure.pi fun _ : ι ↦ gaussianReal 0 1) t =
-      ∏ j, (1 - 2 * t * w j) ^ (-1 / 2 : ℝ) := by
-  rw [mgf_sum_mul_sq_pi_gaussianReal_eq_prod]
-  exact Finset.prod_congr rfl fun j _ ↦ mgf_mul_sq_gaussianReal (ht j)
-
-end pi
-
 /-! ### The standard Gaussian vector -/
 
 section stdGaussian
@@ -157,12 +74,13 @@ theorem mem_integrableExpSet_inner_toEuclideanLin_stdGaussian_iff (t : ℝ) :
     t ∈ integrableExpSet (fun x ↦ ⟪x, B.toEuclideanLin x⟫)
         (stdGaussian (EuclideanSpace ℝ ι)) ↔
       ∀ j, 2 * t * hB.eigenvalues j < 1 := by
-  rw [← mem_integrableExpSet_sum_mul_sq_pi_gaussianReal_iff hB.eigenvalues t]
+  rw [← Probability.mem_integrableExpSet_sum_mul_sq_pi_gaussianReal_iff hB.eigenvalues t]
   simp only [integrableExpSet, Set.mem_ofPred_eq]
   rw [stdGaussian_eq_map_pi_orthonormalBasis hB.eigenvectorBasis,
     integrable_map_measure (by fun_prop) (Measurable.aemeasurable (by fun_prop)),
     Function.comp_def]
-  simp only [hB.inner_toEuclideanLin_sum_smul_eigenvectorBasis]
+  simp only [hB.inner_toEuclideanLin_sum_smul_eigenvectorBasis, RCLike.ofReal_real_eq_id, id_eq,
+    Real.norm_eq_abs, sq_abs]
 
 /-- The moment-generating function of the quadratic form of a real symmetric matrix `B` under
 the standard Gaussian vector is `∏ j, (1 - 2 * t * λ j) ^ (-1 / 2)` over the eigenvalues `λ j`
@@ -170,10 +88,11 @@ of `B`, on its domain. -/
 theorem mgf_inner_toEuclideanLin_stdGaussian (ht : ∀ j, 2 * t * hB.eigenvalues j < 1) :
     mgf (fun x ↦ ⟪x, B.toEuclideanLin x⟫) (stdGaussian (EuclideanSpace ℝ ι)) t =
       ∏ j, (1 - 2 * t * hB.eigenvalues j) ^ (-1 / 2 : ℝ) := by
-  rw [← mgf_sum_mul_sq_pi_gaussianReal ht,
+  rw [← Probability.mgf_sum_mul_sq_pi_gaussianReal ht,
     stdGaussian_eq_map_pi_orthonormalBasis hB.eigenvectorBasis,
     mgf_map (Measurable.aemeasurable (by fun_prop)) (by fun_prop), Function.comp_def]
-  simp only [hB.inner_toEuclideanLin_sum_smul_eigenvectorBasis]
+  simp only [hB.inner_toEuclideanLin_sum_smul_eigenvectorBasis, RCLike.ofReal_real_eq_id, id_eq,
+    Real.norm_eq_abs, sq_abs]
 
 end stdGaussian
 
@@ -198,12 +117,11 @@ theorem mem_integrableExpSet_inner_toEuclideanLin_multivariateGaussian_iff (S : 
   have hB := Matrix.isHermitian_sqrt_mul_mul_sqrt S hΘ
   rw [hB.posDef_one_sub_smul_iff,
     ← mem_integrableExpSet_inner_toEuclideanLin_stdGaussian_iff hB t,
-    multivariateGaussian_zero_eq_map_sqrt]
+    multivariateGaussian_zero_eq_map_stdGaussian_sqrt]
   simp only [integrableExpSet, Set.mem_ofPred_eq]
   rw [integrable_map_measure (by fun_prop) (Measurable.aemeasurable (by fun_prop)),
     Function.comp_def]
-  simp only [← ContinuousLinearMap.coe_coe, Matrix.coe_toEuclideanCLM_eq_toEuclideanLin,
-    Matrix.inner_toEuclideanLin_toEuclideanLin, (Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1.eq]
+  simp only [Matrix.inner_toEuclideanCLM_sqrt_toEuclideanLin]
 
 /-- On its exponential-integrability domain, the moment-generating function of the quadratic
 form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
@@ -214,22 +132,22 @@ theorem mgf_inner_toEuclideanLin_multivariateGaussian_sqrt (S : Matrix ι ι ℝ
       (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).det ^ (-1 / 2 : ℝ) := by
   have hB := Matrix.isHermitian_sqrt_mul_mul_sqrt S hΘ
   have ht' : ∀ j, 2 * t * hB.eigenvalues j < 1 := (hB.posDef_one_sub_smul_iff (2 * t)).1 ht
-  rw [multivariateGaussian_zero_eq_map_sqrt,
+  rw [multivariateGaussian_zero_eq_map_stdGaussian_sqrt,
     mgf_map (Measurable.aemeasurable (by fun_prop)) (by fun_prop), Function.comp_def]
-  simp only [← ContinuousLinearMap.coe_coe, Matrix.coe_toEuclideanCLM_eq_toEuclideanLin,
-    Matrix.inner_toEuclideanLin_toEuclideanLin, (Matrix.LE.le.posSemidef (CFC.sqrt_nonneg S)).1.eq]
+  simp only [Matrix.inner_toEuclideanCLM_sqrt_toEuclideanLin]
+  have hdet := hB.det_one_sub_smul (2 * t)
+  simp only [RCLike.ofReal_real_eq_id, id_eq] at hdet
   rw [mgf_inner_toEuclideanLin_stdGaussian hB ht',
-    Real.finsetProd_rpow _ _ (fun j _ ↦ by linarith [ht' j]) _, ← hB.det_one_sub_smul (2 * t)]
+    Real.finsetProd_rpow _ _ (fun j _ ↦ by linarith [ht' j]) _, ← hdet]
 
 /-- On its exponential-integrability domain, the cumulant-generating function of the quadratic
 form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
-with covariance `S` is the real logarithm of `det (1 - (2 * t) • (√S * Θ * √S)) ^ (-1 / 2)`,
-for every `S`. -/
+with covariance `S` is `-1 / 2 * log (det (1 - (2 * t) • (√S * Θ * √S)))`, for every `S`. -/
 theorem cgf_inner_toEuclideanLin_multivariateGaussian_sqrt (S : Matrix ι ι ℝ)
     (hΘ : Θ.IsHermitian) (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
     cgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =
-      Real.log ((1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).det ^ (-1 / 2 : ℝ)) := by
-  rw [cgf, mgf_inner_toEuclideanLin_multivariateGaussian_sqrt S hΘ ht]
+      -1 / 2 * Real.log (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).det := by
+  rw [cgf, mgf_inner_toEuclideanLin_multivariateGaussian_sqrt S hΘ ht, Real.log_rpow ht.det_pos]
 
 /-- On its exponential-integrability domain, the moment-generating function of the quadratic
 form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
@@ -239,17 +157,17 @@ theorem mgf_inner_toEuclideanLin_multivariateGaussian (hS : S.PosSemidef) (hΘ :
     mgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =
       (1 - (2 * t) • (Θ * S)).det ^ (-1 / 2 : ℝ) := by
   rw [mgf_inner_toEuclideanLin_multivariateGaussian_sqrt S hΘ ht,
-    hS.det_one_sub_smul_sqrt_mul_mul_sqrt Θ (2 * t)]
+    hS.det_one_sub_smul_sqrt_mul_mul_sqrt_eq_det_one_sub_smul_mul Θ (2 * t)]
 
 /-- On its exponential-integrability domain, the cumulant-generating function of the quadratic
 form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
-with positive-semidefinite covariance `S` is the real logarithm of
-`det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`. -/
+with positive-semidefinite covariance `S` is `-1 / 2 * log (det (1 - (2 * t) • (Θ * S)))`. -/
 theorem cgf_inner_toEuclideanLin_multivariateGaussian (hS : S.PosSemidef)
     (hΘ : Θ.IsHermitian) (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
     cgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =
-      Real.log ((1 - (2 * t) • (Θ * S)).det ^ (-1 / 2 : ℝ)) := by
-  rw [cgf, mgf_inner_toEuclideanLin_multivariateGaussian hS hΘ ht]
+      -1 / 2 * Real.log (1 - (2 * t) • (Θ * S)).det := by
+  rw [cgf_inner_toEuclideanLin_multivariateGaussian_sqrt S hΘ ht,
+    hS.det_one_sub_smul_sqrt_mul_mul_sqrt_eq_det_one_sub_smul_mul Θ (2 * t)]
 
 end multivariateGaussian
 

--- a/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
@@ -49,8 +49,6 @@ of squares of independent standard Gaussian coordinates, live in
 * R. J. Muirhead, *Aspects of Multivariate Statistical Theory*, Wiley (1982), Theorem 1.2.6
   (the multivariate Gaussian) and Theorem 3.2.3 (the Wishart moment-generating function, which
   is the product of these).
-* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 3,
-  **Gaussian quadratic forms**.
 -/
 
 public section

--- a/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/QuadraticForm.lean
@@ -13,9 +13,10 @@ public import TauCeti.Probability.Distributions.Gaussian.Multivariate
 /-!
 # Moment-generating functions of Gaussian quadratic forms
 
-Let `S` be a covariance matrix and `Θ` a real symmetric matrix. This file determines exactly
-when the quadratic statistic `x ↦ ⟪x, Θ x⟫` of a centred multivariate Gaussian vector has finite
-exponential moments of order `t`, and computes its moment-generating function there:
+Let `S` be the matrix parameter of a centred multivariate Gaussian and `Θ` a real symmetric
+matrix. This file determines exactly when the quadratic statistic `x ↦ ⟪x, Θ x⟫` of that Gaussian
+vector has finite exponential moments of order `t`, and computes its moment-generating function
+there:
 
 * the integrand is integrable exactly when the pencil `1 - (2 * t) • (√S * Θ * √S)` is positive
   definite, where `√S = CFC.sqrt S`, with no hypothesis on `S`; and
@@ -48,6 +49,8 @@ of squares of independent standard Gaussian coordinates, live in
 * R. J. Muirhead, *Aspects of Multivariate Statistical Theory*, Wiley (1982), Theorem 1.2.6
   (the multivariate Gaussian) and Theorem 3.2.3 (the Wishart moment-generating function, which
   is the product of these).
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 3,
+  **Gaussian quadratic forms**.
 -/
 
 public section
@@ -103,12 +106,12 @@ section multivariateGaussian
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] {S Θ : Matrix ι ι ℝ} {t : ℝ}
 
 /-- The exponential moment of order `t` of the quadratic form `x ↦ ⟪x, Θ x⟫` of a real
-symmetric matrix `Θ` under the centred multivariate Gaussian with covariance `S` is finite
+symmetric matrix `Θ` under the centred multivariate Gaussian with matrix parameter `S` is finite
 exactly when the pencil `1 - (2 * t) • (√S * Θ * √S)` is positive definite.
 
-No hypothesis on `S` is needed: for a covariance matrix that is not positive semidefinite,
-Mathlib's `CFC.sqrt S` is zero, the pencil is the identity, and the law is the Dirac measure
-at the origin. -/
+No hypothesis on `S` is needed. For a parameter that is not positive semidefinite it is not the
+law's covariance: Mathlib's `CFC.sqrt S` is then zero, the pencil is the identity, and the law is
+the Dirac measure at the origin. -/
 theorem mem_integrableExpSet_inner_toEuclideanLin_multivariateGaussian_iff (S : Matrix ι ι ℝ)
     (hΘ : Θ.IsHermitian) (t : ℝ) :
     t ∈ integrableExpSet (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫)
@@ -125,7 +128,7 @@ theorem mem_integrableExpSet_inner_toEuclideanLin_multivariateGaussian_iff (S : 
 
 /-- On its exponential-integrability domain, the moment-generating function of the quadratic
 form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
-with covariance `S` is `det (1 - (2 * t) • (√S * Θ * √S)) ^ (-1 / 2)`, for every `S`. -/
+with matrix parameter `S` is `det (1 - (2 * t) • (√S * Θ * √S)) ^ (-1 / 2)`, for every `S`. -/
 theorem mgf_inner_toEuclideanLin_multivariateGaussian_sqrt (S : Matrix ι ι ℝ)
     (hΘ : Θ.IsHermitian) (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
     mgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =
@@ -142,7 +145,7 @@ theorem mgf_inner_toEuclideanLin_multivariateGaussian_sqrt (S : Matrix ι ι ℝ
 
 /-- On its exponential-integrability domain, the cumulant-generating function of the quadratic
 form `x ↦ ⟪x, Θ x⟫` of a real symmetric matrix `Θ` under the centred multivariate Gaussian
-with covariance `S` is `-1 / 2 * log (det (1 - (2 * t) • (√S * Θ * √S)))`, for every `S`. -/
+with matrix parameter `S` is `-1 / 2 * log (det (1 - (2 * t) • (√S * Θ * √S)))`, for every `S`. -/
 theorem cgf_inner_toEuclideanLin_multivariateGaussian_sqrt (S : Matrix ι ι ℝ)
     (hΘ : Θ.IsHermitian) (ht : (1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)).PosDef) :
     cgf (fun x ↦ ⟪x, Θ.toEuclideanLin x⟫) (multivariateGaussian 0 S) t =

--- a/TauCeti/Probability/Moments/Pi.lean
+++ b/TauCeti/Probability/Moments/Pi.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.Pi
+public import Mathlib.Probability.Moments.Basic
+public import Mathlib.Probability.Moments.IntegrableExpMul
+
+/-!
+# Moment-generating functions of sums of coordinates under a product measure
+
+A statistic of the form `x ↦ ∑ j, f j (x j)` under a finite product measure `Measure.pi μ` has
+exponential `∏ j, exp (t * f j (x j))`, so Fubini's theorem turns its moment-generating function
+into the product of the coordinate ones. Since each factor is positive exactly on its
+exponential-integrability domain, the domain of the sum is the intersection of the domains of
+the coordinates.
+
+These are the facts that turn a quadratic statistic of a Gaussian vector, written in
+eigen-coordinates, into a product of one-dimensional moment-generating functions.
+
+## Main results
+
+* `ProbabilityTheory.mgf_sum_pi` — the moment-generating function of a sum of coordinate
+  statistics factors over the coordinates, for every argument;
+* `ProbabilityTheory.integrableExpSet_sum_pi` — its exponential-integrability domain is the
+  intersection of the coordinate domains.
+-/
+
+public section
+
+open MeasureTheory
+
+namespace ProbabilityTheory
+
+variable {ι : Type*} [Fintype ι] {E : ι → Type*} [∀ i, MeasurableSpace (E i)]
+  {μ : ∀ i, Measure (E i)}
+
+/-- Under a product measure the exponential of a sum of coordinate statistics factors over the
+coordinates, so Fubini's theorem turns its integral into a product of one-dimensional
+moment-generating functions. No integrability hypothesis is needed: off the common domain both
+sides are zero. -/
+theorem mgf_sum_pi [∀ i, SigmaFinite (μ i)] (f : ∀ i, E i → ℝ) (t : ℝ) :
+    mgf (fun x ↦ ∑ j, f j (x j)) (Measure.pi μ) t = ∏ j, mgf (f j) (μ j) t := by
+  simp only [mgf, Finset.mul_sum, Real.exp_sum]
+  exact integral_fintype_prod_eq_prod fun j (u : E j) ↦ Real.exp (t * f j u)
+
+/-- Under a product of probability measures, a sum of coordinate statistics has finite
+exponential moments of order `t` exactly when every coordinate does. -/
+theorem integrableExpSet_sum_pi [∀ i, IsProbabilityMeasure (μ i)] (f : ∀ i, E i → ℝ) :
+    integrableExpSet (fun x ↦ ∑ j, f j (x j)) (Measure.pi μ) =
+      ⋂ j, integrableExpSet (f j) (μ j) := by
+  ext t
+  rw [Set.mem_iInter]
+  have hpi : t ∈ integrableExpSet (fun x ↦ ∑ j, f j (x j)) (Measure.pi μ) ↔
+      0 < ∏ j, mgf (f j) (μ j) t := by
+    rw [← mgf_sum_pi]
+    exact mgf_pos_iff.symm
+  have hj (j : ι) : t ∈ integrableExpSet (f j) (μ j) ↔ 0 < mgf (f j) (μ j) t := mgf_pos_iff.symm
+  simp only [hpi, hj]
+  refine ⟨fun h j ↦ mgf_nonneg.lt_of_ne' fun hj ↦ ?_, fun h ↦ Finset.prod_pos fun j _ ↦ h j⟩
+  exact absurd (Finset.prod_eq_zero (Finset.mem_univ j) hj) h.ne'
+
+end ProbabilityTheory

--- a/TauCeti/Probability/Moments/Pi.lean
+++ b/TauCeti/Probability/Moments/Pi.lean
@@ -23,17 +23,17 @@ eigen-coordinates, into a product of one-dimensional moment-generating functions
 
 ## Main results
 
-* `ProbabilityTheory.mgf_sum_pi` — the moment-generating function of a sum of coordinate
+* `TauCeti.mgf_sum_pi` — the moment-generating function of a sum of coordinate
   statistics factors over the coordinates, for every argument;
-* `ProbabilityTheory.integrableExpSet_sum_pi` — its exponential-integrability domain is the
+* `TauCeti.integrableExpSet_sum_pi` — its exponential-integrability domain is the
   intersection of the coordinate domains.
 -/
 
 public section
 
-open MeasureTheory
+open MeasureTheory ProbabilityTheory
 
-namespace ProbabilityTheory
+namespace TauCeti
 
 variable {ι : Type*} [Fintype ι] {E : ι → Type*} [∀ i, MeasurableSpace (E i)]
   {μ : ∀ i, Measure (E i)}
@@ -63,4 +63,4 @@ theorem integrableExpSet_sum_pi [∀ i, IsProbabilityMeasure (μ i)] (f : ∀ i,
   refine ⟨fun h j ↦ mgf_nonneg.lt_of_ne' fun hj ↦ ?_, fun h ↦ Finset.prod_pos fun j _ ↦ h j⟩
   exact absurd (Finset.prod_eq_zero (Finset.mem_univ j) hj) h.ne'
 
-end ProbabilityTheory
+end TauCeti

--- a/TauCeti/Probability/Moments/Pi.lean
+++ b/TauCeti/Probability/Moments/Pi.lean
@@ -14,9 +14,11 @@ public import Mathlib.Probability.Moments.IntegrableExpMul
 
 A statistic of the form `x ↦ ∑ j, f j (x j)` under a finite product measure `Measure.pi μ` has
 exponential `∏ j, exp (t * f j (x j))`, so Fubini's theorem turns its moment-generating function
-into the product of the coordinate ones. Since each factor is positive exactly on its
-exponential-integrability domain, the domain of the sum is the intersection of the domains of
-the coordinates.
+into the product of the coordinate ones. For a product of *probability* measures each factor is
+positive exactly on its exponential-integrability domain, so the domain of the sum is then the
+intersection of the domains of the coordinates. That step genuinely needs the coordinates to be
+probability measures: under the zero measure, for instance, the moment-generating function
+vanishes everywhere while the integrability domain is all of `ℝ`.
 
 These are the facts that turn a quadratic statistic of a Gaussian vector, written in
 eigen-coordinates, into a product of one-dimensional moment-generating functions.
@@ -25,8 +27,8 @@ eigen-coordinates, into a product of one-dimensional moment-generating functions
 
 * `TauCeti.mgf_sum_pi` — the moment-generating function of a sum of coordinate
   statistics factors over the coordinates, for every argument;
-* `TauCeti.integrableExpSet_sum_pi` — its exponential-integrability domain is the
-  intersection of the coordinate domains.
+* `TauCeti.integrableExpSet_sum_pi` — for a product of probability measures, its
+  exponential-integrability domain is the intersection of the coordinate domains.
 -/
 
 public section


### PR DESCRIPTION
This PR proves the exact exponential-integrability domain and the moment-generating function of a Gaussian quadratic form, the **Gaussian quadratic forms** target of `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5 item 3. For a covariance matrix `S` and a real symmetric `Θ`, the statistic `x ↦ ⟪x, Θ.toEuclideanLin x⟫` under `multivariateGaussian 0 S` has exponential moments of order `t` exactly when `1 - (2 * t) • (CFC.sqrt S * Θ * CFC.sqrt S)` is positive definite, with no hypothesis on `S`, and on that domain its mgf is `det (1 - (2 * t) • (√S * Θ * √S)) ^ (-1 / 2)`, which for positive-semidefinite `S` is `det (1 - (2 * t) • (Θ * S)) ^ (-1 / 2)`; the cgf is `-1 / 2` times the real logarithm of the same determinants (`mem_integrableExpSet_inner_toEuclideanLin_multivariateGaussian_iff`, `mgf_inner_toEuclideanLin_multivariateGaussian_sqrt`, `mgf_inner_toEuclideanLin_multivariateGaussian`, and the two `cgf_` versions).

The proof follows the roadmap's outline. `multivariateGaussian 0 S` is the image of `stdGaussian` under `CFC.sqrt S` (`multivariateGaussian_zero_eq_map_stdGaussian_sqrt`, placed in `Gaussian/Multivariate.lean`), which turns the statistic into the quadratic form of the symmetric sandwich `√S * Θ * √S`; `stdGaussian_eq_map_pi_orthonormalBasis` rotates the standard Gaussian into the eigenbasis of that sandwich, where the form is `∑ j, λ j * c j ^ 2` for independent standard Gaussian coordinates; each summand is a multiple of `chiSquaredMeasure 1` by `gaussianReal_map_sq`, whose mgf `(1 - 2 s) ^ (-1 / 2)` on `s < 1 / 2` is already in the repository, and Fubini multiplies the factors for every `t`, so that `mgf_pos_iff` gives both directions of the domain theorem at once. The domain condition is positive definiteness of the pencil `1 - (2 * t) • (√S * Θ * √S)`, and the product of the factors is a power of its determinant, which `Matrix.det_one_sub_mul_comm` and `CFC.sqrt_mul_sqrt_self` identify with `det (1 - (2 * t) • (Θ * S))`.

The supporting material is stated in the generality it naturally has:

- `TauCeti/Analysis/Matrix/EuclideanLin.lean` — pulling the quadratic form of `B` back along a rectangular `A` gives the quadratic form of `Aᴴ * B * A` (`Matrix.inner_toEuclideanLin_toEuclideanLin`, over any `RCLike` field).
- `TauCeti/Analysis/Matrix/Spectrum.lean` — for a Hermitian `B` over an `RCLike` field with eigenvector basis `b` and real eigenvalues `λ`: the quadratic form at `∑ j, c j • b j` is `∑ j, λ j * ‖c j‖ ^ 2`, and the real pencil `1 - c • B` is positive definite iff every `c * λ j < 1` and has determinant `∏ j, (1 - c * λ j)`.
- `TauCeti/Analysis/Matrix/Sqrt.lean` — the sandwich `√S * Θ * √S` of a Hermitian `Θ` is Hermitian (the lemma the roadmap's Layer 6 calls `isHermitian_wishartSandwich`, stated for a raw Hermitian `Θ` so that the bundled symmetric-matrix version is a one-liner), the quadratic form of `Θ` at `√S x` is that of the sandwich at `x`, and `det (1 - c • (√S * Θ * √S)) = det (1 - c • (Θ * S))` for positive-semidefinite `S`.
- `TauCeti/Probability/Moments/Pi.lean` — under a product measure, the mgf of `x ↦ ∑ j, f j (x j)` is the product of the coordinate mgfs for every `t` (`mgf_sum_pi`), and its exponential-integrability domain is the intersection of the coordinate domains (`integrableExpSet_sum_pi`).
- `TauCeti/Probability/Distributions/Gaussian/ChiSquared.lean` — the domain and mgf of `w * x ^ 2` under `gaussianReal 0 1` and of `∑ j, w j * c j ^ 2` under the product of standard Gaussians, as `@[simp]` lemmas next to `gaussianReal_map_sq`.

The standard-Gaussian versions (`mem_integrableExpSet_inner_toEuclideanLin_stdGaussian_iff`, `mgf_inner_toEuclideanLin_stdGaussian`) are exposed as well, since the Gaussian-Gram Wishart transforms of Layer 6 item 4 are products of exactly these factors over the `Fin ν` sample.

This PR builds on #5836, which freed the name `mgf_inner_toEuclideanLin_multivariateGaussian` that the roadmap reserves for this theorem. After it, Layer 5 item 3 is complete; the Gaussian density (item 2), the conditional law (item 4), the multinomial and Dirichlet families (items 5–6), and the matrix-parameter measurability target (item 7) remain. Layer 6 item 4's `mgf_trace_mul_wishartGramMeasure`, `cgf_trace_mul_wishartGramMeasure`, and their exact-domain theorem reduce to these results by `iIndepFun.mgf_sum` over the sample once the symmetric-matrix carrier of #5745 lands.

Roadmap: StandardDistributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
