### PR TITLE
refactor(CentralSimple): root the two flagged `Algebra.TensorProduct` lemmas

### DIFF
--- a/TauCeti/Algebra/CentralSimple/TensorProduct.lean
+++ b/TauCeti/Algebra/CentralSimple/TensorProduct.lean
@@ -115,7 +115,7 @@ open scoped TensorProduct
 
 namespace TauCeti
 
-namespace Algebra.TensorProduct
+section
 
 section Coordinates
 
@@ -134,7 +134,8 @@ makes `A ⊗[K] B` a scalar tower over `A`; all this adds is the identification 
 coordinates of `(a ⊗ₜ 1) * x` are already normalized by the generic scalar-action lemmas
 (`map_smul`, `Finsupp.smul_apply`, `smul_eq_mul`), so no left-handed coordinate lemma is needed. -/
 @[simp]
-private theorem tmul_one_mul_eq_smul (a : A) (x : A ⊗[K] B) : (a ⊗ₜ[K] (1 : B)) * x = a • x := by
+private theorem _root_.Algebra.TensorProduct.tmul_one_mul_eq_smul (a : A) (x : A ⊗[K] B) :
+    (a ⊗ₜ[K] (1 : B)) * x = a • x := by
   rw [← smul_one_mul a x, Algebra.TensorProduct.one_def, TensorProduct.smul_tmul', smul_eq_mul,
     mul_one]
 
@@ -146,7 +147,8 @@ variable (𝓑 : Basis ι K B)
 left-handed statement it is not an instance of the generic scalar-action API, since right
 multiplication is not the module action `Algebra.TensorProduct.basis` is a basis for. -/
 @[simp]
-private theorem basis_repr_mul_tmul_one (a : A) (x : A ⊗[K] B) (j : ι) :
+private theorem _root_.Algebra.TensorProduct.basis_repr_mul_tmul_one (a : A) (x : A ⊗[K] B)
+    (j : ι) :
     (Algebra.TensorProduct.basis A 𝓑).repr (x * (a ⊗ₜ[K] (1 : B))) j =
       (Algebra.TensorProduct.basis A 𝓑).repr x j * a := by
   induction x using TensorProduct.induction_on with
@@ -161,7 +163,7 @@ private theorem basis_repr_mul_tmul_one (a : A) (x : A ⊗[K] B) (j : ι) :
 
 end Coordinates
 
-end Algebra.TensorProduct
+end
 
 namespace IsSimpleRing
 

--- a/TauCeti/Algebra/CentralSimple/TensorProduct.lean
+++ b/TauCeti/Algebra/CentralSimple/TensorProduct.lean
@@ -15,18 +15,18 @@ module
 public import TauCeti.Algebra.Central.TensorProduct
 public import Mathlib.RingTheory.SimpleRing.Basic
 -- Non-public: none of these appears in the type of an exported declaration. `Basis.ofVectorSpace`,
--- the `A`-basis `Algebra.TensorProduct.basis` of `A ⊗[K] B`, flatness, `TwoSidedIdeal.comap`,
--- `Algebra.TensorProduct.comm`, the transport of simplicity along a ring isomorphism and the two
--- `a ⊗ₜ 1` multiplication formulas of `TauCeti.Algebra.TensorProduct.Mul` are used only inside
--- proofs, and the matrix algebras only by the worked examples at the end of the file, so
--- downstream importers of this module do not pay for any of them.
+-- flatness, `TwoSidedIdeal.comap`, `Algebra.TensorProduct.comm`, the transport of simplicity along
+-- a ring isomorphism and the two `a ⊗ₜ 1` multiplication formulas of
+-- `TauCeti.Algebra.TensorProduct.Mul` are used only inside proofs, and the matrix algebras only by
+-- the worked examples at the end of the file, so downstream importers of this module do not pay
+-- for any of them. The `A`-basis `Algebra.TensorProduct.basis` of `A ⊗[K] B` now arrives with
+-- `Mul`, which publicly imports `Mathlib.RingTheory.TensorProduct.Free`.
 import TauCeti.Algebra.TensorProduct.Mul
 import Mathlib.Algebra.Central.Matrix
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.RingTheory.Flat.Basic
 import Mathlib.RingTheory.SimpleRing.Congr
 import Mathlib.RingTheory.SimpleRing.Matrix
-import Mathlib.RingTheory.TensorProduct.Free
 import Mathlib.RingTheory.TensorProduct.Maps
 import Mathlib.RingTheory.TwoSidedIdeal.Operations
 

--- a/TauCeti/Algebra/CentralSimple/TensorProduct.lean
+++ b/TauCeti/Algebra/CentralSimple/TensorProduct.lean
@@ -16,10 +16,11 @@ public import TauCeti.Algebra.Central.TensorProduct
 public import Mathlib.RingTheory.SimpleRing.Basic
 -- Non-public: none of these appears in the type of an exported declaration. `Basis.ofVectorSpace`,
 -- the `A`-basis `Algebra.TensorProduct.basis` of `A ⊗[K] B`, flatness, `TwoSidedIdeal.comap`,
--- `Algebra.TensorProduct.comm` and the transport of simplicity along a ring isomorphism are used
--- only inside proofs (the sole declaration stating a coordinate of that basis is `private`), and
--- the matrix algebras only by the worked examples at the end of the file, so downstream importers
--- of this module do not pay for any of them.
+-- `Algebra.TensorProduct.comm`, the transport of simplicity along a ring isomorphism and the two
+-- `a ⊗ₜ 1` multiplication formulas of `TauCeti.Algebra.TensorProduct.Mul` are used only inside
+-- proofs, and the matrix algebras only by the worked examples at the end of the file, so
+-- downstream importers of this module do not pay for any of them.
+import TauCeti.Algebra.TensorProduct.Mul
 import Mathlib.Algebra.Central.Matrix
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.RingTheory.Flat.Basic
@@ -76,11 +77,12 @@ that expression. Multiplying by `a ⊗ₜ 1` on one side multiplies every coordi
 which is what makes the coordinatewise bookkeeping of that argument -- the two-sided ideal of
 `i₀`-th coordinates, and the support of an additive commutator -- available. On the left this is
 just the generic scalar-action API: `(a ⊗ₜ 1) * x` is the module action `a • x` by Mathlib's
-`smul_one_mul` (packaged as the private `tmul_one_mul_eq_smul`), and
-`(Algebra.TensorProduct.basis A 𝓑).repr` is `A`-linear. The right-hand
-version is a statement in its own right, the private `basis_repr_mul_tmul_one`, and it is where it
-matters that the coordinates are taken with respect to a basis of `B` over the *base* field: that
-is what lets the scalars pass through `a`.
+`smul_one_mul` (packaged as `Algebra.TensorProduct.tmul_one_mul_eq_smul`), and
+`(Algebra.TensorProduct.basis A 𝓑).repr` is `A`-linear. The right-hand version is a statement in
+its own right, `Algebra.TensorProduct.basis_repr_mul_tmul_one`, and it is where it matters that the
+coordinates are taken with respect to a basis of `B` over the *base* field: that is what lets the
+scalars pass through `a`. Both are general facts about `A ⊗[K] B` and live in
+`TauCeti/Algebra/TensorProduct/Mul.lean`.
 
 Simplicity is then the classical minimal-length argument: given a nonzero two-sided ideal
 `I`, pick a nonzero `y ∈ I` with as few nonzero coordinates as possible; after rescaling one
@@ -114,56 +116,6 @@ open Module
 open scoped TensorProduct
 
 namespace TauCeti
-
-section
-
-section Coordinates
-
-variable {K A B ι : Type*} [CommSemiring K] [Semiring A] [Semiring B] [Algebra K A]
-  [Algebra K B]
-
-/-- Left multiplication by `a ⊗ₜ 1` on `A ⊗[K] B` is the left `A`-module action, the one that
-`Algebra.TensorProduct.basis` is a basis for.
-
-This is Mathlib's `smul_one_mul`, available because `Algebra.TensorProduct.isScalarTower_right`
-makes `A ⊗[K] B` a scalar tower over `A`; all this adds is the identification of `a • 1` with
-`a ⊗ₜ 1`. (`Algebra.smul_def` is not available here: `A` is not assumed commutative, so there is no
-`Algebra A (A ⊗[K] B)` instance.)
-
-`private`: it has no use outside the simplicity proof in this file. With it in the simp set, the
-coordinates of `(a ⊗ₜ 1) * x` are already normalized by the generic scalar-action lemmas
-(`map_smul`, `Finsupp.smul_apply`, `smul_eq_mul`), so no left-handed coordinate lemma is needed. -/
-@[simp]
-private theorem _root_.Algebra.TensorProduct.tmul_one_mul_eq_smul (a : A) (x : A ⊗[K] B) :
-    (a ⊗ₜ[K] (1 : B)) * x = a • x := by
-  rw [← smul_one_mul a x, Algebra.TensorProduct.one_def, TensorProduct.smul_tmul', smul_eq_mul,
-    mul_one]
-
-variable (𝓑 : Basis ι K B)
-
-/-- Multiplying by `a ⊗ₜ 1` on the right multiplies each coordinate of `x` by `a` on the right.
-
-`private`: like `tmul_one_mul_eq_smul` it serves only the simplicity proof in this file. Unlike the
-left-handed statement it is not an instance of the generic scalar-action API, since right
-multiplication is not the module action `Algebra.TensorProduct.basis` is a basis for. -/
-@[simp]
-private theorem _root_.Algebra.TensorProduct.basis_repr_mul_tmul_one (a : A) (x : A ⊗[K] B)
-    (j : ι) :
-    (Algebra.TensorProduct.basis A 𝓑).repr (x * (a ⊗ₜ[K] (1 : B))) j =
-      (Algebra.TensorProduct.basis A 𝓑).repr x j * a := by
-  induction x using TensorProduct.induction_on with
-  | zero => simp
-  | tmul a' b =>
-    rw [Algebra.TensorProduct.tmul_mul_tmul, mul_one, Algebra.TensorProduct.basis_repr_tmul,
-      Algebra.TensorProduct.basis_repr_tmul]
-    simp only [Finsupp.smul_apply, Finsupp.mapRange_apply, smul_eq_mul]
-    rw [mul_assoc, mul_assoc, Algebra.commutes]
-  | add x y hx hy => rw [add_mul, map_add, Finsupp.add_apply, hx, hy, map_add, Finsupp.add_apply,
-      add_mul]
-
-end Coordinates
-
-end
 
 namespace IsSimpleRing
 

--- a/TauCeti/Algebra/TensorProduct/Mul.lean
+++ b/TauCeti/Algebra/TensorProduct/Mul.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+-- `Module.Basis` occurs in the statement of `basis_repr_mul_tmul_one` below.
 public import Mathlib.LinearAlgebra.Basis.Defs
 public import Mathlib.RingTheory.TensorProduct.Basic
 public import Mathlib.RingTheory.TensorProduct.Free
@@ -48,7 +49,7 @@ theorem _root_.Algebra.TensorProduct.tmul_one_mul_eq_smul (a : A) (x : A ⊗[K] 
   rw [← smul_one_mul a x, Algebra.TensorProduct.one_def, TensorProduct.smul_tmul', smul_eq_mul,
     mul_one]
 
-variable (𝓑 : Basis ι K B)
+variable (𝓑 : Module.Basis ι K B)
 
 /-- Multiplying by `a ⊗ₜ 1` on the right multiplies each coordinate of `x` by `a` on the right.
 

--- a/TauCeti/Algebra/TensorProduct/Mul.lean
+++ b/TauCeti/Algebra/TensorProduct/Mul.lean
@@ -5,8 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
--- `Module.Basis` occurs in the statement of `basis_repr_mul_tmul_one` below.
-public import Mathlib.LinearAlgebra.Basis.Defs
 public import Mathlib.RingTheory.TensorProduct.Basic
 public import Mathlib.RingTheory.TensorProduct.Free
 

--- a/TauCeti/Algebra/TensorProduct/Mul.lean
+++ b/TauCeti/Algebra/TensorProduct/Mul.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.LinearAlgebra.Basis.Defs
 public import Mathlib.RingTheory.TensorProduct.Basic
 public import Mathlib.RingTheory.TensorProduct.Free
 

--- a/TauCeti/Algebra/TensorProduct/Mul.lean
+++ b/TauCeti/Algebra/TensorProduct/Mul.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.TensorProduct.Basic
+public import Mathlib.RingTheory.TensorProduct.Free
+
+/-!
+# Multiplying by `a ⊗ₜ 1` in `A ⊗[K] B`
+
+Two formulas for multiplication by a pure tensor `a ⊗ₜ 1` in an algebra tensor product, one on
+each side. Both are general facts about `A ⊗[K] B` over a commutative semiring: neither needs `A`
+or `B` to be central, simple, or even a ring.
+
+## Main results
+
+* `Algebra.TensorProduct.tmul_one_mul_eq_smul`: multiplying on the left by `a ⊗ₜ 1` is the left
+  `A`-module action on `A ⊗[K] B`.
+* `Algebra.TensorProduct.basis_repr_mul_tmul_one`: multiplying on the right by `a ⊗ₜ 1` multiplies
+  each coordinate against `Algebra.TensorProduct.basis` by `a` on the right.
+
+Both are declared into Mathlib's root `Algebra.TensorProduct` namespace, where the type they
+describe lives, so dot notation on it elaborates.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+variable {K A B ι : Type*} [CommSemiring K] [Semiring A] [Semiring B] [Algebra K A] [Algebra K B]
+
+/-- Left multiplication by `a ⊗ₜ 1` on `A ⊗[K] B` is the left `A`-module action, the one that
+`Algebra.TensorProduct.basis` is a basis for.
+
+This is Mathlib's `smul_one_mul`, available because `Algebra.TensorProduct.isScalarTower_right`
+makes `A ⊗[K] B` a scalar tower over `A`; all this adds is the identification of `a • 1` with
+`a ⊗ₜ 1`. (`Algebra.smul_def` is not available here: `A` is not assumed commutative, so there is no
+`Algebra A (A ⊗[K] B)` instance.) -/
+@[simp]
+theorem _root_.Algebra.TensorProduct.tmul_one_mul_eq_smul (a : A) (x : A ⊗[K] B) :
+    (a ⊗ₜ[K] (1 : B)) * x = a • x := by
+  rw [← smul_one_mul a x, Algebra.TensorProduct.one_def, TensorProduct.smul_tmul', smul_eq_mul,
+    mul_one]
+
+variable (𝓑 : Basis ι K B)
+
+/-- Multiplying by `a ⊗ₜ 1` on the right multiplies each coordinate of `x` by `a` on the right.
+
+Unlike the left-handed `Algebra.TensorProduct.tmul_one_mul_eq_smul` this is not an instance of the
+generic scalar-action API, since right multiplication is not the module action
+`Algebra.TensorProduct.basis` is a basis for. -/
+@[simp]
+theorem _root_.Algebra.TensorProduct.basis_repr_mul_tmul_one (a : A) (x : A ⊗[K] B) (j : ι) :
+    (Algebra.TensorProduct.basis A 𝓑).repr (x * (a ⊗ₜ[K] (1 : B))) j =
+      (Algebra.TensorProduct.basis A 𝓑).repr x j * a := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul a' b =>
+    rw [Algebra.TensorProduct.tmul_mul_tmul, mul_one, Algebra.TensorProduct.basis_repr_tmul,
+      Algebra.TensorProduct.basis_repr_tmul]
+    simp only [Finsupp.smul_apply, Finsupp.mapRange_apply, smul_eq_mul]
+    rw [mul_assoc, mul_assoc, Algebra.commutes]
+  | add x y hx hy => rw [add_mul, map_add, Finsupp.add_apply, hx, hy, map_add, Finsupp.add_apply,
+      add_mul]
+
+end TauCeti

--- a/TauCeti/Algebra/TensorProduct/Mul.lean
+++ b/TauCeti/Algebra/TensorProduct/Mul.lean
@@ -22,8 +22,10 @@ or `B` to be central, simple, or even a ring.
 * `Algebra.TensorProduct.basis_repr_mul_tmul_one`: multiplying on the right by `a ⊗ₜ 1` multiplies
   each coordinate against `Algebra.TensorProduct.basis` by `a` on the right.
 
-Both are declared into Mathlib's root `Algebra.TensorProduct` namespace, where the type they
-describe lives, so dot notation on it elaborates.
+Both are declared into Mathlib's root `Algebra.TensorProduct` namespace, which houses the algebra
+tensor product's multiplicative API, rather than into a `TauCeti.`-prefixed copy of it. (The
+underlying type is the root `TensorProduct`; `Algebra.TensorProduct` is where its algebra
+structure and the lemmas about it live.)
 -/
 
 public section


### PR DESCRIPTION
`lint-dot-notation` flags two declarations in `TauCeti.Algebra.TensorProduct`: `tmul_one_mul_eq_smul` and `basis_repr_mul_tmul_one`, both in `TauCeti/Algebra/CentralSimple/TensorProduct.lean`. They are the only two the gate flags in that namespace tree-wide. They move to Mathlib's root `Algebra.TensorProduct`, which houses the algebra tensor product's multiplicative API — the underlying type is the root `TensorProduct`.

`TauCeti.Algebra.TensorProduct` is **not** emptied: it keeps members declared in five other files, none of them flagged. The emptied `namespace Algebra.TensorProduct` wrapper in this file becomes a `section`.

## A public home, at `api-design`'s request

`api-design` asked for the two lemmas to be reusable rather than private implementation detail, and re-affirmed it after a contest. They are general facts about `A ⊗[K] B` over a commutative semiring — neither needs `A` or `B` to be central, simple, or even a ring — so they move to a new `TauCeti/Algebra/TensorProduct/Mul.lean`, drop `private`, and keep `@[simp]`.

**A new module rather than an existing one.** `basis_repr_mul_tmul_one` is stated in terms of `Algebra.TensorProduct.basis`, from `Mathlib.RingTheory.TensorProduct.Free`, which none of the four existing `TauCeti/Algebra/TensorProduct/` modules imports:

| module | transitive importers |
|---|---:|
| `…TensorProduct.BaseChange` | 493 |
| `…TensorProduct.Injective` | 334 |
| `…CentralSimple.TensorProduct` (old home) | 26 |

Adding `Free` to `BaseChange` would charge 493 modules for it. The new module is paid for by the one file that needs it. The central-simple file's import comment, which documents exactly this cost model, is updated to match, as are the two module-docstring sentences that called the lemmas `private`.

## Three things review added

- **`Module.Basis`, not `Basis`.** The source file resolves the bare name through its `open Module`, which did not travel with the move; the new module names `Module.Basis` explicitly instead.
- **Two imports the move made redundant are gone** (`placement`): `Mathlib.LinearAlgebra.Basis.Defs` in the new module, and the central-simple file's direct `Mathlib.RingTheory.TensorProduct.Free`, which it now reaches through `Mul`.
- **The new module's namespace rationale is accurate** (`documentation`): it says `Algebra.TensorProduct` holds the algebra API, not that the type lives there.

`lint-dot-notation`: 994 → 992, 0 new (re-measured against this PR's merge base).

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp