### PR TITLE
refactor: regroup a finite sum by the fibres of a map

### DIFF
--- a/TauCeti/Algebra/BigOperators/Finset/Fiber.lean
+++ b/TauCeti/Algebra/BigOperators/Finset/Fiber.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+
+/-!
+# Regrouping a finite sum by the fibres of a map
+
+A sum over a finite type can be taken fibrewise along any map out of it: sum over the values the
+map actually takes, and within each value over the indices sent there.
+
+Mathlib's `Fintype.sum_fiberwise` says this with the outer sum ranging over the whole codomain,
+which needs the codomain finite. The version here indexes the outer sum by the *image* instead,
+so it applies to a map into an arbitrary type — the situation whenever the codomain is a
+quotient or a subtype with no finiteness available.
+
+## Main results
+
+* `TauCeti.sum_eq_sum_image_fiber`: `∑ i, F i` is the sum, over the values `g` takes, of the sums
+  of `F` over the fibres of `g`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset
+
+/-- **A finite sum is the sum over the values actually taken of the sums over their fibres.**
+Summing `F` over all of `ι` is summing, over each `k` in the image of `g`, the contribution of
+the indices `g` sends to `k`.
+
+The outer index is `Finset.univ.image g` rather than all of `κ`, so no finiteness of `κ` is
+needed; that is the difference from `Fintype.sum_fiberwise`. -/
+theorem sum_eq_sum_image_fiber {ι κ M : Type*} [Fintype ι] [DecidableEq κ] [AddCommMonoid M]
+    (g : ι → κ) (F : ι → M) :
+    ∑ i, F i = ∑ k ∈ univ.image g, ∑ i : {i // g i = k}, F i := by
+  rw [← sum_fiberwise_of_maps_to (g := g) fun i _ ↦ mem_image_of_mem _ (mem_univ i)]
+  exact sum_congr rfl fun k _ ↦
+    sum_subtype (p := fun i ↦ g i = k) (univ.filter fun i ↦ g i = k) (fun i ↦ by simp) F
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.BigOperators.Finset.Fiber
 public import TauCeti.NumberTheory.HeckeRing.Multiplicity.Handedness
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.CuspRing
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Ring
@@ -338,31 +339,6 @@ lemma card_pairs_pairCoset_rightCoset_eq_multiplicity {x : GL (Fin 2) ℚ}
 variable (D₁ D₂)
 
 open Classical in
-/-- **A sum over pairs of right cosets is the sum over the double cosets they land in.** The
-pairs `(v, w)` are partitioned by `pairCoset D₁ D₂`, so summing any `F` over all of them is
-summing, over each double coset `D` met, the contribution of the pairs landing in `D`.
-
-A composite of two slash sums is naturally indexed by pairs of right cosets, while the
-multiplicity-weighted form of the composition law is indexed by double cosets. This is the
-identity between those two index sets, before any weight is attached: `F` is arbitrary, so no
-slash, weight or character enters.
-
-Only the double cosets actually met are summed over, which is why the outer index is the image
-of `pairCoset D₁ D₂` rather than all of `HeckeCoset Δ Γ₁ Γ₃`. Mathlib's `Fintype.sum_fiberwise`
-is the same regrouping over the whole codomain, but it needs that codomain finite, and no
-finiteness of `HeckeCoset Δ Γ₁ Γ₃` is assumed here. -/
-lemma sum_eq_sum_pairCoset_fiber {M : Type*} [AddCommMonoid M]
-    (F : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
-      DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹ → M) :
-    ∑ p, F p = ∑ D ∈ Finset.univ.image (pairCoset D₁ D₂),
-      ∑ q : {q // pairCoset D₁ D₂ q = D}, F q := by
-  rw [← Finset.sum_fiberwise_of_maps_to (g := pairCoset D₁ D₂)
-    (fun p _ ↦ Finset.mem_image_of_mem _ (Finset.mem_univ p))]
-  exact Finset.sum_congr rfl fun D _ ↦
-    Finset.sum_subtype (p := fun q ↦ pairCoset D₁ D₂ q = D)
-      (Finset.univ.filter fun q ↦ pairCoset D₁ D₂ q = D) (fun q ↦ by simp) F
-
-open Classical in
 /-- **The multiplicity-weighted composite**, and with it the general form of the composition law.
 For a `Γ₁`-invariant `f`, the composite of the two slash sums is the sum, over the double cosets
 met by the products `aᵥ b_w`, of Shimura's multiplicity times the slash sum of that coset:
@@ -393,7 +369,8 @@ theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul
   -- points rather than found by synthesis
   let _ : IsHeckeTriple Δ Γ₁ Γ₃ := IsHeckeTriple.trans (H₂ := Γ₂)
   rw [heckeSlashSum_heckeSlashSum, ← Fintype.sum_prod_type',
-    sum_eq_sum_pairCoset_fiber D₁ D₂ fun q ↦ f ∣[k] (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2)]
+    TauCeti.sum_eq_sum_image_fiber (pairCoset D₁ D₂)
+      fun q ↦ f ∣[k] (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2)]
   refine Finset.sum_congr rfl fun D _ ↦ ?_
   exact sum_slash_eq_nsmul_heckeSlashSum k D _ _ (fun i ↦ pairCoset_eq_iff.mp i.2)
     (fun _ hx ↦ card_pairs_pairCoset_rightCoset_eq_multiplicity hx) f hf

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -342,11 +342,10 @@ open Classical in
 pairs `(v, w)` are partitioned by `pairCoset D₁ D₂`, so summing any `F` over all of them is
 summing, over each double coset `D` met, the contribution of the pairs landing in `D`.
 
-This is pure index bookkeeping — no slash, no weight and no character appears — and it is the
-regrouping step shared by `heckeSlashSum_heckeSlashSum_eq_sum_nsmul` below and its
-nebentypus-weighted counterpart `twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_nsmul` in
-`HeckeSlash/Nebentypus/Composition.lean`, which differ only in the `F` they supply and in the
-collapse lemma they then apply to each fibre.
+A composite of two slash sums is naturally indexed by pairs of right cosets, while the
+multiplicity-weighted form of the composition law is indexed by double cosets. This is the
+identity between those two index sets, before any weight is attached: `F` is arbitrary, so no
+slash, weight or character enters.
 
 Only the double cosets actually met are summed over, which is why the outer index is the image
 of `pairCoset D₁ D₂` rather than all of `HeckeCoset Δ Γ₁ Γ₃`. Mathlib's `Fintype.sum_fiberwise`

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -338,6 +338,32 @@ lemma card_pairs_pairCoset_rightCoset_eq_multiplicity {x : GL (Fin 2) ℚ}
 variable (D₁ D₂)
 
 open Classical in
+/-- **A sum over pairs of right cosets is the sum over the double cosets they land in.** The
+pairs `(v, w)` are partitioned by `pairCoset D₁ D₂`, so summing any `F` over all of them is
+summing, over each double coset `D` met, the contribution of the pairs landing in `D`.
+
+This is pure index bookkeeping — no slash, no weight and no character appears — and it is the
+regrouping step shared by `heckeSlashSum_heckeSlashSum_eq_sum_nsmul` below and its
+nebentypus-weighted counterpart `twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_nsmul` in
+`HeckeSlash/Nebentypus/Composition.lean`, which differ only in the `F` they supply and in the
+collapse lemma they then apply to each fibre.
+
+Only the double cosets actually met are summed over, which is why the outer index is the image
+of `pairCoset D₁ D₂` rather than all of `HeckeCoset Δ Γ₁ Γ₃`. Mathlib's `Fintype.sum_fiberwise`
+is the same regrouping over the whole codomain, but it needs that codomain finite, and no
+finiteness of `HeckeCoset Δ Γ₁ Γ₃` is assumed here. -/
+lemma sum_eq_sum_pairCoset_fiber {M : Type*} [AddCommMonoid M]
+    (F : DecompQuotient Γ₂ Γ₁ (D₁.out : GL (Fin 2) ℚ)⁻¹ ×
+      DecompQuotient Γ₃ Γ₂ (D₂.out : GL (Fin 2) ℚ)⁻¹ → M) :
+    ∑ p, F p = ∑ D ∈ Finset.univ.image (pairCoset D₁ D₂),
+      ∑ q : {q // pairCoset D₁ D₂ q = D}, F q := by
+  rw [← Finset.sum_fiberwise_of_maps_to (g := pairCoset D₁ D₂)
+    (fun p _ ↦ Finset.mem_image_of_mem _ (Finset.mem_univ p))]
+  exact Finset.sum_congr rfl fun D _ ↦
+    Finset.sum_subtype (p := fun q ↦ pairCoset D₁ D₂ q = D)
+      (Finset.univ.filter fun q ↦ pairCoset D₁ D₂ q = D) (fun q ↦ by simp) F
+
+open Classical in
 /-- **The multiplicity-weighted composite**, and with it the general form of the composition law.
 For a `Γ₁`-invariant `f`, the composite of the two slash sums is the sum, over the double cosets
 met by the products `aᵥ b_w`, of Shimura's multiplicity times the slash sum of that coset:
@@ -368,12 +394,8 @@ theorem heckeSlashSum_heckeSlashSum_eq_sum_nsmul
   -- points rather than found by synthesis
   let _ : IsHeckeTriple Δ Γ₁ Γ₃ := IsHeckeTriple.trans (H₂ := Γ₂)
   rw [heckeSlashSum_heckeSlashSum, ← Fintype.sum_prod_type',
-    ← Finset.sum_fiberwise_of_maps_to (g := pairCoset D₁ D₂)
-      (fun p _ ↦ Finset.mem_image_of_mem _ (Finset.mem_univ p))]
+    sum_eq_sum_pairCoset_fiber D₁ D₂ fun q ↦ f ∣[k] (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2)]
   refine Finset.sum_congr rfl fun D _ ↦ ?_
-  rw [Finset.sum_subtype (p := fun q ↦ pairCoset D₁ D₂ q = D)
-    (Finset.univ.filter fun q ↦ pairCoset D₁ D₂ q = D) (fun q ↦ by simp)
-    fun q ↦ f ∣[k] (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2)]
   exact sum_slash_eq_nsmul_heckeSlashSum k D _ _ (fun i ↦ pairCoset_eq_iff.mp i.2)
     (fun _ hx ↦ card_pairs_pairCoset_rightCoset_eq_multiplicity hx) f hf
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
@@ -223,7 +223,7 @@ theorem twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_nsmul
           (D₁.out : GL (Fin 2) ℚ)⁻¹ (D.out : GL (Fin 2) ℚ)⁻¹ •
             twistedHeckeSlashSum k χ D f := by
   rw [twistedHeckeSlashSum_twistedHeckeSlashSum, ← Fintype.sum_prod_type',
-    sum_eq_sum_pairCoset_fiber D₁ D₂ fun q ↦ (delta0NebentypusChar N χ
+    TauCeti.sum_eq_sum_image_fiber (pairCoset D₁ D₂) fun q ↦ (delta0NebentypusChar N χ
       ⟨rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2,
         mul_mem (rightCosetRep_mem_Delta0 D₁ q.1) (rightCosetRep_mem_Delta0 D₂ q.2)⟩ : ℂ) •
           (f ∣[k] (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2))]

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
@@ -223,15 +223,11 @@ theorem twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_nsmul
           (D₁.out : GL (Fin 2) ℚ)⁻¹ (D.out : GL (Fin 2) ℚ)⁻¹ •
             twistedHeckeSlashSum k χ D f := by
   rw [twistedHeckeSlashSum_twistedHeckeSlashSum, ← Fintype.sum_prod_type',
-    ← Finset.sum_fiberwise_of_maps_to (g := pairCoset D₁ D₂)
-      (fun p _ ↦ Finset.mem_image_of_mem _ (Finset.mem_univ p))]
-  refine Finset.sum_congr rfl fun D _ ↦ ?_
-  rw [Finset.sum_subtype (p := fun q ↦ pairCoset D₁ D₂ q = D)
-    (Finset.univ.filter fun q ↦ pairCoset D₁ D₂ q = D) (fun q ↦ by simp)
-    fun q ↦ (delta0NebentypusChar N χ
+    sum_eq_sum_pairCoset_fiber D₁ D₂ fun q ↦ (delta0NebentypusChar N χ
       ⟨rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2,
         mul_mem (rightCosetRep_mem_Delta0 D₁ q.1) (rightCosetRep_mem_Delta0 D₂ q.2)⟩ : ℂ) •
           (f ∣[k] (rightCosetRep D₁ q.1 * rightCosetRep D₂ q.2))]
+  refine Finset.sum_congr rfl fun D _ ↦ ?_
   exact sum_nebentypus_smul_slash_eq_nsmul_twistedHeckeSlashSum k χ D _ _
     (fun i ↦ pairCoset_eq_iff.mp i.2)
     (fun _ hx ↦ card_pairs_pairCoset_rightCoset_eq_multiplicity hx) f hf


### PR DESCRIPTION
Roadmap: ModularForms

`heckeSlashSum_heckeSlashSum_eq_sum_nsmul` (`HeckeSlash/Composition.lean`) and its
nebentypus-weighted twin `twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_nsmul`
(`HeckeSlash/Nebentypus/Composition.lean`) both open by regrouping a sum over *pairs* of right
cosets into a sum over the *double cosets* those pairs land in. Each did it the same way —
`Finset.sum_fiberwise_of_maps_to` along `pairCoset D₁ D₂`, then `Finset.sum_subtype` to turn each
filtered fibre into a sum over its subtype — and the five lines differed only in the summand.

That step has nothing to do with Hecke data, so it is stated for an arbitrary map out of a finite
type, in `TauCeti/Algebra/BigOperators/Finset/Fiber.lean`:

```lean
theorem TauCeti.sum_eq_sum_image_fiber {ι κ M : Type*} [Fintype ι] [DecidableEq κ]
    [AddCommMonoid M] (g : ι → κ) (F : ι → M) :
    ∑ i, F i = ∑ k ∈ univ.image g, ∑ i : {i // g i = k}, F i
```

Both proofs instantiate it at `pairCoset D₁ D₂` and keep only the collapse lemma they genuinely
differ in — one supplies `sum_slash_eq_nsmul_heckeSlashSum`, the other
`sum_nebentypus_smul_slash_eq_nsmul_twistedHeckeSlashSum`.

### Why the image, and not the whole codomain

Mathlib's `Fintype.sum_fiberwise` states the same regrouping:

```lean
∑ j, ∑ i : {i // g i = j}, f i = ∑ i, f i
```

but its outer sum ranges over **all** of the codomain and so carries `[Fintype κ]`. At the call
sites the codomain is `HeckeCoset Δ Γ₁ Γ₃`, whose finiteness is deliberately not assumed — as
`heckeSlashSum_heckeSlashSum_eq_sum_nsmul`'s own docstring says, "no finiteness is assumed beyond
the two input Hecke triples". That is why both statements index their outer sum by
`Finset.univ.image (pairCoset D₁ D₂)`, and why the image-restricted form is the one needed. The
new lemma's docstring records this as the difference from `Fintype.sum_fiberwise`.

The proof uses `Finset.sum_fiberwise_of_maps_to` and `Finset.sum_subtype` — the two mathlib
lemmas the call sites were invoking directly.

The file sits beside the existing `TauCeti/Algebra/BigOperators/Finset/Range.lean`, the
directory this repository already uses for generic finite-sum identities.

No statement changes to either composition theorem, and nothing outside these two proofs moves.

### Verification

- `lake build` clean for the new module, both consumers and the downstream `Nebentypus/Action`.
- 13-linter run: 0 errors in 555 declarations.
- No line over 100 characters.

Local building used the rig's cached mathlib `5fcc665`; `main` is on `e21ec05` (#5887), which
touched none of these files. CI verifies against the new pins.

Provenance: none — this is a refactor of already-merged TauCeti code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
