### PR TITLE
feat(ArithmeticDirichletSeries): a weight bounded by one converges on Re s > 1

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -420,25 +420,31 @@ theorem summable_idealTerm_one_iff {K : Type*} [Field K] [NumberField K] {s : �
   exact summable_idealTerm_of_nonneg K 1 (fun _ ↦ zero_le_one)
     ((LSeriesSummable_normCoeff_one_iff K).mpr h)
 
-/-- **A weight bounded by one converges wherever the trivial weight does.** If every value of `f`
-on a nonzero integral ideal has modulus at most `1`, its ideal-indexed Dirichlet series converges
-absolutely on `Re s > 1`.
+/-- **A uniformly bounded weight converges wherever the trivial weight does.** If every value of
+`f` on a nonzero integral ideal has modulus at most `C`, its ideal-indexed Dirichlet series
+converges absolutely on `Re s > 1`.
 
-This is the comparison every unitary weight needs — a Dirichlet or Galois character has values of
-modulus `1` at the good primes and `0` at the bad ones, so it is bounded by `1` everywhere — and it
-is stated for the bound rather than for unitarity so that the vanishing at the bad primes needs no
-special case. The converse of `summable_idealTerm_one_iff` fails here: a weight that vanishes
-identically converges everywhere. -/
-theorem summable_idealTerm_of_norm_le_one {K : Type*} [Field K] [NumberField K]
-    {f : IdealArithmeticFunction K} (hf : ∀ I : (Ideal (𝓞 K))⁰, ‖f I‖ ≤ 1) {s : ℂ}
+The bound may be any real: the comparison is against `C` times the trivial weight's series, and no
+`C = 1` normalisation is wanted, since a weight is often bounded by something other than `1`
+without being rescaled. The unitary case — a Dirichlet or Galois character, of modulus `1` at the
+good primes and `0` at the bad ones — is `C = 1`, and stating the hypothesis as a bound rather than
+as unitarity is what lets the vanishing at the bad primes pass without a special case.
+
+Only one direction holds, unlike `summable_idealTerm_one_iff`: a weight that vanishes identically
+is bounded by every `C` and converges everywhere. -/
+theorem summable_idealTerm_of_norm_le_of_one_lt_re {K : Type*} [Field K] [NumberField K]
+    {f : IdealArithmeticFunction K} {C : ℝ} (hf : ∀ I : (Ideal (𝓞 K))⁰, ‖f I‖ ≤ C) {s : ℂ}
     (hs : 1 < s.re) : Summable (idealTerm K f s) := by
-  refine Summable.of_norm_bounded (g := fun I ↦ ‖idealTerm K (1 : IdealArithmeticFunction K) s I‖)
-    ((summable_idealTerm_one_iff.mpr hs).norm) fun I ↦ ?_
+  refine Summable.of_norm_bounded
+    (g := fun I ↦ C * ‖idealTerm K (1 : IdealArithmeticFunction K) s I‖)
+    (((summable_idealTerm_one_iff.mpr hs).norm).mul_left C) fun I ↦ ?_
   rw [norm_idealTerm, norm_idealTerm]
   have hpos : (0 : ℝ) < (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s.re :=
     Real.rpow_pos_of_pos (by exact_mod_cast Ideal.absNorm_pos_of_nonZeroDivisors I) _
+  have hone : ‖(1 : IdealArithmeticFunction K) I‖ = 1 := by simp
+  rw [hone, mul_one_div]
   gcongr
-  exact (hf I).trans_eq (by simp)
+  exact hf I
 
 /-- **The Dedekind zeta series has abscissa of absolute convergence `1`.** -/
 @[simp]

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -45,6 +45,9 @@ of a convergent series of nonnegative terms must become arbitrarily small.
   `NumberField.dedekindZeta` is the `LSeries` of.  That system counts *all* integral ideals, so it
   differs from the trivial norm coefficients at `n = 0` and the two statements are related only
   through the `n ≠ 0` congruence `LSeries.abscissaOfAbsConv_congr`.
+* `TauCeti.summable_idealTerm_of_norm_le_of_one_lt_re`: a uniformly bounded weight has an
+  absolutely convergent ideal-indexed Dirichlet series on `Re s > 1`, and
+  `TauCeti.summable_idealTerm_of_unitary_of_one_lt_re` is its unitary specialization.
 
 ## Implementation notes
 
@@ -427,9 +430,9 @@ converges absolutely on `Re s > 1`.
 The bound may be any nonnegative real — a negative `C` makes the hypothesis unsatisfiable, since
 `‖f I‖` is a norm — and no `C = 1` normalisation is wanted, since a weight is often bounded by
 something other than `1` without being rescaled. The unitary case — a Dirichlet or Galois
-character, of modulus `1` at the good primes and `0` at the bad ones — is `C = 1`, and stating the
-hypothesis as a bound rather than as unitarity is what lets the vanishing at the bad primes pass
-without a special case.
+character, of modulus `1` at the good primes and `0` at the bad ones — is `C = 1`, and is packaged
+as `summable_idealTerm_of_unitary_of_one_lt_re`. Stating the hypothesis here as a bound rather than
+as unitarity is what lets the vanishing at the bad primes pass without a special case.
 
 Only one direction holds, unlike `summable_idealTerm_one_iff`: a weight that vanishes identically
 is bounded by every nonnegative `C` and converges everywhere. -/
@@ -446,6 +449,20 @@ theorem summable_idealTerm_of_norm_le_of_one_lt_re {K : Type*} [Field K] [Number
   rw [hone, mul_one_div]
   gcongr
   exact hf I
+
+/-- **A unitary weight converges on `Re s > 1`.** The specialization of
+`summable_idealTerm_of_norm_le_of_one_lt_re` at `C = 1`, through
+`TauCeti.UnitaryIdealWeight.norm_le_one`: a unitary weight has modulus `1` on the good ideals and
+vanishes on the rest, so it is bounded by `1` on all of them and the caller is left no case split.
+
+This is the form the Euler-product code consumes, its `hasProd_eulerFactor` asking for exactly a
+`Summable (idealTerm K · s)` hypothesis on the weight's passage to `IdealArithmeticFunction`. -/
+theorem summable_idealTerm_of_unitary_of_one_lt_re {K : Type*} [Field K] [NumberField K]
+    (χ : UnitaryIdealWeight K) {s : ℂ} (hs : 1 < s.re) :
+    Summable (idealTerm K χ.toIdealArithmeticFunction s) := by
+  refine summable_idealTerm_of_norm_le_of_one_lt_re (C := 1) (fun I ↦ ?_) hs
+  rw [UnitaryIdealWeight.toIdealArithmeticFunction_apply]
+  exact χ.norm_le_one _
 
 /-- **The Dedekind zeta series has abscissa of absolute convergence `1`.** -/
 @[simp]

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -45,7 +45,7 @@ of a convergent series of nonnegative terms must become arbitrarily small.
   `NumberField.dedekindZeta` is the `LSeries` of.  That system counts *all* integral ideals, so it
   differs from the trivial norm coefficients at `n = 0` and the two statements are related only
   through the `n ≠ 0` congruence `LSeries.abscissaOfAbsConv_congr`.
-* `TauCeti.summable_idealTerm_of_norm_le_of_one_lt_re`: a uniformly bounded weight has an
+* `TauCeti.summable_idealTerm_of_bounded_of_one_lt_re`: a uniformly bounded weight has an
   absolutely convergent ideal-indexed Dirichlet series on `Re s > 1`, and
   `TauCeti.summable_idealTerm_of_unitary_of_one_lt_re` is its unitary specialization.
 
@@ -436,7 +436,7 @@ as unitarity is what lets the vanishing at the bad primes pass without a special
 
 Only one direction holds, unlike `summable_idealTerm_one_iff`: a weight that vanishes identically
 is bounded by every nonnegative `C` and converges everywhere. -/
-theorem summable_idealTerm_of_norm_le_of_one_lt_re {K : Type*} [Field K] [NumberField K]
+theorem summable_idealTerm_of_bounded_of_one_lt_re {K : Type*} [Field K] [NumberField K]
     {f : IdealArithmeticFunction K} {C : ℝ} (hf : ∀ I : (Ideal (𝓞 K))⁰, ‖f I‖ ≤ C) {s : ℂ}
     (hs : 1 < s.re) : Summable (idealTerm K f s) := by
   refine Summable.of_norm_bounded
@@ -451,7 +451,7 @@ theorem summable_idealTerm_of_norm_le_of_one_lt_re {K : Type*} [Field K] [Number
   exact hf I
 
 /-- **A unitary weight converges on `Re s > 1`.** The specialization of
-`summable_idealTerm_of_norm_le_of_one_lt_re` at `C = 1`, through
+`summable_idealTerm_of_bounded_of_one_lt_re` at `C = 1`, through
 `TauCeti.UnitaryIdealWeight.norm_le_one`: a unitary weight has modulus `1` on the good ideals and
 vanishes on the rest, so it is bounded by `1` on all of them and the caller is left no case split.
 
@@ -460,7 +460,7 @@ This is the form the Euler-product code consumes, its `hasProd_eulerFactor` aski
 theorem summable_idealTerm_of_unitary_of_one_lt_re {K : Type*} [Field K] [NumberField K]
     (χ : UnitaryIdealWeight K) {s : ℂ} (hs : 1 < s.re) :
     Summable (idealTerm K χ.toIdealArithmeticFunction s) := by
-  refine summable_idealTerm_of_norm_le_of_one_lt_re (C := 1) (fun I ↦ ?_) hs
+  refine summable_idealTerm_of_bounded_of_one_lt_re (C := 1) (fun I ↦ ?_) hs
   rw [UnitaryIdealWeight.toIdealArithmeticFunction_apply]
   exact χ.norm_le_one _
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -420,6 +420,26 @@ theorem summable_idealTerm_one_iff {K : Type*} [Field K] [NumberField K] {s : �
   exact summable_idealTerm_of_nonneg K 1 (fun _ ↦ zero_le_one)
     ((LSeriesSummable_normCoeff_one_iff K).mpr h)
 
+/-- **A weight bounded by one converges wherever the trivial weight does.** If every value of `f`
+on a nonzero integral ideal has modulus at most `1`, its ideal-indexed Dirichlet series converges
+absolutely on `Re s > 1`.
+
+This is the comparison every unitary weight needs — a Dirichlet or Galois character has values of
+modulus `1` at the good primes and `0` at the bad ones, so it is bounded by `1` everywhere — and it
+is stated for the bound rather than for unitarity so that the vanishing at the bad primes needs no
+special case. The converse of `summable_idealTerm_one_iff` fails here: a weight that vanishes
+identically converges everywhere. -/
+theorem summable_idealTerm_of_norm_le_one {K : Type*} [Field K] [NumberField K]
+    {f : IdealArithmeticFunction K} (hf : ∀ I : (Ideal (𝓞 K))⁰, ‖f I‖ ≤ 1) {s : ℂ}
+    (hs : 1 < s.re) : Summable (idealTerm K f s) := by
+  refine Summable.of_norm_bounded (g := fun I ↦ ‖idealTerm K (1 : IdealArithmeticFunction K) s I‖)
+    ((summable_idealTerm_one_iff.mpr hs).norm) fun I ↦ ?_
+  rw [norm_idealTerm, norm_idealTerm]
+  have hpos : (0 : ℝ) < (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s.re :=
+    Real.rpow_pos_of_pos (by exact_mod_cast Ideal.absNorm_pos_of_nonZeroDivisors I) _
+  gcongr
+  exact (hf I).trans_eq (by simp)
+
 /-- **The Dedekind zeta series has abscissa of absolute convergence `1`.** -/
 @[simp]
 theorem abscissaOfAbsConv_dedekindZetaCoeff :

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -424,14 +424,15 @@ theorem summable_idealTerm_one_iff {K : Type*} [Field K] [NumberField K] {s : �
 `f` on a nonzero integral ideal has modulus at most `C`, its ideal-indexed Dirichlet series
 converges absolutely on `Re s > 1`.
 
-The bound may be any real: the comparison is against `C` times the trivial weight's series, and no
-`C = 1` normalisation is wanted, since a weight is often bounded by something other than `1`
-without being rescaled. The unitary case — a Dirichlet or Galois character, of modulus `1` at the
-good primes and `0` at the bad ones — is `C = 1`, and stating the hypothesis as a bound rather than
-as unitarity is what lets the vanishing at the bad primes pass without a special case.
+The bound may be any nonnegative real — a negative `C` makes the hypothesis unsatisfiable, since
+`‖f I‖` is a norm — and no `C = 1` normalisation is wanted, since a weight is often bounded by
+something other than `1` without being rescaled. The unitary case — a Dirichlet or Galois
+character, of modulus `1` at the good primes and `0` at the bad ones — is `C = 1`, and stating the
+hypothesis as a bound rather than as unitarity is what lets the vanishing at the bad primes pass
+without a special case.
 
 Only one direction holds, unlike `summable_idealTerm_one_iff`: a weight that vanishes identically
-is bounded by every `C` and converges everywhere. -/
+is bounded by every nonnegative `C` and converges everywhere. -/
 theorem summable_idealTerm_of_norm_le_of_one_lt_re {K : Type*} [Field K] [NumberField K]
     {f : IdealArithmeticFunction K} {C : ℝ} (hf : ∀ I : (Ideal (𝓞 K))⁰, ‖f I‖ ≤ C) {s : ℂ}
     (hs : 1 < s.re) : Summable (idealTerm K f s) := by


### PR DESCRIPTION
> [!NOTE]
> **Unstacked.** The parent #5967 (`UnitaryIdealWeight.norm_le_one`) merged, so this rebased onto
> `main` and the `Weight.lean` hunk is gone from the diff: it is now `Estimates.lean` alone. Ready
> for review.

The `api-design` rubric found that the bounded-weight theorem advertised a unitary use that no
canonical API supported: `UnitaryIdealWeight` exposed `norm_eq_one` only on good ideals, so a
consumer holding a unitary weight still had to reconstruct the bad-ideal case by hand. Its fix was
to "export `UnitaryIdealWeight.norm_le_one` for every ideal ... and provide the direct unitary
summability specialization".

The first half was #5967, now on `main`. This PR supplies the second half:

```lean
theorem summable_idealTerm_of_unitary_of_one_lt_re (χ : UnitaryIdealWeight K) (hs : 1 < s.re) :
    Summable (idealTerm K χ.toIdealArithmeticFunction s)
```

---

A weight whose values have modulus at most one has an absolutely convergent ideal-indexed
Dirichlet series on `Re s > 1`:

```lean
theorem TauCeti.summable_idealTerm_of_bounded_of_one_lt_re {f : IdealArithmeticFunction K}
    {C : ℝ} (hf : ∀ I : (Ideal (𝓞 K))⁰, ‖f I‖ ≤ C) {s : ℂ} (hs : 1 < s.re) :
    Summable (idealTerm K f s)
```

`summable_idealTerm_one_iff` already settles the trivial weight, and every term of a
modulus-bounded weight is dominated by the corresponding term of the trivial one — `norm_idealTerm`
puts both norms over the same `N(I) ^ Re s`. So this is that comparison, made once.

### Review round 1

* **generality** — the bound is now an arbitrary `C` rather than `1`. The comparison never used the
  value `1`: it goes against the trivial weight's series, and a factor of `C` rides through
  untouched. The unitary case is `C = 1` with `C` inferred, so no call site is longer. The finding
  also caught an overclaim in the docstring, which said the lemma covered weights "merely bounded
  rather than unitary" while the statement only allowed bounds at most one; corrected.
* **naming** — renamed to `summable_idealTerm_of_bounded_of_one_lt_re`. The old name promised
  summability from the norm bound alone, but `1 < s.re` is equally essential — without it even the
  trivial weight's series diverges.

### Two deliberate choices in the statement

**The hypothesis is the bound, not unitarity.** `TauCeti.UnitaryIdealWeight` asks for modulus one
on the *good* ideals and permits zero at the bad ones, so a unitary weight is not literally of
modulus one everywhere. Stating the bound directly means the vanishing at ramified primes needs no
special case, and the lemma also covers weights that are merely bounded rather than unitary.

**It is a one-way implication, unlike `summable_idealTerm_one_iff`.** The converse is false: the
zero weight is bounded by every `C` and its series converges for every `s`. Only the trivial weight,
which is bounded *below* away from zero, can support an `iff`.

### Why it is needed

Chebotarev Layer 4 asks for the Euler product of `cyclotomicCharacterWeight`. The
ArithmeticDirichletSeries side already supplies the analytic half —
`MultiplicativeIdealWeight.hasProd_eulerFactor` — but that takes
`Summable (idealTerm K χ.toIdealArithmeticFunction s)` as a hypothesis, and nothing on `main`
discharges it for a character. `summable_idealTerm_one_iff` covers only the trivial weight and
`summable_idealTerm_of_re_le_re` only moves `s`; `summable_idealTerm_of_nonneg` is a different
statement, needing nonnegativity and an `LSeriesSummable` hypothesis rather than a modulus bound.
This is the missing step, and it is stated generally rather than for a Galois character so that
Dirichlet characters and ray-class characters get it too.

### Absence

No declaration on `main` relates a modulus bound on an `IdealArithmeticFunction` to summability of
its `idealTerm`; the three neighbouring `summable_idealTerm_*` lemmas are the ones named above.

`CBirkbeck/chebotarev-density` at `8575c9df` has no `idealTerm` at all (0 files) and no unitary
weight abstraction. It does prove summability for the Galois character series, at
`CebotarevDensity/ZetaProduct.lean:2342`, but by a different route — `LSeriesSummable_of_sum_norm_bigO`
applied to a big-O bound on partial sums of norms, on the `LSeries` side rather than the
ideal-indexed side. Controls were run on the same probes (`theorem` returns 25 files, `Complex` 6),
so the absences are real rather than a broken search. **No `Provenance` line is owed**: this
generalises TauCeti's own `summable_idealTerm_one_iff` and takes nothing from the source.

Roadmap: ArithmeticDirichletSeries

No `tauceti-target:v1` marker: this is a modest generalisation of an existing lemma rather than the
authoring of a roadmap target, so it has no deterministic target id of its own.

### On the cleanup pass

`lean-lsp` has been unreachable for this whole session, so `/cleanup`'s phases 6.5 and 6.6 were
discharged directly. `#lint in TauCeti.NumberTheory.ArithmeticDirichletSeries.Estimates` reports
**0 errors in 28 declarations with all 15 linters**. Axioms are exactly `propext`,
`Classical.choice` and `Quot.sound`; every line is within 100 characters; the proof is 8 lines, so
`/decompose-proof` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF




