### PR TITLE
feat: trivialize skew-zigzag gauges on trees

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Gauge.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Gauge.lean
@@ -87,6 +87,12 @@ backtrack along the edge by this factor. -/
 def backtrackScale (u : ∀ ⦃x y : DoubledQuiver G⦄, (x ⟶ y) → M) {i j : V} (h : G.Adj i j) : M :=
   u (arrow G h) * u (arrow G h.symm)
 
+/-- The backtrack scale is the product of the labels on the two orientations of an edge. -/
+@[simp]
+theorem backtrackScale_apply
+    (u : ∀ ⦃x y : DoubledQuiver G⦄, (x ⟶ y) → M) {i j : V} (h : G.Adj i j) :
+    backtrackScale G u h = u (arrow G h) * u (arrow G h.symm) := (rfl)
+
 /-- The backtrack scale of a unit-valued labelling is the backtrack scale of its underlying scalar
 labelling. -/
 theorem val_backtrackScale {k : Type w} [Monoid k]

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Gauge.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Gauge.lean
@@ -79,7 +79,7 @@ variable {V : Type u} (G : SimpleGraph V)
 
 section Scale
 
-variable {M : Type*} [Monoid M]
+variable {M : Type*} [Mul M]
 
 /-- The **backtrack scale** of a labelling `u` of the arrows of a doubled quiver along an edge: the
 product of the labels of the two orientations of that edge. Rescaling by `u` multiplies the
@@ -93,6 +93,10 @@ theorem backtrackScale_apply
     (u : ∀ ⦃x y : DoubledQuiver G⦄, (x ⟶ y) → M) {i j : V} (h : G.Adj i j) :
     backtrackScale G u h = u (arrow G h) * u (arrow G h.symm) := (rfl)
 
+end Scale
+
+section ScaleUnits
+
 /-- The backtrack scale of a unit-valued labelling is the backtrack scale of its underlying scalar
 labelling. -/
 theorem val_backtrackScale {k : Type w} [Monoid k]
@@ -100,7 +104,7 @@ theorem val_backtrackScale {k : Type w} [Monoid k]
     ((backtrackScale G u h : kˣ) : k) = backtrackScale G (fun _ _ e => ((u e : kˣ) : k)) h :=
   Units.val_mul _ _
 
-end Scale
+end ScaleUnits
 
 section ScaleComm
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Skew.lean
@@ -79,6 +79,23 @@ attribute [simp] SkewZigzagParameter.ratio_self
 
 namespace SkewZigzagParameter
 
+section Ratio
+
+variable {k : Type w} [Monoid k] {V : Type u} {G : SimpleGraph V}
+
+/-- **Skew-zigzag ratios compose along incident edges.** -/
+@[simp]
+theorem ratio_mul_ratio (c : SkewZigzagParameter k G) {i j j' j'' : V}
+    (h : G.Adj i j) (h' : G.Adj i j') (h'' : G.Adj i j'') :
+    c.ratio h h' * c.ratio h' h'' = c.ratio h h'' := by
+  calc
+    c.ratio h h' * c.ratio h' h'' = (c.ratio h'' h)⁻¹ :=
+      eq_inv_of_mul_eq_one_left (c.ratio_cocycle h h' h'')
+    _ = c.ratio h h'' := by
+      rw [eq_inv_of_mul_eq_one_left (c.ratio_inv h'' h), inv_inv]
+
+end Ratio
+
 section One
 
 variable {k : Type w} [Monoid k] {V : Type u} {G : SimpleGraph V}

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Tree.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Tree.lean
@@ -61,15 +61,6 @@ private noncomputable def transition (c : SkewZigzagParameter k G) (hG : G.Conne
     [Nontrivial V] {v w : V} (h : G.Adj v w) : kˣ :=
   localCoordinate c hG h / localCoordinate c hG h.symm
 
-private theorem ratio_mul_ratio (c : SkewZigzagParameter k G) {i j j' j'' : V}
-    (h : G.Adj i j) (h' : G.Adj i j') (h'' : G.Adj i j'') :
-    c.ratio h h' * c.ratio h' h'' = c.ratio h h'' := by
-  calc
-    c.ratio h h' * c.ratio h' h'' = (c.ratio h'' h)⁻¹ :=
-      eq_inv_of_mul_eq_one_left (c.ratio_cocycle h h' h'')
-    _ = c.ratio h h'' := by
-      rw [eq_inv_of_mul_eq_one_left (c.ratio_inv h'' h), inv_inv]
-
 private theorem ratio_eq_localCoordinate_div (c : SkewZigzagParameter k G)
     (hG : G.Connected) [Nontrivial V] {i j j' : V} (h : G.Adj i j)
     (h' : G.Adj i j') :

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Tree.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Tree.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Combinatorics.SimpleGraph.Acyclic
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Componentwise
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Gauge
+
+/-!
+# Skew-zigzag algebras of trees
+
+A skew-zigzag parameter records ratios between backtracks along edges incident to the same vertex.
+On a tree these local ratios can be integrated to a global scale on the unoriented edges: start at
+a root, transport vertex normalizations along the unique paths from it, and use the resulting edge
+scales to rescale one orientation of every edge. Consequently every skew-zigzag parameter on a
+tree is gauge equivalent to the constant parameter, and its relation quotient is isomorphic to the
+ordinary zigzag relation quotient.
+
+## Main results
+
+* `TauCeti.SkewZigzagParameter.isGaugeEquivalent_one_of_isTree`: every skew parameter on a tree is
+  gauge equivalent to the constant parameter.
+* `TauCeti.nonempty_algEquiv_nonisolatedZigzagQuotient_of_isTree`: every skew-zigzag relation
+  quotient of a finite tree is isomorphic to the ordinary relation quotient.
+* `TauCeti.nonempty_algEquiv_zigzagAlgebra_of_isTree`: on a nontrivial finite tree, that ordinary
+  quotient is the public componentwise zigzag algebra.
+
+## References
+
+C. Couture, *Skew-Zigzag Algebras*, Theorem 4.8 and Corollary 4.13,
+https://arxiv.org/abs/1509.08405.
+-/
+
+public section
+
+namespace TauCeti
+
+open DoubledQuiver
+
+universe u w
+
+namespace SkewZigzagParameter
+
+variable {k : Type w} [CommMonoid k] {V : Type u} {G : SimpleGraph V}
+
+/-- A distinguished incident edge at every vertex of a nontrivial connected graph. -/
+private noncomputable def reference (hG : G.Connected) [Nontrivial V] (v : V) :
+    G.neighborSet v := by
+  exact Classical.choice (G.neighborSet_nonempty.mpr (hG.preconnected.not_isIsolated v)).to_subtype
+
+/-- The local coordinate of an incident edge relative to the distinguished edge at its source. -/
+private noncomputable def localCoordinate (c : SkewZigzagParameter k G) (hG : G.Connected)
+    [Nontrivial V] {v w : V} (h : G.Adj v w) : kˣ :=
+  c.ratio h (reference hG v).property
+
+/-- The change of local edge coordinates across an oriented edge. -/
+private noncomputable def transition (c : SkewZigzagParameter k G) (hG : G.Connected)
+    [Nontrivial V] {v w : V} (h : G.Adj v w) : kˣ :=
+  localCoordinate c hG h / localCoordinate c hG h.symm
+
+private theorem ratio_mul_ratio (c : SkewZigzagParameter k G) {i j j' j'' : V}
+    (h : G.Adj i j) (h' : G.Adj i j') (h'' : G.Adj i j'') :
+    c.ratio h h' * c.ratio h' h'' = c.ratio h h'' := by
+  calc
+    c.ratio h h' * c.ratio h' h'' = (c.ratio h'' h)⁻¹ :=
+      eq_inv_of_mul_eq_one_left (c.ratio_cocycle h h' h'')
+    _ = c.ratio h h'' := by
+      rw [eq_inv_of_mul_eq_one_left (c.ratio_inv h'' h), inv_inv]
+
+private theorem ratio_eq_localCoordinate_div (c : SkewZigzagParameter k G)
+    (hG : G.Connected) [Nontrivial V] {i j j' : V} (h : G.Adj i j)
+    (h' : G.Adj i j') :
+    c.ratio h h' = localCoordinate c hG h / localCoordinate c hG h' := by
+  rw [eq_div_iff_mul_eq']
+  exact ratio_mul_ratio c h h' (reference hG i).property
+
+@[simp]
+private theorem transition_symm (c : SkewZigzagParameter k G) (hG : G.Connected)
+    [Nontrivial V] {v w : V} (h : G.Adj v w) :
+    transition c hG h.symm = (transition c hG h)⁻¹ := by
+  rw [transition, transition, inv_div]
+
+private theorem transition_arrow (c : SkewZigzagParameter k G) (hG : G.Connected)
+    [Nontrivial V] {v w : V} (h : G.Adj v w) :
+    transition c hG (arrow G h).down = transition c hG h := by
+  congr <;> simp
+
+/-- The potential obtained by multiplying transition factors along a chosen rooted walk. -/
+private noncomputable def rootedPotential (c : SkewZigzagParameter k G) (hG : G.Connected)
+    [Nontrivial V] (r : V) (p : ∀ v, G.Walk r v) (v : V) : kˣ :=
+  Quiver.Path.weight
+    (fun {x y : DoubledQuiver G} (e : x ⟶ y) ↦ transition c hG e.down)
+    (walkToPath G (p v))
+
+private theorem rootedPotential_mul_transition (c : SkewZigzagParameter k G)
+    (hG : G.Connected) [Nontrivial V] (r : V) (p : ∀ v, G.Walk r v)
+    {v w : V} (h : G.Adj v w) (hp : p w = (p v).concat h) :
+    rootedPotential c hG r p w = rootedPotential c hG r p v * transition c hG h := by
+  simp only [rootedPotential, hp, SimpleGraph.Walk.concat_eq_append,
+    walkToPath_append, Quiver.Path.weight_comp, walkToPath_toWalk,
+    Quiver.Path.weight_toPath]
+  rw [transition_arrow c hG h]
+
+/-- The unoriented edge scale obtained from a vertex potential and the local edge coordinates. -/
+private noncomputable def edgeScale (c : SkewZigzagParameter k G) (hG : G.Connected)
+    [Nontrivial V] (a : V → kˣ) {v w : V} (h : G.Adj v w) : kˣ :=
+  a v * localCoordinate c hG h
+
+private theorem edgeScale_symm_of_potential (c : SkewZigzagParameter k G)
+    (hG : G.Connected) [Nontrivial V] (a : V → kˣ)
+    (ha : ∀ {v w : V} (h : G.Adj v w), a w = a v * transition c hG h)
+    {v w : V} (h : G.Adj v w) :
+    edgeScale c hG a h.symm = edgeScale c hG a h := by
+  rw [edgeScale, edgeScale, ha h, transition]
+  simp only [div_mul_cancel, mul_assoc]
+
+private theorem ratio_eq_edgeScale_div (c : SkewZigzagParameter k G)
+    (hG : G.Connected) [Nontrivial V] (a : V → kˣ) {i j j' : V}
+    (h : G.Adj i j) (h' : G.Adj i j') :
+    c.ratio h h' = edgeScale c hG a h / edgeScale c hG a h' := by
+  rw [ratio_eq_localCoordinate_div c hG h h', edgeScale, edgeScale,
+    mul_div_mul_left_eq_div]
+
+/-- Orient each edge away from a root and put its scale on that orientation only. -/
+private noncomputable def treeLabelling (c : SkewZigzagParameter k G) (hG : G.IsTree)
+    [Nontrivial V] (r : V) (a : V → kˣ) :
+    ∀ ⦃x y : DoubledQuiver G⦄, (x ⟶ y) → kˣ :=
+  fun ⦃x y⦄ e ↦
+    if G.dist r ((vertexEquiv G).symm x) < G.dist r ((vertexEquiv G).symm y) then
+      edgeScale c hG.connected a e.down
+    else 1
+
+private theorem backtrackScale_treeLabelling (c : SkewZigzagParameter k G)
+    (hG : G.IsTree) [Nontrivial V] (r : V) (a : V → kˣ)
+    (ha : ∀ {v w : V} (h : G.Adj v w), a w = a v * transition c hG.connected h)
+    {v w : V} (h : G.Adj v w) :
+    backtrackScale G (treeLabelling c hG r a) h = edgeScale c hG.connected a h := by
+  rcases hG.dist_eq_dist_add_one_of_adj r h with hvw | hwv
+  · rw [DoubledQuiver.backtrackScale_apply]
+    unfold treeLabelling
+    simp only [vertexEquiv_symm_vertex]
+    rw [ite_eq_right (by omega), ite_eq_left (by omega), one_mul,
+      edgeScale_symm_of_potential c hG.connected a ha h]
+  · rw [DoubledQuiver.backtrackScale_apply]
+    unfold treeLabelling
+    simp only [vertexEquiv_symm_vertex]
+    rw [ite_eq_left (by omega), ite_eq_right (by omega), mul_one]
+
+private theorem isGaugeEquivalent_one_of_isTree_of_nontrivial
+    (c : SkewZigzagParameter k G) [Nontrivial V] (hG : G.IsTree) :
+    IsGaugeEquivalent (1 : SkewZigzagParameter k G) c := by
+  let r : V := hG.connected.nonempty.some
+  choose p hp hplen using hG.connected.exists_path_of_dist r
+  let a : V → kˣ := rootedPotential c hG.connected r p
+  have ha : ∀ {v w : V} (h : G.Adj v w), a w = a v * transition c hG.connected h := by
+    intro v w h
+    rcases hG.dist_eq_dist_add_one_of_adj r h with hvw | hwv
+    · have hpv : p v = (p w).concat h.symm := by
+        apply (hG.existsUnique_path r v).unique (hp v)
+        apply SimpleGraph.Walk.isPath_of_length_eq_dist
+        rw [SimpleGraph.Walk.length_concat, hplen, hvw]
+      have hav := rootedPotential_mul_transition c hG.connected r p h.symm hpv
+      dsimp only [a] at hav ⊢
+      rw [transition_symm c hG.connected h] at hav
+      rw [hav]
+      simp
+    · have hpw : p w = (p v).concat h := by
+        apply (hG.existsUnique_path r w).unique (hp w)
+        apply SimpleGraph.Walk.isPath_of_length_eq_dist
+        rw [SimpleGraph.Walk.length_concat, hplen, hwv]
+      exact rootedPotential_mul_transition c hG.connected r p h hpw
+  apply IsGaugeEquivalent.symm
+  rw [isGaugeEquivalent_iff]
+  refine ⟨treeLabelling c hG r a, ?_⟩
+  ext i j j' h h'
+  rw [one_ratio, gauge_ratio,
+    backtrackScale_treeLabelling c hG r a ha h,
+    backtrackScale_treeLabelling c hG r a ha h',
+    ratio_eq_edgeScale_div c hG.connected a h h']
+  simp
+
+/-- **Every skew-zigzag parameter on a tree is gauge equivalent to the constant parameter.** This
+includes the one-vertex tree, where there are no incident-edge ratios to choose. -/
+theorem isGaugeEquivalent_one_of_isTree (c : SkewZigzagParameter k G) (hG : G.IsTree) :
+    IsGaugeEquivalent (1 : SkewZigzagParameter k G) c := by
+  classical
+  cases subsingleton_or_nontrivial V with
+  | inl hV =>
+      let _ := hV
+      have hc : c = 1 := by
+        ext i j j' h
+        exact (h.ne (Subsingleton.elim i j)).elim
+      rw [hc]
+  | inr hV =>
+      let _ := hV
+      exact isGaugeEquivalent_one_of_isTree_of_nontrivial c hG
+
+end SkewZigzagParameter
+
+/-- **Every skew-zigzag relation quotient of a finite tree is isomorphic to the ordinary zigzag
+relation quotient.** The isomorphism is induced by rescaling the doubled arrows. -/
+theorem nonempty_algEquiv_nonisolatedZigzagQuotient_of_isTree
+    (k : Type w) [CommRing k] {V : Type u} (G : SimpleGraph V) [Finite V]
+    (c : SkewZigzagParameter k G) (hG : G.IsTree) :
+    Nonempty (skewZigzagQuotient k G c ≃ₐ[k] nonisolatedZigzagQuotient k G) :=
+  nonempty_algEquiv_nonisolatedZigzagQuotient_of_isGaugeEquivalent_one k G
+    (c.isGaugeEquivalent_one_of_isTree hG)
+
+/-- **Every skew-zigzag relation quotient of a finite nontrivial tree is isomorphic to the public
+ordinary zigzag algebra.** The nontriviality assumption excludes the exceptional one-vertex
+convention, where the public ordinary zigzag algebra is the dual numbers rather than the doubled
+path-algebra quotient. -/
+theorem nonempty_algEquiv_zigzagAlgebra_of_isTree
+    (k : Type w) [CommRing k] {V : Type u} [Finite V] [Nontrivial V]
+    (G : SimpleGraph V) (c : SkewZigzagParameter k G) (hG : G.IsTree) :
+    Nonempty (skewZigzagQuotient k G c ≃ₐ[k] zigzagAlgebra k G) := by
+  obtain ⟨e⟩ := nonempty_algEquiv_nonisolatedZigzagQuotient_of_isTree k G c hG
+  exact ⟨e.trans (zigzagAlgebraEquivNonisolated k G hG.connected).symm⟩
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Tree.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Tree.lean
@@ -10,21 +10,23 @@ public import TauCeti.RepresentationTheory.Quiver.Zigzag.Componentwise
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Gauge
 
 /-!
-# Skew-zigzag algebras of trees
+# Skew-zigzag algebras of trees and forests
 
 A skew-zigzag parameter records ratios between backtracks along edges incident to the same vertex.
-On a tree these local ratios can be integrated to a global scale on the unoriented edges: start at
-a root, transport vertex normalizations along the unique paths from it, and use the resulting edge
-scales to rescale one orientation of every edge. Consequently every skew-zigzag parameter on a
-tree is gauge equivalent to the constant parameter, and its relation quotient is isomorphic to the
-ordinary zigzag relation quotient.
+On an acyclic graph these local ratios can be integrated to a global scale on the unoriented edges:
+choose a root in every connected component, transport vertex normalizations along the unique paths
+from it, and use the resulting edge scales to rescale one orientation of every edge. Consequently
+every skew-zigzag parameter on a forest is gauge equivalent to the constant parameter, and its
+relation quotient is isomorphic to the ordinary zigzag relation quotient. Connectedness enters only
+at the last step, where the ordinary relation quotient of a tree is identified with the public
+componentwise zigzag algebra.
 
 ## Main results
 
-* `TauCeti.SkewZigzagParameter.isGaugeEquivalent_one_of_isTree`: every skew parameter on a tree is
-  gauge equivalent to the constant parameter.
-* `TauCeti.nonempty_algEquiv_nonisolatedZigzagQuotient_of_isTree`: every skew-zigzag relation
-  quotient of a finite tree is isomorphic to the ordinary relation quotient.
+* `TauCeti.SkewZigzagParameter.isGaugeEquivalent_one_of_isAcyclic`: every skew parameter on a
+  forest is gauge equivalent to the constant parameter.
+* `TauCeti.nonempty_algEquiv_nonisolatedZigzagQuotient_of_isAcyclic`: every skew-zigzag relation
+  quotient of a finite forest is isomorphic to the ordinary relation quotient.
 * `TauCeti.nonempty_algEquiv_zigzagAlgebra_of_isTree`: on a nontrivial finite tree, that ordinary
   quotient is the public componentwise zigzag algebra.
 
@@ -46,159 +48,192 @@ namespace SkewZigzagParameter
 
 variable {k : Type w} [CommMonoid k] {V : Type u} {G : SimpleGraph V}
 
-/-- A distinguished incident edge at every vertex of a nontrivial connected graph. -/
-private noncomputable def reference (hG : G.Connected) [Nontrivial V] (v : V) :
-    G.neighborSet v := by
-  exact Classical.choice (G.neighborSet_nonempty.mpr (hG.preconnected.not_isIsolated v)).to_subtype
+/-! ### Local edge coordinates -/
+
+variable (G) in
+/-- A distinguished incident edge at a vertex having at least one. -/
+private noncomputable def reference (v : V) (hv : (G.neighborSet v).Nonempty) :
+    G.neighborSet v :=
+  Classical.choice hv.to_subtype
 
 /-- The local coordinate of an incident edge relative to the distinguished edge at its source. -/
-private noncomputable def localCoordinate (c : SkewZigzagParameter k G) (hG : G.Connected)
-    [Nontrivial V] {v w : V} (h : G.Adj v w) : kˣ :=
-  c.ratio h (reference hG v).property
+private noncomputable def localCoordinate (c : SkewZigzagParameter k G) {v w : V}
+    (h : G.Adj v w) : kˣ :=
+  c.ratio h (reference G v ⟨w, h⟩).property
 
 /-- The change of local edge coordinates across an oriented edge. -/
-private noncomputable def transition (c : SkewZigzagParameter k G) (hG : G.Connected)
-    [Nontrivial V] {v w : V} (h : G.Adj v w) : kˣ :=
-  localCoordinate c hG h / localCoordinate c hG h.symm
+private noncomputable def transition (c : SkewZigzagParameter k G) {v w : V} (h : G.Adj v w) :
+    kˣ :=
+  localCoordinate c h / localCoordinate c h.symm
 
-private theorem ratio_eq_localCoordinate_div (c : SkewZigzagParameter k G)
-    (hG : G.Connected) [Nontrivial V] {i j j' : V} (h : G.Adj i j)
-    (h' : G.Adj i j') :
-    c.ratio h h' = localCoordinate c hG h / localCoordinate c hG h' := by
+private theorem ratio_eq_localCoordinate_div (c : SkewZigzagParameter k G) {i j j' : V}
+    (h : G.Adj i j) (h' : G.Adj i j') :
+    c.ratio h h' = localCoordinate c h / localCoordinate c h' := by
   rw [eq_div_iff_mul_eq']
-  exact ratio_mul_ratio c h h' (reference hG i).property
+  exact ratio_mul_ratio c h h' (reference G i ⟨j, h⟩).property
 
 @[simp]
-private theorem transition_symm (c : SkewZigzagParameter k G) (hG : G.Connected)
-    [Nontrivial V] {v w : V} (h : G.Adj v w) :
-    transition c hG h.symm = (transition c hG h)⁻¹ := by
+private theorem transition_symm (c : SkewZigzagParameter k G) {v w : V} (h : G.Adj v w) :
+    transition c h.symm = (transition c h)⁻¹ := by
   rw [transition, transition, inv_div]
 
-private theorem transition_arrow (c : SkewZigzagParameter k G) (hG : G.Connected)
-    [Nontrivial V] {v w : V} (h : G.Adj v w) :
-    transition c hG (arrow G h).down = transition c hG h := by
+private theorem transition_arrow (c : SkewZigzagParameter k G) {v w : V} (h : G.Adj v w) :
+    transition c (arrow G h).down = transition c h := by
   congr <;> simp
 
-/-- The potential obtained by multiplying transition factors along a chosen rooted walk. -/
-private noncomputable def rootedPotential (c : SkewZigzagParameter k G) (hG : G.Connected)
-    [Nontrivial V] (r : V) (p : ∀ v, G.Walk r v) (v : V) : kˣ :=
-  Quiver.Path.weight
-    (fun {x y : DoubledQuiver G} (e : x ⟶ y) ↦ transition c hG e.down)
-    (walkToPath G (p v))
+/-! ### The potential of a forest -/
 
-private theorem rootedPotential_mul_transition (c : SkewZigzagParameter k G)
-    (hG : G.Connected) [Nontrivial V] (r : V) (p : ∀ v, G.Walk r v)
-    {v w : V} (h : G.Adj v w) (hp : p w = (p v).concat h) :
-    rootedPotential c hG r p w = rootedPotential c hG r p v * transition c hG h := by
-  simp only [rootedPotential, hp, SimpleGraph.Walk.concat_eq_append,
-    walkToPath_append, Quiver.Path.weight_comp, walkToPath_toWalk,
-    Quiver.Path.weight_toPath]
-  rw [transition_arrow c hG h]
+variable (G) in
+/-- The chosen root of the connected component of a vertex. -/
+private noncomputable def root (v : V) : V :=
+  (G.connectedComponentMk v).nonempty_supp.some
+
+private theorem reachable_root (v : V) : G.Reachable (root G v) v :=
+  SimpleGraph.ConnectedComponent.exact
+    ((G.connectedComponentMk v).nonempty_supp.some_mem)
+
+private theorem root_eq_of_adj {v w : V} (h : G.Adj v w) : root G w = root G v :=
+  congrArg (fun C : G.ConnectedComponent => C.nonempty_supp.some)
+    (SimpleGraph.ConnectedComponent.sound h.symm.reachable)
+
+variable (G) in
+/-- The distance from a vertex to the chosen root of its connected component. -/
+private noncomputable def depth (v : V) : ℕ :=
+  G.dist (root G v) v
+
+private theorem depth_eq_add_one_of_adj (hG : G.IsAcyclic) {v w : V} (h : G.Adj v w) :
+    depth G v = depth G w + 1 ∨ depth G w = depth G v + 1 := by
+  unfold depth
+  rw [root_eq_of_adj h]
+  exact hG.dist_eq_dist_add_one_of_adj_of_reachable _ h (reachable_root v)
+
+variable (G) in
+/-- A shortest path from the chosen root of a connected component to one of its vertices. -/
+private noncomputable def rootPath (v : V) : G.Walk (root G v) v :=
+  (reachable_root v).exists_path_of_dist.choose
+
+private theorem rootPath_isPath (v : V) : (rootPath G v).IsPath :=
+  (reachable_root v).exists_path_of_dist.choose_spec.1
+
+private theorem length_rootPath (v : V) : (rootPath G v).length = depth G v :=
+  (reachable_root v).exists_path_of_dist.choose_spec.2
+
+/-- The product of the transition factors along a walk. -/
+private noncomputable def walkTransition (c : SkewZigzagParameter k G) {v w : V}
+    (q : G.Walk v w) : kˣ :=
+  Quiver.Path.weight (fun {x y : DoubledQuiver G} (e : x ⟶ y) ↦ transition c e.down)
+    (walkToPath G q)
+
+private theorem walkTransition_concat (c : SkewZigzagParameter k G) {r v w : V} (q : G.Walk r v)
+    (h : G.Adj v w) : walkTransition c (q.concat h) = walkTransition c q * transition c h := by
+  simp only [walkTransition, SimpleGraph.Walk.concat_eq_append, walkToPath_append,
+    Quiver.Path.weight_comp, walkToPath_toWalk, Quiver.Path.weight_toPath]
+  rw [transition_arrow c h]
+
+/-- The potential obtained by multiplying transition factors along the path from the root of the
+component of a vertex. -/
+private noncomputable def potential (c : SkewZigzagParameter k G) (v : V) : kˣ :=
+  walkTransition c (rootPath G v)
+
+private theorem potential_eq_walkTransition (hG : G.IsAcyclic) (c : SkewZigzagParameter k G)
+    {r v : V} (hr : root G v = r) (q : G.Walk r v) (hq : q.IsPath) :
+    potential c v = walkTransition c q := by
+  subst hr
+  have hpath : rootPath G v = q :=
+    congrArg Subtype.val
+      ((hG.subsingleton_path _ _).allEq ⟨rootPath G v, rootPath_isPath v⟩ ⟨q, hq⟩)
+  rw [potential, hpath]
+
+private theorem potential_mul_transition (hG : G.IsAcyclic) (c : SkewZigzagParameter k G)
+    {v w : V} (h : G.Adj v w) : potential c w = potential c v * transition c h := by
+  have hrt : root G w = root G v := root_eq_of_adj h
+  have hdw : G.dist (root G v) w = depth G w := by unfold depth; rw [hrt]
+  rcases depth_eq_add_one_of_adj hG h with hvw | hwv
+  -- The root path to `v` runs through `w`, so it is the root path to `w` extended by the edge.
+  · obtain ⟨q, hq, hlq⟩ :=
+      (hrt ▸ reachable_root w : G.Reachable (root G v) w).exists_path_of_dist
+    have hcat : (q.concat h.symm).IsPath := by
+      apply SimpleGraph.Walk.isPath_of_length_eq_dist
+      rw [SimpleGraph.Walk.length_concat, hlq, hdw, ← hvw, depth]
+    have hv := potential_eq_walkTransition hG c rfl _ hcat
+    rw [walkTransition_concat, ← potential_eq_walkTransition hG c hrt q hq,
+      transition_symm c h] at hv
+    rw [hv, mul_assoc, inv_mul_cancel, mul_one]
+  -- The root path to `w` is the root path to `v` extended by the edge.
+  · have hcat : ((rootPath G v).concat h).IsPath := by
+      apply SimpleGraph.Walk.isPath_of_length_eq_dist
+      rw [SimpleGraph.Walk.length_concat, length_rootPath, ← hwv, hdw]
+    rw [potential_eq_walkTransition hG c hrt _ hcat, walkTransition_concat, potential]
+
+/-! ### Trivializing the parameter -/
 
 /-- The unoriented edge scale obtained from a vertex potential and the local edge coordinates. -/
-private noncomputable def edgeScale (c : SkewZigzagParameter k G) (hG : G.Connected)
-    [Nontrivial V] (a : V → kˣ) {v w : V} (h : G.Adj v w) : kˣ :=
-  a v * localCoordinate c hG h
+private noncomputable def edgeScale (c : SkewZigzagParameter k G) (a : V → kˣ) {v w : V}
+    (h : G.Adj v w) : kˣ :=
+  a v * localCoordinate c h
 
-private theorem edgeScale_symm_of_potential (c : SkewZigzagParameter k G)
-    (hG : G.Connected) [Nontrivial V] (a : V → kˣ)
-    (ha : ∀ {v w : V} (h : G.Adj v w), a w = a v * transition c hG h)
+private theorem edgeScale_symm_of_potential (c : SkewZigzagParameter k G) (a : V → kˣ)
+    (ha : ∀ {v w : V} (h : G.Adj v w), a w = a v * transition c h)
     {v w : V} (h : G.Adj v w) :
-    edgeScale c hG a h.symm = edgeScale c hG a h := by
+    edgeScale c a h.symm = edgeScale c a h := by
   rw [edgeScale, edgeScale, ha h, transition]
   simp only [div_mul_cancel, mul_assoc]
 
-private theorem ratio_eq_edgeScale_div (c : SkewZigzagParameter k G)
-    (hG : G.Connected) [Nontrivial V] (a : V → kˣ) {i j j' : V}
+private theorem ratio_eq_edgeScale_div (c : SkewZigzagParameter k G) (a : V → kˣ) {i j j' : V}
     (h : G.Adj i j) (h' : G.Adj i j') :
-    c.ratio h h' = edgeScale c hG a h / edgeScale c hG a h' := by
-  rw [ratio_eq_localCoordinate_div c hG h h', edgeScale, edgeScale,
-    mul_div_mul_left_eq_div]
+    c.ratio h h' = edgeScale c a h / edgeScale c a h' := by
+  rw [ratio_eq_localCoordinate_div c h h', edgeScale, edgeScale, mul_div_mul_left_eq_div]
 
-/-- Orient each edge away from a root and put its scale on that orientation only. -/
-private noncomputable def treeLabelling (c : SkewZigzagParameter k G) (hG : G.IsTree)
-    [Nontrivial V] (r : V) (a : V → kˣ) :
+/-- Orient each edge away from the root of its component and put its scale on that orientation
+only. -/
+private noncomputable def forestLabelling (c : SkewZigzagParameter k G) (a : V → kˣ) :
     ∀ ⦃x y : DoubledQuiver G⦄, (x ⟶ y) → kˣ :=
   fun ⦃x y⦄ e ↦
-    if G.dist r ((vertexEquiv G).symm x) < G.dist r ((vertexEquiv G).symm y) then
-      edgeScale c hG.connected a e.down
+    if depth G ((vertexEquiv G).symm x) < depth G ((vertexEquiv G).symm y) then
+      edgeScale c a e.down
     else 1
 
-private theorem backtrackScale_treeLabelling (c : SkewZigzagParameter k G)
-    (hG : G.IsTree) [Nontrivial V] (r : V) (a : V → kˣ)
-    (ha : ∀ {v w : V} (h : G.Adj v w), a w = a v * transition c hG.connected h)
+private theorem backtrackScale_forestLabelling (c : SkewZigzagParameter k G) (hG : G.IsAcyclic)
+    (a : V → kˣ) (ha : ∀ {v w : V} (h : G.Adj v w), a w = a v * transition c h)
     {v w : V} (h : G.Adj v w) :
-    backtrackScale G (treeLabelling c hG r a) h = edgeScale c hG.connected a h := by
-  rcases hG.dist_eq_dist_add_one_of_adj r h with hvw | hwv
+    backtrackScale G (forestLabelling c a) h = edgeScale c a h := by
+  rcases depth_eq_add_one_of_adj hG h with hvw | hwv
   · rw [DoubledQuiver.backtrackScale_apply]
-    unfold treeLabelling
+    unfold forestLabelling
     simp only [vertexEquiv_symm_vertex]
     rw [ite_eq_right (by omega), ite_eq_left (by omega), one_mul,
-      edgeScale_symm_of_potential c hG.connected a ha h]
+      edgeScale_symm_of_potential c a ha h]
   · rw [DoubledQuiver.backtrackScale_apply]
-    unfold treeLabelling
+    unfold forestLabelling
     simp only [vertexEquiv_symm_vertex]
     rw [ite_eq_left (by omega), ite_eq_right (by omega), mul_one]
 
-private theorem isGaugeEquivalent_one_of_isTree_of_nontrivial
-    (c : SkewZigzagParameter k G) [Nontrivial V] (hG : G.IsTree) :
+/-- **Every skew-zigzag parameter on a forest is gauge equivalent to the constant parameter.** This
+includes graphs with isolated vertices, at which there are no incident-edge ratios to trivialize. -/
+theorem isGaugeEquivalent_one_of_isAcyclic (c : SkewZigzagParameter k G) (hG : G.IsAcyclic) :
     IsGaugeEquivalent (1 : SkewZigzagParameter k G) c := by
-  let r : V := hG.connected.nonempty.some
-  choose p hp hplen using hG.connected.exists_path_of_dist r
-  let a : V → kˣ := rootedPotential c hG.connected r p
-  have ha : ∀ {v w : V} (h : G.Adj v w), a w = a v * transition c hG.connected h := by
-    intro v w h
-    rcases hG.dist_eq_dist_add_one_of_adj r h with hvw | hwv
-    · have hpv : p v = (p w).concat h.symm := by
-        apply (hG.existsUnique_path r v).unique (hp v)
-        apply SimpleGraph.Walk.isPath_of_length_eq_dist
-        rw [SimpleGraph.Walk.length_concat, hplen, hvw]
-      have hav := rootedPotential_mul_transition c hG.connected r p h.symm hpv
-      dsimp only [a] at hav ⊢
-      rw [transition_symm c hG.connected h] at hav
-      rw [hav]
-      simp
-    · have hpw : p w = (p v).concat h := by
-        apply (hG.existsUnique_path r w).unique (hp w)
-        apply SimpleGraph.Walk.isPath_of_length_eq_dist
-        rw [SimpleGraph.Walk.length_concat, hplen, hwv]
-      exact rootedPotential_mul_transition c hG.connected r p h hpw
+  have ha : ∀ {v w : V} (h : G.Adj v w), potential c w = potential c v * transition c h :=
+    fun h ↦ potential_mul_transition hG c h
   apply IsGaugeEquivalent.symm
   rw [isGaugeEquivalent_iff]
-  refine ⟨treeLabelling c hG r a, ?_⟩
+  refine ⟨forestLabelling c (potential c), ?_⟩
   ext i j j' h h'
   rw [one_ratio, gauge_ratio,
-    backtrackScale_treeLabelling c hG r a ha h,
-    backtrackScale_treeLabelling c hG r a ha h',
-    ratio_eq_edgeScale_div c hG.connected a h h']
+    backtrackScale_forestLabelling c hG (potential c) ha h,
+    backtrackScale_forestLabelling c hG (potential c) ha h',
+    ratio_eq_edgeScale_div c (potential c) h h']
   simp
-
-/-- **Every skew-zigzag parameter on a tree is gauge equivalent to the constant parameter.** This
-includes the one-vertex tree, where there are no incident-edge ratios to choose. -/
-theorem isGaugeEquivalent_one_of_isTree (c : SkewZigzagParameter k G) (hG : G.IsTree) :
-    IsGaugeEquivalent (1 : SkewZigzagParameter k G) c := by
-  classical
-  cases subsingleton_or_nontrivial V with
-  | inl hV =>
-      let _ := hV
-      have hc : c = 1 := by
-        ext i j j' h
-        exact (h.ne (Subsingleton.elim i j)).elim
-      rw [hc]
-  | inr hV =>
-      let _ := hV
-      exact isGaugeEquivalent_one_of_isTree_of_nontrivial c hG
 
 end SkewZigzagParameter
 
-/-- **Every skew-zigzag relation quotient of a finite tree is isomorphic to the ordinary zigzag
+/-- **Every skew-zigzag relation quotient of a finite forest is isomorphic to the ordinary zigzag
 relation quotient.** The isomorphism is induced by rescaling the doubled arrows. -/
-theorem nonempty_algEquiv_nonisolatedZigzagQuotient_of_isTree
+theorem nonempty_algEquiv_nonisolatedZigzagQuotient_of_isAcyclic
     (k : Type w) [CommRing k] {V : Type u} (G : SimpleGraph V) [Finite V]
-    (c : SkewZigzagParameter k G) (hG : G.IsTree) :
+    (c : SkewZigzagParameter k G) (hG : G.IsAcyclic) :
     Nonempty (skewZigzagQuotient k G c ≃ₐ[k] nonisolatedZigzagQuotient k G) :=
   nonempty_algEquiv_nonisolatedZigzagQuotient_of_isGaugeEquivalent_one k G
-    (c.isGaugeEquivalent_one_of_isTree hG)
+    (c.isGaugeEquivalent_one_of_isAcyclic hG)
 
 /-- **Every skew-zigzag relation quotient of a finite nontrivial tree is isomorphic to the public
 ordinary zigzag algebra.** The nontriviality assumption excludes the exceptional one-vertex
@@ -208,7 +243,7 @@ theorem nonempty_algEquiv_zigzagAlgebra_of_isTree
     (k : Type w) [CommRing k] {V : Type u} [Finite V] [Nontrivial V]
     (G : SimpleGraph V) (c : SkewZigzagParameter k G) (hG : G.IsTree) :
     Nonempty (skewZigzagQuotient k G c ≃ₐ[k] zigzagAlgebra k G) := by
-  obtain ⟨e⟩ := nonempty_algEquiv_nonisolatedZigzagQuotient_of_isTree k G c hG
+  obtain ⟨e⟩ := nonempty_algEquiv_nonisolatedZigzagQuotient_of_isAcyclic k G c hG.isAcyclic
   exact ⟨e.trans (zigzagAlgebraEquivNonisolated k G hG.connected).symm⟩
 
 end TauCeti


### PR DESCRIPTION
This PR proves the Layer 1 tree case in `TauCetiRoadmap/ZigzagPreprojective/README.md`: “prove that every skew-zigzag algebra on a tree is isomorphic to the ordinary one.” Gauge triviality is a componentwise statement, so it is proved at its natural level — every `SkewZigzagParameter` on an arbitrary **acyclic** graph, including graphs with isolated vertices and the one-vertex tree, is gauge equivalent to the constant parameter. For a finite forest this transports to the relation quotients, and for a finite nontrivial **tree** it identifies the skew quotient with the public componentwise `zigzagAlgebra`.

The construction chooses a local reference edge at every vertex that has one, turns the skew ratios into transition factors across oriented edges, and integrates those factors along the unique shortest path from a chosen root of the vertex's own connected component. The resulting scale is independent of edge orientation. Orienting every edge away from its root then realizes that scale as a doubled-arrow labelling, whose gauge transform is the constant parameter. Connectedness is used only in the last theorem, which excludes the exceptional one-vertex convention where `zigzagAlgebra` is the dual numbers rather than the doubled path-algebra quotient.

This serves the Layer 1 milestone “strict ordinary and skew zigzag algebras” and completes its tree-isomorphism clause. After this PR, that milestone still needs the `H¹(G,kˣ)` classification, the even/odd cycle analysis, scalar extension, and the skew Frobenius trace.

The mathematical statement follows C. Couture, *Skew-Zigzag Algebras*, Theorem 4.8 and Corollary 4.13. No Mathlib infrastructure is vendored: the proof reuses Mathlib’s `SimpleGraph.IsAcyclic` unique-path and distance API (`IsAcyclic.subsingleton_path`, `IsAcyclic.dist_eq_dist_add_one_of_adj_of_reachable`), `ConnectedComponent.nonempty_supp`, `Quiver.Path.weight`, and Tau Ceti’s existing gauge-equivalence and componentwise-zigzag comparisons. The existing `DoubledQuiver.backtrackScale` API gains its missing simp application equation so the new module can compute through the definition without unfolding its hidden body, and the general skew-ratio composition identity is exported from `Zigzag/Skew.lean`.

Roadmap: ZigzagPreprojective

<!--tauceti-target:v1 {"focus":"ZigzagPreprojective","id":"skew-zigzag-tree-gauge-triviality"}-->

🤖 Prepared with Codex
