### PR TITLE
refactor(HeckeRing): factor the scalar operator's centrality at the diagonal level

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean
@@ -94,15 +94,23 @@ private lemma heckeT_prime_pow_one : heckeT ⟨p ^ 1, pow_pos hp.pos 1⟩ = heck
   congr 1
   exact Subtype.ext (pow_one p)
 
+/-- **The scalar operator is central**, in the form `T(1, p) · T(p,p) = T(p,p) · T(1, p)`.
+Every commutation below is this one transported: the `T(p)` form is it after
+`heckeT_prime`, and the `p • T(p,p)` form is that scaled. Primality plays no part. -/
+private lemma commute_heckeTDiag_one_heckeTScalar :
+    Commute (heckeTDiag 1 p) (heckeTScalar p) :=
+  -- transposition is an anti-involution fixing every Hecke coset, and a ring carrying one is
+  -- commutative on the cosets it fixes
+  HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
+    (transposeAntiInvolution_onHeckeCoset_eq_self 2) (heckeTDiag 1 p) (heckeTScalar p)
+
 include hp in
-/-- `T(p)` commutes with the scalar operator `T(p,p)`, by `mul_comm_of_antiInvolution`:
-transposition is an anti-involution fixing every Hecke coset, which makes the ring
-commutative on the pair. -/
+/-- `T(p)` commutes with the scalar operator `T(p,p)`. The shape the recurrence steps meet,
+whose left factor is written `T(p)` rather than `T(1, p)`. -/
 private lemma commute_heckeT_prime_heckeTScalar :
     Commute (heckeT ⟨p, hp.pos⟩) (heckeTScalar p) := by
   rw [heckeT_prime p hp]
-  exact HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
-    (transposeAntiInvolution_onHeckeCoset_eq_self 2) (heckeTDiag 1 p) (heckeTScalar p)
+  exact commute_heckeTDiag_one_heckeTScalar p
 
 include hp in
 /-- The inductive step of the recurrence for exponents `≥ 3`: substitute the recurrence at
@@ -192,8 +200,7 @@ private lemma heckeT_prime_pow_recurrence_two :
   rw [heckeT_prime_pow_zero p hp, mul_one, heckeTDiag_one_prime_pow_one, heckeT_prime p hp] at h5
   rw [heckeT_prime_pow_one p hp] at h5 ⊢
   rw [heckeT_prime p hp] at h5 ⊢
-  rw [HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
-    (transposeAntiInvolution_onHeckeCoset_eq_self 2) (heckeTDiag 1 p) (heckeTScalar p)] at h5
+  rw [(commute_heckeTDiag_one_heckeTScalar p).eq] at h5
   linear_combination (norm := module) -h5
 
 include hp in
@@ -227,8 +234,9 @@ sequence over any ring in which `D` and `S` commute — and here they do, the sc
 being central. -/
 
 include hp in
-/-- `T(p)` commutes with the scalar operator `p • T(p,p)`: an integer multiple of a
-commuting element still commutes. -/
+/-- `T(p)` commutes with the scalar operator `p • T(p,p)`. This is the pair the product
+formula hands to `linearRec₂_mul_eq_sum_pow_mul`, whose hypothesis is exactly that the two
+recurrence coefficients commute. -/
 private lemma commute_heckeT_prime_smul_heckeTScalar :
     Commute (heckeT ⟨p, hp.pos⟩) ((p : ℤ) • heckeTScalar p) :=
   (commute_heckeT_prime_heckeTScalar p hp).smul_right _

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean
@@ -95,6 +95,16 @@ private lemma heckeT_prime_pow_one : heckeT ⟨p ^ 1, pow_pos hp.pos 1⟩ = heck
   exact Subtype.ext (pow_one p)
 
 include hp in
+/-- `T(p)` commutes with the scalar operator `T(p,p)`, by `mul_comm_of_antiInvolution`:
+transposition is an anti-involution fixing every Hecke coset, which makes the ring
+commutative on the pair. -/
+private lemma commute_heckeT_prime_heckeTScalar :
+    Commute (heckeT ⟨p, hp.pos⟩) (heckeTScalar p) := by
+  rw [heckeT_prime p hp]
+  exact HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
+    (transposeAntiInvolution_onHeckeCoset_eq_self 2) (heckeTDiag 1 p) (heckeTScalar p)
+
+include hp in
 /-- The inductive step of the recurrence for exponents `≥ 3`: substitute the recurrence at
 `k` into the key product identity, then rearrange. -/
 private lemma heckeT_prime_pow_recurrence_step (k : ℕ) (hk_pos : 0 < k)
@@ -121,11 +131,7 @@ private lemma heckeT_prime_pow_recurrence_step (k : ℕ) (hk_pos : 0 < k)
   -- and `T(p,p)` over the difference on the right
   conv at h5 => rhs; rw [mul_sub]
   -- the scalar operator is central, and the induction hypothesis rewrites `T(p) · T(pᵏ)`
-  have hcomm : heckeT ⟨p, hp.pos⟩ * heckeTScalar p =
-      heckeTScalar p * heckeT ⟨p, hp.pos⟩ := by
-    rw [heckeT_prime p hp]
-    exact HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
-      (transposeAntiInvolution_onHeckeCoset_eq_self 2) (heckeTDiag 1 p) (heckeTScalar p)
+  have hcomm := (commute_heckeT_prime_heckeTScalar p hp).eq
   have hih : heckeT ⟨p, hp.pos⟩ * heckeT ⟨p ^ k, pow_pos hp.pos k⟩ =
       heckeT ⟨p ^ (k + 1), pow_pos hp.pos (k + 1)⟩ +
         (p : ℤ) • (heckeTScalar p * heckeT ⟨p ^ (k - 1), pow_pos hp.pos (k - 1)⟩) := by
@@ -221,16 +227,11 @@ sequence over any ring in which `D` and `S` commute — and here they do, the sc
 being central. -/
 
 include hp in
-/-- `T(p)` commutes with the scalar operator `p • T(p,p)`.
-
-The scalar operator is central by `mul_comm_of_antiInvolution`, and an integer multiple of a
+/-- `T(p)` commutes with the scalar operator `p • T(p,p)`: an integer multiple of a
 commuting element still commutes. -/
 private lemma commute_heckeT_prime_smul_heckeTScalar :
-    Commute (heckeT ⟨p, hp.pos⟩) ((p : ℤ) • heckeTScalar p) := by
-  refine Commute.smul_right ?_ _
-  rw [heckeT_prime p hp]
-  exact HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
-    (transposeAntiInvolution_onHeckeCoset_eq_self 2) (heckeTDiag 1 p) (heckeTScalar p)
+    Commute (heckeT ⟨p, hp.pos⟩) ((p : ℤ) • heckeTScalar p) :=
+  (commute_heckeT_prime_heckeTScalar p hp).smul_right _
 
 include hp in
 /-- **Shimura, Theorem 3.24(4)** — the prime-power product formula:


### PR DESCRIPTION
`Recurrence.lean` appealed to `mul_comm_of_antiInvolution` **three times** to establish the
same thing — that the scalar operator is central — in three different dresses:

| where | statement proved |
|---|---|
| `heckeT_prime_pow_recurrence_step`, inline as `hcomm` | `T(p) · T(p,p) = T(p,p) · T(p)` |
| `heckeT_prime_pow_recurrence_two`, inline as a rewrite | `T(1, p) · T(p,p) = T(p,p) · T(1, p)` |
| `commute_heckeT_prime_smul_heckeTScalar` | `Commute (T(p)) (p • T(p,p))` |

Only the third had a name.

### What changed

The fact is factored **at the diagonal level**, where all three meet:

```lean
private lemma commute_heckeTDiag_one_heckeTScalar :
    Commute (heckeTDiag 1 p) (heckeTScalar p)
```

The other two derive from it — the `T(p)` form by `heckeT_prime`, the `p • T(p,p)` form by
`smul_right` — and `mul_comm_of_antiInvolution` now appears exactly once in the file.

The diagonal level is the right one, not merely a convenient one: the second call site sits
*after* `rw [heckeT_prime]` has already turned `T(p)` into `T(1, p)`, so a lemma stated about
`T(p)` cannot serve it. The base lemma also needs no primality, so it takes no `hp`.

The docstrings now state what each commutation says and which development consumes it, with
the anti-involution argument in an ordinary comment beside the term that makes it.

No statement changes; every caller keeps its signature.

### Round 1 findings

All three were correct and all three are implemented, not contested.

* **generality** and **proof-quality** independently caught a third inline copy at
  `heckeT_prime_pow_recurrence_two` that the first version of this PR missed. `proof-quality`
  offered two routes — reorder the `heckeT_prime` rewrite so the existing lemma matches, or
  "factor the diagonal-level commutation lemma and derive all three uses from it". The second
  is what the mathematics wants: the diagonal statement is the primitive one and the other
  two are transports of it, so reordering rewrites to fit a derived form would have been the
  tail wagging the dog.
* **documentation** was right that both docstrings described the proof rather than the
  result. That is the same slip I made on #5874 and had corrected there; it should not have
  recurred here.

### Verification

* `lake build TauCeti.NumberTheory.HeckeRing.GL2.Recurrence` — clean, 2601 jobs.
* `#lint` with the 13-linter set (`checkType defsWithUnderscore deprecatedNoSince
  impossibleInstance nonClassInstance simpComm simpNF structureInType
  subsetDotNotationLinter synTaut tacticDocs unusedArguments unusedHavesSuffices`) over the
  import cone: **0 errors in 650 declarations**.
* `grep mul_comm_of_antiInvolution` over the file: one hit, inside the base lemma.
* No line over 100 characters; no trailing whitespace.

Roadmap: ModularForms

Provenance: refactor of already-merged TauCeti code; no new mathematics, so no target
marker. Swept github.com/CBirkbeck/AINTLIB @ 2baa76f742bdb4fb8ee323fabba41203bd390e08 at the
pinned revision (Apache-2.0) for `heckeTScalar`, `mul_comm_of_antiInvolution` and
`commute_heckeT`: it has no `heckeTScalar` and no `commute_heckeT_*` lemma, and applies
`mul_comm_of_antiInvolution` inline in the two files that use it. The scalar operator is
TauCeti's own vocabulary, so there was nothing to adopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
