### PR TITLE
feat(Huber): strong noetherianness is preserved by a numerator enlargement

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
@@ -11,11 +11,12 @@ public import TauCeti.RingTheory.Huber.Restricted.Laurent
 public import TauCeti.RingTheory.Huber.StronglyNoetherian
 
 import TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.Identification
+import TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.StronglyNoetherian
 
 /-!
 # Flatness of the Laurent quotient, and of a numerator enlargement
 
-Restriction maps between the rings of a Laurent presentation are flat, at the ring level. Three
+Restriction maps between the rings of a Laurent presentation are flat, at the ring level. Four
 statements, in increasing generality:
 
 * the Laurent quotient `A⟨T/s⟩⟨X⟩ ⧸ (t/s - X)` is a flat `A⟨T/s⟩`-module when that base is a
@@ -24,9 +25,11 @@ statements, in increasing generality:
   when `T'` is `T` with one numerator `t` adjoined. It asks the hypotheses above of `A⟨T/s⟩`,
   together with closedness of the Laurent relation ideal, **only when `t ∉ T`**;
 * the restriction map of an arbitrary enlargement `T ⊆ T'` is flat, assuming `s` topologically
-  nilpotent and `A⟨U/s⟩` strongly noetherian for every `U` with `T ⊆ U ⊂ T'`. This is **not**
-  Wedhorn's Proposition 8.30, which assumes strong noetherianity of `A` alone; see
-  *What this is not*.
+  nilpotent and `A⟨U/s⟩` strongly noetherian for every `U` with `T ⊆ U ⊂ T'`. On its own this is
+  **not** Wedhorn's Proposition 8.30, which assumes strong noetherianity of the base alone; see
+  *What this is not*;
+* **Wedhorn's Proposition 8.30**: the same conclusion asking strong noetherianity only at `T`,
+  the per-intermediate hypothesis being derived rather than assumed.
 
 Changing the localisation that carries a presentation is flat with no hypotheses at all.
 
@@ -53,6 +56,9 @@ in: `s` topologically nilpotent over a strongly noetherian base.
   `A⟨U/s⟩` strongly noetherian for every `U` with `T ⊆ U ⊂ T'`**. That family hypothesis is what
   separates this from Wedhorn's Proposition 8.30, which assumes it of `A` alone; see *What this is
   not*.
+* `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base` :
+  **Wedhorn's Proposition 8.30** — the same conclusion asking strong noetherianity only at `T`,
+  the family hypothesis above being derived from it rather than assumed.
 
 ## What this is not
 
@@ -423,6 +429,10 @@ separates the two is the standing hypothesis of his §8.2 — that rational loca
 strongly noetherian ring are again strongly noetherian — which `hSN` assumes case by case rather
 than deriving.
 
+`TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base`
+supplies that derivation and is Wedhorn's statement; this form remains the one to use when strong
+noetherianity is known only at the intermediate presentations.
+
 The enlargement is arbitrary and so is the localisation `S'` carrying the target, matching
 `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset` and the rest of the restriction
 API.
@@ -457,6 +467,35 @@ theorem flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian
     (flat_restrictionRingHomOfSubset_union P T s S hden T' hTT' hnil hSN (T' \ T) T'
       (Finset.union_sdiff_of_subset hTT').symm le_rfl hTT')
     (flat_restrictionRingHomOfSubset_self P T' s S (hden.mono hTT') S' hden')
+
+
+/-- **Wedhorn's Proposition 8.30 at the ring level**: if the completed localisation carrying the
+`T`-topology is strongly noetherian, the restriction map of any numerator enlargement is flat.
+
+This is `TauCeti.Huber.PairOfDefinition`
+`.flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian` with its per-intermediate
+hypothesis discharged. Strong noetherianness is asked at `T` alone and propagates to every `U`
+with `T ⊆ U` by `TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion_of_subset`, which
+is the standing hypothesis of Wedhorn's §8.2 that the `forall` form assumes case by case. -/
+theorem flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base
+    (hnil : T ⊂ T' → IsTopologicallyNilpotent s)
+    (hSN :
+      letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsStronglyNoetherian (UniformSpace.Completion S)) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    (restrictionRingHomOfSubset P T s S hden T' S' hden' hTT').Flat :=
+  flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian P T s S hden T' S' hden' hTT'
+    hnil fun U hU hUlt ↦
+      isStronglyNoetherian_completion_of_subset P T s S hden
+        (hnil (lt_of_le_of_lt hU hUlt)) hSN U hU
 
 
 end PairOfDefinition

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
@@ -494,8 +494,8 @@ theorem flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base
     (restrictionRingHomOfSubset P T s S hden T' S' hden' hTT').Flat :=
   flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian P T s S hden T' S' hden' hTT'
     hnil fun U hU hUlt ↦
-      isStronglyNoetherian_completion_of_subset P T s S hden
-        (hnil (lt_of_le_of_lt hU hUlt)) hSN U hU
+      isStronglyNoetherian_completion_of_subset P T s S hden U hU
+        (fun _ ↦ hnil (lt_of_le_of_lt hU hUlt)) hSN
 
 
 end PairOfDefinition

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
@@ -10,7 +10,6 @@ public import Mathlib.RingTheory.RingHom.Flat
 public import TauCeti.RingTheory.Huber.Restricted.Laurent
 public import TauCeti.RingTheory.Huber.StronglyNoetherian
 
-import TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.Identification
 import TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.StronglyNoetherian
 
 /-!
@@ -477,13 +476,7 @@ theorem flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian
 completed localisation carrying the `T`-topology is strongly noetherian, the restriction map of
 any numerator enlargement is flat.
 
-This is `TauCeti.Huber.PairOfDefinition`
-`.flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian` with its per-intermediate
-hypothesis discharged: strong noetherianness at `T` propagates to every `U` with `T ⊆ U` by
-`TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion_of_subset`, which is the standing
-hypothesis of Wedhorn's §8.2 that the `forall` form assumes case by case.
-
-**It is still not Wedhorn's Proposition 8.30 as he states it.** He assumes strong noetherianity
+**It is not Wedhorn's Proposition 8.30 as he states it.** He assumes strong noetherianity
 of `A`; this asks it of `A⟨T/s⟩`. Closing that last gap needs the passage from `A` to `A⟨T/s⟩`,
 which is not proved here. Both hypotheses are asked only of a *proper* enlargement: for `T' = T`
 the map is flat outright, by

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
@@ -28,8 +28,9 @@ statements, in increasing generality:
   nilpotent and `A⟨U/s⟩` strongly noetherian for every `U` with `T ⊆ U ⊂ T'`. On its own this is
   **not** Wedhorn's Proposition 8.30, which assumes strong noetherianity of the base alone; see
   *What this is not*;
-* **Wedhorn's Proposition 8.30**: the same conclusion asking strong noetherianity only at `T`,
-  the per-intermediate hypothesis being derived rather than assumed.
+* the same conclusion asking strong noetherianity only at `T`, the per-intermediate hypothesis
+  being derived rather than assumed. This is still not Wedhorn's Proposition 8.30, which asks it
+  of `A`; see *What this is not*.
 
 Changing the localisation that carries a presentation is flat with no hypotheses at all.
 
@@ -57,8 +58,9 @@ in: `s` topologically nilpotent over a strongly noetherian base.
   separates this from Wedhorn's Proposition 8.30, which assumes it of `A` alone; see *What this is
   not*.
 * `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base` :
-  **Wedhorn's Proposition 8.30** — the same conclusion asking strong noetherianity only at `T`,
-  the family hypothesis above being derived from it rather than assumed.
+  the same conclusion asking strong noetherianity only at `T`, the family hypothesis above being
+  derived from it rather than assumed. Wedhorn asks it of `A`, so this is one step short of his
+  statement; see *What this is not*.
 
 ## What this is not
 
@@ -430,8 +432,10 @@ strongly noetherian ring are again strongly noetherian — which `hSN` assumes c
 than deriving.
 
 `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base`
-supplies that derivation and is Wedhorn's statement; this form remains the one to use when strong
-noetherianity is known only at the intermediate presentations.
+supplies that derivation, reducing the family hypothesis to strong noetherianity of `A⟨T/s⟩`
+alone. That is still one step short of Wedhorn, who asks it of `A`: the passage from `A` to
+`A⟨T/s⟩` is not proved here. This form remains the one to use when strong noetherianity is known
+only at the intermediate presentations.
 
 The enlargement is arbitrary and so is the localisation `S'` carrying the target, matching
 `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset` and the rest of the restriction
@@ -469,17 +473,24 @@ theorem flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian
     (flat_restrictionRingHomOfSubset_self P T' s S (hden.mono hTT') S' hden')
 
 
-/-- **Wedhorn's Proposition 8.30 at the ring level**: if the completed localisation carrying the
-`T`-topology is strongly noetherian, the restriction map of any numerator enlargement is flat.
+/-- **The chain form of Proposition 8.30 asking strong noetherianity only at `T`**: if the
+completed localisation carrying the `T`-topology is strongly noetherian, the restriction map of
+any numerator enlargement is flat.
 
 This is `TauCeti.Huber.PairOfDefinition`
 `.flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian` with its per-intermediate
-hypothesis discharged. Strong noetherianness is asked at `T` alone and propagates to every `U`
-with `T ⊆ U` by `TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion_of_subset`, which
-is the standing hypothesis of Wedhorn's §8.2 that the `forall` form assumes case by case. -/
+hypothesis discharged: strong noetherianness at `T` propagates to every `U` with `T ⊆ U` by
+`TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion_of_subset`, which is the standing
+hypothesis of Wedhorn's §8.2 that the `forall` form assumes case by case.
+
+**It is still not Wedhorn's Proposition 8.30 as he states it.** He assumes strong noetherianity
+of `A`; this asks it of `A⟨T/s⟩`. Closing that last gap needs the passage from `A` to `A⟨T/s⟩`,
+which is not proved here. Both hypotheses are asked only of a *proper* enlargement: for `T' = T`
+the map is flat outright, by
+`TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_self`. -/
 theorem flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base
     (hnil : T ⊂ T' → IsTopologicallyNilpotent s)
-    (hSN :
+    (hSN : T ⊂ T' →
       letI := locUniformSpace P T s S hden
       letI := isUniformAddGroup_locUniformSpace P T s S hden
       letI := isTopologicalRing_locUniformSpace P T s S hden
@@ -495,7 +506,7 @@ theorem flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base
   flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian P T s S hden T' S' hden' hTT'
     hnil fun U hU hUlt ↦
       isStronglyNoetherian_completion_of_subset P T s S hden U hU
-        (fun _ ↦ hnil (lt_of_le_of_lt hU hUlt)) hSN
+        (fun _ ↦ hnil (lt_of_le_of_lt hU hUlt)) (hSN (lt_of_le_of_lt hU hUlt))
 
 
 end PairOfDefinition

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/Flat.lean
@@ -63,11 +63,20 @@ in: `s` topologically nilpotent over a strongly noetherian base.
 
 ## What this is not
 
-The chain result is **not** Wedhorn's Proposition 8.30 as he states it. His standing hypothesis is
-that `A` is strongly noetherian; the hypothesis here is that `A⟨U/s⟩` is, for every `U` with
-`T ⊆ U ⊂ T'`. What separates the two is the standing hypothesis of Wedhorn's §8.2 — that rational
-localisations of a strongly noetherian ring are again strongly noetherian. The family hypothesis
-is carried rather than derived from that, and the theorem is named for what it assumes.
+**Neither chain result is Wedhorn's Proposition 8.30 as he states it**, and they fall short in
+different amounts. His standing hypothesis is that `A` is strongly noetherian.
+
+`TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian`
+asks it of `A⟨U/s⟩` for *every* `U` with `T ⊆ U ⊂ T'` — a family of hypotheses, carried rather
+than derived, and the theorem is named for what it assumes. It is the one to use when strong
+noetherianity is known only at the intermediate presentations.
+
+`TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base`
+asks it only at `T`, deriving the rest by
+`TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion_of_subset`. That removes the
+family, but not the last step: it still asks strong noetherianity of `A⟨T/s⟩` rather than of `A`,
+and **nothing here derives the one from the other**. That derivation is what Wedhorn's §8.2
+supplies and what this module still lacks.
 
 The elementary case is unaffected: it needs strong noetherianity only at its own base, which is
 where Lemma 8.31 needs it too.

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.Identification
 public import TauCeti.RingTheory.Huber.LocalizationTopology.StronglyNoetherian
 
-import TauCeti.RingTheory.Huber.LocalizationTopology.Presentation
 import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.FirstCountable
 import TauCeti.Topology.Algebra.GroupCompletion
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.Identification
+public import TauCeti.RingTheory.Huber.StronglyNoetherian
+
+import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.FirstCountable
+import TauCeti.Topology.Algebra.GroupCompletion
+
+/-!
+# Strong noetherianness of a completed rational localisation
+
+Wedhorn's Proposition 8.30 has two halves. The flatness half is in
+`TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.Flat`; this file is the other, that a
+rational localisation of a strongly noetherian Huber ring is again strongly noetherian.
+
+The argument is the chain of Wedhorn's Remark 7.55. Adjoining a single numerator `t` presents the
+enlarged localisation as a quotient of a one-variable restricted power-series algebra over the
+smaller one, by `TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv`, and the presenting
+ideal is closed as soon as that smaller one is strongly noetherian, by
+`TauCeti.Huber.PairOfDefinition.isClosed_laurentRelationIdeal_of_isStronglyNoetherian`. One
+hypothesis therefore carries the whole induction: strong noetherianness of the base both closes
+the ideal and, through `IsOpenQuotientMap.isStronglyNoetherian`, passes to the quotient.
+
+Only the *topology* varies along the chain. The localisation `S` itself is fixed, because
+`IsLocalization.Away s S` does not mention the numerators, so each step is a `hden.mono` away and
+the base case of the induction is the hypothesis itself.
+
+## Main results
+
+* `TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion_of_isClosed` : one enlargement
+  step, with the presenting ideal assumed closed.
+* `TauCeti.Huber.PairOfDefinition`
+  `.isStronglyNoetherian_completion_of_isTopologicallyNilpotent` : the same step with closedness
+  discharged, which is the form the induction consumes.
+* `TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion_of_subset` : the chain form.
+  Strong noetherianness propagates from `T` to every `T' ⊇ T`, which is what
+  `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_union` assumes at every proper
+  intermediate presentation.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Proposition 8.30 and
+  Remark 7.55.
+-/
+
+public section
+
+namespace TauCeti.Huber
+
+open TauCeti.Localization
+
+namespace PairOfDefinition
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
+  (P : PairOfDefinition A) (T : Finset A) (s t : A)
+  (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+  (hden : HasDenominatorPower P T s S)
+  (T' : Finset A) (S' : Type*) [CommRing S'] [Algebra A S'] [IsLocalization.Away s S']
+  (hden' : HasDenominatorPower P T' s S') (hTT' : ∀ u ∈ T, u ∈ T')
+
+include hTT' in
+/-- Adjoining one numerator preserves strong noetherianness of the completed localisation. -/
+theorem isStronglyNoetherian_completion_of_isClosed (ht : t ∈ T')
+    (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl :
+      letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight)))
+    (hSN :
+      letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsStronglyNoetherian (UniformSpace.Completion S)) :
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    IsStronglyNoetherian (UniformSpace.Completion S') := by
+  let := locUniformSpace P T s S hden
+  let := isUniformAddGroup_locUniformSpace P T s S hden
+  let := isTopologicalRing_locUniformSpace P T s S hden
+  let := isHuberRing_locUniformSpace P T s S hden
+  let := locUniformSpace P T' s S' hden'
+  let := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  let := isTopologicalRing_locUniformSpace P T' s S' hden'
+  let := isHuberRing_locUniformSpace P T' s S' hden'
+  have : IsStronglyNoetherian (UniformSpace.Completion S) := hSN
+  have h₁ : IsOpenQuotientMap
+      ⇑(restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)) :=
+    (Homeomorph.mk (restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)).toEquiv
+      (uniformContinuous_restrictedMvPowerSeriesCompletionEquiv
+        (k := 1) (A := UniformSpace.Completion S)).continuous
+      (uniformContinuous_restrictedMvPowerSeriesCompletionEquiv_symm
+        (k := 1) (A := UniformSpace.Completion S)).continuous).isOpenQuotientMap
+  have h₂ : IsOpenQuotientMap
+      ⇑(laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl) :=
+    (Homeomorph.mk (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).toEquiv
+      (continuous_laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl)
+      (continuous_laurentQuotientRingEquiv_symm P T s t S hden T' S' hden' hTT' ht hsplit
+        hcl)).isOpenQuotientMap
+  exact IsOpenQuotientMap.isStronglyNoetherian
+    (π := (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).toRingHom.comp
+      ((Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)).comp
+        (restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)).toRingHom))
+    (h₂.comp ((QuotientRing.isOpenQuotientMap_mk _).comp h₁))
+
+include hTT' in
+/-- **The Laurent step preserves strong noetherianness, for a topologically nilpotent
+denominator.** The closedness hypothesis of
+`TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion_of_isClosed` is then discharged
+by the base's own strong noetherianness, so the two uses of `hSN` are the whole content: it
+closes the relation ideal, and it feeds the open quotient. This is the form the induction over
+the numerators consumes. -/
+theorem isStronglyNoetherian_completion_of_isTopologicallyNilpotent
+    (hnil : IsTopologicallyNilpotent s) (ht : t ∈ T')
+    (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hSN :
+      letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsStronglyNoetherian (UniformSpace.Completion S)) :
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    IsStronglyNoetherian (UniformSpace.Completion S') :=
+  isStronglyNoetherian_completion_of_isClosed P T s t S hden T' S' hden' hTT' ht hsplit
+    (isClosed_laurentRelationIdeal_of_isStronglyNoetherian P T s t S hden hnil hSN) hSN
+
+
+-- The induction behind Proposition 8.30: strong noetherianness propagates from `T` to `T ∪ W`
+-- one numerator at a time. Only the topology on `S` varies; the localisation itself is fixed.
+private theorem isStronglyNoetherian_completion_union [DecidableEq A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S]
+    [IsLocalization.Away s S] (hden : HasDenominatorPower P T s S)
+    (hnil : IsTopologicallyNilpotent s)
+    (hSN :
+      letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsStronglyNoetherian (UniformSpace.Completion S)) :
+    ∀ (W V : Finset A), V = T ∪ W → ∀ hV : T ⊆ V,
+    letI := locUniformSpace P V s S (hden.mono hV)
+    letI := isUniformAddGroup_locUniformSpace P V s S (hden.mono hV)
+    letI := isTopologicalRing_locUniformSpace P V s S (hden.mono hV)
+    letI := isHuberRing_locUniformSpace P V s S (hden.mono hV)
+    IsStronglyNoetherian (UniformSpace.Completion S) := by
+  classical
+  intro W
+  induction W using Finset.induction_on with
+  | empty =>
+    intro V hVdef hV
+    rw [Finset.union_empty] at hVdef
+    subst hVdef
+    exact hSN
+  | @insert a W haW ih =>
+    intro V hVdef hV
+    rw [Finset.union_insert] at hVdef
+    subst hVdef
+    have hTU : T ⊆ T ∪ W := Finset.subset_union_left
+    have hUV : T ∪ W ⊆ insert a (T ∪ W) := Finset.subset_insert _ _
+    exact isStronglyNoetherian_completion_of_isTopologicallyNilpotent P (T ∪ W) s a S
+      (hden.mono hTU) (insert a (T ∪ W)) S (hden.mono hV) hUV hnil
+      (Finset.mem_insert_self _ _)
+      (fun u hu ↦ (Finset.mem_insert.mp hu).symm.imp id id)
+      (ih (T ∪ W) rfl hTU)
+
+/-- **Strong noetherianness propagates along a numerator enlargement.** If the completed
+localisation carries the `T`-topology and is strongly noetherian, then it is strongly noetherian
+for the `T'`-topology of any `T' ⊇ T`, provided the denominator is topologically nilpotent.
+
+This is the half of Wedhorn's Proposition 8.30 that
+`TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_union` assumes: that lemma asks
+for strong noetherianness at every proper intermediate presentation, and this supplies it from
+strong noetherianness at `T` alone. -/
+theorem isStronglyNoetherian_completion_of_subset (P : PairOfDefinition A) (T : Finset A)
+    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) (hnil : IsTopologicallyNilpotent s)
+    (hSN :
+      letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsStronglyNoetherian (UniformSpace.Completion S))
+    (T' : Finset A) (hTT' : T ⊆ T') :
+    letI := locUniformSpace P T' s S (hden.mono hTT')
+    letI := isUniformAddGroup_locUniformSpace P T' s S (hden.mono hTT')
+    letI := isTopologicalRing_locUniformSpace P T' s S (hden.mono hTT')
+    letI := isHuberRing_locUniformSpace P T' s S (hden.mono hTT')
+    IsStronglyNoetherian (UniformSpace.Completion S) := by
+  classical
+  exact isStronglyNoetherian_completion_union P T s S hden hnil hSN (T' \ T) T'
+    (by rw [Finset.union_sdiff_self_eq_union]; exact (Finset.union_eq_right.mpr hTT').symm) hTT'
+
+
+end PairOfDefinition
+
+end TauCeti.Huber
+
+end

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
@@ -67,58 +67,6 @@ variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
   (T' : Finset A) (S' : Type*) [CommRing S'] [Algebra A S'] [IsLocalization.Away s S']
   (hden' : HasDenominatorPower P T' s S') (hTT' : ∀ u ∈ T, u ∈ T')
 
-include hTT' in
-/-- **Adjoining one numerator preserves strong noetherianness of the completed localisation**,
-given that the Laurent relation ideal is closed and that the smaller completed localisation is
-strongly noetherian. `T'` is `T` with `t` adjoined, in the splitting form `hsplit`. -/
-theorem isStronglyNoetherian_completion_of_isClosed (ht : t ∈ T')
-    (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
-    (hcl :
-      letI := locUniformSpace P T s S hden
-      letI := isUniformAddGroup_locUniformSpace P T s S hden
-      letI := isTopologicalRing_locUniformSpace P T s S hden
-      letI := isHuberRing_locUniformSpace P T s S hden
-      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
-        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight)))
-    (hSN :
-      letI := locUniformSpace P T s S hden
-      letI := isUniformAddGroup_locUniformSpace P T s S hden
-      letI := isTopologicalRing_locUniformSpace P T s S hden
-      letI := isHuberRing_locUniformSpace P T s S hden
-      IsStronglyNoetherian (UniformSpace.Completion S)) :
-    letI := locUniformSpace P T' s S' hden'
-    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
-    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
-    letI := isHuberRing_locUniformSpace P T' s S' hden'
-    IsStronglyNoetherian (UniformSpace.Completion S') := by
-  let := locUniformSpace P T s S hden
-  let := isUniformAddGroup_locUniformSpace P T s S hden
-  let := isTopologicalRing_locUniformSpace P T s S hden
-  let := isHuberRing_locUniformSpace P T s S hden
-  let := locUniformSpace P T' s S' hden'
-  let := isUniformAddGroup_locUniformSpace P T' s S' hden'
-  let := isTopologicalRing_locUniformSpace P T' s S' hden'
-  let := isHuberRing_locUniformSpace P T' s S' hden'
-  have : IsStronglyNoetherian (UniformSpace.Completion S) := hSN
-  have h₁ : IsOpenQuotientMap
-      ⇑(restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)) :=
-    (Homeomorph.mk (restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)).toEquiv
-      (uniformContinuous_restrictedMvPowerSeriesCompletionEquiv
-        (k := 1) (A := UniformSpace.Completion S)).continuous
-      (uniformContinuous_restrictedMvPowerSeriesCompletionEquiv_symm
-        (k := 1) (A := UniformSpace.Completion S)).continuous).isOpenQuotientMap
-  have h₂ : IsOpenQuotientMap
-      ⇑(laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl) :=
-    (Homeomorph.mk (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).toEquiv
-      (continuous_laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl)
-      (continuous_laurentQuotientRingEquiv_symm P T s t S hden T' S' hden' hTT' ht hsplit
-        hcl)).isOpenQuotientMap
-  exact IsOpenQuotientMap.isStronglyNoetherian
-    (π := (laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit hcl).toRingHom.comp
-      ((Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)).comp
-        (restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)).toRingHom))
-    (h₂.comp ((QuotientRing.isOpenQuotientMap_mk _).comp h₁))
-
 /-- **Strong noetherianness does not depend on which localisation carries a presentation.** Two
 presentations with the same numerator set and denominator, carried by different localisations of
 `A` at `s`, have isomorphic completions, so one is strongly noetherian exactly when the other is.
@@ -161,6 +109,67 @@ theorem isStronglyNoetherian_completion_self (P : PairOfDefinition A) (T : Finse
     (continuous_presentationRingEquiv_symm P T s S hden T s S' hden' _ _ _ _ _ _)).mp hSN
 
 include hTT' in
+/-- **Adjoining one numerator preserves strong noetherianness of the completed localisation**,
+given that the smaller completed localisation is strongly noetherian and that the Laurent
+relation ideal is closed. `T'` is `T` with `t` adjoined, in the splitting form `hsplit`, so
+closedness is asked only when `t` is a genuinely new numerator: if `t ∈ T` then `T' = T` and this
+is invariance under changing the localisation carrier. -/
+theorem isStronglyNoetherian_completion_of_isClosed (ht : t ∈ T')
+    (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
+    (hcl : t ∉ T →
+      letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsClosed (laurentRelationIdeal P T s t S hden : Set (weightedRestrictedSubring
+        (fun _ : Fin 1 ↦ ({1} : Set (UniformSpace.Completion S))) isWeightFamily_one_weight)))
+    (hSN :
+      letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsStronglyNoetherian (UniformSpace.Completion S)) :
+    letI := locUniformSpace P T' s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s S' hden'
+    letI := isHuberRing_locUniformSpace P T' s S' hden'
+    IsStronglyNoetherian (UniformSpace.Completion S') := by
+  let := locUniformSpace P T s S hden
+  let := isUniformAddGroup_locUniformSpace P T s S hden
+  let := isTopologicalRing_locUniformSpace P T s S hden
+  let := isHuberRing_locUniformSpace P T s S hden
+  let := locUniformSpace P T' s S' hden'
+  let := isUniformAddGroup_locUniformSpace P T' s S' hden'
+  let := isTopologicalRing_locUniformSpace P T' s S' hden'
+  let := isHuberRing_locUniformSpace P T' s S' hden'
+  have : IsStronglyNoetherian (UniformSpace.Completion S) := hSN
+  by_cases htT : t ∈ T
+  · -- `t` was already a numerator, so `T' = T` and closedness is not needed
+    have hT'T : T' = T :=
+      Finset.Subset.antisymm (fun u hu ↦ (hsplit u hu).elim id fun h ↦ h ▸ htT) hTT'
+    subst hT'T
+    exact isStronglyNoetherian_completion_self P T' s S hden S' hden' hSN
+  have h₁ : IsOpenQuotientMap
+      ⇑(restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)) :=
+    (Homeomorph.mk (restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)).toEquiv
+      (uniformContinuous_restrictedMvPowerSeriesCompletionEquiv
+        (k := 1) (A := UniformSpace.Completion S)).continuous
+      (uniformContinuous_restrictedMvPowerSeriesCompletionEquiv_symm
+        (k := 1) (A := UniformSpace.Completion S)).continuous).isOpenQuotientMap
+  set e := laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit (hcl htT) with he
+  have h₂ : IsOpenQuotientMap ⇑e :=
+    (Homeomorph.mk e.toEquiv
+      (he ▸ continuous_laurentQuotientRingEquiv P T s t S hden T' S' hden' hTT' ht hsplit
+        (hcl htT))
+      (he ▸ continuous_laurentQuotientRingEquiv_symm P T s t S hden T' S' hden' hTT' ht hsplit
+        (hcl htT))).isOpenQuotientMap
+  exact IsOpenQuotientMap.isStronglyNoetherian
+    (π := e.toRingHom.comp
+      ((Ideal.Quotient.mk (laurentRelationIdeal P T s t S hden)).comp
+        (restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)).toRingHom))
+    (h₂.comp ((QuotientRing.isOpenQuotientMap_mk _).comp h₁))
+
+include hTT' in
 /-- **Adjoining one numerator preserves strong noetherianness, for a topologically nilpotent
 denominator.** No closedness hypothesis: over a strongly noetherian base the Laurent relation
 ideal is closed of its own accord. Nilpotence is asked only when `t` is a genuinely new
@@ -179,15 +188,10 @@ theorem isStronglyNoetherian_completion_of_isTopologicallyNilpotent
     letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
     letI := isTopologicalRing_locUniformSpace P T' s S' hden'
     letI := isHuberRing_locUniformSpace P T' s S' hden'
-    IsStronglyNoetherian (UniformSpace.Completion S') := by
-  by_cases htT : t ∈ T
-  · -- `t` was already a numerator, so `T' = T` and this is the identity enlargement
-    have hT'T : T' = T :=
-      Finset.Subset.antisymm (fun u hu ↦ (hsplit u hu).elim id fun h ↦ h ▸ htT) hTT'
-    subst hT'T
-    exact isStronglyNoetherian_completion_self P T' s S hden S' hden' hSN
-  · exact isStronglyNoetherian_completion_of_isClosed P T s t S hden T' S' hden' hTT' ht hsplit
-      (isClosed_laurentRelationIdeal_of_isStronglyNoetherian P T s t S hden (hnil htT) hSN) hSN
+    IsStronglyNoetherian (UniformSpace.Completion S') :=
+  isStronglyNoetherian_completion_of_isClosed P T s t S hden T' S' hden' hTT' ht hsplit
+    (fun htT ↦ isClosed_laurentRelationIdeal_of_isStronglyNoetherian P T s t S hden
+      (hnil htT) hSN) hSN
 
 
 -- The induction behind Proposition 8.30: strong noetherianness propagates from `T` to `T ∪ W`

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.Identification
+public import TauCeti.RingTheory.Huber.LocalizationTopology.StronglyNoetherian
 
 import TauCeti.RingTheory.Huber.LocalizationTopology.Presentation
 import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.FirstCountable
@@ -66,47 +67,6 @@ variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
   (hden : HasDenominatorPower P T s S)
   (T' : Finset A) (S' : Type*) [CommRing S'] [Algebra A S'] [IsLocalization.Away s S']
   (hden' : HasDenominatorPower P T' s S') (hTT' : ∀ u ∈ T, u ∈ T')
-
-/-- **Strong noetherianness does not depend on which localisation carries a presentation.** Two
-presentations with the same numerator set and denominator, carried by different localisations of
-`A` at `s`, have isomorphic completions, so one is strongly noetherian exactly when the other is.
-Nothing else is assumed: no nilpotence, no noetherianity.
-
-This is the invariance a caller needs in order to change carriers. -/
-theorem isStronglyNoetherian_completion_self (P : PairOfDefinition A) (T : Finset A)
-    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S)
-    (S' : Type*) [CommRing S'] [Algebra A S'] [IsLocalization.Away s S']
-    (hden' : HasDenominatorPower P T s S')
-    (hSN :
-      letI := locUniformSpace P T s S hden
-      letI := isUniformAddGroup_locUniformSpace P T s S hden
-      letI := isTopologicalRing_locUniformSpace P T s S hden
-      letI := isHuberRing_locUniformSpace P T s S hden
-      IsStronglyNoetherian (UniformSpace.Completion S)) :
-    letI := locUniformSpace P T s S' hden'
-    letI := isUniformAddGroup_locUniformSpace P T s S' hden'
-    letI := isTopologicalRing_locUniformSpace P T s S' hden'
-    letI := isHuberRing_locUniformSpace P T s S' hden'
-    IsStronglyNoetherian (UniformSpace.Completion S') := by
-  let _ := locUniformSpace P T s S hden
-  have _ := isUniformAddGroup_locUniformSpace P T s S hden
-  have _ := isTopologicalRing_locUniformSpace P T s S hden
-  have _ := isHuberRing_locUniformSpace P T s S hden
-  let _ := locUniformSpace P T s S' hden'
-  have _ := isUniformAddGroup_locUniformSpace P T s S' hden'
-  have _ := isTopologicalRing_locUniformSpace P T s S' hden'
-  have _ := isHuberRing_locUniformSpace P T s S' hden'
-  exact (isStronglyNoetherian_congr
-    (presentationRingEquiv P T s S hden T s S' hden'
-      (restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu)
-      (restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu)
-      (continuous_restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu)
-      (continuous_restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu)
-      (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S hden T S' hden' fun _ hu ↦ hu)
-      (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S' hden' T S hden fun _ hu ↦ hu))
-    (continuous_presentationRingEquiv P T s S hden T s S' hden' _ _ _ _ _ _)
-    (continuous_presentationRingEquiv_symm P T s S hden T s S' hden' _ _ _ _ _ _)).mp hSN
 
 include hTT' in
 /-- **Adjoining one numerator preserves strong noetherianness of the completed localisation**,

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.Identification
 public import TauCeti.RingTheory.Huber.StronglyNoetherian
 
+import TauCeti.RingTheory.Huber.LocalizationTopology.Presentation
 import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.FirstCountable
 import TauCeti.Topology.Algebra.GroupCompletion
 
@@ -117,10 +118,16 @@ theorem isStronglyNoetherian_completion_of_isClosed (ht : t ∈ T')
         (restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)).toRingHom))
     (h₂.comp ((QuotientRing.isOpenQuotientMap_mk _).comp h₁))
 
--- Two presentations with the same numerator set, carried by different localisations, have
--- isomorphic completions: the restriction maps in both directions compose to the identity. Strong
--- noetherianness therefore transfers with nothing assumed -- no nilpotence, no noetherianity.
-private theorem isStronglyNoetherian_completion_self (P : PairOfDefinition A) (T : Finset A)
+/-- **Strong noetherianness does not depend on which localisation carries a presentation.** Two
+presentations with the same numerator set and denominator, carried by different localisations of
+`A` at `s`, have isomorphic completions, so one is strongly noetherian exactly when the other is.
+Nothing else is assumed: no nilpotence, no noetherianity.
+
+The isomorphism is `TauCeti.Huber.PairOfDefinition.presentationRingEquiv` applied to the two
+enlargement restriction maps, which are mutually inverse because each fixes the structure map
+from `A`. This is the invariance a caller needs to change carriers without redoing that
+argument. -/
+theorem isStronglyNoetherian_completion_self (P : PairOfDefinition A) (T : Finset A)
     (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
     (hden : HasDenominatorPower P T s S)
     (S' : Type*) [CommRing S'] [Algebra A S'] [IsLocalization.Away s S']
@@ -144,17 +151,16 @@ private theorem isStronglyNoetherian_completion_self (P : PairOfDefinition A) (T
   have _ := isUniformAddGroup_locUniformSpace P T s S' hden'
   have _ := isTopologicalRing_locUniformSpace P T s S' hden'
   have _ := isHuberRing_locUniformSpace P T s S' hden'
-  have h : (restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu).comp
-      (restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu) = RingHom.id _ := by
-    simp
-  have h' : (restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu).comp
-      (restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu) = RingHom.id _ := by
-    simp
   exact (isStronglyNoetherian_congr
-    (RingEquiv.ofRingHom (restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu)
-      (restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu) h' h)
-    (continuous_restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu)
-    (continuous_restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu)).mp hSN
+    (presentationRingEquiv P T s S hden T s S' hden'
+      (restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu)
+      (restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu)
+      (continuous_restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu)
+      (continuous_restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu)
+      (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S hden T S' hden' fun _ hu ↦ hu)
+      (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S' hden' T S hden fun _ hu ↦ hu))
+    (continuous_presentationRingEquiv P T s S hden T s S' hden' _ _ _ _ _ _)
+    (continuous_presentationRingEquiv_symm P T s S hden T s S' hden' _ _ _ _ _ _)).mp hSN
 
 include hTT' in
 /-- **The Laurent step preserves strong noetherianness, for a topologically nilpotent

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
@@ -14,17 +14,21 @@ import TauCeti.Topology.Algebra.GroupCompletion
 /-!
 # Strong noetherianness of a completed rational localisation
 
-Wedhorn's Proposition 8.30 has two halves. The flatness half is in
-`TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.Flat`; this file is the other, that a
-rational localisation of a strongly noetherian Huber ring is again strongly noetherian.
+**Preservation of strong noetherianness by a numerator enlargement.** This is not Wedhorn's
+Proposition 8.30, whose stated conclusion is flatness; it is the auxiliary result that
+proposition is proved from. The flatness statement itself lives in
+`TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.Flat`, which consumes what is proved here.
 
 The argument is the chain of Wedhorn's Remark 7.55. Adjoining a single numerator `t` presents the
 enlarged localisation as a quotient of a one-variable restricted power-series algebra over the
-smaller one, by `TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv`, and the presenting
-ideal is closed as soon as that smaller one is strongly noetherian, by
-`TauCeti.Huber.PairOfDefinition.isClosed_laurentRelationIdeal_of_isStronglyNoetherian`. One
-hypothesis therefore carries the whole induction: strong noetherianness of the base both closes
-the ideal and, through `IsOpenQuotientMap.isStronglyNoetherian`, passes to the quotient.
+smaller one, by `TauCeti.Huber.PairOfDefinition.laurentQuotientRingEquiv`. For a **topologically
+nilpotent** denominator the presenting ideal is then closed as soon as that smaller ring is
+strongly noetherian, by
+`TauCeti.Huber.PairOfDefinition.isClosed_laurentRelationIdeal_of_isStronglyNoetherian`. Given the
+nilpotence, one hypothesis therefore carries the whole induction: strong noetherianness of the
+base both closes the ideal and, through `IsOpenQuotientMap.isStronglyNoetherian`, passes to the
+quotient. Nilpotence is asked only of a genuine enlargement — for `T' = T` there is nothing to
+prove.
 
 Only the *topology* varies along the chain. The localisation `S` itself is fixed, because
 `IsLocalization.Away s S` does not mention the numerators, so each step is a `hden.mono` away and
@@ -113,6 +117,45 @@ theorem isStronglyNoetherian_completion_of_isClosed (ht : t ∈ T')
         (restrictedMvPowerSeriesCompletionEquiv 1 (UniformSpace.Completion S)).toRingHom))
     (h₂.comp ((QuotientRing.isOpenQuotientMap_mk _).comp h₁))
 
+-- Two presentations with the same numerator set, carried by different localisations, have
+-- isomorphic completions: the restriction maps in both directions compose to the identity. Strong
+-- noetherianness therefore transfers with nothing assumed -- no nilpotence, no noetherianity.
+private theorem isStronglyNoetherian_completion_self (P : PairOfDefinition A) (T : Finset A)
+    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (S' : Type*) [CommRing S'] [Algebra A S'] [IsLocalization.Away s S']
+    (hden' : HasDenominatorPower P T s S')
+    (hSN :
+      letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsStronglyNoetherian (UniformSpace.Completion S)) :
+    letI := locUniformSpace P T s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T s S' hden'
+    letI := isHuberRing_locUniformSpace P T s S' hden'
+    IsStronglyNoetherian (UniformSpace.Completion S') := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T s S' hden'
+  have _ := isHuberRing_locUniformSpace P T s S' hden'
+  have h : (restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu).comp
+      (restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu) = RingHom.id _ := by
+    simp
+  have h' : (restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu).comp
+      (restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu) = RingHom.id _ := by
+    simp
+  exact (isStronglyNoetherian_congr
+    (RingEquiv.ofRingHom (restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu)
+      (restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu) h' h)
+    (continuous_restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu)
+    (continuous_restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu)).mp hSN
+
 include hTT' in
 /-- **The Laurent step preserves strong noetherianness, for a topologically nilpotent
 denominator.** The closedness hypothesis of
@@ -121,7 +164,7 @@ by the base's own strong noetherianness, so the two uses of `hSN` are the whole 
 closes the relation ideal, and it feeds the open quotient. This is the form the induction over
 the numerators consumes. -/
 theorem isStronglyNoetherian_completion_of_isTopologicallyNilpotent
-    (hnil : IsTopologicallyNilpotent s) (ht : t ∈ T')
+    (hnil : t ∉ T → IsTopologicallyNilpotent s) (ht : t ∈ T')
     (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
     (hSN :
       letI := locUniformSpace P T s S hden
@@ -133,24 +176,31 @@ theorem isStronglyNoetherian_completion_of_isTopologicallyNilpotent
     letI := isUniformAddGroup_locUniformSpace P T' s S' hden'
     letI := isTopologicalRing_locUniformSpace P T' s S' hden'
     letI := isHuberRing_locUniformSpace P T' s S' hden'
-    IsStronglyNoetherian (UniformSpace.Completion S') :=
-  isStronglyNoetherian_completion_of_isClosed P T s t S hden T' S' hden' hTT' ht hsplit
-    (isClosed_laurentRelationIdeal_of_isStronglyNoetherian P T s t S hden hnil hSN) hSN
+    IsStronglyNoetherian (UniformSpace.Completion S') := by
+  by_cases htT : t ∈ T
+  · -- `t` was already a numerator, so `T' = T` and this is the identity enlargement
+    have hT'T : T' = T :=
+      Finset.Subset.antisymm (fun u hu ↦ (hsplit u hu).elim id fun h ↦ h ▸ htT) hTT'
+    subst hT'T
+    exact isStronglyNoetherian_completion_self P T' s S hden S' hden' hSN
+  · exact isStronglyNoetherian_completion_of_isClosed P T s t S hden T' S' hden' hTT' ht hsplit
+      (isClosed_laurentRelationIdeal_of_isStronglyNoetherian P T s t S hden (hnil htT) hSN) hSN
 
 
 -- The induction behind Proposition 8.30: strong noetherianness propagates from `T` to `T ∪ W`
 -- one numerator at a time. Only the topology on `S` varies; the localisation itself is fixed.
+-- Nilpotence is asked only of a genuine enlargement, so the empty case assumes nothing.
 private theorem isStronglyNoetherian_completion_union [DecidableEq A]
     (P : PairOfDefinition A) (T : Finset A) (s : A) (S : Type*) [CommRing S] [Algebra A S]
     [IsLocalization.Away s S] (hden : HasDenominatorPower P T s S)
-    (hnil : IsTopologicallyNilpotent s)
+    (T' : Finset A) (hTT' : T ⊆ T') (hnil : T ⊂ T' → IsTopologicallyNilpotent s)
     (hSN :
       letI := locUniformSpace P T s S hden
       letI := isUniformAddGroup_locUniformSpace P T s S hden
       letI := isTopologicalRing_locUniformSpace P T s S hden
       letI := isHuberRing_locUniformSpace P T s S hden
       IsStronglyNoetherian (UniformSpace.Completion S)) :
-    ∀ (W V : Finset A), V = T ∪ W → ∀ hV : T ⊆ V,
+    ∀ (W V : Finset A), V = T ∪ W → W ⊆ T' \ T → ∀ hV : T ⊆ V,
     letI := locUniformSpace P V s S (hden.mono hV)
     letI := isUniformAddGroup_locUniformSpace P V s S (hden.mono hV)
     letI := isTopologicalRing_locUniformSpace P V s S (hden.mono hV)
@@ -160,48 +210,55 @@ private theorem isStronglyNoetherian_completion_union [DecidableEq A]
   intro W
   induction W using Finset.induction_on with
   | empty =>
-    intro V hVdef hV
+    intro V hVdef _ hV
     rw [Finset.union_empty] at hVdef
     subst hVdef
     exact hSN
   | @insert a W haW ih =>
-    intro V hVdef hV
+    intro V hVdef hW hV
     rw [Finset.union_insert] at hVdef
     subst hVdef
     have hTU : T ⊆ T ∪ W := Finset.subset_union_left
     have hUV : T ∪ W ⊆ insert a (T ∪ W) := Finset.subset_insert _ _
+    have hWsub : W ⊆ T' \ T := fun x hx ↦ hW (Finset.mem_insert_of_mem hx)
+    -- `a` lies in `T'` and outside `T`, so the enlargement `T ⊆ T'` is proper and `hnil` applies
+    have ha := Finset.mem_sdiff.mp (hW (Finset.mem_insert_self a W))
     exact isStronglyNoetherian_completion_of_isTopologicallyNilpotent P (T ∪ W) s a S
-      (hden.mono hTU) (insert a (T ∪ W)) S (hden.mono hV) hUV hnil
+      (hden.mono hTU) (insert a (T ∪ W)) S (hden.mono hV) hUV
+      (fun _ ↦ hnil ⟨hTT', fun h ↦ ha.2 (h ha.1)⟩)
       (Finset.mem_insert_self _ _)
       (fun u hu ↦ (Finset.mem_insert.mp hu).symm.imp id id)
-      (ih (T ∪ W) rfl hTU)
+      (ih (T ∪ W) rfl hWsub hTU)
 
-/-- **Strong noetherianness propagates along a numerator enlargement.** If the completed
-localisation carries the `T`-topology and is strongly noetherian, then it is strongly noetherian
-for the `T'`-topology of any `T' ⊇ T`, provided the denominator is topologically nilpotent.
+/-- **Strong noetherianness is preserved by a numerator enlargement.** If the completed
+localisation carrying the `T`-topology is strongly noetherian, then it is strongly noetherian for
+the `T'`-topology of any `T' ⊇ T`. Topological nilpotence of the denominator is asked only of a
+*proper* enlargement: for `T' = T` the conclusion is the hypothesis.
 
-This is the half of Wedhorn's Proposition 8.30 that
+This is the auxiliary preservation result that Wedhorn's Proposition 8.30 is proved from, not the
+proposition itself, whose conclusion is flatness. It is what
 `TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_union` assumes: that lemma asks
 for strong noetherianness at every proper intermediate presentation, and this supplies it from
 strong noetherianness at `T` alone. -/
 theorem isStronglyNoetherian_completion_of_subset (P : PairOfDefinition A) (T : Finset A)
     (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) (hnil : IsTopologicallyNilpotent s)
+    (hden : HasDenominatorPower P T s S) (T' : Finset A) (hTT' : T ⊆ T')
+    (hnil : T ⊂ T' → IsTopologicallyNilpotent s)
     (hSN :
       letI := locUniformSpace P T s S hden
       letI := isUniformAddGroup_locUniformSpace P T s S hden
       letI := isTopologicalRing_locUniformSpace P T s S hden
       letI := isHuberRing_locUniformSpace P T s S hden
-      IsStronglyNoetherian (UniformSpace.Completion S))
-    (T' : Finset A) (hTT' : T ⊆ T') :
+      IsStronglyNoetherian (UniformSpace.Completion S)) :
     letI := locUniformSpace P T' s S (hden.mono hTT')
     letI := isUniformAddGroup_locUniformSpace P T' s S (hden.mono hTT')
     letI := isTopologicalRing_locUniformSpace P T' s S (hden.mono hTT')
     letI := isHuberRing_locUniformSpace P T' s S (hden.mono hTT')
     IsStronglyNoetherian (UniformSpace.Completion S) := by
   classical
-  exact isStronglyNoetherian_completion_union P T s S hden hnil hSN (T' \ T) T'
-    (by rw [Finset.union_sdiff_self_eq_union]; exact (Finset.union_eq_right.mpr hTT').symm) hTT'
+  exact isStronglyNoetherian_completion_union P T s S hden T' hTT' hnil hSN (T' \ T) T'
+    (by rw [Finset.union_sdiff_self_eq_union]; exact (Finset.union_eq_right.mpr hTT').symm)
+    Finset.Subset.rfl hTT'
 
 
 end PairOfDefinition

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Laurent/StronglyNoetherian.lean
@@ -6,7 +6,6 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.Identification
-public import TauCeti.RingTheory.Huber.StronglyNoetherian
 
 import TauCeti.RingTheory.Huber.LocalizationTopology.Presentation
 import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.FirstCountable
@@ -69,7 +68,9 @@ variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
   (hden' : HasDenominatorPower P T' s S') (hTT' : ∀ u ∈ T, u ∈ T')
 
 include hTT' in
-/-- Adjoining one numerator preserves strong noetherianness of the completed localisation. -/
+/-- **Adjoining one numerator preserves strong noetherianness of the completed localisation**,
+given that the Laurent relation ideal is closed and that the smaller completed localisation is
+strongly noetherian. `T'` is `T` with `t` adjoined, in the splitting form `hsplit`. -/
 theorem isStronglyNoetherian_completion_of_isClosed (ht : t ∈ T')
     (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
     (hcl :
@@ -123,10 +124,7 @@ presentations with the same numerator set and denominator, carried by different 
 `A` at `s`, have isomorphic completions, so one is strongly noetherian exactly when the other is.
 Nothing else is assumed: no nilpotence, no noetherianity.
 
-The isomorphism is `TauCeti.Huber.PairOfDefinition.presentationRingEquiv` applied to the two
-enlargement restriction maps, which are mutually inverse because each fixes the structure map
-from `A`. This is the invariance a caller needs to change carriers without redoing that
-argument. -/
+This is the invariance a caller needs in order to change carriers. -/
 theorem isStronglyNoetherian_completion_self (P : PairOfDefinition A) (T : Finset A)
     (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
     (hden : HasDenominatorPower P T s S)
@@ -163,12 +161,11 @@ theorem isStronglyNoetherian_completion_self (P : PairOfDefinition A) (T : Finse
     (continuous_presentationRingEquiv_symm P T s S hden T s S' hden' _ _ _ _ _ _)).mp hSN
 
 include hTT' in
-/-- **The Laurent step preserves strong noetherianness, for a topologically nilpotent
-denominator.** The closedness hypothesis of
-`TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion_of_isClosed` is then discharged
-by the base's own strong noetherianness, so the two uses of `hSN` are the whole content: it
-closes the relation ideal, and it feeds the open quotient. This is the form the induction over
-the numerators consumes. -/
+/-- **Adjoining one numerator preserves strong noetherianness, for a topologically nilpotent
+denominator.** No closedness hypothesis: over a strongly noetherian base the Laurent relation
+ideal is closed of its own accord. Nilpotence is asked only when `t` is a genuinely new
+numerator; if `t ∈ T` then `T' = T` and the statement is the invariance above. This is the form
+the induction over the numerators consumes. -/
 theorem isStronglyNoetherian_completion_of_isTopologicallyNilpotent
     (hnil : t ∉ T → IsTopologicallyNilpotent s) (ht : t ∈ T')
     (hsplit : ∀ u ∈ T', u ∈ T ∨ u = t)
@@ -242,10 +239,10 @@ the `T'`-topology of any `T' ⊇ T`. Topological nilpotence of the denominator i
 *proper* enlargement: for `T' = T` the conclusion is the hypothesis.
 
 This is the auxiliary preservation result that Wedhorn's Proposition 8.30 is proved from, not the
-proposition itself, whose conclusion is flatness. It is what
-`TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_union` assumes: that lemma asks
-for strong noetherianness at every proper intermediate presentation, and this supplies it from
-strong noetherianness at `T` alone. -/
+proposition itself, whose conclusion is flatness. It is what supplies strong noetherianness at
+the intermediate enlargements that
+`TauCeti.Huber.PairOfDefinition.flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base`
+needs, from strong noetherianness at `T` alone. -/
 theorem isStronglyNoetherian_completion_of_subset (P : PairOfDefinition A) (T : Finset A)
     (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
     (hden : HasDenominatorPower P T s S) (T' : Finset A) (hTT' : T ⊆ T')

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/StronglyNoetherian.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/StronglyNoetherian.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.RingTheory.Huber.LocalizationTopology.Restriction
+public import TauCeti.RingTheory.Huber.StronglyNoetherian
+
+import TauCeti.RingTheory.Huber.LocalizationTopology.Presentation
+
+/-!
+# Strong noetherianness of a completed localisation is carrier-independent
+
+A presentation `(T, s)` of a rational localisation is carried by *some* localisation `S` of `A`
+at `s`, and the choice is immaterial: two carriers of the same presentation have isomorphic
+completions. Strong noetherianness therefore depends on the presentation alone.
+
+Nothing here is specific to Laurent presentations or to enlarging the numerator set; those live
+in `TauCeti.RingTheory.Huber.LocalizationTopology.Laurent.StronglyNoetherian`, which consumes
+this.
+
+## Main results
+
+* `TauCeti.Huber.PairOfDefinition.isStronglyNoetherian_completion_self`.
+-/
+
+public section
+
+namespace TauCeti.Huber
+
+open TauCeti.Localization
+
+namespace PairOfDefinition
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
+
+/-- **Strong noetherianness does not depend on which localisation carries a presentation.** Two
+presentations with the same numerator set and denominator, carried by different localisations of
+`A` at `s`, have isomorphic completions, so one is strongly noetherian exactly when the other is.
+Nothing else is assumed: no nilpotence, no noetherianity.
+
+This is the invariance a caller needs in order to change carriers. -/
+theorem isStronglyNoetherian_completion_self (P : PairOfDefinition A) (T : Finset A)
+    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (S' : Type*) [CommRing S'] [Algebra A S'] [IsLocalization.Away s S']
+    (hden' : HasDenominatorPower P T s S')
+    (hSN :
+      letI := locUniformSpace P T s S hden
+      letI := isUniformAddGroup_locUniformSpace P T s S hden
+      letI := isTopologicalRing_locUniformSpace P T s S hden
+      letI := isHuberRing_locUniformSpace P T s S hden
+      IsStronglyNoetherian (UniformSpace.Completion S)) :
+    letI := locUniformSpace P T s S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T s S' hden'
+    letI := isTopologicalRing_locUniformSpace P T s S' hden'
+    letI := isHuberRing_locUniformSpace P T s S' hden'
+    IsStronglyNoetherian (UniformSpace.Completion S') := by
+  let _ := locUniformSpace P T s S hden
+  have _ := isUniformAddGroup_locUniformSpace P T s S hden
+  have _ := isTopologicalRing_locUniformSpace P T s S hden
+  have _ := isHuberRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T s S' hden'
+  have _ := isUniformAddGroup_locUniformSpace P T s S' hden'
+  have _ := isTopologicalRing_locUniformSpace P T s S' hden'
+  have _ := isHuberRing_locUniformSpace P T s S' hden'
+  exact (isStronglyNoetherian_congr
+    (presentationRingEquiv P T s S hden T s S' hden'
+      (restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu)
+      (restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu)
+      (continuous_restrictionRingHomOfSubset P T s S hden T S' hden' fun _ hu ↦ hu)
+      (continuous_restrictionRingHomOfSubset P T s S' hden' T S hden fun _ hu ↦ hu)
+      (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S hden T S' hden' fun _ hu ↦ hu)
+      (restrictionRingHomOfSubset_comp_toCompletionLoc P T s S' hden' T S hden fun _ hu ↦ hu))
+    (continuous_presentationRingEquiv P T s S hden T s S' hden' _ _ _ _ _ _)
+    (continuous_presentationRingEquiv_symm P T s S hden T s S' hden' _ _ _ _ _ _)).mp hSN
+
+end PairOfDefinition
+
+end TauCeti.Huber
+
+end


### PR DESCRIPTION
Roadmap: AdicSpaces

No `tauceti-target` marker: this does **not** author Layer 4.1 step 3. It supplies the
preservation theorem that step needs, and reduces the flatness chain's hypothesis, but stops one
step short of Wedhorn's Proposition 8.30 — see *What this is not*.

**Strong noetherianness is preserved by a numerator enlargement**, and the flatness chain of
Wedhorn's §8.2 now asks strong noetherianity only at the base presentation.

## What was missing

The chain form already on main,
`flat_restrictionRingHomOfSubset_of_forall_isStronglyNoetherian`, asks strong noetherianity of
`A⟨U/s⟩` for *every* intermediate `U` with `T ⊆ U ⊂ T'`. Its own docstring says why:

> What separates the two is the standing hypothesis of his §8.2 — that rational localisations of
> a strongly noetherian ring are again strongly noetherian — which `hSN` assumes case by case
> rather than deriving.

This PR derives it, and uses it to collapse the family hypothesis to a single one at `T`.

## What it does

`LocalizationTopology/Laurent/StronglyNoetherian.lean` (new):

* `isStronglyNoetherian_completion_self` — strong noetherianness does not depend on which
  localisation carries a presentation, via `presentationRingEquiv`.
* `isStronglyNoetherian_completion_of_isClosed` — one enlargement step, with the presenting ideal
  assumed closed. Adjoining a numerator presents the larger completed localisation as a quotient
  of a one-variable restricted series algebra over the smaller (`laurentQuotientRingEquiv`);
  composing the comparison equivalence, the quotient map and that identification gives an open
  quotient map out of `A⟨T/s⟩⟨X⟩`, and `IsOpenQuotientMap.isStronglyNoetherian` (#5869) carries
  noetherianity across it.
* `isStronglyNoetherian_completion_of_isTopologicallyNilpotent` — the same step with closedness
  discharged. For a topologically nilpotent denominator,
  `isClosed_laurentRelationIdeal_of_isStronglyNoetherian` asks literally the same hypothesis, so
  it does double duty. Asked only for `t ∉ T`; the identity case is the invariance lemma above.
* `isStronglyNoetherian_completion_of_subset` — the chain form, by induction on the numerators.
  Only the topology varies; the localisation `S` is fixed, because `IsLocalization.Away s S` does
  not mention the numerators. Nilpotence is asked only of a proper enlargement.

`Laurent/Flat.lean` gains `flat_restrictionRingHomOfSubset_of_isStronglyNoetherian_base`, which
asks strong noetherianity only at `T`, and its module docstring, `Main results` and *What this is
not* sections are updated to match.

## What this is not

**Not Wedhorn's Proposition 8.30.** He assumes strong noetherianity of `A`; this asks it of
`A⟨T/s⟩`. Closing the gap needs the passage from `A` to `A⟨T/s⟩`, which is not proved here and is
the natural follow-up. What this PR does remove is the *family* hypothesis — strong noetherianity
at every proper intermediate presentation — which was the obstruction the existing chain theorem
documented.

## What downstream needs it

`AdicSpaces` Layer 4.1 step 3 ("Proposition 8.30: prove that restriction maps between rational
localisations are flat. Use Remark 7.55 for the required chain of rational subsets") — this is
that chain, one hypothesis short. Steps 4–6 consume the result: Corollary 8.32, Lemma 8.33, and
Lemma 8.34.

## Provenance

None. AINTLIB (`github.com/CBirkbeck/AINTLIB` @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
Apache-2.0) was swept and does not contain this: it never concludes `IsStronglyNoetherian` for a
localisation — every occurrence is a `haveI` routed through
`isStronglyNoetherian_of_isNoetherianRing_isTateRing`, which AINTLIB's own comments flag as false
(`RelativePieceKeystone.lean:1228`) — and its `prop_8_30_flat_clean_proof` is the flatness half
with `[IsStronglyNoetherian A]` assumed outright. Nothing was copied or adapted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
