### PR TITLE
refactor(HeckeRing): extract multiplicity_le_one_of_subsingleton

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/ScalarMul.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/ScalarMul.lean
@@ -98,18 +98,7 @@ private lemma multiplicity_const_le_one (c : ℕ) (hcN : Nat.Coprime c N) (b : F
       (((diagCosetGamma0 N (fun _ ↦ c) fun _ ↦ hcN).rep : GL (Fin 2) ℚ))) = 1 := by
     rw [← HeckeCoset.degree_eq_card_decompQuotient]
     exact degree_diagCosetGamma0_const N c _
-  have hsub : Subsingleton (DecompQuotient ((Gamma0 N).map (mapGL ℚ))
-      ((Gamma0 N).map (mapGL ℚ))
-      (((diagCosetGamma0 N (fun _ ↦ c) fun _ ↦ hcN).rep : GL (Fin 2) ℚ))) :=
-    Fintype.card_le_one_iff_subsingleton.mp hcard.le
-  rw [multiplicity_def, Nat.card_eq_fintype_card]
-  refine Fintype.card_le_one_iff_subsingleton.mpr ?_
-  constructor
-  rintro ⟨⟨i₁, j₁⟩, hp₁⟩ ⟨⟨i₂, j₂⟩, hp₂⟩
-  simp only [Set.mem_ofPred_eq] at hp₁ hp₂
-  obtain rfl : i₁ = i₂ := Subsingleton.elim i₁ i₂
-  obtain rfl : j₁ = j₂ := DoubleCoset.snd_eq_of_fst_eq hp₁ hp₂
-  rfl
+  exact multiplicity_le_one_of_subsingleton (Fintype.card_le_one_iff_subsingleton.mp hcard.le)
 
 /-- **Scalar multiplication at level `N`**: `T(c, c) · T(b) = T(c·b)`, the level-`N` analogue of
 `HeckeRing.GLn.diagElem_const_mul`. No hypothesis is needed: where a factor is degenerate — not

--- a/TauCeti/NumberTheory/HeckeRing/GLn/ScalarMul.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/ScalarMul.lean
@@ -94,17 +94,7 @@ private lemma multiplicity_const_le_one (c : ℕ) (b : Fin n → ℕ)
       (((diagCoset fun _ : Fin n ↦ c).rep : GL (Fin n) ℚ))) = 1 := by
     rw [← HeckeCoset.degree_eq_card_decompQuotient]
     exact degree_diagCoset_const n _
-  have hsub : Subsingleton (DecompQuotient (SLnZ n) (SLnZ n)
-      (((diagCoset fun _ : Fin n ↦ c).rep : GL (Fin n) ℚ))) :=
-    Fintype.card_le_one_iff_subsingleton.mp hcard.le
-  rw [multiplicity_def, Nat.card_eq_fintype_card]
-  refine Fintype.card_le_one_iff_subsingleton.mpr ?_
-  constructor
-  rintro ⟨⟨i₁, j₁⟩, hp₁⟩ ⟨⟨i₂, j₂⟩, hp₂⟩
-  simp only [Set.mem_ofPred_eq] at hp₁ hp₂
-  obtain rfl : i₁ = i₂ := Subsingleton.elim i₁ i₂
-  obtain rfl : j₁ = j₂ := DoubleCoset.snd_eq_of_fst_eq hp₁ hp₂
-  rfl
+  exact multiplicity_le_one_of_subsingleton (Fintype.card_le_one_iff_subsingleton.mp hcard.le)
 
 /-- Scalar multiplication in the Hecke ring (Shimura, Proposition 3.17):
 `T(c,...,c) · T(b) = T(c·b)`. -/

--- a/TauCeti/NumberTheory/HeckeRing/Multiplicity/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplicity/Basic.lean
@@ -91,6 +91,27 @@ lemma snd_eq_of_fst_eq {Γ₁ Γ₂ Γ₃ : Subgroup G} {g h d : G} {i : DecompQ
   rw [QuotientGroup.eq] at h ⊢
   simpa [mul_assoc] using h
 
+/-- **A first factor that does not split forces multiplicity at most one.** If `Γ₁ g Γ₂` is a
+single left coset, then no double coset occurs more than once in the product: the fibre has at
+most one pair, because the first component is determined by `Subsingleton` and the second is
+then determined by `snd_eq_of_fst_eq`.
+
+No finiteness is assumed. The fibre is a subsingleton, hence finite, whatever the second
+decomposition quotient does. -/
+lemma multiplicity_le_one_of_subsingleton {Γ₁ Γ₂ Γ₃ : Subgroup G} {g h d : G}
+    (hs : Subsingleton (DecompQuotient Γ₁ Γ₂ g)) :
+    multiplicity Γ₁ Γ₂ Γ₃ g h d ≤ 1 := by
+  rw [multiplicity_def]
+  have hfib : Subsingleton {p : DecompQuotient Γ₁ Γ₂ g × DecompQuotient Γ₂ Γ₃ h |
+      ((p.1.out : G) * g * ((p.2.out : G) * h) : G ⧸ Γ₃) = (d : G ⧸ Γ₃)} := by
+    constructor
+    rintro ⟨⟨i₁, j₁⟩, hp₁⟩ ⟨⟨i₂, j₂⟩, hp₂⟩
+    simp only [Set.mem_ofPred_eq] at hp₁ hp₂
+    obtain rfl : i₁ = i₂ := hs.elim i₁ i₂
+    obtain rfl : j₁ = j₂ := snd_eq_of_fst_eq hp₁ hp₂
+    rfl
+  exact Finite.card_le_one_iff_subsingleton.mpr hfib
+
 /-- When the common second component of two pairs in the fibre of the multiplicity satisfies
 `τⱼ h ∈ Γ₂`, the first components agree. -/
 lemma fst_eq_of_mul_snd_mem {Γ₁ Γ₂ : Subgroup G} {g h d : G} {i₁ i₂ : DecompQuotient Γ₁ Γ₂ g}

--- a/TauCeti/NumberTheory/HeckeRing/Multiplicity/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplicity/Basic.lean
@@ -91,13 +91,11 @@ lemma snd_eq_of_fst_eq {Γ₁ Γ₂ Γ₃ : Subgroup G} {g h d : G} {i : DecompQ
   rw [QuotientGroup.eq] at h ⊢
   simpa [mul_assoc] using h
 
-/-- **A first factor that does not split forces multiplicity at most one.** If `Γ₁ g Γ₂` is a
-single left coset, then no double coset occurs more than once in the product: the fibre has at
-most one pair, because the first component is determined by `Subsingleton` and the second is
-then determined by `snd_eq_of_fst_eq`.
+/-- **A first factor that does not split forces multiplicity at most one.** When `Γ₁ g Γ₂`
+consists of a single left coset, no double coset occurs more than once in the product, for any
+`h` and `d`.
 
-No finiteness is assumed. The fibre is a subsingleton, hence finite, whatever the second
-decomposition quotient does. -/
+No finiteness hypothesis is needed, in particular none on the second decomposition quotient. -/
 lemma multiplicity_le_one_of_subsingleton {Γ₁ Γ₂ Γ₃ : Subgroup G} {g h d : G}
     (hs : Subsingleton (DecompQuotient Γ₁ Γ₂ g)) :
     multiplicity Γ₁ Γ₂ Γ₃ g h d ≤ 1 := by

--- a/TauCeti/NumberTheory/HeckeRing/Normalizer.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Normalizer.lean
@@ -134,9 +134,9 @@ variable {G : Type*} [Group G] {Δ : Submonoid G} {Γ : Subgroup G} {x y : Δ}
 /-- **The basis elements of two normalizing elements multiply**, `[ΓxΓ] · [ΓyΓ] = [Γ(xy)Γ]`,
 over any coefficient semiring.
 
-There is no structure constant to compute: both decomposition quotients are subsingletons, so
-`multiplicity ≤ 1` is automatic, and every pair of representatives multiplies into the same
-double coset. -/
+There is no structure constant to compute: `x` normalizes `Γ`, so its decomposition quotient
+is a subsingleton and `multiplicity ≤ 1` follows, and every pair of representatives multiplies
+into the same double coset. -/
 theorem single_mul_single_of_mem_normalizer [IsHeckeTriple Δ Γ Γ] (R : Type*) [Semiring R]
     (hx : (x : G) ∈ Subgroup.normalizer (Γ : Set G))
     (hy : (y : G) ∈ Subgroup.normalizer (Γ : Set G)) :
@@ -144,14 +144,11 @@ theorem single_mul_single_of_mem_normalizer [IsHeckeTriple Δ Γ Γ] (R : Type*)
       single R (HeckeCoset.mk Γ Γ (x * y)) 1 := by
   classical
   rw [mul_def]
-  have := DoubleCoset.subsingleton_decompQuotient_of_mem_normalizer
-    (HeckeCoset.rep_mk_mem_normalizer_of_mem_normalizer hx)
-  have := DoubleCoset.subsingleton_decompQuotient_of_mem_normalizer
-    (HeckeCoset.rep_mk_mem_normalizer_of_mem_normalizer hy)
   refine mul_single_single_of_mulMap_eq R _ _ _
     (HeckeCoset.mulMap_rep_mk_eq_of_mem_normalizer hx hy) ?_
-  rw [DoubleCoset.multiplicity_def, Nat.card_eq_fintype_card]
-  exact Fintype.card_le_one_iff_subsingleton.mpr inferInstance
+  exact DoubleCoset.multiplicity_le_one_of_subsingleton
+    (DoubleCoset.subsingleton_decompQuotient_of_mem_normalizer
+      (HeckeCoset.rep_mk_mem_normalizer_of_mem_normalizer hx))
 
 end HeckeCosetModule
 


### PR DESCRIPTION
Three places proved "this double coset occurs at most once" by writing out the same argument:
unfold the multiplicity, show the fibre is a subsingleton because the first component is
pinned by `Subsingleton` and the second is then pinned by `snd_eq_of_fst_eq`, conclude
`card ≤ 1`. The argument uses nothing about diagonal cosets, levels or normalizers, so it
belongs next to `snd_eq_of_fst_eq` rather than being re-derived at each use.

`DoubleCoset.multiplicity_le_one_of_subsingleton` states it once:

```lean
lemma multiplicity_le_one_of_subsingleton {Γ₁ Γ₂ Γ₃ : Subgroup G} {g h d : G}
    (hs : Subsingleton (DecompQuotient Γ₁ Γ₂ g)) :
    multiplicity Γ₁ Γ₂ Γ₃ g h d ≤ 1
```

The three consumers — `HeckeRing.GLn.multiplicity_const_le_one`,
`HeckeRing.GL2.Gamma0.Diagonal.multiplicity_const_le_one` and
`HeckeCosetModule.single_mul_single_of_mem_normalizer` — each collapse to one `exact`.

Two details worth flagging for review:

- **No finiteness hypothesis.** The two `ScalarMul` sites reached `card ≤ 1` through
  `Nat.card_eq_fintype_card` and so needed the fibre to be a `Fintype`. The subsingleton
  *is* the finiteness: `Finite.card_le_one_iff_subsingleton` applies with the instance
  derived from `Subsingleton`, so the lemma holds whatever the second decomposition quotient
  does, and the `Nat.card_eq_fintype_card` step disappears.
- **`GLn/CoprimeMul.lean` is deliberately untouched.** Its `multiplicity_coprime_le_one`
  opens the same way but is a different proof: its first components are *not* pinned by a
  subsingleton, they are matched through the coupling criterion. Folding it in would mean
  weakening this lemma to the point of uselessness, so it keeps its own argument.

`Multiplicity/Basic.lean` is vendored from the in-review mathlib4 PR
[#41254](https://github.com/leanprover-community/mathlib4/pull/41254). I checked that PR at
its current head `674528e015e7`: it has `subsingleton_decompQuotient`,
`subsingleton_decompQuotient_of_mem` and `snd_eq_of_fst_eq`, but no `≤ 1` lemma. So this is a
TauCeti addition rather than a backport, and it is one to carry upstream if that stack lands.

Roadmap: ModularForms

Provenance: none — refactor of existing TauCeti code. The edited module is itself vendored
from leanprover-community/mathlib4#41254 @ 674528e015e7 (Apache 2.0, Chris Birkbeck); the new
lemma is not present there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
