### PR TITLE
refactor(ModularForms): use mathlib's Ioo_mem_nhdsGT

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
@@ -467,9 +467,7 @@ theorem hasCauchyPVAt_fdBoundary_arc (hH : 1 < H) (hnorm : ‖w‖ = 1)
       (2 * Real.sin ((3 - t₀) * (Real.pi / 12))))
     (min (1 / 2 - w.re) (min (w.re + 1 / 2) (H - 1))) with hb_def
   have hb : 0 < b := arc_min_radius_pos hH hre ht₀
-  have hIoo : Ioo (0 : ℝ) b ∈ 𝓝[>] (0 : ℝ) := by
-    rw [← Ioi_inter_Iio]
-    exact inter_mem self_mem_nhdsWithin (nhdsWithin_le_nhds (Iio_mem_nhds hb))
+  have hIoo : Ioo (0 : ℝ) b ∈ 𝓝[>] (0 : ℝ) := Ioo_mem_nhdsGT hb
   have hspec : ∀ ε ∈ Ioo (0 : ℝ) b,
       IntervalIntegrable (fun t ↦ if ε < ‖fdBoundary H t - w‖
           then (fdBoundary H t - w)⁻¹ * deriv (fdBoundary H) t else 0) volume 0 5 ∧

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Vertical.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Vertical.lean
@@ -491,9 +491,7 @@ theorem hasCauchyPVAt_fdBoundary_vertical (hre : w.re = 2⁻¹ ∨ w.re = -(2⁻
       min (min 1 (‖w‖ - 1)) (min (H - w.im) (w.im - Real.sqrt 3 / 2)) :=
     lt_min (lt_min one_pos (by linarith)) (lt_min (by linarith) (by linarith))
   have hIoo : Ioo (0 : ℝ) (min (min 1 (‖w‖ - 1)) (min (H - w.im) (w.im - Real.sqrt 3 / 2)))
-      ∈ 𝓝[>] (0 : ℝ) := by
-    rw [← Ioi_inter_Iio]
-    exact inter_mem self_mem_nhdsWithin (nhdsWithin_le_nhds (Iio_mem_nhds hb))
+      ∈ 𝓝[>] (0 : ℝ) := Ioo_mem_nhdsGT hb
   have hspec : ∀ ε ∈ Ioo (0 : ℝ)
       (min (min 1 (‖w‖ - 1)) (min (H - w.im) (w.im - Real.sqrt 3 / 2))),
       IntervalIntegrable (fun t ↦ if ε < ‖fdBoundary H t - w‖

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -407,9 +407,7 @@ theorem hasCauchyPVAt_fdBoundary_rho_add_one (hH : Real.sqrt 3 / 2 < H) :
     lt_min (lt_min (by norm_num) (by linarith)) hsin12
   have hIoo : Ioo (0 : ℝ)
       (min (min (1 : ℝ) (H - Real.sqrt 3 / 2)) (2 * Real.sin (Real.pi / 12))) ∈
-      𝓝[>] (0 : ℝ) := by
-    rw [← Ioi_inter_Iio]
-    exact inter_mem self_mem_nhdsWithin (nhdsWithin_le_nhds (Iio_mem_nhds hε₀))
+      𝓝[>] (0 : ℝ) := Ioo_mem_nhdsGT hε₀
   have hspec : ∀ ε ∈ Ioo (0 : ℝ)
       (min (min (1 : ℝ) (H - Real.sqrt 3 / 2)) (2 * Real.sin (Real.pi / 12))),
       IntervalIntegrable (fun t ↦

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -386,9 +386,7 @@ theorem hasCauchyPVAt_fdBoundary_rho (hH : Real.sqrt 3 / 2 < H) :
     lt_min (lt_min (by norm_num) (by linarith)) hsin12
   have hIoo : Ioo (0 : ℝ)
       (min (min (1 : ℝ) (H - Real.sqrt 3 / 2)) (2 * Real.sin (Real.pi / 12))) ∈
-      𝓝[>] (0 : ℝ) := by
-    rw [← Ioi_inter_Iio]
-    exact inter_mem self_mem_nhdsWithin (nhdsWithin_le_nhds (Iio_mem_nhds hε₀))
+      𝓝[>] (0 : ℝ) := Ioo_mem_nhdsGT hε₀
   have hspec : ∀ ε ∈ Ioo (0 : ℝ)
       (min (min (1 : ℝ) (H - Real.sqrt 3 / 2)) (2 * Real.sin (Real.pi / 12))),
       IntervalIntegrable (fun t ↦ if ε < ‖fdBoundary H t - (UpperHalfPlane.ρ : ℂ)‖


### PR DESCRIPTION
Roadmap: ModularForms

Four principal-value theorems on the fundamental-domain boundary each open by fixing a radius
bound `b` and establishing that `Ioo 0 b` is a neighbourhood of `0` from the right. All four
prove it with the same three lines:

```lean
have hIoo : Ioo (0 : ℝ) b ∈ 𝓝[>] (0 : ℝ) := by
  rw [← Ioi_inter_Iio]
  exact inter_mem self_mem_nhdsWithin (nhdsWithin_le_nhds (Iio_mem_nhds hb))
```

Mathlib already has this, in exactly this form:

```lean
Ioo_mem_nhdsGT : b < a → Ioo b a ∈ 𝓝[>] b
```

so each site becomes `have hIoo : Ioo (0 : ℝ) b ∈ 𝓝[>] (0 : ℝ) := Ioo_mem_nhdsGT hb`.

The four sites are `hasCauchyPVAt_fdBoundary_rho` (`Winding/Rho/Value.lean`),
`hasCauchyPVAt_fdBoundary_rho_add_one` (`Winding/Rho/AddOne/Value.lean`),
`hasCauchyPVAt_fdBoundary_vertical` (`Winding/NonCorner/Vertical.lean`) and
`hasCauchyPVAt_fdBoundary_arc` (`Winding/NonCorner/Arc.lean`) — the two corner cases and the two
non-corner cases of the boundary index computation, which is why the same bound-positivity step
appears in all four.

**No new declarations, and no statement changes** — this only replaces a reproved mathlib fact
with the mathlib lemma. `Ioi_inter_Iio` now appears nowhere in the repository.

### Verification

- `lake build` clean for all four modules and for the downstream `ValencePV`.
- 13-linter run over all four: 0 errors in 452 declarations.
- Compiled probe confirming the mathlib lemma's statement:
  `@Ioo_mem_nhdsGT : ∀ {α} [TopologicalSpace α] [LinearOrder α] [ClosedIciTopology α] {a b : α}, b < a → Ioo b a ∈ 𝓝[>] b`.

Local building used the rig's cached mathlib `5fcc665`; `main` has since bumped to `e21ec05`
(#5887), which touched none of these files. CI verifies against the new pins.

Provenance: none — this is a refactor of already-merged TauCeti code, replacing four local
proofs with a mathlib lemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
