### PR TITLE
feat(Chebotarev): the ideal weight of a Galois character is unitary

### DIFF
--- a/TauCeti/NumberTheory/Chebotarev/GaloisCharacter/Weight.lean
+++ b/TauCeti/NumberTheory/Chebotarev/GaloisCharacter/Weight.lean
@@ -60,11 +60,9 @@ the bad primes of `χ.galoisCharacterWeight` are exactly `ramifiedPrimes K L`.
 `TauCeti.UnitaryIdealWeight K` is the subtype of those multiplicative weights whose values have
 modulus `1` away from the bad primes, so the unitary packaging records strictly more than the
 multiplicative one and is not a replacement for it: `galoisCharacterWeight` remains the definition
-everything else is stated about, and `val_galoisCharacterUnitaryWeight` is the bridge. The unitary
-property is supplied by `TauCeti.UnitaryIdealWeight.ofPowEqOne` with `n = Nat.card (L ≃ₐ[K] L)`,
-which asks only that `galoisCharacterWeight (L := L) χ 𝔭.asIdeal ^ n = 1` at every height-one
-prime `𝔭` outside `badPrimes` — a condition on the *weight*, not on `χ`, which is why no hypothesis
-constrains `χ` itself to the unit circle.
+everything else is stated about, and `val_galoisCharacterUnitaryWeight` is the bridge. Unitarity is
+a property of the weight rather than of `χ`, so no hypothesis constrains `χ` itself to the unit
+circle.
 
 ## References
 
@@ -233,9 +231,9 @@ theorem badPrimes_galoisCharacterWeight (χ : (L ≃ₐ[K] L) →* ℂˣ) :
 unramified prime, and `0` at the ramified ones — which is exactly the `UnitaryIdealWeight`
 contract, `badPrimes` being the ramified set by `badPrimes_galoisCharacterWeight`.
 
-The reason is that `Gal(L/K)` is finite, so every value `χ(Frob 𝔭)` is a root of unity of order
-dividing `#Gal(L/K)`. Nothing about `χ` beyond multiplicativity is used; in particular `χ` is not
-assumed to take values in the unit circle, because for a finite group it cannot do otherwise. -/
+The underlying weight is `galoisCharacterWeight χ` itself, by
+`val_galoisCharacterUnitaryWeight`. No hypothesis beyond multiplicativity is placed on `χ`; in
+particular it is not assumed to take values in the unit circle. -/
 noncomputable def galoisCharacterUnitaryWeight (χ : (L ≃ₐ[K] L) →* ℂˣ) :
     TauCeti.UnitaryIdealWeight K :=
   TauCeti.UnitaryIdealWeight.ofPowEqOne (galoisCharacterWeight (L := L) χ)

--- a/TauCeti/NumberTheory/Chebotarev/GaloisCharacter/Weight.lean
+++ b/TauCeti/NumberTheory/Chebotarev/GaloisCharacter/Weight.lean
@@ -15,7 +15,9 @@ public import TauCeti.NumberTheory.NumberField.ArtinSymbol
 For a finite Galois extension `L / K` of number fields and a character `χ : Gal(L/K) →* ℂˣ`, this
 file builds the *canonical ideal weight* `galoisCharacterWeight χ`: the completely multiplicative
 function on the ideals of `𝓞 K` whose value at a height-one prime `𝔭` is `χ (Frob 𝔭)` when `𝔭` is
-unramified in `L`, and `0` when `𝔭` ramifies.
+unramified in `L`, and `0` when `𝔭` ramifies. Since `Gal(L/K)` is finite those unramified values
+are roots of unity, so the same weight is packaged a second time as a
+`TauCeti.UnitaryIdealWeight K`.
 
 Nothing here assumes that `L / K` is cyclotomic: the construction needs only `[IsGalois K L]`, and
 the character is an arbitrary degree-one complex character of the Galois group. The Dirichlet
@@ -35,6 +37,8 @@ primes is what makes the ramified Euler factors drop out as `(1 - 0)⁻¹ = 1`.
 
 * `MonoidHom.galoisCharacterWeight`: the weight of `χ`, packaged as a
   `TauCeti.MultiplicativeIdealWeight K`.
+* `MonoidHom.galoisCharacterUnitaryWeight`: the same weight packaged as a
+  `TauCeti.UnitaryIdealWeight K`, its values having modulus `1` away from the ramified primes.
 
 ## Main results
 
@@ -44,12 +48,22 @@ primes is what makes the ramified Euler factors drop out as `(1 - 0)⁻¹ = 1`.
   exactly when that prime ramifies in `L`.
 * `MonoidHom.badPrimes_galoisCharacterWeight`: the bad primes of the weight are exactly the
   ramified primes.
+* `MonoidHom.val_galoisCharacterUnitaryWeight`: the unitary packaging has the same underlying
+  weight.
 
 ## Implementation notes
 
 The weight is packaged as a `TauCeti.MultiplicativeIdealWeight K` rather than as a bare function
 `Ideal (𝓞 K) → ℂ`, so that the totality above is expressed in the carrier's own `badPrimes` API:
 the bad primes of `χ.galoisCharacterWeight` are exactly `ramifiedPrimes K L`.
+
+`TauCeti.UnitaryIdealWeight K` is the subtype of those multiplicative weights whose values have
+modulus `1` away from the bad primes, so the unitary packaging records strictly more than the
+multiplicative one and is not a replacement for it: `galoisCharacterWeight` remains the definition
+everything else is stated about, and `val_galoisCharacterUnitaryWeight` is the bridge. The unitary
+property is supplied by `TauCeti.UnitaryIdealWeight.ofPowEqOne` with `n = Nat.card (L ≃ₐ[K] L)`,
+which asks only that `χ 𝔭.asIdeal ^ n = 1` at every height-one prime `𝔭` outside `badPrimes`;
+that is why no hypothesis constrains `χ` to the unit circle.
 
 ## References
 
@@ -213,5 +227,30 @@ theorem badPrimes_galoisCharacterWeight (χ : (L ≃ₐ[K] L) →* ℂˣ) :
   ext 𝔭
   simpa only [TauCeti.MultiplicativeIdealWeight.mem_badPrimes, Finset.mem_coe] using
     galoisCharacterWeight_apply_eq_zero_iff χ 𝔭
+
+/-- **The weight of a Galois character is unitary.** Its values have modulus `1` at every
+unramified prime, and `0` at the ramified ones — which is exactly the `UnitaryIdealWeight`
+contract, `badPrimes` being the ramified set by `badPrimes_galoisCharacterWeight`.
+
+The reason is that `Gal(L/K)` is finite, so every value `χ(Frob 𝔭)` is a root of unity of order
+dividing `#Gal(L/K)`. Nothing about `χ` beyond multiplicativity is used; in particular `χ` is not
+assumed to take values in the unit circle, because for a finite group it cannot do otherwise. -/
+noncomputable def galoisCharacterUnitaryWeight (χ : (L ≃ₐ[K] L) →* ℂˣ) :
+    TauCeti.UnitaryIdealWeight K :=
+  TauCeti.UnitaryIdealWeight.ofPowEqOne (galoisCharacterWeight (L := L) χ)
+    (n := Nat.card (L ≃ₐ[K] L)) Nat.card_pos.ne' (fun 𝔭 h𝔭 ↦ by
+      have hur : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭.asIdeal],
+          Algebra.IsUnramifiedAt (𝓞 K) Q := by
+        by_contra h
+        exact h𝔭 (by simpa [badPrimes_galoisCharacterWeight] using
+          (NumberField.Chebotarev.mem_ramifiedPrimes_iff (L := L) 𝔭).mpr h)
+      rw [galoisCharacterWeight_apply_of_unramified χ 𝔭 hur, ← Units.val_pow_eq_pow_val,
+        ← map_pow, pow_card_eq_one', map_one, Units.val_one])
+
+/-- The unitary packaging has the same underlying weight. -/
+@[simp]
+theorem val_galoisCharacterUnitaryWeight (χ : (L ≃ₐ[K] L) →* ℂˣ) :
+    (galoisCharacterUnitaryWeight (L := L) χ).1 = galoisCharacterWeight (L := L) χ := by
+  simp [galoisCharacterUnitaryWeight]
 
 end MonoidHom

--- a/TauCeti/NumberTheory/Chebotarev/GaloisCharacter/Weight.lean
+++ b/TauCeti/NumberTheory/Chebotarev/GaloisCharacter/Weight.lean
@@ -62,8 +62,9 @@ modulus `1` away from the bad primes, so the unitary packaging records strictly 
 multiplicative one and is not a replacement for it: `galoisCharacterWeight` remains the definition
 everything else is stated about, and `val_galoisCharacterUnitaryWeight` is the bridge. The unitary
 property is supplied by `TauCeti.UnitaryIdealWeight.ofPowEqOne` with `n = Nat.card (L ≃ₐ[K] L)`,
-which asks only that `χ 𝔭.asIdeal ^ n = 1` at every height-one prime `𝔭` outside `badPrimes`;
-that is why no hypothesis constrains `χ` to the unit circle.
+which asks only that `galoisCharacterWeight (L := L) χ 𝔭.asIdeal ^ n = 1` at every height-one
+prime `𝔭` outside `badPrimes` — a condition on the *weight*, not on `χ`, which is why no hypothesis
+constrains `χ` itself to the unit circle.
 
 ## References
 


### PR DESCRIPTION
The ideal weight of a Galois character is unitary:

```lean
noncomputable def MonoidHom.galoisCharacterUnitaryWeight (χ : (L ≃ₐ[K] L) →* ℂˣ) :
    TauCeti.UnitaryIdealWeight K

@[simp] theorem MonoidHom.val_galoisCharacterUnitaryWeight (χ : (L ≃ₐ[K] L) →* ℂˣ) :
    (galoisCharacterUnitaryWeight (L := L) χ).1 = galoisCharacterWeight (L := L) χ
```

`galoisCharacterWeight` is already on `main` as a `MultiplicativeIdealWeight`, with modulus-one
values at the unramified primes and `0` at the ramified ones, and `badPrimes` equal to
`ramifiedPrimes K L`. That is exactly the `UnitaryIdealWeight` contract, so this is a packaging
step rather than new analysis — but the packaging is what later results consume.

### The proof is one observation

`Gal(L/K)` is finite, so `χ(Frob 𝔭) ^ #Gal(L/K) = χ((Frob 𝔭) ^ #Gal(L/K)) = χ(1) = 1`: every value
at a good prime is a root of unity. `TauCeti.UnitaryIdealWeight.ofPowEqOne` takes the hypothesis in
precisely that shape — a positive power equal to `1` at every prime outside `badPrimes` — so the
modulus-one conclusion is its job rather than something proved again here.

Nothing is assumed about `χ` beyond multiplicativity. In particular it is *not* required to take
values in the unit circle: over a finite group a homomorphism to `ℂˣ` cannot do otherwise, and
asking for it as a hypothesis would be asking the caller to prove this lemma.

### Two small notes

`val_galoisCharacterUnitaryWeight` goes through `UnitaryIdealWeight.val_ofPowEqOne` rather than
`rfl`, because `ofPowEqOne`'s body is not exposed and a `rfl` in an exported theorem may only
unfold exposed definitions.

`Nat.card` rather than `Fintype.card`: `pow_card_eq_one'` is the `Nat.card` form and is what the
finiteness instance here provides without a `Fintype` detour.

### Why it is wanted

Chebotarev Layer 4 asks for the Euler product of the character weight. The analytic half is already
in ArithmeticDirichletSeries as `MultiplicativeIdealWeight.hasProd_eulerFactor`, which needs
absolute convergence of the ideal-indexed series; #5956 supplies that for any weight bounded by
one. This PR is the remaining link — it is what says the Galois character weight *is* so bounded.
The three are independent PRs and this one stands alone: unitarity is a fact about the weight
whether or not anything analytic consumes it.

### Absence

Nothing under `TauCeti/NumberTheory/Chebotarev/` on `main` mentions `UnitaryIdealWeight`, and there
is no modulus bound on `galoisCharacterWeight` anywhere.

`CBirkbeck/chebotarev-density` at `8575c9df` has no unitary-weight abstraction at all (`unitary`
and `UnitaryIdealWeight` return 0 files) and no `pow_card_eq_one` argument. It does bound the norm
of its character coefficient — `norm_galoisCharacterCoeff_le` in `CebotarevDensity/ZetaProduct.lean`
— but that is a *private* lemma bounding the grouped `LSeries` coefficient by the number of ideals
of the given norm, not the ideal weight by `1`, and it is used for a big-O summability argument
rather than for unitarity. Controls were run on the same probes (`theorem` returns 25 files,
`MonoidHom` 8), so the absences are real. **No `Provenance` line is owed.**

Roadmap: Chebotarev

No `tauceti-target:v1` marker: this supplies a prerequisite that Layer 4 needs rather than
authoring Layer 4, whose content is the Euler product and the orthogonality identities.

### On the cleanup pass

`lean-lsp` has been unreachable for this whole session, so `/cleanup`'s phases 6.5 and 6.6 were
discharged directly. `#lint in TauCeti.NumberTheory.Chebotarev.GaloisCharacterWeight` reports
**0 errors in 16 declarations with all 15 linters**. Axioms are exactly `propext`,
`Classical.choice` and `Quot.sound`; every line is within 100 characters; the longest new proof is
8 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF
