### PR TITLE
refactor(Topology): put `Convex.isUniformlyLocallyConnected` in the root namespace

### DIFF
--- a/TauCeti/Topology/UniformlyLocallyConnected.lean
+++ b/TauCeti/Topology/UniformlyLocallyConnected.lean
@@ -64,7 +64,7 @@ it, and no Lebesgue-number consequence of this shape.
 * `TauCeti.IsUniformlyLocallyConnected.exists_isConnected_superset` — a small enough subset is
   enclosed in a small connected subset, at a rate independent of the subset.
 * `IsCompact.isUniformlyLocallyConnected_iff` — on a compact set the two notions agree.
-* `TauCeti.Convex.isUniformlyLocallyConnected` — a convex set in a real normed space is uniformly
+* `Convex.isUniformlyLocallyConnected` — a convex set in a real normed space is uniformly
   locally connected, with the joining segment as the connected set.
 * `TauCeti.isUniformlyLocallyConnected_image_of_isCompact` — a continuous image of a compact,
   locally connected set is uniformly locally connected.
@@ -193,7 +193,7 @@ joined by the segment between them, which stays in the set by convexity and, by
 first endpoint, so its points are pairwise within `ε`.
 
 This is the basic example, and the one the closed disc supplies in the conformal application. -/
-protected theorem Convex.isUniformlyLocallyConnected {E : Type*} [NormedAddCommGroup E]
+protected theorem _root_.Convex.isUniformlyLocallyConnected {E : Type*} [NormedAddCommGroup E]
     [NormedSpace ℝ E] {t : Set E} (ht : Convex ℝ t) : IsUniformlyLocallyConnected t := by
   refine isUniformlyLocallyConnected_def.mpr fun ε hε => ⟨ε / 2, by linarith,
     fun a ha b hb hab => ⟨segment ℝ a b,


### PR DESCRIPTION
The theorem takes an explicit `ht : Convex ℝ t`, so its home is the root `Convex` namespace rather
than `TauCeti.Convex`. `scripts/lint-dot-notation.py` flags it for that reason; rooting it takes the
count from **999 to 998 with 0 new** findings.

**This is a consistency fix inside one file.** Its two neighbours in
`Topology/UniformlyLocallyConnected.lean` are already rooted:

```lean
protected theorem _root_.IsCompact.isUniformlyLocallyConnected …          -- :215
protected theorem _root_.IsCompact.isUniformlyLocallyConnected_iff …      -- :284
```

so the convention is already established here, and `Convex.isUniformlyLocallyConnected` at `:196` is
simply the declaration that was missed.

The theorem has **no call sites** — the only other reference is the module docstring's entry, updated
alongside it, so nothing else in the tree changes. Longest added line: 94 characters.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp