### PR TITLE
doc: close out Cloudflare cache migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,8 @@ jobs:
           fi
 
       # Anonymous GETs from the PUBLIC read host, the same trusted, publisher-built data
-      # pr-build restores. The shared script discards a partial fetch rather than keeping it;
-      # see its header.
+      # pr-build restores. The shared script retains hash-verified artifacts between attempts,
+      # then discards the partial cache only if every attempt remains incomplete; see its header.
       #
       # What this does NOT establish: that a restored module matches what a compile of the
       # checked-out source would produce. Lake keys artifacts by an input hash that is a single

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -623,10 +623,10 @@ jobs:
             echo "::notice::merge-group outputs will be staged for pre-landing publication"
           fi
 
-      # Restore TauCeti's own root-package oleans from the public Lake cache. The fetch logic
-      # (retry-from-empty, then fall back to no cache at all) lives in the workflow-pinned
-      # trusted script so ci.yml's post-merge build can restore the very same way; see its
-      # header for why a partial fetch must be discarded rather than kept.
+      # Restore TauCeti's own root-package oleans from the public Lake cache. The workflow-pinned
+      # trusted script retains hash-verified artifacts between attempts and retries only missing
+      # downloads. If all attempts remain incomplete, it discards the partial cache and falls
+      # back to no cache so ci.yml's post-merge build has the same final semantics.
       - name: Fetch TauCeti's own oleans from the Lake cache (network, no token; no PR code)
         if: ${{ env.INFRA != '1' && env.TAUCETI_CACHE_ENABLED == '1' }}
         env:

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -51,10 +51,10 @@ wiring when the pinned cache tool drops the flag.
 
 ## Cloudflare account
 
-This table records the required destination. During the 2026 account migration,
-the live cache and repository variables remain on the older personal account
-until the destination copy has passed verification and the upload key is
-rotated in the same cutover.
+The 2026 account migration is complete. The live bucket, zone, custom domain,
+repository variables, and publisher credential are all in the dedicated
+TauCeti account. The source bucket in the personal account was deleted after
+anonymous reads and an exact trusted publication succeeded.
 
 | | |
 |---|---|
@@ -85,6 +85,20 @@ to sign them, so the read host must be public; only uploads use a key.
 Lake service names: `tauceti-public` for reads, `tauceti-r2` for uploads. Object keys are
 `artifacts/TauCetiProject/TauCeti/<hash>.art`, so the endpoint variables hold only the prefix and
 Lake appends the scope.
+
+## Publisher credential
+
+The GitHub Actions secret `LAKE_CACHE_KEY` contains the S3 access-key pair for
+the non-expiring Cloudflare token named **TauCeti Lake cache R2 publisher**.
+The token belongs to the `tauceti` account and is restricted to object
+read/write/list access in `tauceti-cache`; it has no bucket-administration,
+Worker, DNS, Registrar, or billing authority.
+
+When rotating it, create the replacement in the `tauceti` account, install the
+new `<ACCESS_KEY_ID>:<SECRET_ACCESS_KEY>` pair as `LAKE_CACHE_KEY`, and let an
+isolated `publish-lake-cache` job publish an exact revision before revoking the
+old token. Do not put the token value in a repository variable or expose it to
+the build job.
 
 ## Contributors
 
@@ -257,8 +271,9 @@ Analytics says how much of the 27M is still reaching the bucket.
 
 ## Related
 
-- `pr-build.yml` retries a partial fetch and discards the cache rather than handing it to the
-  offline sandbox. See the comment at that step for when part of it can be simplified.
+- `scripts/lake-cache-get.sh` keeps hash-verified artifacts while retrying only
+  missing downloads. If all three attempts remain incomplete, it discards the
+  partial cache rather than handing it to the offline sandbox.
 - https://github.com/leanprover/lean4/issues/14670, open: Lake fails a build over a cache miss it
   has already recovered from.
 - https://github.com/leanprover/lean4/pull/14651, merged: `lake cache get` exit status was


### PR DESCRIPTION
## Summary

- record that the TauCeti R2 cache, zone, custom domain, variables, and publisher now live in the dedicated account
- document the least-privilege publisher credential and rotation sequence
- update workflow comments and cache documentation to match retained verified artifacts across retries

This changes comments and documentation only; cache behavior is unchanged.

## Verification

- parsed `.github/workflows/ci.yml` and `.github/workflows/pr-build.yml` as YAML
- `git diff --check`

Roadmap: none
