### PR TITLE
refactor(Analysis): each open half-plane of ℂ is unbounded

### DIFF
--- a/TauCeti/Analysis/Complex/HalfPlaneUnbounded.lean
+++ b/TauCeti/Analysis/Complex/HalfPlaneUnbounded.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Complex.Basic
+
+/-!
+# Open half-planes of `ℂ` are unbounded
+
+Each of the four open half-planes cut out by a bound on `re` or `im` contains points of
+arbitrarily large norm. The witnesses are real or purely imaginary, so the norm is read off by
+`Complex.norm_real`.
+
+These are the hypotheses that winding-number vanishing arguments need: transporting a winding
+number through an unbounded connected region requires exhibiting, for each radius, a point of
+the region outside that radius.
+
+## Main results
+
+* `Complex.exists_im_lt_and_lt_norm`, `Complex.exists_lt_im_and_lt_norm`
+* `Complex.exists_re_lt_and_lt_norm`, `Complex.exists_lt_re_and_lt_norm`
+-/
+
+public section
+
+namespace Complex
+
+/-- The open lower half-plane `{z | z.im < c}` is unbounded. -/
+theorem exists_im_lt_and_lt_norm (c R : ℝ) : ∃ z : ℂ, z.im < c ∧ R < ‖z‖ := by
+  refine ⟨((min c 0 - max R 0 - 1 : ℝ) : ℂ) * Complex.I, ?_, ?_⟩
+  · rw [Complex.mul_I_im, Complex.ofReal_re]
+    nlinarith [min_le_left c 0, min_le_right c 0, le_max_right R 0]
+  · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
+      Real.norm_of_nonpos (by nlinarith [min_le_right c 0, le_max_right R 0])]
+    nlinarith [min_le_right c 0, le_max_left R 0]
+
+/-- The open upper half-plane `{z | c < z.im}` is unbounded. -/
+theorem exists_lt_im_and_lt_norm (c R : ℝ) : ∃ z : ℂ, c < z.im ∧ R < ‖z‖ := by
+  refine ⟨((max c 0 + max R 0 + 1 : ℝ) : ℂ) * Complex.I, ?_, ?_⟩
+  · rw [Complex.mul_I_im, Complex.ofReal_re]
+    nlinarith [le_max_left c 0, le_max_right R 0]
+  · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
+      Real.norm_of_nonneg (by nlinarith [le_max_right c 0, le_max_right R 0])]
+    nlinarith [le_max_right c 0, le_max_left R 0]
+
+/-- The open left half-plane `{z | z.re < c}` is unbounded. -/
+theorem exists_re_lt_and_lt_norm (c R : ℝ) : ∃ z : ℂ, z.re < c ∧ R < ‖z‖ := by
+  refine ⟨((min c 0 - max R 0 - 1 : ℝ) : ℂ), ?_, ?_⟩
+  · rw [Complex.ofReal_re]
+    nlinarith [min_le_left c 0, min_le_right c 0, le_max_right R 0]
+  · rw [Complex.norm_real,
+      Real.norm_of_nonpos (by nlinarith [min_le_right c 0, le_max_right R 0])]
+    nlinarith [min_le_right c 0, le_max_left R 0]
+
+/-- The open right half-plane `{z | c < z.re}` is unbounded. -/
+theorem exists_lt_re_and_lt_norm (c R : ℝ) : ∃ z : ℂ, c < z.re ∧ R < ‖z‖ := by
+  refine ⟨((max c 0 + max R 0 + 1 : ℝ) : ℂ), ?_, ?_⟩
+  · rw [Complex.ofReal_re]
+    nlinarith [le_max_left c 0, le_max_right R 0]
+  · rw [Complex.norm_real,
+      Real.norm_of_nonneg (by nlinarith [le_max_right c 0, le_max_right R 0])]
+    nlinarith [le_max_right c 0, le_max_left R 0]
+
+end Complex

--- a/TauCeti/Analysis/Complex/HalfPlaneUnbounded.lean
+++ b/TauCeti/Analysis/Complex/HalfPlaneUnbounded.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Complex.Basic
-import TauCeti.Analysis.Normed.Module.FilledHull
+import TauCeti.Analysis.Normed.Module.HalfSpace
 
 /-!
 # Points of large norm in a coordinate half-plane of `ℂ`

--- a/TauCeti/Analysis/Complex/HalfPlaneUnbounded.lean
+++ b/TauCeti/Analysis/Complex/HalfPlaneUnbounded.lean
@@ -6,72 +6,60 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Complex.Basic
-public import TauCeti.Analysis.Normed.Module.FilledHull
+import TauCeti.Analysis.Normed.Module.FilledHull
 
 /-!
-# Points of large norm in an open half-space
+# Points of large norm in a coordinate half-plane of `ℂ`
 
-`TauCeti.not_isBounded_halfSpace_lt` says an open half-space `{y | φ y < u}` is unbounded.
-`TauCeti.exists_lt_and_lt_norm` restates that in the form its consumers want: for every radius
-there is a point of the half-space outside that radius. `TauCeti.exists_lt_and_lt_norm'` is the
-other side, `u < φ y`, obtained from `-φ`.
+Each of the four inequalities `z.im < c`, `c < z.im`, `z.re < c` and `c < z.re` cuts out an open
+half-plane of `ℂ` — two horizontal, two vertical — and each holds points of arbitrarily large
+norm. These are the specialisations of `TauCeti.exists_apply_lt_and_lt_norm` and
+`TauCeti.exists_lt_apply_and_lt_norm` to `Complex.reLm` and `Complex.imLm`.
 
-Specialising to `Complex.reCLM` and `Complex.imCLM` gives the four open half-planes of `ℂ`. This
-is what a winding-number vanishing argument needs: to transport a winding number through an
+This is what a winding-number vanishing argument needs: to transport a winding number through an
 unbounded connected region one must exhibit, for each radius, a point of the region beyond it.
 
 ## Main results
 
-* `TauCeti.exists_lt_and_lt_norm`, `TauCeti.exists_lt_and_lt_norm'` — the two directions for a
-  nonzero continuous functional on a real normed space.
+* `Complex.reLm_ne_zero`, `Complex.imLm_ne_zero` — the two coordinate functionals of `ℂ` are
+  nonzero.
 * `TauCeti.exists_im_lt_and_lt_norm`, `TauCeti.exists_lt_im_and_lt_norm`,
-  `TauCeti.exists_re_lt_and_lt_norm`, `TauCeti.exists_lt_re_and_lt_norm` — the four half-planes.
+  `TauCeti.exists_re_lt_and_lt_norm`, `TauCeti.exists_lt_re_and_lt_norm` — the four coordinate
+  half-planes.
 -/
 
 public section
 
-open Bornology
+namespace Complex
 
-namespace TauCeti
-
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-
-/-- An open half-space contains points of arbitrarily large norm. -/
-theorem exists_lt_and_lt_norm {φ : E →L[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
-    ∃ y : E, φ y < u ∧ R < ‖y‖ := by
-  by_contra h
-  push Not at h
-  exact not_isBounded_halfSpace_lt hφ u
-    (isBounded_iff_forall_norm_le.mpr ⟨R, fun y hy => h y hy⟩)
-
-/-- The half-space on the other side of the functional, via `-φ`. -/
-theorem exists_lt_and_lt_norm' {φ : E →L[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
-    ∃ y : E, u < φ y ∧ R < ‖y‖ := by
-  obtain ⟨y, hy, hn⟩ := exists_lt_and_lt_norm (φ := -φ) (neg_ne_zero.mpr hφ) (-u) R
-  exact ⟨y, by simpa using hy, hn⟩
-
-private lemma imCLM_ne_zero : (Complex.imCLM : ℂ →L[ℝ] ℝ) ≠ 0 := by
+/-- The imaginary part is not the zero functional. -/
+@[simp] theorem imLm_ne_zero : (imLm : ℂ →ₗ[ℝ] ℝ) ≠ 0 := by
   intro h
   simpa using congrArg (fun ψ => ψ Complex.I) h
 
-private lemma reCLM_ne_zero : (Complex.reCLM : ℂ →L[ℝ] ℝ) ≠ 0 := by
+/-- The real part is not the zero functional. -/
+@[simp] theorem reLm_ne_zero : (reLm : ℂ →ₗ[ℝ] ℝ) ≠ 0 := by
   intro h
   simpa using congrArg (fun ψ => ψ 1) h
 
+end Complex
+
+namespace TauCeti
+
 /-- The open lower half-plane `{z | z.im < c}` contains points of arbitrarily large norm. -/
 theorem exists_im_lt_and_lt_norm (c R : ℝ) : ∃ z : ℂ, z.im < c ∧ R < ‖z‖ :=
-  exists_lt_and_lt_norm imCLM_ne_zero c R
+  exists_apply_lt_and_lt_norm Complex.imLm_ne_zero c R
 
 /-- The open upper half-plane `{z | c < z.im}` contains points of arbitrarily large norm. -/
 theorem exists_lt_im_and_lt_norm (c R : ℝ) : ∃ z : ℂ, c < z.im ∧ R < ‖z‖ :=
-  exists_lt_and_lt_norm' imCLM_ne_zero c R
+  exists_lt_apply_and_lt_norm Complex.imLm_ne_zero c R
 
 /-- The open left half-plane `{z | z.re < c}` contains points of arbitrarily large norm. -/
 theorem exists_re_lt_and_lt_norm (c R : ℝ) : ∃ z : ℂ, z.re < c ∧ R < ‖z‖ :=
-  exists_lt_and_lt_norm reCLM_ne_zero c R
+  exists_apply_lt_and_lt_norm Complex.reLm_ne_zero c R
 
 /-- The open right half-plane `{z | c < z.re}` contains points of arbitrarily large norm. -/
 theorem exists_lt_re_and_lt_norm (c R : ℝ) : ∃ z : ℂ, c < z.re ∧ R < ‖z‖ :=
-  exists_lt_and_lt_norm' reCLM_ne_zero c R
+  exists_lt_apply_and_lt_norm Complex.reLm_ne_zero c R
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/HalfPlaneUnbounded.lean
+++ b/TauCeti/Analysis/Complex/HalfPlaneUnbounded.lean
@@ -6,62 +6,72 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Complex.Basic
+public import TauCeti.Analysis.Normed.Module.FilledHull
 
 /-!
-# Open half-planes of `ℂ` are unbounded
+# Points of large norm in an open half-space
 
-Each of the four open half-planes cut out by a bound on `re` or `im` contains points of
-arbitrarily large norm. The witnesses are real or purely imaginary, so the norm is read off by
-`Complex.norm_real`.
+`TauCeti.not_isBounded_halfSpace_lt` says an open half-space `{y | φ y < u}` is unbounded.
+`TauCeti.exists_lt_and_lt_norm` restates that in the form its consumers want: for every radius
+there is a point of the half-space outside that radius. `TauCeti.exists_lt_and_lt_norm'` is the
+other side, `u < φ y`, obtained from `-φ`.
 
-These are the hypotheses that winding-number vanishing arguments need: transporting a winding
-number through an unbounded connected region requires exhibiting, for each radius, a point of
-the region outside that radius.
+Specialising to `Complex.reCLM` and `Complex.imCLM` gives the four open half-planes of `ℂ`. This
+is what a winding-number vanishing argument needs: to transport a winding number through an
+unbounded connected region one must exhibit, for each radius, a point of the region beyond it.
 
 ## Main results
 
-* `Complex.exists_im_lt_and_lt_norm`, `Complex.exists_lt_im_and_lt_norm`
-* `Complex.exists_re_lt_and_lt_norm`, `Complex.exists_lt_re_and_lt_norm`
+* `TauCeti.exists_lt_and_lt_norm`, `TauCeti.exists_lt_and_lt_norm'` — the two directions for a
+  nonzero continuous functional on a real normed space.
+* `TauCeti.exists_im_lt_and_lt_norm`, `TauCeti.exists_lt_im_and_lt_norm`,
+  `TauCeti.exists_re_lt_and_lt_norm`, `TauCeti.exists_lt_re_and_lt_norm` — the four half-planes.
 -/
 
 public section
 
-namespace Complex
+open Bornology
 
-/-- The open lower half-plane `{z | z.im < c}` is unbounded. -/
-theorem exists_im_lt_and_lt_norm (c R : ℝ) : ∃ z : ℂ, z.im < c ∧ R < ‖z‖ := by
-  refine ⟨((min c 0 - max R 0 - 1 : ℝ) : ℂ) * Complex.I, ?_, ?_⟩
-  · rw [Complex.mul_I_im, Complex.ofReal_re]
-    nlinarith [min_le_left c 0, min_le_right c 0, le_max_right R 0]
-  · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
-      Real.norm_of_nonpos (by nlinarith [min_le_right c 0, le_max_right R 0])]
-    nlinarith [min_le_right c 0, le_max_left R 0]
+namespace TauCeti
 
-/-- The open upper half-plane `{z | c < z.im}` is unbounded. -/
-theorem exists_lt_im_and_lt_norm (c R : ℝ) : ∃ z : ℂ, c < z.im ∧ R < ‖z‖ := by
-  refine ⟨((max c 0 + max R 0 + 1 : ℝ) : ℂ) * Complex.I, ?_, ?_⟩
-  · rw [Complex.mul_I_im, Complex.ofReal_re]
-    nlinarith [le_max_left c 0, le_max_right R 0]
-  · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
-      Real.norm_of_nonneg (by nlinarith [le_max_right c 0, le_max_right R 0])]
-    nlinarith [le_max_right c 0, le_max_left R 0]
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
-/-- The open left half-plane `{z | z.re < c}` is unbounded. -/
-theorem exists_re_lt_and_lt_norm (c R : ℝ) : ∃ z : ℂ, z.re < c ∧ R < ‖z‖ := by
-  refine ⟨((min c 0 - max R 0 - 1 : ℝ) : ℂ), ?_, ?_⟩
-  · rw [Complex.ofReal_re]
-    nlinarith [min_le_left c 0, min_le_right c 0, le_max_right R 0]
-  · rw [Complex.norm_real,
-      Real.norm_of_nonpos (by nlinarith [min_le_right c 0, le_max_right R 0])]
-    nlinarith [min_le_right c 0, le_max_left R 0]
+/-- An open half-space contains points of arbitrarily large norm. -/
+theorem exists_lt_and_lt_norm {φ : E →L[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
+    ∃ y : E, φ y < u ∧ R < ‖y‖ := by
+  by_contra h
+  push Not at h
+  exact not_isBounded_halfSpace_lt hφ u
+    (isBounded_iff_forall_norm_le.mpr ⟨R, fun y hy => h y hy⟩)
 
-/-- The open right half-plane `{z | c < z.re}` is unbounded. -/
-theorem exists_lt_re_and_lt_norm (c R : ℝ) : ∃ z : ℂ, c < z.re ∧ R < ‖z‖ := by
-  refine ⟨((max c 0 + max R 0 + 1 : ℝ) : ℂ), ?_, ?_⟩
-  · rw [Complex.ofReal_re]
-    nlinarith [le_max_left c 0, le_max_right R 0]
-  · rw [Complex.norm_real,
-      Real.norm_of_nonneg (by nlinarith [le_max_right c 0, le_max_right R 0])]
-    nlinarith [le_max_right c 0, le_max_left R 0]
+/-- The half-space on the other side of the functional, via `-φ`. -/
+theorem exists_lt_and_lt_norm' {φ : E →L[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
+    ∃ y : E, u < φ y ∧ R < ‖y‖ := by
+  obtain ⟨y, hy, hn⟩ := exists_lt_and_lt_norm (φ := -φ) (neg_ne_zero.mpr hφ) (-u) R
+  exact ⟨y, by simpa using hy, hn⟩
 
-end Complex
+private lemma imCLM_ne_zero : (Complex.imCLM : ℂ →L[ℝ] ℝ) ≠ 0 := by
+  intro h
+  simpa using congrArg (fun ψ => ψ Complex.I) h
+
+private lemma reCLM_ne_zero : (Complex.reCLM : ℂ →L[ℝ] ℝ) ≠ 0 := by
+  intro h
+  simpa using congrArg (fun ψ => ψ 1) h
+
+/-- The open lower half-plane `{z | z.im < c}` contains points of arbitrarily large norm. -/
+theorem exists_im_lt_and_lt_norm (c R : ℝ) : ∃ z : ℂ, z.im < c ∧ R < ‖z‖ :=
+  exists_lt_and_lt_norm imCLM_ne_zero c R
+
+/-- The open upper half-plane `{z | c < z.im}` contains points of arbitrarily large norm. -/
+theorem exists_lt_im_and_lt_norm (c R : ℝ) : ∃ z : ℂ, c < z.im ∧ R < ‖z‖ :=
+  exists_lt_and_lt_norm' imCLM_ne_zero c R
+
+/-- The open left half-plane `{z | z.re < c}` contains points of arbitrarily large norm. -/
+theorem exists_re_lt_and_lt_norm (c R : ℝ) : ∃ z : ℂ, z.re < c ∧ R < ‖z‖ :=
+  exists_lt_and_lt_norm reCLM_ne_zero c R
+
+/-- The open right half-plane `{z | c < z.re}` contains points of arbitrarily large norm. -/
+theorem exists_lt_re_and_lt_norm (c R : ℝ) : ∃ z : ℂ, c < z.re ∧ R < ‖z‖ :=
+  exists_lt_and_lt_norm' reCLM_ne_zero c R
+
+end TauCeti

--- a/TauCeti/Analysis/Normed/Module/FilledHull.lean
+++ b/TauCeti/Analysis/Normed/Module/FilledHull.lean
@@ -122,13 +122,14 @@ theorem filledHull_subset_closedConvexHull (hK : K.Nonempty) :
       hφx hHK
   -- It is unbounded, because a nonempty `K` forces `φ` to be nonzero.
   obtain ⟨b, hb⟩ := hK
-  have hφne : φ ≠ 0 := by
-    rintro rfl
+  have hφne : (φ : E →ₗ[ℝ] ℝ) ≠ 0 := by
+    intro h
+    have hzero : ∀ y : E, φ y = 0 := fun y =>
+      (LinearMap.congr_fun h y).trans (LinearMap.zero_apply y)
     have hb' := hφC b (subset_closedConvexHull hb)
-    simp only [zero_apply] at hφx hb'
+    rw [hzero] at hφx hb'
     linarith
-  exact not_isBounded_halfSpace_lt (φ := (φ : E →ₗ[ℝ] ℝ))
-    (fun h => hφne (ContinuousLinearMap.coe_injective (by simpa using h))) u (hx.subset hsub)
+  exact not_isBounded_halfSpace_lt (φ := (φ : E →ₗ[ℝ] ℝ)) hφne u (hx.subset hsub)
 
 /-- **The filled hull of the empty set is empty** in a nontrivial space: the whole space is
 connected and unbounded, so every component of `∅ᶜ = univ` is unbounded. -/

--- a/TauCeti/Analysis/Normed/Module/FilledHull.lean
+++ b/TauCeti/Analysis/Normed/Module/FilledHull.lean
@@ -70,6 +70,8 @@ used, and the separation argument is the general Hahn–Banach one.
 * `TauCeti.diam_le_diam_of_subset_filledHull` and
   `IsPreconnected.diam_le_diam_of_disjoint` — a set inside the filled hull of a bounded `K`,
   in particular a preconnected set that `K` cuts off from infinity, is no wider than `K`.
+* `TauCeti.exists_apply_lt_and_lt_norm` and `TauCeti.exists_lt_apply_and_lt_norm` — either open
+  half-space of a nonzero linear functional holds points of arbitrarily large norm, whence
 * `TauCeti.not_isBounded_halfSpace_lt` — an open half-space cut out by a nonzero continuous
   functional is unbounded, and `TauCeti.isBounded_closedConvexHull`,
   `TauCeti.diam_closedConvexHull` — the closed forms of the two convex-hull facts the width
@@ -100,28 +102,42 @@ the closure adding nothing by `Metric.diam_closure`. -/
 theorem diam_closedConvexHull : diam (closedConvexHull ℝ K) = diam K := by
   rw [closedConvexHull_eq_closure_convexHull, diam_closure, convexHull_diam]
 
-/-- **An open half-space cut out by a nonzero continuous functional is unbounded.** Along a
-direction `v` with `φ v = 1` the value of `φ` decreases without bound as one walks towards `-v`,
-while the norm grows without bound, so the half-space contains points of arbitrarily large norm. -/
-theorem not_isBounded_halfSpace_lt {φ : E →L[ℝ] ℝ} (hφ : φ ≠ 0) (u : ℝ) :
-    ¬ IsBounded {y | φ y < u} := by
+/-- **An open half-space contains points of arbitrarily large norm.** For a nonzero linear
+functional `φ`, every bound `u` and every radius `R` admit a `y` with `φ y < u` and `R < ‖y‖`.
+Continuity plays no part: the witness is a multiple of a single vector on which `φ` is nonzero. -/
+theorem exists_apply_lt_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
+    ∃ y : E, φ y < u ∧ R < ‖y‖ := by
   obtain ⟨w, hw⟩ : ∃ w, φ w ≠ 0 := by simpa using DFunLike.ne_iff.mp hφ
   obtain ⟨v, hφv⟩ : ∃ v : E, φ v = 1 :=
     ⟨(φ w)⁻¹ • w, by rw [map_smul, smul_eq_mul, inv_mul_cancel₀ hw]⟩
   have hvnorm : 0 < ‖v‖ := norm_pos_iff.mpr fun h => by simp [h] at hφv
-  intro hbdd
-  obtain ⟨R, hR⟩ := isBounded_iff_forall_norm_le.mp hbdd
-  -- Walk to `-t • v` for a `t` large enough to break both the bound `u` on `φ` and the bound `R`.
+  -- Walk to `-t • v` for a `t` large enough to break both the bound `u` and the radius `R`.
   obtain ⟨t, ht1, ht2⟩ : ∃ t : ℝ, (R + 1) / ‖v‖ ≤ t ∧ |u| + 1 ≤ t :=
     ⟨_, le_max_left _ _, le_max_right _ _⟩
   have ht0 : 0 ≤ t := le_trans (by positivity) ht2
-  have hmem : (-t) • v ∈ {y | φ y < u} := by
-    have hval : φ ((-t) • v) = -t := by rw [map_smul, hφv, smul_eq_mul, mul_one]
-    simp only [mem_ofPred_eq, hval]
+  refine ⟨(-t) • v, ?_, ?_⟩
+  · rw [map_smul, hφv, smul_eq_mul, mul_one]
     linarith [neg_abs_le u]
-  have hnorm := hR _ hmem
-  rw [norm_smul, norm_neg, Real.norm_eq_abs, abs_of_nonneg ht0] at hnorm
-  linarith [(div_le_iff₀ hvnorm).mp ht1]
+  · rw [norm_smul, norm_neg, Real.norm_eq_abs, abs_of_nonneg ht0]
+    linarith [(div_le_iff₀ hvnorm).mp ht1]
+
+/-- **The other side of a nonzero linear functional also contains points of arbitrarily large
+norm**: every bound `u` and radius `R` admit a `y` with `u < φ y` and `R < ‖y‖`. -/
+theorem exists_lt_apply_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
+    ∃ y : E, u < φ y ∧ R < ‖y‖ := by
+  obtain ⟨y, hy, hn⟩ := exists_apply_lt_and_lt_norm (φ := -φ) (neg_ne_zero.mpr hφ) (-u) R
+  exact ⟨y, by simpa using hy, hn⟩
+
+/-- **An open half-space cut out by a nonzero continuous functional is unbounded.** No radius
+bounds it, because by `TauCeti.exists_apply_lt_and_lt_norm` it holds points of every norm. -/
+theorem not_isBounded_halfSpace_lt {φ : E →L[ℝ] ℝ} (hφ : φ ≠ 0) (u : ℝ) :
+    ¬ IsBounded {y | φ y < u} := by
+  have hlin : (φ : E →ₗ[ℝ] ℝ) ≠ 0 := fun h =>
+    hφ (ContinuousLinearMap.coe_injective (by simpa using h))
+  intro hbdd
+  obtain ⟨R, hR⟩ := isBounded_iff_forall_norm_le.mp hbdd
+  obtain ⟨y, hy, hn⟩ := exists_apply_lt_and_lt_norm hlin u R
+  exact absurd (hR y (by simpa using hy)) (not_le.mpr hn)
 
 /-- **The filled hull lies in the closed convex hull.** A point outside the closed convex hull of a
 nonempty `K` is separated from it by a continuous linear functional; the open half-space this

--- a/TauCeti/Analysis/Normed/Module/FilledHull.lean
+++ b/TauCeti/Analysis/Normed/Module/FilledHull.lean
@@ -9,6 +9,7 @@ public import Mathlib.Analysis.Normed.Module.Convex
 public import TauCeti.Topology.FilledHull
 public import TauCeti.Analysis.Normed.Module.Ball.Exterior
 import Mathlib.Analysis.LocallyConvex.Separation
+import TauCeti.Analysis.Normed.Module.HalfSpace
 -- `NormedSpace.toLocallyConvexSpace`, needed to apply `geometric_hahn_banach_point_closed`.
 import Mathlib.Analysis.LocallyConvex.WithSeminorms
 
@@ -70,10 +71,7 @@ used, and the separation argument is the general Hahn–Banach one.
 * `TauCeti.diam_le_diam_of_subset_filledHull` and
   `IsPreconnected.diam_le_diam_of_disjoint` — a set inside the filled hull of a bounded `K`,
   in particular a preconnected set that `K` cuts off from infinity, is no wider than `K`.
-* `TauCeti.exists_apply_lt_and_lt_norm` and `TauCeti.exists_lt_apply_and_lt_norm` — either open
-  half-space of a nonzero linear functional holds points of arbitrarily large norm, whence
-* `TauCeti.not_isBounded_halfSpace_lt` — an open half-space cut out by a nonzero continuous
-  functional is unbounded, and `TauCeti.isBounded_closedConvexHull`,
+* `TauCeti.isBounded_closedConvexHull`,
   `TauCeti.diam_closedConvexHull` — the closed forms of the two convex-hull facts the width
   argument runs on.
 * `TauCeti.connectedComponentIn_compl_eq_of_unbounded_component` — the unbounded connected
@@ -102,43 +100,6 @@ the closure adding nothing by `Metric.diam_closure`. -/
 theorem diam_closedConvexHull : diam (closedConvexHull ℝ K) = diam K := by
   rw [closedConvexHull_eq_closure_convexHull, diam_closure, convexHull_diam]
 
-/-- **An open half-space contains points of arbitrarily large norm.** For a nonzero linear
-functional `φ`, every bound `u` and every radius `R` admit a `y` with `φ y < u` and `R < ‖y‖`.
-Continuity plays no part: the witness is a multiple of a single vector on which `φ` is nonzero. -/
-theorem exists_apply_lt_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
-    ∃ y : E, φ y < u ∧ R < ‖y‖ := by
-  obtain ⟨w, hw⟩ : ∃ w, φ w ≠ 0 := by simpa using DFunLike.ne_iff.mp hφ
-  obtain ⟨v, hφv⟩ : ∃ v : E, φ v = 1 :=
-    ⟨(φ w)⁻¹ • w, by rw [map_smul, smul_eq_mul, inv_mul_cancel₀ hw]⟩
-  have hvnorm : 0 < ‖v‖ := norm_pos_iff.mpr fun h => by simp [h] at hφv
-  -- Walk to `-t • v` for a `t` large enough to break both the bound `u` and the radius `R`.
-  obtain ⟨t, ht1, ht2⟩ : ∃ t : ℝ, (R + 1) / ‖v‖ ≤ t ∧ |u| + 1 ≤ t :=
-    ⟨_, le_max_left _ _, le_max_right _ _⟩
-  have ht0 : 0 ≤ t := le_trans (by positivity) ht2
-  refine ⟨(-t) • v, ?_, ?_⟩
-  · rw [map_smul, hφv, smul_eq_mul, mul_one]
-    linarith [neg_abs_le u]
-  · rw [norm_smul, norm_neg, Real.norm_eq_abs, abs_of_nonneg ht0]
-    linarith [(div_le_iff₀ hvnorm).mp ht1]
-
-/-- **The other side of a nonzero linear functional also contains points of arbitrarily large
-norm**: every bound `u` and radius `R` admit a `y` with `u < φ y` and `R < ‖y‖`. -/
-theorem exists_lt_apply_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
-    ∃ y : E, u < φ y ∧ R < ‖y‖ := by
-  obtain ⟨y, hy, hn⟩ := exists_apply_lt_and_lt_norm (φ := -φ) (neg_ne_zero.mpr hφ) (-u) R
-  exact ⟨y, by simpa using hy, hn⟩
-
-/-- **An open half-space cut out by a nonzero continuous functional is unbounded.** No radius
-bounds it, because by `TauCeti.exists_apply_lt_and_lt_norm` it holds points of every norm. -/
-theorem not_isBounded_halfSpace_lt {φ : E →L[ℝ] ℝ} (hφ : φ ≠ 0) (u : ℝ) :
-    ¬ IsBounded {y | φ y < u} := by
-  have hlin : (φ : E →ₗ[ℝ] ℝ) ≠ 0 := fun h =>
-    hφ (ContinuousLinearMap.coe_injective (by simpa using h))
-  intro hbdd
-  obtain ⟨R, hR⟩ := isBounded_iff_forall_norm_le.mp hbdd
-  obtain ⟨y, hy, hn⟩ := exists_apply_lt_and_lt_norm hlin u R
-  exact absurd (hR y (by simpa using hy)) (not_le.mpr hn)
-
 /-- **The filled hull lies in the closed convex hull.** A point outside the closed convex hull of a
 nonempty `K` is separated from it by a continuous linear functional; the open half-space this
 produces is convex, avoids `K`, and is unbounded, so the component of the point in `Kᶜ` is
@@ -166,7 +127,8 @@ theorem filledHull_subset_closedConvexHull (hK : K.Nonempty) :
     have hb' := hφC b (subset_closedConvexHull hb)
     simp only [zero_apply] at hφx hb'
     linarith
-  exact not_isBounded_halfSpace_lt hφne u (hx.subset hsub)
+  exact not_isBounded_halfSpace_lt (φ := (φ : E →ₗ[ℝ] ℝ))
+    (fun h => hφne (ContinuousLinearMap.coe_injective (by simpa using h))) u (hx.subset hsub)
 
 /-- **The filled hull of the empty set is empty** in a nontrivial space: the whole space is
 connected and unbounded, so every component of `∅ᶜ = univ` is unbounded. -/

--- a/TauCeti/Analysis/Normed/Module/HalfSpace.lean
+++ b/TauCeti/Analysis/Normed/Module/HalfSpace.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Analysis.Normed.Module.Basic
 
+import Mathlib.Algebra.Module.LinearMap.DivisionRing
+
 /-!
 # Strict half-spaces of a real normed space are unbounded
 
@@ -37,9 +39,7 @@ functional `φ`, every bound `u` and every radius `R` admit a `y` with `φ y < u
 Linearity suffices; `φ` need not be continuous. -/
 theorem exists_apply_lt_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
     ∃ y : E, φ y < u ∧ R < ‖y‖ := by
-  obtain ⟨w, hw⟩ : ∃ w, φ w ≠ 0 := by simpa using DFunLike.ne_iff.mp hφ
-  obtain ⟨v, hφv⟩ : ∃ v : E, φ v = 1 :=
-    ⟨(φ w)⁻¹ • w, by rw [map_smul, smul_eq_mul, inv_mul_cancel₀ hw]⟩
+  obtain ⟨v, hφv⟩ := LinearMap.surjective_iff_ne_zero.mpr hφ 1
   have hvnorm : 0 < ‖v‖ := norm_pos_iff.mpr fun h => by simp [h] at hφv
   -- Walk to `-t • v` for a `t` large enough to break both the bound `u` and the radius `R`.
   obtain ⟨t, ht1, ht2⟩ : ∃ t : ℝ, (R + 1) / ‖v‖ ≤ t ∧ |u| + 1 ≤ t :=

--- a/TauCeti/Analysis/Normed/Module/HalfSpace.lean
+++ b/TauCeti/Analysis/Normed/Module/HalfSpace.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.Basic
+
+/-!
+# Open half-spaces of a real normed space are unbounded
+
+An open half-space `{y | φ y < u}` cut out by a nonzero linear functional holds points of
+arbitrarily large norm, and is therefore unbounded. Linearity alone suffices: `φ` need not be
+continuous, so the results apply to a discontinuous functional on an infinite-dimensional space.
+
+## Main results
+
+* `TauCeti.exists_apply_lt_and_lt_norm` and `TauCeti.exists_lt_apply_and_lt_norm` — either side
+  of a nonzero linear functional holds points of arbitrarily large norm.
+* `TauCeti.not_isBounded_halfSpace_lt` — an open half-space is unbounded.
+-/
+
+public section
+
+namespace TauCeti
+
+open Bornology
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- **An open half-space contains points of arbitrarily large norm.** For a nonzero linear
+functional `φ`, every bound `u` and every radius `R` admit a `y` with `φ y < u` and `R < ‖y‖`.
+Linearity suffices; `φ` need not be continuous. -/
+theorem exists_apply_lt_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
+    ∃ y : E, φ y < u ∧ R < ‖y‖ := by
+  obtain ⟨w, hw⟩ : ∃ w, φ w ≠ 0 := by simpa using DFunLike.ne_iff.mp hφ
+  obtain ⟨v, hφv⟩ : ∃ v : E, φ v = 1 :=
+    ⟨(φ w)⁻¹ • w, by rw [map_smul, smul_eq_mul, inv_mul_cancel₀ hw]⟩
+  have hvnorm : 0 < ‖v‖ := norm_pos_iff.mpr fun h => by simp [h] at hφv
+  -- Walk to `-t • v` for a `t` large enough to break both the bound `u` and the radius `R`.
+  obtain ⟨t, ht1, ht2⟩ : ∃ t : ℝ, (R + 1) / ‖v‖ ≤ t ∧ |u| + 1 ≤ t :=
+    ⟨_, le_max_left _ _, le_max_right _ _⟩
+  have ht0 : 0 ≤ t := le_trans (by positivity) ht2
+  refine ⟨(-t) • v, ?_, ?_⟩
+  · rw [map_smul, hφv, smul_eq_mul, mul_one]
+    linarith [neg_abs_le u]
+  · rw [norm_smul, norm_neg, Real.norm_eq_abs, abs_of_nonneg ht0]
+    linarith [(div_le_iff₀ hvnorm).mp ht1]
+
+/-- **The other side of a nonzero linear functional also contains points of arbitrarily large
+norm**: every bound `u` and radius `R` admit a `y` with `u < φ y` and `R < ‖y‖`. -/
+theorem exists_lt_apply_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
+    ∃ y : E, u < φ y ∧ R < ‖y‖ := by
+  obtain ⟨y, hy, hn⟩ := exists_apply_lt_and_lt_norm (φ := -φ) (neg_ne_zero.mpr hφ) (-u) R
+  exact ⟨y, by simpa using hy, hn⟩
+
+/-- **An open half-space cut out by a nonzero linear functional is unbounded.** No radius bounds
+`{y | φ y < u}`. Linearity suffices; `φ` need not be continuous. -/
+theorem not_isBounded_halfSpace_lt {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u : ℝ) :
+    ¬ IsBounded {y | φ y < u} := by
+  intro hbdd
+  obtain ⟨R, hR⟩ := isBounded_iff_forall_norm_le.mp hbdd
+  obtain ⟨y, hy, hn⟩ := exists_apply_lt_and_lt_norm hφ u R
+  exact absurd (hR y (by simpa using hy)) (not_le.mpr hn)
+
+end TauCeti

--- a/TauCeti/Analysis/Normed/Module/HalfSpace.lean
+++ b/TauCeti/Analysis/Normed/Module/HalfSpace.lean
@@ -20,7 +20,8 @@ than open here.
 
 * `TauCeti.exists_apply_lt_and_lt_norm` and `TauCeti.exists_lt_apply_and_lt_norm` — either side
   of a nonzero linear functional holds points of arbitrarily large norm.
-* `TauCeti.not_isBounded_halfSpace_lt` — a strict half-space is unbounded.
+* `TauCeti.not_isBounded_halfSpace_lt` and `TauCeti.not_isBounded_halfSpace_gt` — either strict
+  half-space is unbounded.
 -/
 
 public section
@@ -64,6 +65,15 @@ theorem not_isBounded_halfSpace_lt {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u 
   intro hbdd
   obtain ⟨R, hR⟩ := isBounded_iff_forall_norm_le.mp hbdd
   obtain ⟨y, hy, hn⟩ := exists_apply_lt_and_lt_norm hφ u R
+  exact absurd (hR y (by simpa using hy)) (not_le.mpr hn)
+
+/-- **The half-space on the other side of a nonzero linear functional is unbounded.** No radius
+bounds `{y | u < φ y}` either. Linearity suffices; `φ` need not be continuous. -/
+theorem not_isBounded_halfSpace_gt {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u : ℝ) :
+    ¬ IsBounded {y | u < φ y} := by
+  intro hbdd
+  obtain ⟨R, hR⟩ := isBounded_iff_forall_norm_le.mp hbdd
+  obtain ⟨y, hy, hn⟩ := exists_lt_apply_and_lt_norm hφ u R
   exact absurd (hR y (by simpa using hy)) (not_le.mpr hn)
 
 end TauCeti

--- a/TauCeti/Analysis/Normed/Module/HalfSpace.lean
+++ b/TauCeti/Analysis/Normed/Module/HalfSpace.lean
@@ -8,17 +8,19 @@ module
 public import Mathlib.Analysis.Normed.Module.Basic
 
 /-!
-# Open half-spaces of a real normed space are unbounded
+# Strict half-spaces of a real normed space are unbounded
 
-An open half-space `{y | φ y < u}` cut out by a nonzero linear functional holds points of
+A strict half-space `{y | φ y < u}` cut out by a nonzero linear functional holds points of
 arbitrarily large norm, and is therefore unbounded. Linearity alone suffices: `φ` need not be
 continuous, so the results apply to a discontinuous functional on an infinite-dimensional space.
+For such a `φ` the set need not be topologically open, which is why it is called strict rather
+than open here.
 
 ## Main results
 
 * `TauCeti.exists_apply_lt_and_lt_norm` and `TauCeti.exists_lt_apply_and_lt_norm` — either side
   of a nonzero linear functional holds points of arbitrarily large norm.
-* `TauCeti.not_isBounded_halfSpace_lt` — an open half-space is unbounded.
+* `TauCeti.not_isBounded_halfSpace_lt` — a strict half-space is unbounded.
 -/
 
 public section
@@ -29,7 +31,7 @@ open Bornology
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
-/-- **An open half-space contains points of arbitrarily large norm.** For a nonzero linear
+/-- **A strict half-space contains points of arbitrarily large norm.** For a nonzero linear
 functional `φ`, every bound `u` and every radius `R` admit a `y` with `φ y < u` and `R < ‖y‖`.
 Linearity suffices; `φ` need not be continuous. -/
 theorem exists_apply_lt_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
@@ -55,7 +57,7 @@ theorem exists_lt_apply_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u
   obtain ⟨y, hy, hn⟩ := exists_apply_lt_and_lt_norm (φ := -φ) (neg_ne_zero.mpr hφ) (-u) R
   exact ⟨y, by simpa using hy, hn⟩
 
-/-- **An open half-space cut out by a nonzero linear functional is unbounded.** No radius bounds
+/-- **A strict half-space cut out by a nonzero linear functional is unbounded.** No radius bounds
 `{y | φ y < u}`. Linearity suffices; `φ` need not be continuous. -/
 theorem not_isBounded_halfSpace_lt {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u : ℝ) :
     ¬ IsBounded {y | φ y < u} := by

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -86,7 +86,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {
     (hw : w.im < Real.sqrt 3 / 2) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_im_lt _).isPreconnected
-    ?_ (fun R ↦ (Complex.exists_im_lt_and_lt_norm (Real.sqrt 3 / 2) R).imp
+    ?_ (fun R ↦ (TauCeti.exists_im_lt_and_lt_norm (Real.sqrt 3 / 2) R).imp
       fun _ h ↦ ⟨h.1, h.2⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
@@ -99,7 +99,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     (hw : 2⁻¹ < w.re) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_re_gt _).isPreconnected
-    ?_ (fun R ↦ (Complex.exists_lt_re_and_lt_norm 2⁻¹ R).imp
+    ?_ (fun R ↦ (TauCeti.exists_lt_re_and_lt_norm 2⁻¹ R).imp
       fun _ h ↦ ⟨h.1, h.2⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
@@ -114,7 +114,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
     (hw : w.re < -2⁻¹) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_re_lt _).isPreconnected
-    ?_ (fun R ↦ (Complex.exists_re_lt_and_lt_norm (-2⁻¹) R).imp
+    ?_ (fun R ↦ (TauCeti.exists_re_lt_and_lt_norm (-2⁻¹) R).imp
       fun _ h ↦ ⟨h.1, h.2⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
@@ -129,7 +129,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_lt_im (hH : 1 ≤ H) {w : ℂ}
     (hw : H < w.im) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_im_gt _).isPreconnected
-    ?_ (fun R ↦ (Complex.exists_lt_im_and_lt_norm H R).imp
+    ?_ (fun R ↦ (TauCeti.exists_lt_im_and_lt_norm H R).imp
       fun _ h ↦ ⟨h.1, h.2⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
@@ -152,7 +152,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_norm_lt_one (hH : 1 ≤ H) {w : ℂ}
     positivity
   have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_lt_one.le
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected hconn ?_
-    (fun R ↦ (Complex.exists_im_lt_and_lt_norm (Real.sqrt 3 / 2) R).imp
+    (fun R ↦ (TauCeti.exists_im_lt_and_lt_norm (Real.sqrt 3 / 2) R).imp
       fun _ h ↦ ⟨Or.inr h.1, h.2⟩)
     (Or.inl (by rwa [Metric.mem_ball, dist_zero_right]))
   · rintro z (hz | hz) ⟨t, ht, rfl⟩ <;>

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -79,19 +79,19 @@ private lemma windingNumber_fdBoundary_eq_zero_of_mem_preconnected {S : Set ℂ}
   rw [Metric.mem_closedBall, dist_zero_right] at this
   linarith
 
-/-- **The escape witness.** Every lemma below feeds `hunb` a point of the form
-`-(max R 0 + 1)`, on the real axis or rotated onto the imaginary axis; in both cases it is the
-norm that has to exceed `R`, and `max R 0` makes that work for negative `R` too. -/
+/-- The negative real `-(max R 0 + 1)` has norm exceeding `R`; `max R 0` is what makes this
+hold for negative `R` as well. Multiplying by `I` does not change the norm, so the same bound
+serves the witnesses on either axis. -/
 private lemma lt_norm_neg_max_add_one (R : ℝ) : R < ‖((-(max R 0 + 1) : ℝ) : ℂ)‖ := by
   rw [Complex.norm_real, Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
   nlinarith [le_max_left R 0]
 
-/-- The escape witness rotated onto the imaginary axis sits below the contour's height, so it
-lies in the half-space the `im`-lemmas transport through. -/
-private lemma neg_max_add_one_mul_I_im_lt (R : ℝ) :
-    (((-(max R 0 + 1) : ℝ) : ℂ) * Complex.I).im < Real.sqrt 3 / 2 := by
+/-- Rotated onto the imaginary axis, that witness has negative imaginary part — so it lies
+below any non-negative height, the contour's included. -/
+private lemma neg_max_add_one_mul_I_im_neg (R : ℝ) :
+    (((-(max R 0 + 1) : ℝ) : ℂ) * Complex.I).im < 0 := by
   rw [Complex.mul_I_im, Complex.ofReal_re]
-  nlinarith [le_max_right R 0, Real.sqrt_nonneg 3]
+  nlinarith [le_max_right R 0]
 
 /-- Every point strictly below the contour's height winds zero. -/
 @[simp]
@@ -104,7 +104,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary hH ht))
   · rw [Set.mem_ofPred_eq]
-    exact neg_max_add_one_mul_I_im_lt R
+    exact (neg_max_add_one_mul_I_im_neg R).trans_le (by positivity)
   · rw [norm_mul, Complex.norm_I, mul_one]
     exact lt_norm_neg_max_add_one R
 
@@ -185,7 +185,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_norm_lt_one (hH : 1 ≤ H) {w : ℂ}
       exact absurd hz (not_lt.mpr (one_le_norm_fdBoundary hH ht))
     · exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ht))
   · rw [Set.mem_ofPred_eq]
-    exact neg_max_add_one_mul_I_im_lt R
+    exact (neg_max_add_one_mul_I_im_neg R).trans_le (by positivity)
   · rw [norm_mul, Complex.norm_I, mul_one]
     exact lt_norm_neg_max_add_one R
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.Modular
+public import TauCeti.Analysis.Complex.HalfPlaneUnbounded
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Containment
 
@@ -79,34 +80,17 @@ private lemma windingNumber_fdBoundary_eq_zero_of_mem_preconnected {S : Set ℂ}
   rw [Metric.mem_closedBall, dist_zero_right] at this
   linarith
 
-/-- The negative real `-(max R 0 + 1)` has norm exceeding `R`; `max R 0` is what makes this
-hold for negative `R` as well. Multiplying by `I` does not change the norm, so the same bound
-serves the witnesses on either axis. -/
-private lemma lt_norm_neg_max_add_one (R : ℝ) : R < ‖((-(max R 0 + 1) : ℝ) : ℂ)‖ := by
-  rw [Complex.norm_real, Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
-  nlinarith [le_max_left R 0]
-
-/-- Rotated onto the imaginary axis, that witness has negative imaginary part — so it lies
-below any non-negative height, the contour's included. -/
-private lemma neg_max_add_one_mul_I_im_neg (R : ℝ) :
-    (((-(max R 0 + 1) : ℝ) : ℂ) * Complex.I).im < 0 := by
-  rw [Complex.mul_I_im, Complex.ofReal_re]
-  nlinarith [le_max_right R 0]
-
 /-- Every point strictly below the contour's height winds zero. -/
 @[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {w : ℂ}
     (hw : w.im < Real.sqrt 3 / 2) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_im_lt _).isPreconnected
-    ?_ (fun R ↦ ⟨((-(max R 0 + 1) : ℝ) : ℂ) * Complex.I, ?_, ?_⟩) hw
+    ?_ (fun R ↦ (Complex.exists_im_lt_and_lt_norm (Real.sqrt 3 / 2) R).imp
+      fun _ h ↦ ⟨h.1, h.2⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary hH ht))
-  · rw [Set.mem_ofPred_eq]
-    exact (neg_max_add_one_mul_I_im_neg R).trans_le (by positivity)
-  · rw [norm_mul, Complex.norm_I, mul_one]
-    exact lt_norm_neg_max_add_one R
 
 /-- Every point strictly right of the fundamental strip winds zero. The bound is stated
 in simp-normal form so the lemma can participate in simplification. -/
@@ -115,16 +99,14 @@ theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     (hw : 2⁻¹ < w.re) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_re_gt _).isPreconnected
-    ?_ (fun R ↦ ⟨((max R 0 + 1 : ℝ) : ℂ), ?_, ?_⟩) hw
+    ?_ (fun R ↦ (Complex.exists_lt_re_and_lt_norm 2⁻¹ R).imp
+      fun _ h ↦ ⟨h.1, h.2⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     have := (abs_le.mp (abs_re_fdBoundary_le_half (H := H) ht.2)).2
     rw [Set.mem_ofPred_eq] at hz
     linarith
-  · rw [Set.mem_ofPred_eq, Complex.ofReal_re]
-    nlinarith [le_max_right R 0]
-  · rw [Complex.norm_real, Real.norm_of_nonneg (by positivity)]
-    linarith [le_max_left R 0]
+
 
 /-- Every point strictly left of the fundamental strip winds zero. -/
 @[simp]
@@ -132,15 +114,14 @@ theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
     (hw : w.re < -2⁻¹) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_re_lt _).isPreconnected
-    ?_ (fun R ↦ ⟨((-(max R 0 + 1) : ℝ) : ℂ), ?_, ?_⟩) hw
+    ?_ (fun R ↦ (Complex.exists_re_lt_and_lt_norm (-2⁻¹) R).imp
+      fun _ h ↦ ⟨h.1, h.2⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     have := (abs_le.mp (abs_re_fdBoundary_le_half (H := H) ht.2)).1
     rw [Set.mem_ofPred_eq] at hz
     linarith
-  · rw [Set.mem_ofPred_eq, Complex.ofReal_re]
-    nlinarith [le_max_right R 0]
-  · exact lt_norm_neg_max_add_one R
+
 
 /-- Every point strictly above the contour's height winds zero. -/
 @[simp]
@@ -148,19 +129,13 @@ theorem windingNumber_fdBoundary_eq_zero_of_lt_im (hH : 1 ≤ H) {w : ℂ}
     (hw : H < w.im) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_im_gt _).isPreconnected
-    ?_ (fun R ↦ ⟨((H + max R 0 + 1 : ℝ) : ℂ) * Complex.I, ?_, ?_⟩) hw
+    ?_ (fun R ↦ (Complex.exists_lt_im_and_lt_norm H R).imp
+      fun _ h ↦ ⟨h.1, h.2⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     have := im_fdBoundary_le hH ht
     rw [Set.mem_ofPred_eq] at hz
     linarith
-  · rw [Set.mem_ofPred_eq]
-    have : (((H + max R 0 + 1 : ℝ) : ℂ) * Complex.I).im = H + max R 0 + 1 := by simp
-    rw [this]
-    nlinarith [le_max_right R 0]
-  · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
-      Real.norm_of_nonneg (by nlinarith [le_max_right R 0])]
-    nlinarith [le_max_left R 0]
 
 /-- Every point of the open unit disc winds zero: the disc sits under the arc, inside the
 contour's complement, and connects through the origin to the region below the corner
@@ -177,17 +152,15 @@ theorem windingNumber_fdBoundary_eq_zero_of_norm_lt_one (hH : 1 ≤ H) {w : ℂ}
     positivity
   have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_lt_one.le
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected hconn ?_
-    (fun R ↦ ⟨((-(max R 0 + 1) : ℝ) : ℂ) * Complex.I, Or.inr ?_, ?_⟩)
+    (fun R ↦ (Complex.exists_im_lt_and_lt_norm (Real.sqrt 3 / 2) R).imp
+      fun _ h ↦ ⟨Or.inr h.1, h.2⟩)
     (Or.inl (by rwa [Metric.mem_ball, dist_zero_right]))
   · rintro z (hz | hz) ⟨t, ht, rfl⟩ <;>
       rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     · rw [Metric.mem_ball, dist_zero_right] at hz
       exact absurd hz (not_lt.mpr (one_le_norm_fdBoundary hH ht))
     · exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ht))
-  · rw [Set.mem_ofPred_eq]
-    exact (neg_max_add_one_mul_I_im_neg R).trans_le (by positivity)
-  · rw [norm_mul, Complex.norm_I, mul_one]
-    exact lt_norm_neg_max_add_one R
+
 
 /-- The boundary contour is null-homologous in the truncated fundamental domain: every
 point off the closed truncated domain lies in one of the five exterior regions, where the

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -6,11 +6,11 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.Modular
-public import TauCeti.Analysis.Complex.HalfPlaneUnbounded
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Containment
 
 import Mathlib.Analysis.Complex.Convex
+import TauCeti.Analysis.Complex.HalfPlaneUnbounded
 import TauCeti.Analysis.Contour.Winding.UnboundedComponent
 
 /-!

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -79,6 +79,20 @@ private lemma windingNumber_fdBoundary_eq_zero_of_mem_preconnected {S : Set ℂ}
   rw [Metric.mem_closedBall, dist_zero_right] at this
   linarith
 
+/-- **The escape witness.** Every lemma below feeds `hunb` a point of the form
+`-(max R 0 + 1)`, on the real axis or rotated onto the imaginary axis; in both cases it is the
+norm that has to exceed `R`, and `max R 0` makes that work for negative `R` too. -/
+private lemma lt_norm_neg_max_add_one (R : ℝ) : R < ‖((-(max R 0 + 1) : ℝ) : ℂ)‖ := by
+  rw [Complex.norm_real, Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
+  nlinarith [le_max_left R 0]
+
+/-- The escape witness rotated onto the imaginary axis sits below the contour's height, so it
+lies in the half-space the `im`-lemmas transport through. -/
+private lemma neg_max_add_one_mul_I_im_lt (R : ℝ) :
+    (((-(max R 0 + 1) : ℝ) : ℂ) * Complex.I).im < Real.sqrt 3 / 2 := by
+  rw [Complex.mul_I_im, Complex.ofReal_re]
+  nlinarith [le_max_right R 0, Real.sqrt_nonneg 3]
+
 /-- Every point strictly below the contour's height winds zero. -/
 @[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {w : ℂ}
@@ -89,11 +103,10 @@ theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary hH ht))
-  · rw [Set.mem_ofPred_eq, Complex.mul_I_im, Complex.ofReal_re]
-    nlinarith [le_max_right R 0, Real.sqrt_nonneg 3]
-  · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
-      Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
-    nlinarith [le_max_left R 0]
+  · rw [Set.mem_ofPred_eq]
+    exact neg_max_add_one_mul_I_im_lt R
+  · rw [norm_mul, Complex.norm_I, mul_one]
+    exact lt_norm_neg_max_add_one R
 
 /-- Every point strictly right of the fundamental strip winds zero. The bound is stated
 in simp-normal form so the lemma can participate in simplification. -/
@@ -127,8 +140,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
     linarith
   · rw [Set.mem_ofPred_eq, Complex.ofReal_re]
     nlinarith [le_max_right R 0]
-  · rw [Complex.norm_real, Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
-    nlinarith [le_max_left R 0]
+  · exact lt_norm_neg_max_add_one R
 
 /-- Every point strictly above the contour's height winds zero. -/
 @[simp]
@@ -172,11 +184,10 @@ theorem windingNumber_fdBoundary_eq_zero_of_norm_lt_one (hH : 1 ≤ H) {w : ℂ}
     · rw [Metric.mem_ball, dist_zero_right] at hz
       exact absurd hz (not_lt.mpr (one_le_norm_fdBoundary hH ht))
     · exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ht))
-  · rw [Set.mem_ofPred_eq, Complex.mul_I_im, Complex.ofReal_re]
-    nlinarith [le_max_right R 0, Real.sqrt_nonneg 3]
-  · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
-      Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
-    nlinarith [le_max_left R 0]
+  · rw [Set.mem_ofPred_eq]
+    exact neg_max_add_one_mul_I_im_lt R
+  · rw [norm_mul, Complex.norm_I, mul_one]
+    exact lt_norm_neg_max_add_one R
 
 /-- The boundary contour is null-homologous in the truncated fundamental domain: every
 point off the closed truncated domain lies in one of the five exterior regions, where the


### PR DESCRIPTION
Five `windingNumber_fdBoundary_eq_zero_*` lemmas prove their region unbounded by handing `hunb`
an explicit escape point, and each re-derived that point's properties from scratch — four
different witnesses across four half-plane directions (`im < c` twice; `re > c`, `re < c`,
`im > c` once each), every one carrying its own `max R 0` clamping and its own norm bound.

This PR replaces all of that with the property they were certifying. A new module
`Analysis/Normed/Module/HalfSpace.lean` — importing only `Mathlib.Analysis.Normed.Module.Basic`
— holds the general facts:

```lean
TauCeti.exists_apply_lt_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
    ∃ y : E, φ y < u ∧ R < ‖y‖
TauCeti.exists_lt_apply_and_lt_norm {φ : E →ₗ[ℝ] ℝ} (hφ : φ ≠ 0) (u R : ℝ) :
    ∃ y : E, u < φ y ∧ R < ‖y‖
```

*Either open half-space of a nonzero linear functional holds points of arbitrarily large norm.*
Continuity is not needed, so these are stated for `E →ₗ[ℝ] ℝ`. `TauCeti.not_isBounded_halfSpace_lt`
moves here too and follows them onto linear maps: it used to carry its own copy of the scaling
argument, and is now a four-line corollary, so that argument occurs once in the repository. Its
former home `FilledHull.lean` imports the new module non-publicly, as does `HalfPlaneUnbounded.lean`
— a complex consumer no longer pulls in the filled-hull and separation theory to learn that a
half-plane is unbounded.

`Analysis/Complex/HalfPlaneUnbounded.lean` holds the four coordinate specialisations, at
`Complex.reLm` and `Complex.imLm`, plus the two nonvanishing facts they need:

```lean
TauCeti.exists_im_lt_and_lt_norm (c R : ℝ) : ∃ z : ℂ, z.im < c ∧ R < ‖z‖
TauCeti.exists_lt_im_and_lt_norm (c R : ℝ) : ∃ z : ℂ, c < z.im ∧ R < ‖z‖
TauCeti.exists_re_lt_and_lt_norm (c R : ℝ) : ∃ z : ℂ, z.re < c ∧ R < ‖z‖
TauCeti.exists_lt_re_and_lt_norm (c R : ℝ) : ∃ z : ℂ, c < z.re ∧ R < ‖z‖
```

`Winding/Basic.lean` goes **+14 −41** and no longer mentions `-(max R 0 + 1)` anywhere.

**How this PR got here, since the diff no longer matches the title's history.** It began as a
narrower change: three consumers re-derived the same norm bound, so I named it once as a private
lemma. The `api-design` rubric objected that a domain-independent lemma kept private
under-exposes general infrastructure, and asked for both witnesses to be exported publicly.

I contested that on the merits — exporting `R < ‖((-(max R 0 + 1) : ℝ) : ℂ)‖` publishes a proof
artifact under a name nobody would search for, and the genuinely reusable statement is the
unboundedness of the half-plane, not the witness certifying it. The re-review **kept the finding
and adopted that alternative**, asking for exactly "a public unboundedness lemma for the relevant
half-space [to] avoid exposing witness bookkeeping". Later rounds moved the generic lemmas out of
`Analysis/Complex` and dropped their continuity hypothesis. Reading every consumer while
implementing the first version turned up two `hunb` sites the original scan had missed, which is
why the count went from three to five.

One deliberate departure from a finding's suggested wording: `api-design` proposed publishing the
nonvanishing facts as `Complex.imCLM_ne_zero` / `Complex.reCLM_ne_zero`, but `generality` in the
same round moved the general lemmas to linear maps, so they are stated for `Complex.imLm` /
`Complex.reLm`. `imCLM_coe` and `reCLM_coe` are `rfl` and `@[simp]`, so the `CLM` forms follow by
`simp`; a second pair would be redundant surface.

Roadmap: ModularForms

Provenance: none — refactor of existing TauCeti code; no external source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
