### PR TITLE
refactor(Fredholm): put four index lemmas in their receivers' root namespaces

### DIFF
--- a/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
+++ b/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
@@ -53,7 +53,7 @@ variable [TopologicalSpace X]
 
 /-- The Fredholm index of a continuous family of Fredholm operators is locally constant on the
 parameter space. -/
-theorem Continuous.isLocallyConstant_index {A : X → E →L[K] F}
+theorem _root_.Continuous.isLocallyConstant_index {A : X → E →L[K] F}
     (hA : Continuous A) (hFredholm : ∀ x, ContinuousLinearMap.IsFredholm (A x)) :
     IsLocallyConstant fun x ↦ ContinuousLinearMap.index (A x) := by
   rw [IsLocallyConstant.iff_eventually_eq]
@@ -63,7 +63,7 @@ theorem Continuous.isLocallyConstant_index {A : X → E →L[K] F}
 
 /-- Along a continuous family of Fredholm operators, parameters in the same preconnected set give
 operators with equal index. -/
-theorem ContinuousOn.index_eq_of_isPreconnected {A : X → E →L[K] F} {s : Set X}
+theorem _root_.ContinuousOn.index_eq_of_isPreconnected {A : X → E →L[K] F} {s : Set X}
     (hA : ContinuousOn A s) (hFredholm : ∀ x ∈ s, ContinuousLinearMap.IsFredholm (A x))
     (hs : IsPreconnected s) {x y : X} (hx : x ∈ s) (hy : y ∈ s) :
     ContinuousLinearMap.index (A x) = ContinuousLinearMap.index (A y) := by
@@ -73,14 +73,14 @@ theorem ContinuousOn.index_eq_of_isPreconnected {A : X → E →L[K] F} {s : Set
 
 /-- A continuous family of Fredholm operators over a preconnected parameter space has constant
 index. -/
-theorem Continuous.index_eq_of_preconnectedSpace [PreconnectedSpace X]
+theorem _root_.Continuous.index_eq_of_preconnectedSpace [PreconnectedSpace X]
     {A : X → E →L[K] F} (hA : Continuous A)
     (hFredholm : ∀ x, ContinuousLinearMap.IsFredholm (A x)) (x y : X) :
     ContinuousLinearMap.index (A x) = ContinuousLinearMap.index (A y) :=
   (Continuous.isLocallyConstant_index hA hFredholm).apply_eq_of_preconnectedSpace x y
 
 /-- The endpoints of a continuous path of Fredholm operators have the same index. -/
-theorem Path.index_eq {T S : E →L[K] F} (A : Path T S)
+theorem _root_.Path.index_eq {T S : E →L[K] F} (A : Path T S)
     (hFredholm : ∀ t, ContinuousLinearMap.IsFredholm (A t)) :
     ContinuousLinearMap.index T = ContinuousLinearMap.index S := by
   simpa only [A.source, A.target] using


### PR DESCRIPTION
`Analysis/Fredholm/ContinuousFamily.lean` declares these inside `namespace TauCeti`:

| line | declaration | receiver argument |
|---|---|---|
| 56 | `Continuous.isLocallyConstant_index` | `(hA : Continuous A)` |
| 66 | `ContinuousOn.index_eq_of_isPreconnected` | `(hA : ContinuousOn A s)` |
| 76 | `Continuous.index_eq_of_preconnectedSpace` | `(hA : Continuous A)` |
| 83 | `Path.index_eq` | `(A : Path T S)` |

Each therefore lands in `TauCeti.Continuous`, `TauCeti.ContinuousOn` or `TauCeti.Path` rather
than the namespace of the type it takes, so dot notation on that argument does not elaborate.
`scripts/lint-dot-notation.py` flags exactly this shape — *"A Mathlib type's namespace is
nested inside `namespace TauCeti`, so dot notation on that type does not elaborate. Move the
declaration to the type's root namespace."*

Rooting the four names restores dot notation.

**No use site changes.** Every reference is already written `Continuous.…` / `ContinuousOn.…`,
which resolved through `TauCeti` before and reaches the root directly now — including the only
out-of-file one, `CompactPerturbation.lean:146`. Nothing anywhere writes the
`TauCeti.Continuous.…` or `TauCeti.ContinuousOn.…` form, and no reference targets
`TauCeti.Path.index_eq`. None of the four names is taken in Mathlib.

**Measured with the repo's own lint:** 1020 findings before, **1016 after, 0 new**. These four
are *all* of the `Continuous`, `ContinuousOn` and `Path` findings in the tree.

`TauCeti.Path`'s other members are untouched: they take no `Path` argument, so the lint does not
flag them and they belong where they are. This moves only the declarations whose receiver type
names the namespace.

(The lint also reports its baseline has stale entries — 273 before this change, 277 after. That
file is under `scripts/`, so regenerating it is left to a human.)

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp