### PR TITLE
refactor(Calculus): put `hasFDerivAt_fderiv` in the root `ContDiffAt` namespace

### DIFF
--- a/TauCeti/Analysis/Calculus/Morse/Linearization.lean
+++ b/TauCeti/Analysis/Calculus/Morse/Linearization.lean
@@ -122,7 +122,7 @@ the Hessian operator. -/
 theorem hasFDerivAt_gradient (hf : ContDiffAt ℝ 2 f x) :
     HasFDerivAt (∇ f) (hessianOperator f x) x := by
   have hfd : HasFDerivAt (fderiv ℝ f) (fderiv ℝ (fderiv ℝ f) x) x :=
-    (hf.fderiv_right (m := 1) (by norm_num)).differentiableAt one_ne_zero |>.hasFDerivAt
+    ContDiffAt.hasFDerivAt_fderiv hf le_rfl
   have h := (InnerProductSpace.toDual ℝ E).symm.toContinuousLinearEquiv.hasFDerivAt.comp x hfd
   -- The composed function is the gradient, by the defining property `toDual_gradient` of `∇ f`.
   have hfun : ⇑(InnerProductSpace.toDual ℝ E).symm.toContinuousLinearEquiv ∘ fderiv ℝ f = ∇ f := by

--- a/TauCeti/Analysis/Calculus/ParametricFDeriv.lean
+++ b/TauCeti/Analysis/Calculus/ParametricFDeriv.lean
@@ -137,7 +137,7 @@ private theorem hasDerivAt_spatialFDeriv_apply_mixed {F : 𝕜 × E → F'}
     HasDerivAt (fun s => spatialFDeriv F x s w)
       (fderiv 𝕜 (fderiv 𝕜 F) (t, x) (1, 0) (0, w)) t := by
   have hDF : HasFDerivAt (fderiv 𝕜 F) (fderiv 𝕜 (fderiv 𝕜 F) (t, x)) (t, x) :=
-    TauCeti.ContDiffAt.hasFDerivAt_fderiv hF le_minSmoothness
+    ContDiffAt.hasFDerivAt_fderiv hF le_minSmoothness
   have hParam :=
     (hDF.comp_hasDerivAt t (hasFDerivAt_prodMk_left t x).hasDerivAt).clm_apply_const (0, w)
   simpa only [spatialFDeriv_apply, Function.comp_apply, ContinuousLinearMap.inl_apply] using hParam
@@ -147,7 +147,7 @@ private theorem hasFDerivAt_timeFDeriv_mixed {F : 𝕜 × E → F'} {t : 𝕜} {
     HasFDerivAt (timeFDeriv F t)
       ((fderiv 𝕜 (fderiv 𝕜 F) (t, x) ∘L ContinuousLinearMap.inr 𝕜 𝕜 E).flip (1, 0)) x := by
   have hDF : HasFDerivAt (fderiv 𝕜 F) (fderiv 𝕜 (fderiv 𝕜 F) (t, x)) (t, x) :=
-    TauCeti.ContDiffAt.hasFDerivAt_fderiv hF le_minSmoothness
+    ContDiffAt.hasFDerivAt_fderiv hF le_minSmoothness
   have hSpatial := (hDF.comp x (hasFDerivAt_prodMk_right t x)).clm_apply_const (1, 0)
   rw [timeFDeriv_eq]
   exact hSpatial
@@ -160,7 +160,7 @@ theorem hasDerivAt_spatialFDeriv {F : 𝕜 × E → F'} {t : 𝕜} {x : E}
   -- derivative of `timeFDeriv F t = fun z ↦ DF (t, z) (1, 0)`. Symmetry of the
   -- second derivative identifies these two mixed partials, pointwise in `w`.
   have hDFdiff : DifferentiableAt 𝕜 (fderiv 𝕜 F) (t, x) :=
-    (TauCeti.ContDiffAt.hasFDerivAt_fderiv hF le_minSmoothness).differentiableAt
+    (ContDiffAt.hasFDerivAt_fderiv hF le_minSmoothness).differentiableAt
   have hdiff : DifferentiableAt 𝕜 (spatialFDeriv F x) t := by
     rw [spatialFDeriv_eq]
     fun_prop

--- a/TauCeti/Analysis/Calculus/SecondDerivative.lean
+++ b/TauCeti/Analysis/Calculus/SecondDerivative.lean
@@ -31,7 +31,7 @@ them.
 
 ## Main results
 
-* `TauCeti.ContDiffAt.hasFDerivAt_fderiv`: at a twice continuously differentiable point,
+* `ContDiffAt.hasFDerivAt_fderiv`: at a twice continuously differentiable point,
   `fderiv 𝕜 g` is differentiable, with derivative the second derivative of `g`.
 * `TauCeti.eventually_fderiv_ne`: where the second derivative is invertible, the differential
   avoids any prescribed value on a punctured neighbourhood of the point.
@@ -51,7 +51,7 @@ variable {𝕜 E F G : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup
 
 /-- At a twice continuously differentiable point, `fderiv 𝕜 g` is differentiable, with derivative
 the second derivative of `g`. -/
-theorem ContDiffAt.hasFDerivAt_fderiv {n : WithTop ℕ∞} {g : E → F} {x : E}
+theorem _root_.ContDiffAt.hasFDerivAt_fderiv {n : WithTop ℕ∞} {g : E → F} {x : E}
     (h : ContDiffAt 𝕜 n g x) (hn : 2 ≤ n) :
     HasFDerivAt (fderiv 𝕜 g) (fderiv 𝕜 (fderiv 𝕜 g) x) x :=
   ((h.fderiv_right (m := 1) (by exact_mod_cast hn)).differentiableAt one_ne_zero).hasFDerivAt


### PR DESCRIPTION
`hasFDerivAt_fderiv` takes an explicit `h : ContDiffAt 𝕜 n g x`, so its home is the root `ContDiffAt`
namespace rather than `TauCeti.ContDiffAt`. `scripts/lint-dot-notation.py` flags it for exactly that
reason; rooting it takes the count from **1002 to 1001 with 0 new** findings.

References split two ways, and only one kind needed touching:

- **three** name it in full — `ParametricFDeriv.lean:140`, `:150`, `:163` — plus the module
  docstring's entry; that path disappears, so these are rewritten;
- **three** inside `SecondDerivative.lean` write `ContDiffAt.hasFDerivAt_fderiv` from within
  `namespace TauCeti`, and are left alone: that text now resolves to the root declaration.

**On why the theorem exists at all**, since it is a one-line composition of Mathlib's
`ContDiffAt.fderiv_right` — the module docstring already answers this, and it is the reason this
file exists:

> "Mathlib supplies the differentiability of `fderiv 𝕜 g` at a twice continuously differentiable
> point through `ContDiffAt.fderiv_right`; this file packages that into the single `HasFDerivAt`
> statement that second-order arguments use, so that the identification is made once rather than at
> each use."

It has six call sites across two modules, so the packaging is load-bearing rather than a restatement.
This PR does not change that judgement either way — it only corrects the namespace.

Longest added line: 87 characters.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp