### PR TITLE
feat: clear denominators in localized rational subsets

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
@@ -40,6 +40,9 @@ an admissible finite presentation in `A` and pass from `A(T/s)` to the completed
 ## References
 
 * [T. Wedhorn, *Adic Spaces*][wedhorn_adic], arXiv:1910.05934v1, Proposition 8.2(2).
+* For simultaneous denominator clearing in a localization, see Mathlib's
+  `IsLocalization.commonDenomOfFinset`, `IsLocalization.finsetIntegerMultiple`, and
+  `IsLocalization.finsetIntegerMultiple_image`.
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
@@ -40,9 +40,6 @@ an admissible finite presentation in `A` and pass from `A(T/s)` to the completed
 ## References
 
 * [T. Wedhorn, *Adic Spaces*][wedhorn_adic], arXiv:1910.05934v1, Proposition 8.2(2).
-* The simultaneous clearing of denominators is Mathlib's
-  `IsLocalization.commonDenomOfFinset` and `IsLocalization.finsetIntegerMultiple`, used as
-  they stand.
 -/
 
 public section
@@ -93,9 +90,9 @@ theorem exists_comap_preimage_rationalSubset_inter_spa_eq [TopologicalSpace A]
         rationalSubset Bplus U q := by
   obtain ⟨V, r, hVr⟩ := exists_comap_preimage_basicOpenFinset_eq M U q
   refine ⟨V, r, ?_⟩
-  rw [rationalSubset_def, rationalSubset_def, Set.preimage_inter, hVr]
-  exact Set.ext fun v ↦ ⟨fun hv ↦ ⟨hv.2, hv.1.2⟩,
-    fun hv ↦ ⟨⟨comap_mem_spa hcont hplus hv.1, hv.2⟩, hv.1⟩⟩
+  rw [comap_preimage_basicOpenFinset] at hVr
+  rw [comap_preimage_rationalSubset_inter_spa _ hcont hplus,
+    rationalSubset_def, rationalSubset_def, hVr]
 
 /-- **Rational subsets through the topological-localization homeomorphism.** Every rational
 subset of `Spa(A(T/s), A(T/s)⁺)` is the inverse image, under the canonical homeomorphism with
@@ -118,6 +115,7 @@ theorem exists_spaLocalizationHomeomorph_preimage_rationalSubset_eq
           (integralClosure ↥(Algebra.adjoin Aplus
             (Set.range fun t : T ↦
               (TauCeti.Localization.divBy (t : A) s : S))) S).toSubring U q := by
+  classical
   let _ := locTopology P T s S hden
   have _ := isTopologicalRing_locTopology P T s S hden
   let Bplus := (integralClosure ↥(Algebra.adjoin Aplus
@@ -129,14 +127,16 @@ theorem exists_spaLocalizationHomeomorph_preimage_rationalSubset_eq
           (Set.range fun t : T ↦ (TauCeti.Localization.divBy (t : A) s : S))))
   obtain ⟨V, r, hVr⟩ := exists_comap_preimage_rationalSubset_inter_spa_eq (Submonoid.powers s)
     Aplus Bplus (continuous_algebraMap_locTopology P T s S hden) hplus U q
+  have himage : rationalSubset Bplus (V.image (algebraMap A S)) (algebraMap A S r) =
+      rationalSubset Bplus U q := by
+    rw [← comap_preimage_rationalSubset_inter_spa (algebraMap A S)
+      (continuous_algebraMap_locTopology P T s S hden) hplus]
+    exact hVr
   refine ⟨V, r, Set.ext fun v ↦ ?_⟩
-  have hpoint := Set.ext_iff.mp hVr v.1
-  rw [Set.mem_preimage, Set.mem_preimage, spaLocalizationHomeomorph_apply_val]
-  -- The remaining definitional change only unfolds the two subtype preimages: `v` carries its
-  -- membership in `spa Bplus`, while `hVr` is stated for the underlying point `v.1 : Spv S`.
-  change comap (algebraMap A S) v.1 ∈ rationalSubset Aplus V r ↔
-    v.1 ∈ rationalSubset Bplus U q
-  exact ⟨fun hv ↦ hpoint.mp ⟨hv, v.2⟩, fun hv ↦ (hpoint.mpr hv).1⟩
+  rw [Set.mem_preimage, Set.mem_preimage, spaLocalizationHomeomorph_apply_val, ← himage]
+  simpa only [Set.mem_preimage, spaComap_val] using
+    Set.ext_iff.mp (spaComap_preimage_rationalSubset (algebraMap A S)
+      (continuous_algebraMap_locTopology P T s S hden) Aplus Bplus hplus V r) v
 
 end TauCeti.ValuationSpectrum
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
@@ -41,8 +41,8 @@ an admissible finite presentation in `A` and pass from `A(T/s)` to the completed
 
 ## Provenance
 
-The proof uses Mathlib's `IsLocalization.Away.sec`, which chooses a numerator and denominator
-exponent for each element of a localization. No external formalization was used.
+The proof uses Mathlib's `IsLocalization.exist_integer_multiples_of_finset` to clear a finite
+family of denominators. No external formalization was used.
 -/
 
 public section
@@ -67,27 +67,36 @@ theorem exists_comap_preimage_rationalSubset_eq [TopologicalSpace A] [Topologica
       comap (algebraMap A S) ⁻¹' rationalSubset Aplus V r ∩ spa Bplus =
         rationalSubset Bplus U q := by
   classical
-  obtain ⟨n, a, hclear⟩ := exists_finset_mul_pow_eq_algebraMap s (insert q U)
-  let d : S := algebraMap A S s ^ n
+  obtain ⟨d, hd⟩ :=
+    IsLocalization.exist_integer_multiples_of_finset (Submonoid.powers s) (insert q U)
+  let a : S → A := fun x ↦ if hx : x ∈ insert q U then (hd x hx).choose else 0
+  let dS : S := algebraMap A S d
   let V : Finset A := U.image a
   let r : A := a q
-  have hq : q * d = algebraMap A S r := hclear q (Finset.mem_insert_self q U)
-  have hV : V.image (algebraMap A S) = U.image fun u ↦ u * d := by
+  have hclear (x : S) (hx : x ∈ insert q U) : x * dS = algebraMap A S (a x) := by
+    rw [show a x = (hd x hx).choose by
+      dsimp only [a]
+      split
+      · congr 1
+      · contradiction]
+    simpa only [dS, Algebra.smul_def, mul_comm] using (hd x hx).choose_spec.symm
+  have hq : q * dS = algebraMap A S r := hclear q (Finset.mem_insert_self q U)
+  have hV : V.image (algebraMap A S) = U.image fun u ↦ u * dS := by
     ext x
     constructor
     · intro hx
       obtain ⟨b, hb, rfl⟩ := Finset.mem_image.mp hx
       obtain ⟨u, hu, rfl⟩ := Finset.mem_image.mp hb
       exact Finset.mem_image.mpr ⟨u, hu, by
-        simpa only [d] using hclear u (Finset.mem_insert_of_mem hu)⟩
+        simpa only using hclear u (Finset.mem_insert_of_mem hu)⟩
     · intro hx
       obtain ⟨u, hu, rfl⟩ := Finset.mem_image.mp hx
       exact Finset.mem_image.mpr ⟨a u, Finset.mem_image_of_mem a hu,
-        by simpa only [d] using (hclear u (Finset.mem_insert_of_mem hu)).symm⟩
+        by simpa only using (hclear u (Finset.mem_insert_of_mem hu)).symm⟩
   refine ⟨V, r, ?_⟩
   rw [comap_preimage_rationalSubset_inter_spa (algebraMap A S) hcont hplus]
-  rw [hV, ← hq, rationalSubset_image_mul_right Bplus U q d
-    (IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit s))]
+  rw [hV, ← hq, rationalSubset_image_mul_right Bplus U q dS
+    (IsLocalization.map_units S d)]
 
 /-- **Rational subsets through the topological-localization homeomorphism.** Every rational
 subset of `Spa(A(T/s), A(T/s)⁺)` is the inverse image, under the canonical homeomorphism with
@@ -124,6 +133,8 @@ theorem exists_spaLocalizationHomeomorph_preimage_rationalSubset_eq
   refine ⟨V, r, Set.ext fun v ↦ ?_⟩
   have hpoint := Set.ext_iff.mp hVr v.1
   rw [Set.mem_preimage, Set.mem_preimage, spaLocalizationHomeomorph_apply_val]
+  -- The remaining definitional change only unfolds the two subtype preimages: `v` carries its
+  -- membership in `spa Bplus`, while `hVr` is stated for the underlying point `v.1 : Spv S`.
   change comap (algebraMap A S) v.1 ∈ rationalSubset Aplus V r ↔
     v.1 ∈ rationalSubset Bplus U q
   exact ⟨fun hv ↦ hpoint.mp ⟨hv, v.2⟩, fun hv ↦ (hpoint.mpr hv).1⟩

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
@@ -30,20 +30,19 @@ an admissible finite presentation in `A` and pass from `A(T/s)` to the completed
 
 ## Main results
 
-* `TauCeti.ValuationSpectrum.exists_comap_preimage_rationalSubset_eq`: a rational subset over a
+* `TauCeti.ValuationSpectrum.exists_comap_preimage_basicOpenFinset_eq`: a rational open over a
   localization is the pullback of one presented by elements of the source ring.
+* `TauCeti.ValuationSpectrum.exists_comap_preimage_rationalSubset_inter_spa_eq`: the same for
+  rational subsets, after cutting the pullback down to the target adic spectrum.
 * `TauCeti.ValuationSpectrum.exists_spaLocalizationHomeomorph_preimage_rationalSubset_eq`: the
   same statement through the localization homeomorphism.
 
 ## References
 
 * [T. Wedhorn, *Adic Spaces*][wedhorn_adic], arXiv:1910.05934v1, Proposition 8.2(2).
-
-## Provenance
-
-The proof uses Mathlib's `IsLocalization.commonDenomOfFinset` and
-`IsLocalization.integerMultiple` to clear a finite family of denominators. No external
-formalization was used.
+* The simultaneous clearing of denominators is Mathlib's
+  `IsLocalization.commonDenomOfFinset` and `IsLocalization.finsetIntegerMultiple`, used as
+  they stand.
 -/
 
 public section
@@ -54,44 +53,49 @@ open TauCeti.Huber TauCeti.Huber.PairOfDefinition TauCeti.Localization
 
 variable {A S : Type*} [CommRing A] [CommRing S] [Algebra A S]
 
-/-- **Clear denominators in a rational subset of a localization.** If `S` is a localization of
-`A` at a submonoid `M`, then every rational subset of `Spa(S, S⁺)` is the pullback of a basic
-rational locus presented by a finite family in `A`.
+/-- **Clear denominators in a rational open of a localization.** If `S` is a localization of `A`
+at a submonoid `M`, then every rational open `Spv(S)(U/q)` is the pullback of one presented by a
+finite family in `A`.
 
 No topological admissibility is asserted for the resulting numerator family in `A`. Establishing
 that extra property is the remaining topological-algebra step in Wedhorn Proposition 8.2(2). -/
-theorem exists_comap_preimage_rationalSubset_eq [TopologicalSpace A] [TopologicalSpace S]
-    (M : Submonoid A) [IsLocalization M S] (Aplus : Subring A) (Bplus : Subring S)
-    (hcont : Continuous (algebraMap A S))
+theorem exists_comap_preimage_basicOpenFinset_eq (M : Submonoid A) [IsLocalization M S]
+    (U : Finset S) (q : S) :
+    ∃ (V : Finset A) (r : A),
+      comap (algebraMap A S) ⁻¹' basicOpenFinset V r = basicOpenFinset U q := by
+  classical
+  set d : S := algebraMap A S (IsLocalization.commonDenomOfFinset M (insert q U) : A) with hd
+  have hnum (x : ↥(insert q U)) :
+      algebraMap A S (IsLocalization.integerMultiple M (insert q U) id x) = (x : S) * d := by
+    rw [IsLocalization.map_integerMultiple, Submonoid.smul_def, Algebra.smul_def, hd]
+    exact mul_comm _ _
+  have hV : (IsLocalization.finsetIntegerMultiple M (insert q U)).image (algebraMap A S)
+      = (insert q U).image fun x ↦ x * d := by
+    apply Finset.coe_injective
+    rw [Finset.coe_image, Finset.coe_image, IsLocalization.finsetIntegerMultiple_image,
+      ← Set.image_smul]
+    exact Set.image_congr' fun x ↦ by rw [Submonoid.smul_def, Algebra.smul_def, hd]; ring
+  refine ⟨IsLocalization.finsetIntegerMultiple M (insert q U),
+    IsLocalization.integerMultiple M (insert q U) id ⟨q, Finset.mem_insert_self q U⟩, ?_⟩
+  rw [comap_preimage_basicOpenFinset, hV, hnum ⟨q, Finset.mem_insert_self q U⟩,
+    basicOpenFinset_image_mul_right _ _ _ (IsLocalization.map_units S _),
+    basicOpenFinset_insert_self]
+
+/-- **Clear denominators in a rational subset of a localization.** If `S` is a localization of
+`A` at a submonoid `M`, then every rational subset of `Spa(S, S⁺)` is the trace on `Spa(S, S⁺)`
+of the pullback of a basic rational locus presented by a finite family in `A`. -/
+theorem exists_comap_preimage_rationalSubset_inter_spa_eq [TopologicalSpace A]
+    [TopologicalSpace S] (M : Submonoid A) [IsLocalization M S] (Aplus : Subring A)
+    (Bplus : Subring S) (hcont : Continuous (algebraMap A S))
     (hplus : ∀ a ∈ Aplus, algebraMap A S a ∈ Bplus) (U : Finset S) (q : S) :
     ∃ (V : Finset A) (r : A),
       comap (algebraMap A S) ⁻¹' rationalSubset Aplus V r ∩ spa Bplus =
         rationalSubset Bplus U q := by
-  classical
-  -- Mathlib's `IsLocalization.commonDenom`/`integerMultiple` clear the finitely many
-  -- denominators of `insert q U` simultaneously; only the packaged data is used below.
-  obtain ⟨d, hd, num, hnum⟩ :
-      ∃ d : S, IsUnit d ∧ ∃ num : ∀ x ∈ insert q U, A,
-        ∀ (x : S) (hx : x ∈ insert q U), algebraMap A S (num x hx) = x * d :=
-    ⟨algebraMap A S (IsLocalization.commonDenom M (insert q U) id : A),
-      IsLocalization.map_units S _,
-      fun x hx ↦ IsLocalization.integerMultiple M (insert q U) id ⟨x, hx⟩, fun x hx ↦ by
-        rw [IsLocalization.map_integerMultiple, Submonoid.smul_def, Algebra.smul_def]
-        exact mul_comm _ _⟩
-  refine ⟨U.attach.image fun u ↦ num u.1 (Finset.mem_insert_of_mem u.2),
-    num q (Finset.mem_insert_self q U), ?_⟩
-  have hV : (U.attach.image fun u ↦ num u.1 (Finset.mem_insert_of_mem u.2)).image (algebraMap A S)
-      = U.image fun u ↦ u * d :=
-    calc (U.attach.image fun u ↦ num u.1 (Finset.mem_insert_of_mem u.2)).image (algebraMap A S)
-        = U.attach.image fun u : {x // x ∈ U} ↦ u.1 * d :=
-          Finset.image_image.trans
-            (Finset.image_congr fun u _ ↦ hnum u.1 (Finset.mem_insert_of_mem u.2))
-      _ = (U.attach.image Subtype.val).image fun x ↦ x * d :=
-          (Finset.image_image (f := Subtype.val) (g := fun x : S ↦ x * d)).symm
-      _ = U.image fun u ↦ u * d := by rw [Finset.attach_image_val]
-  rw [comap_preimage_rationalSubset_inter_spa (algebraMap A S) hcont hplus, hV,
-    hnum q (Finset.mem_insert_self q U),
-    rationalSubset_image_mul_right Bplus U q d hd]
+  obtain ⟨V, r, hVr⟩ := exists_comap_preimage_basicOpenFinset_eq M U q
+  refine ⟨V, r, ?_⟩
+  rw [rationalSubset_def, rationalSubset_def, Set.preimage_inter, hVr]
+  exact Set.ext fun v ↦ ⟨fun hv ↦ ⟨hv.2, hv.1.2⟩,
+    fun hv ↦ ⟨⟨comap_mem_spa hcont hplus hv.1, hv.2⟩, hv.1⟩⟩
 
 /-- **Rational subsets through the topological-localization homeomorphism.** Every rational
 subset of `Spa(A(T/s), A(T/s)⁺)` is the inverse image, under the canonical homeomorphism with
@@ -123,8 +127,8 @@ theorem exists_spaLocalizationHomeomorph_preimage_rationalSubset_eq
       (⟨_, Subalgebra.algebraMap_mem _ (⟨a, ha⟩ : Aplus)⟩ :
         ↥(Algebra.adjoin Aplus
           (Set.range fun t : T ↦ (TauCeti.Localization.divBy (t : A) s : S))))
-  obtain ⟨V, r, hVr⟩ := exists_comap_preimage_rationalSubset_eq (Submonoid.powers s) Aplus Bplus
-    (continuous_algebraMap_locTopology P T s S hden) hplus U q
+  obtain ⟨V, r, hVr⟩ := exists_comap_preimage_rationalSubset_inter_spa_eq (Submonoid.powers s)
+    Aplus Bplus (continuous_algebraMap_locTopology P T s S hden) hplus U q
   refine ⟨V, r, Set.ext fun v ↦ ?_⟩
   have hpoint := Set.ext_iff.mp hVr v.1
   rw [Set.mem_preimage, Set.mem_preimage, spaLocalizationHomeomorph_apply_val]

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
@@ -10,10 +10,10 @@ public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Localization.Homeomorph
 /-!
 # Rational subsets under a localization homeomorphism
 
-Let `S` be a localization of `A` away from `s`. Every finite family of elements of `S` has a
-common denominator which is a power of `s`. Multiplying all the numerators and the denominator of
-a rational subset by that common denominator does not change the subset, because the multiplier is
-a unit. Thus every rational subset of `Spa(S, S⁺)` is cut out by elements coming from `A`.
+Let `S` be a localization of `A` at a submonoid `M`. Every finite family of elements of `S` has a
+common denominator in `M`. Multiplying all the numerators and the denominator of a rational subset
+by that common denominator does not change the subset, because the multiplier is a unit. Thus
+every rational subset of `Spa(S, S⁺)` is cut out by elements coming from `A`.
 
 This is the algebraic denominator-clearing part of Wedhorn Proposition 8.2(2), that a rational
 subset of a rational subset is rational in the original adic spectrum. Combined with the
@@ -41,8 +41,9 @@ an admissible finite presentation in `A` and pass from `A(T/s)` to the completed
 
 ## Provenance
 
-The proof uses Mathlib's `IsLocalization.exist_integer_multiples_of_finset` to clear a finite
-family of denominators. No external formalization was used.
+The proof uses Mathlib's `IsLocalization.commonDenomOfFinset` and
+`IsLocalization.integerMultiple` to clear a finite family of denominators. No external
+formalization was used.
 -/
 
 public section
@@ -54,49 +55,43 @@ open TauCeti.Huber TauCeti.Huber.PairOfDefinition TauCeti.Localization
 variable {A S : Type*} [CommRing A] [CommRing S] [Algebra A S]
 
 /-- **Clear denominators in a rational subset of a localization.** If `S` is a localization of
-`A` away from `s`, then every rational subset of `Spa(S, S⁺)` is the pullback of a basic rational
-locus presented by a finite family in `A`.
+`A` at a submonoid `M`, then every rational subset of `Spa(S, S⁺)` is the pullback of a basic
+rational locus presented by a finite family in `A`.
 
 No topological admissibility is asserted for the resulting numerator family in `A`. Establishing
 that extra property is the remaining topological-algebra step in Wedhorn Proposition 8.2(2). -/
 theorem exists_comap_preimage_rationalSubset_eq [TopologicalSpace A] [TopologicalSpace S]
-    (s : A) [IsLocalization.Away s S] (Aplus : Subring A) (Bplus : Subring S)
+    (M : Submonoid A) [IsLocalization M S] (Aplus : Subring A) (Bplus : Subring S)
     (hcont : Continuous (algebraMap A S))
     (hplus : ∀ a ∈ Aplus, algebraMap A S a ∈ Bplus) (U : Finset S) (q : S) :
     ∃ (V : Finset A) (r : A),
       comap (algebraMap A S) ⁻¹' rationalSubset Aplus V r ∩ spa Bplus =
         rationalSubset Bplus U q := by
   classical
-  obtain ⟨d, hd⟩ :=
-    IsLocalization.exist_integer_multiples_of_finset (Submonoid.powers s) (insert q U)
-  let a : S → A := fun x ↦ if hx : x ∈ insert q U then (hd x hx).choose else 0
-  let dS : S := algebraMap A S d
-  let V : Finset A := U.image a
-  let r : A := a q
-  have hclear (x : S) (hx : x ∈ insert q U) : x * dS = algebraMap A S (a x) := by
-    rw [show a x = (hd x hx).choose by
-      dsimp only [a]
-      split
-      · congr 1
-      · contradiction]
-    simpa only [dS, Algebra.smul_def, mul_comm] using (hd x hx).choose_spec.symm
-  have hq : q * dS = algebraMap A S r := hclear q (Finset.mem_insert_self q U)
-  have hV : V.image (algebraMap A S) = U.image fun u ↦ u * dS := by
-    ext x
-    constructor
-    · intro hx
-      obtain ⟨b, hb, rfl⟩ := Finset.mem_image.mp hx
-      obtain ⟨u, hu, rfl⟩ := Finset.mem_image.mp hb
-      exact Finset.mem_image.mpr ⟨u, hu, by
-        simpa only using hclear u (Finset.mem_insert_of_mem hu)⟩
-    · intro hx
-      obtain ⟨u, hu, rfl⟩ := Finset.mem_image.mp hx
-      exact Finset.mem_image.mpr ⟨a u, Finset.mem_image_of_mem a hu,
-        by simpa only using (hclear u (Finset.mem_insert_of_mem hu)).symm⟩
-  refine ⟨V, r, ?_⟩
-  rw [comap_preimage_rationalSubset_inter_spa (algebraMap A S) hcont hplus]
-  rw [hV, ← hq, rationalSubset_image_mul_right Bplus U q dS
-    (IsLocalization.map_units S d)]
+  -- Mathlib's `IsLocalization.commonDenom`/`integerMultiple` clear the finitely many
+  -- denominators of `insert q U` simultaneously; only the packaged data is used below.
+  obtain ⟨d, hd, num, hnum⟩ :
+      ∃ d : S, IsUnit d ∧ ∃ num : ∀ x ∈ insert q U, A,
+        ∀ (x : S) (hx : x ∈ insert q U), algebraMap A S (num x hx) = x * d :=
+    ⟨algebraMap A S (IsLocalization.commonDenom M (insert q U) id : A),
+      IsLocalization.map_units S _,
+      fun x hx ↦ IsLocalization.integerMultiple M (insert q U) id ⟨x, hx⟩, fun x hx ↦ by
+        rw [IsLocalization.map_integerMultiple, Submonoid.smul_def, Algebra.smul_def]
+        exact mul_comm _ _⟩
+  refine ⟨U.attach.image fun u ↦ num u.1 (Finset.mem_insert_of_mem u.2),
+    num q (Finset.mem_insert_self q U), ?_⟩
+  have hV : (U.attach.image fun u ↦ num u.1 (Finset.mem_insert_of_mem u.2)).image (algebraMap A S)
+      = U.image fun u ↦ u * d :=
+    calc (U.attach.image fun u ↦ num u.1 (Finset.mem_insert_of_mem u.2)).image (algebraMap A S)
+        = U.attach.image fun u : {x // x ∈ U} ↦ u.1 * d :=
+          Finset.image_image.trans
+            (Finset.image_congr fun u _ ↦ hnum u.1 (Finset.mem_insert_of_mem u.2))
+      _ = (U.attach.image Subtype.val).image fun x ↦ x * d :=
+          (Finset.image_image (f := Subtype.val) (g := fun x : S ↦ x * d)).symm
+      _ = U.image fun u ↦ u * d := by rw [Finset.attach_image_val]
+  rw [comap_preimage_rationalSubset_inter_spa (algebraMap A S) hcont hplus, hV,
+    hnum q (Finset.mem_insert_self q U),
+    rationalSubset_image_mul_right Bplus U q d hd]
 
 /-- **Rational subsets through the topological-localization homeomorphism.** Every rational
 subset of `Spa(A(T/s), A(T/s)⁺)` is the inverse image, under the canonical homeomorphism with
@@ -128,7 +123,7 @@ theorem exists_spaLocalizationHomeomorph_preimage_rationalSubset_eq
       (⟨_, Subalgebra.algebraMap_mem _ (⟨a, ha⟩ : Aplus)⟩ :
         ↥(Algebra.adjoin Aplus
           (Set.range fun t : T ↦ (TauCeti.Localization.divBy (t : A) s : S))))
-  obtain ⟨V, r, hVr⟩ := exists_comap_preimage_rationalSubset_eq s Aplus Bplus
+  obtain ⟨V, r, hVr⟩ := exists_comap_preimage_rationalSubset_eq (Submonoid.powers s) Aplus Bplus
     (continuous_algebraMap_locTopology P T s S hden) hplus U q
   refine ⟨V, r, Set.ext fun v ↦ ?_⟩
   have hpoint := Set.ext_iff.mp hVr v.1

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Localization.Homeomorph
+
+/-!
+# Rational subsets under a localization homeomorphism
+
+Let `S` be a localization of `A` away from `s`. Every finite family of elements of `S` has a
+common denominator which is a power of `s`. Multiplying all the numerators and the denominator of
+a rational subset by that common denominator does not change the subset, because the multiplier is
+a unit. Thus every rational subset of `Spa(S, S⁺)` is cut out by elements coming from `A`.
+
+This is the algebraic denominator-clearing part of Wedhorn Proposition 8.2(2), that a rational
+subset of a rational subset is rational in the original adic spectrum. Combined with the
+homeomorphism
+
+```text
+Spa(A(T/s), A(T/s)⁺) ≃ R(T/s),
+```
+
+it says that any rational subset on the left is the inverse image of a basic rational locus in
+`Spa(A, A⁺)`. To obtain Proposition 8.2(2) in full, one must still prove that this basic locus has
+an admissible finite presentation in `A` and pass from `A(T/s)` to the completed localization
+`A⟨T/s⟩`.
+
+## Main results
+
+* `TauCeti.ValuationSpectrum.exists_comap_preimage_rationalSubset_eq`: a rational subset over a
+  localization is the pullback of one presented by elements of the source ring.
+* `TauCeti.ValuationSpectrum.exists_spaLocalizationHomeomorph_preimage_rationalSubset_eq`: the
+  same statement through the localization homeomorphism.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic], arXiv:1910.05934v1, Proposition 8.2(2).
+
+## Provenance
+
+The proof uses Mathlib's `IsLocalization.Away.sec`, which chooses a numerator and denominator
+exponent for each element of a localization. No external formalization was used.
+-/
+
+public section
+
+namespace TauCeti.ValuationSpectrum
+
+open TauCeti.Huber TauCeti.Huber.PairOfDefinition TauCeti.Localization
+
+variable {A S : Type*} [CommRing A] [CommRing S] [Algebra A S]
+
+/-- **Clear denominators in a rational subset of a localization.** If `S` is a localization of
+`A` away from `s`, then every rational subset of `Spa(S, S⁺)` is the pullback of a basic rational
+locus presented by a finite family in `A`.
+
+No topological admissibility is asserted for the resulting numerator family in `A`. Establishing
+that extra property is the remaining topological-algebra step in Wedhorn Proposition 8.2(2). -/
+theorem exists_comap_preimage_rationalSubset_eq [TopologicalSpace A] [TopologicalSpace S]
+    (s : A) [IsLocalization.Away s S] (Aplus : Subring A) (Bplus : Subring S)
+    (hcont : Continuous (algebraMap A S))
+    (hplus : ∀ a ∈ Aplus, algebraMap A S a ∈ Bplus) (U : Finset S) (q : S) :
+    ∃ (V : Finset A) (r : A),
+      comap (algebraMap A S) ⁻¹' rationalSubset Aplus V r ∩ spa Bplus =
+        rationalSubset Bplus U q := by
+  classical
+  obtain ⟨n, a, hclear⟩ := exists_finset_mul_pow_eq_algebraMap s (insert q U)
+  let d : S := algebraMap A S s ^ n
+  let V : Finset A := U.image a
+  let r : A := a q
+  have hq : q * d = algebraMap A S r := hclear q (Finset.mem_insert_self q U)
+  have hV : V.image (algebraMap A S) = U.image fun u ↦ u * d := by
+    ext x
+    constructor
+    · intro hx
+      obtain ⟨b, hb, rfl⟩ := Finset.mem_image.mp hx
+      obtain ⟨u, hu, rfl⟩ := Finset.mem_image.mp hb
+      exact Finset.mem_image.mpr ⟨u, hu, by
+        simpa only [d] using hclear u (Finset.mem_insert_of_mem hu)⟩
+    · intro hx
+      obtain ⟨u, hu, rfl⟩ := Finset.mem_image.mp hx
+      exact Finset.mem_image.mpr ⟨a u, Finset.mem_image_of_mem a hu,
+        by simpa only [d] using (hclear u (Finset.mem_insert_of_mem hu)).symm⟩
+  refine ⟨V, r, ?_⟩
+  rw [comap_preimage_rationalSubset_inter_spa (algebraMap A S) hcont hplus]
+  rw [hV, ← hq, rationalSubset_image_mul_right Bplus U q d
+    (IsUnit.pow _ (IsLocalization.Away.algebraMap_isUnit s))]
+
+/-- **Rational subsets through the topological-localization homeomorphism.** Every rational
+subset of `Spa(A(T/s), A(T/s)⁺)` is the inverse image, under the canonical homeomorphism with
+`R(T/s)`, of the restriction of a basic rational locus from `Spa(A, A⁺)`.
+
+This is the denominator-clearing part of Wedhorn Proposition 8.2(2). The statement deliberately
+does not call the locus on the right a rational *subset* of `Spa(A, A⁺)`: that additionally asks
+that its numerator ideal be open, which is a separate input not proved here. -/
+theorem exists_spaLocalizationHomeomorph_preimage_rationalSubset_eq
+    [TopologicalSpace A] [IsTopologicalRing A]
+    (P : PairOfDefinition A) (Aplus : Subring A) (hP : P.ringOfDefinition ≤ Aplus)
+    (T : Finset A) (s : A) [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (U : Finset S) (q : S) :
+    letI := locTopology P T s S hden
+    ∃ (V : Finset A) (r : A),
+      spaLocalizationHomeomorph P Aplus hP T s S hden ⁻¹'
+          ((fun v ↦ (v.1 : spa Aplus).1) ⁻¹' rationalSubset Aplus V r) =
+        Subtype.val ⁻¹' rationalSubset
+          (integralClosure ↥(Algebra.adjoin Aplus
+            (Set.range fun t : T ↦
+              (TauCeti.Localization.divBy (t : A) s : S))) S).toSubring U q := by
+  let _ := locTopology P T s S hden
+  have _ := isTopologicalRing_locTopology P T s S hden
+  let Bplus := (integralClosure ↥(Algebra.adjoin Aplus
+    (Set.range fun t : T ↦ (TauCeti.Localization.divBy (t : A) s : S))) S).toSubring
+  have hplus : ∀ a ∈ Aplus, algebraMap A S a ∈ Bplus := fun a ha ↦
+    Subalgebra.algebraMap_mem (integralClosure _ S)
+      (⟨_, Subalgebra.algebraMap_mem _ (⟨a, ha⟩ : Aplus)⟩ :
+        ↥(Algebra.adjoin Aplus
+          (Set.range fun t : T ↦ (TauCeti.Localization.divBy (t : A) s : S))))
+  obtain ⟨V, r, hVr⟩ := exists_comap_preimage_rationalSubset_eq s Aplus Bplus
+    (continuous_algebraMap_locTopology P T s S hden) hplus U q
+  refine ⟨V, r, Set.ext fun v ↦ ?_⟩
+  have hpoint := Set.ext_iff.mp hVr v.1
+  rw [Set.mem_preimage, Set.mem_preimage, spaLocalizationHomeomorph_apply_val]
+  change comap (algebraMap A S) v.1 ∈ rationalSubset Aplus V r ↔
+    v.1 ∈ rationalSubset Bplus U q
+  exact ⟨fun hv ↦ hpoint.mp ⟨hv, v.2⟩, fun hv ↦ (hpoint.mpr hv).1⟩
+
+end TauCeti.ValuationSpectrum
+
+end

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -69,6 +69,8 @@ layer deferred above.
   subset.
 * `TauCeti.ValuationSpectrum.rationalSubset_insert_self` : the denominator may be inserted
   among the numerators.
+* `TauCeti.ValuationSpectrum.rationalSubset_image_mul_right` : multiplying every numerator and
+  the denominator by the same unit does not change the rational subset.
 * `TauCeti.ValuationSpectrum.rationalSubset_singleton_one` : the whole spectrum is the
   rational subset `R({1}/1)` — Wedhorn's "`Spa (A, A⁺)` itself is rational".
 * `TauCeti.ValuationSpectrum.val_preimage_rationalSubset` : on the subtype `spa A⁺`, a
@@ -213,6 +215,17 @@ theorem rationalSubset_insert_of_forall_vle (Aplus : Subring A) (T : Finset A) (
   rcases Finset.mem_insert.mp ht with rfl | ht
   · exact hu v hv
   · exact hv'.2.1 t ht
+
+open scoped Classical in
+/-- **Multiplying a presentation by a unit changes nothing.** If `u` is a unit, then multiplying
+every numerator and the denominator of `R(T/s)` by `u` gives the same rational subset.
+
+No injectivity of `t ↦ t * u` is needed. -/
+@[simp]
+theorem rationalSubset_image_mul_right (Aplus : Subring A) (T : Finset A) (s u : A)
+    (hu : IsUnit u) :
+    rationalSubset Aplus (T.image fun t ↦ t * u) (s * u) = rationalSubset Aplus T s := by
+  rw [rationalSubset_def, rationalSubset_def, basicOpenFinset_image_mul_right T s u hu]
 
 /-- The whole adic spectrum is the rational subset `R({1}/1)` — Wedhorn's observation that
 `Spa (A, A⁺)` itself is rational. The single condition `v(1) ≤ v(1) ≠ 0` holds at every

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -69,8 +69,6 @@ layer deferred above.
   subset.
 * `TauCeti.ValuationSpectrum.rationalSubset_insert_self` : the denominator may be inserted
   among the numerators.
-* `TauCeti.ValuationSpectrum.rationalSubset_image_mul_right` : multiplying every numerator and
-  the denominator by the same unit does not change the rational subset.
 * `TauCeti.ValuationSpectrum.rationalSubset_singleton_one` : the whole spectrum is the
   rational subset `R({1}/1)` — Wedhorn's "`Spa (A, A⁺)` itself is rational".
 * `TauCeti.ValuationSpectrum.val_preimage_rationalSubset` : on the subtype `spa A⁺`, a
@@ -215,17 +213,6 @@ theorem rationalSubset_insert_of_forall_vle (Aplus : Subring A) (T : Finset A) (
   rcases Finset.mem_insert.mp ht with rfl | ht
   · exact hu v hv
   · exact hv'.2.1 t ht
-
-open scoped Classical in
-/-- **Multiplying a presentation by a unit changes nothing.** If `u` is a unit, then multiplying
-every numerator and the denominator of `R(T/s)` by `u` gives the same rational subset.
-
-No injectivity of `t ↦ t * u` is needed. -/
-@[simp]
-theorem rationalSubset_image_mul_right (Aplus : Subring A) (T : Finset A) (s u : A)
-    (hu : IsUnit u) :
-    rationalSubset Aplus (T.image fun t ↦ t * u) (s * u) = rationalSubset Aplus T s := by
-  rw [rationalSubset_def, rationalSubset_def, basicOpenFinset_image_mul_right T s u hu]
 
 /-- The whole adic spectrum is the rational subset `R({1}/1)` — Wedhorn's observation that
 `Spa (A, A⁺)` itself is rational. The single condition `v(1) ≤ v(1) ≠ 0` holds at every

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -222,8 +222,7 @@ open scoped Classical in
 /-- **Multiplying a presentation by a unit changes nothing.** If `u` is a unit, then multiplying
 every numerator and the denominator of `R(T/s)` by `u` gives the same rational subset.
 
-No injectivity of `t ↦ t * u` is needed: membership in `Finset.image` supplies the forward
-representative, and the original numerator itself supplies the reverse one. -/
+No injectivity of `t ↦ t * u` is needed. -/
 @[simp]
 theorem rationalSubset_image_mul_right (Aplus : Subring A) (T : Finset A) (s u : A)
     (hu : IsUnit u) :

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -121,8 +121,6 @@ layer deferred above.
   source closely: the same `ext`/`constructor` split, the same three-part destructuring, and the
   same use of a witness from `hT` to transport the two `t`-independent conditions. Only the
   unfolding step differs, `mem_rationalSubset_iff` here against `rationalOpen` there.
-* `rationalSubset_image_mul_right` is proved directly from the valuative-relation cancellation
-  law and has no external formalization as its source.
 -/
 
 public section
@@ -227,26 +225,7 @@ No injectivity of `t ↦ t * u` is needed. -/
 theorem rationalSubset_image_mul_right (Aplus : Subring A) (T : Finset A) (s u : A)
     (hu : IsUnit u) :
     rationalSubset Aplus (T.image fun t ↦ t * u) (s * u) = rationalSubset Aplus T s := by
-  have hu0 (v : Spv A) : ¬v.toValuativeRel.vle u 0 :=
-    @TauCeti.ValuativeRel.not_vle_zero_of_isUnit A _ v.toValuativeRel u hu
-  have hmul (v : Spv A) (x y : A) :
-      v.toValuativeRel.vle (x * u) (y * u) ↔ v.toValuativeRel.vle x y :=
-    v.toValuativeRel.mul_vle_mul_iff_left (hu0 v)
-  have hzero (v : Spv A) (x : A) :
-      v.toValuativeRel.vle (x * u) 0 ↔ v.toValuativeRel.vle x 0 := by
-    simpa only [zero_mul] using hmul v x 0
-  ext v
-  simp only [mem_rationalSubset_iff]
-  constructor
-  · rintro ⟨hv, hT, hs⟩
-    exact ⟨hv, fun t ht ↦ (hmul v t s).mp
-      (hT (t * u) (Finset.mem_image_of_mem (fun x ↦ x * u) ht)),
-      fun h ↦ hs ((hzero v s).mpr h)⟩
-  · rintro ⟨hv, hT, hs⟩
-    refine ⟨hv, ?_, fun h ↦ hs ((hzero v s).mp h)⟩
-    intro t ht
-    obtain ⟨x, hx, rfl⟩ := Finset.mem_image.mp ht
-    exact (hmul v x s).mpr (hT x hx)
+  rw [rationalSubset_def, rationalSubset_def, basicOpenFinset_image_mul_right T s u hu]
 
 /-- The whole adic spectrum is the rational subset `R({1}/1)` — Wedhorn's observation that
 `Spa (A, A⁺)` itself is rational. The single condition `v(1) ≤ v(1) ≠ 0` holds at every

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -69,6 +69,8 @@ layer deferred above.
   subset.
 * `TauCeti.ValuationSpectrum.rationalSubset_insert_self` : the denominator may be inserted
   among the numerators.
+* `TauCeti.ValuationSpectrum.rationalSubset_image_mul_right` : multiplying every numerator and
+  the denominator by the same unit does not change the rational subset.
 * `TauCeti.ValuationSpectrum.rationalSubset_singleton_one` : the whole spectrum is the
   rational subset `R({1}/1)` — Wedhorn's "`Spa (A, A⁺)` itself is rational".
 * `TauCeti.ValuationSpectrum.val_preimage_rationalSubset` : on the subtype `spa A⁺`, a
@@ -119,6 +121,8 @@ layer deferred above.
   source closely: the same `ext`/`constructor` split, the same three-part destructuring, and the
   same use of a witness from `hT` to transport the two `t`-independent conditions. Only the
   unfolding step differs, `mem_rationalSubset_iff` here against `rationalOpen` there.
+* `rationalSubset_image_mul_right` is proved directly from the valuative-relation cancellation
+  law and has no external formalization as its source.
 -/
 
 public section
@@ -213,6 +217,37 @@ theorem rationalSubset_insert_of_forall_vle (Aplus : Subring A) (T : Finset A) (
   rcases Finset.mem_insert.mp ht with rfl | ht
   · exact hu v hv
   · exact hv'.2.1 t ht
+
+open scoped Classical in
+/-- **Multiplying a presentation by a unit changes nothing.** If `u` is a unit, then multiplying
+every numerator and the denominator of `R(T/s)` by `u` gives the same rational subset.
+
+No injectivity of `t ↦ t * u` is needed: membership in `Finset.image` supplies the forward
+representative, and the original numerator itself supplies the reverse one. -/
+@[simp]
+theorem rationalSubset_image_mul_right (Aplus : Subring A) (T : Finset A) (s u : A)
+    (hu : IsUnit u) :
+    rationalSubset Aplus (T.image fun t ↦ t * u) (s * u) = rationalSubset Aplus T s := by
+  have hu0 (v : Spv A) : ¬v.toValuativeRel.vle u 0 :=
+    @TauCeti.ValuativeRel.not_vle_zero_of_isUnit A _ v.toValuativeRel u hu
+  have hmul (v : Spv A) (x y : A) :
+      v.toValuativeRel.vle (x * u) (y * u) ↔ v.toValuativeRel.vle x y :=
+    v.toValuativeRel.mul_vle_mul_iff_left (hu0 v)
+  have hzero (v : Spv A) (x : A) :
+      v.toValuativeRel.vle (x * u) 0 ↔ v.toValuativeRel.vle x 0 := by
+    simpa only [zero_mul] using hmul v x 0
+  ext v
+  simp only [mem_rationalSubset_iff]
+  constructor
+  · rintro ⟨hv, hT, hs⟩
+    exact ⟨hv, fun t ht ↦ (hmul v t s).mp
+      (hT (t * u) (Finset.mem_image_of_mem (fun x ↦ x * u) ht)),
+      fun h ↦ hs ((hzero v s).mpr h)⟩
+  · rintro ⟨hv, hT, hs⟩
+    refine ⟨hv, ?_, fun h ↦ hs ((hzero v s).mp h)⟩
+    intro t ht
+    obtain ⟨x, hx, rfl⟩ := Finset.mem_image.mp ht
+    exact (hmul v x s).mpr (hT x hx)
 
 /-- The whole adic spectrum is the rational subset `R({1}/1)` — Wedhorn's observation that
 `Spa (A, A⁺)` itself is rational. The single condition `v(1) ≤ v(1) ≠ 0` holds at every

--- a/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean
@@ -28,6 +28,10 @@ We define the valuation spectrum `Spv A` following Wedhorn, *Adic Spaces*
 * `TauCeti.ValuationSpectrum.supp v` : The support ideal `{a ∈ A | v(a) = 0}`.
 * `TauCeti.ValuationSpectrum.basicOpenFinset_inter` : **Wedhorn's step (i)** in the proof of
   Lemma 7.5, that the rational opens are stable under finite intersection.
+* `TauCeti.ValuationSpectrum.basicOpenFinset_image_mul_right` : scaling every numerator and the
+  denominator by a unit gives the same rational open.
+* `TauCeti.ValuationSpectrum.comap_preimage_basicOpenFinset` : a rational open pulls back to the
+  rational open presented by the images of its numerators and denominator.
 * `TauCeti.ValuationSpectrum.isClosed_setOfPred_forall_vlt_one` : the sub-unit locus of a set
   of ring elements is closed — the closedness behind Wedhorn's Corollary 7.12.
 * `TauCeti.ValuationSpectrum.quotientLift 𝔞 h` : Lift the implicitly inferred point `v` with
@@ -642,6 +646,46 @@ lemma basicOpenFinset_insert_self (T : Finset A) (s : A) :
   simp only [mem_basicOpenFinset_iff, Finset.mem_insert]
   exact ⟨fun ⟨h, hs⟩ ↦ ⟨fun t ht ↦ h t (Or.inr ht), hs⟩,
     fun ⟨h, hs⟩ ↦ ⟨fun t ht ↦ ht.elim (fun e ↦ e ▸ v.toValuativeRel.vle_refl s) (h t), hs⟩⟩
+
+open scoped Classical in
+/-- **Multiplying a presentation by a unit changes nothing.** If `u` is a unit, then multiplying
+every numerator and the denominator of `Spv(A)(T/s)` by `u` gives the same rational open.
+
+No injectivity of `t ↦ t * u` is needed. -/
+@[simp]
+lemma basicOpenFinset_image_mul_right (T : Finset A) (s u : A) (hu : IsUnit u) :
+    basicOpenFinset (T.image fun t ↦ t * u) (s * u) = basicOpenFinset T s := by
+  have hu0 (v : Spv A) : ¬ v.toValuativeRel.vle u 0 :=
+    @TauCeti.ValuativeRel.not_vle_zero_of_isUnit A _ v.toValuativeRel u hu
+  have hmul (v : Spv A) (x y : A) :
+      v.toValuativeRel.vle (x * u) (y * u) ↔ v.toValuativeRel.vle x y :=
+    v.toValuativeRel.mul_vle_mul_iff_left (hu0 v)
+  have hzero (v : Spv A) (x : A) :
+      v.toValuativeRel.vle (x * u) 0 ↔ v.toValuativeRel.vle x 0 := by
+    simpa only [zero_mul] using hmul v x 0
+  ext v
+  simp only [mem_basicOpenFinset_iff]
+  constructor
+  · rintro ⟨hT, hs⟩
+    exact ⟨fun t ht ↦ (hmul v t s).mp (hT (t * u) (Finset.mem_image_of_mem (fun x ↦ x * u) ht)),
+      fun h ↦ hs ((hzero v s).mpr h)⟩
+  · rintro ⟨hT, hs⟩
+    refine ⟨?_, fun h ↦ hs ((hzero v s).mp h)⟩
+    intro t ht
+    obtain ⟨x, hx, rfl⟩ := Finset.mem_image.mp ht
+    exact (hmul v x s).mpr (hT x hx)
+
+open scoped Classical in
+/-- The preimage of `Spv(A)(T/s)` under `comap φ` is `Spv(B)(φ(T)/φ(s))`, the finite-numerator
+form of `comap_preimage_basicOpen`. -/
+lemma comap_preimage_basicOpenFinset {B : Type*} [CommRing B] (φ : A →+* B) (T : Finset A)
+    (s : A) :
+    comap φ ⁻¹' basicOpenFinset T s = basicOpenFinset (T.image φ) (φ s) := by
+  ext v
+  simp only [Set.mem_preimage, mem_basicOpenFinset_iff, comap_vle, map_zero, Finset.mem_image,
+    forall_exists_index, and_imp]
+  exact ⟨fun h ↦ ⟨fun _ t ht hte ↦ hte ▸ h.1 t ht, h.2⟩,
+    fun h ↦ ⟨fun t ht ↦ h.1 (φ t) t ht rfl, h.2⟩⟩
 
 open scoped Classical Pointwise in
 /-- **Wedhorn's step (i) in the proof of Lemma 7.5**: the rational opens are stable under finite

--- a/TauCeti/RingTheory/Localization/Away.lean
+++ b/TauCeti/RingTheory/Localization/Away.lean
@@ -39,8 +39,6 @@ Huber namespace, alongside `TauCeti/RingTheory/Localization/DenIdeal.lean`.
   splits as `(a · r)/s · (b · u)/s`, each half carrying one factor of the denominator.
 * `TauCeti.Localization.awayLift_divBy`: the comparison map to a localisation at a multiple
   `w = u * r` rescales fractions by the cofactor, sending `a/u` to `(a · r)/w`.
-* `TauCeti.Localization.exists_finset_mul_pow_eq_algebraMap`: a finite family in an away
-  localization has a common denominator which is a power of the distinguished element.
 
 ## Provenance
 
@@ -56,8 +54,6 @@ is `TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean`, which records the
 checked against `dev/adic-spaces` at commit `37bbdaeb9`, which has neither the splitting identity
 for a factored denominator nor any statement about `IsLocalization.Away.lift` on distinguished
 fractions. Both are proved here directly from Mathlib's `mk'` API.
-`exists_finset_mul_pow_eq_algebraMap` is also developed here: its proof applies Mathlib's
-`IsLocalization.Away.sec` to a finite family and sums the resulting exponents.
 
 ## References
 
@@ -203,29 +199,6 @@ theorem awayLift_divBy {V W : Type*} [CommSemiring V] [CommSemiring W] [Algebra 
     IsLocalization.Away.lift u hu (divBy a u : V) = (divBy (a * r) w : W) := by
   rw [divBy_def, IsLocalization.Away.lift, IsLocalization.lift_mk'_spec, ← divBy_mul,
     show u * (a * r) = a * w by rw [hw]; ring, divBy_mul_cancel_right]
-
-/-! ### Common denominators -/
-
-open scoped Classical in
-/-- **A finite family in an away localization has a common denominator.** Every element of `T`
-becomes the image of an element of `A` after multiplication by one fixed power of `s`.
-
-Mathlib's `IsLocalization.Away.sec` supplies a possibly different exponent for each element.
-Their sum is a common exponent: multiplying the corresponding numerator by the complementary
-power of `s` gives the required representative. -/
-theorem exists_finset_mul_pow_eq_algebraMap (T : Finset S) :
-    ∃ (n : ℕ) (a : S → A),
-      ∀ x ∈ T, x * algebraMap A S s ^ n = algebraMap A S (a x) := by
-  classical
-  let e : S → ℕ := fun x ↦ (IsLocalization.Away.sec s x).2
-  let n : ℕ := T.sum e
-  let a : S → A := fun x ↦ (IsLocalization.Away.sec s x).1 * s ^ (n - e x)
-  refine ⟨n, a, fun x hx ↦ ?_⟩
-  have he : e x ≤ n := Finset.single_le_sum (fun _ _ ↦ Nat.zero_le _) hx
-  have hpow : e x + (n - e x) = n := Nat.add_sub_of_le he
-  dsimp only [a]
-  rw [map_mul, map_pow, ← IsLocalization.Away.sec_spec s x, mul_assoc, map_pow,
-    ← pow_add, hpow]
 
 /-! ### The trivial denominator
 

--- a/TauCeti/RingTheory/Localization/Away.lean
+++ b/TauCeti/RingTheory/Localization/Away.lean
@@ -39,6 +39,8 @@ Huber namespace, alongside `TauCeti/RingTheory/Localization/DenIdeal.lean`.
   splits as `(a · r)/s · (b · u)/s`, each half carrying one factor of the denominator.
 * `TauCeti.Localization.awayLift_divBy`: the comparison map to a localisation at a multiple
   `w = u * r` rescales fractions by the cofactor, sending `a/u` to `(a · r)/w`.
+* `TauCeti.Localization.exists_finset_mul_pow_eq_algebraMap`: a finite family in an away
+  localization has a common denominator which is a power of the distinguished element.
 
 ## Provenance
 
@@ -54,6 +56,8 @@ is `TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean`, which records the
 checked against `dev/adic-spaces` at commit `37bbdaeb9`, which has neither the splitting identity
 for a factored denominator nor any statement about `IsLocalization.Away.lift` on distinguished
 fractions. Both are proved here directly from Mathlib's `mk'` API.
+`exists_finset_mul_pow_eq_algebraMap` is also developed here: its proof applies Mathlib's
+`IsLocalization.Away.sec` to a finite family and sums the resulting exponents.
 
 ## References
 
@@ -199,6 +203,29 @@ theorem awayLift_divBy {V W : Type*} [CommSemiring V] [CommSemiring W] [Algebra 
     IsLocalization.Away.lift u hu (divBy a u : V) = (divBy (a * r) w : W) := by
   rw [divBy_def, IsLocalization.Away.lift, IsLocalization.lift_mk'_spec, ← divBy_mul,
     show u * (a * r) = a * w by rw [hw]; ring, divBy_mul_cancel_right]
+
+/-! ### Common denominators -/
+
+open scoped Classical in
+/-- **A finite family in an away localization has a common denominator.** Every element of `T`
+becomes the image of an element of `A` after multiplication by one fixed power of `s`.
+
+Mathlib's `IsLocalization.Away.sec` supplies a possibly different exponent for each element.
+Their sum is a common exponent: multiplying the corresponding numerator by the complementary
+power of `s` gives the required representative. -/
+theorem exists_finset_mul_pow_eq_algebraMap (T : Finset S) :
+    ∃ (n : ℕ) (a : S → A),
+      ∀ x ∈ T, x * algebraMap A S s ^ n = algebraMap A S (a x) := by
+  classical
+  let e : S → ℕ := fun x ↦ (IsLocalization.Away.sec s x).2
+  let n : ℕ := T.sum e
+  let a : S → A := fun x ↦ (IsLocalization.Away.sec s x).1 * s ^ (n - e x)
+  refine ⟨n, a, fun x hx ↦ ?_⟩
+  have he : e x ≤ n := Finset.single_le_sum (fun _ _ ↦ Nat.zero_le _) hx
+  have hpow : e x + (n - e x) = n := Nat.add_sub_of_le he
+  dsimp only [a]
+  rw [map_mul, map_pow, ← IsLocalization.Away.sec_spec s x, mul_assoc, map_pow,
+    ← pow_add, hpow]
 
 /-! ### The trivial denominator
 


### PR DESCRIPTION
This PR clears a common denominator from every finite rational presentation over a localization, proves that multiplying a presentation by a unit preserves its locus, and transports the resulting presentation through the canonical homeomorphism `Spa(A(T/s), A(T/s)⁺) ≃ R(T/s)`. It advances `AdicSpaces/README.md`, Layer 2.2, milestone “Rational subsets,” as the algebraic denominator-clearing step of Proposition 8.2(2), and it supplies the presentation input consumed by Layer 4.1 step 6 through Lemma 7.54. After this PR, Proposition 8.2(2) still needs the cleared numerator family to be replaced by an admissible finite family in `A` and the comparison to be carried from `A(T/s)` to the completed coordinate ring `A⟨T/s⟩`.

The denominator clearing itself is Mathlib's: `IsLocalization.commonDenomOfFinset`, `IsLocalization.finsetIntegerMultiple` and `IsLocalization.finsetIntegerMultiple_image` are used as they stand on `insert q U`, so that the denominator is cleared along with the numerators. The two new ambient lemmas on `Spv A` — `basicOpenFinset_image_mul_right`, that scaling a presentation by a unit changes nothing, and `comap_preimage_basicOpenFinset`, the finite-numerator companion of the existing `comap_preimage_basicOpen` — carry the geometric content, with no topology and no plus ring in sight. `exists_comap_preimage_basicOpenFinset_eq` combines them; `exists_comap_preimage_rationalSubset_inter_spa_eq` cuts that down to the adic spectrum, and `exists_spaLocalizationHomeomorph_preimage_rationalSubset_eq` specializes it to the localization topology and the integral-closure plus ring already used by the existing homeomorphism. `rationalSubset_image_mul_right` is the rational-subset shadow of the ambient unit-scaling lemma, derived from it exactly as `rationalSubset_insert_self` is derived from `basicOpenFinset_insert_self`. No Mathlib or external formalization is vendored or copied.

The change adds `TauCeti/AlgebraicGeometry/AdicSpace/Spa/Localization/RationalSubset.lean` and extends `TauCeti/AlgebraicGeometry/AdicSpace/ValuationSpectrum.lean` and `TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean`, for 200 added lines in total.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"rational-subsets-under-localization-homeomorphism"}-->

🤖 Prepared with Codex
