### PR TITLE
feat(Huber): strong noetherianness passes to a strictly finite type algebra

### DIFF
--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -6,7 +6,11 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Topology.Algebra.Ring.Ideal
+public import TauCeti.RingTheory.Huber.StronglyNoetherian
 public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Completion
+
+import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.FirstCountable
+import TauCeti.Topology.Algebra.GroupCompletion
 
 /-!
 # Homomorphisms topologically of finite type
@@ -79,6 +83,9 @@ it.
 * `TauCeti.Huber.isStrictlyTopologicallyFiniteType_quotientMk_algebraMap`: every quotient of
   `A⟨X₁, …, Xₖ⟩` is strictly topologically of finite type over `A` — the shape of every Laurent
   and rational presentation.
+* `TauCeti.Huber.IsStrictlyTopologicallyFiniteType.isStronglyNoetherian`: over a strongly
+  noetherian Huber ring, an algebra strictly topologically of finite type is again strongly
+  noetherian.
 
 ## References
 
@@ -206,5 +213,34 @@ theorem isStrictlyTopologicallyFiniteType_quotientMk_algebraMap (k : ℕ)
   (isStrictlyTopologicallyFiniteType_algebraMap k).quotientMk I
 
 end OpenQuotient
+
+/-! ### Strong noetherianness
+
+Strong noetherianness passes from `A` to any algebra strictly topologically of finite type over
+it. This is the standing hypothesis of Wedhorn's §8.2 in the form the flatness results consume:
+rational localisations of a strongly noetherian ring are again strongly noetherian, once they are
+known to be strictly topologically of finite type.
+-/
+
+section StronglyNoetherian
+
+variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A] [IsHuberRing A]
+  [IsStronglyNoetherian A]
+  [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
+  [T0Space B]
+
+/-- **Strong noetherianness passes to an algebra strictly topologically of finite type.**
+
+The presentation `π : A⟨X₁,…,Xₖ⟩ → B` is an open quotient map, and `A⟨X₁,…,Xₖ⟩` is strongly
+noetherian over a strongly noetherian Huber ring by
+`TauCeti.Huber.IsStronglyNoetherian.restrictedMvPowerSeriesCompletion`, so this is
+`IsOpenQuotientMap.isStronglyNoetherian` applied to that presentation. The presenting equation
+is not used: any open quotient out of `A⟨X₁,…,Xₖ⟩` suffices, whatever it does on constants. -/
+theorem IsStrictlyTopologicallyFiniteType.isStronglyNoetherian {φ : A →+* B}
+    (hφ : IsStrictlyTopologicallyFiniteType φ) : IsStronglyNoetherian B := by
+  obtain ⟨k, π, hπ, -⟩ := hφ
+  exact hπ.isStronglyNoetherian
+
+end StronglyNoetherian
 
 end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -229,16 +229,23 @@ variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A] [
   [CommRing B] [UniformSpace B] [IsUniformAddGroup B] [NonarchimedeanRing B] [CompleteSpace B]
   [T0Space B]
 
-/-- **Strong noetherianness passes to an algebra strictly topologically of finite type.**
+/-- **Strong noetherianness passes to an algebra strictly topologically of finite type.** Over a
+strongly noetherian Huber ring `A`, a complete Hausdorff nonarchimedean ring `B` admitting a map
+`φ : A →+* B` strictly topologically of finite type is again strongly noetherian.
 
-The presentation `π : A⟨X₁,…,Xₖ⟩ → B` is an open quotient map, and `A⟨X₁,…,Xₖ⟩` is strongly
-noetherian over a strongly noetherian Huber ring by
-`TauCeti.Huber.IsStronglyNoetherian.restrictedMvPowerSeriesCompletion`, so this is
-`IsOpenQuotientMap.isStronglyNoetherian` applied to that presentation. The presenting equation
-is not used: any open quotient out of `A⟨X₁,…,Xₖ⟩` suffices, whatever it does on constants. -/
+Only the existence of a presentation is used, never which map it presents: `B` is strongly
+noetherian as soon as *some* open quotient `A⟨X₁,…,Xₖ⟩ ↠ B` exists, whatever that quotient does on
+constants. The hypothesis is stated on `φ` because that is the form a caller holds.
+
+This is the standing hypothesis of Wedhorn's §8.2 in the form the flatness results consume.
+`TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian`
+asks that every rational localisation in a cover be strongly noetherian, and each of those is
+presented as a quotient of a restricted series algebra — strictly of finite type by
+`TauCeti.Huber.isStrictlyTopologicallyFiniteType_quotientMk_algebraMap` — so this is what turns
+that hypothesis into one about the base alone. -/
 theorem IsStrictlyTopologicallyFiniteType.isStronglyNoetherian {φ : A →+* B}
     (hφ : IsStrictlyTopologicallyFiniteType φ) : IsStronglyNoetherian B := by
-  obtain ⟨k, π, hπ, -⟩ := hφ
+  obtain ⟨k, π, hπ, -⟩ := isStrictlyTopologicallyFiniteType_iff.mp hφ
   exact hπ.isStronglyNoetherian
 
 end StronglyNoetherian

--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -237,12 +237,14 @@ Only the existence of a presentation is used, never which map it presents: `B` i
 noetherian as soon as *some* open quotient `A⟨X₁,…,Xₖ⟩ ↠ B` exists, whatever that quotient does on
 constants. The hypothesis is stated on `φ` because that is the form a caller holds.
 
-This is the standing hypothesis of Wedhorn's §8.2 in the form the flatness results consume.
+The intended use is Wedhorn's §8.2, where
 `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian`
-asks that every rational localisation in a cover be strongly noetherian, and each of those is
-presented as a quotient of a restricted series algebra — strictly of finite type by
-`TauCeti.Huber.isStrictlyTopologicallyFiniteType_quotientMk_algebraMap` — so this is what turns
-that hypothesis into one about the base alone. -/
+asks that every rational localisation in a cover be strongly noetherian. That application is not
+yet available here: no result in this repository presents a rational localisation as strictly
+topologically of finite type over its base. Once one does — the presentations of Wedhorn's
+Examples 6.38 and 6.39 take the shape of
+`TauCeti.Huber.isStrictlyTopologicallyFiniteType_quotientMk_algebraMap` — this theorem is what
+will reduce that hypothesis to strong noetherianness of the base alone. -/
 theorem IsStrictlyTopologicallyFiniteType.isStronglyNoetherian {φ : A →+* B}
     (hφ : IsStrictlyTopologicallyFiniteType φ) : IsStronglyNoetherian B := by
   obtain ⟨k, π, hπ, -⟩ := isStrictlyTopologicallyFiniteType_iff.mp hφ

--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -239,12 +239,11 @@ constants. The hypothesis is stated on `φ` because that is the form a caller ho
 
 The intended use is Wedhorn's §8.2, where
 `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian`
-asks that every rational localisation in a cover be strongly noetherian. That application is not
-yet available here: no result in this repository presents a rational localisation as strictly
-topologically of finite type over its base. Once one does — the presentations of Wedhorn's
-Examples 6.38 and 6.39 take the shape of
-`TauCeti.Huber.isStrictlyTopologicallyFiniteType_quotientMk_algebraMap` — this theorem is what
-will reduce that hypothesis to strong noetherianness of the base alone. -/
+asks that every rational localisation in a cover be strongly noetherian. Combined with a strict
+finite type presentation of such a localisation over its base — the shape
+`TauCeti.Huber.isStrictlyTopologicallyFiniteType_quotientMk_algebraMap` produces, and the one
+Wedhorn's Examples 6.38 and 6.39 exhibit — this theorem reduces that hypothesis to strong
+noetherianness of the base alone. -/
 theorem IsStrictlyTopologicallyFiniteType.isStronglyNoetherian {φ : A →+* B}
     (hφ : IsStrictlyTopologicallyFiniteType φ) : IsStronglyNoetherian B := by
   obtain ⟨k, π, hπ, -⟩ := isStrictlyTopologicallyFiniteType_iff.mp hφ

--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -233,10 +233,6 @@ variable {A B : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A] [
 strongly noetherian Huber ring `A`, a complete Hausdorff nonarchimedean ring `B` admitting a map
 `φ : A →+* B` strictly topologically of finite type is again strongly noetherian.
 
-Only the existence of a presentation is used, never which map it presents: `B` is strongly
-noetherian as soon as *some* open quotient `A⟨X₁,…,Xₖ⟩ ↠ B` exists, whatever that quotient does on
-constants. The hypothesis is stated on `φ` because that is the form a caller holds.
-
 The intended use is Wedhorn's §8.2, where
 `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian`
 asks that every rational localisation in a cover be strongly noetherian. Combined with a strict


### PR DESCRIPTION
Roadmap: AdicSpaces

No `tauceti-target` marker: this authors no numbered target, it supplies the standing hypothesis
that one needs.

`TauCeti.Huber.IsStrictlyTopologicallyFiniteType.isStronglyNoetherian` — over a strongly
noetherian Huber ring `A`, any `B` strictly topologically of finite type over `A` is again
strongly noetherian.

## What downstream needs it

`AdicSpaces/README.md` Layer 4.1 **step 3, Proposition 8.30**, the current frontier — whose
elementary case landed in #5753.

That PR's own file says exactly what is missing between it and Wedhorn's statement
(`LocalizationTopology/Laurent/Flat.lean`, *What this is not*):

> The chain result is **not** Wedhorn's Proposition 8.30 as he states it. His standing hypothesis
> is that `A` is strongly noetherian; the hypothesis here is that `A⟨U/s⟩` is, for every `U` with
> `T ⊆ U ⊂ T'`. What separates the two is the standing hypothesis of Wedhorn's §8.2 — that
> rational localisations of a strongly noetherian ring are again strongly noetherian. The family
> hypothesis is carried rather than derived from that.

This PR is the general half of that standing hypothesis. Discharging the family hypothesis of
`flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian` then needs only the remaining
half — that a rational localisation *is* strictly topologically of finite type — which is a
separate PR.

## Proof

Two lines. `IsStrictlyTopologicallyFiniteType φ` unfolds to an open quotient map
`π : A⟨X₁,…,Xₖ⟩ →+* B`; `A⟨X₁,…,Xₖ⟩` is strongly noetherian by
`IsStronglyNoetherian.restrictedMvPowerSeriesCompletion` (#5793); descent along `π` is
`IsOpenQuotientMap.isStronglyNoetherian` (#5869, below in this stack).

The presenting equation `π.comp (algebraMap …) = φ` is destructured away: any open quotient out of
`A⟨X₁,…,Xₖ⟩` gives the conclusion, whatever it does on constants. That is why the statement asks
nothing of `φ` beyond the existence of the presentation.

## Hypotheses

Minimised rather than copied from the descent theorem. The descent is applied at `A⟨X₁,…,Xₖ⟩` —
a completion, carrying its own uniform structure — and **not** at `A`, so nothing about `A`'s own
uniformity is used: `[IsUniformAddGroup A]`, `[CompleteSpace A]` and `[T0Space A]` are unnecessary
(the `unusedSectionVars` linter flags them), and `[UniformSpace A]` weakens all the way to
`[TopologicalSpace A]`, which is also what `IsStrictlyTopologicallyFiniteType` itself asks.
Requiring a uniformity would have excluded Huber rings carrying no ambient one and admitted
unrelated ones. `[NonarchimedeanRing A]` was probed for removal too and is load-bearing, so it
stays.

## Imports

Three added to `TopologicallyFiniteType.lean`, and only one of them is re-exported.

`public import …Huber.StronglyNoetherian` — its class appears in the theorem's statement.

`import …WeightedRestrictedSeries.FirstCountable` and `import TauCeti.Topology.Algebra.GroupCompletion`
(#5873, merged) are plain: the first supplies
`isCountablyGenerated_nhds_zero_weightedRestrictedSubring` and the second lifts that countable
generation to the completion, both only as instances the proof needs internally. Without them the
`(𝓝 0).IsCountablyGenerated` instance the descent theorem asks of its source does not resolve —
but neither occurs in the signature, so neither belongs in this module's public dependency
surface.

## Stacking

Stacked on #5869 (`IsOpenQuotientMap.isStronglyNoetherian`), so this PR's diff also shows #5867's
and #5869's files; only `TopologicallyFiniteType.lean` is new here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1

