### PR TITLE
refactor(HeckeRing): name the factorisation criterion for `mulMap`

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/ScalarMul.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/ScalarMul.lean
@@ -74,13 +74,12 @@ private lemma mulMap_const_eq (c : ℕ) (hc : 0 < c) (hcN : Nat.Coprime c N) (b 
           rw [natDiagGL_const_comm 2 c]
       _ = σ * L₁ * R₁ * τ * L₂ * (natDiagGL 2 (fun _ ↦ c) * natDiagGL 2 b) * R₂ := by
           group
-  rw [HeckeCoset.mulMap_eq_mk]
-  exact (HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
-    ⟨(p.1.out : GL (Fin 2) ℚ) * L₁ * R₁ * p.2.out * L₂,
-      ((Gamma0 N).map (mapGL ℚ)).mul_mem (((Gamma0 N).map (mapGL ℚ)).mul_mem
-        (((Gamma0 N).map (mapGL ℚ)).mul_mem
-          (((Gamma0 N).map (mapGL ℚ)).mul_mem p.1.out.2 hL₁) hR₁) p.2.out.2) hL₂,
-      R₂, hR₂, hprod⟩)).trans (diagCosetGamma0_def N _ _).symm
+  rw [diagCosetGamma0_def N ((fun _ ↦ c) * b) fun _ ↦ hcb]
+  exact HeckeCoset.mulMap_eq_of_eq_mul_mul
+    (((Gamma0 N).map (mapGL ℚ)).mul_mem (((Gamma0 N).map (mapGL ℚ)).mul_mem
+      (((Gamma0 N).map (mapGL ℚ)).mul_mem
+        (((Gamma0 N).map (mapGL ℚ)).mul_mem p.1.out.2 hL₁) hR₁) p.2.out.2) hL₂)
+    hR₂ hprod
 
 /-- The scalar double coset occurs at most once in any product it takes part in. The other
 hypothesis of the structure-constant criterion. -/

--- a/TauCeti/NumberTheory/HeckeRing/GLn/CoprimeMul.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/CoprimeMul.lean
@@ -219,11 +219,10 @@ private lemma mulMap_coprime_eq (a b : Fin n → ℕ) (ha_pos : ∀ i, 0 < a i)
         = σ₁ * h₁a * (natDiagGL n a * (h₂a * σ₂ * h₁b) * natDiagGL n b) * h₂b := by group
       _ = σ₁ * h₁a * (hc₁ * natDiagGL n (a * b) * hc₂) * h₂b := by rw [h_eq]
       _ = σ₁ * h₁a * hc₁ * natDiagGL n (a * b) * (hc₂ * h₂b) := by group
-  rw [HeckeCoset.mulMap_eq_mk]
-  exact (HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
-    ⟨(p.1.out : GL (Fin n) ℚ) * h₁a * hc₁,
-      (SLnZ n).mul_mem ((SLnZ n).mul_mem p.1.out.2 hh₁a) hhc₁,
-      hc₂ * h₂b, (SLnZ n).mul_mem hhc₂ hh₂b, hprod⟩)).trans (diagCoset_def _).symm
+  rw [diagCoset_def (a * b)]
+  exact HeckeCoset.mulMap_eq_of_eq_mul_mul
+    ((SLnZ n).mul_mem ((SLnZ n).mul_mem p.1.out.2 hh₁a) hhc₁)
+    ((SLnZ n).mul_mem hhc₂ hh₂b) hprod
 
 end CoprimeCosets
 

--- a/TauCeti/NumberTheory/HeckeRing/GLn/ScalarMul.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/ScalarMul.lean
@@ -77,12 +77,10 @@ private lemma mulMap_const_eq (c : ℕ) (hc : 0 < c) (b : Fin n → ℕ) (hb : �
           rw [natDiagGL_const_comm n c]
       _ = σ * L₁ * R₁ * τ * L₂ * (natDiagGL n (fun _ ↦ c) * natDiagGL n b) * R₂ := by
           group
-  rw [HeckeCoset.mulMap_eq_mk]
-  exact (HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
-    ⟨(p.1.out : GL (Fin n) ℚ) * L₁ * R₁ * p.2.out * L₂,
-      (SLnZ n).mul_mem ((SLnZ n).mul_mem ((SLnZ n).mul_mem
-        ((SLnZ n).mul_mem p.1.out.2 hL₁) hR₁) p.2.out.2) hL₂,
-      R₂, hR₂, hprod⟩)).trans (diagCoset_def _).symm
+  rw [diagCoset_def ((fun _ ↦ c) * b)]
+  exact HeckeCoset.mulMap_eq_of_eq_mul_mul
+    ((SLnZ n).mul_mem ((SLnZ n).mul_mem ((SLnZ n).mul_mem
+      ((SLnZ n).mul_mem p.1.out.2 hL₁) hR₁) p.2.out.2) hL₂) hR₂ hprod
 
 private lemma multiplicity_const_le_one (c : ℕ) (b : Fin n → ℕ)
     (A : HeckeCoset (posDetInt n) (SLnZ n) (SLnZ n)) :

--- a/TauCeti/NumberTheory/HeckeRing/Multiplicity/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplicity/Basic.lean
@@ -172,6 +172,28 @@ theorem mulMap_eq_mk (H₁ H₂ H₃ : Subgroup G) [IsHeckeTriple Δ H₁ H₂] 
           (Δ.mul_mem (IsHeckeTriple.mem_of_mem_right H₁ p.2.out.2) g₂.2)⟩ :=
   mulMapOf_eq_mk _ _ H₃ g₁ g₂ p
 
+/-- **A factorisation `σᵢ g₁ τⱼ g₂ = l d r` with `l ∈ H₁` and `r ∈ H₃` names the double coset
+of the product**, from bare containments. This is the shape a structure-constant computation
+arrives at: the product of two representatives is rearranged until the intended representative
+`d` stands alone between a left factor and a right factor. -/
+lemma mulMapOf_eq_of_eq_mul_mul {H₁ H₂ H₃ : Subgroup G} {h₁ : H₁.toSubmonoid ≤ Δ}
+    {h₂ : H₂.toSubmonoid ≤ Δ} {g₁ g₂ d : Δ}
+    {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)} {l r : G}
+    (hl : l ∈ H₁) (hr : r ∈ H₃)
+    (h : (p.1.out : G) * g₁ * ((p.2.out : G) * g₂) = l * (d : G) * r) :
+    mulMapOf h₁ h₂ H₃ g₁ g₂ p = mk H₁ H₃ d :=
+  (mulMapOf_eq_mk h₁ h₂ H₃ g₁ g₂ p).trans
+    (HeckeCoset.mk_eq_mk_of_mem (DoubleCoset.mem_doubleCoset.mpr ⟨l, hl, r, hr, h⟩))
+
+/-- A factorisation `σᵢ g₁ τⱼ g₂ = l d r` with `l ∈ H₁` and `r ∈ H₃` names the double coset of
+the product: the Hecke-triple form of `mulMapOf_eq_of_eq_mul_mul`. -/
+lemma mulMap_eq_of_eq_mul_mul {H₁ H₂ H₃ : Subgroup G} [IsHeckeTriple Δ H₁ H₂] {g₁ g₂ d : Δ}
+    {p : DecompQuotient H₁ H₂ (g₁ : G) × DecompQuotient H₂ H₃ (g₂ : G)} {l r : G}
+    (hl : l ∈ H₁) (hr : r ∈ H₃)
+    (h : (p.1.out : G) * g₁ * ((p.2.out : G) * g₂) = l * (d : G) * r) :
+    mulMap H₁ H₂ H₃ g₁ g₂ p = mk H₁ H₃ d :=
+  mulMapOf_eq_of_eq_mul_mul hl hr h
+
 /-- If `σᵢ g₁ τⱼ g₂ H₃ = d H₃` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`,
 from bare containments. -/
 lemma mulMapOf_eq_of_mk_eq {H₁ H₂ H₃ : Subgroup G} {h₁ : H₁.toSubmonoid ≤ Δ}
@@ -180,9 +202,8 @@ lemma mulMapOf_eq_of_mk_eq {H₁ H₂ H₃ : Subgroup G} {h₁ : H₁.toSubmonoi
     (h : ((p.1.out : G) * g₁ * ((p.2.out : G) * g₂) : G ⧸ H₃) = ((d : G) : G ⧸ H₃)) :
     mulMapOf h₁ h₂ H₃ g₁ g₂ p = mk H₁ H₃ d := by
   rw [QuotientGroup.eq] at h
-  rw [mulMapOf_eq_mk]
-  exact HeckeCoset.mk_eq_mk_of_mem (DoubleCoset.mem_doubleCoset.mpr
-    ⟨1, H₁.one_mem, _, H₃.inv_mem h, by rw [one_mul, mul_inv_rev, inv_inv, mul_inv_cancel_left]⟩)
+  exact mulMapOf_eq_of_eq_mul_mul H₁.one_mem (H₃.inv_mem h)
+    (by rw [one_mul, mul_inv_rev, inv_inv, mul_inv_cancel_left])
 
 /-- If `σᵢ g₁ τⱼ g₂ H₃ = d H₃` then the double coset of `σᵢ g₁ τⱼ g₂` equals that of `d`:
 the Hecke-triple form of `mulMapOf_eq_of_mk_eq`. -/

--- a/TauCeti/NumberTheory/HeckeRing/Multiplicity/Unit.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplicity/Unit.lean
@@ -128,10 +128,8 @@ lemma mulMapOf_one_right (h₁ : H₁.toSubmonoid ≤ Δ) (h₂ : H₂.toSubmono
     (p : DecompQuotient H₁ H₂ (g₁ : G) ×
       DecompQuotient H₂ H₂ (((1 : HeckeCoset Δ H₂ H₂).rep : G))) :
     mulMapOf h₁ h₂ H₂ g₁ (1 : HeckeCoset Δ H₂ H₂).rep p = mk H₁ H₂ g₁ :=
-  (HeckeCoset.mulMapOf_eq_mk _ _ _ _ _ _).trans <|
-    HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr ⟨(p.1.out : G), p.1.out.2,
-      (p.2.out : G) * ((1 : HeckeCoset Δ H₂ H₂).rep : G),
-      H₂.mul_mem p.2.out.2 HeckeCoset.rep_one_mem, rfl⟩)
+  HeckeCoset.mulMapOf_eq_of_eq_mul_mul p.1.out.2
+    (H₂.mul_mem p.2.out.2 HeckeCoset.rep_one_mem) rfl
 
 /-- Every pair of representatives multiplies into `mk H₁ H₂ g₁` when the second double coset is
 the identity. -/
@@ -148,11 +146,9 @@ lemma mulMapOf_one_left (h₁ : H₁.toSubmonoid ≤ Δ) (g₁ : Δ)
     (p : DecompQuotient H₁ H₁ (((1 : HeckeCoset Δ H₁ H₁).rep : G)) ×
       DecompQuotient H₁ H₂ (g₁ : G)) :
     mulMapOf h₁ h₁ H₂ (1 : HeckeCoset Δ H₁ H₁).rep g₁ p = mk H₁ H₂ g₁ :=
-  (HeckeCoset.mulMapOf_eq_mk _ _ _ _ _ _).trans <|
-    HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
-      ⟨(p.1.out : G) * ((1 : HeckeCoset Δ H₁ H₁).rep : G) * (p.2.out : G),
-        H₁.mul_mem (H₁.mul_mem p.1.out.2 HeckeCoset.rep_one_mem) p.2.out.2, 1, H₂.one_mem,
-        by simp [mul_assoc]⟩)
+  HeckeCoset.mulMapOf_eq_of_eq_mul_mul
+    (H₁.mul_mem (H₁.mul_mem p.1.out.2 (HeckeCoset.rep_one_mem (Δ := Δ))) p.2.out.2) H₂.one_mem
+    (by simp [mul_assoc])
 
 /-- Every pair of representatives multiplies into `mk H₁ H₂ g₁` when the first double coset is
 the identity. -/

--- a/TauCeti/NumberTheory/HeckeRing/Normalizer.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Normalizer.lean
@@ -121,9 +121,8 @@ lemma mulMap_rep_mk_eq_of_mem_normalizer [IsHeckeTriple Δ Γ Γ]
       u * a * ((x : G) * (v * b) * (x : G)⁻¹) * ((x : G) * (y : G)) * 1 := fun u v ↦ by group
   have key := key₀ (p.1.out : G) (p.2.out : G)
   rw [← hA, ← hB] at key
-  rw [mulMap_eq_mk]
-  exact mk_eq_mk_of_mem (g₂ := x * y) (DoubleCoset.mem_doubleCoset.mpr
-    ⟨_, Subgroup.mul_mem _ (Subgroup.mul_mem _ p.1.out.2 ha) hc, 1, Subgroup.one_mem _, key⟩)
+  exact mulMap_eq_of_eq_mul_mul (d := x * y)
+    (Subgroup.mul_mem _ (Subgroup.mul_mem _ p.1.out.2 ha) hc) (Subgroup.one_mem _) key
 
 end HeckeCoset
 


### PR DESCRIPTION
Seven proofs across `HeckeRing/` ended the same way: rewrite `mulMap` to an explicit `mk`, then
feed `mk_eq_mk_of_mem` a `mem_doubleCoset.mpr` anonymous constructor assembled from a left
factor, the intended representative and a right factor. This PR names that step.

`HeckeCoset.mulMapOf_eq_of_eq_mul_mul` takes `l ∈ H₁`, `r ∈ H₃` and a factorisation
`σᵢ g₁ τⱼ g₂ = l d r`, and concludes `mulMapOf … = mk H₁ H₃ d`. `mulMap_eq_of_eq_mul_mul` is
its Hecke-triple form, following the two-layer shape the rest of the file already uses.

It subsumes the quotient-form lemma next to it: `mulMapOf_eq_of_mk_eq` is the case `l = 1`,
and now derives from the new lemma in one `exact` instead of building its own membership
witness.

Six further sites collapse to a single application each:

| site | was |
|---|---|
| `Multiplicity/Unit.lean` `mulMapOf_one_right` | `mulMapOf_eq_mk` + `mk_eq_mk_of_mem` + `mem_doubleCoset.mpr ⟨…⟩` |
| `Multiplicity/Unit.lean` `mulMapOf_one_left` | as above |
| `Normalizer.lean` `mulMap_rep_mk_eq_of_mem_normalizer` | as above |
| `GLn/ScalarMul.lean` `mulMap_const_eq` | as above, then `.trans (diagCoset_def _).symm` |
| `GLn/CoprimeMul.lean` `mulMap_coprime_eq` | as above |
| `GL2/Gamma0/Diagonal/ScalarMul.lean` `mulMap_const_eq` | as above, with `diagCosetGamma0_def` |

The three diagonal sites now rewrite the goal's `diagCoset` / `diagCosetGamma0` with its
defining equation *first*, so the representative `d` is fixed by the goal. Leaving `d` to be
found by unifying through the sealed definition instead costs a `whnf` timeout in both `GLn/`
sites, which is what the earlier `.trans (…_def _).symm` shape was quietly avoiding by keeping
the `mk` explicit.

No statement changes: the two new lemmas are additions, and every touched declaration keeps its
type. Net `+45 −33` over six files.

`Multiplicity/Basic.lean` is vendored from the in-review mathlib4 PR
[#41254](https://github.com/leanprover-community/mathlib4/pull/41254); the two new lemmas are
Tau Ceti additions to that vendored copy, not content from it.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQieFQn95rzgvYRvNdX3hR
