### PR TITLE
refactor(RootsOfUnity): put `map_eq_pow` in the root `IsPrimitiveRoot` namespace

### DIFF
--- a/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -20,7 +20,7 @@ because the character records nothing but the power the root is sent to.
 
 ## Main results
 
-* `TauCeti.IsPrimitiveRoot.map_eq_pow`: a ring endomorphism sending a primitive `n`-th root of
+* `IsPrimitiveRoot.map_eq_pow`: a ring endomorphism sending a primitive `n`-th root of
   unity `ζ` to `ζ ^ j` sends every `n`-th root of unity `μ` to `μ ^ j`.
 * `IsPrimitiveRoot.autToPow_eq_one_iff`: the cyclotomic character kills an automorphism exactly
   when it fixes the chosen primitive root.
@@ -43,7 +43,7 @@ variable {R : Type u} [CommRing R] [IsDomain R]
 /-- A ring homomorphism that raises one primitive `n`-th root of unity to the `j`-th power raises
 every `n`-th root of unity to the `j`-th power, since the `n`-th roots of unity are exactly the
 powers of a primitive one. -/
-theorem IsPrimitiveRoot.map_eq_pow {n j : ℕ} [NeZero n] {ζ : R} (hζ : IsPrimitiveRoot ζ n)
+theorem _root_.IsPrimitiveRoot.map_eq_pow {n j : ℕ} [NeZero n] {ζ : R} (hζ : IsPrimitiveRoot ζ n)
     (σ : R →+* R) (hσ : σ ζ = ζ ^ j) {μ : R} (hμ : μ ^ n = 1) : σ μ = μ ^ j := by
   obtain ⟨i, -, rfl⟩ := hζ.eq_pow_of_pow_eq_one hμ
   rw [map_pow, hσ, ← pow_mul, ← pow_mul, Nat.mul_comm]


### PR DESCRIPTION
`map_eq_pow` takes `(hζ : IsPrimitiveRoot ζ n)` as its receiver but is declared inside
`namespace TauCeti`, so it lands in `TauCeti.IsPrimitiveRoot` and `hζ.map_eq_pow` does not
elaborate. `scripts/lint-dot-notation.py` flags exactly this.

Rooting the name fixes it — and makes the file consistent with itself: the theorem immediately
below is already written `_root_.IsPrimitiveRoot.autToPow_eq_one_iff`.

**No use site changes.** Both uses in `RepresentationTheory/CharacterTable/Galois.lean` already
write `IsPrimitiveRoot.map_eq_pow`, which resolved through `TauCeti` before and reaches the root
directly now. Nothing inside the file refers to the lemma by short name, and
`IsPrimitiveRoot.map_eq_pow` is free in Mathlib. The module docstring's single
`TauCeti.`-qualified mention is updated.

**Measured with the repo's own lint:** 1020 findings before, **1019 after, 0 new**.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp