### PR TITLE
feat(NumberField): raising the base field raises the Artin symbol to f(𝔓/𝔭)

### DIFF
--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -7,10 +7,11 @@ module
 
 public import Mathlib.NumberTheory.RamificationInertia.Galois
 public import Mathlib.RingTheory.Frobenius
+public import TauCeti.Algebra.Group.Conj
 public import TauCeti.NumberTheory.NumberField.Frobenius.Restriction
 public import TauCeti.NumberTheory.NumberField.UnramifiedTower
-import TauCeti.Algebra.Group.Conj
 import TauCeti.NumberTheory.NumberField.Frobenius.DecompositionGroup
+import TauCeti.NumberTheory.NumberField.Frobenius.Tower
 import TauCeti.NumberTheory.NumberField.SplitsCompletely
 
 /-!
@@ -27,6 +28,12 @@ Exercise 2.
 The same reference gives functoriality in a normal tower: restriction maps the Artin symbol of
 `L/K` to the Artin symbol of `M/K`. Unramifiedness in the intermediate extension is derived from
 unramifiedness in the top extension, rather than assumed separately.
+
+Raising the base field is the companion law, and it takes a power: for `K ⊆ M ⊆ L`, the symbol
+of a prime of `𝒪 M` above `𝔭`, read inside `Gal(L/K)`, is the `f(𝔓/𝔭)`-th power of the symbol of
+`𝔭`. Stated on conjugacy classes it needs no normality hypothesis on `M / K` and names no prime
+of `𝒪 L`, both of which the element-level form in
+`TauCeti.NumberTheory.NumberField.Frobenius.Tower` does need.
 
 Finally, the symbol detects complete splitting: it is the identity class exactly when the
 residue degree is one, equivalently when `𝓞 L` has `[L : K]` primes above `𝔭`.
@@ -222,5 +229,52 @@ theorem artinSymbol_eq_one_iff_ncard_primesOver_eq_finrank (𝔭 : Ideal (𝓞 K
   exact (and_iff_right rfl).symm
 
 end SplitsCompletely
+
+section BaseChange
+
+/-!
+### Raising the base field
+
+The companion to `artinSymbol_map_restrictNormalHom`. That law shrinks the top field of a normal
+tower and takes no power; this one raises the base field and takes the power `f(𝔓/𝔭)`.
+-/
+
+/-- **Raising the base field raises the Artin symbol to the residue degree.** For number fields
+`K ⊆ M ⊆ L` with `L / K` and `L / M` Galois and `𝔓` a prime of `𝓞 M` over `𝔭` unramified in `L`,
+the Artin symbol of `𝔓` for `L / M`, read inside `Gal(L/K)` along `AlgEquiv.restrictScalarsHom`,
+is the `f(𝔓/𝔭)`-th power of the Artin symbol of `𝔭` for `L / K`.
+
+This is the conjugacy-class form of `NumberField.restrictScalars_arithFrobAt_eq_pow_inertiaDeg`,
+and unlike that element-level statement it needs no hypothesis of normality on `M / K` and fixes
+no prime of `𝓞 L`. Both are genuine gains, and they are the same gain: the element identity holds
+only for a Frobenius *at a chosen `Q`*, and fails for an arbitrary conjugate when `M / K` is not
+normal, because a conjugate need not stabilize `Q`. Passing to classes quotients exactly by that
+choice, so what is left is an identity of classes with no chosen prime in it. -/
+theorem artinSymbol_map_restrictScalarsHom {M L : Type*} [Field M] [NumberField M]
+    [Field L] [NumberField L] [Algebra K M] [Algebra M L] [Algebra K L]
+    [IsScalarTower K M L] [IsGalois K L] [IsGalois M L]
+    (𝔓 : Ideal (𝓞 M)) [𝔓.IsMaximal] (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal] [𝔓.LiesOver 𝔭]
+    (hurM : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔓],
+      Algebra.IsUnramifiedAt (𝓞 M) Q)
+    (hurK : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭],
+      Algebra.IsUnramifiedAt (𝓞 K) Q) :
+    ConjClasses.map (AlgEquiv.restrictScalarsHom K) (artinSymbol 𝔓 hurM) =
+      artinSymbol 𝔭 hurK ^ 𝔓.inertiaDeg (𝓞 K) := by
+  obtain ⟨Q, _, _⟩ := (inferInstance : Nonempty (𝔓.primesOver (𝓞 L)))
+  have : Q.LiesOver 𝔭 := Ideal.LiesOver.trans Q 𝔓 𝔭
+  have hQM : Q.under (𝓞 M) = 𝔓 := (Ideal.LiesOver.over (A := 𝓞 M)).symm
+  have hQK : Q.under (𝓞 K) = 𝔭 := (Ideal.LiesOver.over (A := 𝓞 K)).symm
+  obtain ⟨σ, hσ⟩ := exists_isArithFrobAt K Q
+    (Ideal.ne_bot_of_liesOver_of_ne_bot (NeZero.ne 𝔭) Q)
+  -- The element-level tower law supplies a Frobenius `τ` for `L / M` at this same `Q` whose
+  -- restriction is `σ ^ f(𝔓/𝔭)`; both symbols are then read off at `Q` by
+  -- `artinSymbol_eq_mk_of_isArithFrobAt`, and the class statement is what survives.
+  obtain ⟨τ, hτ, hrel⟩ :=
+    exists_isArithFrobAt_pow_inertiaDeg M Q 𝔓 𝔭 hQM hQK hurK σ hσ
+  rw [artinSymbol_eq_mk_of_isArithFrobAt 𝔓 hurM Q τ hτ,
+    artinSymbol_eq_mk_of_isArithFrobAt 𝔭 hurK Q σ hσ,
+    ConjClasses.map_mk, ConjClasses.mk_pow, AlgEquiv.restrictScalarsHom_apply, hrel]
+
+end BaseChange
 
 end NumberField

--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -31,9 +31,8 @@ unramifiedness in the top extension, rather than assumed separately.
 
 Raising the base field is the companion law, and it takes a power: for `K ⊆ M ⊆ L`, the symbol
 of a prime of `𝓞 M` above `𝔭`, read inside `Gal(L/K)`, is the `f(𝔓/𝔭)`-th power of the symbol of
-`𝔭`. Stated on conjugacy classes it needs no normality hypothesis on `M / K` and names no prime
-of `𝓞 L`, both of which the element-level form in
-`TauCeti.NumberTheory.NumberField.Frobenius.Tower` does need.
+`𝔭`. Stated on conjugacy classes it names no prime of `𝓞 L` and no Frobenius representative, both
+of which the element-level form in `TauCeti.NumberTheory.NumberField.Frobenius.Tower` fixes.
 
 Finally, the symbol detects complete splitting: it is the identity class exactly when the
 residue degree is one, equivalently when `𝓞 L` has `[L : K]` primes above `𝔭`.
@@ -239,27 +238,45 @@ The companion to `artinSymbol_map_restrictNormalHom`. That law shrinks the top f
 tower and takes no power; this one raises the base field and takes the power `f(𝔓/𝔭)`.
 -/
 
+-- Source. Both transport laws are specified by `TauCetiRoadmap/Chebotarev/README.md` Layer 1,
+-- which asks for closed transport lemmas derived from `artinSymbol_map_restrictNormalHom` and
+-- `exists_isArithFrobAt_pow_inertiaDeg`. This is the second of the two.
+
+omit [NumberField K] in
+/-- Unramifiedness over `𝓞 M` above `𝔓` is inherited from unramifiedness over `𝓞 K` above `𝔭`:
+a prime of `𝓞 L` above `𝔓` lies above `𝔭`, and `Algebra.IsUnramifiedAt.of_restrictScalars` drops
+the base from `𝓞 K` to `𝓞 M`. So the transport law below asks only for the `𝓞 K` witness. -/
+theorem unramifiedAt_of_liesOver_of_unramifiedAt {M L : Type*} [Field M] [NumberField M]
+    [Field L] [NumberField L] [Algebra K M] [Algebra M L] [Algebra K L] [IsScalarTower K M L]
+    (𝔓 : Ideal (𝓞 M)) (𝔭 : Ideal (𝓞 K)) [𝔓.LiesOver 𝔭]
+    (hurK : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q)
+    (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔓] : Algebra.IsUnramifiedAt (𝓞 M) Q := by
+  have : Q.LiesOver 𝔭 := Ideal.LiesOver.trans Q 𝔓 𝔭
+  have := hurK Q
+  exact Algebra.IsUnramifiedAt.of_restrictScalars (𝓞 K) Q
+
 /-- **Raising the base field raises the Artin symbol to the residue degree.** For number fields
 `K ⊆ M ⊆ L` with `L / K` and `L / M` Galois and `𝔓` a prime of `𝓞 M` over `𝔭` unramified in `L`,
 the Artin symbol of `𝔓` for `L / M`, read inside `Gal(L/K)` along `AlgEquiv.restrictScalarsHom`,
 is the `f(𝔓/𝔭)`-th power of the Artin symbol of `𝔭` for `L / K`.
 
-This is the conjugacy-class form of `NumberField.restrictScalars_arithFrobAt_eq_pow_inertiaDeg`,
-and unlike that element-level statement it needs no hypothesis of normality on `M / K` and fixes
-no prime of `𝓞 L`. Both are genuine gains, and they are the same gain: the element identity holds
-only for a Frobenius *at a chosen `Q`*, and fails for an arbitrary conjugate when `M / K` is not
-normal, because a conjugate need not stabilize `Q`. Passing to classes quotients exactly by that
-choice, so what is left is an identity of classes with no chosen prime in it. -/
-theorem artinSymbol_map_restrictScalarsHom {M L : Type*} [Field M] [NumberField M]
-    [Field L] [NumberField L] [Algebra K M] [Algebra M L] [Algebra K L]
+This is the conjugacy-class form of `NumberField.restrictScalars_arithFrobAt_eq_pow_inertiaDeg`.
+The gain over that element-level statement is that both choices it makes disappear: it is an
+identity between *particular* Frobenius elements at a *particular* prime `Q` of `𝓞 L`, and it can
+fail for another representative of the same class, since a conjugate of `σ` need not stabilize `Q`.
+Passing to conjugacy classes quotients by exactly those choices, leaving an identity with no
+chosen prime and no chosen representative in it — the form a Frobenius-class argument can use,
+having neither in hand. -/
+theorem artinSymbol_map_restrictScalarsHom_eq_pow_inertiaDeg {M L : Type*} [Field M]
+    [NumberField M] [Field L] [NumberField L] [Algebra K M] [Algebra M L] [Algebra K L]
     [IsScalarTower K M L] [IsGalois K L] [IsGalois M L]
     (𝔓 : Ideal (𝓞 M)) [𝔓.IsMaximal] (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal] [𝔓.LiesOver 𝔭]
-    (hurM : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔓],
-      Algebra.IsUnramifiedAt (𝓞 M) Q)
     (hurK : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭],
       Algebra.IsUnramifiedAt (𝓞 K) Q) :
-    ConjClasses.map (AlgEquiv.restrictScalarsHom K) (artinSymbol 𝔓 hurM) =
+    ConjClasses.map (AlgEquiv.restrictScalarsHom K)
+        (artinSymbol 𝔓 (unramifiedAt_of_liesOver_of_unramifiedAt 𝔓 𝔭 hurK)) =
       artinSymbol 𝔭 hurK ^ 𝔓.inertiaDeg (𝓞 K) := by
+  set hurM := unramifiedAt_of_liesOver_of_unramifiedAt (L := L) 𝔓 𝔭 hurK with _
   obtain ⟨Q, _, _⟩ := (inferInstance : Nonempty (𝔓.primesOver (𝓞 L)))
   have : Q.LiesOver 𝔭 := Ideal.LiesOver.trans Q 𝔓 𝔭
   have hQM : Q.under (𝓞 M) = 𝔓 := (Ideal.LiesOver.over (A := 𝓞 M)).symm

--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -242,41 +242,30 @@ tower and takes no power; this one raises the base field and takes the power `f(
 -- which asks for closed transport lemmas derived from `artinSymbol_map_restrictNormalHom` and
 -- `exists_isArithFrobAt_pow_inertiaDeg`. This is the second of the two.
 
-omit [NumberField K] in
-/-- Unramifiedness over `𝓞 M` above `𝔓` is inherited from unramifiedness over `𝓞 K` above `𝔭`:
-a prime of `𝓞 L` above `𝔓` lies above `𝔭`, and `Algebra.IsUnramifiedAt.of_restrictScalars` drops
-the base from `𝓞 K` to `𝓞 M`. So the transport law below asks only for the `𝓞 K` witness. -/
-theorem unramifiedAt_of_liesOver_of_unramifiedAt {M L : Type*} [Field M] [Field L]
-    [Algebra K M] [Algebra M L] [Algebra K L] [IsScalarTower K M L]
-    (𝔓 : Ideal (𝓞 M)) (𝔭 : Ideal (𝓞 K)) [𝔓.LiesOver 𝔭]
-    (hurK : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q)
-    (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔓] : Algebra.IsUnramifiedAt (𝓞 M) Q := by
-  have : Q.LiesOver 𝔭 := Ideal.LiesOver.trans Q 𝔓 𝔭
-  have := hurK Q
-  exact Algebra.IsUnramifiedAt.of_restrictScalars (𝓞 K) Q
-
 /-- **Raising the base field raises the Artin symbol to the residue degree.** For number fields
 `K ⊆ M ⊆ L` with `L / K` and `L / M` Galois and `𝔓` a prime of `𝓞 M` over `𝔭` unramified in `L`,
 the Artin symbol of `𝔓` for `L / M`, read inside `Gal(L/K)` along `AlgEquiv.restrictScalarsHom`,
 is the `f(𝔓/𝔭)`-th power of the Artin symbol of `𝔭` for `L / K`.
 
 This is the conjugacy-class form of `NumberField.restrictScalars_arithFrobAt_eq_pow_inertiaDeg`.
-The gain over that element-level statement is that both choices it makes disappear: it is an
-identity between *particular* Frobenius elements at a *particular* prime `Q` of `𝓞 L`, and it can
-fail for another representative of the same class, since a conjugate of `σ` need not stabilize `Q`.
-Passing to conjugacy classes quotients by exactly those choices, leaving an identity with no
-chosen prime and no chosen representative in it — the form a Frobenius-class argument can use,
-having neither in hand. -/
+The gain over that element-level statement is that the choice it makes disappears. It is an
+identity at a *particular* prime `Q` of `𝓞 L`; there is only one choice there, since at a fixed
+unramified prime the Frobenius is uniquely determined, but the identity does fail for a conjugate
+of `σ`, which need not stabilize `Q`. Passing to conjugacy classes quotients by that choice and
+so never has to name the Frobenius it determines — which is the form a Frobenius-class argument
+can use, having no prime in hand. -/
 theorem artinSymbol_map_restrictScalarsHom_eq_pow_inertiaDeg {M L : Type*} [Field M]
     [NumberField M] [Field L] [NumberField L] [Algebra K M] [Algebra M L] [Algebra K L]
-    [IsScalarTower K M L] [IsGalois K L] [IsGalois M L]
+    [IsScalarTower K M L] [IsGalois K L]
     (𝔓 : Ideal (𝓞 M)) [𝔓.IsMaximal] (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal] [𝔓.LiesOver 𝔭]
     (hurK : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭],
       Algebra.IsUnramifiedAt (𝓞 K) Q) :
+    letI := IsGalois.tower_top_of_isGalois K M L
     ConjClasses.map (AlgEquiv.restrictScalarsHom K)
-        (artinSymbol 𝔓 (unramifiedAt_of_liesOver_of_unramifiedAt 𝔓 𝔭 hurK)) =
+        (artinSymbol 𝔓 (isUnramifiedAt_of_liesOver_of_isUnramifiedAt 𝔓 𝔭 hurK)) =
       artinSymbol 𝔭 hurK ^ 𝔓.inertiaDeg (𝓞 K) := by
-  set hurM := unramifiedAt_of_liesOver_of_unramifiedAt (L := L) 𝔓 𝔭 hurK with _
+  let := IsGalois.tower_top_of_isGalois K M L
+  set hurM := isUnramifiedAt_of_liesOver_of_isUnramifiedAt (L := L) 𝔓 𝔭 hurK with _
   obtain ⟨Q, _, _⟩ := (inferInstance : Nonempty (𝔓.primesOver (𝓞 L)))
   have : Q.LiesOver 𝔭 := Ideal.LiesOver.trans Q 𝔓 𝔭
   have hQM : Q.under (𝓞 M) = 𝔓 := (Ideal.LiesOver.over (A := 𝓞 M)).symm

--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -246,8 +246,8 @@ omit [NumberField K] in
 /-- Unramifiedness over `𝓞 M` above `𝔓` is inherited from unramifiedness over `𝓞 K` above `𝔭`:
 a prime of `𝓞 L` above `𝔓` lies above `𝔭`, and `Algebra.IsUnramifiedAt.of_restrictScalars` drops
 the base from `𝓞 K` to `𝓞 M`. So the transport law below asks only for the `𝓞 K` witness. -/
-theorem unramifiedAt_of_liesOver_of_unramifiedAt {M L : Type*} [Field M] [NumberField M]
-    [Field L] [NumberField L] [Algebra K M] [Algebra M L] [Algebra K L] [IsScalarTower K M L]
+theorem unramifiedAt_of_liesOver_of_unramifiedAt {M L : Type*} [Field M] [Field L]
+    [Algebra K M] [Algebra M L] [Algebra K L] [IsScalarTower K M L]
     (𝔓 : Ideal (𝓞 M)) (𝔭 : Ideal (𝓞 K)) [𝔓.LiesOver 𝔭]
     (hurK : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q)
     (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔓] : Algebra.IsUnramifiedAt (𝓞 M) Q := by

--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -30,9 +30,9 @@ The same reference gives functoriality in a normal tower: restriction maps the A
 unramifiedness in the top extension, rather than assumed separately.
 
 Raising the base field is the companion law, and it takes a power: for `K ⊆ M ⊆ L`, the symbol
-of a prime of `𝒪 M` above `𝔭`, read inside `Gal(L/K)`, is the `f(𝔓/𝔭)`-th power of the symbol of
+of a prime of `𝓞 M` above `𝔭`, read inside `Gal(L/K)`, is the `f(𝔓/𝔭)`-th power of the symbol of
 `𝔭`. Stated on conjugacy classes it needs no normality hypothesis on `M / K` and names no prime
-of `𝒪 L`, both of which the element-level form in
+of `𝓞 L`, both of which the element-level form in
 `TauCeti.NumberTheory.NumberField.Frobenius.Tower` does need.
 
 Finally, the symbol detects complete splitting: it is the identity class exactly when the

--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -243,9 +243,13 @@ tower and takes no power; this one raises the base field and takes the power `f(
 -- `exists_isArithFrobAt_pow_inertiaDeg`. This is the second of the two.
 
 /-- **Raising the base field raises the Artin symbol to the residue degree.** For number fields
-`K ⊆ M ⊆ L` with `L / K` and `L / M` Galois and `𝔓` a prime of `𝓞 M` over `𝔭` unramified in `L`,
-the Artin symbol of `𝔓` for `L / M`, read inside `Gal(L/K)` along `AlgEquiv.restrictScalarsHom`,
-is the `f(𝔓/𝔭)`-th power of the Artin symbol of `𝔭` for `L / K`.
+`K ⊆ M ⊆ L` with `L / K` Galois, `𝔭` a prime of `𝓞 K` unramified in `L / K`, and `𝔓` a prime of
+`𝓞 M` over it: the Artin symbol of `𝔓` for `L / M`, read inside `Gal(L/K)` along
+`AlgEquiv.restrictScalarsHom`, is the `f(𝔓/𝔭)`-th power of the Artin symbol of `𝔭` for `L / K`.
+
+Only the `L / K` hypothesis is asked for. Unramifiedness of `𝔓` in `L / M` follows from it: a
+prime of `𝓞 L` above `𝔓` lies above `𝔭`, so it is unramified over `𝓞 K`, and
+`Algebra.IsUnramifiedAt.of_restrictScalars` drops the base to `𝓞 M`.
 
 This is the conjugacy-class form of `NumberField.restrictScalars_arithFrobAt_eq_pow_inertiaDeg`.
 The gain over that element-level statement is that the choice it makes disappears. It is an
@@ -262,10 +266,17 @@ theorem artinSymbol_map_restrictScalarsHom_eq_pow_inertiaDeg {M L : Type*} [Fiel
       Algebra.IsUnramifiedAt (𝓞 K) Q) :
     letI := IsGalois.tower_top_of_isGalois K M L
     ConjClasses.map (AlgEquiv.restrictScalarsHom K)
-        (artinSymbol 𝔓 (isUnramifiedAt_of_liesOver_of_isUnramifiedAt 𝔓 𝔭 hurK)) =
+        (artinSymbol 𝔓 (fun Q _ _ ↦
+          have : Q.LiesOver 𝔭 := Ideal.LiesOver.trans Q 𝔓 𝔭
+          have := hurK Q
+          Algebra.IsUnramifiedAt.of_restrictScalars (𝓞 K) Q)) =
       artinSymbol 𝔭 hurK ^ 𝔓.inertiaDeg (𝓞 K) := by
   let := IsGalois.tower_top_of_isGalois K M L
-  set hurM := isUnramifiedAt_of_liesOver_of_isUnramifiedAt (L := L) 𝔓 𝔭 hurK with _
+  set hurM : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔓], Algebra.IsUnramifiedAt (𝓞 M) Q :=
+    fun Q _ _ ↦
+      have : Q.LiesOver 𝔭 := Ideal.LiesOver.trans Q 𝔓 𝔭
+      have := hurK Q
+      Algebra.IsUnramifiedAt.of_restrictScalars (𝓞 K) Q with _
   obtain ⟨Q, _, _⟩ := (inferInstance : Nonempty (𝔓.primesOver (𝓞 L)))
   have : Q.LiesOver 𝔭 := Ideal.LiesOver.trans Q 𝔓 𝔭
   have hQM : Q.under (𝓞 M) = 𝔓 := (Ideal.LiesOver.over (A := 𝓞 M)).symm

--- a/TauCeti/NumberTheory/NumberField/UnramifiedTower.lean
+++ b/TauCeti/NumberTheory/NumberField/UnramifiedTower.lean
@@ -77,4 +77,21 @@ theorem isUnramifiedAway_of_intermediateField (M : Type*) [Field M] [NumberField
       ∀ (Q : Ideal (𝓞 M)) [Q.IsPrime] [Q.LiesOver v.asIdeal], Algebra.IsUnramifiedAt (𝓞 K) Q :=
   fun v hv ↦ isUnramifiedAt_of_intermediateExtension (M := M) (L := L) v.asIdeal (hur v hv)
 
+omit [NumberField K] in
+/-- **Unramifiedness over the base descends to the intermediate base.** A prime `Q` of `𝓞 L`
+above `𝔓`, where `𝔓` lies over `𝔭`, lies over `𝔭` as well; if every such prime is unramified over
+`𝓞 K` then `Q` is unramified over the larger ring `𝓞 M`.
+
+The companion to `isUnramifiedAt_of_intermediateExtension`, which moves the *prime* down the tower
+and keeps the base. This one keeps the prime and moves the *base* up, which is what a statement
+indexed by a prime of `𝓞 M` needs in order to ask for only the `𝓞 K` hypothesis. -/
+theorem isUnramifiedAt_of_liesOver_of_isUnramifiedAt {M L : Type*} [Field M] [Field L]
+    [Algebra K M] [Algebra M L] [Algebra K L] [IsScalarTower K M L]
+    (𝔓 : Ideal (𝓞 M)) (𝔭 : Ideal (𝓞 K)) [𝔓.LiesOver 𝔭]
+    (hurK : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q)
+    (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔓] : Algebra.IsUnramifiedAt (𝓞 M) Q := by
+  have : Q.LiesOver 𝔭 := Ideal.LiesOver.trans Q 𝔓 𝔭
+  have := hurK Q
+  exact Algebra.IsUnramifiedAt.of_restrictScalars (𝓞 K) Q
+
 end NumberField

--- a/TauCeti/NumberTheory/NumberField/UnramifiedTower.lean
+++ b/TauCeti/NumberTheory/NumberField/UnramifiedTower.lean
@@ -77,21 +77,4 @@ theorem isUnramifiedAway_of_intermediateField (M : Type*) [Field M] [NumberField
       ∀ (Q : Ideal (𝓞 M)) [Q.IsPrime] [Q.LiesOver v.asIdeal], Algebra.IsUnramifiedAt (𝓞 K) Q :=
   fun v hv ↦ isUnramifiedAt_of_intermediateExtension (M := M) (L := L) v.asIdeal (hur v hv)
 
-omit [NumberField K] in
-/-- **Unramifiedness over the base descends to the intermediate base.** A prime `Q` of `𝓞 L`
-above `𝔓`, where `𝔓` lies over `𝔭`, lies over `𝔭` as well; if every such prime is unramified over
-`𝓞 K` then `Q` is unramified over the larger ring `𝓞 M`.
-
-The companion to `isUnramifiedAt_of_intermediateExtension`, which moves the *prime* down the tower
-and keeps the base. This one keeps the prime and moves the *base* up, which is what a statement
-indexed by a prime of `𝓞 M` needs in order to ask for only the `𝓞 K` hypothesis. -/
-theorem isUnramifiedAt_of_liesOver_of_isUnramifiedAt {M L : Type*} [Field M] [Field L]
-    [Algebra K M] [Algebra M L] [Algebra K L] [IsScalarTower K M L]
-    (𝔓 : Ideal (𝓞 M)) (𝔭 : Ideal (𝓞 K)) [𝔓.LiesOver 𝔭]
-    (hurK : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q)
-    (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔓] : Algebra.IsUnramifiedAt (𝓞 M) Q := by
-  have : Q.LiesOver 𝔭 := Ideal.LiesOver.trans Q 𝔓 𝔭
-  have := hurK Q
-  exact Algebra.IsUnramifiedAt.of_restrictScalars (𝓞 K) Q
-
 end NumberField


### PR DESCRIPTION
For a tower of number fields `K ⊆ M ⊆ L` with `L / K` and `L / M` Galois, raising the base field
raises the Artin symbol to the residue degree:

```lean
theorem NumberField.artinSymbol_map_restrictScalarsHom_eq_pow_inertiaDeg
    (𝔓 : Ideal (𝓞 M)) [𝔓.IsMaximal] (𝔭 : Ideal (𝓞 K)) [𝔭.IsMaximal] [𝔓.LiesOver 𝔭]
    (hurK : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭], Algebra.IsUnramifiedAt (𝓞 K) Q) :
    ConjClasses.map (AlgEquiv.restrictScalarsHom K) (artinSymbol 𝔓 <derived from hurK>) =
      artinSymbol 𝔭 hurK ^ 𝔓.inertiaDeg (𝓞 K)
```

This is the second of the two transport laws Chebotarev Layer 1 asks for. The first — shrinking the
top field of a normal tower, with no power — is already on `main` as
`artinSymbol_map_restrictNormalHom`, immediately above this one in the same file.

### Why the class-level statement is a gain, not a repackaging

The element-level tower law is already on `main`, as
`NumberField.restrictScalars_arithFrobAt_eq_pow_inertiaDeg`. It makes two choices that this
statement does not:

> The statement is *relative to one prime `Q` of `L`*. Replacing `σ` by an arbitrary conjugate — an
> arbitrary representative of the Artin class of `𝔭` — makes it false when `M / K` is not normal: a
> conjugate need not stabilize `Q`, so its `f`-th power need not fix `M` pointwise.

Passing to conjugacy classes quotients by exactly the choices that make the element form fragile:
what is left names neither a prime of `𝓞 L` nor a representative, which is the form a
Frobenius-class argument can consume, having neither in hand.

**Correction, after the `documentation` review.** An earlier version of this description and of
both docstrings also claimed the class-level form "asks nothing of `M / K`", presenting freedom
from normality as a second gain. That was wrong: `restrictScalars_eq_pow_inertiaDeg` has no
normality hypothesis either. I had read the warning above — which is about *conjugates* — as if it
were a hypothesis. The only gain is the elimination of the two choices.

### Review round 1

* **documentation** — the false normality comparison is removed from both docstrings, as above.
* **api-design** and **generality** (second bullet) — `hurM` is gone from the signature. A prime of
  `𝓞 L` above `𝔓` lies above `𝔭` (`Ideal.LiesOver.trans`) and
  `Algebra.IsUnramifiedAt.of_restrictScalars` drops the base, so the `𝓞 M` witness is derivable;
  that derivation is the new `isUnramifiedAt_of_liesOver_of_isUnramifiedAt (deleted at round 3)` and callers pass only
  `hurK`.
* **naming** — renamed to `artinSymbol_map_restrictScalarsHom_eq_pow_inertiaDeg`.
* **attribution** — a non-doc source comment credits `TauCetiRoadmap/Chebotarev/README.md` Layer 1.
### Review round 3

* **reuse** — the helper is deleted and its two lines inlined, as adjudicated. I contested this
  against `placement` and `api-design` (round 2 below), which asked for the declaration to be
  *moved* rather than removed; the rubric answered that the finding stands, and the contest said I
  would inline it if so. With the declaration gone there is nothing left for those two to place,
  and `UnramifiedTower.lean` is byte-identical to `main` again.
* **documentation** — the theorem's docstring described `𝔓` as "unramified in `L`", which reads as
  a hypothesis about `L / M`. The signature asks for something different: every prime over `𝔭`
  unramified over `𝓞 K`. Corrected, with a note that unramifiedness in `L / M` follows rather than
  being assumed. The finding's other bullet asked for the helper to be documented in
  `UnramifiedTower.lean`'s overview; moot now that the helper is gone.

### Review round 2

* **placement** and **api-design** — the helper moved to
  `TauCeti/NumberTheory/NumberField/UnramifiedTower.lean`, beside its exact companion
  `isUnramifiedAt_of_intermediateExtension`: that one moves the prime down the tower and keeps the
  base, this one keeps the prime and moves the base up.
* **naming** — renamed to `isUnramifiedAt_of_liesOver_of_isUnramifiedAt (deleted at round 3)`, restoring the `Is` of
  `Algebra.IsUnramifiedAt`.
* **generality** — `[IsGalois M L]` is now gone, installed by `letI` in the statement. This is the
  remedy the rubric named after I reported that instance search cannot find it; see the superseded
  note below.
* **documentation** — the docstring claimed the element-level law makes two choices, a prime and a
  representative. Only the prime is a choice: at a fixed unramified prime the Frobenius is
  determined. Reworded.
* **reuse** — **contested**, because it and the two above cannot both be satisfied: this one asks
  me to *delete* the helper, those ask me to *move* it. I implemented the move and set out the
  reasoning in the `reuse` thread.

*Superseded note from round 1:*

* **generality** (first bullet), *not done*. `[IsGalois M L]` is mathematically redundant given
  `[IsGalois K L]` and the tower, but it is not derivable by instance search:
  `IsGalois.tower_top_of_isGalois` is a plain theorem, and the instance
  `IsGalois.tower_top_intermediateField` fires only when the middle field is a bundled
  `IntermediateField`, which `M` here is not. Removing the parameter fails to elaborate, with
  `failed to synthesize` at three sites. It could be installed by a `letI` *inside* the statement,
  but that puts a `let` in the theorem's type and makes the law awkward to apply — trading this
  rubric against `api-design`. Happy to do it if that is the preferred reading.

### Proof

Four steps, no new mathematics: choose any `Q` above `𝔓`, take a Frobenius `σ` for `L / K` at `Q`,
feed it to `exists_isArithFrobAt_pow_inertiaDeg` to get the matching `τ` for `L / M` at the same
`Q`, and read both symbols off at `Q` with `artinSymbol_eq_mk_of_isArithFrobAt`. The class algebra
is then `ConjClasses.map_mk` and `ConjClasses.mk_pow`.

Routing through the existence form rather than Mathlib's coherently chosen `arithFrobAt` is
deliberate: `arithFrobAt` requires a `Finite (𝓞 L ⧸ Q)` instance that is not in scope here, while
`exists_isArithFrobAt` needs only `Q ≠ ⊥`, which follows from `𝔭 ≠ ⊥`.

### Absence

No declaration on `main` mentions `artinSymbol` together with any of `pow`, `inertiaDeg` or
`restrictScalars`; the existing `artinSymbol ^ j` occurrences are the von Mangoldt fibre in
`Chebotarev/PrimeCounting/VonMangoldt.lean`, which is a different statement. The result is not
typeclass-derived, and it is confirmed present after this PR by a compiled `#check` rather than by
grep.

`CBirkbeck/chebotarev-density` at `8575c9df` has the analogous *definition* — `frobeniusClass`, in
`CebotarevDensity/Frobenius.lean` — but no transport law for it: its four `frobeniusClass`
declarations are `exists_frobeniusClass`, the definition, `frobeniusClass_eq_mk_of_isArithFrobAt`
and `autToPow_frobeniusClass_out`, and no statement about it involves a power or a residue degree
(the `^` occurrences under `frobeniusClass` are all `absNorm ^ (-s)` in the analytic files).
Controls were run on the same probes — `theorem` returns 25 files and `Frobenius` 16 — so that is a
real absence and not a broken search. **No `Provenance` line is owed.**

### One import changes visibility

`TauCeti.Algebra.Group.Conj` moves from a private `import` to a `public import`. This is forced:
the statement mentions that module's `Pow (ConjClasses M) ℕ` instance, and a public theorem may not
mention a privately imported one — the build fails with `failed to synthesize HPow (ConjClasses
Gal(L/K)) ℕ ?m` otherwise. Nothing else about the file's interface changes, and
`Frobenius.Tower` is added as a private import because only the proof uses it.

Roadmap: Chebotarev

No `tauceti-target:v1` marker: this supplies one of Layer 1's transport lemmas rather than
authoring a whole layer target, so it has no deterministic target id of its own. Same reasoning as
#5812 and #5814.

### On the cleanup pass

`lean-lsp` has been unreachable for this whole session, so `/cleanup`'s phases 6.5 and 6.6 were
discharged directly rather than through their hand-offs. 6.6 by `#count_heartbeats`: **3137**
against the 200000 default. Axioms are exactly `propext`, `Classical.choice` and `Quot.sound`;
every line is within 100 characters; the proof is 14 lines, so `/decompose-proof` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF



