### PR TITLE
refactor(LinearAlgebra): root `mem_span_range_iff_existsUnique`

### DIFF
--- a/TauCeti/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/TauCeti/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -16,19 +16,20 @@ of a unique finitely supported linear combination.
 
 ## Main statements
 
-* `TauCeti.LinearIndependent.mem_span_range_iff_existsUnique`: membership in the span of a
+* `LinearIndependent.mem_span_range_iff_existsUnique`: membership in the span of a
   linearly independent family is equivalent to having unique finitely supported coordinates.
 -/
 
 public section
 
-namespace TauCeti.LinearIndependent
+section
 
 variable {ι R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
 
 /-- An element lies in the span of a linearly independent family exactly when it has a unique
 finitely supported expression in that family. -/
-theorem mem_span_range_iff_existsUnique {v : ι → M} (h : LinearIndependent R v) (x : M) :
+theorem _root_.LinearIndependent.mem_span_range_iff_existsUnique {v : ι → M}
+    (h : LinearIndependent R v) (x : M) :
     x ∈ Submodule.span R (Set.range v) ↔
       ∃! a : ι →₀ R, a.sum (fun i r => r • v i) = x := by
   rw [Finsupp.mem_span_range_iff_exists_finsupp]
@@ -39,4 +40,4 @@ theorem mem_span_range_iff_existsUnique {v : ι → M} (h : LinearIndependent R 
     simpa only [Finsupp.linearCombination_apply] using hb.trans ha.symm
   · exact ExistsUnique.exists
 
-end TauCeti.LinearIndependent
+end

--- a/TauCeti/RingTheory/Binomial.lean
+++ b/TauCeti/RingTheory/Binomial.lean
@@ -167,7 +167,7 @@ theorem mem_ringChooseSpan_iff_existsUnique {r : R}
   rw [← AddSubgroup.toIntSubmodule_toAddSubgroup (ringChooseSpan r),
     Submodule.mem_toAddSubgroup,
     ← span_int_range_ringChoose r]
-  exact TauCeti.LinearIndependent.mem_span_range_iff_existsUnique h x
+  exact LinearIndependent.mem_span_range_iff_existsUnique h x
 
 end Span
 

--- a/TauCeti/RingTheory/DividedPowers/Basis.lean
+++ b/TauCeti/RingTheory/DividedPowers/Basis.lean
@@ -191,7 +191,7 @@ theorem mem_dividedPowerLattice_iff_existsUnique_sum_dividedPower_eq {x y : A}
     y ∈ dividedPowerLattice x ↔
       ∃! c : ℕ →₀ ℤ, c.sum (fun n a => a • dividedPower n x) = y := by
   rw [dividedPowerLattice_def]
-  exact TauCeti.LinearIndependent.mem_span_range_iff_existsUnique h y
+  exact LinearIndependent.mem_span_range_iff_existsUnique h y
 
 /-- Rational independence of the powers gives the canonical `ℤ`-basis of the integral
 divided-power lattice. -/


### PR DESCRIPTION
`TauCeti/LinearAlgebra/Finsupp/LinearCombination.lean` is a 42-line file holding exactly one theorem, and `lint-dot-notation` flags it. The whole file therefore moves to Mathlib's root `LinearIndependent` namespace — 107 declarations live there and none collides with `mem_span_range_iff_existsUnique`.

The compound `namespace TauCeti.LinearIndependent` becomes a `section` rather than disappearing: it carries the `variable` line that would otherwise widen.

## References that followed the move

Three, none of which would have failed a build in a way pointing at this file:

- the module-docstring bullet naming `TauCeti.LinearIndependent.mem_span_range_iff_existsUnique`;
- `TauCeti/RingTheory/Binomial.lean:170` and `TauCeti/RingTheory/DividedPowers/Basis.lean:194`, the two external consumers, which spelled that path out in full.

`lint-dot-notation`: 985 → 984, 0 new (measured against this branch's merge base).

Roadmap: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYwXN9WBAPasmBQXr6iQcp