### PR TITLE
refactor(HeckeRing): name the scalar's positivity-and-coprimality step in the Atkin-Lehner scaling case

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -600,25 +600,14 @@ private lemma gcd_eq_one_of_eq_mul_of_dvd_pow {x : ℤ} {N m b c : ℕ} (hbc : m
     (((Int.isCoprime_iff_gcd_eq_one.mpr hxN).pow_right (n := m)).of_isCoprime_of_dvd_right
         (by exact_mod_cast hb) |>.mul_right (Int.isCoprime_iff_gcd_eq_one.mpr hxc))
 
-/-- **The criterion survives scaling.** If `x` is the multiple `d • x₀` of an element of `Δ₀(N)`
-whose double coset the bar fixes, then the bar fixes the double coset of `x` as well. Neither
-positivity of `d` nor coprimality of `d` to `N` is assumed: both are consequences of `x` lying
-in `Δ₀(N)`. -/
--- The scalar `d` is central in `GL₂(ℚ)`, and the bar fixes it: its integral witness is diagonal,
--- and the entry swap of `atkinLehnerAntiInvolution_bar_val` moves nothing on a diagonal matrix.
--- So this is `HeckeAntiInvolution.bar_mem_doubleCoset_self_mul_of_mem_centralizer` at that
--- scalar, a central element lying in every centralizer.
---
--- The two dropped hypotheses come from `hx`: the witness of `x` is `d • A₀`, so its upper-left
--- entry is `d * A₀ 0 0`, and that entry being a unit mod `N` forces `d` coprime to `N`; while
--- `d = 0` would collapse `x` to the zero matrix, against `0 < det x`.
-theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_smul [NeZero N] (d : ℕ)
-    (x x₀ : GL (Fin 2) ℚ) (hx : x ∈ Delta0 N) (hx₀ : x₀ ∈ Delta0 N)
-    (hsmul : (x : Matrix (Fin 2) (Fin 2) ℚ) = (d : ℚ) • (x₀ : Matrix (Fin 2) (Fin 2) ℚ))
-    (hfix : (atkinLehnerAntiInvolution N).bar x₀ hx₀ ∈
-      DoubleCoset.doubleCoset x₀ ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))) :
-    (atkinLehnerAntiInvolution N).bar x hx ∈
-      DoubleCoset.doubleCoset x ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) := by
+/-- **A scalar relating two `Δ₀(N)` elements is positive and coprime to the level.** The witness
+of `x` is `d • A₀`, so its upper-left entry is `d * A₀ 0 0`, and that entry being a unit mod `N`
+forces `d` coprime to `N`; while `d = 0` would collapse `x` to the zero matrix, against
+`0 < det x`. -/
+private lemma pos_and_coprime_of_coe_eq_smul [NeZero N] (d : ℕ) (x x₀ : GL (Fin 2) ℚ)
+    (hx : x ∈ Delta0 N) (hx₀ : x₀ ∈ Delta0 N)
+    (hsmul : (x : Matrix (Fin 2) (Fin 2) ℚ) = (d : ℚ) • (x₀ : Matrix (Fin 2) (Fin 2) ℚ)) :
+    0 < d ∧ Nat.Coprime d N := by
   obtain ⟨A, hA, hxdet, -, hAunit⟩ := (mem_Delta0_iff N).mp hx
   obtain ⟨A₀, hA₀, -, -, -⟩ := (mem_Delta0_iff N).mp hx₀
   have hmat : A.map (Int.cast : ℤ → ℚ) = (d : ℚ) • A₀.map (Int.cast : ℤ → ℚ) := by
@@ -627,19 +616,35 @@ theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_smul [NeZero N] (d : �
     have h := congrFun (congrFun hmat 0) 0
     simp only [Matrix.map_apply, Matrix.smul_apply, smul_eq_mul] at h
     exact_mod_cast h
-  have hd : 0 < d := by
-    rcases Nat.eq_zero_or_pos d with rfl | h
+  refine ⟨?_, ?_⟩
+  · rcases Nat.eq_zero_or_pos d with rfl | h
     · rw [hsmul] at hxdet
       simp at hxdet
     · exact h
-  have hdN : Nat.Coprime d N := by
-    rw [← ZMod.isUnit_iff_coprime]
+  · rw [← ZMod.isUnit_iff_coprime]
     have hsplit : ((A 0 0 : ℤ) : ZMod N) = (d : ZMod N) * ((A₀ 0 0 : ℤ) : ZMod N) := by
       rw [hA00]
       push_cast
       ring
     rw [hsplit] at hAunit
     exact isUnit_of_mul_isUnit_left hAunit
+
+/-- **The criterion survives scaling.** If `x` is the multiple `d • x₀` of an element of `Δ₀(N)`
+whose double coset the bar fixes, then the bar fixes the double coset of `x` as well. Neither
+positivity of `d` nor coprimality of `d` to `N` is assumed: both are consequences of `x` lying
+in `Δ₀(N)`. -/
+-- The scalar `d` is central in `GL₂(ℚ)`, and the bar fixes it: its integral witness is diagonal,
+-- and the entry swap of `atkinLehnerAntiInvolution_bar_val` moves nothing on a diagonal matrix.
+-- So this is `HeckeAntiInvolution.bar_mem_doubleCoset_self_mul_of_mem_centralizer` at that
+-- scalar, a central element lying in every centralizer.
+theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_smul [NeZero N] (d : ℕ)
+    (x x₀ : GL (Fin 2) ℚ) (hx : x ∈ Delta0 N) (hx₀ : x₀ ∈ Delta0 N)
+    (hsmul : (x : Matrix (Fin 2) (Fin 2) ℚ) = (d : ℚ) • (x₀ : Matrix (Fin 2) (Fin 2) ℚ))
+    (hfix : (atkinLehnerAntiInvolution N).bar x₀ hx₀ ∈
+      DoubleCoset.doubleCoset x₀ ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))) :
+    (atkinLehnerAntiInvolution N).bar x hx ∈
+      DoubleCoset.doubleCoset x ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) := by
+  obtain ⟨hd, hdN⟩ := pos_and_coprime_of_coe_eq_smul N d x x₀ hx hx₀ hsmul
   set s : GL (Fin 2) ℚ := natDiagGL 2 (fun _ ↦ d) with hs_def
   have hs : s ∈ Delta0 N := natDiagGL_mem_Delta0_of_coprime N _ fun _ ↦ hdN
   have hs_wit : (s : Matrix (Fin 2) (Fin 2) ℚ) =

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -600,11 +600,11 @@ private lemma gcd_eq_one_of_eq_mul_of_dvd_pow {x : ℤ} {N m b c : ℕ} (hbc : m
     (((Int.isCoprime_iff_gcd_eq_one.mpr hxN).pow_right (n := m)).of_isCoprime_of_dvd_right
         (by exact_mod_cast hb) |>.mul_right (Int.isCoprime_iff_gcd_eq_one.mpr hxc))
 
-/-- **A scalar relating two `Δ₀(N)` elements is positive and coprime to the level.** The witness
-of `x` is `d • A₀`, so its upper-left entry is `d * A₀ 0 0`, and that entry being a unit mod `N`
-forces `d` coprime to `N`; while `d = 0` would collapse `x` to the zero matrix, against
-`0 < det x`. -/
-private lemma pos_and_coprime_of_coe_eq_smul [NeZero N] (d : ℕ) (x x₀ : GL (Fin 2) ℚ)
+/-- **A scalar relating two `Δ₀(N)` elements is positive and coprime to the level.** These are
+exactly what `atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_smul` asks of its scalar `d`
+before it can form `diag(d, d)` in `Δ₀(N)`, and both come free from `x ∈ Δ₀(N)` — which is why
+that theorem assumes neither. -/
+private lemma pos_and_coprime_of_coe_eq_smul (d : ℕ) (x x₀ : GL (Fin 2) ℚ)
     (hx : x ∈ Delta0 N) (hx₀ : x₀ ∈ Delta0 N)
     (hsmul : (x : Matrix (Fin 2) (Fin 2) ℚ) = (d : ℚ) • (x₀ : Matrix (Fin 2) (Fin 2) ℚ)) :
     0 < d ∧ Nat.Coprime d N := by
@@ -617,10 +617,12 @@ private lemma pos_and_coprime_of_coe_eq_smul [NeZero N] (d : ℕ) (x x₀ : GL (
     simp only [Matrix.map_apply, Matrix.smul_apply, smul_eq_mul] at h
     exact_mod_cast h
   refine ⟨?_, ?_⟩
+  -- `d = 0` would collapse `x` to the zero matrix, against `0 < det x`
   · rcases Nat.eq_zero_or_pos d with rfl | h
     · rw [hsmul] at hxdet
       simp at hxdet
     · exact h
+  -- the upper-left entry of `x`'s witness is `d * A₀ 0 0`, and it is a unit mod `N`
   · rw [← ZMod.isUnit_iff_coprime]
     have hsplit : ((A 0 0 : ℤ) : ZMod N) = (d : ZMod N) * ((A₀ 0 0 : ℤ) : ZMod N) := by
       rw [hA00]


### PR DESCRIPTION
`atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_smul` ran to **49 lines**, and its first
half did a single self-contained job that the theorem's own comment block already named:

> The two dropped hypotheses come from `hx`: the witness of `x` is `d • A₀`, so its
> upper-left entry is `d * A₀ 0 0`, and that entry being a unit mod `N` forces `d` coprime
> to `N`; while `d = 0` would collapse `x` to the zero matrix, against `0 < det x`.

A proof that has to explain in prose what a block of it establishes is describing a lemma
it has not named yet.

### What changed

* New `private lemma pos_and_coprime_of_coe_eq_smul`: from `x, x₀ ∈ Δ₀(N)` and
  `↑x = d • ↑x₀`, concludes `0 < d ∧ Nat.Coprime d N`. The two facts are independent —
  positivity from the determinant, coprimality from the unit-mod-`N` condition on the
  upper-left entry — but they share the destructuring of both `Δ₀(N)` memberships, so one
  lemma returning the conjunction is cheaper than two.

* That comment paragraph **moved onto the new lemma** rather than being duplicated: the
  parent should not narrate a derivation it now delegates. What remains inline in the
  parent is the centrality argument, which its remaining comment still describes accurately.

* `atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_smul` **49L → 29L**.

No statement changes: the theorem keeps its signature and every downstream user is
untouched.

### Correction

An earlier version of this description said the declaration ran to 64 lines and was one of
three in the file over a 50-line cap. That was wrong, and the error was mine: the local
script I measure with runs each declaration's span to the *next* declaration's start, so it
absorbs the following docstring and comment block. Measured to the last line of its own
proof, `_of_smul` was 49L, and no declaration in this file was over 50. The extraction still
stands on its own merits — the block was doing a nameable job and the parent is 20 lines
shorter — but it was never a cap fix, and I would rather say so than let a false premise
ride into the history.

### Verification

* `lake build TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.AtkinLehner` — clean.
* `#lint` with the 13-linter set (`checkType defsWithUnderscore deprecatedNoSince
  impossibleInstance nonClassInstance simpComm simpNF structureInType
  subsetDotNotationLinter synTaut tacticDocs unusedArguments unusedHavesSuffices`) over the
  import cone: **0 errors in 554 declarations**.
* No line over 100 characters; no trailing whitespace.

Roadmap: ModularForms

Provenance: refactor of already-merged TauCeti code; no new mathematics, so no target
marker. Swept github.com/CBirkbeck/AINTLIB @ 2baa76f742bdb4fb8ee323fabba41203bd390e08
(Apache-2.0): its `Eigenforms/AtkinLehner.lean` is a different Atkin–Lehner topic (oldform
q-expansion support), its only `bar_mem_doubleCoset` is the abstract Hecke-ring statement
under a global fixed-point hypothesis, and `diag_scalar_mem_Delta0` goes the other way — a
scalar coprime to `N` yields a `Δ₀(N)` element — rather than deriving coprimality. Nothing
was transcribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
