### PR TITLE
feat: add factor degrees modulo primes

### DIFF
--- a/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
@@ -40,9 +40,6 @@ polynomial carrier and API live in `TauCeti/RingTheory/Polynomial/FactorDegrees.
 * J. Neukirch, *Algebraic Number Theory*, Springer 1999, Chapter I, §8.
 -/
 
--- Provenance: the Tau Ceti `PolynomialGaloisGroups` roadmap README and its `Suggested.lean`,
--- which write down the Lean signatures for these factorization patterns of `X ^ 5 - X - 1`.
-
 public section
 noncomputable section
 

--- a/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Polynomial.Resultant.Discriminant
+public import Mathlib.Algebra.Field.ZMod
+public import Mathlib.Algebra.Polynomial.BigOperators
+public import Mathlib.Algebra.Polynomial.SpecificDegree
+public import Mathlib.RingTheory.Polynomial.UniqueFactorization
+
+/-!
+# Degrees of factors modulo a prime
+
+For an integral polynomial `f` and a prime `p`, `TauCeti.factorDegrees f p` is the multiset of
+degrees of the monic irreducible factors of the reduction of `f` modulo `p`. Multiplicities are
+retained: a repeated irreducible factor contributes its degree repeatedly.
+
+This is the polynomial-side factorization datum compared with cycle types in Dedekind's
+factorization theorem. The API here records its total degree, its behaviour on irreducible
+reductions, and the fact that a prime not dividing the discriminant of a monic polynomial gives a
+squarefree factorization.
+
+## Main declarations
+
+* `TauCeti.factorDegrees`: the multiset of factor degrees of `f` modulo `p`.
+* `TauCeti.factorDegrees_sum_eq_natDegree_map`: the factor degrees sum to the degree after
+  reduction.
+* `TauCeti.factorDegrees_sum`: for monic `f`, this sum is `f.natDegree`.
+* `TauCeti.factorDegrees_eq_singleton`: an irreducible reduction has its degree as its sole
+  factor degree.
+* `TauCeti.separable_map_zmod_of_not_dvd_discr`: a monic polynomial has separable reduction at a
+  prime not dividing its discriminant.
+
+## References
+
+* R. Dedekind, the factorization theorem for prime ideals, in its polynomial factorization form.
+-/
+
+public section
+noncomputable section
+
+open Polynomial UniqueFactorizationMonoid
+
+namespace TauCeti
+
+/-- The multiset of degrees of the monic irreducible factors of the reduction of an integral
+polynomial modulo a prime. Repeated factors occur with their multiplicities. -/
+@[expose] noncomputable def factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p.Prime] : Multiset ℕ :=
+  Multiset.map Polynomial.natDegree
+    (normalizedFactors (f.map (Int.castRingHom (ZMod p))))
+
+/-- The defining equation for `factorDegrees`. -/
+theorem factorDegrees_def (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    factorDegrees f p = Multiset.map Polynomial.natDegree
+      (normalizedFactors (f.map (Int.castRingHom (ZMod p)))) :=
+  rfl
+
+/-- A natural number occurs in `factorDegrees f p` exactly when it is the degree of a normalized
+irreducible factor of the reduction of `f` modulo `p`. -/
+theorem mem_factorDegrees_iff {f : ℤ[X]} {p d : ℕ} [Fact p.Prime] :
+    d ∈ factorDegrees f p ↔ ∃ q ∈ normalizedFactors (f.map (Int.castRingHom (ZMod p))),
+      q.natDegree = d := by
+  simp [factorDegrees]
+
+/-- Every degree occurring in `factorDegrees` is positive. -/
+theorem factorDegrees_pos_of_mem {f : ℤ[X]} {p d : ℕ} [Fact p.Prime]
+    (hd : d ∈ factorDegrees f p) : 0 < d := by
+  obtain ⟨q, hq, rfl⟩ := mem_factorDegrees_iff.mp hd
+  exact (irreducible_of_normalized_factor q hq).natDegree_pos
+
+/-- The number of factor degrees is the number of normalized irreducible factors, counted with
+multiplicity. -/
+@[simp]
+theorem factorDegrees_card (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    (factorDegrees f p).card =
+      (normalizedFactors (f.map (Int.castRingHom (ZMod p)))).card := by
+  simp [factorDegrees]
+
+/-- The zero polynomial has no factor degrees. -/
+@[simp]
+theorem factorDegrees_zero (p : ℕ) [Fact p.Prime] : factorDegrees 0 p = 0 := by
+  simp [factorDegrees]
+
+/-- The constant polynomial one has no factor degrees. -/
+@[simp]
+theorem factorDegrees_one (p : ℕ) [Fact p.Prime] : factorDegrees 1 p = 0 := by
+  simp [factorDegrees]
+
+/-- Factor degrees turn a product whose reductions are nonzero into multiset addition. -/
+theorem factorDegrees_mul (f g : ℤ[X]) (p : ℕ) [Fact p.Prime]
+    (hf : f.map (Int.castRingHom (ZMod p)) ≠ 0)
+    (hg : g.map (Int.castRingHom (ZMod p)) ≠ 0) :
+    factorDegrees (f * g) p = factorDegrees f p + factorDegrees g p := by
+  simp [factorDegrees, normalizedFactors_mul hf hg]
+
+/-- The sum of the factor degrees is the degree of the polynomial after reduction. -/
+@[simp]
+theorem factorDegrees_sum_eq_natDegree_map (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    (factorDegrees f p).sum = (f.map (Int.castRingHom (ZMod p))).natDegree := by
+  let g : (ZMod p)[X] := f.map (Int.castRingHom (ZMod p))
+  change (Multiset.map Polynomial.natDegree (normalizedFactors g)).sum = g.natDegree
+  by_cases hg : g = 0
+  · simp [hg]
+  · have hprod := prod_normalizedFactors hg
+    rw [← Polynomial.natDegree_multiset_prod]
+    · exact Polynomial.natDegree_eq_of_degree_eq
+        (Polynomial.degree_eq_degree_of_associated hprod)
+    · exact zero_notMem_normalizedFactors g
+
+/-- For a monic polynomial, the degrees of all irreducible factors of its reduction modulo a
+prime, counted with multiplicity, sum to the degree of the original polynomial. -/
+@[simp]
+theorem factorDegrees_sum (f : ℤ[X]) (hf : f.Monic) (p : ℕ) [Fact p.Prime] :
+    (factorDegrees f p).sum = f.natDegree := by
+  rw [factorDegrees_sum_eq_natDegree_map, hf.natDegree_map]
+
+/-- If the reduction of `f` modulo `p` is irreducible, its only factor degree is its degree. -/
+@[simp]
+theorem factorDegrees_eq_singleton (f : ℤ[X]) (p : ℕ) [Fact p.Prime]
+    (h : Irreducible (f.map (Int.castRingHom (ZMod p)))) :
+    factorDegrees f p = {(f.map (Int.castRingHom (ZMod p))).natDegree} := by
+  rw [factorDegrees, normalizedFactors_irreducible h, Multiset.map_singleton,
+    Polynomial.natDegree_normalize]
+
+/-- For a monic integral polynomial, having one factor degree is equivalent to its reduction
+being irreducible. -/
+theorem factorDegrees_eq_singleton_iff_irreducible (f : ℤ[X]) (hf : f.Monic) (p : ℕ)
+    [Fact p.Prime] :
+    factorDegrees f p = {f.natDegree} ↔
+      Irreducible (f.map (Int.castRingHom (ZMod p))) := by
+  let g : (ZMod p)[X] := f.map (Int.castRingHom (ZMod p))
+  have hg : g.Monic := hf.map _
+  constructor
+  · intro h
+    obtain ⟨q, hq, -⟩ := Multiset.map_eq_singleton.mp h
+    have hqmem : q ∈ normalizedFactors g := by
+      change q ∈ normalizedFactors (f.map (Int.castRingHom (ZMod p)))
+      rw [hq]
+      simp
+    have hprod := prod_normalizedFactors hg.ne_zero
+    rw [hq, Multiset.prod_singleton] at hprod
+    exact hprod.irreducible (irreducible_of_normalized_factor q hqmem)
+  · intro h
+    rw [factorDegrees_eq_singleton f p h, hf.natDegree_map]
+
+/-- A prime not dividing the discriminant of a monic integral polynomial gives a separable
+reduction modulo that prime. -/
+theorem separable_map_zmod_of_not_dvd_discr (f : ℤ[X]) (hf : f.Monic) (p : ℕ)
+    [Fact p.Prime] (hp : ¬ (p : ℤ) ∣ f.discr) :
+    (f.map (Int.castRingHom (ZMod p))).Separable := by
+  apply (hf.map (Int.castRingHom (ZMod p))).discr_ne_zero_iff.mp
+  rw [hf.discr_map, Int.coe_castRingHom, ne_eq, ZMod.intCast_zmod_eq_zero_iff_dvd]
+  exact hp
+
+/-- At a prime not dividing the discriminant of a monic integral polynomial, its normalized
+irreducible factors modulo that prime have no repetitions. -/
+theorem normalizedFactors_map_zmod_nodup_of_not_dvd_discr (f : ℤ[X]) (hf : f.Monic)
+    (p : ℕ) [Fact p.Prime] (hp : ¬ (p : ℤ) ∣ f.discr) :
+    (normalizedFactors (f.map (Int.castRingHom (ZMod p)))).Nodup := by
+  rw [← squarefree_iff_nodup_normalizedFactors (hf.map _).ne_zero]
+  exact (separable_map_zmod_of_not_dvd_discr f hf p hp).squarefree
+
+private theorem irreducible_X_sq_add_X_add_one_zmod_two :
+    Irreducible (X ^ 2 + X + 1 : (ZMod 2)[X]) := by
+  apply Polynomial.irreducible_of_degree_le_three_of_not_isRoot
+  · have hdeg : (X ^ 2 + X + 1 : (ZMod 2)[X]).natDegree = 2 := by compute_degree!
+    rw [hdeg]
+    decide
+  · intro x
+    rw [Polynomial.IsRoot.def]
+    simp only [Polynomial.eval_add, Polynomial.eval_pow, Polynomial.eval_X, Polynomial.eval_one]
+    fin_cases x <;> decide
+
+private theorem irreducible_X_cube_add_X_sq_add_one_zmod_two :
+    Irreducible (X ^ 3 + X ^ 2 + 1 : (ZMod 2)[X]) := by
+  apply Polynomial.irreducible_of_degree_le_three_of_not_isRoot
+  · have hdeg : (X ^ 3 + X ^ 2 + 1 : (ZMod 2)[X]).natDegree = 3 := by compute_degree!
+    rw [hdeg]
+    decide
+  · intro x
+    rw [Polynomial.IsRoot.def]
+    simp only [Polynomial.eval_add, Polynomial.eval_pow, Polynomial.eval_X, Polynomial.eval_one]
+    fin_cases x <;> decide
+
+/-- The polynomial `X⁵ - X - 1` has factor degrees `3` and `2` modulo `2`. -/
+example : factorDegrees (X ^ 5 - X - 1) 2 = {3, 2} := by
+  have hmap :
+      (X ^ 5 - X - 1 : ℤ[X]).map (Int.castRingHom (ZMod 2)) =
+        (X ^ 3 + X ^ 2 + 1) * (X ^ 2 + X + 1) := by
+    have hneg (a : (ZMod 2)[X]) : -a = a := by
+      ext n
+      simp only [Polynomial.coeff_neg, ZMod.neg_eq_self_mod_two]
+    have htwo : (2 : (ZMod 2)[X]) = 0 := by
+      ext n
+      cases n
+      · rw [Polynomial.coeff_ofNat_zero, Polynomial.coeff_zero]
+        exact show (2 : ZMod 2) = 0 by decide
+      · simp
+    norm_num
+    ring_nf
+    rw [htwo]
+    simp only [mul_zero, add_zero]
+    simp only [sub_eq_add_neg, hneg]
+  have hdeg_three : (X ^ 3 + X ^ 2 + 1 : (ZMod 2)[X]).natDegree = 3 := by
+    compute_degree!
+  have hdeg_two : (X ^ 2 + X + 1 : (ZMod 2)[X]).natDegree = 2 := by
+    compute_degree!
+  rw [factorDegrees, hmap,
+    normalizedFactors_mul irreducible_X_cube_add_X_sq_add_one_zmod_two.ne_zero
+      irreducible_X_sq_add_X_add_one_zmod_two.ne_zero,
+    normalizedFactors_irreducible irreducible_X_cube_add_X_sq_add_one_zmod_two,
+    normalizedFactors_irreducible irreducible_X_sq_add_X_add_one_zmod_two]
+  simp [Polynomial.natDegree_normalize, hdeg_three, hdeg_two]
+
+end TauCeti

--- a/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
@@ -23,9 +23,11 @@ This module supplies the Layer 5 worked computations of `Polynomial.factorDegree
 
 ## Main declarations
 
+* `Polynomial.irreducible_X_sq_add_X_add_one_zmod_two`,
+  `Polynomial.irreducible_X_pow_three_add_X_sq_add_one_zmod_two`: the two irreducibility facts
+  over `ZMod 2` that the modulo `2` example rests on.
 * `Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_two`: the worked example
-  `factorDegrees (X ^ 5 - X - 1) 2 = {3, 2}`, with the two irreducibility facts over `ZMod 2`
-  that it rests on.
+  `factorDegrees (X ^ 5 - X - 1) 2 = {3, 2}`.
 * `Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_five`: the worked example
   `factorDegrees (X ^ 5 - X - 1) 5 = {5}`.
 

--- a/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
@@ -5,38 +5,49 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.RingTheory.Polynomial.Resultant.Discriminant
+public import TauCeti.RingTheory.Polynomial.Factors
 public import Mathlib.Algebra.Field.ZMod
-public import Mathlib.Algebra.Polynomial.BigOperators
 public import Mathlib.Algebra.Polynomial.SpecificDegree
 public import Mathlib.RingTheory.Polynomial.UniqueFactorization
+
+import Mathlib.Algebra.CharP.Two
+import Mathlib.Tactic.ComputeDegree
+import Mathlib.Tactic.LinearCombination
 
 /-!
 # Degrees of factors modulo a prime
 
-For an integral polynomial `f` and a prime `p`, `TauCeti.factorDegrees f p` is the multiset of
+For an integral polynomial `f` and a prime `p`, `Polynomial.factorDegrees f p` is the multiset of
 degrees of the monic irreducible factors of the reduction of `f` modulo `p`. Multiplicities are
 retained: a repeated irreducible factor contributes its degree repeatedly.
 
 This is the polynomial-side factorization datum compared with cycle types in Dedekind's
-factorization theorem. The API here records its total degree, its behaviour on irreducible
-reductions, and the fact that a prime not dividing the discriminant of a monic polynomial gives a
-squarefree factorization.
+factorization theorem. The API here records its total degree, computes it from any factorization
+of the reduction into irreducibles, and characterizes the polynomials whose reduction is
+irreducible. The underlying facts about `normalizedFactors` over a field are proved in
+`TauCeti/RingTheory/Polynomial/Factors.lean`, and the separability of the reduction at a prime
+not dividing the discriminant in `TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean`.
 
 ## Main declarations
 
-* `TauCeti.factorDegrees`: the multiset of factor degrees of `f` modulo `p`.
-* `TauCeti.factorDegrees_sum_eq_natDegree_map`: the factor degrees sum to the degree after
-  reduction.
-* `TauCeti.factorDegrees_sum`: for monic `f`, this sum is `f.natDegree`.
-* `TauCeti.factorDegrees_eq_singleton`: an irreducible reduction has its degree as its sole
-  factor degree.
-* `TauCeti.separable_map_zmod_of_not_dvd_discr`: a monic polynomial has separable reduction at a
-  prime not dividing its discriminant.
+* `Polynomial.factorDegrees`: the multiset of factor degrees of `f` modulo `p`.
+* `Polynomial.factorDegrees_eq_map_natDegree_of_map_eq_prod`: the factor degrees are read off
+  from any factorization of the reduction into irreducibles.
+* `Polynomial.sum_factorDegrees_eq_natDegree_map`, `Polynomial.Monic.sum_factorDegrees`: the
+  factor degrees sum to the degree after reduction, which for monic `f` is `f.natDegree`.
+* `Polynomial.factorDegrees_eq_singleton_of_irreducible`,
+  `Polynomial.irreducible_map_of_card_factorDegrees_eq_one`,
+  `Polynomial.Monic.factorDegrees_eq_singleton_iff_irreducible`: a single factor degree is the
+  same thing as an irreducible reduction.
+* `Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_two`: the worked example
+  `factorDegrees (X ^ 5 - X - 1) 2 = {3, 2}`, with the two irreducibility facts over `ZMod 2`
+  that it rests on.
 
 ## References
 
-* R. Dedekind, the factorization theorem for prime ideals, in its polynomial factorization form.
+* D. A. Marcus, *Number Fields*, 2nd edition, Springer 2018, Chapter 4, where the factorization
+  of `f mod p` is matched with the splitting of `p`.
+* J. Neukirch, *Algebraic Number Theory*, Springer 1999, Chapter I, §8.
 -/
 
 public section
@@ -48,170 +59,151 @@ namespace TauCeti
 
 /-- The multiset of degrees of the monic irreducible factors of the reduction of an integral
 polynomial modulo a prime. Repeated factors occur with their multiplicities. -/
-@[expose] noncomputable def factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p.Prime] : Multiset ℕ :=
+noncomputable def _root_.Polynomial.factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    Multiset ℕ :=
   Multiset.map Polynomial.natDegree
     (normalizedFactors (f.map (Int.castRingHom (ZMod p))))
 
-/-- The defining equation for `factorDegrees`. -/
-theorem factorDegrees_def (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
-    factorDegrees f p = Multiset.map Polynomial.natDegree
+/-- The defining equation for `Polynomial.factorDegrees`. -/
+theorem _root_.Polynomial.factorDegrees_def (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    f.factorDegrees p = Multiset.map Polynomial.natDegree
       (normalizedFactors (f.map (Int.castRingHom (ZMod p)))) :=
-  rfl
+  (rfl)
 
-/-- A natural number occurs in `factorDegrees f p` exactly when it is the degree of a normalized
+/-- A natural number occurs in `f.factorDegrees p` exactly when it is the degree of a normalized
 irreducible factor of the reduction of `f` modulo `p`. -/
-theorem mem_factorDegrees_iff {f : ℤ[X]} {p d : ℕ} [Fact p.Prime] :
-    d ∈ factorDegrees f p ↔ ∃ q ∈ normalizedFactors (f.map (Int.castRingHom (ZMod p))),
+theorem _root_.Polynomial.mem_factorDegrees_iff {f : ℤ[X]} {p d : ℕ} [Fact p.Prime] :
+    d ∈ f.factorDegrees p ↔ ∃ q ∈ normalizedFactors (f.map (Int.castRingHom (ZMod p))),
       q.natDegree = d := by
-  simp [factorDegrees]
+  simp [factorDegrees_def]
 
-/-- Every degree occurring in `factorDegrees` is positive. -/
-theorem factorDegrees_pos_of_mem {f : ℤ[X]} {p d : ℕ} [Fact p.Prime]
-    (hd : d ∈ factorDegrees f p) : 0 < d := by
+/-- Every degree occurring in `f.factorDegrees p` is positive. -/
+theorem _root_.Polynomial.pos_of_mem_factorDegrees {f : ℤ[X]} {p d : ℕ} [Fact p.Prime]
+    (hd : d ∈ f.factorDegrees p) : 0 < d := by
   obtain ⟨q, hq, rfl⟩ := mem_factorDegrees_iff.mp hd
   exact (irreducible_of_normalized_factor q hq).natDegree_pos
 
 /-- The number of factor degrees is the number of normalized irreducible factors, counted with
 multiplicity. -/
 @[simp]
-theorem factorDegrees_card (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
-    (factorDegrees f p).card =
+theorem _root_.Polynomial.card_factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    (f.factorDegrees p).card =
       (normalizedFactors (f.map (Int.castRingHom (ZMod p)))).card := by
-  simp [factorDegrees]
+  simp [factorDegrees_def]
 
 /-- The zero polynomial has no factor degrees. -/
 @[simp]
-theorem factorDegrees_zero (p : ℕ) [Fact p.Prime] : factorDegrees 0 p = 0 := by
-  simp [factorDegrees]
+theorem _root_.Polynomial.factorDegrees_zero (p : ℕ) [Fact p.Prime] :
+    (0 : ℤ[X]).factorDegrees p = 0 := by
+  simp [factorDegrees_def]
 
 /-- The constant polynomial one has no factor degrees. -/
 @[simp]
-theorem factorDegrees_one (p : ℕ) [Fact p.Prime] : factorDegrees 1 p = 0 := by
-  simp [factorDegrees]
+theorem _root_.Polynomial.factorDegrees_one (p : ℕ) [Fact p.Prime] :
+    (1 : ℤ[X]).factorDegrees p = 0 := by
+  simp [factorDegrees_def]
 
 /-- Factor degrees turn a product whose reductions are nonzero into multiset addition. -/
-theorem factorDegrees_mul (f g : ℤ[X]) (p : ℕ) [Fact p.Prime]
+theorem _root_.Polynomial.factorDegrees_mul (f g : ℤ[X]) (p : ℕ) [Fact p.Prime]
     (hf : f.map (Int.castRingHom (ZMod p)) ≠ 0)
     (hg : g.map (Int.castRingHom (ZMod p)) ≠ 0) :
-    factorDegrees (f * g) p = factorDegrees f p + factorDegrees g p := by
-  simp [factorDegrees, normalizedFactors_mul hf hg]
+    (f * g).factorDegrees p = f.factorDegrees p + g.factorDegrees p := by
+  simp [factorDegrees_def, normalizedFactors_mul hf hg]
+
+/-- The factor degrees are read off from any factorization of the reduction into irreducibles,
+without normalizing the factors first. This is how the multiset is computed in practice: a
+factorization of `f mod p` need not come from a factorization over `ℤ`. -/
+theorem _root_.Polynomial.factorDegrees_eq_map_natDegree_of_map_eq_prod {f : ℤ[X]} {p : ℕ}
+    [Fact p.Prime] {s : Multiset (ZMod p)[X]} (hs : ∀ q ∈ s, Irreducible q)
+    (hfs : f.map (Int.castRingHom (ZMod p)) = s.prod) :
+    f.factorDegrees p = s.map Polynomial.natDegree := by
+  rw [factorDegrees_def, hfs, normalizedFactors_prod_eq s hs, Multiset.map_map]
+  exact Multiset.map_congr rfl fun q _ ↦ Polynomial.natDegree_normalize
 
 /-- The sum of the factor degrees is the degree of the polynomial after reduction. -/
 @[simp]
-theorem factorDegrees_sum_eq_natDegree_map (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
-    (factorDegrees f p).sum = (f.map (Int.castRingHom (ZMod p))).natDegree := by
-  let g : (ZMod p)[X] := f.map (Int.castRingHom (ZMod p))
-  change (Multiset.map Polynomial.natDegree (normalizedFactors g)).sum = g.natDegree
-  by_cases hg : g = 0
-  · simp [hg]
-  · have hprod := prod_normalizedFactors hg
-    rw [← Polynomial.natDegree_multiset_prod]
-    · exact Polynomial.natDegree_eq_of_degree_eq
-        (Polynomial.degree_eq_degree_of_associated hprod)
-    · exact zero_notMem_normalizedFactors g
+theorem _root_.Polynomial.sum_factorDegrees_eq_natDegree_map (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    (f.factorDegrees p).sum = (f.map (Int.castRingHom (ZMod p))).natDegree := by
+  rw [factorDegrees_def]
+  exact Polynomial.sum_natDegree_normalizedFactors _
 
 /-- For a monic polynomial, the degrees of all irreducible factors of its reduction modulo a
 prime, counted with multiplicity, sum to the degree of the original polynomial. -/
-theorem factorDegrees_sum (f : ℤ[X]) (hf : f.Monic) (p : ℕ) [Fact p.Prime] :
-    (factorDegrees f p).sum = f.natDegree := by
-  rw [factorDegrees_sum_eq_natDegree_map, hf.natDegree_map]
+theorem _root_.Polynomial.Monic.sum_factorDegrees {f : ℤ[X]} (hf : f.Monic) (p : ℕ)
+    [Fact p.Prime] : (f.factorDegrees p).sum = f.natDegree := by
+  rw [sum_factorDegrees_eq_natDegree_map, hf.natDegree_map]
 
 /-- If the reduction of `f` modulo `p` is irreducible, its only factor degree is its degree. -/
-@[simp]
-theorem factorDegrees_eq_singleton (f : ℤ[X]) (p : ℕ) [Fact p.Prime]
-    (h : Irreducible (f.map (Int.castRingHom (ZMod p)))) :
-    factorDegrees f p = {(f.map (Int.castRingHom (ZMod p))).natDegree} := by
-  rw [factorDegrees, normalizedFactors_irreducible h, Multiset.map_singleton,
-    Polynomial.natDegree_normalize]
+theorem _root_.Polynomial.factorDegrees_eq_singleton_of_irreducible (f : ℤ[X]) (p : ℕ)
+    [Fact p.Prime] (h : Irreducible (f.map (Int.castRingHom (ZMod p)))) :
+    f.factorDegrees p = {(f.map (Int.castRingHom (ZMod p))).natDegree} := by
+  rw [factorDegrees_def]
+  exact Polynomial.map_natDegree_normalizedFactors_eq_singleton_iff.mpr h
 
-/-- For a monic integral polynomial, having one factor degree is equivalent to its reduction
-being irreducible. -/
-theorem factorDegrees_eq_singleton_iff_irreducible (f : ℤ[X]) (hf : f.Monic) (p : ℕ)
-    [Fact p.Prime] :
-    factorDegrees f p = {f.natDegree} ↔
-      Irreducible (f.map (Int.castRingHom (ZMod p))) := by
-  let g : (ZMod p)[X] := f.map (Int.castRingHom (ZMod p))
-  have hg : g.Monic := hf.map _
-  constructor
-  · intro h
-    obtain ⟨q, hq, -⟩ := Multiset.map_eq_singleton.mp h
-    have hqmem : q ∈ normalizedFactors g := by
-      change q ∈ normalizedFactors (f.map (Int.castRingHom (ZMod p)))
-      rw [hq]
-      simp
-    have hprod := prod_normalizedFactors hg.ne_zero
-    rw [hq, Multiset.prod_singleton] at hprod
-    exact hprod.irreducible (irreducible_of_normalized_factor q hqmem)
-  · intro h
-    rw [factorDegrees_eq_singleton f p h, hf.natDegree_map]
+/-- A single factor degree, whatever it is, forces the reduction to be irreducible. -/
+theorem _root_.Polynomial.irreducible_map_of_card_factorDegrees_eq_one {f : ℤ[X]} {p : ℕ}
+    [Fact p.Prime] (h : (f.factorDegrees p).card = 1) :
+    Irreducible (f.map (Int.castRingHom (ZMod p))) :=
+  Polynomial.irreducible_of_card_normalizedFactors_eq_one (by simpa using h)
 
-/-- A prime not dividing the discriminant of a monic integral polynomial gives a separable
-reduction modulo that prime. -/
-theorem separable_map_zmod_of_not_dvd_discr (f : ℤ[X]) (hf : f.Monic) (p : ℕ)
-    [Fact p.Prime] (hp : ¬ (p : ℤ) ∣ f.discr) :
-    (f.map (Int.castRingHom (ZMod p))).Separable := by
-  apply (hf.map (Int.castRingHom (ZMod p))).discr_ne_zero_iff.mp
-  rw [hf.discr_map, Int.coe_castRingHom, ne_eq, ZMod.intCast_zmod_eq_zero_iff_dvd]
-  exact hp
+/-- For a monic integral polynomial, having its own degree as sole factor degree is equivalent to
+its reduction being irreducible. -/
+theorem _root_.Polynomial.Monic.factorDegrees_eq_singleton_iff_irreducible {f : ℤ[X]}
+    (hf : f.Monic) (p : ℕ) [Fact p.Prime] :
+    f.factorDegrees p = {f.natDegree} ↔ Irreducible (f.map (Int.castRingHom (ZMod p))) := by
+  refine ⟨fun h ↦ irreducible_map_of_card_factorDegrees_eq_one ?_, fun h ↦ ?_⟩
+  · rw [h, Multiset.card_singleton]
+  · rw [factorDegrees_eq_singleton_of_irreducible f p h, hf.natDegree_map]
 
-/-- At a prime not dividing the discriminant of a monic integral polynomial, its normalized
-irreducible factors modulo that prime have no repetitions. -/
-theorem normalizedFactors_map_zmod_nodup_of_not_dvd_discr (f : ℤ[X]) (hf : f.Monic)
-    (p : ℕ) [Fact p.Prime] (hp : ¬ (p : ℤ) ∣ f.discr) :
-    (normalizedFactors (f.map (Int.castRingHom (ZMod p)))).Nodup := by
-  rw [← squarefree_iff_nodup_normalizedFactors (hf.map _).ne_zero]
-  exact (separable_map_zmod_of_not_dvd_discr f hf p hp).squarefree
+/-! ### The factorization of `X ^ 5 - X - 1` modulo `2` -/
 
-private theorem irreducible_X_sq_add_X_add_one_zmod_two :
+private theorem natDegree_X_pow_three_add_X_sq_add_one :
+    (X ^ 3 + X ^ 2 + 1 : (ZMod 2)[X]).natDegree = 3 := by compute_degree!
+
+private theorem natDegree_X_sq_add_X_add_one :
+    (X ^ 2 + X + 1 : (ZMod 2)[X]).natDegree = 2 := by compute_degree!
+
+/-- `X ^ 2 + X + 1` is irreducible over `ZMod 2`: it is quadratic and has no root there. -/
+theorem _root_.Polynomial.irreducible_X_sq_add_X_add_one_zmod_two :
     Irreducible (X ^ 2 + X + 1 : (ZMod 2)[X]) := by
   apply Polynomial.irreducible_of_degree_le_three_of_not_isRoot
-  · have hdeg : (X ^ 2 + X + 1 : (ZMod 2)[X]).natDegree = 2 := by compute_degree!
-    rw [hdeg]
+  · rw [natDegree_X_sq_add_X_add_one]
     decide
   · intro x
     rw [Polynomial.IsRoot.def]
     simp only [Polynomial.eval_add, Polynomial.eval_pow, Polynomial.eval_X, Polynomial.eval_one]
     fin_cases x <;> decide
 
-private theorem irreducible_X_cube_add_X_sq_add_one_zmod_two :
+/-- `X ^ 3 + X ^ 2 + 1` is irreducible over `ZMod 2`: it is cubic and has no root there. -/
+theorem _root_.Polynomial.irreducible_X_pow_three_add_X_sq_add_one_zmod_two :
     Irreducible (X ^ 3 + X ^ 2 + 1 : (ZMod 2)[X]) := by
   apply Polynomial.irreducible_of_degree_le_three_of_not_isRoot
-  · have hdeg : (X ^ 3 + X ^ 2 + 1 : (ZMod 2)[X]).natDegree = 3 := by compute_degree!
-    rw [hdeg]
+  · rw [natDegree_X_pow_three_add_X_sq_add_one]
     decide
   · intro x
     rw [Polynomial.IsRoot.def]
     simp only [Polynomial.eval_add, Polynomial.eval_pow, Polynomial.eval_X, Polynomial.eval_one]
     fin_cases x <;> decide
 
-/-- The polynomial `X⁵ - X - 1` has factor degrees `3` and `2` modulo `2`. -/
-example : factorDegrees (X ^ 5 - X - 1) 2 = {3, 2} := by
-  have hmap :
-      (X ^ 5 - X - 1 : ℤ[X]).map (Int.castRingHom (ZMod 2)) =
-        (X ^ 3 + X ^ 2 + 1) * (X ^ 2 + X + 1) := by
-    have hneg (a : (ZMod 2)[X]) : -a = a := by
-      ext n
-      simp only [Polynomial.coeff_neg, ZMod.neg_eq_self_mod_two]
-    have htwo : (2 : (ZMod 2)[X]) = 0 := by
-      ext n
-      cases n
-      · rw [Polynomial.coeff_ofNat_zero, Polynomial.coeff_zero]
-        exact show (2 : ZMod 2) = 0 by decide
-      · simp
-    norm_num
-    ring_nf
-    rw [htwo]
-    simp only [mul_zero, add_zero]
-    simp only [sub_eq_add_neg, hneg]
-  have hdeg_three : (X ^ 3 + X ^ 2 + 1 : (ZMod 2)[X]).natDegree = 3 := by
-    compute_degree!
-  have hdeg_two : (X ^ 2 + X + 1 : (ZMod 2)[X]).natDegree = 2 := by
-    compute_degree!
-  rw [factorDegrees, hmap,
-    normalizedFactors_mul irreducible_X_cube_add_X_sq_add_one_zmod_two.ne_zero
-      irreducible_X_sq_add_X_add_one_zmod_two.ne_zero,
-    normalizedFactors_irreducible irreducible_X_cube_add_X_sq_add_one_zmod_two,
-    normalizedFactors_irreducible irreducible_X_sq_add_X_add_one_zmod_two]
-  simp [Polynomial.natDegree_normalize, hdeg_three, hdeg_two]
+/-- The polynomial `X ^ 5 - X - 1` has factor degrees `3` and `2` modulo `2`: its reduction is
+the product of the irreducibles `X ^ 3 + X ^ 2 + 1` and `X ^ 2 + X + 1`. -/
+theorem _root_.Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_two :
+    (X ^ 5 - X - 1 : ℤ[X]).factorDegrees 2 = {3, 2} := by
+  have hirr : ∀ q ∈ ({X ^ 3 + X ^ 2 + 1, X ^ 2 + X + 1} : Multiset (ZMod 2)[X]),
+      Irreducible q := by
+    intro q hq
+    rcases Multiset.mem_cons.mp hq with rfl | hq
+    · exact Polynomial.irreducible_X_pow_three_add_X_sq_add_one_zmod_two
+    · rw [Multiset.mem_singleton.mp hq]
+      exact Polynomial.irreducible_X_sq_add_X_add_one_zmod_two
+  have hmap : (X ^ 5 - X - 1 : ℤ[X]).map (Int.castRingHom (ZMod 2)) =
+      ({X ^ 3 + X ^ 2 + 1, X ^ 2 + X + 1} : Multiset (ZMod 2)[X]).prod := by
+    rw [Multiset.insert_eq_cons, Multiset.prod_cons, Multiset.prod_singleton]
+    simp only [Polynomial.map_sub, Polynomial.map_pow, Polynomial.map_X, Polynomial.map_one]
+    linear_combination (-(X ^ 4 + X ^ 3 + X ^ 2 + X + 1) : (ZMod 2)[X]) *
+      (CharTwo.two_eq_zero : (2 : (ZMod 2)[X]) = 0)
+  rw [factorDegrees_eq_map_natDegree_of_map_eq_prod hirr hmap]
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    natDegree_X_pow_three_add_X_sq_add_one, natDegree_X_sq_add_X_add_one]
 
 end TauCeti

--- a/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RingTheory.Polynomial.FactorDegrees
-public import Mathlib.Algebra.Polynomial.SpecificDegree
+import Mathlib.Algebra.Polynomial.SpecificDegree
 import Mathlib.RingTheory.Polynomial.SmallDegreeVieta
 
 import Mathlib.Algebra.CharP.Two
@@ -26,6 +26,8 @@ polynomial carrier and API live in `TauCeti/RingTheory/Polynomial/FactorDegrees.
 * `Polynomial.irreducible_X_sq_add_X_add_one_zmod_two`,
   `Polynomial.irreducible_X_pow_three_add_X_sq_add_one_zmod_two`: the two irreducibility facts
   over `ZMod 2` that the modulo `2` example rests on.
+* `Polynomial.irreducible_X_pow_five_sub_X_sub_one_zmod_five`: the irreducibility fact over
+  `ZMod 5` that the modulo `5` example rests on.
 * `Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_two`: the worked example
   `factorDegrees (X ^ 5 - X - 1) 2 = {3, 2}`.
 * `Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_five`: the worked example
@@ -101,7 +103,8 @@ theorem _root_.Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_two :
 
 local instance factPrimeFive : Fact (Nat.Prime 5) := ⟨by decide⟩
 
-private theorem irreducible_X_pow_five_sub_X_sub_one_zmod_five :
+/-- `X ^ 5 - X - 1` is irreducible over `ZMod 5`. -/
+theorem _root_.Polynomial.irreducible_X_pow_five_sub_X_sub_one_zmod_five :
     Irreducible (X ^ 5 - X - 1 : (ZMod 5)[X]) := by
   have hmonic : Monic (X ^ 5 - X - 1 : (ZMod 5)[X]) := by
     rw [sub_sub]
@@ -131,12 +134,14 @@ private theorem irreducible_X_pow_five_sub_X_sub_one_zmod_five :
     norm_num at hdvd
   · let a := q.coeff 1
     let b := q.coeff 0
+    -- Put a hypothetical monic quadratic factor in coefficient form.
     have hqeq : q = X ^ 2 + C a * X + C b := by
       rw [Polynomial.eq_quadratic_of_degree_le_two
         (Polynomial.degree_le_of_natDegree_le hdeg'.le)]
       have hc : q.coeff 2 = 1 := by simpa [hdeg'] using hq.coeff_natDegree
       rw [hc]
       simp [a, b]
+    -- Divide explicitly by that quadratic; the displayed polynomial is the linear remainder.
     let quotient : (ZMod 5)[X] :=
       X ^ 3 - C a * X ^ 2 + C (a ^ 2 - b) * X + C (-a ^ 3 + 2 * a * b)
     let remainder : (ZMod 5)[X] :=
@@ -146,6 +151,7 @@ private theorem irreducible_X_pow_five_sub_X_sub_one_zmod_five :
       simp only [quotient, remainder]
       simp only [map_add, map_sub, map_mul, map_pow, map_neg, map_one, map_ofNat]
       ring
+    -- Divisibility forces the degree-at-most-one remainder to vanish.
     have hrem : q ∣ remainder := by
       rw [hdivision] at hdvd
       obtain ⟨c, hc⟩ := hdvd
@@ -158,6 +164,7 @@ private theorem irreducible_X_pow_five_sub_X_sub_one_zmod_five :
     have hremzero : remainder = 0 := by
       by_contra hr
       exact (hq.not_dvd_of_natDegree_lt hr (by omega)) hrem
+    -- Its two coefficients give equations with no solution among the 25 pairs in `ZMod 5`.
     have ha : a ^ 4 - 3 * a ^ 2 * b + b ^ 2 - 1 = 0 := by
       simpa only [remainder, Polynomial.coeff_add, Polynomial.coeff_C_mul_X,
         Polynomial.coeff_C, one_ne_zero, Polynomial.coeff_zero, ite_true, ite_false, add_zero]
@@ -179,7 +186,7 @@ theorem _root_.Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_five :
       (X ^ 5 - X - 1 : (ZMod 5)[X]) := by norm_num
   rw [hmap]
   constructor
-  · exact irreducible_X_pow_five_sub_X_sub_one_zmod_five
+  · exact Polynomial.irreducible_X_pow_five_sub_X_sub_one_zmod_five
   · rw [sub_sub]
     compute_degree!
 

--- a/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
@@ -17,9 +17,9 @@ import Mathlib.Tactic.LinearCombination
 /-!
 # Degrees of factors modulo a prime
 
-This module supplies the Layer 5 worked computations of `Polynomial.factorDegrees` for
-`X ^ 5 - X - 1`. The generic polynomial carrier and API live in
-`TauCeti/RingTheory/Polynomial/FactorDegrees.lean`.
+This module works out `Polynomial.factorDegrees` explicitly for `X ^ 5 - X - 1`, whose reduction
+splits as a cubic times a quadratic modulo `2` and stays irreducible modulo `5`. The generic
+polynomial carrier and API live in `TauCeti/RingTheory/Polynomial/FactorDegrees.lean`.
 
 ## Main declarations
 
@@ -33,12 +33,13 @@ This module supplies the Layer 5 worked computations of `Polynomial.factorDegree
 
 ## References
 
-* [Tau Ceti PolynomialGaloisGroups roadmap, Layer 5](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/PolynomialGaloisGroups/README.md#layer-5-frobenius-specialization),
-  with Lean signatures in its Layer 5 `Suggested.lean` specification.
 * D. A. Marcus, *Number Fields*, 2nd edition, Springer 2018, Chapter 4, where the factorization
   of `f mod p` is matched with the splitting of `p`.
 * J. Neukirch, *Algebraic Number Theory*, Springer 1999, Chapter I, §8.
 -/
+
+-- Provenance: the Tau Ceti `PolynomialGaloisGroups` roadmap README and its `Suggested.lean`,
+-- which write down the Lean signatures for these factorization patterns of `X ^ 5 - X - 1`.
 
 public section
 noncomputable section

--- a/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
@@ -5,46 +5,34 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.RingTheory.Polynomial.Factors
-public import Mathlib.Algebra.Field.ZMod
+public import TauCeti.RingTheory.Polynomial.FactorDegrees
 public import Mathlib.Algebra.Polynomial.SpecificDegree
-public import Mathlib.RingTheory.Polynomial.UniqueFactorization
+import Mathlib.RingTheory.Polynomial.SmallDegreeVieta
 
 import Mathlib.Algebra.CharP.Two
+import Mathlib.FieldTheory.Finite.Basic
 import Mathlib.Tactic.ComputeDegree
 import Mathlib.Tactic.LinearCombination
 
 /-!
 # Degrees of factors modulo a prime
 
-For an integral polynomial `f` and a prime `p`, `Polynomial.factorDegrees f p` is the multiset of
-degrees of the monic irreducible factors of the reduction of `f` modulo `p`. Multiplicities are
-retained: a repeated irreducible factor contributes its degree repeatedly.
-
-This is the polynomial-side factorization datum compared with cycle types in Dedekind's
-factorization theorem. The API here records its total degree, computes it from any factorization
-of the reduction into irreducibles, and characterizes the polynomials whose reduction is
-irreducible. The underlying facts about `normalizedFactors` over a field are proved in
-`TauCeti/RingTheory/Polynomial/Factors.lean`, and the separability of the reduction at a prime
-not dividing the discriminant in `TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean`.
+This module supplies the Layer 5 worked computations of `Polynomial.factorDegrees` for
+`X ^ 5 - X - 1`. The generic polynomial carrier and API live in
+`TauCeti/RingTheory/Polynomial/FactorDegrees.lean`.
 
 ## Main declarations
 
-* `Polynomial.factorDegrees`: the multiset of factor degrees of `f` modulo `p`.
-* `Polynomial.factorDegrees_eq_map_natDegree_of_map_eq_prod`: the factor degrees are read off
-  from any factorization of the reduction into irreducibles.
-* `Polynomial.sum_factorDegrees_eq_natDegree_map`, `Polynomial.Monic.sum_factorDegrees`: the
-  factor degrees sum to the degree after reduction, which for monic `f` is `f.natDegree`.
-* `Polynomial.factorDegrees_eq_singleton_of_irreducible`,
-  `Polynomial.irreducible_map_of_card_factorDegrees_eq_one`,
-  `Polynomial.Monic.factorDegrees_eq_singleton_iff_irreducible`: a single factor degree is the
-  same thing as an irreducible reduction.
 * `Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_two`: the worked example
   `factorDegrees (X ^ 5 - X - 1) 2 = {3, 2}`, with the two irreducibility facts over `ZMod 2`
   that it rests on.
+* `Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_five`: the worked example
+  `factorDegrees (X ^ 5 - X - 1) 5 = {5}`.
 
 ## References
 
+* [Tau Ceti PolynomialGaloisGroups roadmap, Layer 5](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/PolynomialGaloisGroups/README.md#layer-5-frobenius-specialization),
+  with Lean signatures in its Layer 5 `Suggested.lean` specification.
 * D. A. Marcus, *Number Fields*, 2nd edition, Springer 2018, Chapter 4, where the factorization
   of `f mod p` is matched with the splitting of `p`.
 * J. Neukirch, *Algebraic Number Theory*, Springer 1999, Chapter I, §8.
@@ -53,109 +41,11 @@ not dividing the discriminant in `TauCeti/RingTheory/Polynomial/Resultant/Discri
 public section
 noncomputable section
 
-open Polynomial UniqueFactorizationMonoid
+open Polynomial
 
 namespace TauCeti
 
-/-- The multiset of degrees of the monic irreducible factors of the reduction of an integral
-polynomial modulo a prime. Repeated factors occur with their multiplicities. -/
-noncomputable def _root_.Polynomial.factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
-    Multiset ℕ :=
-  Multiset.map Polynomial.natDegree
-    (normalizedFactors (f.map (Int.castRingHom (ZMod p))))
-
-/-- The defining equation for `Polynomial.factorDegrees`. -/
-theorem _root_.Polynomial.factorDegrees_def (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
-    f.factorDegrees p = Multiset.map Polynomial.natDegree
-      (normalizedFactors (f.map (Int.castRingHom (ZMod p)))) :=
-  (rfl)
-
-/-- A natural number occurs in `f.factorDegrees p` exactly when it is the degree of a normalized
-irreducible factor of the reduction of `f` modulo `p`. -/
-theorem _root_.Polynomial.mem_factorDegrees_iff {f : ℤ[X]} {p d : ℕ} [Fact p.Prime] :
-    d ∈ f.factorDegrees p ↔ ∃ q ∈ normalizedFactors (f.map (Int.castRingHom (ZMod p))),
-      q.natDegree = d := by
-  simp [factorDegrees_def]
-
-/-- Every degree occurring in `f.factorDegrees p` is positive. -/
-theorem _root_.Polynomial.pos_of_mem_factorDegrees {f : ℤ[X]} {p d : ℕ} [Fact p.Prime]
-    (hd : d ∈ f.factorDegrees p) : 0 < d := by
-  obtain ⟨q, hq, rfl⟩ := mem_factorDegrees_iff.mp hd
-  exact (irreducible_of_normalized_factor q hq).natDegree_pos
-
-/-- The number of factor degrees is the number of normalized irreducible factors, counted with
-multiplicity. -/
-@[simp]
-theorem _root_.Polynomial.card_factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
-    (f.factorDegrees p).card =
-      (normalizedFactors (f.map (Int.castRingHom (ZMod p)))).card := by
-  simp [factorDegrees_def]
-
-/-- The zero polynomial has no factor degrees. -/
-@[simp]
-theorem _root_.Polynomial.factorDegrees_zero (p : ℕ) [Fact p.Prime] :
-    (0 : ℤ[X]).factorDegrees p = 0 := by
-  simp [factorDegrees_def]
-
-/-- The constant polynomial one has no factor degrees. -/
-@[simp]
-theorem _root_.Polynomial.factorDegrees_one (p : ℕ) [Fact p.Prime] :
-    (1 : ℤ[X]).factorDegrees p = 0 := by
-  simp [factorDegrees_def]
-
-/-- Factor degrees turn a product whose reductions are nonzero into multiset addition. -/
-theorem _root_.Polynomial.factorDegrees_mul (f g : ℤ[X]) (p : ℕ) [Fact p.Prime]
-    (hf : f.map (Int.castRingHom (ZMod p)) ≠ 0)
-    (hg : g.map (Int.castRingHom (ZMod p)) ≠ 0) :
-    (f * g).factorDegrees p = f.factorDegrees p + g.factorDegrees p := by
-  simp [factorDegrees_def, normalizedFactors_mul hf hg]
-
-/-- The factor degrees are read off from any factorization of the reduction into irreducibles,
-without normalizing the factors first. This is how the multiset is computed in practice: a
-factorization of `f mod p` need not come from a factorization over `ℤ`. -/
-theorem _root_.Polynomial.factorDegrees_eq_map_natDegree_of_map_eq_prod {f : ℤ[X]} {p : ℕ}
-    [Fact p.Prime] {s : Multiset (ZMod p)[X]} (hs : ∀ q ∈ s, Irreducible q)
-    (hfs : f.map (Int.castRingHom (ZMod p)) = s.prod) :
-    f.factorDegrees p = s.map Polynomial.natDegree := by
-  rw [factorDegrees_def, hfs, normalizedFactors_prod_eq s hs, Multiset.map_map]
-  exact Multiset.map_congr rfl fun q _ ↦ Polynomial.natDegree_normalize
-
-/-- The sum of the factor degrees is the degree of the polynomial after reduction. -/
-@[simp]
-theorem _root_.Polynomial.sum_factorDegrees_eq_natDegree_map (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
-    (f.factorDegrees p).sum = (f.map (Int.castRingHom (ZMod p))).natDegree := by
-  rw [factorDegrees_def]
-  exact Polynomial.sum_natDegree_normalizedFactors _
-
-/-- For a monic polynomial, the degrees of all irreducible factors of its reduction modulo a
-prime, counted with multiplicity, sum to the degree of the original polynomial. -/
-theorem _root_.Polynomial.Monic.sum_factorDegrees {f : ℤ[X]} (hf : f.Monic) (p : ℕ)
-    [Fact p.Prime] : (f.factorDegrees p).sum = f.natDegree := by
-  rw [sum_factorDegrees_eq_natDegree_map, hf.natDegree_map]
-
-/-- If the reduction of `f` modulo `p` is irreducible, its only factor degree is its degree. -/
-theorem _root_.Polynomial.factorDegrees_eq_singleton_of_irreducible (f : ℤ[X]) (p : ℕ)
-    [Fact p.Prime] (h : Irreducible (f.map (Int.castRingHom (ZMod p)))) :
-    f.factorDegrees p = {(f.map (Int.castRingHom (ZMod p))).natDegree} := by
-  rw [factorDegrees_def]
-  exact Polynomial.map_natDegree_normalizedFactors_eq_singleton_iff.mpr h
-
-/-- A single factor degree, whatever it is, forces the reduction to be irreducible. -/
-theorem _root_.Polynomial.irreducible_map_of_card_factorDegrees_eq_one {f : ℤ[X]} {p : ℕ}
-    [Fact p.Prime] (h : (f.factorDegrees p).card = 1) :
-    Irreducible (f.map (Int.castRingHom (ZMod p))) :=
-  Polynomial.irreducible_of_card_normalizedFactors_eq_one (by simpa using h)
-
-/-- For a monic integral polynomial, having its own degree as sole factor degree is equivalent to
-its reduction being irreducible. -/
-theorem _root_.Polynomial.Monic.factorDegrees_eq_singleton_iff_irreducible {f : ℤ[X]}
-    (hf : f.Monic) (p : ℕ) [Fact p.Prime] :
-    f.factorDegrees p = {f.natDegree} ↔ Irreducible (f.map (Int.castRingHom (ZMod p))) := by
-  refine ⟨fun h ↦ irreducible_map_of_card_factorDegrees_eq_one ?_, fun h ↦ ?_⟩
-  · rw [h, Multiset.card_singleton]
-  · rw [factorDegrees_eq_singleton_of_irreducible f p h, hf.natDegree_map]
-
-/-! ### The factorization of `X ^ 5 - X - 1` modulo `2` -/
+/-! ### The factorization of `X ^ 5 - X - 1` modulo `2` and `5` -/
 
 private theorem natDegree_X_pow_three_add_X_sq_add_one :
     (X ^ 3 + X ^ 2 + 1 : (ZMod 2)[X]).natDegree = 3 := by compute_degree!
@@ -205,5 +95,89 @@ theorem _root_.Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_two :
   rw [factorDegrees_eq_map_natDegree_of_map_eq_prod hirr hmap]
   simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
     natDegree_X_pow_three_add_X_sq_add_one, natDegree_X_sq_add_X_add_one]
+
+local instance factPrimeFive : Fact (Nat.Prime 5) := ⟨by decide⟩
+
+private theorem irreducible_X_pow_five_sub_X_sub_one_zmod_five :
+    Irreducible (X ^ 5 - X - 1 : (ZMod 5)[X]) := by
+  have hmonic : Monic (X ^ 5 - X - 1 : (ZMod 5)[X]) := by
+    rw [sub_sub]
+    apply Polynomial.monic_X_pow_sub
+    compute_degree!
+  have hpdeg : (X ^ 5 - X - 1 : (ZMod 5)[X]).natDegree = 5 := by
+    rw [sub_sub]
+    compute_degree!
+  have hpone : (X ^ 5 - X - 1 : (ZMod 5)[X]) ≠ 1 := by
+    intro h
+    rw [h, Polynomial.natDegree_one] at hpdeg
+    omega
+  rw [hmonic.irreducible_iff_lt_natDegree_lt hpone]
+  intro q hq hdeg hdvd
+  have hdeg' : q.natDegree = 1 ∨ q.natDegree = 2 := by
+    rw [hpdeg] at hdeg
+    simp only [Finset.mem_Ioc] at hdeg
+    norm_num at hdeg
+    omega
+  rcases hdeg' with hdeg' | hdeg'
+  · rw [hq.eq_X_add_C hdeg'] at hdvd
+    rw [← sub_neg_eq_add, ← Polynomial.C_neg, Polynomial.dvd_iff_isRoot,
+      Polynomial.IsRoot.def] at hdvd
+    simp only [Polynomial.eval_sub, Polynomial.eval_pow, Polynomial.eval_X,
+      Polynomial.eval_one] at hdvd
+    rw [ZMod.pow_card] at hdvd
+    norm_num at hdvd
+  · let a := q.coeff 1
+    let b := q.coeff 0
+    have hqeq : q = X ^ 2 + C a * X + C b := by
+      rw [Polynomial.eq_quadratic_of_degree_le_two
+        (Polynomial.degree_le_of_natDegree_le hdeg'.le)]
+      have hc : q.coeff 2 = 1 := by simpa [hdeg'] using hq.coeff_natDegree
+      rw [hc]
+      simp [a, b]
+    let quotient : (ZMod 5)[X] :=
+      X ^ 3 - C a * X ^ 2 + C (a ^ 2 - b) * X + C (-a ^ 3 + 2 * a * b)
+    let remainder : (ZMod 5)[X] :=
+      C (a ^ 4 - 3 * a ^ 2 * b + b ^ 2 - 1) * X + C (a ^ 3 * b - 2 * a * b ^ 2 - 1)
+    have hdivision : (X ^ 5 - X - 1 : (ZMod 5)[X]) = q * quotient + remainder := by
+      rw [hqeq]
+      simp only [quotient, remainder]
+      simp only [map_add, map_sub, map_mul, map_pow, map_neg, map_one, map_ofNat]
+      ring
+    have hrem : q ∣ remainder := by
+      rw [hdivision] at hdvd
+      obtain ⟨c, hc⟩ := hdvd
+      refine ⟨c - quotient, ?_⟩
+      rw [mul_sub, ← hc]
+      ring
+    have hremdeg : remainder.natDegree ≤ 1 := by
+      simp only [remainder]
+      compute_degree
+    have hremzero : remainder = 0 := by
+      by_contra hr
+      exact (hq.not_dvd_of_natDegree_lt hr (by omega)) hrem
+    have ha : a ^ 4 - 3 * a ^ 2 * b + b ^ 2 - 1 = 0 := by
+      simpa only [remainder, Polynomial.coeff_add, Polynomial.coeff_C_mul_X,
+        Polynomial.coeff_C, one_ne_zero, Polynomial.coeff_zero, ite_true, ite_false, add_zero]
+        using congrArg (fun g : (ZMod 5)[X] ↦ g.coeff 1) hremzero
+    have hb : a ^ 3 * b - 2 * a * b ^ 2 - 1 = 0 := by
+      simpa only [remainder, Polynomial.coeff_add, Polynomial.coeff_C_mul_X,
+        Polynomial.coeff_C, zero_ne_one, Polynomial.coeff_zero, ite_true, ite_false, zero_add]
+        using congrArg (fun g : (ZMod 5)[X] ↦ g.coeff 0) hremzero
+    simp only [a, b] at ha hb
+    generalize q.coeff 1 = a' at ha hb
+    generalize q.coeff 0 = b' at ha hb
+    fin_cases a' <;> fin_cases b' <;> revert ha hb <;> decide
+
+/-- The polynomial `X ^ 5 - X - 1` is irreducible modulo `5`, so its sole factor degree is `5`. -/
+theorem _root_.Polynomial.factorDegrees_X_pow_five_sub_X_sub_one_five :
+    (X ^ 5 - X - 1 : ℤ[X]).factorDegrees 5 = {5} := by
+  rw [Polynomial.factorDegrees_eq_singleton_iff]
+  have hmap : (X ^ 5 - X - 1 : ℤ[X]).map (Int.castRingHom (ZMod 5)) =
+      (X ^ 5 - X - 1 : (ZMod 5)[X]) := by norm_num
+  rw [hmap]
+  constructor
+  · exact irreducible_X_pow_five_sub_X_sub_one_zmod_five
+  · rw [sub_sub]
+    compute_degree!
 
 end TauCeti

--- a/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
+++ b/TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean
@@ -112,7 +112,6 @@ theorem factorDegrees_sum_eq_natDegree_map (f : ℤ[X]) (p : ℕ) [Fact p.Prime]
 
 /-- For a monic polynomial, the degrees of all irreducible factors of its reduction modulo a
 prime, counted with multiplicity, sum to the degree of the original polynomial. -/
-@[simp]
 theorem factorDegrees_sum (f : ℤ[X]) (hf : f.Monic) (p : ℕ) [Fact p.Prime] :
     (factorDegrees f p).sum = f.natDegree := by
   rw [factorDegrees_sum_eq_natDegree_map, hf.natDegree_map]

--- a/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
+++ b/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
@@ -23,6 +23,10 @@ and its relationship with irreducibility. Roadmap-specific worked examples are i
 ## Main declarations
 
 * `Polynomial.factorDegrees`: the multiset of factor degrees of `f` modulo `p`.
+* `Polynomial.mem_factorDegrees_iff`: a number occurs as a factor degree exactly when it is the
+  degree of a normalized irreducible factor of the reduction.
+* `Polynomial.factorDegrees_mul`: the factor degrees of a product with nonzero reductions are the
+  sum of the factor degrees.
 * `Polynomial.factorDegrees_eq_map_natDegree_of_map_eq_prod`: compute the factor degrees from any
   factorization of the reduction into irreducibles.
 * `Polynomial.sum_factorDegrees_eq_natDegree_map`, `Polynomial.Monic.sum_factorDegrees`: the

--- a/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
+++ b/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
@@ -17,7 +17,7 @@ degrees of the monic irreducible factors of the reduction of `f` modulo `p`. Mul
 retained: a repeated irreducible factor contributes its degree repeatedly.
 
 This file gives the generic polynomial API for the carrier: membership, products, total degree,
-and its relationship with irreducibility. Roadmap-specific worked examples are in
+and its relationship with irreducibility. Worked examples for `X ^ 5 - X - 1` are in
 `TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean`.
 
 ## Main declarations
@@ -36,11 +36,12 @@ and its relationship with irreducibility. Roadmap-specific worked examples are i
 
 ## References
 
-* [Tau Ceti PolynomialGaloisGroups roadmap, Layer 5](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/PolynomialGaloisGroups/README.md#layer-5-frobenius-specialization),
-  with Lean signatures in its Layer 5 `Suggested.lean` specification.
 * D. A. Marcus, *Number Fields*, 2nd edition, Springer 2018, Chapter 4.
 * J. Neukirch, *Algebraic Number Theory*, Springer 1999, Chapter I, §8.
 -/
+
+-- Provenance: the Tau Ceti `PolynomialGaloisGroups` roadmap README and its `Suggested.lean`,
+-- which write down the Lean signature of the factor-degree multiset defined here.
 
 public section
 noncomputable section

--- a/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
+++ b/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
@@ -23,6 +23,8 @@ and its relationship with irreducibility. Worked examples for `X ^ 5 - X - 1` ar
 ## Main declarations
 
 * `Polynomial.factorDegrees`: the multiset of factor degrees of `f` modulo `p`.
+* `Polynomial.factorDegrees_def`: the defining equation, which is the only way to unfold the
+  carrier outside this file.
 * `Polynomial.mem_factorDegrees_iff`: a number occurs as a factor degree exactly when it is the
   degree of a normalized irreducible factor of the reduction.
 * `Polynomial.factorDegrees_mul`: the factor degrees of a product with nonzero reductions are the
@@ -57,13 +59,20 @@ noncomputable def _root_.Polynomial.factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p
   Multiset.map Polynomial.natDegree
     (normalizedFactors (f.map (Int.castRingHom (ZMod p))))
 
+/-- The defining equation for `Polynomial.factorDegrees`, which the definition itself does not
+expose outside this file. -/
+theorem _root_.Polynomial.factorDegrees_def (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    f.factorDegrees p = Multiset.map Polynomial.natDegree
+      (normalizedFactors (f.map (Int.castRingHom (ZMod p)))) :=
+  (rfl)
+
 /-- A natural number occurs in `f.factorDegrees p` exactly when it is the degree of a normalized
 irreducible factor of the reduction of `f` modulo `p`. -/
 @[simp]
 theorem _root_.Polynomial.mem_factorDegrees_iff {f : ℤ[X]} {p d : ℕ} [Fact p.Prime] :
     d ∈ f.factorDegrees p ↔ ∃ q ∈ normalizedFactors (f.map (Int.castRingHom (ZMod p))),
       q.natDegree = d := by
-  simp [factorDegrees]
+  simp [factorDegrees_def]
 
 /-- Every degree occurring in `f.factorDegrees p` is positive. -/
 theorem _root_.Polynomial.pos_of_mem_factorDegrees {f : ℤ[X]} {p d : ℕ} [Fact p.Prime]
@@ -77,26 +86,26 @@ multiplicity. -/
 theorem _root_.Polynomial.card_factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
     (f.factorDegrees p).card =
       (normalizedFactors (f.map (Int.castRingHom (ZMod p)))).card := by
-  simp [factorDegrees]
+  simp [factorDegrees_def]
 
 /-- The zero polynomial has no factor degrees. -/
 @[simp]
 theorem _root_.Polynomial.factorDegrees_zero (p : ℕ) [Fact p.Prime] :
     (0 : ℤ[X]).factorDegrees p = 0 := by
-  simp [factorDegrees]
+  simp [factorDegrees_def]
 
 /-- The constant polynomial one has no factor degrees. -/
 @[simp]
 theorem _root_.Polynomial.factorDegrees_one (p : ℕ) [Fact p.Prime] :
     (1 : ℤ[X]).factorDegrees p = 0 := by
-  simp [factorDegrees]
+  simp [factorDegrees_def]
 
 /-- Factor degrees turn a product whose reductions are nonzero into multiset addition. -/
 theorem _root_.Polynomial.factorDegrees_mul (f g : ℤ[X]) (p : ℕ) [Fact p.Prime]
     (hf : f.map (Int.castRingHom (ZMod p)) ≠ 0)
     (hg : g.map (Int.castRingHom (ZMod p)) ≠ 0) :
     (f * g).factorDegrees p = f.factorDegrees p + g.factorDegrees p := by
-  simp [factorDegrees, normalizedFactors_mul hf hg]
+  simp [factorDegrees_def, normalizedFactors_mul hf hg]
 
 /-- The factor degrees are read off from any factorization of the reduction into irreducibles,
 without normalizing the factors first. -/
@@ -104,14 +113,14 @@ theorem _root_.Polynomial.factorDegrees_eq_map_natDegree_of_map_eq_prod {f : ℤ
     [Fact p.Prime] {s : Multiset (ZMod p)[X]} (hs : ∀ q ∈ s, Irreducible q)
     (hfs : f.map (Int.castRingHom (ZMod p)) = s.prod) :
     f.factorDegrees p = s.map Polynomial.natDegree := by
-  rw [factorDegrees, hfs, normalizedFactors_prod_eq s hs, Multiset.map_map]
+  rw [factorDegrees_def, hfs, normalizedFactors_prod_eq s hs, Multiset.map_map]
   exact Multiset.map_congr rfl fun q _ ↦ Polynomial.natDegree_normalize
 
 /-- The sum of the factor degrees is the degree of the polynomial after reduction. -/
 @[simp]
 theorem _root_.Polynomial.sum_factorDegrees_eq_natDegree_map (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
     (f.factorDegrees p).sum = (f.map (Int.castRingHom (ZMod p))).natDegree := by
-  rw [factorDegrees]
+  rw [factorDegrees_def]
   exact Polynomial.sum_natDegree_normalizedFactors _
 
 /-- For a monic polynomial, the degrees of all irreducible factors of its reduction modulo a
@@ -124,7 +133,7 @@ theorem _root_.Polynomial.Monic.sum_factorDegrees {f : ℤ[X]} (hf : f.Monic) (p
 theorem _root_.Polynomial.factorDegrees_eq_singleton_of_irreducible (f : ℤ[X]) (p : ℕ)
     [Fact p.Prime] (h : Irreducible (f.map (Int.castRingHom (ZMod p)))) :
     f.factorDegrees p = {(f.map (Int.castRingHom (ZMod p))).natDegree} := by
-  rw [factorDegrees]
+  rw [factorDegrees_def]
   exact Polynomial.map_natDegree_normalizedFactors_eq_singleton_iff.mpr h
 
 /-- A single factor degree, whatever it is, forces the reduction to be irreducible. -/

--- a/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
+++ b/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
@@ -60,6 +60,7 @@ theorem _root_.Polynomial.factorDegrees_def (f : ℤ[X]) (p : ℕ) [Fact p.Prime
 
 /-- A natural number occurs in `f.factorDegrees p` exactly when it is the degree of a normalized
 irreducible factor of the reduction of `f` modulo `p`. -/
+@[simp]
 theorem _root_.Polynomial.mem_factorDegrees_iff {f : ℤ[X]} {p d : ℕ} [Fact p.Prime] :
     d ∈ f.factorDegrees p ↔ ∃ q ∈ normalizedFactors (f.map (Int.castRingHom (ZMod p))),
       q.natDegree = d := by

--- a/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
+++ b/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
@@ -42,9 +42,6 @@ and its relationship with irreducibility. Worked examples for `X ^ 5 - X - 1` ar
 * J. Neukirch, *Algebraic Number Theory*, Springer 1999, Chapter I, §8.
 -/
 
--- Provenance: the Tau Ceti `PolynomialGaloisGroups` roadmap README and its `Suggested.lean`,
--- which write down the Lean signature of the factor-degree multiset defined here.
-
 public section
 noncomputable section
 
@@ -75,6 +72,7 @@ theorem _root_.Polynomial.mem_factorDegrees_iff {f : ℤ[X]} {p d : ℕ} [Fact p
   simp [factorDegrees_def]
 
 /-- Every degree occurring in `f.factorDegrees p` is positive. -/
+@[grind →]
 theorem _root_.Polynomial.pos_of_mem_factorDegrees {f : ℤ[X]} {p d : ℕ} [Fact p.Prime]
     (hd : d ∈ f.factorDegrees p) : 0 < d := by
   obtain ⟨q, hq, rfl⟩ := mem_factorDegrees_iff.mp hd

--- a/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
+++ b/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.RingTheory.Polynomial.Factors
 public import Mathlib.Algebra.Field.ZMod
-public import Mathlib.RingTheory.Polynomial.UniqueFactorization
+import Mathlib.RingTheory.Polynomial.UniqueFactorization
 
 /-!
 # Degrees of polynomial factors modulo a prime
@@ -57,19 +57,13 @@ noncomputable def _root_.Polynomial.factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p
   Multiset.map Polynomial.natDegree
     (normalizedFactors (f.map (Int.castRingHom (ZMod p))))
 
-/-- The defining equation for `Polynomial.factorDegrees`. -/
-theorem _root_.Polynomial.factorDegrees_def (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
-    f.factorDegrees p = Multiset.map Polynomial.natDegree
-      (normalizedFactors (f.map (Int.castRingHom (ZMod p)))) :=
-  (rfl)
-
 /-- A natural number occurs in `f.factorDegrees p` exactly when it is the degree of a normalized
 irreducible factor of the reduction of `f` modulo `p`. -/
 @[simp]
 theorem _root_.Polynomial.mem_factorDegrees_iff {f : ℤ[X]} {p d : ℕ} [Fact p.Prime] :
     d ∈ f.factorDegrees p ↔ ∃ q ∈ normalizedFactors (f.map (Int.castRingHom (ZMod p))),
       q.natDegree = d := by
-  simp [factorDegrees_def]
+  simp [factorDegrees]
 
 /-- Every degree occurring in `f.factorDegrees p` is positive. -/
 theorem _root_.Polynomial.pos_of_mem_factorDegrees {f : ℤ[X]} {p d : ℕ} [Fact p.Prime]
@@ -83,26 +77,26 @@ multiplicity. -/
 theorem _root_.Polynomial.card_factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
     (f.factorDegrees p).card =
       (normalizedFactors (f.map (Int.castRingHom (ZMod p)))).card := by
-  simp [factorDegrees_def]
+  simp [factorDegrees]
 
 /-- The zero polynomial has no factor degrees. -/
 @[simp]
 theorem _root_.Polynomial.factorDegrees_zero (p : ℕ) [Fact p.Prime] :
     (0 : ℤ[X]).factorDegrees p = 0 := by
-  simp [factorDegrees_def]
+  simp [factorDegrees]
 
 /-- The constant polynomial one has no factor degrees. -/
 @[simp]
 theorem _root_.Polynomial.factorDegrees_one (p : ℕ) [Fact p.Prime] :
     (1 : ℤ[X]).factorDegrees p = 0 := by
-  simp [factorDegrees_def]
+  simp [factorDegrees]
 
 /-- Factor degrees turn a product whose reductions are nonzero into multiset addition. -/
 theorem _root_.Polynomial.factorDegrees_mul (f g : ℤ[X]) (p : ℕ) [Fact p.Prime]
     (hf : f.map (Int.castRingHom (ZMod p)) ≠ 0)
     (hg : g.map (Int.castRingHom (ZMod p)) ≠ 0) :
     (f * g).factorDegrees p = f.factorDegrees p + g.factorDegrees p := by
-  simp [factorDegrees_def, normalizedFactors_mul hf hg]
+  simp [factorDegrees, normalizedFactors_mul hf hg]
 
 /-- The factor degrees are read off from any factorization of the reduction into irreducibles,
 without normalizing the factors first. -/
@@ -110,14 +104,14 @@ theorem _root_.Polynomial.factorDegrees_eq_map_natDegree_of_map_eq_prod {f : ℤ
     [Fact p.Prime] {s : Multiset (ZMod p)[X]} (hs : ∀ q ∈ s, Irreducible q)
     (hfs : f.map (Int.castRingHom (ZMod p)) = s.prod) :
     f.factorDegrees p = s.map Polynomial.natDegree := by
-  rw [factorDegrees_def, hfs, normalizedFactors_prod_eq s hs, Multiset.map_map]
+  rw [factorDegrees, hfs, normalizedFactors_prod_eq s hs, Multiset.map_map]
   exact Multiset.map_congr rfl fun q _ ↦ Polynomial.natDegree_normalize
 
 /-- The sum of the factor degrees is the degree of the polynomial after reduction. -/
 @[simp]
 theorem _root_.Polynomial.sum_factorDegrees_eq_natDegree_map (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
     (f.factorDegrees p).sum = (f.map (Int.castRingHom (ZMod p))).natDegree := by
-  rw [factorDegrees_def]
+  rw [factorDegrees]
   exact Polynomial.sum_natDegree_normalizedFactors _
 
 /-- For a monic polynomial, the degrees of all irreducible factors of its reduction modulo a
@@ -130,7 +124,7 @@ theorem _root_.Polynomial.Monic.sum_factorDegrees {f : ℤ[X]} (hf : f.Monic) (p
 theorem _root_.Polynomial.factorDegrees_eq_singleton_of_irreducible (f : ℤ[X]) (p : ℕ)
     [Fact p.Prime] (h : Irreducible (f.map (Int.castRingHom (ZMod p)))) :
     f.factorDegrees p = {(f.map (Int.castRingHom (ZMod p))).natDegree} := by
-  rw [factorDegrees_def]
+  rw [factorDegrees]
   exact Polynomial.map_natDegree_normalizedFactors_eq_singleton_iff.mpr h
 
 /-- A single factor degree, whatever it is, forces the reduction to be irreducible. -/

--- a/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
+++ b/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Polynomial.Factors
+public import Mathlib.Algebra.Field.ZMod
+public import Mathlib.RingTheory.Polynomial.UniqueFactorization
+
+/-!
+# Degrees of polynomial factors modulo a prime
+
+For an integral polynomial `f` and a prime `p`, `Polynomial.factorDegrees f p` is the multiset of
+degrees of the monic irreducible factors of the reduction of `f` modulo `p`. Multiplicities are
+retained: a repeated irreducible factor contributes its degree repeatedly.
+
+This file gives the generic polynomial API for the carrier: membership, products, total degree,
+and its relationship with irreducibility. Roadmap-specific worked examples are in
+`TauCeti/FieldTheory/GaloisGroups/FactorDegrees.lean`.
+
+## Main declarations
+
+* `Polynomial.factorDegrees`: the multiset of factor degrees of `f` modulo `p`.
+* `Polynomial.factorDegrees_eq_map_natDegree_of_map_eq_prod`: compute the factor degrees from any
+  factorization of the reduction into irreducibles.
+* `Polynomial.sum_factorDegrees_eq_natDegree_map`, `Polynomial.Monic.sum_factorDegrees`: the
+  factor degrees sum to the degree after reduction, which for monic `f` is `f.natDegree`.
+* `Polynomial.factorDegrees_eq_singleton_iff`: the factor degrees are `{n}` exactly when the
+  reduction is irreducible of degree `n`.
+
+## References
+
+* [Tau Ceti PolynomialGaloisGroups roadmap, Layer 5](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/PolynomialGaloisGroups/README.md#layer-5-frobenius-specialization),
+  with Lean signatures in its Layer 5 `Suggested.lean` specification.
+* D. A. Marcus, *Number Fields*, 2nd edition, Springer 2018, Chapter 4.
+* J. Neukirch, *Algebraic Number Theory*, Springer 1999, Chapter I, §8.
+-/
+
+public section
+noncomputable section
+
+open Polynomial UniqueFactorizationMonoid
+
+namespace TauCeti
+
+/-- The multiset of degrees of the monic irreducible factors of the reduction of an integral
+polynomial modulo a prime. Repeated factors occur with their multiplicities. -/
+noncomputable def _root_.Polynomial.factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    Multiset ℕ :=
+  Multiset.map Polynomial.natDegree
+    (normalizedFactors (f.map (Int.castRingHom (ZMod p))))
+
+/-- The defining equation for `Polynomial.factorDegrees`. -/
+theorem _root_.Polynomial.factorDegrees_def (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    f.factorDegrees p = Multiset.map Polynomial.natDegree
+      (normalizedFactors (f.map (Int.castRingHom (ZMod p)))) :=
+  (rfl)
+
+/-- A natural number occurs in `f.factorDegrees p` exactly when it is the degree of a normalized
+irreducible factor of the reduction of `f` modulo `p`. -/
+theorem _root_.Polynomial.mem_factorDegrees_iff {f : ℤ[X]} {p d : ℕ} [Fact p.Prime] :
+    d ∈ f.factorDegrees p ↔ ∃ q ∈ normalizedFactors (f.map (Int.castRingHom (ZMod p))),
+      q.natDegree = d := by
+  simp [factorDegrees_def]
+
+/-- Every degree occurring in `f.factorDegrees p` is positive. -/
+theorem _root_.Polynomial.pos_of_mem_factorDegrees {f : ℤ[X]} {p d : ℕ} [Fact p.Prime]
+    (hd : d ∈ f.factorDegrees p) : 0 < d := by
+  obtain ⟨q, hq, rfl⟩ := mem_factorDegrees_iff.mp hd
+  exact (irreducible_of_normalized_factor q hq).natDegree_pos
+
+/-- The number of factor degrees is the number of normalized irreducible factors, counted with
+multiplicity. -/
+@[simp]
+theorem _root_.Polynomial.card_factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    (f.factorDegrees p).card =
+      (normalizedFactors (f.map (Int.castRingHom (ZMod p)))).card := by
+  simp [factorDegrees_def]
+
+/-- The zero polynomial has no factor degrees. -/
+@[simp]
+theorem _root_.Polynomial.factorDegrees_zero (p : ℕ) [Fact p.Prime] :
+    (0 : ℤ[X]).factorDegrees p = 0 := by
+  simp [factorDegrees_def]
+
+/-- The constant polynomial one has no factor degrees. -/
+@[simp]
+theorem _root_.Polynomial.factorDegrees_one (p : ℕ) [Fact p.Prime] :
+    (1 : ℤ[X]).factorDegrees p = 0 := by
+  simp [factorDegrees_def]
+
+/-- Factor degrees turn a product whose reductions are nonzero into multiset addition. -/
+theorem _root_.Polynomial.factorDegrees_mul (f g : ℤ[X]) (p : ℕ) [Fact p.Prime]
+    (hf : f.map (Int.castRingHom (ZMod p)) ≠ 0)
+    (hg : g.map (Int.castRingHom (ZMod p)) ≠ 0) :
+    (f * g).factorDegrees p = f.factorDegrees p + g.factorDegrees p := by
+  simp [factorDegrees_def, normalizedFactors_mul hf hg]
+
+/-- The factor degrees are read off from any factorization of the reduction into irreducibles,
+without normalizing the factors first. -/
+theorem _root_.Polynomial.factorDegrees_eq_map_natDegree_of_map_eq_prod {f : ℤ[X]} {p : ℕ}
+    [Fact p.Prime] {s : Multiset (ZMod p)[X]} (hs : ∀ q ∈ s, Irreducible q)
+    (hfs : f.map (Int.castRingHom (ZMod p)) = s.prod) :
+    f.factorDegrees p = s.map Polynomial.natDegree := by
+  rw [factorDegrees_def, hfs, normalizedFactors_prod_eq s hs, Multiset.map_map]
+  exact Multiset.map_congr rfl fun q _ ↦ Polynomial.natDegree_normalize
+
+/-- The sum of the factor degrees is the degree of the polynomial after reduction. -/
+@[simp]
+theorem _root_.Polynomial.sum_factorDegrees_eq_natDegree_map (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
+    (f.factorDegrees p).sum = (f.map (Int.castRingHom (ZMod p))).natDegree := by
+  rw [factorDegrees_def]
+  exact Polynomial.sum_natDegree_normalizedFactors _
+
+/-- For a monic polynomial, the degrees of all irreducible factors of its reduction modulo a
+prime, counted with multiplicity, sum to the degree of the original polynomial. -/
+theorem _root_.Polynomial.Monic.sum_factorDegrees {f : ℤ[X]} (hf : f.Monic) (p : ℕ)
+    [Fact p.Prime] : (f.factorDegrees p).sum = f.natDegree := by
+  rw [sum_factorDegrees_eq_natDegree_map, hf.natDegree_map]
+
+/-- If the reduction of `f` modulo `p` is irreducible, its only factor degree is its degree. -/
+theorem _root_.Polynomial.factorDegrees_eq_singleton_of_irreducible (f : ℤ[X]) (p : ℕ)
+    [Fact p.Prime] (h : Irreducible (f.map (Int.castRingHom (ZMod p)))) :
+    f.factorDegrees p = {(f.map (Int.castRingHom (ZMod p))).natDegree} := by
+  rw [factorDegrees_def]
+  exact Polynomial.map_natDegree_normalizedFactors_eq_singleton_iff.mpr h
+
+/-- A single factor degree, whatever it is, forces the reduction to be irreducible. -/
+theorem _root_.Polynomial.irreducible_map_of_card_factorDegrees_eq_one {f : ℤ[X]} {p : ℕ}
+    [Fact p.Prime] (h : (f.factorDegrees p).card = 1) :
+    Irreducible (f.map (Int.castRingHom (ZMod p))) :=
+  Polynomial.irreducible_of_card_normalizedFactors_eq_one (by simpa using h)
+
+/-- The factor degrees of `f` modulo `p` are the singleton `{n}` exactly when the reduction is
+irreducible of degree `n`. -/
+@[simp]
+theorem _root_.Polynomial.factorDegrees_eq_singleton_iff {f : ℤ[X]} {p n : ℕ}
+    [Fact p.Prime] :
+    f.factorDegrees p = {n} ↔
+      Irreducible (f.map (Int.castRingHom (ZMod p))) ∧
+        (f.map (Int.castRingHom (ZMod p))).natDegree = n := by
+  constructor
+  · intro h
+    refine ⟨irreducible_map_of_card_factorDegrees_eq_one ?_, ?_⟩
+    · simp [h]
+    · simpa using congrArg Multiset.sum h
+  · rintro ⟨hirr, hdeg⟩
+    rw [factorDegrees_eq_singleton_of_irreducible f p hirr, hdeg]
+
+/-- For a monic integral polynomial, having its own degree as sole factor degree is equivalent to
+its reduction being irreducible. -/
+theorem _root_.Polynomial.Monic.factorDegrees_eq_singleton_iff_irreducible {f : ℤ[X]}
+    (hf : f.Monic) (p : ℕ) [Fact p.Prime] :
+    f.factorDegrees p = {f.natDegree} ↔ Irreducible (f.map (Int.castRingHom (ZMod p))) := by
+  rw [factorDegrees_eq_singleton_iff, hf.natDegree_map, and_iff_left rfl]
+
+end TauCeti

--- a/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
+++ b/TauCeti/RingTheory/Polynomial/FactorDegrees.lean
@@ -23,8 +23,7 @@ and its relationship with irreducibility. Worked examples for `X ^ 5 - X - 1` ar
 ## Main declarations
 
 * `Polynomial.factorDegrees`: the multiset of factor degrees of `f` modulo `p`.
-* `Polynomial.factorDegrees_def`: the defining equation, which is the only way to unfold the
-  carrier outside this file.
+* `Polynomial.factorDegrees_def`: a convenient defining equation for the carrier.
 * `Polynomial.mem_factorDegrees_iff`: a number occurs as a factor degree exactly when it is the
   degree of a normalized irreducible factor of the reduction.
 * `Polynomial.factorDegrees_mul`: the factor degrees of a product with nonzero reductions are the
@@ -56,8 +55,7 @@ noncomputable def _root_.Polynomial.factorDegrees (f : ℤ[X]) (p : ℕ) [Fact p
   Multiset.map Polynomial.natDegree
     (normalizedFactors (f.map (Int.castRingHom (ZMod p))))
 
-/-- The defining equation for `Polynomial.factorDegrees`, which the definition itself does not
-expose outside this file. -/
+/-- A convenient defining equation for `Polynomial.factorDegrees`. -/
 theorem _root_.Polynomial.factorDegrees_def (f : ℤ[X]) (p : ℕ) [Fact p.Prime] :
     f.factorDegrees p = Multiset.map Polynomial.natDegree
       (normalizedFactors (f.map (Int.castRingHom (ZMod p)))) :=

--- a/TauCeti/RingTheory/Polynomial/Factors.lean
+++ b/TauCeti/RingTheory/Polynomial/Factors.lean
@@ -10,6 +10,7 @@ public import Mathlib.Algebra.Squarefree.Basic
 public import Mathlib.FieldTheory.Separable
 public import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
 
+import Mathlib.Algebra.Polynomial.BigOperators
 import Mathlib.RingTheory.Coprime.Lemmas
 import Mathlib.RingTheory.Ideal.Operations
 import Mathlib.RingTheory.PrincipalIdealDomain
@@ -40,6 +41,12 @@ for the Chinese Remainder decomposition of `K[X] ⧸ (f)` into the fields `K[X] 
 * `Polynomial.Factors.isCoprime`: distinct factors are coprime.
 * `Polynomial.Factors.span_eq_iInf_span`: for `f` nonzero and squarefree,
   `(f) = ⨅ p, (p)`.
+* `Polynomial.sum_natDegree_normalizedFactors`: the degrees of the normalized irreducible
+  factors, counted with multiplicity, sum to the degree.
+* `Polynomial.map_natDegree_normalizedFactors_eq_singleton_iff`: those degrees form a singleton
+  exactly when the polynomial is irreducible.
+* `Polynomial.Separable.nodup_normalizedFactors`: a separable polynomial has no repeated
+  normalized irreducible factor.
 
 ## Roadmap
 
@@ -200,6 +207,49 @@ lemma exists_dvd_map {L : Type*} [Field L] (σ : K →+* L) (hf : f ≠ 0) {q : 
   exact ⟨⟨p₀, (Polynomial.mem_normalizedFactors_iff hf).mp hp₀⟩, hgdvd⟩
 
 end Factors
+
+/-! ### Degrees of the normalized irreducible factors
+
+`Polynomial.Factors` keeps `DecidableEq K` out of its statements by working with a subtype, at
+the cost of forgetting multiplicities. The lemmas below are the counterparts for
+`normalizedFactors`, which does record them.
+-/
+
+variable [DecidableEq K]
+
+/-- The degrees of the normalized irreducible factors of a polynomial over a field, counted with
+multiplicity, sum to its degree. -/
+lemma sum_natDegree_normalizedFactors (g : K[X]) :
+    ((normalizedFactors g).map natDegree).sum = g.natDegree := by
+  by_cases hg : g = 0
+  · simp [hg]
+  · rw [← natDegree_multiset_prod _ (zero_notMem_normalizedFactors g)]
+    exact natDegree_eq_of_degree_eq (degree_eq_degree_of_associated (prod_normalizedFactors hg))
+
+/-- A polynomial over a field with exactly one normalized irreducible factor, counted with
+multiplicity, is irreducible. -/
+lemma irreducible_of_card_normalizedFactors_eq_one {g : K[X]}
+    (h : (normalizedFactors g).card = 1) : Irreducible g := by
+  obtain ⟨q, hq⟩ := Multiset.card_eq_one.mp h
+  have hg : g ≠ 0 := by rintro rfl; simp at h
+  have hprod := prod_normalizedFactors hg
+  rw [hq, Multiset.prod_singleton] at hprod
+  exact hprod.irreducible
+    (irreducible_of_normalized_factor q (hq ▸ Multiset.mem_singleton_self q))
+
+/-- The degrees of the normalized irreducible factors of a polynomial over a field form the
+singleton `{g.natDegree}` exactly when the polynomial is irreducible. -/
+lemma map_natDegree_normalizedFactors_eq_singleton_iff {g : K[X]} :
+    (normalizedFactors g).map natDegree = {g.natDegree} ↔ Irreducible g := by
+  refine ⟨fun h ↦ irreducible_of_card_normalizedFactors_eq_one ?_, fun h ↦ ?_⟩
+  · simpa using congrArg Multiset.card h
+  · rw [normalizedFactors_irreducible h, Multiset.map_singleton, natDegree_normalize]
+
+/-- The normalized irreducible factors of a separable polynomial over a field are pairwise
+distinct: separability is exactly what rules out a repeated factor. -/
+lemma Separable.nodup_normalizedFactors {g : K[X]} (hg : g.Separable) :
+    (normalizedFactors g).Nodup :=
+  (squarefree_iff_nodup_normalizedFactors hg.ne_zero).mp hg.squarefree
 
 end Polynomial
 

--- a/TauCeti/RingTheory/Polynomial/Factors.lean
+++ b/TauCeti/RingTheory/Polynomial/Factors.lean
@@ -45,8 +45,6 @@ for the Chinese Remainder decomposition of `K[X] ⧸ (f)` into the fields `K[X] 
   factors, counted with multiplicity, sum to the degree.
 * `Polynomial.map_natDegree_normalizedFactors_eq_singleton_iff`: those degrees form a singleton
   exactly when the polynomial is irreducible.
-* `Polynomial.Separable.nodup_normalizedFactors`: a separable polynomial has no repeated
-  normalized irreducible factor.
 
 ## Roadmap
 
@@ -239,17 +237,12 @@ lemma irreducible_of_card_normalizedFactors_eq_one {g : K[X]}
 
 /-- The degrees of the normalized irreducible factors of a polynomial over a field form the
 singleton `{g.natDegree}` exactly when the polynomial is irreducible. -/
+@[simp]
 lemma map_natDegree_normalizedFactors_eq_singleton_iff {g : K[X]} :
     (normalizedFactors g).map natDegree = {g.natDegree} ↔ Irreducible g := by
   refine ⟨fun h ↦ irreducible_of_card_normalizedFactors_eq_one ?_, fun h ↦ ?_⟩
   · simpa using congrArg Multiset.card h
   · rw [normalizedFactors_irreducible h, Multiset.map_singleton, natDegree_normalize]
-
-/-- The normalized irreducible factors of a separable polynomial over a field are pairwise
-distinct: separability is exactly what rules out a repeated factor. -/
-lemma Separable.nodup_normalizedFactors {g : K[X]} (hg : g.Separable) :
-    (normalizedFactors g).Nodup :=
-  (squarefree_iff_nodup_normalizedFactors hg.ne_zero).mp hg.squarefree
 
 end Polynomial
 

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -57,7 +57,7 @@ separable.
   `Polynomial.Monic.discr_ne_zero_iff_separable_map`: a monic polynomial is separable exactly
   when its discriminant is a unit; over a field that reads `discr f ≠ 0`, and over a domain the
   correct statement passes to the fraction field.
-* `Polynomial.Monic.separable_map_iff_discr_ne_zero`,
+* `Polynomial.Monic.separable_map_iff_map_discr_ne_zero`,
   `Polynomial.Monic.separable_map_zmod_iff_not_dvd_discr`,
   `Polynomial.Monic.nodup_normalizedFactors_map_zmod_of_not_dvd_discr`: the same criterion read
   along a ring homomorphism into a field, and its specialization to reduction of an integral
@@ -504,7 +504,8 @@ theorem _root_.Polynomial.Monic.discrSqrt_ne_zero {F E : Type*} [CommRing F] [Co
 /-- A monic polynomial becomes separable along a ring homomorphism into a field exactly when its
 discriminant does not become zero. No injectivity is needed: the discriminant commutes with base
 change because monicity preserves the degree. -/
-theorem _root_.Polynomial.Monic.separable_map_iff_discr_ne_zero {K : Type*} [Field K] {f : R[X]}
+theorem _root_.Polynomial.Monic.separable_map_iff_map_discr_ne_zero {K : Type*} [Field K]
+    {f : R[X]}
     (hf : f.Monic) (φ : R →+* K) : (f.map φ).Separable ↔ φ f.discr ≠ 0 := by
   rw [← (hf.map φ).discr_ne_zero_iff, hf.discr_map]
 
@@ -515,7 +516,7 @@ formulated after passage to a fraction field. -/
 theorem _root_.Polynomial.Monic.discr_ne_zero_iff_separable_map (K : Type*) [Field K]
     [Algebra R K] [IsFractionRing R K] {f : R[X]} (hf : f.Monic) :
     f.discr ≠ 0 ↔ (f.map (algebraMap R K)).Separable := by
-  rw [hf.separable_map_iff_discr_ne_zero, map_ne_zero_iff _
+  rw [hf.separable_map_iff_map_discr_ne_zero, map_ne_zero_iff _
     (FaithfulSMul.algebraMap_injective R K)]
 
 /-- A monic integral polynomial has separable reduction modulo a prime exactly when that prime
@@ -523,7 +524,7 @@ does not divide its discriminant. -/
 theorem _root_.Polynomial.Monic.separable_map_zmod_iff_not_dvd_discr {f : ℤ[X]} (hf : f.Monic)
     (p : ℕ) [Fact p.Prime] :
     (f.map (Int.castRingHom (ZMod p))).Separable ↔ ¬ (p : ℤ) ∣ f.discr := by
-  rw [hf.separable_map_iff_discr_ne_zero, Int.coe_castRingHom, ne_eq,
+  rw [hf.separable_map_iff_map_discr_ne_zero, Int.coe_castRingHom, ne_eq,
     ZMod.intCast_zmod_eq_zero_iff_dvd]
 
 /-- At a prime not dividing the discriminant of a monic integral polynomial, the normalized

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.CubicDiscriminant
+public import Mathlib.Algebra.Field.ZMod
 import Mathlib.Algebra.MvPolynomial.Basic
 public import Mathlib.Algebra.Order.BigOperators.Group.LocallyFinite
 import Mathlib.Data.Nat.Choose.Vandermonde
@@ -14,6 +15,7 @@ public import Mathlib.GroupTheory.Perm.Fin
 public import Mathlib.RingTheory.Discriminant
 public import Mathlib.RingTheory.Localization.FractionRing
 public import Mathlib.RingTheory.Polynomial.Resultant.Basic
+import TauCeti.RingTheory.Polynomial.Factors
 import TauCeti.RingTheory.Polynomial.Resultant.Basic
 import TauCeti.RingTheory.Polynomial.Roots
 
@@ -55,6 +57,12 @@ separable.
   `Polynomial.Monic.discr_ne_zero_iff_separable_map`: a monic polynomial is separable exactly
   when its discriminant is a unit; over a field that reads `discr f ≠ 0`, and over a domain the
   correct statement passes to the fraction field.
+* `Polynomial.Monic.separable_map_iff_discr_ne_zero`,
+  `Polynomial.Monic.separable_map_zmod_iff_not_dvd_discr`,
+  `Polynomial.Monic.nodup_normalizedFactors_map_zmod_of_not_dvd_discr`: the same criterion read
+  along a ring homomorphism into a field, and its specialization to reduction of an integral
+  polynomial modulo a prime, where it says that a prime not dividing the discriminant gives a
+  separable, hence repetition-free, factorization.
 * `Cubic.toPoly_discr`: the two discriminants of a cubic with nonzero leading coefficient agree,
   so that `Cubic.discr` and `Polynomial.discr` may be used interchangeably in degree three.
 * `Algebra.discr_powerBasis_eq_minpoly_discr`: the algebra discriminant of a power basis agrees
@@ -493,6 +501,13 @@ theorem _root_.Polynomial.Monic.discrSqrt_ne_zero {F E : Type*} [CommRing F] [Co
   apply ((hf.isUnit_discr_iff.mpr hsep).map (algebraMap F E)).ne_zero
   rw [← hf.discrSqrt_sq hsep e, h, zero_pow two_ne_zero]
 
+/-- A monic polynomial becomes separable along a ring homomorphism into a field exactly when its
+discriminant does not become zero. No injectivity is needed: the discriminant commutes with base
+change because monicity preserves the degree. -/
+theorem _root_.Polynomial.Monic.separable_map_iff_discr_ne_zero {K : Type*} [Field K] {f : R[X]}
+    (hf : f.Monic) (φ : R →+* K) : (f.map φ).Separable ↔ φ f.discr ≠ 0 := by
+  rw [← (hf.map φ).discr_ne_zero_iff, hf.discr_map]
+
 /-- Over a domain, the discriminant of a monic polynomial is nonzero exactly when the polynomial
 becomes separable over the fraction field: over a domain the separability criterion is the one
 formulated after passage to a fraction field. -/
@@ -500,8 +515,24 @@ formulated after passage to a fraction field. -/
 theorem _root_.Polynomial.Monic.discr_ne_zero_iff_separable_map (K : Type*) [Field K]
     [Algebra R K] [IsFractionRing R K] {f : R[X]} (hf : f.Monic) :
     f.discr ≠ 0 ↔ (f.map (algebraMap R K)).Separable := by
-  rw [← (hf.map (algebraMap R K)).discr_ne_zero_iff, hf.discr_map,
-    map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective R K)]
+  rw [hf.separable_map_iff_discr_ne_zero, map_ne_zero_iff _
+    (FaithfulSMul.algebraMap_injective R K)]
+
+/-- A monic integral polynomial has separable reduction modulo a prime exactly when that prime
+does not divide its discriminant. -/
+theorem _root_.Polynomial.Monic.separable_map_zmod_iff_not_dvd_discr {f : ℤ[X]} (hf : f.Monic)
+    (p : ℕ) [Fact p.Prime] :
+    (f.map (Int.castRingHom (ZMod p))).Separable ↔ ¬ (p : ℤ) ∣ f.discr := by
+  rw [hf.separable_map_iff_discr_ne_zero, Int.coe_castRingHom, ne_eq,
+    ZMod.intCast_zmod_eq_zero_iff_dvd]
+
+/-- At a prime not dividing the discriminant of a monic integral polynomial, the normalized
+irreducible factors of its reduction modulo that prime have no repetitions: the factorization is
+squarefree. -/
+theorem _root_.Polynomial.Monic.nodup_normalizedFactors_map_zmod_of_not_dvd_discr {f : ℤ[X]}
+    (hf : f.Monic) (p : ℕ) [Fact p.Prime] (hp : ¬ (p : ℤ) ∣ f.discr) :
+    (UniqueFactorizationMonoid.normalizedFactors (f.map (Int.castRingHom (ZMod p)))).Nodup :=
+  ((hf.separable_map_zmod_iff_not_dvd_discr p).mpr hp).nodup_normalizedFactors
 
 /-! ### The discriminant of a power basis -/
 

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -15,7 +15,6 @@ public import Mathlib.GroupTheory.Perm.Fin
 public import Mathlib.RingTheory.Discriminant
 public import Mathlib.RingTheory.Localization.FractionRing
 public import Mathlib.RingTheory.Polynomial.Resultant.Basic
-import TauCeti.RingTheory.Polynomial.Factors
 import TauCeti.RingTheory.Polynomial.Resultant.Basic
 import TauCeti.RingTheory.Polynomial.Roots
 
@@ -58,11 +57,9 @@ separable.
   when its discriminant is a unit; over a field that reads `discr f ≠ 0`, and over a domain the
   correct statement passes to the fraction field.
 * `Polynomial.Monic.separable_map_iff_map_discr_ne_zero`,
-  `Polynomial.Monic.separable_map_zmod_iff_not_dvd_discr`,
-  `Polynomial.Monic.nodup_normalizedFactors_map_zmod_of_not_dvd_discr`: the same criterion read
-  along a ring homomorphism into a field, and its specialization to reduction of an integral
-  polynomial modulo a prime, where it says that a prime not dividing the discriminant gives a
-  separable, hence repetition-free, factorization.
+  `Polynomial.Monic.separable_map_zmod_iff_not_dvd_discr`: the same criterion read along a ring
+  homomorphism into a field, and its specialization to reduction of an integral polynomial modulo
+  a prime.
 * `Cubic.toPoly_discr`: the two discriminants of a cubic with nonzero leading coefficient agree,
   so that `Cubic.discr` and `Polynomial.discr` may be used interchangeably in degree three.
 * `Algebra.discr_powerBasis_eq_minpoly_discr`: the algebra discriminant of a power basis agrees
@@ -526,14 +523,6 @@ theorem _root_.Polynomial.Monic.separable_map_zmod_iff_not_dvd_discr {f : ℤ[X]
     (f.map (Int.castRingHom (ZMod p))).Separable ↔ ¬ (p : ℤ) ∣ f.discr := by
   rw [hf.separable_map_iff_map_discr_ne_zero, Int.coe_castRingHom, ne_eq,
     ZMod.intCast_zmod_eq_zero_iff_dvd]
-
-/-- At a prime not dividing the discriminant of a monic integral polynomial, the normalized
-irreducible factors of its reduction modulo that prime have no repetitions: the factorization is
-squarefree. -/
-theorem _root_.Polynomial.Monic.nodup_normalizedFactors_map_zmod_of_not_dvd_discr {f : ℤ[X]}
-    (hf : f.Monic) (p : ℕ) [Fact p.Prime] (hp : ¬ (p : ℤ) ∣ f.discr) :
-    (UniqueFactorizationMonoid.normalizedFactors (f.map (Int.castRingHom (ZMod p)))).Nodup :=
-  ((hf.separable_map_zmod_iff_not_dvd_discr p).mpr hp).nodup_normalizedFactors
 
 /-! ### The discriminant of a power basis -/
 

--- a/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean
@@ -501,6 +501,7 @@ theorem _root_.Polynomial.Monic.discrSqrt_ne_zero {F E : Type*} [CommRing F] [Co
 /-- A monic polynomial becomes separable along a ring homomorphism into a field exactly when its
 discriminant does not become zero. No injectivity is needed: the discriminant commutes with base
 change because monicity preserves the degree. -/
+@[simp]
 theorem _root_.Polynomial.Monic.separable_map_iff_map_discr_ne_zero {K : Type*} [Field K]
     {f : R[X]}
     (hf : f.Monic) (φ : R →+* K) : (f.map φ).Separable ↔ φ f.discr ≠ 0 := by
@@ -518,6 +519,10 @@ theorem _root_.Polynomial.Monic.discr_ne_zero_iff_separable_map (K : Type*) [Fie
 
 /-- A monic integral polynomial has separable reduction modulo a prime exactly when that prime
 does not divide its discriminant. -/
+-- Tagged `@[simp high]` rather than `@[simp]`: at the default priority the general
+-- `Monic.separable_map_iff_map_discr_ne_zero` rewrites this left-hand side first, so the prime
+-- divisibility form would not be the simp normal form.
+@[simp high]
 theorem _root_.Polynomial.Monic.separable_map_zmod_iff_not_dvd_discr {f : ℤ[X]} (hf : f.Monic)
     (p : ℕ) [Fact p.Prime] :
     (f.map (Int.castRingHom (ZMod p))).Separable ↔ ¬ (p : ℤ) ∣ f.discr := by


### PR DESCRIPTION
This PR introduces `Polynomial.factorDegrees`, the multiset of degrees of normalized irreducible factors of an integral polynomial after reduction modulo a prime.

It supplies the carrier and basic API requested by PolynomialGaloisGroups Layer 5, “Frobenius specialization”: characterize membership, positivity, and cardinality; prove product and total-degree laws; read the factor degrees off any factorization of the reduction into irreducibles; and characterize singleton patterns by irreducibility. It also verifies the roadmap factor pattern `{3, 2}` for `X^5 - X - 1` modulo `2`, together with the two irreducibility facts over `ZMod 2` that it rests on.

Two supporting files are extended rather than duplicated:

* `TauCeti/RingTheory/Polynomial/Factors.lean` gains the field-level facts the carrier specializes: `Polynomial.sum_natDegree_normalizedFactors`, `Polynomial.irreducible_of_card_normalizedFactors_eq_one`, `Polynomial.map_natDegree_normalizedFactors_eq_singleton_iff`.
* `TauCeti/RingTheory/Polynomial/Resultant/Discriminant.lean` gains `Polynomial.Monic.separable_map_iff_map_discr_ne_zero`, the separability criterion read along an arbitrary ring homomorphism into a field (the existing `Monic.discr_ne_zero_iff_separable_map` is now derived from it), and its consequence for reduction modulo a prime: a prime away from the discriminant of a monic polynomial gives separable reduction.

Use this API as the polynomial-side datum in the forthcoming Dedekind/Frobenius cycle-type comparison. What remains after this PR is the modulo-5 example, the good-prime predicates, the finite-field Frobenius orbit-size theorem, and—after the NumberFieldArithmetic Layer 3.10 supplier lands—the abbreviated Dedekind contract and membership consequences.

Roadmap: PolynomialGaloisGroups

<!--tauceti-target:v1 {"focus":"PolynomialGaloisGroups","id":"factor-degrees"}-->

🤖 Prepared with Codex

