### PR TITLE
refactor(Probability): simplify hypergeometric symmetry proof

### DIFF
--- a/TauCeti/Probability/Distributions/Hypergeometric/Symmetry.lean
+++ b/TauCeti/Probability/Distributions/Hypergeometric/Symmetry.lean
@@ -49,61 +49,30 @@ theorem hypergeometricMeasure_comm (N K n : ℕ) :
       hypergeometricMeasure_real_singleton hn hK]
     by_cases hkK : k ≤ K <;> by_cases hkn : k ≤ n
     · simp only [ite_eq_left hkK, ite_eq_left hkn]
-      by_cases hsupport : n - k ≤ N - K
-      · have hsupport' : K - k ≤ N - n := by omega
-        have hsubK : (N - k) - (K - k) = N - K := by omega
-        have hsubn : (N - k) - (n - k) = N - n := by omega
-        have hsubLeft : K - k + (n - k) - (K - k) = n - k := by omega
-        have hsubRight : K - k + (n - k) - (n - k) = K - k := by omega
-        have hmiddle :
-            (N - k).choose (K - k) * (N - K).choose (n - k) =
-              (N - k).choose (n - k) * (N - n).choose (K - k) := by
-          -- After the `k` common elements are fixed, choose the marked-only and sampled-only
-          -- elements in either order. Both sides are the same multinomial coefficient.
-          calc
-            _ = (N - k).choose (K - k) *
-                ((N - k) - (K - k)).choose (K - k + (n - k) - (K - k)) := by
-              rw [hsubK, hsubLeft]
-            _ = (N - k).choose (K - k + (n - k)) *
-                (K - k + (n - k)).choose (K - k) := by
-              rw [Nat.choose_mul (n := N - k) (k := K - k + (n - k))
-                (s := K - k) (by omega)]
-            _ = (N - k).choose (K - k + (n - k)) *
-                (K - k + (n - k)).choose (n - k) := by
-              rw [Nat.choose_symm_add]
-            _ = (N - k).choose (n - k) *
-                ((N - k) - (n - k)).choose (K - k + (n - k) - (n - k)) := by
-              rw [Nat.choose_mul (n := N - k) (k := K - k + (n - k))
-                (s := n - k) (by omega)]
-            _ = _ := by rw [hsubn, hsubRight]
-        have hchooseK := Nat.choose_mul (n := N) (k := K) (s := k) hkK
-        have hchoosen := Nat.choose_mul (n := N) (k := n) (s := k) hkn
-        -- Cross-multiply the two mass formulas. The outer applications of `Nat.choose_mul`
-        -- choose the common `k` elements first; `hmiddle` exchanges the remaining choices.
-        have hcross :
-            K.choose k * (N - K).choose (n - k) * N.choose K =
-              n.choose k * (N - n).choose (K - k) * N.choose n := by
-          calc
-            _ = (N.choose K * K.choose k) * (N - K).choose (n - k) := by ring
-            _ = (N.choose k * (N - k).choose (K - k)) *
-                (N - K).choose (n - k) := by rw [hchooseK]
-            _ = N.choose k * ((N - k).choose (K - k) *
-                (N - K).choose (n - k)) := by ring
-            _ = N.choose k * ((N - k).choose (n - k) *
-                (N - n).choose (K - k)) := by rw [hmiddle]
-            _ = (N.choose n * n.choose k) * (N - n).choose (K - k) := by
-              rw [hchoosen]
-              ring
-            _ = _ := by ring
-        rw [div_eq_div_iff]
-        · exact_mod_cast hcross
-        · exact_mod_cast Nat.choose_ne_zero hn
-        · exact_mod_cast Nat.choose_ne_zero hK
-      · have hsupport' : ¬ K - k ≤ N - n := by omega
-        -- Failure of the remaining-support inequality is symmetric, so both masses vanish.
-        rw [Nat.choose_eq_zero_of_lt (lt_of_not_ge hsupport),
-          Nat.choose_eq_zero_of_lt (lt_of_not_ge hsupport')]
-        simp
+      have hsubK : (N - k) - (K - k) = N - K := by omega
+      have hsubn : (N - k) - (n - k) = N - n := by omega
+      -- Choose the marked-only and sampled-only elements in either order after fixing
+      -- the common elements. The identity also covers masses outside the support.
+      have hmiddle :
+          (N - k).choose (K - k) * (N - K).choose (n - k) =
+            (N - k).choose (n - k) * (N - n).choose (K - k) := by
+        calc
+          _ = (N - k).choose (K - k + (n - k)) *
+              (K - k + (n - k)).choose (K - k) := by
+            rw [Nat.choose_mul (Nat.le_add_right _ _), Nat.add_sub_cancel_left, hsubK]
+          _ = _ := by
+            rw [Nat.choose_symm_add, Nat.choose_mul (Nat.le_add_left _ _),
+              Nat.add_sub_cancel_right, hsubn]
+      have hchooseK := Nat.choose_mul (n := N) (k := K) (s := k) hkK
+      have hchoosen := Nat.choose_mul (n := N) (k := n) (s := k) hkn
+      have hcross :
+          K.choose k * (N - K).choose (n - k) * N.choose K =
+            n.choose k * (N - n).choose (K - k) * N.choose n := by
+        grind only
+      rw [div_eq_div_iff]
+      · exact_mod_cast hcross
+      · exact_mod_cast Nat.choose_ne_zero hn
+      · exact_mod_cast Nat.choose_ne_zero hK
     · simp [hkK, hkn, Nat.choose_eq_zero_of_lt (lt_of_not_ge hkn)]
     · simp [hkK, hkn, Nat.choose_eq_zero_of_lt (lt_of_not_ge hkK)]
     · simp [hkK, hkn]


### PR DESCRIPTION

The proof of `hypergeometricMeasure_comm` split on the remaining-support inequality even though `Nat.choose_mul` also handles the zero binomial coefficients outside that support. Apply the identity uniformly, remove that case split and its subtraction bookkeeping, and replace the cross-multiplication calculation with `grind only` using the three local identities. This removes 31 lines while preserving the theorem's statement and all parameter cases.

Roadmap: StandardDistributions

This is a proof refactor of the existing hypergeometric parameter-symmetry result associated with `TauCetiRoadmap/StandardDistributions/README.md`, Layer 3, Hypergeometric. It adds no new mathematical declarations.

Validation on the pinned Lean 4.34.0-rc2 and Mathlib e21ec05048292b3de86d4cf1987e2208171a5642:
- `lake build TauCeti.Probability.Distributions.Hypergeometric.Symmetry --iofail` passed (3,084 jobs).
- All 14 environment linters passed for the changed module (1 declaration plus 4 generated declarations).
- The theorem's axiom dependencies are exactly `propext`, `Classical.choice`, and `Quot.sound`.
- `git diff --check` passed.

The full repository build and repository-wide audits are still being checked; the results above are the completed local checks.

Prepared with Codex; Luna assisted with repository research and validation setup.