### PR TITLE
ci: give the environment lint its own watchdog deadline

### DIFF
--- a/scripts/lint-env.sh
+++ b/scripts/lint-env.sh
@@ -202,6 +202,19 @@ run_lean() {
   fi
 }
 
+# Each driver's wall clock, so the margin against the watchdog deadline is visible
+# in the log before it reaches zero rather than only once a build turns red.
+# Call this OUTSIDE the caller's redirect: both drivers have their stdout AND stderr
+# captured into a file that step 4 parses fail-closed, and a stray line there is
+# either a forged-report suspect or an unattributed violation.
+report_elapsed() {
+  if [ -n "${WATCHDOG_TOOLCHAIN:-}" ]; then
+    echo "lint-env: $1 took $((SECONDS - $2))s of its ${TAUCETI_LEAN_TIMEOUT_SECONDS:-300}s watchdog deadline."
+  else
+    echo "lint-env: $1 took $((SECONDS - $2))s (no watchdog deadline outside the sandboxed build)."
+  fi
+}
+
 fail() { echo "::error::lint-env: $*"; echo "LINT-ENV: FAIL — $*"; exit 1; }
 
 TMP="$(mktemp -d)" || fail "mktemp failed"
@@ -351,7 +364,10 @@ run_meta do
 EOF
 } > "$DOCDRIVER"
 
-if ! run_lean "$DOCDRIVER" > "$TMP/docscan.txt" 2>&1; then
+t0=$SECONDS
+run_lean "$DOCDRIVER" > "$TMP/docscan.txt" 2>&1 && docstatus=0 || docstatus=$?
+report_elapsed "docstring-scan driver" "$t0"
+if [ "$docstatus" -ne 0 ]; then
   cat "$TMP/docscan.txt"
   fail "driver failure: the docstring-scan driver did not elaborate cleanly — see output above"
 fi
@@ -467,11 +483,13 @@ fi
 } > "$DRIVER"
 
 # --- 3. elaborate it (exit 1 from lean is EXPECTED when the linters report) -------
+t0=$SECONDS
 if run_lean "$DRIVER" > "$TMP/out.txt" 2>&1; then
   status=0
 else
   status=$?
 fi
+report_elapsed "lint driver" "$t0"
 
 # --- 4. locate the linter report and parse it fail-closed -------------------------
 # Two genuine header shapes (see SECURITY MODEL): N > 0 comes as an error diagnostic

--- a/scripts/sandbox-build.sh
+++ b/scripts/sandbox-build.sh
@@ -23,8 +23,8 @@ test -d "$TRUSTED_SCRIPTS"
 # Lake normally invokes Lean directly. Route every compiler process through a
 # trusted wall-clock watchdog instead. This script and the wrapper are the
 # workflow-pinned copies, and the sandbox does not pass timeout-control variables,
-# so candidate code cannot raise or disable the 300s
-# deadline. The wrapper and Lean both remain inside the same bwrap sandbox.
+# so candidate code cannot raise or disable the deadlines set here. The wrapper and
+# Lean both remain inside the same bwrap sandbox.
 test -n "${WATCHDOG_TOOLCHAIN:-}"
 test -x "$WATCHDOG_TOOLCHAIN/bin/lean"
 export LAKE_OVERRIDE_LEAN=true
@@ -54,7 +54,14 @@ lake env "$WATCHDOG_TOOLCHAIN/bin/lean" --run "$TRUSTED_SCRIPTS/ModuleSystem.lea
 # (scripts/lint-nolints-allowlist.txt) are workflow-pinned trusted copies, and its report parsing
 # is fail-closed (see the SECURITY MODEL in the script). Fails on new violations or
 # unaccounted nolints; fixed baseline entries print a ratchet reminder only.
-bash "$TRUSTED_SCRIPTS/lint-env.sh"
+#
+# Its drivers are the one pair of Lean processes whose cost scales with the whole
+# library rather than with a single module: `#lint` runs over every declaration in
+# TauCeti at once, so its runtime grows with each merged PR while the per-module
+# deadline does not. Give them a larger, still bounded one. The assignment is scoped
+# to this call, and the sandbox's --setenv allowlist keeps candidate code from
+# setting it; the script prints each driver's elapsed time against this deadline.
+TAUCETI_LEAN_TIMEOUT_SECONDS=900 bash "$TRUSTED_SCRIPTS/lint-env.sh"
 
 # Source style lint. The trusted wrapper uses the shared validated TauCeti/ module list, applies
 # Mathlib's copyright/Authors checks (excluding the deliberately empty root), and generates the


### PR DESCRIPTION
Fixes #5927.

`lint-env.sh` elaborates one driver that runs `#lint only … in TauCeti` over all 65,835 declarations, but `lean-watchdog.sh` gives every Lean process the same 300 s deadline. That lint's runtime grows with the library and now sits at 4:40–5:10, so a loaded runner kills it mid-report — after the lint has passed — and the build correctly fails closed on the missing nonce marker.

This is fix 1 from #5927. `sandbox-build.sh` sets `TAUCETI_LEAN_TIMEOUT_SECONDS=900` as a prefix assignment on the `lint-env.sh` call, so only the whole-library lint gets the larger deadline and `lake build` keeps the 300 s per-module one that bounds a pathological proof. The watchdog already reads the variable; production never set it. `pr-build.yml`'s `--setenv` allowlist still excludes it, so candidate code cannot set it itself.

`lint-env.sh` also prints each driver's wall clock against the deadline in effect (`lint-env: lint driver took 291s of its 900s watchdog deadline.`). The print sits outside the caller's redirect, since both drivers have stdout and stderr captured into the file that step 4 parses fail-closed. 900 s is about 3× today's headroom; once the print regularly shows past ~450 s, the durable fix is sharding the driver (option 2 in the issue).

Roadmap: none
