### PR TITLE
feat: add the rank-one Weyl square relation

### DIFF
--- a/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
@@ -388,8 +388,7 @@ theorem coe_rankOneCarrierTorusPoint (A : Type u) [CommRing A] (s : Fin 1 â†’ AË
   rw [rankOneCarrierTorusPoint, rankOneCarrierTorusHom,
     MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
     MulEquiv.subgroupCongr_symm_apply, coe_kostantToralWeightTorusPoints]
-  change rankOneTorusMatrix s = _
-  exact rankOneTorusMatrix_apply s
+  simpa only [rankOneTorusMatrix] using rankOneTorusMatrix_apply s
 
 private theorem rankOneCarrierPoints_eq_hopfIdealPoints
     (A : Type u) [CommRing A] :

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.Lie.Sl2.Kostant.RootSubgroup
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Torus
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Points
 
 /-!
 # The full-weight rank-one Kostant carrier
@@ -43,6 +44,8 @@ scheme-theoretic steps.
   lattice.
 * `TauCeti.Sl2Std.rankOneRootSubgroup` and `TauCeti.Sl2Std.rankOneWeightTorus`: the two root
   subgroups and the closed split torus in that carrier.
+* `TauCeti.Sl2Std.rankOneCarrierPoints`: the matrix-valued points of the carrier, with its
+  root-subgroup and torus points and their functoriality in the value ring.
 * `TauCeti.Sl2Std.rankOneTorusMatrix`: the associated torus representation.
 * `TauCeti.Sl2Std.rankOneTorusMatrix_apply`: its matrix equation `diag(s, s⁻¹)`.
 
@@ -60,7 +63,7 @@ namespace TauCeti.Sl2Std
 
 open TauCeti.UniversalEnvelopingAlgebra
 
-universe u
+universe u v
 
 local notation "e" => ![slFinTwoBasis ℚ 0, slFinTwoBasis ℚ 1]
 local notation "h" => ![slFinTwoBasis ℚ 2]
@@ -287,18 +290,12 @@ instance isClosedImmersion_rankOneRootSubgroup (i : Fin 2) :
   exact @IsClosedImmersion.of_comp _ _ _
     (rankOneRootSubgroup i).hom.hom.left rankOneGroupSchemeι.hom.hom.left hcomp inferInstance
 
-/-! ## Matrix equations -/
+/-! ## Matrix-valued points -/
 
 /-- The represented split torus on `A`-points, written in the integral basis. -/
 noncomputable def rankOneTorusMatrix {A : Type*} [CommRing A] :
     ((Fin 1 → Aˣ) →* Matrix.GeneralLinearGroup (Fin 2) A) :=
   kostantTorusMatrix M b rankOneWeight
-
-/-- The named rank-one torus homomorphism is the specialization of the general Kostant torus
-homomorphism. -/
-theorem rankOneTorusMatrix_def {A : Type*} [CommRing A] :
-    rankOneTorusMatrix (A := A) = kostantTorusMatrix M b rankOneWeight := by
-  rw [rankOneTorusMatrix]
 
 /-- A rank-one torus point is the diagonal matrix `diag(s, s⁻¹)`. -/
 @[simp]
@@ -309,6 +306,195 @@ theorem rankOneTorusMatrix_apply {A : Type*} [CommRing A] (s : Fin 1 → Aˣ) :
   ext i j
   fin_cases i <;> fin_cases j <;>
     simp [rankOneWeight, torusCharacter_def]
+
+/-- The points of the full-weight rank-one Kostant carrier, embedded in `GL₂`. -/
+noncomputable def rankOneCarrierPoints (A : Type u) [CommRing A] :
+    Subgroup (Matrix.GeneralLinearGroup (Fin 2) A) :=
+  kostantToralPointsSubgroup e h ρ M hM hnil b rankOneWeight A
+
+/-- The named rank-one carrier points are the specialization of the generic toral Kostant
+points. -/
+theorem rankOneCarrierPoints_def (A : Type u) [CommRing A] :
+    rankOneCarrierPoints A =
+      kostantToralPointsSubgroup e h ρ M hM hnil b rankOneWeight A := by
+  rw [rankOneCarrierPoints]
+
+/-- Membership in the rank-one carrier points is vanishing on its defining Hopf ideal. -/
+@[simp]
+theorem mem_rankOneCarrierPoints_iff (A : Type u) [CommRing A]
+    (g : Matrix.GeneralLinearGroup (Fin 2) A) :
+    g ∈ rankOneCarrierPoints A ↔
+      ∀ x ∈ kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight,
+        ((GeneralLinear.pointsMulEquiv (R := ℤ) 2).symm g).ofConv x = 0 := by
+  rw [rankOneCarrierPoints_def]
+  exact mem_kostantToralPointsSubgroup_iff e h ρ M hM hnil b rankOneWeight A g
+
+/-- The two parametrized root subgroups in the points of the rank-one carrier. -/
+noncomputable def rankOneCarrierRootSubgroupHom (i : Fin 2) (A : Type u) [CommRing A] :
+    Multiplicative A →* rankOneCarrierPoints A :=
+  ((MulEquiv.subgroupCongr (rankOneCarrierPoints_def A)).symm.toMonoidHom).comp
+    (kostantToralRootSubgroupPoints e h ρ M hM hnil b rankOneWeight i A)
+
+/-- A parametrized root-subgroup point in the rank-one carrier. -/
+noncomputable abbrev rankOneCarrierRootSubgroupPoint
+    (i : Fin 2) (A : Type u) [CommRing A] (t : Multiplicative A) :
+    rankOneCarrierPoints A :=
+  rankOneCarrierRootSubgroupHom i A t
+
+/-- A carrier-valued root-subgroup point is its represented divided-power exponential matrix. -/
+theorem coe_rankOneCarrierRootSubgroupPoint
+    (i : Fin 2) (A : Type u) [CommRing A] (t : Multiplicative A) :
+    (rankOneCarrierRootSubgroupPoint i A t : Matrix.GeneralLinearGroup (Fin 2) A) =
+      kostantRootSubgroupMatrix e h ρ M hM i (hnil i) b
+        ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm t) := by
+  rw [rankOneCarrierRootSubgroupPoint, rankOneCarrierRootSubgroupHom,
+    MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    MulEquiv.subgroupCongr_symm_apply, coe_kostantToralRootSubgroupPoints]
+
+/-- The entries of a carrier-valued root-subgroup point are those of the corresponding elementary
+transvection. -/
+@[simp]
+theorem coe_rankOneCarrierRootSubgroupPoint_apply
+    (i : Fin 2) (A : Type u) [CommRing A] (t : Multiplicative A) (r s : Fin 2) :
+    ((rankOneCarrierRootSubgroupPoint i A t : Matrix.GeneralLinearGroup (Fin 2) A) :
+        Matrix (Fin 2) (Fin 2) A) r s =
+      (if r = s then 1 else 0) +
+        if s = i.rev ∧ r = i then Multiplicative.toAdd t else 0 := by
+  rw [coe_rankOneCarrierRootSubgroupPoint, kostantRootSubgroupMatrix_apply]
+  rw [kostantRootSubgroupPoints_apply_baseChange_basis_one]
+  by_cases hs : s = i.rev <;> simp [hs, Finsupp.single_apply, eq_comm]
+
+/-- The represented full-weight torus homomorphism into the points of the rank-one carrier. -/
+noncomputable def rankOneCarrierTorusHom (A : Type u) [CommRing A] :
+    (Fin 1 → Aˣ) →* rankOneCarrierPoints A :=
+  ((MulEquiv.subgroupCongr (rankOneCarrierPoints_def A)).symm.toMonoidHom).comp
+    (kostantToralWeightTorusPoints e h ρ M hM hnil b rankOneWeight A)
+
+/-- A represented full-weight torus point in the rank-one carrier. -/
+noncomputable abbrev rankOneCarrierTorusPoint
+    (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) : rankOneCarrierPoints A :=
+  rankOneCarrierTorusHom A s
+
+/-- The represented full-weight torus subgroup inside the points of the rank-one carrier. -/
+noncomputable abbrev rankOneCarrierTorusPoints (A : Type u) [CommRing A] :
+    Subgroup (rankOneCarrierPoints A) :=
+  (rankOneCarrierTorusHom A).range
+
+/-- In the standard basis, a carrier torus point is `diag(s, s⁻¹)`. -/
+@[simp]
+theorem coe_rankOneCarrierTorusPoint (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
+    (rankOneCarrierTorusPoint A s : Matrix.GeneralLinearGroup (Fin 2) A) =
+      diagGL ![s 0, (s 0)⁻¹] := by
+  rw [rankOneCarrierTorusPoint, rankOneCarrierTorusHom,
+    MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    MulEquiv.subgroupCongr_symm_apply, coe_kostantToralWeightTorusPoints]
+  change rankOneTorusMatrix s = _
+  exact rankOneTorusMatrix_apply s
+
+private theorem rankOneCarrierPoints_eq_hopfIdealPoints
+    (A : Type u) [CommRing A] :
+    rankOneCarrierPoints A = GeneralLinear.hopfIdealPointsSubgroup 2
+      (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight) A :=
+  (rankOneCarrierPoints_def A).trans
+    (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight A)
+
+/-- The map on rank-one carrier points induced by a homomorphism of value rings. -/
+noncomputable def rankOneCarrierPointsMap
+    {A : Type u} {B : Type v} [CommRing A] [CommRing B]
+    (f : A →+* B) : rankOneCarrierPoints A →* rankOneCarrierPoints B :=
+  ((MulEquiv.subgroupCongr (rankOneCarrierPoints_eq_hopfIdealPoints B)).symm.toMonoidHom).comp
+    ((GeneralLinear.mapHopfIdealPointsSubgroup 2
+      (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight) f.toIntAlgHom).comp
+      (MulEquiv.subgroupCongr (rankOneCarrierPoints_eq_hopfIdealPoints A)).toMonoidHom)
+
+/-- The induced map on rank-one carrier points is the entrywise map. -/
+@[simp]
+theorem coe_rankOneCarrierPointsMap
+    {A : Type u} {B : Type v} [CommRing A] [CommRing B]
+    (f : A →+* B) (g : rankOneCarrierPoints A) :
+    (rankOneCarrierPointsMap f g : Matrix.GeneralLinearGroup (Fin 2) B) =
+      Matrix.GeneralLinearGroup.map f g := by
+  have hring : f.toIntAlgHom.toRingHom = f := RingHom.ext (RingHom.toIntAlgHom_apply f)
+  rw [rankOneCarrierPointsMap]
+  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    MulEquiv.subgroupCongr_symm_apply, GeneralLinear.coe_mapHopfIdealPointsSubgroup,
+    MulEquiv.subgroupCongr_apply, hring]
+
+/-- Entrywise, the induced map applies the value-ring homomorphism to each matrix entry. -/
+theorem coe_rankOneCarrierPointsMap_apply
+    {A : Type u} {B : Type v} [CommRing A] [CommRing B]
+    (f : A →+* B) (g : rankOneCarrierPoints A) (i j : Fin 2) :
+    ((rankOneCarrierPointsMap f g : Matrix.GeneralLinearGroup (Fin 2) B) :
+        Matrix (Fin 2) (Fin 2) B) i j =
+      f (((g : Matrix.GeneralLinearGroup (Fin 2) A) : Matrix (Fin 2) (Fin 2) A) i j) := by
+  rw [coe_rankOneCarrierPointsMap, Matrix.GeneralLinearGroup.map_apply]
+
+/-- The identity homomorphism induces the identity on rank-one carrier points. -/
+@[simp]
+theorem rankOneCarrierPointsMap_id {A : Type u} [CommRing A] :
+    rankOneCarrierPointsMap (RingHom.id A) = MonoidHom.id _ := by
+  have hid : (RingHom.id A).toIntAlgHom = AlgHom.id ℤ A := AlgHom.ext fun _ ↦ rfl
+  rw [rankOneCarrierPointsMap, hid, GeneralLinear.mapHopfIdealPointsSubgroup_id]
+  apply MonoidHom.ext
+  intro g
+  exact (MulEquiv.subgroupCongr
+    (rankOneCarrierPoints_eq_hopfIdealPoints A)).symm_apply_apply g
+
+/-- The induced maps on rank-one carrier points compose. -/
+@[simp]
+theorem rankOneCarrierPointsMap_comp
+    {A : Type u} {B : Type v} {C : Type*} [CommRing A] [CommRing B] [CommRing C]
+    (f : A →+* B) (g : B →+* C) :
+    rankOneCarrierPointsMap (g.comp f) =
+      (rankOneCarrierPointsMap g).comp (rankOneCarrierPointsMap f) := by
+  have hcomp : (g.comp f).toIntAlgHom = g.toIntAlgHom.comp f.toIntAlgHom :=
+    AlgHom.ext fun _ ↦ rfl
+  apply MonoidHom.ext
+  intro x
+  simp only [rankOneCarrierPointsMap, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, hcomp,
+    GeneralLinear.mapHopfIdealPointsSubgroup_comp, MulEquiv.apply_symm_apply]
+
+/-- An injective value-ring homomorphism induces an injective map on rank-one carrier points. -/
+theorem rankOneCarrierPointsMap_injective
+    {A : Type u} {B : Type v} [CommRing A] [CommRing B]
+    {f : A →+* B} (hf : Function.Injective f) :
+    Function.Injective (rankOneCarrierPointsMap f) := by
+  rw [rankOneCarrierPointsMap]
+  exact (MulEquiv.subgroupCongr
+    (rankOneCarrierPoints_eq_hopfIdealPoints B)).symm.injective.comp
+    ((GeneralLinear.mapHopfIdealPointsSubgroup_injective 2
+      (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight) hf).comp
+      (MulEquiv.subgroupCongr (rankOneCarrierPoints_eq_hopfIdealPoints A)).injective)
+
+/-- The induced map carries rank-one root-subgroup parameters along the value-ring map. -/
+@[simp]
+theorem rankOneCarrierPointsMap_rootSubgroupPoint
+    {A : Type u} {B : Type v} [CommRing A] [CommRing B]
+    (f : A →+* B) (i : Fin 2) (t : Multiplicative A) :
+    rankOneCarrierPointsMap f (rankOneCarrierRootSubgroupPoint i A t) =
+      rankOneCarrierRootSubgroupPoint i B
+        (Multiplicative.ofAdd (f (Multiplicative.toAdd t))) := by
+  apply Subtype.ext
+  rw [coe_rankOneCarrierPointsMap]
+  simp only [rankOneCarrierRootSubgroupPoint, rankOneCarrierRootSubgroupHom,
+    MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
+    coe_kostantToralRootSubgroupPoints]
+  rw [map_kostantRootSubgroupMatrix, AdditiveGroup.mapValue_gaPointsMulEquiv_symm_apply,
+    RingHom.toIntAlgHom_apply]
+
+/-- The induced map carries a torus point coordinatewise along the value-ring map. -/
+@[simp]
+theorem rankOneCarrierPointsMap_torusPoint
+    {A : Type u} {B : Type v} [CommRing A] [CommRing B]
+    (f : A →+* B) (s : Fin 1 → Aˣ) :
+    rankOneCarrierPointsMap f (rankOneCarrierTorusPoint A s) =
+      rankOneCarrierTorusPoint B (fun i ↦ Units.map (f : A →* B) (s i)) := by
+  apply Subtype.ext
+  rw [coe_rankOneCarrierPointsMap]
+  simp only [rankOneCarrierTorusPoint, rankOneCarrierTorusHom,
+    MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
+    coe_kostantToralWeightTorusPoints]
+  exact map_kostantTorusMatrix M b rankOneWeight f s
 
 /-- The represented rank-one weight torus on points of a value algebra. -/
 noncomputable def rankOneTorusPoints (A : CommAlgCat.{u} ℤ) :

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.Sl2.Kostant.RootSubgroup
+public import TauCeti.Algebra.Lie.Sl2.Kostant.Points
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Torus
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Points
 
@@ -360,9 +360,10 @@ theorem coe_rankOneCarrierRootSubgroupPoint_apply
         Matrix (Fin 2) (Fin 2) A) r s =
       (if r = s then 1 else 0) +
         if s = i.rev ∧ r = i then Multiplicative.toAdd t else 0 := by
-  rw [coe_rankOneCarrierRootSubgroupPoint, kostantRootSubgroupMatrix_apply]
-  rw [kostantRootSubgroupPoints_apply_baseChange_basis_one]
-  by_cases hs : s = i.rev <;> simp [hs, Finsupp.single_apply, eq_comm]
+  rw [coe_rankOneCarrierRootSubgroupPoint, kostantRootSubgroupMatrix_eq_transvectionUnit,
+    TauCeti.coe_transvectionUnit]
+  simp [Matrix.transvection, Matrix.add_apply, Matrix.one_apply, Matrix.single_apply, eq_comm,
+    and_comm]
 
 /-- The represented full-weight torus homomorphism into the points of the rank-one carrier. -/
 noncomputable def rankOneCarrierTorusHom (A : Type u) [CommRing A] :

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
@@ -294,6 +294,12 @@ noncomputable def rankOneTorusMatrix {A : Type*} [CommRing A] :
     ((Fin 1 → Aˣ) →* Matrix.GeneralLinearGroup (Fin 2) A) :=
   kostantTorusMatrix M b rankOneWeight
 
+/-- The named rank-one torus matrix is the specialization of the general Kostant torus matrix. -/
+theorem rankOneTorusMatrix_eq_kostantTorusMatrix {A : Type*} [CommRing A]
+    (s : Fin 1 → Aˣ) :
+    rankOneTorusMatrix s = kostantTorusMatrix M b rankOneWeight s := by
+  rw [rankOneTorusMatrix]
+
 /-- A rank-one torus point is the diagonal matrix `diag(s, s⁻¹)`. -/
 @[simp]
 theorem rankOneTorusMatrix_apply {A : Type*} [CommRing A] (s : Fin 1 → Aˣ) :

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/GroupScheme.lean
@@ -294,10 +294,10 @@ noncomputable def rankOneTorusMatrix {A : Type*} [CommRing A] :
     ((Fin 1 → Aˣ) →* Matrix.GeneralLinearGroup (Fin 2) A) :=
   kostantTorusMatrix M b rankOneWeight
 
-/-- The named rank-one torus matrix is the specialization of the general Kostant torus matrix. -/
-theorem rankOneTorusMatrix_eq_kostantTorusMatrix {A : Type*} [CommRing A]
-    (s : Fin 1 → Aˣ) :
-    rankOneTorusMatrix s = kostantTorusMatrix M b rankOneWeight s := by
+/-- The named rank-one torus homomorphism is the specialization of the general Kostant torus
+homomorphism. -/
+theorem rankOneTorusMatrix_def {A : Type*} [CommRing A] :
+    rankOneTorusMatrix (A := A) = kostantTorusMatrix M b rankOneWeight := by
   rw [rankOneTorusMatrix]
 
 /-- A rank-one torus point is the diagonal matrix `diag(s, s⁻¹)`. -/

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
@@ -1,0 +1,289 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.Group.NormalizerQuotient.Basic
+public import TauCeti.Algebra.Lie.Sl2.Kostant.GroupScheme
+public import TauCeti.Algebra.Lie.Sl2.Weyl.Standard
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Weyl
+
+/-!
+# The Weyl involution in the rank-one Kostant carrier
+
+For the full-weight `A₁` carrier constructed from the standard two-dimensional `sl₂` module, this
+file specializes the integral Weyl representative
+
+```text
+n = x₀(1) x₁(-1) x₀(1)
+```
+
+to a point of the carrier over an arbitrary commutative ring.  It proves the rank-one Chevalley
+relation
+
+```text
+n² = h(-1),
+```
+
+where `h(s) = diag(s, s⁻¹)` is the represented full-weight torus.  Consequently the image of `n`
+in the pointwise normalizer quotient has square one.  Over a nontrivial ring this image is not the
+identity: the Weyl matrix has a nonzero off-diagonal entry, whereas every torus point is diagonal.
+
+This is the first quotient-level Weyl relation for the Kostant carriers.  It is the rank-one input
+for comparing the normalizer of the represented torus with the Weyl group in the pinned
+Chevalley--Demazure construction.
+
+## Main declarations
+
+* `TauCeti.Sl2Std.rankOneCarrierPoints`: the matrix-valued points of the full-weight rank-one
+  carrier.
+* `TauCeti.Sl2Std.rankOneCarrierTorusPoints`: its represented split-torus subgroup.
+* `TauCeti.Sl2Std.rankOneWeylPoint`: the canonical Weyl representative in the carrier.
+* `TauCeti.Sl2Std.rankOneWeylPoint_sq`: the relation `n² = h(-1)`.
+* `TauCeti.Sl2Std.rankOneWeylClass`: the representative's class in the torus normalizer quotient.
+* `TauCeti.Sl2Std.rankOneWeylClass_sq` and
+  `TauCeti.Sl2Std.orderOf_rankOneWeylClass`: this class has order two.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §§6.4 and 7.1.
+* R. Steinberg, *Lectures on Chevalley Groups*, §3.
+
+This advances Layer 9, "Pinned Chevalley--Demazure group schemes over `ℤ`", of the
+ReductiveGroups roadmap by establishing the first torus-normalizer quotient relation for the
+full-weight rank-one carrier.
+-/
+
+public section
+
+open TensorProduct
+
+namespace TauCeti.Sl2Std
+
+open TauCeti.UniversalEnvelopingAlgebra
+
+universe u v
+
+local notation "e" => ![slFinTwoBasis ℚ 0, slFinTwoBasis ℚ 1]
+local notation "h" => ![slFinTwoBasis ℚ 2]
+local notation "ρ" => repEnveloping ℚ 1
+local notation "M" => Submodule.toAddSubgroup (integralLattice 1)
+local notation "b" => integralLatticeAddSubgroupBasis 1
+local notation "hnil" => isNilpotent_repEnveloping_root ℚ 1
+local notation "hM" => kostantForm_apply_mem_integralLattice 1
+local notation "wℤ" =>
+  kostantWeylRestrict e h ρ M hM (hnil 0) (hnil 1)
+local notation "wPts" =>
+  kostantWeylPoints e h ρ M hM (hnil 0) (hnil 1)
+
+attribute [local instance high] Algebra.toModule
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+/-! ## Carrier, torus, and Weyl points -/
+
+/-- The points of the full-weight rank-one Kostant carrier, embedded in `GL₂`. -/
+noncomputable abbrev rankOneCarrierPoints (A : Type u) [CommRing A] :
+    Subgroup (Matrix.GeneralLinearGroup (Fin 2) A) :=
+  kostantToralPointsSubgroup e h ρ M hM hnil b rankOneWeight A
+
+/-- The represented full-weight torus homomorphism into the points of the rank-one carrier. -/
+noncomputable def rankOneCarrierTorusHom (A : Type u) [CommRing A] :
+    (Fin 1 → Aˣ) →* rankOneCarrierPoints A :=
+  kostantToralWeightTorusPoints e h ρ M hM hnil b rankOneWeight A
+
+/-- A represented full-weight torus point in the rank-one carrier. -/
+noncomputable abbrev rankOneCarrierTorusPoint (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
+    rankOneCarrierPoints A :=
+  rankOneCarrierTorusHom A s
+
+/-- The represented full-weight torus subgroup inside the points of the rank-one carrier. -/
+noncomputable def rankOneCarrierTorusPoints (A : Type u) [CommRing A] :
+    Subgroup (rankOneCarrierPoints A) :=
+  (rankOneCarrierTorusHom A).range
+
+/-- The canonical Weyl representative `x₀(1) x₁(-1) x₀(1)` in the rank-one carrier. -/
+noncomputable def rankOneWeylPoint (A : Type u) [CommRing A] : rankOneCarrierPoints A :=
+  kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight 0 1 A
+
+/-- The Weyl representative is natural in the ring of points. -/
+theorem map_rankOneWeylPoint {A : Type u} {B : Type v} [CommRing A] [CommRing B]
+    (φ : A →+* B) :
+    GeneralLinear.mapHopfIdealPointsSubgroup 2
+        (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight) φ.toIntAlgHom
+        (MulEquiv.subgroupCongr
+          (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight A)
+          (rankOneWeylPoint A)) =
+      MulEquiv.subgroupCongr
+        (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight B)
+        (rankOneWeylPoint B) := by
+  exact map_kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight φ 0 1
+
+/-- In the standard basis, a carrier torus point is `diag(s, s⁻¹)`. -/
+@[simp]
+theorem coe_rankOneCarrierTorusPoint (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
+    (rankOneCarrierTorusPoint A s : Matrix.GeneralLinearGroup (Fin 2) A) =
+      diagGL ![s 0, (s 0)⁻¹] := by
+  change (kostantToralWeightTorusPoints e h ρ M hM hnil b rankOneWeight A s :
+    Matrix.GeneralLinearGroup (Fin 2) A) = _
+  rw [coe_kostantToralWeightTorusPoints]
+  rw [kostantTorusMatrix_apply]
+  apply Matrix.GeneralLinearGroup.ext
+  intro i j
+  fin_cases i <;> fin_cases j <;>
+    simp [rankOneWeight_zero, rankOneWeight_one, diagGL_apply]
+
+/-- The integral rank-one Weyl automorphism sends a standard lattice basis vector to the reversed
+basis vector with the usual sign. -/
+private theorem rankOneKostantWeylRestrict_apply_basis (j : Fin 2) :
+    wℤ (b j) = ((-1 : ℤ) ^ (1 - (j : ℕ))) • b j.rev := by
+  apply Subtype.ext
+  rw [Sl2Std.coe_kostantWeylRestrict_apply]
+  rw [AddSubgroupClass.coe_zsmul, coe_integralLatticeAddSubgroupBasis_apply,
+    coe_integralLatticeAddSubgroupBasis_apply]
+  rw [← Int.cast_smul_eq_zsmul ℚ]
+  push_cast
+  exact Sl2Std.weylUnit_apply_basis ℚ 1 j
+
+/-- The matrix of the rank-one Kostant Weyl automorphism has the signed reversal entries. -/
+private theorem basisMatrix_rankOneKostantWeylGL_apply (A : Type u) [CommRing A]
+    (i j : Fin 2) :
+    ((Units.map (LinearMap.toMatrixAlgEquiv ((b).baseChange A)).toMonoidHom
+        (kostantWeylGL e h ρ M hM (hnil 0) (hnil 1) A) :
+          Matrix.GeneralLinearGroup (Fin 2) A) : Matrix (Fin 2) (Fin 2) A) i j =
+      if i = j.rev then (-1 : A) ^ (i : ℕ) else 0 := by
+  simp only [Units.coe_map]
+  change (LinearMap.toMatrixAlgEquiv ((b).baseChange A)
+    (kostantWeylGL e h ρ M hM (hnil 0) (hnil 1) A).val) i j = _
+  rw [kostantWeylGL_val, LinearMap.toMatrixAlgEquiv_apply,
+    Module.Basis.baseChange_apply]
+  change (((b).baseChange A).repr (wPts A (1 ⊗ₜ[ℤ] b j))) i = _
+  rw [kostantWeylPoints_apply_tmul, rankOneKostantWeylRestrict_apply_basis]
+  fin_cases i <;> fin_cases j <;> simp
+
+/-- The `(i,j)` entry of the rank-one Weyl representative is `(-1)^i` when `i` is the reversal
+of `j`, and zero otherwise. -/
+@[simp]
+theorem coe_rankOneWeylPoint_apply (A : Type u) [CommRing A] (i j : Fin 2) :
+    ((rankOneWeylPoint A : Matrix.GeneralLinearGroup (Fin 2) A) :
+        Matrix (Fin 2) (Fin 2) A) i j =
+      if i = j.rev then (-1 : A) ^ (i : ℕ) else 0 := by
+  rw [rankOneWeylPoint, coe_kostantToralWeylPoint]
+  exact basisMatrix_rankOneKostantWeylGL_apply A i j
+
+/-! ## The square relation -/
+
+/-- **The rank-one Chevalley relation `n² = h(-1)` in the carrier.** -/
+theorem rankOneWeylPoint_sq (A : Type u) [CommRing A] :
+    rankOneWeylPoint A ^ 2 =
+      rankOneCarrierTorusPoint A (fun _ ↦ (-1 : Aˣ)) := by
+  apply Subtype.ext
+  apply Matrix.GeneralLinearGroup.ext
+  intro i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pow_two, coe_rankOneWeylPoint_apply, coe_rankOneCarrierTorusPoint,
+      diagGL_apply, Matrix.mul_apply]
+
+/-- The inverse rank-one Weyl representative is its product with the central torus point
+`h(-1)`. -/
+theorem rankOneWeylPoint_inv (A : Type u) [CommRing A] :
+    (rankOneWeylPoint A)⁻¹ =
+      rankOneCarrierTorusPoint A (fun _ ↦ (-1 : Aˣ)) * rankOneWeylPoint A := by
+  apply inv_eq_of_mul_eq_one_left
+  rw [mul_assoc, ← pow_two, rankOneWeylPoint_sq, ← map_mul]
+  rw [show ((fun _ ↦ (-1 : Aˣ)) * fun _ ↦ (-1 : Aˣ)) = 1 by
+    funext q
+    fin_cases q
+    simp, map_one]
+
+/-- Conjugation by the rank-one Weyl representative inverts the represented torus. -/
+theorem rankOneWeylPoint_conj_torus (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
+    rankOneWeylPoint A * rankOneCarrierTorusPoint A s *
+        (rankOneWeylPoint A)⁻¹ =
+      rankOneCarrierTorusPoint A (fun _ ↦ (s 0)⁻¹) := by
+  apply Subtype.ext
+  apply Matrix.GeneralLinearGroup.ext
+  intro i j
+  fin_cases i <;> fin_cases j <;>
+    simp [rankOneWeylPoint_inv, coe_rankOneWeylPoint_apply, coe_rankOneCarrierTorusPoint,
+      diagGL_apply, Matrix.mul_apply]
+
+/-- The rank-one Weyl representative belongs to the normalizer of the represented torus. -/
+theorem rankOneWeylPoint_mem_normalizer (A : Type u) [CommRing A] :
+    rankOneWeylPoint A ∈
+      _root_.Subgroup.normalizer
+        ((rankOneCarrierTorusPoints A : Subgroup (rankOneCarrierPoints A)) :
+          Set (rankOneCarrierPoints A)) := by
+  rw [_root_.Subgroup.mem_normalizer_iff]
+  intro x
+  constructor
+  · rintro ⟨s, rfl⟩
+    exact ⟨fun _ ↦ (s 0)⁻¹, (rankOneWeylPoint_conj_torus A s).symm⟩
+  · rintro ⟨s, hs⟩
+    have hconj := rankOneWeylPoint_conj_torus A (fun _ ↦ (s 0)⁻¹)
+    have hf : (fun _ ↦ ((s 0)⁻¹)⁻¹) = s := by
+      funext q
+      fin_cases q
+      simp
+    rw [hf] at hconj
+    refine ⟨fun _ ↦ (s 0)⁻¹, ?_⟩
+    apply (MulAut.conj (rankOneWeylPoint A)).injective
+    change rankOneWeylPoint A * rankOneCarrierTorusPoint A (fun _ ↦ (s 0)⁻¹) *
+        (rankOneWeylPoint A)⁻¹ = rankOneWeylPoint A * x * (rankOneWeylPoint A)⁻¹
+    simpa using hconj.trans hs
+
+/-! ## The normalizer-quotient involution -/
+
+/-- The Weyl representative, regarded as a point of the torus normalizer. -/
+noncomputable def rankOneWeylNormalizerPoint (A : Type u) [CommRing A] :
+    _root_.Subgroup.normalizer
+      ((rankOneCarrierTorusPoints A : Subgroup (rankOneCarrierPoints A)) :
+        Set (rankOneCarrierPoints A)) :=
+  ⟨rankOneWeylPoint A, rankOneWeylPoint_mem_normalizer A⟩
+
+/-- The class of the Weyl representative in the pointwise torus normalizer quotient. -/
+noncomputable def rankOneWeylClass (A : Type u) [CommRing A] :
+    TauCeti.Subgroup.normalizerQuotient (rankOneCarrierTorusPoints A) :=
+  TauCeti.Subgroup.normalizerQuotientMk (rankOneCarrierTorusPoints A)
+    (rankOneWeylNormalizerPoint A)
+
+/-- The Weyl class in the torus normalizer quotient has square one. -/
+@[simp]
+theorem rankOneWeylClass_sq (A : Type u) [CommRing A] :
+    rankOneWeylClass A ^ 2 = 1 := by
+  rw [rankOneWeylClass, ← map_pow]
+  apply (TauCeti.Subgroup.normalizerQuotientMk_eq_one_iff
+    (rankOneCarrierTorusPoints A) ((rankOneWeylNormalizerPoint A) ^ 2)).mpr
+  change rankOneWeylPoint A ^ 2 ∈ rankOneCarrierTorusPoints A
+  rw [rankOneWeylPoint_sq]
+  exact ⟨fun _ ↦ (-1 : Aˣ), rfl⟩
+
+/-- Over a nontrivial ring, the Weyl representative does not belong to the represented torus. -/
+theorem rankOneWeylPoint_not_mem_torus (A : Type u) [CommRing A] [Nontrivial A] :
+    rankOneWeylPoint A ∉ rankOneCarrierTorusPoints A := by
+  rintro ⟨s, hs⟩
+  change rankOneCarrierTorusPoint A s = rankOneWeylPoint A at hs
+  have hentry := congrArg
+    (fun g : rankOneCarrierPoints A ↦ ((g : Matrix.GeneralLinearGroup (Fin 2) A) :
+      Matrix (Fin 2) (Fin 2) A) 0 1) hs
+  simp [coe_rankOneCarrierTorusPoint, coe_rankOneWeylPoint_apply,
+    diagGL_apply] at hentry
+
+/-- Over a nontrivial ring, the Weyl class in the torus normalizer quotient is not the identity.
+-/
+theorem rankOneWeylClass_ne_one (A : Type u) [CommRing A] [Nontrivial A] :
+    rankOneWeylClass A ≠ 1 := by
+  intro hclass
+  have hm := (TauCeti.Subgroup.normalizerQuotientMk_eq_one_iff
+    (rankOneCarrierTorusPoints A) (rankOneWeylNormalizerPoint A)).mp hclass
+  exact rankOneWeylPoint_not_mem_torus A hm
+
+/-- Over a nontrivial ring, the Weyl class has order exactly two in the pointwise torus
+normalizer quotient. -/
+@[simp]
+theorem orderOf_rankOneWeylClass (A : Type u) [CommRing A] [Nontrivial A] :
+    orderOf (rankOneWeylClass A) = 2 :=
+  orderOf_eq_prime (rankOneWeylClass_sq A) (rankOneWeylClass_ne_one A)
+
+end TauCeti.Sl2Std

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
@@ -36,11 +36,10 @@ represented torus with the Weyl group in the pinned Chevalley--Demazure construc
 
 ## Main declarations
 
-* `TauCeti.Sl2Std.rankOneCarrierPoints`: the matrix-valued points of the full-weight rank-one
-  carrier.
-* `TauCeti.Sl2Std.rankOneCarrierTorusPoints`: its represented split-torus subgroup.
 * `TauCeti.Sl2Std.rankOneWeylPoint`: the canonical Weyl representative in the carrier.
 * `TauCeti.Sl2Std.rankOneWeylPoint_sq`: the relation `n² = h(-1)`.
+* `TauCeti.Sl2Std.rankOneWeylPoint_conj_rootSubgroupPoint`: conjugation by `n` interchanges the
+  two carrier-valued root subgroups.
 * `TauCeti.Sl2Std.rankOneWeylClass`: the representative's class in the torus normalizer quotient.
 * `TauCeti.Sl2Std.rankOneWeylClass_sq` and
   `TauCeti.Sl2Std.orderOf_rankOneWeylClass`: this class has square one over every commutative ring
@@ -77,72 +76,26 @@ local notation "wPts" =>
 attribute [local instance high] Algebra.toModule
 attribute [local instance 100] LieRing.ofAssociativeRing
 
-/-! ## Carrier, torus, and Weyl points -/
-
-/-- The points of the full-weight rank-one Kostant carrier, embedded in `GL₂`. -/
-noncomputable abbrev rankOneCarrierPoints (A : Type u) [CommRing A] :
-    Subgroup (Matrix.GeneralLinearGroup (Fin 2) A) :=
-  kostantToralPointsSubgroup e h ρ M hM hnil b rankOneWeight A
-
-/-- The represented full-weight torus homomorphism into the points of the rank-one carrier. -/
-noncomputable def rankOneCarrierTorusHom (A : Type u) [CommRing A] :
-    (Fin 1 → Aˣ) →* rankOneCarrierPoints A :=
-  kostantToralWeightTorusPoints e h ρ M hM hnil b rankOneWeight A
-
-/-- A represented full-weight torus point in the rank-one carrier. -/
-noncomputable abbrev rankOneCarrierTorusPoint (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
-    rankOneCarrierPoints A :=
-  rankOneCarrierTorusHom A s
-
-/-- The represented full-weight torus subgroup inside the points of the rank-one carrier. -/
-noncomputable def rankOneCarrierTorusPoints (A : Type u) [CommRing A] :
-    Subgroup (rankOneCarrierPoints A) :=
-  (rankOneCarrierTorusHom A).range
-
-/-- A carrier point belongs to the represented torus exactly when it is parametrized by a torus
-point. -/
-@[simp]
-theorem mem_rankOneCarrierTorusPoints_iff (A : Type u) [CommRing A]
-    (x : rankOneCarrierPoints A) :
-    x ∈ rankOneCarrierTorusPoints A ↔
-      ∃ s : Fin 1 → Aˣ, x = rankOneCarrierTorusPoint A s := by
-  rw [rankOneCarrierTorusPoints, MonoidHom.mem_range]
-  simp only [rankOneCarrierTorusPoint, eq_comm]
-
-/-- The map on rank-one carrier points induced by a homomorphism of value rings. -/
-noncomputable def rankOneCarrierPointsMap {A : Type u} {B : Type v} [CommRing A] [CommRing B]
-    (φ : A →+* B) : rankOneCarrierPoints A →* rankOneCarrierPoints B :=
-  ((MulEquiv.subgroupCongr
-      (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight B)).symm.toMonoidHom).comp
-    ((GeneralLinear.mapHopfIdealPointsSubgroup 2
-      (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight) φ.toIntAlgHom).comp
-      (MulEquiv.subgroupCongr
-        (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight A)).toMonoidHom)
+/-! ## The Weyl point -/
 
 /-- The canonical Weyl representative `x₀(1) x₁(-1) x₀(1)` in the rank-one carrier. -/
 noncomputable def rankOneWeylPoint (A : Type u) [CommRing A] : rankOneCarrierPoints A :=
-  kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight 0 1 A
+  (MulEquiv.subgroupCongr (rankOneCarrierPoints_def A)).symm
+    (kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight 0 1 A)
 
 /-- The Weyl representative is natural in the ring of points. -/
+@[simp]
 theorem map_rankOneWeylPoint {A : Type u} {B : Type v} [CommRing A] [CommRing B]
     (φ : A →+* B) :
     rankOneCarrierPointsMap φ (rankOneWeylPoint A) = rankOneWeylPoint B := by
-  rw [rankOneCarrierPointsMap]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom]
-  simpa only [rankOneWeylPoint, MulEquiv.symm_apply_apply] using
-    congrArg
-      (MulEquiv.subgroupCongr
-        (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight B)).symm
-      (map_kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight φ 0 1)
-
-/-- In the standard basis, a carrier torus point is `diag(s, s⁻¹)`. -/
-@[simp]
-theorem coe_rankOneCarrierTorusPoint (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
-    (rankOneCarrierTorusPoint A s : Matrix.GeneralLinearGroup (Fin 2) A) =
-      diagGL ![s 0, (s 0)⁻¹] := by
-  rw [rankOneCarrierTorusPoint, rankOneCarrierTorusHom,
-    coe_kostantToralWeightTorusPoints]
-  rw [← rankOneTorusMatrix_def, rankOneTorusMatrix_apply]
+  apply Subtype.ext
+  rw [coe_rankOneCarrierPointsMap]
+  simp only [rankOneWeylPoint, MulEquiv.subgroupCongr_symm_apply]
+  have hmap := congrArg Subtype.val
+    (map_kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight φ 0 1)
+  have hring : φ.toIntAlgHom.toRingHom = φ := RingHom.ext (RingHom.toIntAlgHom_apply φ)
+  simpa only [GeneralLinear.coe_mapHopfIdealPointsSubgroup,
+    MulEquiv.subgroupCongr_apply, hring] using hmap
 
 /-- The integral rank-one Weyl automorphism sends a standard lattice basis vector to the reversed
 basis vector with the usual sign. -/
@@ -169,10 +122,17 @@ private theorem basisMatrix_rankOneKostantWeylGL_apply (A : Type u) [CommRing A]
     (kostantWeylGL e h ρ M hM (hnil 0) (hnil 1) A).val) i j = _
   rw [kostantWeylGL_val, LinearMap.toMatrixAlgEquiv_apply,
     Module.Basis.baseChange_apply]
-  -- A matrix entry is definitionally the corresponding coordinate of the image of its column.
-  change (((b).baseChange A).repr (wPts A (1 ⊗ₜ[ℤ] b j))) i = _
-  rw [kostantWeylPoints_apply_tmul, rankOneKostantWeylRestrict_apply_basis]
+  rw [LinearEquiv.coe_coe, kostantWeylPoints_apply_tmul,
+    rankOneKostantWeylRestrict_apply_basis]
   fin_cases i <;> fin_cases j <;> simp
+
+/-- The carrier-valued Weyl point is the matrix of the integral Weyl automorphism. -/
+theorem coe_rankOneWeylPoint (A : Type u) [CommRing A] :
+    (rankOneWeylPoint A : Matrix.GeneralLinearGroup (Fin 2) A) =
+      Units.map (LinearMap.toMatrixAlgEquiv ((b).baseChange A)).toMulEquiv
+        (kostantWeylGL e h ρ M hM (hnil 0) (hnil 1) A) := by
+  rw [rankOneWeylPoint, MulEquiv.subgroupCongr_symm_apply,
+    coe_kostantToralWeylPoint]
 
 /-- The `(i,j)` entry of the rank-one Weyl representative is `(-1)^i` when `i` is the reversal
 of `j`, and zero otherwise. -/
@@ -181,7 +141,7 @@ theorem coe_rankOneWeylPoint_apply (A : Type u) [CommRing A] (i j : Fin 2) :
     ((rankOneWeylPoint A : Matrix.GeneralLinearGroup (Fin 2) A) :
         Matrix (Fin 2) (Fin 2) A) i j =
       if i = j.rev then (-1 : A) ^ (i : ℕ) else 0 := by
-  rw [rankOneWeylPoint, coe_kostantToralWeylPoint]
+  rw [coe_rankOneWeylPoint]
   exact basisMatrix_rankOneKostantWeylGL_apply A i j
 
 /-! ## The square relation -/
@@ -193,7 +153,7 @@ theorem rankOneWeylPoint_sq (A : Type u) [CommRing A] :
       rankOneCarrierTorusPoint A (fun _ ↦ (-1 : Aˣ)) := by
   apply Subtype.ext
   rw [coe_rankOneCarrierTorusPoint]
-  rw [Subgroup.coe_pow, rankOneWeylPoint, coe_kostantToralWeylPoint]
+  rw [Subgroup.coe_pow, coe_rankOneWeylPoint]
   rw [← map_pow, pow_two]
   apply Units.ext
   simp only [Units.coe_map, Units.val_mul, kostantWeylGL_val, Module.End.mul_eq_comp]
@@ -230,6 +190,56 @@ private theorem lie_cartan_root_one_eq_neg_smul (q : Fin 1) :
   fin_cases q
   simp [rankOneRootWeight_zero, rankOneRootWeight_one]
 
+private theorem rankOneWeylPoint_conj_rootSubgroupPoint_zero
+    (A : Type u) [CommRing A] (t : A) :
+    rankOneWeylPoint A *
+        rankOneCarrierRootSubgroupPoint 0 A (Multiplicative.ofAdd t) *
+        (rankOneWeylPoint A)⁻¹ =
+      rankOneCarrierRootSubgroupPoint 1 A (Multiplicative.ofAdd (-t)) := by
+  have hconj := congrArg Subtype.val
+    (kostantToralWeylPoint_conj_rootSubgroupPoints (wt := rankOneWeight)
+      (i := 0) (j := 1) e h ρ M hM hnil b isSl2Triple_repEnveloping_rankOne A t)
+  apply Subtype.ext
+  simpa only [Subgroup.coe_mul, Subgroup.coe_inv, coe_rankOneWeylPoint,
+    coe_rankOneCarrierRootSubgroupPoint, coe_kostantToralWeylPoint,
+    coe_kostantToralRootSubgroupPoints] using hconj
+
+/-- Conjugation by the rank-one Weyl representative interchanges the two root subgroups and
+negates their parameters. -/
+theorem rankOneWeylPoint_conj_rootSubgroupPoint
+    (A : Type u) [CommRing A] (i : Fin 2) (t : Multiplicative A) :
+    rankOneWeylPoint A * rankOneCarrierRootSubgroupPoint i A t *
+        (rankOneWeylPoint A)⁻¹ =
+      rankOneCarrierRootSubgroupPoint i.rev A
+        (Multiplicative.ofAdd (-Multiplicative.toAdd t)) := by
+  fin_cases i
+  · exact rankOneWeylPoint_conj_rootSubgroupPoint_zero A (Multiplicative.toAdd t)
+  · have hzero := rankOneWeylPoint_conj_rootSubgroupPoint_zero A
+      (-Multiplicative.toAdd t)
+    simp only [neg_neg] at hzero
+    have hof : Multiplicative.ofAdd (Multiplicative.toAdd t) = t := rfl
+    rw [hof] at hzero
+    let z := rankOneCarrierTorusPoint A (fun _ ↦ (-1 : Aˣ))
+    let x := rankOneCarrierRootSubgroupPoint 0 A
+      (Multiplicative.ofAdd (-Multiplicative.toAdd t))
+    have hcomm : z * x = x * z := by
+      apply Subtype.ext
+      apply Matrix.GeneralLinearGroup.ext
+      intro r s
+      fin_cases r <;> fin_cases s <;>
+        simp [z, x, Matrix.mul_apply, Fin.sum_univ_two]
+    change rankOneWeylPoint A * rankOneCarrierRootSubgroupPoint 1 A t *
+        (rankOneWeylPoint A)⁻¹ = x
+    rw [← hzero]
+    calc
+      rankOneWeylPoint A * (rankOneWeylPoint A * x * (rankOneWeylPoint A)⁻¹) *
+          (rankOneWeylPoint A)⁻¹ =
+          rankOneWeylPoint A ^ 2 * x * (rankOneWeylPoint A ^ 2)⁻¹ := by
+        rw [pow_two]
+        group
+      _ = z * x * z⁻¹ := by rw [rankOneWeylPoint_sq]
+      _ = x := by rw [hcomm]; group
+
 /-- Conjugation by the rank-one Weyl representative inverts the represented torus. -/
 theorem rankOneWeylPoint_conj_torus (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
     rankOneWeylPoint A * rankOneCarrierTorusPoint A s *
@@ -242,12 +252,27 @@ theorem rankOneWeylPoint_conj_torus (A : Type u) [CommRing A] (s : Fin 1 → Aˣ
     subst q
     rw [weylReflectTorusPoint_apply_same, rankOneRootWeight_zero, torusCharacter_singleton]
     group
-  simpa only [rankOneWeylPoint, rankOneCarrierTorusPoint, rankOneCarrierTorusHom,
-    hreflect] using
+  have hconj := congrArg Subtype.val
     (kostantToralWeylPoint_conj_weightTorusPoints (wt := rankOneWeight)
       (i := 0) (j := 1) (c := 0) (α := rankOneRootWeight 0) e h ρ M hM hnil b
       isSl2Triple_repEnveloping_rankOne (lie_cartan_root_eq_smul 0)
       lie_cartan_root_one_eq_neg_smul isCartanWeightVector_integralLatticeAddSubgroupBasis A s)
+  simp only [Subgroup.coe_mul, Subgroup.coe_inv, coe_kostantToralWeylPoint,
+    coe_kostantToralWeightTorusPoints, hreflect, kostantTorusMatrix_apply] at hconj
+  have hdiag (t : Fin 1 → Aˣ) :
+      (fun i ↦ torusCharacter t (rankOneWeight i)) = ![t 0, (t 0)⁻¹] := by
+    funext i
+    fin_cases i
+    · change torusCharacter t (rankOneWeight 0) = t 0
+      rw [rankOneWeight_zero, torusCharacter_singleton]
+      simp
+    · change torusCharacter t (rankOneWeight 1) = (t 0)⁻¹
+      rw [rankOneWeight_one, torusCharacter_singleton]
+      simp
+  rw [hdiag s, hdiag (fun _ ↦ (s 0)⁻¹)] at hconj
+  apply Subtype.ext
+  simpa only [Subgroup.coe_mul, Subgroup.coe_inv, coe_rankOneWeylPoint,
+    coe_rankOneCarrierTorusPoint] using hconj
 
 /-- The rank-one Weyl representative belongs to the normalizer of the represented torus. -/
 theorem rankOneWeylPoint_mem_normalizer (A : Type u) [CommRing A] :
@@ -255,11 +280,22 @@ theorem rankOneWeylPoint_mem_normalizer (A : Type u) [CommRing A] :
       _root_.Subgroup.normalizer
         ((rankOneCarrierTorusPoints A : Subgroup (rankOneCarrierPoints A)) :
           Set (rankOneCarrierPoints A)) := by
-  simpa only [rankOneWeylPoint, rankOneCarrierTorusPoints, rankOneCarrierTorusHom] using
-    (kostantToralWeylPoint_mem_normalizer_weightTorusPoints (wt := rankOneWeight)
-      (i := 0) (j := 1) (c := 0) (α := rankOneRootWeight 0) e h ρ M hM hnil b
-      isSl2Triple_repEnveloping_rankOne (lie_cartan_root_eq_smul 0)
-      lie_cartan_root_one_eq_neg_smul isCartanWeightVector_integralLatticeAddSubgroupBasis A)
+  rw [_root_.Subgroup.mem_normalizer_iff]
+  intro x
+  constructor
+  · rintro ⟨s, rfl⟩
+    rw [rankOneWeylPoint_conj_torus]
+    exact ⟨fun _ ↦ (s 0)⁻¹, rfl⟩
+  · rintro ⟨s, hs⟩
+    refine ⟨(fun _ ↦ (s 0)⁻¹), ?_⟩
+    apply (MulAut.conj (rankOneWeylPoint A)).injective
+    have hconj := rankOneWeylPoint_conj_torus A (fun _ ↦ (s 0)⁻¹)
+    have hinv : (fun _ : Fin 1 ↦ ((s 0)⁻¹)⁻¹) = s := by
+      funext q
+      fin_cases q
+      simp
+    rw [hinv] at hconj
+    exact hconj.trans hs
 
 /-! ## The normalizer-quotient involution -/
 
@@ -299,7 +335,8 @@ theorem rankOneWeylClass_sq (A : Type u) [CommRing A] :
   simpa only [Subgroup.coe_pow, coe_rankOneWeylNormalizerPoint] using hsquare
 
 /-- Over a nontrivial ring, the Weyl representative does not belong to the represented torus. -/
-theorem rankOneWeylPoint_not_mem_torus (A : Type u) [CommRing A] [Nontrivial A] :
+theorem rankOneWeylPoint_notMem_rankOneCarrierTorusPoints
+    (A : Type u) [CommRing A] [Nontrivial A] :
     rankOneWeylPoint A ∉ rankOneCarrierTorusPoints A := by
   rintro ⟨s, hs⟩
   have hs' : rankOneCarrierTorusPoint A s = rankOneWeylPoint A := by
@@ -307,8 +344,8 @@ theorem rankOneWeylPoint_not_mem_torus (A : Type u) [CommRing A] [Nontrivial A] 
   have hentry := congrArg
     (fun g : rankOneCarrierPoints A ↦ ((g : Matrix.GeneralLinearGroup (Fin 2) A) :
       Matrix (Fin 2) (Fin 2) A) 0 1) hs'
-  simp [coe_rankOneCarrierTorusPoint, coe_rankOneWeylPoint_apply,
-    diagGL_apply] at hentry
+  rw [coe_rankOneCarrierTorusPoint, coe_rankOneWeylPoint_apply] at hentry
+  simp [diagGL_apply] at hentry
 
 /-- Over a nontrivial ring, the Weyl class in the torus normalizer quotient is not the identity.
 -/
@@ -318,7 +355,8 @@ theorem rankOneWeylClass_ne_one (A : Type u) [CommRing A] [Nontrivial A] :
   rw [rankOneWeylClass] at hclass
   have hm := (TauCeti.Subgroup.normalizerQuotientMk_eq_one_iff
     (rankOneCarrierTorusPoints A) (rankOneWeylNormalizerPoint A)).mp hclass
-  exact rankOneWeylPoint_not_mem_torus A (by simpa only [coe_rankOneWeylNormalizerPoint] using hm)
+  exact rankOneWeylPoint_notMem_rankOneCarrierTorusPoints A
+    (by simpa only [coe_rankOneWeylNormalizerPoint] using hm)
 
 /-- Over a nontrivial ring, the Weyl class has order exactly two in the pointwise torus
 normalizer quotient. -/

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
@@ -281,8 +281,11 @@ theorem rankOneWeylClass_eq_normalizerQuotientMk (A : Type u) [CommRing A] :
 /-- The Weyl class in the torus normalizer quotient has square one. -/
 @[simp]
 theorem rankOneWeylClass_sq (A : Type u) [CommRing A] :
-    rankOneWeylClass A ^ 2 = 1 := by
-  rw [rankOneWeylClass_eq_normalizerQuotientMk, ← map_pow]
+    (rankOneWeylNormalizerPoint A :
+      TauCeti.Subgroup.normalizerQuotient (rankOneCarrierTorusPoints A)) ^ 2 = 1 := by
+  change TauCeti.Subgroup.normalizerQuotientMk (rankOneCarrierTorusPoints A)
+      (rankOneWeylNormalizerPoint A) ^ 2 = 1
+  rw [← map_pow]
   apply (TauCeti.Subgroup.normalizerQuotientMk_eq_one_iff
     (rankOneCarrierTorusPoints A) ((rankOneWeylNormalizerPoint A) ^ 2)).mpr
   have hsquare : rankOneWeylPoint A ^ 2 ∈ rankOneCarrierTorusPoints A := by
@@ -316,7 +319,8 @@ theorem rankOneWeylClass_ne_one (A : Type u) [CommRing A] [Nontrivial A] :
 normalizer quotient. -/
 @[simp]
 theorem orderOf_rankOneWeylClass (A : Type u) [CommRing A] [Nontrivial A] :
-    orderOf (rankOneWeylClass A) = 2 :=
+    orderOf (rankOneWeylNormalizerPoint A :
+      TauCeti.Subgroup.normalizerQuotient (rankOneCarrierTorusPoints A)) = 2 :=
   orderOf_eq_prime (rankOneWeylClass_sq A) (rankOneWeylClass_ne_one A)
 
 end TauCeti.Sl2Std

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
@@ -44,16 +44,13 @@ Chevalley--Demazure construction.
 * `TauCeti.Sl2Std.rankOneWeylPoint_sq`: the relation `n² = h(-1)`.
 * `TauCeti.Sl2Std.rankOneWeylClass`: the representative's class in the torus normalizer quotient.
 * `TauCeti.Sl2Std.rankOneWeylClass_sq` and
-  `TauCeti.Sl2Std.orderOf_rankOneWeylClass`: this class has order two.
+  `TauCeti.Sl2Std.orderOf_rankOneWeylClass`: this class has square one over every commutative ring
+  and order exactly two over a nontrivial ring.
 
 ## References
 
 * R. W. Carter, *Simple Groups of Lie Type*, §§6.4 and 7.1.
 * R. Steinberg, *Lectures on Chevalley Groups*, §3.
-
-This advances Layer 9, "Pinned Chevalley--Demazure group schemes over `ℤ`", of the
-ReductiveGroups roadmap by establishing the first torus-normalizer quotient relation for the
-full-weight rank-one carrier.
 -/
 
 public section
@@ -125,9 +122,8 @@ theorem map_rankOneWeylPoint {A : Type u} {B : Type v} [CommRing A] [CommRing B]
 theorem coe_rankOneCarrierTorusPoint (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
     (rankOneCarrierTorusPoint A s : Matrix.GeneralLinearGroup (Fin 2) A) =
       diagGL ![s 0, (s 0)⁻¹] := by
-  change (kostantToralWeightTorusPoints e h ρ M hM hnil b rankOneWeight A s :
-    Matrix.GeneralLinearGroup (Fin 2) A) = _
-  rw [coe_kostantToralWeightTorusPoints]
+  rw [rankOneCarrierTorusPoint, rankOneCarrierTorusHom,
+    coe_kostantToralWeightTorusPoints]
   rw [kostantTorusMatrix_apply]
   apply Matrix.GeneralLinearGroup.ext
   intro i j
@@ -154,10 +150,12 @@ private theorem basisMatrix_rankOneKostantWeylGL_apply (A : Type u) [CommRing A]
           Matrix.GeneralLinearGroup (Fin 2) A) : Matrix (Fin 2) (Fin 2) A) i j =
       if i = j.rev then (-1 : A) ^ (i : ℕ) else 0 := by
   simp only [Units.coe_map]
+  -- The mapped unit's value is definitionally the basis matrix of its underlying endomorphism.
   change (LinearMap.toMatrixAlgEquiv ((b).baseChange A)
     (kostantWeylGL e h ρ M hM (hnil 0) (hnil 1) A).val) i j = _
   rw [kostantWeylGL_val, LinearMap.toMatrixAlgEquiv_apply,
     Module.Basis.baseChange_apply]
+  -- A matrix entry is definitionally the corresponding coordinate of the image of its column.
   change (((b).baseChange A).repr (wPts A (1 ⊗ₜ[ℤ] b j))) i = _
   rw [kostantWeylPoints_apply_tmul, rankOneKostantWeylRestrict_apply_basis]
   fin_cases i <;> fin_cases j <;> simp
@@ -179,11 +177,15 @@ theorem rankOneWeylPoint_sq (A : Type u) [CommRing A] :
     rankOneWeylPoint A ^ 2 =
       rankOneCarrierTorusPoint A (fun _ ↦ (-1 : Aˣ)) := by
   apply Subtype.ext
-  apply Matrix.GeneralLinearGroup.ext
-  intro i j
+  rw [coe_rankOneCarrierTorusPoint]
+  rw [Subgroup.coe_pow, rankOneWeylPoint, coe_kostantToralWeylPoint]
+  rw [← map_pow, pow_two]
+  apply Units.ext
+  simp only [Units.coe_map, Units.val_mul, kostantWeylGL_val, Module.End.mul_eq_comp]
+  rw [kostantWeylPoints_comp_self]
+  ext i j
   fin_cases i <;> fin_cases j <;>
-    simp [pow_two, coe_rankOneWeylPoint_apply, coe_rankOneCarrierTorusPoint,
-      diagGL_apply, Matrix.mul_apply]
+    simp [LinearMap.toMatrixAlgEquiv_apply, diagGL_apply]
 
 /-- The inverse rank-one Weyl representative is its product with the central torus point
 `h(-1)`. -/
@@ -192,22 +194,44 @@ theorem rankOneWeylPoint_inv (A : Type u) [CommRing A] :
       rankOneCarrierTorusPoint A (fun _ ↦ (-1 : Aˣ)) * rankOneWeylPoint A := by
   apply inv_eq_of_mul_eq_one_left
   rw [mul_assoc, ← pow_two, rankOneWeylPoint_sq, ← map_mul]
-  rw [show ((fun _ ↦ (-1 : Aˣ)) * fun _ ↦ (-1 : Aˣ)) = 1 by
+  have hnegOneSq : ((fun _ : Fin 1 ↦ (-1 : Aˣ)) * fun _ ↦ (-1 : Aˣ)) = 1 := by
     funext q
     fin_cases q
-    simp, map_one]
+    simp
+  rw [hnegOneSq, map_one]
+
+private theorem isSl2Triple_repEnveloping_rankOne : IsSl2Triple
+    (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h 0)))
+    (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e 0)))
+    (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e 1))) := by
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_fin_one,
+    repEnveloping_ι_slFinTwoBasis]
+  exact isSl2Triple_diag_raise_lower (K := ℚ) (n := 1) (by norm_num)
+
+private theorem lie_cartan_root_one_eq_neg_smul (q : Fin 1) :
+    ⁅h q, e 1⁆ = -((rankOneRootWeight 0 q : ℚ) • e 1) := by
+  rw [lie_cartan_root_eq_smul]
+  fin_cases q
+  simp [rankOneRootWeight_zero, rankOneRootWeight_one]
 
 /-- Conjugation by the rank-one Weyl representative inverts the represented torus. -/
 theorem rankOneWeylPoint_conj_torus (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
     rankOneWeylPoint A * rankOneCarrierTorusPoint A s *
         (rankOneWeylPoint A)⁻¹ =
       rankOneCarrierTorusPoint A (fun _ ↦ (s 0)⁻¹) := by
-  apply Subtype.ext
-  apply Matrix.GeneralLinearGroup.ext
-  intro i j
-  fin_cases i <;> fin_cases j <;>
-    simp [rankOneWeylPoint_inv, coe_rankOneWeylPoint_apply, coe_rankOneCarrierTorusPoint,
-      diagGL_apply, Matrix.mul_apply]
+  have hreflect : weylReflectTorusPoint (rankOneRootWeight 0) 0 s =
+      (fun _ ↦ (s 0)⁻¹) := by
+    funext q
+    have hq : q = 0 := Subsingleton.elim _ _
+    subst q
+    rw [weylReflectTorusPoint_apply_same, rankOneRootWeight_zero, torusCharacter_singleton]
+    group
+  simpa only [rankOneWeylPoint, rankOneCarrierTorusPoint, rankOneCarrierTorusHom,
+    hreflect] using
+    (kostantToralWeylPoint_conj_weightTorusPoints (wt := rankOneWeight)
+      (i := 0) (j := 1) (c := 0) (α := rankOneRootWeight 0) e h ρ M hM hnil b
+      isSl2Triple_repEnveloping_rankOne (lie_cartan_root_eq_smul 0)
+      lie_cartan_root_one_eq_neg_smul isCartanWeightVector_integralLatticeAddSubgroupBasis A s)
 
 /-- The rank-one Weyl representative belongs to the normalizer of the represented torus. -/
 theorem rankOneWeylPoint_mem_normalizer (A : Type u) [CommRing A] :
@@ -215,23 +239,11 @@ theorem rankOneWeylPoint_mem_normalizer (A : Type u) [CommRing A] :
       _root_.Subgroup.normalizer
         ((rankOneCarrierTorusPoints A : Subgroup (rankOneCarrierPoints A)) :
           Set (rankOneCarrierPoints A)) := by
-  rw [_root_.Subgroup.mem_normalizer_iff]
-  intro x
-  constructor
-  · rintro ⟨s, rfl⟩
-    exact ⟨fun _ ↦ (s 0)⁻¹, (rankOneWeylPoint_conj_torus A s).symm⟩
-  · rintro ⟨s, hs⟩
-    have hconj := rankOneWeylPoint_conj_torus A (fun _ ↦ (s 0)⁻¹)
-    have hf : (fun _ ↦ ((s 0)⁻¹)⁻¹) = s := by
-      funext q
-      fin_cases q
-      simp
-    rw [hf] at hconj
-    refine ⟨fun _ ↦ (s 0)⁻¹, ?_⟩
-    apply (MulAut.conj (rankOneWeylPoint A)).injective
-    change rankOneWeylPoint A * rankOneCarrierTorusPoint A (fun _ ↦ (s 0)⁻¹) *
-        (rankOneWeylPoint A)⁻¹ = rankOneWeylPoint A * x * (rankOneWeylPoint A)⁻¹
-    simpa using hconj.trans hs
+  simpa only [rankOneWeylPoint, rankOneCarrierTorusPoints, rankOneCarrierTorusHom] using
+    (kostantToralWeylPoint_mem_normalizer_weightTorusPoints (wt := rankOneWeight)
+      (i := 0) (j := 1) (c := 0) (α := rankOneRootWeight 0) e h ρ M hM hnil b
+      isSl2Triple_repEnveloping_rankOne (lie_cartan_root_eq_smul 0)
+      lie_cartan_root_one_eq_neg_smul isCartanWeightVector_integralLatticeAddSubgroupBasis A)
 
 /-! ## The normalizer-quotient involution -/
 
@@ -242,31 +254,51 @@ noncomputable def rankOneWeylNormalizerPoint (A : Type u) [CommRing A] :
         Set (rankOneCarrierPoints A)) :=
   ⟨rankOneWeylPoint A, rankOneWeylPoint_mem_normalizer A⟩
 
+/-- The underlying carrier point of the packaged normalizer element is the Weyl representative. -/
+@[simp]
+theorem coe_rankOneWeylNormalizerPoint (A : Type u) [CommRing A] :
+    ((rankOneWeylNormalizerPoint A :
+        _root_.Subgroup.normalizer
+          ((rankOneCarrierTorusPoints A : Subgroup (rankOneCarrierPoints A)) :
+            Set (rankOneCarrierPoints A))) : rankOneCarrierPoints A) =
+      rankOneWeylPoint A :=
+  by rw [rankOneWeylNormalizerPoint]
+
 /-- The class of the Weyl representative in the pointwise torus normalizer quotient. -/
 noncomputable def rankOneWeylClass (A : Type u) [CommRing A] :
     TauCeti.Subgroup.normalizerQuotient (rankOneCarrierTorusPoints A) :=
   TauCeti.Subgroup.normalizerQuotientMk (rankOneCarrierTorusPoints A)
     (rankOneWeylNormalizerPoint A)
 
+/-- The Weyl class is represented by the packaged Weyl normalizer point. -/
+@[simp]
+theorem rankOneWeylClass_eq_normalizerQuotientMk (A : Type u) [CommRing A] :
+    rankOneWeylClass A =
+      TauCeti.Subgroup.normalizerQuotientMk (rankOneCarrierTorusPoints A)
+        (rankOneWeylNormalizerPoint A) :=
+  by rw [rankOneWeylClass]
+
 /-- The Weyl class in the torus normalizer quotient has square one. -/
 @[simp]
 theorem rankOneWeylClass_sq (A : Type u) [CommRing A] :
     rankOneWeylClass A ^ 2 = 1 := by
-  rw [rankOneWeylClass, ← map_pow]
+  rw [rankOneWeylClass_eq_normalizerQuotientMk, ← map_pow]
   apply (TauCeti.Subgroup.normalizerQuotientMk_eq_one_iff
     (rankOneCarrierTorusPoints A) ((rankOneWeylNormalizerPoint A) ^ 2)).mpr
-  change rankOneWeylPoint A ^ 2 ∈ rankOneCarrierTorusPoints A
-  rw [rankOneWeylPoint_sq]
-  exact ⟨fun _ ↦ (-1 : Aˣ), rfl⟩
+  have hsquare : rankOneWeylPoint A ^ 2 ∈ rankOneCarrierTorusPoints A := by
+    rw [rankOneWeylPoint_sq]
+    exact ⟨fun _ ↦ (-1 : Aˣ), rfl⟩
+  simpa only [Subgroup.coe_pow, coe_rankOneWeylNormalizerPoint] using hsquare
 
 /-- Over a nontrivial ring, the Weyl representative does not belong to the represented torus. -/
 theorem rankOneWeylPoint_not_mem_torus (A : Type u) [CommRing A] [Nontrivial A] :
     rankOneWeylPoint A ∉ rankOneCarrierTorusPoints A := by
   rintro ⟨s, hs⟩
-  change rankOneCarrierTorusPoint A s = rankOneWeylPoint A at hs
+  have hs' : rankOneCarrierTorusPoint A s = rankOneWeylPoint A := by
+    simpa only [rankOneCarrierTorusPoint] using hs
   have hentry := congrArg
     (fun g : rankOneCarrierPoints A ↦ ((g : Matrix.GeneralLinearGroup (Fin 2) A) :
-      Matrix (Fin 2) (Fin 2) A) 0 1) hs
+      Matrix (Fin 2) (Fin 2) A) 0 1) hs'
   simp [coe_rankOneCarrierTorusPoint, coe_rankOneWeylPoint_apply,
     diagGL_apply] at hentry
 
@@ -275,9 +307,10 @@ theorem rankOneWeylPoint_not_mem_torus (A : Type u) [CommRing A] [Nontrivial A] 
 theorem rankOneWeylClass_ne_one (A : Type u) [CommRing A] [Nontrivial A] :
     rankOneWeylClass A ≠ 1 := by
   intro hclass
+  rw [rankOneWeylClass_eq_normalizerQuotientMk] at hclass
   have hm := (TauCeti.Subgroup.normalizerQuotientMk_eq_one_iff
     (rankOneCarrierTorusPoints A) (rankOneWeylNormalizerPoint A)).mp hclass
-  exact rankOneWeylPoint_not_mem_torus A hm
+  exact rankOneWeylPoint_not_mem_torus A (by simpa only [coe_rankOneWeylNormalizerPoint] using hm)
 
 /-- Over a nontrivial ring, the Weyl class has order exactly two in the pointwise torus
 normalizer quotient. -/

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
@@ -284,22 +284,35 @@ theorem rankOneWeylPoint_mem_normalizer (A : Type u) [CommRing A] :
       _root_.Subgroup.normalizer
         ((rankOneCarrierTorusPoints A : Subgroup (rankOneCarrierPoints A)) :
           Set (rankOneCarrierPoints A)) := by
-  rw [_root_.Subgroup.mem_normalizer_iff]
-  intro x
-  constructor
-  · rintro ⟨s, rfl⟩
-    rw [rankOneWeylPoint_conj_torusPoint]
-    exact ⟨fun _ ↦ (s 0)⁻¹, rfl⟩
-  · rintro ⟨s, hs⟩
-    refine ⟨(fun _ ↦ (s 0)⁻¹), ?_⟩
-    apply (MulAut.conj (rankOneWeylPoint A)).injective
-    have hconj := rankOneWeylPoint_conj_torusPoint A (fun _ ↦ (s 0)⁻¹)
-    have hinv : (fun _ : Fin 1 ↦ ((s 0)⁻¹)⁻¹) = s := by
-      funext q
-      fin_cases q
-      simp
-    rw [hinv] at hconj
-    exact hconj.trans hs
+  let carrierEquiv : rankOneCarrierPoints A ≃*
+      kostantToralPointsSubgroup e h ρ M hM hnil b rankOneWeight A :=
+    MulEquiv.subgroupCongr (rankOneCarrierPoints_def A)
+  have htorusPoint (s : Fin 1 → Aˣ) :
+      carrierEquiv (rankOneCarrierTorusPoint A s) =
+        kostantToralWeightTorusPoints e h ρ M hM hnil b rankOneWeight A s := by
+    apply Subtype.ext
+    simp only [carrierEquiv, MulEquiv.subgroupCongr_apply]
+    rw [coe_rankOneCarrierTorusPoint,
+      coe_kostantToralWeightTorusPoints, kostantTorusMatrix_apply]
+    apply Units.ext
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [rankOneWeight_zero, rankOneWeight_one, torusCharacter_singleton, diagGL_apply]
+  have htorus : (rankOneCarrierTorusPoints A).map carrierEquiv.toMonoidHom =
+      (kostantToralWeightTorusPoints e h ρ M hM hnil b rankOneWeight A).range := by
+    ext x
+    constructor
+    · rintro ⟨_, ⟨s, rfl⟩, rfl⟩
+      exact ⟨s, (htorusPoint s).symm⟩
+    · rintro ⟨s, rfl⟩
+      exact ⟨rankOneCarrierTorusPoint A s, ⟨s, rfl⟩, htorusPoint s⟩
+  rw [← _root_.Subgroup.mem_map_iff_mem (f := carrierEquiv.toMonoidHom) carrierEquiv.injective,
+    _root_.Subgroup.map_equiv_normalizer_eq, htorus]
+  simpa [rankOneWeylPoint, carrierEquiv] using
+    (kostantToralWeylPoint_mem_normalizer_weightTorusPoints
+      e h ρ M hM hnil b rankOneWeight isSl2Triple_repEnveloping_rankOne
+      (lie_cartan_root_eq_smul 0) lie_cartan_root_one_eq_neg_smul
+      isCartanWeightVector_integralLatticeAddSubgroupBasis A)
 
 /-! ## The normalizer-quotient involution -/
 

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
@@ -85,7 +85,8 @@ noncomputable def rankOneWeylPoint (A : Type u) [CommRing A] : rankOneCarrierPoi
 
 /-- The Weyl representative is natural in the ring of points. -/
 @[simp]
-theorem map_rankOneWeylPoint {A : Type u} {B : Type v} [CommRing A] [CommRing B]
+theorem rankOneCarrierPointsMap_weylPoint
+    {A : Type u} {B : Type v} [CommRing A] [CommRing B]
     (φ : A →+* B) :
     rankOneCarrierPointsMap φ (rankOneWeylPoint A) = rankOneWeylPoint B := by
   apply Subtype.ext
@@ -228,6 +229,7 @@ theorem rankOneWeylPoint_conj_rootSubgroupPoint
       intro r s
       fin_cases r <;> fin_cases s <;>
         simp [z, x, Matrix.mul_apply, Fin.sum_univ_two]
+    -- After `fin_cases`, folding the displayed root point into the local name `x` is definitional.
     change rankOneWeylPoint A * rankOneCarrierRootSubgroupPoint 1 A t *
         (rankOneWeylPoint A)⁻¹ = x
     rw [← hzero]
@@ -241,7 +243,7 @@ theorem rankOneWeylPoint_conj_rootSubgroupPoint
       _ = x := by rw [hcomm]; group
 
 /-- Conjugation by the rank-one Weyl representative inverts the represented torus. -/
-theorem rankOneWeylPoint_conj_torus (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
+theorem rankOneWeylPoint_conj_torusPoint (A : Type u) [CommRing A] (s : Fin 1 → Aˣ) :
     rankOneWeylPoint A * rankOneCarrierTorusPoint A s *
         (rankOneWeylPoint A)⁻¹ =
       rankOneCarrierTorusPoint A (fun _ ↦ (s 0)⁻¹) := by
@@ -263,10 +265,12 @@ theorem rankOneWeylPoint_conj_torus (A : Type u) [CommRing A] (s : Fin 1 → Aˣ
       (fun i ↦ torusCharacter t (rankOneWeight i)) = ![t 0, (t 0)⁻¹] := by
     funext i
     fin_cases i
-    · change torusCharacter t (rankOneWeight 0) = t 0
+    · -- `fin_cases` leaves an eta-expanded `Fin 2` index, so expose its canonical value first.
+      change torusCharacter t (rankOneWeight 0) = t 0
       rw [rankOneWeight_zero, torusCharacter_singleton]
       simp
-    · change torusCharacter t (rankOneWeight 1) = (t 0)⁻¹
+    · -- Likewise, expose the canonical value of the second finite index.
+      change torusCharacter t (rankOneWeight 1) = (t 0)⁻¹
       rw [rankOneWeight_one, torusCharacter_singleton]
       simp
   rw [hdiag s, hdiag (fun _ ↦ (s 0)⁻¹)] at hconj
@@ -284,12 +288,12 @@ theorem rankOneWeylPoint_mem_normalizer (A : Type u) [CommRing A] :
   intro x
   constructor
   · rintro ⟨s, rfl⟩
-    rw [rankOneWeylPoint_conj_torus]
+    rw [rankOneWeylPoint_conj_torusPoint]
     exact ⟨fun _ ↦ (s 0)⁻¹, rfl⟩
   · rintro ⟨s, hs⟩
     refine ⟨(fun _ ↦ (s 0)⁻¹), ?_⟩
     apply (MulAut.conj (rankOneWeylPoint A)).injective
-    have hconj := rankOneWeylPoint_conj_torus A (fun _ ↦ (s 0)⁻¹)
+    have hconj := rankOneWeylPoint_conj_torusPoint A (fun _ ↦ (s 0)⁻¹)
     have hinv : (fun _ : Fin 1 ↦ ((s 0)⁻¹)⁻¹) = s := by
       funext q
       fin_cases q

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
@@ -11,7 +11,7 @@ public import TauCeti.Algebra.Lie.Sl2.Weyl.Standard
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Weyl
 
 /-!
-# The Weyl involution in the rank-one Kostant carrier
+# The rank-one Weyl representative in the Kostant carrier
 
 For the full-weight `A₁` carrier constructed from the standard two-dimensional `sl₂` module, this
 file specializes the integral Weyl representative
@@ -31,9 +31,8 @@ where `h(s) = diag(s, s⁻¹)` is the represented full-weight torus.  Consequent
 in the pointwise normalizer quotient has square one.  Over a nontrivial ring this image is not the
 identity: the Weyl matrix has a nonzero off-diagonal entry, whereas every torus point is diagonal.
 
-This is the first quotient-level Weyl relation for the Kostant carriers.  It is the rank-one input
-for comparing the normalizer of the represented torus with the Weyl group in the pinned
-Chevalley--Demazure construction.
+This quotient-level Weyl relation supplies the rank-one input for comparing the normalizer of the
+represented torus with the Weyl group in the pinned Chevalley--Demazure construction.
 
 ## Main declarations
 
@@ -124,11 +123,7 @@ theorem coe_rankOneCarrierTorusPoint (A : Type u) [CommRing A] (s : Fin 1 → A�
       diagGL ![s 0, (s 0)⁻¹] := by
   rw [rankOneCarrierTorusPoint, rankOneCarrierTorusHom,
     coe_kostantToralWeightTorusPoints]
-  rw [kostantTorusMatrix_apply]
-  apply Matrix.GeneralLinearGroup.ext
-  intro i j
-  fin_cases i <;> fin_cases j <;>
-    simp [rankOneWeight_zero, rankOneWeight_one, diagGL_apply]
+  rw [← rankOneTorusMatrix_eq_kostantTorusMatrix, rankOneTorusMatrix_apply]
 
 /-- The integral rank-one Weyl automorphism sends a standard lattice basis vector to the reversed
 basis vector with the usual sign. -/
@@ -271,7 +266,6 @@ noncomputable def rankOneWeylClass (A : Type u) [CommRing A] :
     (rankOneWeylNormalizerPoint A)
 
 /-- The Weyl class is represented by the packaged Weyl normalizer point. -/
-@[simp]
 theorem rankOneWeylClass_eq_normalizerQuotientMk (A : Type u) [CommRing A] :
     rankOneWeylClass A =
       TauCeti.Subgroup.normalizerQuotientMk (rankOneCarrierTorusPoints A)
@@ -281,11 +275,8 @@ theorem rankOneWeylClass_eq_normalizerQuotientMk (A : Type u) [CommRing A] :
 /-- The Weyl class in the torus normalizer quotient has square one. -/
 @[simp]
 theorem rankOneWeylClass_sq (A : Type u) [CommRing A] :
-    (rankOneWeylNormalizerPoint A :
-      TauCeti.Subgroup.normalizerQuotient (rankOneCarrierTorusPoints A)) ^ 2 = 1 := by
-  change TauCeti.Subgroup.normalizerQuotientMk (rankOneCarrierTorusPoints A)
-      (rankOneWeylNormalizerPoint A) ^ 2 = 1
-  rw [← map_pow]
+    rankOneWeylClass A ^ 2 = 1 := by
+  rw [rankOneWeylClass_eq_normalizerQuotientMk, ← map_pow]
   apply (TauCeti.Subgroup.normalizerQuotientMk_eq_one_iff
     (rankOneCarrierTorusPoints A) ((rankOneWeylNormalizerPoint A) ^ 2)).mpr
   have hsquare : rankOneWeylPoint A ^ 2 ∈ rankOneCarrierTorusPoints A := by
@@ -319,8 +310,7 @@ theorem rankOneWeylClass_ne_one (A : Type u) [CommRing A] [Nontrivial A] :
 normalizer quotient. -/
 @[simp]
 theorem orderOf_rankOneWeylClass (A : Type u) [CommRing A] [Nontrivial A] :
-    orderOf (rankOneWeylNormalizerPoint A :
-      TauCeti.Subgroup.normalizerQuotient (rankOneCarrierTorusPoints A)) = 2 :=
+    orderOf (rankOneWeylClass A) = 2 :=
   orderOf_eq_prime (rankOneWeylClass_sq A) (rankOneWeylClass_ne_one A)
 
 end TauCeti.Sl2Std

--- a/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
+++ b/TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean
@@ -99,6 +99,26 @@ noncomputable def rankOneCarrierTorusPoints (A : Type u) [CommRing A] :
     Subgroup (rankOneCarrierPoints A) :=
   (rankOneCarrierTorusHom A).range
 
+/-- A carrier point belongs to the represented torus exactly when it is parametrized by a torus
+point. -/
+@[simp]
+theorem mem_rankOneCarrierTorusPoints_iff (A : Type u) [CommRing A]
+    (x : rankOneCarrierPoints A) :
+    x ∈ rankOneCarrierTorusPoints A ↔
+      ∃ s : Fin 1 → Aˣ, x = rankOneCarrierTorusPoint A s := by
+  rw [rankOneCarrierTorusPoints, MonoidHom.mem_range]
+  simp only [rankOneCarrierTorusPoint, eq_comm]
+
+/-- The map on rank-one carrier points induced by a homomorphism of value rings. -/
+noncomputable def rankOneCarrierPointsMap {A : Type u} {B : Type v} [CommRing A] [CommRing B]
+    (φ : A →+* B) : rankOneCarrierPoints A →* rankOneCarrierPoints B :=
+  ((MulEquiv.subgroupCongr
+      (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight B)).symm.toMonoidHom).comp
+    ((GeneralLinear.mapHopfIdealPointsSubgroup 2
+      (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight) φ.toIntAlgHom).comp
+      (MulEquiv.subgroupCongr
+        (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight A)).toMonoidHom)
+
 /-- The canonical Weyl representative `x₀(1) x₁(-1) x₀(1)` in the rank-one carrier. -/
 noncomputable def rankOneWeylPoint (A : Type u) [CommRing A] : rankOneCarrierPoints A :=
   kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight 0 1 A
@@ -106,15 +126,14 @@ noncomputable def rankOneWeylPoint (A : Type u) [CommRing A] : rankOneCarrierPoi
 /-- The Weyl representative is natural in the ring of points. -/
 theorem map_rankOneWeylPoint {A : Type u} {B : Type v} [CommRing A] [CommRing B]
     (φ : A →+* B) :
-    GeneralLinear.mapHopfIdealPointsSubgroup 2
-        (kostantToralDefiningIdeal e h ρ M hM hnil b rankOneWeight) φ.toIntAlgHom
-        (MulEquiv.subgroupCongr
-          (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight A)
-          (rankOneWeylPoint A)) =
-      MulEquiv.subgroupCongr
-        (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight B)
-        (rankOneWeylPoint B) := by
-  exact map_kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight φ 0 1
+    rankOneCarrierPointsMap φ (rankOneWeylPoint A) = rankOneWeylPoint B := by
+  rw [rankOneCarrierPointsMap]
+  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom]
+  simpa only [rankOneWeylPoint, MulEquiv.symm_apply_apply] using
+    congrArg
+      (MulEquiv.subgroupCongr
+        (kostantToralPointsSubgroup_def e h ρ M hM hnil b rankOneWeight B)).symm
+      (map_kostantToralWeylPoint e h ρ M hM hnil b rankOneWeight φ 0 1)
 
 /-- In the standard basis, a carrier torus point is `diag(s, s⁻¹)`. -/
 @[simp]
@@ -123,7 +142,7 @@ theorem coe_rankOneCarrierTorusPoint (A : Type u) [CommRing A] (s : Fin 1 → A�
       diagGL ![s 0, (s 0)⁻¹] := by
   rw [rankOneCarrierTorusPoint, rankOneCarrierTorusHom,
     coe_kostantToralWeightTorusPoints]
-  rw [← rankOneTorusMatrix_eq_kostantTorusMatrix, rankOneTorusMatrix_apply]
+  rw [← rankOneTorusMatrix_def, rankOneTorusMatrix_apply]
 
 /-- The integral rank-one Weyl automorphism sends a standard lattice basis vector to the reversed
 basis vector with the usual sign. -/
@@ -168,6 +187,7 @@ theorem coe_rankOneWeylPoint_apply (A : Type u) [CommRing A] (i j : Fin 2) :
 /-! ## The square relation -/
 
 /-- **The rank-one Chevalley relation `n² = h(-1)` in the carrier.** -/
+@[simp]
 theorem rankOneWeylPoint_sq (A : Type u) [CommRing A] :
     rankOneWeylPoint A ^ 2 =
       rankOneCarrierTorusPoint A (fun _ ↦ (-1 : Aˣ)) := by
@@ -184,6 +204,7 @@ theorem rankOneWeylPoint_sq (A : Type u) [CommRing A] :
 
 /-- The inverse rank-one Weyl representative is its product with the central torus point
 `h(-1)`. -/
+@[simp]
 theorem rankOneWeylPoint_inv (A : Type u) [CommRing A] :
     (rankOneWeylPoint A)⁻¹ =
       rankOneCarrierTorusPoint A (fun _ ↦ (-1 : Aˣ)) * rankOneWeylPoint A := by
@@ -265,18 +286,11 @@ noncomputable def rankOneWeylClass (A : Type u) [CommRing A] :
   TauCeti.Subgroup.normalizerQuotientMk (rankOneCarrierTorusPoints A)
     (rankOneWeylNormalizerPoint A)
 
-/-- The Weyl class is represented by the packaged Weyl normalizer point. -/
-theorem rankOneWeylClass_eq_normalizerQuotientMk (A : Type u) [CommRing A] :
-    rankOneWeylClass A =
-      TauCeti.Subgroup.normalizerQuotientMk (rankOneCarrierTorusPoints A)
-        (rankOneWeylNormalizerPoint A) :=
-  by rw [rankOneWeylClass]
-
 /-- The Weyl class in the torus normalizer quotient has square one. -/
 @[simp]
 theorem rankOneWeylClass_sq (A : Type u) [CommRing A] :
     rankOneWeylClass A ^ 2 = 1 := by
-  rw [rankOneWeylClass_eq_normalizerQuotientMk, ← map_pow]
+  rw [rankOneWeylClass, ← map_pow]
   apply (TauCeti.Subgroup.normalizerQuotientMk_eq_one_iff
     (rankOneCarrierTorusPoints A) ((rankOneWeylNormalizerPoint A) ^ 2)).mpr
   have hsquare : rankOneWeylPoint A ^ 2 ∈ rankOneCarrierTorusPoints A := by
@@ -301,7 +315,7 @@ theorem rankOneWeylPoint_not_mem_torus (A : Type u) [CommRing A] [Nontrivial A] 
 theorem rankOneWeylClass_ne_one (A : Type u) [CommRing A] [Nontrivial A] :
     rankOneWeylClass A ≠ 1 := by
   intro hclass
-  rw [rankOneWeylClass_eq_normalizerQuotientMk] at hclass
+  rw [rankOneWeylClass] at hclass
   have hm := (TauCeti.Subgroup.normalizerQuotientMk_eq_one_iff
     (rankOneCarrierTorusPoints A) (rankOneWeylNormalizerPoint A)).mp hclass
   exact rankOneWeylPoint_not_mem_torus A (by simpa only [coe_rankOneWeylNormalizerPoint] using hm)


### PR DESCRIPTION
This PR specializes the integral Weyl representative to the full-weight rank-one Kostant carrier, computes its signed-reversal matrix over every commutative ring, and establishes the Chevalley relation `n_α² = h_α(-1)`. It packages the representative in the represented torus normalizer, proves its quotient class is nontrivial over a nontrivial ring, and identifies its order as exactly two.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, milestone **“The Chevalley–Demazure construction”**, specifically the explicit root-subgroup and torus-normalizer relations needed to recover the Weyl group from the constructed carrier. This is the most effective next step because the carrier-valued Weyl representatives are already available, while passing from those representatives to the normalizer quotient requires precisely the square relation and nontrivial quotient class proved here.

After this PR, the milestone still needs these rank-one relations assembled across the root datum, the comparison of the full torus normalizer quotient with the Weyl group, and the subsequent Borel/pinning and pinned-isomorphism constructions.

The change adds `TauCeti/Algebra/Lie/Sl2/Kostant/Weyl.lean` (289 lines). It reuses Mathlib's quotient-group and element-order APIs and Tau Ceti's normalizer quotient, Kostant Weyl automorphism, full-weight rank-one carrier, and toral-closure point APIs; no upstream implementation is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"rank-one-weyl-square-relation"}-->

🤖 Prepared with Codex
