### PR TITLE
feat: the radical is contained in every Borel subgroup

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Borel/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/BaseChange.lean
@@ -11,17 +11,15 @@ import TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.Solvable.BaseChange
 
 /-!
-# Borel subgroups over an arbitrary field are Borel candidates
+# Borel candidates under field extension
 
-Over an arbitrary field `k`, a Borel subgroup is defined by a condition on its base change to an
-algebraic closure: the base-changed ideal is a maximal Borel candidate there. The three geometric
-conditions defining a Borel candidate — smoothness, geometric connectedness and geometric
-solvability of the coordinate quotient — are therefore only visible after base change. This file
-descends them back to the ground field, so that a Borel subgroup over `k` is in particular a Borel
-candidate over `k`.
+The three conditions defining a Borel candidate — smoothness, geometric connectedness and
+geometric solvability of the coordinate quotient — descend along field extensions. Consequently,
+a Borel subgroup over an arbitrary field, whose base change to an algebraic closure is a maximal
+Borel candidate, is in particular a Borel candidate over the ground field.
 
 Each of the three conditions descends by its own mechanism. Smoothness descends along the
-faithfully flat extension `k → AlgebraicClosure k`, using Mathlib's
+faithfully flat field extension `k → K`, using Mathlib's
 `Algebra.Smooth.of_smooth_tensorProduct_of_faithfullyFlat`. Geometric connectedness and geometric
 solvability are stated in terms of geometric points, and are reflected by an arbitrary field
 extension. In all three cases the coordinate quotient of the base-changed ideal is identified with
@@ -29,6 +27,8 @@ the base change of the coordinate quotient by `CommHopfAlgCat.quotientBaseChange
 
 ## Main declarations
 
+* `TauCeti.HopfIdeal.IsBorelCandidate.of_baseChange`: Borel candidatehood descends along a field
+  extension.
 * `TauCeti.HopfIdeal.IsBorel.isBorelCandidate`: a Borel subgroup over an arbitrary field is a
   Borel candidate over that field.
 
@@ -48,6 +48,41 @@ universe u
 
 noncomputable section
 
+namespace HopfIdeal.IsBorelCandidate
+
+variable {k K : Type u} [Field k] [Field K] [Algebra k K]
+variable {H : CommHopfAlgCat.{u} k} [Algebra.FiniteType k H] {I : HopfIdeal k H}
+
+/-- Borel candidatehood descends along a field extension. -/
+theorem of_baseChange
+    (hI : IsBorelCandidate K
+      (FiniteTypeCommHopfAlgCat.baseChange (K := K)
+        ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩)
+      (CommHopfAlgCat.baseChangeHopfIdeal (K := K) I)) :
+    IsBorelCandidate k ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I := by
+  let H' : FiniteTypeCommHopfAlgCat.{u, u} k :=
+    ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
+  let qIso := CommHopfAlgCat.quotientBaseChangeIso (K := K) I
+  refine IsBorelCandidate.mk ?_ ?_ ?_
+  · rw [smoothCommHopfAlgProperty_iff]
+    -- Unwrap the finite-type quotient for Mathlib's faithfully-flat smoothness descent lemma.
+    change Algebra.Smooth k (CommHopfAlgCat.quotient H I)
+    have hsmooth := (smoothCommHopfAlgProperty K).prop_of_iso qIso hI.smooth
+    let _ : Algebra.Smooth K
+        (CommHopfAlgCat.baseChange (K := K) (CommHopfAlgCat.quotient H I)) :=
+      (smoothCommHopfAlgProperty_iff _).mp hsmooth
+    exact Algebra.Smooth.of_smooth_tensorProduct_of_faithfullyFlat K
+  · apply geometricallyConnectedCommHopfAlgProperty.of_baseChange k K
+      (FiniteTypeCommHopfAlgCat.quotient H' I).obj
+    exact (geometricallyConnectedCommHopfAlgProperty K).prop_of_iso
+      qIso hI.geometricallyConnected
+  · apply geometricallySolvablePointsCommHopfAlgProperty.of_baseChange
+      (K := K) (FiniteTypeCommHopfAlgCat.quotient H' I).obj
+    exact (geometricallySolvablePointsCommHopfAlgProperty K).prop_of_iso
+      qIso hI.geometricallySolvable
+
+end HopfIdeal.IsBorelCandidate
+
 namespace HopfIdeal.IsBorel
 
 variable {k : Type u} [Field k] {H : CommHopfAlgCat.{u} k} [Algebra.FiniteType k H]
@@ -57,34 +92,13 @@ variable {I : HopfIdeal k H}
 is smooth, geometrically connected, and geometrically solvable. -/
 theorem isBorelCandidate (hI : IsBorel k H I) :
     IsBorelCandidate k ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I := by
-  let H' : FiniteTypeCommHopfAlgCat.{u, u} k :=
-    ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
-  let qIso := CommHopfAlgCat.quotientBaseChangeIso (K := AlgebraicClosure k) I
   have hIK : IsBorelCandidate (AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H')
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+        ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩)
       (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I) :=
     ((isBorelOverAlgClosed_iff _ _ _).mp
       ((isBorel_iff_isBorelOverAlgClosed_baseChange k H I).mp hI)).2.1
-  refine IsBorelCandidate.mk ?_ ?_ ?_
-  · rw [smoothCommHopfAlgProperty_iff]
-    -- Unwrap the finite-type quotient for Mathlib's faithfully-flat smoothness descent lemma.
-    change Algebra.Smooth k (CommHopfAlgCat.quotient H I)
-    have hsmooth :=
-      (smoothCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso hIK.smooth
-    let _ : Algebra.Smooth (AlgebraicClosure k)
-        (CommHopfAlgCat.baseChange (K := AlgebraicClosure k)
-          (CommHopfAlgCat.quotient H I)) :=
-      (smoothCommHopfAlgProperty_iff _).mp hsmooth
-    exact Algebra.Smooth.of_smooth_tensorProduct_of_faithfullyFlat (AlgebraicClosure k)
-  · apply geometricallyConnectedCommHopfAlgProperty.of_baseChange k (AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.quotient H' I).obj
-    exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-      qIso hIK.geometricallyConnected
-  · apply geometricallySolvablePointsCommHopfAlgProperty.of_baseChange
-      (K := AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.quotient H' I).obj
-    exact (geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-      qIso hIK.geometricallySolvable
+  exact hIK.of_baseChange
 
 end HopfIdeal.IsBorel
 

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/BaseChange.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Borel.Basic
+import Mathlib.RingTheory.Etale.Descent
+import TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange
+import TauCeti.Algebra.AlgebraicGroup.Solvable.BaseChange
+
+/-!
+# Borel subgroups over an arbitrary field are Borel candidates
+
+Over an arbitrary field `k`, a Borel subgroup is defined by a condition on its base change to an
+algebraic closure: the base-changed ideal is a maximal Borel candidate there. The three geometric
+conditions defining a Borel candidate — smoothness, geometric connectedness and geometric
+solvability of the coordinate quotient — are therefore only visible after base change. This file
+descends them back to the ground field, so that a Borel subgroup over `k` is in particular a Borel
+candidate over `k`.
+
+Each of the three conditions descends by its own mechanism. Smoothness descends along the
+faithfully flat extension `k → AlgebraicClosure k`, using Mathlib's
+`Algebra.Smooth.of_smooth_tensorProduct_of_faithfullyFlat`. Geometric connectedness and geometric
+solvability are stated in terms of geometric points, and are reflected by an arbitrary field
+extension. In all three cases the coordinate quotient of the base-changed ideal is identified with
+the base change of the coordinate quotient by `CommHopfAlgCat.quotientBaseChangeIso`.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.IsBorel.isBorelCandidate`: a Borel subgroup over an arbitrary field is a
+  Borel candidate over that field.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§17.a and 1.h.
+* A. Borel, *Linear Algebraic Groups*, 2nd ed. (1991), §11.21.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal.IsBorel
+
+variable {k : Type u} [Field k] {H : CommHopfAlgCat.{u} k} [Algebra.FiniteType k H]
+variable {I : HopfIdeal k H}
+
+/-- A Borel subgroup over an arbitrary field is a Borel candidate over that field: its quotient
+is smooth, geometrically connected, and geometrically solvable. -/
+theorem isBorelCandidate (hI : IsBorel k H I) :
+    IsBorelCandidate k ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I := by
+  let H' : FiniteTypeCommHopfAlgCat.{u, u} k :=
+    ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
+  let qIso := CommHopfAlgCat.quotientBaseChangeIso (K := AlgebraicClosure k) I
+  have hIK : IsBorelCandidate (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H')
+      (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I) :=
+    ((isBorelOverAlgClosed_iff _ _ _).mp
+      ((isBorel_iff_isBorelOverAlgClosed_baseChange k H I).mp hI)).2.1
+  refine IsBorelCandidate.mk ?_ ?_ ?_
+  · rw [smoothCommHopfAlgProperty_iff]
+    -- Unwrap the finite-type quotient for Mathlib's faithfully-flat smoothness descent lemma.
+    change Algebra.Smooth k (CommHopfAlgCat.quotient H I)
+    have hsmooth :=
+      (smoothCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso hIK.smooth
+    let _ : Algebra.Smooth (AlgebraicClosure k)
+        (CommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+          (CommHopfAlgCat.quotient H I)) :=
+      (smoothCommHopfAlgProperty_iff _).mp hsmooth
+    exact Algebra.Smooth.of_smooth_tensorProduct_of_faithfullyFlat (AlgebraicClosure k)
+  · apply geometricallyConnectedCommHopfAlgProperty.of_baseChange k (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient H' I).obj
+    exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+      qIso hIK.geometricallyConnected
+  · apply geometricallySolvablePointsCommHopfAlgProperty.of_baseChange
+      (K := AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient H' I).obj
+    exact (geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+      qIso hIK.geometricallySolvable
+
+end HopfIdeal.IsBorel
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
@@ -40,8 +40,6 @@ itself smooth, connected and solvable — then it is its own unique Borel subgro
 smooth geometrically connected group with a trivial geometric Borel subgroup is semisimple, since
 its geometric solvable radical is squeezed between the trivial Borel and the identity subgroup.
 
-Conjugacy of Borel subgroups is not proved here, and none of the statements below need it.
-
 ## Main declarations
 
 * `TauCeti.HopfIdeal.IsBorelCandidate.productOfNormal`: the multiplication image of a connected
@@ -76,10 +74,6 @@ Conjugacy of Borel subgroups is not proved here, and none of the statements belo
 The product-image bookkeeping follows the formal organization of
 `TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Product`, where the same three closure
 properties are proved for two normal factors.
-
-This advances Layer 7, "Borel subgroups, maximal tori, and their conjugacy", of the
-ReductiveGroups roadmap, by relating the Borel subgroups constructed there to the radicals of
-Layers 5 and 6. Conjugacy of Borel subgroups remains open.
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
@@ -6,10 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Borel.Existence
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Semisimple
 import Mathlib.RingTheory.Etale.Descent
-import TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.Connected.Product
 import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
 import TauCeti.Algebra.AlgebraicGroup.Smooth.Product
@@ -68,6 +66,9 @@ and the identity subgroup.
 * `TauCeti.HopfIdeal.IsBorel.baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal` and
   `TauCeti.HopfIdeal.IsBorel.baseChangeHopfIdeal_le_unipotentRadicalDefiningIdeal`: over an
   arbitrary field, the base change of a Borel subgroup contains the two geometric radicals.
+* `TauCeti.HopfIdeal.IsBorel.le_solvableRadicalDefiningIdeal` and
+  `TauCeti.HopfIdeal.IsBorel.le_unipotentRadicalDefiningIdeal`: **over an arbitrary field, the
+  solvable radical, and hence the unipotent radical, is contained in every Borel subgroup.**
 * `TauCeti.HopfIdeal.IsBorel.eq_solvableRadicalDefiningIdeal_of_isNormal`: a normal Borel subgroup
   over an arbitrary field is exactly the solvable radical.
 * `TauCeti.HopfIdeal.IsBorel.eq_bot_of_solvableRadicalDefiningIdeal_eq_bot`: if the solvable
@@ -249,6 +250,26 @@ theorem baseChangeHopfIdeal_le_unipotentRadicalDefiningIdeal (hI : IsBorel k H I
   IsBorelOverAlgClosed.le_unipotentRadicalDefiningIdeal
     ((isBorel_iff_isBorelOverAlgClosed_baseChange k H I).mp hI)
 
+/-- **Over an arbitrary field, the solvable radical is contained in every Borel subgroup.**
+
+The containment is checked after base change to an algebraic closure, where it is the geometric
+statement, and descends because the base change of a Hopf ideal is faithfully flat. -/
+theorem le_solvableRadicalDefiningIdeal (hI : IsBorel k H I) :
+    I ≤ FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal
+      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ := by
+  apply (CommHopfAlgCat.baseChangeHopfIdeal_le_iff_of_faithfullyFlat
+    (K := AlgebraicClosure k) I _).mp
+  exact hI.baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal.trans
+    (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_baseChange_le _)
+
+/-- Over an arbitrary field, the unipotent radical is contained in every Borel subgroup, since it
+is contained in the solvable radical. -/
+theorem le_unipotentRadicalDefiningIdeal (hI : IsBorel k H I) :
+    I ≤ FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ :=
+  hI.le_solvableRadicalDefiningIdeal.trans
+    (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_le_unipotentRadicalDefiningIdeal _)
+
 /-- Over an arbitrary field, a normal Borel subgroup is exactly the solvable radical. -/
 theorem eq_solvableRadicalDefiningIdeal_of_isNormal
     (hI : IsBorel k H I) (hnormal : I.IsNormal) :
@@ -283,14 +304,9 @@ theorem eq_solvableRadicalDefiningIdeal_of_isNormal
         (FiniteTypeCommHopfAlgCat.quotient H' I).obj
       exact (geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
         qIso hIK.geometricallySolvable
-  apply le_antisymm
-  · apply (CommHopfAlgCat.baseChangeHopfIdeal_le_iff_of_faithfullyFlat
-      (K := AlgebraicClosure k) I
-      (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal H')).mp
-    exact hI.baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal.trans
-      (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_baseChange_le H')
-  · exact FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_le H' I
-      (hIcandidate.isSolvableRadicalCandidate_of_isNormal hnormal)
+  exact le_antisymm hI.le_solvableRadicalDefiningIdeal
+    (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_le H' I
+      (hIcandidate.isSolvableRadicalCandidate_of_isNormal hnormal))
 
 /-- Over an arbitrary field, if the solvable radical is the whole group, every Borel subgroup is
 the whole group. -/
@@ -298,13 +314,8 @@ theorem eq_bot_of_solvableRadicalDefiningIdeal_eq_bot
     (hI : IsBorel k H I)
     (hH : FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal
       ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ = ⊥) :
-    I = ⊥ := by
-  apply le_antisymm ?_ bot_le
-  rw [← hH]
-  apply (CommHopfAlgCat.baseChangeHopfIdeal_le_iff_of_faithfullyFlat
-    (K := AlgebraicClosure k) I _).mp
-  exact hI.baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal.trans
-    (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_baseChange_le _)
+    I = ⊥ :=
+  le_antisymm (hH ▸ hI.le_solvableRadicalDefiningIdeal) bot_le
 
 end HopfIdeal.IsBorel
 

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Borel.Existence
+public import TauCeti.Algebra.AlgebraicGroup.Borel.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Semisimple
 import TauCeti.Algebra.AlgebraicGroup.Borel.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.Connected.Product

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
@@ -66,6 +66,8 @@ and the identity subgroup.
 * `TauCeti.HopfIdeal.IsBorel.baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal` and
   `TauCeti.HopfIdeal.IsBorel.baseChangeHopfIdeal_le_unipotentRadicalDefiningIdeal`: over an
   arbitrary field, the base change of a Borel subgroup contains the two geometric radicals.
+* `TauCeti.HopfIdeal.IsBorel.isBorelCandidate`: every Borel subgroup over an arbitrary field is a
+  Borel candidate over that field.
 * `TauCeti.HopfIdeal.IsBorel.le_solvableRadicalDefiningIdeal` and
   `TauCeti.HopfIdeal.IsBorel.le_unipotentRadicalDefiningIdeal`: **over an arbitrary field, the
   solvable radical, and hence the unipotent radical, is contained in every Borel subgroup.**
@@ -270,43 +272,48 @@ theorem le_unipotentRadicalDefiningIdeal (hI : IsBorel k H I) :
   hI.le_solvableRadicalDefiningIdeal.trans
     (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_le_unipotentRadicalDefiningIdeal _)
 
+/-- A Borel subgroup over an arbitrary field is a Borel candidate over that field: its quotient
+is smooth, geometrically connected, and geometrically solvable. -/
+theorem isBorelCandidate (hI : IsBorel k H I) :
+    IsBorelCandidate k ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I := by
+  let H' : FiniteTypeCommHopfAlgCat.{u, u} k :=
+    ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
+  let qIso := CommHopfAlgCat.quotientBaseChangeIso (K := AlgebraicClosure k) I
+  have hIK : IsBorelCandidate (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H')
+      (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I) :=
+    ((isBorelOverAlgClosed_iff _ _ _).mp
+      ((isBorel_iff_isBorelOverAlgClosed_baseChange k H I).mp hI)).2.1
+  refine IsBorelCandidate.mk ?_ ?_ ?_
+  · rw [smoothCommHopfAlgProperty_iff]
+    -- Unwrap the finite-type quotient for Mathlib's faithfully-flat smoothness descent lemma.
+    change Algebra.Smooth k (CommHopfAlgCat.quotient H I)
+    have hsmooth :=
+      (smoothCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso hIK.smooth
+    let _ : Algebra.Smooth (AlgebraicClosure k)
+        (CommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+          (CommHopfAlgCat.quotient H I)) :=
+      (smoothCommHopfAlgProperty_iff _).mp hsmooth
+    exact Algebra.Smooth.of_smooth_tensorProduct_of_faithfullyFlat (AlgebraicClosure k)
+  · apply geometricallyConnectedCommHopfAlgProperty.of_baseChange k (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient H' I).obj
+    exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+      qIso hIK.geometricallyConnected
+  · apply geometricallySolvablePointsCommHopfAlgProperty.of_baseChange
+      (K := AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient H' I).obj
+    exact (geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+      qIso hIK.geometricallySolvable
+
 /-- Over an arbitrary field, a normal Borel subgroup is exactly the solvable radical. -/
 theorem eq_solvableRadicalDefiningIdeal_of_isNormal
     (hI : IsBorel k H I) (hnormal : I.IsNormal) :
     I = FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal
-      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ := by
-  let H' : FiniteTypeCommHopfAlgCat.{u, u} k :=
-    ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
-  have hIcandidate : IsBorelCandidate k H' I := by
-    let qIso := CommHopfAlgCat.quotientBaseChangeIso (K := AlgebraicClosure k) I
-    have hIK : IsBorelCandidate (AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H')
-        (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I) :=
-      ((isBorelOverAlgClosed_iff _ _ _).mp
-        ((isBorel_iff_isBorelOverAlgClosed_baseChange k H I).mp hI)).2.1
-    refine IsBorelCandidate.mk ?_ ?_ ?_
-    · rw [smoothCommHopfAlgProperty_iff]
-      -- Unwrap the finite-type quotient for Mathlib's faithfully-flat smoothness descent lemma.
-      change Algebra.Smooth k (CommHopfAlgCat.quotient H I)
-      have hsmooth :=
-        (smoothCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso hIK.smooth
-      let _ : Algebra.Smooth (AlgebraicClosure k)
-          (CommHopfAlgCat.baseChange (K := AlgebraicClosure k)
-            (CommHopfAlgCat.quotient H I)) :=
-        (smoothCommHopfAlgProperty_iff _).mp hsmooth
-      exact Algebra.Smooth.of_smooth_tensorProduct_of_faithfullyFlat (AlgebraicClosure k)
-    · apply geometricallyConnectedCommHopfAlgProperty.of_baseChange k (AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.quotient H' I).obj
-      exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-        qIso hIK.geometricallyConnected
-    · apply geometricallySolvablePointsCommHopfAlgProperty.of_baseChange
-        (K := AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.quotient H' I).obj
-      exact (geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-        qIso hIK.geometricallySolvable
-  exact le_antisymm hI.le_solvableRadicalDefiningIdeal
-    (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_le H' I
-      (hIcandidate.isSolvableRadicalCandidate_of_isNormal hnormal))
+      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ :=
+  le_antisymm hI.le_solvableRadicalDefiningIdeal
+    (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_le
+      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I
+      (hI.isBorelCandidate.isSolvableRadicalCandidate_of_isNormal hnormal))
 
 /-- Over an arbitrary field, if the solvable radical is the whole group, every Borel subgroup is
 the whole group. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
@@ -8,22 +8,28 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.Borel.Existence
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Semisimple
+import Mathlib.RingTheory.Etale.Descent
+import TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.Connected.Product
 import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
 import TauCeti.Algebra.AlgebraicGroup.Smooth.Product
+import TauCeti.Algebra.AlgebraicGroup.Solvable.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.Solvable.NormalProduct
+import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.BaseChange
 
 /-!
 # The radical is contained in every Borel subgroup
 
 Let `H` be the coordinate Hopf algebra of a finite-type affine group over a field. A Borel
-candidate is a smooth, geometrically connected, geometrically solvable closed subgroup, and a
-Borel subgroup is a maximal one. This file proves that every *normal* Borel candidate is
-contained in every maximal one; in particular the solvable radical `R(G)`, and hence the
-unipotent radical `R_u(G)`, lies inside every Borel subgroup.
+candidate is a smooth, geometrically connected, geometrically solvable closed subgroup. A maximal
+Borel candidate is a Borel subgroup over an algebraically closed field; over an arbitrary field,
+a Borel subgroup is one whose base change to an algebraic closure is such a subgroup. This file
+proves that every *normal* Borel candidate is contained in every maximal one; in particular the
+solvable radical `R(G)`, and hence the unipotent radical `R_u(G)`, lies inside every Borel subgroup.
 
 The argument is the standard one and reuses the product machinery that built the two radicals.
-Let `B` be a Borel candidate and let `N` be a connected normal smooth solvable closed subgroup.
+Let `B` be a Borel candidate and let `N` be a geometrically connected normal smooth geometrically
+solvable closed subgroup.
 Since `N` is normal, multiplication is a homomorphism from the conjugation semidirect product of
 `N` and `B` into the ambient group, and its scheme-theoretic image `N · B` contains both factors.
 That image is again smooth, geometrically connected and geometrically solvable, so it is a Borel
@@ -36,33 +42,37 @@ oppositely to the closed subgroups they cut out, so `J ≤ I` says that the subg
 sits inside the subgroup defined by `J`.
 
 Two consequences are recorded. If the radical is the whole group — that is, if the group is
-itself smooth, connected and solvable — then it is its own unique Borel subgroup. Conversely, a
-smooth geometrically connected group with a trivial geometric Borel subgroup is semisimple, since
-its geometric solvable radical is squeezed between the trivial Borel and the identity subgroup.
+itself smooth, geometrically connected and geometrically solvable — then its unique maximal Borel
+candidate is the whole group, and the same conclusion holds for every Borel subgroup over the
+ground field. Conversely, a smooth geometrically connected group with a trivial geometric Borel
+subgroup is semisimple, since its geometric solvable radical is squeezed between the trivial Borel
+and the identity subgroup.
 
 ## Main declarations
 
-* `TauCeti.HopfIdeal.IsBorelCandidate.productOfNormal`: the multiplication image of a connected
-  normal smooth solvable closed subgroup with a Borel candidate is a Borel candidate.
-* `TauCeti.HopfIdeal.IsBorelCandidate.isSolvableRadicalCandidate`: a normal Borel candidate is a
-  solvable-radical candidate.
+* `TauCeti.HopfIdeal.IsBorelCandidate.productOfNormal`: the multiplication image of a
+  geometrically connected normal smooth geometrically solvable closed subgroup with a Borel
+  candidate is a Borel candidate.
+* `TauCeti.HopfIdeal.IsBorelCandidate.isSolvableRadicalCandidate_of_isNormal`: a normal Borel
+  candidate is a solvable-radical candidate.
 * `TauCeti.HopfIdeal.IsSolvableRadicalCandidate.le_of_minimal_isBorelCandidate`: **every
-  connected normal smooth solvable closed subgroup is contained in every Borel subgroup.**
+  geometrically connected normal smooth geometrically solvable closed subgroup is contained in
+  every maximal Borel candidate.**
 * `TauCeti.FiniteTypeCommHopfAlgCat.le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate`:
-  **the solvable radical is contained in every Borel subgroup.**
+  **the solvable radical is contained in every maximal Borel candidate.**
 * `TauCeti.FiniteTypeCommHopfAlgCat.le_unipotentRadicalDefiningIdeal_of_minimal_isBorelCandidate`:
-  the unipotent radical is contained in every Borel subgroup.
-* `TauCeti.FiniteTypeCommHopfAlgCat.eq_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate`:
-  a normal Borel subgroup is exactly the solvable radical.
+  the unipotent radical is contained in every maximal Borel candidate.
 * `TauCeti.HopfIdeal.IsBorelOverAlgClosed.le_solvableRadicalDefiningIdeal` and
   `TauCeti.HopfIdeal.IsBorelOverAlgClosed.le_unipotentRadicalDefiningIdeal`: the same two
   containments for the Borel-subgroup predicate over an algebraically closed field.
 * `TauCeti.HopfIdeal.IsBorel.baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal` and
   `TauCeti.HopfIdeal.IsBorel.baseChangeHopfIdeal_le_unipotentRadicalDefiningIdeal`: over an
   arbitrary field, the base change of a Borel subgroup contains the two geometric radicals.
-* `TauCeti.FiniteTypeCommHopfAlgCat.eq_bot_of_solvableRadicalDefiningIdeal_eq_bot`: a smooth
-  connected solvable affine group is its own unique Borel subgroup.
-* `TauCeti.semisimpleCommHopfAlgProperty_of_minimal_isBorelCandidate_eq_augmentation`: a smooth
+* `TauCeti.HopfIdeal.IsBorel.eq_solvableRadicalDefiningIdeal_of_isNormal`: a normal Borel subgroup
+  over an arbitrary field is exactly the solvable radical.
+* `TauCeti.HopfIdeal.IsBorel.eq_bot_of_solvableRadicalDefiningIdeal_eq_bot`: if the solvable
+  radical is the whole group, every Borel subgroup over the ground field is the whole group.
+* `TauCeti.semisimpleCommHopfAlgProperty_of_isBorelOverAlgClosed_eq_augmentation`: a smooth
   geometrically connected affine group with a trivial geometric Borel subgroup is semisimple.
 
 ## References
@@ -91,8 +101,8 @@ namespace HopfIdeal
 variable {k : Type u} [Field k]
 variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
 
-/-- The scheme-theoretic multiplication image of a connected normal smooth solvable closed
-subgroup with a Borel candidate is again a Borel candidate.
+/-- The scheme-theoretic multiplication image of a geometrically connected normal smooth
+geometrically solvable closed subgroup with a Borel candidate is again a Borel candidate.
 
 Normality of the solvable factor is what makes multiplication a homomorphism out of the
 conjugation semidirect product; the other factor is an arbitrary Borel candidate. -/
@@ -109,8 +119,8 @@ theorem IsBorelCandidate.productOfNormal
       ((smoothCommHopfAlgProperty_iff _).mpr hI.smooth) hJ.smooth
       hI.geometricallySolvable hJ.geometricallySolvable
 
-/-- **Every connected normal smooth solvable closed subgroup is contained in every Borel
-subgroup.**
+/-- **Every geometrically connected normal smooth geometrically solvable closed subgroup is
+contained in every maximal Borel candidate.**
 
 In the contravariant Hopf-ideal order, `J ≤ I` says that the subgroup cut out by `I` is contained
 in the maximal Borel candidate cut out by `J`. -/
@@ -123,7 +133,7 @@ theorem IsSolvableRadicalCandidate.le_of_minimal_isBorelCandidate
 
 /-- A normal Borel candidate is a solvable-radical candidate: normality is the only condition
 separating the two notions. -/
-theorem IsBorelCandidate.isSolvableRadicalCandidate
+theorem IsBorelCandidate.isSolvableRadicalCandidate_of_isNormal
     (hJ : IsBorelCandidate k H J) (hnormal : J.IsNormal) :
     IsSolvableRadicalCandidate H J :=
   IsSolvableRadicalCandidate.mk hnormal hJ.geometricallyConnected
@@ -135,15 +145,15 @@ namespace FiniteTypeCommHopfAlgCat
 
 variable {k : Type u} [Field k]
 
-/-- **The solvable radical is contained in every Borel subgroup.** -/
+/-- **The solvable radical is contained in every maximal Borel candidate.** -/
 theorem le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) {J : HopfIdeal k H}
     (hJ : Minimal (HopfIdeal.IsBorelCandidate k H) J) :
     J ≤ solvableRadicalDefiningIdeal H :=
   (isSolvableRadicalCandidate_solvableRadicalDefiningIdeal H).le_of_minimal_isBorelCandidate hJ
 
-/-- The unipotent radical is contained in every Borel subgroup, since it is contained in the
-solvable radical. -/
+/-- The unipotent radical is contained in every maximal Borel candidate, since it is contained in
+the solvable radical. -/
 theorem le_unipotentRadicalDefiningIdeal_of_minimal_isBorelCandidate
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) {J : HopfIdeal k H}
     (hJ : Minimal (HopfIdeal.IsBorelCandidate k H) J) :
@@ -151,22 +161,24 @@ theorem le_unipotentRadicalDefiningIdeal_of_minimal_isBorelCandidate
   (le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate H hJ).trans
     (solvableRadicalDefiningIdeal_le_unipotentRadicalDefiningIdeal H)
 
-/-- **A normal Borel subgroup is exactly the solvable radical.**
+/-- **A normal maximal Borel candidate is exactly the solvable radical.**
 
-One containment is maximality of the Borel subgroup, the other is the universal property of the
-radical applied to the Borel subgroup, which is a solvable-radical candidate once it is normal. -/
-theorem eq_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate
+One containment is maximality of the Borel candidate, the other is the universal property of the
+radical applied to the candidate, which is a solvable-radical candidate once it is normal. -/
+theorem eq_solvableRadicalDefiningIdeal_of_isNormal_of_minimal_isBorelCandidate
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) {J : HopfIdeal k H}
     (hnormal : J.IsNormal) (hJ : Minimal (HopfIdeal.IsBorelCandidate k H) J) :
     J = solvableRadicalDefiningIdeal H :=
   le_antisymm (le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate H hJ)
-    (solvableRadicalDefiningIdeal_le H J (hJ.1.isSolvableRadicalCandidate hnormal))
+    (solvableRadicalDefiningIdeal_le H J
+      (hJ.1.isSolvableRadicalCandidate_of_isNormal hnormal))
 
-/-- **A smooth connected solvable affine group is its own unique Borel subgroup.**
+/-- **A smooth geometrically connected and geometrically solvable affine group is its own unique
+maximal Borel candidate.**
 
 The hypothesis says that the solvable radical is the whole group, the closed subgroup cut out by
 the zero Hopf ideal. -/
-theorem eq_bot_of_solvableRadicalDefiningIdeal_eq_bot
+theorem eq_bot_of_solvableRadicalDefiningIdeal_eq_bot_of_minimal_isBorelCandidate
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) {J : HopfIdeal k H}
     (hH : solvableRadicalDefiningIdeal H = ⊥)
     (hJ : Minimal (HopfIdeal.IsBorelCandidate k H) J) :
@@ -192,6 +204,23 @@ theorem le_unipotentRadicalDefiningIdeal (hI : IsBorelOverAlgClosed k H I) :
     I ≤ FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal H :=
   FiniteTypeCommHopfAlgCat.le_unipotentRadicalDefiningIdeal_of_minimal_isBorelCandidate H
     ((isBorelOverAlgClosed_iff k H I).mp hI).2
+
+/-- Over an algebraically closed field, a normal Borel subgroup is exactly the solvable
+radical. -/
+theorem eq_solvableRadicalDefiningIdeal_of_isNormal
+    (hI : IsBorelOverAlgClosed k H I) (hnormal : I.IsNormal) :
+    I = FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal H :=
+  FiniteTypeCommHopfAlgCat.eq_solvableRadicalDefiningIdeal_of_isNormal_of_minimal_isBorelCandidate
+    H hnormal ((isBorelOverAlgClosed_iff k H I).mp hI).2
+
+/-- Over an algebraically closed field, if the solvable radical is the whole group, every Borel
+subgroup is the whole group. -/
+theorem eq_bot_of_solvableRadicalDefiningIdeal_eq_bot
+    (hI : IsBorelOverAlgClosed k H I)
+    (hH : FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal H = ⊥) :
+    I = ⊥ :=
+  FiniteTypeCommHopfAlgCat.eq_bot_of_solvableRadicalDefiningIdeal_eq_bot_of_minimal_isBorelCandidate
+    H hH ((isBorelOverAlgClosed_iff k H I).mp hI).2
 
 end HopfIdeal.IsBorelOverAlgClosed
 
@@ -220,6 +249,63 @@ theorem baseChangeHopfIdeal_le_unipotentRadicalDefiningIdeal (hI : IsBorel k H I
   IsBorelOverAlgClosed.le_unipotentRadicalDefiningIdeal
     ((isBorel_iff_isBorelOverAlgClosed_baseChange k H I).mp hI)
 
+/-- Over an arbitrary field, a normal Borel subgroup is exactly the solvable radical. -/
+theorem eq_solvableRadicalDefiningIdeal_of_isNormal
+    (hI : IsBorel k H I) (hnormal : I.IsNormal) :
+    I = FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal
+      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ := by
+  let H' : FiniteTypeCommHopfAlgCat.{u, u} k :=
+    ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
+  have hIcandidate : IsBorelCandidate k H' I := by
+    let qIso := CommHopfAlgCat.quotientBaseChangeIso (K := AlgebraicClosure k) I
+    have hIK : IsBorelCandidate (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H')
+        (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I) :=
+      ((isBorelOverAlgClosed_iff _ _ _).mp
+        ((isBorel_iff_isBorelOverAlgClosed_baseChange k H I).mp hI)).2.1
+    refine IsBorelCandidate.mk ?_ ?_ ?_
+    · rw [smoothCommHopfAlgProperty_iff]
+      -- Unwrap the finite-type quotient for Mathlib's faithfully-flat smoothness descent lemma.
+      change Algebra.Smooth k (CommHopfAlgCat.quotient H I)
+      have hsmooth :=
+        (smoothCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso hIK.smooth
+      let _ : Algebra.Smooth (AlgebraicClosure k)
+          (CommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+            (CommHopfAlgCat.quotient H I)) :=
+        (smoothCommHopfAlgProperty_iff _).mp hsmooth
+      exact Algebra.Smooth.of_smooth_tensorProduct_of_faithfullyFlat (AlgebraicClosure k)
+    · apply geometricallyConnectedCommHopfAlgProperty.of_baseChange k (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.quotient H' I).obj
+      exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+        qIso hIK.geometricallyConnected
+    · apply geometricallySolvablePointsCommHopfAlgProperty.of_baseChange
+        (K := AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.quotient H' I).obj
+      exact (geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+        qIso hIK.geometricallySolvable
+  apply le_antisymm
+  · apply (CommHopfAlgCat.baseChangeHopfIdeal_le_iff_of_faithfullyFlat
+      (K := AlgebraicClosure k) I
+      (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal H')).mp
+    exact hI.baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal.trans
+      (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_baseChange_le H')
+  · exact FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_le H' I
+      (hIcandidate.isSolvableRadicalCandidate_of_isNormal hnormal)
+
+/-- Over an arbitrary field, if the solvable radical is the whole group, every Borel subgroup is
+the whole group. -/
+theorem eq_bot_of_solvableRadicalDefiningIdeal_eq_bot
+    (hI : IsBorel k H I)
+    (hH : FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal
+      ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ = ⊥) :
+    I = ⊥ := by
+  apply le_antisymm ?_ bot_le
+  rw [← hH]
+  apply (CommHopfAlgCat.baseChangeHopfIdeal_le_iff_of_faithfullyFlat
+    (K := AlgebraicClosure k) I _).mp
+  exact hI.baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal.trans
+    (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_baseChange_le _)
+
 end HopfIdeal.IsBorel
 
 variable {k : Type u} [Field k]
@@ -230,21 +316,20 @@ semisimple.**
 The Borel subgroup is taken on the geometric fibre, and triviality means that its defining Hopf
 ideal is the augmentation ideal. The geometric solvable radical is then contained in the identity
 subgroup, hence equal to it. -/
-theorem semisimpleCommHopfAlgProperty_of_minimal_isBorelCandidate_eq_augmentation
+theorem semisimpleCommHopfAlgProperty_of_isBorelOverAlgClosed_eq_augmentation
     (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (hsmooth : Algebra.Smooth k H)
     (hconnected : geometricallyConnectedCommHopfAlgProperty k H.obj)
     {J : HopfIdeal (AlgebraicClosure k)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)}
-    (hJ : Minimal (HopfIdeal.IsBorelCandidate (AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) J)
+    (hJ : HopfIdeal.IsBorelOverAlgClosed (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) J)
     (hJtrivial : J = HopfIdeal.augmentation (AlgebraicClosure k)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) :
     semisimpleCommHopfAlgProperty k H := by
   rw [semisimpleCommHopfAlgProperty_iff_solvableRadicalDefiningIdeal_baseChange_eq_augmentation]
   refine ⟨hsmooth, hconnected, le_antisymm (HopfIdeal.le_augmentation _ _ _) ?_⟩
-  exact hJtrivial ▸
-    FiniteTypeCommHopfAlgCat.le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate _ hJ
+  exact hJtrivial ▸ hJ.le_solvableRadicalDefiningIdeal
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
@@ -7,11 +7,10 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Borel.Existence
 public import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Semisimple
-import Mathlib.RingTheory.Etale.Descent
+import TauCeti.Algebra.AlgebraicGroup.Borel.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.Connected.Product
 import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
 import TauCeti.Algebra.AlgebraicGroup.Smooth.Product
-import TauCeti.Algebra.AlgebraicGroup.Solvable.BaseChange
 import TauCeti.Algebra.AlgebraicGroup.Solvable.NormalProduct
 import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.BaseChange
 
@@ -66,8 +65,6 @@ and the identity subgroup.
 * `TauCeti.HopfIdeal.IsBorel.baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal` and
   `TauCeti.HopfIdeal.IsBorel.baseChangeHopfIdeal_le_unipotentRadicalDefiningIdeal`: over an
   arbitrary field, the base change of a Borel subgroup contains the two geometric radicals.
-* `TauCeti.HopfIdeal.IsBorel.isBorelCandidate`: every Borel subgroup over an arbitrary field is a
-  Borel candidate over that field.
 * `TauCeti.HopfIdeal.IsBorel.le_solvableRadicalDefiningIdeal` and
   `TauCeti.HopfIdeal.IsBorel.le_unipotentRadicalDefiningIdeal`: **over an arbitrary field, the
   solvable radical, and hence the unipotent radical, is contained in every Borel subgroup.**
@@ -271,39 +268,6 @@ theorem le_unipotentRadicalDefiningIdeal (hI : IsBorel k H I) :
       ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ :=
   hI.le_solvableRadicalDefiningIdeal.trans
     (FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal_le_unipotentRadicalDefiningIdeal _)
-
-/-- A Borel subgroup over an arbitrary field is a Borel candidate over that field: its quotient
-is smooth, geometrically connected, and geometrically solvable. -/
-theorem isBorelCandidate (hI : IsBorel k H I) :
-    IsBorelCandidate k ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩ I := by
-  let H' : FiniteTypeCommHopfAlgCat.{u, u} k :=
-    ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩
-  let qIso := CommHopfAlgCat.quotientBaseChangeIso (K := AlgebraicClosure k) I
-  have hIK : IsBorelCandidate (AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H')
-      (CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I) :=
-    ((isBorelOverAlgClosed_iff _ _ _).mp
-      ((isBorel_iff_isBorelOverAlgClosed_baseChange k H I).mp hI)).2.1
-  refine IsBorelCandidate.mk ?_ ?_ ?_
-  · rw [smoothCommHopfAlgProperty_iff]
-    -- Unwrap the finite-type quotient for Mathlib's faithfully-flat smoothness descent lemma.
-    change Algebra.Smooth k (CommHopfAlgCat.quotient H I)
-    have hsmooth :=
-      (smoothCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso hIK.smooth
-    let _ : Algebra.Smooth (AlgebraicClosure k)
-        (CommHopfAlgCat.baseChange (K := AlgebraicClosure k)
-          (CommHopfAlgCat.quotient H I)) :=
-      (smoothCommHopfAlgProperty_iff _).mp hsmooth
-    exact Algebra.Smooth.of_smooth_tensorProduct_of_faithfullyFlat (AlgebraicClosure k)
-  · apply geometricallyConnectedCommHopfAlgProperty.of_baseChange k (AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.quotient H' I).obj
-    exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-      qIso hIK.geometricallyConnected
-  · apply geometricallySolvablePointsCommHopfAlgProperty.of_baseChange
-      (K := AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.quotient H' I).obj
-    exact (geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-      qIso hIK.geometricallySolvable
 
 /-- Over an arbitrary field, a normal Borel subgroup is exactly the solvable radical. -/
 theorem eq_solvableRadicalDefiningIdeal_of_isNormal

--- a/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean
@@ -1,0 +1,257 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Borel.Existence
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Semisimple
+import TauCeti.Algebra.AlgebraicGroup.Connected.Product
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
+import TauCeti.Algebra.AlgebraicGroup.Smooth.Product
+import TauCeti.Algebra.AlgebraicGroup.Solvable.NormalProduct
+
+/-!
+# The radical is contained in every Borel subgroup
+
+Let `H` be the coordinate Hopf algebra of a finite-type affine group over a field. A Borel
+candidate is a smooth, geometrically connected, geometrically solvable closed subgroup, and a
+Borel subgroup is a maximal one. This file proves that every *normal* Borel candidate is
+contained in every maximal one; in particular the solvable radical `R(G)`, and hence the
+unipotent radical `R_u(G)`, lies inside every Borel subgroup.
+
+The argument is the standard one and reuses the product machinery that built the two radicals.
+Let `B` be a Borel candidate and let `N` be a connected normal smooth solvable closed subgroup.
+Since `N` is normal, multiplication is a homomorphism from the conjugation semidirect product of
+`N` and `B` into the ambient group, and its scheme-theoretic image `N · B` contains both factors.
+That image is again smooth, geometrically connected and geometrically solvable, so it is a Borel
+candidate containing `B`. Maximality of `B` forces `N · B = B`, so `N` is contained in `B`.
+Normality of `N` is what makes `N · B` a subgroup at all; no hypothesis is needed on `B` beyond
+being a Borel candidate, and nothing here needs the ground field to be algebraically closed.
+
+Contravariance is the only thing to keep in mind when reading the statements: Hopf ideals order
+oppositely to the closed subgroups they cut out, so `J ≤ I` says that the subgroup defined by `I`
+sits inside the subgroup defined by `J`.
+
+Two consequences are recorded. If the radical is the whole group — that is, if the group is
+itself smooth, connected and solvable — then it is its own unique Borel subgroup. Conversely, a
+smooth geometrically connected group with a trivial geometric Borel subgroup is semisimple, since
+its geometric solvable radical is squeezed between the trivial Borel and the identity subgroup.
+
+Conjugacy of Borel subgroups is not proved here, and none of the statements below need it.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.IsBorelCandidate.productOfNormal`: the multiplication image of a connected
+  normal smooth solvable closed subgroup with a Borel candidate is a Borel candidate.
+* `TauCeti.HopfIdeal.IsBorelCandidate.isSolvableRadicalCandidate`: a normal Borel candidate is a
+  solvable-radical candidate.
+* `TauCeti.HopfIdeal.IsSolvableRadicalCandidate.le_of_minimal_isBorelCandidate`: **every
+  connected normal smooth solvable closed subgroup is contained in every Borel subgroup.**
+* `TauCeti.FiniteTypeCommHopfAlgCat.le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate`:
+  **the solvable radical is contained in every Borel subgroup.**
+* `TauCeti.FiniteTypeCommHopfAlgCat.le_unipotentRadicalDefiningIdeal_of_minimal_isBorelCandidate`:
+  the unipotent radical is contained in every Borel subgroup.
+* `TauCeti.FiniteTypeCommHopfAlgCat.eq_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate`:
+  a normal Borel subgroup is exactly the solvable radical.
+* `TauCeti.HopfIdeal.IsBorelOverAlgClosed.le_solvableRadicalDefiningIdeal` and
+  `TauCeti.HopfIdeal.IsBorelOverAlgClosed.le_unipotentRadicalDefiningIdeal`: the same two
+  containments for the Borel-subgroup predicate over an algebraically closed field.
+* `TauCeti.HopfIdeal.IsBorel.baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal` and
+  `TauCeti.HopfIdeal.IsBorel.baseChangeHopfIdeal_le_unipotentRadicalDefiningIdeal`: over an
+  arbitrary field, the base change of a Borel subgroup contains the two geometric radicals.
+* `TauCeti.FiniteTypeCommHopfAlgCat.eq_bot_of_solvableRadicalDefiningIdeal_eq_bot`: a smooth
+  connected solvable affine group is its own unique Borel subgroup.
+* `TauCeti.semisimpleCommHopfAlgProperty_of_minimal_isBorelCandidate_eq_augmentation`: a smooth
+  geometrically connected affine group with a trivial geometric Borel subgroup is semisimple.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§17.a and 19.b.
+* A. Borel, *Linear Algebraic Groups*, 2nd ed. (1991), §11.21.
+* T. A. Springer, *Linear Algebraic Groups*, §6.2.
+
+The product-image bookkeeping follows the formal organization of
+`TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Product`, where the same three closure
+properties are proved for two normal factors.
+
+This advances Layer 7, "Borel subgroups, maximal tori, and their conjugacy", of the
+ReductiveGroups roadmap, by relating the Borel subgroups constructed there to the radicals of
+Layers 5 and 6. Conjugacy of Borel subgroups remains open.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal
+
+variable {k : Type u} [Field k]
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
+
+/-- The scheme-theoretic multiplication image of a connected normal smooth solvable closed
+subgroup with a Borel candidate is again a Borel candidate.
+
+Normality of the solvable factor is what makes multiplication a homomorphism out of the
+conjugation semidirect product; the other factor is an arbitrary Borel candidate. -/
+theorem IsBorelCandidate.productOfNormal
+    (hJ : IsBorelCandidate k H J) (hI : IsSolvableRadicalCandidate H I) :
+    IsBorelCandidate k H
+      (HopfIdeal.ker (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom) := by
+  refine IsBorelCandidate.mk ?_ ?_ ?_
+  · exact smoothCommHopfAlgProperty.productOfNormal H.obj I J hI.isNormal
+      ((smoothCommHopfAlgProperty_iff _).mpr hI.smooth) hJ.smooth
+  · exact geometricallyConnectedCommHopfAlgProperty.productOfNormal H.obj I J hI.isNormal
+      hI.geometricallyConnected hJ.geometricallyConnected
+  · exact geometricallySolvablePointsCommHopfAlgProperty.productOfNormal H.obj I J hI.isNormal
+      ((smoothCommHopfAlgProperty_iff _).mpr hI.smooth) hJ.smooth
+      hI.geometricallySolvable hJ.geometricallySolvable
+
+/-- **Every connected normal smooth solvable closed subgroup is contained in every Borel
+subgroup.**
+
+In the contravariant Hopf-ideal order, `J ≤ I` says that the subgroup cut out by `I` is contained
+in the maximal Borel candidate cut out by `J`. -/
+theorem IsSolvableRadicalCandidate.le_of_minimal_isBorelCandidate
+    (hI : IsSolvableRadicalCandidate H I) (hJ : Minimal (IsBorelCandidate k H) J) :
+    J ≤ I :=
+  (hJ.2 (hJ.1.productOfNormal hI)
+      (CommHopfAlgCat.ker_productMapOfNormal_le_right H.obj I J hI.isNormal)).trans
+    (CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal)
+
+/-- A normal Borel candidate is a solvable-radical candidate: normality is the only condition
+separating the two notions. -/
+theorem IsBorelCandidate.isSolvableRadicalCandidate
+    (hJ : IsBorelCandidate k H J) (hnormal : J.IsNormal) :
+    IsSolvableRadicalCandidate H J :=
+  IsSolvableRadicalCandidate.mk hnormal hJ.geometricallyConnected
+    ((smoothCommHopfAlgProperty_iff _).mp hJ.smooth) hJ.geometricallySolvable
+
+end HopfIdeal
+
+namespace FiniteTypeCommHopfAlgCat
+
+variable {k : Type u} [Field k]
+
+/-- **The solvable radical is contained in every Borel subgroup.** -/
+theorem le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) {J : HopfIdeal k H}
+    (hJ : Minimal (HopfIdeal.IsBorelCandidate k H) J) :
+    J ≤ solvableRadicalDefiningIdeal H :=
+  (isSolvableRadicalCandidate_solvableRadicalDefiningIdeal H).le_of_minimal_isBorelCandidate hJ
+
+/-- The unipotent radical is contained in every Borel subgroup, since it is contained in the
+solvable radical. -/
+theorem le_unipotentRadicalDefiningIdeal_of_minimal_isBorelCandidate
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) {J : HopfIdeal k H}
+    (hJ : Minimal (HopfIdeal.IsBorelCandidate k H) J) :
+    J ≤ unipotentRadicalDefiningIdeal H :=
+  (le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate H hJ).trans
+    (solvableRadicalDefiningIdeal_le_unipotentRadicalDefiningIdeal H)
+
+/-- **A normal Borel subgroup is exactly the solvable radical.**
+
+One containment is maximality of the Borel subgroup, the other is the universal property of the
+radical applied to the Borel subgroup, which is a solvable-radical candidate once it is normal. -/
+theorem eq_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) {J : HopfIdeal k H}
+    (hnormal : J.IsNormal) (hJ : Minimal (HopfIdeal.IsBorelCandidate k H) J) :
+    J = solvableRadicalDefiningIdeal H :=
+  le_antisymm (le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate H hJ)
+    (solvableRadicalDefiningIdeal_le H J (hJ.1.isSolvableRadicalCandidate hnormal))
+
+/-- **A smooth connected solvable affine group is its own unique Borel subgroup.**
+
+The hypothesis says that the solvable radical is the whole group, the closed subgroup cut out by
+the zero Hopf ideal. -/
+theorem eq_bot_of_solvableRadicalDefiningIdeal_eq_bot
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) {J : HopfIdeal k H}
+    (hH : solvableRadicalDefiningIdeal H = ⊥)
+    (hJ : Minimal (HopfIdeal.IsBorelCandidate k H) J) :
+    J = ⊥ :=
+  le_antisymm (hH ▸ le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate H hJ) bot_le
+
+end FiniteTypeCommHopfAlgCat
+
+namespace HopfIdeal.IsBorelOverAlgClosed
+
+variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k H}
+
+/-- Over an algebraically closed field, the solvable radical is contained in every Borel
+subgroup. -/
+theorem le_solvableRadicalDefiningIdeal (hI : IsBorelOverAlgClosed k H I) :
+    I ≤ FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal H :=
+  FiniteTypeCommHopfAlgCat.le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate H
+    ((isBorelOverAlgClosed_iff k H I).mp hI).2
+
+/-- Over an algebraically closed field, the unipotent radical is contained in every Borel
+subgroup. -/
+theorem le_unipotentRadicalDefiningIdeal (hI : IsBorelOverAlgClosed k H I) :
+    I ≤ FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal H :=
+  FiniteTypeCommHopfAlgCat.le_unipotentRadicalDefiningIdeal_of_minimal_isBorelCandidate H
+    ((isBorelOverAlgClosed_iff k H I).mp hI).2
+
+end HopfIdeal.IsBorelOverAlgClosed
+
+namespace HopfIdeal.IsBorel
+
+variable {k : Type u} [Field k] {H : CommHopfAlgCat.{u} k} [Algebra.FiniteType k H]
+variable {I : HopfIdeal k H}
+
+/-- Over an arbitrary field, the base change of a Borel subgroup contains the geometric solvable
+radical. -/
+theorem baseChangeHopfIdeal_le_solvableRadicalDefiningIdeal (hI : IsBorel k H I) :
+    CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I ≤
+      FiniteTypeCommHopfAlgCat.solvableRadicalDefiningIdeal
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+          ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩) :=
+  IsBorelOverAlgClosed.le_solvableRadicalDefiningIdeal
+    ((isBorel_iff_isBorelOverAlgClosed_baseChange k H I).mp hI)
+
+/-- Over an arbitrary field, the base change of a Borel subgroup contains the geometric unipotent
+radical. -/
+theorem baseChangeHopfIdeal_le_unipotentRadicalDefiningIdeal (hI : IsBorel k H I) :
+    CommHopfAlgCat.baseChangeHopfIdeal (K := AlgebraicClosure k) I ≤
+      FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+          ⟨H, (finiteTypeCommHopfAlgProperty_iff H).2 inferInstance⟩) :=
+  IsBorelOverAlgClosed.le_unipotentRadicalDefiningIdeal
+    ((isBorel_iff_isBorelOverAlgClosed_baseChange k H I).mp hI)
+
+end HopfIdeal.IsBorel
+
+variable {k : Type u} [Field k]
+
+/-- **A smooth geometrically connected affine group with a trivial geometric Borel subgroup is
+semisimple.**
+
+The Borel subgroup is taken on the geometric fibre, and triviality means that its defining Hopf
+ideal is the augmentation ideal. The geometric solvable radical is then contained in the identity
+subgroup, hence equal to it. -/
+theorem semisimpleCommHopfAlgProperty_of_minimal_isBorelCandidate_eq_augmentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hsmooth : Algebra.Smooth k H)
+    (hconnected : geometricallyConnectedCommHopfAlgProperty k H.obj)
+    {J : HopfIdeal (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)}
+    (hJ : Minimal (HopfIdeal.IsBorelCandidate (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) J)
+    (hJtrivial : J = HopfIdeal.augmentation (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) :
+    semisimpleCommHopfAlgProperty k H := by
+  rw [semisimpleCommHopfAlgProperty_iff_solvableRadicalDefiningIdeal_baseChange_eq_augmentation]
+  refine ⟨hsmooth, hconnected, le_antisymm (HopfIdeal.le_augmentation _ _ _) ?_⟩
+  exact hJtrivial ▸
+    FiniteTypeCommHopfAlgCat.le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate _ hJ
+
+end
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the radical of a finite-type affine group over a field is contained in every Borel subgroup, and deduces the same for the unipotent radical. Let `B` be a Borel candidate — a smooth, geometrically connected, geometrically solvable closed subgroup — and let `N` be a connected normal smooth solvable closed subgroup. Because `N` is normal, multiplication is a homomorphism from the conjugation semidirect product of `N` and `B`, and its scheme-theoretic image `N · B` contains both factors; the image is again smooth, geometrically connected and geometrically solvable, so maximality of `B` forces `N · B = B`. Everything is stated in Hopf coordinates, where the ideal order reverses subgroup inclusion, and nothing needs the ground field to be algebraically closed.

The milestone is Layer 7, "Borel subgroups, maximal tori, and their conjugacy", of `contents/ReductiveGroups/README.md`. Its construction half landed recently — maximal tori in TauCeti#5719 and geometric Borel subgroups in TauCeti#5769, via `TauCeti.HopfIdeal.exists_minimal_isBorelCandidate` and `exists_geometricBorel` — and the two radicals `R(G)` and `R_u(G)` are already constructed in Layers 5 and 6. Nothing connected the two: `TauCeti/Algebra/AlgebraicGroup/Borel/Existence.lean` proves only that Borel subgroups exist, and its docstring records that no conjugacy statement is available. This PR supplies the first structural relation between the Borel subgroups and the radicals, which is the standard next step (Milne §17.a; Borel §11.21) and does not depend on conjugacy. After this PR, the milestone still needs conjugacy of Borel subgroups and of maximal tori over an algebraically closed field, which is the remaining gate before roots and Weyl groups can be extracted for an arbitrary reductive group.

New file: `TauCeti/Algebra/AlgebraicGroup/Borel/Radical.lean` (318 lines), containing

- `HopfIdeal.IsBorelCandidate.productOfNormal`: the multiplication image of a solvable-radical candidate with a Borel candidate is a Borel candidate;
- `HopfIdeal.IsSolvableRadicalCandidate.le_of_minimal_isBorelCandidate`: every geometrically connected normal smooth geometrically solvable closed subgroup is contained in every maximal Borel candidate;
- `HopfIdeal.IsBorelCandidate.isSolvableRadicalCandidate_of_isNormal`: normality is the only condition separating the two candidate notions;
- `FiniteTypeCommHopfAlgCat.le_solvableRadicalDefiningIdeal_of_minimal_isBorelCandidate` and `le_unipotentRadicalDefiningIdeal_of_minimal_isBorelCandidate`: `R(G)` and `R_u(G)` are contained in every maximal Borel candidate;
- `FiniteTypeCommHopfAlgCat.eq_solvableRadicalDefiningIdeal_of_isNormal_of_minimal_isBorelCandidate`: a normal maximal Borel candidate is exactly the solvable radical;
- `FiniteTypeCommHopfAlgCat.eq_bot_of_solvableRadicalDefiningIdeal_eq_bot_of_minimal_isBorelCandidate`: a smooth geometrically connected geometrically solvable affine group is its own unique maximal Borel candidate;
- `HopfIdeal.IsBorelOverAlgClosed.le_solvableRadicalDefiningIdeal` and `le_unipotentRadicalDefiningIdeal`, with the equality and `eq_bot` companions, for Borel subgroups over an algebraically closed field;
- `HopfIdeal.IsBorel.le_solvableRadicalDefiningIdeal` and `le_unipotentRadicalDefiningIdeal`, together with their `baseChangeHopfIdeal_le_*` geometric forms and the `eq_solvableRadicalDefiningIdeal_of_isNormal` and `eq_bot_of_solvableRadicalDefiningIdeal_eq_bot` companions: the same containments over an arbitrary field, by faithfully flat descent;
- `semisimpleCommHopfAlgProperty_of_isBorelOverAlgClosed_eq_augmentation`: a smooth geometrically connected group whose geometric Borel subgroup is trivial is semisimple.

Second new file: `TauCeti/Algebra/AlgebraicGroup/Borel/BaseChange.lean` (93 lines), containing `HopfIdeal.IsBorel.isBorelCandidate`: a Borel subgroup over an arbitrary field is a Borel candidate over that field. Smoothness descends along the faithfully flat extension `k → AlgebraicClosure k`; geometric connectedness and geometric solvability are reflected by an arbitrary field extension. This is general Borel base-change infrastructure, independent of the radicals, so it lives beside the Borel predicates rather than in the radical module.

No Mathlib infrastructure was vendored. The three closure properties of the product image reuse the existing `smoothCommHopfAlgProperty.productOfNormal`, `geometricallyConnectedCommHopfAlgProperty.productOfNormal` and `geometricallySolvablePointsCommHopfAlgProperty.productOfNormal`, which already only assume normality of one factor, and the containments `CommHopfAlgCat.ker_productMapOfNormal_le_left`/`_right`; the file's organization follows `TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Product.lean`, where the same three properties are proved for two normal factors.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"radical-contained-in-every-borel"}-->

🤖 Prepared with Claude Code

