### PR TITLE
refactor(ModularForms): name the bar-stays-in-its-coset step used three times

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Action.lean
@@ -59,6 +59,13 @@ attribute [local instance] Fintype.ofFinite
 local notation "Γ₀Q(" N ")" => Subgroup.map (mapGL ℚ) (Gamma0 N)
 local notation "Coset₀(" N ")" => HeckeCoset (Delta0 N) (Γ₀Q(N)) (Γ₀Q(N))
 
+/-- The Atkin-Lehner bar of a coset's chosen representative stays inside that coset. -/
+private lemma bar_out_mem_doubleCoset_rep (D : Coset₀(N)) :
+    ((atkinLehnerAntiInvolution N).bar D.out D.out.2 : GL (Fin 2) ℚ) ∈
+      doubleCoset (D.rep : GL (Fin 2) ℚ) (Γ₀Q(N)) (Γ₀Q(N)) := by
+  rw [HeckeCoset.rep_def]
+  exact atkinLehnerAntiInvolution_bar_mem_doubleCoset N D.out D.out.2
+
 /-- The reversed, inverted multiplicity from a right slash action is the ordinary `Γ₀(N)`
 Hecke-ring structure constant. -/
 theorem multiplicity_inv_reverse_eq (D₁ D₂ D : Coset₀(N)) :
@@ -81,18 +88,6 @@ theorem multiplicity_inv_reverse_eq (D₁ D₂ D : Coset₀(N)) :
         multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
           (c : GL (Fin 2) ℚ) (a : GL (Fin 2) ℚ) (d : GL (Fin 2) ℚ) :=
     ι.multiplicity_comm hfix a c d
-  have hb₁ : (b₁ : GL (Fin 2) ℚ) ∈
-      doubleCoset (D₁.rep : GL (Fin 2) ℚ) (Γ₀Q(N)) (Γ₀Q(N)) := by
-    rw [HeckeCoset.rep_def]
-    exact atkinLehnerAntiInvolution_bar_mem_doubleCoset N D₁.out D₁.out.2
-  have hb₂ : (b₂ : GL (Fin 2) ℚ) ∈
-      doubleCoset (D₂.rep : GL (Fin 2) ℚ) (Γ₀Q(N)) (Γ₀Q(N)) := by
-    rw [HeckeCoset.rep_def]
-    exact atkinLehnerAntiInvolution_bar_mem_doubleCoset N D₂.out D₂.out.2
-  have hb : (b : GL (Fin 2) ℚ) ∈
-      doubleCoset (D.rep : GL (Fin 2) ℚ) (Γ₀Q(N)) (Γ₀Q(N)) := by
-    rw [HeckeCoset.rep_def]
-    exact atkinLehnerAntiInvolution_bar_mem_doubleCoset N D.out D.out.2
   rw [atkinLehnerAutomorphism_map_Gamma0] at hmap
   rw [atkinLehnerAutomorphism_inv_apply N D₂.out.2,
     atkinLehnerAutomorphism_inv_apply N D₁.out.2,
@@ -102,21 +97,21 @@ theorem multiplicity_inv_reverse_eq (D₁ D₂ D : Coset₀(N)) :
         (b₂ : GL (Fin 2) ℚ) (b₁ : GL (Fin 2) ℚ) (b : GL (Fin 2) ℚ) := hmap.symm
     _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
         (b₂ : GL (Fin 2) ℚ) (b₁ : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
-      multiplicity_doubleCoset_congr _ _ hb
+      multiplicity_doubleCoset_congr _ _ (bar_out_mem_doubleCoset_rep D)
     _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
         (b₁ : GL (Fin 2) ℚ) (b₂ : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
       hcomm b₂ b₁ D.rep
     _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
         (b₁ : GL (Fin 2) ℚ) (D₂.rep : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
       multiplicity_doubleCoset_congr_second (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
-        b₁ D.rep hb₂
+        b₁ D.rep (bar_out_mem_doubleCoset_rep D₂)
     _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
         (D₂.rep : GL (Fin 2) ℚ) (b₁ : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
       (hcomm D₂.rep b₁ D.rep).symm
     _ = multiplicity (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
         (D₂.rep : GL (Fin 2) ℚ) (D₁.rep : GL (Fin 2) ℚ) (D.rep : GL (Fin 2) ℚ) :=
       multiplicity_doubleCoset_congr_second (Γ₀Q(N)) (Γ₀Q(N)) (Γ₀Q(N))
-        D₂.rep D.rep hb₁
+        D₂.rep D.rep (bar_out_mem_doubleCoset_rep D₁)
     _ = _ := hcomm D₂.rep D₁.rep D.rep
 
 open Classical in


### PR DESCRIPTION
`multiplicity_inv_reverse_eq` ran to **61 lines**, the only declaration in
`Nebentypus/Action.lean` over the 50-line cap.

Twelve of those lines were the same three-line argument written out once per coset — for
`D₁`, for `D₂`, and for `D`:

```lean
have hb₁ : (b₁ : GL (Fin 2) ℚ) ∈
    doubleCoset (D₁.rep : GL (Fin 2) ℚ) (Γ₀Q(N)) (Γ₀Q(N)) := by
  rw [HeckeCoset.rep_def]
  exact atkinLehnerAntiInvolution_bar_mem_doubleCoset N D₁.out D₁.out.2
```

### What changed

* New `private lemma bar_out_mem_doubleCoset_rep`: the Atkin–Lehner bar of a coset's chosen
  representative stays inside that coset. Called at the three sites, inline in the `calc`.
* `multiplicity_inv_reverse_eq` **61L → 49L**, and the file has **no over-cap declaration
  left**.

No statement changes; the three local abbreviations `b₁`, `b₂`, `b` are all still used.

### On reuse — what this does and does not duplicate

TauCeti already has `HeckeAntiInvolution.bar_mem_doubleCoset_self`
(`HeckeRing/Commutativity.lean:188`), and it is worth being precise about why it is not the
same statement. That lemma concludes membership in `doubleCoset (g : G) H H` — the double
coset of *the element itself*. The step factored here concludes membership in
`doubleCoset (D.rep) …` — the double coset of *the coset's chosen representative*. The
`HeckeCoset.rep_def` bridge between the two is exactly what was being repeated, and no
existing declaration states it.

### Verification

* `lake build TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Action` — clean.
* `#lint` with the 13-linter set (`checkType defsWithUnderscore deprecatedNoSince
  impossibleInstance nonClassInstance simpComm simpNF structureInType
  subsetDotNotationLinter synTaut tacticDocs unusedArguments unusedHavesSuffices`) over the
  import cone: **0 errors in 858 declarations**.
* No line over 100 characters; no trailing whitespace.

Roadmap: ModularForms

Provenance: refactor of already-merged TauCeti code; no new mathematics, so no target
marker. Swept github.com/CBirkbeck/AINTLIB @ 2baa76f742bdb4fb8ee323fabba41203bd390e08
(Apache-2.0): its `bar_mem_doubleCoset` (`AbstractHeckeRing/Commutativity.lean`) is the
abstract statement under a global fixed-point hypothesis for an arbitrary element of the
coset, not this instance at the chosen representative. Nothing was transcribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
