### PR TITLE
feat(FormalGroup): the inverse law of the group law at parameters

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
@@ -41,8 +41,12 @@ universal curve, and `map_specialize` then carries the conclusion to every `W` �
 it follows from `2 ≠ 0` by comparing linear coefficients.
 
 The pair `(z, ι(z))` enters as the substituted family `Sum.elim X (fun _ ↦ formalInverse W)`,
-written inline throughout, as `Add/Unit.lean` writes its own two families inline: it appears only
-in this file, and naming it would add a definition whose unfolding lemma every proof would carry.
+written inline throughout, as `Add/Unit.lean` writes its own two families inline: naming it would
+add a definition whose unfolding lemma every proof would carry. `FormalGroup/PairEval.lean` writes
+the same family inline for the same reason when it transports `subst_invPair_formalAdd` through
+evaluation, but takes `hasSubst_invPair` from here rather than rebuilding it — that witness is
+exported for exactly this transport, because `MvPowerSeries.aeval_subst` needs a `HasSubst` for
+the very family the two public `subst_invPair_*` results are stated about.
 
 ## References
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Inverse.lean
@@ -81,7 +81,7 @@ variable {O : Type*} [CommRing O] (W : WeierstrassCurve O)
 
 /-- Substituting `z` for the first parameter and `ι(z)` for the second is a legitimate
 substitution: both series have vanishing constant coefficient. -/
-private theorem hasSubst_invPair :
+theorem hasSubst_invPair :
     HasSubst (Sum.elim X (fun _ ↦ formalInverse W) : Unit ⊕ Unit → MvPowerSeries Unit O) :=
   hasSubst_pair (constantCoeff_X ()) (constantCoeff_formalInverse W)
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -275,9 +275,6 @@ is the additive inverse of `t` under the group law read at parameters. -/
 theorem formalAddEval_formalInverseEval {t : O} (ht : PowerSeries.HasEval t)
     (hι : PowerSeries.HasEval (W.formalInverseEval t)) :
     W.formalAddEval t (W.formalInverseEval t) = 0 := by
-  have hsub : MvPowerSeries.HasSubst (Sum.elim MvPowerSeries.X (fun _ ↦ formalInverse W) :
-      Unit ⊕ Unit → MvPowerSeries Unit O) :=
-    MvPowerSeries.hasSubst_pair (MvPowerSeries.constantCoeff_X ()) (constantCoeff_formalInverse W)
   have hid : (algebraMap O O) = RingHom.id O := rfl
   -- Evaluating the substituted pair at `t` is evaluating at the pair `(t, ι(t))`.
   have hfam : (fun s : Unit ⊕ Unit ↦ MvPowerSeries.eval₂ (RingHom.id O) (fun _ : Unit ↦ t)
@@ -290,7 +287,7 @@ theorem formalAddEval_formalInverseEval {t : O} (ht : PowerSeries.HasEval t)
         (Sum.elim MvPowerSeries.X (fun _ ↦ formalInverse W) s)) := by
     simp only [MvPowerSeries.coe_aeval, hid, hfam]
     exact hasEval_pair ht hι
-  have h := MvPowerSeries.aeval_subst hsub
+  have h := MvPowerSeries.aeval_subst W.hasSubst_invPair
     (MvPowerSeries.continuous_aeval (PowerSeries.hasEval ht)) hpair W.formalAdd
   rw [W.subst_invPair_formalAdd] at h
   simpa [formalAddEval, MvPowerSeries.coe_aeval, hid, hfam, map_zero] using h.symm

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -66,7 +66,7 @@ Adapted from Michael Stoll's `EllipticCurves` project
 `thirdRootEval_mem`, `thirdRootEval_relation`, `addEval_eq`, `addEval_sub_add_mem` and
 `addEval_iotaEval`.
 
-Three things are spelled differently here.
+Four things are spelled differently here.
 
 * The source's `eval_pair_rename` transports along `MvPowerSeries.rename`; this repository builds
   the one-variable series into two variables with `PowerSeries.toMvPowerSeries` instead, so the
@@ -271,6 +271,7 @@ theorem formalAddEval_eq {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
 
 /-- **The inverse law at parameters**: `F(t, ι(t)) = 0`, so the value of the inverse series at `t`
 is the additive inverse of `t` under the group law read at parameters. -/
+@[simp]
 theorem formalAddEval_formalInverseEval {t : O} (ht : PowerSeries.HasEval t)
     (hι : PowerSeries.HasEval (W.formalInverseEval t)) :
     W.formalAddEval t (W.formalInverseEval t) = 0 := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -8,6 +8,8 @@ module
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Eval
 public import TauCeti.RingTheory.MvPowerSeries.Substitution
+-- Proof-only: supplies the series-level inverse law `F(z, ι(z)) = 0`, named in no statement here.
+import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Inverse
 
 /-!
 # Evaluating the chord construction at a pair of parameters
@@ -37,6 +39,7 @@ variables, so `MvPowerSeries.hasEval_of_finite_of_isTopologicallyNilpotent` appl
 * `WeierstrassCurve.formalThirdRootEval_relation` : Vieta's formula at a pair, cleared of the
   inverse of the cubic's leading coefficient.
 * `WeierstrassCurve.formalAddEval_eq` : `F(t₁, t₂) = ι(t₃(t₁, t₂))`.
+* `WeierstrassCurve.formalAddEval_formalInverseEval` : `F(t, ι(t)) = 0`, the inverse law.
 * `WeierstrassCurve.formalAddEval_sub_add_mem` : `F(t₁, t₂) - (t₁ + t₂) ∈ I ^ (2 * k)` for
   parameters in `I ^ k`, so the group law is `t₁ + t₂` to first order.
 
@@ -60,7 +63,8 @@ Adapted from Michael Stoll's `EllipticCurves` project
 `EllipticCurves/WeierstrassFormalGroup/Eval.lean` — its pair-evaluation layer, declarations
 `slopeEval`, `interceptEval`, `thirdRootEval`, `addEval`, `hasEval_pairElim`, `eval_pair_rename`,
 `eval_pair_subst_single`, `slopeEval_mul_sub`, `interceptEval_eq`, `slopeEval_mem`,
-`thirdRootEval_mem`, `thirdRootEval_relation`, `addEval_eq` and `addEval_sub_add_mem`.
+`thirdRootEval_mem`, `thirdRootEval_relation`, `addEval_eq`, `addEval_sub_add_mem` and
+`addEval_iotaEval`.
 
 Three things are spelled differently here.
 
@@ -73,6 +77,9 @@ Three things are spelled differently here.
   `FormalGroup/Eval.lean`.
 * The source evaluates through its own `ChabautyColeman.MvPSeries.eval`, a wrapper for
   `MvPowerSeries.eval₂ (RingHom.id _)`, which is not ported.
+* The source writes the evaluated inverse series as `iotaEval`; here it is
+  `FormalGroup/Eval.lean`'s `formalInverseEval`, so its `addEval_iotaEval` is
+  `formalAddEval_formalInverseEval`.
 -/
 
 public section
@@ -261,6 +268,31 @@ theorem formalAddEval_eq {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
   rw [← W.formalAdd_def] at h
   simpa [formalAddEval, W.formalInverseEval_def, MvPowerSeries.coe_aeval, PowerSeries.eval₂,
     ← W.formalThirdRootEval_def] using h
+
+/-- **The inverse law at parameters**: `F(t, ι(t)) = 0`, so the value of the inverse series at `t`
+is the additive inverse of `t` under the group law read at parameters. -/
+theorem formalAddEval_formalInverseEval {t : O} (ht : PowerSeries.HasEval t)
+    (hι : PowerSeries.HasEval (W.formalInverseEval t)) :
+    W.formalAddEval t (W.formalInverseEval t) = 0 := by
+  have hsub : MvPowerSeries.HasSubst (Sum.elim MvPowerSeries.X (fun _ ↦ formalInverse W) :
+      Unit ⊕ Unit → MvPowerSeries Unit O) :=
+    MvPowerSeries.hasSubst_pair (MvPowerSeries.constantCoeff_X ()) (constantCoeff_formalInverse W)
+  have hid : (algebraMap O O) = RingHom.id O := rfl
+  -- Evaluating the substituted pair at `t` is evaluating at the pair `(t, ι(t))`.
+  have hfam : (fun s : Unit ⊕ Unit ↦ MvPowerSeries.eval₂ (RingHom.id O) (fun _ : Unit ↦ t)
+        (Sum.elim MvPowerSeries.X (fun _ ↦ formalInverse W) s)) =
+      Sum.elim (fun _ ↦ t) fun _ ↦ W.formalInverseEval t := by
+    funext s
+    rcases s with _ | _ <;> simp [W.formalInverseEval_def, PowerSeries.eval₂]
+  have hpair : MvPowerSeries.HasEval
+      (fun s : Unit ⊕ Unit ↦ MvPowerSeries.aeval (PowerSeries.hasEval ht)
+        (Sum.elim MvPowerSeries.X (fun _ ↦ formalInverse W) s)) := by
+    simp only [MvPowerSeries.coe_aeval, hid, hfam]
+    exact hasEval_pair ht hι
+  have h := MvPowerSeries.aeval_subst hsub
+    (MvPowerSeries.continuous_aeval (PowerSeries.hasEval ht)) hpair W.formalAdd
+  rw [W.subst_invPair_formalAdd] at h
+  simpa [formalAddEval, MvPowerSeries.coe_aeval, hid, hfam, map_zero] using h.symm
 
 /-- **The group law is `t₁ + t₂` to first order**: at parameters of `I ^ k` the addition series
 deviates from their sum by an element of `I ^ (2 * k)`, because it agrees with `z₁ + z₂` below


### PR DESCRIPTION
Transports the series-level inverse law `F(z, ι(z)) = 0` to parameters:

```lean
theorem formalAddEval_formalInverseEval {t : O} (ht : PowerSeries.HasEval t)
    (hι : PowerSeries.HasEval (W.formalInverseEval t)) :
    W.formalAddEval t (W.formalInverseEval t) = 0
```

so the value of the inverse series at `t` is the additive inverse of `t` under the group law
read at parameters. This is the prerequisite for additivity of `formalPoint`.

The proof is the mirror of `formalAddEval_eq`'s transport: there the inner evaluation is at the
pair and the composed family is single-variable, here the inner evaluation is single-variable and
the composed family is the pair. The substitution witness is rebuilt inline from the public
`MvPowerSeries.hasSubst_pair`, `MvPowerSeries.constantCoeff_X` and `constantCoeff_formalInverse`
rather than re-deriving anything, so `Add/Inverse` is needed only for the series law itself and
is imported plainly (proof-only), not re-exported.

Two hypotheses rather than one, matching the neighbouring `formalWEval_formalInverseEval` and
`formalInverseEval_formalInverseEval`: these identities need no ideal, and
`FormalGroup/Eval.lean`'s `hasEval_formalInverseEval` is the documented adic route to the second.

Placed beside `formalAddEval_eq` so the identity laws sit together and the filtration-membership
results stay a separate cluster.

**Roadmap node.** `EllipticCurves/README.md`, `### Layer 1: isogenies, the dual, the invariant
differential, and formal groups (AEC II.2, III.4-6, IV)`, the bullet *"The formal group - four
milestones with four different hypothesis sets, not one"*, milestone **(iii)**: *"Convergence: over
a complete valued field, `Ê(𝔪)` as an honest group of points."*

`Ê(𝔪)` being an honest *group* needs the group axioms at parameters, and the inverse axiom is the
one this PR supplies: `formalAddEval t (formalInverseEval t) = 0` says the value of the inverse
series at `t` is the additive inverse of `t` under `formalAddEval`. Associativity and the identity
are already in place at the parameter level; without this law the parameter-level operation is a
magma with no inverses, so no group structure can be built on `𝔪` and milestone (iii) cannot close.
It is also the prerequisite for additivity of `formalPoint`, which is how the group structure is
transported to actual points on the curve. That same roadmap bullet names the port source: *"the
existing sorry-free Stoll development (provenance) is the port source"*.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"formal-group-inverse-law-at-parameters"}-->

Provenance: github.com/MichaelStollBayreuth/EllipticCurves @ 66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e,
Apache-2.0, `EllipticCurves/WeierstrassFormalGroup/Eval.lean`, declaration `addEval_iotaEval`
(the source writes the evaluated inverse series as `iotaEval`; here it is `formalInverseEval`).
Adapted, not rederived: the source evaluates through its own `MvPSeries.eval` wrapper, which this
repository does not port, so the transport goes through `MvPowerSeries.aeval_subst` and
`MvPowerSeries.coe_aeval`; and the source states everything over `IsLocalRing.maximalIdeal O` at
`k = 1`, deriving its single hypothesis from that membership, where this statement is ideal-free.
