### PR TITLE
feat: the inertia group of a linear character of the alternating group

### DIFF
--- a/TauCeti/GroupTheory/GroupAction/ConjAct.lean
+++ b/TauCeti/GroupTheory/GroupAction/ConjAct.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.GroupAction.ConjAct
+
+/-!
+# Conjugation by an element of a normal subgroup, seen through a commutative target
+
+A normal subgroup `N` of `G` carries the conjugation action `MulAut.conjNormal` of the whole of
+`G`. Conjugation by an element of `N` itself is inner, so a homomorphism `ψ : N →* M` to a
+*commutative* group cannot see it: conjugating the argument conjugates the value, and in a
+commutative group that is the value again.
+
+## Main statements
+
+* `TauCeti.map_conjNormal_val`: a homomorphism from a normal subgroup to a commutative group is
+  unchanged by conjugation by an element of that subgroup.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {G M : Type*} [Group G] [CommGroup M] {N : Subgroup G} [N.Normal]
+
+/-- **Conjugation by an element of a normal subgroup does not move a homomorphism from that
+subgroup to a commutative group**: it conjugates the value, which is the value. -/
+theorem map_conjNormal_val (ψ : N →* M) (a x : N) : ψ (MulAut.conjNormal (a : G) x) = ψ x := by
+  simp [MulAut.conjNormal_val, MulAut.conj_apply]
+
+end TauCeti

--- a/TauCeti/GroupTheory/GroupAction/ConjAct.lean
+++ b/TauCeti/GroupTheory/GroupAction/ConjAct.lean
@@ -17,19 +17,20 @@ commutative group that is the value again.
 
 ## Main statements
 
-* `TauCeti.map_conjNormal_val`: a homomorphism from a normal subgroup to a commutative group is
+* `MonoidHom.map_conjNormal_val`: a homomorphism from a normal subgroup to a commutative group is
   unchanged by conjugation by an element of that subgroup.
 -/
 
 public section
 
-namespace TauCeti
+namespace MonoidHom
 
 variable {G M : Type*} [Group G] [CommGroup M] {N : Subgroup G} [N.Normal]
 
 /-- **Conjugation by an element of a normal subgroup does not move a homomorphism from that
 subgroup to a commutative group**: it conjugates the value, which is the value. -/
+@[simp]
 theorem map_conjNormal_val (ψ : N →* M) (a x : N) : ψ (MulAut.conjNormal (a : G) x) = ψ x := by
   simp [MulAut.conjNormal_val, MulAut.conj_apply]
 
-end TauCeti
+end MonoidHom

--- a/TauCeti/GroupTheory/GroupAction/ConjAct.lean
+++ b/TauCeti/GroupTheory/GroupAction/ConjAct.lean
@@ -12,8 +12,7 @@ public import Mathlib.GroupTheory.GroupAction.ConjAct
 
 A normal subgroup `N` of `G` carries the conjugation action `MulAut.conjNormal` of the whole of
 `G`. Conjugation by an element of `N` itself is inner, so a homomorphism `ψ : N →* M` to a
-*commutative* monoid cannot see it: the images of the conjugating element and of its inverse cancel
-in the target.
+*commutative* monoid cannot see it: conjugate elements of `N` have the same image in `M`.
 
 ## Main statements
 
@@ -28,11 +27,12 @@ namespace MonoidHom
 variable {G M : Type*} [Group G] [CommMonoid M] {N : Subgroup G} [N.Normal]
 
 /-- **Conjugation by an element of a normal subgroup does not move a homomorphism from that
-subgroup to a commutative monoid**: the images of the conjugating element and of its inverse
-cancel. -/
+subgroup to a commutative monoid**: conjugate elements have the same image in a commutative
+target. -/
 @[simp]
 theorem map_conjNormal_val (ψ : N →* M) (a x : N) : ψ (MulAut.conjNormal (a : G) x) = ψ x := by
-  rw [MulAut.conjNormal_val, MulAut.conj_apply, map_mul, map_mul, mul_right_comm, ← map_mul,
-    mul_inv_cancel, map_one, one_mul]
+  have h : IsConj x (MulAut.conjNormal (a : G) x) :=
+    isConj_iff.mpr ⟨a, by rw [MulAut.conjNormal_val, MulAut.conj_apply]⟩
+  exact (isConj_iff_eq.mp (ψ.map_isConj h)).symm
 
 end MonoidHom

--- a/TauCeti/GroupTheory/GroupAction/ConjAct.lean
+++ b/TauCeti/GroupTheory/GroupAction/ConjAct.lean
@@ -12,12 +12,12 @@ public import Mathlib.GroupTheory.GroupAction.ConjAct
 
 A normal subgroup `N` of `G` carries the conjugation action `MulAut.conjNormal` of the whole of
 `G`. Conjugation by an element of `N` itself is inner, so a homomorphism `ψ : N →* M` to a
-*commutative* group cannot see it: conjugating the argument conjugates the value, and in a
-commutative group that is the value again.
+*commutative* monoid cannot see it: the images of the conjugating element and of its inverse cancel
+in the target.
 
 ## Main statements
 
-* `MonoidHom.map_conjNormal_val`: a homomorphism from a normal subgroup to a commutative group is
+* `MonoidHom.map_conjNormal_val`: a homomorphism from a normal subgroup to a commutative monoid is
   unchanged by conjugation by an element of that subgroup.
 -/
 
@@ -25,12 +25,14 @@ public section
 
 namespace MonoidHom
 
-variable {G M : Type*} [Group G] [CommGroup M] {N : Subgroup G} [N.Normal]
+variable {G M : Type*} [Group G] [CommMonoid M] {N : Subgroup G} [N.Normal]
 
 /-- **Conjugation by an element of a normal subgroup does not move a homomorphism from that
-subgroup to a commutative group**: it conjugates the value, which is the value. -/
+subgroup to a commutative monoid**: the images of the conjugating element and of its inverse
+cancel. -/
 @[simp]
 theorem map_conjNormal_val (ψ : N →* M) (a x : N) : ψ (MulAut.conjNormal (a : G) x) = ψ x := by
-  simp [MulAut.conjNormal_val, MulAut.conj_apply]
+  rw [MulAut.conjNormal_val, MulAut.conj_apply, map_mul, map_mul, mul_right_comm, ← map_mul,
+    mul_inv_cancel, map_one, one_mul]
 
 end MonoidHom

--- a/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
+++ b/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
@@ -45,14 +45,14 @@ trivial character.
 
 ## Main statements
 
-* `TauCeti.eq_one_of_map_conjNormal_eq_alternatingGroup`: **a linear character of the alternating
+* `MonoidHom.eq_one_of_map_conjNormal_eq_alternatingGroup`: **a linear character of the alternating
   group fixed by conjugation by an odd permutation is trivial.**
-* `TauCeti.map_conjNormal_alternatingGroup_eq_inv`: **an odd permutation inverts every linear
-  character of the alternating group**, with `TauCeti.comp_conjNormal_alternatingGroup_eq_inv` its
-  form as an equality of homomorphisms.
-* `TauCeti.exists_map_conjNormal_alternatingGroup_ne`: an odd permutation moves every nontrivial
+* `MonoidHom.map_conjNormal_alternatingGroup_eq_inv`: **an odd permutation inverts every linear
+  character of the alternating group**, with `MonoidHom.comp_conjNormal_alternatingGroup_eq_inv`
+  its form as an equality of homomorphisms.
+* `MonoidHom.exists_map_conjNormal_alternatingGroup_ne`: an odd permutation moves every nontrivial
   linear character -- the hypothesis of the Mackey irreducibility criterion.
-* `TauCeti.comp_conjNormal_alternatingGroup_ne`: the same as an inequality of homomorphisms, so
+* `MonoidHom.comp_conjNormal_alternatingGroup_ne`: the same as an inequality of homomorphisms, so
   that a nontrivial linear character and its conjugate by an odd permutation are two distinct
   members of one orbit.
 * `TauCeti.exists_monoidHom_alternatingGroup_ne_one`: **`A₄` has a nontrivial linear character.**
@@ -64,15 +64,11 @@ trivial character.
 
 public section
 
-namespace TauCeti
-
 open Equiv Equiv.Perm
 
 variable {α : Type*} [DecidableEq α] [Fintype α]
 
-section Character
-
-variable {M : Type*} [CommGroup M] (χ : alternatingGroup α →* M)
+namespace TauCeti
 
 /-- Two odd permutations differ by an even one. -/
 private theorem mul_inv_mem_alternatingGroup {g s : Perm α} (hg : g ∉ alternatingGroup α)
@@ -96,6 +92,14 @@ private theorem mul_self_mem_alternatingGroup {s : Perm α} (hs : s ∉ alternat
   · rw [h]
     decide
 
+end TauCeti
+
+namespace MonoidHom
+
+open TauCeti
+
+variable {M : Type*} [CommGroup M] (χ : alternatingGroup α →* M)
+
 /-- A linear character fixed by conjugation by one odd permutation is fixed by conjugation by
 every permutation: the even ones fix it because the target is commutative, and every odd one is an
 even one times the given one. -/
@@ -116,9 +120,8 @@ private theorem map_conjNormal_alternatingGroup_of_fixed {s : Perm α}
     exact (map_conjNormal_val χ ⟨g * s⁻¹, hgs⟩ _).trans (h x)
 
 /-- **A linear character of the alternating group fixed by conjugation by an odd permutation is
-trivial.** Such a character is fixed by conjugation by every permutation, hence takes the same
-value at a three-cycle and at its inverse; that value is therefore its own inverse while also
-cubing to `1`, so it is `1`, and the three-cycles generate the alternating group. -/
+trivial.** Equivalently, the conjugation action of `Equiv.Perm α` on the linear characters of
+`alternatingGroup α` has only the trivial character as a fixed point. -/
 theorem eq_one_of_map_conjNormal_eq_alternatingGroup {s : Perm α} (hs : s ∉ alternatingGroup α)
     (h : ∀ x : alternatingGroup α, χ (MulAut.conjNormal s x) = χ x) : χ = 1 := by
   have hall := map_conjNormal_alternatingGroup_of_fixed χ hs h
@@ -130,7 +133,7 @@ theorem eq_one_of_map_conjNormal_eq_alternatingGroup {s : Perm α} (hs : s ∉ a
     have hconj : MulAut.conjNormal g (⟨c, hcmem⟩ : alternatingGroup α) = (⟨c, hcmem⟩)⁻¹ :=
       Subtype.ext (by simpa using hg)
     have hinv : (χ (⟨c, hcmem⟩ : alternatingGroup α))⁻¹ = χ ⟨c, hcmem⟩ := by
-      rw [← map_inv, ← hconj]
+      rw [← _root_.map_inv, ← hconj]
       exact hall g _
     have hsq : χ (⟨c, hcmem⟩ : alternatingGroup α) ^ 2 = 1 := by
       rw [pow_two]
@@ -138,7 +141,7 @@ theorem eq_one_of_map_conjNormal_eq_alternatingGroup {s : Perm α} (hs : s ∉ a
     have hpow : (⟨c, hcmem⟩ : alternatingGroup α) ^ 3 = 1 :=
       orderOf_dvd_iff_pow_eq_one.mp (by rw [Subgroup.orderOf_mk, hc.orderOf])
     have hcube : χ (⟨c, hcmem⟩ : alternatingGroup α) ^ 3 = 1 := by
-      rw [← map_pow, hpow, map_one]
+      rw [← _root_.map_pow, hpow, _root_.map_one]
     have hstep : χ (⟨c, hcmem⟩ : alternatingGroup α) ^ 2 * χ (⟨c, hcmem⟩ : alternatingGroup α)
         = 1 := by
       rw [← pow_succ]
@@ -156,9 +159,8 @@ theorem eq_one_of_map_conjNormal_eq_alternatingGroup {s : Perm α} (hs : s ∉ a
   rw [MonoidHom.one_apply, ← hyx]
   exact hy
 
-/-- **An odd permutation inverts every linear character of the alternating group.** The product of
-`χ` with its conjugate by `s` is fixed by conjugation by `s`, because `s * s` is even, hence
-trivial. -/
+/-- **An odd permutation inverts every linear character of the alternating group.** -/
+@[simp]
 theorem map_conjNormal_alternatingGroup_eq_inv {s : Perm α} (hs : s ∉ alternatingGroup α)
     (x : alternatingGroup α) : χ (MulAut.conjNormal s x) = (χ x)⁻¹ := by
   have hsq : s * s ∈ alternatingGroup α := mul_self_mem_alternatingGroup hs
@@ -187,8 +189,9 @@ theorem map_conjNormal_alternatingGroup_eq_inv {s : Perm α} (hs : s ∉ alterna
 
 /-- **An odd permutation inverts every linear character of the alternating group**, as an equality
 of homomorphisms. -/
+@[simp]
 theorem comp_conjNormal_alternatingGroup_eq_inv {s : Perm α} (hs : s ∉ alternatingGroup α) :
-    χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom = χ⁻¹ :=
+    χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)) = χ⁻¹ :=
   MonoidHom.ext fun x => map_conjNormal_alternatingGroup_eq_inv χ hs x
 
 /-- **An odd permutation moves every nontrivial linear character of the alternating group.** This
@@ -205,17 +208,16 @@ permutation are distinct**, so the two of them make up a single orbit of the con
 `Equiv.Perm α` on the characters. -/
 theorem comp_conjNormal_alternatingGroup_ne (hχ : χ ≠ 1) {s : Perm α}
     (hs : s ∉ alternatingGroup α) :
-    χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom ≠ χ := fun hcon =>
+    χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)) ≠ χ := fun hcon =>
   hχ (eq_one_of_map_conjNormal_eq_alternatingGroup χ hs
     fun x => congrArg (fun f : alternatingGroup α →* M => f x) hcon)
 
-end Character
+end MonoidHom
 
-section Existence
+namespace TauCeti
 
-/-- **The abelianization of `A₄` is nontrivial**, witnessed by an even permutation outside the
-Klein four subgroup: that subgroup is the commutator subgroup of `A₄`, and it has order `4` inside
-a group of order `12`. -/
+/-- **The abelianization of `A₄` is nontrivial**: its commutator subgroup is the Klein four
+subgroup, a proper subgroup. -/
 theorem exists_abelianization_of_ne_one_alternatingGroup (hα : Nat.card α = 4) :
     ∃ x : alternatingGroup α, Abelianization.of x ≠ 1 := by
   have hne : alternatingGroup.kleinFour α ≠ ⊤ := by
@@ -239,11 +241,8 @@ variable (M : Type*) [CommMonoid M]
   [HasEnoughRootsOfUnity M (Monoid.exponent (Abelianization (alternatingGroup α)))]
 
 /-- **`A₄` has a nontrivial linear character** valued in any commutative monoid with enough roots
-of unity for the exponent of the abelianization `A₄ / V₄` -- through which every such character
-factors, and for which an algebraically closed field of characteristic zero supplies the roots.
-The character comes from that abelianization, which
-`TauCeti.exists_abelianization_of_ne_one_alternatingGroup` shows is nontrivial, by the duality of
-finite abelian groups. -/
+of unity for the exponent of the abelianization `A₄ / V₄`, through which every such character
+factors and for which an algebraically closed field of characteristic zero supplies the roots. -/
 theorem exists_monoidHom_alternatingGroup_ne_one (hα : Nat.card α = 4) :
     ∃ χ : alternatingGroup α →* Mˣ, χ ≠ 1 := by
   obtain ⟨x, hx⟩ := exists_abelianization_of_ne_one_alternatingGroup (α := α) hα
@@ -252,7 +251,5 @@ theorem exists_monoidHom_alternatingGroup_ne_one (hα : Nat.card α = 4) :
       hx
   refine ⟨φ.comp Abelianization.of, fun hcon => hφ ?_⟩
   simpa using congrArg (fun f : alternatingGroup α →* Mˣ => f x) hcon
-
-end Existence
 
 end TauCeti

--- a/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
+++ b/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
@@ -1,0 +1,273 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.FiniteAbelian.Duality
+public import Mathlib.GroupTheory.GroupAction.ConjAct
+public import Mathlib.GroupTheory.SpecificGroups.Alternating.KleinFour
+
+/-!
+# An odd permutation inverts every linear character of the alternating group
+
+Let `α` be a finite type and let `χ` be a homomorphism from `alternatingGroup α` to a commutative
+group. Conjugation by an *even* permutation cannot move `χ`, the target being commutative. This
+file proves that conjugation by an **odd** permutation inverts it:
+
+`χ (s x s⁻¹) = (χ x)⁻¹` for every `s ∉ alternatingGroup α` and every `x`.
+
+The argument is short and uniform in `α`. The product of `χ` with its conjugate by `s` is fixed by
+conjugation by `s`, because `s * s` is even; and a character fixed by conjugation by *one* odd
+permutation is fixed by conjugation by *every* permutation, since the odd permutations form a
+single coset of the even ones. Such a character kills every three-cycle `c`, because `c` is
+conjugate in `Equiv.Perm α` to its own inverse, so the value at `c` is its own inverse while also
+cubing to `1`. Three-cycles generate the alternating group, so the character is trivial, which is
+the claim.
+
+The consequence the file exists for is that a **nontrivial** linear character `χ` satisfies
+`χ ∘ conj s ≠ χ` for every odd `s`: otherwise `χ` would be its own inverse and the same lemma would
+make it trivial. So the odd permutations move `χ`, and `{χ, χ⁻¹}` is a single orbit of two
+characters under the conjugation action of `Equiv.Perm α`. That is exactly the hypothesis of the
+Mackey irreducibility criterion for an induced linear character, applied to `A₄ ◁ S₄` in
+`TauCeti.RepresentationTheory.Induction.Clifford.Alternating`.
+
+For that application to be about something, `alternatingGroup α` must *have* a nontrivial linear
+character, which for `Nat.card α = 4` it does: Mathlib's `alternatingGroup.kleinFour_eq_commutator`
+identifies the commutator subgroup of `A₄` with the Klein four subgroup, of order `4` inside a
+group of order `12`, so the commutator subgroup is proper and the duality of finite abelian groups
+produces a character of the abelianization that does not kill it. For `4 < Nat.card α` the
+alternating group is perfect instead, and the statements above are then all vacuously about the
+trivial character.
+
+## Main statements
+
+* `TauCeti.eq_one_of_map_conjNormal_eq_alternatingGroup`: **a linear character of the alternating
+  group fixed by conjugation by an odd permutation is trivial.**
+* `TauCeti.map_conjNormal_alternatingGroup_eq_inv`: **an odd permutation inverts every linear
+  character of the alternating group**, with `TauCeti.comp_conjNormal_alternatingGroup_eq_inv` its
+  form as an equality of homomorphisms.
+* `TauCeti.exists_map_conjNormal_alternatingGroup_ne`: an odd permutation moves every nontrivial
+  linear character -- the hypothesis of the Mackey irreducibility criterion.
+* `TauCeti.comp_conjNormal_alternatingGroup_ne`: the same as an inequality of homomorphisms, so
+  that a nontrivial linear character and its conjugate by an odd permutation are two distinct
+  members of one orbit.
+* `TauCeti.exists_monoidHom_alternatingGroup_ne_one`: **`A₄` has a nontrivial linear character.**
+
+## References
+
+The group theory behind the "Clifford on `A₄ ◁ S₄`" worked example of
+[the induction and restriction roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md).
+
+* J.-P. Serre, *Linear Representations of Finite Groups*, Chapter 5.
+-/
+
+public section
+
+namespace TauCeti
+
+open Equiv Equiv.Perm
+
+variable {α : Type*} [DecidableEq α] [Fintype α]
+
+section Character
+
+variable {M : Type*} [CommGroup M] (χ : alternatingGroup α →* M)
+
+/-- Conjugation by an element of a normal subgroup does not move a homomorphism from that subgroup
+to a commutative group: it conjugates the value, which is the value. -/
+private theorem map_conjNormal_of_mem_subgroup {G : Type*} [Group G] {N : Subgroup G} [N.Normal]
+    (ψ : N →* M) (a x : N) : ψ (MulAut.conjNormal (a : G) x) = ψ x := by
+  rw [MulAut.conjNormal_val, MulAut.conj_apply, map_mul, map_mul, map_inv,
+    mul_comm (ψ a) (ψ x), mul_assoc, mul_inv_cancel, mul_one]
+
+/-- Two odd permutations differ by an even one. -/
+private theorem mul_inv_mem_alternatingGroup {g s : Perm α} (hg : g ∉ alternatingGroup α)
+    (hs : s ∉ alternatingGroup α) : g * s⁻¹ ∈ alternatingGroup α := by
+  simp only [mem_alternatingGroup] at hg hs ⊢
+  rw [map_mul, map_inv]
+  rcases Int.units_eq_one_or (sign g) with h | h
+  · exact absurd h hg
+  · rcases Int.units_eq_one_or (sign s) with h' | h'
+    · exact absurd h' hs
+    · rw [h, h']
+      decide
+
+/-- The square of an odd permutation is even. -/
+private theorem mul_self_mem_alternatingGroup {s : Perm α} (hs : s ∉ alternatingGroup α) :
+    s * s ∈ alternatingGroup α := by
+  simp only [mem_alternatingGroup] at hs ⊢
+  rw [map_mul]
+  rcases Int.units_eq_one_or (sign s) with h | h
+  · exact absurd h hs
+  · rw [h]
+    decide
+
+/-- A linear character fixed by conjugation by one odd permutation is fixed by conjugation by
+every permutation: the even ones fix it because the target is commutative, and every odd one is an
+even one times the given one. -/
+private theorem map_conjNormal_alternatingGroup_of_fixed {s : Perm α}
+    (hs : s ∉ alternatingGroup α)
+    (h : ∀ x : alternatingGroup α, χ (MulAut.conjNormal s x) = χ x) (g : Perm α)
+    (x : alternatingGroup α) : χ (MulAut.conjNormal g x) = χ x := by
+  by_cases hg : g ∈ alternatingGroup α
+  · exact map_conjNormal_of_mem_subgroup χ ⟨g, hg⟩ x
+  · have hgs : g * s⁻¹ ∈ alternatingGroup α := mul_inv_mem_alternatingGroup hg hs
+    have hfac : (MulAut.conjNormal g : MulAut (alternatingGroup α)) =
+        MulAut.conjNormal ((⟨g * s⁻¹, hgs⟩ : alternatingGroup α) : Perm α) *
+          MulAut.conjNormal s := by
+      rw [← map_mul]
+      congr 1
+      simp
+    rw [hfac]
+    exact (map_conjNormal_of_mem_subgroup χ ⟨g * s⁻¹, hgs⟩ _).trans (h x)
+
+/-- **A linear character of the alternating group fixed by conjugation by an odd permutation is
+trivial.** Such a character is fixed by conjugation by every permutation, hence takes the same
+value at a three-cycle and at its inverse; that value is therefore its own inverse while also
+cubing to `1`, so it is `1`, and the three-cycles generate the alternating group. -/
+theorem eq_one_of_map_conjNormal_eq_alternatingGroup {s : Perm α} (hs : s ∉ alternatingGroup α)
+    (h : ∀ x : alternatingGroup α, χ (MulAut.conjNormal s x) = χ x) : χ = 1 := by
+  have hall := map_conjNormal_alternatingGroup_of_fixed χ hs h
+  -- The character kills every three-cycle.
+  have hthree : ∀ c : Perm α, c.IsThreeCycle → ∀ hc : c ∈ alternatingGroup α, χ ⟨c, hc⟩ = 1 := by
+    intro c hc hcmem
+    -- Every permutation is conjugate to its inverse: the two have the same cycle type.
+    obtain ⟨g, hg⟩ := isConj_iff.mp (isConj_iff_cycleType_eq.mpr (cycleType_inv c).symm)
+    have hconj : MulAut.conjNormal g (⟨c, hcmem⟩ : alternatingGroup α) = (⟨c, hcmem⟩)⁻¹ :=
+      Subtype.ext (by simpa using hg)
+    have hinv : (χ (⟨c, hcmem⟩ : alternatingGroup α))⁻¹ = χ ⟨c, hcmem⟩ := by
+      rw [← map_inv, ← hconj]
+      exact hall g _
+    have hsq : χ (⟨c, hcmem⟩ : alternatingGroup α) ^ 2 = 1 := by
+      rw [pow_two]
+      exact eq_inv_iff_mul_eq_one.mp hinv.symm
+    have hpow : (⟨c, hcmem⟩ : alternatingGroup α) ^ 3 = 1 :=
+      orderOf_dvd_iff_pow_eq_one.mp (by rw [Subgroup.orderOf_mk, hc.orderOf])
+    have hcube : χ (⟨c, hcmem⟩ : alternatingGroup α) ^ 3 = 1 := by
+      rw [← map_pow, hpow, map_one]
+    have hstep : χ (⟨c, hcmem⟩ : alternatingGroup α) ^ 2 * χ (⟨c, hcmem⟩ : alternatingGroup α)
+        = 1 := by
+      rw [← pow_succ]
+      exact hcube
+    rwa [hsq, one_mul] at hstep
+  -- Three-cycles generate the alternating group, so the kernel is everything.
+  have hle : alternatingGroup α ≤ χ.ker.map (alternatingGroup α).subtype := by
+    refine le_trans (le_of_eq closure_three_cycles_eq_alternating.symm) ?_
+    rw [Subgroup.closure_le]
+    rintro c (hc : c.IsThreeCycle)
+    exact Subgroup.mem_map.mpr ⟨⟨c, hc.mem_alternatingGroup⟩, hthree c hc _, rfl⟩
+  ext x
+  obtain ⟨y, hy, hxy⟩ := Subgroup.mem_map.mp (hle x.2)
+  rw [MonoidHom.one_apply, ← show y = x from Subtype.ext hxy]
+  exact hy
+
+/-- **An odd permutation inverts every linear character of the alternating group.** The product of
+`χ` with its conjugate by `s` is fixed by conjugation by `s`, because `s * s` is even, hence
+trivial. -/
+theorem map_conjNormal_alternatingGroup_eq_inv {s : Perm α} (hs : s ∉ alternatingGroup α)
+    (x : alternatingGroup α) : χ (MulAut.conjNormal s x) = (χ x)⁻¹ := by
+  have hsq : s * s ∈ alternatingGroup α := mul_self_mem_alternatingGroup hs
+  have hcomp : ∀ y : alternatingGroup α,
+      (MulAut.conjNormal s) ((MulAut.conjNormal s) y) = MulAut.conjNormal (s * s) y := by
+    intro y
+    rw [map_mul]
+    rfl
+  have hfix : ∀ y : alternatingGroup α,
+      (χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom * χ)
+          (MulAut.conjNormal s y) =
+        (χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom * χ) y := by
+    intro y
+    simp only [MonoidHom.mul_apply, MonoidHom.coe_comp, Function.comp_apply,
+      MulEquiv.coe_toMonoidHom]
+    rw [hcomp y, show χ (MulAut.conjNormal (s * s) y) = χ y from
+      map_conjNormal_of_mem_subgroup χ ⟨s * s, hsq⟩ y, mul_comm]
+  have hone := eq_one_of_map_conjNormal_eq_alternatingGroup _ hs hfix
+  have hx : (χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom * χ) x = 1 := by
+    rw [hone]
+    rfl
+  simp only [MonoidHom.mul_apply, MonoidHom.coe_comp, Function.comp_apply,
+    MulEquiv.coe_toMonoidHom] at hx
+  exact eq_inv_of_mul_eq_one_left hx
+
+/-- **An odd permutation inverts every linear character of the alternating group**, as an equality
+of homomorphisms. -/
+theorem comp_conjNormal_alternatingGroup_eq_inv {s : Perm α} (hs : s ∉ alternatingGroup α) :
+    χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom = χ⁻¹ :=
+  MonoidHom.ext fun x => map_conjNormal_alternatingGroup_eq_inv χ hs x
+
+/-- **An odd permutation moves every nontrivial linear character of the alternating group.** This
+is the hypothesis of the Mackey irreducibility criterion for an induced linear character, checked
+at `A₄ ◁ S₄`. -/
+theorem exists_map_conjNormal_alternatingGroup_ne (hχ : χ ≠ 1) {s : Perm α}
+    (hs : s ∉ alternatingGroup α) : ∃ x : alternatingGroup α, χ (MulAut.conjNormal s x) ≠ χ x := by
+  by_contra hcon
+  push Not at hcon
+  exact hχ (eq_one_of_map_conjNormal_eq_alternatingGroup χ hs hcon)
+
+/-- **A nontrivial linear character of the alternating group and its conjugate by an odd
+permutation are distinct**, so the two of them make up a single orbit of the conjugation action of
+`Equiv.Perm α` on the characters. -/
+theorem comp_conjNormal_alternatingGroup_ne (hχ : χ ≠ 1) {s : Perm α}
+    (hs : s ∉ alternatingGroup α) :
+    χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom ≠ χ := fun hcon =>
+  hχ (eq_one_of_map_conjNormal_eq_alternatingGroup χ hs
+    fun x => congrArg (fun f : alternatingGroup α →* M => f x) hcon)
+
+end Character
+
+section Existence
+
+/-- The canonical map to the abelianization is surjective. -/
+private theorem surjective_abelianization_of (G : Type*) [Group G] :
+    Function.Surjective (Abelianization.of : G →* Abelianization G) := fun y =>
+  QuotientGroup.induction_on y fun x => ⟨x, rfl⟩
+
+/-- **The abelianization of `A₄` is nontrivial**, witnessed by an even permutation outside the
+Klein four subgroup: that subgroup is the commutator subgroup of `A₄`, and it has order `4` inside
+a group of order `12`. -/
+theorem exists_abelianization_of_ne_one_alternatingGroup (hα : Nat.card α = 4) :
+    ∃ x : alternatingGroup α, Abelianization.of x ≠ 1 := by
+  have hne : alternatingGroup.kleinFour α ≠ ⊤ := by
+    intro htop
+    have hcard : Nat.card (alternatingGroup.kleinFour α) = Nat.card (alternatingGroup α) := by
+      rw [htop]
+      exact Nat.card_congr Subgroup.topEquiv.toEquiv
+    rw [alternatingGroup.kleinFour_card_of_card_eq_four hα,
+      alternatingGroup.card_of_card_eq_four hα] at hcard
+    omega
+  obtain ⟨x, hx⟩ : ∃ x : alternatingGroup α, x ∉ alternatingGroup.kleinFour α := by
+    by_contra hcon
+    push Not at hcon
+    exact hne ((Subgroup.eq_top_iff' _).mpr hcon)
+  refine ⟨x, ?_⟩
+  rw [Ne, ← MonoidHom.mem_ker, Abelianization.ker_of,
+    ← alternatingGroup.kleinFour_eq_commutator hα]
+  exact hx
+
+variable (M : Type*) [CommMonoid M]
+  [HasEnoughRootsOfUnity M (Monoid.exponent (alternatingGroup α))]
+
+/-- **`A₄` has a nontrivial linear character** valued in any commutative monoid with enough roots
+of unity for the exponent of `A₄`; an algebraically closed field of characteristic zero supplies
+one. The character comes from the abelianization `A₄ / V₄`, which
+`TauCeti.exists_abelianization_of_ne_one_alternatingGroup` shows is nontrivial, by the duality of
+finite abelian groups. -/
+theorem exists_monoidHom_alternatingGroup_ne_one (hα : Nat.card α = 4) :
+    ∃ χ : alternatingGroup α →* Mˣ, χ ≠ 1 := by
+  obtain ⟨x, hx⟩ := exists_abelianization_of_ne_one_alternatingGroup (α := α) hα
+  have _ : Finite (Abelianization (alternatingGroup α)) :=
+    Finite.of_surjective _ (surjective_abelianization_of (alternatingGroup α))
+  have _ : HasEnoughRootsOfUnity M (Monoid.exponent (Abelianization (alternatingGroup α))) :=
+    HasEnoughRootsOfUnity.of_dvd M
+      (MonoidHom.exponent_dvd (surjective_abelianization_of (alternatingGroup α)))
+  obtain ⟨φ, hφ⟩ :=
+    CommGroup.exists_apply_ne_one_of_hasEnoughRootsOfUnity (Abelianization (alternatingGroup α)) M
+      hx
+  refine ⟨φ.comp Abelianization.of, fun hcon => hφ ?_⟩
+  simpa using congrArg (fun f : alternatingGroup α →* Mˣ => f x) hcon
+
+end Existence
+
+end TauCeti

--- a/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
+++ b/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
@@ -5,9 +5,11 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.GroupTheory.Abelianization.Finite
 public import Mathlib.GroupTheory.FiniteAbelian.Duality
 public import Mathlib.GroupTheory.GroupAction.ConjAct
 public import Mathlib.GroupTheory.SpecificGroups.Alternating.KleinFour
+public import TauCeti.GroupTheory.GroupAction.ConjAct
 
 /-!
 # An odd permutation inverts every linear character of the alternating group
@@ -57,9 +59,6 @@ trivial character.
 
 ## References
 
-The group theory behind the "Clifford on `A₄ ◁ S₄`" worked example of
-[the induction and restriction roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md).
-
 * J.-P. Serre, *Linear Representations of Finite Groups*, Chapter 5.
 -/
 
@@ -74,13 +73,6 @@ variable {α : Type*} [DecidableEq α] [Fintype α]
 section Character
 
 variable {M : Type*} [CommGroup M] (χ : alternatingGroup α →* M)
-
-/-- Conjugation by an element of a normal subgroup does not move a homomorphism from that subgroup
-to a commutative group: it conjugates the value, which is the value. -/
-private theorem map_conjNormal_of_mem_subgroup {G : Type*} [Group G] {N : Subgroup G} [N.Normal]
-    (ψ : N →* M) (a x : N) : ψ (MulAut.conjNormal (a : G) x) = ψ x := by
-  rw [MulAut.conjNormal_val, MulAut.conj_apply, map_mul, map_mul, map_inv,
-    mul_comm (ψ a) (ψ x), mul_assoc, mul_inv_cancel, mul_one]
 
 /-- Two odd permutations differ by an even one. -/
 private theorem mul_inv_mem_alternatingGroup {g s : Perm α} (hg : g ∉ alternatingGroup α)
@@ -112,7 +104,7 @@ private theorem map_conjNormal_alternatingGroup_of_fixed {s : Perm α}
     (h : ∀ x : alternatingGroup α, χ (MulAut.conjNormal s x) = χ x) (g : Perm α)
     (x : alternatingGroup α) : χ (MulAut.conjNormal g x) = χ x := by
   by_cases hg : g ∈ alternatingGroup α
-  · exact map_conjNormal_of_mem_subgroup χ ⟨g, hg⟩ x
+  · exact map_conjNormal_val χ ⟨g, hg⟩ x
   · have hgs : g * s⁻¹ ∈ alternatingGroup α := mul_inv_mem_alternatingGroup hg hs
     have hfac : (MulAut.conjNormal g : MulAut (alternatingGroup α)) =
         MulAut.conjNormal ((⟨g * s⁻¹, hgs⟩ : alternatingGroup α) : Perm α) *
@@ -121,7 +113,7 @@ private theorem map_conjNormal_alternatingGroup_of_fixed {s : Perm α}
       congr 1
       simp
     rw [hfac]
-    exact (map_conjNormal_of_mem_subgroup χ ⟨g * s⁻¹, hgs⟩ _).trans (h x)
+    exact (map_conjNormal_val χ ⟨g * s⁻¹, hgs⟩ _).trans (h x)
 
 /-- **A linear character of the alternating group fixed by conjugation by an odd permutation is
 trivial.** Such a character is fixed by conjugation by every permutation, hence takes the same
@@ -160,7 +152,8 @@ theorem eq_one_of_map_conjNormal_eq_alternatingGroup {s : Perm α} (hs : s ∉ a
     exact Subgroup.mem_map.mpr ⟨⟨c, hc.mem_alternatingGroup⟩, hthree c hc _, rfl⟩
   ext x
   obtain ⟨y, hy, hxy⟩ := Subgroup.mem_map.mp (hle x.2)
-  rw [MonoidHom.one_apply, ← show y = x from Subtype.ext hxy]
+  have hyx : y = x := Subtype.ext hxy
+  rw [MonoidHom.one_apply, ← hyx]
   exact hy
 
 /-- **An odd permutation inverts every linear character of the alternating group.** The product of
@@ -179,10 +172,11 @@ theorem map_conjNormal_alternatingGroup_eq_inv {s : Perm α} (hs : s ∉ alterna
           (MulAut.conjNormal s y) =
         (χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom * χ) y := by
     intro y
+    -- Conjugation by `s * s` lies inside the alternating group, so `χ` does not see it.
+    have hss : χ (MulAut.conjNormal (s * s) y) = χ y := map_conjNormal_val χ ⟨s * s, hsq⟩ y
     simp only [MonoidHom.mul_apply, MonoidHom.coe_comp, Function.comp_apply,
       MulEquiv.coe_toMonoidHom]
-    rw [hcomp y, show χ (MulAut.conjNormal (s * s) y) = χ y from
-      map_conjNormal_of_mem_subgroup χ ⟨s * s, hsq⟩ y, mul_comm]
+    rw [hcomp y, hss, mul_comm]
   have hone := eq_one_of_map_conjNormal_eq_alternatingGroup _ hs hfix
   have hx : (χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom * χ) x = 1 := by
     rw [hone]
@@ -219,11 +213,6 @@ end Character
 
 section Existence
 
-/-- The canonical map to the abelianization is surjective. -/
-private theorem surjective_abelianization_of (G : Type*) [Group G] :
-    Function.Surjective (Abelianization.of : G →* Abelianization G) := fun y =>
-  QuotientGroup.induction_on y fun x => ⟨x, rfl⟩
-
 /-- **The abelianization of `A₄` is nontrivial**, witnessed by an even permutation outside the
 Klein four subgroup: that subgroup is the commutator subgroup of `A₄`, and it has order `4` inside
 a group of order `12`. -/
@@ -247,21 +236,17 @@ theorem exists_abelianization_of_ne_one_alternatingGroup (hα : Nat.card α = 4)
   exact hx
 
 variable (M : Type*) [CommMonoid M]
-  [HasEnoughRootsOfUnity M (Monoid.exponent (alternatingGroup α))]
+  [HasEnoughRootsOfUnity M (Monoid.exponent (Abelianization (alternatingGroup α)))]
 
 /-- **`A₄` has a nontrivial linear character** valued in any commutative monoid with enough roots
-of unity for the exponent of `A₄`; an algebraically closed field of characteristic zero supplies
-one. The character comes from the abelianization `A₄ / V₄`, which
+of unity for the exponent of the abelianization `A₄ / V₄` -- through which every such character
+factors, and for which an algebraically closed field of characteristic zero supplies the roots.
+The character comes from that abelianization, which
 `TauCeti.exists_abelianization_of_ne_one_alternatingGroup` shows is nontrivial, by the duality of
 finite abelian groups. -/
 theorem exists_monoidHom_alternatingGroup_ne_one (hα : Nat.card α = 4) :
     ∃ χ : alternatingGroup α →* Mˣ, χ ≠ 1 := by
   obtain ⟨x, hx⟩ := exists_abelianization_of_ne_one_alternatingGroup (α := α) hα
-  have _ : Finite (Abelianization (alternatingGroup α)) :=
-    Finite.of_surjective _ (surjective_abelianization_of (alternatingGroup α))
-  have _ : HasEnoughRootsOfUnity M (Monoid.exponent (Abelianization (alternatingGroup α))) :=
-    HasEnoughRootsOfUnity.of_dvd M
-      (MonoidHom.exponent_dvd (surjective_abelianization_of (alternatingGroup α)))
   obtain ⟨φ, hφ⟩ :=
     CommGroup.exists_apply_ne_one_of_hasEnoughRootsOfUnity (Abelianization (alternatingGroup α)) M
       hx

--- a/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
+++ b/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.GroupTheory.Abelianization.Finite
 public import Mathlib.GroupTheory.FiniteAbelian.Duality
-public import Mathlib.GroupTheory.GroupAction.ConjAct
 public import Mathlib.GroupTheory.SpecificGroups.Alternating.KleinFour
 public import TauCeti.GroupTheory.GroupAction.ConjAct
 
@@ -15,8 +14,8 @@ public import TauCeti.GroupTheory.GroupAction.ConjAct
 # An odd permutation inverts every linear character of the alternating group
 
 Let `α` be a finite type and let `χ` be a homomorphism from `alternatingGroup α` to a commutative
-group. Conjugation by an *even* permutation cannot move `χ`, the target being commutative. This
-file proves that conjugation by an **odd** permutation inverts it:
+monoid. Conjugation by an *even* permutation cannot move `χ`, the target being commutative. This
+file proves that conjugation by an **odd** permutation inverts it, once the target has inverses:
 
 `χ (s x s⁻¹) = (χ x)⁻¹` for every `s ∉ alternatingGroup α` and every `x`.
 
@@ -24,14 +23,14 @@ The argument is short and uniform in `α`. The product of `χ` with its conjugat
 conjugation by `s`, because `s * s` is even; and a character fixed by conjugation by *one* odd
 permutation is fixed by conjugation by *every* permutation, since the odd permutations form a
 single coset of the even ones. Such a character kills every three-cycle `c`, because `c` is
-conjugate in `Equiv.Perm α` to its own inverse, so the value at `c` is its own inverse while also
+conjugate in `Equiv.Perm α` to its own inverse, so the value at `c` squares to `1` while also
 cubing to `1`. Three-cycles generate the alternating group, so the character is trivial, which is
 the claim.
 
 The consequence the file exists for is that a **nontrivial** linear character `χ` satisfies
-`χ ∘ conj s ≠ χ` for every odd `s`: otherwise `χ` would be its own inverse and the same lemma would
-make it trivial. So the odd permutations move `χ`, and `{χ, χ⁻¹}` is a single orbit of two
-characters under the conjugation action of `Equiv.Perm α`. That is exactly the hypothesis of the
+`χ ∘ conj s ≠ χ` for every odd `s`: otherwise `χ` would be fixed by conjugation by `s` and the same
+lemma would make it trivial. So the odd permutations move `χ`, and `{χ, χ⁻¹}` is a single orbit of
+two characters under the conjugation action of `Equiv.Perm α`. That is exactly the hypothesis of the
 Mackey irreducibility criterion for an induced linear character, applied to `A₄ ◁ S₄` in
 `TauCeti.RepresentationTheory.Induction.Clifford.Alternating`.
 
@@ -98,7 +97,9 @@ namespace MonoidHom
 
 open TauCeti
 
-variable {M : Type*} [CommGroup M] (χ : alternatingGroup α →* M)
+section Fixed
+
+variable {M : Type*} [CommMonoid M] (χ : alternatingGroup α →* M)
 
 /-- A linear character fixed by conjugation by one odd permutation is fixed by conjugation by
 every permutation: the even ones fix it because the target is commutative, and every odd one is an
@@ -132,12 +133,14 @@ theorem eq_one_of_map_conjNormal_eq_alternatingGroup {s : Perm α} (hs : s ∉ a
     obtain ⟨g, hg⟩ := isConj_iff.mp (isConj_iff_cycleType_eq.mpr (cycleType_inv c).symm)
     have hconj : MulAut.conjNormal g (⟨c, hcmem⟩ : alternatingGroup α) = (⟨c, hcmem⟩)⁻¹ :=
       Subtype.ext (by simpa using hg)
-    have hinv : (χ (⟨c, hcmem⟩ : alternatingGroup α))⁻¹ = χ ⟨c, hcmem⟩ := by
-      rw [← _root_.map_inv, ← hconj]
+    have hinv : χ ((⟨c, hcmem⟩ : alternatingGroup α)⁻¹) = χ ⟨c, hcmem⟩ := by
+      rw [← hconj]
       exact hall g _
     have hsq : χ (⟨c, hcmem⟩ : alternatingGroup α) ^ 2 = 1 := by
-      rw [pow_two]
-      exact eq_inv_iff_mul_eq_one.mp hinv.symm
+      have hmul : χ (⟨c, hcmem⟩ : alternatingGroup α) * χ ((⟨c, hcmem⟩ : alternatingGroup α)⁻¹)
+          = 1 := by
+        rw [← map_mul, mul_inv_cancel, _root_.map_one]
+      rwa [hinv, ← pow_two] at hmul
     have hpow : (⟨c, hcmem⟩ : alternatingGroup α) ^ 3 = 1 :=
       orderOf_dvd_iff_pow_eq_one.mp (by rw [Subgroup.orderOf_mk, hc.orderOf])
     have hcube : χ (⟨c, hcmem⟩ : alternatingGroup α) ^ 3 = 1 := by
@@ -158,6 +161,12 @@ theorem eq_one_of_map_conjNormal_eq_alternatingGroup {s : Perm α} (hs : s ∉ a
   have hyx : y = x := Subtype.ext hxy
   rw [MonoidHom.one_apply, ← hyx]
   exact hy
+
+end Fixed
+
+section Inversion
+
+variable {M : Type*} [CommGroup M] (χ : alternatingGroup α →* M)
 
 /-- **An odd permutation inverts every linear character of the alternating group.** -/
 @[simp]
@@ -194,6 +203,12 @@ theorem comp_conjNormal_alternatingGroup_eq_inv {s : Perm α} (hs : s ∉ altern
     χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)) = χ⁻¹ :=
   MonoidHom.ext fun x => map_conjNormal_alternatingGroup_eq_inv χ hs x
 
+end Inversion
+
+section Nontrivial
+
+variable {M : Type*} [CommMonoid M] (χ : alternatingGroup α →* M)
+
 /-- **An odd permutation moves every nontrivial linear character of the alternating group.** This
 is the hypothesis of the Mackey irreducibility criterion for an induced linear character, checked
 at `A₄ ◁ S₄`. -/
@@ -211,6 +226,8 @@ theorem comp_conjNormal_alternatingGroup_ne (hχ : χ ≠ 1) {s : Perm α}
     χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)) ≠ χ := fun hcon =>
   hχ (eq_one_of_map_conjNormal_eq_alternatingGroup χ hs
     fun x => congrArg (fun f : alternatingGroup α →* M => f x) hcon)
+
+end Nontrivial
 
 end MonoidHom
 

--- a/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
+++ b/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
@@ -176,8 +176,7 @@ theorem map_conjNormal_alternatingGroup_eq_inv {s : Perm α} (hs : s ∉ alterna
   have hcomp : ∀ y : alternatingGroup α,
       (MulAut.conjNormal s) ((MulAut.conjNormal s) y) = MulAut.conjNormal (s * s) y := by
     intro y
-    rw [map_mul]
-    rfl
+    rw [map_mul, MulAut.mul_apply]
   have hfix : ∀ y : alternatingGroup α,
       (χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom * χ)
           (MulAut.conjNormal s y) =
@@ -190,8 +189,7 @@ theorem map_conjNormal_alternatingGroup_eq_inv {s : Perm α} (hs : s ∉ alterna
     rw [hcomp y, hss, mul_comm]
   have hone := eq_one_of_map_conjNormal_eq_alternatingGroup _ hs hfix
   have hx : (χ.comp (MulAut.conjNormal s : MulAut (alternatingGroup α)).toMonoidHom * χ) x = 1 := by
-    rw [hone]
-    rfl
+    rw [hone, MonoidHom.one_apply]
   simp only [MonoidHom.mul_apply, MonoidHom.coe_comp, Function.comp_apply,
     MulEquiv.coe_toMonoidHom] at hx
   exact eq_inv_of_mul_eq_one_left hx

--- a/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
+++ b/TauCeti/GroupTheory/Perm/AlternatingCharacter.lean
@@ -37,8 +37,10 @@ Mackey irreducibility criterion for an induced linear character, applied to `A�
 For that application to be about something, `alternatingGroup α` must *have* a nontrivial linear
 character, which for `Nat.card α = 4` it does: Mathlib's `alternatingGroup.kleinFour_eq_commutator`
 identifies the commutator subgroup of `A₄` with the Klein four subgroup, of order `4` inside a
-group of order `12`, so the commutator subgroup is proper and the duality of finite abelian groups
-produces a character of the abelianization that does not kill it. For `4 < Nat.card α` the
+group of order `12`. That subgroup is therefore proper, so some element of `A₄` has a nonidentity
+class in the abelianization `A₄ / V₄`, and the duality of finite abelian groups supplies a
+character of that abelianization nontrivial on that class; pulling it back along
+`Abelianization.of` gives a nontrivial linear character of `A₄`. For `4 < Nat.card α` the
 alternating group is perfect instead, and the statements above are then all vacuously about the
 trivial character.
 
@@ -233,7 +235,7 @@ namespace TauCeti
 
 /-- **The abelianization of `A₄` is nontrivial**: its commutator subgroup is the Klein four
 subgroup, a proper subgroup. -/
-theorem exists_abelianization_of_ne_one_alternatingGroup (hα : Nat.card α = 4) :
+theorem exists_abelianizationOf_ne_one_alternatingGroup (hα : Nat.card α = 4) :
     ∃ x : alternatingGroup α, Abelianization.of x ≠ 1 := by
   have hne : alternatingGroup.kleinFour α ≠ ⊤ := by
     intro htop
@@ -260,7 +262,7 @@ of unity for the exponent of the abelianization `A₄ / V₄`, through which eve
 factors and for which an algebraically closed field of characteristic zero supplies the roots. -/
 theorem exists_monoidHom_alternatingGroup_ne_one (hα : Nat.card α = 4) :
     ∃ χ : alternatingGroup α →* Mˣ, χ ≠ 1 := by
-  obtain ⟨x, hx⟩ := exists_abelianization_of_ne_one_alternatingGroup (α := α) hα
+  obtain ⟨x, hx⟩ := exists_abelianizationOf_ne_one_alternatingGroup (α := α) hα
   obtain ⟨φ, hφ⟩ :=
     CommGroup.exists_apply_ne_one_of_hasEnoughRootsOfUnity (Abelianization (alternatingGroup α)) M
       hx

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean
@@ -33,9 +33,9 @@ representation** of `Equiv.Perm α`.
 
 For `Nat.card α = 4` this is the `A₄ ◁ S₄` case, and it is not vacuous:
 `TauCeti.exists_monoidHom_alternatingGroup_ne_one` produces a nontrivial linear character of `A₄`
-from the identification of its commutator subgroup with the Klein four subgroup. The last statement
-of the file assembles the three facts for that case: over an algebraically closed field of
-characteristic zero, `S₄` has a two-dimensional irreducible representation induced from `A₄`.
+from the identification of its commutator subgroup with the Klein four subgroup. The `example`
+closing the file records that case: over an algebraically closed field of characteristic zero, `S₄`
+has a two-dimensional irreducible representation induced from `A₄`.
 
 Two further facts about the pair `A₄ ◁ S₄` lie outside the scope of this file: that the nontrivial
 linear characters of `A₄` are *exactly* `χ` and `χ⁻¹`, which needs the order of the character group
@@ -44,14 +44,12 @@ of the Clifford correspondence complementary to the one treated here.
 
 ## Main statements
 
+* `MonoidHom.finrank_indFDRep_ofLinearCharacter_alternatingGroup`: what a linear character of the
+  alternating group induces to is two-dimensional, the alternating group having index two.
 * `TauCeti.inertia_ofLinearCharacter_alternatingGroup`: **the inertia group of a nontrivial linear
   character of the alternating group is the alternating group.**
 * `TauCeti.simple_indFDRep_ofLinearCharacter_alternatingGroup`: **a nontrivial linear character of
   the alternating group induces irreducibly** to the symmetric group.
-* `TauCeti.finrank_indFDRep_ofLinearCharacter_alternatingGroup`: what it induces to is
-  two-dimensional, the alternating group having index two.
-* `TauCeti.exists_simple_finrank_two_indFDRep_alternatingGroup`: **the `A₄ ◁ S₄` case**, where
-  such a character exists, so `S₄` has a two-dimensional irreducible induced from `A₄`.
 
 ## References
 
@@ -62,38 +60,14 @@ public section
 
 open CategoryTheory
 
-namespace TauCeti
-
 universe u
 
 variable {α k : Type u} [DecidableEq α] [Fintype α] [Field k]
 
-/-- **The inertia group of a nontrivial linear character of the alternating group is the
-alternating group itself.** Clifford theory always puts the normal subgroup inside the inertia
-group (`TauCeti.le_inertia`); here nothing else is in it, because an odd permutation inverts every
-linear character of the alternating group and so moves a nontrivial one. -/
-theorem inertia_ofLinearCharacter_alternatingGroup {χ : alternatingGroup α →* kˣ} (hχ : χ ≠ 1) :
-    inertia (FDRep.ofLinearCharacter (k := k) χ) = alternatingGroup α := by
-  refine le_antisymm (fun g hg => ?_) (le_inertia _)
-  by_contra hgnot
-  rw [mem_inertia_iff, nonempty_iso_conjNormalFDRep_ofLinearCharacter_iff] at hg
-  obtain ⟨x, hx⟩ :=
-    exists_map_conjNormal_alternatingGroup_ne χ hχ
-      (s := g⁻¹) fun hmem => hgnot (by simpa using inv_mem hmem)
-  exact hx (hg x)
+namespace MonoidHom
 
-variable [IsAlgClosed k] [CharZero k]
+open TauCeti
 
-/-- **A nontrivial linear character of the alternating group induces irreducibly to the symmetric
-group.** The Mackey criterion for an induced linear character asks that no permutation outside the
-alternating group stabilize `χ`, which is
-`TauCeti.exists_map_conjNormal_alternatingGroup_ne`. -/
-theorem simple_indFDRep_ofLinearCharacter_alternatingGroup {χ : alternatingGroup α →* kˣ}
-    (hχ : χ ≠ 1) : Simple (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) :=
-  (simple_indFDRep_ofLinearCharacter_iff χ).mpr fun _ hs =>
-    exists_map_conjNormal_alternatingGroup_ne χ hχ hs
-
-omit [IsAlgClosed k] [CharZero k] in
 /-- **What a linear character of the alternating group induces to is two-dimensional**, the
 alternating group having index two. Together with
 `TauCeti.simple_indFDRep_ofLinearCharacter_alternatingGroup` this is a two-dimensional irreducible
@@ -103,10 +77,41 @@ theorem finrank_indFDRep_ofLinearCharacter_alternatingGroup [Nontrivial α]
     Module.finrank k (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) = 2 := by
   rw [finrank_indFDRep_ofLinearCharacter, alternatingGroup.index_eq_two]
 
-/-- **The `A₄ ◁ S₄` case.** Over an algebraically closed field of characteristic zero, `A₄` has a
-nontrivial linear character; its inertia group in `S₄` is `A₄`, so it induces irreducibly, and what
-it induces to is the two-dimensional irreducible representation of `S₄`. -/
-theorem exists_simple_finrank_two_indFDRep_alternatingGroup (hα : Nat.card α = 4) :
+end MonoidHom
+
+namespace TauCeti
+
+/-- **The inertia group of a nontrivial linear character of the alternating group is the
+alternating group itself**, the smallest value Clifford theory allows. This is the hypothesis the
+Mackey irreducibility criterion for an induced linear character asks for. -/
+theorem inertia_ofLinearCharacter_alternatingGroup {χ : alternatingGroup α →* kˣ} (hχ : χ ≠ 1) :
+    inertia (FDRep.ofLinearCharacter (k := k) χ) = alternatingGroup α := by
+  refine le_antisymm (fun g hg => ?_) (le_inertia _)
+  by_contra hgnot
+  rw [mem_inertia_iff, nonempty_iso_conjNormalFDRep_ofLinearCharacter_iff] at hg
+  obtain ⟨x, hx⟩ :=
+    χ.exists_map_conjNormal_alternatingGroup_ne hχ
+      (s := g⁻¹) fun hmem => hgnot (by simpa using inv_mem hmem)
+  exact hx (hg x)
+
+variable [IsAlgClosed k] [CharZero k]
+
+/-- **A nontrivial linear character of the alternating group induces irreducibly to the symmetric
+group.** With `MonoidHom.finrank_indFDRep_ofLinearCharacter_alternatingGroup` this exhibits a
+two-dimensional irreducible representation of the symmetric group. -/
+theorem simple_indFDRep_ofLinearCharacter_alternatingGroup {χ : alternatingGroup α →* kˣ}
+    (hχ : χ ≠ 1) : Simple (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) :=
+  (simple_indFDRep_ofLinearCharacter_iff χ).mpr fun _ hs =>
+    χ.exists_map_conjNormal_alternatingGroup_ne hχ hs
+
+/- The `A₄ ◁ S₄` case, recorded without claiming a name for it: over an algebraically closed field
+of characteristic zero `A₄` has a nontrivial linear character, its inertia group in `S₄` is `A₄`,
+and what it induces to is the two-dimensional irreducible representation of `S₄`. The three
+conjuncts are `inertia_ofLinearCharacter_alternatingGroup`,
+`simple_indFDRep_ofLinearCharacter_alternatingGroup` and
+`MonoidHom.finrank_indFDRep_ofLinearCharacter_alternatingGroup` applied to a character supplied by
+`exists_monoidHom_alternatingGroup_ne_one`. -/
+example (hα : Nat.card α = 4) :
     ∃ χ : alternatingGroup α →* kˣ,
       inertia (FDRep.ofLinearCharacter (k := k) χ) = alternatingGroup α ∧
         Simple (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) ∧
@@ -119,6 +124,6 @@ theorem exists_simple_finrank_two_indFDRep_alternatingGroup (hα : Nat.card α =
   obtain ⟨χ, hχ⟩ := exists_monoidHom_alternatingGroup_ne_one (α := α) k hα
   exact ⟨χ, inertia_ofLinearCharacter_alternatingGroup hχ,
     simple_indFDRep_ofLinearCharacter_alternatingGroup hχ,
-    finrank_indFDRep_ofLinearCharacter_alternatingGroup χ⟩
+    χ.finrank_indFDRep_ofLinearCharacter_alternatingGroup⟩
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.RootsOfUnity.AlgebraicallyClosed
+public import TauCeti.GroupTheory.Perm.AlternatingCharacter
+public import TauCeti.RepresentationTheory.Induction.Inertia
+public import TauCeti.RepresentationTheory.Induction.LinearCharacter
+public import TauCeti.RepresentationTheory.Induction.Mackey.LinearCharacter
+
+/-!
+# Clifford theory along `A₄ ◁ S₄`: the inertia group of a linear character
+
+The alternating group is normal in the symmetric group, so Clifford theory applies to the pair
+`alternatingGroup α ◁ Equiv.Perm α`, and the first thing it asks for is the **inertia group** of a
+representation of the normal subgroup. This file computes it for a linear character: for a
+*nontrivial* `χ : alternatingGroup α →* kˣ`,
+
+`inertia (FDRep.ofLinearCharacter χ) = alternatingGroup α`,
+
+the smallest value Clifford theory allows, `TauCeti.le_inertia` giving the other inclusion for
+free. The computation is the group theory of `TauCeti.GroupTheory.Perm.AlternatingCharacter`: an
+odd permutation inverts every linear character of the alternating group, so it moves a nontrivial
+one, and `χ` and `χ⁻¹` are two distinct characters making up one conjugation orbit.
+
+A minimal inertia group is exactly what the Mackey irreducibility criterion for an induced linear
+character wants, so `Ind` of a nontrivial `χ` is irreducible; and induction from a subgroup of
+index two doubles the dimension, so what it produces is a **two-dimensional irreducible
+representation** of `Equiv.Perm α`.
+
+For `Nat.card α = 4` this is the roadmap's `A₄ ◁ S₄` example and it is not vacuous:
+`TauCeti.exists_monoidHom_alternatingGroup_ne_one` produces a nontrivial linear character of `A₄`
+from the identification of its commutator subgroup with the Klein four subgroup. The last statement
+of the file assembles the three facts for that case: over an algebraically closed field of
+characteristic zero, `S₄` has a two-dimensional irreducible representation induced from `A₄`.
+
+What the example asks for beyond this is not proved here: that the nontrivial linear characters of
+`A₄` are *exactly* the pair `χ`, `χ⁻¹` -- which needs the order of the character group, not just
+the orbit -- and that the three-dimensional irreducible of `A₄` is `S₄`-fixed, with the Clifford
+correspondence run over each constituent.
+
+## Main statements
+
+* `TauCeti.inertia_ofLinearCharacter_alternatingGroup`: **the inertia group of a nontrivial linear
+  character of the alternating group is the alternating group.**
+* `TauCeti.simple_indFDRep_ofLinearCharacter_alternatingGroup`: **a nontrivial linear character of
+  the alternating group induces irreducibly** to the symmetric group.
+* `TauCeti.finrank_indFDRep_ofLinearCharacter_alternatingGroup`: what it induces to is
+  two-dimensional, the alternating group having index two.
+* `TauCeti.exists_simple_finrank_two_indFDRep_alternatingGroup`: **the `A₄ ◁ S₄` case**, where
+  such a character exists, so `S₄` has a two-dimensional irreducible induced from `A₄`.
+
+## References
+
+The inertia computation of the "Clifford on `A₄ ◁ S₄`" worked example of
+[the induction and restriction roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md).
+
+* J.-P. Serre, *Linear Representations of Finite Groups*, Chapter 8.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+variable {α k : Type u} [DecidableEq α] [Fintype α] [Field k]
+
+/-- **The inertia group of a nontrivial linear character of the alternating group is the
+alternating group itself.** Clifford theory always puts the normal subgroup inside the inertia
+group (`TauCeti.le_inertia`); here nothing else is in it, because an odd permutation inverts every
+linear character of the alternating group and so moves a nontrivial one. -/
+theorem inertia_ofLinearCharacter_alternatingGroup {χ : alternatingGroup α →* kˣ} (hχ : χ ≠ 1) :
+    inertia (FDRep.ofLinearCharacter (k := k) χ) = alternatingGroup α := by
+  refine le_antisymm (fun g hg => ?_) (le_inertia _)
+  by_contra hgnot
+  rw [mem_inertia_iff, nonempty_iso_conjNormalFDRep_ofLinearCharacter_iff] at hg
+  obtain ⟨x, hx⟩ :=
+    exists_map_conjNormal_alternatingGroup_ne χ hχ
+      (s := g⁻¹) fun hmem => hgnot (by simpa using inv_mem hmem)
+  exact hx (hg x)
+
+variable [IsAlgClosed k] [CharZero k]
+
+/-- **A nontrivial linear character of the alternating group induces irreducibly to the symmetric
+group.** The Mackey criterion for an induced linear character asks that no permutation outside the
+alternating group stabilize `χ`, which is
+`TauCeti.exists_map_conjNormal_alternatingGroup_ne`. -/
+theorem simple_indFDRep_ofLinearCharacter_alternatingGroup {χ : alternatingGroup α →* kˣ}
+    (hχ : χ ≠ 1) : Simple (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) :=
+  (simple_indFDRep_ofLinearCharacter_iff χ).mpr fun _ hs =>
+    exists_map_conjNormal_alternatingGroup_ne χ hχ hs
+
+omit [IsAlgClosed k] [CharZero k] in
+/-- **What a linear character of the alternating group induces to is two-dimensional**, the
+alternating group having index two. Together with
+`TauCeti.simple_indFDRep_ofLinearCharacter_alternatingGroup` this is a two-dimensional irreducible
+representation of the symmetric group. -/
+theorem finrank_indFDRep_ofLinearCharacter_alternatingGroup [Nontrivial α]
+    (χ : alternatingGroup α →* kˣ) :
+    Module.finrank k (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) = 2 := by
+  rw [finrank_indFDRep_ofLinearCharacter, alternatingGroup.index_eq_two]
+
+/-- **The `A₄ ◁ S₄` case.** Over an algebraically closed field of characteristic zero, `A₄` has a
+nontrivial linear character; its inertia group in `S₄` is `A₄`, so it induces irreducibly, and what
+it induces to is the two-dimensional irreducible representation of `S₄`. -/
+theorem exists_simple_finrank_two_indFDRep_alternatingGroup (hα : Nat.card α = 4) :
+    ∃ χ : alternatingGroup α →* kˣ,
+      inertia (FDRep.ofLinearCharacter (k := k) χ) = alternatingGroup α ∧
+        Simple (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) ∧
+        Module.finrank k (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) = 2 := by
+  have hnt : Nontrivial α := by
+    rw [← Finite.one_lt_card_iff_nontrivial, hα]
+    norm_num
+  have _ : NeZero ((Monoid.exponent (alternatingGroup α) : ℕ) : k) :=
+    ⟨Nat.cast_ne_zero.mpr Monoid.exponent_ne_zero_of_finite⟩
+  obtain ⟨χ, hχ⟩ := exists_monoidHom_alternatingGroup_ne_one (α := α) k hα
+  exact ⟨χ, inertia_ofLinearCharacter_alternatingGroup hχ,
+    simple_indFDRep_ofLinearCharacter_alternatingGroup hχ,
+    finrank_indFDRep_ofLinearCharacter_alternatingGroup χ⟩
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean
@@ -31,16 +31,16 @@ character wants, so `Ind` of a nontrivial `χ` is irreducible; and induction fro
 index two doubles the dimension, so what it produces is a **two-dimensional irreducible
 representation** of `Equiv.Perm α`.
 
-For `Nat.card α = 4` this is the roadmap's `A₄ ◁ S₄` example and it is not vacuous:
+For `Nat.card α = 4` this is the `A₄ ◁ S₄` case, and it is not vacuous:
 `TauCeti.exists_monoidHom_alternatingGroup_ne_one` produces a nontrivial linear character of `A₄`
 from the identification of its commutator subgroup with the Klein four subgroup. The last statement
 of the file assembles the three facts for that case: over an algebraically closed field of
 characteristic zero, `S₄` has a two-dimensional irreducible representation induced from `A₄`.
 
-What the example asks for beyond this is not proved here: that the nontrivial linear characters of
-`A₄` are *exactly* the pair `χ`, `χ⁻¹` -- which needs the order of the character group, not just
-the orbit -- and that the three-dimensional irreducible of `A₄` is `S₄`-fixed, with the Clifford
-correspondence run over each constituent.
+Two further facts about the pair `A₄ ◁ S₄` lie outside the scope of this file: that the nontrivial
+linear characters of `A₄` are *exactly* `χ` and `χ⁻¹`, which needs the order of the character group
+and not just the orbit; and that the three-dimensional irreducible of `A₄` is `S₄`-fixed, the case
+of the Clifford correspondence complementary to the one treated here.
 
 ## Main statements
 
@@ -54,9 +54,6 @@ correspondence run over each constituent.
   such a character exists, so `S₄` has a two-dimensional irreducible induced from `A₄`.
 
 ## References
-
-The inertia computation of the "Clifford on `A₄ ◁ S₄`" worked example of
-[the induction and restriction roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md).
 
 * J.-P. Serre, *Linear Representations of Finite Groups*, Chapter 8.
 -/
@@ -117,7 +114,7 @@ theorem exists_simple_finrank_two_indFDRep_alternatingGroup (hα : Nat.card α =
   have hnt : Nontrivial α := by
     rw [← Finite.one_lt_card_iff_nontrivial, hα]
     norm_num
-  have _ : NeZero ((Monoid.exponent (alternatingGroup α) : ℕ) : k) :=
+  have _ : NeZero ((Monoid.exponent (Abelianization (alternatingGroup α)) : ℕ) : k) :=
     ⟨Nat.cast_ne_zero.mpr Monoid.exponent_ne_zero_of_finite⟩
   obtain ⟨χ, hχ⟩ := exists_monoidHom_alternatingGroup_ne_one (α := α) k hα
   exact ⟨χ, inertia_ofLinearCharacter_alternatingGroup hχ,

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean
@@ -30,6 +30,8 @@ A minimal inertia group is exactly what the Mackey irreducibility criterion for 
 character wants, so `Ind` of a nontrivial `χ` is irreducible; and induction from a subgroup of
 index two doubles the dimension, so what it produces is a **two-dimensional irreducible
 representation** of `Equiv.Perm α`.
+That dimension count needs nothing new: `TauCeti.finrank_indFDRep_ofLinearCharacter` and
+`alternatingGroup.index_eq_two` give it in one step wherever it is wanted.
 
 For `Nat.card α = 4` this is the `A₄ ◁ S₄` case, and it is not vacuous:
 `TauCeti.exists_monoidHom_alternatingGroup_ne_one` produces a nontrivial linear character of `A₄`
@@ -44,8 +46,6 @@ of the Clifford correspondence complementary to the one treated here.
 
 ## Main statements
 
-* `MonoidHom.finrank_indFDRep_ofLinearCharacter_alternatingGroup`: what a linear character of the
-  alternating group induces to is two-dimensional, the alternating group having index two.
 * `TauCeti.inertia_ofLinearCharacter_alternatingGroup`: **the inertia group of a nontrivial linear
   character of the alternating group is the alternating group.**
 * `TauCeti.simple_indFDRep_ofLinearCharacter_alternatingGroup`: **a nontrivial linear character of
@@ -63,21 +63,6 @@ open CategoryTheory
 universe u
 
 variable {α k : Type u} [DecidableEq α] [Fintype α] [Field k]
-
-namespace MonoidHom
-
-open TauCeti
-
-/-- **What a linear character of the alternating group induces to is two-dimensional**, the
-alternating group having index two. Together with
-`TauCeti.simple_indFDRep_ofLinearCharacter_alternatingGroup` this is a two-dimensional irreducible
-representation of the symmetric group. -/
-theorem finrank_indFDRep_ofLinearCharacter_alternatingGroup [Nontrivial α]
-    (χ : alternatingGroup α →* kˣ) :
-    Module.finrank k (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) = 2 := by
-  rw [finrank_indFDRep_ofLinearCharacter, alternatingGroup.index_eq_two]
-
-end MonoidHom
 
 namespace TauCeti
 
@@ -97,8 +82,9 @@ theorem inertia_ofLinearCharacter_alternatingGroup {χ : alternatingGroup α →
 variable [IsAlgClosed k] [CharZero k]
 
 /-- **A nontrivial linear character of the alternating group induces irreducibly to the symmetric
-group.** With `MonoidHom.finrank_indFDRep_ofLinearCharacter_alternatingGroup` this exhibits a
-two-dimensional irreducible representation of the symmetric group. -/
+group.** What it induces to is two-dimensional, by `TauCeti.finrank_indFDRep_ofLinearCharacter` and
+`alternatingGroup.index_eq_two`, so this exhibits a two-dimensional irreducible representation of
+the symmetric group. -/
 theorem simple_indFDRep_ofLinearCharacter_alternatingGroup {χ : alternatingGroup α →* kˣ}
     (hχ : χ ≠ 1) : Simple (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) :=
   (simple_indFDRep_ofLinearCharacter_iff χ).mpr fun _ hs =>
@@ -106,11 +92,11 @@ theorem simple_indFDRep_ofLinearCharacter_alternatingGroup {χ : alternatingGrou
 
 /- The `A₄ ◁ S₄` case, recorded without claiming a name for it: over an algebraically closed field
 of characteristic zero `A₄` has a nontrivial linear character, its inertia group in `S₄` is `A₄`,
-and what it induces to is the two-dimensional irreducible representation of `S₄`. The three
-conjuncts are `inertia_ofLinearCharacter_alternatingGroup`,
-`simple_indFDRep_ofLinearCharacter_alternatingGroup` and
-`MonoidHom.finrank_indFDRep_ofLinearCharacter_alternatingGroup` applied to a character supplied by
-`exists_monoidHom_alternatingGroup_ne_one`. -/
+and what it induces to is the two-dimensional irreducible representation of `S₄`. The conjuncts
+are `inertia_ofLinearCharacter_alternatingGroup` and
+`simple_indFDRep_ofLinearCharacter_alternatingGroup`, applied to a character supplied by
+`exists_monoidHom_alternatingGroup_ne_one`, together with `finrank_indFDRep_ofLinearCharacter` and
+`alternatingGroup.index_eq_two`. -/
 example (hα : Nat.card α = 4) :
     ∃ χ : alternatingGroup α →* kˣ,
       inertia (FDRep.ofLinearCharacter (k := k) χ) = alternatingGroup α ∧
@@ -122,8 +108,8 @@ example (hα : Nat.card α = 4) :
   have _ : NeZero ((Monoid.exponent (Abelianization (alternatingGroup α)) : ℕ) : k) :=
     ⟨Nat.cast_ne_zero.mpr Monoid.exponent_ne_zero_of_finite⟩
   obtain ⟨χ, hχ⟩ := exists_monoidHom_alternatingGroup_ne_one (α := α) k hα
-  exact ⟨χ, inertia_ofLinearCharacter_alternatingGroup hχ,
-    simple_indFDRep_ofLinearCharacter_alternatingGroup hχ,
-    χ.finrank_indFDRep_ofLinearCharacter_alternatingGroup⟩
+  refine ⟨χ, inertia_ofLinearCharacter_alternatingGroup hχ,
+    simple_indFDRep_ofLinearCharacter_alternatingGroup hχ, ?_⟩
+  rw [finrank_indFDRep_ofLinearCharacter, alternatingGroup.index_eq_two]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean
@@ -62,9 +62,11 @@ open CategoryTheory
 
 universe u
 
-variable {α k : Type u} [DecidableEq α] [Fintype α] [Field k]
-
 namespace TauCeti
+
+section Inertia
+
+variable {α k : Type u} [DecidableEq α] [Fintype α] [CommRing k]
 
 /-- **The inertia group of a nontrivial linear character of the alternating group is the
 alternating group itself**, the smallest value Clifford theory allows. This is the hypothesis the
@@ -79,7 +81,11 @@ theorem inertia_ofLinearCharacter_alternatingGroup {χ : alternatingGroup α →
       (s := g⁻¹) fun hmem => hgnot (by simpa using inv_mem hmem)
   exact hx (hg x)
 
-variable [IsAlgClosed k] [CharZero k]
+end Inertia
+
+section Irreducible
+
+variable {α k : Type u} [DecidableEq α] [Fintype α] [Field k] [IsAlgClosed k] [CharZero k]
 
 /-- **A nontrivial linear character of the alternating group induces irreducibly to the symmetric
 group.** What it induces to is two-dimensional, by `TauCeti.finrank_indFDRep_ofLinearCharacter` and
@@ -111,5 +117,7 @@ example (hα : Nat.card α = 4) :
   refine ⟨χ, inertia_ofLinearCharacter_alternatingGroup hχ,
     simple_indFDRep_ofLinearCharacter_alternatingGroup hχ, ?_⟩
   rw [finrank_indFDRep_ofLinearCharacter, alternatingGroup.index_eq_two]
+
+end Irreducible
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Mackey/SymmetricThree.lean
+++ b/TauCeti/RepresentationTheory/Induction/Mackey/SymmetricThree.lean
@@ -27,8 +27,10 @@ order, so `TauCeti.not_simple_indFDRep_of_prime_card_of_not_normal` applies with
 about the representation at all. The decomposition `sgn ⊕ standard` itself is not proved here.
 
 From the *normal* subgroup `A₃`, on the other hand, every **faithful** linear character induces
-irreducibly, producing the two-dimensional irreducible of `S₃`. Here the normal-subgroup Mackey
-criterion, read on a linear character by
+irreducibly, producing the two-dimensional irreducible of `S₃` -- two-dimensional because induction
+multiplies the dimension by the index of the subgroup
+(`TauCeti.finrank_indFDRep_ofLinearCharacter`), and `A₃` has index two. Here the normal-subgroup
+Mackey criterion, read on a linear character by
 `TauCeti.simple_indFDRep_ofLinearCharacter_iff_centralizer_le`, reduces the question to whether
 anything outside `A₃` centralizes `A₃`, and nothing does. A faithful linear character exists
 because `A₃` is cyclic of order three and the coefficient field has enough roots of unity for the
@@ -50,10 +52,8 @@ is what makes it a *worked* example rather than a further piece of theory.
   stabilizer of `S₃` is irreducible**, in particular not the roadmap's linear characters.
 * `TauCeti.simple_indFDRep_ofLinearCharacter_alternatingGroup_fin_three`: **a faithful linear
   character of `A₃` induces irreducibly to `S₃`**.
-* `TauCeti.finrank_indFDRep_ofLinearCharacter_alternatingGroup_fin_three`: what it induces to is
-  two-dimensional, so this is the two-dimensional irreducible of `S₃`.
 * `TauCeti.exists_monoidHom_alternatingGroup_fin_three_injective`: a faithful linear character of
-  `A₃` exists, so the previous two statements are not vacuous.
+  `A₃` exists, so the previous statement is not vacuous.
 
 ## References
 
@@ -97,15 +97,6 @@ theorem simple_indFDRep_ofLinearCharacter_alternatingGroup_fin_three
     Simple (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) :=
   (simple_indFDRep_ofLinearCharacter_iff_centralizer_le hχ).mpr
     centralizer_alternatingGroup_fin_three_le
-
-omit [IsAlgClosed k] [CharZero k] in
-/-- **What a linear character of `A₃` induces to is two-dimensional**, `A₃` having index two in
-`S₃`. Together with `TauCeti.simple_indFDRep_ofLinearCharacter_alternatingGroup_fin_three` this is
-the roadmap's two-dimensional irreducible of `S₃`. -/
-theorem finrank_indFDRep_ofLinearCharacter_alternatingGroup_fin_three
-    (χ : alternatingGroup (Fin 3) →* kˣ) :
-    Module.finrank k (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) = 2 := by
-  rw [finrank_indFDRep_ofLinearCharacter, alternatingGroup.index_eq_two]
 
 section Faithful
 

--- a/TauCeti/RepresentationTheory/Induction/Mackey/SymmetricThree.lean
+++ b/TauCeti/RepresentationTheory/Induction/Mackey/SymmetricThree.lean
@@ -27,10 +27,8 @@ order, so `TauCeti.not_simple_indFDRep_of_prime_card_of_not_normal` applies with
 about the representation at all. The decomposition `sgn ⊕ standard` itself is not proved here.
 
 From the *normal* subgroup `A₃`, on the other hand, every **faithful** linear character induces
-irreducibly, producing the two-dimensional irreducible of `S₃` -- two-dimensional because induction
-multiplies the dimension by the index of the subgroup
-(`TauCeti.finrank_indFDRep_ofLinearCharacter`), and `A₃` has index two. Here the normal-subgroup
-Mackey criterion, read on a linear character by
+irreducibly, producing the two-dimensional irreducible of `S₃`. Here the normal-subgroup Mackey
+criterion, read on a linear character by
 `TauCeti.simple_indFDRep_ofLinearCharacter_iff_centralizer_le`, reduces the question to whether
 anything outside `A₃` centralizes `A₃`, and nothing does. A faithful linear character exists
 because `A₃` is cyclic of order three and the coefficient field has enough roots of unity for the
@@ -52,8 +50,10 @@ is what makes it a *worked* example rather than a further piece of theory.
   stabilizer of `S₃` is irreducible**, in particular not the roadmap's linear characters.
 * `TauCeti.simple_indFDRep_ofLinearCharacter_alternatingGroup_fin_three`: **a faithful linear
   character of `A₃` induces irreducibly to `S₃`**.
+* `TauCeti.finrank_indFDRep_ofLinearCharacter_alternatingGroup_fin_three`: what it induces to is
+  two-dimensional, so this is the two-dimensional irreducible of `S₃`.
 * `TauCeti.exists_monoidHom_alternatingGroup_fin_three_injective`: a faithful linear character of
-  `A₃` exists, so the previous statement is not vacuous.
+  `A₃` exists, so the previous two statements are not vacuous.
 
 ## References
 
@@ -97,6 +97,15 @@ theorem simple_indFDRep_ofLinearCharacter_alternatingGroup_fin_three
     Simple (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) :=
   (simple_indFDRep_ofLinearCharacter_iff_centralizer_le hχ).mpr
     centralizer_alternatingGroup_fin_three_le
+
+omit [IsAlgClosed k] [CharZero k] in
+/-- **What a linear character of `A₃` induces to is two-dimensional**, `A₃` having index two in
+`S₃`. Together with `TauCeti.simple_indFDRep_ofLinearCharacter_alternatingGroup_fin_three` this is
+the roadmap's two-dimensional irreducible of `S₃`. -/
+theorem finrank_indFDRep_ofLinearCharacter_alternatingGroup_fin_three
+    (χ : alternatingGroup (Fin 3) →* kˣ) :
+    Module.finrank k (indFDRep (FDRep.ofLinearCharacter (k := k) χ)) = 2 := by
+  rw [finrank_indFDRep_ofLinearCharacter, alternatingGroup.index_eq_two]
 
 section Faithful
 


### PR DESCRIPTION
This PR computes the **inertia group of a linear character of the alternating group**, and reads off the two-dimensional irreducible of the symmetric group it induces. For a nontrivial `χ : alternatingGroup α →* kˣ` the inertia group of `FDRep.ofLinearCharacter χ` in `Equiv.Perm α` is `alternatingGroup α` itself — the smallest value Clifford theory allows, `TauCeti.le_inertia` supplying the other inclusion. That is precisely the hypothesis of the Mackey irreducibility criterion for an induced linear character, so `Ind` of such a `χ` is irreducible, and induction from a subgroup of index two makes it two-dimensional. For `Nat.card α = 4` such a character exists, so this is the `A₄ ◁ S₄` case.

The milestone is the "Clifford on `A₄ ◁ S₄`" bullet of the `## Worked examples (acceptance criteria)` section of `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, whose first half asks for the inertia computation: "the linear characters of `A₄` come from `A₄ / V₄ ≅ C₃` … the two nontrivial linear characters form a single `S₄`-orbit under conjugation … Clifford's theorem predicts and the inertia computation confirms how the irreducibles of `S₄` restrict to `A₄`". Its stated prerequisites are on `main`: the inertia group (`TauCeti.inertia`, `TauCeti.le_inertia`), the Mackey criterion for an induced linear character (`TauCeti.simple_indFDRep_ofLinearCharacter_iff`), and the dimension of an induced linear character (`TauCeti.finrank_indFDRep_ofLinearCharacter`). Nothing in `TauCeti/` mentioned `alternatingGroup (Fin 4)` before this; the sibling `A₃ ◁ S₃` example in `Induction/Mackey/SymmetricThree.lean` goes through the *faithful* form of the criterion, `simple_indFDRep_ofLinearCharacter_iff_centralizer_le`, which is useless here — a nontrivial linear character of `A₄` has the Klein four subgroup in its kernel, and `A₄` does centralize itself nowhere outside itself only because of the character, not because of the group.

Three files are added, each in the layer its statement belongs to.

`TauCeti/GroupTheory/Perm/AlternatingCharacter.lean` is the group theory: an **odd permutation inverts every linear character of the alternating group**, `χ (s x s⁻¹) = (χ x)⁻¹`, uniformly in `α`. The proof is a single observation. The product of `χ` with its conjugate by `s` is fixed by conjugation by `s`, because `s * s` is even; and a character fixed by conjugation by one odd permutation is fixed by conjugation by every permutation, the odd permutations being one coset of the even ones. Such a character kills every three-cycle, since a permutation is conjugate to its own inverse (same cycle type), so the value at a three-cycle is its own inverse while also cubing to `1`; and `Equiv.Perm.closure_three_cycles_eq_alternating` finishes. Consequently a nontrivial character is moved by every odd permutation, and it and its conjugate are two distinct members of one orbit. The file also produces a nontrivial linear character of `A₄`: Mathlib's `alternatingGroup.kleinFour_eq_commutator` identifies the commutator subgroup of `A₄` with the Klein four subgroup, of order `4` inside a group of order `12`, so the abelianization is nontrivial and `CommGroup.exists_apply_ne_one_of_hasEnoughRootsOfUnity` gives a character not killing it. For `4 < Nat.card α` the alternating group is perfect and every statement in the file is then about the trivial character.

`TauCeti/GroupTheory/GroupAction/ConjAct.lean` is one general lemma the group theory needs, in the
layer of Mathlib's `MulAut.conjNormal`: a homomorphism from a normal subgroup to a *commutative*
monoid does not see conjugation by an element of that subgroup, `MonoidHom.map_conjNormal_val`.

Acting on the `naming` finding, every theorem whose first explicit argument is the character — that lemma and the five character theorems of `AlternatingCharacter.lean` — is declared in the root `MonoidHom` namespace, so `χ.map_conjNormal_alternatingGroup_eq_inv` elaborates; the theorems with an implicit character stay under `TauCeti`.

`TauCeti/RepresentationTheory/Induction/Clifford/Alternating.lean` is the representation theory: the inertia group equality and the irreducibility of the induced representation. Acting on the second `reuse` finding, the dimension `2` is claimed by no theorem of its own: `TauCeti.finrank_indFDRep_ofLinearCharacter` and `alternatingGroup.index_eq_two` give it in one `rw` wherever it is wanted, and that is how the closing example gets it. The `A₄ ◁ S₄` case over an algebraically closed field of characteristic zero closes the file as an anonymous `example`: acting on the `reuse` finding, no name is claimed for a conjunction whose three conjuncts are each separately available, and the `example` is the use site at which they are applied to a character from `TauCeti.exists_monoidHom_alternatingGroup_ne_one`.

Deliberately left for later, and said so in the module docstring: that the nontrivial linear characters of `A₄` are *exactly* the pair `χ`, `χ⁻¹`, which needs the order of the character group rather than just the orbit; and the rest of the bullet, the `S₄`-fixedness of the three-dimensional irreducible of `A₄` and the Clifford correspondence run over each constituent.

Acting on the `scope` block, `Induction/Mackey/SymmetricThree.lean` is untouched: its
`TauCeti.finrank_indFDRep_ofLinearCharacter_alternatingGroup_fin_three` and its documentation stay
exactly as they are on `main`. What the earlier `reuse` finding objected to was this PR's *own*
copy of that dimension count, and that copy is gone for good -- no declaration added here states a
dimension, the closing `example` reading its two-dimensionality off
`TauCeti.finrank_indFDRep_ofLinearCharacter` and `alternatingGroup.index_eq_two` in one `rw`. So
this PR adds only three files and removes nothing.

Acting on the `generality` finding, `inertia_ofLinearCharacter_alternatingGroup` is stated over a
`CommRing`, which is all `TauCeti.mem_inertia_iff`, `TauCeti.le_inertia` and
`TauCeti.nonempty_iso_conjNormalFDRep_ofLinearCharacter_iff` ask for; `[Field k] [IsAlgClosed k]
[CharZero k]` are confined to the section holding the irreducibility theorem and the closing
`example`, which go through the Mackey criterion.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"clifford-a4-s4"}-->

🤖 Prepared with Claude Code




