### PR TITLE
feat: identify Student t as a Gaussian ratio

### DIFF
--- a/TauCeti/MeasureTheory/Measure/Real.lean
+++ b/TauCeti/MeasureTheory/Measure/Real.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.Probability.CDF
+
+/-!
+# Extensionality for symmetric real probability measures
+
+This file gives an extensionality principle for symmetric probability measures on the real line:
+their pushforwards under squaring determine them. It packages the elementary observation that the
+square records the mass of intervals symmetric about zero, while reflection invariance makes the
+two complementary tails equal.
+
+## Main result
+
+* `TauCeti.MeasureTheory.Measure.eq_of_map_sq_eq_of_map_neg_eq_self` — two symmetric real
+  probability measures with the same law after squaring are equal.
+-/
+
+public section
+
+open MeasureTheory ProbabilityTheory Set
+
+namespace TauCeti
+
+namespace MeasureTheory
+
+/-- Two reflection-invariant probability measures on `ℝ` are equal if their pushforwards under
+squaring are equal. -/
+theorem Measure.eq_of_map_sq_eq_of_map_neg_eq_self {μ ν : Measure ℝ}
+    [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
+    (hμneg : μ.map (fun x : ℝ ↦ -x) = μ) (hνneg : ν.map (fun x : ℝ ↦ -x) = ν)
+    (hsq : μ.map (fun x : ℝ ↦ x ^ 2) = ν.map (fun x : ℝ ↦ x ^ 2)) :
+    μ = ν := by
+  apply Measure.eq_of_cdf
+  ext x
+  rw [cdf_eq_real, cdf_eq_real]
+  by_cases hx : 0 ≤ x
+  -- On the nonnegative half-line, the squared law fixes the central interval `[-x, x]`.
+  -- Symmetry equates its two open complementary tails, hence fixes `Iic x`.
+  · have hsq_preimage : (fun y : ℝ ↦ y ^ 2) ⁻¹' Iic (x ^ 2) = Icc (-x) x := by
+      ext y
+      simp only [mem_preimage, mem_Iic, mem_Icc]
+      constructor
+      · exact fun hy ↦ abs_le_of_sq_le_sq' hy hx
+      · exact fun hy ↦ sq_le_sq' hy.1 hy.2
+    have hcentral : μ.real (Icc (-x) x) = ν.real (Icc (-x) x) := by
+      have h := congrArg (fun ρ : Measure ℝ ↦ ρ.real (Iic (x ^ 2))) hsq
+      rw [map_measureReal_apply (μ := μ) (f := fun y : ℝ ↦ y ^ 2) (by fun_prop)
+          measurableSet_Iic,
+        map_measureReal_apply (μ := ν) (f := fun y : ℝ ↦ y ^ 2) (by fun_prop)
+          measurableSet_Iic,
+        hsq_preimage] at h
+      exact h
+    have hneg_preimage : (fun y : ℝ ↦ -y) ⁻¹' Ioi x = Iio (-x) := by
+      ext y
+      simp only [mem_preimage, mem_Ioi, mem_Iio]
+      constructor <;> intro h <;> linarith
+    have hμtails : μ.real (Iio (-x)) = μ.real (Ioi x) := by
+      have h := congrArg (fun ρ : Measure ℝ ↦ ρ.real (Ioi x)) hμneg
+      rw [map_measureReal_apply (μ := μ) (f := fun y : ℝ ↦ -y) (by fun_prop)
+        measurableSet_Ioi, hneg_preimage] at h
+      exact h
+    have hνtails : ν.real (Iio (-x)) = ν.real (Ioi x) := by
+      have h := congrArg (fun ρ : Measure ℝ ↦ ρ.real (Ioi x)) hνneg
+      rw [map_measureReal_apply (μ := ν) (f := fun y : ℝ ↦ -y) (by fun_prop)
+        measurableSet_Ioi, hneg_preimage] at h
+      exact h
+    have hbounds : -x ≤ x := by linarith
+    have hdisj_inner : Disjoint (Icc (-x) x) (Ioi x) :=
+      (Iic_disjoint_Ioi le_rfl).mono Icc_subset_Iic_self Subset.rfl
+    have hμtotal :
+        1 = μ.real (Iio (-x)) + (μ.real (Icc (-x) x) + μ.real (Ioi x)) := by
+      rw [← probReal_univ (μ := μ), ← Iio_union_Ici (a := -x),
+        measureReal_union (Iio_disjoint_Ici le_rfl) measurableSet_Ici,
+        ← Icc_union_Ioi_eq_Ici hbounds,
+        measureReal_union hdisj_inner measurableSet_Ioi]
+    have hνtotal :
+        1 = ν.real (Iio (-x)) + (ν.real (Icc (-x) x) + ν.real (Ioi x)) := by
+      rw [← probReal_univ (μ := ν), ← Iio_union_Ici (a := -x),
+        measureReal_union (Iio_disjoint_Ici le_rfl) measurableSet_Ici,
+        ← Icc_union_Ioi_eq_Ici hbounds,
+        measureReal_union hdisj_inner measurableSet_Ioi]
+    have hμcdf : μ.real (Iic x) = μ.real (Iio (-x)) + μ.real (Icc (-x) x) := by
+      rw [← Iio_union_Icc_eq_Iic hbounds,
+        measureReal_union ((Iio_disjoint_Ici le_rfl).mono_right Icc_subset_Ici_self)
+          measurableSet_Icc]
+    have hνcdf : ν.real (Iic x) = ν.real (Iio (-x)) + ν.real (Icc (-x) x) := by
+      rw [← Iio_union_Icc_eq_Iic hbounds,
+        measureReal_union ((Iio_disjoint_Ici le_rfl).mono_right Icc_subset_Ici_self)
+          measurableSet_Icc]
+    rw [hμcdf, hνcdf]
+    linarith
+  -- For negative `x`, the squared law fixes `(x, -x)`.  Symmetry equates the two closed
+  -- complementary tails, of which `Iic x` is one.
+  · have hx' : x < 0 := lt_of_not_ge hx
+    have hsq_preimage : (fun y : ℝ ↦ y ^ 2) ⁻¹' Iio (x ^ 2) = Ioo x (-x) := by
+      ext y
+      simp only [mem_preimage, mem_Iio, mem_Ioo]
+      constructor
+      · intro hy
+        have h : y ^ 2 < (-x) ^ 2 := by simpa only [neg_sq] using hy
+        simpa only [neg_neg] using abs_lt_of_sq_lt_sq' h (by linarith)
+      · intro hy
+        have h : -(-x) < y := by linarith [hy.1]
+        simpa only [neg_sq] using sq_lt_sq' h hy.2
+    have hmiddle : μ.real (Ioo x (-x)) = ν.real (Ioo x (-x)) := by
+      have h := congrArg (fun ρ : Measure ℝ ↦ ρ.real (Iio (x ^ 2))) hsq
+      rw [map_measureReal_apply (μ := μ) (f := fun y : ℝ ↦ y ^ 2) (by fun_prop)
+          measurableSet_Iio,
+        map_measureReal_apply (μ := ν) (f := fun y : ℝ ↦ y ^ 2) (by fun_prop)
+          measurableSet_Iio,
+        hsq_preimage] at h
+      exact h
+    have hneg_preimage : (fun y : ℝ ↦ -y) ⁻¹' Ici (-x) = Iic x := by
+      ext y
+      simp only [mem_preimage, mem_Ici, mem_Iic]
+      constructor <;> intro h <;> linarith
+    have hμtails : μ.real (Iic x) = μ.real (Ici (-x)) := by
+      have h := congrArg (fun ρ : Measure ℝ ↦ ρ.real (Ici (-x))) hμneg
+      rw [map_measureReal_apply (μ := μ) (f := fun y : ℝ ↦ -y) (by fun_prop)
+        measurableSet_Ici, hneg_preimage] at h
+      exact h
+    have hνtails : ν.real (Iic x) = ν.real (Ici (-x)) := by
+      have h := congrArg (fun ρ : Measure ℝ ↦ ρ.real (Ici (-x))) hνneg
+      rw [map_measureReal_apply (μ := ν) (f := fun y : ℝ ↦ -y) (by fun_prop)
+        measurableSet_Ici, hneg_preimage] at h
+      exact h
+    have hbounds : x < -x := by linarith
+    have hdisj_inner : Disjoint (Ioo x (-x)) (Ici (-x)) :=
+      (Iio_disjoint_Ici le_rfl).mono Ioo_subset_Iio_self Subset.rfl
+    have hμtotal :
+        1 = μ.real (Iic x) + (μ.real (Ioo x (-x)) + μ.real (Ici (-x))) := by
+      rw [← probReal_univ (μ := μ), ← Iic_union_Ioi (a := x),
+        measureReal_union (Iic_disjoint_Ioi le_rfl) measurableSet_Ioi,
+        ← Ioo_union_Ici_eq_Ioi hbounds,
+        measureReal_union hdisj_inner measurableSet_Ici]
+    have hνtotal :
+        1 = ν.real (Iic x) + (ν.real (Ioo x (-x)) + ν.real (Ici (-x))) := by
+      rw [← probReal_univ (μ := ν), ← Iic_union_Ioi (a := x),
+        measureReal_union (Iic_disjoint_Ioi le_rfl) measurableSet_Ioi,
+        ← Ioo_union_Ici_eq_Ioi hbounds,
+        measureReal_union hdisj_inner measurableSet_Ici]
+    linarith
+
+end MeasureTheory
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Measure/Real.lean
+++ b/TauCeti/MeasureTheory/Measure/Real.lean
@@ -17,7 +17,7 @@ two complementary tails equal.
 
 ## Main result
 
-* `TauCeti.MeasureTheory.Measure.eq_of_map_sq_eq_of_map_neg_eq_self` — two symmetric finite real
+* `MeasureTheory.Measure.eq_of_map_sq_eq_of_map_neg_eq_self` — two symmetric finite real
   measures with the same pushforward after squaring are equal.
 -/
 
@@ -31,7 +31,7 @@ namespace MeasureTheory
 
 /-- Two reflection-invariant finite measures on `ℝ` are equal if their pushforwards under
 squaring are equal. -/
-theorem Measure.eq_of_map_sq_eq_of_map_neg_eq_self {μ ν : Measure ℝ}
+theorem _root_.MeasureTheory.Measure.eq_of_map_sq_eq_of_map_neg_eq_self (μ ν : Measure ℝ)
     [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (hμneg : μ.map (fun x : ℝ ↦ -x) = μ) (hνneg : ν.map (fun x : ℝ ↦ -x) = ν)
     (hsq : μ.map (fun x : ℝ ↦ x ^ 2) = ν.map (fun x : ℝ ↦ x ^ 2)) :

--- a/TauCeti/MeasureTheory/Measure/Real.lean
+++ b/TauCeti/MeasureTheory/Measure/Real.lean
@@ -8,17 +8,17 @@ module
 public import Mathlib.Probability.CDF
 
 /-!
-# Extensionality for symmetric real probability measures
+# Extensionality for symmetric finite real measures
 
-This file gives an extensionality principle for symmetric probability measures on the real line:
+This file gives an extensionality principle for symmetric finite measures on the real line:
 their pushforwards under squaring determine them. It packages the elementary observation that the
 square records the mass of intervals symmetric about zero, while reflection invariance makes the
 two complementary tails equal.
 
 ## Main result
 
-* `TauCeti.MeasureTheory.Measure.eq_of_map_sq_eq_of_map_neg_eq_self` — two symmetric real
-  probability measures with the same law after squaring are equal.
+* `TauCeti.MeasureTheory.Measure.eq_of_map_sq_eq_of_map_neg_eq_self` — two symmetric finite real
+  measures with the same pushforward after squaring are equal.
 -/
 
 public section
@@ -29,16 +29,23 @@ namespace TauCeti
 
 namespace MeasureTheory
 
-/-- Two reflection-invariant probability measures on `ℝ` are equal if their pushforwards under
+/-- Two reflection-invariant finite measures on `ℝ` are equal if their pushforwards under
 squaring are equal. -/
 theorem Measure.eq_of_map_sq_eq_of_map_neg_eq_self {μ ν : Measure ℝ}
-    [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (hμneg : μ.map (fun x : ℝ ↦ -x) = μ) (hνneg : ν.map (fun x : ℝ ↦ -x) = ν)
     (hsq : μ.map (fun x : ℝ ↦ x ^ 2) = ν.map (fun x : ℝ ↦ x ^ 2)) :
     μ = ν := by
-  apply Measure.eq_of_cdf
-  ext x
-  rw [cdf_eq_real, cdf_eq_real]
+  apply Measure.ext_of_Iic
+  intro x
+  rw [← measureReal_eq_measureReal_iff]
+  have htotal : μ.real univ = ν.real univ := by
+    have h := congrArg (fun ρ : Measure ℝ ↦ ρ.real univ) hsq
+    simpa only [map_measureReal_apply (μ := μ) (f := fun y : ℝ ↦ y ^ 2) (by fun_prop)
+        MeasurableSet.univ,
+      map_measureReal_apply (μ := ν) (f := fun y : ℝ ↦ y ^ 2) (by fun_prop)
+        MeasurableSet.univ,
+      preimage_univ] using h
   by_cases hx : 0 ≤ x
   -- On the nonnegative half-line, the squared law fixes the central interval `[-x, x]`.
   -- Symmetry equates its two open complementary tails, hence fixes `Iic x`.
@@ -74,14 +81,14 @@ theorem Measure.eq_of_map_sq_eq_of_map_neg_eq_self {μ ν : Measure ℝ}
     have hdisj_inner : Disjoint (Icc (-x) x) (Ioi x) :=
       (Iic_disjoint_Ioi le_rfl).mono Icc_subset_Iic_self Subset.rfl
     have hμtotal :
-        1 = μ.real (Iio (-x)) + (μ.real (Icc (-x) x) + μ.real (Ioi x)) := by
-      rw [← probReal_univ (μ := μ), ← Iio_union_Ici (a := -x),
+        μ.real univ = μ.real (Iio (-x)) + (μ.real (Icc (-x) x) + μ.real (Ioi x)) := by
+      rw [← Iio_union_Ici (a := -x),
         measureReal_union (Iio_disjoint_Ici le_rfl) measurableSet_Ici,
         ← Icc_union_Ioi_eq_Ici hbounds,
         measureReal_union hdisj_inner measurableSet_Ioi]
     have hνtotal :
-        1 = ν.real (Iio (-x)) + (ν.real (Icc (-x) x) + ν.real (Ioi x)) := by
-      rw [← probReal_univ (μ := ν), ← Iio_union_Ici (a := -x),
+        ν.real univ = ν.real (Iio (-x)) + (ν.real (Icc (-x) x) + ν.real (Ioi x)) := by
+      rw [← Iio_union_Ici (a := -x),
         measureReal_union (Iio_disjoint_Ici le_rfl) measurableSet_Ici,
         ← Icc_union_Ioi_eq_Ici hbounds,
         measureReal_union hdisj_inner measurableSet_Ioi]
@@ -134,14 +141,14 @@ theorem Measure.eq_of_map_sq_eq_of_map_neg_eq_self {μ ν : Measure ℝ}
     have hdisj_inner : Disjoint (Ioo x (-x)) (Ici (-x)) :=
       (Iio_disjoint_Ici le_rfl).mono Ioo_subset_Iio_self Subset.rfl
     have hμtotal :
-        1 = μ.real (Iic x) + (μ.real (Ioo x (-x)) + μ.real (Ici (-x))) := by
-      rw [← probReal_univ (μ := μ), ← Iic_union_Ioi (a := x),
+        μ.real univ = μ.real (Iic x) + (μ.real (Ioo x (-x)) + μ.real (Ici (-x))) := by
+      rw [← Iic_union_Ioi (a := x),
         measureReal_union (Iic_disjoint_Ioi le_rfl) measurableSet_Ioi,
         ← Ioo_union_Ici_eq_Ioi hbounds,
         measureReal_union hdisj_inner measurableSet_Ici]
     have hνtotal :
-        1 = ν.real (Iic x) + (ν.real (Ioo x (-x)) + ν.real (Ici (-x))) := by
-      rw [← probReal_univ (μ := ν), ← Iic_union_Ioi (a := x),
+        ν.real univ = ν.real (Iic x) + (ν.real (Ioo x (-x)) + ν.real (Ici (-x))) := by
+      rw [← Iic_union_Ioi (a := x),
         measureReal_union (Iic_disjoint_Ioi le_rfl) measurableSet_Ioi,
         ← Ioo_union_Ici_eq_Ioi hbounds,
         measureReal_union hdisj_inner measurableSet_Ici]

--- a/TauCeti/Probability/Distributions/StudentT/ChiSquared.lean
+++ b/TauCeti/Probability/Distributions/StudentT/ChiSquared.lean
@@ -147,11 +147,13 @@ theorem map_div_sqrt_chiSquaredMeasure {ν : ℝ} (hν : 0 < ν) :
     calc
       (μ.map ratio).map sq = μ.map (fun z ↦ (ratio z) ^ 2) := by
         rw [Measure.map_map (by fun_prop) (by fun_prop)]
-        rfl
+        exact congrArg (fun f : ℝ × ℝ → ℝ ↦ μ.map f) (funext fun z ↦ by
+          simp only [Function.comp_apply, sq])
       _ = μ.map (fun z ↦ z.1 ^ 2 / 1 / (z.2 / ν)) := Measure.map_congr hratio_sq
       _ = (μ.map (Prod.map sq id)).map (fun z ↦ z.1 / 1 / (z.2 / ν)) := by
         rw [Measure.map_map (by fun_prop) (by fun_prop)]
-        rfl
+        exact congrArg (fun f : ℝ × ℝ → ℝ ↦ μ.map f) (funext fun z ↦ by
+          simp only [Function.comp_apply, sq, Prod.map_apply', id_eq])
       _ = fisherSnedecorMeasure 1 ν := by
         rw [hμ_sq, map_scaled_div_chiSquaredMeasure one_pos hν]
   have hμ_reflect : μ.map reflect = μ := by

--- a/TauCeti/Probability/Distributions/StudentT/ChiSquared.lean
+++ b/TauCeti/Probability/Distributions/StudentT/ChiSquared.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.MeasureTheory.Measure.Real
+public import TauCeti.Probability.Distributions.FisherSnedecor.ChiSquared
+public import TauCeti.Probability.Distributions.Gaussian.ChiSquared
+public import TauCeti.Probability.Distributions.StudentT.Cdf
+
+/-!
+# Student t laws as Gaussian--chi-squared ratios
+
+This file proves the classical construction of a Student t variable: divide a standard Gaussian
+variable by the square root of an independent chi-squared variable divided by its degrees of
+freedom. The measure-level identity is primary, and a `HasLaw` formulation records the exact
+independence assumptions needed for random variables.
+
+The proof first identifies the square of a Student t law with the Fisher--Snedecor law of
+parameters `1` and `ν`.  The candidate ratio has the same squared law by the Gaussian-square and
+chi-squared-ratio identities, and both laws are invariant under reflection.  Extensionality for
+symmetric real probability measures then identifies them.
+
+## Main results
+
+* `TauCeti.Probability.studentTMeasure_map_sq` — squaring a Student t variable gives an
+  `F(1, ν)` variable;
+* `TauCeti.Probability.map_div_sqrt_chiSquaredMeasure` — the measure-level Gaussian--chi-squared
+  ratio identity;
+* `TauCeti.Probability.hasLaw_studentT_of_gaussian_chiSquared` — the corresponding random-variable
+  theorem.
+
+## References
+
+* N. L. Johnson, S. Kotz, N. Balakrishnan, *Continuous Univariate Distributions*, vol. 2,
+  2nd ed., Wiley (1995), ch. 28.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory Real Set
+
+namespace TauCeti
+
+namespace Probability
+
+/-- The square of a Student t law with `ν > 0` degrees of freedom is the Fisher--Snedecor law
+with parameters `1` and `ν`. -/
+@[simp]
+theorem studentTMeasure_map_sq {ν : ℝ} (hν : 0 < ν) :
+    (studentTMeasure ν).map (fun x : ℝ ↦ x ^ 2) = fisherSnedecorMeasure 1 ν := by
+  let _ : IsProbabilityMeasure (studentTMeasure ν) :=
+    isProbabilityMeasure_studentTMeasure hν
+  let _ : IsProbabilityMeasure (fisherSnedecorMeasure 1 ν) :=
+    isProbabilityMeasure_fisherSnedecorMeasure one_pos hν
+  apply Measure.eq_of_cdf
+  ext x
+  rw [cdf_eq_real, map_measureReal_apply (by fun_prop) measurableSet_Iic,
+    cdf_fisherSnedecorMeasure_eq one_pos hν]
+  by_cases hx : x < 0
+  · have hpreimage : (fun y : ℝ ↦ y ^ 2) ⁻¹' Iic x = ∅ := by
+      ext y
+      simp only [mem_preimage, mem_Iic, mem_empty_iff_false, iff_false]
+      exact fun hy ↦ (not_le_of_gt hx) ((sq_nonneg y).trans hy)
+    rw [hpreimage, measureReal_empty, ite_eq_left hx.le]
+  · have hx0 : 0 ≤ x := le_of_not_gt hx
+    have hpreimage : (fun y : ℝ ↦ y ^ 2) ⁻¹' Iic x = Icc (-√x) √x := by
+      ext y
+      simp only [mem_preimage, mem_Iic, mem_Icc]
+      constructor
+      · exact fun hy ↦ abs_le.mp (Real.abs_le_sqrt hy)
+      · intro hy
+        rw [← Real.sq_sqrt hx0]
+        exact sq_le_sq' hy.1 hy.2
+    rw [hpreimage]
+    let _ : NullSingletonClass (studentTMeasure ν) := by
+      rw [studentTMeasure_def]
+      infer_instance
+    by_cases hxzero : x = 0
+    · subst x
+      simp [Measure.real]
+    · have hxpos : 0 < x := lt_of_le_of_ne hx0 (Ne.symm hxzero)
+      have hsqrtpos : 0 < √x := Real.sqrt_pos.2 hxpos
+      have hIoc :
+          (studentTMeasure ν).real (Ioc (-√x) √x) =
+            cdf (studentTMeasure ν) √x - cdf (studentTMeasure ν) (-√x) := by
+        calc
+          (studentTMeasure ν).real (Ioc (-√x) √x) =
+              (cdf (studentTMeasure ν)).measure.real (Ioc (-√x) √x) := by
+            rw [measure_cdf]
+          _ = cdf (studentTMeasure ν) √x - cdf (studentTMeasure ν) (-√x) := by
+            rw [Measure.real, StieltjesFunction.measure_Ioc, ENNReal.toReal_ofReal]
+            exact sub_nonneg.mpr ((cdf (studentTMeasure ν)).mono (by linarith))
+      rw [← measureReal_congr (Ioc_ae_eq_Icc (a := -√x) (b := √x)), hIoc,
+        cdf_studentTMeasure_eq hν, cdf_studentTMeasure_eq hν,
+        ite_eq_right (not_lt_of_ge (Real.sqrt_nonneg x)),
+        ite_eq_left (neg_lt_zero.mpr hsqrtpos), ite_eq_right (not_le_of_gt hxpos), neg_sq,
+        Real.sq_sqrt hx0]
+      have hb : 0 < ν / 2 := by linarith
+      have harg : 1 - x / (ν + x) = ν / (ν + x) := by
+        field_simp
+        ring
+      have hFarg : 1 * x / (ν + 1 * x) = x / (ν + x) := by ring
+      -- The beta reflection formula turns the symmetric Student interval into the `F(1, ν)` cdf.
+      rw [hFarg, regularizedIncompleteBeta_symm one_half_pos hb (x / (ν + x)), harg]
+      ring
+
+/-- Dividing a standard Gaussian law by the square root of an independent chi-squared law,
+normalised by its positive degrees of freedom `ν`, gives the Student t law with `ν` degrees of
+freedom. -/
+theorem map_div_sqrt_chiSquaredMeasure {ν : ℝ} (hν : 0 < ν) :
+    ((gaussianReal 0 1).prod (chiSquaredMeasure ν)).map
+        (fun z : ℝ × ℝ ↦ z.1 / √(z.2 / ν)) = studentTMeasure ν := by
+  let μ := (gaussianReal 0 1).prod (chiSquaredMeasure ν)
+  let ratio : ℝ × ℝ → ℝ := fun z ↦ z.1 / √(z.2 / ν)
+  let sq : ℝ → ℝ := fun x ↦ x ^ 2
+  let reflect : ℝ × ℝ → ℝ × ℝ := Prod.map (fun x : ℝ ↦ -x) id
+  let _ : IsProbabilityMeasure (chiSquaredMeasure ν) :=
+    isProbabilityMeasure_chiSquaredMeasure hν.le
+  let _ : IsProbabilityMeasure (studentTMeasure ν) :=
+    isProbabilityMeasure_studentTMeasure hν
+  let _ : IsProbabilityMeasure μ := by
+    dsimp only [μ]
+    infer_instance
+  -- The chi-squared coordinate is positive almost everywhere, so squaring the ratio may cancel
+  -- its square-root denominator.
+  have hpos : ∀ᵐ z ∂μ, 0 < z.2 := by
+    apply Measure.quasiMeasurePreserving_snd.ae
+    rw [chiSquaredMeasure_eq_gammaMeasure hν]
+    exact ae_pos_gammaMeasure (ν / 2) (1 / 2)
+  have hratio_sq :
+      (fun z ↦ (ratio z) ^ 2) =ᵐ[μ] fun z ↦ z.1 ^ 2 / 1 / (z.2 / ν) := by
+    filter_upwards [hpos] with z hz
+    have hzν : 0 ≤ z.2 / ν := (div_pos hz hν).le
+    simp only [ratio, div_pow, Real.sq_sqrt hzν, div_one]
+  have hμ_sq : μ.map (Prod.map sq id) =
+      (chiSquaredMeasure 1).prod (chiSquaredMeasure ν) := by
+    rw [← Measure.map_prod_map (gaussianReal 0 1) (chiSquaredMeasure ν) (by fun_prop)
+      measurable_id, gaussianReal_map_sq, Measure.map_id]
+  -- Reuse the Gaussian-square and chi-squared-ratio identities to identify the squared law.
+  have hratio_sq_map :
+      (μ.map ratio).map sq = fisherSnedecorMeasure 1 ν := by
+    calc
+      (μ.map ratio).map sq = μ.map (fun z ↦ (ratio z) ^ 2) := by
+        rw [Measure.map_map (by fun_prop) (by fun_prop)]
+        rfl
+      _ = μ.map (fun z ↦ z.1 ^ 2 / 1 / (z.2 / ν)) := Measure.map_congr hratio_sq
+      _ = (μ.map (Prod.map sq id)).map (fun z ↦ z.1 / 1 / (z.2 / ν)) := by
+        rw [Measure.map_map (by fun_prop) (by fun_prop)]
+        rfl
+      _ = fisherSnedecorMeasure 1 ν := by
+        rw [hμ_sq, map_scaled_div_chiSquaredMeasure one_pos hν]
+  have hμ_reflect : μ.map reflect = μ := by
+    rw [← Measure.map_prod_map (gaussianReal 0 1) (chiSquaredMeasure ν) (by fun_prop)
+      measurable_id, gaussianReal_map_neg, Measure.map_id]
+    simp only [neg_zero, μ]
+  -- Reflecting the Gaussian coordinate reflects the ratio without changing its source law.
+  have hratio_reflect : (μ.map ratio).map (fun x ↦ -x) = μ.map ratio := by
+    calc
+      (μ.map ratio).map (fun x ↦ -x) = μ.map ((fun x ↦ -x) ∘ ratio) := by
+        rw [Measure.map_map (by fun_prop) (by fun_prop)]
+      _ = μ.map (ratio ∘ reflect) := by
+        apply Measure.map_congr
+        exact ae_of_all _ fun z ↦ by
+          exact neg_div' √(z.2 / ν) z.1
+      _ = (μ.map reflect).map ratio := by
+        rw [Measure.map_map (by fun_prop) (by fun_prop)]
+      _ = μ.map ratio := by rw [hμ_reflect]
+  exact TauCeti.MeasureTheory.Measure.eq_of_map_sq_eq_of_map_neg_eq_self hratio_reflect
+    (studentTMeasure_map_neg ν) (hratio_sq_map.trans (studentTMeasure_map_sq hν).symm)
+
+variable {Ω : Type*} {mΩ : MeasurableSpace Ω} {P : Measure Ω} {Z V : Ω → ℝ}
+
+/-- If `Z` is standard Gaussian and `V` is an independent chi-squared variable with `ν > 0`
+degrees of freedom, then `Z / √(V / ν)` has the Student t law with `ν` degrees of freedom. -/
+theorem hasLaw_studentT_of_gaussian_chiSquared (hν : 0 < ν) (hZV : IndepFun Z V P)
+    (hZ : HasLaw Z (gaussianReal 0 1) P) (hV : HasLaw V (chiSquaredMeasure ν) P) :
+    HasLaw (fun ω ↦ Z ω / √(V ω / ν)) (studentTMeasure ν) P := by
+  let _ : IsProbabilityMeasure P := hZ.isProbabilityMeasure
+  let _ : IsProbabilityMeasure (chiSquaredMeasure ν) :=
+    isProbabilityMeasure_chiSquaredMeasure hν.le
+  have hpair : HasLaw (fun ω ↦ (Z ω, V ω))
+      ((gaussianReal 0 1).prod (chiSquaredMeasure ν)) P :=
+    hZV.hasLaw_prod hZ hV
+  have hratio : HasLaw (fun z : ℝ × ℝ ↦ z.1 / √(z.2 / ν)) (studentTMeasure ν)
+      ((gaussianReal 0 1).prod (chiSquaredMeasure ν)) :=
+    ⟨by fun_prop, map_div_sqrt_chiSquaredMeasure hν⟩
+  exact hratio.fun_comp hpair
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/StudentT/ChiSquared.lean
+++ b/TauCeti/Probability/Distributions/StudentT/ChiSquared.lean
@@ -172,7 +172,7 @@ theorem map_div_sqrt_chiSquaredMeasure {ν : ℝ} (hν : 0 < ν) :
       _ = (μ.map reflect).map ratio := by
         rw [Measure.map_map (by fun_prop) (by fun_prop)]
       _ = μ.map ratio := by rw [hμ_reflect]
-  exact TauCeti.MeasureTheory.Measure.eq_of_map_sq_eq_of_map_neg_eq_self hratio_reflect
+  exact (μ.map ratio).eq_of_map_sq_eq_of_map_neg_eq_self (studentTMeasure ν) hratio_reflect
     (studentTMeasure_map_neg ν) (hratio_sq_map.trans (studentTMeasure_map_sq hν).symm)
 
 variable {Ω : Type*} {mΩ : MeasurableSpace Ω} {P : Measure Ω} {Z V : Ω → ℝ}


### PR DESCRIPTION
This PR identifies the Student t law as the normalized ratio of an independent standard Gaussian and chi-squared variable, completing the Student t bullet of StandardDistributions Layer 4, milestone 2 “Ratios.” It proves both the underlying measure identity and the requested `HasLaw` theorem. The proof follows the already-merged Gaussian-square and Fisher-ratio prerequisites, making this the next unclaimed critical-path step.

The exact target is `StandardDistributions/README.md`, Layer 4, item 2 “Ratios,” first bullet and key declaration `hasLaw_studentT_of_gaussian_chiSquared`. After this PR, the standard-Gaussian quotient/Cauchy bullet remains before the Ratios item is complete.

The measure proof recovers a reflection-invariant real probability measure from its squared pushforward, retaining the possible atom at zero, and then identifies the squared Student t law with Fisher–Snedecor parameters `(1, ν)`. It reuses Mathlib’s Gaussian reflection, product-map, and CDF infrastructure together with Tau Ceti’s `gaussianReal_map_sq`, `map_scaled_div_chiSquaredMeasure`, Student t/Fisher CDFs, and incomplete-beta reflection. No Mathlib infrastructure is vendored.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"haslaw-studentt-of-gaussian-chisquared"}-->

🤖 Prepared with Codex
