### PR TITLE
feat: prove the symplectic group reductive

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
@@ -71,24 +71,10 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
       (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I)) :
     I = HopfIdeal.augmentation k (finiteTypeCoordinateHopfAlgebra k n) := by
   let e := coordinateHopfAlgebraFiniteTypeObjIso k n
-  let f : coordinateHopfAlgebra k n →ₐc[k] (finiteTypeCoordinateHopfAlgebra k n) :=
-    CommHopfAlgCat.ofIso e
-  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.hom
-  let J : HopfIdeal k (coordinateHopfAlgebra k n) := I.comapOfSurjective f hf.2
-  have hJnormal : J.IsNormal := hI.comapOfSurjective_of_bijective f hf.1 hf.2
-  let qIso : CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J ≅
-      CommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n).obj I :=
-    CommHopfAlgCat.quotientIsoOfIso e I
   let H : FiniteTypeCommHopfAlgCat k :=
     ⟨coordinateHopfAlgebra k n, by
       rw [← finiteTypeCoordinateHopfAlgebra_obj]
       exact (finiteTypeCoordinateHopfAlgebra k n).property⟩
-  let qIso' : FiniteTypeCommHopfAlgCat.quotient H J ≅
-      FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I :=
-    ObjectProperty.isoMk _ qIso
-  have hUJ : smoothUnipotentCommHopfAlgProperty k
-      (FiniteTypeCommHopfAlgCat.quotient H J) :=
-    (smoothUnipotentCommHopfAlgProperty k).prop_of_iso qIso'.symm hU
   let _ : IsReduced H := by
     -- `H` packages this coordinate algebra with its finite-type proof, so its carrier is
     -- definitionally the coordinate algebra on which smoothness supplies reducedness.
@@ -101,12 +87,9 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
     | succ n =>
         let _ : NeZero n.succ := ⟨Nat.succ_ne_zero n⟩
         exact Comodule.isCompletelyReducible_of_isSimpleOrder
-  have hJ : J = HopfIdeal.augmentation k (coordinateHopfAlgebra k n) :=
-    HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful k H (Fin n → k)
-      hcr (isFaithful_standardComodule k n) J hJnormal hUJ
-  rw [← HopfIdeal.comapOfSurjective_eq_comapOfSurjective_iff f hf.2,
-    HopfIdeal.comapOfSurjective_augmentation]
-  exact hJ
+  exact HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso
+    k H (Fin n → k) (finiteTypeCoordinateHopfAlgebra k n) e hcr
+      (isFaithful_standardComodule k n) I hI hU
 
 /-- **The general linear group is reductive over every field.** -/
 theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
@@ -80,24 +80,10 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
       (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I)) :
     I = HopfIdeal.augmentation k (finiteTypeCoordinateHopfAlgebra k n) := by
   let e := coordinateHopfAlgebraFiniteTypeObjIso k n
-  let f : coordinateHopfAlgebra k n →ₐc[k] (finiteTypeCoordinateHopfAlgebra k n) :=
-    CommHopfAlgCat.ofIso e
-  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.hom
-  let J : HopfIdeal k (coordinateHopfAlgebra k n) := I.comapOfSurjective f hf.2
-  have hJnormal : J.IsNormal := hI.comapOfSurjective_of_bijective f hf.1 hf.2
-  let qIso : CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J ≅
-      CommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n).obj I :=
-    CommHopfAlgCat.quotientIsoOfIso e I
   let H : FiniteTypeCommHopfAlgCat k :=
     ⟨coordinateHopfAlgebra k n, by
       rw [← finiteTypeCoordinateHopfAlgebra_obj]
       exact (finiteTypeCoordinateHopfAlgebra k n).property⟩
-  let qIso' : FiniteTypeCommHopfAlgCat.quotient H J ≅
-      FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I :=
-    ObjectProperty.isoMk _ qIso
-  have hUJ : smoothUnipotentCommHopfAlgProperty k
-      (FiniteTypeCommHopfAlgCat.quotient H J) :=
-    (smoothUnipotentCommHopfAlgProperty k).prop_of_iso qIso'.symm hU
   let _ : IsReduced H := by
     -- `H` packages this coordinate algebra with its finite-type proof, so its carrier is
     -- definitionally the coordinate algebra on which smoothness supplies reducedness.
@@ -110,12 +96,9 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
     | succ n =>
         let _ : NeZero n.succ := ⟨Nat.succ_ne_zero n⟩
         exact Comodule.isCompletelyReducible_of_isSimpleOrder
-  have hJ : J = HopfIdeal.augmentation k (coordinateHopfAlgebra k n) :=
-    HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful k H (Fin n → k)
-      hcr (isFaithful_standardComodule k n) J hJnormal hUJ
-  rw [← HopfIdeal.comapOfSurjective_eq_comapOfSurjective_iff f hf.2,
-    HopfIdeal.comapOfSurjective_augmentation]
-  exact hJ
+  exact HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso
+    k H (Fin n → k) (finiteTypeCoordinateHopfAlgebra k n) e hcr
+      (isFaithful_standardComodule k n) I hI hU
 
 /-- **The special linear group is reductive over every field.** -/
 theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Reductive.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Symplectic.StandardComodule
+import TauCeti.Algebra.AlgebraicGroup.Symplectic.BaseChange
+import TauCeti.Algebra.AlgebraicGroup.Symplectic.Connected
+import TauCeti.Algebra.AlgebraicGroup.Symplectic.Smooth
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Faithful
+import TauCeti.RingTheory.Smooth.GeometricallyReduced
+
+/-!
+# The symplectic group is reductive
+
+The coordinate Hopf algebra of the standard symplectic group `Sp₂ₘ` is reductive over every
+field, in every natural rank and in arbitrary characteristic.
+
+The coordinate algebra is smooth and geometrically connected. To eliminate a normal smooth
+unipotent closed subgroup over an algebraically closed field, use the standard representation.
+It is simple in positive rank, hence completely reducible, while in rank zero its carrier is a
+singleton. Normal unipotent subgroups therefore act trivially on it. Since the standard
+representation is faithful in every rank, the subgroup is the identity subgroup.
+
+The result over an arbitrary field follows by transporting this argument across the canonical
+base-change identification
+
+`AlgebraicClosure k ⊗[k] O(Sp₂ₘ) ≃ O(Sp₂ₘ, AlgebraicClosure k)`.
+
+## Main declarations
+
+* `TauCeti.Symplectic.eq_augmentation_of_isNormal_of_smoothUnipotent`: a normal smooth
+  unipotent closed subgroup of `Sp₂ₘ` over an algebraically closed field is trivial.
+* `TauCeti.Symplectic.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`:
+  `Sp₂ₘ` is reductive over every field.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§19.b and 24.6.
+* T. A. Springer, *Linear Algebraic Groups*, §§2.2, 2.4, and Chapter 8.
+
+The proof follows the normal-unipotent elimination used for the general and special linear groups
+in `TauCeti.Algebra.AlgebraicGroup.{GeneralLinear,SpecialLinear}.Reductive`, applied to the
+symplectic standard comodule.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.Symplectic
+
+universe u
+
+noncomputable section
+
+open HopfIdeal
+
+/-- The coordinate Hopf algebra and the underlying object of its finite-type package are
+canonically identical. -/
+private noncomputable def coordinateHopfAlgebraFiniteTypeObjIso
+    (R : Type u) [CommRing R] (m : Nat) :
+    coordinateHopfAlgebra R m ≅ (finiteTypeCoordinateHopfAlgebra R m).obj :=
+  eqToIso (finiteTypeCoordinateHopfAlgebra_obj R m).symm
+
+/-- A normal smooth unipotent closed subgroup of `Sp₂ₘ` over an algebraically closed field is
+trivial. No positivity hypothesis on `m` is needed. -/
+theorem eq_augmentation_of_isNormal_of_smoothUnipotent
+    (k : Type u) [Field k] [IsAlgClosed k] (m : Nat)
+    (I : HopfIdeal k (finiteTypeCoordinateHopfAlgebra k m)) (hI : I.IsNormal)
+    (hU : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k m) I)) :
+    I = HopfIdeal.augmentation k (finiteTypeCoordinateHopfAlgebra k m) := by
+  let e := coordinateHopfAlgebraFiniteTypeObjIso k m
+  let f : coordinateHopfAlgebra k m →ₐc[k] (finiteTypeCoordinateHopfAlgebra k m) :=
+    CommHopfAlgCat.ofIso e
+  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.hom
+  let J : HopfIdeal k (coordinateHopfAlgebra k m) := I.comapOfSurjective f hf.2
+  have hJnormal : J.IsNormal := hI.comapOfSurjective_of_bijective f hf.1 hf.2
+  let qIso : CommHopfAlgCat.quotient (coordinateHopfAlgebra k m) J ≅
+      CommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k m).obj I :=
+    CommHopfAlgCat.quotientIsoOfIso e I
+  let H : FiniteTypeCommHopfAlgCat k :=
+    ⟨coordinateHopfAlgebra k m, by
+      rw [← finiteTypeCoordinateHopfAlgebra_obj]
+      exact (finiteTypeCoordinateHopfAlgebra k m).property⟩
+  let qIso' : FiniteTypeCommHopfAlgCat.quotient H J ≅
+      FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k m) I :=
+    ObjectProperty.isoMk _ qIso
+  have hUJ : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H J) :=
+    (smoothUnipotentCommHopfAlgProperty k).prop_of_iso qIso'.symm hU
+  let _ : IsReduced H := by
+    change IsReduced (coordinateHopfAlgebra k m)
+    exact isReduced_of_smooth_of_field k _
+  let _ : Comodule k (coordinateHopfAlgebra k m) (Fin (m + m) → k) := standardComodule k m
+  have hcr : Comodule.IsCompletelyReducible k (coordinateHopfAlgebra k m)
+      (Fin (m + m) → k) := by
+    cases m with
+    | zero =>
+        let _ : Subsingleton (Fin (0 + 0) → k) :=
+          ⟨fun f g => funext fun i => Fin.elim0 i⟩
+        exact Comodule.isCompletelyReducible_of_subsingleton
+    | succ m =>
+        let _ : NeZero m.succ := ⟨Nat.succ_ne_zero m⟩
+        exact Comodule.isCompletelyReducible_of_isSimpleOrder
+  have hJ : J = HopfIdeal.augmentation k (coordinateHopfAlgebra k m) :=
+    HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful k H
+      (Fin (m + m) → k) hcr (isFaithful_standardComodule k m) J hJnormal hUJ
+  rw [← HopfIdeal.comapOfSurjective_eq_comapOfSurjective_iff f hf.2,
+    HopfIdeal.comapOfSurjective_augmentation]
+  exact hJ
+
+/-- **The standard symplectic group is reductive over every field.** -/
+theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra
+    (k : Type u) [Field k] (m : Nat) :
+    reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k m) := by
+  let e := coordinateHopfAlgebraFiniteTypeObjIso k m
+  apply reductiveCommHopfAlgProperty_of_geometricFiber_iso k _
+    (finiteTypeCoordinateHopfAlgebra (AlgebraicClosure k) m)
+    ((smoothCommHopfAlgProperty_iff _).mp <|
+      (smoothCommHopfAlgProperty k).prop_of_iso e
+        ((smoothCommHopfAlgProperty_iff _).mpr inferInstance))
+    ((geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e
+      (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k m))
+    (finiteTypeCoordinateHopfAlgebraBaseChangeIso k (AlgebraicClosure k) m)
+  intro I hI hU
+  exact eq_augmentation_of_isNormal_of_smoothUnipotent
+    (AlgebraicClosure k) m I hI hU
+
+end
+
+end TauCeti.Symplectic

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Reductive.lean
@@ -41,8 +41,6 @@ base-change identification
 
 * J. S. Milne, *Algebraic Groups* (2017), §§19.b and 24.6.
 * T. A. Springer, *Linear Algebraic Groups*, §§2.2, 2.4, and Chapter 8.
-* The ReductiveGroups roadmap, Layer 6 and its `Sp₂ₙ` worked example, which requests this
-  geometric `R_u = 1` proof in arbitrary characteristic.
 -/
 
 public section
@@ -64,6 +62,9 @@ private noncomputable def coordinateHopfAlgebraFiniteTypeObjIso
     coordinateHopfAlgebra R m ≅ (finiteTypeCoordinateHopfAlgebra R m).obj :=
   eqToIso (finiteTypeCoordinateHopfAlgebra_obj R m).symm
 
+-- The normal-unipotent elimination below adapts the proof architecture from
+-- `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Reductive` and
+-- `TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Reductive`.
 /-- A normal smooth unipotent closed subgroup of `Sp₂ₘ` over an algebraically closed field is
 trivial. No positivity hypothesis on `m` is needed. -/
 theorem eq_augmentation_of_isNormal_of_smoothUnipotent

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Reductive.lean
@@ -43,10 +43,6 @@ base-change identification
 * T. A. Springer, *Linear Algebraic Groups*, §§2.2, 2.4, and Chapter 8.
 * The ReductiveGroups roadmap, Layer 6 and its `Sp₂ₙ` worked example, which requests this
   geometric `R_u = 1` proof in arbitrary characteristic.
-
-The proof follows the normal-unipotent elimination used for the general and special linear groups
-in `TauCeti.Algebra.AlgebraicGroup.{GeneralLinear,SpecialLinear}.Reductive`, applied to the
-symplectic standard comodule.
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Reductive.lean
@@ -41,6 +41,8 @@ base-change identification
 
 * J. S. Milne, *Algebraic Groups* (2017), §§19.b and 24.6.
 * T. A. Springer, *Linear Algebraic Groups*, §§2.2, 2.4, and Chapter 8.
+* The ReductiveGroups roadmap, Layer 6 and its `Sp₂ₙ` worked example, which requests this
+  geometric `R_u = 1` proof in arbitrary characteristic.
 
 The proof follows the normal-unipotent elimination used for the general and special linear groups
 in `TauCeti.Algebra.AlgebraicGroup.{GeneralLinear,SpecialLinear}.Reductive`, applied to the
@@ -75,25 +77,13 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
       (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k m) I)) :
     I = HopfIdeal.augmentation k (finiteTypeCoordinateHopfAlgebra k m) := by
   let e := coordinateHopfAlgebraFiniteTypeObjIso k m
-  let f : coordinateHopfAlgebra k m →ₐc[k] (finiteTypeCoordinateHopfAlgebra k m) :=
-    CommHopfAlgCat.ofIso e
-  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.hom
-  let J : HopfIdeal k (coordinateHopfAlgebra k m) := I.comapOfSurjective f hf.2
-  have hJnormal : J.IsNormal := hI.comapOfSurjective_of_bijective f hf.1 hf.2
-  let qIso : CommHopfAlgCat.quotient (coordinateHopfAlgebra k m) J ≅
-      CommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k m).obj I :=
-    CommHopfAlgCat.quotientIsoOfIso e I
   let H : FiniteTypeCommHopfAlgCat k :=
     ⟨coordinateHopfAlgebra k m, by
       rw [← finiteTypeCoordinateHopfAlgebra_obj]
       exact (finiteTypeCoordinateHopfAlgebra k m).property⟩
-  let qIso' : FiniteTypeCommHopfAlgCat.quotient H J ≅
-      FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k m) I :=
-    ObjectProperty.isoMk _ qIso
-  have hUJ : smoothUnipotentCommHopfAlgProperty k
-      (FiniteTypeCommHopfAlgCat.quotient H J) :=
-    (smoothUnipotentCommHopfAlgProperty k).prop_of_iso qIso'.symm hU
   let _ : IsReduced H := by
+    -- `H` packages this coordinate algebra with its finite-type proof, so its carrier is
+    -- definitionally the coordinate algebra on which smoothness supplies reducedness.
     change IsReduced (coordinateHopfAlgebra k m)
     exact isReduced_of_smooth_of_field k _
   let _ : Comodule k (coordinateHopfAlgebra k m) (Fin (m + m) → k) := standardComodule k m
@@ -107,12 +97,9 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
     | succ m =>
         let _ : NeZero m.succ := ⟨Nat.succ_ne_zero m⟩
         exact Comodule.isCompletelyReducible_of_isSimpleOrder
-  have hJ : J = HopfIdeal.augmentation k (coordinateHopfAlgebra k m) :=
-    HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful k H
-      (Fin (m + m) → k) hcr (isFaithful_standardComodule k m) J hJnormal hUJ
-  rw [← HopfIdeal.comapOfSurjective_eq_comapOfSurjective_iff f hf.2,
-    HopfIdeal.comapOfSurjective_augmentation]
-  exact hJ
+  exact HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso
+    k H (Fin (m + m) → k) (finiteTypeCoordinateHopfAlgebra k m) e hcr
+      (isFaithful_standardComodule k m) I hI hU
 
 /-- **The standard symplectic group is reductive over every field.** -/
 theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Faithful.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Faithful.lean
@@ -37,6 +37,8 @@ nor connectedness of `H` itself is needed; reducedness of `H` is.
   a normal subgroup with reduced quotient and only unipotent points is trivial.
 * `TauCeti.HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful`: a normal
   smooth unipotent closed subgroup of such an `H` is trivial.
+* `TauCeti.HopfIdeal.eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso`:
+  the same conclusion after transporting the subgroup across an isomorphism.
 * `TauCeti.FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_augmentation_of_isFaithful`:
   the unipotent radical of such an `H` is trivial.
 
@@ -110,6 +112,38 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful
     geometricallyUnipotentPointsCommHopfAlgProperty.forall_isUnipotentPoint hgeom
   exact eq_augmentation_of_isNormal_of_forall_isUnipotentPoint_of_isFaithful
     k H M hcr hM I hI hu
+
+/-- **A normal smooth unipotent closed subgroup is trivial when an isomorphic presentation of
+the ambient group has a faithful completely reducible representation.**
+
+This packages the transport of the subgroup ideal, quotient, and augmentation ideal across the
+chosen isomorphism. -/
+theorem eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful_of_iso
+    (H' : FiniteTypeCommHopfAlgCat.{u, u} k) (e : H.obj ≅ H'.obj)
+    (hcr : Comodule.IsCompletelyReducible k H M)
+    (hM : Comodule.IsFaithful (k := k) (H := H) (V := M))
+    (I : HopfIdeal k H') (hI : I.IsNormal)
+    (hU : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H' I)) :
+    I = HopfIdeal.augmentation k H' := by
+  let f : H →ₐc[k] H' := CommHopfAlgCat.ofIso e
+  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.hom
+  let J : HopfIdeal k H := I.comapOfSurjective f hf.2
+  have hJnormal : J.IsNormal := hI.comapOfSurjective_of_bijective f hf.1 hf.2
+  let qIso : CommHopfAlgCat.quotient H.obj J ≅ CommHopfAlgCat.quotient H'.obj I :=
+    CommHopfAlgCat.quotientIsoOfIso e I
+  let qIso' : FiniteTypeCommHopfAlgCat.quotient H J ≅
+      FiniteTypeCommHopfAlgCat.quotient H' I :=
+    ObjectProperty.isoMk _ qIso
+  have hUJ : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H J) :=
+    (smoothUnipotentCommHopfAlgProperty k).prop_of_iso qIso'.symm hU
+  have hJ : J = HopfIdeal.augmentation k H :=
+    eq_augmentation_of_isNormal_of_smoothUnipotent_of_isFaithful
+      k H M hcr hM J hJnormal hUJ
+  rw [← HopfIdeal.comapOfSurjective_eq_comapOfSurjective_iff f hf.2,
+    HopfIdeal.comapOfSurjective_augmentation]
+  exact hJ
 
 end HopfIdeal
 


### PR DESCRIPTION
This PR proves that the standard symplectic group `Sp₂ₘ` is reductive over every field, in every natural rank and arbitrary characteristic. It advances the exact `ReductiveGroups/README.md` worked-example target “`Sp₂ₙ` … prove [it is] reductive … via `R_u = 1` / root data,” using the roadmap's geometric definition from Layer 6: smoothness, geometric connectedness, and triviality of every connected normal smooth unipotent subgroup after base change to an algebraic closure.

The proof applies the existing normal-unipotent elimination theorem to the standard symplectic comodule. In positive rank that comodule is simple and hence completely reducible; in rank zero its carrier is a singleton. Its established faithfulness then forces every normal smooth unipotent subgroup ideal to be the augmentation ideal. Existing smoothness, geometric connectedness, and coordinate base-change results assemble this algebraically closed argument over an arbitrary ground field.

This is the immediate prerequisite consumed by the Layer 9 “Chevalley–Demazure construction” on the type-`C` path: after identifying the base-changed full-weight carrier's defining ideal with the symplectic defining ideal, `TauCeti.SpStd.reductiveCommHopfAlgProperty_finiteTypeSpecialization` can transport the theorem proved here. After this PR, that scheme-theoretic ideal identification and transport remain before the explicit type-`C` carrier is known to be reductive.

The implementation follows the established normal-unipotent elimination architecture in `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Reductive` and `TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Reductive`, specialized to the symplectic standard comodule; the new module records that formal provenance and cites Milne and Springer. No Mathlib infrastructure is vendored.

Adds `TauCeti/Algebra/AlgebraicGroup/Symplectic/Reductive.lean` (136 lines).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"symplectic-group-reductive"}-->

🤖 Prepared with Codex
