### PR TITLE
feat: identify scalar nebentypus Hecke action

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Coset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Coset.lean
@@ -153,9 +153,8 @@ theorem doubleCoset_out_diagCosetGamma0_const_eq_iUnion_rightCosets (c : ℕ)
         ((Gamma0 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
   rw [Set.iUnion_const, diagCosetGamma0_def]
   apply HeckeCoset.doubleCoset_out_mk_eq_rightCoset_of_mem_normalizer
-  exact (show natDiagGL 2 ![c, c] ∈ Subgroup.normalizer ((Gamma0 N).map (mapGL ℚ)) by
-    simpa only [natDiagGL_two_vec_const] using
-      natDiagGL_const_mem_normalizer 2 c ((Gamma0 N).map (mapGL ℚ)))
+  simpa only [natDiagGL_two_vec_const] using
+    natDiagGL_const_mem_normalizer 2 c ((Gamma0 N).map (mapGL ℚ))
 
 /-- **The scalar double coset has degree one**: `diag(c, c)` is central, so its `Γ₀(N)`-double
 coset is a single right coset. The level-`N` companion of `degree_diagCoset_const`; it is what

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Coset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Coset.lean
@@ -143,11 +143,14 @@ lemma exists_rep_diagCosetGamma0_eq_mul_natDiagGL_mul (a : Fin 2 → ℕ)
   exact DoubleCoset.mem_doubleCoset.mp hmem
 
 /-- The scalar `Γ₀(N)` double coset is the single right coset represented by its natural
-diagonal matrix. -/
+diagonal matrix. The coprimality hypothesis is only needed on the positive branch, matching
+the junk-branch convention of `diagCosetGamma0`: at `c = 0` the representative is the
+identity and the statement is the trivial decomposition of `Γ₀(N)` itself. -/
 theorem doubleCoset_out_diagCosetGamma0_const_eq_iUnion_rightCosets (c : ℕ)
-    (hcN : Nat.Coprime c N) :
+    (hcN : 0 < c → Nat.Coprime c N) :
     DoubleCoset.doubleCoset
-        ((diagCosetGamma0 N ![c, c] fun _ ↦ by simpa using hcN).out : GL (Fin 2) ℚ)
+        ((diagCosetGamma0 N ![c, c] fun h ↦ by simpa using hcN (by simpa using h 0)).out :
+          GL (Fin 2) ℚ)
         ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) =
       ⋃ _ : Unit, MulOpposite.op (natDiagGL 2 ![c, c]) •
         ((Gamma0 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Coset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Coset.lean
@@ -151,10 +151,12 @@ theorem doubleCoset_out_diagCosetGamma0_const_eq_iUnion_rightCosets (c : ℕ)
         ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) =
       ⋃ _ : Unit, MulOpposite.op (natDiagGL 2 ![c, c]) •
         ((Gamma0 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
+  have hvec : ![c, c] = fun _ : Fin 2 ↦ c := by
+    funext i
+    fin_cases i <;> rfl
   rw [Set.iUnion_const, diagCosetGamma0_def]
   apply HeckeCoset.doubleCoset_out_mk_eq_rightCoset_of_mem_normalizer
-  simpa only [natDiagGL_two_vec_const] using
-    natDiagGL_const_mem_normalizer 2 c ((Gamma0 N).map (mapGL ℚ))
+  simpa only [hvec] using natDiagGL_const_mem_normalizer 2 c ((Gamma0 N).map (mapGL ℚ))
 
 /-- **The scalar double coset has degree one**: `diag(c, c)` is central, so its `Γ₀(N)`-double
 coset is a single right coset. The level-`N` companion of `degree_diagCoset_const`; it is what

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Coset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Coset.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.CosetMap
 public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
+public import TauCeti.NumberTheory.HeckeRing.Normalizer
 
 /-!
 # The `Γ₀(N)`-double coset of a diagonal matrix
@@ -44,6 +45,8 @@ Ported from the AINTLIB `LeanModularForms` project
 * `HeckeRing.GL2.diagCosetGamma0_one`: the all-ones tuple gives the identity coset.
 * `HeckeRing.GL2.diagCosetGamma0_of_not_pos`: so does any tuple that is not everywhere
   positive.
+* `HeckeRing.GL2.doubleCoset_out_diagCosetGamma0_const_eq_iUnion_rightCosets`: a scalar
+  double coset is a single right coset.
 
 ## References
 
@@ -139,6 +142,21 @@ lemma exists_rep_diagCosetGamma0_eq_mul_natDiagGL_mul (a : Fin 2 → ℕ)
     exact HeckeCoset.rep_mem _
   exact DoubleCoset.mem_doubleCoset.mp hmem
 
+/-- The scalar `Γ₀(N)` double coset is the single right coset represented by its natural
+diagonal matrix. -/
+theorem doubleCoset_out_diagCosetGamma0_const_eq_iUnion_rightCosets (c : ℕ)
+    (hcN : Nat.Coprime c N) :
+    DoubleCoset.doubleCoset
+        ((diagCosetGamma0 N ![c, c] fun _ ↦ by simpa using hcN).out : GL (Fin 2) ℚ)
+        ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) =
+      ⋃ _ : Unit, MulOpposite.op (natDiagGL 2 ![c, c]) •
+        ((Gamma0 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
+  rw [Set.iUnion_const, diagCosetGamma0_def]
+  apply HeckeCoset.doubleCoset_out_mk_eq_rightCoset_of_mem_normalizer
+  exact (show natDiagGL 2 ![c, c] ∈ Subgroup.normalizer ((Gamma0 N).map (mapGL ℚ)) by
+    simpa only [natDiagGL_two_vec_const] using
+      natDiagGL_const_mem_normalizer 2 c ((Gamma0 N).map (mapGL ℚ)))
+
 /-- **The scalar double coset has degree one**: `diag(c, c)` is central, so its `Γ₀(N)`-double
 coset is a single right coset. The level-`N` companion of `degree_diagCoset_const`; it is what
 bounds the multiplicity of a product one of whose factors is scalar. -/
@@ -147,10 +165,7 @@ theorem degree_diagCosetGamma0_const (c : ℕ)
     (hgcd : (∀ _ : Fin 2, 0 < c) → Nat.Coprime c N) :
     (diagCosetGamma0 N (fun _ ↦ c) hgcd).degree = 1 := by
   rw [diagCosetGamma0_def, HeckeCoset.degree_mk]
-  have hnorm : natDiagGL 2 (fun _ ↦ c) ∈ Subgroup.normalizer ((Gamma0 N).map (mapGL ℚ)) := by
-    rw [Subgroup.mem_normalizer_iff]
-    intro x
-    rw [natDiagGL_const_comm 2 c x, mul_assoc, mul_inv_cancel, mul_one]
+  have hnorm := natDiagGL_const_mem_normalizer 2 c ((Gamma0 N).map (mapGL ℚ))
   rw [Subgroup.conjAct_pointwise_smul_eq_self hnorm, Subgroup.relIndex_self]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/NebentypusChar.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/NebentypusChar.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck, Claude
 module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.UpperUnit
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Coset
 public import Mathlib.Basic.Complex.Basic
 
 /-!
@@ -39,6 +40,7 @@ of the one attached to a group element acting on forms. It is inherited directly
   downstream neither `rfl`, `unfold`, `simp [delta0NebentypusChar]` nor `MonoidHom.comp_apply`
   can recover it — but plain `simp` does, *through this lemma*.
 * `HeckeRing.GL2.delta0NebentypusChar_mapGL`: on `Γ₀(N)` it is inverse to `χ ∘ Gamma0Map`.
+* `HeckeRing.GL2.delta0NebentypusChar_natDiagGL`: its value on a positive natural diagonal.
 
 ## References
 
@@ -91,5 +93,20 @@ lemma delta0NebentypusChar_mapGL (χ : (ZMod N)ˣ →* ℂˣ) (γ : Gamma0 N) :
     delta0NebentypusChar N χ ⟨_, mapGL_mem_Delta0 N γ⟩ =
       (χ ((Gamma0Map N).toHomUnits γ))⁻¹ := by
   rw [delta0NebentypusChar_apply, Delta0UpperUnit_mapGL, map_inv]
+
+/-- The twisting character reads a positive natural diagonal from its upper-left entry. -/
+lemma delta0NebentypusChar_natDiagGL (χ : (ZMod N)ˣ →* ℂˣ) (a : Fin 2 → ℕ)
+    (ha : ∀ i, 0 < a i) (haN : Nat.Coprime (a 0) N) :
+    delta0NebentypusChar N χ
+        ⟨natDiagGL 2 a, natDiagGL_mem_Delta0_of_coprime N a fun _ ↦ haN⟩ =
+      χ (ZMod.unitOfCoprime (a 0) haN) := by
+  rw [delta0NebentypusChar_apply]
+  apply congrArg χ
+  apply Units.ext
+  rw [Delta0UpperUnit_apply_val N
+    (A := Matrix.diagonal (fun i : Fin 2 ↦ (a i : ℤ)))
+    (by
+      rw [natDiagGL_coe_eq_map_intCast 2 a ha])]
+  simp [ZMod.coe_unitOfCoprime]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
@@ -51,11 +51,7 @@ branch, which is `1`, whose double coset is the identity — not from centrality
 @[simp]
 theorem degree_diagCoset_const (c : ℕ) : (diagCoset (fun _ : Fin n ↦ c)).degree = 1 := by
   rw [diagCoset_def, HeckeCoset.degree_mk]
-  -- a central element normalizes every subgroup, so Mathlib's lemma applies
-  have hnorm : natDiagGL n (fun _ ↦ c) ∈ Subgroup.normalizer (SLnZ n) := by
-    rw [Subgroup.mem_normalizer_iff]
-    intro x
-    rw [natDiagGL_const_comm n c x, mul_assoc, mul_inv_cancel, mul_one]
+  have hnorm := natDiagGL_const_mem_normalizer n c (SLnZ n)
   rw [Subgroup.conjAct_pointwise_smul_eq_self hnorm, Subgroup.relIndex_self]
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
@@ -36,7 +36,7 @@ Chris Birkbeck), on top of the matrix-level Smith normal form
 ## Main results
 
 * `natDiagGL_const_eq_scalar`, `natDiagGL_const_mem_normalizer`: a constant natural diagonal
-  is scalar when positive and normalizes every subgroup unconditionally.
+  is scalar when positive, and normalizes every subgroup unconditionally.
 * `exists_diagonal_representative`: every double coset of the arithmetic Hecke triple is
   `diagCoset a` for a positive divisibility chain `a` (Smith normal form).
 * `diagCoset_bijective`: positive divisibility chains biject with the double cosets.
@@ -168,19 +168,11 @@ lemma natDiagGL_const_comm (c : ℕ) (g : GL (Fin n) ℚ) :
   · rw [natDiagGL_const_eq_scalar n hc]
     exact Matrix.GeneralLinearGroup.scalar_commute _ _
 
-/-- A constant natural diagonal normalizes every subgroup of `GLₙ(ℚ)`. -/
+/-- A constant natural diagonal normalizes every subgroup of `GLₙ(ℚ)`: it is central. -/
 lemma natDiagGL_const_mem_normalizer (c : ℕ) (Γ : Subgroup (GL (Fin n) ℚ)) :
-    natDiagGL n (fun _ ↦ c) ∈ Subgroup.normalizer Γ := by
-  rw [Subgroup.mem_normalizer_iff]
-  intro x
-  rw [natDiagGL_const_comm n c x, mul_assoc, mul_inv_cancel, mul_one]
-
-/-- The two-entry vector with both entries `c` gives the constant natural diagonal. -/
-lemma natDiagGL_two_vec_const (c : ℕ) :
-    natDiagGL 2 ![c, c] = natDiagGL 2 (fun _ : Fin 2 ↦ c) := by
-  congr 1
-  funext i
-  fin_cases i <;> rfl
+    natDiagGL n (fun _ ↦ c) ∈ Subgroup.normalizer Γ :=
+  Subgroup.center_le_normalizer _
+    (Subgroup.mem_center_iff.mpr fun g ↦ (natDiagGL_const_comm n c g).symm)
 
 @[simp] lemma natDiagGL_one : natDiagGL n (fun _ ↦ 1) = 1 := by
   ext1

--- a/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/DiagonalCosets.lean
@@ -35,6 +35,8 @@ Chris Birkbeck), on top of the matrix-level Smith normal form
 
 ## Main results
 
+* `natDiagGL_const_eq_scalar`, `natDiagGL_const_mem_normalizer`: a constant natural diagonal
+  is scalar when positive and normalizes every subgroup unconditionally.
 * `exists_diagonal_representative`: every double coset of the arithmetic Hecke triple is
   `diagCoset a` for a positive divisibility chain `a` (Smith normal form).
 * `diagCoset_bijective`: positive divisibility chains biject with the double cosets.
@@ -144,7 +146,8 @@ lemma natDiagGL_comm (a b : Fin n → ℕ) :
     · rw [natDiagGL_of_not_pos n hb, one_mul, mul_one]
   · rw [natDiagGL_of_not_pos n ha, one_mul, mul_one]
 
-private lemma natDiagGL_const_eq_scalar {c : ℕ} (hc : 0 < c) :
+/-- A positive constant natural diagonal is the corresponding scalar matrix. -/
+lemma natDiagGL_const_eq_scalar {c : ℕ} (hc : 0 < c) :
     natDiagGL n (fun _ ↦ c) =
       Matrix.GeneralLinearGroup.scalar (Fin n)
         (Units.mk0 (c : ℚ) (by exact_mod_cast hc.ne')) := by
@@ -164,6 +167,20 @@ lemma natDiagGL_const_comm (c : ℕ) (g : GL (Fin n) ℚ) :
   · rw [natDiagGL_of_not_pos n (not_forall.mpr ⟨⟨0, hn⟩, by simp⟩), one_mul, mul_one]
   · rw [natDiagGL_const_eq_scalar n hc]
     exact Matrix.GeneralLinearGroup.scalar_commute _ _
+
+/-- A constant natural diagonal normalizes every subgroup of `GLₙ(ℚ)`. -/
+lemma natDiagGL_const_mem_normalizer (c : ℕ) (Γ : Subgroup (GL (Fin n) ℚ)) :
+    natDiagGL n (fun _ ↦ c) ∈ Subgroup.normalizer Γ := by
+  rw [Subgroup.mem_normalizer_iff]
+  intro x
+  rw [natDiagGL_const_comm n c x, mul_assoc, mul_inv_cancel, mul_one]
+
+/-- The two-entry vector with both entries `c` gives the constant natural diagonal. -/
+lemma natDiagGL_two_vec_const (c : ℕ) :
+    natDiagGL 2 ![c, c] = natDiagGL 2 (fun _ : Fin 2 ↦ c) := by
+  congr 1
+  funext i
+  fin_cases i <;> rfl
 
 @[simp] lemma natDiagGL_one : natDiagGL n (fun _ ↦ 1) = 1 := by
   ext1

--- a/TauCeti/NumberTheory/ModularForms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Basic.lean
@@ -43,8 +43,8 @@ AINTLIB `LeanModularForms` project
 
 ## Main results
 
-* `ModularForm.slash_scalar_of_pos`: a positive scalar matrix acts by its scalar to the
-  power `k - 2` under the weight-`k` slash action.
+* `ModularForm.slash_scalar`: a real scalar matrix acts by its scalar to the power `k - 2`
+  under the weight-`k` slash action.
 * `SlashInvariantFormClass.SL_slash_eq`: a form invariant under the image of `Γ ≤ SL(2, ℤ)`
   is fixed by the slash action of every element of `Γ`.
 * `SlashInvariantForm.slash_action_eqn_of_det_pos`: the transformation law
@@ -208,14 +208,13 @@ theorem _root_.ModularForm.smul_slash_of_det_pos {α : Type*} [SMul α ℂ] [IsS
   ext τ : 1
   simp [ModularForm.slash_apply_of_det_pos k hg, smul_mul_assoc]
 
-/-- A positive real scalar matrix acts trivially on the upper half-plane, and its weight-`k`
+/-- A real scalar matrix acts trivially on the upper half-plane, and its weight-`k`
 slash is multiplication by the scalar to the power `k - 2`.
 
 The calculation generalizes AINTLIB's `slash_diag_scalar` (Chris Birkbeck, Apache-2.0), in
 `LeanModularForms/HeckeRIngs/GL2/Unified/NebentypusHeckeRingHom.lean` at commit
 `2baa76f742bdb4fb8ee323fabba41203bd390e08`. -/
-theorem _root_.ModularForm.slash_scalar_of_pos (k : ℤ) (u : ℝˣ) (hu : 0 < (u : ℝ))
-    (f : ℍ → ℂ) :
+theorem _root_.ModularForm.slash_scalar (k : ℤ) (u : ℝˣ) (f : ℍ → ℂ) :
     f ∣[k] Matrix.GeneralLinearGroup.scalar (Fin 2) u =
       ((u : ℝ) : ℂ) ^ (k - 2) • f := by
   have hdet : ((Matrix.GeneralLinearGroup.scalar (Fin 2) u).det : ℝ) = (u : ℝ) ^ 2 := by
@@ -223,14 +222,14 @@ theorem _root_.ModularForm.slash_scalar_of_pos (k : ℤ) (u : ℝˣ) (hu : 0 < (
     simp
   have hdetpos : 0 < ((Matrix.GeneralLinearGroup.scalar (Fin 2) u).det : ℝ) := by
     rw [hdet]
-    positivity
+    exact (sq_nonneg _).lt_of_ne' (pow_ne_zero 2 u.ne_zero)
   ext z
   rw [ModularForm.slash_apply_of_det_pos k hdetpos, UpperHalfPlane.glScalar_smul,
     UpperHalfPlane.denom_scalar, hdet, abs_of_nonneg (sq_nonneg (u : ℝ))]
   push_cast
   rw [← zpow_natCast (((u : ℝ) : ℂ)) 2, ← zpow_mul]
   simp only [Pi.smul_apply, smul_eq_mul]
-  rw [mul_assoc, ← zpow_add₀ (by exact_mod_cast (ne_of_gt hu)), mul_comm]
+  rw [mul_assoc, ← zpow_add₀ (by exact_mod_cast u.ne_zero), mul_comm]
   congr 1
   ring_nf
 

--- a/TauCeti/NumberTheory/ModularForms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Basic.lean
@@ -43,6 +43,8 @@ AINTLIB `LeanModularForms` project
 
 ## Main results
 
+* `ModularForm.slash_scalar_of_pos`: a positive scalar matrix acts by its scalar to the
+  power `k - 2` under the weight-`k` slash action.
 * `SlashInvariantFormClass.SL_slash_eq`: a form invariant under the image of `Γ ≤ SL(2, ℤ)`
   is fixed by the slash action of every element of `Γ`.
 * `SlashInvariantForm.slash_action_eqn_of_det_pos`: the transformation law
@@ -205,6 +207,32 @@ theorem _root_.ModularForm.smul_slash_of_det_pos {α : Type*} [SMul α ℂ] [IsS
     (c : α) : (c • f) ∣[k] g = c • f ∣[k] g := by
   ext τ : 1
   simp [ModularForm.slash_apply_of_det_pos k hg, smul_mul_assoc]
+
+/-- A positive real scalar matrix acts trivially on the upper half-plane, and its weight-`k`
+slash is multiplication by the scalar to the power `k - 2`.
+
+The calculation generalizes AINTLIB's `slash_diag_scalar` (Chris Birkbeck, Apache-2.0), in
+`LeanModularForms/HeckeRIngs/GL2/Unified/NebentypusHeckeRingHom.lean` at commit
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`. -/
+theorem _root_.ModularForm.slash_scalar_of_pos (k : ℤ) (u : ℝˣ) (hu : 0 < (u : ℝ))
+    (f : ℍ → ℂ) :
+    f ∣[k] Matrix.GeneralLinearGroup.scalar (Fin 2) u =
+      ((u : ℝ) : ℂ) ^ (k - 2) • f := by
+  have hdet : ((Matrix.GeneralLinearGroup.scalar (Fin 2) u).det : ℝ) = (u : ℝ) ^ 2 := by
+    rw [Matrix.GeneralLinearGroup.det_scalar]
+    simp
+  have hdetpos : 0 < ((Matrix.GeneralLinearGroup.scalar (Fin 2) u).det : ℝ) := by
+    rw [hdet]
+    positivity
+  ext z
+  rw [ModularForm.slash_apply_of_det_pos k hdetpos, UpperHalfPlane.glScalar_smul,
+    UpperHalfPlane.denom_scalar, hdet, abs_of_nonneg (sq_nonneg (u : ℝ))]
+  push_cast
+  rw [← zpow_natCast (((u : ℝ) : ℂ)) 2, ← zpow_mul]
+  simp only [Pi.smul_apply, smul_eq_mul]
+  rw [mul_assoc, ← zpow_add₀ (by exact_mod_cast (ne_of_gt hu)), mul_comm]
+  congr 1
+  ring_nf
 
 /-- A form invariant under the image in `GL(2, ℝ)` of a subgroup `Γ ≤ SL(2, ℤ)` is fixed by
 the weight-`k` slash action of every element of `Γ` — the invariance condition read back at

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Involution.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Involution.lean
@@ -91,7 +91,7 @@ public noncomputable def frickeScalar (N : ℕ) (k : ℤ) : ℂ :=
 
 Deliberately not `@[simp]`: `frickeScalar N k` is the normal form here, not the expanded product.
 Every statement below is phrased in terms of the named constant, and the two factors only need to
-be visible inside `frickeGL_sq_slash`, which rewrites with this lemma explicitly. -/
+be visible inside `frickeScalar_eq`, which rewrites with this lemma explicitly. -/
 public theorem frickeScalar_def (N : ℕ) (k : ℤ) :
     frickeScalar N k = (N : ℂ) ^ (2 * (k - 1)) * (-(N : ℂ)) ^ (-k) := (rfl)
 
@@ -138,22 +138,16 @@ slash is the constant `|det W²| ^ (k - 1) * (-N) ^ (-k)`. -/
 public theorem frickeGL_sq_slash (k : ℤ) (f : ℍ → ℂ) :
     f ∣[k] (frickeGL ℝ N * frickeGL ℝ N) = frickeScalar N k • f := by
   have hN : (N : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne N)
-  set u : ℝˣ := Units.mk0 (-(N : ℝ)) (neg_ne_zero.mpr hN) with hu
-  have hdet : ((Matrix.GeneralLinearGroup.scalar (Fin 2) u).det : ℝ) = (N : ℝ) ^ 2 := by
-    rw [Matrix.GeneralLinearGroup.det_scalar]
-    simp [hu, sq]
-  have hpos : 0 < ((Matrix.GeneralLinearGroup.scalar (Fin 2) u).det : ℝ) := by
-    rw [hdet]
-    exact pow_pos ((Nat.cast_pos (α := ℝ)).mpr (NeZero.pos N)) 2
-  have hσ := UpperHalfPlane.σ_eq_refl_of_det_pos hpos
-  ext z
-  rw [ModularForm.slash_apply, frickeGL_sq_eq_scalar hN, ← hu, hσ, glScalar_smul, denom_scalar,
-    hdet, abs_of_nonneg (by positivity : (0 : ℝ) ≤ (N : ℝ) ^ 2)]
-  push_cast [hu, frickeScalar_def]
-  rw [← zpow_natCast (N : ℂ) 2, ← zpow_mul]
-  simp only [ContinuousAlgEquiv.refl_apply, Nat.cast_ofNat, Units.val_mk0, Complex.ofReal_neg,
-    Complex.ofReal_natCast, zpow_neg, Pi.smul_apply, smul_eq_mul]
-  ring
+  rw [frickeGL_sq_eq_scalar hN, ModularForm.slash_scalar, frickeScalar_eq]
+  congr 1
+  -- `ModularForm.slash_scalar` leaves the scalar of `W²`, namely `-N`, raised to `k - 2`.
+  -- Splitting the sign off the base is what turns it into the evaluated form of `frickeScalar`.
+  have hsplit : ((Units.mk0 (-(N : ℝ)) (neg_ne_zero.mpr hN) : ℝˣ) : ℝ) = (-1) * (N : ℝ) := by
+    simp
+  rw [hsplit]
+  push_cast
+  rw [mul_zpow, zpow_sub₀ (by norm_num : (-1 : ℂ) ≠ 0)]
+  norm_num
 
 /-- **Collapsing a Fricke factor**: slashing by `A * W` is `frickeScalar N k •` slashing by
 `A * W⁻¹`, because `A * W = (A * W⁻¹) * W²`. This is the step that lets the two Fricke factors

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/Basic.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
+public import TauCeti.NumberTheory.ModularForms.SlashActionRat
+
+/-!
+# The rational slash action of a diagonal Hecke representative
+
+The Hecke coset representatives that are not upper triangular are the rational diagonal
+matrices `natDiagGL 2 a`. This file records how the weight-`k` rational slash action sees the
+scalar ones: `diag(c, c)` acts trivially on the upper half-plane, so it only contributes the
+automorphy factor, which is `c ^ (k - 2)`.
+
+## Main results
+
+* `TauCeti.rat_slash_natDiagGL_const`: a nonzero constant rational diagonal acts by
+  `c ^ (k - 2)`.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.3.
+-/
+
+public section
+
+open Matrix UpperHalfPlane HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm
+
+namespace TauCeti
+
+/-- A nonzero constant natural diagonal acts through the rational weight-`k` slash by
+`c ^ (k - 2)`. -/
+@[simp]
+lemma rat_slash_natDiagGL_const {c : ℕ} [NeZero c] (k : ℤ) (f : ℍ → ℂ) :
+    f ∣[k] natDiagGL 2 ![c, c] = (c : ℂ) ^ (k - 2) • f := by
+  have hc : 0 < c := Nat.pos_of_ne_zero (NeZero.ne c)
+  have hvec : ![c, c] = fun _ : Fin 2 ↦ c := by
+    funext i
+    fin_cases i <;> rfl
+  rw [hvec, natDiagGL_const_eq_scalar 2 hc, ModularForm.rat_slash,
+    Matrix.GeneralLinearGroup.map_scalar]
+  let u : ℝˣ := Units.map (algebraMap ℚ ℝ)
+    (Units.mk0 (c : ℚ) (by exact_mod_cast hc.ne'))
+  rw [ModularForm.slash_scalar k u]
+  have hu : (((u : ℝ) : ℂ)) = (c : ℂ) := by simp [u]
+  rw [hu]
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/Basic.lean
@@ -11,10 +11,10 @@ public import TauCeti.NumberTheory.ModularForms.SlashActionRat
 /-!
 # The rational slash action of a diagonal Hecke representative
 
-The Hecke coset representatives that are not upper triangular are the rational diagonal
-matrices `natDiagGL 2 a`. This file records how the weight-`k` rational slash action sees the
-scalar ones: `diag(c, c)` acts trivially on the upper half-plane, so it only contributes the
-automorphy factor, which is `c ^ (k - 2)`.
+This file treats the rational diagonal Hecke representatives `natDiagGL 2 a`, specifically
+the scalar ones, and records how the weight-`k` rational slash action sees them: `diag(c, c)`
+acts trivially on the upper half-plane, so it only contributes the automorphy factor, which is
+`c ^ (k - 2)`.
 
 ## Main results
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/Basic.lean
@@ -18,7 +18,7 @@ acts trivially on the upper half-plane, so it only contributes the automorphy fa
 
 ## Main results
 
-* `TauCeti.rat_slash_natDiagGL_const`: a nonzero constant rational diagonal acts by
+* `ModularForm.rat_slash_natDiagGL_const`: a nonzero constant rational diagonal acts by
   `c ^ (k - 2)`.
 
 ## References
@@ -33,7 +33,7 @@ open Matrix UpperHalfPlane HeckeRing.GLn
 
 open scoped MatrixGroups ModularForm
 
-namespace TauCeti
+namespace ModularForm
 
 /-- A nonzero constant natural diagonal acts through the rational weight-`k` slash by
 `c ^ (k - 2)`. -/
@@ -52,6 +52,6 @@ lemma rat_slash_natDiagGL_const {c : ℕ} [NeZero c] (k : ℤ) (f : ℍ → ℂ)
   have hu : (((u : ℝ) : ℂ)) = (c : ℂ) := by simp [u]
   rw [hu]
 
-end TauCeti
+end ModularForm
 
 end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/QExpansion.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/QExpansion.lean
@@ -5,10 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
 public import TauCeti.NumberTheory.ModularForms.Degeneracy
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Diagonal.Basic
-public import TauCeti.NumberTheory.ModularForms.SlashActionRat
 
 import TauCeti.NumberTheory.ModularForms.Cusps.Basic
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/QExpansion.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/QExpansion.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
 public import TauCeti.NumberTheory.ModularForms.Degeneracy
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Diagonal.Basic
 public import TauCeti.NumberTheory.ModularForms.SlashActionRat
 
 import TauCeti.NumberTheory.ModularForms.Cusps.Basic
@@ -34,8 +35,6 @@ from the diamond operator and is not part of the diagonal slash.
   scaling matrix used by `V_d`.
 * `TauCeti.slash_natDiagGL_d_one_eq_smul_levelRaise`: the rational diagonal slash is
   `d ^ (k - 1)` times the degeneracy map.
-* `TauCeti.rat_slash_natDiagGL_const`: a nonzero constant rational diagonal acts by
-  `c ^ (k - 2)`.
 * `ModularForm.qExpansion_slash_natDiagGL_d_one`: the resulting power-series identity.
 * The corresponding `_coeff` lemmas give the divisibility-conditional coefficient formula.
 
@@ -64,20 +63,6 @@ open scoped MatrixGroups ModularForm Pointwise
 namespace TauCeti
 
 variable {k : ℤ} {d : ℕ}
-
-/-- A nonzero constant natural diagonal acts through the rational weight-`k` slash by
-`c ^ (k - 2)`. -/
-@[simp]
-lemma rat_slash_natDiagGL_const {c : ℕ} [NeZero c] (k : ℤ) (f : ℍ → ℂ) :
-    f ∣[k] natDiagGL 2 ![c, c] = (c : ℂ) ^ (k - 2) • f := by
-  have hc : 0 < c := Nat.pos_of_ne_zero (NeZero.ne c)
-  rw [natDiagGL_two_vec_const, natDiagGL_const_eq_scalar 2 hc, ModularForm.rat_slash,
-    Matrix.GeneralLinearGroup.map_scalar]
-  let u : ℝˣ := Units.map (algebraMap ℚ ℝ)
-    (Units.mk0 (c : ℚ) (by exact_mod_cast hc.ne'))
-  rw [ModularForm.slash_scalar_of_pos k u (by simp [u, hc])]
-  have hu : (((u : ℝ) : ℂ)) = (c : ℂ) := by simp [u]
-  rw [hu]
 
 /-- The positive rational diagonal matrix `diag(d, 1)` maps to the real scaling matrix used to
 define the degeneracy operator `V_d`. -/

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/QExpansion.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/QExpansion.lean
@@ -34,6 +34,8 @@ from the diamond operator and is not part of the diagonal slash.
   scaling matrix used by `V_d`.
 * `TauCeti.slash_natDiagGL_d_one_eq_smul_levelRaise`: the rational diagonal slash is
   `d ^ (k - 1)` times the degeneracy map.
+* `TauCeti.rat_slash_natDiagGL_const`: a nonzero constant rational diagonal acts by
+  `c ^ (k - 2)`.
 * `ModularForm.qExpansion_slash_natDiagGL_d_one`: the resulting power-series identity.
 * The corresponding `_coeff` lemmas give the divisibility-conditional coefficient formula.
 
@@ -62,6 +64,20 @@ open scoped MatrixGroups ModularForm Pointwise
 namespace TauCeti
 
 variable {k : ℤ} {d : ℕ}
+
+/-- A nonzero constant natural diagonal acts through the rational weight-`k` slash by
+`c ^ (k - 2)`. -/
+@[simp]
+lemma rat_slash_natDiagGL_const {c : ℕ} [NeZero c] (k : ℤ) (f : ℍ → ℂ) :
+    f ∣[k] natDiagGL 2 ![c, c] = (c : ℂ) ^ (k - 2) • f := by
+  have hc : 0 < c := Nat.pos_of_ne_zero (NeZero.ne c)
+  rw [natDiagGL_two_vec_const, natDiagGL_const_eq_scalar 2 hc, ModularForm.rat_slash,
+    Matrix.GeneralLinearGroup.map_scalar]
+  let u : ℝˣ := Units.map (algebraMap ℚ ℝ)
+    (Units.mk0 (c : ℚ) (by exact_mod_cast hc.ne'))
+  rw [ModularForm.slash_scalar_of_pos k u (by simp [u, hc])]
+  have hu : (((u : ℝ) : ℂ)) = (c : ℂ) := by simp [u]
+  rw [hu]
 
 /-- The positive rational diagonal matrix `diag(d, 1)` maps to the real scaling matrix used to
 define the degeneracy operator `V_d`. -/

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Scalar.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Scalar.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.PrimePower
-public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Diagonal.QExpansion
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Diagonal.Basic
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Action
 
 /-!

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Scalar.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Scalar.lean
@@ -1,0 +1,228 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.PrimePower
+public import TauCeti.NumberTheory.HeckeRing.Normalizer
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Action
+
+/-!
+# Scalar cosets in the nebentypus Hecke action
+
+This file identifies the action of the scalar double coset
+`Γ₀(N) diag(c, c) Γ₀(N)` on modular and cusp forms of nebentypus `χ`. Since the scalar matrix
+normalizes `Γ₀(N)`, its double coset has one right coset. The twisting character reads its
+upper-left entry as `χ(c)`, while the weight-`k` slash action contributes `c ^ (k - 2)`.
+Consequently the scalar Hecke generator acts by
+
+```lean
+(χ (ZMod.unitOfCoprime c hcN) : ℂ) * (c : ℂ) ^ (k - 2).
+```
+
+The factor is `χ(c)`, not `χ(c)⁻¹`: the twisted slash sum is written using right-coset
+representatives in `Δ₀(N)` and weights them by `delta0NebentypusChar`, whose value on the
+scalar representative is its upper-left unit `c`.
+
+## Main results
+
+* `HeckeRing.GL2.twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_const`: the scalar
+  double coset acts by the expected scalar on modular forms.
+* `HeckeRing.GL2.twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_const`: the corresponding
+  statement for cusp forms.
+* `HeckeRing.GL2.heckeRingHomCharSpace_heckeTScalarGamma0`: the scalar generator under the
+  modular-form Hecke-ring action.
+* `HeckeRing.GL2.heckeRingHomCuspCharSpace_heckeTScalarGamma0`: the cusp-form counterpart.
+
+## Provenance
+
+The scalar-slash calculation is adapted from `slash_diag_scalar` in the AINTLIB
+`LeanModularForms` project (Chris Birkbeck, Apache-2.0), file
+`LeanModularForms/HeckeRIngs/GL2/Unified/NebentypusHeckeRingHom.lean` at commit
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`. The coset decomposition here instead uses Tau
+Ceti's normalizer API and its representative-independent right-coset sum.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.3 and §3.5.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
+  HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm Pointwise
+
+namespace HeckeRing.GL2
+
+variable {N : ℕ} (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+
+variable [NeZero N]
+
+omit [NeZero N] in
+/-- The twisting character reads the constant diagonal representative as its scalar entry. -/
+lemma delta0NebentypusChar_natDiagGL_const (c : ℕ) (hc : 0 < c)
+    (hcN : Nat.Coprime c N) :
+    delta0NebentypusChar N χ
+        ⟨natDiagGL 2 ![c, c],
+          natDiagGL_mem_Delta0_of_coprime N _ fun _ ↦ by simpa using hcN⟩ =
+      χ (ZMod.unitOfCoprime c hcN) := by
+  rw [delta0NebentypusChar_apply]
+  apply congrArg χ
+  apply Units.ext
+  rw [Delta0UpperUnit_apply_val N
+    (A := Matrix.diagonal (fun _ : Fin 2 ↦ (c : ℤ)))
+    (by
+      rw [natDiagGL_coe_eq_map_intCast 2 _
+        (fun i ↦ by fin_cases i <;> simpa using hc)]
+      congr 2
+      funext i
+      fin_cases i <;> rfl)]
+  simp [ZMod.coe_unitOfCoprime]
+
+/-- A positive rational scalar matrix acts trivially on the upper half-plane and its
+weight-`k` slash is multiplication by `c ^ (k - 2)`. -/
+lemma rat_slash_natDiagGL_const (c : ℕ) (hc : 0 < c) (f : ℍ → ℂ) :
+    f ∣[k] natDiagGL 2 ![c, c] = (c : ℂ) ^ (k - 2) • f := by
+  have hcpos : ∀ i : Fin 2, 0 < ![c, c] i := by
+    intro i
+    fin_cases i <;> simpa using hc
+  have hdetpos : 0 <
+      (natDiagGL 2 ![c, c] : Matrix (Fin 2) (Fin 2) ℚ).det :=
+    natDiagGL_det_pos 2 _ hcpos
+  have hcne : (c : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr hc.ne'
+  ext z
+  rw [ModularForm.rat_slash_apply_of_det_pos k hdetpos]
+  have hsmul :
+      Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
+          (natDiagGL 2 ![c, c]) • z = z := by
+    apply UpperHalfPlane.ext
+    rw [UpperHalfPlane.coe_smul_of_det_pos (ModularForm.det_map_ratCast_pos hdetpos)]
+    change
+      ((Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
+              (natDiagGL 2 ![c, c])) 0 0 * (z : ℂ) +
+          (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
+              (natDiagGL 2 ![c, c])) 0 1) /
+          ((Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
+              (natDiagGL 2 ![c, c])) 1 0 * (z : ℂ) +
+            (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
+              (natDiagGL 2 ![c, c])) 1 1) = (z : ℂ)
+    simp [Matrix.GeneralLinearGroup.map, natDiagGL_coe 2 _ hcpos, Matrix.map_apply]
+    field_simp
+  have hdenom :
+      denom (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
+          (natDiagGL 2 ![c, c])) z = (c : ℂ) := by
+    change
+      (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
+            (natDiagGL 2 ![c, c])) 1 0 * (z : ℂ) +
+          (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
+            (natDiagGL 2 ![c, c])) 1 1 = (c : ℂ)
+    simp [Matrix.GeneralLinearGroup.map, natDiagGL_coe 2 _ hcpos, Matrix.map_apply]
+  have habsdet :
+      (↑|(Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
+          (natDiagGL 2 ![c, c])).det.val| : ℂ) = (c : ℂ) ^ 2 := by
+    have hdet :
+        (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
+          (natDiagGL 2 ![c, c])).det.val =
+            algebraMap ℚ ℝ
+              (natDiagGL 2 ![c, c]).det.val :=
+      congrArg Units.val
+        (Matrix.GeneralLinearGroup.map_det (algebraMap ℚ ℝ)
+          (natDiagGL 2 ![c, c]))
+    rw [hdet, Matrix.GeneralLinearGroup.val_det_apply,
+      natDiagGL_coe 2 _ hcpos, Matrix.det_diagonal, Fin.prod_univ_two]
+    simp only [map_mul, map_natCast]
+    rw [abs_of_nonneg (by positivity)]
+    push_cast
+    ring
+  rw [hsmul, hdenom, habsdet]
+  change f z * ((c : ℂ) ^ 2) ^ (k - 1) * (c : ℂ) ^ (-k) =
+    (c : ℂ) ^ (k - 2) * f z
+  rw [show ((c : ℂ) ^ 2) = (c : ℂ) ^ (2 : ℤ) by norm_cast, ← _root_.zpow_mul,
+    mul_assoc, ← zpow_add₀ hcne, mul_comm]
+  congr 1
+  ring_nf
+
+omit [NeZero N] in
+private lemma scalarCoset_cover (c : ℕ) (hcN : Nat.Coprime c N) :
+    doubleCoset
+        ((diagCosetGamma0 N ![c, c] fun _ ↦ by simpa using hcN).out : GL (Fin 2) ℚ)
+        ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) =
+      ⋃ _ : Unit, MulOpposite.op (natDiagGL 2 ![c, c]) •
+        ((Gamma0 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
+  rw [Set.iUnion_const, diagCosetGamma0_def]
+  apply HeckeCoset.doubleCoset_out_mk_eq_rightCoset_of_mem_normalizer
+  rw [Subgroup.mem_normalizer_iff]
+  intro x
+  change x ∈ (Gamma0 N).map (mapGL ℚ) ↔
+    natDiagGL 2 ![c, c] * x * (natDiagGL 2 ![c, c])⁻¹ ∈
+      (Gamma0 N).map (mapGL ℚ)
+  have hconst : natDiagGL 2 ![c, c] = natDiagGL 2 (fun _ : Fin 2 ↦ c) := by
+    congr 1
+    funext i
+    fin_cases i <;> rfl
+  rw [hconst]
+  rw [natDiagGL_const_comm 2 c x, mul_assoc, mul_inv_cancel, mul_one]
+
+/-- The constant diagonal double coset acts on modular forms by
+`χ(c) * c ^ (k - 2)`. -/
+theorem twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_const
+    (c : ℕ) (hc : 0 < c) (hcN : Nat.Coprime c N) :
+    twistedHeckeSlashModularFormCharEnd k χ
+        (diagCosetGamma0 N ![c, c] fun _ ↦ by simpa using hcN) =
+      ((χ (ZMod.unitOfCoprime c hcN) : ℂ) * (c : ℂ) ^ (k - 2)) • 1 := by
+  apply LinearMap.ext
+  intro f
+  apply Subtype.ext
+  apply ModularForm.ext
+  intro z
+  rw [congrFun (coe_twistedHeckeSlashModularFormCharEnd_eq_sum k χ _
+    (fun _ : Unit ↦ natDiagGL 2 ![c, c])
+    (scalarCoset_cover c hcN) (fun _ _ _ ↦ Subsingleton.elim _ _) f) z]
+  simp [delta0NebentypusChar_natDiagGL_const χ c hc hcN,
+    rat_slash_natDiagGL_const k c hc, mul_assoc]
+
+/-- The constant diagonal double coset has the same scalar action on cusp forms. -/
+theorem twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_const
+    (c : ℕ) (hc : 0 < c) (hcN : Nat.Coprime c N) :
+    twistedHeckeSlashCuspFormCharEnd k χ
+        (diagCosetGamma0 N ![c, c] fun _ ↦ by simpa using hcN) =
+      ((χ (ZMod.unitOfCoprime c hcN) : ℂ) * (c : ℂ) ^ (k - 2)) • 1 := by
+  apply LinearMap.ext
+  intro f
+  apply Subtype.ext
+  apply CuspForm.ext
+  intro z
+  rw [congrFun (coe_twistedHeckeSlashCuspFormCharEnd_eq_sum k χ _
+    (fun _ : Unit ↦ natDiagGL 2 ![c, c])
+    (scalarCoset_cover c hcN) (fun _ _ _ ↦ Subsingleton.elim _ _) f) z]
+  simp [delta0NebentypusChar_natDiagGL_const χ c hc hcN,
+    rat_slash_natDiagGL_const k c hc, mul_assoc]
+
+/-- The scalar Hecke generator acts on modular forms by
+`χ(c) * c ^ (k - 2)`. -/
+theorem heckeRingHomCharSpace_heckeTScalarGamma0 (c : ℕ) (hc : 0 < c)
+    (hcN : Nat.Coprime c N) :
+    heckeRingHomCharSpace k χ (heckeTScalarGamma0 N c) =
+      ((χ (ZMod.unitOfCoprime c hcN) : ℂ) * (c : ℂ) ^ (k - 2)) • 1 := by
+  rw [heckeTScalarGamma0_of_coprime N hc hcN, heckeRingHomCharSpace_apply,
+    twistedHeckeSlashModularFormCharLinearMap_single, one_smul]
+  rw [twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_const k χ c hc hcN]
+
+/-- The scalar Hecke generator acts on cusp forms by
+`χ(c) * c ^ (k - 2)`. -/
+theorem heckeRingHomCuspCharSpace_heckeTScalarGamma0 (c : ℕ) (hc : 0 < c)
+    (hcN : Nat.Coprime c N) :
+    heckeRingHomCuspCharSpace k χ (heckeTScalarGamma0 N c) =
+      ((χ (ZMod.unitOfCoprime c hcN) : ℂ) * (c : ℂ) ^ (k - 2)) • 1 := by
+  rw [heckeTScalarGamma0_of_coprime N hc hcN, heckeRingHomCuspCharSpace_apply,
+    twistedHeckeSlashCuspFormCharLinearMap_single, one_smul]
+  rw [twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_const k χ c hc hcN]
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Scalar.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Scalar.lean
@@ -78,7 +78,7 @@ theorem twistedHeckeSlashSum_diagCosetGamma0_const (c : ℕ) (hc : 0 < c)
   let _ : NeZero c := ⟨hc.ne'⟩
   rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ _
     (fun _ : Unit ↦ natDiagGL 2 ![c, c])
-    (doubleCoset_out_diagCosetGamma0_const_eq_iUnion_rightCosets N c hcN)
+    (doubleCoset_out_diagCosetGamma0_const_eq_iUnion_rightCosets N c fun _ ↦ hcN)
     (fun _ _ _ ↦ Subsingleton.elim _ _) f hf]
   simp [delta0NebentypusChar_natDiagGL N χ ![c, c]
     (fun i ↦ by fin_cases i <;> simpa using hc) hcN, smul_smul]

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Scalar.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Scalar.lean
@@ -6,14 +6,15 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.PrimePower
-public import TauCeti.NumberTheory.HeckeRing.Normalizer
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Diagonal.QExpansion
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Action
 
 /-!
 # Scalar cosets in the nebentypus Hecke action
 
 This file identifies the action of the scalar double coset
-`Γ₀(N) diag(c, c) Γ₀(N)` on modular and cusp forms of nebentypus `χ`. Since the scalar matrix
+`Γ₀(N) diag(c, c) Γ₀(N)` on functions, modular forms, and cusp forms of nebentypus `χ`.
+Since the scalar matrix
 normalizes `Γ₀(N)`, its double coset has one right coset. The twisting character reads its
 upper-left entry as `χ(c)`, while the weight-`k` slash action contributes `c ^ (k - 2)`.
 Consequently the scalar Hecke generator acts by
@@ -28,10 +29,14 @@ scalar representative is its upper-left unit `c`.
 
 ## Main results
 
+* `HeckeRing.GL2.twistedHeckeSlashSumCharEnd_diagCosetGamma0_const`: the scalar double coset
+  acts by the expected scalar on the function character space.
 * `HeckeRing.GL2.twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_const`: the scalar
   double coset acts by the expected scalar on modular forms.
 * `HeckeRing.GL2.twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_const`: the corresponding
   statement for cusp forms.
+* `HeckeRing.GL2.heckeRingHomFunctionCharSpace_heckeTScalarGamma0`: the scalar generator under
+  the function-space Hecke-ring action.
 * `HeckeRing.GL2.heckeRingHomCharSpace_heckeTScalarGamma0`: the scalar generator under the
   modular-form Hecke-ring action.
 * `HeckeRing.GL2.heckeRingHomCuspCharSpace_heckeTScalarGamma0`: the cusp-form counterpart.
@@ -63,110 +68,31 @@ variable {N : ℕ} (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
 
 variable [NeZero N]
 
-omit [NeZero N] in
-/-- The twisting character reads the constant diagonal representative as its scalar entry. -/
-lemma delta0NebentypusChar_natDiagGL_const (c : ℕ) (hc : 0 < c)
+/-- The constant diagonal double coset acts on the function character space by
+`χ(c) * c ^ (k - 2)`. -/
+theorem twistedHeckeSlashSum_diagCosetGamma0_const (c : ℕ) (hc : 0 < c)
+    (hcN : Nat.Coprime c N) (f : ℍ → ℂ) (hf : f ∈ functionCharSpace k χ) :
+    twistedHeckeSlashSum k χ
+        (diagCosetGamma0 N ![c, c] fun _ ↦ by simpa using hcN) f =
+      ((χ (ZMod.unitOfCoprime c hcN) : ℂ) * (c : ℂ) ^ (k - 2)) • f := by
+  let _ : NeZero c := ⟨hc.ne'⟩
+  rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ _
+    (fun _ : Unit ↦ natDiagGL 2 ![c, c])
+    (doubleCoset_out_diagCosetGamma0_const_eq_iUnion_rightCosets N c hcN)
+    (fun _ _ _ ↦ Subsingleton.elim _ _) f hf]
+  simp [delta0NebentypusChar_natDiagGL N χ ![c, c]
+    (fun i ↦ by fin_cases i <;> simpa using hc) hcN, smul_smul]
+
+/-- The constant diagonal double coset acts by `χ(c) * c ^ (k - 2)` as an endomorphism of
+the function character space. -/
+theorem twistedHeckeSlashSumCharEnd_diagCosetGamma0_const (c : ℕ) (hc : 0 < c)
     (hcN : Nat.Coprime c N) :
-    delta0NebentypusChar N χ
-        ⟨natDiagGL 2 ![c, c],
-          natDiagGL_mem_Delta0_of_coprime N _ fun _ ↦ by simpa using hcN⟩ =
-      χ (ZMod.unitOfCoprime c hcN) := by
-  rw [delta0NebentypusChar_apply]
-  apply congrArg χ
-  apply Units.ext
-  rw [Delta0UpperUnit_apply_val N
-    (A := Matrix.diagonal (fun _ : Fin 2 ↦ (c : ℤ)))
-    (by
-      rw [natDiagGL_coe_eq_map_intCast 2 _
-        (fun i ↦ by fin_cases i <;> simpa using hc)]
-      congr 2
-      funext i
-      fin_cases i <;> rfl)]
-  simp [ZMod.coe_unitOfCoprime]
-
-/-- A positive rational scalar matrix acts trivially on the upper half-plane and its
-weight-`k` slash is multiplication by `c ^ (k - 2)`. -/
-lemma rat_slash_natDiagGL_const (c : ℕ) (hc : 0 < c) (f : ℍ → ℂ) :
-    f ∣[k] natDiagGL 2 ![c, c] = (c : ℂ) ^ (k - 2) • f := by
-  have hcpos : ∀ i : Fin 2, 0 < ![c, c] i := by
-    intro i
-    fin_cases i <;> simpa using hc
-  have hdetpos : 0 <
-      (natDiagGL 2 ![c, c] : Matrix (Fin 2) (Fin 2) ℚ).det :=
-    natDiagGL_det_pos 2 _ hcpos
-  have hcne : (c : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr hc.ne'
-  ext z
-  rw [ModularForm.rat_slash_apply_of_det_pos k hdetpos]
-  have hsmul :
-      Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
-          (natDiagGL 2 ![c, c]) • z = z := by
-    apply UpperHalfPlane.ext
-    rw [UpperHalfPlane.coe_smul_of_det_pos (ModularForm.det_map_ratCast_pos hdetpos)]
-    change
-      ((Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
-              (natDiagGL 2 ![c, c])) 0 0 * (z : ℂ) +
-          (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
-              (natDiagGL 2 ![c, c])) 0 1) /
-          ((Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
-              (natDiagGL 2 ![c, c])) 1 0 * (z : ℂ) +
-            (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
-              (natDiagGL 2 ![c, c])) 1 1) = (z : ℂ)
-    simp [Matrix.GeneralLinearGroup.map, natDiagGL_coe 2 _ hcpos, Matrix.map_apply]
-    field_simp
-  have hdenom :
-      denom (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
-          (natDiagGL 2 ![c, c])) z = (c : ℂ) := by
-    change
-      (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
-            (natDiagGL 2 ![c, c])) 1 0 * (z : ℂ) +
-          (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
-            (natDiagGL 2 ![c, c])) 1 1 = (c : ℂ)
-    simp [Matrix.GeneralLinearGroup.map, natDiagGL_coe 2 _ hcpos, Matrix.map_apply]
-  have habsdet :
-      (↑|(Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
-          (natDiagGL 2 ![c, c])).det.val| : ℂ) = (c : ℂ) ^ 2 := by
-    have hdet :
-        (Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)
-          (natDiagGL 2 ![c, c])).det.val =
-            algebraMap ℚ ℝ
-              (natDiagGL 2 ![c, c]).det.val :=
-      congrArg Units.val
-        (Matrix.GeneralLinearGroup.map_det (algebraMap ℚ ℝ)
-          (natDiagGL 2 ![c, c]))
-    rw [hdet, Matrix.GeneralLinearGroup.val_det_apply,
-      natDiagGL_coe 2 _ hcpos, Matrix.det_diagonal, Fin.prod_univ_two]
-    simp only [map_mul, map_natCast]
-    rw [abs_of_nonneg (by positivity)]
-    push_cast
-    ring
-  rw [hsmul, hdenom, habsdet]
-  change f z * ((c : ℂ) ^ 2) ^ (k - 1) * (c : ℂ) ^ (-k) =
-    (c : ℂ) ^ (k - 2) * f z
-  rw [show ((c : ℂ) ^ 2) = (c : ℂ) ^ (2 : ℤ) by norm_cast, ← _root_.zpow_mul,
-    mul_assoc, ← zpow_add₀ hcne, mul_comm]
-  congr 1
-  ring_nf
-
-omit [NeZero N] in
-private lemma scalarCoset_cover (c : ℕ) (hcN : Nat.Coprime c N) :
-    doubleCoset
-        ((diagCosetGamma0 N ![c, c] fun _ ↦ by simpa using hcN).out : GL (Fin 2) ℚ)
-        ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) =
-      ⋃ _ : Unit, MulOpposite.op (natDiagGL 2 ![c, c]) •
-        ((Gamma0 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  rw [Set.iUnion_const, diagCosetGamma0_def]
-  apply HeckeCoset.doubleCoset_out_mk_eq_rightCoset_of_mem_normalizer
-  rw [Subgroup.mem_normalizer_iff]
-  intro x
-  change x ∈ (Gamma0 N).map (mapGL ℚ) ↔
-    natDiagGL 2 ![c, c] * x * (natDiagGL 2 ![c, c])⁻¹ ∈
-      (Gamma0 N).map (mapGL ℚ)
-  have hconst : natDiagGL 2 ![c, c] = natDiagGL 2 (fun _ : Fin 2 ↦ c) := by
-    congr 1
-    funext i
-    fin_cases i <;> rfl
-  rw [hconst]
-  rw [natDiagGL_const_comm 2 c x, mul_assoc, mul_inv_cancel, mul_one]
+    twistedHeckeSlashSumCharEnd k χ
+        (diagCosetGamma0 N ![c, c] fun _ ↦ by simpa using hcN) =
+      ((χ (ZMod.unitOfCoprime c hcN) : ℂ) * (c : ℂ) ^ (k - 2)) • 1 := by
+  refine LinearMap.ext fun f ↦ Subtype.ext ?_
+  rw [coe_twistedHeckeSlashSumCharEnd, LinearMap.smul_apply, Module.End.one_apply]
+  exact twistedHeckeSlashSum_diagCosetGamma0_const k χ c hc hcN f f.2
 
 /-- The constant diagonal double coset acts on modular forms by
 `χ(c) * c ^ (k - 2)`. -/
@@ -180,11 +106,17 @@ theorem twistedHeckeSlashModularFormCharEnd_diagCosetGamma0_const
   apply Subtype.ext
   apply ModularForm.ext
   intro z
-  rw [congrFun (coe_twistedHeckeSlashModularFormCharEnd_eq_sum k χ _
-    (fun _ : Unit ↦ natDiagGL 2 ![c, c])
-    (scalarCoset_cover c hcN) (fun _ _ _ ↦ Subsingleton.elim _ _) f) z]
-  simp [delta0NebentypusChar_natDiagGL_const χ c hc hcN,
-    rat_slash_natDiagGL_const k c hc, mul_assoc]
+  rw [coe_twistedHeckeSlashModularFormCharEnd]
+  have h := congrFun (twistedHeckeSlashSum_diagCosetGamma0_const k χ c hc hcN
+    (⇑(f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k))
+    ((coe_mem_functionCharSpace_iff k χ _).mpr f.2)) z
+  -- This exposes only scalar multiplication through the endomorphism, subtype, bundled form,
+  -- and function coercions; `h` is the function-space mathematical statement.
+  change twistedHeckeSlashSum k χ _
+      (⇑(f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) z =
+    ((χ (ZMod.unitOfCoprime c hcN) : ℂ) * (c : ℂ) ^ (k - 2)) *
+      (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) z
+  exact h
 
 /-- The constant diagonal double coset has the same scalar action on cusp forms. -/
 theorem twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_const
@@ -197,11 +129,29 @@ theorem twistedHeckeSlashCuspFormCharEnd_diagCosetGamma0_const
   apply Subtype.ext
   apply CuspForm.ext
   intro z
-  rw [congrFun (coe_twistedHeckeSlashCuspFormCharEnd_eq_sum k χ _
-    (fun _ : Unit ↦ natDiagGL 2 ![c, c])
-    (scalarCoset_cover c hcN) (fun _ _ _ ↦ Subsingleton.elim _ _) f) z]
-  simp [delta0NebentypusChar_natDiagGL_const χ c hc hcN,
-    rat_slash_natDiagGL_const k c hc, mul_assoc]
+  rw [coe_twistedHeckeSlashCuspFormCharEnd]
+  have hmem : ⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) ∈ functionCharSpace k χ :=
+    (coe_mem_functionCharSpace_iff k χ _).mpr
+      ((coe_mem_modFormCharSpace_iff k χ _).mpr f.2)
+  have h := congrFun (twistedHeckeSlashSum_diagCosetGamma0_const k χ c hc hcN
+    (⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) hmem) z
+  -- As above, this exposes only the bundled scalar/coercion layers before applying the
+  -- function-space statement.
+  change twistedHeckeSlashSum k χ _
+      (⇑(f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) z =
+    ((χ (ZMod.unitOfCoprime c hcN) : ℂ) * (c : ℂ) ^ (k - 2)) *
+      (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) z
+  exact h
+
+/-- The scalar Hecke generator acts on the function character space by
+`χ(c) * c ^ (k - 2)`. -/
+theorem heckeRingHomFunctionCharSpace_heckeTScalarGamma0 (c : ℕ) (hc : 0 < c)
+    (hcN : Nat.Coprime c N) :
+    heckeRingHomFunctionCharSpace k χ (heckeTScalarGamma0 N c) =
+      ((χ (ZMod.unitOfCoprime c hcN) : ℂ) * (c : ℂ) ^ (k - 2)) • 1 := by
+  rw [heckeTScalarGamma0_of_coprime N hc hcN, heckeRingHomFunctionCharSpace_apply,
+    twistedHeckeSlashRingCharLinearMap_single, one_smul]
+  exact twistedHeckeSlashSumCharEnd_diagCosetGamma0_const k χ c hc hcN
 
 /-- The scalar Hecke generator acts on modular forms by
 `χ(c) * c ^ (k - 2)`. -/


### PR DESCRIPTION
This PR identifies the scalar `Γ₀(N)` double-coset action on nebentypus character spaces: for positive `c` coprime to `N`, the raw scalar generator `Γ₀(N) diag(c,c) Γ₀(N)` acts on modular forms and cusp forms by `(χ(c) : ℂ) * c^(k - 2)`. It proves the result from the one-right-coset normalizer decomposition, computes the `delta0NebentypusChar` weight directly, and packages the conclusion for both `heckeRingHomCharSpace` and `heckeRingHomCuspCharSpace`.

This advances the ModularForms Layer 2 milestone “The diamond operators land in the Hecke algebra — in the right ring,” specifically the target requiring the `Γ₀(N)`-pair scalar cosets to be identified under `heckeRingHomCharSpace`. The raw scalar-coset normalization is now explicit; what remains is to define and identify the normalized composite diamond/`T_n` ring elements with the classical operators, including the Layer 0 slash-defined diamond compatibility, before the Petersson-adjoint step can consume the action.

The scalar-slash calculation is adapted from AINTLIB’s `slash_diag_scalar` in `LeanModularForms/HeckeRIngs/GL2/Unified/NebentypusHeckeRingHom.lean` (Chris Birkbeck, Apache-2.0), commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`. Tau Ceti’s proof uses its existing `natDiagGL`, normalizer, and representative-independent right-coset sum APIs, and derives the character direction from the current `delta0NebentypusChar` convention.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"scalar-hecke-cosets-act-by-nebentypus"}-->

🤖 Prepared with Codex
