### PR TITLE
refactor(BilinForm): drop a `namespace` block left empty by #5879

### DIFF
--- a/TauCeti/LinearAlgebra/BilinearForm/DualLattice.lean
+++ b/TauCeti/LinearAlgebra/BilinearForm/DualLattice.lean
@@ -40,8 +40,6 @@ variable {R K V : Type*} [CommRing R] [IsDomain R]
 variable [Field K] [Algebra R K] [IsFractionRing R K] [Module.IsTorsionFree R K]
 variable [AddCommGroup V] [Module R V] [Module K V] [IsScalarTower R K V]
 
-namespace LinearMap.BilinForm
-
 /-- Surjectivity of Mathlib's canonical pairing `dualSubmoduleToDual` for a free full lattice
 and a nondegenerate bilinear form. -/
 theorem _root_.LinearMap.BilinForm.dualSubmoduleToDual_surjective
@@ -122,7 +120,5 @@ theorem _root_.LinearMap.BilinForm.dualSubmodule_flip_dualSubmodule
   have h := LinearMap.BilinForm.dualSubmodule_dualSubmodule_flip B.flip hB.flip N
   have hflip : B.flip.flip = B := by ext; rfl
   rwa [hflip] at h
-
-end LinearMap.BilinForm
 
 end TauCeti


### PR DESCRIPTION
#5879 moved all five dual-lattice lemmas into the root `LinearMap.BilinForm` namespace, which is
where they belong — each takes a `LinearMap.BilinForm` as its receiver, and
`scripts/lint-dot-notation.py` flagged them for it.

That left the enclosing `namespace LinearMap.BilinForm` block (lines 43–126) putting **no name at
all** into `TauCeti.LinearMap.BilinForm`. It now only makes the file read as though it did — the
same residue #5820, #5838 and #5854 removed elsewhere.

**`TauCeti.LinearMap.BilinForm` itself stays.** `BilinearForm/PosSemidef.lean` and
`QuadraticForm/Signature.lean` still declare into it (1 and 3 declarations). This removes only the
wrapper in the one file that no longer contributes to it.

**Resolution is unchanged**, on two counts:

- nothing inside the block refers to one of the five lemmas by short name — #5879 wrote those
  references in full, as `LinearMap.BilinForm.…`, so they reach the root either way;
- no other name in the block was resolving *through* the enclosing namespace: every reference is
  either dot notation on the term `B` (`B.dualSubmoduleToDual`, `B.dualBasis`, …) or already
  qualified with its own namespace.

There is no `variable` inside the block — the three `variable` lines sit above it at 39–41 — so no
binder scope changes.

Four lines deleted, nothing else.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp