### PR TITLE
feat(RamificationInertia): the ramification bound at the level of number fields

### DIFF
--- a/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
@@ -32,10 +32,6 @@ namespace TauCeti.NumberField
 
 variable {K : Type*} [Field K] [NumberField K]
 
--- Source. Recovered from the branch of the retired pull request #5538, commit
--- `70421db267d9bd6252256f873d27e99e739a931c`, where these were written for the Chebotarev
--- roadmap's Layer 7.2.
-
 /-- **A relative ramification index is at most the degree of the extension.** For a prime `𝔔` of
 `𝓞 F` in an extension `F / K` of number fields, `e(𝔔 / 𝓞 K) ≤ [F : K]`.
 

--- a/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
@@ -34,7 +34,12 @@ namespace TauCeti.NumberField
 variable {K : Type*} [Field K] [NumberField K]
 
 -- Source. Both declarations are recovered from the retired PR #5538, at commit
--- 70421db267d9bd6252256f873d27e99e739a931c.
+-- 70421db267d9bd6252256f873d27e99e739a931c. They are specified by the Chebotarev roadmap:
+-- `TauCetiRoadmap/Chebotarev/README.md` §7.2 step 1 asks that `ℚ(ζ_q)/ℚ`, being totally ramified
+-- at `q`, have "every subfield of `ℚ(ζ_q)` other than `ℚ` ramified at `q`" — which is
+-- `Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank` with `E` that subfield, and the bound
+-- `Ideal.ramificationIdx_le_finrank_numberField` is what makes the ramification index reach the
+-- degree there.
 
 /-- **A relative ramification index is at most the degree of the extension.** For a prime `𝔔` of
 `𝓞 F` in an extension `F / K` of number fields, `e(𝔔 / 𝓞 K) ≤ [F : K]`.

--- a/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.NumberField.Basic
+public import TauCeti.NumberTheory.RamificationInertia.Tower
+
+/-!
+# Ramification indices in an extension of number fields
+
+A consequence of the general ramification bounds for the rings of integers of number fields.
+`TauCeti.NumberTheory.RamificationInertia.Tower` states it for a finite flat extension of
+domains; here it is transported to the fields themselves, so the bound is `[F : K]` rather than
+the rank of `𝓞 F` over `𝓞 K`.
+
+## Main results
+
+* `Ideal.ramificationIdx_le_finrank_numberField`: for a prime `𝔔` of `𝓞 F` in an extension
+  `F / K` of number fields, `e(𝔔 / 𝓞 K) ≤ [F : K]`.
+* `Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank`: in a tower `K ≤ E ≤ B`, a
+  prime of `𝓞 B` as ramified over `𝓞 E` as `[B : K]` allows forces `[E : K] = 1`.
+-/
+
+public section
+
+open scoped NumberField
+
+namespace TauCeti.NumberField
+
+variable {K : Type*} [Field K] [NumberField K]
+
+-- Source. Recovered from the branch of the retired pull request #5538, commit
+-- `70421db267d9bd6252256f873d27e99e739a931c`, where these were written for the Chebotarev
+-- roadmap's Layer 7.2.
+
+/-- **A relative ramification index is at most the degree of the extension.** For a prime `𝔔` of
+`𝓞 F` in an extension `F / K` of number fields, `e(𝔔 / 𝓞 K) ≤ [F : K]`.
+
+It is the number-field form of `TauCeti.RamificationInertia.ramificationIdx_le_finrank`, whose
+bound is the rank of `𝓞 F` over `𝓞 K`; the two agree, and this is the one a caller holding a field
+extension can use directly. -/
+theorem _root_.Ideal.ramificationIdx_le_finrank_numberField {F : Type*} [Field F]
+    [NumberField F] [Algebra K F] (𝔔 : Ideal (𝓞 F)) [𝔔.IsPrime] :
+    𝔔.ramificationIdx (𝓞 K) ≤ Module.finrank K F :=
+  -- The fundamental identity `∑ eᵢ fᵢ = [F : K]` bounds each `eᵢ`, and `[𝓞 F : 𝓞 K] = [F : K]`.
+  (TauCeti.RamificationInertia.ramificationIdx_le_finrank (𝔔.under (𝓞 K)) 𝔔).trans_eq
+    (IsFractionRing.finrank_eq (𝓞 K) K (𝓞 F) F).symm
+
+/-- **A totally ramified prime leaves no room for an intermediate field.** In a tower `K ≤ E ≤ B`
+of number fields, if a prime of `𝓞 B` is already as ramified over `𝓞 E` as the whole degree
+`[B : K]` allows, then `[E : K] = 1`.
+
+This is the form a "no proper intermediate field" argument consumes: total ramification of a
+prime of the top field over the intermediate one collapses the bottom step of the tower. -/
+theorem _root_.Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank
+    {E B : Type*} [Field E] [NumberField E]
+    [Field B] [NumberField B] [Algebra K E] [Algebra K B] [Algebra E B] [IsScalarTower K E B]
+    (𝔔 : Ideal (𝓞 B)) [𝔔.IsPrime]
+    (he : 𝔔.ramificationIdx (𝓞 E) = Module.finrank K B) :
+    Module.finrank K E = 1 := by
+  have hb := Ideal.ramificationIdx_le_finrank_numberField (K := E) (F := B) 𝔔
+  have hle : Module.finrank K E * Module.finrank E B ≤ 1 * Module.finrank E B := by
+    rw [one_mul, Module.finrank_mul_finrank K E B, ← he]; exact hb
+  exact le_antisymm (Nat.le_of_mul_le_mul_right hle Module.finrank_pos) Module.finrank_pos
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
@@ -50,18 +50,25 @@ theorem _root_.Ideal.ramificationIdx_le_finrank_numberField {F : Type*} [Field F
     (IsFractionRing.finrank_eq (𝓞 K) K (𝓞 F) F).symm
 
 /-- **A relative ramification index equal to the full tower degree leaves no room for an
-intermediate field.** In a tower `K ≤ E ≤ B` of number fields, a prime `𝔔` of `𝓞 B` with
+intermediate field.** In a tower `K ≤ E ≤ B`, a prime `𝔔` of `𝓞 B` with
 `e(𝔔 / 𝓞 E) = [B : K]` forces `[E : K] = 1`.
+
+Only `E` and `B` need be number fields; the base `K` is an arbitrary field.
 
 The hypothesis is stronger than total ramification of `B / E`, which asks only
 `e(𝔔 / 𝓞 E) = [B : E]`; here the index must reach the degree of the *whole* tower. That is what a
 "no proper intermediate field" argument supplies, and what collapses the bottom step. -/
-theorem _root_.Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank
+theorem _root_.Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank {K : Type*} [Field K]
     {E B : Type*} [Field E] [NumberField E]
     [Field B] [NumberField B] [Algebra K E] [Algebra K B] [Algebra E B] [IsScalarTower K E B]
     (𝔔 : Ideal (𝓞 B)) [𝔔.IsPrime]
     (he : 𝔔.ramificationIdx (𝓞 E) = Module.finrank K B) :
     Module.finrank K E = 1 := by
+  -- `K` embeds in the number field `E`, so it has characteristic zero and `E` stays finite over it.
+  have : CharZero K := charZero_of_inj_zero fun n hn ↦ by
+    have : (n : E) = 0 := by rw [← map_natCast (algebraMap K E), hn, map_zero]
+    exact_mod_cast this
+  have : Module.Finite K E := Module.Finite.of_restrictScalars_finite ℚ K E
   have hb := Ideal.ramificationIdx_le_finrank_numberField (K := E) (F := B) 𝔔
   have hle : Module.finrank K E * Module.finrank E B ≤ 1 * Module.finrank E B := by
     rw [one_mul, Module.finrank_mul_finrank K E B, ← he]; exact hb

--- a/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
@@ -21,7 +21,8 @@ the rank of `𝓞 F` over `𝓞 K`.
 * `Ideal.ramificationIdx_le_finrank_numberField`: for a prime `𝔔` of `𝓞 F` in an extension
   `F / K` of number fields, `e(𝔔 / 𝓞 K) ≤ [F : K]`.
 * `Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank`: in a tower `K ≤ E ≤ B`, a
-  prime of `𝓞 B` as ramified over `𝓞 E` as `[B : K]` allows forces `[E : K] = 1`.
+  prime of `𝓞 B` with `e(𝔔 / 𝓞 E) = [B : K]` — the full tower degree, not merely `[B : E]` —
+  forces `[E : K] = 1`.
 -/
 
 public section
@@ -45,12 +46,13 @@ theorem _root_.Ideal.ramificationIdx_le_finrank_numberField {F : Type*} [Field F
   (TauCeti.RamificationInertia.ramificationIdx_le_finrank (𝔔.under (𝓞 K)) 𝔔).trans_eq
     (IsFractionRing.finrank_eq (𝓞 K) K (𝓞 F) F).symm
 
-/-- **A totally ramified prime leaves no room for an intermediate field.** In a tower `K ≤ E ≤ B`
-of number fields, if a prime of `𝓞 B` is already as ramified over `𝓞 E` as the whole degree
-`[B : K]` allows, then `[E : K] = 1`.
+/-- **A relative ramification index equal to the full tower degree leaves no room for an
+intermediate field.** In a tower `K ≤ E ≤ B` of number fields, a prime `𝔔` of `𝓞 B` with
+`e(𝔔 / 𝓞 E) = [B : K]` forces `[E : K] = 1`.
 
-This is the form a "no proper intermediate field" argument consumes: total ramification of a
-prime of the top field over the intermediate one collapses the bottom step of the tower. -/
+The hypothesis is stronger than total ramification of `B / E`, which asks only
+`e(𝔔 / 𝓞 E) = [B : E]`; here the index must reach the degree of the *whole* tower. That is what a
+"no proper intermediate field" argument supplies, and what collapses the bottom step. -/
 theorem _root_.Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank
     {E B : Type*} [Field E] [NumberField E]
     [Field B] [NumberField B] [Algebra K E] [Algebra K B] [Algebra E B] [IsScalarTower K E B]

--- a/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
@@ -33,6 +33,9 @@ namespace TauCeti.NumberField
 
 variable {K : Type*} [Field K] [NumberField K]
 
+-- Source. Both declarations are recovered from the retired PR #5538, at commit
+-- 70421db267d9bd6252256f873d27e99e739a931c.
+
 /-- **A relative ramification index is at most the degree of the extension.** For a prime `𝔔` of
 `𝓞 F` in an extension `F / K` of number fields, `e(𝔔 / 𝓞 K) ≤ [F : K]`.
 

--- a/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/NumberField.lean
@@ -18,7 +18,7 @@ the rank of `𝓞 F` over `𝓞 K`.
 
 ## Main results
 
-* `Ideal.ramificationIdx_le_finrank_numberField`: for a prime `𝔔` of `𝓞 F` in an extension
+* `Ideal.ramificationIdx_le_finrank_of_numberField`: for a prime `𝔔` of `𝓞 F` in an extension
   `F / K` of number fields, `e(𝔔 / 𝓞 K) ≤ [F : K]`.
 * `Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank`: in a tower `K ≤ E ≤ B`, a
   prime of `𝓞 B` with `e(𝔔 / 𝓞 E) = [B : K]` — the full tower degree, not merely `[B : E]` —
@@ -38,7 +38,7 @@ variable {K : Type*} [Field K] [NumberField K]
 -- `TauCetiRoadmap/Chebotarev/README.md` §7.2 step 1 asks that `ℚ(ζ_q)/ℚ`, being totally ramified
 -- at `q`, have "every subfield of `ℚ(ζ_q)` other than `ℚ` ramified at `q`" — which is
 -- `Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank` with `E` that subfield, and the bound
--- `Ideal.ramificationIdx_le_finrank_numberField` is what makes the ramification index reach the
+-- `Ideal.ramificationIdx_le_finrank_of_numberField` is what makes the ramification index reach the
 -- degree there.
 
 /-- **A relative ramification index is at most the degree of the extension.** For a prime `𝔔` of
@@ -47,7 +47,7 @@ variable {K : Type*} [Field K] [NumberField K]
 It is the number-field form of `TauCeti.RamificationInertia.ramificationIdx_le_finrank`, whose
 bound is the rank of `𝓞 F` over `𝓞 K`; the two agree, and this is the one a caller holding a field
 extension can use directly. -/
-theorem _root_.Ideal.ramificationIdx_le_finrank_numberField {F : Type*} [Field F]
+theorem _root_.Ideal.ramificationIdx_le_finrank_of_numberField {F : Type*} [Field F]
     [NumberField F] [Algebra K F] (𝔔 : Ideal (𝓞 F)) [𝔔.IsPrime] :
     𝔔.ramificationIdx (𝓞 K) ≤ Module.finrank K F :=
   -- The fundamental identity `∑ eᵢ fᵢ = [F : K]` bounds each `eᵢ`, and `[𝓞 F : 𝓞 K] = [F : K]`.
@@ -69,12 +69,10 @@ theorem _root_.Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank {K : Type*} [F
     (𝔔 : Ideal (𝓞 B)) [𝔔.IsPrime]
     (he : 𝔔.ramificationIdx (𝓞 E) = Module.finrank K B) :
     Module.finrank K E = 1 := by
-  -- `K` embeds in the number field `E`, so it has characteristic zero and `E` stays finite over it.
-  have : CharZero K := charZero_of_inj_zero fun n hn ↦ by
-    have : (n : E) = 0 := by rw [← map_natCast (algebraMap K E), hn, map_zero]
-    exact_mod_cast this
+  -- `K` maps into the number field `E`, so it has characteristic zero and `E` stays finite over it.
+  have : CharZero K := RingHom.charZero (algebraMap K E)
   have : Module.Finite K E := Module.Finite.of_restrictScalars_finite ℚ K E
-  have hb := Ideal.ramificationIdx_le_finrank_numberField (K := E) (F := B) 𝔔
+  have hb := Ideal.ramificationIdx_le_finrank_of_numberField (K := E) (F := B) 𝔔
   have hle : Module.finrank K E * Module.finrank E B ≤ 1 * Module.finrank E B := by
     rw [one_mul, Module.finrank_mul_finrank K E B, ← he]; exact hb
   exact le_antisymm (Nat.le_of_mul_le_mul_right hle Module.finrank_pos) Module.finrank_pos


### PR DESCRIPTION
```lean
theorem Ideal.ramificationIdx_le_finrank_numberField {F : Type*} [Field F] [NumberField F]
    [Algebra K F] (𝔔 : Ideal (𝓞 F)) [𝔔.IsPrime] :
    𝔔.ramificationIdx (𝓞 K) ≤ Module.finrank K F

theorem Ideal.finrank_eq_one_of_ramificationIdx_eq_finrank {E B : Type*} …
    (𝔔 : Ideal (𝓞 B)) [𝔔.IsPrime] (he : 𝔔.ramificationIdx (𝓞 E) = Module.finrank K B) :
    Module.finrank K E = 1
```

The first is the number-field form of the ring-level bound already on `main`,
`TauCeti.RamificationInertia.ramificationIdx_le_finrank`, whose bound is the rank of `𝓞 F` over
`𝓞 K`; a caller holding a field extension wants `[F : K]`. The second is what a "no proper
intermediate field" argument consumes: a prime of `𝓞 B` as ramified over `𝓞 E` as the whole degree
allows collapses the bottom step of the tower.

### Second slice of the retired #5538

#5538 was closed on 2026-09-06 by the queue's round-cap housekeeping — "reviewed to the round cap
without reaching an all-green review" — with its branch kept and a fresh PR explicitly invited. It
is 554 lines across five files, and is coming back a slice at a time rather than whole. #5979 was
the first slice; on it, the `scope` rubric approved that approach, calling the slice "a coherent
prerequisite for Chebotarev Layer 7.2 ... a single focused addition".

**This slice depends on nothing in #5979.** It needs only the ring-level bound, which is on `main`
independently of either PR, so the two can land in any order. Remaining after this:
`Cyclotomic/SqrtFive.lean` (79 lines), `Cyclotomic/Irreducible.lean` (120), and
`NumberField/Cyclotomic/IrreducibleOfUnramified.lean` (259) — the Layer 7.2 payload that #5633 and
the parked #5594 are both waiting on.

### Absence

Mathlib's only statement of this shape is `ramificationIdx_le_finrank` at
`Mathlib/NumberTheory/RamificationInertia/Basic.lean:647`, which is **`@[deprecated]`** ("Use
results of `RingTheory.RamificationInertia.Basic`", since 2026-07-01) and is stated with
`ramificationIdx'` over the fraction fields. The swept queries `ramificationIdx.*≤ Module.finrank`,
`ramificationIdx_le_finrank` and `ramificationIdx.*≤ finrank` find no non-deprecated field-level
bound anywhere in Mathlib. Neither new declaration exists on `main`.

### Documentation

Both docstrings were reworked before opening, applying findings this PR's siblings have already
collected: the proof narration is gone from each (the rubric asks a docstring to state the result
and its use, not how it is proved), and the provenance of the retired PR is a non-doc `--` source
comment rather than docstring prose, the form the attribution rubric accepted on #5812 and #5979.

Roadmap: Chebotarev

Provenance: none external — the content is TauCeti's own, recovered from the kept branch
`chebotarev/cyclotomic-degree` of the retired #5538 at
`70421db267d9bd6252256f873d27e99e739a931c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dmwkBnj4rJc75STgbwsLF
