### PR TITLE
feat: the line family of the Kronecker quiver

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/EulerForm.lean
@@ -78,7 +78,7 @@ theorem titsForm_apply (d : Kronecker A → ℤ) :
 
 /-- The Tits form on the constant dimension vector `(1, 1)` is `2 - n`. This single value decides
 both thresholds below. -/
-private theorem titsForm_one : titsForm (Kronecker A) 1 = 2 - (Fintype.card A : ℤ) := by
+theorem titsForm_one : titsForm (Kronecker A) 1 = 2 - (Fintype.card A : ℤ) := by
   rw [titsForm_apply, Pi.one_apply, Pi.one_apply]
   ring
 

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
@@ -13,7 +13,7 @@ public import TauCeti.RepresentationTheory.Quiver.Representation.FiniteDimension
 public import TauCeti.RepresentationTheory.Quiver.Representation.Indecomposable
 
 /-!
-# The pencil of lines over the generalized Kronecker quiver
+# The line representations of the generalized Kronecker quiver
 
 Put the base field at both vertices of the generalized Kronecker quiver, let one distinguished
 arrow act by multiplication by a scalar `c` and every other arrow by the identity. This file
@@ -25,18 +25,20 @@ made of pairwise non-isomorphic indecomposables:
 Every member of the family has dimension vector `(1, 1)`. So on a quiver with at least two arrows
 the dimension vector of a finite-dimensional indecomposable **does not determine it**, and its
 Tits value is `2 - #arrows`, not `1`. Both facts are sharpness statements: the Gabriel injection
-`TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic` and the root property
+`TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic` and the real-root property
 `TauCeti.titsForm_dimVector_eq_one_of_indecomposable_of_isAcyclic` are proved for an acyclic
 quiver whose Tits form is *positive definite*, and the Kronecker quiver -- acyclic, with the
 positive semidefinite Tits form `(a - b) ^ 2` of `TauCeti.Quiver.Kronecker.titsForm_apply` --
 shows that neither survives the weakening of that hypothesis to acyclicity alone.
 
-The family is the affine chart of the `ℙ¹`-family the Kronecker quiver is known for: letting the
-two arrows of `• ⇉ •` act by a pair of scalars `(c₀, c₁)`, rescaling that pair by a unit produces
-an isomorphic representation, so the classes are the points `[c₀ : c₁]` of the projective line.
-Normalizing the non-distinguished arrows to the identity picks the chart `c₁ ≠ 0` and
-parametrizes it by `c = c₀ / c₁`; the single class it omits is the point at infinity, where the
-distinguished arrow acts by the identity and every other arrow by zero.
+The family is the affine chart of the `ℙ¹`-family the Kronecker quiver is known for, and only that
+chart: letting the two arrows of `• ⇉ •` act by a pair of scalars `(c₀, c₁)`, rescaling that pair
+by a unit produces an isomorphic representation, so the classes are the points `[c₀ : c₁]` of the
+projective line. Normalizing the non-distinguished arrows to the identity picks the chart
+`c₁ ≠ 0` and parametrizes it by `c = c₀ / c₁`. Neither the one class this omits -- the point at
+infinity, where the distinguished arrow acts by the identity and every other arrow by zero -- nor
+the exhaustiveness of the resulting list, is built here; a projective-line-indexed family and its
+classification are left to a later file.
 
 The member at `c = 0` is the smallest Jordan block `TauCeti.kroneckerJordanRep k a₁ 0` of
 `TauCeti.RepresentationTheory.Quiver.Kronecker.FiniteRepType`, up to the identification of
@@ -88,11 +90,12 @@ mixed shape.
 
 ## References
 
-This supplies the `ℙ¹`-family of indecomposables of dimension vector `(1, 1)` asked for by the
-"Kronecker quiver" worked example of
-`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`. See Derksen--Weyman, *An
-Introduction to Quiver Representations*, and Assem--Simson--Skowroński, *Elements of the
-Representation Theory of Associative Algebras I*, Ch. VIII.
+This builds the affine chart of the `ℙ¹`-family of indecomposables of dimension vector `(1, 1)`
+named by the "Kronecker quiver" worked example of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`; the projective family
+itself is not supplied here. See Derksen--Weyman, *An Introduction to Quiver Representations*, and
+Assem--Simson--Skowroński, *Elements of the Representation Theory of Associative Algebras I*,
+Ch. VIII.
 -/
 
 public section
@@ -333,7 +336,10 @@ theorem exists_indecomposable_dimVector_eq_not_nonempty_iso (k : Type u) [Field 
 
 This is the sharpness of `TauCeti.titsForm_dimVector_eq_one_of_indecomposable_of_isAcyclic`: over
 an acyclic quiver whose Tits form is only positive semidefinite, the dimension vector of an
-indecomposable need not be a root. -/
+indecomposable need not have Tits value `1`, that is, need not be a *real* root. It remains a root
+of the Kronecker quiver, an imaginary one: for two arrows `(1, 1)` is the isotropic null root of
+`Ã₁` recorded by `TauCeti.Quiver.Kronecker.titsForm_eq_zero_iff_exists_smul`, and for more arrows
+its Tits value `2 - #arrows` is negative. -/
 theorem titsForm_dimVector_kroneckerLineRep [Fintype A] :
     titsForm (Quiver.Kronecker A)
         (fun j : Quiver.Kronecker A ↦ (dimVector (kroneckerLineRep k a₁ c) j : ℤ)) =

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
@@ -1,0 +1,347 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.CategoryTheory.Preadditive.Indecomposable
+public import TauCeti.RepresentationTheory.Quiver.Kronecker.EulerForm
+public import TauCeti.RepresentationTheory.Quiver.Kronecker.Representation
+public import TauCeti.RepresentationTheory.Quiver.Representation.DimensionVector
+public import TauCeti.RepresentationTheory.Quiver.Representation.FiniteDimensional
+public import TauCeti.RepresentationTheory.Quiver.Representation.Indecomposable
+
+/-!
+# The pencil of lines over the generalized Kronecker quiver
+
+Put the base field at both vertices of the generalized Kronecker quiver, let one distinguished
+arrow act by multiplication by a scalar `c` and every other arrow by the identity. This file
+builds that representation, `TauCeti.kroneckerLineRep`, and proves that the resulting family is
+made of pairwise non-isomorphic indecomposables:
+
+`kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d ↔ c = d`.
+
+Every member of the family has dimension vector `(1, 1)`. So on a quiver with at least two arrows
+the dimension vector of a finite-dimensional indecomposable **does not determine it**, and its
+Tits value is `2 - #arrows`, not `1`. Both facts are sharpness statements: the Gabriel injection
+`TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic` and the root property
+`TauCeti.titsForm_dimVector_eq_one_of_indecomposable_of_isAcyclic` are proved for an acyclic
+quiver whose Tits form is *positive definite*, and the Kronecker quiver -- acyclic, with the
+positive semidefinite Tits form `(a - b) ^ 2` of `TauCeti.Quiver.Kronecker.titsForm_apply` --
+shows that neither survives the weakening of that hypothesis to acyclicity alone.
+
+The family is the affine chart of the `ℙ¹`-family the Kronecker quiver is known for: letting the
+two arrows of `• ⇉ •` act by a pair of scalars `(c₀, c₁)`, rescaling that pair by a unit produces
+an isomorphic representation, so the classes are the points `[c₀ : c₁]` of the projective line.
+Normalizing the non-distinguished arrows to the identity picks the chart `c₁ ≠ 0` and
+parametrizes it by `c = c₀ / c₁`; the single class it omits is the point at infinity, where the
+distinguished arrow acts by the identity and every other arrow by zero.
+
+The member at `c = 0` is the smallest Jordan block `TauCeti.kroneckerJordanRep k a₁ 0` of
+`TauCeti.RepresentationTheory.Quiver.Kronecker.FiniteRepType`, up to the identification of
+`k[X]/(X)` with `k`. That file settles the representation type of the quiver with the blocks of
+every size, which grow in dimension, and records there that the lines below would only settle it
+over an infinite base field. The point of the lines is the other one: they are infinitely many
+indecomposables *at a single dimension vector* when the field is infinite, and already two of
+them over any field at all.
+
+## Main definitions
+
+* `TauCeti.kroneckerLineRep`: the line `k` at both vertices of the generalized Kronecker quiver,
+  the distinguished arrow acting by a scalar and every other arrow by the identity.
+
+## Main results
+
+* `TauCeti.indecomposable_kroneckerLineRep`: a line representation is indecomposable, as soon as
+  some arrow other than the distinguished one exists; its endomorphisms are recorded faithfully by
+  a single scalar.
+* `TauCeti.nonempty_kroneckerLineRep_iso_iff`: **two of them are isomorphic exactly when their
+  scalars agree.**
+* `TauCeti.dimVector_kroneckerLineRep`: every line representation has dimension vector `1` at
+  both vertices.
+* `TauCeti.exists_indecomposable_dimVector_eq_not_nonempty_iso`: **outside Dynkin type the
+  dimension vector does not determine an indecomposable**: over every field, a generalized
+  Kronecker quiver with two distinct arrows carries two non-isomorphic finite-dimensional
+  indecomposables of the same dimension vector.
+* `TauCeti.titsForm_dimVector_kroneckerLineRep`: the Tits value of that common dimension vector is
+  `2 - #arrows`, which is `1` only for the `A₂` quiver.
+
+## Implementation notes
+
+`TauCeti.kroneckerLineRep` carries `@[expose]`, for the reason
+`TauCeti.RepresentationTheory.Quiver.Kronecker.Representation` records for
+`TauCeti.kroneckerRep`: a functor built by `CategoryTheory.Paths.lift` reveals its value on
+objects only through its definition, so without it every statement below reading a component of a
+morphism as a linear map on `k` fails to elaborate.
+
+Indecomposability runs through `TauCeti.indecomposable_of_injective_of_isLocalRing` at the base
+field, as the Jordan blocks do at a truncated polynomial algebra, rather than through the brick
+criterion `TauCeti.indecomposable_of_finrank_end_eq_one`: recording an endomorphism by its scalar
+is the same work either way, and the local-ring route does not also ask for the endomorphism
+*space* to be identified with `k` as a module.
+
+The private scalar recording a morphism is defined for a morphism between two line
+representations with possibly different scalars, not only for an endomorphism: the isomorphism
+classification composes it along an isomorphism and its inverse, which are morphisms of that
+mixed shape.
+
+## References
+
+This supplies the `ℙ¹`-family of indecomposables of dimension vector `(1, 1)` asked for by the
+"Kronecker quiver" worked example of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`. See Derksen--Weyman, *An
+Introduction to Quiver Representations*, and Assem--Simson--Skowroński, *Elements of the
+Representation Theory of Associative Algebras I*, Ch. VIII.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe u v
+
+variable {k : Type u} [Field k] {A : Type v}
+
+/-! ### The line representations -/
+
+-- The distinguished arrow is singled out by an `if`, so a `Decidable` instance for equality in `A`
+-- is needed; it is taken classically rather than imposed as a hypothesis on `A`, as
+-- `TauCeti.kroneckerJordanRep` does. The two lemmas below discharge the `if` in either direction,
+-- so no statement in this file mentions the instance.
+open Classical in
+variable (k) in
+/-- **The line representation of the generalized Kronecker quiver at a scalar `c`**: the base field
+at both vertices, with the arrow `a₁` acting by multiplication by `c` and every other arrow by the
+identity. -/
+@[expose]
+noncomputable def kroneckerLineRep (a₁ : A) (c : k) : QuiverRep k (Quiver.Kronecker A) :=
+  kroneckerRep k (ModuleCat.of k k) (ModuleCat.of k k)
+    fun a ↦ if a = a₁ then ModuleCat.ofHom (LinearMap.mulLeft k c) else 𝟙 _
+
+variable {a₀ a₁ : A} {c d : k}
+
+-- Not `@[simp]`: this and `TauCeti.kroneckerLineRep_map_arrowPath_of_ne` rewrite inside the
+-- `ModuleCat.Hom.hom` of the two `_apply` lemmas below, taking those left-hand sides out of
+-- simp-normal form (`simpNF`), exactly as the corresponding pair for the Jordan blocks does.
+/-- The distinguished arrow acts on a line representation by multiplication by its scalar. -/
+theorem kroneckerLineRep_map_arrowPath_self :
+    (kroneckerLineRep k a₁ c).map (Quiver.Kronecker.arrowPath a₁) =
+      ModuleCat.ofHom (LinearMap.mulLeft k c) :=
+  (kroneckerRep_map_arrowPath _ _ _ a₁).trans (ite_eq_left rfl)
+
+/-- The action of the distinguished arrow, read on an element. -/
+@[simp]
+theorem kroneckerLineRep_map_arrowPath_self_apply (x : k) :
+    ((kroneckerLineRep k a₁ c).map (Quiver.Kronecker.arrowPath a₁)).hom x = c * x := by
+  rw [kroneckerLineRep_map_arrowPath_self]
+  rfl
+
+/-- Every other arrow acts on a line representation by the identity. -/
+theorem kroneckerLineRep_map_arrowPath_of_ne (h : a₀ ≠ a₁) :
+    (kroneckerLineRep k a₁ c).map (Quiver.Kronecker.arrowPath a₀) = 𝟙 (ModuleCat.of k k) :=
+  (kroneckerRep_map_arrowPath _ _ _ a₀).trans (ite_eq_right h)
+
+/-- The action of any other arrow, read on an element. -/
+@[simp]
+theorem kroneckerLineRep_map_arrowPath_of_ne_apply (h : a₀ ≠ a₁) (x : k) :
+    ((kroneckerLineRep k a₁ c).map (Quiver.Kronecker.arrowPath a₀)).hom x = x := by
+  rw [kroneckerLineRep_map_arrowPath_of_ne (c := c) h]
+  exact ModuleCat.id_apply (ModuleCat.of k k) x
+
+/-- A line representation is finite-dimensional: both of its vertex spaces are the base field. -/
+theorem isFinDim_kroneckerLineRep :
+    IsFinDim k (Quiver.Kronecker A) (kroneckerLineRep k a₁ c) := by
+  refine isFinDim_iff.mpr fun w ↦ ?_
+  cases w <;> exact inferInstanceAs (FiniteDimensional k k)
+
+-- Not `@[simp]`: `TauCeti.dimVector_apply` already is, so `simp` unfolds `dimVector` to a
+-- `Module.finrank` before this could fire, exactly as for `TauCeti.dimVector_kroneckerJordanRep`.
+/-- **The dimension vector of a line representation is `1` at both vertices.** The whole family
+therefore sits at the single dimension vector `(1, 1)`. -/
+theorem dimVector_kroneckerLineRep (w : Quiver.Kronecker A) :
+    dimVector (kroneckerLineRep k a₁ c) w = 1 := by
+  rw [dimVector_apply]
+  cases w <;> exact Module.finrank_self k
+
+/-- A line representation is nonzero: its vertex spaces are the base field. -/
+theorem not_isZero_kroneckerLineRep :
+    ¬ IsZero (kroneckerLineRep k a₁ c) := by
+  intro hz
+  have : Subsingleton k :=
+    ModuleCat.subsingleton_of_isZero (hz.obj (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)))
+  exact false_of_nontrivial_of_subsingleton k
+
+/-! ### The morphisms between two line representations -/
+
+/-- The linear map underlying a morphism of line representations at the source vertex. -/
+private noncomputable def lineApp (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    k →ₗ[k] k :=
+  (e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom
+
+private theorem lineApp_eq (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    lineApp e = (e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom := (rfl)
+
+private theorem lineApp_zero :
+    lineApp (0 : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) = 0 := (rfl)
+
+private theorem lineApp_id : lineApp (𝟙 (kroneckerLineRep k a₁ c)) = LinearMap.id := (rfl)
+
+private theorem lineApp_comp {c' : k} (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d)
+    (e' : kroneckerLineRep k a₁ d ⟶ kroneckerLineRep k a₁ c') :
+    lineApp (e ≫ e') = (lineApp e').comp (lineApp e) := (rfl)
+
+/-- The scalar recording a morphism of line representations: the value at `1` of the linear map
+above. -/
+private noncomputable def lineScalar (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) : k :=
+  lineApp e 1
+
+private theorem lineScalar_def (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    lineScalar e = lineApp e 1 := (rfl)
+
+/-- **A morphism of line representations acts at the source by multiplication by its scalar**, that
+component being a linear endomorphism of the base field. -/
+private theorem lineApp_apply (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) (x : k) :
+    lineApp e x = x * lineScalar e := by
+  rw [lineScalar_def, ← smul_eq_mul, ← map_smul, smul_eq_mul, mul_one]
+
+private theorem lineScalar_zero :
+    lineScalar (0 : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) = 0 := by
+  rw [lineScalar_def, lineApp_zero, LinearMap.zero_apply]
+
+private theorem lineScalar_id : lineScalar (𝟙 (kroneckerLineRep k a₁ c)) = 1 := by
+  rw [lineScalar_def, lineApp_id, LinearMap.id_apply]
+
+private theorem lineScalar_comp {c' : k} (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d)
+    (e' : kroneckerLineRep k a₁ d ⟶ kroneckerLineRep k a₁ c') :
+    lineScalar (e ≫ e') = lineScalar e * lineScalar e' := by
+  have h : lineApp (e ≫ e') 1 = lineApp e' (lineApp e 1) := by
+    rw [lineApp_comp, LinearMap.comp_apply]
+  rw [lineScalar_def, h, lineApp_apply e' (lineApp e 1), ← lineScalar_def]
+
+/-- **The two components of a morphism of line representations agree**, by naturality along an
+arrow that acts as the identity on both. -/
+private theorem app_tgt_eq_app_src (h : a₀ ≠ a₁)
+    (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    e.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)) =
+      e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) := by
+  refine ModuleCat.hom_ext (LinearMap.ext fun (x : k) ↦ ?_)
+  have hnat : (e.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A))).hom
+        (((kroneckerLineRep k a₁ c).map (Quiver.Kronecker.arrowPath a₀)).hom x) =
+      ((kroneckerLineRep k a₁ d).map (Quiver.Kronecker.arrowPath a₀)).hom
+        ((e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom x) :=
+    congrArg (fun g ↦ (ModuleCat.Hom.hom g) x) (e.naturality (Quiver.Kronecker.arrowPath a₀))
+  rw [kroneckerLineRep_map_arrowPath_of_ne_apply h] at hnat
+  exact hnat.trans (kroneckerLineRep_map_arrowPath_of_ne_apply h _)
+
+/-- **A morphism of line representations is determined by its component at the source vertex**: the
+component at the target agrees with it. -/
+private theorem lineApp_ext (h : a₀ ≠ a₁)
+    {e e' : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d} (heq : lineApp e = lineApp e') :
+    e = e' := by
+  have hsrc : e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) =
+      e'.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) := ModuleCat.hom_ext heq
+  exact kroneckerRep_hom_ext hsrc
+    (by rw [app_tgt_eq_app_src h e, app_tgt_eq_app_src h e', hsrc])
+
+private theorem lineScalar_injective (h : a₀ ≠ a₁) :
+    Function.Injective
+      (lineScalar : (kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) → k) := by
+  intro e e' heq
+  refine lineApp_ext h (LinearMap.ext fun x ↦ ?_)
+  rw [lineApp_apply, lineApp_apply, heq]
+
+/-- **Naturality along the distinguished arrow**: a morphism from the line at `c` to the line at
+`d` intertwines multiplication by `c` with multiplication by `d`. -/
+private theorem lineApp_mul (h : a₀ ≠ a₁)
+    (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) (x : k) :
+    lineApp e (c * x) = d * lineApp e x := by
+  have hnat : (e.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A))).hom
+        (((kroneckerLineRep k a₁ c).map (Quiver.Kronecker.arrowPath a₁)).hom x) =
+      ((kroneckerLineRep k a₁ d).map (Quiver.Kronecker.arrowPath a₁)).hom
+        ((e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom x) :=
+    congrArg (fun g ↦ (ModuleCat.Hom.hom g) x) (e.naturality (Quiver.Kronecker.arrowPath a₁))
+  rw [kroneckerLineRep_map_arrowPath_self_apply, app_tgt_eq_app_src h e] at hnat
+  rw [lineApp_eq]
+  exact hnat.trans (kroneckerLineRep_map_arrowPath_self_apply _)
+
+/-- The scalars of the two lines agree on the scalar of any morphism between them. -/
+private theorem mul_lineScalar (h : a₀ ≠ a₁)
+    (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    c * lineScalar e = d * lineScalar e := by
+  have h1 := lineApp_mul h e 1
+  rw [mul_one, lineApp_apply, ← lineScalar_def] at h1
+  exact h1
+
+/-! ### Indecomposability and the classification -/
+
+/-- **A line representation is indecomposable, as soon as some arrow other than the distinguished
+one exists.** Its endomorphisms are recorded faithfully by their scalar in the base field, which is
+a local ring, so its only idempotent endomorphisms are `0` and the identity.
+
+The second arrow is what forces the two components of an endomorphism to agree, and it is not an
+artefact: over the `A₂` quiver of a single arrow nothing relates the two components, and the line
+at `c = 0` is there the direct sum of the two vertex simples. That quiver has only the three
+isomorphism classes counted by `TauCeti.card_skeleton_indecomposable_kronecker`, with no room for
+a family. -/
+theorem indecomposable_kroneckerLineRep (h : a₀ ≠ a₁) :
+    Indecomposable (kroneckerLineRep k a₁ c) :=
+  indecomposable_of_injective_of_isLocalRing not_isZero_kroneckerLineRep lineScalar
+    (lineScalar_injective h) lineScalar_zero lineScalar_id fun e ↦ lineScalar_comp e e
+
+/-- **Line representations at different scalars are non-isomorphic.** An isomorphism has an
+invertible scalar, and its naturality along the distinguished arrow then equates the two
+scalars. -/
+theorem eq_of_nonempty_kroneckerLineRep_iso (h : a₀ ≠ a₁)
+    (hiso : Nonempty (kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d)) : c = d := by
+  obtain ⟨e⟩ := hiso
+  have hunit : lineScalar e.hom * lineScalar e.inv = 1 := by
+    rw [← lineScalar_comp, e.hom_inv_id, lineScalar_id]
+  exact mul_right_cancel₀ (left_ne_zero_of_mul_eq_one hunit) (mul_lineScalar h e.hom)
+
+/-- **Two line representations are isomorphic exactly when their scalars agree.** So over an
+infinite field the isomorphism classes of indecomposables at the dimension vector `(1, 1)` are
+infinite in number, the affine chart of the `ℙ¹` of the Kronecker quiver. -/
+theorem nonempty_kroneckerLineRep_iso_iff (h : a₀ ≠ a₁) :
+    Nonempty (kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d) ↔ c = d :=
+  ⟨eq_of_nonempty_kroneckerLineRep_iso h, by rintro rfl; exact ⟨Iso.refl _⟩⟩
+
+/-- **Outside Dynkin type the dimension vector does not determine an indecomposable.** Over every
+field, a generalized Kronecker quiver with two distinct arrows carries two non-isomorphic
+finite-dimensional indecomposable representations with the same dimension vector, the lines at the
+scalars `0` and `1`.
+
+This is the sharpness of `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic`:
+that theorem holds over an acyclic quiver whose Tits form is positive definite, and the Kronecker
+quiver is acyclic with a Tits form that is only positive semidefinite. -/
+theorem exists_indecomposable_dimVector_eq_not_nonempty_iso (k : Type u) [Field k] {A : Type v}
+    {a₀ a₁ : A} (h : a₀ ≠ a₁) :
+    ∃ M N : QuiverRep.{u, 0, v, u} k (Quiver.Kronecker A),
+      IsFinDim k (Quiver.Kronecker A) M ∧ Indecomposable M ∧
+        IsFinDim k (Quiver.Kronecker A) N ∧ Indecomposable N ∧
+        dimVector M = dimVector N ∧ ¬ Nonempty (M ≅ N) :=
+  ⟨kroneckerLineRep k a₁ 0, kroneckerLineRep k a₁ 1, isFinDim_kroneckerLineRep,
+    indecomposable_kroneckerLineRep h, isFinDim_kroneckerLineRep,
+    indecomposable_kroneckerLineRep h,
+    funext fun w ↦ (dimVector_kroneckerLineRep w).trans (dimVector_kroneckerLineRep w).symm,
+    fun hiso ↦ zero_ne_one (eq_of_nonempty_kroneckerLineRep_iso h hiso)⟩
+
+/-- **The Tits value of the dimension vector of a line representation is `2 - #arrows`.** It is
+`1` exactly for the `A₂` quiver of a single arrow, and `0` for the Kronecker quiver `• ⇉ •`.
+
+This is the sharpness of `TauCeti.titsForm_dimVector_eq_one_of_indecomposable_of_isAcyclic`: over
+an acyclic quiver whose Tits form is only positive semidefinite, the dimension vector of an
+indecomposable need not be a root. -/
+theorem titsForm_dimVector_kroneckerLineRep [Fintype A] :
+    titsForm (Quiver.Kronecker A)
+        (fun j : Quiver.Kronecker A ↦ (dimVector (kroneckerLineRep k a₁ c) j : ℤ)) =
+      2 - Fintype.card A := by
+  have hd : (fun j : Quiver.Kronecker A ↦ (dimVector (kroneckerLineRep k a₁ c) j : ℤ)) = 1 := by
+    funext j
+    rw [dimVector_kroneckerLineRep, Nat.cast_one, Pi.one_apply]
+  rw [hd, Quiver.Kronecker.titsForm_apply, Pi.one_apply, Pi.one_apply]
+  ring
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
@@ -127,6 +127,20 @@ noncomputable def kroneckerLineRep (a₁ : A) (c : k) : QuiverRep k (Quiver.Kron
 
 variable {a₀ a₁ : A} {c d : k}
 
+/-- The source vertex of a line representation carries the base field. -/
+@[simp]
+theorem kroneckerLineRep_obj_src :
+    (kroneckerLineRep k a₁ c).obj (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) =
+      ModuleCat.of k k :=
+  kroneckerRep_obj_src _ _ _
+
+/-- The target vertex of a line representation carries the base field. -/
+@[simp]
+theorem kroneckerLineRep_obj_tgt :
+    (kroneckerLineRep k a₁ c).obj (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)) =
+      ModuleCat.of k k :=
+  kroneckerRep_obj_tgt _ _ _
+
 -- Not `@[simp]`: this and `TauCeti.kroneckerLineRep_map_arrowPath_of_ne` rewrite inside the
 -- `ModuleCat.Hom.hom` of the two `_apply` lemmas below, taking those left-hand sides out of
 -- simp-normal form (`simpNF`), exactly as the corresponding pair for the Jordan blocks does.

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
@@ -52,16 +52,22 @@ them over any field at all.
 
 * `TauCeti.kroneckerLineRep`: the line `k` at both vertices of the generalized Kronecker quiver,
   the distinguished arrow acting by a scalar and every other arrow by the identity.
-* `TauCeti.kroneckerLineScalar`: the scalar recording a morphism between two line representations,
-  the value at `1` of its component at the source vertex.
+* `TauCeti.kroneckerLineRepScalar`: the scalar recording a morphism between two line
+  representations, the value at `1` of its component at the source vertex.
+* `TauCeti.kroneckerLineRepHom`: conversely, the morphism of line representations attached to a
+  scalar intertwining the two actions of the distinguished arrow.
 
 ## Main results
 
 * `TauCeti.kroneckerLineRep_hom_app_src_apply`, `TauCeti.kroneckerLineRep_hom_ext` and
-  `TauCeti.mul_kroneckerLineScalar`: a morphism of line representations is multiplication by its
-  scalar at the source vertex; that scalar determines the morphism as soon as the distinguished
-  arrow acts invertibly or some other arrow exists, and satisfies `c * s = d * s` for the two
-  scalars `c` and `d` of its source and target.
+  `TauCeti.kroneckerLineRepScalar_intertwine`: a morphism of line representations is
+  multiplication by its scalar at the source vertex; that scalar determines the morphism as soon
+  as the distinguished arrow acts invertibly or some other arrow exists, and satisfies
+  `c * s = d * s` for the two scalars `c` and `d` of its source and target.
+* `TauCeti.kroneckerLineRepScalar_kroneckerLineRepHom` and
+  `TauCeti.kroneckerLineRepHom_kroneckerLineRepScalar`: the converse identification, on a quiver
+  carrying an arrow other than the distinguished one, of those morphisms with the scalars `s`
+  satisfying `c * s = d * s`.
 * `TauCeti.indecomposable_kroneckerLineRep`: a line representation is indecomposable as soon as
   its scalar is nonzero or some arrow other than the distinguished one exists; its endomorphisms
   are recorded faithfully by a single scalar.
@@ -69,8 +75,9 @@ them over any field at all.
   distinguished one, two of them are isomorphic exactly when their scalars agree.**
 * `TauCeti.dimVector_kroneckerLineRep`: every line representation has dimension vector `1` at
   both vertices.
-* `TauCeti.exists_indecomposable_dimVector_eq_not_nonempty_iso`: **on a generalized Kronecker
-  quiver with two distinct arrows the dimension vector does not determine an indecomposable**:
+* `TauCeti.exists_indecomposable_dimVector_eq_not_nonempty_iso_kronecker`: **on a generalized
+  Kronecker quiver with two distinct arrows the dimension vector does not determine an
+  indecomposable**:
   over every field such a quiver carries two non-isomorphic finite-dimensional indecomposables of
   the same dimension vector.
 * `TauCeti.titsForm_dimVector_kroneckerLineRep`: the Tits value of that common dimension vector is
@@ -173,32 +180,15 @@ theorem not_isZero_kroneckerLineRep :
 
 /-! ### The morphisms between two line representations -/
 
-/-- The linear map underlying a morphism of line representations at the source vertex. Reading that
-component as an endomorphism of the base field is what lets the scalar below be spoken of at all,
-so it is kept as a definition rather than inlined. -/
-private noncomputable def lineApp (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
-    k →ₗ[k] k :=
-  (e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom
-
-private theorem lineApp_zero :
-    lineApp (0 : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) = 0 := (rfl)
-
-private theorem lineApp_id : lineApp (𝟙 (kroneckerLineRep k a₁ c)) = LinearMap.id := (rfl)
-
-private theorem lineApp_comp {c' : k} (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d)
-    (e' : kroneckerLineRep k a₁ d ⟶ kroneckerLineRep k a₁ c') :
-    lineApp (e ≫ e') = (lineApp e').comp (lineApp e) := (rfl)
-
 /-- **The scalar recording a morphism of line representations**: the value at `1` of its component
 at the source vertex, that component being a linear endomorphism of the base field. The morphism is
 multiplication by this scalar at the source (`TauCeti.kroneckerLineRep_hom_app_src_apply`), the
 scalar determines the morphism whenever `TauCeti.kroneckerLineRep_hom_ext` applies, and it is
-constrained by `TauCeti.mul_kroneckerLineScalar`. -/
-noncomputable def kroneckerLineScalar (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) : k :=
-  lineApp e 1
-
-private theorem kroneckerLineScalar_def (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
-    kroneckerLineScalar e = lineApp e 1 := (rfl)
+constrained by `TauCeti.kroneckerLineRepScalar_intertwine`; conversely
+`TauCeti.kroneckerLineRepHom` builds the morphism back from a scalar meeting that constraint. -/
+noncomputable def kroneckerLineRepScalar
+    (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) : k :=
+  (e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom (1 : k)
 
 /-- **A morphism of line representations acts at the source vertex by multiplication by its
 scalar.** -/
@@ -206,32 +196,53 @@ scalar.** -/
 theorem kroneckerLineRep_hom_app_src_apply
     (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) (x : k) :
     (e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom x =
-      x * kroneckerLineScalar e := by
-  -- The rewrites need this component with its source and target read as the base field, which is
-  -- what `lineApp` records; the two statements are the same up to that reading.
-  have h : lineApp e x = x * kroneckerLineScalar e := by
-    rw [kroneckerLineScalar_def, ← smul_eq_mul, ← map_smul, smul_eq_mul, mul_one]
-  exact h
+      x * kroneckerLineRepScalar e := by
+  have hx : (e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom (x • (1 : k)) =
+      x • kroneckerLineRepScalar e := map_smul _ x (1 : k)
+  rwa [smul_eq_mul, mul_one, smul_eq_mul] at hx
 
-@[simp]
-theorem kroneckerLineScalar_zero :
-    kroneckerLineScalar (0 : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) = 0 := by
-  rw [kroneckerLineScalar_def, lineApp_zero, LinearMap.zero_apply]
+-- The three lemmas below read the component at the source vertex of the zero morphism, of the
+-- identity and of a composite. Their category-level statements
+-- `CategoryTheory.NatTrans.app_zero`, `CategoryTheory.NatTrans.id_app` and
+-- `CategoryTheory.NatTrans.comp_app` do not *rewrite* at a vertex of `Paths`, that component not
+-- being type-correct at the transparency `rw`/`simp` work at; they are therefore applied as terms,
+-- which elaborates, and the passage from the resulting morphism of `ModuleCat` to its linear map
+-- is `ModuleCat.hom_zero`, `ModuleCat.hom_id` and `ModuleCat.comp_apply`.
 
+/-- The zero morphism has scalar `0`. -/
 @[simp]
-theorem kroneckerLineScalar_id : kroneckerLineScalar (𝟙 (kroneckerLineRep k a₁ c)) = 1 := by
-  rw [kroneckerLineScalar_def, lineApp_id, LinearMap.id_apply]
+theorem kroneckerLineRepScalar_zero :
+    kroneckerLineRepScalar (0 : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) = 0 := by
+  have h : kroneckerLineRepScalar (0 : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) =
+      (ModuleCat.Hom.hom (0 : ModuleCat.of k k ⟶ ModuleCat.of k k)) (1 : k) :=
+    congrArg (fun g ↦ (ModuleCat.Hom.hom g) (1 : k))
+      (NatTrans.app_zero (F := kroneckerLineRep k a₁ c) (G := kroneckerLineRep k a₁ d)
+        (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)))
+  rw [h, ModuleCat.hom_zero, LinearMap.zero_apply]
 
+/-- The identity has scalar `1`. -/
 @[simp]
-theorem kroneckerLineScalar_comp {c' : k}
+theorem kroneckerLineRepScalar_id : kroneckerLineRepScalar (𝟙 (kroneckerLineRep k a₁ c)) = 1 := by
+  have h : kroneckerLineRepScalar (𝟙 (kroneckerLineRep k a₁ c)) =
+      (ModuleCat.Hom.hom (𝟙 (ModuleCat.of k k))) (1 : k) :=
+    congrArg (fun g ↦ (ModuleCat.Hom.hom g) (1 : k))
+      (NatTrans.id_app (kroneckerLineRep k a₁ c)
+        (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)))
+  rw [h, ModuleCat.hom_id, LinearMap.id_apply]
+
+/-- Composition multiplies the scalars. -/
+@[simp]
+theorem kroneckerLineRepScalar_comp {c' : k}
     (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d)
     (e' : kroneckerLineRep k a₁ d ⟶ kroneckerLineRep k a₁ c') :
-    kroneckerLineScalar (e ≫ e') = kroneckerLineScalar e * kroneckerLineScalar e' := by
-  have h : lineApp (e ≫ e') 1 = lineApp e' (lineApp e 1) := by
-    rw [lineApp_comp, LinearMap.comp_apply]
-  have h' : lineApp e' (lineApp e 1) = lineApp e 1 * kroneckerLineScalar e' :=
-    kroneckerLineRep_hom_app_src_apply e' (lineApp e 1)
-  rw [kroneckerLineScalar_def, h, h', ← kroneckerLineScalar_def]
+    kroneckerLineRepScalar (e ≫ e') = kroneckerLineRepScalar e * kroneckerLineRepScalar e' := by
+  have h : kroneckerLineRepScalar (e ≫ e') =
+      (e'.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom
+        (kroneckerLineRepScalar e : k) :=
+    (congrArg (fun g ↦ (ModuleCat.Hom.hom g) (1 : k))
+      (NatTrans.comp_app e e' (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)))).trans
+        (ModuleCat.comp_apply _ _ _)
+  exact h.trans (kroneckerLineRep_hom_app_src_apply e' (kroneckerLineRepScalar e))
 
 /-- **The two components of a morphism of line representations agree**, by naturality along an
 arrow that acts as the identity on both. -/
@@ -276,33 +287,100 @@ private theorem app_tgt_ext_of_ne_zero (hc : c ≠ 0)
 distinguished arrow acts invertibly or some other arrow exists. -/
 theorem kroneckerLineRep_hom_ext (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁)
     {e e' : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d}
-    (heq : kroneckerLineScalar e = kroneckerLineScalar e') : e = e' := by
-  rw [kroneckerLineScalar_def, kroneckerLineScalar_def] at heq
+    (heq : kroneckerLineRepScalar e = kroneckerLineRepScalar e') : e = e' := by
   have hsrc : e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) =
-      e'.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) :=
-    ModuleCat.hom_ext (LinearMap.ext_ring heq)
+      e'.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) := by
+    refine ModuleCat.hom_ext (LinearMap.ext fun (x : k) ↦ ?_)
+    rw [kroneckerLineRep_hom_app_src_apply, kroneckerLineRep_hom_app_src_apply, heq]
   refine kroneckerRep_hom_ext hsrc ?_
   obtain hc | ⟨a, ha⟩ := h
   · exact app_tgt_ext_of_ne_zero hc hsrc
   · rw [kroneckerLineRep_hom_app_tgt_of_ne ha e, kroneckerLineRep_hom_app_tgt_of_ne ha e', hsrc]
 
-private theorem kroneckerLineScalar_injective (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁) :
+private theorem kroneckerLineRepScalar_injective (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁) :
     Function.Injective
-      (kroneckerLineScalar : (kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) → k) :=
+      (kroneckerLineRepScalar : (kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) → k) :=
   fun _ _ heq ↦ kroneckerLineRep_hom_ext h heq
 
 /-- **The scalars of the two lines agree on the scalar of any morphism between them**, by
 naturality along the distinguished arrow. -/
-theorem mul_kroneckerLineScalar (h : a₀ ≠ a₁)
+theorem kroneckerLineRepScalar_intertwine (h : a₀ ≠ a₁)
     (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
-    c * kroneckerLineScalar e = d * kroneckerLineScalar e := by
+    c * kroneckerLineRepScalar e = d * kroneckerLineRepScalar e := by
   have hnat := app_tgt_comp_mulLeft e
   rw [kroneckerLineRep_hom_app_tgt_of_ne h e] at hnat
-  have h1 : lineApp e (c * 1) = d * lineApp e 1 :=
-    congrArg (fun g ↦ (ModuleCat.Hom.hom g) 1) hnat
-  have h2 : lineApp e c = c * kroneckerLineScalar e :=
-    kroneckerLineRep_hom_app_src_apply e c
-  rwa [mul_one, h2, ← kroneckerLineScalar_def] at h1
+  -- Reading the square at `1` gives the value of the component at `c`, which
+  -- `TauCeti.kroneckerLineRep_hom_app_src_apply` computes on the other side.
+  have h1 : (e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom (c * 1 : k) =
+      d * kroneckerLineRepScalar e :=
+    congrArg (fun g ↦ (ModuleCat.Hom.hom g) (1 : k)) hnat
+  have h2 : (c * 1 : k) * kroneckerLineRepScalar e = d * kroneckerLineRepScalar e :=
+    (kroneckerLineRep_hom_app_src_apply e (c * 1 : k)).symm.trans h1
+  rwa [mul_one] at h2
+
+/-- **Multiplication by `s` carries multiplication by `c` to multiplication by `d`** exactly when
+`c * s = d * s`: the square along the distinguished arrow, stated on the base field, where the two
+vertex spaces of a line representation are read. -/
+private theorem mulLeft_comp_mulRight {s : k} (hs : c * s = d * s) :
+    ModuleCat.ofHom (LinearMap.mulLeft k c) ≫ ModuleCat.ofHom (LinearMap.mulRight k s) =
+      ModuleCat.ofHom (LinearMap.mulRight k s) ≫ ModuleCat.ofHom (LinearMap.mulLeft k d) := by
+  refine ModuleCat.hom_ext (LinearMap.ext fun x ↦ ?_)
+  simp only [ModuleCat.hom_comp, LinearMap.comp_apply, ModuleCat.hom_ofHom,
+    LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
+  rw [mul_right_comm, hs, mul_assoc, mul_comm s x]
+
+/-- **The morphism of line representations attached to an intertwining scalar**: multiplication by
+`s` at both vertices. Every arrow other than the distinguished one acts by the identity on both
+lines, so naturality there is automatic; along the distinguished one it says exactly that `s`
+carries multiplication by `c` to multiplication by `d`. -/
+noncomputable def kroneckerLineRepHom (s : k) (hs : c * s = d * s) :
+    kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d :=
+  kroneckerHom (ModuleCat.ofHom (LinearMap.mulRight k s))
+    (ModuleCat.ofHom (LinearMap.mulRight k s)) fun a ↦ by
+      by_cases ha : a = a₁
+      · subst ha
+        rw [kroneckerLineRep_map_arrowPath_self, kroneckerLineRep_map_arrowPath_self]
+        exact mulLeft_comp_mulRight hs
+      · rw [kroneckerLineRep_map_arrowPath_of_ne ha, kroneckerLineRep_map_arrowPath_of_ne ha]
+        exact (Category.id_comp _).trans (Category.comp_id _).symm
+
+/-- At the source vertex, `TauCeti.kroneckerLineRepHom s hs` is multiplication by `s`. -/
+@[simp]
+theorem kroneckerLineRepHom_app_src (s : k) (hs : c * s = d * s) :
+    (kroneckerLineRepHom (a₁ := a₁) (c := c) (d := d) s hs).app
+        (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) =
+      ModuleCat.ofHom (LinearMap.mulRight k s) :=
+  kroneckerHom_app_src _ _ _
+
+/-- At the target vertex, `TauCeti.kroneckerLineRepHom s hs` is multiplication by `s`. -/
+@[simp]
+theorem kroneckerLineRepHom_app_tgt (s : k) (hs : c * s = d * s) :
+    (kroneckerLineRepHom (a₁ := a₁) (c := c) (d := d) s hs).app
+        (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)) =
+      ModuleCat.ofHom (LinearMap.mulRight k s) :=
+  kroneckerHom_app_tgt _ _ _
+
+/-- The scalar of `TauCeti.kroneckerLineRepHom s hs` is `s`. -/
+@[simp]
+theorem kroneckerLineRepScalar_kroneckerLineRepHom (s : k) (hs : c * s = d * s) :
+    kroneckerLineRepScalar (kroneckerLineRepHom (a₁ := a₁) (c := c) (d := d) s hs) = s := by
+  have h : kroneckerLineRepScalar (kroneckerLineRepHom (a₁ := a₁) (c := c) (d := d) s hs) =
+      1 * s :=
+    congrArg (fun g ↦ (ModuleCat.Hom.hom g) (1 : k))
+      (kroneckerLineRepHom_app_src (a₁ := a₁) (c := c) (d := d) s hs)
+  rw [h, one_mul]
+
+-- Not `@[simp]`: the arrow `a₀` of the hypothesis does not occur in the left-hand side, which
+-- `simpNF` rejects.
+/-- **Every morphism of line representations is the one attached to its scalar.** Together with
+`TauCeti.kroneckerLineRep_hom_ext` this identifies the morphisms `kroneckerLineRep k a₁ c ⟶
+kroneckerLineRep k a₁ d`, on a quiver carrying an arrow other than the distinguished one, with the
+scalars `s` satisfying `c * s = d * s`, mirroring the pair
+`TauCeti.oneLoopRepHom_oneLoopRepScalar` / `TauCeti.oneLoopRep_hom_ext` of the loop quiver. -/
+theorem kroneckerLineRepHom_kroneckerLineRepScalar (h : a₀ ≠ a₁)
+    (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    kroneckerLineRepHom (kroneckerLineRepScalar e) (kroneckerLineRepScalar_intertwine h e) = e :=
+  kroneckerLineRep_hom_ext (Or.inr ⟨a₀, h⟩) (kroneckerLineRepScalar_kroneckerLineRepHom _ _)
 
 /-! ### Indecomposability and the classification -/
 
@@ -319,19 +397,23 @@ simples. That quiver has only the three isomorphism classes counted by
 `TauCeti.card_skeleton_indecomposable_kronecker`, with no room for a family. -/
 theorem indecomposable_kroneckerLineRep (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁) :
     Indecomposable (kroneckerLineRep k a₁ c) :=
-  indecomposable_of_injective_of_isLocalRing not_isZero_kroneckerLineRep kroneckerLineScalar
-    (kroneckerLineScalar_injective h) kroneckerLineScalar_zero kroneckerLineScalar_id
-    fun e ↦ kroneckerLineScalar_comp e e
+  indecomposable_of_injective_of_isLocalRing not_isZero_kroneckerLineRep kroneckerLineRepScalar
+    (kroneckerLineRepScalar_injective h) kroneckerLineRepScalar_zero kroneckerLineRepScalar_id
+    fun e ↦ kroneckerLineRepScalar_comp e e
 
-/-- **Line representations at different scalars are non-isomorphic.** An isomorphism has an
-invertible scalar, and its naturality along the distinguished arrow then equates the two
-scalars. -/
+/-- **On a quiver carrying an arrow `a₀` other than the distinguished one, two isomorphic line
+representations have equal scalars.** An isomorphism has an invertible scalar, and its naturality
+along the distinguished arrow then equates the two scalars. The hypothesis `a₀ ≠ a₁` is essential:
+on the `A₂` quiver of the single arrow `a₁` nothing forces the two components of a morphism to
+agree, and the lines at any two nonzero scalars are isomorphic -- by the pair of multiplications
+by `1` and by `d / c`. -/
 theorem eq_of_nonempty_kroneckerLineRep_iso (h : a₀ ≠ a₁)
     (hiso : Nonempty (kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d)) : c = d := by
   obtain ⟨e⟩ := hiso
-  have hunit : kroneckerLineScalar e.hom * kroneckerLineScalar e.inv = 1 := by
-    rw [← kroneckerLineScalar_comp, e.hom_inv_id, kroneckerLineScalar_id]
-  exact mul_right_cancel₀ (left_ne_zero_of_mul_eq_one hunit) (mul_kroneckerLineScalar h e.hom)
+  have hunit : kroneckerLineRepScalar e.hom * kroneckerLineRepScalar e.inv = 1 := by
+    rw [← kroneckerLineRepScalar_comp, e.hom_inv_id, kroneckerLineRepScalar_id]
+  exact mul_right_cancel₀ (left_ne_zero_of_mul_eq_one hunit)
+    (kroneckerLineRepScalar_intertwine h e.hom)
 
 /-- **Two line representations are isomorphic exactly when their scalars agree.** So over an
 infinite field the isomorphism classes of indecomposables at the dimension vector `(1, 1)` are
@@ -348,8 +430,8 @@ scalars `0` and `1`.
 This is the sharpness of `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic`:
 that theorem holds over an acyclic quiver whose Tits form is positive definite, and the Kronecker
 quiver is acyclic with a Tits form that is only positive semidefinite. -/
-theorem exists_indecomposable_dimVector_eq_not_nonempty_iso (k : Type u) [Field k] {A : Type v}
-    {a₀ a₁ : A} (h : a₀ ≠ a₁) :
+theorem exists_indecomposable_dimVector_eq_not_nonempty_iso_kronecker (k : Type u) [Field k]
+    {A : Type v} {a₀ a₁ : A} (h : a₀ ≠ a₁) :
     ∃ M N : QuiverRep.{u, 0, v, u} k (Quiver.Kronecker A),
       IsFinDim k (Quiver.Kronecker A) M ∧ Indecomposable M ∧
         IsFinDim k (Quiver.Kronecker A) N ∧ Indecomposable N ∧

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
@@ -52,9 +52,16 @@ them over any field at all.
 
 * `TauCeti.kroneckerLineRep`: the line `k` at both vertices of the generalized Kronecker quiver,
   the distinguished arrow acting by a scalar and every other arrow by the identity.
+* `TauCeti.kroneckerLineScalar`: the scalar recording a morphism between two line representations,
+  the value at `1` of its component at the source vertex.
 
 ## Main results
 
+* `TauCeti.kroneckerLineRep_hom_app_src_apply`, `TauCeti.kroneckerLineRep_hom_ext` and
+  `TauCeti.mul_kroneckerLineScalar`: a morphism of line representations is multiplication by its
+  scalar at the source vertex; that scalar determines the morphism as soon as the distinguished
+  arrow acts invertibly or some other arrow exists, and satisfies `c * s = d * s` for the two
+  scalars `c` and `d` of its source and target.
 * `TauCeti.indecomposable_kroneckerLineRep`: a line representation is indecomposable as soon as
   its scalar is nonzero or some arrow other than the distinguished one exists; its endomorphisms
   are recorded faithfully by a single scalar.
@@ -113,21 +120,6 @@ noncomputable def kroneckerLineRep (a₁ : A) (c : k) : QuiverRep k (Quiver.Kron
 
 variable {a₀ a₁ : A} {c d : k}
 
--- Not `@[simp]`: an `obj` lemma of this shape rewrites inside the implicit source and target
--- arguments of `ModuleCat.Hom.hom`, taking the left-hand sides of the `_apply` lemmas below out of
--- simp-normal form (`simpNF`).
-/-- The source vertex of a line representation carries the base field. -/
-theorem kroneckerLineRep_obj_src :
-    (kroneckerLineRep k a₁ c).obj (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) =
-      ModuleCat.of k k :=
-  rfl
-
-/-- The target vertex of a line representation carries the base field. -/
-theorem kroneckerLineRep_obj_tgt :
-    (kroneckerLineRep k a₁ c).obj (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)) =
-      ModuleCat.of k k :=
-  rfl
-
 -- Not `@[simp]`: this and `TauCeti.kroneckerLineRep_map_arrowPath_of_ne` rewrite inside the
 -- `ModuleCat.Hom.hom` of the two `_apply` lemmas below, taking those left-hand sides out of
 -- simp-normal form (`simpNF`), exactly as the corresponding pair for the Jordan blocks does.
@@ -181,13 +173,12 @@ theorem not_isZero_kroneckerLineRep :
 
 /-! ### The morphisms between two line representations -/
 
-/-- The linear map underlying a morphism of line representations at the source vertex. -/
+/-- The linear map underlying a morphism of line representations at the source vertex. Reading that
+component as an endomorphism of the base field is what lets the scalar below be spoken of at all,
+so it is kept as a definition rather than inlined. -/
 private noncomputable def lineApp (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
     k →ₗ[k] k :=
   (e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom
-
-private theorem lineApp_eq (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
-    lineApp e = (e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom := (rfl)
 
 private theorem lineApp_zero :
     lineApp (0 : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) = 0 := (rfl)
@@ -198,37 +189,53 @@ private theorem lineApp_comp {c' : k} (e : kroneckerLineRep k a₁ c ⟶ kroneck
     (e' : kroneckerLineRep k a₁ d ⟶ kroneckerLineRep k a₁ c') :
     lineApp (e ≫ e') = (lineApp e').comp (lineApp e) := (rfl)
 
-/-- The scalar recording a morphism of line representations: the value at `1` of the linear map
-above. -/
-private noncomputable def lineScalar (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) : k :=
+/-- **The scalar recording a morphism of line representations**: the value at `1` of its component
+at the source vertex, that component being a linear endomorphism of the base field. The morphism is
+multiplication by this scalar at the source (`TauCeti.kroneckerLineRep_hom_app_src_apply`), the
+scalar determines the morphism whenever `TauCeti.kroneckerLineRep_hom_ext` applies, and it is
+constrained by `TauCeti.mul_kroneckerLineScalar`. -/
+noncomputable def kroneckerLineScalar (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) : k :=
   lineApp e 1
 
-private theorem lineScalar_def (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
-    lineScalar e = lineApp e 1 := (rfl)
+private theorem kroneckerLineScalar_def (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    kroneckerLineScalar e = lineApp e 1 := (rfl)
 
-/-- **A morphism of line representations acts at the source by multiplication by its scalar**, that
-component being a linear endomorphism of the base field. -/
-private theorem lineApp_apply (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) (x : k) :
-    lineApp e x = x * lineScalar e := by
-  rw [lineScalar_def, ← smul_eq_mul, ← map_smul, smul_eq_mul, mul_one]
+/-- **A morphism of line representations acts at the source vertex by multiplication by its
+scalar.** -/
+@[simp]
+theorem kroneckerLineRep_hom_app_src_apply
+    (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) (x : k) :
+    (e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom x =
+      x * kroneckerLineScalar e := by
+  -- The rewrites need this component with its source and target read as the base field, which is
+  -- what `lineApp` records; the two statements are the same up to that reading.
+  have h : lineApp e x = x * kroneckerLineScalar e := by
+    rw [kroneckerLineScalar_def, ← smul_eq_mul, ← map_smul, smul_eq_mul, mul_one]
+  exact h
 
-private theorem lineScalar_zero :
-    lineScalar (0 : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) = 0 := by
-  rw [lineScalar_def, lineApp_zero, LinearMap.zero_apply]
+@[simp]
+theorem kroneckerLineScalar_zero :
+    kroneckerLineScalar (0 : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) = 0 := by
+  rw [kroneckerLineScalar_def, lineApp_zero, LinearMap.zero_apply]
 
-private theorem lineScalar_id : lineScalar (𝟙 (kroneckerLineRep k a₁ c)) = 1 := by
-  rw [lineScalar_def, lineApp_id, LinearMap.id_apply]
+@[simp]
+theorem kroneckerLineScalar_id : kroneckerLineScalar (𝟙 (kroneckerLineRep k a₁ c)) = 1 := by
+  rw [kroneckerLineScalar_def, lineApp_id, LinearMap.id_apply]
 
-private theorem lineScalar_comp {c' : k} (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d)
+@[simp]
+theorem kroneckerLineScalar_comp {c' : k}
+    (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d)
     (e' : kroneckerLineRep k a₁ d ⟶ kroneckerLineRep k a₁ c') :
-    lineScalar (e ≫ e') = lineScalar e * lineScalar e' := by
+    kroneckerLineScalar (e ≫ e') = kroneckerLineScalar e * kroneckerLineScalar e' := by
   have h : lineApp (e ≫ e') 1 = lineApp e' (lineApp e 1) := by
     rw [lineApp_comp, LinearMap.comp_apply]
-  rw [lineScalar_def, h, lineApp_apply e' (lineApp e 1), ← lineScalar_def]
+  have h' : lineApp e' (lineApp e 1) = lineApp e 1 * kroneckerLineScalar e' :=
+    kroneckerLineRep_hom_app_src_apply e' (lineApp e 1)
+  rw [kroneckerLineScalar_def, h, h', ← kroneckerLineScalar_def]
 
 /-- **The two components of a morphism of line representations agree**, by naturality along an
 arrow that acts as the identity on both. -/
-private theorem app_tgt_eq_app_src (h : a₀ ≠ a₁)
+theorem kroneckerLineRep_hom_app_tgt_of_ne (h : a₀ ≠ a₁)
     (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
     e.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)) =
       e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) := by
@@ -265,34 +272,37 @@ private theorem app_tgt_ext_of_ne_zero (hc : c ≠ 0)
     congrArg (fun g ↦ (ModuleCat.Hom.hom g) (c⁻¹ * y)) hnat
   rwa [← mul_assoc, mul_inv_cancel₀ hc, one_mul] at hy
 
-/-- **A morphism of line representations is determined by its component at the source vertex**, as
-soon as the distinguished arrow acts invertibly or some other arrow exists. -/
-private theorem lineApp_ext (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁)
-    {e e' : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d} (heq : lineApp e = lineApp e') :
-    e = e' := by
+/-- **A morphism of line representations is determined by its scalar**, as soon as the
+distinguished arrow acts invertibly or some other arrow exists. -/
+theorem kroneckerLineRep_hom_ext (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁)
+    {e e' : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d}
+    (heq : kroneckerLineScalar e = kroneckerLineScalar e') : e = e' := by
+  rw [kroneckerLineScalar_def, kroneckerLineScalar_def] at heq
   have hsrc : e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) =
-      e'.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) := ModuleCat.hom_ext heq
+      e'.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) :=
+    ModuleCat.hom_ext (LinearMap.ext_ring heq)
   refine kroneckerRep_hom_ext hsrc ?_
   obtain hc | ⟨a, ha⟩ := h
   · exact app_tgt_ext_of_ne_zero hc hsrc
-  · rw [app_tgt_eq_app_src ha e, app_tgt_eq_app_src ha e', hsrc]
+  · rw [kroneckerLineRep_hom_app_tgt_of_ne ha e, kroneckerLineRep_hom_app_tgt_of_ne ha e', hsrc]
 
-private theorem lineScalar_injective (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁) :
+private theorem kroneckerLineScalar_injective (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁) :
     Function.Injective
-      (lineScalar : (kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) → k) := by
-  intro e e' heq
-  rw [lineScalar_def, lineScalar_def] at heq
-  exact lineApp_ext h (LinearMap.ext_ring heq)
+      (kroneckerLineScalar : (kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) → k) :=
+  fun _ _ heq ↦ kroneckerLineRep_hom_ext h heq
 
-/-- The scalars of the two lines agree on the scalar of any morphism between them. -/
-private theorem mul_lineScalar (h : a₀ ≠ a₁)
+/-- **The scalars of the two lines agree on the scalar of any morphism between them**, by
+naturality along the distinguished arrow. -/
+theorem mul_kroneckerLineScalar (h : a₀ ≠ a₁)
     (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
-    c * lineScalar e = d * lineScalar e := by
+    c * kroneckerLineScalar e = d * kroneckerLineScalar e := by
   have hnat := app_tgt_comp_mulLeft e
-  rw [app_tgt_eq_app_src h e] at hnat
+  rw [kroneckerLineRep_hom_app_tgt_of_ne h e] at hnat
   have h1 : lineApp e (c * 1) = d * lineApp e 1 :=
     congrArg (fun g ↦ (ModuleCat.Hom.hom g) 1) hnat
-  rwa [mul_one, lineApp_apply, ← lineScalar_def] at h1
+  have h2 : lineApp e c = c * kroneckerLineScalar e :=
+    kroneckerLineRep_hom_app_src_apply e c
+  rwa [mul_one, h2, ← kroneckerLineScalar_def] at h1
 
 /-! ### Indecomposability and the classification -/
 
@@ -309,8 +319,9 @@ simples. That quiver has only the three isomorphism classes counted by
 `TauCeti.card_skeleton_indecomposable_kronecker`, with no room for a family. -/
 theorem indecomposable_kroneckerLineRep (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁) :
     Indecomposable (kroneckerLineRep k a₁ c) :=
-  indecomposable_of_injective_of_isLocalRing not_isZero_kroneckerLineRep lineScalar
-    (lineScalar_injective h) lineScalar_zero lineScalar_id fun e ↦ lineScalar_comp e e
+  indecomposable_of_injective_of_isLocalRing not_isZero_kroneckerLineRep kroneckerLineScalar
+    (kroneckerLineScalar_injective h) kroneckerLineScalar_zero kroneckerLineScalar_id
+    fun e ↦ kroneckerLineScalar_comp e e
 
 /-- **Line representations at different scalars are non-isomorphic.** An isomorphism has an
 invertible scalar, and its naturality along the distinguished arrow then equates the two
@@ -318,9 +329,9 @@ scalars. -/
 theorem eq_of_nonempty_kroneckerLineRep_iso (h : a₀ ≠ a₁)
     (hiso : Nonempty (kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d)) : c = d := by
   obtain ⟨e⟩ := hiso
-  have hunit : lineScalar e.hom * lineScalar e.inv = 1 := by
-    rw [← lineScalar_comp, e.hom_inv_id, lineScalar_id]
-  exact mul_right_cancel₀ (left_ne_zero_of_mul_eq_one hunit) (mul_lineScalar h e.hom)
+  have hunit : kroneckerLineScalar e.hom * kroneckerLineScalar e.inv = 1 := by
+    rw [← kroneckerLineScalar_comp, e.hom_inv_id, kroneckerLineScalar_id]
+  exact mul_right_cancel₀ (left_ne_zero_of_mul_eq_one hunit) (mul_kroneckerLineScalar h e.hom)
 
 /-- **Two line representations are isomorphic exactly when their scalars agree.** So over an
 infinite field the isomorphism classes of indecomposables at the dimension vector `(1, 1)` are
@@ -365,7 +376,7 @@ theorem titsForm_dimVector_kroneckerLineRep [Fintype A] :
   have hd : (fun j : Quiver.Kronecker A ↦ (dimVector (kroneckerLineRep k a₁ c) j : ℤ)) = 1 := by
     funext j
     rw [dimVector_kroneckerLineRep, Nat.cast_one, Pi.one_apply]
-  rw [hd, Quiver.Kronecker.titsForm_apply, Pi.one_apply, Pi.one_apply]
-  ring
+  rw [hd]
+  exact Quiver.Kronecker.titsForm_one
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
@@ -10,15 +10,16 @@ public import TauCeti.RepresentationTheory.Quiver.Kronecker.EulerForm
 public import TauCeti.RepresentationTheory.Quiver.Kronecker.Representation
 public import TauCeti.RepresentationTheory.Quiver.Representation.DimensionVector
 public import TauCeti.RepresentationTheory.Quiver.Representation.FiniteDimensional
-public import TauCeti.RepresentationTheory.Quiver.Representation.Indecomposable
 
 /-!
 # The line representations of the generalized Kronecker quiver
 
 Put the base field at both vertices of the generalized Kronecker quiver, let one distinguished
 arrow act by multiplication by a scalar `c` and every other arrow by the identity. This file
-builds that representation, `TauCeti.kroneckerLineRep`, and proves that the resulting family is
-made of pairwise non-isomorphic indecomposables:
+builds that representation, `TauCeti.kroneckerLineRep`. Every member of the family is
+indecomposable as soon as its scalar is nonzero or the quiver carries an arrow other than the
+distinguished one, and on a quiver carrying such a second arrow the family is pairwise
+non-isomorphic:
 
 `kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d ↔ c = d`.
 
@@ -37,8 +38,7 @@ by a unit produces an isomorphic representation, so the classes are the points `
 projective line. Normalizing the non-distinguished arrows to the identity picks the chart
 `c₁ ≠ 0` and parametrizes it by `c = c₀ / c₁`. Neither the one class this omits -- the point at
 infinity, where the distinguished arrow acts by the identity and every other arrow by zero -- nor
-the exhaustiveness of the resulting list, is built here; a projective-line-indexed family and its
-classification are left to a later file.
+the exhaustiveness of the resulting list, is built here.
 
 The member at `c = 0` is the smallest Jordan block `TauCeti.kroneckerJordanRep k a₁ 0` of
 `TauCeti.RepresentationTheory.Quiver.Kronecker.FiniteRepType`, up to the identification of
@@ -55,17 +55,17 @@ them over any field at all.
 
 ## Main results
 
-* `TauCeti.indecomposable_kroneckerLineRep`: a line representation is indecomposable, as soon as
-  some arrow other than the distinguished one exists; its endomorphisms are recorded faithfully by
-  a single scalar.
-* `TauCeti.nonempty_kroneckerLineRep_iso_iff`: **two of them are isomorphic exactly when their
-  scalars agree.**
+* `TauCeti.indecomposable_kroneckerLineRep`: a line representation is indecomposable as soon as
+  its scalar is nonzero or some arrow other than the distinguished one exists; its endomorphisms
+  are recorded faithfully by a single scalar.
+* `TauCeti.nonempty_kroneckerLineRep_iso_iff`: **on a quiver carrying an arrow other than the
+  distinguished one, two of them are isomorphic exactly when their scalars agree.**
 * `TauCeti.dimVector_kroneckerLineRep`: every line representation has dimension vector `1` at
   both vertices.
-* `TauCeti.exists_indecomposable_dimVector_eq_not_nonempty_iso`: **outside Dynkin type the
-  dimension vector does not determine an indecomposable**: over every field, a generalized
-  Kronecker quiver with two distinct arrows carries two non-isomorphic finite-dimensional
-  indecomposables of the same dimension vector.
+* `TauCeti.exists_indecomposable_dimVector_eq_not_nonempty_iso`: **on a generalized Kronecker
+  quiver with two distinct arrows the dimension vector does not determine an indecomposable**:
+  over every field such a quiver carries two non-isomorphic finite-dimensional indecomposables of
+  the same dimension vector.
 * `TauCeti.titsForm_dimVector_kroneckerLineRep`: the Tits value of that common dimension vector is
   `2 - #arrows`, which is `1` only for the `A₂` quiver.
 
@@ -77,23 +77,10 @@ them over any field at all.
 objects only through its definition, so without it every statement below reading a component of a
 morphism as a linear map on `k` fails to elaborate.
 
-Indecomposability runs through `TauCeti.indecomposable_of_injective_of_isLocalRing` at the base
-field, as the Jordan blocks do at a truncated polynomial algebra, rather than through the brick
-criterion `TauCeti.indecomposable_of_finrank_end_eq_one`: recording an endomorphism by its scalar
-is the same work either way, and the local-ring route does not also ask for the endomorphism
-*space* to be identified with `k` as a module.
-
-The private scalar recording a morphism is defined for a morphism between two line
-representations with possibly different scalars, not only for an endomorphism: the isomorphism
-classification composes it along an isomorphism and its inverse, which are morphisms of that
-mixed shape.
-
 ## References
 
-This builds the affine chart of the `ℙ¹`-family of indecomposables of dimension vector `(1, 1)`
-named by the "Kronecker quiver" worked example of
-`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`; the projective family
-itself is not supplied here. See Derksen--Weyman, *An Introduction to Quiver Representations*, and
+The affine chart of the `ℙ¹`-family of indecomposables of dimension vector `(1, 1)` of the
+Kronecker quiver. See Derksen--Weyman, *An Introduction to Quiver Representations*, and
 Assem--Simson--Skowroński, *Elements of the Representation Theory of Associative Algebras I*,
 Ch. VIII.
 -/
@@ -125,6 +112,21 @@ noncomputable def kroneckerLineRep (a₁ : A) (c : k) : QuiverRep k (Quiver.Kron
     fun a ↦ if a = a₁ then ModuleCat.ofHom (LinearMap.mulLeft k c) else 𝟙 _
 
 variable {a₀ a₁ : A} {c d : k}
+
+-- Not `@[simp]`: an `obj` lemma of this shape rewrites inside the implicit source and target
+-- arguments of `ModuleCat.Hom.hom`, taking the left-hand sides of the `_apply` lemmas below out of
+-- simp-normal form (`simpNF`).
+/-- The source vertex of a line representation carries the base field. -/
+theorem kroneckerLineRep_obj_src :
+    (kroneckerLineRep k a₁ c).obj (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) =
+      ModuleCat.of k k :=
+  rfl
+
+/-- The target vertex of a line representation carries the base field. -/
+theorem kroneckerLineRep_obj_tgt :
+    (kroneckerLineRep k a₁ c).obj (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)) =
+      ModuleCat.of k k :=
+  rfl
 
 -- Not `@[simp]`: this and `TauCeti.kroneckerLineRep_map_arrowPath_of_ne` rewrite inside the
 -- `ModuleCat.Hom.hom` of the two `_apply` lemmas below, taking those left-hand sides out of
@@ -230,66 +232,82 @@ private theorem app_tgt_eq_app_src (h : a₀ ≠ a₁)
     (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
     e.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)) =
       e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) := by
-  refine ModuleCat.hom_ext (LinearMap.ext fun (x : k) ↦ ?_)
-  have hnat : (e.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A))).hom
-        (((kroneckerLineRep k a₁ c).map (Quiver.Kronecker.arrowPath a₀)).hom x) =
-      ((kroneckerLineRep k a₁ d).map (Quiver.Kronecker.arrowPath a₀)).hom
-        ((e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom x) :=
-    congrArg (fun g ↦ (ModuleCat.Hom.hom g) x) (e.naturality (Quiver.Kronecker.arrowPath a₀))
-  rw [kroneckerLineRep_map_arrowPath_of_ne_apply h] at hnat
-  exact hnat.trans (kroneckerLineRep_map_arrowPath_of_ne_apply h _)
+  have hnat := kroneckerRep_hom_naturality e a₀
+  rw [ite_eq_right h, ite_eq_right h] at hnat
+  exact (Category.id_comp _).symm.trans (hnat.trans (Category.comp_id _))
 
-/-- **A morphism of line representations is determined by its component at the source vertex**: the
-component at the target agrees with it. -/
-private theorem lineApp_ext (h : a₀ ≠ a₁)
+/-- **Naturality along the distinguished arrow**: a morphism from the line at `c` to the line at
+`d` intertwines multiplication by `c` with multiplication by `d`. -/
+private theorem app_tgt_comp_mulLeft (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    ModuleCat.ofHom (LinearMap.mulLeft k c) ≫
+        e.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)) =
+      e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) ≫
+        ModuleCat.ofHom (LinearMap.mulLeft k d) := by
+  have hnat := kroneckerRep_hom_naturality e a₁
+  rwa [ite_eq_left rfl, ite_eq_left rfl] at hnat
+
+/-- **A morphism of line representations is determined by its component at the source vertex when
+the distinguished arrow acts invertibly**: naturality along that arrow computes the component at
+the target from the one at the source. -/
+private theorem app_tgt_ext_of_ne_zero (hc : c ≠ 0)
+    {e e' : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d}
+    (hsrc : e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) =
+      e'.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))) :
+    e.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)) =
+      e'.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)) := by
+  have hnat := app_tgt_comp_mulLeft e
+  rw [hsrc, ← app_tgt_comp_mulLeft e'] at hnat
+  refine ModuleCat.hom_ext (LinearMap.ext fun (y : k) ↦ ?_)
+  have hy : (ModuleCat.Hom.hom
+        (e.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)))) (c * (c⁻¹ * y)) =
+      (ModuleCat.Hom.hom
+        (e'.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A)))) (c * (c⁻¹ * y)) :=
+    congrArg (fun g ↦ (ModuleCat.Hom.hom g) (c⁻¹ * y)) hnat
+  rwa [← mul_assoc, mul_inv_cancel₀ hc, one_mul] at hy
+
+/-- **A morphism of line representations is determined by its component at the source vertex**, as
+soon as the distinguished arrow acts invertibly or some other arrow exists. -/
+private theorem lineApp_ext (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁)
     {e e' : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d} (heq : lineApp e = lineApp e') :
     e = e' := by
   have hsrc : e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) =
       e'.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A)) := ModuleCat.hom_ext heq
-  exact kroneckerRep_hom_ext hsrc
-    (by rw [app_tgt_eq_app_src h e, app_tgt_eq_app_src h e', hsrc])
+  refine kroneckerRep_hom_ext hsrc ?_
+  obtain hc | ⟨a, ha⟩ := h
+  · exact app_tgt_ext_of_ne_zero hc hsrc
+  · rw [app_tgt_eq_app_src ha e, app_tgt_eq_app_src ha e', hsrc]
 
-private theorem lineScalar_injective (h : a₀ ≠ a₁) :
+private theorem lineScalar_injective (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁) :
     Function.Injective
       (lineScalar : (kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) → k) := by
   intro e e' heq
-  refine lineApp_ext h (LinearMap.ext fun x ↦ ?_)
-  rw [lineApp_apply, lineApp_apply, heq]
-
-/-- **Naturality along the distinguished arrow**: a morphism from the line at `c` to the line at
-`d` intertwines multiplication by `c` with multiplication by `d`. -/
-private theorem lineApp_mul (h : a₀ ≠ a₁)
-    (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) (x : k) :
-    lineApp e (c * x) = d * lineApp e x := by
-  have hnat : (e.app (Quiver.Kronecker.tgt : Paths (Quiver.Kronecker A))).hom
-        (((kroneckerLineRep k a₁ c).map (Quiver.Kronecker.arrowPath a₁)).hom x) =
-      ((kroneckerLineRep k a₁ d).map (Quiver.Kronecker.arrowPath a₁)).hom
-        ((e.app (Quiver.Kronecker.src : Paths (Quiver.Kronecker A))).hom x) :=
-    congrArg (fun g ↦ (ModuleCat.Hom.hom g) x) (e.naturality (Quiver.Kronecker.arrowPath a₁))
-  rw [kroneckerLineRep_map_arrowPath_self_apply, app_tgt_eq_app_src h e] at hnat
-  rw [lineApp_eq]
-  exact hnat.trans (kroneckerLineRep_map_arrowPath_self_apply _)
+  rw [lineScalar_def, lineScalar_def] at heq
+  exact lineApp_ext h (LinearMap.ext_ring heq)
 
 /-- The scalars of the two lines agree on the scalar of any morphism between them. -/
 private theorem mul_lineScalar (h : a₀ ≠ a₁)
     (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
     c * lineScalar e = d * lineScalar e := by
-  have h1 := lineApp_mul h e 1
-  rw [mul_one, lineApp_apply, ← lineScalar_def] at h1
-  exact h1
+  have hnat := app_tgt_comp_mulLeft e
+  rw [app_tgt_eq_app_src h e] at hnat
+  have h1 : lineApp e (c * 1) = d * lineApp e 1 :=
+    congrArg (fun g ↦ (ModuleCat.Hom.hom g) 1) hnat
+  rwa [mul_one, lineApp_apply, ← lineScalar_def] at h1
 
 /-! ### Indecomposability and the classification -/
 
-/-- **A line representation is indecomposable, as soon as some arrow other than the distinguished
-one exists.** Its endomorphisms are recorded faithfully by their scalar in the base field, which is
-a local ring, so its only idempotent endomorphisms are `0` and the identity.
+/-- **A line representation is indecomposable as soon as its scalar is nonzero or some arrow other
+than the distinguished one exists.** Its endomorphisms are recorded faithfully by their scalar in
+the base field, which is a local ring, so its only idempotent endomorphisms are `0` and the
+identity.
 
-The second arrow is what forces the two components of an endomorphism to agree, and it is not an
-artefact: over the `A₂` quiver of a single arrow nothing relates the two components, and the line
-at `c = 0` is there the direct sum of the two vertex simples. That quiver has only the three
-isomorphism classes counted by `TauCeti.card_skeleton_indecomposable_kronecker`, with no room for
-a family. -/
-theorem indecomposable_kroneckerLineRep (h : a₀ ≠ a₁) :
+What forces the two components of an endomorphism to agree is either an arrow other than the
+distinguished one, acting as the identity on both, or the invertibility of the distinguished
+arrow. The hypothesis is not an artefact: over the `A₂` quiver of a single arrow acting by `c = 0`
+nothing relates the two components, and the line is there the direct sum of the two vertex
+simples. That quiver has only the three isomorphism classes counted by
+`TauCeti.card_skeleton_indecomposable_kronecker`, with no room for a family. -/
+theorem indecomposable_kroneckerLineRep (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁) :
     Indecomposable (kroneckerLineRep k a₁ c) :=
   indecomposable_of_injective_of_isLocalRing not_isZero_kroneckerLineRep lineScalar
     (lineScalar_injective h) lineScalar_zero lineScalar_id fun e ↦ lineScalar_comp e e
@@ -311,8 +329,8 @@ theorem nonempty_kroneckerLineRep_iso_iff (h : a₀ ≠ a₁) :
     Nonempty (kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d) ↔ c = d :=
   ⟨eq_of_nonempty_kroneckerLineRep_iso h, by rintro rfl; exact ⟨Iso.refl _⟩⟩
 
-/-- **Outside Dynkin type the dimension vector does not determine an indecomposable.** Over every
-field, a generalized Kronecker quiver with two distinct arrows carries two non-isomorphic
+/-- **On a generalized Kronecker quiver with two distinct arrows the dimension vector does not
+determine an indecomposable.** Over every field such a quiver carries two non-isomorphic
 finite-dimensional indecomposable representations with the same dimension vector, the lines at the
 scalars `0` and `1`.
 
@@ -326,8 +344,8 @@ theorem exists_indecomposable_dimVector_eq_not_nonempty_iso (k : Type u) [Field 
         IsFinDim k (Quiver.Kronecker A) N ∧ Indecomposable N ∧
         dimVector M = dimVector N ∧ ¬ Nonempty (M ≅ N) :=
   ⟨kroneckerLineRep k a₁ 0, kroneckerLineRep k a₁ 1, isFinDim_kroneckerLineRep,
-    indecomposable_kroneckerLineRep h, isFinDim_kroneckerLineRep,
-    indecomposable_kroneckerLineRep h,
+    indecomposable_kroneckerLineRep (Or.inr ⟨a₀, h⟩), isFinDim_kroneckerLineRep,
+    indecomposable_kroneckerLineRep (Or.inr ⟨a₀, h⟩),
     funext fun w ↦ (dimVector_kroneckerLineRep w).trans (dimVector_kroneckerLineRep w).symm,
     fun hiso ↦ zero_ne_one (eq_of_nonempty_kroneckerLineRep_iso h hiso)⟩
 

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
@@ -28,10 +28,15 @@ the dimension vector of a finite-dimensional indecomposable **does not determine
 Tits value is `2 - #arrows`, not `1`. Both facts are sharpness statements: the Gabriel injection
 `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic` and the real-root property
 `TauCeti.titsForm_dimVector_eq_one_of_indecomposable_of_isAcyclic` are proved for an acyclic
-quiver whose Tits form is *positive definite*, and the Kronecker quiver -- acyclic, with the
-positive semidefinite Tits form `TauCeti.Quiver.Kronecker.titsForm_apply`, which on the two arrows
-of `• ⇉ •` is the square `(a - b) ^ 2` of `TauCeti.Quiver.Kronecker.titsForm_eq_sq` --
-shows that neither survives the weakening of that hypothesis to acyclicity alone.
+quiver whose Tits form is *positive definite*, and every generalized Kronecker quiver is acyclic,
+so neither survives the weakening of that hypothesis to acyclicity alone. Already the *smallest*
+such weakening fails, at the Kronecker quiver `• ⇉ •` of exactly two arrows: its Tits form
+`TauCeti.Quiver.Kronecker.titsForm_apply` is there the square `(a - b) ^ 2` of
+`TauCeti.Quiver.Kronecker.titsForm_eq_sq`, hence positive semidefinite but not positive definite,
+which is the threshold `TauCeti.Quiver.Kronecker.titsForm_nonneg` records. That threshold is the
+only place semidefiniteness holds: on three or more arrows the form
+`a ^ 2 + b ^ 2 - #arrows * a * b` is indefinite, taking the negative value `2 - #arrows` at
+`(1, 1)`.
 
 The family is the affine chart of the `ℙ¹`-family the Kronecker quiver is known for, and only that
 chart: letting the two arrows of `• ⇉ •` act by a pair of scalars `(c₀, c₁)`, rescaling that pair
@@ -259,6 +264,34 @@ theorem kroneckerLineRepScalar_comp {c' : k}
         (ModuleCat.comp_apply _ _ _)
   exact h.trans (kroneckerLineRep_hom_app_src_apply e' (kroneckerLineRepScalar e))
 
+-- The three lemmas below record the additive behaviour of the scalar on the preadditive hom
+-- spaces. The addition, negation and subtraction of natural transformations are all defined
+-- componentwise (`CategoryTheory.functorCategoryPreadditive`), as are those of morphisms of
+-- `ModuleCat` and of linear maps, so each is a definitional equality outright and needs none of
+-- the term-level rewriting above. It has to be written `(rfl)` rather than `rfl`: the body of
+-- `TauCeti.kroneckerLineRepScalar` is not exposed, and the parenthesized form is what lets the
+-- elaborator unfold it inside this module.
+
+/-- The scalar of a sum is the sum of the scalars. -/
+@[simp]
+theorem kroneckerLineRepScalar_add
+    (e e' : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    kroneckerLineRepScalar (e + e') = kroneckerLineRepScalar e + kroneckerLineRepScalar e' :=
+  (rfl)
+
+/-- The scalar of a negation is the negation of the scalar. -/
+@[simp]
+theorem kroneckerLineRepScalar_neg (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    kroneckerLineRepScalar (-e) = -kroneckerLineRepScalar e :=
+  (rfl)
+
+/-- The scalar of a difference is the difference of the scalars. -/
+@[simp]
+theorem kroneckerLineRepScalar_sub
+    (e e' : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
+    kroneckerLineRepScalar (e - e') = kroneckerLineRepScalar e - kroneckerLineRepScalar e' :=
+  (rfl)
+
 /-- **The two components of a morphism of line representations agree**, by naturality along an
 arrow that acts as the identity on both. -/
 theorem kroneckerLineRep_hom_app_tgt_of_ne (h : a₀ ≠ a₁)
@@ -448,8 +481,11 @@ finite-dimensional indecomposable representations with the same dimension vector
 scalars `0` and `1`.
 
 This is the sharpness of `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic`:
-that theorem holds over an acyclic quiver whose Tits form is positive definite, and the Kronecker
-quiver is acyclic with a Tits form that is only positive semidefinite. -/
+that theorem holds over an acyclic quiver whose Tits form is positive definite, and every
+generalized Kronecker quiver is acyclic, so acyclicity alone does not suffice. Specializing `A` to
+a two-element type gives the boundary case, where the Tits form is still positive semidefinite by
+`TauCeti.Quiver.Kronecker.titsForm_nonneg`; for three or more arrows, covered here too, it is
+indefinite instead. -/
 theorem exists_indecomposable_dimVector_eq_not_nonempty_iso_kronecker (k : Type u) [Field k]
     (A : Type v) [Nontrivial A] :
     ∃ M N : QuiverRep.{u, 0, v, u} k (Quiver.Kronecker A),
@@ -467,11 +503,13 @@ theorem exists_indecomposable_dimVector_eq_not_nonempty_iso_kronecker (k : Type 
 `1` exactly for the `A₂` quiver of a single arrow, and `0` for the Kronecker quiver `• ⇉ •`.
 
 This is the sharpness of `TauCeti.titsForm_dimVector_eq_one_of_indecomposable_of_isAcyclic`: over
-an acyclic quiver whose Tits form is only positive semidefinite, the dimension vector of an
+an acyclic quiver whose Tits form is not assumed positive definite, the dimension vector of an
 indecomposable need not have Tits value `1`, that is, need not be a *real* root. It remains a root
-of the Kronecker quiver, an imaginary one: for two arrows `(1, 1)` is the isotropic null root of
-`Ã₁` recorded by `TauCeti.Quiver.Kronecker.titsForm_eq_zero_iff_exists_smul`, and for more arrows
-its Tits value `2 - #arrows` is negative. -/
+of the Kronecker quiver, an imaginary one: on exactly two arrows -- the boundary case, where the
+form is still positive semidefinite by `TauCeti.Quiver.Kronecker.titsForm_nonneg` -- `(1, 1)` is
+the isotropic null root of `Ã₁` recorded by
+`TauCeti.Quiver.Kronecker.titsForm_eq_zero_iff_exists_smul`, and on three or more arrows, where the
+form is indefinite, its Tits value `2 - #arrows` is negative. -/
 theorem titsForm_dimVector_kroneckerLineRep [Fintype A] :
     titsForm (Quiver.Kronecker A)
         (fun j : Quiver.Kronecker A ↦ (dimVector (kroneckerLineRep k a₁ c) j : ℤ)) =

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean
@@ -21,7 +21,7 @@ indecomposable as soon as its scalar is nonzero or the quiver carries an arrow o
 distinguished one, and on a quiver carrying such a second arrow the family is pairwise
 non-isomorphic:
 
-`kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d ↔ c = d`.
+`Nonempty (kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d) ↔ c = d`.
 
 Every member of the family has dimension vector `(1, 1)`. So on a quiver with at least two arrows
 the dimension vector of a finite-dimensional indecomposable **does not determine it**, and its
@@ -29,7 +29,8 @@ Tits value is `2 - #arrows`, not `1`. Both facts are sharpness statements: the G
 `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic` and the real-root property
 `TauCeti.titsForm_dimVector_eq_one_of_indecomposable_of_isAcyclic` are proved for an acyclic
 quiver whose Tits form is *positive definite*, and the Kronecker quiver -- acyclic, with the
-positive semidefinite Tits form `(a - b) ^ 2` of `TauCeti.Quiver.Kronecker.titsForm_apply` --
+positive semidefinite Tits form `TauCeti.Quiver.Kronecker.titsForm_apply`, which on the two arrows
+of `• ⇉ •` is the square `(a - b) ^ 2` of `TauCeti.Quiver.Kronecker.titsForm_eq_sq` --
 shows that neither survives the weakening of that hypothesis to acyclicity alone.
 
 The family is the affine chart of the `ℙ¹`-family the Kronecker quiver is known for, and only that
@@ -299,6 +300,7 @@ private theorem app_tgt_ext_of_ne_zero (hc : c ≠ 0)
 
 /-- **A morphism of line representations is determined by its scalar**, as soon as the
 distinguished arrow acts invertibly or some other arrow exists. -/
+@[ext]
 theorem kroneckerLineRep_hom_ext (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁)
     {e e' : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d}
     (heq : kroneckerLineRepScalar e = kroneckerLineRepScalar e') : e = e' := by
@@ -316,11 +318,14 @@ private theorem kroneckerLineRepScalar_injective (h : c ≠ 0 ∨ ∃ a : A, a �
       (kroneckerLineRepScalar : (kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) → k) :=
   fun _ _ heq ↦ kroneckerLineRep_hom_ext h heq
 
-/-- **The scalars of the two lines agree on the scalar of any morphism between them**, by
-naturality along the distinguished arrow. -/
-theorem kroneckerLineRepScalar_intertwine (h : a₀ ≠ a₁)
+/-- **On a quiver carrying more than one arrow the scalars of the two lines agree on the scalar of
+any morphism between them**, by naturality along the distinguished arrow. The hypothesis
+`Nontrivial A` is the existence of an arrow other than the distinguished one: it forces the two
+components of the morphism to agree. -/
+theorem kroneckerLineRepScalar_intertwine [Nontrivial A]
     (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
     c * kroneckerLineRepScalar e = d * kroneckerLineRepScalar e := by
+  obtain ⟨a₀, h⟩ := exists_ne a₁
   have hnat := app_tgt_comp_mulLeft e
   rw [kroneckerLineRep_hom_app_tgt_of_ne h e] at hnat
   -- Reading the square at `1` gives the value of the component at `c`, which
@@ -384,17 +389,16 @@ theorem kroneckerLineRepScalar_kroneckerLineRepHom (s : k) (hs : c * s = d * s) 
       (kroneckerLineRepHom_app_src (a₁ := a₁) (c := c) (d := d) s hs)
   rw [h, one_mul]
 
--- Not `@[simp]`: the arrow `a₀` of the hypothesis does not occur in the left-hand side, which
--- `simpNF` rejects.
 /-- **Every morphism of line representations is the one attached to its scalar.** Together with
 `TauCeti.kroneckerLineRep_hom_ext` this identifies the morphisms `kroneckerLineRep k a₁ c ⟶
 kroneckerLineRep k a₁ d`, on a quiver carrying an arrow other than the distinguished one, with the
 scalars `s` satisfying `c * s = d * s`, mirroring the pair
 `TauCeti.oneLoopRepHom_oneLoopRepScalar` / `TauCeti.oneLoopRep_hom_ext` of the loop quiver. -/
-theorem kroneckerLineRepHom_kroneckerLineRepScalar (h : a₀ ≠ a₁)
+@[simp]
+theorem kroneckerLineRepHom_kroneckerLineRepScalar [Nontrivial A]
     (e : kroneckerLineRep k a₁ c ⟶ kroneckerLineRep k a₁ d) :
-    kroneckerLineRepHom (kroneckerLineRepScalar e) (kroneckerLineRepScalar_intertwine h e) = e :=
-  kroneckerLineRep_hom_ext (Or.inr ⟨a₀, h⟩) (kroneckerLineRepScalar_kroneckerLineRepHom _ _)
+    kroneckerLineRepHom (kroneckerLineRepScalar e) (kroneckerLineRepScalar_intertwine e) = e :=
+  kroneckerLineRep_hom_ext (Or.inr (exists_ne a₁)) (kroneckerLineRepScalar_kroneckerLineRepHom _ _)
 
 /-! ### Indecomposability and the classification -/
 
@@ -415,26 +419,28 @@ theorem indecomposable_kroneckerLineRep (h : c ≠ 0 ∨ ∃ a : A, a ≠ a₁) 
     (kroneckerLineRepScalar_injective h) kroneckerLineRepScalar_zero kroneckerLineRepScalar_id
     fun e ↦ kroneckerLineRepScalar_comp e e
 
-/-- **On a quiver carrying an arrow `a₀` other than the distinguished one, two isomorphic line
+/-- **On a quiver carrying an arrow other than the distinguished one, two isomorphic line
 representations have equal scalars.** An isomorphism has an invertible scalar, and its naturality
-along the distinguished arrow then equates the two scalars. The hypothesis `a₀ ≠ a₁` is essential:
-on the `A₂` quiver of the single arrow `a₁` nothing forces the two components of a morphism to
-agree, and the lines at any two nonzero scalars are isomorphic -- by the pair of multiplications
-by `1` and by `d / c`. -/
-theorem eq_of_nonempty_kroneckerLineRep_iso (h : a₀ ≠ a₁)
+along the distinguished arrow then equates the two scalars. The hypothesis `Nontrivial A` is
+essential: on the `A₂` quiver of the single arrow `a₁` nothing forces the two components of a
+morphism to agree, and the lines at any two nonzero scalars are isomorphic -- by the pair of
+multiplications by `1` and by `d / c`. -/
+theorem eq_of_nonempty_kroneckerLineRep_iso [Nontrivial A]
     (hiso : Nonempty (kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d)) : c = d := by
   obtain ⟨e⟩ := hiso
   have hunit : kroneckerLineRepScalar e.hom * kroneckerLineRepScalar e.inv = 1 := by
     rw [← kroneckerLineRepScalar_comp, e.hom_inv_id, kroneckerLineRepScalar_id]
   exact mul_right_cancel₀ (left_ne_zero_of_mul_eq_one hunit)
-    (kroneckerLineRepScalar_intertwine h e.hom)
+    (kroneckerLineRepScalar_intertwine e.hom)
 
-/-- **Two line representations are isomorphic exactly when their scalars agree.** So over an
-infinite field the isomorphism classes of indecomposables at the dimension vector `(1, 1)` are
-infinite in number, the affine chart of the `ℙ¹` of the Kronecker quiver. -/
-theorem nonempty_kroneckerLineRep_iso_iff (h : a₀ ≠ a₁) :
+/-- **On a quiver carrying an arrow other than the distinguished one, two line representations are
+isomorphic exactly when their scalars agree.** So over an infinite field the isomorphism classes of
+indecomposables at the dimension vector `(1, 1)` are infinite in number, the affine chart of the
+`ℙ¹` of the Kronecker quiver. -/
+@[simp]
+theorem nonempty_kroneckerLineRep_iso_iff [Nontrivial A] :
     Nonempty (kroneckerLineRep k a₁ c ≅ kroneckerLineRep k a₁ d) ↔ c = d :=
-  ⟨eq_of_nonempty_kroneckerLineRep_iso h, by rintro rfl; exact ⟨Iso.refl _⟩⟩
+  ⟨eq_of_nonempty_kroneckerLineRep_iso, by rintro rfl; exact ⟨Iso.refl _⟩⟩
 
 /-- **On a generalized Kronecker quiver with two distinct arrows the dimension vector does not
 determine an indecomposable.** Over every field such a quiver carries two non-isomorphic
@@ -445,16 +451,17 @@ This is the sharpness of `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable
 that theorem holds over an acyclic quiver whose Tits form is positive definite, and the Kronecker
 quiver is acyclic with a Tits form that is only positive semidefinite. -/
 theorem exists_indecomposable_dimVector_eq_not_nonempty_iso_kronecker (k : Type u) [Field k]
-    {A : Type v} {a₀ a₁ : A} (h : a₀ ≠ a₁) :
+    (A : Type v) [Nontrivial A] :
     ∃ M N : QuiverRep.{u, 0, v, u} k (Quiver.Kronecker A),
       IsFinDim k (Quiver.Kronecker A) M ∧ Indecomposable M ∧
         IsFinDim k (Quiver.Kronecker A) N ∧ Indecomposable N ∧
-        dimVector M = dimVector N ∧ ¬ Nonempty (M ≅ N) :=
-  ⟨kroneckerLineRep k a₁ 0, kroneckerLineRep k a₁ 1, isFinDim_kroneckerLineRep,
+        dimVector M = dimVector N ∧ ¬ Nonempty (M ≅ N) := by
+  obtain ⟨a₀, a₁, h⟩ := exists_pair_ne A
+  exact ⟨kroneckerLineRep k a₁ 0, kroneckerLineRep k a₁ 1, isFinDim_kroneckerLineRep,
     indecomposable_kroneckerLineRep (Or.inr ⟨a₀, h⟩), isFinDim_kroneckerLineRep,
     indecomposable_kroneckerLineRep (Or.inr ⟨a₀, h⟩),
     funext fun w ↦ (dimVector_kroneckerLineRep w).trans (dimVector_kroneckerLineRep w).symm,
-    fun hiso ↦ zero_ne_one (eq_of_nonempty_kroneckerLineRep_iso h hiso)⟩
+    fun hiso ↦ zero_ne_one (eq_of_nonempty_kroneckerLineRep_iso hiso)⟩
 
 /-- **The Tits value of the dimension vector of a line representation is `2 - #arrows`.** It is
 `1` exactly for the `A₂` quiver of a single arrow, and `0` for the Kronecker quiver `• ⇉ •`.


### PR DESCRIPTION
This PR builds the line family of the generalized Kronecker quiver: the base field at both vertices, one distinguished arrow acting by a scalar `c` and every other arrow by the identity. The whole family sits at the single dimension vector `(1, 1)`, its members are indecomposable as soon as their scalar is nonzero or a second arrow exists, and two of them are isomorphic exactly when their scalars agree. It builds the affine chart of the `ℙ¹`-family of indecomposables of dimension vector `(1, 1)` named by the "Kronecker quiver `• ⇉ •` (type `Ã₁`)" bullet of the `## Worked examples (acceptance criteria)` section of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose other halves — the positive semidefinite Tits form `(a − b)²` and `¬ IsFiniteRepType` — are already on `main` as `TauCeti.Quiver.Kronecker.titsForm_apply` and `TauCeti.not_isFiniteRepType_kronecker`.

One new file, `TauCeti/RepresentationTheory/Quiver/Kronecker/Line.lean`, beside the existing Kronecker development. `TauCeti.kroneckerLineRep` is built with the file-local `TauCeti.kroneckerRep` constructor of `Quiver/Kronecker/Representation.lean`, so only the two arrow actions have to be described. A morphism between two lines is recorded by a single scalar, the value at `1` of its component at the source vertex: naturality makes the two components agree -- along any non-distinguished arrow, or along the distinguished one when it acts invertibly -- so that scalar is faithful, and `TauCeti.indecomposable_of_injective_of_isLocalRing` at the base field then gives indecomposability, the route the Jordan blocks of `Quiver/Kronecker/FiniteRepType.lean` already take at a truncated polynomial algebra. Naturality along the distinguished arrow gives `c · s = d · s` for the scalar `s` of a morphism from the line at `c` to the line at `d`; along an isomorphism `s` is invertible, which is the classification `TauCeti.nonempty_kroneckerLineRep_iso_iff`.

The morphisms are described in both directions, after the pattern of `TauCeti.oneLoopRepScalar` / `TauCeti.oneLoopRepHom` of the loop quiver: `TauCeti.kroneckerLineRepScalar` reads the scalar off a morphism, `TauCeti.kroneckerLineRepHom` builds the morphism back from a scalar `s` with `c * s = d * s`, and `TauCeti.kroneckerLineRepScalar_kroneckerLineRepHom` together with the eta theorem `TauCeti.kroneckerLineRepHom_kroneckerLineRepScalar` identifies the two on a quiver carrying a second arrow.

The point of the family is what it says about the Gabriel correspondence, and both statements are recorded. `TauCeti.exists_indecomposable_dimVector_eq_not_nonempty_iso_kronecker` exhibits, over every field and for any generalized Kronecker quiver with two distinct arrows, two non-isomorphic finite-dimensional indecomposables with the same dimension vector — the lines at `0` and at `1`. `TauCeti.titsForm_dimVector_kroneckerLineRep` computes the Tits value of that common dimension vector as `2 − #arrows`, so it is `1` only for the `A₂` quiver. Together they are the sharpness of `TauCeti.nonempty_iso_of_dimVector_eq_of_indecomposable_of_isAcyclic` and of `TauCeti.titsForm_dimVector_eq_one_of_indecomposable_of_isAcyclic`: both are proved for an acyclic quiver whose Tits form is *positive definite*, and the Kronecker quiver — acyclic, with a Tits form that is only positive semidefinite — shows that neither survives weakening that hypothesis to acyclicity alone.

The relation to what is already there is spelled out in the module docstring. `Quiver/Kronecker/FiniteRepType.lean` settles the representation type with Jordan blocks that grow in dimension, and records in its implementation notes that the lines built here "are indecomposable and pairwise non-isomorphic, but over a finite field there are only finitely many of them" — so they are the wrong tool for that theorem and are not built there. They are the right tool for this one, since infinitude is not what is wanted: two members over any field already break the injection, and the member at `c = 0` is the smallest Jordan block up to the identification of `k[X]/(X)` with `k`. The family normalizes the non-distinguished arrows to the identity, which is the affine chart `c₁ ≠ 0` of `[c₀ : c₁]`; the one omitted class, where the distinguished arrow acts by the identity and every other arrow by zero, is named in the docstring and not built, and neither is the exhaustiveness of the resulting list. The projective family itself — a construction indexed by `[c₀ : c₁]`, with a classification at every projective point — is not part of this PR, and the module docstring says so.

No Mathlib infrastructure is vendored. `lake build` and `lake exe axioms` are green, the axiom audit reporting all declarations within `[propext, Classical.choice, Quot.sound]`.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"kronecker-p1-family-dimension-vector-1-1"}-->

🤖 Prepared with Claude Code



