### PR TITLE
feat(Multiquadratic): |Gal(K_gen/K)| = |Cl⁺(K)/Cl⁺(K)²| for a quadratic field of either signature

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -9,7 +9,6 @@ public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.G
 public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
 import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.RamifiedPrimes
 import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Quadratic
-import Mathlib.NumberTheory.NumberField.ClassNumber
 import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 
 /-!

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -12,27 +12,33 @@ import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Quadrati
 import Mathlib.NumberTheory.NumberField.ClassNumber
 
 /-!
-# The relative candidate-genus-field Galois group has the same order as `Cl / Cl²`
+# The relative candidate-genus-field Galois group has the same order as `Cl⁺ / Cl⁺²`
 
-For an imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree) let `K_gen` be its candidate
-genus field. This file records that the relative Galois group `Gal(K_gen/K)` has the same order as
-the maximal elementary-`2` quotient `Cl(K) / Cl(K)²` of the ideal class group: both equal
+For a quadratic field `K = ℚ(√d)` (`d` squarefree, not a rational square) let `K_gen` be its
+candidate genus field, the narrow genus field of `K` (`isNarrowGenusField_candidateGenusField`) and,
+for `d < 0`, its genus field (`isGenusField_candidateGenusField`). This file records that the
+relative Galois group `Gal(K_gen/K)` has the same order as the maximal elementary-`2` quotient
+`Cl⁺(K) / Cl⁺(K)²` of the narrow class group, and, for imaginary `K`, as `Cl(K) / Cl(K)²`: all equal
 `2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`.
 
-This is the numerical content of the genus-theoretic summit isomorphism
-`Gal(K_gen/K) ≅ Cl(K) / Cl(K)²` — the two sides have equal cardinality — established **without class
-field theory**, by combining the field-theoretic relative degree `[K_gen : K] = 2 ^ (t - 1)`
-(`card_aut_candidateGenusField_over_base`) with the class-group `2`-rank theorem
-`2-rank Cl(K) = t - 1` (`twoRank_eq_ncard_ramifiedPrimes_sub_one`). The isomorphism itself needs the
-Artin reciprocity map and is not proved here.
+This is the numerical content of the genus-theoretic summit isomorphisms
+`Gal(K_gen/K) ≅ Cl⁺(K) / Cl⁺(K)²` and, for imaginary `K`, `Gal(K_gen/K) ≅ Cl(K) / Cl(K)²` — the two
+sides have equal cardinality — established **without class field theory**, by combining the
+field-theoretic relative degree `[K_gen : K] = 2 ^ (t - 1)`
+(`card_aut_candidateGenusField_over_base`) with the `2`-rank theorems `2-rank Cl⁺(K) = t - 1`
+(`narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one`) and `2-rank Cl(K) = t - 1` for `d < 0`
+(`twoRank_eq_ncard_ramifiedPrimes_sub_one`). The isomorphisms themselves need the Artin
+reciprocity map and are not proved here.
 
 See D. A. Cox, *Primes of the Form x² + ny²*, §6.A, and F. Lemmermeyer, *Reciprocity Laws: From
 Euler to Eisenstein*, §2.2.
 
-## Main result
+## Main results
 
-* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient`: for
-  imaginary `K`, `|Gal(K_gen/K)| = |Cl(K)/Cl(K)²|`.
+* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient`
+  gives `|Gal(K_gen/K)| = |Cl(K)/Cl(K)²|` for imaginary `K`.
+* `card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient` (same namespace)
+  gives `|Gal(K_gen/K)| = |Cl⁺(K)/Cl⁺(K)²|` for `K` of either signature.
 -/
 
 public section
@@ -65,6 +71,26 @@ theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
     TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
     twoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
       (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hneg,
+    card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes
+      (minpoly_candidateGenusFieldBaseGen hd hnsq)
+      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
+
+/-- **The relative candidate-genus-field Galois group and `Cl⁺(K)/Cl⁺(K)²` have equal order.** For a
+quadratic field `K = ℚ(√d)` of either signature (`d` squarefree and not a rational square, with
+`1 < |d|`), `|Gal(K_gen/K)|` equals `|Cl⁺(K)/Cl⁺(K)²|` — both are `2 ^ (t - 1)`, where `t` is the
+number of rational primes ramifying in `K`. This is the cardinality shadow of the summit isomorphism
+`Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²`, established without class field theory. -/
+theorem card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient
+    (hd : Squarefree d) (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) (hd1 : 1 < d.natAbs) :
+    Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =
+      Nat.card
+        (NumberField.NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd)) := by
+  have : NumberField (candidateGenusFieldBase hd) :=
+    NumberField.of_intermediateField (candidateGenusFieldBase hd)
+  rw [card_aut_candidateGenusField_over_base hd hnsq,
+    NumberField.NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
+    narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
+      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hd1,
     card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes
       (minpoly_candidateGenusFieldBaseGen hd hnsq)
       (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -21,7 +21,7 @@ relative Galois group `Gal(K_gen/K)` has the same order as the maximal elementar
 `Cl⁺(K) / Cl⁺(K)²` of the narrow class group, and, for imaginary `K`, as `Cl(K) / Cl(K)²`: all equal
 `2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`.
 
-This is the numerical content of the genus-theoretic summit isomorphisms
+This is the numerical content of the expected genus-field isomorphisms
 `Gal(K_gen/K) ≅ Cl⁺(K) / Cl⁺(K)²` and, for imaginary `K`, `Gal(K_gen/K) ≅ Cl(K) / Cl(K)²` — the two
 sides have equal cardinality — established **without class field theory**, by combining the
 field-theoretic relative degree `[K_gen : K] = 2 ^ (t - 1)`
@@ -53,8 +53,8 @@ variable {d : ℤ}
 /-- **The relative candidate-genus-field Galois group and `Cl(K)/Cl(K)²` have equal order.** For an
 imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree), `|Gal(K_gen/K)|` equals `|Cl(K)/Cl(K)²|`
 — both are `2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`. This is the
-cardinality shadow of the summit isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`, established without
-class field theory. -/
+cardinality shadow of the expected genus-field isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`,
+established without class field theory. -/
 theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
     (hd : Squarefree d) (hneg : d < 0) :
     Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =
@@ -76,15 +76,17 @@ theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
       (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
 
 /-- **The relative candidate-genus-field Galois group and `Cl⁺(K)/Cl⁺(K)²` have equal order.** For a
-quadratic field `K = ℚ(√d)` of either signature (`d` squarefree and not a rational square, with
-`1 < |d|`), `|Gal(K_gen/K)|` equals `|Cl⁺(K)/Cl⁺(K)²|` — both are `2 ^ (t - 1)`, where `t` is the
-number of rational primes ramifying in `K`. This is the cardinality shadow of the summit isomorphism
+quadratic field `K = ℚ(√d)` of either signature (`d` squarefree with `1 < |d|`), `|Gal(K_gen/K)|`
+equals `|Cl⁺(K)/Cl⁺(K)²|` — both are `2 ^ (t - 1)`, where `t` is the number of rational primes
+ramifying in `K`. This is the cardinality shadow of the expected genus-field isomorphism
 `Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²`, established without class field theory. -/
 theorem card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient
-    (hd : Squarefree d) (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) (hd1 : 1 < d.natAbs) :
+    (hd : Squarefree d) (hd1 : 1 < d.natAbs) :
     Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =
       Nat.card
         (NumberField.NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd)) := by
+  have hnsq : ¬ IsSquare ((d : ℤ) : ℚ) :=
+    not_isSquare_intCast_of_squarefree_of_ne_one hd (by rintro rfl; norm_num at hd1)
   have : NumberField (candidateGenusFieldBase hd) :=
     NumberField.of_intermediateField (candidateGenusFieldBase hd)
   rw [card_aut_candidateGenusField_over_base hd hnsq,

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -36,10 +36,11 @@ Euler to Eisenstein*, §2.2.
 
 ## Main results
 
-* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient`
-  gives `|Gal(K_gen/K)| = |Cl(K)/Cl(K)²|` for imaginary `K`.
-* `card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient` (same namespace)
-  gives `|Gal(K_gen/K)| = |Cl⁺(K)/Cl⁺(K)²|` for `K` of either signature.
+* `card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient` (in the namespace
+  `TauCeti.Multiquadratic`) gives `|Gal(K_gen/K)| = |Cl⁺(K)/Cl⁺(K)²|` for `K` of either signature.
+* `card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient` (same namespace) gives
+  `|Gal(K_gen/K)| = |Cl(K)/Cl(K)²|` for imaginary `K`, where the narrow and ordinary class groups
+  coincide.
 -/
 
 public section
@@ -50,6 +51,39 @@ open scoped NumberField
 namespace TauCeti.Multiquadratic
 
 variable {d : ℤ}
+
+/-- **The relative candidate-genus-field Galois group and `Cl⁺(K)/Cl⁺(K)²` have equal order.** For a
+quadratic field `K = ℚ(√d)` of either signature (`d` squarefree, not a rational square),
+`|Gal(K_gen/K)|`
+equals `|Cl⁺(K)/Cl⁺(K)²|` — both are `2 ^ (t - 1)`, where `t` is the number of rational primes
+ramifying in `K`. This is the cardinality shadow of the expected genus-field isomorphism
+`Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²`, established without class field theory. -/
+theorem card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient
+    (hd : Squarefree d) (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
+    Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =
+      Nat.card
+        (NumberField.NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd)) := by
+  have : NumberField (candidateGenusFieldBase hd) :=
+    NumberField.of_intermediateField (candidateGenusFieldBase hd)
+  rw [card_aut_candidateGenusField_over_base hd hnsq,
+    NumberField.NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
+    card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes
+      (minpoly_candidateGenusFieldBaseGen hd hnsq) (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
+  by_cases hd1 : 1 < d.natAbs
+  · rw [narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
+      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hd1]
+  · -- The remaining field is `ℚ(√-1)`, which is totally complex: its narrow and ordinary
+    -- `2`-ranks agree, and the imaginary `2`-rank formula applies.
+    have hne1 : d ≠ 1 := fun h => hnsq ⟨1, by rw [h]; norm_num⟩
+    have hneg : d < 0 := by
+      have := hd.ne_zero
+      omega
+    have : NumberField.IsTotallyComplex (candidateGenusFieldBase hd) :=
+      NumberField.isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg
+        (minpoly_candidateGenusFieldBaseGen hd hnsq) hneg
+    rw [NumberField.NarrowClassGroup.twoRank_eq_classGroupTwoRank,
+      twoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
+        (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hneg]
 
 /-- **The relative candidate-genus-field Galois group and `Cl(K)/Cl(K)²` have equal order.** For an
 imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree), `|Gal(K_gen/K)|` equals `|Cl(K)/Cl(K)²|`
@@ -67,47 +101,11 @@ theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
     linarith
   have : NumberField (candidateGenusFieldBase hd) :=
     NumberField.of_intermediateField (candidateGenusFieldBase hd)
-  have : Finite (ClassGroup (𝓞 (candidateGenusFieldBase hd))) := inferInstance
-  rw [card_aut_candidateGenusField_over_base hd hnsq,
-    TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
-    twoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
-      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hneg,
-    card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes
-      (minpoly_candidateGenusFieldBaseGen hd hnsq)
-      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
-
-/-- **The relative candidate-genus-field Galois group and `Cl⁺(K)/Cl⁺(K)²` have equal order.** For a
-quadratic field `K = ℚ(√d)` of either signature (`d` squarefree, not a rational square),
-`|Gal(K_gen/K)|`
-equals `|Cl⁺(K)/Cl⁺(K)²|` — both are `2 ^ (t - 1)`, where `t` is the number of rational primes
-ramifying in `K`. This is the cardinality shadow of the expected genus-field isomorphism
-`Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²`, established without class field theory. -/
-theorem card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient
-    (hd : Squarefree d) (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
-    Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =
-      Nat.card
-        (NumberField.NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd)) := by
-  have : NumberField (candidateGenusFieldBase hd) :=
-    NumberField.of_intermediateField (candidateGenusFieldBase hd)
-  by_cases hd1 : 1 < d.natAbs
-  · rw [card_aut_candidateGenusField_over_base hd hnsq,
-      NumberField.NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
-      narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
-        (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hd1,
-      card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes
-        (minpoly_candidateGenusFieldBaseGen hd hnsq)
-        (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
-  · -- The remaining field is `ℚ(√-1)`, which is totally complex: its narrow and ordinary class
-    -- groups coincide, and the imaginary statement applies.
-    have hne1 : d ≠ 1 := fun h => hnsq ⟨1, by rw [h]; norm_num⟩
-    have hneg : d < 0 := by
-      have := hd.ne_zero
-      omega
-    have : NumberField.IsTotallyComplex (candidateGenusFieldBase hd) :=
-      NumberField.isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg
-        (minpoly_candidateGenusFieldBaseGen hd hnsq) hneg
-    rw [card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient hd hneg]
-    exact (Nat.card_congr (NumberField.NarrowClassGroup.toClassGroupElementaryTwoQuotientEquiv
-      (candidateGenusFieldBase hd)).toEquiv).symm
+  have : NumberField.IsTotallyComplex (candidateGenusFieldBase hd) :=
+    NumberField.isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg
+      (minpoly_candidateGenusFieldBaseGen hd hnsq) hneg
+  rw [card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient hd hnsq]
+  exact Nat.card_congr (NumberField.NarrowClassGroup.toClassGroupElementaryTwoQuotientEquiv
+    (candidateGenusFieldBase hd)).toEquiv
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -10,6 +10,7 @@ public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
 import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.RamifiedPrimes
 import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Quadratic
 import Mathlib.NumberTheory.NumberField.ClassNumber
+import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 
 /-!
 # The relative candidate-genus-field Galois group has the same order as `Cl⁺ / Cl⁺²`
@@ -76,25 +77,37 @@ theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
       (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
 
 /-- **The relative candidate-genus-field Galois group and `Cl⁺(K)/Cl⁺(K)²` have equal order.** For a
-quadratic field `K = ℚ(√d)` of either signature (`d` squarefree with `1 < |d|`), `|Gal(K_gen/K)|`
+quadratic field `K = ℚ(√d)` of either signature (`d` squarefree, not a rational square),
+`|Gal(K_gen/K)|`
 equals `|Cl⁺(K)/Cl⁺(K)²|` — both are `2 ^ (t - 1)`, where `t` is the number of rational primes
 ramifying in `K`. This is the cardinality shadow of the expected genus-field isomorphism
 `Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²`, established without class field theory. -/
 theorem card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient
-    (hd : Squarefree d) (hd1 : 1 < d.natAbs) :
+    (hd : Squarefree d) (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
     Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =
       Nat.card
         (NumberField.NarrowClassGroup.ElementaryTwoQuotient (candidateGenusFieldBase hd)) := by
-  have hnsq : ¬ IsSquare ((d : ℤ) : ℚ) :=
-    not_isSquare_intCast_of_squarefree_of_ne_one hd (by rintro rfl; norm_num at hd1)
   have : NumberField (candidateGenusFieldBase hd) :=
     NumberField.of_intermediateField (candidateGenusFieldBase hd)
-  rw [card_aut_candidateGenusField_over_base hd hnsq,
-    NumberField.NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
-    narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
-      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hd1,
-    card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes
-      (minpoly_candidateGenusFieldBaseGen hd hnsq)
-      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
+  by_cases hd1 : 1 < d.natAbs
+  · rw [card_aut_candidateGenusField_over_base hd hnsq,
+      NumberField.NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
+      narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
+        (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hd1,
+      card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes
+        (minpoly_candidateGenusFieldBaseGen hd hnsq)
+        (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
+  · -- The remaining field is `ℚ(√-1)`, which is totally complex: its narrow and ordinary class
+    -- groups coincide, and the imaginary statement applies.
+    have hne1 : d ≠ 1 := fun h => hnsq ⟨1, by rw [h]; norm_num⟩
+    have hneg : d < 0 := by
+      have := hd.ne_zero
+      omega
+    have : NumberField.IsTotallyComplex (candidateGenusFieldBase hd) :=
+      NumberField.isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg
+        (minpoly_candidateGenusFieldBaseGen hd hnsq) hneg
+    rw [card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient hd hneg]
+    exact (Nat.card_congr (NumberField.NarrowClassGroup.toClassGroupElementaryTwoQuotientEquiv
+      (candidateGenusFieldBase hd)).toEquiv).symm
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -67,22 +67,9 @@ theorem card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotie
   rw [card_aut_candidateGenusField_over_base hd hnsq,
     NumberField.NarrowClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
     card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes
-      (minpoly_candidateGenusFieldBaseGen hd hnsq) (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
-  by_cases hd1 : 1 < d.natAbs
-  · rw [narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
-      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hd1]
-  · -- The remaining field is `ℚ(√-1)`, which is totally complex: its narrow and ordinary
-    -- `2`-ranks agree, and the imaginary `2`-rank formula applies.
-    have hne1 : d ≠ 1 := fun h => hnsq ⟨1, by rw [h]; norm_num⟩
-    have hneg : d < 0 := by
-      have := hd.ne_zero
-      omega
-    have : NumberField.IsTotallyComplex (candidateGenusFieldBase hd) :=
-      NumberField.isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg
-        (minpoly_candidateGenusFieldBaseGen hd hnsq) hneg
-    rw [NumberField.NarrowClassGroup.twoRank_eq_classGroupTwoRank,
-      twoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
-        (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hneg]
+      (minpoly_candidateGenusFieldBaseGen hd hnsq) (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd,
+    narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
+      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
 
 /-- **The relative candidate-genus-field Galois group and `Cl(K)/Cl(K)²` have equal order.** For an
 imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree), `|Gal(K_gen/K)|` equals `|Cl(K)/Cl(K)²|`


### PR DESCRIPTION
**`|Gal(K_gen/K)| = |Cl⁺(K)/Cl⁺(K)²|` for a quadratic field of either signature.** For `K = ℚ(√d)` with `d` squarefree, not a rational square, and `1 < |d|`, the relative Galois group of the candidate genus field `K_gen` (the narrow genus field of `K`, `isNarrowGenusField_candidateGenusField`) over the embedded copy of `K` has the same order as the maximal elementary-`2` quotient of the narrow class group (`card_aut_candidateGenusField_over_base_eq_card_narrowElementaryTwoQuotient`): both are `2 ^ (t - 1)`, `t` the number of ramified rational primes. This is the signature-free counterpart of the merged imaginary statement `card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient` in the same file, obtained from the field-theoretic degree `card_aut_candidateGenusField_over_base` and the narrow `2`-rank formula `narrowTwoRank_eq_ncard_ramifiedPrimes_sub_one`.

**Roadmap node.** `TauCetiRoadmap/Multiquadratic/README.md`, heading *### Layer 3: the genus field and the 2-rank theorem (the summit)*: "prove `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` (This isomorphism holds for real and imaginary `K` alike …)" and "For real `K` … the `t − 1` count needs the narrow class group and the narrow genus field". The isomorphism itself needs the Artin map (`STATUS.md` frontier "Galois group versus `Cl/Cl²`"); this PR supplies its cardinality shadow in the narrow, either-signature form, completing the numerical half of the summit. Intention: TauCetiRoadmap#332. No new axioms.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"TauCetiRoadmap/Multiquadratic/README.md#layer-3-genus-field-galois-group-vs-narrow-class-group/cardinality"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WouEDwRYZVr9YqX9VFj8wa
