### PR TITLE
refactor(ValuativeRel): root the `comap` family

### DIFF
--- a/TauCeti/RingTheory/Valuation/IntegralOfValuationLeOne.lean
+++ b/TauCeti/RingTheory/Valuation/IntegralOfValuationLeOne.lean
@@ -38,7 +38,7 @@ does not carry. It is removed by **reducing modulo a prime**: by
 `TauCeti.isIntegral_of_forall_isPrime_map` it is enough to be integral over the image of `B` in
 `R ⧸ J` for every prime `J`, and each `R ⧸ J` is a domain, so the domain case applies there. Its
 hypothesis is met because a valuation of `R ⧸ J` pulls back along `Ideal.Quotient.mk J`, by
-`TauCeti.ValuativeRel.comap`, to one of `R`, which the hypothesis on `R` bounds. So the criterion
+`ValuativeRel.comap`, to one of `R`, which the hypothesis on `R` bounds. So the criterion
 holds for `R` in general.
 
 ## Main results

--- a/TauCeti/RingTheory/Valuation/ValuativeRel/Comap.lean
+++ b/TauCeti/RingTheory/Valuation/ValuativeRel/Comap.lean
@@ -14,7 +14,7 @@ We define the pullback (comap) of a `ValuativeRel` along a ring homomorphism.
 
 ## Main definitions
 
-* `TauCeti.ValuativeRel.comap φ v` : Given `φ : A →+* B` and a valuative relation `v` on `B`,
+* `ValuativeRel.comap φ v` : Given `φ : A →+* B` and a valuative relation `v` on `B`,
   the induced `ValuativeRel A` defined by `a₁ ≤ᵥ a₂ ↔ φ(a₁) ≤ᵥ φ(a₂)`.
 
 ## References

--- a/TauCeti/RingTheory/Valuation/ValuativeRel/Comap.lean
+++ b/TauCeti/RingTheory/Valuation/ValuativeRel/Comap.lean
@@ -27,7 +27,7 @@ pinned Mathlib.
 
 public section
 
-namespace TauCeti.ValuativeRel
+section
 
 variable {A B : Type*} [Semiring A] [Semiring B]
 
@@ -36,7 +36,7 @@ variable {A B : Type*} [Semiring A] [Semiring B]
 -- `instance_reducible` is the minimum reducibility the `classDefReducibility` check accepts
 -- for a definition of class type; the body is deliberately not exposed.
 @[instance_reducible]
-def comap (φ : A →+* B) (v : ValuativeRel B) : ValuativeRel A where
+def _root_.ValuativeRel.comap (φ : A →+* B) (v : ValuativeRel B) : ValuativeRel A where
   vle a₁ a₂ := (φ a₁) ≤ᵥ (φ a₂)
   vle_total a₁ a₂ := v.vle_total (φ a₁) (φ a₂)
   vle_trans h₁ h₂ := v.vle_trans h₁ h₂
@@ -50,23 +50,26 @@ def comap (φ : A →+* B) (v : ValuativeRel B) : ValuativeRel A where
 
 /-- The relation pulled back along `φ` compares images under `φ`. -/
 @[simp]
-theorem comap_vle (φ : A →+* B) (v : ValuativeRel B) (a₁ a₂ : A) :
-    (comap φ v).vle a₁ a₂ ↔ v.vle (φ a₁) (φ a₂) := Iff.rfl
+theorem _root_.ValuativeRel.comap_vle (φ : A →+* B) (v : ValuativeRel B) (a₁ a₂ : A) :
+    (ValuativeRel.comap φ v).vle a₁ a₂ ↔ v.vle (φ a₁) (φ a₂) := Iff.rfl
 
 /-- The strict relation pulled back along `φ` compares images under `φ`. -/
 @[simp]
-theorem comap_vlt (φ : A →+* B) (v : ValuativeRel B) (a₁ a₂ : A) :
-    (comap φ v).vlt a₁ a₂ ↔ v.vlt (φ a₁) (φ a₂) := Iff.rfl
+theorem _root_.ValuativeRel.comap_vlt (φ : A →+* B) (v : ValuativeRel B) (a₁ a₂ : A) :
+    (ValuativeRel.comap φ v).vlt a₁ a₂ ↔ v.vlt (φ a₁) (φ a₂) := Iff.rfl
 
 /-- Pulling back along the identity homomorphism is the identity. -/
 @[simp]
-theorem comap_id (v : ValuativeRel A) : comap (RingHom.id A) v = v := by
+theorem _root_.ValuativeRel.comap_id (v : ValuativeRel A) :
+    ValuativeRel.comap (RingHom.id A) v = v := by
   ext a₁ a₂; rfl
 
 /-- Pulling back along a composite is the composite of the pullbacks. -/
 @[simp]
-theorem comap_comp {C : Type*} [Semiring C] (φ : A →+* B) (ψ : B →+* C) (v : ValuativeRel C) :
-    comap (ψ.comp φ) v = comap φ (comap ψ v) := by
+theorem _root_.ValuativeRel.comap_comp {C : Type*} [Semiring C] (φ : A →+* B) (ψ : B →+* C)
+    (v : ValuativeRel C) :
+    ValuativeRel.comap (ψ.comp φ) v =
+      ValuativeRel.comap φ (ValuativeRel.comap ψ v) := by
   ext a₁ a₂; rfl
 
-end TauCeti.ValuativeRel
+end


### PR DESCRIPTION
All five declarations in `RingTheory/Valuation/ValuativeRel/Comap.lean` take an explicit
`ValuativeRel` argument and are flagged by `scripts/lint-dot-notation.py`. They move to the root
`ValuativeRel` namespace together: **998 → 993 findings, 0 new**.

**Why five and not six.** `TauCeti.ValuativeRel` keeps one member — `not_vle_zero_of_isUnit` in the
sibling `Basic.lean` — and it is deliberately untouched. The gate's rule is that a finding needs an
*explicit* receiver of the namespace's type; there, `ValuativeRel` appears as an instance argument
`[ValuativeRel A]`, so dot notation could never apply and it is not flagged.

Three consequences handled with the move:

- **The wrapper becomes `section`.** Rooting the five empties the compound
  `namespace TauCeti.ValuativeRel` of its own declarations, and it carries a `variable` line that
  would otherwise widen.
- **Four internal references to `comap`** resolved only through the wrapper and are now written
  `ValuativeRel.comap` — including two inside theorem *statements*.
- **`comap_comp`'s binders are wrapped**: rooted on one line the header would reach 114 characters.

External users are unaffected: the six uses in `AdicSpace/ValuationSpectrum.lean` already read
`ValuativeRel.comap…` and now resolve to the root declarations.

Mathlib's `ValuativeRel` namespace has no `comap` — the nearby `Valuation.comap` is a different
operation — so nothing collides. Longest added line: 91 characters.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp