### PR TITLE
feat(Multiquadratic): the narrow ambiguous class number formula for either signature

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/AmbiguousClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/AmbiguousClassNumber.lean
@@ -6,9 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
-public import TauCeti.NumberTheory.NumberField.Quadratic.Conjugation.Ambiguous.Basic
 public import TauCeti.NumberTheory.NumberField.Quadratic.Conjugation.Ambiguous.Narrow
-public import TauCeti.NumberTheory.NumberField.Quadratic.Conjugation.ClassGroup
 import Mathlib.NumberTheory.NumberField.ClassNumber
 import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/AmbiguousClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/AmbiguousClassNumber.lean
@@ -15,9 +15,9 @@ import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 /-!
 # The ambiguous class number formula for a quadratic field
 
-Let `K = ℚ(√d)` with `d` squarefree, and let `t` be the number of rational primes that ramify in
-`K`. An ideal class is *ambiguous* when it is fixed by the quadratic conjugation `σ`; since `σ` acts
-on `Cl(K)` by inversion, the ambiguous classes are exactly the `2`-torsion classes
+Let `K = ℚ(√d)` with `d` squarefree and `1 < |d|`, and let `t` be the number of rational primes that
+ramify in `K`. An ideal class is *ambiguous* when it is fixed by the quadratic conjugation `σ`;
+since `σ` acts on `Cl(K)` by inversion, the ambiguous classes are exactly the `2`-torsion classes
 (`NumberField.mulEquiv_ringOfIntegersQuadraticConj_apply_eq_self_iff`), and for an imaginary field
 each of them is the class of an *ambiguous ideal* `I = σI`
 (`NumberField.sq_eq_one_iff_exists_map_ringOfIntegersQuadraticConj_eq_self`). In the narrow class
@@ -49,9 +49,10 @@ and the clean formula `2 ^ (t - 1)` is a statement about the narrow class group.
 * `TauCeti.Multiquadratic.natCard_exists_map_ringOfIntegersQuadraticConj_eq_self_eq_two_pow`: the
   same count for the classes of ambiguous ideals.
 * `TauCeti.Multiquadratic.natCard_narrowClassGroup_sq_eq_one_eq_two_pow`: a quadratic field of
-  either signature has exactly `2 ^ (t - 1)` narrow ideal classes of order dividing `2`.
-* `TauCeti.Multiquadratic.natCard_narrowClassGroup_exists_map_conj_eq_self_eq_two_pow` counts the
-  same narrow classes as narrow classes of ambiguous ideals.
+  either signature with `1 < |d|` has exactly `2 ^ (t - 1)` narrow ideal classes of order
+  dividing `2`.
+* `natCard_narrowClassGroup_exists_map_ringOfIntegersQuadraticConj_eq_self_eq_two_pow` (same
+  namespace) counts the same narrow classes as narrow classes of ambiguous ideals.
 -/
 
 public section
@@ -118,7 +119,7 @@ theorem natCard_narrowClassGroup_sq_eq_one_eq_two_pow
 with `d` squarefree and `1 < |d|`, of either signature, exactly `2 ^ (t - 1)` narrow ideal classes
 are represented by an ideal fixed by the quadratic conjugation, where `t` is the number of rational
 primes ramifying in `K`. -/
-theorem natCard_narrowClassGroup_exists_map_conj_eq_self_eq_two_pow
+theorem natCard_narrowClassGroup_exists_map_ringOfIntegersQuadraticConj_eq_self_eq_two_pow
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
     (hsf : Squarefree d) (hd : 1 < d.natAbs) :
     Nat.card {C : NarrowClassGroup K // ∃ I : (Ideal (𝓞 K))⁰,

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/AmbiguousClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/AmbiguousClassNumber.lean
@@ -109,18 +109,8 @@ theorem natCard_narrowClassGroup_sq_eq_one_eq_two_pow
     (hsf : Squarefree d) :
     Nat.card {C : NarrowClassGroup K // C ^ 2 = 1} = 2 ^ ((ramifiedPrimes K).ncard - 1) := by
   rw [← TauCeti.card_elementaryTwoQuotient_eq_card_twoTorsion,
-    NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank]
-  by_cases hd1 : 1 < d.natAbs
-  · rw [narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf hd1]
-  · -- The remaining field is `ℚ(√-1)`, which is totally complex: its narrow and ordinary
-    -- `2`-ranks agree, and the imaginary `2`-rank formula applies.
-    have hne1 : d ≠ 1 := fun h => not_isSquare_radicand hmin ⟨1, by rw [h]; norm_num⟩
-    have hneg : d < 0 := by
-      have := hsf.ne_zero
-      omega
-    have : IsTotallyComplex K := isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg hmin hneg
-    rw [NarrowClassGroup.twoRank_eq_classGroupTwoRank,
-      twoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf hneg]
+    NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
+    narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf]
 
 /-- **The narrow ambiguous class number formula, counted by ambiguous ideals.** For `K = ℚ(√d)`
 with `d` squarefree, of either signature, exactly `2 ^ (t - 1)` narrow ideal classes are

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/AmbiguousClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/AmbiguousClassNumber.lean
@@ -13,8 +13,8 @@ import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 /-!
 # The ambiguous class number formula for a quadratic field
 
-Let `K = ℚ(√d)` with `d` squarefree and `1 < |d|`, and let `t` be the number of rational primes that
-ramify in `K`. An ideal class is *ambiguous* when it is fixed by the quadratic conjugation `σ`;
+Let `K = ℚ(√d)` with `d` squarefree, and let `t` be the number of rational primes that ramify in
+`K`. An ideal class is *ambiguous* when it is fixed by the quadratic conjugation `σ`;
 since `σ` acts on `Cl(K)` by inversion, the ambiguous classes are exactly the `2`-torsion classes
 (`NumberField.mulEquiv_ringOfIntegersQuadraticConj_apply_eq_self_iff`), and for an imaginary field
 each of them is the class of an *ambiguous ideal* `I = σI`
@@ -47,8 +47,7 @@ and the clean formula `2 ^ (t - 1)` is a statement about the narrow class group.
 * `TauCeti.Multiquadratic.natCard_exists_map_ringOfIntegersQuadraticConj_eq_self_eq_two_pow`: the
   same count for the classes of ambiguous ideals.
 * `TauCeti.Multiquadratic.natCard_narrowClassGroup_sq_eq_one_eq_two_pow`: a quadratic field of
-  either signature with `1 < |d|` has exactly `2 ^ (t - 1)` narrow ideal classes of order
-  dividing `2`.
+  either signature has exactly `2 ^ (t - 1)` narrow ideal classes of order dividing `2`.
 * `natCard_narrowClassGroup_exists_map_ringOfIntegersQuadraticConj_eq_self_eq_two_pow` (same
   namespace) counts the same narrow classes as narrow classes of ambiguous ideals.
 -/
@@ -102,28 +101,38 @@ theorem natCard_exists_map_ringOfIntegersQuadraticConj_eq_self_eq_two_pow
 
 /-! ### The narrow class group, for either signature -/
 
-/-- **The narrow ambiguous class number formula.** For `K = ℚ(√d)` with `d` squarefree and
-`1 < |d|`, of either signature, the number of narrow ideal classes `C` with `C ^ 2 = 1` is
-`2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`. -/
+/-- **The narrow ambiguous class number formula.** For `K = ℚ(√d)` with `d` squarefree, of either
+signature, the number of narrow ideal classes `C` with `C ^ 2 = 1` is `2 ^ (t - 1)`, where `t` is
+the number of rational primes ramifying in `K`. -/
 theorem natCard_narrowClassGroup_sq_eq_one_eq_two_pow
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
-    (hsf : Squarefree d) (hd : 1 < d.natAbs) :
+    (hsf : Squarefree d) :
     Nat.card {C : NarrowClassGroup K // C ^ 2 = 1} = 2 ^ ((ramifiedPrimes K).ncard - 1) := by
   rw [← TauCeti.card_elementaryTwoQuotient_eq_card_twoTorsion,
-    NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
-    narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf hd]
+    NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank]
+  by_cases hd1 : 1 < d.natAbs
+  · rw [narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf hd1]
+  · -- The remaining field is `ℚ(√-1)`, which is totally complex: its narrow and ordinary
+    -- `2`-ranks agree, and the imaginary `2`-rank formula applies.
+    have hne1 : d ≠ 1 := fun h => not_isSquare_radicand hmin ⟨1, by rw [h]; norm_num⟩
+    have hneg : d < 0 := by
+      have := hsf.ne_zero
+      omega
+    have : IsTotallyComplex K := isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg hmin hneg
+    rw [NarrowClassGroup.twoRank_eq_classGroupTwoRank,
+      twoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf hneg]
 
 /-- **The narrow ambiguous class number formula, counted by ambiguous ideals.** For `K = ℚ(√d)`
-with `d` squarefree and `1 < |d|`, of either signature, exactly `2 ^ (t - 1)` narrow ideal classes
-are represented by an ideal fixed by the quadratic conjugation, where `t` is the number of rational
+with `d` squarefree, of either signature, exactly `2 ^ (t - 1)` narrow ideal classes are
+represented by an ideal fixed by the quadratic conjugation, where `t` is the number of rational
 primes ramifying in `K`. -/
 theorem natCard_narrowClassGroup_exists_map_ringOfIntegersQuadraticConj_eq_self_eq_two_pow
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
-    (hsf : Squarefree d) (hd : 1 < d.natAbs) :
+    (hsf : Squarefree d) :
     Nat.card {C : NarrowClassGroup K // ∃ I : (Ideal (𝓞 K))⁰,
       Ideal.map (ringOfIntegersQuadraticConj hmin hgen) (I : Ideal (𝓞 K)) = (I : Ideal (𝓞 K)) ∧
         NarrowClassGroup.mk0 I = C} = 2 ^ ((ramifiedPrimes K).ncard - 1) := by
-  rw [← natCard_narrowClassGroup_sq_eq_one_eq_two_pow hmin hgen hsf hd]
+  rw [← natCard_narrowClassGroup_sq_eq_one_eq_two_pow hmin hgen hsf]
   exact Nat.card_congr (Equiv.subtypeEquivRight fun C =>
     (NarrowClassGroup.sq_eq_one_iff_exists_map_ringOfIntegersQuadraticConj_eq_self hmin hgen
       C).symm)

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/AmbiguousClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/AmbiguousClassNumber.lean
@@ -7,32 +7,38 @@ module
 
 public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
 public import TauCeti.NumberTheory.NumberField.Quadratic.Conjugation.Ambiguous.Basic
+public import TauCeti.NumberTheory.NumberField.Quadratic.Conjugation.Ambiguous.Narrow
 public import TauCeti.NumberTheory.NumberField.Quadratic.Conjugation.ClassGroup
 import Mathlib.NumberTheory.NumberField.ClassNumber
 import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 
 /-!
-# The ambiguous class number formula for an imaginary quadratic field
+# The ambiguous class number formula for a quadratic field
 
-Let `K = ℚ(√d)` with `d < 0` squarefree, and let `t` be the number of rational primes that ramify
-in `K`. An ideal class of `K` is *ambiguous* when it is fixed by the quadratic conjugation `σ`;
-since `σ` acts on `Cl(K)` by inversion, the ambiguous classes are exactly the `2`-torsion classes
-(`NumberField.mulEquiv_ringOfIntegersQuadraticConj_apply_eq_self_iff`), and since `K` is totally
-complex each of them is the class of an *ambiguous ideal* `I = σI`
-(`NumberField.sq_eq_one_iff_exists_map_ringOfIntegersQuadraticConj_eq_self`). The **ambiguous class
-number formula** counts them:
+Let `K = ℚ(√d)` with `d` squarefree, and let `t` be the number of rational primes that ramify in
+`K`. An ideal class is *ambiguous* when it is fixed by the quadratic conjugation `σ`; since `σ` acts
+on `Cl(K)` by inversion, the ambiguous classes are exactly the `2`-torsion classes
+(`NumberField.mulEquiv_ringOfIntegersQuadraticConj_apply_eq_self_iff`), and for an imaginary field
+each of them is the class of an *ambiguous ideal* `I = σI`
+(`NumberField.sq_eq_one_iff_exists_map_ringOfIntegersQuadraticConj_eq_self`). In the narrow class
+group `Cl⁺(K)` of a field of either signature, the `2`-torsion classes are likewise exactly the
+narrow classes of ambiguous ideals
+(`NumberField.NarrowClassGroup.sq_eq_one_iff_exists_map_ringOfIntegersQuadraticConj_eq_self`). The
+**ambiguous class number formula** counts them:
 
+`#{C ∈ Cl⁺(K) | C² = 1} = 2 ^ (t - 1)`, and, for `d < 0`,
 `#{C ∈ Cl(K) | σC = C} = #{C ∈ Cl(K) | C² = 1} = 2 ^ (t - 1)`.
 
-This is the cardinality form of the `2`-rank formula `rank₂ Cl(K) = t - 1`
+These are the cardinality forms of the `2`-rank formulas `rank₂ Cl⁺(K) = t - 1`
+(`narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one`) and, for imaginary `K`, `rank₂ Cl(K) = t - 1`
 (`twoRank_eq_ncard_ramifiedPrimes_sub_one`): the `2`-torsion subgroup and the maximal
 elementary-`2` quotient of a finite abelian group have the same size
-(`TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_card_twoTorsion`).
+(`TauCeti.card_elementaryTwoQuotient_eq_card_twoTorsion`).
 
 The formula is classical; see D. A. Cox, *Primes of the Form x² + ny²*, §3.B and §6.A, and
 F. Lemmermeyer, *Reciprocity Laws: From Euler to Eisenstein*, §2.2. For a real quadratic field the
-count of ambiguous classes of the ordinary class group also depends on the norms of the units, and
-the clean formula `2 ^ (t - 1)` is a statement about the narrow class group.
+count of ambiguous classes of the *ordinary* class group also depends on the norms of the units,
+and the clean formula `2 ^ (t - 1)` is a statement about the narrow class group.
 
 ## Main results
 
@@ -42,6 +48,10 @@ the clean formula `2 ^ (t - 1)` is a statement about the narrow class group.
   same count for the classes fixed by quadratic conjugation, the ambiguous classes.
 * `TauCeti.Multiquadratic.natCard_exists_map_ringOfIntegersQuadraticConj_eq_self_eq_two_pow`: the
   same count for the classes of ambiguous ideals.
+* `TauCeti.Multiquadratic.natCard_narrowClassGroup_sq_eq_one_eq_two_pow`: a quadratic field of
+  either signature has exactly `2 ^ (t - 1)` narrow ideal classes of order dividing `2`.
+* `TauCeti.Multiquadratic.natCard_narrowClassGroup_exists_map_conj_eq_self_eq_two_pow` counts the
+  same narrow classes as narrow classes of ambiguous ideals.
 -/
 
 public section
@@ -90,5 +100,33 @@ theorem natCard_exists_map_ringOfIntegersQuadraticConj_eq_self_eq_two_pow
   rw [← natCard_classGroup_sq_eq_one_eq_two_pow hmin hgen hsf hd]
   exact Nat.card_congr (Equiv.subtypeEquivRight fun C =>
     (sq_eq_one_iff_exists_map_ringOfIntegersQuadraticConj_eq_self hmin hgen C).symm)
+
+/-! ### The narrow class group, for either signature -/
+
+/-- **The narrow ambiguous class number formula.** For `K = ℚ(√d)` with `d` squarefree and
+`1 < |d|`, of either signature, the number of narrow ideal classes `C` with `C ^ 2 = 1` is
+`2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`. -/
+theorem natCard_narrowClassGroup_sq_eq_one_eq_two_pow
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (hd : 1 < d.natAbs) :
+    Nat.card {C : NarrowClassGroup K // C ^ 2 = 1} = 2 ^ ((ramifiedPrimes K).ncard - 1) := by
+  rw [← TauCeti.card_elementaryTwoQuotient_eq_card_twoTorsion,
+    NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
+    narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf hd]
+
+/-- **The narrow ambiguous class number formula, counted by ambiguous ideals.** For `K = ℚ(√d)`
+with `d` squarefree and `1 < |d|`, of either signature, exactly `2 ^ (t - 1)` narrow ideal classes
+are represented by an ideal fixed by the quadratic conjugation, where `t` is the number of rational
+primes ramifying in `K`. -/
+theorem natCard_narrowClassGroup_exists_map_conj_eq_self_eq_two_pow
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hsf : Squarefree d) (hd : 1 < d.natAbs) :
+    Nat.card {C : NarrowClassGroup K // ∃ I : (Ideal (𝓞 K))⁰,
+      Ideal.map (ringOfIntegersQuadraticConj hmin hgen) (I : Ideal (𝓞 K)) = (I : Ideal (𝓞 K)) ∧
+        NarrowClassGroup.mk0 I = C} = 2 ^ ((ramifiedPrimes K).ncard - 1) := by
+  rw [← natCard_narrowClassGroup_sq_eq_one_eq_two_pow hmin hgen hsf hd]
+  exact Nat.card_congr (Equiv.subtypeEquivRight fun C =>
+    (NarrowClassGroup.sq_eq_one_iff_exists_map_ringOfIntegersQuadraticConj_eq_self hmin hgen
+      C).symm)
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/TwoRank.lean
@@ -19,8 +19,8 @@ import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 /-!
 # The `2`-rank of a quadratic class group
 
-For a squarefree integer `d` with `1 < |d|` let `K = ℚ(√d)` and let `t` be the number of rational
-primes that ramify in `K`. Genus theory computes the `2`-rank of the *narrow* class group `Cl⁺(K)`,
+For a squarefree integer `d` let `K = ℚ(√d)` and let `t` be the number of rational primes that
+ramify in `K`. Genus theory computes the `2`-rank of the *narrow* class group `Cl⁺(K)`,
 the dimension over `𝔽₂` of `Cl⁺(K)/Cl⁺(K)²`, to be exactly `t - 1`. This file proves that formula,
 
 `2-rank Cl⁺(K) = t - 1`,
@@ -250,14 +250,25 @@ theorem ncard_ramifiedPrimes_sub_one_le_narrowTwoRank
   exact card_sub_one_le_narrowTwoRank hs heven hprod hmin hgen hsf
 
 /-- **The `2`-rank formula for the narrow class group of a quadratic field.** For `K = ℚ(√d)` with
-`d` squarefree and `1 < |d|`, of either signature, the `2`-rank of `Cl⁺(K)` is exactly `t - 1`,
-where `t` is the number of rational primes ramifying in `K`. For an imaginary `K` the narrow and
-ordinary class groups coincide, and this recovers `twoRank_eq_ncard_ramifiedPrimes_sub_one`. -/
+`d` squarefree, of either signature, the `2`-rank of `Cl⁺(K)` is exactly `t - 1`, where `t` is the
+number of rational primes ramifying in `K`. For an imaginary `K` the narrow and ordinary class
+groups coincide, and this recovers `twoRank_eq_ncard_ramifiedPrimes_sub_one`; that identity is also
+how the Gaussian field `d = -1`, which the ambiguous class number bound excludes, is covered. -/
 theorem narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
-    (hsf : Squarefree d) (hd : 1 < d.natAbs) :
-    NumberField.NarrowClassGroup.twoRank K = (ramifiedPrimes K).ncard - 1 :=
-  le_antisymm (narrowTwoRank_le_ncard_ramifiedPrimes_sub_one hmin hgen hsf hd)
-    (ncard_ramifiedPrimes_sub_one_le_narrowTwoRank hmin hgen hsf)
+    (hsf : Squarefree d) :
+    NumberField.NarrowClassGroup.twoRank K = (ramifiedPrimes K).ncard - 1 := by
+  by_cases hd : 1 < d.natAbs
+  · exact le_antisymm (narrowTwoRank_le_ncard_ramifiedPrimes_sub_one hmin hgen hsf hd)
+      (ncard_ramifiedPrimes_sub_one_le_narrowTwoRank hmin hgen hsf)
+  · have hne1 : d ≠ 1 := fun h =>
+      NumberField.not_isSquare_radicand hmin ⟨1, by rw [h]; norm_num⟩
+    have hneg : d < 0 := by
+      have := hsf.ne_zero
+      omega
+    have : IsTotallyComplex K :=
+      NumberField.isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg hmin hneg
+    rw [NumberField.NarrowClassGroup.twoRank_eq_classGroupTwoRank,
+      twoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf hneg]
 
 end TauCeti.Multiquadratic


### PR DESCRIPTION
**The narrow ambiguous class number formula, for either signature.** For `K = ℚ(√d)` with `d` squarefree and `1 < |d|`, exactly `2 ^ (t - 1)` narrow ideal classes have order dividing `2` (`natCard_narrowClassGroup_sq_eq_one_eq_two_pow`), equivalently exactly `2 ^ (t - 1)` narrow classes are represented by an ambiguous ideal `I = σI` (`natCard_narrowClassGroup_exists_map_conj_eq_self_eq_two_pow`), with `t` the number of ramified rational primes. Both are corollaries of the narrow `2`-rank formula `narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one` through `|Cl⁺/Cl⁺²| = |Cl⁺[2]|` and the merged narrow descent `NarrowClassGroup.sq_eq_one_iff_exists_map_ringOfIntegersQuadraticConj_eq_self`. They extend the imaginary, ordinary-class-group formulas of `Quadratic/AmbiguousClassNumber.lean` to real quadratic fields, where the clean count `2 ^ (t - 1)` is a statement about the narrow class group.

**Roadmap node.** `TauCetiRoadmap/Multiquadratic/README.md`, heading *### Layer 2: the 2-elementary quotient of the class group*: "the ambiguous-class-number formula", and Layer 3: "the `t − 1` count needs the narrow class group". Intention: TauCetiRoadmap#332. No new axioms.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"TauCetiRoadmap/Multiquadratic/README.md#layer-2-ambiguous-class-number-formula/narrow"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WouEDwRYZVr9YqX9VFj8wa
