### PR TITLE
feat(RamificationInertia): unramifiedness descends to a subring

### DIFF
--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -117,7 +117,8 @@ theorem artinSymbol_map_restrictNormalHom {M L : Type*} [Field M] [NumberField M
       Algebra.IsUnramifiedAt (𝓞 K) Q) :
     ConjClasses.map (AlgEquiv.restrictNormalHom (F := K) (K₁ := L) M)
         (artinSymbol 𝔭 hur) =
-      artinSymbol 𝔭 (isUnramifiedAt_of_intermediateExtension (M := M) (L := L) 𝔭 hur) := by
+      artinSymbol 𝔭 (fun P _ _ ↦
+        TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt (S := 𝓞 L) hur P) := by
   let Q : 𝔭.primesOver (𝓞 L) := Classical.choice inferInstance
   let _ : Q.1.IsPrime := Q.2.1
   let _ : Q.1.LiesOver 𝔭 := Q.2.2
@@ -127,7 +128,8 @@ theorem artinSymbol_map_restrictNormalHom {M L : Type*} [Field M] [NumberField M
     (Ideal.ne_bot_of_liesOver_of_ne_bot h𝔭ne Q.1)
   rw [artinSymbol_eq_mk_of_isArithFrobAt 𝔭 hur Q.1 σ hσ,
     artinSymbol_eq_mk_of_isArithFrobAt 𝔭
-      (isUnramifiedAt_of_intermediateExtension (M := M) (L := L) 𝔭 hur)
+      (fun P _ _ ↦
+        TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt (S := 𝓞 L) hur P)
       (Q.1.under (𝓞 M))
       (σ.restrictNormal M) hσ.restrictNormal]
   -- `AlgEquiv.restrictNormalHom M σ` is `σ.restrictNormal M`, so this is exactly the computation

--- a/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
+++ b/TauCeti/NumberTheory/NumberField/ArtinSymbol.lean
@@ -10,6 +10,7 @@ public import Mathlib.RingTheory.Frobenius
 public import TauCeti.Algebra.Group.Conj
 public import TauCeti.NumberTheory.NumberField.Frobenius.Restriction
 public import TauCeti.NumberTheory.NumberField.UnramifiedTower
+public import TauCeti.NumberTheory.RamificationInertia.Tower
 import TauCeti.NumberTheory.NumberField.Frobenius.DecompositionGroup
 import TauCeti.NumberTheory.NumberField.Frobenius.Tower
 import TauCeti.NumberTheory.NumberField.SplitsCompletely
@@ -118,7 +119,8 @@ theorem artinSymbol_map_restrictNormalHom {M L : Type*} [Field M] [NumberField M
     ConjClasses.map (AlgEquiv.restrictNormalHom (F := K) (K₁ := L) M)
         (artinSymbol 𝔭 hur) =
       artinSymbol 𝔭 (fun P _ _ ↦
-        TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt (S := 𝓞 L) hur P) := by
+        TauCeti.RamificationInertia.isUnramifiedAt_of_isUnramifiedIn (S := 𝓞 L)
+          (fun Q hQ hQ' ↦ @hur Q hQ hQ') P) := by
   let Q : 𝔭.primesOver (𝓞 L) := Classical.choice inferInstance
   let _ : Q.1.IsPrime := Q.2.1
   let _ : Q.1.LiesOver 𝔭 := Q.2.2
@@ -129,7 +131,8 @@ theorem artinSymbol_map_restrictNormalHom {M L : Type*} [Field M] [NumberField M
   rw [artinSymbol_eq_mk_of_isArithFrobAt 𝔭 hur Q.1 σ hσ,
     artinSymbol_eq_mk_of_isArithFrobAt 𝔭
       (fun P _ _ ↦
-        TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt (S := 𝓞 L) hur P)
+        TauCeti.RamificationInertia.isUnramifiedAt_of_isUnramifiedIn (S := 𝓞 L)
+          (fun Q hQ hQ' ↦ @hur Q hQ hQ') P)
       (Q.1.under (𝓞 M))
       (σ.restrictNormal M) hσ.restrictNormal]
   -- `AlgEquiv.restrictNormalHom M σ` is `σ.restrictNormal M`, so this is exactly the computation

--- a/TauCeti/NumberTheory/NumberField/UnramifiedTower.lean
+++ b/TauCeti/NumberTheory/NumberField/UnramifiedTower.lean
@@ -8,14 +8,15 @@ module
 public import Mathlib.NumberTheory.NumberField.Basic
 public import Mathlib.NumberTheory.RamificationInertia.Unramified
 public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
-public import TauCeti.NumberTheory.RamificationInertia.Tower
+
+import TauCeti.NumberTheory.RamificationInertia.Tower
 
 /-!
 # Unramifiedness descends along a tower of number fields
 
 For a tower `L / M / K` of number fields, unramifiedness over `K` of every prime of `𝓞 L` above a
 place of `𝓞 K` descends to the primes of `𝓞 M` above it. The prime-by-prime statement is
-`TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt`, proved there for an
+`TauCeti.RamificationInertia.isUnramifiedAt_of_isUnramifiedIn`, proved there for an
 arbitrary base ring; what this file adds is the version quantified over the places outside a finite
 set, which is the shape the unramified-away hypotheses take.
 
@@ -57,6 +58,6 @@ theorem isUnramifiedAway_of_intermediateField (M : Type*) [Field M] [NumberField
     ∀ v : HeightOneSpectrum (𝓞 K), v ∉ S →
       ∀ (Q : Ideal (𝓞 M)) [Q.IsPrime] [Q.LiesOver v.asIdeal], Algebra.IsUnramifiedAt (𝓞 K) Q :=
   fun v hv P _ _ ↦
-    TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt (S := 𝓞 L) (hur v hv) P
+    TauCeti.RamificationInertia.isUnramifiedAt_of_isUnramifiedIn (S := 𝓞 L) (hur v hv) P
 
 end NumberField

--- a/TauCeti/NumberTheory/NumberField/UnramifiedTower.lean
+++ b/TauCeti/NumberTheory/NumberField/UnramifiedTower.lean
@@ -8,15 +8,17 @@ module
 public import Mathlib.NumberTheory.NumberField.Basic
 public import Mathlib.NumberTheory.RamificationInertia.Unramified
 public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
+public import TauCeti.NumberTheory.RamificationInertia.Tower
 import Mathlib.RingTheory.Ideal.GoingUp
 
 /-!
 # Unramifiedness descends along a tower of number fields
 
-For a tower `L / M / K` of number fields and a prime `𝔭` of `𝓞 K`, unramifiedness over `K` of
-every prime of `𝓞 L` above `𝔭` implies unramifiedness over `K` of every prime of `𝓞 M` above
-`𝔭`. Every prime `P` of `𝓞 M` above `𝔭` carries a prime of `𝓞 L` above it, and Mathlib's
-`Algebra.IsUnramifiedAt.of_liesOver` transfers unramifiedness downwards along that prime.
+For a tower `L / M / K` of number fields, unramifiedness over `K` of every prime of `𝓞 L` above a
+place of `𝓞 K` descends to the primes of `𝓞 M` above it. The prime-by-prime statement is
+`TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt`, proved there for an
+arbitrary base ring; what this file adds is the version quantified over the places outside a finite
+set, which is the shape the unramified-away hypotheses take.
 
 The hypothesis and conclusion are stated as the quantified `Algebra.IsUnramifiedAt` condition
 rather than through `Algebra.IsUnramifiedIn`, which is the form the Artin symbol takes as its
@@ -29,8 +31,6 @@ field into the corresponding hypothesis about every subextension.
 
 ## Main results
 
-* `NumberField.isUnramifiedAt_of_intermediateExtension`: unramifiedness above `𝔭` in the top
-  field descends to the intermediate field.
 * `NumberField.isUnramifiedAway_of_intermediateField`: unramifiedness outside a finite set of
   finite places descends to an intermediate field.
 -/
@@ -45,24 +45,6 @@ namespace NumberField
 
 variable {K : Type*} [Field K] [NumberField K]
 
-/-- **Unramifiedness descends to an intermediate extension.** If every prime of `L` over `𝔭` is
-unramified over `K`, then every prime of an intermediate field `M` over `𝔭` is unramified over
-`K` as well. -/
-theorem isUnramifiedAt_of_intermediateExtension {M L : Type*} [Field M] [NumberField M]
-    [Field L] [NumberField L] [Algebra K M] [Algebra M L] [Algebra K L]
-    [IsScalarTower K M L] (𝔭 : Ideal (𝓞 K))
-    (hur : ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver 𝔭],
-      Algebra.IsUnramifiedAt (𝓞 K) Q) :
-    ∀ (P : Ideal (𝓞 M)) [P.IsPrime] [P.LiesOver 𝔭],
-      Algebra.IsUnramifiedAt (𝓞 K) P := by
-  intro P _ _
-  let Q : P.primesOver (𝓞 L) := Classical.choice inferInstance
-  let _ : Q.1.IsPrime := Q.2.1
-  let _ : Q.1.LiesOver P := Q.2.2
-  let _ : Q.1.LiesOver 𝔭 := Ideal.LiesOver.trans Q.1 P 𝔭
-  let _ : Algebra.IsUnramifiedAt (𝓞 K) Q.1 := hur Q.1
-  exact Algebra.IsUnramifiedAt.of_liesOver (𝓞 K) P Q.1
-
 /-- **Unramifiedness outside a finite set of finite places descends to an intermediate field.**
 If every prime of `L` above a place of `K` outside `S` is unramified over `K`, then so is every
 prime of an intermediate field `M` above such a place. This is what makes the unramified
@@ -75,6 +57,7 @@ theorem isUnramifiedAway_of_intermediateField (M : Type*) [Field M] [NumberField
       ∀ (Q : Ideal (𝓞 L)) [Q.IsPrime] [Q.LiesOver v.asIdeal], Algebra.IsUnramifiedAt (𝓞 K) Q) :
     ∀ v : HeightOneSpectrum (𝓞 K), v ∉ S →
       ∀ (Q : Ideal (𝓞 M)) [Q.IsPrime] [Q.LiesOver v.asIdeal], Algebra.IsUnramifiedAt (𝓞 K) Q :=
-  fun v hv ↦ isUnramifiedAt_of_intermediateExtension (M := M) (L := L) v.asIdeal (hur v hv)
+  fun v hv P _ _ ↦
+    TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt (S := 𝓞 L) (hur v hv) P
 
 end NumberField

--- a/TauCeti/NumberTheory/NumberField/UnramifiedTower.lean
+++ b/TauCeti/NumberTheory/NumberField/UnramifiedTower.lean
@@ -9,7 +9,6 @@ public import Mathlib.NumberTheory.NumberField.Basic
 public import Mathlib.NumberTheory.RamificationInertia.Unramified
 public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
 public import TauCeti.NumberTheory.RamificationInertia.Tower
-import Mathlib.RingTheory.Ideal.GoingUp
 
 /-!
 # Unramifiedness descends along a tower of number fields

--- a/TauCeti/NumberTheory/RamificationInertia/Tower.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/Tower.lean
@@ -172,6 +172,10 @@ variable {A R S : Type*} [CommRing A] [CommRing R] [IsDedekindDomain R] [CommRin
   [Algebra A R] [Algebra A S] [Algebra R S] [IsScalarTower A R S] [Algebra.IsIntegral R S]
   [Module.IsTorsionFree R S] [Algebra.EssFiniteType A R] [Algebra.EssFiniteType A S]
 
+-- Source. The descent is specified by the Chebotarev roadmap:
+-- `TauCetiRoadmap/Chebotarev/README.md` §7.2 argues that `K ∩ ℚ(ζ_q) = ℚ` "because a subfield of
+-- `K` ramified at `q` would force `q` to ramify in `K`", which is this statement's contrapositive.
+
 /-- **Unramifiedness descends to a subring.** If every prime of `S` lying over an ideal `I` of the
 base `A` is unramified over `A`, then so is every prime of `R` lying over `I`. The direction is
 descent, not ascent: the hypothesis is upstairs and the conclusion downstairs.

--- a/TauCeti/NumberTheory/RamificationInertia/Tower.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/Tower.lean
@@ -39,8 +39,10 @@ the compositum is unramified over the quadratic base.
   every absolute ramification index upstairs by the intermediate absolute ramification index.
 * `TauCeti.RamificationInertia.isUnramifiedIn_of_finrank_le_of_under_ramificationIdx_eq_one`: a
   transverse unramified subextension of sufficiently small relative degree supplies that bound.
-* `TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt`: unramifiedness descends
-  from an integral extension to the subring below it, over any base ring and any ideal of it.
+* `TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt`: unramifiedness over the
+  base descends from an integral extension to the subring below it, for `S` integral and
+  torsion-free over the Dedekind domain `R`, with `R` and `S` both essentially of finite type over
+  the base `A` and `A ≤ R ≤ S` a scalar tower. The base ring and the ideal are arbitrary.
 -/
 
 public section
@@ -170,18 +172,18 @@ variable {A R S : Type*} [CommRing A] [CommRing R] [IsDedekindDomain R] [CommRin
   [Algebra A R] [Algebra A S] [Algebra R S] [IsScalarTower A R S] [Algebra.IsIntegral R S]
   [Module.IsTorsionFree R S] [Algebra.EssFiniteType A R] [Algebra.EssFiniteType A S]
 
+-- Source. Recovered from the branch of the retired pull request #5538, commit
+-- `70421db267d9bd6252256f873d27e99e739a931c`, where it was written for the Chebotarev roadmap's
+-- Layer 7.2; the descent step it performs is the one that roadmap prescribes, through Mathlib's
+-- `Algebra.IsUnramifiedAt.of_liesOver`.
+
 /-- **Unramifiedness descends to a subring.** If every prime of `S` lying over an ideal `I` of the
-base `A` is unramified over `A`, then so is every prime of `R` lying over `I`, for `S` integral and
-torsion-free over the Dedekind domain `R`.
+base `A` is unramified over `A`, then so is every prime of `R` lying over `I`. The direction is
+descent, not ascent: the hypothesis is upstairs and the conclusion downstairs.
 
-The direction is descent, not ascent: the hypothesis is upstairs and the conclusion downstairs.
-Every prime of `R` has some prime of `S` above it, that prime lies over the same `I`, and
-`Algebra.IsUnramifiedAt.of_liesOver` passes unramifiedness back down the relation.
-
-Nothing in the argument inspects `A` or `I`, which is why both are left arbitrary. What does the
-work is the ambient hypothesis block: it is there that `Nonempty (𝔮.primesOver S)` is synthesized,
-supplying the prime of `S` above `𝔮`. The number-field use is the case `A := ℤ`,
-`I := Ideal.span {(p : ℤ)}`. -/
+`A` and `I` are arbitrary; the hypotheses that carry the argument are the ambient ones on `R` and
+`S`. Its number-field instance is `NumberField.isUnramifiedAway_of_intermediateField`, which
+quantifies it over the places outside a finite set. -/
 theorem isUnramifiedAt_of_forall_isUnramifiedAt {I : Ideal A}
     (hur : ∀ (P : Ideal S) [P.IsPrime] [P.LiesOver I], Algebra.IsUnramifiedAt A P)
     (𝔮 : Ideal R) [𝔮.IsPrime] [𝔮.LiesOver I] :

--- a/TauCeti/NumberTheory/RamificationInertia/Tower.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/Tower.lean
@@ -39,6 +39,8 @@ the compositum is unramified over the quadratic base.
   every absolute ramification index upstairs by the intermediate absolute ramification index.
 * `TauCeti.RamificationInertia.isUnramifiedIn_of_finrank_le_of_under_ramificationIdx_eq_one`: a
   transverse unramified subextension of sufficiently small relative degree supplies that bound.
+* `TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt`: unramifiedness descends
+  from an integral extension to the subring below it, over any base ring and any ideal of it.
 -/
 
 public section
@@ -161,5 +163,35 @@ theorem isUnramifiedIn_of_finrank_le_of_under_ramificationIdx_eq_one
     _ ≤ q.ramificationIdx R := hrank
 
 end Tower
+
+section Descent
+
+variable {A R S : Type*} [CommRing A] [CommRing R] [IsDedekindDomain R] [CommRing S] [IsDomain S]
+  [Algebra A R] [Algebra A S] [Algebra R S] [IsScalarTower A R S] [Algebra.IsIntegral R S]
+  [Module.IsTorsionFree R S] [Algebra.EssFiniteType A R] [Algebra.EssFiniteType A S]
+
+/-- **Unramifiedness descends to a subring.** If every prime of `S` lying over an ideal `I` of the
+base `A` is unramified over `A`, then so is every prime of `R` lying over `I`, for `S` integral and
+torsion-free over the Dedekind domain `R`.
+
+The direction is descent, not ascent: the hypothesis is upstairs and the conclusion downstairs.
+Every prime of `R` has some prime of `S` above it, that prime lies over the same `I`, and
+`Algebra.IsUnramifiedAt.of_liesOver` passes unramifiedness back down the relation.
+
+Nothing in the argument inspects `A` or `I`, which is why both are left arbitrary. What does the
+work is the ambient hypothesis block: it is there that `Nonempty (𝔮.primesOver S)` is synthesized,
+supplying the prime of `S` above `𝔮`. The number-field use is the case `A := ℤ`,
+`I := Ideal.span {(p : ℤ)}`. -/
+theorem isUnramifiedAt_of_forall_isUnramifiedAt {I : Ideal A}
+    (hur : ∀ (P : Ideal S) [P.IsPrime] [P.LiesOver I], Algebra.IsUnramifiedAt A P)
+    (𝔮 : Ideal R) [𝔮.IsPrime] [𝔮.LiesOver I] :
+    Algebra.IsUnramifiedAt A 𝔮 := by
+  obtain ⟨P⟩ := (inferInstance : Nonempty (𝔮.primesOver S))
+  have : (P : Ideal S).IsPrime := P.2.1
+  have : (P : Ideal S).LiesOver 𝔮 := P.2.2
+  have : (P : Ideal S).LiesOver I := Ideal.LiesOver.trans (P : Ideal S) 𝔮 I
+  exact Algebra.IsUnramifiedAt.of_liesOver A 𝔮 (P : Ideal S)
+
+end Descent
 
 end TauCeti.RamificationInertia

--- a/TauCeti/NumberTheory/RamificationInertia/Tower.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/Tower.lean
@@ -39,7 +39,7 @@ the compositum is unramified over the quadratic base.
   every absolute ramification index upstairs by the intermediate absolute ramification index.
 * `TauCeti.RamificationInertia.isUnramifiedIn_of_finrank_le_of_under_ramificationIdx_eq_one`: a
   transverse unramified subextension of sufficiently small relative degree supplies that bound.
-* `TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt`: unramifiedness over the
+* `TauCeti.RamificationInertia.isUnramifiedAt_of_isUnramifiedIn`: unramifiedness over the
   base descends from an integral extension to the subring below it, for `S` integral and
   torsion-free over the Dedekind domain `R`, with `R` and `S` both essentially of finite type over
   the base `A` and `A ≤ R ≤ S` a scalar tower. The base ring and the ideal are arbitrary.
@@ -172,25 +172,24 @@ variable {A R S : Type*} [CommRing A] [CommRing R] [IsDedekindDomain R] [CommRin
   [Algebra A R] [Algebra A S] [Algebra R S] [IsScalarTower A R S] [Algebra.IsIntegral R S]
   [Module.IsTorsionFree R S] [Algebra.EssFiniteType A R] [Algebra.EssFiniteType A S]
 
--- Source. The descent is specified by the Chebotarev roadmap:
--- `TauCetiRoadmap/Chebotarev/README.md` §7.2 argues that `K ∩ ℚ(ζ_q) = ℚ` "because a subfield of
--- `K` ramified at `q` would force `q` to ramify in `K`", which is this statement's contrapositive.
+-- Source. Recovered from the retired PR #5538, at commit
+-- 70421db267d9bd6252256f873d27e99e739a931c.
 
-/-- **Unramifiedness descends to a subring.** If every prime of `S` lying over an ideal `I` of the
-base `A` is unramified over `A`, then so is every prime of `R` lying over `I`. The direction is
-descent, not ascent: the hypothesis is upstairs and the conclusion downstairs.
+/-- **Unramifiedness descends to a subring.** If an ideal `I` of the base `A` is unramified in `S`,
+then every prime of an intermediate ring `R` lying over `I` is unramified over `A`. The direction
+is descent, not ascent: the hypothesis is upstairs and the conclusion downstairs.
 
 `A` and `I` are arbitrary; the hypotheses that carry the argument are the ambient ones on `R` and
 `S`. Its number-field instance is `NumberField.isUnramifiedAway_of_intermediateField`, which
 quantifies it over the places outside a finite set. -/
-theorem isUnramifiedAt_of_forall_isUnramifiedAt {I : Ideal A}
-    (hur : ∀ (P : Ideal S) [P.IsPrime] [P.LiesOver I], Algebra.IsUnramifiedAt A P)
+theorem isUnramifiedAt_of_isUnramifiedIn {I : Ideal A} (hur : Algebra.IsUnramifiedIn S I)
     (𝔮 : Ideal R) [𝔮.IsPrime] [𝔮.LiesOver I] :
     Algebra.IsUnramifiedAt A 𝔮 := by
   obtain ⟨P⟩ := (inferInstance : Nonempty (𝔮.primesOver S))
   have : (P : Ideal S).IsPrime := P.2.1
   have : (P : Ideal S).LiesOver 𝔮 := P.2.2
   have : (P : Ideal S).LiesOver I := Ideal.LiesOver.trans (P : Ideal S) 𝔮 I
+  have : Algebra.IsUnramifiedAt A (P : Ideal S) := hur (P : Ideal S) ‹_› ‹_›
   exact Algebra.IsUnramifiedAt.of_liesOver A 𝔮 (P : Ideal S)
 
 end Descent

--- a/TauCeti/NumberTheory/RamificationInertia/Tower.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/Tower.lean
@@ -172,11 +172,6 @@ variable {A R S : Type*} [CommRing A] [CommRing R] [IsDedekindDomain R] [CommRin
   [Algebra A R] [Algebra A S] [Algebra R S] [IsScalarTower A R S] [Algebra.IsIntegral R S]
   [Module.IsTorsionFree R S] [Algebra.EssFiniteType A R] [Algebra.EssFiniteType A S]
 
--- Source. Recovered from the branch of the retired pull request #5538, commit
--- `70421db267d9bd6252256f873d27e99e739a931c`, where it was written for the Chebotarev roadmap's
--- Layer 7.2; the descent step it performs is the one that roadmap prescribes, through Mathlib's
--- `Algebra.IsUnramifiedAt.of_liesOver`.
-
 /-- **Unramifiedness descends to a subring.** If every prime of `S` lying over an ideal `I` of the
 base `A` is unramified over `A`, then so is every prime of `R` lying over `I`. The direction is
 descent, not ascent: the hypothesis is upstairs and the conclusion downstairs.


### PR DESCRIPTION
```lean
theorem TauCeti.RamificationInertia.isUnramifiedAt_of_forall_isUnramifiedAt {I : Ideal A}
    (hur : ∀ (P : Ideal S) [P.IsPrime] [P.LiesOver I], Algebra.IsUnramifiedAt A P)
    (𝔮 : Ideal R) [𝔮.IsPrime] [𝔮.LiesOver I] :
    Algebra.IsUnramifiedAt A 𝔮
```

If every prime of `S` over an ideal `I` of the base `A` is unramified over `A`, then so is every
prime of `R` over `I`, for `S` integral and torsion-free over the Dedekind domain `R`. The
direction is descent, not ascent: the hypothesis is upstairs and the conclusion downstairs. Every
prime of `R` has a prime of `S` above it, that prime lies over the same `I`, and Mathlib's
`Algebra.IsUnramifiedAt.of_liesOver` passes unramifiedness back down the relation.

### Where it comes from

This is recovered from the branch of **#5538**, which the queue's round-cap housekeeping retired on
2026-09-06 — "reviewed to the round cap without reaching an all-green review" — with the note that
the branch is kept and "it is completely fine to open a fresh PR once you have had another think
about the approach". This is that rethink: #5538 was 554 lines across five files, and it is being
resubmitted a slice at a time rather than whole.

This slice was the smallest and most independent — 32 lines added to a file already on `main`,
depending on none of the other four. The `reuse` rubric then found that `main` already had a
number-field specialization of it, `NumberField.isUnramifiedAt_of_intermediateExtension`, whose
proof performs the identical primes-over choice, `LiesOver.trans` and `IsUnramifiedAt.of_liesOver`
descent. That specialization is now deleted and its three consumers — the two in `ArtinSymbol.lean`
and `isUnramifiedAway_of_intermediateField` — call the generic theorem directly, so the PR both
adds the general statement and removes the duplicate it exposed. Two docstring sentences were corrected against the binders on
the way: the conclusion is about primes of `R` *lying over `I`*, not vaguely "below"; and it is the
ambient hypothesis block, not integrality alone, that synthesizes `Nonempty (𝔮.primesOver S)`.

Restoring #5538's content also unblocks **#5633** (Layer 7.1, the auxiliary prime), which is stuck
behind the retirement and cannot be unstacked the way #5594 was, because its theorem genuinely
consumes Layer 7.2's `irreducible_cyclotomic_of_unramified`.

### Generality

`A` and `I` are arbitrary and nothing in the argument inspects them; the number-field use is
`A := ℤ` with `I := Ideal.span {(p : ℤ)}`. The statement is deliberately not phrased over number
fields, since integrality and torsion-freeness over a Dedekind domain are all the argument uses.

### Absence

Mathlib has the single-step `Algebra.IsUnramifiedAt.of_liesOver`
(`NumberTheory/RamificationInertia/Unramified.lean:83`), which moves unramifiedness across one
`LiesOver` relation, but no quantified descent statement of this shape; `main` has none either.

Roadmap: Chebotarev

Provenance: none — no external code adapted. The content is TauCeti's own, recovered from the kept
branch `chebotarev/cyclotomic-degree` of the retired #5538 at
`70421db267d9bd6252256f873d27e99e739a931c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF

