### PR TITLE
feat: the Riemann–Roch theorem

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -1,0 +1,254 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.FunctionField.Differential.Dimension
+public import TauCeti.FieldTheory.FunctionField.RiemannRoch.Uniqueness
+
+/-!
+# The divisor of a Weil differential, and the Riemann–Roch theorem
+
+`TauCeti.Divisor.IsRiemannRochDivisor` records what it means for a divisor `W` to satisfy the
+Riemann–Roch identity `ℓ(D) = deg D + 1 - g₀ + ℓ(W - D)`, and everything about such a `W` —
+that `g₀` is the genus, that `deg W = 2g - 2` and `ℓ(W) = g`, that any two are linearly
+equivalent — is proved there.  What is missing, and is supplied here, is that **one exists**.
+That is the Riemann–Roch theorem.
+
+The witness is the divisor of a nonzero Weil differential.  Enlarging a divisor shrinks the space
+`Ω_F(D)` of Weil differentials it bounds, so the divisors bounding a fixed `ω` form a downward
+closed family; the two facts that make it have a *greatest* element are that the family is stable
+under suprema — because `A_F(D ⊔ E) = A_F(D) + A_F(E)`, which is
+`TauCeti.adeleFiltration_sup` — and that its degrees are bounded above, because past the
+threshold of Riemann's theorem the index of specialty vanishes and with it `Ω_F(D)`.
+A divisor of maximal degree in the family is then the greatest, since places have positive degree.
+
+Writing `W` for that greatest divisor, multiplication by a function is an injective `k`-linear map
+`F → Ω_F` carrying `L(W - D)` onto `Ω_F(D)`: a nonzero `x` has `x · ω ∈ Ω_F(D)` exactly when
+`ω ∈ Ω_F(D - div x)`, which by maximality says `D - div x ≤ W`, that is `x ∈ L(W - D)`; and it is
+onto because every Weil differential is a multiple of `ω` (Proposition 1.5.9, already available as
+`TauCeti.exists_repartitionDualMul_eq`).  So `ℓ(W - D) = dim_k Ω_F(D) = i(D)`, which rearranges to
+the Riemann–Roch identity.
+
+This completes Section I.5 of Stichtenoth.  It also supplies the divisor whose absence is noted in
+`TauCeti/FieldTheory/FunctionField/Differential/LocalComponent.lean`, where the remaining
+statements of Section I.7 are held back for want of it.
+
+## Main definitions
+
+* `TauCeti.riemannRochSpaceEquivWeilDifferentialFiltration`: **the duality isomorphism**
+  `L(W - D) ≃ Ω_F(D)`, `x ↦ x · ω` (Stichtenoth, Theorem 1.5.14).
+
+## Main results
+
+* `TauCeti.mem_weilDifferentialFiltration_sup`: a Weil differential bounded by `D` and by `E` is
+  bounded by `D ⊔ E`.
+* `TauCeti.exists_forall_degree_lt_of_mem_weilDifferentialFiltration`: the divisors bounding a
+  fixed nonzero Weil differential have bounded degree.
+* `TauCeti.exists_isGreatest_mem_weilDifferentialFiltration`: **the divisor of a nonzero Weil
+  differential** — among the divisors bounding it there is a greatest (Stichtenoth,
+  Proposition 1.5.11).
+* `TauCeti.mem_weilDifferentialFiltration_iff_le_of_isGreatest`: `ω ∈ Ω_F(D) ↔ D ≤ (ω)`, the
+  characteristic property of that divisor.
+* `TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace`: the
+  membership `x · ω ∈ Ω_F(D) ↔ x ∈ L(W - D)` that carries the theorem.
+* `TauCeti.map_riemannRochSpace_repartitionDualMulRight` and
+  `TauCeti.dim_sub_eq_finrank_weilDifferentialFiltration`: **the duality theorem** — `x ↦ x · ω`
+  maps `L(W - D)` onto `Ω_F(D)`, so `ℓ(W - D) = dim_k Ω_F(D)` (Stichtenoth, Theorem 1.5.14).
+* `TauCeti.isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration`: that divisor is a
+  Riemann–Roch divisor for the genus (Stichtenoth, Theorem 1.5.15).
+* `TauCeti.exists_isRiemannRochDivisor`: **the Riemann–Roch theorem** — a Riemann–Roch divisor
+  exists.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Section I.5, in particular Proposition 1.5.11, Theorem 1.5.14 and Theorem 1.5.15.
+* [The algebraic curves roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/AlgebraicCurves/README.md),
+  Layer 4.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {k F : Type*} [Field k] [Field F] [Algebra k F]
+
+/-! ### Weil differentials bounded by a supremum -/
+
+/-- A Weil differential bounded by each of two divisors is bounded by their supremum: by
+`TauCeti.adeleFiltration_sup` a repartition bounded by `D ⊔ E` is a sum of two on which the
+differential already vanishes. -/
+theorem mem_weilDifferentialFiltration_sup {D E : Divisor k F}
+    {ω : Module.Dual k ↥(repartitionSpace k F)} (hD : ω ∈ weilDifferentialFiltration D)
+    (hE : ω ∈ weilDifferentialFiltration E) :
+    ω ∈ weilDifferentialFiltration (D ⊔ E) := by
+  refine mem_weilDifferentialFiltration_of_apply_eq_zero (fun a ha ↦ ?_) (fun a ha ↦
+    weilDifferentialFiltration_apply_eq_zero_of_mem_diagonalRepartitions hD a ha)
+  obtain ⟨x, hx, y, hy, hxy⟩ := Submodule.mem_sup.mp ((adeleFiltration_sup D E).le ha)
+  have hxA : x ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace D hx
+  have hyA : y ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace E hy
+  have hsplit : a = ⟨x, hxA⟩ + ⟨y, hyA⟩ := Subtype.ext hxy.symm
+  rw [hsplit, map_add]
+  simp [weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hD ⟨x, hxA⟩ hx,
+    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hE ⟨y, hyA⟩ hy]
+
+/-! ### The divisor of a nonzero Weil differential -/
+
+/-- The divisors bounding a fixed nonzero Weil differential have bounded degree: past the
+threshold of `TauCeti.exists_forall_indexOfSpecialty_eq_zero` the divisor is nonspecial, and a
+nonspecial divisor bounds no nonzero Weil differential. -/
+theorem exists_forall_degree_lt_of_mem_weilDifferentialFiltration (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) :
+    ∃ c : ℤ, ∀ D : Divisor k F, ω ∈ weilDifferentialFiltration D → Divisor.degree D < c := by
+  obtain ⟨c, hc⟩ := exists_forall_indexOfSpecialty_eq_zero hF hex
+  refine ⟨c, fun D hD ↦ ?_⟩
+  by_contra hcon
+  push Not at hcon
+  have hbot : weilDifferentialFiltration D = ⊥ :=
+    (weilDifferentialFiltration_eq_bot_iff_indexOfSpecialty_eq_zero hF hex D).2 (hc D hcon)
+  exact hω (by simpa [hbot] using hD)
+
+/-- **The divisor of a nonzero Weil differential** (Stichtenoth, Proposition 1.5.11): the
+divisors bounding `ω` have a greatest element.
+
+Degrees are bounded above, so a divisor `W` of maximal degree among them exists; for any other
+`D` bounding `ω`, the supremum `D ⊔ W` also bounds `ω` and has degree at least that of `W` by
+monotonicity and at most by maximality, hence equals `W` because places have positive degree. -/
+theorem exists_isGreatest_mem_weilDifferentialFiltration (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
+    ∃ W : Divisor k F, IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W := by
+  classical
+  obtain ⟨c, hc⟩ := exists_forall_degree_lt_of_mem_weilDifferentialFiltration hF hex hω
+  obtain ⟨D₀, hD₀⟩ := mem_weilDifferentialSpace_iff.mp hmem
+  obtain ⟨m, ⟨W, hWmem, hWdeg⟩, hmax⟩ :=
+    Int.exists_greatest_of_bdd
+      (P := fun n : ℤ ↦ ∃ D : Divisor k F, ω ∈ weilDifferentialFiltration D ∧
+        Divisor.degree D = n)
+      ⟨c, fun n ⟨D, hD, hDn⟩ ↦ hDn ▸ (hc D hD).le⟩
+      ⟨Divisor.degree D₀, D₀, hD₀, rfl⟩
+  refine ⟨W, hWmem, fun D hD ↦ ?_⟩
+  have hsup : ω ∈ weilDifferentialFiltration (D ⊔ W) := mem_weilDifferentialFiltration_sup hD hWmem
+  have hle : Divisor.degree (D ⊔ W) ≤ Divisor.degree W := hWdeg ▸ hmax _ ⟨D ⊔ W, hsup, rfl⟩
+  have hge : Divisor.degree W ≤ Divisor.degree (D ⊔ W) := Divisor.degree_le_of_le le_sup_right
+  have hWeq : W = D ⊔ W := Divisor.eq_of_le_of_degree_eq hF le_sup_right (le_antisymm hge hle)
+  exact hWeq ▸ le_sup_left
+
+/-- The characteristic property of the divisor of `ω`, in the form consumers use: `ω` is bounded
+by `D` exactly when `D` is at most the divisor of `ω`.  The forward direction is maximality; the
+reverse is antitonicity of the filtration. -/
+theorem mem_weilDifferentialFiltration_iff_le_of_isGreatest
+    {ω : Module.Dual k ↥(repartitionSpace k F)} {W : Divisor k F}
+    (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
+    ω ∈ weilDifferentialFiltration D ↔ D ≤ W :=
+  ⟨fun h ↦ hW.2 h, fun h ↦ weilDifferentialFiltration_antitone h hW.1⟩
+
+/-! ### The Riemann–Roch theorem -/
+
+/-- **Duality between `L(W - D)` and `Ω_F(D)`**, for `W` the divisor of `ω`: a function `x`
+multiplies `ω` into `Ω_F(D)` exactly when it lies in `L(W - D)`.
+
+For nonzero `x`, multiplication translates the filtration by the principal divisor of `x`
+(`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`), so `x · ω ∈ Ω_F(D)` says
+`ω ∈ Ω_F(D - div x)`, which by maximality of `W` says `D - div x ≤ W`. -/
+theorem repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace
+    (hF : IsFunctionField k F) {ω : Module.Dual k ↥(repartitionSpace k F)} {W : Divisor k F}
+    (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W)
+    (D : Divisor k F) (x : F) :
+    repartitionDualMul hF x ω ∈ weilDifferentialFiltration D ↔ x ∈ riemannRochSpace (W - D) := by
+  rcases eq_or_ne x 0 with rfl | hx
+  · simp
+  obtain ⟨z, rfl⟩ : ∃ z : Fˣ, (z : F) = x := ⟨Units.mk0 x hx, rfl⟩
+  have habel : W - (D - Divisor.principal hF z) = Divisor.principal hF z + (W - D) := by abel
+  have hrw : D - Divisor.principal hF z + Divisor.principal hF z = D := by abel
+  have hiff : (D - Divisor.principal hF z ≤ W) ↔ 0 ≤ Divisor.principal hF z + (W - D) := by
+    rw [← habel]; exact sub_nonneg.symm
+  rw [mem_riemannRochSpace_units_iff hF, ← hiff]
+  constructor
+  · intro h
+    refine hW.2 ((repartitionDualMul_mem_weilDifferentialFiltration_iff hF z).mp ?_)
+    rwa [hrw]
+  · intro h
+    have hmem := (repartitionDualMul_mem_weilDifferentialFiltration_iff hF z).mpr
+      (weilDifferentialFiltration_antitone h hW.1)
+    rwa [hrw] at hmem
+
+/-- **The image of `L(W - D)` under multiplication by `ω` is `Ω_F(D)`.**  One inclusion is
+`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace`; the other
+is Proposition 1.5.9, every Weil differential being a multiple of `ω`
+(`TauCeti.exists_repartitionDualMul_eq`). -/
+theorem map_riemannRochSpace_repartitionDualMulRight (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0)
+    {W : Divisor k F}
+    (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
+    Submodule.map (repartitionDualMulRight hF ω) (riemannRochSpace (W - D)) =
+      weilDifferentialFiltration D := by
+  have key (x : F) : repartitionDualMulRight hF ω x ∈ weilDifferentialFiltration D ↔
+      x ∈ riemannRochSpace (W - D) := by
+    simpa using repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace hF hW D x
+  refine le_antisymm ?_ fun η hη ↦ ?_
+  · rintro _ ⟨x, hx, rfl⟩
+    exact (key x).mpr hx
+  · obtain ⟨c, hc⟩ := exists_repartitionDualMul_eq hF hex
+      (weilDifferentialFiltration_le_weilDifferentialSpace W hW.1) hω
+      (weilDifferentialFiltration_le_weilDifferentialSpace D hη)
+    exact ⟨c, (key c).mp (by simpa [hc] using hη), by simpa using hc⟩
+
+/-- **The duality theorem** (Stichtenoth, Theorem 1.5.14): for `W` the divisor of a nonzero Weil
+differential `ω`, multiplication by `ω` is a `k`-linear isomorphism `L(W - D) ≃ Ω_F(D)`.  It is
+injective by `TauCeti.injective_repartitionDualMulRight` and onto by
+`TauCeti.map_riemannRochSpace_repartitionDualMulRight`. -/
+noncomputable def riemannRochSpaceEquivWeilDifferentialFiltration (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0)
+    {W : Divisor k F}
+    (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
+    ↥(riemannRochSpace (W - D)) ≃ₗ[k] ↥(weilDifferentialFiltration D) :=
+  (Submodule.equivMapOfInjective _ (injective_repartitionDualMulRight hF hω)
+    (riemannRochSpace (W - D))).trans
+      (LinearEquiv.ofEq _ _ (map_riemannRochSpace_repartitionDualMulRight hF hex hω hW D))
+
+/-- **The duality theorem, in dimensions**: `ℓ(W - D) = dim_k Ω_F(D)`. -/
+theorem dim_sub_eq_finrank_weilDifferentialFiltration (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0)
+    {W : Divisor k F}
+    (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
+    Divisor.dim (W - D) = Module.finrank k ↥(weilDifferentialFiltration D) := by
+  rw [Divisor.dim_def]
+  exact (riemannRochSpaceEquivWeilDifferentialFiltration hF hex hω hW D).finrank_eq
+
+/-- **The Riemann–Roch theorem** (Stichtenoth, Theorem 1.5.15): the divisor of a nonzero Weil
+differential is a Riemann–Roch divisor for the genus.
+
+Duality gives `ℓ(W - D) = dim_k Ω_F(D)`, which is `i(D)` by
+`TauCeti.finrank_weilDifferentialFiltration` (Lemma 1.5.7); unfolding the index of specialty
+rearranges that to the Riemann–Roch identity. -/
+theorem isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration
+    (hF : IsFunctionField k F) (hex : IsIntegrallyClosedIn k F)
+    {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) {W : Divisor k F}
+    (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) :
+    W.IsRiemannRochDivisor (genus k F) := by
+  rw [Divisor.isRiemannRochDivisor_iff]
+  intro D
+  have hi := finrank_weilDifferentialFiltration hF hex D
+  rw [← dim_sub_eq_finrank_weilDifferentialFiltration hF hex hω hW D,
+    Divisor.indexOfSpecialty_def] at hi
+  omega
+
+/-- **The Riemann–Roch theorem, existence form** (Stichtenoth, Theorem 1.5.15 with
+Corollary 1.5.16): every algebraic function field with exact constant field has a Riemann–Roch
+divisor, namely the divisor of any nonzero Weil differential.  With
+`TauCeti.Divisor.IsRiemannRochDivisor.dim_eq` and
+`TauCeti.Divisor.IsRiemannRochDivisor.degree_eq` this gives `ℓ(W) = g` and `deg W = 2g - 2`, and
+with `TauCeti.Divisor.IsRiemannRochDivisor.linearlyEquivalent` the class of `W` — the canonical
+class — is well defined. -/
+theorem exists_isRiemannRochDivisor (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) :
+    ∃ W : Divisor k F, W.IsRiemannRochDivisor (genus k F) := by
+  obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
+  obtain ⟨W, hW⟩ := exists_isGreatest_mem_weilDifferentialFiltration hF hex hωmem hω0
+  exact ⟨W, isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration hF hex hω0 hW⟩
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -32,10 +32,6 @@ onto because every Weil differential is a multiple of `ω` (Proposition 1.5.9, a
 `TauCeti.exists_repartitionDualMul_eq`).  So `ℓ(W - D) = dim_k Ω_F(D) = i(D)`, which rearranges to
 the Riemann–Roch identity.
 
-This completes Section I.5 of Stichtenoth.  It also supplies the divisor whose absence is noted in
-`TauCeti/FieldTheory/FunctionField/Differential/LocalComponent.lean`, where the remaining
-statements of Section I.7 are held back for want of it.
-
 ## Main definitions
 
 * `TauCeti.riemannRochSpaceEquivWeilDifferentialFiltration`: **the duality isomorphism**
@@ -66,8 +62,7 @@ statements of Section I.7 are held back for want of it.
 
 * H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
   Section I.5, in particular Proposition 1.5.11, Theorem 1.5.14 and Theorem 1.5.15.
-* [The algebraic curves roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/AlgebraicCurves/README.md),
-  Layer 4.
+* [The algebraic curves roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/AlgebraicCurves/README.md).
 -/
 
 public section
@@ -199,16 +194,29 @@ theorem map_riemannRochSpace_repartitionDualMulRight (hF : IsFunctionField k F)
 
 /-- **The duality theorem** (Stichtenoth, Theorem 1.5.14): for `W` the divisor of a nonzero Weil
 differential `ω`, multiplication by `ω` is a `k`-linear isomorphism `L(W - D) ≃ Ω_F(D)`.  It is
-injective by `TauCeti.injective_repartitionDualMulRight` and onto by
+injective by `TauCeti.repartitionDualMulRight_injective` and onto by
 `TauCeti.map_riemannRochSpace_repartitionDualMulRight`. -/
 noncomputable def riemannRochSpaceEquivWeilDifferentialFiltration (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0)
     {W : Divisor k F}
     (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
     ↥(riemannRochSpace (W - D)) ≃ₗ[k] ↥(weilDifferentialFiltration D) :=
-  (Submodule.equivMapOfInjective _ (injective_repartitionDualMulRight hF hω)
+  (Submodule.equivMapOfInjective _ (repartitionDualMulRight_injective hF hω)
     (riemannRochSpace (W - D))).trans
       (LinearEquiv.ofEq _ _ (map_riemannRochSpace_repartitionDualMulRight hF hex hω hW D))
+
+/-- The duality equivalence sends `x` to the Weil differential `x · ω`. -/
+@[simp]
+theorem riemannRochSpaceEquivWeilDifferentialFiltration_apply (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0)
+    {W : Divisor k F}
+    (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F)
+    (x : ↥(riemannRochSpace (W - D))) :
+    (riemannRochSpaceEquivWeilDifferentialFiltration hF hex hω hW D x :
+      Module.Dual k ↥(repartitionSpace k F)) = repartitionDualMul hF x ω := by
+  rw [riemannRochSpaceEquivWeilDifferentialFiltration, LinearEquiv.trans_apply,
+    LinearEquiv.coe_ofEq_apply, Submodule.coe_equivMapOfInjective_apply,
+    repartitionDualMulRight_apply]
 
 /-- **The duality theorem, in dimensions**: `ℓ(W - D) = dim_k Ω_F(D)`. -/
 theorem dim_sub_eq_finrank_weilDifferentialFiltration (hF : IsFunctionField k F)

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -19,7 +19,7 @@ genus, `deg W = 2g - 2` and `ℓ(W) = g`, and any two such divisors are linearly
 The witness is the divisor of a nonzero Weil differential.  Enlarging a divisor shrinks the space
 `Ω_F(D)` of Weil differentials it bounds, so the divisors bounding a fixed `ω` form a downward
 closed family; the two facts that make it have a *greatest* element are that the family is stable
-under suprema (`TauCeti.mem_weilDifferentialFiltration_sup`) and that its degrees are bounded
+under suprema (`TauCeti.weilDifferentialFiltration_sup`) and that its degrees are bounded
 above, because past the threshold of Riemann's theorem the index of specialty vanishes and with
 it `Ω_F(D)`.
 A divisor of maximal degree in the family is then the greatest, since places have positive degree.
@@ -124,7 +124,9 @@ theorem exists_isGreatest_mem_weilDifferentialFiltration (hF : IsFunctionField k
       ⟨c, fun n ⟨D, hD, hDn⟩ ↦ hDn ▸ (hc D hD).le⟩
       ⟨Divisor.degree D₀, D₀, hD₀, rfl⟩
   refine ⟨W, hWmem, fun D hD ↦ ?_⟩
-  have hsup : ω ∈ weilDifferentialFiltration (D ⊔ W) := mem_weilDifferentialFiltration_sup hD hWmem
+  have hsup : ω ∈ weilDifferentialFiltration (D ⊔ W) := by
+    rw [weilDifferentialFiltration_sup]
+    exact ⟨hD, hWmem⟩
   have hle : Divisor.degree (D ⊔ W) ≤ Divisor.degree W := hWdeg ▸ hmax _ ⟨D ⊔ W, hsup, rfl⟩
   have hge : Divisor.degree W ≤ Divisor.degree (D ⊔ W) := Divisor.degree_le_of_le le_sup_right
   have hWeq : W = D ⊔ W := Divisor.eq_of_le_of_degree_eq hF le_sup_right (le_antisymm hge hle)
@@ -181,6 +183,19 @@ theorem coeff_weilDifferentialDivisor (hF : IsFunctionField k F)
     (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (P : Place k F) :
     (weilDifferentialDivisor hF hex hmem hω).coeff P = weilDifferentialOrder hF hex hmem hω P :=
   (rfl)
+
+/-- A nonzero Weil differential is regular (or holomorphic), meaning that it is bounded by the
+zero divisor, exactly when its order is nonnegative at every place. -/
+@[simp]
+theorem mem_weilDifferentialFiltration_zero_iff_forall_order_nonneg
+    (hF : IsFunctionField k F) (hex : IsIntegrallyClosedIn k F)
+    {ω : Module.Dual k ↥(repartitionSpace k F)} (hmem : ω ∈ weilDifferentialSpace k F)
+    (hω : ω ≠ 0) :
+    ω ∈ weilDifferentialFiltration (0 : Divisor k F) ↔
+      ∀ P : Place k F, 0 ≤ weilDifferentialOrder hF hex hmem hω P := by
+  rw [mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor hF hex hmem hω]
+  change (∀ P : Place k F, 0 ≤ (weilDifferentialDivisor hF hex hmem hω).coeff P) ↔ _
+  simp only [coeff_weilDifferentialDivisor]
 
 /-- **The transformation law `(z · ω) = div z + (ω)`** (Stichtenoth, Proposition 1.5.13): the
 divisor of a Weil differential changes by a principal divisor when the differential is multiplied

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -123,6 +123,7 @@ theorem exists_isGreatest_mem_weilDifferentialFiltration (hF : IsFunctionField k
 /-- The characteristic property of the divisor of `ω`, in the form consumers use: `ω` is bounded
 by `D` exactly when `D` is at most the divisor of `ω`.  The forward direction is maximality; the
 reverse is antitonicity of the filtration. -/
+@[simp]
 theorem mem_weilDifferentialFiltration_iff_le_of_isGreatest
     {ω : Module.Dual k ↥(repartitionSpace k F)} {W : Divisor k F}
     (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
@@ -149,6 +150,7 @@ theorem isGreatest_weilDifferentialDivisor (hF : IsFunctionField k F)
 
 /-- **The characteristic property of `(ω)`**: a nonzero Weil differential is bounded by `D`
 exactly when `D ≤ (ω)`. -/
+@[simp]
 theorem mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
     (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (D : Divisor k F) :
@@ -232,6 +234,7 @@ multiplies `ω` into `Ω_F(D)` exactly when it lies in `L(W - D)`.
 For nonzero `x`, multiplication translates the filtration by the principal divisor of `x`
 (`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`), so `x · ω ∈ Ω_F(D)` says
 `ω ∈ Ω_F(D - div x)`, which by maximality of `W` says `D - div x ≤ W`. -/
+@[simp]
 theorem repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace
     (hF : IsFunctionField k F) {ω : Module.Dual k ↥(repartitionSpace k F)} {W : Divisor k F}
     (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W)

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -79,9 +79,6 @@ the Riemann–Roch identity.
 * H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
   Section I.5, in particular Lemma 1.5.10, Theorem 1.5.14 and Theorem 1.5.15, and
   Proposition 1.6.2.
-* Tau Ceti pull request
-  [#5207](https://github.com/TauCetiProject/TauCeti/pull/5207), the predecessor formalization of
-  these results, which the present development adapts.
 -/
 
 public section
@@ -112,6 +109,7 @@ theorem exists_isGreatest_mem_weilDifferentialFiltration (hF : IsFunctionField k
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
     (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
     ∃ W : Divisor k F, IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W := by
+  -- This maximal-degree construction adapts the predecessor formalization in Tau Ceti PR #5207.
   -- Degrees are bounded above, so a divisor `W` of maximal degree among them exists; for any
   -- other `D` bounding `ω`, the supremum `D ⊔ W` also bounds `ω` and has degree at least that of
   -- `W` by monotonicity and at most by maximality, hence equals `W` because places have positive

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -48,7 +48,7 @@ the Riemann–Roch identity.
   fixed nonzero Weil differential have bounded degree.
 * `TauCeti.exists_isGreatest_mem_weilDifferentialFiltration`: **the divisor of a nonzero Weil
   differential** — among the divisors bounding it there is a greatest (Stichtenoth,
-  Proposition 1.5.11).
+  Lemma 1.5.10).
 * `TauCeti.mem_weilDifferentialFiltration_iff_le_of_isGreatest` and
   `TauCeti.mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor`: `ω ∈ Ω_F(D) ↔ D ≤ (ω)`,
   the characteristic property of that divisor.
@@ -77,7 +77,7 @@ the Riemann–Roch identity.
 ## References
 
 * H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
-  Section I.5, in particular Proposition 1.5.11, Theorem 1.5.14 and Theorem 1.5.15, and
+  Section I.5, in particular Lemma 1.5.10, Theorem 1.5.14 and Theorem 1.5.15, and
   Proposition 1.6.2.
 * Tau Ceti pull request
   [#5207](https://github.com/TauCetiProject/TauCeti/pull/5207), the predecessor formalization of
@@ -106,7 +106,7 @@ theorem exists_forall_degree_lt_of_mem_weilDifferentialFiltration (hF : IsFuncti
     (weilDifferentialFiltration_eq_bot_iff_indexOfSpecialty_eq_zero hF hex D).2 (hc D hcon)
   exact hω (by simpa [hbot] using hD)
 
-/-- **The divisor of a nonzero Weil differential** (Stichtenoth, Proposition 1.5.11): the
+/-- **The divisor of a nonzero Weil differential** (Stichtenoth, Lemma 1.5.10): the
 divisors bounding `ω` have a greatest element. -/
 theorem exists_isGreatest_mem_weilDifferentialFiltration (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
@@ -437,11 +437,10 @@ theorem divisorClass_eq_canonicalClass_iff (hF : IsFunctionField k F)
     have hone : 1 ≤ Divisor.dim (weilDifferentialDivisor hF hex hωmem hω0 - D) := by
       rw [hdeg] at hid
       omega
-    obtain ⟨z, hz⟩ :=
-      (Divisor.one_le_dim_iff_exists_principal_eq_of_degree_eq_zero hF hdegsub).mp hone
     have hclass : (Place.orderSystem hF).divisorClass
         (weilDifferentialDivisor hF hex hωmem hω0 - D) = 0 :=
-      (Divisor.divisorClass_eq_zero_iff hF).mpr ⟨z, hz⟩
+      (riemannRochSpace_ne_bot_iff_divisorClass_eq_zero_of_degree_eq_zero hF hdegsub).mp
+        ((Divisor.one_le_dim_iff_riemannRochSpace_ne_bot hF _).mp hone)
     rw [map_sub, sub_eq_zero, divisorClass_weilDifferentialDivisor hF hex hωmem hω0] at hclass
     exact hclass.symm
 

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -187,6 +187,7 @@ Multiplication translates the filtration by `div z`
 (`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`), so it carries the divisors
 bounding `ω` bijectively onto those bounding `z · ω`, hence greatest element to greatest
 element. -/
+@[simp]
 theorem weilDifferentialDivisor_repartitionDualMul (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
     (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (z : Fˣ) :
@@ -239,6 +240,7 @@ noncomputable def canonicalClass (hF : IsFunctionField k F)
       ((Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)).choose_spec.2)
 
 /-- Every nonzero Weil differential represents the canonical class. -/
+@[simp]
 theorem divisorClass_weilDifferentialDivisor (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
     (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -123,7 +123,6 @@ theorem exists_isGreatest_mem_weilDifferentialFiltration (hF : IsFunctionField k
 /-- The characteristic property of the divisor of `ω`, in the form consumers use: `ω` is bounded
 by `D` exactly when `D` is at most the divisor of `ω`.  The forward direction is maximality; the
 reverse is antitonicity of the filtration. -/
-@[simp]
 theorem mem_weilDifferentialFiltration_iff_le_of_isGreatest
     {ω : Module.Dual k ↥(repartitionSpace k F)} {W : Divisor k F}
     (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
@@ -234,7 +233,6 @@ multiplies `ω` into `Ω_F(D)` exactly when it lies in `L(W - D)`.
 For nonzero `x`, multiplication translates the filtration by the principal divisor of `x`
 (`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`), so `x · ω ∈ Ω_F(D)` says
 `ω ∈ Ω_F(D - div x)`, which by maximality of `W` says `D - div x ≤ W`. -/
-@[simp]
 theorem repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace
     (hF : IsFunctionField k F) {ω : Module.Dual k ↥(repartitionSpace k F)} {W : Divisor k F}
     (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W)

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -12,10 +12,9 @@ public import TauCeti.FieldTheory.FunctionField.RiemannRoch.Uniqueness
 # The divisor of a Weil differential, and the Riemann–Roch theorem
 
 `TauCeti.Divisor.IsRiemannRochDivisor` records what it means for a divisor `W` to satisfy the
-Riemann–Roch identity `ℓ(D) = deg D + 1 - g₀ + ℓ(W - D)`, and everything about such a `W` —
-that `g₀` is the genus, that `deg W = 2g - 2` and `ℓ(W) = g`, that any two are linearly
-equivalent — is proved there.  What is missing, and is supplied here, is that **one exists**.
-That is the Riemann–Roch theorem.
+Riemann–Roch identity `ℓ(D) = deg D + 1 - g₀ + ℓ(W - D)`; for such a `W` the number `g₀` is the
+genus, `deg W = 2g - 2` and `ℓ(W) = g`, and any two such divisors are linearly equivalent.
+**The Riemann–Roch theorem**, proved here, is that such a `W` exists.
 
 The witness is the divisor of a nonzero Weil differential.  Enlarging a divisor shrinks the space
 `Ω_F(D)` of Weil differentials it bounds, so the divisors bounding a fixed `ω` form a downward
@@ -28,7 +27,7 @@ A divisor of maximal degree in the family is then the greatest, since places hav
 Writing `W` for that greatest divisor, multiplication by a function is an injective `k`-linear map
 `F → Ω_F` carrying `L(W - D)` onto `Ω_F(D)`: a nonzero `x` has `x · ω ∈ Ω_F(D)` exactly when
 `ω ∈ Ω_F(D - div x)`, which by maximality says `D - div x ≤ W`, that is `x ∈ L(W - D)`; and it is
-onto because every Weil differential is a multiple of `ω` (Proposition 1.5.9, already available as
+onto because every Weil differential is a multiple of `ω` (Proposition 1.5.9,
 `TauCeti.exists_repartitionDualMul_eq`).  So `ℓ(W - D) = dim_k Ω_F(D) = i(D)`, which rearranges to
 the Riemann–Roch identity.
 
@@ -68,6 +67,7 @@ the Riemann–Roch identity.
   for the genus (Stichtenoth, Theorem 1.5.15).
 * `TauCeti.dim_weilDifferentialDivisor` and `TauCeti.degree_weilDifferentialDivisor`:
   `ℓ((ω)) = g` and `deg (ω) = 2g - 2` (Stichtenoth, Corollary 1.5.16).
+* `TauCeti.degreeClass_canonicalClass`: the canonical class has degree `2g - 2`.
 * `TauCeti.exists_isRiemannRochDivisor`: **the Riemann–Roch theorem** — a Riemann–Roch divisor
   exists.
 * `TauCeti.divisorClass_eq_canonicalClass_iff`: **the characterization of canonical divisors**
@@ -79,6 +79,9 @@ the Riemann–Roch identity.
 * H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
   Section I.5, in particular Proposition 1.5.11, Theorem 1.5.14 and Theorem 1.5.15, and
   Proposition 1.6.2.
+* Tau Ceti pull request
+  [#5207](https://github.com/TauCetiProject/TauCeti/pull/5207), the predecessor formalization of
+  these results, which the present development adapts.
 -/
 
 public section
@@ -89,12 +92,12 @@ variable {k F : Type*} [Field k] [Field F] [Algebra k F]
 
 /-! ### The divisor of a nonzero Weil differential -/
 
-/-- The divisors bounding a fixed nonzero Weil differential have bounded degree: past the
-threshold of `TauCeti.exists_forall_indexOfSpecialty_eq_zero` the divisor is nonspecial, and a
-nonspecial divisor bounds no nonzero Weil differential. -/
+/-- The divisors bounding a fixed nonzero Weil differential have bounded degree. -/
 theorem exists_forall_degree_lt_of_mem_weilDifferentialFiltration (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) :
     ∃ c : ℤ, ∀ D : Divisor k F, ω ∈ weilDifferentialFiltration D → Divisor.degree D < c := by
+  -- Past the threshold of `exists_forall_indexOfSpecialty_eq_zero` a divisor is nonspecial, and
+  -- a nonspecial divisor bounds no nonzero Weil differential.
   obtain ⟨c, hc⟩ := exists_forall_indexOfSpecialty_eq_zero hF hex
   refine ⟨c, fun D hD ↦ ?_⟩
   by_contra hcon
@@ -104,15 +107,15 @@ theorem exists_forall_degree_lt_of_mem_weilDifferentialFiltration (hF : IsFuncti
   exact hω (by simpa [hbot] using hD)
 
 /-- **The divisor of a nonzero Weil differential** (Stichtenoth, Proposition 1.5.11): the
-divisors bounding `ω` have a greatest element.
-
-Degrees are bounded above, so a divisor `W` of maximal degree among them exists; for any other
-`D` bounding `ω`, the supremum `D ⊔ W` also bounds `ω` and has degree at least that of `W` by
-monotonicity and at most by maximality, hence equals `W` because places have positive degree. -/
+divisors bounding `ω` have a greatest element. -/
 theorem exists_isGreatest_mem_weilDifferentialFiltration (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
     (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
     ∃ W : Divisor k F, IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W := by
+  -- Degrees are bounded above, so a divisor `W` of maximal degree among them exists; for any
+  -- other `D` bounding `ω`, the supremum `D ⊔ W` also bounds `ω` and has degree at least that of
+  -- `W` by monotonicity and at most by maximality, hence equals `W` because places have positive
+  -- degree.
   classical
   obtain ⟨c, hc⟩ := exists_forall_degree_lt_of_mem_weilDifferentialFiltration hF hex hω
   obtain ⟨D₀, hD₀⟩ := mem_weilDifferentialSpace_iff.mp hmem
@@ -130,8 +133,7 @@ theorem exists_isGreatest_mem_weilDifferentialFiltration (hF : IsFunctionField k
   exact hWeq ▸ le_sup_left
 
 /-- The characteristic property of the divisor of `ω`, in the form consumers use: `ω` is bounded
-by `D` exactly when `D` is at most the divisor of `ω`.  The forward direction is maximality; the
-reverse is antitonicity of the filtration. -/
+by `D` exactly when `D` is at most the divisor of `ω`. -/
 theorem mem_weilDifferentialFiltration_iff_le_of_isGreatest
     {ω : Module.Dual k ↥(repartitionSpace k F)} {W : Divisor k F}
     (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
@@ -185,12 +187,7 @@ theorem coeff_weilDifferentialDivisor (hF : IsFunctionField k F)
 /-- **The transformation law `(z · ω) = div z + (ω)`** (Stichtenoth, Proposition 1.5.13): the
 divisor of a Weil differential changes by a principal divisor when the differential is multiplied
 by a nonzero function, so the class of `(ω)` in the divisor class group — the canonical class —
-does not depend on `ω`.
-
-Multiplication translates the filtration by `div z`
-(`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`), so it carries the divisors
-bounding `ω` bijectively onto those bounding `z · ω`, hence greatest element to greatest
-element. -/
+does not depend on `ω`. -/
 @[simp]
 theorem weilDifferentialDivisor_repartitionDualMul (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
@@ -198,6 +195,10 @@ theorem weilDifferentialDivisor_repartitionDualMul (hF : IsFunctionField k F)
     weilDifferentialDivisor hF hex (repartitionDualMul_mem_weilDifferentialSpace hF (z : F) hmem)
         (repartitionDualMul_ne_zero hF (Units.ne_zero z) hω) =
       Divisor.principal hF z + weilDifferentialDivisor hF hex hmem hω := by
+  -- Multiplication translates the filtration by `div z`
+  -- (`repartitionDualMul_mem_weilDifferentialFiltration_iff`), so it carries the divisors
+  -- bounding `ω` bijectively onto those bounding `z · ω`, hence greatest element to greatest
+  -- element.
   have hW := isGreatest_weilDifferentialDivisor hF hex hmem hω
   refine (isGreatest_weilDifferentialDivisor hF hex
     (repartitionDualMul_mem_weilDifferentialSpace hF (z : F) hmem)
@@ -213,15 +214,15 @@ theorem weilDifferentialDivisor_repartitionDualMul (hF : IsFunctionField k F)
     rw [add_comm]
     exact sub_le_iff_le_add.mp (hW.2 h)
 
-/-- The divisors of any two nonzero Weil differentials have the same divisor class.  Indeed,
-one differential is a nonzero function multiple of the other, and the transformation law says
-that their divisors differ by the corresponding principal divisor. -/
+/-- The divisors of any two nonzero Weil differentials have the same divisor class. -/
 theorem divisorClass_weilDifferentialDivisor_eq (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω η : Module.Dual k ↥(repartitionSpace k F)}
     (hωmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0)
     (hηmem : η ∈ weilDifferentialSpace k F) (hη : η ≠ 0) :
     (Place.orderSystem hF).divisorClass (weilDifferentialDivisor hF hex hωmem hω) =
       (Place.orderSystem hF).divisorClass (weilDifferentialDivisor hF hex hηmem hη) := by
+  -- One differential is a nonzero function multiple of the other, and the transformation law
+  -- says that their divisors differ by the corresponding principal divisor.
   obtain ⟨c, hc⟩ := exists_repartitionDualMul_eq hF hex hωmem hω hηmem
   subst hc
   have hc0 : c ≠ 0 := by
@@ -256,16 +257,15 @@ theorem divisorClass_weilDifferentialDivisor (hF : IsFunctionField k F)
 /-! ### The Riemann–Roch theorem -/
 
 /-- **Duality between `L(W - D)` and `Ω_F(D)`**, for `W` the divisor of `ω`: a function `x`
-multiplies `ω` into `Ω_F(D)` exactly when it lies in `L(W - D)`.
-
-For nonzero `x`, multiplication translates the filtration by the principal divisor of `x`
-(`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`), so `x · ω ∈ Ω_F(D)` says
-`ω ∈ Ω_F(D - div x)`, which by maximality of `W` says `D - div x ≤ W`. -/
+multiplies `ω` into `Ω_F(D)` exactly when it lies in `L(W - D)`. -/
 theorem repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace
     (hF : IsFunctionField k F) {ω : Module.Dual k ↥(repartitionSpace k F)} {W : Divisor k F}
     (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W)
     (D : Divisor k F) (x : F) :
     repartitionDualMul hF x ω ∈ weilDifferentialFiltration D ↔ x ∈ riemannRochSpace (W - D) := by
+  -- For nonzero `x`, multiplication translates the filtration by the principal divisor of `x`
+  -- (`repartitionDualMul_mem_weilDifferentialFiltration_iff`), so `x · ω ∈ Ω_F(D)` says
+  -- `ω ∈ Ω_F(D - div x)`, which by maximality of `W` says `D - div x ≤ W`.
   rcases eq_or_ne x 0 with rfl | hx
   · simp
   obtain ⟨z, rfl⟩ : ∃ z : Fˣ, (z : F) = x := ⟨Units.mk0 x hx, rfl⟩
@@ -283,16 +283,18 @@ theorem repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpa
       (weilDifferentialFiltration_antitone h hW.1)
     rwa [hrw] at hmem
 
-/-- **The image of `L(W - D)` under multiplication by `ω` is `Ω_F(D)`.**  One inclusion is
-`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace`; the other
-is Proposition 1.5.9, every Weil differential being a multiple of `ω`
-(`TauCeti.exists_repartitionDualMul_eq`). -/
+/-- **The image of `L(W - D)` under multiplication by `ω` is `Ω_F(D)`**, for `W` the divisor of
+a nonzero Weil differential `ω`. -/
 theorem map_riemannRochSpace_repartitionDualMulRight (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0)
     {W : Divisor k F}
     (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
     Submodule.map (repartitionDualMulRight hF ω) (riemannRochSpace (W - D)) =
       weilDifferentialFiltration D := by
+  -- One inclusion is
+  -- `repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace`; the other is
+  -- Proposition 1.5.9, every Weil differential being a multiple of `ω`
+  -- (`exists_repartitionDualMul_eq`).
   have key (x : F) : repartitionDualMulRight hF ω x ∈ weilDifferentialFiltration D ↔
       x ∈ riemannRochSpace (W - D) := by
     simpa using repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace hF hW D x
@@ -305,9 +307,7 @@ theorem map_riemannRochSpace_repartitionDualMulRight (hF : IsFunctionField k F)
     exact ⟨c, (key c).mp (by simpa [hc] using hη), by simpa using hc⟩
 
 /-- **The duality theorem** (Stichtenoth, Theorem 1.5.14): for `W` the divisor of a nonzero Weil
-differential `ω`, multiplication by `ω` is a `k`-linear isomorphism `L(W - D) ≃ Ω_F(D)`.  It is
-injective by `TauCeti.repartitionDualMulRight_injective` and onto by
-`TauCeti.map_riemannRochSpace_repartitionDualMulRight`. -/
+differential `ω`, multiplication by `ω` is a `k`-linear isomorphism `L(W - D) ≃ Ω_F(D)`. -/
 noncomputable def riemannRochSpaceEquivWeilDifferentialFiltration (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0)
     {W : Divisor k F}
@@ -340,16 +340,15 @@ theorem dim_sub_eq_finrank_weilDifferentialFiltration (hF : IsFunctionField k F)
   exact (riemannRochSpaceEquivWeilDifferentialFiltration hF hex hω hW D).finrank_eq
 
 /-- **The Riemann–Roch theorem** (Stichtenoth, Theorem 1.5.15): the divisor of a nonzero Weil
-differential is a Riemann–Roch divisor for the genus.
-
-Duality gives `ℓ(W - D) = dim_k Ω_F(D)`, which is `i(D)` by
-`TauCeti.finrank_weilDifferentialFiltration` (Lemma 1.5.7); unfolding the index of specialty
-rearranges that to the Riemann–Roch identity. -/
+differential is a Riemann–Roch divisor for the genus. -/
 theorem isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration
     (hF : IsFunctionField k F) (hex : IsIntegrallyClosedIn k F)
     {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) {W : Divisor k F}
     (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) :
     W.IsRiemannRochDivisor (genus k F) := by
+  -- Duality gives `ℓ(W - D) = dim_k Ω_F(D)`, which is `i(D)` by
+  -- `finrank_weilDifferentialFiltration` (Lemma 1.5.7); unfolding the index of specialty
+  -- rearranges that to the Riemann–Roch identity.
   rw [Divisor.isRiemannRochDivisor_iff]
   intro D
   have hi := finrank_weilDifferentialFiltration hF hex D
@@ -382,6 +381,14 @@ theorem degree_weilDifferentialDivisor (hF : IsFunctionField k F)
     Divisor.degree (weilDifferentialDivisor hF hex hmem hω) = 2 * genus k F - 2 :=
   (isRiemannRochDivisor_weilDifferentialDivisor hF hex hmem hω).degree_eq hF hex
 
+/-- **The canonical class has degree `2g - 2`** (Stichtenoth, Corollary 1.5.16). -/
+@[simp]
+theorem degreeClass_canonicalClass (hF : IsFunctionField k F) (hex : IsIntegrallyClosedIn k F) :
+    Divisor.degreeClass hF (canonicalClass hF hex) = 2 * genus k F - 2 := by
+  obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
+  rw [← divisorClass_weilDifferentialDivisor hF hex hωmem hω0, Divisor.degreeClass_divisorClass,
+    degree_weilDifferentialDivisor]
+
 /-- **The Riemann–Roch theorem, existence form** (Stichtenoth, Theorem 1.5.15): every algebraic
 function field with exact constant field has a Riemann–Roch divisor, namely the divisor of any
 nonzero Weil differential, whose dimension and degree are recorded by
@@ -395,14 +402,13 @@ theorem exists_isRiemannRochDivisor (hF : IsFunctionField k F)
 
 /-! ### The characterization of canonical divisors -/
 
-/-- A divisor representing the canonical class is a Riemann–Roch divisor for the genus: it is
-linearly equivalent to the divisor of a nonzero Weil differential, and being a Riemann–Roch
-divisor depends only on the divisor class
-(`TauCeti.Divisor.IsRiemannRochDivisor.of_linearlyEquivalent`). -/
+/-- A divisor representing the canonical class is a Riemann–Roch divisor for the genus. -/
 theorem isRiemannRochDivisor_of_divisorClass_eq_canonicalClass (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {D : Divisor k F}
     (hD : (Place.orderSystem hF).divisorClass D = canonicalClass hF hex) :
     D.IsRiemannRochDivisor (genus k F) := by
+  -- Such a `D` is linearly equivalent to the divisor of a nonzero Weil differential, and being a
+  -- Riemann–Roch divisor depends only on the divisor class.
   obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
   refine (isRiemannRochDivisor_weilDifferentialDivisor hF hex hωmem hω0).of_linearlyEquivalent hF
     ((Place.orderSystem hF).divisorClass_eq_iff.mp ?_)
@@ -410,18 +416,16 @@ theorem isRiemannRochDivisor_of_divisorClass_eq_canonicalClass (hF : IsFunctionF
 
 /-- **The characterization of canonical divisors** (Stichtenoth, Proposition 1.6.2): a divisor
 represents the canonical class exactly when it has degree `2g - 2` and its Riemann–Roch space
-has dimension at least the genus.
-
-For the substantial direction, take `W` to be the divisor of a nonzero Weil differential.  Once
-`deg D = 2g - 2`, the Riemann–Roch identity at `D` reads `ℓ(D) = g - 1 + ℓ(W - D)`, so `ℓ(D) ≥ g`
-forces `ℓ(W - D) ≥ 1`; as `W - D` has degree zero it is then principal
-(`TauCeti.Divisor.one_le_dim_iff_exists_principal_eq_of_degree_eq_zero`), that is, `D` has the
-class of `W`.  Conversely such a `D` is itself a Riemann–Roch divisor, whose degree and dimension
-are `2g - 2` and `g` by Corollary 1.5.16. -/
+has dimension at least the genus. -/
 theorem divisorClass_eq_canonicalClass_iff (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) (D : Divisor k F) :
     (Place.orderSystem hF).divisorClass D = canonicalClass hF hex ↔
       Divisor.degree D = 2 * genus k F - 2 ∧ genus k F ≤ Divisor.dim D := by
+  -- For the substantial direction, take `W` to be the divisor of a nonzero Weil differential.
+  -- Once `deg D = 2g - 2`, the Riemann–Roch identity at `D` reads `ℓ(D) = g - 1 + ℓ(W - D)`, so
+  -- `ℓ(D) ≥ g` forces `ℓ(W - D) ≥ 1`; as `W - D` has degree zero it is then principal, that is,
+  -- `D` has the class of `W`.  Conversely such a `D` is itself a Riemann–Roch divisor, whose
+  -- degree and dimension are `2g - 2` and `g` by Corollary 1.5.16.
   obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
   refine ⟨fun hD ↦ ?_, fun ⟨hdeg, hdim⟩ ↦ ?_⟩
   · have hRR := isRiemannRochDivisor_of_divisorClass_eq_canonicalClass hF hex hD

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -189,13 +189,14 @@ bounding `ω` bijectively onto those bounding `z · ω`, hence greatest element 
 element. -/
 theorem weilDifferentialDivisor_repartitionDualMul (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
-    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (z : Fˣ)
-    (hzmem : repartitionDualMul hF (z : F) ω ∈ weilDifferentialSpace k F)
-    (hz : repartitionDualMul hF (z : F) ω ≠ 0) :
-    weilDifferentialDivisor hF hex hzmem hz =
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (z : Fˣ) :
+    weilDifferentialDivisor hF hex (repartitionDualMul_mem_weilDifferentialSpace hF (z : F) hmem)
+        (repartitionDualMul_ne_zero hF (Units.ne_zero z) hω) =
       Divisor.principal hF z + weilDifferentialDivisor hF hex hmem hω := by
   have hW := isGreatest_weilDifferentialDivisor hF hex hmem hω
-  refine (isGreatest_weilDifferentialDivisor hF hex hzmem hz).unique ⟨?_, fun D hD ↦ ?_⟩
+  refine (isGreatest_weilDifferentialDivisor hF hex
+    (repartitionDualMul_mem_weilDifferentialSpace hF (z : F) hmem)
+    (repartitionDualMul_ne_zero hF (Units.ne_zero z) hω)).unique ⟨?_, fun D hD ↦ ?_⟩
   · have h := (repartitionDualMul_mem_weilDifferentialFiltration_iff hF z
       (D := weilDifferentialDivisor hF hex hmem hω) (ω := ω)).mpr hW.1
     rwa [add_comm] at h
@@ -222,7 +223,7 @@ theorem divisorClass_weilDifferentialDivisor_eq (hF : IsFunctionField k F)
     rintro rfl
     exact hη (by simp)
   obtain ⟨z, rfl⟩ : ∃ z : Fˣ, (z : F) = c := ⟨Units.mk0 c hc0, rfl⟩
-  rw [weilDifferentialDivisor_repartitionDualMul hF hex hωmem hω z hηmem hη, map_add,
+  rw [weilDifferentialDivisor_repartitionDualMul hF hex hωmem hω z, map_add,
     (Divisor.divisorClass_eq_zero_iff hF).mpr ⟨z, rfl⟩, zero_add]
 
 /-- **The canonical class** of an algebraic function field with exact constant field: the divisor

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -185,8 +185,9 @@ theorem coeff_weilDifferentialDivisor (hF : IsFunctionField k F)
   (rfl)
 
 /-- A nonzero Weil differential is regular (or holomorphic), meaning that it is bounded by the
-zero divisor, exactly when its order is nonnegative at every place. -/
-@[simp]
+zero divisor, exactly when its order is nonnegative at every place.  This is deliberately not
+`@[simp]`: `TauCeti.mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor` already sends
+the left-hand side to the divisor inequality `0 ≤ (ω)`, which is the simp-normal form. -/
 theorem mem_weilDifferentialFiltration_zero_iff_forall_order_nonneg
     (hF : IsFunctionField k F) (hex : IsIntegrallyClosedIn k F)
     {ω : Module.Dual k ↥(repartitionSpace k F)} (hmem : ω ∈ weilDifferentialSpace k F)

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -38,6 +38,8 @@ the Riemann–Roch identity.
   (Stichtenoth, Definition 1.5.11), the greatest divisor bounding it.
 * `TauCeti.canonicalClass`: **the canonical class** in the divisor class group, represented by
   the divisor of any nonzero Weil differential.
+* `TauCeti.weilDifferentialOrder`: **the order `v_P(ω)`** of a nonzero Weil differential at a
+  place, the coefficient of `P` in `(ω)`.
 * `TauCeti.riemannRochSpaceEquivWeilDifferentialFiltration`: **the duality isomorphism**
   `L(W - D) ≃ Ω_F(D)`, `x ↦ x · ω` (Stichtenoth, Theorem 1.5.14).
 
@@ -61,8 +63,11 @@ the Riemann–Roch identity.
 * `TauCeti.map_riemannRochSpace_repartitionDualMulRight` and
   `TauCeti.dim_sub_eq_finrank_weilDifferentialFiltration`: **the duality theorem** — `x ↦ x · ω`
   maps `L(W - D)` onto `Ω_F(D)`, so `ℓ(W - D) = dim_k Ω_F(D)` (Stichtenoth, Theorem 1.5.14).
-* `TauCeti.isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration`: that divisor is a
-  Riemann–Roch divisor for the genus (Stichtenoth, Theorem 1.5.15).
+* `TauCeti.isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration` and
+  `TauCeti.isRiemannRochDivisor_weilDifferentialDivisor`: that divisor is a Riemann–Roch divisor
+  for the genus (Stichtenoth, Theorem 1.5.15).
+* `TauCeti.dim_weilDifferentialDivisor` and `TauCeti.degree_weilDifferentialDivisor`:
+  `ℓ((ω)) = g` and `deg (ω) = 2g - 2` (Stichtenoth, Corollary 1.5.16).
 * `TauCeti.exists_isRiemannRochDivisor`: **the Riemann–Roch theorem** — a Riemann–Roch divisor
   exists.
 
@@ -156,6 +161,22 @@ theorem mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor (hF : IsFu
     ω ∈ weilDifferentialFiltration D ↔ D ≤ weilDifferentialDivisor hF hex hmem hω :=
   mem_weilDifferentialFiltration_iff_le_of_isGreatest
     (isGreatest_weilDifferentialDivisor hF hex hmem hω) D
+
+/-- **The order `v_P(ω)` of a nonzero Weil differential at a place** (Stichtenoth,
+Definition 1.5.11): the coefficient of `P` in the divisor `(ω)`.  A differential is regular, or
+holomorphic, exactly when all of its orders are nonnegative, that is when `0 ≤ (ω)`. -/
+noncomputable def weilDifferentialOrder (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (P : Place k F) : ℤ :=
+  (weilDifferentialDivisor hF hex hmem hω).coeff P
+
+/-- The divisor of a nonzero Weil differential has the orders `v_P(ω)` as its coefficients. -/
+@[simp]
+theorem coeff_weilDifferentialDivisor (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (P : Place k F) :
+    (weilDifferentialDivisor hF hex hmem hω).coeff P = weilDifferentialOrder hF hex hmem hω P :=
+  (rfl)
 
 /-- **The transformation law `(z · ω) = div z + (ω)`** (Stichtenoth, Proposition 1.5.13): the
 divisor of a Weil differential changes by a principal divisor when the differential is multiplied
@@ -329,19 +350,40 @@ theorem isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration
     Divisor.indexOfSpecialty_def] at hi
   omega
 
-/-- **The Riemann–Roch theorem, existence form** (Stichtenoth, Theorem 1.5.15 with
-Corollary 1.5.16): every algebraic function field with exact constant field has a Riemann–Roch
-divisor, namely the divisor of any nonzero Weil differential.  With
-`TauCeti.Divisor.IsRiemannRochDivisor.dim_eq` and
-`TauCeti.Divisor.IsRiemannRochDivisor.degree_eq` this gives `ℓ(W) = g` and `deg W = 2g - 2`, and
-with `TauCeti.Divisor.IsRiemannRochDivisor.linearlyEquivalent` the class of `W` — the canonical
-class — is well defined. -/
+/-- **The Riemann–Roch theorem** (Stichtenoth, Theorem 1.5.15), for the divisor `(ω)` itself:
+the divisor of a nonzero Weil differential is a Riemann–Roch divisor for the genus. -/
+theorem isRiemannRochDivisor_weilDifferentialDivisor (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
+    (weilDifferentialDivisor hF hex hmem hω).IsRiemannRochDivisor (genus k F) :=
+  isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration hF hex hω
+    (isGreatest_weilDifferentialDivisor hF hex hmem hω)
+
+/-- **`ℓ((ω)) = g`** (Stichtenoth, Corollary 1.5.16): the divisor of a nonzero Weil differential
+has Riemann–Roch space of dimension the genus. -/
+theorem dim_weilDifferentialDivisor (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
+    Divisor.dim (weilDifferentialDivisor hF hex hmem hω) = genus k F :=
+  (isRiemannRochDivisor_weilDifferentialDivisor hF hex hmem hω).dim_eq hF hex
+
+/-- **`deg (ω) = 2g - 2`** (Stichtenoth, Corollary 1.5.16): the divisor of a nonzero Weil
+differential has degree `2g - 2`, so the canonical class has that degree. -/
+theorem degree_weilDifferentialDivisor (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
+    Divisor.degree (weilDifferentialDivisor hF hex hmem hω) = 2 * genus k F - 2 :=
+  (isRiemannRochDivisor_weilDifferentialDivisor hF hex hmem hω).degree_eq hF hex
+
+/-- **The Riemann–Roch theorem, existence form** (Stichtenoth, Theorem 1.5.15): every algebraic
+function field with exact constant field has a Riemann–Roch divisor, namely the divisor of any
+nonzero Weil differential, whose dimension and degree are recorded by
+`TauCeti.dim_weilDifferentialDivisor` and `TauCeti.degree_weilDifferentialDivisor`. -/
 theorem exists_isRiemannRochDivisor (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) :
     ∃ W : Divisor k F, W.IsRiemannRochDivisor (genus k F) := by
   obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
   exact ⟨weilDifferentialDivisor hF hex hωmem hω0,
-    isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration hF hex hω0
-      (isGreatest_weilDifferentialDivisor hF hex hωmem hω0)⟩
+    isRiemannRochDivisor_weilDifferentialDivisor hF hex hωmem hω0⟩
 
 end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -36,6 +36,8 @@ the Riemann–Roch identity.
 
 * `TauCeti.weilDifferentialDivisor`: **the divisor `(ω)` of a Weil differential** (Stichtenoth,
   Definition 1.5.11), the greatest divisor bounding it.
+* `TauCeti.canonicalClass`: **the canonical class** in the divisor class group, represented by
+  the divisor of any nonzero Weil differential.
 * `TauCeti.riemannRochSpaceEquivWeilDifferentialFiltration`: **the duality isomorphism**
   `L(W - D) ≃ Ω_F(D)`, `x ↦ x · ω` (Stichtenoth, Theorem 1.5.14).
 
@@ -54,6 +56,8 @@ the Riemann–Roch identity.
 * `TauCeti.weilDifferentialDivisor_repartitionDualMul`: **the transformation law**
   `(z · ω) = div z + (ω)` (Stichtenoth, Proposition 1.5.13), which is what makes the class of
   `(ω)` — the canonical class — independent of `ω`.
+* `TauCeti.divisorClass_weilDifferentialDivisor`: the divisor of every nonzero Weil differential
+  represents `TauCeti.canonicalClass`.
 * `TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace`: the
   membership `x · ω ∈ Ω_F(D) ↔ x ∈ L(W - D)` that carries the theorem.
 * `TauCeti.map_riemannRochSpace_repartitionDualMulRight` and
@@ -85,15 +89,38 @@ theorem mem_weilDifferentialFiltration_sup {D E : Divisor k F}
     {ω : Module.Dual k ↥(repartitionSpace k F)} (hD : ω ∈ weilDifferentialFiltration D)
     (hE : ω ∈ weilDifferentialFiltration E) :
     ω ∈ weilDifferentialFiltration (D ⊔ E) := by
-  refine mem_weilDifferentialFiltration_of_apply_eq_zero (fun a ha ↦ ?_) (fun a ha ↦
-    weilDifferentialFiltration_apply_eq_zero_of_mem_diagonalRepartitions hD a ha)
-  obtain ⟨x, hx, y, hy, hxy⟩ := Submodule.mem_sup.mp ((adeleFiltration_sup D E).le ha)
-  have hxA : x ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace D hx
-  have hyA : y ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace E hy
-  have hsplit : a = ⟨x, hxA⟩ + ⟨y, hyA⟩ := Subtype.ext hxy.symm
-  rw [hsplit, map_add]
-  simp [weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hD ⟨x, hxA⟩ hx,
-    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hE ⟨y, hyA⟩ hy]
+  have hsub : submoduleOfAdeleFiltrationSupDiagonalRepartitions (D ⊔ E) =
+      submoduleOfAdeleFiltrationSupDiagonalRepartitions D ⊔
+        submoduleOfAdeleFiltrationSupDiagonalRepartitions E := by
+    have htrace (X : Submodule k (Place k F → F))
+        (hX : X ≤ repartitionSpace k F) :
+        (X ⊔ diagonalRepartitions k F).submoduleOf (repartitionSpace k F) =
+          X.submoduleOf (repartitionSpace k F) ⊔
+            (diagonalRepartitions k F).submoduleOf (repartitionSpace k F) := by
+      apply Submodule.map_injective_of_injective (repartitionSpace k F).subtype_injective
+      simp only [Submodule.submoduleOf, Submodule.map_comap_eq, Submodule.map_sup,
+        Submodule.range_subtype]
+      rw [inf_comm (repartitionSpace k F) (X ⊔ diagonalRepartitions k F),
+        inf_comm (repartitionSpace k F) X,
+        inf_comm (repartitionSpace k F) (diagonalRepartitions k F),
+        sup_inf_assoc_of_le _ hX, inf_eq_left.mpr hX]
+    rw [submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf (D ⊔ E),
+      submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf D,
+      submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf E,
+      adeleFiltration_sup,
+      htrace (adeleFiltration D ⊔ adeleFiltration E)
+        (sup_le (adeleFiltration_le_repartitionSpace D)
+          (adeleFiltration_le_repartitionSpace E)),
+      Submodule.submoduleOf_sup_of_le (adeleFiltration_le_repartitionSpace D)
+        (adeleFiltration_le_repartitionSpace E),
+      htrace (adeleFiltration D) (adeleFiltration_le_repartitionSpace D),
+      htrace (adeleFiltration E) (adeleFiltration_le_repartitionSpace E)]
+    ac_rfl
+  rw [weilDifferentialFiltration_eq_dualAnnihilator D] at hD
+  rw [weilDifferentialFiltration_eq_dualAnnihilator E] at hE
+  rw [weilDifferentialFiltration_eq_dualAnnihilator (D ⊔ E), hsub,
+    Submodule.dualAnnihilator_sup_eq]
+  exact ⟨hD, hE⟩
 
 /-! ### The divisor of a nonzero Weil differential -/
 
@@ -206,6 +233,54 @@ theorem weilDifferentialDivisor_repartitionDualMul (hF : IsFunctionField k F)
     rw [hcancel, Divisor.principal_inv, ← sub_eq_add_neg] at h
     rw [add_comm]
     exact sub_le_iff_le_add.mp (hW.2 h)
+
+/-- The divisors of any two nonzero Weil differentials have the same divisor class.  Indeed,
+one differential is a nonzero function multiple of the other, and the transformation law says
+that their divisors differ by the corresponding principal divisor. -/
+theorem divisorClass_weilDifferentialDivisor_eq (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω η : Module.Dual k ↥(repartitionSpace k F)}
+    (hωmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0)
+    (hηmem : η ∈ weilDifferentialSpace k F) (hη : η ≠ 0) :
+    (Place.orderSystem hF).divisorClass (weilDifferentialDivisor ω) =
+      (Place.orderSystem hF).divisorClass (weilDifferentialDivisor η) := by
+  obtain ⟨c, hc⟩ := exists_repartitionDualMul_eq hF hex hωmem hω hηmem
+  have hc0 : c ≠ 0 := fun hc0 ↦ hη (by
+    rw [← hc, hc0, map_zero]
+    rfl)
+  let z : Fˣ := Units.mk0 c hc0
+  symm
+  calc
+    (Place.orderSystem hF).divisorClass (weilDifferentialDivisor η) =
+        (Place.orderSystem hF).divisorClass
+          (weilDifferentialDivisor (repartitionDualMul hF (z : F) ω)) := by
+            rw [show (z : F) = c by rfl, hc]
+    _ = (Place.orderSystem hF).divisorClass
+          (Divisor.principal hF z + weilDifferentialDivisor ω) := by
+            rw [weilDifferentialDivisor_repartitionDualMul hF hex hωmem hω]
+    _ = (Place.orderSystem hF).divisorClass (weilDifferentialDivisor ω) := by
+            rw [map_add, (Divisor.divisorClass_eq_zero_iff hF).mpr ⟨z, rfl⟩, zero_add]
+
+open Classical in
+/-- **The canonical class** of an algebraic function field with exact constant field: the divisor
+class of a nonzero Weil differential.  Such a differential exists by
+`TauCeti.weilDifferentialSpace_ne_bot`, and
+`TauCeti.divisorClass_weilDifferentialDivisor` shows that the class is independent of the chosen
+differential. -/
+noncomputable def canonicalClass (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) : (Place.orderSystem hF).ClassGroup :=
+  (Place.orderSystem hF).divisorClass
+    (weilDifferentialDivisor
+      (((Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)).choose))
+
+/-- Every nonzero Weil differential represents the canonical class. -/
+theorem divisorClass_weilDifferentialDivisor (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
+    (Place.orderSystem hF).divisorClass (weilDifferentialDivisor ω) = canonicalClass hF hex := by
+  unfold canonicalClass
+  apply divisorClass_weilDifferentialDivisor_eq hF hex hmem hω
+  · exact ((Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)).choose_spec.1
+  · exact ((Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)).choose_spec.2
 
 /-! ### The Riemann–Roch theorem -/
 

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -34,6 +34,8 @@ the Riemann–Roch identity.
 
 ## Main definitions
 
+* `TauCeti.weilDifferentialDivisor`: **the divisor `(ω)` of a Weil differential** (Stichtenoth,
+  Definition 1.5.11), the greatest divisor bounding it.
 * `TauCeti.riemannRochSpaceEquivWeilDifferentialFiltration`: **the duality isomorphism**
   `L(W - D) ≃ Ω_F(D)`, `x ↦ x · ω` (Stichtenoth, Theorem 1.5.14).
 
@@ -46,8 +48,12 @@ the Riemann–Roch identity.
 * `TauCeti.exists_isGreatest_mem_weilDifferentialFiltration`: **the divisor of a nonzero Weil
   differential** — among the divisors bounding it there is a greatest (Stichtenoth,
   Proposition 1.5.11).
-* `TauCeti.mem_weilDifferentialFiltration_iff_le_of_isGreatest`: `ω ∈ Ω_F(D) ↔ D ≤ (ω)`, the
-  characteristic property of that divisor.
+* `TauCeti.mem_weilDifferentialFiltration_iff_le_of_isGreatest` and
+  `TauCeti.mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor`: `ω ∈ Ω_F(D) ↔ D ≤ (ω)`,
+  the characteristic property of that divisor.
+* `TauCeti.weilDifferentialDivisor_repartitionDualMul`: **the transformation law**
+  `(z · ω) = div z + (ω)` (Stichtenoth, Proposition 1.5.13), which is what makes the class of
+  `(ω)` — the canonical class — independent of `ω`.
 * `TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff_mem_riemannRochSpace`: the
   membership `x · ω ∈ Ω_F(D) ↔ x ∈ L(W - D)` that carries the theorem.
 * `TauCeti.map_riemannRochSpace_repartitionDualMulRight` and
@@ -62,7 +68,6 @@ the Riemann–Roch identity.
 
 * H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
   Section I.5, in particular Proposition 1.5.11, Theorem 1.5.14 and Theorem 1.5.15.
-* [The algebraic curves roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/AlgebraicCurves/README.md).
 -/
 
 public section
@@ -140,6 +145,67 @@ theorem mem_weilDifferentialFiltration_iff_le_of_isGreatest
     (hW : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) (D : Divisor k F) :
     ω ∈ weilDifferentialFiltration D ↔ D ≤ W :=
   ⟨fun h ↦ hW.2 h, fun h ↦ weilDifferentialFiltration_antitone h hW.1⟩
+
+open Classical in
+/-- **The divisor `(ω)` of a Weil differential** (Stichtenoth, Definition 1.5.11): the greatest
+divisor bounding `ω` when there is one, and `0` otherwise.  For a nonzero Weil differential over
+an exact constant field the greatest divisor does exist, by
+`TauCeti.exists_isGreatest_mem_weilDifferentialFiltration`, and
+`TauCeti.isGreatest_weilDifferentialDivisor` identifies it with this one; the junk value in the
+remaining cases is what lets the divisor be a function of `ω` alone. -/
+noncomputable def weilDifferentialDivisor (ω : Module.Dual k ↥(repartitionSpace k F)) :
+    Divisor k F :=
+  if h : ∃ W : Divisor k F, IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W then
+    h.choose else 0
+
+/-- The divisor of a nonzero Weil differential is indeed the greatest divisor bounding it. -/
+theorem isGreatest_weilDifferentialDivisor (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
+    IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D}
+      (weilDifferentialDivisor ω) := by
+  have h := exists_isGreatest_mem_weilDifferentialFiltration hF hex hmem hω
+  rw [weilDifferentialDivisor, dite_eq_left h]
+  exact h.choose_spec
+
+/-- **The characteristic property of `(ω)`**: a nonzero Weil differential is bounded by `D`
+exactly when `D ≤ (ω)`. -/
+theorem mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (D : Divisor k F) :
+    ω ∈ weilDifferentialFiltration D ↔ D ≤ weilDifferentialDivisor ω :=
+  mem_weilDifferentialFiltration_iff_le_of_isGreatest
+    (isGreatest_weilDifferentialDivisor hF hex hmem hω) D
+
+/-- **The transformation law `(z · ω) = div z + (ω)`** (Stichtenoth, Proposition 1.5.13): the
+divisor of a Weil differential changes by a principal divisor when the differential is multiplied
+by a nonzero function, so the class of `(ω)` in the divisor class group — the canonical class —
+does not depend on `ω`.
+
+Multiplication translates the filtration by `div z`
+(`TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`), so it carries the divisors
+bounding `ω` bijectively onto those bounding `z · ω`, hence greatest element to greatest
+element. -/
+theorem weilDifferentialDivisor_repartitionDualMul (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (z : Fˣ) :
+    weilDifferentialDivisor (repartitionDualMul hF (z : F) ω) =
+      Divisor.principal hF z + weilDifferentialDivisor ω := by
+  have hW := isGreatest_weilDifferentialDivisor hF hex hmem hω
+  have hz0 : repartitionDualMul hF (z : F) ω ≠ 0 := fun h ↦ hω (by
+    rw [← repartitionDualMul_inv_repartitionDualMul hF (Units.ne_zero z) ω, h, map_zero])
+  refine (isGreatest_weilDifferentialDivisor hF hex
+    (repartitionDualMul_mem_weilDifferentialSpace hF _ hmem) hz0).unique ⟨?_, fun D hD ↦ ?_⟩
+  · have h := (repartitionDualMul_mem_weilDifferentialFiltration_iff hF z
+      (D := weilDifferentialDivisor ω) (ω := ω)).mpr hW.1
+    rwa [add_comm] at h
+  · have h := (repartitionDualMul_mem_weilDifferentialFiltration_iff hF z⁻¹
+      (D := D) (ω := repartitionDualMul hF (z : F) ω)).mpr hD
+    have hcancel : repartitionDualMul hF ((z⁻¹ : Fˣ) : F) (repartitionDualMul hF (z : F) ω) = ω :=
+      by simp
+    rw [hcancel, Divisor.principal_inv, ← sub_eq_add_neg] at h
+    rw [add_comm]
+    exact sub_le_iff_le_add.mp (hW.2 h)
 
 /-! ### The Riemann–Roch theorem -/
 
@@ -256,7 +322,8 @@ theorem exists_isRiemannRochDivisor (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) :
     ∃ W : Divisor k F, W.IsRiemannRochDivisor (genus k F) := by
   obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
-  obtain ⟨W, hW⟩ := exists_isGreatest_mem_weilDifferentialFiltration hF hex hωmem hω0
-  exact ⟨W, isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration hF hex hω0 hW⟩
+  exact ⟨weilDifferentialDivisor ω,
+    isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration hF hex hω0
+      (isGreatest_weilDifferentialDivisor hF hex hωmem hω0)⟩
 
 end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -194,9 +194,9 @@ theorem mem_weilDifferentialFiltration_zero_iff_forall_order_nonneg
     (hω : ω ≠ 0) :
     ω ∈ weilDifferentialFiltration (0 : Divisor k F) ↔
       ∀ P : Place k F, 0 ≤ weilDifferentialOrder hF hex hmem hω P := by
-  rw [mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor hF hex hmem hω]
-  change (∀ P : Place k F, 0 ≤ (weilDifferentialDivisor hF hex hmem hω).coeff P) ↔ _
-  simp only [coeff_weilDifferentialDivisor]
+  rw [mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor hF hex hmem hω,
+    AlgebraicGeometry.WeilDivisor.le_iff]
+  simp only [AlgebraicGeometry.WeilDivisor.coeff_zero, coeff_weilDifferentialDivisor]
 
 /-- **The transformation law `(z · ω) = div z + (ω)`** (Stichtenoth, Proposition 1.5.13): the
 divisor of a Weil differential changes by a principal divisor when the differential is multiplied

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -70,11 +70,15 @@ the Riemann–Roch identity.
   `ℓ((ω)) = g` and `deg (ω) = 2g - 2` (Stichtenoth, Corollary 1.5.16).
 * `TauCeti.exists_isRiemannRochDivisor`: **the Riemann–Roch theorem** — a Riemann–Roch divisor
   exists.
+* `TauCeti.divisorClass_eq_canonicalClass_iff`: **the characterization of canonical divisors**
+  (Stichtenoth, Proposition 1.6.2) — a divisor represents the canonical class exactly when
+  `deg D = 2g - 2` and `ℓ(D) ≥ g`.
 
 ## References
 
 * H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
-  Section I.5, in particular Proposition 1.5.11, Theorem 1.5.14 and Theorem 1.5.15.
+  Section I.5, in particular Proposition 1.5.11, Theorem 1.5.14 and Theorem 1.5.15, and
+  Proposition 1.6.2.
 -/
 
 public section
@@ -388,5 +392,53 @@ theorem exists_isRiemannRochDivisor (hF : IsFunctionField k F)
   obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
   exact ⟨weilDifferentialDivisor hF hex hωmem hω0,
     isRiemannRochDivisor_weilDifferentialDivisor hF hex hωmem hω0⟩
+
+/-! ### The characterization of canonical divisors -/
+
+/-- A divisor representing the canonical class is a Riemann–Roch divisor for the genus: it is
+linearly equivalent to the divisor of a nonzero Weil differential, and being a Riemann–Roch
+divisor depends only on the divisor class
+(`TauCeti.Divisor.IsRiemannRochDivisor.of_linearlyEquivalent`). -/
+theorem isRiemannRochDivisor_of_divisorClass_eq_canonicalClass (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {D : Divisor k F}
+    (hD : (Place.orderSystem hF).divisorClass D = canonicalClass hF hex) :
+    D.IsRiemannRochDivisor (genus k F) := by
+  obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
+  refine (isRiemannRochDivisor_weilDifferentialDivisor hF hex hωmem hω0).of_linearlyEquivalent hF
+    ((Place.orderSystem hF).divisorClass_eq_iff.mp ?_)
+  rw [divisorClass_weilDifferentialDivisor hF hex hωmem hω0, hD]
+
+/-- **The characterization of canonical divisors** (Stichtenoth, Proposition 1.6.2): a divisor
+represents the canonical class exactly when it has degree `2g - 2` and its Riemann–Roch space
+has dimension at least the genus.
+
+For the substantial direction, take `W` to be the divisor of a nonzero Weil differential.  Once
+`deg D = 2g - 2`, the Riemann–Roch identity at `D` reads `ℓ(D) = g - 1 + ℓ(W - D)`, so `ℓ(D) ≥ g`
+forces `ℓ(W - D) ≥ 1`; as `W - D` has degree zero it is then principal
+(`TauCeti.Divisor.one_le_dim_iff_exists_principal_eq_of_degree_eq_zero`), that is, `D` has the
+class of `W`.  Conversely such a `D` is itself a Riemann–Roch divisor, whose degree and dimension
+are `2g - 2` and `g` by Corollary 1.5.16. -/
+theorem divisorClass_eq_canonicalClass_iff (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) (D : Divisor k F) :
+    (Place.orderSystem hF).divisorClass D = canonicalClass hF hex ↔
+      Divisor.degree D = 2 * genus k F - 2 ∧ genus k F ≤ Divisor.dim D := by
+  obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
+  refine ⟨fun hD ↦ ?_, fun ⟨hdeg, hdim⟩ ↦ ?_⟩
+  · have hRR := isRiemannRochDivisor_of_divisorClass_eq_canonicalClass hF hex hD
+    exact ⟨hRR.degree_eq hF hex, (hRR.dim_eq hF hex).ge⟩
+  · have hid := Divisor.isRiemannRochDivisor_iff.mp
+      (isRiemannRochDivisor_weilDifferentialDivisor hF hex hωmem hω0) D
+    have hdegsub : Divisor.degree (weilDifferentialDivisor hF hex hωmem hω0 - D) = 0 := by
+      rw [Divisor.degree_sub, degree_weilDifferentialDivisor hF hex hωmem hω0, hdeg, sub_self]
+    have hone : 1 ≤ Divisor.dim (weilDifferentialDivisor hF hex hωmem hω0 - D) := by
+      rw [hdeg] at hid
+      omega
+    obtain ⟨z, hz⟩ :=
+      (Divisor.one_le_dim_iff_exists_principal_eq_of_degree_eq_zero hF hdegsub).mp hone
+    have hclass : (Place.orderSystem hF).divisorClass
+        (weilDifferentialDivisor hF hex hωmem hω0 - D) = 0 :=
+      (Divisor.divisorClass_eq_zero_iff hF).mpr ⟨z, hz⟩
+    rw [map_sub, sub_eq_zero, divisorClass_weilDifferentialDivisor hF hex hωmem hω0] at hclass
+    exact hclass.symm
 
 end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean
@@ -20,9 +20,9 @@ That is the Riemann–Roch theorem.
 The witness is the divisor of a nonzero Weil differential.  Enlarging a divisor shrinks the space
 `Ω_F(D)` of Weil differentials it bounds, so the divisors bounding a fixed `ω` form a downward
 closed family; the two facts that make it have a *greatest* element are that the family is stable
-under suprema — because `A_F(D ⊔ E) = A_F(D) + A_F(E)`, which is
-`TauCeti.adeleFiltration_sup` — and that its degrees are bounded above, because past the
-threshold of Riemann's theorem the index of specialty vanishes and with it `Ω_F(D)`.
+under suprema (`TauCeti.mem_weilDifferentialFiltration_sup`) and that its degrees are bounded
+above, because past the threshold of Riemann's theorem the index of specialty vanishes and with
+it `Ω_F(D)`.
 A divisor of maximal degree in the family is then the greatest, since places have positive degree.
 
 Writing `W` for that greatest divisor, multiplication by a function is an injective `k`-linear map
@@ -34,8 +34,8 @@ the Riemann–Roch identity.
 
 ## Main definitions
 
-* `TauCeti.weilDifferentialDivisor`: **the divisor `(ω)` of a Weil differential** (Stichtenoth,
-  Definition 1.5.11), the greatest divisor bounding it.
+* `TauCeti.weilDifferentialDivisor`: **the divisor `(ω)` of a nonzero Weil differential**
+  (Stichtenoth, Definition 1.5.11), the greatest divisor bounding it.
 * `TauCeti.canonicalClass`: **the canonical class** in the divisor class group, represented by
   the divisor of any nonzero Weil differential.
 * `TauCeti.riemannRochSpaceEquivWeilDifferentialFiltration`: **the duality isomorphism**
@@ -43,8 +43,6 @@ the Riemann–Roch identity.
 
 ## Main results
 
-* `TauCeti.mem_weilDifferentialFiltration_sup`: a Weil differential bounded by `D` and by `E` is
-  bounded by `D ⊔ E`.
 * `TauCeti.exists_forall_degree_lt_of_mem_weilDifferentialFiltration`: the divisors bounding a
   fixed nonzero Weil differential have bounded degree.
 * `TauCeti.exists_isGreatest_mem_weilDifferentialFiltration`: **the divisor of a nonzero Weil
@@ -79,48 +77,6 @@ public section
 namespace TauCeti
 
 variable {k F : Type*} [Field k] [Field F] [Algebra k F]
-
-/-! ### Weil differentials bounded by a supremum -/
-
-/-- A Weil differential bounded by each of two divisors is bounded by their supremum: by
-`TauCeti.adeleFiltration_sup` a repartition bounded by `D ⊔ E` is a sum of two on which the
-differential already vanishes. -/
-theorem mem_weilDifferentialFiltration_sup {D E : Divisor k F}
-    {ω : Module.Dual k ↥(repartitionSpace k F)} (hD : ω ∈ weilDifferentialFiltration D)
-    (hE : ω ∈ weilDifferentialFiltration E) :
-    ω ∈ weilDifferentialFiltration (D ⊔ E) := by
-  have hsub : submoduleOfAdeleFiltrationSupDiagonalRepartitions (D ⊔ E) =
-      submoduleOfAdeleFiltrationSupDiagonalRepartitions D ⊔
-        submoduleOfAdeleFiltrationSupDiagonalRepartitions E := by
-    have htrace (X : Submodule k (Place k F → F))
-        (hX : X ≤ repartitionSpace k F) :
-        (X ⊔ diagonalRepartitions k F).submoduleOf (repartitionSpace k F) =
-          X.submoduleOf (repartitionSpace k F) ⊔
-            (diagonalRepartitions k F).submoduleOf (repartitionSpace k F) := by
-      apply Submodule.map_injective_of_injective (repartitionSpace k F).subtype_injective
-      simp only [Submodule.submoduleOf, Submodule.map_comap_eq, Submodule.map_sup,
-        Submodule.range_subtype]
-      rw [inf_comm (repartitionSpace k F) (X ⊔ diagonalRepartitions k F),
-        inf_comm (repartitionSpace k F) X,
-        inf_comm (repartitionSpace k F) (diagonalRepartitions k F),
-        sup_inf_assoc_of_le _ hX, inf_eq_left.mpr hX]
-    rw [submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf (D ⊔ E),
-      submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf D,
-      submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf E,
-      adeleFiltration_sup,
-      htrace (adeleFiltration D ⊔ adeleFiltration E)
-        (sup_le (adeleFiltration_le_repartitionSpace D)
-          (adeleFiltration_le_repartitionSpace E)),
-      Submodule.submoduleOf_sup_of_le (adeleFiltration_le_repartitionSpace D)
-        (adeleFiltration_le_repartitionSpace E),
-      htrace (adeleFiltration D) (adeleFiltration_le_repartitionSpace D),
-      htrace (adeleFiltration E) (adeleFiltration_le_repartitionSpace E)]
-    ac_rfl
-  rw [weilDifferentialFiltration_eq_dualAnnihilator D] at hD
-  rw [weilDifferentialFiltration_eq_dualAnnihilator E] at hE
-  rw [weilDifferentialFiltration_eq_dualAnnihilator (D ⊔ E), hsub,
-    Submodule.dualAnnihilator_sup_eq]
-  exact ⟨hD, hE⟩
 
 /-! ### The divisor of a nonzero Weil differential -/
 
@@ -173,34 +129,30 @@ theorem mem_weilDifferentialFiltration_iff_le_of_isGreatest
     ω ∈ weilDifferentialFiltration D ↔ D ≤ W :=
   ⟨fun h ↦ hW.2 h, fun h ↦ weilDifferentialFiltration_antitone h hW.1⟩
 
-open Classical in
-/-- **The divisor `(ω)` of a Weil differential** (Stichtenoth, Definition 1.5.11): the greatest
-divisor bounding `ω` when there is one, and `0` otherwise.  For a nonzero Weil differential over
-an exact constant field the greatest divisor does exist, by
-`TauCeti.exists_isGreatest_mem_weilDifferentialFiltration`, and
-`TauCeti.isGreatest_weilDifferentialDivisor` identifies it with this one; the junk value in the
-remaining cases is what lets the divisor be a function of `ω` alone. -/
-noncomputable def weilDifferentialDivisor (ω : Module.Dual k ↥(repartitionSpace k F)) :
-    Divisor k F :=
-  if h : ∃ W : Divisor k F, IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W then
-    h.choose else 0
+/-- **The divisor `(ω)` of a nonzero Weil differential** (Stichtenoth, Definition 1.5.11): the
+greatest divisor bounding `ω`, which exists by
+`TauCeti.exists_isGreatest_mem_weilDifferentialFiltration`.  The hypotheses are exactly what that
+existence needs, so the value is always the divisor it is meant to denote; its characteristic
+property is `TauCeti.mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor`. -/
+noncomputable def weilDifferentialDivisor (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) : Divisor k F :=
+  (exists_isGreatest_mem_weilDifferentialFiltration hF hex hmem hω).choose
 
 /-- The divisor of a nonzero Weil differential is indeed the greatest divisor bounding it. -/
 theorem isGreatest_weilDifferentialDivisor (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
     (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
     IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D}
-      (weilDifferentialDivisor ω) := by
-  have h := exists_isGreatest_mem_weilDifferentialFiltration hF hex hmem hω
-  rw [weilDifferentialDivisor, dite_eq_left h]
-  exact h.choose_spec
+      (weilDifferentialDivisor hF hex hmem hω) :=
+  (exists_isGreatest_mem_weilDifferentialFiltration hF hex hmem hω).choose_spec
 
 /-- **The characteristic property of `(ω)`**: a nonzero Weil differential is bounded by `D`
 exactly when `D ≤ (ω)`. -/
 theorem mem_weilDifferentialFiltration_iff_le_weilDifferentialDivisor (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
     (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (D : Divisor k F) :
-    ω ∈ weilDifferentialFiltration D ↔ D ≤ weilDifferentialDivisor ω :=
+    ω ∈ weilDifferentialFiltration D ↔ D ≤ weilDifferentialDivisor hF hex hmem hω :=
   mem_weilDifferentialFiltration_iff_le_of_isGreatest
     (isGreatest_weilDifferentialDivisor hF hex hmem hω) D
 
@@ -215,16 +167,15 @@ bounding `ω` bijectively onto those bounding `z · ω`, hence greatest element 
 element. -/
 theorem weilDifferentialDivisor_repartitionDualMul (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
-    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (z : Fˣ) :
-    weilDifferentialDivisor (repartitionDualMul hF (z : F) ω) =
-      Divisor.principal hF z + weilDifferentialDivisor ω := by
+    (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (z : Fˣ)
+    (hzmem : repartitionDualMul hF (z : F) ω ∈ weilDifferentialSpace k F)
+    (hz : repartitionDualMul hF (z : F) ω ≠ 0) :
+    weilDifferentialDivisor hF hex hzmem hz =
+      Divisor.principal hF z + weilDifferentialDivisor hF hex hmem hω := by
   have hW := isGreatest_weilDifferentialDivisor hF hex hmem hω
-  have hz0 : repartitionDualMul hF (z : F) ω ≠ 0 := fun h ↦ hω (by
-    rw [← repartitionDualMul_inv_repartitionDualMul hF (Units.ne_zero z) ω, h, map_zero])
-  refine (isGreatest_weilDifferentialDivisor hF hex
-    (repartitionDualMul_mem_weilDifferentialSpace hF _ hmem) hz0).unique ⟨?_, fun D hD ↦ ?_⟩
+  refine (isGreatest_weilDifferentialDivisor hF hex hzmem hz).unique ⟨?_, fun D hD ↦ ?_⟩
   · have h := (repartitionDualMul_mem_weilDifferentialFiltration_iff hF z
-      (D := weilDifferentialDivisor ω) (ω := ω)).mpr hW.1
+      (D := weilDifferentialDivisor hF hex hmem hω) (ω := ω)).mpr hW.1
     rwa [add_comm] at h
   · have h := (repartitionDualMul_mem_weilDifferentialFiltration_iff hF z⁻¹
       (D := D) (ω := repartitionDualMul hF (z : F) ω)).mpr hD
@@ -241,26 +192,17 @@ theorem divisorClass_weilDifferentialDivisor_eq (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω η : Module.Dual k ↥(repartitionSpace k F)}
     (hωmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0)
     (hηmem : η ∈ weilDifferentialSpace k F) (hη : η ≠ 0) :
-    (Place.orderSystem hF).divisorClass (weilDifferentialDivisor ω) =
-      (Place.orderSystem hF).divisorClass (weilDifferentialDivisor η) := by
+    (Place.orderSystem hF).divisorClass (weilDifferentialDivisor hF hex hωmem hω) =
+      (Place.orderSystem hF).divisorClass (weilDifferentialDivisor hF hex hηmem hη) := by
   obtain ⟨c, hc⟩ := exists_repartitionDualMul_eq hF hex hωmem hω hηmem
-  have hc0 : c ≠ 0 := fun hc0 ↦ hη (by
-    rw [← hc, hc0, map_zero]
-    rfl)
-  let z : Fˣ := Units.mk0 c hc0
-  symm
-  calc
-    (Place.orderSystem hF).divisorClass (weilDifferentialDivisor η) =
-        (Place.orderSystem hF).divisorClass
-          (weilDifferentialDivisor (repartitionDualMul hF (z : F) ω)) := by
-            rw [show (z : F) = c by rfl, hc]
-    _ = (Place.orderSystem hF).divisorClass
-          (Divisor.principal hF z + weilDifferentialDivisor ω) := by
-            rw [weilDifferentialDivisor_repartitionDualMul hF hex hωmem hω]
-    _ = (Place.orderSystem hF).divisorClass (weilDifferentialDivisor ω) := by
-            rw [map_add, (Divisor.divisorClass_eq_zero_iff hF).mpr ⟨z, rfl⟩, zero_add]
+  subst hc
+  have hc0 : c ≠ 0 := by
+    rintro rfl
+    exact hη (by simp)
+  obtain ⟨z, rfl⟩ : ∃ z : Fˣ, (z : F) = c := ⟨Units.mk0 c hc0, rfl⟩
+  rw [weilDifferentialDivisor_repartitionDualMul hF hex hωmem hω z hηmem hη, map_add,
+    (Divisor.divisorClass_eq_zero_iff hF).mpr ⟨z, rfl⟩, zero_add]
 
-open Classical in
 /-- **The canonical class** of an algebraic function field with exact constant field: the divisor
 class of a nonzero Weil differential.  Such a differential exists by
 `TauCeti.weilDifferentialSpace_ne_bot`, and
@@ -269,18 +211,18 @@ differential. -/
 noncomputable def canonicalClass (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) : (Place.orderSystem hF).ClassGroup :=
   (Place.orderSystem hF).divisorClass
-    (weilDifferentialDivisor
-      (((Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)).choose))
+    (weilDifferentialDivisor hF hex
+      ((Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)).choose_spec.1
+      ((Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)).choose_spec.2)
 
 /-- Every nonzero Weil differential represents the canonical class. -/
 theorem divisorClass_weilDifferentialDivisor (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) {ω : Module.Dual k ↥(repartitionSpace k F)}
     (hmem : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
-    (Place.orderSystem hF).divisorClass (weilDifferentialDivisor ω) = canonicalClass hF hex := by
+    (Place.orderSystem hF).divisorClass (weilDifferentialDivisor hF hex hmem hω) =
+      canonicalClass hF hex := by
   unfold canonicalClass
-  apply divisorClass_weilDifferentialDivisor_eq hF hex hmem hω
-  · exact ((Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)).choose_spec.1
-  · exact ((Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)).choose_spec.2
+  exact divisorClass_weilDifferentialDivisor_eq hF hex hmem hω _ _
 
 /-! ### The Riemann–Roch theorem -/
 
@@ -397,7 +339,7 @@ theorem exists_isRiemannRochDivisor (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) :
     ∃ W : Divisor k F, W.IsRiemannRochDivisor (genus k F) := by
   obtain ⟨ω, hωmem, hω0⟩ := (Submodule.ne_bot_iff _).mp (weilDifferentialSpace_ne_bot hF hex)
-  exact ⟨weilDifferentialDivisor ω,
+  exact ⟨weilDifferentialDivisor hF hex hωmem hω0,
     isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration hF hex hω0
       (isGreatest_weilDifferentialDivisor hF hex hωmem hω0)⟩
 

--- a/TauCeti/FieldTheory/FunctionField/Differential/Dimension.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Dimension.lean
@@ -218,9 +218,8 @@ theorem exists_repartitionDualMul_eq (hF : IsFunctionField k F)
       by_contra hx₂
       refine hcon (-(x₂⁻¹ * x₁)) ?_
       have h := congrArg (repartitionDualMul hF x₂⁻¹) hx
-      rw [map_add, map_zero, repartitionDualMul_repartitionDualMul,
-        repartitionDualMul_repartitionDualMul, inv_mul_cancel₀ hx₂, map_one,
-        Module.End.one_apply] at h
+      rw [map_add, map_zero, repartitionDualMul_inv_repartitionDualMul hF hx₂ ω₂,
+        repartitionDualMul_repartitionDualMul] at h
       rw [map_neg, LinearMap.neg_apply, eq_comm, eq_neg_iff_add_eq_zero, add_comm]
       exact h
     subst hx₂
@@ -229,8 +228,7 @@ theorem exists_repartitionDualMul_eq (hF : IsFunctionField k F)
     by_contra hx₁
     refine hω₁ ?_
     have h := congrArg (repartitionDualMul hF x₁⁻¹) hx
-    rwa [repartitionDualMul_repartitionDualMul, inv_mul_cancel₀ hx₁, map_one,
-      Module.End.one_apply, map_zero] at h
+    rwa [repartitionDualMul_inv_repartitionDualMul hF hx₁ ω₁, map_zero] at h
   -- a divisor `B` of large degree makes the estimate and Riemann's theorem incompatible
   obtain ⟨B, hBpos, hBdeg⟩ := exists_pos_le_degree hF
     (3 * genus k F - Divisor.degree D₁ - Divisor.degree D₂)

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -34,6 +34,8 @@ specialty, and are proved in `TauCeti/FieldTheory/FunctionField/Differential/Dim
   multiplication of repartitions by a function (Definition 1.5.8).
 * `TauCeti.weilDifferentialSpaceMul` and `TauCeti.weilDifferentialSpaceModule`: its restriction
   to `Ω_F`, and the resulting `F`-vector space structure.
+* `TauCeti.repartitionDualMulRight`: that action with the linear form frozen, as the `k`-linear
+  map `F → Ω_F`, `x ↦ x · ω`.
 
 ## Main results
 
@@ -47,6 +49,10 @@ specialty, and are proved in `TauCeti/FieldTheory/FunctionField/Differential/Dim
   some single divisor bounds it.
 * `TauCeti.weilDifferentialFiltration_eq_bot_iff`: `Ω_F(D) = 0` exactly when every repartition
   differs from a constant by one bounded by `D`.
+* `TauCeti.repartitionDualMul_inv_repartitionDualMul`: multiplying by a unit and then by its
+  inverse restores the form, so the action of a nonzero function is invertible.
+* `TauCeti.injective_repartitionDualMulRight`: multiplication by a nonzero linear form is an
+  injective map `F → Ω_F`.
 * `TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`: for `z ∈ Fˣ`, a linear form
   lies in `Ω_F(D)` exactly when `z · ω` lies in `Ω_F(D + div z)`, so `Ω_F` is stable under the
   action (`TauCeti.repartitionDualMul_mem_weilDifferentialSpace`).
@@ -211,6 +217,44 @@ theorem repartitionDualMul_repartitionDualMul (hF : IsFunctionField k F) (f g : 
     repartitionDualMul hF f (repartitionDualMul hF g ω) = repartitionDualMul hF (f * g) ω := by
   rw [← Module.End.mul_apply, ← map_mul]
 
+/-- **Multiplying by a nonzero function and then by its inverse restores the linear form.** The
+cancellation that makes multiplication by a nonzero function invertible on `Ω_F`. -/
+@[simp]
+theorem repartitionDualMul_inv_repartitionDualMul (hF : IsFunctionField k F) {x : F} (hx : x ≠ 0)
+    (ω : Module.Dual k ↥(repartitionSpace k F)) :
+    repartitionDualMul hF x⁻¹ (repartitionDualMul hF x ω) = ω := by
+  rw [← Module.End.mul_apply, ← map_mul, inv_mul_cancel₀ hx, map_one, Module.End.one_apply]
+
+/-- **Multiplication of a fixed linear form by a varying function**, as a `k`-linear map
+`F → Ω_F`: the map `x ↦ x · ω` obtained by freezing the second argument of
+`TauCeti.repartitionDualMul`.  For `ω ≠ 0` it is injective
+(`TauCeti.injective_repartitionDualMulRight`), and Riemann–Roch is the computation of its image
+on a Riemann–Roch space. -/
+noncomputable def repartitionDualMulRight (hF : IsFunctionField k F)
+    (ω : Module.Dual k ↥(repartitionSpace k F)) :
+    F →ₗ[k] Module.Dual k ↥(repartitionSpace k F) :=
+  (LinearMap.applyₗ ω).comp (repartitionDualMul hF).toLinearMap
+
+@[simp]
+theorem repartitionDualMulRight_apply (hF : IsFunctionField k F)
+    (ω : Module.Dual k ↥(repartitionSpace k F)) (x : F) :
+    repartitionDualMulRight hF ω x = repartitionDualMul hF x ω :=
+  (rfl)
+
+/-- **Multiplication by a nonzero Weil differential is injective.** A function in the kernel is
+either zero or a unit, and a unit can be cancelled by
+`TauCeti.repartitionDualMul_inv_repartitionDualMul`, forcing `ω = 0`. -/
+theorem injective_repartitionDualMulRight (hF : IsFunctionField k F)
+    {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) :
+    Function.Injective (repartitionDualMulRight hF ω) := by
+  rw [injective_iff_map_eq_zero]
+  intro x hx
+  by_contra hx0
+  obtain ⟨z, rfl⟩ : ∃ z : Fˣ, (z : F) = x := ⟨Units.mk0 x hx0, rfl⟩
+  refine hω ?_
+  rw [← repartitionDualMul_inv_repartitionDualMul hF (Units.ne_zero z) ω,
+    ← repartitionDualMulRight_apply hF ω (z : F), hx, map_zero]
+
 /-- **Multiplication translates the filtration by a principal divisor**: for a nonzero function
 `z`, a linear form is bounded by `D` exactly when `z · ω` is bounded by `D + div z`, exactly as
 multiplication by `z` carries `A_F(D + div z)` into `A_F(D)`. -/
@@ -234,8 +278,7 @@ theorem repartitionDualMul_mem_weilDifferentialFiltration_iff (hF : IsFunctionFi
       exact smul_mem_diagonalRepartitions (y : F) ha
   refine ⟨fun h ↦ ?_, key z D ω⟩
   have hzz : repartitionDualMul hF ((z⁻¹ : Fˣ) : F) (repartitionDualMul hF (z : F) ω) = ω := by
-    rw [← Module.End.mul_apply, ← map_mul, ← Units.val_mul, inv_mul_cancel, Units.val_one,
-      map_one, Module.End.one_apply]
+    simp
   have hD : D + Divisor.principal hF z + Divisor.principal hF z⁻¹ = D := by
     rw [Divisor.principal_inv, add_neg_cancel_right]
   have h' := key z⁻¹ _ _ h

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -51,7 +51,7 @@ specialty, and are proved in `TauCeti/FieldTheory/FunctionField/Differential/Dim
   differs from a constant by one bounded by `D`.
 * `TauCeti.repartitionDualMul_inv_repartitionDualMul`: multiplying by a unit and then by its
   inverse restores the form, so the action of a nonzero function is invertible.
-* `TauCeti.injective_repartitionDualMulRight`: multiplication by a nonzero linear form is an
+* `TauCeti.repartitionDualMulRight_injective`: multiplication by a nonzero linear form is an
   injective map `F → Ω_F`.
 * `TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`: for `z ∈ Fˣ`, a linear form
   lies in `Ω_F(D)` exactly when `z · ω` lies in `Ω_F(D + div z)`, so `Ω_F` is stable under the
@@ -228,7 +228,7 @@ theorem repartitionDualMul_inv_repartitionDualMul (hF : IsFunctionField k F) {x 
 /-- **Multiplication of a fixed linear form by a varying function**, as a `k`-linear map
 `F → Ω_F`: the map `x ↦ x · ω` obtained by freezing the second argument of
 `TauCeti.repartitionDualMul`.  For `ω ≠ 0` it is injective
-(`TauCeti.injective_repartitionDualMulRight`), and Riemann–Roch is the computation of its image
+(`TauCeti.repartitionDualMulRight_injective`), and Riemann–Roch is the computation of its image
 on a Riemann–Roch space. -/
 noncomputable def repartitionDualMulRight (hF : IsFunctionField k F)
     (ω : Module.Dual k ↥(repartitionSpace k F)) :
@@ -244,7 +244,7 @@ theorem repartitionDualMulRight_apply (hF : IsFunctionField k F)
 /-- **Multiplication by a nonzero Weil differential is injective.** A function in the kernel is
 either zero or a unit, and a unit can be cancelled by
 `TauCeti.repartitionDualMul_inv_repartitionDualMul`, forcing `ω = 0`. -/
-theorem injective_repartitionDualMulRight (hF : IsFunctionField k F)
+theorem repartitionDualMulRight_injective (hF : IsFunctionField k F)
     {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) :
     Function.Injective (repartitionDualMulRight hF ω) := by
   rw [injective_iff_map_eq_zero]

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -48,8 +48,8 @@ specialty, and are proved in `TauCeti/FieldTheory/FunctionField/Differential/Dim
 * `TauCeti.weilDifferentialFiltration_antitone` and `TauCeti.mem_weilDifferentialSpace_iff`: the
   filtration is antitone and directed, so a `k`-linear form is a Weil differential exactly when
   some single divisor bounds it.
-* `TauCeti.mem_weilDifferentialFiltration_sup`: a Weil differential bounded by `D` and by `E` is
-  bounded by their supremum `D ⊔ E`.
+* `TauCeti.weilDifferentialFiltration_sup`: the exact supremum rule
+  `Ω_F(D ⊔ E) = Ω_F(D) ∩ Ω_F(E)`.
 * `TauCeti.weilDifferentialFiltration_eq_bot_iff`: `Ω_F(D) = 0` exactly when every repartition
   differs from a constant by one bounded by `D`.
 * `TauCeti.repartitionDualMul_inv_repartitionDualMul`: multiplying by a unit and then by its
@@ -155,33 +155,42 @@ theorem weilDifferentialFiltration_antitone :
       Submodule k (Module.Dual k ↥(repartitionSpace k F))) := fun _ _ h ↦
   Submodule.dualAnnihilator_anti (submoduleOfAdeleFiltrationSupDiagonalRepartitions_mono h)
 
-/-- **A Weil differential bounded by each of two divisors is bounded by their supremum.** -/
-theorem mem_weilDifferentialFiltration_sup {D E : Divisor k F}
-    {ω : Module.Dual k ↥(repartitionSpace k F)} (hD : ω ∈ weilDifferentialFiltration D)
-    (hE : ω ∈ weilDifferentialFiltration E) :
-    ω ∈ weilDifferentialFiltration (D ⊔ E) := by
-  refine mem_weilDifferentialFiltration_of_apply_eq_zero (fun a ha ↦ ?_)
-    (fun a ha ↦ weilDifferentialFiltration_apply_eq_zero_of_mem_diagonalRepartitions hD a ha)
-  rw [adeleFiltration_sup] at ha
-  obtain ⟨x, hx, y, hy, hxy⟩ := Submodule.mem_sup.mp ha
-  have hxA : x ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace D hx
-  have hyA : y ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace E hy
-  have hsplit : a = ⟨x, hxA⟩ + ⟨y, hyA⟩ := Subtype.ext hxy.symm
-  rw [hsplit, map_add,
-    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hD ⟨x, hxA⟩ hx,
-    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hE ⟨y, hyA⟩ hy, add_zero]
-
 /-- **The filtration turns suprema of divisors into intersections of spaces of Weil
 differentials**: `Ω_F(D ⊔ E) = Ω_F(D) ∩ Ω_F(E)`. -/
 @[simp]
 theorem weilDifferentialFiltration_sup (D E : Divisor k F) :
     weilDifferentialFiltration (D ⊔ E) =
       weilDifferentialFiltration D ⊓ weilDifferentialFiltration E := by
-  refine le_antisymm
-    (le_inf (weilDifferentialFiltration_antitone le_sup_left)
-      (weilDifferentialFiltration_antitone le_sup_right)) ?_
-  intro ω hω
-  exact mem_weilDifferentialFiltration_sup hω.1 hω.2
+  have hsub : submoduleOfAdeleFiltrationSupDiagonalRepartitions (D ⊔ E) =
+      submoduleOfAdeleFiltrationSupDiagonalRepartitions D ⊔
+        submoduleOfAdeleFiltrationSupDiagonalRepartitions E := by
+    have htrace (X : Submodule k (Place k F → F))
+        (hX : X ≤ repartitionSpace k F) :
+        (X ⊔ diagonalRepartitions k F).submoduleOf (repartitionSpace k F) =
+          X.submoduleOf (repartitionSpace k F) ⊔
+            (diagonalRepartitions k F).submoduleOf (repartitionSpace k F) := by
+      apply Submodule.map_injective_of_injective (repartitionSpace k F).subtype_injective
+      simp only [Submodule.submoduleOf, Submodule.map_comap_eq, Submodule.map_sup,
+        Submodule.range_subtype]
+      rw [inf_comm (repartitionSpace k F) (X ⊔ diagonalRepartitions k F),
+        inf_comm (repartitionSpace k F) X,
+        inf_comm (repartitionSpace k F) (diagonalRepartitions k F),
+        sup_inf_assoc_of_le _ hX, inf_eq_left.mpr hX]
+    rw [submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf,
+      submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf,
+      submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf,
+      TauCeti.adeleFiltration_sup]
+    rw [htrace (adeleFiltration D ⊔ adeleFiltration E)
+        (sup_le (adeleFiltration_le_repartitionSpace D)
+          (adeleFiltration_le_repartitionSpace E)),
+      Submodule.submoduleOf_sup_of_le (adeleFiltration_le_repartitionSpace D)
+        (adeleFiltration_le_repartitionSpace E),
+      htrace (adeleFiltration D) (adeleFiltration_le_repartitionSpace D),
+      htrace (adeleFiltration E) (adeleFiltration_le_repartitionSpace E)]
+    ac_rfl
+  rw [weilDifferentialFiltration_eq_dualAnnihilator,
+    weilDifferentialFiltration_eq_dualAnnihilator,
+    weilDifferentialFiltration_eq_dualAnnihilator, hsub, Submodule.dualAnnihilator_sup_eq]
 
 /-- **`Ω_F(D)` vanishes exactly when `A_F(D) + F` is everything**: the only `k`-linear form on
 `A_F` vanishing on `A_F(D) + F` is `0` precisely when every repartition already differs from a

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -48,6 +48,8 @@ specialty, and are proved in `TauCeti/FieldTheory/FunctionField/Differential/Dim
 * `TauCeti.weilDifferentialFiltration_antitone` and `TauCeti.mem_weilDifferentialSpace_iff`: the
   filtration is antitone and directed, so a `k`-linear form is a Weil differential exactly when
   some single divisor bounds it.
+* `TauCeti.mem_weilDifferentialFiltration_sup`: a Weil differential bounded by `D` and by `E` is
+  bounded by their supremum `D ⊔ E`.
 * `TauCeti.weilDifferentialFiltration_eq_bot_iff`: `Ω_F(D) = 0` exactly when every repartition
   differs from a constant by one bounded by `D`.
 * `TauCeti.repartitionDualMul_inv_repartitionDualMul`: multiplying by a unit and then by its
@@ -151,6 +153,46 @@ theorem weilDifferentialFiltration_antitone :
     Antitone (weilDifferentialFiltration : Divisor k F →
       Submodule k (Module.Dual k ↥(repartitionSpace k F))) := fun _ _ h ↦
   Submodule.dualAnnihilator_anti (submoduleOfAdeleFiltrationSupDiagonalRepartitions_mono h)
+
+/-- **A Weil differential bounded by each of two divisors is bounded by their supremum.** By
+`TauCeti.adeleFiltration_sup` a repartition bounded by `D ⊔ E` is a sum of one bounded by `D` and
+one bounded by `E`, on both of which the differential already vanishes. -/
+theorem mem_weilDifferentialFiltration_sup {D E : Divisor k F}
+    {ω : Module.Dual k ↥(repartitionSpace k F)} (hD : ω ∈ weilDifferentialFiltration D)
+    (hE : ω ∈ weilDifferentialFiltration E) :
+    ω ∈ weilDifferentialFiltration (D ⊔ E) := by
+  have hsub : submoduleOfAdeleFiltrationSupDiagonalRepartitions (D ⊔ E) =
+      submoduleOfAdeleFiltrationSupDiagonalRepartitions D ⊔
+        submoduleOfAdeleFiltrationSupDiagonalRepartitions E := by
+    have htrace (X : Submodule k (Place k F → F))
+        (hX : X ≤ repartitionSpace k F) :
+        (X ⊔ diagonalRepartitions k F).submoduleOf (repartitionSpace k F) =
+          X.submoduleOf (repartitionSpace k F) ⊔
+            (diagonalRepartitions k F).submoduleOf (repartitionSpace k F) := by
+      apply Submodule.map_injective_of_injective (repartitionSpace k F).subtype_injective
+      simp only [Submodule.submoduleOf, Submodule.map_comap_eq, Submodule.map_sup,
+        Submodule.range_subtype]
+      rw [inf_comm (repartitionSpace k F) (X ⊔ diagonalRepartitions k F),
+        inf_comm (repartitionSpace k F) X,
+        inf_comm (repartitionSpace k F) (diagonalRepartitions k F),
+        sup_inf_assoc_of_le _ hX, inf_eq_left.mpr hX]
+    rw [submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf (D ⊔ E),
+      submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf D,
+      submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf E,
+      adeleFiltration_sup,
+      htrace (adeleFiltration D ⊔ adeleFiltration E)
+        (sup_le (adeleFiltration_le_repartitionSpace D)
+          (adeleFiltration_le_repartitionSpace E)),
+      Submodule.submoduleOf_sup_of_le (adeleFiltration_le_repartitionSpace D)
+        (adeleFiltration_le_repartitionSpace E),
+      htrace (adeleFiltration D) (adeleFiltration_le_repartitionSpace D),
+      htrace (adeleFiltration E) (adeleFiltration_le_repartitionSpace E)]
+    ac_rfl
+  rw [weilDifferentialFiltration_eq_dualAnnihilator D] at hD
+  rw [weilDifferentialFiltration_eq_dualAnnihilator E] at hE
+  rw [weilDifferentialFiltration_eq_dualAnnihilator (D ⊔ E), hsub,
+    Submodule.dualAnnihilator_sup_eq]
+  exact ⟨hD, hE⟩
 
 /-- **`Ω_F(D)` vanishes exactly when `A_F(D) + F` is everything**: the only `k`-linear form on
 `A_F` vanishing on `A_F(D) + F` is `0` precisely when every repartition already differs from a

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -35,7 +35,8 @@ specialty, and are proved in `TauCeti/FieldTheory/FunctionField/Differential/Dim
 * `TauCeti.weilDifferentialSpaceMul` and `TauCeti.weilDifferentialSpaceModule`: its restriction
   to `Ω_F`, and the resulting `F`-vector space structure.
 * `TauCeti.repartitionDualMulRight`: that action with the linear form frozen, as the `k`-linear
-  map `F → Ω_F`, `x ↦ x · ω`.
+  map `F → Module.Dual k A_F`, `x ↦ x · ω`.  It restricts to a map `F → Ω_F` when `ω` is a Weil
+  differential, by `TauCeti.repartitionDualMul_mem_weilDifferentialSpace`.
 
 ## Main results
 
@@ -51,8 +52,8 @@ specialty, and are proved in `TauCeti/FieldTheory/FunctionField/Differential/Dim
   differs from a constant by one bounded by `D`.
 * `TauCeti.repartitionDualMul_inv_repartitionDualMul`: multiplying by a unit and then by its
   inverse restores the form, so the action of a nonzero function is invertible.
-* `TauCeti.repartitionDualMulRight_injective`: multiplication by a nonzero linear form is an
-  injective map `F → Ω_F`.
+* `TauCeti.repartitionDualMulRight_injective`: for a nonzero linear form `ω`, the map
+  `x ↦ x · ω` is injective.
 * `TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`: for `z ∈ Fˣ`, a linear form
   lies in `Ω_F(D)` exactly when `z · ω` lies in `Ω_F(D + div z)`, so `Ω_F` is stable under the
   action (`TauCeti.repartitionDualMul_mem_weilDifferentialSpace`).
@@ -226,8 +227,10 @@ theorem repartitionDualMul_inv_repartitionDualMul (hF : IsFunctionField k F) {x 
   rw [← Module.End.mul_apply, ← map_mul, inv_mul_cancel₀ hx, map_one, Module.End.one_apply]
 
 /-- **Multiplication of a fixed linear form by a varying function**, as a `k`-linear map
-`F → Ω_F`: the map `x ↦ x · ω` obtained by freezing the second argument of
-`TauCeti.repartitionDualMul`.  For `ω ≠ 0` it is injective
+`F → Module.Dual k A_F`: the map `x ↦ x · ω` obtained by freezing the second argument of
+`TauCeti.repartitionDualMul`.  Here `ω` is an arbitrary `k`-linear form on `A_F`; when it is a
+Weil differential the map lands in `Ω_F`, by
+`TauCeti.repartitionDualMul_mem_weilDifferentialSpace`.  For `ω ≠ 0` it is injective
 (`TauCeti.repartitionDualMulRight_injective`), and Riemann–Roch is the computation of its image
 on a Riemann–Roch space. -/
 noncomputable def repartitionDualMulRight (hF : IsFunctionField k F)
@@ -241,7 +244,7 @@ theorem repartitionDualMulRight_apply (hF : IsFunctionField k F)
     repartitionDualMulRight hF ω x = repartitionDualMul hF x ω :=
   (rfl)
 
-/-- **Multiplication by a nonzero Weil differential is injective.** A function in the kernel is
+/-- **Multiplication by a nonzero linear form is injective.** A function in the kernel is
 either zero or a unit, and a unit can be cancelled by
 `TauCeti.repartitionDualMul_inv_repartitionDualMul`, forcing `ω = 0`. -/
 theorem repartitionDualMulRight_injective (hF : IsFunctionField k F)

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -155,13 +155,13 @@ theorem weilDifferentialFiltration_antitone :
       Submodule k (Module.Dual k ↥(repartitionSpace k F))) := fun _ _ h ↦
   Submodule.dualAnnihilator_anti (submoduleOfAdeleFiltrationSupDiagonalRepartitions_mono h)
 
-/-- **A Weil differential bounded by each of two divisors is bounded by their supremum.** By
-`TauCeti.adeleFiltration_sup` a repartition bounded by `D ⊔ E` is a sum of one bounded by `D` and
-one bounded by `E`, on both of which the differential already vanishes. -/
+/-- **A Weil differential bounded by each of two divisors is bounded by their supremum.** -/
 theorem mem_weilDifferentialFiltration_sup {D E : Divisor k F}
     {ω : Module.Dual k ↥(repartitionSpace k F)} (hD : ω ∈ weilDifferentialFiltration D)
     (hE : ω ∈ weilDifferentialFiltration E) :
     ω ∈ weilDifferentialFiltration (D ⊔ E) := by
+  -- By `adeleFiltration_sup` a repartition bounded by `D ⊔ E` is a sum of one bounded by `D` and
+  -- one bounded by `E`, on both of which the differential already vanishes.
   have hsub : submoduleOfAdeleFiltrationSupDiagonalRepartitions (D ⊔ E) =
       submoduleOfAdeleFiltrationSupDiagonalRepartitions D ⊔
         submoduleOfAdeleFiltrationSupDiagonalRepartitions E := by
@@ -261,8 +261,8 @@ theorem repartitionDualMul_repartitionDualMul (hF : IsFunctionField k F) (f g : 
     repartitionDualMul hF f (repartitionDualMul hF g ω) = repartitionDualMul hF (f * g) ω := by
   rw [← Module.End.mul_apply, ← map_mul]
 
-/-- **Multiplying by a nonzero function and then by its inverse restores the linear form.** The
-cancellation that makes multiplication by a nonzero function invertible on `Ω_F`. -/
+/-- **Multiplying by a nonzero function and then by its inverse restores the linear form**, so
+multiplication by a nonzero function is invertible on `Ω_F`. -/
 @[simp]
 theorem repartitionDualMul_inv_repartitionDualMul (hF : IsFunctionField k F) {x : F} (hx : x ≠ 0)
     (ω : Module.Dual k ↥(repartitionSpace k F)) :
@@ -287,12 +287,13 @@ theorem repartitionDualMulRight_apply (hF : IsFunctionField k F)
     repartitionDualMulRight hF ω x = repartitionDualMul hF x ω :=
   (rfl)
 
-/-- **Multiplication by a nonzero linear form is injective.** A function in the kernel is
-either zero or a unit, and a unit can be cancelled by
-`TauCeti.repartitionDualMul_inv_repartitionDualMul`, forcing `ω = 0`. -/
+/-- **Multiplication by a nonzero linear form is injective**: a function `x` with `x · ω = 0`
+is itself zero. -/
 theorem repartitionDualMulRight_injective (hF : IsFunctionField k F)
     {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) :
     Function.Injective (repartitionDualMulRight hF ω) := by
+  -- A function in the kernel is either zero or a unit, and a unit can be cancelled by
+  -- `repartitionDualMul_inv_repartitionDualMul`, forcing `ω = 0`.
   rw [injective_iff_map_eq_zero]
   intro x hx
   by_contra hx0
@@ -301,8 +302,7 @@ theorem repartitionDualMulRight_injective (hF : IsFunctionField k F)
   rw [← repartitionDualMul_inv_repartitionDualMul hF (Units.ne_zero z) ω,
     ← repartitionDualMulRight_apply hF ω (z : F), hx, map_zero]
 
-/-- **A nonzero function times a nonzero linear form is nonzero**, by injectivity of
-`TauCeti.repartitionDualMulRight`. -/
+/-- **A nonzero function times a nonzero linear form is nonzero.** -/
 theorem repartitionDualMul_ne_zero (hF : IsFunctionField k F) {z : F} (hz : z ≠ 0)
     {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) :
     repartitionDualMul hF z ω ≠ 0 := fun h ↦ hz <|

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -54,8 +54,9 @@ specialty, and are proved in `TauCeti/FieldTheory/FunctionField/Differential/Dim
   differs from a constant by one bounded by `D`.
 * `TauCeti.repartitionDualMul_inv_repartitionDualMul`: multiplying by a unit and then by its
   inverse restores the form, so the action of a nonzero function is invertible.
-* `TauCeti.repartitionDualMulRight_injective`: for a nonzero linear form `ω`, the map
-  `x ↦ x · ω` is injective.
+* `TauCeti.repartitionDualMulRight_injective` and `TauCeti.repartitionDualMul_ne_zero`: for a
+  nonzero linear form `ω`, the map `x ↦ x · ω` is injective, so `z · ω` is again nonzero for
+  `z ≠ 0`.
 * `TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`: for `z ∈ Fˣ`, a linear form
   lies in `Ω_F(D)` exactly when `z · ω` lies in `Ω_F(D + div z)`, so `Ω_F` is stable under the
   action (`TauCeti.repartitionDualMul_mem_weilDifferentialSpace`).
@@ -299,6 +300,14 @@ theorem repartitionDualMulRight_injective (hF : IsFunctionField k F)
   refine hω ?_
   rw [← repartitionDualMul_inv_repartitionDualMul hF (Units.ne_zero z) ω,
     ← repartitionDualMulRight_apply hF ω (z : F), hx, map_zero]
+
+/-- **A nonzero function times a nonzero linear form is nonzero**, by injectivity of
+`TauCeti.repartitionDualMulRight`. -/
+theorem repartitionDualMul_ne_zero (hF : IsFunctionField k F) {z : F} (hz : z ≠ 0)
+    {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) :
+    repartitionDualMul hF z ω ≠ 0 := fun h ↦ hz <|
+  (injective_iff_map_eq_zero _).mp (repartitionDualMulRight_injective hF hω) z
+    (by rw [repartitionDualMulRight_apply, h])
 
 /-- **Multiplication translates the filtration by a principal divisor**: for a nonzero function
 `z`, a linear form is bounded by `D` exactly when `z · ω` is bounded by `D + div z`, exactly as

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -160,40 +160,28 @@ theorem mem_weilDifferentialFiltration_sup {D E : Divisor k F}
     {ω : Module.Dual k ↥(repartitionSpace k F)} (hD : ω ∈ weilDifferentialFiltration D)
     (hE : ω ∈ weilDifferentialFiltration E) :
     ω ∈ weilDifferentialFiltration (D ⊔ E) := by
-  -- By `adeleFiltration_sup` a repartition bounded by `D ⊔ E` is a sum of one bounded by `D` and
-  -- one bounded by `E`, on both of which the differential already vanishes.
-  have hsub : submoduleOfAdeleFiltrationSupDiagonalRepartitions (D ⊔ E) =
-      submoduleOfAdeleFiltrationSupDiagonalRepartitions D ⊔
-        submoduleOfAdeleFiltrationSupDiagonalRepartitions E := by
-    have htrace (X : Submodule k (Place k F → F))
-        (hX : X ≤ repartitionSpace k F) :
-        (X ⊔ diagonalRepartitions k F).submoduleOf (repartitionSpace k F) =
-          X.submoduleOf (repartitionSpace k F) ⊔
-            (diagonalRepartitions k F).submoduleOf (repartitionSpace k F) := by
-      apply Submodule.map_injective_of_injective (repartitionSpace k F).subtype_injective
-      simp only [Submodule.submoduleOf, Submodule.map_comap_eq, Submodule.map_sup,
-        Submodule.range_subtype]
-      rw [inf_comm (repartitionSpace k F) (X ⊔ diagonalRepartitions k F),
-        inf_comm (repartitionSpace k F) X,
-        inf_comm (repartitionSpace k F) (diagonalRepartitions k F),
-        sup_inf_assoc_of_le _ hX, inf_eq_left.mpr hX]
-    rw [submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf (D ⊔ E),
-      submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf D,
-      submoduleOfAdeleFiltrationSupDiagonalRepartitions_eq_submoduleOf E,
-      adeleFiltration_sup,
-      htrace (adeleFiltration D ⊔ adeleFiltration E)
-        (sup_le (adeleFiltration_le_repartitionSpace D)
-          (adeleFiltration_le_repartitionSpace E)),
-      Submodule.submoduleOf_sup_of_le (adeleFiltration_le_repartitionSpace D)
-        (adeleFiltration_le_repartitionSpace E),
-      htrace (adeleFiltration D) (adeleFiltration_le_repartitionSpace D),
-      htrace (adeleFiltration E) (adeleFiltration_le_repartitionSpace E)]
-    ac_rfl
-  rw [weilDifferentialFiltration_eq_dualAnnihilator D] at hD
-  rw [weilDifferentialFiltration_eq_dualAnnihilator E] at hE
-  rw [weilDifferentialFiltration_eq_dualAnnihilator (D ⊔ E), hsub,
-    Submodule.dualAnnihilator_sup_eq]
-  exact ⟨hD, hE⟩
+  refine mem_weilDifferentialFiltration_of_apply_eq_zero (fun a ha ↦ ?_)
+    (fun a ha ↦ weilDifferentialFiltration_apply_eq_zero_of_mem_diagonalRepartitions hD a ha)
+  rw [adeleFiltration_sup] at ha
+  obtain ⟨x, hx, y, hy, hxy⟩ := Submodule.mem_sup.mp ha
+  have hxA : x ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace D hx
+  have hyA : y ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace E hy
+  have hsplit : a = ⟨x, hxA⟩ + ⟨y, hyA⟩ := Subtype.ext hxy.symm
+  rw [hsplit, map_add,
+    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hD ⟨x, hxA⟩ hx,
+    weilDifferentialFiltration_apply_eq_zero_of_mem_adeleFiltration hE ⟨y, hyA⟩ hy, add_zero]
+
+/-- **The filtration turns suprema of divisors into intersections of spaces of Weil
+differentials**: `Ω_F(D ⊔ E) = Ω_F(D) ∩ Ω_F(E)`. -/
+@[simp]
+theorem weilDifferentialFiltration_sup (D E : Divisor k F) :
+    weilDifferentialFiltration (D ⊔ E) =
+      weilDifferentialFiltration D ⊓ weilDifferentialFiltration E := by
+  refine le_antisymm
+    (le_inf (weilDifferentialFiltration_antitone le_sup_left)
+      (weilDifferentialFiltration_antitone le_sup_right)) ?_
+  intro ω hω
+  exact mem_weilDifferentialFiltration_sup hω.1 hω.2
 
 /-- **`Ω_F(D)` vanishes exactly when `A_F(D) + F` is everything**: the only `k`-linear form on
 `A_F` vanishing on `A_F(D) + F` is `0` precisely when every repartition already differs from a
@@ -279,7 +267,7 @@ on a Riemann–Roch space. -/
 noncomputable def repartitionDualMulRight (hF : IsFunctionField k F)
     (ω : Module.Dual k ↥(repartitionSpace k F)) :
     F →ₗ[k] Module.Dual k ↥(repartitionSpace k F) :=
-  (LinearMap.applyₗ ω).comp (repartitionDualMul hF).toLinearMap
+  (repartitionDualMul hF).toLinearMap.flip ω
 
 @[simp]
 theorem repartitionDualMulRight_apply (hF : IsFunctionField k F)

--- a/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
@@ -54,6 +54,7 @@ differentials are the work that consumes this file.
 * `TauCeti.adeleFiltration_le_repartitionSpace`, `TauCeti.adeleFiltration_mono` and
   `TauCeti.directed_adeleFiltration`: the filtration lands in `A_F`, and is monotone and
   directed.
+* `TauCeti.adeleFiltration_sup`: `A_F(D ⊔ E) = A_F(D) + A_F(E)`, the place-by-place splitting.
 * `TauCeti.repartitionSpace_eq_iSup` and `TauCeti.coe_repartitionSpace_eq_iUnion`:
   `A_F = ⋃_D A_F(D)`, the exhaustion.
 * `TauCeti.diagonalRepartitions_le_repartitionSpace`: the diagonal `F ↪ A_F`, which is where
@@ -211,6 +212,37 @@ theorem mem_adeleFiltration_zero_iff {a : Place k F → F} :
 theorem adeleFiltration_mono {D E : Divisor k F} (h : D ≤ E) :
     adeleFiltration D ≤ adeleFiltration E := fun _ ha P ↦
   (ha P).trans (WithZero.exp_le_exp.mpr (WeilDivisor.coeff_le_coeff h P))
+
+/-- **The filtration turns suprema of divisors into sums of subspaces.** The inclusion that has
+content is `≤`: a repartition bounded by `D ⊔ E` respects, at each place separately, one of the
+two bounds, so assigning each entry to a side splits it as a sum. -/
+@[simp]
+theorem adeleFiltration_sup (D E : Divisor k F) :
+    adeleFiltration (D ⊔ E) = adeleFiltration D ⊔ adeleFiltration E := by
+  refine le_antisymm (fun a ha ↦ ?_)
+    (sup_le (adeleFiltration_mono le_sup_left) (adeleFiltration_mono le_sup_right))
+  classical
+  set a₁ : Place k F → F :=
+    fun P => if P.valuation (a P) ≤ WithZero.exp (D.coeff P) then a P else 0 with ha₁
+  have h₁ : a₁ ∈ adeleFiltration D := by
+    refine mem_adeleFiltration_iff.mpr fun P ↦ ?_
+    by_cases h : P.valuation (a P) ≤ WithZero.exp (D.coeff P) <;> simp [ha₁, h]
+  have h₂ : a - a₁ ∈ adeleFiltration E := by
+    refine mem_adeleFiltration_iff.mpr fun P ↦ ?_
+    by_cases h : P.valuation (a P) ≤ WithZero.exp (D.coeff P)
+    · simp [ha₁, h]
+    · have hmax := mem_adeleFiltration_iff.mp ha P
+      rw [WeilDivisor.coeff_sup] at hmax
+      have hexp : WithZero.exp ((D.coeff P) ⊔ (E.coeff P)) =
+          WithZero.exp (D.coeff P) ⊔ WithZero.exp (E.coeff P) := by
+        rcases le_total (D.coeff P) (E.coeff P) with hle | hle
+        · rw [sup_eq_right.mpr hle, sup_eq_right.mpr (WithZero.exp_le_exp.mpr hle)]
+        · rw [sup_eq_left.mpr hle, sup_eq_left.mpr (WithZero.exp_le_exp.mpr hle)]
+      rw [hexp] at hmax
+      have : P.valuation (a P) ≤ WithZero.exp (E.coeff P) :=
+        (le_sup_iff.mp hmax).resolve_left h
+      simpa [ha₁, h] using this
+  exact Submodule.mem_sup.mpr ⟨a₁, h₁, a - a₁, h₂, by ring⟩
 
 /-- The filtration is directed: any two of its members are contained in a third, namely the one
 attached to the pointwise maximum of the two divisors. -/

--- a/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
@@ -232,13 +232,9 @@ theorem adeleFiltration_sup (D E : Divisor k F) :
     by_cases h : P.valuation (a P) ≤ WithZero.exp (D.coeff P)
     · simp [ha₁, h]
     · have hmax := mem_adeleFiltration_iff.mp ha P
-      rw [WeilDivisor.coeff_sup] at hmax
-      have hexp : WithZero.exp ((D.coeff P) ⊔ (E.coeff P)) =
-          WithZero.exp (D.coeff P) ⊔ WithZero.exp (E.coeff P) := by
-        rcases le_total (D.coeff P) (E.coeff P) with hle | hle
-        · rw [sup_eq_right.mpr hle, sup_eq_right.mpr (WithZero.exp_le_exp.mpr hle)]
-        · rw [sup_eq_left.mpr hle, sup_eq_left.mpr (WithZero.exp_le_exp.mpr hle)]
-      rw [hexp] at hmax
+      rw [WeilDivisor.coeff_sup,
+        Monotone.map_sup (fun _ _ hle ↦ WithZero.exp_le_exp.mpr hle) (D.coeff P) (E.coeff P)]
+        at hmax
       have : P.valuation (a P) ≤ WithZero.exp (E.coeff P) :=
         (le_sup_iff.mp hmax).resolve_left h
       simpa [ha₁, h] using this

--- a/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
@@ -213,12 +213,14 @@ theorem adeleFiltration_mono {D E : Divisor k F} (h : D ≤ E) :
     adeleFiltration D ≤ adeleFiltration E := fun _ ha P ↦
   (ha P).trans (WithZero.exp_le_exp.mpr (WeilDivisor.coeff_le_coeff h P))
 
-/-- **The filtration turns suprema of divisors into sums of subspaces.** The inclusion that has
-content is `≤`: a repartition bounded by `D ⊔ E` respects, at each place separately, one of the
-two bounds, so assigning each entry to a side splits it as a sum. -/
+/-- **The filtration turns suprema of divisors into sums of subspaces**: `A_F(D ⊔ E)` is the sum
+of `A_F(D)` and `A_F(E)`. -/
 @[simp]
 theorem adeleFiltration_sup (D E : Divisor k F) :
     adeleFiltration (D ⊔ E) = adeleFiltration D ⊔ adeleFiltration E := by
+  -- The inclusion that has content is `≤`: a repartition bounded by `D ⊔ E` respects, at each
+  -- place separately, one of the two bounds, so assigning each entry to a side splits it as a
+  -- sum.
   refine le_antisymm (fun a ha ↦ ?_)
     (sup_le (adeleFiltration_mono le_sup_left) (adeleFiltration_mono le_sup_right))
   classical


### PR DESCRIPTION
This PR proves the **Riemann–Roch theorem** for an algebraic function field `F/k` with exact constant field, closing the summit of Layer 4 of the AlgebraicCurves roadmap (Stichtenoth I.5): it constructs the divisor of a nonzero Weil differential, proves the duality theorem `L(W − D) ≃ Ω_F(D)` (Theorem 1.5.14), and concludes that this divisor is a Riemann–Roch divisor for the genus (Theorem 1.5.15), so that `TauCeti.Divisor.IsRiemannRochDivisor` — which already carries `ℓ(W) = g`, `deg W = 2g − 2`, the equality of `g₀` with the genus, and linear equivalence of any two such divisors — is inhabited and the canonical class is well defined.

The witness is `(ω)` for `ω ≠ 0`. Enlarging a divisor shrinks `Ω_F(D)`, so the divisors bounding a fixed `ω` are downward closed; the family is stable under suprema, because `A_F(D ⊔ E) = A_F(D) + A_F(E)` (a repartition bounded by `D ⊔ E` respects one of the two bounds at each place separately, so assigning entries to sides splits it), and its degrees are bounded above, because past the threshold of Riemann's theorem the index of specialty vanishes and with it `Ω_F(D)`. A divisor of maximal degree in that family is therefore its greatest element, places having positive degree. Multiplication by a function is then an injective `k`-linear map `F → Ω_F` carrying `L(W − D)` onto `Ω_F(D)`: a nonzero `x` has `x · ω ∈ Ω_F(D)` exactly when `ω ∈ Ω_F(D − div x)`, which by maximality says `x ∈ L(W − D)`; surjectivity is Proposition 1.5.9, already on `main` as `exists_repartitionDualMul_eq`. Hence `ℓ(W − D) = dim_k Ω_F(D) = i(D)`, which rearranges to the Riemann–Roch identity. Essentially all of the machinery was already on `main` — the local-to-global quotient engine, Riemann's theorem, `dim_k Ω_F(D) = i(D)` and `dim_F Ω_F = 1`; what is added is the maximality argument, the duality isomorphism, and the rearrangement.

New: `TauCeti/FieldTheory/FunctionField/Differential/CanonicalDivisor.lean`, with `exists_isGreatest_mem_weilDifferentialFiltration`, `mem_weilDifferentialFiltration_iff_le_of_isGreatest`, `riemannRochSpaceEquivWeilDifferentialFiltration`, `dim_sub_eq_finrank_weilDifferentialFiltration`, `isRiemannRochDivisor_of_isGreatest_mem_weilDifferentialFiltration`, `exists_isRiemannRochDivisor` and, closing the layer's last bullet, the characterization of canonical divisors `divisorClass_eq_canonicalClass_iff` (`deg D = 2g − 2` and `ℓ(D) ≥ g` ⟺ `D` canonical, Proposition 1.6.2) with its companion `isRiemannRochDivisor_of_divisorClass_eq_canonicalClass`. Two supporting lemmas go beside the theory they elaborate: `adeleFiltration_sup` in `Repartition/Basic.lean`, and in `Differential/Weil.lean` the cancellation `repartitionDualMul_inv_repartitionDualMul` together with `repartitionDualMulRight`, the action with the linear form frozen, and its injectivity for `ω ≠ 0`.

This supersedes the retired #5207, whose three review findings are addressed here: the bounded-degree proof now goes through `exists_forall_indexOfSpecialty_eq_zero` and `weilDifferentialFiltration_eq_bot_iff_indexOfSpecialty_eq_zero` rather than re-deriving them (reuse), `adeleFiltration_sup` is `@[simp]` (api-design), and the unit cancellation is factored into a named lemma instead of an inline rewrite chain (proof-quality). Beyond those, the duality isomorphism that was buried inside the Riemann–Roch proof is now exported as a named `k`-linear equivalence, matching the roadmap's Layer 4 wording, and the cancellation lemma is stated for a nonzero function rather than a unit so that its left-hand side is simp-normal.

What remains in Layer 4 after this: nothing — the layer's remaining bullets were `(ω)`, the canonical class, duality, Riemann–Roch, and the characterization of canonical divisors (Proposition 1.6.2); uniqueness of the Riemann–Roch data (Proposition 1.6.1) is already on `main` in `RiemannRoch/Uniqueness.lean`. Layer 5's consequences (`deg D ≥ 2g − 1 ⟹ ℓ(D) = deg D + 1 − g`, genus 0, Weierstrass gaps, Clifford) and Layer 7's cotrace and Riemann–Hurwitz now become reachable.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"exists-isriemannrochdivisor"}-->

🤖 Prepared with Claude Code

