### PR TITLE
refactor(Contour): name the crossing finset's ordered-endpoint membership

### DIFF
--- a/TauCeti/Analysis/Contour/Crossing/Finiteness.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Finiteness.lean
@@ -222,6 +222,8 @@ theorem IsPwC1ImmersionOn.mem_toFinset_finite_crossings (h : IsPwC1ImmersionOn �
 `IsPwC1ImmersionOn.mem_toFinset_finite_crossings` for `a ≤ b`, where the crossing parameters
 range over `Icc a b` rather than `uIcc a b`. Every multi-crossing principal-value argument
 indexes its windows this way. -/
+-- Not `@[simp]`: the `simpNF` linter rejects it, because `Set.Finite.mem_toFinset` is itself
+-- `@[simp]`, so the left-hand side is simplified away before this rewrite could fire.
 theorem IsPwC1ImmersionOn.mem_toFinset_finite_crossings_of_le (h : IsPwC1ImmersionOn γ a b)
     (hab : a ≤ b) {t : ℝ} :
     t ∈ (h.finite_crossings (z₀ := z₀)).toFinset ↔ t ∈ Icc a b ∧ γ t = z₀ := by

--- a/TauCeti/Analysis/Contour/Crossing/Finiteness.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Finiteness.lean
@@ -218,6 +218,15 @@ theorem IsPwC1ImmersionOn.mem_toFinset_finite_crossings (h : IsPwC1ImmersionOn �
     t ∈ (h.finite_crossings (z₀ := z₀)).toFinset ↔ t ∈ uIcc a b ∧ γ t = z₀ := by
   rw [Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_preimage, Set.mem_singleton_iff]
 
+/-- **Crossings at ordered endpoints.** The form of
+`IsPwC1ImmersionOn.mem_toFinset_finite_crossings` for `a ≤ b`, where the crossing parameters
+range over `Icc a b` rather than `uIcc a b`. Every multi-crossing principal-value argument
+indexes its windows this way. -/
+theorem IsPwC1ImmersionOn.mem_toFinset_finite_crossings_of_le (h : IsPwC1ImmersionOn γ a b)
+    (hab : a ≤ b) {t : ℝ} :
+    t ∈ (h.finite_crossings (z₀ := z₀)).toFinset ↔ t ∈ Icc a b ∧ γ t = z₀ := by
+  rw [h.mem_toFinset_finite_crossings, uIcc_of_le hab]
+
 end TauCeti.Contour
 
 end

--- a/TauCeti/Analysis/Contour/Crossing/ImmersionDecomposition.lean
+++ b/TauCeti/Analysis/Contour/Crossing/ImmersionDecomposition.lean
@@ -77,7 +77,7 @@ theorem IsPwC1ImmersionOn.exists_crossingDecomposition
   classical
   set T : Finset ℝ := (h_imm.finite_crossings (z₀ := s)).toFinset with hT_def
   have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {_} => by
-    rw [hT_def, h_imm.mem_toFinset_finite_crossings, uIcc_of_le hab.le]
+    rw [hT_def, h_imm.mem_toFinset_finite_crossings_of_le hab.le]
   have hcomplete : ∀ t ∈ Icc a b, γ t = s → t ∈ T :=
     fun t ht heq => hT_mem.mpr ⟨ht, heq⟩
   have hinterior : ∀ t ∈ T, t ∈ Ioo a b := by

--- a/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
+++ b/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
@@ -143,7 +143,7 @@ theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {
   · simpa using HasCauchyPVAt.of_eq γ rfl (fun z => c / (z - s) ^ k) s
   set T : Finset ℝ := (h_imm.finite_crossings (z₀ := s)).toFinset with hT_def
   have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {_} => by
-    rw [hT_def, h_imm.mem_toFinset_finite_crossings, uIcc_of_le hab.le]
+    rw [hT_def, h_imm.mem_toFinset_finite_crossings_of_le hab.le]
   have h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ T := fun t ht h_eq => hT_mem.mpr ⟨ht, h_eq⟩
   have h_Ioo : ∀ t ∈ T, t ∈ Ioo a b := fun t ht =>
     h_interior t (hT_mem.mp ht).1 (hT_mem.mp ht).2

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -149,7 +149,7 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
   · exact CauchyPVExistsAt.of_eq γ rfl _ s
   set T : Finset ℝ := (h_imm.finite_crossings (z₀ := s)).toFinset with hT_def
   have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {_} => by
-    rw [hT_def, h_imm.mem_toFinset_finite_crossings, uIcc_of_le hab.le]
+    rw [hT_def, h_imm.mem_toFinset_finite_crossings_of_le hab.le]
   have h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ T := fun t ht h_eq => hT_mem.mpr ⟨ht, h_eq⟩
   have h_Ioo : ∀ t ∈ T, t ∈ Ioo a b := fun t ht =>
     h_interior t (hT_mem.mp ht).1 (hT_mem.mp ht).2

--- a/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
@@ -320,7 +320,7 @@ theorem IsPwC1ImmersionOn.exists_int_windingNumber_eq_add_sum_crossingAngle_toFi
       = k + ((∑ t ∈ (h_imm.finite_crossings (z₀ := s)).toFinset, crossingAngle γ t : ℝ) : ℂ)
           / (2 * (Real.pi : ℂ)) :=
   h_imm.exists_int_windingNumber_eq_add_sum_crossingAngle hab hclosed hbase fun t => by
-    rw [h_imm.mem_toFinset_finite_crossings, uIcc_of_le hab]
+    rw [h_imm.mem_toFinset_finite_crossings_of_le hab]
 
 /-- **Every smooth crossing contributes `½`.** A crossing where the two one-sided tangents agree
 has angle `π` (`TauCeti.Contour.crossingAngle_eq_pi`), hence winding weight `π / 2π = ½`. So a

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral/OnCurve.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral/OnCurve.lean
@@ -250,7 +250,7 @@ private theorem isBounded_intervalIntegrable_cauchyPV_of_interior_crossings
     exact (Set.finite_singleton _).isBounded
   set T : Finset ℝ := (h_imm.finite_crossings (z₀ := s)).toFinset with hT_def
   have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {_} => by
-    rw [hT_def, h_imm.mem_toFinset_finite_crossings, uIcc_of_le hab.le]
+    rw [hT_def, h_imm.mem_toFinset_finite_crossings_of_le hab.le]
   have h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ T := fun t ht h_eq => hT_mem.mpr ⟨ht, h_eq⟩
   have h_Ioo : ∀ t ∈ T, t ∈ Ioo a b := fun t ht =>
     h_interior t (hT_mem.mp ht).1 (hT_mem.mp ht).2


### PR DESCRIPTION
`IsPwC1ImmersionOn.mem_toFinset_finite_crossings` characterises the crossing finset over
`uIcc a b`. Its own docstring tells callers what to do next:

> …they need the characterisation and not just the finiteness; **for ordered endpoints follow
> with `uIcc_of_le`**.

Five call sites, in five different files, follow that instruction literally:

```lean
rw [h_imm.mem_toFinset_finite_crossings, uIcc_of_le hab]
```

This turns the instruction into the lemma. `mem_toFinset_finite_crossings_of_le` states the
`Icc a b` form directly, given `a ≤ b`, and the five sites use it:

| file | context |
|---|---|
| `InvSubCPVExistence.lean` | crossing-window setup |
| `HigherOrder/CPV.lean` | crossing-window setup |
| `Winding/RealIntegral/OnCurve.lean` | crossing-window setup |
| `Crossing/ImmersionDecomposition.lean` | window decomposition |
| `Winding/CrossingAngleSum.lean` | passes `hab`, not `hab.le` |

The first three share a seven-line setup block verbatim; the last two share only this step,
which is why a text-level duplication scan finds three of the five. Grepping for the lemma the
proofs *invoke* rather than for the shape they are written in finds all five.

Roadmap: none

Provenance: none — refactor of existing TauCeti code; no external source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
