### PR TITLE
feat(ArithmeticDirichletSeries): a unitary weight is bounded by one everywhere

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -613,11 +613,10 @@ theorem norm_eq_one (χ : UnitaryIdealWeight K) {I : Ideal (𝓞 K)} (hI : χ.1.
   refine hI.induction_on (by simp) fun 𝔭 J h𝔭 _ ih ↦ ?_
   rw [map_mul, norm_mul, χ.2 𝔭 h𝔭, ih, one_mul]
 
-/-- **A unitary weight is bounded by one on every ideal.** On a good ideal the modulus is exactly
-`1`; on a bad one the weight vanishes, by `apply_eq_zero_iff_not_isGood`. The bound therefore
-carries no goodness hypothesis, which is the form a convergence comparison wants: such a
-comparison is indexed by all of `(Ideal (𝓞 K))⁰`, so it can apply this bound termwise, where
-`norm_eq_one` would oblige every call site to split that index type first. -/
+/-- **A unitary weight is bounded by one on every ideal.** The bound is unconditional: it carries
+no goodness hypothesis, so a comparison indexed by all of `(Ideal (𝓞 K))⁰` can apply it termwise.
+`norm_eq_one` is sharper where it applies, but obliges the caller to split that index type first;
+this is the form a convergence estimate wants. -/
 theorem norm_le_one (χ : UnitaryIdealWeight K) (I : Ideal (𝓞 K)) : ‖χ.1 I‖ ≤ 1 := by
   by_cases hI : χ.1.IsGood I
   · exact (norm_eq_one χ hI).le

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -614,11 +614,10 @@ theorem norm_eq_one (χ : UnitaryIdealWeight K) {I : Ideal (𝓞 K)} (hI : χ.1.
   rw [map_mul, norm_mul, χ.2 𝔭 h𝔭, ih, one_mul]
 
 /-- **A unitary weight is bounded by one on every ideal.** On a good ideal the modulus is exactly
-`1`; on a bad one the weight vanishes, by `apply_eq_zero_iff_not_isGood`. So a unitary weight is
-bounded everywhere without any goodness hypothesis, which is the form a convergence comparison
-wants: such a comparison is indexed by all of `(Ideal (𝓞 K))⁰` and cannot use a bound that holds
-only away from the bad primes, since splitting the sum there would mean redoing the
-finite-exceptional-set argument at every call site. -/
+`1`; on a bad one the weight vanishes, by `apply_eq_zero_iff_not_isGood`. The bound therefore
+carries no goodness hypothesis, which is the form a convergence comparison wants: such a
+comparison is indexed by all of `(Ideal (𝓞 K))⁰`, so it can apply this bound termwise, where
+`norm_eq_one` would oblige every call site to split that index type first. -/
 theorem norm_le_one (χ : UnitaryIdealWeight K) (I : Ideal (𝓞 K)) : ‖χ.1 I‖ ≤ 1 := by
   by_cases hI : χ.1.IsGood I
   · exact (norm_eq_one χ hI).le

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -616,8 +616,9 @@ theorem norm_eq_one (χ : UnitaryIdealWeight K) {I : Ideal (𝓞 K)} (hI : χ.1.
 /-- **A unitary weight is bounded by one on every ideal.** On a good ideal the modulus is exactly
 `1`; on a bad one the weight vanishes, by `apply_eq_zero_iff_not_isGood`. So a unitary weight is
 bounded everywhere without any goodness hypothesis, which is the form a convergence comparison
-wants — `summable_idealTerm_of_norm_le_of_one_lt_re` asks for a bound on all of `(Ideal (𝓞 K))⁰`
-and cannot be handed one that holds only away from the bad primes. -/
+wants: such a comparison is indexed by all of `(Ideal (𝓞 K))⁰` and cannot use a bound that holds
+only away from the bad primes, since splitting the sum there would mean redoing the
+finite-exceptional-set argument at every call site. -/
 theorem norm_le_one (χ : UnitaryIdealWeight K) (I : Ideal (𝓞 K)) : ‖χ.1 I‖ ≤ 1 := by
   by_cases hI : χ.1.IsGood I
   · exact (norm_eq_one χ hI).le

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -613,6 +613,12 @@ theorem norm_eq_one (χ : UnitaryIdealWeight K) {I : Ideal (𝓞 K)} (hI : χ.1.
   refine hI.induction_on (by simp) fun 𝔭 J h𝔭 _ ih ↦ ?_
   rw [map_mul, norm_mul, χ.2 𝔭 h𝔭, ih, one_mul]
 
+-- Source. The statement and its proof follow `DirichletCharacter.norm_le_one` in Mathlib's
+-- `Mathlib/NumberTheory/DirichletCharacter/Bounds.lean`, transposed from a Dirichlet character on
+-- `ZMod n` to a unitary ideal weight: the case split there is on `IsUnit a` and closes with
+-- `map_nonunit`, here it is on `MultiplicativeIdealWeight.IsGood` and closes with
+-- `apply_eq_zero_iff_not_isGood`.
+
 /-- **A unitary weight is bounded by one on every ideal.** The bound is unconditional: it carries
 no goodness hypothesis, so a comparison indexed by all of `(Ideal (𝓞 K))⁰` can apply it termwise.
 `norm_eq_one` is sharper where it applies, but obliges the caller to split that index type first;

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -613,6 +613,17 @@ theorem norm_eq_one (χ : UnitaryIdealWeight K) {I : Ideal (𝓞 K)} (hI : χ.1.
   refine hI.induction_on (by simp) fun 𝔭 J h𝔭 _ ih ↦ ?_
   rw [map_mul, norm_mul, χ.2 𝔭 h𝔭, ih, one_mul]
 
+/-- **A unitary weight is bounded by one on every ideal.** On a good ideal the modulus is exactly
+`1`; on a bad one the weight vanishes, by `apply_eq_zero_iff_not_isGood`. So a unitary weight is
+bounded everywhere without any goodness hypothesis, which is the form a convergence comparison
+wants — `summable_idealTerm_of_norm_le_of_one_lt_re` asks for a bound on all of `(Ideal (𝓞 K))⁰`
+and cannot be handed one that holds only away from the bad primes. -/
+theorem norm_le_one (χ : UnitaryIdealWeight K) (I : Ideal (𝓞 K)) : ‖χ.1 I‖ ≤ 1 := by
+  by_cases hI : χ.1.IsGood I
+  · exact (norm_eq_one χ hI).le
+  · rw [(MultiplicativeIdealWeight.apply_eq_zero_iff_not_isGood χ.1 I).mpr hI, norm_zero]
+    exact zero_le_one
+
 /-- The trivial weight is unitary. -/
 noncomputable instance : One (UnitaryIdealWeight K) :=
   ⟨1, fun 𝔭 _ ↦ by simp [MultiplicativeIdealWeight.one_apply, 𝔭.ne_bot]⟩


### PR DESCRIPTION
A unitary ideal weight is bounded by one on *every* ideal, not just the good ones:

```lean
theorem TauCeti.UnitaryIdealWeight.norm_le_one (χ : UnitaryIdealWeight K) (I : Ideal (𝓞 K)) :
    ‖χ.1 I‖ ≤ 1
```

`UnitaryIdealWeight.norm_eq_one` already gives modulus exactly one on the good ideals. At a bad
ideal the weight vanishes — `MultiplicativeIdealWeight.apply_eq_zero_iff_not_isGood` — so the
inequality holds there too, and the combined statement needs no goodness hypothesis.

### Why the unconditional form is the useful one

`norm_eq_one` cannot be handed to a convergence comparison. Such a comparison asks for a bound on
the whole index type `(Ideal (𝓞 K))⁰`, and a hypothesis that holds only away from the bad primes
would force every caller to split the sum and redo the finite-exceptional-set argument. The bad
primes are exactly where a unitary weight is *most* convenient — it is zero there — so the bound is
easiest to state without the side condition, not hardest.

Four lines, by cases on `IsGood`.

### Absence

Nothing in `TauCeti/NumberTheory/ArithmeticDirichletSeries/` relates a unitary weight to a bound on
all ideals; `norm_eq_one` (good ideals, equality) and `norm_normTwist` (good ideals, under a norm
twist) are the neighbouring statements, and both carry the goodness hypothesis this one drops.

`CBirkbeck/chebotarev-density` at `8575c9df` has no unitary-weight abstraction at all — `unitary`
and `UnitaryIdealWeight` return zero files — so there is nothing there to adapt. **No `Provenance`
line is owed.**

Roadmap: ArithmeticDirichletSeries

No `tauceti-target:v1` marker: this extends an existing lemma from the good ideals to all ideals,
which is improvement of existing code rather than the authoring of a roadmap target.

### On the cleanup pass

`lean-lsp` has been unreachable for this whole session, so `/cleanup`'s phases 6.5 and 6.6 were
discharged directly. `#lint in TauCeti.NumberTheory.ArithmeticDirichletSeries.Weight` reports
**0 errors in 107 declarations with all 15 linters**. Axioms are exactly `propext`,
`Classical.choice` and `Quot.sound`; every line is within 100 characters; the proof is 4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF
