### PR TITLE
refactor(ModularForms): name the shared coset-fibre count

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
@@ -187,6 +187,41 @@ theorem heckeSlashSum_eq_sum_of_mem_doubleCoset {δ : GL (Fin 2) ℚ}
   rw [← doubleCoset_eq_of_mem hδ]
   exact doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ δ
 
+omit [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)] in
+/-- **Each fibre of the naming map has `m` elements.** Let `g` name, for each index `i`, the
+right coset that `aᵢ` lies in — `Γ₁ aᵢ = Γ₁ (rightCosetRep D (g i))` — and let every right coset
+of the double coset be named by exactly `m` members of the family. Then `g i = v` for exactly
+`m` indices `i`, whatever `v`.
+
+The hypothesis counts indices by the coset they name and the conclusion counts them by their
+image under `g`; the two agree because `rightCosetRep` names distinct cosets by distinct
+elements (`op_rightCosetRep_smul_injective`).
+
+Like `exists_bijective_rightCosetRep_smul_eq` this is pure coset bookkeeping — no slash, no
+weight and no character appears. It is the counting step of the multiplicity-weighted
+`sum_slash_eq_nsmul_heckeSlashSum` below and of the nebentypus-weighted
+`sum_nebentypus_smul_slash_eq_nsmul_twistedHeckeSlashSum` in
+`HeckeSlash/Nebentypus/Independence.lean`, which differ only in the per-summand lemma they then
+supply. -/
+theorem card_filter_eq_of_rightCosetRep_smul_eq {ι : Type*} [Fintype ι] {a : ι → GL (Fin 2) ℚ}
+    {m : ℕ} (hcard : ∀ x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂,
+      Nat.card {i // MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))} = m)
+    {g : ι → DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹}
+    (hg : ∀ i, MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+      MulOpposite.op (rightCosetRep D (g i)) • (Γ₁ : Set (GL (Fin 2) ℚ)))
+    (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) [DecidablePred fun i ↦ g i = v] :
+    (Finset.univ.filter fun i ↦ g i = v).card = m := by
+  classical
+  have hfib : (Finset.univ.filter fun i ↦ g i = v) =
+      Finset.univ.filter fun i ↦ MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) :=
+    Finset.filter_congr fun i _ ↦
+      ⟨fun h ↦ h ▸ hg i, fun h ↦ op_rightCosetRep_smul_injective D ((hg i).symm.trans h)⟩
+  have hm := hcard _ (rightCosetRep_mem_doubleCoset D v)
+  rw [Nat.card_eq_fintype_card, Fintype.card_subtype] at hm
+  rw [hfib, hm]
+
 /-- **A family naming each right coset the same number of times sums to a multiple of the slash
 sum.** In place of the injectivity of `heckeSlashSum_eq_sum_of_rightCosets`, ask that every right
 coset of the double coset be named by exactly `m` members of the family: then the sum over the
@@ -218,17 +253,8 @@ theorem sum_slash_eq_nsmul_heckeSlashSum {ι : Type*} [Fintype ι] (a : ι → G
   -- On the fibre of `v` every term is the slash by `v`'s representative, so the fibre
   -- contributes its cardinality times that one value.
   rw [Finset.sum_congr rfl fun i hi ↦
-      slash_eq_of_rightCoset_eq k hf ((Finset.mem_filter.mp hi).2 ▸ hg i), Finset.sum_const]
-  -- That cardinality is `m`: the fibre of `v` is the set of indices naming `v`'s right coset,
-  -- since `g i` and `v` name the same coset exactly when they are equal.
-  have hfib : (Finset.univ.filter fun i ↦ g i = v) =
-      Finset.univ.filter fun i ↦ MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
-        MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) :=
-    Finset.filter_congr fun i _ ↦
-      ⟨fun h ↦ h ▸ hg i, fun h ↦ op_rightCosetRep_smul_injective D ((hg i).symm.trans h)⟩
-  have hm := hcard _ (rightCosetRep_mem_doubleCoset D v)
-  rw [Nat.card_eq_fintype_card, Fintype.card_subtype] at hm
-  rw [hfib, hm]
+      slash_eq_of_rightCoset_eq k hf ((Finset.mem_filter.mp hi).2 ▸ hg i), Finset.sum_const,
+    card_filter_eq_of_rightCosetRep_smul_eq D hcard hg v]
 
 section Form
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
@@ -175,17 +175,7 @@ theorem sum_nebentypus_smul_slash_eq_nsmul_twistedHeckeSlashSum
         ⟨a i, IsHeckeTriple.mem_of_mem_doubleCoset D.out.2 (hmem i)⟩ : ℂ) • (f ∣[k] a i)]
   refine Finset.sum_congr rfl fun v _ ↦ ?_
   rw [Finset.sum_congr rfl fun i hi ↦ ?_, Finset.sum_const]
-  · have hfib : (Finset.univ.filter fun i ↦ g i = v) =
-        Finset.univ.filter fun i ↦ MulOpposite.op (a i) •
-          (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
-            MulOpposite.op (rightCosetRep D v) •
-              (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
-                Set (GL (Fin 2) ℚ)) :=
-      Finset.filter_congr fun i _ ↦
-        ⟨fun h ↦ h ▸ hg i, fun h ↦ op_rightCosetRep_smul_injective D ((hg i).symm.trans h)⟩
-    have hm := hcard _ (rightCosetRep_mem_doubleCoset D v)
-    rw [Nat.card_eq_fintype_card, Fintype.card_subtype] at hm
-    rw [hfib, hm]
+  · rw [card_filter_eq_of_rightCosetRep_smul_eq D hcard hg v]
   · rw [nebentypusWeight_def]
     exact (smul_slash_eq_of_rightCoset_eq k χ f hf
       (IsHeckeTriple.mem_of_mem_doubleCoset D.out.2 (hmem i))


### PR DESCRIPTION
Roadmap: ModularForms

`sum_slash_eq_nsmul_heckeSlashSum` (`HeckeSlash/Independence.lean`) and its nebentypus-weighted
twin `sum_nebentypus_smul_slash_eq_nsmul_twistedHeckeSlashSum`
(`HeckeSlash/Nebentypus/Independence.lean`) both reach a point where they need one fact about the
chosen naming map `g`: exactly `m` indices satisfy `g i = v`. Each derives it the same way —
rewrite the fibre of `v` as the set of indices naming `v`'s right coset, then read the count off
the uniformity hypothesis — and the derivation is the same nine lines twice, in two files.

This names that step:

```lean
theorem card_filter_eq_of_rightCosetRep_smul_eq {ι : Type*} [Fintype ι] {a : ι → GL (Fin 2) ℚ}
    {m : ℕ} (hcard : ∀ x ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂,
      Nat.card {i // MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
        MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ))} = m)
    {g : ι → DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹}
    (hg : ∀ i, MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
      MulOpposite.op (rightCosetRep D (g i)) • (Γ₁ : Set (GL (Fin 2) ℚ)))
    (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) [DecidablePred fun i ↦ g i = v] :
    (Finset.univ.filter fun i ↦ g i = v).card = m
```

and both proofs now call it, each ending in a single `rw`.

### Why here, and why this shape

The file already set the precedent. `exists_bijective_rightCosetRep_smul_eq` factors out the
coset bookkeeping shared by the **unweighted** pair, and its docstring records that its two
consumers "differ only in the per-summand lemma they then supply". The **weighted** pair differs
in exactly the same way — one supplies `slash_eq_of_rightCoset_eq`, the other
`smul_slash_eq_of_rightCoset_eq` — but its bookkeeping had never been factored out. It now sits
beside the bijection lemma it is the companion of.

The generic statement (`Γ₁`, `Γ₂` arbitrary) covers the nebentypus call site, which instantiates
both at `(Gamma0 N).map (mapGL ℚ)`; that is why the twisted proof loses six lines of subgroup
ascriptions along with the argument itself. The `Finite (DecompQuotient …)` instance in scope is
`omit`ted — the fibre count does not need it.

No statement changes: both theorems keep their signatures, and nothing outside these two proofs
moves.

### Verification

- `lake build` clean for both modules and every downstream importer.
- 13-linter run over both: 0 errors in 429 declarations.
- No line over 100 characters; longest declaration 22 lines.

Local building used the rig's cached mathlib `5fcc665`; `main` has since bumped to `e21ec05`
(#5887), which touched neither file and adapted only `LinearAlgebra` dual/tensor API. CI verifies
against the new pins.

Provenance: none — this is a refactor of already-merged TauCeti code. The AINTLIB and Shimura
credits the two files carry are untouched and continue to cover the surrounding material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
