### PR TITLE
feat: the total sign homomorphism and simultaneous approximation in Kˣ

### DIFF
--- a/TauCeti/Algebra/Order/Ring/Units.lean
+++ b/TauCeti/Algebra/Order/Ring/Units.lean
@@ -6,14 +6,27 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Order.Ring.Units
+public import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.Algebra.Ring.Int.Units
 
 /-!
-# Finite index of the positive-units subgroup
+# The sign group of a linearly ordered ring
 
 For a linearly ordered ring, the positive units `Units.posSubgroup R` form an index-`2` subgroup, so
 it has finite index. Together with the general finite-index-preimage instance
 (`Subgroup.instFiniteIndexComap`), this yields the finiteness of the totally positive units of a
 number field, hence of its narrow class group.
+
+Being of index `2`, the quotient `Rˣ ⧸ Units.posSubgroup R` is *the* two-element sign group; over a
+commutative ring, where that quotient is a group, `Units.signEquiv` identifies it with `ℤˣ`, which
+is how a sign is usually presented concretely.
+
+## Main definitions and results
+
+* `Units.instFiniteIndexPosSubgroup`: the positive units have finite index.
+* `Units.signEquiv`: the sign isomorphism `Rˣ ⧸ Units.posSubgroup R ≃* ℤˣ`, with
+  `Units.signEquiv_mk_eq_one_iff` and `Units.signEquiv_mk_eq_neg_one_iff` reading its two values
+  off the sign of a unit.
 -/
 
 public section
@@ -25,5 +38,60 @@ subgroup. -/
 instance instFiniteIndexPosSubgroup (R : Type*) [Ring R] [LinearOrder R] [IsStrictOrderedRing R] :
     (Units.posSubgroup R).FiniteIndex :=
   ⟨by rw [Units.index_posSubgroup]; decide⟩
+
+variable {R : Type*} [CommRing R] [LinearOrder R] [IsStrictOrderedRing R]
+
+variable (R) in
+/-- **The sign isomorphism of a linearly ordered commutative ring.** The units of `R` modulo the
+positive ones form the two-element sign group `ℤˣ`, the class of a unit being its sign.
+
+It is built as the inverse of the map `ℤˣ → Rˣ ⧸ Units.posSubgroup R` induced by `Int.cast`, which
+is what makes it a homomorphism without a case analysis. -/
+noncomputable def signEquiv : Rˣ ⧸ Units.posSubgroup R ≃* ℤˣ :=
+  (MulEquiv.ofBijective
+    ((QuotientGroup.mk' (Units.posSubgroup R)).comp (Units.map (Int.castRingHom R).toMonoidHom))
+    ⟨by
+      refine (injective_iff_map_eq_one _).mpr fun u hu => ?_
+      rcases Int.units_eq_one_or u with h | h
+      · exact h
+      · rw [h, MonoidHom.comp_apply, QuotientGroup.mk'_apply, QuotientGroup.eq_one_iff,
+          Units.mem_posSubgroup] at hu
+        exact absurd hu (by simp),
+      by
+      refine fun q => QuotientGroup.induction_on q fun u => ?_
+      have hmap : Units.map (Int.castRingHom R).toMonoidHom (-1 : ℤˣ) = (-1 : Rˣ) := by
+        ext
+        simp
+      rcases lt_or_gt_of_ne u.ne_zero with h | h
+      · refine ⟨-1, ?_⟩
+        rw [MonoidHom.comp_apply, QuotientGroup.mk'_apply, hmap, QuotientGroup.eq,
+          Units.mem_posSubgroup, inv_eq_of_mul_eq_one_right (by simp : (-1 : Rˣ) * (-1) = 1),
+          neg_one_mul, Units.val_neg]
+        exact neg_pos.mpr h
+      · refine ⟨1, ?_⟩
+        rw [MonoidHom.comp_apply, QuotientGroup.mk'_apply, map_one, QuotientGroup.eq, inv_one,
+          one_mul, Units.mem_posSubgroup]
+        exact h⟩).symm
+
+-- Not a `simp` lemma: the simp set already reaches this statement through
+-- `EmbeddingLike.map_eq_one_iff` and `QuotientGroup.eq_one_iff`, so tagging it fails `simpNF`.
+/-- The sign of a unit is `1` exactly when the unit is positive. -/
+theorem signEquiv_mk_eq_one_iff (u : Rˣ) :
+    signEquiv R (QuotientGroup.mk u) = 1 ↔ (0 : R) < u := by
+  rw [map_eq_one_iff _ (signEquiv R).injective, QuotientGroup.eq_one_iff, Units.mem_posSubgroup]
+
+/-- The sign of a unit is `-1` exactly when the unit is negative. -/
+@[simp] theorem signEquiv_mk_eq_neg_one_iff (u : Rˣ) :
+    signEquiv R (QuotientGroup.mk u) = -1 ↔ (u : R) < 0 := by
+  constructor
+  · intro h
+    rcases lt_or_gt_of_ne u.ne_zero with h' | h'
+    · exact h'
+    · rw [(signEquiv_mk_eq_one_iff u).mpr h'] at h
+      exact absurd h (by decide)
+  · intro h
+    rcases Int.units_eq_one_or (signEquiv R (QuotientGroup.mk u)) with h1 | h1
+    · exact absurd ((signEquiv_mk_eq_one_iff u).mp h1) (asymm h)
+    · exact h1
 
 end Units

--- a/TauCeti/Algebra/Order/Ring/Units.lean
+++ b/TauCeti/Algebra/Order/Ring/Units.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Order.Ring.Units
-public import Mathlib.GroupTheory.QuotientGroup.Basic
 import Mathlib.Algebra.Ring.Int.Units
+import Mathlib.GroupTheory.IndexNormal
 
 /-!
 # The sign group of a linearly ordered ring
@@ -17,9 +17,8 @@ it has finite index. Together with the general finite-index-preimage instance
 (`Subgroup.instFiniteIndexComap`), this yields the finiteness of the totally positive units of a
 number field, hence of its narrow class group.
 
-Being of index `2`, the quotient `Rˣ ⧸ Units.posSubgroup R` is *the* two-element sign group; over a
-commutative ring, where that quotient is a group, `Units.signEquiv` identifies it with `ℤˣ`, which
-is how a sign is usually presented concretely.
+Being of index `2`, the quotient `Rˣ ⧸ Units.posSubgroup R` is *the* two-element sign group;
+`Units.signEquiv` identifies it with `ℤˣ`, which is how a sign is usually presented concretely.
 
 ## Main definitions and results
 
@@ -39,10 +38,13 @@ instance instFiniteIndexPosSubgroup (R : Type*) [Ring R] [LinearOrder R] [IsStri
     (Units.posSubgroup R).FiniteIndex :=
   ⟨by rw [Units.index_posSubgroup]; decide⟩
 
-variable {R : Type*} [CommRing R] [LinearOrder R] [IsStrictOrderedRing R]
+variable {R : Type*} [Ring R] [LinearOrder R] [IsStrictOrderedRing R]
+
+local instance : (Units.posSubgroup R).Normal :=
+  Subgroup.normal_of_index_eq_two (Units.index_posSubgroup R)
 
 variable (R) in
-/-- **The sign isomorphism of a linearly ordered commutative ring.** The units of `R` modulo the
+/-- **The sign isomorphism of a linearly ordered ring.** The units of `R` modulo the
 positive ones form the two-element sign group `ℤˣ`, the class of a unit being its sign.
 
 It is built as the inverse of the map `ℤˣ → Rˣ ⧸ Units.posSubgroup R` induced by `Int.cast`, which
@@ -54,9 +56,10 @@ noncomputable def signEquiv : Rˣ ⧸ Units.posSubgroup R ≃* ℤˣ :=
       refine (injective_iff_map_eq_one _).mpr fun u hu => ?_
       rcases Int.units_eq_one_or u with h | h
       · exact h
-      · rw [h, MonoidHom.comp_apply, QuotientGroup.mk'_apply, QuotientGroup.eq_one_iff,
-          Units.mem_posSubgroup] at hu
-        exact absurd hu (by simp),
+      · subst u
+        have : (1 : R) < 0 := by
+          simpa [MonoidHom.comp_apply, QuotientGroup.eq_one_iff, Units.mem_posSubgroup] using hu
+        exact (not_lt_of_ge zero_le_one this).elim,
       by
       refine fun q => QuotientGroup.induction_on q fun u => ?_
       have hmap : Units.map (Int.castRingHom R).toMonoidHom (-1 : ℤˣ) = (-1 : Rˣ) := by
@@ -64,13 +67,10 @@ noncomputable def signEquiv : Rˣ ⧸ Units.posSubgroup R ≃* ℤˣ :=
         simp
       rcases lt_or_gt_of_ne u.ne_zero with h | h
       · refine ⟨-1, ?_⟩
-        rw [MonoidHom.comp_apply, QuotientGroup.mk'_apply, hmap, QuotientGroup.eq,
-          Units.mem_posSubgroup, inv_eq_of_mul_eq_one_right (by simp : (-1 : Rˣ) * (-1) = 1),
-          neg_one_mul, Units.val_neg]
-        exact neg_pos.mpr h
+        simpa [MonoidHom.comp_apply, hmap, QuotientGroup.eq, Units.mem_posSubgroup] using
+          neg_pos.mpr h
       · refine ⟨1, ?_⟩
-        rw [MonoidHom.comp_apply, QuotientGroup.mk'_apply, map_one, QuotientGroup.eq, inv_one,
-          one_mul, Units.mem_posSubgroup]
+        rw [map_one, eq_comm, QuotientGroup.eq_one_iff, Units.mem_posSubgroup]
         exact h⟩).symm
 
 -- Not a `simp` lemma: the simp set already reaches this statement through

--- a/TauCeti/Algebra/Order/Ring/Units.lean
+++ b/TauCeti/Algebra/Order/Ring/Units.lean
@@ -47,8 +47,8 @@ variable (R) in
 /-- **The sign isomorphism of a linearly ordered ring.** The units of `R` modulo the
 positive ones form the two-element sign group `ℤˣ`, the class of a unit being its sign.
 
-It is built as the inverse of the map `ℤˣ → Rˣ ⧸ Units.posSubgroup R` induced by `Int.cast`, which
-is what makes it a homomorphism without a case analysis. -/
+The class of a positive unit is sent to `1` and the class of a negative unit to `-1`; these two
+values are read off by `Units.signEquiv_mk_eq_one_iff` and `Units.signEquiv_mk_eq_neg_one_iff`. -/
 noncomputable def signEquiv : Rˣ ⧸ Units.posSubgroup R ≃* ℤˣ :=
   (MulEquiv.ofBijective
     ((QuotientGroup.mk' (Units.posSubgroup R)).comp (Units.map (Int.castRingHom R).toMonoidHom))

--- a/TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean
+++ b/TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.NumberTheory.NumberField.Completion.InfinitePlace
 public import Mathlib.RingTheory.DedekindDomain.AdicValuation
-public import TauCeti.NumberTheory.NumberField.Global.Places.Sign
+public import TauCeti.NumberTheory.NumberField.Units.Signature.Integer
 public import TauCeti.RingTheory.Valuation.Approximation
 
 /-!
@@ -47,10 +47,11 @@ directly in terms of the real embeddings.
 
 * `GlobalNumberFields.weakApproximation_denseRange`: the diagonal image of a number field is dense
   in every finite product of finite and infinite completions.
-* `GlobalNumberFields.exists_unit_valuation_sub_lt_and_signHom_eq`: one unit of `K` approximates
+* `GlobalNumberFields.exists_fieldUnit_valuation_sub_lt_and_signHom_eq`: one field unit of `K`
+  approximates
   independently prescribed targets at finitely many finite places while realizing a prescribed
   sign at every real place.
-* `GlobalNumberFields.exists_unit_valuation_eq_and_signHom_eq`: the same with prescribed
+* `GlobalNumberFields.exists_fieldUnit_valuation_eq_and_signHom_eq`: the same with prescribed
   valuations in place of the approximation targets.
 
 ## References
@@ -278,13 +279,13 @@ requirements directly as predicates on the real embeddings.
 
 /-- **Simultaneous approximation with prescribed signs.**  Given a finite set `S` of finite
 places, a target `a v` and a nonzero radius `γ v` at each place of `S`, and a prescribed sign at
-*every* real place, one and the same unit of `K` approximates each finite target to within its own
-radius and has each prescribed sign.
+*every* real place, one and the same field unit of `K` approximates each finite target to within
+its own radius and has each prescribed sign.
 
 The finite conditions are independent of one another and of the archimedean ones; this is the
 `Kˣ`-valued form of `weakApproximation_denseRange`, and it is what a congruence-and-positivity
 statement for a modulus is built from. -/
-theorem exists_unit_valuation_sub_lt_and_signHom_eq
+theorem exists_fieldUnit_valuation_sub_lt_and_signHom_eq
     {S : Finset (HeightOneSpectrum (RingOfIntegers K))}
     (a : HeightOneSpectrum (RingOfIntegers K) → K)
     (γ : HeightOneSpectrum (RingOfIntegers K) → ℤᵐ⁰) (hγ : ∀ v ∈ S, γ v ≠ 0)
@@ -310,20 +311,20 @@ theorem exists_unit_valuation_sub_lt_and_signHom_eq
     simpa using h
 
 /-- **Independent valuations at finitely many finite places, with prescribed signs.**  There is a
-unit of `K` whose valuation at each place of a finite set `S` is the prescribed one, and whose
+field unit of `K` whose valuation at each place of a finite set `S` is the prescribed one, and whose
 sign at each real place is the prescribed one.
 
-This is `exists_unit_valuation_sub_lt_and_signHom_eq` with the approximation targets taken to be
-elements of the required valuation; the ultrametric inequality then turns "close to a target" into
-"equal valuation". -/
-theorem exists_unit_valuation_eq_and_signHom_eq
+This is `exists_fieldUnit_valuation_sub_lt_and_signHom_eq` with the approximation targets taken to
+be elements of the required valuation; the ultrametric inequality then turns "close to a target"
+into "equal valuation". -/
+theorem exists_fieldUnit_valuation_eq_and_signHom_eq
     (S : Finset (HeightOneSpectrum (RingOfIntegers K)))
     (n : HeightOneSpectrum (RingOfIntegers K) → ℤ)
     (s : {w : InfinitePlace K // w.IsReal} → ℤˣ) :
     ∃ x : Kˣ, (∀ v ∈ S, v.valuation K (x : K) = WithZero.exp (n v)) ∧ signHom x = s := by
   choose p hp using fun v : HeightOneSpectrum (RingOfIntegers K) =>
     v.valuation_surjective K (WithZero.exp (n v))
-  obtain ⟨x, hxf, hxs⟩ := exists_unit_valuation_sub_lt_and_signHom_eq (S := S) p
+  obtain ⟨x, hxf, hxs⟩ := exists_fieldUnit_valuation_sub_lt_and_signHom_eq (S := S) p
     (fun v => WithZero.exp (n v)) (fun _ _ => WithZero.exp_ne_zero) s
   refine ⟨x, fun v hv => ?_, hxs⟩
   have hlt : v.valuation K ((x : K) - p v) < v.valuation K (p v) := by

--- a/TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean
+++ b/TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean
@@ -314,14 +314,17 @@ theorem exists_fieldUnit_valuation_sub_lt_and_signHom_eq
 field unit of `K` whose valuation at each place of a finite set `S` is the prescribed one, and whose
 sign at each real place is the prescribed one.
 
-This is `exists_fieldUnit_valuation_sub_lt_and_signHom_eq` with the approximation targets taken to
-be elements of the required valuation; the ultrametric inequality then turns "close to a target"
-into "equal valuation". -/
+The valuations at the places of `S` are prescribed independently of one another and of the signs,
+and `WithZero.exp (n v)` is an arbitrary nonzero value of `v.valuation K`, so this produces a field
+unit of prescribed order at each prime of a modulus and of prescribed sign at each of its real
+places — the form in which an ideal is moved to a representative prime to that modulus. -/
 theorem exists_fieldUnit_valuation_eq_and_signHom_eq
     (S : Finset (HeightOneSpectrum (RingOfIntegers K)))
     (n : HeightOneSpectrum (RingOfIntegers K) → ℤ)
     (s : {w : InfinitePlace K // w.IsReal} → ℤˣ) :
     ∃ x : Kˣ, (∀ v ∈ S, v.valuation K (x : K) = WithZero.exp (n v)) ∧ signHom x = s := by
+  -- Approximate targets of the required valuation; `Valuation.map_eq_of_sub_lt` then turns
+  -- "close to a target" into "equal valuation".
   choose p hp using fun v : HeightOneSpectrum (RingOfIntegers K) =>
     v.valuation_surjective K (WithZero.exp (n v))
   obtain ⟨x, hxf, hxs⟩ := exists_fieldUnit_valuation_sub_lt_and_signHom_eq (S := S) p

--- a/TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean
+++ b/TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.NumberTheory.NumberField.Completion.InfinitePlace
 public import Mathlib.RingTheory.DedekindDomain.AdicValuation
+public import TauCeti.NumberTheory.NumberField.Global.Places.Sign
 public import TauCeti.RingTheory.Valuation.Approximation
 
 /-!
@@ -28,10 +29,27 @@ The resulting approximation inside the number field is then promoted to the actu
 Density of the field in each individual completion supplies nearby field-valued targets, and a
 second simultaneous approximation remains inside the prescribed product neighbourhood.
 
-## Main result
+Two consequences for a *unit* of `K` are derived from it.  Prescribing an approximation target at
+each of finitely many finite places and a sign at each real place is one open condition on the
+product, so one element of `Kˣ` meets all of them at once; specializing the finite targets to
+elements of prescribed valuation gives independent valuations instead.  Taking no finite place at
+all leaves the surjectivity of the total sign homomorphism, which is the archimedean input to the
+narrow class group.
+
+The conclusions are about `Kˣ` rather than `K`, and this is not cosmetic: an approximation
+statement in `K` cannot prescribe signs, because `0` is close to everything and has no sign.
+
+## Main results
 
 * `GlobalNumberFields.weakApproximation_denseRange`: the diagonal image of a number field is dense
   in every finite product of finite and infinite completions.
+* `GlobalNumberFields.exists_units_valuation_sub_lt_and_signHom_eq`: one unit of `K` approximates
+  independently prescribed targets at finitely many finite places while realizing a prescribed
+  sign at every real place.
+* `GlobalNumberFields.exists_units_valuation_eq_and_signHom_eq`: the same with prescribed
+  valuations in place of the approximation targets.
+* `GlobalNumberFields.signHom_surjective`: every pattern of signs at the real places is realized
+  by a unit of `K`.
 
 ## References
 
@@ -248,5 +266,103 @@ theorem weakApproximation_denseRange
       ← (WithAbs.equiv w.1.1).apply_symm_apply (x - ainf w),
       InfinitePlace.Completion.norm_coe]
     exact hxinf w
+
+/-! ### Simultaneous approximation in `Kˣ`
+
+The three statements below are all about `Kˣ`.  A version in `K` would be strictly weaker: `0` is
+within every prescribed distance of nothing in particular but carries no sign, so it satisfies the
+archimedean half of a sign prescription vacuously.
+-/
+
+/-- **Simultaneous approximation with prescribed signs.**  Given a finite set `S` of finite
+places, a target `a v` and a nonzero radius `γ v` at each place of `S`, and a prescribed sign at
+*every* real place, one and the same unit of `K` approximates each finite target to within its own
+radius and has each prescribed sign.
+
+The finite conditions are independent of one another and of the archimedean ones; this is the
+`Kˣ`-valued form of `weakApproximation_denseRange`, and it is what a congruence-and-positivity
+statement for a modulus is built from. -/
+theorem exists_units_valuation_sub_lt_and_signHom_eq
+    {S : Finset (HeightOneSpectrum (RingOfIntegers K))}
+    (a : HeightOneSpectrum (RingOfIntegers K) → K)
+    (γ : HeightOneSpectrum (RingOfIntegers K) → ℤᵐ⁰) (hγ : ∀ v ∈ S, γ v ≠ 0)
+    (s : {w : InfinitePlace K // w.IsReal} → ℤˣ) :
+    ∃ x : Kˣ, (∀ v ∈ S, v.valuation K ((x : K) - a v) < γ v) ∧ signHom x = s := by
+  classical
+  obtain ⟨w₀⟩ := (inferInstance : Nonempty (InfinitePlace K))
+  -- The archimedean targets: the prescribed sign at a real place, and `1` at a complex place.
+  obtain ⟨b, hbsign, hbabs⟩ : ∃ b : InfinitePlace K → K,
+      (∀ w : {w : InfinitePlace K // w.IsReal},
+        InfinitePlace.embedding_of_isReal w.2 (b w.1) = ((s w : ℤ) : ℝ)) ∧
+      ∀ w : InfinitePlace K, w (b w) = 1 := by
+    refine ⟨fun w => if h : w.IsReal then ((s ⟨w, h⟩ : ℤ) : K) else 1, fun w => ?_, fun w => ?_⟩
+    · dsimp only
+      rw [dite_eq_left w.2, Subtype.coe_eta, map_intCast]
+    · dsimp only
+      by_cases h : w.IsReal
+      · rw [dite_eq_left h]
+        rcases Int.units_eq_one_or (s ⟨w, h⟩) with hs | hs <;> rw [hs]
+        · simp
+        · rw [InfinitePlace.coe_apply]
+          simp
+      · rw [dite_eq_right h, map_one]
+  obtain ⟨x, hxf, hxi⟩ := exists_mixed_approximation (Sₑ := S) (Sinf := Finset.univ)
+    (fun v => a v.1) (fun w => b w.1) (fun v => γ v.1) (fun v => hγ v.1 v.2)
+    (fun _ => 1 / 2) (fun _ => by norm_num)
+  have hxi' : ∀ w : InfinitePlace K, w (x - b w) < 1 / 2 := fun w => hxi ⟨w, Finset.mem_univ w⟩
+  -- A point within `1/2` of an element of absolute value one at some place is nonzero.
+  have hx0 : x ≠ 0 := by
+    intro h
+    have h1 := hxi' w₀
+    rw [h, zero_sub, InfinitePlace.coe_apply, w₀.1.map_neg, ← InfinitePlace.coe_apply,
+      hbabs w₀] at h1
+    norm_num at h1
+  refine ⟨Units.mk0 x hx0, fun v hv => by simpa using hxf ⟨v, hv⟩, ?_⟩
+  funext w
+  have hclose : |InfinitePlace.embedding_of_isReal w.2 (x - b w.1)| < 1 / 2 := by
+    rw [← Real.norm_eq_abs, InfinitePlace.norm_embedding_of_isReal]
+    exact hxi' w.1
+  rw [map_sub, hbsign w, abs_lt] at hclose
+  rcases Int.units_eq_one_or (s w) with hs | hs <;> rw [hs] at hclose ⊢
+  · rw [signHom_apply_eq_one_iff, Units.val_mk0]
+    push_cast at hclose
+    linarith [hclose.1]
+  · rw [signHom_apply_eq_neg_one_iff, Units.val_mk0]
+    push_cast at hclose
+    linarith [hclose.2]
+
+/-- **Independent valuations at finitely many finite places, with prescribed signs.**  There is a
+unit of `K` whose valuation at each place of a finite set `S` is the prescribed one, and whose
+sign at each real place is the prescribed one.
+
+This is `exists_units_valuation_sub_lt_and_signHom_eq` with the approximation targets taken to be
+elements of the required valuation; the ultrametric inequality then turns "close to a target" into
+"equal valuation". -/
+theorem exists_units_valuation_eq_and_signHom_eq
+    (S : Finset (HeightOneSpectrum (RingOfIntegers K)))
+    (n : HeightOneSpectrum (RingOfIntegers K) → ℤ)
+    (s : {w : InfinitePlace K // w.IsReal} → ℤˣ) :
+    ∃ x : Kˣ, (∀ v ∈ S, v.valuation K (x : K) = WithZero.exp (n v)) ∧ signHom x = s := by
+  choose p hp using fun v : HeightOneSpectrum (RingOfIntegers K) =>
+    v.valuation_surjective K (WithZero.exp (n v))
+  obtain ⟨x, hxf, hxs⟩ := exists_units_valuation_sub_lt_and_signHom_eq (S := S) p
+    (fun v => WithZero.exp (n v)) (fun _ _ => WithZero.exp_ne_zero) s
+  refine ⟨x, fun v hv => ?_, hxs⟩
+  have hlt : v.valuation K ((x : K) - p v) < v.valuation K (p v) := by
+    rw [hp v]
+    exact hxf v hv
+  have h := Valuation.map_add_eq_of_lt_right (v.valuation K) hlt
+  rw [sub_add_cancel] at h
+  rw [h, hp v]
+
+/-- **The total sign homomorphism is surjective on `Kˣ`.**  Every pattern of signs at the real
+places of `K` is realized by an element of `Kˣ`.
+
+Surjectivity fails in general after restricting along `(𝓞 K)ˣ → Kˣ`, and that failure is the
+obstruction which separates the narrow class group of `K` from the wide one; nothing here bears on
+the restricted map. -/
+theorem signHom_surjective : Function.Surjective (signHom (K := K)) := fun s => by
+  obtain ⟨x, -, hx⟩ := exists_units_valuation_eq_and_signHom_eq (∅ : Finset _) (fun _ => 0) s
+  exact ⟨x, hx⟩
 
 end TauCeti.GlobalNumberFields

--- a/TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean
+++ b/TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean
@@ -9,7 +9,6 @@ public import Mathlib.NumberTheory.NumberField.Completion.InfinitePlace
 public import Mathlib.RingTheory.DedekindDomain.AdicValuation
 public import TauCeti.NumberTheory.NumberField.Global.Places.Sign
 public import TauCeti.RingTheory.Valuation.Approximation
-import TauCeti.NumberTheory.NumberField.SignApproximation
 
 /-!
 # Weak approximation at finite and infinite places
@@ -40,17 +39,18 @@ approximation of it are
 `NumberField.mul_pos_of_infinitePlace_sub_lt`, shared with the purely archimedean statement
 `NumberField.exists_ne_zero_forall_isReal_pos`.
 
-The conclusions are about `Kˣ` rather than `K`, and this is not cosmetic: an approximation
-statement in `K` cannot prescribe signs, because `0` is close to everything and has no sign.
+The conclusions use `Kˣ` to package the required nonvanishing and make `signHom` applicable.  A
+`K`-valued formulation would instead need an explicit `x ≠ 0` condition and sign predicates stated
+directly in terms of the real embeddings.
 
 ## Main results
 
 * `GlobalNumberFields.weakApproximation_denseRange`: the diagonal image of a number field is dense
   in every finite product of finite and infinite completions.
-* `GlobalNumberFields.exists_units_valuation_sub_lt_and_signHom_eq`: one unit of `K` approximates
+* `GlobalNumberFields.exists_unit_valuation_sub_lt_and_signHom_eq`: one unit of `K` approximates
   independently prescribed targets at finitely many finite places while realizing a prescribed
   sign at every real place.
-* `GlobalNumberFields.exists_units_valuation_eq_and_signHom_eq`: the same with prescribed
+* `GlobalNumberFields.exists_unit_valuation_eq_and_signHom_eq`: the same with prescribed
   valuations in place of the approximation targets.
 
 ## References
@@ -271,9 +271,9 @@ theorem weakApproximation_denseRange
 
 /-! ### Simultaneous approximation in `Kˣ`
 
-The two statements below are both about `Kˣ`.  A version in `K` would be strictly weaker: `0` is
-within every prescribed distance of nothing in particular but carries no sign, so it satisfies the
-archimedean half of a sign prescription vacuously.
+The two statements below use `Kˣ` to package the required nonvanishing and make `signHom`
+applicable.  A `K`-valued version would need an explicit `x ≠ 0` condition and would state the sign
+requirements directly as predicates on the real embeddings.
 -/
 
 /-- **Simultaneous approximation with prescribed signs.**  Given a finite set `S` of finite
@@ -284,7 +284,7 @@ radius and has each prescribed sign.
 The finite conditions are independent of one another and of the archimedean ones; this is the
 `Kˣ`-valued form of `weakApproximation_denseRange`, and it is what a congruence-and-positivity
 statement for a modulus is built from. -/
-theorem exists_units_valuation_sub_lt_and_signHom_eq
+theorem exists_unit_valuation_sub_lt_and_signHom_eq
     {S : Finset (HeightOneSpectrum (RingOfIntegers K))}
     (a : HeightOneSpectrum (RingOfIntegers K) → K)
     (γ : HeightOneSpectrum (RingOfIntegers K) → ℤᵐ⁰) (hγ : ∀ v ∈ S, γ v ≠ 0)
@@ -298,13 +298,7 @@ theorem exists_units_valuation_sub_lt_and_signHom_eq
     (fun v => a v.1) (fun w => b w.1) (fun v => γ v.1) (fun v => hγ v.1 v.2)
     (fun _ => 1) (fun _ => one_pos)
   have hxi' : ∀ w : InfinitePlace K, w (x - b w) < 1 := fun w => hxi ⟨w, Finset.mem_univ w⟩
-  -- A point within `1` of a target of absolute value one at some place is nonzero.
-  have hx0 : x ≠ 0 := by
-    intro h
-    have h1 := hxi' w₀
-    rw [h, zero_sub, InfinitePlace.coe_apply, w₀.1.map_neg, ← InfinitePlace.coe_apply,
-      hbabs w₀] at h1
-    exact lt_irrefl 1 h1
+  have hx0 := NumberField.ne_zero_of_infinitePlace_sub_lt (hbabs w₀) (hxi' w₀)
   refine ⟨Units.mk0 x hx0, fun v hv => by simpa using hxf ⟨v, hv⟩, ?_⟩
   funext w
   have h := NumberField.mul_pos_of_infinitePlace_sub_lt w.2 (hbabs w.1) (hxi' w.1)
@@ -319,17 +313,17 @@ theorem exists_units_valuation_sub_lt_and_signHom_eq
 unit of `K` whose valuation at each place of a finite set `S` is the prescribed one, and whose
 sign at each real place is the prescribed one.
 
-This is `exists_units_valuation_sub_lt_and_signHom_eq` with the approximation targets taken to be
+This is `exists_unit_valuation_sub_lt_and_signHom_eq` with the approximation targets taken to be
 elements of the required valuation; the ultrametric inequality then turns "close to a target" into
 "equal valuation". -/
-theorem exists_units_valuation_eq_and_signHom_eq
+theorem exists_unit_valuation_eq_and_signHom_eq
     (S : Finset (HeightOneSpectrum (RingOfIntegers K)))
     (n : HeightOneSpectrum (RingOfIntegers K) → ℤ)
     (s : {w : InfinitePlace K // w.IsReal} → ℤˣ) :
     ∃ x : Kˣ, (∀ v ∈ S, v.valuation K (x : K) = WithZero.exp (n v)) ∧ signHom x = s := by
   choose p hp using fun v : HeightOneSpectrum (RingOfIntegers K) =>
     v.valuation_surjective K (WithZero.exp (n v))
-  obtain ⟨x, hxf, hxs⟩ := exists_units_valuation_sub_lt_and_signHom_eq (S := S) p
+  obtain ⟨x, hxf, hxs⟩ := exists_unit_valuation_sub_lt_and_signHom_eq (S := S) p
     (fun v => WithZero.exp (n v)) (fun _ _ => WithZero.exp_ne_zero) s
   refine ⟨x, fun v hv => ?_, hxs⟩
   have hlt : v.valuation K ((x : K) - p v) < v.valuation K (p v) := by

--- a/TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean
+++ b/TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean
@@ -9,6 +9,7 @@ public import Mathlib.NumberTheory.NumberField.Completion.InfinitePlace
 public import Mathlib.RingTheory.DedekindDomain.AdicValuation
 public import TauCeti.NumberTheory.NumberField.Global.Places.Sign
 public import TauCeti.RingTheory.Valuation.Approximation
+import TauCeti.NumberTheory.NumberField.SignApproximation
 
 /-!
 # Weak approximation at finite and infinite places
@@ -32,9 +33,12 @@ second simultaneous approximation remains inside the prescribed product neighbou
 Two consequences for a *unit* of `K` are derived from it.  Prescribing an approximation target at
 each of finitely many finite places and a sign at each real place is one open condition on the
 product, so one element of `Kˣ` meets all of them at once; specializing the finite targets to
-elements of prescribed valuation gives independent valuations instead.  Taking no finite place at
-all leaves the surjectivity of the total sign homomorphism, which is the archimedean input to the
-narrow class group.
+elements of prescribed valuation gives independent valuations instead.  The archimedean half of the
+prescription is not redone here: the target family and the estimate that reads a sign off an
+approximation of it are
+`NumberField.exists_forall_apply_eq_one_and_embedding_of_isReal_eq` and
+`NumberField.mul_pos_of_infinitePlace_sub_lt`, shared with the purely archimedean statement
+`NumberField.exists_ne_zero_forall_isReal_pos`.
 
 The conclusions are about `Kˣ` rather than `K`, and this is not cosmetic: an approximation
 statement in `K` cannot prescribe signs, because `0` is close to everything and has no sign.
@@ -48,8 +52,6 @@ statement in `K` cannot prescribe signs, because `0` is close to everything and 
   sign at every real place.
 * `GlobalNumberFields.exists_units_valuation_eq_and_signHom_eq`: the same with prescribed
   valuations in place of the approximation targets.
-* `GlobalNumberFields.signHom_surjective`: every pattern of signs at the real places is realized
-  by a unit of `K`.
 
 ## References
 
@@ -269,7 +271,7 @@ theorem weakApproximation_denseRange
 
 /-! ### Simultaneous approximation in `Kˣ`
 
-The three statements below are all about `Kˣ`.  A version in `K` would be strictly weaker: `0` is
+The two statements below are both about `Kˣ`.  A version in `K` would be strictly weaker: `0` is
 within every prescribed distance of nothing in particular but carries no sign, so it satisfies the
 archimedean half of a sign prescription vacuously.
 -/
@@ -288,48 +290,30 @@ theorem exists_units_valuation_sub_lt_and_signHom_eq
     (γ : HeightOneSpectrum (RingOfIntegers K) → ℤᵐ⁰) (hγ : ∀ v ∈ S, γ v ≠ 0)
     (s : {w : InfinitePlace K // w.IsReal} → ℤˣ) :
     ∃ x : Kˣ, (∀ v ∈ S, v.valuation K ((x : K) - a v) < γ v) ∧ signHom x = s := by
-  classical
   obtain ⟨w₀⟩ := (inferInstance : Nonempty (InfinitePlace K))
-  -- The archimedean targets: the prescribed sign at a real place, and `1` at a complex place.
-  obtain ⟨b, hbsign, hbabs⟩ : ∃ b : InfinitePlace K → K,
-      (∀ w : {w : InfinitePlace K // w.IsReal},
-        InfinitePlace.embedding_of_isReal w.2 (b w.1) = ((s w : ℤ) : ℝ)) ∧
-      ∀ w : InfinitePlace K, w (b w) = 1 := by
-    refine ⟨fun w => if h : w.IsReal then ((s ⟨w, h⟩ : ℤ) : K) else 1, fun w => ?_, fun w => ?_⟩
-    · dsimp only
-      rw [dite_eq_left w.2, Subtype.coe_eta, map_intCast]
-    · dsimp only
-      by_cases h : w.IsReal
-      · rw [dite_eq_left h]
-        rcases Int.units_eq_one_or (s ⟨w, h⟩) with hs | hs <;> rw [hs]
-        · simp
-        · rw [InfinitePlace.coe_apply]
-          simp
-      · rw [dite_eq_right h, map_one]
+  -- The archimedean targets: absolute value one everywhere, with the prescribed signs.
+  obtain ⟨b, hbabs, hbsign⟩ :=
+    NumberField.exists_forall_apply_eq_one_and_embedding_of_isReal_eq (K := K) s
   obtain ⟨x, hxf, hxi⟩ := exists_mixed_approximation (Sₑ := S) (Sinf := Finset.univ)
     (fun v => a v.1) (fun w => b w.1) (fun v => γ v.1) (fun v => hγ v.1 v.2)
-    (fun _ => 1 / 2) (fun _ => by norm_num)
-  have hxi' : ∀ w : InfinitePlace K, w (x - b w) < 1 / 2 := fun w => hxi ⟨w, Finset.mem_univ w⟩
-  -- A point within `1/2` of an element of absolute value one at some place is nonzero.
+    (fun _ => 1) (fun _ => one_pos)
+  have hxi' : ∀ w : InfinitePlace K, w (x - b w) < 1 := fun w => hxi ⟨w, Finset.mem_univ w⟩
+  -- A point within `1` of a target of absolute value one at some place is nonzero.
   have hx0 : x ≠ 0 := by
     intro h
     have h1 := hxi' w₀
     rw [h, zero_sub, InfinitePlace.coe_apply, w₀.1.map_neg, ← InfinitePlace.coe_apply,
       hbabs w₀] at h1
-    norm_num at h1
+    exact lt_irrefl 1 h1
   refine ⟨Units.mk0 x hx0, fun v hv => by simpa using hxf ⟨v, hv⟩, ?_⟩
   funext w
-  have hclose : |InfinitePlace.embedding_of_isReal w.2 (x - b w.1)| < 1 / 2 := by
-    rw [← Real.norm_eq_abs, InfinitePlace.norm_embedding_of_isReal]
-    exact hxi' w.1
-  rw [map_sub, hbsign w, abs_lt] at hclose
-  rcases Int.units_eq_one_or (s w) with hs | hs <;> rw [hs] at hclose ⊢
+  have h := NumberField.mul_pos_of_infinitePlace_sub_lt w.2 (hbabs w.1) (hxi' w.1)
+  rw [hbsign w] at h
+  rcases Int.units_eq_one_or (s w) with hs | hs <;> rw [hs] at h ⊢
   · rw [signHom_apply_eq_one_iff, Units.val_mk0]
-    push_cast at hclose
-    linarith [hclose.1]
+    simpa using h
   · rw [signHom_apply_eq_neg_one_iff, Units.val_mk0]
-    push_cast at hclose
-    linarith [hclose.2]
+    simpa using h
 
 /-- **Independent valuations at finitely many finite places, with prescribed signs.**  There is a
 unit of `K` whose valuation at each place of a finite set `S` is the prescribed one, and whose
@@ -351,18 +335,6 @@ theorem exists_units_valuation_eq_and_signHom_eq
   have hlt : v.valuation K ((x : K) - p v) < v.valuation K (p v) := by
     rw [hp v]
     exact hxf v hv
-  have h := Valuation.map_add_eq_of_lt_right (v.valuation K) hlt
-  rw [sub_add_cancel] at h
-  rw [h, hp v]
-
-/-- **The total sign homomorphism is surjective on `Kˣ`.**  Every pattern of signs at the real
-places of `K` is realized by an element of `Kˣ`.
-
-Surjectivity fails in general after restricting along `(𝓞 K)ˣ → Kˣ`, and that failure is the
-obstruction which separates the narrow class group of `K` from the wide one; nothing here bears on
-the restricted map. -/
-theorem signHom_surjective : Function.Surjective (signHom (K := K)) := fun s => by
-  obtain ⟨x, -, hx⟩ := exists_units_valuation_eq_and_signHom_eq (∅ : Finset _) (fun _ => 0) s
-  exact ⟨x, hx⟩
+  rw [Valuation.map_eq_of_sub_lt (v.valuation K) hlt, hp v]
 
 end TauCeti.GlobalNumberFields

--- a/TauCeti/NumberTheory/NumberField/Global/Places/Sign.lean
+++ b/TauCeti/NumberTheory/NumberField/Global/Places/Sign.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.NumberField.InfinitePlace.Basic
+
+/-!
+# The total sign homomorphism of a number field
+
+A real place `w` of a number field `K` carries an embedding
+`NumberField.InfinitePlace.embedding_of_isReal : K →+* ℝ`, so every nonzero element of `K` has a
+sign at `w`.  Collecting those signs over all the real places gives the **total sign
+homomorphism**
+
+```text
+signHom : Kˣ →* ({w : InfinitePlace K // w.IsReal} → ℤˣ).
+```
+
+This is the archimedean half of a multiplicative congruence in group-theoretic form: `x` is
+totally positive exactly when `signHom x = 1`.
+
+Surjectivity of `signHom` is not formal — it is a consequence of weak approximation, and is proved
+as `TauCeti.GlobalNumberFields.signHom_surjective` in
+`TauCeti.NumberTheory.NumberField.Global.Approximation.Weak`.  The composite
+`(𝓞 K)ˣ → Kˣ → ({w // w.IsReal} → ℤˣ)` need *not* be surjective, and its failure to be so is
+exactly the obstruction that separates the narrow class group from the wide one; nothing here
+asserts otherwise.
+
+## Main definitions
+
+* `TauCeti.GlobalNumberFields.signHom`: the total sign homomorphism.
+
+## Main results
+
+* `TauCeti.GlobalNumberFields.signHom_apply_eq_one_iff` and
+  `TauCeti.GlobalNumberFields.signHom_apply_eq_neg_one_iff`: the two possible signs, read off as
+  positivity and negativity of the real embedding.
+* `TauCeti.GlobalNumberFields.signHom_eq_one_iff`: an element lies in the kernel exactly when it
+  is totally positive.
+
+## References
+
+* J. Neukirch, *Algebraic Number Theory*, Chapter VI, §1.
+-/
+
+public section
+
+open NumberField
+
+namespace TauCeti.GlobalNumberFields
+
+variable {K : Type*} [Field K]
+
+/-- A real embedding of a number field does not vanish on a unit. -/
+theorem embedding_of_isReal_ne_zero (w : {w : InfinitePlace K // w.IsReal}) (x : Kˣ) :
+    InfinitePlace.embedding_of_isReal w.2 (x : K) ≠ 0 :=
+  (map_ne_zero_iff _ (InfinitePlace.embedding_of_isReal w.2).injective).mpr x.ne_zero
+
+/-- **The total sign homomorphism of a number field**: the signs of a unit of `K` at all of the
+real places at once, valued in the product of copies of `ℤˣ` indexed by those places.
+
+The domain is `Kˣ` rather than `K`, so that every value really is a sign: a formulation on `K`
+would have to invent a sign for `0`. -/
+noncomputable def signHom : Kˣ →* ({w : InfinitePlace K // w.IsReal} → ℤˣ) where
+  toFun x w := if 0 < InfinitePlace.embedding_of_isReal w.2 (x : K) then 1 else -1
+  map_one' := by
+    funext w
+    simp
+  map_mul' x y := by
+    funext w
+    have hx := lt_or_gt_of_ne (embedding_of_isReal_ne_zero w x)
+    have hy := lt_or_gt_of_ne (embedding_of_isReal_ne_zero w y)
+    simp only [Pi.mul_apply, Units.val_mul, map_mul]
+    rcases hx with hx | hx <;> rcases hy with hy | hy
+    · rw [ite_eq_left (mul_pos_of_neg_of_neg hx hy), ite_eq_right (not_lt.mpr hx.le),
+        ite_eq_right (not_lt.mpr hy.le)]
+      simp
+    · rw [ite_eq_right (not_lt.mpr (mul_neg_of_neg_of_pos hx hy).le),
+        ite_eq_right (not_lt.mpr hx.le), ite_eq_left hy]
+      simp
+    · rw [ite_eq_right (not_lt.mpr (mul_neg_of_pos_of_neg hx hy).le), ite_eq_left hx,
+        ite_eq_right (not_lt.mpr hy.le)]
+      simp
+    · rw [ite_eq_left (mul_pos hx hy), ite_eq_left hx, ite_eq_left hy]
+      simp
+
+private theorem signHom_apply (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
+    signHom x w = if 0 < InfinitePlace.embedding_of_isReal w.2 (x : K) then 1 else -1 := rfl
+
+/-- **A sign is `1` exactly at a positive element.** -/
+@[simp] theorem signHom_apply_eq_one_iff (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
+    signHom x w = 1 ↔ 0 < InfinitePlace.embedding_of_isReal w.2 (x : K) := by
+  rw [signHom_apply]
+  split_ifs with h
+  · simp [h]
+  · simp [h]
+
+/-- **A sign is `-1` exactly at a negative element.** -/
+@[simp] theorem signHom_apply_eq_neg_one_iff (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
+    signHom x w = -1 ↔ InfinitePlace.embedding_of_isReal w.2 (x : K) < 0 := by
+  rw [signHom_apply]
+  rcases lt_or_gt_of_ne (embedding_of_isReal_ne_zero w x) with h | h
+  · rw [ite_eq_right (not_lt.mpr h.le)]
+    simp [h]
+  · rw [ite_eq_left h]
+    simp [asymm h]
+
+/-- **The kernel of the total sign homomorphism is the totally positive elements.** -/
+theorem signHom_eq_one_iff (x : Kˣ) :
+    signHom x = 1 ↔ ∀ w : {w : InfinitePlace K // w.IsReal},
+      0 < InfinitePlace.embedding_of_isReal w.2 (x : K) := by
+  rw [funext_iff]
+  exact forall_congr' fun w ↦ by rw [Pi.one_apply, signHom_apply_eq_one_iff]
+
+end TauCeti.GlobalNumberFields

--- a/TauCeti/NumberTheory/NumberField/Global/Places/Sign.lean
+++ b/TauCeti/NumberTheory/NumberField/Global/Places/Sign.lean
@@ -5,33 +5,34 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.NumberTheory.NumberField.InfinitePlace.Basic
+public import TauCeti.Algebra.Order.Ring.Units
+public import TauCeti.NumberTheory.NumberField.Units.Signature.Surjective
 
 /-!
-# The total sign homomorphism of a number field
+# The total sign homomorphism of a number field, valued in `ℤˣ`
 
-A real place `w` of a number field `K` carries an embedding
-`NumberField.InfinitePlace.embedding_of_isReal : K →+* ℝ`, so every nonzero element of `K` has a
-sign at `w`.  Collecting those signs over all the real places gives the **total sign
-homomorphism**
+`NumberField.fieldUnitSignature` records the sign of a unit of `K` at each real place as a class in
+`ℝˣ ⧸ Units.posSubgroup ℝ`.  Transporting each of those classes along the sign isomorphism
+`Units.signEquiv` gives the same data in the concrete two-element group `ℤˣ`:
 
 ```text
 signHom : Kˣ →* ({w : InfinitePlace K // w.IsReal} → ℤˣ).
 ```
 
 This is the archimedean half of a multiplicative congruence in group-theoretic form: `x` is
-totally positive exactly when `signHom x = 1`.
+totally positive exactly when `signHom x = 1`.  There is no second sign homomorphism here — this is
+`NumberField.fieldUnitSignature` read in `ℤˣ`, and the two are interchangeable through
+`Units.signEquiv`.
 
-Surjectivity of `signHom` is not formal — it is a consequence of weak approximation, and is proved
-as `TauCeti.GlobalNumberFields.signHom_surjective` in
-`TauCeti.NumberTheory.NumberField.Global.Approximation.Weak`.  The composite
+Surjectivity of `signHom` is not formal — it is weak approximation at the real places, and is
+inherited from `NumberField.fieldUnitSignature_surjective`.  The composite
 `(𝓞 K)ˣ → Kˣ → ({w // w.IsReal} → ℤˣ)` need *not* be surjective, and its failure to be so is
 exactly the obstruction that separates the narrow class group from the wide one; nothing here
 asserts otherwise.
 
 ## Main definitions
 
-* `TauCeti.GlobalNumberFields.signHom`: the total sign homomorphism.
+* `TauCeti.GlobalNumberFields.signHom`: the total sign homomorphism, valued in `ℤˣ`.
 
 ## Main results
 
@@ -40,6 +41,8 @@ asserts otherwise.
   positivity and negativity of the real embedding.
 * `TauCeti.GlobalNumberFields.signHom_eq_one_iff`: an element lies in the kernel exactly when it
   is totally positive.
+* `TauCeti.GlobalNumberFields.signHom_surjective`: every pattern of signs at the real places is
+  realized by a unit of `K`.
 
 ## References
 
@@ -48,71 +51,58 @@ asserts otherwise.
 
 public section
 
-open NumberField
+open NumberField NumberField.InfinitePlace
 
 namespace TauCeti.GlobalNumberFields
 
 variable {K : Type*} [Field K]
 
-/-- A real embedding of a number field does not vanish on a unit. -/
-theorem embedding_of_isReal_ne_zero (w : {w : InfinitePlace K // w.IsReal}) (x : Kˣ) :
-    InfinitePlace.embedding_of_isReal w.2 (x : K) ≠ 0 :=
-  (map_ne_zero_iff _ (InfinitePlace.embedding_of_isReal w.2).injective).mpr x.ne_zero
-
 /-- **The total sign homomorphism of a number field**: the signs of a unit of `K` at all of the
 real places at once, valued in the product of copies of `ℤˣ` indexed by those places.
 
+It is `NumberField.fieldUnitSignature` with each component read through the sign isomorphism
+`Units.signEquiv`, so it carries exactly the same information.
+
 The domain is `Kˣ` rather than `K`, so that every value really is a sign: a formulation on `K`
 would have to invent a sign for `0`. -/
-noncomputable def signHom : Kˣ →* ({w : InfinitePlace K // w.IsReal} → ℤˣ) where
-  toFun x w := if 0 < InfinitePlace.embedding_of_isReal w.2 (x : K) then 1 else -1
-  map_one' := by
-    funext w
-    simp
-  map_mul' x y := by
-    funext w
-    have hx := lt_or_gt_of_ne (embedding_of_isReal_ne_zero w x)
-    have hy := lt_or_gt_of_ne (embedding_of_isReal_ne_zero w y)
-    simp only [Pi.mul_apply, Units.val_mul, map_mul]
-    rcases hx with hx | hx <;> rcases hy with hy | hy
-    · rw [ite_eq_left (mul_pos_of_neg_of_neg hx hy), ite_eq_right (not_lt.mpr hx.le),
-        ite_eq_right (not_lt.mpr hy.le)]
-      simp
-    · rw [ite_eq_right (not_lt.mpr (mul_neg_of_neg_of_pos hx hy).le),
-        ite_eq_right (not_lt.mpr hx.le), ite_eq_left hy]
-      simp
-    · rw [ite_eq_right (not_lt.mpr (mul_neg_of_pos_of_neg hx hy).le), ite_eq_left hx,
-        ite_eq_right (not_lt.mpr hy.le)]
-      simp
-    · rw [ite_eq_left (mul_pos hx hy), ite_eq_left hx, ite_eq_left hy]
-      simp
+noncomputable def signHom : Kˣ →* ({w : InfinitePlace K // w.IsReal} → ℤˣ) :=
+  (MonoidHom.piMap fun _ : {w : InfinitePlace K // w.IsReal} =>
+    (Units.signEquiv ℝ).toMonoidHom).comp fieldUnitSignature
 
-private theorem signHom_apply (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
-    signHom x w = if 0 < InfinitePlace.embedding_of_isReal w.2 (x : K) then 1 else -1 := rfl
+/-- Componentwise evaluation of the total sign homomorphism. -/
+theorem signHom_apply (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
+    signHom x w = Units.signEquiv ℝ (fieldUnitSignature x w) := (rfl)
 
 /-- **A sign is `1` exactly at a positive element.** -/
 @[simp] theorem signHom_apply_eq_one_iff (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
-    signHom x w = 1 ↔ 0 < InfinitePlace.embedding_of_isReal w.2 (x : K) := by
-  rw [signHom_apply]
-  split_ifs with h
-  · simp [h]
-  · simp [h]
+    signHom x w = 1 ↔ 0 < embedding_of_isReal w.2 (x : K) := by
+  rw [signHom_apply, fieldUnitSignature_apply, Units.signEquiv_mk_eq_one_iff]
+  simp
 
 /-- **A sign is `-1` exactly at a negative element.** -/
 @[simp] theorem signHom_apply_eq_neg_one_iff (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
-    signHom x w = -1 ↔ InfinitePlace.embedding_of_isReal w.2 (x : K) < 0 := by
-  rw [signHom_apply]
-  rcases lt_or_gt_of_ne (embedding_of_isReal_ne_zero w x) with h | h
-  · rw [ite_eq_right (not_lt.mpr h.le)]
-    simp [h]
-  · rw [ite_eq_left h]
-    simp [asymm h]
+    signHom x w = -1 ↔ embedding_of_isReal w.2 (x : K) < 0 := by
+  rw [signHom_apply, fieldUnitSignature_apply, Units.signEquiv_mk_eq_neg_one_iff]
+  simp
 
 /-- **The kernel of the total sign homomorphism is the totally positive elements.** -/
-theorem signHom_eq_one_iff (x : Kˣ) :
-    signHom x = 1 ↔ ∀ w : {w : InfinitePlace K // w.IsReal},
-      0 < InfinitePlace.embedding_of_isReal w.2 (x : K) := by
-  rw [funext_iff]
-  exact forall_congr' fun w ↦ by rw [Pi.one_apply, signHom_apply_eq_one_iff]
+theorem signHom_eq_one_iff (x : Kˣ) : signHom x = 1 ↔ IsTotallyPositive (x : K) := by
+  rw [← fieldUnitSignature_eq_one_iff, funext_iff, funext_iff]
+  exact forall_congr' fun w => by
+    rw [Pi.one_apply, Pi.one_apply, signHom_apply,
+      map_eq_one_iff _ (Units.signEquiv ℝ).injective]
+
+/-- **The total sign homomorphism is surjective on `Kˣ`.**  Every pattern of signs at the real
+places of `K` is realized by an element of `Kˣ`.
+
+This is `NumberField.fieldUnitSignature_surjective` read in `ℤˣ`.  Surjectivity fails in general
+after restricting along `(𝓞 K)ˣ → Kˣ`, and that failure is the obstruction which separates the
+narrow class group of `K` from the wide one; nothing here bears on the restricted map. -/
+theorem signHom_surjective [NumberField K] : Function.Surjective (signHom (K := K)) := fun s => by
+  obtain ⟨x, hx⟩ :=
+    NumberField.fieldUnitSignature_surjective (K := K) fun w => (Units.signEquiv ℝ).symm (s w)
+  refine ⟨x, funext fun w => ?_⟩
+  rw [signHom_apply, hx]
+  exact (Units.signEquiv ℝ).apply_symm_apply (s w)
 
 end TauCeti.GlobalNumberFields

--- a/TauCeti/NumberTheory/NumberField/Global/Places/Sign.lean
+++ b/TauCeti/NumberTheory/NumberField/Global/Places/Sign.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Order.Ring.Units
 public import TauCeti.NumberTheory.NumberField.Units.Signature.Surjective
 
 /-!
@@ -86,7 +85,7 @@ theorem signHom_apply (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
   simp
 
 /-- **The kernel of the total sign homomorphism is the totally positive elements.** -/
-theorem signHom_eq_one_iff (x : Kˣ) : signHom x = 1 ↔ IsTotallyPositive (x : K) := by
+@[simp] theorem signHom_eq_one_iff (x : Kˣ) : signHom x = 1 ↔ IsTotallyPositive (x : K) := by
   rw [← fieldUnitSignature_eq_one_iff, funext_iff, funext_iff]
   exact forall_congr' fun w => by
     rw [Pi.one_apply, Pi.one_apply, signHom_apply,

--- a/TauCeti/NumberTheory/NumberField/SignApproximation.lean
+++ b/TauCeti/NumberTheory/NumberField/SignApproximation.lean
@@ -26,6 +26,11 @@ or complex, keeps the element away from `0`.
 
 * `NumberField.exists_forall_infinitePlace_sub_lt`: weak approximation at the infinite
   places in `ε`-`δ` form, with targets in `K` measured by the places themselves.
+* `NumberField.exists_forall_apply_eq_one_and_embedding_of_isReal_eq`: the family of targets that
+  such an approximation is aimed at, of absolute value one at every infinite place and of
+  prescribed sign at every real place.
+* `NumberField.mul_pos_of_infinitePlace_sub_lt`: an element within `1` of a target of absolute
+  value one at a real place has the sign of that target there.
 * `NumberField.exists_ne_zero_forall_isReal_pos`: a nonzero element of `K` whose real
   embeddings have prescribed signs.
 * `NumberField.exists_ne_zero_neg_iff_mem`: the same statement with the prescription given
@@ -66,6 +71,52 @@ theorem exists_forall_infinitePlace_sub_lt (a : InfinitePlace K → K)
   rw [coe_apply, AbsoluteValue.map_sub]
   exact h.trans_le (Finset.inf'_le r (Finset.mem_univ v))
 
+omit [NumberField K] in
+/-- **A family of targets of absolute value one with prescribed signs.**  For any prescribed sign
+at each real place of a number field there is a family `b`, one element of `K` for each infinite
+place, whose entry at `v` has absolute value one at `v` and whose entry at a real place `w` has
+there exactly the prescribed sign.
+
+This is the family that weak approximation at the infinite places is aimed at: absolute value one
+keeps an approximation of it away from `0`, and
+`NumberField.mul_pos_of_infinitePlace_sub_lt` turns the approximation into a sign prescription. -/
+theorem exists_forall_apply_eq_one_and_embedding_of_isReal_eq
+    (s : {w : InfinitePlace K // w.IsReal} → ℤˣ) :
+    ∃ b : InfinitePlace K → K, (∀ v : InfinitePlace K, v (b v) = 1) ∧
+      ∀ w : {w : InfinitePlace K // w.IsReal},
+        embedding_of_isReal w.2 (b w.1) = ((s w : ℤ) : ℝ) := by
+  classical
+  refine ⟨fun v => if h : v.IsReal then ((s ⟨v, h⟩ : ℤ) : K) else 1, fun v => ?_, fun w => ?_⟩
+  · dsimp only
+    by_cases h : v.IsReal
+    · rw [dite_eq_left h]
+      rcases Int.units_eq_one_or (s ⟨v, h⟩) with hs | hs <;> rw [hs]
+      · simp
+      · rw [coe_apply]
+        simp
+    · rw [dite_eq_right h, map_one]
+  · dsimp only
+    rw [dite_eq_left w.2, Subtype.coe_eta, map_intCast]
+
+/-- **An approximation of a target of absolute value one has the sign of that target.**  At a real
+place `w`, an element `x` within `1` of a target `y` with `w y = 1` has the same sign as `y` under
+the real embedding at `w`.
+
+Together with `NumberField.exists_forall_apply_eq_one_and_embedding_of_isReal_eq` this is the whole
+archimedean content of a sign prescription: everything else is the approximation itself. -/
+theorem mul_pos_of_infinitePlace_sub_lt {w : InfinitePlace K} (hw : w.IsReal) {x y : K}
+    (hy : w y = 1) (h : w (x - y) < 1) :
+    0 < embedding_of_isReal hw y * embedding_of_isReal hw x := by
+  have hy' : |embedding_of_isReal hw y| = 1 := by
+    rw [← Real.norm_eq_abs, norm_embedding_of_isReal]
+    exact hy
+  have hσ : |embedding_of_isReal hw x - embedding_of_isReal hw y| < 1 := by
+    rw [← map_sub, ← Real.norm_eq_abs, norm_embedding_of_isReal]
+    exact h
+  rw [abs_lt] at hσ
+  rcases (abs_eq (by norm_num : (0 : ℝ) ≤ 1)).mp hy' with hy1 | hy1 <;> rw [hy1] at hσ ⊢ <;>
+    linarith [hσ.1, hσ.2]
+
 /-- **A nonzero element with prescribed signs at the real places.** For any family of nonzero
 reals `s`, indexed by the real infinite places of a number field `K`, some nonzero `x : K` has
 `s w` and the image of `x` under the real embedding at `w` of the same sign, at every real place
@@ -75,39 +126,28 @@ theorem exists_ne_zero_forall_isReal_pos (s : {w : InfinitePlace K // w.IsReal} 
     ∃ x : K, x ≠ 0 ∧
       ∀ w : {w : InfinitePlace K // w.IsReal}, 0 < s w * embedding_of_isReal w.2 x := by
   classical
-  -- Aim at `1` where the prescribed sign is positive and at `-1` where it is negative; at a
-  -- complex place the target is irrelevant, and `1` serves.
-  set a : InfinitePlace K → K := fun v =>
-    if h : v.IsReal then (if 0 < s ⟨v, h⟩ then 1 else -1) else 1 with ha
-  have hreal : ∀ w : {w : InfinitePlace K // w.IsReal}, a w.1 = if 0 < s w then 1 else -1 := by
-    intro w
-    simp [ha, w.2]
-  -- Every target has absolute value `1` at its own place, so it stays away from `0`.
-  have habs : ∀ v : InfinitePlace K, v (a v) = 1 := by
-    intro v
-    have h : a v = 1 ∨ a v = -1 := by
-      simp only [ha]
-      split_ifs <;> simp
-    rw [coe_apply]
-    rcases h with h | h <;> rw [h] <;> simp
-  obtain ⟨x, hx⟩ := exists_forall_infinitePlace_sub_lt a (fun _ => 1) fun _ => one_pos
+  -- Aim at `1` where the prescribed sign is positive and at `-1` where it is negative.
+  obtain ⟨b, habs, hb⟩ := exists_forall_apply_eq_one_and_embedding_of_isReal_eq (K := K)
+    fun w => if 0 < s w then 1 else -1
+  have hb' : ∀ w : {w : InfinitePlace K // w.IsReal},
+      embedding_of_isReal w.2 (b w.1) = if 0 < s w then (1 : ℝ) else -1 := fun w => by
+    rw [hb w]
+    split_ifs <;> simp
+  obtain ⟨x, hx⟩ := exists_forall_infinitePlace_sub_lt b (fun _ => 1) fun _ => one_pos
+  -- A point within `1` of a target of absolute value one at some place is nonzero.
   have hx0 : x ≠ 0 := by
     rintro rfl
     have h := hx (Classical.arbitrary (InfinitePlace K))
     rw [coe_apply, zero_sub, AbsoluteValue.map_neg, ← coe_apply, habs] at h
     exact lt_irrefl 1 h
   refine ⟨x, hx0, fun w => ?_⟩
-  -- At a real place the place is the absolute value of the real embedding.
-  have hσ : |embedding_of_isReal w.2 x - embedding_of_isReal w.2 (a w.1)| < 1 := by
-    rw [← map_sub, ← Real.norm_eq_abs, norm_embedding_of_isReal]
-    exact hx w.1
+  have h := mul_pos_of_infinitePlace_sub_lt w.2 (habs w.1) (hx w.1)
+  rw [hb' w] at h
   by_cases h' : 0 < s w
-  · have hax : a w.1 = 1 := by rw [hreal w]; simp [h']
-    rw [hax, map_one, abs_lt] at hσ
-    exact mul_pos h' (by linarith [hσ.1])
-  · have hax : a w.1 = -1 := by rw [hreal w]; simp [h']
-    rw [hax, map_neg, map_one, sub_neg_eq_add, abs_lt] at hσ
-    exact mul_pos_of_neg_of_neg (lt_of_le_of_ne (not_lt.mp h') (hs w)) (by linarith [hσ.2])
+  · rw [ite_eq_left h', one_mul] at h
+    exact mul_pos h' h
+  · rw [ite_eq_right h', neg_one_mul, neg_pos] at h
+    exact mul_pos_of_neg_of_neg (lt_of_le_of_ne (not_lt.mp h') (hs w)) h
 
 /-- **A nonzero element of `K` negative at exactly a prescribed set of real places.** Since the
 real places at which an element is negative determine its sign pattern, this is

--- a/TauCeti/NumberTheory/NumberField/SignApproximation.lean
+++ b/TauCeti/NumberTheory/NumberField/SignApproximation.lean
@@ -31,6 +31,8 @@ or complex, keeps the element away from `0`.
   prescribed sign at every real place.
 * `NumberField.mul_pos_of_infinitePlace_sub_lt`: an element within `1` of a target of absolute
   value one at a real place has the sign of that target there.
+* `NumberField.ne_zero_of_infinitePlace_sub_lt`: an element within `1` of a target of absolute
+  value one at any infinite place is nonzero.
 * `NumberField.exists_ne_zero_forall_isReal_pos`: a nonzero element of `K` whose real
   embeddings have prescribed signs.
 * `NumberField.exists_ne_zero_neg_iff_mem`: the same statement with the prescription given
@@ -117,6 +119,14 @@ theorem mul_pos_of_infinitePlace_sub_lt {w : InfinitePlace K} (hw : w.IsReal) {x
   rcases (abs_eq (by norm_num : (0 : ℝ) ≤ 1)).mp hy' with hy1 | hy1 <;> rw [hy1] at hσ ⊢ <;>
     linarith [hσ.1, hσ.2]
 
+omit [NumberField K] in
+/-- An element within `1` of a target of absolute value one at an infinite place is nonzero. -/
+theorem ne_zero_of_infinitePlace_sub_lt {w : InfinitePlace K} {x y : K} (hy : w y = 1)
+    (h : w (x - y) < 1) : x ≠ 0 := by
+  rintro rfl
+  rw [coe_apply, zero_sub, AbsoluteValue.map_neg, ← coe_apply, hy] at h
+  exact lt_irrefl 1 h
+
 /-- **A nonzero element with prescribed signs at the real places.** For any family of nonzero
 reals `s`, indexed by the real infinite places of a number field `K`, some nonzero `x : K` has
 `s w` and the image of `x` under the real embedding at `w` of the same sign, at every real place
@@ -134,12 +144,8 @@ theorem exists_ne_zero_forall_isReal_pos (s : {w : InfinitePlace K // w.IsReal} 
     rw [hb w]
     split_ifs <;> simp
   obtain ⟨x, hx⟩ := exists_forall_infinitePlace_sub_lt b (fun _ => 1) fun _ => one_pos
-  -- A point within `1` of a target of absolute value one at some place is nonzero.
-  have hx0 : x ≠ 0 := by
-    rintro rfl
-    have h := hx (Classical.arbitrary (InfinitePlace K))
-    rw [coe_apply, zero_sub, AbsoluteValue.map_neg, ← coe_apply, habs] at h
-    exact lt_irrefl 1 h
+  have hx0 := ne_zero_of_infinitePlace_sub_lt
+    (habs (Classical.arbitrary (InfinitePlace K))) (hx (Classical.arbitrary (InfinitePlace K)))
   refine ⟨x, hx0, fun w => ?_⟩
   have h := mul_pos_of_infinitePlace_sub_lt w.2 (habs w.1) (hx w.1)
   rw [hb' w] at h

--- a/TauCeti/NumberTheory/NumberField/SignApproximation.lean
+++ b/TauCeti/NumberTheory/NumberField/SignApproximation.lean
@@ -100,6 +100,7 @@ theorem exists_forall_apply_eq_one_and_embedding_of_isReal_eq
   · dsimp only
     rw [dite_eq_left w.2, Subtype.coe_eta, map_intCast]
 
+omit [NumberField K] in
 /-- **An approximation of a target of absolute value one has the sign of that target.**  At a real
 place `w`, an element `x` within `1` of a target `y` with `w y = 1` has the same sign as `y` under
 the real embedding at `w`.

--- a/TauCeti/NumberTheory/NumberField/Units/Signature/Integer.lean
+++ b/TauCeti/NumberTheory/NumberField/Units/Signature/Integer.lean
@@ -5,13 +5,14 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.Order.Ring.Units
 public import TauCeti.NumberTheory.NumberField.Units.Signature.Surjective
 
 /-!
 # The total sign homomorphism of a number field, valued in `ℤˣ`
 
-`NumberField.fieldUnitSignature` records the sign of a unit of `K` at each real place as a class in
-`ℝˣ ⧸ Units.posSubgroup ℝ`.  Transporting each of those classes along the sign isomorphism
+`NumberField.fieldUnitSignature` records the sign of a field unit of `K` at each real place as a
+class in `ℝˣ ⧸ Units.posSubgroup ℝ`.  Transporting each of those classes along the sign isomorphism
 `Units.signEquiv` gives the same data in the concrete two-element group `ℤˣ`:
 
 ```text
@@ -41,7 +42,7 @@ asserts otherwise.
 * `TauCeti.GlobalNumberFields.signHom_eq_one_iff`: an element lies in the kernel exactly when it
   is totally positive.
 * `TauCeti.GlobalNumberFields.signHom_surjective`: every pattern of signs at the real places is
-  realized by a unit of `K`.
+  realized by a field unit of `K`.
 
 ## References
 
@@ -56,8 +57,8 @@ namespace TauCeti.GlobalNumberFields
 
 variable {K : Type*} [Field K]
 
-/-- **The total sign homomorphism of a number field**: the signs of a unit of `K` at all of the
-real places at once, valued in the product of copies of `ℤˣ` indexed by those places.
+/-- **The total sign homomorphism of a number field**: the signs of a field unit of `K` at all of
+the real places at once, valued in the product of copies of `ℤˣ` indexed by those places.
 
 It is `NumberField.fieldUnitSignature` with each component read through the sign isomorphism
 `Units.signEquiv`, so it carries exactly the same information.
@@ -65,11 +66,11 @@ It is `NumberField.fieldUnitSignature` with each component read through the sign
 The domain is `Kˣ` rather than `K`, so that every value really is a sign: a formulation on `K`
 would have to invent a sign for `0`. -/
 noncomputable def signHom : Kˣ →* ({w : InfinitePlace K // w.IsReal} → ℤˣ) :=
-  (MonoidHom.piMap fun _ : {w : InfinitePlace K // w.IsReal} =>
-    (Units.signEquiv ℝ).toMonoidHom).comp fieldUnitSignature
+  (MulEquiv.piCongrRight fun _ : {w : InfinitePlace K // w.IsReal} =>
+    Units.signEquiv ℝ).toMonoidHom.comp fieldUnitSignature
 
 /-- Componentwise evaluation of the total sign homomorphism. -/
-theorem signHom_apply (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
+@[simp] theorem signHom_apply (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
     signHom x w = Units.signEquiv ℝ (fieldUnitSignature x w) := (rfl)
 
 /-- **A sign is `1` exactly at a positive element.** -/
@@ -98,10 +99,7 @@ This is `NumberField.fieldUnitSignature_surjective` read in `ℤˣ`.  Surjectivi
 after restricting along `(𝓞 K)ˣ → Kˣ`, and that failure is the obstruction which separates the
 narrow class group of `K` from the wide one; nothing here bears on the restricted map. -/
 theorem signHom_surjective [NumberField K] : Function.Surjective (signHom (K := K)) := fun s => by
-  obtain ⟨x, hx⟩ :=
-    NumberField.fieldUnitSignature_surjective (K := K) fun w => (Units.signEquiv ℝ).symm (s w)
-  refine ⟨x, funext fun w => ?_⟩
-  rw [signHom_apply, hx]
-  exact (Units.signEquiv ℝ).apply_symm_apply (s w)
+  exact (MulEquiv.piCongrRight fun _ : {w : InfinitePlace K // w.IsReal} =>
+    Units.signEquiv ℝ).surjective.comp NumberField.fieldUnitSignature_surjective s
 
 end TauCeti.GlobalNumberFields

--- a/TauCeti/NumberTheory/NumberField/Units/Signature/Integer.lean
+++ b/TauCeti/NumberTheory/NumberField/Units/Signature/Integer.lean
@@ -74,13 +74,13 @@ noncomputable def signHom : Kˣ →* ({w : InfinitePlace K // w.IsReal} → ℤ�
     signHom x w = Units.signEquiv ℝ (fieldUnitSignature x w) := (rfl)
 
 /-- **A sign is `1` exactly at a positive element.** -/
-@[simp] theorem signHom_apply_eq_one_iff (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
+theorem signHom_apply_eq_one_iff (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
     signHom x w = 1 ↔ 0 < embedding_of_isReal w.2 (x : K) := by
   rw [signHom_apply, fieldUnitSignature_apply, Units.signEquiv_mk_eq_one_iff]
   simp
 
 /-- **A sign is `-1` exactly at a negative element.** -/
-@[simp] theorem signHom_apply_eq_neg_one_iff (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
+theorem signHom_apply_eq_neg_one_iff (x : Kˣ) (w : {w : InfinitePlace K // w.IsReal}) :
     signHom x w = -1 ↔ embedding_of_isReal w.2 (x : K) < 0 := by
   rw [signHom_apply, fieldUnitSignature_apply, Units.signEquiv_mk_eq_neg_one_iff]
   simp


### PR DESCRIPTION
This PR completes Layer 1 of the GlobalNumberFields roadmap by adding the two things that layer still owes after mixed-place weak approximation landed: the `Kˣ`-valued consequences of that theorem, and the total sign homomorphism to the product of `ℤˣ` together with its surjectivity on `Kˣ`. Layer 1 asks to "derive simultaneous independent finite-place targets and real-place signs for one element of `Kˣ`" and to "define the total sign homomorphism to the product of `ℤˣ` over real places [and] prove its surjectivity on `Kˣ`, while recording that the restriction to `𝓞_Kˣ` need not be surjective"; `TauCeti.GlobalNumberFields.exists_units_valuation_sub_lt_and_signHom_eq`, `exists_units_valuation_eq_and_signHom_eq`, `signHom` and `signHom_surjective` are exactly those targets, and with them Layer 1 has nothing left open.

`signHom : Kˣ →* ({w : InfinitePlace K // w.IsReal} → ℤˣ)` is **not** a second sign homomorphism. The repo already has one, `NumberField.fieldUnitSignature`, valued in `ℝˣ ⧸ Units.posSubgroup ℝ`; `signHom` is that map with each component read through the sign isomorphism `Units.signEquiv : Rˣ ⧸ Units.posSubgroup R ≃* ℤˣ` added to `TauCeti/Algebra/Order/Ring/Units.lean` (the file that already carries the `posSubgroup` material). Everything about `signHom` is inherited rather than reproved: `signHom_eq_one_iff` is `fieldUnitSignature_eq_one_iff` and is stated with the existing `NumberField.IsTotallyPositive` predicate, and `signHom_surjective` is `fieldUnitSignature_surjective` transported, so the archimedean statement needs no mixed finite/infinite approximation.

`TauCeti/NumberTheory/NumberField/Global/Approximation/Weak.lean` gains the two approximation statements: one unit of `K` that approximates independently prescribed targets to independently prescribed radii at finitely many finite places while realizing a prescribed sign at every real place, and the same with prescribed valuations `WithZero.exp (n v)` in place of the targets, obtained from the first by Mathlib's `Valuation.map_eq_of_sub_lt`. The conclusions are stated for `Kˣ` rather than `K` on purpose, as the roadmap requires: `0` carries no sign, so a formulation in `K` would let it satisfy a negative sign request vacuously. Nonvanishing of the witness is forced by approximating an element of absolute value one at *every* infinite place, which is also where the archimedean targets `±1` come from.

The archimedean half of that argument is shared rather than duplicated. `TauCeti/NumberTheory/NumberField/SignApproximation.lean` — which already had the purely archimedean `exists_ne_zero_forall_isReal_pos` — now exposes the two pieces both proofs use: `exists_forall_apply_eq_one_and_embedding_of_isReal_eq`, the family of targets of absolute value one with prescribed signs, and `mul_pos_of_infinitePlace_sub_lt`, the estimate that reads a sign off an approximation of such a target. `exists_ne_zero_forall_isReal_pos` is reproved from them and its statement is unchanged.

The domain of `signHom` is `Kˣ` and nothing here claims anything about the composite `(𝓞 K)ˣ → Kˣ → ({w // w.IsReal} → ℤˣ)`; that map is not surjective in general, and its failure is exactly the obstruction Layer 2 phrases the narrow class group against. The docstrings say so rather than leaving the stronger reading available.

What remains on the milestone path after this PR: Layer 2's moving lemma and `idealClass_surjective`, whose proof is the first consumer of `exists_units_valuation_eq_and_signHom_eq` — an ideal of a given ray class is moved to an integral representative prime to the modulus by a unit with prescribed valuations at the primes of the modulus and of the ideal and prescribed signs at the real places of the modulus — followed by `finite_rayClassGroup` and the class-number formula.

No Mathlib infrastructure was vendored; the files build on Mathlib's `NumberField.InfinitePlace.embedding_of_isReal`, `IsDedekindDomain.HeightOneSpectrum.valuation_surjective` and `Valuation.map_eq_of_sub_lt`, and on the existing `TauCeti.GlobalNumberFields.weakApproximation_denseRange` and `NumberField.fieldUnitSignature`.

Roadmap: GlobalNumberFields

<!--tauceti-target:v1 {"focus":"GlobalNumberFields","id":"signhom-surjective"}-->

🤖 Prepared with Claude Code
