### PR TITLE
refactor(Huber): go through the unfolding lemmas for the finite-type predicates

### DIFF
--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -146,14 +146,15 @@ theorem isStrictlyTopologicallyFiniteType_algebraMap (k : ℕ) :
 presentation is a presentation. -/
 theorem IsStrictlyTopologicallyFiniteType.isTopologicallyFiniteType {φ : A →+* B}
     (h : IsStrictlyTopologicallyFiniteType φ) : IsTopologicallyFiniteType φ := by
-  obtain ⟨k, π, hπ, hcomm⟩ := h
-  exact ⟨k, _, fun _ ↦ Set.finite_singleton 1, isWeightFamily_one_weight, π, hπ, hcomm⟩
+  obtain ⟨k, π, hπ, hcomm⟩ := isStrictlyTopologicallyFiniteType_iff.mp h
+  exact isTopologicallyFiniteType_iff.mpr
+    ⟨k, _, fun _ ↦ Set.finite_singleton 1, isWeightFamily_one_weight, π, hπ, hcomm⟩
 
 /-- A homomorphism topologically of finite type is continuous: it factors as an open quotient map
 after the presenting algebra's structure map, and both are continuous. -/
 theorem IsTopologicallyFiniteType.continuous {φ : A →+* B} (h : IsTopologicallyFiniteType φ) :
     Continuous φ := by
-  obtain ⟨k, T, _, hT, π, hπ, hcomm⟩ := h
+  obtain ⟨k, T, _, hT, π, hπ, hcomm⟩ := isTopologicallyFiniteType_iff.mp h
   rw [← hcomm]
   exact hπ.continuous.comp (continuous_algebraMap_completion_weightedRestrictedSubring k A hT)
 
@@ -176,8 +177,9 @@ the presenting `A⟨X₁, …, Xₖ⟩ ↠ B` with `ψ`, and use that open quoti
 theorem IsStrictlyTopologicallyFiniteType.comp_isOpenQuotientMap {φ : A →+* B} {ψ : B →+* C}
     (h : IsStrictlyTopologicallyFiniteType φ) (hψ : IsOpenQuotientMap ψ) :
     IsStrictlyTopologicallyFiniteType (ψ.comp φ) := by
-  obtain ⟨k, π, hπ, hcomm⟩ := h
-  exact ⟨k, ψ.comp π, hψ.comp hπ, by rw [RingHom.comp_assoc, hcomm]⟩
+  obtain ⟨k, π, hπ, hcomm⟩ := isStrictlyTopologicallyFiniteType_iff.mp h
+  exact isStrictlyTopologicallyFiniteType_iff.mpr
+    ⟨k, ψ.comp π, hψ.comp hπ, by rw [RingHom.comp_assoc, hcomm]⟩
 
 /-- **A presentation pushes along an open quotient map**, the weighted form of
 `TauCeti.Huber.IsStrictlyTopologicallyFiniteType.comp_isOpenQuotientMap`. The weight family is
@@ -185,8 +187,9 @@ carried across unchanged; only the presenting map moves. -/
 theorem IsTopologicallyFiniteType.comp_isOpenQuotientMap {φ : A →+* B} {ψ : B →+* C}
     (h : IsTopologicallyFiniteType φ) (hψ : IsOpenQuotientMap ψ) :
     IsTopologicallyFiniteType (ψ.comp φ) := by
-  obtain ⟨k, T, hTfin, hT, π, hπ, hcomm⟩ := h
-  exact ⟨k, T, hTfin, hT, ψ.comp π, hψ.comp hπ, by rw [RingHom.comp_assoc, hcomm]⟩
+  obtain ⟨k, T, hTfin, hT, π, hπ, hcomm⟩ := isTopologicallyFiniteType_iff.mp h
+  exact isTopologicallyFiniteType_iff.mpr
+    ⟨k, T, hTfin, hT, ψ.comp π, hψ.comp hπ, by rw [RingHom.comp_assoc, hcomm]⟩
 
 variable [IsTopologicalRing B]
 


### PR DESCRIPTION
Roadmap: AdicSpaces

No `tauceti-target` marker: this is a refactor of existing code and authors no roadmap target.
Being invisible to the duplicate sweeper is the intended behaviour for that.

`IsTopologicallyFiniteType` and `IsStrictlyTopologicallyFiniteType` are sealed definitions, and
the file provides `isTopologicallyFiniteType_iff` and `isStrictlyTopologicallyFiniteType_iff` for
going through them. Four proofs still destructured and rebuilt the predicates with the anonymous
constructor, coupling them to the representation; a fifth — added in #5906 — already went through
the lemma, after `proof-quality` asked for it there:

> Destructuring `hφ` directly unfolds the sealed `IsStrictlyTopologicallyFiniteType` definition,
> making the proof brittle under representation changes.

That argument applies equally to the other four, and to construction as much as destructuring.
This makes them consistent: `.mp` to take a presentation apart, `.mpr` to assemble one.

Affected: `IsStrictlyTopologicallyFiniteType.isTopologicallyFiniteType`,
`IsTopologicallyFiniteType.continuous`,
`IsStrictlyTopologicallyFiniteType.comp_isOpenQuotientMap`,
`IsTopologicallyFiniteType.comp_isOpenQuotientMap`.

No statement, docstring or hypothesis changes. The proof terms are the same modulo the round trip
through the iff, and the file builds unchanged otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb8uv44XKmG5Mw9BvLjsb1
