### PR TITLE
feat(WeilDivisor): add inverse formula for prime classes

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/ClassGroup.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/ClassGroup.lean
@@ -27,7 +27,7 @@ an isomorphism of quotients
 
 `classGroupAddEquiv : (OrderSystem.ofDedekindDomain R K).ClassGroup ≃+ Additive (ClassGroup R)`,
 
-the Weil-divisor divisor class group of the affine Dedekind curve identified with Mathlib's ideal
+the Weil divisor class group of the affine Dedekind curve identified with Mathlib's ideal
 class group `ClassGroup R`. It is characterized by sending the class of the Weil divisor of an
 invertible fractional ideal `I` to the ideal class of `I`, and its inverse sends the ideal class
 of `I` back to the divisor class of the divisor of `I`; in particular the class of the point
@@ -73,7 +73,7 @@ private lemma map_toPrincipalIdeal_range :
 
 /-- **The divisor class group of the affine Dedekind curve is the ideal class group.**
 
-For a Dedekind domain `R` with fraction field `K`, the Weil-divisor divisor class group
+For a Dedekind domain `R` with fraction field `K`, the Weil divisor class group
 `(OrderSystem.ofDedekindDomain R K).ClassGroup` of the height-one spectrum is isomorphic to the
 ideal class group `ClassGroup R`, via the isomorphism `fractionalIdealDivisorAddEquiv R K` of
 invertible fractional ideals with Weil divisors descended to the quotient by principal
@@ -158,6 +158,14 @@ lemma classGroupAddEquiv_divisorClass_ofPoint (v : HeightOneSpectrum R) :
       Additive.ofMul v.classGroupMk := by
   rw [← fractionalIdealDivisor_asIdeal (K := K) v,
     classGroupAddEquiv_divisorClass_fractionalIdealDivisor, v.classGroupMk_eq_mk K]
+
+/-- The inverse of the class group isomorphism sends the ideal class of a height-one prime `v` to
+the class of its point divisor `[v]`. -/
+lemma classGroupAddEquiv_symm_ofMul_classGroupMk (v : HeightOneSpectrum R) :
+    (classGroupAddEquiv R K).symm (Additive.ofMul v.classGroupMk) =
+      (OrderSystem.ofDedekindDomain R K).divisorClass (ofPoint v) :=
+  (classGroupAddEquiv R K).symm_apply_eq.mpr
+    (classGroupAddEquiv_divisorClass_ofPoint (K := K) v).symm
 
 end WeilDivisor
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/ClassGroup.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/ClassGroup.lean
@@ -159,16 +159,27 @@ lemma classGroupAddEquiv_divisorClass_ofPoint (v : HeightOneSpectrum R) :
   rw [← fractionalIdealDivisor_asIdeal (K := K) v,
     classGroupAddEquiv_divisorClass_fractionalIdealDivisor, v.classGroupMk_eq_mk K]
 
-/-- The inverse of the class group isomorphism sends the ideal class of a height-one prime `v` to
-the class of its point divisor `[v]`. -/
-lemma classGroupAddEquiv_symm_ofMul_classGroupMk (v : HeightOneSpectrum R) :
-    (classGroupAddEquiv R K).symm (Additive.ofMul v.classGroupMk) =
-      (OrderSystem.ofDedekindDomain R K).divisorClass (ofPoint v) :=
-  (classGroupAddEquiv R K).symm_apply_eq.mpr
-    (classGroupAddEquiv_divisorClass_ofPoint (K := K) v).symm
-
 end WeilDivisor
 
 end AlgebraicGeometry
 
 end TauCeti
+
+namespace IsDedekindDomain.HeightOneSpectrum
+
+variable {R K : Type*} [CommRing R] [IsDedekindDomain R]
+    [Field K] [Algebra R K] [IsFractionRing R K]
+
+/-- The inverse of the class group isomorphism sends the ideal class of a height-one prime `v` to
+the class of its point divisor `[v]`. -/
+@[simp]
+lemma classGroupAddEquiv_symm_apply_classGroupMk (v : HeightOneSpectrum R) :
+    (TauCeti.AlgebraicGeometry.WeilDivisor.classGroupAddEquiv R K).symm
+        (Additive.ofMul v.classGroupMk) =
+      (TauCeti.AlgebraicGeometry.WeilDivisor.OrderSystem.ofDedekindDomain R K).divisorClass
+        (TauCeti.AlgebraicGeometry.WeilDivisor.ofPoint v) :=
+  (TauCeti.AlgebraicGeometry.WeilDivisor.classGroupAddEquiv R K).symm_apply_eq.mpr
+    (TauCeti.AlgebraicGeometry.WeilDivisor.classGroupAddEquiv_divisorClass_ofPoint
+      (K := K) v).symm
+
+end IsDedekindDomain.HeightOneSpectrum

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/ClassGroup.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/ClassGroup.lean
@@ -159,27 +159,17 @@ lemma classGroupAddEquiv_divisorClass_ofPoint (v : HeightOneSpectrum R) :
   rw [← fractionalIdealDivisor_asIdeal (K := K) v,
     classGroupAddEquiv_divisorClass_fractionalIdealDivisor, v.classGroupMk_eq_mk K]
 
+/-- The inverse of the class group isomorphism sends the ideal class of a height-one prime `v` to
+the class of its point divisor `[v]`. -/
+@[simp]
+lemma classGroupAddEquiv_symm_ofMul_classGroupMk (v : HeightOneSpectrum R) :
+    (classGroupAddEquiv R K).symm (Additive.ofMul v.classGroupMk) =
+      (OrderSystem.ofDedekindDomain R K).divisorClass (ofPoint v) :=
+  (classGroupAddEquiv R K).symm_apply_eq.mpr
+    (classGroupAddEquiv_divisorClass_ofPoint (K := K) v).symm
+
 end WeilDivisor
 
 end AlgebraicGeometry
 
 end TauCeti
-
-namespace IsDedekindDomain.HeightOneSpectrum
-
-variable {R K : Type*} [CommRing R] [IsDedekindDomain R]
-    [Field K] [Algebra R K] [IsFractionRing R K]
-
-/-- The inverse of the class group isomorphism sends the ideal class of a height-one prime `v` to
-the class of its point divisor `[v]`. -/
-@[simp]
-lemma classGroupAddEquiv_symm_apply_classGroupMk (v : HeightOneSpectrum R) :
-    (TauCeti.AlgebraicGeometry.WeilDivisor.classGroupAddEquiv R K).symm
-        (Additive.ofMul v.classGroupMk) =
-      (TauCeti.AlgebraicGeometry.WeilDivisor.OrderSystem.ofDedekindDomain R K).divisorClass
-        (TauCeti.AlgebraicGeometry.WeilDivisor.ofPoint v) :=
-  (TauCeti.AlgebraicGeometry.WeilDivisor.classGroupAddEquiv R K).symm_apply_eq.mpr
-    (TauCeti.AlgebraicGeometry.WeilDivisor.classGroupAddEquiv_divisorClass_ofPoint
-      (K := K) v).symm
-
-end IsDedekindDomain.HeightOneSpectrum

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/ClassGroup.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/ClassGroup.lean
@@ -159,15 +159,6 @@ lemma classGroupAddEquiv_divisorClass_ofPoint (v : HeightOneSpectrum R) :
   rw [← fractionalIdealDivisor_asIdeal (K := K) v,
     classGroupAddEquiv_divisorClass_fractionalIdealDivisor, v.classGroupMk_eq_mk K]
 
-/-- The inverse of the class group isomorphism sends the ideal class of a height-one prime `v` to
-the class of its point divisor `[v]`. -/
-@[simp]
-lemma classGroupAddEquiv_symm_ofMul_classGroupMk (v : HeightOneSpectrum R) :
-    (classGroupAddEquiv R K).symm (Additive.ofMul v.classGroupMk) =
-      (OrderSystem.ofDedekindDomain R K).divisorClass (ofPoint v) :=
-  (classGroupAddEquiv R K).symm_apply_eq.mpr
-    (classGroupAddEquiv_divisorClass_ofPoint (K := K) v).symm
-
 end WeilDivisor
 
 end AlgebraicGeometry


### PR DESCRIPTION
Roadmap: none

Adds the inverse point-class formula for the Dedekind-domain class-group equivalence. The existing API computes the image of a point divisor; this adds the matching formula for the inverse equivalence on the ideal class of a height-one prime.

Also removes duplicated wording in the surrounding documentation.

Validation:
- `lake build`
- `lake exe axioms`
- `lake exe module-system`
- `lake exe lint-style TauCeti.AlgebraicGeometry.WeilDivisor.Dedekind.ClassGroup`
- header-style audit for the changed file
- `git diff --check`