### PR TITLE
refactor(LegendreSymbol): root the `IsArithFrobAt` theorems

### DIFF
--- a/TauCeti/NumberTheory/LegendreSymbol/Frobenius.lean
+++ b/TauCeti/NumberTheory/LegendreSymbol/Frobenius.lean
@@ -30,9 +30,9 @@ multiquadratic generators.
 
 ## Main results
 
-* `TauCeti.AlgHom.IsArithFrobAt.apply_sqrt`: `φ x = legendreSym p d • x` for an arithmetic
+* `AlgHom.IsArithFrobAt.apply_sqrt`: `φ x = legendreSym p d • x` for an arithmetic
   Frobenius `φ : S →ₐ[ℤ] S` at `Q` and `x² = d`.
-* `TauCeti.IsArithFrobAt.smul_sqrt`: the same for a Frobenius element `σ` of a monoid acting
+* `IsArithFrobAt.smul_sqrt`: the same for a Frobenius element `σ` of a monoid acting
   on `S`.
 -/
 
@@ -57,7 +57,8 @@ omit [Fact p.Prime] in
 /-- The base Frobenius congruence over a rational prime: for an arithmetic Frobenius
 `φ : S →ₐ[ℤ] S` at an ideal `Q` lying over `(p)`, `φ y ≡ y ^ p (mod Q)`, the exponent being `p`,
 the cardinality of the base residue ring `ℤ ⧸ Q ∩ ℤ`. Internal plumbing for `apply_sqrt`. -/
-private theorem AlgHom.IsArithFrobAt.sub_pow_mem {φ : S →ₐ[ℤ] S} (H : φ.IsArithFrobAt Q)
+private theorem _root_.AlgHom.IsArithFrobAt.sub_pow_mem {φ : S →ₐ[ℤ] S}
+    (H : φ.IsArithFrobAt Q)
     [Q.LiesOver (span {(p : ℤ)})] (y : S) : φ y - y ^ p ∈ Q := by
   have h := H y
   rwa [natCard_quotient_under (p := p) Q] at h
@@ -68,7 +69,7 @@ omit [IsDomain S] in
 /-- The **Frobenius congruence for a square root, refined by Euler's criterion**: for an
 arithmetic Frobenius `φ : S →ₐ[ℤ] S` at `Q` lying over the odd rational prime `p`, if
 `x² = d` then `φ x ≡ legendreSym p d • x (mod Q)`. Internal step of `apply_sqrt`. -/
-private theorem AlgHom.IsArithFrobAt.sub_legendreSym_smul_mem {φ : S →ₐ[ℤ] S}
+private theorem _root_.AlgHom.IsArithFrobAt.sub_legendreSym_smul_mem {φ : S →ₐ[ℤ] S}
     (H : φ.IsArithFrobAt Q) [Q.LiesOver (span {(p : ℤ)})] (hodd : p ≠ 2)
     (hx : x ^ 2 = algebraMap ℤ S d) : φ x - legendreSym p d • x ∈ Q := by
   -- `p` is odd, so `p = 2·(p/2) + 1`; hence `x ^ p = (x²)^(p/2) · x = d^(p/2) · x`.
@@ -120,7 +121,7 @@ Frobenius at `Q`. If `x² = d` for an integer `d` not divisible by `p`, then
 `φ x = legendreSym p d • x`: the Frobenius fixes `√d` when `d` is a quadratic residue mod `p`
 and negates it otherwise. (Primality of `Q` is not needed: the sign separation comes from `S`
 being a domain and `Q ∩ ℤ = (p)`.) -/
-theorem AlgHom.IsArithFrobAt.apply_sqrt {φ : S →ₐ[ℤ] S} (H : φ.IsArithFrobAt Q)
+theorem _root_.AlgHom.IsArithFrobAt.apply_sqrt {φ : S →ₐ[ℤ] S} (H : φ.IsArithFrobAt Q)
     [Q.LiesOver (span {(p : ℤ)})] (hodd : p ≠ 2) (hd : ¬ (p : ℤ) ∣ d)
     (hx : x ^ 2 = algebraMap ℤ S d) :
     φ x = legendreSym p d • x := by
@@ -148,12 +149,12 @@ theorem AlgHom.IsArithFrobAt.apply_sqrt {φ : S →ₐ[ℤ] S} (H : φ.IsArithFr
 /-- **A Frobenius element acts on square roots by the Legendre symbol**, action form: if `σ : M`
 is an arithmetic Frobenius at an ideal `Q` over the odd prime `p` and `x² = d` with `p ∤ d`,
 then `σ • x = legendreSym p d • x`. Only a monoid action is needed. -/
-theorem IsArithFrobAt.smul_sqrt {M : Type*} [Monoid M] [MulSemiringAction M S]
+theorem _root_.IsArithFrobAt.smul_sqrt {M : Type*} [Monoid M] [MulSemiringAction M S]
     [SMulCommClass M ℤ S] {σ : M} (H : _root_.IsArithFrobAt ℤ σ Q)
     [Q.LiesOver (span {(p : ℤ)})] (hodd : p ≠ 2) (hd : ¬ (p : ℤ) ∣ d)
     (hx : x ^ 2 = algebraMap ℤ S d) :
     σ • x = legendreSym p d • x := by
   simpa only [MulSemiringAction.toAlgHom_apply] using
-    TauCeti.AlgHom.IsArithFrobAt.apply_sqrt H hodd hd hx
+    AlgHom.IsArithFrobAt.apply_sqrt H hodd hd hx
 
 end TauCeti

--- a/TauCeti/NumberTheory/NumberField/Frobenius.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius.lean
@@ -34,7 +34,7 @@ services on top of Mathlib's `RingTheory/Frobenius.lean`:
 * **the square-root action** — for a number field `K`, `p` odd, and `x ∈ K` with
   `x² = d ∈ ℤ`, `p ∤ d`, a
   Frobenius at any ideal `Q` over `p` satisfies `σ x = legendreSym p d • x`, transporting the
-  `𝓞 K`-level computation `TauCeti.AlgHom.IsArithFrobAt.apply_sqrt` along the Galois action
+  `𝓞 K`-level computation `AlgHom.IsArithFrobAt.apply_sqrt` along the Galois action
   on the ring of integers (via `NumberField.algebraMap_smul_eq_apply`), with the `σ x = x`
   characterization read off from it.
 
@@ -172,7 +172,7 @@ theorem isArithFrobAt_apply_sqrt (hodd : p ≠ 2) {d : ℤ} (hd : ¬ (p : ℤ) �
     σ x = legendreSym p d • x := by
   -- Apply the `𝓞 K`-level computation to the packaged square root and push down along `𝓞 K ↪ K`.
   have hsmul : σ • integralSqrt hx = legendreSym p d • integralSqrt hx :=
-    TauCeti.IsArithFrobAt.smul_sqrt hσ hodd hd (integralSqrt_sq hx)
+    IsArithFrobAt.smul_sqrt hσ hodd hd (integralSqrt_sq hx)
   have hcoe := congrArg (algebraMap (𝓞 K) K) hsmul
   rw [map_zsmul, algebraMap_integralSqrt, algebraMap_smul_eq_apply] at hcoe
   rwa [algebraMap_integralSqrt] at hcoe


### PR DESCRIPTION
All four declarations `lint-dot-notation` flags in `TauCeti/NumberTheory/LegendreSymbol/Frobenius.lean` move together — three in `AlgHom.IsArithFrobAt` and one in `IsArithFrobAt`:

| | |
|---|---|
| `AlgHom.IsArithFrobAt.sub_pow_mem` | `private`, stays private |
| `AlgHom.IsArithFrobAt.sub_legendreSym_smul_mem` | `private`, stays private |
| `AlgHom.IsArithFrobAt.apply_sqrt` | public |
| `IsArithFrobAt.smul_sqrt` | public |

Both namespaces are root in Mathlib — `AlgHom.IsArithFrobAt` has 14 declarations there, `IsArithFrobAt` has 8 — and neither carries a colliding name. **Nothing is left flagged in the file**, so this is not a slice of a larger group.

No namespace surgery: the headers are dotted declarations sitting directly in `namespace TauCeti`, and the file has no nested namespace at all, so only `_root_.` is added.

## References that followed the move

Five, none of which would have failed a build in a way pointing here:

- two module-docstring bullets naming `TauCeti.AlgHom.IsArithFrobAt.apply_sqrt` and `TauCeti.IsArithFrobAt.smul_sqrt`;
- one in-proof use in this file;
- two in `TauCeti/NumberTheory/NumberField/Frobenius.lean`, the external consumer, which spelled both paths out in full.

`lint-dot-notation`: 985 → 981, 0 new.

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp