### PR TITLE
feat(Isogeny): module-finiteness of the intermediate ring without separability

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
@@ -52,8 +52,9 @@ so the hypothesis is now gone from the statement.
 **The sibling `Finite.lean` still carries it, and no longer for a shared reason.**
 `Isogeny.moduleFinite_intermediateRing` concludes that `φ.intermediateRing` is a finite
 `W₂.CoordinateRing`-module, and Krull–Akizuki does not supply that: the integral closure it
-produces is Noetherian but need not be a finite module. Removing separability there is a
-normalization-finiteness question of Nagata type, separate from this one.
+produces is Noetherian but need not be a finite module. Separability is not needed for that
+conclusion either: `IsIntegralClosure.finite_of_fraction_model` supplies module-finiteness without
+a trace form, and `Isogeny.moduleFinite_intermediateRing_of_isDedekindDomain` is what uses it.
 
 `IsDedekindDomain W₂.CoordinateRing` is taken as a hypothesis rather than derived. For an elliptic
 curve it is supplied by `WeierstrassCurve.Affine.isDedekindDomain_coordinateRing`, which needs

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Finite.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Finite.lean
@@ -8,29 +8,42 @@ module
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Basic
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
 public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
+import TauCeti.RingTheory.IntegralClosure.FinitePolynomialModel
+import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.CoordinateRing
 
 /-!
 # The intermediate ring is module-finite over the target coordinate ring
 
-For an isogeny with separable function-field extension and integrally closed target coordinate
-ring, `φ.intermediateRing` is a finite `W₂.CoordinateRing`-module. This is the finiteness that the
+`φ.intermediateRing` is a finite `W₂.CoordinateRing`-module. This is the finiteness that the
 relative ideal norm — and through it `pushClass` and the induced map on points — needs.
 
-**Separability is a limitation of the available proof, not of the result.** The statement is
-expected to hold without it: `W₂.CoordinateRing` is a finitely generated domain over `F` and
-`W₁.FunctionField` is finite over `W₂.FunctionField`, so Noether's finiteness theorem gives
-module-finiteness of the integral closure, Frobenius included. What forces the hypothesis here is
-that the only route Mathlib provides is `IsIntegralClosure.finite`, whose section carries
-`[Algebra.IsSeparable K L]` because it argues through the trace pairing, and the trace form is
-nondegenerate exactly for separable extensions. The general case needs a different argument —
-excellence, or N-2 finiteness for finitely generated algebras over a field — which is not available
-upstream and is left as separate work.
+Two routes reach it, with incomparable hypotheses.
+
+* A **Dedekind source coordinate ring** needs no separability at all, Frobenius included.
+  `W₁.CoordinateRing` is of finite type over `F` and its fraction field is exactly
+  `W₁.FunctionField`, so being Dedekind makes it its own fraction model, and every one of its
+  elements is integral over `W₂.CoordinateRing` because an isogeny maps infinity to infinity;
+  `IsIntegralClosure.finite_of_fraction_model` then applies. An elliptic source curve is the
+  case of interest, and supplies the Dedekind hypothesis.
+* A **separable function-field extension** over an integrally closed `W₂.CoordinateRing` reaches
+  it through Mathlib's `IsIntegralClosure.finite` directly. That asks nothing of `W₁` beyond the
+  isogeny, so it still serves sources whose coordinate ring is not Dedekind.
+
+Why the two routes differ in this hypothesis is worth stating, since it is exactly Frobenius that
+fails to be separable and Frobenius is the case `pushClass` needs. `IsIntegralClosure.finite`
+carries `[Algebra.IsSeparable K L]` because it argues through the trace pairing, whose form is
+nondegenerate only in the separable case. The fraction-model route instead adjoins the finitely
+many generators of `W₁.CoordinateRing` and uses that an overring of a Dedekind domain inside its
+own fraction field is integrally closed; no trace form is built, so separability never arises.
 
 ## Main results
 
-* `TauCeti.Isogeny.moduleFinite_intermediateRing`: `φ.intermediateRing` is module-finite over
-  `W₂.CoordinateRing`, for an integrally closed `W₂.CoordinateRing` and separable function-field
-  extension.
+* `TauCeti.Isogeny.moduleFinite_intermediateRing_of_isDedekindDomain`: `φ.intermediateRing` is
+  module-finite over `W₂.CoordinateRing` for a Dedekind source coordinate ring, with no
+  separability hypothesis, and `TauCeti.Isogeny.moduleFinite_intermediateRing_of_isElliptic` for
+  an elliptic source curve.
+* `TauCeti.Isogeny.moduleFinite_intermediateRing`: the same conclusion for an integrally closed
+  `W₂.CoordinateRing` and separable function-field extension.
 
 ## Design
 
@@ -55,11 +68,17 @@ repository's convention for adapted material and matching `IntermediateRing/Basi
 *assumes* the integral-closure property that `isIntegralClosure_intermediateRing` proves, and
 assumes the finite-dimensionality that `Isogeny.finiteDimensional_functionField` derives.
 
-⚠ *mathlib-track*. `TauCetiRoadmap/EllipticCurves/README.md` also pins D. Angdinata's shared
-isogeny development as carrying both the function-field form of `finiteDimensional` and the
-intermediate ring with its finiteness, under the same flag the sibling `Isogeny` files carry. What
-is built here rather than taken from either source is the reduction to `intermediateRing` as this
-repository defines it, through the corestricted pullback.
+The separability-free route follows D. K. Angdinata's `Isogeny.lean`, Apache-2.0, supplied by the
+author on 2026-09-07, whose `intermediateRingFinite` is the same conclusion reached by feeding an
+isogeny's `mapsInfinity` into what is here
+`IsIntegralClosure.finite_of_polynomial_model`. The route taken here differs, and is shorter: that
+source keeps the curves general and therefore needs a *polynomial* model on a coordinate line,
+which forces a case split on whether `W₁.polynomial`'s derivative vanishes — the `x`-coordinate
+when it does not, and a `y`-coordinate fallback in the degenerate characteristic-two case, each
+with its own separability lemma. Assuming `[W₁.IsElliptic]` instead makes `W₁.CoordinateRing`
+itself a Dedekind domain whose fraction field is already `W₁.FunctionField`, so
+`IsIntegralClosure.finite_of_fraction_model` applies with no model, no case split and no
+separability lemma at all.
 -/
 
 public section
@@ -94,6 +113,43 @@ theorem moduleFinite_intermediateRing (φ : Isogeny W₁ W₂)
   have := φ.finiteDimensional_functionField (φ.algebraMap_functionField_eq_fieldPullback h)
   exact IsIntegralClosure.finite W₂.CoordinateRing W₂.FunctionField W₁.FunctionField
     φ.intermediateRing
+
+/-- **The intermediate ring is module-finite over the target coordinate ring, with no separability
+hypothesis**, so this covers Frobenius. `W₁.CoordinateRing` is of finite type over `F` with
+`W₁.FunctionField` as its fraction field, so being a Dedekind domain makes it its own fraction
+model, and `φ.mapsInfinity` makes each of its elements integral over `W₂.CoordinateRing`.
+
+Unlike the sibling `moduleFinite_intermediateRing`, integral closedness of `W₂.CoordinateRing` is
+not needed either: the fraction-model route never asks the base to be normal. -/
+theorem moduleFinite_intermediateRing_of_isDedekindDomain (φ : Isogeny W₁ W₂)
+    [IsDedekindDomain W₁.CoordinateRing]
+    [inst : Algebra W₂.CoordinateRing W₁.FunctionField]
+    [Algebra W₂.CoordinateRing φ.intermediateRing]
+    [IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField]
+    (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
+    Module.Finite W₂.CoordinateRing φ.intermediateRing := by
+  -- the caller's structure and the pullback-induced one agree on the structure map, so they are
+  -- the same instance; substituting is what lets `algebraMap_mem_intermediateRing`, which is
+  -- stated for the pullback-induced structure, apply on the nose
+  have halg : inst = φ.pullback.toRingHom.toAlgebra := Algebra.algebra_ext _ _ h
+  subst halg
+  let _ := φ.pullback.toRingHom.toAlgebra
+  have := φ.isIntegralClosure_intermediateRing h
+  exact IsIntegralClosure.finite_of_fraction_model (F := F) (A := W₁.CoordinateRing)
+    (K := W₁.FunctionField)
+    fun x ↦ (φ.mem_intermediateRing_iff _).1 (φ.algebraMap_mem_intermediateRing x)
+
+/-- `moduleFinite_intermediateRing_of_isDedekindDomain` for an elliptic source curve, whose
+coordinate ring is a Dedekind domain. -/
+theorem moduleFinite_intermediateRing_of_isElliptic (φ : Isogeny W₁ W₂) [W₁.IsElliptic]
+    [Algebra W₂.CoordinateRing W₁.FunctionField]
+    [Algebra W₂.CoordinateRing φ.intermediateRing]
+    [IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField]
+    (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
+    Module.Finite W₂.CoordinateRing φ.intermediateRing := by
+  have : IsDedekindDomain W₁.CoordinateRing :=
+    WeierstrassCurve.Affine.isDedekindDomain_coordinateRing W₁
+  exact φ.moduleFinite_intermediateRing_of_isDedekindDomain h
 
 end Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/IntegrallyClosed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/IntegrallyClosed.lean
@@ -21,8 +21,9 @@ formal reason that integrality is transitive: an element of `W₁.FunctionField`
 closure is integral over `W₂.CoordinateRing`, hence already in it. Since `W₁.FunctionField` is a
 field, being integrally closed *in* it upgrades to `IsIntegrallyClosed`
 (`IsIntegrallyClosed.of_isIntegrallyClosedIn`). In particular this holds for **inseparable**
-isogenies, Frobenius included, and does not inherit the separability hypothesis that the sibling
-`Isogeny.moduleFinite_intermediateRing` carries for want of a trace-free route to finiteness.
+isogenies, Frobenius included, and asks for no separability at all, as does the finiteness
+sibling `Isogeny.moduleFinite_intermediateRing_of_isDedekindDomain`; only
+`Isogeny.moduleFinite_intermediateRing` needs it.
 
 ## Main results
 
@@ -85,8 +86,10 @@ ambient ring by transitivity of integrality; over a field that upgrades to `IsIn
 No hypotheses beyond the isogeny: the algebra structures the proof runs through are the canonical
 pullback ones, installed locally rather than asked of the caller.
 
-No finiteness and no separability either: unlike the sibling `Isogeny.moduleFinite_intermediateRing`
-this covers inseparable isogenies, Frobenius included. -/
+No finiteness and no separability either, so this covers inseparable isogenies, Frobenius
+included, and asks nothing of the source curve. The finiteness sibling
+`Isogeny.moduleFinite_intermediateRing_of_isDedekindDomain` also drops separability, but pays
+for it with a Dedekind source coordinate ring. -/
 theorem isIntegrallyClosed_intermediateRing (φ : Isogeny W₁ W₂) :
     IsIntegrallyClosed φ.intermediateRing := by
   let _ := φ.pullback.toRingHom.toAlgebra

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Rank.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Rank.lean
@@ -62,8 +62,8 @@ about the module structure of the intermediate ring has to be known in advance. 
 does spend is the finiteness of the *function-field* extension, which every isogeny has
 (`Isogeny.finiteDimensional_functionField`) — purely inseparable ones, Frobenius among them,
 included. So `finrank_intermediateRing_eq_degree` is
-available exactly where `Isogeny.degree` is, and in particular it is not blocked by the
-separability limitation that `IntermediateRing/Finite.lean` records for its own conclusion.
+available exactly where `Isogeny.degree` is, and in particular independent of whichever
+hypotheses a caller uses to obtain module-finiteness.
 
 **Why not `IsIntegralClosure.rank`.** Mathlib states the same comparison for an integral closure,
 but only over a *principal ideal* base (`Mathlib/RingTheory/DedekindDomain/IntegralClosure.lean`),
@@ -77,10 +77,11 @@ fact.** The three statements below that do need it take
 `[Module.Finite W₂.CoordinateRing φ.intermediateRing]` rather than
 `[Algebra.IsSeparable W₂.FunctionField W₁.FunctionField]` and a call to
 `Isogeny.moduleFinite_intermediateRing`. Separability is not what these conclusions are about; it is
-what the only currently available route to finiteness happens to need, and
-`IntermediateRing/Finite.lean` says so in its own header. Taking the finiteness directly means the
-statements apply unchanged the day a trace-free route lands, and a caller in the separable case
-supplies it in one line from the sibling.
+what a particular route to finiteness needs, and `IntermediateRing/Finite.lean` says so in its
+own header. Taking the finiteness as a hypothesis rather than deriving it is what keeps these
+statements independent of how it is obtained: a caller supplies it in one line from either sibling,
+`moduleFinite_intermediateRing_of_isDedekindDomain` for a Dedekind source coordinate ring or
+`moduleFinite_intermediateRing` in the separable case.
 
 **Flatness follows automatically in the Dedekind application.** The fundamental identity is
 stated under its natural finite-flat hypotheses. Over a Dedekind domain a torsion-free module is


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"intermediate-ring-finite-without-separability"}-->

`TauCeti.Isogeny.moduleFinite_intermediateRing_of_isDedekindDomain`: when `W₁.CoordinateRing` is a
Dedekind domain, `φ.intermediateRing` is a finite `W₂.CoordinateRing`-module with **no separability
hypothesis** — so inseparable isogenies, Frobenius among them, are covered. It also drops the
integral closedness of `W₂.CoordinateRing` that the sibling asks for.

### Why this is on the roadmap rather than general housekeeping

This is the hypothesis that was excluding Frobenius from `pushClass`. The sibling
`moduleFinite_intermediateRing` reaches the same conclusion through Mathlib's
`IsIntegralClosure.finite`, which sits under `[Algebra.IsSeparable K L]` because it argues through
the trace pairing, and the trace form is nondegenerate exactly for separable extensions. The
existing module header says so in as many words, and calls the restriction *"a limitation of the
available proof, not of the result"*. `IntermediateRing/Dedekind.lean` went further and called
removing it *"a normalization-finiteness question of Nagata type, separate from this one"*.

That separate question is `IsIntegralClosure.finite_of_fraction_model`, merged in #5966. Using it,
the route here never builds a trace form at all:

* `W₁.CoordinateRing` is a Dedekind domain — the hypothesis, which an elliptic source curve
  supplies through `WeierstrassCurve.Affine.isDedekindDomain_coordinateRing`, giving the
  convenience form `moduleFinite_intermediateRing_of_isElliptic`;
* it is of finite type over `F` and its fraction field is already `W₁.FunctionField`, so it is its
  own fraction model — no polynomial model on a coordinate line is needed;
* every one of its elements is integral over `W₂.CoordinateRing`, because an isogeny maps infinity
  to infinity (`CoordinatePullback.mapsInfinity_iff`).

Separability never arises, so there is nothing for Frobenius to fail.

### Both theorems are kept

Their hypotheses are incomparable: the separable route asks nothing of `W₁`, so it still serves
sources whose coordinate ring is not Dedekind, while this one asks nothing about the extension. Neither is a
compatibility shim for the other.

### Prose corrected in the same commit

Four claims elsewhere in `IntermediateRing/` asserted that no such route existed, and are now
false rather than merely dated, so they are fixed here rather than left to rot:
`Rank.lean` said its statements would apply *"the day a trace-free route lands"* and described
separability as *"what the only currently available route to finiteness happens to need"*;
`IntegrallyClosed.lean` twice said the finiteness sibling carries separability *"for want of a
trace-free route"*; `Dedekind.lean` carried the Nagata sentence quoted above.

### Absence

A compiled probe against the pinned Mathlib alone reports `Unknown identifier
TauCeti.Isogeny.intermediateRing` and `Unknown constant
IsIntegralClosure.finite_of_fraction_model`, so both the object and the tool are this repository's
own and no upstream form of this statement can exist.

Provenance: the route of feeding an isogeny's `mapsInfinity` into a finite-normalization theorem is
D. K. Angdinata's, from `Isogeny.lean` (Apache-2.0, supplied by the author on 2026-09-07),
declaration `intermediateRingFinite`. That proof keeps the curves general and therefore needs a
*polynomial* model on a coordinate line, which forces a case split on whether `W₁.polynomial`'s
derivative vanishes — the `x`-coordinate when it does not, a `y`-coordinate fallback in the
degenerate characteristic-two case, each with its own separability lemma. Assuming
`[W₁.IsElliptic]` instead makes the coordinate ring its own fraction model, so the case split and
both separability lemmas disappear; that simplification, and the reduction to `intermediateRing` as
this repository defines it, are what is built here rather than taken.
