### PR TITLE
feat(NumberField): splitting fields over number fields are number fields

### DIFF
--- a/TauCeti/NumberTheory/NumberField/SplittingField.lean
+++ b/TauCeti/NumberTheory/NumberField/SplittingField.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.SplittingField.Construction
+public import Mathlib.NumberTheory.NumberField.Basic
+
+/-!
+# Splitting fields over number fields are number fields
+
+The splitting field `f.SplittingField` of a polynomial `f` over a number field `K` is a finite
+extension of `K`, hence a number field. In particular the splitting field of a rational
+polynomial is a number field, so its Galois group `f.Gal` is the Galois group of a number field
+and the arithmetic of `𝓞 f.SplittingField` (primes, Frobenius elements) is available in it
+directly.
+
+## Main results
+
+* `Polynomial.SplittingField.instNumberField`: the splitting field of a polynomial over a number
+  field is a number field.
+-/
+
+public section
+
+namespace Polynomial.SplittingField
+
+variable {K : Type*} [Field K] [NumberField K]
+
+-- The instance is Layer 3.8 of the human-authored roadmap
+-- `TauCetiRoadmap/NumberFieldArithmetic/Suggested.lean`, stated there for `K = ℚ`.
+/-- The splitting field of a polynomial over a number field is a number field. -/
+instance instNumberField (f : K[X]) : NumberField f.SplittingField :=
+  NumberField.of_module_finite K f.SplittingField
+
+end Polynomial.SplittingField


### PR DESCRIPTION
**Splitting fields over number fields are number fields.** For a number field `K` and a polynomial `f : K[X]`, Mathlib already knows that `f.SplittingField` is a finite extension of `K` (`Polynomial.SplittingField.instFiniteDimensional`), and that a finite extension of a number field is a number field (`NumberField.of_module_finite`), but there is no instance putting the two together. This PR adds it: `Polynomial.SplittingField.instNumberField (f : K[X]) : NumberField f.SplittingField`. In particular the splitting field of a rational polynomial is a number field, so `f.Gal` is the Galois group of a number field and its ring of integers, primes and Frobenius elements are available directly. The instance is stated over any number field `K` rather than only `ℚ`, and needs no `f ≠ 0` hypothesis, since Mathlib's finiteness of the splitting field has none.

**Roadmap node.** `TauCetiRoadmap/NumberFieldArithmetic/README.md`, Layer 3.8 "Splitting fields of rational polynomials are number fields": "For `0 ≠ f : ℚ[X]`, give the instance `NumberField f.SplittingField`. Without it, Layer 3.9 can be stated only in an auxiliary Galois number field where `f` splits." Prototyped in `Suggested.lean` as `example (f : ℚ[X]) (hf : f ≠ 0) : NumberField f.SplittingField`. Intention: TauCetiRoadmap#342. New file `TauCeti/NumberTheory/NumberField/SplittingField.lean`; no new axioms.

Roadmap: NumberFieldArithmetic

<!--tauceti-target:v1 {"focus":"NumberFieldArithmetic","id":"TauCetiRoadmap/NumberFieldArithmetic/README.md#layer-3/3.8-splitting-fields-of-rational-polynomials-are-number-fields"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WouEDwRYZVr9YqX9VFj8wa
