### PR TITLE
refactor(Subgroup): put `center_le_ker` in the root `MonoidHom` namespace

### DIFF
--- a/TauCeti/Algebra/Group/Subgroup/Map.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Map.lean
@@ -35,7 +35,7 @@ uses it rather than repeating the composition of `MulEquiv.subgroupMap` with
   `f` is.
 * `TauCeti.Subgroup.map_center_le`: a surjective homomorphism carries central elements to central
   elements.
-* `TauCeti.MonoidHom.center_le_ker`: the centre lies in the kernel of a surjection onto a
+* `MonoidHom.center_le_ker`: the centre lies in the kernel of a surjection onto a
   centreless group.
 * `TauCeti.Subgroup.map_commutator_eq_commutator`: a surjective homomorphism carries the derived
   subgroup onto the derived subgroup.
@@ -72,7 +72,7 @@ theorem Subgroup.map_center_eq_center (e : G ≃* H) :
   exact Subgroup.map_center_le (e.symm : H →* G) e.symm.surjective ⟨y, hy, rfl⟩
 
 /-- The centre of a group lies in the kernel of every surjection onto a centreless group. -/
-theorem MonoidHom.center_le_ker (f : G →* H) (hf : Function.Surjective f)
+theorem _root_.MonoidHom.center_le_ker (f : G →* H) (hf : Function.Surjective f)
     (hH : Subgroup.center H = ⊥) : Subgroup.center G ≤ f.ker := by
   intro x hx
   have hfx := Subgroup.map_center_le f hf ⟨x, hx, rfl⟩

--- a/TauCeti/GroupTheory/DerivedCentralQuotient.lean
+++ b/TauCeti/GroupTheory/DerivedCentralQuotient.lean
@@ -120,7 +120,7 @@ theorem card_dvd_card : Nat.card (DerivedCentralQuotient G) ∣ Nat.card G :=
 quotient. -/
 def lift {K : Type*} [Group K] (f : ↥(commutator G) →* K) (hf : Function.Surjective f)
     (hK : center K = ⊥) : DerivedCentralQuotient G →* K :=
-  QuotientGroup.lift _ f (TauCeti.MonoidHom.center_le_ker f hf hK)
+  QuotientGroup.lift _ f (MonoidHom.center_le_ker f hf hK)
 
 @[simp]
 theorem lift_mk {K : Type*} [Group K] (f : ↥(commutator G) →* K) (hf : Function.Surjective f)
@@ -141,7 +141,7 @@ the quotient sits between `[G, G]` and the centreless group it was mapped onto. 
 theorem lift_surjective {K : Type*} [Group K] (f : ↥(commutator G) →* K)
     (hf : Function.Surjective f) (hK : center K = ⊥) : Function.Surjective (lift f hf hK) :=
   QuotientGroup.lift_surjective_of_surjective _ f hf
-    (TauCeti.MonoidHom.center_le_ker f hf hK)
+    (MonoidHom.center_le_ker f hf hK)
 
 /-! ### The recipe on groups it has already succeeded on -/
 


### PR DESCRIPTION
`center_le_ker` takes an explicit `f : G →* H` and concludes about `f.ker`, so its home is the root
`MonoidHom` namespace, not `TauCeti.MonoidHom`. `scripts/lint-dot-notation.py` flags it for exactly
that reason; rooting it takes the count from **1003 to 1002 with 0 new** findings.

Both call sites name the theorem **in full** as `TauCeti.MonoidHom.center_le_ker`
(`GroupTheory/DerivedCentralQuotient.lean:123` and `:144`), so rooting deletes the path they use and
they are rewritten here, along with the module docstring's entry. No reference to the old path
remains.

**Why only this declaration, when the file has two `MonoidHom` theorems.** The lint's rule is that
a finding needs "a Mathlib namespace candidate and a corresponding *explicit* receiver type". The
other one, `MonoidHom.subgroupComap_injective_of_injective`, takes its hom **implicitly**
(`{f : H →* G}`), so dot notation could never apply to it and the gate does not flag it. Rooting it
would be a different question from the one the lint asks, so it is left alone.

Checks run before pushing: the longest added line is 82 characters; the short name is never used
unqualified; `center_le_ker` does not exist anywhere in the pinned Mathlib (the near-miss grep hits
are `lowerCentralSeries_one_inf_center_le_ker_traceForm`, a different declaration).

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp