### PR TITLE
refactor(Lie): root the whole `LieSubalgebra` rationalization namespace

### DIFF
--- a/TauCeti/Algebra/Lie/Subalgebra/Rationalization.lean
+++ b/TauCeti/Algebra/Lie/Subalgebra/Rationalization.lean
@@ -26,7 +26,7 @@ rationalization construction.
 
 ## Main declaration
 
-* `TauCeti.LieSubalgebra.rationalizationEquiv`: the canonical Lie equivalence from the scalar
+* `LieSubalgebra.rationalizationEquiv`: the canonical Lie equivalence from the scalar
   extension of a free full integral Lie subalgebra to its ambient rational Lie algebra.
 
 ## References
@@ -45,7 +45,7 @@ open scoped TensorProduct
 
 namespace TauCeti
 
-namespace LieSubalgebra
+section
 
 universe u v w
 
@@ -53,7 +53,7 @@ variable {R : Type u} {K : Type v} {L : Type w}
   [CommRing R] [IsDomain R] [Field K] [Algebra R K] [IsFractionRing R K]
   [LieRing L] [LieAlgebra R L] [LieAlgebra K L] [IsScalarTower R K L]
 
-private theorem rationalizationEquiv_map_lie (M : LieSubalgebra R L)
+private theorem _root_.LieSubalgebra.rationalizationEquiv_map_lie (M : LieSubalgebra R L)
     [Module.Free R M] [M.toSubmodule.IsLattice K] (x y : K ⊗[R] M) :
     Submodule.rationalizationEquiv M.toSubmodule ⁅x, y⁆ =
       ⁅Submodule.rationalizationEquiv M.toSubmodule x,
@@ -82,7 +82,7 @@ equivalence.
 
 The underlying linear equivalence is `TauCeti.Submodule.rationalizationEquiv`. The bracket on its
 source is Mathlib's scalar-extension bracket on `K ⊗[R] M`. -/
-noncomputable def rationalizationEquiv (M : LieSubalgebra R L)
+noncomputable def _root_.LieSubalgebra.rationalizationEquiv (M : LieSubalgebra R L)
     [Module.Free R M] [M.toSubmodule.IsLattice K] :
     K ⊗[R] M ≃ₗ⁅K⁆ L where
   __ := Submodule.rationalizationEquiv M.toSubmodule
@@ -92,23 +92,23 @@ noncomputable def rationalizationEquiv (M : LieSubalgebra R L)
     change Submodule.rationalizationEquiv M.toSubmodule ⁅x, y⁆ =
       ⁅Submodule.rationalizationEquiv M.toSubmodule x,
         Submodule.rationalizationEquiv M.toSubmodule y⁆
-    exact rationalizationEquiv_map_lie M x y
+    exact LieSubalgebra.rationalizationEquiv_map_lie M x y
 
 /-- Rationalization sends a pure tensor to scalar multiplication of the embedded integral
 element. -/
 @[simp]
-theorem rationalizationEquiv_tmul (M : LieSubalgebra R L)
+theorem _root_.LieSubalgebra.rationalizationEquiv_tmul (M : LieSubalgebra R L)
     [Module.Free R M] [M.toSubmodule.IsLattice K] (q : K) (x : M) :
-    rationalizationEquiv M (q ⊗ₜ[R] x) = q • (x : L) :=
+    LieSubalgebra.rationalizationEquiv M (q ⊗ₜ[R] x) = q • (x : L) :=
   Submodule.rationalizationEquiv_tmul M.toSubmodule q x
 
 /-- The inverse rationalization sends an embedded integral element to its unit pure tensor. -/
 @[simp]
-theorem rationalizationEquiv_symm_coe (M : LieSubalgebra R L)
+theorem _root_.LieSubalgebra.rationalizationEquiv_symm_coe (M : LieSubalgebra R L)
     [Module.Free R M] [M.toSubmodule.IsLattice K] (x : M) :
-    (rationalizationEquiv M).symm (x : L) = 1 ⊗ₜ[R] x :=
+    (LieSubalgebra.rationalizationEquiv M).symm (x : L) = 1 ⊗ₜ[R] x :=
   Submodule.rationalizationEquiv_symm_coe M.toSubmodule x
 
-end LieSubalgebra
+end
 
 end TauCeti


### PR DESCRIPTION
All four declarations of `TauCeti.LieSubalgebra` live in this one file, and **all four** are flagged
by `scripts/lint-dot-notation.py`. They move to the root `LieSubalgebra` namespace together:
**999 → 995 findings, 0 new**.

Taking the namespace whole is deliberate. Rooting one of a group invites "why only this one?"; here
the answer is that there is no remainder — `TauCeti.LieSubalgebra` has **no members left**, this file
having been its only source.

Two consequences handled with it:

- **The wrapper becomes `section`, not nothing.** The block carries
  `variable {R : Type u} {K : Type v} {L : Type w}`, which would otherwise widen to the rest of
  `namespace TauCeti`.
- **Three internal references were resolving through the wrapper** — `rationalizationEquiv_map_lie M x y`
  at the end of `rationalizationEquiv`'s proof, and `rationalizationEquiv M` in the statements of
  `rationalizationEquiv_tmul` and `rationalizationEquiv_symm_coe`. With the wrapper gone those short
  names no longer resolve, so they are written `LieSubalgebra.…`, which reaches the root declarations.

The four have no callers outside this file: the `rationalizationEquiv` names in
`Algebra/Module/Lattice.lean` belong to the parallel `Submodule` construction and are untouched.
Longest added line: 89 characters.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp