### PR TITLE
feat(Huber): the structure map into a family of rational localisations

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Cover.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Cover.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.RingTheory.Huber.LocalizationTopology.Completion
+
+/-!
+# The structure map into a standard rational cover
+
+For a finite set `T` of numerators, the rational localisations `A⟨T/t⟩` for `t ∈ T` carry a single
+structure map out of `A` apiece. This file bundles them into one ring homomorphism
+`A →+* ∀ t : T, A⟨T/t⟩` and records that it is continuous.
+
+When `T` generates the unit ideal the family `(R(T/t))_{t ∈ T}` is a cover of `Spa(A,A⁺)`, by
+`TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top`, and this map is the
+comparison whose faithful flatness and injectivity Wedhorn's Corollary 8.32 asserts. Neither of
+those is proved here; this is the map they are about.
+
+## Implementation notes
+
+The localisations are given as a *family* `S : T → Type*`, one type per numerator, because that is
+how the rest of this development takes a localisation — as a parameter satisfying
+`IsLocalization.Away`, not as a construction. Their uniform structures are likewise supplied,
+which is why the three `letI` families appear before the codomain: `UniformSpace.Completion (S t)`
+is not a ring until `locUniformSpace`, `isUniformAddGroup_locUniformSpace` and
+`isTopologicalRing_locUniformSpace` are in scope for that `t`, and the product type mentions them
+all.
+
+## Main results
+
+* `TauCeti.Huber.PairOfDefinition.coverStructureHom`, with
+  `TauCeti.Huber.PairOfDefinition.coverStructureHom_apply` its computation rule and
+  `TauCeti.Huber.PairOfDefinition.continuous_coverStructureHom` its continuity.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Corollary 7.53 for the cover and
+  Corollary 8.32 for what this map is for.
+-/
+
+public section
+
+namespace TauCeti.Huber.PairOfDefinition
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
+  (P : PairOfDefinition A) (T : Finset A) (S : ∀ _ : T, Type*) [∀ t : T, CommRing (S t)]
+  [∀ t : T, Algebra A (S t)] [∀ t : T, IsLocalization.Away (t : A) (S t)]
+  (hden : ∀ t : T, HasDenominatorPower P T (t : A) (S t))
+
+/-- **The structure map into a standard rational cover**: the tuple of the structure maps
+`A → A⟨T/t⟩`, one for each numerator `t ∈ T`. -/
+noncomputable def coverStructureHom :
+    letI : ∀ t : T, UniformSpace (S t) := fun t ↦ locUniformSpace P T (t : A) (S t) (hden t)
+    letI : ∀ t : T, IsUniformAddGroup (S t) := fun t ↦
+      isUniformAddGroup_locUniformSpace P T (t : A) (S t) (hden t)
+    letI : ∀ t : T, IsTopologicalRing (S t) := fun t ↦
+      isTopologicalRing_locUniformSpace P T (t : A) (S t) (hden t)
+    A →+* ∀ t : T, UniformSpace.Completion (S t) :=
+  letI : ∀ t : T, UniformSpace (S t) := fun t ↦ locUniformSpace P T (t : A) (S t) (hden t)
+  letI : ∀ t : T, IsUniformAddGroup (S t) := fun t ↦
+    isUniformAddGroup_locUniformSpace P T (t : A) (S t) (hden t)
+  letI : ∀ t : T, IsTopologicalRing (S t) := fun t ↦
+    isTopologicalRing_locUniformSpace P T (t : A) (S t) (hden t)
+  RingHom.pi fun t ↦ toCompletionLoc P T (t : A) (S t) (hden t)
+
+/-- Each component of `TauCeti.Huber.PairOfDefinition.coverStructureHom` is the structure map into
+that rational localisation. The body is not exported, so this is how a consumer computes with
+it. -/
+@[simp]
+theorem coverStructureHom_apply (a : A) (t : T) :
+    letI : ∀ t : T, UniformSpace (S t) := fun t ↦ locUniformSpace P T (t : A) (S t) (hden t)
+    letI : ∀ t : T, IsUniformAddGroup (S t) := fun t ↦
+      isUniformAddGroup_locUniformSpace P T (t : A) (S t) (hden t)
+    letI : ∀ t : T, IsTopologicalRing (S t) := fun t ↦
+      isTopologicalRing_locUniformSpace P T (t : A) (S t) (hden t)
+    coverStructureHom P T S hden a t = toCompletionLoc P T (t : A) (S t) (hden t) a := (rfl)
+
+/-- **The structure map into a standard rational cover is continuous**, the product topology on the
+codomain being the one each factor carries. -/
+theorem continuous_coverStructureHom :
+    letI : ∀ t : T, UniformSpace (S t) := fun t ↦ locUniformSpace P T (t : A) (S t) (hden t)
+    letI : ∀ t : T, IsUniformAddGroup (S t) := fun t ↦
+      isUniformAddGroup_locUniformSpace P T (t : A) (S t) (hden t)
+    letI : ∀ t : T, IsTopologicalRing (S t) := fun t ↦
+      isTopologicalRing_locUniformSpace P T (t : A) (S t) (hden t)
+    Continuous (coverStructureHom P T S hden) :=
+  continuous_pi fun t ↦ continuous_toCompletionLoc P T (t : A) (S t) (hden t)
+
+end TauCeti.Huber.PairOfDefinition
+
+end

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Pi.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Pi.lean
@@ -8,16 +8,20 @@ module
 public import TauCeti.RingTheory.Huber.LocalizationTopology.Completion
 
 /-!
-# The structure map into a standard rational cover
+# The structure map into a family of rational localisations
 
 For a finite set `T` of numerators, the rational localisations `A⟨T/t⟩` for `t ∈ T` carry a single
 structure map out of `A` apiece. This file bundles them into one ring homomorphism
-`A →+* ∀ t : T, A⟨T/t⟩` and records that it is continuous.
+`A →+* ∀ t : T, A⟨T/t⟩` and records that it is continuous. No hypothesis relating the members of
+`T` is needed for either, so none is imposed: what is defined here is the product map for an
+arbitrary finite `T`.
 
-When `T` generates the unit ideal the family `(R(T/t))_{t ∈ T}` is a cover of `Spa(A,A⁺)`, by
-`TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top`, and this map is the
-comparison whose faithful flatness and injectivity Wedhorn's Corollary 8.32 asserts. Neither of
-those is proved here; this is the map they are about.
+The family `(R(T/t))_{t ∈ T}` is a cover of `Spa(A,A⁺)` — a *standard rational cover* — precisely
+when `T` generates the unit ideal, by
+`TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top`. Under that hypothesis
+this map is the comparison whose faithful flatness and injectivity Wedhorn's Corollary 8.32
+asserts. Neither the hypothesis nor those conclusions appear below; this is the map they are
+about.
 
 ## Implementation notes
 
@@ -31,9 +35,9 @@ all.
 
 ## Main results
 
-* `TauCeti.Huber.PairOfDefinition.coverStructureHom`, with
-  `TauCeti.Huber.PairOfDefinition.coverStructureHom_apply` its computation rule and
-  `TauCeti.Huber.PairOfDefinition.continuous_coverStructureHom` its continuity.
+* `TauCeti.Huber.PairOfDefinition.rationalLocalizationPiHom`, with
+  `TauCeti.Huber.PairOfDefinition.rationalLocalizationPiHom_apply` its computation rule and
+  `TauCeti.Huber.PairOfDefinition.continuous_rationalLocalizationPiHom` its continuity.
 
 ## References
 
@@ -50,9 +54,10 @@ variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
   [∀ t : T, Algebra A (S t)] [∀ t : T, IsLocalization.Away (t : A) (S t)]
   (hden : ∀ t : T, HasDenominatorPower P T (t : A) (S t))
 
-/-- **The structure map into a standard rational cover**: the tuple of the structure maps
-`A → A⟨T/t⟩`, one for each numerator `t ∈ T`. -/
-noncomputable def coverStructureHom :
+/-- **The structure map into a family of rational localisations**: the tuple of the structure maps
+`A → A⟨T/t⟩`, one for each numerator `t ∈ T`. The family is a standard rational cover exactly when
+`Ideal.span (T : Set A) = ⊤`, which nothing here requires. -/
+noncomputable def rationalLocalizationPiHom :
     letI : ∀ t : T, UniformSpace (S t) := fun t ↦ locUniformSpace P T (t : A) (S t) (hden t)
     letI : ∀ t : T, IsUniformAddGroup (S t) := fun t ↦
       isUniformAddGroup_locUniformSpace P T (t : A) (S t) (hden t)
@@ -66,27 +71,27 @@ noncomputable def coverStructureHom :
     isTopologicalRing_locUniformSpace P T (t : A) (S t) (hden t)
   RingHom.pi fun t ↦ toCompletionLoc P T (t : A) (S t) (hden t)
 
-/-- Each component of `TauCeti.Huber.PairOfDefinition.coverStructureHom` is the structure map into
-that rational localisation. The body is not exported, so this is how a consumer computes with
-it. -/
+/-- Each component of `TauCeti.Huber.PairOfDefinition.rationalLocalizationPiHom` is the structure
+map into that rational localisation. The body is not exported, so this is how a consumer computes
+with it. -/
 @[simp]
-theorem coverStructureHom_apply (a : A) (t : T) :
+theorem rationalLocalizationPiHom_apply (a : A) (t : T) :
     letI : ∀ t : T, UniformSpace (S t) := fun t ↦ locUniformSpace P T (t : A) (S t) (hden t)
     letI : ∀ t : T, IsUniformAddGroup (S t) := fun t ↦
       isUniformAddGroup_locUniformSpace P T (t : A) (S t) (hden t)
     letI : ∀ t : T, IsTopologicalRing (S t) := fun t ↦
       isTopologicalRing_locUniformSpace P T (t : A) (S t) (hden t)
-    coverStructureHom P T S hden a t = toCompletionLoc P T (t : A) (S t) (hden t) a := (rfl)
+    rationalLocalizationPiHom P T S hden a t = toCompletionLoc P T (t : A) (S t) (hden t) a := (rfl)
 
-/-- **The structure map into a standard rational cover is continuous**, the product topology on the
-codomain being the one each factor carries. -/
-theorem continuous_coverStructureHom :
+/-- **The structure map into a family of rational localisations is continuous**, the product
+topology on the codomain being the one each factor carries. -/
+theorem continuous_rationalLocalizationPiHom :
     letI : ∀ t : T, UniformSpace (S t) := fun t ↦ locUniformSpace P T (t : A) (S t) (hden t)
     letI : ∀ t : T, IsUniformAddGroup (S t) := fun t ↦
       isUniformAddGroup_locUniformSpace P T (t : A) (S t) (hden t)
     letI : ∀ t : T, IsTopologicalRing (S t) := fun t ↦
       isTopologicalRing_locUniformSpace P T (t : A) (S t) (hden t)
-    Continuous (coverStructureHom P T S hden) :=
+    Continuous (rationalLocalizationPiHom P T S hden) :=
   continuous_pi fun t ↦ continuous_toCompletionLoc P T (t : A) (S t) (hden t)
 
 end TauCeti.Huber.PairOfDefinition

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Pi.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Pi.lean
@@ -16,9 +16,12 @@ structure map out of `A` apiece. This file bundles them into one ring homomorphi
 `T` is needed for either, so none is imposed: what is defined here is the product map for an
 arbitrary finite `T`.
 
-The family `(R(T/t))_{t ∈ T}` is a cover of `Spa(A,A⁺)` — a *standard rational cover* — precisely
-when `T` generates the unit ideal, by
-`TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top`. Under that hypothesis
+The family `(R(T/t))_{t ∈ T}` is a cover of `Spa(A,A⁺)` — a *standard rational cover* — **when**
+`T` generates the unit ideal, by
+`TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top`, which needs nothing of
+`A`. The converse holds as well, but only once every maximal ideal of `A` is open
+(`TauCeti.ValuationSpectrum.span_eq_top_iff_spa_eq_biUnion_rationalSubset`, Corollary 7.53), and
+that hypothesis is not carried here. Under the spanning hypothesis
 this map is the comparison whose faithful flatness and injectivity Wedhorn's Corollary 8.32
 asserts. Neither the hypothesis nor those conclusions appear below; this is the map they are
 about.
@@ -55,7 +58,7 @@ variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
   (hden : ∀ t : T, HasDenominatorPower P T (t : A) (S t))
 
 /-- **The structure map into a family of rational localisations**: the tuple of the structure maps
-`A → A⟨T/t⟩`, one for each numerator `t ∈ T`. The family is a standard rational cover exactly when
+`A → A⟨T/t⟩`, one for each numerator `t ∈ T`. The family is a standard rational cover when
 `Ideal.span (T : Set A) = ⊤`, which nothing here requires. -/
 noncomputable def rationalLocalizationPiHom :
     letI : ∀ t : T, UniformSpace (S t) := fun t ↦ locUniformSpace P T (t : A) (S t) (hden t)


### PR DESCRIPTION
Roadmap: AdicSpaces

No `tauceti-target` marker: this authors no numbered target, it supplies a prerequisite one
needs.

`TauCeti.Huber.PairOfDefinition.rationalLocalizationPiHom : A →+* ∀ t : T, A⟨T/t⟩` — the tuple of
the structure maps into the rational localisations of a finite numerator set `T`, with its
computation rule and its continuity.

## What downstream needs it

`AdicSpaces/README.md` Layer 4.1 steps 4–6 and the section's concluding requirement, "exactness
in every degree of the augmented Čech complex for every finite rational cover of a rational
subset". This map is that augmentation. Corollary 8.32 (step 4) states its faithful flatness and
injectivity; Lemma 8.33 (step 5) and the 7.54/8.34 refinement (step 6) are the exactness claims
above it. None of those is proved here — this PR supplies the map they quantify over.

The cover itself already exists:
`TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top` says that a finite `T`
generating the unit ideal makes `(R(T/t))_{t ∈ T}` a cover of `Spa(A,A⁺)` (Corollary 7.53).

## Scope: what is still missing above this

Step 3 is **not** complete. #5753 landed Proposition 8.30's *elementary case and the chain it
composes into*, not the full statement that restriction maps between rational localisations are
flat. The `scope` review is right that no theorem about this map can be proved until that lands,
and I am not claiming otherwise: what is here is a definition and a continuity lemma, neither of
which mentions flatness, so neither can be reshaped by how 8.30 is finished. Completing
Proposition 8.30 is the next piece of mathematics in this chain.

Landing step 4 in turn unblocks **#5559**, which its `scope` review parked behind "the PR
completing steps 3–4".

## Why no spanning hypothesis

`Ideal.span (T : Set A) = ⊤` is what makes the family a *cover*, and it is deliberately absent:
the construction never uses it, so imposing it on the definition would push a hypothesis through
every later statement that does not need one. The results that do need it will carry it. The
declarations are named for the unconditional product map they are, and the docstrings say when
the family is a cover rather than assuming it is.

## Implementation note

The localisations arrive as a *family* `S : T → Type*`, one type per numerator, because that is
how this development takes a localisation throughout — as a parameter satisfying
`IsLocalization.Away`, never as a construction. Their uniform structures are supplied the same
way, which forces the three `letI` families *above* the codomain: `UniformSpace.Completion (S t)`
is not a ring until `locUniformSpace`, `isUniformAddGroup_locUniformSpace` and
`isTopologicalRing_locUniformSpace` are in scope for that `t`, and the product type mentions
every `t` at once. Putting them inside the `RingHom.pi` lambda instead fails with
`failed to synthesize NonAssocSemiring ((t : ↥T) → UniformSpace.Completion (S t))`.

## Reuse

`toCompletionLoc` and `continuous_toCompletionLoc` are taken from
`LocalizationTopology/Completion.lean`; `RingHom.pi` and `continuous_pi` from mathlib. Both
proofs are one line — `(rfl)` and `continuous_pi fun t ↦ …`. Nothing is re-derived. There is no
`algebraMap A (∀ t : T, UniformSpace.Completion (S t))` to reuse instead: Mathlib's completion
algebra instance requires `UniformContinuousConstSMul A (S t)`, which does not hold of
`locUniformSpace` without a further lemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
