### PR TITLE
refactor(Spectral): root the two `IsClosed` theorems

### DIFF
--- a/TauCeti/Topology/Spectral/ProConstructible.lean
+++ b/TauCeti/Topology/Spectral/ProConstructible.lean
@@ -44,7 +44,7 @@ Recall that Mathlib orders topologies by *reverse* inclusion of their open sets,
 ## Main results
 
 * `TauCeti.IsOpen.isOpen_constructibleTopology` — on a prespectral space the constructible
-  topology refines the given one; hence `TauCeti.IsClosed.isProConstructible`.
+  topology refines the given one; hence `IsClosed.isProConstructible`.
 * `IsCompact.isProConstructible` — a quasi-compact open subset is pro-constructible. It is
   in fact clopen for the constructible topology, which is what makes the two previous families
   interact.
@@ -60,7 +60,7 @@ Recall that Mathlib orders topologies by *reverse* inclusion of their open sets,
   the sobriety half of the main theorem.
 * `TauCeti.IsProConstructible.spectralSpace` — **a pro-constructible subspace of a spectral space
   is spectral**, together with `TauCeti.IsProConstructible.isSpectralMap_subtypeVal`: its
-  inclusion is a spectral map. `TauCeti.IsClosed.spectralSpace` is the closed special case, the
+  inclusion is a spectral map. `IsClosed.spectralSpace` is the closed special case, the
   counterpart of Mathlib's `Topology.IsOpenEmbedding.spectralSpace`.
 
 ## References
@@ -176,7 +176,7 @@ theorem _root_.IsCompact.isProConstructible {s : Set X} (hcomp : IsCompact s) (h
         hopen.isClosed_compl
 
 /-- A closed subset of a prespectral space is pro-constructible. -/
-theorem IsClosed.isProConstructible [PrespectralSpace X] {s : Set X} (hs : IsClosed s) :
+theorem _root_.IsClosed.isProConstructible [PrespectralSpace X] {s : Set X} (hs : IsClosed s) :
     IsProConstructible s := by
   rw [IsProConstructible, ← isOpen_compl_iff, ← Set.preimage_compl]
   exact IsOpen.isOpen_preimage_ofTopology hs.isOpen_compl
@@ -369,7 +369,7 @@ theorem IsProConstructible.spectralSpace (hs : IsProConstructible s) : SpectralS
 
 /-- A closed subspace of a spectral space is spectral. Mathlib has the open counterpart,
 `Topology.IsOpenEmbedding.spectralSpace`; this is the closed one. -/
-theorem IsClosed.spectralSpace (hs : IsClosed s) : SpectralSpace s :=
+theorem _root_.IsClosed.spectralSpace (hs : IsClosed s) : SpectralSpace s :=
   IsProConstructible.spectralSpace (IsClosed.isProConstructible hs)
 
 end Spectral


### PR DESCRIPTION
`lint-dot-notation` flags both `TauCeti.IsClosed` declarations in `TauCeti/Topology/Spectral/ProConstructible.lean`:

- `IsClosed.isProConstructible` (line 179)
- `IsClosed.spectralSpace` (line 372)

They are the **whole namespace** — nothing else in the tree declares into `TauCeti.IsClosed` — and `IsClosed` is a root Mathlib namespace with no colliding `isProConstructible` or `spectralSpace`.

## The file has already set this convention

`_root_.IsCompact.isProConstructible` sits **four lines above** the first of these, and the file roots three declarations in total (`IsCompact.isProConstructible`, `Finset.isProConstructible_biUnion`, `Set.Finite.isProConstructible_biUnion`). So this completes a convention the file already follows rather than introducing one; the closed and compact cases now live side by side in the same namespace.

No namespace surgery is needed: both headers are dotted declarations sitting directly in `namespace TauCeti`, so only `_root_.` is added. The in-file uses at lines 349 and 373 are written `IsClosed.isProConstructible` and continue to resolve through the root fallback.

Two module-docstring references named the `TauCeti.IsClosed.…` path the move destroys — lines 47 and 63 — and both now name the rooted form. Neither would have failed a build.

`lint-dot-notation`: 989 → 987, 0 new.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp