### PR TITLE
feat(FormalGroup): the unit laws of the group law at parameters

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -40,6 +40,8 @@ variables, so `MvPowerSeries.hasEval_of_finite_of_isTopologicallyNilpotent` appl
   inverse of the cubic's leading coefficient.
 * `WeierstrassCurve.formalAddEval_eq` : `F(t₁, t₂) = ι(t₃(t₁, t₂))`.
 * `WeierstrassCurve.formalAddEval_formalInverseEval` : `F(t, ι(t)) = 0`, the inverse law.
+* `WeierstrassCurve.formalAddEval_zero_right` and
+  `WeierstrassCurve.formalAddEval_zero_left` : the unit laws `F(t, 0) = t` and `F(0, t) = t`.
 * `WeierstrassCurve.formalAddEval_sub_add_mem` : `F(t₁, t₂) - (t₁ + t₂) ∈ I ^ (2 * k)` for
   parameters in `I ^ k`, so the group law is `t₁ + t₂` to first order, and
   `WeierstrassCurve.formalAddEval_mem` : each level `I ^ k` is therefore closed under the
@@ -67,6 +69,15 @@ Adapted from Michael Stoll's `EllipticCurves` project
 `eval_pair_subst_single`, `slopeEval_mul_sub`, `interceptEval_eq`, `slopeEval_mem`,
 `thirdRootEval_mem`, `thirdRootEval_relation`, `addEval_eq`, `addEval_sub_add_mem` and
 `addEval_iotaEval`.
+
+The unit laws `formalAddEval_zero_right` and `formalAddEval_zero_left` follow the same project's
+`EllipticCurves/Mathlib/Chabauty/FormalGroupLaw/Points.lean`, where they are the `zero_add` and
+`add_zero` fields of the `AddCommMonoid` instance on `FormalGroupLaw.Points`
+(`def Points _Φ := ι → maximalIdeal O`). That generic formal-group scaffolding is not ported
+here: Mathlib's `RingTheory/FormalGroup` supersedes it, and its `FormalGroup.Point` is a
+different object — series carrying `PowerSeries.HasSubst`, not elements of an ideal — so the
+laws are stated as standalone lemmas about `formalAddEval`, ideal-free and taking
+`PowerSeries.HasEval`.
 
 Four things are spelled differently here.
 
@@ -323,5 +334,56 @@ theorem formalAddEval_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O
   have := Ideal.add_mem _ (hle (W.formalAddEval_sub_add_mem hI hk₁ hk₂))
     (Ideal.add_mem _ hk₁ hk₂)
   simpa using this
+
+/-- **The right unit law at parameters**: `F(t, 0) = t`, so the origin's parameter is neutral for
+the group law read at parameters. -/
+@[simp]
+theorem formalAddEval_zero_right {t : O} (ht : PowerSeries.HasEval t) :
+    W.formalAddEval t 0 = t := by
+  have hfam : (fun s : Unit ⊕ Unit ↦ MvPowerSeries.eval₂ (RingHom.id O) (fun _ : Unit ↦ t)
+        ((Sum.elim MvPowerSeries.X (fun _ ↦ 0) :
+          Unit ⊕ Unit → MvPowerSeries Unit O) s)) =
+      Sum.elim (fun _ ↦ t) fun _ ↦ (0 : O) := by
+    funext s
+    rcases s with _ | _
+    · simp
+    · simpa using
+        MvPowerSeries.eval₂_C (φ := RingHom.id O) (a := fun _ : Unit ↦ t) (0 : O)
+  have hev : MvPowerSeries.HasEval fun s : Unit ⊕ Unit ↦
+      MvPowerSeries.aeval (PowerSeries.hasEval ht)
+        ((Sum.elim MvPowerSeries.X (fun _ ↦ 0) : Unit ⊕ Unit → MvPowerSeries Unit O) s) := by
+    simp only [MvPowerSeries.coe_aeval, Algebra.algebraMap_self, hfam]
+    exact hasEval_pair ht IsTopologicallyNilpotent.zero
+  have h := MvPowerSeries.aeval_subst
+    (MvPowerSeries.hasSubst_pair (q₁ := MvPowerSeries.X ()) (q₂ := 0) (by simp) (by simp))
+    (MvPowerSeries.continuous_aeval (PowerSeries.hasEval ht)) hev W.formalAdd
+  rw [W.subst_unitR_formalAdd] at h
+  simpa [formalAddEval, MvPowerSeries.coe_aeval, Algebra.algebraMap_self, hfam,
+    PowerSeries.X, MvPowerSeries.eval₂_X] using h.symm
+
+/-- **The left unit law at parameters**: `F(0, t) = t`. -/
+@[simp]
+theorem formalAddEval_zero_left {t : O} (ht : PowerSeries.HasEval t) :
+    W.formalAddEval 0 t = t := by
+  have hfam : (fun s : Unit ⊕ Unit ↦ MvPowerSeries.eval₂ (RingHom.id O) (fun _ : Unit ↦ t)
+        ((Sum.elim (fun _ ↦ 0) MvPowerSeries.X :
+          Unit ⊕ Unit → MvPowerSeries Unit O) s)) =
+      Sum.elim (fun _ ↦ (0 : O)) fun _ ↦ t := by
+    funext s
+    rcases s with _ | _
+    · simpa using
+        MvPowerSeries.eval₂_C (φ := RingHom.id O) (a := fun _ : Unit ↦ t) (0 : O)
+    · simp
+  have hev : MvPowerSeries.HasEval fun s : Unit ⊕ Unit ↦
+      MvPowerSeries.aeval (PowerSeries.hasEval ht)
+        ((Sum.elim (fun _ ↦ 0) MvPowerSeries.X : Unit ⊕ Unit → MvPowerSeries Unit O) s) := by
+    simp only [MvPowerSeries.coe_aeval, Algebra.algebraMap_self, hfam]
+    exact hasEval_pair IsTopologicallyNilpotent.zero ht
+  have h := MvPowerSeries.aeval_subst
+    (MvPowerSeries.hasSubst_pair (q₁ := 0) (q₂ := MvPowerSeries.X ()) (by simp) (by simp))
+    (MvPowerSeries.continuous_aeval (PowerSeries.hasEval ht)) hev W.formalAdd
+  rw [W.subst_unitL_formalAdd] at h
+  simpa [formalAddEval, MvPowerSeries.coe_aeval, Algebra.algebraMap_self, hfam,
+    PowerSeries.X, MvPowerSeries.eval₂_X] using h.symm
 
 end WeierstrassCurve


### PR DESCRIPTION
Transports the series-level unit laws to parameters:

```lean
@[simp] theorem formalAddEval_zero_right (ht : PowerSeries.HasEval t) : W.formalAddEval t 0 = t
@[simp] theorem formalAddEval_zero_left  (ht : PowerSeries.HasEval t) : W.formalAddEval 0 t = t
```

so the origin's parameter is neutral for the group law read at parameters. Each is the
evaluation of `subst_unitR_formalAdd` / `subst_unitL_formalAdd`, by the same
`MvPowerSeries.aeval_subst` + `MvPowerSeries.coe_aeval` transport as
`formalAddEval_formalInverseEval`.

**Roadmap node.** `EllipticCurves/README.md`, `### Layer 1: isogenies, the dual, the invariant
differential, and formal groups (AEC II.2, III.4-6, IV)`, the bullet *"The formal group - four
milestones with four different hypothesis sets, not one"*, milestone **(iii)**: *"Convergence: over
a complete valued field, `Ê(𝔪)` as an honest group of points."*

`Ê(𝔪)` being a group needs the group axioms *at parameters*, because the object milestone (iii)
asks for is 𝔪 under `formalAddEval` — not Mathlib's `FormalGroup.Point`, which is a different
object (series carrying `PowerSeries.HasSubst`). These two lemmas are the identity axiom. Closure
is `formalAddEval_mem` (#5909) and the inverse axiom is `formalAddEval_formalInverseEval` (#5917);
associativity at parameters is the remaining gap and is deliberately left to its own PR, since it
needs a three-variable evaluation family rather than the pair used here.

The substitution witnesses are **not** promoted out of `Add/Unit.lean`; both unit proofs pass
`MvPowerSeries.hasSubst_pair (by simp) (by simp)` directly, so this PR touches one file and leaves
`Add/Unit.lean` untouched. That is the opposite of the resolution taken on #5917 for
`hasSubst_invPair`, and deliberately so: that witness carries real content
(`constantCoeff_formalInverse`), so rebuilding it duplicated a lemma, whereas `hasSubst_unitR` is
`hasSubst_pair` with both constant-coefficient goals closed by `simp` — no elliptic content at all
— so using the general combinator *is* reuse rather than duplication.

Both proofs call Mathlib's `MvPowerSeries.aeval_subst` directly and convert with
`MvPowerSeries.coe_aeval` in the final `simpa`, exactly as this file's own `formalAddEval_eq`
already does; the two zero-evaluation branches come from Mathlib's `MvPowerSeries.eval₂_C` at `0`.
No local wrapper or specialisation is introduced, so the PR is one file.

A parameter-level commutativity lemma would be a tidier route to the left law from the right one,
but it needs an `eval₂`-of-`rename` transport for `MvPowerSeries` that neither Mathlib nor this
repository has (Mathlib's `eval₂_rename` is `MvPolynomial`-only, and
`RingTheory/MvPowerSeries/Rename.lean` here carries `subst_rename` but no evaluation analogue);
that belongs in its own infrastructure PR.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"formal-group-unit-laws-at-parameters"}-->

Provenance: github.com/MichaelStollBayreuth/EllipticCurves @ 66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e,
Apache-2.0. The source proves the parameter-level unit laws only as fields of the `AddCommMonoid`
instance on its own `FormalGroupLaw.Points` (`EllipticCurves/Mathlib/Chabauty/FormalGroupLaw/Points.lean`,
`def Points _Φ := ι → maximalIdeal O`, instance at line 84), a generic formal-group scaffolding this
repository deliberately does not port because Mathlib's `RingTheory/FormalGroup` supersedes it. The
laws are therefore stated here as standalone lemmas about `formalAddEval`, ideal-free and taking
`PowerSeries.HasEval`, matching `FormalGroup/Eval.lean`'s convention.
