### PR TITLE
fix(ContinuousLinearMap): enable dot notation for bilinear nondegeneracy

### DIFF
--- a/TauCeti/Topology/Algebra/Module/BilinearForm.lean
+++ b/TauCeti/Topology/Algebra/Module/BilinearForm.lean
@@ -24,7 +24,7 @@ itself, rather than with any of its users.
 
 ## Main results
 
-* `TauCeti.ContinuousLinearMap.separatingLeft_toBilinForm_iff_injective`: the bilinear form of a
+* `ContinuousLinearMap.separatingLeft_toBilinForm_iff_injective`: the bilinear form of a
   continuous linear map into the dual is left-separating if and only if the map is injective.
 * `TauCeti.ContinuousLinearMap.isInvertible_of_injective`: in finite dimensions an injective map
   into the dual is already invertible, the dual having the same dimension as the space.
@@ -40,7 +40,8 @@ variable {𝕜 E : Type*} [NormedField 𝕜] [AddCommGroup E] [Module 𝕜 E] [T
 
 /-- The bilinear form of a continuous linear map into the dual space is left-separating exactly
 when the map is injective. -/
-theorem separatingLeft_toBilinForm_iff_injective (L : E →L[𝕜] E →L[𝕜] 𝕜) :
+theorem _root_.ContinuousLinearMap.separatingLeft_toBilinForm_iff_injective
+    (L : E →L[𝕜] E →L[𝕜] 𝕜) :
     L.toBilinForm.SeparatingLeft ↔ Function.Injective L := by
   rw [LinearMap.separatingLeft_iff_ker_eq_bot, LinearMap.ker_eq_bot]
   exact ⟨fun h v w hvw ↦ h (LinearMap.ext fun u ↦ by simp [hvw]),


### PR DESCRIPTION
Roadmap: none

`separatingLeft_toBilinForm_iff_injective` is currently declared inside
`TauCeti.ContinuousLinearMap`, although its first explicit argument is a Mathlib
`ContinuousLinearMap`. Consequently the natural call
`L.separatingLeft_toBilinForm_iff_injective` does not elaborate. The repository's
dot-notation lint flags the declaration.

This moves the existing lemma into the root `ContinuousLinearMap` namespace and
updates its module documentation. Its hypotheses, statement, and proof are
unchanged; no compatibility alias is added. The two callers in
`Analysis/Calculus/Morse/Basic.lean` already use `ContinuousLinearMap.…`.
The neighboring `isInvertible_of_injective` is outside this change: its map is
implicit, so this is not the same receiver problem.

Validation on WSL at base `d98c6a4e86f5244f257bddaeae70fe336e9a0ba5`, Lean
4.34.0-rc2, Mathlib `5fcc6656691ed31965746c369f41fa75e567ac9d`:

- The changed module and `TauCeti.Analysis.Calculus.Morse.Basic` build before
  and after the change (2,390 build jobs, using cached dependencies).
- A standalone example using `L.separatingLeft_toBilinForm_iff_injective` fails
  before with `lean.invalidField` and compiles afterward.
- The focused dot-notation lint reports one finding before and zero afterward.
- The changed file passes the repository's header check and `git diff --check`.

This is targeted validation, not a whole-library build; CI still needs to pass.

AI disclosure: OpenAI Codex prepared this change and documentation; a separate
Codex Luna agent performed a read-only source/consumer audit. Bryan Ehrlich
requested and authorized the contribution. This has not had independent expert
human review. I would appreciate feedback on whether this is a useful API fix
and whether the scope, naming, or validation should be improved. This is our
first contribution as part of https://github.com/ehrlich-b/lean.
